### PR TITLE
spec-194: remove the author-kind (Everyone/System/People) filter row from the doc-wide Comments view

### DIFF
--- a/packages/ui/e2e/journey-15-spec-detail-layout.spec.ts
+++ b/packages/ui/e2e/journey-15-spec-detail-layout.spec.ts
@@ -62,11 +62,12 @@ test.describe("Spec detail layout", () => {
     await expect(page.getByRole("button", { name: /^Decisions & ACs/ })).toBeVisible();
     await expect(page.getByRole("button", { name: /^Comments/ })).toBeVisible();
 
-    // spec-185: the human comment-type filter chip row was removed from the
-    // doc-wide Comments view (and the per-target tray). The authorship/state
-    // filters stay; only the type-chip row is gone.
+    // spec-185 removed the comment-type chip row from the doc-wide Comments
+    // view; spec-194 then removed the author-kind (Everyone/System/People) row.
+    // Only the Open/Resolved/All status row survives.
     await page.getByRole("button", { name: /^Comments/ }).click();
     await expect(page.getByTestId("comment-filter-chips")).toHaveCount(0);
+    await expect(page.getByTestId("author-filter")).toHaveCount(0);
 
     await page.getByRole("button", { name: /^Decisions & ACs/ }).click();
     // A spec opened via /docs/:id canonicalises to /specs/:id (DocDocument route).

--- a/packages/ui/src/components/AllComments.test.tsx
+++ b/packages/ui/src/components/AllComments.test.tsx
@@ -6,11 +6,13 @@ import type { DocSection, Decision, Task, Comment } from '../api/types';
 import { tagAc } from "@memex-ai-ac/vitest";
 
 const AC_FILTER_LOADBEARING = 'mindset-prod/memex-building-itself/specs/spec-100/acs/ac-9';
-const AC_FILTER_USABLE = 'mindset-prod/memex-building-itself/specs/spec-100/acs/ac-4';
 const AC_DEEPLINK = 'mindset-prod/memex-building-itself/specs/spec-100/acs/ac-6';
 // spec-185 — remove the human comment-type filter chips.
 const AC185 = (n: number) =>
   `mindset-prod/memex-building-itself/specs/spec-185/acs/ac-${n}`;
+// spec-194 — remove the author-kind (Everyone/System/People) filter row.
+const AC194 = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-194/acs/ac-${n}`;
 
 function makeComment(overrides: Partial<Comment> = {}): Comment {
   return {
@@ -205,12 +207,10 @@ describe('AllComments', () => {
     expect(screen.getByText('task issue')).toBeInTheDocument();
   });
 
-  // ── spec-100 ac-9 / ac-4: author-kind + status filtering ──
+  // ── spec-194: author-kind row removed; status filtering retained (spec-100 ac-9 status half) ──
 
-  it('filters to system (agent) comments when the System chip is clicked', async () => {
-    tagAc(AC_FILTER_LOADBEARING);
-    tagAc(AC185(9)); // spec-185 ac-9: authorship filter row unchanged by chip removal
-    const user = userEvent.setup();
+  it('renders no author-kind filter row — Everyone/System/People removed (spec-194 ac-5)', () => {
+    tagAc(AC194(5));
     const section = makeSection();
     render(
       <AllComments
@@ -224,19 +224,35 @@ describe('AllComments', () => {
         onNavigateToSection={vi.fn()}
       />
     );
+    expect(screen.queryByTestId('author-filter')).not.toBeInTheDocument();
+    for (const kind of ['all', 'system', 'human']) {
+      expect(screen.queryByTestId(`author-filter-${kind}`)).not.toBeInTheDocument();
+    }
+  });
 
-    // Default (Everyone): both visible.
+  it('renders human and agent/system comments together — no author-kind narrowing (spec-194 ac-7)', () => {
+    tagAc(AC194(7));
+    const section = makeSection();
+    render(
+      <AllComments
+        sections={[section]}
+        commentsBySection={{
+          [section.id]: [
+            makeComment({ id: 'h', content: 'human note', source: 'human' }),
+            makeComment({ id: 's', content: 'system flag', source: 'agent' }),
+          ],
+        }}
+        onNavigateToSection={vi.fn()}
+      />
+    );
+    // Both render with no way (and no need) to filter by author kind.
     expect(screen.getByText('human note')).toBeInTheDocument();
     expect(screen.getByText('system flag')).toBeInTheDocument();
-
-    await user.click(screen.getByTestId('author-filter-system'));
-    expect(screen.getByText('system flag')).toBeInTheDocument();
-    expect(screen.queryByText('human note')).not.toBeInTheDocument();
   });
 
   it('surfaces resolved comments only when the Resolved status is selected', async () => {
-    tagAc(AC_FILTER_LOADBEARING);
-    tagAc(AC185(9)); // spec-185 ac-9: state filter row unchanged by chip removal
+    tagAc(AC_FILTER_LOADBEARING); // spec-100 ac-9 — status half retained
+    tagAc(AC194(6)); // spec-194 ac-6: status filter still renders + works
     const user = userEvent.setup();
     const section = makeSection();
     render(
@@ -259,36 +275,6 @@ describe('AllComments', () => {
     await user.click(screen.getByTestId('status-filter-resolved'));
     expect(screen.getByText('resolved one')).toBeInTheDocument();
     expect(screen.queryByText('open one')).not.toBeInTheDocument();
-  });
-
-  it('stays usable at 20+ comments: filtering to system narrows to the seeded flags', async () => {
-    tagAc(AC_FILTER_USABLE);
-    const user = userEvent.setup();
-    const section = makeSection();
-    const many: Comment[] = [];
-    for (let i = 0; i < 22; i++) {
-      many.push(makeComment({ id: `h-${i}`, content: `human ${i}`, source: 'human' }));
-    }
-    many.push(makeComment({ id: 'sys-a', content: 'seeded weakness A', source: 'agent', commentType: 'issue' }));
-    many.push(makeComment({ id: 'sys-b', content: 'seeded weakness B', source: 'agent', commentType: 'issue' }));
-
-    render(
-      <AllComments
-        sections={[section]}
-        commentsBySection={{ [section.id]: many }}
-        onNavigateToSection={vi.fn()}
-      />
-    );
-
-    // All 24 rendered at the default view (noisy).
-    expect(screen.getByText('human 0')).toBeInTheDocument();
-
-    // Filtering to System collapses the noise to just the two seeded flags.
-    await user.click(screen.getByTestId('author-filter-system'));
-    expect(screen.getByText('seeded weakness A')).toBeInTheDocument();
-    expect(screen.getByText('seeded weakness B')).toBeInTheDocument();
-    expect(screen.queryByText('human 0')).not.toBeInTheDocument();
-    expect(screen.queryByText('human 21')).not.toBeInTheDocument();
   });
 
   // ── spec-100 ac-6: deep-link to a comment ──

--- a/packages/ui/src/components/AllComments.tsx
+++ b/packages/ui/src/components/AllComments.tsx
@@ -1,11 +1,7 @@
 import { useState } from 'react';
 import type { Comment, DocSection, Decision, Task } from '../api/types';
 import { CommentBubble } from './CommentTray';
-import {
-  filterComments,
-  type AuthorKindFilter,
-  type StatusFilter,
-} from '../utils/filterComments';
+import { filterComments, type StatusFilter } from '../utils/filterComments';
 import { commentAnchorId, buildCommentLink } from '../utils/commentDeepLink';
 
 // spec-100 ac-6: wrap a comment with a stable scroll anchor (`comment-c-{seq}`)
@@ -36,13 +32,9 @@ function AnchoredCommentBubble({ comment }: { comment: Comment }) {
   );
 }
 
-// spec-100 ac-9: author kind + status are the load-bearing Comments-tab
-// filters. Small segmented control mirroring the type-chip styling.
-const AUTHOR_KIND_OPTIONS: { value: AuthorKindFilter; label: string }[] = [
-  { value: 'all', label: 'Everyone' },
-  { value: 'system', label: 'System' },
-  { value: 'human', label: 'People' },
-];
+// spec-194: the author-kind row (Everyone/System/People) was removed — status
+// is the only Comments-tab filter now. (spec-100 ac-9's author-kind half + ac-4
+// are superseded; the shared filterComments predicate stays intact.)
 const STATUS_OPTIONS: { value: StatusFilter; label: string }[] = [
   { value: 'open', label: 'Open' },
   { value: 'resolved', label: 'Resolved' },
@@ -106,13 +98,13 @@ export function AllComments({
   onNavigateToSection,
   onTabChange,
 }: AllCommentsProps) {
-  // spec-100 ac-9: author kind + status are the load-bearing filters, owned
-  // locally (no refetch needed — both fields are already on the loaded rows).
+  // spec-194: author-kind filtering removed — status is the only local filter.
   // Status defaults to 'open'; resolved comments are history, shown on demand.
-  const [authorKind, setAuthorKind] = useState<AuthorKindFilter>('all');
+  // authorKind is fixed to 'all' so the shared filterComments predicate keeps
+  // its signature (it's reused by the spec-view marker dimming).
   const [status, setStatus] = useState<StatusFilter>('open');
   const applyLocal = (list: Comment[]) =>
-    filterComments(list, { authorKind, status, type: null });
+    filterComments(list, { authorKind: 'all', status, type: null });
 
   // spec-185: the comment-type filter chips were removed, so there is no type
   // narrowing — author kind and status are the only filters, applied here
@@ -154,29 +146,17 @@ export function AllComments({
   return (
     <div className="space-y-6 ml-8">
       {hasAnyComments && (
-        <div className="space-y-2">
-          <SegmentedFilter
-            group="author"
-            options={AUTHOR_KIND_OPTIONS}
-            active={authorKind}
-            onChange={setAuthorKind}
-          />
-          <SegmentedFilter
-            group="status"
-            options={STATUS_OPTIONS}
-            active={status}
-            onChange={setStatus}
-          />
-        </div>
+        <SegmentedFilter
+          group="status"
+          options={STATUS_OPTIONS}
+          active={status}
+          onChange={setStatus}
+        />
       )}
 
       {totalCount === 0 && (
         <p className="text-sm text-muted py-8">
-          {status === 'resolved'
-            ? 'No resolved comments.'
-            : authorKind === 'system'
-              ? 'No system comments in this view.'
-              : 'No open comments.'}
+          {status === 'resolved' ? 'No resolved comments.' : 'No open comments.'}
         </p>
       )}
 


### PR DESCRIPTION
## What

Removes the **author-kind** filter row (`Everyone / System / People`) from the doc-wide Comments view (`AllComments`). Soft-launch Comments simplification — sibling of **spec-153** (composer dropdown) and **spec-185** (type filter chips). The **status** row (`Open / Resolved / All`) stays, so resolved-comment history is still reachable.

Spec: https://memex.ai/mindset-prod/memex-building-itself/specs/spec-194 (dec-1 resolved)

## Changes

- **AllComments.tsx** — drop `AUTHOR_KIND_OPTIONS` + the author `SegmentedFilter` render + the `authorKind` state; `applyLocal` passes a fixed `authorKind: 'all'` to the shared `filterComments` predicate; simplify the empty-state message. Status row + shared `SegmentedFilter` kept.
- **`utils/filterComments.ts` untouched** — it's reused by the spec-view marker dimming; AllComments just stops passing a non-`all` author-kind.
- **Tests** — remove the two breaking spec-100 author-filter tests (`ac-9` System-filter, `ac-4` 20+-narrow); retain + retag the status test (spec-100 `ac-9` status half + spec-194 `ac-6`); add spec-194 `ac-5`/`ac-7`. Extend e2e `journey-15` to assert the author-filter row is absent (std-28).

## Cross-spec (acknowledged, accepted by owner)

Supersedes the **author-kind half of spec-100/ac-9** + **spec-100/ac-4** and the **authorship half of spec-185/ac-9** (comments left on both specs). Trade-off: the doc-wide Comments view no longer separates human vs agent/system comments — after spec-185 removed the type chips, this was the last such control. The per-target `CommentTray` (no author filter) and `comment.source` are untouched.

## Verification

- `tsc --noEmit` clean; full UI vitest green (**117 files, 992 passed / 1 skipped**).
- `make e2e-cold` green (**42/42**, incl. extended journey-15).
- AC emission (`ac-5`/`ac-6`/`ac-7`) lands when the suite runs with `MEMEX_EMIT_KEY`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)