### PR TITLE
feat: inject integration state into agent system prompt (spec-180)

### DIFF
--- a/packages/server/src/agent/integration-state.ts
+++ b/packages/server/src/agent/integration-state.ts
@@ -1,0 +1,86 @@
+// spec-180: resolve which messaging integrations are active for the current
+// request. The logic mirrors each tool's own credential-resolution path so
+// the injected system-prompt block can never diverge from what the tools
+// report at call time.
+import { and, eq, inArray, isNull } from "drizzle-orm";
+import { db } from "../db/connection.js";
+import { orgDiscordWebhooks, orgMemberships, userSlackTokens } from "../db/schema.js";
+import { getOrgIdForMemex } from "../services/memexes.js";
+
+export interface IntegrationState {
+  slackConnected: boolean;
+  discordConnected: boolean;
+  discordAmbiguous: boolean;
+  discordChannelName: string | null;
+}
+
+/**
+ * Mirrors the credential resolution used by memex__send_discord_message and
+ * memex__send_slack_message so the injected system-prompt block reflects what
+ * the tools will actually do at execution time.
+ *
+ * Discord: tries the memex's owning org first; if the memex has no org
+ * (personal namespace), auto-discovers across the user's active memberships —
+ * same auto-discovery path as the Discord tool.
+ *
+ * Slack: queries userSlackTokens with the same (userId, orgId) filter and
+ * revokedAt check as getSlackClientForUser in services/.ee/slack/client.ts.
+ */
+export async function resolveIntegrationState(
+  memexId: string,
+  userId: string | undefined,
+): Promise<IntegrationState> {
+  const orgId = await getOrgIdForMemex(memexId);
+
+  // Discord resolution — mirrors send_discord_message handler.
+  let discordOrgId = orgId;
+  let discordAmbiguous = false;
+
+  if (!discordOrgId && userId) {
+    const memberships = await db
+      .select({ orgId: orgMemberships.orgId })
+      .from(orgMemberships)
+      .where(and(eq(orgMemberships.userId, userId), eq(orgMemberships.status, "active")));
+
+    const orgIds = memberships.map((m) => m.orgId);
+    if (orgIds.length > 0) {
+      const webhooks = await db
+        .select({ orgId: orgDiscordWebhooks.orgId })
+        .from(orgDiscordWebhooks)
+        .where(inArray(orgDiscordWebhooks.orgId, orgIds));
+
+      if (webhooks.length === 1) {
+        discordOrgId = webhooks[0].orgId;
+      } else if (webhooks.length > 1) {
+        discordAmbiguous = true;
+      }
+    }
+  }
+
+  // Slack resolution — mirrors getSlackClientForUser in services/.ee/slack/client.ts.
+  // orgId null → isNull() to match the legacy global-token fallback path.
+  const slackWhere = userId
+    ? and(
+        eq(userSlackTokens.userId, userId),
+        orgId ? eq(userSlackTokens.orgId, orgId) : isNull(userSlackTokens.orgId),
+      )
+    : undefined;
+
+  const [discordWebhook, slackToken] = await Promise.all([
+    discordOrgId
+      ? db.query.orgDiscordWebhooks.findFirst({
+          where: eq(orgDiscordWebhooks.orgId, discordOrgId),
+        })
+      : Promise.resolve(undefined),
+    slackWhere
+      ? db.query.userSlackTokens.findFirst({ where: slackWhere })
+      : Promise.resolve(undefined),
+  ]);
+
+  return {
+    slackConnected: !!(slackToken && !slackToken.revokedAt),
+    discordConnected: discordAmbiguous || !!discordWebhook,
+    discordAmbiguous,
+    discordChannelName: discordWebhook?.channelName ?? null,
+  };
+}

--- a/packages/server/src/agent/system-prompt.test.ts
+++ b/packages/server/src/agent/system-prompt.test.ts
@@ -13,9 +13,9 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const PHASES_DIR = resolve(__dirname, "phases");
 
 describe("buildSystemBlocks", () => {
-  it("returns two blocks", () => {
+  it("returns three blocks (instructions, context, integration state)", () => {
     const blocks = buildSystemBlocks("Some context", "plan");
-    expect(blocks).toHaveLength(2);
+    expect(blocks).toHaveLength(3);
   });
 
   it("first block contains the React-only role orientation", () => {
@@ -219,6 +219,95 @@ describe("buildSystemBlocks", () => {
         );
       }
     });
+  });
+});
+
+// spec-180: integration state block tests
+describe("spec-180: integration state block in buildSystemBlocks", () => {
+  const AC180 = (n: number) =>
+    `mindset-prod/memex-building-itself/specs/spec-180/acs/ac-${n}`;
+
+  // ac-4 + ac-5: the integration block is a SEPARATE third block with no cache_control,
+  // sitting after the ephemeral context block — so it never busts the tool-definition cache.
+  it("ac-4 + ac-5: integration block is a separate 3rd block with no cache_control; context block (2nd) retains its ephemeral marker", () => {
+    tagAc(AC180(4));
+    tagAc(AC180(5));
+    const blocks = buildSystemBlocks("ctx", "plan");
+    expect(blocks).toHaveLength(3);
+    // context block (index 1) carries the cache breakpoint — unchanged by spec-180
+    expect(blocks[1].cache_control).toEqual({ type: "ephemeral" });
+    // integration block (index 2) has no cache_control — always fresh
+    expect(blocks[2].cache_control).toBeUndefined();
+  });
+
+  // ac-6 + ac-8: block is always present and always states both integrations explicitly.
+  it("ac-6 + ac-8: always injects the block with both Slack and Discord lines — even with no integrationState passed", () => {
+    tagAc(AC180(6));
+    tagAc(AC180(8));
+    const blocks = buildSystemBlocks("ctx", "plan");
+    const text = blocks[2].text;
+    expect(text).toContain("## Active integrations");
+    expect(text).toContain("Slack:");
+    expect(text).toContain("Discord:");
+  });
+
+  // ac-8: both lines present regardless of configuration state.
+  it("ac-8: integration block always states both Slack and Discord regardless of what is configured", () => {
+    tagAc(AC180(8));
+    // Both unconfigured
+    const noneBlocks = buildSystemBlocks("ctx", "plan", false, false, false, {
+      slackConnected: false, discordConnected: false, discordAmbiguous: false, discordChannelName: null,
+    });
+    expect(noneBlocks[2].text).toContain("Slack:");
+    expect(noneBlocks[2].text).toContain("Discord:");
+
+    // Both configured
+    const bothBlocks = buildSystemBlocks("ctx", "plan", false, false, false, {
+      slackConnected: true, discordConnected: true, discordAmbiguous: false, discordChannelName: "general",
+    });
+    expect(bothBlocks[2].text).toContain("Slack:");
+    expect(bothBlocks[2].text).toContain("Discord:");
+  });
+
+  // ac-1: Discord-only case — block must not mislead agent into thinking Slack is the only option.
+  it("ac-1: Discord configured + Slack not connected — block says Discord is ready and Slack will fail", () => {
+    tagAc(AC180(1));
+    tagAc(AC180(7));
+    const blocks = buildSystemBlocks("ctx", "plan", false, false, false, {
+      slackConnected: false, discordConnected: true, discordAmbiguous: false, discordChannelName: "build",
+    });
+    const text = blocks[2].text;
+    expect(text).toContain("memex__send_discord_message is ready");
+    expect(text).toContain("Slack: not connected");
+    expect(text).not.toContain("Slack: connected");
+  });
+
+  // ac-2: Slack-only case — block must not mislead agent into thinking Discord is available.
+  it("ac-2: Slack connected + Discord not configured — block says Slack is ready and Discord will fail", () => {
+    tagAc(AC180(2));
+    const blocks = buildSystemBlocks("ctx", "plan", false, false, false, {
+      slackConnected: true, discordConnected: false, discordAmbiguous: false, discordChannelName: null,
+    });
+    const text = blocks[2].text;
+    expect(text).toContain("Slack: connected");
+    expect(text).toContain("Discord: no webhook configured");
+    expect(text).not.toContain("memex__send_discord_message is ready");
+  });
+
+  it("reports Discord as configured with channel name when available", () => {
+    const blocks = buildSystemBlocks("ctx", "plan", false, false, false, {
+      slackConnected: false, discordConnected: true, discordAmbiguous: false, discordChannelName: "build",
+    });
+    expect(blocks[2].text).toContain("Discord: webhook configured (#build)");
+    expect(blocks[2].text).toContain("memex__send_discord_message is ready");
+  });
+
+  it("reports Discord as ambiguous when multiple orgs have webhooks", () => {
+    const blocks = buildSystemBlocks("ctx", "plan", false, false, false, {
+      slackConnected: false, discordConnected: true, discordAmbiguous: true, discordChannelName: null,
+    });
+    expect(blocks[2].text).toContain("multiple orgs");
+    expect(blocks[2].text).toContain("memex");
   });
 });
 

--- a/packages/server/src/agent/system-prompt.ts
+++ b/packages/server/src/agent/system-prompt.ts
@@ -11,6 +11,7 @@ import {
   type SpecPhase,
 } from "@memex/shared";
 import type { SystemBlock } from "./types.js";
+import type { IntegrationState } from "./integration-state.js";
 import { loadSkill } from "./skills.js";
 
 // ──────────────────────────────────────────────
@@ -119,6 +120,7 @@ export function buildSystemBlocks(
   readOnly = false,
   reviewer = false,
   driftMode = false,
+  integrationState?: IntegrationState,
 ): SystemBlock[] {
   const projectedPhase: SpecPhase = phase === "draft" ? "plan" : phase;
   const instructionBlocks = toPromptBlocks(BASE_SCAFFOLD, projectedPhase);
@@ -158,7 +160,33 @@ export function buildSystemBlocks(
     cache_control: { type: "ephemeral" },
   };
 
-  return [instructions, context];
+  // spec-180 (dec-2): always inject the integration state block — both integrations
+  // stated explicitly so the agent never infers availability from silence.
+  // (dec-1): separate block with no cache_control so it resolves fresh per request
+  // without busting the tool-definition cache carried by `context`.
+  const slackLine = integrationState?.slackConnected
+    ? "- Slack: connected — memex__send_slack_message is ready"
+    : "- Slack: not connected (no token) — memex__send_slack_message will fail";
+
+  let discordLine: string;
+  if (integrationState?.discordAmbiguous) {
+    discordLine =
+      "- Discord: configured in multiple orgs — pass the `memex` parameter to target the right one";
+  } else if (integrationState?.discordConnected) {
+    const channel = integrationState.discordChannelName
+      ? ` (#${integrationState.discordChannelName})`
+      : "";
+    discordLine = `- Discord: webhook configured${channel} — memex__send_discord_message is ready`;
+  } else {
+    discordLine = "- Discord: no webhook configured — memex__send_discord_message will fail";
+  }
+
+  const integration: SystemBlock = {
+    type: "text",
+    text: `## Active integrations\n${slackLine}\n${discordLine}`,
+  };
+
+  return [instructions, context, integration];
 }
 
 /**

--- a/packages/server/src/agent/tools.ts
+++ b/packages/server/src/agent/tools.ts
@@ -280,9 +280,10 @@ const REVIEWER_WRITE_ALLOWLIST = new Set<string>([
   // Raise an Issue (spec-112) — a reviewer's sanctioned way to flag a problem
   // (dec-3). The other issue verbs (update/resolve/convert) stay editor-only.
   "register_issue",
-  // Slack message — external action, does not mutate the Spec. A reviewer may
-  // ping a teammate or send a status update without needing editor rights.
+  // Slack + Discord messages — external actions, do not mutate the Spec. A
+  // reviewer may ping a teammate or send a status update without editor rights.
   "memex__send_slack_message",
+  "memex__send_discord_message",
   // @mention (spec-79) is NOT here — the tool isn't built, so we don't permit
   // (or advertise) it. Add it when spec-79 lands.
 ]);

--- a/packages/server/src/routes/llm.test.ts
+++ b/packages/server/src/routes/llm.test.ts
@@ -69,6 +69,18 @@ vi.mock("../services/doc-members.js", () => ({
   resolveRole: vi.fn().mockResolvedValue("editor"),
 }));
 
+// spec-180: mock resolveIntegrationState so /chat tests don't need DB access.
+// vi.hoisted so the value is available inside the hoisted vi.mock factory.
+const mockIntegrationState = vi.hoisted(() => ({
+  slackConnected: false,
+  discordConnected: false,
+  discordAmbiguous: false,
+  discordChannelName: null,
+}));
+vi.mock("../agent/integration-state.js", () => ({
+  resolveIntegrationState: vi.fn().mockResolvedValue(mockIntegrationState),
+}));
+
 vi.mock("../services/conversations.js", () => ({
   getOrCreateConversation: vi.fn().mockResolvedValue({ id: "conv-1" }),
   getMessages: vi.fn().mockResolvedValue([]),
@@ -117,6 +129,7 @@ import { tagAc } from "@memex-ai-ac/vitest";
 import { executeServerTool } from "../agent/tools.js";
 import { buildDocumentContext, buildDriftContext } from "../agent/context-builder.js";
 import { buildSystemBlocks, buildCreationSystemBlocks } from "../agent/system-prompt.js";
+import { resolveIntegrationState } from "../agent/integration-state.js";
 import { getCreationToolDefinitions, getToolDefinitions, isToolAllowedForReviewer, isReadOnlyTool, isDriftModeTool } from "../agent/tools.js";
 import { resolveRole } from "../services/doc-members.js";
 import { getOrCreateConversation, getMessages, clearConversation, replaceMessages } from "../services/conversations.js";
@@ -272,7 +285,8 @@ describe("POST /llm/chat", () => {
     // false here because the mocked resolveRole returns "editor". Mock returns
     // { context: "Mock document context", phase: "plan" }.
     // spec-143 t-4 (dec-6) adds a 5th `driftMode` arg — false here (not drift).
-    expect(buildSystemBlocks).toHaveBeenCalledWith("Mock document context", "plan", false, false, false);
+    // spec-180 adds a 6th `integrationState` arg — the resolved integration status.
+    expect(buildSystemBlocks).toHaveBeenCalledWith("Mock document context", "plan", false, false, false, mockIntegrationState);
   });
 
   it("uses fallback context when no docId", async () => {
@@ -294,6 +308,8 @@ describe("POST /llm/chat", () => {
       false,
       // spec-143 t-4 (dec-6): the 5th driftMode arg — false here (not drift).
       false,
+      // spec-180: the 6th integrationState arg — the resolved integration status.
+      mockIntegrationState,
     );
   });
 
@@ -314,7 +330,7 @@ describe("POST /llm/chat", () => {
     await res.text();
 
     expect(canWriteMemex).toHaveBeenCalledWith("test-user-id", "test-account-id");
-    expect(buildSystemBlocks).toHaveBeenCalledWith("Mock document context", "plan", true, false, false);
+    expect(buildSystemBlocks).toHaveBeenCalledWith("Mock document context", "plan", true, false, false, mockIntegrationState);
   });
 
   it("passes readOnly=false to buildSystemBlocks for a writing member (ac-13)", async () => {
@@ -329,7 +345,7 @@ describe("POST /llm/chat", () => {
     });
     await res.text();
 
-    expect(buildSystemBlocks).toHaveBeenCalledWith("Mock document context", "plan", false, false, false);
+    expect(buildSystemBlocks).toHaveBeenCalledWith("Mock document context", "plan", false, false, false, mockIntegrationState);
   });
 
   // spec-143 t-4 (dec-6): drift mode — the in-UI drift agent runs against the
@@ -362,8 +378,24 @@ describe("POST /llm/chat", () => {
       false,
       false,
       true,
+      mockIntegrationState,
     );
     expect(getToolDefinitions).toHaveBeenCalledWith({ reviewer: false, mode: "drift" });
+  });
+
+  // spec-180 ac-3: integration state resolved server-side per request — not cached.
+  it("ac-3: resolveIntegrationState is called on every /chat request with the current memexId and userId", async () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-180/acs/ac-3");
+    const docId = "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d";
+
+    const res = await app.request("/llm/chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ docId, messages: [{ role: "user", content: "Hello" }] }),
+    });
+    await res.text();
+
+    expect(resolveIntegrationState).toHaveBeenCalledWith("test-account-id", "test-user-id");
   });
 });
 
@@ -688,7 +720,7 @@ describe("spec-126 review overlay", () => {
     // ac-1: the overlay threads reviewer into the server-built prompt + tool list.
     // spec-143 t-4 (dec-6): the 5th driftMode arg is false here; getToolDefinitions
     // now also receives `mode` (undefined when not in drift mode).
-    expect(buildSystemBlocks).toHaveBeenCalledWith("Mock document context", "plan", false, true, false);
+    expect(buildSystemBlocks).toHaveBeenCalledWith("Mock document context", "plan", false, true, false, mockIntegrationState);
     expect(getToolDefinitions).toHaveBeenCalledWith({ reviewer: true, mode: undefined });
   });
 

--- a/packages/server/src/routes/llm.ts
+++ b/packages/server/src/routes/llm.ts
@@ -146,7 +146,12 @@ llmRouter.post("/chat", async (c) => {
   c.header("Cache-Control", "no-cache, no-transform");
   c.header("X-Accel-Buffering", "no");
 
-  logRequest("chat", messages as MessageParam[]);
+  // Strip any tool_use blocks that have no matching tool_result — happens when
+  // the user types a follow-up message instead of acting on a compose widget,
+  // leaving an orphaned tool_use in history that Anthropic rejects with 400.
+  const sanitisedMessages = stripDanglingToolUses(messages as MessageParam[]);
+
+  logRequest("chat", sanitisedMessages);
 
   return streamSSE(c, async (stream) => {
     try {
@@ -155,7 +160,7 @@ llmRouter.post("/chat", async (c) => {
         max_tokens: 4096,
         system: systemBlocks,
         tools: tools as Anthropic.Tool[],
-        messages: messages as MessageParam[],
+        messages: sanitisedMessages,
       });
 
       // Event-listener pattern — mirrors `doc-events.ts`, the other SSE endpoint

--- a/packages/server/src/routes/llm.ts
+++ b/packages/server/src/routes/llm.ts
@@ -16,6 +16,7 @@ import type { MemexResolverEnv } from "../middleware/memex-resolver.js";
 import { requireMemexId } from "./shared.js";
 import { canWriteMemex, READ_ONLY_PUBLIC_MESSAGE } from "../mcp/auth.js";
 import { resolveRole } from "../services/doc-members.js";
+import { resolveIntegrationState } from "../agent/integration-state.js";
 
 const MODEL = "claude-sonnet-4-5-20250929";
 
@@ -99,24 +100,34 @@ llmRouter.post("/chat", async (c) => {
   // canWriteMemex against the resolved memex. Members → false (default), so the
   // member prompt is unchanged. Server-side enforcement still lives in the MCP
   // read/write gate (t-4); this is the prompt-level counterpart.
+  // spec-180: all three pre-LLM lookups (write-access, role, integration state)
+  // are independent — run them in parallel to eliminate sequential DB round trips.
   const currentUserId = c.get("currentUserId");
-  const readOnly = currentUserId
-    ? !(await canWriteMemex(currentUserId, memexId).catch(() => true))
-    : false;
-
-  // spec-126 (dec-1/dec-2): the review overlay, mirroring readOnly. The viewer's
-  // per-doc role is derived SERVER-side from doc_members (`resolveRole`) — never
-  // client-passed (ac-3), so it can't be spoofed. Only a doc-bound chat has a
-  // role; the no-doc creation fallback is never review mode. A non-member / no
-  // editor row resolves to `reviewer` by default (ac-4). On a transient lookup
-  // error we fall back to editor for the PROMPT overlay only — the /tools/execute
-  // gate independently re-derives role and is the authoritative enforcement, so a
-  // prompt fail-open never permits a mutation.
-  const reviewer =
+  const [readOnly, reviewer, integrationState] = await Promise.all([
+    // spec-111 t-9 (dec-2): a signed-in NON-member chatting on a public Memex
+    // gets the read-only agent posture — it can answer/search but must explain it
+    // cannot mutate. Members → false (default). Server-side enforcement still lives
+    // in the MCP read/write gate (t-4); this is the prompt-level counterpart.
+    currentUserId
+      ? canWriteMemex(currentUserId, memexId).then(can => !can).catch(() => false)
+      : Promise.resolve(false),
+    // spec-126 (dec-1/dec-2): the review overlay. Role derived SERVER-side from
+    // doc_members — never client-passed (ac-3). Only doc-bound chats have a role;
+    // creation fallback is never review mode. Fail-open to editor for PROMPT overlay
+    // only — /tools/execute re-derives role authoritatively.
     docId && currentUserId
-      ? (await resolveRole(memexId, docId, currentUserId).catch(() => "editor")) ===
-        "reviewer"
-      : false;
+      ? resolveRole(memexId, docId, currentUserId).then(r => r === "reviewer").catch(() => false)
+      : Promise.resolve(false),
+    // spec-180: inject accurate Slack/Discord state so the agent never hallucinates
+    // about tool availability. Fail-open (both not configured) on any DB error so a
+    // lookup failure never hangs the route.
+    resolveIntegrationState(memexId, currentUserId ?? undefined).catch(() => ({
+      slackConnected: false,
+      discordConnected: false,
+      discordAmbiguous: false,
+      discordChannelName: null,
+    })),
+  ]);
 
   const systemBlocks = buildSystemBlocks(
     documentContext.context,
@@ -124,6 +135,7 @@ llmRouter.post("/chat", async (c) => {
     readOnly,
     reviewer,
     driftMode,
+    integrationState,
   );
   // dec-3 definition filter: a reviewer's model never sees the blocked mutations.
   // spec-143 t-4 (dec-6): in drift mode the model sees only the focused drift


### PR DESCRIPTION
## Summary

- **spec-180**: Resolves Slack/Discord hallucination — the agent now knows the actual integration state per-request instead of guessing
- **Reviewer can now send Discord** (like Slack — external action, doesn't mutate the Spec)
- **Fix 400 from Anthropic** when user types a follow-up after a compose widget leaves an orphaned `tool_use` in history

## Changes

### `agent/integration-state.ts` (new)
`resolveIntegrationState()` mirrors the exact credential-resolution paths of both tools:
- Discord: tries the memex's owning org first; for personal memexes auto-discovers across the user's active org memberships (same path as the tool)
- Slack: `(userId, orgId)` + `revokedAt` filter — identical to `getSlackClientForUser`

### `agent/system-prompt.ts`
`buildSystemBlocks()` gains an optional `IntegrationState` 6th param and returns a **third block with no `cache_control`** (dec-1: separate from the cached context block so it resolves fresh per request without busting the tool-definition cache; dec-2: both integrations always stated so the agent never infers from silence).

### `routes/llm.ts`
- Runs `canWriteMemex`, `resolveRole`, and `resolveIntegrationState` in parallel via `Promise.all`
- Integration lookup has `.catch()` fail-open — a DB error never hangs the route
- Applies `stripDanglingToolUses` to messages before sending to Anthropic (was missing from `/chat`; only `/chat/create` had it)

### `agent/tools.ts`
Adds `memex__send_discord_message` to `REVIEWER_WRITE_ALLOWLIST` alongside `memex__send_slack_message` — both are external actions that don't mutate the Spec.

## Verified locally

- Asked "do you have Discord?" → agent correctly reports `#build` webhook connected and Slack not connected
- Sent a Discord message as a reviewer → succeeds (previously blocked)
- Typed a follow-up after a Discord compose widget → no more 400 from Anthropic

## Test plan

- [ ] `pnpm --filter @memex/server test` — spec-180 ACs green (8/8)
- [ ] Dev stack: ask "do you have Discord?" → agent reports actual DB state
- [ ] Dev stack: send Discord message as reviewer → succeeds
- [ ] Dev stack: type follow-up after compose widget appears → no 400 error
- [ ] Verify no regression on creation, drift, and editor-mode flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)