### PR TITLE
ci: per-PR production build gate (pnpm build) — std-17 cl-55

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,6 +107,26 @@ jobs:
           path: packages/server/coverage/
           retention-days: 14
 
+  # Production build gate (std-17 §6 / cl-55): `make build` is what the deploy
+  # actually runs, and vitest does NOT typecheck — a green test matrix can hide
+  # a TS2741 that splits the deploy (exactly how PR #44's AcPill gap shipped:
+  # every per-PR job passed, then both develop deploys went red at `tsc -b`).
+  # Running `pnpm build` (= make build) per PR moves that failure from the
+  # deploy tail to the merge gate.
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Production build (tsc + vite) — the same gate the deploy runs
+        run: pnpm build
+
   # React UI unit tests (jsdom) + coverage gate. No database.
   ui:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What

Adds a `build` job to the PR test workflow running `pnpm build` (= `make build`) — the production typecheck + compile the deploy actually runs.

## Why now

std-17 §6 documents that vitest doesn't typecheck and `make build` is the real gate — but until today that gate only fired at the deploy tail. PR #44 shipped a `TS2741` (AcPill's maps missing the new `accepted` state) through a fully-green check matrix, and both develop deploys since went red at `tsc -b` (fixed forward in #48). This is exactly std-17 **cl-55**'s "candidate future automation": fail the PR, not the deploy.

## Follow-up (repo settings)

Add `build` to the required status checks on develop + main branch protection alongside `e2e-result`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)