### PR TITLE
spec-211: Specky demo walkthrough — step-by-step, speech-synced phase tour

### DIFF
--- a/packages/server/src/agent/voice/guide-prompt.test.ts
+++ b/packages/server/src/agent/voice/guide-prompt.test.ts
@@ -48,8 +48,19 @@ describe("guide system prompt — demo walkthrough beats (spec-206 t-4)", () => 
     tagAc(AC(4));
   });
 
-  it("instructs the guide to advance the demo board during the walkthrough", () => {
-    expect(text).toContain("advance_demo");
-    expect(text.toLowerCase()).toContain("walkthrough");
+  it("instructs the guide to hand the walkthrough to the app, not self-advance (spec-211 ac-15 / ac-6)", () => {
+    const lower = text.toLowerCase();
+    // The guide hands off via start_walkthrough...
+    expect(text).toContain("start_walkthrough");
+    // ...and is explicitly told NOT to drive the board itself.
+    expect(lower).toContain("do not advance the board yourself");
+    expect(lower).toContain("never call `advance_demo`");
+    // The OLD burst instruction is gone.
+    expect(text).not.toContain("After you finish narrating each phase, call `advance_demo`");
+    expect(text).not.toContain("Narrate these five phases in order when the user accepts");
+    // The beats are still single-sourced from the fixture (ac-6).
+    for (const p of HANDHOLD_PHASES) expect(text).toContain(p.valueCallout);
+    tagAc(AC(15));
+    tagAc(AC(6));
   });
 });

--- a/packages/server/src/agent/voice/guide-prompt.test.ts
+++ b/packages/server/src/agent/voice/guide-prompt.test.ts
@@ -13,6 +13,9 @@ import { HANDHOLD_PHASES } from "../../db/handhold-demo.fixture.js";
 
 const AC = (n: number) =>
   `mindset-prod/memex-building-itself/specs/spec-206/acs/ac-${n}`;
+// spec-211 t-4 reworked the walkthrough prompt — those assertions tag spec-211.
+const AC211 = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-211/acs/ac-${n}`;
 
 const blocks = buildGuideSystemBlocks({
   screenKey: "specs-list",
@@ -60,7 +63,7 @@ describe("guide system prompt — demo walkthrough beats (spec-206 t-4)", () => 
     expect(text).not.toContain("Narrate these five phases in order when the user accepts");
     // The beats are still single-sourced from the fixture (ac-6).
     for (const p of HANDHOLD_PHASES) expect(text).toContain(p.valueCallout);
-    tagAc(AC(15));
-    tagAc(AC(6));
+    tagAc(AC211(15));
+    tagAc(AC211(6));
   });
 });

--- a/packages/server/src/agent/voice/guide-prompt.ts
+++ b/packages/server/src/agent/voice/guide-prompt.ts
@@ -24,16 +24,20 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 // Read once at module load — the prompt is static.
 const GUIDE_SYSTEM = readFileSync(resolve(__dirname, "guide-system.md"), "utf8");
 
-// spec-206 t-4 (dec-1 / ac-6 / ac-9): the demo walkthrough beats, SINGLE-SOURCED
-// from the spec-178 fixture (HANDHOLD_PHASES[].valueCallout) — NOT re-typed here
-// and NOT fetched via any doc-lookup tool (the demo specs are invisible to every
-// agent surface, spec-178 dec-11). Built once at module load; static per deploy,
-// so it rides the cached system block. guide-system.md tells Specky how to narrate
-// these and when to call `advance_demo`.
+// spec-206 t-4 / spec-211 t-4 (dec-1 / ac-6 / ac-9): the demo walkthrough beats,
+// SINGLE-SOURCED from the spec-178 fixture (HANDHOLD_PHASES[].valueCallout) — NOT
+// re-typed here and NOT fetched via any doc-lookup tool (the demo specs are
+// invisible to every agent surface, spec-178 dec-11). Built once at module load;
+// static per deploy, so it rides the cached system block.
+//
+// spec-211: the app drives the walkthrough one phase at a time (it opens each demo
+// spec and advances the board). Each turn it asks the guide to narrate ONE named
+// phase — the guide uses that phase's beat below. The guide does NOT narrate all
+// five at once and does NOT advance the board itself (see guide-system.md).
 const WALKTHROUGH_BEATS = [
   "## Demo walkthrough beats",
   "",
-  "Narrate these five phases in order when the user accepts the demo-specs walkthrough, calling `advance_demo` after each (see the instructions above). One short spoken beat per phase:",
+  "Reference beats for the demo-specs walkthrough — one per phase. When the app asks you to narrate a specific phase, narrate THAT phase using its beat below (a sentence or two, spoken), then give a short cue toward the next phase. Do not narrate phases you weren't asked about, and do not advance the board yourself — the app does that.",
   "",
   ...HANDHOLD_PHASES.map((p) => `- **${p.phase}** — ${p.valueCallout}`),
 ].join("\n");

--- a/packages/server/src/agent/voice/guide-system.md
+++ b/packages/server/src/agent/voice/guide-system.md
@@ -24,7 +24,7 @@ If the user asks about their own content by description ("take me to the spec ab
 - `highlight` — visually highlight an element on the CURRENT screen (use an element id from the screen context).
 - `navigate` — take the user to another registered screen. Only registered screen keys work; for a specific entity the user names, navigate to the relevant list screen and highlight its search affordance rather than guessing.
 - `search_guide` — look something up in the product documentation when the current screen context doesn't cover it. This searches GUIDE content only, never the user's data.
-- `advance_demo` — during the demo-specs walkthrough only, move the on-screen demo board to the next phase (see "First-run demo walkthrough" below).
+- `start_walkthrough` — call this ONCE when the user accepts your offer to walk them through the demo specs; it hands the walkthrough to the app (see "First-run demo walkthrough" below).
 
 You have no other tools. You cannot create, edit, or read Specs, Standards, or any tenant content.
 
@@ -32,9 +32,9 @@ You have no other tools. You cannot create, edit, or read Specs, Standards, or a
 
 A user's personal Memex is seeded with five **demo specs** — the same example feature shown at each phase of its life (draft → specify → build → verify → done). You cannot read them (they are demo content, invisible to you like all tenant data), but their walkthrough **beats** are provided to you below under "Demo walkthrough beats". That provided text is your ONLY source for the walkthrough — narrate from it; never try to look the demo specs up.
 
-When you offer to walk the user through the demo specs and they accept (or they ask you to show how a spec evolves):
+**The app drives this walkthrough, not you.** Here is how it works:
 
-- Narrate the **five phases in order** — draft, specify, build, verify, done — using the matching beat below. Keep each to a spoken sentence or two, in your own warm voice; don't read the markdown aloud.
-- **After you finish narrating each phase, call `advance_demo`** so the demo board visibly moves that spec to the next column in sync with what you're saying. One `advance_demo` call per phase.
-- End on **done**. `advance_demo` is a no-op once you're already at the final phase, so don't call it after done.
-- If the user declines the walkthrough, don't narrate the phases or call `advance_demo` — just stay available for their questions.
+- When you offer to walk the user through the demo specs and they accept ("yes", "sure", "go on"), call **`start_walkthrough`** exactly once. Do not narrate the phases yet, and do **not** move the board yourself — calling `start_walkthrough` hands control to the app.
+- The app then opens each demo spec and moves the board one phase at a time, and on each step it will ask you to **narrate that one phase**. When asked, narrate **only that phase** using its beat below — a spoken sentence or two in your own warm voice — and end with a short cue toward the next phase (e.g. "next, let's look at specify"). Then stop and wait; the app advances the board and asks you about the next phase.
+- Never narrate all five phases at once, and never call `advance_demo` — the app advances the board in sync with you.
+- If the user declines, don't start the walkthrough — just stay available for their questions.

--- a/packages/shared/src/guide-tools.test.ts
+++ b/packages/shared/src/guide-tools.test.ts
@@ -17,13 +17,28 @@ const AC206_7 = 'mindset-prod/memex-building-itself/specs/spec-206/acs/ac-7';
 
 describe('guide toolset — no product-data tools (ac-28)', () => {
   it('contains exactly the UI/guide tools and nothing else', () => {
-    // spec-206 added advance_demo (a pure UI affordance — no tenant data).
+    // spec-206 added advance_demo, spec-211 added start_walkthrough — both pure UI
+    // affordances (no tenant data).
     expect([...GUIDE_TOOL_NAMES].sort()).toEqual([
       'advance_demo',
       'highlight',
       'navigate',
       'search_guide',
+      'start_walkthrough',
     ]);
+  });
+
+  it('exposes start_walkthrough and neutralises advance_demo so the guide never self-advances (spec-211 ac-15)', () => {
+    const start = GUIDE_TOOLS.find((t) => t.name === 'start_walkthrough');
+    expect(start).toBeDefined();
+    expect(start!.description.toLowerCase()).toContain('accept');
+    expect(start!.description.toLowerCase()).toContain('do not advance the board yourself');
+
+    // advance_demo is kept on the rail but must NOT instruct the guide to call it
+    // per phase (that was the burst); its description tells the guide NOT to call it.
+    const advance = GUIDE_TOOLS.find((t) => t.name === 'advance_demo');
+    expect(advance!.description.toLowerCase()).toContain('do not call this');
+    tagAc('mindset-prod/memex-building-itself/specs/spec-211/acs/ac-15');
   });
 
   it('exposes advance_demo for the demo-specs walkthrough (spec-206 ac-7)', () => {

--- a/packages/shared/src/guide-tools.ts
+++ b/packages/shared/src/guide-tools.ts
@@ -64,14 +64,26 @@ export const GUIDE_TOOLS: GuideToolDefinition[] = [
       required: ['query'],
     },
   },
-  // spec-206 t-4 (dec-1): the synced demo walkthrough. A pure UI affordance — it
-  // touches NO tenant data (it just moves the on-screen demo board), so it does
-  // not breach the dec-4 boundary. The guide calls it once after narrating each
-  // phase of the demo-specs walkthrough.
+  // spec-206 t-4 / spec-211 t-4 (dec-1/dec-5): a pure UI affordance — moves the
+  // on-screen demo board, touches NO tenant data. As of spec-211 the APP drives the
+  // demo walkthrough advances itself (speech-synced), so the guide does NOT call
+  // this — kept on the toolset for the rail, but neutralised in description.
   {
     name: 'advance_demo',
     description:
-      'During the demo-specs walkthrough ONLY: advance the on-screen demo board to the next phase (draft → specify → build → verify → done). Call this once right after you finish narrating each phase, so the visible demo spec moves to the next column in sync with what you are saying. Takes no input; it is a no-op once already at the final phase. Never use it outside the walkthrough.',
+      'Reserved for the demo-specs walkthrough. The app now advances the demo board itself, in sync with your narration — do NOT call this tool. To begin a walkthrough, call start_walkthrough instead.',
+    input_schema: {
+      type: 'object',
+      properties: {},
+    },
+  },
+  // spec-211 t-4 (dec-1): hand the demo walkthrough to the app. Pure UI affordance
+  // (no tenant data). The guide calls this ONCE when the user accepts the offer;
+  // the app then drives the speech-synced, one-phase-at-a-time tour.
+  {
+    name: 'start_walkthrough',
+    description:
+      'Call this ONCE when the user accepts your offer to walk them through the demo specs (e.g. they say "yes", "sure", "go on"). It hands the walkthrough to the app, which opens each demo spec and advances the board one phase at a time in sync with your narration. After calling it, narrate ONLY the phase you are asked to narrate each turn — do not narrate all phases at once and do not advance the board yourself. Takes no input.',
     input_schema: {
       type: 'object',
       properties: {},

--- a/packages/ui/e2e/journey-23-first-run-greeting.spec.ts
+++ b/packages/ui/e2e/journey-23-first-run-greeting.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, bareUrl, emitAcEvents, setOnboardingGreeted, DEV_EMAIL } from "./helpers/index.js";
+import { clearAnthropicQueue, queueAnthropicResponse } from "./helpers/anthropic-fake.js";
 
 // Journey 23 — first-run Specky greeting (spec-206 t-5).
 //
@@ -24,11 +25,14 @@ const AC1 = "mindset-prod/memex-building-itself/specs/spec-206/acs/ac-1";
 const AC5 = "mindset-prod/memex-building-itself/specs/spec-206/acs/ac-5";
 const AC14 = "mindset-prod/memex-building-itself/specs/spec-206/acs/ac-14";
 const AC17 = "mindset-prod/memex-building-itself/specs/spec-206/acs/ac-17";
+// spec-211: accepting the walkthrough opens the demo spec (the tour begins).
+const AC211_1 = "mindset-prod/memex-building-itself/specs/spec-211/acs/ac-1";
 
 // Which ACs each test proves (emit on pass AND fail per the discipline).
 const ACS_BY_TITLE: Record<string, string[]> = {
   "first session auto-starts the greeting with no tap, and no welcome modal (ac-1 / ac-17)": [AC1, AC17],
   "a user who has already been greeted is not greeted again (ac-5 / ac-14)": [AC5, AC14],
+  "accepting the walkthrough starts the guided tour and opens the demo spec (spec-211 ac-1)": [AC211_1],
 };
 
 test.afterEach(async ({}, testInfo) => {
@@ -77,4 +81,35 @@ test("a user who has already been greeted is not greeted again (ac-5 / ac-14)", 
   // isn't forced on them again.)
   await expect(page.locator("[data-voice-pill]")).toHaveCount(0);
   await expect(page.locator("[data-voice-affordance]")).toBeVisible();
+});
+
+test("accepting the walkthrough starts the guided tour and opens the demo spec (spec-211 ac-1)", async ({
+  page,
+}) => {
+  // Drive acceptance deterministically: the guide's first (proactive) turn returns
+  // the start_walkthrough tool — exactly what it emits when the user says "yes".
+  // That hands control to the client sequencer (spec-211), which OPENS the draft
+  // demo spec before any narration. (The live voice→LLM→narration timing + the
+  // per-phase board progression are unit-tested + verified live on INT.)
+  await clearAnthropicQueue();
+  await queueAnthropicResponse({
+    textDeltas: [],
+    content: [{ type: "tool_use", id: "toolu_sp211", name: "start_walkthrough", input: {} }],
+    stopReason: "tool_use",
+  });
+  // Follow-up turn after the tool_result (the graph loops back to the model).
+  await queueAnthropicResponse({
+    textDeltas: ["Let's begin."],
+    content: [{ type: "text", text: "Let's begin." }],
+    stopReason: "end_turn",
+  });
+
+  await setOnboardingGreeted(DEV_EMAIL, false);
+  await page.goto(bareUrl("/"));
+  await expect(page.getByRole("heading", { name: "Specs" })).toBeVisible({ timeout: 15_000 });
+
+  // The greeting auto-starts → its opening turn emits start_walkthrough → the
+  // sequencer opens the demo spec's detail view (/specs/<handle>), leaving the board.
+  await page.waitForURL(/\/specs\/spec-\d+(\?|#|$)/, { timeout: 20_000 });
+  expect(page.url()).toMatch(/\/specs\/spec-\d+/);
 });

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -49,6 +49,7 @@ import { tenantBase } from './api/http';
 import { SearchProvider } from './components/SearchContext';
 import { WhatsNewRibbonConnected } from './components/whats-new/WhatsNewRibbonConnected';
 import { FirstRunGreeting } from './components/onboarding/FirstRunGreeting';
+import { DemoWalkthroughController } from './voice/walkthrough/DemoWalkthroughController';
 
 declare const __BUILD_TIME__: string;
 
@@ -239,6 +240,9 @@ function VoiceGuideMount({
   // orchestrator so the guide's `advance_demo` tool walks the board during the
   // synced walkthrough (dec-1). Read via the provider that wraps this component.
   const { advance: advanceDemo } = useHandholdRevealValue(namespace || null, memex || null);
+  // spec-211 t-3: the demo-walkthrough sequencer registers its start() here; the
+  // guide's start_walkthrough tool invokes it through the orchestrator dep below.
+  const walkthroughStartRef = useRef<() => void>(() => {});
   // All live values flow through this ref so the factory can be created ONCE and
   // never change identity. `navigate` in particular gets a new identity on router
   // re-renders; if the factory depended on it, the provider's memoized orchestrator
@@ -252,6 +256,7 @@ function VoiceGuideMount({
       createVoiceOrchestratorFactory({
         navigate: (path: string) => liveRef.current.navigate(path),
         advanceDemo: () => liveRef.current.advanceDemo(),
+        startWalkthrough: () => walkthroughStartRef.current(),
         authToken: () => liveRef.current.token,
         tenantBase: () => tenantBase(),
         origin: typeof window !== 'undefined' ? window.location.origin : '',
@@ -274,6 +279,14 @@ function VoiceGuideMount({
   return (
     <VoiceSessionProvider orchestratorFactory={factory}>
       {children}
+      {/* spec-211 t-3: the demo-walkthrough sequencer (renders nothing). Inside the
+          provider so it can drive narratePhase; registers start() into the ref the
+          start_walkthrough tool calls. */}
+      <DemoWalkthroughController
+        namespace={namespace || null}
+        memex={memex || null}
+        startRef={walkthroughStartRef}
+      />
       <VoiceLayer />
     </VoiceSessionProvider>
   );

--- a/packages/ui/src/components/onboarding/FirstRunGreeting.test.tsx
+++ b/packages/ui/src/components/onboarding/FirstRunGreeting.test.tsx
@@ -26,12 +26,13 @@ const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-206/acs
 
 // Records the opening context the provider hands the orchestrator on start().
 let recordedOpening: string | undefined;
-const recordingFactory: OrchestratorFactory = () => ({
+const recordingFactory: OrchestratorFactory = (hooks) => ({
   start: async (_stream, opening) => {
     recordedOpening = opening;
   },
   interrupt: () => {},
   stop: () => {},
+  narratePhase: () => hooks.onTurnComplete?.(),
 });
 
 const fakeStream = { getTracks: () => [] } as unknown as MediaStream;

--- a/packages/ui/src/voice/guideGraph.ts
+++ b/packages/ui/src/voice/guideGraph.ts
@@ -21,7 +21,13 @@ import type { MessageParam, ContentBlock, ToolUseBlock } from '../agent/types';
  *  registry element, navigate to a registry screen (dec-4, t-5), and advance the
  *  demo board during the synced walkthrough (spec-206 t-4, dec-1). search_guide is
  *  a SERVER tool (dec-6, t-6) executed via the injected executor. */
-export const GUIDE_CLIENT_TOOLS = new Set(['highlight', 'navigate', 'advance_demo']);
+export const GUIDE_CLIENT_TOOLS = new Set([
+  'highlight',
+  'navigate',
+  'advance_demo',
+  // spec-211 t-3: handing control to the client demo-walkthrough sequencer.
+  'start_walkthrough',
+]);
 
 export const GuideState = Annotation.Root({
   /** Anthropic-format conversation. */

--- a/packages/ui/src/voice/guideTools.test.ts
+++ b/packages/ui/src/voice/guideTools.test.ts
@@ -92,4 +92,12 @@ describe('dispatchGuideUiTool — client toolset guard (ac-28)', () => {
     // ctx() has no advanceDemo — degrade gracefully rather than throw.
     expect(dispatchGuideUiTool('advance_demo', {}, ctx()).ok).toBe(false);
   });
+
+  it('routes start_walkthrough to the wired sequencer trigger (spec-211 t-3)', () => {
+    const startWalkthrough = vi.fn();
+    expect(dispatchGuideUiTool('start_walkthrough', {}, { ...ctx(), startWalkthrough }).ok).toBe(true);
+    expect(startWalkthrough).toHaveBeenCalledTimes(1);
+    // No-op (never throws) when nothing is wired.
+    expect(dispatchGuideUiTool('start_walkthrough', {}, ctx()).ok).toBe(false);
+  });
 });

--- a/packages/ui/src/voice/guideTools.ts
+++ b/packages/ui/src/voice/guideTools.ts
@@ -44,6 +44,10 @@ export interface NavigateContext {
    *  draft→specify→build→verify→done). Optional so callers that don't wire it
    *  (and tests) degrade to a no-op rather than throwing. */
   advanceDemo?: () => void;
+  /** spec-211 t-3 (dec-1): hand control to the client demo-walkthrough sequencer.
+   *  The guide calls `start_walkthrough` when the user accepts the offer; the
+   *  client then drives the speech-synced per-phase tour. Optional → no-op. */
+  startWalkthrough?: () => void;
 }
 
 export interface AdvanceDemoResult {
@@ -55,6 +59,14 @@ export interface AdvanceDemoResult {
 export function executeAdvanceDemo(ctx: NavigateContext): AdvanceDemoResult {
   if (!ctx.advanceDemo) return { ok: false };
   ctx.advanceDemo();
+  return { ok: true };
+}
+
+/** spec-211 t-3: start the client demo-walkthrough sequencer. Best-effort no-op
+ *  when nothing is wired (tests / no sequencer mounted). */
+export function executeStartWalkthrough(ctx: NavigateContext): { ok: boolean } {
+  if (!ctx.startWalkthrough) return { ok: false };
+  ctx.startWalkthrough();
   return { ok: true };
 }
 
@@ -84,6 +96,9 @@ export const GUIDE_CLIENT_TOOL_NAMES: ReadonlySet<string> = new Set([
   // spec-206 t-2 (dec-1): the synced-walkthrough advance. The graph emits it per
   // narrated phase (t-4); React walks the shared reveal pointer here.
   'advance_demo',
+  // spec-211 t-3 (dec-1): the guide calls this when the user accepts the demo
+  // walkthrough; the client sequencer then drives the speech-synced tour.
+  'start_walkthrough',
 ]);
 
 /**
@@ -103,6 +118,8 @@ export function dispatchGuideUiTool(
       return executeNavigate(input as { screen?: string }, ctx);
     case 'advance_demo':
       return executeAdvanceDemo(ctx);
+    case 'start_walkthrough':
+      return executeStartWalkthrough(ctx);
     default:
       return { ok: false };
   }

--- a/packages/ui/src/voice/orchestrator/voiceGuideOrchestrator.test.ts
+++ b/packages/ui/src/voice/orchestrator/voiceGuideOrchestrator.test.ts
@@ -79,24 +79,37 @@ function fakeGraph(behaviour: (cb: Record<string, (...a: never[]) => void>) => v
   } as unknown as ReturnType<typeof import('../guideGraph').createGuideGraph>;
 }
 
-function hooks(): OrchestratorHooks & { states: string[]; earcons: string[]; errors: string[] } {
+function hooks(): OrchestratorHooks & {
+  states: string[];
+  earcons: string[];
+  errors: string[];
+  turnCompletes: number;
+} {
   const states: string[] = [];
   const earcons: string[] = [];
   const errors: string[] = [];
+  const box = { turnCompletes: 0 };
   return {
     states,
     earcons,
     errors,
+    get turnCompletes() {
+      return box.turnCompletes;
+    },
     setLoopState: (s) => states.push(s),
     playEarcon: (e) => earcons.push(e),
     onError: (m) => errors.push(m),
     onEnded: () => {},
+    onTurnComplete: () => {
+      box.turnCompletes += 1;
+    },
   };
 }
 
 const react = {
   navigate: vi.fn(),
   advanceDemo: vi.fn(),
+  startWalkthrough: vi.fn(),
   authToken: () => 'tok',
   tenantBase: () => '/api/ns/mx',
   origin: 'http://localhost',
@@ -241,6 +254,64 @@ describe('voice orchestrator wiring (ac-11)', () => {
     expect(input.guideContext).toEqual([seed]); // entry text seeded for Specky to explain
     const spoke = sock.sent.map((s) => (typeof s === 'string' ? JSON.parse(s) : null)).find((m) => m?.type === 'speak');
     expect(spoke?.text).toContain('see what shipped');
+  });
+
+  it('narratePhase drives a proactive turn seeded with the phase beat, and speaks (spec-211 ac-7)', async () => {
+    tagAc('mindset-prod/memex-building-itself/specs/spec-211/acs/ac-7');
+    const sock = fakeSocket();
+    const graph = fakeGraph((cb) => cb.onTextDelta?.('This spec is in draft — it captures the why.' as never));
+    const h = hooks();
+    const orch = createVoiceOrchestratorFactory(react, {
+      socketFactory: sock.factory,
+      vadEngine: fakeVad().engine,
+      capture: fakeCapture(),
+      playback: fakePlayback(),
+      graph,
+      newId: () => 'narrate-1',
+    })(h);
+    await orch.start(fakeStream);
+    sock.sock.onmessage?.({ data: JSON.stringify({ type: 'ready' }) });
+
+    const beat = '**Specify the why.** The idea is captured as a Spec.';
+    orch.narratePhase(beat);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // A proactive turn ran with the beat as guideContext (no user transcript).
+    expect(graph.invoke).toHaveBeenCalledTimes(1);
+    const input = graph.invoke.mock.calls[0][0] as { guideContext: string[] };
+    expect(input.guideContext).toEqual([beat]);
+    const spoke = sock.sent.map((s) => (typeof s === 'string' ? JSON.parse(s) : null)).find((m) => m?.type === 'speak');
+    expect(spoke?.text).toContain('draft');
+  });
+
+  it('fires onTurnComplete when the narration turn finishes playing (spec-211 ac-8)', async () => {
+    tagAc('mindset-prod/memex-building-itself/specs/spec-211/acs/ac-8');
+    const sock = fakeSocket();
+    const graph = fakeGraph((cb) => cb.onTextDelta?.('Draft captures the why.' as never));
+    const playback = fakePlayback();
+    const h = hooks();
+    const orch = createVoiceOrchestratorFactory(react, {
+      socketFactory: sock.factory,
+      vadEngine: fakeVad().engine,
+      capture: fakeCapture(),
+      playback,
+      graph,
+      newId: () => 'narrate-1',
+    })(h);
+    await orch.start(fakeStream);
+    sock.sock.onmessage?.({ data: JSON.stringify({ type: 'ready' }) });
+
+    orch.narratePhase('beat');
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Speaking, not yet complete — the signal must wait for playback to drain.
+    expect(h.turnCompletes).toBe(0);
+    sock.sock.onmessage?.({ data: JSON.stringify({ type: 'audio', requestId: 'narrate-1', audio: '', isFinal: true }) });
+    expect(h.turnCompletes).toBe(0); // final chunk received, audio still playing
+    playback.drain(); // audio finished playing out
+    expect(h.turnCompletes).toBe(1);
   });
 
   it('does NOT seed an opening turn without openingContext (additive — ac-15)', async () => {

--- a/packages/ui/src/voice/orchestrator/voiceGuideOrchestrator.ts
+++ b/packages/ui/src/voice/orchestrator/voiceGuideOrchestrator.ts
@@ -45,6 +45,9 @@ export interface VoiceOrchestratorReactDeps {
   /** spec-206 t-2/dec-1: advance the shared Handhold reveal pointer — the guide's
    *  `advance_demo` tool calls this to walk the demo board during the walkthrough. */
   advanceDemo: () => void;
+  /** spec-211 t-3 (dec-1): start the client demo-walkthrough sequencer — the
+   *  guide's `start_walkthrough` tool calls this when the user accepts the offer. */
+  startWalkthrough: () => void;
   getScreenContext: () => ScreenContext;
   /** Current session bearer token (for the WS connect-query + the SSE leg). */
   authToken: () => string | null;
@@ -235,6 +238,7 @@ class VoiceGuideOrchestrator implements VoiceOrchestrator {
                   memex,
                   navigate: this.react.navigate,
                   advanceDemo: this.react.advanceDemo,
+                  startWalkthrough: this.react.startWalkthrough,
                 });
               },
             },
@@ -244,6 +248,9 @@ class VoiceGuideOrchestrator implements VoiceOrchestrator {
     } catch (err) {
       this.hooks.onError(err instanceof Error ? err.message : String(err));
       this.hooks.setLoopState('listening');
+      // spec-211 t-1: settle the turn even on error so an awaiting sequencer
+      // (dec-1) never hangs.
+      this.hooks.onTurnComplete?.();
       return;
     }
 
@@ -260,6 +267,9 @@ class VoiceGuideOrchestrator implements VoiceOrchestrator {
       this.ws?.speak(requestId, assistantText);
     } else {
       this.hooks.setLoopState('listening');
+      // spec-211 t-1: no speech to play (empty/aborted) — settle immediately so an
+      // awaiting sequencer advances rather than hangs.
+      if (!this.stopped) this.hooks.onTurnComplete?.();
     }
   }
 
@@ -280,10 +290,30 @@ class VoiceGuideOrchestrator implements VoiceOrchestrator {
     this.barge?.endTurn();
     this.speakingRequestId = null;
     this.hooks.setLoopState('listening');
+    // spec-211 t-1: the agent's spoken turn has fully played out — signal the
+    // client tour sequencer so it can advance one phase (dec-1).
+    this.hooks.onTurnComplete?.();
   }
 
   interrupt(): void {
     this.barge?.tapInterrupt();
+  }
+
+  // spec-211 t-1 (dec-1): a proactive narration turn for the demo walkthrough.
+  // No user speech — mirrors the seeded-opening path (a synthetic prompt + the
+  // phase beat as guideContext). Completion is signalled via hooks.onTurnComplete
+  // (fired when playback drains, or immediately if there's no socket/speech), so
+  // the client sequencer advances one phase only after this narration finishes.
+  narratePhase(context: string): void {
+    if (this.stopped || !this.ws) {
+      // Nothing will speak → settle now so an awaiting sequencer doesn't hang.
+      if (!this.stopped) this.hooks.onTurnComplete?.();
+      return;
+    }
+    void this.runTurn(
+      'Narrate this walkthrough step for the user in a sentence or two, then give a short cue toward the next step.',
+      [context],
+    );
   }
 
   stop(): void {

--- a/packages/ui/src/voice/session/VoiceSessionContext.tsx
+++ b/packages/ui/src/voice/session/VoiceSessionContext.tsx
@@ -45,6 +45,11 @@ export interface VoiceSessionValue extends VoiceSessionState {
   end: () => void;
   /** Retry from the permission-denied recovery UI. */
   retryPermission: () => Promise<void>;
+  /** spec-211 t-1 (dec-1): trigger a proactive narration turn for the demo
+   *  walkthrough and resolve when that spoken turn has finished playing. Resolves
+   *  immediately if no session is active. The client tour sequencer awaits this to
+   *  advance one phase at a time, synced to speech. */
+  narratePhase: (context: string) => Promise<void>;
 }
 
 const VoiceSessionContext = createContext<VoiceSessionValue | null>(null);
@@ -91,6 +96,16 @@ export function VoiceSessionProvider({
 
   const streamRef = useRef<MediaStream | null>(null);
 
+  // spec-211 t-1: the resolver for an in-flight narratePhase() promise. The
+  // orchestrator's onTurnComplete hook (and end/ended) resolves it so the client
+  // tour sequencer's await unblocks exactly when the spoken turn finishes.
+  const pendingTurnResolve = useRef<(() => void) | null>(null);
+  const resolvePendingTurn = useCallback(() => {
+    const resolve = pendingTurnResolve.current;
+    pendingTurnResolve.current = null;
+    resolve?.();
+  }, []);
+
   // Earcon player + orchestrator are created once. The orchestrator's hooks drive
   // the live loop state (only while active, so a late callback can't resurrect an
   // ended session).
@@ -109,17 +124,24 @@ export function VoiceSessionProvider({
       setLoopState: (loopState) =>
         setState((s) => (s.status === 'active' ? { ...s, loopState } : s)),
       playEarcon: (e) => earconPlayer.play(e),
-      onError: (message) =>
-        setState((s) => ({ ...s, status: 'error', error: message })),
-      onEnded: () =>
+      onError: (message) => {
+        setState((s) => ({ ...s, status: 'error', error: message }));
+        resolvePendingTurn(); // unblock a walkthrough await (spec-211 t-1)
+      },
+      onEnded: () => {
         setState((s) =>
           s.status === 'active'
             ? { ...s, status: 'inactive', loopState: 'idle' }
             : s,
-        ),
+        );
+        resolvePendingTurn(); // session ended mid-narration → unblock (spec-211 t-1)
+      },
+      // spec-211 t-1: a proactive/agent turn finished playing — resolve the
+      // pending narratePhase() promise so the sequencer advances one phase.
+      onTurnComplete: () => resolvePendingTurn(),
     };
     return orchestratorFactory(hooks);
-  }, [orchestratorFactory, earconPlayer]);
+  }, [orchestratorFactory, earconPlayer, resolvePendingTurn]);
 
   const releaseStream = useCallback(() => {
     streamRef.current?.getTracks().forEach((t) => t.stop());
@@ -169,7 +191,27 @@ export function VoiceSessionProvider({
     releaseStream();
     earconPlayer.play('end');
     setState((s) => ({ ...s, status: 'inactive', loopState: 'idle', error: null }));
-  }, [orchestrator, releaseStream, earconPlayer]);
+    // spec-211 t-1/dec-4: a Stop mid-walkthrough must unblock the sequencer's
+    // await so it can observe the ended session and halt (no orphaned advances).
+    resolvePendingTurn();
+  }, [orchestrator, releaseStream, earconPlayer, resolvePendingTurn]);
+
+  // spec-211 t-1 (dec-1): proactive narration turn → resolves when it finishes
+  // playing (via onTurnComplete) or when the session ends. No-op (resolved) if no
+  // session is active, so a sequencer that races a teardown never hangs.
+  const narratePhase = useCallback(
+    (context: string): Promise<void> => {
+      if (stateRef.current.status !== 'active') return Promise.resolve();
+      // A new narration supersedes any still-pending await (shouldn't happen with
+      // sequential awaits, but never leak a resolver).
+      resolvePendingTurn();
+      return new Promise<void>((resolve) => {
+        pendingTurnResolve.current = resolve;
+        orchestrator.narratePhase(context);
+      });
+    },
+    [orchestrator, resolvePendingTurn],
+  );
 
   // Tear down on unmount — never leave the mic hot.
   useEffect(() => {
@@ -181,8 +223,8 @@ export function VoiceSessionProvider({
   }, [orchestrator, releaseStream, earconPlayer]);
 
   const value = useMemo<VoiceSessionValue>(
-    () => ({ ...state, start, interrupt, end, retryPermission: start }),
-    [state, start, interrupt, end],
+    () => ({ ...state, start, interrupt, end, retryPermission: start, narratePhase }),
+    [state, start, interrupt, end, narratePhase],
   );
 
   return <VoiceSessionContext.Provider value={value}>{children}</VoiceSessionContext.Provider>;

--- a/packages/ui/src/voice/session/orchestrator.ts
+++ b/packages/ui/src/voice/session/orchestrator.ts
@@ -14,6 +14,10 @@ export interface OrchestratorHooks {
   onError: (message: string) => void;
   /** The loop ended on its own (not a user `end()`); fold back to inactive. */
   onEnded: () => void;
+  /** spec-211 t-1 (dec-1): an agent turn has fully played out (or settled with no
+   *  speech / an error) and the loop is back to listening. The client tour
+   *  sequencer awaits this to advance one phase only after narration finishes. */
+  onTurnComplete?: () => void;
 }
 
 export interface VoiceOrchestrator {
@@ -29,6 +33,11 @@ export interface VoiceOrchestrator {
   interrupt(): void;
   /** Full teardown — close sockets, stop playback, release nodes. */
   stop(): void;
+  /** spec-211 t-1 (dec-1): trigger a PROACTIVE narration turn (no user speech) for
+   *  the demo walkthrough — `context` is the phase's fixture beat, fed to the guide
+   *  as guideContext. Completion is signalled via `onTurnComplete`. No-op once
+   *  stopped or while a session isn't running. */
+  narratePhase(context: string): void;
 }
 
 export type OrchestratorFactory = (hooks: OrchestratorHooks) => VoiceOrchestrator;
@@ -39,8 +48,11 @@ export type OrchestratorFactory = (hooks: OrchestratorHooks) => VoiceOrchestrato
  * With the stub a started session sits in `listening` until the user ends it —
  * enough to build + demo the icon/pill (and wire Specky) ahead of the loop.
  */
-export const stubOrchestratorFactory: OrchestratorFactory = () => ({
+export const stubOrchestratorFactory: OrchestratorFactory = (hooks) => ({
   start: () => {},
   interrupt: () => {},
   stop: () => {},
+  // The stub has no audio loop, so a requested narration "completes" immediately
+  // — keeps a client sequencer driving the stub from hanging on the await.
+  narratePhase: () => hooks.onTurnComplete?.(),
 });

--- a/packages/ui/src/voice/session/voiceSession.spec-190.test.tsx
+++ b/packages/ui/src/voice/session/voiceSession.spec-190.test.tsx
@@ -42,6 +42,7 @@ function fakeOrchestrator(): {
       start: () => { calls.push('start'); },
       interrupt: () => { calls.push('interrupt'); },
       stop: () => { calls.push('stop'); },
+      narratePhase: () => { calls.push('narratePhase'); hooks.onTurnComplete?.(); },
     };
   };
   return { factory, hooks: () => captured!, calls };

--- a/packages/ui/src/voice/walkthrough/DemoWalkthroughController.tsx
+++ b/packages/ui/src/voice/walkthrough/DemoWalkthroughController.tsx
@@ -1,0 +1,91 @@
+// spec-211 t-3: mounts the demo walkthrough sequencer into the voice layer and
+// registers its `start` so the guide's `start_walkthrough` tool (emitted when the
+// user accepts — t-4) can hand control to the client. Renders nothing.
+
+import { useCallback, useEffect, useRef, type MutableRefObject } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useVoiceSession } from '../session/VoiceSessionContext';
+import { useHandholdRevealValue } from '../../hooks/HandholdRevealContext';
+import { REVEAL_PHASES, type RevealPhase } from '../../hooks/useHandholdReveal';
+import { fetchDocs } from '../../api/client';
+import { tenantPath } from '../../utils/tenantUrl';
+import type { DocSummary } from '../../api/types';
+import { runDemoTour } from './demoWalkthrough';
+import { demoSpecPathForPhase } from './demoSpecs';
+
+const DEFAULT_BOARD_PAUSE_MS = 900;
+
+const defaultFetchDemoDocs = async (): Promise<DocSummary[]> =>
+  (await fetchDocs('spec')).filter((d) => d.isDemo === true);
+
+const defaultPause = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+export interface DemoWalkthroughControllerProps {
+  namespace: string | null;
+  memex: string | null;
+  /** A ref the parent threads into the orchestrator's `startWalkthrough` dep; the
+   *  controller writes its `start` fn here so the guide tool can trigger the tour. */
+  startRef: MutableRefObject<() => void>;
+  /** Injectable for tests. */
+  fetchDemoDocs?: () => Promise<DocSummary[]>;
+  pause?: (ms: number) => Promise<void>;
+  boardPauseMs?: number;
+}
+
+export function DemoWalkthroughController({
+  namespace,
+  memex,
+  startRef,
+  fetchDemoDocs = defaultFetchDemoDocs,
+  pause = defaultPause,
+  boardPauseMs = DEFAULT_BOARD_PAUSE_MS,
+}: DemoWalkthroughControllerProps): null {
+  const session = useVoiceSession();
+  const { reset: resetReveal, advance: advanceReveal } = useHandholdRevealValue(namespace, memex);
+  const navigate = useNavigate();
+
+  // Live status for the loop's isActive() guard (avoids a stale closure).
+  const statusRef = useRef(session.status);
+  statusRef.current = session.status;
+  // narratePhase identity changes per render; read it fresh from a ref too.
+  const narrateRef = useRef(session.narratePhase);
+  narrateRef.current = session.narratePhase;
+
+  const runningRef = useRef(false);
+  const boardPath = tenantPath('/specs');
+
+  const start = useCallback(() => {
+    if (runningRef.current) return;
+    runningRef.current = true;
+    void (async () => {
+      try {
+        const docs = await fetchDemoDocs();
+        await runDemoTour({
+          phases: REVEAL_PHASES,
+          isActive: () => statusRef.current === 'active',
+          resetReveal,
+          advanceReveal,
+          openPath: (phase: RevealPhase) => demoSpecPathForPhase(docs, phase),
+          navigate,
+          boardPath,
+          narratePhase: (phase: RevealPhase) =>
+            narrateRef.current(
+              `Narrate the ${phase} phase of the demo walkthrough now, in a sentence or two, then give a short cue toward the next step.`,
+            ),
+          pause,
+          boardPauseMs,
+        });
+      } finally {
+        runningRef.current = false;
+      }
+    })();
+  }, [fetchDemoDocs, resetReveal, advanceReveal, navigate, boardPath, pause, boardPauseMs]);
+
+  // Register the start fn so the orchestrator's startWalkthrough dep can call it.
+  useEffect(() => {
+    startRef.current = start;
+  }, [start, startRef]);
+
+  return null;
+}

--- a/packages/ui/src/voice/walkthrough/demoSpecs.test.ts
+++ b/packages/ui/src/voice/walkthrough/demoSpecs.test.ts
@@ -1,0 +1,65 @@
+// spec-211 t-2 (ac-10 / ac-11): resolving the demo spec to open per phase.
+
+import { describe, it, expect } from 'vitest';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { demoSpecForPhase, demoSpecPath, demoSpecPathForPhase } from './demoSpecs';
+import type { DocSummary } from '../../api/types';
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-211/acs/ac-${n}`;
+
+function doc(partial: Partial<DocSummary>): DocSummary {
+  return {
+    id: partial.id ?? `id-${partial.handle}`,
+    handle: partial.handle ?? 'spec-1',
+    title: 'In-app Memex search (⌘K)',
+    docType: 'spec',
+    status: partial.status ?? 'draft',
+    parentDocId: null,
+    createdAt: '',
+    statusChangedAt: '',
+    sectionCount: 0,
+    pausedAt: null,
+    archivedAt: null,
+    isDemo: partial.isDemo,
+  } as DocSummary;
+}
+
+// Five demo specs (one per phase) + a couple of real specs sharing phases.
+const docs: DocSummary[] = [
+  doc({ handle: 'spec-90', status: 'draft', isDemo: true }),
+  doc({ handle: 'spec-91', status: 'specify', isDemo: true }),
+  doc({ handle: 'spec-92', status: 'build', isDemo: true }),
+  doc({ handle: 'spec-93', status: 'verify', isDemo: true }),
+  doc({ handle: 'spec-94', status: 'done', isDemo: true }),
+  doc({ handle: 'spec-7', status: 'build', isDemo: false }), // real spec, same phase
+  doc({ handle: 'spec-8', status: 'draft' }), // real spec, isDemo undefined
+];
+
+describe('demoSpecForPhase (spec-211 ac-11)', () => {
+  it('returns the isDemo doc whose status matches the phase — never a real spec', () => {
+    expect(demoSpecForPhase(docs, 'draft')?.handle).toBe('spec-90');
+    expect(demoSpecForPhase(docs, 'specify')?.handle).toBe('spec-91');
+    expect(demoSpecForPhase(docs, 'build')?.handle).toBe('spec-92'); // not spec-7 (real)
+    expect(demoSpecForPhase(docs, 'verify')?.handle).toBe('spec-93');
+    expect(demoSpecForPhase(docs, 'done')?.handle).toBe('spec-94');
+    tagAc(AC(11));
+  });
+
+  it('returns null when no demo spec is seeded for the phase', () => {
+    expect(demoSpecForPhase([doc({ handle: 'spec-8', status: 'draft' })], 'verify')).toBeNull();
+  });
+});
+
+describe('demoSpecPath / demoSpecPathForPhase (spec-211 ac-10)', () => {
+  it('builds the /specs/<handle> detail route for the demo spec at a phase', () => {
+    // Out of tenant context (jsdom default origin), tenantPath returns the bare path.
+    expect(demoSpecPath(doc({ handle: 'spec-92' }))).toBe('/specs/spec-92');
+    expect(demoSpecPathForPhase(docs, 'build')).toBe('/specs/spec-92');
+    expect(demoSpecPathForPhase(docs, 'done')).toBe('/specs/spec-94');
+    tagAc(AC(10));
+  });
+
+  it('is null for a phase with no demo spec', () => {
+    expect(demoSpecPathForPhase([], 'draft')).toBeNull();
+  });
+});

--- a/packages/ui/src/voice/walkthrough/demoSpecs.ts
+++ b/packages/ui/src/voice/walkthrough/demoSpecs.ts
@@ -1,0 +1,36 @@
+// spec-211 t-2 (dec-2): resolve which demo spec to OPEN at a given walkthrough
+// phase, and the route to it.
+//
+// The demo specs are the five frozen spec-64 copies seeded into a personal Memex
+// (spec-178) — one per phase. The client already holds them from the REST board
+// fetch (fetchDocs), each carrying `handle` / `status` / `isDemo`. Resolving the
+// per-phase demo doc from THAT list (never an agent doc-lookup) is what keeps
+// spec-178 dec-11 intact — the demo specs stay invisible to every agent surface.
+
+import type { DocSummary } from '../../api/types';
+import type { RevealPhase } from '../../hooks/useHandholdReveal';
+import { tenantPath } from '../../utils/tenantUrl';
+
+/** The demo doc revealed at `phase`: the `isDemo` doc whose status matches it.
+ *  Null if no demo spec is seeded for that phase. */
+export function demoSpecForPhase(
+  docs: DocSummary[],
+  phase: RevealPhase,
+): DocSummary | null {
+  return docs.find((d) => d.isDemo === true && d.status === phase) ?? null;
+}
+
+/** Detail-route path for a demo spec (the route the board card links to:
+ *  `/<ns>/<mx>/specs/<handle>`). */
+export function demoSpecPath(doc: DocSummary): string {
+  return tenantPath(`/specs/${doc.handle}`);
+}
+
+/** Convenience: the detail path for the demo spec at `phase`, or null if absent. */
+export function demoSpecPathForPhase(
+  docs: DocSummary[],
+  phase: RevealPhase,
+): string | null {
+  const doc = demoSpecForPhase(docs, phase);
+  return doc ? demoSpecPath(doc) : null;
+}

--- a/packages/ui/src/voice/walkthrough/demoWalkthrough.test.ts
+++ b/packages/ui/src/voice/walkthrough/demoWalkthrough.test.ts
@@ -49,6 +49,9 @@ describe('runDemoTour — speech-synced per-phase loop (spec-211)', () => {
     expect(log[log.length - 1]).toBe('nav:/board');
     tagAc(AC(1));
     tagAc(AC(3));
+    // ac-4: every phase is opened (its detail), and the opened path matches the
+    // phase being narrated — asserted by the open-before-narrate loop above.
+    tagAc(AC(4));
     tagAc(AC(12));
   });
 

--- a/packages/ui/src/voice/walkthrough/demoWalkthrough.test.ts
+++ b/packages/ui/src/voice/walkthrough/demoWalkthrough.test.ts
@@ -1,0 +1,120 @@
+// spec-211 t-3: the client tour sequencer (runDemoTour) — the speech-synced,
+// one-phase-at-a-time loop that replaces the burst.
+
+import { describe, it, expect } from 'vitest';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { runDemoTour, type DemoTourDeps } from './demoWalkthrough';
+import { REVEAL_PHASES } from '../../hooks/useHandholdReveal';
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-211/acs/ac-${n}`;
+
+function harness(overrides: Partial<DemoTourDeps> = {}) {
+  const log: string[] = [];
+  let active = true;
+  const deps: DemoTourDeps = {
+    phases: REVEAL_PHASES,
+    isActive: () => active,
+    resetReveal: () => log.push('reset'),
+    advanceReveal: () => log.push('advance'),
+    openPath: (p) => `/specs/${p}`,
+    navigate: (path) => log.push(`nav:${path}`),
+    boardPath: '/board',
+    narratePhase: async (p) => {
+      log.push(`narrate:${p}:start`);
+      await Promise.resolve();
+      log.push(`narrate:${p}:end`);
+    },
+    pause: async () => {
+      log.push('pause');
+    },
+    boardPauseMs: 0,
+    ...overrides,
+  };
+  return { log, deps, setActive: (v: boolean) => (active = v) };
+}
+
+describe('runDemoTour — speech-synced per-phase loop (spec-211)', () => {
+  it('opens each demo spec before narrating it, and ends on the board (ac-1/ac-3/ac-12)', async () => {
+    const { log, deps } = harness();
+    await runDemoTour(deps);
+
+    // Draft: opened (navigated) before its narration begins.
+    expect(log.indexOf('nav:/specs/draft')).toBeLessThan(log.indexOf('narrate:draft:start'));
+    // Every phase opens before it narrates.
+    for (const p of REVEAL_PHASES) {
+      expect(log.indexOf(`nav:/specs/${p}`)).toBeGreaterThanOrEqual(0);
+      expect(log.indexOf(`nav:/specs/${p}`)).toBeLessThan(log.indexOf(`narrate:${p}:start`));
+    }
+    // Ends back on the board (dec-3).
+    expect(log[log.length - 1]).toBe('nav:/board');
+    tagAc(AC(1));
+    tagAc(AC(3));
+    tagAc(AC(12));
+  });
+
+  it('advances exactly one phase at a time, only AFTER the prior narration finishes — no burst (ac-2/ac-9)', async () => {
+    const { log, deps } = harness();
+    await runDemoTour(deps);
+
+    // The first advance (into specify) must come AFTER draft's narration ENDED.
+    const firstAdvance = log.indexOf('advance');
+    expect(firstAdvance).toBeGreaterThan(log.indexOf('narrate:draft:end'));
+
+    // No two advances are adjacent / batched: between consecutive advances there is
+    // always a completed narration. Exactly 4 advances (draft is opened, not advanced).
+    const advances = log.filter((e) => e === 'advance');
+    expect(advances).toHaveLength(REVEAL_PHASES.length - 1);
+    // Each advance is preceded by the previous phase's narrate:end.
+    REVEAL_PHASES.slice(1).forEach((p, i) => {
+      const prev = REVEAL_PHASES[i]!; // phase before p
+      const advanceIdx = nthIndex(log, 'advance', i + 1);
+      expect(advanceIdx).toBeGreaterThan(log.indexOf(`narrate:${prev}:end`));
+      expect(advanceIdx).toBeLessThan(log.indexOf(`narrate:${p}:start`));
+    });
+    tagAc(AC(2));
+    tagAc(AC(9));
+  });
+
+  it('runs automatically through all five phases in order (ac-5/ac-13)', async () => {
+    const { log, deps } = harness();
+    await runDemoTour(deps);
+    const narrated = log.filter((e) => e.endsWith(':start')).map((e) => e.split(':')[1]);
+    expect(narrated).toEqual([...REVEAL_PHASES]);
+    tagAc(AC(5));
+    tagAc(AC(13));
+  });
+
+  it('halts immediately when the session is stopped mid-tour — no further advance/open/board-nav (ac-14)', async () => {
+    const h = harness();
+    // Stop the session at the end of the draft narration.
+    h.deps.narratePhase = async (p) => {
+      h.log.push(`narrate:${p}:start`);
+      await Promise.resolve();
+      h.log.push(`narrate:${p}:end`);
+      if (p === 'draft') h.setActive(false);
+    };
+    await runDemoTour(h.deps);
+
+    // Draft ran; nothing after it.
+    expect(h.log).toContain('narrate:draft:start');
+    expect(h.log.filter((e) => e === 'advance')).toHaveLength(0); // never advanced
+    expect(h.log.some((e) => e.startsWith('narrate:specify'))).toBe(false);
+    // The end-of-tour board nav is also suppressed (only the per-phase opens ran).
+    expect(h.log[h.log.length - 1]).toBe('narrate:draft:end');
+    tagAc(AC(14));
+  });
+
+  it('does nothing if the session is already inactive when invoked', async () => {
+    const h = harness({ isActive: () => false });
+    await runDemoTour(h.deps);
+    expect(h.log).toEqual([]);
+  });
+});
+
+function nthIndex(arr: string[], value: string, n: number): number {
+  let count = 0;
+  for (let i = 0; i < arr.length; i++) {
+    if (arr[i] === value && ++count === n) return i;
+  }
+  return -1;
+}

--- a/packages/ui/src/voice/walkthrough/demoWalkthrough.ts
+++ b/packages/ui/src/voice/walkthrough/demoWalkthrough.ts
@@ -1,0 +1,68 @@
+// spec-211 t-3 (dec-1/dec-3/dec-4): the client tour sequencer — the heart of the
+// fix. When the user accepts the walkthrough, this drives a LINEAR, speech-synced
+// loop: open the demo spec for the phase → narrate it → and only AFTER that
+// narration finishes, show the board, advance one phase, open the next spec, and
+// narrate again — through draft→specify→build→verify→done, then back to the board.
+// It NEVER advances ahead of the narration (that was the burst bug), and it halts
+// immediately if the Specky session is stopped mid-tour.
+
+import type { RevealPhase } from '../../hooks/useHandholdReveal';
+
+export interface DemoTourDeps {
+  /** Lifecycle phases in order (REVEAL_PHASES). */
+  phases: readonly RevealPhase[];
+  /** True while the Specky session is still active — checked before every step so
+   *  a Stop mid-tour halts the loop with no orphaned advance / open / board-nav. */
+  isActive: () => boolean;
+  /** Reset the reveal pointer to the first phase (draft) before the tour starts. */
+  resetReveal: () => void;
+  /** Advance the reveal pointer one phase (the board card moves a column). */
+  advanceReveal: () => void;
+  /** Detail-route path for the demo spec at a phase, or null if none is seeded. */
+  openPath: (phase: RevealPhase) => string | null;
+  /** Router navigate. */
+  navigate: (path: string) => void;
+  /** The Specs board path (where the tour starts the move + ends, dec-3). */
+  boardPath: string;
+  /** Trigger a proactive narration turn for `phase`; resolves when it finishes
+   *  playing (spec-211 t-1 — the speech-sync primitive). */
+  narratePhase: (phase: RevealPhase) => Promise<void>;
+  /** Pause helper (a short beat on the board so the card move is visible). */
+  pause: (ms: number) => Promise<void>;
+  /** How long to dwell on the board after advancing so the move is seen. */
+  boardPauseMs: number;
+}
+
+/**
+ * Run the demo walkthrough. Resolves when the tour finishes or is halted (the
+ * session ended). Pure orchestration over injected deps — no React, so it's
+ * directly testable.
+ */
+export async function runDemoTour(d: DemoTourDeps): Promise<void> {
+  if (!d.isActive()) return;
+  // Always start at the first phase, even if the board pointer drifted.
+  d.resetReveal();
+
+  for (let i = 0; i < d.phases.length; i++) {
+    if (!d.isActive()) return; // stopped → halt, no further work
+    const phase = d.phases[i]!;
+
+    if (i > 0) {
+      // Show the board and move the card one column, so the user SEES the
+      // advance — then dwell briefly before opening the next spec.
+      d.navigate(d.boardPath);
+      d.advanceReveal();
+      await d.pause(d.boardPauseMs);
+      if (!d.isActive()) return;
+    }
+
+    // Open the demo spec for this phase (its detail view), then narrate it.
+    const path = d.openPath(phase);
+    if (path) d.navigate(path);
+    if (!d.isActive()) return;
+    await d.narratePhase(phase); // resolves only when the spoken turn drains
+  }
+
+  // dec-3: end back on the board.
+  if (d.isActive()) d.navigate(d.boardPath);
+}

--- a/packages/ui/src/voice/walkthrough/greetingUnchanged.spec-211.test.ts
+++ b/packages/ui/src/voice/walkthrough/greetingUnchanged.spec-211.test.ts
@@ -1,0 +1,26 @@
+// spec-211 t-4 (ac-16): the spec-206 first-run greeting + walkthrough OFFER are
+// unchanged by this fix — only what happens AFTER "yes" changed. We assert the
+// spec-206 opening context still greets by name and still offers the walkthrough.
+
+import { describe, it, expect } from 'vitest';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { buildOnboardingOpeningContext } from '../../components/onboarding/FirstRunGreeting';
+
+const AC16 = 'mindset-prod/memex-building-itself/specs/spec-211/acs/ac-16';
+
+describe('spec-206 greeting + offer unchanged (spec-211 ac-16)', () => {
+  it('the first-run opening context still greets by first name and offers the walkthrough', () => {
+    const ctx = buildOnboardingOpeningContext('Ryan');
+    expect(ctx).toContain('Ryan'); // still greets by name
+    expect(ctx.toLowerCase()).toContain('walk them through the demo specs'); // still offers it
+    // The greeting still carries the value prop + orientation (spec-206 behaviour).
+    expect(ctx.toLowerCase()).toContain('living spec');
+    tagAc(AC16);
+  });
+
+  it('still falls back to a warm nameless greeting when no name is available', () => {
+    const ctx = buildOnboardingOpeningContext(null);
+    expect(ctx.toLowerCase()).toContain('hi there');
+    expect(ctx).not.toMatch(/\bnull\b/);
+  });
+});


### PR DESCRIPTION
## What this is

Fixes the demo-spec walkthrough delivered in **spec-206** (t-4). The wiring worked, but the choreography was wrong: on "yes, walk me through the demo specs", Specky fired all five `advance_demo` calls in one burst — the board raced draft→done instantly while Specky was still narrating draft — and it never *opened* any demo spec.

Now a **client-orchestrated, speech-synced** tour drives it: open the demo spec at draft → narrate it → and only **after** that narration finishes, show the board, advance one phase, open the next spec, narrate — through draft→specify→build→verify→done, then back to the board. Board and voice are locked together; **Stop** aborts anytime.

Spec: https://memex.ai/mindset-prod/memex-building-itself/specs/spec-211

## Tasks (all 5 complete)

- **t-1 — orchestrator seams.** Public `narratePhase(context)` (a proactive turn reusing `runTurn` + the phase beat as guideContext) + an `onTurnComplete` hook (fires on playback drain / settle); session-level `narratePhase(): Promise<void>` resolves when the spoken turn finishes — the speech-sync primitive.
- **t-2 — demo-spec resolver.** `demoSpecForPhase` / `demoSpecPath`: the per-phase demo doc + its `/specs/<handle>` route, resolved from the **REST board docs** (never an agent doc-lookup — spec-178 dec-11 intact).
- **t-3 — the sequencer.** `runDemoTour` (the linear, speech-synced loop with stop-halt + return-to-board) + `DemoWalkthroughController` + a new **`start_walkthrough` guide tool** (the guide calls it on accept → hands control to the client).
- **t-4 — prompt supersede.** `guide-system.md` + the beats block no longer self-advance; `advance_demo` neutralised (kept on the rail per dec-5); the guide narrates only the one phase the app names per step. spec-206 greeting + walkthrough **offer** unchanged.
- **t-5 — e2e.** Accepting the walkthrough deterministically opens the demo spec detail (trigger → sequencer → open).

## Verification

- **16/16 ACs tagged.**
- **Full `make e2e-cold` → 54/54** (incl. journey-21 + journey-23 — the spec-206 greeting is unaffected). shared/server/ui `tsc -b` clean.

## Reviewer notes / gates

- ⚠️ **Live voice-driven progression is manual-INT** (same gate as spec-190/200/206): the per-phase board advance is gated on fake-TTS drain + there's no headless STT, so e2e asserts the deterministic trigger→open; the full ordering (open-before-narrate, advance-only-after-narration, all five in order, Stop-halts, return-to-board) is comprehensively **unit-tested** (`runDemoTour`). Verify the live tour on INT after deploy.
- **The burst is killed three ways:** the self-advance prompt instruction is gone, `advance_demo`'s tool description tells the model not to call it, and the client sequencer is the sole driver.
- **dec-5:** only the burst *choreography* is superseded — the `advance_demo` rail + shared `useHandholdReveal` pointer + fixture beats are reused, and the spec-206 greeting/offer is untouched.
- **Pre-existing:** the lone server `tsc` error (`discord-webhook.test.ts`) is on `develop`, not from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)