### PR TITLE
test(server): co-tag spec-153 scope ACs ac-3/ac-5 (unblock done)

### DIFF
--- a/packages/server/src/services/comments.integration.test.ts
+++ b/packages/server/src/services/comments.integration.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, afterAll, beforeAll } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
 import { eq } from "drizzle-orm";
 import { db } from "../db/connection.js";
 import { documents, docSections, docComments } from "../db/schema.js";
@@ -21,6 +22,15 @@ import { createTask } from "./tasks.js";
 import { NotFoundError, ValidationError } from "../types/errors.js";
 import { COMMENT_TYPES } from "../types/roles.js";
 import { makeTestMemex } from "./test-helpers.js";
+
+// spec-153 scope guarantees (soft-launch UI-only slice): removing the human
+// comment-type picker is purely front-end. ac-5 — the add_comment write contract
+// and the comment_type column/CHECK constraint are unchanged (human → freeform
+// discussion; the full taxonomy still round-trips). ac-3 — the agent/system typed
+// channel (drift, plan_revision, readiness_check, cross_reference, progress) is
+// unaffected. These are asserted by the existing real-DB tests below.
+const SPEC_153_AC3 = "mindset-prod/memex-building-itself/specs/spec-153/acs/ac-3";
+const SPEC_153_AC5 = "mindset-prod/memex-building-itself/specs/spec-153/acs/ac-5";
 
 const createdDocIds: string[] = [];
 
@@ -330,6 +340,10 @@ describe("listCommentsForDoc with decisions and tasks", () => {
 
 describe("backfill: comment_type and source defaults (Section 7)", () => {
   it("omitted commentType + source default to discussion/human", async () => {
+    // spec-153 ac-5: the add_comment write contract is unchanged — a human comment
+    // with no type omitted lands as a freeform (discussion, human), which is exactly
+    // what removing the composer's type picker relies on.
+    tagAc(SPEC_153_AC5);
     const doc = await createDocDraft(memexId, "Backfill defaults", "Purpose");
     createdDocIds.push(doc.id);
 
@@ -380,6 +394,12 @@ describe("backfill: comment_type and source defaults (Section 7)", () => {
 
 describe("typed comments: 12-type round-trip", () => {
   it("persists every COMMENT_TYPES value end-to-end on a section comment", async () => {
+    // spec-153 ac-5: the comment_type column + its CHECK constraint are unchanged —
+    // the full 12-value taxonomy still round-trips (no schema/taxonomy migration).
+    // spec-153 ac-3: the agent/system channel (drift, plan_revision, readiness_check,
+    // cross_reference, progress) is still emitted and consumed unchanged.
+    tagAc(SPEC_153_AC5);
+    tagAc(SPEC_153_AC3);
     const doc = await createDocDraft(memexId, "All-types section doc", "Purpose");
     createdDocIds.push(doc.id);
     const sectionId = doc.sections[0].id;

--- a/packages/server/src/services/drift-inbox.integration.test.ts
+++ b/packages/server/src/services/drift-inbox.integration.test.ts
@@ -12,6 +12,10 @@ import { listDriftInbox } from "./drift-inbox.js";
 import { makeTestMemex } from "./test-helpers.js";
 
 const SPEC_143 = "mindset-prod/memex-building-itself/specs/spec-143";
+// spec-153 ac-3 (scope guarantee): removing the human comment-type picker left
+// the agent/system typed-comment channel and the Drift Inbox untouched — drift +
+// plan_revision are still emitted and consumed by the inbox exactly as before.
+const SPEC_153_AC3 = "mindset-prod/memex-building-itself/specs/spec-153/acs/ac-3";
 
 const createdDocIds: string[] = [];
 let memexId: string;
@@ -32,6 +36,9 @@ afterAll(async () => {
 // `c.memex_id` (column renamed by migration 0038). Source-fix landed; unskipping.
 describe("listDriftInbox", () => {
   it("returns open drift + plan_revision comments with parent doc/section context", async () => {
+    // spec-153 ac-3: the machine-emitted channel + Drift Inbox are unaffected by
+    // the removal of the human composer's type picker.
+    tagAc(SPEC_153_AC3);
     const std = await createStandard(memexId, {
       title: "Inbox target",
       sections: [


### PR DESCRIPTION
## Why

spec-153 (remove the human comment-type picker) is **shipped to PROD** and sits in \`verify\`, but it can't move to \`done\`: two of its five scope ACs are at **0 tests**, so coverage is 60% and the gate won't pass.

Both are *boundary-guarantee* scope ACs — they assert what the UI-only change **did not** touch — and the invariants are already covered by existing, passing real-DB tests. They were just never tagged. This is the same label-only cleanup as spec-185 (#54) and spec-194 (#55).

## What

No production code. Only \`tagAc(...)\` added to tests that already pass:

| AC | Tagged test | Proves |
|---|---|---|
| **ac-3** — agent/system channel + Drift Inbox unchanged | \`drift-inbox.integration.test.ts\` → "returns open drift + plan_revision comments…" | drift + plan_revision emitted/consumed; Drift Inbox works |
| **ac-3** | \`comments.integration.test.ts\` → "persists every COMMENT_TYPES value end-to-end" | readiness_check / cross_reference / progress (full agent taxonomy) persist via source=agent |
| **ac-5** — \`add_comment\` write contract + \`comment_type\` column/CHECK unchanged, no migration | \`comments.integration.test.ts\` → "omitted commentType + source default to discussion/human" | human write contract intact (no type → freeform \`discussion\`) |
| **ac-5** | \`comments.integration.test.ts\` → "persists every COMMENT_TYPES value end-to-end" | CHECK constraint still accepts the full 12-value taxonomy (schema intact) |

## Verification

- \`tsc -b\` clean for the edited files (only the pre-existing \`discord-webhook.test.ts\` error remains on develop — unrelated).
- All three affected files green locally: **53/53** (\`MEMEX_EMIT=false\`).
- On merge, the CI \`server\` job re-emits the tagged events to \`memex.ai\` → ac-3/ac-5 flip green → spec-153 reaches 100% coverage and is ready for the human to flip → \`done\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)