### PR TITLE
spec-214: stop Specky's voice echo / self-talk loop (half-duplex + barge-in removal)

### DIFF
--- a/packages/guide-sdk/src/orchestrator/voiceGuideOrchestrator.spec-214.test.ts
+++ b/packages/guide-sdk/src/orchestrator/voiceGuideOrchestrator.spec-214.test.ts
@@ -1,0 +1,439 @@
+// spec-214 — half-duplex + barge-in-removal wiring tests for the orchestrator.
+// All browser glue is faked (no real audio), exercising the loop's control flow:
+//   - dec-1: mic PCM forwarded to STT only while `listening` (ac-6); no commit from
+//            non-listening audio (ac-7)
+//   - dec-2: a fresh STT session (start_listening) opens on each entry to listening
+//            (ac-8)
+//   - dec-3: a committed transcript that echoes the just-spoken reply within the
+//            cooldown is dropped (ac-10); a dissimilar one survives (ac-11)
+//   - dec-4: a VAD onset while speaking neither ducks nor cuts (ac-12); a speech-end
+//            while listening still commits (ac-13); Stop halts-and-stays (ac-14)
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { createVoiceOrchestratorFactory } from './voiceGuideOrchestrator';
+import type { SocketLike, SocketFactory } from './voiceWsClient';
+import type { VadEngine } from '../micVad';
+import type { OrchestratorHooks } from '../session/orchestrator';
+import type { NavigationAdapter } from '../navigation/NavigationAdapter';
+
+const SPEC = 'mindset-prod/memex-building-itself/specs/spec-214';
+const AC = (n: number) => `${SPEC}/acs/ac-${n}`;
+
+function fakeSocket() {
+  const sent: unknown[] = [];
+  let closed = false;
+  const sock: SocketLike = {
+    binaryType: '',
+    readyState: 1, // WebSocket.OPEN
+    onopen: null,
+    onmessage: null,
+    onerror: null,
+    onclose: null,
+    send: (d) => sent.push(d),
+    close: () => {
+      closed = true;
+    },
+  };
+  return { sock, sent, factory: (() => sock) as SocketFactory, isClosed: () => closed };
+}
+
+function fakeVad() {
+  let onSpeech: ((s: boolean) => void) | null = null;
+  const engine: VadEngine = {
+    start: (_stream, cb) => {
+      onSpeech = cb;
+    },
+    stop: vi.fn(),
+  };
+  return { engine, speak: (s: boolean) => onSpeech?.(s) };
+}
+
+function fakePlayback() {
+  let drainCb: (() => void) | null = null;
+  return {
+    startTurn: vi.fn(),
+    enqueue: vi.fn(),
+    duck: vi.fn(),
+    restore: vi.fn(),
+    flush: vi.fn(() => {
+      drainCb = null;
+    }),
+    playedMs: () => 0,
+    onDrain: vi.fn((cb: () => void) => {
+      drainCb = cb;
+    }),
+    dispose: vi.fn(),
+    drain: () => {
+      const cb = drainCb;
+      drainCb = null;
+      cb?.();
+    },
+  };
+}
+
+// Capture exposes its onFrame callback so a test can feed mic PCM frames and assert
+// whether they were forwarded upstream (binary frames land in sock.sent).
+function fakeCapture() {
+  let onFrame: ((pcm: ArrayBuffer) => void) | null = null;
+  return {
+    start: (_stream: MediaStream, cb: (pcm: ArrayBuffer) => void) => {
+      onFrame = cb;
+    },
+    stop: vi.fn(),
+    frame: () => onFrame?.(new ArrayBuffer(8)),
+  };
+}
+
+function fakeGraph(text: string) {
+  return {
+    invoke: vi.fn(
+      async (
+        _input: unknown,
+        config: { configurable: { callbacks: Record<string, (...a: never[]) => void> } },
+      ) => {
+        config.configurable.callbacks.onTextDelta?.(text as never);
+      },
+    ),
+  } as unknown as ReturnType<typeof import('../guideGraph').createGuideGraph>;
+}
+
+function hooks(): OrchestratorHooks & { states: string[]; earcons: string[] } {
+  const states: string[] = [];
+  const earcons: string[] = [];
+  return {
+    states,
+    earcons,
+    setLoopState: (s) => states.push(s),
+    playEarcon: (e) => earcons.push(e),
+    onError: () => {},
+    onEnded: () => {},
+    onTurnComplete: () => {},
+  };
+}
+
+// spec-222: the orchestrator navigates only through an injected NavigationAdapter.
+// These echo/barge tests don't assert navigation, so a minimal adapter suffices.
+const adapter: NavigationAdapter = {
+  resolveScreenKey: () => null,
+  currentScreenKey: () => 'specs-list',
+  findElement: () => null,
+  navigate: () => ({ ok: true, path: '/ns/mx/specs' }),
+};
+
+const react = {
+  adapter,
+  advanceDemo: vi.fn(),
+  startWalkthrough: vi.fn(),
+  authToken: () => 'tok',
+  tenantBase: () => '/api/ns/mx',
+  origin: 'http://localhost',
+  getScreenContext: () => ({ screenKey: 'specs-list', screenRegistry: [], namespace: 'ns', memex: 'mx' }),
+};
+
+const fakeStream = {} as MediaStream;
+const ready = { data: JSON.stringify({ type: 'ready' }) };
+const transcript = (text: string) => ({ data: JSON.stringify({ type: 'transcript', text, isFinal: true }) });
+const audioFinal = (requestId: string) => ({ data: JSON.stringify({ type: 'audio', requestId, audio: '', isFinal: true }) });
+const START_LISTENING = JSON.stringify({ type: 'start_listening' });
+const END_UTTERANCE = JSON.stringify({ type: 'end_utterance' });
+
+const isBinary = (s: unknown) => typeof s !== 'string';
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('spec-214 — half-duplex mic→STT gate (dec-1)', () => {
+  it('forwards mic PCM only while listening, never while speaking (ac-6, ac-1)', async () => {
+    tagAc(AC(6));
+    tagAc(AC(1)); // scope: the agent's own captured speech never enters the STT pipeline
+    const sock = fakeSocket();
+    const vad = fakeVad();
+    const capture = fakeCapture();
+    const playback = fakePlayback();
+    const h = hooks();
+    const orch = createVoiceOrchestratorFactory(react, {
+      socketFactory: sock.factory,
+      vadEngine: vad.engine,
+      capture,
+      playback,
+      graph: fakeGraph('Here you go.'),
+      newId: () => 'r1',
+    })(h);
+    await orch.start(fakeStream);
+    sock.sock.onmessage?.(ready); // → listening
+
+    const beforeListen = sock.sent.filter(isBinary).length;
+    capture.frame(); // captured while listening → forwarded
+    expect(sock.sent.filter(isBinary).length).toBe(beforeListen + 1);
+
+    // Drive a turn to speaking.
+    sock.sock.onmessage?.(transcript('how do phases work?'));
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(h.states[h.states.length - 1]).toBe('speaking');
+
+    const whileSpeaking = sock.sent.filter(isBinary).length;
+    capture.frame(); // captured echo while speaking → DROPPED
+    capture.frame();
+    expect(sock.sent.filter(isBinary).length).toBe(whileSpeaking);
+  });
+
+  it('does not commit (end_utterance) on a speech-end while the agent is speaking (ac-7, ac-1)', async () => {
+    tagAc(AC(7));
+    tagAc(AC(1)); // scope: no commit path exists from audio captured outside listening
+    const sock = fakeSocket();
+    const vad = fakeVad();
+    const graph = fakeGraph('A spoken answer.');
+    const orch = createVoiceOrchestratorFactory(react, {
+      socketFactory: sock.factory,
+      vadEngine: vad.engine,
+      capture: fakeCapture(),
+      playback: fakePlayback(),
+      graph,
+      newId: () => 'r1',
+    })(hooks());
+    await orch.start(fakeStream);
+    sock.sock.onmessage?.(ready);
+    sock.sock.onmessage?.(transcript('a question'));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const endsBefore = sock.sent.filter((s) => s === END_UTTERANCE).length;
+    // Echo trips the VAD while the agent speaks: onset then end.
+    vad.speak(true);
+    vad.speak(false);
+    expect(sock.sent.filter((s) => s === END_UTTERANCE).length).toBe(endsBefore); // no commit
+    expect(graph.invoke).toHaveBeenCalledTimes(1); // no second (self-)turn
+  });
+});
+
+describe('spec-214 — per-turn STT session (dec-2)', () => {
+  it('opens a fresh STT session (start_listening) on each entry to listening (ac-8)', async () => {
+    tagAc(AC(8));
+    const sock = fakeSocket();
+    const playback = fakePlayback();
+    const orch = createVoiceOrchestratorFactory(react, {
+      socketFactory: sock.factory,
+      vadEngine: fakeVad().engine,
+      capture: fakeCapture(),
+      playback,
+      graph: fakeGraph('Answer one.'),
+      newId: () => 'r1',
+    })(hooks());
+    await orch.start(fakeStream);
+    sock.sock.onmessage?.(ready); // entry #1 → start_listening
+    expect(sock.sent.filter((s) => s === START_LISTENING)).toHaveLength(1);
+
+    // A full turn: speak then drain back to listening.
+    sock.sock.onmessage?.(transcript('q?'));
+    await Promise.resolve();
+    await Promise.resolve();
+    sock.sock.onmessage?.(audioFinal('r1'));
+    playback.drain(); // entry #2 → fresh start_listening
+    expect(sock.sent.filter((s) => s === START_LISTENING)).toHaveLength(2);
+  });
+});
+
+describe('spec-214 — self-echo guard (dec-3)', () => {
+  // Drive one spoken turn, drain it (stamps speakingEndedAt), then feed a follow-up
+  // transcript with a controllable clock to land inside / outside the cooldown.
+  async function speakThenDrain(text: string, sock: ReturnType<typeof fakeSocket>, playback: ReturnType<typeof fakePlayback>) {
+    sock.sock.onmessage?.(ready);
+    sock.sock.onmessage?.(transcript('opening question'));
+    await Promise.resolve();
+    await Promise.resolve();
+    sock.sock.onmessage?.(audioFinal('r1'));
+    playback.drain(); // speaking → listening; speakingEndedAt stamped
+    void text;
+  }
+
+  it('drops a committed transcript that echoes the just-spoken reply within cooldown (ac-10)', async () => {
+    tagAc(AC(10));
+    let clock = 1000;
+    const sock = fakeSocket();
+    const playback = fakePlayback();
+    const graph = fakeGraph('hello there I am Specky');
+    const orch = createVoiceOrchestratorFactory(react, {
+      socketFactory: sock.factory,
+      vadEngine: fakeVad().engine,
+      capture: fakeCapture(),
+      playback,
+      graph,
+      newId: () => 'r1',
+      now: () => clock,
+    })(hooks());
+    await orch.start(fakeStream);
+    await speakThenDrain('hello there I am Specky', sock, playback);
+    expect(graph.invoke).toHaveBeenCalledTimes(1);
+
+    // 200ms later the speaker tail bleeds back, transcribed as (near-)the reply.
+    clock = 1200;
+    sock.sock.onmessage?.(transcript('hello there I am Specky'));
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(graph.invoke).toHaveBeenCalledTimes(1); // dropped — no self-turn
+  });
+
+  it('keeps a dissimilar user turn that lands within the cooldown (ac-11)', async () => {
+    tagAc(AC(11));
+    let clock = 1000;
+    const sock = fakeSocket();
+    const playback = fakePlayback();
+    const graph = fakeGraph('hello there I am Specky');
+    const orch = createVoiceOrchestratorFactory(react, {
+      socketFactory: sock.factory,
+      vadEngine: fakeVad().engine,
+      capture: fakeCapture(),
+      playback,
+      graph,
+      newId: () => 'r1',
+      now: () => clock,
+    })(hooks());
+    await orch.start(fakeStream);
+    await speakThenDrain('hello there I am Specky', sock, playback);
+    expect(graph.invoke).toHaveBeenCalledTimes(1);
+
+    // A genuine, dissimilar question inside the cooldown window must NOT be dropped.
+    clock = 1200;
+    sock.sock.onmessage?.(transcript('how do phases work'));
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(graph.invoke).toHaveBeenCalledTimes(2); // genuine turn ran
+  });
+});
+
+describe('spec-214 — a proactive opening turn does not start a self-conversation (ac-2)', () => {
+  it('greets first, then drops its own echoed greeting — no self-turn fires (ac-2, ac-1)', async () => {
+    tagAc(AC(2));
+    tagAc(AC(1));
+    let clock = 5000;
+    const sock = fakeSocket();
+    const capture = fakeCapture();
+    const playback = fakePlayback();
+    // The greeting Specky speaks first (the spec-206 first-run welcome scenario).
+    const graph = fakeGraph('hello there I am Specky');
+    const h = hooks();
+    const orch = createVoiceOrchestratorFactory(react, {
+      socketFactory: sock.factory,
+      vadEngine: fakeVad().engine,
+      capture,
+      playback,
+      graph,
+      newId: () => 'r1',
+      now: () => clock,
+    })(h);
+
+    // Seeded opening context → the guide opens PROACTIVELY (no user speech).
+    await orch.start(fakeStream, 'Greet the user warmly by name.');
+    sock.sock.onmessage?.(ready); // → runTurn(seed) → speaking the greeting
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(h.states[h.states.length - 1]).toBe('speaking');
+    expect(graph.invoke).toHaveBeenCalledTimes(1); // the opening turn only
+
+    // The greeting bleeds from the speakers into the mic WHILE speaking — the gate
+    // (dec-1) drops these frames, so they never reach STT.
+    const binBefore = sock.sent.filter(isBinary).length;
+    capture.frame();
+    capture.frame();
+    expect(sock.sent.filter(isBinary).length).toBe(binBefore);
+
+    // Greeting finishes; 150ms later the speaker tail is transcribed as (near) the
+    // greeting itself — the self-echo guard (dec-3) drops it.
+    sock.sock.onmessage?.(audioFinal('r1'));
+    playback.drain(); // speaking → listening; speakingEndedAt stamped
+    clock = 5150;
+    sock.sock.onmessage?.(transcript('hello there I am Specky'));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Specky did NOT answer itself — still just the one opening turn.
+    expect(graph.invoke).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('spec-214 — voice barge-in removed; Stop is the sole interruption (dec-4)', () => {
+  it('does not duck or cut the agent on a VAD onset while speaking (ac-12)', async () => {
+    tagAc(AC(12));
+    const sock = fakeSocket();
+    const vad = fakeVad();
+    const playback = fakePlayback();
+    const h = hooks();
+    const orch = createVoiceOrchestratorFactory(react, {
+      socketFactory: sock.factory,
+      vadEngine: vad.engine,
+      capture: fakeCapture(),
+      playback,
+      graph: fakeGraph('A long spoken answer.'),
+      newId: () => 'r1',
+    })(h);
+    await orch.start(fakeStream);
+    sock.sock.onmessage?.(ready);
+    sock.sock.onmessage?.(transcript('q?'));
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(h.states[h.states.length - 1]).toBe('speaking');
+
+    const flushes = playback.flush.mock.calls.length;
+    vad.speak(true); // onset over the agent — must be inert (no barge-in)
+    expect(h.states[h.states.length - 1]).toBe('speaking'); // not 'ducked'
+    expect(playback.flush.mock.calls.length).toBe(flushes); // no cut/flush
+    expect(playback.duck).not.toHaveBeenCalled();
+    expect(sock.sent).not.toContainEqual(JSON.stringify({ type: 'abort', requestId: 'r1' }));
+
+    // The turn still finishes naturally on drain.
+    sock.sock.onmessage?.(audioFinal('r1'));
+    playback.drain();
+    expect(h.states[h.states.length - 1]).toBe('listening');
+  });
+
+  it('commits the user turn (end_utterance) on a speech-end while listening (ac-13, ac-3)', async () => {
+    tagAc(AC(13));
+    tagAc(AC(3)); // scope: genuine human turn-taking is preserved (the user is still heard)
+    const sock = fakeSocket();
+    const vad = fakeVad();
+    const h = hooks();
+    const orch = createVoiceOrchestratorFactory(react, {
+      socketFactory: sock.factory,
+      vadEngine: vad.engine,
+      capture: fakeCapture(),
+      playback: fakePlayback(),
+      graph: fakeGraph(''),
+      newId: () => 'r1',
+    })(h);
+    await orch.start(fakeStream); // start() enters listening
+    vad.speak(true); // user starts
+    vad.speak(false); // user stops → end of utterance
+    expect(sock.sent).toContainEqual(END_UTTERANCE);
+    expect(h.earcons).toContain('ping');
+    expect(h.states).toContain('thinking');
+  });
+
+  it('Stop halts in-flight TTS and returns to listening without ending the session (ac-14, ac-3)', async () => {
+    tagAc(AC(14));
+    tagAc(AC(3)); // scope: the user can still interrupt (via Stop) and keep talking
+    const sock = fakeSocket();
+    const playback = fakePlayback();
+    const h = hooks();
+    const orch = createVoiceOrchestratorFactory(react, {
+      socketFactory: sock.factory,
+      vadEngine: fakeVad().engine,
+      capture: fakeCapture(),
+      playback,
+      graph: fakeGraph('Speaking now.'),
+      newId: () => 'r1',
+    })(h);
+    await orch.start(fakeStream);
+    sock.sock.onmessage?.(ready);
+    sock.sock.onmessage?.(transcript('q?'));
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(h.states[h.states.length - 1]).toBe('speaking');
+
+    orch.interrupt(); // Stop
+    expect(sock.sent).toContainEqual(JSON.stringify({ type: 'abort', requestId: 'r1' }));
+    expect(playback.flush).toHaveBeenCalled();
+    expect(h.states[h.states.length - 1]).toBe('listening');
+    expect(sock.isClosed()).toBe(false); // session + mic stay open (halt-and-stay)
+  });
+});

--- a/packages/guide-sdk/src/orchestrator/voiceGuideOrchestrator.ts
+++ b/packages/guide-sdk/src/orchestrator/voiceGuideOrchestrator.ts
@@ -4,23 +4,48 @@
 //   - voiceWsClient   — the audio-leg WS (mic PCM up; transcript + TTS audio down)
 //   - micPcmCapture   — 16 kHz PCM frames from the granted stream
 //   - SileroWorkletVadEngine — local speech onset/end (ac-23)
-//   - BargeInController + WebAudioPlayback — duck-then-cut + gapless playback (dec-8)
+//   - WebAudioPlayback — gapless TTS playback
 //   - guideGraph      — the client LangGraph turn (calls the /voice/guide-chat SSE leg)
 //   - dispatchGuideUiTool — highlight / navigate (dec-4)
 //
+// spec-214 (dec-1/dec-3/dec-4): the loop is HALF-DUPLEX. Mic PCM is forwarded to
+// the STT leg ONLY while the loop is `listening` (dec-1) — Specky's own speech can
+// never be transcribed and answered, which was the self-talk loop. A fresh STT
+// session is opened per human turn (dec-2). Voice barge-in is REMOVED (dec-4,
+// supersedes spec-190/dec-8): the VAD no longer ducks/cuts the agent; it endpoints
+// only the user's turn during `listening`. Stop (interrupt) is the sole
+// interruption — it halts TTS and returns to listening, session live. A self-echo
+// guard (dec-3) drops any committed transcript that echoes the just-spoken reply
+// within a short cooldown, covering the momentary drain→listening tail window.
+//
 // PATH 1 status: the STRUCTURE + wiring are here and unit-tested with fakes; the
-// live loop (real audio timing, interim-transcript handling, partial-text TTS,
-// cut-truncation into graph state) is tuned + validated ON-DEVICE (t-9), the same
-// way t-1's provider and the Silero engine are. All browser glue is injectable so
-// the orchestration logic is exercised without real Web Audio / sockets.
+// live loop (real audio timing, interim-transcript handling, partial-text TTS) is
+// tuned + validated ON-DEVICE (t-9 / spec-214 t-4), the same way t-1's provider and
+// the Silero engine are. All browser glue is injectable so the orchestration logic
+// is exercised without real Web Audio / sockets.
 
 import type { GuideElement, NavigationAdapter } from '../navigation/NavigationAdapter';
 import { SileroWorkletVadEngine } from '../micVad';
 import type { VadEngine } from '../micVad';
 import { WebAudioPlayback } from '../playbackQueue';
-import { BargeInController } from '../bargeIn';
-import type { PlaybackSink, CharAlignment } from '../bargeIn';
+import type { PlaybackSink } from '../bargeIn';
 import { createGuideGraph } from '../guideGraph';
+
+// spec-214 dec-3 — self-echo guard tuning. A committed transcript is dropped as the
+// agent's own echo ONLY when BOTH hold: it lands within the cooldown after speaking
+// ended, AND a high fraction of its tokens appear in the just-spoken reply. Both
+// gates together keep a genuine (dissimilar) user turn that happens to land in the
+// window — and a similar one that lands much later — from being swallowed.
+const SELF_ECHO_COOLDOWN_MS = 1500;
+const SELF_ECHO_CONTAINMENT_THRESHOLD = 0.6;
+
+/** Normalise to lowercase alphanumeric word tokens for the self-echo containment check. */
+function tokenize(text: string): string[] {
+  return text
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean);
+}
 import { dispatchGuideUiTool } from '../guideTools';
 import type { GuideCapabilities } from '../guideTools';
 import { setGuideAuthToken } from '../guideLlmClient';
@@ -32,6 +57,7 @@ import type {
   OrchestratorHooks,
   VoiceOrchestrator,
 } from '../session/orchestrator';
+import type { VoiceLoopState } from '../session/voiceSessionModel';
 
 /** Live screen context, read fresh each turn (screens are state — ac-11). */
 export interface ScreenContext {
@@ -71,6 +97,8 @@ export interface VoiceOrchestratorGlue {
   capture?: PcmCapture;
   graph?: ReturnType<typeof createGuideGraph>;
   newId?: () => string;
+  /** Injectable clock for the self-echo cooldown (dec-3); defaults to Date.now. */
+  now?: () => number;
 }
 
 type PlaybackImpl = PlaybackSink & {
@@ -92,16 +120,23 @@ class VoiceGuideOrchestrator implements VoiceOrchestrator {
   private vad: VadEngine | null = null;
   private playback: PlaybackImpl | null = null;
   private capture: PcmCapture | null = null;
-  private barge: BargeInController | null = null;
   private graph: ReturnType<typeof createGuideGraph>;
   private readonly threadId: string;
   private turnAbort: AbortController | null = null;
   private speakingRequestId: string | null = null;
   private stopped = false;
+  // spec-214 dec-1: the live loop state, tracked here so the mic→STT gate can read
+  // it synchronously. Mic PCM is forwarded to STT ONLY while this is 'listening'.
+  private loopState: VoiceLoopState = 'idle';
+  // spec-214 dec-3: token set of the reply most recently spoken, + when speaking
+  // last ended — together they drive the self-echo guard's containment + cooldown.
+  private lastSpokenTokens: Set<string> = new Set();
+  private speakingEndedAt: number | null = null;
   // spec-200 t-7: a one-shot opening context (a What's New entry) the guide
   // explains proactively on session start. Consumed on ws ready, then cleared.
   private openingContext: string | null = null;
   private readonly newId: () => string;
+  private readonly now: () => number;
 
   constructor(
     private readonly hooks: OrchestratorHooks,
@@ -109,6 +144,7 @@ class VoiceGuideOrchestrator implements VoiceOrchestrator {
     private readonly glue: VoiceOrchestratorGlue,
   ) {
     this.newId = glue.newId ?? (() => crypto.randomUUID());
+    this.now = glue.now ?? (() => Date.now());
     this.threadId = this.newId();
     // The graph touches no browser API, so it's safe at construction.
     // Layer-2 retrieval runs server-side every turn (ac-15), so an explicit
@@ -139,46 +175,44 @@ class VoiceGuideOrchestrator implements VoiceOrchestrator {
     // Capture non-null locals — TS resets instance-field narrowing after the
     // openVoiceWs / vad.start calls below.
     const vad = (this.vad = this.glue.vadEngine ?? new SileroWorkletVadEngine());
-    const playback = (this.playback = this.glue.playback ?? (new WebAudioPlayback() as PlaybackImpl));
+    this.playback = this.glue.playback ?? (new WebAudioPlayback() as PlaybackImpl);
     const capture = (this.capture = this.glue.capture ?? makePcmCapture());
-
-    // Barge-in over the playback sink (dec-8).
-    this.barge = new BargeInController(playback, {
-      abortTts: () => {
-        if (this.speakingRequestId) this.ws?.abort(this.speakingRequestId);
-      },
-      abortLlm: () => this.turnAbort?.abort(),
-      onCut: () => {
-        // The user cut in — stop speaking and return to listening. Truncating the
-        // assistant turn into graph state to the spoken prefix is on-device work.
-        this.speakingRequestId = null;
-        this.hooks.setLoopState('listening');
-      },
-    });
 
     this.ws = openVoiceWs(
       buildVoiceWsUrl(base, token, this.react.origin, getGuideBackend().voicePath),
       {
         onReady: () => {
-          this.ws?.startListening();
           // spec-200 t-7: if seeded, the guide opens by explaining the entry —
           // a proactive first turn grounded on the entry text (guideContext),
-          // requiring no user speech. Consumed once.
+          // requiring no user speech. Consumed once. While it speaks the mic→STT
+          // gate (dec-1) is closed, so the opening monologue can't be self-heard.
           const seed = this.openingContext;
           this.openingContext = null;
           if (seed && !this.stopped) {
             void this.runTurn('Tell me what this update is and why it matters, in a sentence or two.', [seed]);
+          } else if (!this.stopped) {
+            // No opening turn — open the first human-turn STT session and listen.
+            this.beginListeningTurn();
           }
         },
         onTranscript: (text, isFinal) => {
           if (!isFinal) return;
-          if (text.trim()) void this.runTurn(text);
+          const t = text.trim();
+          // spec-214 dec-3: drop the agent's own echo — a transcript that lands in
+          // the post-speaking cooldown AND largely repeats the just-spoken reply is
+          // the speaker tail bleeding into the fresh listening window, not the user.
+          if (t && this.isSelfEcho(t)) {
+            if (!this.stopped) this.beginListeningTurn();
+            return;
+          }
+          if (t) void this.runTurn(t);
           // Empty committed transcript (a throat-clear / noise tripped the VAD but
           // STT recognized no words). onSpeechEnd already moved us to 'thinking';
-          // with no turn to run we'd hang there forever. Recover to listening.
-          else if (!this.stopped) this.hooks.setLoopState('listening');
+          // with no turn to run we'd hang there forever. Recover to listening
+          // (re-opening the STT session for the next human turn — dec-2).
+          else if (!this.stopped) this.beginListeningTurn();
         },
-        onAudio: (_requestId, audio, alignment, isFinal) => this.onAudio(audio, alignment, isFinal),
+        onAudio: (_requestId, audio, _alignment, isFinal) => this.onAudio(audio, isFinal),
         onError: (message) => this.hooks.onError(message),
         onClose: () => {
           if (!this.stopped) this.hooks.onEnded();
@@ -188,43 +222,80 @@ class VoiceGuideOrchestrator implements VoiceOrchestrator {
     );
 
     await vad.start(stream, (speaking) => (speaking ? this.onSpeechStart() : this.onSpeechEnd()));
-    capture.start(stream, (pcm) => this.ws?.sendAudio(pcm));
-    this.hooks.setLoopState('listening');
+    // spec-214 dec-1: half-duplex gate. Forward mic PCM to the STT leg ONLY while
+    // the loop is `listening`. While the agent is speaking/thinking, its own
+    // speaker output (echo) is captured but never sent upstream — so it cannot be
+    // transcribed and answered (the self-talk loop). The local VAD still runs over
+    // the full stream for user-turn endpointing.
+    capture.start(stream, (pcm) => {
+      if (this.loopState === 'listening') this.ws?.sendAudio(pcm);
+    });
+    // Initial state: `listening` so onSpeechEnd endpoints and the gate is open
+    // before the ws `ready` frame arrives (ready then re-opens the STT session via
+    // beginListeningTurn, or runs the seeded opening turn).
+    this.enterState('listening');
+  }
+
+  /** spec-214 dec-1/dec-2: enter the live loop state and keep the internal
+   *  `loopState` (which the mic→STT gate reads) in lockstep with the pill's. */
+  private enterState(state: VoiceLoopState): void {
+    this.loopState = state;
+    this.hooks.setLoopState(state);
+  }
+
+  /** spec-214 dec-2: begin a human turn — open a FRESH STT session for it (so each
+   *  utterance is bounded to one human turn and never carries agent audio) and
+   *  enter `listening` (opening the mic→STT gate). */
+  private beginListeningTurn(): void {
+    if (this.stopped) return;
+    this.ws?.startListening();
+    this.enterState('listening');
   }
 
   private onSpeechStart(): void {
-    // If the agent is mid-speech, this ducks + arms the cut (dec-8). If idle, it's
-    // the user starting their turn — inert for barge-in.
-    const wasSpeaking = this.barge?.state === 'speaking' || this.barge?.state === 'ducked';
-    this.barge?.onSpeechStart();
-    if (wasSpeaking) this.hooks.setLoopState('ducked');
+    // spec-214 dec-4: voice barge-in is removed (supersedes spec-190/dec-8). While
+    // the agent is speaking, a VAD onset is IGNORED — no duck, no cut; the turn
+    // plays to completion. During `listening` it's the user starting their turn;
+    // the commit happens on speech END (onSpeechEnd). Nothing to do on onset.
   }
 
   private onSpeechEnd(): void {
-    const wasInterrupting = this.barge?.state === 'ducked';
-    this.barge?.onSpeechEnd();
-    if (wasInterrupting) return; // transient over agent speech — bargeIn restored it
+    // Only a speech-end DURING the user's listening turn ends an utterance. An onset/
+    // end while the agent is speaking or thinking is echo or noise (the gate already
+    // dropped its audio) — ignore it so it can't commit a turn (dec-1/dec-4).
+    if (this.loopState !== 'listening') return;
     // Genuine end of the user's turn: commit STT, ack ping immediately (masks the
     // retrieval + LLM latency, dec-6), and show "thinking".
     this.ws?.endUtterance();
     this.hooks.playEarcon('ping');
-    this.hooks.setLoopState('acknowledged');
-    this.hooks.setLoopState('thinking');
+    this.enterState('acknowledged');
+    this.enterState('thinking');
+  }
+
+  /** spec-214 dec-3: is this committed transcript the agent's own echo? True only
+   *  when it lands within the cooldown after speaking ended AND a high fraction of
+   *  its tokens appear in the just-spoken reply. Both gates required so a genuine,
+   *  dissimilar user turn in the window — or a similar turn long after — survives. */
+  private isSelfEcho(committed: string): boolean {
+    if (this.speakingEndedAt === null) return false;
+    if (this.now() - this.speakingEndedAt > SELF_ECHO_COOLDOWN_MS) return false;
+    if (this.lastSpokenTokens.size === 0) return false;
+    const tokens = tokenize(committed);
+    if (tokens.length === 0) return false;
+    let inSpoken = 0;
+    for (const tok of tokens) if (this.lastSpokenTokens.has(tok)) inSpoken++;
+    return inSpoken / tokens.length >= SELF_ECHO_CONTAINMENT_THRESHOLD;
   }
 
   private async runTurn(transcript: string, guideContext: string[] = []): Promise<void> {
-    // A new user turn supersedes any in-flight agent speech (barge-in, or a fast
-    // follow-up before the previous reply finished): stop the old TTS leg and flush
-    // its already-queued audio so the previous answer doesn't keep playing over this
-    // one. The duck-then-cut timer (dec-8) only fires on SUSTAINED speech; a short
-    // interjection ("standards", "stop") ends before it, so without this the old
-    // audio plays on. endTurn() resets barge state for the fresh turn.
+    // A new turn supersedes any in-flight agent speech (a fast follow-up before the
+    // previous reply finished, or a Stop→ask): stop the old TTS leg and flush its
+    // already-queued audio so the previous answer doesn't keep playing over this one.
     if (this.speakingRequestId) {
       this.ws?.abort(this.speakingRequestId);
       this.speakingRequestId = null;
     }
     this.playback?.flush();
-    this.barge?.endTurn();
 
     const { screenKey, screenRegistry } = this.react.getScreenContext();
     this.turnAbort = new AbortController();
@@ -254,7 +325,9 @@ class VoiceGuideOrchestrator implements VoiceOrchestrator {
       );
     } catch (err) {
       this.hooks.onError(err instanceof Error ? err.message : String(err));
-      this.hooks.setLoopState('listening');
+      // spec-214 dec-1/dec-2: recover through beginListeningTurn so the internal
+      // gate state (and a fresh STT session) follow the pill back to listening.
+      this.beginListeningTurn();
       // spec-211 t-1: settle the turn even on error so an awaiting sequencer
       // (dec-1) never hangs.
       this.hooks.onTurnComplete?.();
@@ -264,39 +337,42 @@ class VoiceGuideOrchestrator implements VoiceOrchestrator {
     if (assistantText.trim() && !this.stopped) {
       const requestId = this.newId();
       this.speakingRequestId = requestId;
-      // Reset the playback turn alongside the barge turn: this restores the gain to
-      // full (a prior barge-in duck-then-cut leaves it attenuated) and re-bases the
-      // played-ms clock used for truncation. Without it every reply after the first
-      // interruption plays at the ducked volume.
+      // spec-214 dec-3: remember what we're about to say so the self-echo guard can
+      // recognise this reply bleeding back into the mic after it plays out.
+      this.lastSpokenTokens = new Set(tokenize(assistantText));
+      // Re-base the playback turn (full gain + fresh played-ms clock).
       this.playback?.startTurn();
-      this.barge?.startTurn();
-      this.hooks.setLoopState('speaking');
+      // spec-214 dec-1: entering `speaking` closes the mic→STT gate — captured echo
+      // is no longer forwarded upstream.
+      this.enterState('speaking');
       this.ws?.speak(requestId, assistantText);
     } else {
-      this.hooks.setLoopState('listening');
-      // spec-211 t-1: no speech to play (empty/aborted) — settle immediately so an
-      // awaiting sequencer advances rather than hangs.
+      // No speech to play (empty/aborted). spec-214 dec-2: re-open the STT session
+      // for the next human turn. spec-211 t-1: settle so an awaiting sequencer
+      // advances rather than hangs.
+      this.beginListeningTurn();
       if (!this.stopped) this.hooks.onTurnComplete?.();
     }
   }
 
-  private onAudio(audio: ArrayBuffer, alignment: CharAlignment | undefined, isFinal: boolean): void {
+  private onAudio(audio: ArrayBuffer, isFinal: boolean): void {
     void this.playback?.enqueue(audio);
-    this.barge?.appendChunk(alignment);
     // isFinal marks the last chunk RECEIVED, but the audio is still playing out of
-    // the queue. Stay in 'speaking' — barge armed, the Stop control visible — until
-    // playback actually drains, so the user can interrupt for as long as they can
-    // hear the agent. onDrain fires immediately if nothing is queued.
+    // the queue. Stay in 'speaking' — the Stop control visible — until playback
+    // actually drains, so the user can hit Stop for as long as they hear the agent.
+    // onDrain fires immediately if nothing is queued.
     if (isFinal) this.playback?.onDrain(() => this.onPlaybackDrained());
   }
 
-  /** The agent's speech has fully played out (no interruption). Now — not on the
-   *  final-chunk receipt — return to listening and disarm the barge. */
+  /** The agent's speech has fully played out. Now — not on the final-chunk receipt
+   *  — return to listening (opening a fresh STT session for the next human turn). */
   private onPlaybackDrained(): void {
     if (this.stopped) return;
-    this.barge?.endTurn();
     this.speakingRequestId = null;
-    this.hooks.setLoopState('listening');
+    // spec-214 dec-3: mark when speaking ended so the self-echo guard's cooldown can
+    // catch the speaker tail bleeding into the start of this listening window.
+    this.speakingEndedAt = this.now();
+    this.beginListeningTurn();
     // spec-211 t-1: the agent's spoken turn has fully played out — signal the
     // client tour sequencer so it can advance one phase (dec-1).
     this.hooks.onTurnComplete?.();
@@ -307,8 +383,19 @@ class VoiceGuideOrchestrator implements VoiceOrchestrator {
     this.react.adapter.onPlaybackDrained?.();
   }
 
+  // spec-214 dec-4: Stop is the SOLE interruption (voice barge-in removed). Halt the
+  // in-flight LLM turn + TTS, flush queued audio, and return to listening with the
+  // session + mic still open (halt-and-stay, NOT end-and-restart).
   interrupt(): void {
-    this.barge?.tapInterrupt();
+    if (this.stopped) return;
+    this.turnAbort?.abort();
+    if (this.speakingRequestId) {
+      this.ws?.abort(this.speakingRequestId);
+      this.speakingRequestId = null;
+    }
+    this.playback?.flush();
+    this.speakingEndedAt = this.now();
+    this.beginListeningTurn();
   }
 
   // spec-211 t-1 (dec-1): a proactive narration turn for the demo walkthrough.
@@ -339,7 +426,6 @@ class VoiceGuideOrchestrator implements VoiceOrchestrator {
     this.capture?.stop();
     this.vad?.stop();
     this.playback?.dispose();
-    this.barge?.dispose();
   }
 }
 

--- a/packages/server/src/routes/voice.test.ts
+++ b/packages/server/src/routes/voice.test.ts
@@ -40,6 +40,10 @@ const SPEC = "mindset-prod/memex-building-itself/specs/spec-190";
 const AC6 = `${SPEC}/acs/ac-6`;
 const AC7 = `${SPEC}/acs/ac-7`;
 const AC32 = `${SPEC}/acs/ac-32`;
+// spec-214 — half-duplex server backstop (dec-2).
+const SPEC214 = "mindset-prod/memex-building-itself/specs/spec-214";
+const AC214_5 = `${SPEC214}/acs/ac-5`;
+const AC214_9 = `${SPEC214}/acs/ac-9`;
 
 const OK_AUTH: VoiceAuthResult = { ok: true, userId: "u1", closeCode: 1000, closeReason: "ok" };
 
@@ -165,6 +169,55 @@ describe("ac-7 — streaming TTS through the server", () => {
     expect(typeof audio[0].audio).toBe("string");
     expect(Buffer.from(audio[0].audio ?? "", "base64").toString()).toContain("hello");
     tagAc(AC7);
+  });
+});
+
+describe("spec-214 dec-2 — server drops inbound audio while a TTS speak is in flight", () => {
+  beforeEach(() => {
+    process.env.MEMEX_ELEVENLABS_FAKE = "1";
+    __resetVoiceProviderForTests();
+    clearFakeVoiceQueue();
+  });
+
+  it("ignores captured echo while speaking, then accepts audio again once listening (ac-9, ac-5)", async () => {
+    // The fake STT emits one interim transcript per pushAudio — so an interim is
+    // proof a frame reached STT. We assert frames sent WHILE the agent is speaking
+    // produce none (dropped, ac-9), and a frame sent after produces one (the leg
+    // works — the drop is conditional on speaking, not a broken STT). This is the
+    // self-talk regression guard (ac-5): the agent's own echo can't be transcribed.
+    enqueueFakeTranscript({
+      events: [
+        { text: "echo one", isFinal: false },
+        { text: "echo one two", isFinal: false },
+        { text: "the user finally speaks", isFinal: true },
+      ],
+    });
+    const { sink, sent } = recordingSink();
+    const s = new VoiceSession(sink, { configured: true, auth: OK_AUTH });
+    s.open();
+    s.handleText(JSON.stringify({ type: "start_listening" }));
+
+    // Agent begins speaking — ttsAborts is populated synchronously by speak().
+    s.handleText(JSON.stringify({ type: "speak", requestId: "r1", text: "hello there friend how are you" }));
+    // Speaker output bleeds into the mic while the agent talks — these frames must
+    // be DROPPED (not appended to STT), so no interim transcript appears.
+    s.handleBinary(new Uint8Array([1, 2, 3]));
+    s.handleBinary(new Uint8Array([4, 5, 6]));
+    await flush();
+
+    const interimsWhileSpeaking = sent.filter((m) => m.type === "transcript" && !m.isFinal);
+    expect(interimsWhileSpeaking).toHaveLength(0); // echo never reached STT (ac-9)
+    // TTS still streamed out normally.
+    expect(sent.some((m) => m.type === "audio")).toBe(true);
+
+    // Speaking has finished (ttsAborts drained) — a genuine user frame now reaches
+    // STT and yields an interim, proving the gate is conditional, not a dead leg.
+    s.handleBinary(new Uint8Array([7, 8, 9]));
+    await flush();
+    expect(sent.filter((m) => m.type === "transcript" && !m.isFinal).length).toBeGreaterThanOrEqual(1);
+
+    tagAc(AC214_9);
+    tagAc(AC214_5);
   });
 });
 

--- a/packages/server/src/routes/voice.ts
+++ b/packages/server/src/routes/voice.ts
@@ -282,9 +282,17 @@ export class VoiceSession {
     return false;
   }
 
-  /** A binary frame from the browser = a chunk of mic audio → STT. */
+  /** A binary frame from the browser = a chunk of mic audio → STT.
+   *
+   *  spec-214 dec-2 (server backstop): while a TTS `speak` is in flight for this
+   *  session, DROP inbound audio rather than appending it to STT. On a speaker-
+   *  equipped device the agent's own playback bleeds into the mic; forwarding it
+   *  would let STT transcribe Specky's own words and feed them back as a user turn
+   *  (the self-talk loop). The client also gates this (dec-1), but the server is
+   *  authoritative — it holds even if a client regresses. */
   handleBinary(bytes: Uint8Array): void {
     if (!this.active()) return;
+    if (this.ttsAborts.size > 0) return; // agent is speaking — ignore captured echo
     this.stt?.pushAudio(bytes);
   }
 
@@ -314,7 +322,8 @@ export class VoiceSession {
         break;
       }
       case "abort": {
-        // Barge-in cut (dec-8): abort the in-flight TTS for this request.
+        // Stop / new-turn supersede (spec-214 dec-4): abort the in-flight TTS for
+        // this request. (Was barge-in cut, dec-8 — voice barge-in now removed.)
         const ac = msg.requestId ? this.ttsAborts.get(msg.requestId) : undefined;
         ac?.abort();
         if (msg.requestId) this.ttsAborts.delete(msg.requestId);


### PR DESCRIPTION
## What & why
On INT, Specky talked to itself — "I am Specky" → "Hello Becky, I am Specky" → … — because the voice loop was **full-duplex**: the agent's own TTS leaked from the speakers into the mic, was transcribed by STT, and committed as a user turn, so it answered itself. Barbie/Barrie reported it; full root-cause in [spec-214](https://memex.ai/mindset-prod/memex-building-itself/specs/spec-214).

This makes the loop **half-duplex** and removes voice barge-in — the direction Barrie endorsed (ElevenLabs' own site avoids auto-interruptibility for the same reason).

## Changes (spec-214 dec-1..4)
- **dec-1 — mic→STT gate:** `voiceGuideOrchestrator` forwards mic PCM upstream only while loop state is `listening`. Echo captured while `speaking`/`thinking` never reaches the STT commit.
- **dec-2 — utterance bounding + backstop:** client re-issues `start_listening` on each entry to `listening` (fresh STT session per human turn). Server `VoiceSession.handleBinary` drops inbound audio while a TTS `speak` is in flight — authoritative, survives a client regression.
- **dec-3 — self-echo guard:** a committed transcript that echoes the just-spoken reply (token containment ≥ 0.6) **and** lands within a 1.5s cooldown is dropped — covers the brief drain→listening tail.
- **dec-4 — barge-in removed (⚠️ SUPERSEDES spec-190/dec-8):** the VAD no longer ducks/cuts the agent; it only endpoints the user's turn during `listening`. **Stop** is the sole interruption (halt-and-stay-listening, session stays open). `bargeIn.ts` is left as an unused shell — full delete deferred to keep the diff focused.

## Testing
- **9 new orchestrator tests** (`voiceGuideOrchestrator.spec-214.test.ts`) + **1 server backstop test** → ac-5…14.
- Full UI voice suite **73/73** green (existing spec-190/200/211 tests untouched); server voice **10/10**; `tsc` clean for these files.
- `make e2e-cold` **58/58**.
- **ac-4 validated live on-device through speakers**: Specky greets once then listens — no self-talk. (Headless tests can't reproduce real acoustic echo, so this was a manual gate.)

## ACs
13/14 implementation+scope ACs verified via emitted tests; ac-4 verified manually on-device (above).

## Notes for review
- dec-4 intentionally reverses the shipped duck-then-cut barge-in. If we later want conversational interruption back, it's a follow-up, not a regression.
- `bargeIn.ts` is now dead (no orchestrator wiring); its own unit tests still pass. Gut-vs-keep is a deferred cleanup call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)