### PR TITLE
fix(onboarding): backfill onboarding_greeted_at — first-run greeting only for genuinely-new users (spec-213)

### DIFF
--- a/packages/server/drizzle/0083_backfill_users_onboarding_greeted_at.sql
+++ b/packages/server/drizzle/0083_backfill_users_onboarding_greeted_at.sql
@@ -1,0 +1,30 @@
+-- spec-213 t-1 (dec-1 / ac-5): backfill onboarding_greeted_at for pre-existing users.
+--
+-- spec-206 added the first-run greeting, gated server-side on
+-- `onboarding_greeted_at IS NULL` (routes/onboarding.ts). Its schema migration
+-- (0082) added the column as NULLABLE with NO backfill, so EVERY user who already
+-- existed reads as null → eligible → auto-greeted on their next landing. That is
+-- wrong: the greeting is meant only for people arriving in Memex for the FIRST
+-- TIME IN HISTORY, not the entire pre-existing user base.
+--
+-- The gate logic is correct; only the historical data population is wrong. This
+-- migration draws the line at deploy time: every user who already exists is, by
+-- definition, not a first-time arrival, so we stamp them as already-greeted. After
+-- this runs:
+--   * existing users      → non-null → greet=false → never auto-greeted (ac-6)
+--   * new signups (later)  → null    → greet=true  → greeted exactly once (ac-7)
+--
+-- Idempotent + safe to re-run: the WHERE clause only touches still-null rows, so a
+-- row that already carries a timestamp (a user who was genuinely greeted, on any
+-- device) is left untouched and never re-stamped (ac-8). The hand-migration runner
+-- tracks this file in `manual_migrations` and wraps it in a single transaction, so
+-- it applies exactly once per database on the CI/CD `db:migrate` path (INT on
+-- develop, PROD on main).
+--
+-- One-way data correction: the revert is a documented no-op — once stamped, a
+-- backfilled row is indistinguishable from a naturally-greeted one, so there is
+-- nothing safe to roll back to.
+
+UPDATE users
+   SET onboarding_greeted_at = now()
+ WHERE onboarding_greeted_at IS NULL;

--- a/packages/server/drizzle/reverts/0083_backfill_users_onboarding_greeted_at.revert.sql
+++ b/packages/server/drizzle/reverts/0083_backfill_users_onboarding_greeted_at.revert.sql
@@ -1,0 +1,10 @@
+-- Revert spec-213 t-1 (0083_backfill_users_onboarding_greeted_at.sql).
+--
+-- Intentionally a NO-OP. The backfill is a one-way data correction: it stamped
+-- onboarding_greeted_at = now() on every previously-null row. Once stamped, a
+-- backfilled row is indistinguishable from a row stamped by a genuine greeting,
+-- so there is no safe predicate to undo only the backfilled rows. Blanket-nulling
+-- the column would wrongly re-greet users who were legitimately greeted. If the
+-- column itself ever needs removing, that is the concern of 0082's revert
+-- (DROP COLUMN), not this data migration.
+SELECT 1;

--- a/packages/server/src/routes/onboarding-backfill.api.test.ts
+++ b/packages/server/src/routes/onboarding-backfill.api.test.ts
@@ -1,0 +1,155 @@
+// spec-213 t-1 — backfill onboarding_greeted_at for pre-existing users.
+//
+// spec-206 gates the first-run greeting on `onboarding_greeted_at IS NULL`, but its
+// schema migration (0082) left the column null for the entire pre-existing user
+// base — so every existing user reads as eligible. Migration 0083 corrects the DATA
+// (not the gate): it stamps every still-null row at deploy time.
+//
+//   ac-5 — 0083 issues the canonical guarded UPDATE (SET ... = now() WHERE ... IS NULL).
+//   ac-6 — a backfilled (now non-null) user returns greet=false from the gate.
+//   ac-7 — a user still null after the backfill (a new signup) returns greet=true.
+//   ac-8 — the backfill is idempotent: a row already carrying a timestamp is untouched.
+//
+// The behavioural tests run the migration's ACTUAL UPDATE statement (read from the
+// .sql file) but SCOPED to the user ids this test creates (`AND id IN (...)`). The
+// real migration is unbounded by design; scoping here keeps it from stamping users
+// that parallel test files (e.g. onboarding.api.test.ts) create and expect to stay
+// null. The unbounded form itself is asserted statically against the file (ac-5).
+//
+// Runs against a REAL Postgres through the full Hono app + strict sessionMiddleware.
+
+import { describe, it, expect, afterAll, vi } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { inArray, sql } from "drizzle-orm";
+
+vi.hoisted(() => {
+  // Force auth-mode session middleware so per-user Bearer tokens are honored
+  // (mirrors onboarding.api.test.ts). Without GOOGLE_CLIENT_ID the middleware
+  // falls into dev-mode and authenticates everyone as dev@memex.ai.
+  process.env.GOOGLE_CLIENT_ID = "test-client.apps.googleusercontent.com";
+  process.env.AUTH_JWT_SECRET = process.env.AUTH_JWT_SECRET ?? "x".repeat(48);
+  return undefined;
+});
+
+import { db } from "../db/connection.js";
+import { app } from "../app.js";
+import { users } from "../db/schema.js";
+import { upsertUserByEmail, getUserById } from "../services/users.js";
+import { signSessionToken } from "../services/auth-jwt.js";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+const AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-213/acs/ac-${n}`;
+
+const MIGRATION_PATH = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../drizzle/0083_backfill_users_onboarding_greeted_at.sql",
+);
+
+const createdUserIds: string[] = [];
+
+function uniqueEmail(prefix: string): string {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}@example.com`;
+}
+
+async function makeUser(prefix: string) {
+  const user = await upsertUserByEmail(uniqueEmail(prefix));
+  createdUserIds.push(user.id);
+  return { id: user.id, bearer: signSessionToken(user.id) };
+}
+
+async function greet(bearer: string): Promise<boolean> {
+  const res = await app.request("/api/onboarding/greeting", {
+    headers: new Headers({ Authorization: `Bearer ${bearer}` }),
+  });
+  expect(res.status).toBe(200);
+  return (await res.json()).greet;
+}
+
+/** The exact UPDATE statement from the migration file, comments stripped and the
+ *  trailing `;` removed — so the behavioural tests run the real migration SQL. */
+function migrationUpdateStatement(): string {
+  const raw = readFileSync(MIGRATION_PATH, "utf8");
+  const sqlOnly = raw
+    .split("\n")
+    .filter((line) => !line.trim().startsWith("--"))
+    .join("\n")
+    .trim();
+  return sqlOnly.replace(/;\s*$/, "");
+}
+
+/** Run the migration's UPDATE, scoped to the given ids so it can't touch rows
+ *  other test files own. The ids are test-minted UUIDs, never user input. */
+async function runScopedBackfill(ids: string[]): Promise<void> {
+  if (ids.length === 0) return;
+  const idList = ids.map((id) => `'${id}'`).join(", ");
+  await db.execute(
+    sql.raw(`${migrationUpdateStatement()} AND id IN (${idList})`),
+  );
+}
+
+afterAll(async () => {
+  if (createdUserIds.length) {
+    await db.delete(users).where(inArray(users.id, createdUserIds));
+  }
+});
+
+describe("onboarding_greeted_at backfill (spec-213 t-1)", () => {
+  it("the migration issues the canonical guarded UPDATE (SET = now() WHERE IS NULL)", () => {
+    tagAc(AC(5));
+    const stmt = migrationUpdateStatement().replace(/\s+/g, " ").toLowerCase();
+    expect(stmt).toContain("update users");
+    expect(stmt).toContain("set onboarding_greeted_at = now()");
+    expect(stmt).toContain("where onboarding_greeted_at is null");
+    // No id/email predicate in the real migration — it stamps the whole null set.
+    expect(stmt).not.toContain(" id in (");
+    expect(stmt).not.toContain("where id");
+  });
+
+  it("a pre-existing (null) user is stamped by the backfill → greet=false", async () => {
+    tagAc(AC(6));
+    const u = await makeUser("sp213-existing");
+    // Pre-existing user: null flag, so the gate would greet them.
+    expect((await getUserById(u.id))!.onboardingGreetedAt).toBeNull();
+    expect(await greet(u.bearer)).toBe(true);
+
+    await runScopedBackfill([u.id]);
+
+    // After the backfill they carry a timestamp and are no longer greeted.
+    expect((await getUserById(u.id))!.onboardingGreetedAt).toBeInstanceOf(Date);
+    expect(await greet(u.bearer)).toBe(false);
+  });
+
+  it("a user created after the backfill is still null → greet=true (new signups preserved)", async () => {
+    tagAc(AC(7));
+    // Model a backfill that has already run over the existing population...
+    const existing = await makeUser("sp213-before");
+    await runScopedBackfill([existing.id]);
+    expect((await getUserById(existing.id))!.onboardingGreetedAt).toBeInstanceOf(Date);
+
+    // ...then a brand-new signup arrives. It was NOT in the backfill set, so its
+    // flag is null and the spec-206 first-run greeting still fires for it.
+    const newcomer = await makeUser("sp213-newcomer");
+    expect((await getUserById(newcomer.id))!.onboardingGreetedAt).toBeNull();
+    expect(await greet(newcomer.bearer)).toBe(true);
+  });
+
+  it("is idempotent — a row already stamped is not overwritten", async () => {
+    tagAc(AC(8));
+    const u = await makeUser("sp213-idem");
+
+    // First backfill stamps it.
+    await runScopedBackfill([u.id]);
+    const firstTs = (await getUserById(u.id))!.onboardingGreetedAt;
+    expect(firstTs).toBeInstanceOf(Date);
+
+    // Re-running the (guarded) backfill leaves the existing timestamp untouched —
+    // the WHERE ... IS NULL clause skips already-stamped rows, so a genuinely
+    // greeted user is never re-stamped.
+    await runScopedBackfill([u.id]);
+    const secondTs = (await getUserById(u.id))!.onboardingGreetedAt;
+    expect(secondTs!.getTime()).toBe(firstTs!.getTime());
+  });
+});


### PR DESCRIPTION
## What & why

spec-206 auto-greets a user on their **first** Memex session, gated server-side on `users.onboarding_greeted_at IS NULL`. Its schema migration (0082) added that column **nullable with no backfill**, so *every pre-existing user* reads as eligible and gets auto-greeted on their next landing — not just genuinely-new signups. **Barrie reported exactly this on INT** (he is not a new user).

The gate logic is correct; only the historical data population is wrong.

## The fix

Migration **0083** stamps every still-null row at deploy time:

```sql
UPDATE users SET onboarding_greeted_at = now() WHERE onboarding_greeted_at IS NULL;
```

After it runs on each deploy's `db:migrate`:
- **pre-existing users** → non-null → `greet=false` → never auto-greeted
- **new signups** (rows created later) → null → greeted exactly once (spec-206 preserved)

**No application-code change** — the greeting gate in `routes/onboarding.ts` / `services/users.ts` is untouched. Idempotent (guarded `WHERE ... IS NULL`), rides the hand-migration runner (tracked once in `manual_migrations`, single transaction). Revert is a documented no-op (one-way data correction).

## Verification

- Backfill suite (`onboarding-backfill.api.test.ts`) **4/4** green — tags ac-5..ac-8.
- Run alongside spec-206 `onboarding.api.test.ts` **7/7** green (no cross-test interference: the test scopes its UPDATE to its own user ids and asserts the unbounded form statically).
- `make e2e-cold` **53/53** green (incl. journey-23 "already-greeted user is not greeted again").
- tsc clean for these files (the one server tsc error is the pre-existing `discord-webhook.test.ts` issue already on develop).

## Notes

- AC test-events (ac-5..ac-8) emit only with `MEMEX_EMIT_KEY` (CI secret) — they'll flip on the CI `server` job.
- **Known limitation:** spec-206 is already live on INT, so a few existing users may have already seen the greeting during the live window — the backfill stops all *future* unintended greetings but can't retroactively un-greet them (they won't see it again regardless).

Spec: mindset-prod/memex-building-itself/specs/spec-213

🤖 Generated with [Claude Code](https://claude.com/claude-code)