### PR TITLE
spec-201: in-product setup — Genesis prompt, AC-emitter install, claude.ai/Cursor connect

### DIFF
--- a/packages/server/src/__regression__/scaffold-drift-guard.regression.test.ts
+++ b/packages/server/src/__regression__/scaffold-drift-guard.regression.test.ts
@@ -90,6 +90,13 @@ const ALLOWLISTED_PROSE_FILES = new Set(
     // to paste into a coding agent. Not consumed by Mindset's own agent.
     "packages/ui/src/utils/specInitPrompt.ts",
     "packages/ui/src/utils/taskInitPrompt.ts",
+    // spec-201: the "Genesis prompt" — clipboard text a human pastes into a
+    // fresh Claude Code / Cursor session to wire their own agent up to Memex
+    // (register the MCP server + write a CLAUDE.md / .cursor rule). Same
+    // category as the Init Prompts above: human-pasted, NOT consumed by
+    // Mindset's own agent, so it belongs here rather than in scaffold-data.ts
+    // (which owns Mindset-agent system-prompt / nudge / rubric prose).
+    "packages/ui/src/utils/genesisPrompt.ts",
     // One-shot Postgres seed for the b-3 "reviewer" persona — bootstrap
     // data, not a runtime nudge channel.
     "packages/server/src/db/seed-reviewer.ts",

--- a/packages/shared/src/ac-emitter-manifest.test.ts
+++ b/packages/shared/src/ac-emitter-manifest.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { tagAc } from '@memex-ai-ac/vitest';
+import {
+  acEmitterManifest,
+  AC_EMITTER_STATUSES,
+  type AcEmitterEntry,
+} from './ac-emitter-manifest';
+
+const AC_MANIFEST_EXISTS = 'mindset-prod/memex-building-itself/specs/spec-201/acs/ac-12';
+const AC_MANIFEST_GUARD = 'mindset-prod/memex-building-itself/specs/spec-201/acs/ac-14';
+
+describe('spec-201 ac-12: AC-emitter manifest is plain data with the required shape', () => {
+  it('exports a non-empty array of entries', () => {
+    tagAc(AC_MANIFEST_EXISTS);
+    expect(Array.isArray(acEmitterManifest)).toBe(true);
+    expect(acEmitterManifest.length).toBeGreaterThan(0);
+  });
+
+  it('every entry carries language, framework, package, installCommand, status, docsUrl', () => {
+    tagAc(AC_MANIFEST_EXISTS);
+    for (const e of acEmitterManifest) {
+      const keys: (keyof AcEmitterEntry)[] = [
+        'language',
+        'framework',
+        'package',
+        'installCommand',
+        'status',
+        'docsUrl',
+      ];
+      for (const k of keys) {
+        expect(typeof e[k]).toBe('string');
+        expect((e[k] as string).length).toBeGreaterThan(0);
+      }
+    }
+  });
+});
+
+describe('spec-201 ac-14: anti-drift guard on the manifest', () => {
+  it('includes the Vitest adapter with status "available"', () => {
+    tagAc(AC_MANIFEST_GUARD);
+    const vitest = acEmitterManifest.find((e) => e.package === '@memex-ai-ac/vitest');
+    expect(vitest).toBeDefined();
+    expect(vitest?.status).toBe('available');
+    expect(vitest?.installCommand).toContain('@memex-ai-ac/vitest');
+  });
+
+  it('constrains every entry status to the allowed enum', () => {
+    tagAc(AC_MANIFEST_GUARD);
+    for (const e of acEmitterManifest) {
+      expect(AC_EMITTER_STATUSES).toContain(e.status);
+    }
+  });
+
+  it('has no duplicate package names', () => {
+    tagAc(AC_MANIFEST_GUARD);
+    const pkgs = acEmitterManifest.map((e) => e.package);
+    expect(new Set(pkgs).size).toBe(pkgs.length);
+  });
+});

--- a/packages/shared/src/ac-emitter-manifest.ts
+++ b/packages/shared/src/ac-emitter-manifest.ts
@@ -1,0 +1,65 @@
+// spec-201 dec-3: the per-language AC-emitter adapter catalogue, single-sourced
+// as committed plain data (mirrors tool-manifest.ts, std-16). The Integrations
+// page renders this matrix; each adapter PR flips its own entry's `status`, and
+// ac-emitter-manifest.test.ts guards it against drift. Dependency-free so it can
+// be imported by both the UI and the server without dragging anything in.
+
+export type AcEmitterStatus = 'available' | 'coming-soon' | 'planned';
+
+export interface AcEmitterEntry {
+  /** Language family, e.g. "TypeScript / JavaScript". */
+  readonly language: string;
+  /** Test framework the adapter targets, e.g. "Vitest". */
+  readonly framework: string;
+  /** Published (or reserved) package name. */
+  readonly package: string;
+  /** Copy-pasteable install command for the package. */
+  readonly installCommand: string;
+  /** Availability of the adapter. */
+  readonly status: AcEmitterStatus;
+  /** Where to read more (npm/PyPI/registry or docs). */
+  readonly docsUrl: string;
+}
+
+export const AC_EMITTER_STATUSES: readonly AcEmitterStatus[] = [
+  'available',
+  'coming-soon',
+  'planned',
+];
+
+// One row per adapter. Keep `vitest` first — it's the reference adapter (spec-89)
+// and the only one shipped today. pytest is next (spec-128).
+export const acEmitterManifest: readonly AcEmitterEntry[] = [
+  {
+    language: 'TypeScript / JavaScript',
+    framework: 'Vitest',
+    package: '@memex-ai-ac/vitest',
+    installCommand: 'npm install --save-dev @memex-ai-ac/vitest',
+    status: 'available',
+    docsUrl: 'https://www.npmjs.com/package/@memex-ai-ac/vitest',
+  },
+  {
+    language: 'Python',
+    framework: 'pytest',
+    package: 'memex-ai-ac-pytest',
+    installCommand: 'pip install --upgrade memex-ai-ac-pytest',
+    status: 'coming-soon',
+    docsUrl: 'https://pypi.org/project/memex-ai-ac-pytest/',
+  },
+  {
+    language: 'TypeScript / JavaScript',
+    framework: 'Jest',
+    package: '@memex-ai-ac/jest',
+    installCommand: 'npm install --save-dev @memex-ai-ac/jest',
+    status: 'planned',
+    docsUrl: 'https://www.npmjs.com/package/@memex-ai-ac/jest',
+  },
+  {
+    language: 'Go',
+    framework: 'go test',
+    package: 'github.com/mindset-ai/memex-ai-ac-go',
+    installCommand: 'go get github.com/mindset-ai/memex-ai-ac-go',
+    status: 'planned',
+    docsUrl: 'https://pkg.go.dev/github.com/mindset-ai/memex-ai-ac-go',
+  },
+];

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -24,6 +24,11 @@ export type {
 export { toolManifest } from './tool-manifest.js';
 export type { ToolManifestEntry } from './tool-manifest.js';
 
+// spec-201 dec-3: the per-language AC-emitter adapter catalogue (single source
+// for the Integrations install matrix).
+export { acEmitterManifest, AC_EMITTER_STATUSES } from './ac-emitter-manifest.js';
+export type { AcEmitterEntry, AcEmitterStatus } from './ac-emitter-manifest.js';
+
 // b-68 t-1: the scaffold model. The base scaffold DATA (records) will be
 // added in t-2 as `scaffold-data.ts`; this export surface is the shape +
 // projection contract everything else builds against.

--- a/packages/ui/src/App.routes.spec-201.test.ts
+++ b/packages/ui/src/App.routes.spec-201.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { tagAc } from '@memex-ai-ac/vitest';
+
+// spec-201 dec-1 (ac-7): the install/setup content lives ONLY on
+// /settings/integrations. No net-new top-level /setup page, and the retired
+// /installation + /install routes must redirect there (not serve content).
+// A source-level guard is the right granularity: it pins the routing contract
+// without booting the whole authenticated <App/> provider tree.
+const AC_NO_NEW_ROUTE = 'mindset-prod/memex-building-itself/specs/spec-201/acs/ac-7';
+
+const SRC_DIR = dirname(fileURLToPath(import.meta.url));
+const appSource = readFileSync(join(SRC_DIR, 'App.tsx'), 'utf8');
+
+describe('spec-201 ac-7: no new setup/installation route; install content is on Integrations', () => {
+  it('serves the install content from /settings/integrations', () => {
+    tagAc(AC_NO_NEW_ROUTE);
+    expect(appSource).toContain('path="/settings/integrations"');
+    expect(appSource).toMatch(/path="\/settings\/integrations"[\s\S]*?SettingsIntegrations/);
+  });
+
+  it('redirects the retired /installation and /install routes there', () => {
+    tagAc(AC_NO_NEW_ROUTE);
+    expect(appSource).toMatch(
+      /path="\/installation"\s+element=\{<Navigate to="\/settings\/integrations"/
+    );
+    expect(appSource).toMatch(
+      /path="\/install"\s+element=\{<Navigate to="\/settings\/integrations"/
+    );
+  });
+
+  it('introduces no /setup route', () => {
+    tagAc(AC_NO_NEW_ROUTE);
+    expect(appSource).not.toMatch(/path="\/?setup"/);
+  });
+});

--- a/packages/ui/src/components/AcEmitterSection.test.tsx
+++ b/packages/ui/src/components/AcEmitterSection.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { acEmitterManifest } from '@memex/shared';
+
+const AC_INSTALL_CMD = 'mindset-prod/memex-building-itself/specs/spec-201/acs/ac-9';
+const AC_KEYS_LINK = 'mindset-prod/memex-building-itself/specs/spec-201/acs/ac-10';
+const AC_EMIT_KEY_TAG = 'mindset-prod/memex-building-itself/specs/spec-201/acs/ac-11';
+const AC_MATRIX = 'mindset-prod/memex-building-itself/specs/spec-201/acs/ac-13';
+
+vi.mock('./AuthContext', () => ({
+  useAuth: () => ({
+    session: { memberships: [{ slug: 'acme', memexSlug: 'team', kind: 'team' }] },
+  }),
+}));
+
+// jsdom clipboard for the CopyButton.
+Object.assign(navigator, {
+  clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+});
+
+import { AcEmitterSection } from './AcEmitterSection';
+
+function renderSection() {
+  return render(
+    <MemoryRouter initialEntries={['/settings/integrations']}>
+      <AcEmitterSection />
+    </MemoryRouter>
+  );
+}
+
+describe('spec-201 ac-13: adapter matrix is rendered from the shared manifest', () => {
+  it('renders exactly one row per manifest entry', () => {
+    tagAc(AC_MATRIX);
+    renderSection();
+    expect(screen.getAllByRole('row')).toHaveLength(acEmitterManifest.length);
+  });
+
+  it('shows each adapter package name and a status badge', () => {
+    tagAc(AC_MATRIX);
+    renderSection();
+    for (const adapter of acEmitterManifest) {
+      expect(screen.getByText(adapter.package)).toBeInTheDocument();
+    }
+    // The available adapter shows the "Available" badge.
+    expect(screen.getAllByText('Available').length).toBeGreaterThan(0);
+  });
+});
+
+describe('spec-201 ac-9: install command for the selected adapter', () => {
+  it('defaults to the available adapter and shows its install command in a code block', () => {
+    tagAc(AC_INSTALL_CMD);
+    renderSection();
+    const vitest = acEmitterManifest.find((a) => a.status === 'available')!;
+    expect(screen.getByText(vitest.installCommand)).toBeInTheDocument();
+  });
+});
+
+describe('spec-201 ac-10: deep link to the per-Memex Emission Keys panel', () => {
+  it('links to /:namespace/:memex/keys resolved from the session membership', () => {
+    tagAc(AC_KEYS_LINK);
+    renderSection();
+    const link = screen.getByRole('link', { name: 'Emission Keys' });
+    expect(link).toHaveAttribute('href', '/acme/team/keys');
+  });
+});
+
+describe('spec-201 ac-11: MEMEX_EMIT_KEY + tagAc example', () => {
+  it('shows how to set MEMEX_EMIT_KEY and a tagAc() tagged-test example', () => {
+    tagAc(AC_EMIT_KEY_TAG);
+    renderSection();
+    expect(screen.getByText(/MEMEX_EMIT_KEY=/)).toBeInTheDocument();
+    // The tagAc example code block contains the call.
+    const blocks = document.querySelectorAll('pre code');
+    const joined = Array.from(blocks).map((b) => b.textContent ?? '').join('\n');
+    expect(joined).toContain("tagAc('your-namespace/your-memex/specs/spec-1/acs/ac-1')");
+  });
+});
+
+describe('spec-201: selecting a different available adapter updates the install command', () => {
+  it('keeps coming-soon/planned adapters non-selectable', () => {
+    tagAc(AC_MATRIX);
+    renderSection();
+    const planned = acEmitterManifest.find((a) => a.status === 'planned')!;
+    // The planned row is rendered but disabled (not selectable).
+    const rows = screen.getAllByRole('row');
+    const plannedRow = rows.find((r) => within(r).queryByText(planned.package));
+    expect(plannedRow).toBeDefined();
+    expect(plannedRow).toBeDisabled();
+  });
+});

--- a/packages/ui/src/components/AcEmitterSection.tsx
+++ b/packages/ui/src/components/AcEmitterSection.tsx
@@ -1,0 +1,141 @@
+// spec-201 dec-2: the "Install the AC emitter" section on the Integrations page.
+// Sibling of CliInstallSection. Static copy (no guided checklist): pick an
+// adapter from the manifest-driven matrix → copy its install command → mint a
+// MEMEX_EMIT_KEY (deep link to the per-Memex Emission Keys panel) → tag a test.
+//
+// The adapter matrix is rendered from the @memex/shared acEmitterManifest
+// (dec-3), so it can't drift from the shipped adapters.
+
+import { useState } from 'react';
+import { Link, useLocation } from 'react-router-dom';
+import {
+  acEmitterManifest,
+  type AcEmitterEntry,
+  type AcEmitterStatus,
+} from '@memex/shared';
+import { CodeBlock, InlineCode } from './CodeBlock';
+import { Badge } from './ui/Badge';
+import { resolveNavTo } from '../utils/tenantUrl';
+import { useAuth } from './AuthContext';
+
+// Map the adapter availability onto the shared lifecycle palette (statusStyles
+// via Badge): available → success/green, coming-soon → info/blue, planned →
+// neutral. Reusing Badge keeps the look consistent and stays clear of the
+// spec-167 single-consumer accent-foreground token.
+const STATUS_TO_DOMAIN: Record<AcEmitterStatus, string> = {
+  available: 'done',
+  'coming-soon': 'build',
+  planned: 'draft',
+};
+const STATUS_LABEL: Record<AcEmitterStatus, string> = {
+  available: 'Available',
+  'coming-soon': 'Coming soon',
+  planned: 'Planned',
+};
+
+const TAG_EXAMPLE = `import { tagAc } from '@memex-ai-ac/vitest';
+
+it('keeps the cache warm', () => {
+  tagAc('your-namespace/your-memex/specs/spec-1/acs/ac-1');
+  expect(cache.isWarm()).toBe(true);
+});`;
+
+function defaultAdapter(): AcEmitterEntry {
+  return acEmitterManifest.find((a) => a.status === 'available') ?? acEmitterManifest[0];
+}
+
+export function AcEmitterSection() {
+  const location = useLocation();
+  const { session } = useAuth();
+  const [selected, setSelected] = useState<AcEmitterEntry>(defaultAdapter);
+
+  const keysHref = resolveNavTo('/keys', location.pathname, session?.memberships);
+  const emitKeyCmd = `MEMEX_EMIT_KEY=mxk_your_key_here npm test`;
+
+  return (
+    <section id="install-ac-emitter" aria-labelledby="install-ac-emitter-heading">
+      <h2 id="install-ac-emitter-heading" className="text-xl font-semibold mb-2 text-heading">
+        Install the AC emitter
+      </h2>
+      <p className="mb-6 text-secondary">
+        Tag your tests with an acceptance-criterion ref and Memex turns the AC green when
+        the test passes. Pick your adapter, install it, set your emission key, and tag a
+        test.
+      </p>
+
+      {/* Adapter matrix — one row per manifest entry (ac-13). */}
+      <div className="mb-8 border rounded-lg divide-y border-edge divide-edge" role="table" aria-label="AC emitter adapters">
+        {acEmitterManifest.map((adapter) => {
+          const isSelected = adapter.package === selected.package;
+          const isAvailable = adapter.status === 'available';
+          return (
+            <button
+              key={adapter.package}
+              role="row"
+              aria-selected={isSelected}
+              disabled={!isAvailable}
+              onClick={() => isAvailable && setSelected(adapter)}
+              className={
+                'w-full text-left px-4 py-3 flex items-center justify-between gap-4 transition-colors ' +
+                (isSelected ? 'bg-overlay ' : '') +
+                (isAvailable ? 'hover:bg-overlay cursor-pointer' : 'opacity-60 cursor-not-allowed')
+              }
+            >
+              <span className="flex flex-col">
+                <span className="text-sm font-medium text-primary">
+                  {adapter.framework}{' '}
+                  <span className="text-secondary font-normal">· {adapter.language}</span>
+                </span>
+                <a
+                  href={adapter.docsUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  onClick={(e) => e.stopPropagation()}
+                  className="text-xs underline text-muted hover:text-primary"
+                >
+                  {adapter.package}
+                </a>
+              </span>
+              <Badge
+                status={STATUS_TO_DOMAIN[adapter.status]}
+                label={STATUS_LABEL[adapter.status]}
+              />
+            </button>
+          );
+        })}
+      </div>
+
+      {/* 1. Install (ac-9) */}
+      <div className="mb-8">
+        <h3 className="text-base font-medium mb-3 text-heading">
+          1. Install the {selected.framework} adapter
+        </h3>
+        <CodeBlock code={selected.installCommand} />
+      </div>
+
+      {/* 2. Emission key (ac-10, ac-11) */}
+      <div className="mb-8">
+        <h3 className="text-base font-medium mb-3 text-heading">2. Set your emission key</h3>
+        <p className="text-sm mb-3 text-secondary">
+          Mint a key in the{' '}
+          <Link to={keysHref} className="underline hover:text-primary">
+            Emission Keys
+          </Link>{' '}
+          panel, then expose it to your test runner as{' '}
+          <InlineCode>MEMEX_EMIT_KEY</InlineCode> (or store it as a CI secret):
+        </p>
+        <CodeBlock code={emitKeyCmd} />
+      </div>
+
+      {/* 3. Tag a test (ac-11) */}
+      <div>
+        <h3 className="text-base font-medium mb-3 text-heading">3. Tag a test</h3>
+        <p className="text-sm mb-3 text-secondary">
+          Call <InlineCode>tagAc()</InlineCode> with the AC's full ref inside the test that
+          proves it:
+        </p>
+        <CodeBlock code={TAG_EXAMPLE} />
+      </div>
+    </section>
+  );
+}

--- a/packages/ui/src/components/AppShell.spec-201.test.tsx
+++ b/packages/ui/src/components/AppShell.spec-201.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { ThemeProvider } from './ThemeContext';
+
+// spec-201 dec-1: the Integrations entry (which hosts the install instructions)
+// must stay member-visible — not gated on administrator — so coders who connect
+// agents can reach it.
+const AC_MEMBER_VISIBLE = 'mindset-prod/memex-building-itself/specs/spec-201/acs/ac-8';
+
+// A plain (non-admin) team MEMBER membership matching the tenant in the URL.
+const TEAM_MEMBER = {
+  memexId: 'm1',
+  slug: 'acme',
+  memexSlug: 'team',
+  name: 'Acme Inc',
+  memexName: 'Team',
+  kind: 'team' as const,
+  role: 'member' as const,
+};
+
+const session = {
+  user: { name: 'Member', email: 'm@acme.test' },
+  memberships: [TEAM_MEMBER],
+  currentMemexId: 'm1',
+};
+
+vi.mock('./AuthContext', () => ({
+  useAuth: () => ({
+    user: { name: 'Member', email: 'm@acme.test' },
+    session,
+    logout: vi.fn(),
+  }),
+}));
+
+vi.mock('./MemexSwitcher', () => ({
+  MemexSwitcher: () => <div data-testid="memex-switcher" />,
+}));
+
+vi.mock('./InviteMembersDialog', () => ({
+  InviteMembersDialog: () => <div data-testid="invite-dialog" />,
+}));
+
+vi.mock('../hooks/useMemexAccess', () => ({
+  useMemexAccess: () => ({ isAuthenticated: true, isVisitedReadOnly: false }),
+}));
+
+vi.mock('../hooks/useDriftInboxCount', () => ({
+  useDriftInboxCount: () => 0,
+}));
+
+import { AppShell } from './AppShell';
+
+function renderShell() {
+  return render(
+    <ThemeProvider>
+      <MemoryRouter initialEntries={['/acme/team/specs']}>
+        <AppShell>
+          <div data-testid="page-content">page</div>
+        </AppShell>
+      </MemoryRouter>
+    </ThemeProvider>
+  );
+}
+
+describe('spec-201 ac-8: Integrations entry is member-visible', () => {
+  it('shows the Integrations link in the user menu for a non-admin member', () => {
+    tagAc(AC_MEMBER_VISIBLE);
+    renderShell();
+    fireEvent.click(screen.getByText('Member'));
+
+    expect(screen.getByRole('link', { name: 'Integrations' })).toHaveAttribute(
+      'href',
+      '/settings/integrations'
+    );
+    // It is NOT behind the admin-only gate (Org configuration is admin-gated and
+    // must be absent for a plain member).
+    expect(screen.queryByRole('link', { name: 'Org configuration' })).toBeNull();
+  });
+});

--- a/packages/ui/src/components/AppShell.tsx
+++ b/packages/ui/src/components/AppShell.tsx
@@ -14,7 +14,7 @@ import { SearchTrigger } from './SearchTrigger';
 import {
   getCurrentTenant,
   parseTenantFromPathname,
-  parseNamespaceFromPathname,
+  resolveNavTo,
 } from '../utils/tenantUrl';
 
 // Strip the leading /<namespace>/<memex> from a pathname so we can match
@@ -35,31 +35,6 @@ function stripTenantPrefix(pathname: string): string {
 // the user's default landing tenant when the URL is fully flat. Pure helper
 // so it can be exercised without rendering — `useNavTo` below is the React
 // wrapper that pulls session + location from context.
-function resolveNavTo(
-  toInTenant: string,
-  pathname: string,
-  memberships: Array<{ slug: string; memexSlug: string; kind: 'personal' | 'team' }> | undefined,
-): string {
-  const normalized = toInTenant.startsWith('/') ? toInTenant : `/${toInTenant}`;
-  const suffix = normalized === '/' ? '' : normalized;
-
-  const tenant = parseTenantFromPathname(pathname);
-  if (tenant) return `/${tenant.namespace}/${tenant.memex}${suffix}`;
-
-  const ns = parseNamespaceFromPathname(pathname);
-  if (ns && memberships) {
-    const m = memberships.find((row) => row.slug === ns);
-    if (m) return `/${ns}/${m.memexSlug}${suffix}`;
-  }
-
-  if (memberships && memberships.length > 0) {
-    const personal = memberships.find((row) => row.kind === 'personal') ?? memberships[0];
-    return `/${personal.slug}/${personal.memexSlug}${suffix}`;
-  }
-
-  return normalized;
-}
-
 const PRIMARY_NAV_LINKS: ReadonlyArray<{
   to: string;
   label: string;

--- a/packages/ui/src/components/CliInstallSection.test.tsx
+++ b/packages/ui/src/components/CliInstallSection.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { CliInstallSection } from './CliInstallSection';
+import { installBase, mcpUrl } from '../utils/mcpUrl';
+
+const AC_URL_DERIVED = 'mindset-prod/memex-building-itself/specs/spec-201/acs/ac-15';
+const AC_MORE_CLIENTS = 'mindset-prod/memex-building-itself/specs/spec-201/acs/ac-16';
+
+describe('spec-201 ac-15: connect instructions derive the MCP URL from the environment', () => {
+  it('renders the MCP URL as installBase + /mcp, not a hardcoded host', () => {
+    tagAc(AC_URL_DERIVED);
+    render(<CliInstallSection />);
+    // The "Other clients" block shows the derived MCP URL in its own code block.
+    expect(screen.getByText(`${installBase}/mcp`)).toBeInTheDocument();
+    expect(mcpUrl).toBe(`${installBase}/mcp`);
+  });
+});
+
+describe('spec-201 ac-16: claude.ai web + Cursor connect steps', () => {
+  it('includes a claude.ai (web) connect block', () => {
+    tagAc(AC_MORE_CLIENTS);
+    render(<CliInstallSection />);
+    expect(screen.getByRole('heading', { name: 'claude.ai (web)' })).toBeInTheDocument();
+    expect(screen.getByText(/Add custom connector/)).toBeInTheDocument();
+  });
+
+  it('includes a Cursor connect block with the derived URL in its config', () => {
+    tagAc(AC_MORE_CLIENTS);
+    render(<CliInstallSection />);
+    expect(screen.getByRole('heading', { name: 'Cursor' })).toBeInTheDocument();
+    const cursorConfig = screen.getByText(/"mcpServers"[\s\S]*"memex"[\s\S]*\/mcp/);
+    expect(cursorConfig.textContent).toContain(`${installBase}/mcp`);
+  });
+
+  it('exposes a copy control for the MCP URL', () => {
+    tagAc(AC_MORE_CLIENTS);
+    render(<CliInstallSection />);
+    // The derived-URL block and the Cursor config each carry a Copy button.
+    expect(screen.getAllByRole('button', { name: 'Copy' }).length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/packages/ui/src/components/CliInstallSection.tsx
+++ b/packages/ui/src/components/CliInstallSection.tsx
@@ -4,18 +4,13 @@
 // (/install/mcp/auth, InstallAuth) is unaffected — this is only the
 // human-facing "how to install" copy. Cross-link to MCP tokens is now an
 // in-page anchor.
+//
+// spec-201: the URL derivation moved to utils/mcpUrl.ts and the code-block
+// primitives to components/CodeBlock.tsx, both shared with GenesisPromptSection.
 
 import { useState } from 'react';
-
-const API_URL = import.meta.env.VITE_API_URL ?? '';
-const isDeployed = API_URL.startsWith('http');
-
-// Bootstrap URLs (/install.{sh,ps1}) are served from the same Cloud Run service
-// that hosts the API — the canonical host is whatever VITE_API_URL resolves to.
-// In dev we point at the local server's bootstrap path.
-const installBase = isDeployed
-  ? API_URL.replace(/\/api\/?$/, '')
-  : 'http://localhost:8080';
+import { CodeBlock, InlineCode } from './CodeBlock';
+import { installBase } from '../utils/mcpUrl';
 
 const SH_COMMAND = `curl -fsSL ${installBase}/install.sh | sh`;
 const PS_COMMAND = `irm ${installBase}/install.ps1 | iex`;
@@ -28,40 +23,6 @@ function detectOs(): 'mac' | 'linux' | 'windows' | 'unknown' {
   if (p.includes('win') || u.includes('windows')) return 'windows';
   if (p.includes('linux') || u.includes('linux')) return 'linux';
   return 'unknown';
-}
-
-function CopyButton({ text }: { text: string }) {
-  const [copied, setCopied] = useState(false);
-  return (
-    <button
-      onClick={() => {
-        navigator.clipboard.writeText(text).then(() => {
-          setCopied(true);
-          setTimeout(() => setCopied(false), 2000);
-        });
-      }}
-      className="absolute top-2 right-2 px-2 py-1 text-xs font-medium rounded transition-colors bg-btn-secondary hover:bg-btn-secondary-hover text-secondary"
-    >
-      {copied ? 'Copied!' : 'Copy'}
-    </button>
-  );
-}
-
-function CodeBlock({ code }: { code: string }) {
-  return (
-    <div className="relative group">
-      <CopyButton text={code} />
-      <pre className="border rounded-lg p-4 overflow-x-auto text-sm leading-relaxed bg-surface border-edge">
-        <code className="text-primary">{code}</code>
-      </pre>
-    </div>
-  );
-}
-
-function InlineCode({ children }: { children: React.ReactNode }) {
-  return (
-    <code className="px-1.5 py-0.5 rounded text-xs text-primary bg-input">{children}</code>
-  );
 }
 
 export function CliInstallSection() {

--- a/packages/ui/src/components/CliInstallSection.tsx
+++ b/packages/ui/src/components/CliInstallSection.tsx
@@ -15,6 +15,20 @@ import { installBase } from '../utils/mcpUrl';
 const SH_COMMAND = `curl -fsSL ${installBase}/install.sh | sh`;
 const PS_COMMAND = `irm ${installBase}/install.ps1 | iex`;
 
+// spec-201 dec-4: the canonical MCP endpoint, shared by the claude.ai web and
+// Cursor connect steps below. Same derivation as the manual configs.
+const MCP_URL = `${installBase}/mcp`;
+
+// Cursor MCP config — remote server over HTTP. url-only is correct for dynamic
+// OAuth (spec-31): Cursor runs the sign-in flow on connect (no static token).
+const CURSOR_CONFIG = `{
+  "mcpServers": {
+    "memex": {
+      "url": "${MCP_URL}"
+    }
+  }
+}`;
+
 function detectOs(): 'mac' | 'linux' | 'windows' | 'unknown' {
   if (typeof navigator === 'undefined') return 'unknown';
   const p = navigator.platform.toLowerCase();
@@ -37,7 +51,8 @@ export function CliInstallSection() {
       <h2 id="install-cli-heading" className="text-xl font-semibold mb-2 text-heading">Install Memex MCP</h2>
       <p className="mb-8 text-secondary">
         Connect Memex to Claude Code and Claude Desktop. The installer opens your browser
-        once to authorize this device — after that it works without ever expiring.
+        once to authorize this device — after that it works without ever expiring. Using
+        claude.ai (web) or Cursor instead? See <a href="#other-clients" className="underline hover:text-primary">Other clients</a> below.
       </p>
 
       <div className="mb-10">
@@ -63,6 +78,38 @@ export function CliInstallSection() {
           </a>{' '}
           section above.
         </p>
+      </div>
+
+      {/* spec-201 dec-4: claude.ai web + Cursor. Both complete OAuth on connect,
+          so there's no token to paste — they just need the MCP URL. */}
+      <div id="other-clients" className="mb-10">
+        <h3 className="text-base font-medium mb-3 text-heading">Other clients</h3>
+        <p className="text-sm mb-3 text-secondary">
+          claude.ai (web) and Cursor connect to the same endpoint and sign in over OAuth —
+          no token to paste. Your MCP URL:
+        </p>
+        <CodeBlock code={MCP_URL} />
+
+        <div className="mt-6 space-y-6">
+          <div>
+            <h4 className="text-sm font-medium mb-2 text-heading">claude.ai (web)</h4>
+            <ol className="list-decimal list-inside text-sm space-y-1 text-secondary">
+              <li>Open <strong>Settings → Connectors</strong>.</li>
+              <li>Click <strong>Add custom connector</strong>.</li>
+              <li>Name it <InlineCode>Memex</InlineCode> and paste the MCP URL above.</li>
+              <li>Save, then complete the sign-in in the popup.</li>
+            </ol>
+          </div>
+          <div>
+            <h4 className="text-sm font-medium mb-2 text-heading">Cursor</h4>
+            <p className="text-xs mb-2 text-secondary">
+              Add to <InlineCode>.cursor/mcp.json</InlineCode> (this project) or{' '}
+              <InlineCode>~/.cursor/mcp.json</InlineCode> (everywhere), then reload Cursor and
+              complete the OAuth sign-in:
+            </p>
+            <CodeBlock code={CURSOR_CONFIG} />
+          </div>
+        </div>
       </div>
 
       <div>

--- a/packages/ui/src/components/CodeBlock.tsx
+++ b/packages/ui/src/components/CodeBlock.tsx
@@ -1,0 +1,39 @@
+// spec-201: shared copy-to-clipboard code primitives, extracted from
+// CliInstallSection (spec-141) so the new GenesisPromptSection reuses them
+// rather than duplicating. Pure presentation, open core.
+
+import { useState } from 'react';
+
+export function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <button
+      onClick={() => {
+        navigator.clipboard.writeText(text).then(() => {
+          setCopied(true);
+          setTimeout(() => setCopied(false), 2000);
+        });
+      }}
+      className="absolute top-2 right-2 px-2 py-1 text-xs font-medium rounded transition-colors bg-btn-secondary hover:bg-btn-secondary-hover text-secondary"
+    >
+      {copied ? 'Copied!' : 'Copy'}
+    </button>
+  );
+}
+
+export function CodeBlock({ code }: { code: string }) {
+  return (
+    <div className="relative group">
+      <CopyButton text={code} />
+      <pre className="border rounded-lg p-4 overflow-x-auto text-sm leading-relaxed bg-surface border-edge">
+        <code className="text-primary">{code}</code>
+      </pre>
+    </div>
+  );
+}
+
+export function InlineCode({ children }: { children: React.ReactNode }) {
+  return (
+    <code className="px-1.5 py-0.5 rounded text-xs text-primary bg-input">{children}</code>
+  );
+}

--- a/packages/ui/src/components/GenesisPromptSection.test.tsx
+++ b/packages/ui/src/components/GenesisPromptSection.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { GenesisPromptSection } from './GenesisPromptSection';
+import { mcpUrl } from '../utils/mcpUrl';
+
+const AC_ENV_DERIVED = 'mindset-prod/memex-building-itself/specs/spec-201/acs/ac-18';
+const AC_STATIC = 'mindset-prod/memex-building-itself/specs/spec-201/acs/ac-21';
+
+// jsdom has no clipboard by default; the CopyButton calls navigator.clipboard.
+Object.assign(navigator, {
+  clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+});
+
+function getPromptText(): string {
+  // The prompt is the only <code> inside a <pre> in this section.
+  const pre = document.querySelector('pre code');
+  return pre?.textContent ?? '';
+}
+
+describe('spec-201: GenesisPromptSection', () => {
+  it('renders the section heading and a copy-pasteable prompt block', () => {
+    tagAc(AC_STATIC);
+    render(<GenesisPromptSection />);
+    expect(
+      screen.getByRole('heading', { name: 'Set up with one prompt' })
+    ).toBeInTheDocument();
+    expect(document.querySelector('pre code')).not.toBeNull();
+  });
+
+  it('ac-21: is static copy only — a Copy control, no Run/Verify/Install action', () => {
+    tagAc(AC_STATIC);
+    render(<GenesisPromptSection />);
+    expect(screen.getByRole('button', { name: 'Copy' })).toBeInTheDocument();
+    // No control that would execute or verify the bootstrap on the user's behalf.
+    expect(screen.queryByRole('button', { name: /run|verify|install|connect/i })).toBeNull();
+  });
+
+  it('defaults to the Claude Code prompt (claude mcp add + CLAUDE.md)', () => {
+    tagAc(AC_STATIC);
+    render(<GenesisPromptSection />);
+    const text = getPromptText();
+    expect(text).toContain('claude mcp add');
+    expect(text).toContain('CLAUDE.md');
+  });
+
+  it('switches to the Cursor prompt (.cursor/rules/memex.mdc) on tab change', () => {
+    tagAc(AC_STATIC);
+    render(<GenesisPromptSection />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Cursor' }));
+    const text = getPromptText();
+    expect(text).toContain('.cursor/rules/memex.mdc');
+    expect(text).toContain('.cursor/mcp.json');
+  });
+
+  it('ac-18: the rendered prompt embeds the environment-derived MCP URL', () => {
+    tagAc(AC_ENV_DERIVED);
+    render(<GenesisPromptSection />);
+    expect(getPromptText()).toContain(mcpUrl);
+    expect(mcpUrl.endsWith('/mcp')).toBe(true);
+  });
+});

--- a/packages/ui/src/components/GenesisPromptSection.tsx
+++ b/packages/ui/src/components/GenesisPromptSection.tsx
@@ -1,0 +1,71 @@
+// spec-201 dec-6: the "Genesis prompt" connect section. A sibling of
+// CliInstallSection on the Integrations page. Renders a single copy-pasteable
+// prompt the user drops into a fresh Claude Code or Cursor session; the agent
+// then registers the Memex MCP server in its own config and writes a durable
+// Memex-use clause into its project memory.
+//
+// Static copy only (ac-21): nothing here runs or verifies the bootstrap — the
+// pasted agent does the work. The embedded MCP URL is environment-derived
+// (ac-18) via utils/mcpUrl.ts, the same source CliInstallSection uses.
+
+import { useState } from 'react';
+import { CodeBlock, InlineCode } from './CodeBlock';
+import { mcpUrl } from '../utils/mcpUrl';
+import { buildClaudeCodePrompt, buildCursorPrompt } from '../utils/genesisPrompt';
+
+type Client = 'claude-code' | 'cursor';
+
+const CLIENTS: { id: Client; label: string }[] = [
+  { id: 'claude-code', label: 'Claude Code' },
+  { id: 'cursor', label: 'Cursor' },
+];
+
+export function GenesisPromptSection() {
+  const [client, setClient] = useState<Client>('claude-code');
+
+  const prompt =
+    client === 'claude-code' ? buildClaudeCodePrompt(mcpUrl) : buildCursorPrompt(mcpUrl);
+
+  const memoryFile =
+    client === 'claude-code' ? 'CLAUDE.md' : '.cursor/rules/memex.mdc';
+
+  return (
+    <section id="genesis-prompt" aria-labelledby="genesis-prompt-heading">
+      <h2 id="genesis-prompt-heading" className="text-xl font-semibold mb-2 text-heading">
+        Set up with one prompt
+      </h2>
+      <p className="mb-6 text-secondary">
+        Prefer to let your agent wire itself up? Paste this into a fresh{' '}
+        <strong>Claude Code</strong> or <strong>Cursor</strong> session. It registers the
+        Memex MCP server and writes a short "how to use Memex" note into your{' '}
+        <InlineCode>{memoryFile}</InlineCode> so the agent reaches for Memex every session
+        — not just this one.
+      </p>
+
+      <div role="tablist" aria-label="Choose your agent" className="flex gap-2 mb-4">
+        {CLIENTS.map(({ id, label }) => (
+          <button
+            key={id}
+            role="tab"
+            aria-selected={client === id}
+            onClick={() => setClient(id)}
+            className={
+              client === id
+                ? 'px-3 py-1.5 text-sm font-medium rounded transition-colors bg-btn-primary text-on-primary'
+                : 'px-3 py-1.5 text-sm font-medium rounded transition-colors bg-btn-secondary hover:bg-btn-secondary-hover text-secondary'
+            }
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+
+      <CodeBlock code={prompt} />
+
+      <p className="text-xs mt-3 text-muted">
+        This is just text to copy — Memex doesn't run anything on your machine. Your agent
+        completes the browser sign-in itself when it adds the server.
+      </p>
+    </section>
+  );
+}

--- a/packages/ui/src/pages/SettingsIntegrations.test.tsx
+++ b/packages/ui/src/pages/SettingsIntegrations.test.tsx
@@ -55,4 +55,12 @@ describe('spec-141 ac-3: consolidated Integrations page', () => {
       await screen.findByRole('heading', { name: 'Set up with one prompt' })
     ).toBeInTheDocument();
   });
+
+  it('ac-6: composes the spec-201 "Install the AC emitter" section', async () => {
+    tagAc('mindset-prod/memex-building-itself/specs/spec-201/acs/ac-6');
+    renderPage();
+    expect(
+      await screen.findByRole('heading', { name: 'Install the AC emitter' })
+    ).toBeInTheDocument();
+  });
 });

--- a/packages/ui/src/pages/SettingsIntegrations.test.tsx
+++ b/packages/ui/src/pages/SettingsIntegrations.test.tsx
@@ -47,4 +47,12 @@ describe('spec-141 ac-3: consolidated Integrations page', () => {
     expect(screen.getByRole('heading', { name: 'MCP Tokens' })).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Install Memex MCP' })).toBeInTheDocument();
   });
+
+  it('composes the spec-201 Genesis-prompt section', async () => {
+    tagAc('mindset-prod/memex-building-itself/specs/spec-201/acs/ac-21');
+    renderPage();
+    expect(
+      await screen.findByRole('heading', { name: 'Set up with one prompt' })
+    ).toBeInTheDocument();
+  });
 });

--- a/packages/ui/src/pages/SettingsIntegrations.test.tsx
+++ b/packages/ui/src/pages/SettingsIntegrations.test.tsx
@@ -2,8 +2,12 @@ import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { tagAc } from '@memex-ai-ac/vitest';
+import { acEmitterManifest } from '@memex/shared';
+import { mcpUrl } from '../utils/mcpUrl';
 
 const AC_CONSOLIDATED = 'mindset-prod/memex-building-itself/specs/spec-141/acs/ac-3';
+const SCOPE = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-201/acs/ac-${n}`;
 
 vi.mock('../components/AuthContext', () => ({
   useAuth: () => ({ token: 'test-token' }),
@@ -62,5 +66,67 @@ describe('spec-141 ac-3: consolidated Integrations page', () => {
     expect(
       await screen.findByRole('heading', { name: 'Install the AC emitter' })
     ).toBeInTheDocument();
+  });
+});
+
+// Scope ACs (manager-authored outcomes). These are deliberately page-level
+// integration assertions — they verify the whole Integrations surface delivers
+// the promised outcome, not a single component's internals (those are the
+// implementation ACs ac-6..ac-16). ac-5 is NOT here: it asserts spec-73's
+// document content, which lives in the Memex, not this repo — see the spec-201
+// handover note for its (doc-state) disposition.
+describe('spec-201 scope ACs: the Integrations page as one discoverable setup surface', () => {
+  it('ac-1: one discoverable surface covers BOTH connecting an agent and installing the AC emitter', async () => {
+    tagAc(SCOPE(1));
+    renderPage();
+    // Reachable as a single page (the member-visible /settings/integrations).
+    expect(
+      await screen.findByRole('heading', { name: 'Integrations', level: 1 })
+    ).toBeInTheDocument();
+    // Connect-an-agent content…
+    expect(screen.getByRole('heading', { name: 'Install Memex MCP' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Set up with one prompt' })).toBeInTheDocument();
+    // …and install-the-emitter content, on the same surface.
+    expect(screen.getByRole('heading', { name: 'Install the AC emitter' })).toBeInTheDocument();
+  });
+
+  it('ac-2: per-client connect steps for all four clients, with the env-derived MCP URL + copy', async () => {
+    tagAc(SCOPE(2));
+    renderPage();
+    await screen.findByRole('heading', { name: 'Install Memex MCP' });
+    // All four clients are named on the surface.
+    expect(screen.getAllByText(/Claude Code/).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Claude Desktop/).length).toBeGreaterThan(0);
+    expect(screen.getByRole('heading', { name: 'claude.ai (web)' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Cursor' })).toBeInTheDocument();
+    // The MCP URL shown is the env-derived one (not a hardcoded host), with copy controls.
+    expect(screen.getAllByText(mcpUrl).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole('button', { name: 'Copy' }).length).toBeGreaterThan(0);
+  });
+
+  it('ac-3: AC-emitter install instructions — command, MEMEX_EMIT_KEY, Emission Keys deep link, tagAc example', async () => {
+    tagAc(SCOPE(3));
+    renderPage();
+    await screen.findByRole('heading', { name: 'Install the AC emitter' });
+    const vitest = acEmitterManifest.find((a) => a.status === 'available')!;
+    expect(screen.getByText(vitest.installCommand)).toBeInTheDocument();
+    expect(screen.getByText(/MEMEX_EMIT_KEY=/)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Emission Keys' })).toBeInTheDocument();
+    const codeBlocks = Array.from(document.querySelectorAll('pre code'))
+      .map((b) => b.textContent ?? '')
+      .join('\n');
+    expect(codeBlocks).toContain('tagAc(');
+  });
+
+  it('ac-4: per-language adapter matrix sourced from the shared manifest (one row per entry, statuses shown)', async () => {
+    tagAc(SCOPE(4));
+    renderPage();
+    await screen.findByRole('heading', { name: 'Install the AC emitter' });
+    // Every adapter in the manifest is rendered — the matrix is data-sourced, not hardcoded.
+    for (const adapter of acEmitterManifest) {
+      expect(screen.getByText(adapter.package)).toBeInTheDocument();
+    }
+    expect(screen.getAllByText('Available').length).toBeGreaterThan(0);
+    expect(screen.getByText('Coming soon')).toBeInTheDocument();
   });
 });

--- a/packages/ui/src/pages/SettingsIntegrations.tsx
+++ b/packages/ui/src/pages/SettingsIntegrations.tsx
@@ -7,6 +7,7 @@
 //   - <McpTokensSection/>          — open core (MCP token management).
 //   - <CliInstallSection/>         — open core (install instructions).
 //   - <GenesisPromptSection/>      — open core (spec-201: one-paste agent setup).
+//   - <AcEmitterSection/>          — open core (spec-201: install the AC emitter).
 // The retired routes redirect here (see App.tsx).
 
 import { SlackIntegrationSection } from '../components/.ee/SlackIntegrationSection';
@@ -14,6 +15,7 @@ import { DiscordIntegrationSection } from '../components/.ee/DiscordIntegrationS
 import { McpTokensSection } from '../components/McpTokensSection';
 import { CliInstallSection } from '../components/CliInstallSection';
 import { GenesisPromptSection } from '../components/GenesisPromptSection';
+import { AcEmitterSection } from '../components/AcEmitterSection';
 
 export function SettingsIntegrations() {
   // AppShell's <main> is `overflow-hidden`, so each page owns its own scroll
@@ -33,6 +35,7 @@ export function SettingsIntegrations() {
         <McpTokensSection />
         <CliInstallSection />
         <GenesisPromptSection />
+        <AcEmitterSection />
       </div>
     </div>
   );

--- a/packages/ui/src/pages/SettingsIntegrations.tsx
+++ b/packages/ui/src/pages/SettingsIntegrations.tsx
@@ -6,12 +6,14 @@
 //   - <DiscordIntegrationSection/> — Enterprise (lives under components/.ee/, spec-138)
 //   - <McpTokensSection/>          — open core (MCP token management).
 //   - <CliInstallSection/>         — open core (install instructions).
+//   - <GenesisPromptSection/>      — open core (spec-201: one-paste agent setup).
 // The retired routes redirect here (see App.tsx).
 
 import { SlackIntegrationSection } from '../components/.ee/SlackIntegrationSection';
 import { DiscordIntegrationSection } from '../components/.ee/DiscordIntegrationSection';
 import { McpTokensSection } from '../components/McpTokensSection';
 import { CliInstallSection } from '../components/CliInstallSection';
+import { GenesisPromptSection } from '../components/GenesisPromptSection';
 
 export function SettingsIntegrations() {
   // AppShell's <main> is `overflow-hidden`, so each page owns its own scroll
@@ -30,6 +32,7 @@ export function SettingsIntegrations() {
         <DiscordIntegrationSection />
         <McpTokensSection />
         <CliInstallSection />
+        <GenesisPromptSection />
       </div>
     </div>
   );

--- a/packages/ui/src/utils/genesisPrompt.test.ts
+++ b/packages/ui/src/utils/genesisPrompt.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { tagAc } from '@memex-ai-ac/vitest';
+import {
+  buildClaudeCodePrompt,
+  buildCursorPrompt,
+  MEMEX_USAGE_GUIDANCE,
+} from './genesisPrompt';
+import { deriveMcpUrl } from './mcpUrl';
+
+const AC_ENV_DERIVED = 'mindset-prod/memex-building-itself/specs/spec-201/acs/ac-18';
+const AC_CLAUDE_CODE = 'mindset-prod/memex-building-itself/specs/spec-201/acs/ac-19';
+const AC_CURSOR = 'mindset-prod/memex-building-itself/specs/spec-201/acs/ac-20';
+
+const PROD_MCP_URL = deriveMcpUrl('https://memex.ai/api'); // https://memex.ai/mcp
+
+describe('spec-201 ac-19: Claude Code Genesis prompt', () => {
+  it('instructs the agent to register the MCP server via `claude mcp add` with the given URL', () => {
+    tagAc(AC_CLAUDE_CODE);
+    const prompt = buildClaudeCodePrompt(PROD_MCP_URL);
+    expect(prompt).toContain('claude mcp add');
+    expect(prompt).toContain(`memex ${PROD_MCP_URL}`);
+  });
+
+  it('instructs the agent to write the Memex-use clause into CLAUDE.md', () => {
+    tagAc(AC_CLAUDE_CODE);
+    const prompt = buildClaudeCodePrompt(PROD_MCP_URL);
+    expect(prompt).toContain('CLAUDE.md');
+    expect(prompt).toContain(MEMEX_USAGE_GUIDANCE);
+  });
+});
+
+describe('spec-201 ac-20: Cursor Genesis prompt', () => {
+  it('instructs the agent to add the server to Cursor MCP config with the given URL', () => {
+    tagAc(AC_CURSOR);
+    const prompt = buildCursorPrompt(PROD_MCP_URL);
+    expect(prompt).toContain('.cursor/mcp.json');
+    expect(prompt).toContain(`"url": "${PROD_MCP_URL}"`);
+  });
+
+  it('instructs the agent to add a .cursor/rules/*.mdc Memex-use rule', () => {
+    tagAc(AC_CURSOR);
+    const prompt = buildCursorPrompt(PROD_MCP_URL);
+    expect(prompt).toContain('.cursor/rules/memex.mdc');
+    expect(prompt).toContain(MEMEX_USAGE_GUIDANCE);
+  });
+});
+
+describe('spec-201 ac-18: prompts embed the derived MCP URL (per environment)', () => {
+  it('uses the int URL when given the int API URL', () => {
+    tagAc(AC_ENV_DERIVED);
+    const intUrl = deriveMcpUrl('https://int.memex.ai/api'); // https://int.memex.ai/mcp
+    expect(buildClaudeCodePrompt(intUrl)).toContain('https://int.memex.ai/mcp');
+    expect(buildCursorPrompt(intUrl)).toContain('https://int.memex.ai/mcp');
+  });
+});

--- a/packages/ui/src/utils/genesisPrompt.ts
+++ b/packages/ui/src/utils/genesisPrompt.ts
@@ -1,0 +1,58 @@
+// spec-201 dec-6: the "Genesis prompt" — a copy-pasteable first prompt a user
+// drops into a fresh Claude Code or Cursor session so the AGENT bootstraps
+// itself: it registers the Memex MCP server in its own config AND writes a
+// durable "how to use Memex" clause into the project's agent memory, so the
+// agent reaches for Memex on every future session.
+//
+// Pure string builders parameterised by the environment-derived MCP URL
+// (utils/mcpUrl.ts) so the prompt is correct per environment and the content is
+// unit-testable without rendering (ac-18/ac-19/ac-20).
+
+// The durable usage clause. This is the part nothing else does — the installer
+// and the Connectors Directory cover MCP registration, but only this teaches the
+// agent how to work with Memex on every subsequent session.
+export const MEMEX_USAGE_GUIDANCE = `## Using Memex
+
+Memex hosts our Specs — living plans that capture a piece of work's purpose, its decisions, and its tasks. Whenever you do spec work:
+
+- Call \`list_memexes\` and pick the right workspace — never assume the default.
+- Orient with \`list_docs\` / \`get_doc\` before mutating anything.
+- Resolve decisions before creating tasks; tasks exist only in the \`build\` phase.
+- Reference items by handle: spec-N, dec-N, t-N, ac-N.`;
+
+export function buildClaudeCodePrompt(mcpUrl: string): string {
+  return `Set up Memex in this repo:
+
+1. Register the Memex MCP server:
+   claude mcp add --transport http memex ${mcpUrl}
+   Then complete the browser sign-in if you're prompted to authorize.
+
+2. Add the following to this project's CLAUDE.md (create the file if it doesn't
+   exist; if a "Using Memex" section is already there, leave it):
+
+${MEMEX_USAGE_GUIDANCE}
+
+Then confirm both steps are done and that calling \`list_memexes\` works.`;
+}
+
+export function buildCursorPrompt(mcpUrl: string): string {
+  return `Set up Memex in this project:
+
+1. Add the Memex MCP server to Cursor's MCP config — \`.cursor/mcp.json\` in this
+   project (or \`~/.cursor/mcp.json\` for every project):
+   {
+     "mcpServers": {
+       "memex": { "url": "${mcpUrl}" }
+     }
+   }
+   Reload Cursor and complete the browser sign-in if you're prompted to authorize.
+
+2. Create \`.cursor/rules/memex.mdc\` with this content:
+   ---
+   description: How to use Memex for spec-driven work
+   alwaysApply: true
+   ---
+${MEMEX_USAGE_GUIDANCE}
+
+Then confirm both steps are done and that the Memex tools are available.`;
+}

--- a/packages/ui/src/utils/mcpUrl.test.ts
+++ b/packages/ui/src/utils/mcpUrl.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { deriveInstallBase, deriveMcpUrl } from './mcpUrl';
+
+const AC_ENV_DERIVED = 'mindset-prod/memex-building-itself/specs/spec-201/acs/ac-18';
+
+describe('spec-201 ac-18: MCP URL is derived from VITE_API_URL, not hardcoded', () => {
+  it('strips a trailing /api from a deployed API URL', () => {
+    tagAc(AC_ENV_DERIVED);
+    expect(deriveInstallBase('https://int.memex.ai/api')).toBe('https://int.memex.ai');
+    expect(deriveInstallBase('https://memex.ai/api/')).toBe('https://memex.ai');
+  });
+
+  it('appends /mcp to the derived host, per environment', () => {
+    tagAc(AC_ENV_DERIVED);
+    // int vs prod resolve to different hosts purely from the input — no hardcoded host.
+    expect(deriveMcpUrl('https://int.memex.ai/api')).toBe('https://int.memex.ai/mcp');
+    expect(deriveMcpUrl('https://memex.ai/api')).toBe('https://memex.ai/mcp');
+  });
+
+  it('falls back to the local server when VITE_API_URL is not an http URL', () => {
+    tagAc(AC_ENV_DERIVED);
+    expect(deriveMcpUrl(undefined)).toBe('http://localhost:8080/mcp');
+    expect(deriveMcpUrl('')).toBe('http://localhost:8080/mcp');
+  });
+});

--- a/packages/ui/src/utils/mcpUrl.ts
+++ b/packages/ui/src/utils/mcpUrl.ts
@@ -1,0 +1,23 @@
+// spec-201: single source for the Memex MCP endpoint URL shown in connect
+// instructions. Mirrors the derivation that originated in CliInstallSection
+// (spec-141): the MCP server is hosted on the same Cloud Run service as the API,
+// so strip a trailing `/api` from VITE_API_URL to get the host, then append
+// `/mcp`. In local dev (VITE_API_URL not an http URL) point at the local server.
+//
+// Kept as a pure function so the derivation is unit-testable per environment
+// (int vs prod) without booting the app — see mcpUrl.test.ts (ac-18).
+
+const LOCAL_BASE = 'http://localhost:8080';
+
+export function deriveInstallBase(apiUrl: string | undefined): string {
+  const url = apiUrl ?? '';
+  return url.startsWith('http') ? url.replace(/\/api\/?$/, '') : LOCAL_BASE;
+}
+
+export function deriveMcpUrl(apiUrl: string | undefined): string {
+  return `${deriveInstallBase(apiUrl)}/mcp`;
+}
+
+// Resolved-once values for the current environment.
+export const installBase = deriveInstallBase(import.meta.env.VITE_API_URL);
+export const mcpUrl = deriveMcpUrl(import.meta.env.VITE_API_URL);

--- a/packages/ui/src/utils/tenantUrl.ts
+++ b/packages/ui/src/utils/tenantUrl.ts
@@ -125,3 +125,44 @@ export function tenantPathFor(
 export function namespaceHomePath(slug: string): string {
   return `/${slug}/`;
 }
+
+// Minimal membership shape resolveNavTo needs (a subset of the session
+// membership rows).
+export interface MembershipForNav {
+  slug: string;
+  memexSlug: string;
+  kind: "personal" | "team";
+}
+
+// spec-201: resolve a tenant-relative path (e.g. "/keys") to an absolute,
+// memex-scoped URL. Extracted from AppShell so non-shell surfaces (the
+// Integrations AC-emitter section) can build the same deep links.
+//
+// Resolution order: (1) the tenant in the current path, (2) the namespace in
+// the current path matched against a membership, (3) the user's personal (or
+// first) membership, (4) the path unchanged when no tenant context exists.
+export function resolveNavTo(
+  toInTenant: string,
+  pathname: string,
+  memberships: MembershipForNav[] | undefined,
+): string {
+  const normalized = toInTenant.startsWith("/") ? toInTenant : `/${toInTenant}`;
+  const suffix = normalized === "/" ? "" : normalized;
+
+  const tenant = parseTenantFromPathname(pathname);
+  if (tenant) return `/${tenant.namespace}/${tenant.memex}${suffix}`;
+
+  const ns = parseNamespaceFromPathname(pathname);
+  if (ns && memberships) {
+    const m = memberships.find((row) => row.slug === ns);
+    if (m) return `/${ns}/${m.memexSlug}${suffix}`;
+  }
+
+  if (memberships && memberships.length > 0) {
+    const personal =
+      memberships.find((row) => row.kind === "personal") ?? memberships[0];
+    return `/${personal.slug}/${personal.memexSlug}${suffix}`;
+  }
+
+  return normalized;
+}


### PR DESCRIPTION
Implements [spec-201](https://memex.ai/mindset-prod/memex-building-itself/specs/spec-201) — surface MCP agent connect + AC-emitter install inside the Memex UI. All five tasks (t-1…t-5) complete; extends the consolidated `/settings/integrations` page rather than adding a new surface (spec-141 dec-3).

## What's in it

**Genesis prompt (t-1, dec-6)** — a copy-pasteable block on `/settings/integrations` that a user drops into a fresh **Claude Code** or **Cursor** session; the agent then registers the Memex MCP server in its own config **and** writes a durable Memex-use clause into `CLAUDE.md` (Claude Code) / `.cursor/rules/memex.mdc` (Cursor). Static copy — the agent does the bootstrap, not the UI. Syntax (`claude mcp add --transport http`, Cursor `mcp.json` `url`, `.mdc` frontmatter) verified against official Anthropic/Cursor docs.

**AC-emitter install section + adapter matrix (t-3/t-4, dec-2/dec-3)** — new `@memex/shared` `acEmitterManifest` (vitest available · pytest coming-soon · jest/go planned) with an anti-drift regression test; rendered as a status-badged matrix, with the install command, a deep link to the per-Memex Emission Keys panel, and a `tagAc()` example.

**claude.ai web + Cursor connect steps (t-2, dec-4)** — added to `CliInstallSection`, reusing the env-derived MCP URL.

**spec-73 carve (t-5, dec-5)** — connect/install ownership moved here; spec-73's CTA now deep-links to this page (Memex-side edit).

**Shared extractions** (no behaviour change): `utils/mcpUrl.ts` (the `VITE_API_URL`→`/mcp` derivation), `components/CodeBlock.tsx` (copy primitives), and `resolveNavTo` lifted into `utils/tenantUrl.ts`.

## AC verification

spec-201: **19/19 ACs verified** by tagged tests (scope ac-1…ac-4 + implementation ac-6…ac-16, ac-18…ac-21). dec-5 is intentionally AC-less (a documentation-coordination decision; its discharge is the t-5 doc edit). Two weak doc-state ACs (ac-5, ac-17) were scrapped after review rather than carried as unverifiable.

## Test plan

- [x] Full recursive suite green on `develop`-merged branch: **server 3481 · ui 1128 · shared 636 · cli 35 · ac-emit-vitest 69 · extractor 62** (0 failures).
- [x] `tsc -b` clean across packages.
- [x] `scaffold-drift-guard` passes — `genesisPrompt.ts` allowlisted as human-clipboard prose (sibling of the Init Prompts), not moved into `scaffold-data.ts`.
- [ ] Manual smoke on int after deploy: open `/settings/integrations`, confirm the four connect clients, the Genesis prompt tabs, and the adapter matrix render with the correct per-env MCP URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)