### PR TITLE
test: raise handhold reset timeout to outlast waitForDemoDocs poll window

### DIFF
--- a/packages/server/src/routes/handhold.api.test.ts
+++ b/packages/server/src/routes/handhold.api.test.ts
@@ -288,5 +288,5 @@ describe("spec-178 t-6 — resetHandholdDemo service contract (ac-17)", () => {
     const result = await resetHandholdDemo(owner.memexId);
     expect(result.seeded).toBe(HANDHOLD_PHASES.length);
     expect(await countDemoDocs(owner.memexId)).toBe(HANDHOLD_PHASES.length);
-  });
+  }, 20_000);
 });


### PR DESCRIPTION
## Summary

- `waitForDemoDocs` polls for up to 15s. The wrapping `it()` used the vitest default 5s timeout — on a slow CI run the background seed hadn't finished within 5s, causing a spurious timeout.
- Fix: pass `20_000` as the test timeout, giving a 5s margin above the poll window.

Not caused by any code change — the `waitForDemoDocs` timeout mismatch has always been there, it just showed up when the CI runner was under load.

## Test plan
- [ ] CI test suite passes (no timeout on `spec-178 t-6 — resetHandholdDemo service contract`)