### PR TITLE
Release: ac-emit-vitest publish-exports fix + 0.2.0 (develop → main)

### DIFF
--- a/packages/ac-emit-vitest/package.json
+++ b/packages/ac-emit-vitest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memex-ai-ac/vitest",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "Acceptance Criteria emit helper for Vitest. Tag tests with tagAc(), emit pass/fail to a Memex workspace.",
   "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "https://memex.ai",

--- a/packages/ac-emit-vitest/src/published-exports.test.ts
+++ b/packages/ac-emit-vitest/src/published-exports.test.ts
@@ -1,0 +1,45 @@
+// spec-90 — guard the published artifact's exports.
+//
+// Commit 01215fe added a `development: ./src/index.ts` condition to the
+// top-level exports so workspace consumers resolve TS source (a stale dist
+// can't silently drop the emission key). But Vite/Vitest sets the `development`
+// condition for EXTERNAL consumers too, and `src/` is not shipped (files =
+// dist/README/LICENSE) — so an `npm install`ed consumer's import resolved to a
+// missing `./src/index.ts` and failed: "Failed to resolve entry for package".
+// This was caught by packing the tarball and importing it from a throwaway
+// consumer; the in-repo tests never saw it because they resolve the same
+// `development` condition against the real on-disk src.
+//
+// Fix: keep `development->src` at the top level (for the workspace) but override
+// the published manifest via `publishConfig.exports` (dist-only). pnpm applies
+// publishConfig field overrides at pack/publish time. These assertions pin that
+// the published exports never reference src again.
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const pkg = JSON.parse(
+  readFileSync(fileURLToPath(new URL("../package.json", import.meta.url)), "utf8"),
+) as {
+  files?: string[];
+  exports?: Record<string, unknown>;
+  publishConfig?: { exports?: Record<string, unknown> };
+};
+
+describe("published package exports are dist-only (no src leak)", () => {
+  it("publishConfig.exports overrides the workspace dev exports and references no ./src", () => {
+    const pub = pkg.publishConfig?.exports;
+    expect(pub, "publishConfig.exports must shadow the development->src exports at publish").toBeTruthy();
+    const json = JSON.stringify(pub);
+    expect(json).not.toMatch(/src\//);
+    expect(json).not.toMatch(/development/);
+    expect(json).toMatch(/dist\/index\.js/);
+    expect(json).toMatch(/dist\/setup\.js/);
+  });
+
+  it("the package ships dist (and never src)", () => {
+    expect(pkg.files ?? []).toContain("dist");
+    expect(pkg.files ?? []).not.toContain("src");
+  });
+});


### PR DESCRIPTION
## Scope

Promotes `develop` to `main`. As of this PR the range is **exactly one change** — the prior spec-90 work (A1+B1 + the brief→spec telemetry sweep) already reached `main` via PR #61.

### Commits
- `185da9a` fix(ac-emit-vitest): stop the `dev→src` exports leak breaking published consumers; bump `0.1.3 → 0.2.0` (PR #62).

### Files
- `packages/ac-emit-vitest/package.json` — `0.2.0` + `publishConfig.exports` (dist-only published manifest; workspace keeps `development→src`).
- `packages/ac-emit-vitest/src/published-exports.test.ts` — regression guard that the published exports never reference `src`.

## Why it matters
Without this, publishing `@memex-ai-ac/vitest` from `main` would ship an artifact that fails to import in any external Vitest consumer (`Failed to resolve entry`), caught by packing the tarball and importing it from a throwaway consumer. Fix verified: consumer tarball test 6/6, workspace suite green, package suite 69/69.

## ⚠️ Publish note
After merge, publish with **`pnpm publish`** (not `npm publish` — npm ignores `publishConfig` field overrides and would re-introduce the leak). Deploy server A1 to memex.ai before publishing so client B1 emissions land.