### PR TITLE
spec-168: canonical Secret-Manager deploy config (t-3) + docs (t-4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ A deployed instance is configured through environment variables. The full list l
 |---|---|
 | `MEMEX_OWN_NAMESPACE` | The namespace this deployment treats as *its own* Memex (the one it writes its self-hosted Specs to). Mindset's hosted service sets `mindset-int` in int and `mindset-prod` in prod. **Required:** if it's unset the server is fail-closed — the self-emission path returns an error rather than guessing. |
 
-For Mindset's own deploys the per-env value is wired in **[`scripts/deploy-config.sh`](scripts/deploy-config.sh)** (which sources a gitignored `scripts/deploy.<env>.env`); self-hosters set it however they manage their own environment.
+For Mindset's own deploys the per-env value (and the rest of the deploy config) is resolved by **[`scripts/deploy-config.sh`](scripts/deploy-config.sh)** from a single canonical source — a Secret Manager secret `memex-<env>-deploy-env` fetched at deploy time, so every deployer ships identical config with no per-machine drift (a local `scripts/deploy.<env>.env` stays available as an opt-in override). See **[`scripts/deploy.env.example`](scripts/deploy.env.example)** for the template; self-hosters set these however they manage their own environment.
 
 ## 📖 Documentation
 

--- a/packages/server/src/__regression__/deploy-config-secret-fetch.regression.test.ts
+++ b/packages/server/src/__regression__/deploy-config-secret-fetch.regression.test.ts
@@ -1,0 +1,227 @@
+// spec-168 dec-1/dec-2/dec-3 — scripts/deploy-config.sh resolves the canonical
+// per-environment deploy config from a Secret Manager secret (memex-<env>-deploy-env)
+// as the always-fetch baseline, honours an explicit opt-in local override, and
+// FAILS CLOSED when the secret can't be read.
+//
+// This exercises the REAL loader: it copies scripts/deploy-config.sh into a temp
+// dir and `source`s it under `set -euo pipefail` (the same posture the deploy
+// scripts use) with a FAKE `gcloud` on PATH. The fake stands in for Secret
+// Manager so the resolution logic is verified end-to-end without any cloud access.
+//
+// Covers:
+//   ac-6:  the loader fetches the secret via `gcloud secrets versions access`.
+//   ac-7:  without read access the deploy fails closed with a clear error
+//          (the deploy-config.sh half — the PAM-grant half is infra/t-2).
+//   ac-8:  with no local deploy.<env>.env present, the loader fetches and
+//          proceeds — no "deploy.<env>.env not found" abort.
+//   ac-9:  a local file overrides only via explicit opt-in; with the opt-in
+//          pointed at the secret it cannot silently take over.
+//   ac-10: every instance value (GCP_PROJECT, REGION, hosts, buckets, SERVICE,
+//          client ids, MEMEX_OWN_NAMESPACE, HIDDEN_FEATURES, the DB_PASS fetch)
+//          resolves from the one canonical config.
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, writeFileSync, copyFileSync, chmodSync, rmSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+const SPEC = "mindset-prod/memex-building-itself/specs/spec-168";
+const REPO_ROOT = join(__dirname, "..", "..", "..", "..");
+const REAL_SCRIPT = join(REPO_ROOT, "scripts", "deploy-config.sh");
+
+let TMP: string;
+let SCRIPT: string; // copy of deploy-config.sh whose CONFIG_DIR is the temp dir
+let FAKE_BIN: string;
+
+// A fake `gcloud`. For the canonical-config fetch it emits a self-contained
+// deploy.<env>.env body; the inner DB_PASS fetch line resolves through the same
+// fake. FAKE_GCLOUD_MODE switches it to a failing / empty posture.
+const FAKE_GCLOUD = `#!/bin/bash
+case "\${FAKE_GCLOUD_MODE:-ok}" in
+  fail)  echo "PERMISSION_DENIED: secretmanager.versions.access denied (fake)" >&2; exit 1 ;;
+  empty) exit 0 ;;
+esac
+if [[ "$*" == *"--secret=memex-int-deploy-env"* ]]; then
+  cat <<'BODY'
+GCP_PROJECT="fake-int-project"
+REGION="us-fake1"
+CLOUD_SQL_INSTANCE_NAME="fake-sql"
+DB_NAME="memex"
+DB_USER="postgres"
+DB_PASS="$(gcloud secrets versions access latest --secret=fake-db-password --project="\${GCP_PROJECT}")"
+SERVICE="memex-api"
+STATIC_BUCKET="gs://fake-static-bucket"
+URL_MAP_NAME="fake-lb"
+PUBLIC_HOST="fake.example.com"
+API_PUBLIC_HOST="fake.example.com"
+GOOGLE_CLIENT_ID="fake-client-id.apps.googleusercontent.com"
+EMAIL_FROM="Fake <support@example.com>"
+SLACK_CLIENT_ID="fake-slack-id"
+MEMEX_OWN_NAMESPACE="fake-ns"
+HIDDEN_FEATURES="scaffold,spec-pause,pulse"
+BODY
+else
+  # the inner DB_PASS secret fetch
+  echo "fake-db-password-value"
+fi
+`;
+
+// Run the real loader for ENV=int and return the process result. `localFile`
+// optionally seeds a temp deploy.int.env; `env` overrides/augments the process
+// env. On success the harness prints a __RESULT__ line we can parse.
+function runLoader(opts: {
+  env?: Record<string, string>;
+  localFile?: string | null;
+}): { status: number | null; stdout: string; stderr: string } {
+  const localPath = join(TMP, "deploy.int.env");
+  if (opts.localFile != null) writeFileSync(localPath, opts.localFile);
+  else rmSync(localPath, { force: true });
+
+  const harness = `
+set -euo pipefail
+source "${SCRIPT}"
+echo "__RESULT__ GCP_PROJECT=\${GCP_PROJECT}|REGION=\${REGION}|PUBLIC_HOST=\${PUBLIC_HOST}|SERVICE=\${SERVICE}|STATIC_BUCKET=\${STATIC_BUCKET}|GOOGLE_CLIENT_ID=\${GOOGLE_CLIENT_ID}|MEMEX_OWN_NAMESPACE=\${MEMEX_OWN_NAMESPACE}|HIDDEN_FEATURES=\${HIDDEN_FEATURES:-<unset>}|DB_PASS=\${DB_PASS}"
+`;
+  const res = spawnSync("bash", ["-c", harness], {
+    encoding: "utf-8",
+    env: {
+      ...process.env,
+      PATH: `${FAKE_BIN}:${process.env.PATH}`,
+      ENV: "int",
+      FAKE_GCLOUD_MODE: "ok",
+      // Default bootstrap project; individual tests override.
+      DEPLOY_CONFIG_PROJECT: "fake-int-project",
+      // Don't inherit the caller's source preference.
+      DEPLOY_CONFIG_SOURCE: "",
+      ...(opts.env ?? {}),
+    },
+  });
+  return { status: res.status, stdout: res.stdout ?? "", stderr: res.stderr ?? "" };
+}
+
+function parseResult(stdout: string): Record<string, string> {
+  const line = stdout.split("\n").find((l) => l.startsWith("__RESULT__"));
+  if (!line) return {};
+  return Object.fromEntries(
+    line
+      .replace("__RESULT__ ", "")
+      .split("|")
+      .map((kv) => {
+        const i = kv.indexOf("=");
+        return [kv.slice(0, i), kv.slice(i + 1)];
+      }),
+  );
+}
+
+beforeAll(() => {
+  TMP = mkdtempSync(join(tmpdir(), "deploy-config-test-"));
+  SCRIPT = join(TMP, "deploy-config.sh");
+  copyFileSync(REAL_SCRIPT, SCRIPT); // exercise the real loader bytes
+  FAKE_BIN = join(TMP, "bin");
+  mkdirSync(FAKE_BIN);
+  const fakeGcloud = join(FAKE_BIN, "gcloud");
+  writeFileSync(fakeGcloud, FAKE_GCLOUD);
+  chmodSync(fakeGcloud, 0o755);
+});
+
+afterAll(() => {
+  if (TMP) rmSync(TMP, { recursive: true, force: true });
+});
+
+describe("spec-168 ac-6 + ac-8: the loader fetches the canonical secret and proceeds with no local file", () => {
+  it("fetches memex-int-deploy-env via `gcloud secrets versions access` and resolves config (no 'not found' abort)", () => {
+    tagAc(`${SPEC}/acs/ac-6`);
+    tagAc(`${SPEC}/acs/ac-8`);
+    const { status, stdout, stderr } = runLoader({ localFile: null });
+    expect(status).toBe(0);
+    expect(stderr).toContain("source=SECRET-MANAGER");
+    expect(stderr).toContain("secret=memex-int-deploy-env");
+    expect(stdout).not.toContain("not found"); // the old clean-checkout abort is gone
+    const r = parseResult(stdout);
+    expect(r.GCP_PROJECT).toBe("fake-int-project");
+  });
+});
+
+describe("spec-168 ac-10: every instance value resolves from the one canonical config", () => {
+  it("populates project/region/hosts/bucket/service/client-id/namespace/HIDDEN_FEATURES and the DB_PASS fetch from the secret", () => {
+    tagAc(`${SPEC}/acs/ac-10`);
+    const { status, stdout } = runLoader({ localFile: null });
+    expect(status).toBe(0);
+    const r = parseResult(stdout);
+    expect(r).toMatchObject({
+      GCP_PROJECT: "fake-int-project",
+      REGION: "us-fake1",
+      PUBLIC_HOST: "fake.example.com",
+      SERVICE: "memex-api",
+      STATIC_BUCKET: "gs://fake-static-bucket",
+      GOOGLE_CLIENT_ID: "fake-client-id.apps.googleusercontent.com",
+      MEMEX_OWN_NAMESPACE: "fake-ns",
+      HIDDEN_FEATURES: "scaffold,spec-pause,pulse",
+    });
+    // the DB_PASS *fetch line* in the payload resolved through Secret Manager too
+    expect(r.DB_PASS).toBe("fake-db-password-value");
+  });
+});
+
+describe("spec-168 ac-9: a local file overrides only via explicit opt-in; the secret stays authoritative otherwise", () => {
+  const LOCAL = [
+    'GCP_PROJECT="LOCAL-project"',
+    'REGION="us-local1"',
+    'CLOUD_SQL_INSTANCE_NAME="local-sql"',
+    'DB_NAME="memex"',
+    'DB_USER="postgres"',
+    'DB_PASS="local-db-pass"',
+    'SERVICE="memex-api"',
+    'STATIC_BUCKET="gs://local-bucket"',
+    'URL_MAP_NAME="local-lb"',
+    'PUBLIC_HOST="local.example.com"',
+    'API_PUBLIC_HOST="local.example.com"',
+    'GOOGLE_CLIENT_ID="local-client-id.apps.googleusercontent.com"',
+    'EMAIL_FROM="Local <support@local.example.com>"',
+    'SLACK_CLIENT_ID="local-slack"',
+    'MEMEX_OWN_NAMESPACE="local-ns"',
+  ].join("\n");
+
+  it("a present local file (no DEPLOY_CONFIG_SOURCE) is an opt-in override and wins, loudly", () => {
+    tagAc(`${SPEC}/acs/ac-9`);
+    const { status, stdout, stderr } = runLoader({ localFile: LOCAL, env: { DEPLOY_CONFIG_SOURCE: "" } });
+    expect(status).toBe(0);
+    expect(stderr).toContain("source=LOCAL-OVERRIDE");
+    expect(parseResult(stdout).GCP_PROJECT).toBe("LOCAL-project");
+  });
+
+  it("DEPLOY_CONFIG_SOURCE=secret makes the canonical secret win even when a local file is present", () => {
+    tagAc(`${SPEC}/acs/ac-9`);
+    const { status, stdout, stderr } = runLoader({ localFile: LOCAL, env: { DEPLOY_CONFIG_SOURCE: "secret" } });
+    expect(status).toBe(0);
+    expect(stderr).toContain("source=SECRET-MANAGER");
+    // the stray local file did NOT silently take over
+    expect(parseResult(stdout).GCP_PROJECT).toBe("fake-int-project");
+  });
+});
+
+describe("spec-168 ac-7 + ac-8: fail closed — never a silent fallback to stale/empty config", () => {
+  it("aborts with a clear error when the secret can't be read (gcloud fails)", () => {
+    tagAc(`${SPEC}/acs/ac-7`);
+    const { status, stdout, stderr } = runLoader({ localFile: null, env: { FAKE_GCLOUD_MODE: "fail" } });
+    expect(status).not.toBe(0); // deploy aborts
+    expect(stdout).not.toContain("__RESULT__"); // never reached the resolution / export
+    expect(stderr).toContain("fail-closed");
+  });
+
+  it("aborts when the secret is empty rather than shipping a blank config", () => {
+    tagAc(`${SPEC}/acs/ac-7`);
+    const { status, stdout } = runLoader({ localFile: null, env: { FAKE_GCLOUD_MODE: "empty" } });
+    expect(status).not.toBe(0);
+    expect(stdout).not.toContain("__RESULT__");
+  });
+
+  it("aborts when DEPLOY_CONFIG_PROJECT is unset rather than guessing a project (spec-168 dec-5 bootstrap)", () => {
+    tagAc(`${SPEC}/acs/ac-8`);
+    const { status, stderr } = runLoader({ localFile: null, env: { DEPLOY_CONFIG_PROJECT: "" } });
+    expect(status).not.toBe(0);
+    expect(stderr).toContain("DEPLOY_CONFIG_PROJECT is not set");
+  });
+});

--- a/scripts/deploy-config.sh
+++ b/scripts/deploy-config.sh
@@ -4,11 +4,23 @@
 # Sourced by the deploy.sh scripts (root + packages/server + packages/ui)
 # to populate per-environment variables. Driven by `ENV` (defaults to `int`).
 #
-# Per-environment VALUES are NOT stored here — they live in gitignored files
-# alongside this script: scripts/deploy.int.env, scripts/deploy.prod.env, ...
-# Copy scripts/deploy.env.example to scripts/deploy.<env>.env and fill in your
-# deployment's coordinates. This keeps instance-specific config (project ids,
-# hosts, buckets, client ids) out of the repo — same model as .env/.env.example.
+# WHERE per-environment VALUES come from (spec-168 — single source of truth):
+#   1. CANONICAL: a Secret Manager secret `memex-${ENV}-deploy-env` holding the
+#      full deploy.<env>.env body, fetched at deploy time (the same model
+#      DB_PASS already uses). Fetched on EVERY normal deploy, so there is no
+#      per-machine file to drift. Bootstrap: the fetch needs to know which GCP
+#      project holds the secret BEFORE it has the config, so set
+#      DEPLOY_CONFIG_PROJECT to that project — the one pointer that cannot live
+#      inside the secret (spec-168 dec-5). Fetch FAILS CLOSED: an unreadable
+#      secret aborts the deploy loudly, never falling back to empty/stale config.
+#   2. LOCAL OVERRIDE (opt-in, ad-hoc testing only): a present
+#      scripts/deploy.<env>.env, or DEPLOY_CONFIG_SOURCE=local, takes precedence
+#      and is sourced instead of the secret. Force the secret even when a local
+#      file exists with DEPLOY_CONFIG_SOURCE=secret. The local file is NEVER
+#      required and never silently authoritative — when used, the loader says so
+#      on stderr.
+# Either way the VALUES (project ids, hosts, buckets, client ids) stay OUT of
+# this tracked, open-core file — same reason as .env / .env.example.
 #
 # PAM-gated access — deployers hold no standing roles on the GCP projects.
 # Request the relevant PAM entitlement before running any deploy script that
@@ -30,9 +42,12 @@
 #   source "${REPO_ROOT}/scripts/deploy-config.sh"
 #   # Then use $GCP_PROJECT, $PUBLIC_HOST, $APP_BASE_URL, etc.
 #
-# Adding a new env: create scripts/deploy.<env>.env from the example and add
-# the env name to the case below. Do NOT hardcode env-specific values in the
-# per-package deploy.sh files — keep them in the per-env file.
+# Adding a new env: add the env name to the case below, create the canonical
+# secret memex-<env>-deploy-env (seeded from scripts/deploy.env.example) in that
+# env's GCP project, and extend the memex-<env>-deploy-server PAM entitlement's
+# secretAccessor condition to cover it. Do NOT hardcode env-specific values in
+# the per-package deploy.sh files or here — they belong in the canonical secret
+# (a local scripts/deploy.<env>.env stays available as an opt-in override).
 
 ENV="${ENV:-int}"
 
@@ -46,15 +61,64 @@ esac
 
 CONFIG_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ENV_FILE="${CONFIG_DIR}/deploy.${ENV}.env"
+CONFIG_SECRET="memex-${ENV}-deploy-env"
 
-if [[ ! -f "$ENV_FILE" ]]; then
-  echo "ERROR: $ENV_FILE not found." >&2
-  echo "       Copy scripts/deploy.env.example to scripts/deploy.${ENV}.env and fill it in." >&2
-  return 1 2>/dev/null || exit 1
+# Decide the config source (spec-168 dec-2, hybrid). DEPLOY_CONFIG_SOURCE forces
+# a source explicitly; otherwise a present local file is an opt-in override and
+# everything else falls through to the canonical Secret Manager fetch.
+_use_local=0
+case "${DEPLOY_CONFIG_SOURCE:-}" in
+  local)  _use_local=1 ;;
+  secret) _use_local=0 ;;
+  "")     [[ -f "$ENV_FILE" ]] && _use_local=1 ;;
+  *)
+    echo "ERROR: DEPLOY_CONFIG_SOURCE='${DEPLOY_CONFIG_SOURCE}' is invalid (use 'local' or 'secret')." >&2
+    return 1 2>/dev/null || exit 1
+    ;;
+esac
+
+if [[ "$_use_local" == "1" ]]; then
+  # Explicit/opt-in LOCAL override — ad-hoc testing only. Announced loudly so it
+  # is never silently authoritative (spec-168 dec-2 / ac-9).
+  if [[ ! -f "$ENV_FILE" ]]; then
+    echo "ERROR: DEPLOY_CONFIG_SOURCE=local but $ENV_FILE not found." >&2
+    echo "       Copy scripts/deploy.env.example to scripts/deploy.${ENV}.env and fill it in," >&2
+    echo "       or unset DEPLOY_CONFIG_SOURCE to fetch the canonical config from Secret Manager." >&2
+    return 1 2>/dev/null || exit 1
+  fi
+  echo "[deploy-config] source=LOCAL-OVERRIDE file=$ENV_FILE (canonical secret $CONFIG_SECRET bypassed)" >&2
+  # shellcheck source=/dev/null
+  source "$ENV_FILE"
+else
+  # CANONICAL source of truth: fetch memex-<env>-deploy-env every deploy
+  # (spec-168 dec-1/dec-3 / ac-6, ac-8). No per-machine file => no drift path.
+  if [[ -z "${DEPLOY_CONFIG_PROJECT:-}" ]]; then
+    echo "ERROR: DEPLOY_CONFIG_PROJECT is not set — cannot locate the canonical deploy-config secret." >&2
+    echo "       Set it to the GCP project holding '$CONFIG_SECRET' (the one pointer that can't live in the secret, spec-168 dec-5)," >&2
+    echo "       or use a local override: set DEPLOY_CONFIG_SOURCE=local with scripts/deploy.${ENV}.env present." >&2
+    return 1 2>/dev/null || exit 1
+  fi
+  echo "[deploy-config] source=SECRET-MANAGER secret=$CONFIG_SECRET project=$DEPLOY_CONFIG_PROJECT" >&2
+  # Capture stdout only; let gcloud's own error stream to the terminal. Fetch
+  # FAILS CLOSED — an unreadable secret aborts rather than shipping empty/stale
+  # config (spec-168 dec-2 / ac-7, ac-8). The ${var:-} guards keep `set -u` happy.
+  _fetch_failed=0
+  _config_payload="$(gcloud secrets versions access latest --secret="$CONFIG_SECRET" --project="$DEPLOY_CONFIG_PROJECT")" || _fetch_failed=1
+  if [[ "$_fetch_failed" == "1" || -z "${_config_payload:-}" ]]; then
+    echo "ERROR: could not read canonical deploy config from Secret Manager (fail-closed, no fallback)." >&2
+    echo "       secret=$CONFIG_SECRET project=$DEPLOY_CONFIG_PROJECT" >&2
+    echo "       Confirm the secret exists and you hold the memex-${ENV}-deploy-server PAM grant (secretAccessor)." >&2
+    return 1 2>/dev/null || exit 1
+  fi
+  # macOS /bin/bash is 3.2, which can't reliably `source <(...)` a process
+  # substitution, so write the payload to a private temp file (mktemp => 0600)
+  # and source that — mirroring the original `source "$ENV_FILE"` path.
+  _config_tmp="$(mktemp "${TMPDIR:-/tmp}/deploy-config.XXXXXX")"
+  printf '%s\n' "$_config_payload" > "$_config_tmp"
+  # shellcheck source=/dev/null
+  source "$_config_tmp"
+  rm -f "$_config_tmp"
 fi
-
-# shellcheck source=/dev/null
-source "$ENV_FILE"
 
 # Derived values — composed from the per-env settings above.
 CLOUD_SQL_INSTANCE_CONN="${GCP_PROJECT}:${REGION}:${CLOUD_SQL_INSTANCE_NAME}"

--- a/scripts/deploy.env.example
+++ b/scripts/deploy.env.example
@@ -1,15 +1,26 @@
 # scripts/deploy.env.example — template for per-environment deploy config.
 #
-# Copy this to scripts/deploy.<env>.env (one per environment you deploy) and
-# fill in your own values. These files are GITIGNORED: they hold your specific
-# deployment's coordinates (project ids, hosts, buckets, OAuth client ids), not
-# the project's source. This mirrors how .env / .env.example work for app config.
+# This file is the value-free TEMPLATE; the KEY="value" shape below is also the
+# body that lives in the canonical config store. Either way the values stay OUT
+# of this tracked, open-core repo (project ids, hosts, buckets, OAuth client ids
+# are instance config, not source) — same idea as .env / .env.example.
 #
-#   cp scripts/deploy.env.example scripts/deploy.int.env
-#   cp scripts/deploy.env.example scripts/deploy.prod.env
+# WHERE the real values live at deploy time (spec-168 — single source of truth):
+#   * CANONICAL: a Secret Manager secret `memex-${ENV}-deploy-env` holding this
+#     exact KEY="value" body. deploy-config.sh fetches it on every deploy, so
+#     there is no per-machine file to drift. Set DEPLOY_CONFIG_PROJECT to the
+#     GCP project that holds the secret (the one pointer that can't live inside
+#     it). To change an env-wide setting: add a new secret version, redeploy.
+#   * LOCAL OVERRIDE (opt-in, ad-hoc testing only): copy this template to
+#     scripts/deploy.<env>.env (GITIGNORED) and it takes precedence; or force a
+#     source with DEPLOY_CONFIG_SOURCE=local | secret. Seed the canonical secret
+#     from such a file:
+#       gcloud secrets create memex-<env>-deploy-env \
+#         --project=<gcp-project> --replication-policy=user-managed \
+#         --locations=<region> --data-file=scripts/deploy.<env>.env
 #
-# deploy-config.sh sources scripts/deploy.${ENV}.env (ENV defaults to "int").
-# Each file is a plain bash fragment of KEY="value" assignments.
+# deploy-config.sh resolves ENV (defaults to "int"); each source is a plain bash
+# fragment of KEY="value" assignments.
 
 GCP_PROJECT="your-gcp-project"
 REGION="us-east4"


### PR DESCRIPTION
Implements spec-168 — replaces per-machine `scripts/deploy.<env>.env` drift with a single canonical Secret Manager secret `memex-${ENV}-deploy-env` that `deploy-config.sh` fetches every deploy. Spec: https://memex.ai/mindset-prod/memex-building-itself/specs/spec-168

**What's here (t-3 + t-4):**
- `scripts/deploy-config.sh`: always-fetch the secret via `gcloud secrets versions access`; explicit opt-in local override (`DEPLOY_CONFIG_SOURCE=local|secret` or a present file); fail-closed on unreadable/empty secret or missing bootstrap.
- `DEPLOY_CONFIG_PROJECT` bootstrap (dec-5, Option A) — no instance project id in the open-core repo.
- Fix: source a `mktemp` file, not `source <(...)` — process substitution silently fails under macOS /bin/bash 3.2 and would abort every clean-checkout deploy.
- Behavioral regression test exercising all paths (tags ac-6/7/8/9/10).
- Docs: `deploy.env.example`, `deploy-config.sh` header, README.

**Status:** t-2 secrets are provisioned (memex-{env}-deploy-env exist; prod PAM extended). 

⚠️ **After merge, a deploy needs `DEPLOY_CONFIG_PROJECT=memex-ai-${ENV}` set and a *re-requested* deploy-server PAM grant** (existing grants don't inherit the secretAccessor change). Not yet deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)