### PR TITLE
feat(ui): livelier Specky idle loop — bob + sway + smile (spec-197 polish)

### DIFF
--- a/assets/specky/specky-static.svg
+++ b/assets/specky/specky-static.svg
@@ -2,11 +2,11 @@
   <!-- specky-static.svg — the QUIET in-view doorway variant (spec-197 dec-2 / ac-8).
        Byte-for-byte the same artwork as specky.svg with the entire animated style
        block (and keyframes) removed, so it renders the neutral base pose (clip
-       upright, eyes open,
-       brows level) and never moves. The animated specky.svg is used for the live
-       session-pill avatar (dec-1); this static frame keeps the entry affordance
-       calm and "decays-with-familiarity" rather than a paperclip wobbling in every
-       view. Derived from specky.svg — keep the two artworks in sync. -->
+       upright, centred, eyes open, brows level, friendly smile) and never moves.
+       The animated specky.svg is used for the live session-pill avatar (dec-1);
+       this static frame keeps the entry affordance calm and "decays-with-
+       familiarity" rather than a paperclip wobbling in every view. Derived from
+       specky.svg — keep the two artworks in sync. -->
   <defs>
     <linearGradient id="wire" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0" stop-color="#c3ced9"/>
@@ -19,28 +19,34 @@
     </linearGradient>
   </defs>
 
-  <g class="clip-root">
+  <g class="float">
+    <g class="clip-root">
 
-    <path d="M 78 300 L 78 122 A 42 42 0 0 1 162 122 L 162 252 A 28 28 0 0 1 106 252 L 106 152"
-          fill="none" stroke="url(#wire)" stroke-width="16" stroke-linecap="round"/>
+      <path d="M 78 300 L 78 122 A 42 42 0 0 1 162 122 L 162 252 A 28 28 0 0 1 106 252 L 106 152"
+            fill="none" stroke="url(#wire)" stroke-width="16" stroke-linecap="round"/>
 
-    <path d="M 74.5 300 L 74.5 122 A 45.5 45.5 0 0 1 120 76.5"
-          fill="none" stroke="url(#wireHi)" stroke-width="3.5" stroke-linecap="round"/>
+      <path d="M 74.5 300 L 74.5 122 A 45.5 45.5 0 0 1 120 76.5"
+            fill="none" stroke="url(#wireHi)" stroke-width="3.5" stroke-linecap="round"/>
 
-    <g class="brows" fill="none" stroke="#6e7a88" stroke-width="7" stroke-linecap="round">
-      <path d="M 84 46 Q 99 35 113 45"/>
-      <path d="M 127 45 Q 141 35 156 46"/>
-    </g>
-
-    <g class="eyes">
-      <ellipse cx="99" cy="86" rx="18" ry="23" fill="#ffffff" stroke="#3d4654" stroke-width="3.5"/>
-      <ellipse cx="141" cy="86" rx="18" ry="23" fill="#ffffff" stroke="#3d4654" stroke-width="3.5"/>
-      <g class="pupils" fill="#1d242e">
-        <circle cx="99" cy="89" r="7.5"/>
-        <circle cx="141" cy="89" r="7.5"/>
-        <circle cx="96.5" cy="86" r="2.2" fill="#ffffff"/>
-        <circle cx="138.5" cy="86" r="2.2" fill="#ffffff"/>
+      <g class="brows" fill="none" stroke="#6e7a88" stroke-width="7" stroke-linecap="round">
+        <path d="M 84 46 Q 99 35 113 45"/>
+        <path d="M 127 45 Q 141 35 156 46"/>
       </g>
+
+      <g class="eyes">
+        <ellipse cx="99" cy="86" rx="18" ry="23" fill="#ffffff" stroke="#3d4654" stroke-width="3.5"/>
+        <ellipse cx="141" cy="86" rx="18" ry="23" fill="#ffffff" stroke="#3d4654" stroke-width="3.5"/>
+        <g class="pupils" fill="#1d242e">
+          <circle cx="99" cy="89" r="7.5"/>
+          <circle cx="141" cy="89" r="7.5"/>
+          <circle cx="96.5" cy="86" r="2.2" fill="#ffffff"/>
+          <circle cx="138.5" cy="86" r="2.2" fill="#ffffff"/>
+        </g>
+      </g>
+
+      <!-- friendly smile (the warmer face from the mock) -->
+      <path d="M 107 114 Q 120 126 133 114" fill="none" stroke="#6e7a88"
+            stroke-width="5" stroke-linecap="round"/>
     </g>
   </g>
 </svg>

--- a/assets/specky/specky.svg
+++ b/assets/specky/specky.svg
@@ -1,28 +1,31 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 330" width="240" height="330">
   <style>
+    /* spec-197 — Specky idle loop. Livelier per the spec-200 mock: a
+       continuous BOB (float) + soft SWAY (tilt), over the glance/blink/brow
+       life. Still an idle loop only (dec-1=a), no session-state variants.
+       NOTE: keep this asset apostrophe-free so Vite inlines it as a URL-
+       encoded data URI (an apostrophe trips Vite nestedQuotesRE -> base64,
+       which the spec-197 wiring test cannot decode). */
+    .float { animation: bob 3.4s ease-in-out infinite; }
     .clip-root {
       transform-box: fill-box;
       transform-origin: 50% 90%;
-      animation: wobble 7s ease-in-out infinite;
+      animation: sway 3.4s ease-in-out infinite;
     }
-    .pupils {
-      animation: look 9s ease-in-out infinite;
-    }
+    .pupils { animation: look 9s ease-in-out infinite; }
     .eyes {
       transform-box: fill-box;
       transform-origin: 50% 50%;
       animation: blink 6.5s linear infinite;
     }
-    .brows {
-      animation: brows 9s ease-in-out infinite;
+    .brows { animation: brows 9s ease-in-out infinite; }
+    @keyframes bob {
+      0%, 100% { transform: translateY(0px); }
+      50%      { transform: translateY(-11px); }
     }
-    @keyframes wobble {
-      0%, 68%  { transform: rotate(0deg); }
-      71%      { transform: rotate(-5deg); }
-      74%      { transform: rotate(4deg); }
-      77%      { transform: rotate(-2.5deg); }
-      80%      { transform: rotate(1.5deg); }
-      83%, 100% { transform: rotate(0deg); }
+    @keyframes sway {
+      0%, 100% { transform: rotate(-2deg); }
+      50%      { transform: rotate(2deg); }
     }
     @keyframes look {
       0%, 16%   { transform: translate(0px, 0px); }
@@ -44,20 +47,11 @@
       84%, 100% { transform: translate(0px, 0px); }
     }
 
-    /* spec-197 dec-5(b) / ac-4 — honour prefers-reduced-motion by freezing
-       Specky to a neutral static frame (animation:none resets each element to
-       its base pose: clip upright, pupils centred, eyes open, brows level).
-       The character is never hidden — the affordance must stay discoverable
-       for motion-sensitive users. This rule lives inside the SVG so the asset
-       self-handles reduced motion even when embedded as a plain <img>, with
-       no consuming-component CSS required (dec-3=a drop-in img). */
+    /* dec-5(b) / ac-4 — prefers-reduced-motion freezes Specky to its base
+       pose. The character is never hidden, so the affordance stays
+       discoverable for motion-sensitive users. */
     @media (prefers-reduced-motion: reduce) {
-      .clip-root,
-      .pupils,
-      .eyes,
-      .brows {
-        animation: none;
-      }
+      .float, .clip-root, .pupils, .eyes, .brows { animation: none; }
     }
   </style>
 
@@ -73,28 +67,34 @@
     </linearGradient>
   </defs>
 
-  <g class="clip-root">
+  <g class="float">
+    <g class="clip-root">
 
-    <path d="M 78 300 L 78 122 A 42 42 0 0 1 162 122 L 162 252 A 28 28 0 0 1 106 252 L 106 152"
-          fill="none" stroke="url(#wire)" stroke-width="16" stroke-linecap="round"/>
+      <path d="M 78 300 L 78 122 A 42 42 0 0 1 162 122 L 162 252 A 28 28 0 0 1 106 252 L 106 152"
+            fill="none" stroke="url(#wire)" stroke-width="16" stroke-linecap="round"/>
 
-    <path d="M 74.5 300 L 74.5 122 A 45.5 45.5 0 0 1 120 76.5"
-          fill="none" stroke="url(#wireHi)" stroke-width="3.5" stroke-linecap="round"/>
+      <path d="M 74.5 300 L 74.5 122 A 45.5 45.5 0 0 1 120 76.5"
+            fill="none" stroke="url(#wireHi)" stroke-width="3.5" stroke-linecap="round"/>
 
-    <g class="brows" fill="none" stroke="#6e7a88" stroke-width="7" stroke-linecap="round">
-      <path d="M 84 46 Q 99 35 113 45"/>
-      <path d="M 127 45 Q 141 35 156 46"/>
-    </g>
-
-    <g class="eyes">
-      <ellipse cx="99" cy="86" rx="18" ry="23" fill="#ffffff" stroke="#3d4654" stroke-width="3.5"/>
-      <ellipse cx="141" cy="86" rx="18" ry="23" fill="#ffffff" stroke="#3d4654" stroke-width="3.5"/>
-      <g class="pupils" fill="#1d242e">
-        <circle cx="99" cy="89" r="7.5"/>
-        <circle cx="141" cy="89" r="7.5"/>
-        <circle cx="96.5" cy="86" r="2.2" fill="#ffffff"/>
-        <circle cx="138.5" cy="86" r="2.2" fill="#ffffff"/>
+      <g class="brows" fill="none" stroke="#6e7a88" stroke-width="7" stroke-linecap="round">
+        <path d="M 84 46 Q 99 35 113 45"/>
+        <path d="M 127 45 Q 141 35 156 46"/>
       </g>
+
+      <g class="eyes">
+        <ellipse cx="99" cy="86" rx="18" ry="23" fill="#ffffff" stroke="#3d4654" stroke-width="3.5"/>
+        <ellipse cx="141" cy="86" rx="18" ry="23" fill="#ffffff" stroke="#3d4654" stroke-width="3.5"/>
+        <g class="pupils" fill="#1d242e">
+          <circle cx="99" cy="89" r="7.5"/>
+          <circle cx="141" cy="89" r="7.5"/>
+          <circle cx="96.5" cy="86" r="2.2" fill="#ffffff"/>
+          <circle cx="138.5" cy="86" r="2.2" fill="#ffffff"/>
+        </g>
+      </g>
+
+      <!-- friendly smile (the warmer face from the mock) -->
+      <path d="M 107 114 Q 120 126 133 114" fill="none" stroke="#6e7a88"
+            stroke-width="5" stroke-linecap="round"/>
     </g>
   </g>
 </svg>

--- a/packages/ui/src/assets/specky-static.svg
+++ b/packages/ui/src/assets/specky-static.svg
@@ -2,11 +2,11 @@
   <!-- specky-static.svg — the QUIET in-view doorway variant (spec-197 dec-2 / ac-8).
        Byte-for-byte the same artwork as specky.svg with the entire animated style
        block (and keyframes) removed, so it renders the neutral base pose (clip
-       upright, eyes open,
-       brows level) and never moves. The animated specky.svg is used for the live
-       session-pill avatar (dec-1); this static frame keeps the entry affordance
-       calm and "decays-with-familiarity" rather than a paperclip wobbling in every
-       view. Derived from specky.svg — keep the two artworks in sync. -->
+       upright, centred, eyes open, brows level, friendly smile) and never moves.
+       The animated specky.svg is used for the live session-pill avatar (dec-1);
+       this static frame keeps the entry affordance calm and "decays-with-
+       familiarity" rather than a paperclip wobbling in every view. Derived from
+       specky.svg — keep the two artworks in sync. -->
   <defs>
     <linearGradient id="wire" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0" stop-color="#c3ced9"/>
@@ -19,28 +19,34 @@
     </linearGradient>
   </defs>
 
-  <g class="clip-root">
+  <g class="float">
+    <g class="clip-root">
 
-    <path d="M 78 300 L 78 122 A 42 42 0 0 1 162 122 L 162 252 A 28 28 0 0 1 106 252 L 106 152"
-          fill="none" stroke="url(#wire)" stroke-width="16" stroke-linecap="round"/>
+      <path d="M 78 300 L 78 122 A 42 42 0 0 1 162 122 L 162 252 A 28 28 0 0 1 106 252 L 106 152"
+            fill="none" stroke="url(#wire)" stroke-width="16" stroke-linecap="round"/>
 
-    <path d="M 74.5 300 L 74.5 122 A 45.5 45.5 0 0 1 120 76.5"
-          fill="none" stroke="url(#wireHi)" stroke-width="3.5" stroke-linecap="round"/>
+      <path d="M 74.5 300 L 74.5 122 A 45.5 45.5 0 0 1 120 76.5"
+            fill="none" stroke="url(#wireHi)" stroke-width="3.5" stroke-linecap="round"/>
 
-    <g class="brows" fill="none" stroke="#6e7a88" stroke-width="7" stroke-linecap="round">
-      <path d="M 84 46 Q 99 35 113 45"/>
-      <path d="M 127 45 Q 141 35 156 46"/>
-    </g>
-
-    <g class="eyes">
-      <ellipse cx="99" cy="86" rx="18" ry="23" fill="#ffffff" stroke="#3d4654" stroke-width="3.5"/>
-      <ellipse cx="141" cy="86" rx="18" ry="23" fill="#ffffff" stroke="#3d4654" stroke-width="3.5"/>
-      <g class="pupils" fill="#1d242e">
-        <circle cx="99" cy="89" r="7.5"/>
-        <circle cx="141" cy="89" r="7.5"/>
-        <circle cx="96.5" cy="86" r="2.2" fill="#ffffff"/>
-        <circle cx="138.5" cy="86" r="2.2" fill="#ffffff"/>
+      <g class="brows" fill="none" stroke="#6e7a88" stroke-width="7" stroke-linecap="round">
+        <path d="M 84 46 Q 99 35 113 45"/>
+        <path d="M 127 45 Q 141 35 156 46"/>
       </g>
+
+      <g class="eyes">
+        <ellipse cx="99" cy="86" rx="18" ry="23" fill="#ffffff" stroke="#3d4654" stroke-width="3.5"/>
+        <ellipse cx="141" cy="86" rx="18" ry="23" fill="#ffffff" stroke="#3d4654" stroke-width="3.5"/>
+        <g class="pupils" fill="#1d242e">
+          <circle cx="99" cy="89" r="7.5"/>
+          <circle cx="141" cy="89" r="7.5"/>
+          <circle cx="96.5" cy="86" r="2.2" fill="#ffffff"/>
+          <circle cx="138.5" cy="86" r="2.2" fill="#ffffff"/>
+        </g>
+      </g>
+
+      <!-- friendly smile (the warmer face from the mock) -->
+      <path d="M 107 114 Q 120 126 133 114" fill="none" stroke="#6e7a88"
+            stroke-width="5" stroke-linecap="round"/>
     </g>
   </g>
 </svg>

--- a/packages/ui/src/assets/specky.svg
+++ b/packages/ui/src/assets/specky.svg
@@ -1,28 +1,31 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 330" width="240" height="330">
   <style>
+    /* spec-197 — Specky idle loop. Livelier per the spec-200 mock: a
+       continuous BOB (float) + soft SWAY (tilt), over the glance/blink/brow
+       life. Still an idle loop only (dec-1=a), no session-state variants.
+       NOTE: keep this asset apostrophe-free so Vite inlines it as a URL-
+       encoded data URI (an apostrophe trips Vite nestedQuotesRE -> base64,
+       which the spec-197 wiring test cannot decode). */
+    .float { animation: bob 3.4s ease-in-out infinite; }
     .clip-root {
       transform-box: fill-box;
       transform-origin: 50% 90%;
-      animation: wobble 7s ease-in-out infinite;
+      animation: sway 3.4s ease-in-out infinite;
     }
-    .pupils {
-      animation: look 9s ease-in-out infinite;
-    }
+    .pupils { animation: look 9s ease-in-out infinite; }
     .eyes {
       transform-box: fill-box;
       transform-origin: 50% 50%;
       animation: blink 6.5s linear infinite;
     }
-    .brows {
-      animation: brows 9s ease-in-out infinite;
+    .brows { animation: brows 9s ease-in-out infinite; }
+    @keyframes bob {
+      0%, 100% { transform: translateY(0px); }
+      50%      { transform: translateY(-11px); }
     }
-    @keyframes wobble {
-      0%, 68%  { transform: rotate(0deg); }
-      71%      { transform: rotate(-5deg); }
-      74%      { transform: rotate(4deg); }
-      77%      { transform: rotate(-2.5deg); }
-      80%      { transform: rotate(1.5deg); }
-      83%, 100% { transform: rotate(0deg); }
+    @keyframes sway {
+      0%, 100% { transform: rotate(-2deg); }
+      50%      { transform: rotate(2deg); }
     }
     @keyframes look {
       0%, 16%   { transform: translate(0px, 0px); }
@@ -44,20 +47,11 @@
       84%, 100% { transform: translate(0px, 0px); }
     }
 
-    /* spec-197 dec-5(b) / ac-4 — honour prefers-reduced-motion by freezing
-       Specky to a neutral static frame (animation:none resets each element to
-       its base pose: clip upright, pupils centred, eyes open, brows level).
-       The character is never hidden — the affordance must stay discoverable
-       for motion-sensitive users. This rule lives inside the SVG so the asset
-       self-handles reduced motion even when embedded as a plain <img>, with
-       no consuming-component CSS required (dec-3=a drop-in img). */
+    /* dec-5(b) / ac-4 — prefers-reduced-motion freezes Specky to its base
+       pose. The character is never hidden, so the affordance stays
+       discoverable for motion-sensitive users. */
     @media (prefers-reduced-motion: reduce) {
-      .clip-root,
-      .pupils,
-      .eyes,
-      .brows {
-        animation: none;
-      }
+      .float, .clip-root, .pupils, .eyes, .brows { animation: none; }
     }
   </style>
 
@@ -73,28 +67,34 @@
     </linearGradient>
   </defs>
 
-  <g class="clip-root">
+  <g class="float">
+    <g class="clip-root">
 
-    <path d="M 78 300 L 78 122 A 42 42 0 0 1 162 122 L 162 252 A 28 28 0 0 1 106 252 L 106 152"
-          fill="none" stroke="url(#wire)" stroke-width="16" stroke-linecap="round"/>
+      <path d="M 78 300 L 78 122 A 42 42 0 0 1 162 122 L 162 252 A 28 28 0 0 1 106 252 L 106 152"
+            fill="none" stroke="url(#wire)" stroke-width="16" stroke-linecap="round"/>
 
-    <path d="M 74.5 300 L 74.5 122 A 45.5 45.5 0 0 1 120 76.5"
-          fill="none" stroke="url(#wireHi)" stroke-width="3.5" stroke-linecap="round"/>
+      <path d="M 74.5 300 L 74.5 122 A 45.5 45.5 0 0 1 120 76.5"
+            fill="none" stroke="url(#wireHi)" stroke-width="3.5" stroke-linecap="round"/>
 
-    <g class="brows" fill="none" stroke="#6e7a88" stroke-width="7" stroke-linecap="round">
-      <path d="M 84 46 Q 99 35 113 45"/>
-      <path d="M 127 45 Q 141 35 156 46"/>
-    </g>
-
-    <g class="eyes">
-      <ellipse cx="99" cy="86" rx="18" ry="23" fill="#ffffff" stroke="#3d4654" stroke-width="3.5"/>
-      <ellipse cx="141" cy="86" rx="18" ry="23" fill="#ffffff" stroke="#3d4654" stroke-width="3.5"/>
-      <g class="pupils" fill="#1d242e">
-        <circle cx="99" cy="89" r="7.5"/>
-        <circle cx="141" cy="89" r="7.5"/>
-        <circle cx="96.5" cy="86" r="2.2" fill="#ffffff"/>
-        <circle cx="138.5" cy="86" r="2.2" fill="#ffffff"/>
+      <g class="brows" fill="none" stroke="#6e7a88" stroke-width="7" stroke-linecap="round">
+        <path d="M 84 46 Q 99 35 113 45"/>
+        <path d="M 127 45 Q 141 35 156 46"/>
       </g>
+
+      <g class="eyes">
+        <ellipse cx="99" cy="86" rx="18" ry="23" fill="#ffffff" stroke="#3d4654" stroke-width="3.5"/>
+        <ellipse cx="141" cy="86" rx="18" ry="23" fill="#ffffff" stroke="#3d4654" stroke-width="3.5"/>
+        <g class="pupils" fill="#1d242e">
+          <circle cx="99" cy="89" r="7.5"/>
+          <circle cx="141" cy="89" r="7.5"/>
+          <circle cx="96.5" cy="86" r="2.2" fill="#ffffff"/>
+          <circle cx="138.5" cy="86" r="2.2" fill="#ffffff"/>
+        </g>
+      </g>
+
+      <!-- friendly smile (the warmer face from the mock) -->
+      <path d="M 107 114 Q 120 126 133 114" fill="none" stroke="#6e7a88"
+            stroke-width="5" stroke-linecap="round"/>
     </g>
   </g>
 </svg>

--- a/packages/ui/src/voice/session/VoiceSessionPill.tsx
+++ b/packages/ui/src/voice/session/VoiceSessionPill.tsx
@@ -34,7 +34,7 @@ export function VoiceSessionPill(): React.JSX.Element {
             dec-1=a). It does NOT change per session state; the StateBlip beside
             it conveys listening/thinking/speaking, so Specky stays a single idle
             character (ac-7). Decorative — the state label carries the meaning. */}
-        <Specky size={24} />
+        <Specky size={30} />
         <StateBlip loopState={session.loopState} muted={session.muted} />
         <span className={`text-sm ${ducked ? 'opacity-70' : ''}`} data-voice-state-label>
           {label}


### PR DESCRIPTION
## What

Follow-up polish on **spec-197** (Specky, already shipped via #68). Reworks the shipped Specky asset so its idle motion matches the energy of the **spec-200 What's New** mock Ryan liked:

- **Continuous bob (float) + soft sway (tilt)** on a 3.4s loop, replacing the rare 7s wobble — Specky now reads as gently *alive* rather than mostly still.
- A **friendly smile** added to the face (warmer, per the mock).
- Glance / blink / brows life and the `prefers-reduced-motion` freeze (dec-5) preserved.
- Still strictly an **idle loop** (dec-1=a) — no session-state variants.
- Pill avatar bumped **24 → 30px** for a touch more presence.

## Where it shows

The animated `specky.svg` drives the **live session-pill avatar** — that's where the upgrade is visible. The **in-view doorway stays static per dec-2** (it gains the smile but does not move until a session starts). No decision is reversed here. _(A separate "make the resting doorway bigger/animated" change — i.e. revisiting dec-2 — was deliberately **not** included.)_

## Test contract kept intact

The spec-197 wiring test decodes the inlined data-URI, so the asset must stay:
- **apostrophe-free** — an apostrophe trips Vite's `nestedQuotesRE` → base64, which the test can't decode (regression fixed + commented in-asset);
- **under the 4096-byte inline limit** — final 4028 B (68 B margin);
- viewBox `0 0 240 330`, clip-body signature path, transparent.

Canonical (`assets/specky/`) and UI (`packages/ui/src/assets/`) copies stay byte-identical (guarded by a tagged test).

## Verification

- ✅ All 20 spec-197 tests (asset + Specky renderer + voice wiring)
- ✅ `tsc -b` clean
- ✅ `make e2e-cold` — **48/48** journeys green, incl. journey-21 voice-guide (start → pill → mute → end)

🤖 Generated with [Claude Code](https://claude.com/claude-code)