### PR TITLE
fix(migration): 0085 purge orphaned share_tokens before NOT NULL constraint

### DIFF
--- a/packages/server/drizzle/0085_share_tokens_memex_id.sql
+++ b/packages/server/drizzle/0085_share_tokens_memex_id.sql
@@ -10,5 +10,9 @@ UPDATE share_tokens
   FROM documents
   WHERE share_tokens.document_id = documents.id;
 
+-- Purge orphaned tokens whose document was already deleted — they reference
+-- a non-existent document and are unusable. Required before the NOT NULL below.
+DELETE FROM share_tokens WHERE memex_id IS NULL;
+
 ALTER TABLE share_tokens
   ALTER COLUMN memex_id SET NOT NULL;


### PR DESCRIPTION
## What broke

PROD deploy failed: migration 0085 added `memex_id` column to `share_tokens`, backfilled via JOIN to `documents`, then tried to set NOT NULL — but PROD had 5 orphaned tokens whose documents had already been deleted. The UPDATE found 0 matching rows, leaving all 5 NULL, and the NOT NULL constraint failed.

The transaction rolled back cleanly, but 0081 (FORCE RLS) had already committed in the same `db:migrate` run, causing a PROD outage (all specs disappeared). FORCE RLS has been manually rolled back via `NO FORCE ROW LEVEL SECURITY` on all 14 tables to restore service.

## Fix

Add `DELETE FROM share_tokens WHERE memex_id IS NULL` between the backfill UPDATE and the NOT NULL constraint. Orphaned tokens reference deleted documents and are unusable anyway.

## Test plan
- [ ] Migration 0085 applies cleanly on PROD (no orphaned rows remain to block NOT NULL)
- [ ] PROD smoke passes post-deploy (public + authed tier)