### PR TITLE
Smoke: fix prod apex-redirect false negative in spec-167 probe

### DIFF
--- a/packages/server/src/__smoke__/oauth-consent-allow-button.smoke.test.ts
+++ b/packages/server/src/__smoke__/oauth-consent-allow-button.smoke.test.ts
@@ -21,11 +21,20 @@ describe(`oauth consent Allow-button legibility smoke @ ${SMOKE_BASE_URL}`, () =
     tagAc(AC6);
 
     // 1. The SPA index references a content-hashed CSS bundle.
-    const indexRes = await fetch(`${SMOKE_BASE_URL}/`);
-    expect(indexRes.status).toBe(200);
+    //
+    // Fetch /login, NOT the bare apex `/`: on prod the apex root 301s to the
+    // www marketing site (std-2 topology — marketing on www, app on tenant
+    // paths), whose HTML has no Vite bundle. /login is SPA-served on every
+    // environment. Caught by the first CI prod deploy (2026-06-05): int went
+    // green, prod went red on the marketing redirect, the app itself was fine.
+    // Deep links are served via GCS's NotFound fallback — index.html body
+    // with a 404 status — on BOTH envs (the SPA does client-side routing).
+    // The status is routing trivia; the body is what this smoke cares about.
+    const indexRes = await fetch(`${SMOKE_BASE_URL}/login`);
+    expect([200, 404]).toContain(indexRes.status);
     const html = await indexRes.text();
     const ref = html.match(/\/assets\/index-[\w-]+\.css/);
-    expect(ref, "index.html should reference a hashed CSS bundle").toBeTruthy();
+    expect(ref, "SPA index should reference a hashed CSS bundle").toBeTruthy();
 
     // 2. Fetch the actual deployed stylesheet.
     const cssRes = await fetch(`${SMOKE_BASE_URL}${ref![0]}`);


### PR DESCRIPTION
The first CI prod deploy (run 26999847498) failed ONLY at the smoke tail: the spec-167 consent-legibility probe fetched the bare apex `/`, which on prod 301s to the www marketing site (std-2 topology). int serves the SPA at `/`, so the assumption never surfaced before.

- Probe `/login` (SPA-served on every env) instead of `/`
- Accept GCS's NotFound-fallback status (404 + index.html body) that deep links get on both envs — the test's subject is the deployed CSS bundle, not LB routing
- Verified green against live prod and int

Prod itself was confirmed healthy: identical content-hashed bundle (`index-GyMWSXiN.css`) live on both envs, `/api/health` 200. No rollback needed; the deploy run's red was a probe artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)