### PR TITLE
spec-172 issues: dev-mode JWT honoured (issue-1), switcher reactivity rewritten (issue-3), e2e port defaults unified

### DIFF
--- a/packages/server/src/middleware/session.test.ts
+++ b/packages/server/src/middleware/session.test.ts
@@ -266,3 +266,134 @@ describe("sessionMiddleware — production dev-mode guard (b-38 F-1)", () => {
     ),
   );
 });
+
+// spec-172 issue-1 — the dev bypass is a fallback for token-less requests, not a
+// shadow over real identities. Pre-fix, isDevMode() short-circuited BEFORE the
+// Authorization header was read, so the e2e stack (GOOGLE_CLIENT_ID unset) could
+// never authenticate as a freshly signed-up native-auth user: every Bearer JWT
+// resolved to dev@memex.ai. Post-fix, a valid presented token wins; the dev user
+// is resolved only when no usable token is presented.
+describe("sessionMiddleware — dev mode honours a presented valid JWT (spec-172 issue-1)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  function withEnv(env: Record<string, string | undefined>, fn: () => Promise<void>) {
+    const original: Record<string, string | undefined> = {};
+    return async () => {
+      for (const key of Object.keys(env)) {
+        original[key] = process.env[key];
+        if (env[key] === undefined) delete process.env[key];
+        else process.env[key] = env[key];
+      }
+      try {
+        await fn();
+      } finally {
+        for (const key of Object.keys(original)) {
+          if (original[key] === undefined) delete process.env[key];
+          else process.env[key] = original[key];
+        }
+      }
+    };
+  }
+
+  const devUser = {
+    ...sampleUser,
+    id: "user-dev",
+    email: "dev@memex.ai",
+    namespaceId: "ns-dev",
+  };
+
+  const signedUpUser = {
+    ...sampleUser,
+    id: "user-signup",
+    email: "fresh@example.com",
+    namespaceId: "ns-signup",
+  };
+
+  it(
+    "a valid Bearer JWT resolves THAT user in dev mode, not dev@memex.ai",
+    withEnv(
+      { NODE_ENV: "development", GOOGLE_CLIENT_ID: undefined },
+      async () => {
+        // If the dev fallback were (wrongly) taken, it would succeed with
+        // user-dev — so a 200 alone can't pass; the userId must match the token.
+        upsertUserByEmail.mockResolvedValue(devUser);
+        getUserById.mockResolvedValue(signedUpUser);
+
+        const res = await app.request("/test", { headers: auth(signedUpUser.id) });
+        expect(res.status).toBe(200);
+        const body = (await res.json()) as { userId: string };
+        expect(body.userId).toBe(signedUpUser.id);
+        // The dev-user upsert path must not have run at all.
+        expect(upsertUserByEmail).not.toHaveBeenCalled();
+      },
+    ),
+  );
+
+  it(
+    "no token in dev mode still resolves dev@memex.ai (local-dev convenience preserved)",
+    withEnv(
+      { NODE_ENV: "development", GOOGLE_CLIENT_ID: undefined },
+      async () => {
+        upsertUserByEmail.mockResolvedValue(devUser);
+        getUserById.mockResolvedValue(devUser);
+
+        const res = await app.request("/test");
+        expect(res.status).toBe(200);
+        const body = (await res.json()) as { userId: string };
+        expect(body.userId).toBe(devUser.id);
+      },
+    ),
+  );
+
+  it(
+    "a malformed token in dev mode falls back to dev@memex.ai (stale localStorage token never bricks local dev)",
+    withEnv(
+      { NODE_ENV: "development", GOOGLE_CLIENT_ID: undefined },
+      async () => {
+        upsertUserByEmail.mockResolvedValue(devUser);
+        getUserById.mockResolvedValue(devUser);
+
+        const res = await app.request("/test", {
+          headers: { Authorization: "Bearer not-a-jwt" },
+        });
+        expect(res.status).toBe(200);
+        const body = (await res.json()) as { userId: string };
+        expect(body.userId).toBe(devUser.id);
+      },
+    ),
+  );
+
+  it(
+    "a valid token whose subject is gone falls back to dev@memex.ai in dev mode",
+    withEnv(
+      { NODE_ENV: "development", GOOGLE_CLIENT_ID: undefined },
+      async () => {
+        upsertUserByEmail.mockResolvedValue(devUser);
+        // Token verifies but the user row is gone → dev fallback, not 401.
+        getUserById
+          .mockResolvedValueOnce(null) // claims.sub lookup misses
+          .mockResolvedValue(devUser); // any later lookups (resolveDevUser refresh)
+
+        const res = await app.request("/test", { headers: auth("deleted-user") });
+        expect(res.status).toBe(200);
+        const body = (await res.json()) as { userId: string };
+        expect(body.userId).toBe(devUser.id);
+      },
+    ),
+  );
+
+  it(
+    "real mode (GOOGLE_CLIENT_ID set) is unchanged: valid token resolves its user",
+    withEnv(
+      { NODE_ENV: "development", GOOGLE_CLIENT_ID: "real-client-id" },
+      async () => {
+        getUserById.mockResolvedValue(signedUpUser);
+        const res = await app.request("/test", { headers: auth(signedUpUser.id) });
+        expect(res.status).toBe(200);
+        const body = (await res.json()) as { userId: string };
+        expect(body.userId).toBe(signedUpUser.id);
+        expect(upsertUserByEmail).not.toHaveBeenCalled();
+      },
+    ),
+  );
+});

--- a/packages/server/src/middleware/session.ts
+++ b/packages/server/src/middleware/session.ts
@@ -144,15 +144,18 @@ type BearerResolution =
 async function resolveBearerUser(
   c: Parameters<Parameters<typeof createMiddleware<SessionEnv>>[0]>[0],
 ): Promise<BearerResolution> {
-  if (isDevMode()) {
-    // Dev mode auto-logins as dev@memex.ai — same on both strict and lax paths
-    // so local dev keeps working without a token. isDevMode() throws in prod
-    // when GOOGLE_CLIENT_ID is missing (b-38 F-1); that throw propagates.
-    return { kind: "user", user: await resolveDevUser() };
-  }
+  // Evaluate the dev flag BEFORE any token work so the b-38 F-1 prod guard
+  // (isDevMode() throws when GOOGLE_CLIENT_ID is missing in production) still
+  // fires on every request; that throw propagates.
+  const devMode = isDevMode();
 
   const authHeader = c.req.header("Authorization");
   if (!authHeader?.startsWith("Bearer ")) {
+    // No token presented: dev mode auto-logins as dev@memex.ai — same on both
+    // strict and lax paths so local dev keeps working without a token.
+    if (devMode) {
+      return { kind: "user", user: await resolveDevUser() };
+    }
     return { kind: "anonymous" };
   }
   const token = authHeader.slice(7);
@@ -163,12 +166,26 @@ async function resolveBearerUser(
     if (!user) {
       // A well-formed token whose subject no longer exists. Strict path renders
       // this as a distinct 401 ("Sign in again"); permissive path treats it as
-      // anonymous so a public read still proceeds.
+      // anonymous so a public read still proceeds. Dev mode falls back to the
+      // dev user so a stale localStorage token never bricks local dev.
+      if (devMode) {
+        return { kind: "user", user: await resolveDevUser() };
+      }
       return { kind: "userGone" };
     }
+    // A valid presented token resolves THAT user — even in dev mode (spec-172
+    // issue-1): the dev bypass is a fallback for token-less requests, not a
+    // shadow over real identities. This is what lets the e2e stack (and any
+    // local client) authenticate as a freshly signed-up native-auth user while
+    // token-less requests keep resolving dev@memex.ai.
     return { kind: "user", user };
   } catch (err) {
     if (err instanceof InvalidTokenError) {
+      // Malformed/expired token: dev mode keeps the no-token convenience
+      // (fall back to the dev user); real mode reports anonymous.
+      if (devMode) {
+        return { kind: "user", user: await resolveDevUser() };
+      }
       return { kind: "anonymous" };
     }
     throw err;

--- a/packages/ui/e2e/README.md
+++ b/packages/ui/e2e/README.md
@@ -59,16 +59,18 @@ test it tears down tracked namespaces (via `resources.slug(...)`) and loose docs
 per suite, after the webServer boots** (Playwright starts webServers before globalSetup).
 It ensures `dev@memex.ai` exists **with a display name** before any journey runs, so a
 cold, freshly-migrated CI database doesn't route every journey into Onboarding. The
-onboarding flow keeps its own explicit journey that clears the name and walks the screen
-— see `verify-spec-172-setup.spec.ts` for the complementary "named by default" check
-(ac-10).
+onboarding screen keeps explicit coverage via the lifecycle-spine signup leg — a freshly
+signed-up user is nameless, so the name step renders for real — with
+`verify-spec-172-setup.spec.ts` as the complementary "named by default" check (ac-10).
 
 ## How tests authenticate
 
-The suite runs against **dev mode** — `GOOGLE_CLIENT_ID` is unset, so the server accepts
-the dev user `dev@memex.ai` without a real Google token, and `AuthContext` bootstraps a
-real dev session. The lifecycle-spine journey (t-7) signs up a *new* user via native auth
-[per std-13] instead of the dev bypass.
+The suite runs against **dev mode** — `GOOGLE_CLIENT_ID` is unset, so token-less requests
+resolve to the dev user `dev@memex.ai` without a real Google token, and `AuthContext`
+bootstraps a real dev session. A presented **valid session JWT wins over the dev bypass**
+(spec-172 issue-1 fix in `session.ts#resolveBearerUser`), which is what lets the
+lifecycle-spine journey (t-7) sign up a *new* user via native auth [per std-13] and drive
+the browser as that user.
 
 ## Environment
 

--- a/packages/ui/e2e/helpers/anthropic-fake.ts
+++ b/packages/ui/e2e/helpers/anthropic-fake.ts
@@ -2,7 +2,11 @@
 // Requires the server to run with MEMEX_ANTHROPIC_FAKE=1 (set in playwright.config.ts).
 // See packages/server/src/agent/anthropic-fake.ts + packages/server/src/routes/__test__.ts.
 
-const API_URL = process.env.E2E_API_URL ?? "http://localhost:8090";
+// Default tracks E2E_SERVER_PORT so a port override moves the helpers with the
+// server (overriding one without the other sent every request to a dead port).
+const API_URL =
+  process.env.E2E_API_URL ??
+  `http://localhost:${process.env.E2E_SERVER_PORT ?? 8090}`;
 
 export type FakeContentBlock =
   | { type: "text"; text: string }

--- a/packages/ui/e2e/helpers/fixtures.ts
+++ b/packages/ui/e2e/helpers/fixtures.ts
@@ -83,7 +83,11 @@ export const test = base.extend<{ resources: TestResources }>({
 
 export { expect } from "@playwright/test";
 
-const BASE_URL = process.env.E2E_BASE_URL ?? "http://localhost:5173";
+// Default tracks E2E_UI_PORT so a port override moves the URL helpers with the
+// Vite server (overriding one without the other pointed journeys at a dead port).
+const BASE_URL =
+  process.env.E2E_BASE_URL ??
+  `http://localhost:${process.env.E2E_UI_PORT ?? 5173}`;
 
 /**
  * Path-based tenant URL [per std-2]: resolves `/<namespace>/<memex>${path}` on

--- a/packages/ui/e2e/helpers/retained.ts
+++ b/packages/ui/e2e/helpers/retained.ts
@@ -7,7 +7,11 @@
 //
 // The base-URL + error handling mirror seed.ts exactly.
 
-const API_URL = process.env.E2E_API_URL ?? "http://localhost:8090";
+// Default tracks E2E_SERVER_PORT so a port override moves the helpers with the
+// server (overriding one without the other sent every request to a dead port).
+const API_URL =
+  process.env.E2E_API_URL ??
+  `http://localhost:${process.env.E2E_SERVER_PORT ?? 8090}`;
 
 async function call<T>(method: string, path: string, body?: unknown): Promise<T> {
   const res = await fetch(`${API_URL}/api/__test__${path}`, {

--- a/packages/ui/e2e/helpers/seed.ts
+++ b/packages/ui/e2e/helpers/seed.ts
@@ -9,7 +9,11 @@
 // the anthropic-fake helper) rather than via the Vite proxy, so seeding is
 // independent of the browser page and any /api proxy rewrites.
 
-const API_URL = process.env.E2E_API_URL ?? "http://localhost:8090";
+// Default tracks E2E_SERVER_PORT so a port override moves the helpers with the
+// server (overriding one without the other sent every request to a dead port).
+const API_URL =
+  process.env.E2E_API_URL ??
+  `http://localhost:${process.env.E2E_SERVER_PORT ?? 8090}`;
 
 async function call<T>(
   method: string,
@@ -243,11 +247,10 @@ export async function seedOpenDecision(opts: {
  * persists only its sha256 hash, so the raw value can only be recovered through
  * this seam — Postmark is never contacted.
  *
- * ⚠ This provisions the user + token, but the e2e stack CANNOT authenticate as
- * the signed-up user: GOOGLE_CLIENT_ID is unset → isDevMode() is true →
- * session.ts#resolveBearerUser short-circuits to dev@memex.ai before reading the
- * Authorization header. The signup→verify→onboard arc is unrunnable as the new
- * user without a server change. See the lifecycle-spine journey's blocked leg.
+ * The browser CAN then authenticate as the signed-up user: since the spec-172
+ * issue-1 fix, session.ts#resolveBearerUser honours a presented valid session
+ * JWT even in dev mode (the dev@memex.ai bypass applies only to token-less
+ * requests). See the lifecycle-spine journey's signup leg.
  */
 export async function signupWithToken(opts: {
   email: string;

--- a/packages/ui/e2e/journey-12-cross-tab-drift.spec.ts
+++ b/packages/ui/e2e/journey-12-cross-tab-drift.spec.ts
@@ -14,7 +14,7 @@ import { seedOrgTenant, seedSpec, seedDoc, seedOpenDecision } from "./helpers/re
 // exemption), keeping the test focused on the SSE round-trip rather than the
 // resolution dialog.
 
-const API_URL = process.env.E2E_API_URL ?? "http://localhost:8090";
+const API_URL = process.env.E2E_API_URL ?? `http://localhost:${process.env.E2E_SERVER_PORT ?? 8090}`;
 
 test("resolving a decision in one tab lights the drift badge on a standard in another", async ({
   browser,

--- a/packages/ui/e2e/journey-16-reactivity.spec.ts
+++ b/packages/ui/e2e/journey-16-reactivity.spec.ts
@@ -66,7 +66,7 @@ const test = base.extend<{ react: ReactivityResources }>({
 });
 
 function tenantPath(tenant: ReactivityTenant, suffix: string = ""): string {
-  const base = process.env.E2E_BASE_URL ?? "http://localhost:5173";
+  const base = process.env.E2E_BASE_URL ?? `http://localhost:${process.env.E2E_UI_PORT ?? 5173}`;
   const clean = suffix.replace(/^\//, "");
   return `${base}/${tenant.namespaceSlug}/${tenant.memexSlug}${clean ? "/" + clean : ""}`;
 }
@@ -336,16 +336,22 @@ test.describe("doc-16 Wave 1 reactivity journeys", () => {
   });
 
   // Wave 3 — MemexSwitcher reactivity. When the signed-in user creates a new
-  // org from another channel, the AuthContext receives a memex.created /
-  // org.created / org_membership.created event on /api/me/events (filtered by
-  // userId), refetches /api/auth/me, and the switcher dropdown reflects the
-  // new org without a page reload.
-  // FIXME (spec-172 issue-3): the new org is created (createResp.ok) but does NOT
-  // surface in the already-open switcher via the user-scoped /api/me/events stream
-  // in the e2e dev-session posture. The other reactivity sub-tests (doc-scoped SSE)
-  // pass cold; this user-scoped reactivity edge is time-boxed out of the gate and
-  // tracked as spec-172 issue-3 rather than blocking the suite.
-  test.fixme("memex-switcher-reactive: creating a new org adds it to the open MemexSwitcher dropdown", async ({
+  // org WITH a memex from another channel, the AuthContext receives the
+  // user-scoped memex.created event on /api/me/events (filtered by userId),
+  // refetches /api/auth/me, and the open switcher dropdown reflects the new
+  // org without a page reload.
+  //
+  // Resolved (spec-172 issue-3): the original test created a BARE org and
+  // expected it in the dropdown — but /api/me/events delivery was never the
+  // gap. Per doc-19 dec-1 org creation makes no Memex, and the session's
+  // membership list (services/users.ts#listMemberships) inner-joins memexes,
+  // so a memex-less org contributes no membership row BY DESIGN: the switcher
+  // lists places you can go (memexes), and an empty org appears in Manage
+  // Orgs, not the switcher — reload or no reload. The reactive behaviour the
+  // product actually has is asserted here: org + memex created via the real
+  // REST surface → memex.created (userId-scoped) → session refetch → the new
+  // org surfaces in the still-open dropdown.
+  test("memex-switcher-reactive: a new org+memex surfaces in the open MemexSwitcher dropdown", async ({
     browser,
     react,
   }) => {
@@ -363,23 +369,36 @@ test.describe("doc-16 Wave 1 reactivity journeys", () => {
     // Initial state: one org membership in the dropdown (the seeded tenant).
     await expect(tab.getByText("Your orgs").first()).toBeVisible();
 
-    // Create a new org via the REST surface. The session middleware in dev
-    // mode resolves the dev user automatically; createOrgWithOwner emits a
-    // composite (memex/org/user_namespace/org_membership) with userId set,
-    // which /api/me/events delivers, which refetches the session.
-    // /api/orgs (createOrgForUser) rejects an unverified owner; the dev-user
-    // bypass mints dev@memex.ai without emailVerifiedAt. Verify it through the
-    // test surface before the create (Postmark never contacted).
+    // Create a new org via the REST surface. /api/orgs (createOrgForUser)
+    // rejects an unverified owner; the dev-user bypass mints dev@memex.ai
+    // without emailVerifiedAt. Verify it through the test surface before the
+    // create (Postmark never contacted).
     await markEmailVerified(DEV_EMAIL);
     const newOrgSlug = `react-mxsw-new-${Date.now().toString(36)}-${Math.random()
       .toString(36)
       .slice(2, 6)}`.toLowerCase();
-    const apiBase = process.env.E2E_API_URL ?? "http://localhost:8090";
+    const apiBase =
+      process.env.E2E_API_URL ??
+      `http://localhost:${process.env.E2E_SERVER_PORT ?? 8090}`;
     const createResp = await tab.request.post(`${apiBase}/api/orgs`, {
       data: { slug: newOrgSlug, name: `New Org ${newOrgSlug}` },
       headers: { "Content-Type": "application/json" },
     });
     expect(createResp.ok()).toBeTruthy();
+    const { org } = (await createResp.json()) as { org: { namespaceId: string } };
+
+    // A bare org renders in Manage Orgs, not the switcher (no memex → no
+    // membership row). Create a memex inside it via the real REST surface —
+    // createMemex emits memex.created with userId set [per std-8], which is
+    // the event that wakes the user stream.
+    const memexResp = await tab.request.post(
+      `${apiBase}/api/namespaces/${org.namespaceId}/memexes`,
+      {
+        data: { slug: "main" },
+        headers: { "Content-Type": "application/json" },
+      }
+    );
+    expect(memexResp.ok()).toBeTruthy();
 
     // The new org's name should appear in the dropdown without a manual
     // reload. AuthContext refetched the session via the user-events SSE; the

--- a/packages/ui/e2e/journey-17-spec-role-controls.spec.ts
+++ b/packages/ui/e2e/journey-17-spec-role-controls.spec.ts
@@ -44,7 +44,7 @@ const test2 = test.extend<{ seed: RoleSeed }>({
 
 async function gotoSpec(page: Page, seed: RoleSeed) {
   await page.goto(
-    `${process.env.E2E_BASE_URL ?? "http://localhost:5173"}/${seed.tenant.namespaceSlug}/${seed.tenant.memexSlug}/docs/${seed.docId}`,
+    `${process.env.E2E_BASE_URL ?? `http://localhost:${process.env.E2E_UI_PORT ?? 5173}`}/${seed.tenant.namespaceSlug}/${seed.tenant.memexSlug}/docs/${seed.docId}`,
   );
   await expect(page.getByRole("heading", { name: "Roles Spec", level: 1 })).toBeVisible({
     timeout: 15_000,

--- a/packages/ui/e2e/journey-19-lifecycle-spine.spec.ts
+++ b/packages/ui/e2e/journey-19-lifecycle-spine.spec.ts
@@ -16,30 +16,23 @@
 //     drives only the RESOLVE half (open-option → Resolve → rationale → Save),
 //     the half journey-14 stops short of.
 //
-// ── BLOCKER: the signup-as-new-user leg cannot run (ac-13 criterion 2) ────────
+// ── The signup-as-new-user leg (ac-13 criterion 2) ───────────────────────────
 // ac-13 wants "a new user … signing up via native auth … landing in their
-// personal memex … each step asserted in the UI … not the dev bypass". That leg
-// is authored below as `test.fixme` because it is UNRUNNABLE in the e2e stack
-// without a server change:
+// personal memex … each step asserted in the UI … not the dev bypass". This was
+// originally BLOCKED (spec-172 issue-1): resolveBearerUser() short-circuited to
+// dev@memex.ai before reading the Authorization header in dev mode, so the
+// browser could never BE the signed-up user. The server now honours a presented
+// valid session JWT over the dev fallback (session.ts — the dev bypass applies
+// only to token-less requests), so the leg runs for real: signup via the
+// /signup-with-token seam (raw email-verification token, Postmark never
+// contacted) → /verify-email consumes it and stores the new user's JWT →
+// Onboarding name step (the explicit onboarding-screen coverage ac-10 promises)
+// → personal-memex Specs board, asserted as the NEW user, not dev@memex.ai.
 //
-//   In dev mode (GOOGLE_CLIENT_ID unset, the e2e posture — see the e2e README
-//   "How tests authenticate"), packages/server/src/middleware/session.ts's
-//   resolveBearerUser() checks isDevMode() FIRST (session.ts:147) and returns
-//   dev@memex.ai UNCONDITIONALLY (session.ts:147-152) — it never reads the
-//   Authorization header (session.ts:154). So every authenticated API request
-//   the browser makes resolves to the dev user, and a native-auth JWT the
-//   signed-up user holds in localStorage is shadowed completely. The signup
-//   API itself works (/api/auth/signup → /api/auth/verify-email, raw token via
-//   the /signup-with-token test seam), but the browser session can never BE the
-//   new user. Honouring a presented session JWT even in dev mode (so a real
-//   token wins over the dev fallback) is the server change required — out of
-//   scope for this test-authoring task, surfaced on the Spec instead of coded
-//   around.
-//
-// Until that lands, the spine's post-authentication arc — the bulk of the
-// lifecycle — runs as the (named) dev user, which still exercises org → memex →
-// Spec → decision resolve → phase transitions end-to-end in the real UI on a
-// cold DB. That is the running test below; the signup leg is the fixme.
+// The post-authentication arc — org → memex → Spec → decision resolve → phase
+// transitions — runs as the (named) dev user in the first test below; the
+// signup leg runs as its own test with a fresh browser context so the two
+// identities never share storage.
 
 import {
   test,
@@ -230,13 +223,14 @@ test("lifecycle spine: org → memex → Spec → resolve decision → phase mov
   ).toHaveCount(0);
 });
 
-// ── The signup-as-new-user leg — BLOCKED (see file header) ───────────────────
-// Authored so the intent is recorded and the criterion is visible, marked
-// `fixme` so it is reported as skipped (never a false pass) until the server
-// honours a presented session JWT in dev mode. The signup + verify API calls
-// are real; the assertion that the BROWSER is the new user is what cannot hold.
-test.fixme(
-  "new user signs up via native auth, verifies email, onboards, lands in personal memex (BLOCKED: dev-mode session shadows native-auth JWT — session.ts#resolveBearerUser)",
+// ── The signup-as-new-user leg (see file header) ─────────────────────────────
+// Runs as the NEW user end-to-end: the server honours the presented session JWT
+// over the dev-mode fallback (spec-172 issue-1 fix), so every assertion below is
+// made as `email`, not dev@memex.ai. Also the suite's explicit walk of the
+// Onboarding profile screen (ac-10's second clause): a freshly signed-up user is
+// nameless, so the name step renders for real — no clearUserName crutch needed.
+test(
+  "new user signs up via native auth, verifies email, onboards, lands in personal memex",
   async ({ page, resources }) => {
     const email = resources.email("spine-newuser");
     const { verificationToken } = await signupWithToken({
@@ -245,22 +239,39 @@ test.fixme(
     });
     resources.emails.push(email);
 
-    // Real verification — consumes the token, stamps email_verified_at. Postmark
+    // Real verification — consumes the token, stamps email_verified_at, and the
+    // page stores the returned session JWT client-side (acceptSession). Postmark
     // never contacted (token came from the /signup-with-token seam).
     await page.goto(
       bareUrl(`/verify-email?token=${encodeURIComponent(verificationToken)}`),
       { waitUntil: "commit" }
     );
+    await expect(
+      page.getByRole("heading", { name: /You're all set!/ })
+    ).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByText(email)).toBeVisible();
 
-    // From here the journey would: complete Onboarding (the name step in
-    // Onboarding.tsx — fill "Your display name", press Continue), then assert it
-    // lands on the new user's personal-memex Specs board. BLOCKED: in dev mode
-    // the browser's session is dev@memex.ai regardless of the JWT acceptSession
-    // stored, so /api/auth/me + every memex read resolve as the dev user, not
-    // `email`. The onboarding screen + personal-memex landing can't be asserted
-    // for the NEW user. Unblock = server honours a presented JWT over the dev
-    // fallback; then this body fills in and the running test's post-auth spine
-    // moves under it.
-    await expect(page.getByText("What's your name?")).toBeVisible();
+    // Continue → the personal-memex landing. The new user is NAMELESS, so the
+    // session carries needsOnboarding and the Onboarding profile screen renders
+    // in place of the tenant page (App.tsx gates on session.needsOnboarding).
+    await page.getByRole("button", { name: /Continue to your Memex/ }).click();
+    await expect(page.getByText("What's your name?")).toBeVisible({
+      timeout: 15_000,
+    });
+
+    // Complete onboarding: set the display name. updateProfileApi runs AS the
+    // signed-up user (Bearer JWT) — possible only because a presented valid
+    // token now wins over the dev bypass.
+    const displayName = `Spine Newuser ${resources.uniq}`;
+    await page.getByPlaceholder("Your display name").fill(displayName);
+    await page.getByRole("button", { name: /^Continue$/ }).click();
+
+    // The session refreshes and the personal-memex Specs board renders — as the
+    // NEW user (sidebar identity shows `email`), never dev@memex.ai.
+    await expect(page.getByRole("heading", { name: "Specs" })).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(page.getByText(email)).toBeVisible();
+    await expect(page.getByText(DEV_EMAIL)).toHaveCount(0);
   }
 );

--- a/packages/ui/e2e/journey-8-agent-chat-streaming.spec.ts
+++ b/packages/ui/e2e/journey-8-agent-chat-streaming.spec.ts
@@ -74,7 +74,7 @@ test("agent chat streams assistant text and persists the turn", async ({
   // the dev user's PERSONAL memex, not this seeded org memex, so it would miss
   // the thread). Hit the API origin directly via the browser context so the dev
   // session cookie rides along.
-  const apiBase = process.env.E2E_API_URL ?? "http://localhost:8090";
+  const apiBase = process.env.E2E_API_URL ?? `http://localhost:${process.env.E2E_SERVER_PORT ?? 8090}`;
   const convPath = `/api/${tenant.namespaceSlug}/${tenant.memexSlug}/llm/conversations/${docId}`;
   await expect
     .poll(

--- a/packages/ui/src/components/AuthContext.tsx
+++ b/packages/ui/src/components/AuthContext.tsx
@@ -262,6 +262,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     if (session) return;
     if (devLoggedOut) return;
     if (token) return; // rehydration effect will handle it
+    // Token-consuming public pages establish their OWN session (verify-email →
+    // acceptSession as the token's user). Auto-logging-in dev@memex.ai here
+    // races that flow and whichever response lands last wins — which made the
+    // signup→verify e2e leg flap between identities (spec-172 issue-1). Stand
+    // down and let the page's explicit flow own the session.
+    if (typeof window !== 'undefined' && window.location.pathname === '/verify-email') return;
     ssoLoginApi('')
       .then(acceptSession)
       .catch((err) => console.warn('Dev session bootstrap failed:', err));


### PR DESCRIPTION
Resolves the three open Issues on [spec-172](https://memex.ai/mindset-prod/memex-building-itself/specs/spec-172) ahead of closing the Spec.

## issue-1 — dev-mode session shadows native-auth JWT (bug, medium)
`session.ts#resolveBearerUser` returned `dev@memex.ai` before reading the `Authorization` header in dev mode, so the e2e stack could never authenticate as a freshly signed-up native-auth user.

- A **valid presented session JWT now resolves that user** even in dev mode; the dev bypass remains the fallback for token-less / invalid-token / user-gone requests. The b-38 F-1 production guard still fires before any token work. 5 new middleware tests.
- `AuthContext`'s dev bootstrap stands down on `/verify-email` — it raced the token-consumer flow and whichever response landed last owned the session.
- **journey-19's signup leg flips from `test.fixme` to live**: signup → verify-email → Onboarding name step → personal memex, asserted as the new user, never `dev@memex.ai`. This also gives the Onboarding screen real e2e coverage (ac-10's second clause, previously unmet prose).

## issue-3 — new org doesn't surface in open MemexSwitcher (bug, low)
SSE delivery was never broken — a live capture shows `org`/`user_namespace`/`org_membership` created events arriving on the token-less dev stream. The fixme'd test created a **bare org** and expected it in the switcher, but `listMemberships` inner-joins `memexes` and org creation makes no memex (doc-19 dec-1): a memex-less org renders in Manage Orgs, not the switcher, **by design**. The test is rewritten to assert the real reactive flow (org + memex via REST → user-scoped `memex.created` → session refetch → open dropdown updates) and now runs un-fixme'd.

## issue-2 — journey-8 reload-rehydration (todo, low)
Owner-confirmed **working as intended** (spec-159 clears the conversation on open). No code change; resolved on the Spec.

## e2e foundation hardening
`E2E_UI_PORT`/`E2E_SERVER_PORT` moved the servers while the URL-helper defaults stayed pinned to 5173/8090 unless `E2E_BASE_URL`/`E2E_API_URL` were *also* set — a partial override sent every journey to a dead port (34 false failures during verification). All defaults now derive from the port vars; README updated.

## Verification
- `make e2e-cold`: **37/37 green, twice consecutively** (suite previously 35 + 2 fixmes — both fixmes now run)
- server suite: 3304 passed (2 known env flakes — parallel-worker deadlock passes solo; emission-key guard needs the root `.env`)
- ui suite: 974 passed; `tsc` build configs clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)