### PR TITLE
docs(cd): deploy.yml header — prod ships unattended on merge to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,9 +3,9 @@ name: deploy
 # Branch-bound CD per std-21: merge to `develop` deploys int; merge to `main`
 # deploys prod. Both protected branches only take merges from PRs whose `test`
 # + `e2e` checks are green, so a push event here is by construction a reviewed,
-# CI-passing change. The prod job additionally pauses on the GitHub `prod`
-# environment's required-reviewer gate — merge is the decision to ship, the
-# approval click is the moment of shipping.
+# CI-passing change. Prod deploys run unattended on merge to `main` — merging
+# the develop→main PR IS the decision to ship (the prod environment's
+# required-reviewer gate was removed 2026-06-05).
 #
 # The deploy itself is the SAME ./deploy.sh a human runs locally (server
 # migrations + Cloud Run, UI build + GCS + CDN, then the std-17 smoke tail


### PR DESCRIPTION
Comment-only. The GitHub `prod` environment's required-reviewer gate was removed on 2026-06-05 (repo Settings → Environments) — merging the develop→main release PR is now the decision to ship, verified live by release PR #28's unattended prod deploy. This updates the workflow header to match.

The matching **std-21 amendment** (cl-36/cl-42 still describe the one-click gate) is filed as a plan_revision proposal on std-21 §5 for the standard owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)