### PR TITLE
spec-178 t-5: wire Handhold existing-memex backfill into the CI/CD deploy (ac-28)

### DIFF
--- a/packages/server/deploy.sh
+++ b/packages/server/deploy.sh
@@ -138,6 +138,23 @@ DATABASE_URL="${DB_URL}" pnpm db:migrate
 echo "  1b. hand-written migrations..."
 DATABASE_URL="${DB_URL}" bash "${PKG_DIR}/scripts/apply-hand-migrations.sh"
 
+# 1c. spec-178 t-5 / ac-28 — backfill the Handhold onboarding demo into EXISTING
+# personal Memexes (namespaces.kind='user') that predate the feature. New signups
+# already get the five frozen demo specs via the post-commit hook in
+# ensureUserNamespace; this is the one-time catch-up. It's idempotent
+# (seedHandholdDemo no-ops on any Memex already holding an is_demo spec), so it's
+# safe to run on EVERY deploy — once seeded it does zero work. It runs here, while
+# the cloud-sql-proxy is still up, against the same proxied DB the migrations used,
+# and because it lives in the shared deploy.sh it covers BOTH environments: INT on
+# each develop deploy, PROD on the daily develop→main promotion.
+#
+# NON-GATING (dec-7): a backfill hiccup must NEVER fail a live deploy. The `|| echo`
+# swallows a non-zero exit so `set -e` can't abort the deploy; the next deploy retries
+# (the work that did land stays, since the seed is per-Memex idempotent).
+echo "  1c. handhold demo backfill (spec-178 t-5 / ac-28)..."
+DATABASE_URL="${DB_URL}" pnpm db:backfill-handhold \
+  || echo "  ⚠ handhold backfill failed (non-gating) — existing Memexes not backfilled this run; retries next deploy."
+
 kill $PROXY_PID 2>/dev/null
 wait $PROXY_PID 2>/dev/null || true
 

--- a/packages/server/src/__regression__/handhold-backfill-deploy-wiring.regression.test.ts
+++ b/packages/server/src/__regression__/handhold-backfill-deploy-wiring.regression.test.ts
@@ -1,0 +1,69 @@
+// spec-178 t-5 / ac-28 — the existing-memex Handhold backfill runs automatically
+// as part of the CI/CD deploy, with NO manual step.
+//
+// The deploy workflow (.github/workflows/deploy.yml) runs the SAME
+// packages/server/deploy.sh a human runs locally, so asserting the backfill is
+// wired into that script proves the "automatic / no manual step" contract: every
+// INT deploy (push to develop) and every PROD deploy (the develop→main promotion)
+// executes it. It is mirrored here as a static guard so a future edit that drops
+// the hook fails CI instead of silently un-wiring the backfill.
+//
+// This guard covers the DEPLOY-WIRING half of ac-28. The RUNTIME half — the
+// backfill is idempotent, reuses seedHandholdDemo under the 0-demo guard, mutates
+// via mutate(), and a re-deploy never double-seeds — is covered by the
+// backfill/self-heal cases in services/handhold-demo.integration.test.ts.
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+const REPO_ROOT = join(__dirname, "..", "..", "..", "..");
+const SERVER_DEPLOY_SH = join(REPO_ROOT, "packages", "server", "deploy.sh");
+const DEPLOY_WORKFLOW = join(REPO_ROOT, ".github", "workflows", "deploy.yml");
+const AC_28 = "mindset-prod/memex-building-itself/specs/spec-178/acs/ac-28";
+
+const deploySh = readFileSync(SERVER_DEPLOY_SH, "utf-8");
+
+// Positions of the load-bearing landmarks in deploy.sh, reused across the
+// ordering assertions below. -1 (not found) is asserted away in each test.
+const migrateIdx = deploySh.search(/apply-hand-migrations\.sh|pnpm db:migrate/);
+const backfillIdx = deploySh.search(/db:backfill-handhold|backfill-handhold-demo\.ts/);
+const killProxyIdx = deploySh.search(/kill\s+\$PROXY_PID/);
+
+describe("spec-178 ac-28: the Handhold backfill is wired into the CI/CD deploy (no manual step)", () => {
+  it("packages/server/deploy.sh invokes the backfill", () => {
+    tagAc(AC_28);
+    // Tolerant of either the package script alias or the raw script path.
+    expect(backfillIdx).toBeGreaterThanOrEqual(0);
+  });
+
+  it("runs the backfill AFTER the database migrations", () => {
+    tagAc(AC_28);
+    // ac-28 depends on the is_demo column existing — the backfill must follow the
+    // migration steps, never precede them.
+    expect(migrateIdx).toBeGreaterThanOrEqual(0);
+    expect(backfillIdx).toBeGreaterThan(migrateIdx);
+  });
+
+  it("runs the backfill against the proxied DB while the cloud-sql-proxy is still up", () => {
+    tagAc(AC_28);
+    // Must use the same proxied DATABASE_URL the migrations used, and run before
+    // the proxy is torn down (otherwise it has nothing to connect to).
+    expect(deploySh).toMatch(/DATABASE_URL="\$\{DB_URL\}"\s+pnpm db:backfill-handhold/);
+    expect(killProxyIdx).toBeGreaterThan(backfillIdx);
+  });
+
+  it("invokes the backfill NON-GATING — a failure cannot abort the deploy under set -e", () => {
+    tagAc(AC_28);
+    // The invocation is followed by `|| <fallback>`, so a non-zero exit is
+    // swallowed and `set -e` cannot abort a live deploy over a data hiccup.
+    expect(deploySh).toMatch(/pnpm db:backfill-handhold[\s\S]{0,160}\|\|/);
+  });
+
+  it("the deploy workflow runs the same deploy.sh, so the wiring actually executes in CI", () => {
+    tagAc(AC_28);
+    const workflow = readFileSync(DEPLOY_WORKFLOW, "utf-8");
+    expect(workflow).toMatch(/bash deploy\.sh/);
+  });
+});


### PR DESCRIPTION
## spec-178 t-5 — wire the Handhold backfill into the CI/CD deploy (ac-28)

Follow-up to #32. The Handhold demo feature is merged and live on INT; new signups already get the demo seeded via the post-commit hook in `ensureUserNamespace`. This PR closes the last open piece — backfilling **existing** personal Memexes — by wiring the (already-built, already-tested) backfill into the deploy pipeline.

### Change
One step added to [packages/server/deploy.sh](packages/server/deploy.sh), right after the migrations and while the cloud-sql-proxy is still up:

```bash
DATABASE_URL="${DB_URL}" pnpm db:backfill-handhold \
  || echo "  ⚠ handhold backfill failed (non-gating) — …; retries next deploy."
```

`deploy.yml` runs this same `deploy.sh`, so the backfill now runs **automatically, with no manual step**, on both environments:
- **INT** — on every deploy to `develop`
- **PROD** — on the daily `develop`→`main` promotion

It's per-Memex **idempotent** (no-ops once a Memex holds an `is_demo` spec), so running on every deploy does zero work after the first, and **non-gating** (`|| echo`) so a backfill hiccup can never abort a live deploy under `set -e`.

### Verification
- **Local rehearsal of the exact deploy sequence** against a throwaway DB: `db:migrate` (applied through `0077`) → `db:backfill-handhold` ran via `tsx`, connected, and exited cleanly (`[handhold-backfill] done … seeded 0`).
- `bash -n` clean on both `deploy.sh` scripts.
- New `handhold-backfill-deploy-wiring.regression.test.ts` (tagged **ac-28**): static guard that `deploy.sh` invokes the backfill after migrations, against the proxied DB, non-gating, and that `deploy.yml` runs `deploy.sh`. Passes locally; CI emits it → ac-28 flips to verified.
- Server typecheck clean (save the pre-existing `discord-webhook.test.ts` error already on `develop`, unrelated to this change and invisible to CI).

### Closes
- **ac-28** "backfill runs automatically as part of the CI/CD deploy (no manual step)" → lets spec-178 **t-5** flip to complete.

Once merged to `develop`, the INT deploy runs the backfill against INT; PROD picks it up on the next daily promotion. Merge is the maintainer's call (gated INT deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
