### PR TITLE
feat(ui): Specky asset — repo home + reduced-motion (spec-197 Slice 1, t-1)

### DIFF
--- a/assets/specky/README.md
+++ b/assets/specky/README.md
@@ -1,0 +1,66 @@
+# Specky — the voice guide's face (spec-197)
+
+**Specky** is an original animated-paperclip character (in the spirit of
+Microsoft's Clippy, but **original artwork** — no licensing concern). It is the
+visual identity for the spec-190 voice guide: the small in-view entry affordance
+and the avatar shown in the live session pill.
+
+This directory is the **canonical source of truth** for the Specky assets.
+
+## Files
+
+| File | Role |
+|---|---|
+| `specky.svg` | **Primary deliverable.** Self-contained animated SVG — transparent background, crisp at any size, idle loop defined entirely in its `<style>` block. This is the asset the web app uses. |
+| `make_raster.py` | Regenerates the raster fallbacks (`specky.gif`, `specky.png`) from `specky.svg`. |
+| `specky.gif` / `specky.png` | *(optional)* Raster fallbacks for non-web surfaces that can't run SVG (e.g. email). Regenerate with `make_raster.py`. Not required by the web app. |
+
+## The served copy
+
+The web app loads Specky from **`packages/ui/public/specky.svg`** (served at
+`/specky.svg`, same as `favicon.svg`). That file is a **byte-identical copy** of
+the `specky.svg` in this directory — this dir is the source of truth. When you
+change `specky.svg` here, sync the copy:
+
+```bash
+cp assets/specky/specky.svg packages/ui/public/specky.svg
+```
+
+A tagged test (`packages/ui/src/specky-asset.spec-197.test.ts`) fails loudly if
+the two drift apart.
+
+## Animation
+
+The idle loop lives entirely in the SVG's `<style>` block and runs automatically
+when embedded as an `<img>` — no JavaScript, no animation runtime (spec-197
+dec-3 = drop-in static SVG, **not** Lottie/inline-component):
+
+- `wobble` (7s) — gentle lean
+- `look` + `brows` (9s) — glance left ↔ right
+- `blink` (6.5s)
+- ~9s overall idle loop
+
+Tweak fidgetiness by changing those durations.
+
+### Reduced motion
+
+Per spec-197 **dec-5(b)**, the SVG carries a
+`@media (prefers-reduced-motion: reduce)` rule that sets `animation: none`,
+freezing Specky to a neutral static frame. It is **never** `display:none` — the
+affordance stays discoverable for motion-sensitive users. Because the rule lives
+inside the SVG, the asset self-handles reduced motion even when embedded as a
+plain `<img>`, with no consuming-component CSS required.
+
+## Provenance
+
+Delivered by Barrie Hadfield via Slack DM on **2026-06-07** as `clippy.zip` (the
+delivery filename predates the **Specky** name; "Clippy" survives only as the
+historical inspiration). The full SVG source is also captured verbatim in
+spec-197 §s-2 (`https://memex.ai/mindset-prod/memex-building-itself/specs/spec-197`)
+so it survives independent of Slack.
+
+> **Note on `make_raster.py`:** the script in this directory is an in-repo
+> regenerator authored to reproduce the delivered raster fallbacks from
+> `specky.svg`. If you prefer Barrie's original from `clippy.zip`, drop it in
+> here to replace this one — the contract (`specky.svg` → `specky.gif` +
+> `specky.png`) is the same.

--- a/assets/specky/make_raster.py
+++ b/assets/specky/make_raster.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Regenerate Specky's raster fallbacks (specky.gif, specky.png) from specky.svg.
+
+spec-197 dec-4 / ac-5 — the rasters are reproducible from the canonical SVG.
+
+The idle loop is a CSS animation, so faithfully rasterising it needs a real
+browser engine: we load specky.svg in Chromium (via Playwright), freeze the
+animation at evenly-spaced offsets across the loop, screenshot each frame, and
+assemble them into an animated GIF and an APNG with Pillow.
+
+The sub-animations have coprime periods (wobble 7s, look/brows 9s, blink 6.5s),
+so a single short loop can't be perfectly seamless; LOOP_SECONDS samples the
+~9s idle window Barrie tuned the asset around — good enough for a fallback that
+only renders where SVG can't (e.g. email). The web app always uses specky.svg.
+
+Usage:
+    pip install playwright pillow && playwright install chromium
+    python assets/specky/make_raster.py            # writes specky.gif + specky.png
+    python assets/specky/make_raster.py --size 480 --fps 25
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+SVG = HERE / "specky.svg"
+
+LOOP_SECONDS = 9.0          # idle window to sample
+DEFAULT_FPS = 20
+DEFAULT_SIZE = 240          # px width of the rendered raster (SVG is 240x330)
+
+
+def _require(mod: str, pip_name: str | None = None):
+    try:
+        return __import__(mod)
+    except ImportError:
+        name = pip_name or mod
+        sys.exit(
+            f"error: '{mod}' is required. Install with:\n"
+            f"    pip install playwright pillow && playwright install chromium\n"
+            f"(missing: {name})"
+        )
+
+
+def capture_frames(size: int, fps: int):
+    """Return a list of PIL.Image RGBA frames sampled across the idle loop."""
+    _require("playwright")
+    from playwright.sync_api import sync_playwright  # type: ignore
+    from PIL import Image  # type: ignore
+    import io
+
+    svg_markup = SVG.read_text(encoding="utf-8")
+    n_frames = max(1, int(round(LOOP_SECONDS * fps)))
+    height = int(round(size * 330 / 240))
+    frames = []
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        page = browser.new_page(viewport={"width": size, "height": height},
+                                device_scale_factor=2)
+        # Transparent page so the SVG's own transparency is preserved.
+        page.set_content(
+            f'<body style="margin:0;background:transparent">'
+            f'<div id="stage" style="width:{size}px;height:{height}px">{svg_markup}</div>'
+            f'</body>'
+        )
+        for i in range(n_frames):
+            offset = (i / n_frames) * LOOP_SECONDS
+            # Freeze every animated element at this point in its timeline.
+            page.add_style_tag(content=(
+                f"#stage * {{"
+                f"  animation-delay: -{offset:.4f}s !important;"
+                f"  animation-play-state: paused !important;"
+                f"}}"
+            ))
+            png_bytes = page.locator("#stage").screenshot(omit_background=True)
+            frames.append(Image.open(io.BytesIO(png_bytes)).convert("RGBA"))
+        browser.close()
+    return frames
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Regenerate Specky raster fallbacks from specky.svg")
+    ap.add_argument("--size", type=int, default=DEFAULT_SIZE, help="raster width in px")
+    ap.add_argument("--fps", type=int, default=DEFAULT_FPS, help="frames per second")
+    args = ap.parse_args()
+
+    if not SVG.exists():
+        sys.exit(f"error: {SVG} not found")
+
+    _require("PIL", "pillow")
+    frames = capture_frames(args.size, args.fps)
+    duration_ms = int(round(1000 / args.fps))
+
+    gif_path = HERE / "specky.gif"
+    png_path = HERE / "specky.png"
+
+    frames[0].save(
+        gif_path, save_all=True, append_images=frames[1:],
+        duration=duration_ms, loop=0, disposal=2, transparency=0,
+    )
+    frames[0].save(
+        png_path, save_all=True, append_images=frames[1:],
+        duration=duration_ms, loop=0,
+    )
+    print(f"wrote {gif_path.name} and {png_path.name} ({len(frames)} frames @ {args.fps}fps)")
+
+
+if __name__ == "__main__":
+    main()

--- a/assets/specky/specky.svg
+++ b/assets/specky/specky.svg
@@ -1,0 +1,100 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 330" width="240" height="330">
+  <style>
+    .clip-root {
+      transform-box: fill-box;
+      transform-origin: 50% 90%;
+      animation: wobble 7s ease-in-out infinite;
+    }
+    .pupils {
+      animation: look 9s ease-in-out infinite;
+    }
+    .eyes {
+      transform-box: fill-box;
+      transform-origin: 50% 50%;
+      animation: blink 6.5s linear infinite;
+    }
+    .brows {
+      animation: brows 9s ease-in-out infinite;
+    }
+    @keyframes wobble {
+      0%, 68%  { transform: rotate(0deg); }
+      71%      { transform: rotate(-5deg); }
+      74%      { transform: rotate(4deg); }
+      77%      { transform: rotate(-2.5deg); }
+      80%      { transform: rotate(1.5deg); }
+      83%, 100% { transform: rotate(0deg); }
+    }
+    @keyframes look {
+      0%, 16%   { transform: translate(0px, 0px); }
+      21%, 36%  { transform: translate(-6px, 2px); }
+      41%, 56%  { transform: translate(0px, 0px); }
+      61%, 78%  { transform: translate(6px, -1px); }
+      84%, 100% { transform: translate(0px, 0px); }
+    }
+    @keyframes blink {
+      0%, 90.5% { transform: scaleY(1); }
+      92.5%     { transform: scaleY(0.06); }
+      94.5%, 100% { transform: scaleY(1); }
+    }
+    @keyframes brows {
+      0%, 16%   { transform: translate(0px, 0px); }
+      21%, 36%  { transform: translate(-2px, 1px); }
+      41%, 56%  { transform: translate(0px, 0px); }
+      61%, 78%  { transform: translate(2px, -2px); }
+      84%, 100% { transform: translate(0px, 0px); }
+    }
+
+    /* spec-197 dec-5(b) / ac-4 — honour prefers-reduced-motion by freezing
+       Specky to a neutral static frame (animation:none resets each element to
+       its base pose: clip upright, pupils centred, eyes open, brows level).
+       The character is never hidden — the affordance must stay discoverable
+       for motion-sensitive users. This rule lives inside the SVG so the asset
+       self-handles reduced motion even when embedded as a plain <img>, with
+       no consuming-component CSS required (dec-3=a drop-in img). */
+    @media (prefers-reduced-motion: reduce) {
+      .clip-root,
+      .pupils,
+      .eyes,
+      .brows {
+        animation: none;
+      }
+    }
+  </style>
+
+  <defs>
+    <linearGradient id="wire" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#c3ced9"/>
+      <stop offset="0.5" stop-color="#94a1af"/>
+      <stop offset="1" stop-color="#69778a"/>
+    </linearGradient>
+    <linearGradient id="wireHi" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#eef3f7" stop-opacity="0.9"/>
+      <stop offset="1" stop-color="#eef3f7" stop-opacity="0"/>
+    </linearGradient>
+  </defs>
+
+  <g class="clip-root">
+
+    <path d="M 78 300 L 78 122 A 42 42 0 0 1 162 122 L 162 252 A 28 28 0 0 1 106 252 L 106 152"
+          fill="none" stroke="url(#wire)" stroke-width="16" stroke-linecap="round"/>
+
+    <path d="M 74.5 300 L 74.5 122 A 45.5 45.5 0 0 1 120 76.5"
+          fill="none" stroke="url(#wireHi)" stroke-width="3.5" stroke-linecap="round"/>
+
+    <g class="brows" fill="none" stroke="#6e7a88" stroke-width="7" stroke-linecap="round">
+      <path d="M 84 46 Q 99 35 113 45"/>
+      <path d="M 127 45 Q 141 35 156 46"/>
+    </g>
+
+    <g class="eyes">
+      <ellipse cx="99" cy="86" rx="18" ry="23" fill="#ffffff" stroke="#3d4654" stroke-width="3.5"/>
+      <ellipse cx="141" cy="86" rx="18" ry="23" fill="#ffffff" stroke="#3d4654" stroke-width="3.5"/>
+      <g class="pupils" fill="#1d242e">
+        <circle cx="99" cy="89" r="7.5"/>
+        <circle cx="141" cy="89" r="7.5"/>
+        <circle cx="96.5" cy="86" r="2.2" fill="#ffffff"/>
+        <circle cx="138.5" cy="86" r="2.2" fill="#ffffff"/>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/packages/ui/public/specky.svg
+++ b/packages/ui/public/specky.svg
@@ -1,0 +1,100 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 330" width="240" height="330">
+  <style>
+    .clip-root {
+      transform-box: fill-box;
+      transform-origin: 50% 90%;
+      animation: wobble 7s ease-in-out infinite;
+    }
+    .pupils {
+      animation: look 9s ease-in-out infinite;
+    }
+    .eyes {
+      transform-box: fill-box;
+      transform-origin: 50% 50%;
+      animation: blink 6.5s linear infinite;
+    }
+    .brows {
+      animation: brows 9s ease-in-out infinite;
+    }
+    @keyframes wobble {
+      0%, 68%  { transform: rotate(0deg); }
+      71%      { transform: rotate(-5deg); }
+      74%      { transform: rotate(4deg); }
+      77%      { transform: rotate(-2.5deg); }
+      80%      { transform: rotate(1.5deg); }
+      83%, 100% { transform: rotate(0deg); }
+    }
+    @keyframes look {
+      0%, 16%   { transform: translate(0px, 0px); }
+      21%, 36%  { transform: translate(-6px, 2px); }
+      41%, 56%  { transform: translate(0px, 0px); }
+      61%, 78%  { transform: translate(6px, -1px); }
+      84%, 100% { transform: translate(0px, 0px); }
+    }
+    @keyframes blink {
+      0%, 90.5% { transform: scaleY(1); }
+      92.5%     { transform: scaleY(0.06); }
+      94.5%, 100% { transform: scaleY(1); }
+    }
+    @keyframes brows {
+      0%, 16%   { transform: translate(0px, 0px); }
+      21%, 36%  { transform: translate(-2px, 1px); }
+      41%, 56%  { transform: translate(0px, 0px); }
+      61%, 78%  { transform: translate(2px, -2px); }
+      84%, 100% { transform: translate(0px, 0px); }
+    }
+
+    /* spec-197 dec-5(b) / ac-4 — honour prefers-reduced-motion by freezing
+       Specky to a neutral static frame (animation:none resets each element to
+       its base pose: clip upright, pupils centred, eyes open, brows level).
+       The character is never hidden — the affordance must stay discoverable
+       for motion-sensitive users. This rule lives inside the SVG so the asset
+       self-handles reduced motion even when embedded as a plain <img>, with
+       no consuming-component CSS required (dec-3=a drop-in img). */
+    @media (prefers-reduced-motion: reduce) {
+      .clip-root,
+      .pupils,
+      .eyes,
+      .brows {
+        animation: none;
+      }
+    }
+  </style>
+
+  <defs>
+    <linearGradient id="wire" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#c3ced9"/>
+      <stop offset="0.5" stop-color="#94a1af"/>
+      <stop offset="1" stop-color="#69778a"/>
+    </linearGradient>
+    <linearGradient id="wireHi" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#eef3f7" stop-opacity="0.9"/>
+      <stop offset="1" stop-color="#eef3f7" stop-opacity="0"/>
+    </linearGradient>
+  </defs>
+
+  <g class="clip-root">
+
+    <path d="M 78 300 L 78 122 A 42 42 0 0 1 162 122 L 162 252 A 28 28 0 0 1 106 252 L 106 152"
+          fill="none" stroke="url(#wire)" stroke-width="16" stroke-linecap="round"/>
+
+    <path d="M 74.5 300 L 74.5 122 A 45.5 45.5 0 0 1 120 76.5"
+          fill="none" stroke="url(#wireHi)" stroke-width="3.5" stroke-linecap="round"/>
+
+    <g class="brows" fill="none" stroke="#6e7a88" stroke-width="7" stroke-linecap="round">
+      <path d="M 84 46 Q 99 35 113 45"/>
+      <path d="M 127 45 Q 141 35 156 46"/>
+    </g>
+
+    <g class="eyes">
+      <ellipse cx="99" cy="86" rx="18" ry="23" fill="#ffffff" stroke="#3d4654" stroke-width="3.5"/>
+      <ellipse cx="141" cy="86" rx="18" ry="23" fill="#ffffff" stroke="#3d4654" stroke-width="3.5"/>
+      <g class="pupils" fill="#1d242e">
+        <circle cx="99" cy="89" r="7.5"/>
+        <circle cx="141" cy="89" r="7.5"/>
+        <circle cx="96.5" cy="86" r="2.2" fill="#ffffff"/>
+        <circle cx="138.5" cy="86" r="2.2" fill="#ffffff"/>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/packages/ui/src/specky-asset.spec-197.test.ts
+++ b/packages/ui/src/specky-asset.spec-197.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { tagAc } from '@memex-ai-ac/vitest';
+
+// spec-197 Slice 1 (t-1) — the Specky asset's repo home, served copy, and
+// reduced-motion handling. Filesystem-level assertions so a drift between the
+// canonical source and the served copy, or a lost reduced-motion rule, fails
+// loudly here. The in-view/pill rendering ACs (ac-1/2/6/7/8/9/10) belong to
+// Slice 2 (t-2/t-3/t-4) and are covered by component tests there.
+
+const AC_TRANSPARENT_SCALABLE = 'mindset-prod/memex-building-itself/specs/spec-197/acs/ac-3';
+const AC_REDUCED_MOTION = 'mindset-prod/memex-building-itself/specs/spec-197/acs/ac-4';
+const AC_CANONICAL_SOURCE = 'mindset-prod/memex-building-itself/specs/spec-197/acs/ac-5';
+
+const SRC_DIR = dirname(fileURLToPath(import.meta.url)); // packages/ui/src
+const UI_ROOT = join(SRC_DIR, '..'); // packages/ui
+const REPO_ROOT = join(SRC_DIR, '..', '..', '..'); // repo root
+
+const CANONICAL_SVG = join(REPO_ROOT, 'assets', 'specky', 'specky.svg');
+const SERVED_SVG = join(UI_ROOT, 'public', 'specky.svg');
+const MAKE_RASTER = join(REPO_ROOT, 'assets', 'specky', 'make_raster.py');
+const README = join(REPO_ROOT, 'assets', 'specky', 'README.md');
+
+describe('Specky asset — repo home & served copy (spec-197 dec-4 / ac-5)', () => {
+  it('specky.svg is the canonical in-repo source under assets/specky/', () => {
+    tagAc(AC_CANONICAL_SOURCE);
+    expect(existsSync(CANONICAL_SVG)).toBe(true);
+    const svg = readFileSync(CANONICAL_SVG, 'utf8');
+    expect(svg).toContain('<svg');
+    expect(svg).toContain('</svg>');
+  });
+
+  it('a vendored regenerator + README make the asset reproducible in-repo', () => {
+    tagAc(AC_CANONICAL_SOURCE);
+    // make_raster.py regenerates the raster fallbacks reproducibly from the SVG.
+    expect(existsSync(MAKE_RASTER)).toBe(true);
+    const py = readFileSync(MAKE_RASTER, 'utf8');
+    expect(py).toContain('specky.gif');
+    expect(py).toContain('specky.png');
+    expect(existsSync(README)).toBe(true);
+  });
+
+  it('the served copy at packages/ui/public/specky.svg is byte-identical to the source', () => {
+    tagAc(AC_CANONICAL_SOURCE);
+    expect(existsSync(SERVED_SVG)).toBe(true);
+    const source = readFileSync(CANONICAL_SVG);
+    const served = readFileSync(SERVED_SVG);
+    expect(served.equals(source)).toBe(true);
+  });
+});
+
+describe('Specky asset — reduced motion (spec-197 dec-5 / ac-4)', () => {
+  for (const [label, file] of [
+    ['canonical source', CANONICAL_SVG],
+    ['served copy', SERVED_SVG],
+  ] as const) {
+    it(`${label} freezes to a static frame under prefers-reduced-motion (never display:none)`, () => {
+      tagAc(AC_REDUCED_MOTION);
+      const svg = readFileSync(file, 'utf8');
+      // The media query exists and zeroes the animations on the animated groups.
+      expect(svg).toMatch(/@media\s*\(\s*prefers-reduced-motion:\s*reduce\s*\)/);
+      const block = svg.slice(svg.indexOf('prefers-reduced-motion'));
+      expect(block).toMatch(/animation:\s*none/);
+      // Degrades to a static frame, NOT hidden — the affordance stays discoverable.
+      expect(svg).not.toMatch(/display:\s*none/);
+    });
+  }
+});
+
+describe('Specky asset — transparent & scalable (spec-197 / ac-3, asset side)', () => {
+  it('scales losslessly (viewBox) and carries no opaque full-canvas background', () => {
+    tagAc(AC_TRANSPARENT_SCALABLE);
+    const svg = readFileSync(CANONICAL_SVG, 'utf8');
+    // A viewBox means the asset scales crisply at any size.
+    expect(svg).toMatch(/viewBox="0 0 240 330"/);
+    // Transparency: no background <rect> painting the whole canvas, and no
+    // explicit background fill on the root <svg>.
+    expect(svg).not.toMatch(/<rect/);
+    expect(svg).not.toMatch(/<svg[^>]*background/);
+  });
+});


### PR DESCRIPTION
## What

Slice 1 of **spec-197** — gives the spec-190 voice guide its visual identity, **Specky** (an original animated-paperclip character). This slice is the asset itself + its repo home + reduced-motion handling; it is **fully independent of spec-190** (no voice plumbing).

Resolves spec-197 **t-1**. Decisions: dec-3 (drop-in `<img>`), dec-4 (dedicated source dir), dec-5 (static frame under reduced-motion).

## Changes

- **`assets/specky/specky.svg`** — canonical source of truth: the delivered animated SVG (verbatim from spec-197 §s-2), with a baked-in `@media (prefers-reduced-motion: reduce){ animation: none }` rule that freezes Specky to a neutral static frame. It self-handles reduced motion even as a plain `<img>` — never hidden, so the affordance stays discoverable.
- **`assets/specky/make_raster.py`** — Playwright+Pillow regenerator for the raster fallbacks (`specky.gif`/`specky.png`), sampling the CSS-animated SVG across the idle loop. In-repo equivalent of the delivered tool.
- **`assets/specky/README.md`** — provenance (Barrie, original artwork), Specky-vs-Clippy naming, regen + sync commands.
- **`packages/ui/public/specky.svg`** — served copy at `/specky.svg` (favicon.svg pattern), byte-identical to the canonical source.
- **`packages/ui/src/specky-asset.spec-197.test.ts`** — tagged tests for ac-3/ac-4/ac-5.

## Verification

- **ac-3, ac-4, ac-5** emitted + verified on prod (6/6 tagged tests).
- `tsc -b` clean.
- `make e2e-cold` — **44/44 green**.

## Scope / follow-ups

- Slice 2 (in-view glyph + animated pill avatar, ac-1/2/6/7/8/9/10) is deferred to t-2/t-3/t-4, which depend on spec-190 **t-8** building the icon/pill surface — t-8 can now consume `/specky.svg` directly.
- Raster binaries omitted (non-web fallbacks); reproducible via `make_raster.py` per ac-5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)