### PR TITLE
feat(canary): continuous live-env canary + Slack claxons and deploy notifications (spec-243)

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -1,0 +1,71 @@
+# spec-243: continuous canary — authenticated probes against the live envs
+# every 10 minutes, claxons to the per-env Slack channel on 2 consecutive
+# failures, all-clear on recovery (dec-1/dec-2/dec-4).
+#
+# NOTE: GitHub only evaluates `schedule:` triggers on the DEFAULT branch
+# (develop). The canary starts ticking when this file lands there; nothing is
+# deployed. `workflow_dispatch` exists so it can be fired manually (including
+# from a branch) to test the pipe.
+#
+# Cost posture (dec-1): ~6 runs/hour × ~1 billed minute ≈ $25-35/month for the
+# private repo. The 10-minute cadence was chosen over 5 specifically to halve
+# this; revisit alongside issue-1 (Cloud Run port) if it creeps.
+#
+# Required repo secrets:
+#   SLACK_WEBHOOK_PROD / SLACK_WEBHOOK_INT      incoming webhooks (#memex-prod-alerts / #memex-int-alerts)
+#   CANARY_EMIT_KEY_PROD / CANARY_EMIT_KEY_INT  emission keys minted in the canary Memex
+#   CANARY_MCP_TOKEN_PROD / CANARY_MCP_TOKEN_INT  mxt_ tokens for the canary Memex
+# Required repo variables:
+#   CANARY_AC_UID_PROD / CANARY_AC_UID_INT      ac_uid the hidden emission targets
+#   CANARY_VERBOSE                              'true' → post a success line on every
+#                                               green run (rollout proof); flip off in
+#                                               the UI, no code change.
+name: canary
+
+on:
+  schedule:
+    - cron: "*/10 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: read # notify.mjs reads the previous run's job conclusions
+
+concurrency:
+  group: canary-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  probe:
+    strategy:
+      fail-fast: false
+      matrix:
+        env: [prod, int]
+    name: canary (${{ matrix.env }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: scripts/canary
+
+      - name: Probe ${{ matrix.env }}
+        id: probe
+        env:
+          CANARY_EMIT_KEY_PROD: ${{ secrets.CANARY_EMIT_KEY_PROD }}
+          CANARY_EMIT_KEY_INT: ${{ secrets.CANARY_EMIT_KEY_INT }}
+          CANARY_MCP_TOKEN_PROD: ${{ secrets.CANARY_MCP_TOKEN_PROD }}
+          CANARY_MCP_TOKEN_INT: ${{ secrets.CANARY_MCP_TOKEN_INT }}
+          CANARY_AC_UID_PROD: ${{ vars.CANARY_AC_UID_PROD }}
+          CANARY_AC_UID_INT: ${{ vars.CANARY_AC_UID_INT }}
+        run: node scripts/canary/probe.mjs ${{ matrix.env }}
+
+      - name: Notify Slack
+        if: always()
+        env:
+          CANARY_ENV: ${{ matrix.env }}
+          PROBE_RESULTS: ${{ steps.probe.outputs.results }}
+          SLACK_WEBHOOK: ${{ matrix.env == 'prod' && secrets.SLACK_WEBHOOK_PROD || secrets.SLACK_WEBHOOK_INT }}
+          CANARY_VERBOSE: ${{ vars.CANARY_VERBOSE }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/canary/notify.mjs

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -109,3 +109,30 @@ jobs:
           SMOKE_SESSION_TOKEN: ${{ secrets.SMOKE_SESSION_TOKEN }}
           MEMEX_EMIT_KEY: ${{ secrets.MEMEX_EMIT_KEY }}
         run: bash deploy.sh
+
+      # spec-243 dec-2: every deploy posts a friendly note to the matching
+      # env's Slack channel (#memex-prod-alerts / #memex-int-alerts), so each
+      # channel is the single timeline of "what changed and what broke" for
+      # its environment. Friendly register on success; a short red line when
+      # the deploy job itself fails (the canary covers what happens after).
+      - name: Notify Slack (deploy)
+        if: always()
+        env:
+          SLACK_WEBHOOK: ${{ env.ENV == 'prod' && secrets.SLACK_WEBHOOK_PROD || secrets.SLACK_WEBHOOK_INT }}
+          HOST: ${{ env.ENV == 'prod' && 'memex.ai' || 'int.memex.ai' }}
+          COMMIT_SUBJECT: ${{ github.event.head_commit.message }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          OUTCOME: ${{ job.status }}
+        run: |
+          if [ -z "$SLACK_WEBHOOK" ]; then
+            echo "::warning::SLACK_WEBHOOK_${ENV^^} not set — skipping deploy notification"
+            exit 0
+          fi
+          SUBJECT_FIRST_LINE="$(printf '%s' "$COMMIT_SUBJECT" | head -n 1)"
+          if [ "$OUTCOME" = "success" ]; then
+            TEXT="🚀 *${HOST}* just got a fresh deploy: \"${SUBJECT_FIRST_LINE}\" (by ${GITHUB_ACTOR}). Smoke is green. <${RUN_URL}|Details>"
+          else
+            TEXT="🛑 Deploy to *${HOST}* did not complete (\"${SUBJECT_FIRST_LINE}\", by ${GITHUB_ACTOR}). <${RUN_URL}|Run log>"
+          fi
+          jq -n --arg text "$TEXT" '{text: $text}' | \
+            curl -sS -X POST -H 'Content-type: application/json' -d @- "$SLACK_WEBHOOK"

--- a/packages/server/src/__regression__/canary-wiring.regression.test.ts
+++ b/packages/server/src/__regression__/canary-wiring.regression.test.ts
@@ -1,0 +1,131 @@
+// spec-243 — continuous canary: static assertions that the wiring making the
+// scope ACs true stays in place (same shape as the cicd-deploy-config and
+// deploy.sh regression tests: read the workflow/script files, fail if the
+// load-bearing pieces are removed).
+//
+// These tests verify the WIRING; the live behaviour (probes actually firing
+// every 10 minutes, claxons reaching Slack) is observable in the channels and
+// the Actions run history, and is verified operationally during rollout via
+// the CANARY_VERBOSE success lines.
+//
+//   ac-1: both envs probed by real authenticated operations on a 10-minute
+//         schedule (page + emission + MCP read per env).
+//   ac-2: 2-consecutive-failure claxon to the matching env's channel, with
+//         all-clear on recovery.
+//   ac-3: fate isolation — runs on GitHub-hosted runners, not inside GCP.
+//   ac-4: probe writes are hidden:true and carry the canary marker.
+//   ac-5: the probe inventory is one readable list in one file.
+//   ac-6: every deploy posts a notification to the matching env's channel.
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+const SPEC = "mindset-prod/memex-building-itself/specs/spec-243";
+const REPO_ROOT = join(__dirname, "..", "..", "..", "..");
+const CANARY_YML = readFileSync(
+  join(REPO_ROOT, ".github", "workflows", "canary.yml"),
+  "utf-8",
+);
+const DEPLOY_YML = readFileSync(
+  join(REPO_ROOT, ".github", "workflows", "deploy.yml"),
+  "utf-8",
+);
+const PROBE_MJS = readFileSync(
+  join(REPO_ROOT, "scripts", "canary", "probe.mjs"),
+  "utf-8",
+);
+const NOTIFY_MJS = readFileSync(
+  join(REPO_ROOT, "scripts", "canary", "notify.mjs"),
+  "utf-8",
+);
+
+describe("spec-243: canary wiring", () => {
+  it("ac-1: canary runs on a 10-minute schedule against both envs", () => {
+    tagAc(`${SPEC}/acs/ac-1`);
+
+    expect(CANARY_YML).toContain('cron: "*/10 * * * *"');
+    expect(CANARY_YML).toContain("env: [prod, int]");
+    expect(CANARY_YML).toContain("node scripts/canary/probe.mjs");
+    // Manual trigger stays available for pipe-testing from branches.
+    expect(CANARY_YML).toContain("workflow_dispatch");
+  });
+
+  it("ac-1: the probes are real authenticated operations, not pings", () => {
+    tagAc(`${SPEC}/acs/ac-1`);
+
+    // The emission probe is the exact 2026-06-10 failure path: a real key,
+    // a real POST, a 201 demanded.
+    expect(PROBE_MJS).toContain("/api/test-events");
+    expect(PROBE_MJS).toContain("res.status === 201");
+    // The MCP probe drives a real tool call with a real token.
+    expect(PROBE_MJS).toContain('method: "tools/call"');
+    expect(PROBE_MJS).toContain("Authorization");
+    // No /health anywhere — pings are explicitly not probes (s-1).
+    expect(PROBE_MJS).not.toContain("/api/health");
+  });
+
+  it("ac-1: a missing credential is a failure, never a silent skip", () => {
+    tagAc(`${SPEC}/acs/ac-1`);
+
+    // std-17's authed tier self-skipping (describe.skipIf) is part of how the
+    // 2026-06-10 outage stayed dark. The canary must hard-fail instead: a
+    // missing credential produces an ok:false probe result, and no probe
+    // result kind other than ok/failed exists (no "skipped" state at all).
+    expect(PROBE_MJS).toContain('ok: false, detail: `missing credential');
+    expect(PROBE_MJS).not.toMatch(/status.*skipped|skipped.*probe/i);
+  });
+
+  it("ac-2: claxon on 2 consecutive failures, all-clear on recovery, routed per env", () => {
+    tagAc(`${SPEC}/acs/ac-2`);
+
+    expect(NOTIFY_MJS).toContain("CANARY RED");
+    expect(NOTIFY_MJS).toContain("All clear");
+    // The blip allowance: a red run after a green one stays silent.
+    expect(NOTIFY_MJS).toContain("staying silent per dec-4");
+    // Per-env webhook routing in the workflow.
+    expect(CANARY_YML).toContain(
+      "matrix.env == 'prod' && secrets.SLACK_WEBHOOK_PROD || secrets.SLACK_WEBHOOK_INT",
+    );
+    // The notifier always runs, even when the probe step failed.
+    expect(CANARY_YML).toContain("if: always()");
+  });
+
+  it("ac-3: the canary runs on GitHub-hosted runners, outside GCP", () => {
+    tagAc(`${SPEC}/acs/ac-3`);
+
+    expect(CANARY_YML).toContain("runs-on: ubuntu-latest");
+    expect(CANARY_YML).not.toContain("self-hosted");
+  });
+
+  it("ac-4: canary emissions are hidden and marked as canary traffic", () => {
+    tagAc(`${SPEC}/acs/ac-4`);
+
+    expect(PROBE_MJS).toContain("hidden: true");
+    expect(PROBE_MJS).toContain("spec-243 canary");
+  });
+
+  it("ac-5: the probe inventory is one readable list", () => {
+    tagAc(`${SPEC}/acs/ac-5`);
+
+    // Adding a probe = one entry in PROBES + its function. If this list moves
+    // or fragments, the "what is monitored" single-place property is gone.
+    expect(PROBE_MJS).toContain("const PROBES = [");
+    for (const probe of ["page", "emission", "mcp_read"]) {
+      expect(PROBE_MJS).toContain(`"${probe}"`);
+    }
+  });
+
+  it("ac-6: every deploy posts to the matching env's channel", () => {
+    tagAc(`${SPEC}/acs/ac-6`);
+
+    expect(DEPLOY_YML).toContain("Notify Slack (deploy)");
+    expect(DEPLOY_YML).toContain(
+      "env.ENV == 'prod' && secrets.SLACK_WEBHOOK_PROD || secrets.SLACK_WEBHOOK_INT",
+    );
+    // Friendly on success, short red line on a failed deploy, never skipped.
+    expect(DEPLOY_YML).toContain("🚀");
+    expect(DEPLOY_YML).toContain("🛑");
+  });
+});

--- a/scripts/canary/notify.mjs
+++ b/scripts/canary/notify.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+// spec-243: canary → Slack notifier. Runs as the workflow's `if: always()`
+// tail step, decides whether THIS run's outcome warrants a message, and posts
+// it to the environment's webhook.
+//
+// Decision table (dec-4: alert on 2 consecutive failures; single blips silent):
+//   this run RED   + previous RED    → claxon
+//   this run RED   + previous GREEN  → silent (the blip allowance)
+//   this run GREEN + previous RED    → all-clear
+//   this run GREEN + previous GREEN  → silent, unless CANARY_VERBOSE=true
+//
+// "Previous" is the same env's job conclusion in the most recent completed
+// run of this workflow — fetched via the GitHub API, so the consecutive rule
+// needs no state store. When no previous run exists (first ever run), a red
+// run alerts immediately: better one early claxon than a silent broken start.
+//
+// Required env: CANARY_ENV (prod|int), PROBE_RESULTS (JSON from probe.mjs),
+// SLACK_WEBHOOK, GITHUB_TOKEN, GITHUB_REPOSITORY, GITHUB_RUN_ID.
+// Optional: CANARY_VERBOSE=true.
+
+const env = process.env.CANARY_ENV ?? "unknown";
+const webhook = process.env.SLACK_WEBHOOK;
+const verbose = process.env.CANARY_VERBOSE === "true";
+const repo = process.env.GITHUB_REPOSITORY;
+const runId = process.env.GITHUB_RUN_ID;
+const runUrl = `https://github.com/${repo}/actions/runs/${runId}`;
+
+function parseResults() {
+  try {
+    return JSON.parse(process.env.PROBE_RESULTS ?? "");
+  } catch {
+    // The probe step crashing before it could emit results is itself a red
+    // result — report it rather than dying silently.
+    return { env, ok: false, results: { probe_step: { ok: false, detail: "probe step produced no results (crashed or cancelled)", body: "" } } };
+  }
+}
+
+async function previousConclusion() {
+  // Most recent COMPLETED run of this workflow before this one, any trigger
+  // (schedule or manual) — then the conclusion of this env's job within it.
+  const headers = {
+    Authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
+    Accept: "application/vnd.github+json",
+  };
+  try {
+    const runsRes = await fetch(
+      `https://api.github.com/repos/${repo}/actions/workflows/canary.yml/runs?status=completed&per_page=5`,
+      { headers },
+    );
+    const runs = (await runsRes.json()).workflow_runs ?? [];
+    const prev = runs.find((r) => String(r.id) !== String(runId));
+    if (!prev) return "none";
+    const jobsRes = await fetch(prev.jobs_url, { headers });
+    const jobs = (await jobsRes.json()).jobs ?? [];
+    const job = jobs.find((j) => j.name.includes(env));
+    return job?.conclusion ?? "none";
+  } catch (err) {
+    console.error(`[canary-notify] previous-run lookup failed: ${err}`);
+    return "unknown";
+  }
+}
+
+function failureLines(results) {
+  return Object.entries(results)
+    .filter(([, r]) => !r.ok)
+    .map(([name, r]) => `• *${name}*: ${r.detail}${r.body ? `\n  > ${r.body}` : ""}`)
+    .join("\n");
+}
+
+async function post(text) {
+  if (!webhook) {
+    console.error("[canary-notify] SLACK_WEBHOOK not set — cannot deliver:");
+    console.error(text);
+    process.exit(1);
+  }
+  const res = await fetch(webhook, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ text }),
+  });
+  if (!res.ok) {
+    console.error(`[canary-notify] Slack webhook returned ${res.status}`);
+    process.exit(1);
+  }
+  console.error("[canary-notify] posted to Slack");
+}
+
+async function main() {
+  const summary = parseResults();
+  const prev = await previousConclusion();
+  const host = env === "prod" ? "memex.ai" : "int.memex.ai";
+
+  if (!summary.ok) {
+    const isConsecutive = prev === "failure" || prev === "none" || prev === "unknown";
+    if (!isConsecutive) {
+      console.error(`[canary-notify] single failure (previous=${prev}) — staying silent per dec-4`);
+      return;
+    }
+    await post(
+      `🚨 *CANARY RED — ${host}* 🚨\n` +
+        `${failureLines(summary.results)}\n` +
+        `Second consecutive failure (previous run: ${prev}). <${runUrl}|Run log>`,
+    );
+    return;
+  }
+
+  if (prev === "failure") {
+    await post(`✅ *All clear — ${host}*: canary is green again. <${runUrl}|Run log>`);
+    return;
+  }
+
+  if (verbose) {
+    const details = Object.entries(summary.results)
+      .map(([name, r]) => `${name} ✓`)
+      .join(", ");
+    await post(`✅ canary green on ${host}: ${details}. _(verbose mode — flip the CANARY_VERBOSE repo variable off to silence these)_`);
+  }
+}
+
+main();

--- a/scripts/canary/probe.mjs
+++ b/scripts/canary/probe.mjs
@@ -1,0 +1,192 @@
+#!/usr/bin/env node
+// spec-243: continuous canary — three fast probes against one live environment.
+//
+// Usage: node scripts/canary/probe.mjs <prod|int>
+//
+// Probes (dec-3):
+//   page      GET  <base>/                      → 200 after redirects
+//   emission  POST <base>/api/test-events       → 201 (hidden:true, real key)
+//   mcp_read  POST <base>/mcp  tools/call       → result present (real mxt_ token)
+//
+// Each probe does the smallest REAL authenticated unit of work. /health-style
+// pings are deliberately absent: the 2026-06-10 outage returned 200 on every
+// public surface all day while every authenticated emission 401'd.
+//
+// A missing credential is a FAILURE, not a skip. std-17's authed smoke tier
+// silently skipping (describe.skipIf(!SMOKE_MCP_TOKEN)) is part of how the
+// 2026-06-10 outage stayed dark for 12 hours; the canary does not repeat that.
+//
+// Output: human lines to stderr, one JSON summary line to stdout, and (when
+// running in GitHub Actions) the summary written to $GITHUB_OUTPUT as
+// `results`. Exit code 0 = all probes green, 1 = at least one red.
+
+const ENVS = {
+  prod: {
+    baseUrl: "https://memex.ai",
+    emitKeyVar: "CANARY_EMIT_KEY_PROD",
+    mcpTokenVar: "CANARY_MCP_TOKEN_PROD",
+    acUidVar: "CANARY_AC_UID_PROD",
+  },
+  int: {
+    baseUrl: "https://int.memex.ai",
+    emitKeyVar: "CANARY_EMIT_KEY_INT",
+    mcpTokenVar: "CANARY_MCP_TOKEN_INT",
+    acUidVar: "CANARY_AC_UID_INT",
+  },
+};
+
+const PROBE_TIMEOUT_MS = 10_000;
+// One in-run retry after a short pause absorbs transient 5xx/network blips
+// (dec-4); the retry's result is what counts.
+const RETRY_DELAY_MS = 10_000;
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function timedFetch(url, init = {}) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), PROBE_TIMEOUT_MS);
+  const startedAt = Date.now();
+  try {
+    const res = await fetch(url, { ...init, signal: controller.signal });
+    const text = await res.text();
+    return { status: res.status, text, ms: Date.now() - startedAt };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function snippet(text) {
+  return (text ?? "").replace(/\s+/g, " ").slice(0, 200);
+}
+
+// ── The three probes. Each returns {ok, detail} and throws nothing. ─────────
+
+async function probePage(cfg) {
+  const res = await timedFetch(`${cfg.baseUrl}/`, { redirect: "follow" });
+  return {
+    ok: res.status === 200,
+    detail: `GET / → ${res.status} (${res.ms}ms)`,
+    body: res.status === 200 ? "" : snippet(res.text),
+  };
+}
+
+async function probeEmission(cfg, env) {
+  const key = process.env[cfg.emitKeyVar];
+  if (!key) {
+    return { ok: false, detail: `missing credential ${cfg.emitKeyVar}`, body: "" };
+  }
+  const acUid = process.env[cfg.acUidVar];
+  if (!acUid) {
+    return { ok: false, detail: `missing config ${cfg.acUidVar}`, body: "" };
+  }
+  const res = await timedFetch(`${cfg.baseUrl}/api/test-events`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${key}`,
+    },
+    body: JSON.stringify({
+      ac_uid: acUid,
+      status: "pass",
+      hidden: true,
+      test_identifier: "canary/probe.mjs",
+      run_id: `canary-${env}-${process.env.GITHUB_RUN_ID ?? "local"}`,
+      metadata: { source: "spec-243 canary", env },
+    }),
+  });
+  return {
+    ok: res.status === 201,
+    detail: `POST /api/test-events → ${res.status} (${res.ms}ms)`,
+    body: res.status === 201 ? "" : snippet(res.text),
+  };
+}
+
+async function probeMcpRead(cfg) {
+  const token = process.env[cfg.mcpTokenVar];
+  if (!token) {
+    return { ok: false, detail: `missing credential ${cfg.mcpTokenVar}`, body: "" };
+  }
+  const res = await timedFetch(`${cfg.baseUrl}/mcp`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json, text/event-stream",
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/call",
+      params: { name: "list_docs", arguments: {} },
+    }),
+  });
+  // The MCP streamable-HTTP transport may reply as plain JSON OR an SSE frame
+  // (same handling as __smoke__/smoke-env.ts callMcpTool).
+  let body = {};
+  try {
+    const dataLine = res.text.split("\n").find((l) => l.startsWith("data:"));
+    body = JSON.parse(dataLine ? dataLine.slice(5).trim() : res.text);
+  } catch {
+    body = {};
+  }
+  const ok = res.status === 200 && body.result !== undefined && body.error === undefined;
+  return {
+    ok,
+    detail: `POST /mcp list_docs → ${res.status}${body.error ? ` rpc-error: ${snippet(JSON.stringify(body.error))}` : ""} (${res.ms}ms)`,
+    body: ok ? "" : snippet(res.text),
+  };
+}
+
+const PROBES = [
+  ["page", probePage],
+  ["emission", probeEmission],
+  ["mcp_read", probeMcpRead],
+];
+
+async function runProbe(name, fn, cfg, env) {
+  let result;
+  try {
+    result = await fn(cfg, env);
+  } catch (err) {
+    result = { ok: false, detail: `threw: ${snippet(String(err))}`, body: "" };
+  }
+  if (result.ok) return result;
+  // A missing credential/config is deterministic — retrying can't change it.
+  if (result.detail.startsWith("missing ")) return result;
+  console.error(`[canary:${env}] ${name} FAILED (${result.detail}) — retrying in ${RETRY_DELAY_MS / 1000}s`);
+  await sleep(RETRY_DELAY_MS);
+  try {
+    return await fn(cfg, env);
+  } catch (err) {
+    return { ok: false, detail: `threw on retry: ${snippet(String(err))}`, body: "" };
+  }
+}
+
+async function main() {
+  const env = process.argv[2];
+  const cfg = ENVS[env];
+  if (!cfg) {
+    console.error(`usage: probe.mjs <${Object.keys(ENVS).join("|")}>`);
+    process.exit(2);
+  }
+
+  const results = {};
+  for (const [name, fn] of PROBES) {
+    const r = await runProbe(name, fn, cfg, env);
+    results[name] = { ok: r.ok, detail: r.detail, body: r.body ?? "" };
+    console.error(`[canary:${env}] ${r.ok ? "✅" : "❌"} ${name}: ${r.detail}`);
+  }
+
+  const allOk = Object.values(results).every((r) => r.ok);
+  const summary = { env, ok: allOk, results };
+  console.log(JSON.stringify(summary));
+
+  if (process.env.GITHUB_OUTPUT) {
+    const { appendFileSync } = await import("node:fs");
+    appendFileSync(process.env.GITHUB_OUTPUT, `results=${JSON.stringify(summary)}\n`);
+  }
+
+  process.exit(allOk ? 0 : 1);
+}
+
+main();

--- a/scripts/canary/probe.mjs
+++ b/scripts/canary/probe.mjs
@@ -106,6 +106,14 @@ async function probeMcpRead(cfg) {
   if (!token) {
     return { ok: false, detail: `missing credential ${cfg.mcpTokenVar}`, body: "" };
   }
+  // mxt_ tokens are user-scoped, not Memex-scoped — so the read must name the
+  // canary Memex explicitly. Derive `<namespace>/<memex>` from the ac_uid the
+  // emission probe already targets; one config value drives both probes.
+  const acUid = process.env[cfg.acUidVar] ?? "";
+  const canaryMemex = acUid.split("/").slice(0, 2).join("/");
+  if (!canaryMemex.includes("/")) {
+    return { ok: false, detail: `cannot derive canary memex from ${cfg.acUidVar}`, body: "" };
+  }
   const res = await timedFetch(`${cfg.baseUrl}/mcp`, {
     method: "POST",
     headers: {
@@ -117,7 +125,7 @@ async function probeMcpRead(cfg) {
       jsonrpc: "2.0",
       id: 1,
       method: "tools/call",
-      params: { name: "list_docs", arguments: {} },
+      params: { name: "list_docs", arguments: { memex: canaryMemex } },
     }),
   });
   // The MCP streamable-HTTP transport may reply as plain JSON OR an SSE frame


### PR DESCRIPTION
## What

Implements spec-243 (https://memex.ai/mindset-prod/memex-building-itself/specs/spec-243), born from the 2026-06-10 emission outage that ran 12 hours undetected.

1. **`scripts/canary/probe.mjs`** — three probes per environment, each doing the smallest *real authenticated* unit of work (dec-3): public page → 200, hidden emission POST /api/test-events → 201 (the exact 2026-06-10 failure path), MCP `list_docs` tool call → result. No /health pings: prod returned 200 on those all day during the outage. A missing credential is a hard failure, never a skip (the smoke suite's silent authed-tier skip is part of how the outage stayed dark). One in-run retry absorbs transient blips; deterministic failures (missing creds) fail instantly.
2. **`.github/workflows/canary.yml`** — `*/10` schedule (dec-1/dec-4: ~$25-35/month, worst-case time-to-alert ~20min), prod+int matrix, `workflow_dispatch` for manual pipe-testing. Claxon to the matching env's channel (#memex-prod-alerts / #memex-int-alerts) on **2 consecutive failures** of the same env's job (stateless: previous run's job conclusion via the GitHub API), all-clear on recovery, and a success line on every green run while the `CANARY_VERBOSE` repo variable is `true` (rollout proof; flipped off in the UI, no code change).
3. **`.github/workflows/deploy.yml`** — friendly deploy notification to the matching env's channel on every deploy (dec-2/ac-6), short red line if the deploy job fails.
4. **`canary-wiring.regression.test.ts`** — pins all of the above wiring, tagged to spec-243 ac-1..ac-6.

## Why this is safe

- **No production code paths change.** The server, UI, and CLI are untouched; the diff is two workflows, two standalone scripts, and a test.
- **The deploy.yml change is additive**: one tail step, `if: always()`, that exits 0 when the webhook secret is absent — a missing secret degrades to a skipped notification, never a failed deploy. All existing deploy-shape regression tests pass unchanged.
- **Canary writes are invisible and tenant-safe**: emissions are `hidden: true` (stored, excluded from verification badges) and target a dedicated canary Memex; no customer tenant is ever touched (ac-4).
- **Secrets stay secret**: webhook URLs and keys live in repo secrets; the scripts read env vars only.
- **Schedule only activates on merge**: GitHub evaluates `schedule:` triggers on the default branch (develop), so nothing runs until this lands; `workflow_dispatch` allows a controlled first run.

## Before the canary goes fully green (post-merge provisioning)

Repo secrets already set: `SLACK_WEBHOOK_PROD`, `SLACK_WEBHOOK_INT` (both webhooks verified with a test message). Still needed, human-only (emission keys can only be minted in the UI):
- canary Memex in prod + int, `CANARY_EMIT_KEY_PROD/INT` + `CANARY_MCP_TOKEN_PROD/INT` secrets, `CANARY_AC_UID_PROD/INT` + `CANARY_VERBOSE=true` repo variables.

Until those exist the canary will (correctly, by design) claxon about missing credentials — provision the secrets before merging, or expect loud channels.

## Test plan

- [x] `canary-wiring.regression.test.ts` — 8/8 green
- [x] deploy-shape regression suites (cicd-deploy-config, secret-fetch, hidden-features guard) — 18/18 green
- [x] `probe.mjs` dry-run against live prod: page ✅, emission/mcp fail fast on missing creds, exit 1
- [x] Both Slack webhooks verified end to end with a test message
- [ ] Post-merge: `workflow_dispatch` a first run with `CANARY_VERBOSE=true` and watch the success lines land in both channels