### PR TITLE
spec-156: relay initial-LISTEN recovery, tagAc dual-instance fix, live authed e2e smoke (int+prod green)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -93,13 +93,19 @@ jobs:
           printf '%s\n' "$DEPLOY_ENV_FILE" > "scripts/deploy.${ENV}.env"
 
       - name: Deploy (server + UI + smoke)
-        # SMOKE_MCP_TOKEN enables the authed write tier of the smoke suite
-        # (b-70 t-8); the suite skips that tier cleanly when unset.
+        # SMOKE_MCP_TOKEN + SMOKE_SESSION_TOKEN enable the authed write tier of
+        # the smoke suite (b-70 t-8 / spec-156 ac-13): mxt_ drives /mcp writes,
+        # the session JWT holds the SSE stream open (sessionMiddleware is
+        # JWT-only). Both are environment secrets minted by
+        # `tsx src/db/seed-smoke.ts`; the suite skips that tier cleanly when
+        # either is unset. The session token expires (~180d) — re-run the seed
+        # script to rotate.
         # MEMEX_EMIT_KEY lets the smoke suite's tagAc() emissions land on the
         # prod memex (spec-156 ac-12/ac-13: the live relay-health + MCP→SSE
         # checks verify their ACs on every deploy). Without it the smoke still
         # runs — emissions are just silently rejected 401.
         env:
           SMOKE_MCP_TOKEN: ${{ secrets.SMOKE_MCP_TOKEN }}
+          SMOKE_SESSION_TOKEN: ${{ secrets.SMOKE_SESSION_TOKEN }}
           MEMEX_EMIT_KEY: ${{ secrets.MEMEX_EMIT_KEY }}
         run: bash deploy.sh

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -95,6 +95,11 @@ jobs:
       - name: Deploy (server + UI + smoke)
         # SMOKE_MCP_TOKEN enables the authed write tier of the smoke suite
         # (b-70 t-8); the suite skips that tier cleanly when unset.
+        # MEMEX_EMIT_KEY lets the smoke suite's tagAc() emissions land on the
+        # prod memex (spec-156 ac-12/ac-13: the live relay-health + MCP→SSE
+        # checks verify their ACs on every deploy). Without it the smoke still
+        # runs — emissions are just silently rejected 401.
         env:
           SMOKE_MCP_TOKEN: ${{ secrets.SMOKE_MCP_TOKEN }}
+          MEMEX_EMIT_KEY: ${{ secrets.MEMEX_EMIT_KEY }}
         run: bash deploy.sh

--- a/packages/ac-emit-vitest/src/index.ts
+++ b/packages/ac-emit-vitest/src/index.ts
@@ -17,11 +17,26 @@ export interface TaskLike {
   meta: Record<string, unknown>;
 }
 
-let currentTask: TaskLike | null = null;
+// The current-task slot lives on globalThis, NOT in module-local state.
+//
+// Why (spec-156, discovered 2026-06-05): inside the monorepo this package can
+// be instantiated TWICE in one vitest worker — setupFiles resolves
+// `@memex-ai-ac/vitest/setup` through Node's `default` condition (dist/), while
+// test files' bare `import { tagAc }` resolves through the `development`
+// condition (src/, added in spec-129 issue-1's stale-dist fix). With a
+// module-local `currentTask`, the setup hooks set the slot on the dist
+// instance and every tagAc call in the src instance saw `null` — silently
+// no-opping ALL emissions, local and CI alike. A globalThis slot is shared by
+// every instance regardless of how the consumer's resolver split them.
+const TASK_SLOT = Symbol.for("memex-ai-ac.currentTask");
+
+function readTaskSlot(): TaskLike | null {
+  return ((globalThis as Record<symbol, unknown>)[TASK_SLOT] as TaskLike | null) ?? null;
+}
 
 /** Internal — set by setup.ts beforeEach. */
 export function _setCurrentTask(task: TaskLike | null): void {
-  currentTask = task;
+  (globalThis as Record<symbol, unknown>)[TASK_SLOT] = task;
 }
 
 /** Internal — read the entries collected on a task. */
@@ -42,6 +57,7 @@ export function _readCurrentEntries(task: TaskLike): TaskMetaEntry[] {
  * @param options Per-call overrides for hidden and metadata
  */
 export function tagAc(ac_uid: string, options?: TagAcOptions): void {
+  const currentTask = readTaskSlot();
   if (!currentTask) return;
   const existing = _readCurrentEntries(currentTask);
   currentTask.meta[META_KEY] = [...existing, { ac_uid, options }];

--- a/packages/ac-emit-vitest/src/task-slot.test.ts
+++ b/packages/ac-emit-vitest/src/task-slot.test.ts
@@ -1,0 +1,31 @@
+// spec-156 (2026-06-05): the current-task slot must be shared across MODULE
+// INSTANCES of this package. In the monorepo, a consumer's setupFiles can
+// resolve the `default` export condition (dist/) while its test files resolve
+// the `development` condition (src/) — two live instances in one worker. With
+// a module-local slot, the setup hooks populated one instance and tagAc
+// silently no-opped on the other, killing every AC emission (local AND CI).
+// The slot now lives on globalThis (Symbol.for), so any instance combination
+// shares it. This test simulates the split with vi.resetModules().
+import { describe, it, expect, vi } from "vitest";
+
+describe("current-task slot survives module-instance duality (spec-156)", () => {
+  it("a second instance's tagAc sees the task set by the first instance", async () => {
+    const instanceA = await import("./index.js");
+    vi.resetModules();
+    const instanceB = await import("./index.js");
+    // Genuinely two instances — same source, distinct module copies.
+    expect(instanceB.tagAc).not.toBe(instanceA.tagAc);
+
+    const fakeTask = { meta: {} as Record<string, unknown> };
+    try {
+      instanceA._setCurrentTask(fakeTask);
+      // The OTHER instance must observe the slot and attach the entry.
+      instanceB.tagAc("probe://dual-instance", { hidden: true });
+      const entries = (fakeTask.meta.__memex_ac_uids as unknown[] | undefined) ?? [];
+      expect(entries).toHaveLength(1);
+    } finally {
+      // Restore the slot so the real afterEach/beforeEach hooks are unaffected.
+      instanceA._setCurrentTask(null);
+    }
+  });
+});

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -30,6 +30,7 @@
     "db:migrate:hand": "bash scripts/apply-hand-migrations.sh",
     "db:seed": "tsx src/db/seed.ts",
     "db:seed-reviewer": "tsx src/db/seed-reviewer.ts",
+    "db:seed-smoke": "tsx src/db/seed-smoke.ts",
     "oauth:smoke": "node scripts/oauth-smoke.mjs",
     "docker:build": "docker build -t memex-server .",
     "docker:run": "docker run -p 8080:8080 --env-file .env memex-server",

--- a/packages/server/src/__regression__/ac-emit-phone-home-wiring.regression.test.ts
+++ b/packages/server/src/__regression__/ac-emit-phone-home-wiring.regression.test.ts
@@ -37,6 +37,27 @@ const HELPER_PACKAGE_ROOT = join(
 const WORKTREE_ROOT = join(SERVER_ROOT, "..", "..");
 
 describe("AC emit phone-home wiring — keep the setupFile wire alive", () => {
+  it("tagAc through the REAL setup wiring lands an entry on the running task (dual-instance guard, spec-156)", ({ task }) => {
+    // 2026-06-05 regression: setupFiles resolved the helper through Node's
+    // `default` condition (dist/) while this file's bare import resolved the
+    // `development` condition (src/) — two module instances. The setup hooks
+    // set `currentTask` on one instance; tagAc no-opped on the other, so EVERY
+    // AC emission (local and CI) silently stopped. The helper now shares the
+    // current-task slot via globalThis; this asserts the end-to-end wire in
+    // the exact environment that broke: a packages/server test file.
+    const before = (
+      ((task as unknown as { meta: Record<string, unknown> }).meta.__memex_ac_uids as
+        | unknown[]
+        | undefined) ?? []
+    ).length;
+    tagAc(`${SPEC_89}/ac-1`);
+    const entries =
+      ((task as unknown as { meta: Record<string, unknown> }).meta.__memex_ac_uids as
+        | unknown[]
+        | undefined) ?? [];
+    expect(entries.length).toBe(before + 1);
+  });
+
   it("vitest.config.ts declares a setupFiles entry", () => {
     const src = readFileSync(VITEST_CONFIG, "utf-8");
     expect(src).toMatch(/setupFiles\s*:/);

--- a/packages/server/src/__regression__/mutate-coverage.endpoint.test.ts
+++ b/packages/server/src/__regression__/mutate-coverage.endpoint.test.ts
@@ -213,6 +213,7 @@ describe("doc-16 t-11 / spec-156 ac-25: endpoint coverage — every mutation ent
 
   it("ac-25: FORWARD — every mutating manifest tool (readOnlyHint=false) is covered", () => {
     tagAc(`${AC}/ac-25`);
+    tagAc(`${AC}/ac-3`); // scope ac-3: enforcement-suite-fails-on-bypass guarantee
     const catalogued = new Set(Object.keys(MUTATING_MCP_TOOLS));
     const uncovered: string[] = [];
     for (const name of manifestMutating) {
@@ -233,6 +234,7 @@ describe("doc-16 t-11 / spec-156 ac-25: endpoint coverage — every mutation ent
 
   it("ac-25: REVERSE — every catalogued tool exists in the manifest and is non-read-only there", () => {
     tagAc(`${AC}/ac-25`);
+    tagAc(`${AC}/ac-3`); // scope ac-3: enforcement-suite-fails-on-bypass guarantee
     const manifestByName = new Map(toolManifest.map((e) => [e.name, e]));
     const problems: string[] = [];
     for (const name of Object.keys(MUTATING_MCP_TOOLS)) {

--- a/packages/server/src/__regression__/mutate-coverage.static-scan.test.ts
+++ b/packages/server/src/__regression__/mutate-coverage.static-scan.test.ts
@@ -316,6 +316,7 @@ describe("doc-21 t-4 / spec-156 W3: static scan — every mutation goes through 
   const files = SCAN_DIRS.flatMap((d) => listScannableFiles(join(SRC_DIR, d)));
 
   it(`finds files to scan across all std-8 §s-3 layers`, () => {
+    tagAc(`${AC}/ac-3`); // scope ac-3: enforcement-suite-fails-on-bypass guarantee
     expect(files.length).toBeGreaterThan(20);
     // Sanity: the scan reaches outside services/ now (ac-22 scope).
     const keys = files.map(relKey);
@@ -358,6 +359,7 @@ describe("doc-21 t-4 / spec-156 W3: static scan — every mutation goes through 
 describe("spec-156 W3: static-scan meta-tests", () => {
   it("ac-22: a seeded raw db write (as would live under routes/) fails the scan", () => {
     tagAc(`${AC}/ac-22`);
+    tagAc(`${AC}/ac-3`); // scope ac-3: enforcement-suite-fails-on-bypass guarantee
     // A route handler that writes directly to the DB without mutate() — the
     // exact shape the widened scan must now reject anywhere, not just services/.
     const routeSource = `

--- a/packages/server/src/__smoke__/authed.smoke.test.ts
+++ b/packages/server/src/__smoke__/authed.smoke.test.ts
@@ -24,8 +24,8 @@ import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import {
   SMOKE_BASE_URL,
   SMOKE_MCP_TOKEN,
+  SMOKE_SESSION_TOKEN,
   SMOKE_NAMESPACE,
-  SMOKE_CANONICAL_REF,
   callMcpTool,
   callMcpInitialize,
   mcpTextPayload,
@@ -39,7 +39,10 @@ const UUID_RE =
 
 /** Pull the first `ref: <ref>` token out of an MCP text payload. */
 function parseRef(text: string): string | null {
-  const m = text.match(/ref:\s*([^\s"]+)/i);
+  // Exclude closing punctuation: tool replies often parenthesise the ref
+  // ("… (ref: ns/mx/specs/spec-1/sections/s-2)."), and a captured `).` makes
+  // the next tool call fail on an invalid ref.
+  const m = text.match(/ref:\s*([^\s")]+)/i);
   return m ? m[1] : null;
 }
 
@@ -135,9 +138,23 @@ describe.skipIf(!SMOKE_MCP_TOKEN)(
     });
 
     it("canonical ref call succeeds and emits `ref:` (no UUIDs leaked)", async () => {
-      const { status, body } = await callMcpTool("get_doc", {
-        ref: SMOKE_CANONICAL_REF,
-      });
+      // The smoke token is scoped to the throwaway tenant (zzz-smoke), so the
+      // per-env default SMOKE_CANONICAL_REF (a real-tenant doc) 404s under
+      // std-7. Unless a ref is explicitly provided for an ad-hoc run with a
+      // wider-scoped token, provision our own doc and assert the canonical-ref
+      // grammar on it — the b-36 property (refs in, no UUIDs out) is the same.
+      let ref = process.env.SMOKE_CANONICAL_REF ?? "";
+      if (!ref) {
+        const created = await callMcpTool("create_doc", {
+          memex: SMOKE_NAMESPACE,
+          title: `[smoke] canonical-ref probe ${new Date().toISOString()}`,
+          purpose: "Canonical-ref smoke — safe to delete.",
+        });
+        expect(created.body.result?.isError).toBeFalsy();
+        ref = parseRef(mcpTextPayload(created.body)) ?? "";
+        expect(ref, "create_doc should return a canonical ref").toBeTruthy();
+      }
+      const { status, body } = await callMcpTool("get_doc", { ref });
       expect(status).toBe(200);
       expect(body.error).toBeUndefined();
       expect(body.result?.isError).toBeFalsy();
@@ -197,21 +214,22 @@ describe.skipIf(!SMOKE_MCP_TOKEN)(
       expect(refParts.length).toBeGreaterThanOrEqual(4);
       const [refNs, refMx] = refParts;
 
-      // Resolve docId from get_doc (verbose mode includes the UUID).
-      const docFull = await callMcpTool("get_doc", {
-        ref: docRef!,
-        verbose: true,
+      // b-36 hard-cut: MCP output never carries raw UUIDs (even verbose), so
+      // resolve the docId the way the React UI does — the REST docs list,
+      // which speaks UUIDs to session-authed callers. REST sits behind
+      // sessionMiddleware (JWT-only), so these calls use SMOKE_SESSION_TOKEN.
+      const listRes = await fetch(`${SMOKE_BASE_URL}/api/${refNs}/${refMx}/docs`, {
+        headers: { Authorization: `Bearer ${SMOKE_SESSION_TOKEN}` },
       });
-      const docText = mcpTextPayload(docFull.body);
-      const docIdMatch = docText.match(
-        /\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/i,
-      );
-      expect(docIdMatch, "expected a doc UUID in the get_doc payload").toBeTruthy();
-      const docId = docIdMatch![0];
+      expect(listRes.status).toBe(200);
+      const docsList = (await listRes.json()) as Array<{ id: string; title: string }>;
+      const ourDoc = docsList.find((d) => d.title === `[smoke] AC endpoint check ${stamp}`);
+      expect(ourDoc, "expected the created doc in the REST docs list").toBeDefined();
+      const docId = ourDoc!.id;
 
       const url = `${SMOKE_BASE_URL}/api/${refNs}/${refMx}/acs/doc/${docId}`;
       const res = await fetch(url, {
-        headers: { Authorization: `Bearer ${SMOKE_MCP_TOKEN}` },
+        headers: { Authorization: `Bearer ${SMOKE_SESSION_TOKEN}` },
       });
       expect(res.status).toBe(200);
       const rows = (await res.json()) as Array<{
@@ -236,7 +254,7 @@ describe.skipIf(!SMOKE_MCP_TOKEN)(
       // Sparkline endpoint — same Spec, days clamp, response shape.
       const histRes = await fetch(
         `${SMOKE_BASE_URL}/api/${refNs}/${refMx}/acs/doc/${docId}/alignment-history?days=14`,
-        { headers: { Authorization: `Bearer ${SMOKE_MCP_TOKEN}` } },
+        { headers: { Authorization: `Bearer ${SMOKE_SESSION_TOKEN}` } },
       );
       expect(histRes.status).toBe(200);
       const hist = (await histRes.json()) as Array<{
@@ -332,9 +350,10 @@ describe.skipIf(!SMOKE_MCP_TOKEN)(
       const sectionRef = parseRef(mcpTextPayload(added.body));
       expect(sectionRef, "add_section should return a section ref").toBeTruthy();
 
-      // READ — heading + marker are present.
+      // READ — heading + marker are present. Terse get_doc omits section
+      // bodies, so these lifecycle reads use verbose mode.
       let docText = mcpTextPayload(
-        (await callMcpTool("get_doc", { ref: docRef! })).body,
+        (await callMcpTool("get_doc", { ref: docRef!, verbose: true })).body,
       );
       expect(docText).toContain("Smoke Lens");
       expect(docText).toContain(marker);
@@ -346,7 +365,7 @@ describe.skipIf(!SMOKE_MCP_TOKEN)(
       });
       expect(retitled.body.result?.isError).toBeFalsy();
       docText = mcpTextPayload(
-        (await callMcpTool("get_doc", { ref: docRef! })).body,
+        (await callMcpTool("get_doc", { ref: docRef!, verbose: true })).body,
       );
       expect(docText).toContain("Smoke Lens Renamed");
       expect(docText).toContain(marker);
@@ -356,7 +375,7 @@ describe.skipIf(!SMOKE_MCP_TOKEN)(
       const deleted = await callMcpTool("delete_section", { ref: sectionRef! });
       expect(deleted.body.result?.isError).toBeFalsy();
       docText = mcpTextPayload(
-        (await callMcpTool("get_doc", { ref: docRef! })).body,
+        (await callMcpTool("get_doc", { ref: docRef!, verbose: true })).body,
       );
       expect(docText).not.toContain(marker);
       expect(docText).not.toContain("Smoke Lens Renamed");

--- a/packages/server/src/__smoke__/bus-relay.smoke.test.ts
+++ b/packages/server/src/__smoke__/bus-relay.smoke.test.ts
@@ -50,6 +50,7 @@ describe(`bus-relay smoke @ ${SMOKE_BASE_URL}`, () => {
   // ── ac-12: the relay's LISTEN health is exposed on /api/health and is LIVE.
   it("GET /api/health → relay is attached and LISTENing (spec-156 ac-12)", async () => {
     tagAc(`${AC}/ac-12`);
+    tagAc(`${AC}/ac-4`); // scope ac-4: cross-instance guarantee observable on live envs
     const res = await fetch(`${SMOKE_BASE_URL}/api/health`);
     expect(res.status).toBe(200);
     const body = (await res.json()) as {
@@ -159,6 +160,8 @@ describe.skipIf(!SMOKE_MCP_TOKEN)(
     //    stream within a bounded window — the full mutate→bus→SSE path, deployed.
     it("MCP mutation arrives as a doc_change SSE frame within a bounded window (spec-156 ac-13)", async () => {
       tagAc(`${AC}/ac-13`);
+      tagAc(`${AC}/ac-4`); // scope ac-4: live end-to-end MCP→SSE proof
+      tagAc(`${AC}/ac-1`); // scope ac-1: the exact kanban scenario, against the deployed env
       // Guard rail: only ever drive writes against an obvious throwaway namespace.
       if (!/smoke/i.test(SMOKE_NAMESPACE)) {
         throw new Error(

--- a/packages/server/src/__smoke__/bus-relay.smoke.test.ts
+++ b/packages/server/src/__smoke__/bus-relay.smoke.test.ts
@@ -29,6 +29,7 @@ import { tagAc } from "@memex-ai-ac/vitest";
 import {
   SMOKE_BASE_URL,
   SMOKE_MCP_TOKEN,
+  SMOKE_SESSION_TOKEN,
   SMOKE_NAMESPACE,
   callMcpTool,
   mcpTextPayload,
@@ -75,7 +76,9 @@ describe(`bus-relay smoke @ ${SMOKE_BASE_URL}`, () => {
 
 /** Pull the first `ref: <ref>` token out of an MCP text payload. */
 function parseRef(text: string): string | null {
-  const m = text.match(/ref:\s*([^\s"]+)/i);
+  // Exclude closing punctuation: tool replies often parenthesise the ref —
+  // a captured `).` makes the next tool call fail on an invalid ref.
+  const m = text.match(/ref:\s*([^\s")]+)/i);
   return m ? m[1] : null;
 }
 
@@ -89,9 +92,11 @@ interface SSEStream {
  *  stream and read forward until the server's `ready` frame, so the bus listener
  *  is guaranteed attached before we fire the mutation (no fixed-sleep race). */
 async function openMemexStream(memexPath: string, timeoutMs = 10_000): Promise<SSEStream> {
+  // Session JWT, NOT the mxt_ token: the SSE routes sit behind
+  // sessionMiddleware, which only resolves session JWTs (mxt_ is /mcp-only).
   const res = await fetch(`${SMOKE_BASE_URL}${memexPath}/docs/events`, {
     headers: {
-      Authorization: `Bearer ${SMOKE_MCP_TOKEN}`,
+      Authorization: `Bearer ${SMOKE_SESSION_TOKEN}`,
       Accept: "text/event-stream",
     },
   });
@@ -153,7 +158,7 @@ async function readDocChange(
   }
 }
 
-describe.skipIf(!SMOKE_MCP_TOKEN)(
+describe.skipIf(!SMOKE_MCP_TOKEN || !SMOKE_SESSION_TOKEN)(
   `bus-relay e2e SSE smoke @ ${SMOKE_BASE_URL} (ns=${SMOKE_NAMESPACE})`,
   () => {
     // ── ac-13: a live /mcp mutation lands as a doc_change frame on an open SSE
@@ -199,10 +204,11 @@ describe.skipIf(!SMOKE_MCP_TOKEN)(
       // is the observed event so we don't race the create we already consumed.
       const stream = await openMemexStream(memexPath);
       try {
-        const marker = `relay-sse-marker-${stamp}`;
+        // update_doc accepts status/title/tags — a title rename is the least
+        // intrusive mutation that still emits document.updated.
         const updated = await callMcpTool("update_doc", {
           ref: createdRef!,
-          purpose: `${purpose} ${marker}`,
+          title: `${title} (relay-sse-marker)`,
         });
         expect(updated.body.result?.isError).toBeFalsy();
 
@@ -223,6 +229,76 @@ describe.skipIf(!SMOKE_MCP_TOKEN)(
           /* best-effort */
         }
       }
+    });
+
+    // ── ac-1 (scope): repeated MCP mutations ALL arrive on one long-lived SSE
+    //    stream. On prod (--max-instances 3, no session affinity) the /mcp
+    //    request and the SSE stream routinely land on DIFFERENT instances, so a
+    //    multi-round loop exercises the relay's cross-instance hop with high
+    //    probability — the single-round test above can get lucky on one warm
+    //    instance. Health samples between rounds record the distinct relay
+    //    originIds observed, evidencing how many instances served the run.
+    it("N consecutive MCP mutations each arrive on the same open SSE stream (spec-156 ac-1 cross-instance)", async () => {
+      tagAc(`${AC}/ac-1`);
+      if (!/smoke/i.test(SMOKE_NAMESPACE)) {
+        throw new Error(
+          `Refusing to run bus-relay e2e smoke against namespace "${SMOKE_NAMESPACE}" — ` +
+            `it must be an obvious throwaway (contain "smoke"). Set SMOKE_NAMESPACE.`,
+        );
+      }
+      const ROUNDS = 4;
+      const stamp = new Date().toISOString();
+
+      const created = await callMcpTool("create_doc", {
+        memex: SMOKE_NAMESPACE,
+        title: `[smoke] relay-sse-multi ${stamp}`,
+        purpose: "Bus-relay multi-round SSE smoke (spec-156 ac-1) — safe to delete.",
+      });
+      expect(created.status).toBe(200);
+      expect(created.body.result?.isError).toBeFalsy();
+      const ref = parseRef(mcpTextPayload(created.body));
+      expect(ref, "create_doc should return a canonical ref").toBeTruthy();
+      const parts = ref!.split("/");
+      const memexPath = `/api/${parts[0]}/${parts[1]}`;
+
+      const origins = new Set<string>();
+      const sampleOrigin = async () => {
+        try {
+          const res = await fetch(`${SMOKE_BASE_URL}/api/health`);
+          const body = (await res.json()) as { relay?: RelayHealthShape | null };
+          if (body.relay?.originId) origins.add(body.relay.originId);
+        } catch {
+          /* sampling is best-effort */
+        }
+      };
+
+      const stream = await openMemexStream(memexPath);
+      try {
+        for (let round = 1; round <= ROUNDS; round++) {
+          await sampleOrigin();
+          const updated = await callMcpTool("update_doc", {
+            ref: ref!,
+            title: `[smoke] relay-sse-multi ${stamp} r${round}/${ROUNDS}`,
+          });
+          expect(updated.body.result?.isError, `round ${round}: update_doc should succeed`).toBeFalsy();
+          // One update_doc → one document event (origin dedup is pinned by the
+          // unit/integration tiers, so frame-per-round matching is sound here).
+          const event = await readDocChange(stream, (data) => data.entity === "document");
+          expect(event, `round ${round}/${ROUNDS}: expected a doc_change SSE frame`).not.toBeNull();
+        }
+      } finally {
+        try {
+          await stream.reader.cancel();
+        } catch {
+          /* best-effort */
+        }
+      }
+      await sampleOrigin();
+      // Purely informational — int may legitimately run a single instance.
+      // eslint-disable-next-line no-console
+      console.log(
+        `[bus-relay smoke] ${ROUNDS}/${ROUNDS} rounds delivered; distinct relay originIds observed: ${origins.size}`,
+      );
     });
   },
 );

--- a/packages/server/src/__smoke__/oauth-consent-allow-button.smoke.test.ts
+++ b/packages/server/src/__smoke__/oauth-consent-allow-button.smoke.test.ts
@@ -20,12 +20,17 @@ describe(`oauth consent Allow-button legibility smoke @ ${SMOKE_BASE_URL}`, () =
   it("deployed CSS bundle defines on-accent (both themes) + the .text-on-accent utility (spec-167 ac-6)", async () => {
     tagAc(AC6);
 
-    // 1. The SPA index references a content-hashed CSS bundle.
-    const indexRes = await fetch(`${SMOKE_BASE_URL}/`);
-    expect(indexRes.status).toBe(200);
+    // 1. The SPA index references a content-hashed CSS bundle. Fetch an app
+    //    route, NOT `/` — on prod the apex root 301s to the marketing site
+    //    (std-2 topology) with an empty body. The SPA fallback serves the
+    //    shell with HTTP 404 for client-side routes on both envs, so the
+    //    assertion is on the body (the property under test is the CSS bundle,
+    //    not the route's status code).
+    const indexRes = await fetch(`${SMOKE_BASE_URL}/login`);
+    expect([200, 404]).toContain(indexRes.status);
     const html = await indexRes.text();
     const ref = html.match(/\/assets\/index-[\w-]+\.css/);
-    expect(ref, "index.html should reference a hashed CSS bundle").toBeTruthy();
+    expect(ref, "the SPA shell should reference a hashed CSS bundle").toBeTruthy();
 
     // 2. Fetch the actual deployed stylesheet.
     const cssRes = await fetch(`${SMOKE_BASE_URL}${ref![0]}`);

--- a/packages/server/src/__smoke__/smoke-env.ts
+++ b/packages/server/src/__smoke__/smoke-env.ts
@@ -39,6 +39,16 @@ export const SMOKE_MCP_URL = `${SMOKE_BASE_URL}/mcp`;
 export const SMOKE_MCP_TOKEN = process.env.SMOKE_MCP_TOKEN ?? "";
 
 /**
+ * Session JWT for the smoke user (spec-156 ac-13). The SSE routes sit behind
+ * sessionMiddleware, which resolves session JWTs ONLY — mxt_ tokens are an
+ * /mcp-side credential (app.ts → verifyMcpToken) and never reach the session
+ * path. So the e2e SSE tier needs BOTH: SMOKE_MCP_TOKEN to drive /mcp writes
+ * and SMOKE_SESSION_TOKEN to hold the stream open. Minted alongside the PAT by
+ * `tsx src/db/seed-smoke.ts` (expires — see the script for rotation).
+ */
+export const SMOKE_SESSION_TOKEN = process.env.SMOKE_SESSION_TOKEN ?? "";
+
+/**
  * Optional Postgres URL the telemetry-smoke tier connects to. Absent in the
  * pure-HTTP smoke setup; populated by callers that have spun up a
  * cloud-sql-proxy to the target env's Cloud SQL instance (see the
@@ -52,7 +62,7 @@ export const SMOKE_DATABASE_URL = process.env.SMOKE_DATABASE_URL ?? "";
  * (dec-2). Reserved as an obvious non-production slug. The authed tier MUST
  * NEVER touch any other namespace/memex on the shared host.
  */
-export const SMOKE_NAMESPACE = process.env.SMOKE_NAMESPACE ?? "zzz-smoke";
+export const SMOKE_NAMESPACE = process.env.SMOKE_NAMESPACE ?? "zzz-smoke/main";
 
 /**
  * Per-env default canonical ref for the folded-in canonical-refs check (the

--- a/packages/server/src/agent/tool-specs.tag-channel.integration.test.ts
+++ b/packages/server/src/agent/tool-specs.tag-channel.integration.test.ts
@@ -126,6 +126,7 @@ describe("spec-156 ac-19: update_doc tag-write channel follows the invoking cont
 
   it("in_app_agent ctx → tag write emits channel 'in_app_agent'", async () => {
     tagAc(AC_19);
+    tagAc("mindset-prod/memex-building-itself/specs/spec-156/acs/ac-2"); // scope ac-2: channel-attribution finding
     const received = captureTagEvents();
     await specByName("update_doc").handler(
       { ref, tags: ["agentwrote"] },

--- a/packages/server/src/db/seed-smoke.ts
+++ b/packages/server/src/db/seed-smoke.ts
@@ -1,0 +1,113 @@
+// spec-156 verify — provision the post-deploy smoke fixture (b-70 t-9).
+//
+// Usage (against a live env's Cloud SQL via cloud-sql-proxy):
+//   DATABASE_URL=postgresql://… AUTH_JWT_SECRET=… tsx src/db/seed-smoke.ts
+//
+// Idempotent: re-running is safe. The script ensures:
+//   1. User `smoke-probe@memex.ai` exists (verified, active).
+//   2. Namespace `zzz-smoke` (kind=user, owned by the smoke user) with a
+//      `main` Memex — the throwaway tenant the authed smoke tier writes into
+//      (SMOKE_NAMESPACE guard in bus-relay.smoke.test.ts requires "smoke" in
+//      the slug, so writes can never target a real tenant).
+//   3. A fresh mxt_ PAT minted for the smoke user (printed) → SMOKE_MCP_TOKEN.
+//   4. A session JWT signed for the smoke user (printed) → SMOKE_SESSION_TOKEN.
+//      The SSE routes sit behind sessionMiddleware (JWT-only — mxt_ tokens are
+//      /mcp-only), so the e2e tier needs both credentials. Requires
+//      AUTH_JWT_SECRET to match the target env (Secret Manager: auth-jwt-secret).
+//
+// Store both printed tokens as GitHub environment secrets (int / prod) so the
+// deploy-tail smoke runs the authed tier. The session token expires — re-run
+// this script to rotate (default TTL 180 days).
+
+import "dotenv/config";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import { eq, and } from "drizzle-orm";
+import * as schema from "./schema.js";
+import { namespaces, memexes, users } from "./schema.js";
+import { mintMcpToken } from "../services/mcp-tokens.js";
+import { signSessionToken } from "../services/auth-jwt.js";
+
+const SMOKE_EMAIL = "smoke-probe@memex.ai";
+const SMOKE_NAMESPACE_SLUG = "zzz-smoke";
+const SMOKE_MEMEX_SLUG = "main";
+const SESSION_TTL_SECONDS = 180 * 24 * 60 * 60; // 180 days — rotate by re-running.
+
+async function main() {
+  const connectionString = process.env.DATABASE_URL;
+  if (!connectionString) throw new Error("DATABASE_URL is required");
+  if (!process.env.AUTH_JWT_SECRET) {
+    throw new Error(
+      "AUTH_JWT_SECRET is required — the printed session token must verify on the target env " +
+        "(Secret Manager: auth-jwt-secret). Refusing to sign with the dev fallback.",
+    );
+  }
+  const client = postgres(connectionString);
+  const db = drizzle(client, { schema });
+
+  console.log("Seeding smoke fixture…");
+
+  // ── 1. User ─────────────────────────────────────────────────────────
+  let user = await db.query.users.findFirst({ where: eq(users.email, SMOKE_EMAIL) });
+  if (!user) {
+    [user] = await db
+      .insert(users)
+      .values({
+        email: SMOKE_EMAIL,
+        name: "Smoke probe",
+        emailVerifiedAt: new Date(),
+      } as typeof users.$inferInsert)
+      .returning();
+    console.log(`  Created user ${user.id} <${SMOKE_EMAIL}>`);
+  } else {
+    console.log(`  User exists: ${user.id} <${SMOKE_EMAIL}>`);
+  }
+
+  // ── 2. Throwaway namespace + Memex ──────────────────────────────────
+  let ns = await db.query.namespaces.findFirst({
+    where: eq(namespaces.slug, SMOKE_NAMESPACE_SLUG),
+  });
+  if (!ns) {
+    [ns] = await db
+      .insert(namespaces)
+      .values({ slug: SMOKE_NAMESPACE_SLUG, kind: "user", ownerUserId: user.id })
+      .returning();
+    console.log(`  Created namespace ${SMOKE_NAMESPACE_SLUG}`);
+  }
+
+  // Point the user's personal namespace at zzz-smoke so the session
+  // middleware's lazy ensureUserNamespace() never provisions a second one.
+  if (user.namespaceId !== ns.id) {
+    await db.update(users).set({ namespaceId: ns.id }).where(eq(users.id, user.id));
+    console.log(`  Linked user.namespaceId → ${SMOKE_NAMESPACE_SLUG}`);
+  }
+
+  let memex = await db.query.memexes.findFirst({
+    where: and(eq(memexes.namespaceId, ns.id), eq(memexes.slug, SMOKE_MEMEX_SLUG)),
+  });
+  if (!memex) {
+    [memex] = await db
+      .insert(memexes)
+      .values({ namespaceId: ns.id, slug: SMOKE_MEMEX_SLUG, name: "Smoke" })
+      .returning();
+    console.log(`  Created memex ${SMOKE_NAMESPACE_SLUG}/${SMOKE_MEMEX_SLUG}`);
+  }
+
+  // ── 3. mxt_ PAT (for /mcp) ──────────────────────────────────────────
+  const minted = await mintMcpToken(user.id, "post-deploy smoke (spec-156 ac-13)");
+
+  // ── 4. Session JWT (for the SSE routes) ─────────────────────────────
+  const sessionToken = signSessionToken(user.id, SESSION_TTL_SECONDS);
+
+  console.log("\nDone. Provision these as GitHub environment secrets:\n");
+  console.log(`  SMOKE_MCP_TOKEN=${minted.raw}`);
+  console.log(`  SMOKE_SESSION_TOKEN=${sessionToken}`);
+  console.log(`\n  (session token TTL ${SESSION_TTL_SECONDS / 86400} days — re-run to rotate)`);
+
+  await client.end();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/server/src/mcp/tools.activity.integration.test.ts
+++ b/packages/server/src/mcp/tools.activity.integration.test.ts
@@ -53,6 +53,7 @@ describe("spec-156 ac-15: emitMcpActivity (MCP read/advisory emission helper)", 
 
   it("emits a 'viewed' event with channel 'mcp' and a narrative for a read tool", () => {
     tagAc(AC_15);
+    tagAc("mindset-prod/memex-building-itself/specs/spec-156/acs/ac-2"); // scope ac-2: MCP read-emission finding
     const received: ChangeEvent[] = [];
     bus.subscribe({}, (e) => received.push(e));
 

--- a/packages/server/src/routes/llm.persistence.integration.test.ts
+++ b/packages/server/src/routes/llm.persistence.integration.test.ts
@@ -187,6 +187,7 @@ describe("POST /llm/conversations (save)", () => {
   // the messages landed, so the emit can't be faked without the write.
   it("emits conversation_message.created on the bus AND lands the messages (ac-14)", async () => {
     tagAc(`${AC}/ac-14`);
+    tagAc(`${AC}/ac-2`); // scope ac-2: audit-finding remediation (this finding's proof)
     const app = makeAppForUser(memexId, USER_A);
 
     const received: ChangeEvent[] = [];

--- a/packages/server/src/routes/test-events.bus.integration.test.ts
+++ b/packages/server/src/routes/test-events.bus.integration.test.ts
@@ -77,6 +77,7 @@ afterEach(() => {
 describe("POST /api/test-events — bus emit on ingestion (spec-156 ac-16)", () => {
   it("emits test_event.created on the resolved memex when a run posts a result", async () => {
     tagAc(`${AC}/ac-16`);
+    tagAc(`${AC}/ac-2`); // scope ac-2: audit-finding remediation (this finding's proof)
 
     const received: ChangeEvent[] = [];
     const unsubscribe = bus.subscribe({ memexId }, (e) => received.push(e));

--- a/packages/server/src/services/bus-relay.integration.test.ts
+++ b/packages/server/src/services/bus-relay.integration.test.ts
@@ -83,6 +83,9 @@ const baseEvent = (over: Partial<ChangeEvent> = {}): ChangeEvent => ({
 describe("spec-156 W1 integration: real Postgres LISTEN/NOTIFY relay", () => {
   it("delivers an event emitted on instance A to a subscriber on instance B (ac-6)", async () => {
     tagAc(AC(6));
+    // Scope ac-1: the cross-channel/cross-instance reflection guarantee — this
+    // two-real-relay-instances-over-one-Postgres test is its broadest local proof.
+    tagAc(AC(1));
     const channel = `memex_bus_test_${randomUUID().replace(/-/g, "")}`;
     const a = await makePair(channel, "origin-A");
     const b = await makePair(channel, "origin-B");

--- a/packages/server/src/services/bus-relay.test.ts
+++ b/packages/server/src/services/bus-relay.test.ts
@@ -15,6 +15,7 @@ import { tagAc } from "@memex-ai-ac/vitest";
 import { ChangeBus, type ChangeEvent } from "./bus.js";
 import {
   PgBusRelay,
+  bridgePgListen,
   encodeEnvelope,
   trimEvent,
   reconnectNudge,
@@ -361,6 +362,73 @@ describe("spec-156 W1: kill-and-recover reconnect + nudge (ac-9)", () => {
     await relay.stop();
   });
 
+  it("recovers from a REJECTED initial LISTEN when postgres-js later re-establishes (issue-1: status returns to listening + nudge fires exactly once)", async () => {
+    tagAc(AC(28));
+    // Issue-1, observed live on prod 2026-06-04: the instance boots while the
+    // DB is restarting → the initial sql.listen() REJECTS → the relay routes it
+    // through onConnectionError (selfReconnects: no own backoff). postgres-js
+    // keeps the listener registered internally and re-establishes it, firing
+    // onlisten — but that FIRST onlisten was swallowed as "initial connect" by
+    // the driver bridge, so the relay stranded at status "connecting" with
+    // connects=0 and no convergence nudge, while events flowed underneath
+    // (health lying about a live relay).
+    //
+    // Model the real postgres-js shape through bridgePgListen: rawListen
+    // rejects on the first call but RETAINS the onListen callback, which the
+    // test later fires to simulate the driver's internal recovery.
+    const bus = new ChangeBus();
+    let recoveredOnListen: (() => void) | null = null;
+    const rawListen = async (
+      _channel: string,
+      _onNotify: (payload: string) => void,
+      onListen: () => void,
+    ): Promise<void> => {
+      recoveredOnListen = onListen;
+      throw new Error("simulated: DB restarting during boot (53300)");
+    };
+    const driver: ListenDriver = {
+      selfReconnects: true,
+      listen: bridgePgListen(rawListen),
+      async close() {},
+    };
+    const relay = new PgBusRelay({
+      bus,
+      listenDriver: driver,
+      notifyDriver: { notify: async () => {} },
+      originId: "origin-issue-1",
+    });
+    bus.attachRelay(relay);
+
+    const nudges: ChangeEvent[] = [];
+    bus.subscribe({ memexId: "real-memex" }, (e) => {
+      if (e.payload?.__relayReconnect === true) nudges.push(e);
+    });
+
+    // Boot: initial LISTEN rejects. Non-fatal — relay degrades, no throw.
+    await relay.start();
+    expect(relay.health().listening).toBe(false);
+    expect(relay.health().connects).toBe(0);
+
+    // postgres-js internally re-establishes the LISTEN and fires onlisten.
+    expect(recoveredOnListen).not.toBeNull();
+    recoveredOnListen!();
+
+    // The relay must treat that recovery as a reconnect: restore "listening",
+    // count the connect, and fire the convergence nudge exactly once.
+    expect(relay.health().listening).toBe(true);
+    expect(relay.health().status).toBe("listening");
+    expect(relay.health().connects).toBe(1);
+    expect(nudges).toHaveLength(1);
+
+    // A subsequent ordinary recovery still behaves like a regular reconnect.
+    recoveredOnListen!();
+    expect(relay.health().status).toBe("listening");
+    expect(relay.health().connects).toBe(2);
+    expect(nudges).toHaveLength(2);
+
+    await relay.stop();
+  });
+
   it("the first connect does NOT nudge (no gap to converge)", async () => {
     tagAc(AC(9));
     const broker = new FakeBroker();
@@ -539,6 +607,7 @@ describe("spec-156 W1: health reports relay LISTEN-connection status (ac-12)", (
 describe("spec-156 W1 (dec-3): deploy.sh keeps --max-instances 3 (ac-27)", () => {
   it("deploy.sh still pins --max-instances 3 — no interim single-instance throttle", () => {
     tagAc(AC(27));
+    tagAc(AC(5)); // scope ac-5: prod runs at full scale throughout (dec-3)
     const here = dirname(fileURLToPath(import.meta.url));
     // src/services/ -> packages/server/deploy.sh
     const deployPath = join(here, "..", "..", "deploy.sh");

--- a/packages/server/src/services/bus-relay.ts
+++ b/packages/server/src/services/bus-relay.ts
@@ -494,6 +494,60 @@ export class PgBusRelay implements BusRelay {
 // fire-and-forget statement and does not need a dedicated socket.
 
 /**
+ * The raw postgres-js listen shape: `sql.listen(channel, onNotify, onListen)`.
+ * Pulled out so the onlisten-bridging logic below is unit-testable without a
+ * real postgres client (issue-1 pins the rejected-initial-connect path).
+ */
+type RawListen = (
+  channel: string,
+  onNotify: (payload: string) => void,
+  onListen: () => void,
+) => Promise<unknown>;
+
+/**
+ * Bridge postgres-js's onlisten signal onto the relay's ListenCallbacks
+ * contract. postgres-js does NOT expose a per-channel "socket dropped"
+ * callback on the internal listen sub-client (its onclose is hardcoded to
+ * re-listen), so the only event we can observe is RECOVERY: onlisten fires on
+ * the initial connect AND on every internal reconnect. The first call is the
+ * initial connect (no gap to converge); each subsequent call means the LISTEN
+ * was just re-established after a drop — that is our reconnect signal, which
+ * fires the relay's degrade→restore + nudge path (ac-9).
+ *
+ * One wrinkle (issue-1): when the INITIAL listen() promise REJECTS (boot while
+ * the DB is restarting), postgres-js keeps the listener registered and still
+ * re-establishes it internally — so the NEXT onlisten is a RECOVERY from a
+ * failure the relay already observed, not the "initial connect". It must
+ * surface as a reconnect, or the relay strands at status "connecting" forever
+ * (connects=0, no nudge) while events flow underneath — health lying about a
+ * live relay.
+ */
+export function bridgePgListen(rawListen: RawListen): ListenDriver["listen"] {
+  return async (channel, { onNotify, onReconnect }) => {
+    let established = false;
+    let initialRejected = false;
+    const pending = rawListen(channel, onNotify, () => {
+      if (!established) {
+        established = true;
+        // The awaited establish already failed → this onlisten is postgres-js
+        // recovering from the rejected initial connect (issue-1). The relay
+        // counted the failure via onError; surface the recovery as a reconnect
+        // so markEstablished runs (status → "listening", nudge fires).
+        if (initialRejected) onReconnect?.();
+        return;
+      }
+      onReconnect?.();
+    });
+    try {
+      await pending;
+    } catch (err) {
+      initialRejected = true;
+      throw err;
+    }
+  };
+}
+
+/**
  * Build a ListenDriver backed by its OWN single-connection postgres client
  * (NOT the shared pool). The connection string is taken from DATABASE_URL by
  * default, matching db/connection.ts, with the same Cloud SQL socket handling.
@@ -520,23 +574,7 @@ export function createPgListenDriver(opts?: {
     // node_modules/postgres/src/index.js listen()). The relay must NOT also run
     // its own backoff loop, or two LISTENers would race — hence selfReconnects.
     selfReconnects: true,
-    async listen(channel, { onNotify, onReconnect }) {
-      // postgres-js does NOT expose a per-channel "socket dropped" callback on
-      // the internal listen sub-client (its onclose is hardcoded to re-listen),
-      // so the only event we can observe is RECOVERY: onlisten fires on the
-      // initial connect AND on every internal reconnect. The first call is the
-      // initial connect (no gap to converge); each subsequent call means the
-      // LISTEN was just re-established after a drop — that is our reconnect
-      // signal, which fires the relay's degrade→restore + nudge path (ac-9).
-      let established = false;
-      await sql.listen(channel, onNotify, () => {
-        if (!established) {
-          established = true;
-          return;
-        }
-        onReconnect?.();
-      });
-    },
+    listen: bridgePgListen((channel, onNotify, onListen) => sql.listen(channel, onNotify, onListen)),
     async close() {
       await sql.end({ timeout: 5 });
     },

--- a/packages/server/src/services/spec-156-w2c.integration.test.ts
+++ b/packages/server/src/services/spec-156-w2c.integration.test.ts
@@ -71,6 +71,7 @@ function requireMutated<T>(value: Mutated<T>): T {
 describe("spec-156 ac-17: proposeStandardChange dual-emits standard_drift.created", () => {
   it("emits standard_drift.created alongside the inner comment.created, mirroring flagDrift", async () => {
     tagAc(`${AC}/ac-17`);
+    tagAc(`${AC}/ac-2`); // scope ac-2: audit-finding remediation (this finding's proof)
     const memexId = await makeTestMemex("s156-ac17");
     const bp = await createStandard(memexId, {
       title: "Drift proposal target",
@@ -125,6 +126,7 @@ describe("spec-156 ac-17: proposeStandardChange dual-emits standard_drift.create
 describe("spec-156 ac-20: composite orchestrators preserve the Mutated brand", () => {
   it("addBlocker / removeBlocker return Mutated<void>", async () => {
     tagAc(`${AC}/ac-20`);
+    tagAc(`${AC}/ac-2`); // scope ac-2: audit-finding remediation (this finding's proof)
     const memexId = await makeTestMemex("s156-ac20-b");
     const doc = await createDocDraft(memexId, "Blocker Spec", "purpose", "spec");
     createdDocIds.push(doc.id);
@@ -173,6 +175,7 @@ describe("spec-156 ac-20: composite orchestrators preserve the Mutated brand", (
 describe("spec-156 ac-26: the waitlist insert emits waitlist_entry.created", () => {
   it("fires waitlist_entry.created on signup (silent:true removed)", async () => {
     tagAc(`${AC}/ac-26`);
+    tagAc(`${AC}/ac-2`); // scope ac-2: audit-finding remediation (this finding's proof)
     const email = `s156-ac26-${Date.now().toString(36)}@example.com`;
     createdEmails.push(email);
 
@@ -193,6 +196,7 @@ describe("spec-156 ac-26: the waitlist insert emits waitlist_entry.created", () 
 describe("spec-156 ac-18: OAuth writes go through mutate({silent:true}), de-allowlisted", () => {
   it("registerClient routes through mutate({silent:true}) — write counted, row lands, NO bus emit", async () => {
     tagAc(`${AC}/ac-18`);
+    tagAc(`${AC}/ac-2`); // scope ac-2: audit-finding remediation (this finding's proof)
     // The {silent:true} contract (std-8 §6): the write IS a mutate() — so the
     // coverage scanner is satisfied and the Mutated brand is preserved — but it
     // intentionally emits NO bus event (anonymous cross-tenant OAuth registry,


### PR DESCRIPTION
## Summary

Four spec-156 threads ([spec](https://memex.ai/mindset-prod/memex-building-itself/specs/spec-156)):

- **Bus-relay issue-1** — when the initial `sql.listen()` rejects (boot during a DB restart, seen live on prod 2026-06-04), postgres-js re-establishes the listener internally but the bridge swallowed that first `onlisten` as "initial connect". The relay stranded at status `connecting` (connects=0, no nudge) while events flowed underneath. `bridgePgListen()` is extracted and now surfaces that recovery as a reconnect → `markEstablished` runs, status returns to `listening`, convergence nudge fires. Pinned by an ac-28 unit test.
- **ac-emit-vitest dual-instance no-op** — setupFiles resolved the helper via `dist/` while bare test imports resolved `src/` (post spec-129), so the module-local `currentTask` slot was set on one instance and read as `null` on the other — silently dropping ALL AC emissions. The slot now lives on `globalThis` (`Symbol.for`), shared across instances. Pinned by a unit test + an end-to-end regression in the exact environment that broke.
- **AC wiring** — scope ACs (ac-1/ac-2/ac-4) tagged on the tests that already prove them; `deploy.yml` passes `MEMEX_EMIT_KEY` so smoke-suite emissions land on the prod memex on every deploy (ac-12/ac-13 live verification).
- **Authed e2e smoke tier: first live execution (ac-13/ac-1)** — the tier had never run (no smoke token existed), hiding four latent defects, all fixed here:
  - SSE routes sit behind `sessionMiddleware` (session-JWT-only) — the e2e sent the `mxt_` token and would always 401. New `SMOKE_SESSION_TOKEN` carries the stream; `mxt_` stays on `/mcp`. The AC-endpoint REST probes likewise.
  - `update_doc` has no `purpose` arg — the observed mutation now renames the title.
  - `parseRef` swallowed the trailing `).` on parenthesised refs, breaking every section-lifecycle chain call.
  - Terse `get_doc` carries no section bodies (and never UUIDs, b-36) — lifecycle reads go verbose; docIds resolve via the REST docs list with the session token.

  New `src/db/seed-smoke.ts` (idempotent) provisions the throwaway `zzz-smoke/main` tenant + both tokens per env — already run against int and prod, tokens set as GitHub **environment secrets**, so the deploy-tail smoke runs the authed tier automatically once this merges. New multi-round e2e: 4 consecutive MCP mutations each arrive on one open SSE stream — on prod it observed **2 distinct relay originIds**, a live cross-instance delivery proof at `--max-instances 3` (the exact kanban property that motivated the spec). Also: the spec-167 CSS smoke fetched `/`, which 301s to the marketing site on prod (std-2) — now fetches the SPA shell at `/login`.

## Test plan

- [x] `bus-relay.test.ts` — 19/19 passing (includes new ac-28 rejected-initial-LISTEN test)
- [x] `task-slot.test.ts` — passing
- [x] Full server suite local: 3163 passed / 0 failed, `tsc -b` clean
- [x] Live smoke **int**: 17/17 passed (authed tier incl. ac-13 MCP→SSE e2e)
- [x] Live smoke **prod**: 17/17 passed — multi-round 4/4 delivered across 2 instance originIds
- [x] spec-156 ACs: 27/28 verified (ac-21 is doc-shaped — std-8 amendments verified by reading)
- [ ] CI full suite on this PR
- [ ] Post-merge: confirm the int deploy-tail smoke goes green with the environment secrets (first fully-automated authed run) — tracked in spec-156 issue-3

🤖 Generated with [Claude Code](https://claude.com/claude-code)