### PR TITLE
spec-185: remove the human comment-type filter chips from the Comments surface

### DIFF
--- a/packages/ui/e2e/journey-15-spec-detail-layout.spec.ts
+++ b/packages/ui/e2e/journey-15-spec-detail-layout.spec.ts
@@ -62,6 +62,12 @@ test.describe("Spec detail layout", () => {
     await expect(page.getByRole("button", { name: /^Decisions & ACs/ })).toBeVisible();
     await expect(page.getByRole("button", { name: /^Comments/ })).toBeVisible();
 
+    // spec-185: the human comment-type filter chip row was removed from the
+    // doc-wide Comments view (and the per-target tray). The authorship/state
+    // filters stay; only the type-chip row is gone.
+    await page.getByRole("button", { name: /^Comments/ }).click();
+    await expect(page.getByTestId("comment-filter-chips")).toHaveCount(0);
+
     await page.getByRole("button", { name: /^Decisions & ACs/ }).click();
     // A spec opened via /docs/:id canonicalises to /specs/:id (DocDocument route).
     // Switching sub-tabs is in-page — assert we're still on the spec, not that the

--- a/packages/ui/src/components/AllComments.test.tsx
+++ b/packages/ui/src/components/AllComments.test.tsx
@@ -8,6 +8,9 @@ import { tagAc } from "@memex-ai-ac/vitest";
 const AC_FILTER_LOADBEARING = 'mindset-prod/memex-building-itself/specs/spec-100/acs/ac-9';
 const AC_FILTER_USABLE = 'mindset-prod/memex-building-itself/specs/spec-100/acs/ac-4';
 const AC_DEEPLINK = 'mindset-prod/memex-building-itself/specs/spec-100/acs/ac-6';
+// spec-185 — remove the human comment-type filter chips.
+const AC185 = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-185/acs/ac-${n}`;
 
 function makeComment(overrides: Partial<Comment> = {}): Comment {
   return {
@@ -159,11 +162,10 @@ describe('AllComments', () => {
     expect(onTabChange).toHaveBeenCalledWith('decisions');
   });
 
-  // ── Filter chips (t-15) ──
+  // ── Comment-type filter chips removed (spec-185) ──
 
-  it('chip click emits onFilterChange so the parent can refetch with ?type= (W3.3 server-side filter)', async () => {
-    const user = userEvent.setup();
-    const onFilterChange = vi.fn();
+  it('renders no comment-type filter row even with open comments of mixed type (spec-185 ac-7)', () => {
+    tagAc(AC185(7));
     const section = makeSection();
     const decision = makeDecision();
     const task = makeTask();
@@ -189,40 +191,25 @@ describe('AllComments', () => {
           ],
         }}
         onNavigateToSection={vi.fn()}
-        filter={null}
-        onFilterChange={onFilterChange}
       />
     );
 
-    // All three visible at start (parent has not yet narrowed the data).
+    // No comment-type chip row in the doc-wide view (consistent with CommentTray).
+    expect(screen.queryByTestId('comment-filter-chips')).not.toBeInTheDocument();
+    for (const chip of ['all', 'plan', 'progress', 'question', 'issue', 'drift']) {
+      expect(screen.queryByTestId(`comment-filter-${chip}`)).not.toBeInTheDocument();
+    }
+    // ...and every comment renders regardless of type (no type narrowing).
     expect(screen.getByText('plan section')).toBeInTheDocument();
     expect(screen.getByText('decision question')).toBeInTheDocument();
     expect(screen.getByText('task issue')).toBeInTheDocument();
-
-    await user.click(screen.getByTestId('comment-filter-plan'));
-    // The chip click drives the parent's filter setter — the actual narrowing
-    // happens after the parent's refetch with ?type=plan returns the smaller
-    // dataset. Asserting the callback was called (with the right type) is the
-    // contract for server-side filtering.
-    expect(onFilterChange).toHaveBeenCalledWith('plan');
-  });
-
-  it('filter chips are hidden when there are no open comments at all', () => {
-    render(
-      <AllComments
-        sections={[makeSection()]}
-        commentsBySection={{}}
-        onNavigateToSection={vi.fn()}
-      />
-    );
-    expect(screen.queryByTestId('comment-filter-chips')).not.toBeInTheDocument();
-    expect(screen.getByText('No open comments.')).toBeInTheDocument();
   });
 
   // ── spec-100 ac-9 / ac-4: author-kind + status filtering ──
 
   it('filters to system (agent) comments when the System chip is clicked', async () => {
     tagAc(AC_FILTER_LOADBEARING);
+    tagAc(AC185(9)); // spec-185 ac-9: authorship filter row unchanged by chip removal
     const user = userEvent.setup();
     const section = makeSection();
     render(
@@ -249,6 +236,7 @@ describe('AllComments', () => {
 
   it('surfaces resolved comments only when the Resolved status is selected', async () => {
     tagAc(AC_FILTER_LOADBEARING);
+    tagAc(AC185(9)); // spec-185 ac-9: state filter row unchanged by chip removal
     const user = userEvent.setup();
     const section = makeSection();
     render(

--- a/packages/ui/src/components/AllComments.tsx
+++ b/packages/ui/src/components/AllComments.tsx
@@ -1,15 +1,12 @@
-import { useMemo, useState } from 'react';
-import type { Comment, CommentType, DocSection, Decision, Task } from '../api/types';
-import { CommentBubble, CommentFilterChips } from './CommentTray';
-import { FILTER_CHIP_TYPES, commentTypeLabel, type FilterChipType } from '../utils/commentStyles';
+import { useState } from 'react';
+import type { Comment, DocSection, Decision, Task } from '../api/types';
+import { CommentBubble } from './CommentTray';
 import {
   filterComments,
   type AuthorKindFilter,
   type StatusFilter,
 } from '../utils/filterComments';
 import { commentAnchorId, buildCommentLink } from '../utils/commentDeepLink';
-
-type ChipFilter = 'all' | FilterChipType;
 
 // spec-100 ac-6: wrap a comment with a stable scroll anchor (`comment-c-{seq}`)
 // and a copy-link button so a viewer can be taken straight to it.
@@ -97,11 +94,6 @@ interface AllCommentsProps {
   commentsByTask?: Record<string, Comment[]>;
   onNavigateToSection: (sectionId: string) => void;
   onTabChange?: (tab: string) => void;
-  // t-19 W3.3: chip filter is owned by the parent (DocDocument) so a chip click
-  // drives a server-side `?type=` refetch via fetchDocComments instead of a
-  // client-side filter pass after the fact. `null` means "All".
-  filter?: CommentType | null;
-  onFilterChange?: (next: CommentType | null) => void;
 }
 
 export function AllComments({
@@ -113,8 +105,6 @@ export function AllComments({
   commentsByTask = {},
   onNavigateToSection,
   onTabChange,
-  filter = null,
-  onFilterChange,
 }: AllCommentsProps) {
   // spec-100 ac-9: author kind + status are the load-bearing filters, owned
   // locally (no refetch needed — both fields are already on the loaded rows).
@@ -123,32 +113,10 @@ export function AllComments({
   const [status, setStatus] = useState<StatusFilter>('open');
   const applyLocal = (list: Comment[]) =>
     filterComments(list, { authorKind, status, type: null });
-  // Doc-wide chip counts. With server-side filtering active, these counts only
-  // reflect the comments the server returned for the current filter — when the
-  // filter is "All" they represent every open comment in the doc; when a
-  // specific filter is active they show how many are in *that* set. Per the
-  // t-19 W3.3 spec we accept this as a deliberate UX trade-off: counts now
-  // describe "what's loaded" rather than "what exists across all types".
-  const counts = useMemo(() => {
-    const allOpen: Comment[] = [];
-    for (const list of Object.values(commentsBySection)) {
-      for (const c of list) if (!c.resolvedAt) allOpen.push(c);
-    }
-    for (const list of Object.values(commentsByDecision)) {
-      for (const c of list) if (!c.resolvedAt) allOpen.push(c);
-    }
-    for (const list of Object.values(commentsByTask)) {
-      for (const c of list) if (!c.resolvedAt) allOpen.push(c);
-    }
-    const out: Partial<Record<ChipFilter, number>> = { all: allOpen.length };
-    for (const t of FILTER_CHIP_TYPES) {
-      out[t] = allOpen.filter((c) => (c.commentType ?? 'discussion') === t).length;
-    }
-    return out;
-  }, [commentsBySection, commentsByDecision, commentsByTask]);
 
-  // The parent has already narrowed by type (server-side ?type=); author kind
-  // and status are applied here client-side over that slice.
+  // spec-185: the comment-type filter chips were removed, so there is no type
+  // narrowing — author kind and status are the only filters, applied here
+  // client-side over every loaded comment.
   const sectionEntries = sections
     .map((section, index) => ({
       section,
@@ -183,23 +151,6 @@ export function AllComments({
     decisionEntries.reduce((n, e) => n + e.comments.length, 0) +
     taskEntries.reduce((n, e) => n + e.comments.length, 0);
 
-  // Show the chip row whenever any open comment exists in the current view OR
-  // when a filter is active (the user can clear it). Hidden only on a doc with
-  // truly nothing to filter.
-  const hasAnyOpen = (counts.all ?? 0) > 0 || filter !== null;
-
-  // The chip row only renders the FILTER_CHIP_TYPES tuple; if the active filter
-  // is set to a type outside that set (e.g. `discussion`), the chip row shows
-  // "All" while the data is still server-filtered to the requested type.
-  const activeChip: ChipFilter =
-    filter && (FILTER_CHIP_TYPES as readonly string[]).includes(filter)
-      ? (filter as FilterChipType)
-      : 'all';
-  const handleChipChange = (next: ChipFilter) => {
-    if (!onFilterChange) return;
-    onFilterChange(next === 'all' ? null : (next as CommentType));
-  };
-
   return (
     <div className="space-y-6 ml-8">
       {hasAnyComments && (
@@ -219,23 +170,13 @@ export function AllComments({
         </div>
       )}
 
-      {hasAnyOpen && (
-        <CommentFilterChips
-          active={activeChip}
-          onChange={handleChipChange}
-          counts={counts}
-        />
-      )}
-
       {totalCount === 0 && (
         <p className="text-sm text-muted py-8">
-          {filter === null
-            ? status === 'resolved'
-              ? 'No resolved comments.'
-              : authorKind === 'system'
-                ? 'No system comments in this view.'
-                : 'No open comments.'
-            : `No ${commentTypeLabel(filter).toLowerCase()} comments.`}
+          {status === 'resolved'
+            ? 'No resolved comments.'
+            : authorKind === 'system'
+              ? 'No system comments in this view.'
+              : 'No open comments.'}
         </p>
       )}
 

--- a/packages/ui/src/components/CommentTray.test.tsx
+++ b/packages/ui/src/components/CommentTray.test.tsx
@@ -4,7 +4,6 @@ import userEvent from '@testing-library/user-event';
 import { tagAc } from '@memex-ai-ac/vitest';
 import { CommentTray } from './CommentTray';
 import type { Comment } from '../api/types';
-import { FILTER_CHIP_TYPES } from '../utils/commentStyles';
 
 // spec-153 — remove the human comment-type dropdown.
 const AC_NO_DROPDOWN =
@@ -13,6 +12,9 @@ const AC_POSTS_AS_DISCUSSION =
   'mindset-prod/memex-building-itself/specs/spec-153/acs/ac-2';
 const AC_EXISTING_UNTOUCHED =
   'mindset-prod/memex-building-itself/specs/spec-153/acs/ac-4';
+// spec-185 — remove the human comment-type filter chips.
+const AC185 = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-185/acs/ac-${n}`;
 
 const mockCreate = vi.fn();
 const mockCreateDecision = vi.fn();
@@ -165,7 +167,7 @@ describe('CommentTray', () => {
     expect(onCommentsChange).toHaveBeenCalled();
   });
 
-  // ── Composer (spec-153: no human type picker) + filter chips + visual language ──
+  // ── Composer (spec-153: no human type picker) + comment-type chips removed (spec-185) + visual language ──
 
   it('composer has no comment-type dropdown', () => {
     tagAc(AC_NO_DROPDOWN);
@@ -191,60 +193,46 @@ describe('CommentTray', () => {
     expect(mockCreate).toHaveBeenCalledWith('sec-1', 'Tester', 'Just a thought', undefined);
   });
 
-  it('renders the filter chip row with all six chip variants when comments are present', () => {
-    tagAc(AC_EXISTING_UNTOUCHED);
+  it('renders no comment-type filter row — chips removed (spec-185 ac-6)', () => {
+    tagAc(AC185(6));
     render(
       <CommentTray
         targetType="section"
         targetId="sec-1"
-        comments={[comment({ id: 'c1' })]}
+        comments={[comment({ id: 'c1', commentType: 'plan' })]}
       />
     );
-    // Reading/filtering by type is untouched by the composer change.
-    expect(screen.getByTestId('comment-filter-chips')).toBeInTheDocument();
-    expect(screen.getByTestId('comment-filter-all')).toBeInTheDocument();
-    for (const t of FILTER_CHIP_TYPES) {
-      expect(screen.getByTestId(`comment-filter-${t}`)).toBeInTheDocument();
+    expect(screen.queryByTestId('comment-filter-chips')).not.toBeInTheDocument();
+    for (const chip of ['all', 'plan', 'progress', 'question', 'issue', 'drift']) {
+      expect(screen.queryByTestId(`comment-filter-${chip}`)).not.toBeInTheDocument();
     }
   });
 
-  it('clicking a filter chip narrows the list and clicking again clears', async () => {
-    const user = userEvent.setup();
-    const planComment = comment({
-      id: 'c-plan',
-      content: 'plan body',
-      commentType: 'plan',
-    });
-    const issueComment = comment({
-      id: 'c-issue',
-      content: 'issue body',
-      commentType: 'issue',
-    });
-
+  it('renders open comments of every type with no type filtering (spec-185 ac-8)', () => {
+    tagAc(AC185(8));
+    const comments = [
+      comment({ id: 'c-disc', content: 'a discussion', commentType: 'discussion' }),
+      comment({ id: 'c-plan', content: 'a plan', commentType: 'plan' }),
+      comment({ id: 'c-prog', content: 'a progress', commentType: 'progress' }),
+      comment({ id: 'c-q', content: 'a question', commentType: 'question' }),
+      comment({ id: 'c-issue', content: 'an issue', commentType: 'issue' }),
+      comment({ id: 'c-drift', content: 'a drift', commentType: 'drift' }),
+    ];
     render(
-      <CommentTray
-        targetType="section"
-        targetId="sec-1"
-        comments={[planComment, issueComment]}
-      />
+      <CommentTray targetType="section" targetId="sec-1" comments={comments} />
     );
-
-    // Both visible at start.
-    expect(screen.getByText('plan body')).toBeInTheDocument();
-    expect(screen.getByText('issue body')).toBeInTheDocument();
-
-    // Click the "plan" chip — only plan body shows.
-    await user.click(screen.getByTestId('comment-filter-plan'));
-    expect(screen.getByText('plan body')).toBeInTheDocument();
-    expect(screen.queryByText('issue body')).not.toBeInTheDocument();
-
-    // Click again to clear.
-    await user.click(screen.getByTestId('comment-filter-plan'));
-    expect(screen.getByText('plan body')).toBeInTheDocument();
-    expect(screen.getByText('issue body')).toBeInTheDocument();
+    for (const body of ['a discussion', 'a plan', 'a progress', 'a question', 'an issue', 'a drift']) {
+      expect(screen.getByText(body)).toBeInTheDocument();
+    }
+    expect(screen.getAllByTestId('comment-item')).toHaveLength(6);
   });
 
   it('renders the type pill and source avatar with the correct data-attributes', () => {
+    // spec-153 ac-4: existing comments keep their per-type badges (the
+    // "filter chips still work" half of ac-4 is superseded by spec-185, which
+    // removed the chips). spec-185 ac-9: per-type pills survive the removal.
+    tagAc(AC_EXISTING_UNTOUCHED);
+    tagAc(AC185(9));
     const agentPlan = comment({
       id: 'c-agent',
       content: 'agent plan body',
@@ -277,8 +265,11 @@ describe('CommentTray', () => {
 });
 
 // spec-164 dec-6 — agent chatter (plan/progress) muted by default in trays
-// that opt in (the task tray); human-loop types still auto-surface; the chips
-// act as the default-off reveal.
+// that opt in (the task tray); human-loop types still auto-surface. spec-185
+// removed the comment-type chips, so the chip-based reveal is gone (dec-2):
+// muting-by-default is preserved and surfaced via the count note; spec-164
+// ac-24's chip-reveal half and ac-25 (chip counts) are superseded — see the
+// supersession comment on spec-164.
 describe('CommentTray — muteAgentChatter (spec-164)', () => {
   const AC164 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-164/acs/ac-${n}`;
 
@@ -289,9 +280,14 @@ describe('CommentTray — muteAgentChatter (spec-164)', () => {
     comment({ id: 'c-q', commentType: 'question', content: 'human question' } as Partial<Comment>),
   ];
 
-  it('hides plan/progress on the default All view; review/question still render', () => {
+  it('hides plan/progress on the default view; review/question still render (spec-164 ac-9/ac-24; spec-185 ac-10/ac-11)', () => {
+    // Muting-by-default survives the spec-185 chip removal (spec-185 ac-10);
+    // the discoverability note names the count and no longer points at the
+    // removed chips (spec-185 ac-11). spec-164 ac-24 keeps its muting half.
     tagAc(AC164(24));
     tagAc('mindset-prod/memex-building-itself/specs/spec-164/acs/ac-9');
+    tagAc(AC185(10));
+    tagAc(AC185(11));
     render(
       <CommentTray targetType="task" targetId="t-1" comments={chatterSet()} muteAgentChatter />,
     );
@@ -299,27 +295,10 @@ describe('CommentTray — muteAgentChatter (spec-164)', () => {
     expect(screen.queryByText('agent plan note')).not.toBeInTheDocument();
     expect(screen.getByText('human review feedback')).toBeInTheDocument();
     expect(screen.getByText('human question')).toBeInTheDocument();
-    // The discoverability note names the hidden count.
-    expect(screen.getByTestId('comment-chatter-note')).toHaveTextContent('2 agent updates hidden');
-  });
-
-  it('selecting the Progress chip reveals the muted chatter (default-off filter)', async () => {
-    tagAc(AC164(24));
-    const user = userEvent.setup();
-    render(
-      <CommentTray targetType="task" targetId="t-1" comments={chatterSet()} muteAgentChatter />,
-    );
-    await user.click(screen.getByTestId('comment-filter-progress'));
-    expect(screen.getByText('agent progress update')).toBeInTheDocument();
-  });
-
-  it('chip counts still reflect ALL open comments, including the hidden chatter', () => {
-    tagAc(AC164(25));
-    render(
-      <CommentTray targetType="task" targetId="t-1" comments={chatterSet()} muteAgentChatter />,
-    );
-    expect(screen.getByTestId('comment-filter-all')).toHaveTextContent('All · 4');
-    expect(screen.getByTestId('comment-filter-progress')).toHaveTextContent('Progress · 1');
+    const note = screen.getByTestId('comment-chatter-note');
+    expect(note).toHaveTextContent('2 agent updates hidden');
+    expect(note).not.toHaveTextContent(/chip/i);
+    expect(note).not.toHaveTextContent(/Plan \/ Progress/);
   });
 
   it('without the opt-in (section/decision trays) chatter renders as before', () => {

--- a/packages/ui/src/components/CommentTray.tsx
+++ b/packages/ui/src/components/CommentTray.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, useRef } from 'react';
+import { useState, useRef } from 'react';
 import type { Comment, CommentTargetType } from '../api/types';
 import { useAuth } from './AuthContext';
 import {
@@ -14,12 +14,7 @@ import { Button } from './ui';
 import { CommentTypePill } from './CommentTypePill';
 import { CommentSourceAvatar } from './CommentSourceAvatar';
 import { DecisionLink, TaskLink, parseEntityRefs } from './DecisionLink';
-import {
-  FILTER_CHIP_TYPES,
-  commentTypeAccentBorder,
-  commentTypeLabel,
-  type FilterChipType,
-} from '../utils/commentStyles';
+import { commentTypeAccentBorder } from '../utils/commentStyles';
 
 interface CommentTrayProps {
   targetType: CommentTargetType;
@@ -35,17 +30,16 @@ interface CommentTrayProps {
   canWrite?: boolean;
   /**
    * spec-164 dec-6: when true (the task tray), agent-generated chatter —
-   * `plan` / `progress` typed comments — is hidden from the default "All"
-   * view behind its existing type chips, which act as the default-off
-   * filter. Human-loop types (review / question / drift / plan_revision /
-   * discussion) still auto-surface. Counts keep reflecting ALL open
-   * comments so hidden chatter stays discoverable. Defaults to false so
-   * section/decision trays are unchanged.
+   * `plan` / `progress` typed comments — is hidden from the default view.
+   * Human-loop types (review / question / drift / plan_revision /
+   * discussion) still auto-surface, and a discoverability note names the
+   * hidden count. Defaults to false so section/decision trays are unchanged.
+   *
+   * spec-185: the comment-type filter chips were removed, so the chip-based
+   * reveal is gone — hidden chatter is surfaced via the count note only.
    */
   muteAgentChatter?: boolean;
 }
-
-type ChipFilter = 'all' | FilterChipType;
 
 // The agent-chatter comment types dec-6 mutes by default in the task tray.
 const AGENT_CHATTER_TYPES: ReadonlyArray<string> = ['plan', 'progress'];
@@ -54,86 +48,23 @@ function isAgentChatter(comment: Comment): boolean {
   return AGENT_CHATTER_TYPES.includes(comment.commentType ?? 'discussion');
 }
 
-interface CommentFilterChipsProps {
-  active: ChipFilter;
-  onChange: (next: ChipFilter) => void;
-  /**
-   * Optional per-type counts. When provided, each chip renders its count;
-   * chips with zero count are still rendered so the row stays stable as the
-   * user filters.
-   */
-  counts?: Partial<Record<ChipFilter, number>>;
-}
-
-/**
- * Filter chip row shown above CommentTray and AllComments. Per Section 7 of
- * doc-10: All / Plan / Progress / Question / Issue / Drift. The same component
- * is exported for reuse so the doc-wide view in AllComments stays visually
- * consistent with the per-target tray.
- */
-export function CommentFilterChips({ active, onChange, counts }: CommentFilterChipsProps) {
-  const chips: ChipFilter[] = ['all', ...FILTER_CHIP_TYPES];
-  return (
-    <div data-testid="comment-filter-chips" className="flex flex-wrap gap-1.5 mb-2">
-      {chips.map((chip) => {
-        const label = chip === 'all' ? 'All' : commentTypeLabel(chip);
-        const count = counts?.[chip];
-        const isActive = active === chip;
-        return (
-          <button
-            key={chip}
-            type="button"
-            data-testid={`comment-filter-${chip}`}
-            data-active={isActive ? 'true' : 'false'}
-            onClick={() => onChange(isActive ? 'all' : chip)}
-            className={`text-[11px] rounded-full px-2 py-0.5 border transition-colors ${
-              isActive
-                ? 'bg-accent text-white border-accent'
-                : 'bg-overlay text-secondary border-divider hover:border-accent/50'
-            }`}
-          >
-            {label}
-            {count !== undefined ? ` · ${count}` : ''}
-          </button>
-        );
-      })}
-    </div>
-  );
-}
-
-function matchesFilter(comment: Comment, filter: ChipFilter): boolean {
-  if (filter === 'all') return true;
-  return (comment.commentType ?? 'discussion') === filter;
-}
-
 export function CommentTray({ targetType, targetId, comments, onCommentsChange, canWrite = true, muteAgentChatter = false }: CommentTrayProps) {
   const { user } = useAuth();
   const [content, setContent] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const [showResolved, setShowResolved] = useState(false);
-  const [filter, setFilter] = useState<ChipFilter>('all');
   const inputRef = useRef<HTMLTextAreaElement>(null);
 
-  const counts = useMemo(() => {
-    const open = comments.filter((c) => !c.resolvedAt);
-    const out: Partial<Record<ChipFilter, number>> = { all: open.length };
-    for (const t of FILTER_CHIP_TYPES) {
-      out[t] = open.filter((c) => (c.commentType ?? 'discussion') === t).length;
-    }
-    return out;
-  }, [comments]);
-
-  // spec-164 dec-6: on the default "All" view of a muted tray, agent chatter
-  // (plan/progress) is excluded — selecting its chip reveals it. Explicit
-  // chip selections are never muted.
-  const chatterMuted = muteAgentChatter && filter === 'all';
+  // spec-164 dec-6: in a muted tray (the task tray) agent chatter
+  // (plan/progress) is hidden by default and a discoverability note names the
+  // hidden count. spec-185 removed the comment-type chip row, so there is no
+  // longer a chip to reveal it — muting is gated on the opt-in alone.
+  const chatterMuted = muteAgentChatter;
   const openComments = comments
     .filter((c) => !c.resolvedAt)
-    .filter((c) => matchesFilter(c, filter))
     .filter((c) => !(chatterMuted && isAgentChatter(c)));
   const resolvedComments = comments
     .filter((c) => c.resolvedAt)
-    .filter((c) => matchesFilter(c, filter))
     .filter((c) => !(chatterMuted && isAgentChatter(c)));
   const hiddenChatterCount = chatterMuted
     ? comments.filter((c) => !c.resolvedAt && isAgentChatter(c)).length
@@ -192,25 +123,16 @@ export function CommentTray({ targetType, targetId, comments, onCommentsChange, 
 
   return (
     <div data-testid="comment-tray" className="flex flex-col">
-      {comments.some((c) => !c.resolvedAt) && (
-        <CommentFilterChips active={filter} onChange={setFilter} counts={counts} />
-      )}
-
-      {/* spec-164 dec-6: discoverability line for muted agent chatter — the
-          count badge upstream already includes it; this names where it went. */}
+      {/* spec-164 dec-6: discoverability line for muted agent chatter — names
+          the hidden count. (spec-185 removed the chip-based reveal.) */}
       {hiddenChatterCount > 0 && (
         <p data-testid="comment-chatter-note" className="text-[11px] text-muted mb-2">
-          {hiddenChatterCount} agent update{hiddenChatterCount === 1 ? '' : 's'} hidden — use
-          the Plan / Progress chips to show {hiddenChatterCount === 1 ? 'it' : 'them'}.
+          {hiddenChatterCount} agent update{hiddenChatterCount === 1 ? '' : 's'} hidden.
         </p>
       )}
 
       {/* Comment list */}
       <div className="space-y-3">
-        {openComments.length === 0 && filter !== 'all' && (
-          <p className="text-xs text-muted">No {commentTypeLabel(filter).toLowerCase()} comments.</p>
-        )}
-
         {openComments.map((comment) => (
           <div key={comment.id} data-testid="comment-item" data-comment-id={comment.id}>
             <CommentBubble

--- a/packages/ui/src/pages/DocDocument.tsx
+++ b/packages/ui/src/pages/DocDocument.tsx
@@ -15,7 +15,7 @@ import {
   type AcWithVerification,
   type DocAssigneeView,
 } from '../api/client';
-import type { Comment, CommentType, DocWithGraph, Issue, SpecStatus, Tag } from '../api/types';
+import type { Comment, DocWithGraph, Issue, SpecStatus, Tag } from '../api/types';
 import { TagPicker } from '../components/TagPicker';
 import { Spinner } from '../components/Spinner';
 import { SectionCard } from '../components/SectionCard';
@@ -152,10 +152,6 @@ export function DocDocument() {
   const [moveOpen, setMoveOpen] = useState(false);
   const [showDownloadDialog, setShowDownloadDialog] = useState(false);
   const [showInitPromptDialog, setShowInitPromptDialog] = useState(false);
-  // t-19 W3.3: chip filter lifted from AllComments. Driving it from here lets us
-  // pass `?type=` through to fetchDocComments (server-side filter) instead of
-  // doing a client-side pass after the fact. `null` = "All".
-  const [commentTypeFilter, setCommentTypeFilter] = useState<CommentType | null>(null);
   // spec-100: collapse the comment gutters doc-wide (leaving only inline bubbles).
   const [commentsCollapsed, setCommentsCollapsed] = useState(false);
 
@@ -209,7 +205,6 @@ export function DocDocument() {
   useEffect(() => {
     if (!id) return;
 
-    const types = commentTypeFilter ? [commentTypeFilter] : undefined;
     fetchDoc(id)
       .then((d) => {
         // Per doc-30 dec-4 (post-b-105 rename): typed top-level routes. If the
@@ -232,7 +227,7 @@ export function DocDocument() {
           return;
         }
         setDoc(d);
-        fetchDocComments(d.id, types).then(applyComments).catch(console.error);
+        fetchDocComments(d.id).then(applyComments).catch(console.error);
       })
       .catch((err) => {
         if (err instanceof NotFoundError) {
@@ -247,7 +242,7 @@ export function DocDocument() {
     // don't want to re-fetch on that change. `id` already triggers re-fetch
     // when the route param changes.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [id, applyComments, commentTypeFilter, navigate]);
+  }, [id, applyComments, navigate]);
 
   // spec-159 t-6: pull the Spec's ACs / issues / assignees alongside the doc.
   // These feed the transition-sentence counts and the done report; they refresh
@@ -386,13 +381,12 @@ export function DocDocument() {
 
   const reloadDoc = useCallback(() => {
     if (!id) return;
-    const types = commentTypeFilter ? [commentTypeFilter] : undefined;
     fetchDoc(id).then((d) => {
       setDoc(d);
-      fetchDocComments(d.id, types).then(applyComments).catch(console.error);
+      fetchDocComments(d.id).then(applyComments).catch(console.error);
       reloadAux(d.id);
     }).catch(console.error);
-  }, [id, applyComments, commentTypeFilter, reloadAux]);
+  }, [id, applyComments, reloadAux]);
 
   // Refetch when any source (agent, MCP, REST, other clients) mutates this document
   useDocChangeStream(doc?.id ?? null, reloadDoc);
@@ -946,8 +940,6 @@ export function DocDocument() {
       commentsByTask={commentsByTask}
       onNavigateToSection={handleSelectSection}
       onTabChange={handleTabChange}
-      filter={commentTypeFilter}
-      onFilterChange={setCommentTypeFilter}
     />
   );
 

--- a/packages/ui/src/utils/commentStyles.ts
+++ b/packages/ui/src/utils/commentStyles.ts
@@ -110,22 +110,8 @@ export function commentTypeLabel(type: CommentType | undefined | null): string {
   return commentTypeStyle(type).label;
 }
 
-/**
- * Filter chips shown above CommentTray / AllComments.
- *
- * Per Section 7: All / plan / progress / question / issue / drift. Kept short so the chip
- * row fits the 30%-wide chat panel; the dropdown inside the composer offers the full list.
- */
-export const FILTER_CHIP_TYPES = [
-  'plan',
-  'progress',
-  'question',
-  'issue',
-  'drift',
-] as const satisfies ReadonlyArray<CommentType>;
-export type FilterChipType = (typeof FILTER_CHIP_TYPES)[number];
-
-// spec-153: the human composer no longer offers a comment-type picker — humans
-// write freeform `discussion` comments. The typed taxonomy below remains an
-// internal agent/system channel (drift / plan_revision / readiness_check / …) and
-// still drives the FILTER_CHIP_TYPES above plus per-type rendering of existing rows.
+// spec-153 / spec-185: the human composer no longer offers a comment-type picker
+// and the human-facing comment-type filter chips have been removed — humans write
+// and read freeform `discussion` comments. The typed taxonomy (STYLES above) remains
+// an internal agent/system channel (drift / plan_revision / readiness_check / …) and
+// drives only the per-type rendering pills of existing rows.


### PR DESCRIPTION
## What

Removes the comment-type **filter chip row** (`All · Plan · Progress · Question · Issue · Drift`) from both human render sites — the per-target `CommentTray` and the doc-wide `AllComments`. This is the read-side twin of **spec-153**'s composer-dropdown removal: after spec-153 humans author only freeform `discussion`, so the chip row was the last human-facing remnant of the taxonomy — mostly-empty (`· 0`) clutter on most specs.

Spec: https://memex.ai/mindset-prod/memex-building-itself/specs/spec-185 (dec-1 → Option A, dec-2 → supersede)

## Changes

- **CommentTray** — drop `CommentFilterChips` + `filter` state / `counts` memo / `matchesFilter`; comments render unfiltered by type. spec-164 dec-6 agent-chatter muting **preserved** (`chatterMuted` gated on `muteAgentChatter` alone); discoverability note trimmed of the dead "use the Plan/Progress chips" clause.
- **AllComments + DocDocument** — drop the chip row and the now-dead `commentTypeFilter` state + its `?type=` refetch plumbing. Authorship (System/People/Everyone) and state (Open/Resolved/All) filters untouched.
- **commentStyles** — retire `FILTER_CHIP_TYPES` / `FilterChipType`; reword the spec-153 note.
- **Tests** — add spec-185 `ac-6..ac-11` tagged tests; re-home spec-153/ac-4's surviving "badges untouched" clause onto the pill test; remove the chip-reveal (spec-164/ac-24) + chip-count (spec-164/ac-25) test proxies — **both ACs keep primary coverage elsewhere** (CommentTray muting tests + TaskPanel read-only surface). Extend e2e `journey-15` to assert the chip row is gone (std-28).

## Out of scope (unchanged)

Underlying `comment_type` taxonomy, the CHECK + `source` columns, per-type rendering pills (`commentTypeStyle`), and the Drift Inbox (`services/drift-inbox.ts`). Schema work is owned by **spec-113**.

## Cross-spec notes

- **spec-164/dec-6** — chip-based *reveal* retired; muting-by-default preserved. Comment left on dec-6 (c-12).
- **spec-153/ac-4** — its "filter chips still work" clause is superseded by design; other clauses hold. Comment left on spec-153 (c-2).

## Verification

- `tsc --noEmit` clean (UI); full UI vitest suite green (**117 files, 973 passed / 1 skipped**).
- AC emission (`ac-6..ac-11`) lands when the suite runs with `MEMEX_EMIT_KEY` (CI secret / manual run) — agent is hard-blocked from firing prod test-events.
- ⚠️ `make e2e-cold` (std-28) not run locally (needs the full cold-DB stack) — run before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)