### PR TITLE
fix(ui): spec-182 issue-3 — editors get the Specify review affordances behind a collapsed disclosure

### DIFF
--- a/packages/ui/src/pages/DocDocument.spec-159.test.tsx
+++ b/packages/ui/src/pages/DocDocument.spec-159.test.tsx
@@ -498,8 +498,38 @@ describe('spec-159 — Rubicon line + in-situ directives', () => {
     // Editors still get the PhaseTabBar (3 phase tabs) and the Rubicon line.
     expect(screen.getAllByRole('tab')).toHaveLength(3);
     expect(screen.getByTestId('transition-sentence')).toBeInTheDocument();
-    // spec-182 dec-3: at Specify the review-action row renders for editors too.
+    // spec-182 dec-3 + issue-3: at Specify the editor keeps ACCESS to the
+    // review actions, but behind a collapsed-by-default disclosure.
+    expect(screen.getByTestId('review-actions-toggle')).toBeInTheDocument();
+    expect(screen.queryByTestId('review-action-row')).not.toBeInTheDocument();
+  });
+
+  // spec-182 issue-3 — the editor's Specify view was visually dominated by the
+  // reviewer workflow (four review buttons + two handoff lines). The user's
+  // call (2026-06-05): collapse, don't remove — editors keep dec-3's access
+  // behind a "Review actions" disclosure; reviewers see it expanded, no chrome.
+  it('editor at Specify: the disclosure expands to the review row + review handoff, and collapses again (issue-3)', async () => {
+    tagAc(AC182(10));
+    tagAc(AC182(11));
+    mockRole = 'editor';
+    const user = userEvent.setup();
+    renderAt('plan');
+
+    const toggle = await screen.findByTestId('review-actions-toggle');
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByTestId('review-action-row')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('review-handoff-line')).not.toBeInTheDocument();
+    // The editor's own phase handoff is NOT behind the disclosure.
+    expect(screen.getByTestId('phase-handoff-line')).toBeInTheDocument();
+
+    await user.click(toggle);
+    expect(toggle).toHaveAttribute('aria-expanded', 'true');
     expect(screen.getByTestId('review-action-row')).toBeInTheDocument();
+    expect(screen.getByTestId('review-handoff-line')).toBeInTheDocument();
+
+    await user.click(toggle);
+    expect(screen.queryByTestId('review-action-row')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('review-handoff-line')).not.toBeInTheDocument();
   });
 });
 
@@ -528,6 +558,9 @@ describe('spec-182 — unified reviewer phase block', () => {
     // The Rubicon line renders status-only: present, but no [Yes] (dec-2).
     const sentence = screen.getByTestId('transition-sentence');
     expect(within(sentence).queryByRole('button', { name: 'Yes' })).not.toBeInTheDocument();
+    // issue-3: the collapse disclosure is editor chrome — reviewers get the
+    // row expanded directly, no toggle.
+    expect(screen.queryByTestId('review-actions-toggle')).not.toBeInTheDocument();
   });
 
   it('header pill reads "You are reviewing"; picking Editing promotes to editor', async () => {

--- a/packages/ui/src/pages/DocDocument.tsx
+++ b/packages/ui/src/pages/DocDocument.tsx
@@ -124,6 +124,11 @@ export function DocDocument() {
         ? 'decisions'
         : 'narrative',
   );
+  // spec-182 issue-3: for EDITORS the Specify review affordances sit behind a
+  // collapsed-by-default "Review actions" disclosure — the reviewer workflow
+  // shouldn't visually dominate the editor's page. Reviewers see them expanded
+  // (no disclosure chrome): it's their workflow.
+  const [reviewActionsOpen, setReviewActionsOpen] = useState(false);
   const [shareOpen, setShareOpen] = useState(false);
   const [shareLinkOpen, setShareLinkOpen] = useState(false);
   const [renameOpen, setRenameOpen] = useState(false);
@@ -1043,38 +1048,66 @@ export function DocDocument() {
                 decisions and narrative before they harden), so the row keys on
                 the Spec's phase, not the viewer's posture. No other phase
                 (draft included) shows it. The four buttons resolve their
-                prompts from the Scaffold (std-23) and send through the chat. */}
+                prompts from the Scaffold (std-23) and send through the chat.
+                spec-182 issue-3: for EDITORS the row + review handoff sit
+                behind a collapsed-by-default disclosure — access survives,
+                but the reviewer workflow no longer dominates the editor's
+                page. Reviewers get them expanded, no chrome. */}
             {phase === 'plan' && (
               <>
-                <div
-                  data-testid="review-action-row"
-                  className="flex flex-wrap items-center gap-2 pt-1"
-                >
-                  {REVIEW_ACTIONS.map((action) => (
-                    <Button
-                      key={action.buttonId}
-                      type="button"
-                      variant="secondary"
-                      size="sm"
-                      onClick={() => sendReviewPrompt(action.buttonId)}
+                {canEdit && (
+                  <button
+                    type="button"
+                    data-testid="review-actions-toggle"
+                    aria-expanded={reviewActionsOpen}
+                    onClick={() => setReviewActionsOpen((v) => !v)}
+                    className="flex items-center gap-1 pt-1 text-sm text-secondary hover:text-heading transition-colors"
+                  >
+                    <svg
+                      className={`w-3 h-3 transition-transform ${reviewActionsOpen ? 'rotate-90' : ''}`}
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      strokeWidth={2}
                     >
-                      {action.label}
-                    </Button>
-                  ))}
-                </div>
-                {/* Review handoff line — copy a coding-agent prompt to conduct
-                    the review from there. Specify-only, like the row (dec-3). */}
-                <div data-testid="review-handoff-line">
-                  <PromptButton
-                    buttonId="review-handoff"
-                    context={handoffContext}
-                    orgBlocks={orgBlocks}
-                    sentencePrefix="You can copy and paste "
-                    linkText="this prompt"
-                    sentence="into your coding agent if you prefer to conduct the review from there."
-                    sentenceLabel="You can copy and paste this prompt into your coding agent if you prefer to conduct the review from there."
-                  />
-                </div>
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
+                    </svg>
+                    Review actions
+                  </button>
+                )}
+                {(!canEdit || reviewActionsOpen) && (
+                  <>
+                    <div
+                      data-testid="review-action-row"
+                      className="flex flex-wrap items-center gap-2 pt-1"
+                    >
+                      {REVIEW_ACTIONS.map((action) => (
+                        <Button
+                          key={action.buttonId}
+                          type="button"
+                          variant="secondary"
+                          size="sm"
+                          onClick={() => sendReviewPrompt(action.buttonId)}
+                        >
+                          {action.label}
+                        </Button>
+                      ))}
+                    </div>
+                    {/* Review handoff line — copy a coding-agent prompt to conduct
+                        the review from there. Specify-only, like the row (dec-3). */}
+                    <div data-testid="review-handoff-line">
+                      <PromptButton
+                        buttonId="review-handoff"
+                        context={handoffContext}
+                        orgBlocks={orgBlocks}
+                        sentencePrefix="You can copy and paste "
+                        linkText="this prompt"
+                        sentence="into your coding agent if you prefer to conduct the review from there."
+                        sentenceLabel="You can copy and paste this prompt into your coding agent if you prefer to conduct the review from there."
+                      />
+                    </div>
+                  </>
+                )}
               </>
             )}
             {/* spec-159 ac-17: the next-action handoff line — a "Copy a prompt


### PR DESCRIPTION
## What

**spec-182 issue-3** — at Specify, an editor was confronted with the reviewer workflow: four review buttons + the review handoff line stacked above their own phase handoff (screenshot in the issue). Confusing — "why am I being offered reviewer options?"

User's call (from three options — posture-gate / collapse / drop-handoff-only): **collapse, don't remove**. dec-3's "review is a planning act editors do too" survives as *access*:

- **Editors** at Specify get a collapsed-by-default **"Review actions ▸"** disclosure; expanding reveals the review-action row + review handoff. Their own phase-handoff line stays outside it.
- **Reviewers** see the row + review handoff expanded directly — no disclosure chrome; it's their workflow.

## Memex

- ac-10 / ac-11 amended to pin the per-posture presentation
- Pinned by new tests: editor disclosure expand/collapse cycle, phase handoff outside the disclosure, reviewer no-toggle

## Verification

- Full `packages/ui` vitest suite green (931 passed / 1 pre-existing skip)
- `make build` clean (typecheck)
- Exercised live on the dev build in both postures

🤖 Generated with [Claude Code](https://claude.com/claude-code)