### PR TITLE
fix(pulse): readable narratives for doc_member/doc_assignee (no raw UUIDs)

### DIFF
--- a/packages/server/src/services/doc-assignees.integration.test.ts
+++ b/packages/server/src/services/doc-assignees.integration.test.ts
@@ -101,6 +101,16 @@ describe("spec-118 assignment emits on the unified bus (ac-20)", () => {
     });
     const mine = events.filter((e) => e.docId === doc.id && e.entity === "doc_assignee");
     expect(mine.map((e) => e.action)).toEqual(["created", "deleted"]);
+
+    // spec-122: the Pulse narrative names the spec handle + the assignee, and
+    // NEVER leaks the raw doc UUID (the "doc_assignee 322dda5d-…" bug report).
+    // bob has no display name → actor_name falls back to his email.
+    const [created, deleted] = mine;
+    expect(created.narrative).toBe(`assigned ${doc.handle} to spec118-assignee-b@example.com`);
+    expect(deleted.narrative).toBe(`unassigned spec118-assignee-b@example.com from ${doc.handle}`);
+    for (const e of mine) {
+      expect(e.narrative, "narrative must not contain the raw doc UUID").not.toContain(doc.id);
+    }
   });
 });
 

--- a/packages/server/src/services/doc-assignees.ts
+++ b/packages/server/src/services/doc-assignees.ts
@@ -23,16 +23,30 @@ import { docAssignees, documents, users } from "../db/schema.js";
 import type { DocAssignee } from "../db/schema.js";
 import { NotFoundError } from "../types/errors.js";
 import { mutate, type Mutated } from "./mutate.js";
+import { actorName } from "./actor.js";
 
 export type { DocAssignee };
 
-async function assertSpecInMemex(memexId: string, docId: string): Promise<void> {
+// Returns the Spec's handle (404 on a cross-tenant miss, std-7) so callers can
+// name it in the Pulse narrative instead of leaking the raw doc UUID (spec-122).
+async function assertSpecInMemex(memexId: string, docId: string): Promise<string> {
   const doc = await db.query.documents.findFirst({
     where: and(eq(documents.id, docId), eq(documents.memexId, memexId)),
+    columns: { handle: true },
   });
   if (!doc) {
     throw new NotFoundError(`Spec ${docId} not found in memex ${memexId}`);
   }
+  return doc.handle;
+}
+
+// The assignee's display snapshot for the Pulse narrative. spec-122.
+async function assigneeDisplayName(userId: string): Promise<string> {
+  const u = await db.query.users.findFirst({
+    where: eq(users.id, userId),
+    columns: { name: true, email: true },
+  });
+  return u ? actorName(u) : "a member";
 }
 
 export interface DocAssigneeView {
@@ -159,10 +173,18 @@ export async function assign(
   userId: string,
   assignedBy: string | null,
 ): Promise<Mutated<DocAssignee>> {
-  await assertSpecInMemex(memexId, docId);
+  const handle = await assertSpecInMemex(memexId, docId);
+  const who = await assigneeDisplayName(userId);
   return mutate(
     {},
-    { memexId, docId, entity: "doc_assignee", action: "created" },
+    {
+      memexId,
+      docId,
+      entity: "doc_assignee",
+      action: "created",
+      // spec-122: name the spec + assignee instead of leaking the doc UUID.
+      narrative: `assigned ${handle} to ${who}`,
+    },
     async () => {
       await db
         .insert(docAssignees)
@@ -192,10 +214,17 @@ export async function unassign(
   docId: string,
   userId: string,
 ): Promise<Mutated<UnassignResult>> {
-  await assertSpecInMemex(memexId, docId);
+  const handle = await assertSpecInMemex(memexId, docId);
+  const who = await assigneeDisplayName(userId);
   return mutate(
     {},
-    { memexId, docId, entity: "doc_assignee", action: "deleted" },
+    {
+      memexId,
+      docId,
+      entity: "doc_assignee",
+      action: "deleted",
+      narrative: `unassigned ${who} from ${handle}`,
+    },
     async () => {
       await db
         .delete(docAssignees)

--- a/packages/server/src/services/doc-members.integration.test.ts
+++ b/packages/server/src/services/doc-members.integration.test.ts
@@ -161,6 +161,16 @@ describe("spec-118 promote / demote (frictionless, reversible, no last-editor lo
     });
     const mine = events.filter((e) => e.docId === doc.id && e.entity === "doc_member");
     expect(mine.map((e) => e.action)).toEqual(["created", "deleted"]);
+
+    // spec-122: readable Pulse narrative naming the spec handle + member, never
+    // the raw doc UUID (the "doc_member 322dda5d-…" bug report). `other` has no
+    // display name → actor_name falls back to the email.
+    const [created, deleted] = mine;
+    expect(created.narrative).toBe(`promoted spec118-other@example.com to editor on ${doc.handle}`);
+    expect(deleted.narrative).toBe(`demoted spec118-other@example.com to reviewer on ${doc.handle}`);
+    for (const e of mine) {
+      expect(e.narrative, "narrative must not contain the raw doc UUID").not.toContain(doc.id);
+    }
   });
 
   it("a teammate can promote another member, and demoting the LAST editor succeeds (zero editors allowed) (ac-16)", async () => {

--- a/packages/server/src/services/doc-members.ts
+++ b/packages/server/src/services/doc-members.ts
@@ -24,6 +24,7 @@ import { docMembers, documents, users } from "../db/schema.js";
 import type { DocMember } from "../db/schema.js";
 import { NotFoundError } from "../types/errors.js";
 import { mutate, type Mutated } from "./mutate.js";
+import { actorName } from "./actor.js";
 
 export type { DocMember };
 
@@ -37,14 +38,29 @@ export function isDocRole(value: string): value is DocRole {
 }
 
 // Verifies the Spec exists in the memex; 404 (not 403) on a cross-tenant miss
-// (std-7). Mirrors assertSpecInMemex in issues.ts.
-async function assertSpecInMemex(memexId: string, docId: string): Promise<void> {
+// (std-7). Mirrors assertSpecInMemex in issues.ts. Returns the Spec's handle so
+// callers can name it in the Pulse narrative (spec-122) instead of leaking the
+// raw doc UUID.
+async function assertSpecInMemex(memexId: string, docId: string): Promise<string> {
   const doc = await db.query.documents.findFirst({
     where: and(eq(documents.id, docId), eq(documents.memexId, memexId)),
+    columns: { handle: true },
   });
   if (!doc) {
     throw new NotFoundError(`Spec ${docId} not found in memex ${memexId}`);
   }
+  return doc.handle;
+}
+
+// The affected member's display snapshot for the Pulse narrative — name, else
+// email, else a neutral fallback (the user must exist for a role write, but stay
+// defensive so attribution never throws on the feed path). spec-122.
+async function memberDisplayName(userId: string): Promise<string> {
+  const u = await db.query.users.findFirst({
+    where: eq(users.id, userId),
+    columns: { name: true, email: true },
+  });
+  return u ? actorName(u) : "a member";
 }
 
 // The read path: 'editor' iff an editor row exists for (docId,userId), else the
@@ -133,10 +149,18 @@ export async function promoteToEditor(
   docId: string,
   userId: string,
 ): Promise<Mutated<DocMember>> {
-  await assertSpecInMemex(memexId, docId);
+  const handle = await assertSpecInMemex(memexId, docId);
+  const who = await memberDisplayName(userId);
   return mutate(
     {},
-    { memexId, docId, entity: "doc_member", action: "created" },
+    {
+      memexId,
+      docId,
+      entity: "doc_member",
+      action: "created",
+      // spec-122: name the person + spec instead of leaking the doc UUID.
+      narrative: `promoted ${who} to editor on ${handle}`,
+    },
     async () => {
       await db
         .insert(docMembers)
@@ -168,10 +192,17 @@ export async function demoteToReviewer(
   docId: string,
   userId: string,
 ): Promise<Mutated<DemoteResult>> {
-  await assertSpecInMemex(memexId, docId);
+  const handle = await assertSpecInMemex(memexId, docId);
+  const who = await memberDisplayName(userId);
   return mutate(
     {},
-    { memexId, docId, entity: "doc_member", action: "deleted" },
+    {
+      memexId,
+      docId,
+      entity: "doc_member",
+      action: "deleted",
+      narrative: `demoted ${who} to reviewer on ${handle}`,
+    },
     async () => {
       await db
         .delete(docMembers)

--- a/packages/server/src/services/mutate.ts
+++ b/packages/server/src/services/mutate.ts
@@ -12,6 +12,7 @@
 // `services/__test__/mutate-helpers.ts` (`testMutate()`).
 
 import { bus, type ChangeAction, type ChangeEntity, type ChangeEvent } from "./bus.js";
+import { isUuid } from "./shared/identifiers.js";
 
 declare const __mutated: unique symbol;
 
@@ -150,9 +151,13 @@ function resourceIdentifier(resolved: ChangeKey, result: unknown): string | unde
     const prefix = HANDLE_PREFIX[resolved.entity];
     if (prefix && typeof row.seq === "number") return `${prefix}${row.seq}`;
   }
-  // Fall back to whatever id the key/row carries (UUIDs as a last resort).
-  if (resolved.docId) return resolved.docId;
-  if (row && typeof row.id === "string" && row.id) return row.id;
+  // Last resort: an id off the key/row — but NEVER a raw UUID. A bare UUID in the
+  // Pulse feed reads as line noise ("created doc_member 322dda5d-…", spec-122
+  // bug report); better to omit the identifier entirely (→ "created doc_member")
+  // and let the emit site supply a human narrative naming the spec handle. Only
+  // a human handle (spec-N / std-N / doc-N) is ever surfaced here.
+  if (resolved.docId && !isUuid(resolved.docId)) return resolved.docId;
+  if (row && typeof row.id === "string" && row.id && !isUuid(row.id)) return row.id;
   return undefined;
 }
 


### PR DESCRIPTION
## Fix: Pulse feed showed raw doc UUIDs for member/assignee events

Follow-up to #116. The live board rendered rows like `doc_member 322dda5d-b14c-…` and `doc_assignee 322dda5d-…` instead of anything human-readable.

### Root cause
`composeNarrative` (mutate.ts) builds `[action, entity, identifier]`. For `doc_member`/`doc_assignee` the entity has no handle prefix and the written row carries no handle, so `resourceIdentifier` hit its last-resort fallback `return resolved.docId` — leaking the raw doc UUID straight into the feed line. The four emit sites (`promoteToEditor`, `demoteToReviewer`, `assign`, `unassign`) also passed no `narrative`.

### Fix
- **`mutate.ts`** — `composeNarrative` never surfaces a raw UUID now: the `docId`/`row.id` fallbacks are guarded by `isUuid()`, so any entity with no human handle yields a clean `"<action> <entity>"` instead of a GUID. Defense-in-depth for every entity.
- **`doc-members.ts` / `doc-assignees.ts`** — promote/demote/assign/unassign compose a human narrative naming the spec handle + the affected member:
  - `promoted <name> to editor on spec-N` / `demoted <name> to reviewer on spec-N`
  - `assigned spec-N to <name>` / `unassigned <name> from spec-N`
  - `assertSpecInMemex` now returns the handle (no extra query); the member name uses the same `actorName()` snapshot as the rest of the activity contract. The `spec-N` handle is auto-linkified by `ActivityRow`.

### Verification
- doc-members / doc-assignees bus tests now assert the exact narrative **and** that it contains no doc UUID.
- Full server suite green (**3762 passed**).

### Known follow-up (not in this PR)
These rows still render actor **"System"** — they emit through `mutate({})` with no `RequestCtx`. Attributing them to the acting human is a separate ctx-threading change (same pattern as the `createDocDraft` attribution fix in #116).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
