### PR TITLE
spec-190: voice guide on Haiku 4.5 — cut the thinking-phase latency

### DIFF
--- a/packages/server/src/routes/voice.ts
+++ b/packages/server/src/routes/voice.ts
@@ -52,10 +52,13 @@ import { GUIDE_TOOLS } from "@memex/shared";
 import type { MemexResolverEnv } from "../middleware/memex-resolver.js";
 import type { SessionEnv } from "../middleware/session.js";
 
-// Same model as the main agent proxy (routes/llm.ts). Voice replies are short
-// (max_tokens kept low) and TTS streams from the first token, so latency rides
-// on time-to-first-token, not total length.
-const GUIDE_MODEL = "claude-sonnet-4-5-20250929";
+// The voice guide deliberately runs a FASTER model than the main agent proxy
+// (routes/llm.ts uses Sonnet). Voice replies are short (max_tokens kept low) and
+// TTS streams from the first token, so the FELT latency is time-to-first-token —
+// which dominated the "thinking" gap (int guide-chat ran ~2-3s/turn on Sonnet).
+// Haiku's lower TTFT is the win for short product-navigation answers; the small
+// quality trade is acceptable here (spec-190 latency follow-up).
+const GUIDE_MODEL = "claude-haiku-4-5-20251001";
 
 const guideChatSchema = z.object({
   messages: z.array(z.object({ role: z.enum(["user", "assistant"]), content: z.any() })),


### PR DESCRIPTION
## Why
GTM testing flagged the voice guide feels slow in the "thinking" phase — the pause between finishing speaking and Specky starting to talk.

Int logs isolate it to the **LLM leg** (`voice/guide-chat`): ~1.3–3s/turn typical, spiking to 6–7s. TTS is not the cost (first audio chunk ~270ms); VAD/STT aren't either. Because TTS streams from the first token, the felt latency is **time-to-first-token** — so the guide model's TTFT dominates the gap.

The guide ran **Sonnet 4.5** (matched to the main agent proxy). For short product-navigation answers, that's overkill on latency.

## Change
`routes/voice.ts`: `GUIDE_MODEL` → **`claude-haiku-4-5-20251001`**. Haiku's lower TTFT directly shrinks the thinking gap; the quality trade is small for short guide replies. One-line change + comment.

No test pins the model id; voice-guide-chat tests green (7/7).

## Companion (already applied to int, not in this PR)
- `minScale=1` on int `memex-api` (revision `memex-api-00202-gcb`) to kill cold-start spikes / slow first turn during GTM testing.

## Follow-up (not in this PR)
spec-190 dec-6's documented optimization: **speculative retrieval** off the STT interim transcript so per-turn retrieval (currently `await`ed before the stream) finishes before end-of-speech. Bigger change; own PR if the Haiku win isn't enough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)