### PR TITLE
fix(memex-server): AC coverage summary leads with the gap, not a trophy (spec-207)

### DIFF
--- a/packages/server/src/__regression__/coverage-summary-honesty.regression.test.ts
+++ b/packages/server/src/__regression__/coverage-summary-honesty.regression.test.ts
@@ -1,0 +1,176 @@
+// spec-207 — the AC coverage summary an agent reads to judge "is this Spec
+// done?" must lead with the gap, never flatter a partial result, and never let
+// a filter hide untested ACs. These pin `formatAcCoverageSummary` (the single
+// helper both renderers now route through, dec-1) so the contract can't drift
+// back to the "verified (of covered)" trophy that caused the spec-201
+// false-done.
+//
+// Pure-function assertions (no DB) — the helper is pure over the rows it's
+// handed. Tagged to the spec's three scope ACs so a green run flips them
+// verified on prod (the dogfood loop).
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { formatAcCoverageSummary } from "../agent/tool-specs.js";
+import type { AcWithVerification, VerificationState } from "../services/acs.js";
+
+const SPEC = "mindset-prod/memex-building-itself/specs/spec-207";
+const acRef = (n: number) => `${SPEC}/acs/ac-${n}`;
+
+const TOOL_SPECS_SRC = readFileSync(
+  join(__dirname, "..", "agent", "tool-specs.ts"),
+  "utf-8",
+);
+
+// A non-untested state implies the AC carries at least one test event; untested
+// implies none. `covered` keys off tests.length, so mirror that here.
+function makeAc(seq: number, state: VerificationState): AcWithVerification {
+  return {
+    ac: {
+      seq,
+      kind: "scope",
+      statement: `claim ${seq}`,
+      status: "active",
+    } as unknown as AcWithVerification["ac"],
+    canonicalRef: acRef(seq),
+    tests:
+      state === "untested"
+        ? []
+        : ([{ testIdentifier: `t-${seq}`, latestStatus: "pass", runCount: 1 }] as unknown as AcWithVerification["tests"]),
+    verificationState: state,
+    daysSinceLastRun: state === "untested" ? null : 1,
+    parents: [],
+  };
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// ac-1 — leads with the not-verified gap and its AC handles.
+// ──────────────────────────────────────────────────────────────────────────
+describe("ac-1 — summary leads with the gap, by handle", () => {
+  it("opens with the not-verified count and the failing/untested handles", () => {
+    tagAc(acRef(1));
+    const out = formatAcCoverageSummary([
+      makeAc(1, "verified"),
+      makeAc(2, "untested"),
+      makeAc(3, "failing"),
+      makeAc(4, "stale"),
+    ]);
+    expect(out).toBe("2 of 4 ACs NOT VERIFIED: ac-2 ac-3 · 75% covered (of 4)");
+  });
+
+  it("names only the not-verified ACs — verified handles never appear in the lead", () => {
+    tagAc(acRef(1));
+    const out = formatAcCoverageSummary([
+      makeAc(1, "verified"),
+      makeAc(5, "untested"),
+    ]);
+    expect(out.startsWith("1 of 2 ACs NOT VERIFIED: ac-5")).toBe(true);
+    expect(out).not.toContain("ac-1");
+  });
+
+  it("treats stale and accepted as covered, not as gaps (mirrors the nag footer)", () => {
+    tagAc(acRef(1));
+    const out = formatAcCoverageSummary([
+      makeAc(1, "stale"),
+      makeAc(2, "accepted"),
+    ]);
+    expect(out).toBe("0 of 2 ACs not verified · 100% covered (of 2)");
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// ac-2 — no "verified (of covered)" trophy; percentages over total.
+// ──────────────────────────────────────────────────────────────────────────
+describe("ac-2 — no self-selecting trophy metric", () => {
+  it("a partially covered Spec never reads as 100% verified", () => {
+    tagAc(acRef(2));
+    const out = formatAcCoverageSummary([
+      makeAc(1, "verified"),
+      makeAc(2, "untested"),
+      makeAc(3, "untested"),
+      makeAc(4, "untested"),
+    ]);
+    expect(out).toBe(
+      "3 of 4 ACs NOT VERIFIED: ac-2 ac-3 ac-4 · 25% covered (of 4)",
+    );
+    expect(out).not.toMatch(/100%/);
+    expect(out).not.toMatch(/verified \(of covered\)/);
+  });
+
+  it("denominates the coverage percentage over total, not the covered subset", () => {
+    tagAc(acRef(2));
+    // 1 covered of 4 → 25% (over total). The old trophy would have shown the
+    // single covered AC as 100% verified-of-covered.
+    const out = formatAcCoverageSummary([
+      makeAc(1, "verified"),
+      makeAc(2, "untested"),
+      makeAc(3, "untested"),
+      makeAc(4, "untested"),
+    ]);
+    expect(out).toContain("25% covered (of 4)");
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// ac-3 — a filter can't silently hide active ACs.
+// ──────────────────────────────────────────────────────────────────────────
+describe("ac-3 — filtered views surface what they hide", () => {
+  it("states how many active ACs fall outside the filter", () => {
+    tagAc(acRef(3));
+    const out = formatAcCoverageSummary([makeAc(1, "untested")], {
+      hiddenByFilter: 5,
+    });
+    expect(out).toBe(
+      "1 of 1 AC NOT VERIFIED: ac-1 · 0% covered (of 1) · ⚠ 5 active ACs outside this filter (not counted above)",
+    );
+  });
+
+  it("singularises the warning and omits it when nothing is hidden", () => {
+    tagAc(acRef(3));
+    expect(
+      formatAcCoverageSummary([makeAc(1, "verified")], { hiddenByFilter: 1 }),
+    ).toContain("⚠ 1 active AC outside this filter (not counted above)");
+    expect(
+      formatAcCoverageSummary([makeAc(1, "verified")], { hiddenByFilter: 0 }),
+    ).not.toContain("outside this filter");
+    expect(formatAcCoverageSummary([makeAc(1, "verified")])).not.toContain(
+      "outside this filter",
+    );
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// ac-4 (dec-1) — one shared helper, consumed by both renderers, no trophy.
+// Source-text wiring assertions: the runtime contract is pinned above; this
+// guards that BOTH call sites actually route through the single helper and that
+// the "verified (of covered)" computation is gone from the file entirely.
+// ──────────────────────────────────────────────────────────────────────────
+describe("ac-4 — single shared helper consumed by both call sites", () => {
+  it("exports one formatAcCoverageSummary helper", () => {
+    tagAc(acRef(4));
+    expect(TOOL_SPECS_SRC).toMatch(/export function formatAcCoverageSummary\(/);
+  });
+
+  it("formatCoverageHeader routes its headline through the helper", () => {
+    tagAc(acRef(4));
+    expect(TOOL_SPECS_SRC).toMatch(
+      /\*\*AC coverage:\*\* \$\{formatAcCoverageSummary\(active\)\}/,
+    );
+  });
+
+  it("the list_acs handler routes its headline through the helper, with the filter delta", () => {
+    tagAc(acRef(4));
+    expect(TOOL_SPECS_SRC).toMatch(
+      /formatAcCoverageSummary\(rows,\s*\{\s*hiddenByFilter\s*\}\)/,
+    );
+  });
+
+  it("the 'verified (of covered)' trophy computation is gone from the whole file", () => {
+    tagAc(acRef(4));
+    // Target the computed metric (`${pct}% verified (of covered)`), not prose
+    // mentions of the phrase in the helper's own explanatory comments.
+    expect(TOOL_SPECS_SRC).not.toMatch(/% verified \(of covered\)/);
+  });
+});

--- a/packages/server/src/__regression__/test-coverage-nudges.regression.test.ts
+++ b/packages/server/src/__regression__/test-coverage-nudges.regression.test.ts
@@ -42,9 +42,13 @@ describe("Channel 1 — list_acs surfaces coverage gap", () => {
     expect(toolSpecs).toMatch(/verificationState/);
   });
 
-  it("emits an aggregate covered/verified header at the top", () => {
+  it("emits an aggregate coverage header that leads with the gap, not a trophy", () => {
+    // spec-207 dec-1: the headline routes through formatAcCoverageSummary.
     expect(toolSpecs).toMatch(/% covered/);
-    expect(toolSpecs).toMatch(/% verified \(of covered\)/);
+    expect(toolSpecs).toMatch(/formatAcCoverageSummary/);
+    // The self-flattering "verified (of covered)" trophy is gone — a partially
+    // covered Spec must never read as 100% verified (spec-207 ac-2).
+    expect(toolSpecs).not.toMatch(/% verified \(of covered\)/);
   });
 
   it("emits a tail nudge pointing at the test-coverage topic when any AC is untested", () => {

--- a/packages/server/src/agent/tool-specs.ts
+++ b/packages/server/src/agent/tool-specs.ts
@@ -763,6 +763,60 @@ async function formatCoverageNudge(
 }
 
 /**
+ * spec-207 dec-1 — the single source of truth for the one-line AC coverage
+ * summary an agent reads to judge "is this Spec done?". Consumed by BOTH
+ * renderers — `formatCoverageHeader` (the get_doc doc-state header) and the
+ * `list_acs` handler — so the contract can't silently drift between them again.
+ * The two had already drifted in wording, and a `kind`-filtered `list_acs` once
+ * read fully green while scope ACs sat untested (the spec-201 false-done).
+ *
+ * Contract:
+ *  - LEADS WITH THE GAP: the count of not-verified ACs (untested + failing) and
+ *    their handles (`ac-1 ac-2 …`). The honest signal is never demoted to a
+ *    tail clause. (ac-1)
+ *  - No "verified (of covered)" headline — that trophy reads *better* the more
+ *    ACs you leave untested. Any percentage is denominated over the TOTAL rows
+ *    in the set, never the self-selecting covered subset. (ac-2)
+ *  - `hiddenByFilter` (list_acs only): when a kind/status filter shrank the set,
+ *    state how many active ACs fall outside it, so a filtered view can't
+ *    silently understate the gap. (ac-3)
+ *
+ * Pure over the `rows` it's handed (no DB, no clock). `stale` and `accepted`
+ * count as covered / not-a-gap, mirroring the spec-121 nag footer.
+ */
+export function formatAcCoverageSummary(
+  rows: AcWithVerification[],
+  opts: { hiddenByFilter?: number } = {},
+): string {
+  const total = rows.length;
+  const s = total === 1 ? "" : "s";
+  const notVerified = rows.filter(
+    (r) =>
+      r.verificationState === "untested" || r.verificationState === "failing",
+  );
+  const covered = rows.filter((r) => r.tests.length > 0).length;
+  const pctCovered = total === 0 ? 0 : Math.round((covered / total) * 100);
+
+  const gapLead =
+    notVerified.length === 0
+      ? `0 of ${total} AC${s} not verified`
+      : `${notVerified.length} of ${total} AC${s} NOT VERIFIED: ${notVerified
+          .map((r) => `ac-${r.ac.seq}`)
+          .join(" ")}`;
+
+  const parts = [gapLead, `${pctCovered}% covered (of ${total})`];
+
+  if (opts.hiddenByFilter && opts.hiddenByFilter > 0) {
+    const h = opts.hiddenByFilter;
+    parts.push(
+      `⚠ ${h} active AC${h === 1 ? "" : "s"} outside this filter (not counted above)`,
+    );
+  }
+
+  return parts.join(" · ");
+}
+
+/**
  * Render a one-line coverage header for a Spec, suitable for prepending to a
  * verbose doc-state dump. Returns "" when the Spec has no ACs (no signal),
  * or when the doc isn't a Spec.
@@ -777,23 +831,7 @@ async function formatCoverageHeader(
     const rows = await listAcsForBriefWithVerification(memexId, briefId);
     const active = rows.filter((r) => r.ac.status === "active");
     if (active.length === 0) return "";
-    const covered = active.filter((r) => r.tests.length > 0).length;
-    const total = active.length;
-    const untested = total - covered;
-    const failing = active.filter((r) => r.verificationState === "failing").length;
-    const verified = active.filter((r) => r.verificationState === "verified").length;
-    const pctCovered = Math.round((covered / total) * 100);
-    const pctVerified = covered === 0 ? 0 : Math.round((verified / covered) * 100);
-
-    const parts: string[] = [
-      `${total} active AC${total === 1 ? "" : "s"}`,
-      `${pctCovered}% covered`,
-      `${pctVerified}% verified (of covered)`,
-    ];
-    if (untested > 0) parts.push(`${untested} UNTESTED`);
-    if (failing > 0) parts.push(`${failing} failing`);
-
-    return `**AC coverage:** ${parts.join(" · ")}\n\n`;
+    return `**AC coverage:** ${formatAcCoverageSummary(active)}\n\n`;
   } catch {
     return "";
   }
@@ -2305,10 +2343,9 @@ export const toolSpecs: ToolSpec[] = [
       // test count + derived state. Filtering is client-side because the
       // service signature doesn't accept filters — the row set is tiny
       // (rarely > 50 ACs per Spec) so the JS pass is negligible.
-      let rows: AcWithVerification[] = await listAcsForBriefWithVerification(
-        memexId,
-        doc.id,
-      );
+      const allRows: AcWithVerification[] =
+        await listAcsForBriefWithVerification(memexId, doc.id);
+      let rows = allRows;
       if (kind) rows = rows.filter((r) => r.ac.kind === kind);
       if (status) rows = rows.filter((r) => r.ac.status === status);
 
@@ -2316,25 +2353,29 @@ export const toolSpecs: ToolSpec[] = [
         return `No ACs on ${slugs.namespace}/${slugs.memex}/specs/${doc.handle} matching the filter.`;
       }
 
-      // Aggregate header — the coverage gap is the action signal. The
-      // agent enumerates ACs constantly during build; lighting up "X
-      // untested" at the top of every list_acs response makes the gap
-      // unmissable in the context the agent is already reading.
-      const total = rows.length;
+      // spec-207 ac-3 — a kind/status filter shrinks `rows`; surface how many
+      // active ACs it hides so a filtered view can't silently understate the
+      // gap. Counted over the active set on both sides (proposed/superseded ACs
+      // aren't part of the "is this done?" signal).
+      const filterActive = Boolean(kind || status);
+      const hiddenByFilter = filterActive
+        ? allRows.filter((r) => r.ac.status === "active").length -
+          rows.filter((r) => r.ac.status === "active").length
+        : 0;
+
+      // Aggregate header — the coverage gap is the action signal. The agent
+      // enumerates ACs constantly during build; spec-207 dec-1 routes the
+      // headline through the shared `formatAcCoverageSummary` so it leads with
+      // the not-verified gap (and the filter-hiding warning) instead of a
+      // self-flattering "verified (of covered)" trophy.
       const covered = rows.filter((r) => r.tests.length > 0).length;
-      const untested = total - covered;
+      const untested = rows.length - covered;
       const verified = rows.filter((r) => r.verificationState === "verified").length;
       const failing = rows.filter((r) => r.verificationState === "failing").length;
       const stale = rows.filter((r) => r.verificationState === "stale").length;
-      const pctCovered = total === 0 ? 0 : Math.round((covered / total) * 100);
-      const pctVerified =
-        covered === 0 ? 0 : Math.round((verified / covered) * 100);
 
-      const headerParts: string[] = [
-        `${total} AC${total === 1 ? "" : "s"}`,
-        `${pctCovered}% covered (${covered}/${total} with ≥1 tagged test)`,
-        `${pctVerified}% verified (of covered)`,
-      ];
+      const summary = formatAcCoverageSummary(rows, { hiddenByFilter });
+      // Full state distribution stays below the headline as a breakdown.
       const breakdown: string[] = [];
       if (verified > 0) breakdown.push(`${verified} verified`);
       if (failing > 0) breakdown.push(`${failing} failing`);
@@ -2370,7 +2411,7 @@ export const toolSpecs: ToolSpec[] = [
         // Best-effort.
       }
 
-      const header = `${headerParts.join(" · ")}\nBreakdown: ${breakdown.join(", ")}${decisionLine}`;
+      const header = `${summary}\nBreakdown: ${breakdown.join(", ")}${decisionLine}`;
 
       // Per-row line — surfaces the AC's tagged-test count so the gap is
       // visible per AC, not just in the aggregate. UNTESTED is uppercase


### PR DESCRIPTION
## Why

The one-line AC coverage summary an agent reads to judge *"is this Spec done?"* actively flattered partial results, and a `kind`/`status` filter could silently hide the gap. This caused a real false-done: a thread building spec-201 called `list_acs({kind:'implementation'})`, read **"94% covered · 100% verified (of covered)"**, and declared done while five *scope* ACs (excluded by the filter) sat untested.

Two faults in the summary made that easy:
1. **A self-selecting denominator reads as a trophy** — the headline was `verified ÷ covered`, so the more ACs you leave untested, the *better* "100% of covered" looks.
2. **A filter silently shrinks the counted set** — `list_acs` filtered, then summarised only the survivors, with no hint that ACs existed outside the filter.

This is the surface an agent queries *directly* (distinct from spec-121's nag footer and spec-120's `assess_spec` fact sheet).

## What changed

All in `packages/server/src/agent/tool-specs.ts` (spec-207 dec-1):

- **Extract one shared `formatAcCoverageSummary(rows, opts?)` helper**, consumed by both `formatCoverageHeader` (the get_doc doc-state header) and the `list_acs` handler. The two had hand-duplicated the computation and already drifted in wording; now there's a single source of truth.
- **Leads with the gap** — `N of M ACs NOT VERIFIED: ac-2 ac-3` (untested + failing), named by handle. The honest signal is no longer demoted to a tail clause.
- **Drops the trophy** — no `verified (of covered)`; any percentage (`% covered`) is denominated over total rows, never the covered subset.
- **Filter honesty** — `list_acs` captures the pre-filter active count and appends `⚠ N active ACs outside this filter (not counted above)` when a `kind`/`status` filter shrinks the set. The `Breakdown:` and decision-coverage lines are preserved.

## Scope

Server-side summary formatter only. `formatState` (spec-203 footer), the `assess_spec` fact sheet (spec-120), the React AC-matrix UI, and the kanban acHealth path (spec-162) are untouched. No schema, no new surface (Security n/a).

## Tests

- New `coverage-summary-honesty.regression.test.ts` — pins the helper contract with inline-exact output, tagged to spec-207 ac-1..ac-4 (the dogfood loop; all four are verified on prod).
- Updated `test-coverage-nudges.regression.test.ts` — the assertion that previously *required* the `verified (of covered)` string now guards its absence.
- Full battery green: **server 3523 passed / 28 skipped**, shared 646, ac-emit-vitest 69 — 0 failures.

Spec: https://memex.ai/mindset-prod/memex-building-itself/specs/spec-207