### PR TITLE
Bump Cloud Run memory 256Mi → 512Mi

### DIFF
--- a/packages/server/deploy.sh
+++ b/packages/server/deploy.sh
@@ -193,7 +193,7 @@ gcloud run deploy "${SERVICE}" \
   --project "${GCP_PROJECT}" \
   --allow-unauthenticated \
   --port 8080 \
-  --memory 256Mi \
+  --memory 512Mi \
   --min-instances 0 \
   --max-instances 3 \
   --add-cloudsql-instances "${CLOUD_SQL_INSTANCE_CONN}" \


### PR DESCRIPTION
Rehomes the memory-bump commit that was made directly on local develop (which doesn't take direct pushes) — rebased onto current origin/develop, content unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)