### PR TITLE
fix: make namespace INSERT idempotent on signup retry (spec-177)

### DIFF
--- a/packages/server/src/services/user-namespaces.ts
+++ b/packages/server/src/services/user-namespaces.ts
@@ -103,14 +103,17 @@ export async function ensureUserNamespace(
         ({ memexId: r.memex.id, userId, entity: "memex" as const, action: "created" as const }),
     ],
     () => db.transaction(async (tx) => {
-      const [namespace] = await tx
+      const [inserted] = await tx
         .insert(namespaces)
         .values({
           slug,
           kind: "user",
           ownerUserId: userId,
         })
+        .onConflictDoNothing()
         .returning();
+      const namespace = inserted ?? await tx.query.namespaces.findFirst({ where: eq(namespaces.slug, slug) });
+      if (!namespace) throw new Error(`Namespace ${slug} not found after insert`);
 
       const [memex] = await tx
         .insert(memexes)


### PR DESCRIPTION
## Summary

- `ensureUserNamespace` used a plain `INSERT` with no conflict handling, causing a `23505 duplicate key` crash when two concurrent calls (e.g. signup + email resend) both read `namespaceId=null` and derived the same slug
- Changed to `INSERT ... ON CONFLICT DO NOTHING` with a fallback `findFirst` so the transaction always resolves a namespace row, even if it was already created by a racing caller
- No schema migration required — the unique constraint on `namespaces.slug` already exists

## Test plan

- [ ] Sign up with a new email → confirm namespace and personal memex are created
- [ ] Hit "Resend email" one or more times → no 500 error in server logs, no `duplicate key` error
- [ ] Verify `users.namespace_id` is correctly linked after the flow completes
- [ ] Check server logs show no unhandled `PostgresError` during the signup retry path

Spec: https://memex.ai/mindset-prod/memex-building-itself/specs/spec-177