### PR TITLE
spec-206: Specky first-run welcome — auto-greet new users + demo-spec walkthrough

### DIFF
--- a/packages/server/drizzle/0082_add_users_onboarding_greeted_at.sql
+++ b/packages/server/drizzle/0082_add_users_onboarding_greeted_at.sql
@@ -1,0 +1,18 @@
+-- spec-206 t-1 (dec-3 / ac-12): add onboarding_greeted_at to the users table.
+--
+-- The server-authoritative first-run flag for the Specky welcome (spec-206).
+-- Null = the user has never been greeted; a timestamp = the first session where
+-- Specky's opening turn actually started speaking (dec-4 stamps it only once the
+-- voice session reaches `active`, so a blocked/denied mic does not consume the
+-- one-shot). True once-per-user across devices — the auto-greeting never re-fires.
+--
+-- Additive + reversible: a single NULLABLE timestamptz with no default. Every
+-- existing row gets null, which is correct — no existing user has been greeted by
+-- the new flow, so they all become eligible exactly once. The revert is DROP COLUMN.
+--
+-- Idempotent (IF NOT EXISTS): the hand-migration runner wraps each file in a
+-- transaction and tracks it in manual_migrations; the guard lets a retry re-apply
+-- cleanly if a prior run committed the DDL but not the tracking row.
+
+ALTER TABLE users
+  ADD COLUMN IF NOT EXISTS onboarding_greeted_at timestamptz;

--- a/packages/server/drizzle/reverts/0082_add_users_onboarding_greeted_at.revert.sql
+++ b/packages/server/drizzle/reverts/0082_add_users_onboarding_greeted_at.revert.sql
@@ -1,0 +1,2 @@
+-- Revert spec-206 t-1 (0082_add_users_onboarding_greeted_at.sql).
+ALTER TABLE users DROP COLUMN IF EXISTS onboarding_greeted_at;

--- a/packages/server/src/agent/voice/guide-prompt.test.ts
+++ b/packages/server/src/agent/voice/guide-prompt.test.ts
@@ -1,0 +1,55 @@
+// spec-206 t-4 — the demo walkthrough beats in the guide's system prompt.
+//
+// ac-4 — the five phases are present, in lifecycle order, for narration.
+// ac-6 / ac-9 — the narration text is single-sourced from the spec-178 fixture
+//   (HANDHOLD_PHASES[].valueCallout) and lives in the system PROMPT, so the guide
+//   narrates from context — never via a doc-lookup tool (the demo specs are
+//   invisible to every agent surface, spec-178 dec-11).
+
+import { describe, it, expect } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { buildGuideSystemBlocks } from "./guide-prompt.js";
+import { HANDHOLD_PHASES } from "../../db/handhold-demo.fixture.js";
+
+const AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-206/acs/ac-${n}`;
+
+const blocks = buildGuideSystemBlocks({
+  screenKey: "specs-list",
+  screenRegistry: [],
+  guideContext: [],
+});
+const text = blocks.map((b) => b.text).join("\n");
+
+describe("guide system prompt — demo walkthrough beats (spec-206 t-4)", () => {
+  it("includes every phase beat verbatim, single-sourced from the spec-178 fixture (ac-6 / ac-9)", () => {
+    // Each beat is the fixture's own valueCallout — re-typing it here would drift,
+    // so this proves the prompt is built FROM the fixture, not a copy.
+    for (const p of HANDHOLD_PHASES) {
+      expect(text).toContain(p.valueCallout);
+    }
+    tagAc(AC(6));
+    tagAc(AC(9));
+  });
+
+  it("lists all five phases in lifecycle order for narration (ac-4)", () => {
+    // Scope to the beats BLOCK — the instruction prose also names the phases
+    // ("draft → specify → … → done"), which would fool an indexOf over all text.
+    const beatsBlock = blocks.find((b) => b.text.startsWith("## Demo walkthrough beats"));
+    expect(beatsBlock).toBeDefined();
+    const beats = beatsBlock!.text;
+    const order = ["draft", "specify", "build", "verify", "done"];
+    const positions = order.map((ph) => beats.indexOf(`**${ph}**`));
+    // Every phase present...
+    expect(positions.every((i) => i >= 0)).toBe(true);
+    // ...and in strictly ascending order (draft → specify → build → verify → done).
+    const ascending = [...positions].sort((a, b) => a - b);
+    expect(positions).toEqual(ascending);
+    tagAc(AC(4));
+  });
+
+  it("instructs the guide to advance the demo board during the walkthrough", () => {
+    expect(text).toContain("advance_demo");
+    expect(text.toLowerCase()).toContain("walkthrough");
+  });
+});

--- a/packages/server/src/agent/voice/guide-prompt.ts
+++ b/packages/server/src/agent/voice/guide-prompt.ts
@@ -17,11 +17,26 @@ import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { GuideElement } from "@memex/shared";
+import { HANDHOLD_PHASES } from "../../db/handhold-demo.fixture.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 // Read once at module load — the prompt is static.
 const GUIDE_SYSTEM = readFileSync(resolve(__dirname, "guide-system.md"), "utf8");
+
+// spec-206 t-4 (dec-1 / ac-6 / ac-9): the demo walkthrough beats, SINGLE-SOURCED
+// from the spec-178 fixture (HANDHOLD_PHASES[].valueCallout) — NOT re-typed here
+// and NOT fetched via any doc-lookup tool (the demo specs are invisible to every
+// agent surface, spec-178 dec-11). Built once at module load; static per deploy,
+// so it rides the cached system block. guide-system.md tells Specky how to narrate
+// these and when to call `advance_demo`.
+const WALKTHROUGH_BEATS = [
+  "## Demo walkthrough beats",
+  "",
+  "Narrate these five phases in order when the user accepts the demo-specs walkthrough, calling `advance_demo` after each (see the instructions above). One short spoken beat per phase:",
+  "",
+  ...HANDHOLD_PHASES.map((p) => `- **${p.phase}** — ${p.valueCallout}`),
+].join("\n");
 
 export interface GuideSystemBlock {
   type: "text";
@@ -76,6 +91,10 @@ function renderScreenContext(input: GuidePromptInput): string {
 export function buildGuideSystemBlocks(input: GuidePromptInput): GuideSystemBlock[] {
   return [
     { type: "text", text: GUIDE_SYSTEM, cache_control: { type: "ephemeral" } },
+    // spec-206 t-4: the demo walkthrough beats — static per deploy, so it shares
+    // the cached prefix with the instruction prompt above (ac-6 / ac-9: narration
+    // is single-sourced from the fixture, never a doc-lookup).
+    { type: "text", text: WALKTHROUGH_BEATS, cache_control: { type: "ephemeral" } },
     { type: "text", text: renderScreenContext(input) },
   ];
 }

--- a/packages/server/src/agent/voice/guide-system.md
+++ b/packages/server/src/agent/voice/guide-system.md
@@ -24,5 +24,17 @@ If the user asks about their own content by description ("take me to the spec ab
 - `highlight` — visually highlight an element on the CURRENT screen (use an element id from the screen context).
 - `navigate` — take the user to another registered screen. Only registered screen keys work; for a specific entity the user names, navigate to the relevant list screen and highlight its search affordance rather than guessing.
 - `search_guide` — look something up in the product documentation when the current screen context doesn't cover it. This searches GUIDE content only, never the user's data.
+- `advance_demo` — during the demo-specs walkthrough only, move the on-screen demo board to the next phase (see "First-run demo walkthrough" below).
 
 You have no other tools. You cannot create, edit, or read Specs, Standards, or any tenant content.
+
+## First-run demo walkthrough
+
+A user's personal Memex is seeded with five **demo specs** — the same example feature shown at each phase of its life (draft → specify → build → verify → done). You cannot read them (they are demo content, invisible to you like all tenant data), but their walkthrough **beats** are provided to you below under "Demo walkthrough beats". That provided text is your ONLY source for the walkthrough — narrate from it; never try to look the demo specs up.
+
+When you offer to walk the user through the demo specs and they accept (or they ask you to show how a spec evolves):
+
+- Narrate the **five phases in order** — draft, specify, build, verify, done — using the matching beat below. Keep each to a spoken sentence or two, in your own warm voice; don't read the markdown aloud.
+- **After you finish narrating each phase, call `advance_demo`** so the demo board visibly moves that spec to the next column in sync with what you're saying. One `advance_demo` call per phase.
+- End on **done**. `advance_demo` is a no-op once you're already at the final phase, so don't call it after done.
+- If the user declines the walkthrough, don't narrate the phases or call `advance_demo` — just stay available for their questions.

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -34,6 +34,7 @@ import { wellKnown, publicBaseUrl } from "./routes/well-known.js";
 import driftRouter from "./routes/drift.js";
 import { search } from "./routes/search.js";
 import { handhold } from "./routes/handhold.js";
+import { onboarding } from "./routes/onboarding.js";
 import { testEventsRouter } from "./routes/test-events.js";
 import { testOnlyRouter } from "./routes/__test__.js";
 import { hostGuard, memexResolver } from "./middleware/memex-resolver.js";
@@ -302,6 +303,10 @@ app.route("/api/llm", llmRouter);
 // per-memex semantics, so prefixing them would be noise.
 app.route("/api/waitlist", waitlist);
 app.route("/api/auth", auth);
+// /api/onboarding — spec-206: the user-level first-run greeting gate for the
+// Specky welcome (greet-eligibility read + once-per-user stamp). User-keyed, no
+// memex semantics, so it stays flat.
+app.route("/api/onboarding", onboarding);
 // /api/orgs — t-14 + t-16 of doc-15. Single org-creation + admin surface.
 // Replaces the retired /api/accounts and /api/account mounts.
 app.route("/api/orgs", orgsRouter);

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -1087,6 +1087,12 @@ export const users = pgTable("users", {
   // for legacy rows. Nullable to break the chicken-and-egg with
   // `namespaces.owner_user_id` at signup time. UNIQUE so one user → one namespace.
   namespaceId: uuid("namespace_id").references(() => namespaces.id, { onDelete: "set null" }),
+  // spec-206 (dec-3): the server-authoritative first-run flag for the Specky
+  // welcome. Null = the user has never been greeted; a timestamp = the first
+  // session where Specky's opening turn actually started speaking (dec-4 — a
+  // blocked/denied audio start does NOT stamp it). True once-per-user across
+  // devices, so the auto-greeting never re-fires.
+  onboardingGreetedAt: timestamp("onboarding_greeted_at", { withTimezone: true }),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
 }, (table) => [

--- a/packages/server/src/middleware/memex-resolver.ts
+++ b/packages/server/src/middleware/memex-resolver.ts
@@ -54,6 +54,8 @@ const NON_TENANT_API_PREFIXES = [
   "/api/me",
   "/api/oauth/",
   "/api/oauth",
+  "/api/onboarding/",
+  "/api/onboarding", // exact — spec-206 first-run greeting gate (user-level)
   "/api/install",
   "/install.sh",
   "/install.ps1",
@@ -92,6 +94,7 @@ const RESERVED_API_ROOTS = new Set([
   "cli",
   "mcp",
   "me",
+  "onboarding",
   "orgs",
   "namespaces",
   "consent",

--- a/packages/server/src/middleware/permissions.test.ts
+++ b/packages/server/src/middleware/permissions.test.ts
@@ -35,6 +35,7 @@ function buildApp(routePath: string) {
       emailVerifiedAt: new Date(),
       status: "active",
       namespaceId: "ns-user-1",
+      onboardingGreetedAt: null,
       createdAt: new Date(),
       updatedAt: new Date(),
     });

--- a/packages/server/src/routes/__test__.ts
+++ b/packages/server/src/routes/__test__.ts
@@ -19,6 +19,7 @@ import {
   upsertUserByEmail,
   updateUserProfile,
   markEmailVerified,
+  markOnboardingGreeted,
   createUserWithPassword,
 } from "../services/users.js";
 import { ensureUserNamespace, ensureUserMemex } from "../services/user-namespaces.js";
@@ -161,6 +162,37 @@ testOnlyRouter.post("/user-name", async (c) => {
       .where(eq(users.id, user.id));
   } else {
     await updateUserProfile(user.id, { name });
+  }
+  return c.json({ ok: true });
+});
+
+// spec-206 t-5: set/clear a user's first-run greeting flag. The onboarding journey
+// un-greets the dev user to drive the auto-greeting deterministically; the per-test
+// fixture + globalSetup pre-stamp it greeted so the auto-greeting never surprises
+// OTHER journeys (it would otherwise fire on the shared dev user's first board load
+// wherever a mic is available). greeted=true uses the real service; greeted=false
+// is a direct nulling (un-greeting exists only for tests).
+const onboardingGreetedSchema = z.object({
+  email: z.string().email(),
+  greeted: z.boolean(),
+});
+testOnlyRouter.post("/onboarding-greeted", async (c) => {
+  const body = await c.req.json().catch(() => null);
+  const parsed = onboardingGreetedSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: "Invalid request", details: parsed.error.issues }, 400);
+  }
+  const { email, greeted } = parsed.data;
+  const user = await getUserByEmail(email);
+  if (!user) return c.json({ error: `User ${email} not found` }, 404);
+
+  if (greeted) {
+    await markOnboardingGreeted(user.id);
+  } else {
+    await db
+      .update(users)
+      .set({ onboardingGreetedAt: null, updatedAt: new Date() })
+      .where(eq(users.id, user.id));
   }
   return c.json({ ok: true });
 });

--- a/packages/server/src/routes/onboarding.api.test.ts
+++ b/packages/server/src/routes/onboarding.api.test.ts
@@ -1,0 +1,132 @@
+// Integration tests for the first-run greeting gate (spec-206 t-1).
+//
+//   GET  /api/onboarding/greeting  → { greet, firstName }  (ac-13)
+//   POST /api/onboarding/greeting  → stamps onboarding_greeted_at (ac-14)
+//
+// ac-12 — the nullable onboarding_greeted_at column exists and defaults null for
+//         a fresh user (proven by reading the row straight after upsert).
+// ac-13 — greet is true iff onboarding_greeted_at IS NULL.
+// ac-14 — the stamp is idempotent (first greeting wins) and scoped to the current
+//         user, so the greeting never re-fires (any device); anonymous → 401.
+//
+// Runs against a REAL Postgres through the full Hono app + strict sessionMiddleware.
+
+import { describe, it, expect, afterAll, vi } from "vitest";
+import { inArray } from "drizzle-orm";
+
+vi.hoisted(() => {
+  // Force auth-mode session middleware so per-user Bearer tokens are honored
+  // (mirrors handhold.api.test.ts). Without GOOGLE_CLIENT_ID the middleware
+  // falls into dev-mode and authenticates everyone as dev@memex.ai.
+  process.env.GOOGLE_CLIENT_ID = "test-client.apps.googleusercontent.com";
+  process.env.AUTH_JWT_SECRET = process.env.AUTH_JWT_SECRET ?? "x".repeat(48);
+  return undefined;
+});
+
+import { db } from "../db/connection.js";
+import { app } from "../app.js";
+import { users } from "../db/schema.js";
+import { eq } from "drizzle-orm";
+import {
+  upsertUserByEmail,
+  updateUserProfile,
+  getUserById,
+} from "../services/users.js";
+import { signSessionToken } from "../services/auth-jwt.js";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+const AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-206/acs/ac-${n}`;
+
+const createdUserIds: string[] = [];
+
+function uniqueEmail(prefix: string): string {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}@example.com`;
+}
+
+async function makeUser(prefix: string, name?: string) {
+  const user = await upsertUserByEmail(uniqueEmail(prefix));
+  if (name) await updateUserProfile(user.id, { name });
+  createdUserIds.push(user.id);
+  return { id: user.id, bearer: signSessionToken(user.id) };
+}
+
+function getGreeting(bearer?: string) {
+  const headers = new Headers();
+  if (bearer) headers.set("Authorization", `Bearer ${bearer}`);
+  return app.request("/api/onboarding/greeting", { headers });
+}
+
+function postGreeting(bearer?: string) {
+  const headers = new Headers();
+  if (bearer) headers.set("Authorization", `Bearer ${bearer}`);
+  return app.request("/api/onboarding/greeting", { method: "POST", headers });
+}
+
+afterAll(async () => {
+  if (createdUserIds.length) {
+    // Deleting the user cascades its lazily-provisioned namespace/memex/docs.
+    await db.delete(users).where(inArray(users.id, createdUserIds));
+  }
+});
+
+describe("first-run greeting gate (spec-206 t-1)", () => {
+  it("a fresh user's onboarding_greeted_at column exists and defaults null", async () => {
+    tagAc(AC(12));
+    const { id } = await makeUser("sp206-col");
+    const row = await getUserById(id);
+    // Column is present (typed access compiles) and null for a never-greeted user.
+    expect(row).toBeTruthy();
+    expect(row!.onboardingGreetedAt).toBeNull();
+  });
+
+  it("GET returns greet=true while ungreeted, greet=false once stamped", async () => {
+    tagAc(AC(13));
+    const { id, bearer } = await makeUser("sp206-gate", "Ryan Soosayraj");
+
+    const before = await getGreeting(bearer);
+    expect(before.status).toBe(200);
+    const beforeBody = await before.json();
+    expect(beforeBody.greet).toBe(true);
+    // firstName is the first token of users.name (sanity; ac-10 owned by t-3).
+    expect(beforeBody.firstName).toBe("Ryan");
+
+    // Establish the session (lazy-provision) is already done; now stamp.
+    const stamp = await postGreeting(bearer);
+    expect(stamp.status).toBe(200);
+
+    const after = await getGreeting(bearer);
+    const afterBody = await after.json();
+    expect(afterBody.greet).toBe(false);
+
+    // Sanity: the column actually carries a timestamp now.
+    const row = await getUserById(id);
+    expect(row!.onboardingGreetedAt).toBeInstanceOf(Date);
+  });
+
+  it("POST is idempotent (first greeting wins) and isolated per user; anonymous → 401", async () => {
+    tagAc(AC(14));
+    const a = await makeUser("sp206-a");
+    const b = await makeUser("sp206-b");
+
+    // First stamp on A.
+    expect((await postGreeting(a.bearer)).status).toBe(200);
+    const firstTs = (await getUserById(a.id))!.onboardingGreetedAt;
+    expect(firstTs).toBeInstanceOf(Date);
+
+    // Second stamp on A is a no-op — the original timestamp is preserved
+    // (greeting never re-fires, on this device or another).
+    expect((await postGreeting(a.bearer)).status).toBe(200);
+    const secondTs = (await getUserById(a.id))!.onboardingGreetedAt;
+    expect(secondTs!.getTime()).toBe(firstTs!.getTime());
+
+    // B was never stamped by A's calls — cross-user isolation.
+    expect((await getUserById(b.id))!.onboardingGreetedAt).toBeNull();
+    const bGate = await getGreeting(b.bearer);
+    expect((await bGate.json()).greet).toBe(true);
+
+    // Anonymous (no Bearer) is 401'd before the handler — cannot read or stamp.
+    expect((await getGreeting()).status).toBe(401);
+    expect((await postGreeting()).status).toBe(401);
+  });
+});

--- a/packages/server/src/routes/onboarding.ts
+++ b/packages/server/src/routes/onboarding.ts
@@ -1,0 +1,51 @@
+// spec-206 — the first-run greeting gate for the Specky welcome.
+//
+// User-level (NOT memex-scoped): the flag lives on the users row (dec-3), so this
+// router is mounted at /api/onboarding with no /<ns>/<mx>/ prefix. Both routes sit
+// behind the STRICT sessionMiddleware, so an anonymous caller is 401'd before the
+// handler runs and `currentUserId` / `user` are always present.
+//
+// GET  /api/onboarding/greeting  → { greet, firstName }
+//     greet = the user has never been greeted (onboarding_greeted_at IS NULL).
+//     firstName = first whitespace token of users.name, or null (dec-2; the client
+//     renders a warm nameless fallback when null — ac-11). The client calls this on
+//     board mount and only auto-starts Specky when greet === true (ac-1, ac-13).
+//
+// POST /api/onboarding/greeting  → { status: "ok" }
+//     Stamps onboarding_greeted_at = now() for the current user (idempotent — first
+//     greeting wins). The client calls this ONLY once Specky's opening turn actually
+//     reaches `active` (dec-4), so a blocked/denied mic does not consume the one-shot
+//     (ac-16). A second call (this or another device) is a no-op → never re-greeted
+//     (ac-14).
+
+import { Hono } from "hono";
+import { sessionMiddleware, type SessionEnv } from "../middleware/session.js";
+import { markOnboardingGreeted } from "../services/users.js";
+
+const onboarding = new Hono<SessionEnv>();
+
+// STRICT session policy — anonymous → 401 before any handler.
+onboarding.use("/*", sessionMiddleware);
+
+/** First whitespace-delimited token of a display name (dec-2 / ac-10), or null
+ *  when there is no usable name (ac-11 — the client renders a warm fallback). */
+export function deriveFirstName(name: string | null | undefined): string | null {
+  const first = (name ?? "").trim().split(/\s+/)[0];
+  return first ? first : null;
+}
+
+onboarding.get("/greeting", (c) => {
+  const user = c.get("user");
+  return c.json({
+    greet: user.onboardingGreetedAt == null,
+    firstName: deriveFirstName(user.name),
+  });
+});
+
+onboarding.post("/greeting", async (c) => {
+  const currentUserId = c.get("currentUserId") as string;
+  await markOnboardingGreeted(currentUserId);
+  return c.json({ status: "ok" });
+});
+
+export { onboarding };

--- a/packages/server/src/services/users.ts
+++ b/packages/server/src/services/users.ts
@@ -178,6 +178,23 @@ export async function markEmailVerified(userId: string): Promise<User> {
   return updated;
 }
 
+// spec-206 t-1 (dec-3 / dec-4 / ac-14): stamp the first-run greeting flag.
+// Idempotent — the FIRST greeting wins; a later call is a no-op that preserves
+// the original timestamp, so the auto-greeting never re-fires (on any device).
+// Called by the client only once Specky's opening turn reaches `active` (dec-4).
+export async function markOnboardingGreeted(userId: string): Promise<User> {
+  const existing = await getUserById(userId);
+  if (!existing) throw new ValidationError(`User ${userId} not found`);
+  if (existing.onboardingGreetedAt) return existing;
+
+  const [updated] = await db
+    .update(users)
+    .set({ onboardingGreetedAt: new Date(), updatedAt: new Date() })
+    .where(eq(users.id, userId))
+    .returning();
+  return updated;
+}
+
 export async function setUserPasswordHash(userId: string, passwordHash: string): Promise<User> {
   const [updated] = await db
     .update(users)

--- a/packages/shared/src/guide-tools.test.ts
+++ b/packages/shared/src/guide-tools.test.ts
@@ -12,10 +12,26 @@ import {
 
 const AC26 = 'mindset-prod/memex-building-itself/specs/spec-190/acs/ac-26';
 const AC28 = 'mindset-prod/memex-building-itself/specs/spec-190/acs/ac-28';
+// spec-206 t-4: the synced-walkthrough advance tool.
+const AC206_7 = 'mindset-prod/memex-building-itself/specs/spec-206/acs/ac-7';
 
 describe('guide toolset — no product-data tools (ac-28)', () => {
-  it('contains exactly highlight, navigate, search_guide and nothing else', () => {
-    expect([...GUIDE_TOOL_NAMES].sort()).toEqual(['highlight', 'navigate', 'search_guide']);
+  it('contains exactly the UI/guide tools and nothing else', () => {
+    // spec-206 added advance_demo (a pure UI affordance — no tenant data).
+    expect([...GUIDE_TOOL_NAMES].sort()).toEqual([
+      'advance_demo',
+      'highlight',
+      'navigate',
+      'search_guide',
+    ]);
+  });
+
+  it('exposes advance_demo for the demo-specs walkthrough (spec-206 ac-7)', () => {
+    const tool = GUIDE_TOOLS.find((t) => t.name === 'advance_demo');
+    expect(tool).toBeDefined();
+    expect(tool!.description.toLowerCase()).toContain('walkthrough');
+    expect(tool!.input_schema.type).toBe('object');
+    tagAc(AC206_7);
   });
 
   it('contains NO product-data / tenant-content tool', () => {

--- a/packages/shared/src/guide-tools.ts
+++ b/packages/shared/src/guide-tools.ts
@@ -64,6 +64,19 @@ export const GUIDE_TOOLS: GuideToolDefinition[] = [
       required: ['query'],
     },
   },
+  // spec-206 t-4 (dec-1): the synced demo walkthrough. A pure UI affordance — it
+  // touches NO tenant data (it just moves the on-screen demo board), so it does
+  // not breach the dec-4 boundary. The guide calls it once after narrating each
+  // phase of the demo-specs walkthrough.
+  {
+    name: 'advance_demo',
+    description:
+      'During the demo-specs walkthrough ONLY: advance the on-screen demo board to the next phase (draft → specify → build → verify → done). Call this once right after you finish narrating each phase, so the visible demo spec moves to the next column in sync with what you are saying. Takes no input; it is a no-op once already at the final phase. Never use it outside the walkthrough.',
+    input_schema: {
+      type: 'object',
+      properties: {},
+    },
+  },
 ];
 
 /** The guide tool names as a set (dispatch + guard). */

--- a/packages/ui/e2e/global-setup.ts
+++ b/packages/ui/e2e/global-setup.ts
@@ -10,11 +10,21 @@
 // the onboarding journey deliberately clears the name to walk that screen (the
 // per-test fixture re-asserts the name so it can't leak forward).
 
-import { ensureUser, setUserName, DEV_EMAIL, DEV_NAME } from "./helpers/index.js";
+import {
+  ensureUser,
+  setUserName,
+  setOnboardingGreeted,
+  DEV_EMAIL,
+  DEV_NAME,
+} from "./helpers/index.js";
 
 export default async function globalSetup(): Promise<void> {
   // ensureUser provisions dev@memex.ai + its personal namespace/memex through the
   // server's real services; setUserName then skips the onboarding profile screen.
   await ensureUser(DEV_EMAIL);
   await setUserName(DEV_EMAIL, DEV_NAME);
+  // spec-206: pre-stamp the dev user greeted so Specky's first-run auto-greeting
+  // doesn't fire on the first journey to load the board (the per-test fixture
+  // re-asserts this too; the onboarding journey un-greets to drive it).
+  await setOnboardingGreeted(DEV_EMAIL, true);
 }

--- a/packages/ui/e2e/helpers/fixtures.ts
+++ b/packages/ui/e2e/helpers/fixtures.ts
@@ -10,6 +10,7 @@ import { test as base, expect as pwExpect, type Page } from "@playwright/test";
 import {
   ensureUser,
   setUserName,
+  setOnboardingGreeted,
   clearOrgMemberships,
   cleanup,
 } from "./seed.js";
@@ -44,6 +45,11 @@ export const test = base.extend<{ resources: TestResources }>({
     await ensureUser(DEV_EMAIL);
     await clearOrgMemberships(DEV_EMAIL);
     await setUserName(DEV_EMAIL, DEV_NAME);
+    // spec-206: pre-stamp the dev user as already greeted so Specky's first-run
+    // auto-greeting never fires unexpectedly on a journey's first board load
+    // (it would otherwise trigger wherever a mic is available, e.g. journey-21).
+    // The onboarding journey explicitly un-greets to drive the auto-greeting.
+    await setOnboardingGreeted(DEV_EMAIL, true);
 
     const uniq = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
     const namespaceSlugs: string[] = [];

--- a/packages/ui/e2e/helpers/index.ts
+++ b/packages/ui/e2e/helpers/index.ts
@@ -18,6 +18,7 @@ export {
   ensureUser,
   setUserName,
   clearUserName,
+  setOnboardingGreeted,
   seedSpecInMemex,
   deleteDoc,
   clearOrgMemberships,

--- a/packages/ui/e2e/helpers/seed.ts
+++ b/packages/ui/e2e/helpers/seed.ts
@@ -82,6 +82,17 @@ export async function clearUserName(email: string): Promise<void> {
 }
 
 /**
+ * Set/clear a user's first-run greeting flag (spec-206). `greeted: true` stamps
+ * onboarding_greeted_at (so Specky's auto-greeting won't fire); `false` un-greets
+ * so it will. The per-test fixture pre-stamps the dev user `true` so the greeting
+ * never surprises other journeys; the onboarding journey sets it `false` to drive
+ * the auto-greeting deterministically.
+ */
+export async function setOnboardingGreeted(email: string, greeted: boolean): Promise<void> {
+  await call("POST", "/onboarding-greeted", { email, greeted });
+}
+
+/**
  * Seed a Spec into a memex through the server's createDocDraft service — so the
  * bus emits `document created` and the SSE-reactive UI sees it like a real Spec.
  * The service mints the handle; we return both the docId (cleanup) and the

--- a/packages/ui/e2e/journey-23-first-run-greeting.spec.ts
+++ b/packages/ui/e2e/journey-23-first-run-greeting.spec.ts
@@ -1,0 +1,80 @@
+import { test, expect, bareUrl, emitAcEvents, setOnboardingGreeted, DEV_EMAIL } from "./helpers/index.js";
+
+// Journey 23 — first-run Specky greeting (spec-206 t-5).
+//
+// SCOPE: the user-facing first-run surface — there is NO welcome modal (ac-17),
+// the voice greeting auto-starts on a first session with no tap (ac-1), and a
+// user who has already been greeted is NOT greeted again (ac-5 / ac-14). The
+// spoken greeting itself (mic → STT → graph → TTS) is NOT driven here — it can't
+// be made deterministic headless (same gate as journey-21); the opening-context
+// content + stamp-on-active are covered by the unit suites (t-3). This journey is
+// the std-28 gate for the surface and emits the user-facing scope ACs.
+//
+// Like journey-21, voice runs against the fake provider with a fake mic device and
+// an auto-accepted permission prompt, so the auto-start can actually reach `active`.
+
+test.use({
+  launchOptions: {
+    args: ["--use-fake-ui-for-media-stream", "--use-fake-device-for-media-stream"],
+  },
+  permissions: ["microphone"],
+});
+
+const AC1 = "mindset-prod/memex-building-itself/specs/spec-206/acs/ac-1";
+const AC5 = "mindset-prod/memex-building-itself/specs/spec-206/acs/ac-5";
+const AC14 = "mindset-prod/memex-building-itself/specs/spec-206/acs/ac-14";
+const AC17 = "mindset-prod/memex-building-itself/specs/spec-206/acs/ac-17";
+
+// Which ACs each test proves (emit on pass AND fail per the discipline).
+const ACS_BY_TITLE: Record<string, string[]> = {
+  "first session auto-starts the greeting with no tap, and no welcome modal (ac-1 / ac-17)": [AC1, AC17],
+  "a user who has already been greeted is not greeted again (ac-5 / ac-14)": [AC5, AC14],
+};
+
+test.afterEach(async ({}, testInfo) => {
+  if (testInfo.status === "skipped") return;
+  const acs = ACS_BY_TITLE[testInfo.title] ?? [];
+  if (acs.length === 0) return;
+  await emitAcEvents(
+    acs,
+    testInfo.status === "passed" ? "pass" : "fail",
+    `packages/ui/e2e/journey-23-first-run-greeting.spec.ts::${testInfo.title}`,
+    testInfo.duration,
+  );
+});
+
+test("first session auto-starts the greeting with no tap, and no welcome modal (ac-1 / ac-17)", async ({
+  page,
+}) => {
+  // Un-greet the dev user so this IS a first session (the fixture pre-stamped it).
+  await setOnboardingGreeted(DEV_EMAIL, false);
+
+  await page.goto(bareUrl("/"));
+  await expect(page.getByRole("heading", { name: "Specs" })).toBeVisible({ timeout: 15_000 });
+
+  // ac-17: the first-run experience is voice-only — NO welcome modal/dialog.
+  await expect(page.getByRole("dialog")).toHaveCount(0);
+
+  // ac-1: Specky initiates the session ITSELF — the active-session pill appears
+  // with no click on the affordance. (The pill is how an active session renders.)
+  await expect(page.locator("[data-voice-pill]")).toBeVisible({ timeout: 15_000 });
+});
+
+test("a user who has already been greeted is not greeted again (ac-5 / ac-14)", async ({
+  page,
+}) => {
+  // Mark the dev user already-greeted (the once-per-user flag is set).
+  await setOnboardingGreeted(DEV_EMAIL, true);
+
+  await page.goto(bareUrl("/"));
+  await expect(page.getByRole("heading", { name: "Specs" })).toBeVisible({ timeout: 15_000 });
+
+  // Give the first-run controller the same window it had above to (not) auto-start.
+  await page.waitForTimeout(3_000);
+
+  // ac-5 / ac-14: no auto-greeting — the idle in-view affordance is shown, not an
+  // auto-started session pill. (The user can still start one manually; it just
+  // isn't forced on them again.)
+  await expect(page.locator("[data-voice-pill]")).toHaveCount(0);
+  await expect(page.locator("[data-voice-affordance]")).toBeVisible();
+});

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -44,9 +44,11 @@ import { VoiceLayer } from './voice/session/VoiceLayer';
 import { createVoiceOrchestratorFactory } from './voice/orchestrator/voiceGuideOrchestrator';
 import { currentScreenKey } from './voice/guideElements';
 import { guideElementsForScreen } from '@memex/shared';
+import { HandholdRevealProvider, useHandholdRevealValue } from './hooks/HandholdRevealContext';
 import { tenantBase } from './api/http';
 import { SearchProvider } from './components/SearchContext';
 import { WhatsNewRibbonConnected } from './components/whats-new/WhatsNewRibbonConnected';
+import { FirstRunGreeting } from './components/onboarding/FirstRunGreeting';
 
 declare const __BUILD_TIME__: string;
 
@@ -181,22 +183,36 @@ function TenantLayout() {
   // callback; useDocChangeStream captures tenantBase() once on connect).
   return (
     <ChatProvider>
-      {/* spec-190 t-8/t-3: the voice guide is available on authed tenant routes
-          (the guide-chat SSE leg needs a session). VoiceGuideMount supplies the
-          real mic→STT→graph→TTS orchestrator factory + renders VoiceLayer beside
-          AppShell, so the shell needs no edit and the public branch — which never
-          mounts VoiceGuideMount — has no voice surface. */}
-      <VoiceGuideMount namespace={namespace ?? ''} memex={memex ?? ''}>
-        <OrgConsentDialog />
-        {/* spec-200: global What's New ribbon — authed shell only (inside
-            VoiceGuideMount so t-7's ear can reach the voice session). */}
-        <WhatsNewRibbonConnected />
-        <AppShell>
-          <Fragment key={`${namespace}/${memex}`}>
-            <Outlet />
-          </Fragment>
-        </AppShell>
-      </VoiceGuideMount>
+      {/* spec-206 t-2: one shared Handhold reveal pointer per tenant, wrapping
+          BOTH the voice layer (VoiceGuideMount threads `advance` into the
+          orchestrator's `advance_demo` tool) and the board pages (Outlet), so
+          Specky's synced walkthrough and the visible board advance together.
+          Keyed by tenant so it re-reads the per-tenant localStorage pointer. */}
+      <HandholdRevealProvider
+        key={`${namespace}/${memex}`}
+        namespace={namespace ?? null}
+        memex={memex ?? null}
+      >
+        {/* spec-190 t-8/t-3: the voice guide is available on authed tenant routes
+            (the guide-chat SSE leg needs a session). VoiceGuideMount supplies the
+            real mic→STT→graph→TTS orchestrator factory + renders VoiceLayer beside
+            AppShell, so the shell needs no edit and the public branch — which never
+            mounts VoiceGuideMount — has no voice surface. */}
+        <VoiceGuideMount namespace={namespace ?? ''} memex={memex ?? ''}>
+          <OrgConsentDialog />
+          {/* spec-200: global What's New ribbon — authed shell only (inside
+              VoiceGuideMount so t-7's ear can reach the voice session). */}
+          <WhatsNewRibbonConnected />
+          {/* spec-206 t-3: first-run greeting controller — auto-starts Specky on
+              a user's first session (no modal, no tap). Renders nothing. */}
+          <FirstRunGreeting />
+          <AppShell>
+            <Fragment key={`${namespace}/${memex}`}>
+              <Outlet />
+            </Fragment>
+          </AppShell>
+        </VoiceGuideMount>
+      </HandholdRevealProvider>
     </ChatProvider>
   );
 }
@@ -219,18 +235,23 @@ function VoiceGuideMount({
 }) {
   const { token } = useAuth();
   const navigate = useNavigate();
+  // spec-206 t-2: the shared reveal pointer's advance — threaded into the
+  // orchestrator so the guide's `advance_demo` tool walks the board during the
+  // synced walkthrough (dec-1). Read via the provider that wraps this component.
+  const { advance: advanceDemo } = useHandholdRevealValue(namespace || null, memex || null);
   // All live values flow through this ref so the factory can be created ONCE and
   // never change identity. `navigate` in particular gets a new identity on router
   // re-renders; if the factory depended on it, the provider's memoized orchestrator
   // would be recreated mid-turn — and its cleanup effect would stop() the in-flight
   // orchestrator, dropping the spoken reply (the turn finished with stopped=true).
-  const liveRef = useRef({ token, namespace, memex, navigate });
-  liveRef.current = { token, namespace, memex, navigate };
+  const liveRef = useRef({ token, namespace, memex, navigate, advanceDemo });
+  liveRef.current = { token, namespace, memex, navigate, advanceDemo };
 
   const factory = useMemo(
     () =>
       createVoiceOrchestratorFactory({
         navigate: (path: string) => liveRef.current.navigate(path),
+        advanceDemo: () => liveRef.current.advanceDemo(),
         authToken: () => liveRef.current.token,
         tenantBase: () => tenantBase(),
         origin: typeof window !== 'undefined' ? window.location.origin : '',

--- a/packages/ui/src/api/client.ts
+++ b/packages/ui/src/api/client.ts
@@ -382,6 +382,30 @@ export async function resetHandholdDemo(namespace: string, memex: string): Promi
   }
 }
 
+// spec-206 t-1/t-3: the user-level first-run greeting gate (NOT tenant-scoped).
+export interface GreetingGate {
+  /** True iff the user has never been greeted (onboarding_greeted_at IS NULL). */
+  greet: boolean;
+  /** First whitespace token of users.name, or null → warm nameless fallback. */
+  firstName: string | null;
+}
+
+/** Should Specky greet this user on first run? Called on board mount. */
+export async function fetchGreetingGate(): Promise<GreetingGate> {
+  return fetchJsonRaw<GreetingGate>(fetchWithRetry, `${BASE_URL}/onboarding/greeting`);
+}
+
+/** Stamp onboarding_greeted_at — called ONLY once the greeting actually starts
+ *  speaking (dec-4 / ac-16). Idempotent server-side; never re-greets after. */
+export async function stampGreeting(): Promise<void> {
+  const res = await fetchWithRetry(`${BASE_URL}/onboarding/greeting`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: '{}',
+  });
+  if (!res.ok) throw new Error(`Failed to stamp greeting: ${res.status}`);
+}
+
 export interface MoveDocInput {
   targetMemexId: string;
   includeDecisions: boolean;

--- a/packages/ui/src/components/onboarding/FirstRunGreeting.test.tsx
+++ b/packages/ui/src/components/onboarding/FirstRunGreeting.test.tsx
@@ -1,0 +1,134 @@
+// spec-206 t-3 — the first-run greeting controller.
+//
+// Unit: the opening-context builder carries the required beats (ac-2/3/10/11).
+// Integration: against a REAL VoiceSessionProvider (injected mic/orchestrator), the
+// controller auto-starts on a first session with no tap (ac-1), stamps only once the
+// session reaches `active` (ac-16), and no-ops when audio is unavailable (ac-15).
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { render, waitFor } from '@testing-library/react';
+
+// Mock the user-level greeting API the controller calls.
+const fetchGreetingGate = vi.fn();
+const stampGreeting = vi.fn();
+vi.mock('../../api/client', () => ({
+  fetchGreetingGate: () => fetchGreetingGate(),
+  stampGreeting: () => stampGreeting(),
+}));
+
+import { FirstRunGreeting, buildOnboardingOpeningContext } from './FirstRunGreeting';
+import { VoiceSessionProvider } from '../../voice/session/VoiceSessionContext';
+import { noopEarconPlayer } from '../../voice/session/earcons';
+import type { OrchestratorFactory } from '../../voice/session/orchestrator';
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-206/acs/ac-${n}`;
+
+// Records the opening context the provider hands the orchestrator on start().
+let recordedOpening: string | undefined;
+const recordingFactory: OrchestratorFactory = () => ({
+  start: async (_stream, opening) => {
+    recordedOpening = opening;
+  },
+  interrupt: () => {},
+  stop: () => {},
+});
+
+const fakeStream = { getTracks: () => [] } as unknown as MediaStream;
+
+function renderController(opts: { micAvailable: boolean; grant?: boolean }) {
+  return render(
+    <VoiceSessionProvider
+      orchestratorFactory={recordingFactory}
+      earcons={noopEarconPlayer}
+      detectMic={() => opts.micAvailable}
+      getUserMedia={async () => {
+        if (opts.grant === false) throw new Error('denied');
+        return fakeStream;
+      }}
+    >
+      <FirstRunGreeting />
+    </VoiceSessionProvider>,
+  );
+}
+
+beforeEach(() => {
+  fetchGreetingGate.mockReset();
+  stampGreeting.mockReset();
+  recordedOpening = undefined;
+});
+
+describe('buildOnboardingOpeningContext (spec-206 ac-2/3/10/11)', () => {
+  it('greets by first name and carries the value prop, orientation, invite, and offer', () => {
+    const ctx = buildOnboardingOpeningContext('Ryan');
+    expect(ctx).toContain('Ryan'); // ac-10: greet by first name
+    expect(ctx.toLowerCase()).toContain('living spec'); // ac-2: value prop
+    expect(ctx.toLowerCase()).toContain('phase columns'); // ac-2: on-screen orientation
+    expect(ctx.toLowerCase()).toContain('ask'); // ac-3: invite questions
+    expect(ctx.toLowerCase()).toContain('walk you through the demo specs'); // ac-3: offer
+    expect(ctx.toLowerCase()).toContain('under a minute'); // ac-2: brevity
+    tagAc(AC(2));
+    tagAc(AC(3));
+    tagAc(AC(10));
+  });
+
+  it('uses a warm nameless fallback when no name is available, never a placeholder', () => {
+    const ctx = buildOnboardingOpeningContext(null);
+    expect(ctx.toLowerCase()).toContain('hi there'); // warm nameless hello
+    expect(ctx).not.toMatch(/\bnull\b/); // never a placeholder/empty name
+    expect(ctx).not.toContain('undefined');
+    tagAc(AC(11));
+  });
+});
+
+describe('FirstRunGreeting controller', () => {
+  it('auto-starts the greeting on a first session (no tap) and stamps once active', async () => {
+    fetchGreetingGate.mockResolvedValue({ greet: true, firstName: 'Ryan' });
+    stampGreeting.mockResolvedValue(undefined);
+
+    renderController({ micAvailable: true, grant: true });
+
+    // No user interaction — the controller drives it (ac-1).
+    await waitFor(() => expect(fetchGreetingGate).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(recordedOpening).toContain('Ryan'));
+    // Session reached `active` → the flag is stamped exactly once (ac-16).
+    await waitFor(() => expect(stampGreeting).toHaveBeenCalledTimes(1));
+    tagAc(AC(1));
+    tagAc(AC(16));
+  });
+
+  it('no-ops when audio is unavailable — never greets, never stamps (ac-15)', async () => {
+    fetchGreetingGate.mockResolvedValue({ greet: true, firstName: 'Ryan' });
+
+    renderController({ micAvailable: false });
+
+    // Give any async effects a chance to (not) run.
+    await new Promise((r) => setTimeout(r, 20));
+    expect(fetchGreetingGate).not.toHaveBeenCalled(); // gate not even hit
+    expect(recordedOpening).toBeUndefined(); // session never started
+    expect(stampGreeting).not.toHaveBeenCalled(); // one-shot preserved
+    tagAc(AC(15));
+  });
+
+  it('does not greet a returning user (greet=false) and does not stamp', async () => {
+    fetchGreetingGate.mockResolvedValue({ greet: false, firstName: 'Ryan' });
+
+    renderController({ micAvailable: true, grant: true });
+
+    await waitFor(() => expect(fetchGreetingGate).toHaveBeenCalledTimes(1));
+    await new Promise((r) => setTimeout(r, 20));
+    expect(recordedOpening).toBeUndefined();
+    expect(stampGreeting).not.toHaveBeenCalled();
+  });
+
+  it('does not stamp the one-shot when mic permission is denied (ac-16)', async () => {
+    fetchGreetingGate.mockResolvedValue({ greet: true, firstName: 'Ryan' });
+
+    renderController({ micAvailable: true, grant: false });
+
+    await waitFor(() => expect(fetchGreetingGate).toHaveBeenCalledTimes(1));
+    await new Promise((r) => setTimeout(r, 20));
+    // start() was attempted but permission was denied → never `active` → no stamp.
+    expect(stampGreeting).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/components/onboarding/FirstRunGreeting.tsx
+++ b/packages/ui/src/components/onboarding/FirstRunGreeting.tsx
@@ -22,7 +22,7 @@ import { fetchGreetingGate, stampGreeting } from '../../api/client';
 
 /**
  * The seed context handed to the guide for its proactive opening turn (dec-2).
- * The guide LLM produces the actual spoken greeting from this brief. Encodes:
+ * The guide LLM produces the actual spoken greeting from this seed. Encodes:
  * a warm first-name greeting (or a nameless fallback), the value prop, on-screen
  * orientation, the open invitation, and the demo-walkthrough offer — all "under a
  * minute" (ac-2 / ac-3 / ac-10 / ac-11).
@@ -34,7 +34,7 @@ export function buildOnboardingOpeningContext(firstName: string | null): string 
   return [
     `This is the user's very first time in Memex. You are opening the conversation proactively, before they have said anything.`,
     greeting,
-    `Then, in under a minute total, give a brief spoken welcome that:`,
+    `Then, in under a minute total, give a short spoken welcome that:`,
     `1. Explains what Memex is — a living spec and shared graph that humans and AI coding agents both read and write, so the plan stays live and what's done is proven by CI.`,
     `2. Orients them to what is on screen right now — the Specs board and its phase columns (draft, specify, build, verify, done).`,
     `3. Invites them to ask you about anything they can see on the screen.`,

--- a/packages/ui/src/components/onboarding/FirstRunGreeting.tsx
+++ b/packages/ui/src/components/onboarding/FirstRunGreeting.tsx
@@ -1,0 +1,97 @@
+// spec-206 t-3 — the first-run greeting controller.
+//
+// On a user's first session, Specky initiates the conversation ITSELF — no modal,
+// no tap (ac-1). This component (mounted inside VoiceGuideMount, so it has the
+// voice session + the shared reveal pointer in scope) does four things:
+//
+//   1. On board mount, asks the server whether to greet (GET /api/onboarding/greeting).
+//   2. If greet && audio is available, auto-starts the voice session seeded with the
+//      onboarding opening context — Specky opens by greeting + explaining (dec-1/dec-2).
+//   3. If audio is unavailable (no mic / denied / no key), it no-ops — the user just
+//      lands on the board (dec-4 / ac-15). The flag is left null so a later session
+//      can still greet.
+//   4. Stamps onboarding_greeted_at ONLY once the session actually reaches `active`
+//      (dec-4 / ac-16) — a blocked/denied start never consumes the one-shot.
+//
+// Renders nothing — it's a behavioural controller, like WhatsNewRibbonConnected.
+
+import { useEffect, useRef } from 'react';
+import { useVoiceSession } from '../../voice/session/VoiceSessionContext';
+import { isAffordanceDisabled } from '../../voice/session/voiceSessionModel';
+import { fetchGreetingGate, stampGreeting } from '../../api/client';
+
+/**
+ * The seed context handed to the guide for its proactive opening turn (dec-2).
+ * The guide LLM produces the actual spoken greeting from this brief. Encodes:
+ * a warm first-name greeting (or a nameless fallback), the value prop, on-screen
+ * orientation, the open invitation, and the demo-walkthrough offer — all "under a
+ * minute" (ac-2 / ac-3 / ac-10 / ac-11).
+ */
+export function buildOnboardingOpeningContext(firstName: string | null): string {
+  const greeting = firstName
+    ? `Greet the user warmly by their first name, ${firstName}.`
+    : `Greet the user warmly — no name is available, so open with a friendly nameless hello (e.g. "Hi there — welcome to Memex!"). Never say a blank or placeholder name.`;
+  return [
+    `This is the user's very first time in Memex. You are opening the conversation proactively, before they have said anything.`,
+    greeting,
+    `Then, in under a minute total, give a brief spoken welcome that:`,
+    `1. Explains what Memex is — a living spec and shared graph that humans and AI coding agents both read and write, so the plan stays live and what's done is proven by CI.`,
+    `2. Orients them to what is on screen right now — the Specs board and its phase columns (draft, specify, build, verify, done).`,
+    `3. Invites them to ask you about anything they can see on the screen.`,
+    `4. Offers to walk them through the demo specs — ask "would you like me to walk you through the demo specs?".`,
+    `Keep it warm, concise, and conversational — this is a spoken greeting, not a script reading.`,
+  ].join('\n');
+}
+
+export function FirstRunGreeting(): null {
+  const session = useVoiceSession();
+  const { start, status, micAvailable } = session;
+  // Guard one-shots: we auto-start at most once, and stamp at most once — and only
+  // for a greeting WE initiated (a user-started session must never stamp the flag).
+  const startedRef = useRef(false);
+  const stampedRef = useRef(false);
+
+  // 1–3: check the gate once on mount and auto-start when eligible + audible.
+  useEffect(() => {
+    if (startedRef.current) return;
+    // Audio can't run → no-op, land on board (ac-15). Don't even hit the gate, so
+    // the one-shot is preserved for a later session that does have a mic.
+    if (isAffordanceDisabled({ status, micAvailable } as Parameters<typeof isAffordanceDisabled>[0])) {
+      return;
+    }
+    let cancelled = false;
+    void (async () => {
+      let gate;
+      try {
+        gate = await fetchGreetingGate();
+      } catch {
+        return; // gate unreachable → silently skip; never block the board
+      }
+      if (cancelled || !gate.greet || startedRef.current) return;
+      startedRef.current = true;
+      // start() itself requests mic permission; a denial routes to permission_denied
+      // (not active), so the stamp effect below won't fire — the one-shot survives.
+      void start(buildOnboardingOpeningContext(gate.firstName));
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // Mount-once: live status is read by the stamp effect below.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // 4: stamp only once the greeting actually starts speaking (status → active).
+  useEffect(() => {
+    if (!startedRef.current || stampedRef.current) return;
+    if (status === 'active') {
+      stampedRef.current = true;
+      void stampGreeting().catch(() => {
+        // Stamp failed — allow a retry on a later 'active' transition rather than
+        // burning the one-shot on a network blip.
+        stampedRef.current = false;
+      });
+    }
+  }, [status]);
+
+  return null;
+}

--- a/packages/ui/src/hooks/HandholdRevealContext.test.tsx
+++ b/packages/ui/src/hooks/HandholdRevealContext.test.tsx
@@ -1,0 +1,65 @@
+// spec-206 t-2 (ac-8): the reveal pointer is lifted to a SHARED, commandable
+// surface. One provider drives every consumer (the board + the voice-layer
+// bridge), so an orchestrator-issued advance walks the demo phase everyone reads.
+// Without a provider, the consumer falls back to a standalone pointer (preserving
+// the many existing SpecList/DocDocument tests that render without it).
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { render, screen, act } from '@testing-library/react';
+import { HandholdRevealProvider, useHandholdRevealValue } from './HandholdRevealContext';
+
+const AC8 = 'mindset-prod/memex-building-itself/specs/spec-206/acs/ac-8';
+
+// A board-ish consumer that shows the revealed phase.
+function PhaseReadout({ label }: { label: string }) {
+  const { revealedPhase } = useHandholdRevealValue('acme', 'team');
+  return <span data-testid={label}>{revealedPhase}</span>;
+}
+
+// Stands in for the voice-layer bridge: holds the advance fn the orchestrator calls.
+let orchestratorAdvance: () => void = () => {};
+function OrchestratorBridge() {
+  const { advance } = useHandholdRevealValue('acme', 'team');
+  orchestratorAdvance = advance;
+  return null;
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+  orchestratorAdvance = () => {};
+});
+
+describe('HandholdRevealProvider — shared, commandable reveal pointer (spec-206 ac-8)', () => {
+  it('an orchestrator-issued advance walks the phase for every board consumer', () => {
+    render(
+      <HandholdRevealProvider namespace="acme" memex="team">
+        <PhaseReadout label="board-a" />
+        <PhaseReadout label="board-b" />
+        <OrchestratorBridge />
+      </HandholdRevealProvider>,
+    );
+
+    // Both consumers start at the default first phase.
+    expect(screen.getByTestId('board-a').textContent).toBe('draft');
+    expect(screen.getByTestId('board-b').textContent).toBe('draft');
+
+    // The "orchestrator" advances — both shared consumers move together.
+    act(() => orchestratorAdvance());
+    expect(screen.getByTestId('board-a').textContent).toBe('specify');
+    expect(screen.getByTestId('board-b').textContent).toBe('specify');
+
+    act(() => orchestratorAdvance());
+    expect(screen.getByTestId('board-a').textContent).toBe('build');
+    expect(screen.getByTestId('board-b').textContent).toBe('build');
+
+    tagAc(AC8);
+  });
+
+  it('falls back to a standalone pointer when no provider is mounted', () => {
+    // No provider — the consumer still works (default phase), proving the
+    // back-compat path the existing page tests rely on.
+    render(<PhaseReadout label="solo" />);
+    expect(screen.getByTestId('solo').textContent).toBe('draft');
+  });
+});

--- a/packages/ui/src/hooks/HandholdRevealContext.tsx
+++ b/packages/ui/src/hooks/HandholdRevealContext.tsx
@@ -1,0 +1,54 @@
+// spec-206 t-2 (dec-1): lift the Handhold reveal pointer to a SHARED, orchestrator-
+// commandable surface.
+//
+// spec-178 instantiated `useHandholdReveal` as LOCAL state in two places
+// (SpecList + DocDocument), reconciled only through localStorage on mount. The
+// Specky synced walkthrough (spec-206 dec-1) needs the voice orchestrator to drive
+// the SAME pointer the board reads, so Specky's narration and the visible board
+// advance together. This provider owns one pointer per tenant and hands it to both
+// the pages and the voice layer (App.tsx threads `advance` into the orchestrator's
+// react deps → the `advance_demo` guide tool).
+//
+// Back-compat: the consumer hook FALLS BACK to a standalone `useHandholdReveal`
+// when no provider is mounted, so the pages still work in isolation (the many
+// existing SpecList/DocDocument tests render them without this provider).
+
+import { createContext, useContext, type ReactNode } from 'react';
+import { useHandholdReveal, type HandholdReveal } from './useHandholdReveal';
+
+const HandholdRevealContext = createContext<HandholdReveal | null>(null);
+
+/** Owns one reveal pointer for the current tenant and shares it with every
+ *  descendant (board pages + the voice layer). Key this by `${ns}/${mx}` at the
+ *  call site so it re-reads the per-tenant localStorage pointer on tenant change. */
+export function HandholdRevealProvider({
+  namespace,
+  memex,
+  children,
+}: {
+  namespace: string | null;
+  memex: string | null;
+  children: ReactNode;
+}): React.JSX.Element {
+  const reveal = useHandholdReveal(namespace, memex);
+  return (
+    <HandholdRevealContext.Provider value={reveal}>
+      {children}
+    </HandholdRevealContext.Provider>
+  );
+}
+
+/**
+ * The reveal pointer for the current tenant. Returns the shared provider value
+ * when one is mounted (the real app), otherwise a standalone instance keyed by the
+ * passed tenant (test/isolation fallback). `useHandholdReveal` is always called so
+ * the rules of hooks hold regardless of which branch wins.
+ */
+export function useHandholdRevealValue(
+  ns: string | null,
+  mx: string | null,
+): HandholdReveal {
+  const shared = useContext(HandholdRevealContext);
+  const standalone = useHandholdReveal(ns, mx);
+  return shared ?? standalone;
+}

--- a/packages/ui/src/pages/DocDocument.tsx
+++ b/packages/ui/src/pages/DocDocument.tsx
@@ -55,7 +55,8 @@ import { formatDate, docSeq } from '../utils/format';
 import { tenantPath, getCurrentTenant } from '../utils/tenantUrl';
 import { PromptButton } from '../components/PromptButton';
 import { useMemexAccess } from '../hooks/useMemexAccess';
-import { useHandholdReveal, nextRevealPhase } from '../hooks/useHandholdReveal';
+import { nextRevealPhase } from '../hooks/useHandholdReveal';
+import { useHandholdRevealValue } from '../hooks/HandholdRevealContext';
 import { BylineAssignees } from '../components/BylineAssignees';
 import { useDocRole } from '../hooks/useDocRole';
 import { useOrgScaffoldBlocks } from '../hooks/useOrgScaffoldBlocks';
@@ -82,7 +83,7 @@ export function DocDocument() {
     revealedPhase,
     advance: advanceReveal,
     reset: resetReveal,
-  } = useHandholdReveal(namespace ?? null, memex ?? null);
+  } = useHandholdRevealValue(namespace ?? null, memex ?? null);
   // spec-111 t-8: gate every mutation surface on this doc page behind write
   // access to the current Memex. A non-member reading a public Memex sees the
   // full document, decisions, tasks, ACs, and comments — but no edit/create/

--- a/packages/ui/src/pages/SpecList.tsx
+++ b/packages/ui/src/pages/SpecList.tsx
@@ -17,7 +17,8 @@ import { RenameSpecDialog } from '../components/RenameSpecDialog';
 import { MoveSpecDialog } from '../components/MoveSpecDialog';
 import { tenantPath, getCurrentTenant } from '../utils/tenantUrl';
 import { useAuth } from '../components/AuthContext';
-import { useHandholdReveal, nextRevealPhase, type RevealPhase } from '../hooks/useHandholdReveal';
+import { nextRevealPhase, type RevealPhase } from '../hooks/useHandholdReveal';
+import { useHandholdRevealValue } from '../hooks/HandholdRevealContext';
 import { useIsFeatureHidden } from '../hooks/useIsFeatureHidden';
 import { useMemexAccess } from '../hooks/useMemexAccess';
 import { CreateOrgBanner } from '../components/CreateOrgBanner';
@@ -414,7 +415,10 @@ export function SpecList() {
   // tracks its own walkthrough. `getCurrentTenant()` is null on caller-scoped
   // routes; the hook is null-safe and just collapses to a shared key there.
   const revealTenant = getCurrentTenant();
-  const { revealedPhase, advance: advanceReveal, reset: resetReveal } = useHandholdReveal(
+  // spec-206 t-2: read the SHARED reveal pointer (provider in App.tsx) so the
+  // Specky synced walkthrough and the board advance together; falls back to a
+  // standalone pointer when no provider is mounted (isolation/tests).
+  const { revealedPhase, advance: advanceReveal, reset: resetReveal } = useHandholdRevealValue(
     revealTenant?.namespace ?? null,
     revealTenant?.memex ?? null,
   );

--- a/packages/ui/src/voice/guideGraph.test.ts
+++ b/packages/ui/src/voice/guideGraph.test.ts
@@ -125,9 +125,12 @@ describe('guide graph (ac-11)', () => {
     tagAc(AC11);
   });
 
-  it('classifies highlight/navigate as client tools and search_guide as a server tool', () => {
+  it('classifies highlight/navigate/advance_demo as client tools and search_guide as a server tool', () => {
     expect(GUIDE_CLIENT_TOOLS.has('highlight')).toBe(true);
     expect(GUIDE_CLIENT_TOOLS.has('navigate')).toBe(true);
+    // spec-206 t-4: the synced-walkthrough advance is React-executed (the graph
+    // routes it to onUiTool → dispatchGuideUiTool → the shared reveal pointer).
+    expect(GUIDE_CLIENT_TOOLS.has('advance_demo')).toBe(true);
     expect(GUIDE_CLIENT_TOOLS.has('search_guide')).toBe(false);
   });
 });

--- a/packages/ui/src/voice/guideGraph.ts
+++ b/packages/ui/src/voice/guideGraph.ts
@@ -18,9 +18,10 @@ import { callGuideLlmProxy, type GuideScreenElement } from './guideLlmClient';
 import type { MessageParam, ContentBlock, ToolUseBlock } from '../agent/types';
 
 /** Tools the guide executes CLIENT-side (React performs them): highlight a
- *  registry element, navigate to a registry screen (dec-4, t-5). search_guide is
+ *  registry element, navigate to a registry screen (dec-4, t-5), and advance the
+ *  demo board during the synced walkthrough (spec-206 t-4, dec-1). search_guide is
  *  a SERVER tool (dec-6, t-6) executed via the injected executor. */
-export const GUIDE_CLIENT_TOOLS = new Set(['highlight', 'navigate']);
+export const GUIDE_CLIENT_TOOLS = new Set(['highlight', 'navigate', 'advance_demo']);
 
 export const GuideState = Annotation.Root({
   /** Anthropic-format conversation. */

--- a/packages/ui/src/voice/guideTools.test.ts
+++ b/packages/ui/src/voice/guideTools.test.ts
@@ -17,6 +17,8 @@ const AC28 = 'mindset-prod/memex-building-itself/specs/spec-190/acs/ac-28';
 // screen it's talking about; ac-4 = on request it navigates to the right section.
 const AC3 = 'mindset-prod/memex-building-itself/specs/spec-190/acs/ac-3';
 const AC4 = 'mindset-prod/memex-building-itself/specs/spec-190/acs/ac-4';
+// spec-206 t-2: the orchestrator-commandable advance.
+const AC206_8 = 'mindset-prod/memex-building-itself/specs/spec-206/acs/ac-8';
 
 function ctx(navigate = vi.fn()): NavigateContext {
   return { namespace: 'acme', memex: 'team', navigate };
@@ -76,5 +78,18 @@ describe('dispatchGuideUiTool — client toolset guard (ac-28)', () => {
     }
     expect(navigate).toHaveBeenCalledTimes(1); // only the legit navigate fired
     tagAc(AC28);
+  });
+
+  it('routes advance_demo to the wired advance callback (spec-206 ac-8)', () => {
+    const advanceDemo = vi.fn();
+    const r = dispatchGuideUiTool('advance_demo', {}, { ...ctx(), advanceDemo });
+    expect(r.ok).toBe(true);
+    expect(advanceDemo).toHaveBeenCalledTimes(1);
+    tagAc(AC206_8);
+  });
+
+  it('advance_demo is a no-op (never throws) when no advance callback is wired', () => {
+    // ctx() has no advanceDemo — degrade gracefully rather than throw.
+    expect(dispatchGuideUiTool('advance_demo', {}, ctx()).ok).toBe(false);
   });
 });

--- a/packages/ui/src/voice/guideTools.ts
+++ b/packages/ui/src/voice/guideTools.ts
@@ -40,6 +40,22 @@ export interface NavigateContext {
   memex: string;
   /** The app router's navigate (react-router). */
   navigate: (path: string) => void;
+  /** spec-206 t-2/dec-1: advance the shared Handhold reveal pointer (board walks
+   *  draft→specify→build→verify→done). Optional so callers that don't wire it
+   *  (and tests) degrade to a no-op rather than throwing. */
+  advanceDemo?: () => void;
+}
+
+export interface AdvanceDemoResult {
+  ok: boolean;
+}
+
+/** Advance the demo reveal pointer one phase (dec-1). Best-effort: a missing
+ *  callback (no provider wired) is a no-op, never a throw — mirrors highlight. */
+export function executeAdvanceDemo(ctx: NavigateContext): AdvanceDemoResult {
+  if (!ctx.advanceDemo) return { ok: false };
+  ctx.advanceDemo();
+  return { ok: true };
 }
 
 export interface NavigateResult {
@@ -62,12 +78,18 @@ export function executeNavigate(input: { screen?: string }, ctx: NavigateContext
 
 /** The names the guide executes CLIENT-side. (search_guide is a SERVER tool,
  *  handled by the graph's tools node, not here.) */
-export const GUIDE_CLIENT_TOOL_NAMES: ReadonlySet<string> = new Set(['highlight', 'navigate']);
+export const GUIDE_CLIENT_TOOL_NAMES: ReadonlySet<string> = new Set([
+  'highlight',
+  'navigate',
+  // spec-206 t-2 (dec-1): the synced-walkthrough advance. The graph emits it per
+  // narrated phase (t-4); React walks the shared reveal pointer here.
+  'advance_demo',
+]);
 
 /**
- * Dispatch a guide UI tool emitted by the graph. Knows ONLY highlight + navigate
- * — any other tool name (including any product-data tool) is not a client UI tool
- * and is refused here (dec-4 / ac-28).
+ * Dispatch a guide UI tool emitted by the graph. Knows ONLY the client UI tools
+ * (highlight / navigate / advance_demo) — any other tool name (including any
+ * product-data tool) is not a client UI tool and is refused here (dec-4 / ac-28).
  */
 export function dispatchGuideUiTool(
   name: string,
@@ -79,6 +101,8 @@ export function dispatchGuideUiTool(
       return executeHighlight(input as { elementId?: string });
     case 'navigate':
       return executeNavigate(input as { screen?: string }, ctx);
+    case 'advance_demo':
+      return executeAdvanceDemo(ctx);
     default:
       return { ok: false };
   }

--- a/packages/ui/src/voice/orchestrator/voiceGuideOrchestrator.test.ts
+++ b/packages/ui/src/voice/orchestrator/voiceGuideOrchestrator.test.ts
@@ -96,6 +96,7 @@ function hooks(): OrchestratorHooks & { states: string[]; earcons: string[]; err
 
 const react = {
   navigate: vi.fn(),
+  advanceDemo: vi.fn(),
   authToken: () => 'tok',
   tenantBase: () => '/api/ns/mx',
   origin: 'http://localhost',

--- a/packages/ui/src/voice/orchestrator/voiceGuideOrchestrator.ts
+++ b/packages/ui/src/voice/orchestrator/voiceGuideOrchestrator.ts
@@ -42,6 +42,9 @@ export interface ScreenContext {
 /** React-bound deps the factory needs (only resolvable inside the router tree). */
 export interface VoiceOrchestratorReactDeps {
   navigate: (path: string) => void;
+  /** spec-206 t-2/dec-1: advance the shared Handhold reveal pointer — the guide's
+   *  `advance_demo` tool calls this to walk the demo board during the walkthrough. */
+  advanceDemo: () => void;
   getScreenContext: () => ScreenContext;
   /** Current session bearer token (for the WS connect-query + the SSE leg). */
   authToken: () => string | null;
@@ -227,7 +230,12 @@ class VoiceGuideOrchestrator implements VoiceOrchestrator {
                 assistantText += t;
               },
               onUiTool: (name: string, _id: string, input: Record<string, unknown>) => {
-                dispatchGuideUiTool(name, input, { namespace, memex, navigate: this.react.navigate });
+                dispatchGuideUiTool(name, input, {
+                  namespace,
+                  memex,
+                  navigate: this.react.navigate,
+                  advanceDemo: this.react.advanceDemo,
+                });
               },
             },
           },


### PR DESCRIPTION
## What this is

On a user's **first session**, Specky (the voice guide) initiates the conversation itself — **no modal, no tap**: greets them warmly by first name, gives the Memex value prop, orients them to what's on screen, invites questions, and **offers to walk them through the demo specs**. On "yes", it narrates the five-phase lifecycle (draft → specify → build → verify → done) and drives the board's reveal pointer **in sync** so one demo spec walks across the columns (dec-1 synced tour).

Spec: https://memex.ai/mindset-prod/memex-building-itself/specs/spec-206

## Tasks (all 5 complete)

- **t-1 — server gate.** Migration `0082` adds `users.onboarding_greeted_at`; `markOnboardingGreeted()` (idempotent); `GET/POST /api/onboarding/greeting` (strict session, user-scoped). Added `onboarding` to the memex-resolver reserved lists so the flat route isn't resolved as a tenant.
- **t-2 — shared reveal pointer.** `HandholdRevealProvider` / `useHandholdRevealValue` lift spec-178's `useHandholdReveal` out of local `SpecList`/`DocDocument` state into a shared, commandable surface. `App.tsx` threads `advance()` into the orchestrator as the `advance_demo` client tool.
- **t-3 — greeting controller.** `FirstRunGreeting` (mounted in `VoiceGuideMount`): gate-check → `buildOnboardingOpeningContext(firstName)` → `start()` → stamp **only on `active`** (dec-4). No-ops + lands on the board when audio is unavailable; one-shot preserved.
- **t-4 — synced walkthrough.** `advance_demo` tool in `@memex/shared` GUIDE_TOOLS + client graph; `guide-system.md` walkthrough instructions; the five beats are rendered **from the spec-178 fixture** (`HANDHOLD_PHASES[].valueCallout`) — single-sourced, never a doc-lookup (honours spec-178 dec-11).
- **t-5 — e2e.** `journey-23-first-run-greeting` (auto-greet + no-modal; not-re-greeted) + `POST /api/__test__/onboarding-greeted`.

## Verification

- **17/17 ACs tagged + verified** (emitted to prod).
- **Full `make e2e-cold` → 51/51.** shared/server/ui `tsc -b` clean.

## Reviewer notes / gates

- ⚠️ **Live-audio slice is NOT headless-testable** (same gate as spec-190/200): the AC suite proves wiring, opening-context content, the gate, and once-only behaviour, but "Specky actually *speaks* the greeting and the board advances mid-walkthrough" needs a real mic + `ELEVENLABS_API_KEY` — to be checked manually on INT after this auto-deploys.
- **Cross-journey safety:** the auto-greeting would otherwise fire on the shared dev user in any mic-enabled journey (e.g. journey-21), so the per-test fixture + `global-setup` pre-stamp the dev user "greeted"; only journey-23 un-greets. journey-21 confirmed still green.
- **Pre-existing:** the lone remaining server `tsc` error (`discord-webhook.test.ts` `DiscordEmbedFooter`) is on `develop`, not from this PR.
- **Follow-up (not in this PR):** spec-73's first-run *modal* is superseded by this voice-first welcome (dec-5) — its supersede/archive note is the author's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)