### PR TITLE
fix: spec-177 AC coverage + vitest config DATABASE_URL alignment

### DIFF
--- a/packages/server/src/services/user-namespaces.integration.test.ts
+++ b/packages/server/src/services/user-namespaces.integration.test.ts
@@ -4,11 +4,18 @@
 // replaced by PERSONAL_MEMEX_NAME exported from user-namespaces.ts.
 
 import { describe, it, expect, afterAll } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
 import { eq, inArray } from "drizzle-orm";
 import { db } from "../db/connection.js";
 import { users, namespaces } from "../db/schema.js";
 import { upsertUserByEmail, getUserById } from "./users.js";
 import { ensureUserMemex, ensureUserNamespace, PERSONAL_MEMEX_NAME } from "./user-namespaces.js";
+
+// spec-177 AC refs
+const AC_1 = "mindset-prod/memex-building-itself/specs/spec-177/acs/ac-1"; // resend email does not error
+const AC_2 = "mindset-prod/memex-building-itself/specs/spec-177/acs/ac-2"; // namespace created exactly once
+const AC_4 = "mindset-prod/memex-building-itself/specs/spec-177/acs/ac-4"; // no unhandled PostgresError
+const AC_5 = "mindset-prod/memex-building-itself/specs/spec-177/acs/ac-5"; // ON CONFLICT DO NOTHING
 
 const createdUserIds: string[] = [];
 
@@ -24,6 +31,7 @@ function uniqueEmail(prefix: string): string {
 
 describe("ensureUserMemex / ensureUserNamespace", () => {
   it("creates a personal namespace + memex on first call", async () => {
+    tagAc(AC_2);
     const user = await upsertUserByEmail(uniqueEmail("personal"));
     createdUserIds.push(user.id);
 
@@ -35,7 +43,10 @@ describe("ensureUserMemex / ensureUserNamespace", () => {
     expect(refreshed?.namespaceId).toBeTruthy();
   });
 
-  it("is idempotent — second call returns the existing memex", async () => {
+  it("is idempotent — second call returns the existing memex without error", async () => {
+    tagAc(AC_1);
+    tagAc(AC_2);
+    tagAc(AC_4);
     const user = await upsertUserByEmail(uniqueEmail("idempotent"));
     createdUserIds.push(user.id);
 
@@ -44,7 +55,27 @@ describe("ensureUserMemex / ensureUserNamespace", () => {
     expect(second.id).toBe(first.id);
   });
 
+  it("concurrent calls do not throw — ON CONFLICT DO NOTHING absorbs the race (ac-5)", async () => {
+    tagAc(AC_1);
+    tagAc(AC_4);
+    tagAc(AC_5);
+    // Two concurrent ensureUserNamespace calls with the same userId simulate the
+    // email-resend race: both see namespaceId=null, derive the same slug, and race
+    // to INSERT. The loser hits ON CONFLICT DO NOTHING and falls back to a SELECT.
+    const user = await upsertUserByEmail(uniqueEmail("race"));
+    createdUserIds.push(user.id);
+
+    const [r1, r2] = await Promise.all([
+      ensureUserNamespace(user.id),
+      ensureUserNamespace(user.id),
+    ]);
+
+    expect(r1.namespace.id).toBe(r2.namespace.id);
+    expect(r1.namespace.slug).toBe(r2.namespace.slug);
+  });
+
   it("creates a user-kind namespace owned by the user", async () => {
+    tagAc(AC_2);
     const user = await upsertUserByEmail(uniqueEmail("nsowner"));
     createdUserIds.push(user.id);
 

--- a/packages/server/vitest.config.ts
+++ b/packages/server/vitest.config.ts
@@ -37,7 +37,25 @@ const rootEnv = readRootEnv();
 // vitest.worker-db.setup.ts, which runs inside each worker.
 // Escape hatch: MEMEX_TEST_DATABASE_URL pins an exact URL (workers still
 // append their `_w<poolId>` suffix to it).
-const TEST_DATABASE_URL = resolveTestDatabaseUrl();
+//
+// The local packages/server/.env may contain DATABASE_URL (non-default host,
+// port, or credentials). Parse it WITHOUT mutating process.env so that the
+// same URL is used here (config time) and in vitest.global-setup.ts (which
+// uses `import "dotenv/config"` — same file). Without this, the config falls
+// back to the hardcoded default (localhost:5432/postgres) while global-setup
+// uses the local .env, and workers connect to a different host than where the
+// test databases were created.
+function readLocalEnv(): Record<string, string> {
+  try {
+    return dotenv.parse(
+      readFileSync(resolve(dirname(fileURLToPath(import.meta.url)), ".env"), "utf8"),
+    );
+  } catch {
+    return {};
+  }
+}
+const localEnv = readLocalEnv();
+const TEST_DATABASE_URL = resolveTestDatabaseUrl({ ...process.env, ...localEnv });
 
 export default defineConfig({
   test: {


### PR DESCRIPTION
## Summary

- **vitest config fix**: `vitest.config.ts` was computing `TEST_DATABASE_URL` at config-eval time before `dotenv/config` ran, so it fell back to `localhost:5432` while `vitest.global-setup.ts` created worker databases at `localhost:5433`. Added `readLocalEnv()` to parse `packages/server/.env` without side-effects and pass it to `resolveTestDatabaseUrl()`, aligning both sides on the same base URL.
- **spec-177 AC coverage**: Added `tagAc` calls for ac-1, ac-2, ac-4, and ac-5 to `user-namespaces.integration.test.ts`. Added a new concurrent-race test for ac-5 that fires two `ensureUserNamespace` calls in parallel with the same userId and asserts both return the same namespace (exercising the `ON CONFLICT DO NOTHING` + fallback SELECT path).

## Test plan

- [x] `npx vitest run src/services/user-namespaces.integration.test.ts` — 4/4 passing
- [x] `npx vitest run src/services/discord-webhook.test.ts` — 6/6 passing
- [ ] CI green on this branch