### PR TITLE
spec-182: Reviewer experience on the Spec page — unified layout, posture-gated powers

### DIFF
--- a/packages/ui/src/components/IssuePanel.test.tsx
+++ b/packages/ui/src/components/IssuePanel.test.tsx
@@ -284,3 +284,36 @@ describe('IssuePanel — inline expansion (spec-164)', () => {
     expect(screen.getByTestId('issue-expanded')).toHaveTextContent('full detail');
   });
 });
+
+// spec-182 dec-4 — issue powers split by posture: register stays canWrite,
+// dispositions (Convert to Task / Won't fix) move to canEdit.
+describe('IssuePanel — posture-split powers (spec-182)', () => {
+  const AC182_12 = 'mindset-prod/memex-building-itself/specs/spec-182/acs/ac-12';
+  const AC182_4 = 'mindset-prod/memex-building-itself/specs/spec-182/acs/ac-4';
+
+  it('a writable reviewer (canWrite, no canEdit) can register but sees no dispositions', async () => {
+    tagAc(AC182_12);
+    tagAc(AC182_4);
+    mockFetchIssues.mockResolvedValue([makeIssue({ id: 'iss-1', seq: 1, status: 'open' })]);
+
+    render(<IssuePanel docId="doc-1" canWrite canEdit={false} />);
+    await screen.findByTestId('issue-card');
+
+    // Register stays available…
+    expect(screen.getByTestId('issue-add')).toBeInTheDocument();
+    // …the dispositions do not.
+    expect(screen.queryByTestId('issue-convert')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('issue-wontfix')).not.toBeInTheDocument();
+  });
+
+  it('an editor (canEdit) keeps both dispositions on an open issue', async () => {
+    tagAc(AC182_12);
+    mockFetchIssues.mockResolvedValue([makeIssue({ id: 'iss-1', seq: 1, status: 'open' })]);
+
+    render(<IssuePanel docId="doc-1" canWrite canEdit />);
+    await screen.findByTestId('issue-card');
+
+    expect(screen.getByTestId('issue-convert')).toBeInTheDocument();
+    expect(screen.getByTestId('issue-wontfix')).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/IssuePanel.tsx
+++ b/packages/ui/src/components/IssuePanel.tsx
@@ -38,6 +38,13 @@ interface IssuePanelProps {
   /** spec-111-style read gate: when false (non-member reading a public Memex),
    *  every mutation control is suppressed; the list stays readable. */
   canWrite?: boolean;
+  /**
+   * spec-182 dec-4: the posture gate for issue DISPOSITIONS. Registering an
+   * issue stays on canWrite (raising concerns is the reviewer's job); the two
+   * dispositions — Convert to Task and Won't fix — are editor calls and gate
+   * here. Defaults to true so legacy call sites keep today's behaviour.
+   */
+  canEdit?: boolean;
   /** Bubble up after a mutation so the rest of the spec view (counts, etc.)
    *  picks up related changes. */
   onUpdate?: () => void;
@@ -75,6 +82,7 @@ function chipLabel(issue: Issue): string {
 export function IssuePanel({
   docId,
   canWrite = true,
+  canEdit = true,
   onUpdate,
   highlightIssueHandle,
 }: IssuePanelProps) {
@@ -296,7 +304,9 @@ export function IssuePanel({
                   </div>
                 )}
               </div>
-              {canWrite && issue.status === 'open' && (
+              {/* spec-182 dec-4: dispositions are editor calls — canEdit on top
+                  of the spec-111 read gate (canWrite false suppresses everything). */}
+              {canWrite && canEdit && issue.status === 'open' && (
                 <div className="flex-none flex items-center gap-2">
                   <Button
                     data-testid="issue-convert"

--- a/packages/ui/src/components/TransitionSentence.test.tsx
+++ b/packages/ui/src/components/TransitionSentence.test.tsx
@@ -264,3 +264,56 @@ describe('Rubicon line — posture (i-1) and the Yes mutation', () => {
     await waitFor(() => expect(onTransitioned).toHaveBeenCalledWith('verify'));
   });
 });
+
+// spec-182 dec-6 — the reviewer's door: where the editor's [Yes] renders, a
+// viewer who can't transition but CAN switch posture gets the switch link.
+describe('switch-to-Editing link (spec-182 dec-6)', () => {
+  const AC182 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-182/acs/ac-${n}`;
+
+  it('renders the link in the button slot for a writable reviewer and fires the callback', async () => {
+    tagAc(AC182(14));
+    tagAc(AC182(6));
+    const onSwitchToEdit = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <TransitionSentence
+        {...baseProps()}
+        canTransition={false}
+        onSwitchToEdit={onSwitchToEdit}
+      />,
+    );
+
+    const slot = screen.getByTestId('switch-to-editing');
+    expect(slot.textContent).toContain("You're reviewing — switch to Editing to act.");
+    // No Yes/No render alongside it.
+    expect(screen.queryByRole('button', { name: 'Yes' })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'switch to Editing' }));
+    expect(onSwitchToEdit).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the link on a BLOCKED sentence too — the slot follows the sentence, not the offer', () => {
+    tagAc(AC182(14));
+    render(
+      <TransitionSentence
+        {...baseProps({ openDecisionCount: 2 })}
+        canTransition={false}
+        onSwitchToEdit={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId('switch-to-editing')).toBeInTheDocument();
+  });
+
+  it('read-only viewers (no callback) get NO link; editors (canTransition) get Yes, no link', () => {
+    tagAc(AC182(15));
+    const { unmount } = render(
+      <TransitionSentence {...baseProps()} canTransition={false} />,
+    );
+    expect(screen.queryByTestId('switch-to-editing')).not.toBeInTheDocument();
+    unmount();
+
+    render(<TransitionSentence {...baseProps()} canTransition onSwitchToEdit={vi.fn()} />);
+    expect(screen.getByRole('button', { name: 'Yes' })).toBeInTheDocument();
+    expect(screen.queryByTestId('switch-to-editing')).not.toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/TransitionSentence.tsx
+++ b/packages/ui/src/components/TransitionSentence.tsx
@@ -79,6 +79,15 @@ export interface TransitionSentenceProps {
   onTransitioned?: (newPhase: SpecStatus) => void;
   /** The browse-confirm's [No]: return the view to the current phase's tab. */
   onCancelBrowse?: () => void;
+  /**
+   * spec-182 dec-6: the reviewer's door to acting. When the viewer cannot
+   * transition (`canTransition` false) but CAN switch posture — a writable
+   * reviewer — the parent passes this callback and the button slot renders
+   * "You're reviewing — switch to Editing to act." with the link wired to the
+   * same switchPosture path as the header pill. Read-only visitors get no
+   * callback and therefore no link.
+   */
+  onSwitchToEdit?: () => void;
 }
 
 /**
@@ -166,6 +175,7 @@ export function TransitionSentence({
   unverifiedAcCount = 0,
   onTransitioned,
   onCancelBrowse,
+  onSwitchToEdit,
 }: TransitionSentenceProps) {
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -227,6 +237,21 @@ export function TransitionSentence({
       {error}
     </span>
   );
+  // spec-182 dec-6: the reviewer's slot-filler — renders exactly where the
+  // editor's [Yes] would, only when the viewer can't transition but can switch.
+  const switchLink = !canTransition && onSwitchToEdit && (
+    <span data-testid="switch-to-editing">
+      You're reviewing —{' '}
+      <button
+        type="button"
+        onClick={() => onSwitchToEdit()}
+        className="underline underline-offset-2 text-primary hover:text-heading"
+      >
+        switch to Editing
+      </button>{' '}
+      to act.
+    </span>
+  );
 
   // No target at all (e.g. done with nothing further) → nothing to say; the
   // tab bar already carries the phase (and `done` collapses the whole block
@@ -242,7 +267,8 @@ export function TransitionSentence({
       // buttons to press.
       return (
         <p className="text-sm text-secondary" data-testid="transition-sentence">
-          {renderBlockers(blockers)} before this spec can move to {phaseDisplayName(target)}.
+          {renderBlockers(blockers)} before this spec can move to {phaseDisplayName(target)}.{' '}
+          {switchLink}
         </p>
       );
     }
@@ -251,6 +277,7 @@ export function TransitionSentence({
     return (
       <p className="text-sm text-secondary" data-testid="transition-sentence">
         {verb} to move this spec to {phaseDisplayName(target)}? {yesButton}
+        {switchLink}
         {errorNote}
       </p>
     );
@@ -270,6 +297,7 @@ export function TransitionSentence({
     <p className="text-sm text-secondary" data-testid="transition-sentence">
       {showSummary && <>{renderBlockers(blockers)} before {phaseDisplayName(target)}. </>}
       {question} {yesButton} {noButton}
+      {switchLink}
       {errorNote}
     </p>
   );

--- a/packages/ui/src/licensing.spec-182.test.ts
+++ b/packages/ui/src/licensing.spec-182.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { tagAc } from '@memex-ai-ac/vitest';
+
+// spec-182 dec-7 / ac-16 — Fair-code core: nothing this spec ships carries an
+// `.ee.` filename or `.ee/` dirname marker.
+
+const AC_CORE = 'mindset-prod/memex-building-itself/specs/spec-182/acs/ac-16';
+
+const SRC_DIR = dirname(fileURLToPath(import.meta.url));
+
+const TOUCHED = [
+  'pages/DocDocument.tsx',
+  'components/TransitionSentence.tsx',
+  'components/IssuePanel.tsx',
+];
+
+describe('licensing tier (spec-182 dec-7)', () => {
+  it('every touched file exists at its core (non-.ee) path', () => {
+    tagAc(AC_CORE);
+    for (const rel of TOUCHED) {
+      expect(existsSync(join(SRC_DIR, rel)), `${rel} should exist`).toBe(true);
+      expect(rel.includes('.ee.'), `${rel} must not carry the .ee. marker`).toBe(false);
+      expect(rel.includes('.ee/'), `${rel} must not sit under .ee/`).toBe(false);
+    }
+  });
+});

--- a/packages/ui/src/pages/DocDocument.spec-159.test.tsx
+++ b/packages/ui/src/pages/DocDocument.spec-159.test.tsx
@@ -498,30 +498,36 @@ describe('spec-159 — Rubicon line + in-situ directives', () => {
     // Editors still get the PhaseTabBar (3 phase tabs) and the Rubicon line.
     expect(screen.getAllByRole('tab')).toHaveLength(3);
     expect(screen.getByTestId('transition-sentence')).toBeInTheDocument();
-    // …and NOT the reviewer block.
-    expect(screen.queryByTestId('review-action-row')).not.toBeInTheDocument();
+    // spec-182 dec-3: at Specify the review-action row renders for editors too.
+    expect(screen.getByTestId('review-action-row')).toBeInTheDocument();
   });
 });
 
-// spec-159 ac-19 (amended) — a writable reviewer sees the review-oriented phase
-// block in place of the editor's PhaseTabBar + TransitionSentence: the four
-// review-action prompts and a reviewer handoff line — and NO phase tabs. The
-// posture itself lives in the header's PostureDropdown pill (bidirectional:
-// reviewer → Editing promotes, editor → Reviewing demotes).
-describe('spec-159 ac-19 — writable reviewer phase block', () => {
+// spec-182 dec-1/dec-2/dec-3 — the spec-159 ac-19 reviewer block is DISSOLVED.
+// A writable reviewer gets the same page as everyone: full phase tab bar
+// (browse-only), the status-only Rubicon line, and — at Specify only, for both
+// postures — the review-action row + review handoff. The posture itself still
+// lives in the header's PostureDropdown pill (bidirectional).
+const AC182 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-182/acs/ac-${n}`;
+
+describe('spec-182 — unified reviewer phase block', () => {
   beforeEach(() => {
     mockRole = 'reviewer';
   });
 
-  it('renders NO phase tabs and NO transition sentence for a reviewer', async () => {
-    tagAc(AC(19));
+  it('a reviewer gets the full phase tab bar and the status-only transition sentence', async () => {
+    tagAc(AC182(7));
+    tagAc(AC182(9));
+    tagAc('mindset-prod/memex-building-itself/specs/spec-182/acs/ac-1');
+    tagAc('mindset-prod/memex-building-itself/specs/spec-182/acs/ac-2');
     renderAt('plan');
 
     await screen.findByTestId('review-action-row');
-    // The PhaseTabBar (role="tab") is gone — a reviewer browses only the current
-    // phase's layout. The Rubicon transition sentence is gone too.
-    expect(screen.queryAllByRole('tab')).toHaveLength(0);
-    expect(screen.queryByTestId('transition-sentence')).not.toBeInTheDocument();
+    // The PhaseTabBar renders for reviewers too (dec-1) — browse-only.
+    expect(screen.getAllByRole('tab')).toHaveLength(3);
+    // The Rubicon line renders status-only: present, but no [Yes] (dec-2).
+    const sentence = screen.getByTestId('transition-sentence');
+    expect(within(sentence).queryByRole('button', { name: 'Yes' })).not.toBeInTheDocument();
   });
 
   it('header pill reads "You are reviewing"; picking Editing promotes to editor', async () => {
@@ -566,7 +572,9 @@ describe('spec-159 ac-19 — writable reviewer phase block', () => {
   });
 
   it('renders the four review-action buttons; clicking one sends the scaffold prompt through chat', async () => {
-    tagAc(AC(19));
+    tagAc(AC182(10));
+    tagAc(AC182(11));
+    tagAc(AC182(3));
     const user = userEvent.setup();
     renderAt('plan');
 
@@ -587,7 +595,7 @@ describe('spec-159 ac-19 — writable reviewer phase block', () => {
   });
 
   it('renders the reviewer handoff line — "You can copy and paste this prompt …conduct the review from there."', async () => {
-    tagAc(AC(19));
+    tagAc(AC182(11));
     renderAt('plan');
 
     const line = await screen.findByTestId('review-handoff-line');
@@ -599,28 +607,71 @@ describe('spec-159 ac-19 — writable reviewer phase block', () => {
       name: /^You can copy and paste this prompt/,
     });
     expect(copyButton.textContent).toBe('this prompt');
-    // No editor-only phase handoff line for a reviewer.
-    expect(screen.queryByTestId('phase-handoff-line')).not.toBeInTheDocument();
+    // spec-182 dec-1: the phase handoff renders for every viewer now — the
+    // reviewer sees BOTH lines at Specify (ac-17's "every viewer" restored).
+    expect(screen.getByTestId('phase-handoff-line')).toBeInTheDocument();
   });
 
-  it('renders the CURRENT phase layout only (build → Tasks | Issues, no tabs)', async () => {
-    tagAc(AC(19));
+  it('build: tabs render, panels render, and NO review actions outside Specify', async () => {
+    tagAc(AC182(10));
+    tagAc(AC182(3));
     renderAt('build');
 
-    // The build layout renders (current phase) with no phase tabs to browse.
     await screen.findByTestId('task-panel');
     expect(screen.getByTestId('issue-panel')).toBeInTheDocument();
-    expect(screen.queryAllByRole('tab')).toHaveLength(0);
-    expect(screen.getByTestId('review-action-row')).toBeInTheDocument();
-  });
-
-  it('done collapses to the DoneSummary — no reviewer block', async () => {
-    tagAc(AC(19));
-    renderAt('done');
-
-    await screen.findByTestId('done-summary');
+    // dec-1: the tab bar renders for reviewers; dec-3: no review row off-Specify.
+    expect(screen.getAllByRole('tab')).toHaveLength(3);
     expect(screen.queryByTestId('review-action-row')).not.toBeInTheDocument();
     expect(screen.queryByTestId('review-handoff-line')).not.toBeInTheDocument();
+  });
+
+  it('draft shows NO review actions either — the row is Specify-only (dec-3)', async () => {
+    tagAc(AC182(10));
+    tagAc(AC182(3));
+    renderAt('draft');
+
+    await screen.findByText('Narrative');
+    expect(screen.queryByTestId('review-action-row')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('review-handoff-line')).not.toBeInTheDocument();
+  });
+
+  it('a reviewer browses another phase without moving the spec (ac-8)', async () => {
+    tagAc(AC182(8));
+    const user = userEvent.setup();
+    renderAt('build');
+
+    await screen.findByTestId('task-panel');
+    // Click the Verify tab — the verify layout renders, the phase is untouched.
+    await user.click(screen.getAllByRole('tab').find((t) => t.getAttribute('data-tab') === 'verify')!);
+    await screen.findByTestId('ac-panel');
+    expect(updateDocStatus).not.toHaveBeenCalled();
+  });
+
+  it("the reviewer's sentence slot carries the switch-to-Editing link wired to promoteToEditor", async () => {
+    tagAc(AC182(14));
+    tagAc(AC182(6));
+    const user = userEvent.setup();
+    renderAt('plan');
+
+    const sentence = await screen.findByTestId('transition-sentence');
+    const slot = within(sentence).getByTestId('switch-to-editing');
+    expect(slot.textContent).toContain("You're reviewing — switch to Editing to act.");
+
+    await user.click(within(slot).getByRole('button', { name: 'switch to Editing' }));
+    // Same path as the header pill: useSwitchPosture → promoteToEditor + refetch.
+    await waitFor(() => expect(promoteToEditor).toHaveBeenCalledWith('doc-uuid'));
+  });
+
+  it('done collapses to the DoneSummary for reviewers — no review block, no Reopen', async () => {
+    tagAc(AC182(13));
+    tagAc(AC182(5));
+    renderAt('done');
+
+    const summary = await screen.findByTestId('done-summary');
+    expect(screen.queryByTestId('review-action-row')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('review-handoff-line')).not.toBeInTheDocument();
+    // Reopen stays canEdit-gated (spec-164 dec-5) — absent for a reviewer.
+    expect(summary).toHaveAttribute('data-can-reopen', 'false');
   });
 });
 
@@ -678,19 +729,20 @@ describe('spec-159 ac-17 — next-action handoff line', () => {
     expect(screen.queryByTestId('phase-handoff-line')).not.toBeInTheDocument();
   });
 
-  it('a writable reviewer gets the reviewer handoff line, not the editor phase handoff (ac-19)', async () => {
+  it('a writable reviewer at Specify gets BOTH the phase handoff and the review handoff (spec-182)', async () => {
     tagAc(AC(17));
-    tagAc(AC(19));
+    tagAc(AC182(11));
     mockRole = 'reviewer';
     renderAt('plan');
 
-    // The reviewer block replaces the editor handoff: the reviewer handoff line
-    // renders and the editor's phase-handoff-line does not.
+    // spec-182 dec-1 dissolved the reviewer fork: ac-17's "renders for every
+    // viewer" now genuinely includes reviewers, and dec-3's review handoff
+    // joins it at Specify.
     const line = await screen.findByTestId('review-handoff-line');
     expect(line.textContent).toContain(
       'You can copy and paste this prompt into your coding agent if you prefer to conduct the review from there.',
     );
-    expect(screen.queryByTestId('phase-handoff-line')).not.toBeInTheDocument();
+    expect(screen.getByTestId('phase-handoff-line')).toBeInTheDocument();
   });
 });
 

--- a/packages/ui/src/pages/DocDocument.tsx
+++ b/packages/ui/src/pages/DocDocument.tsx
@@ -868,6 +868,9 @@ export function DocDocument() {
     <IssuePanel
       docId={doc.id}
       canWrite={canWrite}
+      /* spec-182 dec-4: dispositions (convert / won't-fix) are editor calls;
+         registering stays open to reviewers via canWrite. */
+      canEdit={canEdit}
       onUpdate={reloadDoc}
       highlightIssueHandle={initialIssueHandle}
     />
@@ -1000,57 +1003,16 @@ export function DocDocument() {
         />
       )}
 
-      {/* spec-159 ac-19: a WRITABLE REVIEWER gets a review-oriented phase block
-          in place of the editor's PhaseTabBar + TransitionSentence. It has no
-          tabs (a reviewer browses only the current phase's layout) and offers no
-          forward move — a reviewer observes. EDITORS and read-only visitors
-          (canWrite false) fall through to the existing block below, unchanged.
-          `done` collapses into the DoneSummary for everyone. */}
-      {doc.docType === 'spec' && phase !== 'done' && isWritableReviewer ? (
-        <div className="mb-4 space-y-2">
-          {/* The posture itself ("you are reviewing", switch to editing) lives
-              in the header's PostureDropdown pill — this block carries only the
-              review actions and the handoff line. */}
-          {/* Review action row — the four scaffold review prompts, sent through
-              the chat (mirrors OpeningTurn's reviewer set + chat_prompt arm). */}
-          <div
-            data-testid="review-action-row"
-            className="flex flex-wrap items-center gap-2 pt-1"
-          >
-            {REVIEW_ACTIONS.map((action) => (
-              <Button
-                key={action.buttonId}
-                type="button"
-                variant="secondary"
-                size="sm"
-                onClick={() => sendReviewPrompt(action.buttonId)}
-              >
-                {action.label}
-              </Button>
-            ))}
-          </div>
-          {/* Reviewer handoff line — copy a coding-agent prompt to conduct the
-              review from there. Same sentence form as the editor handoff. */}
-          <div data-testid="review-handoff-line">
-            <PromptButton
-              buttonId="review-handoff"
-              context={handoffContext}
-              orgBlocks={orgBlocks}
-              sentencePrefix="You can copy and paste "
-              linkText="this prompt"
-              sentence="into your coding agent if you prefer to conduct the review from there."
-              sentenceLabel="You can copy and paste this prompt into your coding agent if you prefer to conduct the review from there."
-            />
-          </div>
-        </div>
-      ) : (
-        /* spec-159 t-6/t-7: the phase control is now an in-page affordance. The
-           PhaseTabBar browses phase views (Plan / Build / Verify) without ever
-           moving the Spec; the TransitionSentence beneath it is the *only* phase
-           mutation — one [Yes], no modal. Specs only. The sentence renders for
-           every viewer (it's the page's phase status line); the Yes itself gates
-           on canEdit. `done` collapses both into the DoneSummary. */
-        doc.docType === 'spec' &&
+      {/* spec-182 dec-1: ONE shared phase block for every posture — the
+          spec-159 ac-19 reviewer fork is dissolved (a writable reviewer used to
+          get a review-action block IN PLACE of the tab bar; that inverted the
+          trust gradient — read-only strangers could browse phases, trusted
+          reviewers couldn't). The PhaseTabBar browses phase views without ever
+          moving the Spec; the TransitionSentence beneath it is the *only* phase
+          mutation — one [Yes], no modal, gated on canEdit. Reviewers reach the
+          sentence as a status-only line (dec-2) carrying the switch-to-Editing
+          link (dec-6). `done` collapses both into the DoneSummary for everyone. */}
+      {doc.docType === 'spec' &&
         phase !== 'done' && (
           <div className="mb-4 space-y-2">
             <PhaseTabBar
@@ -1077,7 +1039,53 @@ export function DocDocument() {
                 reloadDoc();
               }}
               onCancelBrowse={() => setSelectedTab(null)}
+              /* spec-182 dec-6: only a WRITABLE REVIEWER gets the in-slot
+                 "switch to Editing" door — same switchPosture path as the
+                 header pill. Read-only visitors have no posture to switch,
+                 so no callback and no link. */
+              onSwitchToEdit={
+                isWritableReviewer ? () => void switchPosture('editor') : undefined
+              }
             />
+            {/* spec-182 dec-3: the review actions are a SPECIFY-phase fixture
+                for BOTH postures — review is a planning act (you review the
+                decisions and narrative before they harden), so the row keys on
+                the Spec's phase, not the viewer's posture. No other phase
+                (draft included) shows it. The four buttons resolve their
+                prompts from the Scaffold (std-23) and send through the chat. */}
+            {phase === 'plan' && (
+              <>
+                <div
+                  data-testid="review-action-row"
+                  className="flex flex-wrap items-center gap-2 pt-1"
+                >
+                  {REVIEW_ACTIONS.map((action) => (
+                    <Button
+                      key={action.buttonId}
+                      type="button"
+                      variant="secondary"
+                      size="sm"
+                      onClick={() => sendReviewPrompt(action.buttonId)}
+                    >
+                      {action.label}
+                    </Button>
+                  ))}
+                </div>
+                {/* Review handoff line — copy a coding-agent prompt to conduct
+                    the review from there. Specify-only, like the row (dec-3). */}
+                <div data-testid="review-handoff-line">
+                  <PromptButton
+                    buttonId="review-handoff"
+                    context={handoffContext}
+                    orgBlocks={orgBlocks}
+                    sentencePrefix="You can copy and paste "
+                    linkText="this prompt"
+                    sentence="into your coding agent if you prefer to conduct the review from there."
+                    sentenceLabel="You can copy and paste this prompt into your coding agent if you prefer to conduct the review from there."
+                  />
+                </div>
+              </>
+            )}
             {/* spec-159 ac-17: the next-action handoff line — a "Copy a prompt
                 to …" sentence keyed to the CURRENT phase. Renders for every
                 viewer (copying a prompt is read-only); absent at `done`. */}
@@ -1095,13 +1103,12 @@ export function DocDocument() {
               </div>
             )}
           </div>
-        )
-      )}
+        )}
 
       {/* Content area. `done` → the retrospective report replaces it entirely;
           every other phase renders its declarative layout. Non-Spec docs (no
-          phase layer) fall back to the Narrative view. Reviewers have no phase
-          tabs, so `viewedTab` stays pinned to the current phase's layout. */}
+          phase layer) fall back to the Narrative view. Every posture browses
+          via the tab bar above (spec-182 dec-1). */}
       {doc.docType === 'spec' && phase === 'done' ? (
         <DoneSummary
           doc={doc}


### PR DESCRIPTION
Implements **spec-182** (https://memex.ai/mindset-prod/memex-building-itself/specs/spec-182) — one commit, `67251eb`. Follows on from #17 (spec-164), which this builds on.

## What changes
- **The spec-159 ac-19 reviewer fork is dissolved** (dec-1/dec-2): one shared phase block — PhaseTabBar + TransitionSentence + phase handoff — for editors, writable reviewers, and read-only visitors. Reviewers browse all phase views; browsing never moves the spec. The trust-gradient inversion (read-only strangers had more navigation than trusted reviewers) is gone.
- **Review actions are a Specify-phase fixture for BOTH postures** (dec-3): the four review buttons (Summarise / Security / Design / Architecture) and the review handoff render only while the spec is in Specify — editors see them too; no other phase (draft included) shows them.
- **Reviewers get a door to acting** (dec-6): `TransitionSentence` gains `onSwitchToEdit` — where an editor sees `[Yes]`, a writable reviewer sees "You're reviewing — switch to Editing to act.", wired to the same `switchPosture` path as the header pill. Read-only visitors get no link.
- **Issue powers split by posture** (dec-4): Convert to Task and Won't fix gate on `canWrite && canEdit`; registering issues stays reviewer-open on `canWrite`.
- **Done unified** (dec-5): reviewers get the DoneSummary minus Reopen (already `canEdit`-gated by spec-164).
- **Licensing** (dec-7, per std-25): Fair-code core, pinned by `licensing.spec-182.test.ts`.

Notable contract change: at Specify, both prompt lines render for every viewer — the phase handoff (create Decisions/ACs) *and* the review handoff.

## Verification
- packages/ui vitest: **109 files, 926 passed** — all 16 spec-182 ACs carry `tagAc`'d tests
- `make build` (tsc + vite): green
- spec-182 sits in **verify** in Memex with 0 open decisions/tasks/drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)