### PR TITLE
spec-190: Specky voice fixes — Stop button, drain-gated speaking, volume restore, icon, drop mute, rename

### DIFF
--- a/assets/specky/specky.svg
+++ b/assets/specky/specky.svg
@@ -49,8 +49,8 @@
        its base pose: clip upright, pupils centred, eyes open, brows level).
        The character is never hidden — the affordance must stay discoverable
        for motion-sensitive users. This rule lives inside the SVG so the asset
-       self-handles reduced motion even when embedded as a plain <img>, with
-       no consuming-component CSS required (dec-3=a drop-in img). */
+       self-handles reduced motion even when embedded as a plain img element,
+       with no consuming-component CSS required (dec-3=a drop-in img). */
     @media (prefers-reduced-motion: reduce) {
       .clip-root,
       .pupils,

--- a/packages/server/src/agent/voice/guide-system.md
+++ b/packages/server/src/agent/voice/guide-system.md
@@ -1,4 +1,6 @@
-You are the **Memex voice guide** — a friendly, concise spoken assistant that helps people learn and navigate the Memex product by voice.
+You are **Specky** — a friendly, concise spoken assistant that helps people learn and navigate the Memex product by voice. Always refer to yourself as Specky, never as "the Memex voice guide".
+
+**Pronunciation:** say "Memex" as **MEM-eks** ("M-EM-MEX") — never "my-mix" / "mimix".
 
 ## Who you are
 

--- a/packages/server/src/routes/voice.test.ts
+++ b/packages/server/src/routes/voice.test.ts
@@ -290,6 +290,10 @@ describe("ac-32 — one authenticated socket carries the whole loop", () => {
       await flush();
       const audio = sent.filter((m) => m.type === "audio");
       expect(audio.length).toBeLessThan(8); // cut short by the abort
+      // An abort is INTENTIONAL — it must NOT emit an error frame. The client
+      // escalates {type:'error'} to status:'error', which unmounts the pill and
+      // ends the session, so a barge-in/Stop would beep-and-close every time.
+      expect(sent.filter((m) => m.type === "error")).toHaveLength(0);
       tagAc(AC32);
     });
   });

--- a/packages/server/src/routes/voice.ts
+++ b/packages/server/src/routes/voice.ts
@@ -316,7 +316,14 @@ export class VoiceSession {
         });
       }
     } catch {
-      this.send({ type: "error", requestId, message: "tts_failed" });
+      // A barge-in / Stop aborts the synthesize() generator mid-stream, which
+      // surfaces here as a throw — that is INTENTIONAL, not a failure. Sending an
+      // error frame would make the client escalate to status:'error', which
+      // unmounts the pill (the beep-then-close bug) and kills the session on every
+      // interruption. Only surface a REAL synthesis failure (not an abort).
+      if (!ac.signal.aborted) {
+        this.send({ type: "error", requestId, message: "tts_failed" });
+      }
     } finally {
       this.ttsAborts.delete(requestId);
     }

--- a/packages/ui/e2e/journey-21-voice-guide.spec.ts
+++ b/packages/ui/e2e/journey-21-voice-guide.spec.ts
@@ -48,7 +48,7 @@ test("voice affordance is in-view on a registered screen, not in the global nav 
   await expect(page.getByTestId("primary-nav").locator("[data-voice-affordance]")).toHaveCount(0);
 });
 
-test("start → pill → mute → end, and an active session never blocks the app (ac-1 / ac-5)", async ({
+test("start → pill → end, and an active session never blocks the app (ac-1 / ac-5)", async ({
   page,
 }) => {
   await page.goto(bareUrl("/"));
@@ -62,14 +62,6 @@ test("start → pill → mute → end, and an active session never blocks the ap
   const pill = page.locator("[data-voice-pill]");
   await expect(pill).toBeVisible({ timeout: 15_000 });
   await expect(page.locator("[data-voice-affordance]")).toHaveCount(0);
-
-  // Mute is available and toggles (ac-5).
-  const mute = page.locator("[data-voice-mute]");
-  await expect(mute).toHaveAttribute("aria-label", "Mute microphone");
-  await mute.click();
-  await expect(mute).toHaveAttribute("aria-label", "Unmute microphone");
-  await mute.click();
-  await expect(mute).toHaveAttribute("aria-label", "Mute microphone");
 
   // ac-5: the session never blocks normal use — the app still navigates with a
   // session active, and the pill persists across the route change (it's mounted at

--- a/packages/ui/src/assets/specky.svg
+++ b/packages/ui/src/assets/specky.svg
@@ -49,8 +49,8 @@
        its base pose: clip upright, pupils centred, eyes open, brows level).
        The character is never hidden — the affordance must stay discoverable
        for motion-sensitive users. This rule lives inside the SVG so the asset
-       self-handles reduced motion even when embedded as a plain <img>, with
-       no consuming-component CSS required (dec-3=a drop-in img). */
+       self-handles reduced motion even when embedded as a plain img element,
+       with no consuming-component CSS required (dec-3=a drop-in img). */
     @media (prefers-reduced-motion: reduce) {
       .clip-root,
       .pupils,

--- a/packages/ui/src/voice/orchestrator/micPcmCapture.ts
+++ b/packages/ui/src/voice/orchestrator/micPcmCapture.ts
@@ -10,8 +10,6 @@
 
 export interface PcmCapture {
   start(stream: MediaStream, onFrame: (pcm: ArrayBuffer) => void): Promise<void> | void;
-  /** Stop forwarding frames without tearing down (mute). */
-  setMuted(muted: boolean): void;
   stop(): void;
 }
 
@@ -21,7 +19,6 @@ export class WebAudioPcmCapture implements PcmCapture {
   private ctx: AudioContext | null = null;
   private source: MediaStreamAudioSourceNode | null = null;
   private processor: ScriptProcessorNode | null = null;
-  private muted = false;
 
   start(stream: MediaStream, onFrame: (pcm: ArrayBuffer) => void): void {
     const ctx = new AudioContext();
@@ -31,7 +28,6 @@ export class WebAudioPcmCapture implements PcmCapture {
     const ratio = ctx.sampleRate / TARGET_RATE;
 
     processor.onaudioprocess = (e) => {
-      if (this.muted) return;
       const input = e.inputBuffer.getChannelData(0);
       const outLen = Math.floor(input.length / ratio);
       const pcm = new Int16Array(outLen);
@@ -52,10 +48,6 @@ export class WebAudioPcmCapture implements PcmCapture {
 
     this.source = source;
     this.processor = processor;
-  }
-
-  setMuted(muted: boolean): void {
-    this.muted = muted;
   }
 
   stop(): void {

--- a/packages/ui/src/voice/orchestrator/voiceGuideOrchestrator.test.ts
+++ b/packages/ui/src/voice/orchestrator/voiceGuideOrchestrator.test.ts
@@ -43,18 +43,31 @@ function fakeVad() {
 }
 
 function fakePlayback() {
+  let drainCb: (() => void) | null = null;
   return {
+    startTurn: vi.fn(),
     enqueue: vi.fn(),
     duck: vi.fn(),
     restore: vi.fn(),
-    flush: vi.fn(),
+    flush: vi.fn(() => {
+      drainCb = null;
+    }),
     playedMs: () => 0,
+    onDrain: vi.fn((cb: () => void) => {
+      drainCb = cb;
+    }),
     dispose: vi.fn(),
+    /** Test helper: simulate the scheduled audio finishing playback. */
+    drain: () => {
+      const cb = drainCb;
+      drainCb = null;
+      cb?.();
+    },
   };
 }
 
 function fakeCapture() {
-  return { start: vi.fn(), setMuted: vi.fn(), stop: vi.fn() };
+  return { start: vi.fn(), stop: vi.fn() };
 }
 
 // A fake graph whose invoke drives the callbacks the test wants (text + tools).
@@ -143,12 +156,13 @@ describe('voice orchestrator wiring (ac-11)', () => {
     tagAc(AC11);
     const sock = fakeSocket();
     const graph = fakeGraph((cb) => cb.onTextDelta?.('This is the Specs board.' as never));
+    const playback = fakePlayback();
     const h = hooks();
     const orch = createVoiceOrchestratorFactory(react, {
       socketFactory: sock.factory,
       vadEngine: fakeVad().engine,
       capture: fakeCapture(),
-      playback: fakePlayback(),
+      playback,
       graph,
       newId: () => 'req-1',
     })(h);
@@ -163,6 +177,40 @@ describe('voice orchestrator wiring (ac-11)', () => {
     const sentSpeak = sock.sent.map((s) => (typeof s === 'string' ? JSON.parse(s) : null)).find((m) => m?.type === 'speak');
     expect(sentSpeak).toMatchObject({ type: 'speak', requestId: 'req-1', text: 'This is the Specs board.' });
     expect(h.states).toContain('speaking');
+    // Each spoken turn re-bases playback so a prior barge-in duck-then-cut can't
+    // leave the gain attenuated (volume must return to full on the next reply).
+    expect(playback.startTurn).toHaveBeenCalled();
+  });
+
+  it('holds "speaking" until playback drains — not on the final chunk (Stop stays available)', async () => {
+    tagAc(AC11);
+    const sock = fakeSocket();
+    const graph = fakeGraph((cb) => cb.onTextDelta?.('Here is the answer.' as never));
+    const playback = fakePlayback();
+    const h = hooks();
+    const orch = createVoiceOrchestratorFactory(react, {
+      socketFactory: sock.factory,
+      vadEngine: fakeVad().engine,
+      capture: fakeCapture(),
+      playback,
+      graph,
+      newId: () => 'req-1',
+    })(h);
+    await orch.start(fakeStream);
+    sock.sock.onmessage?.({ data: JSON.stringify({ type: 'transcript', text: 'q?', isFinal: true }) });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(h.states[h.states.length - 1]).toBe('speaking');
+
+    // Final TTS chunk arrives, but the audio is still playing out of the queue —
+    // we must NOT drop to listening yet (else the Stop affordance vanishes mid-speech).
+    sock.sock.onmessage?.({ data: JSON.stringify({ type: 'audio', requestId: 'req-1', audio: '', isFinal: true }) });
+    expect(playback.onDrain).toHaveBeenCalled();
+    expect(h.states[h.states.length - 1]).toBe('speaking');
+
+    // Playback finishes → now we return to listening.
+    playback.drain();
+    expect(h.states[h.states.length - 1]).toBe('listening');
   });
 
   it('dispatches a navigate UI tool through the app router', async () => {

--- a/packages/ui/src/voice/orchestrator/voiceGuideOrchestrator.ts
+++ b/packages/ui/src/voice/orchestrator/voiceGuideOrchestrator.ts
@@ -53,14 +53,20 @@ export interface VoiceOrchestratorReactDeps {
 export interface VoiceOrchestratorGlue {
   socketFactory?: SocketFactory;
   vadEngine?: VadEngine;
-  playback?: PlaybackSink & { enqueue(audio: ArrayBuffer): Promise<void> | void; dispose(): void };
+  playback?: PlaybackImpl;
   capture?: PcmCapture;
   graph?: ReturnType<typeof createGuideGraph>;
   newId?: () => string;
 }
 
 type PlaybackImpl = PlaybackSink & {
+  /** Begin a fresh spoken turn: reset gain to full + re-base the played clock. */
+  startTurn(): void;
   enqueue(audio: ArrayBuffer): Promise<void> | void;
+  /** Fire `cb` once the scheduled audio has finished playing (or immediately if
+   *  nothing is queued) — lets the loop hold 'speaking' until the agent is
+   *  actually inaudible, not merely until the final chunk has arrived. */
+  onDrain(cb: () => void): void;
   dispose(): void;
 };
 
@@ -78,7 +84,6 @@ class VoiceGuideOrchestrator implements VoiceOrchestrator {
   private turnAbort: AbortController | null = null;
   private speakingRequestId: string | null = null;
   private stopped = false;
-  private muted = false;
   private readonly newId: () => string;
 
   constructor(
@@ -103,7 +108,6 @@ class VoiceGuideOrchestrator implements VoiceOrchestrator {
     // mount — leaving stopped=true. Without this reset every turn would finish with
     // stopped=true and refuse to speak even though the reply was ready.
     this.stopped = false;
-    this.muted = false; // fresh session starts unmuted (instance is reused)
     const token = this.react.authToken();
     const base = this.react.tenantBase();
     if (!token || !base) {
@@ -160,10 +164,6 @@ class VoiceGuideOrchestrator implements VoiceOrchestrator {
   }
 
   private onSpeechStart(): void {
-    // Muted = "don't listen to me": the VAD keeps running (capture.setMuted only
-    // stops the STT audio), so we ignore its onset here too — no barge-in, no
-    // earcon, no state change.
-    if (this.muted) return;
     // If the agent is mid-speech, this ducks + arms the cut (dec-8). If idle, it's
     // the user starting their turn — inert for barge-in.
     const wasSpeaking = this.barge?.state === 'speaking' || this.barge?.state === 'ducked';
@@ -172,9 +172,6 @@ class VoiceGuideOrchestrator implements VoiceOrchestrator {
   }
 
   private onSpeechEnd(): void {
-    // Muted: ignore the VAD entirely (it still fires, but capture is silenced) so a
-    // muted user never triggers the ack ping / "thinking" with no audio behind it.
-    if (this.muted) return;
     const wasInterrupting = this.barge?.state === 'ducked';
     this.barge?.onSpeechEnd();
     if (wasInterrupting) return; // transient over agent speech — bargeIn restored it
@@ -230,6 +227,11 @@ class VoiceGuideOrchestrator implements VoiceOrchestrator {
     if (assistantText.trim() && !this.stopped) {
       const requestId = this.newId();
       this.speakingRequestId = requestId;
+      // Reset the playback turn alongside the barge turn: this restores the gain to
+      // full (a prior barge-in duck-then-cut leaves it attenuated) and re-bases the
+      // played-ms clock used for truncation. Without it every reply after the first
+      // interruption plays at the ducked volume.
+      this.playback?.startTurn();
       this.barge?.startTurn();
       this.hooks.setLoopState('speaking');
       this.ws?.speak(requestId, assistantText);
@@ -241,20 +243,24 @@ class VoiceGuideOrchestrator implements VoiceOrchestrator {
   private onAudio(audio: ArrayBuffer, alignment: CharAlignment | undefined, isFinal: boolean): void {
     void this.playback?.enqueue(audio);
     this.barge?.appendChunk(alignment);
-    if (isFinal) {
-      this.barge?.endTurn();
-      this.speakingRequestId = null;
-      this.hooks.setLoopState('listening');
-    }
+    // isFinal marks the last chunk RECEIVED, but the audio is still playing out of
+    // the queue. Stay in 'speaking' — barge armed, the Stop control visible — until
+    // playback actually drains, so the user can interrupt for as long as they can
+    // hear the agent. onDrain fires immediately if nothing is queued.
+    if (isFinal) this.playback?.onDrain(() => this.onPlaybackDrained());
+  }
+
+  /** The agent's speech has fully played out (no interruption). Now — not on the
+   *  final-chunk receipt — return to listening and disarm the barge. */
+  private onPlaybackDrained(): void {
+    if (this.stopped) return;
+    this.barge?.endTurn();
+    this.speakingRequestId = null;
+    this.hooks.setLoopState('listening');
   }
 
   interrupt(): void {
     this.barge?.tapInterrupt();
-  }
-
-  setMuted(muted: boolean): void {
-    this.muted = muted;
-    this.capture?.setMuted(muted);
   }
 
   stop(): void {

--- a/packages/ui/src/voice/playbackQueue.ts
+++ b/packages/ui/src/voice/playbackQueue.ts
@@ -24,6 +24,10 @@ export class WebAudioPlayback implements PlaybackSink {
   // ctx.currentTime when the current turn's playback began (for playedMs).
   private turnStartedAt = 0;
   private turnPlaying = false;
+  // One-shot callback fired when the scheduled queue has finished playing out.
+  // The orchestrator arms this on the FINAL chunk so 'speaking' is held until the
+  // user stops hearing the agent — not merely until the last chunk arrives.
+  private drainCb: (() => void) | null = null;
 
   constructor(ctx?: AudioContext) {
     this.ctx = ctx ?? new AudioContext();
@@ -33,6 +37,7 @@ export class WebAudioPlayback implements PlaybackSink {
 
   /** Start a fresh assistant turn — reset the schedule + the played clock. */
   startTurn(): void {
+    this.drainCb = null; // a new turn supersedes any pending drain of the old one
     this.nextStartAt = this.ctx.currentTime;
     this.turnStartedAt = this.ctx.currentTime;
     this.turnPlaying = true;
@@ -63,7 +68,27 @@ export class WebAudioPlayback implements PlaybackSink {
     src.start(startAt);
     this.nextStartAt = startAt + buffer.duration;
     this.sources.add(src);
-    src.onended = () => this.sources.delete(src);
+    src.onended = () => {
+      this.sources.delete(src);
+      // The last scheduled source has the latest end time, so an empty set here
+      // means the queue has truly drained. drainCb is only armed (after the final
+      // chunk) by onDrain(); before that this is a no-op.
+      if (this.sources.size === 0) this.fireDrain();
+    };
+  }
+
+  /** Arm a one-shot callback for when the currently-scheduled audio finishes
+   *  playing. Fires immediately if nothing is queued. Cleared by flush()/startTurn()
+   *  so a barge-in cut or a superseding turn takes precedence. */
+  onDrain(cb: () => void): void {
+    this.drainCb = cb;
+    if (this.sources.size === 0) this.fireDrain();
+  }
+
+  private fireDrain(): void {
+    const cb = this.drainCb;
+    this.drainCb = null;
+    cb?.();
   }
 
   duck(): void {
@@ -94,6 +119,7 @@ export class WebAudioPlayback implements PlaybackSink {
     this.sources.clear();
     this.nextStartAt = this.ctx.currentTime;
     this.turnPlaying = false;
+    this.drainCb = null; // a hard cut returns to listening via onCut, not drain
   }
 
   /** Milliseconds of audio actually played in the current turn. Clamped so a cut

--- a/packages/ui/src/voice/session/VoiceIcon.tsx
+++ b/packages/ui/src/voice/session/VoiceIcon.tsx
@@ -26,8 +26,8 @@ export function VoiceIcon({ mark }: VoiceIconProps): React.JSX.Element {
     <button
       type="button"
       data-voice-affordance
-      aria-label={disabled ? 'Voice guide (microphone unavailable)' : 'Ask the voice guide'}
-      title={disabled ? 'Microphone unavailable' : 'Ask the voice guide'}
+      aria-label={disabled ? 'Specky (microphone unavailable)' : 'Ask Specky'}
+      title={disabled ? 'Microphone unavailable' : 'Ask Specky'}
       disabled={disabled || requesting}
       onClick={() => void session.start()}
       className="flex h-12 w-12 items-center justify-center rounded-full bg-surface shadow-lg ring-1 ring-border transition hover:scale-105 disabled:opacity-40 disabled:hover:scale-100"

--- a/packages/ui/src/voice/session/VoiceSessionContext.tsx
+++ b/packages/ui/src/voice/session/VoiceSessionContext.tsx
@@ -39,7 +39,6 @@ export interface VoiceSessionValue extends VoiceSessionState {
   start: () => Promise<void>;
   /** Tap-to-interrupt the agent mid-speech (manual barge-in fallback). */
   interrupt: () => void;
-  toggleMute: () => void;
   /** End the session and release the mic. */
   end: () => void;
   /** Retry from the permission-denied recovery UI. */
@@ -113,7 +112,7 @@ export function VoiceSessionProvider({
       onEnded: () =>
         setState((s) =>
           s.status === 'active'
-            ? { ...s, status: 'inactive', loopState: 'idle', muted: false }
+            ? { ...s, status: 'inactive', loopState: 'idle' }
             : s,
         ),
     };
@@ -147,7 +146,7 @@ export function VoiceSessionProvider({
 
     streamRef.current = stream;
     earconPlayer.play('start');
-    setState((s) => ({ ...s, status: 'active', loopState: 'listening', muted: false }));
+    setState((s) => ({ ...s, status: 'active', loopState: 'listening' }));
 
     try {
       await orchestrator.start(stream); // consumes the granted, AEC'd stream
@@ -163,20 +162,11 @@ export function VoiceSessionProvider({
     setState((s) => (s.status === 'active' ? { ...s, loopState: 'listening' } : s));
   }, [orchestrator]);
 
-  const toggleMute = useCallback(() => {
-    setState((s) => {
-      if (s.status !== 'active') return s;
-      const muted = !s.muted;
-      orchestrator.setMuted(muted);
-      return { ...s, muted };
-    });
-  }, [orchestrator]);
-
   const end = useCallback(() => {
     orchestrator.stop();
     releaseStream();
     earconPlayer.play('end');
-    setState((s) => ({ ...s, status: 'inactive', loopState: 'idle', muted: false, error: null }));
+    setState((s) => ({ ...s, status: 'inactive', loopState: 'idle', error: null }));
   }, [orchestrator, releaseStream, earconPlayer]);
 
   // Tear down on unmount — never leave the mic hot.
@@ -189,8 +179,8 @@ export function VoiceSessionProvider({
   }, [orchestrator, releaseStream, earconPlayer]);
 
   const value = useMemo<VoiceSessionValue>(
-    () => ({ ...state, start, interrupt, toggleMute, end, retryPermission: start }),
-    [state, start, interrupt, toggleMute, end],
+    () => ({ ...state, start, interrupt, end, retryPermission: start }),
+    [state, start, interrupt, end],
   );
 
   return <VoiceSessionContext.Provider value={value}>{children}</VoiceSessionContext.Provider>;

--- a/packages/ui/src/voice/session/VoiceSessionPill.tsx
+++ b/packages/ui/src/voice/session/VoiceSessionPill.tsx
@@ -35,7 +35,7 @@ export function VoiceSessionPill(): React.JSX.Element {
             it conveys listening/thinking/speaking, so Specky stays a single idle
             character (ac-7). Decorative — the state label carries the meaning. */}
         <Specky size={24} />
-        <StateBlip loopState={session.loopState} muted={session.muted} />
+        <StateBlip loopState={session.loopState} />
         <span className={`text-sm ${ducked ? 'opacity-70' : ''}`} data-voice-state-label>
           {label}
         </span>
@@ -60,17 +60,6 @@ export function VoiceSessionPill(): React.JSX.Element {
         )}
         <button
           type="button"
-          data-voice-mute
-          aria-pressed={session.muted}
-          aria-label={session.muted ? 'Unmute microphone' : 'Mute microphone'}
-          title={session.muted ? 'Unmute' : 'Mute'}
-          onClick={session.toggleMute}
-          className="rounded-full p-1 text-text-secondary hover:bg-surface-hover"
-        >
-          {session.muted ? '🔇' : '🎙️'}
-        </button>
-        <button
-          type="button"
           data-voice-end
           aria-label="End voice session"
           title="End session"
@@ -88,20 +77,16 @@ export function VoiceSessionPill(): React.JSX.Element {
  *  loop state. The 'acknowledged' state is the blink that fires with the ping. */
 function StateBlip({
   loopState,
-  muted,
 }: {
   loopState: string;
-  muted: boolean;
 }): React.JSX.Element {
-  const pulsing = !muted && (loopState === 'listening' || loopState === 'acknowledged' || loopState === 'speaking');
+  const pulsing = loopState === 'listening' || loopState === 'acknowledged' || loopState === 'speaking';
   const color =
-    muted
-      ? 'bg-text-secondary'
-      : loopState === 'speaking'
-        ? 'bg-accent'
-        : loopState === 'thinking'
-          ? 'bg-amber-400'
-          : 'bg-emerald-400';
+    loopState === 'speaking'
+      ? 'bg-accent'
+      : loopState === 'thinking'
+        ? 'bg-amber-400'
+        : 'bg-emerald-400';
   return (
     <span
       data-voice-blip

--- a/packages/ui/src/voice/session/VoiceSessionPill.tsx
+++ b/packages/ui/src/voice/session/VoiceSessionPill.tsx
@@ -42,6 +42,22 @@ export function VoiceSessionPill(): React.JSX.Element {
       </button>
 
       <div className="ml-1 flex items-center gap-1">
+        {/* Explicit Stop — appears the moment the agent has audio to interrupt
+            (speaking or ducked). Gives the user deliberate, discoverable control
+            without waiting on the VAD-driven barge-in; same hard-cut path as the
+            body tap (session.interrupt → orchestrator.interrupt → tapInterrupt). */}
+        {(session.loopState === 'speaking' || session.loopState === 'ducked') && (
+          <button
+            type="button"
+            data-voice-stop
+            aria-label="Stop the guide"
+            title="Stop"
+            onClick={session.interrupt}
+            className="rounded-full p-1 text-accent hover:bg-surface-hover"
+          >
+            <span aria-hidden className="block h-3 w-3 rounded-[2px] bg-current" />
+          </button>
+        )}
         <button
           type="button"
           data-voice-mute

--- a/packages/ui/src/voice/session/orchestrator.ts
+++ b/packages/ui/src/voice/session/orchestrator.ts
@@ -23,7 +23,6 @@ export interface VoiceOrchestrator {
   start(stream: MediaStream): Promise<void> | void;
   /** Tap-to-interrupt / barge-in cut (dec-8). */
   interrupt(): void;
-  setMuted(muted: boolean): void;
   /** Full teardown — close sockets, stop playback, release nodes. */
   stop(): void;
 }
@@ -39,6 +38,5 @@ export type OrchestratorFactory = (hooks: OrchestratorHooks) => VoiceOrchestrato
 export const stubOrchestratorFactory: OrchestratorFactory = () => ({
   start: () => {},
   interrupt: () => {},
-  setMuted: () => {},
   stop: () => {},
 });

--- a/packages/ui/src/voice/session/specky-wiring.spec-197.test.tsx
+++ b/packages/ui/src/voice/session/specky-wiring.spec-197.test.tsx
@@ -48,7 +48,7 @@ function renderVoice(initialPath = REGISTERED) {
 
 async function startSession(): Promise<void> {
   await act(async () => {
-    fireEvent.click(screen.getByLabelText('Ask the voice guide'));
+    fireEvent.click(screen.getByLabelText('Ask Specky'));
   });
 }
 
@@ -81,7 +81,7 @@ describe('spec-197 wiring — Specky in the spec-190 voice surface', () => {
     tagAc(AC_QUIET_ENTRY);
     tagAc(AC_IDENTITY);
     renderVoice(REGISTERED);
-    const affordance = screen.getByLabelText('Ask the voice guide');
+    const affordance = screen.getByLabelText('Ask Specky');
     const img = affordance.querySelector('img');
     // Specky is the identity (an <img>), replacing the placeholder sound-wave glyph.
     expect(img).not.toBeNull();
@@ -106,13 +106,13 @@ describe('spec-197 wiring — Specky in the spec-190 voice surface', () => {
     expect(avatar).not.toBeNull();
     expect(isAnimated(avatar)).toBe(true);
     // The inactive entry icon is gone (we're in-session now).
-    expect(screen.queryByLabelText('Ask the voice guide')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Ask Specky')).not.toBeInTheDocument();
   });
 
   it('the SAME character serves both the entry doorway and the pill avatar (ac-1)', async () => {
     tagAc(AC_IDENTITY);
     renderVoice(REGISTERED);
-    const entryMarkup = svgOf(screen.getByLabelText('Ask the voice guide').querySelector('img'));
+    const entryMarkup = svgOf(screen.getByLabelText('Ask Specky').querySelector('img'));
     await startSession();
     const pillMarkup = svgOf(document.querySelector('[data-voice-pill] img'));
     // Both carry Specky's signature artwork (the clip body path + the eyes),
@@ -126,7 +126,7 @@ describe('spec-197 wiring — Specky in the spec-190 voice surface', () => {
     tagAc(AC_ABSENT_WHEN_DISABLED);
     const { container } = renderVoice(UNREGISTERED);
     // VoiceLayer renders nothing on an unregistered screen — so no affordance...
-    expect(screen.queryByLabelText('Ask the voice guide')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Ask Specky')).not.toBeInTheDocument();
     // ...and no Specky artwork anywhere. Specky is purely the visual layer over
     // the guide; it never appears on its own.
     expect(container.querySelector('img')).toBeNull();

--- a/packages/ui/src/voice/session/voiceSession.spec-190.test.tsx
+++ b/packages/ui/src/voice/session/voiceSession.spec-190.test.tsx
@@ -41,7 +41,6 @@ function fakeOrchestrator(): {
     return {
       start: () => { calls.push('start'); },
       interrupt: () => { calls.push('interrupt'); },
-      setMuted: (m) => { calls.push(`setMuted:${m}`); },
       stop: () => { calls.push('stop'); },
     };
   };
@@ -88,7 +87,7 @@ function fakeStream(): MediaStream {
 
 async function startSession(): Promise<void> {
   await act(async () => {
-    fireEvent.click(screen.getByLabelText('Ask the voice guide'));
+    fireEvent.click(screen.getByLabelText('Ask Specky'));
   });
 }
 
@@ -100,19 +99,19 @@ describe('voice icon affordance (ac-29 / ac-1 / ac-31)', () => {
     tagAc(AC1); // scope: in-view affordance to start a voice conversation
 
     renderVoice({ initialPath: '/ns/mx/specs' });
-    expect(screen.getByLabelText('Ask the voice guide')).toBeInTheDocument();
+    expect(screen.getByLabelText('Ask Specky')).toBeInTheDocument();
   });
 
   it('does NOT render the icon on a non-registered route', () => {
     tagAc(AC29);
     renderVoice({ initialPath: '/ns/mx/not-a-registered-screen' });
-    expect(screen.queryByLabelText('Ask the voice guide')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Ask Specky')).not.toBeInTheDocument();
   });
 
   it('disables the affordance when no mic is available (ac-31)', () => {
     tagAc(AC31);
     renderVoice({ detectMic: () => false });
-    expect(screen.getByLabelText('Voice guide (microphone unavailable)')).toBeDisabled();
+    expect(screen.getByLabelText('Specky (microphone unavailable)')).toBeDisabled();
   });
 
   it('does NOT request mic permission on load — only on start (ac-31)', async () => {
@@ -126,14 +125,13 @@ describe('voice icon affordance (ac-29 / ac-1 / ac-31)', () => {
 });
 
 describe('session pill (ac-29)', () => {
-  it('opens the pill on start, with mute + end + tap-to-interrupt controls', async () => {
+  it('opens the pill on start, with end + tap-to-interrupt controls', async () => {
     tagAc(AC29);
     renderVoice();
     await startSession();
     expect(screen.getByTestId('nav-/ns/mx/standards')).toBeInTheDocument();
     const pill = document.querySelector('[data-voice-pill]');
     expect(pill).toBeTruthy();
-    expect(document.querySelector('[data-voice-mute]')).toBeTruthy();
     expect(document.querySelector('[data-voice-end]')).toBeTruthy();
     expect(document.querySelector('[data-voice-interrupt]')).toBeTruthy();
   });
@@ -149,7 +147,7 @@ describe('session pill (ac-29)', () => {
     });
     expect(document.querySelector('[data-voice-pill]')).toBeTruthy();
     // And the icon must NOT show while a session is active.
-    expect(screen.queryByLabelText('Ask the voice guide')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Ask Specky')).not.toBeInTheDocument();
   });
 
   it('reflects the live loop state driven by the orchestrator', async () => {
@@ -164,17 +162,15 @@ describe('session pill (ac-29)', () => {
     expect(document.querySelector('[data-voice-pill]')?.getAttribute('data-loop-state')).toBe('speaking');
   });
 
-  it('tap-to-interrupt and mute call the orchestrator; end stops + closes the pill', async () => {
+  it('tap-to-interrupt calls the orchestrator; end stops + closes the pill', async () => {
     tagAc(AC29);
-    tagAc(AC5); // scope: interrupt / mute / end at any time
+    tagAc(AC5); // scope: interrupt / end at any time
 
     const orch = fakeOrchestrator();
     renderVoice({ factory: orch.factory });
     await startSession();
     fireEvent.click(document.querySelector('[data-voice-interrupt]')!);
     expect(orch.calls).toContain('interrupt');
-    fireEvent.click(document.querySelector('[data-voice-mute]')!);
-    expect(orch.calls).toContain('setMuted:true');
     fireEvent.click(document.querySelector('[data-voice-end]')!);
     expect(orch.calls).toContain('stop');
     expect(document.querySelector('[data-voice-pill]')).toBeFalsy();

--- a/packages/ui/src/voice/session/voiceSessionModel.ts
+++ b/packages/ui/src/voice/session/voiceSessionModel.ts
@@ -34,7 +34,6 @@ export type Earcon = 'start' | 'ping' | 'end' | 'error';
 export interface VoiceSessionState {
   status: SessionStatus;
   loopState: VoiceLoopState;
-  muted: boolean;
   /** False when the browser exposes no usable mic — disables the affordance. */
   micAvailable: boolean;
   /** Last error message, surfaced in the error state. */
@@ -45,7 +44,6 @@ export function initialVoiceSessionState(micAvailable: boolean): VoiceSessionSta
   return {
     status: 'inactive',
     loopState: 'idle',
-    muted: false,
     micAvailable,
     error: null,
   };
@@ -63,7 +61,6 @@ export function isAffordanceDisabled(s: VoiceSessionState): boolean {
 
 /** Human label for the current pill state (spoken-UX copy, not a transcript). */
 export function loopStateLabel(s: VoiceSessionState): string {
-  if (s.muted) return 'Muted';
   switch (s.loopState) {
     case 'listening':
       return 'Listening…';


### PR DESCRIPTION
## What & why

Polish + bug fixes for the spec-190 voice guide ("Specky"), building on the explicit Stop button (fbfc71a) and the abort≠error fix (6c674e3) already on this branch.

### Fixes in this PR

1. **Stay in "Speaking" until audio actually drains.** `onAudio` flipped the loop state to `listening` the instant the *final TTS chunk arrived from the server*, but the audio was still playing out of the queue for seconds — so the pill said "Listening…" and the Stop control vanished while Specky was still talking. Added `WebAudioPlayback.onDrain()`; the orchestrator now holds `speaking` (Stop visible, barge-in armed) and only returns to `listening` once the queue drains.

2. **Volume not restoring after an interruption.** `WebAudioPlayback.startTurn()` (which resets gain to 1.0) was never called — a VAD barge-in ducked the gain to 0.15, the cut left it there, and every later reply played at 15%. The orchestrator now calls `playback.startTurn()` at the start of each spoken turn. Side benefit: this also re-bases the played-ms clock, so `playedMs()`/barge truncation actually works (it was silently a no-op because `turnPlaying` stayed false).

3. **Broken Specky avatar.** `specky.svg` had a literal `<img>` inside a CSS comment; SVG `<style>` is parsed as XML, so the unclosed tag invalidated the document and the browser showed a broken-image box. Reworded the comment; canonical (`assets/specky/`) and bundled UI copy stay byte-identical (keeps the spec-197 drift test green).

4. **Removed the mute control** end-to-end (button, `toggleMute`, `muted` state/label, `setMuted` on the orchestrator + capture). Not needed.

5. **Renamed the guide to "Specky"** in the system prompt and the in-view tooltip ("Ask the voice guide" → "Ask Specky"), and added a pronunciation note: say "Memex" as **MEM-eks** ("M-EM-MEX"), never "mimix".

## Tests

- UI: `tsc -b` clean; 62 voice/specky unit tests pass (added a drain-gated-speaking test and a `startTurn`-on-speak assertion; updated mute + label assertions).
- Server: voice route tests pass (18). Pronunciation/name change is in `guide-system.md` (std-15).

## Notes / follow-ups

- **AC drift (std-20):** ac-29 / ac-5 still describe a mute control ("offers mute and end controls", "interrupt / mute / end at any time"). Removing mute contradicts those — the Spec ACs should be updated to match.
- A pre-existing, unrelated `tsc` error in `src/services/discord-webhook.test.ts` (DiscordEmbedFooter `text`) is present on the branch — not touched here.
- An unrelated `SpecList.tsx` Done-column layout tweak was deliberately **left out** of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)