### PR TITLE
spec-182 dec-6 amended: remove the switch-to-Editing nag

### DIFF
--- a/packages/ui/src/components/TransitionSentence.test.tsx
+++ b/packages/ui/src/components/TransitionSentence.test.tsx
@@ -265,55 +265,26 @@ describe('Rubicon line — posture (i-1) and the Yes mutation', () => {
   });
 });
 
-// spec-182 dec-6 — the reviewer's door: where the editor's [Yes] renders, a
-// viewer who can't transition but CAN switch posture gets the switch link.
-describe('switch-to-Editing link (spec-182 dec-6)', () => {
+// spec-182 dec-6 (amended 2026-06-05) — the in-slot "switch to Editing" nag
+// was removed at the user's call; the header posture pill is the only switch
+// affordance. This pins the absence so the nag doesn't quietly return.
+describe('no switch-to-Editing nag (spec-182 dec-6, amended)', () => {
   const AC182 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-182/acs/ac-${n}`;
 
-  it('renders the link in the button slot for a writable reviewer and fires the callback', async () => {
+  it('a non-transitioning viewer sees a clean status line — no nag in any sentence shape', () => {
     tagAc(AC182(14));
     tagAc(AC182(6));
-    const onSwitchToEdit = vi.fn();
-    const user = userEvent.setup();
-    render(
-      <TransitionSentence
-        {...baseProps()}
-        canTransition={false}
-        onSwitchToEdit={onSwitchToEdit}
-      />,
-    );
-
-    const slot = screen.getByTestId('switch-to-editing');
-    expect(slot.textContent).toContain("You're reviewing — switch to Editing to act.");
-    // No Yes/No render alongside it.
-    expect(screen.queryByRole('button', { name: 'Yes' })).not.toBeInTheDocument();
-
-    await user.click(screen.getByRole('button', { name: 'switch to Editing' }));
-    expect(onSwitchToEdit).toHaveBeenCalledTimes(1);
-  });
-
-  it('renders the link on a BLOCKED sentence too — the slot follows the sentence, not the offer', () => {
-    tagAc(AC182(14));
-    render(
-      <TransitionSentence
-        {...baseProps({ openDecisionCount: 2 })}
-        canTransition={false}
-        onSwitchToEdit={vi.fn()}
-      />,
-    );
-    expect(screen.getByTestId('switch-to-editing')).toBeInTheDocument();
-  });
-
-  it('read-only viewers (no callback) get NO link; editors (canTransition) get Yes, no link', () => {
-    tagAc(AC182(15));
-    const { unmount } = render(
-      <TransitionSentence {...baseProps()} canTransition={false} />,
-    );
+    // Clean offer shape.
+    const { unmount } = render(<TransitionSentence {...baseProps()} canTransition={false} />);
     expect(screen.queryByTestId('switch-to-editing')).not.toBeInTheDocument();
+    expect(text()).not.toContain("You're reviewing");
     unmount();
 
-    render(<TransitionSentence {...baseProps()} canTransition onSwitchToEdit={vi.fn()} />);
-    expect(screen.getByRole('button', { name: 'Yes' })).toBeInTheDocument();
+    // Blocked shape.
+    render(
+      <TransitionSentence {...baseProps({ openDecisionCount: 2 })} canTransition={false} />,
+    );
     expect(screen.queryByTestId('switch-to-editing')).not.toBeInTheDocument();
+    expect(text()).not.toContain("You're reviewing");
   });
 });

--- a/packages/ui/src/components/TransitionSentence.tsx
+++ b/packages/ui/src/components/TransitionSentence.tsx
@@ -79,15 +79,6 @@ export interface TransitionSentenceProps {
   onTransitioned?: (newPhase: SpecStatus) => void;
   /** The browse-confirm's [No]: return the view to the current phase's tab. */
   onCancelBrowse?: () => void;
-  /**
-   * spec-182 dec-6: the reviewer's door to acting. When the viewer cannot
-   * transition (`canTransition` false) but CAN switch posture — a writable
-   * reviewer — the parent passes this callback and the button slot renders
-   * "You're reviewing — switch to Editing to act." with the link wired to the
-   * same switchPosture path as the header pill. Read-only visitors get no
-   * callback and therefore no link.
-   */
-  onSwitchToEdit?: () => void;
 }
 
 /**
@@ -175,7 +166,6 @@ export function TransitionSentence({
   unverifiedAcCount = 0,
   onTransitioned,
   onCancelBrowse,
-  onSwitchToEdit,
 }: TransitionSentenceProps) {
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -237,21 +227,6 @@ export function TransitionSentence({
       {error}
     </span>
   );
-  // spec-182 dec-6: the reviewer's slot-filler — renders exactly where the
-  // editor's [Yes] would, only when the viewer can't transition but can switch.
-  const switchLink = !canTransition && onSwitchToEdit && (
-    <span data-testid="switch-to-editing">
-      You're reviewing —{' '}
-      <button
-        type="button"
-        onClick={() => onSwitchToEdit()}
-        className="underline underline-offset-2 text-primary hover:text-heading"
-      >
-        switch to Editing
-      </button>{' '}
-      to act.
-    </span>
-  );
 
   // No target at all (e.g. done with nothing further) → nothing to say; the
   // tab bar already carries the phase (and `done` collapses the whole block
@@ -267,8 +242,7 @@ export function TransitionSentence({
       // buttons to press.
       return (
         <p className="text-sm text-secondary" data-testid="transition-sentence">
-          {renderBlockers(blockers)} before this spec can move to {phaseDisplayName(target)}.{' '}
-          {switchLink}
+          {renderBlockers(blockers)} before this spec can move to {phaseDisplayName(target)}.
         </p>
       );
     }
@@ -277,7 +251,6 @@ export function TransitionSentence({
     return (
       <p className="text-sm text-secondary" data-testid="transition-sentence">
         {verb} to move this spec to {phaseDisplayName(target)}? {yesButton}
-        {switchLink}
         {errorNote}
       </p>
     );
@@ -297,7 +270,6 @@ export function TransitionSentence({
     <p className="text-sm text-secondary" data-testid="transition-sentence">
       {showSummary && <>{renderBlockers(blockers)} before {phaseDisplayName(target)}. </>}
       {question} {yesButton} {noButton}
-      {switchLink}
       {errorNote}
     </p>
   );

--- a/packages/ui/src/pages/DocDocument.spec-159.test.tsx
+++ b/packages/ui/src/pages/DocDocument.spec-159.test.tsx
@@ -647,19 +647,14 @@ describe('spec-182 — unified reviewer phase block', () => {
     expect(updateDocStatus).not.toHaveBeenCalled();
   });
 
-  it("the reviewer's sentence slot carries the switch-to-Editing link wired to promoteToEditor", async () => {
+  it("the reviewer's sentence is a clean status line — no switch-to-Editing nag (dec-6 amended)", async () => {
     tagAc(AC182(14));
     tagAc(AC182(6));
-    const user = userEvent.setup();
     renderAt('plan');
 
     const sentence = await screen.findByTestId('transition-sentence');
-    const slot = within(sentence).getByTestId('switch-to-editing');
-    expect(slot.textContent).toContain("You're reviewing — switch to Editing to act.");
-
-    await user.click(within(slot).getByRole('button', { name: 'switch to Editing' }));
-    // Same path as the header pill: useSwitchPosture → promoteToEditor + refetch.
-    await waitFor(() => expect(promoteToEditor).toHaveBeenCalledWith('doc-uuid'));
+    expect(within(sentence).queryByTestId('switch-to-editing')).not.toBeInTheDocument();
+    expect(sentence.textContent).not.toContain("You're reviewing");
   });
 
   it('done collapses to the DoneSummary for reviewers — no review block, no Reopen', async () => {

--- a/packages/ui/src/pages/DocDocument.tsx
+++ b/packages/ui/src/pages/DocDocument.tsx
@@ -142,16 +142,13 @@ export function DocDocument() {
   // `canEdit` is the conjunction of org write access and an editor posture.
   const { myRole, loading: roleLoading } = useDocRole(doc?.id ?? null);
   const canEdit = canWrite && myRole === 'editor';
-  // spec-159 ac-19: a WRITABLE reviewer (org member who hasn't taken the editor
-  // posture on this Spec) gets a review-oriented phase block — a row of
-  // review-action prompts and a reviewer handoff line — in place of the
-  // editor's PhaseTabBar + TransitionSentence. Editors and read-only visitors
-  // (canWrite false) keep the existing block untouched. The posture itself
-  // (and the switch between editing/reviewing) lives in the header's
-  // PostureDropdown pill, not in this block.
-  const isWritableReviewer = canWrite && myRole === 'reviewer';
-  // The posture switch behind the header pill — promote/demote + role refetch
-  // (the role flip then swaps the phase block). Null-safe before the doc loads.
+  // spec-182 dec-1 dissolved the spec-159 ac-19 reviewer fork — every posture
+  // renders the same phase block, so no per-posture flag remains here. The
+  // posture itself (and the switch between editing/reviewing) lives in the
+  // header's PostureDropdown pill (dec-6, amended: the pill is the ONLY
+  // switch affordance — no in-page nag).
+  // The posture switch behind the header pill — promote/demote + role refetch.
+  // Null-safe before the doc loads.
   const switchPosture = useSwitchPosture(doc?.id ?? '');
   // spec-159 ac-17: Org scaffold appends for the phase handoff line's
   // PromptButton — threaded into toButtonPrompt exactly as OpeningTurn does.
@@ -1010,8 +1007,9 @@ export function DocDocument() {
           reviewers couldn't). The PhaseTabBar browses phase views without ever
           moving the Spec; the TransitionSentence beneath it is the *only* phase
           mutation — one [Yes], no modal, gated on canEdit. Reviewers reach the
-          sentence as a status-only line (dec-2) carrying the switch-to-Editing
-          link (dec-6). `done` collapses both into the DoneSummary for everyone. */}
+          sentence as a status-only line (dec-2); the header posture pill is the
+          only switch affordance (dec-6, amended 2026-06-05 — the in-slot nag
+          was removed). `done` collapses both into the DoneSummary for everyone. */}
       {doc.docType === 'spec' &&
         phase !== 'done' && (
           <div className="mb-4 space-y-2">
@@ -1039,13 +1037,6 @@ export function DocDocument() {
                 reloadDoc();
               }}
               onCancelBrowse={() => setSelectedTab(null)}
-              /* spec-182 dec-6: only a WRITABLE REVIEWER gets the in-slot
-                 "switch to Editing" door — same switchPosture path as the
-                 header pill. Read-only visitors have no posture to switch,
-                 so no callback and no link. */
-              onSwitchToEdit={
-                isWritableReviewer ? () => void switchPosture('editor') : undefined
-              }
             />
             {/* spec-182 dec-3: the review actions are a SPECIFY-phase fixture
                 for BOTH postures — review is a planning act (you review the


### PR DESCRIPTION
Follow-up to #18. The in-slot "You're reviewing — **switch to Editing** to act." link shipped in spec-182, was reviewed live on the dev build, and was reversed by the user the same day — it read as nag functionality.

- `onSwitchToEdit` removed from `TransitionSentence` (all three sentence shapes back to a clean status line)
- DocDocument wiring removed; the now-dead `isWritableReviewer` flag dropped
- The header posture pill is the **only** switch affordance on the spec page
- Absence pinned by tests so the nag doesn't quietly return; spec-182's dec-6 resolution amended in Memex and ac-6/ac-14/ac-15 re-pointed at the clean-line / pill-only claims

Verification: UI suite 924 passed, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)