### PR TITLE
spec-200: AI worthiness gate for What's New (dec-7) — only noteworthy Specs get announced

### DIFF
--- a/packages/server/drizzle/0081_add_whats_new_skips.sql
+++ b/packages/server/drizzle/0081_add_whats_new_skips.sql
@@ -1,0 +1,25 @@
+-- spec-200 dec-7: persist the AI worthiness verdict for Specs NOT announced.
+--
+-- The generation step judges each shipped Spec's noteworthiness (worthAnnouncing).
+-- Worthy → a row in whats_new_entries. NOT worthy → a row HERE, recording that the
+-- Spec was evaluated and deliberately skipped (with the model's reason). This makes
+-- the judgement happen exactly ONCE per Spec: the candidate set excludes Specs
+-- present in EITHER table, so a skipped Spec is never re-judged on later deploys
+-- (no wasted LLM calls, and no risk of a "skip" later flipping to "announce" and
+-- appearing weeks after it shipped).
+--
+-- Global, like whats_new_entries — no memex/user scoping. Revert:
+-- drizzle/reverts/0081_add_whats_new_skips.revert.sql drops the table.
+
+CREATE TABLE "whats_new_skips" (
+  "id"                uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  "source_spec_ref"   text NOT NULL,
+  "source_spec_handle" text NOT NULL,
+  -- The model's reason for skipping (debug / audit only).
+  "reason"            text,
+  "created_at"        timestamptz NOT NULL DEFAULT now()
+);
+
+-- One verdict per source Spec — the judged-once key.
+CREATE UNIQUE INDEX "whats_new_skips_source_spec_ref_idx"
+  ON "whats_new_skips" ("source_spec_ref");

--- a/packages/server/drizzle/reverts/0081_add_whats_new_skips.revert.sql
+++ b/packages/server/drizzle/reverts/0081_add_whats_new_skips.revert.sql
@@ -1,0 +1,2 @@
+-- Revert spec-200 dec-7 (0081_add_whats_new_skips.sql).
+DROP TABLE IF EXISTS "whats_new_skips";

--- a/packages/server/scripts/generate-whats-new.ts
+++ b/packages/server/scripts/generate-whats-new.ts
@@ -43,8 +43,9 @@ async function main(): Promise<void> {
   console.log(`[whats-new] generating entries for ${NAMESPACE_SLUG}/${MEMEX_SLUG}…`);
   const result = await runWhatsNewGeneration(row.memexId);
   console.log(
-    `[whats-new] done — generated ${result.generated}, skipped ${result.skipped} of ${result.total} shippable spec(s)` +
-      (result.capped ? " (CAPPED this run — remaining specs publish on the next deploy)." : "."),
+    `[whats-new] done — judged ${result.evaluated} of ${result.total} shippable spec(s): ` +
+      `${result.generated} published, ${result.skipped} skipped (not noteworthy)` +
+      (result.capped ? " (CAPPED this run — remaining specs judged on the next deploy)." : "."),
   );
   process.exit(0);
 }

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -2507,3 +2507,21 @@ export const whatsNewEntries = pgTable(
 
 export type WhatsNewEntry = InferSelectModel<typeof whatsNewEntries>;
 export type WhatsNewEntryInsert = InferInsertModel<typeof whatsNewEntries>;
+
+// spec-200 dec-7: persisted "judged not worth announcing" verdicts, so each Spec
+// is evaluated exactly once (the candidate set excludes Specs in entries OR skips).
+export const whatsNewSkips = pgTable(
+  "whats_new_skips",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    sourceSpecRef: text("source_spec_ref").notNull(),
+    sourceSpecHandle: text("source_spec_handle").notNull(),
+    // The model's reason for skipping (debug / audit only).
+    reason: text("reason"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [uniqueIndex("whats_new_skips_source_spec_ref_idx").on(table.sourceSpecRef)]
+);
+
+export type WhatsNewSkip = InferSelectModel<typeof whatsNewSkips>;
+export type WhatsNewSkipInsert = InferInsertModel<typeof whatsNewSkips>;

--- a/packages/server/src/services/whats-new-generation.spec-200.test.ts
+++ b/packages/server/src/services/whats-new-generation.spec-200.test.ts
@@ -1,16 +1,18 @@
-// spec-200 t-2 — auto-generation of a What's New entry from a Spec.
+// spec-200 t-2 / dec-7 — auto-generation + AI worthiness gate.
 //
-// Unit/integration test against the live local Postgres with a STUBBED Anthropic
-// client (key-free). Seeds a Spec (overview + resolved decision + scope AC), then
-// proves:
-//   ac-6 — draft-from-spec is written straight to the feed (no approval path).
-//   ac-7 — a draft/specify (private/authoring) Spec produces NO entry.
+// Integration test against the live local Postgres with a STUBBED Anthropic client
+// (key-free). Proves:
+//   ac-6 — a worthy Spec is drafted from its content and published, no approval.
+//   ac-7 — a draft/specify (private/authoring) Spec produces no entry.
+//   ac-16 — a NOT-worthy Spec publishes nothing, its skip verdict is persisted,
+//           and it is never re-judged (no second LLM call).
+//   ac-8 — the batch judges each shippable spec once, bounded per run.
 
 import { describe, it, expect, afterAll } from "vitest";
-import { eq, inArray, like } from "drizzle-orm";
+import { eq, inArray } from "drizzle-orm";
 import { tagAc } from "@memex-ai-ac/vitest";
 import { db } from "../db/connection.js";
-import { users, documents, docSections, decisions, acs, whatsNewEntries } from "../db/schema.js";
+import { users, documents, docSections, decisions, acs, whatsNewEntries, whatsNewSkips } from "../db/schema.js";
 import { createOrgWithMemexAndOwner } from "./__test__/seed-org.js";
 import {
   draftEntryForSpec,
@@ -29,17 +31,15 @@ const createdSpecRefs: string[] = [];
 
 afterAll(async () => {
   if (createdSpecRefs.length) {
-    await db
-      .delete(whatsNewEntries)
-      .where(inArray(whatsNewEntries.sourceSpecRef, createdSpecRefs))
-      .catch(() => {});
+    await db.delete(whatsNewEntries).where(inArray(whatsNewEntries.sourceSpecRef, createdSpecRefs)).catch(() => {});
+    await db.delete(whatsNewSkips).where(inArray(whatsNewSkips.sourceSpecRef, createdSpecRefs)).catch(() => {});
   }
   for (const id of createdUserIds) {
     await db.delete(users).where(eq(users.id, id)).catch(() => {});
   }
 });
 
-/** A stub client that returns a fixed structured draft and counts calls. */
+/** A stub client that returns a fixed structured verdict+draft and counts calls. */
 function stubClient(draft: WhatsNewDraft): AnthropicLike & { calls: number } {
   let calls = 0;
   const client = {
@@ -54,11 +54,17 @@ function stubClient(draft: WhatsNewDraft): AnthropicLike & { calls: number } {
   return client as unknown as AnthropicLike & { calls: number };
 }
 
+/** A worthy verdict the stub returns by default. */
+const WORTHY: WhatsNewDraft = {
+  worthAnnouncing: true,
+  reason: "a new user-facing feature",
+  title: "Resize your sidebar",
+  what: "You can now drag the left navigation wider or narrower.",
+  why: "Set the layout that suits you — it sticks across visits.",
+};
+
 /** Seed a Spec with an overview, one resolved decision, and one scope AC. */
-async function seedSpec(opts: { status: string; handle: string }): Promise<{
-  memexId: string;
-  sourceSpecRef: string;
-}> {
+async function seedSpec(opts: { status: string; handle: string }): Promise<{ memexId: string; sourceSpecRef: string }> {
   const [u] = await db
     .insert(users)
     .values({ email: `wn-gen-${crypto.randomUUID()}@example.com`, emailVerifiedAt: new Date() })
@@ -105,45 +111,36 @@ async function seedSpec(opts: { status: string; handle: string }): Promise<{
 }
 
 describe("whats-new generation (spec-200 t-2)", () => {
-  it("drafts What/Why from a shipped Spec and writes straight to the feed — no approval (ac-6)", async () => {
+  it("drafts a worthy Spec and publishes straight to the feed — no approval (ac-6)", async () => {
     const { memexId, sourceSpecRef } = await seedSpec({ status: "build", handle: "spec-wn-a" });
-    const client = stubClient({
-      title: "Resize your sidebar",
-      what: "You can now drag the left navigation wider or narrower.",
-      why: "Set the layout that suits you — it sticks across visits.",
-    });
+    const client = stubClient(WORTHY);
 
-    const published = await generateAndPublishForSpec(memexId, "spec-wn-a", { client });
+    const outcome = await generateAndPublishForSpec(memexId, "spec-wn-a", { client });
 
-    expect(published).not.toBeNull();
+    expect(outcome.status).toBe("published");
     expect(client.calls).toBe(1);
-    // It went straight to the published feed — no pending/approval indirection.
     const stored = await getEntryBySpecRef(sourceSpecRef);
     expect(stored).not.toBeNull();
     expect(stored!.title).toBe("Resize your sidebar");
     expect(stored!.whatText).toContain("drag the left navigation");
-    expect(stored!.whyText).toContain("sticks across visits");
     expect(stored!.sourceSpecHandle).toBe("spec-wn-a");
 
     tagAc(AC(6));
-    // Scope ACs proven by this same flow: ac-1 (each entry states What+Why,
-    // derived from the Spec) and ac-4 (auto-drafted, no hand-authored changelog,
-    // published with no approval gate).
+    // Scope ACs proven by this same flow: ac-1 (What+Why derived from the Spec)
+    // and ac-4 (auto-drafted, no changelog, published with no approval gate).
     tagAc(AC(1));
     tagAc(AC(4));
   });
 
-  it("does NOT generate an entry for a draft/specify Spec (ac-7)", async () => {
+  it("does NOT generate for a draft/specify Spec (ac-7)", async () => {
     const { memexId, sourceSpecRef } = await seedSpec({ status: "draft", handle: "spec-wn-b" });
-    const client = stubClient({ title: "x", what: "x", why: "x" });
+    const client = stubClient(WORTHY);
 
-    // The resilient publish path returns null and writes nothing.
-    const published = await generateAndPublishForSpec(memexId, "spec-wn-b", { client });
-    expect(published).toBeNull();
-    expect(client.calls).toBe(0); // never even called the model
+    const outcome = await generateAndPublishForSpec(memexId, "spec-wn-b", { client });
+    expect(outcome.status).toBe("not-shippable");
+    expect(client.calls).toBe(0); // never called the model
     expect(await getEntryBySpecRef(sourceSpecRef)).toBeNull();
 
-    // The lower-level draft fn throws for a non-shippable Spec.
     await expect(draftEntryForSpec(memexId, "spec-wn-b", { client })).rejects.toThrow(/not shippable/i);
 
     tagAc(AC(7));
@@ -151,16 +148,36 @@ describe("whats-new generation (spec-200 t-2)", () => {
 
   it("specify-phase Spec is also withheld (ac-7)", async () => {
     const { memexId, sourceSpecRef } = await seedSpec({ status: "specify", handle: "spec-wn-c" });
-    const client = stubClient({ title: "x", what: "x", why: "x" });
-    expect(await generateAndPublishForSpec(memexId, "spec-wn-c", { client })).toBeNull();
+    const client = stubClient(WORTHY);
+    expect((await generateAndPublishForSpec(memexId, "spec-wn-c", { client })).status).toBe("not-shippable");
     expect(await getEntryBySpecRef(sourceSpecRef)).toBeNull();
     tagAc(AC(7));
+  });
+
+  it("a NOT-worthy Spec publishes nothing, persists the skip, and is never re-judged (ac-16 / dec-7)", async () => {
+    const { memexId, sourceSpecRef } = await seedSpec({ status: "verify", handle: "spec-wn-d" });
+    const client = stubClient({ worthAnnouncing: false, reason: "internal bug fix, no user-facing benefit" });
+
+    const first = await generateAndPublishForSpec(memexId, "spec-wn-d", { client });
+    expect(first.status).toBe("skipped");
+    expect(client.calls).toBe(1);
+    expect(await getEntryBySpecRef(sourceSpecRef)).toBeNull(); // nothing published
+    // Skip verdict persisted.
+    const skipRow = await db.select().from(whatsNewSkips).where(eq(whatsNewSkips.sourceSpecRef, sourceSpecRef));
+    expect(skipRow).toHaveLength(1);
+
+    // Re-judged? No — already evaluated, so NO second LLM call.
+    const second = await generateAndPublishForSpec(memexId, "spec-wn-d", { client });
+    expect(second.status).toBe("already-evaluated");
+    expect(client.calls).toBe(1); // unchanged — not re-judged
+
+    tagAc(AC(16));
   });
 });
 
 describe("runWhatsNewGeneration batch (spec-200 t-3 / ac-8)", () => {
-  // Seed one memex with N shippable specs + one draft spec, all in that memex.
-  async function seedMemexWithSpecs(): Promise<{ memexId: string; refPrefix: string }> {
+  // Seed one memex with 2 shippable specs (build + verify) + one draft spec.
+  async function seedMemexWithSpecs(): Promise<{ memexId: string }> {
     const [u] = await db
       .insert(users)
       .values({ email: `wn-batch-${crypto.randomUUID()}@example.com`, emailVerifiedAt: new Date() })
@@ -173,43 +190,41 @@ describe("runWhatsNewGeneration batch (spec-200 t-3 / ac-8)", () => {
 
     for (const [i, status] of [["a", "build"], ["b", "verify"], ["c", "draft"]].entries()) {
       const handle = `spec-batch-${status[0]}${i}`;
-      await db
-        .insert(documents)
-        .values({ memexId, handle, title: `Spec ${handle}`, docType: "spec", status: status[1] });
+      await db.insert(documents).values({ memexId, handle, title: `Spec ${handle}`, docType: "spec", status: status[1] });
       createdSpecRefs.push(`${slug}/main/specs/${handle}`);
     }
-    return { memexId, refPrefix: `${slug}/main/specs/` };
+    return { memexId };
   }
 
-  it("publishes one entry per shippable spec, excludes drafts, and is idempotent on re-run (ac-8)", async () => {
+  it("judges each shippable spec once, excludes drafts, idempotent on re-run (ac-8)", async () => {
     const { memexId } = await seedMemexWithSpecs();
-    const client = stubClient({ title: "T", what: "W.", why: "Y." });
+    const client = stubClient(WORTHY);
 
     const first = await runWhatsNewGeneration(memexId, { client });
-    // Two shippable specs (build + verify); the draft is filtered out before the loop.
-    expect(first.total).toBe(2);
+    expect(first.total).toBe(2); // build + verify; draft filtered out
+    expect(first.evaluated).toBe(2);
     expect(first.generated).toBe(2);
     expect(first.capped).toBe(false);
 
-    // Idempotent: a second run drafts nothing (all already published).
+    // Idempotent: a second run judges nothing (both already evaluated).
     const second = await runWhatsNewGeneration(memexId, { client });
+    expect(second.evaluated).toBe(0);
     expect(second.generated).toBe(0);
-    expect(second.skipped).toBe(2);
 
     tagAc(AC(8));
   });
 
-  it("caps the number generated per run (bounded — spec-178 t-5 lesson) (ac-8)", async () => {
+  it("caps LLM judgements per run (bounded — spec-178 t-5 lesson) (ac-8)", async () => {
     const { memexId } = await seedMemexWithSpecs();
-    const client = stubClient({ title: "T", what: "W.", why: "Y." });
+    const client = stubClient(WORTHY);
 
     const capped = await runWhatsNewGeneration(memexId, { client, max: 1 });
-    expect(capped.generated).toBe(1);
+    expect(capped.evaluated).toBe(1);
     expect(capped.capped).toBe(true);
 
     // The next run picks up the remainder.
     const rest = await runWhatsNewGeneration(memexId, { client, max: 1 });
-    expect(rest.generated).toBe(1);
+    expect(rest.evaluated).toBe(1);
     expect(rest.capped).toBe(false);
 
     tagAc(AC(8));

--- a/packages/server/src/services/whats-new-generation.ts
+++ b/packages/server/src/services/whats-new-generation.ts
@@ -13,6 +13,10 @@
 // ac-7: only ingest shippable Specs — a draft/specify (private/authoring) Spec
 //       produces no entry. The deploy hook (t-3) supplies the stronger "actually
 //       promoted to prod" gate; this is the service-level backstop.
+// ac-16 (dec-7): the model also judges WORTHINESS — only noteworthy, user-facing
+//       Specs publish; bug-fixes / internal / chores are recorded as skips so the
+//       feed stays a curated highlights list, not a changelog. Each Spec is judged
+//       exactly once (the skip verdict is persisted in whats_new_skips).
 
 import { z } from "zod";
 import { zodOutputFormat } from "@anthropic-ai/sdk/helpers/zod";
@@ -24,7 +28,7 @@ import { documents, memexes, namespaces } from "../db/schema.js";
 import { getDoc } from "./documents.js";
 import { listDecisions } from "./decisions.js";
 import { listAcsForBrief } from "./acs.js";
-import { publishEntry, getEntryBySpecRef, type NewWhatsNewEntry } from "./whats-new.js";
+import { publishEntry, recordSkip, isAlreadyEvaluated, type NewWhatsNewEntry } from "./whats-new.js";
 import type { WhatsNewEntry } from "../db/schema.js";
 
 // Same model as clause-translator + the chat route (std-11 / routes/llm.ts).
@@ -43,16 +47,36 @@ export class SpecNotShippableError extends Error {
   }
 }
 
-// Structured-output contract: a user-facing release-note entry.
+// Structured-output contract: the worthiness verdict (dec-7) + the draft (only
+// when worthy). title/what/why are optional because the model omits them when it
+// judges the Spec not worth announcing.
 export const WhatsNewDraftSchema = z.object({
-  // A short, benefit-led headline (NOT the raw Spec title).
-  title: z.string(),
-  // WHAT shipped, plain language.
-  what: z.string(),
-  // WHY it matters to the user, plain language.
-  why: z.string(),
+  // dec-7: is this a noteworthy, user-facing change worth a What's New entry?
+  worthAnnouncing: z.boolean(),
+  // One-line justification for the verdict (debug / audit).
+  reason: z.string(),
+  // A short, benefit-led headline (NOT the raw Spec title). Present iff worthy.
+  title: z.string().optional(),
+  // WHAT shipped, plain language. Present iff worthy.
+  what: z.string().optional(),
+  // WHY it matters to the user, plain language. Present iff worthy.
+  why: z.string().optional(),
 });
 export type WhatsNewDraft = z.infer<typeof WhatsNewDraftSchema>;
+
+/** The verdict + (when worthy) the entry to publish. */
+export interface DraftVerdict {
+  worthAnnouncing: boolean;
+  reason: string;
+  entry: NewWhatsNewEntry | null;
+}
+
+/** Outcome of evaluating one Spec (drives the batch cap + the script log). */
+export type GenerationOutcome =
+  | { status: "published"; entry: WhatsNewEntry }
+  | { status: "skipped"; reason: string }
+  | { status: "already-evaluated" }
+  | { status: "not-shippable" };
 
 // Minimal Anthropic surface used here, so tests inject a stub.
 export interface AnthropicLike {
@@ -60,6 +84,11 @@ export interface AnthropicLike {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     parse: (args: any) => Promise<{ parsed_output: WhatsNewDraft | null }>;
   };
+}
+
+/** True when the model judged the Spec worth announcing AND gave usable copy. */
+function isPublishableDraft(d: WhatsNewDraft): boolean {
+  return !!d.worthAnnouncing && !!d.title?.trim() && !!d.what?.trim() && !!d.why?.trim();
 }
 
 export interface GenerateOptions {
@@ -117,14 +146,15 @@ function buildSpecDigest(args: {
 }
 
 /**
- * Draft a What's New entry for a Spec (no DB write). Throws SpecNotShippableError
- * for a draft/specify Spec (ac-7), and Error for a non-spec or empty model output.
+ * Judge + draft for a Spec (no DB write). Returns the worthiness verdict (dec-7)
+ * and, when worthy, the entry to publish. Throws SpecNotShippableError for a
+ * draft/specify Spec (ac-7) and Error for a non-spec or malformed model output.
  */
 export async function draftEntryForSpec(
   memexId: string,
   specHandleOrId: string,
   opts: GenerateOptions = {},
-): Promise<NewWhatsNewEntry> {
+): Promise<DraftVerdict> {
   const doc = await getDoc(memexId, specHandleOrId);
   if (doc.docType !== "spec") {
     throw new Error(`Document ${specHandleOrId} is not a spec (docType=${doc.docType}).`);
@@ -163,76 +193,89 @@ export async function draftEntryForSpec(
   });
 
   const draft = message.parsed_output;
-  if (!draft || !draft.what.trim() || !draft.why.trim() || !draft.title.trim()) {
-    throw new Error(`Empty What's New draft for ${doc.handle}.`);
+  if (!draft) throw new Error(`Empty What's New model output for ${doc.handle}.`);
+
+  // dec-7: not worth announcing → no entry (the caller persists the skip verdict).
+  if (!isPublishableDraft(draft)) {
+    return { worthAnnouncing: false, reason: draft.reason || "not noteworthy", entry: null };
   }
 
   return {
-    sourceSpecRef,
-    sourceSpecHandle: doc.handle,
-    title: draft.title.trim(),
-    whatText: draft.what.trim(),
-    whyText: draft.why.trim(),
+    worthAnnouncing: true,
+    reason: draft.reason || "",
+    entry: {
+      sourceSpecRef,
+      sourceSpecHandle: doc.handle,
+      title: draft.title!.trim(),
+      whatText: draft.what!.trim(),
+      whyText: draft.why!.trim(),
+    },
   };
 }
 
 /**
- * Generate + publish an entry for a Spec, idempotently (ac-6). Returns the
- * published row, or null if the Spec isn't a shippable spec (ac-7) or already
- * had an entry — so a deploy-time batch loop is resilient and never throws
- * per-Spec.
- *
- * The cheap guards (not-a-spec / not-shippable / already-published) run BEFORE
- * the LLM call, so a re-run over already-published Specs costs zero model calls
- * — important for bounding the daily deploy batch.
+ * Evaluate a Spec and act on the verdict (dec-7), idempotently. Cheap guards
+ * (not-a-spec / not-shippable / already-evaluated) run BEFORE the LLM call so a
+ * re-run costs zero model calls. Worthy → publish; not worthy → record the skip
+ * so the Spec is never re-judged. Never throws per-Spec — safe for the batch.
  */
 export async function generateAndPublishForSpec(
   memexId: string,
   specHandleOrId: string,
   opts: GenerateOptions = {},
-): Promise<WhatsNewEntry | null> {
+): Promise<GenerationOutcome> {
   const doc = await getDoc(memexId, specHandleOrId);
-  if (doc.docType !== "spec") return null;
-  if (NON_SHIPPABLE_PHASES.has(doc.status)) return null; // ac-7
+  if (doc.docType !== "spec") return { status: "not-shippable" };
+  if (NON_SHIPPABLE_PHASES.has(doc.status)) return { status: "not-shippable" }; // ac-7
 
   const slugs = await resolveSpecSlugs(doc.id);
-  if (!slugs) return null;
+  if (!slugs) return { status: "not-shippable" };
   const sourceSpecRef = `${slugs.namespace}/${slugs.memex}/specs/${slugs.handle}`;
 
-  // Idempotent: already published → no rewrite, and crucially no LLM call.
-  if (await getEntryBySpecRef(sourceSpecRef)) return null;
+  // dec-7: judged exactly once — already published OR skipped → no LLM call.
+  if (await isAlreadyEvaluated(sourceSpecRef)) return { status: "already-evaluated" };
 
-  const draft = await draftEntryForSpec(memexId, specHandleOrId, opts);
-  return publishEntry(draft);
+  const verdict = await draftEntryForSpec(memexId, specHandleOrId, opts);
+  if (!verdict.worthAnnouncing || !verdict.entry) {
+    await recordSkip({ sourceSpecRef, sourceSpecHandle: doc.handle, reason: verdict.reason });
+    return { status: "skipped", reason: verdict.reason };
+  }
+
+  const entry = await publishEntry(verdict.entry);
+  // A concurrent run may have published first; treat that as already-evaluated.
+  return entry ? { status: "published", entry } : { status: "already-evaluated" };
 }
 
 /** Outcome of a batch generation run (returned to the deploy script for logging). */
 export interface WhatsNewGenerationResult {
-  /** Specs newly published this run. */
+  /** Specs newly PUBLISHED this run (judged worthy). */
   generated: number;
-  /** Specs skipped (already published, or filtered out before the loop). */
+  /** Specs judged NOT worth announcing this run (skip verdict persisted). */
   skipped: number;
+  /** Specs that consumed an LLM judgement this run (generated + skipped). */
+  evaluated: number;
   /** Total shippable, non-archived specs considered. */
   total: number;
-  /** True if MAX_PER_RUN was hit and shippable specs remain for the next run. */
+  /** True if the per-run evaluation cap was hit and un-judged specs remain. */
   capped: boolean;
 }
 
-// Bound the LLM fan-out per deploy (spec-178 t-5 lesson: a deploy step that
-// fans out unboundedly hung the deploy). Only UNPUBLISHED shippable specs draft,
-// so steady state is "today's promotions"; the cap protects the first backfill
-// run, which resumes idempotently on the next deploy.
+// Bound the LLM fan-out per deploy (spec-178 t-5 lesson: a deploy step that fans
+// out unboundedly hung the deploy). Caps the number of LLM JUDGEMENTS per run —
+// already-evaluated specs (published OR skipped, dec-7) cost zero calls, so steady
+// state is just "today's promotions"; the cap protects only the first backfill,
+// which resumes idempotently on the next deploy.
 const MAX_PER_RUN_DEFAULT = 25;
 
 export interface BatchOptions extends GenerateOptions {
-  /** Max entries to GENERATE this run. Default 25. */
+  /** Max LLM judgements this run. Default 25. */
   max?: number;
 }
 
 /**
- * Generate + publish entries for all shippable, not-yet-published Specs in a
- * Memex (dec-2: run at the daily prod promotion). Idempotent, bounded by `max`,
- * and never throws per-Spec — safe for a non-gating deploy step.
+ * Evaluate all shippable, not-yet-judged Specs in a Memex (dec-2: run at the daily
+ * prod promotion). Judges each once (dec-7) — worthy → publish, else → record skip.
+ * Idempotent, bounded by `max` LLM judgements, never throws per-Spec.
  */
 export async function runWhatsNewGeneration(
   memexId: string,
@@ -255,13 +298,21 @@ export async function runWhatsNewGeneration(
 
   let generated = 0;
   let skipped = 0;
+  let evaluated = 0;
   for (const { handle } of candidates) {
-    if (generated >= max) {
-      return { generated, skipped, total: candidates.length, capped: true };
+    if (evaluated >= max) {
+      return { generated, skipped, evaluated, total: candidates.length, capped: true };
     }
-    const published = await generateAndPublishForSpec(memexId, handle, opts);
-    if (published) generated++;
-    else skipped++;
+    const outcome = await generateAndPublishForSpec(memexId, handle, opts);
+    // Only LLM judgements count toward the cap; already-evaluated / non-shippable
+    // specs short-circuit before the model call.
+    if (outcome.status === "published") {
+      generated++;
+      evaluated++;
+    } else if (outcome.status === "skipped") {
+      skipped++;
+      evaluated++;
+    }
   }
-  return { generated, skipped, total: candidates.length, capped: false };
+  return { generated, skipped, evaluated, total: candidates.length, capped: false };
 }

--- a/packages/server/src/services/whats-new.ts
+++ b/packages/server/src/services/whats-new.ts
@@ -9,7 +9,7 @@
 
 import { desc, eq } from "drizzle-orm";
 import { db } from "../db/connection.js";
-import { whatsNewEntries, type WhatsNewEntry } from "../db/schema.js";
+import { whatsNewEntries, whatsNewSkips, type WhatsNewEntry } from "../db/schema.js";
 
 /** The fields the generation service supplies for a new entry. */
 export interface NewWhatsNewEntry {
@@ -57,4 +57,42 @@ export async function getEntryBySpecRef(sourceSpecRef: string): Promise<WhatsNew
     .where(eq(whatsNewEntries.sourceSpecRef, sourceSpecRef))
     .limit(1);
   return rows[0] ?? null;
+}
+
+/**
+ * Record that a Spec was judged NOT worth announcing (dec-7), idempotently. The
+ * persisted verdict means the Spec is evaluated exactly once — never re-judged on
+ * a later deploy. Returns true if a new skip row was written, false if one existed.
+ */
+export async function recordSkip(skip: {
+  sourceSpecRef: string;
+  sourceSpecHandle: string;
+  reason?: string;
+}): Promise<boolean> {
+  const rows = await db
+    .insert(whatsNewSkips)
+    .values({ ...skip, reason: skip.reason ?? null })
+    .onConflictDoNothing({ target: whatsNewSkips.sourceSpecRef })
+    .returning();
+  return rows.length > 0;
+}
+
+/**
+ * Has this Spec already been evaluated (published OR skipped)? Used as the cheap
+ * pre-LLM gate so an already-judged Spec is never re-judged (dec-7).
+ */
+export async function isAlreadyEvaluated(sourceSpecRef: string): Promise<boolean> {
+  const [entry, skip] = await Promise.all([
+    db
+      .select({ id: whatsNewEntries.id })
+      .from(whatsNewEntries)
+      .where(eq(whatsNewEntries.sourceSpecRef, sourceSpecRef))
+      .limit(1),
+    db
+      .select({ id: whatsNewSkips.id })
+      .from(whatsNewSkips)
+      .where(eq(whatsNewSkips.sourceSpecRef, sourceSpecRef))
+      .limit(1),
+  ]);
+  return entry.length > 0 || skip.length > 0;
 }

--- a/packages/shared/src/scaffold-data.ts
+++ b/packages/shared/src/scaffold-data.ts
@@ -1952,19 +1952,24 @@ export const BASE_SCAFFOLD: ScaffoldDataset = {
 // spec-200 t-2: the What's New generation prompt. Lives here (not inline in
 // services/whats-new-generation.ts) per the prompt-prose-in-shared rule the
 // scaffold-drift-guard enforces — same home as CLAUSE_TRANSLATOR_PROMPT.
-export const WHATS_NEW_SYSTEM_PROMPT = `You write release notes for Memex users.
+export const WHATS_NEW_SYSTEM_PROMPT = `You curate and write the "What's New" feed for Memex users.
 
-You are given a digest of a software Spec that just shipped to production: its purpose, the decisions made, and the acceptance criteria that define success. Turn it into ONE release-note entry with three fields:
+You are given a digest of a software Spec that just shipped to production: its purpose, the decisions made, and the acceptance criteria that define success. You do TWO things: (1) judge whether it is worth announcing, and (2) if so, write the release note.
 
-- "title": a short, friendly, benefit-led headline (max ~8 words). Describe the user-visible win, not the internal feature name. No "spec-N", no jargon.
+STEP 1 — Judge worthiness ("worthAnnouncing"). What's New is a curated highlights feed, NOT a changelog. Only genuinely noteworthy, user-facing changes belong.
+- ANNOUNCE (worthAnnouncing = true): a new feature; a meaningful capability or UX improvement a user would actually notice and care about; something you'd put in a product update email.
+- SKIP (worthAnnouncing = false): pure bug fixes; internal/infrastructure/refactor/deploy/CI work; chores; tiny cosmetic tweaks; developer-only or process changes; anything with no clear, compelling user-facing benefit. When in doubt, SKIP — a sparse feed of real highlights beats a noisy one.
+- Always fill "reason" with a one-line justification for the verdict.
+
+STEP 2 — If (and only if) worthAnnouncing is true, write the note (omit these fields when skipping):
+- "title": a short, friendly, benefit-led headline (max ~8 words). The user-visible win, not the internal feature name. No "spec-N", no jargon.
 - "what": one or two plain sentences saying WHAT changed, from the user's point of view.
 - "why": one or two plain sentences saying WHY it matters to the user — the benefit they get.
 
-Rules:
+Writing rules (for announced entries):
 - Write for an end user, never an engineer. No internal vocabulary (no "decision", "AC", "migration", "endpoint", phase names, file paths).
-- Lead with the benefit. This is a "here's what's new and why you'll like it" note, not a changelog line.
-- Be concrete and warm, never marketing-fluffy. No exclamation-mark spam.
-- If the Spec is purely internal with no user-facing effect, still describe the closest user benefit honestly (e.g. reliability, speed) rather than inventing a feature.`;
+- Lead with the benefit. A "here's what's new and why you'll like it" note, not a changelog line.
+- Be concrete and warm, never marketing-fluffy. No exclamation-mark spam.`;
 
 export const CLAUSE_TRANSLATOR_PROMPT = `You split ONE section of a standard into clauses.
 


### PR DESCRIPTION
## What & why

Follow-up to spec-200 (#82). Right now **every** shipped Spec becomes a What's New entry — so a one-line bug fix or internal/infra Spec would show up and dilute the feed. This adds an **AI worthiness gate** (spec-200 dec-7) so only noteworthy, user-facing changes get announced.

## How

- **Judge + draft in one call.** `WhatsNewDraftSchema` now returns `worthAnnouncing` + `reason` alongside the (now-optional) `title/what/why`. `WHATS_NEW_SYSTEM_PROMPT` instructs Claude to **announce** features / meaningful UX wins and **skip** bug fixes, internal/infra/refactors, chores, and anything with no clear user benefit ("when in doubt, skip").
- **Judged exactly once.** New migration `0081_whats_new_skips` persists the skip verdict. The candidate set excludes Specs already in `whats_new_entries` *or* `whats_new_skips`, and the cheap pre-LLM check covers both — so a skipped Spec is never re-judged on a later deploy (no wasted calls, no risk of a "skip" later flipping to "announce" and appearing weeks late).
- **Bounded.** `runWhatsNewGeneration` now caps **LLM judgements** per run (not just publishes) — `generateAndPublishForSpec` returns a discriminated outcome (`published` / `skipped` / `already-evaluated` / `not-shippable`); already-evaluated specs short-circuit before the model call. Protects the first backfill; steady state is just "today's promotions".

## Tests
- New **ac-16**: a not-worthy Spec publishes nothing, persists its skip, and is **not re-judged** (no second LLM call).
- Updated ac-6/ac-7/ac-8 for the verdict-based contract. **224 server tests green** incl. `mutate-coverage.static-scan` + `scaffold-drift-guard`. journey-22 green on the new schema. `tsc` clean (only the pre-existing `discord-webhook.test.ts` error).

## Notes
- Fully auto, no human approval (consistent with dec-1). The prompt is the only control; "noteworthy" is subjective so the model will occasionally mis-judge — a manual unpublish / force-include is a possible fast-follow.
- Migration `0081` is additive (new table). The deploy step 1f no-ops on INT (source memex is prod-only) exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
