### PR TITLE
feat: auto-inject Discord Spec footer and update format (spec-180 t-2)

### DIFF
--- a/packages/server/src/agent/tool-specs.ts
+++ b/packages/server/src/agent/tool-specs.ts
@@ -4403,12 +4403,28 @@ export const toolSpecs: ToolSpec[] = [
         ? await ctx.resolveRef(specRef).catch(() => null)
         : null;
 
-      const embedFooter = explicitSpec
-        ? {
-            text: `📄 From Spec: ${explicitSpec.doc.title}`,
-            url: `${buildTenantUrl(explicitSpec.slugs)}/specs/${explicitSpec.doc.handle}`,
-          }
-        : undefined;
+      // Auto-build the footer from the current doc when specRef is omitted.
+      // The /chat route always passes currentDocId when the agent is bound to a
+      // Spec — fall back to it so the footer is consistent without requiring the
+      // agent to remember to pass the parameter.
+      // Format mirrors the Slack context block: **Spec:** [title](url) _(handle)_  ·  Sent via Memex
+      const embedFooter = await (async () => {
+        const buildDescription = (title: string, _handle: string, url: string) =>
+          `**Spec:** [${title}](${url})`;
+
+        if (explicitSpec) {
+          const url = `${buildTenantUrl(explicitSpec.slugs)}/specs/${explicitSpec.doc.handle}`;
+          return { description: buildDescription(explicitSpec.doc.title, explicitSpec.doc.handle, url) };
+        }
+        if (!ctx.currentDocId) return undefined;
+        const [doc, slugs] = await Promise.all([
+          db.query.documents.findFirst({ where: eq(documents.id, ctx.currentDocId) }),
+          memexSlugsById(memexId),
+        ]);
+        if (!doc || !slugs) return undefined;
+        const url = `${buildTenantUrl(slugs)}/specs/${doc.handle}`;
+        return { description: buildDescription(doc.title, doc.handle, url) };
+      })();
 
       await postToDiscord(webhook.webhookUrl, text, embedFooter);
 

--- a/packages/server/src/services/discord-webhook.test.ts
+++ b/packages/server/src/services/discord-webhook.test.ts
@@ -54,20 +54,18 @@ describe("postToDiscord: payload shape", () => {
     expect(body.embeds).toHaveLength(1);
   });
 
-  it("embed description is a markdown hyperlink containing text and url (dec-3)", async () => {
+  it("embed description is placed as-is from the footer description field (dec-3)", async () => {
     tagAc(AC_10);
     const fetchSpy = vi.mocked(fetch);
 
     const footer = {
-      text: "📄 From Spec: Discord Integration",
-      url: "https://memex.ai/mindset-prod/memex-building-itself/specs/spec-138",
+      description: "**Spec:** [Discord Integration](https://memex.ai/mindset-prod/memex-building-itself/specs/spec-138)",
     };
     await postToDiscord("https://discord.com/api/webhooks/test", "msg", footer);
 
     const body = capturedBody(fetchSpy) as { embeds: Array<{ description: string }> };
     const embed = body.embeds[0];
-    // Discord renders description markdown as a clickable link — footer field is plain text only.
-    expect(embed.description).toBe(`[${footer.text}](${footer.url})`);
+    expect(embed.description).toBe(footer.description);
   });
 
   it("message text is passed as-is — no markdown conversion applied (dec-4)", async () => {

--- a/packages/server/src/services/discord-webhook.ts
+++ b/packages/server/src/services/discord-webhook.ts
@@ -17,10 +17,10 @@ export interface DiscordWebhookRow {
 }
 
 // When specRef is provided, the payload gains an embeds array carrying the Spec
-// link footer. The text and url are pre-built by the caller (tool handler).
+// link footer. The description is built by the caller and placed as-is in the
+// Discord embed description field (supports Discord markdown + hyperlinks).
 export interface DiscordEmbedFooter {
-  text: string; // e.g. "📄 From Spec: Voice-to-Voice Platform Feature"
-  url: string;  // e.g. "https://memex.ai/mindset-prod/memex-building-itself/specs/spec-138"
+  description: string; // e.g. "**Spec:** [Title](url) _(handle)_  ·  Sent via Memex"
 }
 
 // ─── CRUD ────────────────────────────────────────────────────────────────────
@@ -72,9 +72,9 @@ export async function deleteDiscordWebhook(orgId: string): Promise<Mutated<void>
 
 // Builds the wire-format Discord payload and POSTs it to the webhook URL.
 //
-// Payload shapes (dec-2):
+// Payload shapes:
 //   no embedFooter → { "content": "<text>" }
-//   embedFooter    → { "content": "<text>", "embeds": [{ "footer": { "text": "..." }, "url": "..." }] }
+//   embedFooter    → { "content": "<text>", "embeds": [{ "description": "..." }] }
 //
 // Text is forwarded as-is — no markdown conversion (dec-4). Discord renders
 // **bold**, *italic*, `code`, [links](url) natively.
@@ -83,12 +83,10 @@ export async function postToDiscord(
   content: string,
   embedFooter?: DiscordEmbedFooter,
 ): Promise<void> {
-  // Discord footer fields are plain text only — links don't render there.
-  // Using embed description with a markdown hyperlink gives a clickable link.
   const payload = embedFooter
     ? {
         content,
-        embeds: [{ description: `[${embedFooter.text}](${embedFooter.url})` }],
+        embeds: [{ description: embedFooter.description }],
       }
     : { content };
 


### PR DESCRIPTION
## Summary

Follow-up to #19 (spec-180). Discovered during testing after the main PR merged.

- **Auto-inject footer**: `memex__send_discord_message` now falls back to `ctx.currentDocId` to build the Spec embed when the agent omits `specRef`. The `/chat` route always passes `currentDocId` when bound to a Spec, so the footer appears consistently without requiring the agent to pass the parameter.
- **Footer format**: `**Spec:** [title](url)` — cleaner than the old `📄 From Spec: title`, matches the Slack context block style, drops the handle suffix.
- **`DiscordEmbedFooter` simplified**: changed from `{text, url}` to `{description: string}` — caller builds the full markdown string, `postToDiscord` places it as-is in the embed `description` field.

Tracked as spec-180 t-2.

## Test plan

- [ ] Send Discord message from a Spec context without passing `specRef` — embed footer appears with correct title and link
- [ ] Send Discord message outside a Spec context — no embed
- [ ] Footer renders as `**Spec:** [title](url)` in Discord (bold label, clickable title)

🤖 Generated with [Claude Code](https://claude.com/claude-code)