### PR TITLE
CD: grant cloudkms.viewer to github-deployer

### DIFF
--- a/scripts/setup-github-deployer.sh
+++ b/scripts/setup-github-deployer.sh
@@ -89,6 +89,11 @@ fi
 #   secretmanager.secretAccessor  DB_PASS fetch in deploy.<env>.env
 #   secretmanager.viewer       the pre-flight `gcloud secrets describe` loop
 #   compute.loadBalancerAdmin  admin CDN cache invalidation
+#   cloudkms.viewer            the pre-flight `gcloud kms keys describe` for the
+#                              slack-tokens key (describe-only; the Cloud Run
+#                              runtime SA does the actual encrypt/decrypt). The
+#                              check swallows stderr, so a missing grant reads
+#                              as "key not found" — the first CI deploy hit this.
 for ROLE in \
   roles/run.admin \
   roles/iam.serviceAccountUser \
@@ -98,7 +103,8 @@ for ROLE in \
   roles/cloudsql.client \
   roles/secretmanager.secretAccessor \
   roles/secretmanager.viewer \
-  roles/compute.loadBalancerAdmin; do
+  roles/compute.loadBalancerAdmin \
+  roles/cloudkms.viewer; do
   gcloud projects add-iam-policy-binding "${GCP_PROJECT}" \
     --member "serviceAccount:${SA_EMAIL}" --role "${ROLE}" \
     --condition None --quiet >/dev/null


### PR DESCRIPTION
First authenticated int deploy (run 26999254926) got past WIF auth and Secret Manager checks, then failed at the KMS pre-flight: `gcloud kms keys describe` swallows stderr, so the deployer SA's missing `cloudkms.viewer` grant surfaced as "key not found". Adds the role to the setup script's standing-roles list (describe-only — runtime encrypt/decrypt stays with the Cloud Run SA).

The grants themselves are being applied directly with gcloud; this PR makes the script match for the next environment/person.

🤖 Generated with [Claude Code](https://claude.com/claude-code)