### PR TITLE
spec-190: fix VAD asset 404 on int — serve Silero/onnxruntime under /assets/vad/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,4 @@ _private/
 # TypeScript incremental compile cache — produced by `tsc` when
 # `--incremental` is on (default for some configs). Per-machine artefact.
 *.tsbuildinfo
-packages/ui/public/vad/
+packages/ui/public/assets/vad/

--- a/packages/ui/scripts/copy-vad-assets.mjs
+++ b/packages/ui/scripts/copy-vad-assets.mjs
@@ -1,8 +1,15 @@
-// spec-190 t-8/dec-8 — stage the Silero VAD runtime assets into public/vad so
-// they're served at /vad/ for the browser AudioWorklet (the local speech-onset
-// detector, ac-23). Runs on predev + prebuild so both `pnpm dev` and `pnpm build`
-// (incl. the CI/deploy build) have the assets without committing ~14MB of binary
-// (.onnx model + onnxruntime-web .wasm) into git.
+// spec-190 t-8/dec-8 — stage the Silero VAD runtime assets into public/assets/vad
+// so they're served at /assets/vad/ for the browser AudioWorklet (the local
+// speech-onset detector, ac-23). Runs on predev + prebuild so both `pnpm dev` and
+// `pnpm build` (incl. the CI/deploy build) have the assets without committing
+// ~14MB of binary (.onnx model + onnxruntime-web .wasm) into git.
+//
+// WHY under /assets/ and not a web-root /vad/: the deployed SPA's GCS/LB only
+// routes /assets/* straight to the bucket; every other path is rewritten to
+// /index.html, so a raw /vad/ asset 404s in INT/PROD even though it works in the
+// Vite dev server. Living under /assets/ means the existing recursive
+// `dist/assets/` rsync uploads them with correct MIME, no LB rule needed. Same
+// fix spec-197 dec-3 applied to Specky.
 //
 // What gets copied:
 //   - @ricky0123/vad-web: the AudioWorklet bundle + the Silero ONNX models
@@ -19,7 +26,7 @@ import { fileURLToPath } from "node:url";
 
 const require = createRequire(import.meta.url);
 const here = dirname(fileURLToPath(import.meta.url));
-const PUBLIC_VAD = join(here, "..", "public", "vad");
+const PUBLIC_VAD = join(here, "..", "public", "assets", "vad");
 
 // vad-web dist (main = dist/index.js → its dir).
 const vadDist = dirname(require.resolve("@ricky0123/vad-web"));
@@ -70,5 +77,5 @@ for (const f of ORT_FILES) {
 
 const expected = 2 + ORT_FILES.length;
 console.log(
-  `[copy-vad-assets] ${copied} file(s) staged into public/vad (${expected} expected; rest already current).`,
+  `[copy-vad-assets] ${copied} file(s) staged into public/assets/vad (${expected} expected; rest already current).`,
 );

--- a/packages/ui/src/voice/micVad.ts
+++ b/packages/ui/src/voice/micVad.ts
@@ -103,14 +103,19 @@ export class MicVad {
 //     ScriptProcessor main-thread fallback), matching dec-8/ac-23.
 //
 // The runtime assets (worklet bundle, Silero .onnx, onnxruntime-web .wasm) are
-// served from `baseAssetPath` / `onnxWASMBasePath` — staged into public/vad by
-// scripts/copy-vad-assets.mjs (predev/prebuild). Validated on a real device
+// served from `baseAssetPath` / `onnxWASMBasePath` — staged into public/assets/vad
+// by scripts/copy-vad-assets.mjs (predev/prebuild). They live UNDER /assets/ (not
+// a web-root /vad/) so the deployed SPA actually serves them: the GCS/LB only
+// routes /assets/* straight to the bucket — every other path is rewritten to
+// /index.html, which would 404 a raw /vad/ asset (the same reason spec-197 dec-3
+// moved Specky under /assets/). The recursive dist/assets/ rsync uploads them with
+// correct MIME (.mjs→text/javascript, .wasm→application/wasm). Validated on a real device
 // (jsdom has no AudioWorklet / WebAssembly mic pipeline), the same way t-1's real
 // ElevenLabs provider is validated once a key lands.
 export interface SileroWorkletOptions {
-  /** Where the worklet bundle + Silero ONNX model are served (default '/vad/'). */
+  /** Where the worklet bundle + Silero ONNX model are served (default '/assets/vad/'). */
   baseAssetPath?: string;
-  /** Where the onnxruntime-web wasm is served (default '/vad/'). */
+  /** Where the onnxruntime-web wasm is served (default '/assets/vad/'). */
   onnxWASMBasePath?: string;
   /** Silero model variant. Default 'v5' (current); 'legacy' is the older model. */
   model?: 'v5' | 'legacy';
@@ -145,7 +150,7 @@ export class SileroWorkletVadEngine implements VadEngine {
 
   async start(stream: MediaStream, onSpeech: (speaking: boolean) => void): Promise<void> {
     const { MicVAD } = await import('@ricky0123/vad-web');
-    const base = this.opts.baseAssetPath ?? '/vad/';
+    const base = this.opts.baseAssetPath ?? '/assets/vad/';
     this.vad = await MicVAD.new({
       // Use the AEC'd stream we already opened — never let vad-web open its own.
       getStream: async () => stream,

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -6,15 +6,16 @@ import { existsSync, createReadStream } from 'node:fs'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
-// spec-190 (dec-8) — serve the Silero VAD / onnxruntime-web assets from public/vad
-// as RAW files in DEV. onnxruntime-web 1.26 loads its wasm glue by dynamically
-// importing `/vad/ort-wasm-simd-threaded.mjs`; Vite's dev server refuses to serve a
-// file under /public through the module pipeline (it appends `?import` and throws
-// "should not be imported from source code"), which 500s VAD init and stops a voice
-// session from starting. Intercept `/vad/*` BEFORE Vite's transform middleware and
-// stream the bytes with a correct content-type. DEV-ONLY: configureServer never runs
-// for `vite build`, and the prod build copies public/ as-is (served statically, no
-// guard) — so this changes nothing about the shipped bundle.
+// spec-190 (dec-8) — serve the Silero VAD / onnxruntime-web assets from
+// public/assets/vad as RAW files in DEV. onnxruntime-web 1.26 loads its wasm glue
+// by dynamically importing `/assets/vad/ort-wasm-simd-threaded.mjs`; Vite's dev
+// server refuses to serve a file under /public through the module pipeline (it
+// appends `?import` and throws "should not be imported from source code"), which
+// 500s VAD init and stops a voice session from starting. Intercept `/assets/vad/*`
+// BEFORE Vite's transform middleware and stream the bytes with a correct
+// content-type. DEV-ONLY: configureServer never runs for `vite build`, and the prod
+// build copies public/ as-is (served statically under /assets/, which the deployed
+// LB routes straight to the bucket) — so this changes nothing about the shipped bundle.
 const serveVadAssetsRaw: PluginOption = {
   name: 'spec190-serve-vad-assets-raw',
   configureServer(server) {
@@ -22,7 +23,7 @@ const serveVadAssetsRaw: PluginOption = {
     // internal transform/public-file middlewares.
     server.middlewares.use((req, res, next) => {
       const url = req.url ?? ''
-      if (!url.startsWith('/vad/')) return next()
+      if (!url.startsWith('/assets/vad/')) return next()
       const rel = url.split('?')[0] // drop ?import and friends
       const file = join(__dirname, 'public', rel)
       if (!existsSync(file)) return next()


### PR DESCRIPTION
**Follow-up to #70.** #70 merged with the secret/runtime-SA doc change but the VAD asset fix landed on its branch *after* merge, so it never reached `develop`. Confirmed live: `https://int.memex.ai/assets/vad/silero_vad_v5.onnx` → **404**, voice still broken on int. This PR carries the actual fix.

## The break

Voice errors on int.memex.ai: `no available backend found … Failed to fetch dynamically imported module: /vad/ort-wasm-simd-threaded.mjs` (+ `/vad/silero_vad_v5.onnx` 404). Invisible in `make dev` because a Vite middleware serves `/vad/*` locally.

Cause: the assets were served from a **web-root `/vad/`** path, but the deployed GCS/LB only routes **`/assets/*`** straight to the bucket — every other path is rewritten to `/index.html`, so the raw asset 404s. Same class of bug **spec-197 dec-3** fixed for Specky by moving it under `/assets/`.

## Fix

Stage the Silero VAD + onnxruntime-web assets under `public/assets/vad/` (was `public/vad/`) and default `baseAssetPath`/`onnxWASMBasePath` to `/assets/vad/`. They now land in `dist/assets/vad/`, ride the **existing recursive `dist/assets/` rsync**, and are served by the existing `/assets/` LB rule — **no url-map change, auto-applies to prod**. gcloud auto-sets correct MIME (`.mjs→text/javascript`, `.wasm→application/wasm`; verified).

- `copy-vad-assets.mjs` → stage into `public/assets/vad/`
- `micVad.ts` → default base path `/assets/vad/`
- `vite.config.ts` → dev middleware intercepts `/assets/vad/*`
- `.gitignore` → ignore `packages/ui/public/assets/vad/`

**Validated:** `pnpm run build` emits all 4 assets to `dist/assets/vad/` (built bundle `index-O5CeyybP.js` = the exact file from the error console); 45 voice unit tests green.

Merging deploys int and makes the voice guide actually work. Prod gets the fix automatically at promotion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)