### PR TITLE
fix(rls): spec-199 t-14 — safe uuid cast + resolveRef pre-lookup

### DIFF
--- a/packages/server/drizzle/0086_rls_safe_uuid_cast.sql
+++ b/packages/server/drizzle/0086_rls_safe_uuid_cast.sql
@@ -1,0 +1,156 @@
+-- spec-199 t-14: Fix RLS policy uuid cast — nullif guard
+--
+-- Migration 0081 created USING/WITH CHECK clauses of the form:
+--
+--   nullif(current_setting('app.memex_id', true), '') IS NOT NULL
+--   AND memex_id = current_setting('app.memex_id', true)::uuid
+--
+-- PostgreSQL does NOT guarantee short-circuit AND evaluation, so when
+-- app.memex_id is unset (returns ''), the second operand evaluates
+-- current_setting(...)::uuid = ''::uuid which throws:
+--
+--   ERROR: invalid input syntax for type uuid: ""
+--
+-- Fix: wrap the cast side in the same nullif so the empty-string case
+-- produces NULL::uuid = NULL (falsy, row blocked) instead of an error.
+-- The IS NOT NULL guard is kept for readability / defence-in-depth.
+
+ALTER POLICY documents_memex_isolation ON documents
+  USING (
+    nullif(current_setting('app.memex_id', true), '') IS NOT NULL
+    AND memex_id = nullif(current_setting('app.memex_id', true), '')::uuid
+  )
+  WITH CHECK (
+    nullif(current_setting('app.memex_id', true), '') IS NOT NULL
+    AND memex_id = nullif(current_setting('app.memex_id', true), '')::uuid
+  );
+
+ALTER POLICY standard_clauses_memex_isolation ON standard_clauses
+  USING (
+    nullif(current_setting('app.memex_id', true), '') IS NOT NULL
+    AND memex_id = nullif(current_setting('app.memex_id', true), '')::uuid
+  )
+  WITH CHECK (
+    nullif(current_setting('app.memex_id', true), '') IS NOT NULL
+    AND memex_id = nullif(current_setting('app.memex_id', true), '')::uuid
+  );
+
+ALTER POLICY clause_refs_memex_isolation ON clause_refs
+  USING (
+    nullif(current_setting('app.memex_id', true), '') IS NOT NULL
+    AND memex_id = nullif(current_setting('app.memex_id', true), '')::uuid
+  )
+  WITH CHECK (
+    nullif(current_setting('app.memex_id', true), '') IS NOT NULL
+    AND memex_id = nullif(current_setting('app.memex_id', true), '')::uuid
+  );
+
+ALTER POLICY doc_comments_memex_isolation ON doc_comments
+  USING (
+    nullif(current_setting('app.memex_id', true), '') IS NOT NULL
+    AND memex_id = nullif(current_setting('app.memex_id', true), '')::uuid
+  )
+  WITH CHECK (
+    nullif(current_setting('app.memex_id', true), '') IS NOT NULL
+    AND memex_id = nullif(current_setting('app.memex_id', true), '')::uuid
+  );
+
+ALTER POLICY decisions_memex_isolation ON decisions
+  USING (
+    nullif(current_setting('app.memex_id', true), '') IS NOT NULL
+    AND memex_id = nullif(current_setting('app.memex_id', true), '')::uuid
+  )
+  WITH CHECK (
+    nullif(current_setting('app.memex_id', true), '') IS NOT NULL
+    AND memex_id = nullif(current_setting('app.memex_id', true), '')::uuid
+  );
+
+ALTER POLICY tasks_memex_isolation ON tasks
+  USING (
+    nullif(current_setting('app.memex_id', true), '') IS NOT NULL
+    AND memex_id = nullif(current_setting('app.memex_id', true), '')::uuid
+  )
+  WITH CHECK (
+    nullif(current_setting('app.memex_id', true), '') IS NOT NULL
+    AND memex_id = nullif(current_setting('app.memex_id', true), '')::uuid
+  );
+
+ALTER POLICY acs_memex_isolation ON acs
+  USING (
+    nullif(current_setting('app.memex_id', true), '') IS NOT NULL
+    AND memex_id = nullif(current_setting('app.memex_id', true), '')::uuid
+  )
+  WITH CHECK (
+    nullif(current_setting('app.memex_id', true), '') IS NOT NULL
+    AND memex_id = nullif(current_setting('app.memex_id', true), '')::uuid
+  );
+
+ALTER POLICY issues_memex_isolation ON issues
+  USING (
+    nullif(current_setting('app.memex_id', true), '') IS NOT NULL
+    AND memex_id = nullif(current_setting('app.memex_id', true), '')::uuid
+  )
+  WITH CHECK (
+    nullif(current_setting('app.memex_id', true), '') IS NOT NULL
+    AND memex_id = nullif(current_setting('app.memex_id', true), '')::uuid
+  );
+
+ALTER POLICY doc_members_memex_isolation ON doc_members
+  USING (
+    nullif(current_setting('app.memex_id', true), '') IS NOT NULL
+    AND memex_id = nullif(current_setting('app.memex_id', true), '')::uuid
+  )
+  WITH CHECK (
+    nullif(current_setting('app.memex_id', true), '') IS NOT NULL
+    AND memex_id = nullif(current_setting('app.memex_id', true), '')::uuid
+  );
+
+ALTER POLICY doc_assignees_memex_isolation ON doc_assignees
+  USING (
+    nullif(current_setting('app.memex_id', true), '') IS NOT NULL
+    AND memex_id = nullif(current_setting('app.memex_id', true), '')::uuid
+  )
+  WITH CHECK (
+    nullif(current_setting('app.memex_id', true), '') IS NOT NULL
+    AND memex_id = nullif(current_setting('app.memex_id', true), '')::uuid
+  );
+
+ALTER POLICY tags_memex_isolation ON tags
+  USING (
+    nullif(current_setting('app.memex_id', true), '') IS NOT NULL
+    AND memex_id = nullif(current_setting('app.memex_id', true), '')::uuid
+  )
+  WITH CHECK (
+    nullif(current_setting('app.memex_id', true), '') IS NOT NULL
+    AND memex_id = nullif(current_setting('app.memex_id', true), '')::uuid
+  );
+
+ALTER POLICY document_tags_memex_isolation ON document_tags
+  USING (
+    nullif(current_setting('app.memex_id', true), '') IS NOT NULL
+    AND memex_id = nullif(current_setting('app.memex_id', true), '')::uuid
+  )
+  WITH CHECK (
+    nullif(current_setting('app.memex_id', true), '') IS NOT NULL
+    AND memex_id = nullif(current_setting('app.memex_id', true), '')::uuid
+  );
+
+ALTER POLICY memex_emission_keys_memex_isolation ON memex_emission_keys
+  USING (
+    nullif(current_setting('app.memex_id', true), '') IS NOT NULL
+    AND memex_id = nullif(current_setting('app.memex_id', true), '')::uuid
+  )
+  WITH CHECK (
+    nullif(current_setting('app.memex_id', true), '') IS NOT NULL
+    AND memex_id = nullif(current_setting('app.memex_id', true), '')::uuid
+  );
+
+ALTER POLICY repos_memex_isolation ON repos
+  USING (
+    nullif(current_setting('app.memex_id', true), '') IS NOT NULL
+    AND memex_id = nullif(current_setting('app.memex_id', true), '')::uuid
+  )
+  WITH CHECK (
+    nullif(current_setting('app.memex_id', true), '') IS NOT NULL
+    AND memex_id = nullif(current_setting('app.memex_id', true), '')::uuid
+  );

--- a/packages/server/src/mcp/tools.ts
+++ b/packages/server/src/mcp/tools.ts
@@ -404,6 +404,25 @@ export function createMcpServer(
             return memexId;
           },
           resolveRef: async (ref) => {
+            // spec-199 t-14: pre-populate rlsStore.memexId from the ref's
+            // namespace/memex slug before resolveRefForUser runs the canonical
+            // resolver, which queries the RLS-gated `documents` table.
+            // resolveWorkspaceForRead touches only non-RLS tables (namespaces,
+            // memexes, org_memberships, user_memex_access). Errors are swallowed
+            // — resolveRefForUser surfaces the authoritative failure.
+            const preParsed = parseRef(ref);
+            if (preParsed.ok) {
+              try {
+                const { memexId: preMemexId } = await resolveWorkspaceForRead(
+                  userId,
+                  `${preParsed.ref.namespace}/${preParsed.ref.memex}`,
+                  orgFilter,
+                );
+                rlsStore.memexId = preMemexId;
+              } catch {
+                // best-effort
+              }
+            }
             const result = await resolveRefForUser(userId, ref, orgFilter);
             resolvedMemexId = result.memexId;
             enforceWriteGate(result.readOnly);


### PR DESCRIPTION
## Summary

- **Migration 0086** (`ALTER POLICY` on all 14 tenant tables): wraps the `::uuid` cast in `nullif(...)` so an unset `app.memex_id` (empty string) produces `NULL::uuid = NULL` (row blocked, no error) instead of throwing `invalid input syntax for type uuid: ""`. Defence-in-depth — prevents crashes from any code path that legitimately runs without a store.

- **`ctx.resolveRef` pre-lookup** (`packages/server/src/mcp/tools.ts`): calls `resolveWorkspaceForRead` with the ref's `namespace/memex` slug BEFORE `resolveRefForUser` runs the canonical resolver. `resolveRefForUser` queries the RLS-gated `documents` table inside `resolveCanonicalRef` — this pre-populates `rlsStore.memexId` so the proxy's `set_config` fires with the correct tenant ID. `resolveWorkspaceForRead` touches only non-RLS tables (`namespaces`, `memexes`, `org_memberships`, `user_memex_access`). Pre-lookup errors are swallowed; `resolveRefForUser` surfaces the authoritative failure.

**Root cause**: PostgreSQL does not guarantee short-circuit `AND`. Migration 0081's `nullif IS NOT NULL AND memex_id = current_setting(...)::uuid` evaluated the cast side even when `app.memex_id` was empty, causing a hard DB error on every `resolveRef`-based tool call (`update_doc`, `get_doc`, `create_task`, `create_ac`, `add_section`, `create_decision`).

**What already works**: `create_doc` (uses `resolveMemex`, which sets the store before any document query) has been passing since PR #100.

## Test plan

- [ ] Apply migration 0086 against INT DB: `pnpm db:migrate:hand`
- [ ] Verify no `invalid input syntax for type uuid` errors in INT DB smoke log after deploy
- [ ] Smoke test `create → read → delete` journey passes: `create_doc` → `update_doc` → `create_task` → `get_doc` → `delete_task`
- [ ] Verify remaining tools: `create_ac`, `add_section`, `create_decision` return non-error responses
- [ ] Check `create_doc` still passes (no regression on `resolveMemex` path)