### PR TITLE
fix: make seed idempotent and auto-add DEV_USER_EMAIL to seed org

### DIFF
--- a/packages/server/src/db/seed.ts
+++ b/packages/server/src/db/seed.ts
@@ -3,7 +3,7 @@ import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
 import { eq } from "drizzle-orm";
 import * as schema from "./schema.js";
-import { namespaces, orgs, memexes, documents, docSections } from "./schema.js";
+import { namespaces, orgs, memexes, documents, docSections, orgMemberships, users } from "./schema.js";
 
 const connectionString = process.env.DATABASE_URL;
 if (!connectionString) {
@@ -22,12 +22,15 @@ async function seed() {
   let ns = await db.query.namespaces.findFirst({
     where: eq(namespaces.slug, seedSlug),
   });
+  let org = ns
+    ? await db.query.orgs.findFirst({ where: eq(orgs.namespaceId, ns.id) })
+    : undefined;
   if (!ns) {
     [ns] = await db
       .insert(namespaces)
       .values({ slug: seedSlug, kind: "org" })
       .returning();
-    const [org] = await db
+    [org] = await db
       .insert(orgs)
       .values({ namespaceId: ns.id, name: "Seed" })
       .returning();
@@ -46,44 +49,60 @@ async function seed() {
       .returning();
   }
 
-  const [doc] = await db
-    .insert(documents)
-    .values({
-      memexId: memex.id,
-      handle: "doc-1",
-      title: "Q3 Growth Spec",
-      docType: "document",
-    })
-    .returning();
+  let doc = await db.query.documents.findFirst({ where: eq(documents.memexId, memex.id) });
+  if (!doc) {
+    [doc] = await db
+      .insert(documents)
+      .values({
+        memexId: memex.id,
+        handle: "doc-1",
+        title: "Q3 Growth Spec",
+        docType: "document",
+      })
+      .returning();
 
-  await db.insert(docSections).values([
-    {
-      docId: doc.id,
-      sectionType: "purpose",
-      title: "Purpose",
-      content: "Expand into enterprise segment while maintaining SMB retention above 90%.",
-      seq: 1,
-      position: 1,
-    },
-    {
-      docId: doc.id,
-      sectionType: "approach",
-      title: "Approach",
-      content: "Hire dedicated enterprise sales team. Build SSO and audit log features. Launch partner programme.",
-      seq: 2,
-      position: 2,
-    },
-    {
-      docId: doc.id,
-      sectionType: "risks",
-      title: "Risks",
-      content: "Enterprise sales cycle is 3-6 months. Risk of neglecting SMB product roadmap during transition.",
-      seq: 3,
-      position: 3,
-    },
-  ]);
+    await db.insert(docSections).values([
+      {
+        docId: doc.id,
+        sectionType: "purpose",
+        title: "Purpose",
+        content: "Expand into enterprise segment while maintaining SMB retention above 90%.",
+        seq: 1,
+        position: 1,
+      },
+      {
+        docId: doc.id,
+        sectionType: "approach",
+        title: "Approach",
+        content: "Hire dedicated enterprise sales team. Build SSO and audit log features. Launch partner programme.",
+        seq: 2,
+        position: 2,
+      },
+      {
+        docId: doc.id,
+        sectionType: "risks",
+        title: "Risks",
+        content: "Enterprise sales cycle is 3-6 months. Risk of neglecting SMB product roadmap during transition.",
+        seq: 3,
+        position: 3,
+      },
+    ]);
+    console.log(`Created document "${doc.title}" with 3 sections.`);
+  }
 
-  console.log(`Created document "${doc.title}" with 3 sections.`);
+  // Add DEV_USER_EMAIL as org admin so they can see the seed org on login.
+  const devEmail = process.env.DEV_USER_EMAIL;
+  if (devEmail && org) {
+    const devUser = await db.query.users.findFirst({ where: eq(users.email, devEmail) });
+    if (devUser) {
+      await db
+        .insert(orgMemberships)
+        .values({ userId: devUser.id, orgId: org.id, role: "administrator" })
+        .onConflictDoNothing();
+      console.log(`Added ${devEmail} as administrator of seed org.`);
+    }
+  }
+
   await client.end();
 }
 

--- a/packages/server/src/db/seed.ts
+++ b/packages/server/src/db/seed.ts
@@ -57,7 +57,7 @@ async function seed() {
         memexId: memex.id,
         handle: "doc-1",
         title: "Q3 Growth Spec",
-        docType: "document",
+        docType: "spec",
       })
       .returning();
 


### PR DESCRIPTION
## Summary

- **Idempotent doc insert** — `db:seed` previously always re-inserted the `Q3 Growth Spec` document and sections on every run, creating duplicates. Now checks for an existing doc before inserting.
- **DEV_USER_EMAIL membership** — on a fresh install, the developer running `start-memex` would see an empty workspace because their user account was never added to the seed org. The seed now adds `DEV_USER_EMAIL` as org administrator automatically (no-op if the env var is not set or the user doesn't exist yet).

## Notes

- Safe to run repeatedly — fully idempotent
- `DEV_USER_EMAIL` guard means this is a no-op in CI and production where the var is not set
- Only affects local dev (`make db-seed` / `start-memex`)

## Test plan

- [ ] Fresh DB: run `db:seed` → seed org appears in UI for `DEV_USER_EMAIL` user
- [ ] Existing DB: run `db:seed` again → no duplicate docs, no errors
- [ ] CI env (no `DEV_USER_EMAIL`): seed runs cleanly with no membership step