### PR TITLE
spec-172: scope ACs self-report (ac-1 CI emission, ac-2/ac-6 inventory guard)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -254,7 +254,27 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 2
+    env:
+      MEMEX_EMIT_KEY: ${{ secrets.MEMEX_EMIT_KEY }}
     steps:
+      # spec-172 ac-1 self-reports from here: this aggregator IS the "full
+      # Playwright suite passed against a cold, freshly-migrated DB" signal,
+      # so it emits the AC's test event — pass AND fail alike, per the
+      # ac-emission discipline — to the canonical Memex. A missing key or a
+      # failed POST never flips the check itself (`|| true`), matching the
+      # vitest helper's warn-and-move-on semantics.
+      - name: Emit spec-172 ac-1 (full e2e suite cold)
+        run: |
+          STATUS=$([ "${{ needs.e2e.result }}" = "success" ] && echo pass || echo fail)
+          if [ -z "$MEMEX_EMIT_KEY" ]; then
+            echo "MEMEX_EMIT_KEY unset — skipping ac-1 emission (status would be: $STATUS)"
+          else
+            curl -sS -X POST "https://memex.ai/api/test-events" \
+              -H "Authorization: Bearer $MEMEX_EMIT_KEY" \
+              -H "Content-Type: application/json" \
+              -d "{\"ac_uid\":\"mindset-prod/memex-building-itself/specs/spec-172/acs/ac-1\",\"status\":\"$STATUS\",\"test_identifier\":\".github/workflows/test.yml::e2e-result\",\"actor\":\"${{ github.actor }}\",\"metadata\":{\"branch\":\"${{ github.ref_name }}\",\"commit\":\"${{ github.sha }}\",\"run_id\":\"${{ github.run_id }}\"}}" \
+              && echo "ac-1 emitted: $STATUS" || echo "ac-1 emission failed (non-blocking)"
+          fi
       - name: All e2e shards green?
         run: |
           if [ "${{ needs.e2e.result }}" != "success" ]; then

--- a/packages/server/src/__regression__/spec-172-e2e-journey-inventory.regression.test.ts
+++ b/packages/server/src/__regression__/spec-172-e2e-journey-inventory.regression.test.ts
@@ -1,0 +1,172 @@
+// Journey-inventory guard for the spec-172 e2e rebuild (ac-2 + ac-6).
+//
+// Sibling of spec-172-e2e-schema-drift.static-scan.test.ts (same deliberate
+// cross-package fs walk — see that file's header for why this lives in the
+// server's __regression__ tree rather than the ui package).
+//
+// The two scope ACs this file gives a standing, self-reporting guard:
+//
+//   ac-2 — "Every account-era journey (1, 2, 3, 4, 6, 7) has an explicit
+//           recorded disposition — ported … parked … or deleted — none is left
+//           silently failing or silently skipped."
+//          dec-1 recorded the disposition: all six DELETED, their underlying
+//          flows re-covered by fresh tenancy journeys (ac-5). The standing,
+//          repo-checkable shape of that disposition is therefore: the six
+//          account-era files stay dead, AND the six tenancy replacements stay
+//          present. A future PR resurrecting an account-era journey (or
+//          dropping a tenancy journey without a successor) trips this guard
+//          instead of silently un-recording the disposition.
+//
+//   ac-6 — "The 12 retained journeys (5, 8–18) run on the rebuilt e2e base
+//           (new fixtures/seed mechanism) … none passes vacuously or asserts
+//           retired UI."
+//          The build-phase half (each journey individually sanity-checked
+//          against the current UI) was human/agent judgement; the standing
+//          half asserted here is structural: all 12 retained journey files
+//          exist, import ONLY the rebuilt foundation (./helpers — never the
+//          pre-0038 helpers/db / reactivity-fixtures / a postgres driver),
+//          and carry no test.skip / test.fixme / describe.skip — so none can
+//          quietly become a vacuous pass or a silent skip. (The "passes on a
+//          cold DB" half is the e2e job itself — ac-1's emission.)
+//
+// The per-file CONTENT rot (dropped-table SQL, subdomain URLs) is the
+// static-scan sibling's job (ac-7/ac-3); this file owns the INVENTORY shape.
+
+import { describe, it, expect } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { readFileSync, readdirSync, existsSync } from "node:fs";
+import { join } from "node:path";
+
+const AC = "mindset-prod/memex-building-itself/specs/spec-172/acs";
+
+// packages/server/src/__regression__ -> packages/ui/e2e
+const E2E_DIR = join(__dirname, "..", "..", "..", "ui", "e2e");
+
+// dec-1: the six account-era journeys, deleted outright (never ported).
+const DELETED_ACCOUNT_ERA = [
+  "journey-1-account-creation",
+  "journey-2-team-invite",
+  "journey-3-auto-grouping",
+  "journey-4-multi-account",
+  "journey-6-member-management",
+  "journey-7-domain-conflict",
+];
+
+// ac-5: the fresh tenancy set that re-covers the six deleted flows.
+const TENANCY_REPLACEMENTS = [
+  "tenancy-1-org-creation.spec.ts",
+  "tenancy-2-invite-accept.spec.ts",
+  "tenancy-3-domains-autogrouping.spec.ts",
+  "tenancy-4-switching.spec.ts",
+  "tenancy-5-member-management.spec.ts",
+  "tenancy-6-domain-conflict.spec.ts",
+];
+
+// ac-6: the 12 retained journeys, re-based onto the new foundation.
+const RETAINED = [
+  "journey-5-external-sharing.spec.ts",
+  "journey-8-agent-chat-streaming.spec.ts",
+  "journey-9-agent-tool-use.spec.ts",
+  "journey-10-primary-nav.spec.ts",
+  "journey-11-plan-submit-approve.spec.ts",
+  "journey-12-cross-tab-drift.spec.ts",
+  "journey-13-spec-tab-filtering.spec.ts",
+  "journey-14-candidate-decision.spec.ts",
+  "journey-15-spec-detail-layout.spec.ts",
+  "journey-16-reactivity.spec.ts",
+  "journey-17-spec-role-controls.spec.ts",
+  "journey-18-global-search.spec.ts",
+];
+
+// Pre-0038 foundation imports that must never come back into a journey.
+const RETIRED_IMPORTS = [
+  /from\s+["']\.\/helpers\/db(\.js)?["']/,
+  /from\s+["']\.\/helpers\/db-memex(\.js)?["']/,
+  /from\s+["']\.\/helpers\/reactivity-fixtures(\.js)?["']/,
+  /from\s+["']postgres["']/,
+];
+
+// Silent-skip shapes — a retained journey must run, not vacuously report.
+const SKIP_SHAPES = [/\btest\.skip\(/, /\btest\.fixme\(/, /\bdescribe\.skip\(/, /\btest\.only\(/];
+
+function specFiles(): string[] {
+  return readdirSync(E2E_DIR).filter((f) => f.endsWith(".spec.ts"));
+}
+
+describe("spec-172 ac-2: account-era journey dispositions stay recorded in the tree", () => {
+  it("the six deleted account-era journeys stay dead — no file resurrects their names", () => {
+    tagAc(`${AC}/ac-2`);
+    const present = specFiles();
+    for (const dead of DELETED_ACCOUNT_ERA) {
+      const resurrected = present.filter((f) => f.startsWith(dead));
+      expect(
+        resurrected,
+        `${dead}* reappeared in packages/ui/e2e — dec-1 recorded these as DELETED; ` +
+          `a successor flow belongs in the tenancy-N set or a NEW journey name, ` +
+          `not a resurrected account-era file`,
+      ).toEqual([]);
+    }
+  });
+
+  it("each deleted flow's tenancy replacement is present (deleted ≠ dropped: dec-1 re-covered all six)", () => {
+    tagAc(`${AC}/ac-2`);
+    const present = new Set(specFiles());
+    for (const replacement of TENANCY_REPLACEMENTS) {
+      expect(
+        present.has(replacement),
+        `${replacement} is missing — it is the recorded successor of a deleted ` +
+          `account-era journey (dec-1/ac-5); removing it un-records the disposition`,
+      ).toBe(true);
+    }
+  });
+});
+
+describe("spec-172 ac-6: the 12 retained journeys live on the rebuilt foundation", () => {
+  it("all 12 retained journey files exist", () => {
+    tagAc(`${AC}/ac-6`);
+    for (const f of RETAINED) {
+      expect(existsSync(join(E2E_DIR, f)), `${f} is missing from packages/ui/e2e`).toBe(true);
+    }
+  });
+
+  it("retained journeys import only the rebuilt foundation — no pre-0038 helpers, no postgres", () => {
+    tagAc(`${AC}/ac-6`);
+    for (const f of RETAINED) {
+      const src = readFileSync(join(E2E_DIR, f), "utf8");
+      for (const retired of RETIRED_IMPORTS) {
+        expect(
+          retired.test(src),
+          `${f} imports a retired pre-0038 module (${retired}) — journeys seed only ` +
+            `through the test-only HTTP surface [per std-28 cl-5]`,
+        ).toBe(false);
+      }
+    }
+  });
+
+  it("no retained journey is silently skipped, fixme'd, or .only'd", () => {
+    tagAc(`${AC}/ac-6`);
+    for (const f of RETAINED) {
+      const src = readFileSync(join(E2E_DIR, f), "utf8");
+      for (const shape of SKIP_SHAPES) {
+        expect(
+          shape.test(src),
+          `${f} carries ${shape} — a retained journey that doesn't run is exactly ` +
+            `the silent rot ac-6 exists to prevent; fix it or surface an Issue, ` +
+            `don't park it`,
+        ).toBe(false);
+      }
+    }
+  });
+});
+
+describe("spec-172 journey-inventory meta-tests (the guard itself trips)", () => {
+  it("the skip-shape scanner trips on a fixme'd test body", () => {
+    const sample = `test.fixme("parked", async () => {});`;
+    expect(SKIP_SHAPES.some((s) => s.test(sample))).toBe(true);
+  });
+
+  it("the retired-import scanner trips on a helpers/db import", () => {
+    const sample = `import { seedAccount } from "./helpers/db.js";`;
+    expect(RETIRED_IMPORTS.some((s) => s.test(sample))).toBe(true);
+  });
+});

--- a/packages/server/src/routes/handhold.api.test.ts
+++ b/packages/server/src/routes/handhold.api.test.ts
@@ -123,6 +123,16 @@ async function makePersonalUser(prefix: string): Promise<{
   };
 }
 
+// spec-186: the vitest config disables the signup seed hook suite-wide (its
+// detached promise races other tests' cleanup). THIS suite tests the hook
+// itself, so opt back in — the gate reads process.env at call time.
+beforeAll(() => {
+  process.env.MEMEX_HANDHOLD_SIGNUP_SEED = "on";
+});
+afterAll(() => {
+  process.env.MEMEX_HANDHOLD_SIGNUP_SEED = "off";
+});
+
 afterAll(async () => {
   // Namespaces cascade to memex + documents; do those first, then the users.
   if (createdNamespaceIds.length > 0) {

--- a/packages/server/src/services/doc-move.ts
+++ b/packages/server/src/services/doc-move.ts
@@ -15,6 +15,7 @@ import type { Doc } from "../db/schema.js";
 import { NotFoundError, ValidationError } from "../types/errors.js";
 import { mutate, type Mutated } from "./mutate.js";
 import { nextSpecHandle, nextDocHandle } from "./documents.js";
+import { withSeqRetry } from "./shared/sequence.js";
 
 // Error surfaced when the caller isn't a member of the target memex.
 export class ForbiddenError extends Error {
@@ -79,7 +80,11 @@ export async function moveDoc(
       { memexId: toMemexId, docId, entity: "document", action: "updated" },
     ],
     async () => {
-  const result = await db.transaction(async (tx) => {
+  // spec-187: the handle re-mint inside this tx is the racy MAX+1 read — a
+  // concurrent create/move into the target memex can collide on
+  // `documents_memex_id_handle_unique`. The tx is pure-DB, so retrying it
+  // wholesale re-mints cleanly (same shape as createDocDraft's wrap).
+  const result = await withSeqRetry(() => db.transaction(async (tx) => {
     // Lock the row so concurrent writes (agent/MCP/REST) serialize against the move.
     const [doc] = await tx
       .select()
@@ -221,7 +226,7 @@ export async function moveDoc(
       removedTaskDeps: taskDepResult.length,
       revokedShareTokens: revokeResult.length,
     };
-  });
+  }), "documents_memex_id_handle_unique");
 
   return {
     doc: result.doc,

--- a/packages/server/src/services/documents.ts
+++ b/packages/server/src/services/documents.ts
@@ -6,6 +6,7 @@ import type { DocSummary } from "../types/index.js";
 import { NotFoundError, ValidationError } from "../types/errors.js";
 import { mutate, type ChangeKey, type Mutated } from "./mutate.js";
 import { isUuid } from "./shared/identifiers.js";
+import { withSeqRetry } from "./shared/sequence.js";
 import { embedAndStoreSection, embedAndStoreDecision } from "./memex-embeddings.js";
 import { aggregateAcHealthForBriefs } from "./acs.js";
 import { maybeAutoResolveIssuesForPromotedDoc } from "./issues.js";
@@ -109,27 +110,34 @@ export async function createDocDraft(
   // `resolveRef`). Standards created through the dedicated React-UI flow
   // (`createStandard → nextStandardHandle`) were unaffected; MCP creates
   // route through this function and need the explicit branch.
-  const handle =
-    docType === "spec"
-      ? await nextSpecHandle(memexId)
-      : docType === "standard"
-        ? await nextStandardHandle(memexId)
-        : await nextDocHandle(memexId);
-
   return mutate(
     {},
     // The new doc's id isn't known until the insert returns, so use a key
     // factory that reads it off the resolved result.
     (created) => ({ memexId, docId: created.id, entity: "document", action: "created" }),
     async () => {
-      // Handle collisions across accounts (same `doc-N` in two tenants) are possible because
-      // the handle column has a global unique constraint. Catch and retry with a higher seq if
-      // a race produces a dup. For dev workloads the bare insert is fine; future hardening can
-      // tighten this.
-      const [doc] = await db
-        .insert(documents)
-        .values({ memexId, handle, title, docType, status: "draft", createdByUserId: createdByUserId ?? null, isDemo: extras?.isDemo ?? false })
-        .returning();
+      // spec-187 (b-38 F-3 finally reaching documents): the handle mint is a
+      // racy COALESCE(MAX(...))+1 read — two concurrent creates in the same
+      // memex can both read N and both insert handle N+1, and Postgres 23505s
+      // the loser on `documents_memex_id_handle_unique`. Mirror the
+      // decisions/comments/acs hardening: allocator + insert inside
+      // withSeqRetry, re-minting the handle on each collision.
+      const doc = await withSeqRetry(
+        async () => {
+          const handle =
+            docType === "spec"
+              ? await nextSpecHandle(memexId)
+              : docType === "standard"
+                ? await nextStandardHandle(memexId)
+                : await nextDocHandle(memexId);
+          const [row] = await db
+            .insert(documents)
+            .values({ memexId, handle, title, docType, status: "draft", createdByUserId: createdByUserId ?? null, isDemo: extras?.isDemo ?? false })
+            .returning();
+          return row;
+        },
+        "documents_memex_id_handle_unique",
+      );
 
       // spec-118 dec-4: the creator becomes the Spec's first editor. On the MCP
       // path createdByUserId is always the HUMAN token owner (no separate agent

--- a/packages/server/src/services/execution_plans.ts
+++ b/packages/server/src/services/execution_plans.ts
@@ -5,6 +5,7 @@ import type { Doc, DocSection } from "../db/schema.js";
 import { NotFoundError, ValidationError } from "../types/errors.js";
 import { mutate, type Mutated } from "./mutate.js";
 import { nextDocHandle } from "./documents.js";
+import { withSeqRetry } from "./shared/sequence.js";
 
 // Standardised section types for execution plans, per dec-13. Order is the order they get
 // inserted (and thus the order they render). `readiness_assessment` is intentionally NOT
@@ -93,7 +94,10 @@ export async function createExecutionPlan(
       { memexId, docId: item.docId, entity: "task", action: "updated" },
     ],
     async () => {
-      const result = await db.transaction(async (tx) => {
+      // spec-187: the doc-N handle mint is the racy MAX+1 read — a concurrent
+      // doc/plan create in the same memex can collide on
+      // `documents_memex_id_handle_unique`. Pure-DB tx → retry it wholesale.
+      const result = await withSeqRetry(() => db.transaction(async (tx) => {
         const handle = await nextDocHandle(memexId, tx);
         const [doc] = await tx
           .insert(documents)
@@ -123,7 +127,7 @@ export async function createExecutionPlan(
           .where(and(eq(tasks.id, taskId), eq(tasks.memexId, memexId)));
 
         return { doc, sections };
-      });
+      }), "documents_memex_id_handle_unique");
 
       return { ...result.doc, sections: result.sections };
     },

--- a/packages/server/src/services/shared/sequence.integration.test.ts
+++ b/packages/server/src/services/shared/sequence.integration.test.ts
@@ -12,7 +12,7 @@
 import { describe, it, expect } from "vitest";
 import { eq, sql } from "drizzle-orm";
 import { db } from "../../db/connection.js";
-import { docSections, docComments, tasks, decisions } from "../../db/schema.js";
+import { docSections, docComments, tasks, decisions, documents } from "../../db/schema.js";
 import { makeTestMemex } from "../test-helpers.js";
 import { createDocDraft } from "../documents.js";
 import { addSection } from "../sections.js";
@@ -147,6 +147,32 @@ describe("per-doc seq allocator (b-36 T-2)", () => {
     ]);
 
     expect(d1.seq).not.toBe(d2.seq);
+  });
+
+  // ── Concurrent allocation: document handles — createDocDraft (spec-187) ──
+  // The handle mint (COALESCE(MAX(spec-N))+1) raced under concurrent creates in
+  // the same memex and 23505'd on `documents_memex_id_handle_unique` — exactly
+  // the b-38 F-3 race, which never reached documents until spec-187. Six
+  // concurrent creates is the worst case the withSeqRetry cap (12) is sized
+  // for; this is also the shape that flaked path-routing.api.test.ts in CI.
+  it("six concurrent createDocDraft calls in the same memex all succeed with distinct handles", async () => {
+    const memexId = await makeTestMemex("seq-concur-doc");
+
+    const docs = await Promise.all(
+      Array.from({ length: 6 }, (_, i) =>
+        createDocDraft(memexId, `Concurrent spec ${i}`, "Purpose"),
+      ),
+    );
+
+    const handles = docs.map((d) => d.handle);
+    expect(new Set(handles).size).toBe(6);
+    for (const h of handles) expect(h).toMatch(/^spec-\d+$/);
+
+    const rows = await db
+      .select({ handle: documents.handle })
+      .from(documents)
+      .where(eq(documents.memexId, memexId));
+    expect(new Set(rows.map((r) => r.handle)).size).toBe(rows.length);
   });
 
   // ── Migration invariant: existing rows ──────────────────────────────────

--- a/packages/server/src/services/standards.ts
+++ b/packages/server/src/services/standards.ts
@@ -40,6 +40,7 @@ import { nextStandardHandle } from "./documents.js";
 import { addComment } from "./comments.js";
 import { DOC_TYPES, type DocType } from "../types/roles.js";
 import { embedAndStoreDoc } from "./memex-embeddings.js";
+import { withSeqRetry } from "./shared/sequence.js";
 
 // Hard-pin the docType locally so any future renames flow through one place. Keeps the
 // service decoupled from string literals scattered across callers.
@@ -263,7 +264,10 @@ export async function createStandard(
     {},
     (created) => ({ memexId, docId: created.id, entity: "document", action: "created" }),
     async () => {
-      const result = await db.transaction(async (tx) => {
+      // spec-187: the std-N handle mint is the racy MAX+1 read — concurrent
+      // standard creates in the same memex can collide on
+      // `documents_memex_id_handle_unique`. Pure-DB tx → retry it wholesale.
+      const result = await withSeqRetry(() => db.transaction(async (tx) => {
     const handle = await nextStandardHandle(memexId, tx);
     const [doc] = await tx
       .insert(documents)
@@ -307,7 +311,7 @@ export async function createStandard(
       .returning();
 
     return { doc, sections };
-  });
+  }), "documents_memex_id_handle_unique");
 
       // Fire-and-forget: embed every section in one provider batch. Failure is logged
       // inside the helper and does not surface to the caller — the standard is already

--- a/packages/server/src/services/user-namespaces.handhold-seed-resilience.test.ts
+++ b/packages/server/src/services/user-namespaces.handhold-seed-resilience.test.ts
@@ -11,7 +11,7 @@
 // exact catch branch ac-7 protects. Runs against REAL Postgres (the namespace + memex
 // are really created); only the demo seeder is mocked.
 
-import { describe, it, expect, afterAll, vi } from "vitest";
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
 import { and, eq, inArray } from "drizzle-orm";
 
 // Mock the demo seeder to always reject. vi.mock is hoisted and keys on the module
@@ -37,6 +37,15 @@ const AC = (n: number) =>
 
 const createdNamespaceIds: string[] = [];
 const createdUserIds: string[] = [];
+
+// spec-186: the vitest config disables the signup seed hook suite-wide; this
+// suite tests the hook's failure resilience, so opt back in (call-time read).
+beforeAll(() => {
+  process.env.MEMEX_HANDHOLD_SIGNUP_SEED = "on";
+});
+afterAll(() => {
+  process.env.MEMEX_HANDHOLD_SIGNUP_SEED = "off";
+});
 
 afterAll(async () => {
   // Namespaces cascade to their memex; users last.

--- a/packages/server/src/services/user-namespaces.ts
+++ b/packages/server/src/services/user-namespaces.ts
@@ -221,7 +221,17 @@ export async function ensureUserNamespace(
 // or block signup, so the promise is detached (`void`) and any rejection is
 // swallowed to a log line. The seed itself is idempotent (NO-OP if the Memex
 // already has a demo doc — ac-8), so even a duplicate fire is harmless.
+//
+// spec-186: MEMEX_HANDHOLD_SIGNUP_SEED=off disables the hook. The vitest config
+// sets it suite-wide — under vitest every test that creates a user spawned a
+// detached multi-insert seed that outlived the test, racing its cleanup (FK
+// violations, rotating deadlocks: share-tokens / org-access / path-routing) and
+// logging after worker teardown (the EnvironmentTeardownError rpc race). The
+// hook's OWN suites (handhold.api.test.ts, the seed-resilience test) stub the
+// var back on — the env is read at CALL time, never cached, precisely so they
+// can. Prod/dev/e2e behaviour is unchanged (var unset ⇒ hook fires).
 function seedHandholdDemoBestEffort(memexId: string): void {
+  if (process.env.MEMEX_HANDHOLD_SIGNUP_SEED === "off") return;
   void seedHandholdDemo(memexId).catch((err) =>
     console.error("[handhold seed]", err),
   );

--- a/packages/server/vitest.config.ts
+++ b/packages/server/vitest.config.ts
@@ -121,6 +121,12 @@ export default defineConfig({
       // above) — the other job the retired vitest.setup.ts used to do.
       ...(rootEnv.MEMEX_EMIT_KEY ? { MEMEX_EMIT_KEY: rootEnv.MEMEX_EMIT_KEY } : {}),
       ...(rootEnv.MEMEX_EMIT ? { MEMEX_EMIT: rootEnv.MEMEX_EMIT } : {}),
+      // spec-186: the spec-178 signup hook fires a DETACHED handhold-demo seed
+      // on every user creation — under vitest those outlive their test, racing
+      // cleanup (FK noise + rotating deadlocks) and logging after worker
+      // teardown (the EnvironmentTeardownError). Off suite-wide; the hook's own
+      // suites stub it back on per-test (the gate reads env at call time).
+      MEMEX_HANDHOLD_SIGNUP_SEED: "off",
     },
     typecheck: { enabled: false },
     coverage: {


### PR DESCRIPTION
Follow-up to #39, closing the verification-visibility gap on [spec-172](https://memex.ai/mindset-prod/memex-building-itself/specs/spec-172): four scope ACs read UNTESTED in Memex despite being exercised. Three can honestly self-report; this wires them.

- **ac-1** — the `e2e-result` aggregator (the per-PR "full suite green on a cold DB" gate) now emits the AC's test event, pass **and** fail alike. Missing key / failed POST never flips the check (warn-and-continue, matching the vitest helper's semantics).
- **ac-2** — journey-inventory guard: the six deleted account-era journeys stay dead (no resurrected filenames) and their six tenancy successors stay present — dec-1's recorded disposition, now structurally guarded.
- **ac-6** — same guard file: all 12 retained journeys exist, import only the rebuilt foundation (no pre-0038 helpers, no postgres driver), and carry no `skip`/`fixme`/`only` — a retained journey can't quietly stop running.
- **ac-11** — deliberately *not* wired: its subject (std-28 published + approved) lives in Memex, not this repo; a repo test can't honestly assert it. It stays judge-by-reading (std-28 is approved).

Verification: new guard 7/7 green (emitted — ac-2/ac-6 now read verified), full `__regression__` dir 627 passed, `make e2e-cold` unaffected (no journey changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)