### PR TITLE
spec-189: traffic-driven phase advancement + auto-assignment from agent tool calls

### DIFF
--- a/packages/server/src/__regression__/tools-coverage.regression.test.ts
+++ b/packages/server/src/__regression__/tools-coverage.regression.test.ts
@@ -268,3 +268,90 @@ describe("regression: tool manifest ↔ MCP catalogue parity (b-67 t-4)", () => 
     });
   });
 });
+
+// ──────────────────────────────────────────────────────────────────────────
+// Traffic-class classification (spec-189 dec-4 / ac-9)
+//
+// Every manifest entry carries `trafficClass` (required — omitting it on a
+// new tool is a type error). The transition + auto-assignment services derive
+// their behaviour EXCLUSIVELY from this classification; there is no standalone
+// tool-name map anywhere else. The exact class membership is pinned below so
+// reclassifying a tool is a deliberate, reviewed edit — not drift.
+// ──────────────────────────────────────────────────────────────────────────
+
+describe("regression: manifest traffic-class classification (spec-189 dec-4)", () => {
+  const SPEC_189 = "mindset-prod/memex-building-itself/specs/spec-189";
+
+  it("every entry carries a valid trafficClass and read-only tools are never classified", () => {
+    tagAc(`${SPEC_189}/acs/ac-9`);
+    const valid = new Set(["specify", "build", "verify", null]);
+    for (const e of toolManifest) {
+      expect(valid.has(e.trafficClass), `${e.name} has invalid trafficClass ${String(e.trafficClass)}`).toBe(true);
+      if (e.readOnlyHint) {
+        // Query-class traffic never moves a Spec — a read-only tool with a
+        // traffic class would contradict the matrix's query column.
+        expect(e.trafficClass, `${e.name} is read-only but classified '${String(e.trafficClass)}'`).toBeNull();
+        expect(e.autoAssignExempt, `${e.name} is read-only — autoAssignExempt is meaningless on it`).toBeUndefined();
+      }
+    }
+  });
+
+  it("the specify-class and build-class memberships match dec-1 exactly", () => {
+    tagAc(`${SPEC_189}/acs/ac-9`);
+    const byClass = (cls: string) =>
+      toolManifest.filter((e) => e.trafficClass === cls).map((e) => e.name).sort();
+
+    // dec-1: decision authoring/resolution + AC authoring = specify-class.
+    expect(byClass("specify")).toEqual([
+      "approve_candidate",
+      "create_ac",
+      "create_decision",
+      "delete_ac",
+      "delete_decision",
+      "link_ac_to_decision",
+      "reject_candidate",
+      "resolve_decision",
+      "update_ac",
+      "update_decision",
+    ]);
+
+    // dec-1: task lifecycle + issue registration/lifecycle = build-class.
+    expect(byClass("build")).toEqual([
+      "convert_issue_to_task",
+      "create_task",
+      "delete_task",
+      "kick_task_to_issue",
+      "register_issue",
+      "resolve_issue",
+      "update_issue",
+      "update_task",
+    ]);
+
+    // No MCP tool is verify-class today: AC verification arrives via
+    // POST /api/test-events, which the server wires to verify-class directly.
+    expect(byClass("verify")).toEqual([]);
+  });
+
+  it("auto-assignment exemptions are exactly the assignment/role managers + notify-only tools", () => {
+    tagAc(`${SPEC_189}/acs/ac-9`);
+    const exempt = toolManifest
+      .filter((e) => e.autoAssignExempt === true)
+      .map((e) => e.name)
+      .sort();
+    // Tools whose JOB is managing the assignment/role axis must not be fought
+    // by auto-assignment (unassign_spec(self) would instantly undo itself);
+    // the messaging tools mutate nothing on the Spec.
+    expect(exempt).toEqual([
+      "assign_spec",
+      "memex__send_discord_message",
+      "memex__send_slack_message",
+      "set_spec_role",
+      "unassign_spec",
+    ]);
+    for (const e of toolManifest) {
+      if (e.autoAssignExempt) {
+        expect(e.readOnlyHint, `${e.name}: exemption only applies to mutating tools`).toBe(false);
+      }
+    }
+  });
+});

--- a/packages/server/src/__smoke__/authed.smoke.test.ts
+++ b/packages/server/src/__smoke__/authed.smoke.test.ts
@@ -380,5 +380,56 @@ describe.skipIf(!SMOKE_MCP_TOKEN)(
       expect(docText).not.toContain(marker);
       expect(docText).not.toContain("Smoke Lens Renamed");
     });
+
+    // ── spec-189: traffic-driven phase advancement on the LIVE /mcp surface.
+    //
+    //    Specify-class traffic (create_decision) at a freshly-created draft
+    //    Spec must auto-advance it draft → specify; build-class traffic
+    //    (create_task) must then advance it specify → build. This is the
+    //    deployed-contract probe for the runToolWithSpecTraffic seam — the
+    //    exact class of /mcp wiring that std-17's first live run proved local
+    //    suites can miss. The full matrix is locked by unit + integration
+    //    tests; the smoke probe asserts the seam is ALIVE on the deployed
+    //    image, not the matrix itself.
+    it("spec-189: agent traffic auto-advances a draft Spec (draft → specify → build)", async () => {
+      const created = await callMcpTool("create_doc", {
+        memex: SMOKE_NAMESPACE,
+        title: `[smoke] spec-189 traffic probe ${new Date().toISOString()}`,
+        purpose: "Throwaway probe — traffic-driven phase advancement.",
+      });
+      expect(created.status).toBe(200);
+      expect(created.body.result?.isError).toBeFalsy();
+      const specRef = parseRef(mcpTextPayload(created.body));
+      expect(specRef, "create_doc should return a spec ref").toBeTruthy();
+
+      // Specify-class traffic: decision authoring.
+      const dec = await callMcpTool("create_decision", {
+        ref: specRef!,
+        title: "[smoke] spec-189 probe decision",
+      });
+      expect(dec.status).toBe(200);
+      expect(dec.body.result?.isError).toBeFalsy();
+
+      let docText = mcpTextPayload(
+        (await callMcpTool("get_doc", { ref: specRef! })).body,
+      );
+      expect(docText).toMatch(/status:\s*specify|\[SPECIFY\]|phase:\s*specify/i);
+
+      // Build-class traffic: task creation (also sweeps via createdTaskRefs).
+      const task = await callMcpTool("create_task", {
+        ref: specRef!,
+        title: "[smoke] spec-189 probe task",
+        description: "Throwaway — drives specify → build.",
+      });
+      expect(task.status).toBe(200);
+      expect(task.body.result?.isError).toBeFalsy();
+      const taskRef = parseRef(mcpTextPayload(task.body));
+      if (taskRef) createdTaskRefs.push(taskRef);
+
+      docText = mcpTextPayload(
+        (await callMcpTool("get_doc", { ref: specRef! })).body,
+      );
+      expect(docText).toMatch(/status:\s*build|\[BUILD\]|phase:\s*build/i);
+    });
   },
 );

--- a/packages/server/src/agent/tools.ts
+++ b/packages/server/src/agent/tools.ts
@@ -39,6 +39,7 @@ import {
 import { parseRef } from "../services/refs.js";
 import { resolveRef as resolveCanonicalRef } from "../services/resolver.js";
 import { emitInAppAgentActivity } from "../services/conversations.js";
+import { runToolWithSpecTraffic } from "../services/spec-traffic.js";
 import { deriveActivity } from "./derive-activity.js";
 
 // ══════════════════════════════════════
@@ -615,7 +616,13 @@ export async function executeServerTool(
     // No-op — emission must never affect the agent turn.
   }
 
-  return spec.handler(input, ctx);
+  // spec-189: handler execution goes through the channel-neutral traffic
+  // seam — after a SUCCESSFUL call, the Spec the call resolved to may
+  // auto-advance phase and auto-assign the caller (see
+  // services/spec-traffic.ts). Identical wiring on the MCP surface
+  // (mcp/tools.ts) per dec-5; ctx.channel ('in_app_agent' here) is what
+  // distinguishes the surfaces.
+  return runToolWithSpecTraffic(spec, input, ctx);
 }
 
 // Avoid unused-import warning — `and` is kept around because the lookup

--- a/packages/server/src/mcp/phase-descriptions.test.ts
+++ b/packages/server/src/mcp/phase-descriptions.test.ts
@@ -222,13 +222,17 @@ describe("b-68 t-7 ac-23: mcp-descriptions.md files are retired", () => {
 
   it("toolManifest entries carry no phase-conditional summary / args content (pinning regression — manifest is phase-agnostic)", () => {
     tagAc("mindset-prod/memex-building-itself/specs/spec-68/acs/ac-23");
-    // ToolManifestEntry shape carries `{name, summary, args, group, readOnlyHint}`.
-    // None of those fields branch on Spec phase — they're authored once and
-    // shipped to every surface uniformly. This test pins that contract so a
-    // future change (e.g. adding a `summaryByPhase`) is flagged as drift
-    // from b-68 dec-6 ("one model, many projections" — phase-specific tool
-    // descriptions arrive as scaffold-data GuidanceBlocks, NOT manifest
-    // entries). (spec-156 ac-25 added the phase-agnostic `readOnlyHint`.)
+    // ToolManifestEntry shape carries `{name, summary, args, group,
+    // readOnlyHint, trafficClass, autoAssignExempt?}`. None of those fields
+    // branch on Spec phase — they're authored once and shipped to every
+    // surface uniformly. This test pins that contract so a future change
+    // (e.g. adding a `summaryByPhase`) is flagged as drift from b-68 dec-6
+    // ("one model, many projections" — phase-specific tool descriptions
+    // arrive as scaffold-data GuidanceBlocks, NOT manifest entries).
+    // (spec-156 ac-25 added the phase-agnostic `readOnlyHint`; spec-189
+    // dec-4 added the equally phase-agnostic `trafficClass` +
+    // `autoAssignExempt` — the CLASSIFICATION is static per tool; the
+    // phase-dependent behaviour lives in nextPhaseForTraffic, not here.)
     for (const entry of toolManifest) {
       expect(entry).toEqual({
         name: expect.any(String),
@@ -236,6 +240,13 @@ describe("b-68 t-7 ac-23: mcp-descriptions.md files are retired", () => {
         args: expect.any(String),
         group: expect.any(String),
         readOnlyHint: expect.any(Boolean),
+        trafficClass:
+          entry.trafficClass === null
+            ? null
+            : expect.stringMatching(/^(specify|build|verify)$/),
+        ...(entry.autoAssignExempt !== undefined
+          ? { autoAssignExempt: expect.any(Boolean) }
+          : {}),
       });
     }
   });

--- a/packages/server/src/mcp/spec-tools.integration.test.ts
+++ b/packages/server/src/mcp/spec-tools.integration.test.ts
@@ -295,7 +295,10 @@ describe("Spec MCP tools (post-doc-14, b-105)", () => {
     const result = await callTool(actor.user.id, "get_doc", { ref });
     expect(result.isError).toBeFalsy();
     const text = result.content[0].text;
-    expect(text).toContain("# StatusOne [DRAFT]");
+    // spec-189: the decision + task traffic above auto-advanced the draft
+    // Spec (draft → specify on create_decision, specify → build on
+    // create_task) — the doc state now reports the traffic-driven phase.
+    expect(text).toContain("# StatusOne [BUILD]");
     // formatFullDocState now emits "## Decisions (1 total: …)" / "## Tasks (1 total: …)".
     expect(text).toMatch(/Decisions \(1/);
     expect(text).toMatch(/Tasks \(1/);

--- a/packages/server/src/mcp/spec-traffic.integration.test.ts
+++ b/packages/server/src/mcp/spec-traffic.integration.test.ts
@@ -1,0 +1,412 @@
+// spec-189 t-4 — traffic-driven phase advancement + auto-assignment, exercised
+// end-to-end through the REAL tool surfaces against Postgres. Mirrors the
+// wiring idiom of spec-roles-tools.integration.test.ts: every case drives a
+// real registered tool (createMcpServer registry for channel 'mcp',
+// executeServerTool for channel 'in_app_agent') and asserts the resulting
+// document status, doc_assignees row, and doc_members editor row — never the
+// pure function alone (that matrix is locked in
+// packages/shared/src/spec-readiness.traffic.test.ts).
+//
+// ACs delivered here:
+//   ac-1  (scope) — a Spec worked through MCP alone is represented correctly:
+//          its phase follows the observed traffic with no web-UI involvement.
+//   ac-2  (scope) — the gated rules end-to-end: no verify→build regression,
+//          no traffic-driven entry to verify except from draft/done, done
+//          reopens per class.
+//   ac-5  (scope) — mutating calls assign + promote; query calls never do;
+//          multi-assignee, adds-only.
+//   ac-8  — transitions are unconditional (open decisions don't gate).
+//   ac-10 — channel parity: identical effects for mcp / in_app_agent;
+//          rest_ui never triggers.
+//   ac-11 — auto-assign also grants editor; manual assign_spec stays
+//          role-independent (spec-118 dec-3 preserved on the manual path).
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { eq, inArray } from "drizzle-orm";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { db } from "../db/connection.js";
+import {
+  decisions,
+  docAssignees,
+  docMembers,
+  documents,
+  issues,
+  memexes,
+  namespaces,
+  orgMemberships,
+  orgs,
+  tasks,
+  users,
+} from "../db/schema.js";
+import { createMcpServer } from "./tools.js";
+import { executeServerTool } from "../agent/tools.js";
+import { createDocDraft, updateDocStatus } from "../services/documents.js";
+import { listAssignees } from "../services/doc-assignees.js";
+import { resolveRole } from "../services/doc-members.js";
+import {
+  observeSpecTraffic,
+  observeTestEventTraffic,
+  type SpecTrafficEvent,
+} from "../services/spec-traffic.js";
+import { bus, type ChangeEvent } from "../services/bus.js";
+
+const SPEC = "mindset-prod/memex-building-itself/specs/spec-189";
+const AC = (n: number) => `${SPEC}/acs/ac-${n}`;
+
+const created = {
+  users: [] as string[],
+  memexes: [] as string[],
+  docs: [] as string[],
+};
+
+afterAll(async () => {
+  if (created.docs.length) {
+    await db.delete(issues).where(inArray(issues.docId, created.docs)).catch(() => {});
+    await db.delete(tasks).where(inArray(tasks.docId, created.docs)).catch(() => {});
+    await db.delete(decisions).where(inArray(decisions.docId, created.docs)).catch(() => {});
+    await db.delete(docAssignees).where(inArray(docAssignees.docId, created.docs)).catch(() => {});
+    await db.delete(docMembers).where(inArray(docMembers.docId, created.docs)).catch(() => {});
+    await db.delete(documents).where(inArray(documents.id, created.docs)).catch(() => {});
+  }
+  if (created.memexes.length) {
+    await db.delete(memexes).where(inArray(memexes.id, created.memexes)).catch(() => {});
+  }
+  if (created.users.length) {
+    await db.delete(users).where(inArray(users.id, created.users)).catch(() => {});
+  }
+});
+
+interface ToolResult {
+  isError?: boolean;
+  content: Array<{ type: string; text: string }>;
+}
+interface RegisteredToolLike {
+  handler: (args: Record<string, unknown>, extra: unknown) => Promise<ToolResult> | ToolResult;
+}
+
+// Channel 'mcp': through the real createMcpServer registry (the seam wraps
+// every registered handler — see mcp/tools.ts).
+async function callMcp(
+  userId: string,
+  name: string,
+  args: Record<string, unknown>,
+): Promise<ToolResult> {
+  const server = createMcpServer(userId);
+  const registry = (
+    server as unknown as { _registeredTools: Record<string, RegisteredToolLike> }
+  )._registeredTools;
+  const tool = registry[name];
+  if (!tool) throw new Error(`Tool not registered: ${name}`);
+  return await tool.handler(args, {} as unknown);
+}
+
+async function setupActor(prefix: string) {
+  const sub = `${prefix}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`
+    .toLowerCase()
+    .slice(0, 39);
+  const [owner] = await db
+    .insert(users)
+    .values({ email: `traffic-${sub}@memex.ai` } as typeof users.$inferInsert)
+    .returning();
+  created.users.push(owner.id);
+  const [ns] = await db
+    .insert(namespaces)
+    .values({ slug: sub, kind: "org" } as typeof namespaces.$inferInsert)
+    .returning();
+  const [org] = await db
+    .insert(orgs)
+    .values({ namespaceId: ns.id, name: `Traffic ${sub}` } as typeof orgs.$inferInsert)
+    .returning();
+  await db.update(namespaces).set({ ownerOrgId: org.id }).where(eq(namespaces.id, ns.id));
+  const [mx] = await db
+    .insert(memexes)
+    .values({ name: `Traffic ${sub}`, slug: "main", namespaceId: ns.id } as typeof memexes.$inferInsert)
+    .returning();
+  created.memexes.push(mx.id);
+  await db
+    .insert(orgMemberships)
+    .values({ userId: owner.id, orgId: org.id, role: "administrator" } as typeof orgMemberships.$inferInsert);
+
+  // A second org member: the MCP/in-app caller whose traffic we observe.
+  // Distinct from the creator so assignment/editor rows are unambiguous
+  // (createDocDraft seeds the CREATOR as editor).
+  const [member] = await db
+    .insert(users)
+    .values({ email: `traffic-member-${sub}@memex.ai` } as typeof users.$inferInsert)
+    .returning();
+  created.users.push(member.id);
+  await db
+    .insert(orgMemberships)
+    .values({ userId: member.id, orgId: org.id, role: "member" } as typeof orgMemberships.$inferInsert);
+
+  return { owner, member, slug: ns.slug, memexId: mx.id };
+}
+
+let actor: Awaited<ReturnType<typeof setupActor>>;
+
+beforeAll(async () => {
+  actor = await setupActor("traffic");
+});
+
+async function makeSpec(
+  title: string,
+  status?: string,
+): Promise<{ id: string; ref: string; handle: string }> {
+  const doc = await createDocDraft(
+    actor.memexId,
+    title,
+    "purpose",
+    "spec",
+    undefined,
+    undefined,
+    actor.owner.id,
+  );
+  created.docs.push(doc.id);
+  if (status && status !== "draft") {
+    await updateDocStatus(actor.memexId, doc.id, status);
+  }
+  return { id: doc.id, ref: `${actor.slug}/main/specs/${doc.handle}`, handle: doc.handle };
+}
+
+async function specStatus(id: string): Promise<string> {
+  const row = await db.query.documents.findFirst({ where: eq(documents.id, id) });
+  return row!.status;
+}
+
+async function assigneeIds(id: string): Promise<string[]> {
+  return (await listAssignees(actor.memexId, id)).map((a) => a.userId);
+}
+
+describe("spec-189: traffic-driven phase advancement through real MCP tool calls", () => {
+  it("draft + specify-class traffic (create_decision) → specify, with assignment + editor (ac-1, ac-5, ac-11)", async () => {
+    tagAc(AC(1));
+    tagAc(AC(5));
+    tagAc(AC(11));
+    const spec = await makeSpec("Draft to Specify");
+
+    const events: ChangeEvent[] = [];
+    const unsub = bus.subscribe(
+      { memexId: actor.memexId, entity: "document" },
+      (e) => events.push(e),
+    );
+    let res: ToolResult;
+    try {
+      res = await callMcp(actor.member.id, "create_decision", {
+        ref: spec.ref,
+        title: "Which storage engine?",
+      });
+    } finally {
+      unsub();
+    }
+    expect(res.isError).toBeFalsy();
+
+    // Phase advanced — the board now shows reality with zero web-UI touches.
+    expect(await specStatus(spec.id)).toBe("specify");
+    // The caller is assigned AND an editor (dec-6) — the creator's seeded
+    // editor row is separate; the member's rows are the auto ones.
+    expect(await assigneeIds(spec.id)).toContain(actor.member.id);
+    expect(await resolveRole(actor.memexId, spec.id, actor.member.id)).toBe("editor");
+    // std-8: the status flip emitted a payload-carrying status_changed event
+    // whose narrative attributes the AUTO move.
+    const statusChanged = events.find(
+      (e) => e.docId === spec.id && e.action === "status_changed",
+    );
+    expect(statusChanged).toBeDefined();
+    expect(statusChanged!.narrative).toContain("auto-advanced");
+    expect(statusChanged!.payload).toMatchObject({ from: "draft", to: "specify" });
+  });
+
+  it("draft + build-class traffic (register_issue) → build (ac-1, ac-7)", async () => {
+    tagAc(AC(1));
+    tagAc(AC(7));
+    const spec = await makeSpec("Draft to Build");
+    const res = await callMcp(actor.member.id, "register_issue", {
+      spec_ref: spec.ref,
+      title: "Crash on save",
+      body: "Repro: save twice.",
+      type: "bug",
+    });
+    expect(res.isError).toBeFalsy();
+    expect(await specStatus(spec.id)).toBe("build");
+    expect(await assigneeIds(spec.id)).toContain(actor.member.id);
+  });
+
+  it("draft + verify-class traffic (test_event arriving) → verify; done reopens to verify (ac-2, ac-7)", async () => {
+    tagAc(AC(2));
+    tagAc(AC(7));
+    // Verify-class has no MCP tool (dec-1): it arrives as CI test_events.
+    // observeTestEventTraffic is exactly what POST /api/test-events invokes
+    // after an accepted, non-hidden emission.
+    const fromDraft = await makeSpec("Draft to Verify");
+    await observeTestEventTraffic(
+      actor.memexId,
+      `${actor.slug}/main/specs/${fromDraft.handle}/acs/ac-1`,
+    );
+    expect(await specStatus(fromDraft.id)).toBe("verify");
+
+    const fromDone = await makeSpec("Done reopens to Verify", "done");
+    await observeTestEventTraffic(
+      actor.memexId,
+      `${actor.slug}/main/specs/${fromDone.handle}/acs/ac-1`,
+    );
+    expect(await specStatus(fromDone.id)).toBe("verify");
+  });
+
+  it("specify + build-class traffic (create_task) → build, even with open decisions (ac-7, ac-8)", async () => {
+    tagAc(AC(7));
+    tagAc(AC(8));
+    const spec = await makeSpec("Specify to Build", "specify");
+    // An OPEN decision would fail the assess_spec rubric — the transition is
+    // unconditional (dec-3): traffic reflects what's already happening.
+    const dec = await callMcp(actor.member.id, "create_decision", {
+      ref: spec.ref,
+      title: "Open and unresolved",
+    });
+    expect(dec.isError).toBeFalsy();
+    expect(await specStatus(spec.id)).toBe("specify"); // specify-class: stays
+
+    const res = await callMcp(actor.member.id, "create_task", {
+      ref: spec.ref,
+      title: "Implement the thing",
+      description: "Do it.",
+    });
+    expect(res.isError).toBeFalsy();
+    expect(await specStatus(spec.id)).toBe("build");
+  });
+
+  it("build + specify-class traffic stays in build; verify never regresses to build (ac-2)", async () => {
+    tagAc(AC(2));
+    const inBuild = await makeSpec("Build stays on specify traffic", "build");
+    const res1 = await callMcp(actor.member.id, "create_decision", {
+      ref: inBuild.ref,
+      title: "Mid-build decision",
+    });
+    expect(res1.isError).toBeFalsy();
+    expect(await specStatus(inBuild.id)).toBe("build");
+
+    const inVerify = await makeSpec("Verify never regresses", "verify");
+    const res2 = await callMcp(actor.member.id, "create_task", {
+      ref: inVerify.ref,
+      title: "Late task",
+      description: "Build-class traffic on a verify Spec.",
+    });
+    expect(res2.isError).toBeFalsy();
+    expect(await specStatus(inVerify.id)).toBe("verify");
+  });
+
+  it("done reopens to the traffic's phase: specify-class → specify, build-class → build (ac-2)", async () => {
+    tagAc(AC(2));
+    const toSpecify = await makeSpec("Done reopens to specify", "done");
+    const res1 = await callMcp(actor.member.id, "create_decision", {
+      ref: toSpecify.ref,
+      title: "Post-done decision",
+    });
+    expect(res1.isError).toBeFalsy();
+    expect(await specStatus(toSpecify.id)).toBe("specify");
+
+    const toBuild = await makeSpec("Done reopens to build", "done");
+    const res2 = await callMcp(actor.member.id, "register_issue", {
+      spec_ref: toBuild.ref,
+      title: "Bug found after close",
+      body: "It broke.",
+      type: "bug",
+    });
+    expect(res2.isError).toBeFalsy();
+    expect(await specStatus(toBuild.id)).toBe("build");
+  });
+
+  it("query-class traffic changes nothing and assigns nobody (ac-5)", async () => {
+    tagAc(AC(5));
+    const spec = await makeSpec("Query is inert");
+    const res = await callMcp(actor.member.id, "get_doc", { ref: spec.ref });
+    expect(res.isError).toBeFalsy();
+    expect(await specStatus(spec.id)).toBe("draft");
+    expect(await assigneeIds(spec.id)).not.toContain(actor.member.id);
+    expect(await resolveRole(actor.memexId, spec.id, actor.member.id)).toBe("reviewer");
+  });
+
+  it("channel parity: in_app_agent traffic produces identical effects; rest_ui never triggers (ac-10)", async () => {
+    tagAc(AC(10));
+    // in_app_agent: the React agent loop's executeServerTool — same seam.
+    const viaAgent = await makeSpec("In-app agent parity");
+    const text = await executeServerTool(
+      actor.memexId,
+      "create_decision",
+      { ref: viaAgent.ref, title: "Decision from the in-app agent" },
+      actor.member.id,
+    );
+    expect(text).toBeTruthy();
+    expect(await specStatus(viaAgent.id)).toBe("specify");
+    expect(await assigneeIds(viaAgent.id)).toContain(actor.member.id);
+    expect(await resolveRole(actor.memexId, viaAgent.id, actor.member.id)).toBe("editor");
+
+    // rest_ui: structurally excluded (REST routes never pass the seam), and
+    // the observer itself refuses the channel even if handed one.
+    const viaRest = await makeSpec("rest_ui is inert");
+    await observeSpecTraffic({
+      toolName: "create_decision",
+      channel: "rest_ui",
+      userId: actor.member.id,
+      memexId: actor.memexId,
+      docId: viaRest.id,
+    } as unknown as SpecTrafficEvent);
+    expect(await specStatus(viaRest.id)).toBe("draft");
+    expect(await assigneeIds(viaRest.id)).not.toContain(actor.member.id);
+  });
+
+  it("manual assignment tools are exempt: unassign_spec(self) sticks, assign_spec grants no editor row (ac-5, ac-11)", async () => {
+    tagAc(AC(5));
+    tagAc(AC(11));
+    const spec = await makeSpec("Exempt manual tools");
+
+    // Manual assign of the member by the owner: assignment lands, but the
+    // manual path stays role-independent (spec-118 dec-3) — no editor row —
+    // and the OWNER (the mutating caller) is not auto-assigned either.
+    const res1 = await callMcp(actor.owner.id, "assign_spec", {
+      ref: spec.ref,
+      user: actor.member.email,
+    });
+    expect(res1.isError).toBeFalsy();
+    expect(await assigneeIds(spec.id)).toContain(actor.member.id);
+    expect(await assigneeIds(spec.id)).not.toContain(actor.owner.id);
+    expect(await resolveRole(actor.memexId, spec.id, actor.member.id)).toBe("reviewer");
+
+    // unassign_spec(self) must not instantly undo itself via auto-assignment.
+    const res2 = await callMcp(actor.member.id, "unassign_spec", {
+      ref: spec.ref,
+      user: actor.member.email,
+    });
+    expect(res2.isError).toBeFalsy();
+    expect(await assigneeIds(spec.id)).not.toContain(actor.member.id);
+  });
+
+  it("auto-assignment is additive and idempotent: many assignees, repeat traffic adds nothing (ac-5)", async () => {
+    tagAc(AC(5));
+    const spec = await makeSpec("Multi-assignee");
+    await callMcp(actor.member.id, "create_decision", { ref: spec.ref, title: "One" });
+    await callMcp(actor.owner.id, "create_decision", { ref: spec.ref, title: "Two" });
+    await callMcp(actor.member.id, "create_decision", { ref: spec.ref, title: "Three" });
+    const ids = await assigneeIds(spec.id);
+    expect(ids).toContain(actor.member.id);
+    expect(ids).toContain(actor.owner.id);
+    expect(ids.filter((id) => id === actor.member.id)).toHaveLength(1);
+  });
+
+  it("paused Specs still assign but never auto-transition; hidden-style flags stay untouched", async () => {
+    const spec = await makeSpec("Paused stays put");
+    await db
+      .update(documents)
+      .set({ pausedAt: new Date() })
+      .where(eq(documents.id, spec.id));
+    const res = await callMcp(actor.member.id, "create_task", {
+      ref: spec.ref,
+      title: "Task at a paused Spec",
+      description: "Should assign, not move.",
+    });
+    expect(res.isError).toBeFalsy();
+    expect(await specStatus(spec.id)).toBe("draft");
+    expect(await assigneeIds(spec.id)).toContain(actor.member.id);
+    const row = await db.query.documents.findFirst({ where: eq(documents.id, spec.id) });
+    expect(row!.pausedAt).not.toBeNull();
+  });
+});

--- a/packages/server/src/mcp/tools.ts
+++ b/packages/server/src/mcp/tools.ts
@@ -38,6 +38,7 @@ import { applyPhaseDescriptionOverrides } from "./phase-descriptions.js";
 import { resolveRef as resolveCanonicalRef } from "../services/resolver.js";
 import { parseRef } from "../services/refs.js";
 import { logToolCall } from "../services/mcp-telemetry.js";
+import { runToolWithSpecTraffic } from "../services/spec-traffic.js";
 import { bus } from "../services/bus.js";
 import { deriveActivity } from "../agent/derive-activity.js";
 import type { ToolSpec } from "../agent/tool-specs.js";
@@ -400,7 +401,13 @@ export function createMcpServer(
         // Throw on error — withTelemetry catches, captures the FULL error
         // (name + message + stack) into mcp_tool_calls.error, then calls
         // handleError to produce the redacted agent-facing envelope.
-        return await spec.handler(input, ctx);
+        //
+        // spec-189: handler execution goes through the channel-neutral
+        // traffic seam — after a SUCCESSFUL call, the Spec the call resolved
+        // to may auto-advance phase and auto-assign the caller (see
+        // services/spec-traffic.ts). Identical wiring on the in-app agent
+        // surface (agent/tools.ts → executeServerTool) per dec-5.
+        return await runToolWithSpecTraffic(spec, input, ctx);
       },
       () => resolvedMemexId,
       // spec-156 ac-15: pass the spec so the wrap emits a 'mcp'-channel

--- a/packages/server/src/routes/test-events.ts
+++ b/packages/server/src/routes/test-events.ts
@@ -55,6 +55,7 @@ import {
   resolveMemexId,
 } from "../services/emission-keys.js";
 import { mutate } from "../services/mutate.js";
+import { observeTestEventTraffic } from "../services/spec-traffic.js";
 import type { ChangeEntity } from "../services/bus.js";
 
 const testEventsRouter = new Hono();
@@ -363,6 +364,16 @@ testEventsRouter.post("/", async (c) => {
   // spec-129 ac-17: record that this key is live. Fire-and-forget (silent) so a missed
   // bump never blocks or fails the emission — it only leaves a slightly stale timestamp.
   bumpLastUsed(emissionKey.id);
+
+  // spec-189: a test_event arriving is verify-class traffic on the AC's Spec
+  // (dec-1) — a done Spec reopens to verify; a draft Spec advances to verify.
+  // Hidden emissions are excluded by design (`hidden: true` exists to keep an
+  // emission out of the visible signals — e.g. iterating on a done-phase
+  // regression fix must not reopen the Spec). Best-effort and non-throwing;
+  // no assignment (an emission key carries no acting user).
+  if (!insertValues.hidden) {
+    await observeTestEventTraffic(targetMemexId, insertValues.acUid);
+  }
 
   // Stdout log so observers can tail the dev server output during deploys
   // and behavioural probes. Cheap and useful.

--- a/packages/server/src/services/doc-assignees.ts
+++ b/packages/server/src/services/doc-assignees.ts
@@ -6,6 +6,11 @@
 // (spec-84) is subsumed by "assignee": the live responsibility pointer the board
 // shows, more prominent than the creator.
 //
+// spec-189 dec-6 carve-out: the TRAFFIC-DRIVEN path (services/spec-traffic.ts —
+// auto-assignment from mutating agent tool calls) deliberately couples the two
+// axes: it calls assign() AND promoteToEditor() together. The manual tools
+// (assign_spec / unassign_spec) keep the role-independence described above.
+//
 // A Spec supports one-or-more assignees (UNIQUE(doc_id,user_id) makes assign an
 // idempotent upsert and unassign a delete). assign/unassign flow through mutate()
 // with entity:"doc_assignee" and emit on the unified bus (std-8, ac-20) — so

--- a/packages/server/src/services/doc-members.ts
+++ b/packages/server/src/services/doc-members.ts
@@ -13,7 +13,10 @@
 // any org member can one-click self-promote again.
 //
 // Assignment (doc_assignees) is a SEPARATE, independent relation — see
-// services/doc-assignees.ts. A row here is never implied by an assignment (dec-3).
+// services/doc-assignees.ts. A row here is never implied by a MANUAL assignment
+// (dec-3). spec-189 dec-6 carve-out: TRAFFIC-DRIVEN auto-assignment
+// (services/spec-traffic.ts) does imply one — a user actively mutating a Spec
+// through an agent is promoted to editor alongside the assignment.
 
 import { and, eq } from "drizzle-orm";
 import { db } from "../db/connection.js";

--- a/packages/server/src/services/documents.ts
+++ b/packages/server/src/services/documents.ts
@@ -4,7 +4,7 @@ import { documents, docSections, docComments, decisions, users, tags, documentTa
 import type { Doc, DocSection, Decision } from "../db/schema.js";
 import type { DocSummary } from "../types/index.js";
 import { NotFoundError, ValidationError } from "../types/errors.js";
-import { mutate, type ChangeKey, type Mutated } from "./mutate.js";
+import { mutate, type ChangeKey, type Mutated, type RequestCtx } from "./mutate.js";
 import { isUuid } from "./shared/identifiers.js";
 import { withSeqRetry } from "./shared/sequence.js";
 import { embedAndStoreSection, embedAndStoreDecision } from "./memex-embeddings.js";
@@ -823,12 +823,18 @@ export { DOC_STATUSES, SPEC_STATUSES, type DocStatus, type SpecStatus };
 // dec-3 warning when an agent closes a Spec without first running
 // `assess_phase_transition`. `opts.source` is preserved as a hook for future
 // per-source logging / telemetry; today nothing reads it.
+//
+// spec-189: `opts.ctx` threads the originating channel into the emitted
+// events (Pulse attribution for traffic-driven auto-advances) and
+// `opts.narrative` overrides the default status_changed prose so automatic
+// transitions read as auto-advanced rather than humanly moved. Both
+// optional — existing callers are unchanged.
 export async function updateDocStatus(
   memexId: string,
   id: string,
   status: string,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  opts: { source?: "agent" | "rest" } = {},
+  opts: { source?: "agent" | "rest"; ctx?: RequestCtx; narrative?: string } = {},
 ): Promise<Mutated<Doc>> {
   if (!(DOC_STATUSES as readonly string[]).includes(status)) {
     throw new ValidationError(
@@ -855,13 +861,13 @@ export async function updateDocStatus(
       docId: id,
       entity: "document",
       action: "status_changed",
-      narrative: `moved ${doc.handle} ${doc.status} → ${status}`,
+      narrative: opts.narrative ?? `moved ${doc.handle} ${doc.status} → ${status}`,
       payload: { from: doc.status, to: status },
     });
   }
 
   const updated = await mutate(
-    {},
+    opts.ctx ?? {},
     keys,
     async () => {
       const [row] = await db

--- a/packages/server/src/services/spec-traffic.ts
+++ b/packages/server/src/services/spec-traffic.ts
@@ -1,0 +1,204 @@
+// spec-189: traffic-driven phase advancement + auto-assignment.
+//
+// Agent tool traffic (channels 'mcp' and 'in_app_agent' — dec-5; never
+// 'rest_ui', where the human is present with full phase controls) is observed
+// AFTER each successful tool call and drives two automatic behaviours:
+//
+//   1. Phase advancement — the tool's `trafficClass` from the @memex/shared
+//      manifest (dec-4, the single classification source) feeds the pure
+//      transition function `nextPhaseForTraffic` (spec-readiness.ts, the
+//      single place the matrix lives — ac-3). A resulting change applies
+//      through `updateDocStatus()` → mutate() → bus, so the Kanban board
+//      updates live (std-8).
+//   2. Auto-assignment + editor role — any mutating, non-exempt call assigns
+//      the calling user to the Spec AND idempotently promotes them to editor
+//      (dec-6: someone actively mutating a Spec through an agent is
+//      functionally an editor already). This deliberately supersedes
+//      spec-118 dec-3's role/assignment independence for the TRAFFIC-DRIVEN
+//      path only; manual assign_spec / unassign_spec / set_spec_role keep
+//      their role-independent semantics (they're `autoAssignExempt` in the
+//      manifest precisely so auto-assignment can't fight them —
+//      unassign_spec(self) must not instantly undo itself).
+//
+// Verify-class traffic has no MCP tool today: it arrives as CI test_events
+// via POST /api/test-events, which calls `observeTestEventTraffic` below
+// (transition only — an emission key carries no acting user, so there is
+// nothing to assign).
+//
+// Failure posture: observation is best-effort and MUST NEVER fail or delay
+// the user's tool call semantics — every entry point catches everything and
+// logs to stdout.
+
+import { and, eq } from "drizzle-orm";
+import {
+  nextPhaseForTraffic,
+  toolManifest,
+  type ToolManifestEntry,
+} from "@memex/shared";
+import { db } from "../db/connection.js";
+import { documents } from "../db/schema.js";
+import { isSpecStatus } from "../types/roles.js";
+import { assign } from "./doc-assignees.js";
+import { promoteToEditor } from "./doc-members.js";
+import { updateDocStatus } from "./documents.js";
+// Type-only imports — erased at compile time, so no runtime cycle with
+// agent/tool-specs.ts (which imports this module's consumers).
+import type { ToolCtx } from "../agent/tool-specs.js";
+
+// One lookup table, built once from the single-source manifest (dec-4).
+const manifestByName: ReadonlyMap<string, ToolManifestEntry> = new Map(
+  toolManifest.map((e) => [e.name, e]),
+);
+
+export interface SpecTrafficEvent {
+  toolName: string;
+  /** The surface the call came from. Only 'mcp' / 'in_app_agent' act (dec-5). */
+  channel: "mcp" | "in_app_agent";
+  /** The authenticated caller — the user behind the MCP token / in-app session. */
+  userId: string;
+  /** The Spec the call resolved to. Absent → the call targeted no Spec; no-op. */
+  memexId?: string;
+  docId?: string;
+}
+
+/**
+ * Observe one successful agent tool call. Never throws.
+ *
+ * Order of effects: assignment+role first (they apply to ANY mutating,
+ * non-exempt call), then the phase transition (only for classified traffic).
+ * Each is independently guarded so one failing cannot suppress the other.
+ */
+export async function observeSpecTraffic(event: SpecTrafficEvent): Promise<void> {
+  try {
+    const entry = manifestByName.get(event.toolName);
+    // Unknown tool (MCP-only extras like list_memexes never resolve a Spec
+    // anyway) or read-only → query-class: never moves a Spec, never assigns.
+    if (!entry || entry.readOnlyHint) return;
+    if (event.channel !== "mcp" && event.channel !== "in_app_agent") return;
+    if (!event.memexId || !event.docId) return;
+
+    const doc = await db.query.documents.findFirst({
+      where: and(
+        eq(documents.id, event.docId),
+        eq(documents.memexId, event.memexId),
+      ),
+    });
+    // Only Specs have a lifecycle to advance / an assignment surface; demo
+    // Specs are inert to the whole agent surface (spec-178).
+    if (!doc || doc.docType !== "spec" || doc.isDemo) return;
+
+    // ── Auto-assignment + editor role (dec-6) ─────────────────────────
+    if (entry.autoAssignExempt !== true) {
+      try {
+        await assign(event.memexId, event.docId, event.userId, event.userId);
+        await promoteToEditor(event.memexId, event.docId, event.userId);
+      } catch (err) {
+        console.warn(
+          `[spec-traffic] auto-assign failed for ${event.toolName} on ${doc.handle}:`,
+          err,
+        );
+      }
+    }
+
+    // ── Phase advancement ─────────────────────────────────────────────
+    // paused/archived are deliberate placements — auto-advance must not
+    // fight them (same principle as dec-5's rest_ui exclusion). Traffic
+    // never unflags; it also doesn't shuffle the phase underneath a flag.
+    if (entry.trafficClass === null) return;
+    if (doc.pausedAt !== null || doc.archivedAt !== null) return;
+    if (!isSpecStatus(doc.status)) return;
+
+    const next = nextPhaseForTraffic(doc.status, entry.trafficClass);
+    if (next === doc.status) return;
+
+    await updateDocStatus(event.memexId, event.docId, next, {
+      ctx: { channel: event.channel },
+      narrative: `auto-advanced ${doc.handle} ${doc.status} → ${next} (agent activity via ${event.toolName})`,
+    });
+  } catch (err) {
+    // Observation is advisory — never break or fail the tool call.
+    console.warn("[spec-traffic] observation failed:", err);
+  }
+}
+
+/**
+ * The channel-neutral seam (dec-5): BOTH tool surfaces — the MCP wrap
+ * (mcp/tools.ts) and the in-app agent loop (agent/tools.ts →
+ * executeServerTool) — execute their tool handlers through this one
+ * function, so traffic observation has exactly one implementation.
+ *
+ * The wrapped ctx records the Spec each `resolveRef` lands on (every
+ * doc-targeting tool resolves its ref through ctx.resolveRef); after the
+ * handler SUCCEEDS, the observation runs. A throwing handler observes
+ * nothing — failed calls are not traffic.
+ */
+export async function runToolWithSpecTraffic(
+  spec: {
+    name: string;
+    handler: (input: Record<string, unknown>, ctx: ToolCtx) => Promise<string>;
+  },
+  input: Record<string, unknown>,
+  ctx: ToolCtx,
+): Promise<string> {
+  let target: { memexId: string; docId: string } | undefined;
+  const wrappedCtx: ToolCtx = {
+    ...ctx,
+    resolveRef: async (ref) => {
+      const result = await ctx.resolveRef(ref);
+      target = { memexId: result.memexId, docId: result.doc.id };
+      return result;
+    },
+  };
+  const text = await spec.handler(input, wrappedCtx);
+  // Awaited (not detached) so the effects are deterministic for callers and
+  // tests; observeSpecTraffic never throws.
+  await observeSpecTraffic({
+    toolName: spec.name,
+    // ToolCtx.channel defaults to 'mcp' at the call sites that omit it —
+    // mirror that here (see ToolCtx.channel docs in tool-specs.ts).
+    channel: ctx.channel ?? "mcp",
+    userId: ctx.userId,
+    ...target,
+  });
+  return text;
+}
+
+/**
+ * Verify-class traffic from CI: a test_event arriving for an AC is evidence
+ * of verification activity on the AC's Spec (dec-1). Transition only — the
+ * emission key authenticates a Memex, not a user, so there is no caller to
+ * assign. Hidden emissions are excluded: `hidden: true` exists precisely to
+ * keep an emission out of the visible signals (e.g. iterating on a
+ * done-phase regression fix must not reopen the Spec). Never throws.
+ */
+export async function observeTestEventTraffic(
+  memexId: string,
+  acUid: string,
+): Promise<void> {
+  try {
+    // ac_uid grammar: <namespace>/<memex>/specs/<spec-handle>/acs/<ac-handle>
+    const match = /\/specs\/([^/]+)\/acs\//.exec(acUid);
+    const specHandle = match?.[1];
+    if (!specHandle) return;
+
+    const doc = await db.query.documents.findFirst({
+      where: and(
+        eq(documents.memexId, memexId),
+        eq(documents.handle, specHandle),
+      ),
+    });
+    if (!doc || doc.docType !== "spec" || doc.isDemo) return;
+    if (doc.pausedAt !== null || doc.archivedAt !== null) return;
+    if (!isSpecStatus(doc.status)) return;
+
+    const next = nextPhaseForTraffic(doc.status, "verify");
+    if (next === doc.status) return;
+
+    await updateDocStatus(memexId, doc.id, next, {
+      ctx: { channel: "server" },
+      narrative: `auto-advanced ${doc.handle} ${doc.status} → ${next} (test event for ${acUid.split("/").pop()})`,
+    });
+  } catch (err) {
+    console.warn("[spec-traffic] test-event observation failed:", err);
+  }
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -7,6 +7,9 @@ export {
   isForwardTransition,
   isBackwardTransition,
   shouldBlockForwardTransition,
+  // spec-189: the traffic-driven phase-advancement matrix (the single place
+  // the gated transition rules live — ac-3).
+  nextPhaseForTraffic,
 } from './spec-readiness.js';
 export type {
   SpecPhase,
@@ -16,6 +19,7 @@ export type {
   ReadinessInput,
   OutstandingItem,
   SpecReadiness,
+  TrafficClass,
 } from './spec-readiness.js';
 export { toolManifest } from './tool-manifest.js';
 export type { ToolManifestEntry } from './tool-manifest.js';

--- a/packages/shared/src/scaffold-data.ts
+++ b/packages/shared/src/scaffold-data.ts
@@ -800,13 +800,11 @@ const TOOLS: ToolNode[] = toolManifest.map(
         `Missing rationale for tool "${entry.name}" — add an entry to TOOL_RATIONALES in scaffold-data.ts.`,
       );
     }
+    // Spread the manifest entry whole so new manifest fields (e.g. spec-189's
+    // trafficClass / autoAssignExempt) ride along without a forking edit here.
     return {
+      ...entry,
       kind: 'tool',
-      name: entry.name,
-      summary: entry.summary,
-      args: entry.args,
-      group: entry.group,
-      readOnlyHint: entry.readOnlyHint,
       rationale,
     };
   },

--- a/packages/shared/src/scaffold-model.ts
+++ b/packages/shared/src/scaffold-model.ts
@@ -397,6 +397,11 @@ export function toInitPromptRef(tool: ToolNode): InitPromptRefEntry {
     args: tool.args,
     group: tool.group,
     readOnlyHint: tool.readOnlyHint,
+    // spec-189 dec-4: the classification travels with the manifest shape.
+    trafficClass: tool.trafficClass,
+    ...(tool.autoAssignExempt !== undefined
+      ? { autoAssignExempt: tool.autoAssignExempt }
+      : {}),
   };
 }
 

--- a/packages/shared/src/spec-readiness.traffic.test.ts
+++ b/packages/shared/src/spec-readiness.traffic.test.ts
@@ -1,0 +1,121 @@
+// spec-189 t-1 — the traffic-driven phase-advancement matrix, locked cell by cell.
+//
+// **ac-2** (scope) — gated transition rules: build-class traffic advances but
+// never regresses verify → build; verify-class traffic never advances a Spec
+// into verify except out of draft or reopening from done; done reopens to the
+// traffic's phase.
+// **ac-3** (scope) — ALL gating logic lives in one pure function,
+// `nextPhaseForTraffic` in spec-readiness.ts, testable in complete isolation.
+// **ac-6** — class → phase mapping: specify-class and verify-class are
+// distinct inputs and the function consumes the class, never a tool name.
+// **ac-7** — draft moves on any class; from specify only build-class
+// advances; no auto-regression except reopening from done.
+//
+// The table below IS the spec-189 matrix. Every (phase × class) cell is
+// asserted — 5 phases × 4 classes (specify / build / verify / null) = 20
+// cells. A change to any gated condition fails here first.
+
+import { describe, it, expect } from 'vitest';
+import { tagAc } from '@memex-ai-ac/vitest';
+import {
+  nextPhaseForTraffic,
+  type SpecPhase,
+  type TrafficClass,
+} from './spec-readiness.js';
+
+const SPEC = 'mindset-prod/memex-building-itself/specs/spec-189';
+const AC2 = `${SPEC}/acs/ac-2`;
+const AC3 = `${SPEC}/acs/ac-3`;
+const AC6 = `${SPEC}/acs/ac-6`;
+const AC7 = `${SPEC}/acs/ac-7`;
+
+// The full matrix, transcribed from spec-189's Overview. Row order mirrors the
+// lifecycle; column order is specify / build / verify / query(null).
+const MATRIX: Array<{
+  current: SpecPhase;
+  traffic: TrafficClass;
+  next: SpecPhase;
+}> = [
+  // draft is special: ANY classified traffic re-homes it (dec-2)
+  { current: 'draft', traffic: 'specify', next: 'specify' },
+  { current: 'draft', traffic: 'build', next: 'build' },
+  { current: 'draft', traffic: 'verify', next: 'verify' },
+  { current: 'draft', traffic: null, next: 'draft' },
+  // specify: only build-class traffic advances
+  { current: 'specify', traffic: 'specify', next: 'specify' },
+  { current: 'specify', traffic: 'build', next: 'build' },
+  { current: 'specify', traffic: 'verify', next: 'specify' },
+  { current: 'specify', traffic: null, next: 'specify' },
+  // build: nothing moves it — entering verify is never traffic-driven
+  { current: 'build', traffic: 'specify', next: 'build' },
+  { current: 'build', traffic: 'build', next: 'build' },
+  { current: 'build', traffic: 'verify', next: 'build' },
+  { current: 'build', traffic: null, next: 'build' },
+  // verify: nothing moves it — no regression back to build (dec-1 narrative)
+  { current: 'verify', traffic: 'specify', next: 'verify' },
+  { current: 'verify', traffic: 'build', next: 'verify' },
+  { current: 'verify', traffic: 'verify', next: 'verify' },
+  { current: 'verify', traffic: null, next: 'verify' },
+  // done is reopenable by activity: traffic moves it BACK to the class phase
+  { current: 'done', traffic: 'specify', next: 'specify' },
+  { current: 'done', traffic: 'build', next: 'build' },
+  { current: 'done', traffic: 'verify', next: 'verify' },
+  { current: 'done', traffic: null, next: 'done' },
+];
+
+describe('spec-189 t-1: nextPhaseForTraffic — the full transition matrix', () => {
+  it.each(MATRIX)(
+    '($current, $traffic) → $next',
+    ({ current, traffic, next }) => {
+      tagAc(AC2);
+      tagAc(AC3);
+      expect(nextPhaseForTraffic(current, traffic)).toBe(next);
+    },
+  );
+
+  it('draft moves on every traffic class; specify advances only on build-class (ac-7)', () => {
+    tagAc(AC7);
+    // draft → the class's phase, for each class
+    expect(nextPhaseForTraffic('draft', 'specify')).toBe('specify');
+    expect(nextPhaseForTraffic('draft', 'build')).toBe('build');
+    expect(nextPhaseForTraffic('draft', 'verify')).toBe('verify');
+    // specify: build-class is the only mover
+    expect(nextPhaseForTraffic('specify', 'build')).toBe('build');
+    expect(nextPhaseForTraffic('specify', 'specify')).toBe('specify');
+    expect(nextPhaseForTraffic('specify', 'verify')).toBe('specify');
+  });
+
+  it('never auto-regresses except reopening from done (ac-7)', () => {
+    tagAc(AC7);
+    const phases: SpecPhase[] = ['draft', 'specify', 'build', 'verify', 'done'];
+    const classes: TrafficClass[] = ['specify', 'build', 'verify', null];
+    const order: Record<SpecPhase, number> = {
+      draft: 0,
+      specify: 1,
+      build: 2,
+      verify: 3,
+      done: 4,
+    };
+    for (const current of phases) {
+      for (const traffic of classes) {
+        const next = nextPhaseForTraffic(current, traffic);
+        if (current !== 'done' && current !== 'draft') {
+          // between the open ends, motion is forward-only
+          expect(order[next]).toBeGreaterThanOrEqual(order[current]);
+        }
+      }
+    }
+  });
+
+  it('consumes a TrafficClass, never a tool name — specify and verify are distinct inputs (ac-6)', () => {
+    tagAc(AC6);
+    // The same Spec state reacts differently to the two classes that dec-1
+    // split: specify-class moves a draft to specify; verify-class moves the
+    // same draft to verify. The function signature admits only the class.
+    expect(nextPhaseForTraffic('draft', 'specify')).toBe('specify');
+    expect(nextPhaseForTraffic('draft', 'verify')).toBe('verify');
+    // and query-class (null) is inert everywhere
+    expect(nextPhaseForTraffic('draft', null)).toBe('draft');
+    expect(nextPhaseForTraffic('done', null)).toBe('done');
+  });
+});

--- a/packages/shared/src/spec-readiness.ts
+++ b/packages/shared/src/spec-readiness.ts
@@ -210,3 +210,66 @@ export function computeSpecReadiness(input: ReadinessInput): SpecReadiness {
 export function blockerLines(readiness: SpecReadiness): string[] {
   return readiness.outstandingItems.map((item) => `${item.label} — ${item.cta}`);
 }
+
+// ---------------------------------------------------------------------------
+// spec-189: traffic-driven phase advancement.
+//
+// Agent tool traffic (channels 'mcp' / 'in_app_agent') is classified by the
+// @memex/shared tool manifest into a TrafficClass; this pure function is THE
+// single place (spec-189 ac-3) that decides whether observed traffic moves a
+// Spec. The server applies the result through updateDocStatus() → mutate() →
+// bus (std-8); nothing else may re-encode these rules.
+//
+// The matrix (spec-189 dec-1, dec-2, dec-3):
+//
+//   current ↓ / traffic →   specify     build      verify
+//   draft                   → specify   → build    → verify
+//   specify                 stay        → build    stay
+//   build                   stay        stay       stay
+//   verify                  stay        stay       stay
+//   done                    → specify   → build    → verify
+//
+//   - `null` (query-class) traffic never moves a Spec.
+//   - draft is special: ANY classified traffic re-homes the Spec to the
+//     class's phase — a draft with traffic arriving is beyond sketching.
+//   - done is reopenable by activity: traffic moves it BACK to the class's
+//     phase.
+//   - between those open ends, motion is forward-only and only build-class
+//     traffic drives it (specify → build). Entering verify is never
+//     traffic-driven from specify/build; verify never regresses to build.
+//   - transitions are unconditional (dec-3) — readiness gating stays soft
+//     per spec-12 dec-6 and is not consulted here.
+
+/**
+ * How a tool's traffic reads against the Spec lifecycle. Values deliberately
+ * mirror the SpecPhase the traffic "belongs" to; `null` is query-class
+ * (read-only) traffic, which never moves a Spec and never assigns.
+ */
+export type TrafficClass = 'specify' | 'build' | 'verify' | null;
+
+/**
+ * The pure transition function: (current phase × traffic class) → next phase.
+ * Returns the unchanged phase when the traffic doesn't move the Spec. Zero
+ * I/O; exhaustively unit-tested cell-by-cell.
+ */
+export function nextPhaseForTraffic(
+  current: SpecPhase,
+  traffic: TrafficClass,
+): SpecPhase {
+  if (traffic === null) return current;
+
+  // TrafficClass values are SpecPhase names by construction — the class IS
+  // the phase the traffic re-homes a Spec to from the open ends.
+  const target: SpecPhase = traffic;
+
+  // The open ends: draft (any traffic means we're beyond sketching) and done
+  // (reopenable by activity) re-home to the class's phase.
+  if (current === 'draft' || current === 'done') return target;
+
+  // Between the ends: forward-only, and only build-class traffic drives it.
+  if (traffic === 'build' && isForwardTransition(current, 'build')) {
+    return 'build';
+  }
+
+  return current;
+}

--- a/packages/shared/src/tool-manifest.ts
+++ b/packages/shared/src/tool-manifest.ts
@@ -24,6 +24,8 @@
 // MEMEX_MCP_TOOLS_REFERENCE: Read (any phase) → 'read', Planning phase →
 // 'planning', Build phase → 'build', Comments → 'comments'.
 
+import type { TrafficClass } from './spec-readiness.js';
+
 export interface ToolManifestEntry {
   name: string;
   summary: string;
@@ -35,6 +37,27 @@ export interface ToolManifestEntry {
   // this in the b-67 cross-check; the mutate-coverage endpoint gate derives the
   // mutating tool set from `!readOnlyHint`.
   readOnlyHint: boolean;
+  // spec-189 dec-4: how this tool's traffic reads against the Spec lifecycle,
+  // feeding nextPhaseForTraffic (spec-readiness.ts). REQUIRED so adding a tool
+  // forces a classification here — no standalone map that can drift.
+  //   'specify' — decision authoring/resolution + AC authoring (dec-1)
+  //   'build'   — task create/update/delete + issue registration/lifecycle
+  //   'verify'  — AC verification (none on MCP today: verify-class traffic
+  //               arrives via POST /api/test-events, wired server-side)
+  //   null      — traffic that never drives a phase transition: all read-only
+  //               tools, plus mutating tools that either (a) explicitly manage
+  //               the lifecycle (update_doc / publish_spec / assess_spec —
+  //               auto-advance must not fight deliberate placement, same
+  //               principle as dec-5's rest_ui exclusion), (b) shape narrative
+  //               (sections are legitimate draft-phase work and must not bump
+  //               draft → specify; dec-1 scopes specify-class to decisions +
+  //               ACs), or (c) target non-Spec entities (standards clauses).
+  trafficClass: TrafficClass;
+  // spec-189 dec-6/dec-5 corollary: mutating tools whose JOB is managing the
+  // assignment/role axis (or that only notify humans) are exempt from
+  // auto-assignment — otherwise unassign_spec(self) would instantly undo
+  // itself. Absent = false: every other mutating tool auto-assigns its caller.
+  autoAssignExempt?: boolean;
 }
 
 export const toolManifest: ToolManifestEntry[] = [
@@ -46,6 +69,7 @@ export const toolManifest: ToolManifestEntry[] = [
     args: 'get_information(topic?)',
     group: 'read',
     readOnlyHint: true,
+    trafficClass: null,
   },
   // ── Read (any phase) ──────────────────────────────────────
   {
@@ -55,6 +79,7 @@ export const toolManifest: ToolManifestEntry[] = [
     args: 'list_memexes()',
     group: 'read',
     readOnlyHint: true,
+    trafficClass: null,
   },
   {
     name: 'list_docs',
@@ -63,6 +88,7 @@ export const toolManifest: ToolManifestEntry[] = [
     args: 'list_docs(memex?, docType?, tags?)',
     group: 'read',
     readOnlyHint: true,
+    trafficClass: null,
   },
   {
     name: 'get_doc',
@@ -71,6 +97,7 @@ export const toolManifest: ToolManifestEntry[] = [
     args: 'get_doc(ref)',
     group: 'read',
     readOnlyHint: true,
+    trafficClass: null,
   },
   {
     name: 'export_doc',
@@ -79,6 +106,7 @@ export const toolManifest: ToolManifestEntry[] = [
     args: 'export_doc(ref)',
     group: 'read',
     readOnlyHint: true,
+    trafficClass: null,
   },
   {
     name: 'list_tasks',
@@ -87,6 +115,7 @@ export const toolManifest: ToolManifestEntry[] = [
     args: 'list_tasks(ref, readyOnly?)',
     group: 'read',
     readOnlyHint: true,
+    trafficClass: null,
   },
   {
     name: 'list_comments',
@@ -95,6 +124,7 @@ export const toolManifest: ToolManifestEntry[] = [
     args: 'list_comments(ref, types?, mode?)',
     group: 'read',
     readOnlyHint: true,
+    trafficClass: null,
   },
   {
     name: 'search_memex',
@@ -103,6 +133,7 @@ export const toolManifest: ToolManifestEntry[] = [
     args: 'search_memex(memex?, query, kind?, includeArchived?, includeCurrentDoc?, limit?)',
     group: 'read',
     readOnlyHint: true,
+    trafficClass: null,
   },
   {
     name: 'search_issues',
@@ -111,6 +142,7 @@ export const toolManifest: ToolManifestEntry[] = [
     args: 'search_issues(memex?, query, includeArchived?, limit?)',
     group: 'read',
     readOnlyHint: true,
+    trafficClass: null,
   },
 
   // ── Planning phase (draft / specify) ──────────────────────
@@ -121,6 +153,7 @@ export const toolManifest: ToolManifestEntry[] = [
     args: 'create_doc(memex?, title, purpose?, docType?, decisions?, promoteFromTaskRef?, promoteFromIssueRef?)',
     group: 'planning',
     readOnlyHint: false,
+    trafficClass: null,
   },
   {
     name: 'update_doc',
@@ -129,22 +162,25 @@ export const toolManifest: ToolManifestEntry[] = [
     args: 'update_doc(ref, status?, title?, tags?, removeTags?)',
     group: 'planning',
     readOnlyHint: false,
+    trafficClass: null,
   },
   {
     name: 'add_section',
     summary:
-      'Add a new section to a document; the (doc, sectionType) pair is unique. STANDARDS are authored as clauses: pass clauses[] (one aspect each), not content; other doc types pass content. The wrong field for the doc type is rejected with guidance.',
+      'Add a new section to a document; the (doc, sectionType) pair is unique. STANDARDS are authored as clauses: pass clauses[] (one aspect each), not content; other doc types pass content. Wrong field for the doc type → rejected with guidance.',
     args: 'add_section(ref, sectionType, content?, clauses?, title?, description?)',
     group: 'planning',
     readOnlyHint: false,
+    trafficClass: null,
   },
   {
     name: 'update_section',
     summary:
-      'Update the markdown content of a NON-standard document section (+ optional sectionType key / description). Blocked on standards — edit those at the clause grain via add_clause/edit_clause/delete_clause. A sectionType collision fails with a readable error.',
+      'Update the markdown content of a NON-standard document section (+ optional sectionType key / description). Blocked on standards — edit at the clause grain (add/edit/delete_clause). A sectionType collision fails with a readable error.',
     args: 'update_section(ref, content, sectionType?, description?)',
     group: 'planning',
     readOnlyHint: false,
+    trafficClass: null,
   },
   {
     name: 'add_clause',
@@ -153,6 +189,7 @@ export const toolManifest: ToolManifestEntry[] = [
     args: 'add_clause(ref, body, position?)',
     group: 'planning',
     readOnlyHint: false,
+    trafficClass: null,
   },
   {
     name: 'edit_clause',
@@ -161,6 +198,7 @@ export const toolManifest: ToolManifestEntry[] = [
     args: 'edit_clause(ref, body)',
     group: 'planning',
     readOnlyHint: false,
+    trafficClass: null,
   },
   {
     name: 'delete_clause',
@@ -169,6 +207,7 @@ export const toolManifest: ToolManifestEntry[] = [
     args: 'delete_clause(ref)',
     group: 'planning',
     readOnlyHint: false,
+    trafficClass: null,
   },
   {
     name: 'retitle_section',
@@ -177,6 +216,7 @@ export const toolManifest: ToolManifestEntry[] = [
     args: 'retitle_section(ref, title, sectionType?)',
     group: 'planning',
     readOnlyHint: false,
+    trafficClass: null,
   },
   {
     name: 'delete_section',
@@ -185,6 +225,7 @@ export const toolManifest: ToolManifestEntry[] = [
     args: 'delete_section(ref)',
     group: 'planning',
     readOnlyHint: false,
+    trafficClass: null,
   },
   {
     name: 'create_decision',
@@ -193,6 +234,7 @@ export const toolManifest: ToolManifestEntry[] = [
     args: 'create_decision(ref, title, context?, status?, options?)',
     group: 'planning',
     readOnlyHint: false,
+    trafficClass: 'specify',
   },
   {
     name: 'update_decision',
@@ -201,6 +243,7 @@ export const toolManifest: ToolManifestEntry[] = [
     args: 'update_decision(ref, status?, title?, context?, resolution?, chosenOptionIndex?)',
     group: 'planning',
     readOnlyHint: false,
+    trafficClass: 'specify',
   },
   {
     name: 'delete_decision',
@@ -209,6 +252,7 @@ export const toolManifest: ToolManifestEntry[] = [
     args: 'delete_decision(ref)',
     group: 'planning',
     readOnlyHint: false,
+    trafficClass: 'specify',
   },
   {
     name: 'resolve_decision',
@@ -217,6 +261,7 @@ export const toolManifest: ToolManifestEntry[] = [
     args: 'resolve_decision(ref, resolution, chosenOptionIndex?)',
     group: 'planning',
     readOnlyHint: false,
+    trafficClass: 'specify',
   },
   {
     name: 'approve_candidate',
@@ -225,6 +270,7 @@ export const toolManifest: ToolManifestEntry[] = [
     args: 'approve_candidate(ref)',
     group: 'planning',
     readOnlyHint: false,
+    trafficClass: 'specify',
   },
   {
     name: 'reject_candidate',
@@ -233,6 +279,7 @@ export const toolManifest: ToolManifestEntry[] = [
     args: 'reject_candidate(ref, reason)',
     group: 'planning',
     readOnlyHint: false,
+    trafficClass: 'specify',
   },
   {
     name: 'assess_spec',
@@ -241,6 +288,7 @@ export const toolManifest: ToolManifestEntry[] = [
     args: 'assess_spec(ref, mode, target?, codeGrounding?)',
     group: 'planning',
     readOnlyHint: false,
+    trafficClass: null,
   },
   {
     name: 'publish_spec',
@@ -249,6 +297,7 @@ export const toolManifest: ToolManifestEntry[] = [
     args: 'publish_spec(ref, status?)',
     group: 'planning',
     readOnlyHint: false,
+    trafficClass: null,
   },
 
   // ── Build phase (build) ───────────────────────────────────
@@ -259,6 +308,7 @@ export const toolManifest: ToolManifestEntry[] = [
     args: 'create_task(ref, title, description, acceptanceCriteria?, sectionRef?)',
     group: 'build',
     readOnlyHint: false,
+    trafficClass: 'build',
   },
   {
     name: 'update_task',
@@ -267,6 +317,7 @@ export const toolManifest: ToolManifestEntry[] = [
     args: 'update_task(ref, status?, title?, description?, acceptanceCriteria?, sectionRef?, addBlockerRef?, removeBlockerRef?)',
     group: 'build',
     readOnlyHint: false,
+    trafficClass: 'build',
   },
   {
     name: 'delete_task',
@@ -274,6 +325,7 @@ export const toolManifest: ToolManifestEntry[] = [
     args: 'delete_task(ref)',
     group: 'build',
     readOnlyHint: false,
+    trafficClass: 'build',
   },
 
   // ── Standards protocol (build) ────────────────────────────
@@ -287,6 +339,7 @@ export const toolManifest: ToolManifestEntry[] = [
     args: 'flag_drift(ref, observation)',
     group: 'build',
     readOnlyHint: false,
+    trafficClass: null,
   },
   {
     name: 'propose_standard_change',
@@ -295,6 +348,7 @@ export const toolManifest: ToolManifestEntry[] = [
     args: 'propose_standard_change(ref, proposedContent, rationale?)',
     group: 'build',
     readOnlyHint: false,
+    trafficClass: null,
   },
 
   // ── Issues (any phase) ────────────────────────────────────
@@ -305,6 +359,7 @@ export const toolManifest: ToolManifestEntry[] = [
     args: 'register_issue(memex?, spec_ref?, title, body, type, severity?, promote_to_spec?)',
     group: 'build',
     readOnlyHint: false,
+    trafficClass: 'build',
   },
   {
     name: 'list_issues',
@@ -312,6 +367,7 @@ export const toolManifest: ToolManifestEntry[] = [
     args: 'list_issues(ref, type?, status?)',
     group: 'build',
     readOnlyHint: true,
+    trafficClass: null,
   },
   {
     name: 'get_issue',
@@ -319,6 +375,7 @@ export const toolManifest: ToolManifestEntry[] = [
     args: 'get_issue(ref)',
     group: 'build',
     readOnlyHint: true,
+    trafficClass: null,
   },
   {
     name: 'update_issue',
@@ -326,6 +383,7 @@ export const toolManifest: ToolManifestEntry[] = [
     args: 'update_issue(ref, title?, body?, severity?)',
     group: 'build',
     readOnlyHint: false,
+    trafficClass: 'build',
   },
   {
     name: 'resolve_issue',
@@ -333,6 +391,7 @@ export const toolManifest: ToolManifestEntry[] = [
     args: 'resolve_issue(ref, resolution)',
     group: 'build',
     readOnlyHint: false,
+    trafficClass: 'build',
   },
   {
     name: 'convert_issue_to_task',
@@ -341,6 +400,7 @@ export const toolManifest: ToolManifestEntry[] = [
     args: 'convert_issue_to_task(ref)',
     group: 'build',
     readOnlyHint: false,
+    trafficClass: 'build',
   },
   {
     name: 'kick_task_to_issue',
@@ -349,6 +409,7 @@ export const toolManifest: ToolManifestEntry[] = [
     args: 'kick_task_to_issue(ref, reason)',
     group: 'build',
     readOnlyHint: false,
+    trafficClass: 'build',
   },
 
   // ── Roles + assignment (any phase) ────────────────────────
@@ -359,6 +420,8 @@ export const toolManifest: ToolManifestEntry[] = [
     args: 'set_spec_role(ref, user, role?)',
     group: 'build',
     readOnlyHint: false,
+    trafficClass: null,
+    autoAssignExempt: true,
   },
   {
     name: 'get_spec_roles',
@@ -367,6 +430,7 @@ export const toolManifest: ToolManifestEntry[] = [
     args: 'get_spec_roles(ref)',
     group: 'read',
     readOnlyHint: true,
+    trafficClass: null,
   },
   {
     name: 'assign_spec',
@@ -375,6 +439,8 @@ export const toolManifest: ToolManifestEntry[] = [
     args: 'assign_spec(ref, user?)',
     group: 'build',
     readOnlyHint: false,
+    trafficClass: null,
+    autoAssignExempt: true,
   },
   {
     name: 'unassign_spec',
@@ -383,6 +449,8 @@ export const toolManifest: ToolManifestEntry[] = [
     args: 'unassign_spec(ref, user)',
     group: 'build',
     readOnlyHint: false,
+    trafficClass: null,
+    autoAssignExempt: true,
   },
 
   // ── Acceptance Criteria (specify + build) ─────────────────
@@ -393,6 +461,7 @@ export const toolManifest: ToolManifestEntry[] = [
     args: "create_ac(ref, kind, statement, status?, parent_decision_ref?)",
     group: 'build',
     readOnlyHint: false,
+    trafficClass: 'specify',
   },
   {
     name: 'list_acs',
@@ -400,6 +469,7 @@ export const toolManifest: ToolManifestEntry[] = [
     args: 'list_acs(ref, kind?, status?)',
     group: 'build',
     readOnlyHint: true,
+    trafficClass: null,
   },
   {
     name: 'get_ac',
@@ -407,6 +477,7 @@ export const toolManifest: ToolManifestEntry[] = [
     args: 'get_ac(ref)',
     group: 'build',
     readOnlyHint: true,
+    trafficClass: null,
   },
   {
     name: 'update_ac',
@@ -415,6 +486,7 @@ export const toolManifest: ToolManifestEntry[] = [
     args: 'update_ac(ref, statement)',
     group: 'build',
     readOnlyHint: false,
+    trafficClass: 'specify',
   },
   {
     name: 'delete_ac',
@@ -423,6 +495,7 @@ export const toolManifest: ToolManifestEntry[] = [
     args: 'delete_ac(ref)',
     group: 'build',
     readOnlyHint: false,
+    trafficClass: 'specify',
   },
   {
     name: 'link_ac_to_decision',
@@ -431,6 +504,7 @@ export const toolManifest: ToolManifestEntry[] = [
     args: 'link_ac_to_decision(ac_ref, decision_ref)',
     group: 'build',
     readOnlyHint: false,
+    trafficClass: 'specify',
   },
 
   // ── Comments (any phase) ──────────────────────────────────
@@ -441,6 +515,7 @@ export const toolManifest: ToolManifestEntry[] = [
     args: 'add_comment(ref, authorName, content, type?, referenceRef?, anchorOffset?)',
     group: 'comments',
     readOnlyHint: false,
+    trafficClass: null,
   },
   {
     name: 'update_comment',
@@ -449,6 +524,7 @@ export const toolManifest: ToolManifestEntry[] = [
     args: 'update_comment(ref, status, resolution?)',
     group: 'comments',
     readOnlyHint: false,
+    trafficClass: null,
   },
   {
     name: 'memex__send_slack_message',
@@ -457,6 +533,8 @@ export const toolManifest: ToolManifestEntry[] = [
     args: 'memex__send_slack_message(memex?, channelOrUser, text, specRef?)',
     group: 'comments',
     readOnlyHint: false,
+    trafficClass: null,
+    autoAssignExempt: true,
   },
   {
     name: 'memex__send_discord_message',
@@ -465,5 +543,7 @@ export const toolManifest: ToolManifestEntry[] = [
     args: 'memex__send_discord_message(memex?, channelOrUser?, text, specRef?)',
     group: 'comments',
     readOnlyHint: false,
+    trafficClass: null,
+    autoAssignExempt: true,
   },
 ];

--- a/packages/ui/e2e/journey-20-mcp-traffic-phase.spec.ts
+++ b/packages/ui/e2e/journey-20-mcp-traffic-phase.spec.ts
@@ -1,0 +1,144 @@
+// Journey 20 — spec-189: automatic phase advancement + assignment from MCP
+// traffic, observed live on the Kanban board [per std-28].
+//
+// The user-facing promise (ac-1): someone working a Spec exclusively through
+// the MCP server — never touching the web UI — still sees that Spec
+// represented truthfully on the board: traffic moves the card between phase
+// columns and the caller appears as an assignee, live over SSE.
+//
+// The journey drives REAL MCP-channel traffic at `/mcp` (Bearer
+// mxt_DEV_LOCAL_ONLY_NEVER_PRODUCTION — the dev-only PAT the e2e webServer
+// accepts because GOOGLE_CLIENT_ID="" puts it in dev mode, resolving to
+// dev@memex.ai). REST traffic deliberately can't stand in here: spec-189
+// dec-5 makes rest_ui inert by design — only the agent channels move Specs.
+//
+//   1. Seed an org tenant (owner dev@memex.ai) + a draft Spec; open the board.
+//   2. Card sits in Draft, unassigned.
+//   3. MCP create_decision (specify-class) → card moves to Specify AND grows
+//      the dev user's assignee avatar — no page interaction at all.
+//   4. MCP create_task (build-class) → card moves on to Build.
+//
+// Emits ac-1 + ac-4 per the ac-emission discipline (pass AND fail).
+
+import { test, expect, bareUrl } from "./helpers/index.js";
+import {
+  seedOrgTenant,
+  seedSpec,
+  type SeededOrgTenant,
+} from "./helpers/retained.js";
+import { emitAcEvents } from "./helpers/emit-ac.js";
+
+const ACS = [
+  "mindset-prod/memex-building-itself/specs/spec-189/acs/ac-1",
+  "mindset-prod/memex-building-itself/specs/spec-189/acs/ac-4",
+];
+
+const DEV_MCP_BEARER = "mxt_DEV_LOCAL_ONLY_NEVER_PRODUCTION";
+
+// `/mcp` is served by the API server directly (the Vite proxy only carries
+// /api/*), so target the server port — same env chain as helpers/retained.ts.
+const MCP_URL =
+  (process.env.E2E_API_URL ??
+    `http://localhost:${process.env.E2E_SERVER_PORT ?? 8090}`) + "/mcp";
+
+test.afterEach(async ({}, testInfo) => {
+  if (testInfo.status === "skipped") return;
+  await emitAcEvents(
+    ACS,
+    testInfo.status === "passed" ? "pass" : "fail",
+    `packages/ui/e2e/journey-20-mcp-traffic-phase.spec.ts::${testInfo.title}`,
+    testInfo.duration
+  );
+});
+
+/** Call a real MCP tool over the wire, exactly as a coding agent would. */
+async function mcpToolCall(
+  request: import("@playwright/test").APIRequestContext,
+  name: string,
+  args: Record<string, unknown>
+): Promise<void> {
+  const res = await request.post(MCP_URL, {
+    headers: {
+      Authorization: `Bearer ${DEV_MCP_BEARER}`,
+      "Content-Type": "application/json",
+      Accept: "application/json, text/event-stream",
+    },
+    data: {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/call",
+      params: { name, arguments: args },
+    },
+  });
+  expect(res.ok(), `MCP ${name} should succeed (got ${res.status()})`).toBeTruthy();
+  const text = await res.text();
+  // The streamable transport answers as SSE; the tool result rides the first
+  // data: line. A tool-level error carries isError — surface it loudly.
+  const dataLine = text.split("\n").find((l) => l.startsWith("data: "));
+  expect(dataLine, `MCP ${name} returned no SSE data: ${text}`).toBeTruthy();
+  const payload = JSON.parse(dataLine!.slice(6));
+  expect(
+    payload.result?.isError,
+    `MCP ${name} tool error: ${payload.result?.content?.[0]?.text}`
+  ).toBeFalsy();
+}
+
+test("MCP traffic moves the Spec card across the board and assigns the caller, live", async ({
+  page,
+  resources,
+}) => {
+  // ── 1. Seed tenant + draft Spec, open the Specs board ────────────────────
+  const slug = resources.slug("traffic");
+  const tenant: SeededOrgTenant = await seedOrgTenant({ slug });
+  const spec = await seedSpec({
+    memexId: tenant.memexId,
+    title: "Worked entirely over MCP",
+    purpose: "spec-189 journey subject.",
+  });
+  const specRef = `${tenant.namespaceSlug}/${tenant.memexSlug}/specs/${spec.handle}`;
+
+  await page.goto(bareUrl(`/${tenant.namespaceSlug}/${tenant.memexSlug}`));
+  const board = page.getByTestId("kanban-board");
+  await expect(board).toBeVisible({ timeout: 15_000 });
+
+  // Column locator: the column root carries its phase heading; scope card
+  // lookups inside it so "which column is the card in" is unambiguous.
+  const column = (label: string) =>
+    board
+      .locator("div.flex.flex-col", {
+        has: page.getByRole("heading", { name: label, exact: true }),
+      })
+      .first();
+  // Card titles render with a board-sequence prefix ("1.Worked entirely…"),
+  // so match on substring, scoped to the column.
+  const card = (col: ReturnType<typeof column>) =>
+    col.getByText("Worked entirely over MCP");
+
+  // ── 2. The seeded Spec sits in Draft ─────────────────────────────────────
+  await expect(card(column("Draft"))).toBeVisible({ timeout: 15_000 });
+
+  // ── 3. Specify-class MCP traffic: decision authoring ─────────────────────
+  // No UI interaction from here on — the board must follow the traffic.
+  await mcpToolCall(page.request, "create_decision", {
+    ref: specRef,
+    title: "Which queue do we use?",
+  });
+
+  // The card moves Draft → Specify over SSE (status_changed on the bus)…
+  await expect(card(column("Specify"))).toBeVisible({ timeout: 15_000 });
+  await expect(card(column("Draft"))).not.toBeVisible();
+  // …and the calling user (dev) is now an assignee on the card (dec-6 also
+  // makes them an editor server-side; the card surfaces the avatar).
+  const specifyCard = column("Specify").locator('[data-testid="spec-assignees"]');
+  await expect(specifyCard).toBeVisible({ timeout: 15_000 });
+
+  // ── 4. Build-class MCP traffic: task creation ────────────────────────────
+  await mcpToolCall(page.request, "create_task", {
+    ref: specRef,
+    title: "Wire the queue",
+    description: "Implementation begins.",
+  });
+
+  await expect(card(column("Build"))).toBeVisible({ timeout: 15_000 });
+  await expect(card(column("Specify"))).not.toBeVisible();
+});


### PR DESCRIPTION
## What

MCP-first users leave Specs misrepresented on the Kanban board. This observes agent tool traffic and drives two automatic behaviours, per [spec-189](https://memex.ai/mindset-prod/memex-building-itself/specs/spec-189) (6/6 decisions resolved, 11/11 ACs verified):

### Phase advancement — one pure function
`nextPhaseForTraffic(phase, trafficClass)` in `packages/shared/src/spec-readiness.ts` is the **single place** the matrix lives:

| current ↓ / traffic → | specify | build | verify |
|---|---|---|---|
| draft | → specify | → build | → verify |
| specify | stay | → build | stay |
| build | stay | stay | stay |
| verify | stay | stay | stay |
| done | → specify | → build | → verify |

Unconditional (dec-3; gates stay soft per spec-12 dec-6). Verify-class arrives via `POST /api/test-events` (hidden emissions excluded). Paused/archived specs never auto-move.

### Auto-assignment + editor role
Any mutating, non-exempt agent call assigns the caller AND promotes them to editor (dec-6 — deliberately supersedes spec-118 dec-3 for the traffic-driven path only). `assign_spec`/`unassign_spec`/`set_spec_role` + messaging tools are `autoAssignExempt` so auto-assignment can't fight them.

### Plumbing
- Classification is manifest-only (dec-4 / std-16): `ToolManifestEntry` gains required `trafficClass` + optional `autoAssignExempt`; memberships pinned by regression test
- Channels `mcp` + `in_app_agent` share one seam (`runToolWithSpecTraffic`); `rest_ui` is inert (dec-5)
- Auto-advances emit channel-attributed `status_changed` events with "auto-advanced" narratives (std-8) — board follows over SSE
- Observation never fails or delays the user's tool call

## Tests
- **Shared**: full 5×4 matrix table-locked (23 tests) — 587 pass
- **Server**: 11 MCP-boundary integration cases (real tools, live Postgres: every matrix row, channel parity, exemptions, paused behaviour) — 3,349 pass
- **E2E** [per std-28]: `journey-20` drives real JSON-RPC at `/mcp` and watches the card cross the board live + grow an assignee avatar — `make e2e-cold` 38/38
- Two outdated expectations updated (spec-tools now expects `[BUILD]` — the feature working); manifest shape-pin extended; two pre-existing over-length manifest summaries trimmed (shared suite was red on develop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)