### PR TITLE
spec-178: Handhold onboarding demo — seed/reset/backfill, progressive reveal, agent+search exclusion

### DIFF
--- a/.legacy-spec-vocab-allowlist.txt
+++ b/.legacy-spec-vocab-allowlist.txt
@@ -212,3 +212,14 @@ packages/ui/src/agent/graph.test.ts:Document\|Brief\|Spec prefix
 packages/ui/src/agent/graph.test.ts:Brief created: ref
 packages/ui/src/agent/graph.test.ts:briefs/b-42
 packages/ui/src/agent/graph.test.ts:Brief Era
+
+# ============================================================
+# spec-178 Handhold demo fixture — verbatim spec-64 content
+# ============================================================
+# The Handhold onboarding demo seeds five frozen copies of spec-64, whose content
+# is reproduced VERBATIM in this fixture (spec-178 ac-2 — wording unchanged; the
+# DEMO badge is the only differentiator, so rewording the source is not an option).
+# spec-64's t-5 AC uses "vector-strategy" in the SEARCH-strategy sense (handle | FTS
+# | semantic) — the same technical usage already allowlisted for
+# services/memex-search.ts above, not the legacy product noun. Line-pinned.
+packages/server/src/db/handhold-demo.fixture.ts:vector-strategy

--- a/packages/server/drizzle/0077_add_documents_is_demo.sql
+++ b/packages/server/drizzle/0077_add_documents_is_demo.sql
@@ -1,0 +1,20 @@
+-- spec-178 t-1 (ac-9): add is_demo flag to the documents table.
+--
+-- When true, marks the document as one of the five frozen copies of the canonical
+-- ⌘K-search Spec (spec-64) seeded into a personal Memex for the multi-phase Handhold
+-- onboarding demo. Demo docs render a DEMO badge + per-phase value banner, suppress
+-- handle auto-linking, are excluded from ⌘K/search and every agent surface (dec-11;
+-- only the board REST list/get returns them), and excluded from Pulse/usage analytics.
+-- The reset endpoint (POST .../handhold/reset) hard-deletes all is_demo docs (and their
+-- seeded test-event emissions) and re-seeds from handhold-demo.fixture.ts.
+--
+-- Additive + reversible: a single NOT NULL boolean column with a safe default (false).
+-- Every existing row gets false, which is correct — no existing docs are demo docs.
+-- The revert is simply DROP COLUMN.
+--
+-- Idempotent (IF NOT EXISTS): the hand-migration runner wraps each file in a
+-- transaction and tracks it in manual_migrations; the guard lets a retry re-apply
+-- cleanly if a prior run committed the DDL but not the tracking row.
+
+ALTER TABLE documents
+  ADD COLUMN IF NOT EXISTS is_demo boolean NOT NULL DEFAULT false;

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -31,6 +31,7 @@
     "db:seed": "tsx src/db/seed.ts",
     "db:seed-reviewer": "tsx src/db/seed-reviewer.ts",
     "db:seed-smoke": "tsx src/db/seed-smoke.ts",
+    "db:backfill-handhold": "tsx scripts/backfill-handhold-demo.ts",
     "oauth:smoke": "node scripts/oauth-smoke.mjs",
     "docker:build": "docker build -t memex-server .",
     "docker:run": "docker run -p 8080:8080 --env-file .env memex-server",

--- a/packages/server/scripts/backfill-handhold-demo.ts
+++ b/packages/server/scripts/backfill-handhold-demo.ts
@@ -1,0 +1,34 @@
+// Backfill the Handhold onboarding demo into EXISTING personal Memexes (spec-178 t-5 / dec-7).
+//
+// New signups get the five frozen ⌘K-search demo specs automatically via the
+// post-commit hook in ensureUserNamespace. THIS script is the one-time catch-up
+// for personal Memexes that were created BEFORE the feature shipped — it seeds
+// every personal namespace (namespaces.kind='user') that doesn't already have them.
+//
+// Usage:
+//   pnpm --filter @memex/server tsx scripts/backfill-handhold-demo.ts
+//
+// Idempotent + non-destructive: seedHandholdDemo() no-ops on any Memex that already
+// has is_demo specs, so re-running (e.g. on every deploy) does zero work once seeded.
+// It only INSERTs demo content — it never touches real specs or team Memexes.
+//
+// CI/CD wiring (dec-7, "wired into the deploy, never run by hand"): the deploy owner
+// adds this AFTER migrations in the deploy step, best-effort / non-gating so a backfill
+// hiccup never fails a live deploy:
+//   pnpm --filter @memex/server tsx scripts/backfill-handhold-demo.ts || true
+
+import { backfillHandholdDemo } from "../src/services/handhold-demo.js";
+
+async function main(): Promise<void> {
+  console.log("[handhold-backfill] starting — seeding existing personal Memexes that lack the demo…");
+  const { memexesSeeded } = await backfillHandholdDemo();
+  console.log(
+    `[handhold-backfill] done — seeded ${memexesSeeded} personal Memex(es); already-seeded ones were skipped.`,
+  );
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error("[handhold-backfill] failed:", err);
+  process.exit(1);
+});

--- a/packages/server/src/__regression__/mutate-coverage.static-scan.test.ts
+++ b/packages/server/src/__regression__/mutate-coverage.static-scan.test.ts
@@ -142,6 +142,8 @@ const ALLOWLIST: Record<string, string> = {
     "Code-intelligence ingestion (repo_endpoints). Silent-allowed per std-8 §6 — extractor background work, no bus entity, no SSE subscriber. Same client:Db/repoId shape as services/repos.ts; mutate() wrap deferred.",
   "services/repo-meta.ts":
     "Code-intelligence ingestion (repo_structure / repo_patterns / repo_domains / repo_tech_stack). Silent-allowed per std-8 §6 — extractor background work, no bus entity, no SSE subscriber. Same client:Db/repoId shape as services/repos.ts; mutate() wrap deferred.",
+  "services/handhold-demo.ts":
+    "Handhold demo seed/reset (spec-178). Its DOCUMENT mutations all go through mutate() (createDocDraft / addSection / createDecision / createTask / createAc, the terminal phase-flip, and the per-doc delete loop). The raw writes the scan flags are NON-document log tables with no SSE doc-entity: the synthetic test_events / test_event_latest emissions seeded so verify/done demo ACs read 'verified' (dec-9 — same category as services/test-event-latest.ts), and the activity_log cleanup on reset (issue-1 / ac-39 — same category as services/activity-log.ts). These are append-only emission/activity logs, not tenant-doc content; they must not emit, exactly like the two log services already allowlisted above.",
 };
 
 function isScannableFile(path: string): boolean {

--- a/packages/server/src/__regression__/scaffold-drift-guard.regression.test.ts
+++ b/packages/server/src/__regression__/scaffold-drift-guard.regression.test.ts
@@ -101,6 +101,12 @@ const ALLOWLISTED_PROSE_FILES = new Set(
     // alongside `role`. Logged as expected residue; remove this entry once
     // the migration lands.
     "packages/server/src/mcp/tools.ts",
+    // spec-178: the Handhold demo fixture embeds spec-64's VERBATIM content as
+    // multi-line markdown template literals (HANDHOLD_SECTIONS) — by design (ac-2,
+    // wording unchanged). It is frozen DEMO CONTENT seeded into a personal Memex,
+    // not agent-prompt prose / a nudge channel, so it does not belong in
+    // scaffold-data.ts. Exempt the fixture from the prose-location guard.
+    "packages/server/src/db/handhold-demo.fixture.ts",
   ].map((p) => p.split("/").join(sep)),
 );
 

--- a/packages/server/src/agent/tool-specs.ts
+++ b/packages/server/src/agent/tool-specs.ts
@@ -901,6 +901,11 @@ export const toolSpecs: ToolSpec[] = [
         docType: docTypeArg,
         includePaused: false,
         statusIn: ["plan", "build", "verify"],
+        // spec-178 t-11 / dec-11 (ac-37): the MCP/agent enumeration must NOT
+        // surface handhold demo specs. The REST board route omits this flag so
+        // its cards still show demo specs (with the DEMO badge); only this
+        // agent-facing list path opts into the exclusion.
+        excludeDemo: true,
         ...(parsedTags ? { tags: parsedTags } : {}),
       });
 

--- a/packages/server/src/agent/tools.ts
+++ b/packages/server/src/agent/tools.ts
@@ -547,6 +547,17 @@ async function resolveRefForAgent(
   if (doc.memexId !== boundMemexId) {
     throw new NotFoundError(`Ref "${ref}" not found.`);
   }
+  // spec-178 t-11 / dec-11 (ac-38): the in-app agents (the server Anthropic-SDK
+  // agent per std-11, AND the React/LangGraph agent — which executes every
+  // server tool through this same resolver via /tools/execute → executeServerTool)
+  // must not read or act on a handhold demo spec. All doc-targeting agent tools
+  // resolve their ref here, so a single not-found guard makes a demo spec inert to
+  // the whole agent surface. The bound current-doc context path (buildDocumentContext
+  // → getDoc) is intentionally untouched: that's the doc the user explicitly opened,
+  // analogous to the board's getDoc, and is out of scope for this exclusion.
+  if (doc.isDemo) {
+    throw new NotFoundError(`Ref "${ref}" not found.`);
+  }
   return {
     entity,
     memexId: doc.memexId,

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -31,6 +31,7 @@ import { oauth, isOAuthEnabled } from "./routes/oauth/index.js";
 import { wellKnown, publicBaseUrl } from "./routes/well-known.js";
 import driftRouter from "./routes/drift.js";
 import { search } from "./routes/search.js";
+import { handhold } from "./routes/handhold.js";
 import { testEventsRouter } from "./routes/test-events.js";
 import { testOnlyRouter } from "./routes/__test__.js";
 import { hostGuard, memexResolver } from "./middleware/memex-resolver.js";
@@ -225,6 +226,11 @@ app.route("/api/:namespace/:memex/activity", activity);
 // Spec analytics for the Insights page (spec-179). Path-prefixed only — the
 // aggregates are inherently per-Memex, same reasoning as /activity above.
 app.route("/api/:namespace/:memex/analytics", analytics);
+// spec-178 t-6 — handhold onboarding demo reset. Path-prefixed only: the reset
+// is gated to the owner of a PERSONAL Memex (std-7 404 otherwise), so the memex
+// must come from the resolved /<ns>/<mx>/ path — there's no flat entity-keyed
+// mount. STRICT sessionMiddleware + the owner gate live inside the router.
+app.route("/api/:namespace/:memex/handhold", handhold);
 app.use("/api/:namespace/:memex/llm/*", sessionMiddleware);
 app.route("/api/:namespace/:memex/llm", llmRouter);
 // Tenancy-scoped membership / admin surfaces — drift fix to t-12. These were

--- a/packages/server/src/db/handhold-demo.fixture.ts
+++ b/packages/server/src/db/handhold-demo.fixture.ts
@@ -1,0 +1,367 @@
+/**
+ * Handhold onboarding demo — golden seed fixture (spec-178).
+ * ---------------------------------------------------------------------------
+ * The five demo Specs are the SAME spec — spec-64, "In-app Memex search (⌘K)" —
+ * frozen at five phases. To avoid duplicating ~12k words five times, the canonical
+ * content is defined ONCE below, and HANDHOLD_PHASES declares which elements each
+ * frozen copy includes (spec-178 ac-2):
+ *
+ *   draft  → overview only (the raw idea)
+ *   plan   → overview + narrative sections + decisions (the "why", with rejected options)
+ *   build  → + tasks (the agent hand-off)
+ *   verify → + tasks complete + acceptance criteria checked (proof it works)
+ *   done   → same as verify, closed
+ *
+ * Content is reproduced VERBATIM from spec-64 (spec-178 ac-2 / dec — language unchanged,
+ * differentiation is the DEMO badge, not reworded text).
+ *
+ * seedHandholdDemo(memexId) maps this into createDocDraft() + add_section / create_decision /
+ * create_task / create_ac primitives, then sets documents.is_demo=true and documents.status to
+ * each phase. Reset (POST .../handhold/reset) hard-deletes the memex's is_demo docs and re-seeds
+ * from this file.
+ *
+ * TWO JUDGEMENT CALLS — RESOLVED with product (2026-06-05):
+ *  1. spec-64's "Rollout / deployment status" section is OMITTED — a real deploy log
+ *     (MR numbers, Cloud Run revisions), not demo-relevant feature content. (Confirmed: leave out.)
+ *  2. spec-64's cross-references (spec-34 / spec-36 / spec-118 / D-6, …) are KEPT VERBATIM but
+ *     must render as PLAIN TEXT, not clickable links (they don't resolve in a fresh personal
+ *     Memex). The seed/render path suppresses handle auto-linking for is_demo content
+ *     (ac-24: SectionCard skips the rehypeRefLinkifier rehype plugin for is_demo specs).
+ *
+ * PLAN DECISIONS dec-7 / dec-8 / dec-9 — RESOLVED (2026-06-05):
+ *  • dec-7 (backfill): existing personal memexes are backfilled by a one-shot idempotent routine
+ *    (reusing seedHandholdDemo under the 0-demo guard) that fires AUTOMATICALLY in the CI/CD
+ *    deploy — never run by hand.
+ *  • dec-8 (value banner): the `valueCallout` below is served as a per-phase CONSTANT from this
+ *    fixture; it is NOT stored per demo document.
+ *  • dec-9 (verified ACs): for the verify & done phases, seedHandholdDemo also writes synthetic
+ *    PASSING test-event emissions (keyed by each demo AC's ac_uid) so the ACs render 'verified';
+ *    Reset must delete those emissions explicitly (test_events has no docId cascade).
+ */
+
+export const HANDHOLD_TITLE = "In-app Memex search (⌘K)";
+
+// ---------------------------------------------------------------------------
+// Narrative sections (verbatim spec-64). `overview` is the Spec's purpose/Overview.
+// ---------------------------------------------------------------------------
+
+export const HANDHOLD_SECTIONS = {
+  overview: `The Memex backend can already search — the UI cannot surface it.
+
+\`searchMemex\` (spec-34) runs unified handle + Postgres FTS + pgvector search across Specs, Standards, Documents, Decisions, and Issues, RRF-merged, returning a structured \`MemexSearchHit[]\` — but it is reachable **only** through the \`search_memex\` MCP tool. There is no REST route and no UI; a developer in the React UI cannot run the query an agent runs.
+
+This Spec builds the missing **UI** surface over that existing backend. It reuses the semantic core unchanged and adds only a thin structured lookup for exact navigation:
+
+**Global search via a ⌘K command palette (tiered hybrid, D-6).** A REST route exposes both the structured semantic hits and a fast title / number / assignee lookup as JSON; a ⌘K palette runs them from anywhere in the UI. Results are tiered — exact *Jump to* matches (Spec number, title, assignee) sit above semantic *In content* matches grouped by entity kind (Specs / Standards / Documents / Decisions / Issues), so it's immediately clear which hits are which. Snippets render from structured fields as plain text; the agent-facing markdown never reaches the browser.
+
+Builds on spec-34 (unified search + the per-section embedding pipeline), spec-36 (the search-output URL grammar), and spec-118 (per-Spec assignment).`,
+
+  scope: `Two workstreams. The semantic core (\`searchMemex\`) is reused unchanged; the only new query logic is a thin title / handle / assignee lookup for the *Jump to* tier.
+
+**A. REST search route**
+- New \`GET /api/:namespace/:memex/search?q=&kind=&limit=\` returning a combined JSON payload \`{ jumpTo, assigned, content }\` (D-1, D-6). \`content\` is \`searchMemex\`'s \`MemexSearchHit[]\` — kind, canonical path, title, status, RRF score, matching-section snippets, no internal UUIDs — and mirrors the MCP tool's options. \`jumpTo\` is exact handle + title-substring matches over Specs; \`assigned\` is title/handle filtered by assignee via \`doc_assignees\` (spec-118).
+- **No status filter — returns what the agent sees** (D-4). The route applies no visibility logic of its own: it inherits \`searchMemex\`'s existing archived/paused exclusion and returns everything else, including \`draft\` documents and decisions/issues on draft parents. This keeps the content tier a pure pass-through over the search core, identical to the MCP/agent surface. (Tradeoff: in-progress drafts are findable by every member with memex access — the same visibility agents already have.)
+- The MCP \`search_memex\` markdown formatter stays MCP-only; the REST route is a parallel surface over the same search core.
+
+**B. ⌘K command palette — tiered hybrid (D-6)**
+- Global keyboard-triggered overlay (⌘K / Ctrl+K), mounted app-wide, consuming the new REST route.
+- Built on the **cmdk** library (D-5) for the accessibility plumbing (focus trap, focus restore, ARIA dialog/listbox semantics, roving arrow-key nav); styled with Tailwind. The ⌘K/Ctrl+K hotkey stays a thin app-level \`keydown\` listener with \`preventDefault\` — cmdk does not own the global shortcut.
+- Debounced query input. The query prefix selects the mode: \`spec-N\` → exact handle jump; \`@name\` → assignee filter; free text → title substring + semantic content.
+- **Two tiers.** *Jump to* — exact handle / title-substring / assignee matches, rendered as navigation rows with a kind+status badge and no snippet — sits above *In content* — \`searchMemex\` semantic/FTS hits grouped by entity kind (Specs / Standards / Documents / Decisions / Issues), each with one matching-section snippet.
+- Snippets render from the structured \`MemexSearchHit\` fields as plain text (markdown stripped); the MCP markdown formatter never reaches the UI.
+- Keyboard navigation (arrow keys across tiers, Enter to navigate by canonical \`path\`).
+- Optional kind-scope pills mapping to the \`kind\` param; the MVP may ship "All" only.
+- No separate /search page or shareable ?q= URLs for the MVP — deferred pending demand (D-2).`,
+
+  approach: `**The semantic backend is complete.** \`searchMemex\` (spec-34) unifies handle + FTS + pgvector via RRF and returns structured \`MemexSearchHit[]\`. The REST route reuses it unchanged for the *In content* tier and adds a thin structured query for the *Jump to* / assignee tier; the palette is a tiered cmdk consumer (D-5, D-6).
+
+**Tiered hybrid surface (D-6).** The palette shows two tiers. *Jump to* answers precise navigation — exact handle (\`spec-N\`), title substring, and assignee (\`@name\`) matches resolved by a thin query over \`documents\` + \`doc_assignees\` (spec-118); these render as badge-tagged navigation rows with no snippet. *In content* answers recall — \`searchMemex\`'s semantic + FTS \`MemexSearchHit[]\`, grouped by entity kind (Specs / Standards / Documents / Decisions / Issues), each with a single matching-section snippet. Snippets are built from the structured \`MemexSearchHit\` fields and rendered as plain text — the MCP markdown formatter (\`formatSearchResults\`) stays MCP-only and never reaches the browser. This keeps the vector→markdown path out of the UI: the browser consumes structured JSON, not agent prose.
+
+**No visibility filter (D-4).** The REST route adds no status logic of its own — it returns the same set as the MCP/agent search: \`searchMemex\` excludes archived/paused content, and everything else comes back, including \`draft\` documents and decisions/issues on draft parents. The palette therefore sees exactly what an agent sees, and the route stays a literal thin pass-through with no new search logic. The tradeoff — in-progress drafts are findable via ⌘K by every member with memex access — is accepted for the MVP (it matches the visibility agents already have).
+
+**Graceful FTS fallback (D-3).** Vector is a recall enhancement — if embeddings aren't backfilled or the provider key is unset, \`searchMemex\` already falls back to FTS-only. Build verification confirms the spec-34 T-2 backfill has run on int + prod; no "semantic unavailable" UI for the MVP.
+
+**Canonical-path navigation.** The palette navigates by \`path\` (e.g. \`/memex-app/specs/spec-34\`), preserving spec-36's no-UUID boundary. Internal UUIDs are dropped from the REST payload or kept only as React keys.`,
+
+  nonGoals: `- **Not** building new *semantic* search logic. The unified handle + FTS + pgvector core (spec-34) is reused unchanged; the only new query is a thin title / handle / assignee lookup for the *Jump to* tier over \`documents\` + \`doc_assignees\`.
+- **Not** building a /search page or shareable ?q= URLs for the MVP. The palette is the MVP surface; a dedicated page can be added later over the same REST route if demand surfaces.
+- **Not** adding "semantic search unavailable" UI. The FTS fallback is silent and correct; no UI state for the MVP.`,
+
+  architectureSecurity: `**New surface, existing trust boundary.** The only new server surface is \`GET /api/:namespace/:memex/search\`, mounted path-scoped only alongside the other tenant GETs (app.ts). It uses the same read stack as \`routes/documents.ts\` — \`publicSessionMiddleware\` + \`resolveReadableMemexId\` — so visibility matches the platform's existing read model (spec-111): a **public** memex is searchable by anyone (including anonymous); a **private** memex 404s for non-members and anonymous callers; an unknown namespace/memex 404s at \`memexResolver\` before the handler runs (std-7 — unauthorized access returns 404, not 403). Every query is scoped by the resolved \`memex_id\` exactly as \`searchMemex\` already enforces, and the route returns nothing the existing per-entity GETs don't already expose. No new auth path.
+
+**Data exposure.** The route returns structured JSON; internal UUIDs (\`MemexSearchHit.id\` / \`parentDocId\`) are stripped from the payload (or kept only as React keys), preserving spec-36's no-UUID boundary. Per D-4 the surface applies no status filter beyond \`searchMemex\`'s archived/paused exclusion, so \`draft\` content is returned — a deliberate, accepted visibility posture (drafts are already visible to agents and on other surfaces), bounded by the read model above (members only for a private memex; anyone for a public one).
+
+**Assignee join.** The *Jump to* / assignee tier reads \`doc_assignees\` (spec-118), scoped by the same \`memex_id\`; it exposes only assignment facts already rendered on the Specs board. No new PII surface. For anonymous public-read callers the caller-specific assignment lane returns empty rather than a 401, preserving the public-read contract.
+
+**Injection / cost.** Query text flows into Postgres FTS via parameterised \`plainto_tsquery\` (no string-built SQL — no injection surface) and into the embedding provider for the vector arm. Volume is bounded by the client debounce and the \`limit\` cap; the embedding call is the only outbound dependency and already degrades to FTS-only when the key is absent (D-3). The structured tier is a bounded title/handle/assignee lookup over \`documents\` + \`doc_assignees\`.
+
+**Dependencies.** One new client dependency — \`cmdk\` (D-5), a small unstyled UI primitive pinned to a React-19-compatible version. No new server dependency.`,
+} as const;
+
+// ---------------------------------------------------------------------------
+// Decisions (verbatim spec-64). Seeded as RESOLVED at plan and beyond.
+// ---------------------------------------------------------------------------
+
+export const HANDHOLD_DECISIONS = [
+  {
+    handle: "dec-1",
+    title:
+      "How does the React UI consume search — a structured-JSON REST route, or the existing MCP markdown?",
+    chosen:
+      "Chosen: new structured-JSON REST route. Add `GET /api/:namespace/:memex/search?q=&kind=&limit=` that returns structured JSON the UI consumes with no parsing. Per D-6 the payload is a combined `{ jumpTo, assigned, content }`: `content` is `searchMemex`'s `MemexSearchHit[]` (kind / canonical path / title / status / RRF score / matching-section snippets) feeding the semantic *In content* tier; `jumpTo` is exact handle + title-substring matches over Specs; `assigned` is title/handle filtered by assignee via `doc_assignees` (spec-118). The content tier mirrors `searchMemex`'s options. The MCP markdown formatter stays MCP-only. Internal UUIDs are dropped from the payload (or kept only as React keys); the UI navigates by `path`, preserving spec-36's no-UUID boundary, and the route joins the existing path-scoped surface (documents.ts, drift.ts). Rejected: reusing the MCP markdown path — agent-shaped prose with no scores/strategies/UUIDs would force brittle client parsing.",
+    context:
+      "`searchMemex` (spec-34, services/memex-search.ts) already produces a structured `MemexSearchHit[]` internally — kind, canonical `path`, title, status, RRF score, contributing strategies, and matching-section snippets. The `search_memex` MCP tool then runs that through a formatter that emits canonical-URL markdown with no UUIDs (spec-36). The ⌘K palette needs structured fields it can group by kind and navigate by path; parsing agent-shaped markdown in the client would be brittle and would lose the structured fields.",
+  },
+  {
+    handle: "dec-2",
+    title: "What is the search UI surface?",
+    chosen:
+      "Chosen: ⌘K command palette. A global keyboard-triggered overlay mounted app-wide, debounced query, keyboard navigation, navigate by canonical `path`. Lowest-chrome surface, reachable from anywhere, and mirrors how agents reach search. Per D-6 results are organised in two tiers: an exact *Jump to* tier (handle / title-substring / assignee, navigation rows with a kind+status badge, no snippet) above an *In content* tier of semantic/FTS hits grouped and labelled by entity kind (Specs / Standards / Documents / Decisions / Issues) so it's immediately clear which hits are which. The query prefix selects mode (`spec-N` → jump, `@name` → assignee, free text → title + content). A dedicated /search page and shareable ?q= URLs are deferred — they can be added later over the same REST route and results component if demand surfaces.",
+    context:
+      "Search must be reachable across the React UI and must make it obvious which hits are Standards vs other content (user requirement). Options differ in invocation cost, discoverability, and how much page chrome they add.",
+  },
+  {
+    handle: "dec-3",
+    title:
+      "How does the search UI behave when pgvector embeddings aren't backfilled?",
+    chosen:
+      "Chosen: confirm backfill; graceful FTS fallback, no UI state. Vector is a recall enhancement, not a correctness requirement — `searchMemex` already falls back to FTS-only when embeddings/provider are absent, so search still works lexically. Build carries a verification step: confirm the spec-34 T-2 backfill has run and the embedding provider key is set on int + prod before ship. No \"semantic unavailable\" UI for the MVP — revisit only if the fallback proves confusing in practice.",
+    context:
+      "Search fuses Postgres FTS and pgvector cosine via RRF. Vector recall depends on backfilled `doc_sections.embedding` rows, produced by spec-34 T-2's fire-and-forget pipeline plus a backfill script. If int/prod aren't backfilled (or the embedding provider key is unset), `searchMemex` silently returns FTS-only results. The UI needs a defined posture.",
+  },
+  {
+    handle: "dec-4",
+    title: "Should the in-app search surface return draft documents?",
+    chosen:
+      "Reversed 2026-06-03 (was: exclude draft documents). The in-app search surface returns the SAME visibility set as the MCP/agent search — it applies no status/visibility filter of its own. `searchMemex`'s existing archived/paused exclusion stays the only visibility gate; `draft` documents (and decisions/issues whose parent is a draft) ARE returned. So the content tier stays a literal pass-through over the search core — no new *visibility* logic — and the palette shows exactly what an agent sees. (The Jump-to tier's title/handle/assignee query, per D-6, is the only new query logic, and it inherits the same no-status-filter posture.) Prior choice (rejected): adding a `draft`-exclusion status filter to the REST surface to mirror list_docs()' ACTIVE-only posture — it diverged the REST surface from the search core and was the only new logic in an otherwise thin mirror. Tradeoff accepted: in-progress drafts become findable via ⌘K by every member with memex access — the same visibility agents already have.",
+    context:
+      "`searchMemex` (services/memex-search.ts) scopes every query by `memex_id` and excludes only archived/paused content — `AND d.archived_at IS NULL AND d.paused_at IS NULL`. It does NOT filter by `status`, so `draft` documents are returned. But `draft` is the private-authoring phase (std-1; phase guidance: \"private authoring\"), and `list_docs()` already shows ACTIVE Specs only. Without a status filter the ⌘K palette would surface in-progress drafts (e.g. spec-64 itself) to everyone with memex access — contradicting the draft = private intent.",
+  },
+  {
+    handle: "dec-5",
+    title: "How is the ⌘K palette built — cmdk library or hand-rolled?",
+    chosen:
+      "Chosen: build the palette on the cmdk library. A deliberate, scoped exception to the zero-dep bias — that bias targets platform infra (backend deps + SaaS), and a small unstyled UI primitive doesn't carry the same risk. cmdk gives the accessibility plumbing (focus trap, focus restore, ARIA dialog/listbox/combobox, roving arrow-key nav) that a hand-roll would have to reimplement and is easy to get wrong; we keep styling in Tailwind and wire it to the new REST search route. ⌘K/Ctrl+K invocation stays a thin app-level keydown listener with preventDefault (cmdk does not own the global hotkey). Build must pin a cmdk version with React 19 peer support (admin is react ^19.0.0) and verify it mounts cleanly under React 19. Rejected: hand-rolling — saves the dependency but re-implements well-trodden a11y semantics for no real gain here.",
+    context:
+      "dec-2 settled the surface (⌘K command palette) but not the implementation. The platform's default bias is zero-dep / hand-rolled (no new npm deps for platform infra). A hand-rolled palette is ~40 lines (global keydown + portal overlay), but the fiddly part is accessibility plumbing — focus trap, focus restore on close, ARIA dialog/listbox/combobox semantics, arrow-key roving — which is easy to get subtly wrong. cmdk (pacocoursey, used by shadcn/ui and Vercel) is a small, unstyled React primitive that provides exactly this: keyboard nav, filtering hooks, and the a11y semantics, leaving styling to Tailwind. The admin package is React 19 (packages/admin/package.json: react ^19.0.0); cmdk declares React 18/19 peer support.",
+  },
+  {
+    handle: "dec-6",
+    title:
+      "What is the MVP search surface — pure semantic search, a structured Spec filter, or a hybrid?",
+    chosen:
+      "Chosen: C — a tiered HYBRID palette. The ⌘K overlay shows two tiers. **Jump to** (precise navigation): exact handle (`spec-N`), title-substring, and assignee (`@name`) matches resolved by a thin query over `documents` + `doc_assignees` (spec-118) — rendered as navigation rows with a kind+status badge and no snippet. **In content** (recall): `searchMemex`'s semantic + FTS `MemexSearchHit[]`, grouped by entity kind (Specs / Standards / Documents / Decisions / Issues), each with one matching-section snippet. The query prefix selects mode: `spec-N` → jump, `@name` → assignee, free text → title + content. Critically, snippets render from the structured `MemexSearchHit` fields as plain text (markdown stripped); the MCP markdown formatter (`formatSearchResults`) stays MCP-only and never reaches the browser — this keeps the vector→markdown path out of the UI (Barrie's concern). Rejected: A (pure semantic, `kind:'spec'`) — can't do assignee and offers no exact title/number jump; B (pure structured filter) — simplest and reuses the Specs board, but drops the semantic recall that is the whole point of the spec-34 investment. Consequence: extends D-1 (route returns a combined `{ jumpTo, assigned, content }` payload, not bare `MemexSearchHit[]`) and refines D-2 (grouping is tiers-then-kinds, and the kind list now includes Issues). The structured tier is the only new query logic; `searchMemex`'s core is reused unchanged.",
+    context:
+      "D-2 settled the surface (⌘K palette) and D-1 settled how the UI consumes search (structured-JSON REST over `searchMemex`). A review thread (Barrie/Ryan) surfaced two complications. (1) `searchMemex` does FTS+pgvector over section *content* and structures hits as markdown for the coding agent — so the UI has to think hard about how it renders ranked, snippet-bearing semantic results. (2) Ryan proposed scoping the MVP to Spec Title / Spec Number / Assignee matches to simplify. Grounding both against `origin/develop`: the only \"scope\" param on `searchMemex` is `kind` (entity type) — it does NOT field-scope to title/number/assignee. Spec Number maps to the existing handle short-circuit (`spec-N`); Spec Title is only matched insofar as title words appear in section content; and Assignee is NOT searchable at all — assignment lives in `doc_assignees` (spec-118), which `searchMemex` never joins. So the three options are: A) pure semantic via `searchMemex` scoped to `kind:'spec'`; B) pure structured title/handle/assignee filter; C) hybrid — both, layered in one palette.",
+  },
+] as const;
+
+// ---------------------------------------------------------------------------
+// Tasks (verbatim spec-64). All COMPLETE in source. Visible from build onward.
+// `acs` are the task's acceptance-criteria statements; at verify/done they read as checked.
+// ---------------------------------------------------------------------------
+
+export const HANDHOLD_TASKS = [
+  {
+    handle: "t-1",
+    title: "REST search route — content tier + combined payload envelope",
+    body: "Add `GET /api/:namespace/:memex/search?q=&kind=&limit=` mounted on the tenant prefix in app.ts (alongside docs/drift). It calls `searchMemex` for the `content` tier and returns the combined `{ jumpTo, assigned, content }` envelope (jumpTo/assigned are populated by T-2; this task establishes the route, the envelope, and the content tier). Forward `kind`/`limit` to `searchMemex`; strip internal UUIDs (`id`, `parentDocId`) from `content[]`; apply no status filter of its own (drafts returned; archived/paused excluded by `searchMemex`); unknown namespace/memex → 404 (std-7). When the embedding key is unset, `content` is FTS-only and the route still responds 200. The MCP `formatSearchResults` path is untouched. Delivers ac-6, ac-7, ac-11, ac-13, ac-14.",
+    acs: [
+      "Route mounted under /api/:namespace/:memex/search; unknown tenant returns 404 (std-7)",
+      "Response is { jumpTo, assigned, content }; content[] carries MemexSearchHit fields with no internal UUIDs (ac-6, ac-7)",
+      "kind and limit query params are forwarded to searchMemex (ac-7)",
+      "Provider key unset → 200 with FTS-only content (ac-11)",
+      "Draft docs present in results; archived/paused absent; MCP search_memex unchanged (ac-13, ac-14)",
+    ],
+  },
+  {
+    handle: "t-2",
+    title: "Structured Jump-to + assignee query (handle / title / assignee)",
+    body: "Build the structured tier feeding `jumpTo` and `assigned`: exact handle resolution (spec-N / std-N / doc-N), Spec title-substring match over `documents`, and assignee match over `documents` ⋈ `doc_assignees` (spec-118), all scoped by `memex_id` and honouring the same archived/paused + draft posture as the content tier. Wire the results into the route's `jumpTo` / `assigned` keys (depends on T-1). A `@<name>` query routes to the assignee path. Delivers the data side of ac-17, ac-18, ac-19 and completes ac-6's populated envelope.",
+    acs: [
+      "Handle query (spec-N) returns the exact entity in jumpTo (ac-17)",
+      "Free-text returns Spec title-substring matches in jumpTo alongside searchMemex content (ac-18)",
+      "@name returns Specs assigned to that member via doc_assignees in assigned (ac-19)",
+      "All arms scoped by memex_id; drafts included; archived/paused excluded — EXCEPT the exact-handle jump arm, which allows paused (user-confirmed 2026-06-03)",
+    ],
+  },
+  {
+    handle: "t-3",
+    title: "cmdk palette shell + global ⌘K listener",
+    body: "Add `cmdk` (pinned to a React-19-compatible version; admin is react ^19.0.0) and build the overlay shell mounted app-wide, consuming the new REST route. A thin app-level `keydown` listener toggles the palette on ⌘K / Ctrl+K with `preventDefault` — cmdk does not own the hotkey. Esc closes and restores focus to the previously focused element. Verify a clean mount under React 19 (no peer/runtime warnings) with role=dialog + listbox/option a11y semantics and aria-selected on the active row. Delivers ac-8, ac-15, ac-16.",
+    acs: [
+      "cmdk pinned to a React-19-peer version; mounts with no peer/runtime warnings (ac-15)",
+      "⌘K / Ctrl+K opens the palette from any route; Esc closes and restores focus (ac-8)",
+      "Hotkey is an app-level keydown listener with preventDefault, not cmdk-owned (ac-16)",
+      "role=dialog + listbox/option roles with aria-selected on the active row (ac-15)",
+    ],
+  },
+  {
+    handle: "t-4",
+    title: "Tiered results rendering + keyboard navigation",
+    body: "Render the combined payload as two tiers — *Jump to* (badge-tagged navigation rows, no snippet) above *In content* (grouped under kind headers: Specs / Standards / Documents / Decisions / Issues), each with one matching-section snippet built from `MemexSearchHit.matchingSections` rendered as plain text (markdown stripped — never render the `formatSearchResults` output). Single roving arrow-key selection across all tiers and groups; Enter navigates by canonical `path`. Debounced input. FTS-only results render identically with no \"semantic unavailable\" state. Depends on T-1/T-2 for data. Delivers ac-9, ac-10, ac-12, ac-20 and the display side of ac-17/18/19.",
+    acs: [
+      "Two ordered tiers; In content grouped by kind with kind+status badges (ac-9)",
+      "Roving arrow-key selection across tiers/groups; Enter navigates to canonical path (ac-10)",
+      "Snippets are plain text from matchingSections; jump rows render no snippet; no markdown rendered in the browser (ac-20)",
+      "FTS-only results render with no degraded/unavailable UI (ac-12)",
+    ],
+  },
+  {
+    handle: "t-5",
+    title: "Confirm pgvector backfill + embedding key on int + prod",
+    body: "Deploy-readiness gate for the semantic tier (D-3). Confirm the spec-34 T-2 embedding backfill has run (`doc_sections.embedding` populated for active sections) and the embedding provider key is set on both int and prod, so the *In content* tier returns semantic results in deployed environments. If not backfilled, run `scripts/backfill-memex-embeddings.ts`. No application code change — this is a verification/ops step. Supports ac-11/ac-12 in live envs.",
+    acs: [
+      "doc_sections.embedding populated for active Spec/Standard/Document sections on int + prod",
+      "Embedding provider key set on int + prod",
+      "A live query on int returns ≥1 vector-strategy hit — semantic path confirmed live",
+    ],
+  },
+  {
+    handle: "t-6",
+    title: "Playwright e2e — ⌘K search palette journey",
+    body: "Add a Playwright e2e journey proving the palette's real-browser behaviours that the jsdom component tests can't: actual ⌘K/Ctrl+K interception, focus restore to the triggering element on Esc (ac-8), visual tiered rendering + kind badges (ac-9), and arrow-key + Enter navigation to a Spec (ac-10). Follow the existing `packages/admin/e2e/journey-*.spec.ts` conventions (auth/seed/baseURL/webServer in `playwright.config.ts`); new file e.g. `e2e/journey-18-global-search.spec.ts`. Strengthens browser-level verification of ac-8/9/10/16.",
+    acs: [
+      "New e2e/journey-18-global-search.spec.ts follows existing journey auth/seed/webServer conventions",
+      "⌘K opens the palette on a tenant page; Esc closes and focus returns to the previously focused element (real browser — ac-8)",
+      "A query renders tiered results with kind badges; ArrowDown + Enter navigates to the hit's page (ac-9/ac-10)",
+    ],
+  },
+  {
+    handle: "t-7",
+    title:
+      "⌘K \"In content\" tier has no relevance floor — low-signal queries return unrelated sections",
+    body: "Symptom: a ⌘K query with no strong lexical match (e.g. a personal name) returns a full page of \"In content\" hits — none of which contain the query terms. Root cause: the vector arm has no distance/similarity threshold and the RRF merge has no minimum-score cutoff, so when FTS returns nothing the vector neighbours flow straight through to the limit cap. Fix: add a relevance floor to the semantic tier (max cosine-distance cutoff on the vector arms, or a minimum RRF-score floor) so low-confidence neighbours are dropped rather than displayed. Tune empirically (name queries should collapse to Jump-to + assignee only). (Converted from Issue i-1 [bug, medium].)",
+    acs: [
+      "A query with no lexical or semantic match returns an empty content[] (not the top-N nearest sections)",
+      "A genuinely relevant query is unaffected; covered by an AC-tagged integration test",
+    ],
+  },
+  {
+    handle: "t-8",
+    title:
+      "⌘K palette: make tier/group separators (Assigned / Specs / Standards / Documents) more visually prominent",
+    body: "The ⌘K palette groups results under tier/kind headers, but they read as faint, low-contrast uppercase labels inline with the rows, so the boundary between groups is easy to miss. D-6 made \"it's immediately clear which hits are which\" explicit; the current treatment underdelivers. Strengthen the group-header treatment in `SearchPalette.tsx` so each separator is unambiguously a section break (divider rule / higher-contrast header / subtle background band / sticky headers). Keep cmdk's listbox/option semantics intact (group headings stay non-focusable). Purely visual. (Converted from Issue i-2 [todo].)",
+    acs: [
+      "Group headers render as distinct, unambiguous section separators across multiple tiers",
+      "cmdk a11y semantics preserved (group headings non-focusable)",
+    ],
+  },
+  {
+    handle: "t-9",
+    title:
+      "⌘K Decision/Issue hits navigate to a dead deep-link → bounce to the user's personal Memex",
+    body: "Symptom: hitting Enter on a Decision or Issue result navigates to the user's personal Memex specs board instead of the hit. Root cause (routing, not search): App.tsx registers `specs/:id` but has no `specs/:id/decisions/:decId` or `specs/:id/issues/:issueId` route, so the deep-link falls to the catch-all RootRedirect. Fix (option B, chosen): add real client routes `specs/:id/decisions/:decId` and `specs/:id/issues/:issueId` rendering the same DocumentShell/DocDocument as `specs/:id`; DocDocument reads the optional sub-param and opens/scrolls to the target. No palette change. (Converted from Issue i-3 [bug, high].)",
+    acs: [
+      "A decision deep-link renders the Spec document (DocDocument), not a redirect to the default/personal tenant",
+      "An issue deep-link behaves the same; the manual ⌘K repro on INT no longer bounces",
+    ],
+  },
+] as const;
+
+// ---------------------------------------------------------------------------
+// Phase composition (spec-178 ac-2). seedHandholdDemo() reads this to decide what each
+// frozen copy contains, and sets documents.status to `phase`.
+//   - includeSections: which HANDHOLD_SECTIONS keys render (overview is the Spec purpose)
+//   - includeDecisions: seed the 6 resolved decisions
+//   - includeTasks: seed the 9 tasks
+//   - tasksComplete: if true, tasks seed as complete and their ACs read as checked/verified
+//                    (verify/done); if false, tasks seed as the not-yet-done plan (build)
+//   - includeAcs: acceptance criteria are surfaced/verified (verify/done)
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Spec-level acceptance criteria (spec-178 t-2 / ac-22). The verify & done frozen
+// copies surface the Spec's acceptance criteria as first-class AC rows; this is the
+// flat list derived from every task's `.acs` statements (HANDHOLD_TASKS.flatMap).
+// All are kind 'implementation' — they're the technical, agent-spawned checks the
+// build delivered (the demo has no manager-authored 'scope' ACs). ~23 items.
+//
+// seedHandholdDemo() creates one AC per entry under the verify/done demo Spec and
+// writes a synthetic PASSING test-event emission per AC (dec-9) so each reads
+// 'verified'. Reset deletes those emissions (test_events has no docId cascade).
+// ---------------------------------------------------------------------------
+
+export const HANDHOLD_ACS: readonly { statement: string; kind: "implementation" }[] =
+  HANDHOLD_TASKS.flatMap((t) =>
+    t.acs.map((statement) => ({ statement, kind: "implementation" as const })),
+  );
+
+export type HandholdPhase = "draft" | "plan" | "build" | "verify" | "done";
+
+export interface HandholdPhaseSlice {
+  phase: HandholdPhase;
+  includeSections: (keyof typeof HANDHOLD_SECTIONS)[];
+  includeDecisions: boolean;
+  includeTasks: boolean;
+  tasksComplete: boolean;
+  includeAcs: boolean;
+  /**
+   * Per-phase value call-out, rendered as a banner at the TOP of the demo spec, visually
+   * DISTINCT from the verbatim spec-64 content (it is demo guidance, not part of the Spec).
+   * Names the value Memex adds at this phase. Framing adopted from Barrie's spec-156 writeup;
+   * the `done` beat borrows its "stays verified forever" line. (spec-178.)
+   */
+  valueCallout: string;
+}
+
+const ALL_SECTIONS: (keyof typeof HANDHOLD_SECTIONS)[] = [
+  "overview",
+  "scope",
+  "approach",
+  "nonGoals",
+  "architectureSecurity",
+];
+
+export const HANDHOLD_PHASES: HandholdPhaseSlice[] = [
+  {
+    phase: "draft",
+    includeSections: ["overview"],
+    includeDecisions: false,
+    includeTasks: false,
+    tasksComplete: false,
+    includeAcs: false,
+    valueCallout:
+      "**Specify the *why*, in plain language.** The idea is captured as a Spec — the observed problem and the shape of the work — instead of living in a Slack thread or someone's head.",
+  },
+  {
+    phase: "plan",
+    includeSections: ALL_SECTIONS,
+    includeDecisions: true,
+    includeTasks: false,
+    tasksComplete: false,
+    includeAcs: false,
+    valueCallout:
+      "**Decisions become first-class — with the roads not taken.** Each real choice (⌘K palette vs. a search page, off-the-shelf vs. hand-rolled, hybrid vs. pure-semantic) is recorded with its reasoning and its rejected alternatives. Nobody re-litigates it in six months.",
+  },
+  {
+    phase: "build",
+    includeSections: ALL_SECTIONS,
+    includeDecisions: true,
+    includeTasks: true,
+    tasksComplete: false,
+    includeAcs: false,
+    valueCallout:
+      "**The plan becomes executable work, and tests phone home.** Decisions turn into tasks a coding agent runs; every acceptance criterion is tagged to a test, and the runner reports each pass/fail back to the Spec — so the page shows what's *proven*, live, not claimed.",
+  },
+  {
+    phase: "verify",
+    includeSections: ALL_SECTIONS,
+    includeDecisions: true,
+    includeTasks: true,
+    tasksComplete: true,
+    includeAcs: true,
+    valueCallout:
+      "**Confidence against the running system, not the diff.** The criteria are walked against the live app — suite green, the path exercised — and what's proven is visible at a glance.",
+  },
+  {
+    phase: "done",
+    includeSections: ALL_SECTIONS,
+    includeDecisions: true,
+    includeTasks: true,
+    tasksComplete: true,
+    includeAcs: true,
+    valueCallout:
+      "**And it stays verified — forever.** Every deploy re-runs the checks against the live environment and re-emits results onto these criteria, so verification is never a point-in-time claim. The full record — spec, decisions, tasks, verified ACs — is permanent; a new joiner gets the whole story instantly.",
+  },
+];

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -85,6 +85,15 @@ export const documents = pgTable("documents", {
   // Last time the Spec narrative was consolidated by the agent. NULL = never
   // consolidated. Spec-only.
   narrativeLastConsolidatedAt: timestamp("narrative_last_consolidated_at", { withTimezone: true }),
+  // Handhold onboarding demo flag (spec-178). When true, this document is one of
+  // the five frozen copies of the canonical ⌘K-search Spec (spec-64) seeded into a
+  // personal Memex to walk a new user through the spec lifecycle. Demo docs render a
+  // DEMO badge + a per-phase value banner, suppress handle auto-linking, are excluded
+  // from ⌘K/search and every agent surface (dec-11; only the board REST list/get still
+  // returns them), and are excluded from Pulse/usage analytics. Reset (POST
+  // .../handhold/reset) hard-deletes all is_demo docs in the memex + their seeded
+  // test-event emissions and re-seeds from handhold-demo.fixture.ts.
+  isDemo: boolean("is_demo").notNull().default(false),
 }, (table) => [
   unique("documents_memex_id_handle_unique").on(table.memexId, table.handle),
   index("documents_memex_id_idx").on(table.memexId),

--- a/packages/server/src/mcp/ac-nag-sketch.test.ts
+++ b/packages/server/src/mcp/ac-nag-sketch.test.ts
@@ -69,6 +69,7 @@ function makeSpecDoc(overrides: Partial<Doc> = {}): Doc & { sections: DocSection
     archivedAt: null,
     pausedAt: null,
     narrativeLastConsolidatedAt: null,
+    isDemo: false,
     ...overrides,
     sections: [
       {

--- a/packages/server/src/mcp/formatters.test.ts
+++ b/packages/server/src/mcp/formatters.test.ts
@@ -39,6 +39,7 @@ function makeDoc(overrides: Partial<Doc> = {}): Doc {
     archivedAt: null,
     pausedAt: null,
     narrativeLastConsolidatedAt: null,
+    isDemo: false,
     ...overrides,
   };
 }

--- a/packages/server/src/mcp/spec-shape-lens-parity.test.ts
+++ b/packages/server/src/mcp/spec-shape-lens-parity.test.ts
@@ -51,6 +51,7 @@ function makePlanSpec(): Doc & { sections: DocSection[] } {
     archivedAt: null,
     pausedAt: null,
     narrativeLastConsolidatedAt: null,
+    isDemo: false,
     sections: [
       {
         id: "section-uuid-1",

--- a/packages/server/src/mcp/tools.test.ts
+++ b/packages/server/src/mcp/tools.test.ts
@@ -52,6 +52,7 @@ const DOC_ROW = {
   archivedAt: null,
   pausedAt: null,
   narrativeLastConsolidatedAt: null,
+  isDemo: false,
 };
 const SECTION_ROW = {
   id: TEST_SECTION_ID,
@@ -530,6 +531,10 @@ describe("MCP Tool handlers via HTTP", () => {
     expect(resolveWorkspaceForRead).toHaveBeenCalledWith(TEST_USER_ID, "mindset", undefined);
     expect(listDocs).toHaveBeenCalledWith(TEST_MEMEX_ID, {
       docType: "spec",
+      // spec-178 t-11 / dec-11 (ac-37): the MCP/agent enumeration path excludes
+      // is_demo specs (the REST board path leaves it unset). Asserted here so the
+      // exclusion can't silently regress off the agent surface.
+      excludeDemo: true,
       includePaused: false,
       statusIn: ["plan", "build", "verify"],
     });

--- a/packages/server/src/mcp/tools.ts
+++ b/packages/server/src/mcp/tools.ts
@@ -451,6 +451,16 @@ export async function resolveRefForUser(
 
   const entity = result.entity;
   const doc = "doc" in entity ? entity.doc : entity.row;
+  // spec-178 t-11 / dec-11 (ac-37): a handhold demo spec is inert to the MCP
+  // surface — a coding agent must not be able to read it (get_doc/export_doc)
+  // or mutate against it (update_doc, add_section, decision/task writes, …),
+  // and every one of those tools resolves its target ref through here. Treat a
+  // demo doc as not-found (std-7: missing, not forbidden) so the agent gets the
+  // same answer as for a ref that doesn't exist. The board's REST getDoc path
+  // is untouched — it never goes through resolveRefForUser.
+  if (doc.isDemo) {
+    throw new NotFoundError(`Ref "${ref}" not found.`);
+  }
   const memexId = doc.memexId;
   // orgFilter (b-31 dec-8) — undefined for PAT (skip), null for personal-only
   // OAuth, <orgId> for Org-scoped OAuth. The read gate enforces it (a private

--- a/packages/server/src/routes/documents.test.ts
+++ b/packages/server/src/routes/documents.test.ts
@@ -184,6 +184,7 @@ describe("GET /api/docs/:id", () => {
       archivedAt: null,
       pausedAt: null,
       narrativeLastConsolidatedAt: null,
+      isDemo: false,
       sections: [],
       creator: null,
     });
@@ -211,6 +212,7 @@ describe("GET /api/docs/:id", () => {
       archivedAt: null,
       pausedAt: null,
       narrativeLastConsolidatedAt: null,
+      isDemo: false,
       sections: [],
       creator: null,
     });
@@ -304,6 +306,7 @@ function mockDoc(id: string, handle: string) {
     archivedAt: null,
     pausedAt: null,
     narrativeLastConsolidatedAt: null,
+    isDemo: false,
     sections: [],
     creator: null,
   });

--- a/packages/server/src/routes/handhold.api.test.ts
+++ b/packages/server/src/routes/handhold.api.test.ts
@@ -1,0 +1,281 @@
+// Integration tests for the handhold onboarding demo (spec-178).
+//
+//   t-4 signup hook  — ensureUserNamespace() seeds 5 is_demo Specs into a fresh
+//                      user's personal Memex (ac-6: seeding runs only for kind='user'
+//                      memexes; creating an org/team memex seeds none). ac-7 (a seed
+//                      FAILURE never blocks signup) is the resilience guarantee — it is
+//                      exercised by user-namespaces.handhold-seed-resilience.test.ts,
+//                      which mocks the seeder to reject. The success-path cases below
+//                      assert ac-6 (personal-only seeding), not ac-7.
+//   t-6 reset route  — POST /api/:namespace/:memex/handhold/reset is gated to the
+//                      personal owner (std-7 404 for a non-owner / non-personal
+//                      target, no mutation) and, for the owner, returns 200 and
+//                      leaves exactly 5 is_demo Specs (ac-17).
+//
+// These run against a REAL Postgres through the full Hono app + middleware
+// stack (memexResolver → sessionMiddleware → owner gate → resetHandholdDemo).
+
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+import { and, eq, inArray } from "drizzle-orm";
+
+vi.hoisted(() => {
+  // Force auth-mode session middleware so per-user Bearer tokens are honored
+  // (mirrors issues-list.integration.test.ts). Without GOOGLE_CLIENT_ID set the
+  // middleware falls into dev-mode and authenticates everyone as dev@memex.ai,
+  // which would defeat the non-owner 404 assertion.
+  process.env.GOOGLE_CLIENT_ID = "test-client.apps.googleusercontent.com";
+  process.env.AUTH_JWT_SECRET = process.env.AUTH_JWT_SECRET ?? "x".repeat(48);
+  return undefined;
+});
+
+import { db } from "../db/connection.js";
+import { app } from "../app.js";
+import { documents, namespaces, memexes, users } from "../db/schema.js";
+import { ensureUserNamespace } from "../services/user-namespaces.js";
+import { makeTestMemexWithDevAdmin } from "../services/test-helpers.js";
+import { resetHandholdDemo } from "../services/handhold-demo.js";
+import { upsertUserByEmail } from "../services/users.js";
+import { signSessionToken } from "../services/auth-jwt.js";
+import { HANDHOLD_PHASES } from "../db/handhold-demo.fixture.js";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+const AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-178/acs/ac-${n}`;
+
+// Users / namespaces we mint, torn down at the end. Deleting the namespace
+// cascades to its memex + documents; deleting the user cascades the rest.
+const createdUserIds: string[] = [];
+const createdNamespaceIds: string[] = [];
+
+function uniqueEmail(prefix: string): string {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}@example.com`;
+}
+
+// Count the is_demo Specs in a Memex (the read paths the demo cares about).
+async function countDemoDocs(memexId: string): Promise<number> {
+  const rows = await db
+    .select({ id: documents.id })
+    .from(documents)
+    .where(and(eq(documents.memexId, memexId), eq(documents.isDemo, true)));
+  return rows.length;
+}
+
+// The signup seed is fire-and-forget (a detached promise in ensureUserNamespace),
+// so poll until the demo docs land rather than asserting synchronously.
+async function waitForDemoDocs(
+  memexId: string,
+  expected: number,
+  timeoutMs = 15_000,
+): Promise<number> {
+  const deadline = Date.now() + timeoutMs;
+  let last = 0;
+  while (Date.now() < deadline) {
+    last = await countDemoDocs(memexId);
+    if (last >= expected) return last;
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  return last;
+}
+
+// Resolve the personal namespace + memex a user owns (created by ensureUserNamespace).
+async function personalOf(userId: string): Promise<{
+  namespaceSlug: string;
+  memexSlug: string;
+  memexId: string;
+  namespaceId: string;
+}> {
+  const [ns] = await db
+    .select({ id: namespaces.id, slug: namespaces.slug })
+    .from(namespaces)
+    .where(and(eq(namespaces.ownerUserId, userId), eq(namespaces.kind, "user")))
+    .limit(1);
+  const [mx] = await db
+    .select({ id: memexes.id, slug: memexes.slug })
+    .from(memexes)
+    .where(eq(memexes.namespaceId, ns.id))
+    .limit(1);
+  return {
+    namespaceSlug: ns.slug,
+    memexSlug: mx.slug,
+    memexId: mx.id,
+    namespaceId: ns.id,
+  };
+}
+
+async function makePersonalUser(prefix: string): Promise<{
+  userId: string;
+  bearer: string;
+  namespaceSlug: string;
+  memexSlug: string;
+  memexId: string;
+}> {
+  const user = await upsertUserByEmail(uniqueEmail(prefix));
+  createdUserIds.push(user.id);
+  await ensureUserNamespace(user.id);
+  const p = await personalOf(user.id);
+  createdNamespaceIds.push(p.namespaceId);
+  return {
+    userId: user.id,
+    bearer: signSessionToken(user.id),
+    namespaceSlug: p.namespaceSlug,
+    memexSlug: p.memexSlug,
+    memexId: p.memexId,
+  };
+}
+
+afterAll(async () => {
+  // Namespaces cascade to memex + documents; do those first, then the users.
+  if (createdNamespaceIds.length > 0) {
+    await db
+      .delete(namespaces)
+      .where(inArray(namespaces.id, createdNamespaceIds))
+      .catch(() => {});
+  }
+  if (createdUserIds.length > 0) {
+    await db.delete(users).where(inArray(users.id, createdUserIds)).catch(() => {});
+  }
+});
+
+function reset(
+  namespaceSlug: string,
+  memexSlug: string,
+  bearer: string,
+): Promise<Response> {
+  const headers = new Headers();
+  headers.set("Host", "memex.ai");
+  headers.set("Authorization", `Bearer ${bearer}`);
+  return Promise.resolve(
+    app.request(`/api/${namespaceSlug}/${memexSlug}/handhold/reset`, {
+      method: "POST",
+      headers,
+    }),
+  );
+}
+
+describe("spec-178 t-4 — signup seed hook (ac-6 / ac-7)", () => {
+  it("ensureUserNamespace seeds 5 is_demo Specs into a fresh user's personal Memex", async () => {
+    tagAc(AC(6));
+    const user = await makePersonalUser("h178-signup");
+    const count = await waitForDemoDocs(user.memexId, HANDHOLD_PHASES.length);
+    expect(count).toBe(HANDHOLD_PHASES.length);
+    expect(HANDHOLD_PHASES.length).toBe(5);
+  });
+
+  it("org / team Memex creation seeds NO demo Specs (the demo is personal-only)", async () => {
+    tagAc(AC(6));
+    // makeTestMemexWithDevAdmin builds a kind:'org' namespace + memex — the
+    // signup hook never runs for it, so it must carry zero demo docs.
+    const made = await makeTestMemexWithDevAdmin("h178-org");
+    createdNamespaceIds.push(
+      (
+        await db
+          .select({ id: namespaces.id })
+          .from(namespaces)
+          .where(eq(namespaces.slug, made.slug))
+          .limit(1)
+      )[0].id,
+    );
+    // Give any (incorrectly-wired) async seed a moment; it must still be zero.
+    await new Promise((r) => setTimeout(r, 300));
+    expect(await countDemoDocs(made.memexId)).toBe(0);
+  });
+});
+
+describe("spec-178 t-6 — reset route owner gate (ac-17)", () => {
+  it("the personal owner gets 200 and exactly 5 is_demo Specs after reset", async () => {
+    tagAc(AC(17));
+    const owner = await makePersonalUser("h178-owner");
+    // Let the signup seed settle so reset exercises the delete+reseed path, not
+    // a cold seed.
+    await waitForDemoDocs(owner.memexId, HANDHOLD_PHASES.length);
+
+    const res = await reset(owner.namespaceSlug, owner.memexSlug, owner.bearer);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { status: string; seeded: number };
+    expect(body.status).toBe("ok");
+    expect(body.seeded).toBe(HANDHOLD_PHASES.length);
+    // resetHandholdDemo is awaited in the handler, so the count is final on return.
+    expect(await countDemoDocs(owner.memexId)).toBe(HANDHOLD_PHASES.length);
+  });
+
+  it("a non-owner with a valid token gets 404 (not 403) and no mutation runs", async () => {
+    tagAc(AC(17));
+    const owner = await makePersonalUser("h178-victim");
+    await waitForDemoDocs(owner.memexId, HANDHOLD_PHASES.length);
+    const before = await countDemoDocs(owner.memexId);
+
+    const stranger = await upsertUserByEmail(uniqueEmail("h178-stranger"));
+    createdUserIds.push(stranger.id);
+    const strangerBearer = signSessionToken(stranger.id);
+
+    const res = await reset(owner.namespaceSlug, owner.memexSlug, strangerBearer);
+    expect(res.status).toBe(404);
+    expect(res.status).not.toBe(403);
+    // No mutation: the demo doc set is untouched.
+    expect(await countDemoDocs(owner.memexId)).toBe(before);
+  });
+
+  it("a non-personal (org) Memex returns 404 even for an org member", async () => {
+    tagAc(AC(17));
+    // dev@memex.ai is enrolled as administrator member of this org memex.
+    const made = await makeTestMemexWithDevAdmin("h178-orggate");
+    createdNamespaceIds.push(
+      (
+        await db
+          .select({ id: namespaces.id })
+          .from(namespaces)
+          .where(eq(namespaces.slug, made.slug))
+          .limit(1)
+      )[0].id,
+    );
+    const dev = await upsertUserByEmail("dev@memex.ai");
+    const devBearer = signSessionToken(dev.id);
+
+    const res = await reset(made.slug, "main", devBearer);
+    // namespace.kind === 'org' → std-7 404, never 403, no seed/mutation.
+    expect(res.status).toBe(404);
+    expect(res.status).not.toBe(403);
+    expect(await countDemoDocs(made.memexId)).toBe(0);
+  });
+
+  it("an anonymous request is rejected before the handler (401, no mutation)", async () => {
+    tagAc(AC(17));
+    const owner = await makePersonalUser("h178-anon");
+    await waitForDemoDocs(owner.memexId, HANDHOLD_PHASES.length);
+    const before = await countDemoDocs(owner.memexId);
+
+    const headers = new Headers();
+    headers.set("Host", "memex.ai");
+    const res = await app.request(
+      `/api/${owner.namespaceSlug}/${owner.memexSlug}/handhold/reset`,
+      { method: "POST", headers },
+    );
+    // STRICT sessionMiddleware: no Bearer → 401 (write never reachable anonymously).
+    expect(res.status).toBe(401);
+    expect(await countDemoDocs(owner.memexId)).toBe(before);
+  });
+
+  it("an unknown namespace/memex returns 404", async () => {
+    tagAc(AC(17));
+    const owner = await makePersonalUser("h178-unknown");
+    const res = await reset(
+      `no-such-namespace-${Date.now()}`,
+      "nope",
+      owner.bearer,
+    );
+    expect(res.status).toBe(404);
+  });
+});
+
+// Direct service-level guard so the reset count contract is pinned independent of
+// the HTTP layer (defense in depth for ac-17's "exactly 5" clause).
+describe("spec-178 t-6 — resetHandholdDemo service contract (ac-17)", () => {
+  it("reset returns { seeded: 5 } and leaves exactly 5 is_demo Specs", async () => {
+    tagAc(AC(17));
+    const owner = await makePersonalUser("h178-svc");
+    await waitForDemoDocs(owner.memexId, HANDHOLD_PHASES.length);
+    const result = await resetHandholdDemo(owner.memexId);
+    expect(result.seeded).toBe(HANDHOLD_PHASES.length);
+    expect(await countDemoDocs(owner.memexId)).toBe(HANDHOLD_PHASES.length);
+  });
+});

--- a/packages/server/src/routes/handhold.ts
+++ b/packages/server/src/routes/handhold.ts
@@ -1,0 +1,53 @@
+// POST /api/:namespace/:memex/handhold/reset — re-seed the handhold onboarding
+// demo (spec-178 t-6). Hard-deletes every is_demo Spec in the caller's PERSONAL
+// Memex (and the synthetic emissions that back their AC health), then re-seeds
+// the five frozen demo Specs from the fixture. Returns { status, seeded }.
+//
+// This is the user's "reset the tour" button: a personal-namespace owner can
+// blow away their experiments on the demo Specs and get a pristine set back.
+//
+// Authorization (std-7): the demo lives ONLY in personal Memexes, so the reset
+// is gated to the owner of a `kind:'user'` namespace. Anyone else — a stranger,
+// a member of an ORG Memex, or even the owner pointing at a non-personal Memex —
+// gets a 404 (never 403), indistinguishable from a non-existent route, and NO
+// mutation runs. The write sits behind the STRICT sessionMiddleware so an
+// anonymous caller is 401'd before reaching the handler; the explicit ownership
+// gate below then narrows from "any member" to "the personal owner".
+
+import { Hono } from "hono";
+import { sessionMiddleware, type SessionEnv } from "../middleware/session.js";
+import type { MemexResolverEnv } from "../middleware/memex-resolver.js";
+import type { Namespace } from "../db/schema.js";
+import { requireMemexId } from "./shared.js";
+import { resetHandholdDemo } from "../services/handhold-demo.js";
+
+type Env = MemexResolverEnv & SessionEnv;
+const handhold = new Hono<Env>();
+
+// STRICT session policy — this is a mutation. Anonymous → 401, non-member → 404
+// (membership proven by sessionMiddleware before the handler runs).
+handhold.use("/*", sessionMiddleware);
+
+handhold.post("/reset", async (c) => {
+  const memexId = requireMemexId(c);
+  const currentUserId = c.get("currentUserId") as string | null;
+  // Set by memexResolver from the /<ns>/<mx>/ path prefix; the reset route is
+  // path-prefixed only, so this is always present for a resolved Memex.
+  const namespace = c.get("namespace") as Namespace | null | undefined;
+
+  // std-7 gate: the demo only exists in a personal Memex, and only its owner may
+  // reset it. Anything else (org namespace, someone else's personal namespace,
+  // or no resolved namespace at all) → 404, NEVER 403. No mutation runs.
+  if (
+    !namespace ||
+    namespace.kind !== "user" ||
+    namespace.ownerUserId !== currentUserId
+  ) {
+    return c.json({ error: "Not found" }, 404);
+  }
+
+  const result = await resetHandholdDemo(memexId);
+  return c.json({ status: "ok", seeded: result.seeded });
+});
+
+export { handhold };

--- a/packages/server/src/services/activity-log-demo-exclusion.integration.test.ts
+++ b/packages/server/src/services/activity-log-demo-exclusion.integration.test.ts
@@ -1,0 +1,220 @@
+// Handhold onboarding demo — analytics/Pulse exclusion + search inclusion
+// (spec-178 t-9, ac-21 + ac-20).
+//
+// Two guarantees, both tested against REAL Postgres (no mocks):
+//
+//   ac-21 (Pulse exclusion): listActivity() must drop rows whose `brief_id`
+//     references an `is_demo` document, while KEEPING (a) memex-level rows
+//     (brief_id IS NULL) and (b) rows for non-demo docs. This is the read-path
+//     filter — demo docs may pre-exist the persisted rows, so we cannot rely on
+//     a persist-time skip.
+//
+//   ac-20 (search EXCLUSION): searchMemex() must NOT return a demo spec.
+//     spec-178 t-11 / dec-11 reverses the earlier "searchable" posture — a demo
+//     spec is invisible AND inert to ⌘K and to the MCP `search_memex` tool. These
+//     two cases prove the exclusion on the two arms a demo spec could otherwise
+//     surface through: the FTS content arm and the exact-handle short-circuit.
+//
+// Cleanup deletes activity_log + documents for our memexes, then the namespaces
+// (cascading to org/memex/memberships).
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import { inArray, eq } from "drizzle-orm";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { db } from "../db/connection.js";
+import { activityLog, documents, memexes, namespaces } from "../db/schema.js";
+import type { ActivityLogInsert } from "../db/schema.js";
+import { makeTestMemex } from "./test-helpers.js";
+import { createDocDraft } from "./documents.js";
+import { addSection } from "./sections.js";
+import { embedAndStoreDoc } from "./memex-embeddings.js";
+import { listActivity } from "./activity-log.js";
+import { searchMemex } from "./memex-search.js";
+import type { EmbeddingProvider } from "./embedding-provider.js";
+
+const AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-178/acs/ac-${n}`;
+
+const createdMemexIds: string[] = [];
+let memexId: string;
+
+// Deterministic provider so the vector arm never calls a real embedding API.
+// Content matters only for FTS here; the vector is a stable hash ramp.
+function makeFakeProvider(name = "fake-demo-1536"): EmbeddingProvider {
+  return {
+    name,
+    dim: 1536,
+    maxBatchSize: 16,
+    async embed(texts: string[]): Promise<number[][]> {
+      return texts.map((t) => {
+        const seed = Array.from(t).reduce((acc, ch) => acc + ch.charCodeAt(0), 0);
+        return Array.from({ length: 1536 }, (_, i) => ((seed + i) % 100) / 100);
+      });
+    },
+  };
+}
+
+// Insert one raw activity_log row (the sink's persisted shape) directly, so the
+// test controls exactly which brief_id each row references.
+async function insertActivity(
+  memex: string,
+  briefId: string | null,
+  narrative: string,
+): Promise<string> {
+  const row: ActivityLogInsert = {
+    memexId: memex,
+    briefId,
+    actorKind: "system",
+    channel: "server",
+    entity: "document",
+    action: briefId ? "updated" : "created",
+    narrative,
+  };
+  const [inserted] = await db.insert(activityLog).values(row).returning();
+  return inserted.id;
+}
+
+beforeAll(async () => {
+  memexId = await makeTestMemex("demoexcl");
+  createdMemexIds.push(memexId);
+});
+
+afterAll(async () => {
+  await db
+    .delete(activityLog)
+    .where(inArray(activityLog.memexId, createdMemexIds))
+    .catch(() => {});
+  await db
+    .delete(documents)
+    .where(inArray(documents.memexId, createdMemexIds))
+    .catch(() => {});
+  const memexRows = await db
+    .select({ namespaceId: memexes.namespaceId })
+    .from(memexes)
+    .where(inArray(memexes.id, createdMemexIds))
+    .catch(() => [] as { namespaceId: string }[]);
+  await db.delete(memexes).where(inArray(memexes.id, createdMemexIds)).catch(() => {});
+  const namespaceIds = memexRows.map((r) => r.namespaceId);
+  if (namespaceIds.length) {
+    await db.delete(namespaces).where(inArray(namespaces.id, namespaceIds)).catch(() => {});
+  }
+});
+
+// Clean activity_log between cases so row-count assertions are exact.
+beforeEach(async () => {
+  await db.delete(activityLog).where(inArray(activityLog.memexId, createdMemexIds));
+});
+
+describe("listActivity — handhold demo exclusion (ac-21)", () => {
+  it("drops activity for is_demo docs but keeps memex-level + non-demo activity", async () => {
+    tagAc(AC(21));
+
+    // A demo spec and an ordinary spec.
+    const demo = await createDocDraft(memexId, "Demo spec", "Demo overview.", "spec");
+    const real = await createDocDraft(memexId, "Real spec", "Real overview.", "spec");
+    await db
+      .update(documents)
+      .set({ isDemo: true })
+      .where(eq(documents.id, demo.id));
+
+    // Three activity rows: demo-doc-scoped, real-doc-scoped, memex-level (null).
+    const demoRowId = await insertActivity(memexId, demo.id, "edited the demo spec");
+    const realRowId = await insertActivity(memexId, real.id, "edited the real spec");
+    const memexRowId = await insertActivity(memexId, null, "memex-level event");
+
+    const rows = await listActivity({ memexId });
+    const ids = rows.map((r) => r.id);
+
+    // Demo-doc activity is excluded.
+    expect(ids).not.toContain(demoRowId);
+    // Non-demo + memex-level activity is kept.
+    expect(ids).toContain(realRowId);
+    expect(ids).toContain(memexRowId);
+    expect(rows).toHaveLength(2);
+  });
+
+  it("excludes demo activity even when filtering by that demo's briefId", async () => {
+    tagAc(AC(21));
+
+    const demo = await createDocDraft(memexId, "Demo spec 2", "Demo overview.", "spec");
+    await db
+      .update(documents)
+      .set({ isDemo: true })
+      .where(eq(documents.id, demo.id));
+    await insertActivity(memexId, demo.id, "edited the demo spec");
+
+    // Even a briefId-scoped query for the demo doc returns nothing — the demo
+    // exclusion is unconditional, not just a default-list filter.
+    const rows = await listActivity({ memexId, briefId: demo.id });
+    expect(rows).toHaveLength(0);
+  });
+
+  it("keeps a non-demo doc's activity that shares a memex with demo docs", async () => {
+    tagAc(AC(21));
+
+    const demo = await createDocDraft(memexId, "Demo spec 3", "Demo overview.", "spec");
+    const real = await createDocDraft(memexId, "Real spec 3", "Real overview.", "spec");
+    await db
+      .update(documents)
+      .set({ isDemo: true })
+      .where(eq(documents.id, demo.id));
+    await insertActivity(memexId, demo.id, "demo activity");
+    const realRowId = await insertActivity(memexId, real.id, "real activity");
+
+    const rows = await listActivity({ memexId, briefId: real.id });
+    expect(rows.map((r) => r.id)).toEqual([realRowId]);
+  });
+});
+
+describe("searchMemex — demo specs are excluded (ac-20)", () => {
+  it("does NOT return an is_demo spec from full-text search", async () => {
+    tagAc(AC(20));
+
+    const provider = makeFakeProvider();
+    // Unique FTS token so, were the doc NOT a demo, the content arm would
+    // deterministically surface it — the exclusion is what keeps it out.
+    const token = "handholddemoxyzsearchable";
+    const spec = await createDocDraft(
+      memexId,
+      "Handhold demo searchable spec",
+      `This demo overview mentions ${token} so FTS can find it.`,
+      "spec",
+    );
+    await addSection(memexId, spec.id, "scope", `In scope: ${token} coverage.`);
+    await db
+      .update(documents)
+      .set({ isDemo: true })
+      .where(eq(documents.id, spec.id));
+    await embedAndStoreDoc(spec.id, { provider });
+
+    // FTS-only (vector disabled) so the assertion does not depend on embedding
+    // geometry — the content token would resolve the doc if it weren't is_demo.
+    const ftsHits = await searchMemex(memexId, token, {
+      provider,
+      disableVector: true,
+    });
+    expect(ftsHits.find((h) => h.id === spec.id)).toBeUndefined();
+  });
+
+  it("does NOT return an is_demo spec via the handle short-circuit", async () => {
+    tagAc(AC(20));
+
+    const provider = makeFakeProvider();
+    const spec = await createDocDraft(
+      memexId,
+      "Handhold demo by handle",
+      "Overview.",
+      "spec",
+    );
+    await db
+      .update(documents)
+      .set({ isDemo: true })
+      .where(eq(documents.id, spec.id));
+    await embedAndStoreDoc(spec.id, { provider });
+
+    // Even an exact handle lookup must miss a demo spec — the handle
+    // short-circuit now carries the same `is_demo IS NOT TRUE` predicate.
+    const hits = await searchMemex(memexId, spec.handle, { provider });
+    expect(hits.find((h) => h.id === spec.id)).toBeUndefined();
+  });
+});

--- a/packages/server/src/services/activity-log.ts
+++ b/packages/server/src/services/activity-log.ts
@@ -17,9 +17,9 @@
 // awaited insert reject into the synchronous dispatch path. We log + swallow so
 // the originating mutation/read is never affected by a logging failure.
 
-import { and, desc, eq, lt } from "drizzle-orm";
+import { and, desc, eq, isNull, lt, ne, or } from "drizzle-orm";
 import { db, type Db } from "../db/connection.js";
-import { activityLog } from "../db/schema.js";
+import { activityLog, documents } from "../db/schema.js";
 import type { ActivityLog, ActivityLogInsert } from "../db/schema.js";
 import { bus, type ChangeEvent, type Unsubscribe } from "./bus.js";
 
@@ -184,6 +184,15 @@ const MAX_LIMIT = 200;
  * `since` to fetch the next batch.
  *
  * Backs the later GET /api/.../activity REST endpoint (t-? downstream).
+ *
+ * Handhold demo exclusion (spec-178 t-9 / ac-21): activity attributable to an
+ * `is_demo` document is filtered out of Pulse so the seeded onboarding specs
+ * never pollute the timeline/usage analytics. We LEFT JOIN the document the row
+ * references (`brief_id`) and keep a row only when it has NO doc (`brief_id IS
+ * NULL` — memex-level activity, always kept) OR its doc is not a demo. The
+ * filter runs on the READ path (not at persist time) because demo docs may
+ * pre-exist any persisted rows, and the demo seed/reset cycle can flip a doc's
+ * lifecycle independently of the activity already written.
  */
 export async function listActivity(
   opts: ListActivityOptions,
@@ -198,9 +207,33 @@ export async function listActivity(
   if (opts.clientId !== undefined) conditions.push(eq(activityLog.clientId, opts.clientId));
   if (opts.since !== undefined) conditions.push(lt(activityLog.createdAt, opts.since));
 
+  // Demo-exclusion predicate: keep memex-level rows (brief_id IS NULL) and rows
+  // whose referenced doc is NOT a demo. `ne(isDemo, true)` resolves to FALSE for
+  // demo docs and TRUE for non-demo docs; the brief_id-NULL arm keeps the LEFT
+  // JOIN's unmatched rows. (documents.is_demo is NOT NULL, so a three-valued-
+  // logic NULL only arises from the JOIN miss, already covered by the IS NULL arm.)
+  conditions.push(or(isNull(activityLog.briefId), ne(documents.isDemo, true))!);
+
   return conn
-    .select()
+    // Project the activity_log columns explicitly so a joined SELECT still
+    // returns a flat ActivityLog[] (a bare .select() over a join nests rows
+    // under table keys).
+    .select({
+      id: activityLog.id,
+      memexId: activityLog.memexId,
+      briefId: activityLog.briefId,
+      actorUserId: activityLog.actorUserId,
+      actorKind: activityLog.actorKind,
+      channel: activityLog.channel,
+      clientId: activityLog.clientId,
+      entity: activityLog.entity,
+      action: activityLog.action,
+      narrative: activityLog.narrative,
+      payload: activityLog.payload,
+      createdAt: activityLog.createdAt,
+    })
     .from(activityLog)
+    .leftJoin(documents, eq(activityLog.briefId, documents.id))
     .where(and(...conditions))
     // id as a stable tiebreaker so pagination is deterministic when several rows
     // share a created_at (a burst of events in the same millisecond).

--- a/packages/server/src/services/documents.ts
+++ b/packages/server/src/services/documents.ts
@@ -1,4 +1,4 @@
-import { and, eq, desc, count, isNull, inArray, or, exists, sql, type SQL } from "drizzle-orm";
+import { and, eq, ne, desc, count, isNull, inArray, or, exists, sql, type SQL } from "drizzle-orm";
 import { db } from "../db/connection.js";
 import { documents, docSections, docComments, decisions, users, tags, documentTags } from "../db/schema.js";
 import type { Doc, DocSection, Decision } from "../db/schema.js";
@@ -12,6 +12,7 @@ import { maybeAutoResolveIssuesForPromotedDoc } from "./issues.js";
 import { seedCreatorAsEditor } from "./doc-members.js";
 import { listAssigneesForDocs } from "./doc-assignees.js";
 import type { ParsedTag } from "./tags.js";
+import { HANDHOLD_PHASES } from "../db/handhold-demo.fixture.js";
 
 // Per-account handle sequence: doc-1, doc-2, ... within an account. Avoids cross-tenant
 // collisions on the (account_id, handle) unique constraint. Accepts a db OR tx client so
@@ -73,6 +74,15 @@ export interface CreateDocExtras {
   bodySections?: BodySectionInput[];
   /** Definition-of-done / acceptance criteria section, appended last when present. */
   acceptanceCriteria?: string;
+  /**
+   * spec-178 (issue-2): mark the new doc as a Handhold demo spec on the SAME insert
+   * that creates the row, so it reads is_demo=true from its first committed state.
+   * Without this the seeder created the row is_demo=false and flipped the flag only
+   * on a later terminal write — so an interrupted seed could leave a committed
+   * is_demo=false row that reads as a REAL spec (search/agent/board-visible) and
+   * survives the demo's idempotency guard + Reset. Defaults to false (real docs).
+   */
+  isDemo?: boolean;
 }
 
 export async function createDocDraft(
@@ -118,7 +128,7 @@ export async function createDocDraft(
       // tighten this.
       const [doc] = await db
         .insert(documents)
-        .values({ memexId, handle, title, docType, status: "draft", createdByUserId: createdByUserId ?? null })
+        .values({ memexId, handle, title, docType, status: "draft", createdByUserId: createdByUserId ?? null, isDemo: extras?.isDemo ?? false })
         .returning();
 
       // spec-118 dec-4: the creator becomes the Spec's first editor. On the MCP
@@ -259,6 +269,13 @@ export interface ListDocsOptions {
   // in one round-trip. Specs with no assignees leave `assignees` unset → the card
   // renders an "Unassigned" state.
   includeAssignees?: boolean;
+  // spec-178 t-11 / dec-11 (ac-37): when true, exclude is_demo docs from the
+  // result. Default falsy — the REST board route (routes/documents.ts) leaves
+  // this unset so the Specs board KEEPS rendering demo specs (with the DEMO
+  // badge). Only the MCP/agent `list_docs` path sets excludeDemo:true so a
+  // coding agent never sees a demo spec in its enumeration. Demo specs are
+  // invisible/inert to all agent surfaces but visible on the board.
+  excludeDemo?: boolean;
   // spec-136 t-3: narrow the result to docs carrying the given tags. Facet semantics
   // (dec-1): AND across different scopes, OR within a single scope; each flat (unscoped)
   // tag is its own AND clause. Resolved via an indexed (scope, value) join — no LIKE.
@@ -336,6 +353,14 @@ export async function listDocs(
   // Paused docs are included by default (React UI kanban renders them under a
   // "Show paused" toggle). MCP list_missions passes includePaused=false.
   if (opts.includePaused === false) conditions.push(isNull(documents.pausedAt));
+  // spec-178 t-11 / dec-11 (ac-37): exclude demo specs from the agent/MCP
+  // enumeration when asked. is_demo is NOT NULL DEFAULT false, but the
+  // `isNull OR ne(true)` guard is robust against any legacy NULL while still
+  // letting the board (excludeDemo falsy) keep its demo cards.
+  if (opts.excludeDemo) {
+    const notDemo = or(isNull(documents.isDemo), ne(documents.isDemo, true));
+    if (notDemo) conditions.push(notDemo);
+  }
   if (opts.statusIn && opts.statusIn.length > 0) {
     conditions.push(inArray(documents.status, opts.statusIn as string[]));
   }
@@ -359,6 +384,9 @@ export async function listDocs(
       // surface for the Specs kanban "Show paused" toggle.
       pausedAt: documents.pausedAt,
       archivedAt: documents.archivedAt,
+      // spec-178 t-1 (ac-9): is_demo rides on every DocSummary (like pausedAt/archivedAt)
+      // so the board can render the DEMO badge. Always projected — not behind an include opt.
+      isDemo: documents.isDemo,
       sectionCount: count(docSections.id),
       // LEFT JOIN — null when the doc predates migration 0036 or the creator
       // has been deleted (FK is ON DELETE SET NULL). The React UI renders
@@ -585,7 +613,16 @@ export async function getDoc(
   memexId: string,
   idOrHandle: string,
   opts: GetDocOptions = {},
-): Promise<Doc & { sections: DocSection[]; creator: { name: string | null; email: string | null } | null }> {
+): Promise<
+  Doc & {
+    sections: DocSection[];
+    creator: { name: string | null; email: string | null } | null;
+    // spec-178 dec-8 / ac-28: for is_demo docs, the per-phase value-banner copy
+    // (a fixture CONSTANT keyed by the doc's phase) the UI renders atop the demo
+    // spec. Unset for non-demo docs and for any demo phase with no callout.
+    demoValueCallout?: string;
+  }
+> {
   const idMatch = isUuid(idOrHandle)
     ? eq(documents.id, idOrHandle)
     : eq(documents.handle, idOrHandle);
@@ -624,6 +661,16 @@ export async function getDoc(
       .from(users)
       .where(eq(users.id, doc.createdByUserId));
     if (u) creator = u;
+  }
+
+  // spec-178 dec-8 / ac-28: a demo Spec carries its phase's value-banner copy from
+  // the fixture (a per-phase CONSTANT, never stored on the row). Non-demo docs are
+  // untouched — no field is attached, so the wire shape is identical for them.
+  if (doc.isDemo) {
+    const callout = HANDHOLD_PHASES.find((p) => p.phase === doc.status)?.valueCallout;
+    if (callout !== undefined) {
+      return { ...doc, sections, creator, demoValueCallout: callout };
+    }
   }
 
   return { ...doc, sections, creator };

--- a/packages/server/src/services/handhold-demo.integration.test.ts
+++ b/packages/server/src/services/handhold-demo.integration.test.ts
@@ -1,0 +1,540 @@
+// Integration tests for the handhold onboarding demo seed/reset/backfill (spec-178
+// t-2 / t-3 / t-5). DB-backed by design: seedHandholdDemo composes ~8 real service
+// primitives + the canonical-ref join that the verified-AC emission depends on, so a
+// pure unit test would pass while the join (and therefore the GREEN health) silently
+// broke. These assert against the same read paths the board + AC tab consume.
+//
+// Emission no-ops locally without MEMEX_EMIT_KEY — that's expected and irrelevant
+// here: the demo's synthetic emissions are written DIRECTLY via the seed's private
+// helper (mirroring the real /api/test-events route), not POSTed to prod.
+
+import { describe, it, expect, afterAll, beforeAll } from "vitest";
+import { eq, and, inArray, sql } from "drizzle-orm";
+import { db } from "../db/connection.js";
+import {
+  documents,
+  docSections,
+  decisions,
+  tasks,
+  acs,
+  testEvents,
+  testEventLatest,
+  activityLog,
+  namespaces,
+  memexes,
+  orgs,
+  users,
+} from "../db/schema.js";
+import type { ActivityLogInsert } from "../db/schema.js";
+import {
+  seedHandholdDemo,
+  resetHandholdDemo,
+  backfillHandholdDemo,
+} from "./handhold-demo.js";
+import { getDoc, createDocDraft } from "./documents.js";
+import { listActivity } from "./activity-log.js";
+import { aggregateAcHealthForBriefs, buildAcRef } from "./acs.js";
+import { makeTestMemex } from "./test-helpers.js";
+import {
+  HANDHOLD_TITLE,
+  HANDHOLD_PHASES,
+  HANDHOLD_DECISIONS,
+  HANDHOLD_TASKS,
+  HANDHOLD_ACS,
+} from "../db/handhold-demo.fixture.js";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+const SPEC = "mindset-prod/memex-building-itself/specs/spec-178";
+
+// Track every memex we make so afterAll can wipe its demo docs + emissions even if
+// an assertion throws mid-test.
+const memexIds: string[] = [];
+const userNamespaceIds: string[] = [];
+
+function uniqueSlug(prefix: string): string {
+  const tail = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+  return `${prefix}-${tail}`.toLowerCase().slice(0, 39);
+}
+
+// A personal (kind='user') namespace + memex — makeTestMemex makes an org-kind one,
+// which backfill (namespaces.kind='user') must NOT pick up. We build a user one by hand.
+async function makePersonalMemex(): Promise<{ memexId: string; namespaceId: string }> {
+  const [user] = await db
+    .insert(users)
+    .values({ email: `${uniqueSlug("hd-user")}@example.com`, name: "HD User" })
+    .returning();
+  const [ns] = await db
+    .insert(namespaces)
+    .values({ slug: uniqueSlug("hd-ns"), kind: "user", ownerUserId: user.id })
+    .returning();
+  const [memex] = await db
+    .insert(memexes)
+    .values({ namespaceId: ns.id, slug: "personal", name: "Personal" })
+    .returning();
+  userNamespaceIds.push(ns.id);
+  return { memexId: memex.id, namespaceId: ns.id };
+}
+
+// All ac_uids that could have been emitted under a memex's demo docs, so cleanup can
+// purge test_events / test_event_latest (no docId cascade on test_events).
+async function demoAcUids(memexId: string): Promise<string[]> {
+  const [slugRow] = await db
+    .select({ namespace: namespaces.slug, memex: memexes.slug })
+    .from(memexes)
+    .innerJoin(namespaces, eq(memexes.namespaceId, namespaces.id))
+    .where(eq(memexes.id, memexId))
+    .limit(1);
+  if (!slugRow) return [];
+  const docRows = await db
+    .select({ id: documents.id, handle: documents.handle })
+    .from(documents)
+    .where(and(eq(documents.memexId, memexId), eq(documents.isDemo, true)));
+  const handleById = new Map(docRows.map((d) => [d.id, d.handle]));
+  const docIds = docRows.map((d) => d.id);
+  if (docIds.length === 0) return [];
+  const acRows = await db
+    .select({ briefId: acs.briefId, seq: acs.seq })
+    .from(acs)
+    .where(and(eq(acs.memexId, memexId), inArray(acs.briefId, docIds)));
+  return acRows
+    .map((a) => {
+      const handle = handleById.get(a.briefId);
+      return handle
+        ? buildAcRef(
+            { namespace: slugRow.namespace, memex: slugRow.memex, briefHandle: handle },
+            a.seq,
+          )
+        : null;
+    })
+    .filter((u): u is string => u !== null);
+}
+
+afterAll(async () => {
+  for (const memexId of memexIds) {
+    const acUids = await demoAcUids(memexId).catch(() => []);
+    if (acUids.length) {
+      await db.delete(testEvents).where(inArray(testEvents.acUid, acUids)).catch(() => {});
+      await db.delete(testEventLatest).where(inArray(testEventLatest.acUid, acUids)).catch(() => {});
+    }
+    await db.delete(activityLog).where(eq(activityLog.memexId, memexId)).catch(() => {});
+    await db.delete(documents).where(eq(documents.memexId, memexId)).catch(() => {});
+  }
+  // namespaces cascade to memexes/orgs; user-namespace rows we made directly.
+  for (const nsId of userNamespaceIds) {
+    await db.delete(namespaces).where(eq(namespaces.id, nsId)).catch(() => {});
+  }
+});
+
+async function demoDocs(memexId: string) {
+  return db
+    .select()
+    .from(documents)
+    .where(and(eq(documents.memexId, memexId), eq(documents.isDemo, true)));
+}
+
+describe("seedHandholdDemo — the five frozen demo Specs", () => {
+  let memexId: string;
+
+  beforeAll(async () => {
+    memexId = await makeTestMemex("hd-seed");
+    memexIds.push(memexId);
+    await seedHandholdDemo(memexId);
+  });
+
+  it("seeds exactly five demo Specs, one per phase, all is_demo with the canonical title", async () => {
+    tagAc(`${SPEC}/acs/ac-10`);
+    const docs = await demoDocs(memexId);
+    expect(docs).toHaveLength(HANDHOLD_PHASES.length);
+    expect(docs.length).toBe(5);
+
+    // One demo doc per phase, all flagged + titled spec-64 verbatim.
+    const byPhase = new Map(docs.map((d) => [d.status, d]));
+    for (const slice of HANDHOLD_PHASES) {
+      const doc = byPhase.get(slice.phase);
+      expect(doc, `expected a demo doc at phase ${slice.phase}`).toBeDefined();
+      expect(doc!.isDemo).toBe(true);
+      expect(doc!.docType).toBe("spec");
+      expect(doc!.title).toBe(HANDHOLD_TITLE);
+    }
+    expect(byPhase.size).toBe(5);
+  });
+
+  it("composes phase-appropriate content: draft is overview-only; plan resolves decisions; build adds tasks", async () => {
+    tagAc(`${SPEC}/acs/ac-13`);
+    const docs = await demoDocs(memexId);
+    const byPhase = new Map(docs.map((d) => [d.status, d.id]));
+
+    // draft → overview only (no decisions, no tasks), exactly one section.
+    const draftId = byPhase.get("draft")!;
+    const draftSections = await db
+      .select()
+      .from(docSections)
+      .where(eq(docSections.docId, draftId));
+    expect(draftSections).toHaveLength(1);
+    expect(draftSections[0].sectionType).toBe("overview");
+    expect(
+      await db.select().from(decisions).where(eq(decisions.docId, draftId)),
+    ).toHaveLength(0);
+    expect(await db.select().from(tasks).where(eq(tasks.docId, draftId))).toHaveLength(0);
+
+    // plan → all sections + all decisions RESOLVED, but still no tasks.
+    const planId = byPhase.get("plan")!;
+    const planDecisions = await db
+      .select()
+      .from(decisions)
+      .where(eq(decisions.docId, planId));
+    expect(planDecisions).toHaveLength(HANDHOLD_DECISIONS.length);
+    expect(planDecisions.every((d) => d.status === "resolved")).toBe(true);
+    expect(planDecisions.every((d) => !!d.resolution)).toBe(true);
+    expect(await db.select().from(tasks).where(eq(tasks.docId, planId))).toHaveLength(0);
+
+    // build → tasks present (not complete), decisions still resolved, no ACs yet.
+    const buildId = byPhase.get("build")!;
+    const buildTasks = await db.select().from(tasks).where(eq(tasks.docId, buildId));
+    expect(buildTasks).toHaveLength(HANDHOLD_TASKS.length);
+    expect(buildTasks.every((t) => t.status !== "complete")).toBe(true);
+    expect(await db.select().from(acs).where(eq(acs.briefId, buildId))).toHaveLength(0);
+  });
+
+  it("verify & done surface the spec-level ACs, with completed tasks", async () => {
+    tagAc(`${SPEC}/acs/ac-22`);
+    const docs = await demoDocs(memexId);
+    const byPhase = new Map(docs.map((d) => [d.status, d.id]));
+
+    for (const phase of ["verify", "done"] as const) {
+      const docId = byPhase.get(phase)!;
+      const acRows = await db.select().from(acs).where(eq(acs.briefId, docId));
+      expect(acRows.length).toBe(HANDHOLD_ACS.length);
+      expect(acRows.every((a) => a.kind === "implementation")).toBe(true);
+      expect(acRows.every((a) => a.status === "active")).toBe(true);
+
+      const taskRows = await db.select().from(tasks).where(eq(tasks.docId, docId));
+      expect(taskRows).toHaveLength(HANDHOLD_TASKS.length);
+      expect(taskRows.every((t) => t.status === "complete")).toBe(true);
+    }
+  });
+
+  it("verify & done ACs read GREEN — every active AC is verified via aggregateAcHealthForBriefs (dec-9)", async () => {
+    tagAc(`${SPEC}/acs/ac-30`);
+    tagAc(`${SPEC}/acs/ac-31`);
+    const docs = await demoDocs(memexId);
+    const byPhase = new Map(docs.map((d) => [d.status, d.id]));
+    const verifyDoneIds = [byPhase.get("verify")!, byPhase.get("done")!];
+
+    const health = await aggregateAcHealthForBriefs(memexId, verifyDoneIds);
+    for (const id of verifyDoneIds) {
+      const h = health.get(id)!;
+      expect(h.totalActive).toBe(HANDHOLD_ACS.length);
+      // Every AC verified, none failing/stale/untested → the card is unambiguously GREEN.
+      expect(h.verified).toBe(HANDHOLD_ACS.length);
+      expect(h.failing).toBe(0);
+      expect(h.stale).toBe(0);
+      expect(h.untested).toBe(0);
+    }
+  });
+
+  it("getDoc attaches the per-phase value banner only for demo docs (dec-8 / ac-28)", async () => {
+    tagAc(`${SPEC}/acs/ac-28`);
+    const docs = await demoDocs(memexId);
+    for (const slice of HANDHOLD_PHASES) {
+      const doc = docs.find((d) => d.status === slice.phase)!;
+      const fetched = await getDoc(memexId, doc.id);
+      expect(fetched.demoValueCallout).toBe(slice.valueCallout);
+    }
+  });
+
+  it("is idempotent — re-seeding an already-seeded memex adds no sixth doc (ac-8)", async () => {
+    tagAc(`${SPEC}/acs/ac-8`);
+    const before = await demoDocs(memexId);
+    expect(before).toHaveLength(5);
+    await seedHandholdDemo(memexId);
+    await seedHandholdDemo(memexId);
+    const after = await demoDocs(memexId);
+    expect(after).toHaveLength(5);
+    // The very same rows — no churn (ids stable).
+    expect(new Set(after.map((d) => d.id))).toEqual(new Set(before.map((d) => d.id)));
+  });
+});
+
+describe("resetHandholdDemo", () => {
+  it("wipes user edits, re-seeds five, and leaves no orphan test_events (ac-14 / ac-15)", async () => {
+    tagAc(`${SPEC}/acs/ac-14`);
+    tagAc(`${SPEC}/acs/ac-15`);
+    const memexId = await makeTestMemex("hd-reset");
+    memexIds.push(memexId);
+    await seedHandholdDemo(memexId);
+
+    const before = await demoDocs(memexId);
+    expect(before).toHaveLength(5);
+    const beforeIds = new Set(before.map((d) => d.id));
+
+    // Simulate a user mucking with a demo doc: rename it + delete a section.
+    const victim = before[0];
+    await db.update(documents).set({ title: "USER EDIT" }).where(eq(documents.id, victim.id));
+    await db.delete(docSections).where(eq(docSections.docId, victim.id));
+
+    // The demo's ac_uids are deterministic (handle + ac seq) so a re-seed reuses
+    // the SAME uids. The orphan test is therefore about COUNT, not presence: after
+    // reset there must be EXACTLY one emission (+ one summary) per verify/done AC —
+    // the old rows purged and not doubled-up — proving the explicit delete ran
+    // (test_events has no docId cascade).
+    const acUids = await demoAcUids(memexId);
+    expect(acUids.length).toBeGreaterThan(0);
+    const expectedEmissions = HANDHOLD_ACS.length * 2; // verify + done
+    const logBefore = await db
+      .select()
+      .from(testEvents)
+      .where(inArray(testEvents.acUid, acUids));
+    expect(logBefore).toHaveLength(expectedEmissions);
+
+    const result = await resetHandholdDemo(memexId);
+    expect(result.seeded).toBe(5);
+
+    const after = await demoDocs(memexId);
+    expect(after).toHaveLength(5);
+    // Fresh docs: the edited doc is gone (new ids), titles all back to canonical.
+    expect(after.every((d) => d.title === HANDHOLD_TITLE)).toBe(true);
+    expect(after.some((d) => beforeIds.has(d.id))).toBe(false);
+
+    // No doubling: still exactly one emission + one summary row per verify/done AC.
+    // Had the reset skipped the explicit test_events delete, this would be 2×.
+    const acUidsAfter = await demoAcUids(memexId);
+    const orphanLog = await db
+      .select()
+      .from(testEvents)
+      .where(inArray(testEvents.acUid, acUidsAfter));
+    expect(orphanLog).toHaveLength(expectedEmissions);
+    const orphanSummary = await db
+      .select()
+      .from(testEventLatest)
+      .where(inArray(testEventLatest.acUid, acUidsAfter));
+    expect(orphanSummary).toHaveLength(expectedEmissions);
+
+    // The freshly re-seeded verify/done ACs are GREEN again.
+    const byPhase = new Map(after.map((d) => [d.status, d.id]));
+    const health = await aggregateAcHealthForBriefs(memexId, [
+      byPhase.get("verify")!,
+      byPhase.get("done")!,
+    ]);
+    for (const id of [byPhase.get("verify")!, byPhase.get("done")!]) {
+      expect(health.get(id)!.verified).toBe(HANDHOLD_ACS.length);
+    }
+  });
+});
+
+describe("backfillHandholdDemo", () => {
+  it("seeds personal (user) memexes idempotently; org memexes are untouched (ac-16 / ac-32)", async () => {
+    tagAc(`${SPEC}/acs/ac-16`);
+    tagAc(`${SPEC}/acs/ac-32`);
+
+    // Two fresh personal memexes (kind='user') with no demo docs yet.
+    const a = await makePersonalMemex();
+    const b = await makePersonalMemex();
+    memexIds.push(a.memexId, b.memexId);
+
+    // An org memex (kind='org') that must NOT be backfilled.
+    const orgMemexId = await makeTestMemex("hd-org");
+    memexIds.push(orgMemexId);
+
+    await backfillHandholdDemo();
+
+    // Both personal memexes now hold the five demo Specs.
+    expect(await demoDocs(a.memexId)).toHaveLength(5);
+    expect(await demoDocs(b.memexId)).toHaveLength(5);
+    // The org memex was skipped entirely.
+    expect(await demoDocs(orgMemexId)).toHaveLength(0);
+
+    // Idempotent: a second backfill seeds nothing new (both already have demo docs).
+    const second = await backfillHandholdDemo();
+    expect(second.memexesSeeded).toBe(0);
+    expect(await demoDocs(a.memexId)).toHaveLength(5);
+    expect(await demoDocs(b.memexId)).toHaveLength(5);
+  });
+});
+
+// issue-2 / t-13 (H2): the seed is not atomic — a partial/interrupted seed must not
+// permanently wedge the idempotency guard, and a demo doc must be is_demo from its
+// first committed state (no search/agent-visible is_demo=false orphan window).
+describe("seedHandholdDemo — atomicity / self-healing guard (ac-40)", () => {
+  it("self-heals a partial demo set to exactly five instead of treating it as already-seeded", async () => {
+    tagAc(`${SPEC}/acs/ac-40`);
+    const mx = await makeTestMemex("hd-selfheal");
+    memexIds.push(mx);
+    await seedHandholdDemo(mx);
+    const full = await demoDocs(mx);
+    expect(full).toHaveLength(5);
+
+    // Simulate an interrupted seed: drop the draft + plan demo docs (neither carries
+    // ACs/emissions), leaving 3 of 5 behind.
+    const byPhase = new Map(full.map((d) => [d.status, d.id]));
+    await db
+      .delete(documents)
+      .where(inArray(documents.id, [byPhase.get("draft")!, byPhase.get("plan")!]));
+    expect(await demoDocs(mx)).toHaveLength(3);
+
+    // The old guard ("any is_demo doc exists → skip") would leave this wedged at 3
+    // forever. The count-aware guard detects 3 ≠ 5 and re-seeds a fresh full set.
+    await seedHandholdDemo(mx);
+    const healed = await demoDocs(mx);
+    expect(healed).toHaveLength(5);
+    expect(new Set(healed.map((d) => d.status))).toEqual(
+      new Set(["draft", "plan", "build", "verify", "done"]),
+    );
+  });
+
+  it("createDocDraft persists is_demo=true atomically at creation (no is_demo=false orphan window)", async () => {
+    tagAc(`${SPEC}/acs/ac-40`);
+    const mx = await makeTestMemex("hd-flagcreate");
+    memexIds.push(mx);
+    // The seeder builds demo docs with is_demo set on the SAME insert as the row —
+    // so even a crash before the terminal phase-flip leaves a proper demo doc
+    // (excluded/badged/resettable), never a fake real spec.
+    const created = await createDocDraft(mx, HANDHOLD_TITLE, "overview", "spec", undefined, {
+      isDemo: true,
+    });
+    const [row] = await db.select().from(documents).where(eq(documents.id, created.id));
+    expect(row.isDemo).toBe(true);
+  });
+});
+
+// issue-1 / t-12 (H1): activity_log.brief_id is ON DELETE SET NULL, so demo-doc
+// activity that survives a Reset's hard-delete re-surfaces as memex-level activity
+// and leaks into Pulse. Reset must delete the demo docs' activity_log rows.
+describe("resetHandholdDemo — clears demo activity so it cannot leak into Pulse (ac-39)", () => {
+  it("deletes the demo docs' activity_log rows on reset (brief_id SET NULL would otherwise re-surface them)", async () => {
+    tagAc(`${SPEC}/acs/ac-39`);
+    const mx = await makeTestMemex("hd-pulse-leak");
+    memexIds.push(mx);
+    await seedHandholdDemo(mx);
+    const demoIds = (await demoDocs(mx)).map((d) => d.id);
+    expect(demoIds).toHaveLength(5);
+
+    // Simulate the seed-time activity the bus sink writes against a demo doc.
+    const marker = `demo-seed-activity-${Date.now()}`;
+    const row: ActivityLogInsert = {
+      memexId: mx,
+      briefId: demoIds[0],
+      actorKind: "system",
+      channel: "server",
+      entity: "document",
+      action: "updated",
+      narrative: marker,
+    };
+    await db.insert(activityLog).values(row);
+    // Steady state: excluded while the demo doc is live (is_demo=true).
+    expect((await listActivity({ memexId: mx })).some((r) => r.narrative === marker)).toBe(false);
+
+    await resetHandholdDemo(mx);
+
+    // The demo doc is hard-deleted; without the fix brief_id → NULL and the row
+    // re-surfaces as memex-level activity. The fix deletes it during reset.
+    const after = await listActivity({ memexId: mx });
+    expect(after.some((r) => r.narrative === marker)).toBe(false);
+    // Defensive: no doc-scoped activity leaked with a nulled brief_id.
+    expect(after.some((r) => r.briefId === null && r.entity !== "memex")).toBe(false);
+  });
+});
+
+// t-1 (ac-9): the migration's column contract — is_demo is NOT NULL DEFAULT false,
+// so every pre-existing doc (created before the migration / without setting it) reads
+// false, and the column can never hold NULL.
+describe("documents.is_demo column contract (ac-9)", () => {
+  it("is NOT NULL DEFAULT false — a row created without is_demo reads false; setting it NULL is rejected", async () => {
+    tagAc(`${SPEC}/acs/ac-9`);
+    const mx = await makeTestMemex("hd-isdemo-col");
+    memexIds.push(mx);
+
+    // DEFAULT false: insert a documents row WITHOUT mentioning is_demo — exactly the
+    // shape of every row that existed before the migration. It must read back false.
+    const [row] = await db
+      .insert(documents)
+      .values({
+        memexId: mx,
+        handle: `spec-coltest-${Date.now()}`,
+        title: "is_demo column test",
+        docType: "spec",
+        status: "draft",
+      })
+      .returning();
+    expect(row.isDemo).toBe(false);
+
+    // NOT NULL: forcing is_demo to NULL is rejected by the column constraint (23502).
+    await expect(
+      db.execute(sql`UPDATE documents SET is_demo = NULL WHERE id = ${row.id}`),
+    ).rejects.toThrow();
+  });
+});
+
+// dec-8 (ac-29): the per-phase value banner is SERVED as a fixture constant keyed by
+// phase — it is NOT persisted on the demo document (no new column beyond is_demo, and
+// not stored as a section). ac-26/ac-28 prove getDoc returns it; this pins the negative
+// contract a regression (adding a value_callout column + reading from it) would violate.
+describe("value banner is served from the fixture, not stored on the doc (ac-29)", () => {
+  it("documents has no callout column (only is_demo was added), and no demo doc stores the callout text as a section", async () => {
+    tagAc(`${SPEC}/acs/ac-29`);
+
+    // (1) No callout/banner column was added to documents — only is_demo (ac-9).
+    const cols = (await db.execute(sql`
+      SELECT column_name FROM information_schema.columns
+      WHERE table_name = 'documents'
+    `)) as unknown as { column_name: string }[];
+    const names = cols.map((c) => c.column_name);
+    expect(names).toContain("is_demo");
+    expect(names.some((n) => /callout|banner|value_call/i.test(n))).toBe(false);
+
+    // (2) Seed a demo; getDoc returns the per-phase callout sourced from the fixture…
+    const mx = await makeTestMemex("hd-callout-store");
+    memexIds.push(mx);
+    await seedHandholdDemo(mx);
+    const docs = await demoDocs(mx);
+    for (const slice of HANDHOLD_PHASES) {
+      const doc = docs.find((d) => d.status === slice.phase)!;
+      const fetched = await getDoc(mx, doc.id);
+      expect(fetched.demoValueCallout).toBe(slice.valueCallout);
+    }
+
+    // (3) …but the callout text is NOT persisted as a section on ANY demo doc — it
+    // lives only in the fixture, served at read time.
+    const sectionRows = await db
+      .select()
+      .from(docSections)
+      .where(inArray(docSections.docId, docs.map((d) => d.id)));
+    const calloutTexts = new Set(HANDHOLD_PHASES.map((p) => p.valueCallout));
+    expect(sectionRows.some((s) => calloutTexts.has(s.content))).toBe(false);
+  });
+});
+
+// dec-6 (ac-23): the demo ships ON-BY-DEFAULT — seeding (signup hook + backfill) and
+// Reset are conditioned on NO feature flag, so they run in every environment even when
+// HIDDEN_FEATURES is set (the soft-launch switch hiding Scaffold/pause/Pulse). This
+// guards the launch-critical "always on" contract against a future regression that
+// wires the demo behind HIDDEN_FEATURES and silently disables it wherever that var is
+// set — the exact footgun dec-6 rejected.
+describe("Handhold demo is on-by-default — not gated by any feature flag (ac-23)", () => {
+  let priorHiddenFeatures: string | undefined;
+  beforeAll(() => {
+    priorHiddenFeatures = process.env.HIDDEN_FEATURES;
+    // Hide everything we plausibly could, including a hypothetical 'handhold' token —
+    // if the seed/reset paths read this flag at all, the assertions below would fail.
+    process.env.HIDDEN_FEATURES = "handhold,scaffold,pause,pulse";
+  });
+  afterAll(() => {
+    if (priorHiddenFeatures === undefined) delete process.env.HIDDEN_FEATURES;
+    else process.env.HIDDEN_FEATURES = priorHiddenFeatures;
+  });
+
+  it("seeds and resets regardless of HIDDEN_FEATURES — the seed/reset paths read no flag", async () => {
+    tagAc(`${SPEC}/acs/ac-23`);
+    const mx = await makeTestMemex("hd-noflag");
+    memexIds.push(mx);
+
+    // Seeding runs with HIDDEN_FEATURES set → still produces the 5 demo specs.
+    await seedHandholdDemo(mx);
+    expect(await demoDocs(mx)).toHaveLength(5);
+
+    // Reset runs with HIDDEN_FEATURES set → still re-seeds the 5.
+    const result = await resetHandholdDemo(mx);
+    expect(result.seeded).toBe(5);
+    expect(await demoDocs(mx)).toHaveLength(5);
+  });
+});

--- a/packages/server/src/services/handhold-demo.ts
+++ b/packages/server/src/services/handhold-demo.ts
@@ -1,0 +1,391 @@
+// Handhold onboarding demo — seed / reset / backfill (spec-178 t-2 / t-3 / t-5).
+//
+// Seeds every personal Memex with five frozen copies of spec-64 ("In-app Memex
+// search (⌘K)"), one per phase (draft / plan / build / verify / done), so a new
+// user can walk the whole Spec lifecycle on real content. The canonical content
+// lives ONCE in db/handhold-demo.fixture.ts; this module maps it through the
+// existing service primitives (createDocDraft / addSection / createDecision /
+// resolveDecision / createTask / updateTaskStatus / createAc / updateDocStatus —
+// each already wraps mutate() + emits, std-8) and flips documents.is_demo=true.
+//
+// The five demo Specs are EXCLUDED from ⌘K/searchMemex and every agent surface
+// (dec-11, which reverses the earlier dec-5/ac-20 "searchable" posture) — that
+// exclusion lives in memex-search.ts + the MCP/agent ref-resolvers, NOT here. Their
+// per-card AC health shows GREEN at verify/done (dec-9) — so this module does NOT
+// touch memex-search or aggregateAcHealthForBriefs; it just writes real rows the
+// existing board read paths (REST listDocs/getDoc) already understand. The ONLY
+// demo-specific shaping is the is_demo flag (badge + banner, owned by the UI agent)
+// and the per-phase value banner (attached by getDoc).
+
+import { and, eq, inArray } from "drizzle-orm";
+import { db } from "../db/connection.js";
+import {
+  documents,
+  namespaces,
+  memexes,
+  testEvents,
+  testEventLatest,
+  activityLog,
+} from "../db/schema.js";
+import { mutate } from "./mutate.js";
+import { createDocDraft } from "./documents.js";
+import { addSection } from "./sections.js";
+import { createDecision, resolveDecision } from "./decisions.js";
+import { createTask, updateTaskStatus, type AcceptanceCriterion } from "./tasks.js";
+import { createAc, buildAcRef } from "./acs.js";
+import { applyEmissionToSummary } from "./test-event-latest.js";
+import {
+  HANDHOLD_TITLE,
+  HANDHOLD_SECTIONS,
+  HANDHOLD_DECISIONS,
+  HANDHOLD_TASKS,
+  HANDHOLD_ACS,
+  HANDHOLD_PHASES,
+  type HandholdPhaseSlice,
+} from "../db/handhold-demo.fixture.js";
+
+// The synthetic emission's test_identifier. A single stable label so reset can
+// target it explicitly if ever needed, and so it's recognisable in the matrix
+// view as demo-seeded rather than a real CI run.
+const HANDHOLD_TEST_IDENTIFIER = "handhold-demo";
+
+// Map the fixture's section keys (other than `overview`, which is the doc purpose
+// / first "Overview" section seeded by createDocDraft) to a section_type slug +
+// human title for addSection. Kept here, not in the fixture, because it's a
+// seed-mechanics concern, not content.
+const SECTION_META: Record<
+  keyof typeof HANDHOLD_SECTIONS,
+  { sectionType: string; title: string }
+> = {
+  overview: { sectionType: "overview", title: "Overview" },
+  scope: { sectionType: "scope", title: "Scope" },
+  approach: { sectionType: "approach", title: "Approach" },
+  nonGoals: { sectionType: "non-goals", title: "Non-goals" },
+  architectureSecurity: {
+    sectionType: "architecture-security",
+    title: "Architecture & security",
+  },
+};
+
+// Resolve namespace.slug + memex.slug for a memex so we can build canonical AC
+// refs (ac_uid) identically to acs.ts. One round-trip per seed (only used when a
+// phase includes ACs).
+async function resolveMemexSlugs(
+  memexId: string,
+): Promise<{ namespace: string; memex: string }> {
+  const [row] = await db
+    .select({ namespace: namespaces.slug, memex: memexes.slug })
+    .from(memexes)
+    .innerJoin(namespaces, eq(memexes.namespaceId, namespaces.id))
+    .where(eq(memexes.id, memexId))
+    .limit(1);
+  if (!row) {
+    throw new Error(`Memex ${memexId} not found while seeding handhold demo`);
+  }
+  return row;
+}
+
+// Private mirror of test-helpers.ts:seedTestEvent — production code must NOT import
+// the test-only helper (per the grounding note). Insert a passing test_events log
+// row AND maintain its test_event_latest summary in ONE transaction, so the badge
+// read paths (aggregateAcHealthForBriefs / listAcsForBriefWithVerification) see the
+// emission as soon as the seed commits. Mirrors the real emission route (spec-162).
+async function seedPassingEmission(acUid: string): Promise<void> {
+  await db.transaction(async (tx) => {
+    const [row] = await tx
+      .insert(testEvents)
+      .values({
+        acUid,
+        status: "pass",
+        testIdentifier: HANDHOLD_TEST_IDENTIFIER,
+        hidden: false,
+      })
+      .returning({ createdAt: testEvents.createdAt });
+    await applyEmissionToSummary(tx, {
+      acUid,
+      testIdentifier: HANDHOLD_TEST_IDENTIFIER,
+      status: "pass",
+      latestRunAt: row.createdAt,
+      hidden: false,
+    });
+  });
+}
+
+// Build ONE frozen demo Spec for a phase slice. Returns the created doc id.
+//
+// Order matters:
+//   1. createDocDraft (status=draft, "Overview" seeded from HANDHOLD_SECTIONS.overview)
+//   2. add the other includeSections via addSection
+//   3. if includeDecisions: createDecision → resolveDecision(chosen) for each
+//   4. if includeTasks: createTask for each (ACs mapped from .acs, done=tasksComplete);
+//      if tasksComplete, updateTaskStatus('complete'). Done WHILE the doc is still
+//      'draft' so the build→verify auto-promote (tasks.ts:maybeAutoPromoteToVerify)
+//      can't fire and clobber the phase we set in step 6.
+//   5. if includeAcs: createAc for each HANDHOLD_ACS (kind 'implementation', active)
+//   6. ONE mutate() flips is_demo=true + status=phase + statusChangedAt=now.
+//   7. if includeAcs: now that the doc carries its final handle and the ACs have
+//      seqs, build each ac_uid and write a passing emission so it reads 'verified'.
+async function seedOnePhase(
+  memexId: string,
+  slice: HandholdPhaseSlice,
+  slugs: { namespace: string; memex: string } | null,
+): Promise<string> {
+  const created = await createDocDraft(
+    memexId,
+    HANDHOLD_TITLE,
+    HANDHOLD_SECTIONS.overview,
+    "spec",
+    undefined,
+    // issue-2: flag is_demo on the SAME insert that creates the row, so the doc is
+    // is_demo=true from its first committed state. If the seed is interrupted before
+    // the terminal phase-flip below, the leftover is a proper demo doc (excluded from
+    // search/agents, badged, removable by Reset), never a search-visible fake real spec.
+    { isDemo: true },
+  );
+  const docId = created.id;
+
+  // Sections beyond `overview` (which createDocDraft already seeded as the first
+  // "Overview" section from the purpose argument).
+  for (const key of slice.includeSections) {
+    if (key === "overview") continue;
+    const meta = SECTION_META[key];
+    await addSection(memexId, docId, meta.sectionType, HANDHOLD_SECTIONS[key], meta.title);
+  }
+
+  if (slice.includeDecisions) {
+    for (const dec of HANDHOLD_DECISIONS) {
+      const createdDec = await createDecision(memexId, docId, dec.title, dec.context);
+      await resolveDecision(memexId, createdDec.id, dec.chosen);
+    }
+  }
+
+  if (slice.includeTasks) {
+    for (const task of HANDHOLD_TASKS) {
+      const acceptanceCriteria: AcceptanceCriterion[] = task.acs.map((description) => ({
+        description,
+        done: slice.tasksComplete,
+      }));
+      const createdTask = await createTask(
+        memexId,
+        docId,
+        task.title,
+        task.body,
+        acceptanceCriteria,
+      );
+      if (slice.tasksComplete) {
+        // Safe to complete here: the doc is still 'draft', so updateTaskStatus's
+        // build→verify auto-promote (which only fires on a 'build' Spec) is inert.
+        await updateTaskStatus(memexId, createdTask.id, "complete");
+      }
+    }
+  }
+
+  const createdAcSeqs: number[] = [];
+  if (slice.includeAcs) {
+    for (const ac of HANDHOLD_ACS) {
+      const createdAc = await createAc({
+        memexId,
+        briefId: docId,
+        kind: ac.kind,
+        statement: ac.statement,
+      });
+      createdAcSeqs.push(createdAc.seq);
+    }
+  }
+
+  // One terminal write that lands the target phase. is_demo is already true from
+  // creation (issue-2), so re-setting it here is idempotent belt-and-suspenders —
+  // the load-bearing change is the status flip. Goes through mutate() (std-8) so the
+  // document.updated event fires for live UIs.
+  await mutate(
+    {},
+    { memexId, docId, entity: "document", action: "updated" },
+    async () => {
+      const [row] = await db
+        .update(documents)
+        .set({ isDemo: true, status: slice.phase, statusChangedAt: new Date() })
+        .where(and(eq(documents.id, docId), eq(documents.memexId, memexId)))
+        .returning();
+      return row;
+    },
+  );
+
+  // verify / done: each AC reads 'verified' via a synthetic passing emission
+  // keyed by its canonical ac_uid (dec-9 / ac-30 / ac-31). Built AFTER the doc is
+  // at its phase so the handle + ac seqs that compose the ref already exist.
+  if (slice.includeAcs && createdAcSeqs.length > 0) {
+    const resolvedSlugs = slugs ?? (await resolveMemexSlugs(memexId));
+    for (const seq of createdAcSeqs) {
+      const acUid = buildAcRef(
+        {
+          namespace: resolvedSlugs.namespace,
+          memex: resolvedSlugs.memex,
+          briefHandle: created.handle,
+        },
+        seq,
+      );
+      await seedPassingEmission(acUid);
+    }
+  }
+
+  return docId;
+}
+
+// List the memex's is_demo doc ids. Includes archived/paused — reset/idempotency
+// must see EVERY demo doc, not just the active ones.
+async function listDemoDocIds(memexId: string): Promise<string[]> {
+  const rows = await db
+    .select({ id: documents.id })
+    .from(documents)
+    .where(and(eq(documents.memexId, memexId), eq(documents.isDemo, true)));
+  return rows.map((r) => r.id);
+}
+
+/**
+ * Idempotently seed the five frozen demo Specs into `memexId`.
+ *
+ * NO-OP if the memex already has any is_demo document (the guard makes backfill
+ * + reset + repeated calls safe). Builds one frozen copy per HANDHOLD_PHASES
+ * entry; sets documents.is_demo=true + the phase status on each.
+ */
+export async function seedHandholdDemo(memexId: string): Promise<void> {
+  const existing = await listDemoDocIds(memexId);
+  // Idempotency + self-healing (issue-2): a memex holding the EXACT full set is
+  // already seeded → no-op. Any OTHER non-zero count is a NON-canonical leftover —
+  // a partial set from an interrupted seed, or a doubled set from a signup×backfill
+  // race. The old guard ("any is_demo doc exists → skip") mistook those for "seeded"
+  // and left them permanently wedged (a 3-of-5 demo, or a 10-doc double). Clear the
+  // leftover (docs + their emissions + activity) and re-seed a clean set, so any
+  // partial/doubled state converges to exactly five on the next seed invocation
+  // (signup, deploy backfill, or Reset).
+  if (existing.length === HANDHOLD_PHASES.length) return;
+  if (existing.length > 0) await clearDemoDocs(memexId, existing);
+
+  // Resolve slugs once up-front IFF any phase needs ACs (so we build refs without
+  // a per-phase round-trip). Phases without ACs never touch this.
+  const anyAcs = HANDHOLD_PHASES.some((p) => p.includeAcs);
+  const slugs = anyAcs ? await resolveMemexSlugs(memexId) : null;
+
+  for (const slice of HANDHOLD_PHASES) {
+    await seedOnePhase(memexId, slice, slugs);
+  }
+}
+
+/**
+ * Tear down a set of demo docs completely, in the order their tables require:
+ *  1. the synthetic AC emissions keyed to them — test_events / test_event_latest
+ *     have NO docId cascade (dec-9), so they must be removed explicitly;
+ *  2. the activity_log rows that reference them — brief_id is ON DELETE SET NULL,
+ *     so leaving them would null brief_id on the hard-delete below and re-surface
+ *     seeded demo activity in Pulse as memex-level activity, defeating the ac-21
+ *     exclusion (which keys off a live join to the now-deleted doc) (issue-1 / ac-39);
+ *  3. the documents themselves — doc_sections / decisions / tasks / acs / doc_comments
+ *     cascade via the docId FKs.
+ * One mutate() per doc keeps the std-8 'document deleted' emission so live boards
+ * refresh. Shared by resetHandholdDemo and seedHandholdDemo's self-heal.
+ */
+async function clearDemoDocs(memexId: string, demoDocIds: string[]): Promise<void> {
+  if (demoDocIds.length === 0) return;
+
+  // Compute the ac_uids for every AC under the demo docs BEFORE deleting the docs
+  // (deleting cascades the acs rows away, so we can't resolve seqs after).
+  const slugs = await resolveMemexSlugs(memexId);
+  const docRows = await db
+    .select({ id: documents.id, handle: documents.handle })
+    .from(documents)
+    .where(and(eq(documents.memexId, memexId), inArray(documents.id, demoDocIds)));
+  const handleByDocId = new Map(docRows.map((d) => [d.id, d.handle]));
+
+  const { acs } = await import("../db/schema.js");
+  const acRows = await db
+    .select({ briefId: acs.briefId, seq: acs.seq })
+    .from(acs)
+    .where(and(eq(acs.memexId, memexId), inArray(acs.briefId, demoDocIds)));
+
+  const acUids = acRows
+    .map((a) => {
+      const handle = handleByDocId.get(a.briefId);
+      if (!handle) return null;
+      return buildAcRef(
+        { namespace: slugs.namespace, memex: slugs.memex, briefHandle: handle },
+        a.seq,
+      );
+    })
+    .filter((u): u is string => u !== null);
+
+  if (acUids.length > 0) {
+    // Delete the log rows AND the derived summary rows so no orphaned emission or
+    // stale 'latest' survives (test_events has no docId cascade).
+    await db.delete(testEvents).where(inArray(testEvents.acUid, acUids));
+    await db.delete(testEventLatest).where(inArray(testEventLatest.acUid, acUids));
+  }
+
+  // issue-1 / ac-39: drop the demo docs' activity_log rows BEFORE the hard-delete.
+  // brief_id is ON DELETE SET NULL, so leaving them would null brief_id and leak the
+  // seeded demo activity into Pulse as memex-level activity. Scoped to this memex.
+  await db
+    .delete(activityLog)
+    .where(and(eq(activityLog.memexId, memexId), inArray(activityLog.briefId, demoDocIds)));
+
+  // Hard-delete the demo documents. One mutate() per doc keeps the std-8 emission
+  // contract (a 'document deleted' event each).
+  for (const id of demoDocIds) {
+    await mutate(
+      {},
+      { memexId, docId: id, entity: "document", action: "deleted" },
+      async () => {
+        const [row] = await db
+          .delete(documents)
+          .where(and(eq(documents.id, id), eq(documents.memexId, memexId)))
+          .returning();
+        return row;
+      },
+    );
+  }
+}
+
+/**
+ * Hard-reset the demo in `memexId`: unconditionally tear down every is_demo doc
+ * (plus the emissions + activity that reference them — see clearDemoDocs), then
+ * re-seed from the fixture.
+ *
+ * Unlike seedHandholdDemo (which treats a full set as already-seeded), reset always
+ * rebuilds — it is the viewer's "discard my edits and restore a pristine demo" button.
+ *
+ * Returns { seeded } — the count of demo Specs after the re-seed (5).
+ */
+export async function resetHandholdDemo(memexId: string): Promise<{ seeded: number }> {
+  const demoDocIds = await listDemoDocIds(memexId);
+  await clearDemoDocs(memexId, demoDocIds);
+  // Re-seed from the fixture. seedHandholdDemo now sees zero demo docs.
+  await seedHandholdDemo(memexId);
+  return { seeded: HANDHOLD_PHASES.length };
+}
+
+/**
+ * Backfill: seed the demo into every PERSONAL Memex that doesn't already have it.
+ *
+ * Iterates personal namespaces (namespaces.kind='user') joined to their memexes
+ * and calls seedHandholdDemo on each — the per-memex 0-demo guard makes re-runs
+ * (e.g. every CI/CD deploy, dec-7) safe and cheap. Returns the count of memexes
+ * seeded on THIS run (memexes that already had demo docs are skipped, not counted).
+ */
+export async function backfillHandholdDemo(): Promise<{ memexesSeeded: number }> {
+  const personalMemexes = await db
+    .select({ memexId: memexes.id })
+    .from(memexes)
+    .innerJoin(namespaces, eq(memexes.namespaceId, namespaces.id))
+    .where(eq(namespaces.kind, "user"));
+
+  let memexesSeeded = 0;
+  for (const { memexId } of personalMemexes) {
+    const before = await listDemoDocIds(memexId);
+    // Call seedHandholdDemo UNCONDITIONALLY (issue-2): it no-ops on a canonical full
+    // set and self-heals a partial/doubled set, so the per-deploy backfill doubles as
+    // the periodic self-heal trigger. Count only memexes that had ZERO demo docs and
+    // got a fresh seed — a heal of a partial set is not a new seed.
+    await seedHandholdDemo(memexId);
+    if (before.length === 0) memexesSeeded += 1;
+  }
+  return { memexesSeeded };
+}

--- a/packages/server/src/services/memex-search-demo-exclusion.integration.test.ts
+++ b/packages/server/src/services/memex-search-demo-exclusion.integration.test.ts
@@ -1,0 +1,198 @@
+// Handhold demo specs are invisible AND inert to ⌘K / MCP search, to the MCP +
+// agent enumeration, and to the MCP + agent read/act path (spec-178 t-11 /
+// dec-11). This is the EXCLUDE posture that reverses the earlier "searchable"
+// stance (ac-20, flipped in activity-log-demo-exclusion.integration.test.ts).
+//
+// All four guarantees run against REAL Postgres (no mocks):
+//
+//   ac-36 (search): searchMemex() omits an is_demo spec on every arm. Here we
+//     prove the FTS content arm and the exact-handle short-circuit both miss it.
+//     The board does NOT use searchMemex, so the exclusion is unconditional —
+//     there is no opt-in flag to assert.
+//
+//   ac-37 (enumeration): listDocs(memexId, { excludeDemo: true }) — the MCP /
+//     agent `list_docs` path — omits the demo spec, while the plain
+//     listDocs(memexId) the REST board uses STILL includes it (no board
+//     regression). The same case also proves the MCP doc-resolution chokepoint
+//     (resolveRefForUser) treats an is_demo spec as not-found (std-7), so a
+//     coding agent can neither read (get_doc) nor mutate against it.
+//
+//   ac-38 (in-app agents): an agent cannot DISCOVER or ACT on a demo spec — every
+//     autonomous doc path (search / enumeration / ref-resolution via
+//     resolveRefForAgent) excludes it. This case drives the ref-resolution arm:
+//     get_doc against a demo spec's ref returns not-found. (Documented carve-out per
+//     ac-38: the chat agent MAY read the ONE demo spec the user has explicitly opened
+//     as bound current-doc context — buildDocumentContext → getDoc — which is the
+//     intended exception, not an exclusion path, and is not exercised here.)
+//
+// Cleanup deletes doc_sections + documents for our memexes, then the namespaces
+// (cascading to org/memex/memberships).
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { inArray, eq } from "drizzle-orm";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { db } from "../db/connection.js";
+import { docSections, documents, memexes, namespaces } from "../db/schema.js";
+import { makeTestMemexWithDevAdmin } from "./test-helpers.js";
+import { upsertUserByEmail } from "./users.js";
+import { createDocDraft, listDocs } from "./documents.js";
+import { addSection } from "./sections.js";
+import { embedAndStoreDoc } from "./memex-embeddings.js";
+import { searchMemex } from "./memex-search.js";
+import { resolveRefForUser } from "../mcp/tools.js";
+import { executeServerTool } from "../agent/tools.js";
+import { NotFoundError } from "../types/errors.js";
+import type { EmbeddingProvider } from "./embedding-provider.js";
+
+const AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-178/acs/ac-${n}`;
+
+const createdMemexIds: string[] = [];
+let memexId: string;
+let nsSlug: string;
+let devUserId: string;
+
+// Deterministic provider so the vector arm never calls a real embedding API.
+function makeFakeProvider(name = "fake-demo-excl-1536"): EmbeddingProvider {
+  return {
+    name,
+    dim: 1536,
+    maxBatchSize: 16,
+    async embed(texts: string[]): Promise<number[][]> {
+      return texts.map((t) => {
+        const seed = Array.from(t).reduce((acc, ch) => acc + ch.charCodeAt(0), 0);
+        return Array.from({ length: 1536 }, (_, i) => ((seed + i) % 100) / 100);
+      });
+    },
+  };
+}
+
+beforeAll(async () => {
+  const made = await makeTestMemexWithDevAdmin("demoexcl");
+  memexId = made.memexId;
+  nsSlug = made.slug;
+  createdMemexIds.push(memexId);
+  const dev = await upsertUserByEmail("dev@memex.ai");
+  devUserId = dev.id;
+});
+
+afterAll(async () => {
+  const docRows = await db
+    .select({ id: documents.id })
+    .from(documents)
+    .where(inArray(documents.memexId, createdMemexIds))
+    .catch(() => [] as { id: string }[]);
+  const docIds = docRows.map((r) => r.id);
+  if (docIds.length) {
+    await db.delete(docSections).where(inArray(docSections.docId, docIds)).catch(() => {});
+  }
+  await db.delete(documents).where(inArray(documents.memexId, createdMemexIds)).catch(() => {});
+  const memexRows = await db
+    .select({ namespaceId: memexes.namespaceId })
+    .from(memexes)
+    .where(inArray(memexes.id, createdMemexIds))
+    .catch(() => [] as { namespaceId: string }[]);
+  await db.delete(memexes).where(inArray(memexes.id, createdMemexIds)).catch(() => {});
+  const namespaceIds = memexRows.map((r) => r.namespaceId);
+  if (namespaceIds.length) {
+    await db.delete(namespaces).where(inArray(namespaces.id, namespaceIds)).catch(() => {});
+  }
+});
+
+describe("handhold demo exclusion — search (ac-36)", () => {
+  it("searchMemex omits an is_demo spec on the FTS and handle arms", async () => {
+    tagAc(AC(36));
+
+    const provider = makeFakeProvider();
+    const token = "handholddemoexcludexyztoken";
+    const spec = await createDocDraft(
+      memexId,
+      "Demo spec for search exclusion",
+      `This demo overview mentions ${token} so FTS could find it.`,
+      "spec",
+    );
+    await addSection(memexId, spec.id, "scope", `In scope: ${token} coverage.`);
+    await db.update(documents).set({ isDemo: true }).where(eq(documents.id, spec.id));
+    await embedAndStoreDoc(spec.id, { provider });
+
+    // FTS content arm — would surface the doc on its unique token if it weren't demo.
+    const ftsHits = await searchMemex(memexId, token, { provider, disableVector: true });
+    expect(ftsHits.find((h) => h.id === spec.id)).toBeUndefined();
+
+    // Exact-handle short-circuit — also misses a demo spec.
+    const handleHits = await searchMemex(memexId, spec.handle, { provider });
+    expect(handleHits.find((h) => h.id === spec.id)).toBeUndefined();
+  });
+});
+
+describe("handhold demo exclusion — enumeration + read/act (ac-37)", () => {
+  it("MCP list path omits a demo spec; plain board listDocs still includes it; MCP resolver 404s it", async () => {
+    tagAc(AC(37));
+
+    // A demo spec + an ordinary spec, both in plan so the agent list's
+    // statusIn:['plan','build','verify'] surfaces the non-demo one.
+    const demo = await createDocDraft(memexId, "Demo spec enum", "Demo overview.", "spec");
+    const real = await createDocDraft(memexId, "Real spec enum", "Real overview.", "spec");
+    await db.update(documents).set({ isDemo: true, status: "plan" }).where(eq(documents.id, demo.id));
+    await db.update(documents).set({ status: "plan" }).where(eq(documents.id, real.id));
+
+    // MCP / agent enumeration: excludeDemo:true (+ the agent list's status scope)
+    // drops the demo spec but keeps the real one.
+    const agentList = await listDocs(memexId, {
+      docType: "spec",
+      includePaused: false,
+      statusIn: ["plan", "build", "verify"],
+      excludeDemo: true,
+    });
+    const agentIds = agentList.map((d) => d.id);
+    expect(agentIds).not.toContain(demo.id);
+    expect(agentIds).toContain(real.id);
+
+    // REST board enumeration: NO excludeDemo → the demo spec is STILL listed
+    // (the board renders it with a DEMO badge). No regression.
+    const boardList = await listDocs(memexId, "spec");
+    const boardIds = boardList.map((d) => d.id);
+    expect(boardIds).toContain(demo.id);
+    expect(boardIds).toContain(real.id);
+    // ...and the demo flag rides on the board summary so the badge can render.
+    expect(boardList.find((d) => d.id === demo.id)?.isDemo).toBe(true);
+
+    // MCP doc-resolution chokepoint: resolving the demo spec's ref is not-found
+    // (std-7), so get_doc / mutating tools can't read or act on it.
+    const demoRow = boardList.find((d) => d.id === demo.id)!;
+    const demoRef = `${nsSlug}/main/specs/${demoRow.handle}`;
+    await expect(resolveRefForUser(devUserId, demoRef, undefined)).rejects.toBeInstanceOf(
+      NotFoundError,
+    );
+
+    // Control: the real spec's ref STILL resolves through the same chokepoint.
+    const realRow = boardList.find((d) => d.id === real.id)!;
+    const realRef = `${nsSlug}/main/specs/${realRow.handle}`;
+    const resolved = await resolveRefForUser(devUserId, realRef, undefined);
+    expect(resolved.doc.id).toBe(real.id);
+  });
+});
+
+describe("handhold demo exclusion — in-app agent read path (ac-38)", () => {
+  it("the agent get_doc tool treats a demo spec as not-found", async () => {
+    tagAc(AC(38));
+
+    const demo = await createDocDraft(memexId, "Demo spec agent read", "Demo overview.", "spec");
+    const real = await createDocDraft(memexId, "Real spec agent read", "Real overview.", "spec");
+    await db.update(documents).set({ isDemo: true }).where(eq(documents.id, demo.id));
+
+    const slugs = { ns: nsSlug, mx: "main" };
+    const demoRef = `${slugs.ns}/${slugs.mx}/specs/${demo.handle}`;
+    const realRef = `${slugs.ns}/${slugs.mx}/specs/${real.handle}`;
+
+    // The React/LangGraph agent and the server Anthropic-SDK agent both run
+    // get_doc through executeServerTool → buildAgentCtx → resolveRefForAgent.
+    await expect(
+      executeServerTool(memexId, "get_doc", { ref: demoRef }, devUserId),
+    ).rejects.toBeInstanceOf(NotFoundError);
+
+    // Control: the non-demo spec is readable through the very same path.
+    const out = await executeServerTool(memexId, "get_doc", { ref: realRef }, devUserId);
+    expect(out).toContain(real.handle);
+  });
+});

--- a/packages/server/src/services/memex-search.ts
+++ b/packages/server/src/services/memex-search.ts
@@ -38,6 +38,16 @@
 //
 // Archived and paused content is excluded by default (per b-34 spec
 // requirement); `includeArchived: true` opts back in.
+//
+// Handhold demo specs (documents.is_demo) are excluded UNCONDITIONALLY from
+// every arm (spec-178 t-11 / dec-11, ac-36). This reverses the earlier
+// "searchable" posture (ac-20): a demo spec must be invisible AND inert to ⌘K
+// AND to the MCP `search_memex` tool (and thereby to both in-app agents, which
+// reach search only through this function). The board (SpecList) does NOT use
+// searchMemex — it renders demo specs via listDocs — so no opt-in flag is
+// needed here; the predicate is hard-wired into every query. The canonical
+// predicate is `AND d.is_demo IS NOT TRUE` (column is NOT NULL DEFAULT false,
+// but IS NOT TRUE is robust against any legacy NULL and reads as the intent).
 
 import { sql } from "drizzle-orm";
 import { db } from "../db/connection.js";
@@ -437,6 +447,7 @@ async function lookupByHandle(
     LEFT JOIN doc_sections s ON s.doc_id = d.id
     WHERE d.memex_id = ${memexId}
       ${archivedClause}
+      AND d.is_demo IS NOT TRUE
       AND d.handle = ${query.toLowerCase()}
     ORDER BY s.seq
   `)) as unknown as SectionRow[];
@@ -541,6 +552,7 @@ export async function resolveJumpTo(
       AND d.doc_type = 'spec'
       AND d.archived_at IS NULL
       AND d.paused_at IS NULL
+      AND d.is_demo IS NOT TRUE
       AND d.title ILIKE ${pattern} ESCAPE '\\'
     ORDER BY length(d.title) ASC, d.title ASC
     LIMIT ${JUMP_TITLE_LIMIT}
@@ -589,11 +601,23 @@ export async function resolveAssignedSpecs(
   const slugs = await loadMemexSlugs(memexId);
   if (!slugs) return [];
 
+  // spec-178 t-11 / dec-11 (ac-36): a demo spec must not surface in the
+  // assigned lane either. listSpecsAssignedToUser (doc-assignees.ts) excludes
+  // archived/paused but not is_demo and doesn't project the flag, so resolve the
+  // demo doc ids for this memex in one batched read and skip them below. The
+  // demo set is tiny (one per phase), so this is a cheap single round-trip.
+  const demoRows = (await db.execute(sql`
+    SELECT id FROM documents
+    WHERE memex_id = ${memexId} AND is_demo IS TRUE
+  `)) as unknown as { id: string }[];
+  const demoDocIds = new Set(demoRows.map((r) => r.id));
+
   const hits: MemexSearchHit[] = [];
   const seenDocIds = new Set<string>();
   for (const userId of userIds) {
     const rows = await listSpecsAssignedToUser(memexId, userId);
     for (const r of rows) {
+      if (demoDocIds.has(r.docId)) continue;
       if (seenDocIds.has(r.docId)) continue;
       seenDocIds.add(r.docId);
       hits.push({
@@ -648,6 +672,7 @@ async function runSectionFts(
     WHERE d.memex_id = ${memexId}
       AND d.doc_type IN ${sql.raw(`(${docTypes.map((t) => `'${t}'`).join(",")})`)}
       ${archivedClause}
+      AND d.is_demo IS NOT TRUE
       ${excludeClause}
       AND (s.status <> 'deleted' OR s.status IS NULL)
       AND s.content_tsv @@ plainto_tsquery('english', ${query})
@@ -701,6 +726,7 @@ async function runSectionVector(
     WHERE d.memex_id = ${memexId}
       AND d.doc_type IN ${sql.raw(`(${docTypes.map((t) => `'${t}'`).join(",")})`)}
       ${archivedClause}
+      AND d.is_demo IS NOT TRUE
       ${excludeClause}
       AND (s.status <> 'deleted' OR s.status IS NULL)
       AND s.embedding IS NOT NULL
@@ -752,6 +778,7 @@ async function runDecisionFts(
     INNER JOIN documents d ON d.id = dec.doc_id
     WHERE dec.memex_id = ${memexId}
       ${archivedClause}
+      AND d.is_demo IS NOT TRUE
       ${excludeClause}
       AND to_tsvector('english',
             coalesce(dec.title, '') || ' ' ||
@@ -807,6 +834,7 @@ async function runDecisionVector(
     INNER JOIN documents d ON d.id = dec.doc_id
     WHERE dec.memex_id = ${memexId}
       ${archivedClause}
+      AND d.is_demo IS NOT TRUE
       ${excludeClause}
       AND dec.embedding IS NOT NULL
       AND dec.embedding_model = ${provider.name}
@@ -859,6 +887,7 @@ async function runIssueFts(
     INNER JOIN documents d ON d.id = iss.doc_id
     WHERE iss.memex_id = ${memexId}
       ${archivedClause}
+      AND d.is_demo IS NOT TRUE
       ${excludeClause}
       AND to_tsvector('english',
             coalesce(iss.title, '') || ' ' ||
@@ -913,6 +942,7 @@ async function runIssueVector(
     INNER JOIN documents d ON d.id = iss.doc_id
     WHERE iss.memex_id = ${memexId}
       ${archivedClause}
+      AND d.is_demo IS NOT TRUE
       ${excludeClause}
       AND iss.embedding IS NOT NULL
       AND iss.embedding_model = ${provider.name}

--- a/packages/server/src/services/standards.ts
+++ b/packages/server/src/services/standards.ts
@@ -692,6 +692,7 @@ export async function findStandardsAffectedByDecision(
           archivedAt: row.docArchivedAt,
           pausedAt: row.docPausedAt,
           narrativeLastConsolidatedAt: row.docNarrativeLastConsolidatedAt,
+          isDemo: false,
         },
         matchingSections: [],
       };

--- a/packages/server/src/services/user-namespaces.handhold-seed-resilience.test.ts
+++ b/packages/server/src/services/user-namespaces.handhold-seed-resilience.test.ts
@@ -1,0 +1,95 @@
+// issue-3 / t-14 (H3): ac-7 promises that a demo-seed FAILURE never blocks signup —
+// "the user account and personal memex are still created, and the seeding error is
+// logged rather than surfaced to the user." The pre-existing ac-7 tests only exercised
+// the SUCCESS path (seed lands 5 / org seeds 0), so the resilience the AC exists to
+// guarantee was unverified: a regression that let a seed error propagate out of
+// ensureUserNamespace (dropping the `.catch`, or awaiting the seed) would have passed
+// every tagged test. This drives the FAILURE path directly.
+//
+// seedHandholdDemo is fired as a detached best-effort step inside ensureUserNamespace
+// (`void seedHandholdDemo(memexId).catch(...)`), so mocking it to reject exercises the
+// exact catch branch ac-7 protects. Runs against REAL Postgres (the namespace + memex
+// are really created); only the demo seeder is mocked.
+
+import { describe, it, expect, afterAll, vi } from "vitest";
+import { and, eq, inArray } from "drizzle-orm";
+
+// Mock the demo seeder to always reject. vi.mock is hoisted and keys on the module
+// path; ensureUserNamespace imports `seedHandholdDemo` from this same module, so its
+// import resolves to this mock. The rejection value is created via vi.hoisted (also
+// hoisted) — a plain top-level const would be in the temporal dead zone when the
+// hoisted mock factory executes at import time.
+const { seedError } = vi.hoisted(() => ({
+  seedError: new Error("handhold seed boom (issue-3 resilience test)"),
+}));
+vi.mock("./handhold-demo.js", () => ({
+  seedHandholdDemo: vi.fn().mockRejectedValue(seedError),
+}));
+
+import { db } from "../db/connection.js";
+import { namespaces, memexes, users } from "../db/schema.js";
+import { ensureUserNamespace } from "./user-namespaces.js";
+import { upsertUserByEmail } from "./users.js";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+const AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-178/acs/ac-${n}`;
+
+const createdNamespaceIds: string[] = [];
+const createdUserIds: string[] = [];
+
+afterAll(async () => {
+  // Namespaces cascade to their memex; users last.
+  if (createdNamespaceIds.length) {
+    await db
+      .delete(namespaces)
+      .where(inArray(namespaces.id, createdNamespaceIds))
+      .catch(() => {});
+  }
+  if (createdUserIds.length) {
+    await db.delete(users).where(inArray(users.id, createdUserIds)).catch(() => {});
+  }
+});
+
+describe("ensureUserNamespace — a demo-seed failure never blocks signup (ac-7 / ac-41)", () => {
+  it("still creates the user's namespace + personal memex, resolves, and logs the seed error when seeding throws", async () => {
+    tagAc(AC(7));
+    tagAc(AC(41));
+
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const user = await upsertUserByEmail(
+      `h178-seedfail-${Date.now()}-${Math.random().toString(36).slice(2, 8)}@example.com`,
+    );
+    createdUserIds.push(user.id);
+
+    // The seed is mocked to reject; ensureUserNamespace must still RESOLVE (the seed
+    // is post-commit + best-effort, so a seed failure can never block signup).
+    await expect(ensureUserNamespace(user.id)).resolves.toBeDefined();
+
+    // The account artifacts exist: a personal (kind='user') namespace + its memex.
+    const [ns] = await db
+      .select({ id: namespaces.id })
+      .from(namespaces)
+      .where(and(eq(namespaces.ownerUserId, user.id), eq(namespaces.kind, "user")))
+      .limit(1);
+    expect(ns).toBeDefined();
+    createdNamespaceIds.push(ns.id);
+    const [mx] = await db
+      .select({ id: memexes.id })
+      .from(memexes)
+      .where(eq(memexes.namespaceId, ns.id))
+      .limit(1);
+    expect(mx).toBeDefined();
+
+    // The detached best-effort seed rejects on a microtask after the call returns;
+    // give it a tick, then assert the error was logged (swallowed, not surfaced).
+    await new Promise((r) => setTimeout(r, 50));
+    expect(errSpy).toHaveBeenCalled();
+    const loggedTheSeedError = errSpy.mock.calls.some((args) =>
+      args.some((arg) => arg === seedError),
+    );
+    expect(loggedTheSeedError).toBe(true);
+
+    errSpy.mockRestore();
+  });
+});

--- a/packages/server/src/services/user-namespaces.ts
+++ b/packages/server/src/services/user-namespaces.ts
@@ -1,4 +1,4 @@
-import { eq } from "drizzle-orm";
+import { eq, and } from "drizzle-orm";
 import { db } from "../db/connection.js";
 import { namespaces, memexes, users } from "../db/schema.js";
 import type { Memex, Namespace } from "../db/schema.js";
@@ -74,14 +74,25 @@ export async function ensureUserNamespace(
         {},
         (r) => ({ memexId: r.memex.id, userId, entity: "memex", action: "created" }),
         async () => {
-          const [memex] = await db
+          // spec-177 ac-5 — absorb the concurrent-signup race on the personal
+          // memex too: a parallel call can insert the same (namespace_id,
+          // 'personal') memex first, so the loser must fall back to SELECT
+          // rather than throw memexes_namespace_id_slug_unique.
+          const [insertedMemex] = await db
             .insert(memexes)
             .values({
               namespaceId: ns.id,
               slug: "personal",
               name: PERSONAL_MEMEX_NAME,
             })
+            .onConflictDoNothing()
             .returning();
+          const memex =
+            insertedMemex ??
+            (await db.query.memexes.findFirst({
+              where: and(eq(memexes.namespaceId, ns.id), eq(memexes.slug, "personal")),
+            }));
+          if (!memex) throw new Error(`Personal memex not found after insert for namespace ${ns.id}`);
           return { namespace: ns, memex };
         },
       );
@@ -120,14 +131,27 @@ export async function ensureUserNamespace(
       const namespace = inserted ?? await tx.query.namespaces.findFirst({ where: eq(namespaces.slug, slug) });
       if (!namespace) throw new Error(`Namespace ${slug} not found after insert`);
 
-      const [memex] = await tx
+      // spec-177 ac-5 — mirror the namespace insert above: the personal memex
+      // insert must also absorb the concurrent-signup race. Two parallel calls
+      // can resolve the same namespace (the loser via the SELECT fallback), then
+      // race to INSERT (namespace_id, 'personal'); without onConflictDoNothing the
+      // loser throws memexes_namespace_id_slug_unique. Latent until spec-178's
+      // signup seed added concurrent load that reliably widened the window.
+      const [insertedMemex] = await tx
         .insert(memexes)
         .values({
           namespaceId: namespace.id,
           slug: "personal",
           name: PERSONAL_MEMEX_NAME,
         })
+        .onConflictDoNothing()
         .returning();
+      const memex =
+        insertedMemex ??
+        (await tx.query.memexes.findFirst({
+          where: and(eq(memexes.namespaceId, namespace.id), eq(memexes.slug, "personal")),
+        }));
+      if (!memex) throw new Error(`Personal memex not found after insert for namespace ${namespace.id}`);
 
       await tx
         .update(users)

--- a/packages/server/src/services/user-namespaces.ts
+++ b/packages/server/src/services/user-namespaces.ts
@@ -4,6 +4,7 @@ import { namespaces, memexes, users } from "../db/schema.js";
 import type { Memex, Namespace } from "../db/schema.js";
 import { ValidationError } from "../types/errors.js";
 import { mutate, type Mutated } from "./mutate.js";
+import { seedHandholdDemo } from "./handhold-demo.js";
 
 // Canonical display name for personal memexes. Per product decision, personal memexes
 // cannot be renamed — the switcher always shows "Personal Memex" so there's no ambiguity
@@ -69,7 +70,7 @@ export async function ensureUserNamespace(
         );
       }
 
-      return mutate(
+      const created = await mutate(
         {},
         (r) => ({ memexId: r.memex.id, userId, entity: "memex", action: "created" }),
         async () => {
@@ -84,13 +85,17 @@ export async function ensureUserNamespace(
           return { namespace: ns, memex };
         },
       );
+      // spec-178 t-4 — seed the handhold onboarding demo into the freshly-created
+      // personal Memex (create path only, never the idempotent fast-path above).
+      seedHandholdDemoBestEffort(created.memex.id);
+      return created;
     }
     // Dangling FK — fall through to recreate.
   }
 
   const slug = await deriveAvailableSlug(existingUser.email, userId);
 
-  return mutate(
+  const created = await mutate(
     {},
     // Composite: a new user namespace AND its default personal memex. Two
     // logical changes; subscribers filter on entity. memexId resolves to the
@@ -131,6 +136,23 @@ export async function ensureUserNamespace(
 
       return { namespace, memex };
     }),
+  );
+  // spec-178 t-4 — seed the handhold onboarding demo into the brand-new personal
+  // Memex. AFTER the mutate() commits, on the create path only (the fast-path
+  // returns earlier and never reaches here). This funnels every signup flow
+  // (password / magic-link / SSO) — they all create the namespace through here.
+  seedHandholdDemoBestEffort(created.memex.id);
+  return created;
+}
+
+// Fire-and-forget the handhold demo seed for a newly-created personal Memex
+// (spec-178 t-4). Best-effort by contract: a seed failure must NEVER roll back
+// or block signup, so the promise is detached (`void`) and any rejection is
+// swallowed to a log line. The seed itself is idempotent (NO-OP if the Memex
+// already has a demo doc — ac-8), so even a duplicate fire is harmless.
+function seedHandholdDemoBestEffort(memexId: string): void {
+  void seedHandholdDemo(memexId).catch((err) =>
+    console.error("[handhold seed]", err),
   );
 }
 

--- a/packages/server/src/types/index.ts
+++ b/packages/server/src/types/index.ts
@@ -56,6 +56,11 @@ export interface DocSummary {
   // honest if callers later opt into includeArchived.
   pausedAt: Date | null;
   archivedAt: Date | null;
+  // spec-178 t-1 (ac-9): demo flag — true on the five frozen spec-64 copies seeded into
+  // a personal Memex for the Handhold onboarding walkthrough. Always projected by
+  // listDocs; drives the DEMO badge client-side and the Pulse/analytics exclusion
+  // server-side. Optional on the type for other DocSummary constructors / legacy payloads.
+  isDemo?: boolean;
   // Set when ?include=driftCount is requested (t-19 W2). Open `commentType='drift'` count
   // joined via doc_sections.doc_id = this.id. Undefined when not requested so callers
   // that don't pass `include` aren't paying for the join.

--- a/packages/ui/src/api/client.ts
+++ b/packages/ui/src/api/client.ts
@@ -365,6 +365,23 @@ export async function unpauseDoc(docId: string): Promise<void> {
   }
 }
 
+// spec-178 (UI CLIENT CONTRACT): re-seed the personal Memex's Handhold demo. POSTs
+// the route the ROUTE agent owns — POST /api/:namespace/:memex/handhold/reset — which
+// hard-deletes the existing demo specs (+ their seeded emissions) and re-seeds the five
+// frozen spec-64 copies. The namespace/memex are passed explicitly (the SpecList board's
+// Reset button supplies them from the current tenant context) rather than inferred from
+// the URL, so the call site is unambiguous. Owner-of-personal-namespace gate is enforced
+// server-side; a non-owner / non-personal target returns 404 (std-7).
+export async function resetHandholdDemo(namespace: string, memex: string): Promise<void> {
+  const res = await fetchWithRetry(`${BASE_URL}/${namespace}/${memex}/handhold/reset`, {
+    method: 'POST',
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(text || `Failed to reset demo: ${res.status}`);
+  }
+}
+
 export interface MoveDocInput {
   targetMemexId: string;
   includeDecisions: boolean;

--- a/packages/ui/src/api/types.ts
+++ b/packages/ui/src/api/types.ts
@@ -99,6 +99,12 @@ export interface DocSummary {
    * future opt-in archive view.
    */
   archivedAt: string | null;
+  /**
+   * spec-178: demo flag — true on the five frozen spec-64 copies seeded into a personal
+   * Memex for the Handhold onboarding walkthrough. Drives the DEMO badge on the board
+   * card. Always returned by the server; absent/false for real specs.
+   */
+  isDemo?: boolean;
   /** Set when fetchDocs is called with `{ include: ['driftCount'] }` — open drift
    *  comment count for the doc. Undefined when not requested. (t-19 W2) */
   driftCount?: number;
@@ -165,6 +171,20 @@ export interface Doc {
   statusChangedAt: string;
   /** See DocSummary.pausedAt — same semantics. */
   pausedAt?: string | null;
+  /**
+   * spec-178: demo flag — true on the five frozen spec-64 copies. Threaded into
+   * SectionCard / DecisionPanel to suppress handle auto-linking (ac-24) and into the
+   * per-phase value banner atop the demo spec. Absent/false for real specs.
+   */
+  isDemo?: boolean;
+  /**
+   * spec-178 dec-8 (ac-25/ac-26): the per-phase value callout the server attaches to a
+   * demo spec's GET payload, sourced from HANDHOLD_PHASES.find(p=>p.phase===status).valueCallout.
+   * Rendered by DocDocument as a banner atop the demo spec, visually distinct from the
+   * spec content (it is demo guidance, not part of the spec). Absent for real specs and
+   * for demo specs whose phase has no callout.
+   */
+  demoValueCallout?: string;
   /**
    * Timestamp of the last narrative consolidation (doc-12 t-1 column). NULL =
    * never consolidated. Spec-only — non-spec docTypes leave it null.

--- a/packages/ui/src/components/DecisionPanel.demo.test.tsx
+++ b/packages/ui/src/components/DecisionPanel.demo.test.tsx
@@ -1,0 +1,82 @@
+// spec-178 (A-UI, t-7): the demo variant of DecisionPanel suppresses handle
+// auto-linking in decision context / resolution prose, mirroring SectionCard. A
+// frozen demo spec's refs belong to the original spec-64's world, so they must
+// stay plain text rather than become navigable links (ac-24). ac-11 pins the
+// no-regression baseline (a non-demo decision keeps its auto-links).
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import { DecisionPanel } from './DecisionPanel';
+import type { Decision } from '../api/types';
+import { tagAc } from '@memex-ai-ac/vitest';
+
+const SPEC_178 = 'mindset-prod/memex-building-itself/specs/spec-178';
+const AC = (n: number) => `${SPEC_178}/acs/ac-${n}`;
+
+vi.mock('./ChatContext', () => ({
+  useChat: () => ({ addContextChip: vi.fn(), sendMessage: vi.fn() }),
+}));
+vi.mock('./AuthContext', () => ({
+  useAuth: () => ({ user: { name: 'Tester', email: 'tester@memex.ai' } }),
+}));
+vi.mock('../api/client', () => ({
+  createDecision: vi.fn(),
+  approveDecisionApi: vi.fn(),
+  rejectDecisionApi: vi.fn(),
+  resolveDecisionApi: vi.fn(),
+  createDecisionComment: vi.fn(),
+  // The polling effect calls this on mount; return an empty AC set.
+  fetchAcsForBrief: vi.fn().mockResolvedValue([]),
+}));
+vi.mock('./CommentTray', () => ({
+  CommentTray: ({ targetId }: { targetId: string }) => (
+    <div data-testid="comment-tray-stub" data-target-id={targetId} />
+  ),
+}));
+
+const REF = 'mindset-prod/memex-building-itself/specs/spec-34';
+
+function makeDecision(overrides: Partial<Decision> = {}): Decision {
+  return {
+    id: 'd-1',
+    docId: 'doc-1',
+    seq: 1,
+    title: 'Which database?',
+    context: `Builds on ${REF}, the prior decision.`,
+    status: 'open',
+    resolution: null,
+    resolvedAt: null,
+    createdAt: new Date().toISOString(),
+    options: null,
+    chosenOptionIndex: null,
+    ...overrides,
+  } as Decision;
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('DecisionPanel demo handle suppression (spec-178)', () => {
+  it('ac-24: a demo decision renders a handle ref in its context as plain text', () => {
+    tagAc(AC(24));
+    // An OPEN decision is expanded by default, so its context markdown renders.
+    render(
+      <DecisionPanel docId="doc-1" decisions={[makeDecision()]} onUpdate={vi.fn()} isDemo />,
+    );
+    const panel = screen.getByTestId('decision-panel');
+    expect(panel).toHaveTextContent(REF);
+    // No anchor / ref-link element anywhere in the demo decision prose.
+    expect(panel.querySelector('a')).toBeNull();
+    expect(panel.querySelector('[data-ref-link="true"]')).toBeNull();
+  });
+
+  it('ac-11: a non-demo decision renders unchanged — the handle ref IS an auto-link', () => {
+    tagAc(AC(11));
+    render(
+      <DecisionPanel docId="doc-1" decisions={[makeDecision()]} onUpdate={vi.fn()} />,
+    );
+    const panel = screen.getByTestId('decision-panel');
+    const link = within(panel).getByRole('link', { name: REF });
+    expect(link).toHaveAttribute('href', `/${REF}`);
+    expect(link).toHaveAttribute('data-ref-link', 'true');
+  });
+});

--- a/packages/ui/src/components/DecisionPanel.tsx
+++ b/packages/ui/src/components/DecisionPanel.tsx
@@ -59,12 +59,23 @@ interface DecisionPanelProps {
    * legitimately create them in draft, spec-12 dec-1).
    */
   specPhase?: string;
+  /**
+   * spec-178 ac-24: when true (a frozen Handhold demo spec) the decision context /
+   * resolution markdown does NOT run rehypeRefLinkifier — handle refs render as plain
+   * text instead of navigable `<a>` links, mirroring SectionCard. The demo replicates
+   * spec-64; its refs belong to the original spec's world, not the user's, so linking
+   * them would dead-end. Defaults to false (real specs keep auto-linking).
+   */
+  isDemo?: boolean;
 }
 
 type TabId = 'candidates' | 'open' | 'resolved';
 
-export function DecisionPanel({ docId, decisions, commentsByDecision = {}, forceShowComments: _forceShowComments, onCommentsChange, onUpdate, highlightDecisionHandle, onJumpToAc, canWrite = true, canEdit = true, specPhase }: DecisionPanelProps) {
+export function DecisionPanel({ docId, decisions, commentsByDecision = {}, forceShowComments: _forceShowComments, onCommentsChange, onUpdate, highlightDecisionHandle, onJumpToAc, canWrite = true, canEdit = true, specPhase, isDemo = false }: DecisionPanelProps) {
   const panelRef = useRef<HTMLDivElement>(null);
+  // spec-178 ac-24: suppress handle auto-linking inside a frozen demo spec's
+  // decision prose. Mirrors SectionCard's rehypePlugins switch.
+  const decisionRehypePlugins = isDemo ? [] : [rehypeRefLinkifier];
   const [highlightedId, setHighlightedId] = useState<string | null>(null);
   const chat = useChat();
   const { user } = useAuth();
@@ -356,7 +367,7 @@ export function DecisionPanel({ docId, decisions, commentsByDecision = {}, force
                   <div className="mt-2 pl-2 border-l-2 border-edge-subtle">
                     <span className="text-[10px] uppercase tracking-wider text-muted font-medium">Context</span>
                     <div className="prose-dark prose-sm mt-0.5 opacity-80 [&>*]:my-1 [&_h1]:text-sm [&_h2]:text-sm [&_h3]:text-xs [&_h1]:font-semibold [&_h2]:font-semibold [&_h3]:font-medium">
-                      <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeRefLinkifier]}>{dec.context}</ReactMarkdown>
+                      <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={decisionRehypePlugins}>{dec.context}</ReactMarkdown>
                     </div>
                   </div>
                 )}
@@ -581,7 +592,7 @@ export function DecisionPanel({ docId, decisions, commentsByDecision = {}, force
                       <div className="mt-2 pl-2 border-l-2 border-edge-subtle">
                         <span className="text-[10px] uppercase tracking-wider text-muted font-medium">Context</span>
                         <div className="prose-dark prose-sm mt-0.5 opacity-80 [&>*]:my-1 [&_h1]:text-sm [&_h2]:text-sm [&_h3]:text-xs [&_h1]:font-semibold [&_h2]:font-semibold [&_h3]:font-medium">
-                          <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeRefLinkifier]}>{dec.context}</ReactMarkdown>
+                          <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={decisionRehypePlugins}>{dec.context}</ReactMarkdown>
                         </div>
                       </div>
                     )}
@@ -804,13 +815,13 @@ export function DecisionPanel({ docId, decisions, commentsByDecision = {}, force
                         <div className="pl-2 border-l-2 border-status-success-border/50">
                           <span className="text-[10px] uppercase tracking-wider text-status-success-text font-medium">Decision</span>
                           <div className="prose-dark prose-sm mt-0.5 [&>*]:my-1 [&_h1]:text-sm [&_h2]:text-sm [&_h3]:text-xs [&_h1]:font-semibold [&_h2]:font-semibold [&_h3]:font-medium">
-                            <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeRefLinkifier]}>{dec.resolution}</ReactMarkdown>
+                            <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={decisionRehypePlugins}>{dec.resolution}</ReactMarkdown>
                           </div>
                         </div>
                       )}
                       {dec.context && (
                         <div className="prose-dark prose-sm opacity-80 [&>*]:my-1 [&_h1]:text-sm [&_h2]:text-sm [&_h3]:text-xs [&_h1]:font-semibold [&_h2]:font-semibold [&_h3]:font-medium">
-                          <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeRefLinkifier]}>{dec.context}</ReactMarkdown>
+                          <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={decisionRehypePlugins}>{dec.context}</ReactMarkdown>
                         </div>
                       )}
                     </div>

--- a/packages/ui/src/components/SectionCard.demo.test.tsx
+++ b/packages/ui/src/components/SectionCard.demo.test.tsx
@@ -1,0 +1,78 @@
+// spec-178 (A-UI, t-7): the demo variant of SectionCard suppresses handle
+// auto-linking so a frozen demo spec's `[per dec-N]` / canonical-path refs render
+// as plain text — they belong to the original spec-64's world, not the user's.
+// ac-24 covers the suppression; ac-11 pins the no-regression baseline (a real,
+// non-demo section keeps its auto-links and renders unchanged).
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import { SectionCard } from './SectionCard';
+import type { DocSection } from '../api/types';
+import { tagAc } from '@memex-ai-ac/vitest';
+
+const SPEC_178 = 'mindset-prod/memex-building-itself/specs/spec-178';
+const AC = (n: number) => `${SPEC_178}/acs/ac-${n}`;
+
+vi.mock('./ChatContext', () => ({
+  useChat: () => ({ addContextChip: vi.fn() }),
+}));
+vi.mock('./AuthContext', () => ({
+  useAuth: () => ({ user: { id: 'u-1', name: 'Tester' } }),
+}));
+vi.mock('../api/client', () => ({
+  resolveComment: vi.fn().mockResolvedValue({}),
+  deleteComment: vi.fn().mockResolvedValue(undefined),
+  createComment: vi.fn().mockResolvedValue({}),
+}));
+
+// A canonical path ref the refLinkifier auto-links when present (it matches the
+// REF_PATTERN: <ns>/<mx>/specs/spec-N). In a real section this becomes an <a>;
+// in a demo section it must stay plain text.
+const REF = 'mindset-prod/memex-building-itself/specs/spec-34';
+
+function makeSection(overrides: Partial<DocSection> = {}): DocSection {
+  return {
+    id: 'sec-1',
+    docId: 'doc-1',
+    sectionType: 'approach',
+    title: 'Approach',
+    content: `See ${REF} for the prior art.`,
+    seq: 1,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  } as DocSection;
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('SectionCard demo handle suppression (spec-178)', () => {
+  it('ac-24: a demo section renders a handle ref as plain text — no <a> auto-link', () => {
+    tagAc(AC(24));
+    render(<SectionCard section={makeSection()} sectionNumber={1} isDemo />);
+    const body = screen.getByTestId('section-body');
+    // The ref text is present...
+    expect(body).toHaveTextContent(REF);
+    // ...but it is NOT wrapped in an anchor (the refLinkifier was suppressed).
+    expect(body.querySelector('a')).toBeNull();
+    expect(body.querySelector('[data-ref-link="true"]')).toBeNull();
+  });
+
+  it('ac-11: a non-demo section renders unchanged — the handle ref IS an auto-link', () => {
+    tagAc(AC(11));
+    render(<SectionCard section={makeSection()} sectionNumber={1} />);
+    const body = screen.getByTestId('section-body');
+    const link = within(body).getByRole('link', { name: REF });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', `/${REF}`);
+    expect(link).toHaveAttribute('data-ref-link', 'true');
+  });
+
+  it('ac-11: isDemo defaults to false — omitting the prop keeps auto-linking', () => {
+    tagAc(AC(11));
+    // No isDemo prop at all (default path) → real-spec behaviour.
+    render(<SectionCard section={makeSection()} sectionNumber={1} isDemo={false} />);
+    const body = screen.getByTestId('section-body');
+    expect(body.querySelector('[data-ref-link="true"]')).not.toBeNull();
+  });
+});

--- a/packages/ui/src/components/SectionCard.tsx
+++ b/packages/ui/src/components/SectionCard.tsx
@@ -61,6 +61,15 @@ interface SectionCardProps {
    * `canWrite`, so reviewers keep commenting. Defaults to true.
    */
   canEdit?: boolean;
+  /**
+   * spec-178 ac-24: when true (a frozen Handhold demo spec) the section body
+   * does NOT run rehypeRefLinkifier — `[per dec-N]` / canonical-path handle refs
+   * render as plain text instead of becoming navigable `<a>` links. The demo is a
+   * self-contained replica of spec-64; its handle refs point at the original spec's
+   * world, not the user's, so auto-linking them would send the user down a dead end.
+   * Defaults to false (real specs keep auto-linking).
+   */
+  isDemo?: boolean;
 }
 
 export const SectionCard = memo(function SectionCard({
@@ -74,6 +83,7 @@ export const SectionCard = memo(function SectionCard({
   onSelect,
   canWrite = true,
   commentsCollapsed = false,
+  isDemo = false,
 }: SectionCardProps) {
   const [revealed, setRevealed] = useState(!isNew);
 
@@ -408,7 +418,7 @@ export const SectionCard = memo(function SectionCard({
             data-testid="section-body"
             className="min-w-0 pr-8"
           >
-            <MemoizedMarkdown content={withRenderedMarkers(section.content, visibleSeqs)} />
+            <MemoizedMarkdown content={withRenderedMarkers(section.content, visibleSeqs)} isDemo={isDemo} />
           </div>
 
           {/* right-edge comment indicators, one per open comment, vertically
@@ -521,7 +531,11 @@ export const SectionCard = memo(function SectionCard({
 });
 
 const remarkPlugins = [remarkGfm];
-const rehypePlugins = [rehypeHighlight, rehypeRefLinkifier];
+// spec-178 ac-24: the demo variant drops rehypeRefLinkifier so handle refs in a
+// frozen demo spec render as plain text (no auto-linking). Pre-built once per
+// variant so the markdown renderer still gets a stable array reference.
+const rehypePluginsDefault = [rehypeHighlight, rehypeRefLinkifier];
+const rehypePluginsDemo = [rehypeHighlight];
 
 // spec-100: a `📍c-N` inline-code span (produced by withRenderedMarkers) renders
 // as an interactive marker badge — clickable + locatable from the gutter via its
@@ -562,7 +576,14 @@ const markdownComponents = {
   },
 };
 
-const MemoizedMarkdown = memo(function MemoizedMarkdown({ content }: { content: string }) {
+const MemoizedMarkdown = memo(function MemoizedMarkdown({
+  content,
+  isDemo = false,
+}: {
+  content: string;
+  isDemo?: boolean;
+}) {
+  const rehypePlugins = isDemo ? rehypePluginsDemo : rehypePluginsDefault;
   return (
     <div className="prose-dark overflow-hidden">
       <ReactMarkdown remarkPlugins={remarkPlugins} rehypePlugins={rehypePlugins} components={markdownComponents}>

--- a/packages/ui/src/components/ui/Badge.tsx
+++ b/packages/ui/src/components/ui/Badge.tsx
@@ -8,10 +8,18 @@ interface BadgeProps {
   className?: string;
 }
 
+// spec-178 (ac-3/ac-12): the DEMO badge needs a treatment that reads as "this is a
+// guided demo", visually distinct from the lifecycle status palette. `statusClasses`
+// maps any unknown status to the neutral grey, which would make a DEMO pill blend into
+// real specs — so we special-case `demo` here with the accent token rather than touch
+// the shared statusStyles map (this component owns the demo affordance's look).
+const DEMO_CLASSES = 'bg-accent/15 text-accent border-accent/40';
+
 export function Badge({ status, label, className = '' }: BadgeProps) {
+  const palette = status === 'demo' ? DEMO_CLASSES : statusClasses(status);
   return (
     <span
-      className={`inline-flex items-center rounded-full font-medium border px-1.5 py-0.5 text-[11px] leading-none ${statusClasses(status)} ${className}`}
+      className={`inline-flex items-center rounded-full font-medium border px-1.5 py-0.5 text-[11px] leading-none ${palette} ${className}`}
     >
       {label ?? status.replace(/_/g, ' ')}
     </span>

--- a/packages/ui/src/hooks/useHandholdReveal.ts
+++ b/packages/ui/src/hooks/useHandholdReveal.ts
@@ -1,0 +1,112 @@
+import { useCallback, useState } from 'react';
+import type { SpecStatus } from '../api/types';
+
+/**
+ * spec-178 t-10 (dec-10): progressive reveal of the five Handhold demo specs.
+ *
+ * All five demo specs (one per phase) are seeded into the personal Memex, but
+ * the board shows only ONE at a time — the one whose `status` matches a
+ * client-side pointer. Advancing the pointer makes the current demo card
+ * disappear and the next phase's demo card appear, giving the impression of a
+ * single spec walking across the board (draft → plan → build → verify → done).
+ *
+ * The pointer is purely a UI affordance for the walkthrough, so it lives in
+ * localStorage (no server state — this is CLIENT-SIDE ONLY, dec-10). It is
+ * keyed by namespace/memex so each personal Memex tracks its own progress and
+ * one user's walkthrough never bleeds into another tenant's board.
+ */
+
+// dec-4 Spec lifecycle order. The demo walks these in sequence; `done` is the
+// terminal phase (no "next" — the advance control becomes Reset there).
+export const REVEAL_PHASES = ['draft', 'plan', 'build', 'verify', 'done'] as const;
+export type RevealPhase = (typeof REVEAL_PHASES)[number];
+
+const DEFAULT_PHASE: RevealPhase = 'draft';
+
+// Storage key per dec-10: `handhold-reveal:${ns}/${mx}`. A null tenant (e.g. a
+// caller-scoped route with no Memex) collapses to a single shared key — the
+// hook is still safe to call, it just won't be tenant-scoped.
+function storageKey(ns: string | null, mx: string | null): string {
+  return `handhold-reveal:${ns ?? '_'}/${mx ?? '_'}`;
+}
+
+function isRevealPhase(value: string | null): value is RevealPhase {
+  return value != null && (REVEAL_PHASES as readonly string[]).includes(value);
+}
+
+function readPointer(key: string): RevealPhase {
+  if (typeof window === 'undefined') return DEFAULT_PHASE;
+  try {
+    const raw = window.localStorage.getItem(key);
+    return isRevealPhase(raw) ? raw : DEFAULT_PHASE;
+  } catch {
+    // localStorage can throw under privacy modes / disabled storage — fall back
+    // to the default rather than crashing the board.
+    return DEFAULT_PHASE;
+  }
+}
+
+function writePointer(key: string, phase: RevealPhase): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(key, phase);
+  } catch {
+    // Silent on storage failures — the in-memory state still drives the render
+    // this session; only cross-navigation persistence is lost.
+  }
+}
+
+export interface HandholdReveal {
+  /** The single demo phase currently revealed on the board. Default 'draft'. */
+  revealedPhase: RevealPhase;
+  /**
+   * Move the pointer to the next phase in the lifecycle. No-op at 'done' (the
+   * terminal phase) — callers wire the done-phase control to `reset()` instead.
+   */
+  advance: () => void;
+  /** Restore the pointer to 'draft' so only the first demo spec shows again. */
+  reset: () => void;
+}
+
+/**
+ * Returns the reveal pointer for the given tenant plus advance/reset actions.
+ * Lazily reads localStorage on first render so the user's progress survives
+ * navigation; writes through on every mutation. `revealedPhase` is `SpecStatus`-
+ * compatible so call sites can compare it directly against a card's `status`.
+ */
+export function useHandholdReveal(
+  ns: string | null,
+  mx: string | null,
+): HandholdReveal {
+  const key = storageKey(ns, mx);
+  const [revealedPhase, setRevealedPhase] = useState<RevealPhase>(() => readPointer(key));
+
+  const advance = useCallback(() => {
+    setRevealedPhase((current) => {
+      const idx = REVEAL_PHASES.indexOf(current);
+      // Clamp at the terminal phase — there is no phase after 'done'.
+      const next = idx >= 0 && idx < REVEAL_PHASES.length - 1 ? REVEAL_PHASES[idx + 1]! : current;
+      if (next !== current) writePointer(key, next);
+      return next;
+    });
+  }, [key]);
+
+  const reset = useCallback(() => {
+    writePointer(key, DEFAULT_PHASE);
+    setRevealedPhase(DEFAULT_PHASE);
+  }, [key]);
+
+  return { revealedPhase, advance, reset };
+}
+
+/** The phase that follows `phase`, or null at the terminal 'done'. Exposed for
+ *  the advance control's "See it in <next> →" label. */
+export function nextRevealPhase(phase: RevealPhase): RevealPhase | null {
+  const idx = REVEAL_PHASES.indexOf(phase);
+  if (idx < 0 || idx >= REVEAL_PHASES.length - 1) return null;
+  return REVEAL_PHASES[idx + 1]!;
+}
+
+// Re-export the SpecStatus alias for call sites that thread the phase into
+// status-typed props without importing both modules.
+export type { SpecStatus };

--- a/packages/ui/src/pages/DocDocument.demo.test.tsx
+++ b/packages/ui/src/pages/DocDocument.demo.test.tsx
@@ -1,0 +1,238 @@
+// spec-178 (A-UI, t-7): the per-phase value banner atop a demo spec.
+//   ac-25: when a doc is a demo AND carries a demoValueCallout, the banner renders
+//          the callout text at the top of the document view.
+//   ac-26: the banner is visually DISTINCT from the spec content — it sits outside
+//          the section/decision panels (it is demo guidance, not part of the spec)
+//          and carries the DEMO marker.
+//   ac-11: a real (non-demo) spec renders NO banner; a demo spec whose phase has no
+//          callout renders no banner either.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, within, waitFor, fireEvent } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { tagAc } from '@memex-ai-ac/vitest';
+import type { DocWithGraph } from '../api/types';
+
+const SPEC_178 = 'mindset-prod/memex-building-itself/specs/spec-178';
+const AC = (n: number) => `${SPEC_178}/acs/ac-${n}`;
+
+// Heavy children → identity markers.
+vi.mock('../components/DecisionPanel', () => ({ DecisionPanel: () => <div data-testid="decision-panel" /> }));
+vi.mock('../components/AcPanel', () => ({ AcPanel: () => <div data-testid="ac-panel" /> }));
+vi.mock('../components/TaskPanel', () => ({ TaskPanel: () => <div data-testid="task-panel" /> }));
+vi.mock('../components/IssuePanel', () => ({ IssuePanel: () => <div data-testid="issue-panel" /> }));
+vi.mock('../components/AllComments', () => ({ AllComments: () => <div data-testid="all-comments" /> }));
+vi.mock('../components/SectionCard', () => ({
+  SectionCard: () => <div data-testid="section-card">section content</div>,
+}));
+vi.mock('../components/DocOutline', () => ({ DocOutline: () => <div data-testid="doc-outline" /> }));
+vi.mock('../components/TagPicker', () => ({ TagPicker: () => null }));
+vi.mock('../components/BylineAssignees', () => ({ BylineAssignees: () => <div data-testid="byline-assignees" /> }));
+vi.mock('../components/DoneSummary', () => ({ DoneSummary: () => <div data-testid="done-summary" /> }));
+
+vi.mock('../hooks/useMemexAccess', () => ({
+  useMemexAccess: () => ({ canWrite: true, isReadOnly: false }),
+}));
+// IMPORTANT: return a STABLE object. DocDocument's `useSwitchPosture` memoises on
+// `refetch`, and that feeds the `headerActions` useMemo → `useHeaderSlot` effect.
+// A fresh `refetch` (or result object) every render makes `headerActions` a new
+// node each render, so the header-slot setContent effect fires on every render —
+// once any post-mount re-render occurs (e.g. the reveal pointer bumps), that
+// becomes an infinite render loop. A hoisted singleton keeps the chain stable.
+const { docRoleResult } = vi.hoisted(() => ({
+  docRoleResult: { myRole: 'editor', editors: [], loading: false, refetch: () => {} },
+}));
+vi.mock('../hooks/useDocRole', () => ({
+  useDocRole: () => docRoleResult,
+}));
+vi.mock('../hooks/useDocChangeStream', () => ({ useDocChangeStream: () => {} }));
+vi.mock('../hooks/useOrgScaffoldBlocks', () => ({ useOrgScaffoldBlocks: () => [] }));
+vi.mock('../components/ChatContext', () => ({
+  useChat: () => ({ setDocId: vi.fn(), setDoc: vi.fn(), setOpenCommentCount: vi.fn(), sendMessage: vi.fn() }),
+}));
+
+let docIsDemo = false;
+let docValueCallout: string | undefined;
+let docStatus: DocWithGraph['status'] = 'plan';
+
+function makeDoc(): DocWithGraph {
+  return {
+    id: 'doc-uuid',
+    handle: 'spec-1',
+    title: 'In-app Memex search (⌘K)',
+    docType: 'spec',
+    status: docStatus,
+    creator: { name: 'Barrie', email: 'barrie@mindset.ai' },
+    createdAt: '2026-06-01T00:00:00Z',
+    statusChangedAt: '2026-06-04T00:00:00Z',
+    narrativeLastConsolidatedAt: null,
+    isDemo: docIsDemo,
+    demoValueCallout: docValueCallout,
+    sections: [{ id: 's-1', seq: 1, sectionType: 'overview', title: 'Overview', content: 'x', createdAt: '', updatedAt: '' }],
+    decisions: [],
+    tasks: [],
+    tags: [],
+  } as unknown as DocWithGraph;
+}
+
+const resetHandholdDemoMock = vi.fn();
+vi.mock('../api/client', () => ({
+  NotFoundError: class NotFoundError extends Error {},
+  fetchDoc: () => Promise.resolve(makeDoc()),
+  fetchDocComments: () => Promise.resolve({ sections: [], decisions: [], tasks: [] }),
+  fetchAcsForBrief: () => Promise.resolve([]),
+  fetchIssues: () => Promise.resolve([]),
+  fetchDocAssignees: () => Promise.resolve([]),
+  archiveDoc: vi.fn(),
+  pauseDoc: vi.fn(),
+  unpauseDoc: vi.fn(),
+  updateDocStatus: vi.fn(),
+  resetHandholdDemo: (...args: unknown[]) => resetHandholdDemoMock(...args),
+  promoteToEditor: vi.fn(),
+  demoteToReviewer: vi.fn(),
+}));
+
+import { DocDocument } from './DocDocument';
+import { HeaderSlotProvider, useHeaderSlotContent } from '../components/HeaderSlot';
+
+function HeaderSink() {
+  return <div data-testid="header-slot">{useHeaderSlotContent()}</div>;
+}
+
+function renderDoc() {
+  return render(
+    <MemoryRouter initialEntries={['/alice/personal/specs/spec-1']}>
+      <HeaderSlotProvider>
+        <HeaderSink />
+        <Routes>
+          {/* Production param names — the reveal hook reads :namespace / :memex. */}
+          <Route path="/:namespace/:memex/specs/:id" element={<DocDocument />} />
+          {/* Landing target after an in-page advance / reset. A catch-all so it
+              matches wherever the board navigate resolves (tenantPath() depends
+              on window.location, which MemoryRouter doesn't drive). */}
+          <Route path="*" element={<div data-testid="board-landing">board</div>} />
+        </Routes>
+      </HeaderSlotProvider>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  docIsDemo = false;
+  docValueCallout = undefined;
+  docStatus = 'plan';
+  // Reset the per-tenant reveal pointer between tests.
+  try {
+    window.localStorage.clear();
+  } catch {
+    /* jsdom always has storage; guard anyway */
+  }
+});
+
+const REVEAL_KEY = 'handhold-reveal:alice/personal';
+
+describe('DocDocument demo value banner (spec-178)', () => {
+  it('ac-25/ac-26: a demo spec renders the per-phase value callout as a distinct banner', async () => {
+    tagAc(AC(25));
+    tagAc(AC(26));
+    docIsDemo = true;
+    docValueCallout = 'In Specify you lock the decisions before any code is written.';
+    renderDoc();
+
+    const banner = await screen.findByTestId('demo-value-banner');
+    expect(banner).toHaveTextContent(docValueCallout!);
+    // It carries the DEMO marker (guidance, not spec content).
+    expect(within(banner).getByText('DEMO')).toBeInTheDocument();
+    // ac-26: distinct from the spec content — the banner is NOT inside any
+    // section card; the callout text does not appear within section content.
+    const sectionCard = screen.getByTestId('section-card');
+    expect(sectionCard).not.toContainElement(banner);
+    expect(sectionCard).not.toHaveTextContent(docValueCallout!);
+  });
+
+  it('ac-11: a real (non-demo) spec renders NO value banner', async () => {
+    tagAc(AC(11));
+    docIsDemo = false;
+    docValueCallout = 'should never show because not a demo';
+    renderDoc();
+
+    await screen.findByTestId('section-card');
+    expect(screen.queryByTestId('demo-value-banner')).not.toBeInTheDocument();
+  });
+
+  it('ac-11: a demo spec with no callout for its phase renders NO banner', async () => {
+    tagAc(AC(11));
+    docIsDemo = true;
+    docValueCallout = undefined; // e.g. a phase that carries no valueCallout
+    renderDoc();
+
+    await screen.findByTestId('section-card');
+    expect(screen.queryByTestId('demo-value-banner')).not.toBeInTheDocument();
+  });
+});
+
+describe('DocDocument in-page reveal advance control (spec-178)', () => {
+  it('ac-33/ac-34: a demo spec renders an advance control near the banner; a real spec does not', async () => {
+    tagAc(AC(33));
+    tagAc(AC(34));
+    docIsDemo = true;
+    docValueCallout = 'Specify locks the decisions before any code is written.';
+    renderDoc();
+
+    // The control is present on the demo spec, offering the next phase. Default
+    // pointer is 'draft', so next is 'plan' → "Specify".
+    const advance = await screen.findByTestId('demo-advance-control');
+    expect(advance).toHaveTextContent('Specify');
+  });
+
+  it('ac-34: a real (non-demo) spec renders NO advance control', async () => {
+    tagAc(AC(34));
+    docIsDemo = false;
+    renderDoc();
+
+    await screen.findByTestId('section-card');
+    expect(screen.queryByTestId('demo-advance-control')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('demo-reset-control')).not.toBeInTheDocument();
+  });
+
+  it('ac-33/ac-34: advancing bumps the pointer and navigates back to the board', async () => {
+    tagAc(AC(33));
+    tagAc(AC(34));
+    docIsDemo = true;
+    // Pointer at 'draft' (default) → advance bumps it to 'plan'.
+    renderDoc();
+
+    // fireEvent (not userEvent): the click navigates away, unmounting the
+    // clicked node mid-interaction — userEvent's pointer/timer machinery spins
+    // on the detached element. A plain synchronous click is the right tool here.
+    fireEvent.click(await screen.findByTestId('demo-advance-control'));
+
+    // Pointer bumped + navigated to the board.
+    await screen.findByTestId('board-landing');
+    expect(window.localStorage.getItem(REVEAL_KEY)).toBe('plan');
+  });
+
+  it('ac-34: at the done phase the control is Reset — re-seeds, clears the pointer, returns to the board', async () => {
+    tagAc(AC(34));
+    docIsDemo = true;
+    resetHandholdDemoMock.mockResolvedValue(undefined);
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    // Pointer at the terminal 'done' phase → no next, so the control is Reset.
+    window.localStorage.setItem(REVEAL_KEY, 'done');
+    renderDoc();
+
+    const reset = await screen.findByTestId('demo-reset-control');
+    expect(screen.queryByTestId('demo-advance-control')).not.toBeInTheDocument();
+
+    // fireEvent: the handler navigates away, unmounting the button — same
+    // detached-node hazard for userEvent as the advance test above.
+    fireEvent.click(reset);
+
+    await waitFor(() => expect(resetHandholdDemoMock).toHaveBeenCalledWith('alice', 'personal'));
+    // Pointer cleared back to draft, then navigated to the board.
+    await waitFor(() => expect(window.localStorage.getItem(REVEAL_KEY)).toBe('draft'));
+    await screen.findByTestId('board-landing');
+    confirmSpy.mockRestore();
+  });
+});

--- a/packages/ui/src/pages/DocDocument.tsx
+++ b/packages/ui/src/pages/DocDocument.tsx
@@ -10,6 +10,7 @@ import {
   pauseDoc,
   unpauseDoc,
   updateDocStatus,
+  resetHandholdDemo,
   NotFoundError,
   type AcWithVerification,
   type DocAssigneeView,
@@ -49,6 +50,7 @@ import { formatDate, docSeq } from '../utils/format';
 import { tenantPath, getCurrentTenant } from '../utils/tenantUrl';
 import { PromptButton } from '../components/PromptButton';
 import { useMemexAccess } from '../hooks/useMemexAccess';
+import { useHandholdReveal, nextRevealPhase } from '../hooks/useHandholdReveal';
 import { BylineAssignees } from '../components/BylineAssignees';
 import { useDocRole } from '../hooks/useDocRole';
 import { useOrgScaffoldBlocks } from '../hooks/useOrgScaffoldBlocks';
@@ -58,9 +60,24 @@ export function DocDocument() {
   // deep-links `specs/:id/decisions/:decId` and `specs/:id/issues/:issueId` (the
   // shape the ⌘K palette navigates to). `id` is the Spec handle; `decId`/`issueId`
   // are the optional sub-targets that open the relevant tab + scroll into view.
-  const { id, decId, issueId } = useParams<{ id: string; decId?: string; issueId?: string }>();
+  const { id, decId, issueId, namespace, memex } = useParams<{
+    id: string;
+    decId?: string;
+    issueId?: string;
+    namespace?: string;
+    memex?: string;
+  }>();
   const navigate = useNavigate();
   const location = useLocation();
+  // spec-178 t-10 (dec-10): the progressive-reveal pointer, scoped to the
+  // tenant in the route. Same hook the board uses, so advancing here and the
+  // board's filter agree on which demo phase is shown. Tenant comes from the
+  // route params (router-driven, unlike window.location); the hook is null-safe.
+  const {
+    revealedPhase,
+    advance: advanceReveal,
+    reset: resetReveal,
+  } = useHandholdReveal(namespace ?? null, memex ?? null);
   // spec-111 t-8: gate every mutation surface on this doc page behind write
   // access to the current Memex. A non-member reading a public Memex sees the
   // full document, decisions, tasks, ACs, and comments — but no edit/create/
@@ -564,6 +581,40 @@ export function DocDocument() {
     url: `${window.location.origin}/${tenant?.namespace ?? ''}/${tenant?.memex ?? ''}/specs/${doc.handle}`,
   };
 
+  // ── spec-178 t-10 (dec-10): the in-page progressive-reveal advance control ──
+  // On a demo spec the page mirrors the board's advance affordance near the
+  // value banner. Advancing bumps the shared reveal pointer and navigates back
+  // to the board, where the freshly-revealed (next-phase) demo card is now the
+  // one shown — the cleaner of the two offered paths (the board is the demo's
+  // home; the spec we just walked away from is no longer revealed). At the
+  // terminal 'done' phase there is no next: the control becomes "Reset demo",
+  // firing the SAME re-seed (resetHandholdDemo) the board's Reset button does
+  // plus reset()-ing the pointer to 'draft', then returning to the board.
+  const demoNextPhase = doc.isDemo ? nextRevealPhase(revealedPhase) : null;
+  const handleDemoAdvance = () => {
+    advanceReveal();
+    navigate(tenantPath('/specs'));
+  };
+  const handleDemoResetFromDoc = async () => {
+    if (
+      !window.confirm(
+        'Reset the demo specs? This deletes the current demo specs and re-seeds a fresh set. Your real specs are untouched.',
+      )
+    ) {
+      return;
+    }
+    try {
+      // Tenant comes from the route params (same source the reveal hook keys
+      // on), so the re-seed target and the pointer key always agree.
+      if (namespace && memex) await resetHandholdDemo(namespace, memex);
+      resetReveal();
+    } catch (err) {
+      window.alert(err instanceof Error ? err.message : 'Failed to reset demo');
+      return;
+    }
+    navigate(tenantPath('/specs'));
+  };
+
   // ── spec-159 ac-19: the writable reviewer's review-action row ──────────────
   // The same four scaffold chat prompts the OpeningTurn reviewer set surfaces
   // (Summarise / Security / Design / Architecture). Each resolves its prose from
@@ -818,6 +869,8 @@ export function DocDocument() {
             canEdit={canEdit}
             commentsCollapsed={commentsCollapsed}
             onExpandComments={() => setCommentsCollapsed(false)}
+            /* spec-178 ac-24: a frozen demo spec suppresses handle auto-linking. */
+            isDemo={doc?.isDemo ?? false}
           />
         ))}
       </div>
@@ -845,6 +898,8 @@ export function DocDocument() {
       onJumpToAc={handleJumpToAc}
       canWrite={canWrite}
       canEdit={canEdit}
+      /* spec-178 ac-24: same handle auto-linking suppression for demo decisions. */
+      isDemo={doc.isDemo ?? false}
     />
   );
 
@@ -980,6 +1035,53 @@ export function DocDocument() {
             spec-159 — it's handled elsewhere; SpecRoleControls is no longer
             rendered here. */}
       </div>
+
+      {/* spec-178 ac-25/ac-26 (dec-8): the per-phase value banner atop a demo spec.
+          The server attaches `demoValueCallout` to the GET payload of an is_demo doc,
+          keyed to the doc's current phase. It is DEMO GUIDANCE — a "what this phase is
+          for" callout — NOT part of the spec content, so it renders as a distinct
+          accent panel above the document body rather than inside a section. Shown only
+          when the doc is a demo AND a callout exists for its phase; absent on real
+          specs and on demo phases that carry no callout. */}
+      {doc.isDemo && doc.demoValueCallout && (
+        <div
+          data-testid="demo-value-banner"
+          className="mb-4 flex items-start gap-2.5 rounded-lg border border-accent/40 bg-accent/10 px-4 py-3"
+        >
+          <Badge status="demo" label="DEMO" className="flex-none mt-0.5" />
+          <p className="text-sm text-primary leading-relaxed">{doc.demoValueCallout}</p>
+        </div>
+      )}
+
+      {/* spec-178 ac-33/ac-34 (dec-10): the in-page progressive-reveal advance
+          control, near the value banner and rendered ONLY on a demo spec. It
+          walks the shared reveal pointer and returns to the board (the demo's
+          home), where the next-phase demo card is now revealed. At 'done' there
+          is no next, so it becomes "Reset demo" — same re-seed + pointer reset
+          as the board's Reset button. Absent on real specs. */}
+      {doc.isDemo && (
+        <div className="mb-4">
+          {demoNextPhase ? (
+            <button
+              type="button"
+              data-testid="demo-advance-control"
+              onClick={handleDemoAdvance}
+              className="text-sm font-medium text-accent hover:text-accent-hover inline-flex items-center gap-1 px-3 py-1.5 rounded-md border border-accent/40 bg-accent/10 hover:bg-accent/20 transition-colors"
+            >
+              See it in {phaseDisplayName(demoNextPhase)} →
+            </button>
+          ) : (
+            <button
+              type="button"
+              data-testid="demo-reset-control"
+              onClick={handleDemoResetFromDoc}
+              className="text-sm font-medium text-secondary hover:text-primary inline-flex items-center gap-1 px-3 py-1.5 rounded-md border border-edge hover:bg-overlay transition-colors"
+            >
+              Reset demo
+            </button>
+          )}
+        </div>
+      )}
 
       {shareOpen && <ShareModal docId={doc.id} onClose={() => setShareOpen(false)} />}
       {/* The header Share pill — the Spec's canonical URL with a Copy button

--- a/packages/ui/src/pages/SpecList.demo.test.tsx
+++ b/packages/ui/src/pages/SpecList.demo.test.tsx
@@ -1,0 +1,385 @@
+// spec-178 (A-UI, t-8): the Specs board's demo surfaces.
+//   ac-3 / ac-12: a DEMO badge marks each is_demo card; real specs carry none.
+//   ac-11:        non-demo specs render unchanged (no badge).
+//   ac-18:        the Reset-demo button shows ONLY when ≥1 demo spec is present.
+//   ac-19:        clicking Reset confirms before hitting the reset endpoint.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { SpecList } from './SpecList';
+import type { DocSummary } from '../api/types';
+import { tagAc } from '@memex-ai-ac/vitest';
+
+const SPEC_178 = 'mindset-prod/memex-building-itself/specs/spec-178';
+const AC = (n: number) => `${SPEC_178}/acs/ac-${n}`;
+
+// Hermetic: useDocChangeStream opens a real EventSource otherwise.
+vi.mock('../hooks/useDocChangeStream', () => ({
+  useDocChangeStream: () => {},
+}));
+
+const fetchDocsMock = vi.fn();
+const resetHandholdDemoMock = vi.fn();
+vi.mock('../api/client', () => ({
+  fetchDocs: (...args: unknown[]) => fetchDocsMock(...args),
+  updateDocStatus: vi.fn(),
+  archiveDoc: vi.fn(),
+  pauseDoc: vi.fn(),
+  unpauseDoc: vi.fn(),
+  resetHandholdDemo: (...args: unknown[]) => resetHandholdDemoMock(...args),
+}));
+
+// The Reset button reads the current tenant for the namespace/memex it POSTs to.
+const { mockTenant } = vi.hoisted(() => ({
+  mockTenant: { value: { namespace: 'alice', memex: 'personal' } as { namespace: string; memex: string } | null },
+}));
+vi.mock('../utils/tenantUrl', async () => {
+  const actual = await vi.importActual<typeof import('../utils/tenantUrl')>('../utils/tenantUrl');
+  return {
+    ...actual,
+    getCurrentTenant: () => mockTenant.value,
+  };
+});
+
+vi.mock('../components/NewSpecModal', () => ({ NewSpecModal: () => null }));
+vi.mock('../components/ShareModal', () => ({ ShareModal: () => null }));
+vi.mock('../components/RenameSpecDialog', () => ({ RenameSpecDialog: () => null }));
+vi.mock('../components/MoveSpecDialog', () => ({ MoveSpecDialog: () => null }));
+vi.mock('../components/CreateOrgBanner', () => ({ CreateOrgBanner: () => null }));
+
+vi.mock('../components/AuthContext', () => ({
+  useAuth: () => ({ session: null }),
+}));
+
+// Reset / New-Spec controls gate on write access; default to writable here so the
+// demo-management surfaces actually render (jsdom would otherwise pin canWrite false).
+const { mockCanWrite } = vi.hoisted(() => ({ mockCanWrite: { value: true } }));
+vi.mock('../hooks/useMemexAccess', () => ({
+  useMemexAccess: () => ({
+    isAuthenticated: true,
+    membership: null,
+    canWrite: mockCanWrite.value,
+    isReadOnly: !mockCanWrite.value,
+    isVisitedReadOnly: false,
+  }),
+}));
+
+function spec(overrides: Partial<DocSummary> = {}): DocSummary {
+  return {
+    id: 's-1',
+    handle: 'doc-1',
+    title: 'Untitled spec',
+    docType: 'spec',
+    status: 'draft',
+    parentDocId: null,
+    createdAt: '2025-01-01T00:00:00Z',
+    statusChangedAt: '2025-01-01T00:00:00Z',
+    sectionCount: 0,
+    pausedAt: null,
+    archivedAt: null,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockCanWrite.value = true;
+  mockTenant.value = { namespace: 'alice', memex: 'personal' };
+  // The reveal pointer persists in localStorage keyed by tenant — clear it so
+  // each test starts from the default 'draft' phase.
+  try {
+    window.localStorage.clear();
+  } catch {
+    /* jsdom always has storage; guard anyway */
+  }
+});
+
+// spec-178 t-10 (dec-10): the five demo specs, one per phase. Shared by the
+// progressive-reveal tests below — fetchDocs returns all five, the board reveals
+// one at a time.
+const DEMO_PHASES = ['draft', 'plan', 'build', 'verify', 'done'] as const;
+function demoSet() {
+  return DEMO_PHASES.map((phase, i) =>
+    spec({
+      id: `demo-${phase}`,
+      title: `Demo ${phase}`,
+      handle: `spec-${i + 1}`,
+      status: phase,
+      isDemo: true,
+    }),
+  );
+}
+
+describe('SpecList demo badge (spec-178)', () => {
+  it('ac-3/ac-12: a DEMO badge marks an is_demo card and not a real one', async () => {
+    tagAc(AC(3));
+    tagAc(AC(12));
+    fetchDocsMock.mockResolvedValueOnce([
+      spec({ id: 'demo-1', title: 'Demo spec', handle: 'spec-1', isDemo: true }),
+      spec({ id: 'real-1', title: 'Real spec', handle: 'spec-2' }),
+    ]);
+
+    render(
+      <MemoryRouter>
+        <SpecList />
+      </MemoryRouter>,
+    );
+
+    const demoCard = (await screen.findByText('Demo spec')).closest('a')!;
+    const realCard = screen.getByText('Real spec').closest('a')!;
+    // The demo card carries the DEMO badge — the visible Badge label plus the
+    // sr-only test hook (both read "DEMO"), so it appears inside the demo card.
+    expect(within(demoCard).getAllByText('DEMO').length).toBeGreaterThan(0);
+    expect(within(demoCard).getByTestId('spec-demo-pill')).toBeInTheDocument();
+    // The real card has neither the badge nor the pill.
+    expect(within(realCard).queryByText('DEMO')).not.toBeInTheDocument();
+    expect(within(realCard).queryByTestId('spec-demo-pill')).not.toBeInTheDocument();
+    // Exactly one DEMO pill across the board.
+    expect(screen.getAllByTestId('spec-demo-pill')).toHaveLength(1);
+  });
+
+  it('ac-11: a board of only real specs shows no DEMO badge anywhere', async () => {
+    tagAc(AC(11));
+    fetchDocsMock.mockResolvedValueOnce([
+      spec({ id: 'real-1', title: 'Real spec A', handle: 'spec-1' }),
+      spec({ id: 'real-2', title: 'Real spec B', handle: 'spec-2' }),
+    ]);
+
+    render(
+      <MemoryRouter>
+        <SpecList />
+      </MemoryRouter>,
+    );
+
+    await screen.findByText('Real spec A');
+    expect(screen.queryByText('DEMO')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('spec-demo-pill')).not.toBeInTheDocument();
+  });
+});
+
+describe('SpecList reset-demo button (spec-178)', () => {
+  it('ac-18: the Reset-demo button is ABSENT when no demo specs are present', async () => {
+    tagAc(AC(18));
+    fetchDocsMock.mockResolvedValueOnce([
+      spec({ id: 'real-1', title: 'Real spec', handle: 'spec-1' }),
+    ]);
+
+    render(
+      <MemoryRouter>
+        <SpecList />
+      </MemoryRouter>,
+    );
+
+    await screen.findByText('Real spec');
+    expect(screen.queryByTestId('reset-demo-button')).not.toBeInTheDocument();
+  });
+
+  it('ac-18: the Reset-demo button is PRESENT when ≥1 demo spec is on the board', async () => {
+    tagAc(AC(18));
+    fetchDocsMock.mockResolvedValueOnce([
+      spec({ id: 'demo-1', title: 'Demo spec', handle: 'spec-1', isDemo: true }),
+      spec({ id: 'real-1', title: 'Real spec', handle: 'spec-2' }),
+    ]);
+
+    render(
+      <MemoryRouter>
+        <SpecList />
+      </MemoryRouter>,
+    );
+
+    await screen.findByText('Demo spec');
+    expect(screen.getByTestId('reset-demo-button')).toBeInTheDocument();
+  });
+
+  it('ac-19: clicking Reset confirms BEFORE calling the endpoint — cancel aborts', async () => {
+    tagAc(AC(19));
+    const user = userEvent.setup();
+    fetchDocsMock.mockResolvedValue([
+      spec({ id: 'demo-1', title: 'Demo spec', handle: 'spec-1', isDemo: true }),
+    ]);
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+
+    render(
+      <MemoryRouter>
+        <SpecList />
+      </MemoryRouter>,
+    );
+
+    await screen.findByTestId('reset-demo-button');
+    await user.click(screen.getByTestId('reset-demo-button'));
+
+    // Confirm was asked; the user declined → the endpoint was never hit.
+    expect(confirmSpy).toHaveBeenCalledTimes(1);
+    expect(resetHandholdDemoMock).not.toHaveBeenCalled();
+    confirmSpy.mockRestore();
+  });
+
+  it('ac-19: confirming fires the reset for the current tenant, then refetches', async () => {
+    tagAc(AC(19));
+    const user = userEvent.setup();
+    fetchDocsMock.mockResolvedValue([
+      spec({ id: 'demo-1', title: 'Demo spec', handle: 'spec-1', isDemo: true }),
+    ]);
+    resetHandholdDemoMock.mockResolvedValue(undefined);
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+
+    render(
+      <MemoryRouter>
+        <SpecList />
+      </MemoryRouter>,
+    );
+
+    await screen.findByTestId('reset-demo-button');
+    // One initial board load before the click.
+    expect(fetchDocsMock).toHaveBeenCalledTimes(1);
+
+    await user.click(screen.getByTestId('reset-demo-button'));
+
+    await waitFor(() =>
+      expect(resetHandholdDemoMock).toHaveBeenCalledWith('alice', 'personal'),
+    );
+    // After the reset the board refetches (a second loadDocs call).
+    await waitFor(() => expect(fetchDocsMock).toHaveBeenCalledTimes(2));
+    confirmSpy.mockRestore();
+  });
+});
+
+describe('SpecList progressive reveal (spec-178)', () => {
+  it('ac-33/ac-34: first view reveals ONLY the draft demo; real specs are unaffected', async () => {
+    tagAc(AC(33));
+    tagAc(AC(34));
+    fetchDocsMock.mockResolvedValue([
+      ...demoSet(),
+      spec({ id: 'real-1', title: 'Real spec', handle: 'spec-99', status: 'plan' }),
+    ]);
+
+    render(
+      <MemoryRouter>
+        <SpecList />
+      </MemoryRouter>,
+    );
+
+    // Only the draft demo shows; the other four demo phases are hidden.
+    await screen.findByText('Demo draft');
+    expect(screen.queryByText('Demo plan')).not.toBeInTheDocument();
+    expect(screen.queryByText('Demo build')).not.toBeInTheDocument();
+    expect(screen.queryByText('Demo verify')).not.toBeInTheDocument();
+    expect(screen.queryByText('Demo done')).not.toBeInTheDocument();
+    // A non-demo spec at the same phase is untouched by the reveal filter.
+    expect(screen.getByText('Real spec')).toBeInTheDocument();
+    // Exactly one demo card → exactly one advance control on the board.
+    expect(screen.getAllByTestId('demo-advance-control')).toHaveLength(1);
+  });
+
+  it('ac-34: the advance control is ABSENT on a non-demo card', async () => {
+    tagAc(AC(34));
+    fetchDocsMock.mockResolvedValue([
+      spec({ id: 'demo-draft', title: 'Demo draft', handle: 'spec-1', status: 'draft', isDemo: true }),
+      spec({ id: 'real-1', title: 'Real spec', handle: 'spec-2', status: 'draft' }),
+    ]);
+
+    render(
+      <MemoryRouter>
+        <SpecList />
+      </MemoryRouter>,
+    );
+
+    const realCard = (await screen.findByText('Real spec')).closest('a')!;
+    const realCardWrapper = realCard.parentElement!;
+    // The advance control lives on the demo card only — never within a real card.
+    expect(within(realCardWrapper).queryByTestId('demo-advance-control')).not.toBeInTheDocument();
+    // The single board-wide advance control belongs to the demo card.
+    expect(screen.getAllByTestId('demo-advance-control')).toHaveLength(1);
+  });
+
+  it('ac-33/ac-34: advancing reveals ONLY the next (plan) demo and bumps the pointer', async () => {
+    tagAc(AC(33));
+    tagAc(AC(34));
+    const user = userEvent.setup();
+    fetchDocsMock.mockResolvedValue(demoSet());
+
+    render(
+      <MemoryRouter>
+        <SpecList />
+      </MemoryRouter>,
+    );
+
+    await screen.findByText('Demo draft');
+    // The draft card's control offers the next phase ("Specify" is plan's display name).
+    const advance = screen.getByTestId('demo-advance-control');
+    expect(advance).toHaveTextContent('Specify');
+
+    await user.click(advance);
+
+    // The pointer bumped to 'plan': only the plan demo shows now, draft is gone.
+    await screen.findByText('Demo plan');
+    expect(screen.queryByText('Demo draft')).not.toBeInTheDocument();
+    expect(screen.queryByText('Demo build')).not.toBeInTheDocument();
+    // Persisted to localStorage under the tenant-scoped key.
+    expect(window.localStorage.getItem('handhold-reveal:alice/personal')).toBe('plan');
+  });
+
+  it('ac-34: at the done phase the control becomes Reset, wired to the reset action', async () => {
+    tagAc(AC(34));
+    const user = userEvent.setup();
+    fetchDocsMock.mockResolvedValue(demoSet());
+    resetHandholdDemoMock.mockResolvedValue(undefined);
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    // Pre-seed the pointer at 'done' so the revealed demo is the terminal one.
+    window.localStorage.setItem('handhold-reveal:alice/personal', 'done');
+
+    render(
+      <MemoryRouter>
+        <SpecList />
+      </MemoryRouter>,
+    );
+
+    // The done demo lives in the Done rail (auto-visible while it's the revealed
+    // card via the board's reset, but here the rail is collapsed by default —
+    // the board header Reset is the always-visible terminal action). Assert the
+    // done demo is the only revealed card.
+    await screen.findByText('Demo done');
+    expect(screen.queryByText('Demo draft')).not.toBeInTheDocument();
+    expect(screen.queryByText('Demo plan')).not.toBeInTheDocument();
+
+    // The board header's Reset button is the always-available terminal action;
+    // clicking it re-seeds AND clears the reveal pointer back to 'draft'.
+    await user.click(screen.getByTestId('reset-demo-button'));
+    await waitFor(() => expect(resetHandholdDemoMock).toHaveBeenCalledWith('alice', 'personal'));
+    await waitFor(() =>
+      expect(window.localStorage.getItem('handhold-reveal:alice/personal')).toBe('draft'),
+    );
+    confirmSpy.mockRestore();
+  });
+
+  it('ac-33/ac-34: board Reset clears the pointer → draft-only is restored', async () => {
+    tagAc(AC(33));
+    tagAc(AC(34));
+    const user = userEvent.setup();
+    fetchDocsMock.mockResolvedValue(demoSet());
+    resetHandholdDemoMock.mockResolvedValue(undefined);
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    // Pointer advanced to 'build' before the reset.
+    window.localStorage.setItem('handhold-reveal:alice/personal', 'build');
+
+    render(
+      <MemoryRouter>
+        <SpecList />
+      </MemoryRouter>,
+    );
+
+    // Build demo is the only one revealed pre-reset.
+    await screen.findByText('Demo build');
+    expect(screen.queryByText('Demo draft')).not.toBeInTheDocument();
+
+    await user.click(screen.getByTestId('reset-demo-button'));
+
+    // Reset snaps the pointer to draft → only the draft demo shows again.
+    await screen.findByText('Demo draft');
+    await waitFor(() => expect(screen.queryByText('Demo build')).not.toBeInTheDocument());
+    expect(window.localStorage.getItem('handhold-reveal:alice/personal')).toBe('draft');
+    confirmSpy.mockRestore();
+  });
+});

--- a/packages/ui/src/pages/SpecList.tsx
+++ b/packages/ui/src/pages/SpecList.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, useCallback, useMemo, type DragEvent, type ReactNode } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
-import { fetchDocs, updateDocStatus, archiveDoc, pauseDoc, unpauseDoc } from '../api/client';
+import { fetchDocs, updateDocStatus, archiveDoc, pauseDoc, unpauseDoc, resetHandholdDemo } from '../api/client';
 import { type DocSummary, type DocSummaryAssignee } from '../api/types';
 import { statusTextClass } from '../utils/statusStyles';
 import { phaseDisplayName } from '../utils/phaseDisplay';
@@ -15,8 +15,9 @@ import { TagFilter } from '../components/TagFilter';
 import { ShareModal } from '../components/ShareModal';
 import { RenameSpecDialog } from '../components/RenameSpecDialog';
 import { MoveSpecDialog } from '../components/MoveSpecDialog';
-import { tenantPath } from '../utils/tenantUrl';
+import { tenantPath, getCurrentTenant } from '../utils/tenantUrl';
 import { useAuth } from '../components/AuthContext';
+import { useHandholdReveal, nextRevealPhase, type RevealPhase } from '../hooks/useHandholdReveal';
 import { useIsFeatureHidden } from '../hooks/useIsFeatureHidden';
 import { useMemexAccess } from '../hooks/useMemexAccess';
 import { CreateOrgBanner } from '../components/CreateOrgBanner';
@@ -125,6 +126,14 @@ interface KanbanColumnProps {
   // Renders the "+ Add spec" pinned card at the top of the column when set.
   // Click invokes the same NewSpecModal as the page-header button.
   onAddSpec?: () => void;
+  // spec-178 t-10 (dec-10): progressive-reveal advance control. Rendered ONLY on
+  // is_demo cards. `revealNextPhase` is the phase that follows the revealed one
+  // (null at 'done' — the terminal phase, where the control becomes Reset).
+  // `onAdvanceDemo` bumps the reveal pointer; `onResetDemo` is the done-phase
+  // terminal action (re-seed + pointer reset). Absent on non-demo boards.
+  revealNextPhase?: RevealPhase | null;
+  onAdvanceDemo?: () => void;
+  onResetDemo?: () => void;
 }
 
 function KanbanColumn(props: KanbanColumnProps) {
@@ -145,6 +154,9 @@ function KanbanColumn(props: KanbanColumnProps) {
     className = '',
     headerExtra,
     onAddSpec,
+    revealNextPhase,
+    onAdvanceDemo,
+    onResetDemo,
   } = props;
   return (
     <div
@@ -208,6 +220,13 @@ function KanbanColumn(props: KanbanColumnProps) {
                     )}
                     {d.title}
                   </h3>
+                  {/* spec-178 ac-3/ac-12: the DEMO badge marks each frozen
+                      Handhold demo spec on the board. Real specs carry no
+                      `isDemo`, so they never render it (ac-11/ac-12). Mirrors the
+                      Paused badge's chrome; the two can co-exist on one card. */}
+                  {d.isDemo && (
+                    <Badge status="demo" label="DEMO" className="flex-none" />
+                  )}
                   {isPaused && (
                     <Badge
                       status="paused"
@@ -218,6 +237,14 @@ function KanbanColumn(props: KanbanColumnProps) {
                     />
                   )}
                 </div>
+                {d.isDemo && (
+                  // Hidden DOM hook for the test — mirrors the paused pill: the
+                  // visible Badge above is the user-facing surface, this lets a
+                  // test assert the DEMO pill without coupling to Badge classes.
+                  <span data-testid="spec-demo-pill" className="sr-only">
+                    DEMO
+                  </span>
+                )}
                 {isPaused && (
                   // Hidden DOM hook for the test — the visible Badge above is
                   // the user-facing surface; this lets us assert the pill
@@ -261,6 +288,36 @@ function KanbanColumn(props: KanbanColumnProps) {
                 )}
                 <SpecHealthStrip health={d.acHealth} />
               </Link>
+              {/* spec-178 ac-33/ac-34 (dec-10): the progressive-reveal advance
+                  control. Renders ONLY on is_demo cards (never on real specs),
+                  and only when the demo-management callbacks are wired (i.e. the
+                  board owns a reveal pointer). Clicking it walks the demo one
+                  phase along — the current card disappears and the next phase's
+                  demo card appears, giving the impression of one spec moving
+                  across the board. At the terminal 'done' phase there is no
+                  next: the control becomes "Reset demo", wired to the same
+                  re-seed + pointer-reset as the board header's Reset button. */}
+              {d.isDemo && onAdvanceDemo && onResetDemo && (
+                revealNextPhase ? (
+                  <button
+                    type="button"
+                    data-testid="demo-advance-control"
+                    onClick={onAdvanceDemo}
+                    className="mt-2 w-full text-xs font-medium text-accent hover:text-accent-hover inline-flex items-center justify-center gap-1 px-2 py-1.5 rounded-md border border-accent/40 bg-accent/10 hover:bg-accent/20 transition-colors"
+                  >
+                    See it in {phaseDisplayName(revealNextPhase)} →
+                  </button>
+                ) : (
+                  <button
+                    type="button"
+                    data-testid="demo-reset-control"
+                    onClick={onResetDemo}
+                    className="mt-2 w-full text-xs font-medium text-secondary hover:text-primary inline-flex items-center justify-center gap-1 px-2 py-1.5 rounded-md border border-edge hover:bg-overlay transition-colors"
+                  >
+                    Reset demo
+                  </button>
+                )
+              )}
               {canWrite && (
                 <div className="absolute top-1.5 right-1.5 opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity">
                   <SpecMenu
@@ -347,6 +404,18 @@ export function SpecList() {
     (m) => m.memexId === session?.currentMemexId,
   );
   const showPersonalBanner = currentMembership?.kind === 'personal';
+  // spec-178 t-10 (dec-10): the progressive-reveal pointer. The five demo specs
+  // are all seeded (one per phase) but only ONE is shown on the board at a time
+  // — the one whose status === revealedPhase. Advancing the pointer walks the
+  // demo across the board (draft → plan → build → verify → done). Purely a
+  // client-side affordance, keyed by the current tenant so each personal Memex
+  // tracks its own walkthrough. `getCurrentTenant()` is null on caller-scoped
+  // routes; the hook is null-safe and just collapses to a shared key there.
+  const revealTenant = getCurrentTenant();
+  const { revealedPhase, advance: advanceReveal, reset: resetReveal } = useHandholdReveal(
+    revealTenant?.namespace ?? null,
+    revealTenant?.memex ?? null,
+  );
   const [docs, setDocs] = useState<DocSummary[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -385,6 +454,16 @@ export function SpecList() {
       // Same fallback as the reader — silent on storage failures.
     }
   }, [showPaused]);
+
+  // spec-178 t-10 (dec-10): when the demo has been walked all the way to 'done'
+  // the revealed card lives in the Done rail — which collapses by default.
+  // Auto-expand it whenever a done-phase demo is the revealed card so the
+  // walkthrough's final card (and its on-card "Reset demo" control) is visible,
+  // including on a fresh page load with the pointer already at 'done'.
+  const hasRevealedDoneDemo = docs.some((d) => d.isDemo && d.status === 'done');
+  useEffect(() => {
+    if (revealedPhase === 'done' && hasRevealedDoneDemo) setDoneExpanded(true);
+  }, [revealedPhase, hasRevealedDoneDemo]);
 
   const loadDocs = useCallback(() => {
     // b-66 t-3: ask the server for the per-Spec AC-health roll-up. The
@@ -536,6 +615,39 @@ export function SpecList() {
     }
   }, [docs]);
 
+  // spec-178 ac-18/ac-19: re-seed the personal Memex's Handhold demo. The button
+  // that calls this is shown ONLY when at least one demo spec is on the board (see
+  // hasDemoSpecs below); a window.confirm step (ac-19) gates the destructive
+  // re-seed before the endpoint is hit. The namespace/memex come from the current
+  // tenant context (the path-based router puts them in the first two URL segments).
+  // After the reset the board refetches so the re-seeded specs replace the old set.
+  const [resetting, setResetting] = useState(false);
+  const handleResetDemo = useCallback(async () => {
+    const tenant = getCurrentTenant();
+    if (!tenant) return;
+    if (
+      !window.confirm(
+        'Reset the demo specs? This deletes the current demo specs and re-seeds a fresh set. Your real specs are untouched.',
+      )
+    ) {
+      return;
+    }
+    setResetting(true);
+    try {
+      await resetHandholdDemo(tenant.namespace, tenant.memex);
+      // spec-178 ac-34 (dec-10): a board Reset restores the draft-only view —
+      // re-seed the demo specs AND snap the reveal pointer back to 'draft' so
+      // only the first demo spec shows again.
+      resetReveal();
+      loadDocs();
+    } catch (err) {
+      console.error('Failed to reset demo', err);
+      window.alert(err instanceof Error ? err.message : 'Failed to reset demo');
+    } finally {
+      setResetting(false);
+    }
+  }, [loadDocs, resetReveal]);
+
   const buildMenuItems = useCallback(
     (doc: DocSummary): SpecMenuItem[] => {
       const items: SpecMenuItem[] = [
@@ -601,6 +713,14 @@ export function SpecList() {
     // effectiveShowPaused above).
     if (d.archivedAt) continue;
     if (d.pausedAt && !effectiveShowPaused) continue;
+    // spec-178 ac-33/ac-34 (dec-10): progressive reveal. fetchDocs returns all
+    // five demo specs (one per phase), but the board shows only the one whose
+    // status matches the reveal pointer — hide the other four client-side. Real
+    // (non-demo) specs are never touched by this filter. Demo specs carry the
+    // canonical phase values (draft/plan/build/verify/done), so we compare the
+    // raw status against the pointer before the legacy review/implementation
+    // remap below (which never applies to demo rows).
+    if (d.isDemo && d.status !== revealedPhase) continue;
     // spec-118 ac-19: assignee filter (assigned to me / specific person / all).
     if (!matchesAssigneeFilter(d)) continue;
     // Specs should never carry `approved` (execution-plan terminal state, t-20 W-B);
@@ -616,6 +736,21 @@ export function SpecList() {
     if (!(remapped in docsByColumn)) continue;
     docsByColumn[remapped].push(d);
   }
+
+  // spec-178 t-10 (dec-10): the phase the revealed demo spec advances INTO. Null
+  // at the terminal 'done' phase — its advance control becomes "Reset demo".
+  const revealNextPhase = nextRevealPhase(revealedPhase);
+  // Advancing the reveal one phase along. When the next phase is 'done' the demo
+  // card lands in the Done rail (collapsed by default) — auto-expand it so the
+  // walkthrough's final card (and its "Reset demo" control) is actually visible.
+  const onAdvanceDemo = () => {
+    if (revealNextPhase === 'done') setDoneExpanded(true);
+    advanceReveal();
+  };
+  // The done-phase terminal control re-uses the SAME action as the board's
+  // header Reset button (re-seed + pointer reset). Only meaningful when at
+  // least one demo spec is on the board; the demo card render gates on isDemo.
+  const onResetDemo = handleResetDemo;
 
   return (
     <div className="h-full flex flex-col px-6 py-6">
@@ -660,6 +795,20 @@ export function SpecList() {
                 Show paused
               </label>
             )}
+            {/* spec-178 ac-18: the Reset-demo button appears on the board header
+                ONLY when at least one demo spec is present, and is absent
+                otherwise. ac-19: clicking it confirms before the re-seed runs.
+                Gated on write access alongside the other mutating board controls. */}
+            {canWrite && docs.some((d) => d.isDemo) && (
+              <Button
+                variant="secondary"
+                onClick={handleResetDemo}
+                disabled={resetting}
+                data-testid="reset-demo-button"
+              >
+                {resetting ? 'Resetting…' : 'Reset demo'}
+              </Button>
+            )}
             {canWrite && <Button onClick={() => setModalOpen(true)}>+ New Spec</Button>}
           </>
         }
@@ -697,6 +846,9 @@ export function SpecList() {
             onDrop={handleDrop}
             className="flex-1 min-w-[14rem]"
             onAddSpec={col.id === 'draft' ? () => setModalOpen(true) : undefined}
+            revealNextPhase={revealNextPhase}
+            onAdvanceDemo={onAdvanceDemo}
+            onResetDemo={onResetDemo}
           />
         ))}
         {/* Done rail (dec-5): collapsed by default, click to expand. While a
@@ -721,6 +873,9 @@ export function SpecList() {
               onDragLeave={() => setDragOverColumn((c) => (c === 'done' ? null : c))}
               onDrop={handleDrop}
               className="flex-1"
+              revealNextPhase={revealNextPhase}
+              onAdvanceDemo={onAdvanceDemo}
+              onResetDemo={onResetDemo}
               headerExtra={
                 <button
                   type="button"


### PR DESCRIPTION
## spec-178 — Handhold onboarding demo

Seeds every new **personal** Memex with a resettable 5-phase walkthrough built from five frozen copies of spec-64, so a brand-new user sees a worked example of a Spec moving `draft → done`. Spec: `mindset-prod/memex-building-itself/specs/spec-178` (11/11 decisions resolved).

### What it does
- **Seed on signup** — `ensureUserNamespace` best-effort seeds the 5 demo specs into each new personal (`kind='user'`) Memex; idempotent (0-demo guard, `is_demo` set at creation).
- **Progressive reveal** — client-side `useHandholdReveal` (localStorage pointer per ns/memex) shows one phase at a time; a demo-only advance control walks `draft → … → done`, then "Reset demo".
- **Reset** — owner-gated `POST /api/:ns/:memex/handhold/reset` (std-7 404s otherwise); hard-deletes demo docs + their synthetic emissions, then re-seeds and clears the reveal pointer.
- **Excluded from ⌘K and ALL agent surfaces** (dec-11 reverses dec-5): `searchMemex`, the MCP `listDocs` path, and both `resolveRefForUser` (coding agent) + `resolveRefForAgent` (in-app agent) 404 on demo docs. Demo specs render on the **board UI only**.
- **DEMO badge + per-phase value banner**; rehype ref-linkifier suppressed on demo content.
- **Pulse/analytics exclusion** — `activity-log` filters out demo docs.
- **3 HIGH adversarial-review fixes folded in** (issue-1/2/3 → t-12/13/14): Pulse activity_log leak on reset, seed atomicity / double-seed self-heal, ac-7 seed-failure resilience.

### Migration
Adds hand-written migration **`0077_add_documents_is_demo.sql`** (`documents.is_demo NOT NULL DEFAULT false`). Applied by `scripts/apply-hand-migrations.sh` (tracked in `manual_migrations`, not the drizzle journal). Rebased on top of develop's `0076_add_clause_refs`; the two are independent (different tables) and verified to coexist on a fresh test DB.

### ⚠️ CODEOWNERS gate — needs @barriehadfield
This PR adds one line to **`.legacy-spec-vocab-allowlist.txt`** (`packages/server/src/db/handhold-demo.fixture.ts:vector-strategy`). The demo fixture reproduces spec-64's content **verbatim** (ac-2 — wording unchanged is the contract), and spec-64's t-5 AC uses "vector-strategy" in the *search-strategy* sense (handle | FTS | semantic) — the same technical usage already allowlisted for `services/memex-search.ts`, not the legacy product noun. Per `.github/CODEOWNERS`, additions to this file require **@barriehadfield**'s explicit approval.

### Still outstanding — t-5 deploy.sh backfill hook (deploy owner)
The backfill routine (`backfillHandholdDemo()`) + CLI (`scripts/backfill-handhold-demo.ts`, `pnpm --filter @memex/server db:backfill-handhold`) exist and are tested. **What's NOT wired (intentionally left for the deploy/CI-CD owner — spec-168 territory):** the non-gating hook in the deploy pipeline, after migrations:

```
pnpm --filter @memex/server tsx scripts/backfill-handhold-demo.ts || true
```

This is what closes **ac-28** ("backfill runs automatically as part of the CI/CD deploy") and lets **t-5** flip to complete. Left out of this PR so the feature change doesn't touch the deploy pipeline.

### Verification
- `tsc --noEmit` clean across server + UI (the one pre-existing `discord-webhook.test.ts` type error is on `develop`, in a file this PR does not touch, and is invisible to CI which runs vitest, not tsc).
- 342 server + 23 UI affected/feature tests green locally (handhold seed/reset/backfill, search + agent exclusion, Pulse exclusion, progressive reveal, regression guards).
- AC verification (tagged-suite emission with `MEMEX_EMIT_KEY`) runs on **merge** via CI — emissions are key-gated and not fired from this branch.

### Note on merge
Merge → `develop` is the **gated INT deploy** — that's the maintainer's call, not auto-done here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
