### PR TITLE
feat(ui): the resting voice doorway is now alive + bigger (spec-197, dec-2 revised)

### DIFF
--- a/assets/specky/specky.svg
+++ b/assets/specky/specky.svg
@@ -21,11 +21,11 @@
     .brows { animation: brows 9s ease-in-out infinite; }
     @keyframes bob {
       0%, 100% { transform: translateY(0px); }
-      50%      { transform: translateY(-11px); }
+      50%      { transform: translateY(-24px); }
     }
     @keyframes sway {
-      0%, 100% { transform: rotate(-2deg); }
-      50%      { transform: rotate(2deg); }
+      0%, 100% { transform: rotate(-3deg); }
+      50%      { transform: rotate(3deg); }
     }
     @keyframes look {
       0%, 16%   { transform: translate(0px, 0px); }

--- a/packages/ui/src/assets/specky.svg
+++ b/packages/ui/src/assets/specky.svg
@@ -21,11 +21,11 @@
     .brows { animation: brows 9s ease-in-out infinite; }
     @keyframes bob {
       0%, 100% { transform: translateY(0px); }
-      50%      { transform: translateY(-11px); }
+      50%      { transform: translateY(-24px); }
     }
     @keyframes sway {
-      0%, 100% { transform: rotate(-2deg); }
-      50%      { transform: rotate(2deg); }
+      0%, 100% { transform: rotate(-3deg); }
+      50%      { transform: rotate(3deg); }
     }
     @keyframes look {
       0%, 16%   { transform: translate(0px, 0px); }

--- a/packages/ui/src/voice/session/VoiceIcon.tsx
+++ b/packages/ui/src/voice/session/VoiceIcon.tsx
@@ -30,7 +30,7 @@ export function VoiceIcon({ mark }: VoiceIconProps): React.JSX.Element {
       title={disabled ? 'Microphone unavailable' : 'Ask Specky'}
       disabled={disabled || requesting}
       onClick={() => void session.start()}
-      className="flex h-12 w-12 items-center justify-center rounded-full bg-surface shadow-lg ring-1 ring-border transition hover:scale-105 disabled:opacity-40 disabled:hover:scale-100"
+      className="flex h-16 w-16 items-center justify-center rounded-full bg-surface shadow-lg ring-1 ring-border transition hover:scale-105 disabled:opacity-40 disabled:hover:scale-100"
     >
       {mark ?? <DefaultMark spinning={requesting} />}
     </button>

--- a/packages/ui/src/voice/session/VoiceLayer.tsx
+++ b/packages/ui/src/voice/session/VoiceLayer.tsx
@@ -40,13 +40,16 @@ export function VoiceLayer(): React.JSX.Element | null {
   }
 
   // Inactive / requesting / mic-unavailable → the icon, on registered screens only.
-  // spec-197: the entry doorway carries Specky's identity but stays QUIET — the
-  // static (non-animated) frame, not the wobbling idle loop (dec-2 / ac-8). The
-  // animated Specky only appears in the pill once a session is live (dec-1).
+  // spec-197: the entry doorway IS Specky — present and alive (the animated idle
+  // loop, dec-2 revised 2026-06-08 / ac-8). dec-2 originally kept this a quiet
+  // static frame, but the product owner chose the livelier doorway so the guide
+  // reads as inviting rather than dormant. Reduced-motion still freezes it to the
+  // base pose via the SVG's own media query (dec-5), so it stays calm for
+  // motion-sensitive users without any code here.
   if (resolveScreenKey(pathname) === null) return null;
   return (
     <div className={ANCHOR}>
-      <VoiceIcon mark={<Specky animated={false} size={28} />} />
+      <VoiceIcon mark={<Specky size={40} />} />
     </div>
   );
 }

--- a/packages/ui/src/voice/session/specky-wiring.spec-197.test.tsx
+++ b/packages/ui/src/voice/session/specky-wiring.spec-197.test.tsx
@@ -77,7 +77,7 @@ function isAnimated(img: Element | null | undefined): boolean {
 beforeEach(() => vi.clearAllMocks());
 
 describe('spec-197 wiring — Specky in the spec-190 voice surface', () => {
-  it('the in-view entry doorway shows the QUIET (static) Specky, not the neutral glyph (ac-8 / ac-1 entry)', () => {
+  it('the in-view entry doorway shows the ANIMATED (alive) Specky, not the neutral glyph (ac-8 / ac-1 entry)', () => {
     tagAc(AC_QUIET_ENTRY);
     tagAc(AC_IDENTITY);
     renderVoice(REGISTERED);
@@ -86,9 +86,11 @@ describe('spec-197 wiring — Specky in the spec-190 voice surface', () => {
     // Specky is the identity (an <img>), replacing the placeholder sound-wave glyph.
     expect(img).not.toBeNull();
     expect(affordance.querySelector('svg')).toBeNull(); // the neutral DefaultMark <svg> is gone
-    // ...and it is the STATIC variant — a quiet doorway, not the wobbling idle loop.
-    expect(isStatic(img)).toBe(true);
-    expect(isAnimated(img)).toBe(false);
+    // ...and it is the ANIMATED idle-loop variant — an alive, inviting doorway
+    // (dec-2 revised 2026-06-08; the static frame is now used only for the
+    // reduced-motion freeze inside the SVG, not as a separate quiet doorway).
+    expect(isAnimated(img)).toBe(true);
+    expect(isStatic(img)).toBe(false);
   });
 
   it('one click opens the session AND surfaces the ANIMATED Specky avatar in the pill (ac-2 / ac-9 / ac-1 pill)', async () => {


### PR DESCRIPTION
## What

Follow-up to the merged #77 (Specky liveliness). #77 made the **session-pill avatar** livelier; this makes the **in-view entry doorway** — the icon at rest, before any session — match it.

- The doorway now renders the **animated** idle Specky (was a quiet static frame) and is **bigger**: ring 48→64px, Specky 28→40px.
- Bumps the idle **bob** amplitude (−11→−24 viewBox units) + sway (2→3°) so the float actually reads at doorway/pill render sizes (~30–40px); at the old amplitude it scaled down to ~1.5px and looked static.

## Decision change

This **reverses dec-2** (was: "quiet static doorway → animated only in the pill on click"; now: the animated Specky in-view at rest). Product owner call (2026-06-08) — the static doorway read as dormant on INT. Memex updated: dec-2 resolution amended, ac-8 reworded, reversal logged as comment c-8 on spec-197.

Accessibility unchanged: `prefers-reduced-motion` still freezes Specky to its base pose via the SVG's own media query (dec-5).

## Coordination note

Cherry-picked cleanly onto the current develop, which already carries Barrie's spec-190 voice polish (Stop button, barge-in, "Ask Specky" rename, dropped mute). **Nothing of that is touched** — this only flips the doorway in `VoiceLayer`, enlarges the `VoiceIcon` ring, and bumps the asset; the "Ask Specky" rename is preserved.

## Verification

- ✅ 20/20 spec-197 tests (asset + Specky + wiring, flipped to assert the animated doorway) + spec-190 voice test
- ✅ `tsc -b` clean
- ✅ `make e2e-cold` — voice journeys (journey-21) pass clean; 3 unrelated SSE/lifecycle journeys were flaky (failed once, passed on retry — known flake, not a regression)
- Asset stays apostrophe-free + under the 4096-byte inline limit (4028 B)

🤖 Generated with [Claude Code](https://claude.com/claude-code)