### PR TITLE
spec-178 t-5 (take 2): deploy-safe Handhold backfill — exclude demo from embed/drift + timeout-bounded hook

### DIFF
--- a/packages/server/deploy.sh
+++ b/packages/server/deploy.sh
@@ -138,6 +138,25 @@ DATABASE_URL="${DB_URL}" pnpm db:migrate
 echo "  1b. hand-written migrations..."
 DATABASE_URL="${DB_URL}" bash "${PKG_DIR}/scripts/apply-hand-migrations.sh"
 
+# 1c. spec-178 t-5 / ac-28 — backfill the Handhold onboarding demo into EXISTING
+# personal Memexes (namespaces.kind='user') that predate the feature. New signups
+# already get it via the post-commit hook in ensureUserNamespace; this is the
+# one-time catch-up. seedHandholdDemo is per-Memex idempotent (no-ops once a Memex
+# holds an is_demo spec), so it does zero work after the first successful pass and
+# is safe to run on every deploy. Lives in the shared deploy.sh so it covers BOTH
+# environments: INT on each develop deploy, PROD on the daily develop→main promotion.
+#
+# Bounded + non-gating (learned the hard way — an earlier unbounded version hung the
+# deploy to the 30-min job timeout): `timeout` caps the run, and `|| echo` swallows
+# BOTH a timeout (exit 124) and any error so `set -e` can never abort a live deploy.
+# If the cap is hit mid-backfill the deploy still proceeds and the next deploy resumes
+# (idempotent), so partial progress is safe. demo seeding is also off the embedding +
+# drift-scan paths now (dec-11 / ac-42), so this is pure fast inserts. `timeout` is
+# GNU coreutils — present on the CI ubuntu runner that actually runs this deploy.
+echo "  1c. handhold demo backfill (spec-178 t-5 / ac-28)..."
+DATABASE_URL="${DB_URL}" timeout 600 pnpm db:backfill-handhold \
+  || echo "  ⚠ handhold backfill timed out or failed (non-gating, exit $?) — deploy continues; next deploy resumes (idempotent)."
+
 kill $PROXY_PID 2>/dev/null
 wait $PROXY_PID 2>/dev/null || true
 

--- a/packages/server/src/__regression__/handhold-backfill-deploy-wiring.regression.test.ts
+++ b/packages/server/src/__regression__/handhold-backfill-deploy-wiring.regression.test.ts
@@ -1,0 +1,69 @@
+// spec-178 t-5 / ac-28 — the existing-Memex Handhold backfill runs automatically
+// as part of the CI/CD deploy, with NO manual step, and CANNOT stall the deploy.
+//
+// deploy.yml runs the SAME packages/server/deploy.sh a human runs, so asserting the
+// backfill is wired into that script proves the "automatic / no manual step" contract:
+// every INT deploy (push to develop) and every PROD deploy (the develop→main promotion)
+// executes it. Mirrored here as a static guard so a future edit that drops the hook —
+// or, just as important, drops the `timeout` bound — fails CI.
+//
+// History: an earlier unbounded version hung the INT deploy to the 30-min job timeout
+// (the backfill awaited a standards drift scan per demo decision). The fix is twofold:
+// demo seeding is now off the embedding + drift-scan paths (ac-42), AND the hook is
+// bounded by `timeout` + non-gating so even a pathological hang can never abort a deploy.
+// This guard nails down the deploy-wiring half (the runtime idempotency / no-double-seed
+// half is covered by services/handhold-demo.integration.test.ts, and the agent-surface
+// suppression by services/handhold-demo-agent-surface-exclusion.integration.test.ts).
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+const REPO_ROOT = join(__dirname, "..", "..", "..", "..");
+const SERVER_DEPLOY_SH = join(REPO_ROOT, "packages", "server", "deploy.sh");
+const DEPLOY_WORKFLOW = join(REPO_ROOT, ".github", "workflows", "deploy.yml");
+const AC_28 = "mindset-prod/memex-building-itself/specs/spec-178/acs/ac-28";
+
+const deploySh = readFileSync(SERVER_DEPLOY_SH, "utf-8");
+
+const migrateIdx = deploySh.search(/apply-hand-migrations\.sh|pnpm db:migrate/);
+const backfillIdx = deploySh.search(/db:backfill-handhold|backfill-handhold-demo\.ts/);
+const killProxyIdx = deploySh.search(/kill\s+\$PROXY_PID/);
+
+describe("spec-178 ac-28: the Handhold backfill is wired into the CI/CD deploy (no manual step, bounded)", () => {
+  it("packages/server/deploy.sh invokes the backfill", () => {
+    tagAc(AC_28);
+    expect(backfillIdx).toBeGreaterThanOrEqual(0);
+  });
+
+  it("runs the backfill AFTER the database migrations", () => {
+    tagAc(AC_28);
+    expect(migrateIdx).toBeGreaterThanOrEqual(0);
+    expect(backfillIdx).toBeGreaterThan(migrateIdx);
+  });
+
+  it("runs the backfill against the proxied DB while the cloud-sql-proxy is still up", () => {
+    tagAc(AC_28);
+    expect(deploySh).toMatch(/DATABASE_URL="\$\{DB_URL\}"\s+timeout\s+\d+\s+pnpm db:backfill-handhold/);
+    expect(killProxyIdx).toBeGreaterThan(backfillIdx);
+  });
+
+  it("BOUNDS the backfill with `timeout` so a hang can never stall the deploy", () => {
+    tagAc(AC_28);
+    // The unbounded version hung to the 30-min job timeout. The bound is non-negotiable.
+    expect(deploySh).toMatch(/timeout\s+\d+\s+pnpm db:backfill-handhold/);
+  });
+
+  it("invokes the backfill NON-GATING — a timeout/failure cannot abort the deploy under set -e", () => {
+    tagAc(AC_28);
+    // Followed by `|| <fallback>`, so a non-zero exit (incl. timeout's 124) is swallowed.
+    expect(deploySh).toMatch(/pnpm db:backfill-handhold[\s\S]{0,200}\|\|/);
+  });
+
+  it("the deploy workflow runs the same deploy.sh, so the wiring actually executes in CI", () => {
+    tagAc(AC_28);
+    const workflow = readFileSync(DEPLOY_WORKFLOW, "utf-8");
+    expect(workflow).toMatch(/bash deploy\.sh/);
+  });
+});

--- a/packages/server/src/services/decisions.ts
+++ b/packages/server/src/services/decisions.ts
@@ -732,6 +732,19 @@ export async function resolveDecision(
   // comment insertion may fail for reasons unrelated to the decision change). The UI
   // can rediscover drift via list_doc_comments / SSE on subsequent activity.
   try {
+    // dec-11: Handhold demo (is_demo) specs are excluded from every agent surface,
+    // so resolving a demo decision must NOT trigger a standards drift scan. This is
+    // also the primary fix for the spec-178 backfill hang: scanForDecisionDrift is
+    // AWAITED here (it runs a standards FTS per resolve), so seeding 5×N demo specs
+    // put N× full drift scans on the critical path and stalled the deploy. Skip them.
+    const [docRow] = await db
+      .select({ isDemo: documents.isDemo })
+      .from(documents)
+      .where(eq(documents.id, decision.docId))
+      .limit(1);
+    if (docRow?.isDemo) {
+      return updated;
+    }
     // Lazy import to avoid any circular dependency surprises (services/standards.ts
     // imports services/comments.ts, which has no path back here, but the lazy load
     // also keeps the cost out of the hot path when no standards exist).

--- a/packages/server/src/services/handhold-demo-agent-surface-exclusion.integration.test.ts
+++ b/packages/server/src/services/handhold-demo-agent-surface-exclusion.integration.test.ts
@@ -1,0 +1,139 @@
+// spec-178 ac-42 (dec-11) — is_demo content is excluded from the embedding and
+// standards-drift agent surfaces.
+//
+// This is both a dec-11 correctness guarantee (demo specs are off every agent
+// surface, and embeddings + drift are agent surfaces) AND the load-bearing fix
+// for the existing-Memex backfill: scanForDecisionDrift is AWAITED on the
+// resolveDecision path (a standards FTS per resolve), so seeding 5×N demo specs
+// would otherwise put N× full drift scans on the critical path and stall the
+// deploy (the spec-178 backfill incident). Both arms run against real Postgres.
+//
+//   embed arm:  embedAndStoreSection / embedAndStoreDecision return 'skipped-demo'
+//               for a doc with is_demo=true, BEFORE the provider check — and a
+//               non-demo section/decision does NOT get that status.
+//   drift arm:  resolving a DEMO decision posts no drift comment on a standard
+//               that references its handle, while resolving a NON-DEMO decision
+//               with the identical setup DOES — proving the resolveDecision guard.
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { inArray, eq, and } from "drizzle-orm";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { db } from "../db/connection.js";
+import { docSections, documents, docComments, memexes, namespaces } from "../db/schema.js";
+import { makeTestMemexWithDevAdmin } from "./test-helpers.js";
+import { createDocDraft } from "./documents.js";
+import { addSection } from "./sections.js";
+import { createDecision, resolveDecision } from "./decisions.js";
+import { embedAndStoreSection, embedAndStoreDecision } from "./memex-embeddings.js";
+
+const AC_42 = "mindset-prod/memex-building-itself/specs/spec-178/acs/ac-42";
+
+const createdMemexIds: string[] = [];
+
+beforeAll(async () => {
+  // two memexes: one drives the demo arm, one the non-demo control for drift.
+  const a = await makeTestMemexWithDevAdmin("ac42a");
+  const b = await makeTestMemexWithDevAdmin("ac42b");
+  createdMemexIds.push(a.memexId, b.memexId);
+  memexDemo = a.memexId;
+  memexControl = b.memexId;
+});
+
+let memexDemo: string;
+let memexControl: string;
+
+afterAll(async () => {
+  const docRows = await db
+    .select({ id: documents.id })
+    .from(documents)
+    .where(inArray(documents.memexId, createdMemexIds))
+    .catch(() => [] as { id: string }[]);
+  const docIds = docRows.map((r) => r.id);
+  if (docIds.length) {
+    await db.delete(docSections).where(inArray(docSections.docId, docIds)).catch(() => {});
+  }
+  await db.delete(documents).where(inArray(documents.memexId, createdMemexIds)).catch(() => {});
+  const memexRows = await db
+    .select({ namespaceId: memexes.namespaceId })
+    .from(memexes)
+    .where(inArray(memexes.id, createdMemexIds))
+    .catch(() => [] as { namespaceId: string }[]);
+  await db.delete(memexes).where(inArray(memexes.id, createdMemexIds)).catch(() => {});
+  const namespaceIds = memexRows.map((r) => r.namespaceId);
+  if (namespaceIds.length) {
+    await db.delete(namespaces).where(inArray(namespaces.id, namespaceIds)).catch(() => {});
+  }
+});
+
+describe("ac-42: is_demo content is never embedded", () => {
+  it("embedAndStoreSection/Decision return 'skipped-demo' for a demo doc, not for a real one", async () => {
+    tagAc(AC_42);
+
+    // Demo doc — created with is_demo at creation (the real seed path).
+    const demo = await createDocDraft(memexDemo, "Demo embed", "Demo overview.", "spec", undefined, {
+      isDemo: true,
+    });
+    const demoSection = await addSection(memexDemo, demo.id, "scope", "demo scope content");
+    const demoDecision = await createDecision(memexDemo, demo.id, "Demo decision", "ctx");
+
+    const demoSectionResult = await embedAndStoreSection(demoSection.id, { memexId: memexDemo });
+    const demoDecisionResult = await embedAndStoreDecision(demoDecision.id, { memexId: memexDemo });
+    expect(demoSectionResult.status).toBe("skipped-demo");
+    expect(demoDecisionResult.status).toBe("skipped-demo");
+
+    // Real doc — must NOT be treated as demo (guard is is_demo-specific, not a
+    // blanket skip). In the test env there is no embedding provider, so a real
+    // section/decision returns 'skipped-no-provider' — the point is it is NOT
+    // 'skipped-demo'.
+    const real = await createDocDraft(memexDemo, "Real embed", "Real overview.", "spec");
+    const realSection = await addSection(memexDemo, real.id, "scope", "real scope content");
+    const realDecision = await createDecision(memexDemo, real.id, "Real decision", "ctx");
+
+    const realSectionResult = await embedAndStoreSection(realSection.id, { memexId: memexDemo });
+    const realDecisionResult = await embedAndStoreDecision(realDecision.id, { memexId: memexDemo });
+    expect(realSectionResult.status).not.toBe("skipped-demo");
+    expect(realDecisionResult.status).not.toBe("skipped-demo");
+  });
+});
+
+describe("ac-42: resolving a demo decision does not run the standards drift scan", () => {
+  // Build a standard section that references `[per dec-1]` and a spec whose first
+  // decision is dec-1, then resolve that decision. A non-demo decision posts a
+  // drift comment on the standard; a demo decision must post none.
+  async function setup(memexId: string, isDemo: boolean): Promise<string> {
+    // Standard with a clause that references the decision handle.
+    const std = await createDocDraft(memexId, "Drift standard", "std purpose", "standard");
+    const stdSection = await addSection(
+      memexId,
+      std.id,
+      "do",
+      "Deploys must follow the rule [per dec-1].",
+    );
+    // Spec whose first decision becomes dec-1 (seq is per-doc).
+    const spec = await createDocDraft(memexId, "Drift spec", "spec overview", "spec", undefined, {
+      isDemo,
+    });
+    const decision = await createDecision(memexId, spec.id, "Choose the deploy rule", "ctx");
+    expect(decision.seq).toBe(1); // referenced as [per dec-1] above
+    await resolveDecision(memexId, decision.id, "Resolved: use the rule.");
+    return stdSection.id;
+  }
+
+  it("a NON-DEMO decision posts a drift comment (control)", async () => {
+    tagAc(AC_42);
+    const stdSectionId = await setup(memexControl, /* isDemo */ false);
+    const drift = await db.query.docComments.findMany({
+      where: and(eq(docComments.sectionId, stdSectionId), eq(docComments.commentType, "drift")),
+    });
+    expect(drift.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("a DEMO decision posts NO drift comment (the spec-178 fix)", async () => {
+    tagAc(AC_42);
+    const stdSectionId = await setup(memexDemo, /* isDemo */ true);
+    const drift = await db.query.docComments.findMany({
+      where: and(eq(docComments.sectionId, stdSectionId), eq(docComments.commentType, "drift")),
+    });
+    expect(drift).toHaveLength(0);
+  });
+});

--- a/packages/server/src/services/memex-embeddings.ts
+++ b/packages/server/src/services/memex-embeddings.ts
@@ -82,6 +82,7 @@ interface SectionWithDoc {
   id: string;
   doc_id: string;
   content: string;
+  is_demo: boolean;
 }
 
 async function loadSection(
@@ -99,7 +100,7 @@ async function loadSection(
   // the mutation). The argument is optional so legacy / test paths that
   // already trust the caller can skip it.
   const rows = (await db.execute(sql`
-    SELECT s.id, s.doc_id, s.content
+    SELECT s.id, s.doc_id, s.content, d.is_demo
     FROM doc_sections s
     INNER JOIN documents d ON d.id = s.doc_id
     WHERE s.id = ${sectionId}
@@ -128,7 +129,7 @@ async function writeEmbedding(
 // b-34 D-2 there is no docType gate — every section flows through.
 
 export interface EmbedSectionResult {
-  status: "embedded" | "skipped-empty" | "skipped-no-provider" | "failed";
+  status: "embedded" | "skipped-empty" | "skipped-no-provider" | "skipped-demo" | "failed";
   reason?: string;
   model?: string;
 }
@@ -141,6 +142,14 @@ export async function embedAndStoreSection(
   if (!section) {
     log(`section ${sectionId} not found — nothing to embed`);
     return { status: "failed", reason: "section-not-found" };
+  }
+
+  // dec-11: Handhold demo (is_demo) content is excluded from every agent/search
+  // surface, so it must never be embedded. Skipping here also keeps demo seeding
+  // off the embedding path entirely — the spec-178 backfill seeds many Memexes at
+  // once, and an embed-per-section cascade was part of what stalled it.
+  if (section.is_demo) {
+    return { status: "skipped-demo" };
   }
 
   const provider =
@@ -364,6 +373,7 @@ interface DecisionRow {
   context: string | null;
   resolution: string | null;
   doc_id: string;
+  is_demo: boolean;
 }
 
 async function loadDecision(
@@ -371,10 +381,11 @@ async function loadDecision(
   memexId?: string,
 ): Promise<DecisionRow | null> {
   const rows = (await db.execute(sql`
-    SELECT id, title, context, resolution, doc_id
-    FROM decisions
-    WHERE id = ${decisionId}
-      ${memexId ? sql`AND memex_id = ${memexId}` : sql``}
+    SELECT dn.id, dn.title, dn.context, dn.resolution, dn.doc_id, d.is_demo
+    FROM decisions dn
+    INNER JOIN documents d ON d.id = dn.doc_id
+    WHERE dn.id = ${decisionId}
+      ${memexId ? sql`AND dn.memex_id = ${memexId}` : sql``}
     LIMIT 1
   `)) as unknown as DecisionRow[];
   return rows[0] ?? null;
@@ -410,7 +421,7 @@ async function writeDecisionEmbedding(
 }
 
 export interface EmbedDecisionResult {
-  status: "embedded" | "skipped-empty" | "skipped-no-provider" | "failed";
+  status: "embedded" | "skipped-empty" | "skipped-no-provider" | "skipped-demo" | "failed";
   reason?: string;
   model?: string;
 }
@@ -423,6 +434,13 @@ export async function embedAndStoreDecision(
   if (!decision) {
     log(`decision ${decisionId} not found — nothing to embed`);
     return { status: "failed", reason: "decision-not-found" };
+  }
+
+  // dec-11: demo (is_demo) decisions are excluded from agent/search surfaces and
+  // must never be embedded. (See embedAndStoreSection — same rule, same backfill
+  // motivation.)
+  if (decision.is_demo) {
+    return { status: "skipped-demo" };
   }
 
   const provider =


### PR DESCRIPTION
## spec-178 t-5 (take 2) — deploy-safe Handhold backfill

Re-lands the existing-Memex backfill that was reverted in #34 after the first attempt (#33) **hung the INT deploy to the 30-min job timeout**. This version fixes the root cause and adds the verification that was missing the first time.

### Root cause of the hang
`scanForDecisionDrift` is **`await`ed inside `resolveDecision`** (a standards FTS per resolve). Seeding 5×N demo specs therefore put N× full drift scans on the seed's critical path, plus an embed spawn per section/decision — the backfill never returned. My old `|| echo` guard only caught a non-zero *exit*, not a *hang*.

### The fix — two parts

**1. Exclude `is_demo` content from the embed + drift agent surfaces (dec-11 / new ac-42).** Demo specs are already excluded from every other agent surface; embeddings and drift are agent surfaces too, so this is just-correct *and* removes the cascade at its source:
- `resolveDecision` skips `scanForDecisionDrift` (and the re-embed) for a demo decision — one cheap `is_demo` lookup on `decision.docId`.
- `embedAndStoreSection` / `embedAndStoreDecision` return `'skipped-demo'` before the provider check. `loadSection` already joins `documents`; `loadDecision` now does too — so the check costs **no extra query**.

**2. Re-wire the deploy hook, bounded.** `deploy.sh` step 1c now runs the backfill under `timeout` and non-gating, so a hang can **never** stall a deploy again; if the cap is hit mid-run the deploy proceeds and the next deploy resumes (idempotent). Since `deploy.yml` runs this `deploy.sh`, it's automatic with no manual step on INT (develop) + PROD (daily promotion) — closes **ac-28**.

### Verification (the gap that caused the incident — now closed)
- **Populated-DB rehearsal** (the missing test): 8 un-seeded personal Memexes backfilled in **~1.0s with zero drift/embed agent lines**; idempotent re-run **2ms**. Pre-fix, a handful of Memexes hung for 30 min.
- New `handhold-demo-agent-surface-exclusion.integration.test.ts` (**ac-42**): demo section/decision → `skipped-demo` (real → not); resolving a demo decision posts **no** drift comment on a referencing standard, while a non-demo decision **does**.
- `handhold-backfill-deploy-wiring.regression.test.ts` (**ac-28**) now also asserts the `timeout` bound.
- Full server typecheck clean (save the pre-existing `discord-webhook.test.ts` error already on develop); embedding/decision/drift/demo suites — **186 tests** — green.

### Why I'm confident this time
The original tests passed because the background-agent subscribers weren't wired in the unit-test context, so they never exercised the cascade. This PR verifies against a **real populated DB with the real seed path**, which is what blew up in the deploy.

Merge is the maintainer's call (gated INT deploy → runs the backfill on INT; PROD on the next daily promotion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
