### PR TITLE
spec-196: rename Narrative→Spec, specify→build narrative gate, done-view "Read the spec"

### DIFF
--- a/packages/server/src/agent/tools-status-nudge.integration.test.ts
+++ b/packages/server/src/agent/tools-status-nudge.integration.test.ts
@@ -240,7 +240,7 @@ describe("update_doc_status nudge (t-7)", () => {
     );
     expect(result).toMatch(/Outstanding work:/);
     expect(result).toMatch(/not yet reflected in the narrative/);
-    expect(result).toMatch(/"New decisions — update narrative"/);
+    expect(result).toMatch(/"Update spec narrative"/);
   });
 
   it("omits the 'Outstanding work' list when the Spec is clean", async () => {

--- a/packages/server/src/routes/__test__.ts
+++ b/packages/server/src/routes/__test__.ts
@@ -22,7 +22,8 @@ import {
   createUserWithPassword,
 } from "../services/users.js";
 import { ensureUserNamespace, ensureUserMemex } from "../services/user-namespaces.js";
-import { createDocDraft } from "../services/documents.js";
+import { createDocDraft, updateDocStatus } from "../services/documents.js";
+import { markNarrativeConsolidated } from "../services/narrative.js";
 import { createDecision } from "../services/decisions.js";
 import { hashPassword } from "../services/passwords.js";
 import { issueAuthToken } from "../services/auth-tokens.js";
@@ -585,6 +586,44 @@ testOnlyRouter.get("/doc-status/:id", async (c) => {
   });
   if (!doc) return c.json({ error: `Document ${docId} not found` }, 404);
   return c.json({ status: doc.status });
+});
+
+// spec-196 t-5: set a doc's status through the real updateDocStatus service
+// (bus-emitted, SSE-visible). Journeys use this to seed a Spec in a phase the
+// UI can't browse to (e.g. `done` for the DoneSummary read view) without
+// driving every intermediate gate.
+const setDocStatusSchema = z.object({
+  memexId: z.string().uuid(),
+  docId: z.string().uuid(),
+  status: z.string(),
+});
+testOnlyRouter.post("/set-doc-status", async (c) => {
+  const body = await c.req.json().catch(() => null);
+  const parsed = setDocStatusSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: "Invalid request", details: parsed.error.issues }, 400);
+  }
+  const { memexId, docId, status } = parsed.data;
+  const result = await updateDocStatus(memexId, docId, status);
+  return c.json({ docId: result.id, status: result.status });
+});
+
+// spec-196 t-5: stamp `narrativeLastConsolidatedAt = now()` through the real
+// markNarrativeConsolidated service — what `assess_spec({mode:'consolidate'})`
+// does, reachable for journeys (the MCP surface isn't drivable from Playwright).
+const consolidateSchema = z.object({
+  memexId: z.string().uuid(),
+  docId: z.string().uuid(),
+});
+testOnlyRouter.post("/consolidate-narrative", async (c) => {
+  const body = await c.req.json().catch(() => null);
+  const parsed = consolidateSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: "Invalid request", details: parsed.error.issues }, 400);
+  }
+  const { memexId, docId } = parsed.data;
+  const result = await markNarrativeConsolidated(memexId, docId);
+  return c.json({ consolidatedAt: result.consolidatedAt });
 });
 
 // Resolve the latest active share token for a doc — the schema-current

--- a/packages/shared/src/refresh-copy.spec-196.test.ts
+++ b/packages/shared/src/refresh-copy.spec-196.test.ts
@@ -1,0 +1,88 @@
+// spec-196 t-3 — the dec-3 consolidation copy, pinned at its live homes.
+//
+// dec-1: human-facing strings say "spec narrative"; internal vocabulary keeps
+// "narrative" (node ids, field names, the assess_spec mode). dec-3 set the two
+// approved strings. The LIVE home of the refresh prompt is the scaffold's
+// `opening-refresh-narrative` opening-turn helper (spec-123) — the top-bar
+// RefreshSpecButton is unmounted and merely kept in sync.
+//
+//   ac-2  : every human-facing prompt string says "spec narrative"; the old
+//           phrasings are gone.
+//   ac-7  : no internal rename — node id, field names, exports unchanged.
+//   ac-11 : the refresh prompt equals the dec-3 string exactly.
+
+import { describe, it, expect } from 'vitest';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { BASE_SCAFFOLD } from './scaffold-data';
+import {
+  computeSpecReadiness,
+  isSpecNarrativeStale,
+  countStaleDecisions,
+} from './spec-readiness';
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-196/acs/ac-${n}`;
+
+const DEC3_PROMPT =
+  'Update the spec narrative — walk every decision modified since the last consolidation and update the affected sections so the narrative reflects what was decided.';
+
+function refreshNode() {
+  const node = BASE_SCAFFOLD.promptButtons.find((b) => b.id === 'opening-refresh-narrative');
+  if (!node) throw new Error('opening-refresh-narrative node missing from BASE_SCAFFOLD');
+  return node;
+}
+
+describe('spec-196 t-3 — consolidation copy (dec-3)', () => {
+  it('the opening-turn refresh helper carries the exact dec-3 prompt and the "spec narrative" label (ac-2, ac-11)', () => {
+    tagAc(AC(2));
+    tagAc(AC(11));
+    const node = refreshNode();
+    expect(node.text).toBe(DEC3_PROMPT);
+    expect(node.label).toBe('Update spec narrative');
+  });
+
+  it('the stale-narrative CTA points at the live helper in "spec narrative" terms (ac-2)', () => {
+    tagAc(AC(2));
+    const r = computeSpecReadiness({
+      currentPhase: 'specify',
+      decisions: [
+        {
+          id: 'd-1',
+          createdAt: '2026-06-01T00:00:00Z',
+          resolvedAt: '2026-06-05T00:00:00Z',
+          status: 'resolved',
+        },
+      ],
+      openCommentCount: 0,
+      narrativeLastConsolidatedAt: '2026-06-02T00:00:00Z',
+    });
+    const stale = r.outstandingItems.find((i) => i.kind === 'stale_narrative');
+    expect(stale?.cta).toBe('Use the "Update spec narrative" helper to consolidate.');
+  });
+
+  it('the retired phrasings are gone from every prompt-button string (ac-2)', () => {
+    tagAc(AC(2));
+    for (const b of BASE_SCAFFOLD.promptButtons) {
+      expect(b.text).not.toMatch(/Refresh the Spec narrative/i);
+      expect(b.label).not.toMatch(/^Update narrative$/i);
+    }
+  });
+
+  it('no internal rename: node id and shared staleness exports keep the word "narrative" (ac-7)', () => {
+    tagAc(AC(7));
+    // The node id is internal vocabulary — dec-1 keeps it.
+    expect(refreshNode().id).toBe('opening-refresh-narrative');
+    // The shared staleness surface is intact under its original names.
+    expect(typeof isSpecNarrativeStale).toBe('function');
+    expect(typeof countStaleDecisions).toBe('function');
+    expect(
+      isSpecNarrativeStale('2026-06-06T00:00:00Z', [
+        {
+          id: 'd-1',
+          createdAt: '2026-06-01T00:00:00Z',
+          resolvedAt: '2026-06-05T00:00:00Z',
+          status: 'resolved',
+        },
+      ]),
+    ).toBe(false);
+  });
+});

--- a/packages/shared/src/scaffold-data.ts
+++ b/packages/shared/src/scaffold-data.ts
@@ -1577,12 +1577,13 @@ const OPENING_TURN_PROMPT_BUTTONS: PromptButtonNode[] = [
   {
     kind: 'prompt_button',
     id: 'opening-refresh-narrative',
-    label: 'Update narrative',
-    // VERBATIM the prompt RefreshSpecButton sends today (spec-123 ac-11).
-    text: 'Refresh the Spec narrative — walk every decision modified since the last consolidation and propose updates to the affected sections.',
+    label: 'Update spec narrative',
+    // spec-196 dec-3: the approved consolidation prompt. Human-facing copy
+    // says "spec narrative" (dec-1); the node id keeps the internal word.
+    text: 'Update the spec narrative — walk every decision modified since the last consolidation and update the affected sections so the narrative reflects what was decided.',
     surfaces: ['opening-turn'],
     rationale:
-      'spec-123 dec-4/ac-11: the "New decisions — update narrative" secondary-helper trigger. Verbatim the text the top-bar RefreshSpecButton injects today.',
+      'spec-123 dec-4/ac-11 housed the trigger; spec-196 dec-3 set the copy: human-facing strings say "spec narrative" and the prompt asks for the sections to be UPDATED (not merely proposed) so the prose reflects what was decided before specify→build.',
   },
   {
     kind: 'prompt_button',

--- a/packages/shared/src/spec-readiness.test.ts
+++ b/packages/shared/src/spec-readiness.test.ts
@@ -291,7 +291,7 @@ describe('computeSpecReadiness', () => {
       staleDecisionCount: 2,
       label: '2 decisions not yet reflected in the narrative',
     });
-    expect(r.outstandingItems[0].cta).toContain('New decisions — update narrative');
+    expect(r.outstandingItems[0].cta).toContain('Update spec narrative');
   });
 
   it('uses singular "decision" when only one is stale', () => {
@@ -524,7 +524,7 @@ describe('blockerLines', () => {
     const lines = blockerLines(r);
     expect(lines).toEqual([
       '1 open comment — Use the "Resolve Comments" button to walk them with the agent.',
-      '3 decisions not yet reflected in the narrative — Use the "New decisions — update narrative" button to consolidate.',
+      '3 decisions not yet reflected in the narrative — Use the "Update spec narrative" helper to consolidate.',
     ]);
   });
 

--- a/packages/shared/src/spec-readiness.ts
+++ b/packages/shared/src/spec-readiness.ts
@@ -62,8 +62,11 @@ export type SpecReadiness = {
 
 const RESOLVE_COMMENTS_CTA =
   'Use the "Resolve Comments" button to walk them with the agent.';
+// spec-196 dec-3/dec-1: human-facing copy says "spec narrative"; the live
+// affordance is the opening-turn "Update spec narrative" helper (spec-123),
+// not the retired top-bar button.
 const REFRESH_SPEC_CTA =
-  'Use the "New decisions — update narrative" button to consolidate.';
+  'Use the "Update spec narrative" helper to consolidate.';
 const RESOLVE_DECISIONS_CTA =
   'Resolve them on the Decisions tab — tasks are first-class only once decisions are settled.';
 const OPEN_ISSUES_CTA =
@@ -205,7 +208,7 @@ export function computeSpecReadiness(input: ReadinessInput): SpecReadiness {
 /**
  * Convenience: human-readable lines for a confirm dialog or MCP response.
  * One line per outstanding item, formatted like:
- *   `3 decisions not yet reflected in the narrative — use the "New decisions — update narrative" button to consolidate.`
+ *   `3 decisions not yet reflected in the narrative — Use the "Update spec narrative" helper to consolidate.`
  */
 export function blockerLines(readiness: SpecReadiness): string[] {
   return readiness.outstandingItems.map((item) => `${item.label} — ${item.cta}`);

--- a/packages/ui/e2e/helpers/retained.ts
+++ b/packages/ui/e2e/helpers/retained.ts
@@ -64,6 +64,25 @@ export async function seedSpec(opts: {
   return call("POST", "/seed-spec", opts);
 }
 
+/** spec-196: set a doc's status through the real updateDocStatus service —
+ *  for phases the UI can't browse to (e.g. `done` for the read view). */
+export async function setDocStatus(opts: {
+  memexId: string;
+  docId: string;
+  status: string;
+}): Promise<{ docId: string; status: string }> {
+  return call("POST", "/set-doc-status", opts);
+}
+
+/** spec-196: stamp narrativeLastConsolidatedAt = now() through the real
+ *  markNarrativeConsolidated service (assess_spec consolidate's effect). */
+export async function consolidateNarrative(opts: {
+  memexId: string;
+  docId: string;
+}): Promise<{ consolidatedAt: string }> {
+  return call("POST", "/consolidate-narrative", opts);
+}
+
 /** Seed a standard / document (first section carries `body` for FTS). */
 export async function seedDoc(opts: {
   memexId: string;

--- a/packages/ui/e2e/journey-15-spec-detail-layout.spec.ts
+++ b/packages/ui/e2e/journey-15-spec-detail-layout.spec.ts
@@ -68,10 +68,10 @@ test.describe("Spec detail layout", () => {
     await expect(bodyHeader.getByRole("button", { name: "Share", exact: true })).toHaveCount(0);
     await expect(bodyHeader.getByRole("button", { name: "Download Spec" })).toHaveCount(0);
 
-    // Plan-phase sub-tabs (post spec-164/159 redesign): Narrative active by
+    // Plan-phase sub-tabs (post spec-164/159 redesign): the Spec sub-tab (the narrative) active by
     // default, then Decisions & ACs, then Comments. Tasks moved under the Build
     // PHASE tab (not a sub-tab pill here), so it's no longer in this row.
-    await expect(page.getByRole("button", { name: /^Narrative/ })).toBeVisible();
+    await expect(page.getByRole("button", { name: /^Spec\b/ })).toBeVisible();
     await expect(page.getByRole("button", { name: /^Decisions & ACs/ })).toBeVisible();
     await expect(page.getByRole("button", { name: /^Comments/ })).toBeVisible();
 
@@ -89,7 +89,7 @@ test.describe("Spec detail layout", () => {
     // Switching sub-tabs is in-page — assert we're still on the spec, not that the
     // path is /docs/.
     await expect(page).toHaveURL(/\/specs\//);
-    await page.getByRole("button", { name: /^Narrative/ }).click();
+    await page.getByRole("button", { name: /^Spec\b/ }).click();
 
     // Floating outline (DocOutline) — Segments label + section list visible. The
     // seeded spec's first section is the createDocDraft "Overview" (not "Purpose").

--- a/packages/ui/e2e/journey-21-spec-196-narrative.spec.ts
+++ b/packages/ui/e2e/journey-21-spec-196-narrative.spec.ts
@@ -1,0 +1,182 @@
+// Journey 21 — spec-196 (std-28 PR-gate journey).
+//
+// Two user-facing flows this Spec adds:
+//
+//   1. The specify→build narrative gate: with every decision resolved but the
+//      spec narrative stale (decisions newer than narrativeLastConsolidatedAt),
+//      the Rubicon line states that the SPEC NARRATIVE must be updated — with
+//      the how — instead of offering the move to Build. Once consolidation
+//      stamps the timestamp, the advancement offer appears. (ac-3, ac-4, ac-9)
+//   2. The done view's "Read the spec" control: any viewer expands the full
+//      record inline — narrative sections + decisions/tasks/ACs/issues — with
+//      no reopen and no phase change. (ac-12)
+//
+// Seeding goes over the env-gated test surface (no raw SQL): seed-spec,
+// seed-open-decision, seed-ac, seed-task, set-doc-status, consolidate-narrative.
+// Navigation is path-based [per std-2]. The sub-tab reading "Spec" (t-1) is
+// asserted by journey-15's layout walk.
+
+import {
+  test,
+  expect,
+  tenantPath,
+  switchToEditing,
+  seedAc,
+  seedTask,
+  seedOpenDecision,
+  emitAcEvents,
+} from "./helpers/index.js";
+import {
+  seedOrgTenant,
+  seedSpec,
+  setDocStatus,
+  consolidateNarrative,
+} from "./helpers/retained.js";
+
+const SPEC196 = "mindset-prod/memex-building-itself/specs/spec-196";
+const ACS_BY_TEST: Record<string, string[]> = {
+  "specify→build gate: stale narrative blocks the offer; consolidation restores it": [
+    `${SPEC196}/acs/ac-3`,
+    `${SPEC196}/acs/ac-4`,
+    `${SPEC196}/acs/ac-9`,
+  ],
+  '"Read the spec" on a done Spec: full record inline, no reopen, no phase change': [
+    `${SPEC196}/acs/ac-12`,
+  ],
+};
+
+test.afterEach(async ({}, testInfo) => {
+  if (testInfo.status === "skipped") return;
+  const refs = ACS_BY_TEST[testInfo.title];
+  if (!refs) return;
+  await emitAcEvents(
+    refs,
+    testInfo.status === "passed" ? "pass" : "fail",
+    `packages/ui/e2e/journey-21-spec-196-narrative.spec.ts::${testInfo.title}`,
+    testInfo.duration
+  );
+});
+
+test("specify→build gate: stale narrative blocks the offer; consolidation restores it", async ({
+  page,
+  resources,
+}) => {
+  const tenant = await seedOrgTenant({ slug: resources.slug("j21a") });
+  const spec = await seedSpec({
+    memexId: tenant.memexId,
+    title: "Narrative gate journey",
+    purpose: "Exercise the spec-narrative staleness gate.",
+  });
+
+  // Shape the rubric so the ONLY remaining specify→build condition after the
+  // decision resolves is narrative freshness: an AC exists, one open decision.
+  await seedAc({
+    memexId: tenant.memexId,
+    docId: spec.docId,
+    kind: "scope",
+    statement: "The gate journey passes.",
+  });
+  await seedOpenDecision({
+    memexId: tenant.memexId,
+    docId: spec.docId,
+    title: "Pick the gate's colour",
+    context: "Amber or green.",
+    options: [
+      { label: "Amber", trade_offs: "Cautious." },
+      { label: "Green", trade_offs: "Confident." },
+    ],
+  });
+  await setDocStatus({ memexId: tenant.memexId, docId: spec.docId, status: "specify" });
+
+  await page.goto(
+    tenantPath(tenant.namespaceSlug, tenant.memexSlug, `/specs/${spec.handle}`)
+  );
+  // While the decision is open, the decisions blocker leads — no narrative talk.
+  const rubicon = page.getByTestId("transition-sentence");
+  await expect(rubicon).toContainText(/1 Decision must be resolved/i, { timeout: 15_000 });
+  await expect(rubicon).not.toContainText(/spec narrative/i);
+
+  // Resolve the decision through the real UI (editor posture required).
+  await switchToEditing(page);
+  await page.getByRole("button", { name: /Decisions & ACs/ }).click();
+  const panel = page.getByTestId("decision-panel");
+  await expect(panel).toContainText(/Pick the gate's colour/, { timeout: 15_000 });
+  await panel.getByTestId("open-option-1").first().check();
+  await panel.getByTestId("decision-resolve").first().click();
+  await panel.getByTestId("open-resolution-text").first().fill("Green — we're confident.");
+  await panel.getByTestId("open-resolve-confirm").first().click();
+  await expect(panel.getByRole("button", { name: /^Resolved 1$/ })).toBeVisible({
+    timeout: 15_000,
+  });
+
+  // All decisions resolved + AC present + never consolidated → the Rubicon
+  // states the staleness condition WITH the how-to tail, and offers no move.
+  await expect(rubicon).toContainText(
+    /The spec narrative must be updated to reflect the resolved decisions before this spec can move to Build — use the refresh action to generate the update prompt\./,
+    { timeout: 15_000 }
+  );
+  await expect(rubicon.getByRole("button", { name: /^Yes$/ })).toHaveCount(0);
+
+  // Consolidate (what assess_spec({mode:'consolidate'}) stamps) → the live
+  // change stream refreshes the doc and the advancement offer appears.
+  await consolidateNarrative({ memexId: tenant.memexId, docId: spec.docId });
+  await expect(rubicon).toContainText(/Do you wish to move this spec to Build\?/, {
+    timeout: 15_000,
+  });
+  await expect(rubicon).not.toContainText(/spec narrative/i);
+});
+
+test('"Read the spec" on a done Spec: full record inline, no reopen, no phase change', async ({
+  page,
+  resources,
+}) => {
+  const tenant = await seedOrgTenant({ slug: resources.slug("j21b") });
+  const spec = await seedSpec({
+    memexId: tenant.memexId,
+    title: "Done read journey",
+    purpose: "The whole narrative readable in place.",
+  });
+  await seedTask({
+    memexId: tenant.memexId,
+    docId: spec.docId,
+    title: "Ship the read control",
+    status: "complete",
+  });
+  await seedAc({
+    memexId: tenant.memexId,
+    docId: spec.docId,
+    kind: "scope",
+    statement: "Readers read without reopening.",
+  });
+  await setDocStatus({ memexId: tenant.memexId, docId: spec.docId, status: "done" });
+
+  await page.goto(
+    tenantPath(tenant.namespaceSlug, tenant.memexSlug, `/specs/${spec.handle}`)
+  );
+
+  // The done report renders. The dev user opens the seeded Spec as a REVIEWER
+  // (no doc_members row) but WITH org write access — so spec-196's relaxed gate
+  // shows BOTH the read control (reading is not a write) and Reopen (gated on
+  // write access, not editor posture). Both sit on one footer row.
+  const report = page.getByTestId("done-summary");
+  await expect(report).toContainText(/completed on/, { timeout: 15_000 });
+  await expect(page.getByTestId("done-reopen")).toBeVisible();
+  const toggle = page.getByTestId("done-read-spec");
+  await expect(toggle).toBeVisible();
+  await expect(page.getByTestId("done-read-spec-body")).toHaveCount(0);
+
+  // Expand: the full record — narrative prose, task, AC — inline, read-only.
+  await toggle.click();
+  const body = page.getByTestId("done-read-spec-body");
+  await expect(body).toContainText("The whole narrative readable in place.");
+  await expect(body).toContainText("Ship the read control");
+  await expect(body).toContainText("Readers read without reopening.");
+  // No mutation affordances inside the record.
+  await expect(body.getByRole("button")).toHaveCount(0);
+
+  // Collapse — and the Spec never left `done` (the phase pill still says so;
+  // expanding was pure presentation).
+  await toggle.click();
+  await expect(page.getByTestId("done-read-spec-body")).toHaveCount(0);
+  await expect(report).toContainText(/completed on/);
+});

--- a/packages/ui/src/components/DoneSummary.spec-196.test.tsx
+++ b/packages/ui/src/components/DoneSummary.spec-196.test.tsx
@@ -1,0 +1,243 @@
+// spec-196 t-4 — "Read the spec" on the done view (dec-4).
+//
+// A done Spec's content was unreachable without reopening it (a phase change
+// just to READ). DoneSummary now carries a "Read the spec" toggle beneath the
+// Reopen area: every posture sees it, it's collapsed by default, and the
+// expanded record renders the sorted narrative sections plus read-only
+// decision/task/AC/issue detail — all from the props the page already passes
+// (NOT the live panels, which fetch their own data).
+//
+//   ac-12 : any viewer reads the whole spec in place; no reopen, no phase change.
+//   ac-13 : toggle below Reopen, all postures, collapsed default; expanded =
+//           sections + decisions + tasks + ACs + issues from props.
+//   ac-14 : zero network, zero mutation affordances, zero phase mutation.
+
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { DoneSummary } from './DoneSummary';
+import type { Decision, Task, Issue, DocWithGraph } from '../api/types';
+import type { AcWithVerification } from '../api/client';
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-196/acs/ac-${n}`;
+
+const CREATED_AT = '2026-06-02T12:00:00Z';
+const COMPLETED_AT = '2026-06-09T12:00:00Z';
+
+function makeDoc(overrides: Partial<DocWithGraph> = {}): DocWithGraph {
+  return {
+    id: 'doc-uuid',
+    handle: 'spec-196',
+    title: 'Done view read control',
+    docType: 'spec',
+    status: 'done',
+    creator: { name: 'Barrie Hadfield', email: 'barrie@mindset.ai' },
+    createdAt: CREATED_AT,
+    statusChangedAt: COMPLETED_AT,
+    // Deliberately out of order — the read view must sort by seq.
+    sections: [
+      {
+        id: 's-2',
+        sectionType: 'design',
+        title: 'Design & UX',
+        content: 'The **second** section.',
+        seq: 2,
+        createdAt: CREATED_AT,
+        updatedAt: COMPLETED_AT,
+      },
+      {
+        id: 's-1',
+        sectionType: 'overview',
+        title: null,
+        content: 'The *first* section.',
+        seq: 1,
+        createdAt: CREATED_AT,
+        updatedAt: COMPLETED_AT,
+      },
+    ],
+    decisions: [],
+    tasks: [],
+    ...overrides,
+  } as DocWithGraph;
+}
+
+const DECISIONS: Decision[] = [
+  {
+    id: 'dec-1',
+    docId: 'doc-uuid',
+    seq: 1,
+    title: 'Pick the approach',
+    context: null,
+    status: 'resolved',
+    resolution: 'We picked the calm one.',
+    resolvedAt: COMPLETED_AT,
+    createdAt: CREATED_AT,
+    options: null,
+    chosenOptionIndex: null,
+  },
+];
+
+const TASKS: Task[] = [
+  {
+    id: 't-1',
+    docId: 'doc-uuid',
+    seq: 1,
+    title: 'Ship the thing',
+    description: '',
+    acceptanceCriteria: [],
+    sectionRef: null,
+    status: 'complete',
+    blocked: false,
+    blockedByDecisions: [],
+    blockedByTasks: [],
+    createdAt: CREATED_AT,
+    startedAt: null,
+    completedAt: COMPLETED_AT,
+  },
+];
+
+const ACS: AcWithVerification[] = [
+  {
+    ac: {
+      id: 'ac-1',
+      memexId: 'memex',
+      briefId: 'doc-uuid',
+      seq: 1,
+      kind: 'scope',
+      statement: 'The thing ships',
+      status: 'active',
+      createdAt: CREATED_AT,
+      updatedAt: COMPLETED_AT,
+    },
+    canonicalRef: 'x/y/specs/spec-196/acs/ac-1',
+    tests: [],
+    verificationState: 'verified',
+    daysSinceLastRun: null,
+    parents: [],
+  } as unknown as AcWithVerification,
+];
+
+const ISSUES: Issue[] = [
+  {
+    id: 'i-1',
+    docId: 'doc-uuid',
+    seq: 1,
+    title: 'A wobble',
+    body: '',
+    type: 'bug',
+    severity: null,
+    status: 'resolved',
+    source: 'human',
+    satisfyingTaskId: null,
+    promotedDocId: null,
+    createdAt: CREATED_AT,
+    updatedAt: COMPLETED_AT,
+  } as Issue,
+];
+
+let fetchSpy: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  // Any fetch from inside the component is a contract violation (ac-14, and
+  // spec-159's original ac-9 no-network posture).
+  fetchSpy = vi.fn(() => Promise.reject(new Error('DoneSummary must not fetch')));
+  vi.stubGlobal('fetch', fetchSpy);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function renderDone(props: Partial<React.ComponentProps<typeof DoneSummary>> = {}) {
+  return render(
+    <DoneSummary
+      doc={makeDoc()}
+      decisions={DECISIONS}
+      tasks={TASKS}
+      acs={ACS}
+      issues={ISSUES}
+      {...props}
+    />,
+  );
+}
+
+describe('spec-196 — "Read the spec" on the done view', () => {
+  it('renders for a non-member (canReopen false → no Reopen) and is collapsed by default (ac-12, ac-13)', () => {
+    tagAc(AC(12));
+    tagAc(AC(13));
+    renderDone({ canReopen: false });
+
+    // Reading is offered to everyone; Reopen needs write access (canReopen),
+    // so a non-member sees the read control but not Reopen.
+    expect(screen.queryByTestId('done-reopen')).not.toBeInTheDocument();
+    const toggle = screen.getByTestId('done-read-spec');
+    expect(toggle).toHaveTextContent('Read the spec');
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    // Collapsed: the record body is absent.
+    expect(screen.queryByTestId('done-read-spec-body')).not.toBeInTheDocument();
+  });
+
+  it('Reopen and Read the spec share one footer action row (ac-16)', () => {
+    tagAc(AC(16));
+    renderDone({ canReopen: true });
+
+    const read = screen.getByTestId('done-read-spec');
+    const reopen = screen.getByTestId('done-reopen');
+    // Both buttons sit in the SAME row container — not two stacked,
+    // separately-divided blocks (the old layout).
+    expect(read.parentElement).toBe(reopen.parentElement);
+    // Exactly one divider rule fronts the footer (the row's container), not
+    // one per button.
+    const row = read.parentElement!;
+    expect(row.className).toContain('flex');
+  });
+
+  it('expanding shows the sorted sections and the full detail; collapsing hides it (ac-12, ac-13)', () => {
+    tagAc(AC(12));
+    tagAc(AC(13));
+    renderDone({ canReopen: true });
+
+    fireEvent.click(screen.getByTestId('done-read-spec'));
+    const body = screen.getByTestId('done-read-spec-body');
+
+    // Sections render sorted by seq (s-1 first despite prop order), title
+    // falling back to sectionType, markdown rendered as prose.
+    const sections = within(body).getAllByTestId('done-read-section');
+    expect(sections).toHaveLength(2);
+    expect(sections[0].textContent).toContain('1. overview');
+    expect(sections[0].textContent).toContain('The first section.');
+    expect(sections[0].querySelector('em')?.textContent).toBe('first');
+    expect(sections[1].textContent).toContain('2. Design & UX');
+    expect(sections[1].querySelector('strong')?.textContent).toBe('second');
+
+    // The detail record — decisions (with resolution), tasks, ACs, issues.
+    expect(within(body).getByTestId('done-read-decision').textContent).toContain(
+      'We picked the calm one.',
+    );
+    expect(within(body).getByTestId('done-read-task').textContent).toContain('Ship the thing');
+    expect(within(body).getByTestId('done-read-ac').textContent).toContain('The thing ships');
+    expect(within(body).getByTestId('done-read-ac').textContent).toContain('verified');
+    expect(within(body).getByTestId('done-read-issue').textContent).toContain('A wobble');
+
+    // Toggle closed again — the calm report is the resting state.
+    fireEvent.click(screen.getByTestId('done-read-spec'));
+    expect(screen.queryByTestId('done-read-spec-body')).not.toBeInTheDocument();
+  });
+
+  it('reading is inert: no fetch, no mutation affordances, no phase change (ac-14)', () => {
+    tagAc(AC(14));
+    const onReopen = vi.fn();
+    renderDone({ canReopen: true, onReopen });
+
+    fireEvent.click(screen.getByTestId('done-read-spec'));
+    const body = screen.getByTestId('done-read-spec-body');
+
+    // Zero network across render + expand.
+    expect(fetchSpy).not.toHaveBeenCalled();
+    // Zero mutation affordances inside the record — not a single button.
+    expect(within(body).queryAllByRole('button')).toHaveLength(0);
+    // Zero phase mutation — expanding/collapsing never touches onReopen.
+    fireEvent.click(screen.getByTestId('done-read-spec'));
+    expect(onReopen).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/components/DoneSummary.tsx
+++ b/packages/ui/src/components/DoneSummary.tsx
@@ -11,12 +11,25 @@
 // no new endpoint, no new table. The same panels (DecisionPanel / TaskPanel /
 // AcPanel / IssuePanel) are handed these exact shapes elsewhere on the page.
 //
+// spec-196 dec-4: beneath the report, a "Read the spec" toggle (ALL postures —
+// reading is not a write) expands the full record inline: the sorted narrative
+// sections plus read-only decision/task/AC/issue detail. It shares the footer's
+// single action row with Reopen (which spec-196 relaxed from an editor-posture
+// gate to an org-write gate — the reviewer/editor split means nothing here).
+// Deliberately NOT the live panels — AcPanel and IssuePanel fetch their own
+// data and TaskPanel fetches plan readiness, which would break this
+// component's fetch-free posture (ac-9 / spec-196 ac-14). The detail renders
+// from the props above; no mutation affordances; expanding never changes phase.
+//
 // Timeline degradation: the doc data carries only `createdAt` and the LATEST
 // `statusChangedAt` (when it became `done`) — there is no per-phase change log
 // on the doc today. So the timeline renders what's actually known (start → done
 // + total elapsed) rather than fabricating intermediate specify/build/verify dates.
 
 import { useState } from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import rehypeHighlight from 'rehype-highlight';
 import type { Decision, Task, Issue, DocWithGraph } from '../api/types';
 import type { AcWithVerification, DocAssigneeView } from '../api/client';
 import { Button, Card } from './ui';
@@ -40,11 +53,12 @@ interface DoneSummaryProps {
    */
   people?: DocAssigneeView[];
   /**
-   * spec-164 dec-5: when true (editor posture, same gate as the transition
-   * sentence's Yes), the report carries a single "Reopen" affordance — the
-   * one deliberate door back to `verify`. Hidden for read-only viewers and
-   * writable reviewers. Defaults to false so existing call sites stay
-   * report-only.
+   * spec-164 dec-5 (relaxed by spec-196): when true the report carries the
+   * "Reopen" affordance — the one deliberate door back to `verify`. The parent
+   * now gates this on org WRITE ACCESS, not an editor posture: the
+   * reviewer/editor distinction carries no meaning on a closed spec, so any
+   * member who could write may reopen. Still hidden for read-only (non-member)
+   * viewers, whose reopen would 403. Defaults to false.
    */
   canReopen?: boolean;
   /**
@@ -110,6 +124,11 @@ export function DoneSummary({
   // Yes/Cancel; 'submitting' while the parent's status write is in flight.
   const [reopenState, setReopenState] = useState<'idle' | 'confirming' | 'submitting'>('idle');
 
+  // spec-196 dec-4: "Read the spec" — collapsed by default so the calm
+  // retrospective stays the landing state; expanding is pure presentation
+  // (no fetch, no phase change).
+  const [readOpen, setReadOpen] = useState(false);
+
   const handleReopenYes = async () => {
     setReopenState('submitting');
     try {
@@ -153,6 +172,10 @@ export function DoneSummary({
 
   const completedAt = doc.statusChangedAt;
   const totalDays = daysBetween(doc.createdAt, completedAt);
+
+  // spec-196 dec-4: the full record, from data already in hand.
+  const sortedSections = [...(doc.sections ?? [])].sort((a, b) => a.seq - b.seq);
+  const recordHeading = 'text-sm font-semibold text-muted tracking-wide mb-3';
 
   return (
     <Card variant="panel" data-testid="done-summary" className="max-w-3xl mx-auto">
@@ -198,46 +221,147 @@ export function DoneSummary({
         </ReportRow>
       </div>
 
-      {/* spec-164 dec-5: the one deliberate door back. Editor-gated; an
-          explicit confirm; the parent performs the verify status write. */}
-      {canReopen && (
-        <div className="mt-6 pt-4 border-t border-edge-subtle text-center text-sm text-secondary">
-          {reopenState === 'idle' ? (
-            <Button
-              type="button"
-              variant="secondary"
-              size="sm"
-              data-testid="done-reopen"
-              onClick={() => setReopenState('confirming')}
-            >
-              Reopen
-            </Button>
-          ) : (
-            <span data-testid="done-reopen-confirm">
-              Move this spec back to {phaseDisplayName('verify')}?{' '}
-              <Button
-                type="button"
-                variant="primary"
-                size="sm"
-                data-testid="done-reopen-yes"
-                disabled={reopenState === 'submitting'}
-                onClick={() => void handleReopenYes()}
-              >
-                {reopenState === 'submitting' ? 'Reopening…' : 'Yes'}
-              </Button>{' '}
+      {/* The done view's action footer — one divider, one centred row.
+          • "Read the spec" (spec-196 dec-4) is offered to everyone — reading is
+            not a write.
+          • "Reopen" (spec-164 dec-5, relaxed by spec-196) needs org write
+            access (canReopen) but NOT an editor posture — the reviewer/editor
+            distinction is meaningless on a closed spec. An explicit two-step
+            confirm; the parent performs the verify status write. */}
+      <div className="mt-6 pt-4 border-t border-edge-subtle">
+        <div className="flex flex-wrap items-center justify-center gap-3 text-sm text-secondary">
+          <Button
+            type="button"
+            variant="secondary"
+            size="sm"
+            data-testid="done-read-spec"
+            aria-expanded={readOpen}
+            onClick={() => setReadOpen((v) => !v)}
+          >
+            {readOpen ? 'Hide the spec' : 'Read the spec'}
+          </Button>
+
+          {canReopen &&
+            (reopenState === 'idle' ? (
               <Button
                 type="button"
                 variant="secondary"
                 size="sm"
-                disabled={reopenState === 'submitting'}
-                onClick={() => setReopenState('idle')}
+                data-testid="done-reopen"
+                onClick={() => setReopenState('confirming')}
               >
-                Cancel
+                Reopen
               </Button>
-            </span>
-          )}
+            ) : (
+              <span
+                data-testid="done-reopen-confirm"
+                className="inline-flex flex-wrap items-center gap-2"
+              >
+                Move this spec back to {phaseDisplayName('verify')}?
+                <Button
+                  type="button"
+                  variant="primary"
+                  size="sm"
+                  data-testid="done-reopen-yes"
+                  disabled={reopenState === 'submitting'}
+                  onClick={() => void handleReopenYes()}
+                >
+                  {reopenState === 'submitting' ? 'Reopening…' : 'Yes'}
+                </Button>
+                <Button
+                  type="button"
+                  variant="secondary"
+                  size="sm"
+                  disabled={reopenState === 'submitting'}
+                  onClick={() => setReopenState('idle')}
+                >
+                  Cancel
+                </Button>
+              </span>
+            ))}
         </div>
-      )}
+
+        {readOpen && (
+          <div data-testid="done-read-spec-body" className="mt-6 space-y-8 text-left">
+            {/* The narrative — sorted sections, same prose treatment as the
+                live page, minus comments/editing. */}
+            <div className="space-y-6">
+              {sortedSections.map((section, index) => (
+                <div key={section.id} data-testid="done-read-section">
+                  <h4 className="text-base font-semibold text-primary mb-2">
+                    {index + 1}. {section.title || section.sectionType}
+                  </h4>
+                  <div className="prose-dark overflow-hidden">
+                    <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>
+                      {section.content}
+                    </ReactMarkdown>
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            {decisions.length > 0 && (
+              <div>
+                <h3 className={recordHeading}>Decisions</h3>
+                <ul className="space-y-3">
+                  {decisions.map((d) => (
+                    <li key={d.id} className="text-sm" data-testid="done-read-decision">
+                      <span className="font-medium text-primary">{d.title}</span>{' '}
+                      <span className="text-muted">({d.status})</span>
+                      {d.resolution && (
+                        <div className="text-secondary mt-1 whitespace-pre-wrap">{d.resolution}</div>
+                      )}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+
+            {tasks.length > 0 && (
+              <div>
+                <h3 className={recordHeading}>Tasks</h3>
+                <ul className="space-y-1.5">
+                  {tasks.map((t) => (
+                    <li key={t.id} className="text-sm text-primary" data-testid="done-read-task">
+                      {t.title} <span className="text-muted">({t.status.replace('_', ' ')})</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+
+            {acs.length > 0 && (
+              <div>
+                <h3 className={recordHeading}>Acceptance Criteria</h3>
+                <ul className="space-y-1.5">
+                  {acs.map((a) => (
+                    <li key={a.ac.id} className="text-sm text-primary" data-testid="done-read-ac">
+                      {a.ac.statement}{' '}
+                      <span className="text-muted">
+                        ({a.ac.kind}
+                        {a.verificationState === 'verified' ? ' · verified' : ''})
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+
+            {issues.length > 0 && (
+              <div>
+                <h3 className={recordHeading}>Issues</h3>
+                <ul className="space-y-1.5">
+                  {issues.map((i) => (
+                    <li key={i.id} className="text-sm text-primary" data-testid="done-read-issue">
+                      {i.title} <span className="text-muted">({i.status})</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
     </Card>
   );
 }

--- a/packages/ui/src/components/RefreshSpecButton.test.tsx
+++ b/packages/ui/src/components/RefreshSpecButton.test.tsx
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { BASE_SCAFFOLD } from '@memex/shared';
 import {
   RefreshSpecButton,
   isSpecNarrativeStale,
@@ -137,7 +139,28 @@ describe('RefreshSpecButton — click behavior', () => {
 
     expect(mockSendMessage).toHaveBeenCalledTimes(1);
     expect(mockSendMessage).toHaveBeenCalledWith(
-      expect.stringMatching(/Refresh the Spec narrative/i),
+      expect.stringMatching(/Update the spec narrative/i),
     );
+  });
+});
+
+// spec-196 t-3 (ac-11): the orphaned top-bar button stays verbatim-in-sync
+// with the LIVE home of this copy — the scaffold's opening-refresh-narrative
+// helper. A drift between the two would ship two different consolidation
+// prompts depending on which surface fires.
+describe('spec-196 — dec-3 copy kept in sync with the scaffold node', () => {
+  const AC11 = 'mindset-prod/memex-building-itself/specs/spec-196/acs/ac-11';
+
+  it('the clipboard prompt equals the dec-3 string exactly and matches the scaffold node', async () => {
+    tagAc(AC11);
+    const user = userEvent.setup();
+    renderRefresh();
+    await user.click(screen.getByRole('button', { name: /update spec narrative/i }));
+
+    const expected =
+      'Update the spec narrative — walk every decision modified since the last consolidation and update the affected sections so the narrative reflects what was decided.';
+    expect(mockSendMessage).toHaveBeenCalledWith(expected);
+    const node = BASE_SCAFFOLD.promptButtons.find((b) => b.id === 'opening-refresh-narrative');
+    expect(node?.text).toBe(expected);
   });
 });

--- a/packages/ui/src/components/RefreshSpecButton.tsx
+++ b/packages/ui/src/components/RefreshSpecButton.tsx
@@ -27,8 +27,12 @@ export interface RefreshSpecButtonProps {
   decisions: Decision[];
 }
 
+// spec-196 dec-3: the approved consolidation prompt. Kept verbatim in sync
+// with the scaffold's `opening-refresh-narrative` node (scaffold-data.ts),
+// which is the LIVE home of this copy — this component is currently unmounted
+// (the opening-turn helper superseded the top-bar button, spec-123).
 const REFRESH_PROMPT =
-  'Refresh the Spec narrative — walk every decision modified since the last consolidation and propose updates to the affected sections.';
+  'Update the spec narrative — walk every decision modified since the last consolidation and update the affected sections so the narrative reflects what was decided.';
 
 // Doc-12 DRY refactor: the staleness rule (max(createdAt, resolvedAt) >
 // narrativeLastConsolidatedAt) lives in @memex/shared/spec-readiness so
@@ -57,10 +61,10 @@ export function RefreshSpecButton({
       type="button"
       variant="secondary"
       size="sm"
-      aria-label="New decisions — update Spec narrative"
+      aria-label="New decisions — update spec narrative"
       onClick={() => chat.sendMessage(REFRESH_PROMPT)}
     >
-      New decisions — update narrative
+      New decisions — update spec narrative
     </Button>
   );
 }

--- a/packages/ui/src/components/TransitionSentence.spec-196.test.tsx
+++ b/packages/ui/src/components/TransitionSentence.spec-196.test.tsx
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { TransitionSentence } from './TransitionSentence';
+import type { SpecStatus } from '../api/types';
+
+// spec-196 t-2 — the Rubicon line's narrative-staleness blocker (dec-2/dec-3).
+//
+// On the specify→build axis, once every decision is resolved, a stale
+// narrative (any decision modified after narrativeLastConsolidatedAt — the
+// shared isSpecNarrativeStale signal, threaded in as `narrativeStale`) blocks
+// the advancement offer with the exact dec-3 copy. Once fresh, the offer
+// renders. The blocker composes with the AC fragment, respects the non-editor
+// status-only posture, and keeps the browse-tab escape hatch.
+//
+//   ac-8  : blockerFragments emits the staleness blocker for specify.
+//   ac-9  : stale → blocker instead of offer; fresh → offer; escape hatch kept.
+//   ac-10 : the exact dec-3 sentence, "The spec narrative" emphasised.
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-196/acs/ac-${n}`;
+
+const updateDocStatus = vi.fn();
+vi.mock('../api/client', () => ({
+  updateDocStatus: (...a: unknown[]) => updateDocStatus(...a),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  updateDocStatus.mockResolvedValue(undefined);
+});
+
+const DOC = { id: 'doc-1' };
+
+// Defaults: specify phase, decisions all resolved, ACs authored — a rubric
+// that is clean EXCEPT where a test sets narrativeStale.
+function baseProps(overrides: Partial<React.ComponentProps<typeof TransitionSentence>> = {}) {
+  return {
+    doc: DOC,
+    currentPhase: 'specify' as SpecStatus,
+    viewedTab: 'specify' as SpecStatus,
+    totalDecisionCount: 2,
+    openDecisionCount: 0,
+    hasAcceptanceCriteria: true,
+    totalTaskCount: 0,
+    openTaskCount: 0,
+    unverifiedAcCount: 0,
+    ...overrides,
+  };
+}
+
+function text() {
+  return (screen.getByTestId('transition-sentence').textContent ?? '').trim();
+}
+
+describe('spec-196 — Rubicon narrative-staleness blocker at specify→build', () => {
+  it('all decisions resolved + stale narrative → the dec-3 blocker, no advancement offer (ac-8, ac-9, ac-10)', () => {
+    tagAc(AC(8));
+    tagAc(AC(9));
+    tagAc(AC(10));
+    render(<TransitionSentence {...baseProps({ narrativeStale: true })} />);
+
+    // The exact dec-3 sentence.
+    expect(text()).toBe(
+      'The spec narrative must be updated to reflect the resolved decisions before this spec can move to Build — use the refresh action to generate the update prompt.',
+    );
+    // The entity carries the blocker emphasis.
+    const sentence = screen.getByTestId('transition-sentence');
+    const strong = sentence.querySelector('strong');
+    expect(strong?.textContent).toBe('The spec narrative');
+    // No offer, no buttons — shape 2 (blocked) has nothing to confirm.
+    expect(text()).not.toContain('Do you wish');
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('narrative fresh → the advancement offer renders (ac-9)', () => {
+    tagAc(AC(9));
+    render(<TransitionSentence {...baseProps({ narrativeStale: false })} />);
+    expect(text()).toContain('Do you wish to move this spec to Build?');
+    expect(screen.getByRole('button', { name: 'Yes' })).toBeInTheDocument();
+  });
+
+  it('open decisions lead alone — staleness waits until they are resolved (ac-8)', () => {
+    tagAc(AC(8));
+    render(
+      <TransitionSentence {...baseProps({ openDecisionCount: 2, narrativeStale: true })} />,
+    );
+    expect(text()).toContain('2 Decisions must be resolved');
+    expect(text()).not.toContain('spec narrative');
+  });
+
+  it('composes with the AC fragment under the shared renderer (ac-8)', () => {
+    tagAc(AC(8));
+    render(
+      <TransitionSentence
+        {...baseProps({ narrativeStale: true, hasAcceptanceCriteria: false })}
+      />,
+    );
+    expect(text()).toBe(
+      'The spec narrative must be updated to reflect the resolved decisions and Acceptance Criteria (ACs) must be created before this spec can move to Build — use the refresh action to generate the update prompt.',
+    );
+  });
+
+  it('browse-tab escape hatch survives: blocker summary + "Move this spec anyway?" (ac-9)', async () => {
+    tagAc(AC(9));
+    const user = userEvent.setup();
+    const onTransitioned = vi.fn();
+    render(
+      <TransitionSentence
+        {...baseProps({ viewedTab: 'build', narrativeStale: true, onTransitioned })}
+      />,
+    );
+    expect(text()).toContain(
+      'The spec narrative must be updated to reflect the resolved decisions before Build — use the refresh action to generate the update prompt.',
+    );
+    expect(text()).toContain('Move this spec anyway?');
+
+    // Yes still moves the phase — deliberate friction, not a hard gate.
+    await user.click(screen.getByRole('button', { name: 'Yes' }));
+    expect(updateDocStatus).toHaveBeenCalledWith('doc-1', 'build');
+  });
+
+  it('non-editor posture stays status-only: blocker renders, no questions or buttons (ac-9)', () => {
+    tagAc(AC(9));
+    render(<TransitionSentence {...baseProps({ narrativeStale: true, canTransition: false })} />);
+    expect(text()).toContain('The spec narrative must be updated');
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('staleness is a specify-axis condition only — build→verify ignores it (ac-8)', () => {
+    tagAc(AC(8));
+    render(
+      <TransitionSentence
+        {...baseProps({
+          currentPhase: 'build',
+          viewedTab: 'build',
+          narrativeStale: true,
+          totalTaskCount: 2,
+        })}
+      />,
+    );
+    expect(text()).toContain('Do you want to move this spec to Verify?');
+    expect(text()).not.toContain('spec narrative');
+  });
+});

--- a/packages/ui/src/components/TransitionSentence.tsx
+++ b/packages/ui/src/components/TransitionSentence.tsx
@@ -79,6 +79,14 @@ export interface TransitionSentenceProps {
   openTaskCount?: number;
   /** Active-but-unverified ACs (verify→done axis). */
   unverifiedAcCount?: number;
+  /**
+   * spec-196 dec-2: whether the spec narrative is stale relative to the
+   * decisions graph (shared `isSpecNarrativeStale` semantics — any decision
+   * modified after `narrativeLastConsolidatedAt`). On the specify→build axis,
+   * once every decision is resolved, a stale narrative blocks the advancement
+   * offer: the prose must reflect the resolutions before build.
+   */
+  narrativeStale?: boolean;
   /** Fired after a successful transition so the parent can refetch / re-render. */
   onTransitioned?: (newPhase: SpecStatus) => void;
   /** The browse-confirm's [No]: return the view to the current phase's tab. */
@@ -98,6 +106,7 @@ function blockerFragments(p: {
   totalTaskCount: number;
   openTaskCount: number;
   unverifiedAcCount: number;
+  narrativeStale: boolean;
 }): BlockerPart[] {
   const parts: BlockerPart[] = [];
   if (p.currentPhase === 'specify') {
@@ -105,6 +114,15 @@ function blockerFragments(p: {
       parts.push({ em: 'Decisions', rest: 'must be created' });
     } else if (p.openDecisionCount > 0) {
       parts.push({ em: plural(p.openDecisionCount, 'Decision'), rest: 'must be resolved' });
+    } else if (p.narrativeStale) {
+      // spec-196 dec-2: decisions are settled but the prose hasn't caught up.
+      // Only fires once every decision is resolved — while decisions are still
+      // open, consolidating would be premature (the narrative will go stale
+      // again as they resolve), so the decisions blocker leads alone.
+      parts.push({
+        em: 'The spec narrative',
+        rest: 'must be updated to reflect the resolved decisions',
+      });
     }
     if (!p.hasAcceptanceCriteria) {
       parts.push({ em: 'Acceptance Criteria (ACs)', rest: 'must be created' });
@@ -168,6 +186,7 @@ export function TransitionSentence({
   totalTaskCount = 0,
   openTaskCount = 0,
   unverifiedAcCount = 0,
+  narrativeStale = false,
   onTransitioned,
   onCancelBrowse,
 }: TransitionSentenceProps) {
@@ -194,7 +213,15 @@ export function TransitionSentence({
     totalTaskCount,
     openTaskCount,
     unverifiedAcCount,
+    narrativeStale,
   });
+
+  // spec-196 dec-3: when the staleness blocker is present, the sentence carries
+  // the how-to tail — the user shouldn't have to know where the refresh lives.
+  const narrativeBlocked = blockers.some((b) => b.em === 'The spec narrative');
+  const refreshTail = narrativeBlocked
+    ? ' — use the refresh action to generate the update prompt'
+    : '';
 
   async function handleYes() {
     if (!target) return;
@@ -248,7 +275,8 @@ export function TransitionSentence({
       // buttons to press.
       return (
         <p className="text-sm text-secondary" data-testid="transition-sentence">
-          {renderBlockers(blockers)} before this spec can move to {phaseDisplayName(target)}.
+          {renderBlockers(blockers)} before this spec can move to {phaseDisplayName(target)}
+          {refreshTail}.
         </p>
       );
     }
@@ -281,7 +309,8 @@ export function TransitionSentence({
     }
     return (
       <p className="text-sm text-secondary" data-testid="transition-sentence">
-        {renderBlockers(blockers)} before {phaseDisplayName(target)}.
+        {renderBlockers(blockers)} before {phaseDisplayName(target)}
+        {refreshTail}.
       </p>
     );
   }
@@ -292,7 +321,12 @@ export function TransitionSentence({
       : `Are you sure you want to move this spec to ${phaseDisplayName(target)}?`;
   return (
     <p className="text-sm text-secondary" data-testid="transition-sentence">
-      {showSummary && <>{renderBlockers(blockers)} before {phaseDisplayName(target)}. </>}
+      {showSummary && (
+        <>
+          {renderBlockers(blockers)} before {phaseDisplayName(target)}
+          {refreshTail}.{' '}
+        </>
+      )}
       {question} {yesButton} {noButton}
       {errorNote}
     </p>

--- a/packages/ui/src/pages/DocDocument.spec-159.test.tsx
+++ b/packages/ui/src/pages/DocDocument.spec-159.test.tsx
@@ -205,12 +205,12 @@ describe('spec-159 t-6 — DocDocument phase layouts', () => {
     const user = userEvent.setup();
     renderAt('specify');
 
-    // Specify view is current → its sub-tab bar shows Narrative / Decisions & ACs / Comments.
-    await screen.findByText('Narrative');
+    // Specify view is current → its sub-tab bar shows Spec / Decisions & ACs / Comments.
+    await screen.findByText('Spec');
     expect(screen.getByText('Decisions & ACs')).toBeInTheDocument();
     expect(screen.getByText('Comments')).toBeInTheDocument();
 
-    // Default sub-tab is Narrative (section cards render).
+    // Default sub-tab is Spec (the narrative) (section cards render).
     expect(screen.getByTestId('section-card')).toBeInTheDocument();
 
     // Switch to Decisions & ACs → both panels render side by side.
@@ -284,7 +284,7 @@ describe('spec-159 t-6 — DocDocument phase layouts', () => {
   it('mounts no PhaseDropdown and no other phase-control affordance (ac-1)', async () => {
     tagAc(AC(1));
     renderAt('specify');
-    await screen.findByText('Narrative');
+    await screen.findByText('Spec');
 
     // No listbox-style phase dropdown trigger anywhere.
     expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
@@ -349,7 +349,7 @@ describe('spec-159 — Rubicon line + in-situ directives', () => {
     const user = userEvent.setup();
     docDecisions = [decision('d-1', 'open')];
     renderAt('specify');
-    await screen.findByText('Narrative');
+    await screen.findByText('Spec');
 
     await user.click(phaseTab('build'));
     const sentence = screen.getByTestId('transition-sentence');
@@ -362,7 +362,7 @@ describe('spec-159 — Rubicon line + in-situ directives', () => {
     // No → back to the current phase's view, no phase mutation.
     await user.click(within(sentence).getByRole('button', { name: 'No' }));
     expect(phaseTab('specify')).toHaveAttribute('data-selected', 'true');
-    expect(screen.getByText('Narrative')).toBeInTheDocument();
+    expect(screen.getByText('Spec')).toBeInTheDocument();
     expect(updateDocStatus).not.toHaveBeenCalled();
   });
 
@@ -454,7 +454,7 @@ describe('spec-159 — Rubicon line + in-situ directives', () => {
     docDecisions = [decision('d-1', 'open')];
     docTasks = [{ id: 't-1', status: 'in_progress' }];
     renderAt('specify');
-    await screen.findByText('Narrative');
+    await screen.findByText('Spec');
 
     await user.click(phaseTab('build'));
     await screen.findByTestId('task-panel');
@@ -472,7 +472,7 @@ describe('spec-159 — Rubicon line + in-situ directives', () => {
     await screen.findByTestId('task-panel');
 
     await user.click(phaseTab('specify'));
-    await screen.findByText('Narrative');
+    await screen.findByText('Spec');
     expect(phaseTab('build')).toHaveAttribute('data-current', 'true');
 
     // The refetch after the transition returns the moved doc.
@@ -493,7 +493,7 @@ describe('spec-159 — Rubicon line + in-situ directives', () => {
     tagAc(AC(19));
     mockRole = 'editor';
     renderAt('specify');
-    await screen.findByText('Narrative');
+    await screen.findByText('Spec');
 
     // Editors still get the PhaseTabBar (3 phase tabs) and the Rubicon line.
     expect(screen.getAllByRole('tab')).toHaveLength(3);
@@ -590,12 +590,12 @@ describe('spec-182 — unified reviewer phase block', () => {
     mockRole = 'editor';
     const user = userEvent.setup();
     renderAt('specify');
-    await screen.findByText('Narrative');
+    await screen.findByText('Spec');
 
     const header = screen.getByTestId('header-slot');
     // findByRole: the header slot populates via a useHeaderSlot effect a tick
     // after the page body renders — under full-suite load the pill can land
-    // after 'Narrative' is already visible (same async class as i-2).
+    // after 'Spec' is already visible (same async class as i-2).
     await user.click(await within(header).findByRole('button', { name: /You are editing/ }));
     await user.click(screen.getByRole('menuitemradio', { name: /Reviewing/ }));
     // useSwitchPosture → demoteToReviewer(docId) then a role refetch.
@@ -682,7 +682,7 @@ describe('spec-182 — unified reviewer phase block', () => {
     tagAc(AC182(3));
     renderAt('draft');
 
-    await screen.findByText('Narrative');
+    await screen.findByText('Spec');
     expect(screen.queryByTestId('review-action-row')).not.toBeInTheDocument();
     expect(screen.queryByTestId('review-handoff-line')).not.toBeInTheDocument();
   });
@@ -709,16 +709,21 @@ describe('spec-182 — unified reviewer phase block', () => {
     expect(sentence.textContent).not.toContain("You're reviewing");
   });
 
-  it('done collapses to the DoneSummary for reviewers — no review block, no Reopen', async () => {
+  it('done collapses to the DoneSummary for reviewers — no review block; Reopen is offered (spec-196)', async () => {
     tagAc(AC182(13));
     tagAc(AC182(5));
+    // spec-196 ac-15: a writable reviewer sees Reopen at done (gate relaxed
+    // from editor posture to org write access).
+    tagAc('mindset-prod/memex-building-itself/specs/spec-196/acs/ac-15');
     renderAt('done');
 
     const summary = await screen.findByTestId('done-summary');
     expect(screen.queryByTestId('review-action-row')).not.toBeInTheDocument();
     expect(screen.queryByTestId('review-handoff-line')).not.toBeInTheDocument();
-    // Reopen stays canEdit-gated (spec-164 dec-5) — absent for a reviewer.
-    expect(summary).toHaveAttribute('data-can-reopen', 'false');
+    // spec-196 relaxed spec-164 dec-5: Reopen now gates on org write access,
+    // not editor posture, so a writable reviewer sees it (the reviewer/editor
+    // distinction is meaningless on a closed spec). canWrite is true here.
+    expect(summary).toHaveAttribute('data-can-reopen', 'true');
   });
 });
 

--- a/packages/ui/src/pages/DocDocument.spec-196.test.tsx
+++ b/packages/ui/src/pages/DocDocument.spec-196.test.tsx
@@ -214,10 +214,16 @@ describe('spec-196 t-1 — Specify sub-tab reads "Spec", id stays narrative', ()
     unmount();
 
     // Consolidation refreshed past the decision → the advancement offer.
+    // waitFor (not a bare findByTestId assertion): the offer only appears once
+    // the async fetchAcsForBrief settles — until then hasAcceptanceCriteria is
+    // false and the AC blocker transiently shares the line. Asserting on the
+    // first render tick races that fetch (green locally, flaky under CI load).
     docNarrativeConsolidatedAt = '2026-06-06T00:00:00Z';
     renderAt();
     const fresh = await screen.findByTestId('transition-sentence');
-    expect(fresh.textContent).toContain('Do you wish to move this spec to Build?');
+    await waitFor(() =>
+      expect(fresh.textContent).toContain('Do you wish to move this spec to Build?'),
+    );
   });
 
   it("source pins the pair: label 'Spec' with id 'narrative' (ac-6)", () => {

--- a/packages/ui/src/pages/DocDocument.spec-196.test.tsx
+++ b/packages/ui/src/pages/DocDocument.spec-196.test.tsx
@@ -1,0 +1,234 @@
+// spec-196 t-1 — the Specify sub-tab label "Narrative" → "Spec".
+//
+// dec-1: the rename is UI-label-only. The tab READS "Spec" (the prose sections
+// ARE the spec) while its id stays 'narrative' — internal vocabulary, deep
+// links, and comment routing are deliberately unchanged.
+//
+//   ac-1 : the sub-tab reads "Spec"; "Narrative" no longer appears in the UI.
+//   ac-5 : deep links / routing to the narrative tab keep working.
+//   ac-6 : label "Spec", id 'narrative' — both pinned.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { tagAc } from '@memex-ai-ac/vitest';
+import type { DocWithGraph } from '../api/types';
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-196/acs/ac-${n}`;
+
+// ── Heavy children → identity markers (same trim as the spec-159 suite) ─────
+vi.mock('../components/DecisionPanel', () => ({
+  DecisionPanel: () => <div data-testid="decision-panel" />,
+}));
+vi.mock('../components/AcPanel', () => ({
+  AcPanel: () => <div data-testid="ac-panel" />,
+}));
+vi.mock('../components/TaskPanel', () => ({
+  TaskPanel: () => <div data-testid="task-panel" />,
+}));
+vi.mock('../components/IssuePanel', () => ({
+  IssuePanel: () => <div data-testid="issue-panel" />,
+}));
+vi.mock('../components/AllComments', () => ({
+  AllComments: () => <div data-testid="all-comments" />,
+}));
+vi.mock('../components/SectionCard', () => ({
+  SectionCard: () => <div data-testid="section-card" />,
+}));
+vi.mock('../components/DocOutline', () => ({ DocOutline: () => <div data-testid="doc-outline" /> }));
+vi.mock('../components/TagPicker', () => ({ TagPicker: () => null }));
+vi.mock('../components/BylineAssignees', () => ({
+  BylineAssignees: () => <div data-testid="byline-assignees" />,
+}));
+vi.mock('../components/DoneSummary', () => ({
+  DoneSummary: () => <div data-testid="done-summary" />,
+}));
+
+vi.mock('../hooks/useMemexAccess', () => ({
+  useMemexAccess: () => ({ canWrite: true, isReadOnly: false }),
+}));
+// NB: refetch must be a STABLE identity — an inline `vi.fn()` here mints a new
+// function per render, which feeds an effect → header-slot → re-render loop
+// that runs the page to OOM the moment any click re-renders it.
+const refetchRole = vi.fn();
+vi.mock('../hooks/useDocRole', () => ({
+  useDocRole: () => ({ myRole: 'editor', editors: [], loading: false, refetch: refetchRole }),
+}));
+vi.mock('../hooks/useDocChangeStream', () => ({ useDocChangeStream: () => {} }));
+vi.mock('../hooks/useOrgScaffoldBlocks', () => ({ useOrgScaffoldBlocks: () => [] }));
+const chat = {
+  setDocId: vi.fn(),
+  setDoc: vi.fn(),
+  setOpenCommentCount: vi.fn(),
+  sendMessage: vi.fn(),
+};
+vi.mock('../components/ChatContext', () => ({ useChat: () => chat }));
+
+// Mutable fixtures: t-2's staleness tests shape the decisions graph and the
+// consolidation timestamp per test (the staleness signal compares the two).
+let docDecisions: unknown[] = [];
+let docAcs: unknown[] = [];
+let docNarrativeConsolidatedAt: string | null = null;
+
+function resolvedDecision(id: string, resolvedAt: string) {
+  return {
+    id,
+    docId: 'doc-uuid',
+    seq: 1,
+    title: id,
+    context: null,
+    status: 'resolved',
+    resolution: 'done',
+    resolvedAt,
+    createdAt: '2026-06-01T00:00:00Z',
+    options: null,
+    chosenOptionIndex: null,
+  };
+}
+
+function makeDoc(): DocWithGraph {
+  return {
+    id: 'doc-uuid',
+    handle: 'spec-196',
+    title: 'Rename test fixture',
+    docType: 'spec',
+    status: 'specify',
+    creator: { name: 'Barrie', email: 'barrie@mindset.ai' },
+    createdAt: '2026-06-01T00:00:00Z',
+    statusChangedAt: '2026-06-04T00:00:00Z',
+    narrativeLastConsolidatedAt: docNarrativeConsolidatedAt,
+    sections: [{ id: 's-1', seq: 1, title: 'Intro', body: 'x' }],
+    decisions: docDecisions,
+    tasks: [],
+    tags: [],
+  } as unknown as DocWithGraph;
+}
+
+vi.mock('../api/client', () => ({
+  NotFoundError: class NotFoundError extends Error {},
+  fetchDoc: () => Promise.resolve(makeDoc()),
+  fetchDocComments: () => Promise.resolve({ sections: [], decisions: [], tasks: [] }),
+  fetchAcsForBrief: () => Promise.resolve(docAcs),
+  fetchIssues: () => Promise.resolve([]),
+  fetchDocAssignees: () => Promise.resolve([]),
+  archiveDoc: vi.fn(),
+  pauseDoc: vi.fn(),
+  unpauseDoc: vi.fn(),
+  updateDocStatus: vi.fn(),
+  promoteToEditor: vi.fn(),
+  demoteToReviewer: vi.fn(),
+}));
+
+import { DocDocument } from './DocDocument';
+import { HeaderSlotProvider, useHeaderSlotContent } from '../components/HeaderSlot';
+
+// The app shell's global header consumes the slot; without a sink the slot
+// content has nowhere to land (same wiring as the spec-158/159 suites).
+function HeaderSink() {
+  return <div data-testid="header-slot">{useHeaderSlotContent()}</div>;
+}
+
+function renderAt(path = '/n/m/specs/spec-196') {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <HeaderSlotProvider>
+        <HeaderSink />
+        <Routes>
+          <Route path="/:ns/:mx/specs/:id" element={<DocDocument />} />
+        </Routes>
+      </HeaderSlotProvider>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  docDecisions = [];
+  docAcs = [];
+  docNarrativeConsolidatedAt = null;
+});
+
+describe('spec-196 t-1 — Specify sub-tab reads "Spec", id stays narrative', () => {
+  it('renders the sub-tab as "Spec"; "Narrative" appears nowhere; sections are the default view (ac-1, ac-6)', async () => {
+    tagAc(AC(1));
+    tagAc(AC(6));
+    renderAt();
+
+    // The first sub-tab reads "Spec".
+    expect(await screen.findByRole('button', { name: 'Spec' })).toBeInTheDocument();
+    // The old label is gone from the rendered UI.
+    expect(screen.queryByText('Narrative')).not.toBeInTheDocument();
+    // It's still the default sub-tab: the narrative (section cards) renders.
+    expect(screen.getByTestId('section-card')).toBeInTheDocument();
+  });
+
+  it('the renamed tab still routes on the internal id — away to Decisions & ACs and back (ac-5, ac-6)', async () => {
+    tagAc(AC(5));
+    tagAc(AC(6));
+    const user = userEvent.setup();
+    renderAt();
+
+    await screen.findByText('Spec');
+
+    // Away: Decisions & ACs renders its two-column panels.
+    await user.click(screen.getByText('Decisions & ACs'));
+    expect(screen.getByTestId('decision-panel')).toBeInTheDocument();
+    expect(screen.queryByTestId('section-card')).not.toBeInTheDocument();
+
+    // Back: the "Spec" tab routes to the narrative view via the unchanged
+    // 'narrative' id (deep-link integrity itself is covered by the spec-158 /
+    // spec-100 suites, which key on these ids, not labels).
+    await user.click(screen.getByText('Spec'));
+    expect(screen.getByTestId('section-card')).toBeInTheDocument();
+  });
+
+  it('stale narrative threads from the doc payload to the Rubicon; consolidation clears it (ac-9)', async () => {
+    tagAc(AC(9));
+    // A resolved decision NEWER than the consolidation timestamp → stale.
+    docDecisions = [resolvedDecision('d-1', '2026-06-05T00:00:00Z')];
+    docAcs = [{ ac: { id: 'ac-1', status: 'active' }, verificationState: 'verified' }];
+    docNarrativeConsolidatedAt = '2026-06-02T00:00:00Z';
+    const { unmount } = renderAt();
+
+    // waitFor: the aux AC fetch settles a tick after the sentence first
+    // renders (until then the AC blocker shares the line).
+    const sentence = await screen.findByTestId('transition-sentence');
+    await waitFor(() =>
+      expect(sentence.textContent).toContain(
+        'The spec narrative must be updated to reflect the resolved decisions before this spec can move to Build — use the refresh action to generate the update prompt.',
+      ),
+    );
+    expect(sentence.textContent).not.toContain('Acceptance Criteria');
+    expect(sentence.textContent).not.toContain('Do you wish');
+
+    // The in-situ phase directive on Decisions & ACs mirrors the Rubicon copy.
+    const user = userEvent.setup();
+    await user.click(screen.getByText('Decisions & ACs'));
+    expect(screen.getByTestId('phase-directive').textContent).toContain(
+      'The spec narrative must be updated to reflect the resolved decisions before this spec can move to Build — use the refresh action to generate the update prompt.',
+    );
+    unmount();
+
+    // Consolidation refreshed past the decision → the advancement offer.
+    docNarrativeConsolidatedAt = '2026-06-06T00:00:00Z';
+    renderAt();
+    const fresh = await screen.findByTestId('transition-sentence');
+    expect(fresh.textContent).toContain('Do you wish to move this spec to Build?');
+  });
+
+  it("source pins the pair: label 'Spec' with id 'narrative' (ac-6)", () => {
+    tagAc(AC(6));
+    const src = readFileSync(
+      join(dirname(fileURLToPath(import.meta.url)), 'DocDocument.tsx'),
+      'utf8',
+    );
+    // dec-1: the label renames, the id does not. A drive-by "consistency"
+    // rename of the id would break deep links and comment routing — fail here.
+    expect(src).toMatch(/id:\s*'narrative',\s*label:\s*'Spec'/);
+    expect(src).not.toMatch(/label:\s*'Narrative'/);
+  });
+});

--- a/packages/ui/src/pages/DocDocument.tsx
+++ b/packages/ui/src/pages/DocDocument.tsx
@@ -34,7 +34,12 @@ import { InitPromptDialog } from '../components/InitPromptDialog';
 import { useChat } from '../components/ChatContext';
 import { useSwitchPosture } from '../hooks/useSwitchPosture';
 import { PostureDropdown, HEADER_PILL_CLASS } from '../components/PostureDropdown';
-import { countUnresolvedDecisions, toButtonPrompt, BASE_SCAFFOLD } from '@memex/shared';
+import {
+  countUnresolvedDecisions,
+  isSpecNarrativeStale,
+  toButtonPrompt,
+  BASE_SCAFFOLD,
+} from '@memex/shared';
 import { useDocChangeStream } from '../hooks/useDocChangeStream';
 import { COMMENT_PARAM, parseCommentParam, commentAnchorId } from '../utils/commentDeepLink';
 import { phaseDisplayName } from '../utils/phaseDisplay';
@@ -729,6 +734,19 @@ export function DocDocument() {
       status: d.status,
     })),
   );
+  // spec-196 dec-2: the specify→build rubric also gates on narrative freshness.
+  // Same shared signal the refresh affordances key on — any decision modified
+  // after `narrativeLastConsolidatedAt` means the prose hasn't caught up with
+  // the decisions graph yet.
+  const narrativeStale = isSpecNarrativeStale(
+    doc.narrativeLastConsolidatedAt ?? null,
+    decs.map((d) => ({
+      id: d.id,
+      createdAt: d.createdAt,
+      resolvedAt: d.resolvedAt,
+      status: d.status,
+    })),
+  );
 
   // spec-159 dec-4 (amended): the readiness rubric is ADVISORY. The transition
   // sentence always offers the move; this in-situ directive spans the full
@@ -742,7 +760,7 @@ export function DocDocument() {
   // browsing the build tab from verify.
   const pluralise = (n: number, noun: string) => `${n} ${noun}${n === 1 ? '' : 's'}`;
   type DirectivePart = { em: string; rest: string };
-  const directiveLine = (parts: DirectivePart[], target: string) => {
+  const directiveLine = (parts: DirectivePart[], target: string, tail = '') => {
     if (parts.length === 0) return null;
     // Merge consecutive same-requirement fragments: their entities join with
     // "and" ahead of one shared verb phrase. Distinct requirements also join
@@ -772,11 +790,17 @@ export function DocDocument() {
               {g.rest}
             </span>
           ))}{' '}
-          before this spec can move to {phaseDisplayName(target)}.
+          before this spec can move to {phaseDisplayName(target)}
+          {tail}.
         </span>
       </p>
     );
   };
+  // spec-196 dec-2: the narrative-staleness condition joins the specify→build
+  // axis — but only once every decision is resolved (consolidating while
+  // decisions are still open would be premature; the prose chases a moving
+  // target). Mirrors the Rubicon line's fragment + how-to tail (dec-3 copy).
+  const planNarrativeStale = decs.length > 0 && openDecisionCount === 0 && narrativeStale;
   const planDirective = directiveLine(
     phase === 'specify'
       ? [
@@ -785,12 +809,21 @@ export function DocDocument() {
             : openDecisionCount > 0
               ? [{ em: pluralise(openDecisionCount, 'Decision'), rest: 'must be resolved' }]
               : []),
+          ...(planNarrativeStale
+            ? [
+                {
+                  em: 'The spec narrative',
+                  rest: 'must be updated to reflect the resolved decisions',
+                },
+              ]
+            : []),
           ...(!hasAcceptanceCriteria
             ? [{ em: 'Acceptance Criteria (ACs)', rest: 'must be created' }]
             : []),
         ]
       : [],
     'build',
+    planNarrativeStale ? ' — use the refresh action to generate the update prompt' : '',
   );
   const buildDirective = directiveLine(
     phase === 'build'
@@ -830,7 +863,10 @@ export function DocDocument() {
 
   // Plan's three sub-tabs. Build / Verify carry no sub-tab bar (ac-11).
   const planSubTabs = [
-    { id: 'narrative', label: 'Narrative', count: sectionCommentCount, countVariant: 'warning' as const },
+    /* spec-196 dec-1 / ac-1+ac-6: the label reads "Spec" (the prose sections ARE
+       the spec); the id stays 'narrative' — internal vocabulary and deep links
+       are deliberately unchanged. */
+    { id: 'narrative', label: 'Spec', count: sectionCommentCount, countVariant: 'warning' as const },
     { id: 'decisions', label: 'Decisions & ACs', count: decisionCommentCount, countVariant: 'warning' as const },
     { id: 'comments', label: 'Comments', count: totalCommentCount, countVariant: 'warning' as const },
   ];
@@ -1167,6 +1203,7 @@ export function DocDocument() {
               totalTaskCount={ts.length}
               openTaskCount={openTaskCount}
               unverifiedAcCount={unverifiedAcCount}
+              narrativeStale={narrativeStale}
               onTransitioned={() => {
                 // The view follows the move: clear the browsed-tab pin so
                 // `viewedTab` falls back to the (re-fetched) current phase's
@@ -1277,12 +1314,13 @@ export function DocDocument() {
           acs={acs}
           issues={issues}
           people={assignees}
-          /* spec-164 dec-5: the one deliberate door back from done. Gates on
-             the same editor posture as the transition sentence's Yes; the
-             status write lives here (DoneSummary stays fetch-free, ac-9).
-             After the write the view follows the move, exactly like
-             TransitionSentence's onTransitioned. */
-          canReopen={canEdit}
+          /* spec-164 dec-5, relaxed by spec-196: the one deliberate door back
+             from done. Gates on org WRITE ACCESS (canWrite), not an editor
+             posture — the reviewer/editor distinction is meaningless on a
+             closed spec, and the status write here would 403 only for a
+             non-member. DoneSummary stays fetch-free (ac-9); after the write
+             the view follows the move, like TransitionSentence's onTransitioned. */
+          canReopen={canWrite}
           onReopen={async () => {
             await updateDocStatus(doc.id, 'verify');
             setSelectedTab(null);


### PR DESCRIPTION
Implements [spec-196](https://memex.ai/mindset-prod/memex-building-itself/specs/spec-196).

## What changes

**1. Tab rename (dec-1).** The Specify view's first sub-tab reads **Spec** instead of "Narrative" — label only; the `'narrative'` id, deep links, and comment routing are unchanged. Human-facing agent copy now says "spec narrative"; internal vocabulary (`assess_spec` mode `'narrative'`, `narrativeLastConsolidatedAt`, `isSpecNarrativeStale`) keeps the word "narrative".

**2. specify→build narrative gate (dec-2 / dec-3).** Once every decision is resolved, a stale spec narrative blocks the advancement offer with the approved copy + a how-to tail, in both the Rubicon line (`TransitionSentence`) and the in-situ phase directive. Driven by the existing shared `isSpecNarrativeStale` signal. The refresh prompt copy is updated at its live home (the scaffold `opening-refresh-narrative` helper) and the `spec-readiness` CTA; the orphaned `RefreshSpecButton` is kept verbatim-in-sync.

**3. Done-view "Read the spec" (dec-4).** Any viewer expands the full record inline — sorted narrative sections (markdown) + read-only decision/task/AC/issue detail — from already-fetched props. Fetch-free, no mutation affordances, no phase change.

**4. Footer + Reopen (dec-5).** The done footer is one action row under a single divider (`ac-16`). Reopen's gate is relaxed from editor posture to **org write access** (`ac-15`) — the reviewer/editor distinction is meaningless on a closed spec. This deliberately relaxes spec-164 dec-5 (noted on the spec).

## Tests

- New spec-196 unit suites (UI + shared) + extended `TransitionSentence` / `DoneSummary` coverage.
- New e2e `journey-21` (narrative gate stale→consolidate→offer; done read view), plus journey-15 label updates.
- Two env-gated test-surface endpoints: `set-doc-status`, `consolidate-narrative`.
- **`make e2e-cold` green (46/46)**; affected unit suites green; tsc clean. Rebased onto latest develop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)