### PR TITLE
spec-194 (dec-2): restore the author-kind row — People→Humans, one combined row, distinct colour

### DIFF
--- a/packages/ui/e2e/journey-15-spec-detail-layout.spec.ts
+++ b/packages/ui/e2e/journey-15-spec-detail-layout.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, tenantPath } from "./helpers/index.js";
-import { seedOrgTenant, seedSpec, seedSection } from "./helpers/retained.js";
+import { seedOrgTenant, seedSpec, seedSection, tenantApiUrl } from "./helpers/retained.js";
 
 // Journey 15: Spec detail page layout. Locks in the structure shipped with the
 // design refresh — header actions live in the top nav (not the body), tabs
@@ -27,7 +27,7 @@ test.describe("Spec detail layout", () => {
   }) => {
     const slug = resources.slug("j15");
     const tenant = await seedOrgTenant({ slug });
-    const { docId } = await seedSpec({
+    const { docId, sectionId } = await seedSpec({
       memexId: tenant.memexId,
       title: "Layout Spec",
       purpose: "Spec for layout regression testing.",
@@ -37,6 +37,19 @@ test.describe("Spec detail layout", () => {
     await seedSection({ memexId: tenant.memexId, docId, title: "Design Approach", content: "Design body.", sectionType: "design" });
     await seedSection({ memexId: tenant.memexId, docId, title: "Testing Plan", content: "Testing body.", sectionType: "testing" });
     await seedSection({ memexId: tenant.memexId, docId, title: "Rollout Plan", content: "Rollout body.", sectionType: "rollout" });
+    // spec-194: seed one comment so the Comments-tab filter rows render (they're
+    // hidden when the doc has no comments).
+    {
+      const res = await fetch(
+        tenantApiUrl(tenant.namespaceSlug, tenant.memexSlug, `comments/section/${sectionId}`),
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ authorName: "Alex Rivera", content: "A note for the filter row." }),
+        },
+      );
+      expect(res.ok).toBe(true);
+    }
 
     await page.goto(tenantPath(tenant.namespaceSlug, tenant.memexSlug, `/docs/${docId}`));
     await expect(page.getByRole("heading", { name: "Layout Spec", level: 1 })).toBeVisible({
@@ -62,12 +75,14 @@ test.describe("Spec detail layout", () => {
     await expect(page.getByRole("button", { name: /^Decisions & ACs/ })).toBeVisible();
     await expect(page.getByRole("button", { name: /^Comments/ })).toBeVisible();
 
-    // spec-185 removed the comment-type chip row from the doc-wide Comments
-    // view; spec-194 then removed the author-kind (Everyone/System/People) row.
-    // Only the Open/Resolved/All status row survives.
+    // Comments filter rows: the comment-type chip row is gone (spec-185); the
+    // author-kind row is present and renamed People→Humans (spec-194), sharing
+    // one combined row with the Open/Resolved/All status row.
     await page.getByRole("button", { name: /^Comments/ }).click();
     await expect(page.getByTestId("comment-filter-chips")).toHaveCount(0);
-    await expect(page.getByTestId("author-filter")).toHaveCount(0);
+    await expect(page.getByTestId("author-filter")).toBeVisible();
+    await expect(page.getByTestId("author-filter-human")).toHaveText("Humans");
+    await expect(page.getByTestId("status-filter")).toBeVisible();
 
     await page.getByRole("button", { name: /^Decisions & ACs/ }).click();
     // A spec opened via /docs/:id canonicalises to /specs/:id (DocDocument route).

--- a/packages/ui/src/components/AllComments.test.tsx
+++ b/packages/ui/src/components/AllComments.test.tsx
@@ -207,31 +207,32 @@ describe('AllComments', () => {
     expect(screen.getByText('task issue')).toBeInTheDocument();
   });
 
-  // ── spec-194: author-kind row removed; status filtering retained (spec-100 ac-9 status half) ──
+  // ── spec-194 (dec-2): author-kind row restored (People→Humans), one combined row, distinct colour ──
 
-  it('renders no author-kind filter row — Everyone/System/People removed (spec-194 ac-5)', () => {
+  it('renders the author-kind row with Everyone/System/Humans — People renamed to Humans (spec-194 ac-5)', () => {
     tagAc(AC194(5));
     const section = makeSection();
     render(
       <AllComments
         sections={[section]}
         commentsBySection={{
-          [section.id]: [
-            makeComment({ id: 'h', content: 'human note', source: 'human' }),
-            makeComment({ id: 's', content: 'system flag', source: 'agent' }),
-          ],
+          [section.id]: [makeComment({ id: 'h', content: 'human note', source: 'human' })],
         }}
         onNavigateToSection={vi.fn()}
       />
     );
-    expect(screen.queryByTestId('author-filter')).not.toBeInTheDocument();
+    expect(screen.getByTestId('author-filter')).toBeInTheDocument();
     for (const kind of ['all', 'system', 'human']) {
-      expect(screen.queryByTestId(`author-filter-${kind}`)).not.toBeInTheDocument();
+      expect(screen.getByTestId(`author-filter-${kind}`)).toBeInTheDocument();
     }
+    // The human option reads "Humans", not "People".
+    expect(screen.getByTestId('author-filter-human')).toHaveTextContent('Humans');
+    expect(screen.queryByText('People')).not.toBeInTheDocument();
   });
 
-  it('renders human and agent/system comments together — no author-kind narrowing (spec-194 ac-7)', () => {
+  it('author-kind filtering narrows: System → agent only, Humans → human only (spec-194 ac-7)', async () => {
     tagAc(AC194(7));
+    const user = userEvent.setup();
     const section = makeSection();
     render(
       <AllComments
@@ -245,9 +246,47 @@ describe('AllComments', () => {
         onNavigateToSection={vi.fn()}
       />
     );
-    // Both render with no way (and no need) to filter by author kind.
+    // Default (Everyone): both visible.
     expect(screen.getByText('human note')).toBeInTheDocument();
     expect(screen.getByText('system flag')).toBeInTheDocument();
+    // System → only agent-sourced.
+    await user.click(screen.getByTestId('author-filter-system'));
+    expect(screen.getByText('system flag')).toBeInTheDocument();
+    expect(screen.queryByText('human note')).not.toBeInTheDocument();
+    // Humans → only human-sourced.
+    await user.click(screen.getByTestId('author-filter-human'));
+    expect(screen.getByText('human note')).toBeInTheDocument();
+    expect(screen.queryByText('system flag')).not.toBeInTheDocument();
+  });
+
+  it('renders author-kind + status chips on one combined row (spec-194 ac-9)', () => {
+    tagAc(AC194(9));
+    const section = makeSection();
+    render(
+      <AllComments
+        sections={[section]}
+        commentsBySection={{ [section.id]: [makeComment({ id: 'h', content: 'human note' })] }}
+        onNavigateToSection={vi.fn()}
+      />
+    );
+    const author = screen.getByTestId('author-filter');
+    const statusRow = screen.getByTestId('status-filter');
+    // Same parent element → one combined row (author group, divider, status group).
+    expect(author.parentElement).toBe(statusRow.parentElement);
+  });
+
+  it('author-kind chips carry the agent tone, status chips the accent tone (spec-194 ac-10)', () => {
+    tagAc(AC194(10));
+    const section = makeSection();
+    render(
+      <AllComments
+        sections={[section]}
+        commentsBySection={{ [section.id]: [makeComment({ id: 'h', content: 'human note' })] }}
+        onNavigateToSection={vi.fn()}
+      />
+    );
+    expect(screen.getByTestId('author-filter')).toHaveAttribute('data-tone', 'agent');
+    expect(screen.getByTestId('status-filter')).toHaveAttribute('data-tone', 'accent');
   });
 
   it('surfaces resolved comments only when the Resolved status is selected', async () => {

--- a/packages/ui/src/components/AllComments.tsx
+++ b/packages/ui/src/components/AllComments.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import type { Comment, DocSection, Decision, Task } from '../api/types';
 import { CommentBubble } from './CommentTray';
-import { filterComments, type StatusFilter } from '../utils/filterComments';
+import { filterComments, type AuthorKindFilter, type StatusFilter } from '../utils/filterComments';
 import { commentAnchorId, buildCommentLink } from '../utils/commentDeepLink';
 
 // spec-100 ac-6: wrap a comment with a stable scroll anchor (`comment-c-{seq}`)
@@ -32,9 +32,16 @@ function AnchoredCommentBubble({ comment }: { comment: Comment }) {
   );
 }
 
-// spec-194: the author-kind row (Everyone/System/People) was removed — status
-// is the only Comments-tab filter now. (spec-100 ac-9's author-kind half + ac-4
-// are superseded; the shared filterComments predicate stays intact.)
+// spec-194 (dec-2): author-kind + status filters share one combined row.
+// People → Humans (the `'human'` value is unchanged); the shared filterComments
+// predicate stays intact. The two groups are tone-coloured to read as distinct:
+// author = `agent` (violet), status = `accent` (blue) — both theme tokens with
+// light + dark values.
+const AUTHOR_KIND_OPTIONS: { value: AuthorKindFilter; label: string }[] = [
+  { value: 'all', label: 'Everyone' },
+  { value: 'system', label: 'System' },
+  { value: 'human', label: 'Humans' },
+];
 const STATUS_OPTIONS: { value: StatusFilter; label: string }[] = [
   { value: 'open', label: 'Open' },
   { value: 'resolved', label: 'Resolved' },
@@ -46,14 +53,26 @@ function SegmentedFilter<T extends string>({
   options,
   active,
   onChange,
+  tone = 'accent',
 }: {
   group: string;
   options: { value: T; label: string }[];
   active: T;
   onChange: (next: T) => void;
+  /** spec-194 dec-2: which theme accent the chips use. 'accent' = blue (status),
+   *  'agent' = violet (author-kind). Both tokens carry light + dark values. */
+  tone?: 'accent' | 'agent';
 }) {
+  const activeCls =
+    tone === 'agent'
+      ? 'bg-agent text-white border-agent'
+      : 'bg-accent text-white border-accent';
+  const idleCls =
+    tone === 'agent'
+      ? 'bg-overlay text-secondary border-divider hover:border-agent/50'
+      : 'bg-overlay text-secondary border-divider hover:border-accent/50';
   return (
-    <div data-testid={`${group}-filter`} className="flex flex-wrap gap-1.5">
+    <div data-testid={`${group}-filter`} data-tone={tone} className="flex flex-wrap gap-1.5">
       {options.map((opt) => {
         const isActive = active === opt.value;
         return (
@@ -64,9 +83,7 @@ function SegmentedFilter<T extends string>({
             data-active={isActive ? 'true' : 'false'}
             onClick={() => onChange(opt.value)}
             className={`text-[11px] rounded-full px-2 py-0.5 border transition-colors ${
-              isActive
-                ? 'bg-accent text-white border-accent'
-                : 'bg-overlay text-secondary border-divider hover:border-accent/50'
+              isActive ? activeCls : idleCls
             }`}
           >
             {opt.label}
@@ -98,17 +115,14 @@ export function AllComments({
   onNavigateToSection,
   onTabChange,
 }: AllCommentsProps) {
-  // spec-194: author-kind filtering removed — status is the only local filter.
-  // Status defaults to 'open'; resolved comments are history, shown on demand.
-  // authorKind is fixed to 'all' so the shared filterComments predicate keeps
-  // its signature (it's reused by the spec-view marker dimming).
+  // spec-194 dec-2: author-kind + status are the local filters (type chips were
+  // removed by spec-185). Status defaults to 'open'; resolved comments are
+  // history, shown on demand. authorKind defaults to 'all' (Everyone).
+  const [authorKind, setAuthorKind] = useState<AuthorKindFilter>('all');
   const [status, setStatus] = useState<StatusFilter>('open');
   const applyLocal = (list: Comment[]) =>
-    filterComments(list, { authorKind: 'all', status, type: null });
+    filterComments(list, { authorKind, status, type: null });
 
-  // spec-185: the comment-type filter chips were removed, so there is no type
-  // narrowing — author kind and status are the only filters, applied here
-  // client-side over every loaded comment.
   const sectionEntries = sections
     .map((section, index) => ({
       section,
@@ -146,17 +160,31 @@ export function AllComments({
   return (
     <div className="space-y-6 ml-8">
       {hasAnyComments && (
-        <SegmentedFilter
-          group="status"
-          options={STATUS_OPTIONS}
-          active={status}
-          onChange={setStatus}
-        />
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5">
+          <SegmentedFilter
+            group="author"
+            options={AUTHOR_KIND_OPTIONS}
+            active={authorKind}
+            onChange={setAuthorKind}
+            tone="agent"
+          />
+          <span aria-hidden className="h-4 w-px bg-edge-subtle" />
+          <SegmentedFilter
+            group="status"
+            options={STATUS_OPTIONS}
+            active={status}
+            onChange={setStatus}
+          />
+        </div>
       )}
 
       {totalCount === 0 && (
         <p className="text-sm text-muted py-8">
-          {status === 'resolved' ? 'No resolved comments.' : 'No open comments.'}
+          {status === 'resolved'
+            ? 'No resolved comments.'
+            : authorKind === 'system'
+              ? 'No system comments in this view.'
+              : 'No open comments.'}
         </p>
       )}
 


### PR DESCRIPTION
## What

Reverses spec-194 **dec-1** (which removed the author-kind row and shipped it to INT) per a change of direction. The doc-wide Comments view (`AllComments`) now shows the author-kind chips **Everyone / System / Humans** and the status chips **Open / Resolved / All** on a **single combined row**, with the two groups in **distinct theme colours**.

Spec: https://memex.ai/mindset-prod/memex-building-itself/specs/spec-194 (dec-2)

## Changes

- **AllComments.tsx** — re-add `AUTHOR_KIND_OPTIONS` (**People → Humans**; the `'human'` value is unchanged) + the `authorKind` state; `applyLocal` uses the live `authorKind`. Add a `tone?: 'accent' | 'agent'` prop to the shared `SegmentedFilter` (default `accent`/blue for status; `agent`/violet for the author group), exposing `data-tone`. Both are theme tokens with light + dark values, so contrast/theming is handled automatically. Both filters render in **one flex row** with a subtle divider. Restore the system empty-state message. `utils/filterComments.ts` + the per-target `CommentTray` are untouched.
- **Tests** — reverse the removal tests: author row renders (Humans label, not People); interactive narrowing (System → agent, Humans → human); one combined row; `data-tone` = agent/accent split. Re-extend e2e `journey-15` (seed a comment; assert `author-filter` present + "Humans" + status row).
- **Cross-spec** — withdraw dec-1's supersession of **spec-100/ac-9 + ac-4** and **spec-185/ac-9** (follow-up comments on both) — the author-kind filtering is reinstated, renamed/merged/recoloured.

## Colour choice

`accent` (blue: blue-400 dark / blue-600 light) for status; `agent` (violet: violet-500 dark / violet-600 light) for author-kind — the two existing solid theme accents, both defined for light + dark.

## Verification

- `tsc --noEmit` clean; full UI vitest green (**117 files, 994 passed / 1 skipped**).
- `make e2e-cold` green (**43/43**, incl. re-extended journey-15).
- AC emission (ac-5/6/7/9/10) lands on a `MEMEX_EMIT_KEY` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)