### PR TITLE
fix(rls): exclude memex_emission_keys from RLS to restore /api/test-events auth (prod emission outage)

### DIFF
--- a/packages/server/drizzle/0087_emission_keys_rls_exclusion.sql
+++ b/packages/server/drizzle/0087_emission_keys_rls_exclusion.sql
@@ -1,0 +1,33 @@
+-- Exclude memex_emission_keys from RLS: it is an identity-ESTABLISHMENT table.
+--
+-- verifyEmissionKey() (services/emission-keys.ts) queries this table to
+-- AUTHENTICATE POST /api/test-events before any ALS tenant context exists:
+-- the key lookup is itself what resolves the tenant. This is the same
+-- chicken-and-egg that excluded user_memex_access from 0081 ("queried in
+-- publicSessionMiddleware before ALS sets memex_id; adding a standard policy
+-- breaks session establishment with 0 rows"), but this table was missed.
+--
+-- 2026-06-10 incident: the spec-199 t-14 role cutover (DATABASE_URL user
+-- postgres → memex_app, revision memex-api-00050-dnd) activated 0081's policy
+-- on this table. With no app.memex_id GUC set at verify time, the USING clause
+-- filtered every row, verifyEmissionKey() hit its null branch, and every
+-- emission key (UI-minted, freshly-minted, and CI's) returned 401 from
+-- /api/test-events. Platform-wide AC emission was down from 09:25:34Z (last
+-- test_event saved one second before the new revision took traffic). The
+-- fire-and-forget bumpLastUsed() UPDATE was silently filtered by the same
+-- policy.
+--
+-- Why exclusion is safe here:
+--   * Tenant isolation is enforced at the service layer: every read/write in
+--     services/emission-keys.ts is scoped by memexId in its WHERE clause
+--     (list, revoke), and the verify path's spec-129 ac-10 check confirms the
+--     key's memexId matches the memex named in ac_uid.
+--   * The stored secret is a SHA-256 hash of a 256-bit-entropy key, so row
+--     visibility carries no credential risk.
+--
+-- Guarded by __regression__/emission-key-contextless-verify.regression.test.ts,
+-- which pins "key verification must work before tenant context exists" against
+-- any future RLS sweep re-adding this table.
+DROP POLICY IF EXISTS memex_emission_keys_memex_isolation ON memex_emission_keys;
+ALTER TABLE memex_emission_keys NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE memex_emission_keys DISABLE ROW LEVEL SECURITY;

--- a/packages/server/drizzle/reverts/0087_emission_keys_rls_exclusion.revert.sql
+++ b/packages/server/drizzle/reverts/0087_emission_keys_rls_exclusion.revert.sql
@@ -1,0 +1,17 @@
+-- Revert 0087_emission_keys_rls_exclusion.sql: re-apply RLS to
+-- memex_emission_keys in its 0086 shape (nullif-guarded uuid cast).
+-- WARNING: reverting re-breaks /api/test-events key verification under the
+-- memex_app runtime role (the 2026-06-10 outage): only do this together with
+-- a code change that gives the verify path a tenant-context-free lookup.
+ALTER TABLE memex_emission_keys ENABLE ROW LEVEL SECURITY;
+ALTER TABLE memex_emission_keys FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS memex_emission_keys_memex_isolation ON memex_emission_keys;
+CREATE POLICY memex_emission_keys_memex_isolation ON memex_emission_keys
+  USING (
+    nullif(current_setting('app.memex_id', true), '') IS NOT NULL
+    AND memex_id = nullif(current_setting('app.memex_id', true), '')::uuid
+  )
+  WITH CHECK (
+    nullif(current_setting('app.memex_id', true), '') IS NOT NULL
+    AND memex_id = nullif(current_setting('app.memex_id', true), '')::uuid
+  );

--- a/packages/server/src/__regression__/emission-key-contextless-verify.regression.test.ts
+++ b/packages/server/src/__regression__/emission-key-contextless-verify.regression.test.ts
@@ -1,0 +1,112 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { eq, inArray, sql } from "drizzle-orm";
+import postgres from "postgres";
+import { db } from "../db/connection.js";
+import { memexEmissionKeys, memexes, namespaces } from "../db/schema.js";
+import {
+  generateRawKey,
+  hashKey,
+  displayPrefix,
+  verifyEmissionKey,
+} from "../services/emission-keys.js";
+
+// Regression guard for the 2026-06-10 emission outage.
+//
+// memex_emission_keys is an identity-ESTABLISHMENT table: verifyEmissionKey()
+// is the query that AUTHENTICATES POST /api/test-events, so it necessarily
+// runs before any ALS tenant context exists: the key lookup is what resolves
+// the tenant. Migration 0081 (spec-199 Phase 2) put a memex_id RLS policy on
+// it anyway; the policy lay dormant while the runtime connected as `postgres`
+// (BYPASSRLS) and detonated the moment t-14 cut DATABASE_URL over to the
+// `memex_app` role: with no app.memex_id GUC set at verify time the policy
+// filtered every row, verifyEmissionKey() hit its null branch, and every key
+// (UI-minted, freshly-minted, CI's) got 401. Platform-wide AC emission was
+// down from 09:25:34Z until migration 0087 excluded the table from RLS.
+//
+// These tests pin the invariant "key verification must work before tenant
+// context exists" against any future RLS sweep re-adding this table. The
+// production path is simulated the same way as spec-199-rls-schema.test.ts:
+// SET LOCAL ROLE memex_app inside a transaction drops BYPASSRLS, so the
+// connection sees exactly what Cloud Run's runtime role sees.
+
+const NS_SLUG = "emission-rls-regress-ns";
+
+describe("regression: emission-key verification needs no tenant context (0087)", () => {
+  let memexId: string;
+  let rawKey: string;
+
+  beforeAll(async () => {
+    const [ns] = await db
+      .insert(namespaces)
+      .values({ slug: NS_SLUG, kind: "org" })
+      .returning({ id: namespaces.id });
+    const [mx] = await db
+      .insert(memexes)
+      .values({ namespaceId: ns!.id, slug: "emission-rls-regress-mx", name: "Emission RLS Regress" })
+      .returning({ id: memexes.id });
+    memexId = mx!.id;
+
+    rawKey = generateRawKey();
+    await db.insert(memexEmissionKeys).values({
+      memexId,
+      name: "contextless-verify regression",
+      hashedKey: hashKey(rawKey),
+      prefix: displayPrefix(rawKey),
+    });
+  });
+
+  afterAll(async () => {
+    // Clean up in FK order; the test namespace is kind='org' without
+    // owner_org_id (test-only shortcut), which would otherwise trip the
+    // owner-XOR invariant check in migration-smoke.api.test.ts.
+    if (memexId) {
+      await db
+        .delete(memexEmissionKeys)
+        .where(eq(memexEmissionKeys.memexId, memexId))
+        .catch(() => {});
+      await db.delete(memexes).where(inArray(memexes.id, [memexId])).catch(() => {});
+    }
+    await db.delete(namespaces).where(eq(namespaces.slug, NS_SLUG)).catch(() => {});
+  });
+
+  it("memex_emission_keys has RLS disabled (migration 0087 applied)", async () => {
+    const rows = (await db.execute(sql`
+      SELECT c.relrowsecurity AS rowsecurity,
+             c.relforcerowsecurity AS forcerowsecurity
+      FROM pg_class c
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+      WHERE n.nspname = 'public' AND c.relname = 'memex_emission_keys'
+    `)) as unknown as Array<{ rowsecurity: boolean; forcerowsecurity: boolean }>;
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.rowsecurity, "RLS re-enabled on memex_emission_keys: this re-breaks /api/test-events auth").toBe(false);
+    expect(rows[0]!.forcerowsecurity).toBe(false);
+  });
+
+  it("memex_app role with NO GUC finds the key row (the verifyEmissionKey production path)", async () => {
+    const dbUrl =
+      process.env.DATABASE_URL ?? "postgresql://postgres:postgres@localhost:5432/memex";
+    const superSql = postgres(dbUrl, { max: 1 });
+    try {
+      // The exact lookup verifyEmissionKey() issues, run as the Cloud Run
+      // runtime role with no app.memex_id set. Before 0087 this returned
+      // 0 rows and every emission 401'd.
+      const rows = await superSql.begin(async (tx) => {
+        await tx.unsafe("SET LOCAL ROLE memex_app");
+        return tx.unsafe(
+          "SELECT id FROM memex_emission_keys WHERE hashed_key = $1 AND revoked_at IS NULL",
+          [hashKey(rawKey)],
+        );
+      });
+      expect(rows).toHaveLength(1);
+    } finally {
+      await superSql.end({ timeout: 5 });
+    }
+  });
+
+  it("verifyEmissionKey() resolves the key end to end", async () => {
+    const row = await verifyEmissionKey(rawKey);
+    expect(row).not.toBeNull();
+    expect(row!.memexId).toBe(memexId);
+  });
+});

--- a/packages/server/src/db/spec-199-rls-schema.test.ts
+++ b/packages/server/src/db/spec-199-rls-schema.test.ts
@@ -165,9 +165,15 @@ describe("spec-199 ac-16: RLS tenant isolation", () => {
     ).rejects.toThrow();
   });
 
-  it("ac-16: RLS is enabled and forced on all 14 tenant tables", async () => {
+  it("ac-16: RLS is enabled and forced on all 13 tenant tables", async () => {
     tagAc(AC_15);
     tagAc(AC_16);
+
+    // memex_emission_keys is deliberately absent: it is an identity-
+    // establishment table (verifyEmissionKey runs before ALS context exists)
+    // and was excluded from RLS by migration 0087 after the 2026-06-10
+    // emission outage. See 0087_emission_keys_rls_exclusion.sql and
+    // __regression__/emission-key-contextless-verify.regression.test.ts.
 
     // pg_class has relrowsecurity + relforcerowsecurity (pg_tables lacks the latter)
     const rows = (await db.execute(sql`
@@ -181,7 +187,7 @@ describe("spec-199 ac-16: RLS tenant isolation", () => {
         AND c.relname IN (
           'documents', 'standard_clauses', 'clause_refs', 'doc_comments',
           'decisions', 'tasks', 'acs', 'issues', 'doc_members', 'doc_assignees',
-          'tags', 'document_tags', 'memex_emission_keys', 'repos'
+          'tags', 'document_tags', 'repos'
         )
       ORDER BY c.relname
     `)) as unknown as Array<{
@@ -193,7 +199,7 @@ describe("spec-199 ac-16: RLS tenant isolation", () => {
     const expected = [
       "acs", "clause_refs", "decisions", "doc_assignees", "doc_comments",
       "doc_members", "document_tags", "documents", "issues",
-      "memex_emission_keys", "repos", "standard_clauses", "tags", "tasks",
+      "repos", "standard_clauses", "tags", "tasks",
     ];
 
     expect(rows.length, "table count mismatch").toBe(expected.length);
@@ -229,10 +235,11 @@ describe("spec-199 ac-16: RLS tenant isolation", () => {
     }
   });
 
-  it("ac-16: all 14 tables have the memex_isolation policy covering ALL commands", async () => {
+  it("ac-16: all 13 tables have the memex_isolation policy covering ALL commands", async () => {
     tagAc(AC_15);
     tagAc(AC_16);
 
+    // memex_emission_keys excluded by migration 0087 (see the 13-table test above).
     const rows = (await db.execute(sql`
       SELECT tablename, policyname, cmd
       FROM pg_policies
@@ -240,7 +247,7 @@ describe("spec-199 ac-16: RLS tenant isolation", () => {
         AND tablename IN (
           'documents', 'standard_clauses', 'clause_refs', 'doc_comments',
           'decisions', 'tasks', 'acs', 'issues', 'doc_members', 'doc_assignees',
-          'tags', 'document_tags', 'memex_emission_keys', 'repos'
+          'tags', 'document_tags', 'repos'
         )
         AND policyname = tablename || '_memex_isolation'
       ORDER BY tablename
@@ -250,7 +257,7 @@ describe("spec-199 ac-16: RLS tenant isolation", () => {
       cmd: string;
     }>;
 
-    expect(rows.length, "policy count mismatch — some tables are missing their policy").toBe(14);
+    expect(rows.length, "policy count mismatch — some tables are missing their policy").toBe(13);
     for (const row of rows) {
       expect(row.cmd, `${row.tablename}: policy should cover ALL commands`).toBe("ALL");
     }


### PR DESCRIPTION
## Incident

Since **2026-06-10 09:25:34 UTC**, every `POST /api/test-events` on memex.ai has returned `401 {"error":"unauthorized","message":"A valid emission key is required..."}` for every emission key: UI-minted, freshly-minted, and CI's (PR #111's run 27298993177 got 401 on every AC across every spec). Platform-wide AC emission is down; tests pass in CI but no test_event can be recorded, so every spec's ACs sit at untested.

## Root cause

Migration `0081_rls_phase2_tenant_tables.sql` (spec-199 Phase 2) put a standard `memex_id` RLS policy on `memex_emission_keys` and FORCEd it. The policy lay dormant while the runtime connected as `postgres` (BYPASSRLS). The t-14 cutover, shipped in revision `memex-api-00050-dnd` at 09:25 UTC, switched `DATABASE_URL` to the `memex_app` role (NOBYPASSRLS), activating every policy.

`memex_emission_keys` is an identity-establishment table: `verifyEmissionKey()` is the query that *authenticates* `/api/test-events`, so it necessarily runs before any ALS tenant context exists; the key lookup is itself what resolves the tenant. With no `app.memex_id` GUC set, the policy's USING clause filters every row, `verifyEmissionKey()` hits its null branch, and the route 401s unconditionally. This is the exact chicken-and-egg for which 0081's own header excluded `user_memex_access` ("queried in publicSessionMiddleware before ALS sets memex_id; adding a standard policy breaks session establishment with 0 rows"); this table was missed.

The UI mint/list/revoke paths kept working because they run inside authenticated sessions where ALS sets the GUC, which is why minted keys "list as active" while failing at verify.

### Evidence

- Single Cloud Run revision serving 100% traffic; all env identical between revisions 00049 and 00050 **except** the DATABASE_URL user: `postgres` -> `memex_app`. (Disproves the earlier revision/DB-split theory.)
- Prod DB, as `memex_app` with no GUC: `SELECT count(*) FROM memex_emission_keys` returns **0**. With the GUC set to memex-building-itself's id: **9 keys, 8 active**, including one minted tonight. Mint was never broken; only the contextless lookup is.
- `pg_class`: `memex_emission_keys` has `relrowsecurity = t, relforcerowsecurity = t`. The other tables in the route's path (`memexes`, `namespaces`, `test_events`, `test_event_latest`) have no RLS, so this is the only broken link.
- Last test_event saved 09:25:34Z; the new revision was stamped 09:25:35Z. Thousands of events per hour landed right up to that second, zero since.

## What this PR does

1. **`drizzle/0087_emission_keys_rls_exclusion.sql`** (hand migration, applied by `apply-hand-migrations.sh` during deploy before traffic cutover): drops `memex_emission_keys_memex_isolation`, then `NO FORCE` + `DISABLE ROW LEVEL SECURITY` on `memex_emission_keys`. Header documents the incident and the rationale. Because enforcement lives in Postgres, the fix takes effect for the already-serving revision the moment the migration commits; the deploy that follows is a no-op for this bug.
2. **`drizzle/reverts/0087_...revert.sql`**: restores the policy in its 0086 shape, per the repo's revert convention, with a warning that reverting re-breaks emission auth unless the verify path gains a context-free lookup first.
3. **`src/db/spec-199-rls-schema.test.ts`**: the three pinned table lists drop `memex_emission_keys` (14 -> 13), with a comment pointing at 0087 and the new regression test.
4. **`src/__regression__/emission-key-contextless-verify.regression.test.ts`** (new): the test that would have caught this. It seeds a key, then runs the exact `verifyEmissionKey` lookup inside a transaction under `SET LOCAL ROLE memex_app` (the production runtime role, NOBYPASSRLS) with **no** GUC set, and asserts the row is found. Also pins `pg_class` rowsecurity = false on this table, and exercises `verifyEmissionKey()` end to end. This pins the invariant "key verification must work before tenant context exists" against any future RLS sweep re-adding the table.

## Why this is deemed safe

- **Tenant isolation is preserved at the service layer.** Every read/write in `services/emission-keys.ts` is memexId-scoped in its WHERE clause (`listEmissionKeysForMemex`, `listEmissionKeysForOwner`, `revokeEmissionKey`). The verify path additionally enforces spec-129 ac-10: the authenticated key's `memexId` must equal the memex resolved from `ac_uid`, so a key only ever authorises its own Memex. No route exposes an unscoped read of this table.
- **Row exposure carries no credential risk.** The stored secret is a SHA-256 hash of a 256-bit-entropy key (spec-129 dec-1/dec-5); the plaintext `prefix` column is display metadata by design.
- **Precedent inside the same migration.** 0081 already excludes `user_memex_access` for the identical reason (queried to establish identity before context exists). This PR extends that documented exclusion to the second identity-establishment table rather than inventing a new mechanism.
- **Narrow blast radius.** The migration touches exactly one table's RLS state. The other 13 tenant tables keep ENABLE + FORCE + policy untouched, and the updated spec-199 suite still asserts that.
- **Reversible.** The revert file restores the 0086-shape policy verbatim.
- Alternatives considered and rejected for the hotfix: a SECURITY DEFINER lookup function (more moving parts under incident pressure, same effective trust), and reordering the route to set the GUC from `ac_uid` before key lookup (inverts spec-129 ac-9's auth-before-payload ordering; a design change, not a hotfix).

## Test results

- New regression suite + updated spec-199 schema suite: **10/10 pass** (global setup applies 0087 to the fresh test DB).
- All emission-key and RLS-adjacent suites (`emission-keys-routes`, `emission-keys-member-access`, `emission-auth`, `spec-129-emission-keys-schema`, `spec-199-als-proxy`, `spec-199-memex-app-role`): **40/40 pass**.
- Full server suite with this change: 3670 passed, 1 failed: `standards-graph.spec-179.integration.test.ts` ("exactly one pair clears the 0.5 floor"). That test passes in isolation both with and without this diff, and a clean-main full run in the same environment failed 3 tests across 2 files (worse), so it is parallel-run interference, not introduced here; this diff touches no standards/graph/document code. Flagging honestly for CI to arbitrate on a fresh DB.

## Post-merge verification plan

1. Watch the deploy job apply 0087 (the `apply-hand-migrations.sh` step logs `DROP POLICY` + 2x `ALTER TABLE`).
2. `POST https://memex.ai/api/test-events` with a live emission key and a `hidden: true` probe payload: expect 201.
3. Confirm new rows in `test_events` and that the next CI run's emissions land (SpecList AC chips update).
