### PR TITLE
feat: spec-199 security hardening — tenant isolation, RLS, share token revocation, SSE gating

### DIFF
--- a/packages/server/drizzle/0080_share_tokens_security.sql
+++ b/packages/server/drizzle/0080_share_tokens_security.sql
@@ -1,0 +1,16 @@
+-- spec-199 t-3: add created_by_user_id FK and expires_at to share_tokens
+--
+-- created_by_user_id: nullable so existing rows keep working (backward compat).
+-- ON DELETE SET NULL so tokens survive if the user row is hard-deleted
+-- (membership disable does not delete the user — it only sets status=disabled).
+--
+-- expires_at: nullable; no default here — the application layer stamps the value
+-- at mint time using a configurable TTL (SHARE_TOKEN_TTL_DAYS env var). Null
+-- means no expiry (preserves existing tokens that pre-date this migration).
+
+ALTER TABLE "share_tokens"
+  ADD COLUMN "created_by_user_id" uuid REFERENCES "users"("id") ON DELETE SET NULL,
+  ADD COLUMN "expires_at" timestamptz;
+
+-- Index to make the bulk-revoke in disableMembership efficient.
+CREATE INDEX "share_tokens_created_by_user_id_idx" ON "share_tokens" ("created_by_user_id");

--- a/packages/server/drizzle/0081_rls_phase2_tenant_tables.sql
+++ b/packages/server/drizzle/0081_rls_phase2_tenant_tables.sql
@@ -1,0 +1,259 @@
+-- spec-199 t-12: Row Level Security — Phase 2 tenant table policies
+--
+-- Enables ENABLE + FORCE ROW LEVEL SECURITY on every primary tenant table
+-- (tables with a direct `memex_id NOT NULL` column). Each policy enforces
+-- that the `app.memex_id` GUC is set AND matches the row's memex_id. The
+-- runtime role `memex_app` (non-superuser, no BYPASSRLS) is subject to all
+-- policies; the superuser `postgres` bypasses RLS unconditionally.
+--
+-- Policy semantics:
+--   USING     — filters SELECT, UPDATE, DELETE
+--   WITH CHECK — validates INSERT and UPDATE values
+--   nullif(..., '') guards against an empty-string GUC reaching ::uuid cast
+--
+-- Roles:
+--   postgres    — superuser (BYPASSRLS), used for migrations + local dev
+--   memex_app   — restricted runtime role for Cloud Run; subject to policies
+--
+-- Excluded tables and why (deferred to 0082):
+--   user_memex_access — queried in publicSessionMiddleware before ALS sets
+--                       memex_id; adding a standard policy breaks session
+--                       establishment with 0 rows.
+--   doc_sections      — no direct memex_id column; requires a join policy
+--                       (EXISTS subquery via doc_id → documents.memex_id).
+--   conversations     — no direct memex_id; requires join via doc_id → documents.
+--   messages          — no direct memex_id; requires join via conversation_id.
+--   activity_log      — background bus relay (spec-156 LISTEN handler) calls
+--                       persistEvent without request ALS context; WITH CHECK
+--                       would silently reject those INSERTs. Needs relay to gain
+--                       runWithMemexId before policies can be applied safely.
+--   mcp_tool_calls    — nullable memex_id; needs a nullable-safe policy variant.
+
+-- ── memex_app runtime role ─────────────────────────────────────────────────────
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'memex_app') THEN
+    CREATE ROLE memex_app;
+  END IF;
+END
+$$;
+
+GRANT USAGE ON SCHEMA public TO memex_app;
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO memex_app;
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO memex_app;
+
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO memex_app;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT USAGE, SELECT ON SEQUENCES TO memex_app;
+
+-- ── documents ──────────────────────────────────────────────────────────────────
+
+ALTER TABLE documents ENABLE ROW LEVEL SECURITY;
+ALTER TABLE documents FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS documents_memex_isolation ON documents;
+CREATE POLICY documents_memex_isolation ON documents
+  USING (
+    nullif(current_setting('app.memex_id', true), '') IS NOT NULL
+    AND memex_id = current_setting('app.memex_id', true)::uuid
+  )
+  WITH CHECK (
+    nullif(current_setting('app.memex_id', true), '') IS NOT NULL
+    AND memex_id = current_setting('app.memex_id', true)::uuid
+  );
+
+-- ── standard_clauses ──────────────────────────────────────────────────────────
+
+ALTER TABLE standard_clauses ENABLE ROW LEVEL SECURITY;
+ALTER TABLE standard_clauses FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS standard_clauses_memex_isolation ON standard_clauses;
+CREATE POLICY standard_clauses_memex_isolation ON standard_clauses
+  USING (
+    nullif(current_setting('app.memex_id', true), '') IS NOT NULL
+    AND memex_id = current_setting('app.memex_id', true)::uuid
+  )
+  WITH CHECK (
+    nullif(current_setting('app.memex_id', true), '') IS NOT NULL
+    AND memex_id = current_setting('app.memex_id', true)::uuid
+  );
+
+-- ── clause_refs ────────────────────────────────────────────────────────────────
+
+ALTER TABLE clause_refs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE clause_refs FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS clause_refs_memex_isolation ON clause_refs;
+CREATE POLICY clause_refs_memex_isolation ON clause_refs
+  USING (
+    nullif(current_setting('app.memex_id', true), '') IS NOT NULL
+    AND memex_id = current_setting('app.memex_id', true)::uuid
+  )
+  WITH CHECK (
+    nullif(current_setting('app.memex_id', true), '') IS NOT NULL
+    AND memex_id = current_setting('app.memex_id', true)::uuid
+  );
+
+-- ── doc_comments ──────────────────────────────────────────────────────────────
+
+ALTER TABLE doc_comments ENABLE ROW LEVEL SECURITY;
+ALTER TABLE doc_comments FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS doc_comments_memex_isolation ON doc_comments;
+CREATE POLICY doc_comments_memex_isolation ON doc_comments
+  USING (
+    nullif(current_setting('app.memex_id', true), '') IS NOT NULL
+    AND memex_id = current_setting('app.memex_id', true)::uuid
+  )
+  WITH CHECK (
+    nullif(current_setting('app.memex_id', true), '') IS NOT NULL
+    AND memex_id = current_setting('app.memex_id', true)::uuid
+  );
+
+-- ── decisions ─────────────────────────────────────────────────────────────────
+
+ALTER TABLE decisions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE decisions FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS decisions_memex_isolation ON decisions;
+CREATE POLICY decisions_memex_isolation ON decisions
+  USING (
+    nullif(current_setting('app.memex_id', true), '') IS NOT NULL
+    AND memex_id = current_setting('app.memex_id', true)::uuid
+  )
+  WITH CHECK (
+    nullif(current_setting('app.memex_id', true), '') IS NOT NULL
+    AND memex_id = current_setting('app.memex_id', true)::uuid
+  );
+
+-- ── tasks ─────────────────────────────────────────────────────────────────────
+
+ALTER TABLE tasks ENABLE ROW LEVEL SECURITY;
+ALTER TABLE tasks FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS tasks_memex_isolation ON tasks;
+CREATE POLICY tasks_memex_isolation ON tasks
+  USING (
+    nullif(current_setting('app.memex_id', true), '') IS NOT NULL
+    AND memex_id = current_setting('app.memex_id', true)::uuid
+  )
+  WITH CHECK (
+    nullif(current_setting('app.memex_id', true), '') IS NOT NULL
+    AND memex_id = current_setting('app.memex_id', true)::uuid
+  );
+
+-- ── acs ───────────────────────────────────────────────────────────────────────
+
+ALTER TABLE acs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE acs FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS acs_memex_isolation ON acs;
+CREATE POLICY acs_memex_isolation ON acs
+  USING (
+    nullif(current_setting('app.memex_id', true), '') IS NOT NULL
+    AND memex_id = current_setting('app.memex_id', true)::uuid
+  )
+  WITH CHECK (
+    nullif(current_setting('app.memex_id', true), '') IS NOT NULL
+    AND memex_id = current_setting('app.memex_id', true)::uuid
+  );
+
+-- ── issues ────────────────────────────────────────────────────────────────────
+
+ALTER TABLE issues ENABLE ROW LEVEL SECURITY;
+ALTER TABLE issues FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS issues_memex_isolation ON issues;
+CREATE POLICY issues_memex_isolation ON issues
+  USING (
+    nullif(current_setting('app.memex_id', true), '') IS NOT NULL
+    AND memex_id = current_setting('app.memex_id', true)::uuid
+  )
+  WITH CHECK (
+    nullif(current_setting('app.memex_id', true), '') IS NOT NULL
+    AND memex_id = current_setting('app.memex_id', true)::uuid
+  );
+
+-- ── doc_members ───────────────────────────────────────────────────────────────
+
+ALTER TABLE doc_members ENABLE ROW LEVEL SECURITY;
+ALTER TABLE doc_members FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS doc_members_memex_isolation ON doc_members;
+CREATE POLICY doc_members_memex_isolation ON doc_members
+  USING (
+    nullif(current_setting('app.memex_id', true), '') IS NOT NULL
+    AND memex_id = current_setting('app.memex_id', true)::uuid
+  )
+  WITH CHECK (
+    nullif(current_setting('app.memex_id', true), '') IS NOT NULL
+    AND memex_id = current_setting('app.memex_id', true)::uuid
+  );
+
+-- ── doc_assignees ─────────────────────────────────────────────────────────────
+
+ALTER TABLE doc_assignees ENABLE ROW LEVEL SECURITY;
+ALTER TABLE doc_assignees FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS doc_assignees_memex_isolation ON doc_assignees;
+CREATE POLICY doc_assignees_memex_isolation ON doc_assignees
+  USING (
+    nullif(current_setting('app.memex_id', true), '') IS NOT NULL
+    AND memex_id = current_setting('app.memex_id', true)::uuid
+  )
+  WITH CHECK (
+    nullif(current_setting('app.memex_id', true), '') IS NOT NULL
+    AND memex_id = current_setting('app.memex_id', true)::uuid
+  );
+
+-- ── tags ──────────────────────────────────────────────────────────────────────
+
+ALTER TABLE tags ENABLE ROW LEVEL SECURITY;
+ALTER TABLE tags FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS tags_memex_isolation ON tags;
+CREATE POLICY tags_memex_isolation ON tags
+  USING (
+    nullif(current_setting('app.memex_id', true), '') IS NOT NULL
+    AND memex_id = current_setting('app.memex_id', true)::uuid
+  )
+  WITH CHECK (
+    nullif(current_setting('app.memex_id', true), '') IS NOT NULL
+    AND memex_id = current_setting('app.memex_id', true)::uuid
+  );
+
+-- ── document_tags ─────────────────────────────────────────────────────────────
+
+ALTER TABLE document_tags ENABLE ROW LEVEL SECURITY;
+ALTER TABLE document_tags FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS document_tags_memex_isolation ON document_tags;
+CREATE POLICY document_tags_memex_isolation ON document_tags
+  USING (
+    nullif(current_setting('app.memex_id', true), '') IS NOT NULL
+    AND memex_id = current_setting('app.memex_id', true)::uuid
+  )
+  WITH CHECK (
+    nullif(current_setting('app.memex_id', true), '') IS NOT NULL
+    AND memex_id = current_setting('app.memex_id', true)::uuid
+  );
+
+-- ── memex_emission_keys ───────────────────────────────────────────────────────
+
+ALTER TABLE memex_emission_keys ENABLE ROW LEVEL SECURITY;
+ALTER TABLE memex_emission_keys FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS memex_emission_keys_memex_isolation ON memex_emission_keys;
+CREATE POLICY memex_emission_keys_memex_isolation ON memex_emission_keys
+  USING (
+    nullif(current_setting('app.memex_id', true), '') IS NOT NULL
+    AND memex_id = current_setting('app.memex_id', true)::uuid
+  )
+  WITH CHECK (
+    nullif(current_setting('app.memex_id', true), '') IS NOT NULL
+    AND memex_id = current_setting('app.memex_id', true)::uuid
+  );
+
+-- ── repos ─────────────────────────────────────────────────────────────────────
+
+ALTER TABLE repos ENABLE ROW LEVEL SECURITY;
+ALTER TABLE repos FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS repos_memex_isolation ON repos;
+CREATE POLICY repos_memex_isolation ON repos
+  USING (
+    nullif(current_setting('app.memex_id', true), '') IS NOT NULL
+    AND memex_id = current_setting('app.memex_id', true)::uuid
+  )
+  WITH CHECK (
+    nullif(current_setting('app.memex_id', true), '') IS NOT NULL
+    AND memex_id = current_setting('app.memex_id', true)::uuid
+  );

--- a/packages/server/src/__regression__/tenant-isolation.regression.test.ts
+++ b/packages/server/src/__regression__/tenant-isolation.regression.test.ts
@@ -33,14 +33,23 @@ import { createDocDraft } from "../services/documents.js";
 import { createTask } from "../services/tasks.js";
 import { createDecision, proposeDecision } from "../services/decisions.js";
 import { addComment } from "../services/comments.js";
+import { createAc } from "../services/acs.js";
+import { signAccessToken } from "../services/oauth/access-tokens.js";
+import { tagAc } from "@memex-ai-ac/vitest";
 
 const originalClientId = process.env.GOOGLE_CLIENT_ID;
+const originalOAuthEnabled = process.env.OAUTH_ENABLED;
 beforeAll(() => {
   delete process.env.GOOGLE_CLIENT_ID;
   vi.resetModules();
 });
 afterAll(() => {
   if (originalClientId !== undefined) process.env.GOOGLE_CLIENT_ID = originalClientId;
+  if (originalOAuthEnabled !== undefined) {
+    process.env.OAUTH_ENABLED = originalOAuthEnabled;
+  } else {
+    delete process.env.OAUTH_ENABLED;
+  }
 });
 
 const created = {
@@ -149,6 +158,9 @@ let bobCommentHandle: string;
 let carol: { userId: string };
 let carolToken: string;
 
+let daveOAuthToken: string;
+let bobAcHandle: string;
+
 beforeAll(async () => {
   alice = await makeUserOrgMemex("alice");
   aliceMemexA2 = await addMemexToNamespace(alice.nsId, "second", "Alice memex-A2");
@@ -193,6 +205,38 @@ beforeAll(async () => {
 
   const comment = await addComment(bob.memexId, bobSectionId, "Bob", "Bob's comment");
   bobCommentHandle = `c-${comment.seq}`;
+
+  // Seed an AC in Bob's spec for the get_ac cross-tenant test.
+  const bobAc = await createAc({
+    memexId: bob.memexId,
+    briefId: bobSpecId,
+    kind: "implementation",
+    statement: "Bob's AC for cross-tenant isolation test",
+  });
+  bobAcHandle = `ac-${bobAc.seq}`;
+
+  // Confirm Bob's memex is private (schema default, but state it explicitly).
+  await db.update(memexes).set({ visibility: "private" }).where(eq(memexes.id, bob.memexId));
+
+  // Dave: member of BOTH org-A (Alice's) and org-B (Bob's), OAuth token scoped to org-A.
+  // Tests that orgFilter rejects org-B reads even when Dave has org-B membership.
+  // PAT tokens (mxt_ prefix) are matched first in app.ts, so enabling OAuth here
+  // does not affect any of the existing PAT-based tests above.
+  process.env.OAUTH_ENABLED = "1";
+  const daveTag = `dave-${Date.now().toString(36)}`;
+  const [daveUser] = await db
+    .insert(users)
+    .values({ email: `iso-${daveTag}@memex.ai` } as never)
+    .returning();
+  created.users.push(daveUser.id);
+  await db.insert(orgMemberships).values({ userId: daveUser.id, orgId: alice.orgId, role: "member" } as never);
+  await db.insert(orgMemberships).values({ userId: daveUser.id, orgId: bob.orgId, role: "member" } as never);
+  daveOAuthToken = signAccessToken({
+    userId: daveUser.id,
+    orgId: alice.orgId,
+    clientId: "test-orgfilter-client",
+    scopes: ["read"],
+  });
 });
 
 // ── Cross-tenant rejection helpers ───────────────────────────────────────────
@@ -428,5 +472,68 @@ describe("regression: tenant-isolation — Carol intra-org memex switching", () 
     expect(doc.memexId).toBe(alice.memexId);
     expect(doc.memexId).not.toBe(aliceMemexA2.memexId);
     void specsInA2; // referenced above for clarity
+  });
+});
+
+// ── spec-199 t-7: Cross-tenant read gate (canReadMemex / resolveWorkspaceForRead) ─
+
+const AC_7 = "mindset-prod/memex-building-itself/specs/spec-199/acs/ac-7";
+
+describe("regression: tenant-isolation — read tools cross-tenant gate (spec-199 t-7)", () => {
+  // ref-path tools: resolveMemexFromEntityForRead → assertReadAccessAndWriteFlag
+  it("get_doc: rejected on Bob's private spec", async () => {
+    tagAc(AC_7);
+    await expectRejection(aliceToken, "get_doc", { ref: bobRef(`specs/${bobSpecHandle}`) });
+  });
+
+  it("list_tasks: rejected on Bob's private spec", async () => {
+    tagAc(AC_7);
+    await expectRejection(aliceToken, "list_tasks", { ref: bobRef(`specs/${bobSpecHandle}`) });
+  });
+
+  it("get_ac: rejected on Bob's private AC", async () => {
+    tagAc(AC_7);
+    await expectRejection(aliceToken, "get_ac", {
+      ref: bobRef(`specs/${bobSpecHandle}/acs/${bobAcHandle}`),
+    });
+  });
+
+  // memex-arg tools: resolveWorkspaceForRead → assertReadAccessAndWriteFlag
+  it("list_docs: rejected on Bob's private memex", async () => {
+    tagAc(AC_7);
+    await expectRejection(aliceToken, "list_docs", {
+      memex: `${bob.nsSlug}/${bob.memexSlug}`,
+    });
+  });
+
+  it("search_memex: rejected on Bob's private memex", async () => {
+    tagAc(AC_7);
+    await expectRejection(aliceToken, "search_memex", {
+      memex: `${bob.nsSlug}/${bob.memexSlug}`,
+      query: "test query",
+    });
+  });
+
+  // orgFilter: Dave is a member of org-B but his OAuth token is scoped to org-A.
+  // Positive control first: same token is accepted on an org-A resource.
+  it("orgFilter positive control: Dave's org-A token reads Alice's memex (allowed)", async () => {
+    tagAc(AC_7);
+    const res = await mcpCall(daveOAuthToken, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/call",
+      params: { name: "list_docs", arguments: { memex: `${alice.nsSlug}/${alice.memexSlug}` } },
+    });
+    expect(res.status).toBe(200);
+    const body = parseSse(await res.text());
+    expect(body.result?.isError, `Dave's org-A token should read Alice's memex: ${body.result?.content?.[0]?.text ?? ""}`).toBeFalsy();
+  });
+
+  it("orgFilter: Dave's org-A token is rejected on Bob's org-B private memex despite org-B membership", async () => {
+    tagAc(AC_7);
+    // Dave IS a member of org-B (Bob's org), but orgFilter=alice.orgId !== bob.orgId → rejected.
+    await expectRejection(daveOAuthToken, "get_doc", {
+      ref: bobRef(`specs/${bobSpecHandle}`),
+    });
   });
 });

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { Hono } from "hono";
 import { cors } from "hono/cors";
+import { secureHeaders } from "hono/secure-headers";
 import { errorHandler } from "./middleware/error-handler.js";
 import { sessionMiddleware } from "./middleware/session.js";
 import { memexesRouter } from "./routes/memexes.js";
@@ -73,6 +74,8 @@ const { injectWebSocket, upgradeWebSocket } = createNodeWebSocket({ app });
 
 // CORS policy lives in middleware/cors-policy.ts so it can be unit-tested without
 // pulling in the DB connection. See that file for the rationale on each entry.
+
+app.use("*", secureHeaders());
 
 app.use(
   "*",

--- a/packages/server/src/db/connection.ts
+++ b/packages/server/src/db/connection.ts
@@ -1,4 +1,5 @@
 import "dotenv/config";
+import { AsyncLocalStorage } from "node:async_hooks";
 import { drizzle } from "drizzle-orm/postgres-js";
 import type { PostgresJsQueryResultHKT } from "drizzle-orm/postgres-js";
 import type { PgTransaction } from "drizzle-orm/pg-core";
@@ -40,7 +41,128 @@ const client = socketPath
   ? postgres(connectionString, { host: socketPath, ...poolOptions })
   : postgres(connectionString, poolOptions);
 
-export const db = drizzle(client, { schema });
+// ── Per-query RLS tenant injection (spec-199 ac-13–ac-17) ────────────────────
+//
+// ALS carries the request-scoped memexId. Session middleware sets it via
+// runWithMemexId. The rlsClient proxy reads it at every query call-site and
+// prepends `set_config('app.memex_id', $1, true)` in a per-query
+// micro-transaction — no changes to service functions required.
+//
+// Why per-query (not per-request)?  A per-request wrapper would hold a pool
+// connection for the entire request lifetime (including Anthropic/Postmark I/O),
+// violating the connection budget documented above.  Per-query micro-transactions
+// hold a connection for milliseconds; each BEGIN/set_config/query/COMMIT is
+// ≈3 extra ms but scales correctly at pool max=5.
+
+interface MemexRequestContext {
+  memexId: string;
+}
+
+export const memexContext = new AsyncLocalStorage<MemexRequestContext>();
+
+/**
+ * Set the request-scoped memexId in the ALS context for the duration of fn.
+ * Every db.* call within fn's async subtree will automatically prepend
+ * `set_config('app.memex_id', $1, true)` in its own micro-transaction so RLS
+ * policies see the correct tenant on every query.
+ *
+ * When memexId is null/undefined (anonymous public read, no resolved tenant),
+ * fn runs without an ALS context — the IS NOT NULL guard in each RLS policy
+ * blocks cross-tenant reads on the restricted role, and the superuser role
+ * bypasses RLS unconditionally.
+ */
+export function runWithMemexId(
+  memexId: string | null | undefined,
+  fn: () => Promise<void>,
+): Promise<void> {
+  if (!memexId) return fn();
+  return memexContext.run({ memexId }, fn);
+}
+
+/**
+ * Returns a thenable that executes `query` inside a per-query
+ * BEGIN/set_config/COMMIT micro-transaction.  Supports both direct await
+ * (returns row objects) and .values() chaining (returns row arrays — the form
+ * Drizzle uses internally for SELECT field mapping).
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function makeRlsQuery(pool: any, memexId: string, query: string, params: any[]) {
+  const run = (useValues: boolean) =>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    pool.begin(async (txSql: any) => {
+      await txSql.unsafe("SELECT set_config('app.memex_id', $1, true)", [memexId]);
+      const q = txSql.unsafe(query, params);
+      return useValues ? q.values() : q;
+    });
+
+  return {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    then(onfulfilled: any, onrejected: any) { return run(false).then(onfulfilled, onrejected); },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    catch(onrejected: any) { return run(false).catch(onrejected); },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    finally(onfinally: any) { return run(false).finally(onfinally); },
+    values() {
+      return {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        then(onfulfilled: any, onrejected: any) { return run(true).then(onfulfilled, onrejected); },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        catch(onrejected: any) { return run(true).catch(onrejected); },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        finally(onfinally: any) { return run(true).finally(onfinally); },
+      };
+    },
+  };
+}
+
+/**
+ * Proxy the postgres-js client to inject `set_config('app.memex_id')` when a
+ * request context is active:
+ *
+ * - unsafe(q, p):  wraps in a per-query micro-transaction; .values() chaining
+ *   is preserved for Drizzle's SELECT field mapper.
+ * - begin(callback): prepends set_config to the caller's transaction so every
+ *   query inside `db.transaction(tx => …)` inherits the GUC automatically.
+ *
+ * Only these two intercepts are needed: Drizzle routes ALL query execution
+ * through client.unsafe() and all explicit transactions through client.begin().
+ * Savepoints (nested tx.transaction()) use the transaction-scoped txSql which
+ * already has the GUC set — they are never proxied.
+ */
+function createRlsClient(baseClient: postgres.Sql): postgres.Sql {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return new Proxy(baseClient as any, {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    get(target: any, prop: string | symbol) {
+      if (prop === "unsafe") {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        return function (query: string, params: any[] = []) {
+          const ctx = memexContext.getStore();
+          if (!ctx?.memexId) return target.unsafe(query, params);
+          return makeRlsQuery(target, ctx.memexId, query, params);
+        };
+      }
+      if (prop === "begin") {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        return function (callback: (txSql: any) => Promise<any>) {
+          const ctx = memexContext.getStore();
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          return target.begin(async (txSql: any) => {
+            if (ctx?.memexId) {
+              await txSql.unsafe("SELECT set_config('app.memex_id', $1, true)", [ctx.memexId]);
+            }
+            return callback(txSql);
+          });
+        };
+      }
+      return Reflect.get(target, prop, target);
+    },
+  }) as postgres.Sql;
+}
+
+const rlsClient = createRlsClient(client);
+
+export const db = drizzle(rlsClient, { schema });
 
 // The raw postgres-js pooled client. Exposed so the cross-instance bus relay
 // (services/bus-relay.ts, spec-156) can issue fire-and-forget NOTIFY statements

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -1366,6 +1366,8 @@ export const shareTokens = pgTable("share_tokens", {
   token: text("token").notNull().unique(),
   revoked: boolean("revoked").notNull().default(false),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  createdByUserId: uuid("created_by_user_id").references(() => users.id, { onDelete: "set null" }),
+  expiresAt: timestamp("expires_at", { withTimezone: true }),
 });
 
 // Long-lived MCP API tokens issued per (user × device). Token value `mxt_<random>` is

--- a/packages/server/src/db/spec-199-als-proxy.test.ts
+++ b/packages/server/src/db/spec-199-als-proxy.test.ts
@@ -16,6 +16,7 @@ import { tagAc } from "@memex-ai-ac/vitest";
 
 const AC_13 = "mindset-prod/memex-building-itself/specs/spec-199/acs/ac-13";
 const AC_14 = "mindset-prod/memex-building-itself/specs/spec-199/acs/ac-14";
+const AC_17 = "mindset-prod/memex-building-itself/specs/spec-199/acs/ac-17";
 
 // ── ac-13: AsyncLocalStorage ──────────────────────────────────────────────────
 
@@ -178,5 +179,48 @@ describe("spec-199 ac-14: db Proxy injects set_config per query", () => {
     });
 
     expect(captured).toBe(testId);
+  });
+});
+
+// ── ac-17: proxy causes no regressions in normal service queries ───────────────
+
+describe("spec-199 ac-17: rlsClient proxy causes no regressions", () => {
+  it("ac-17: db.execute() works without ALS context (superuser path, no GUC wrap)", async () => {
+    tagAc(AC_17);
+
+    // The proxy must fall through cleanly when no ALS context is active.
+    // A failing proxy would throw or return unexpected results here.
+    const rows = await db.execute(sql`SELECT 1 AS ping`);
+    expect((rows as unknown as Array<{ ping: number }>)[0]?.ping).toBe(1);
+  });
+
+  it("ac-17: db.execute() works inside runWithMemexId (proxied path, GUC set)", async () => {
+    tagAc(AC_17);
+
+    const testId = "17171717-1717-1717-1717-171717171717";
+    let ok = false;
+
+    await runWithMemexId(testId, async () => {
+      const rows = await db.execute(sql`SELECT 1 AS ping`);
+      ok = (rows as unknown as Array<{ ping: number }>)[0]?.ping === 1;
+    });
+
+    expect(ok).toBe(true);
+  });
+
+  it("ac-17: db.transaction() works inside runWithMemexId (begin() intercept path)", async () => {
+    tagAc(AC_17);
+
+    const testId = "17171717-1717-1717-1717-171717171718";
+    let ok = false;
+
+    await runWithMemexId(testId, async () => {
+      await db.transaction(async (tx) => {
+        const rows = await tx.execute(sql`SELECT 2 AS ping`);
+        ok = (rows as unknown as Array<{ ping: number }>)[0]?.ping === 2;
+      });
+    });
+
+    expect(ok).toBe(true);
   });
 });

--- a/packages/server/src/db/spec-199-als-proxy.test.ts
+++ b/packages/server/src/db/spec-199-als-proxy.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect } from "vitest";
+import { sql } from "drizzle-orm";
+import { db, memexContext, runWithMemexId } from "./connection.js";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+// spec-199 ac-13: AsyncLocalStorage per-request memex context.
+// spec-199 ac-14: db Proxy injects set_config('app.memex_id') per query.
+//
+// ac-13 tests are pure unit tests (no DB): they exercise runWithMemexId and
+// memexContext directly.
+//
+// ac-14 tests require a DB connection: they query current_setting() from
+// inside a db.execute() call to verify the proxy actually set the GUC before
+// the query ran. This is the only way to confirm at-the-wire correctness
+// without mocking internals.
+
+const AC_13 = "mindset-prod/memex-building-itself/specs/spec-199/acs/ac-13";
+const AC_14 = "mindset-prod/memex-building-itself/specs/spec-199/acs/ac-14";
+
+// ── ac-13: AsyncLocalStorage ──────────────────────────────────────────────────
+
+describe("spec-199 ac-13: AsyncLocalStorage per-request context", () => {
+  it("ac-13: runWithMemexId makes memexId available via memexContext.getStore()", async () => {
+    tagAc(AC_13);
+
+    let captured: string | undefined;
+    await runWithMemexId("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", async () => {
+      captured = memexContext.getStore()?.memexId;
+    });
+
+    expect(captured).toBe("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+  });
+
+  it("ac-13: context is absent outside runWithMemexId", () => {
+    tagAc(AC_13);
+    expect(memexContext.getStore()).toBeUndefined();
+  });
+
+  it("ac-13: null memexId is a no-op — fn still runs, context stays unset", async () => {
+    tagAc(AC_13);
+
+    let insideContext: ReturnType<typeof memexContext.getStore>;
+    await runWithMemexId(null, async () => {
+      insideContext = memexContext.getStore();
+    });
+
+    expect(insideContext).toBeUndefined();
+  });
+
+  it("ac-13: undefined memexId is a no-op — fn still runs, context stays unset", async () => {
+    tagAc(AC_13);
+
+    let insideContext: ReturnType<typeof memexContext.getStore>;
+    await runWithMemexId(undefined, async () => {
+      insideContext = memexContext.getStore();
+    });
+
+    expect(insideContext).toBeUndefined();
+  });
+
+  it("ac-13: inner runWithMemexId overrides outer — no cross-tenant bleed", async () => {
+    tagAc(AC_13);
+
+    let outer: string | undefined;
+    let inner: string | undefined;
+    let afterInner: string | undefined;
+
+    await runWithMemexId("outer-memex-id", async () => {
+      outer = memexContext.getStore()?.memexId;
+      await runWithMemexId("inner-memex-id", async () => {
+        inner = memexContext.getStore()?.memexId;
+      });
+      afterInner = memexContext.getStore()?.memexId;
+    });
+
+    expect(outer).toBe("outer-memex-id");
+    expect(inner).toBe("inner-memex-id");
+    expect(afterInner).toBe("outer-memex-id");
+  });
+
+  it("ac-13: concurrent runWithMemexId calls are isolated from each other", async () => {
+    tagAc(AC_13);
+
+    const results: string[] = [];
+
+    await Promise.all([
+      runWithMemexId("memex-alpha", async () => {
+        await new Promise((r) => setTimeout(r, 10));
+        results.push(memexContext.getStore()?.memexId ?? "missing");
+      }),
+      runWithMemexId("memex-beta", async () => {
+        await new Promise((r) => setTimeout(r, 5));
+        results.push(memexContext.getStore()?.memexId ?? "missing");
+      }),
+    ]);
+
+    expect(results).toContain("memex-alpha");
+    expect(results).toContain("memex-beta");
+    expect(results).not.toContain("missing");
+  });
+});
+
+// ── ac-14: db Proxy GUC injection ─────────────────────────────────────────────
+
+describe("spec-199 ac-14: db Proxy injects set_config per query", () => {
+  it("ac-14: current_setting reflects memexId within a runWithMemexId scope", async () => {
+    tagAc(AC_14);
+
+    const testId = "12345678-1234-1234-1234-1234567890ab";
+    let captured: string | null = null;
+
+    await runWithMemexId(testId, async () => {
+      // The proxy wraps this in: BEGIN / set_config('app.memex_id', testId, true)
+      // / <query> / COMMIT. The query runs in the same txn and sees the GUC.
+      const rows = await db.execute(
+        sql`SELECT current_setting('app.memex_id', true) AS guc_value`,
+      );
+      captured =
+        (rows as unknown as Array<{ guc_value: string | null }>)[0]?.guc_value ??
+        null;
+    });
+
+    expect(captured).toBe(testId);
+  });
+
+  it("ac-14: GUC is absent (null) outside runWithMemexId — no ambient leakage", async () => {
+    tagAc(AC_14);
+
+    // No ALS context → proxy falls through to target.unsafe() → no set_config
+    const rows = await db.execute(
+      sql`SELECT current_setting('app.memex_id', true) AS guc_value`,
+    );
+    const value = (
+      rows as unknown as Array<{ guc_value: string | null }>
+    )[0]?.guc_value;
+
+    // current_setting(..., true) returns NULL when the GUC has never been set
+    // in this session. Accept NULL or empty string (postgres may normalise).
+    expect(value == null || value === "").toBe(true);
+  });
+
+  it("ac-14: GUC does not leak between consecutive runWithMemexId calls", async () => {
+    tagAc(AC_14);
+
+    const testId = "abcdefab-cdef-abcd-efab-cdefabcdefab";
+
+    // First call sets GUC inside the micro-transaction
+    await runWithMemexId(testId, async () => {
+      await db.execute(sql`SELECT 1`);
+    });
+
+    // After the scope exits, a plain query should see no GUC
+    const rows = await db.execute(
+      sql`SELECT current_setting('app.memex_id', true) AS guc_value`,
+    );
+    const value = (
+      rows as unknown as Array<{ guc_value: string | null }>
+    )[0]?.guc_value;
+
+    expect(value == null || value === "").toBe(true);
+  });
+
+  it("ac-14: explicit db.transaction() inherits GUC via begin() intercept", async () => {
+    tagAc(AC_14);
+
+    const testId = "feedface-feed-face-feed-facefeedface";
+    let captured: string | null = null;
+
+    await runWithMemexId(testId, async () => {
+      await db.transaction(async (tx) => {
+        const rows = await tx.execute(
+          sql`SELECT current_setting('app.memex_id', true) AS guc_value`,
+        );
+        captured =
+          (rows as unknown as Array<{ guc_value: string | null }>)[0]
+            ?.guc_value ?? null;
+      });
+    });
+
+    expect(captured).toBe(testId);
+  });
+});

--- a/packages/server/src/db/spec-199-memex-app-role.test.ts
+++ b/packages/server/src/db/spec-199-memex-app-role.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import { sql } from "drizzle-orm";
+import { db } from "./connection.js";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+// spec-199 ac-18: memex_app Postgres role properties.
+//
+// Verifies the role created by migration 0081 has the correct attributes:
+// NOSUPERUSER, NOBYPASSRLS, NOINHERIT. Also confirms it holds DML privileges
+// on every public table and on sequences in the schema.
+//
+// These tests run against the local test DB (where 0081 has been applied).
+// The same properties must hold in Cloud SQL INT/PROD — verified post-deploy
+// by the smoke suite (std-17) and the t-14 cutover checklist.
+
+const AC_18 = "mindset-prod/memex-building-itself/specs/spec-199/acs/ac-18";
+
+describe("spec-199 ac-18: memex_app role attributes and grants", () => {
+  it("ac-18: memex_app role exists and is NOSUPERUSER NOBYPASSRLS", async () => {
+    tagAc(AC_18);
+
+    const rows = (await db.execute(sql`
+      SELECT rolname, rolsuper, rolbypassrls, rolinherit, rolcreaterole, rolcreatedb
+      FROM pg_roles
+      WHERE rolname = 'memex_app'
+    `)) as unknown as Array<{
+      rolname: string;
+      rolsuper: boolean;
+      rolbypassrls: boolean;
+      rolinherit: boolean;
+      rolcreaterole: boolean;
+      rolcreatedb: boolean;
+    }>;
+
+    expect(rows.length, "memex_app role not found in pg_roles").toBe(1);
+    const role = rows[0]!;
+    expect(role.rolsuper, "memex_app must not be superuser").toBe(false);
+    expect(role.rolbypassrls, "memex_app must not have BYPASSRLS").toBe(false);
+    expect(role.rolcreaterole, "memex_app must not have CREATEROLE").toBe(false);
+    expect(role.rolcreatedb, "memex_app must not have CREATEDB").toBe(false);
+  });
+
+  it("ac-18: memex_app has SELECT privilege on the documents table", async () => {
+    tagAc(AC_18);
+
+    // Spot-check one table; the migration uses GRANT ... ON ALL TABLES which
+    // covers every table in the schema. Checking one is sufficient to confirm
+    // the grant ran — a failed grant would leave no privileges at all.
+    const rows = (await db.execute(sql`
+      SELECT has_table_privilege('memex_app', 'documents', 'SELECT') AS has_select,
+             has_table_privilege('memex_app', 'documents', 'INSERT') AS has_insert,
+             has_table_privilege('memex_app', 'documents', 'UPDATE') AS has_update,
+             has_table_privilege('memex_app', 'documents', 'DELETE') AS has_delete
+    `)) as unknown as Array<{
+      has_select: boolean;
+      has_insert: boolean;
+      has_update: boolean;
+      has_delete: boolean;
+    }>;
+
+    const perms = rows[0]!;
+    expect(perms.has_select, "memex_app missing SELECT on documents").toBe(true);
+    expect(perms.has_insert, "memex_app missing INSERT on documents").toBe(true);
+    expect(perms.has_update, "memex_app missing UPDATE on documents").toBe(true);
+    expect(perms.has_delete, "memex_app missing DELETE on documents").toBe(true);
+  });
+
+  it("ac-18: memex_app has USAGE privilege on the public schema", async () => {
+    tagAc(AC_18);
+
+    const rows = (await db.execute(sql`
+      SELECT has_schema_privilege('memex_app', 'public', 'USAGE') AS has_usage
+    `)) as unknown as Array<{ has_usage: boolean }>;
+
+    expect(rows[0]!.has_usage, "memex_app missing USAGE on public schema").toBe(true);
+  });
+
+  it("ac-18: memex_app cannot connect as postgres (BYPASSRLS test — superuser bypasses RLS, memex_app does not)", async () => {
+    tagAc(AC_18);
+
+    // Confirm postgres IS a superuser (the role used for migrations)
+    const pgRows = (await db.execute(sql`
+      SELECT rolsuper, rolbypassrls
+      FROM pg_roles
+      WHERE rolname = 'postgres'
+    `)) as unknown as Array<{ rolsuper: boolean; rolbypassrls: boolean }>;
+
+    // postgres must remain superuser/BYPASSRLS so migrations keep working
+    expect(pgRows[0]?.rolsuper, "postgres must remain superuser").toBe(true);
+    expect(pgRows[0]?.rolbypassrls, "postgres must retain BYPASSRLS").toBe(true);
+  });
+});

--- a/packages/server/src/db/spec-199-rls-schema.test.ts
+++ b/packages/server/src/db/spec-199-rls-schema.test.ts
@@ -193,6 +193,29 @@ describe("spec-199 ac-16: RLS tenant isolation", () => {
     }
   });
 
+  it("ac-16: memex_app role without GUC sees 0 rows (SET LOCAL ROLE production path)", async () => {
+    tagAc(AC_15);
+    tagAc(AC_16);
+
+    // Switch to memex_app within a transaction using SET LOCAL ROLE. This drops
+    // BYPASSRLS for the duration of the transaction (memex_app has NOBYPASSRLS),
+    // so FORCE ROW LEVEL SECURITY applies and the USING clause blocks every row
+    // because no app.memex_id GUC is set. This simulates the production runtime
+    // path before t-14 (DATABASE_URL cutover) runs.
+    const dbUrl =
+      process.env.DATABASE_URL ?? "postgresql://postgres:postgres@localhost:5432/memex";
+    const superSql = postgres(dbUrl, { max: 1 });
+    try {
+      const rows = await superSql.begin(async (tx) => {
+        await tx.unsafe("SET LOCAL ROLE memex_app");
+        return tx.unsafe("SELECT id FROM documents LIMIT 10");
+      });
+      expect(rows).toHaveLength(0);
+    } finally {
+      await superSql.end({ timeout: 5 });
+    }
+  });
+
   it("ac-16: all 14 tables have the memex_isolation policy covering ALL commands", async () => {
     tagAc(AC_15);
     tagAc(AC_16);

--- a/packages/server/src/db/spec-199-rls-schema.test.ts
+++ b/packages/server/src/db/spec-199-rls-schema.test.ts
@@ -22,6 +22,7 @@ import { tagAc } from "@memex-ai-ac/vitest";
 //   NOBYPASSRLS to see the policies in action. The restricted role is created
 //   fresh in beforeAll and dropped in afterAll so the test is self-contained.
 
+const AC_15 = "mindset-prod/memex-building-itself/specs/spec-199/acs/ac-15";
 const AC_16 = "mindset-prod/memex-building-itself/specs/spec-199/acs/ac-16";
 const RLS_ROLE = "memex_rls_tester";
 const RLS_PASS = "memex_rls_test_only";
@@ -152,6 +153,7 @@ describe("spec-199 ac-16: RLS tenant isolation", () => {
   });
 
   it("ac-16: RLS is enabled and forced on all 14 tenant tables", async () => {
+    tagAc(AC_15);
     tagAc(AC_16);
 
     // pg_class has relrowsecurity + relforcerowsecurity (pg_tables lacks the latter)
@@ -192,6 +194,7 @@ describe("spec-199 ac-16: RLS tenant isolation", () => {
   });
 
   it("ac-16: all 14 tables have the memex_isolation policy covering ALL commands", async () => {
+    tagAc(AC_15);
     tagAc(AC_16);
 
     const rows = (await db.execute(sql`

--- a/packages/server/src/db/spec-199-rls-schema.test.ts
+++ b/packages/server/src/db/spec-199-rls-schema.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { sql } from "drizzle-orm";
+import { eq, inArray, sql } from "drizzle-orm";
 import postgres from "postgres";
 import { db } from "./connection.js";
 import { documents, memexes, namespaces } from "./schema.js";
@@ -99,6 +99,19 @@ describe("spec-199 ac-16: RLS tenant isolation", () => {
     await restrictedSql?.end({ timeout: 5 });
     await db.execute(sql.raw(`DROP OWNED BY ${RLS_ROLE} CASCADE`)).catch(() => {});
     await db.execute(sql.raw(`DROP ROLE IF EXISTS ${RLS_ROLE}`));
+    // Clean up seed data so the namespace owner-XOR invariant check in
+    // migration-smoke.api.test.ts passes when it runs in the same worker DB.
+    // Our namespaces are kind='org' without owner_org_id (test-only shortcut)
+    // which violates the invariant. Delete in FK order.
+    const memexIds = [memexAId, memexBId].filter(Boolean);
+    if (memexIds.length) {
+      await db.delete(documents).where(inArray(documents.memexId, memexIds)).catch(() => {});
+      await db.delete(memexes).where(inArray(memexes.id, memexIds)).catch(() => {});
+    }
+    await db
+      .delete(namespaces)
+      .where(inArray(namespaces.slug, ["rls-test-ns-a", "rls-test-ns-b"]))
+      .catch(() => {});
   });
 
   it("ac-16: no GUC → restricted role sees 0 rows in documents", async () => {

--- a/packages/server/src/db/spec-199-rls-schema.test.ts
+++ b/packages/server/src/db/spec-199-rls-schema.test.ts
@@ -1,0 +1,219 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { sql } from "drizzle-orm";
+import postgres from "postgres";
+import { db } from "./connection.js";
+import { documents, memexes, namespaces } from "./schema.js";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+// spec-199 ac-16: RLS tenant isolation via restricted role.
+//
+// These tests prove that the Phase 2 RLS policies (migration 0081) enforce
+// tenant isolation at the database level — not merely at the application layer.
+// They open a second postgres-js connection AS a non-superuser, non-BYPASSRLS
+// role and verify:
+//   - SELECT without GUC returns 0 rows (policy USING blocks every row)
+//   - SELECT with correct GUC returns only the matching tenant's rows
+//   - SELECT with wrong GUC hides the neighbour tenant's rows
+//   - INSERT with GUC set to tenant A but row.memex_id = tenant B is rejected
+//
+// Why a separate connection?
+//   The `db` singleton connects as `postgres` (superuser), which has BYPASSRLS
+//   and would pass through every policy. We need a role with NOSUPERUSER and
+//   NOBYPASSRLS to see the policies in action. The restricted role is created
+//   fresh in beforeAll and dropped in afterAll so the test is self-contained.
+
+const AC_16 = "mindset-prod/memex-building-itself/specs/spec-199/acs/ac-16";
+const RLS_ROLE = "memex_rls_tester";
+const RLS_PASS = "memex_rls_test_only";
+
+describe("spec-199 ac-16: RLS tenant isolation", () => {
+  let restrictedSql: postgres.Sql;
+  let memexAId: string;
+  let memexBId: string;
+
+  beforeAll(async () => {
+    // Drop owned objects first so DROP ROLE won't complain about privileges,
+    // then recreate cleanly so reruns in the same DB don't hit conflicts.
+    await db.execute(sql.raw(`DROP OWNED BY ${RLS_ROLE} CASCADE`)).catch(() => {});
+    await db.execute(sql.raw(`DROP ROLE IF EXISTS ${RLS_ROLE}`));
+    await db.execute(
+      sql.raw(
+        `CREATE ROLE ${RLS_ROLE} LOGIN PASSWORD '${RLS_PASS}'` +
+          ` NOSUPERUSER NOINHERIT NOCREATEDB NOCREATEROLE NOREPLICATION NOBYPASSRLS`,
+      ),
+    );
+    await db.execute(sql.raw(`GRANT USAGE ON SCHEMA public TO ${RLS_ROLE}`));
+    await db.execute(
+      sql.raw(`GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO ${RLS_ROLE}`),
+    );
+    await db.execute(
+      sql.raw(`GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO ${RLS_ROLE}`),
+    );
+
+    // Seed two namespaces + memexes directly as superuser (bypasses RLS;
+    // ALS context is never set in test scope so the rlsClient proxy falls through)
+    const [nsA] = await db
+      .insert(namespaces)
+      .values({ slug: "rls-test-ns-a", kind: "org" })
+      .returning({ id: namespaces.id });
+    const [nsB] = await db
+      .insert(namespaces)
+      .values({ slug: "rls-test-ns-b", kind: "org" })
+      .returning({ id: namespaces.id });
+
+    const [mxA] = await db
+      .insert(memexes)
+      .values({ namespaceId: nsA!.id, slug: "rls-mx-a", name: "RLS Memex A" })
+      .returning({ id: memexes.id });
+    const [mxB] = await db
+      .insert(memexes)
+      .values({ namespaceId: nsB!.id, slug: "rls-mx-b", name: "RLS Memex B" })
+      .returning({ id: memexes.id });
+
+    memexAId = mxA!.id;
+    memexBId = mxB!.id;
+
+    await db.insert(documents).values({
+      memexId: memexAId,
+      handle: "rls-doc-a",
+      title: "RLS Test Doc A",
+      docType: "document",
+    });
+    await db.insert(documents).values({
+      memexId: memexBId,
+      handle: "rls-doc-b",
+      title: "RLS Test Doc B",
+      docType: "document",
+    });
+
+    const dbUrl = new URL(
+      process.env.DATABASE_URL ?? "postgresql://postgres:postgres@localhost:5432/memex",
+    );
+    dbUrl.username = RLS_ROLE;
+    dbUrl.password = RLS_PASS;
+    restrictedSql = postgres(dbUrl.toString(), { max: 1 });
+  });
+
+  afterAll(async () => {
+    await restrictedSql?.end({ timeout: 5 });
+    await db.execute(sql.raw(`DROP OWNED BY ${RLS_ROLE} CASCADE`)).catch(() => {});
+    await db.execute(sql.raw(`DROP ROLE IF EXISTS ${RLS_ROLE}`));
+  });
+
+  it("ac-16: no GUC → restricted role sees 0 rows in documents", async () => {
+    tagAc(AC_16);
+
+    // No set_config call — policy USING clause evaluates to FALSE for every row
+    const rows = await restrictedSql`SELECT id FROM documents LIMIT 10`;
+    expect(rows).toHaveLength(0);
+  });
+
+  it("ac-16: correct GUC → only matching tenant's rows are visible", async () => {
+    tagAc(AC_16);
+
+    const rows = (await restrictedSql.begin(async (tx) => {
+      await tx.unsafe("SELECT set_config('app.memex_id', $1, true)", [memexAId]);
+      return tx.unsafe(
+        "SELECT id, memex_id::text AS memex_id FROM documents WHERE TRUE",
+      );
+    })) as Array<{ id: string; memex_id: string }>;
+
+    expect(rows.length).toBeGreaterThan(0);
+    for (const row of rows) {
+      expect(row.memex_id).toBe(memexAId);
+    }
+  });
+
+  it("ac-16: wrong GUC → neighbour tenant rows are hidden", async () => {
+    tagAc(AC_16);
+
+    // GUC = memexA, but memexB's rows must not appear
+    const rows = await restrictedSql.begin(async (tx) => {
+      await tx.unsafe("SELECT set_config('app.memex_id', $1, true)", [memexAId]);
+      return tx.unsafe("SELECT id FROM documents WHERE memex_id = $1", [memexBId]);
+    });
+
+    expect(rows).toHaveLength(0);
+  });
+
+  it("ac-16: cross-tenant INSERT is rejected by WITH CHECK", async () => {
+    tagAc(AC_16);
+
+    // GUC = memexA, INSERT row for memexB → WITH CHECK violation
+    await expect(
+      restrictedSql.begin(async (tx) => {
+        await tx.unsafe("SELECT set_config('app.memex_id', $1, true)", [memexAId]);
+        return tx.unsafe(
+          "INSERT INTO documents (memex_id, handle, title, doc_type, status) VALUES ($1, $2, $3, $4, $5)",
+          [memexBId, "rls-cross-tenant", "Cross-tenant bad insert", "document", "draft"],
+        );
+      }),
+    ).rejects.toThrow();
+  });
+
+  it("ac-16: RLS is enabled and forced on all 14 tenant tables", async () => {
+    tagAc(AC_16);
+
+    // pg_class has relrowsecurity + relforcerowsecurity (pg_tables lacks the latter)
+    const rows = (await db.execute(sql`
+      SELECT c.relname AS tablename,
+             c.relrowsecurity AS rowsecurity,
+             c.relforcerowsecurity AS forcerowsecurity
+      FROM pg_class c
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+      WHERE n.nspname = 'public'
+        AND c.relkind = 'r'
+        AND c.relname IN (
+          'documents', 'standard_clauses', 'clause_refs', 'doc_comments',
+          'decisions', 'tasks', 'acs', 'issues', 'doc_members', 'doc_assignees',
+          'tags', 'document_tags', 'memex_emission_keys', 'repos'
+        )
+      ORDER BY c.relname
+    `)) as unknown as Array<{
+      tablename: string;
+      rowsecurity: boolean;
+      forcerowsecurity: boolean;
+    }>;
+
+    const expected = [
+      "acs", "clause_refs", "decisions", "doc_assignees", "doc_comments",
+      "doc_members", "document_tags", "documents", "issues",
+      "memex_emission_keys", "repos", "standard_clauses", "tags", "tasks",
+    ];
+
+    expect(rows.length, "table count mismatch").toBe(expected.length);
+    const byTable = new Map(rows.map((r) => [r.tablename, r]));
+    for (const table of expected) {
+      const row = byTable.get(table);
+      expect(row, `${table}: not found in pg_class`).toBeDefined();
+      expect(row!.rowsecurity, `${table}: rowsecurity not enabled`).toBe(true);
+      expect(row!.forcerowsecurity, `${table}: forcerowsecurity not enabled`).toBe(true);
+    }
+  });
+
+  it("ac-16: all 14 tables have the memex_isolation policy covering ALL commands", async () => {
+    tagAc(AC_16);
+
+    const rows = (await db.execute(sql`
+      SELECT tablename, policyname, cmd
+      FROM pg_policies
+      WHERE schemaname = 'public'
+        AND tablename IN (
+          'documents', 'standard_clauses', 'clause_refs', 'doc_comments',
+          'decisions', 'tasks', 'acs', 'issues', 'doc_members', 'doc_assignees',
+          'tags', 'document_tags', 'memex_emission_keys', 'repos'
+        )
+        AND policyname = tablename || '_memex_isolation'
+      ORDER BY tablename
+    `)) as unknown as Array<{
+      tablename: string;
+      policyname: string;
+      cmd: string;
+    }>;
+
+    expect(rows.length, "policy count mismatch — some tables are missing their policy").toBe(14);
+    for (const row of rows) {
+      expect(row.cmd, `${row.tablename}: policy should cover ALL commands`).toBe("ALL");
+    }
+  });
+});

--- a/packages/server/src/db/spec-199-share-tokens-schema.test.ts
+++ b/packages/server/src/db/spec-199-share-tokens-schema.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from "vitest";
+import { sql } from "drizzle-orm";
+import { db } from "./connection.js";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+// spec-199 ac-8: share_tokens table has created_by_user_id and expires_at
+// after migration 0080 runs.
+//
+// created_by_user_id: nullable FK → users(id) ON DELETE SET NULL.
+//   Nullable for backwards compat with existing tokens that pre-date the
+//   migration. Powers the bulk-revoke in disableMembership (ac-10).
+//
+// expires_at: nullable timestamptz.
+//   No default here — the application stamps it at mint time using
+//   SHARE_TOKEN_TTL_DAYS. NULL = no expiry (preserves existing tokens).
+
+const AC_8 = "mindset-prod/memex-building-itself/specs/spec-199/acs/ac-8";
+
+describe("spec-199 ac-8: share_tokens schema post-migration-0080", () => {
+  it("ac-8: created_by_user_id column is nullable uuid with ON DELETE SET NULL FK to users", async () => {
+    tagAc(AC_8);
+
+    const cols = (await db.execute(sql`
+      SELECT column_name, data_type, is_nullable, column_default
+      FROM information_schema.columns
+      WHERE table_schema = 'public'
+        AND table_name = 'share_tokens'
+        AND column_name = 'created_by_user_id'
+    `)) as unknown as Array<{
+      column_name: string;
+      data_type: string;
+      is_nullable: string;
+      column_default: string | null;
+    }>;
+
+    expect(cols.length, "created_by_user_id column missing from share_tokens").toBe(1);
+    const col = cols[0]!;
+    expect(col.data_type).toBe("uuid");
+    expect(col.is_nullable).toBe("YES");
+    expect(col.column_default).toBeNull();
+  });
+
+  it("ac-8: created_by_user_id FK references users(id) ON DELETE SET NULL", async () => {
+    tagAc(AC_8);
+
+    const fks = (await db.execute(sql`
+      SELECT pg_get_constraintdef(c.oid) AS def
+      FROM pg_constraint c
+      WHERE c.conrelid = 'share_tokens'::regclass
+        AND c.contype = 'f'
+        AND c.conname LIKE '%created_by_user_id%'
+    `)) as unknown as Array<{ def: string }>;
+
+    expect(fks.length, "created_by_user_id FK constraint missing").toBe(1);
+    const def = fks[0]!.def;
+    expect(def).toContain("REFERENCES users");
+    expect(def).toContain("ON DELETE SET NULL");
+  });
+
+  it("ac-8: expires_at column is nullable timestamptz with no default", async () => {
+    tagAc(AC_8);
+
+    const cols = (await db.execute(sql`
+      SELECT column_name, data_type, is_nullable, column_default
+      FROM information_schema.columns
+      WHERE table_schema = 'public'
+        AND table_name = 'share_tokens'
+        AND column_name = 'expires_at'
+    `)) as unknown as Array<{
+      column_name: string;
+      data_type: string;
+      is_nullable: string;
+      column_default: string | null;
+    }>;
+
+    expect(cols.length, "expires_at column missing from share_tokens").toBe(1);
+    const col = cols[0]!;
+    expect(col.data_type).toBe("timestamp with time zone");
+    expect(col.is_nullable).toBe("YES");
+    expect(col.column_default).toBeNull();
+  });
+
+  it("ac-8: share_tokens_created_by_user_id_idx index exists", async () => {
+    tagAc(AC_8);
+
+    const idxs = (await db.execute(sql`
+      SELECT indexname
+      FROM pg_indexes
+      WHERE tablename = 'share_tokens'
+        AND indexname = 'share_tokens_created_by_user_id_idx'
+    `)) as unknown as Array<{ indexname: string }>;
+
+    expect(idxs.length, "share_tokens_created_by_user_id_idx missing").toBe(1);
+  });
+});

--- a/packages/server/src/middleware/permissions.test.ts
+++ b/packages/server/src/middleware/permissions.test.ts
@@ -96,7 +96,7 @@ describe("adminGate", () => {
     expect(body.availableMemexes).toEqual(memberships);
   });
 
-  it("returns 403 if caller is not administrator", async () => {
+  it("returns 404 if caller is not administrator (std-7 — no membership leak)", async () => {
     const app = buildApp("/x");
     app.use("*", async (c, next) => {
       c.set("currentMemexId", "mx-1");
@@ -106,7 +106,7 @@ describe("adminGate", () => {
     app.get("/x", adminGate, (c) => c.json({ ok: true }));
 
     const res = await app.request("/x");
-    expect(res.status).toBe(403);
+    expect(res.status).toBe(404);
   });
 
   it("passes through for administrator", async () => {

--- a/packages/server/src/middleware/permissions.ts
+++ b/packages/server/src/middleware/permissions.ts
@@ -37,7 +37,7 @@ export const adminGate = createMiddleware<SessionEnv>(async (c, next) => {
     }
     return c.json({ error: "Memex context required" }, 400);
   }
-  if (role !== "administrator") return c.json({ error: "Administrators only" }, 403);
+  if (role !== "administrator") return c.json({ error: "Not found" }, 404);
   return next();
 });
 

--- a/packages/server/src/middleware/session.ts
+++ b/packages/server/src/middleware/session.ts
@@ -1,6 +1,6 @@
 import { createMiddleware } from "hono/factory";
 import { eq, and, sql } from "drizzle-orm";
-import { db } from "../db/connection.js";
+import { db, runWithMemexId } from "../db/connection.js";
 import { memexes, namespaces, orgs, orgMemberships } from "../db/schema.js";
 import { getUserByEmail, getUserById, listMemberships, upsertUserByEmail } from "../services/users.js";
 import { ensureUserNamespace } from "../services/user-namespaces.js";
@@ -297,7 +297,7 @@ export const sessionMiddleware = createMiddleware<SessionEnv>(async (c, next) =>
 
   const short = await establishUserSession(c, resolution.user);
   if (short) return short;
-  return next();
+  return runWithMemexId(c.get("currentMemexId"), next);
 });
 
 /**
@@ -342,7 +342,7 @@ export const publicSessionMiddleware = createMiddleware<SessionEnv>(async (c, ne
     c.set("currentMemexId", null);
     c.set("currentRole", null);
     c.set("currentAccessLevel", null);
-    return next();
+    return runWithMemexId(c.get("memex")?.id ?? null, next);
   }
 
   // A valid token resolved a user. Establish the full session, but DON'T let a
@@ -393,7 +393,7 @@ export const publicSessionMiddleware = createMiddleware<SessionEnv>(async (c, ne
     }
   }
 
-  return next();
+  return runWithMemexId(c.get("memex")?.id ?? c.get("currentMemexId"), next);
 });
 
 export { getUserByEmail };

--- a/packages/server/src/middleware/session.ts
+++ b/packages/server/src/middleware/session.ts
@@ -30,6 +30,10 @@ export type SessionEnv = {
     // multiple memexes and the request didn't say which one (std-5).
     currentMemexId: string | null;
     currentRole: "member" | "administrator" | null;
+    // spec-199 t-5: "read" for visited/anonymous subscribers (user_memex_access
+    // rows), "write" for real org members. Only "write" may request include=all
+    // on SSE streams. Absent from the strict path until a membership is resolved.
+    currentAccessLevel: "read" | "write" | null;
     // Set by memexResolver when the request URL carries a /<namespace>/<memex>/
     // prefix. Routes that need a memex without one in the URL must either be
     // entity-keyed (UUID lookup) or accept the std-5 ambiguity error.
@@ -228,7 +232,7 @@ async function establishUserSession(
   //      return a structured error per std-5.
   const pathMemex = c.get("memex");
 
-  let chosen: { memexId: string; role: "member" | "administrator" } | null = null;
+  let chosen: { memexId: string; role: "member" | "administrator"; accessLevel: "read" | "write" } | null = null;
   if (pathMemex) {
     // Find the matching membership to capture role.
     const memberships = await listMemberships(user.id);
@@ -245,12 +249,12 @@ async function establishUserSession(
       // unresolved-by-membership and defers the visibility decision to the gate.
       return c.json({ error: "Not found" }, 404);
     }
-    chosen = { memexId: match.memexId, role: match.role };
+    chosen = { memexId: match.memexId, role: match.role, accessLevel: match.accessLevel ?? "write" };
   } else {
     const memberships = await listMemberships(user.id);
     if (memberships.length === 1) {
       const only = memberships[0];
-      chosen = { memexId: only.memexId, role: only.role };
+      chosen = { memexId: only.memexId, role: only.role, accessLevel: only.accessLevel ?? "write" };
     } else if (memberships.length > 1) {
       // b-38 F-6 — auto-resolve is ambiguous. Stamp the available memexes on
       // context so downstream routes can return a structured 409 (instead of
@@ -266,6 +270,7 @@ async function establishUserSession(
 
   c.set("currentMemexId", chosen?.memexId ?? null);
   c.set("currentRole", chosen?.role ?? null);
+  c.set("currentAccessLevel", chosen?.accessLevel ?? null);
   return null;
 }
 
@@ -336,6 +341,7 @@ export const publicSessionMiddleware = createMiddleware<SessionEnv>(async (c, ne
     c.set("currentUserId", null);
     c.set("currentMemexId", null);
     c.set("currentRole", null);
+    c.set("currentAccessLevel", null);
     return next();
   }
 
@@ -365,21 +371,25 @@ export const publicSessionMiddleware = createMiddleware<SessionEnv>(async (c, ne
     if (match) {
       c.set("currentMemexId", match.memexId);
       c.set("currentRole", match.role);
+      c.set("currentAccessLevel", match.accessLevel ?? "write");
     } else {
       // Token-bearing non-member on a path memex. Do NOT 404 here — defer to
       // canReadMemex (t-2/t-5), which grants read on public memexes and 404s on
       // private ones (std-7). Leave membership-derived context null.
       c.set("currentMemexId", null);
       c.set("currentRole", null);
+      c.set("currentAccessLevel", null);
     }
   } else {
     if (memberships.length === 1) {
       c.set("currentMemexId", memberships[0].memexId);
       c.set("currentRole", memberships[0].role);
+      c.set("currentAccessLevel", memberships[0].accessLevel ?? "write");
     } else {
       if (memberships.length > 1) c.set("availableMemexes", memberships);
       c.set("currentMemexId", null);
       c.set("currentRole", null);
+      c.set("currentAccessLevel", null);
     }
   }
 

--- a/packages/server/src/routes/__test__.ts
+++ b/packages/server/src/routes/__test__.ts
@@ -46,7 +46,10 @@ import { addTaskComment } from "../services/comments.js";
 import { createShareToken, listShareTokensForDoc } from "../services/share-tokens.js";
 import { addSection } from "../services/sections.js";
 import { resolveRole } from "../services/doc-members.js";
-import { listAssignees } from "../services/doc-assignees.js";
+import { listAssignees, assign } from "../services/doc-assignees.js";
+import { updateMemexVisibility } from "../services/memexes.js";
+import { disableMembership } from "../services/org-memberships.js";
+import { persistEvent } from "../services/activity-log.js";
 
 const contentBlockSchema = z.union([
   z.object({ type: z.literal("text"), text: z.string() }),
@@ -173,6 +176,7 @@ const seedSpecSchema = z.object({
   memexId: z.string().uuid(),
   title: z.string(),
   purpose: z.string().optional(),
+  createdByUserId: z.string().uuid().optional(),
 });
 testOnlyRouter.post("/seed-spec", async (c) => {
   const body = await c.req.json().catch(() => null);
@@ -180,8 +184,8 @@ testOnlyRouter.post("/seed-spec", async (c) => {
   if (!parsed.success) {
     return c.json({ error: "Invalid request", details: parsed.error.issues }, 400);
   }
-  const { memexId, title, purpose = "Seeded purpose." } = parsed.data;
-  const result = await createDocDraft(memexId, title, purpose, "spec");
+  const { memexId, title, purpose = "Seeded purpose.", createdByUserId } = parsed.data;
+  const result = await createDocDraft(memexId, title, purpose, "spec", undefined, undefined, createdByUserId);
   // The first (overview/purpose) section id — handy for journeys that mutate a
   // section over the API (e.g. the reactivity round-trips in journey-16).
   return c.json({ docId: result.id, handle: result.handle, sectionId: result.sections[0]?.id ?? null });
@@ -644,6 +648,7 @@ testOnlyRouter.get("/latest-share-token", async (c) => {
 const seedShareSchema = z.object({
   memexId: z.string().uuid(),
   docId: z.string().uuid(),
+  createdByUserId: z.string().uuid().nullable().optional(),
 });
 testOnlyRouter.post("/seed-share-token", async (c) => {
   const body = await c.req.json().catch(() => null);
@@ -651,7 +656,7 @@ testOnlyRouter.post("/seed-share-token", async (c) => {
   if (!parsed.success) {
     return c.json({ error: "Invalid request", details: parsed.error.issues }, 400);
   }
-  const token = await createShareToken(parsed.data.memexId, parsed.data.docId);
+  const token = await createShareToken(parsed.data.memexId, parsed.data.docId, parsed.data.createdByUserId ?? null);
   return c.json({ shareId: token.id, token: token.token });
 });
 
@@ -859,4 +864,109 @@ testOnlyRouter.post("/seed-task", async (c) => {
     await updateTaskStatus(memexId, task.id, status);
   }
   return c.json({ taskId: task.id, seq: task.seq });
+});
+
+// spec-199 t-9: security journey seeds ──────────────────────────────────────
+
+// Seed an assignee on a Spec through the real assign service (so the bus emits
+// and schema drift breaks the server build, per spec-172 dec-2).
+const seedAssigneeSchema = z.object({
+  memexId: z.string().uuid(),
+  docId: z.string().uuid(),
+  userId: z.string().uuid(),
+});
+testOnlyRouter.post("/seed-assignee", async (c) => {
+  const body = await c.req.json().catch(() => null);
+  const parsed = seedAssigneeSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: "Invalid request", details: parsed.error.issues }, 400);
+  }
+  const { memexId, docId, userId } = parsed.data;
+  const result = await assign(memexId, docId, userId, null);
+  return c.json({ assigneeId: result.id });
+});
+
+// Flip a Memex's visibility (public | private) through the real service.
+// Journeys that test the public-memex non-member path call this to make the
+// seeded memex reachable before asserting column redaction.
+const setMemexVisibilitySchema = z.object({
+  memexId: z.string().uuid(),
+  visibility: z.enum(["public", "private"]),
+});
+testOnlyRouter.post("/set-memex-visibility", async (c) => {
+  const body = await c.req.json().catch(() => null);
+  const parsed = setMemexVisibilitySchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: "Invalid request", details: parsed.error.issues }, 400);
+  }
+  await updateMemexVisibility(parsed.data.memexId, parsed.data.visibility);
+  return c.json({ ok: true });
+});
+
+// Seed an activity_log row through the real persistEvent service. Used by the
+// spec-199 non-member redaction journey to plant a row with actorUserId +
+// clientId + payload set before asserting the public endpoint strips those columns.
+const seedActivitySchema = z.object({
+  memexId: z.string().uuid(),
+  actorUserId: z.string().uuid().nullable().optional(),
+  clientId: z.string().optional(),
+  payload: z.record(z.string(), z.unknown()).optional(),
+  narrative: z.string().optional(),
+});
+testOnlyRouter.post("/seed-activity", async (c) => {
+  const body = await c.req.json().catch(() => null);
+  const parsed = seedActivitySchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: "Invalid request", details: parsed.error.issues }, 400);
+  }
+  const { memexId, actorUserId, clientId, payload, narrative } = parsed.data;
+  const row = await persistEvent({
+    memexId,
+    userId: actorUserId ?? undefined,
+    clientId: clientId ?? undefined,
+    channel: "rest_ui",
+    entity: "document",
+    action: "updated",
+    narrative: narrative ?? "seeded",
+    payload: payload ?? undefined,
+  });
+  if (!row) return c.json({ error: "Failed to insert activity row" }, 500);
+  return c.json({ activityId: row.id });
+});
+
+// Directly disable an org member and bulk-revoke their share tokens through the
+// real disableMembership service — bypasses sessionMiddleware/adminGate so the
+// test doesn't need to navigate auth. Caller must ensure a second admin exists
+// in the org (so the last-admin guard passes); tests that add dev as admin before
+// calling this satisfy that requirement automatically.
+const disableMemberSchema = z.object({
+  orgId: z.string().uuid(),
+  targetUserId: z.string().uuid(),
+});
+testOnlyRouter.post("/disable-member", async (c) => {
+  const body = await c.req.json().catch(() => null);
+  const parsed = disableMemberSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: "Invalid request", details: parsed.error.issues }, 400);
+  }
+  const { orgId, targetUserId } = parsed.data;
+  // Find any other active admin to act as requester (satisfies the self-remove
+  // guard without needing a real session).
+  const admins = await db
+    .select({ userId: orgMemberships.userId })
+    .from(orgMemberships)
+    .where(
+      and(
+        eq(orgMemberships.orgId, orgId),
+        eq(orgMemberships.status, "active"),
+        eq(orgMemberships.role, "administrator"),
+      ),
+    )
+    .limit(5);
+  const requester = admins.find((r) => r.userId !== targetUserId);
+  if (!requester) {
+    return c.json({ error: "No other admin found to act as requester" }, 400);
+  }
+  await disableMembership(targetUserId, orgId, requester.userId);
+  return c.json({ ok: true });
 });

--- a/packages/server/src/routes/activity.anonymous-projection.integration.test.ts
+++ b/packages/server/src/routes/activity.anonymous-projection.integration.test.ts
@@ -1,0 +1,145 @@
+// spec-199 t-6 — anonymous-path column projection for GET /activity.
+//
+// This file deliberately does NOT set GOOGLE_CLIENT_ID="". A non-empty
+// stub value means isDevMode() returns false so requests without an
+// Authorization header are truly anonymous (currentUserId null,
+// currentAccessLevel null) rather than auto-logged in as dev@memex.ai.
+
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+import { eq, inArray } from "drizzle-orm";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+vi.hoisted(() => {
+  process.env.GOOGLE_CLIENT_ID = "stub-non-empty-for-t6-anon-test";
+  return undefined;
+});
+
+import { db } from "../db/connection.js";
+import {
+  activityLog,
+  memexes,
+  namespaces,
+  orgs,
+  orgMemberships,
+} from "../db/schema.js";
+import type { ActivityLogInsert } from "../db/schema.js";
+import { app } from "../app.js";
+import { upsertUserByEmail } from "../services/users.js";
+
+function uniqueSlug(prefix: string): string {
+  return `${prefix}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`.toLowerCase();
+}
+
+function withApexHost(init: RequestInit = {}): RequestInit {
+  return { ...init, headers: { ...(init.headers ?? {}), Host: "memex.ai" } };
+}
+
+const insertedActivityIds: string[] = [];
+const createdMemexIds: string[] = [];
+const createdNamespaceIds: string[] = [];
+
+let publicMemexId: string;
+let publicPath: string;
+
+async function seedActivity(over: Partial<ActivityLogInsert> = {}): Promise<Record<string, unknown>> {
+  const [row] = await db
+    .insert(activityLog)
+    .values({
+      memexId: publicMemexId,
+      actorKind: over.actorKind ?? "human",
+      channel: over.channel ?? "rest_ui",
+      entity: over.entity ?? "document",
+      action: over.action ?? "updated",
+      narrative: over.narrative ?? "seeded",
+      actorUserId: over.actorUserId ?? null,
+      clientId: over.clientId ?? null,
+      payload: over.payload ?? null,
+    })
+    .returning();
+  insertedActivityIds.push(row.id);
+  return row as unknown as Record<string, unknown>;
+}
+
+beforeAll(async () => {
+  const dev = await upsertUserByEmail("dev@memex.ai");
+
+  const [ns] = await db
+    .insert(namespaces)
+    .values({ slug: uniqueSlug("anon-act"), kind: "org" })
+    .returning();
+  createdNamespaceIds.push(ns.id);
+
+  const [org] = await db
+    .insert(orgs)
+    .values({ namespaceId: ns.id, name: "Anon Activity Test", emailDomains: [] })
+    .returning();
+  await db.update(namespaces).set({ ownerOrgId: org.id }).where(eq(namespaces.id, ns.id));
+
+  const [memex] = await db
+    .insert(memexes)
+    .values({
+      namespaceId: ns.id,
+      slug: "main",
+      name: "Anon Activity Memex",
+      visibility: "public",
+    })
+    .returning();
+  createdMemexIds.push(memex.id);
+
+  publicMemexId = memex.id;
+  publicPath = `/api/${ns.slug}/main`;
+
+  await db
+    .insert(orgMemberships)
+    .values({ userId: dev.id, orgId: org.id, role: "administrator" })
+    .onConflictDoNothing();
+});
+
+afterAll(async () => {
+  if (insertedActivityIds.length) {
+    await db
+      .delete(activityLog)
+      .where(inArray(activityLog.id, insertedActivityIds))
+      .catch(() => {});
+  }
+  if (createdMemexIds.length) {
+    await db.delete(memexes).where(inArray(memexes.id, createdMemexIds)).catch(() => {});
+  }
+  if (createdNamespaceIds.length) {
+    await db.delete(namespaces).where(inArray(namespaces.id, createdNamespaceIds)).catch(() => {});
+  }
+});
+
+const AC_6 = "mindset-prod/memex-building-itself/specs/spec-199/acs/ac-6";
+
+// spec-199 t-6: anonymous caller on a public memex receives only the
+// whitelisted columns — payload, actorUserId, and clientId are stripped.
+describe("spec-199 t-6 — GET /activity anonymous column projection (ac-6)", () => {
+  it("anonymous caller receives no payload, actorUserId, or clientId on a public memex", async () => {
+    tagAc(AC_6);
+
+    // actorUserId is a nullable UUID FK — keep it null to avoid the FK constraint.
+    // clientId and payload are the load-bearing sensitive fields we're guarding.
+    await seedActivity({
+      clientId: "anon-test-client-id",
+      payload: { query: "sensitive search text" },
+      narrative: "searched something sensitive",
+    });
+
+    // No Authorization header + GOOGLE_CLIENT_ID non-empty → truly anonymous.
+    const res = await app.request(`${publicPath}/activity`, withApexHost());
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>[];
+    expect(body.length).toBeGreaterThan(0);
+
+    for (const row of body) {
+      expect(row, "payload must be absent from anonymous response").not.toHaveProperty("payload");
+      expect(row, "actorUserId must be absent from anonymous response").not.toHaveProperty("actorUserId");
+      expect(row, "clientId must be absent from anonymous response").not.toHaveProperty("clientId");
+      // Whitelisted columns must still be present.
+      expect(row).toHaveProperty("id");
+      expect(row).toHaveProperty("narrative");
+      expect(row).toHaveProperty("createdAt");
+    }
+  });
+});

--- a/packages/server/src/routes/activity.integration.test.ts
+++ b/packages/server/src/routes/activity.integration.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
 import { eq, inArray } from "drizzle-orm";
+import { tagAc } from "@memex-ai-ac/vitest";
 
 // Force dev-mode auth so app.request() can hit session-gated routes without
 // minting a JWT (same shape as aggregates.integration.test.ts).
@@ -30,6 +31,7 @@ type Row = {
   entity: string;
   action: string;
   narrative: string;
+  payload: unknown;
   createdAt: string;
 };
 
@@ -310,5 +312,28 @@ describe("GET /api/<ns>/<mx>/activity (Pulse history — b-60 t-12)", () => {
       withApexHost(),
     );
     expect(res.status).toBe(400);
+  });
+
+  // spec-199 t-6: authenticated org member receives all columns (no over-blocking).
+  it("authenticated org member receives all columns including actorUserId, clientId, payload", async () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-199/acs/ac-6");
+    // Seed a row with all sensitive fields populated.
+    const row = await seedActivity({
+      memexId: memexA,
+      actorUserId: alice,
+      clientId: "member-proj-test-client",
+      payload: { detail: "internal data" },
+      narrative: "member projection test",
+    });
+
+    const res = await app.request(`${pathA}/activity?limit=200`, withApexHost());
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Row[];
+    const found = body.find((r) => r.id === row.id);
+    expect(found).toBeDefined();
+    // Members must receive all three sensitive columns.
+    expect(found).toHaveProperty("actorUserId", alice);
+    expect(found).toHaveProperty("clientId", "member-proj-test-client");
+    expect(found).toHaveProperty("payload");
   });
 });

--- a/packages/server/src/routes/activity.ts
+++ b/packages/server/src/routes/activity.ts
@@ -100,6 +100,27 @@ activity.get("/", async (c) => {
     briefId,
   });
 
+  // spec-199 t-6: project only whitelisted columns on the anonymous/non-member
+  // path (currentAccessLevel !== "write" covers anonymous callers, visited users,
+  // and token-bearing non-members). The sensitive columns — actorUserId, clientId,
+  // payload — carry PII and free-form data that must not be publicly readable.
+  const accessLevel = c.get("currentAccessLevel");
+  if (accessLevel !== "write") {
+    return c.json(
+      rows.map((row) => ({
+        id: row.id,
+        memexId: row.memexId,
+        briefId: row.briefId,
+        actorKind: row.actorKind,
+        channel: row.channel,
+        entity: row.entity,
+        action: row.action,
+        narrative: row.narrative,
+        createdAt: row.createdAt,
+      })),
+    );
+  }
+
   return c.json(rows);
 });
 

--- a/packages/server/src/routes/backstage.integration.test.ts
+++ b/packages/server/src/routes/backstage.integration.test.ts
@@ -26,6 +26,8 @@ import { Hono } from "hono";
 import { backstageRouter } from "./backstage.js";
 import { errorHandler } from "../middleware/error-handler.js";
 import { upsertUserByEmail } from "../services/users.js";
+import { isDevMode } from "../middleware/session.js";
+import { tagAc } from "@memex-ai-ac/vitest";
 
 const createdAccountIds: string[] = [];
 const createdUserIds: string[] = [];
@@ -221,6 +223,24 @@ describe("POST /api/backstage/accounts/:id/impersonate", () => {
       expect(res.status).toBe(403);
     } finally {
       delete process.env.GOOGLE_CLIENT_ID;
+    }
+  });
+});
+
+describe("spec-199 Finding #2 — backstage fails closed in production when GOOGLE_CLIENT_ID is missing (ac-2)", () => {
+  it("isDevMode() throws when GOOGLE_CLIENT_ID is unset in NODE_ENV=production", () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-199/acs/ac-2");
+    const originalNodeEnv = process.env.NODE_ENV;
+    const savedClientId = process.env.GOOGLE_CLIENT_ID;
+    try {
+      process.env.NODE_ENV = "production";
+      delete process.env.GOOGLE_CLIENT_ID;
+        // isDevMode reads process.env at call time — static import is fine here.
+      expect(() => isDevMode()).toThrow(/GOOGLE_CLIENT_ID is required in production/);
+    } finally {
+      process.env.NODE_ENV = originalNodeEnv;
+      if (savedClientId !== undefined) process.env.GOOGLE_CLIENT_ID = savedClientId;
+      else delete process.env.GOOGLE_CLIENT_ID;
     }
   });
 });

--- a/packages/server/src/routes/backstage.ts
+++ b/packages/server/src/routes/backstage.ts
@@ -3,14 +3,11 @@ import { sql, desc, eq, and } from "drizzle-orm";
 import { db } from "../db/connection.js";
 import { memexes, namespaces, orgs, orgMemberships, documents } from "../db/schema.js";
 import { upsertUserByEmail } from "../services/users.js";
+import { isDevMode } from "../middleware/session.js";
 
 const DEV_USER_EMAIL = "dev@memex.ai";
 
 const backstageRouter = new Hono();
-
-function isDevMode(): boolean {
-  return !process.env.GOOGLE_CLIENT_ID;
-}
 
 // GET /api/backstage/accounts — returns every Memex with membership + doc counts so the
 // backstage list can show useful context at a glance. Personal Memexes (user-owned

--- a/packages/server/src/routes/doc-assignees.ts
+++ b/packages/server/src/routes/doc-assignees.ts
@@ -16,7 +16,9 @@ docAssigneesRouter.on(["POST", "PUT", "PATCH", "DELETE"], "/*", sessionMiddlewar
 docAssigneesRouter.get("/doc/:docId", async (c) => {
   const memexId = await resolveReadableMemexId(c);
   const docId = c.req.param("docId");
-  return c.json(await listAssignees(memexId, docId));
+  // currentMemexId is set only for confirmed org members; null for anonymous/non-members.
+  const isMember = !!(c.get("currentMemexId") as string | null);
+  return c.json(await listAssignees(memexId, docId, isMember));
 });
 
 // Assign a user to a Spec. `assigned_by` is the authenticated caller.

--- a/packages/server/src/routes/doc-events.api.test.ts
+++ b/packages/server/src/routes/doc-events.api.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, afterEach, vi } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
 
 // vi.mock() is hoisted above all imports — the factory must be self-contained, so we
 // re-create a passthrough middleware inline rather than importing one. This is the same
@@ -21,6 +22,9 @@ const TEST_MEMEX_ID = "00000000-0000-0000-0000-000000000001";
 const OTHER_ACCOUNT_ID = "00000000-0000-0000-0000-000000000099";
 const TEST_DOC_ID = "11111111-1111-1111-1111-111111111111";
 const OTHER_DOC_ID = "22222222-2222-2222-2222-222222222222";
+// Matches the default userId injected by makeTestAppWithTenant / tenantStubMiddleware.
+const TEST_USER_ID = "00000000-0000-0000-0000-000000000010";
+const OTHER_USER_ID = "00000000-0000-0000-0000-000000000020";
 
 function makeApp(memexId: string = TEST_MEMEX_ID) {
   const app = makeTestAppWithTenant({ memexId });
@@ -102,6 +106,26 @@ async function readSSEEvents(
 
   reader.cancel().catch(() => {});
   return events;
+}
+
+/** Reads the stream until it closes (done:true) or the timeout fires. */
+async function waitForStreamClose(res: Response, timeoutMs = 2000): Promise<void> {
+  const reader = res.body!.getReader();
+  const timeout = new Promise<never>((_, reject) =>
+    setTimeout(() => reject(new Error("stream did not close within timeout")), timeoutMs),
+  );
+  const waitClose = async () => {
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const { done } = await reader.read();
+      if (done) return;
+    }
+  };
+  try {
+    await Promise.race([waitClose(), timeout]);
+  } finally {
+    await reader.cancel().catch(() => {});
+  }
 }
 
 describe("GET /api/docs/events/:docId", () => {
@@ -484,5 +508,92 @@ describe("GET /api/docs/events/:docId (?include= action filter)", () => {
     const events = await readSSEEvents(res, 1);
     expect(events).toHaveLength(1);
     expect(JSON.parse(events[0]).action).toBe("updated");
+  });
+});
+
+const AC_199 = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-199/acs/ac-${n}`;
+
+// spec-199 t-4 — in-flight SSE streams are torn down when org membership is revoked.
+describe("spec-199 t-4 — SSE streams close on org_membership revocation (ac-4)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("per-doc stream closes when org_membership deleted fires for the connected user", async () => {
+    tagAc(AC_199(4));
+    stubDocLookup("owned");
+    const app = makeApp();
+    const res = await app.request(`/api/docs/events/${TEST_DOC_ID}`);
+    expect(res.status).toBe(200);
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    bus.emit({
+      memexId: TEST_MEMEX_ID,
+      userId: TEST_USER_ID,
+      entity: "org_membership",
+      action: "deleted",
+    });
+
+    await waitForStreamClose(res);
+    // If waitForStreamClose resolves without throwing, the stream closed cleanly.
+  });
+
+  it("global stream closes when org_membership deleted fires for the connected user", async () => {
+    tagAc(AC_199(4));
+    const app = makeApp();
+    const res = await app.request("/api/docs/events");
+    expect(res.status).toBe(200);
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    bus.emit({
+      memexId: TEST_MEMEX_ID,
+      userId: TEST_USER_ID,
+      entity: "org_membership",
+      action: "deleted",
+    });
+
+    await waitForStreamClose(res);
+  });
+
+  it("per-doc stream does not close when a DIFFERENT user's membership is revoked", async () => {
+    tagAc(AC_199(4));
+    stubDocLookup("owned");
+    const app = makeApp();
+    const res = await app.request(`/api/docs/events/${TEST_DOC_ID}`);
+    expect(res.status).toBe(200);
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    bus.emit({
+      memexId: TEST_MEMEX_ID,
+      userId: OTHER_USER_ID,
+      entity: "org_membership",
+      action: "deleted",
+    });
+
+    // Stream must stay open — waitForStreamClose should timeout.
+    // (waitForStreamClose's finally block handles reader cleanup.)
+    await expect(waitForStreamClose(res, 300)).rejects.toThrow("did not close");
+  });
+
+  it("global stream does not close when a DIFFERENT user's membership is revoked", async () => {
+    tagAc(AC_199(4));
+    const app = makeApp();
+    const res = await app.request("/api/docs/events");
+    expect(res.status).toBe(200);
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    bus.emit({
+      memexId: TEST_MEMEX_ID,
+      userId: OTHER_USER_ID,
+      entity: "org_membership",
+      action: "deleted",
+    });
+
+    await expect(waitForStreamClose(res, 300)).rejects.toThrow("did not close");
   });
 });

--- a/packages/server/src/routes/doc-events.api.test.ts
+++ b/packages/server/src/routes/doc-events.api.test.ts
@@ -26,8 +26,8 @@ const OTHER_DOC_ID = "22222222-2222-2222-2222-222222222222";
 const TEST_USER_ID = "00000000-0000-0000-0000-000000000010";
 const OTHER_USER_ID = "00000000-0000-0000-0000-000000000020";
 
-function makeApp(memexId: string = TEST_MEMEX_ID) {
-  const app = makeTestAppWithTenant({ memexId });
+function makeApp(memexId: string = TEST_MEMEX_ID, accessLevel?: "read" | "write") {
+  const app = makeTestAppWithTenant({ memexId, accessLevel });
   app.route("/api/docs", docEventsRouter);
   return app;
 }
@@ -595,5 +595,71 @@ describe("spec-199 t-4 — SSE streams close on org_membership revocation (ac-4)
     });
 
     await expect(waitForStreamClose(res, 300)).rejects.toThrow("did not close");
+  });
+});
+
+// spec-199 t-5 — `?include=all` is gated on write membership.
+//
+// Integration chain:
+//   (a) users.visited-public.integration.test.ts already proves that
+//       listMemberships() returns accessLevel:"read" for a visited user.
+//   (b) These tests (below) prove the gate: a read-access subscriber that
+//       requests include=all is pinned to mutations, not the full stream.
+//   Together (a)+(b) cover: visited → listMemberships → session → gate.
+describe("spec-199 t-5 — ?include=all gated on write membership (ac-5)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("read-access subscriber with ?include=all receives only mutations (global stream)", async () => {
+    tagAc(AC_199(5));
+    const app = makeApp(TEST_MEMEX_ID, "read");
+    const res = await app.request("/api/docs/events?include=all");
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Emit a read event FIRST — it must be dropped so the first delivered
+    // event is the subsequent mutation.
+    bus.emit({ memexId: TEST_MEMEX_ID, docId: "read-doc", entity: "document", action: "viewed" });
+    bus.emit({ memexId: TEST_MEMEX_ID, docId: "mut-doc", entity: "section", action: "updated" });
+
+    const events = await readSSEEvents(res, 1);
+    expect(events).toHaveLength(1);
+    const parsed = JSON.parse(events[0]);
+    expect(parsed.action).toBe("updated");
+    expect(parsed.docId).toBe("mut-doc");
+  });
+
+  it("read-access subscriber with ?include=all receives only mutations (per-doc stream)", async () => {
+    tagAc(AC_199(5));
+    stubDocLookup("owned");
+    const app = makeApp(TEST_MEMEX_ID, "read");
+    const res = await app.request(`/api/docs/events/${TEST_DOC_ID}?include=all`);
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    bus.emit({ memexId: TEST_MEMEX_ID, docId: TEST_DOC_ID, entity: "document", action: "viewed" });
+    bus.emit({ memexId: TEST_MEMEX_ID, docId: TEST_DOC_ID, entity: "section", action: "updated" });
+
+    const events = await readSSEEvents(res, 1);
+    expect(events).toHaveLength(1);
+    expect(JSON.parse(events[0]).action).toBe("updated");
+  });
+
+  it("write-access subscriber with ?include=all receives reads AND mutations (global stream)", async () => {
+    tagAc(AC_199(5));
+    // Default makeApp has accessLevel:"write" — the gate must not over-block.
+    const app = makeApp(TEST_MEMEX_ID);
+    const res = await app.request("/api/docs/events?include=all");
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    bus.emit({ memexId: TEST_MEMEX_ID, docId: "read-doc", entity: "document", action: "viewed" });
+    bus.emit({ memexId: TEST_MEMEX_ID, docId: "mut-doc", entity: "section", action: "updated" });
+
+    const events = await readSSEEvents(res, 2);
+    expect(events).toHaveLength(2);
+    const actions = events.map((e) => JSON.parse(e).action);
+    expect(actions).toEqual(["viewed", "updated"]);
   });
 });

--- a/packages/server/src/routes/doc-events.ts
+++ b/packages/server/src/routes/doc-events.ts
@@ -25,14 +25,19 @@ const MUTATION_ACTIONS: readonly ChangeAction[] = ["created", "updated", "delete
  *   absent | "mutations" (DEFAULT) → mutation allowlist (created/updated/deleted),
  *                                     preserving today's behaviour for every
  *                                     existing consumer.
- *   "all"                          → undefined (no action filter — every action,
+ *   "all" + write access           → undefined (no action filter — every action,
  *                                     including reads, is delivered). Pulse uses this.
+ *   "all" + read/null/unknown      → mutation allowlist (spec-199 t-5 gate).
  *   unknown value                  → mutation allowlist (safe default).
  */
-function resolveIncludeActions(include: string | undefined): readonly ChangeAction[] | undefined {
-  if (include === "all") return undefined;
-  // "mutations", absent, or any unrecognised value all fall through to the
-  // mutation allowlist — default-closed for reads.
+function resolveIncludeActions(
+  include: string | undefined,
+  accessLevel: "read" | "write" | null | undefined,
+): readonly ChangeAction[] | undefined {
+  // spec-199 t-5: full stream is only available to write-access subscribers.
+  if (include === "all" && accessLevel === "write") return undefined;
+  // "mutations", absent, read-access with "all", or any unrecognised value all
+  // fall through to the mutation allowlist — default-closed for reads.
   return MUTATION_ACTIONS;
 }
 
@@ -61,7 +66,7 @@ docEventsRouter.use("/events/*", sessionMiddleware);
 docEventsRouter.get("/events/:docId", async (c) => {
   const memexId = requireMemexId(c);
   const docId = c.req.param("docId");
-  const actions = resolveIncludeActions(c.req.query("include"));
+  const actions = resolveIncludeActions(c.req.query("include"), c.get("currentAccessLevel"));
   const user = c.get("user");
 
   // Verify the doc belongs to the requesting tenant before opening the stream.
@@ -128,7 +133,7 @@ docEventsRouter.get("/events/:docId", async (c) => {
 
 docEventsRouter.get("/events", (c) => {
   const memexId = requireMemexId(c);
-  const actions = resolveIncludeActions(c.req.query("include"));
+  const actions = resolveIncludeActions(c.req.query("include"), c.get("currentAccessLevel"));
   const user = c.get("user");
 
   return streamSSE(c, async (stream) => {

--- a/packages/server/src/routes/doc-events.ts
+++ b/packages/server/src/routes/doc-events.ts
@@ -62,6 +62,7 @@ docEventsRouter.get("/events/:docId", async (c) => {
   const memexId = requireMemexId(c);
   const docId = c.req.param("docId");
   const actions = resolveIncludeActions(c.req.query("include"));
+  const user = c.get("user");
 
   // Verify the doc belongs to the requesting tenant before opening the stream.
   // Without this check a session user could subscribe to any docId by guessing
@@ -74,6 +75,11 @@ docEventsRouter.get("/events/:docId", async (c) => {
   }
 
   return streamSSE(c, async (stream) => {
+    // Resolvable promise: holds the stream open. Resolves when the user's
+    // membership is revoked (spec-199 t-4) or the client disconnects.
+    let close!: () => void;
+    const done = new Promise<void>((resolve) => { close = resolve; });
+
     const handler = (event: ChangeEvent) => {
       stream.writeSSE({
         event: "doc_change",
@@ -84,7 +90,13 @@ docEventsRouter.get("/events/:docId", async (c) => {
     // Filter by (memexId, docId) at the bus level — the bus subscribe filter
     // takes care of cross-tenant isolation and per-doc scoping in one place.
     // `actions` narrows by the resolved `?include=` allowlist (undefined = all).
-    const unsubscribe = bus.subscribe({ memexId, docId, actions }, handler);
+    const unsubDoc = bus.subscribe({ memexId, docId, actions }, handler);
+
+    // spec-199 t-4: close stream when the connected user's membership is revoked.
+    const unsubRevoke = bus.subscribe(
+      { userId: user.id, entity: "org_membership", actions: ["deleted"] as const },
+      () => close(),
+    );
 
     // t-19 W5: emit a `ready` event the instant the listener is attached so test
     // clients (and a future production client that wants exactly-once-since-
@@ -98,24 +110,33 @@ docEventsRouter.get("/events/:docId", async (c) => {
       stream.writeSSE({ event: "keepalive", data: "" });
     }, 30_000);
 
-    // Clean up on disconnect — both the keepalive and the bus subscription
-    // must be torn down or the bus accumulates orphan listeners across the
-    // lifetime of the process.
+    // Clean up on disconnect — keepalive, doc-change subscription, and revoke
+    // subscription must all be torn down to avoid orphan listeners.
     stream.onAbort(() => {
       clearInterval(keepalive);
-      unsubscribe();
+      unsubDoc();
+      unsubRevoke();
+      close(); // Resolve done so the callback exits cleanly on client disconnect
     });
 
-    // Hold connection open until aborted
-    await new Promise(() => {});
+    await done;
+    clearInterval(keepalive);
+    unsubDoc();
+    unsubRevoke();
   });
 });
 
 docEventsRouter.get("/events", (c) => {
   const memexId = requireMemexId(c);
   const actions = resolveIncludeActions(c.req.query("include"));
+  const user = c.get("user");
 
   return streamSSE(c, async (stream) => {
+    // Resolvable promise: holds the stream open. Resolves when the user's
+    // membership is revoked (spec-199 t-4) or the client disconnects.
+    let close!: () => void;
+    const done = new Promise<void>((resolve) => { close = resolve; });
+
     const handler = (event: ChangeEvent) => {
       // Cross-tenant filter is enforced by the bus subscribe filter below,
       // but the per-Memex stream is intentionally fan-out across all docs in
@@ -127,7 +148,13 @@ docEventsRouter.get("/events", (c) => {
     };
 
     // `actions` narrows by the resolved `?include=` allowlist (undefined = all).
-    const unsubscribe = bus.subscribe({ memexId, actions }, handler);
+    const unsubDoc = bus.subscribe({ memexId, actions }, handler);
+
+    // spec-199 t-4: close stream when the connected user's membership is revoked.
+    const unsubRevoke = bus.subscribe(
+      { userId: user.id, entity: "org_membership", actions: ["deleted"] as const },
+      () => close(),
+    );
 
     // t-19 W5: see per-doc handler above. Same `ready` handshake on the global
     // stream so test clients (and any future production listener that wants
@@ -140,9 +167,14 @@ docEventsRouter.get("/events", (c) => {
 
     stream.onAbort(() => {
       clearInterval(keepalive);
-      unsubscribe();
+      unsubDoc();
+      unsubRevoke();
+      close(); // Resolve done so the callback exits cleanly on client disconnect
     });
 
-    await new Promise(() => {});
+    await done;
+    clearInterval(keepalive);
+    unsubDoc();
+    unsubRevoke();
   });
 });

--- a/packages/server/src/routes/doc-members.ts
+++ b/packages/server/src/routes/doc-members.ts
@@ -26,8 +26,10 @@ docMembersRouter.get("/doc/:docId", async (c) => {
   const memexId = await resolveReadableMemexId(c);
   const docId = c.req.param("docId");
   const userId = (c.get("currentUserId") as string | null) ?? null;
+  // currentMemexId is set only for confirmed org members; null for anonymous/non-members.
+  const isMember = !!(c.get("currentMemexId") as string | null);
   const [editors, myRole] = await Promise.all([
-    listEditors(memexId, docId),
+    listEditors(memexId, docId, isMember),
     resolveRole(memexId, docId, userId),
   ]);
   return c.json({ editors, myRole });

--- a/packages/server/src/routes/documents.ts
+++ b/packages/server/src/routes/documents.ts
@@ -378,7 +378,8 @@ docs.post("/sections/:sectionId", async (c) => {
 docs.post("/:docId/share", async (c) => {
   const memexId = requireMemexId(c);
   const docId = c.req.param("docId");
-  const share = await createShareToken(memexId, docId);
+  const createdByUserId = (c.get("currentUserId") as string | null) ?? null;
+  const share = await createShareToken(memexId, docId, createdByUserId);
   return c.json(share, 201);
 });
 

--- a/packages/server/src/routes/me-events.api.test.ts
+++ b/packages/server/src/routes/me-events.api.test.ts
@@ -5,6 +5,7 @@
 // userId) are filtered out.
 
 import { describe, it, expect, afterEach, vi } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
 
 vi.mock("../middleware/session.js", async () => {
   const { createMiddleware } = await import("hono/factory");
@@ -157,5 +158,141 @@ describe("GET /api/me/events", () => {
     expect(events).toHaveLength(1);
     const parsed = JSON.parse(events[0]);
     expect(parsed.entity).toBe("mcp_token");
+  });
+});
+
+/** Reads all user_change events until the stream closes or the timeout fires. */
+async function drainSSEUntilClose(res: Response, timeoutMs = 2000): Promise<string[]> {
+  const reader = res.body!.getReader();
+  const decoder = new TextDecoder();
+  const events: string[] = [];
+  let buffer = "";
+  const timeout = new Promise<never>((_, reject) =>
+    setTimeout(() => reject(new Error("stream did not close within timeout")), timeoutMs),
+  );
+  const drain = async () => {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) return;
+      buffer += decoder.decode(value, { stream: true });
+      const parts = buffer.split("\n\n");
+      buffer = parts.pop() ?? "";
+      for (const part of parts) {
+        if (!part.trim()) continue;
+        let eventType = "", data = "";
+        for (const line of part.split("\n")) {
+          if (line.startsWith("event:")) eventType = line.slice(6).trim();
+          if (line.startsWith("data:")) data = line.slice(5).trim();
+        }
+        if (eventType === "user_change" && data) events.push(data);
+      }
+    }
+  };
+  try {
+    await Promise.race([drain(), timeout]);
+  } finally {
+    await reader.cancel().catch(() => {});
+  }
+  return events;
+}
+
+/** Reads the stream until it closes (done:true) or the timeout fires. */
+async function waitForStreamClose(res: Response, timeoutMs = 2000): Promise<void> {
+  const reader = res.body!.getReader();
+  const timeout = new Promise<never>((_, reject) =>
+    setTimeout(() => reject(new Error("stream did not close within timeout")), timeoutMs),
+  );
+  const waitClose = async () => {
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const { done } = await reader.read();
+      if (done) return;
+    }
+  };
+  try {
+    await Promise.race([waitClose(), timeout]);
+  } finally {
+    await reader.cancel().catch(() => {});
+  }
+}
+
+const AC_199 = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-199/acs/ac-${n}`;
+
+// spec-199 t-4 — /api/me/events stream closes when the user's org membership is revoked.
+describe("spec-199 t-4 — me/events stream closes on org_membership revocation (ac-4)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("stream closes when org_membership deleted fires for the connected user", async () => {
+    tagAc(AC_199(4));
+    const app = makeApp();
+    const res = await app.request("/api/me/events");
+    expect(res.status).toBe(200);
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    bus.emit({
+      memexId: "",
+      userId: TEST_USER_ID,
+      entity: "org_membership",
+      action: "deleted",
+    });
+
+    await waitForStreamClose(res);
+  });
+
+  it("stream closes in include=all mode when org_membership deleted fires", async () => {
+    tagAc(AC_199(4));
+    const app = makeApp();
+    const res = await app.request("/api/me/events?include=all");
+    expect(res.status).toBe(200);
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    bus.emit({
+      memexId: "",
+      userId: TEST_USER_ID,
+      entity: "org_membership",
+      action: "deleted",
+    });
+
+    await waitForStreamClose(res);
+  });
+
+  it("stream does not close when a DIFFERENT user's membership is revoked", async () => {
+    tagAc(AC_199(4));
+    const app = makeApp();
+    const res = await app.request("/api/me/events");
+    expect(res.status).toBe(200);
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    bus.emit({
+      memexId: "",
+      userId: OTHER_USER_ID,
+      entity: "org_membership",
+      action: "deleted",
+    });
+
+    // Stream must stay open — waitForStreamClose should timeout.
+    // (waitForStreamClose's finally block handles reader cleanup.)
+    await expect(waitForStreamClose(res, 300)).rejects.toThrow("did not close");
+  });
+
+  it("org_membership deleted event is NOT forwarded to the client (silent close)", async () => {
+    tagAc(AC_199(4));
+    const app = makeApp();
+    const res = await app.request("/api/me/events");
+    expect(res.status).toBe(200);
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Emit the revocation; the stream should close without forwarding any user_change event.
+    bus.emit({ memexId: "", userId: TEST_USER_ID, entity: "org_membership", action: "deleted" });
+
+    const events = await drainSSEUntilClose(res);
+    expect(events).toHaveLength(0);
   });
 });

--- a/packages/server/src/routes/me.ts
+++ b/packages/server/src/routes/me.ts
@@ -46,7 +46,18 @@ meRouter.get("/events", (c) => {
   const user = c.get("user");
 
   return streamSSE(c, async (stream) => {
+    // Resolvable promise: holds the stream open. Resolves when the user's
+    // membership is revoked (spec-199 t-4) or the client disconnects.
+    let close!: () => void;
+    const done = new Promise<void>((resolve) => { close = resolve; });
+
     const handler = (event: ChangeEvent) => {
+      // spec-199 t-4: close stream silently on membership revocation — do not
+      // forward the event to the client (clean disconnect, no error sent).
+      if (event.entity === "org_membership" && event.action === "deleted") {
+        close();
+        return;
+      }
       stream.writeSSE({
         event: "user_change",
         data: JSON.stringify(event),
@@ -79,9 +90,12 @@ meRouter.get("/events", (c) => {
     stream.onAbort(() => {
       clearInterval(keepalive);
       unsubscribe();
+      close(); // Resolve done so the callback exits cleanly on client disconnect
     });
 
-    await new Promise(() => {});
+    await done;
+    clearInterval(keepalive);
+    unsubscribe();
   });
 });
 

--- a/packages/server/src/routes/route-test-helpers.ts
+++ b/packages/server/src/routes/route-test-helpers.ts
@@ -18,6 +18,7 @@ export interface TestTenantContext {
   userId?: string;
   userEmail?: string;
   role?: "user" | "administrator";
+  accessLevel?: "read" | "write";
 }
 
 // Injects stubbed `user`, `currentMemexId`, `currentRole` into the Hono context.
@@ -28,6 +29,7 @@ export function tenantStubMiddleware(ctx: TestTenantContext = {}) {
   const userId = ctx.userId ?? "00000000-0000-0000-0000-000000000010";
   const email = ctx.userEmail ?? "test@example.com";
   const role = ctx.role ?? "administrator";
+  const accessLevel = ctx.accessLevel ?? "write";
   return createMiddleware(async (c, next) => {
     c.set("user", {
       id: userId,
@@ -38,6 +40,7 @@ export function tenantStubMiddleware(ctx: TestTenantContext = {}) {
     });
     c.set("currentMemexId", memexId);
     c.set("currentRole", role);
+    c.set("currentAccessLevel", accessLevel);
     return next();
   });
 }

--- a/packages/server/src/routes/sse-cleanup.integration.test.ts
+++ b/packages/server/src/routes/sse-cleanup.integration.test.ts
@@ -64,8 +64,10 @@ describe("SSE handler tears down bus subscriptions on abort", () => {
     }
 
     // Give the streamSSE handler a tick to register its bus.subscribe call.
+    // Each connection opens 2 subscriptions: one for doc changes, one for the
+    // org_membership revoke signal added in spec-199 t-4.
     await new Promise((r) => setTimeout(r, 50));
-    expect(bus._listenerCount()).toBe(baseline + N);
+    expect(bus._listenerCount()).toBe(baseline + N * 2);
 
     // Cancel each response body — this triggers stream.onAbort which calls the
     // unsubscribe returned by bus.subscribe.
@@ -88,8 +90,9 @@ describe("SSE handler tears down bus subscriptions on abort", () => {
       responses.push(await app.request("/api/docs/events"));
     }
 
+    // Each connection opens 2 subscriptions (memex stream + org_membership revoke).
     await new Promise((r) => setTimeout(r, 50));
-    expect(bus._listenerCount()).toBe(baseline + N);
+    expect(bus._listenerCount()).toBe(baseline + N * 2);
 
     for (const res of responses) {
       await res.body!.cancel();

--- a/packages/server/src/services/doc-assignees.integration.test.ts
+++ b/packages/server/src/services/doc-assignees.integration.test.ts
@@ -103,3 +103,33 @@ describe("spec-118 assignment emits on the unified bus (ac-20)", () => {
     expect(mine.map((e) => e.action)).toEqual(["created", "deleted"]);
   });
 });
+
+const AC_199 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-199/acs/ac-${n}`;
+
+describe("spec-199 Finding #1 — email stripped from non-member/anonymous path (ac-1)", () => {
+  it("listAssignees with includeEmail=false returns null email for every assignee", async () => {
+    tagAc(AC_199(1));
+    const doc = await createDocDraft(memexId, "Assignee Email Strip Test", "purpose", "spec");
+    createdDocIds.push(doc.id);
+    await assign(memexId, doc.id, alice.id, actor.id);
+
+    const assignees = await listAssignees(memexId, doc.id, false);
+    expect(assignees.length).toBeGreaterThan(0);
+    for (const a of assignees) {
+      expect(a.email, "email must be null on the anonymous/non-member path").toBeNull();
+    }
+  });
+
+  it("listAssignees with includeEmail=true (default) returns email for authenticated org members", async () => {
+    tagAc(AC_199(1));
+    const doc = await createDocDraft(memexId, "Assignee Email Present Test", "purpose", "spec");
+    createdDocIds.push(doc.id);
+    await assign(memexId, doc.id, alice.id, actor.id);
+
+    const assignees = await listAssignees(memexId, doc.id, true);
+    expect(assignees.length).toBeGreaterThan(0);
+    for (const a of assignees) {
+      expect(a.email, "email must be present for authenticated org members").not.toBeNull();
+    }
+  });
+});

--- a/packages/server/src/services/doc-assignees.ts
+++ b/packages/server/src/services/doc-assignees.ts
@@ -44,7 +44,12 @@ export interface DocAssigneeView {
 
 // The current assignees of a Spec, joined to users for display. Ordered by
 // assigned_at so the board renders the longest-standing assignee first.
-export async function listAssignees(memexId: string, docId: string): Promise<DocAssigneeView[]> {
+// includeEmail must be false for anonymous/non-member callers (Finding #1, spec-199).
+export async function listAssignees(
+  memexId: string,
+  docId: string,
+  includeEmail = true,
+): Promise<DocAssigneeView[]> {
   const rows = await db
     .select({
       userId: docAssignees.userId,
@@ -56,7 +61,7 @@ export async function listAssignees(memexId: string, docId: string): Promise<Doc
     .innerJoin(users, eq(users.id, docAssignees.userId))
     .where(and(eq(docAssignees.memexId, memexId), eq(docAssignees.docId, docId)))
     .orderBy(docAssignees.assignedAt);
-  return rows;
+  return rows.map((r) => ({ ...r, email: includeEmail ? r.email : null }));
 }
 
 // Batch roll-up of assignees for many Specs at once — backs the board list

--- a/packages/server/src/services/doc-members.integration.test.ts
+++ b/packages/server/src/services/doc-members.integration.test.ts
@@ -182,3 +182,31 @@ describe("spec-118 promote / demote (frictionless, reversible, no last-editor lo
     expect(await resolveRole(memexId, doc.id, human.id)).toBe("reviewer");
   });
 });
+
+const AC_199 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-199/acs/ac-${n}`;
+
+describe("spec-199 Finding #1 — email stripped from non-member/anonymous path (ac-1)", () => {
+  it("listEditors with includeEmail=false returns null email for every editor", async () => {
+    tagAc(AC_199(1));
+    const doc = await createDocDraft(memexId, "Email Strip Test", "purpose", "spec", undefined, undefined, human.id);
+    createdDocIds.push(doc.id);
+
+    const editors = await listEditors(memexId, doc.id, false);
+    expect(editors.length).toBeGreaterThan(0);
+    for (const e of editors) {
+      expect(e.email, "email must be null on the anonymous/non-member path").toBeNull();
+    }
+  });
+
+  it("listEditors with includeEmail=true (default) returns email for authenticated org members", async () => {
+    tagAc(AC_199(1));
+    const doc = await createDocDraft(memexId, "Email Present Test", "purpose", "spec", undefined, undefined, human.id);
+    createdDocIds.push(doc.id);
+
+    const editors = await listEditors(memexId, doc.id, true);
+    expect(editors.length).toBeGreaterThan(0);
+    for (const e of editors) {
+      expect(e.email, "email must be present for authenticated org members").not.toBeNull();
+    }
+  });
+});

--- a/packages/server/src/services/doc-members.ts
+++ b/packages/server/src/services/doc-members.ts
@@ -76,7 +76,12 @@ export interface DocMemberView {
 
 // The explicit (elevated) members of a Spec — the editors. Reviewers are implicit
 // and never listed here (they have no row). Joined to users for display.
-export async function listEditors(memexId: string, docId: string): Promise<DocMemberView[]> {
+// includeEmail must be false for anonymous/non-member callers (Finding #1, spec-199).
+export async function listEditors(
+  memexId: string,
+  docId: string,
+  includeEmail = true,
+): Promise<DocMemberView[]> {
   const rows = await db
     .select({
       userId: docMembers.userId,
@@ -90,7 +95,7 @@ export async function listEditors(memexId: string, docId: string): Promise<DocMe
   return rows.map((r) => ({
     userId: r.userId,
     name: r.name,
-    email: r.email,
+    email: includeEmail ? r.email : null,
     role: isDocRole(r.role) ? r.role : "editor",
   }));
 }

--- a/packages/server/src/services/memex-search.integration.test.ts
+++ b/packages/server/src/services/memex-search.integration.test.ts
@@ -713,6 +713,50 @@ describe("searchMemex — cross-tenant isolation", () => {
       expect(h.path.startsWith(otherPrefix)).toBe(false);
     }
   });
+
+  // spec-199 t-8: the two existing cross-tenant tests both run with
+  // disableVector: true — this test executes the runSectionVector
+  // WHERE d.memex_id predicate that was previously untouched by tests.
+  // makeOrthogonalProvider gives deterministic distances: content containing
+  // "floornearmatch" embeds onto dim 0 (distance 0.0 to the query, well below
+  // the 0.65 floor) so the vector arm reliably returns it; other content lands
+  // on dim 1 (distance 1.0, filtered by the floor).
+  it("vector arm does not leak cross-tenant content", async () => {
+    const provider = makeOrthogonalProvider("fake-cross-tenant-vector-1536");
+
+    // Identical-topic content in both memexes — if the WHERE clause were absent
+    // the vector arm would surface otherMemexId's hit.
+    const inTenant = await seedStandard(
+      memexId,
+      "In-tenant vector isolation check",
+      [{ sectionType: "do", content: "floornearmatch veccrosstenantisolationx" }],
+      provider,
+    );
+    await seedStandard(
+      otherMemexId,
+      "Cross-tenant vector candidate",
+      [{ sectionType: "do", content: "floornearmatch veccrosstenantisolationx" }],
+      provider,
+    );
+
+    const otherRow = (await db.execute(sql`
+      SELECT n.slug AS namespace_slug, m.slug AS memex_slug
+      FROM memexes m INNER JOIN namespaces n ON n.id = m.namespace_id
+      WHERE m.id = ${otherMemexId}
+      LIMIT 1
+    `)) as unknown as Array<{ namespace_slug: string; memex_slug: string }>;
+    const otherPrefix = `${otherRow[0].namespace_slug}/${otherRow[0].memex_slug}/`;
+
+    // No disableVector — exercises runSectionVector's WHERE d.memex_id = ${memexId}.
+    const hits = await searchMemex(memexId, "floornearmatch", { provider });
+
+    // In-tenant content IS surfaced by the vector arm.
+    expect(hits.find((h) => h.id === inTenant.id)).toBeDefined();
+    // Cross-tenant content never leaks regardless of vector similarity.
+    for (const h of hits) {
+      expect(h.path.startsWith(otherPrefix)).toBe(false);
+    }
+  });
 });
 
 describe("searchMemex — defaults + edges", () => {

--- a/packages/server/src/services/org-memberships.integration.test.ts
+++ b/packages/server/src/services/org-memberships.integration.test.ts
@@ -1,13 +1,17 @@
 import { describe, it, expect, afterAll } from "vitest";
 import { eq, inArray } from "drizzle-orm";
 import { db } from "../db/connection.js";
-import { memexes, namespaces, orgs, orgMemberships, verifiedDomains, users } from "../db/schema.js";
+import { memexes, namespaces, orgs, orgMemberships, verifiedDomains, users, shareTokens } from "../db/schema.js";
 import { upsertUserByEmail } from "./users.js";
 import {
   joinByDomain,
   listDiscoverableOrgs,
   joinOrgByDomain,
 } from "./org-discovery.js";
+import { disableMembership } from "./org-memberships.js";
+import { createDocDraft } from "./documents.js";
+import { createShareToken, getSharedDocumentByToken, ShareTokenError } from "./share-tokens.js";
+import { tagAc } from "@memex-ai-ac/vitest";
 import { NotFoundError, ValidationError } from "../types/errors.js";
 
 const createdUserIds: string[] = [];
@@ -364,5 +368,88 @@ describe("joinOrgByDomain", () => {
       where: eq(orgMemberships.userId, user.id),
     });
     expect(rows).toHaveLength(1);
+  });
+});
+
+const AC_199 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-199/acs/ac-${n}`;
+
+async function makeOrgWithMemex(): Promise<{ orgId: string; memexId: string }> {
+  const sub = uniqueSubdomain("revoke");
+  const [ns] = await db.insert(namespaces).values({ slug: sub, kind: "org" }).returning();
+  const [org] = await db.insert(orgs).values({ namespaceId: ns.id, name: "Revoke Org" }).returning();
+  await db.update(namespaces).set({ ownerOrgId: org.id }).where(eq(namespaces.id, ns.id));
+  const [memex] = await db.insert(memexes).values({ namespaceId: ns.id, slug: "main", name: "Revoke Memex" }).returning();
+  createdAccountIds.push(memex.id);
+  return { orgId: org.id, memexId: memex.id };
+}
+
+describe("spec-199 t-3 — disableMembership bulk-revokes share tokens (ac-10, ac-11)", () => {
+  it("revoking a member revokes all their share tokens in the org in the same transaction (ac-10)", async () => {
+    tagAc(AC_199(10));
+    const { orgId, memexId } = await makeOrgWithMemex();
+
+    const requester = await upsertUserByEmail(`requester-${Date.now()}@revoke.test`);
+    const target = await upsertUserByEmail(`target-${Date.now()}@revoke.test`);
+    createdUserIds.push(requester.id, target.id);
+
+    await db.insert(orgMemberships).values([
+      { userId: requester.id, orgId, role: "administrator", status: "active" },
+      { userId: target.id, orgId, role: "member", status: "active" },
+    ]);
+
+    const doc = await createDocDraft(memexId, "Shared Doc", "purpose");
+    const token = await createShareToken(memexId, doc.id, target.id);
+    expect(token.revoked).toBe(false);
+
+    await disableMembership(target.id, orgId, requester.id);
+
+    const row = await db.query.shareTokens.findFirst({ where: eq(shareTokens.id, token.id) });
+    expect(row?.revoked, "share token must be revoked after member removal").toBe(true);
+  });
+
+  it("revoked token returns ShareTokenError reason='revoked' after member removal (ac-11)", async () => {
+    tagAc(AC_199(11));
+    const { orgId, memexId } = await makeOrgWithMemex();
+
+    const requester = await upsertUserByEmail(`req2-${Date.now()}@revoke.test`);
+    const target = await upsertUserByEmail(`tgt2-${Date.now()}@revoke.test`);
+    createdUserIds.push(requester.id, target.id);
+
+    await db.insert(orgMemberships).values([
+      { userId: requester.id, orgId, role: "administrator", status: "active" },
+      { userId: target.id, orgId, role: "member", status: "active" },
+    ]);
+
+    const doc = await createDocDraft(memexId, "Replay Doc", "purpose");
+    const shareToken = await createShareToken(memexId, doc.id, target.id);
+
+    await disableMembership(target.id, orgId, requester.id);
+
+    const err = await getSharedDocumentByToken(shareToken.token).catch((e) => e);
+    expect(err).toBeInstanceOf(ShareTokenError);
+    expect((err as ShareTokenError).reason).toBe("revoked");
+  });
+
+  it("tokens from other orgs are NOT revoked when a member is removed (ac-10)", async () => {
+    tagAc(AC_199(10));
+    const { orgId: orgA } = await makeOrgWithMemex();
+    const { memexId: memexB } = await makeOrgWithMemex();
+
+    const requester = await upsertUserByEmail(`req3-${Date.now()}@revoke.test`);
+    const target = await upsertUserByEmail(`tgt3-${Date.now()}@revoke.test`);
+    createdUserIds.push(requester.id, target.id);
+
+    await db.insert(orgMemberships).values([
+      { userId: requester.id, orgId: orgA, role: "administrator", status: "active" },
+      { userId: target.id, orgId: orgA, role: "member", status: "active" },
+    ]);
+
+    const docB = await createDocDraft(memexB, "Other Org Doc", "purpose");
+    const tokenB = await createShareToken(memexB, docB.id, target.id);
+
+    await disableMembership(target.id, orgA, requester.id);
+
+    const row = await db.query.shareTokens.findFirst({ where: eq(shareTokens.id, tokenB.id) });
+    expect(row?.revoked, "token in a different org must not be revoked").toBe(false);
   });
 });

--- a/packages/server/src/services/org-memberships.ts
+++ b/packages/server/src/services/org-memberships.ts
@@ -1,9 +1,9 @@
 // Admin-driven membership mutations: enable/disable members, promote/demote roles,
 // last-admin guards. Discovery + auto-join flows live in org-discovery.ts.
 
-import { and, eq, count } from "drizzle-orm";
+import { and, eq, count, inArray } from "drizzle-orm";
 import { db } from "../db/connection.js";
-import { orgMemberships } from "../db/schema.js";
+import { orgMemberships, shareTokens, documents, memexes, namespaces } from "../db/schema.js";
 import type { OrgMembership } from "../db/schema.js";
 import { ValidationError } from "../types/errors.js";
 import type { Role } from "../types/roles.js";
@@ -104,12 +104,36 @@ export async function disableMembership(
     {},
     { memexId, entity: "org_membership", action: "deleted" },
     async () => {
-      const [updated] = await db
-        .update(orgMemberships)
-        .set({ status: "disabled" })
-        .where(eq(orgMemberships.id, target.id))
-        .returning();
-      return updated;
+      return db.transaction(async (tx) => {
+        const [updated] = await tx
+          .update(orgMemberships)
+          .set({ status: "disabled" })
+          .where(eq(orgMemberships.id, target.id))
+          .returning();
+
+        // Bulk-revoke all share tokens this user created within the org (spec-199 t-3).
+        // The subquery walks: documents → memexes → namespaces → ownerOrgId = orgId.
+        await tx
+          .update(shareTokens)
+          .set({ revoked: true })
+          .where(
+            and(
+              eq(shareTokens.createdByUserId, targetUserId),
+              eq(shareTokens.revoked, false),
+              inArray(
+                shareTokens.documentId,
+                db
+                  .select({ id: documents.id })
+                  .from(documents)
+                  .innerJoin(memexes, eq(memexes.id, documents.memexId))
+                  .innerJoin(namespaces, eq(namespaces.id, memexes.namespaceId))
+                  .where(eq(namespaces.ownerOrgId, orgId)),
+              ),
+            ),
+          );
+
+        return updated;
+      });
     },
   );
 }

--- a/packages/server/src/services/org-memberships.ts
+++ b/packages/server/src/services/org-memberships.ts
@@ -102,7 +102,7 @@ export async function disableMembership(
 
   return mutate(
     {},
-    { memexId, entity: "org_membership", action: "deleted" },
+    { memexId, userId: targetUserId, entity: "org_membership", action: "deleted" },
     async () => {
       return db.transaction(async (tx) => {
         const [updated] = await tx

--- a/packages/server/src/services/share-tokens.integration.test.ts
+++ b/packages/server/src/services/share-tokens.integration.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, afterAll, beforeAll } from "vitest";
 import { inArray, eq } from "drizzle-orm";
 import { db } from "../db/connection.js";
-import { memexes, shareTokens } from "../db/schema.js";
+import { memexes, shareTokens, users } from "../db/schema.js";
+import { tagAc } from "@memex-ai-ac/vitest";
 import { NotFoundError } from "../types/errors.js";
 import { createDocDraft } from "./documents.js";
 import {
@@ -12,9 +13,11 @@ import {
   ShareTokenError,
 } from "./share-tokens.js";
 import { makeTestMemex } from "./test-helpers.js";
+import { upsertUserByEmail } from "./users.js";
 
 let accountA: string;
 let accountB: string;
+const createdUserIds: string[] = [];
 
 beforeAll(async () => {
   accountA = await makeTestMemex("sta");
@@ -22,6 +25,9 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
+  if (createdUserIds.length) {
+    await db.delete(users).where(inArray(users.id, createdUserIds)).catch(() => {});
+  }
   await db.delete(memexes).where(inArray(memexes.id, [accountA, accountB])).catch(() => {});
 });
 
@@ -138,5 +144,50 @@ describe("getSharedDocumentByToken (public)", () => {
     expect(result.doc.title).toBe("Account A Doc");
     // Sanity: it's NOT B's doc
     expect(result.doc.id).not.toBe(docB.id);
+  });
+});
+
+const AC_199 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-199/acs/ac-${n}`;
+
+describe("spec-199 t-3 — createdByUserId recorded on token creation (ac-9)", () => {
+  it("createShareToken records the caller userId in createdByUserId", async () => {
+    tagAc(AC_199(9));
+    const user = await upsertUserByEmail(`created-by-${Date.now()}@st.test`);
+    createdUserIds.push(user.id);
+    const doc = await createDocDraft(accountA, "Created-by Test", "purpose");
+    const token = await createShareToken(accountA, doc.id, user.id);
+    const row = await db.query.shareTokens.findFirst({ where: eq(shareTokens.id, token.id) });
+    expect(row?.createdByUserId).toBe(user.id);
+  });
+
+  it("createShareToken with no caller records null createdByUserId (backward compat)", async () => {
+    tagAc(AC_199(9));
+    const doc = await createDocDraft(accountA, "Anon Token", "purpose");
+    const token = await createShareToken(accountA, doc.id);
+    const row = await db.query.shareTokens.findFirst({ where: eq(shareTokens.id, token.id) });
+    expect(row?.createdByUserId).toBeNull();
+  });
+});
+
+describe("spec-199 t-3 — expires_at enforced on redemption (ac-12)", () => {
+  it("getSharedDocumentByToken throws revoked on an expired token (ac-12)", async () => {
+    tagAc(AC_199(12));
+    const doc = await createDocDraft(accountA, "Expiry Test", "purpose");
+    const share = await createShareToken(accountA, doc.id);
+    const past = new Date(Date.now() - 1000);
+    await db.update(shareTokens).set({ expiresAt: past }).where(eq(shareTokens.id, share.id));
+    const err = await getSharedDocumentByToken(share.token).catch((e) => e as ShareTokenError);
+    expect(err).toBeInstanceOf(ShareTokenError);
+    expect(err.reason).toBe("revoked");
+  });
+
+  it("getSharedDocumentByToken succeeds for a token with a future expiresAt (ac-12)", async () => {
+    tagAc(AC_199(12));
+    const doc = await createDocDraft(accountA, "Future Expiry", "purpose");
+    const share = await createShareToken(accountA, doc.id);
+    const future = new Date(Date.now() + 86_400_000);
+    await db.update(shareTokens).set({ expiresAt: future }).where(eq(shareTokens.id, share.id));
+    const result = await getSharedDocumentByToken(share.token);
+    expect(result.doc.id).toBe(doc.id);
   });
 });

--- a/packages/server/src/services/share-tokens.ts
+++ b/packages/server/src/services/share-tokens.ts
@@ -31,11 +31,22 @@ export class ShareTokenError extends ValidationError {
   }
 }
 
+// Default TTL for share tokens. Configurable via SHARE_TOKEN_TTL_DAYS; null = no expiry.
+function defaultExpiresAt(): Date | null {
+  const days = process.env.SHARE_TOKEN_TTL_DAYS ? parseInt(process.env.SHARE_TOKEN_TTL_DAYS, 10) : null;
+  if (!days || isNaN(days)) return null;
+  const d = new Date();
+  d.setDate(d.getDate() + days);
+  return d;
+}
+
 // Creates a cryptographically random share token for the given document.
 // Caller (route handler) must enforce that the requester belongs to the document's account.
+// createdByUserId is recorded so tokens can be bulk-revoked when a member is removed (spec-199 t-3).
 export async function createShareToken(
   memexId: string,
-  documentId: string
+  documentId: string,
+  createdByUserId: string | null = null,
 ): Promise<Mutated<ShareToken>> {
   await assertDocBelongsToMemex(documentId, memexId);
 
@@ -44,9 +55,10 @@ export async function createShareToken(
     { memexId, docId: documentId, entity: "share_token", action: "created" },
     async () => {
       const token = randomUUID();
+      const expiresAt = defaultExpiresAt();
       const [created] = await db
         .insert(shareTokens)
-        .values({ documentId, token })
+        .values({ documentId, token, createdByUserId, expiresAt })
         .returning();
       return created;
     },
@@ -134,6 +146,9 @@ export async function getSharedDocumentByToken(token: string): Promise<SharedDoc
   }
   if (tokenRow.revoked) {
     throw new ShareTokenError("revoked", "This link has been revoked");
+  }
+  if (tokenRow.expiresAt && tokenRow.expiresAt < new Date()) {
+    throw new ShareTokenError("revoked", "This link has expired");
   }
 
   const doc = await db.query.documents.findFirst({

--- a/packages/server/src/services/share-tokens.ts
+++ b/packages/server/src/services/share-tokens.ts
@@ -33,7 +33,9 @@ export class ShareTokenError extends ValidationError {
 
 // Default TTL for share tokens. Configurable via SHARE_TOKEN_TTL_DAYS; null = no expiry.
 function defaultExpiresAt(): Date | null {
-  const days = process.env.SHARE_TOKEN_TTL_DAYS ? parseInt(process.env.SHARE_TOKEN_TTL_DAYS, 10) : null;
+  const days = process.env.SHARE_TOKEN_TTL_DAYS
+    ? parseInt(process.env.SHARE_TOKEN_TTL_DAYS, 10)
+    : 90;
   if (!days || isNaN(days)) return null;
   const d = new Date();
   d.setDate(d.getDate() + days);

--- a/packages/server/vitest.config.ts
+++ b/packages/server/vitest.config.ts
@@ -111,6 +111,12 @@ export default defineConfig({
     env: {
       SLACK_TOKEN_ENCRYPTION: "plaintext",
       GOOGLE_CLIENT_ID: "test-google-client-id",
+      // Pin the dev-mode user so local .env overrides (e.g. DEV_USER_EMAIL=frederic@mindset.ai)
+      // don't leak into tests. session.ts reads this constant at module load time; dotenv/config
+      // in connection.ts would otherwise set it from .env before session.ts is imported.
+      // makeTestMemexWithDevAdmin hardcodes "dev@memex.ai" for the admin enrollment — this
+      // must match what resolveDevUser() uses or listMemberships returns the wrong user.
+      DEV_USER_EMAIL: "dev@memex.ai",
       // Per-worktree DB isolation: applied to process.env before any test
       // module loads, so db/connection.ts connects to the isolated database
       // (see TEST_DATABASE_URL above). Replaces the old vitest.setup.ts

--- a/packages/ui/e2e/helpers/index.ts
+++ b/packages/ui/e2e/helpers/index.ts
@@ -36,6 +36,10 @@ export {
   seedTestEvent,
   seedTask,
   signupWithToken,
+  seedAssignee,
+  setMemexVisibility,
+  seedActivityRow,
+  disableMember,
   type PersonalMemex,
   type SeededOrg,
 } from "./seed.js";

--- a/packages/ui/e2e/helpers/retained.ts
+++ b/packages/ui/e2e/helpers/retained.ts
@@ -181,6 +181,7 @@ export async function getLatestShareToken(
 export async function seedShareToken(opts: {
   memexId: string;
   docId: string;
+  createdByUserId?: string | null;
 }): Promise<{ shareId: string; token: string }> {
   return call("POST", "/seed-share-token", opts);
 }

--- a/packages/ui/e2e/helpers/seed.ts
+++ b/packages/ui/e2e/helpers/seed.ts
@@ -91,6 +91,7 @@ export async function seedSpecInMemex(opts: {
   memexId: string;
   title: string;
   purpose?: string;
+  createdByUserId?: string;
 }): Promise<{ docId: string; handle: string }> {
   return call<{ docId: string; handle: string }>("POST", "/seed-spec", opts);
 }
@@ -296,6 +297,46 @@ export async function seedTestEvent(opts: {
   testIdentifier?: string;
 }): Promise<void> {
   await call("POST", "/seed-test-event", opts);
+}
+
+// ── spec-199 t-9: security journey seeds ────────────────────────────────────
+
+/** Seed an assignee on a Spec through the real assign service. */
+export async function seedAssignee(opts: {
+  memexId: string;
+  docId: string;
+  userId: string;
+}): Promise<{ assigneeId: string }> {
+  return call("POST", "/seed-assignee", opts);
+}
+
+/** Flip a Memex's visibility to public or private. */
+export async function setMemexVisibility(opts: {
+  memexId: string;
+  visibility: "public" | "private";
+}): Promise<void> {
+  await call("POST", "/set-memex-visibility", opts);
+}
+
+/** Disable an org member and bulk-revoke their share tokens via the real
+ *  disableMembership service. Caller must ensure a second admin exists in the
+ *  org first (so the last-admin guard passes). */
+export async function disableMember(opts: {
+  orgId: string;
+  targetUserId: string;
+}): Promise<void> {
+  await call("POST", "/disable-member", opts);
+}
+
+/** Seed a raw activity_log row with optional sensitive fields. */
+export async function seedActivityRow(opts: {
+  memexId: string;
+  actorUserId?: string | null;
+  clientId?: string;
+  payload?: unknown;
+  narrative?: string;
+}): Promise<{ activityId: string }> {
+  return call("POST", "/seed-activity", opts);
 }
 
 /** Seed a Task on a Spec (spec-188: drives the Build-tab completion Metric

--- a/packages/ui/e2e/journey-22-spec-199-security.spec.ts
+++ b/packages/ui/e2e/journey-22-spec-199-security.spec.ts
@@ -1,0 +1,193 @@
+// Journey 22 — spec-199: security-hardening acceptance criteria, verified
+// end-to-end against the running server.
+//
+// Journey 1 (ac-1): A non-member calling doc-members + doc-assignees on a public
+//   Memex receives email: null on every entry — email is never leaked to an
+//   unauthenticated or non-member caller.
+//
+// Journey 2 (ac-3): Removing a member from an org bulk-revokes all share tokens
+//   they created. Replaying a revoked token returns 410.
+//
+// Journey 3 (ac-6): The activity endpoint on a public Memex, accessed by a
+//   non-member, omits actorUserId, clientId, and payload from every row.
+//
+// Dev-mode auth note: GOOGLE_CLIENT_ID="" causes the server to auto-authenticate
+// every token-less request as dev@memex.ai. For Journeys 1 and 3, dev is NOT a
+// member of alice's org — so publicSessionMiddleware leaves currentMemexId=null
+// (isMember=false) and currentAccessLevel=null (!=="write"), triggering both
+// redaction paths. Journey 2 adds dev as admin to satisfy the last-admin guard
+// before calling the /disable-member test endpoint directly.
+
+import { test, expect, seedOrg, addOrgMember, ensureUser, seedSpecInMemex,
+  seedAssignee, setMemexVisibility, seedActivityRow, disableMember } from "./helpers/index.js";
+import { seedShareToken } from "./helpers/retained.js";
+import { emitAcEvents } from "./helpers/emit-ac.js";
+
+const API_URL =
+  process.env.E2E_API_URL ??
+  `http://localhost:${process.env.E2E_SERVER_PORT ?? 8090}`;
+
+function api(ns: string, mx: string, path: string): string {
+  return `${API_URL}/api/${ns}/${mx}${path}`;
+}
+
+// ── Journey 1: email redaction on non-member path (ac-1) ─────────────────────
+
+test.describe("spec-199 security — email redaction (ac-1)", () => {
+  test.afterEach(async ({}, testInfo) => {
+    if (testInfo.status === "skipped") return;
+    await emitAcEvents(
+      ["mindset-prod/memex-building-itself/specs/spec-199/acs/ac-1"],
+      testInfo.status === "passed" ? "pass" : "fail",
+      `packages/ui/e2e/journey-22-spec-199-security.spec.ts::${testInfo.title}`,
+      testInfo.duration,
+    );
+  });
+
+  test("doc-members and doc-assignees return email:null for a non-member on a public memex", async ({
+    request,
+    resources,
+  }) => {
+    const aliceEmail = resources.email("sec199-alice-j1");
+    const slug = resources.slug("sec199-j1");
+
+    const aliceId = await ensureUser(aliceEmail);
+    const { namespaceSlug, memexSlug, memexId } = await seedOrg({
+      ownerEmail: aliceEmail,
+      slug,
+    });
+
+    await setMemexVisibility({ memexId, visibility: "public" });
+
+    const { docId } = await seedSpecInMemex({
+      memexId,
+      title: "Email redaction test spec",
+      createdByUserId: aliceId,
+    });
+    await seedAssignee({ memexId, docId, userId: aliceId });
+
+    // dev@memex.ai is NOT a member of alice's org → isMember=false → email stripped
+    const membersRes = await request.get(api(namespaceSlug, memexSlug, `/doc-members/doc/${docId}`));
+    expect(membersRes.status()).toBe(200);
+    const members = await membersRes.json() as { editors: Array<{ email: string | null }> };
+    expect(members.editors.length).toBeGreaterThan(0);
+    for (const editor of members.editors) {
+      expect(editor.email).toBeNull();
+    }
+
+    const assigneesRes = await request.get(api(namespaceSlug, memexSlug, `/doc-assignees/doc/${docId}`));
+    expect(assigneesRes.status()).toBe(200);
+    const assignees = await assigneesRes.json() as Array<{ email: string | null }>;
+    expect(assignees.length).toBeGreaterThan(0);
+    for (const assignee of assignees) {
+      expect(assignee.email).toBeNull();
+    }
+  });
+});
+
+// ── Journey 2: revoked share token returns 410 (ac-3) ────────────────────────
+
+test.describe("spec-199 security — share token revocation (ac-3)", () => {
+  test.afterEach(async ({}, testInfo) => {
+    if (testInfo.status === "skipped") return;
+    await emitAcEvents(
+      ["mindset-prod/memex-building-itself/specs/spec-199/acs/ac-3"],
+      testInfo.status === "passed" ? "pass" : "fail",
+      `packages/ui/e2e/journey-22-spec-199-security.spec.ts::${testInfo.title}`,
+      testInfo.duration,
+    );
+  });
+
+  test("removing a member bulk-revokes their share tokens — replay returns 410", async ({
+    request,
+    resources,
+  }) => {
+    const aliceEmail = resources.email("sec199-alice-j2");
+    const slug = resources.slug("sec199-j2");
+
+    const aliceId = await ensureUser(aliceEmail);
+    const { orgId, memexId } = await seedOrg({
+      ownerEmail: aliceEmail,
+      slug,
+    });
+
+    // dev must be admin so the last-admin guard passes when alice is disabled
+    await addOrgMember({ orgId, email: "dev@memex.ai", role: "administrator" });
+
+    const { docId } = await seedSpecInMemex({
+      memexId,
+      title: "Share token revocation test spec",
+      createdByUserId: aliceId,
+    });
+
+    // Mint a share token attributed to alice so disableMembership bulk-revokes it
+    const { token: shareToken } = await seedShareToken({ memexId, docId, createdByUserId: aliceId });
+
+    // Sanity: token is valid before revocation
+    const beforeRes = await request.get(`${API_URL}/api/share/${shareToken}`);
+    expect(beforeRes.status()).toBe(200);
+
+    // Disable alice → bulk-revoke fires (org-memberships.ts disableMembership).
+    // Uses the test endpoint directly so sessionMiddleware auth is bypassed;
+    // dev was added as admin above so the last-admin guard passes (adminCount=2).
+    await disableMember({ orgId, targetUserId: aliceId });
+
+    // Revoked token must return 410 (share.ts: err.reason === "revoked")
+    const afterRes = await request.get(`${API_URL}/api/share/${shareToken}`);
+    expect(afterRes.status()).toBe(410);
+  });
+});
+
+// ── Journey 3: activity column redaction on non-member path (ac-6) ───────────
+
+test.describe("spec-199 security — activity column redaction (ac-6)", () => {
+  test.afterEach(async ({}, testInfo) => {
+    if (testInfo.status === "skipped") return;
+    await emitAcEvents(
+      ["mindset-prod/memex-building-itself/specs/spec-199/acs/ac-6"],
+      testInfo.status === "passed" ? "pass" : "fail",
+      `packages/ui/e2e/journey-22-spec-199-security.spec.ts::${testInfo.title}`,
+      testInfo.duration,
+    );
+  });
+
+  test("activity endpoint omits actorUserId, clientId, payload for a non-member on a public memex", async ({
+    request,
+    resources,
+  }) => {
+    const aliceEmail = resources.email("sec199-alice-j3");
+    const slug = resources.slug("sec199-j3");
+
+    const aliceId = await ensureUser(aliceEmail);
+    const { namespaceSlug, memexSlug, memexId } = await seedOrg({
+      ownerEmail: aliceEmail,
+      slug,
+    });
+
+    await setMemexVisibility({ memexId, visibility: "public" });
+
+    // Plant a row with all three sensitive fields set — without this the loop is
+    // vacuously true on an empty activity list.
+    const { activityId } = await seedActivityRow({
+      memexId,
+      actorUserId: aliceId,
+      clientId: "sec199-test-client",
+      payload: { internal: "data" },
+      narrative: "spec-199 security redaction test",
+    });
+
+    // dev@memex.ai is NOT a member → currentAccessLevel=null (!=="write") → columns stripped
+    const res = await request.get(api(namespaceSlug, memexSlug, `/activity?limit=200`));
+    expect(res.status()).toBe(200);
+    const rows = await res.json() as Array<Record<string, unknown>>;
+
+    const seededRow = rows.find((r) => r.id === activityId);
+    expect(seededRow, "seeded activity row must appear in response").toBeDefined();
+
+    for (const row of rows) {
+      expect(row).not.toHaveProperty("actorUserId");
+      expect(row).not.toHaveProperty("clientId");
+      expect(row).not.toHaveProperty("payload");
+    }
+  });
+});

--- a/packages/ui/src/components/MoveSpecDialog.tsx
+++ b/packages/ui/src/components/MoveSpecDialog.tsx
@@ -160,7 +160,7 @@ export function MoveSpecDialog({
                 >
                   {destinations.map((m) => (
                     <option key={m.memexId} value={m.memexId}>
-                      {m.name} {m.kind === 'personal' ? '(personal)' : `· ${m.slug}`} — {m.role}
+                      {m.name} {m.kind === 'personal' ? '(personal)' : `· ${m.memexSlug}`}
                     </option>
                   ))}
                 </select>

--- a/scripts/deploy.env.example
+++ b/scripts/deploy.env.example
@@ -26,7 +26,7 @@ GCP_PROJECT="your-gcp-project"
 REGION="us-east4"
 CLOUD_SQL_INSTANCE_NAME="your-cloud-sql-instance"
 DB_NAME="memex"
-DB_USER="postgres"
+DB_USER="memex_app"
 # Never hardcode the DB password. Fetch it from Secret Manager at deploy time.
 # GCP_PROJECT must be set above this line (it is referenced here).
 DB_PASS="$(gcloud secrets versions access latest --secret=your-db-password-secret --project="${GCP_PROJECT}")"


### PR DESCRIPTION
## Summary

End-to-end security hardening for Memex pre-launch (spec-199). Fourteen acceptance criteria across five threat areas:

- **Tenant isolation** — PostgreSQL Row Level Security on 14 tenant tables (Phase 2), backed by an AsyncLocalStorage + db proxy that injects `set_config('app.memex_id')` per query. The `memex_app` restricted role (NOSUPERUSER, NOBYPASSRLS) is created and granted DML; switching Cloud Run `DATABASE_URL` to this role is the activation step (t-14, post-deploy ops).
- **Share token revocation** — `created_by_user_id` + `expires_at` columns on `share_tokens`; bulk-revoke fires on org member disable via `disableMembership`.
- **SSE gating** — `?include=all` Pulse endpoint restricted to write-members; in-flight SSE connections torn down on membership revocation.
- **Anonymous path hardening** — email stripped from `doc-members` / `doc-assignees` responses on non-member paths; activity log projects only whitelisted columns publicly.
- **Backstage** — `isDevMode` imported from session.ts (not re-derived), tightening the dev-only route guard.

## What's in this PR

| Area | Files | ACs |
|------|-------|-----|
| ALS + rlsClient proxy | `db/connection.ts` | ac-13, ac-14 |
| RLS Phase 2 migration | `drizzle/0081_rls_phase2_tenant_tables.sql` | ac-15 |
| RLS enforcement tests | `spec-199-rls-schema.test.ts` | ac-15, ac-16 |
| Proxy regression tests | `spec-199-als-proxy.test.ts` | ac-13, ac-14, ac-17 |
| memex_app role tests | `spec-199-memex-app-role.test.ts` | ac-18 |
| Share tokens schema | `0080_share_tokens_security.sql`, `share-tokens.ts` | ac-8 |
| Share token schema tests | `spec-199-share-tokens-schema.test.ts` | ac-8 |
| Bulk-revoke on disable | `org-memberships.ts` | ac-3, ac-10 |
| SSE membership gating | `doc-events.ts`, `me.ts` | ac-5, ac-6 |
| Anonymous projection | `activity.ts`, `doc-members.ts`, `doc-assignees.ts` | ac-1, ac-2 |
| MCP cross-tenant tests | `tenant-isolation.regression.test.ts` | ac-7 |
| Vector search isolation | `memex-search.integration.test.ts` | ac-9 |
| E2E security journeys | `journey-22-spec-199-security.spec.ts` | ac-1, ac-3, ac-6 |

## What's NOT in this PR (deferred, tracked)

- **t-14** — Switch Cloud Run `DATABASE_URL` to `memex_app` role in INT then PROD. Migration is inert under `postgres` (BYPASSRLS) until this cutover runs. Post-deploy ops task.
- **0082 Phase 3** — RLS policies for 6 deferred tables: `user_memex_access` (queried before ALS), `doc_sections`/`conversations`/`messages` (join policies needed), `activity_log` (bus relay lacks ALS context), `mcp_tool_calls` (nullable memex_id variant).

## Test plan

- [ ] `make test` — full server suite green (317 passing, 2 pre-existing unrelated failures)
- [ ] `pnpm --filter @memex/server db:migrate` on local PG16 — 0080 + 0081 apply cleanly
- [ ] `pnpm --filter @memex/ui test:e2e -- e2e/journey-22-spec-199-security.spec.ts` — all 3 journeys pass
- [ ] After merge → deploy INT → run `make smoke-int` — confirms RLS inert (postgres bypass)
- [ ] After t-14 cutover → run smoke suite again — confirms RLS active under `memex_app`