### PR TITLE
fix(ui): spec-182 issue-4 — handoff links lead the line and name their prompt

### DIFF
--- a/packages/ui/src/pages/DocDocument.spec-159.test.tsx
+++ b/packages/ui/src/pages/DocDocument.spec-159.test.tsx
@@ -627,19 +627,20 @@ describe('spec-182 — unified reviewer phase block', () => {
     expect(prompt).toContain('security');
   });
 
-  it('renders the reviewer handoff line — "You can copy and paste this prompt …conduct the review from there."', async () => {
+  it('renders the reviewer handoff line — "Copy the review prompt …conduct the review from there."', async () => {
     tagAc(AC182(11));
     renderAt('plan');
 
     const line = await screen.findByTestId('review-handoff-line');
     expect(line.textContent).toContain(
-      'You can copy and paste this prompt into your coding agent if you prefer to conduct the review from there.',
+      'Copy the review prompt into your coding agent if you prefer to conduct the review from there.',
     );
-    // The clickable words are "this prompt", an action button.
+    // issue-4: the clickable words LEAD the line and NAME the prompt, so
+    // adjacent handoff lines are distinguishable from the link text alone.
     const copyButton = within(line).getByRole('button', {
-      name: /^You can copy and paste this prompt/,
+      name: /^Copy the review prompt/,
     });
-    expect(copyButton.textContent).toBe('this prompt');
+    expect(copyButton.textContent).toBe('Copy the review prompt');
     // spec-182 issue-2: the phase handoff is an editor affordance — its prompt
     // drives state changes and building. A reviewer gets the review handoff
     // ONLY (amends ac-17's "renders for every viewer").
@@ -726,46 +727,47 @@ describe('spec-182 — unified reviewer phase block', () => {
 // ac-17's "renders for every viewer": the line is editor-only (canEdit) — its
 // prompt drives state changes and building, which are not reviewer powers.
 describe('spec-159 ac-17 — next-action handoff line', () => {
-  it('plan: "Copy and paste this prompt into your coding agent to create Decisions and ACs." with bold entities', async () => {
+  it('plan: "Copy the Specify prompt into your coding agent to create Decisions and ACs." with bold entities', async () => {
     tagAc(AC(17));
     renderAt('plan');
 
     const line = await screen.findByTestId('phase-handoff-line');
     expect(line.textContent).toContain(
-      'Copy and paste this prompt into your coding agent to create Decisions and ACs.',
+      'Copy the Specify prompt into your coding agent to create Decisions and ACs.',
     );
     // The entity names render bold (<strong>) — "ACs" abbreviated since the
     // Rubicon line above already spells it out in full.
     const bolded = Array.from(line.querySelectorAll('strong')).map((el) => el.textContent);
     expect(bolded).toContain('Decisions');
     expect(bolded).toContain('ACs');
-    // The clickable words are "this prompt" (mid-sentence), an action button
-    // whose accessible name carries the full sentence.
+    // issue-4: the clickable words LEAD the line and NAME the prompt (matching
+    // the tab bar's phase display name); the accessible name carries the full
+    // sentence.
     const copyButton = within(line).getByRole('button', {
-      name: /^Copy and paste this prompt/,
+      name: /^Copy the Specify prompt/,
     });
-    expect(copyButton.textContent).toBe('this prompt');
+    expect(copyButton.textContent).toBe('Copy the Specify prompt');
   });
 
-  it('build: "Copy and paste this prompt into your coding agent to complete the Tasks and build this spec."', async () => {
+  it('build: "Copy the Build prompt into your coding agent to complete the Tasks and build this spec."', async () => {
     tagAc(AC(17));
     renderAt('build');
 
     await screen.findByTestId('task-panel');
     const line = screen.getByTestId('phase-handoff-line');
     expect(line.textContent).toContain(
-      'Copy and paste this prompt into your coding agent to complete the Tasks and build this spec.',
+      'Copy the Build prompt into your coding agent to complete the Tasks and build this spec.',
     );
   });
 
-  it('verify: "Copy and paste this prompt into your coding agent to verify this spec against its ACs."', async () => {
+  it('verify: "Copy the Verify prompt into your coding agent to verify this spec against its ACs."', async () => {
     tagAc(AC(17));
     renderAt('verify');
 
     await screen.findByTestId('ac-panel');
     const line = screen.getByTestId('phase-handoff-line');
     expect(line.textContent).toContain(
-      'Copy and paste this prompt into your coding agent to verify this spec against its ACs.',
+      'Copy the Verify prompt into your coding agent to verify this spec against its ACs.',
     );
   });
 
@@ -787,7 +789,7 @@ describe('spec-159 ac-17 — next-action handoff line', () => {
     // keeps dec-3's review handoff at Specify and nothing else.
     const line = await screen.findByTestId('review-handoff-line');
     expect(line.textContent).toContain(
-      'You can copy and paste this prompt into your coding agent if you prefer to conduct the review from there.',
+      'Copy the review prompt into your coding agent if you prefer to conduct the review from there.',
     );
     expect(screen.queryByTestId('phase-handoff-line')).not.toBeInTheDocument();
   });
@@ -840,7 +842,7 @@ describe('spec-164 issue-1 — draft hides the create-Decisions-and-ACs handoff'
 
     const line = await screen.findByTestId('phase-handoff-line');
     expect(line.textContent).toContain(
-      'Copy and paste this prompt into your coding agent to create Decisions and ACs.',
+      'Copy the Specify prompt into your coding agent to create Decisions and ACs.',
     );
   });
 });

--- a/packages/ui/src/pages/DocDocument.tsx
+++ b/packages/ui/src/pages/DocDocument.tsx
@@ -596,8 +596,7 @@ export function DocDocument() {
   const handoff: {
     buttonId: string;
     sentence: React.ReactNode;
-    /** Prose before the link + the clickable words (default "Copy"). */
-    sentencePrefix?: React.ReactNode;
+    /** The clickable words — they lead the line and name the prompt (issue-4). */
     linkText?: string;
     /** Plain-text FULL sentence for the accessible name (needed when sentence is a node). */
     sentenceLabel?: string;
@@ -610,15 +609,19 @@ export function DocDocument() {
     // invite the move to Specify FIRST. A coding-agent prompt to "create
     // Decisions and ACs" while in draft contradicts that gate-the-invitation
     // principle, so draft now yields null (no handoff); plan keeps plan-handoff.
+    // spec-182 issue-4: the hyperlink LEADS each handoff line and NAMES its
+    // prompt ("Copy the Specify prompt …"), so adjacent handoff lines are
+    // distinguishable from the blue text alone — the old shape buried the
+    // purpose at the end of two near-identical "Copy and paste this prompt…"
+    // sentences. Link names match the tab bar's phase display names.
     phase === 'plan'
       ? {
           buttonId: 'plan-handoff',
-          // "Copy and paste *this prompt* into your coding agent to create
-          // **Decisions** and **ACs**." — the link sits on "this prompt";
-          // entities bold. "ACs" stays abbreviated: the Rubicon line above
-          // already spells out "Acceptance Criteria (ACs)" in full.
-          sentencePrefix: 'Copy and paste ',
-          linkText: 'this prompt',
+          // "*Copy the Specify prompt* into your coding agent to create
+          // **Decisions** and **ACs**." — entities bold. "ACs" stays
+          // abbreviated: the Rubicon line above already spells out
+          // "Acceptance Criteria (ACs)" in full.
+          linkText: 'Copy the Specify prompt',
           sentence: (
             <>
               into your coding agent to create{' '}
@@ -627,15 +630,14 @@ export function DocDocument() {
             </>
           ),
           sentenceLabel:
-            'Copy and paste this prompt into your coding agent to create Decisions and ACs.',
+            'Copy the Specify prompt into your coding agent to create Decisions and ACs.',
         }
       : phase === 'build'
         ? {
             buttonId: 'opening-build-handoff',
-            // "Copy and paste *this prompt* into your coding agent to complete
+            // "*Copy the Build prompt* into your coding agent to complete
             // the **Tasks** and build this spec."
-            sentencePrefix: 'Copy and paste ',
-            linkText: 'this prompt',
+            linkText: 'Copy the Build prompt',
             sentence: (
               <>
                 into your coding agent to complete the{' '}
@@ -643,17 +645,16 @@ export function DocDocument() {
               </>
             ),
             sentenceLabel:
-              'Copy and paste this prompt into your coding agent to complete the Tasks and build this spec.',
+              'Copy the Build prompt into your coding agent to complete the Tasks and build this spec.',
           }
         : phase === 'verify'
           ? {
               buttonId: 'verify-spec',
-              // "Copy and paste *this prompt* into your coding agent to verify
+              // "*Copy the Verify prompt* into your coding agent to verify
               // this spec against its **ACs**." — "ACs" stays abbreviated: the
               // Rubicon line above already spells out "Acceptance Criteria
               // (ACs)" in full.
-              sentencePrefix: 'Copy and paste ',
-              linkText: 'this prompt',
+              linkText: 'Copy the Verify prompt',
               sentence: (
                 <>
                   into your coding agent to verify this spec against its{' '}
@@ -661,7 +662,7 @@ export function DocDocument() {
                 </>
               ),
               sentenceLabel:
-                'Copy and paste this prompt into your coding agent to verify this spec against its ACs.',
+                'Copy the Verify prompt into your coding agent to verify this spec against its ACs.',
             }
           : null; // done → no handoff line
 
@@ -1094,16 +1095,16 @@ export function DocDocument() {
                       ))}
                     </div>
                     {/* Review handoff line — copy a coding-agent prompt to conduct
-                        the review from there. Specify-only, like the row (dec-3). */}
+                        the review from there. Specify-only, like the row (dec-3).
+                        The link leads and names the prompt (issue-4). */}
                     <div data-testid="review-handoff-line">
                       <PromptButton
                         buttonId="review-handoff"
                         context={handoffContext}
                         orgBlocks={orgBlocks}
-                        sentencePrefix="You can copy and paste "
-                        linkText="this prompt"
+                        linkText="Copy the review prompt"
                         sentence="into your coding agent if you prefer to conduct the review from there."
-                        sentenceLabel="You can copy and paste this prompt into your coding agent if you prefer to conduct the review from there."
+                        sentenceLabel="Copy the review prompt into your coding agent if you prefer to conduct the review from there."
                       />
                     </div>
                   </>
@@ -1124,7 +1125,6 @@ export function DocDocument() {
                   context={handoffContext}
                   orgBlocks={orgBlocks}
                   sentence={handoff.sentence}
-                  sentencePrefix={handoff.sentencePrefix}
                   linkText={handoff.linkText}
                   sentenceLabel={handoff.sentenceLabel}
                 />


### PR DESCRIPTION
## What

**spec-182 issue-4** — follow-up to #25 (the commit was pushed moments after #25 merged, so it gets its own PR).

With the editor's review disclosure expanded at Specify, two handoff lines stacked with identical mid-sentence "this prompt" links and the purpose buried at the sentence end — you had to read both sentences in full to tell them apart. The hyperlink now **leads each line and names its prompt**, matching the tab bar's phase display names:

- **Copy the review prompt** into your coding agent if you prefer to conduct the review from there.
- **Copy the Specify prompt** into your coding agent to create **Decisions** and **ACs**.
- **Copy the Build prompt** into your coding agent to complete the **Tasks** and build this spec.
- **Copy the Verify prompt** into your coding agent to verify this spec against its **ACs**.

UI-side prose only — prompt content stays Scaffold-sourced (std-23). Drops the now-unused sentencePrefix from the handoff object. Accessible names carry the full sentences.

## Verification

- Full `packages/ui` vitest suite green (931 passed / 1 pre-existing skip)
- `make build` clean (typecheck)
- Exercised live on the dev build in both postures

🤖 Generated with [Claude Code](https://claude.com/claude-code)