### PR TITLE
fix(server): spec-177 issue-1 — resolve personal namespaces by ownership, closing the concurrent-signup race

### DIFF
--- a/packages/server/src/__regression__/mutate-coverage.static-scan.test.ts
+++ b/packages/server/src/__regression__/mutate-coverage.static-scan.test.ts
@@ -76,6 +76,14 @@ const ALLOWLIST: Record<string, string> = {
   // log with no bus entity of its own.
   "services/test-event-latest.ts":
     "tx-helper indirection (spec-162) — applyEmissionToSummary / removeSummaryForPair write test_event_latest only inside callers' mutate() callbacks (routes/test-events.ts, services/acs.ts discontinueTestEventsForAc); both public write paths return through mutate().",
+  // spec-177 issue-1 — findOrCreatePersonalMemex is a tx-helper invoked ONLY from
+  // inside ensureUserNamespace's mutate() callbacks (both the ownership-repair
+  // branch and the create branch). It race-safely find-or-creates the "personal"
+  // memex (ON CONFLICT + re-read). The callback-scoped heuristic (ac-24) cannot
+  // follow the helper indirection; ensureUserNamespace itself returns Mutated<T>
+  // and emits the user_namespace/memex keys.
+  "services/user-namespaces.ts":
+    "tx-helper indirection (spec-177 issue-1) — findOrCreatePersonalMemex inserts memexes only inside ensureUserNamespace's mutate() callbacks; the public writer returns Mutated<T> with user_namespace + memex emissions.",
   // spec-150 standards decomposition — develop-side entry ported to the
   // path-keyed scheme during the spec-156 rebase.
   "services/standards-migration.ts":

--- a/packages/server/src/services/user-namespaces.integration.test.ts
+++ b/packages/server/src/services/user-namespaces.integration.test.ts
@@ -59,19 +59,65 @@ describe("ensureUserMemex / ensureUserNamespace", () => {
     tagAc(AC_1);
     tagAc(AC_4);
     tagAc(AC_5);
-    // Two concurrent ensureUserNamespace calls with the same userId simulate the
-    // email-resend race: both see namespaceId=null, derive the same slug, and race
-    // to INSERT. The loser hits ON CONFLICT DO NOTHING and falls back to a SELECT.
+    // Concurrent ensureUserNamespace calls with the same userId simulate the
+    // email-resend race: all see namespaceId=null, derive the same slug, and race
+    // to INSERT. Losers are absorbed by ON CONFLICT DO NOTHING and resolve the
+    // winner's row BY OWNERSHIP (spec-177 issue-1 — a bare-slug re-read let the
+    // loser suffix past the winner's row and create a second namespace).
     const user = await upsertUserByEmail(uniqueEmail("race"));
     createdUserIds.push(user.id);
 
-    const [r1, r2] = await Promise.all([
-      ensureUserNamespace(user.id),
-      ensureUserNamespace(user.id),
-    ]);
+    const results = await Promise.all(
+      Array.from({ length: 5 }, () => ensureUserNamespace(user.id)),
+    );
 
-    expect(r1.namespace.id).toBe(r2.namespace.id);
-    expect(r1.namespace.slug).toBe(r2.namespace.slug);
+    const ids = new Set(results.map((r) => r.namespace.id));
+    expect(ids.size).toBe(1);
+    expect(new Set(results.map((r) => r.namespace.slug)).size).toBe(1);
+    // All calls converge on the same personal memex too — the loser path used to
+    // throw duplicate-key on a second "personal" insert (issue-1).
+    expect(new Set(results.map((r) => r.memex.id)).size).toBe(1);
+
+    // Stronger than same-id returns: the DATABASE holds exactly one namespace for
+    // this user — the issue-1 bug left an orphaned second row even when callers
+    // happened to return the winner.
+    const rows = await db.query.namespaces.findMany({
+      where: eq(namespaces.ownerUserId, user.id),
+    });
+    expect(rows).toHaveLength(1);
+  });
+
+  it("a losing call reuses the winner's namespace — never suffixes past its own row (issue-1, deterministic)", async () => {
+    tagAc(AC_2);
+    tagAc(AC_5);
+    // The race's losing interleave, recreated without timing: the winner's
+    // namespace row is committed (owned by the user, under the email-derived
+    // slug) but users.namespaceId is not yet linked from the loser's point of
+    // view. The buggy code treated that row as a FOREIGN slug collision,
+    // suffixed to `<slug>-2`, and created a second namespace for the user.
+    const email = uniqueEmail("loser");
+    const user = await upsertUserByEmail(email);
+    createdUserIds.push(user.id);
+
+    const derivedSlug = email.split("@")[0]; // uniqueEmail local-parts are already slug-shaped
+    const [winner] = await db
+      .insert(namespaces)
+      .values({ slug: derivedSlug, kind: "user", ownerUserId: user.id })
+      .returning();
+
+    const result = await ensureUserNamespace(user.id);
+
+    // Reused, not suffixed past.
+    expect(result.namespace.id).toBe(winner.id);
+    expect(result.memex.slug).toBe("personal");
+    // Exactly one namespace for the user — no orphaned second row.
+    const rows = await db.query.namespaces.findMany({
+      where: eq(namespaces.ownerUserId, user.id),
+    });
+    expect(rows).toHaveLength(1);
+    // The fast pointer is repaired.
+    const refreshed = await getUserById(user.id);
+    expect(refreshed?.namespaceId).toBe(winner.id);
   });
 
   it("creates a user-kind namespace owned by the user", async () => {

--- a/packages/server/src/services/user-namespaces.ts
+++ b/packages/server/src/services/user-namespaces.ts
@@ -1,4 +1,4 @@
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { db } from "../db/connection.js";
 import { namespaces, memexes, users } from "../db/schema.js";
 import type { Memex, Namespace } from "../db/schema.js";
@@ -10,8 +10,10 @@ import { mutate, type Mutated } from "./mutate.js";
 // about which context the user is in.
 export const PERSONAL_MEMEX_NAME = "Personal Memex";
 
+type Tx = Parameters<Parameters<typeof db.transaction>[0]>[0];
+
 // Slug-from-email-localpart with collision-resolve (mirrors migration 0038's algorithm).
-// Returns a slug guaranteed not to collide with an existing namespace.slug.
+// Returns a slug that is either free or already OURS — never a stranger's.
 async function deriveAvailableSlug(email: string, userId: string): Promise<string> {
   // local-part: lowercase, replace non-[a-z0-9-] with '-', collapse repeats, trim leading
   // hyphen, ensure it starts with [a-z0-9].
@@ -34,9 +36,47 @@ async function deriveAvailableSlug(email: string, userId: string): Promise<strin
       where: eq(namespaces.slug, candidate),
     });
     if (!existing) return candidate;
+    // spec-177 issue-1: our OWN personal namespace is not a collision to suffix
+    // around — a concurrent ensureUserNamespace call (the signup-resend race) may
+    // have just created it. Reuse the slug; the caller's ON CONFLICT + ownership
+    // re-read converge on the same row. Without this, the losing call saw the
+    // winner's row as foreign, suffixed to `base-2`, and created a SECOND
+    // namespace for the user.
+    if (existing.kind === "user" && existing.ownerUserId === userId) return candidate;
   }
   // Fallback — userId-derived guaranteed unique
   return `u-${userId.slice(0, 30)}`;
+}
+
+// The user's personal namespace, resolved by OWNERSHIP — the authoritative lookup.
+// users.namespaceId is only the fast pointer to it (issue-1: a null or dangling
+// pointer does not mean the namespace is absent).
+function findOwnNamespace(executor: Tx | typeof db, userId: string): Promise<Namespace | undefined> {
+  return executor.query.namespaces.findFirst({
+    where: and(eq(namespaces.ownerUserId, userId), eq(namespaces.kind, "user")),
+  });
+}
+
+// Find-or-create the default memex inside a namespace, race-safely: a concurrent
+// call may have created "personal" between our read and our insert — the
+// memexes_namespace_id_slug_unique constraint turns that into a conflict we
+// absorb and re-read (the bare INSERT here used to throw duplicate-key, issue-1).
+async function findOrCreatePersonalMemex(tx: Tx, namespaceId: string): Promise<Memex> {
+  const existing = await tx.query.memexes.findFirst({
+    where: eq(memexes.namespaceId, namespaceId),
+  });
+  if (existing) return existing;
+  const [inserted] = await tx
+    .insert(memexes)
+    .values({ namespaceId, slug: "personal", name: PERSONAL_MEMEX_NAME })
+    .onConflictDoNothing()
+    .returning();
+  if (inserted) return inserted;
+  const raced = await tx.query.memexes.findFirst({
+    where: and(eq(memexes.namespaceId, namespaceId), eq(memexes.slug, "personal")),
+  });
+  if (!raced) throw new Error(`Personal memex for namespace ${namespaceId} not found after insert`);
+  return raced;
 }
 
 // Idempotent: if the user already has a namespace + default memex, returns the memex.
@@ -44,48 +84,63 @@ async function deriveAvailableSlug(email: string, userId: string): Promise<strin
 // users.namespace_id. Every signup path (password, SSO, magic-link) funnels through this
 // helper so the invariant "every active user has exactly one namespace + memex" is
 // maintained centrally.
+//
+// spec-177 issue-1 (concurrency): two concurrent calls for the same user (the
+// email-resend race) must converge on ONE namespace. The original code resolved
+// purely by slug, which left two holes: the losing call could see the winner's
+// fresh row as a foreign slug collision and suffix past it (second namespace), and
+// the post-conflict re-read by bare slug could adopt a STRANGER's namespace if a
+// foreign signup grabbed the candidate in the derive→insert window. Resolution is
+// now ownership-first at every step.
 export async function ensureUserNamespace(
   userId: string,
 ): Promise<Mutated<{ namespace: Namespace; memex: Memex }>> {
   const existingUser = await db.query.users.findFirst({ where: eq(users.id, userId) });
   if (!existingUser) throw new ValidationError(`User ${userId} not found`);
 
+  let ns: Namespace | undefined;
   if (existingUser.namespaceId) {
-    const ns = await db.query.namespaces.findFirst({
+    ns = await db.query.namespaces.findFirst({
       where: eq(namespaces.id, existingUser.namespaceId),
     });
-    if (ns) {
-      // Find or create a default memex inside the namespace.
-      const existingMemex = await db.query.memexes.findFirst({
-        where: eq(memexes.namespaceId, ns.id),
-      });
-      if (existingMemex) {
-        // silent: idempotent fast path — no DB write, no UI consequence.
-        return mutate(
-          {},
-          { memexId: existingMemex.id, userId, entity: "memex", action: "created" },
-          async () => ({ namespace: ns, memex: existingMemex }),
-          { silent: true },
-        );
-      }
+    // Dangling FK — fall through to the ownership lookup.
+  }
+  ns ??= await findOwnNamespace(db, userId);
 
+  if (ns) {
+    const namespace = ns;
+    // Repair the fast pointer when it was null or dangling — the race's losing
+    // call lands here after the winner created the namespace but before (or
+    // without) this user row pointing at it.
+    const needsLink = existingUser.namespaceId !== namespace.id;
+    const existingMemex = await db.query.memexes.findFirst({
+      where: eq(memexes.namespaceId, namespace.id),
+    });
+    if (existingMemex && !needsLink) {
+      // silent: idempotent fast path — no DB write, no UI consequence.
       return mutate(
         {},
-        (r) => ({ memexId: r.memex.id, userId, entity: "memex", action: "created" }),
-        async () => {
-          const [memex] = await db
-            .insert(memexes)
-            .values({
-              namespaceId: ns.id,
-              slug: "personal",
-              name: PERSONAL_MEMEX_NAME,
-            })
-            .returning();
-          return { namespace: ns, memex };
-        },
+        { memexId: existingMemex.id, userId, entity: "memex", action: "created" },
+        async () => ({ namespace, memex: existingMemex }),
+        { silent: true },
       );
     }
-    // Dangling FK — fall through to recreate.
+
+    return mutate(
+      {},
+      (r) => ({ memexId: r.memex.id, userId, entity: "memex", action: "created" }),
+      () =>
+        db.transaction(async (tx) => {
+          const memex = await findOrCreatePersonalMemex(tx, namespace.id);
+          if (needsLink) {
+            await tx
+              .update(users)
+              .set({ namespaceId: namespace.id, updatedAt: new Date() })
+              .where(eq(users.id, userId));
+          }
+          return { namespace, memex };
+        }),
+    );
   }
 
   const slug = await deriveAvailableSlug(existingUser.email, userId);
@@ -103,7 +158,10 @@ export async function ensureUserNamespace(
         ({ memexId: r.memex.id, userId, entity: "memex" as const, action: "created" as const }),
     ],
     () => db.transaction(async (tx) => {
-      const [inserted] = await tx
+      // INSERT ... ON CONFLICT DO NOTHING (dec-1). The losing call's insert is
+      // absorbed here and resolved below by OWNERSHIP, never by bare slug — a
+      // slug-only re-read could adopt a stranger's namespace (issue-1).
+      const inserted = await tx
         .insert(namespaces)
         .values({
           slug,
@@ -112,17 +170,25 @@ export async function ensureUserNamespace(
         })
         .onConflictDoNothing()
         .returning();
-      const namespace = inserted ?? await tx.query.namespaces.findFirst({ where: eq(namespaces.slug, slug) });
-      if (!namespace) throw new Error(`Namespace ${slug} not found after insert`);
+      let namespace: Namespace | undefined = inserted[0] ?? (await findOwnNamespace(tx, userId));
+      if (!namespace) {
+        // The conflict was a FOREIGN row — a stranger grabbed the slug in the
+        // derive→insert window — and no concurrent call created ours. Retry once
+        // with the userId-derived slug, which only our own calls can contend for.
+        const retried = await tx
+          .insert(namespaces)
+          .values({
+            slug: `u-${userId.slice(0, 30)}`,
+            kind: "user",
+            ownerUserId: userId,
+          })
+          .onConflictDoNothing()
+          .returning();
+        namespace = retried[0] ?? (await findOwnNamespace(tx, userId));
+      }
+      if (!namespace) throw new Error(`Personal namespace for user ${userId} not found after insert`);
 
-      const [memex] = await tx
-        .insert(memexes)
-        .values({
-          namespaceId: namespace.id,
-          slug: "personal",
-          name: PERSONAL_MEMEX_NAME,
-        })
-        .returning();
+      const memex = await findOrCreatePersonalMemex(tx, namespace.id);
 
       await tx
         .update(users)


### PR DESCRIPTION
## What

Fixes **spec-177/issue-1** (high) — the `ensureUserNamespace` concurrency hole that flaked CI **3× today** (PRs #24, #27's merge, release #28) and is a real prod-path bug: a signup-resend race could create two personal namespaces for one user.

### Root cause

`deriveAvailableSlug` re-checked slug availability before the INSERT. The race's losing call saw the winner's freshly-committed row as a **foreign** slug collision, suffixed to `base-2`, and inserted past it — `ON CONFLICT` never fired because the slugs differed. Two more latent holes in the loser path:

- the post-conflict re-read by **bare slug** could adopt a *stranger's* namespace (cross-tenant link) if a foreign signup grabbed the candidate in the derive→insert window
- the second `"personal"` memex insert threw an unhandled duplicate-key (`memexes_namespace_id_slug_unique`)

### Fix — ownership-first resolution (keeps dec-1's ON CONFLICT DO NOTHING)

- `deriveAvailableSlug` reuses the user's **own** row instead of suffixing past it
- an ownership lookup (`ownerUserId + kind='user'`) absorbs the race before the create path and repairs a null/dangling `users.namespaceId` pointer
- the post-conflict re-read resolves **by ownership, never bare slug**, with one retry on a userId-derived slug if a stranger stole ours
- `findOrCreatePersonalMemex` absorbs the memex-level race (std-8 static-scan allowlist entry, same tx-helper-indirection pattern as `clauses.ts` / `clause-refs.ts` / `test-event-latest.ts`)

No migration; app-level only.

### Verification

- **Causality proven**: new deterministic loser-interleave test fails on the old code with the exact CI flake signature (two different namespace UUIDs) and passes on the fix
- ac-5 race test widened to 5 concurrent calls + a DB-level *exactly-one-namespace* assertion (catches orphaned rows even when callers return the winner)
- 12/12 local stress runs green; full server suite green (3224); `make build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)