### PR TITLE
fix(migration): 0085 orphaned share_tokens — PROD deploy unblock

### DIFF
--- a/packages/server/drizzle/0085_share_tokens_memex_id.sql
+++ b/packages/server/drizzle/0085_share_tokens_memex_id.sql
@@ -10,5 +10,9 @@ UPDATE share_tokens
   FROM documents
   WHERE share_tokens.document_id = documents.id;
 
+-- Purge orphaned tokens whose document was already deleted — they reference
+-- a non-existent document and are unusable. Required before the NOT NULL below.
+DELETE FROM share_tokens WHERE memex_id IS NULL;
+
 ALTER TABLE share_tokens
   ALTER COLUMN memex_id SET NOT NULL;


### PR DESCRIPTION
## Context

The previous PROD deploy (PR #103) failed on migration 0085 because PROD had 5 share_tokens
with deleted documents. The partially-applied run committed 0081 (FORCE RLS) before failing,
causing a PROD outage (all specs disappeared). FORCE RLS has been manually rolled back to restore
service; PROD is currently stable.

## This PR

Patches 0085 to purge orphaned tokens before applying NOT NULL. The deploy will:
- Apply 0085 (fixed) → 0086 (uuid cast fix) cleanly
- Update Cloud Run to the new revision (ALS proxy + resolveRef pre-lookup)
- Run post-deploy smoke (public + authed MCP tier)

FORCE RLS re-enable is a manual post-deploy step once the new code is confirmed live.