### PR TITLE
feat(footer): centralized phase-handoff delivery + auditable footer (spec-203)

### DIFF
--- a/packages/server/drizzle/0080_add_mcp_tool_calls_footer_text.sql
+++ b/packages/server/drizzle/0080_add_mcp_tool_calls_footer_text.sql
@@ -1,0 +1,8 @@
+-- spec-203 dec-3: footer-only audit capture.
+--
+-- Adds the column that stores the platform footer (everything after
+-- FOOTER_DELIMITER), captured UNCONDITIONALLY by services/mcp-telemetry.ts
+-- logToolCall. It never holds the full tool output — only the platform-injected
+-- guidance. Nullable: NULL when a response carried no footer (non-Spec docs,
+-- terse responses). Hand-migration (0009+) per packages/server/TEST.md.
+ALTER TABLE "mcp_tool_calls" ADD COLUMN IF NOT EXISTS "footer_text" text;

--- a/packages/server/src/__regression__/test-coverage-nudges.regression.test.ts
+++ b/packages/server/src/__regression__/test-coverage-nudges.regression.test.ts
@@ -85,12 +85,16 @@ describe("Channel 2 — phase-transition advice carries a coverage paragraph", (
 
   it("verbose get_doc prepends the coverage header for Specs", () => {
     // The wiring lives inside the get_doc handler — assert the helper is
-    // called there and its result is concatenated with the formatted state.
+    // called there and its result reaches the composer as a header-zone block.
     expect(toolSpecs).toMatch(
       /const coverageHeader = await formatCoverageHeader\([\s\S]*?doc\.docType,[\s\S]*?\);/,
     );
+    // spec-203 t-3: the coverage header is now passed to formatState as a
+    // header-zone InjectedBlock (the composer places it above the doc), not
+    // string-concatenated at the call site. Output is byte-identical; this
+    // guard pins the new wiring.
     expect(toolSpecs).toMatch(
-      /\$\{coverageHeader\}\$\{await formatState\(url, state, ctx\)\}/,
+      /\{ zone: "header", content: coverageHeader \}/,
     );
   });
 });

--- a/packages/server/src/agent/tool-specs.ts
+++ b/packages/server/src/agent/tool-specs.ts
@@ -161,6 +161,7 @@ import {
   formatStandard,
   renderStandardSectionBody,
   formatTerseSpecPhase,
+  type InjectedBlock,
 } from "../mcp/formatters.js";
 import { buildSketchBlock, type SketchAc } from "../mcp/ac-test-sketch.js";
 import { getStandard, flagDrift, proposeStandardChange } from "../services/standards.js";
@@ -190,9 +191,14 @@ import {
 import {
   blockerLines,
   toolManifest,
+  BASE_SCAFFOLD,
+  HANDOFF_BUTTON_BY_PHASE,
+  toButtonPrompt,
   type SpecPhase,
+  type Phase,
   type GuidanceBlock,
 } from "@memex/shared";
+import { claimFullHandoffDelivery } from "../services/handoff-delivery.js";
 import {
   assessNarrativeFreshness,
   markNarrativeConsolidated,
@@ -233,6 +239,15 @@ export interface ResolvedRef {
 
 export interface ToolCtx {
   userId: string;
+  /**
+   * spec-203 Layer 2 (dec-2): the MCP `Mcp-Session-Id` for this call, threaded
+   * from the dispatch layer (`createMcpServer`). The centralized footer machine
+   * (`formatState`) keys its once-per-(user, session, spec, phase) full-handoff
+   * delivery on it. Present only on the MCP surface; undefined for the in-app
+   * agent (which is primed via the shared_nudge channel, spec-123 dec-8) and for
+   * hand-rolled test ctxes — both keep the compressed-essence footer path.
+   */
+  sessionId?: string;
   /**
    * spec-156 ac-19: the surface invoking this handler — `mcp` for the MCP
    * server wrap (`mcp/tools.ts`), `in_app_agent` for the React agent loop
@@ -539,6 +554,10 @@ async function formatState(
   baseUrl: string,
   state: FullDocState,
   ctx?: ToolCtx,
+  // spec-203 dec-3 (t-3): tool-injected guidance blocks (coverage header, tag
+  // summary, nudges). Tools report these instead of concatenating around the
+  // call; the composer places them by zone. Absent for the many bare callers.
+  blocks?: readonly InjectedBlock[],
 ): Promise<string> {
   // The nudge channel only fires for Spec docs; skip the Org
   // blocks fetch for everything else to keep the cost off the hot path.
@@ -548,9 +567,34 @@ async function formatState(
     briefLike && ctx?.getOrgBlocksForNudge
       ? await ctx.getOrgBlocksForNudge()
       : undefined;
+  // spec-203 Layer 2 (dec-2): decide whether THIS response carries the full
+  // current-phase handoff (once per user+session+spec+phase, TTL-backstopped) or
+  // the compressed essence (Layer 1, every other response). Only the MCP surface
+  // threads a sessionId; the in-app agent (no sessionId) stays on the essence
+  // path. Resolve the interpolation context BEFORE claiming, so a context we
+  // can't build never burns a delivery.
+  let fullHandoff: string | undefined;
+  if (briefLike && ctx?.sessionId) {
+    const handoffButtonId = HANDOFF_BUTTON_BY_PHASE[state.doc.status as Phase];
+    const handoffContext = handoffButtonId
+      ? handoffInterpolationContext(baseUrl, state.doc)
+      : undefined;
+    if (
+      handoffButtonId &&
+      handoffContext &&
+      claimFullHandoffDelivery(ctx.userId, ctx.sessionId, state.doc.id, state.doc.status)
+    ) {
+      fullHandoff =
+        toButtonPrompt({
+          dataset: BASE_SCAFFOLD,
+          buttonId: handoffButtonId,
+          context: handoffContext,
+        }) ?? undefined;
+    }
+  }
   const nudge =
-    briefLike && (ctx?.toolName || orgBlocks)
-      ? { tool: ctx?.toolName, orgBlocks }
+    briefLike && (ctx?.toolName || orgBlocks || fullHandoff)
+      ? { tool: ctx?.toolName, orgBlocks, fullHandoff }
       : undefined;
   // spec-121 mechanism 1 — feed the build-phase nag its live AC-state lookup.
   // Only fetched for a Spec in `build` (the nag's only phase), reusing the same
@@ -579,7 +623,41 @@ async function formatState(
     acVerifications,
     // spec-136 t-4: the Spec's tags, rendered as a one-line strip in the header.
     state.tags,
+    // spec-203 dec-3 (t-3): tool-injected guidance, placed by the composer.
+    blocks,
   );
+}
+
+// spec-203 Layer 2 (dec-2): build the {namespace}/{memex}/{handle}/{title}/{url}
+// interpolation context the full handoff prompt needs, from the workspace URL
+// (origin/<namespace>/<memex>, the same `baseUrl` formatState already holds) and
+// the doc. Returns undefined when the URL can't be parsed (e.g. the in-app
+// agent's no-op empty workspace URL), in which case the footer keeps the
+// token-free essence rather than emitting an un-interpolated full prompt.
+function handoffInterpolationContext(
+  workspaceUrl: string,
+  doc: { handle: string; title: string },
+): { namespace: string; memex: string; handle: string; title: string; url: string } | undefined {
+  if (!workspaceUrl) return undefined;
+  let pathname: string;
+  try {
+    pathname = new URL(workspaceUrl).pathname;
+  } catch {
+    return undefined;
+  }
+  const segs = pathname.split("/").filter(Boolean);
+  if (segs.length < 2) return undefined;
+  const memex = segs[segs.length - 1];
+  const namespace = segs[segs.length - 2];
+  return {
+    namespace,
+    memex,
+    handle: doc.handle,
+    title: doc.title,
+    // Spec docs render under /specs/ (refs.ts DB_DOC_TYPE_TO_URL); the handoff
+    // only fires for specs, so the path segment is fixed.
+    url: `${workspaceUrl}/specs/${doc.handle}`,
+  };
 }
 
 // Per doc-12 t-6 / t-7 — soft guidance nudge appended to forward Spec
@@ -1027,7 +1105,11 @@ export const toolSpecs: ToolSpec[] = [
           doc.id,
           doc.docType,
         );
-        return `${coverageHeader}${await formatState(url, state, ctx)}`;
+        // spec-203 dec-3 (t-3): the coverage header is a header-zone block — the
+        // composer places it above the doc; this handler no longer concatenates.
+        return await formatState(url, state, ctx, [
+          { zone: "header", content: coverageHeader },
+        ]);
       }
 
       // Terse: agent already has the doc context injected by the system
@@ -1329,7 +1411,12 @@ export const toolSpecs: ToolSpec[] = [
       if (ctx.verbose) {
         const state = await fullDocState(memexId, before.id);
         const url = await ctx.workspaceUrl(memexId);
-        return `${await formatState(url, state, ctx)}${tagSuffix}${nudge}`;
+        // spec-203 dec-3 (t-3): tag summary + transition nudge are footer-zone
+        // blocks, placed after the machine footer by the composer (same order).
+        return await formatState(url, state, ctx, [
+          { zone: "footer", content: tagSuffix },
+          { zone: "footer", content: nudge },
+        ]);
       }
       const fresh = await getDoc(memexId, before.id);
       // Per dec-1: on a status change include the deterministic phase header so
@@ -2944,8 +3031,16 @@ export const toolSpecs: ToolSpec[] = [
         const fresh = await getTask(memexId, taskUuid);
         const state = await fullDocState(memexId, fresh.docId);
         const url = await ctx.workspaceUrl(memexId);
-        const base = await formatState(url, state, ctx);
-        return status === "complete" ? `${base}\n\n> ${COMPLETION_NUDGE}` : base;
+        // spec-203 dec-3 (t-3): the completion nudge is a footer-zone block,
+        // present only when the task was completed.
+        return await formatState(
+          url,
+          state,
+          ctx,
+          status === "complete"
+            ? [{ zone: "footer", content: `\n\n> ${COMPLETION_NUDGE}` }]
+            : [],
+        );
       }
 
       if (messages.length === 0) {
@@ -3396,7 +3491,10 @@ export const toolSpecs: ToolSpec[] = [
       if (ctx.verbose) {
         const state = await fullDocState(memexId, doc.id);
         const url = await ctx.workspaceUrl(memexId);
-        return `${await formatState(url, state, ctx)}${nudge}`;
+        // spec-203 dec-3 (t-3): the transition nudge is a footer-zone block.
+        return await formatState(url, state, ctx, [
+          { zone: "footer", content: nudge },
+        ]);
       }
       const fresh = await getDoc(memexId, doc.id);
       // Per dec-1 / t-8: replace the best-effort `nudge` with the deterministic

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -2455,6 +2455,11 @@ export const mcpToolCalls = pgTable(
     // Dev-only capture — gated by isDevMode() in services/telemetry.ts.
     // NULL in production until per-customer opt-in lands.
     resultText: text("result_text"),
+    // spec-203 dec-3: the platform footer (everything after FOOTER_DELIMITER),
+    // captured UNCONDITIONALLY (prod included) by splitting the result — never
+    // the full tool output. NULL when the response carried no footer (non-Spec
+    // docs, terse responses). The audit trail of exactly what guidance we inject.
+    footerText: text("footer_text"),
   },
   (table) => [
     index("mcp_tool_calls_session_idx").on(table.sessionId, table.createdAt),

--- a/packages/server/src/mcp/footer-delimiter.spec-203.test.ts
+++ b/packages/server/src/mcp/footer-delimiter.spec-203.test.ts
@@ -1,0 +1,96 @@
+// spec-203 dec-3 (t-4) ac-11: the footer delimiter is the single source of truth
+// that makes the platform footer machine-separable from the tool's real output.
+
+import { describe, it, expect } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { FOOTER_DELIMITER, splitToolResult } from "./footer-delimiter.js";
+import { formatFullDocState } from "./formatters.js";
+import type { Doc, DocSection } from "../db/schema.js";
+
+const AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-203/acs/ac-${n}`;
+
+const baseDate = new Date("2026-03-25T12:00:00Z");
+
+function makeSpec(status: string): Doc & { sections: DocSection[] } {
+  return {
+    id: "doc-uuid-1",
+    memexId: "test-account",
+    handle: "spec-1",
+    title: "Test Spec",
+    docType: "spec",
+    status,
+    parentDocId: null,
+    createdByUserId: null,
+    createdAt: baseDate,
+    statusChangedAt: baseDate,
+    archivedAt: null,
+    pausedAt: null,
+    narrativeLastConsolidatedAt: null,
+    isDemo: false,
+    sections: [
+      {
+        id: "section-uuid-1",
+        docId: "doc-uuid-1",
+        sectionType: "overview",
+        title: "Overview",
+        description: null,
+        content: "Some overview content.",
+        seq: 1,
+        preamble: null,
+        position: 1,
+        status: "active",
+        previousStatus: null,
+        createdAt: baseDate,
+        updatedAt: baseDate,
+      },
+    ],
+  };
+}
+
+describe("splitToolResult", () => {
+  it("splits a result into body + footer at the delimiter", () => {
+    tagAc(AC(11));
+    const result = `the real tool output\n${FOOTER_DELIMITER}\nthe platform footer`;
+    const { body, footer } = splitToolResult(result);
+    expect(body).toBe("the real tool output\n");
+    expect(footer).toBe("the platform footer");
+  });
+
+  it("returns footer=null when no delimiter is present (no footer injected)", () => {
+    tagAc(AC(11));
+    const { body, footer } = splitToolResult("just tool output, no footer");
+    expect(body).toBe("just tool output, no footer");
+    expect(footer).toBeNull();
+  });
+
+  it("splits on the FIRST delimiter occurrence", () => {
+    tagAc(AC(11));
+    const { footer } = splitToolResult(`a ${FOOTER_DELIMITER} b ${FOOTER_DELIMITER} c`);
+    expect(footer).toContain("b ");
+    expect(footer).toContain("c");
+  });
+});
+
+describe("formatFullDocState — footer delimiter boundary (spec-203 dec-3)", () => {
+  it("emits the delimiter exactly once at the doc-state→footer boundary for a Spec", () => {
+    tagAc(AC(11));
+    const out = formatFullDocState(makeSpec("build"), [], []);
+    const occurrences = out.split(FOOTER_DELIMITER).length - 1;
+    expect(occurrences).toBe(1);
+    // Everything before the delimiter is the tool's real output (the doc state);
+    // splitting recovers the platform footer (which carries the phase handoff).
+    const { body, footer } = splitToolResult(out);
+    expect(body).toContain("# Test Spec");
+    expect(body).not.toContain("BUILD handoff (full prompt:");
+    expect(footer).toContain("BUILD handoff (full prompt:");
+  });
+
+  it("emits NO delimiter for a non-Spec doc (no footer to separate)", () => {
+    tagAc(AC(11));
+    const doc = { ...makeSpec("build"), docType: "document" };
+    const out = formatFullDocState(doc, [], []);
+    expect(out).not.toContain(FOOTER_DELIMITER);
+    expect(splitToolResult(out).footer).toBeNull();
+  });
+});

--- a/packages/server/src/mcp/footer-delimiter.ts
+++ b/packages/server/src/mcp/footer-delimiter.ts
@@ -1,0 +1,34 @@
+// spec-203 dec-3: the ONE source of truth for the in-chat footer boundary.
+//
+// The footer (platform-injected phase guidance / handoff / nudges) rides inside
+// the single MCP `content[0].text` blob — there is no separate transport field.
+// This delimiter marks where the tool's real output ends and the platform footer
+// begins, so the footer is machine-separable (for the audit trail) and visibly
+// labelled (for the agent).
+//
+// It is deliberately ONE knob. If the labelled banner ever provokes adverse agent
+// behaviour, revert it to a minimal marker (e.g. `"---"` or `"_____"`) HERE and
+// nothing else changes: `formatFullDocState` emits this exact string at the
+// boundary, and the audit split (`splitToolResult`) reads the same constant.
+export const FOOTER_DELIMITER =
+  "##### MEMEX FOOTER · platform guidance, not tool output #####";
+
+/**
+ * Split a tool-result string at the footer boundary. Returns the tool's real
+ * output (`body`) and the platform footer (`footer` — everything after the first
+ * delimiter, leading whitespace trimmed). `footer` is `null` when no delimiter is
+ * present, i.e. no footer was injected (non-Spec docs, terse responses). The
+ * first occurrence wins; the labelled delimiter is collision-proof against real
+ * document content by construction.
+ */
+export function splitToolResult(result: string): {
+  body: string;
+  footer: string | null;
+} {
+  const idx = result.indexOf(FOOTER_DELIMITER);
+  if (idx === -1) return { body: result, footer: null };
+  return {
+    body: result.slice(0, idx),
+    footer: result.slice(idx + FOOTER_DELIMITER.length).replace(/^\s+/, ""),
+  };
+}

--- a/packages/server/src/mcp/formatters.handoff-essence.spec-203.test.ts
+++ b/packages/server/src/mcp/formatters.handoff-essence.spec-203.test.ts
@@ -1,0 +1,99 @@
+// spec-203 dec-1 (Layer 1): the in-chat footer machine emits the current
+// phase's handoff essence on every spec-tool response.
+//
+// formatFullDocState is the one function ~22 spec-touching tools pass through
+// to compose their footer (the Spec's "discovery"). These tests prove the
+// compressed handoff essence now rides that footer for each forward phase —
+// closing the spec-120 gap where a chat-driven build agent never saw the
+// handoff's "minting tasks is your job / recommend verify" steps — and stays
+// absent for draft/done.
+
+import { describe, it, expect } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { formatFullDocState } from "./formatters.js";
+import { FOOTER_DELIMITER } from "./footer-delimiter.js";
+import type { Doc, DocSection } from "../db/schema.js";
+
+const AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-203/acs/ac-${n}`;
+
+const baseDate = new Date("2026-03-25T12:00:00Z");
+
+function makeSpec(status: string): Doc & { sections: DocSection[] } {
+  return {
+    id: "doc-uuid-1",
+    memexId: "test-account",
+    handle: "spec-1",
+    title: "Test Spec",
+    docType: "spec",
+    status,
+    parentDocId: null,
+    createdByUserId: null,
+    createdAt: baseDate,
+    statusChangedAt: baseDate,
+    archivedAt: null,
+    pausedAt: null,
+    narrativeLastConsolidatedAt: null,
+    isDemo: false,
+    sections: [
+      {
+        id: "section-uuid-1",
+        docId: "doc-uuid-1",
+        sectionType: "overview",
+        title: "Overview",
+        description: null,
+        content: "Some overview content.",
+        seq: 1,
+        preamble: null,
+        position: 1,
+        status: "active",
+        previousStatus: null,
+        createdAt: baseDate,
+        updatedAt: baseDate,
+      },
+    ],
+  };
+}
+
+describe("formatFullDocState — phase handoff essence in the footer (spec-203)", () => {
+  it("emits the BUILD handoff essence on a build-phase Spec", () => {
+    tagAc(AC(7));
+    const out = formatFullDocState(makeSpec("build"), [], []);
+    expect(out).toContain('BUILD handoff (full prompt: the "Build handoff" button)');
+    expect(out).toContain("deriving the task graph");
+    expect(out).toContain("recommend `verify`");
+  });
+
+  it("emits the SPECIFY handoff essence on a specify-phase Spec", () => {
+    tagAc(AC(7));
+    tagAc(AC(4)); // scope: phase-general (specify gets its handoff)
+    const out = formatFullDocState(makeSpec("specify"), [], []);
+    expect(out).toContain('SPECIFY handoff (full prompt: the "Plan handoff" button)');
+  });
+
+  it("emits the VERIFY handoff essence on a verify-phase Spec", () => {
+    const out = formatFullDocState(makeSpec("verify"), [], []);
+    expect(out).toContain('VERIFY handoff (full prompt: the "Verify handoff" button)');
+  });
+
+  it("emits NO handoff essence on a draft-phase Spec", () => {
+    tagAc(AC(7));
+    const out = formatFullDocState(makeSpec("draft"), [], []);
+    expect(out).not.toContain("handoff (full prompt:");
+  });
+
+  it("emits NO handoff essence on a done-phase Spec", () => {
+    tagAc(AC(7));
+    tagAc(AC(4)); // scope: phase-general (done surfaces none)
+    const out = formatFullDocState(makeSpec("done"), [], []);
+    expect(out).not.toContain("handoff (full prompt:");
+  });
+
+  it("places the essence after the footer delimiter (in the footer, not the body)", () => {
+    const out = formatFullDocState(makeSpec("build"), [], []);
+    const delimIdx = out.indexOf(FOOTER_DELIMITER);
+    const essenceIdx = out.indexOf("BUILD handoff (full prompt:");
+    expect(delimIdx).toBeGreaterThanOrEqual(0);
+    expect(essenceIdx).toBeGreaterThan(delimIdx);
+  });
+});

--- a/packages/server/src/mcp/formatters.handoff-fulldelivery.spec-203.test.ts
+++ b/packages/server/src/mcp/formatters.handoff-fulldelivery.spec-203.test.ts
@@ -1,0 +1,79 @@
+// spec-203 Layer 2 (dec-2): the footer renderer is dumb — when the centralized
+// machine hands it a pre-resolved FULL handoff via `nudge.fullHandoff`, it emits
+// that in place of the Layer 1 compressed essence; otherwise it emits the
+// essence. This proves the either/or at the renderer boundary (formatFullDocState
+// is exported; the decision logic itself is covered by handoff-delivery.test.ts,
+// and the end-to-end wiring by the integration test).
+
+import { describe, it, expect } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { formatFullDocState } from "./formatters.js";
+import type { Doc, DocSection } from "../db/schema.js";
+
+const AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-203/acs/ac-${n}`;
+
+const baseDate = new Date("2026-03-25T12:00:00Z");
+
+function makeSpec(status: string): Doc & { sections: DocSection[] } {
+  return {
+    id: "doc-uuid-1",
+    memexId: "test-account",
+    handle: "spec-1",
+    title: "Test Spec",
+    docType: "spec",
+    status,
+    parentDocId: null,
+    createdByUserId: null,
+    createdAt: baseDate,
+    statusChangedAt: baseDate,
+    archivedAt: null,
+    pausedAt: null,
+    narrativeLastConsolidatedAt: null,
+    isDemo: false,
+    sections: [
+      {
+        id: "section-uuid-1",
+        docId: "doc-uuid-1",
+        sectionType: "overview",
+        title: "Overview",
+        description: null,
+        content: "Some overview content.",
+        seq: 1,
+        preamble: null,
+        position: 1,
+        status: "active",
+        previousStatus: null,
+        createdAt: baseDate,
+        updatedAt: baseDate,
+      },
+    ],
+  };
+}
+
+const ESSENCE_MARKER = 'BUILD handoff (full prompt: the "Build handoff" button)';
+const FULL_SENTINEL = "FULL-HANDOFF-SENTINEL-You-are-working-in-Memex";
+
+describe("formatFullDocState — full-handoff vs essence in the footer (spec-203 L2)", () => {
+  it("emits the provided full handoff in place of the essence", () => {
+    tagAc(AC(9));
+    const out = formatFullDocState(
+      makeSpec("build"),
+      [],
+      [],
+      undefined,
+      undefined,
+      undefined,
+      { fullHandoff: FULL_SENTINEL },
+    );
+    expect(out).toContain(FULL_SENTINEL);
+    expect(out).not.toContain(ESSENCE_MARKER); // essence suppressed when full is delivered
+  });
+
+  it("falls back to the compressed essence when no full handoff is provided", () => {
+    tagAc(AC(9));
+    const out = formatFullDocState(makeSpec("build"), [], []);
+    expect(out).toContain(ESSENCE_MARKER);
+    expect(out).not.toContain(FULL_SENTINEL);
+  });
+});

--- a/packages/server/src/mcp/formatters.injected-blocks.spec-203.test.ts
+++ b/packages/server/src/mcp/formatters.injected-blocks.spec-203.test.ts
@@ -1,0 +1,111 @@
+// spec-203 dec-3 (t-3) ac-13: formatFullDocState is the single composer of the
+// response envelope. Tools inject guidance as InjectedBlock[] tagged with a zone;
+// the composer places header blocks before the doc and footer blocks after the
+// machine footer, by zone alone — no tool-name logic.
+
+import { describe, it, expect } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { formatFullDocState, type InjectedBlock } from "./formatters.js";
+import { FOOTER_DELIMITER } from "./footer-delimiter.js";
+import type { Doc, DocSection } from "../db/schema.js";
+
+const AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-203/acs/ac-${n}`;
+
+const baseDate = new Date("2026-03-25T12:00:00Z");
+
+function makeSpec(): Doc & { sections: DocSection[] } {
+  return {
+    id: "doc-uuid-1",
+    memexId: "test-account",
+    handle: "spec-1",
+    title: "Test Spec",
+    docType: "spec",
+    status: "build",
+    parentDocId: null,
+    createdByUserId: null,
+    createdAt: baseDate,
+    statusChangedAt: baseDate,
+    archivedAt: null,
+    pausedAt: null,
+    narrativeLastConsolidatedAt: null,
+    isDemo: false,
+    sections: [
+      {
+        id: "section-uuid-1",
+        docId: "doc-uuid-1",
+        sectionType: "overview",
+        title: "Overview",
+        description: null,
+        content: "Some overview content.",
+        seq: 1,
+        preamble: null,
+        position: 1,
+        status: "active",
+        previousStatus: null,
+        createdAt: baseDate,
+        updatedAt: baseDate,
+      },
+    ],
+  };
+}
+
+// Helper: call with a trailing blocks arg (positional #10).
+function render(blocks?: InjectedBlock[]): string {
+  return formatFullDocState(
+    makeSpec(),
+    [],
+    [],
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    blocks,
+  );
+}
+
+describe("formatFullDocState — injected-block envelope (spec-203 dec-3)", () => {
+  it("places a header block before the doc title", () => {
+    tagAc(AC(13));
+    const out = render([{ zone: "header", content: "HEADER-BLOCK-X\n\n" }]);
+    expect(out.indexOf("HEADER-BLOCK-X")).toBeGreaterThanOrEqual(0);
+    expect(out.indexOf("HEADER-BLOCK-X")).toBeLessThan(out.indexOf("# Test Spec"));
+  });
+
+  it("places a footer block after the machine footer (below the delimiter)", () => {
+    tagAc(AC(13));
+    const out = render([{ zone: "footer", content: "FOOTER-BLOCK-Y" }]);
+    expect(out.indexOf("FOOTER-BLOCK-Y")).toBeGreaterThan(out.indexOf(FOOTER_DELIMITER));
+    // …and after the handoff that the machine footer carries.
+    expect(out.indexOf("FOOTER-BLOCK-Y")).toBeGreaterThan(
+      out.indexOf("BUILD handoff (full prompt:"),
+    );
+  });
+
+  it("renders multiple footer blocks in array order", () => {
+    tagAc(AC(13));
+    const out = render([
+      { zone: "footer", content: "FIRST" },
+      { zone: "footer", content: "SECOND" },
+    ]);
+    expect(out.indexOf("FIRST")).toBeLessThan(out.indexOf("SECOND"));
+  });
+
+  it("composes header and footer together, by zone alone (no tool-name logic)", () => {
+    tagAc(AC(13));
+    const out = render([
+      { zone: "footer", content: "THE-FOOTER" },
+      { zone: "header", content: "THE-HEADER\n\n" },
+    ]);
+    // Declared order is footer-then-header, but ZONE decides placement:
+    expect(out.indexOf("THE-HEADER")).toBeLessThan(out.indexOf("# Test Spec"));
+    expect(out.indexOf("THE-FOOTER")).toBeGreaterThan(out.indexOf(FOOTER_DELIMITER));
+  });
+
+  it("with no blocks, output is byte-identical to omitting the arg", () => {
+    tagAc(AC(13));
+    expect(render([])).toBe(render(undefined));
+  });
+});

--- a/packages/server/src/mcp/formatters.ts
+++ b/packages/server/src/mcp/formatters.ts
@@ -14,11 +14,13 @@ import type {
   AffectedStandardMatch,
 } from "../services/standards.js";
 import { buildChildRef, buildDocRef, docTypeForUrl } from "./refs.js";
+import { FOOTER_DELIMITER } from "./footer-delimiter.js";
 import { formatRef } from "../services/refs.js";
 import {
   BASE_SCAFFOLD,
   BUILD_AC_NAG_PROSE,
   toNudge,
+  toHandoffEssence,
   type GuidanceBlock,
   type PhaseNode,
 } from "@memex/shared";
@@ -116,6 +118,23 @@ interface AcceptanceCriterion {
 export interface NudgeContext {
   tool?: string;
   orgBlocks?: readonly GuidanceBlock[];
+  // spec-203 Layer 2 (dec-2): when set, the footer emits this pre-resolved FULL
+  // handoff (the interpolated copy-button prompt) in place of the compressed
+  // essence. The delivery decision + interpolation happen up in the centralized
+  // formatState machine; the renderer stays dumb and emits whatever it's handed.
+  fullHandoff?: string;
+}
+
+// spec-203 dec-3 (t-3): a piece of platform-injected guidance a tool reports for
+// the composer to place. The tool supplies the rendered `content` and declares
+// its `zone` (above the doc / below it) — placement is data, NOT a tool-name
+// conditional in the composer. Header blocks land before the doc title; footer
+// blocks land after the machine footer (phase guidance / handoff), inside the
+// delimited region. The composer never inspects which tool sent a block.
+export type InjectedZone = "header" | "footer";
+export interface InjectedBlock {
+  zone: InjectedZone;
+  content: string;
 }
 
 // spec-136 t-4: one-line tag strip for a doc-state header. Renders structured
@@ -139,6 +158,11 @@ export function formatFullDocState(
   // spec-136 t-4: appended LAST so the existing positional callers (and the
   // develop nudge/acVerifications params at 7/8) keep compiling unchanged.
   tags?: Tag[],
+  // spec-203 dec-3 (t-3): tool-injected guidance blocks. The composer is the ONE
+  // place that lays out the response envelope — header blocks before the doc,
+  // footer blocks after the machine footer — driven by each block's zone, never
+  // by tool name. Absent for the many callers that inject nothing.
+  blocks?: readonly InjectedBlock[],
 ): string {
   const lines: string[] = [];
 
@@ -196,12 +220,24 @@ export function formatFullDocState(
     lines.push("");
   }
 
-  // Phase-aware guidance (Spec docs)
+  // Phase-aware guidance (Spec docs) — the machine's own always-on footer.
   if (doc.docType === "spec") {
     lines.push(formatSpecGuidance(doc, decisions, tasks, nudge, acVerifications));
   }
 
-  return lines.join("\n").trimEnd();
+  // spec-203 dec-3 (t-3): the envelope. Header blocks wrap above the doc, footer
+  // blocks after the machine footer, placement by zone alone. Joining each zone
+  // with "" preserves the exact bytes the call sites used to concatenate.
+  const body = lines.join("\n").trimEnd();
+  const headerStr = (blocks ?? [])
+    .filter((b) => b.zone === "header")
+    .map((b) => b.content)
+    .join("");
+  const footerStr = (blocks ?? [])
+    .filter((b) => b.zone === "footer")
+    .map((b) => b.content)
+    .join("");
+  return `${headerStr}${body}${footerStr}`;
 }
 
 // ══════════════════════════════════════
@@ -1048,7 +1084,11 @@ function renderSpecPhaseGuidance(
   nudge?: NudgeContext,
   acVerifications?: AcWithVerification[],
 ): string {
-  const lines: string[] = ["---"];
+  // spec-203 dec-3: the footer boundary. Replaces the ambiguous markdown `---`
+  // with the single FOOTER_DELIMITER constant so the platform footer is
+  // machine-separable from the tool's real output (audit trail) and visibly
+  // marked for the agent. One knob — see footer-delimiter.ts.
+  const lines: string[] = [FOOTER_DELIMITER];
   const openDecs = decs.filter((d) => d.status === "open");
   const resolvedDecs = decs.filter((d) => d.status === "resolved");
   const ready = tasksList.filter((t) => !t.blocked && t.status === "not_started");
@@ -1069,6 +1109,20 @@ function renderSpecPhaseGuidance(
   });
   if (nudgeText.length > 0) {
     lines.push(nudgeText);
+  }
+
+  // spec-203: the current phase's handoff in the footer. Layer 2 (the
+  // centralized formatState machine) hands us the FULL interpolated handoff to
+  // deliver once per (user, session, spec, phase) via `nudge.fullHandoff`;
+  // absent that, Layer 1 emits the compressed, token-free essence on every
+  // response. Either way a chat-driven agent (which never copies the button)
+  // gets the phase's handoff. Job-then-state: the handoff ("here's your job this
+  // phase") precedes the dynamic open-decision / task counts below ("here's the
+  // current state"). draft/done yield no essence.
+  const handoffBlock = nudge?.fullHandoff ?? toHandoffEssence(BASE_SCAFFOLD, phase);
+  if (handoffBlock) {
+    lines.push("");
+    lines.push(handoffBlock);
   }
 
   // Dynamic per-Spec counts — stay in code because they're derived from the

--- a/packages/server/src/mcp/spec-tools.integration.test.ts
+++ b/packages/server/src/mcp/spec-tools.integration.test.ts
@@ -21,11 +21,13 @@ import {
   decisions,
   tasks,
   users,
+  mcpSessions,
 } from "../db/schema.js";
 import { createMcpServer } from "./tools.js";
 import { createDocDraft, updateDocStatus } from "../services/documents.js";
 import { createTask } from "../services/tasks.js";
 import { _clearRecentAssessments } from "../services/phase-assessment.js";
+import { _clearHandoffDeliveries } from "../services/handoff-delivery.js";
 import { tagAc } from "@memex-ai-ac/vitest";
 
 const created = {
@@ -553,5 +555,87 @@ describe("list_specs active-only filter (doc-12 t-15)", () => {
     expect(text).not.toContain("DoneSpec");
     expect(text).not.toContain("PausedSpec");
     expect(text).not.toContain("ArchivedSpec");
+  });
+});
+
+// spec-203 Layer 2 (dec-2) ac-10: the end-to-end delivery decision through the
+// real createMcpServer dispatch — proves session_id is threaded from dispatch
+// into ctx and the footer delivers the FULL handoff once per (session, spec,
+// phase) then the essence, re-delivering for a new session.
+const AC203 = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-203/acs/ac-${n}`;
+
+async function callToolWithSession(
+  userId: string,
+  sessionId: string,
+  name: string,
+  args: Record<string, unknown>,
+): Promise<ToolResult> {
+  const server = createMcpServer(userId, undefined, sessionId);
+  const registry = (
+    server as unknown as { _registeredTools: Record<string, RegisteredToolLike> }
+  )._registeredTools;
+  const tool = registry[name];
+  if (!tool) throw new Error(`Tool not registered: ${name}`);
+  const withVerbose = "verbose" in args ? args : { ...args, verbose: true };
+  return await tool.handler(withVerbose, {} as unknown);
+}
+
+describe("phase handoff full-vs-essence delivery (spec-203 Layer 2, ac-10)", () => {
+  // Static opening of the full handoff prompt + a STEP-1 detail that lives ONLY
+  // in the full text, never in the compressed essence.
+  const FULL_MARKER = "You are working in Memex";
+  const FULL_ONLY = "minting them is your job";
+  const ESSENCE_MARKER = 'BUILD handoff (full prompt: the "Build handoff" button)';
+
+  let buildSpecRef: string;
+
+  beforeAll(async () => {
+    _clearHandoffDeliveries();
+    const doc = await createDocDraft(actor.account.id, "HandoffDelivery Spec", "P", "spec");
+    created.docs.push(doc.id);
+    // Drop straight to build so the footer carries the build handoff (the test
+    // exercises the delivery machine, not the specify→build gate).
+    await db.update(documents).set({ status: "build" }).where(eq(documents.id, doc.id));
+    // Seed the MCP sessions so the error-swallowing tool-call telemetry insert
+    // (which FK-references mcp_sessions) stays quiet during the test.
+    await db
+      .insert(mcpSessions)
+      .values([
+        { sessionId: "handoff-sess-A", userId: actor.user.id },
+        { sessionId: "handoff-sess-B", userId: actor.user.id },
+      ])
+      .onConflictDoNothing();
+    buildSpecRef = `${actor.account.slug}/main/specs/${doc.handle}`;
+  });
+
+  it("delivers the FULL handoff on the first response of a session+phase, the essence after", async () => {
+    tagAc(AC203(10));
+    // Scope outcomes this end-to-end run also proves: a chat-driven agent gets
+    // the handoff in the footer (ac-1), and full-once-then-essence (ac-3).
+    tagAc(AC203(1));
+    tagAc(AC203(3));
+    const first = await callToolWithSession(actor.user.id, "handoff-sess-A", "get_doc", {
+      ref: buildSpecRef,
+    });
+    const firstText = first.content[0].text;
+    expect(firstText).toContain(FULL_MARKER);
+    expect(firstText).toContain(FULL_ONLY);
+    expect(firstText).not.toContain(ESSENCE_MARKER);
+
+    const second = await callToolWithSession(actor.user.id, "handoff-sess-A", "get_doc", {
+      ref: buildSpecRef,
+    });
+    const secondText = second.content[0].text;
+    expect(secondText).toContain(ESSENCE_MARKER);
+    expect(secondText).not.toContain(FULL_MARKER);
+  });
+
+  it("re-delivers the FULL handoff for a different session", async () => {
+    tagAc(AC203(10));
+    const fresh = await callToolWithSession(actor.user.id, "handoff-sess-B", "get_doc", {
+      ref: buildSpecRef,
+    });
+    expect(fresh.content[0].text).toContain(FULL_MARKER);
   });
 });

--- a/packages/server/src/mcp/tools.ts
+++ b/packages/server/src/mcp/tools.ts
@@ -354,6 +354,12 @@ export function createMcpServer(
       async (input: Record<string, unknown>) => {
         const ctx: ToolCtx = {
           userId,
+          // spec-203 Layer 2 (dec-2): thread the dispatch-layer session id into
+          // ctx so the centralized footer machine can key its once-per-(user,
+          // session, spec, phase) full-handoff delivery on it. Undefined in
+          // stateless/test paths (createMcpServer's sessionId param), which is
+          // exactly when the footer falls back to the compressed essence.
+          sessionId,
           // spec-156 ac-19: this is the MCP surface. Handlers that derive a
           // mutate() channel from ctx (update_doc's tag writes) read this so
           // Pulse attributes MCP-driven activity to the `mcp` channel.

--- a/packages/server/src/services/handoff-delivery.test.ts
+++ b/packages/server/src/services/handoff-delivery.test.ts
@@ -1,0 +1,68 @@
+// spec-203 Layer 2 (dec-2): the full-vs-essence delivery decision.
+//
+// `claimFullHandoffDelivery` is the trigger: the full handoff rides the footer
+// once per (user, session, spec, phase), re-firing on phase change (phase is in
+// the key) and after the TTL idle backstop. `now` is injected so these tests are
+// deterministic without touching the clock.
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import {
+  claimFullHandoffDelivery,
+  _clearHandoffDeliveries,
+  FULL_HANDOFF_TTL_MS,
+} from "./handoff-delivery.js";
+
+const AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-203/acs/ac-${n}`;
+
+const U = "user-1";
+const S = "session-1";
+const SPEC = "spec-1";
+const T0 = 1_000_000;
+
+describe("claimFullHandoffDelivery", () => {
+  beforeEach(() => _clearHandoffDeliveries());
+
+  it("delivers the full handoff on the first call for a (user, session, spec, phase)", () => {
+    tagAc(AC(8));
+    expect(claimFullHandoffDelivery(U, S, SPEC, "build", T0)).toBe(true);
+  });
+
+  it("shows the essence (false) on repeat calls within the TTL", () => {
+    tagAc(AC(8));
+    expect(claimFullHandoffDelivery(U, S, SPEC, "build", T0)).toBe(true);
+    expect(claimFullHandoffDelivery(U, S, SPEC, "build", T0 + 60_000)).toBe(false);
+    expect(claimFullHandoffDelivery(U, S, SPEC, "build", T0 + FULL_HANDOFF_TTL_MS - 1)).toBe(false);
+  });
+
+  it("re-delivers once the TTL backstop has elapsed", () => {
+    tagAc(AC(8));
+    expect(claimFullHandoffDelivery(U, S, SPEC, "build", T0)).toBe(true);
+    expect(claimFullHandoffDelivery(U, S, SPEC, "build", T0 + FULL_HANDOFF_TTL_MS)).toBe(true);
+    // …and the re-delivery resets the window.
+    expect(claimFullHandoffDelivery(U, S, SPEC, "build", T0 + FULL_HANDOFF_TTL_MS + 1)).toBe(false);
+  });
+
+  it("re-delivers when the phase changes (phase is part of the key)", () => {
+    tagAc(AC(8));
+    expect(claimFullHandoffDelivery(U, S, SPEC, "specify", T0)).toBe(true);
+    expect(claimFullHandoffDelivery(U, S, SPEC, "specify", T0 + 1)).toBe(false);
+    // Same session, same spec, new phase → fresh key → full again.
+    expect(claimFullHandoffDelivery(U, S, SPEC, "build", T0 + 1)).toBe(true);
+  });
+
+  it("keys per session, per user, and per spec", () => {
+    tagAc(AC(8));
+    expect(claimFullHandoffDelivery(U, S, SPEC, "build", T0)).toBe(true);
+    expect(claimFullHandoffDelivery(U, "session-2", SPEC, "build", T0)).toBe(true); // new session
+    expect(claimFullHandoffDelivery("user-2", S, SPEC, "build", T0)).toBe(true); // new user
+    expect(claimFullHandoffDelivery(U, S, "spec-2", "build", T0)).toBe(true); // new spec
+  });
+
+  it("isolates state between tests via _clearHandoffDeliveries", () => {
+    expect(claimFullHandoffDelivery(U, S, SPEC, "build", T0)).toBe(true);
+    _clearHandoffDeliveries();
+    expect(claimFullHandoffDelivery(U, S, SPEC, "build", T0)).toBe(true);
+  });
+});

--- a/packages/server/src/services/handoff-delivery.ts
+++ b/packages/server/src/services/handoff-delivery.ts
@@ -1,0 +1,62 @@
+// spec-203 Layer 2 (dec-2): the module-local store that decides WHEN the in-chat
+// footer machine delivers the FULL phase handoff (the ~1500-word copy-button
+// prompt) versus the compressed essence (Layer 1, every other response).
+//
+// The full handoff rides the footer ONCE per (user, session, spec, phase) —
+// re-firing automatically on phase change (phase is part of the key) and after a
+// TTL idle backstop. Keyed on the `session_id` the MCP dispatch already carries:
+// prod telemetry (spec-203 dec-2) showed 99.7% of real tool traffic reuses one
+// stable session_id across a working session, so a continuous session is primed
+// once per phase and shown the essence thereafter.
+//
+// Process-local, mirroring phase-assessment.ts's `recentAssessments` Map: fine
+// for a single Cloud Run instance, and cross-instance loss only causes a benign
+// re-delivery (the full handoff shown again). Per dec-2 we bias toward
+// delivering — never priming the agent is the costly failure, re-showing is
+// cheap. If we ever need cross-instance precision, swap for Redis.
+
+const lastFullDelivery = new Map<string, number>();
+
+// TTL backstop. Per spec-203 dec-2 this is POLISH, not load-bearing: session_id
+// is stable across ~99-min sessions, so within one session+phase the full is
+// delivered once and the essence thereafter — the TTL only re-primes a session
+// that returns after a long idle gap (or after cross-instance store loss).
+export const FULL_HANDOFF_TTL_MS = 30 * 60 * 1000;
+
+function deliveryKey(
+  userId: string,
+  sessionId: string,
+  specId: string,
+  phase: string,
+): string {
+  return `${userId}:${sessionId}:${specId}:${phase}`;
+}
+
+/**
+ * Check-and-claim: returns true (and records `now`) when the full handoff SHOULD
+ * ride this response — it has not been delivered for this (user, session, spec,
+ * phase) yet, or the TTL backstop has elapsed since the last delivery. Returns
+ * false when a recent delivery means the footer should carry the compressed
+ * essence instead. Atomic (synchronous check-and-set) so two concurrent calls on
+ * one instance cannot both claim the same delivery.
+ */
+export function claimFullHandoffDelivery(
+  userId: string,
+  sessionId: string,
+  specId: string,
+  phase: string,
+  now: number = Date.now(),
+  ttlMs: number = FULL_HANDOFF_TTL_MS,
+): boolean {
+  const key = deliveryKey(userId, sessionId, specId, phase);
+  const last = lastFullDelivery.get(key);
+  if (last !== undefined && now - last < ttlMs) return false;
+  lastFullDelivery.set(key, now);
+  return true;
+}
+
+/** Test-only escape hatch — clears the delivery store so cross-test state can't
+ *  leak. Production never calls it. */
+export function _clearHandoffDeliveries(): void {
+  lastFullDelivery.clear();
+}

--- a/packages/server/src/services/mcp-telemetry.integration.test.ts
+++ b/packages/server/src/services/mcp-telemetry.integration.test.ts
@@ -24,6 +24,11 @@ import {
   users,
 } from "../db/schema.js";
 import { upsertSession, logToolCall } from "./mcp-telemetry.js";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { FOOTER_DELIMITER } from "../mcp/footer-delimiter.js";
+
+const AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-203/acs/ac-${n}`;
 
 const createdMemexIds: string[] = [];
 const createdNamespaceIds: string[] = [];
@@ -418,5 +423,75 @@ describe("logToolCall", () => {
     expect(row.error?.length).toBeGreaterThan(300); // sanity: not redacted to a short envelope
     expect(row.error).toContain("ENOENT");
     expect(row.error).toContain("at async listTopics");
+  });
+});
+
+// spec-203 dec-3 (t-5) ac-12: footer-only audit capture. The default mode in
+// this file is production-like (isDevMode false → result_text suppressed), so
+// these tests prove the footer is captured UNCONDITIONALLY — present even when
+// the full output is not — and that only the footer (never the body) lands.
+describe("logToolCall — footer-only audit capture (spec-203 dec-3)", () => {
+  it("persists ONLY the footer (split on the delimiter), not the full output, on the prod path", async () => {
+    tagAc(AC(12));
+    const userId = await seedUser();
+    const sessionId = unique("footer-sess");
+    createdSessionIds.push(sessionId);
+    await db.insert(mcpSessions).values({ sessionId, userId });
+
+    // Exercise the PRODUCTION path: isDevMode() false, so result_text is
+    // dropped. If footer_text still lands, the footer capture is genuinely
+    // unconditional. (isDevMode throws on NODE_ENV=production with no client id,
+    // so set both; the file's beforeEach resets env for the next test.)
+    process.env.NODE_ENV = "production";
+    process.env.GOOGLE_CLIENT_ID = "fake-client-for-test";
+
+    const body = "# Spec X\nthe real tool output body";
+    const footer = 'BUILD handoff (full prompt: the "Build handoff" button). phase guidance';
+    await logToolCall({
+      sessionId,
+      userId,
+      memexId: null,
+      toolName: "get_doc",
+      args: { ref: "x" },
+      durationMs: 5,
+      error: null,
+      resultText: `${body}\n${FOOTER_DELIMITER}\n${footer}`,
+    });
+
+    const [row] = await db
+      .select()
+      .from(mcpToolCalls)
+      .where(eq(mcpToolCalls.sessionId, sessionId));
+    // Footer captured (unconditional — this is the prod path)…
+    expect(row.footerText).toBe(footer);
+    // …and the tool's real output body is NOT in the captured footer…
+    expect(row.footerText).not.toContain("the real tool output body");
+    // …and the full output is NOT persisted on the prod path.
+    expect(row.resultText).toBeNull();
+  });
+
+  it("persists NULL footer when the result carried no delimiter", async () => {
+    tagAc(AC(12));
+    const userId = await seedUser();
+    const sessionId = unique("footer-none-sess");
+    createdSessionIds.push(sessionId);
+    await db.insert(mcpSessions).values({ sessionId, userId });
+
+    await logToolCall({
+      sessionId,
+      userId,
+      memexId: null,
+      toolName: "list_memexes",
+      args: {},
+      durationMs: 2,
+      error: null,
+      resultText: "a terse response with no footer",
+    });
+
+    const [row] = await db
+      .select()
+      .from(mcpToolCalls)
+      .where(eq(mcpToolCalls.sessionId, sessionId));
+    expect(row.footerText).toBeNull();
   });
 });

--- a/packages/server/src/services/mcp-telemetry.ts
+++ b/packages/server/src/services/mcp-telemetry.ts
@@ -26,6 +26,7 @@ import {
   orgs,
 } from "../db/schema.js";
 import { isDevMode } from "../middleware/session.js";
+import { splitToolResult } from "../mcp/footer-delimiter.js";
 
 function log(...args: unknown[]): void {
   // eslint-disable-next-line no-console
@@ -185,6 +186,14 @@ export async function logToolCall(input: LogToolCallInput): Promise<void> {
       isDevMode() && input.resultText
         ? clip(input.resultText, MAX_RESULT_TEXT_LENGTH)
         : null;
+    // spec-203 dec-3: capture ONLY the platform footer (everything after the
+    // FOOTER_DELIMITER), UNCONDITIONALLY — prod included, NOT gated by isDevMode
+    // like result_text above. The full tool output is never persisted by this
+    // path. NULL when the response carried no footer.
+    const footer = input.resultText
+      ? splitToolResult(input.resultText).footer
+      : null;
+    const footerText = footer ? clip(footer, MAX_RESULT_TEXT_LENGTH) : null;
     // Derive org_id from memex_id at insert time so analytics queries
     // don't need a 3-table join every time. lookupOrgForMemex returns
     // null for personal-kind memexes (no owning org).
@@ -200,6 +209,7 @@ export async function logToolCall(input: LogToolCallInput): Promise<void> {
       durationMs: input.durationMs,
       error,
       resultText,
+      footerText,
     });
   } catch (err) {
     log("logToolCall failed", { toolName: input.toolName, err });

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -40,6 +40,8 @@ export {
   toRubric,
   toInitPromptRef,
   toButtonPrompt,
+  toHandoffEssence,
+  HANDOFF_BUTTON_BY_PHASE,
 } from './scaffold-model.js';
 export type {
   Phase,

--- a/packages/shared/src/scaffold-data.handoff-essence.spec-203.test.ts
+++ b/packages/shared/src/scaffold-data.handoff-essence.spec-203.test.ts
@@ -1,0 +1,113 @@
+// spec-203 dec-1: tests for the footer-handoff-essence projection.
+//
+// The Spec's headline promise is that the copy button (full `text`) and the
+// in-chat footer (compressed `essence`) are two projections of ONE canonical
+// handoff node, so they cannot drift. These tests pin that contract:
+//   - toHandoffEssence returns the right phase's essence, null for draft/done;
+//   - the phase→node map (HANDOFF_BUTTON_BY_PHASE) and the essence field stay
+//     bound in BOTH directions (no mapped phase without an essence; no essence
+//     node the map can't reach) — the std-15 "one home" guarantee in test form;
+//   - text and essence physically co-habit one node for every handoff phase.
+
+import { describe, it, expect } from 'vitest';
+import { tagAc } from '@memex-ai-ac/vitest';
+import {
+  toHandoffEssence,
+  HANDOFF_BUTTON_BY_PHASE,
+  type Phase,
+} from './scaffold-model.js';
+import { BASE_SCAFFOLD } from './scaffold-data.js';
+
+const AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-203/acs/ac-${n}`;
+
+const FORWARD_PHASES: Phase[] = ['specify', 'build', 'verify'];
+const NO_HANDOFF_PHASES: Phase[] = ['draft', 'done'];
+
+describe('toHandoffEssence', () => {
+  it('returns the build handoff essence for the build phase', () => {
+    tagAc(AC(5));
+    const essence = toHandoffEssence(BASE_SCAFFOLD, 'build');
+    expect(essence).toContain('BUILD handoff');
+    // The behaviours spec-120 proved never reach a chat agent must be present.
+    expect(essence).toContain('deriving the task graph');
+    expect(essence).toContain('recommend `verify`');
+  });
+
+  it('returns the specify handoff essence for the specify phase', () => {
+    const essence = toHandoffEssence(BASE_SCAFFOLD, 'specify');
+    expect(essence).toContain('SPECIFY handoff');
+    expect(essence).toContain('create_decision');
+    expect(essence).toContain('scope ACs');
+  });
+
+  it('returns the verify handoff essence for the verify phase', () => {
+    const essence = toHandoffEssence(BASE_SCAFFOLD, 'verify');
+    expect(essence).toContain('VERIFY handoff');
+    expect(essence).toContain('all SIX dimensions');
+  });
+
+  it.each(NO_HANDOFF_PHASES)('returns null for the %s phase (no handoff)', (phase) => {
+    tagAc(AC(5));
+    expect(toHandoffEssence(BASE_SCAFFOLD, phase)).toBeNull();
+  });
+
+  it('returns null when the mapped node carries no essence', () => {
+    // A dataset whose handoff node has had its essence stripped must degrade to
+    // null, never to an empty/whitespace string in the footer.
+    const stripped = {
+      ...BASE_SCAFFOLD,
+      promptButtons: BASE_SCAFFOLD.promptButtons.map((b) =>
+        b.id === HANDOFF_BUTTON_BY_PHASE.build ? { ...b, essence: '   ' } : b,
+      ),
+    };
+    expect(toHandoffEssence(stripped, 'build')).toBeNull();
+  });
+});
+
+describe('handoff essence ↔ phase-map parity (spec-203 dec-1, std-15)', () => {
+  it('every phase the map names resolves to an existing node WITH an essence', () => {
+    tagAc(AC(6));
+    for (const phase of FORWARD_PHASES) {
+      const buttonId = HANDOFF_BUTTON_BY_PHASE[phase];
+      expect(buttonId, `map must name a handoff for ${phase}`).toBeTruthy();
+      const node = BASE_SCAFFOLD.promptButtons.find((b) => b.id === buttonId);
+      expect(node, `node ${buttonId} must exist`).toBeDefined();
+      expect(node?.essence?.trim(), `node ${buttonId} must carry an essence`).toBeTruthy();
+    }
+  });
+
+  it('every node that carries an essence is reachable from the phase map (no orphans)', () => {
+    tagAc(AC(6));
+    const reachable = new Set(Object.values(HANDOFF_BUTTON_BY_PHASE));
+    const essenceNodes = BASE_SCAFFOLD.promptButtons.filter((b) => b.essence?.trim());
+    for (const node of essenceNodes) {
+      expect(
+        reachable.has(node.id),
+        `node ${node.id} has an essence but no phase maps to it — orphaned footer prose`,
+      ).toBe(true);
+    }
+  });
+
+  it('text and essence co-habit one node for every handoff phase (cannot drift)', () => {
+    tagAc(AC(6));
+    // Scope outcome: footer and copy button are one canonical source that
+    // cannot silently diverge (ac-2).
+    tagAc(AC(2));
+    for (const phase of FORWARD_PHASES) {
+      const node = BASE_SCAFFOLD.promptButtons.find(
+        (b) => b.id === HANDOFF_BUTTON_BY_PHASE[phase],
+      );
+      // The full copy-button prompt and the footer essence are fields on the
+      // SAME object — the structural form of the "one canonical source" promise.
+      expect(node?.text?.length, `${phase} node must have full text`).toBeGreaterThan(0);
+      expect(node?.essence?.length, `${phase} node must have essence`).toBeGreaterThan(0);
+    }
+  });
+
+  it('draft and done are absent from the map (encodes "no handoff line")', () => {
+    for (const phase of NO_HANDOFF_PHASES) {
+      expect(HANDOFF_BUTTON_BY_PHASE[phase]).toBeUndefined();
+    }
+  });
+});

--- a/packages/shared/src/scaffold-data.ts
+++ b/packages/shared/src/scaffold-data.ts
@@ -1666,6 +1666,12 @@ PARALLELISE ONLY WHEN IT PAYS. If you can spawn sub-agents / run workflows AND t
   • If everything is green or consciously signed off, recommend moving to \`verify\` — you do NOT move it, and you never move to \`done\`; both are the human's call. If anything is unverified, leave those tasks open and report exactly what remains and why.
 Finish with a summary: per-task outcome, AC verification state, any new decisions you surfaced, and any standards drift or decision-vs-code mismatches you found.`,
     surfaces: ['opening-turn'],
+    // spec-203 dec-1: the compressed footer projection of this build handoff —
+    // the in-chat essence a chat-driven agent gets on every spec-tool response.
+    // Distils the STEP structure to the behaviours spec-120 proved never reach a
+    // chat agent (task-minting is your job; recommend verify). Token-free; names
+    // the full-prompt button so the agent can escalate.
+    essence: `BUILD handoff (full prompt: the "Build handoff" button). This Spec's plan is settled — BUILD it end-to-end, don't sketch it. 0 tasks + untested ACs is the NORMAL build-start state: deriving the task graph from the NARRATIVE is YOUR job (create_task — build only). Ground every code-naming decision against current source first; a drifted anchor is a decision-vs-code mismatch to surface, not a silent relocation. Verify each task in the shape of its claim — behaviour → test-first red→green, tagged to the AC's canonical ref (don't override test-event routing); prose/config → exercise the artifact. COMPLETE only when verification actually RAN clean. When everything's green or consciously signed off, recommend \`verify\` — you do NOT move the phase, and never to \`done\`. A fork the plan didn't settle → create_decision; don't invent the answer.`,
     rationale:
       'Hand a build-phase Spec to a coding agent to build it end-to-end: ground the resolved decisions against current source, derive the task graph from the narrative, implement and verify in the shape of each task, and recommend `verify` (never close — that is the human\'s call). Portable per std-22 — every tooling-specific step gated on "if the project has it". Authored and hardened via spec-149 across four read-only dry-runs. Rendered as the build "Build handoff" action on the opening turn.',
   },
@@ -1779,6 +1785,8 @@ Scope ACs with no test: judge by reading + exercising the running behaviour.
 ── STEP 4: close out ──
 Give a per-dimension verdict (pass / fail / gap) and an overall read. "Clean" = all ACs verified (cross-checked in list_acs, not just a clean gate), all tasks reproduced, no security gap, the testing requirements in this Memex's Standards met, and every open comment resolved or consciously carried forward. If clean, recommend moving to \`done\` (you do NOT move it). If anything failed, recommend reopening the specific task(s) (update_task) so the Spec returns to build — do not call update_doc to change phase yourself.`,
     surfaces: ['spec-header'],
+    // spec-203 dec-1: compressed footer projection of the verify handoff.
+    essence: `VERIFY handoff (full prompt: the "Verify handoff" button). This Spec finished \`build\` — earn confidence it's GENUINELY done, against the RUNNING SYSTEM, not the diff. Run the deterministic gate (assess_spec target:'done'), but a clean gate can coexist with a FAILING AC — cross-check list_acs and treat THAT as the truth on AC health. Verify across all SIX dimensions, none skippable: acceptance criteria, tasks-actually-ran, scope completeness, security, standards drift, test-coverage gaps. An UNtagged passing test moves no AC; don't override test-event routing. File BLOCKERS as Issues (register_issue), ADVISORIES as review comments. If clean, recommend \`done\`; if anything failed, reopen the specific task(s) (update_task) — you do NOT move the phase yourself.`,
     rationale:
       'Hand a verify-phase Spec to a coding agent to verify its acceptance ' +
       'criteria — run tests + type checks and exercise the path, not just ' +
@@ -1834,6 +1842,8 @@ Author the scope ACs that define what finishing this Spec MEANS — the manager-
   • If decisions are resolved, the narrative reflects them, and scope ACs cover the work, recommend moving to \`build\` — you do NOT move it; that is the human's call. If anything is still open, leave it open and report exactly what remains and why.
 Finish with a summary: the decisions you surfaced and how each resolved, the scope ACs you authored, any standards drift or decision-vs-code mismatches you found, and what (if anything) still blocks the move to build.`,
     surfaces: ['spec-header'],
+    // spec-203 dec-1: compressed footer projection of the specify/plan handoff.
+    essence: `SPECIFY handoff (full prompt: the "Plan handoff" button). This Spec is still PLANNING — do NOT write product code, create tasks, or build (those belong to \`build\`). Surface the choices the work hinges on as Decisions (create_decision), grounding each against current source AND the Memex's history (search_memex kind:'decision' / 'standard') BEFORE resolving — never self-resolve a load-bearing choice; that's the user's call. Pin down what "done" means as scope ACs (create_ac kind:'scope') — one per observable outcome, implementation-agnostic. Reflect every resolution back into the narrative (update_section) — an unrecorded decision hasn't truly been made. When decisions are resolved, the narrative reflects them, and scope ACs cover the work, recommend \`build\` — you do NOT move the phase.`,
     rationale:
       'Hand a draft/specify-phase Spec to a coding agent to make it buildable: ' +
       'ground the narrative against current source + Standards, surface and ' +

--- a/packages/shared/src/scaffold-model.ts
+++ b/packages/shared/src/scaffold-model.ts
@@ -103,6 +103,15 @@ export interface PromptButtonNode extends BaseNodeShape {
   label: string;
   text: string;
   surfaces: readonly string[];
+  /** spec-203 dec-1: the compressed footer projection of this handoff. The full
+   *  `text` rides the copy button (clipboard / opening-turn); `essence` is the
+   *  short nudge the in-chat footer machine emits on every spec-tool response so
+   *  a chat-driven agent gets the current phase's handoff without the ~1500-word
+   *  prompt. Co-located with `text` on ONE node so the two projections cannot
+   *  drift (std-15). Only the three phase handoffs carry it; absent on every
+   *  other button (opening-turn triggers, review actions). Projected by
+   *  `toHandoffEssence` via `HANDOFF_BUTTON_BY_PHASE`. */
+  essence?: string;
 }
 
 /** Tool node — extends b-67's `ToolManifestEntry` without forking it. Shared
@@ -384,6 +393,33 @@ export function toButtonPrompt(input: ToButtonPromptInput): string | null {
 
   const composed = [button.text, ...orgAppends.map((b) => b.text)].join('\n\n');
   return interpolateContext(composed, context);
+}
+
+/** spec-203 dec-1: the single canonical phase→handoff-node mapping. Both the
+ *  copy button (UI, `DocDocument`) and the in-chat footer (`toHandoffEssence`)
+ *  select the handoff for a phase through THIS map, so node-selection is
+ *  single-source and cannot drift between the two projections. `draft` and
+ *  `done` carry no handoff (draft invites the move to specify first — spec-164
+ *  issue-1; done is terminal). */
+export const HANDOFF_BUTTON_BY_PHASE: Readonly<Partial<Record<Phase, string>>> = {
+  specify: 'plan-handoff',
+  build: 'opening-build-handoff',
+  verify: 'verify-spec',
+};
+
+/** Returns the compressed footer `essence` of the handoff for `phase`, or
+ *  `null` when the phase has no handoff (draft / done) or its node carries no
+ *  essence. This is the footer projection half of spec-203 dec-1 — the copy
+ *  button projects the node's full `text` via `toButtonPrompt`; the footer
+ *  projects the same node's `essence` here. Token-free by construction (the
+ *  footer header already carries the Spec ref / URL), so it needs no
+ *  interpolation context and Layer 1 stays free of identity/ctx plumbing. */
+export function toHandoffEssence(dataset: ScaffoldDataset, phase: Phase): string | null {
+  const buttonId = HANDOFF_BUTTON_BY_PHASE[phase];
+  if (!buttonId) return null;
+  const node = dataset.promptButtons.find((b) => b.id === buttonId);
+  const essence = node?.essence?.trim();
+  return essence ? essence : null;
 }
 
 /** Returns the Init Prompt tool reference entry. Same shape as b-67's

--- a/packages/ui/src/pages/DocDocument.tsx
+++ b/packages/ui/src/pages/DocDocument.tsx
@@ -39,6 +39,7 @@ import {
   isSpecNarrativeStale,
   toButtonPrompt,
   BASE_SCAFFOLD,
+  HANDOFF_BUTTON_BY_PHASE,
 } from '@memex/shared';
 import { useDocChangeStream } from '../hooks/useDocChangeStream';
 import { COMMENT_PARAM, parseCommentParam, commentAnchorId } from '../utils/commentDeepLink';
@@ -643,6 +644,13 @@ export function DocDocument() {
     chat.sendMessage(prompt);
   };
 
+  // spec-203 dec-1: the handoff node id is sourced from the single shared
+  // HANDOFF_BUTTON_BY_PHASE map — the SAME map the in-chat footer projection
+  // (`toHandoffEssence`) selects through — so the copy button and the footer
+  // can never drift on which handoff belongs to a phase. The map also encodes
+  // the "draft / done → no handoff" rule (those phases are absent), so an absent
+  // id collapses the whole line to null.
+  const handoffButtonId = HANDOFF_BUTTON_BY_PHASE[phase];
   const handoff: {
     buttonId: string;
     sentence: React.ReactNode;
@@ -651,6 +659,9 @@ export function DocDocument() {
     /** Plain-text FULL sentence for the accessible name (needed when sentence is a node). */
     sentenceLabel?: string;
   } | null =
+    !handoffButtonId
+      ? null
+      :
     // spec-164 issue-1: draft shows NO handoff line. Originally spec-159 ac-17
     // shared the specify handoff between draft and specify (one arm,
     // `phase === 'draft' || phase === 'specify'`). But dec-3 gates the Decisions &
@@ -668,7 +679,7 @@ export function DocDocument() {
     // sentences. Link names match the tab bar's phase display names.
     phase === 'specify'
       ? {
-          buttonId: 'plan-handoff',
+          buttonId: handoffButtonId,
           // "*Copy the Specify prompt* into your coding agent to create
           // **Decisions** and **ACs**." — entities bold. "ACs" stays
           // abbreviated: the Rubicon line above already spells out
@@ -686,7 +697,7 @@ export function DocDocument() {
         }
       : phase === 'build'
         ? {
-            buttonId: 'opening-build-handoff',
+            buttonId: handoffButtonId,
             // "*Copy the Build prompt* into your coding agent to complete
             // the **Tasks** and build this spec."
             linkText: 'Copy the Build prompt',
@@ -701,7 +712,7 @@ export function DocDocument() {
           }
         : phase === 'verify'
           ? {
-              buttonId: 'verify-spec',
+              buttonId: handoffButtonId,
               // "*Copy the Verify prompt* into your coding agent to verify
               // this spec against its **ACs**." — "ACs" stays abbreviated: the
               // Rubicon line above already spells out "Acceptance Criteria


### PR DESCRIPTION
## What

spec-203: deliver each lifecycle phase's honed handoff to a **chat-driven** agent through the in-chat footer machine — closing the gap where an agent driven directly in chat (not via the human "Copy the X prompt" button) got only AC nags and phase prose, never the handoff itself (the spec-120 failure mode).

Memex spec: https://memex.ai/mindset-prod/memex-building-itself/specs/spec-203

## Layers

- **Layer 1 (dec-1)** — `essence` on `PromptButtonNode` + `toHandoffEssence`; one shared `HANDOFF_BUTTON_BY_PHASE` map consumed by both the copy button (`DocDocument`) and the footer projection, so the two can't drift. (ac-5/6/7, ac-1/2/4)
- **Layer 2 (dec-2)** — `session_id` threaded into `ToolCtx` at the dispatch layer; the full handoff is delivered once per `(user, session, spec, phase)` with a TTL backstop, the compressed essence otherwise, decided in the centralized `formatState` machine. Grain settled on prod telemetry (99.7% of tool calls reuse one stable session_id). (ac-8/9/10, ac-3)
- **Auditable footer (dec-3)** — one configurable `FOOTER_DELIMITER` marks the tool-output → footer boundary; `logToolCall` splits each result and persists **only** the footer (`mcp_tool_calls.footer_text`, hand-migration 0080), unconditionally and never the full output. (ac-11/12)
- **Single composer (dec-3)** — `formatFullDocState` owns the whole response envelope; the four decorating tools (`get_doc`/`update_doc`/`update_task`/`publish_spec`) report `InjectedBlock[]` tagged header/footer instead of concatenating — placement by zone, no tool-name logic, byte-identical output. (ac-13)

## :warning: Deploy ordering

Hand-migration **0080** (`mcp_tool_calls.footer_text`) must run **with or before** this code — `logToolCall` inserts `footer_text` on every call, so the column must exist first.

## Verification

All **13/13 ACs verified on prod** (tagged tests emitting pass events to the workspace). Local suites green: shared + server, including the four tools' integration tests as the byte-identical guardrail, the end-to-end delivery integration test, and the footer-only persistence integration test. Both typechecks clean.