### PR TITLE
fix(smoke): spec-189 probe — match terse get_doc's real phase format

### DIFF
--- a/packages/server/src/__smoke__/authed.smoke.test.ts
+++ b/packages/server/src/__smoke__/authed.smoke.test.ts
@@ -410,10 +410,13 @@ describe.skipIf(!SMOKE_MCP_TOKEN)(
       expect(dec.status).toBe(200);
       expect(dec.body.result?.isError).toBeFalsy();
 
+      // Terse get_doc renders `ref: <ref> "<title>" [spec, <phase>].` —
+      // verified against the live int surface (first probe run guessed
+      // `[SPECIFY]` and failed while the feature itself worked).
       let docText = mcpTextPayload(
         (await callMcpTool("get_doc", { ref: specRef! })).body,
       );
-      expect(docText).toMatch(/status:\s*specify|\[SPECIFY\]|phase:\s*specify/i);
+      expect(docText).toMatch(/\[spec,\s*specify\]|status:\s*specify|phase:\s*specify/i);
 
       // Build-class traffic: task creation (also sweeps via createdTaskRefs).
       const task = await callMcpTool("create_task", {
@@ -429,7 +432,7 @@ describe.skipIf(!SMOKE_MCP_TOKEN)(
       docText = mcpTextPayload(
         (await callMcpTool("get_doc", { ref: specRef! })).body,
       );
-      expect(docText).toMatch(/status:\s*build|\[BUILD\]|phase:\s*build/i);
+      expect(docText).toMatch(/\[spec,\s*build\]|status:\s*build|phase:\s*build/i);
     });
   },
 );


### PR DESCRIPTION
## What

The spec-189 smoke probe failed its first live run on its own regex: terse `get_doc` renders `[spec, specify]`, the probe guessed `[SPECIFY]` / `status: specify`. Two regexes corrected to the live-verified format.

## Feature status (verified manually against int)

spec-189 itself is **working live** on `mindset-int/memex-app/specs/spec-69`:
- `create_decision` → draft → **specify** ✓
- `create_task` → specify → **build** ✓
- post-done decision traffic → done → **specify** (reopen) ✓
- caller promoted to **editor** ✓

The deploy's revision swap succeeded; only the smoke tail was red, on this regex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)