### PR TITLE
spec-191: ⌘K jump by spec number — bare-number & short-handle resolution

### DIFF
--- a/packages/server/src/routes/search.integration.test.ts
+++ b/packages/server/src/routes/search.integration.test.ts
@@ -363,3 +363,44 @@ describe("spec-64 t-2 — @name returns that member's assigned Specs (ac-19)", (
     expect(body.assigned).toEqual([]);
   });
 });
+
+// spec-191: full canonical AC ref for the number-jump follow-on.
+const AC191 = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-191/acs/ac-${n}`;
+
+describe("spec-191 — number jump is additive to jumpTo; content tier unchanged (ac-6)", () => {
+  it("a numeric query surfaces the number jump in jumpTo while the content FTS lane is untouched", async () => {
+    tagAc(AC191(6));
+    // A dedicated Spec whose body carries no digit token, so the content FTS lane
+    // finds nothing for a bare number — proving the number jump is purely additive
+    // to the jumpTo lane and never altered searchMemex (FTS + pgvector + RRF).
+    const numSpec = await createDocDraft(
+      memexId,
+      "Number jump route target",
+      "Body without any digit token.",
+      "spec",
+    );
+    createdDocIds.push(numSpec.id);
+    const num = Number(numSpec.handle.split("-")[1]);
+
+    const res = await req(searchUrl({ q: String(num) }));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as SearchEnvelope;
+
+    // The number jump reaches the human ⌘K palette through the REST route.
+    const jumpTo = body.jumpTo as ContentHit[];
+    const jumpHit = jumpTo.find((h) => h.path.endsWith(`/specs/${numSpec.handle}`));
+    expect(jumpHit).toBeDefined();
+    expect(jumpHit?.kind).toBe("spec");
+    // Public shape preserved (no UUIDs leak through the jump lane).
+    expect(jumpHit?.id).toBeUndefined();
+
+    // The content tier is unchanged: a bare digit has no FTS lexeme match against
+    // the seeded text, so the Spec does NOT appear as a content hit — the number
+    // jump never touched the semantic core.
+    const inContent = body.content.find((h) =>
+      h.path.endsWith(`/specs/${numSpec.handle}`),
+    );
+    expect(inContent).toBeUndefined();
+  });
+});

--- a/packages/server/src/services/memex-search.integration.test.ts
+++ b/packages/server/src/services/memex-search.integration.test.ts
@@ -27,6 +27,7 @@ import {
 import { tagAc } from "@memex-ai-ac/vitest";
 import {
   searchMemex,
+  resolveJumpTo,
   formatSearchResults,
   type MemexSearchHit,
 } from "./memex-search.js";
@@ -989,5 +990,168 @@ describe("formatSearchResults — [current doc] tag (includeCurrentDoc opt-in)",
 
     const out = formatSearchResults("q", [hit], { currentDocId });
     expect(out).not.toContain("[current doc]");
+  });
+});
+
+// ── spec-191: number / short-handle jump in the ⌘K Jump-to lane ────────────────
+// resolveJumpTo gains a number-jump arm so typing a bare Spec number (or a short
+// `s-178`/`std178`/`doc178` form) navigates to the doc(s) carrying that number.
+// We use a FRESH makeTestMemex so the first Spec / Standard / Document each mint
+// number 1 (independent per-kind sequences sharing the memex-global number space),
+// giving us a deterministic `spec-1` / `std-1` / `doc-1` trio for the ambiguity
+// case. The arm reuses lookupByHandle, so it needs no embedding provider.
+const SPEC191_AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-191/acs/ac-${n}`;
+
+describe("resolveJumpTo — number / short-handle jump (spec-191)", () => {
+  let jumpMemexId: string;
+  let specId: string;
+  let stdId: string;
+  let docId: string;
+  let specHandle: string;
+  let stdHandle: string;
+  let docHandle: string;
+  let n: number; // the shared number — 1 in a fresh memex
+  const ours = (h: { id: string }) => [specId, stdId, docId].includes(h.id);
+
+  beforeAll(async () => {
+    jumpMemexId = await makeTestMemex("jump191");
+    const spec = await createDocDraft(jumpMemexId, "Number jump target", "Overview body.", "spec");
+    const std = await createStandard(jumpMemexId, {
+      title: "Number jump rule",
+      sections: [{ sectionType: "do", content: "A rule body." }],
+    });
+    const doc = await createDocDraft(jumpMemexId, "Number jump note", "Doc body.", "document");
+    specId = spec.id;
+    stdId = std.id;
+    docId = doc.id;
+    specHandle = spec.handle;
+    stdHandle = std.handle;
+    docHandle = doc.handle;
+    createdDocIds.push(specId, stdId, docId);
+    n = Number(specHandle.split("-")[1]);
+  });
+
+  it("a bare Spec number surfaces the Spec as a jumpTo row (ac-1)", async () => {
+    tagAc(SPEC191_AC(1));
+    const hits = await resolveJumpTo(jumpMemexId, String(n));
+    const specHit = hits.find((h) => h.id === specId);
+    expect(specHit).toBeDefined();
+    expect(specHit?.kind).toBe("spec");
+    expect(specHit?.path).toContain(`/specs/${specHandle}`);
+  });
+
+  it("a bare number matching all three kinds returns rows ordered spec→std→doc with scores in (0.5,1) (ac-2, ac-7)", async () => {
+    tagAc(SPEC191_AC(2));
+    tagAc(SPEC191_AC(7));
+    // In this fresh memex the three docs share the number (independent sequences
+    // each start at 1) — assert that precondition explicitly.
+    expect(stdHandle).toBe(`std-${n}`);
+    expect(docHandle).toBe(`doc-${n}`);
+
+    const hits = await resolveJumpTo(jumpMemexId, String(n));
+    // A bare number doesn't match HANDLE_REGEX (no exact-handle hit) and no Spec
+    // title contains the digit (no title-substring rows), so our three docs are
+    // the number-jump rows. Filter to them to stay robust to incidental rows.
+    const rows = hits.filter(ours);
+    expect(rows.map((h) => h.id)).toEqual([specId, stdId, docId]);
+    expect(rows.map((h) => h.kind)).toEqual(["spec", "standard", "document"]);
+    // Each ranks below an exact full-handle hit (1) and above the title tier (0.5),
+    // and strictly descending so the spec→std→doc order is stable.
+    for (const h of rows) {
+      expect(h.score).toBeGreaterThan(0.5);
+      expect(h.score).toBeLessThan(1);
+    }
+    expect(rows[0].score).toBeGreaterThan(rows[1].score);
+    expect(rows[1].score).toBeGreaterThan(rows[2].score);
+  });
+
+  it("a short/explicit prefix scopes the jump to one kind (ac-3, ac-8)", async () => {
+    tagAc(SPEC191_AC(3));
+    tagAc(SPEC191_AC(8));
+    // s / s- / spec / spec- + number → the Spec only.
+    for (const q of [`s${n}`, `s-${n}`, `spec${n}`, `spec-${n}`]) {
+      const rows = (await resolveJumpTo(jumpMemexId, q)).filter(ours);
+      expect(rows).toHaveLength(1);
+      expect(rows[0].id).toBe(specId);
+      expect(rows[0].kind).toBe("spec");
+    }
+    // std + number → the Standard only (longest-first alternation, not the s-branch).
+    {
+      const rows = (await resolveJumpTo(jumpMemexId, `std${n}`)).filter(ours);
+      expect(rows).toHaveLength(1);
+      expect(rows[0].id).toBe(stdId);
+      expect(rows[0].kind).toBe("standard");
+    }
+    // doc + number → the Document only.
+    {
+      const rows = (await resolveJumpTo(jumpMemexId, `doc${n}`)).filter(ours);
+      expect(rows).toHaveLength(1);
+      expect(rows[0].id).toBe(docId);
+      expect(rows[0].kind).toBe("document");
+    }
+  });
+
+  it("a number matching no document produces no fabricated jumpTo row (ac-4)", async () => {
+    tagAc(SPEC191_AC(4));
+    const hits = await resolveJumpTo(jumpMemexId, "999999");
+    // No doc carries 999999 across any kind, and no Spec title contains it — the
+    // query falls through with an empty jump lane, no fabricated row.
+    expect(hits.filter(ours)).toHaveLength(0);
+  });
+
+  it("honours Jump-to visibility: archived and demo docs excluded, drafts included (ac-5)", async () => {
+    tagAc(SPEC191_AC(5));
+    const visMemex = await makeTestMemex("jumpvis191");
+    const draftSpec = await createDocDraft(visMemex, "Draft target", "body", "spec");
+    const archivedSpec = await createDocDraft(visMemex, "Archived target", "body", "spec");
+    await db.execute(sql`UPDATE documents SET archived_at = now() WHERE id = ${archivedSpec.id}`);
+    const demoSpec = await createDocDraft(visMemex, "Demo target", "body", "spec", undefined, {
+      isDemo: true,
+    });
+    createdDocIds.push(draftSpec.id, archivedSpec.id, demoSpec.id);
+
+    const numOf = (handle: string) => Number(handle.split("-")[1]);
+
+    // A freshly created Spec is status 'draft' — drafts are eligible (no status filter).
+    const draftHits = await resolveJumpTo(visMemex, String(numOf(draftSpec.handle)));
+    expect(draftHits.find((h) => h.id === draftSpec.id)).toBeDefined();
+    expect(draftHits.find((h) => h.id === draftSpec.id)?.status).toBe("draft");
+
+    // Archived excluded (lookupByHandle filters archived_at IS NULL).
+    const archivedHits = await resolveJumpTo(visMemex, String(numOf(archivedSpec.handle)));
+    expect(archivedHits.find((h) => h.id === archivedSpec.id)).toBeUndefined();
+
+    // Demo excluded (lookupByHandle filters is_demo IS NOT TRUE — spec-178 dec-11).
+    const demoHits = await resolveJumpTo(visMemex, String(numOf(demoSpec.handle)));
+    expect(demoHits.find((h) => h.id === demoSpec.id)).toBeUndefined();
+  });
+
+  it("does not collide with the exact-handle or @name paths (ac-9)", async () => {
+    tagAc(SPEC191_AC(9));
+    // A full handle is resolved by the exact-handle arm (score 1) and deduped — the
+    // number arm sees it in seenDocIds and does NOT add a second row at 0.9.
+    const handleHits = await resolveJumpTo(jumpMemexId, specHandle); // e.g. "spec-1"
+    const specRows = handleHits.filter((h) => h.id === specId);
+    expect(specRows).toHaveLength(1);
+    expect(specRows[0].score).toBe(1);
+
+    // An @name assignee query carries no digit in the numeric position, so the
+    // number grammar never matches and contributes no number row.
+    const atHits = await resolveJumpTo(jumpMemexId, "@dev");
+    expect(atHits.filter(ours)).toHaveLength(0);
+  });
+
+  it("searchMemex (the agent core) does NOT short-circuit a bare number to a handle hit (ac-10)", async () => {
+    tagAc(SPEC191_AC(10));
+    // The number-jump arm lives ONLY in resolveJumpTo (dec-3). HANDLE_REGEX still
+    // matches only full `kind-N` handles, so a bare number must not short-circuit
+    // searchMemex to spec-N. With vector disabled, a bare digit has no FTS lexeme
+    // match against our text → no handle hit for the Spec.
+    const hits = await searchMemex(jumpMemexId, String(n), { disableVector: true });
+    const handleHit = hits.find(
+      (h) => h.id === specId && h.strategies.includes("handle"),
+    );
+    expect(handleHit).toBeUndefined();
   });
 });

--- a/packages/server/src/services/memex-search.ts
+++ b/packages/server/src/services/memex-search.ts
@@ -59,6 +59,27 @@ import { listSpecsAssignedToUser } from "./doc-assignees.js";
 
 const HANDLE_REGEX = /^(spec|std|doc)-\d+$/i;
 
+// spec-191: the number-jump grammar for the ⌘K Jump-to lane (dec-2). An optional
+// type token + optional single `-`/space separator + a required integer, anchored
+// to the whole query, case-insensitive. The token+separator form ONE optional
+// group, so a lone leading separator (e.g. `-178`) does NOT parse as a bare number.
+// The alternation is ordered longest-first (`spec|std|doc|s`) so `std178` resolves
+// the Standard, and only a lone leading `s` (`s178`/`s-178`) takes the single-letter
+// Spec short form (std-1's `s-N` vocabulary). A bare integer (no token) fans out to
+// all three memex-global kinds (dec-1); a token scopes to one. `@name` assignee
+// queries never match — they carry no digit in this position. Capture groups:
+// [1] = optional type token, [2] = the integer.
+const NUMBER_JUMP_REGEX = /^(?:(spec|std|doc|s)[\s-]?)?(\d+)$/i;
+
+// Number-jump rows rank below an exact full-handle hit (score 1) and above the
+// title-substring rows (0.5); the descending per-kind scores also keep the
+// spec→std→doc order (dec-1) stable regardless of how the parallel lookups resolve.
+const NUMBER_JUMP_SCORE: Record<"spec" | "std" | "doc", number> = {
+  spec: 0.9,
+  std: 0.8,
+  doc: 0.7,
+};
+
 // Reciprocal-rank-fusion constant. 60 is the canonical default from the
 // original Cormack/Clarke 2009 paper. Lower k weights top ranks more heavily,
 // higher k flattens the curve. Keep at 60 unless we have measurements that
@@ -532,6 +553,47 @@ export async function resolveJumpTo(
       hits.push(direct);
       seenDocIds.add(direct.id);
     }
+  }
+
+  // 1b. Number / short-handle jump (spec-191). A bare integer — or a kind-scoped
+  //     short/long form — resolves to the doc(s) carrying that number across the
+  //     three memex-global kinds (spec-N / std-N / doc-N). It reuses the SAME
+  //     lookupByHandle the exact-handle arm uses, so the number jump and the
+  //     full-handle jump always agree on what a handle points at — no new SQL
+  //     pattern, just indexed equality lookups. A bare number fans out to all
+  //     three kinds, specs first (dec-1); a prefix scopes to one (s/spec → Spec,
+  //     std → Standard, doc → Document — dec-2). The semantic core (searchMemex)
+  //     is deliberately NOT taught numbers (dec-3): this arm is UI-only. A full
+  //     handle like `spec-178` is already resolved by the exact-handle arm above
+  //     and deduped here via seenDocIds, so it is never listed twice; visibility
+  //     (archived + is_demo excluded, drafts included) is inherited from
+  //     lookupByHandle unchanged.
+  const numberMatch = NUMBER_JUMP_REGEX.exec(trimmed);
+  if (numberMatch) {
+    const token = numberMatch[1]?.toLowerCase();
+    const n = Number.parseInt(numberMatch[2], 10);
+    // token → ordered candidate kinds. No token → all three, specs first (dec-1).
+    // `s` is the single-letter short form for a Spec (std-1's `s-N` vocabulary).
+    const kinds: ReadonlyArray<"spec" | "std" | "doc"> =
+      token === undefined
+        ? ["spec", "std", "doc"]
+        : token === "std"
+          ? ["std"]
+          : token === "doc"
+            ? ["doc"]
+            : ["spec"]; // "s" | "spec"
+    // Resolve the (≤3) candidate handles in parallel, then push in kind order so
+    // the spec→std→doc ranking is deterministic regardless of resolution timing.
+    const resolved = await Promise.all(
+      kinds.map((kind) => lookupByHandle(memexId, slugs, `${kind}-${n}`, false)),
+    );
+    kinds.forEach((kind, i) => {
+      const hit = resolved[i];
+      if (hit && !seenDocIds.has(hit.id)) {
+        seenDocIds.add(hit.id);
+        hits.push({ ...hit, score: NUMBER_JUMP_SCORE[kind] });
+      }
+    });
   }
 
   // 2. Spec title-substring (ac-18) — docType='spec' only ("Spec title"),

--- a/packages/ui/e2e/journey-18-global-search.spec.ts
+++ b/packages/ui/e2e/journey-18-global-search.spec.ts
@@ -25,6 +25,11 @@ import {
 //   ac-9   typing a Spec title surfaces a result row with a kind badge.
 //   ac-10  ArrowDown moves the roving selection, Enter navigates to the hit.
 //   ac-8   Esc closes the dialog AND restores focus to the prior element.
+//
+// spec-191 extends this journey: typing the bare Spec NUMBER (the new number-jump
+// arm in resolveJumpTo) now surfaces the Spec under "Jump to" and navigates to it
+// — the real-browser proof that a bare number reaches the lane (spec-191 ac-1
+// through the human ⌘K surface; std-28 PR-gate journey).
 
 // A title unlikely to collide with anything already in the local dev memex, so
 // the query resolves to exactly our seeded Spec.
@@ -146,5 +151,52 @@ test.describe("Journey 18 — global ⌘K search palette", () => {
     await expect(reopened).not.toBeVisible();
     // ac-8: focus is restored to the element that was focused before opening.
     await expect(backLink).toBeFocused();
+  });
+
+  // spec-191: the bare-number jump. The reporter (Barrie) typed a Spec number into
+  // ⌘K and got nothing; this proves it now navigates. We type just the seeded
+  // Spec's number (parsed from its server-minted `spec-N` handle) and assert it
+  // surfaces under "Jump to" with the right path, then clicking it navigates.
+  // Presence-based (not exclusive) so demo specs / other same-numbered docs in the
+  // dev memex can't make it flaky.
+  test("typing the bare Spec number surfaces it under 'Jump to' and navigates (spec-191 ac-1)", async ({
+    page,
+  }) => {
+    await page.goto(bareUrl("/"));
+    await expect(page.getByRole("heading", { name: "Specs" })).toBeVisible({
+      timeout: 15_000,
+    });
+
+    await page.keyboard.press(HOTKEY);
+    const dialog = page.getByRole("dialog", { name: "Search this memex" });
+    await expect(dialog).toBeVisible();
+
+    // The number alone — no `spec-` prefix. This is the path that did nothing
+    // before spec-191 (it fell through to the content FTS tier, which matches body
+    // text, not handles).
+    const specNumber = specHandle.split("-")[1];
+    await page.getByPlaceholder(/Search specs/i).fill(specNumber);
+
+    const specRow = dialog
+      .locator('[data-testid="search-result"][data-kind="spec"]')
+      .filter({ hasText: SPEC_TITLE })
+      .first();
+    await expect(specRow).toBeVisible({ timeout: 10_000 });
+    // It lands in the Jump-to tier (the number arm sits there, above content).
+    await expect(dialog.getByText("Jump to", { exact: true })).toBeVisible();
+    await expect(specRow).toHaveAttribute(
+      "data-path",
+      `${nsSlug}/${mxSlug}/specs/${specHandle}`,
+    );
+
+    // Selecting the number-jump row navigates to the Spec detail page.
+    await specRow.click();
+    await expect(page).toHaveURL(
+      new RegExp(`/${nsSlug}/${mxSlug}/specs/${specHandle}$`),
+    );
+    await expect(dialog).not.toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: SPEC_TITLE, level: 1 }),
+    ).toBeVisible({ timeout: 15_000 });
   });
 });


### PR DESCRIPTION
## What

Adds a **number-jump arm** to `resolveJumpTo` (the human ⌘K *Jump to* lane) so typing a bare Spec number — the most natural way to navigate to a Spec you know by number — actually takes you there. Promoted from **spec-64 / issue-4** (reported by Barrie on INT).

Before: `resolveJumpTo` only resolved a *full handle* (`HANDLE_REGEX = /^(spec|std|doc)-\d+$/i`). A bare `178` fell through to the FTS/vector **content** tier (which matches section body text, not handles), so it never navigated.

## Behaviour

- **Bare integer** (`178`) → resolves the doc(s) carrying that number across the three memex-global kinds (`spec-N` / `std-N` / `doc-N`), surfaced as Jump-to rows ranked **Spec → Standard → Document** (dec-1).
- **Prefix scopes to one kind** (dec-2): `s`/`spec` → Spec, `std` → Standard, `doc` → Document. Accepts `s-178`, `s178`, `spec178`, `spec-178`, `std178`, `doc 178`, etc. (optional single `-`/space separator, case-insensitive; alternation ordered longest-first so `std178` → Standard, not the `s`→Spec branch).
- **Reuses `lookupByHandle`** — indexed equality lookups, **no new SQL pattern, no schema, no embeddings**. Visibility (archived + `is_demo` excluded, drafts included) is inherited unchanged.
- **Ranking**: number rows score in `(0.5, 1)` — below an exact full-handle hit (`1`), above title-substring rows (`0.5`). A full handle already resolved by the exact-handle arm is **deduped** (never double-listed).

## Scope (decisions)

- **dec-1** (resolved): ambiguity → show all matching kinds, specs first.
- **dec-2** (resolved): full grammar (bare + `s`/`spec`/`std`/`doc` prefix forms).
- **dec-3** (resolved): **UI-only** — `searchMemex`'s MCP/agent handle short-circuit is left untouched (it returns one hit, can't represent an ambiguous bare number; agents already pass full handles; std-16/spec-36 dec-8 keep MCP=agent, REST=human). The semantic core (FTS + pgvector + RRF + relevance floor) is unchanged (ac-6).

## Tests (AC-tagged)

- `services/memex-search.integration.test.ts` — ac-1, ac-2, ac-3, ac-4, ac-5, ac-7, ac-8, ac-9, ac-10.
- `routes/search.integration.test.ts` — ac-6 (number jump is additive to `jumpTo`; content tier untouched).
- `e2e/journey-18-global-search.spec.ts` — bare-number jump through the real ⌘K palette (std-28).

Full server suite green (**3342 passed**); typecheck clean (the only `tsc` error is the pre-existing `discord-webhook.test.ts` one on develop, untouched here). AC events emit on this PR's server CI run.

Spec: https://memex.ai/mindset-prod/memex-building-itself/specs/spec-191

🤖 Generated with [Claude Code](https://claude.com/claude-code)