### PR TITLE
feat: restrict int account creation to allowed email domains (spec-174)

### DIFF
--- a/packages/server/deploy.sh
+++ b/packages/server/deploy.sh
@@ -197,7 +197,7 @@ gcloud run deploy "${SERVICE}" \
   --min-instances 0 \
   --max-instances 3 \
   --add-cloudsql-instances "${CLOUD_SQL_INSTANCE_CONN}" \
-  --update-env-vars "^|^NODE_ENV=production|DATABASE_URL=postgresql://${DB_USER}:${DB_PASS_ENC}@localhost:${DB_PORT}/${DB_NAME}|CLOUD_SQL_SOCKET=/cloudsql/${CLOUD_SQL_INSTANCE_CONN}|GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID}|EMAIL_FROM=${EMAIL_FROM}|APP_BASE_URL=${APP_BASE_URL}|OAUTH_ENABLED=1|SLACK_CLIENT_ID=${SLACK_CLIENT_ID}|SLACK_OAUTH_REDIRECT_URI=${API_BASE_URL}/api/auth/slack/callback|KMS_KEY_NAME=projects/${GCP_PROJECT}/locations/${REGION}/keyRings/memex/cryptoKeys/slack-tokens|MEMEX_OWN_NAMESPACE=${MEMEX_OWN_NAMESPACE}${HIDDEN_FEATURES+|HIDDEN_FEATURES=${HIDDEN_FEATURES}}" \
+  --update-env-vars "^|^NODE_ENV=production|DATABASE_URL=postgresql://${DB_USER}:${DB_PASS_ENC}@localhost:${DB_PORT}/${DB_NAME}|CLOUD_SQL_SOCKET=/cloudsql/${CLOUD_SQL_INSTANCE_CONN}|GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID}|EMAIL_FROM=${EMAIL_FROM}|APP_BASE_URL=${APP_BASE_URL}|OAUTH_ENABLED=1|SLACK_CLIENT_ID=${SLACK_CLIENT_ID}|SLACK_OAUTH_REDIRECT_URI=${API_BASE_URL}/api/auth/slack/callback|KMS_KEY_NAME=projects/${GCP_PROJECT}/locations/${REGION}/keyRings/memex/cryptoKeys/slack-tokens|MEMEX_OWN_NAMESPACE=${MEMEX_OWN_NAMESPACE}${HIDDEN_FEATURES+|HIDDEN_FEATURES=${HIDDEN_FEATURES}}${SIGNUP_DOMAIN_ALLOWLIST+|SIGNUP_DOMAIN_ALLOWLIST=${SIGNUP_DOMAIN_ALLOWLIST}}" \
   --update-secrets "${SECRETS_WIRING}"
 
 # ── Done ──────────────────────────────────────────────────────

--- a/packages/server/src/routes/auth-signup.integration.test.ts
+++ b/packages/server/src/routes/auth-signup.integration.test.ts
@@ -2,7 +2,7 @@
 // Spawns a minimal Hono app with the auth router, mocks the email sender to capture
 // outgoing messages, and drives the HTTP surface with app.request().
 
-import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeAll, afterAll, afterEach, beforeEach, vi } from "vitest";
 import { eq, inArray } from "drizzle-orm";
 
 // Must run before imports so module-level googleClientId/AUTH_JWT_SECRET captures load cleanly.
@@ -28,8 +28,12 @@ import {
 } from "../services/email/sender.js";
 
 import { Hono } from "hono";
+import { tagAc } from "@memex-ai-ac/vitest";
 import { auth } from "./auth.js";
+import { waitlist } from "./waitlist.js";
 import { errorHandler } from "../middleware/error-handler.js";
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-174/acs/ac-${n}`;
 
 afterAll(() => {
   if (ORIGINAL_CLIENT_ID !== undefined) process.env.GOOGLE_CLIENT_ID = ORIGINAL_CLIENT_ID;
@@ -49,6 +53,7 @@ let sender: CapturingSender;
 const app = new Hono();
 app.onError(errorHandler);
 app.route("/api/auth", auth);
+app.route("/api/waitlist", waitlist);
 
 const createdEmails: string[] = [];
 
@@ -333,6 +338,137 @@ describe("rate limiting", () => {
       body: JSON.stringify({ email, password: "wrong" }),
     });
     expect(blocked.status).toBe(429);
+  });
+});
+
+describe("SIGNUP_DOMAIN_ALLOWLIST enforcement", () => {
+  const ORIGINAL_ALLOWLIST = process.env.SIGNUP_DOMAIN_ALLOWLIST;
+
+  beforeEach(() => {
+    process.env.SIGNUP_DOMAIN_ALLOWLIST = "mindset.ai,memex.ai";
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_ALLOWLIST !== undefined) {
+      process.env.SIGNUP_DOMAIN_ALLOWLIST = ORIGINAL_ALLOWLIST;
+    } else {
+      delete process.env.SIGNUP_DOMAIN_ALLOWLIST;
+    }
+  });
+
+  it("rejects password signup from a disallowed domain and creates no user row", async () => {
+    tagAc(AC(6)); tagAc(AC(2)); tagAc(AC(4)); tagAc(AC(10));
+    const email = "blocked-signup@example.com";
+    const res = await app.request("/api/auth/signup", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email, password: "correctbattery" }),
+    });
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.code).toBe("domain_not_allowed");
+    expect(await getUserByEmail(email)).toBeUndefined();
+    expect(sender.sent).toHaveLength(0);
+  });
+
+  it("allows password signup from an allowed domain", async () => {
+    tagAc(AC(1)); tagAc(AC(10));
+    const email = `test-allowed-${Date.now()}@mindset.ai`;
+    createdEmails.push(email);
+    const res = await app.request("/api/auth/signup", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email, password: "correctbattery" }),
+    });
+    expect(res.status).toBe(201);
+  });
+
+  it("magic-link send always returns {ok:true} regardless of domain (no enumeration)", async () => {
+    tagAc(AC(8));
+    const res = await app.request("/api/auth/magic-link", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: "blocked-ml@example.com" }),
+    });
+    expect(res.status).toBe(200);
+    expect((await res.json()).ok).toBe(true);
+  });
+
+  it("magic-link consume rejects a new account with a disallowed domain", async () => {
+    tagAc(AC(7)); tagAc(AC(4));
+    // Send succeeds; domain gate fires at consume time.
+    await app.request("/api/auth/magic-link", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: "blocked-consume@example.com" }),
+    });
+    const token = extractLinkToken(sender.sent[0].text)!;
+    sender.sent.length = 0;
+
+    const res = await app.request("/api/auth/magic-link/consume", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token }),
+    });
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.code).toBe("domain_not_allowed");
+    expect(await getUserByEmail("blocked-consume@example.com")).toBeUndefined();
+  });
+
+  it("magic-link consume allows sign-in for an account that already exists with a disallowed domain", async () => {
+    tagAc(AC(7));
+    // Create the account before the restriction takes effect.
+    delete process.env.SIGNUP_DOMAIN_ALLOWLIST;
+    const email = uniqueEmail("existing-before-restriction");
+    await app.request("/api/auth/magic-link", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email }),
+    });
+    await app.request("/api/auth/magic-link/consume", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token: extractLinkToken(sender.sent[0].text)! }),
+    });
+    sender.sent.length = 0;
+
+    // Restriction now active — existing user should still be able to sign in.
+    process.env.SIGNUP_DOMAIN_ALLOWLIST = "mindset.ai,memex.ai";
+    await app.request("/api/auth/magic-link", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email }),
+    });
+    const res = await app.request("/api/auth/magic-link/consume", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token: extractLinkToken(sender.sent[0].text)! }),
+    });
+    expect(res.status).toBe(200);
+    expect((await res.json()).user.email).toBe(email);
+  });
+
+  it("imposes no restriction when SIGNUP_DOMAIN_ALLOWLIST is unset", async () => {
+    tagAc(AC(9));
+    delete process.env.SIGNUP_DOMAIN_ALLOWLIST;
+    const email = uniqueEmail("unrestricted");
+    const res = await app.request("/api/auth/signup", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email, password: "correctbattery" }),
+    });
+    expect(res.status).toBe(201);
+  });
+
+  it("waitlist accepts any email domain even when SIGNUP_DOMAIN_ALLOWLIST is set", async () => {
+    tagAc(AC(3));
+    const res = await app.request("/api/waitlist", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: "external@anydomain.io", name: "Test User", company: "Acme" }),
+    });
+    expect(res.status).toBe(201);
   });
 });
 

--- a/packages/server/src/services/users.ts
+++ b/packages/server/src/services/users.ts
@@ -2,7 +2,7 @@ import { eq, and, sql, asc } from "drizzle-orm";
 import { db } from "../db/connection.js";
 import { users, orgMemberships, namespaces, orgs, memexes, userMemexAccess } from "../db/schema.js";
 import type { User } from "../db/schema.js";
-import { ValidationError } from "../types/errors.js";
+import { ForbiddenError, ValidationError } from "../types/errors.js";
 import { mutate, type Mutated } from "./mutate.js";
 
 export interface MembershipSummary {
@@ -56,6 +56,17 @@ function normalizeEmail(email: string): string {
   return email.trim().toLowerCase();
 }
 
+// When SIGNUP_DOMAIN_ALLOWLIST is set (comma-separated domains), new account creation is
+// restricted to those domains. Unset = no restriction. Existing users are never blocked.
+function isSignupDomainAllowed(email: string): boolean {
+  const raw = process.env.SIGNUP_DOMAIN_ALLOWLIST;
+  if (!raw) return true;
+  const allowed = raw.split(",").map((d) => d.trim().toLowerCase()).filter(Boolean);
+  if (allowed.length === 0) return true;
+  const domain = email.split("@")[1]?.toLowerCase() ?? "";
+  return allowed.includes(domain);
+}
+
 export async function getUserByEmail(email: string): Promise<User | undefined> {
   return db.query.users.findFirst({
     where: eq(users.email, normalizeEmail(email)),
@@ -77,6 +88,10 @@ export async function upsertUserByEmail(email: string): Promise<User> {
       .where(eq(users.id, existing.id))
       .returning();
     return updated;
+  }
+
+  if (!isSignupDomainAllowed(normalized)) {
+    throw new ForbiddenError("Sign-up is not allowed for this email domain", "domain_not_allowed");
   }
 
   // Note: users.namespace_id is NOT NULL — callers must follow up with
@@ -135,6 +150,10 @@ export async function createUserWithPassword(input: {
       .where(eq(users.id, existing.id))
       .returning();
     return updated;
+  }
+
+  if (!isSignupDomainAllowed(normalized)) {
+    throw new ForbiddenError("Sign-up is not allowed for this email domain", "domain_not_allowed");
   }
 
   // namespace_id NOT NULL — see comment in upsertUserByEmail. Callers in the auth flow

--- a/scripts/deploy-config.sh
+++ b/scripts/deploy-config.sh
@@ -156,5 +156,12 @@ export MEMEX_OWN_NAMESPACE
 if [ -n "${HIDDEN_FEATURES+set}" ]; then
   export HIDDEN_FEATURES
 fi
+# SIGNUP_DOMAIN_ALLOWLIST — comma-separated domains allowed for new account creation
+# (spec-174). Set in int to restrict to mindset.ai,memex.ai. Unset in prod = no restriction.
+# Same set-vs-unset semantics as HIDDEN_FEATURES: a deploy from a checkout that never
+# set this value must not silently clear a live int restriction.
+if [ -n "${SIGNUP_DOMAIN_ALLOWLIST+set}" ]; then
+  export SIGNUP_DOMAIN_ALLOWLIST
+fi
 
 echo "[deploy-config] ENV=$ENV  project=$GCP_PROJECT  host=$PUBLIC_HOST  api=$API_PUBLIC_HOST"


### PR DESCRIPTION
## Summary

- Adds `SIGNUP_DOMAIN_ALLOWLIST` env-var guard to restrict new account creation on int to `mindset.ai` and `memex.ai` domains
- Enforced at the service layer (`upsertUserByEmail` + `createUserWithPassword` in `services/users.ts`), covering all three creation paths: password signup, magic-link consume, and Google SSO
- Existing users are never blocked; only **new account creation** is gated
- Returns `ForbiddenError` (`code: domain_not_allowed` → 403); magic-link send always returns `{ok:true}` (no enumeration)
- Unset = no restriction → prod behaviour unchanged without any code branching
- Deploy wiring: `SIGNUP_DOMAIN_ALLOWLIST` added to `memex-int-deploy-env` secret (v2), exported from `deploy-config.sh`, spliced into `deploy.sh` Cloud Run env vars (same `${var+...}` guard as `HIDDEN_FEATURES`)
- Applied live to int Cloud Run revision `00164-5mx`

## Files changed

| File | What |
|---|---|
| `packages/server/src/services/users.ts` | `isSignupDomainAllowed()` helper + domain check before INSERT in both creation functions |
| `packages/server/src/routes/auth-signup.integration.test.ts` | 7 new integration tests tagged to spec-174 ACs via `tagAc()` |
| `scripts/deploy-config.sh` | Export `SIGNUP_DOMAIN_ALLOWLIST` with set-vs-unset guard |
| `packages/server/deploy.sh` | Wire `SIGNUP_DOMAIN_ALLOWLIST` into Cloud Run `--update-env-vars` |

## Test plan

- [x] `pnpm test` passes — 7 new domain-restriction tests cover: password signup blocked/allowed, magic-link send (no enumeration), magic-link consume blocked/allowed for new vs existing accounts, no restriction when var unset, waitlist accepts any domain
- [x] AC emission verified — 9/11 ACs emitted to `mindset-prod/memex-building-itself/specs/spec-174`
- [x] `SIGNUP_DOMAIN_ALLOWLIST=mindset.ai,memex.ai` live on int (`gcloud run services describe` confirmed)
- [ ] Smoke test on int: attempt signup with a `@gmail.com` address → expect 403 `domain_not_allowed`
- [ ] Smoke test on int: sign in with an existing out-of-domain account → expect success

🤖 Generated with [Claude Code](https://claude.com/claude-code)