### PR TITLE
spec-190: make int voice guide work — VAD asset serving + runtime-SA grant docs

### DIFF
--- a/packages/server/deploy.sh
+++ b/packages/server/deploy.sh
@@ -68,10 +68,22 @@ else
 fi
 # ELEVENLABS_API_KEY is optional (spec-190 voice guide). Wired ONLY if the secret
 # exists, so a deploy never breaks before it's provisioned — voice simply stays
-# disabled (isVoiceConfigured() is false) until the secret lands. Create it once
-# per project to light voice up (no code change needed):
+# disabled (isVoiceConfigured() is false) until the secret lands. To light voice
+# up in an env, provisioning the secret is TWO steps (no code change needed):
+# create it, AND grant the Cloud Run runtime SA read access. The runtime SA reads
+# secrets PER-SECRET here (resource-level binding), not project-wide — so a
+# freshly-created secret is unreadable until bound, and the next deploy would
+# fail to mount ELEVENLABS_API_KEY without the grant. The deploy preflight below
+# (run by the github-deployer SA, which DOES have project-level access) detects
+# the secret either way; it's the runtime mount that needs the binding.
 #   printf %s "<key>" | gcloud secrets create elevenlabs-api-key --data-file=- \
 #     --project "${GCP_PROJECT}" --replication-policy=user-managed --locations=us-east4
+#   gcloud secrets add-iam-policy-binding elevenlabs-api-key --project "${GCP_PROJECT}" \
+#     --member="serviceAccount:<cloud-run-runtime-SA>" \
+#     --role="roles/secretmanager.secretAccessor"
+# Runtime SA: int = default compute SA (…-compute@developer); prod =
+# memex-api-runtime@memex-ai-prod.iam.gserviceaccount.com. (Mirrors how every
+# other Cloud Run secret — anthropic/openai/postmark — is already bound.)
 if gcloud secrets describe elevenlabs-api-key --project "${GCP_PROJECT}" >/dev/null 2>&1; then
   echo "  ✓ elevenlabs-api-key present — voice guide enabled"
   HAS_ELEVENLABS=1


### PR DESCRIPTION
Merging to `develop` deploys int (keyless WIF CD) and makes the Specky voice guide **actually work** there. Two fixes + a doc fix.

## 1. VAD assets 404 on int (the user-visible break)

Voice errored on int.memex.ai: `no available backend found … Failed to fetch dynamically imported module: /vad/ort-wasm-simd-threaded.mjs` (+ `/vad/silero_vad_v5.onnx` 404). Invisible in `make dev` because a Vite middleware serves `/vad/*` locally.

Two compounding causes:
- The deployed **GCS/LB only routes `/assets/*`** straight to the bucket; every other path (incl. a web-root `/vad/*`) hits the catch-all that rewrites to `/index.html` → the raw asset 404s. Same class of bug **spec-197 dec-3** fixed for Specky by moving it under `/assets/`.
- The UI deploy upload only syncs `dist/assets/` (recursive), `dist/index.html`, and top-level `dist/*` **files** — it skips the `dist/vad/` **subdirectory** (`-f "$f"` test).

**Fix:** stage the Silero VAD + onnxruntime-web assets under `public/assets/vad/` (was `public/vad/`) and default `baseAssetPath`/`onnxWASMBasePath` to `/assets/vad/`. They now land in `dist/assets/vad/`, get swept up by the **existing recursive `dist/assets/` rsync**, and are served by the existing `/assets/` LB rule — **no url-map change, auto-applies to prod**. gcloud auto-sets correct MIME (`.mjs→text/javascript`, `.wasm→application/wasm`; verified).

Validated: `pnpm run build` emits all 4 assets to `dist/assets/vad/`; the built bundle is `index-O5CeyybP.js` (the exact file from the error console); 45 voice unit tests green.

## 2. Runtime-SA secret grant (the deploy-comment fix)

`packages/server/deploy.sh` previously showed only `gcloud secrets create`, implying that enables voice. It doesn't — the Cloud Run **runtime SA reads secrets per-secret** (resource-level IAM), not project-wide, so a freshly-created secret is unreadable until granted `secretAccessor`, and the deploy fails to mount the env var. (The `github-deployer` preflight `describe` succeeds regardless, masking the gap.) Comment now documents both steps + the per-env runtime SA.

This bit us provisioning the int `elevenlabs-api-key` secret (now resolved: secret + runtime-SA binding in place). std-9 cl-327/cl-328 capture the rule.

## Scope / prod note
- App/build + deploy-comment changes only; no infra/url-map mutation.
- **Prod at promotion** still needs the two-step secret provisioning (create + runtime-SA grant for `memex-api-runtime@memex-ai-prod`) — the VAD fix carries over automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)