### PR TITLE
spec-190: robust barge-in — deep duck + gap-tolerant cut (agent actually stops)

### DIFF
--- a/packages/ui/src/voice/bargeIn.test.ts
+++ b/packages/ui/src/voice/bargeIn.test.ts
@@ -28,7 +28,7 @@ function harness(playedMs = 0) {
     abortLlm: vi.fn(),
     onCut: vi.fn(),
   };
-  const ctrl = new BargeInController(playback, cb, { cutMs: 280 });
+  const ctrl = new BargeInController(playback, cb, { cutMs: 280, restoreMs: 120 });
   return { ctrl, playback, cb };
 }
 
@@ -59,17 +59,41 @@ describe('BargeInController duck-then-cut (ac-24)', () => {
     expect(playback.flush).not.toHaveBeenCalled();
   });
 
-  it('restores (no cut) when speech ends before the cut threshold — a transient', () => {
+  it('restores (no cut) only after SUSTAINED silence — a transient cough/backchannel', () => {
     const { ctrl, playback, cb } = harness();
     ctrl.startTurn();
     ctrl.onSpeechStart();
-    vi.advanceTimersByTime(150);
-    ctrl.onSpeechEnd(); // backchannel / cough
+    vi.advanceTimersByTime(80); // a short blip
+    ctrl.onSpeechEnd();
+    // A single gap does NOT restore immediately — it arms the restore timer.
+    expect(playback.restore).not.toHaveBeenCalled();
+    expect(ctrl.state).toBe('ducked');
+    vi.advanceTimersByTime(120); // restoreMs of continuous silence → transient confirmed
     expect(playback.restore).toHaveBeenCalledTimes(1);
     expect(ctrl.state).toBe('speaking');
     vi.advanceTimersByTime(500); // the armed cut must have been cancelled
     expect(cb.abortTts).not.toHaveBeenCalled();
     expect(cb.onCut).not.toHaveBeenCalled();
+  });
+
+  it('tolerates a brief gap mid-interruption and still cuts (choppy real speech)', () => {
+    const { ctrl, playback, cb } = harness(120);
+    ctrl.startTurn();
+    ctrl.appendChunk({ chars: [...'hi there'], charStartMs: [0, 50, 100, 150, 200, 250, 300, 350] });
+    ctrl.onSpeechStart(); // t=0: duck + arm cut(280)
+    vi.advanceTimersByTime(100); // t=100
+    ctrl.onSpeechEnd(); // gap begins → arm restore(120 → would fire at t=220)
+    vi.advanceTimersByTime(80); // t=180, gap=80ms < restoreMs → still ducked, no restore
+    expect(playback.restore).not.toHaveBeenCalled();
+    ctrl.onSpeechStart(); // speech resumes → cancels restore, cut timer keeps running
+    expect(ctrl.state).toBe('ducked');
+    vi.advanceTimersByTime(100); // t=280 → the original cut fires
+    expect(playback.flush).toHaveBeenCalledTimes(1);
+    expect(cb.abortTts).toHaveBeenCalledTimes(1);
+    expect(cb.onCut).toHaveBeenCalledWith('hi ');
+    expect(ctrl.state).toBe('cut');
+    expect(playback.restore).not.toHaveBeenCalled(); // never wrongly restored
+    tagAc(AC24);
   });
 
   it('cuts on sustained speech: flush + abort TTS + abort LLM + truncated turn', () => {

--- a/packages/ui/src/voice/bargeIn.test.ts
+++ b/packages/ui/src/voice/bargeIn.test.ts
@@ -76,7 +76,7 @@ describe('BargeInController duck-then-cut (ac-24)', () => {
     expect(cb.onCut).not.toHaveBeenCalled();
   });
 
-  it('tolerates a brief gap mid-interruption and still cuts (choppy real speech)', () => {
+  it('tolerates a short gap mid-interruption and still cuts (choppy real speech)', () => {
     const { ctrl, playback, cb } = harness(120);
     ctrl.startTurn();
     ctrl.appendChunk({ chars: [...'hi there'], charStartMs: [0, 50, 100, 150, 200, 250, 300, 350] });

--- a/packages/ui/src/voice/bargeIn.ts
+++ b/packages/ui/src/voice/bargeIn.ts
@@ -61,7 +61,7 @@ const DEFAULT_DUCK_MS = 50;
 // from the deep duck at onset (playbackQueue ducks the agent to ~5% in ~50ms — the
 // user instantly hears it yield), so this window can be long enough to be robust
 // without feeling laggy. It is gap-TOLERANT: armed once on the first onset and NOT
-// reset by brief VAD dips (real interruption speech is choppy, and on speakers the
+// reset by short VAD dips (real interruption speech is choppy, and on speakers the
 // agent's echo bleed makes the VAD flicker). Only `restoreMs` of CONTINUOUS silence
 // aborts it — see onSpeechEnd. (dec-8 / t-9; was 160ms, which never landed because
 // any single dip cancelled it.)
@@ -142,7 +142,7 @@ export class BargeInController {
   }
 
   /** VAD speech onset. While the agent speaks: duck immediately and arm the
-   *  sustained-interruption cut timer. A re-onset after a brief gap cancels the
+   *  sustained-interruption cut timer. A re-onset after a short gap cancels the
    *  pending restore and KEEPS the cut timer running (gap tolerance) — it never
    *  re-arms, so the cut measures sustained interruption from the FIRST onset.
    *  Inert outside a turn — there's nothing to interrupt, and the agent's own

--- a/packages/ui/src/voice/bargeIn.ts
+++ b/packages/ui/src/voice/bargeIn.ts
@@ -40,8 +40,13 @@ export interface BargeInCallbacks {
 export interface BargeInOptions {
   /** Duck ramp duration the playback layer targets (~50ms). Advisory here. */
   duckMs?: number;
-  /** Sustained-speech threshold before a full cut (~250–300ms). */
+  /** Sustained-speech threshold before a full cut (~300ms). */
   cutMs?: number;
+  /** Continuous-silence window that confirms a transient and aborts the pending
+   *  cut (~120ms). A gap SHORTER than this is tolerated — the cut keeps heading
+   *  in — so choppy real interruption speech (and speaker echo flicker) still
+   *  cuts; only sustained silence restores. */
+  restoreMs?: number;
 }
 
 /** Char-level alignment for a synthesized chunk (from ElevenLabs TTS). */
@@ -52,10 +57,19 @@ export interface CharAlignment {
 }
 
 const DEFAULT_DUCK_MS = 50;
-// Sustained-speech window before a hard cut. Kept short so a real interruption
-// cuts the agent promptly; below this a blip (cough/backchannel) just ducks then
-// restores. Tuned down from 280ms on-device — 280 felt unresponsive (dec-8 / t-9).
-const DEFAULT_CUT_MS = 160;
+// Sustained-interruption window before a hard cut. The FELT responsiveness comes
+// from the deep duck at onset (playbackQueue ducks the agent to ~5% in ~50ms — the
+// user instantly hears it yield), so this window can be long enough to be robust
+// without feeling laggy. It is gap-TOLERANT: armed once on the first onset and NOT
+// reset by brief VAD dips (real interruption speech is choppy, and on speakers the
+// agent's echo bleed makes the VAD flicker). Only `restoreMs` of CONTINUOUS silence
+// aborts it — see onSpeechEnd. (dec-8 / t-9; was 160ms, which never landed because
+// any single dip cancelled it.)
+const DEFAULT_CUT_MS = 300;
+// Continuous silence that confirms a blip was a transient (cough/backchannel) and
+// restores full volume. Must stay BELOW cutMs so a genuine transient restores
+// before the cut fires; the gap between them is the speech-gap tolerance.
+const DEFAULT_RESTORE_MS = 120;
 
 /**
  * The prefix of the synthesized text whose characters had begun playing by
@@ -74,11 +88,15 @@ export function spokenPrefix(chars: string[], charStartMs: number[], cutMs: numb
 export class BargeInController {
   private _state: BargeInState = 'idle';
   private cutTimer: ReturnType<typeof setTimeout> | null = null;
+  // Pending "this was a transient, restore" timer — armed on a VAD gap while
+  // ducked, cancelled if speech resumes before it fires (gap tolerance).
+  private restoreTimer: ReturnType<typeof setTimeout> | null = null;
   // Accumulated alignment of the CURRENT assistant turn, for truncation on cut.
   private chars: string[] = [];
   private startMs: number[] = [];
   private readonly duckMs: number;
   private readonly cutMs: number;
+  private readonly restoreMs: number;
 
   constructor(
     private readonly playback: PlaybackSink,
@@ -87,6 +105,7 @@ export class BargeInController {
   ) {
     this.duckMs = opts.duckMs ?? DEFAULT_DUCK_MS;
     this.cutMs = opts.cutMs ?? DEFAULT_CUT_MS;
+    this.restoreMs = opts.restoreMs ?? DEFAULT_RESTORE_MS;
   }
 
   get state(): BargeInState {
@@ -101,7 +120,7 @@ export class BargeInController {
 
   /** Agent begins a spoken turn — reset truncation accounting. */
   startTurn(): void {
-    this.clearCutTimer();
+    this.clearTimers();
     this.chars = [];
     this.startMs = [];
     this._state = 'speaking';
@@ -118,31 +137,37 @@ export class BargeInController {
 
   /** Agent finished speaking naturally (no interruption). */
   endTurn(): void {
-    this.clearCutTimer();
+    this.clearTimers();
     if (this._state !== 'cut') this._state = 'idle';
   }
 
   /** VAD speech onset. While the agent speaks: duck immediately and arm the
-   *  sustained-speech cut timer. Inert outside a turn — there's nothing to
-   *  interrupt, and the agent's own earcons never reach here (AEC, ac-23). */
+   *  sustained-interruption cut timer. A re-onset after a brief gap cancels the
+   *  pending restore and KEEPS the cut timer running (gap tolerance) — it never
+   *  re-arms, so the cut measures sustained interruption from the FIRST onset.
+   *  Inert outside a turn — there's nothing to interrupt, and the agent's own
+   *  earcons never reach here (AEC, ac-23). */
   onSpeechStart(): void {
+    this.clearRestoreTimer(); // speech (re)started — this was not sustained silence
     if (this._state === 'speaking') {
-      this.playback.duck(); // agent audibly yields (~duckMs ramp)
+      this.playback.duck(); // agent audibly yields (deep + fast ~duckMs ramp)
       this._state = 'ducked';
       this.armCutTimer();
     } else if (this._state === 'ducked') {
-      this.armCutTimer(); // already ducked; ensure the cut timer is running
+      this.armCutTimer(); // already ducked mid-interruption; keep the timer running
     }
     // 'idle' / 'cut' → inert.
   }
 
-  /** VAD speech end. If it ends before the cut fires it was a transient
-   *  (backchannel/cough): restore volume, cancel the pending cut. */
+  /** VAD speech end. A single gap does NOT restore — real interruption speech is
+   *  choppy and speaker echo makes the VAD flicker, so an immediate restore is why
+   *  the cut never landed. Instead arm a restore timer: only `restoreMs` of
+   *  CONTINUOUS silence confirms a transient (cough/backchannel) and restores +
+   *  cancels the cut. If speech resumes first, onSpeechStart cancels this and the
+   *  cut keeps heading in. */
   onSpeechEnd(): void {
     if (this._state !== 'ducked') return;
-    this.clearCutTimer();
-    this.playback.restore();
-    this._state = 'speaking';
+    this.armRestoreTimer();
   }
 
   /** Manual tap-to-interrupt fallback: immediate full cut. */
@@ -151,7 +176,7 @@ export class BargeInController {
   }
 
   dispose(): void {
-    this.clearCutTimer();
+    this.clearTimers();
   }
 
   private armCutTimer(): void {
@@ -162,6 +187,17 @@ export class BargeInController {
     }, this.cutMs);
   }
 
+  /** Arm the transient-confirm timer: sustained silence → restore + cancel cut. */
+  private armRestoreTimer(): void {
+    if (this.restoreTimer) return;
+    this.restoreTimer = setTimeout(() => {
+      this.restoreTimer = null;
+      this.clearCutTimer();
+      this.playback.restore();
+      this._state = 'speaking';
+    }, this.restoreMs);
+  }
+
   private clearCutTimer(): void {
     if (this.cutTimer) {
       clearTimeout(this.cutTimer);
@@ -169,8 +205,20 @@ export class BargeInController {
     }
   }
 
-  private cut(): void {
+  private clearRestoreTimer(): void {
+    if (this.restoreTimer) {
+      clearTimeout(this.restoreTimer);
+      this.restoreTimer = null;
+    }
+  }
+
+  private clearTimers(): void {
     this.clearCutTimer();
+    this.clearRestoreTimer();
+  }
+
+  private cut(): void {
+    this.clearTimers();
     // Truncate to the words actually heard BEFORE flushing (playedMs is read now).
     const spoken = spokenPrefix(this.chars, this.startMs, this.playback.playedMs());
     this.playback.flush();

--- a/packages/ui/src/voice/playbackQueue.ts
+++ b/packages/ui/src/voice/playbackQueue.ts
@@ -8,7 +8,13 @@
 
 import type { PlaybackSink } from './bargeIn';
 
-const DEFAULT_DUCK_GAIN = 0.15;
+// Duck to near-silence on the FIRST sign of barge-in (was 0.15). The deep duck is
+// what makes interruption feel instant — the agent effectively stops the moment you
+// speak, before the hard cut commits ~cutMs later (bargeIn.ts). On speakers it also
+// collapses the agent→mic echo bleed that was making the VAD flicker, which is half
+// of why the cut never landed. 0.05 (not 0) keeps a hair of presence so a transient
+// (cough) restore isn't a jarring pop. (spec-190 dec-8 barge-in tuning.)
+const DEFAULT_DUCK_GAIN = 0.05;
 const DEFAULT_DUCK_RAMP_S = 0.05; // ~50ms, matches BargeInController.duckDelayMs
 // Sample rate of the raw PCM the server streams (ElevenLabs output_format
 // pcm_24000). Keep in sync with DEFAULT_TTS_FORMAT in server elevenlabs-client.ts.


### PR DESCRIPTION
## Problem (reported on int, speakers)
When you speak over Specky, the VAD detects you and listens, but **the agent isn't silenced** — you talk over each other.

Root cause in `bargeIn.ts`: the duck-then-cut hard cut almost never landed. `onSpeechEnd` restored full volume and **cancelled the pending cut on the first momentary VAD dip**. Real interruption speech is choppy, and on speakers the agent's audio bleeds into the mic and makes the VAD flicker — so the 160ms "sustained" cut kept resetting. Result: duck → restore → duck, never a clean cut.

## Fix (spec-190 dec-8 barge-in tuning)

**1. Deep duck on onset** — `playbackQueue` `DUCK_GAIN` 0.15 → **0.05**. The agent drops to near-silence in ~50ms the instant you speak. This is what makes interruption *feel* immediate, and on speakers it collapses the agent→mic echo bleed that was confusing the VAD.

**2. Gap-tolerant cut** — `bargeIn.ts`. The cut timer is armed once on the first onset and is **no longer cancelled by a brief gap**. A VAD gap now arms a *restore* timer; only **`restoreMs` (120ms) of continuous silence** confirms a transient and restores + cancels the cut. So:
- choppy real interruption (micro-gaps between words) → **cuts cleanly**
- one-off cough / "mhm" backchannel (short sound then silence) → ducks then restores, no false cut

`cutMs` 160 → **300** — felt latency now rides the deep duck, not the cut, so the longer window is safe and far more robust.

## Tests
`bargeIn.test.ts` updated for the debounced restore + a **new gap-tolerance test** (gap mid-interruption still cuts; never wrongly restores). Voice suite **46/46 green**; ui typecheck clean.

## ⚠️ Needs on-device validation
This tunes the spec's explicitly-flagged risk area. After it deploys to int, please test on **speakers** (the hard case) and headphones. If the cut still feels too eager/too slow, the two knobs are `cutMs` (300) and `restoreMs` (120) — easy to tune.

🤖 Generated with [Claude Code](https://claude.com/claude-code)