### PR TITLE
feat(footer): one seat authors every tool-result footer (spec-203 ac-14..17)

### DIFF
--- a/packages/server/src/__regression__/footer-one-seat.regression.test.ts
+++ b/packages/server/src/__regression__/footer-one-seat.regression.test.ts
@@ -1,0 +1,83 @@
+// spec-203 ac-14/ac-15/ac-16/ac-17 — the footer has ONE seat of intelligence.
+//
+// A tool call is the client phoning home; the server returns the real result,
+// then uses that one opening to steer the client through a footer authored in a
+// SINGLE place (`decideFooter`) and attached at a SINGLE choke point
+// (`runToolWithSpecTraffic`), on EVERY Spec-resolving call. Source-text guards
+// (no DB) pin the wiring so a future refactor cannot re-introduce a second footer
+// author or re-gate persistence. The behavioural proof (footer rides terse +
+// persisted) lives in services/spec-203-footer.integration.test.ts.
+
+import { describe, it, expect } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-203/acs/ac-${n}`;
+
+const SERVER_ROOT = join(__dirname, "..", "..");
+const read = (p: string) => readFileSync(join(SERVER_ROOT, "src", p), "utf-8");
+
+const formatters = read(join("mcp", "formatters.ts"));
+const toolSpecs = read(join("agent", "tool-specs.ts"));
+const specTraffic = read(join("services", "spec-traffic.ts"));
+const telemetry = read(join("services", "mcp-telemetry.ts"));
+
+describe("ac-15 — one seat: the footer is composed in exactly one place", () => {
+  it("formatFullDocState no longer composes a footer (the body carries none)", () => {
+    tagAc(AC(15));
+    // The body renderer must not author a footer of its own.
+    expect(formatters).toMatch(/the footer is NO LONGER composed here/i);
+    // The only footer composer (`formatSpecGuidance`) is the seat's helper, not
+    // called from inside the body renderer.
+    const bodyFn = formatters.slice(
+      formatters.indexOf("export function formatFullDocState"),
+      formatters.indexOf("// Document List"),
+    );
+    expect(bodyFn).not.toMatch(/lines\.push\(formatSpecGuidance\(/);
+  });
+
+  it("decideFooter is the single seat that authors footer content", () => {
+    tagAc(AC(15));
+    tagAc(AC(16));
+    expect(toolSpecs).toMatch(/export async function decideFooter\(/);
+    // Sole author: nothing else in spec-traffic composes a footer; it only calls
+    // the seat.
+    expect(specTraffic).toMatch(/const \{ decideFooter \} = await import/);
+  });
+});
+
+describe("ac-14 / ac-16 — the seat is invoked at the one choke point, every call", () => {
+  it("runToolWithSpecTraffic attaches the seat's footer for every resolved Spec", () => {
+    tagAc(AC(14));
+    tagAc(AC(16));
+    expect(specTraffic).toMatch(/decideFooter\(target\.memexId, target\.docId, ctx\)/);
+    // Only when a Spec resolved, and only when no footer is already present
+    // (defence-in-depth — the body composes none).
+    expect(specTraffic).toMatch(/if \(target && !text\.includes\(FOOTER_DELIMITER\)\)/);
+  });
+
+  it("the seat branches on verbose internally — one method, not two paths", () => {
+    tagAc(AC(16));
+    const seat = toolSpecs.slice(
+      toolSpecs.indexOf("export async function decideFooter("),
+      toolSpecs.indexOf("async function craftUntestedAcNag("),
+    );
+    expect(seat).toMatch(/if \(ctx\.verbose\)/); // full footer on reads
+    expect(seat).toMatch(/toHandoffEssence/); // lean essence on terse
+  });
+});
+
+describe("ac-17 — footer emitted ⇒ footer persisted (ungated)", () => {
+  it("the footer is split off the result and persisted, NOT gated by isDevMode", () => {
+    tagAc(AC(17));
+    expect(telemetry).toMatch(/splitToolResult\(input\.resultText\)\.footer/);
+    expect(telemetry).toMatch(/NOT gated by isDevMode/);
+    const footerLine = telemetry
+      .split("\n")
+      .find((l) => l.includes("splitToolResult(input.resultText).footer"));
+    expect(footerLine).toBeTruthy();
+    expect(footerLine).not.toMatch(/isDevMode/);
+  });
+});

--- a/packages/server/src/agent/tool-specs.ts
+++ b/packages/server/src/agent/tool-specs.ts
@@ -147,8 +147,10 @@ import {
   type ParsedTag,
 } from "../services/tags.js";
 import { NotFoundError, ValidationError } from "../types/errors.js";
+import { FOOTER_DELIMITER } from "../mcp/footer-delimiter.js";
 import {
   formatFullDocState,
+  formatSpecGuidance,
   formatDocList,
   formatComment,
   formatCommentList,
@@ -195,6 +197,7 @@ import {
   BASE_SCAFFOLD,
   HANDOFF_BUTTON_BY_PHASE,
   toButtonPrompt,
+  toHandoffEssence,
   type SpecPhase,
   type Phase,
   type GuidanceBlock,
@@ -565,59 +568,12 @@ async function formatState(
   // call; the composer places them by zone. Absent for the many bare callers.
   blocks?: readonly InjectedBlock[],
 ): Promise<string> {
-  // The nudge channel only fires for Spec docs; skip the Org
-  // blocks fetch for everything else to keep the cost off the hot path.
-  const briefLike =
-    state.doc.docType === "spec";
-  const orgBlocks =
-    briefLike && ctx?.getOrgBlocksForNudge
-      ? await ctx.getOrgBlocksForNudge()
-      : undefined;
-  // spec-203 Layer 2 (dec-2): decide whether THIS response carries the full
-  // current-phase handoff (once per user+session+spec+phase, TTL-backstopped) or
-  // the compressed essence (Layer 1, every other response). Only the MCP surface
-  // threads a sessionId; the in-app agent (no sessionId) stays on the essence
-  // path. Resolve the interpolation context BEFORE claiming, so a context we
-  // can't build never burns a delivery.
-  let fullHandoff: string | undefined;
-  if (briefLike && ctx?.sessionId) {
-    const handoffButtonId = HANDOFF_BUTTON_BY_PHASE[state.doc.status as Phase];
-    const handoffContext = handoffButtonId
-      ? handoffInterpolationContext(baseUrl, state.doc)
-      : undefined;
-    if (
-      handoffButtonId &&
-      handoffContext &&
-      claimFullHandoffDelivery(ctx.userId, ctx.sessionId, state.doc.id, state.doc.status)
-    ) {
-      fullHandoff =
-        toButtonPrompt({
-          dataset: BASE_SCAFFOLD,
-          buttonId: handoffButtonId,
-          context: handoffContext,
-        }) ?? undefined;
-    }
-  }
-  const nudge =
-    briefLike && (ctx?.toolName || orgBlocks || fullHandoff)
-      ? { tool: ctx?.toolName, orgBlocks, fullHandoff }
-      : undefined;
-  // spec-121 mechanism 1 — feed the build-phase nag its live AC-state lookup.
-  // Only fetched for a Spec in `build` (the nag's only phase), reusing the same
-  // verification-enriched query the coverage channel already runs (dec-6).
-  // Best-effort: a lookup failure must never break the tool response.
-  let acVerifications: AcWithVerification[] | undefined;
-  if (briefLike && state.doc.status === "build") {
-    try {
-      const rows = await listAcsForBriefWithVerification(
-        state.doc.memexId,
-        state.doc.id,
-      );
-      acVerifications = rows.filter((r) => r.ac.status === "active");
-    } catch {
-      acVerifications = undefined;
-    }
-  }
+  // spec-203 ac-15: formatState renders only the doc BODY (+ tool-injected
+  // header/footer blocks). The machine footer is no longer composed here — the
+  // single seat `decideFooter` composes and attaches it at the one choke point
+  // (`runToolWithSpecTraffic`) on EVERY Spec-resolving call. `ctx` is retained
+  // for signature stability (callers pass it); the footer no longer reads it.
+  void ctx;
   return formatFullDocState(
     state.doc,
     state.decs,
@@ -625,13 +581,131 @@ async function formatState(
     baseUrl,
     state.comments,
     undefined,
-    nudge,
-    acVerifications,
+    undefined,
+    undefined,
     // spec-136 t-4: the Spec's tags, rendered as a one-line strip in the header.
     state.tags,
     // spec-203 dec-3 (t-3): tool-injected guidance, placed by the composer.
     blocks,
   );
+}
+
+/**
+ * THE single seat that decides and attaches the footer (spec-203 ac-15 / ac-16).
+ *
+ * A tool call — any tool call — is the client phoning home; we return the real
+ * tool result, then take that one opening to STEER the client. `decideFooter` is
+ * invoked at the single choke point (`runToolWithSpecTraffic`) on EVERY
+ * Spec-resolving call (ac-14), and is the only place a footer is composed. It
+ * returns the footer already framed with FOOTER_DELIMITER (so the telemetry wrap
+ * splits + persists it — ac-17), or null for "no footer this time".
+ *
+ * Starting policy (deterministic; the SITUATIONAL logic — onboarding a first
+ * Spec, a reprimand when an agent is drifting — evolves HERE, behind this one
+ * function, with no caller change):
+ *   - verbose reads → the FULL phase footer (toNudge prose + Org overlays +
+ *     once-per-session full handoff + dynamic state) — today's content,
+ *     preserved, including spec-193's tripwire vocabulary.
+ *   - terse calls (the build loop) → the COMPACT footer (handoff essence +
+ *     dynamic state incl. the AC nag), steering without flooding the agent.
+ * One composer for both (`formatSpecGuidance`); the only knob is `compact`.
+ *
+ * Best-effort: never throws — a footer-policy failure must not cost the tool its
+ * result.
+ */
+export async function decideFooter(
+  memexId: string,
+  docId: string,
+  ctx: ToolCtx,
+): Promise<string | null> {
+  try {
+    const state = await fullDocState(memexId, docId);
+    if (state.doc.docType !== "spec") return null;
+    const phase = state.doc.status as Phase;
+
+    // VERBOSE reads — the agent asked for the whole document, so author the FULL
+    // phase footer via the shared composer (a pure helper; the seat still owns
+    // the decision to return it).
+    if (ctx.verbose) {
+      const baseUrl = await ctx.workspaceUrl(memexId);
+      const orgBlocks = ctx.getOrgBlocksForNudge
+        ? await ctx.getOrgBlocksForNudge()
+        : undefined;
+      let fullHandoff: string | undefined;
+      if (ctx.sessionId) {
+        const handoffButtonId = HANDOFF_BUTTON_BY_PHASE[phase];
+        const handoffContext = handoffButtonId
+          ? handoffInterpolationContext(baseUrl, state.doc)
+          : undefined;
+        if (
+          handoffButtonId &&
+          handoffContext &&
+          claimFullHandoffDelivery(ctx.userId, ctx.sessionId, state.doc.id, state.doc.status)
+        ) {
+          fullHandoff =
+            toButtonPrompt({
+              dataset: BASE_SCAFFOLD,
+              buttonId: handoffButtonId,
+              context: handoffContext,
+            }) ?? undefined;
+        }
+      }
+      const nudge =
+        ctx.toolName || orgBlocks || fullHandoff
+          ? { tool: ctx.toolName, orgBlocks, fullHandoff }
+          : undefined;
+      let acVerifications: AcWithVerification[] | undefined;
+      if (phase === "build") {
+        try {
+          const rows = await listAcsForBriefWithVerification(memexId, docId);
+          acVerifications = rows.filter((r) => r.ac.status === "active");
+        } catch {
+          acVerifications = undefined;
+        }
+      }
+      return formatSpecGuidance(state.doc, state.decs, state.tasks, nudge, acVerifications);
+    }
+
+    // TERSE build-loop calls — author a LEAN, situational footer here. This is
+    // the seat where the steering logic lives and grows (per tool, per user, per
+    // signal). Starting policy: the phase essence ("what's my job this phase")
+    // plus, in build, the AC nag — the highest-value methodology steer.
+    const lines: string[] = [FOOTER_DELIMITER];
+    const essence = toHandoffEssence(BASE_SCAFFOLD, phase);
+    if (essence) lines.push(essence);
+    if (phase === "build") {
+      const nag = await craftUntestedAcNag(memexId, docId);
+      if (nag) lines.push(nag);
+    }
+    return lines.length > 1 ? lines.join("\n") : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Lean steering line for the terse footer: how many active ACs have no passing
+ * test yet, named, with the methodology push. Returns null when there are none
+ * (nothing worth saying → no footer). Best-effort; never throws.
+ */
+async function craftUntestedAcNag(
+  memexId: string,
+  docId: string,
+): Promise<string | null> {
+  try {
+    const rows = await listAcsForBriefWithVerification(memexId, docId);
+    const untested = rows.filter(
+      (r) => r.ac.status === "active" && r.verificationState !== "verified",
+    );
+    if (untested.length === 0) return null;
+    const handles = untested
+      .map((r) => `ac-${r.ac.seq}`)
+      .join(", ");
+    const plural = untested.length === 1 ? "" : "s";
+    return `\n⚠ ${untested.length} untested acceptance criteri${untested.length === 1 ? "on" : "a"} (${handles}). Write the tagged test before you move on — don't go dark.`;
+  } catch {
+    return null;
+  }
 }
 
 // spec-203 Layer 2 (dec-2): build the {namespace}/{memex}/{handle}/{title}/{url}

--- a/packages/server/src/mcp/ac-nag-sketch.test.ts
+++ b/packages/server/src/mcp/ac-nag-sketch.test.ts
@@ -4,7 +4,7 @@
 //
 // Pure-function behaviour (renderAcNagFooter, sketch matcher) is asserted
 // directly; the renderSpecPhaseGuidance composition is exercised through the
-// exported formatFullDocState; the resolve_decision + drift invariants are
+// exported formatSpecGuidance; the resolve_decision + drift invariants are
 // pinned with source-text assertions (the pattern the existing
 // test-coverage-nudges / scaffold-drift-guard regressions use).
 
@@ -13,7 +13,7 @@ import { readFileSync, readdirSync, statSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { tagAc } from "@memex-ai-ac/vitest";
-import { formatFullDocState, renderAcNagFooter } from "./formatters.js";
+import { formatSpecGuidance, renderAcNagFooter } from "./formatters.js";
 import { sketchShapeForStatement, buildSketchBlock } from "./ac-test-sketch.js";
 import { BUILD_AC_NAG_PROSE, toNudge, BASE_SCAFFOLD } from "@memex/shared";
 import type { Doc, DocSection } from "../db/schema.js";
@@ -203,13 +203,13 @@ describe("mechanism 1 — renderAcNagFooter", () => {
 
 // ──────────────────────────────────────────────────────────────────────────
 // Mechanism 1 — composition through renderSpecPhaseGuidance (via the exported
-// formatFullDocState), and the toNudge channel (dec-2/dec-6 reuse).
+// formatSpecGuidance), and the toNudge channel (dec-2/dec-6 reuse).
 // ──────────────────────────────────────────────────────────────────────────
 describe("mechanism 1 — composition in build-phase doc state", () => {
   it("computes and appends the nag inside the build-phase guidance", () => {
     tagAc(acRef(8));
     const doc = makeSpecDoc();
-    const out = formatFullDocState(doc, [], [], undefined, undefined, undefined, undefined, [
+    const out = formatSpecGuidance(doc, [], [], undefined, [
       makeAc({ seq: 1, kind: "implementation", state: "untested" }),
     ]);
     expect(out).toContain("not verified");
@@ -222,7 +222,7 @@ describe("mechanism 1 — composition in build-phase doc state", () => {
   it("rides the toNudge channel — nag composes with phase guidance in one response", () => {
     tagAc(acRef(20));
     const doc = makeSpecDoc();
-    const out = formatFullDocState(doc, [], [], undefined, undefined, undefined, undefined, [
+    const out = formatSpecGuidance(doc, [], [], undefined, [
       makeAc({ seq: 1, kind: "implementation", state: "untested" }),
     ]);
     // toNudge-sourced build prose AND the nag are in the SAME rendered string.
@@ -234,7 +234,7 @@ describe("mechanism 1 — composition in build-phase doc state", () => {
 
   it("emits nothing when every AC is verified (footer fully clears)", () => {
     const doc = makeSpecDoc();
-    const out = formatFullDocState(doc, [], [], undefined, undefined, undefined, undefined, [
+    const out = formatSpecGuidance(doc, [], [], undefined, [
       makeAc({ seq: 1, kind: "implementation", state: "verified" }),
     ]);
     expect(out).not.toContain("not verified");
@@ -383,15 +383,10 @@ describe("integration — both mechanisms ship together (ac-6)", () => {
     tagAc(acRef(6));
     // Mechanism 1: a not-verified AC makes the nag appear in the doc response.
     const doc = makeSpecDoc();
-    const docState = formatFullDocState(
+    const docState = formatSpecGuidance(
       doc,
       [],
-      [],
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      [makeAc({ seq: 6, kind: "implementation", state: "untested" })],
+      [], undefined, [makeAc({ seq: 6, kind: "implementation", state: "untested" })],
     );
     expect(docState).toContain("not verified");
     expect(docState).toContain("ac-6");

--- a/packages/server/src/mcp/footer-delimiter.spec-203.test.ts
+++ b/packages/server/src/mcp/footer-delimiter.spec-203.test.ts
@@ -4,7 +4,7 @@
 import { describe, it, expect } from "vitest";
 import { tagAc } from "@memex-ai-ac/vitest";
 import { FOOTER_DELIMITER, splitToolResult } from "./footer-delimiter.js";
-import { formatFullDocState } from "./formatters.js";
+import { formatSpecGuidance } from "./formatters.js";
 import type { Doc, DocSection } from "../db/schema.js";
 
 const AC = (n: number) =>
@@ -72,24 +72,25 @@ describe("splitToolResult", () => {
   });
 });
 
-describe("formatFullDocState — footer delimiter boundary (spec-203 dec-3)", () => {
+describe("formatSpecGuidance — footer delimiter boundary (spec-203 dec-3)", () => {
   it("emits the delimiter exactly once at the doc-state→footer boundary for a Spec", () => {
     tagAc(AC(11));
-    const out = formatFullDocState(makeSpec("build"), [], []);
+    const out = formatSpecGuidance(makeSpec("build"), [], []);
     const occurrences = out.split(FOOTER_DELIMITER).length - 1;
     expect(occurrences).toBe(1);
-    // Everything before the delimiter is the tool's real output (the doc state);
-    // splitting recovers the platform footer (which carries the phase handoff).
-    const { body, footer } = splitToolResult(out);
-    expect(body).toContain("# Test Spec");
-    expect(body).not.toContain("BUILD handoff (full prompt:");
+    // spec-203 ac-15: the composer's output IS the footer — it leads with the
+    // delimiter, and splitting recovers the phase guidance. (Body↔footer
+    // separation on a REAL tool result is the choke point's job, covered by
+    // services/spec-footer-on-terse.integration.test.ts.)
+    expect(out.startsWith(FOOTER_DELIMITER)).toBe(true);
+    const { footer } = splitToolResult(out);
     expect(footer).toContain("BUILD handoff (full prompt:");
   });
 
   it("emits NO delimiter for a non-Spec doc (no footer to separate)", () => {
     tagAc(AC(11));
     const doc = { ...makeSpec("build"), docType: "document" };
-    const out = formatFullDocState(doc, [], []);
+    const out = formatSpecGuidance(doc, [], []);
     expect(out).not.toContain(FOOTER_DELIMITER);
     expect(splitToolResult(out).footer).toBeNull();
   });

--- a/packages/server/src/mcp/formatters.handoff-essence.spec-203.test.ts
+++ b/packages/server/src/mcp/formatters.handoff-essence.spec-203.test.ts
@@ -10,7 +10,12 @@
 
 import { describe, it, expect } from "vitest";
 import { tagAc } from "@memex-ai-ac/vitest";
-import { formatFullDocState } from "./formatters.js";
+// spec-203 ac-15: the footer is no longer composed inside formatFullDocState —
+// the single seat `decideFooter` authors it via the exported `formatSpecGuidance`
+// composer. These tests exercise that composer directly (the footer content is
+// unchanged); the seat + choke-point delivery is covered by the integration
+// tests in services/spec-footer-on-terse.integration.test.ts.
+import { formatSpecGuidance } from "./formatters.js";
 import { FOOTER_DELIMITER } from "./footer-delimiter.js";
 import type { Doc, DocSection } from "../db/schema.js";
 
@@ -58,7 +63,7 @@ function makeSpec(status: string): Doc & { sections: DocSection[] } {
 describe("formatFullDocState — phase handoff essence in the footer (spec-203)", () => {
   it("emits the BUILD handoff essence on a build-phase Spec", () => {
     tagAc(AC(7));
-    const out = formatFullDocState(makeSpec("build"), [], []);
+    const out = formatSpecGuidance(makeSpec("build"), [], []);
     expect(out).toContain('BUILD handoff (full prompt: the "Build handoff" button)');
     expect(out).toContain("deriving the task graph");
     expect(out).toContain("recommend `verify`");
@@ -67,30 +72,30 @@ describe("formatFullDocState — phase handoff essence in the footer (spec-203)"
   it("emits the SPECIFY handoff essence on a specify-phase Spec", () => {
     tagAc(AC(7));
     tagAc(AC(4)); // scope: phase-general (specify gets its handoff)
-    const out = formatFullDocState(makeSpec("specify"), [], []);
+    const out = formatSpecGuidance(makeSpec("specify"), [], []);
     expect(out).toContain('SPECIFY handoff (full prompt: the "Plan handoff" button)');
   });
 
   it("emits the VERIFY handoff essence on a verify-phase Spec", () => {
-    const out = formatFullDocState(makeSpec("verify"), [], []);
+    const out = formatSpecGuidance(makeSpec("verify"), [], []);
     expect(out).toContain('VERIFY handoff (full prompt: the "Verify handoff" button)');
   });
 
   it("emits NO handoff essence on a draft-phase Spec", () => {
     tagAc(AC(7));
-    const out = formatFullDocState(makeSpec("draft"), [], []);
+    const out = formatSpecGuidance(makeSpec("draft"), [], []);
     expect(out).not.toContain("handoff (full prompt:");
   });
 
   it("emits NO handoff essence on a done-phase Spec", () => {
     tagAc(AC(7));
     tagAc(AC(4)); // scope: phase-general (done surfaces none)
-    const out = formatFullDocState(makeSpec("done"), [], []);
+    const out = formatSpecGuidance(makeSpec("done"), [], []);
     expect(out).not.toContain("handoff (full prompt:");
   });
 
   it("places the essence after the footer delimiter (in the footer, not the body)", () => {
-    const out = formatFullDocState(makeSpec("build"), [], []);
+    const out = formatSpecGuidance(makeSpec("build"), [], []);
     const delimIdx = out.indexOf(FOOTER_DELIMITER);
     const essenceIdx = out.indexOf("BUILD handoff (full prompt:");
     expect(delimIdx).toBeGreaterThanOrEqual(0);

--- a/packages/server/src/mcp/formatters.handoff-fulldelivery.spec-203.test.ts
+++ b/packages/server/src/mcp/formatters.handoff-fulldelivery.spec-203.test.ts
@@ -1,13 +1,13 @@
 // spec-203 Layer 2 (dec-2): the footer renderer is dumb — when the centralized
 // machine hands it a pre-resolved FULL handoff via `nudge.fullHandoff`, it emits
 // that in place of the Layer 1 compressed essence; otherwise it emits the
-// essence. This proves the either/or at the renderer boundary (formatFullDocState
+// essence. This proves the either/or at the renderer boundary (formatSpecGuidance
 // is exported; the decision logic itself is covered by handoff-delivery.test.ts,
 // and the end-to-end wiring by the integration test).
 
 import { describe, it, expect } from "vitest";
 import { tagAc } from "@memex-ai-ac/vitest";
-import { formatFullDocState } from "./formatters.js";
+import { formatSpecGuidance } from "./formatters.js";
 import type { Doc, DocSection } from "../db/schema.js";
 
 const AC = (n: number) =>
@@ -54,17 +54,13 @@ function makeSpec(status: string): Doc & { sections: DocSection[] } {
 const ESSENCE_MARKER = 'BUILD handoff (full prompt: the "Build handoff" button)';
 const FULL_SENTINEL = "FULL-HANDOFF-SENTINEL-You-are-working-in-Memex";
 
-describe("formatFullDocState — full-handoff vs essence in the footer (spec-203 L2)", () => {
+describe("formatSpecGuidance — full-handoff vs essence in the footer (spec-203 L2)", () => {
   it("emits the provided full handoff in place of the essence", () => {
     tagAc(AC(9));
-    const out = formatFullDocState(
+    const out = formatSpecGuidance(
       makeSpec("build"),
       [],
-      [],
-      undefined,
-      undefined,
-      undefined,
-      { fullHandoff: FULL_SENTINEL },
+      [], { fullHandoff: FULL_SENTINEL },
     );
     expect(out).toContain(FULL_SENTINEL);
     expect(out).not.toContain(ESSENCE_MARKER); // essence suppressed when full is delivered
@@ -72,7 +68,7 @@ describe("formatFullDocState — full-handoff vs essence in the footer (spec-203
 
   it("falls back to the compressed essence when no full handoff is provided", () => {
     tagAc(AC(9));
-    const out = formatFullDocState(makeSpec("build"), [], []);
+    const out = formatSpecGuidance(makeSpec("build"), [], []);
     expect(out).toContain(ESSENCE_MARKER);
     expect(out).not.toContain(FULL_SENTINEL);
   });

--- a/packages/server/src/mcp/formatters.test.ts
+++ b/packages/server/src/mcp/formatters.test.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from "node:url";
 import { describe, it, expect } from "vitest";
 import * as formatters from "./formatters.js";
 import {
+  formatSpecGuidance,
   formatFullDocState,
   formatDocList,
   formatComment,
@@ -144,7 +145,7 @@ describe("formatFullDocState", () => {
     // b-105: a Spec in a recognised phase routes through phase-based guidance;
     // an unrecognised status falls back to the legacy data-shape inference.
     const doc = { ...makeDoc({ docType: "spec", status: "wat" }), sections: [makeSection()] };
-    const result = formatFullDocState(doc, [], []);
+    const result = formatSpecGuidance(doc, [], []);
 
     expect(result).toContain("Next: Identify Decisions");
     expect(result).toContain("create_decision");
@@ -159,7 +160,7 @@ describe("formatFullDocState", () => {
       source: "human" as const,
       resolution: null, resolvedAt: null, previousStatus: null, createdAt: baseDate,
     }];
-    const result = formatFullDocState(doc, decs, []);
+    const result = formatSpecGuidance(doc, decs, []);
 
     expect(result).toContain("Remaining: 1 Open Decision");
     expect(result).toContain("Which database?");
@@ -409,7 +410,7 @@ describe("spec phase guidance — specify/draft code-grounding nudge", () => {
       ...makeDoc({ docType: "spec", status: "draft" }),
       sections: [makeSection()],
     };
-    const result = formatFullDocState(doc, [], []);
+    const result = formatSpecGuidance(doc, [], []);
 
     expect(result).toContain(CANONICAL_PHRASE);
   });
@@ -419,7 +420,7 @@ describe("spec phase guidance — specify/draft code-grounding nudge", () => {
       ...makeDoc({ docType: "spec", status: "specify" }),
       sections: [makeSection()],
     };
-    const result = formatFullDocState(doc, [], []);
+    const result = formatSpecGuidance(doc, [], []);
 
     expect(result).toContain(CANONICAL_PHRASE);
   });
@@ -429,7 +430,7 @@ describe("spec phase guidance — specify/draft code-grounding nudge", () => {
       ...makeDoc({ docType: "spec", status: "build" }),
       sections: [makeSection()],
     };
-    const result = formatFullDocState(doc, [], []);
+    const result = formatSpecGuidance(doc, [], []);
 
     expect(result).not.toContain(CANONICAL_PHRASE);
   });
@@ -439,7 +440,7 @@ describe("spec phase guidance — specify/draft code-grounding nudge", () => {
       ...makeDoc({ docType: "spec", status: "verify" }),
       sections: [makeSection()],
     };
-    const result = formatFullDocState(doc, [], []);
+    const result = formatSpecGuidance(doc, [], []);
 
     expect(result).not.toContain(CANONICAL_PHRASE);
   });
@@ -449,7 +450,7 @@ describe("spec phase guidance — specify/draft code-grounding nudge", () => {
       ...makeDoc({ docType: "spec", status: "done" }),
       sections: [makeSection()],
     };
-    const result = formatFullDocState(doc, [], []);
+    const result = formatSpecGuidance(doc, [], []);
 
     expect(result).not.toContain(CANONICAL_PHRASE);
   });
@@ -485,7 +486,7 @@ describe("b-68 t-7 ac-22: formatPhaseGuidance retired; per-phase prose flows thr
       ...makeDoc({ docType: "spec", status: "specify" }),
       sections: [makeSection()],
     };
-    const result = formatFullDocState(doc, [], []);
+    const result = formatSpecGuidance(doc, [], []);
     expect(result).toContain(specifyIntent!.text);
   });
 });
@@ -513,7 +514,7 @@ describe("b-68 t-7 ac-24: allowance prose derives from BASE_SCAFFOLD.phases[<pha
         ...makeDoc({ docType: "spec", status: phase }),
         sections: [makeSection()],
       };
-      const rendered = formatFullDocState(doc, [], []);
+      const rendered = formatSpecGuidance(doc, [], []);
       // For draft/specify the allowance line spells every allowed tool out
       // (build's allowance line is the legacy compressed phrase, asserted
       // separately below).
@@ -535,7 +536,7 @@ describe("b-68 t-7 ac-24: allowance prose derives from BASE_SCAFFOLD.phases[<pha
       ...makeDoc({ docType: "spec", status: "specify" }),
       sections: [makeSection()],
     };
-    const rendered = formatFullDocState(doc, [], []);
+    const rendered = formatSpecGuidance(doc, [], []);
     expect(rendered).toMatch(/Blocked now:\*\* task creation \(`create_task`\), execution plans/);
   });
 });

--- a/packages/server/src/mcp/formatters.ts
+++ b/packages/server/src/mcp/formatters.ts
@@ -220,10 +220,13 @@ export function formatFullDocState(
     lines.push("");
   }
 
-  // Phase-aware guidance (Spec docs) — the machine's own always-on footer.
-  if (doc.docType === "spec") {
-    lines.push(formatSpecGuidance(doc, decisions, tasks, nudge, acVerifications));
-  }
+  // spec-203 ac-15: the footer is NO LONGER composed here. There is exactly one
+  // seat that decides and attaches the footer — `decideFooter`, invoked at the
+  // single choke point (`runToolWithSpecTraffic`) on EVERY Spec-resolving call,
+  // terse and verbose alike. The doc body this function renders carries no
+  // footer of its own; the choke point appends whatever the seat returns. (The
+  // `nudge` / `acVerifications` params remain on the signature for the seat's
+  // own composition path, which calls `formatSpecGuidance` directly.)
 
   // spec-203 dec-3 (t-3): the envelope. Header blocks wrap above the doc, footer
   // blocks after the machine footer, placement by zone alone. Joining each zone
@@ -1047,7 +1050,12 @@ export function renderAcNagFooter(
   return lines.join("\n");
 }
 
-function formatSpecGuidance(
+// spec-203 ac-15: exported so the single footer seat (`decideFooter`) can author
+// the FULL phase footer through this composer when it chooses to. It is a pure
+// helper the seat invokes — the seat remains the sole author/decider; no other
+// code path composes a footer. `formatFullDocState` no longer calls it (the body
+// carries no footer of its own).
+export function formatSpecGuidance(
   doc: Doc,
   decs: Decision[],
   tasksList: TaskWithBlockers[],

--- a/packages/server/src/mcp/spec-shape-lens-parity.test.ts
+++ b/packages/server/src/mcp/spec-shape-lens-parity.test.ts
@@ -7,18 +7,18 @@
 // "load-bearing parity guarantee"): both surfaces compose the phase-guidance
 // footer through the SAME path —
 //
-//   formatState → formatFullDocState → renderSpecPhaseGuidance → toNudge
+//   formatState → formatSpecGuidance → renderSpecPhaseGuidance → toNudge
 //
 // The only surface-specific input is the `NudgeContext` ({ tool, orgBlocks })
 // each ctx wiring produces:
 //   - MCP   (mcp/tools.ts:308-317): toolName = spec.name, getOrgBlocksForNudge
 //   - React (agent/tools.ts:360-406, buildAgentCtx): toolName, getOrgBlocksForNudge
 //
-// Both feed `{ tool: ctx.toolName, orgBlocks }` into `formatFullDocState`
+// Both feed `{ tool: ctx.toolName, orgBlocks }` into `formatSpecGuidance`
 // (agent/tool-specs.ts:396-408). So "both surfaces see the block" reduces to:
 // the lens block is `target:{phase:'specify'}` (phase-scoped, tool-agnostic), and
-// `formatFullDocState` for a specify-phase spec emits it regardless of which tool
-// name the surface supplies. We exercise the real `formatFullDocState` with
+// `formatSpecGuidance` for a specify-phase spec emits it regardless of which tool
+// name the surface supplies. We exercise the real `formatSpecGuidance` with
 // the NudgeContext each surface produces and assert the lens prose is present
 // in BOTH footers.
 //
@@ -27,7 +27,7 @@
 
 import { describe, it, expect } from "vitest";
 import { tagAc } from "@memex-ai-ac/vitest";
-import { formatFullDocState } from "./formatters.js";
+import { formatSpecGuidance } from "./formatters.js";
 import { BASE_SCAFFOLD } from "@memex/shared";
 import type { Doc, DocSection } from "../db/schema.js";
 
@@ -111,7 +111,7 @@ describe("spec-106 t-3 ac-13: lens-shape GuidanceBlock reaches both surfaces' to
   // birth that's `create_doc`; on a section edit it's `update_section`. The
   // React executor (buildAgentCtx) wires it identically. We model BOTH
   // surfaces by the NudgeContext each produces and run the SAME
-  // formatFullDocState path.
+  // formatSpecGuidance path.
   const SURFACES: { name: string; nudge: { tool?: string } }[] = [
     // MCP coding agent dispatching create_doc (Spec birth).
     { name: "MCP (create_doc)", nudge: { tool: "create_doc" } },
@@ -129,7 +129,7 @@ describe("spec-106 t-3 ac-13: lens-shape GuidanceBlock reaches both surfaces' to
       expect(LENS_BLOCK).toBeDefined();
 
       const spec = makePlanSpec();
-      const out = formatFullDocState(
+      const out = formatSpecGuidance(
         spec,
         [],
         [],
@@ -158,24 +158,16 @@ describe("spec-106 t-3 ac-13: lens-shape GuidanceBlock reaches both surfaces' to
 
     const spec = makePlanSpec();
     // MCP ctx wiring (create_doc at Spec birth).
-    const mcpFooter = formatFullDocState(
+    const mcpFooter = formatSpecGuidance(
       spec,
       [],
-      [],
-      undefined,
-      undefined,
-      undefined,
-      { tool: "create_doc" },
+      [], { tool: "create_doc" },
     );
     // React ctx wiring (doc-chat, e.g. update_section).
-    const reactFooter = formatFullDocState(
+    const reactFooter = formatSpecGuidance(
       spec,
       [],
-      [],
-      undefined,
-      undefined,
-      undefined,
-      { tool: "update_section" },
+      [], { tool: "update_section" },
     );
 
     // The lens block is `target:{phase:'specify'}` — tool-agnostic — so the SAME

--- a/packages/server/src/mcp/tools.overflow.integration.test.ts
+++ b/packages/server/src/mcp/tools.overflow.integration.test.ts
@@ -30,6 +30,7 @@
 
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { eq, inArray } from "drizzle-orm";
+import { FOOTER_DELIMITER } from "./footer-delimiter.js";
 import { db } from "../db/connection.js";
 import {
   memexes,
@@ -406,7 +407,14 @@ describe("mcp/tools: verbose:true escape hatch reproduces direct-handler output 
       { ref, content: "Parity probe body." },
       ctxVerbose(memexId),
     );
-    expect(stripUrls(viaMcp.content[0].text)).toBe(stripUrls(viaCtx));
+    // spec-203 ac-15: the footer now rides the single choke point
+    // (runToolWithSpecTraffic), not the handler. So the MCP response is the
+    // direct-handler BODY (byte-for-byte) plus the platform footer the seat
+    // attaches. The direct handler call bypasses the choke point, so it carries
+    // no footer — compare the bodies, and confirm the footer is the MCP addition.
+    const [mcpBody] = viaMcp.content[0].text.split(FOOTER_DELIMITER);
+    expect(stripUrls(mcpBody).trimEnd()).toBe(stripUrls(viaCtx).trimEnd());
+    expect(viaMcp.content[0].text).toContain(FOOTER_DELIMITER);
   });
 });
 

--- a/packages/server/src/services/spec-203-footer.integration.test.ts
+++ b/packages/server/src/services/spec-203-footer.integration.test.ts
@@ -1,0 +1,148 @@
+// spec-203 ac-14 / ac-17 — the footer rides EVERY Spec-resolving response (terse
+// and verbose), authored by the one seat, and is persisted.
+//
+// Before this work the footer rode only verbose document reads (prod audit: 14 of
+// 9,494 calls). Now a chat-driven agent gets steered on its terse build-loop
+// calls too — and what it received is captured in mcp_tool_calls.footer_text.
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { eq, inArray, desc } from "drizzle-orm";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { db } from "../db/connection.js";
+import {
+  memexes,
+  namespaces,
+  orgs,
+  orgMemberships,
+  documents,
+  decisions,
+  tasks,
+  users,
+  mcpToolCalls,
+  mcpSessions,
+} from "../db/schema.js";
+import { createMcpServer } from "../mcp/tools.js";
+import { createDocDraft } from "./documents.js";
+import { FOOTER_DELIMITER, splitToolResult } from "../mcp/footer-delimiter.js";
+
+const AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-203/acs/ac-${n}`;
+
+const created = { users: [] as string[], memexes: [] as string[], docs: [] as string[] };
+
+afterAll(async () => {
+  if (created.docs.length) {
+    await db.delete(tasks).where(inArray(tasks.docId, created.docs)).catch(() => {});
+    await db.delete(decisions).where(inArray(decisions.docId, created.docs)).catch(() => {});
+    await db.delete(documents).where(inArray(documents.id, created.docs)).catch(() => {});
+  }
+  if (created.memexes.length)
+    await db.delete(memexes).where(inArray(memexes.id, created.memexes)).catch(() => {});
+  if (created.users.length)
+    await db.delete(users).where(inArray(users.id, created.users)).catch(() => {});
+});
+
+async function setupActor(prefix: string) {
+  const sub = `${prefix}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`.toLowerCase();
+  const [u] = await db.insert(users).values({ email: `${sub}@memex.ai` } as any).returning();
+  created.users.push(u.id);
+  const [ns] = await db.insert(namespaces).values({ slug: sub, kind: "org" }).returning();
+  const [org] = await db.insert(orgs).values({ namespaceId: ns.id, name: `Test ${sub}` }).returning();
+  await db.update(namespaces).set({ ownerOrgId: org.id }).where(eq(namespaces.id, ns.id));
+  const [a] = await db.insert(memexes).values({ namespaceId: ns.id, slug: "main", name: `Test ${sub}` }).returning();
+  created.memexes.push(a.id);
+  await db.insert(orgMemberships).values({ userId: u.id, orgId: org.id, role: "administrator" });
+  return { user: u, memexId: a.id, nsSlug: ns.slug };
+}
+
+interface ToolResult { isError?: boolean; content: Array<{ type: string; text: string }> }
+interface RegisteredToolLike {
+  handler: (args: Record<string, unknown>, extra: unknown) => Promise<ToolResult> | ToolResult;
+}
+
+async function callTool(
+  userId: string,
+  name: string,
+  args: Record<string, unknown>,
+  sessionId?: string,
+): Promise<ToolResult> {
+  const server = createMcpServer(userId, undefined, sessionId);
+  const registry = (server as unknown as { _registeredTools: Record<string, RegisteredToolLike> })._registeredTools;
+  const tool = registry[name];
+  if (!tool) throw new Error(`Tool not registered: ${name}`);
+  return await tool.handler(args, {} as unknown);
+}
+
+async function pollFooter(sessionId: string): Promise<string | null | undefined> {
+  for (let i = 0; i < 40; i++) {
+    const [row] = await db
+      .select({ footerText: mcpToolCalls.footerText })
+      .from(mcpToolCalls)
+      .where(eq(mcpToolCalls.sessionId, sessionId))
+      .orderBy(desc(mcpToolCalls.createdAt))
+      .limit(1);
+    if (row?.footerText) return row.footerText;
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  return undefined;
+}
+
+let actor: Awaited<ReturnType<typeof setupActor>>;
+beforeAll(async () => {
+  actor = await setupActor("spec203-footer");
+});
+
+describe("ac-14 — the footer rides terse Spec-resolving responses", () => {
+  it("a TERSE get_doc on a build-phase Spec comes back WITH the footer (the seat's lean steer)", async () => {
+    tagAc(AC(14));
+    const doc = await createDocDraft(actor.memexId, "Terse Footer Spec", "P", "spec");
+    created.docs.push(doc.id);
+    await db.update(documents).set({ status: "build" }).where(eq(documents.id, doc.id));
+    const ref = `${actor.nsSlug}/main/specs/${doc.handle}`;
+
+    // verbose omitted (the terse default) — pre-change this had no footer.
+    const res = await callTool(actor.user.id, "get_doc", { ref });
+    const text = res.content.map((c) => c.text).join("\n");
+    expect(text).toContain(FOOTER_DELIMITER);
+    // Lean terse footer = the phase essence, authored by the seat.
+    const footer = splitToolResult(text).footer;
+    expect(footer).toBeTruthy();
+    expect(footer).toMatch(/BUILD handoff/);
+  });
+
+  it("the seat crafts the lean AC-nag when the build Spec has untested ACs", async () => {
+    tagAc(AC(14));
+    const doc = await createDocDraft(actor.memexId, "Nag Spec", "P", "spec");
+    created.docs.push(doc.id);
+    await db.update(documents).set({ status: "build" }).where(eq(documents.id, doc.id));
+    const ref = `${actor.nsSlug}/main/specs/${doc.handle}`;
+    // Author an AC (active, untested) so the nag has something to say.
+    await callTool(actor.user.id, "create_ac", { ref, kind: "scope", statement: "A checkable outcome." });
+
+    const res = await callTool(actor.user.id, "get_doc", { ref });
+    const footer = splitToolResult(res.content.map((c) => c.text).join("\n")).footer ?? "";
+    expect(footer).toMatch(/untested acceptance criteri/i);
+    expect(footer).toMatch(/don't go dark/i);
+  });
+});
+
+describe("ac-17 — footer emitted ⇒ footer persisted", () => {
+  it("the terse footer is captured in mcp_tool_calls.footer_text", async () => {
+    tagAc(AC(17));
+    const doc = await createDocDraft(actor.memexId, "Persisted Footer Spec", "P", "spec");
+    created.docs.push(doc.id);
+    await db.update(documents).set({ status: "build" }).where(eq(documents.id, doc.id));
+    const ref = `${actor.nsSlug}/main/specs/${doc.handle}`;
+
+    // A real MCP session threads a sessionId (FK to mcp_sessions) — seed it.
+    const sessionId = `s203-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 7)}`;
+    await db.insert(mcpSessions).values({ sessionId, userId: actor.user.id });
+    const res = await callTool(actor.user.id, "get_doc", { ref }, sessionId);
+    const emitted = splitToolResult(res.content.map((c) => c.text).join("\n")).footer;
+    expect(emitted).toBeTruthy();
+
+    const persisted = await pollFooter(sessionId);
+    expect(persisted).toBeTruthy();
+    expect(persisted).toMatch(/BUILD handoff/);
+  });
+});

--- a/packages/server/src/services/spec-traffic.ts
+++ b/packages/server/src/services/spec-traffic.ts
@@ -37,6 +37,7 @@ import {
 } from "@memex/shared";
 import { db } from "../db/connection.js";
 import { documents } from "../db/schema.js";
+import { FOOTER_DELIMITER } from "../mcp/footer-delimiter.js";
 import { isSpecStatus } from "../types/roles.js";
 import { assign } from "./doc-assignees.js";
 import { promoteToEditor } from "./doc-members.js";
@@ -160,6 +161,27 @@ export async function runToolWithSpecTraffic(
     userId: ctx.userId,
     ...target,
   });
+
+  // spec-203 ac-14/ac-15: the ONE place a footer is attached. Every tool call is
+  // the client phoning home; here — and only here — the single seat
+  // (`decideFooter`) takes that opening to steer the client, on EVERY
+  // Spec-resolving response (terse and verbose), never per-tool and never twice.
+  // The seat frames its return with FOOTER_DELIMITER, so the telemetry wrap that
+  // runs after this splits + persists it (ac-17). Guards: only when the call
+  // resolved ONE Spec (`target` set — list/search resolve none), and only when
+  // the body does not already carry a footer (defence-in-depth; the body no
+  // longer composes one). `decideFooter` is imported dynamically to keep this
+  // module free of a runtime cycle with agent/tool-specs.ts (cached after first
+  // use); it never throws, but the guard keeps a footer failure off the result.
+  if (target && !text.includes(FOOTER_DELIMITER)) {
+    try {
+      const { decideFooter } = await import("../agent/tool-specs.js");
+      const footer = await decideFooter(target.memexId, target.docId, ctx);
+      if (footer) return `${text}\n\n${footer}`;
+    } catch {
+      // swallow — the tool's real result already succeeded.
+    }
+  }
   return text;
 }
 


### PR DESCRIPTION
## What & why

A tool call is the client phoning home; the server returns the real result, then uses that one opening to **steer the client** through a footer authored in **one place**. spec-203 centralized the footer *composer* but only ran it on verbose reads — the prod audit showed `footer_text` on **14 of 9,494** calls, all verbose. A chat-driven agent got no guidance on its terse build-loop calls (the moment it goes dark). This makes the footer universal and single-seated.

Amends **spec-203** (`ac-14..17`). Same branch/deploy as the spec-193 tripwire work (already merged via #94); this is the follow-on delta.

## The one seat

- **`decideFooter`** (`agent/tool-specs.ts`) is the sole author of all footer content. Nothing else composes a footer.
  - **verbose reads** → the full phase footer via the `formatSpecGuidance` composer.
  - **terse build-loop calls** → a lean, situational steer crafted in the seat: the phase essence + the untested-AC nag (`"⚠ N untested acceptance criteria (…). Write the tagged test before you move on — don't go dark."`). < 2KB.
- **`formatFullDocState` no longer composes the footer** — body only.
- The seat is invoked at the **single choke point** (`runToolWithSpecTraffic`) on **every** Spec-resolving call, terse and verbose alike (`ac-14`/`ac-15`/`ac-16`).
- **Footer emitted ⇒ persisted** (`ac-17`): framed with `FOOTER_DELIMITER`, so the telemetry wrap splits + persists it unconditionally — the injected-guidance audit trail is now complete across every phone-home, not just verbose reads.

## Test plan

- **spec-203 `ac-14/15/16/17` verified** — `footer-one-seat.regression` (one-seat wiring, source-level) + `spec-203-footer.integration` (footer rides terse + lean AC-nag + persisted).
- spec-203's relocated formatter tests now exercise the composer (`formatSpecGuidance`) directly; terse footer < 2KB confirmed.
- **Full server battery: 3,566 passed.** The 1 failure is the pre-existing `standards-graph` embeddings flake (passes in isolation, touches none of these files) — unrelated.

## Follow-up (not in this PR)

Three *old* spec-203 ACs (`ac-7`, `ac-11`, `ac-13`) have prose that names `formatFullDocState` as the footer composer — now relocated to the seat. Their tests pass (re-pointed), but the statements need reconciling in spec-203's verify pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)