### PR TITLE
spec-200: fetch ANTHROPIC_API_KEY for the What's New deploy hook (1f)

### DIFF
--- a/packages/server/deploy.sh
+++ b/packages/server/deploy.sh
@@ -230,8 +230,17 @@ DATABASE_URL="${DB_URL}" timeout 600 pnpm db:import-guide-content \
 # cost is just today's promotions and the first backfill resumes idempotently.
 # A missing Anthropic key just means no drafts land (next deploy retries) — it
 # never fails the deploy.
+#
+# The Anthropic key is wired into the Cloud Run SERVICE at step 4 (--set-secrets),
+# but that wiring never reaches THIS migration-phase shell on the CI runner, where
+# the generation script actually runs. So fetch it from Secret Manager here, the
+# same way scripts/deploy-config.sh sources DB_PASS (`versions access`). Guarded
+# with `|| true` so a fetch hiccup can't trip `set -e` and abort the deploy — an
+# empty key just yields no drafts, exactly like the missing-key case above. The
+# secret's existence is already asserted in the pre-flight block.
+ANTHROPIC_API_KEY="$(gcloud secrets versions access latest --secret=anthropic-api-key --project="${GCP_PROJECT}" 2>/dev/null)" || true
 echo "  1f. What's New generation (spec-200 t-3 / ac-8)..."
-DATABASE_URL="${DB_URL}" timeout 600 pnpm db:generate-whats-new \
+DATABASE_URL="${DB_URL}" ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY}" timeout 600 pnpm db:generate-whats-new \
   || echo "  ⚠ What's New generation timed out or failed (non-gating, exit $?) — deploy continues; next deploy resumes (idempotent)."
 
 kill $PROXY_PID 2>/dev/null


### PR DESCRIPTION
## Problem

The **What's New** ribbon/popup has never appeared on PROD because the feed is empty. The deploy hook that populates it — `deploy.sh` step **1f** (`db:generate-whats-new`) — has failed on **every** prod deploy with:

```
[whats-new] failed: LlmNotConfiguredError: ANTHROPIC_API_KEY is not set.
```

Confirmed in the prod deploy logs for run `27266468307` (2026-06-10) and the feature's first prod deploy `27170075087` (2026-06-08) → **0 entries ever published**.

Tracked as **spec-200 / issue-1** (`mindset-prod/memex-building-itself/specs/spec-200/issues/issue-1`, bug, high).

## Root cause

Migration steps `1a`–`1f` run on the GitHub Actions runner, talking to Cloud SQL via the proxy, with only `DATABASE_URL` exported. `ANTHROPIC_API_KEY` is wired into the Cloud Run **service** at step 4 (`--set-secrets`), which never reaches this migration-phase shell. So `getAnthropicClient()` saw no key and threw. Because `1f` is non-gating (`|| echo`), the exit-1 was swallowed and deploys went green while publishing nothing.

## Fix

Fetch the key from Secret Manager before `1f`, the same way `scripts/deploy-config.sh` sources `DB_PASS` (`versions access`). Guarded with `|| true` so a fetch hiccup can't trip `set -e` and abort a live deploy — an empty key just yields no drafts, identical to the existing missing-key path. The secret's existence is already asserted in the pre-flight block.

## Validation / rollout

- `bash -n deploy.sh` clean. Shell-only change — no app code, so no e2e journey is exercised (std-28 N/A).
- **INT** validates harmlessly: the fetch runs there too, but generation still no-ops (source memex `mindset-prod/memex-building-itself` doesn't exist on INT). The INT deploy log should show `1f` reaching `... not found ... skipping` **without** the `LlmNotConfiguredError`.
- The next **`develop`→`main` promotion** runs `1f` for real → backfills up to `MAX_PER_RUN=25` entries → ribbon appears. Generation is idempotent + judged-once, so re-runs are no-ops. Resolves spec-200 / issue-1.

⚠️ Those entries publish **unreviewed** (dec-1, no approval gate) — eyeball the prose right after the promotion; unpublish/edit is the fast-follow lever.

## Follow-up (separate, not this PR)

`1f`'s non-gating `|| echo` makes this failure class invisible in green deploys. Consider a louder warning / "published N, skipped M" summary so a silent empty feed is caught next time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)