### PR TITLE
fix(activity): keep raw UUIDs out of composed narratives (un-reds the int smoke)

### DIFF
--- a/packages/server/src/services/mutate.test.ts
+++ b/packages/server/src/services/mutate.test.ts
@@ -29,13 +29,34 @@ describe("mutate() success path", () => {
     expect(events).toHaveLength(1);
     // Pulse (b-60): the exact key shape is preserved and a human narrative is
     // layered on. No clientId/channel here — the ctx ({}) supplies neither.
+    // The row carries no handle/seq, so the narrative names no identifier —
+    // in production docId is a raw UUID, and b-36 forbids UUIDs in narratives
+    // (they surface in get_doc's activity block).
     expect(events[0]).toEqual({
       memexId: "m1",
       docId: "d1",
       entity: "task",
       action: "created",
-      narrative: 'created task d1 "hello"',
+      narrative: 'created task "hello"',
     });
+  });
+
+  it("never leaks a raw UUID into the narrative — b-36 (spec-122 int-smoke regression)", async () => {
+    const events = captureEmissions();
+    // A handle-less row (doc_member/doc_assignee shape): both the resolved docId
+    // and the row id are UUIDs. The narrative must degrade to verb + noun, not
+    // fall back to either UUID — get_doc's activity block surfaces it verbatim.
+    await mutate(
+      {},
+      {
+        memexId: "m1",
+        docId: "8198ba7e-d1d9-47e6-b585-67516a7b4d28",
+        entity: "doc_member",
+        action: "created",
+      },
+      async () => ({ id: "0b9f3c52-aaaa-bbbb-cccc-0123456789ab" }),
+    );
+    expect(events[0].narrative).toBe("created doc_member");
   });
 
   it("preserves the structural type of T (Mutated<T> is assignable to T)", async () => {
@@ -165,8 +186,9 @@ describe("mutate() key factory", () => {
       docId: "doc-xyz",
       entity: "document",
       action: "created",
-      // Identifier falls back to the resolved docId; no title on the result.
-      narrative: "created document doc-xyz",
+      // No handle/seq on the row (and ids are UUIDs in production — b-36 keeps
+      // them out of narratives), so the narrative is verb + noun only.
+      narrative: "created document",
     });
   });
 
@@ -257,7 +279,7 @@ describe("mutate() Pulse activity capture (b-60)", () => {
       async () => ({ id: "t-1", title: longTitle }),
     );
     expect(events).toHaveLength(1);
-    expect(events[0].narrative).toBe(`created task d1 "${"x".repeat(57)}…"`);
+    expect(events[0].narrative).toBe(`created task "${"x".repeat(57)}…"`);
   });
 
   it("degrades to verb + noun when no identifying fields are available", async () => {

--- a/packages/server/src/services/mutate.ts
+++ b/packages/server/src/services/mutate.ts
@@ -141,8 +141,10 @@ function composeNarrative(resolved: ChangeKey, result: unknown): string {
   return parts.join(" ");
 }
 
-// Pull the best resource handle/id from the resolved key or the written row.
-// Prefers a human handle (`handle`, or `<prefix>-<seq>`) over a raw UUID.
+// Pull the best resource handle from the written row. Human handles only
+// (`handle`, or `<prefix>-<seq>`) — NEVER a raw UUID: narratives surface in
+// agent-facing output (get_doc's activity block), and b-36 forbids UUIDs there.
+// With no handle the narrative degrades to `<action> <entity>`.
 function resourceIdentifier(resolved: ChangeKey, result: unknown): string | undefined {
   const row = asRecord(result);
   if (row) {
@@ -150,9 +152,6 @@ function resourceIdentifier(resolved: ChangeKey, result: unknown): string | unde
     const prefix = HANDLE_PREFIX[resolved.entity];
     if (prefix && typeof row.seq === "number") return `${prefix}${row.seq}`;
   }
-  // Fall back to whatever id the key/row carries (UUIDs as a last resort).
-  if (resolved.docId) return resolved.docId;
-  if (row && typeof row.id === "string" && row.id) return row.id;
   return undefined;
 }
 


### PR DESCRIPTION
## What

The int deploy of #117 failed at the post-deploy authed smoke: `canonical ref call succeeds and emits ref: (no UUIDs leaked)`. Root cause is spec-122's activity narrative fallback, not #117's content:

- `composeNarrative` → `resourceIdentifier` fell back to `resolved.docId` / `row.id` ("UUIDs as a last resort"), contradicting its own header comment ("degrades to `<action> <entity>`").
- Every doc create also fires `seedCreatorAsEditor`, whose `doc_member`/`doc_assignee` rows carry no handle/seq → narratives like `created doc_member 8198ba7e-d1d9-…` (confirmed in int's `activity_log` at the failing run's timestamps).
- Those rows surface through `get_doc`'s new activity block (`kind='activity_log'` is in `MATERIAL_KINDS`), so the freshly created smoke doc's `get_doc` text contained a raw UUID → b-36 assertion tripped.

Fix: the identifier comes only from human handles (`handle` / `<prefix>-<seq>`); with neither, the narrative is verb + noun. Updated the two unit tests that pinned the UUID fallback and added a b-36 regression test reproducing the doc_member shape.

## Verification
- Full server suite: 3763 passed / 0 failed.
- Existing rows in int's activity_log keep their old narratives, but the smoke creates a fresh doc per run, so its feed will be clean — next deploy's smoke should go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)