### PR TITLE
feat(server): assess_spec done gate reads AC verification state (spec-120)

### DIFF
--- a/packages/server/src/services/phase-assessment.integration.test.ts
+++ b/packages/server/src/services/phase-assessment.integration.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
 import { eq } from "drizzle-orm";
 import { db } from "../db/connection.js";
-import { documents, decisions, tasks, docComments, issues } from "../db/schema.js";
+import { documents, decisions, tasks, docComments, issues, acs, memexes, namespaces } from "../db/schema.js";
 import { createDocDraft, updateDocStatus } from "./documents.js";
 import { createDecision, resolveDecision } from "./decisions.js";
 import { createTask, updateTaskStatus } from "./tasks.js";
@@ -15,8 +15,13 @@ import {
   _clearRecentAssessments,
 } from "./phase-assessment.js";
 import { addSection } from "./sections.js";
+import {
+  createAc,
+  listAcsForBriefWithVerification,
+  STALE_THRESHOLD_DAYS,
+} from "./acs.js";
 import { NotFoundError, ValidationError } from "../types/errors.js";
-import { makeTestMemex } from "./test-helpers.js";
+import { makeTestMemex, seedTestEvent } from "./test-helpers.js";
 import { tagAc } from "@memex-ai-ac/vitest";
 
 const SPEC = "mindset-prod/memex-building-itself/specs/spec-106";
@@ -29,6 +34,7 @@ afterAll(async () => {
     await db.delete(issues).where(eq(issues.docId, id)).catch(() => {});
     await db.delete(tasks).where(eq(tasks.docId, id)).catch(() => {});
     await db.delete(decisions).where(eq(decisions.docId, id)).catch(() => {});
+    await db.delete(acs).where(eq(acs.briefId, id)).catch(() => {});
     await db.delete(documents).where(eq(documents.id, id)).catch(() => {});
   }
 });
@@ -389,5 +395,252 @@ describe("verify→done open/converted Issue warning (spec-112 t-8)", () => {
     // ...yet the transition to done still goes through — soft nudge, never a gate.
     const updated = await updateDocStatus(memexId, docId, "done");
     expect(updated.status).toBe("done");
+  });
+});
+
+// spec-120 — Complete the verify fact sheet. The done gate must read AC
+// verification state (not just coverage), surface it from the SAME test_events
+// derivation list_acs uses, raise an explicit hold signal for failing/stale
+// ACs, and break open comments down by type. DB-backed by design: the parity
+// claim ("the gate and list_acs can never silently disagree") depends on the
+// canonical ac_uid join, which only an integration test exercises.
+const SPEC_120 = "mindset-prod/memex-building-itself/specs/spec-120";
+const AC120 = (n: number) => `${SPEC_120}/acs/ac-${n}`;
+
+describe("verify fact sheet completeness (spec-120)", () => {
+  let namespaceSlug: string;
+  let memexSlug: string;
+
+  beforeAll(async () => {
+    const [row] = await db
+      .select({ memexSlug: memexes.slug, namespaceSlug: namespaces.slug })
+      .from(memexes)
+      .innerJoin(namespaces, eq(memexes.namespaceId, namespaces.id))
+      .where(eq(memexes.id, memexId))
+      .limit(1);
+    if (!row) throw new Error("could not resolve test memex slugs");
+    memexSlug = row.memexSlug;
+    namespaceSlug = row.namespaceSlug;
+  });
+
+  // A Spec carried all the way to `verify`, ready for the done gate. Mirrors the
+  // spec-112 `specInVerify` helper but local to this block.
+  async function specReadyForDone(title: string): Promise<{ id: string; handle: string }> {
+    const spec = await createDocDraft(memexId, title, "Purpose", "spec");
+    createdDocIds.push(spec.id);
+    await updateDocStatus(memexId, spec.id, "specify");
+    await updateDocStatus(memexId, spec.id, "build");
+    await updateDocStatus(memexId, spec.id, "verify");
+    return { id: spec.id, handle: spec.handle! };
+  }
+
+  function acRef(briefHandle: string, seq: number): string {
+    return `${namespaceSlug}/${memexSlug}/specs/${briefHandle}/acs/ac-${seq}`;
+  }
+
+  // Create an `active` scope AC and put it into a known verification state by
+  // seeding test_events through the same path the emission route uses.
+  async function makeAcInState(
+    briefId: string,
+    briefHandle: string,
+    state: "verified" | "failing" | "stale" | "untested",
+  ): Promise<string> {
+    const ac = await createAc({
+      memexId,
+      briefId,
+      kind: "scope",
+      statement: `ac in ${state}`,
+    });
+    const handle = `ac-${ac.seq}`;
+    const uid = acRef(briefHandle, ac.seq);
+    if (state === "verified") {
+      await seedTestEvent({ acUid: uid, status: "pass" });
+    } else if (state === "failing") {
+      await seedTestEvent({ acUid: uid, status: "fail" });
+    } else if (state === "stale") {
+      const longAgo = new Date(Date.now() - (STALE_THRESHOLD_DAYS + 2) * 86_400_000);
+      await seedTestEvent({ acUid: uid, status: "pass", createdAt: longAgo });
+    }
+    // untested: no emission at all.
+    return handle;
+  }
+
+  it("ac-1: fact sheet carries AC verification counts + failing/stale handles, drawn from the list_acs derivation", async () => {
+    tagAc(AC120(1));
+    const spec = await specReadyForDone("AC verification fact sheet");
+    const verifiedH = await makeAcInState(spec.id, spec.handle, "verified");
+    const failingH = await makeAcInState(spec.id, spec.handle, "failing");
+    const staleH = await makeAcInState(spec.id, spec.handle, "stale");
+    const untestedH = await makeAcInState(spec.id, spec.handle, "untested");
+
+    const result = await assessPhaseTransition(memexId, spec.id, "done");
+    const acv = result.facts.acVerification;
+
+    expect(acv.totalActive).toBe(4);
+    expect(acv.verified).toBe(1);
+    expect(acv.failing).toBe(1);
+    expect(acv.stale).toBe(1);
+    expect(acv.untested).toBe(1);
+    expect(acv.covered).toBe(3); // verified + failing + stale have ≥1 event
+    expect(acv.failingHandles).toEqual([failingH]);
+    expect(acv.staleHandles).toEqual([staleH]);
+    // The verified / untested handles are NOT mislabelled as hold signals.
+    expect(acv.failingHandles).not.toContain(verifiedH);
+    expect(acv.failingHandles).not.toContain(untestedH);
+
+    // Rendered fact sheet shows the roll-up line and names the hold handles.
+    const rendered = formatPhaseAssessment(result);
+    expect(rendered).toMatch(/AC verification: 4 active — 1 verified, 1 failing, 1 stale, 1 untested/);
+    expect(rendered).toMatch(new RegExp(`FAILING: ${failingH}`));
+    expect(rendered).toMatch(new RegExp(`STALE: ${staleH}`));
+  });
+
+  it("ac-4: the fact-sheet counts equal what listAcsForBriefWithVerification derives (one voice, no new query path)", async () => {
+    tagAc(AC120(4));
+    const spec = await specReadyForDone("AC verification parity");
+    await makeAcInState(spec.id, spec.handle, "verified");
+    await makeAcInState(spec.id, spec.handle, "failing");
+    await makeAcInState(spec.id, spec.handle, "untested");
+
+    const result = await assessPhaseTransition(memexId, spec.id, "done");
+    const acv = result.facts.acVerification;
+
+    // Independently derive the same numbers straight from the list_acs path the
+    // AC tab consumes. If the gate ever forks to a different derivation, these
+    // diverge — which is exactly the silent disagreement spec-120 closes.
+    const rows = (await listAcsForBriefWithVerification(memexId, spec.id)).filter(
+      (r) => r.ac.status === "active",
+    );
+    const tally = { verified: 0, failing: 0, stale: 0, untested: 0, accepted: 0 };
+    for (const r of rows) tally[r.verificationState] += 1;
+
+    expect(acv.totalActive).toBe(rows.length);
+    expect(acv.verified).toBe(tally.verified);
+    expect(acv.failing).toBe(tally.failing);
+    expect(acv.stale).toBe(tally.stale);
+    expect(acv.untested).toBe(tally.untested);
+  });
+
+  it("ac-2: a failing AC raises an explicit hold-signal nudge at done that NAMES the handle", async () => {
+    tagAc(AC120(2));
+    const spec = await specReadyForDone("Failing AC hold signal");
+    const failingH = await makeAcInState(spec.id, spec.handle, "failing");
+
+    const result = await assessPhaseTransition(memexId, spec.id, "done");
+
+    const holdNudge = result.nudges.find((n) => /FAILING/.test(n));
+    expect(holdNudge).toBeDefined();
+    expect(holdNudge).toMatch(new RegExp(failingH));
+    expect(holdNudge).toMatch(/1 acceptance criterion is FAILING/);
+
+    // Visible in the rendered assessment's Nudges section too.
+    const rendered = formatPhaseAssessment(result);
+    expect(rendered).toMatch(/## Nudges/);
+    expect(rendered).toMatch(/acceptance criterion is FAILING/);
+  });
+
+  it("ac-2: a stale AC raises an explicit hold-signal nudge at done that NAMES the handle", async () => {
+    tagAc(AC120(2));
+    const spec = await specReadyForDone("Stale AC hold signal");
+    const staleH = await makeAcInState(spec.id, spec.handle, "stale");
+
+    const result = await assessPhaseTransition(memexId, spec.id, "done");
+
+    const staleNudge = result.nudges.find((n) => /STALE/.test(n));
+    expect(staleNudge).toBeDefined();
+    expect(staleNudge).toMatch(new RegExp(staleH));
+    expect(staleNudge).toMatch(/1 acceptance criterion is STALE/);
+  });
+
+  it("ac-2: the AC hold signal is done-scoped — no warning at the build→verify gate", async () => {
+    tagAc(AC120(2));
+    // A Spec sitting in `build` with a failing AC: the verify gate should not
+    // raise the done-only AC hold signal (mirrors the openIssues done-scoping).
+    const spec = await createDocDraft(memexId, "Failing AC at verify gate", "Purpose", "spec");
+    createdDocIds.push(spec.id);
+    await updateDocStatus(memexId, spec.id, "specify");
+    await updateDocStatus(memexId, spec.id, "build");
+    await makeAcInState(spec.id, spec.handle!, "failing");
+
+    const result = await assessPhaseTransition(memexId, spec.id, "verify");
+    expect(result.nudges.some((n) => /FAILING/.test(n))).toBe(false);
+    // The fact sheet still carries the count truthfully, regardless of target.
+    expect(result.facts.acVerification.failing).toBe(1);
+  });
+
+  it("ac-2: the hold signal is NON-BLOCKING — update_doc({status:'done'}) still succeeds with a failing AC", async () => {
+    tagAc(AC120(2));
+    const spec = await specReadyForDone("Done despite failing AC");
+    await makeAcInState(spec.id, spec.handle, "failing");
+
+    const result = await assessPhaseTransition(memexId, spec.id, "done");
+    expect(result.nudges.some((n) => /FAILING/.test(n))).toBe(true);
+
+    const updated = await updateDocStatus(memexId, spec.id, "done");
+    expect(updated.status).toBe("done");
+  });
+
+  it("ac-2: a clean AC slate raises NO hold signal at done", async () => {
+    tagAc(AC120(2));
+    const spec = await specReadyForDone("All ACs verified");
+    await makeAcInState(spec.id, spec.handle, "verified");
+    await makeAcInState(spec.id, spec.handle, "verified");
+
+    const result = await assessPhaseTransition(memexId, spec.id, "done");
+    expect(result.nudges.some((n) => /FAILING|STALE/.test(n))).toBe(false);
+    expect(result.facts.acVerification.failing).toBe(0);
+    expect(result.facts.acVerification.stale).toBe(0);
+  });
+
+  it("ac-3: the fact sheet breaks open comments down by type", async () => {
+    tagAc(AC120(3));
+    const spec = await specReadyForDone("Open comments by type");
+    const section = await addSection(
+      memexId,
+      spec.id,
+      "approach",
+      "Body to hang comments on",
+      "Approach",
+    );
+
+    // Two hold-signal types and one provenance type, all unresolved.
+    await addComment(memexId, section.id, "tester", "needs another look", { type: "review" });
+    await addComment(memexId, section.id, "tester", "is this right?", { type: "question" });
+    await addComment(memexId, section.id, "tester", "did the thing", { type: "progress" });
+
+    const result = await assessPhaseTransition(memexId, spec.id, "done");
+
+    expect(result.facts.openCommentsCount).toBe(3);
+    expect(result.facts.openCommentsByType).toMatchObject({
+      review: 1,
+      question: 1,
+      progress: 1,
+    });
+
+    // Rendered fact sheet enumerates the per-type breakdown.
+    const rendered = formatPhaseAssessment(result);
+    expect(rendered).toMatch(/- Open comments: 3/);
+    expect(rendered).toMatch(/ {2}- review: 1/);
+    expect(rendered).toMatch(/ {2}- question: 1/);
+    expect(rendered).toMatch(/ {2}- progress: 1/);
+  });
+
+  it("ac-5: a failing AC makes the done gate self-sufficient — the assessment alone reveals it, no separate list_acs call", async () => {
+    tagAc(AC120(5));
+    const spec = await specReadyForDone("Self-sufficient done gate");
+    const failingH = await makeAcInState(spec.id, spec.handle, "failing");
+
+    // The done assessment is the ONLY thing consulted here — no list_acs.
+    const result = await assessPhaseTransition(memexId, spec.id, "done");
+
+    // A reader of the gate alone learns the AC is failing: it's in the fact
+    // sheet AND raised as a hold nudge. This is what lets spec-116's verify
+    // prompt drop its "always cross-check list_acs" workaround.
+    expect(result.facts.acVerification.failing).toBe(1);
+    expect(result.facts.acVerification.failingHandles).toEqual([failingH]);
+    expect(result.nudges.some((n) => /FAILING/.test(n) && new RegExp(failingH).test(n))).toBe(true);
+
+    const rendered = formatPhaseAssessment(result);
+    expect(rendered).toMatch(new RegExp(`FAILING: ${failingH}`));
   });
 });

--- a/packages/server/src/services/phase-assessment.ts
+++ b/packages/server/src/services/phase-assessment.ts
@@ -5,7 +5,11 @@ import { and, eq, isNull } from "drizzle-orm";
 import { db } from "../db/connection.js";
 import { documents, decisions, tasks, docComments, docSections, issues } from "../db/schema.js";
 import type { Decision, Task, DocSection } from "../db/schema.js";
-import { listResolvedDecisionImplAcCoverage } from "./acs.js";
+import {
+  listResolvedDecisionImplAcCoverage,
+  listAcsForBriefWithVerification,
+  STALE_THRESHOLD_DAYS,
+} from "./acs.js";
 import { NotFoundError, ValidationError } from "../types/errors.js";
 import { getReadyTasks } from "./tasks.js";
 import { parsePhaseDescriptions } from "../mcp/phase-descriptions.js";
@@ -211,6 +215,31 @@ export interface DecisionAcCoverageFact {
   implementationAcCount: number;
 }
 
+/**
+ * spec-120 ac-1 — AC verification roll-up for the fact sheet. Drawn from the
+ * SAME `test_events` derivation `list_acs` uses (`listAcsForBriefWithVerification`
+ * → `deriveVerificationState`), so the deterministic gate and `list_acs` can
+ * never silently disagree. Counts cover only `active` ACs (matching the
+ * `list_acs` default), and the `failing` / `stale` handles are surfaced inline
+ * so the done-rubric hold signal can name them without a second tool call.
+ */
+export interface AcVerificationFact {
+  /** Active ACs on this Spec (matches `list_acs` default scope). */
+  totalActive: number;
+  /** Active ACs with ≥1 tagged test event (any status). */
+  covered: number;
+  verified: number;
+  failing: number;
+  stale: number;
+  untested: number;
+  /** Manually accepted (spec-188) with no failing evidence. */
+  accepted: number;
+  /** Handles (`ac-N`) of every `failing` AC — the hold signals. */
+  failingHandles: string[];
+  /** Handles (`ac-N`) of every `stale` AC — also a hold signal at `done`. */
+  staleHandles: string[];
+}
+
 export interface PhaseAssessment {
   briefId: string;
   specHandle: string;
@@ -243,6 +272,22 @@ export interface PhaseAssessment {
     incompleteTasks: { handle: string; title: string; status: string; blocked: boolean }[];
     unresolvedDriftCount: number;
     unresolvedPlanRevisionCount: number;
+    /**
+     * spec-120 ac-3: total open (unresolved) comments whose target lives on
+     * this Spec, plus the same figure broken down by `commentType`. The
+     * breakdown lets a verifier distinguish hold-signals (review / question /
+     * drift / plan_revision) from benign provenance notes (progress / plan)
+     * inline, without a separate `list_comments` call. `openCommentsCount` is
+     * the sum of `openCommentsByType` values.
+     */
+    openCommentsCount: number;
+    openCommentsByType: Record<string, number>;
+    /**
+     * spec-120 ac-1: AC verification roll-up, derived from the same
+     * `test_events` path `list_acs` uses so the gate and `list_acs` speak with
+     * one voice. See `AcVerificationFact`.
+     */
+    acVerification: AcVerificationFact;
     /**
      * spec-112 t-8: count of Issues still in flight on this Spec (`open` +
      * `converted`). Drives the SOFT verify→done warning (ac-17). 0 when the Spec
@@ -280,26 +325,101 @@ export interface PhaseAssessment {
   codeGroundingPromptPending?: boolean;
 }
 
-// Open-comments count used by the shared readiness computation. Counts every
-// unresolved comment whose target lives on the Spec, regardless of type.
-async function countOpenCommentsOnSpec(
+// spec-120 ac-3: open-comments on a Spec, both as a total AND broken down by
+// `commentType`. Counts every unresolved comment whose target (section /
+// decision / task) lives on this Spec. One query; the by-type map lets the
+// fact sheet distinguish hold-signals from provenance notes inline.
+async function breakdownOpenCommentsOnSpec(
   memexId: string,
   sectionIdSet: Set<string>,
   decisionIdSet: Set<string>,
   taskIdSet: Set<string>,
-): Promise<number> {
+): Promise<{ total: number; byType: Record<string, number> }> {
   const open = await db.query.docComments.findMany({
     where: and(
       eq(docComments.memexId, memexId),
       isNull(docComments.resolvedAt),
     ),
   });
-  return open.filter(
+  const onSpec = open.filter(
     (c) =>
       (c.sectionId !== null && sectionIdSet.has(c.sectionId)) ||
       (c.decisionId !== null && decisionIdSet.has(c.decisionId)) ||
       (c.taskId !== null && taskIdSet.has(c.taskId)),
-  ).length;
+  );
+  const byType: Record<string, number> = {};
+  for (const c of onSpec) {
+    byType[c.commentType] = (byType[c.commentType] ?? 0) + 1;
+  }
+  return { total: onSpec.length, byType };
+}
+
+// Open-comments count used by the shared readiness computation. Counts every
+// unresolved comment whose target lives on the Spec, regardless of type — a
+// thin wrapper over `breakdownOpenCommentsOnSpec` so the total and the by-type
+// view derive from a single query path.
+async function countOpenCommentsOnSpec(
+  memexId: string,
+  sectionIdSet: Set<string>,
+  decisionIdSet: Set<string>,
+  taskIdSet: Set<string>,
+): Promise<number> {
+  const { total } = await breakdownOpenCommentsOnSpec(
+    memexId,
+    sectionIdSet,
+    decisionIdSet,
+    taskIdSet,
+  );
+  return total;
+}
+
+// spec-120 ac-1: AC verification roll-up for a single Spec, computed through
+// `listAcsForBriefWithVerification` — the EXACT path `list_acs` uses — so the
+// gate's counts and `list_acs` derive from one `deriveVerificationState` call
+// and can never silently disagree. Scoped to `active` ACs to match the
+// `list_acs` default; failing / stale handles are collected for the hold signal.
+async function summarizeAcVerification(
+  memexId: string,
+  briefId: string,
+): Promise<AcVerificationFact> {
+  const rows = (await listAcsForBriefWithVerification(memexId, briefId)).filter(
+    (r) => r.ac.status === "active",
+  );
+  const fact: AcVerificationFact = {
+    totalActive: rows.length,
+    covered: 0,
+    verified: 0,
+    failing: 0,
+    stale: 0,
+    untested: 0,
+    accepted: 0,
+    failingHandles: [],
+    staleHandles: [],
+  };
+  for (const r of rows) {
+    if (r.tests.length > 0) fact.covered += 1;
+    const handle = `ac-${r.ac.seq}`;
+    switch (r.verificationState) {
+      case "verified":
+        fact.verified += 1;
+        break;
+      case "failing":
+        fact.failing += 1;
+        fact.failingHandles.push(handle);
+        break;
+      case "stale":
+        fact.stale += 1;
+        fact.staleHandles.push(handle);
+        break;
+      case "untested":
+        fact.untested += 1;
+        break;
+      case "accepted":
+        fact.accepted += 1;
+        break;
+    }
+  }
+  return fact;
 }
 
 // spec-112 t-8 — count the Issues that are still in flight on a Spec:
@@ -496,6 +616,22 @@ export async function assessPhaseTransition(
   // SOFT verify→done warning below and the matching fact.
   const openIssuesCount = await countOpenIssuesOnSpec(memexId, briefId);
 
+  // spec-120 ac-3: open comments on this Spec, total + by-type. Computed once
+  // here; `.total` feeds the shared readiness view below (same figure as
+  // before) and `.byType` rides the fact sheet so hold-signals are
+  // distinguishable from provenance notes inline.
+  const openComments = await breakdownOpenCommentsOnSpec(
+    memexId,
+    sectionIdSet,
+    decisionIdSet,
+    taskIdSet,
+  );
+
+  // spec-120 ac-1: AC verification roll-up drawn from the same `test_events`
+  // derivation `list_acs` uses, so the gate and `list_acs` can never silently
+  // disagree. Drives the `done` hold signal below (ac-2) and the fact sheet.
+  const acVerification = await summarizeAcVerification(memexId, briefId);
+
   // b-68 t-7: the legacy per-target `.md`-sourced rubric is retired. Only the
   // friendly note for the rubric-less draft→specify transition remains; the
   // composed `rubricProse` below carries the full rubric prose.
@@ -552,6 +688,30 @@ export async function assessPhaseTransition(
       `There ${openIssuesCount === 1 ? "is" : "are"} ${openIssuesCount} open or converted Issue${openIssuesCount === 1 ? "" : "s"} on this Spec. ` +
         `Closing it to 'done' leaves that work unresolved — resolve, convert, or mark them wont_fix first, or close anyway if intentional.`,
     );
+  }
+
+  // spec-120 ac-2: failing / stale AC hold signal on the verify→done gate.
+  // Mirrors how open drift is surfaced — an explicit warning line that NAMES
+  // the offending AC handles, drawn from the same `test_events` derivation
+  // `list_acs` uses (acVerification above). Closing a Spec to 'done' while a
+  // tagged test is emitting `fail`, or while a once-passing AC has gone `stale`
+  // (>7d), means the gate would otherwise read clean while an acceptance
+  // criterion is unmet — exactly the gap spec-116's dry-runs surfaced. SOFT
+  // (a nudge, not a hard gate), consistent with the other done-phase warnings.
+  if (targetPhase === "done") {
+    const { failing, stale, failingHandles, staleHandles } = acVerification;
+    if (failing > 0) {
+      nudges.push(
+        `${failing} acceptance criteri${failing === 1 ? "on is" : "a are"} FAILING (${failingHandles.join(", ")}). ` +
+          `A clean done gate would otherwise hide this — fix the code or the test so the tagged test passes before closing to 'done'.`,
+      );
+    }
+    if (stale > 0) {
+      nudges.push(
+        `${stale} acceptance criteri${stale === 1 ? "on is" : "a are"} STALE (${staleHandles.join(", ")}) — last passing run is older than ${STALE_THRESHOLD_DAYS} days. ` +
+          `Re-run the tagged tests to refresh verification before closing to 'done', or close anyway if intentional.`,
+      );
+    }
   }
 
   // Decisions-need-ACs gate: any resolved decision on the specify→build path that
@@ -613,12 +773,8 @@ export async function assessPhaseTransition(
 
   // Cross-surface readiness — same shape consumed by the React UI's
   // PhaseDropdown, computed via @memex/shared so behaviour stays in lockstep.
-  const openCommentCountAll = await countOpenCommentsOnSpec(
-    memexId,
-    sectionIdSet,
-    decisionIdSet,
-    taskIdSet,
-  );
+  // spec-120 ac-3: the total open-comment figure reuses the by-type breakdown
+  // computed above — one query path, no double count.
   const readiness = computeSpecReadiness({
     currentPhase: spec.status as SpecPhase,
     decisions: allDecisions.map((d) => ({
@@ -627,7 +783,7 @@ export async function assessPhaseTransition(
       resolvedAt: d.resolvedAt,
       status: d.status as 'open' | 'resolved' | 'candidate' | 'rejected',
     })),
-    openCommentCount: openCommentCountAll,
+    openCommentCount: openComments.total,
     narrativeLastConsolidatedAt: spec.narrativeLastConsolidatedAt ?? null,
     // spec-112 t-8: same in-flight Issue count feeds the shared readiness view
     // so the React UI's PhaseDropdown and the MCP fact sheet speak with one
@@ -660,6 +816,9 @@ export async function assessPhaseTransition(
       })),
       unresolvedDriftCount: specDrift.length,
       unresolvedPlanRevisionCount: specPlanRevisions.length,
+      openCommentsCount: openComments.total,
+      openCommentsByType: openComments.byType,
+      acVerification,
       openIssuesCount,
       sections: sectionRows.map((s) => ({
         sectionType: s.sectionType,
@@ -710,7 +869,32 @@ export function formatPhaseAssessment(assessment: PhaseAssessment): string {
   }
   lines.push(`- Unresolved drift comments: ${f.unresolvedDriftCount}`);
   lines.push(`- Unresolved plan_revision comments: ${f.unresolvedPlanRevisionCount}`);
+  // spec-120 ac-3: open comments broken down by type so hold-signals
+  // (review / question / drift / plan_revision) are distinguishable from
+  // provenance notes (progress / plan) without a separate list_comments call.
+  lines.push(`- Open comments: ${f.openCommentsCount}`);
+  if (f.openCommentsCount > 0) {
+    const byType = Object.entries(f.openCommentsByType).sort((a, b) =>
+      a[0].localeCompare(b[0]),
+    );
+    for (const [type, count] of byType) {
+      lines.push(`  - ${type}: ${count}`);
+    }
+  }
   lines.push(`- Open/converted Issues: ${f.openIssuesCount}`);
+  // spec-120 ac-1: AC verification state, from the same test_events derivation
+  // list_acs uses — the gate and list_acs can never silently disagree. Failing
+  // / stale handles are named inline so a verifier never needs a second call.
+  const acv = f.acVerification;
+  lines.push(
+    `- AC verification: ${acv.totalActive} active — ${acv.verified} verified, ${acv.failing} failing, ${acv.stale} stale, ${acv.untested} untested${acv.accepted > 0 ? `, ${acv.accepted} accepted` : ""}`,
+  );
+  if (acv.failingHandles.length > 0) {
+    lines.push(`  - FAILING: ${acv.failingHandles.join(", ")}`);
+  }
+  if (acv.staleHandles.length > 0) {
+    lines.push(`  - STALE: ${acv.staleHandles.join(", ")}`);
+  }
   lines.push(`- Sections: ${f.sections.length}`);
   if (f.resolvedDecisionCoverage.length > 0) {
     lines.push("- Resolved-decision narrative coverage (best-effort):");


### PR DESCRIPTION
## What

Completes the deterministic verify fact sheet so `assess_spec({ mode:'phase', target:'done' })` can no longer return a fully clean gate while an acceptance criterion is **failing**. This closes the highest-leverage gap surfaced by the spec-116 verify-prompt dry-runs: today the only thing stopping a false PASS is a hand-written sentence in the verify prompt telling the agent to cross-check `list_acs`.

Memex spec: [`mindset-prod/memex-building-itself/specs/spec-120`](https://memex.ai/mindset-prod/memex-building-itself/specs/spec-120)

## Changes (all in `phase-assessment.ts` — no new storage/primitive/query path)

1. **Fold AC verification state into the fact sheet.** `summarizeAcVerification` runs through `listAcsForBriefWithVerification` → `deriveVerificationState` — the *exact* path `list_acs` uses — so the gate and `list_acs` can never silently disagree. Surfaces counts (verified / failing / stale / untested / accepted) plus the **handles** of any failing or stale AC, scoped to `active` ACs (matching the `list_acs` default).
2. **Hold-signal on the verify→done gate.** A failing or stale AC now raises an explicit warning line that names the offending handles, mirroring how open drift is surfaced today. SOFT (never blocks the transition) and `done`-scoped, consistent with the open-Issues warning.
3. **Open comments broken down by type.** The fact sheet now shows the open-comments figure per `commentType`, so a verifier can tell hold-signals (review / question / drift / plan_revision) from provenance notes (progress / plan) inline, without a separate `list_comments` call. The total reuses the same single query and feeds the shared readiness view unchanged.

## Acceptance criteria

All five spec-120 scope ACs are now **100% covered / 100% verified** by tagged tests:

- **ac-1** — fact sheet carries AC verification counts + failing/stale handles, from the `list_acs` derivation
- **ac-2** — failing/stale AC raises an explicit hold-signal at done (done-scoped, non-blocking)
- **ac-3** — open comments broken down by type
- **ac-4** — no new query path; counts equal `listAcsForBriefWithVerification`; std-16 manifest-parity test stays green
- **ac-5** — a clean done gate is self-sufficient evidence of AC health

## Test plan

- [x] 9 new integration tests in `phase-assessment.integration.test.ts` (all green, 29/29 in that suite)
- [x] Full `@memex/server` suite green except **two pre-existing failures on `develop`** (`memex-embeddings` re-embed + a `semanticEdges` length check) — confirmed pre-existing by re-running with this change stashed out; both are embedding/semantic-edge suites untouched here
- [x] `tsc --noEmit` clean for the changed files (one unrelated pre-existing error in `discord-webhook.test.ts`)
- [x] Manifest-parity regression green (ac-4)