### PR TITLE
fix(mcp): address standards-drift verbs by ref, not UUID (spec-143 ac-14)

### DIFF
--- a/packages/server/src/__regression__/mutate-coverage.runtime.test.ts
+++ b/packages/server/src/__regression__/mutate-coverage.runtime.test.ts
@@ -49,7 +49,7 @@ interface RuntimeFixtures {
   decisionRef: string;
   taskRef: string;
   commentRef: string;
-  standardSectionId: string;
+  standardSectionRef: string;
 }
 
 async function makeRuntimeFixtures(): Promise<RuntimeFixtures> {
@@ -83,8 +83,8 @@ async function makeRuntimeFixtures(): Promise<RuntimeFixtures> {
     description: "Coverage standard",
     sections: [{ sectionType: "rule", content: "Be excellent." }],
   });
-  // Standards put sections under doc_sections rooted at the std doc. We need
-  // a section UUID for flag_drift's target.
+  // Standards put sections under doc_sections rooted at the std doc. spec-143
+  // ac-14: flag_drift targets the section by canonical ref, not a UUID.
   const stdSection = await db.query.docSections.findFirst({
     where: (s, { eq }) => eq(s.docId, std.id),
   });
@@ -99,7 +99,7 @@ async function makeRuntimeFixtures(): Promise<RuntimeFixtures> {
     decisionRef: `${base}/decisions/dec-${decision.seq}`,
     taskRef: `${base}/tasks/t-${task.seq}`,
     commentRef: `${base}/comments/c-${comment.seq}`,
-    standardSectionId: stdSection!.id,
+    standardSectionRef: `${built.ns.slug}/main/standards/${std.handle}/sections/s-${stdSection!.seq}`,
   };
 }
 
@@ -201,7 +201,7 @@ const RUNTIME_CASES: RuntimeCase[] = [
   // {
   //   tool: "flag_drift",
   //   args: (f) => ({
-  //     standardSectionId: f.standardSectionId,
+  //     ref: f.standardSectionRef,
   //     observation: "Drift observed by runtime cov.",
   //   }),
   //   expected: { entity: "standard_drift", action: "created" },

--- a/packages/server/src/__regression__/ref-emission.regression.test.ts
+++ b/packages/server/src/__regression__/ref-emission.regression.test.ts
@@ -221,8 +221,8 @@ describe("regression: every entity-acting MCP tool emits `ref:` and no raw UUID 
   // Standard fixtures (spec-143 dec-1): flag_drift + propose_standard_change
   // act on a standard SECTION (raw UUID input — no handle scheme) and emit a
   // `ref:` to the comment that lands under the standard's std-N handle.
-  let driftSectionId: string;
-  let proposeSectionId: string;
+  let driftSectionRef: string;
+  let proposeSectionRef: string;
 
   beforeAll(async () => {
     memexId = await makeTestMemex("ref-emit");
@@ -358,8 +358,10 @@ describe("regression: every entity-acting MCP tool emits `ref:` and no raw UUID 
       ],
     });
     cleanup.docs.push(std.id);
-    driftSectionId = std.sections.find((s) => s.sectionType === "rule-drift")!.id;
-    proposeSectionId = std.sections.find((s) => s.sectionType === "rule-propose")!.id;
+    // spec-143 ac-14: the drift verbs take the canonical section ref, not a UUID.
+    const stdBase = `${slugs.namespace}/${slugs.memex}/standards/${std.handle}`;
+    driftSectionRef = `${stdBase}/sections/s-${std.sections.find((s) => s.sectionType === "rule-drift")!.seq}`;
+    proposeSectionRef = `${stdBase}/sections/s-${std.sections.find((s) => s.sectionType === "rule-propose")!.seq}`;
   });
 
   // Build the per-tool case registry. One per shared spec that emits a
@@ -583,14 +585,14 @@ describe("regression: every entity-acting MCP tool emits `ref:` and no raw UUID 
       ],
       ["assign_spec", { input: () => ({ ref: refForDoc(slugs, docHandle), user: userId }) }],
       ["unassign_spec", { input: () => ({ ref: refForDoc(slugs, docHandle), user: userId }) }],
-      // ── Standards drift tools (spec-143 dec-1) ──
-      // Raw standard-section UUID in (no handle scheme), `ref:` to the comment
-      // under the standard's std-N handle out.
+      // ── Standards drift tools (spec-143 dec-1, ac-14) ──
+      // Canonical standard-section `ref` in, `ref:` to the comment under the
+      // standard's std-N handle out.
       [
         "flag_drift",
         {
           input: () => ({
-            standardSectionId: driftSectionId,
+            ref: driftSectionRef,
             observation: "RefEmit: the code no longer matches this rule.",
           }),
         },
@@ -599,7 +601,7 @@ describe("regression: every entity-acting MCP tool emits `ref:` and no raw UUID 
         "propose_standard_change",
         {
           input: () => ({
-            standardSectionId: proposeSectionId,
+            ref: proposeSectionRef,
             proposedContent: "RefEmit: corrected rule body.",
             rationale: "refemit rationale",
           }),

--- a/packages/server/src/agent/tool-specs.audit.integration.test.ts
+++ b/packages/server/src/agent/tool-specs.audit.integration.test.ts
@@ -766,8 +766,8 @@ describe("audit: b-36 D-8 — every terse mutation/list response emits `ref:` an
   // Standard fixtures (spec-143 dec-1): flag_drift + propose_standard_change
   // act on a standard SECTION (raw UUID input — no handle scheme), and emit a
   // `ref:` to the comment that lands under the standard's std-N handle.
-  let driftSectionId: string;
-  let proposeSectionId: string;
+  let driftSectionRef: string;
+  let proposeSectionRef: string;
 
   beforeAll(async () => {
     memexId = await makeTestMemex("probe-ref");
@@ -913,8 +913,10 @@ describe("audit: b-36 D-8 — every terse mutation/list response emits `ref:` an
       ],
     });
     cleanup.docs.push(std.id);
-    driftSectionId = std.sections.find((s) => s.sectionType === "rule-drift")!.id;
-    proposeSectionId = std.sections.find((s) => s.sectionType === "rule-propose")!.id;
+    // spec-143 ac-14: drift verbs take the canonical section ref, not a UUID.
+    const stdBase = `${slugs.namespace}/${slugs.memex}/standards/${std.handle}`;
+    driftSectionRef = `${stdBase}/sections/s-${std.sections.find((s) => s.sectionType === "rule-drift")!.seq}`;
+    proposeSectionRef = `${stdBase}/sections/s-${std.sections.find((s) => s.sectionType === "rule-propose")!.seq}`;
   });
 
   type ProbeCase = {
@@ -1201,14 +1203,14 @@ describe("audit: b-36 D-8 — every terse mutation/list response emits `ref:` an
       ],
       ["assign_spec", { input: () => ({ ref: docRef(slugs, docHandle), user: userId }) }],
       ["unassign_spec", { input: () => ({ ref: docRef(slugs, docHandle), user: userId }) }],
-      // ── Standards drift tools (spec-143 dec-1) ──
-      // Both take a raw standard-section UUID (no handle scheme) but emit a
-      // `ref:` to the comment that lands under the standard's std-N handle.
+      // ── Standards drift tools (spec-143 dec-1, ac-14) ──
+      // Both take a canonical standard-section `ref` and emit a `ref:` to the
+      // comment that lands under the standard's std-N handle.
       [
         "flag_drift",
         {
           input: () => ({
-            standardSectionId: driftSectionId,
+            ref: driftSectionRef,
             observation: "Probe: the code no longer matches this rule.",
           }),
         },
@@ -1217,7 +1219,7 @@ describe("audit: b-36 D-8 — every terse mutation/list response emits `ref:` an
         "propose_standard_change",
         {
           input: () => ({
-            standardSectionId: proposeSectionId,
+            ref: proposeSectionRef,
             proposedContent: "Probe: corrected rule body.",
             rationale: "probe rationale",
           }),
@@ -1309,8 +1311,9 @@ const ID_PARAM_UUID_ONLY = new Set<string>([
   "add_comment.sectionId",
   "list_comments.sectionId",
   "update_comment.commentId",
-  "flag_drift.standardSectionId",
-  "propose_standard_change.standardSectionId",
+  // spec-143 ac-14: flag_drift / propose_standard_change no longer take a raw
+  // section UUID — they take a canonical section `ref` resolved server-side
+  // (resolveStandardSectionRef), so they are no longer listed here.
   // Cross-reference target id is opaque (depends on referenceType), not a
   // memex-scoped handle.
   "add_comment.referenceId",

--- a/packages/server/src/agent/tool-specs.ts
+++ b/packages/server/src/agent/tool-specs.ts
@@ -432,12 +432,12 @@ interface FullDocState {
 
 /**
  * Build the canonical ref for a comment that landed on a standard SECTION
- * (flag_drift / propose_standard_change). The tools take a raw standard-section
- * UUID (standard sections have no handle scheme — see ID_PARAM_UUID_ONLY), but
- * the resulting comment lives under the standard's `std-N` handle and so has a
- * canonical ref. Returns null only if the section/standard or memex slugs can't
- * be resolved (in which case the handler omits the `ref:` line entirely rather
- * than leaking a raw UUID).
+ * (flag_drift / propose_standard_change). The tools take a canonical section
+ * ref and resolve it to the section UUID server-side (see
+ * resolveStandardSectionRef, spec-143 ac-14); the resulting comment lives under
+ * the standard's `std-N` handle and so also has a canonical ref. Returns null
+ * only if the section/standard or memex slugs can't be resolved (in which case
+ * the handler omits the `ref:` line entirely rather than leaking a raw UUID).
  */
 async function buildStandardCommentRef(
   memexId: string,
@@ -455,6 +455,38 @@ async function buildStandardCommentRef(
   const slugs = await memexSlugsById(memexId);
   if (!slugs) return null;
   return buildChildRef(slugs, standard, { type: "comments", seq: commentSeq });
+}
+
+/**
+ * Resolve a standard-section `ref` arg (e.g.
+ * `<ns>/<mx>/standards/std-N/sections/s-M`) to its owning memex + raw section
+ * UUID, for the standards-drift verbs (`flag_drift` / `propose_standard_change`).
+ *
+ * spec-143 ac-14: these verbs used to take a raw section UUID via
+ * `resolveMemexFromEntity("section", …)`, but the read surface only ever emits
+ * `s-N` section refs (see `formatStandard` — `Section #N | ref: …/sections/s-N`),
+ * never a section UUID, so the UUID-only contract made them uncallable from MCP
+ * and contradicted the "UUIDs are not accepted on the MCP boundary" invariant.
+ * They now take the canonical ref and resolve it server-side, exactly like
+ * `update_section` / `edit_clause`. `resolveRefArg` rejects a raw UUID up front
+ * via `assertRefNotUuid`.
+ */
+async function resolveStandardSectionRef(
+  ctx: ToolCtx,
+  ref: string,
+): Promise<{ memexId: string; sectionId: string }> {
+  const resolved = await resolveRefArg(ctx, ref);
+  if (resolved.entity.kind !== "section") {
+    throw new ValidationError(
+      `Expected a standard section ref (e.g. \`<ns>/<mx>/standards/std-N/sections/s-M\`); got ${resolved.entity.kind}.`,
+    );
+  }
+  if (resolved.doc.docType !== "standard") {
+    throw new ValidationError(
+      `\`${ref}\` is a section on a ${resolved.doc.docType}, not a standard. flag_drift / propose_standard_change only operate on standard sections.`,
+    );
+  }
+  return { memexId: resolved.memexId, sectionId: resolved.entity.row.id };
 }
 
 async function fullDocState(memexId: string, docIdOrHandle: string): Promise<FullDocState> {
@@ -3811,17 +3843,23 @@ export const toolSpecs: ToolSpec[] = [
     description:
       "Flag drift on a standard section — post a typed `drift` comment (sourced 'agent') describing the gap between the rule and observed reality. Drift often surfaces *mid-change*, not at the start of a task: stay watchful as you implement and flag the moment you see the gap. If the rule itself is wrong (not just out-of-sync with code), use `propose_standard_change` instead.",
     schema: {
-      standardSectionId: z.string().describe("Standard section UUID"),
+      ref: z
+        .string()
+        .describe(
+          "Canonical ref to the standard section, e.g. `<ns>/<mx>/standards/std-7/sections/s-3` — the same `ref:` form get_doc / search_memex emit. NOT a UUID.",
+        ),
       observation: z
         .string()
         .describe("What the agent observed that diverges from the standard rule"),
       verbose: VERBOSE_FIELD,
     },
     async handler(input, ctx) {
-      const sectionId = input.standardSectionId as string;
+      const ref = input.ref as string;
       const observation = input.observation as string;
 
-      const memexId = await ctx.resolveMemexFromEntity("section", sectionId);
+      // spec-143 ac-14: address the section by canonical ref, not a raw UUID
+      // (see resolveStandardSectionRef).
+      const { memexId, sectionId } = await resolveStandardSectionRef(ctx, ref);
       // spec-156 W2 (FINDING 3): thread the invoking surface so the
       // standard_drift event is attributed to the actor (mcp vs in_app_agent)
       // instead of falling back to channel 'server' / actorKind 'system'.
@@ -3830,10 +3868,9 @@ export const toolSpecs: ToolSpec[] = [
         channel: ctx.channel ?? "mcp",
       });
       // b-36 D-8: emit the affected entity as a canonical `ref:` (the drift
-      // comment on the standard), never a raw UUID. The section input is a
-      // UUID (standard sections have no handle scheme — ID_PARAM_UUID_ONLY),
-      // but the drift comment lives under the standard's std-N handle and so
-      // has a ref. Load the owning standard to build it.
+      // comment on the standard), never a raw UUID. The drift comment lives
+      // under the standard's std-N handle and so has a ref. Load the owning
+      // standard to build it.
       const commentRef = await buildStandardCommentRef(memexId, sectionId, comment.seq);
       if (ctx.verbose) {
         return commentRef
@@ -3849,7 +3886,11 @@ export const toolSpecs: ToolSpec[] = [
     description:
       "Propose a corrected version of a standard section. Lands as a typed `plan_revision` comment (sourced 'agent') containing the full proposed replacement and a rationale. The standard owner reviews + accepts in the React UI Drift Inbox.",
     schema: {
-      standardSectionId: z.string().describe("Standard section UUID"),
+      ref: z
+        .string()
+        .describe(
+          "Canonical ref to the standard section, e.g. `<ns>/<mx>/standards/std-7/sections/s-3` — the same `ref:` form get_doc / search_memex emit. NOT a UUID.",
+        ),
       proposedContent: z
         .string()
         .describe("The full replacement markdown for the section."),
@@ -3860,11 +3901,13 @@ export const toolSpecs: ToolSpec[] = [
       verbose: VERBOSE_FIELD,
     },
     async handler(input, ctx) {
-      const sectionId = input.standardSectionId as string;
+      const ref = input.ref as string;
       const proposedContent = input.proposedContent as string;
       const rationale = input.rationale as string | undefined;
 
-      const memexId = await ctx.resolveMemexFromEntity("section", sectionId);
+      // spec-143 ac-14: address the section by canonical ref, not a raw UUID
+      // (see resolveStandardSectionRef).
+      const { memexId, sectionId } = await resolveStandardSectionRef(ctx, ref);
       // spec-156 W2 (FINDING 3): thread the invoking surface so the
       // standard_drift event carries channel/user attribution (mcp vs
       // in_app_agent), not the channel 'server' / actorKind 'system' default.

--- a/packages/server/src/mcp/codebase-formatters.ts
+++ b/packages/server/src/mcp/codebase-formatters.ts
@@ -36,7 +36,7 @@ export const CODEBASE_LOOP_FOOTER = [
   "**Codebase loop** — when reading code as part of `build`:",
   "- Read before write. Use `list_symbols`, `code_search`, `get_symbol(include:['dependencies'])` to ground the change before generating.",
   "- `search_memex({ query, kind: 'standard' })` for the area you're about to touch — pinned team rules live there.",
-  "- If you spot a rule that's wrong or stale, `propose_standard_change(standardSectionId, proposedContent)`. If the rule is right but the code has drifted, `flag_drift(standardSectionId, observation)`. Don't route around either.",
+  "- If you spot a rule that's wrong or stale, `propose_standard_change(ref, proposedContent)` where `ref` is the section's canonical ref (e.g. `…/standards/std-N/sections/s-M`). If the rule is right but the code has drifted, `flag_drift(ref, observation)`. Don't route around either.",
   "- A task is `complete` only when verification actually runs (type checks + tests + the new path exercised). Plausibility is the failure mode.",
 ].join("\n");
 

--- a/packages/server/src/mcp/standard-tools.integration.test.ts
+++ b/packages/server/src/mcp/standard-tools.integration.test.ts
@@ -4,6 +4,7 @@
 // what the caller tries to pass).
 
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
 import { eq, inArray } from "drizzle-orm";
 import { db } from "../db/connection.js";
 import {
@@ -19,6 +20,7 @@ import {
 } from "../db/schema.js";
 import { createMcpServer } from "./tools.js";
 import { createDocDraft } from "../services/documents.js";
+import { createStandard } from "../services/standards.js";
 
 const created = {
   users: [] as string[],
@@ -202,8 +204,10 @@ describe.skip("Standard MCP tools (post-doc-14)", () => {
     });
     const verify = sections.find((s) => s.sectionType === "verify")!;
 
+    // spec-143 ac-14: flag_drift takes the canonical section ref, not a UUID.
+    const ref = `${actor.account.slug}/main/standards/${doc!.handle}/sections/s-${verify.seq}`;
     const result = await callTool(actor.user.id, "flag_drift", {
-      standardSectionId: verify.id,
+      ref,
       observation: "Repo uses ArgoCD now, not kubectl.",
     });
     expect(result.isError).toBeFalsy();
@@ -240,11 +244,92 @@ describe.skip("Standard MCP tools (post-doc-14)", () => {
     const sections = await db.query.docSections.findMany({
       where: (s, { eq }) => eq(s.docId, spec.id),
     });
+    // spec-143 ac-14: a section ref on a non-standard doc is rejected.
+    const ref = `${actor.account.slug}/main/specs/${spec.handle}/sections/s-${sections[0].seq}`;
     const result = await callTool(actor.user.id, "flag_drift", {
-      standardSectionId: sections[0].id,
+      ref,
       observation: "x",
     });
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toMatch(/not a standard/);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// spec-143 ac-14: the standards-drift verbs (flag_drift / propose_standard_change)
+// must address the target section by its CANONICAL REF (the only form any read
+// surface emits — `…/standards/std-N/sections/s-M`), never a raw section UUID.
+// A raw UUID — even the section's real id — is rejected. This is its own
+// (un-skipped) block: the doc-24 describe.skip above predates the spec-143
+// restoration and stays skipped, so it can't carry this coverage.
+// ─────────────────────────────────────────────────────────────────────────
+const AC_REF_ADDRESSING =
+  "mindset-prod/memex-building-itself/specs/spec-143/acs/ac-14";
+
+describe("spec-143 ac-14: drift verbs address by canonical ref, not UUID", () => {
+  let sectionRef: string;
+  let sectionUuid: string;
+
+  beforeAll(async () => {
+    // Standards are born with no body section via create_doc — they're authored
+    // as clauses. Use the createStandard service directly (as ref-emission /
+    // audit / mutate-coverage do) to get a standard WITH a section to target.
+    const std = await createStandard(actor.account.id, {
+      title: "Ac14 RefAddressing",
+      sections: [{ sectionType: "rule", content: "Original rule body." }],
+    });
+    created.docs.push(std.id);
+    const section = std.sections.find((s) => s.sectionType === "rule")!;
+    sectionUuid = section.id;
+    sectionRef = `${actor.account.slug}/main/standards/${std.handle}/sections/s-${section.seq}`;
+  });
+
+  it("propose_standard_change accepts a canonical section ref", async () => {
+    tagAc(AC_REF_ADDRESSING);
+    const res = await callTool(actor.user.id, "propose_standard_change", {
+      ref: sectionRef,
+      proposedContent: "Corrected rule body.",
+      rationale: "ac-14 ref addressing",
+    });
+    expect(res.isError).toBeFalsy();
+    expect(res.content[0].text).toMatch(/Proposed change recorded/);
+    const comments = await db.query.docComments.findMany({
+      where: eq(docComments.sectionId, sectionUuid),
+    });
+    expect(comments.some((c) => c.commentType === "plan_revision")).toBe(true);
+  });
+
+  it("propose_standard_change rejects a raw section UUID (even the real one)", async () => {
+    tagAc(AC_REF_ADDRESSING);
+    const res = await callTool(actor.user.id, "propose_standard_change", {
+      ref: sectionUuid,
+      proposedContent: "should never land",
+    });
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toMatch(/UUID inputs no longer accepted|pass the ref/i);
+  });
+
+  it("flag_drift accepts a canonical section ref", async () => {
+    tagAc(AC_REF_ADDRESSING);
+    const res = await callTool(actor.user.id, "flag_drift", {
+      ref: sectionRef,
+      observation: "ac-14: the code diverged from this rule.",
+    });
+    expect(res.isError).toBeFalsy();
+    expect(res.content[0].text).toMatch(/Drift flagged/);
+    const comments = await db.query.docComments.findMany({
+      where: eq(docComments.sectionId, sectionUuid),
+    });
+    expect(comments.some((c) => c.commentType === "drift")).toBe(true);
+  });
+
+  it("flag_drift rejects a raw section UUID (even the real one)", async () => {
+    tagAc(AC_REF_ADDRESSING);
+    const res = await callTool(actor.user.id, "flag_drift", {
+      ref: sectionUuid,
+      observation: "should never land",
+    });
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toMatch(/UUID inputs no longer accepted|pass the ref/i);
   });
 });

--- a/packages/server/src/mcp/workflows.integration.test.ts
+++ b/packages/server/src/mcp/workflows.integration.test.ts
@@ -302,9 +302,12 @@ describe.skip("Workflow: Standards drift loop", () => {
     });
     expect(doSection).toBeTruthy();
 
+    // spec-143 ac-14: the standards-drift verbs take the canonical section ref.
+    const doSectionRef = refForSection(actor, std!, doSection!.seq);
+
     // 2. flag_drift on the section
     const flagRes = await callTool(actor.user.id, "flag_drift", {
-      standardSectionId: doSection!.id,
+      ref: doSectionRef,
       observation: "auth/login.ts:42 still uses bcrypt — diverges from this rule.",
     });
     expect(flagRes.isError).toBeFalsy();
@@ -316,7 +319,7 @@ describe.skip("Workflow: Standards drift loop", () => {
 
     // 3. propose_standard_change
     const proposeRes = await callTool(actor.user.id, "propose_standard_change", {
-      standardSectionId: doSection!.id,
+      ref: doSectionRef,
       proposedContent: "Always use scrypt or argon2id for password hashing.",
       rationale: "argon2id is the OWASP-recommended default for new code.",
     });

--- a/packages/server/src/routes/llm.test.ts
+++ b/packages/server/src/routes/llm.test.ts
@@ -419,7 +419,7 @@ describe("POST /llm/tools/execute — drift mode (spec-143 t-4)", () => {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         toolName: "flag_drift",
-        input: { standardSectionId: "sec-1", observation: "X drifted" },
+        input: { ref: "ns/mx/standards/std-1/sections/s-1", observation: "X drifted" },
         mode: "drift",
       }),
     });

--- a/packages/shared/src/scaffold-data.ts
+++ b/packages/shared/src/scaffold-data.ts
@@ -269,8 +269,8 @@ const BASE_STANDARDS_PROTOCOL: PromptBlockNode = {
   surface: 'shared_nudge',
   text:
     '**Standards protocol** — when working with a standard:\n' +
-    '- If the rule is wrong or out of date, call `propose_standard_change(standardId, proposed)` with the corrected text. The proposal lands as a `plan_revision` typed comment for the standard owner to accept or reject.\n' +
-    '- If the rule is correct but the codebase has drifted from it, call `flag_drift(standardSectionId, observation)`. Drift comments surface in the Standards Drift Inbox (sourced \'agent\').\n' +
+    '- If the rule is wrong or out of date, call `propose_standard_change(ref, proposed)` with the corrected text — `ref` is the section\'s canonical ref (e.g. `…/standards/std-N/sections/s-M`), not a UUID. The proposal lands as a `plan_revision` typed comment for the standard owner to accept or reject.\n' +
+    '- If the rule is correct but the codebase has drifted from it, call `flag_drift(ref, observation)` with the section\'s canonical ref. Drift comments surface in the Standards Drift Inbox (sourced \'agent\').\n' +
     '- When citing a standard in code or in another doc, use the `[per std-N]` form so the back-reference resolves automatically.\n' +
     '- Use `search_memex({ query, kind: \'standard\' })` (handle / FTS / vector) before authoring new rules — duplicate standards confuse the agent loop.',
   rationale:

--- a/packages/shared/src/tool-manifest.ts
+++ b/packages/shared/src/tool-manifest.ts
@@ -284,7 +284,7 @@ export const toolManifest: ToolManifestEntry[] = [
     name: 'flag_drift',
     summary:
       "Flag drift on a standard section — post a typed `drift` comment (sourced 'agent') describing the gap between the rule and observed reality. Use when the rule is right but the code drifted; if the rule is wrong, use propose_standard_change.",
-    args: 'flag_drift(standardSectionId, observation)',
+    args: 'flag_drift(ref, observation)',
     group: 'build',
     readOnlyHint: false,
   },
@@ -292,7 +292,7 @@ export const toolManifest: ToolManifestEntry[] = [
     name: 'propose_standard_change',
     summary:
       'Propose a corrected version of a standard section. Lands as a typed `plan_revision` comment (sourced \'agent\') with the full proposed replacement and a rationale, for the standard owner to accept or reject in the Drift Inbox.',
-    args: 'propose_standard_change(standardSectionId, proposedContent, rationale?)',
+    args: 'propose_standard_change(ref, proposedContent, rationale?)',
     group: 'build',
     readOnlyHint: false,
   },


### PR DESCRIPTION
## Why

`propose_standard_change` and `flag_drift` took a raw standard-section **UUID** (`standardSectionId`) resolved via the UUID-only `resolveMemexFromEntity` path. But **no read surface ever emits section UUIDs** — `get_doc` / `list_docs` / `search_memex` / `export_doc` render only `s-N` section refs (`Section #N | ref: …/sections/s-N`). So once **spec-143** restored these verbs they were effectively **uncallable from MCP**, and the contract directly contradicted the spec-143 standards-protocol invariant that *"UUIDs are not accepted on the MCP boundary."*

This was reported externally (Barrie): *"sectionId must be a UUID … but get_doc / list_docs / search_memex / export_doc none of them render section UUIDs."* The diagnosis: spec-143 un-hid two verbs that had **always** been UUID-addressed (since the initial commit) — it didn't reintroduce UUIDs, it surfaced a pre-existing UUID-only contract that the rest of the tool surface had since moved off of (e.g. `edit_clause` / `update_section` are ref-addressed).

## What

Both verbs now take a canonical section **`ref`** (`<ns>/<mx>/standards/std-N/sections/s-M`), resolved server-side via the shared `resolveRefArg` path — the same one `edit_clause` / `update_section` use — which rejects a raw UUID up front via `assertRefNotUuid`. The service layer (`flagDrift` / `proposeStandardChange`) is unchanged; the handler resolves `ref → UUID` internally.

- **`tool-specs.ts`**: new `resolveStandardSectionRef` helper; both schemas `standardSectionId` → `ref`; refreshed handler/comment prose.
- **`@memex/shared`**: manifest `args` + scaffold-data standards-protocol prose + codebase-formatters prose → ref form.
- **audit `ID_PARAM_UUID_ONLY`**: dropped the two now-renamed entries.
- **existing callers** (ref-emission, workflows, audit probe, mutate-coverage runtime, llm) → pass canonical refs.

## Acceptance criterion

Locks the contract so it can't silently regress: **`spec-143/acs/ac-14`** (implementation, parented to dec-1) — both verbs address by canonical ref, raw UUID rejected.

## Tests

New `ac-14` block in `standard-tools.integration.test.ts` (tagged `ac-14`), 4 cases: each verb **accepts a canonical ref** and **rejects a raw section UUID** (even the real one).

Verified locally (server): standard-tools, workflows, ref-emission, audit, mutate-coverage runtime/endpoint, llm, tool-manifest-args, tools-coverage, tool-annotations, system-prompt.t21, tools.drift-mode, authoring-standards-guidance — all green. Shared rebuilt; server typechecks clean (pre-existing unrelated `discord-webhook.test.ts` error aside). `packages/ui` render test not run locally (deps not installed); it derives from the same manifest the passing `tool-manifest-args` regression covers.

## Follow-ups (out of scope)

- `describe.skip` blocks in `standard-tools` / `workflows` predate the spec-143 restoration and stay skipped — worth un-skipping separately.
- `ID_PARAM_UUID_ONLY` still lists stale params (`update_section.sectionId`, `add_comment.sectionId`, …) that no longer exist on those schemas — harmless dead entries, candidate for cleanup.