### PR TITLE
spec-192: discoverable ⌘K search triggers (Specs board + doc header)

### DIFF
--- a/packages/ui/e2e/journey-18-global-search.spec.ts
+++ b/packages/ui/e2e/journey-18-global-search.spec.ts
@@ -4,6 +4,7 @@ import {
   setUserName,
   seedSpecInMemex,
   deleteDoc,
+  emitAcEvents,
 } from "./helpers/index.js";
 
 // Journey 18 (spec-64 t-6): the global ⌘K search palette, end-to-end in a real
@@ -64,6 +65,33 @@ test.describe("Journey 18 — global ⌘K search palette", () => {
 
   test.afterEach(async () => {
     if (docId) await deleteDoc(docId);
+  });
+
+  // spec-192 t-5: emit AC pass/fail for the two trigger tests (ac-8 board, ac-10
+  // doc-header; ac-2 = both open the SAME palette). Title→refs map per the repo's
+  // e2e emission idiom (journey-20); the spec-64/191 tests above carry no refs and
+  // emit nothing. Routing is namespace-derived; gated by MEMEX_EMIT.
+  const SPEC192 = "mindset-prod/memex-building-itself/specs/spec-192";
+  const ACS_BY_TEST: Record<string, string[]> = {
+    "clicking the Specs-board search trigger opens the palette (spec-192 ac-8)": [
+      `${SPEC192}/acs/ac-8`,
+      `${SPEC192}/acs/ac-2`,
+    ],
+    "clicking the doc-page header search trigger opens the palette (spec-192 ac-10)": [
+      `${SPEC192}/acs/ac-10`,
+      `${SPEC192}/acs/ac-2`,
+    ],
+  };
+  test.afterEach(async ({}, testInfo) => {
+    if (testInfo.status === "skipped") return;
+    const refs = ACS_BY_TEST[testInfo.title];
+    if (!refs) return;
+    await emitAcEvents(
+      refs,
+      testInfo.status === "passed" ? "pass" : "fail",
+      `packages/ui/e2e/journey-18-global-search.spec.ts::${testInfo.title}`,
+      testInfo.duration ?? 0,
+    );
   });
 
   // The keyboard chord differs by platform. The app-level listener (App.tsx
@@ -198,5 +226,40 @@ test.describe("Journey 18 — global ⌘K search palette", () => {
     await expect(
       page.getByRole("heading", { name: SPEC_TITLE, level: 1 }),
     ).toBeVisible({ timeout: 15_000 });
+  });
+
+  // ── spec-192: the two persistent search TRIGGERS (buttons, not the hotkey) ──
+  // The discoverability buttons added by spec-192 must open the SAME palette the
+  // ⌘K shortcut does — one on the Specs board header, one on the doc-page header
+  // (where the sidebar is hidden). Real-browser proof the click reaches the shared
+  // open-state and the cmdk dialog mounts + takes focus.
+  test("clicking the Specs-board search trigger opens the palette (spec-192 ac-8)", async ({
+    page,
+  }) => {
+    await page.goto(bareUrl("/"));
+    await expect(page.getByRole("heading", { name: "Specs" })).toBeVisible({
+      timeout: 15_000,
+    });
+
+    await page.getByTestId("search-palette-trigger-board").click();
+    const dialog = page.getByRole("dialog", { name: "Search this memex" });
+    await expect(dialog).toBeVisible();
+    // Same palette as ⌘K: the search input takes focus on open.
+    await expect(page.getByPlaceholder(/Search specs/i)).toBeFocused();
+  });
+
+  test("clicking the doc-page header search trigger opens the palette (spec-192 ac-10)", async ({
+    page,
+  }) => {
+    // The sidebar is hidden on spec/doc pages — the header trigger is the cue here.
+    await page.goto(bareUrl(`/${nsSlug}/${mxSlug}/specs/${specHandle}`));
+    await expect(
+      page.getByRole("heading", { name: SPEC_TITLE, level: 1 }),
+    ).toBeVisible({ timeout: 15_000 });
+
+    await page.getByTestId("search-palette-trigger-header").click();
+    const dialog = page.getByRole("dialog", { name: "Search this memex" });
+    await expect(dialog).toBeVisible();
+    await expect(page.getByPlaceholder(/Search specs/i)).toBeFocused();
   });
 });

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useState, useEffect, useRef, useCallback } from 'react';
+import { Fragment, useState, useEffect } from 'react';
 import { Routes, Route, useLocation, useParams, Navigate, Outlet } from 'react-router-dom';
 import { Pulse } from './pages/Pulse';
 import { Insights } from './pages/Insights';
@@ -39,7 +39,7 @@ import { parseTenantFromPathname } from './utils/tenantUrl';
 import { isFeatureHidden } from './utils/featureFlags';
 import { probePublicMemex, type PublicMemexProbe } from './api/client';
 import { PublicMemexProvider } from './components/PublicMemexContext';
-import { SearchPalette } from './components/SearchPalette';
+import { SearchProvider } from './components/SearchContext';
 
 declare const __BUILD_TIME__: string;
 
@@ -360,52 +360,11 @@ function FlatShell({ children }: { children: React.ReactNode }) {
   );
 }
 
-// spec-64 t-3 (ac-8/ac-16): the global ⌘K / Ctrl+K host. A THIN app-level
-// keydown listener owns the hotkey — it toggles the palette and calls
-// preventDefault() so the browser/cmdk never sees it (cmdk does NOT register the
-// global shortcut, ac-16). It also owns focus-restoration (ac-8): because the
-// palette opens programmatically (no Radix Dialog.Trigger), Radix has nothing to
-// restore focus to on close and it would fall to <body>. So we capture the
-// focused element when the palette opens and restore it on close — whether the
-// close came from Esc, an overlay click, or a ⌘K toggle. (The jsdom component
-// test can't model real focus restoration; journey-18 proves it.) Mounted
-// app-wide so the omnibox is reachable from any route.
-function GlobalSearchHost() {
-  const [open, setOpen] = useState(false);
-  const openRef = useRef(false);
-  const restoreFocusRef = useRef<HTMLElement | null>(null);
-
-  const setOpenSafe = useCallback((next: boolean) => {
-    if (next && !openRef.current) {
-      // Opening: remember where focus was so we can hand it back on close.
-      restoreFocusRef.current = document.activeElement as HTMLElement | null;
-    }
-    openRef.current = next;
-    setOpen(next);
-    if (!next) {
-      const el = restoreFocusRef.current;
-      restoreFocusRef.current = null;
-      // Restore on the next frame, after Radix's own close-autofocus (which
-      // targets the absent trigger) has run — so our restore wins.
-      if (el && typeof el.focus === 'function') {
-        requestAnimationFrame(() => el.focus());
-      }
-    }
-  }, []);
-
-  useEffect(() => {
-    function onKeyDown(e: KeyboardEvent) {
-      if ((e.metaKey || e.ctrlKey) && (e.key === 'k' || e.key === 'K')) {
-        e.preventDefault();
-        setOpenSafe(!openRef.current);
-      }
-    }
-    window.addEventListener('keydown', onKeyDown);
-    return () => window.removeEventListener('keydown', onKeyDown);
-  }, [setOpenSafe]);
-
-  return <SearchPalette open={open} onOpenChange={setOpenSafe} />;
-}
+// spec-192 t-1: the ⌘K omnibox host — open-state, the ⌘K / Ctrl K hotkey, and
+// open/close focus-restoration (originally spec-64's GlobalSearchHost) — now
+// lives in SearchProvider (components/SearchContext) so the Specs-board and
+// doc-page chrome can open the same single palette. App just mounts the provider
+// around the router below.
 
 export function App() {
   console.log(`[memex.ai] deployed: ${__BUILD_TIME__}`);
@@ -451,10 +410,13 @@ export function App() {
           </Routes>
         ) : (
           <AuthGate>
-            {/* spec-64 t-3: mount the ⌘K omnibox app-wide so it's reachable from
-                every authenticated/public-tenant route. */}
-            <GlobalSearchHost />
-            <PostLoginRouter />
+            {/* spec-64 t-3 / spec-192 t-1: SearchProvider owns the single ⌘K
+                palette + open-state and exposes openSearch() to the chrome
+                (Specs-board + doc-page triggers); it wraps the router so those
+                surfaces sit inside the context. */}
+            <SearchProvider>
+              <PostLoginRouter />
+            </SearchProvider>
           </AuthGate>
         )}
       </AuthProvider>

--- a/packages/ui/src/components/AppShell.spec-192.test.tsx
+++ b/packages/ui/src/components/AppShell.spec-192.test.tsx
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { useMemo, type ReactNode } from 'react';
+import { tagAc } from '@memex-ai-ac/vitest';
+import type { SessionPayload } from '../api/client';
+import { ThemeProvider } from './ThemeContext';
+import { SearchProvider } from './SearchContext';
+import { useHeaderSlot } from './HeaderSlot';
+import { AppShell } from './AppShell';
+
+// spec-192 t-3: the doc-page header search trigger. The sidebar is hidden on doc
+// pages, so this is the only discovery cue there (dec-2). ac-10: clicking it
+// opens the palette. ac-11: it coexists with the page's Edit/Share/⋯ actions.
+
+const AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-192/acs/ac-${n}`;
+const DIALOG = { name: 'Search this memex' } as const;
+
+const mockSession: SessionPayload = {
+  user: {
+    id: 'u-1',
+    email: 'alice@example.com',
+    name: 'Alice',
+    status: 'active',
+    emailVerified: true,
+  },
+  memberships: [
+    {
+      memexId: 'mx-alice',
+      slug: 'alice',
+      memexSlug: 'personal',
+      name: 'Personal Memex',
+      kind: 'personal' as const,
+      role: 'administrator' as const,
+    },
+  ],
+  currentMemexId: 'mx-alice',
+  currentRole: 'administrator' as const,
+  needsOnboarding: false,
+  hiddenFeatures: [],
+};
+
+vi.mock('./AuthContext', async () => {
+  const real = await vi.importActual<typeof import('./AuthContext')>('./AuthContext');
+  return {
+    ...real,
+    useAuth: () => ({
+      session: mockSession,
+      user: { name: 'Alice', email: 'alice@example.com', picture: '' },
+      token: 'fake-token',
+      isAuthenticated: true,
+      authError: null,
+      logout: vi.fn(),
+      updateSession: vi.fn(),
+      acceptSession: vi.fn(),
+    }),
+  };
+});
+
+// A doc page that injects the right-side header actions via HeaderSlot, exactly
+// as DocDocument does — so we can prove the search trigger coexists with them.
+function DocBody() {
+  // Memoized like the real caller (DocDocument): useHeaderSlot's effect depends
+  // on `content`, so a fresh element each render would loop infinitely.
+  const actions = useMemo(
+    () => (
+      <>
+        <button data-testid="hdr-edit">Edit</button>
+        <button data-testid="hdr-share">Share</button>
+        <button data-testid="hdr-menu">⋯</button>
+      </>
+    ),
+    [],
+  );
+  useHeaderSlot(actions);
+  return <div data-testid="doc-body">doc</div>;
+}
+
+function renderDocShell(children: ReactNode) {
+  return render(
+    <ThemeProvider>
+      <MemoryRouter initialEntries={['/docs/doc-1']}>
+        <SearchProvider>
+          <AppShell>{children}</AppShell>
+        </SearchProvider>
+      </MemoryRouter>
+    </ThemeProvider>,
+  );
+}
+
+describe('spec-192 t-3: doc-page header search trigger', () => {
+  it('renders on a doc page (sidebar hidden) and clicking it opens the palette (ac-10)', async () => {
+    tagAc(AC(10));
+    tagAc(AC(1)); // scope ac-1: persistent, visible trigger exists on doc/spec pages too
+    tagAc(AC(4)); // scope ac-4: palette discoverable on doc pages via the header trigger
+    renderDocShell(<DocBody />);
+
+    // Doc pages drop the sidebar — the header trigger is the discovery cue here.
+    expect(screen.queryByTestId('primary-nav')).not.toBeInTheDocument();
+
+    const trigger = screen.getByTestId('search-palette-trigger-header');
+    expect(screen.queryByRole('dialog', DIALOG)).not.toBeInTheDocument();
+
+    fireEvent.click(trigger);
+    expect(await screen.findByRole('dialog', DIALOG)).toBeInTheDocument();
+  });
+
+  it('coexists with the existing Edit / Share / ⋯ header controls (ac-11)', () => {
+    tagAc(AC(11));
+    tagAc(AC(6)); // scope ac-6: existing header controls stay fully visible alongside the trigger
+    // Unit level = COMPOSITIONAL proof: the trigger and every action control
+    // coexist in the DOM (the trigger didn't replace or hide them). jsdom has no
+    // layout engine, so VISUAL non-overlap is proven by journey-18 e2e — clicking
+    // the doc-header trigger in a real browser with the actions present.
+    renderDocShell(<DocBody />);
+
+    expect(screen.getByTestId('hdr-edit')).toBeInTheDocument();
+    expect(screen.getByTestId('hdr-share')).toBeInTheDocument();
+    expect(screen.getByTestId('hdr-menu')).toBeInTheDocument();
+    expect(screen.getByTestId('search-palette-trigger-header')).toBeInTheDocument();
+  });
+});
+
+// spec-192 t-4 (ac-7): the sidebar (non-doc layout) carries NO search trigger —
+// discovery on list views lives on the Specs board (SpecList), not the shell.
+function renderSidebarShell() {
+  return render(
+    <ThemeProvider>
+      <MemoryRouter initialEntries={['/alice/personal/specs']}>
+        <SearchProvider>
+          <AppShell>
+            <div data-testid="page-content">page</div>
+          </AppShell>
+        </SearchProvider>
+      </MemoryRouter>
+    </ThemeProvider>,
+  );
+}
+
+describe('spec-192 t-4: sidebar has no search trigger (ac-7)', () => {
+  it('renders the sidebar but no search trigger of either variant', () => {
+    tagAc(AC(7));
+    renderSidebarShell();
+    // Sidebar IS shown on a non-doc route...
+    expect(screen.getByTestId('primary-nav')).toBeInTheDocument();
+    // ...and the shell itself adds no search trigger.
+    expect(screen.queryByTestId('search-palette-trigger-board')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('search-palette-trigger-header')).not.toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/AppShell.tsx
+++ b/packages/ui/src/components/AppShell.tsx
@@ -10,6 +10,7 @@ import { InviteMembersDialog } from './InviteMembersDialog';
 import { PublicAuthButtons, ReadOnlyBadge } from './PublicAccessControls';
 import { useMemexAccess } from '../hooks/useMemexAccess';
 import { HeaderSlotProvider, useHeaderSlotContent } from './HeaderSlot';
+import { SearchTrigger } from './SearchTrigger';
 import {
   getCurrentTenant,
   parseTenantFromPathname,
@@ -381,26 +382,35 @@ function NavItem({
 
 // Doc-page header. Renders inside HeaderSlotProvider so it can read the
 // page-supplied right-side actions (status dropdown, share, download, menu).
+// spec-192 t-3 (dec-2): the sidebar is hidden on doc pages, so the search trigger
+// lives here. It sits as its OWN full-height flex column at the far right, AFTER
+// the page actions (which stay in the flex-1 inner row) — so the borderless
+// recess bleeds to the bar's top/bottom/right edges and can never overlap the
+// Edit / Share / download / ⋯ controls (ac-11). The bar's background + border +
+// blur move to the outer <header> so they sit behind the trigger too.
 function DocPageHeader() {
   const slot = useHeaderSlotContent();
   const { session } = useAuth();
   const { pathname } = useLocation();
   const specsHref = resolveNavTo('/specs', pathname, session?.memberships);
   return (
-    <header className="border-b flex-none px-6 py-3 flex items-center gap-8 backdrop-blur-sm border-edge bg-page/80">
-      <Link
-        to={specsHref}
-        className="text-lg font-semibold tracking-tight text-heading hover:text-heading"
-      >
-        memex<span className="text-[#7b93b8]">.ai</span>
-      </Link>
-      <Link
-        to={specsHref}
-        className="text-sm transition-colors text-muted hover:text-primary"
-      >
-        &larr; All specs
-      </Link>
-      {slot && <div className="ml-auto flex items-center gap-2">{slot}</div>}
+    <header className="border-b flex-none flex items-stretch backdrop-blur-sm border-edge bg-page/80">
+      <div className="flex-1 min-w-0 flex items-center gap-8 px-6 py-3">
+        <Link
+          to={specsHref}
+          className="text-lg font-semibold tracking-tight text-heading hover:text-heading"
+        >
+          memex<span className="text-[#7b93b8]">.ai</span>
+        </Link>
+        <Link
+          to={specsHref}
+          className="text-sm transition-colors text-muted hover:text-primary"
+        >
+          &larr; All specs
+        </Link>
+        {slot && <div className="ml-auto flex items-center gap-2">{slot}</div>}
+      </div>
+      <SearchTrigger variant="doc-header" />
     </header>
   );
 }

--- a/packages/ui/src/components/SearchContext.spec-192.test.tsx
+++ b/packages/ui/src/components/SearchContext.spec-192.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { SearchProvider, useSearch } from './SearchContext';
+
+// spec-192 t-1: the ⌘K open-state was lifted out of App.tsx's GlobalSearchHost
+// into SearchProvider so the chrome (Specs-board + doc-page triggers) can open
+// the one palette. These tests prove the lift preserved the shortcut and that a
+// non-host component drives the same single palette instance (Scope ac-2).
+
+const AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-192/acs/ac-${n}`;
+
+const DIALOG = { name: 'Search this memex' } as const;
+
+// A minimal chrome consumer — stands in for the real triggers, proving a
+// component OTHER than the provider can drive the open-state via context.
+function OpenButton() {
+  const search = useSearch();
+  return (
+    <button data-testid="open-search" onClick={() => search?.openSearch()}>
+      open
+    </button>
+  );
+}
+
+function renderProvider() {
+  return render(
+    <MemoryRouter>
+      <SearchProvider>
+        <OpenButton />
+      </SearchProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe('spec-192 t-1: lifted ⌘K open-state (SearchProvider)', () => {
+  it('a non-host component opens the one palette via openSearch(), no second instance (ac-2)', async () => {
+    tagAc(AC(2));
+    renderProvider();
+    expect(screen.queryByRole('dialog', DIALOG)).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('open-search'));
+
+    expect(await screen.findByRole('dialog', DIALOG)).toBeInTheDocument();
+    // One palette, one source of truth — never a second dialog instance.
+    expect(screen.getAllByRole('dialog', DIALOG)).toHaveLength(1);
+  });
+
+  it('⌘K still toggles the palette (spec-64 ac-16 preserved through the lift)', async () => {
+    renderProvider();
+    expect(screen.queryByRole('dialog', DIALOG)).not.toBeInTheDocument();
+
+    fireEvent.keyDown(window, { key: 'k', metaKey: true });
+    expect(await screen.findByRole('dialog', DIALOG)).toBeInTheDocument();
+
+    fireEvent.keyDown(window, { key: 'k', metaKey: true });
+    await waitFor(() =>
+      expect(screen.queryByRole('dialog', DIALOG)).not.toBeInTheDocument(),
+    );
+  });
+
+  it('Ctrl K (non-mac modifier) also opens the palette', async () => {
+    renderProvider();
+    fireEvent.keyDown(window, { key: 'k', ctrlKey: true });
+    expect(await screen.findByRole('dialog', DIALOG)).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/SearchContext.tsx
+++ b/packages/ui/src/components/SearchContext.tsx
@@ -1,0 +1,92 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+import { SearchPalette } from './SearchPalette';
+
+// spec-192 t-1 (ac-2 / ac-8 / ac-10): the global ⌘K search open-state lives here
+// so the app chrome — the Specs board header (SpecList) and the doc-page header
+// (AppShell) — can open the SAME palette instance the keyboard shortcut toggles.
+// One palette, one source of truth: a single <SearchPalette> mount and a single
+// `open` boolean, exposed to the chrome via `openSearch()` on this context.
+//
+// Lifted verbatim out of spec-64's GlobalSearchHost (App.tsx): the ⌘K / Ctrl K
+// keydown listener (spec-64 ac-16) and the open/close focus-restoration
+// (spec-64 ac-8) are preserved unchanged — only their home moved from a leaf host
+// to this provider so the open-state is reachable from the chrome above the
+// router. SearchPalette's controlled `open`/`onOpenChange` contract is unchanged.
+
+interface SearchContextValue {
+  /** Whether the command palette is currently open. */
+  open: boolean;
+  /** Open the palette (the chrome triggers + the ⌘K shortcut all call this). */
+  openSearch: () => void;
+  /** Close the palette. */
+  closeSearch: () => void;
+}
+
+const SearchContext = createContext<SearchContextValue | null>(null);
+
+// Returns the palette controls, or null when called outside a SearchProvider
+// (e.g. an isolated component test that renders a trigger without the provider).
+// Callers null-guard so a trigger renders inertly rather than throwing.
+export function useSearch(): SearchContextValue | null {
+  return useContext(SearchContext);
+}
+
+export function SearchProvider({ children }: { children: ReactNode }) {
+  const [open, setOpen] = useState(false);
+  const openRef = useRef(false);
+  const restoreFocusRef = useRef<HTMLElement | null>(null);
+
+  // spec-64 ac-8: the palette opens programmatically (no Radix Dialog.Trigger),
+  // so Radix has nothing to restore focus to on close — it would fall to <body>.
+  // Capture the focused element on open and hand it back on close, whether the
+  // close came from Esc, an overlay click, a ⌘K toggle, or a trigger click.
+  const setOpenSafe = useCallback((next: boolean) => {
+    if (next && !openRef.current) {
+      restoreFocusRef.current = document.activeElement as HTMLElement | null;
+    }
+    openRef.current = next;
+    setOpen(next);
+    if (!next) {
+      const el = restoreFocusRef.current;
+      restoreFocusRef.current = null;
+      // Restore on the next frame, after Radix's own close-autofocus (which
+      // targets the absent trigger) has run — so our restore wins.
+      if (el && typeof el.focus === 'function') {
+        requestAnimationFrame(() => el.focus());
+      }
+    }
+  }, []);
+
+  // spec-64 ac-16: the app-level ⌘K / Ctrl K hotkey. A thin window listener owns
+  // the shortcut and preventDefault()s so the browser/cmdk never sees it; it
+  // toggles the single open-state. Mounted app-wide so the omnibox is reachable
+  // from any route.
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if ((e.metaKey || e.ctrlKey) && (e.key === 'k' || e.key === 'K')) {
+        e.preventDefault();
+        setOpenSafe(!openRef.current);
+      }
+    }
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [setOpenSafe]);
+
+  const openSearch = useCallback(() => setOpenSafe(true), [setOpenSafe]);
+  const closeSearch = useCallback(() => setOpenSafe(false), [setOpenSafe]);
+
+  return (
+    <SearchContext.Provider value={{ open, openSearch, closeSearch }}>
+      {children}
+      <SearchPalette open={open} onOpenChange={setOpenSafe} />
+    </SearchContext.Provider>
+  );
+}

--- a/packages/ui/src/components/SearchTrigger.spec-192.test.tsx
+++ b/packages/ui/src/components/SearchTrigger.spec-192.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { ThemeProvider } from './ThemeContext';
+import { SearchTrigger, searchKeycapLabel, type SearchTriggerVariant } from './SearchTrigger';
+
+// spec-192 t-2: the shared SearchTrigger button. dec-3 fixes that it is a button
+// (never an inline input — ac-12) carrying a platform-aware keycap (ac-13).
+
+const AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-192/acs/ac-${n}`;
+
+function renderTrigger(variant: SearchTriggerVariant) {
+  return render(
+    <ThemeProvider>
+      <SearchTrigger variant={variant} />
+    </ThemeProvider>,
+  );
+}
+
+// Stub navigator.platform for the OS-branch test, then restore it.
+function withPlatform(platform: string, fn: () => void) {
+  const desc = Object.getOwnPropertyDescriptor(navigator, 'platform');
+  Object.defineProperty(navigator, 'platform', { value: platform, configurable: true });
+  try {
+    fn();
+  } finally {
+    if (desc) Object.defineProperty(navigator, 'platform', desc);
+  }
+}
+
+describe('spec-192 t-2: SearchTrigger', () => {
+  it('renders as a <button>, never an inline input (ac-12)', () => {
+    tagAc(AC(12));
+
+    tagAc(AC(3)); // scope ac-3: the trigger is a button, never an inline search input
+    const { container, unmount } = renderTrigger('spec-board');
+    const board = screen.getByTestId('search-palette-trigger-board');
+    expect(board.tagName).toBe('BUTTON');
+    expect(container.querySelector('input')).toBeNull();
+    unmount();
+
+    const { container: c2 } = renderTrigger('doc-header');
+    const header = screen.getByTestId('search-palette-trigger-header');
+    expect(header.tagName).toBe('BUTTON');
+    expect(c2.querySelector('input')).toBeNull();
+  });
+
+  it('keycap label is OS-derived — ⌘K on Apple platforms, Ctrl K elsewhere (ac-13)', () => {
+    tagAc(AC(13));
+    tagAc(AC(5)); // scope ac-5: the keycap reflects the user's OS
+    // Apple platforms → ⌘K (the OS check also matches iPhone/iPad).
+    withPlatform('MacIntel', () => expect(searchKeycapLabel()).toBe('⌘K'));
+    withPlatform('iPhone', () => expect(searchKeycapLabel()).toBe('⌘K'));
+    // Everything else → Ctrl K.
+    withPlatform('Win32', () => expect(searchKeycapLabel()).toBe('Ctrl K'));
+    withPlatform('Linux x86_64', () => expect(searchKeycapLabel()).toBe('Ctrl K'));
+  });
+
+  it('renders the derived keycap label inside the button', () => {
+    withPlatform('MacIntel', () => {
+      renderTrigger('spec-board');
+      expect(screen.getByTestId('search-palette-trigger-board')).toHaveTextContent('⌘K');
+    });
+  });
+});

--- a/packages/ui/src/components/SearchTrigger.tsx
+++ b/packages/ui/src/components/SearchTrigger.tsx
@@ -1,0 +1,104 @@
+import { useThemeName } from './ThemeContext';
+import { useSearch } from './SearchContext';
+
+// spec-192 t-2 (dec-3 / ac-12 / ac-13): the shared search trigger button used by
+// BOTH surfaces — the Specs board header (a contained recess pill) and the
+// doc-page header (a borderless edge-bleed recess). It is ALWAYS a <button> that
+// opens the palette via the shared open-state (SearchContext.openSearch); it is
+// NEVER an inline input — search happens only inside the palette (the user's hard
+// constraint). The keycap is platform-aware: ⌘K on macOS, Ctrl K elsewhere
+// (App's listener already accepts both metaKey and ctrlKey, so this is label-only).
+
+export type SearchTriggerVariant = 'spec-board' | 'doc-header';
+
+// ⌘K on Apple platforms, Ctrl K everywhere else. Read at call time so a test can
+// stub navigator before render. `userAgentData.platform` is preferred where
+// present (navigator.platform is deprecated), with sensible fallbacks.
+export function searchKeycapLabel(): string {
+  if (typeof navigator === 'undefined') return 'Ctrl K';
+  const nav = navigator as Navigator & { userAgentData?: { platform?: string } };
+  const platform = nav.userAgentData?.platform || nav.platform || nav.userAgent || '';
+  return /mac|iphone|ipad|ipod/i.test(platform) ? '⌘K' : 'Ctrl K';
+}
+
+function SearchIcon() {
+  return (
+    <svg
+      className="w-4 h-4 flex-none"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      strokeWidth={1.75}
+      aria-hidden="true"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M21 21l-4.35-4.35m1.6-5.4a7 7 0 11-14 0 7 7 0 0114 0z"
+      />
+    </svg>
+  );
+}
+
+const TEST_IDS: Record<SearchTriggerVariant, string> = {
+  'spec-board': 'search-palette-trigger-board',
+  'doc-header': 'search-palette-trigger-header',
+};
+
+export function SearchTrigger({ variant }: { variant: SearchTriggerVariant }) {
+  const search = useSearch();
+  // useThemeName (not useTheme) is the provider-tolerant read: SearchTrigger is a
+  // leaf in SpecList / DocPageHeader, and several existing unit tests mount those
+  // WITHOUT a ThemeProvider. It defaults to 'dark' when no provider is present;
+  // inside the app the provider always exists, so theme switching stays live.
+  const isDark = useThemeName() === 'dark';
+  const label = searchKeycapLabel();
+
+  // Bespoke per-theme values from spec-192 s-6 (validated against the index.css
+  // tokens). The recess starts at the page background (--color-page) and
+  // gradients into a darker shade; the keycap is a small inset cap. These are the
+  // only non-token values — everything else follows the theme tokens.
+  const recessEnd = isDark ? '#121419' : '#e7ebf1';
+  const recessStyle = {
+    backgroundImage: `linear-gradient(to right, rgb(var(--color-page)) 0%, ${recessEnd} 100%)`,
+  };
+  const keycapStyle = isDark
+    ? { backgroundColor: 'rgba(62,68,81,.55)', borderColor: '#4b525f', color: '#cbd5e1', borderBottomWidth: 2 }
+    : { backgroundColor: '#f1f5f9', borderColor: '#cbd5e1', color: '#475569', borderBottomWidth: 2 };
+
+  const common =
+    'group inline-flex items-center gap-2 text-sm text-secondary transition-colors hover:text-primary focus-visible:outline-none focus-visible:text-primary';
+
+  // doc-header: fills the bar height (self-stretch) and sits as its own flex
+  // column at the far right of DocPageHeader, so the recess bleeds to the top/
+  // bottom/right bar edges and never overlaps the Edit/Share/download/⋯ controls.
+  // spec-board: a self-contained rounded recess pill, sized to the Button md
+  // height (px-3 py-1.5) so it sits cleanly at the end of the actions row.
+  const variantClass =
+    variant === 'doc-header' ? 'self-stretch px-5' : 'rounded-lg px-3 py-1.5';
+
+  return (
+    <button
+      type="button"
+      data-testid={TEST_IDS[variant]}
+      data-variant={variant}
+      onClick={() => search?.openSearch()}
+      aria-label="Search (open command palette)"
+      title="Search"
+      style={recessStyle}
+      className={`${common} ${variantClass}`}
+    >
+      <SearchIcon />
+      {/* Decorative shortcut hint: the button's aria-label ("Search (open
+          command palette)") already carries the accessible name, so the keycap is
+          aria-hidden to avoid a confusing "Command K" announcement. */}
+      <kbd
+        aria-hidden="true"
+        style={keycapStyle}
+        className="rounded border px-1.5 py-0.5 text-[11px] font-medium leading-none"
+      >
+        {label}
+      </kbd>
+    </button>
+  );
+}

--- a/packages/ui/src/pages/SpecList.spec-192.test.tsx
+++ b/packages/ui/src/pages/SpecList.spec-192.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { tagAc } from '@memex-ai-ac/vitest';
+import type { SessionPayload } from '../api/client';
+import { ThemeProvider } from '../components/ThemeContext';
+import { SearchProvider } from '../components/SearchContext';
+
+// spec-192 t-4: the Specs board search trigger (ac-8). Wired in SpecList's
+// PageHeader actions; clicking it opens the same palette the ⌘K shortcut does.
+
+const AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-192/acs/ac-${n}`;
+const DIALOG = { name: 'Search this memex' } as const;
+
+vi.mock('../hooks/useDocChangeStream', () => ({ useDocChangeStream: () => {} }));
+
+const fetchDocsMock = vi.fn();
+vi.mock('../api/client', () => ({
+  fetchDocs: (...args: unknown[]) => fetchDocsMock(...args),
+  updateDocStatus: vi.fn(),
+  archiveDoc: vi.fn(),
+  pauseDoc: vi.fn(),
+  unpauseDoc: vi.fn(),
+  resetHandholdDemo: vi.fn(),
+}));
+vi.mock('../components/NewSpecModal', () => ({ NewSpecModal: () => null }));
+vi.mock('../components/ShareModal', () => ({ ShareModal: () => null }));
+vi.mock('../components/RenameSpecDialog', () => ({ RenameSpecDialog: () => null }));
+vi.mock('../components/MoveSpecDialog', () => ({ MoveSpecDialog: () => null }));
+
+const { mockSession } = vi.hoisted(() => ({
+  mockSession: { value: null as SessionPayload | null },
+}));
+vi.mock('../components/AuthContext', () => ({
+  useAuth: () => ({ session: mockSession.value }),
+}));
+
+const { mockCanWrite } = vi.hoisted(() => ({ mockCanWrite: { value: false } }));
+vi.mock('../hooks/useMemexAccess', () => ({
+  useMemexAccess: () => ({
+    isAuthenticated: false,
+    membership: null,
+    canWrite: mockCanWrite.value,
+    isReadOnly: !mockCanWrite.value,
+    isVisitedReadOnly: false,
+  }),
+}));
+
+import { SpecList } from './SpecList';
+
+beforeEach(() => {
+  fetchDocsMock.mockResolvedValue([]);
+  mockSession.value = null;
+  mockCanWrite.value = false;
+});
+
+function renderBoard() {
+  return render(
+    <ThemeProvider>
+      <MemoryRouter>
+        <SearchProvider>
+          <SpecList />
+        </SearchProvider>
+      </MemoryRouter>
+    </ThemeProvider>,
+  );
+}
+
+describe('spec-192 t-4: Specs board search trigger', () => {
+  it('renders the trigger in the board header and clicking it opens the palette (ac-8)', async () => {
+    tagAc(AC(8));
+    tagAc(AC(1)); // scope ac-1: a persistent, visible trigger exists on the Specs board
+    renderBoard();
+
+    const trigger = await screen.findByTestId('search-palette-trigger-board');
+    expect(screen.queryByRole('dialog', DIALOG)).not.toBeInTheDocument();
+
+    fireEvent.click(trigger);
+    expect(await screen.findByRole('dialog', DIALOG)).toBeInTheDocument();
+  });
+
+  it('shows the trigger even for read-only users (search is a read action, not gated on canWrite)', async () => {
+    mockCanWrite.value = false;
+    renderBoard();
+    expect(await screen.findByTestId('search-palette-trigger-board')).toBeInTheDocument();
+    // The write-gated "+ New Spec" button is absent, but the search trigger is not.
+    expect(screen.queryByRole('button', { name: /New Spec/i })).not.toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/pages/SpecList.tsx
+++ b/packages/ui/src/pages/SpecList.tsx
@@ -22,6 +22,7 @@ import { useIsFeatureHidden } from '../hooks/useIsFeatureHidden';
 import { useMemexAccess } from '../hooks/useMemexAccess';
 import { CreateOrgBanner } from '../components/CreateOrgBanner';
 import { PageHeader } from '../components/PageHeader';
+import { SearchTrigger } from '../components/SearchTrigger';
 import {
   borderClassForHealth,
   SpecHealthChip,
@@ -811,6 +812,12 @@ export function SpecList() {
               </Button>
             )}
             {canWrite && <Button onClick={() => setModalOpen(true)}>+ New Spec</Button>}
+            {/* spec-192 t-4 (dec-1): the Specs board is the ONLY list page that
+                carries a search trigger, and it's wired HERE in SpecList — not in
+                the shared PageHeader — so no other list page (Issues / Standards /
+                Insights / Pulse) gets one. Shown to everyone (search is a read
+                action), so it is NOT gated on canWrite. */}
+            <SearchTrigger variant="spec-board" />
           </>
         }
       />

--- a/packages/ui/src/pages/listPagesNoTrigger.spec-192.test.tsx
+++ b/packages/ui/src/pages/listPagesNoTrigger.spec-192.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { PageHeader } from '../components/PageHeader';
+import { StandardList } from './StandardList';
+import { IssuesList } from './IssuesList';
+
+// spec-192 t-4 (ac-9): the search trigger is wired in SpecList ONLY, never the
+// shared PageHeader — so no OTHER list page carries one. We render the REAL
+// (UNMOCKED) PageHeader directly, plus the real Issues and Standards pages, so a
+// trigger leaking via the shared component — the exact failure ac-9 guards —
+// would be caught rather than hidden behind a PageHeader stub.
+//
+// In-scope list pages: Specs (HAS the trigger — see SpecList.spec-192.test.tsx),
+// Issues, Standards. Pulse / Insights / Scaffold / Drift also render through this
+// same shared PageHeader, so the direct-PageHeader assertion below covers them
+// transitively (none add a trigger locally).
+
+const AC9 = 'mindset-prod/memex-building-itself/specs/spec-192/acs/ac-9';
+
+vi.mock('../hooks/useDocChangeStream', () => ({ useDocChangeStream: () => {} }));
+vi.mock('../components/StandardsMap', () => ({
+  StandardsMap: () => <div data-testid="mock-standards-map" />,
+}));
+vi.mock('../components/NewSpecModal', () => ({ NewSpecModal: () => null }));
+
+// Real PageHeader reads useAuth for the breadcrumb — give it a session so it
+// renders (getCurrentTenant + useAnonymousPublicMemex are null-safe without
+// providers). We deliberately DON'T mock PageHeader: that's the whole point.
+vi.mock('../components/AuthContext', async () => {
+  const real = await vi.importActual<typeof import('../components/AuthContext')>(
+    '../components/AuthContext',
+  );
+  return {
+    ...real,
+    useAuth: () => ({
+      session: {
+        user: { id: 'u-1', email: 'a@example.com', name: 'Alice', status: 'active', emailVerified: true },
+        memberships: [
+          { memexId: 'mx-1', slug: 'alice', memexSlug: 'personal', name: 'Personal Memex', kind: 'personal', role: 'administrator' },
+        ],
+        currentMemexId: 'mx-1',
+        currentRole: 'administrator',
+        needsOnboarding: false,
+        hiddenFeatures: [],
+      },
+    }),
+  };
+});
+
+const fetchDocsMock = vi.fn();
+const fetchMemexIssuesMock = vi.fn();
+vi.mock('../api/client', () => ({
+  fetchDocs: (...a: unknown[]) => fetchDocsMock(...a),
+  fetchMemexIssues: (...a: unknown[]) => fetchMemexIssuesMock(...a),
+  updateIssueStatusApi: vi.fn(),
+}));
+
+beforeEach(() => {
+  fetchDocsMock.mockResolvedValue([]);
+  fetchMemexIssuesMock.mockResolvedValue([]);
+});
+
+function expectNoTrigger() {
+  expect(screen.queryByTestId('search-palette-trigger-board')).not.toBeInTheDocument();
+  expect(screen.queryByTestId('search-palette-trigger-header')).not.toBeInTheDocument();
+}
+
+describe('spec-192 t-4: only the Specs board carries a search trigger (ac-9)', () => {
+  it('the SHARED PageHeader renders no search trigger (so no list page inherits one)', () => {
+    tagAc(AC9);
+    render(
+      <MemoryRouter>
+        <PageHeader title="Issues" actions={<button>an action</button>} />
+      </MemoryRouter>,
+    );
+    expectNoTrigger();
+  });
+
+  it('the Standards page header has no search trigger', async () => {
+    tagAc(AC9);
+    render(
+      <MemoryRouter>
+        <StandardList />
+      </MemoryRouter>,
+    );
+    await screen.findByRole('heading', { level: 1, name: 'Standards' });
+    expectNoTrigger();
+  });
+
+  it('the Issues page header has no search trigger', async () => {
+    tagAc(AC9);
+    render(
+      <MemoryRouter initialEntries={['/acme/main/issues']}>
+        <Routes>
+          <Route path="/:namespace/:memex/issues" element={<IssuesList />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+    await screen.findByRole('heading', { level: 1, name: 'Issues' });
+    expectNoTrigger();
+  });
+});


### PR DESCRIPTION
## What
Adds persistent, discoverable **search triggers** that open the existing spec-64 ⌘K command palette — so users can find search without already knowing the shortcut. Two surfaces:

- **Specs board header** — a contained recess pill (wired in `SpecList`, not the shared `PageHeader`).
- **Doc-page header** — a borderless full-height recess at the far right (the sidebar is hidden on doc pages).

Both are **buttons, never inline inputs** (search happens only inside the palette), and share **one** palette open-state with the ⌘K / Ctrl K shortcut. Platform-aware keycap (⌘K mac / Ctrl K else).

Implements [spec-192](https://memex.ai/mindset-prod/memex-building-itself/specs/spec-192).

## How
- Lifted spec-64's `GlobalSearchHost` (open-state + ⌘K listener + focus-restoration) into a `SearchProvider` (`components/SearchContext.tsx`) wrapping the router; exposes `openSearch()` — one palette, one source of truth.
- New shared `SearchTrigger` (two variants, platform keycap, `useThemeName`).
- `DocPageHeader` restructured so the trigger is a full-height flex sibling that can't clip the Edit / Share / ⋯ controls.

## Tests
- 5 new vitest files + journey-18 extended with both triggers.
- Full UI suite green (1008), `tsc -b` clean, `make e2e-cold` green (44 journeys).
- spec-192 ACs ac-1…ac-13 tagged + **13/13 verified** on prod.

## Notes
- No sidebar trigger (dec-1) and no trigger on other list pages (ac-9) — the Specs board is the single list-page home for discovery.
- UI-only; reuses spec-64's palette / route / search core (no new route, data, or auth surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
