### PR TITLE
fix(security): spec-199 — MCP write tools broken by FORCE ROW LEVEL SECURITY on Cloud SQL

### DIFF
--- a/packages/server/src/mcp/tools.ts
+++ b/packages/server/src/mcp/tools.ts
@@ -39,6 +39,7 @@ import { resolveRef as resolveCanonicalRef } from "../services/resolver.js";
 import { parseRef } from "../services/refs.js";
 import { logToolCall } from "../services/mcp-telemetry.js";
 import { runToolWithSpecTraffic } from "../services/spec-traffic.js";
+import { memexContext } from "../db/connection.js";
 import { bus } from "../services/bus.js";
 import { deriveActivity } from "../agent/derive-activity.js";
 import type { ToolSpec } from "../agent/tool-specs.js";
@@ -366,6 +367,11 @@ export function createMcpServer(
             );
             resolvedMemexId = memexId;
             enforceWriteGate(readOnly);
+            // spec-199 t-14: Cloud SQL postgres lacks BYPASSRLS, so FORCE ROW
+            // LEVEL SECURITY on tenant tables applies to every role. Set the
+            // ALS context so all subsequent DB calls in this handler execution
+            // have app.memex_id injected by the rlsClient proxy.
+            memexContext.enterWith({ memexId });
             return memexId;
           },
           resolveMemexFromEntity: async (kind, id) => {
@@ -377,12 +383,14 @@ export function createMcpServer(
             );
             resolvedMemexId = memexId;
             enforceWriteGate(readOnly);
+            memexContext.enterWith({ memexId });
             return memexId;
           },
           resolveRef: async (ref) => {
             const result = await resolveRefForUser(userId, ref, orgFilter);
             resolvedMemexId = result.memexId;
             enforceWriteGate(result.readOnly);
+            memexContext.enterWith({ memexId: result.memexId });
             return result;
           },
           workspaceUrl,


### PR DESCRIPTION
## Root cause

Cloud SQL's `postgres` user has no `BYPASSRLS` attribute (only `Create role, Create DB`). After migration 0081 set `FORCE ROW LEVEL SECURITY` on `documents` (and 13 other tenant tables), every INSERT/UPDATE via the MCP endpoint fails:

```
PostgresError: new row violates row-level security policy for table "documents"
```

Every `create_doc` call returned `isError: true`. Same for all write tools.

## Why

The MCP tool dispatch path (`mcp/tools.ts`) calls `ctx.resolveMemex` / `ctx.resolveRef` / `ctx.resolveMemexFromEntity` to resolve the tenant ID, but never sets the `AsyncLocalStorage` context that the `rlsClient` proxy reads to prepend `SET app.memex_id = $1` to each query.

Session-middleware REST routes are fine — `runWithMemexId` wraps the entire request handler. The `/mcp` endpoint has no session middleware; that gap breaks every write tool.

## Fix

Call `memexContext.enterWith({ memexId })` in all three `ctx` resolvers immediately after the `memexId` is known. `enterWith` persists for the rest of the async execution context (the request lifetime), so all subsequent `db.*` calls in the same handler automatically carry the correct GUC.

The in-app agent path (`agent/tools.ts`) is unaffected — it runs inside the REST session middleware which already sets ALS via `runWithMemexId`.

## Evidence

```
mcp_tool_calls.error for create_doc on INT (17:44:57 UTC):
  PostgresError: new row violates row-level security policy for table "documents"
```

## Test plan

- [ ] CI: server tests pass (includes MCP integration tests)
- [ ] Post-merge deploy to INT: smoke suite green (authed tier: `create_doc`, `update_doc`, all write tools)

🤖 Generated with [Claude Code](https://claude.com/claude-code)