### PR TITLE
fix: drift agent can edit clause-backed Standards (spec-175) [prod/main]

### DIFF
--- a/packages/server/src/__regression__/tools-coverage.regression.test.ts
+++ b/packages/server/src/__regression__/tools-coverage.regression.test.ts
@@ -267,4 +267,21 @@ describe("regression: tool manifest ↔ MCP catalogue parity (b-67 t-4)", () => 
       inManifestNotSpecs: [],
     });
   });
+
+  // spec-175: Standards are clause-backed (spec-150 / spec-161), so update_section
+  // hard-rejects on a Standard. The drift agent edits rule text at clause grain,
+  // so the clause verbs MUST be in its focused surface or it cannot resolve the
+  // drift it raises. Asserted at the drift-mode surface (DRIFT_SERVER_TOOLS), which
+  // gates both the tool definitions the model sees and execution (isDriftModeTool).
+  it("the drift agent's tool surface includes the clause-editing verbs (spec-175)", () => {
+    const driftNames = new Set(
+      getToolDefinitions({ mode: "drift" }).map((t) => t.name),
+    );
+    for (const name of ["add_clause", "edit_clause", "delete_clause"]) {
+      expect(
+        driftNames.has(name),
+        `drift surface missing ${name} — agent cannot edit clause-backed Standards`,
+      ).toBe(true);
+    }
+  });
 });

--- a/packages/server/src/__regression__/tools-coverage.regression.test.ts
+++ b/packages/server/src/__regression__/tools-coverage.regression.test.ts
@@ -267,21 +267,4 @@ describe("regression: tool manifest ↔ MCP catalogue parity (b-67 t-4)", () => 
       inManifestNotSpecs: [],
     });
   });
-
-  // spec-175: Standards are clause-backed (spec-150 / spec-161), so update_section
-  // hard-rejects on a Standard. The drift agent edits rule text at clause grain,
-  // so the clause verbs MUST be in its focused surface or it cannot resolve the
-  // drift it raises. Asserted at the drift-mode surface (DRIFT_SERVER_TOOLS), which
-  // gates both the tool definitions the model sees and execution (isDriftModeTool).
-  it("the drift agent's tool surface includes the clause-editing verbs (spec-175)", () => {
-    const driftNames = new Set(
-      getToolDefinitions({ mode: "drift" }).map((t) => t.name),
-    );
-    for (const name of ["add_clause", "edit_clause", "delete_clause"]) {
-      expect(
-        driftNames.has(name),
-        `drift surface missing ${name} — agent cannot edit clause-backed Standards`,
-      ).toBe(true);
-    }
-  });
 });

--- a/packages/server/src/agent/tools.drift-mode.test.ts
+++ b/packages/server/src/agent/tools.drift-mode.test.ts
@@ -31,6 +31,13 @@ const EXPECTED_DRIFT_SERVER_TOOLS = [
   "list_comments",
   "update_section",
   "update_comment",
+  // spec-175: Standards are clause-backed (spec-150 / spec-161), so
+  // update_section hard-rejects on a Standard. The clause verbs are how the
+  // drift agent actually edits rule text; the cl-N refs they need are surfaced
+  // inline by get_doc.
+  "add_clause",
+  "edit_clause",
+  "delete_clause",
 ];
 
 describe("getToolDefinitions — drift mode subset", () => {

--- a/packages/server/src/agent/tools.ts
+++ b/packages/server/src/agent/tools.ts
@@ -327,6 +327,11 @@ export function isReadOnlyTool(name: string): boolean {
 //     (resolves the section by its s-N ref, memex-scoped).
 //   - update_comment — resolve a drift / proposal comment (status='resolved' +
 //     a resolution note for accept / reject / dismiss), addressed by its c-N ref.
+//   - add_clause / edit_clause / delete_clause (spec-175) — apply a rule change
+//     at clause grain. Standards are clause-backed (spec-150 / spec-161), so
+//     update_section now hard-rejects on a Standard; these are the verbs that
+//     actually let the drift agent edit rule text. The cl-N refs they need are
+//     surfaced inline by get_doc.
 // update_section and update_comment both resolve their target memex-scoped via
 // the input ref (no bound docId needed). render_confirmation (a UI tool, always
 // included below) gates EVERY mutation — the agent proposes before it writes.
@@ -338,6 +343,9 @@ const DRIFT_SERVER_TOOLS = new Set<string>([
   "list_comments",
   "update_section",
   "update_comment",
+  "add_clause",
+  "edit_clause",
+  "delete_clause",
 ]);
 
 /** All tool definitions for the Anthropic API. Last tool has cache_control.


### PR DESCRIPTION
## Prod-targeted twin of #10

Same branch, targeting `main` directly so the production merge carries **only** this change. The branch was cut from `main`, so this PR is a clean diff with no dependence on `develop`'s state (which may accumulate other in-flight work before promotion).

## Change

Add `add_clause` / `edit_clause` / `delete_clause` to `DRIFT_SERVER_TOOLS` (`packages/server/src/agent/tools.ts`) so the live drift agent can edit clause-backed Standards. The set gates both the model-visible tool definitions and execution (`isDriftModeTool`), so one change covers both. The `cl-N` refs the edit/delete verbs need are already surfaced inline by `get_doc`.

Standards are clause-backed (spec-150 / spec-161), so `update_section` now hard-rejects on a Standard; the drift agent's focused surface only carried `update_section`, leaving it unable to edit the rule text of the Standards it raises drift on.

## Commits
1. Add the clause verbs to the drift surface.
2. Update the `tools.drift-mode.test.ts` characterization snapshot (and drop a redundant assertion) to pin the new drift set.

## Tests
- `tools.drift-mode.test.ts`: 6 passed (pins the exact drift surface incl. the clause verbs).
- Full server suite green in CI parity; see #10 for the int validation run.

## Scope
Minimal production unblock. The broader refactor (unify the three tool-surface filters) is tracked in spec-175 and intentionally not in this PR.