### PR TITLE
fix(ui): spec-182 issues 1+2 — reviewer sees no transition questions, no phase handoff

### DIFF
--- a/packages/ui/src/components/TransitionSentence.test.tsx
+++ b/packages/ui/src/components/TransitionSentence.test.tsx
@@ -239,12 +239,60 @@ describe('Rubicon line — shape 3: browsing another tab → Are-you-sure + Yes/
   });
 });
 
+// spec-182 issue-1 (2026-06-05): the Rubicon is STATUS-ONLY for non-editors.
+// Blocker statements render (they're the page's phase status); the transition
+// questions never do, and a clean rubric renders nothing at all — the tab
+// pill already carries the phase.
 describe('Rubicon line — posture (i-1) and the Yes mutation', () => {
-  it('canTransition=false renders the line but withholds Yes/No', () => {
-    tagAc(AC(3));
+  const AC182_9 = 'mindset-prod/memex-building-itself/specs/spec-182/acs/ac-9';
+
+  it('canTransition=false browsing forward with a clean rubric renders NOTHING — no question', () => {
+    tagAc(AC182_9);
     render(<TransitionSentence {...baseProps({ viewedTab: 'build', canTransition: false })} />);
-    expect(text()).toContain('Are you sure you want to move this spec to Build?');
+    expect(screen.queryByTestId('transition-sentence')).toBeNull();
     expect(screen.queryByRole('button')).toBeNull();
+  });
+
+  it('canTransition=false on the current tab with a clean rubric renders NOTHING — no offer', () => {
+    tagAc(AC182_9);
+    render(<TransitionSentence {...baseProps({ canTransition: false })} />);
+    expect(screen.queryByTestId('transition-sentence')).toBeNull();
+  });
+
+  it('canTransition=false on the current tab, blocked → the rubric condition, no buttons', () => {
+    tagAc(AC182_9);
+    render(
+      <TransitionSentence
+        {...baseProps({ openDecisionCount: 2, canTransition: false })}
+      />,
+    );
+    expect(text()).toContain('2 Decisions');
+    expect(text()).toContain('must be resolved');
+    expect(text()).not.toContain('?');
+    expect(screen.queryByRole('button')).toBeNull();
+  });
+
+  it('canTransition=false browsing forward, blocked → blocker summary only, no "Move anyway?"', () => {
+    tagAc(AC182_9);
+    render(
+      <TransitionSentence
+        {...baseProps({ viewedTab: 'build', openDecisionCount: 2, canTransition: false })}
+      />,
+    );
+    expect(text()).toContain('2 Decisions');
+    expect(text()).not.toContain('Move this spec anyway?');
+    expect(text()).not.toContain('?');
+    expect(screen.queryByRole('button')).toBeNull();
+  });
+
+  it('canTransition=false browsing backward renders NOTHING — no back-move question', () => {
+    tagAc(AC182_9);
+    render(
+      <TransitionSentence
+        {...baseProps({ currentPhase: 'verify', viewedTab: 'build', canTransition: false })}
+      />,
+    );
+    expect(screen.queryByTestId('transition-sentence')).toBeNull();
   });
 
   it('pressing Yes calls updateDocStatus(docId, target) immediately, no dialog (ac-6)', async () => {
@@ -274,13 +322,14 @@ describe('no switch-to-Editing nag (spec-182 dec-6, amended)', () => {
   it('a non-transitioning viewer sees a clean status line — no nag in any sentence shape', () => {
     tagAc(AC182(14));
     tagAc(AC182(6));
-    // Clean offer shape.
+    // Clean offer shape — renders nothing at all for a non-editor
+    // (spec-182 issue-1), so trivially no nag.
     const { unmount } = render(<TransitionSentence {...baseProps()} canTransition={false} />);
     expect(screen.queryByTestId('switch-to-editing')).not.toBeInTheDocument();
-    expect(text()).not.toContain("You're reviewing");
+    expect(screen.queryByTestId('transition-sentence')).toBeNull();
     unmount();
 
-    // Blocked shape.
+    // Blocked shape — the status line renders, nag-free.
     render(
       <TransitionSentence {...baseProps({ openDecisionCount: 2 })} canTransition={false} />,
     );

--- a/packages/ui/src/components/TransitionSentence.test.tsx
+++ b/packages/ui/src/components/TransitionSentence.test.tsx
@@ -265,55 +265,26 @@ describe('Rubicon line — posture (i-1) and the Yes mutation', () => {
   });
 });
 
-// spec-182 dec-6 — the reviewer's door: where the editor's [Yes] renders, a
-// viewer who can't transition but CAN switch posture gets the switch link.
-describe('switch-to-Editing link (spec-182 dec-6)', () => {
+// spec-182 dec-6 (amended 2026-06-05) — the in-slot "switch to Editing" nag
+// was removed at the user's call; the header posture pill is the only switch
+// affordance. This pins the absence so the nag doesn't quietly return.
+describe('no switch-to-Editing nag (spec-182 dec-6, amended)', () => {
   const AC182 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-182/acs/ac-${n}`;
 
-  it('renders the link in the button slot for a writable reviewer and fires the callback', async () => {
+  it('a non-transitioning viewer sees a clean status line — no nag in any sentence shape', () => {
     tagAc(AC182(14));
     tagAc(AC182(6));
-    const onSwitchToEdit = vi.fn();
-    const user = userEvent.setup();
-    render(
-      <TransitionSentence
-        {...baseProps()}
-        canTransition={false}
-        onSwitchToEdit={onSwitchToEdit}
-      />,
-    );
-
-    const slot = screen.getByTestId('switch-to-editing');
-    expect(slot.textContent).toContain("You're reviewing — switch to Editing to act.");
-    // No Yes/No render alongside it.
-    expect(screen.queryByRole('button', { name: 'Yes' })).not.toBeInTheDocument();
-
-    await user.click(screen.getByRole('button', { name: 'switch to Editing' }));
-    expect(onSwitchToEdit).toHaveBeenCalledTimes(1);
-  });
-
-  it('renders the link on a BLOCKED sentence too — the slot follows the sentence, not the offer', () => {
-    tagAc(AC182(14));
-    render(
-      <TransitionSentence
-        {...baseProps({ openDecisionCount: 2 })}
-        canTransition={false}
-        onSwitchToEdit={vi.fn()}
-      />,
-    );
-    expect(screen.getByTestId('switch-to-editing')).toBeInTheDocument();
-  });
-
-  it('read-only viewers (no callback) get NO link; editors (canTransition) get Yes, no link', () => {
-    tagAc(AC182(15));
-    const { unmount } = render(
-      <TransitionSentence {...baseProps()} canTransition={false} />,
-    );
+    // Clean offer shape.
+    const { unmount } = render(<TransitionSentence {...baseProps()} canTransition={false} />);
     expect(screen.queryByTestId('switch-to-editing')).not.toBeInTheDocument();
+    expect(text()).not.toContain("You're reviewing");
     unmount();
 
-    render(<TransitionSentence {...baseProps()} canTransition onSwitchToEdit={vi.fn()} />);
-    expect(screen.getByRole('button', { name: 'Yes' })).toBeInTheDocument();
+    // Blocked shape.
+    render(
+      <TransitionSentence {...baseProps({ openDecisionCount: 2 })} canTransition={false} />,
+    );
     expect(screen.queryByTestId('switch-to-editing')).not.toBeInTheDocument();
+    expect(text()).not.toContain("You're reviewing");
   });
 });

--- a/packages/ui/src/components/TransitionSentence.tsx
+++ b/packages/ui/src/components/TransitionSentence.tsx
@@ -24,9 +24,12 @@ import { Button } from './ui';
 //      the view to the current phase's tab. Backward moves never carry
 //      blockers (dec-5).
 //
-// The sentence renders for every viewer — it is the page's phase status line —
-// and the buttons gate on `canTransition` (editor posture, i-1). Pressing Yes
-// is the only thing that moves the phase, anywhere on the page.
+// Posture (spec-182 issue-1): the Rubicon is STATUS-ONLY for non-editors.
+// When `canTransition` is false the blocker statements still render — they are
+// the page's phase status — but the questions ("Do you wish…?", "Are you
+// sure…?", "Move anyway?") never appear without the power to act, and a
+// ready-to-advance spec renders nothing at all. Pressing Yes is the only
+// thing that moves the phase, anywhere on the page.
 
 // `draft` is treated as "before plan": its home is the Plan tab, draft → plan
 // is never gated, and the forward target of every phase is simply the next
@@ -59,8 +62,9 @@ export interface TransitionSentenceProps {
   viewedTab: SpecStatus;
   /**
    * Whether the viewer may actually move the phase (editor posture + org write
-   * access). When false the sentence still renders — it's the page's phase
-   * status line — but the Yes/No buttons are withheld.
+   * access). When false the Rubicon is status-only: blocker statements render
+   * (they're the page's phase status) but the transition questions and Yes/No
+   * buttons never appear (spec-182 issue-1).
    */
   canTransition?: boolean;
   /** Total decisions on the Spec — distinguishes "none created" from "open". */
@@ -206,12 +210,14 @@ export function TransitionSentence({
     }
   }
 
-  const yesButton = canTransition && (
+  // The question shapes below only render when canTransition is true, so the
+  // buttons need no further gate of their own.
+  const yesButton = (
     <Button type="button" size="sm" variant="primary" onClick={handleYes} disabled={submitting}>
       {submitting ? 'Moving…' : 'Yes'}
     </Button>
   );
-  const noButton = canTransition && (
+  const noButton = (
     <Button
       type="button"
       size="sm"
@@ -246,7 +252,12 @@ export function TransitionSentence({
         </p>
       );
     }
-    // Ready: the advancement offer.
+    // Ready: the advancement offer — editors only. A non-editor has nothing
+    // to act on, and the tab bar's filled pill already carries the phase
+    // (spec-182 issue-1).
+    if (!canTransition) {
+      return null;
+    }
     const verb = target === 'verify' || target === 'done' ? 'Do you want' : 'Do you wish';
     return (
       <p className="text-sm text-secondary" data-testid="transition-sentence">
@@ -261,6 +272,19 @@ export function TransitionSentence({
   // (which already names the target) and asks "Move this spec anyway?" —
   // naming the target once, with the friction carried by "anyway".
   const showSummary = !backward && blockers.length > 0;
+  if (!canTransition) {
+    // Non-editor browsing: status only (spec-182 issue-1). Forward+blocked
+    // still states the rubric's outstanding work; otherwise there is no
+    // question to ask someone who can't press Yes.
+    if (!showSummary) {
+      return null;
+    }
+    return (
+      <p className="text-sm text-secondary" data-testid="transition-sentence">
+        {renderBlockers(blockers)} before {phaseDisplayName(target)}.
+      </p>
+    );
+  }
   const question = backward
     ? `Do you want to move this spec back to ${phaseDisplayName(target)}?`
     : showSummary

--- a/packages/ui/src/components/TransitionSentence.tsx
+++ b/packages/ui/src/components/TransitionSentence.tsx
@@ -79,15 +79,6 @@ export interface TransitionSentenceProps {
   onTransitioned?: (newPhase: SpecStatus) => void;
   /** The browse-confirm's [No]: return the view to the current phase's tab. */
   onCancelBrowse?: () => void;
-  /**
-   * spec-182 dec-6: the reviewer's door to acting. When the viewer cannot
-   * transition (`canTransition` false) but CAN switch posture — a writable
-   * reviewer — the parent passes this callback and the button slot renders
-   * "You're reviewing — switch to Editing to act." with the link wired to the
-   * same switchPosture path as the header pill. Read-only visitors get no
-   * callback and therefore no link.
-   */
-  onSwitchToEdit?: () => void;
 }
 
 /**
@@ -175,7 +166,6 @@ export function TransitionSentence({
   unverifiedAcCount = 0,
   onTransitioned,
   onCancelBrowse,
-  onSwitchToEdit,
 }: TransitionSentenceProps) {
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -237,21 +227,6 @@ export function TransitionSentence({
       {error}
     </span>
   );
-  // spec-182 dec-6: the reviewer's slot-filler — renders exactly where the
-  // editor's [Yes] would, only when the viewer can't transition but can switch.
-  const switchLink = !canTransition && onSwitchToEdit && (
-    <span data-testid="switch-to-editing">
-      You're reviewing —{' '}
-      <button
-        type="button"
-        onClick={() => onSwitchToEdit()}
-        className="underline underline-offset-2 text-primary hover:text-heading"
-      >
-        switch to Editing
-      </button>{' '}
-      to act.
-    </span>
-  );
 
   // No target at all (e.g. done with nothing further) → nothing to say; the
   // tab bar already carries the phase (and `done` collapses the whole block
@@ -267,8 +242,7 @@ export function TransitionSentence({
       // buttons to press.
       return (
         <p className="text-sm text-secondary" data-testid="transition-sentence">
-          {renderBlockers(blockers)} before this spec can move to {phaseDisplayName(target)}.{' '}
-          {switchLink}
+          {renderBlockers(blockers)} before this spec can move to {phaseDisplayName(target)}.
         </p>
       );
     }
@@ -277,7 +251,6 @@ export function TransitionSentence({
     return (
       <p className="text-sm text-secondary" data-testid="transition-sentence">
         {verb} to move this spec to {phaseDisplayName(target)}? {yesButton}
-        {switchLink}
         {errorNote}
       </p>
     );
@@ -297,7 +270,6 @@ export function TransitionSentence({
     <p className="text-sm text-secondary" data-testid="transition-sentence">
       {showSummary && <>{renderBlockers(blockers)} before {phaseDisplayName(target)}. </>}
       {question} {yesButton} {noButton}
-      {switchLink}
       {errorNote}
     </p>
   );

--- a/packages/ui/src/pages/DocDocument.spec-159.test.tsx
+++ b/packages/ui/src/pages/DocDocument.spec-159.test.tsx
@@ -647,19 +647,14 @@ describe('spec-182 — unified reviewer phase block', () => {
     expect(updateDocStatus).not.toHaveBeenCalled();
   });
 
-  it("the reviewer's sentence slot carries the switch-to-Editing link wired to promoteToEditor", async () => {
+  it("the reviewer's sentence is a clean status line — no switch-to-Editing nag (dec-6 amended)", async () => {
     tagAc(AC182(14));
     tagAc(AC182(6));
-    const user = userEvent.setup();
     renderAt('plan');
 
     const sentence = await screen.findByTestId('transition-sentence');
-    const slot = within(sentence).getByTestId('switch-to-editing');
-    expect(slot.textContent).toContain("You're reviewing — switch to Editing to act.");
-
-    await user.click(within(slot).getByRole('button', { name: 'switch to Editing' }));
-    // Same path as the header pill: useSwitchPosture → promoteToEditor + refetch.
-    await waitFor(() => expect(promoteToEditor).toHaveBeenCalledWith('doc-uuid'));
+    expect(within(sentence).queryByTestId('switch-to-editing')).not.toBeInTheDocument();
+    expect(sentence.textContent).not.toContain("You're reviewing");
   });
 
   it('done collapses to the DoneSummary for reviewers — no review block, no Reopen', async () => {

--- a/packages/ui/src/pages/DocDocument.spec-159.test.tsx
+++ b/packages/ui/src/pages/DocDocument.spec-159.test.tsx
@@ -607,9 +607,27 @@ describe('spec-182 — unified reviewer phase block', () => {
       name: /^You can copy and paste this prompt/,
     });
     expect(copyButton.textContent).toBe('this prompt');
-    // spec-182 dec-1: the phase handoff renders for every viewer now — the
-    // reviewer sees BOTH lines at Specify (ac-17's "every viewer" restored).
-    expect(screen.getByTestId('phase-handoff-line')).toBeInTheDocument();
+    // spec-182 issue-2: the phase handoff is an editor affordance — its prompt
+    // drives state changes and building. A reviewer gets the review handoff
+    // ONLY (amends ac-17's "renders for every viewer").
+    expect(screen.queryByTestId('phase-handoff-line')).not.toBeInTheDocument();
+  });
+
+  it('a reviewer at Build sees NO coding-agent handoff line (issue-2)', async () => {
+    tagAc(AC182(17));
+    renderAt('build');
+
+    await screen.findByTestId('task-panel');
+    expect(screen.queryByTestId('phase-handoff-line')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('review-handoff-line')).not.toBeInTheDocument();
+  });
+
+  it('a reviewer at Verify sees NO coding-agent handoff line (issue-2)', async () => {
+    tagAc(AC182(17));
+    renderAt('verify');
+
+    await screen.findByTestId('ac-panel');
+    expect(screen.queryByTestId('phase-handoff-line')).not.toBeInTheDocument();
   });
 
   it('build: tabs render, panels render, and NO review actions outside Specify', async () => {
@@ -671,7 +689,9 @@ describe('spec-182 — unified reviewer phase block', () => {
 });
 
 // spec-159 ac-17 — the next-action handoff line beneath the Rubicon line. Keyed
-// to the Spec's CURRENT phase, renders for every viewer, absent at `done`.
+// to the Spec's CURRENT phase, absent at `done`. spec-182 issue-2 amended
+// ac-17's "renders for every viewer": the line is editor-only (canEdit) — its
+// prompt drives state changes and building, which are not reviewer powers.
 describe('spec-159 ac-17 — next-action handoff line', () => {
   it('plan: "Copy and paste this prompt into your coding agent to create Decisions and ACs." with bold entities', async () => {
     tagAc(AC(17));
@@ -724,20 +744,19 @@ describe('spec-159 ac-17 — next-action handoff line', () => {
     expect(screen.queryByTestId('phase-handoff-line')).not.toBeInTheDocument();
   });
 
-  it('a writable reviewer at Specify gets BOTH the phase handoff and the review handoff (spec-182)', async () => {
-    tagAc(AC(17));
+  it('a writable reviewer at Specify gets the review handoff ONLY — no phase handoff (spec-182 issue-2)', async () => {
+    tagAc(AC182(17));
     tagAc(AC182(11));
     mockRole = 'reviewer';
     renderAt('plan');
 
-    // spec-182 dec-1 dissolved the reviewer fork: ac-17's "renders for every
-    // viewer" now genuinely includes reviewers, and dec-3's review handoff
-    // joins it at Specify.
+    // spec-182 issue-2: the phase handoff is canEdit-gated — the reviewer
+    // keeps dec-3's review handoff at Specify and nothing else.
     const line = await screen.findByTestId('review-handoff-line');
     expect(line.textContent).toContain(
       'You can copy and paste this prompt into your coding agent if you prefer to conduct the review from there.',
     );
-    expect(screen.getByTestId('phase-handoff-line')).toBeInTheDocument();
+    expect(screen.queryByTestId('phase-handoff-line')).not.toBeInTheDocument();
   });
 });
 

--- a/packages/ui/src/pages/DocDocument.tsx
+++ b/packages/ui/src/pages/DocDocument.tsx
@@ -142,16 +142,13 @@ export function DocDocument() {
   // `canEdit` is the conjunction of org write access and an editor posture.
   const { myRole, loading: roleLoading } = useDocRole(doc?.id ?? null);
   const canEdit = canWrite && myRole === 'editor';
-  // spec-159 ac-19: a WRITABLE reviewer (org member who hasn't taken the editor
-  // posture on this Spec) gets a review-oriented phase block — a row of
-  // review-action prompts and a reviewer handoff line — in place of the
-  // editor's PhaseTabBar + TransitionSentence. Editors and read-only visitors
-  // (canWrite false) keep the existing block untouched. The posture itself
-  // (and the switch between editing/reviewing) lives in the header's
-  // PostureDropdown pill, not in this block.
-  const isWritableReviewer = canWrite && myRole === 'reviewer';
-  // The posture switch behind the header pill — promote/demote + role refetch
-  // (the role flip then swaps the phase block). Null-safe before the doc loads.
+  // spec-182 dec-1 dissolved the spec-159 ac-19 reviewer fork — every posture
+  // renders the same phase block, so no per-posture flag remains here. The
+  // posture itself (and the switch between editing/reviewing) lives in the
+  // header's PostureDropdown pill (dec-6, amended: the pill is the ONLY
+  // switch affordance — no in-page nag).
+  // The posture switch behind the header pill — promote/demote + role refetch.
+  // Null-safe before the doc loads.
   const switchPosture = useSwitchPosture(doc?.id ?? '');
   // spec-159 ac-17: Org scaffold appends for the phase handoff line's
   // PromptButton — threaded into toButtonPrompt exactly as OpeningTurn does.
@@ -1010,8 +1007,9 @@ export function DocDocument() {
           reviewers couldn't). The PhaseTabBar browses phase views without ever
           moving the Spec; the TransitionSentence beneath it is the *only* phase
           mutation — one [Yes], no modal, gated on canEdit. Reviewers reach the
-          sentence as a status-only line (dec-2) carrying the switch-to-Editing
-          link (dec-6). `done` collapses both into the DoneSummary for everyone. */}
+          sentence as a status-only line (dec-2); the header posture pill is the
+          only switch affordance (dec-6, amended 2026-06-05 — the in-slot nag
+          was removed). `done` collapses both into the DoneSummary for everyone. */}
       {doc.docType === 'spec' &&
         phase !== 'done' && (
           <div className="mb-4 space-y-2">
@@ -1039,13 +1037,6 @@ export function DocDocument() {
                 reloadDoc();
               }}
               onCancelBrowse={() => setSelectedTab(null)}
-              /* spec-182 dec-6: only a WRITABLE REVIEWER gets the in-slot
-                 "switch to Editing" door — same switchPosture path as the
-                 header pill. Read-only visitors have no posture to switch,
-                 so no callback and no link. */
-              onSwitchToEdit={
-                isWritableReviewer ? () => void switchPosture('editor') : undefined
-              }
             />
             {/* spec-182 dec-3: the review actions are a SPECIFY-phase fixture
                 for BOTH postures — review is a planning act (you review the

--- a/packages/ui/src/pages/DocDocument.tsx
+++ b/packages/ui/src/pages/DocDocument.tsx
@@ -1078,9 +1078,13 @@ export function DocDocument() {
               </>
             )}
             {/* spec-159 ac-17: the next-action handoff line — a "Copy a prompt
-                to …" sentence keyed to the CURRENT phase. Renders for every
-                viewer (copying a prompt is read-only); absent at `done`. */}
-            {handoff && (
+                to …" sentence keyed to the CURRENT phase; absent at `done`.
+                spec-182 issue-2 amends ac-17's "renders for every viewer":
+                the prompt's CONTENT drives state changes and building, so the
+                line is an editor affordance — gated on canEdit. The review
+                handoff above stays for both postures (dec-3: reviewing is the
+                reviewer's own workflow). */}
+            {canEdit && handoff && (
               <div data-testid="phase-handoff-line">
                 <PromptButton
                   buttonId={handoff.buttonId}


### PR DESCRIPTION
## What

Two reviewer-posture gating leaks found in live review of the unified phase block (spec-182), registered and resolved as **spec-182 issue-1** and **issue-2**.

### issue-1 — the Rubicon is now genuinely status-only for non-editors
`TransitionSentence` only withheld the Yes/No buttons when `canTransition=false`; the question text ("Do you wish to move this spec to Build?", "Are you sure…?", "Move this spec anyway?") still rendered for reviewers in every phase. Now:
- blocker statements render with no buttons (they're the page's phase status)
- the transition questions never render
- a clean rubric renders nothing — the tab pill carries the phase
- backward browsing renders nothing

dec-2 amended; ac-9 amended and pinned by the rewritten posture test block.

### issue-2 — the phase handoff is editor-only
The "Copy and paste this prompt into your coding agent to …" line gated on phase only. The copy is read-only, but the prompt's *content* drives state changes and building — an editor workflow. Now gated on `canEdit`. The Specify-only **review** handoff keeps rendering for both postures (dec-3).

Amends spec-159 ac-17's "renders for every viewer"; pinned by new spec-182 ac-17.

## Note

This branch is stacked on `6cf30d2` (PR #22, the dec-6 nag removal) since both touch `TransitionSentence` — this PR includes that commit until #22 merges, at which point it'll show only `8d4a674`.

## Verification

- Full `packages/ui` vitest suite green (930 passed / 1 pre-existing skip), `MEMEX_EMIT=false` locally
- `make build` clean (typecheck)
- Exercised live on the dev build in Reviewing posture across draft/plan/build/verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)