### PR TITLE
feat(scaffold): surface the todo Issue as the planning parking lot (spec-202)

### DIFF
--- a/packages/shared/src/scaffold-data.test.ts
+++ b/packages/shared/src/scaffold-data.test.ts
@@ -162,3 +162,71 @@ describe('spec-176 ac-10: BASE_CREATE_FROM_DOC is react_only', () => {
     expect(block?.surface).toBe('react_only');
   });
 });
+
+// spec-202: surface the `todo` Issue as the planning parking lot — route
+// don't-forget actions in specify (PHASE_PLAN_DISCIPLINE), triage open todos
+// at the specify→build gate (TRANSITION_BUILD). ACs are verified by asserting
+// the BASE scaffold prose directly — the prose IS the deliverable.
+describe('spec-202: planning parking lot — specify routing + specify→build triage', () => {
+  const AC202 = (n: number) =>
+    `mindset-prod/memex-building-itself/specs/spec-202/acs/ac-${n}`;
+
+  const disciplineText = () =>
+    BASE_SCAFFOLD.promptBlocks.find((b) => b.id === 'phase-specify-discipline')?.text ?? '';
+  const intentText = () =>
+    BASE_SCAFFOLD.promptBlocks.find((b) => b.id === 'phase-specify-intent')?.text ?? '';
+  const buildRubricText = () =>
+    BASE_SCAFFOLD.transitions.find((t) => t.transition === 'build')?.text ?? '';
+
+  it('ac-5/ac-1: PHASE_PLAN_DISCIPLINE routes capture by kind and names register_issue({type:todo}) as the parking lot', () => {
+    tagAc(AC202(5));
+    tagAc(AC202(1)); // scope outcome ac-1 is verified by this same assertion
+    const text = disciplineText();
+    expect(text).toContain("register_issue({ type: 'todo' })");
+    expect(text).toContain('create_decision');
+    expect(text).toContain('update_section');
+    expect(text.toLowerCase()).toContain('parking lot');
+  });
+
+  it('ac-6/ac-2: PHASE_PLAN_DISCIPLINE states the decision-in-disguise anti-pattern', () => {
+    tagAc(AC202(6));
+    tagAc(AC202(2)); // scope outcome ac-2 is verified by this same assertion
+    const text = disciplineText();
+    expect(text).toContain('task in disguise');
+    expect(text).toContain('pollutes the gate');
+  });
+
+  it('ac-7: routing is single-homed — PHASE_PLAN_INTENT carries no register_issue duplicate', () => {
+    tagAc(AC202(7));
+    const intent = intentText();
+    expect(intent.length, 'phase-specify-intent block missing').toBeGreaterThan(0);
+    expect(intent).not.toContain('register_issue');
+  });
+
+  it('ac-8/ac-3: TRANSITION_BUILD enumerates open todo Issues for triage (convert/defer/close)', () => {
+    tagAc(AC202(8));
+    tagAc(AC202(3)); // scope outcome ac-3 is verified by this same assertion
+    const text = buildRubricText();
+    expect(text).toContain('todo');
+    expect(text).toContain('convert_issue_to_task');
+    expect(text.toLowerCase()).toContain('defer');
+    expect(text.toLowerCase()).toContain('close');
+    expect(text.toLowerCase()).toContain('parking lot');
+  });
+
+  it('ac-9: TRANSITION_BUILD stays advisory — open todos never force a hold', () => {
+    tagAc(AC202(9));
+    const text = buildRubricText();
+    expect(text).toContain('This rubric is advisory.');
+    expect(text).toContain('never downgrades the verdict to `hold`');
+    expect(text).toContain('Open `todo` Issues have each been converted, deferred, or closed');
+  });
+
+  it('ac-4: both edits live in scaffold-data BASE_SCAFFOLD — the single owner of scaffold prose', () => {
+    tagAc(AC202(4));
+    // Both changes are sourced from scaffold-data.ts (BASE_SCAFFOLD), not a new
+    // phases/*.md or inline server prose — which is what keeps the drift guard green.
+    expect(disciplineText()).toContain("register_issue({ type: 'todo' })");
+    expect(buildRubricText()).toContain('convert_issue_to_task');
+  });
+});

--- a/packages/shared/src/scaffold-data.ts
+++ b/packages/shared/src/scaffold-data.ts
@@ -342,8 +342,11 @@ const PHASE_PLAN_DISCIPLINE: PromptBlockNode = {
   surface: 'shared_nudge',
   text:
     '## Phase discipline\n\n' +
-    '- **Tasks are NOT first-class in `specify` or `draft`.** Never call `create_task` while the Spec is in either phase. If work needs to be captured, surface it as a decision or a section update instead. Tasks belong in `build`.\n' +
-    '- The work here is decision resolution and narrative shaping — nothing else.\n' +
+    '- **Tasks are NOT first-class in `specify` or `draft`.** Never call `create_task` while the Spec is in either phase — tasks belong in `build`. When something needs capturing, route it by what it *is*:\n' +
+    '  - **A fork to resolve** (a choice the work hinges on) → `create_decision`. Open decisions gate the specify→build transition, and that is correct — an unresolved fork *should* hold up the build.\n' +
+    '  - **An action to remember** (a follow-up, a "we must also…", a don\'t-forget) → `register_issue({ type: \'todo\' })`. This is the parking lot: gate-neutral (it never blocks the transition), build-visible, and promotable straight to a Task via `convert_issue_to_task` once you reach `build`. Do **not** file an action as a Decision — a "decision" with no options and nothing to resolve is a task in disguise, and it pollutes the gate with a non-question.\n' +
+    '  - **Context, or a choice already shaped** → fold it into the narrative with `update_section`. The Spec is the source of truth.\n' +
+    '- The *work* here is decision resolution and narrative shaping; capturing a fork, an action, or context (above) is done in passing, not as the main activity.\n' +
     '- Verify against current code before resolving — read the relevant source, don\'t lean on CLAUDE.md or prior knowledge. Decisions that name code (files, symbols, schema, routes) must be grounded against current source here in specify; the specify→build gate (`assess_spec`) will ask you to classify that grounding as `not_applicable`, `verified`, or `not_verified`.',
   rationale:
     'Specify-phase guardrails: no tasks, just decisions + narrative + code grounding. Mirrors the "## Phase discipline" block of `specify/system.md`.',
@@ -853,7 +856,8 @@ const TRANSITION_BUILD: TransitionRubric = {
     '5. **UX shape.** If the Spec has a user-facing surface, Design (or equivalent) describes the flow concretely enough that a task could be derived from it. Vague gestures ("we\'ll figure out the UI") are a hold signal.\n' +
     '6. **Scope acceptance criteria.** The Spec\'s Scope ACs (`create_ac({kind:\'scope\'})`) read as outcomes, not implementation steps, and match the agreed scope. Without scope ACs, the Spec has no measurable success criteria at the manager\'s level.\n' +
     '7. **Standards.** `search_memex({ kind: \'standard\' })` has been run for the load-bearing concerns; gaps are acknowledged (cold-start) rather than ignored.\n' +
-    '8. **Open questions.** No `question`-typed comments are unresolved on sections the upcoming tasks will touch.\n\n' +
+    '8. **Open questions.** No `question`-typed comments are unresolved on sections the upcoming tasks will touch.\n' +
+    '9. **Open `todo` Issues — the parking lot.** Walk the Spec\'s open `todo` Issues (actions parked during specify). For each, decide with the human: convert it to a Task now (`convert_issue_to_task`, which mints its verifying AC), defer it explicitly (note why and where), or close it as no-longer-relevant — in the context of the tasks now forming. This is advisory: surface the list and recommend a disposition, but an un-triaged `todo` never downgrades the verdict to `hold` (a `todo` Issue is gate-neutral by design). A `todo` carried silently into build is a forgotten commitment — make the triage visible, not blocking.\n\n' +
     '## Narrative consolidation (mandatory per dec-11)\n\n' +
     'Before recommending `proceed`, walk every resolved decision and confirm:\n\n' +
     '- Its architectural consequence appears in a narrative section. If not, propose an `add_section` or `update_section` to surface it.\n' +
@@ -866,6 +870,7 @@ const TRANSITION_BUILD: TransitionRubric = {
     '- Each resolved decision has ≥1 active implementation AC linked to it (`resolvedDecisionAcCoverage` shows zero naked).\n' +
     '- The Approach / Architecture reads coherently end-to-end.\n' +
     '- Standards search has been done; cold-start gaps are noted.\n' +
+    '- Open `todo` Issues have each been converted, deferred, or closed — none carried in silently.\n' +
     '- The user has seen and confirmed the consolidated narrative.\n\n' +
     '## Verdict format\n\n' +
     'Return a short narrative ending with one of:\n' +


### PR DESCRIPTION
## What
Make spec-112's `todo` Issue the visible parking lot during planning, and triage parked todos at the specify→build gate. Two prose edits to the single scaffold source (`packages/shared/src/scaffold-data.ts`).

## Why
During planning, a "must not forget" action had no visible home, so it got filed as a `create_decision` — a "decision" with no fork to resolve. That pollutes the specify→build gate (every open decision blocks the transition). The `todo` Issue primitive already existed (spec-112) but the specify scaffold never named it, so agents reached for the nearest exit.

## Changes
- **`PHASE_PLAN_DISCIPLINE`** — route capture by kind: a fork to resolve → `create_decision`, an action to remember → `register_issue({type:'todo'})`, context → `update_section`; name the decision-in-disguise anti-pattern. Single-homed — `PHASE_PLAN_INTENT` left unchanged (avoids the spec-33 dec-11 over-restatement).
- **`TRANSITION_BUILD`** — advisory inspect item that walks open `todo` Issues (convert via `convert_issue_to_task` / defer / close), never a hold (the `todo` Issue is gate-neutral by design), plus a matching "what good looks like" line.
- No schema/tool/model change — reuses existing primitives.

## Testing
- Tagged assertions in `scaffold-data.test.ts` cover **all 9 spec-202 ACs** (scope + implementation); all show `verified` on the Spec.
- Full `@memex/shared` suite green (606); server `scaffold-drift-guard` + `scaffold-parity` regression green; `tsc` clean.

## Spec
[mindset-prod/memex-building-itself/specs/spec-202](https://memex.ai/mindset-prod/memex-building-itself/specs/spec-202) — build-complete, 9/9 ACs verified.
