### PR TITLE
spec-233: rename prose sub-tab "Spec" → "Narrative"

### DIFF
--- a/packages/ui/e2e/journey-15-spec-detail-layout.spec.ts
+++ b/packages/ui/e2e/journey-15-spec-detail-layout.spec.ts
@@ -68,10 +68,11 @@ test.describe("Spec detail layout", () => {
     await expect(bodyHeader.getByRole("button", { name: "Share", exact: true })).toHaveCount(0);
     await expect(bodyHeader.getByRole("button", { name: "Download Spec" })).toHaveCount(0);
 
-    // Plan-phase sub-tabs (post spec-164/159 redesign): the Spec sub-tab (the narrative) active by
-    // default, then Decisions & ACs, then Comments. Tasks moved under the Build
-    // PHASE tab (not a sub-tab pill here), so it's no longer in this row.
-    await expect(page.getByRole("button", { name: /^Spec\b/ })).toBeVisible();
+    // Plan-phase sub-tabs (post spec-164/159 redesign; spec-233 relabelled the
+    // prose tab "Spec" → "Narrative"): the Narrative sub-tab active by default,
+    // then Decisions & ACs, then Comments. Tasks moved under the Build PHASE tab
+    // (not a sub-tab pill here), so it's no longer in this row.
+    await expect(page.getByRole("button", { name: /^Narrative\b/ })).toBeVisible();
     await expect(page.getByRole("button", { name: /^Decisions & ACs/ })).toBeVisible();
     await expect(page.getByRole("button", { name: /^Comments/ })).toBeVisible();
 
@@ -89,7 +90,7 @@ test.describe("Spec detail layout", () => {
     // Switching sub-tabs is in-page — assert we're still on the spec, not that the
     // path is /docs/.
     await expect(page).toHaveURL(/\/specs\//);
-    await page.getByRole("button", { name: /^Spec\b/ }).click();
+    await page.getByRole("button", { name: /^Narrative\b/ }).click();
 
     // Floating outline (DocOutline) — Segments label + section list visible. The
     // seeded spec's first section is the createDocDraft "Overview" (not "Purpose").

--- a/packages/ui/e2e/journey-21-spec-196-narrative.spec.ts
+++ b/packages/ui/e2e/journey-21-spec-196-narrative.spec.ts
@@ -13,8 +13,9 @@
 //
 // Seeding goes over the env-gated test surface (no raw SQL): seed-spec,
 // seed-open-decision, seed-ac, seed-task, set-doc-status, consolidate-narrative.
-// Navigation is path-based [per std-2]. The sub-tab reading "Spec" (t-1) is
-// asserted by journey-15's layout walk.
+// Navigation is path-based [per std-2]. The prose sub-tab reading "Narrative"
+// (spec-233 t-1, reversing spec-196 dec-1's "Spec") is asserted inline in the
+// gate test below; the layout walk also lives in journey-15.
 
 import {
   test,
@@ -34,11 +35,16 @@ import {
 } from "./helpers/retained.js";
 
 const SPEC196 = "mindset-prod/memex-building-itself/specs/spec-196";
+const SPEC233 = "mindset-prod/memex-building-itself/specs/spec-233";
 const ACS_BY_TEST: Record<string, string[]> = {
   "specify→build gate: stale narrative blocks the offer; consolidation restores it": [
     `${SPEC196}/acs/ac-3`,
     `${SPEC196}/acs/ac-4`,
     `${SPEC196}/acs/ac-9`,
+    // spec-233 t-1: the prose sub-tab reads "Narrative" and still routes (ac-2);
+    // no UI/flow asserts the old "Spec" label (ac-5).
+    `${SPEC233}/acs/ac-2`,
+    `${SPEC233}/acs/ac-5`,
   ],
   '"Read the spec" on a done Spec: full record inline, no reopen, no phase change': [
     `${SPEC196}/acs/ac-12`,
@@ -95,6 +101,21 @@ test("specify→build gate: stale narrative blocks the offer; consolidation rest
   const rubicon = page.getByTestId("transition-sentence");
   await expect(rubicon).toContainText(/1 Decision must be resolved/i, { timeout: 15_000 });
   await expect(rubicon).not.toContainText(/spec narrative/i);
+
+  // spec-233 t-1 (ac-2, ac-5): the prose sub-tab reads "Narrative", not "Spec"
+  // — "Spec" names the whole object. Clicking it opens the prose view, and the
+  // unchanged 'narrative' id keeps routing working (away to Decisions & ACs and
+  // back).
+  const subTabs = page.getByTestId("canvas");
+  const narrativeTab = subTabs.getByRole("button", { name: "Narrative", exact: true });
+  await expect(narrativeTab).toBeVisible({ timeout: 15_000 });
+  await expect(subTabs.getByRole("button", { name: "Spec", exact: true })).toHaveCount(0);
+  await page.getByRole("button", { name: /Decisions & ACs/ }).click();
+  await expect(page.getByTestId("decision-panel")).toBeVisible({ timeout: 15_000 });
+  await narrativeTab.click();
+  await expect(page.getByText("Exercise the spec-narrative staleness gate.")).toBeVisible({
+    timeout: 15_000,
+  });
 
   // Resolve the decision through the real UI (editor posture required).
   await switchToEditing(page);

--- a/packages/ui/src/pages/DocDocument.spec-159.test.tsx
+++ b/packages/ui/src/pages/DocDocument.spec-159.test.tsx
@@ -206,7 +206,7 @@ describe('spec-159 t-6 — DocDocument phase layouts', () => {
     renderAt('specify');
 
     // Specify view is current → its sub-tab bar shows Spec / Decisions & ACs / Comments.
-    await screen.findByText('Spec');
+    await screen.findByText('Narrative');
     expect(screen.getByText('Decisions & ACs')).toBeInTheDocument();
     expect(screen.getByText('Comments')).toBeInTheDocument();
 
@@ -284,7 +284,7 @@ describe('spec-159 t-6 — DocDocument phase layouts', () => {
   it('mounts no PhaseDropdown and no other phase-control affordance (ac-1)', async () => {
     tagAc(AC(1));
     renderAt('specify');
-    await screen.findByText('Spec');
+    await screen.findByText('Narrative');
 
     // No listbox-style phase dropdown trigger anywhere.
     expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
@@ -349,7 +349,7 @@ describe('spec-159 — Rubicon line + in-situ directives', () => {
     const user = userEvent.setup();
     docDecisions = [decision('d-1', 'open')];
     renderAt('specify');
-    await screen.findByText('Spec');
+    await screen.findByText('Narrative');
 
     await user.click(phaseTab('build'));
     const sentence = screen.getByTestId('transition-sentence');
@@ -362,7 +362,7 @@ describe('spec-159 — Rubicon line + in-situ directives', () => {
     // No → back to the current phase's view, no phase mutation.
     await user.click(within(sentence).getByRole('button', { name: 'No' }));
     expect(phaseTab('specify')).toHaveAttribute('data-selected', 'true');
-    expect(screen.getByText('Spec')).toBeInTheDocument();
+    expect(screen.getByText('Narrative')).toBeInTheDocument();
     expect(updateDocStatus).not.toHaveBeenCalled();
   });
 
@@ -454,7 +454,7 @@ describe('spec-159 — Rubicon line + in-situ directives', () => {
     docDecisions = [decision('d-1', 'open')];
     docTasks = [{ id: 't-1', status: 'in_progress' }];
     renderAt('specify');
-    await screen.findByText('Spec');
+    await screen.findByText('Narrative');
 
     await user.click(phaseTab('build'));
     await screen.findByTestId('task-panel');
@@ -472,7 +472,7 @@ describe('spec-159 — Rubicon line + in-situ directives', () => {
     await screen.findByTestId('task-panel');
 
     await user.click(phaseTab('specify'));
-    await screen.findByText('Spec');
+    await screen.findByText('Narrative');
     expect(phaseTab('build')).toHaveAttribute('data-current', 'true');
 
     // The refetch after the transition returns the moved doc.
@@ -493,7 +493,7 @@ describe('spec-159 — Rubicon line + in-situ directives', () => {
     tagAc(AC(19));
     mockRole = 'editor';
     renderAt('specify');
-    await screen.findByText('Spec');
+    await screen.findByText('Narrative');
 
     // Editors still get the PhaseTabBar (3 phase tabs) and the Rubicon line.
     expect(screen.getAllByRole('tab')).toHaveLength(3);
@@ -590,7 +590,7 @@ describe('spec-182 — unified reviewer phase block', () => {
     mockRole = 'editor';
     const user = userEvent.setup();
     renderAt('specify');
-    await screen.findByText('Spec');
+    await screen.findByText('Narrative');
 
     const header = screen.getByTestId('header-slot');
     // findByRole: the header slot populates via a useHeaderSlot effect a tick
@@ -682,7 +682,7 @@ describe('spec-182 — unified reviewer phase block', () => {
     tagAc(AC182(3));
     renderAt('draft');
 
-    await screen.findByText('Spec');
+    await screen.findByText('Narrative');
     expect(screen.queryByTestId('review-action-row')).not.toBeInTheDocument();
     expect(screen.queryByTestId('review-handoff-line')).not.toBeInTheDocument();
   });

--- a/packages/ui/src/pages/DocDocument.spec-196.test.tsx
+++ b/packages/ui/src/pages/DocDocument.spec-196.test.tsx
@@ -1,12 +1,20 @@
-// spec-196 t-1 — the Specify sub-tab label "Narrative" → "Spec".
+// spec-196 t-1 / spec-233 t-1 — the prose sub-tab label.
 //
-// dec-1: the rename is UI-label-only. The tab READS "Spec" (the prose sections
-// ARE the spec) while its id stays 'narrative' — internal vocabulary, deep
-// links, and comment routing are deliberately unchanged.
+// spec-196 dec-1 renamed "Narrative" → "Spec". spec-233 dec-1 REVERSES that
+// back to "Narrative": labelling one tab "Spec" misread as if that tab were the
+// whole object. The whole object is the Spec; this tab is the prose lens within
+// it. The rename stays UI-label-only — the id stays 'narrative', so internal
+// vocabulary, deep links, and comment routing are unchanged across both specs.
 //
-//   ac-1 : the sub-tab reads "Spec"; "Narrative" no longer appears in the UI.
-//   ac-5 : deep links / routing to the narrative tab keep working.
-//   ac-6 : label "Spec", id 'narrative' — both pinned.
+// The label-bearing assertions now tag spec-233 (it owns the current label);
+// the still-true id/routing invariant keeps tagging spec-196 ac-5.
+//
+//   spec-233 ac-1 : the sub-tab reads "Narrative"; no tab reads "Spec".
+//   spec-233 ac-2 : clicking it opens the prose view; routing is unchanged.
+//   spec-233 ac-4 : source pins label 'Narrative' with id 'narrative'.
+//   spec-233 ac-5 : no test/source pins the old "Spec" label.
+//   spec-196 ac-5 : deep links / routing to the narrative tab keep working.
+//   spec-196 ac-9 : the narrative-staleness Rubicon gate (label-independent).
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { readFileSync } from 'node:fs';
@@ -19,6 +27,7 @@ import { tagAc } from '@memex-ai-ac/vitest';
 import type { DocWithGraph } from '../api/types';
 
 const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-196/acs/ac-${n}`;
+const AC233 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-233/acs/ac-${n}`;
 
 // ── Heavy children → identity markers (same trim as the spec-159 suite) ─────
 vi.mock('../components/DecisionPanel', () => ({
@@ -152,37 +161,37 @@ beforeEach(() => {
   docNarrativeConsolidatedAt = null;
 });
 
-describe('spec-196 t-1 — Specify sub-tab reads "Spec", id stays narrative', () => {
-  it('renders the sub-tab as "Spec"; "Narrative" appears nowhere; sections are the default view (ac-1, ac-6)', async () => {
-    tagAc(AC(1));
-    tagAc(AC(6));
+describe('spec-233 t-1 — prose sub-tab reads "Narrative", id stays narrative', () => {
+  it('renders the sub-tab as "Narrative"; no tab reads "Spec"; sections are the default view (ac-1, ac-4)', async () => {
+    tagAc(AC233(1));
+    tagAc(AC233(4));
     renderAt();
 
-    // The first sub-tab reads "Spec".
-    expect(await screen.findByRole('button', { name: 'Spec' })).toBeInTheDocument();
-    // The old label is gone from the rendered UI.
-    expect(screen.queryByText('Narrative')).not.toBeInTheDocument();
+    // The first sub-tab reads "Narrative".
+    expect(await screen.findByRole('button', { name: 'Narrative' })).toBeInTheDocument();
+    // No sub-tab is labelled "Spec" — "Spec" is reserved for the whole object.
+    expect(screen.queryByRole('button', { name: 'Spec' })).not.toBeInTheDocument();
     // It's still the default sub-tab: the narrative (section cards) renders.
     expect(screen.getByTestId('section-card')).toBeInTheDocument();
   });
 
-  it('the renamed tab still routes on the internal id — away to Decisions & ACs and back (ac-5, ac-6)', async () => {
+  it('the renamed tab still routes on the internal id — away to Decisions & ACs and back (spec-233 ac-2, spec-196 ac-5)', async () => {
+    tagAc(AC233(2));
     tagAc(AC(5));
-    tagAc(AC(6));
     const user = userEvent.setup();
     renderAt();
 
-    await screen.findByText('Spec');
+    await screen.findByText('Narrative');
 
     // Away: Decisions & ACs renders its two-column panels.
     await user.click(screen.getByText('Decisions & ACs'));
     expect(screen.getByTestId('decision-panel')).toBeInTheDocument();
     expect(screen.queryByTestId('section-card')).not.toBeInTheDocument();
 
-    // Back: the "Spec" tab routes to the narrative view via the unchanged
+    // Back: the "Narrative" tab routes to the prose view via the unchanged
     // 'narrative' id (deep-link integrity itself is covered by the spec-158 /
     // spec-100 suites, which key on these ids, not labels).
-    await user.click(screen.getByText('Spec'));
+    await user.click(screen.getByText('Narrative'));
     expect(screen.getByTestId('section-card')).toBeInTheDocument();
   });
 
@@ -226,15 +235,19 @@ describe('spec-196 t-1 — Specify sub-tab reads "Spec", id stays narrative', ()
     );
   });
 
-  it("source pins the pair: label 'Spec' with id 'narrative' (ac-6)", () => {
-    tagAc(AC(6));
+  it("source pins the pair: label 'Narrative' with id 'narrative' (ac-3, ac-4, ac-5)", () => {
+    tagAc(AC233(3));
+    tagAc(AC233(4));
+    tagAc(AC233(5));
     const src = readFileSync(
       join(dirname(fileURLToPath(import.meta.url)), 'DocDocument.tsx'),
       'utf8',
     );
-    // dec-1: the label renames, the id does not. A drive-by "consistency"
-    // rename of the id would break deep links and comment routing — fail here.
-    expect(src).toMatch(/id:\s*'narrative',\s*label:\s*'Spec'/);
-    expect(src).not.toMatch(/label:\s*'Narrative'/);
+    // spec-233 dec-1: the label renames back to "Narrative"; the id does not.
+    // A drive-by "consistency" rename of the id would break deep links and
+    // comment routing — fail here. And no source still pins the old "Spec"
+    // label (ac-5).
+    expect(src).toMatch(/id:\s*'narrative',\s*label:\s*'Narrative'/);
+    expect(src).not.toMatch(/label:\s*'Spec'/);
   });
 });

--- a/packages/ui/src/pages/DocDocument.tsx
+++ b/packages/ui/src/pages/DocDocument.tsx
@@ -875,10 +875,12 @@ export function DocDocument() {
 
   // Plan's three sub-tabs. Build / Verify carry no sub-tab bar (ac-11).
   const planSubTabs = [
-    /* spec-196 dec-1 / ac-1+ac-6: the label reads "Spec" (the prose sections ARE
-       the spec); the id stays 'narrative' — internal vocabulary and deep links
-       are deliberately unchanged. */
-    { id: 'narrative', label: 'Spec', count: sectionCommentCount, countVariant: 'warning' as const },
+    /* spec-233 dec-1 (supersedes spec-196 dec-1): the label reads "Narrative".
+       Calling this single tab "Spec" misread as if it WERE the whole spec — the
+       whole object is the Spec; this tab is the prose lens within it. The id
+       stays 'narrative' — internal vocabulary, deep links and comment routing
+       are deliberately unchanged (display-label-only). */
+    { id: 'narrative', label: 'Narrative', count: sectionCommentCount, countVariant: 'warning' as const },
     { id: 'decisions', label: 'Decisions & ACs', count: decisionCommentCount, countVariant: 'warning' as const },
     { id: 'comments', label: 'Comments', count: totalCommentCount, countVariant: 'warning' as const },
   ];


### PR DESCRIPTION
## What & why

Renames the prose sub-tab on the spec view from **"Spec"** → **"Narrative"**, reversing spec-196 dec-1. Onboarding feedback (Ryan & Christine) showed that labelling one tab "Spec" reads as if that single tab *is* the spec — disorienting new users at exactly the point they start specifying. The whole object is the Spec; this tab is the prose lens within it.

Implements **spec-233** (`mindset-prod/memex-building-itself/specs/spec-233`).

## Scope

Display-label-only. The sub-tab `id` stays `'narrative'`, so deep links, comment routing, and `handleTabChange` are unchanged.

- `DocDocument.tsx` — `label: 'Spec'` → `'Narrative'` at the `planSubTabs` call site (id unchanged)
- `DocDocument.spec-196.test.tsx` — assertions flipped to "Narrative"; label ACs re-tagged to spec-233 (ac-1…5); the still-true id/routing test keeps spec-196 ac-5, staleness test keeps ac-9
- `DocDocument.spec-159.test.tsx` — sub-tab anchor text updated
- `journey-15` + `journey-21` — assert the "Narrative" tab + unchanged routing [per std-28]

## Verification

- UI vitest: **1088 passed** / 1 skipped; `tsc -b` clean
- `make e2e-cold` (full suite): **58 passed, 0 failed**

## Notes

- **Supersedes spec-196 dec-1** (and the human-facing "spec"/"Narrative" vocabulary it introduced). spec-196 ac-1/ac-6 (which asserted the tab reads "Spec") are now factually reversed — their verifying tests were re-pointed at spec-233, so they'll read *stale* rather than *failing*. Recommend marking spec-196 ac-1/ac-6 superseded (out of scope here).
- spec-233 ACs (ac-1…5) verify via CI's emission key on this PR. (Local laptop emission is currently blocked by a separate prod `/api/test-events` key-store inconsistency — reported to Barrie/Wic; unrelated to this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)