### PR TITLE
feat(guidance): centralize tool-output guidance into one surgical seat (spec-219)

### DIFF
--- a/packages/server/src/__regression__/footer-one-seat.regression.test.ts
+++ b/packages/server/src/__regression__/footer-one-seat.regression.test.ts
@@ -1,9 +1,9 @@
 // spec-203 ac-14/ac-15/ac-16/ac-17 — the footer has ONE seat of intelligence.
 //
 // A tool call is the client phoning home; the server returns the real result,
-// then uses that one opening to steer the client through a footer authored in a
-// SINGLE place (`decideFooter`) and attached at a SINGLE choke point
-// (`runToolWithSpecTraffic`), on EVERY Spec-resolving call. Source-text guards
+// then uses that one opening to steer the client through guidance authored in a
+// SINGLE place (`composeGuidanceEnvelope`, spec-219) and attached at a SINGLE
+// choke point (`runToolWithSpecTraffic`), on EVERY Spec-resolving call. Source-text guards
 // (no DB) pin the wiring so a future refactor cannot re-introduce a second footer
 // author or re-gate persistence. The behavioural proof (footer rides terse +
 // persisted) lives in services/spec-203-footer.integration.test.ts.
@@ -38,13 +38,13 @@ describe("ac-15 — one seat: the footer is composed in exactly one place", () =
     expect(bodyFn).not.toMatch(/lines\.push\(formatSpecGuidance\(/);
   });
 
-  it("decideFooter is the single seat that authors footer content", () => {
+  it("composeGuidanceEnvelope is the single seat that authors guidance content", () => {
     tagAc(AC(15));
     tagAc(AC(16));
-    expect(toolSpecs).toMatch(/export async function decideFooter\(/);
+    expect(toolSpecs).toMatch(/export async function composeGuidanceEnvelope\(/);
     // Sole author: nothing else in spec-traffic composes a footer; it only calls
     // the seat.
-    expect(specTraffic).toMatch(/const \{ decideFooter \} = await import/);
+    expect(specTraffic).toMatch(/const \{ composeGuidanceEnvelope \} = await import/);
   });
 });
 
@@ -52,7 +52,10 @@ describe("ac-14 / ac-16 — the seat is invoked at the one choke point, every ca
   it("runToolWithSpecTraffic attaches the seat's footer for every resolved Spec", () => {
     tagAc(AC(14));
     tagAc(AC(16));
-    expect(specTraffic).toMatch(/decideFooter\(target\.memexId, target\.docId, ctx\)/);
+    expect(specTraffic).toMatch(/composeGuidanceEnvelope\(/);
+    // The choke point owns the single delimiter, assembling header + body +
+    // FOOTER_DELIMITER + footer (spec-219 ac-7).
+    expect(specTraffic).toMatch(/\$\{FOOTER_DELIMITER\}\\n\$\{footer\}/);
     // Only when a Spec resolved, and only when no footer is already present
     // (defence-in-depth — the body composes none).
     expect(specTraffic).toMatch(/if \(target && !text\.includes\(FOOTER_DELIMITER\)\)/);
@@ -61,7 +64,7 @@ describe("ac-14 / ac-16 — the seat is invoked at the one choke point, every ca
   it("the seat branches on verbose internally — one method, not two paths", () => {
     tagAc(AC(16));
     const seat = toolSpecs.slice(
-      toolSpecs.indexOf("export async function decideFooter("),
+      toolSpecs.indexOf("export async function composeGuidanceEnvelope("),
       toolSpecs.indexOf("async function craftUntestedAcNag("),
     );
     expect(seat).toMatch(/if \(ctx\.verbose\)/); // full footer on reads

--- a/packages/server/src/__regression__/spec-219-guidance-catalogue.regression.test.ts
+++ b/packages/server/src/__regression__/spec-219-guidance-catalogue.regression.test.ts
@@ -1,0 +1,83 @@
+// spec-219 ac-3 — the guidance catalogue is honoured: every guidance item that
+// production appends today still has a live producer. Nothing is lost by
+// omission. Source-text guards (no DB) pin each producer so a future refactor
+// can't silently delete a nudge the catalogue (spec-219 §"Guidance catalogue")
+// committed to keeping.
+
+import { describe, it, expect } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-219/acs/ac-${n}`;
+
+const SERVER_ROOT = join(__dirname, "..", "..");
+const read = (p: string) => readFileSync(join(SERVER_ROOT, "src", p), "utf-8");
+
+const toolSpecs = read(join("agent", "tool-specs.ts"));
+const formatters = read(join("mcp", "formatters.ts"));
+const specTraffic = read(join("services", "spec-traffic.ts"));
+
+describe("ac-3 — terse embedded nudges KEPT", () => {
+  it("create_doc still pushes scope ACs", () => {
+    tagAc(AC(3));
+    expect(toolSpecs).toMatch(/author Scope ACs/);
+  });
+  it("resolve_decision still pushes implementation ACs", () => {
+    tagAc(AC(3));
+    expect(toolSpecs).toMatch(/author the implementation AC/);
+  });
+  it("create_ac still reminds about ac-emission tagging", () => {
+    tagAc(AC(3));
+    expect(toolSpecs).toMatch(/topic='ac-emission'/);
+  });
+  it("update_task terse still reports completion + unblocked dependents", () => {
+    tagAc(AC(3));
+    expect(toolSpecs).toMatch(/Unblocked dependents/);
+    expect(toolSpecs).toMatch(/COMPLETION_NUDGE/);
+  });
+});
+
+describe("ac-3 — verbose blocks CHANGED (centralized), not dropped", () => {
+  it("the get_doc coverage header is now seat-composed (verbose && get_doc)", () => {
+    tagAc(AC(3));
+    expect(toolSpecs).toMatch(/ctx\.toolName === "get_doc"[\s\S]*?formatCoverageHeader\(/);
+  });
+  it("the handler footer nudges route through the footer slot", () => {
+    tagAc(AC(3));
+    expect(toolSpecs).toMatch(/ctx\.footerSlot\.content =/);
+    expect(specTraffic).toMatch(/footerSlot/);
+  });
+  it("the InjectedBlock zone plumbing is KEPT (inert) — still present in the composer", () => {
+    tagAc(AC(3));
+    expect(formatters).toMatch(/InjectedBlock/);
+    expect(formatters).toMatch(/zone === "header"/);
+    expect(formatters).toMatch(/zone === "footer"/);
+  });
+});
+
+describe("ac-3 — machine-footer internals KEPT / CHANGED", () => {
+  it("FOOTER_DELIMITER ownership moved to the choke point (written once there)", () => {
+    tagAc(AC(3));
+    expect(specTraffic).toMatch(/\$\{FOOTER_DELIMITER\}\\n\$\{footer\}/);
+  });
+  it("phase guidance via toNudge is kept", () => {
+    tagAc(AC(3));
+    expect(formatters).toMatch(/toNudge\(/);
+  });
+  it("the terse build AC nag is kept", () => {
+    tagAc(AC(3));
+    expect(toolSpecs).toMatch(/craftUntestedAcNag/);
+  });
+  it("the org_scaffold_additions overlay path is kept", () => {
+    tagAc(AC(3));
+    expect(toolSpecs).toMatch(/getOrgBlocksForNudge/);
+    expect(toolSpecs).toMatch(/orgBlocks/);
+  });
+  it("the NEW per-tool steer registry is present", () => {
+    tagAc(AC(3));
+    expect(toolSpecs).toMatch(/STEER_BY_TOOL/);
+    expect(toolSpecs).toMatch(/function composeToolSteer/);
+  });
+});

--- a/packages/server/src/__regression__/spec-219-lockstep-203.regression.test.ts
+++ b/packages/server/src/__regression__/spec-219-lockstep-203.regression.test.ts
@@ -1,0 +1,52 @@
+// spec-219 ac-13 — lockstep with spec-203.
+//
+// The envelope work INVERTS spec-203 ac-13 ("formatFullDocState is the single
+// composer of the doc-state envelope, with NO tool-name conditionals; the four
+// decorating tools pass InjectedBlocks"). spec-219's single seat composes the
+// envelope PER-TOOL and the choke point attaches it, so formatFullDocState
+// composes neither header nor footer. These source-text guards pin the code side
+// of the inversion; the Memex side (spec-203 ac-13 retired, ac-15 softened,
+// spec-203 shows no failing ACs) is reconciled via the AC tools in the SAME
+// change set and confirmed with list_acs(spec-203).
+
+import { describe, it, expect } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-219/acs/ac-${n}`;
+
+const SERVER_ROOT = join(__dirname, "..", "..");
+const read = (p: string) => readFileSync(join(SERVER_ROOT, "src", p), "utf-8");
+const toolSpecs = read(join("agent", "tool-specs.ts"));
+const formatters = read(join("mcp", "formatters.ts"));
+
+describe("spec-219 ac-13 — the per-tool seat inverts spec-203 ac-13", () => {
+  it("the seat composes the envelope PER-TOOL (tool-name conditionals)", () => {
+    tagAc(AC(13));
+    const seat = toolSpecs.slice(
+      toolSpecs.indexOf("export async function composeGuidanceEnvelope("),
+      toolSpecs.indexOf("async function craftUntestedAcNag("),
+    );
+    // Inverts spec-203 ac-13's "NO tool-name conditionals": the header is gated
+    // on the dispatching tool, and per-tool steering keys on the tool.
+    expect(seat).toMatch(/ctx\.toolName === "get_doc"/);
+    expect(toolSpecs).toMatch(/const STEER_BY_TOOL/);
+    expect(toolSpecs).toMatch(/function composeToolSteer/);
+  });
+
+  it("formatFullDocState composes neither a header nor a footer (no longer the single composer)", () => {
+    tagAc(AC(13));
+    expect(formatters).toMatch(/the footer is NO LONGER composed here/i);
+    const bodyFn = formatters.slice(
+      formatters.indexOf("export function formatFullDocState"),
+      formatters.indexOf("// Document List"),
+    );
+    // The body renderer emits no machine footer (no delimiter) and no
+    // AC-coverage header — the seat owns both.
+    expect(bodyFn).not.toMatch(/FOOTER_DELIMITER/);
+    expect(bodyFn).not.toMatch(/formatCoverageHeader/);
+    expect(bodyFn).not.toMatch(/formatSpecGuidance\(/);
+  });
+});

--- a/packages/server/src/__regression__/test-coverage-nudges.regression.test.ts
+++ b/packages/server/src/__regression__/test-coverage-nudges.regression.test.ts
@@ -87,19 +87,17 @@ describe("Channel 2 — phase-transition advice carries a coverage paragraph", (
     expect(toolSpecs).toMatch(/\*\*AC coverage:\*\*/);
   });
 
-  it("verbose get_doc prepends the coverage header for Specs", () => {
-    // The wiring lives inside the get_doc handler — assert the helper is
-    // called there and its result reaches the composer as a header-zone block.
+  it("verbose get_doc prepends the coverage header via the one seat (spec-219 ac-10)", () => {
+    // spec-219: the wiring moved OUT of the get_doc handler INTO the single seat
+    // (composeGuidanceEnvelope), which composes the header — verbose AND get_doc
+    // only — and the choke point prepends it above the body. Behaviour (and the
+    // byte output) is preserved; this guard pins the new location.
     expect(toolSpecs).toMatch(
-      /const coverageHeader = await formatCoverageHeader\([\s\S]*?doc\.docType,[\s\S]*?\);/,
+      /ctx\.toolName === "get_doc"[\s\S]*?formatCoverageHeader\(/,
     );
-    // spec-203 t-3: the coverage header is now passed to formatState as a
-    // header-zone InjectedBlock (the composer places it above the doc), not
-    // string-concatenated at the call site. Output is byte-identical; this
-    // guard pins the new wiring.
-    expect(toolSpecs).toMatch(
-      /\{ zone: "header", content: coverageHeader \}/,
-    );
+    // The header is no longer injected as a header-zone block inside the get_doc
+    // handler — re-introducing that would re-fragment the one-seat composer.
+    expect(toolSpecs).not.toMatch(/\{ zone: "header", content: coverageHeader \}/);
   });
 });
 

--- a/packages/server/src/agent/tool-specs.ts
+++ b/packages/server/src/agent/tool-specs.ts
@@ -147,10 +147,9 @@ import {
   type ParsedTag,
 } from "../services/tags.js";
 import { NotFoundError, ValidationError } from "../types/errors.js";
-import { FOOTER_DELIMITER } from "../mcp/footer-delimiter.js";
 import {
   formatFullDocState,
-  formatSpecGuidance,
+  formatSpecGuidanceBody,
   formatDocList,
   formatComment,
   formatCommentList,
@@ -339,6 +338,20 @@ export interface ToolCtx {
    * memex has no Org context (personal namespaces).
    */
   getOrgBlocksForNudge?: () => Promise<readonly GuidanceBlock[]>;
+  /**
+   * spec-219 dec-3 (t-3): the stable slot a handler parks its dynamic footer
+   * nugget in — the result-reporting / steering text it used to inject as a
+   * `{ zone: "footer" }` block on its own `formatState` call. The single seat
+   * (`composeGuidanceEnvelope`) reads it and folds it into the footer, so the
+   * choke point lands it AFTER `FOOTER_DELIMITER` and the telemetry split
+   * persists it to `mcp_tool_calls.footer_text` (it never was while the nugget
+   * rode the body, before the delimiter). A shared mutable holder: the choke
+   * point (`runToolWithSpecTraffic`) creates one, threads it into the handler's
+   * ctx, and reads it back when it composes the envelope. Absent on hand-rolled
+   * test ctxes that bypass the choke — there the nugget is simply not delivered,
+   * exactly as any footer needs the choke to attach it.
+   */
+  footerSlot?: { content?: string };
 }
 
 /**
@@ -591,14 +604,19 @@ async function formatState(
 }
 
 /**
- * THE single seat that decides and attaches the footer (spec-203 ac-15 / ac-16).
+ * THE single seat that composes the platform guidance ENVELOPE — header + footer
+ * (spec-203 ac-15 / ac-16; spec-219 ac-6).
  *
  * A tool call — any tool call — is the client phoning home; we return the real
- * tool result, then take that one opening to STEER the client. `decideFooter` is
- * invoked at the single choke point (`runToolWithSpecTraffic`) on EVERY
- * Spec-resolving call (ac-14), and is the only place a footer is composed. It
- * returns the footer already framed with FOOTER_DELIMITER (so the telemetry wrap
- * splits + persists it — ac-17), or null for "no footer this time".
+ * tool result, then take that one opening to STEER the client.
+ * `composeGuidanceEnvelope` is invoked at the single choke point
+ * (`runToolWithSpecTraffic`) on EVERY Spec-resolving call (ac-14), and is the
+ * only place a header or footer is composed (`formatFullDocState` composes
+ * neither). It returns `{ header?, footer? }` where BOTH are DELIMITER-LESS
+ * content: the choke point owns the single `FOOTER_DELIMITER` and writes it
+ * exactly once when it assembles `header + body + FOOTER_DELIMITER + footer`
+ * (spec-219 ac-7); the telemetry wrap then splits + persists the footer (ac-17).
+ * An empty envelope `{}` means "nothing to add this time".
  *
  * Starting policy (deterministic; the SITUATIONAL logic — onboarding a first
  * Spec, a reprimand when an agent is drifting — evolves HERE, behind this one
@@ -608,20 +626,88 @@ async function formatState(
  *     preserved, including spec-193's tripwire vocabulary.
  *   - terse calls (the build loop) → the COMPACT footer (handoff essence +
  *     dynamic state incl. the AC nag), steering without flooding the agent.
- * One composer for both (`formatSpecGuidance`); the only knob is `compact`.
+ * One composer for both (`formatSpecGuidanceBody`).
  *
- * Best-effort: never throws — a footer-policy failure must not cost the tool its
- * result.
+ * Best-effort: never throws — a guidance-policy failure must not cost the tool
+ * its result.
  */
-export async function decideFooter(
+export interface GuidanceEnvelope {
+  header?: string;
+  footer?: string;
+}
+
+/**
+ * spec-219 dec-5 (t-4): the per-tool STEERING registry — the ONE place the
+ * transition map (tool T → the move we want next, T+1) lives. Keyed by the
+ * dispatching tool, it is the seam that makes the footer TRANSITION-keyed rather
+ * than purely phase-keyed (ac-11): two tools resolving the same Spec in the same
+ * phase can get different footers.
+ *
+ * Division of labour (dec-5): handlers own RESULT-REPORTING (the footer slot,
+ * t-3 — what the tool just did); the seat owns STEERING (this registry + the
+ * phase guidance — where to go next). A steer here MUST COMPLEMENT, never echo,
+ * the handler's slot nugget (ac-12) — so a tool that already parks a slot steer
+ * (update_task's completion nudge, update_doc / publish_spec transition nudges)
+ * deliberately has NO entry here. Phase 2 migrates the remaining scattered
+ * per-tool steers (create_doc's scope-AC push, resolve_decision's impl-AC push,
+ * …) into this one map; this is the seam they land on.
+ */
+const STEER_BY_TOOL: Partial<Record<string, (phase: Phase) => string | undefined>> = {
+  // After editing a section while shaping the plan, the surgical next move is to
+  // keep the narrative honest against the decisions. No other surface says this
+  // per-tool, and update_section parks no slot nugget — so no echo.
+  update_section: (phase) =>
+    phase === "specify" || phase === "draft"
+      ? "Steer: if this edit captures a resolved decision, confirm the decision's consequence now reads in the prose; if a new fork surfaced while writing, capture it with create_decision before it gets buried."
+      : undefined,
+};
+
+/**
+ * Compose the per-tool steer for this (tool, phase). Undefined when the tool has
+ * no registered steer — the footer then carries only the phase guidance (+ any
+ * handler slot). This is the single read of the transition map (ac-5: the
+ * per-tool nudge notion has exactly one author, the seat).
+ */
+function composeToolSteer(toolName: string | undefined, phase: Phase): string | undefined {
+  if (!toolName) return undefined;
+  return STEER_BY_TOOL[toolName]?.(phase);
+}
+
+export async function composeGuidanceEnvelope(
   memexId: string,
   docId: string,
   ctx: ToolCtx,
-): Promise<string | null> {
+): Promise<GuidanceEnvelope> {
+  // spec-219 dec-3 (t-3): a handler may have parked a dynamic footer nugget in
+  // the slot (the result-reporting / steering it used to inject as a footer
+  // block). `compose` folds it into the footer — BEFORE the seat's phase
+  // guidance, matching the order it had on the body side — so the choke point
+  // lands it past the delimiter and the telemetry split persists it (ac-9). The
+  // handler kept its own DB read; the seat only composes (ac-8).
+  const slotRaw = ctx.footerSlot?.content;
+  const slot = slotRaw && slotRaw.trim().length > 0 ? slotRaw : undefined;
+  const compose = (
+    header: string | undefined,
+    footer: string | undefined,
+  ): GuidanceEnvelope => {
+    const footerBody =
+      [slot, footer].filter((s): s is string => Boolean(s)).join("\n\n") || undefined;
+    const env: GuidanceEnvelope = {};
+    if (header) env.header = header;
+    if (footerBody) env.footer = footerBody;
+    return env;
+  };
   try {
     const state = await fullDocState(memexId, docId);
-    if (state.doc.docType !== "spec") return null;
+    if (state.doc.docType !== "spec") return compose(undefined, undefined);
     const phase = state.doc.status as Phase;
+    // spec-219 dec-5 (t-4): the seat's per-tool steer for this (tool, phase) — the
+    // transition-keyed element of the footer. Folded BEFORE the general phase
+    // guidance (surgical steer first); complements, never echoes, the handler's
+    // slot result-reporting (ac-12).
+    const toolSteer = composeToolSteer(ctx.toolName, phase);
+    const withSteer = (footer: string | undefined): string | undefined =>
+      [toolSteer, footer].filter((s): s is string => Boolean(s)).join("\n\n") || undefined;
 
     // VERBOSE reads — the agent asked for the whole document, so author the FULL
     // phase footer via the shared composer (a pure helper; the seat still owns
@@ -663,23 +749,41 @@ export async function decideFooter(
           acVerifications = undefined;
         }
       }
-      return formatSpecGuidance(state.doc, state.decs, state.tasks, nudge, acVerifications);
+      const footer = formatSpecGuidanceBody(
+        state.doc,
+        state.decs,
+        state.tasks,
+        nudge,
+        acVerifications,
+      );
+      // spec-219 ac-10 / dec-4: the AC-coverage HEADER is composed HERE (the one
+      // seat), not in the get_doc handler. It is the get_doc-verbose-only surface
+      // — emitted only when this is a `get_doc` call (the coverage summary above
+      // the doc body), with NO header delimiter (the `**AC coverage:**` line is
+      // self-labelling and re-derivable, so it is not persisted). The choke point
+      // prepends it above the body, byte-identical to the former header block.
+      const header =
+        ctx.toolName === "get_doc"
+          ? (await formatCoverageHeader(memexId, docId, state.doc.docType)) || undefined
+          : undefined;
+      return compose(header, withSteer(footer ?? undefined));
     }
 
     // TERSE build-loop calls — author a LEAN, situational footer here. This is
     // the seat where the steering logic lives and grows (per tool, per user, per
     // signal). Starting policy: the phase essence ("what's my job this phase")
-    // plus, in build, the AC nag — the highest-value methodology steer.
-    const lines: string[] = [FOOTER_DELIMITER];
+    // plus, in build, the AC nag — the highest-value methodology steer. The body
+    // is DELIMITER-LESS (spec-219 ac-7): the choke point frames it.
+    const lines: string[] = [];
     const essence = toHandoffEssence(BASE_SCAFFOLD, phase);
     if (essence) lines.push(essence);
     if (phase === "build") {
       const nag = await craftUntestedAcNag(memexId, docId);
       if (nag) lines.push(nag);
     }
-    return lines.length > 1 ? lines.join("\n") : null;
+    return compose(undefined, withSteer(lines.length > 0 ? lines.join("\n") : undefined));
   } catch {
-    return null;
+    return compose(undefined, undefined);
   }
 }
 
@@ -1214,20 +1318,12 @@ export const toolSpecs: ToolSpec[] = [
           return formatStandard(standard, url);
         }
         const state = await fullDocState(memexId, doc.id);
-        // Prepend an AC-coverage header for Specs so the agent sees the
-        // gap before reading the full state. Returns "" for non-Spec docs
-        // or Specs with no active ACs, so the header is non-intrusive when
-        // it doesn't apply.
-        const coverageHeader = await formatCoverageHeader(
-          memexId,
-          doc.id,
-          doc.docType,
-        );
-        // spec-203 dec-3 (t-3): the coverage header is a header-zone block — the
-        // composer places it above the doc; this handler no longer concatenates.
-        return await formatState(url, state, ctx, [
-          { zone: "header", content: coverageHeader },
-        ]);
+        // spec-219 ac-10 / dec-4: the AC-coverage header is NO LONGER injected
+        // here. The single seat (`composeGuidanceEnvelope`) composes it — verbose
+        // AND get_doc only — and the choke point (`runToolWithSpecTraffic`)
+        // prepends it above the body. Centralizing both header and footer in the
+        // one seat is the whole point (ac-6); this handler renders only the body.
+        return await formatState(url, state, ctx);
       }
 
       // Terse: agent already has the doc context injected by the system
@@ -1529,12 +1625,12 @@ export const toolSpecs: ToolSpec[] = [
       if (ctx.verbose) {
         const state = await fullDocState(memexId, before.id);
         const url = await ctx.workspaceUrl(memexId);
-        // spec-203 dec-3 (t-3): tag summary + transition nudge are footer-zone
-        // blocks, placed after the machine footer by the composer (same order).
-        return await formatState(url, state, ctx, [
-          { zone: "footer", content: tagSuffix },
-          { zone: "footer", content: nudge },
-        ]);
+        // spec-219 dec-3 (t-3): park the tag summary + transition nudge in the
+        // footer slot; the single seat folds them into the footer (after the
+        // delimiter, so they persist to footer_text — they never did while they
+        // rode the body). The handler keeps its own reads.
+        if (ctx.footerSlot) ctx.footerSlot.content = `${tagSuffix}${nudge}`;
+        return await formatState(url, state, ctx);
       }
       const fresh = await getDoc(memexId, before.id);
       // Per dec-1: on a status change include the deterministic phase header so
@@ -3152,16 +3248,13 @@ export const toolSpecs: ToolSpec[] = [
         const fresh = await getTask(memexId, taskUuid);
         const state = await fullDocState(memexId, fresh.docId);
         const url = await ctx.workspaceUrl(memexId);
-        // spec-203 dec-3 (t-3): the completion nudge is a footer-zone block,
-        // present only when the task was completed.
-        return await formatState(
-          url,
-          state,
-          ctx,
-          status === "complete"
-            ? [{ zone: "footer", content: `\n\n> ${COMPLETION_NUDGE}` }]
-            : [],
-        );
+        // spec-219 dec-3 (t-3): park the completion nudge in the footer slot
+        // (only when the task was completed); the seat folds it into the footer,
+        // past the delimiter, so it persists to footer_text.
+        if (status === "complete" && ctx.footerSlot) {
+          ctx.footerSlot.content = `> ${COMPLETION_NUDGE}`;
+        }
+        return await formatState(url, state, ctx);
       }
 
       if (messages.length === 0) {
@@ -3612,10 +3705,10 @@ export const toolSpecs: ToolSpec[] = [
       if (ctx.verbose) {
         const state = await fullDocState(memexId, doc.id);
         const url = await ctx.workspaceUrl(memexId);
-        // spec-203 dec-3 (t-3): the transition nudge is a footer-zone block.
-        return await formatState(url, state, ctx, [
-          { zone: "footer", content: nudge },
-        ]);
+        // spec-219 dec-3 (t-3): park the transition nudge in the footer slot; the
+        // seat folds it into the footer, past the delimiter, so it persists.
+        if (ctx.footerSlot) ctx.footerSlot.content = nudge;
+        return await formatState(url, state, ctx);
       }
       const fresh = await getDoc(memexId, doc.id);
       // Per dec-1 / t-8: replace the best-effort `nudge` with the deterministic

--- a/packages/server/src/mcp/formatters.handoff-essence.spec-203.test.ts
+++ b/packages/server/src/mcp/formatters.handoff-essence.spec-203.test.ts
@@ -11,10 +11,11 @@
 import { describe, it, expect } from "vitest";
 import { tagAc } from "@memex-ai-ac/vitest";
 // spec-203 ac-15: the footer is no longer composed inside formatFullDocState —
-// the single seat `decideFooter` authors it via the exported `formatSpecGuidance`
-// composer. These tests exercise that composer directly (the footer content is
-// unchanged); the seat + choke-point delivery is covered by the integration
-// tests in services/spec-footer-on-terse.integration.test.ts.
+// the single seat `composeGuidanceEnvelope` (spec-219) authors it via the
+// exported `formatSpecGuidance` / `formatSpecGuidanceBody` composer. These tests
+// exercise that composer directly (the footer content is unchanged); the seat +
+// choke-point delivery is covered by the integration tests in
+// services/spec-203-footer.integration.test.ts.
 import { formatSpecGuidance } from "./formatters.js";
 import { FOOTER_DELIMITER } from "./footer-delimiter.js";
 import type { Doc, DocSection } from "../db/schema.js";

--- a/packages/server/src/mcp/formatters.ts
+++ b/packages/server/src/mcp/formatters.ts
@@ -1050,11 +1050,34 @@ export function renderAcNagFooter(
   return lines.join("\n");
 }
 
-// spec-203 ac-15: exported so the single footer seat (`decideFooter`) can author
-// the FULL phase footer through this composer when it chooses to. It is a pure
-// helper the seat invokes — the seat remains the sole author/decider; no other
-// code path composes a footer. `formatFullDocState` no longer calls it (the body
-// carries no footer of its own).
+// spec-203 ac-15 / spec-219 ac-6: exported so the single footer seat
+// (`composeGuidanceEnvelope`) can author the FULL phase footer through this
+// composer. The seat remains the sole author/decider; no other code path
+// composes a footer. `formatFullDocState` no longer calls it (the body carries
+// no footer of its own).
+//
+// spec-219 ac-6/ac-7: `formatSpecGuidanceBody` returns the DELIMITER-LESS footer
+// body — the single `FOOTER_DELIMITER` is owned by the choke point
+// (`runToolWithSpecTraffic`), which writes it exactly once when it assembles
+// `header + body + FOOTER_DELIMITER + footer`. The seat returns this body as the
+// `footer` of its envelope. `formatSpecGuidance` is kept as a thin wrapper that
+// prefixes the one delimiter, preserving its self-contained contract for direct
+// callers/tests (returns `null`-free, leads with the delimiter for a Spec).
+export function formatSpecGuidanceBody(
+  doc: Doc,
+  decs: Decision[],
+  tasksList: TaskWithBlockers[],
+  nudge?: NudgeContext,
+  acVerifications?: AcWithVerification[],
+): string | null {
+  if (doc.docType === "spec") {
+    const phase = phaseFromStatus(doc.status);
+    if (phase)
+      return renderSpecPhaseGuidance(doc, phase, decs, tasksList, nudge, acVerifications);
+  }
+  return null;
+}
+
 export function formatSpecGuidance(
   doc: Doc,
   decs: Decision[],
@@ -1062,11 +1085,8 @@ export function formatSpecGuidance(
   nudge?: NudgeContext,
   acVerifications?: AcWithVerification[],
 ): string {
-  if (doc.docType === "spec") {
-    const phase = phaseFromStatus(doc.status);
-    if (phase)
-      return renderSpecPhaseGuidance(doc, phase, decs, tasksList, nudge, acVerifications);
-  }
+  const body = formatSpecGuidanceBody(doc, decs, tasksList, nudge, acVerifications);
+  if (body !== null) return `${FOOTER_DELIMITER}\n${body}`;
   return formatLegacyDataShapeGuidance(doc, decs, tasksList);
 }
 
@@ -1092,11 +1112,11 @@ function renderSpecPhaseGuidance(
   nudge?: NudgeContext,
   acVerifications?: AcWithVerification[],
 ): string {
-  // spec-203 dec-3: the footer boundary. Replaces the ambiguous markdown `---`
-  // with the single FOOTER_DELIMITER constant so the platform footer is
-  // machine-separable from the tool's real output (audit trail) and visibly
-  // marked for the agent. One knob — see footer-delimiter.ts.
-  const lines: string[] = [FOOTER_DELIMITER];
+  // spec-219 ac-6/ac-7: the footer body is DELIMITER-LESS. The single
+  // FOOTER_DELIMITER (spec-203 dec-3) is no longer emitted here — the choke
+  // point owns it and writes it exactly once between body and footer. See
+  // formatSpecGuidanceBody / runToolWithSpecTraffic.
+  const lines: string[] = [];
   const openDecs = decs.filter((d) => d.status === "open");
   const resolvedDecs = decs.filter((d) => d.status === "resolved");
   const ready = tasksList.filter((t) => !t.blocked && t.status === "not_started");

--- a/packages/server/src/services/spec-219-envelope.integration.test.ts
+++ b/packages/server/src/services/spec-219-envelope.integration.test.ts
@@ -1,0 +1,233 @@
+// spec-219 ac-6 / ac-7 — the platform guidance is composed as a single ENVELOPE
+// by one seat (`composeGuidanceEnvelope`), and the choke point
+// (`runToolWithSpecTraffic`) assembles `header + body + FOOTER_DELIMITER + footer`
+// — owning the single delimiter and writing it exactly once.
+//
+// ac-6: the seat returns `{ header?, footer? }` (delimiter-LESS content) and is
+//       the sole composer; `formatFullDocState` composes neither.
+// ac-7: the assembled response carries the body, then the one delimiter, then the
+//       footer — the delimiter is owned by the choke point, not the body.
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { eq, inArray } from "drizzle-orm";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { db } from "../db/connection.js";
+import {
+  memexes,
+  namespaces,
+  orgs,
+  orgMemberships,
+  documents,
+  decisions,
+  tasks,
+  users,
+} from "../db/schema.js";
+import { createMcpServer } from "../mcp/tools.js";
+import { createDocDraft } from "./documents.js";
+import { composeGuidanceEnvelope } from "../agent/tool-specs.js";
+import type { ToolCtx } from "../agent/tool-specs.js";
+import { FOOTER_DELIMITER, splitToolResult } from "../mcp/footer-delimiter.js";
+
+const AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-219/acs/ac-${n}`;
+
+const created = { users: [] as string[], memexes: [] as string[], docs: [] as string[] };
+
+afterAll(async () => {
+  if (created.docs.length) {
+    await db.delete(tasks).where(inArray(tasks.docId, created.docs)).catch(() => {});
+    await db.delete(decisions).where(inArray(decisions.docId, created.docs)).catch(() => {});
+    await db.delete(documents).where(inArray(documents.id, created.docs)).catch(() => {});
+  }
+  if (created.memexes.length)
+    await db.delete(memexes).where(inArray(memexes.id, created.memexes)).catch(() => {});
+  if (created.users.length)
+    await db.delete(users).where(inArray(users.id, created.users)).catch(() => {});
+});
+
+async function setupActor(prefix: string) {
+  const sub = `${prefix}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`.toLowerCase();
+  const [u] = await db.insert(users).values({ email: `${sub}@memex.ai` } as any).returning();
+  created.users.push(u.id);
+  const [ns] = await db.insert(namespaces).values({ slug: sub, kind: "org" }).returning();
+  const [org] = await db.insert(orgs).values({ namespaceId: ns.id, name: `Test ${sub}` }).returning();
+  await db.update(namespaces).set({ ownerOrgId: org.id }).where(eq(namespaces.id, ns.id));
+  const [a] = await db.insert(memexes).values({ namespaceId: ns.id, slug: "main", name: `Test ${sub}` }).returning();
+  created.memexes.push(a.id);
+  await db.insert(orgMemberships).values({ userId: u.id, orgId: org.id, role: "administrator" });
+  return { user: u, memexId: a.id, nsSlug: ns.slug };
+}
+
+interface ToolResult { isError?: boolean; content: Array<{ type: string; text: string }> }
+interface RegisteredToolLike {
+  handler: (args: Record<string, unknown>, extra: unknown) => Promise<ToolResult> | ToolResult;
+}
+
+async function callTool(
+  userId: string,
+  name: string,
+  args: Record<string, unknown>,
+): Promise<ToolResult> {
+  const server = createMcpServer(userId);
+  const registry = (server as unknown as { _registeredTools: Record<string, RegisteredToolLike> })._registeredTools;
+  const tool = registry[name];
+  if (!tool) throw new Error(`Tool not registered: ${name}`);
+  return await tool.handler(args, {} as unknown);
+}
+
+const textOf = (res: ToolResult) => res.content.map((c) => c.text).join("\n");
+
+async function buildSpec(title: string): Promise<{ id: string; ref: string }> {
+  const doc = await createDocDraft(actor.memexId, title, "Purpose.", "spec");
+  created.docs.push(doc.id);
+  await db.update(documents).set({ status: "build" }).where(eq(documents.id, doc.id));
+  return { id: doc.id, ref: `${actor.nsSlug}/main/specs/${doc.handle}` };
+}
+
+let actor: Awaited<ReturnType<typeof setupActor>>;
+beforeAll(async () => {
+  actor = await setupActor("spec219-envelope");
+});
+
+describe("ac-6 — the seat composes an ENVELOPE { header?, footer? }, delimiter-less", () => {
+  it("composeGuidanceEnvelope returns an object whose footer carries no FOOTER_DELIMITER", async () => {
+    tagAc(AC(6));
+    const { id } = await buildSpec("Envelope Object Spec");
+
+    // Terse call (verbose:false) — the lean build-loop steer. The seat reads no
+    // other ctx field on this path, so a minimal ctx is faithful.
+    const env = await composeGuidanceEnvelope(actor.memexId, id, {
+      verbose: false,
+    } as unknown as ToolCtx);
+
+    // It is an envelope OBJECT, not a raw footer string.
+    expect(env).toBeTypeOf("object");
+    expect(Array.isArray(env)).toBe(false);
+    // Header is a get_doc-verbose concern (centralized in t-2); absent here.
+    expect(env.header).toBeUndefined();
+    // The footer body is present but DELIMITER-LESS — the choke point owns the
+    // single delimiter.
+    expect(env.footer).toBeTruthy();
+    expect(env.footer).not.toContain(FOOTER_DELIMITER);
+    expect(env.footer).toMatch(/BUILD handoff/);
+  });
+
+  it("returns an empty envelope for a non-Spec target (nothing to compose)", async () => {
+    tagAc(AC(6));
+    const doc = await createDocDraft(actor.memexId, "A plain document", "Body.", "document");
+    created.docs.push(doc.id);
+    const env = await composeGuidanceEnvelope(actor.memexId, doc.id, {
+      verbose: false,
+    } as unknown as ToolCtx);
+    expect(env.header).toBeUndefined();
+    expect(env.footer).toBeUndefined();
+  });
+});
+
+describe("ac-7 — the choke point assembles body + FOOTER_DELIMITER + footer", () => {
+  it("a Spec-resolving tool response carries the delimiter exactly once, body before / footer after", async () => {
+    tagAc(AC(7));
+    const { ref } = await buildSpec("Assembled Order Spec");
+
+    const res = await callTool(actor.user.id, "get_doc", { ref });
+    const text = res.content.map((c) => c.text).join("\n");
+
+    // The single delimiter is written exactly once (owned by the choke point).
+    expect(text.split(FOOTER_DELIMITER).length - 1).toBe(1);
+
+    const idx = text.indexOf(FOOTER_DELIMITER);
+    expect(idx).toBeGreaterThan(0); // real tool output (body) precedes the delimiter
+
+    const { body, footer } = splitToolResult(text);
+    expect(body.length).toBeGreaterThan(0);
+    expect(body).not.toContain(FOOTER_DELIMITER); // body is delimiter-less
+    expect(footer).toMatch(/BUILD handoff/); // footer sits after the delimiter
+  });
+});
+
+describe("ac-1 — all platform guidance is composed in ONE place, addressed by (tool, phase, live state)", () => {
+  it("the envelope is assembled once per response and varies by tool and by phase", async () => {
+    tagAc(AC(1));
+    const { id, ref } = await buildSpec("One-Place Addressed Spec");
+    await callTool(actor.user.id, "create_ac", { ref, kind: "scope", statement: "An outcome." });
+
+    const build = textOf(await callTool(actor.user.id, "get_doc", { ref, verbose: true }));
+    // ONE composed envelope (a single delimiter), header above + footer below.
+    expect(build.split(FOOTER_DELIMITER).length - 1).toBe(1);
+    // Addressed by TOOL: get_doc carries the coverage header …
+    expect(build).toContain("**AC coverage:**");
+    // … addressed by LIVE STATE (phase): build surfaces the BUILD handoff.
+    expect(splitToolResult(build).footer).toMatch(/BUILD handoff/);
+
+    // Addressed by TOOL: list_acs on the same Spec/phase gets no header.
+    const list = textOf(await callTool(actor.user.id, "list_acs", { ref, verbose: true }));
+    expect(list).not.toContain("**AC coverage:**");
+
+    // Addressed by LIVE STATE: move the phase, the footer changes accordingly.
+    await db.update(documents).set({ status: "verify" }).where(eq(documents.id, id));
+    const verifyFooter =
+      splitToolResult(textOf(await callTool(actor.user.id, "get_doc", { ref, verbose: true }))).footer ?? "";
+    expect(verifyFooter).not.toMatch(/BUILD handoff/);
+  });
+});
+
+describe("ac-10 — the coverage header is verbose + get_doc only, no header delimiter", () => {
+  it("verbose get_doc on a Spec with active ACs prepends **AC coverage:** above the body", async () => {
+    tagAc(AC(10));
+    const { ref } = await buildSpec("Coverage Header Spec");
+    await callTool(actor.user.id, "create_ac", {
+      ref,
+      kind: "scope",
+      statement: "A checkable outcome.",
+    });
+
+    const res = await callTool(actor.user.id, "get_doc", { ref, verbose: true });
+    const text = res.content.map((c) => c.text).join("\n");
+
+    expect(text).toContain("**AC coverage:**");
+    // The header sits ABOVE the doc body (before the title) ...
+    const hdr = text.indexOf("**AC coverage:**");
+    const title = text.indexOf("# Coverage Header Spec");
+    expect(hdr).toBeGreaterThanOrEqual(0);
+    expect(title).toBeGreaterThan(hdr);
+    // ... in the body region (not inside the footer), and carries no delimiter of
+    // its own — the only delimiter present is the single footer one.
+    const { body } = splitToolResult(text);
+    expect(body).toContain("**AC coverage:**");
+    expect(text.split(FOOTER_DELIMITER).length - 1).toBe(1);
+  });
+
+  it("verbose get_doc on a Spec with NO active ACs emits no coverage header", async () => {
+    tagAc(AC(10));
+    const { ref } = await buildSpec("No ACs Spec");
+    const res = await callTool(actor.user.id, "get_doc", { ref, verbose: true });
+    const text = res.content.map((c) => c.text).join("\n");
+    expect(text).not.toContain("**AC coverage:**");
+  });
+
+  it("the header is get_doc-only: another verbose tool on the same Spec gets no coverage header", async () => {
+    tagAc(AC(10));
+    const { ref } = await buildSpec("Tool-Gated Header Spec");
+    await callTool(actor.user.id, "create_ac", {
+      ref,
+      kind: "scope",
+      statement: "Another outcome.",
+    });
+    const res = await callTool(actor.user.id, "list_acs", { ref, verbose: true });
+    const text = res.content.map((c) => c.text).join("\n");
+    expect(text).not.toContain("**AC coverage:**");
+  });
+
+  it("the header is verbose-only: terse get_doc emits no coverage header", async () => {
+    tagAc(AC(10));
+    const { ref } = await buildSpec("Terse No Header Spec");
+    await callTool(actor.user.id, "create_ac", {
+      ref,
+      kind: "scope",
+      statement: "Yet another outcome.",
+    });
+    const res = await callTool(actor.user.id, "get_doc", { ref }); // terse
+    const text = res.content.map((c) => c.text).join("\n");
+    expect(text).not.toContain("**AC coverage:**");
+  });
+});

--- a/packages/server/src/services/spec-219-footer-slot.integration.test.ts
+++ b/packages/server/src/services/spec-219-footer-slot.integration.test.ts
@@ -1,0 +1,178 @@
+// spec-219 ac-8 / ac-9 — the footer SLOT: a handler parks its dynamic footer
+// nugget in a stable ctx slot; the single seat folds it into the footer, so it
+// lands AFTER the delimiter and is persisted to mcp_tool_calls.footer_text.
+//
+// ac-8: the handler hands the seat its dynamic footer content via the slot; the
+//       seat composes it; the handler keeps its own DB read/write.
+// ac-9: the parked string lands after FOOTER_DELIMITER and is captured in
+//       mcp_tool_calls.footer_text by the telemetry split (it never was while
+//       the nudge rode the body, before the delimiter).
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { eq, inArray, desc } from "drizzle-orm";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { db } from "../db/connection.js";
+import {
+  memexes,
+  namespaces,
+  orgs,
+  orgMemberships,
+  documents,
+  decisions,
+  tasks,
+  users,
+  mcpToolCalls,
+  mcpSessions,
+} from "../db/schema.js";
+import { createMcpServer } from "../mcp/tools.js";
+import { createDocDraft } from "./documents.js";
+import { COMPLETION_NUDGE } from "../agent/tool-specs.js";
+import { FOOTER_DELIMITER, splitToolResult } from "../mcp/footer-delimiter.js";
+
+const AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-219/acs/ac-${n}`;
+
+const created = { users: [] as string[], memexes: [] as string[], docs: [] as string[] };
+
+afterAll(async () => {
+  if (created.docs.length) {
+    await db.delete(tasks).where(inArray(tasks.docId, created.docs)).catch(() => {});
+    await db.delete(decisions).where(inArray(decisions.docId, created.docs)).catch(() => {});
+    await db.delete(documents).where(inArray(documents.id, created.docs)).catch(() => {});
+  }
+  if (created.memexes.length)
+    await db.delete(memexes).where(inArray(memexes.id, created.memexes)).catch(() => {});
+  if (created.users.length)
+    await db.delete(users).where(inArray(users.id, created.users)).catch(() => {});
+});
+
+async function setupActor(prefix: string) {
+  const sub = `${prefix}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`.toLowerCase();
+  const [u] = await db.insert(users).values({ email: `${sub}@memex.ai` } as any).returning();
+  created.users.push(u.id);
+  const [ns] = await db.insert(namespaces).values({ slug: sub, kind: "org" }).returning();
+  const [org] = await db.insert(orgs).values({ namespaceId: ns.id, name: `Test ${sub}` }).returning();
+  await db.update(namespaces).set({ ownerOrgId: org.id }).where(eq(namespaces.id, ns.id));
+  const [a] = await db.insert(memexes).values({ namespaceId: ns.id, slug: "main", name: `Test ${sub}` }).returning();
+  created.memexes.push(a.id);
+  await db.insert(orgMemberships).values({ userId: u.id, orgId: org.id, role: "administrator" });
+  return { user: u, memexId: a.id, nsSlug: ns.slug };
+}
+
+interface ToolResult { isError?: boolean; content: Array<{ type: string; text: string }> }
+interface RegisteredToolLike {
+  handler: (args: Record<string, unknown>, extra: unknown) => Promise<ToolResult> | ToolResult;
+}
+
+async function callTool(
+  userId: string,
+  name: string,
+  args: Record<string, unknown>,
+  sessionId?: string,
+): Promise<ToolResult> {
+  const server = createMcpServer(userId, undefined, sessionId);
+  const registry = (server as unknown as { _registeredTools: Record<string, RegisteredToolLike> })._registeredTools;
+  const tool = registry[name];
+  if (!tool) throw new Error(`Tool not registered: ${name}`);
+  return await tool.handler(args, {} as unknown);
+}
+
+async function pollFooter(sessionId: string): Promise<string | null | undefined> {
+  for (let i = 0; i < 40; i++) {
+    const [row] = await db
+      .select({ footerText: mcpToolCalls.footerText })
+      .from(mcpToolCalls)
+      .where(eq(mcpToolCalls.sessionId, sessionId))
+      .orderBy(desc(mcpToolCalls.createdAt))
+      .limit(1);
+    if (row?.footerText) return row.footerText;
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  return undefined;
+}
+
+async function buildSpecWithTask(title: string): Promise<{ specRef: string; taskRef: string }> {
+  const doc = await createDocDraft(actor.memexId, title, "Purpose.", "spec");
+  created.docs.push(doc.id);
+  await db.update(documents).set({ status: "build" }).where(eq(documents.id, doc.id));
+  const specRef = `${actor.nsSlug}/main/specs/${doc.handle}`;
+  await callTool(actor.user.id, "create_task", {
+    ref: specRef,
+    title: "A unit of work",
+    description: "Delivers something checkable.",
+  });
+  const task = await db.query.tasks.findFirst({ where: eq(tasks.docId, doc.id) });
+  const taskRef = `${specRef}/tasks/t-${task!.seq}`;
+  return { specRef, taskRef };
+}
+
+let actor: Awaited<ReturnType<typeof setupActor>>;
+beforeAll(async () => {
+  actor = await setupActor("spec219-slot");
+});
+
+describe("ac-9 — the parked nugget lands after the delimiter and persists", () => {
+  it("verbose update_task(complete) puts the completion nudge in the footer, not the body", async () => {
+    tagAc(AC(9));
+    const { taskRef } = await buildSpecWithTask("Slot Placement Spec");
+
+    const res = await callTool(actor.user.id, "update_task", {
+      ref: taskRef,
+      status: "complete",
+      verbose: true,
+    });
+    const text = res.content.map((c) => c.text).join("\n");
+
+    const { body, footer } = splitToolResult(text);
+    // The nugget moved OUT of the body and now rides the footer (past the delimiter).
+    expect(body).not.toContain(COMPLETION_NUDGE);
+    expect(footer).toContain(COMPLETION_NUDGE);
+  });
+
+  it("the completion nudge is captured in mcp_tool_calls.footer_text", async () => {
+    tagAc(AC(9));
+    const { taskRef } = await buildSpecWithTask("Slot Persistence Spec");
+
+    const sessionId = `s219-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 7)}`;
+    await db.insert(mcpSessions).values({ sessionId, userId: actor.user.id });
+
+    const res = await callTool(
+      actor.user.id,
+      "update_task",
+      { ref: taskRef, status: "complete", verbose: true },
+      sessionId,
+    );
+    const emitted = splitToolResult(res.content.map((c) => c.text).join("\n")).footer;
+    expect(emitted).toContain(COMPLETION_NUDGE);
+
+    const persisted = await pollFooter(sessionId);
+    expect(persisted).toBeTruthy();
+    expect(persisted).toContain(COMPLETION_NUDGE);
+  });
+});
+
+describe("ac-8 — a handler hands the seat its dynamic footer content via the slot", () => {
+  it("verbose update_doc tagging routes the tag summary through the slot into the footer", async () => {
+    tagAc(AC(8));
+    const doc = await createDocDraft(actor.memexId, "Slot Tag Spec", "Purpose.", "spec");
+    created.docs.push(doc.id);
+    await db.update(documents).set({ status: "build" }).where(eq(documents.id, doc.id));
+    const ref = `${actor.nsSlug}/main/specs/${doc.handle}`;
+
+    const res = await callTool(actor.user.id, "update_doc", {
+      ref,
+      tags: ["priority::high"],
+      verbose: true,
+    });
+    const text = res.content.map((c) => c.text).join("\n");
+
+    // The handler did its OWN tag write/read and parked the resulting summary in
+    // the slot; the seat folded it into the footer (after the delimiter).
+    const { footer } = splitToolResult(text);
+    expect(footer).toContain("tagged priority::high");
+    // And the handler's write actually landed (its read/mutation stayed in the
+    // handler — the seat only composed the string).
+    const fresh = await db.query.documents.findFirst({ where: eq(documents.id, doc.id) });
+    expect(fresh).toBeTruthy();
+  });
+});

--- a/packages/server/src/services/spec-219-org-overlay.integration.test.ts
+++ b/packages/server/src/services/spec-219-org-overlay.integration.test.ts
@@ -1,0 +1,138 @@
+// spec-219 ac-4 — the org_scaffold_additions tenant overlay is honoured
+// unchanged: same targeting/scoping, appended in the footer exactly as today.
+// The centralization (one seat) must not alter tenant overlays — the seat still
+// threads ctx.getOrgBlocksForNudge() → toNudge, so an enabled Org block still
+// rides the footer.
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { eq, inArray } from "drizzle-orm";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { db } from "../db/connection.js";
+import {
+  memexes,
+  namespaces,
+  orgs,
+  orgMemberships,
+  documents,
+  decisions,
+  tasks,
+  users,
+  orgScaffoldAdditions,
+} from "../db/schema.js";
+import { createMcpServer } from "../mcp/tools.js";
+import { createDocDraft } from "./documents.js";
+import { createOrgScaffoldAddition } from "./scaffold-additions.js";
+import { FOOTER_DELIMITER, splitToolResult } from "../mcp/footer-delimiter.js";
+
+const AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-219/acs/ac-${n}`;
+
+const created = {
+  users: [] as string[],
+  memexes: [] as string[],
+  docs: [] as string[],
+  scaffolds: [] as string[],
+};
+
+afterAll(async () => {
+  if (created.scaffolds.length)
+    await db.delete(orgScaffoldAdditions).where(inArray(orgScaffoldAdditions.id, created.scaffolds)).catch(() => {});
+  if (created.docs.length) {
+    await db.delete(tasks).where(inArray(tasks.docId, created.docs)).catch(() => {});
+    await db.delete(decisions).where(inArray(decisions.docId, created.docs)).catch(() => {});
+    await db.delete(documents).where(inArray(documents.id, created.docs)).catch(() => {});
+  }
+  if (created.memexes.length)
+    await db.delete(memexes).where(inArray(memexes.id, created.memexes)).catch(() => {});
+  if (created.users.length)
+    await db.delete(users).where(inArray(users.id, created.users)).catch(() => {});
+});
+
+async function setupActor(prefix: string) {
+  const sub = `${prefix}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`.toLowerCase();
+  const [u] = await db.insert(users).values({ email: `${sub}@memex.ai` } as any).returning();
+  created.users.push(u.id);
+  const [ns] = await db.insert(namespaces).values({ slug: sub, kind: "org" }).returning();
+  const [org] = await db.insert(orgs).values({ namespaceId: ns.id, name: `Test ${sub}` }).returning();
+  await db.update(namespaces).set({ ownerOrgId: org.id }).where(eq(namespaces.id, ns.id));
+  const [a] = await db.insert(memexes).values({ namespaceId: ns.id, slug: "main", name: `Test ${sub}` }).returning();
+  created.memexes.push(a.id);
+  await db.insert(orgMemberships).values({ userId: u.id, orgId: org.id, role: "administrator" });
+  return { user: u, orgId: org.id, memexId: a.id, nsSlug: ns.slug };
+}
+
+interface ToolResult { isError?: boolean; content: Array<{ type: string; text: string }> }
+interface RegisteredToolLike {
+  handler: (args: Record<string, unknown>, extra: unknown) => Promise<ToolResult> | ToolResult;
+}
+
+async function callTool(userId: string, name: string, args: Record<string, unknown>): Promise<ToolResult> {
+  const server = createMcpServer(userId);
+  const registry = (server as unknown as { _registeredTools: Record<string, RegisteredToolLike> })._registeredTools;
+  const tool = registry[name];
+  if (!tool) throw new Error(`Tool not registered: ${name}`);
+  return await tool.handler(args, {} as unknown);
+}
+
+let actor: Awaited<ReturnType<typeof setupActor>>;
+beforeAll(async () => {
+  actor = await setupActor("spec219-org");
+});
+
+describe("ac-4 — org_scaffold_additions tenant overlay honoured unchanged", () => {
+  it("an enabled Org block still rides the footer (same targeting, in the footer region)", async () => {
+    tagAc(AC(4));
+    const sentinel = `ORG-OVERLAY-${Math.random().toString(36).slice(2, 10)}`;
+    // Phase-agnostic target ({}) — matches every phase, exactly as a tenant-wide
+    // scaffold addition does in production.
+    const block = await createOrgScaffoldAddition({
+      orgId: actor.orgId,
+      authorId: actor.user.id,
+      target: {},
+      text: sentinel,
+      rationale: "spec-219 ac-4 fixture — tenant overlay must survive centralization.",
+      enabled: true,
+    });
+    created.scaffolds.push(block.id);
+
+    const doc = await createDocDraft(actor.memexId, "Org Overlay Spec", "Purpose.", "spec");
+    created.docs.push(doc.id);
+    await db.update(documents).set({ status: "build" }).where(eq(documents.id, doc.id));
+    const ref = `${actor.nsSlug}/main/specs/${doc.handle}`;
+
+    const res = await callTool(actor.user.id, "get_doc", { ref, verbose: true });
+    const text = res.content.map((c) => c.text).join("\n");
+
+    // Honoured: the overlay rides the FOOTER (past the delimiter), not the body.
+    const { body, footer } = splitToolResult(text);
+    expect(footer).toContain(sentinel);
+    expect(body).not.toContain(sentinel);
+    // Not doubled by the centralization — exactly one occurrence.
+    expect(text.split(sentinel).length - 1).toBe(1);
+    // Sanity: there is a real footer region to ride.
+    expect(text).toContain(FOOTER_DELIMITER);
+  });
+
+  it("a disabled Org block does NOT leak into the footer (scoping unchanged)", async () => {
+    tagAc(AC(4));
+    const sentinel = `ORG-DISABLED-${Math.random().toString(36).slice(2, 10)}`;
+    const block = await createOrgScaffoldAddition({
+      orgId: actor.orgId,
+      authorId: actor.user.id,
+      target: {},
+      text: sentinel,
+      rationale: "spec-219 ac-4 fixture — disabled overlay must stay off the footer.",
+      enabled: false,
+    });
+    created.scaffolds.push(block.id);
+
+    const doc = await createDocDraft(actor.memexId, "Org Disabled Overlay Spec", "Purpose.", "spec");
+    created.docs.push(doc.id);
+    await db.update(documents).set({ status: "build" }).where(eq(documents.id, doc.id));
+    const ref = `${actor.nsSlug}/main/specs/${doc.handle}`;
+
+    const res = await callTool(actor.user.id, "get_doc", { ref, verbose: true });
+    const text = res.content.map((c) => c.text).join("\n");
+    expect(text).not.toContain(sentinel);
+  });
+});

--- a/packages/server/src/services/spec-219-transition-keyed.integration.test.ts
+++ b/packages/server/src/services/spec-219-transition-keyed.integration.test.ts
@@ -1,0 +1,180 @@
+// spec-219 ac-11 / ac-12 / ac-5 — the footer is TRANSITION-keyed (per-tool), the
+// seat owns steering while handlers own result-reporting, and the seat never
+// echoes a handler's slot nugget.
+//
+// ac-11: two different tools resolving the same Spec in the same phase can
+//        produce different footers (the seat's per-tool steer registry).
+// ac-12: the seat's footer does not echo a handler's result nugget for the same
+//        call — no duplication.
+// ac-5:  the per-tool nudge notion is preserved and centralized: the steer is
+//        authored by the one seat (rides the footer), not a scattered handler.
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { eq, inArray } from "drizzle-orm";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { db } from "../db/connection.js";
+import {
+  memexes,
+  namespaces,
+  orgs,
+  orgMemberships,
+  documents,
+  decisions,
+  tasks,
+  users,
+} from "../db/schema.js";
+import { createMcpServer } from "../mcp/tools.js";
+import { createDocDraft } from "./documents.js";
+import { COMPLETION_NUDGE } from "../agent/tool-specs.js";
+import { splitToolResult } from "../mcp/footer-delimiter.js";
+
+const AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-219/acs/ac-${n}`;
+
+// A distinctive fragment of the update_section steer (STEER_BY_TOOL).
+const SECTION_STEER = "capture it with create_decision";
+
+const created = { users: [] as string[], memexes: [] as string[], docs: [] as string[] };
+
+afterAll(async () => {
+  if (created.docs.length) {
+    await db.delete(tasks).where(inArray(tasks.docId, created.docs)).catch(() => {});
+    await db.delete(decisions).where(inArray(decisions.docId, created.docs)).catch(() => {});
+    await db.delete(documents).where(inArray(documents.id, created.docs)).catch(() => {});
+  }
+  if (created.memexes.length)
+    await db.delete(memexes).where(inArray(memexes.id, created.memexes)).catch(() => {});
+  if (created.users.length)
+    await db.delete(users).where(inArray(users.id, created.users)).catch(() => {});
+});
+
+async function setupActor(prefix: string) {
+  const sub = `${prefix}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`.toLowerCase();
+  const [u] = await db.insert(users).values({ email: `${sub}@memex.ai` } as any).returning();
+  created.users.push(u.id);
+  const [ns] = await db.insert(namespaces).values({ slug: sub, kind: "org" }).returning();
+  const [org] = await db.insert(orgs).values({ namespaceId: ns.id, name: `Test ${sub}` }).returning();
+  await db.update(namespaces).set({ ownerOrgId: org.id }).where(eq(namespaces.id, ns.id));
+  const [a] = await db.insert(memexes).values({ namespaceId: ns.id, slug: "main", name: `Test ${sub}` }).returning();
+  created.memexes.push(a.id);
+  await db.insert(orgMemberships).values({ userId: u.id, orgId: org.id, role: "administrator" });
+  return { user: u, memexId: a.id, nsSlug: ns.slug };
+}
+
+interface ToolResult { isError?: boolean; content: Array<{ type: string; text: string }> }
+interface RegisteredToolLike {
+  handler: (args: Record<string, unknown>, extra: unknown) => Promise<ToolResult> | ToolResult;
+}
+
+async function callTool(userId: string, name: string, args: Record<string, unknown>): Promise<ToolResult> {
+  const server = createMcpServer(userId);
+  const registry = (server as unknown as { _registeredTools: Record<string, RegisteredToolLike> })._registeredTools;
+  const tool = registry[name];
+  if (!tool) throw new Error(`Tool not registered: ${name}`);
+  return await tool.handler(args, {} as unknown);
+}
+
+const textOf = (res: ToolResult) => res.content.map((c) => c.text).join("\n");
+
+async function specifySpec(title: string): Promise<{ ref: string; sectionRef: string }> {
+  const doc = await createDocDraft(actor.memexId, title, "Purpose.", "spec");
+  created.docs.push(doc.id);
+  await db.update(documents).set({ status: "specify" }).where(eq(documents.id, doc.id));
+  const ref = `${actor.nsSlug}/main/specs/${doc.handle}`;
+  return { ref, sectionRef: `${ref}/sections/s-1` };
+}
+
+let actor: Awaited<ReturnType<typeof setupActor>>;
+beforeAll(async () => {
+  actor = await setupActor("spec219-transition");
+});
+
+describe("ac-11 — the footer is transition-keyed (per-tool)", () => {
+  it("two tools resolving the same Spec in the same phase produce different footers", async () => {
+    tagAc(AC(11));
+    tagAc(AC(5));
+    const { ref, sectionRef } = await specifySpec("Transition-Keyed Spec");
+
+    // update_section carries the seat's per-tool steer (STEER_BY_TOOL).
+    const sectionRes = await callTool(actor.user.id, "update_section", {
+      ref: sectionRef,
+      content: "Revised overview body.",
+      verbose: true,
+    });
+    const sectionFooter = splitToolResult(textOf(sectionRes)).footer ?? "";
+
+    // get_doc, same Spec, same phase — no per-tool steer registered.
+    const getRes = await callTool(actor.user.id, "get_doc", { ref, verbose: true });
+    const getFooter = splitToolResult(textOf(getRes)).footer ?? "";
+
+    expect(sectionFooter).toContain(SECTION_STEER);
+    expect(getFooter).not.toContain(SECTION_STEER);
+    // Same Spec, same phase, different tool ⇒ different footers.
+    expect(sectionFooter).not.toEqual(getFooter);
+  });
+});
+
+describe("ac-5 — the per-tool steer is authored by the one seat (centralized)", () => {
+  it("the steer rides the footer (after the delimiter), not the tool's body", async () => {
+    tagAc(AC(5));
+    const { sectionRef } = await specifySpec("Centralized Steer Spec");
+    const res = await callTool(actor.user.id, "update_section", {
+      ref: sectionRef,
+      content: "Another revision.",
+      verbose: true,
+    });
+    const { body, footer } = splitToolResult(textOf(res));
+    expect(footer).toContain(SECTION_STEER); // seat-composed, in the footer
+    expect(body).not.toContain(SECTION_STEER); // not in the handler's own body output
+  });
+});
+
+describe("ac-2 — the agent is steered toward the next move (drives the five behaviours)", () => {
+  it("build responses steer toward writing tagged tests; specify update_section steers toward decisions", async () => {
+    tagAc(AC(2));
+    // Build phase with an untested AC → the footer steers toward tests
+    // created/run (the AC nag) — one of the five affirmed behaviours.
+    const doc = await createDocDraft(actor.memexId, "Steer Behaviours Spec", "Purpose.", "spec");
+    created.docs.push(doc.id);
+    await db.update(documents).set({ status: "build" }).where(eq(documents.id, doc.id));
+    const ref = `${actor.nsSlug}/main/specs/${doc.handle}`;
+    await callTool(actor.user.id, "create_ac", { ref, kind: "scope", statement: "An outcome to verify." });
+    const buildFooter = splitToolResult(textOf(await callTool(actor.user.id, "get_doc", { ref }))).footer ?? "";
+    expect(buildFooter).toMatch(/untested acceptance criteri/i);
+
+    // Specify phase: editing a section steers toward capturing decisions — the
+    // "scope + implementation ACs created / decisions resolved" behaviour.
+    const { sectionRef } = await specifySpec("Steer Decisions Spec");
+    const sectionFooter = splitToolResult(
+      textOf(await callTool(actor.user.id, "update_section", { ref: sectionRef, content: "Edited.", verbose: true })),
+    ).footer ?? "";
+    expect(sectionFooter).toContain("create_decision");
+  });
+});
+
+describe("ac-12 — the seat's footer does not echo a handler's result nugget", () => {
+  it("update_task(complete) yields the completion nudge exactly once (no seat echo)", async () => {
+    tagAc(AC(12));
+    const doc = await createDocDraft(actor.memexId, "No-Echo Spec", "Purpose.", "spec");
+    created.docs.push(doc.id);
+    await db.update(documents).set({ status: "build" }).where(eq(documents.id, doc.id));
+    const specRef = `${actor.nsSlug}/main/specs/${doc.handle}`;
+    await callTool(actor.user.id, "create_task", {
+      ref: specRef,
+      title: "Lone task",
+      description: "Delivers something checkable.",
+    });
+    const task = await db.query.tasks.findFirst({ where: eq(tasks.docId, doc.id) });
+
+    const res = await callTool(actor.user.id, "update_task", {
+      ref: `${specRef}/tasks/t-${task!.seq}`,
+      status: "complete",
+      verbose: true,
+    });
+    const text = textOf(res);
+    // The completion nudge is the handler's slot (result-reporting); the seat
+    // registers NO steer for update_task, so it appears exactly once — the seat
+    // never echoes the handler's nugget.
+    expect(text.split(COMPLETION_NUDGE).length - 1).toBe(1);
+  });
+});

--- a/packages/server/src/services/spec-traffic.ts
+++ b/packages/server/src/services/spec-traffic.ts
@@ -142,8 +142,14 @@ export async function runToolWithSpecTraffic(
   ctx: ToolCtx,
 ): Promise<string> {
   let target: { memexId: string; docId: string } | undefined;
+  // spec-219 dec-3 (t-3): the shared footer slot. A handler parks its dynamic
+  // footer nugget here; the seat (`composeGuidanceEnvelope`) reads it back and
+  // folds it into the footer, so it lands AFTER the delimiter and is persisted.
+  // One holder, threaded into the handler's ctx AND handed to the seat below.
+  const footerSlot: { content?: string } = {};
   const wrappedCtx: ToolCtx = {
     ...ctx,
+    footerSlot,
     resolveRef: async (ref) => {
       const result = await ctx.resolveRef(ref);
       target = { memexId: result.memexId, docId: result.doc.id };
@@ -162,22 +168,34 @@ export async function runToolWithSpecTraffic(
     ...target,
   });
 
-  // spec-203 ac-14/ac-15: the ONE place a footer is attached. Every tool call is
-  // the client phoning home; here — and only here — the single seat
-  // (`decideFooter`) takes that opening to steer the client, on EVERY
-  // Spec-resolving response (terse and verbose), never per-tool and never twice.
-  // The seat frames its return with FOOTER_DELIMITER, so the telemetry wrap that
-  // runs after this splits + persists it (ac-17). Guards: only when the call
-  // resolved ONE Spec (`target` set — list/search resolve none), and only when
-  // the body does not already carry a footer (defence-in-depth; the body no
-  // longer composes one). `decideFooter` is imported dynamically to keep this
-  // module free of a runtime cycle with agent/tool-specs.ts (cached after first
-  // use); it never throws, but the guard keeps a footer failure off the result.
+  // spec-203 ac-14/ac-15 + spec-219 ac-6/ac-7: the ONE place the platform
+  // guidance ENVELOPE is attached. Every tool call is the client phoning home;
+  // here — and only here — the single seat (`composeGuidanceEnvelope`) takes that
+  // opening to steer the client, on EVERY Spec-resolving response (terse and
+  // verbose), never per-tool and never twice. The seat returns DELIMITER-LESS
+  // `{ header?, footer? }`; this choke point assembles
+  // `header + body + FOOTER_DELIMITER + footer` — header prepended above the
+  // body, the single FOOTER_DELIMITER owned HERE (written exactly once), footer
+  // after it — so the telemetry wrap that runs after this splits + persists the
+  // footer (ac-17). Guards: only when the call resolved ONE Spec (`target` set —
+  // list/search resolve none), and only when the body does not already carry a
+  // footer (defence-in-depth; the body composes none). `composeGuidanceEnvelope`
+  // is imported dynamically to keep this module free of a runtime cycle with
+  // agent/tool-specs.ts (cached after first use); it never throws, but the guard
+  // keeps a guidance failure off the result.
   if (target && !text.includes(FOOTER_DELIMITER)) {
     try {
-      const { decideFooter } = await import("../agent/tool-specs.js");
-      const footer = await decideFooter(target.memexId, target.docId, ctx);
-      if (footer) return `${text}\n\n${footer}`;
+      const { composeGuidanceEnvelope } = await import("../agent/tool-specs.js");
+      // Pass wrappedCtx — it carries the footerSlot the handler may have parked.
+      const { header, footer } = await composeGuidanceEnvelope(
+        target.memexId,
+        target.docId,
+        wrappedCtx,
+      );
+      let out = text;
+      if (header) out = `${header}${out}`;
+      if (footer) out = `${out}\n\n${FOOTER_DELIMITER}\n${footer}`;
+      return out;
     } catch {
       // swallow — the tool's real result already succeeded.
     }


### PR DESCRIPTION
## Summary

Phase 2 of spec-203 ([Memex spec-219](https://memex.ai/mindset-prod/memex-building-itself/specs/spec-219)). Replaces the decentralized tool-output guidance (a phase-keyed footer, ~10 handler-authored nudges, and a separate `get_doc` header) with a **single seat** — `composeGuidanceEnvelope` — that composes the platform guidance envelope `{ header, footer }` for every Spec-resolving tool response, addressed by `(tool, transition, live state)`.

### What changed
- **The seat (ac-6, ac-7):** `decideFooter` → `composeGuidanceEnvelope` returning `{ header?, footer? }` (delimiter-less). The choke point `runToolWithSpecTraffic` now owns the single `FOOTER_DELIMITER`, assembling `header + body + FOOTER_DELIMITER + footer`.
- **Header centralized (ac-10):** the `get_doc` AC-coverage header moved out of the handler into the seat (verbose && `tool === 'get_doc'`, no header delimiter).
- **Footer slot (ac-8, ac-9):** a stable `ctx.footerSlot` lets a handler park its dynamic nudge; the seat folds it past the delimiter so it now persists to `mcp_tool_calls.footer_text`. The `update_doc` / `update_task` / `publish_spec` footer nudges migrated onto it.
- **Transition-keyed steering (ac-11, ac-12, ac-5):** `STEER_BY_TOOL` — a per-tool steering registry (the one place the T→T+1 map lives), with a no-echo discipline (a tool that parks a slot nudge gets no registry entry).
- **Catalogue + tenant overlay (ac-3, ac-4):** documented keep/drop/change for every guidance item (0 dropped); `org_scaffold_additions` honoured unchanged.
- **Lockstep spec-203 (ac-13):** retired ac-13, softened ac-15, name-fixed ac-7/ac-11; spec-203 stays 17/17 verified.

Output is **byte-identical to develop** for the verbose and terse assembled responses (Phase-1 "mimic"); the situational / read-migration work is Phase 2.

### Test plan
- [x] `tsc --noEmit` clean
- [x] 6 new spec-219 test files (~37 tagged tests) — all **13 spec-219 ACs verified** (emitted to Memex)
- [x] spec-203 guards updated in lockstep — spec-203 **17/17 verified**
- [x] Full server suite green except two **pre-existing** parallel-isolation flakes (`memex-embeddings.integration`, `issue-tools.integration` vector ranking) — both pass in isolation, both byte-identical to develop, neither touched by this PR
- [ ] Reviewer: optional spot-check of the byte-identical claim against a prod footer sample
