### PR TITLE
fix(deploy): ship voice/*.md in the server image (unblocks spec-190 INT deploy)

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -33,3 +33,8 @@ blueprint
 *.md
 !packages/server/src/agent/skills/*.md
 !packages/server/src/agent/phases/**/*.md
+# spec-190: the voice guide's system prompt is a runtime-loaded markdown asset
+# (std-15), copied into the image by the server build. Without this negation the
+# *.md rule above strips it from the Cloud Build context → `cp src/agent/voice/*.md`
+# fails and the image build dies.
+!packages/server/src/agent/voice/*.md


### PR DESCRIPTION
## Why
The PR #67 INT deploy **failed** at the image build:
```
cp: can't stat 'src/agent/voice/*.md': No such file or directory
```
`.gcloudignore` excludes all `*.md` from the Cloud Build upload and only re-includes `skills/` + `phases/`. spec-190 added the voice guide's runtime system prompt (`guide-system.md`, loaded at runtime per std-15) plus a build step that copies `voice/*.md` — but no `voice/` negation. So the prompt was stripped from the build context, the `cp` failed, and **the whole server image build died → nothing deployed to INT** (live bundle still has no voice code).

## Fix
One line: `!packages/server/src/agent/voice/*.md` in `.gcloudignore`, mirroring the existing skills/phases negations. Passed locally because the file is present there; only the Cloud Build upload strips it.

## After merge
INT auto-deploys → the server image builds (voice prompt included) → the voice icon appears on registered screens. (Voice audio still needs the `elevenlabs-api-key` secret — separate, with Barrie.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)