### PR TITLE
fix(ac-emit-vitest): publish-exports leak + 0.2.0 bump (follow-up to #60)

### DIFF
--- a/packages/ac-emit-vitest/package.json
+++ b/packages/ac-emit-vitest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memex-ai-ac/vitest",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "Acceptance Criteria emit helper for Vitest. Tag tests with tagAc(), emit pass/fail to a Memex workspace.",
   "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "https://memex.ai",

--- a/packages/ac-emit-vitest/src/published-exports.test.ts
+++ b/packages/ac-emit-vitest/src/published-exports.test.ts
@@ -1,0 +1,45 @@
+// spec-90 — guard the published artifact's exports.
+//
+// Commit 01215fe added a `development: ./src/index.ts` condition to the
+// top-level exports so workspace consumers resolve TS source (a stale dist
+// can't silently drop the emission key). But Vite/Vitest sets the `development`
+// condition for EXTERNAL consumers too, and `src/` is not shipped (files =
+// dist/README/LICENSE) — so an `npm install`ed consumer's import resolved to a
+// missing `./src/index.ts` and failed: "Failed to resolve entry for package".
+// This was caught by packing the tarball and importing it from a throwaway
+// consumer; the in-repo tests never saw it because they resolve the same
+// `development` condition against the real on-disk src.
+//
+// Fix: keep `development->src` at the top level (for the workspace) but override
+// the published manifest via `publishConfig.exports` (dist-only). pnpm applies
+// publishConfig field overrides at pack/publish time. These assertions pin that
+// the published exports never reference src again.
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const pkg = JSON.parse(
+  readFileSync(fileURLToPath(new URL("../package.json", import.meta.url)), "utf8"),
+) as {
+  files?: string[];
+  exports?: Record<string, unknown>;
+  publishConfig?: { exports?: Record<string, unknown> };
+};
+
+describe("published package exports are dist-only (no src leak)", () => {
+  it("publishConfig.exports overrides the workspace dev exports and references no ./src", () => {
+    const pub = pkg.publishConfig?.exports;
+    expect(pub, "publishConfig.exports must shadow the development->src exports at publish").toBeTruthy();
+    const json = JSON.stringify(pub);
+    expect(json).not.toMatch(/src\//);
+    expect(json).not.toMatch(/development/);
+    expect(json).toMatch(/dist\/index\.js/);
+    expect(json).toMatch(/dist\/setup\.js/);
+  });
+
+  it("the package ships dist (and never src)", () => {
+    expect(pkg.files ?? []).toContain("dist");
+    expect(pkg.files ?? []).not.toContain("src");
+  });
+});


### PR DESCRIPTION
## Why this exists (follow-up to #60)

#60 merged with the brief→spec sweep + A1/B1. **This one commit (`feba3e2`) missed that merge** — it was pushed to the branch *after* #60 was already merged, so it never entered `develop`. It is the publish-blocker fix surfaced by pre-publish artifact testing.

## What's in here

`@memex-ai-ac/vitest` as it sits on `develop` would publish a **broken-for-consumers** artifact:
- `exports."."` carries `development → ./src/index.ts` (added in 01215fe so the *workspace* resolves TS source).
- Vite/Vitest sets the `development` condition for **external** consumers too, but `src/` is not shipped (`files = dist/README/LICENSE`).
- Result: a real `npm install` consumer's import fails — `Failed to resolve entry for package "@memex-ai-ac/vitest"`. The in-repo tests never catch it because they resolve that condition against on-disk `src`.

**Fix:** keep `development → src` at the top level (workspace behaviour from 01215fe preserved) and add `publishConfig.exports` (dist-only). `pnpm` applies `publishConfig` field overrides at pack/publish, so the **published** manifest is dist-only while the workspace still resolves `src`. Bumps `0.1.3 → 0.2.0` (B1 routing behaviour change). Adds `published-exports.test.ts` to pin that the published exports never reference `src` again.

## Empirical proof
- Packed with `pnpm pack`; tarball manifest is dist-only; installed in a throwaway consumer → **6/6** (B1 routing on dist, `emit()` wire format over real HTTP, setup hook fires).
- Workspace (`development → src`) still green; package suite **69/69**.

## ⚠️ Publish note
Publish with **`pnpm publish`**, not `npm publish` — npm ignores `publishConfig` field overrides, which would re-introduce the `dev→src` leak. And deploy server A1 (already on `develop` via #60) to memex.ai before publishing, so client B1 emissions actually land.