### PR TITLE
feat(security): spec-199 t-14 — RLS cutover pre-requisites (share_tokens + runtime creds split)

### DIFF
--- a/packages/server/deploy.sh
+++ b/packages/server/deploy.sh
@@ -157,6 +157,14 @@ sleep 3
 DB_PASS_ENC=$(python3 -c "import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1], safe=''))" "${DB_PASS}")
 DB_URL="postgresql://${DB_USER}:${DB_PASS_ENC}@localhost:${PROXY_PORT}/${DB_NAME}"
 
+# Runtime credentials for Cloud Run (spec-199 t-14). Migrations ALWAYS use the
+# superuser path (DB_USER/DB_PASS) — RUNTIME_DB_* is the restricted memex_app
+# role that RLS enforces on. Defaults to DB_USER/DB_PASS until t-14 is rolled
+# out per environment via RUNTIME_DB_USER/RUNTIME_DB_PASS in the deploy-env secret.
+RUNTIME_DB_USER="${RUNTIME_DB_USER:-$DB_USER}"
+RUNTIME_DB_PASS="${RUNTIME_DB_PASS:-$DB_PASS}"
+RUNTIME_DB_PASS_ENC=$(python3 -c "import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1], safe=''))" "${RUNTIME_DB_PASS}")
+
 echo "  1a. drizzle-kit journal migrations..."
 DATABASE_URL="${DB_URL}" pnpm db:migrate
 
@@ -288,7 +296,7 @@ gcloud run deploy "${SERVICE}" \
   --min-instances 0 \
   --max-instances 3 \
   --add-cloudsql-instances "${CLOUD_SQL_INSTANCE_CONN}" \
-  --update-env-vars "^|^NODE_ENV=production|DATABASE_URL=postgresql://${DB_USER}:${DB_PASS_ENC}@localhost:${DB_PORT}/${DB_NAME}|CLOUD_SQL_SOCKET=/cloudsql/${CLOUD_SQL_INSTANCE_CONN}|GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID}|EMAIL_FROM=${EMAIL_FROM}|APP_BASE_URL=${APP_BASE_URL}|OAUTH_ENABLED=1|SLACK_CLIENT_ID=${SLACK_CLIENT_ID}|SLACK_OAUTH_REDIRECT_URI=${API_BASE_URL}/api/auth/slack/callback|KMS_KEY_NAME=projects/${GCP_PROJECT}/locations/${REGION}/keyRings/memex/cryptoKeys/slack-tokens${HIDDEN_FEATURES+|HIDDEN_FEATURES=${HIDDEN_FEATURES}}${SIGNUP_DOMAIN_ALLOWLIST+|SIGNUP_DOMAIN_ALLOWLIST=${SIGNUP_DOMAIN_ALLOWLIST}}" \
+  --update-env-vars "^|^NODE_ENV=production|DATABASE_URL=postgresql://${RUNTIME_DB_USER}:${RUNTIME_DB_PASS_ENC}@localhost:${DB_PORT}/${DB_NAME}|CLOUD_SQL_SOCKET=/cloudsql/${CLOUD_SQL_INSTANCE_CONN}|GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID}|EMAIL_FROM=${EMAIL_FROM}|APP_BASE_URL=${APP_BASE_URL}|OAUTH_ENABLED=1|SLACK_CLIENT_ID=${SLACK_CLIENT_ID}|SLACK_OAUTH_REDIRECT_URI=${API_BASE_URL}/api/auth/slack/callback|KMS_KEY_NAME=projects/${GCP_PROJECT}/locations/${REGION}/keyRings/memex/cryptoKeys/slack-tokens${HIDDEN_FEATURES+|HIDDEN_FEATURES=${HIDDEN_FEATURES}}${SIGNUP_DOMAIN_ALLOWLIST+|SIGNUP_DOMAIN_ALLOWLIST=${SIGNUP_DOMAIN_ALLOWLIST}}" \
   --update-secrets "${SECRETS_WIRING}"
 
 # ── Done ──────────────────────────────────────────────────────

--- a/packages/server/drizzle/0085_share_tokens_memex_id.sql
+++ b/packages/server/drizzle/0085_share_tokens_memex_id.sql
@@ -1,0 +1,14 @@
+-- spec-199 t-14: share_tokens needs memex_id to bootstrap ALS context on the
+-- public share endpoint (no session middleware, no currentMemexId). Without it,
+-- getSharedDocumentByToken cannot call runWithMemexId before querying RLS-gated
+-- tables, so every valid share link returns 404 under memex_app.
+ALTER TABLE share_tokens
+  ADD COLUMN memex_id uuid REFERENCES memexes(id) ON DELETE CASCADE;
+
+UPDATE share_tokens
+  SET memex_id = documents.memex_id
+  FROM documents
+  WHERE share_tokens.document_id = documents.id;
+
+ALTER TABLE share_tokens
+  ALTER COLUMN memex_id SET NOT NULL;

--- a/packages/server/src/db/connection.ts
+++ b/packages/server/src/db/connection.ts
@@ -71,10 +71,10 @@ export const memexContext = new AsyncLocalStorage<MemexRequestContext>();
  * blocks cross-tenant reads on the restricted role, and the superuser role
  * bypasses RLS unconditionally.
  */
-export function runWithMemexId(
+export function runWithMemexId<T>(
   memexId: string | null | undefined,
-  fn: () => Promise<void>,
-): Promise<void> {
+  fn: () => Promise<T>,
+): Promise<T> {
   if (!memexId) return fn();
   return memexContext.run({ memexId }, fn);
 }

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -1380,6 +1380,9 @@ export const shareTokens = pgTable("share_tokens", {
   documentId: uuid("document_id")
     .notNull()
     .references(() => documents.id, { onDelete: "cascade" }),
+  memexId: uuid("memex_id")
+    .notNull()
+    .references(() => memexes.id, { onDelete: "cascade" }),
   token: text("token").notNull().unique(),
   revoked: boolean("revoked").notNull().default(false),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),

--- a/packages/server/src/services/share-tokens.ts
+++ b/packages/server/src/services/share-tokens.ts
@@ -1,6 +1,6 @@
 import { and, desc, eq } from "drizzle-orm";
 import { randomUUID } from "node:crypto";
-import { db } from "../db/connection.js";
+import { db, runWithMemexId } from "../db/connection.js";
 import {
   shareTokens,
   documents,
@@ -60,7 +60,7 @@ export async function createShareToken(
       const expiresAt = defaultExpiresAt();
       const [created] = await db
         .insert(shareTokens)
-        .values({ documentId, token, createdByUserId, expiresAt })
+        .values({ documentId, memexId, token, createdByUserId, expiresAt })
         .returning();
       return created;
     },
@@ -153,57 +153,63 @@ export async function getSharedDocumentByToken(token: string): Promise<SharedDoc
     throw new ShareTokenError("revoked", "This link has expired");
   }
 
-  const doc = await db.query.documents.findFirst({
-    where: eq(documents.id, tokenRow.documentId),
+  // Bootstrap ALS so RLS policies are satisfied: share_tokens is not RLS-gated
+  // (no memex_id column in the 0081 policy list), so token resolution works
+  // without a context. All subsequent queries hit RLS-protected tables and
+  // require app.memex_id to be set, hence the runWithMemexId wrapper below.
+  return runWithMemexId(tokenRow.memexId, async () => {
+    const doc = await db.query.documents.findFirst({
+      where: eq(documents.id, tokenRow.documentId),
+    });
+    if (!doc) {
+      // Should be impossible via CASCADE, but defensive
+      throw new ShareTokenError("unknown", "Invalid share link");
+    }
+
+    const sections = await db
+      .select()
+      .from(docSections)
+      .where(eq(docSections.docId, doc.id))
+      .orderBy(docSections.seq);
+
+    const memex = await db.query.memexes.findFirst({
+      where: eq(memexes.id, doc.memexId),
+    });
+    const ns = memex
+      ? await db.query.namespaces.findFirst({
+          where: eq(namespaces.id, memex.namespaceId),
+        })
+      : null;
+
+    // Surface all comments on the doc so external commenters see the thread.
+    const comments = await db.query.docComments.findMany({
+      where: eq(docComments.memexId, doc.memexId),
+      orderBy: (c, { asc }) => [asc(c.createdAt)],
+    });
+
+    // Filter to only comments attached to this doc's children (sections/decisions/tasks),
+    // to avoid leaking comments from other docs in the same account.
+    const sectionIds = new Set(sections.map((s) => s.id));
+    const docDecisions = await db.select({ id: decisions.id }).from(decisions).where(eq(decisions.docId, doc.id));
+    const decisionIds = new Set(docDecisions.map((d) => d.id));
+    const docTasks = await db.select({ id: tasks.id }).from(tasks).where(eq(tasks.docId, doc.id));
+    const taskIds = new Set(docTasks.map((w) => w.id));
+
+    const scoped = comments.filter(
+      (c) =>
+        (c.sectionId && sectionIds.has(c.sectionId)) ||
+        (c.decisionId && decisionIds.has(c.decisionId)) ||
+        (c.taskId && taskIds.has(c.taskId))
+    );
+
+    return {
+      doc,
+      sections,
+      namespaceSlug: ns?.slug ?? "",
+      memexName: memex?.name ?? "",
+      comments: scoped,
+    };
   });
-  if (!doc) {
-    // Should be impossible via CASCADE, but defensive
-    throw new ShareTokenError("unknown", "Invalid share link");
-  }
-
-  const sections = await db
-    .select()
-    .from(docSections)
-    .where(eq(docSections.docId, doc.id))
-    .orderBy(docSections.seq);
-
-  const memex = await db.query.memexes.findFirst({
-    where: eq(memexes.id, doc.memexId),
-  });
-  const ns = memex
-    ? await db.query.namespaces.findFirst({
-        where: eq(namespaces.id, memex.namespaceId),
-      })
-    : null;
-
-  // Surface all comments on the doc so external commenters see the thread.
-  const comments = await db.query.docComments.findMany({
-    where: eq(docComments.memexId, doc.memexId),
-    orderBy: (c, { asc }) => [asc(c.createdAt)],
-  });
-
-  // Filter to only comments attached to this doc's children (sections/decisions/tasks),
-  // to avoid leaking comments from other docs in the same account.
-  const sectionIds = new Set(sections.map((s) => s.id));
-  const docDecisions = await db.select({ id: decisions.id }).from(decisions).where(eq(decisions.docId, doc.id));
-  const decisionIds = new Set(docDecisions.map((d) => d.id));
-  const docTasks = await db.select({ id: tasks.id }).from(tasks).where(eq(tasks.docId, doc.id));
-  const taskIds = new Set(docTasks.map((w) => w.id));
-
-  const scoped = comments.filter(
-    (c) =>
-      (c.sectionId && sectionIds.has(c.sectionId)) ||
-      (c.decisionId && decisionIds.has(c.decisionId)) ||
-      (c.taskId && taskIds.has(c.taskId))
-  );
-
-  return {
-    doc,
-    sections,
-    namespaceSlug: ns?.slug ?? "",
-    memexName: memex?.name ?? "",
-    comments: scoped,
-  };
 }
 
 export type ShareCommentTarget =
@@ -241,6 +247,9 @@ export async function createExternalComment(
     throw new ShareTokenError("revoked", "This link has been revoked");
   }
 
+  // share.ts has no session middleware, so no ALS context is set. Bootstrap
+  // runWithMemexId from the token's memex_id so RLS-gated lookups below succeed.
+  return runWithMemexId(tokenRow.memexId, async () => {
   const doc = await db.query.documents.findFirst({
     where: eq(documents.id, tokenRow.documentId),
   });
@@ -305,5 +314,6 @@ export async function createExternalComment(
         DOC_COMMENTS_SEQ_CONSTRAINT,
       ),
   );
+  }); // end runWithMemexId
 }
 

--- a/scripts/deploy.env.example
+++ b/scripts/deploy.env.example
@@ -26,10 +26,15 @@ GCP_PROJECT="your-gcp-project"
 REGION="us-east4"
 CLOUD_SQL_INSTANCE_NAME="your-cloud-sql-instance"
 DB_NAME="memex"
-DB_USER="memex_app"
+DB_USER="postgres"
 # Never hardcode the DB password. Fetch it from Secret Manager at deploy time.
 # GCP_PROJECT must be set above this line (it is referenced here).
 DB_PASS="$(gcloud secrets versions access latest --secret=your-db-password-secret --project="${GCP_PROJECT}")"
+# spec-199 t-14: restricted runtime role (NOSUPERUSER NOBYPASSRLS) used by Cloud Run.
+# Migrations continue to use DB_USER (superuser). Both default to DB_USER/DB_PASS when unset.
+# Set these once the memex_app role has LOGIN + password configured per environment.
+RUNTIME_DB_USER="memex_app"
+RUNTIME_DB_PASS="$(gcloud secrets versions access latest --secret=memex-app-db-password --project="${GCP_PROJECT}")"
 SERVICE="memex-api"
 STATIC_BUCKET="gs://your-static-bucket"
 URL_MAP_NAME="your-url-map"


### PR DESCRIPTION
## Summary

- **Migration 0085**: adds `memex_id NOT NULL` to `share_tokens`, backfilled from `documents`. Required so the public share endpoint can bootstrap ALS from the token row alone — no session middleware, no `currentMemexId` in context.
- **`runWithMemexId` generic**: changes return type from `Promise<void>` to `Promise<T>` so service functions can be wrapped without losing their return value.
- **Share-token public paths fixed**: `getSharedDocumentByToken` and `createExternalComment` now call `runWithMemexId(tokenRow.memexId, ...)` before querying RLS-protected tables (`documents`, `docSections`, `doc_comments`, `decisions`, `tasks`). Under `memex_app` without this, every valid share link returns 404/unknown.
- **deploy.sh credential split**: `RUNTIME_DB_USER`/`RUNTIME_DB_PASS` (optional, falls back to `DB_USER`/`DB_PASS`) used for the Cloud Run `DATABASE_URL`. Migrations still use `DB_USER` (postgres superuser — required for `CREATE ROLE`, `ENABLE ROW LEVEL SECURITY` in migration DDL).
- **deploy.env.example**: documents `RUNTIME_DB_USER`/`RUNTIME_DB_PASS` keys and how to populate them.

## Why this must land before the t-14 credential flip

Switching Cloud Run `DATABASE_URL` from `postgres` (BYPASSRLS) to `memex_app` (NOBYPASSRLS) without this PR means every public share link returns 404. The fix is in `getSharedDocumentByToken` — without `runWithMemexId`, RLS filters `documents` to 0 rows.

## Test plan

- [ ] `make typecheck` — no new type errors (pre-existing share-token test error is unrelated)
- [ ] CI integration tests against pg16 (`share-tokens.integration.test.ts`, `share-tokens.external-comment.integration.test.ts`)
- [ ] After merge to develop: auto-deploy to INT runs migration 0085 (backfills `memex_id` on existing share_tokens rows)
- [ ] After code deploys to INT: fix `memex_app` role (LOGIN + NOCREATEROLE + NOCREATEDB + password), then flip `DATABASE_URL` via `gcloud run services update` and run authed smoke tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)