### PR TITLE
fix(decisions): resolve_decision tolerates chosenOptionIndex on optionless decisions (spec-209)

### DIFF
--- a/packages/server/src/services/decisions.integration.test.ts
+++ b/packages/server/src/services/decisions.integration.test.ts
@@ -739,6 +739,9 @@ describe("resolveDecision with chosenOptionIndex", () => {
   });
 
   it("persists chosenOptionIndex when within bounds", async () => {
+    // spec-209 ac-4: the with-options path is unchanged — an in-bounds index records.
+    tagAc("mindset-prod/memex-building-itself/specs/spec-209/acs/ac-4");
+    tagAc("mindset-prod/memex-building-itself/specs/spec-209/acs/ac-2"); // scope
     const dec = await createDecision(memexId, docId, "Pick");
     await setDecisionOptions(memexId, dec.id, [
       { label: "A", trade_offs: "x" },
@@ -750,6 +753,9 @@ describe("resolveDecision with chosenOptionIndex", () => {
   });
 
   it("throws when chosenOptionIndex is out of bounds", async () => {
+    // spec-209 ac-4: the with-options path is unchanged — out-of-bounds still errors.
+    tagAc("mindset-prod/memex-building-itself/specs/spec-209/acs/ac-4");
+    tagAc("mindset-prod/memex-building-itself/specs/spec-209/acs/ac-2"); // scope
     const dec = await createDecision(memexId, docId, "Pick OOB");
     await setDecisionOptions(memexId, dec.id, [{ label: "Solo", trade_offs: "only" }]);
     await expect(
@@ -757,11 +763,17 @@ describe("resolveDecision with chosenOptionIndex", () => {
     ).rejects.toThrow(ValidationError);
   });
 
-  it("throws when chosenOptionIndex is provided but no options exist", async () => {
-    const dec = await createDecision(memexId, docId, "No options");
-    await expect(resolveDecision(memexId, dec.id, "should fail", 0)).rejects.toThrow(
-      ValidationError,
-    );
+  it("resolves on the prose when a chosenOptionIndex is supplied but no options exist (spec-209 dec-1)", async () => {
+    // Pre-spec-209 this threw "chosenOptionIndex requires options to be set" —
+    // the dominant resolve_decision failure (88% of its errors on prod). Now the
+    // meaningless index is dropped and the decision resolves on the prose.
+    tagAc("mindset-prod/memex-building-itself/specs/spec-209/acs/ac-3");
+    tagAc("mindset-prod/memex-building-itself/specs/spec-209/acs/ac-1"); // scope
+    const dec = await createDecision(memexId, docId, "No options, index supplied");
+    const resolved = await resolveDecision(memexId, dec.id, "resolved on prose", 0);
+    expect(resolved.status).toBe("resolved");
+    expect(resolved.resolution).toBe("resolved on prose");
+    expect(resolved.chosenOptionIndex).toBeNull();
   });
 
   it("works without chosenOptionIndex (legacy callers)", async () => {

--- a/packages/server/src/services/decisions.ts
+++ b/packages/server/src/services/decisions.ts
@@ -688,8 +688,17 @@ export async function resolveDecision(
     );
   }
 
-  if (chosenOptionIndex !== undefined) {
-    validateChosenIndex(decision.options as DecisionOption[] | null, chosenOptionIndex);
+  // spec-209 dec-1: graceful-degrade. A chosenOptionIndex is meaningless on a
+  // decision with no options (the common `open`, prose-resolved case), and
+  // throwing there was the dominant resolve_decision failure (88% of its errors
+  // on prod). Drop the index and resolve on the prose instead. An index on a
+  // decision that DOES have options is still validated (out-of-bounds errors).
+  // Scoped here only — validateChosenIndex and update_decision are untouched.
+  const hasOptions =
+    Array.isArray(decision.options) && (decision.options as DecisionOption[]).length > 0;
+  const effectiveChosenIndex = hasOptions ? chosenOptionIndex : undefined;
+  if (effectiveChosenIndex !== undefined) {
+    validateChosenIndex(decision.options as DecisionOption[] | null, effectiveChosenIndex);
   }
 
   const now = new Date();
@@ -708,7 +717,7 @@ export async function resolveDecision(
           status: "resolved",
           resolution,
           resolvedAt: now,
-          ...(chosenOptionIndex !== undefined ? { chosenOptionIndex } : {}),
+          ...(effectiveChosenIndex !== undefined ? { chosenOptionIndex: effectiveChosenIndex } : {}),
         })
         .where(and(eq(decisions.id, id), eq(decisions.memexId, memexId)))
         .returning();


### PR DESCRIPTION
## What

`resolve_decision` threw `ValidationError: chosenOptionIndex requires options to be set on the decision first` when an agent passed `chosenOptionIndex` on an `open` decision that has no options. Empirically this is the **dominant `resolve_decision` failure**: 13.5% overall error rate on prod (90 / 666 calls, 13 users, 30d), of which **88% (79 errors, 9 users)** is exactly this.

Memex spec: https://memex.ai/mindset-prod/memex-building-itself/specs/spec-209

## The fix

Graceful-degrade in `resolveDecision` (`services/decisions.ts`): if a `chosenOptionIndex` is supplied on a decision with no options, drop it and resolve on the `resolution` text instead of throwing.

| case | after |
|---|---|
| `chosenOptionIndex` on an optionless decision (the 88%) | resolves on the prose, index dropped |
| `chosenOptionIndex` on a decision **with** options | unchanged — out-of-bounds still errors, in-bounds persisted |
| no `chosenOptionIndex` | unchanged |

Scoped to `resolveDecision` only — `validateChosenIndex` and `update_decision` are untouched.

## Design-neutral by intent

Takes **no** position on whether optionless decisions *should* exist (mandating ≥2 options + a worthiness bar is **spec-133**'s territory / the designers' call). Compatible with either future: if options later become mandatory, this branch is harmless dead code; otherwise it's the correct lenient behaviour.

Expected effect: resolve_decision error rate **13.5% → ~1.5%**.

## Verification

ac-1..4 verified on prod (tagged tests emitting to the workspace). The previously-passing test that asserted the old throw was updated to the new behaviour; the with-options validation tests are unchanged and now also tagged.