### PR TITLE
fix(pulse): strip raw UUIDs from activity display (Pulse feed + get_doc footer, b-36)

### DIFF
--- a/packages/server/src/agent/spec-122-get-doc-activity.integration.test.ts
+++ b/packages/server/src/agent/spec-122-get-doc-activity.integration.test.ts
@@ -14,7 +14,7 @@ import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { eq, inArray } from "drizzle-orm";
 import { tagAc } from "@memex-ai-ac/vitest";
 import { db } from "../db/connection.js";
-import { users, namespaces, orgs, orgMemberships, memexes, documents, acs } from "../db/schema.js";
+import { users, namespaces, orgs, orgMemberships, memexes, documents, acs, activityLog } from "../db/schema.js";
 import { createDocDraft } from "../services/documents.js";
 import { createAc } from "../services/acs.js";
 import { markPresent } from "../services/presence.js";
@@ -66,6 +66,11 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
+  if (created.memexes.length) {
+    // The b-36 test inserts an activity_log row directly; clear it before the
+    // memex delete so its FK doesn't block teardown.
+    await db.delete(activityLog).where(inArray(activityLog.memexId, created.memexes)).catch(() => {});
+  }
   if (created.docs.length) {
     await db.delete(acs).where(inArray(acs.briefId, created.docs)).catch(() => {});
     await db.delete(documents).where(inArray(documents.id, created.docs)).catch(() => {});
@@ -120,6 +125,32 @@ describe("get_doc ACTIVITY block [spec-122 t-8]", () => {
     const block = await craftActivityBlock(memexId, docId, userB);
     // recent line may still show B's own change, but never the collision warning.
     expect(block === null || !block.includes("⚠")).toBe(true);
+  });
+
+  // b-36 hard cut (authed.smoke.test.ts): get_doc must never emit a raw UUID.
+  // The footer replays IMMUTABLE activity_log narratives, so a row written before
+  // the spec-122 narrative fix can still read "created doc_member <uuid>" — the
+  // footer must strip it rather than leak it. Guards against the int smoke red.
+  it("b-36: a historical activity_log narrative carrying a raw UUID is stripped from the footer", async () => {
+    tagAc(`${AC}/ac-23`);
+    const leakedId = "322dda5d-b14c-4597-b106-c13b847905ac";
+    await db.insert(activityLog).values({
+      memexId,
+      briefId: docId,
+      actorKind: "system",
+      channel: "server",
+      entity: "doc_member",
+      action: "created",
+      narrative: `created doc_member ${leakedId}`,
+    });
+    const block = await craftActivityBlock(memexId, docId, userA);
+    expect(block).toBeTruthy();
+    expect(
+      block!,
+      "the ACTIVITY footer must never emit a raw UUID (b-36 no-UUIDs-out)",
+    ).not.toMatch(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i);
+    // The readable remainder survives the strip — only the UUID token is removed.
+    expect(block!).toContain("doc_member");
   });
 
   it("ac-24: the call returns normally — advisory only, never blocks or throws", async () => {

--- a/packages/server/src/agent/tool-specs.ts
+++ b/packages/server/src/agent/tool-specs.ts
@@ -116,6 +116,7 @@ import {
 import type { RequestCtx } from "../services/mutate.js";
 import { listActivityView } from "../services/activity-view.js";
 import { resolveTestEventActors } from "../services/who-resolver.js";
+import { stripUuids, containsUuid } from "../services/shared/identifiers.js";
 import { listPresent } from "../services/presence.js";
 import {
   createIssue,
@@ -1023,6 +1024,21 @@ const MATERIAL_KINDS: ReadonlySet<string> = new Set([
   "test_event",
 ]);
 
+// The b-36 hard cut — canonical refs in, NO raw UUIDs out — is a live smoke
+// invariant (authed.smoke.test.ts). The ACTIVITY footer is composed from
+// activity_view, whose activity_log arm replays IMMUTABLE historical narratives:
+// a row written before the spec-122 narrative fix can still read "created
+// doc_member <uuid>", which a forward-only narrative fix can't rewrite. So the
+// footer guards itself via the shared stripUuids (below) and never lets a
+// UUID-bearing actor name through. Belt-and-suspenders for the invariant.
+//
+// A resolved actor name that contains a raw UUID (an unattributed actor_raw,
+// say) is not a name — drop it so the caller falls back to "someone".
+function sanitizeActorName(name: string | null): string | null {
+  if (!name) return null;
+  return containsUuid(name) ? null : name;
+}
+
 function agoLabel(at: Date, now: number): string {
   const ms = Math.max(0, now - at.getTime());
   const mins = Math.round(ms / 60000);
@@ -1063,7 +1079,7 @@ export async function craftActivityBlock(
     // Most recent material change + who.
     const recent = rows.find((r) => MATERIAL_KINDS.has(r.kind));
     if (recent) {
-      const who = whoOf(recent).name ?? "someone";
+      const who = sanitizeActorName(whoOf(recent).name) ?? "someone";
       const what = recent.narrative ?? `${recent.action ?? "changed"} ${recent.kind}`;
       lines.push(`recent: ${what} — ${who} ${agoLabel(recent.at, now)}`);
     }
@@ -1071,7 +1087,9 @@ export async function craftActivityBlock(
     // Live presence, excluding the caller.
     const others = present.filter((p) => p.actorUserId !== currentUserId);
     if (others.length > 0) {
-      const names = [...new Set(others.map((p) => p.actorName ?? "someone"))].join(", ");
+      const names = [
+        ...new Set(others.map((p) => sanitizeActorName(p.actorName) ?? "someone")),
+      ].join(", ");
       lines.push(`present now: ${names}`);
     }
 
@@ -1086,7 +1104,7 @@ export async function craftActivityBlock(
       return userId !== null && userId !== currentUserId;
     });
     if (advancing) {
-      const who = whoOf(advancing).name ?? "another session";
+      const who = sanitizeActorName(whoOf(advancing).name) ?? "another session";
       lines.push(
         `⚠ ${who} is actively advancing this spec right now — coordinate before you pick it up. ` +
           `(Advisory only; proceed if you mean to.)`,
@@ -1094,7 +1112,11 @@ export async function craftActivityBlock(
     }
 
     if (lines.length === 0) return null;
-    return ["── ACTIVITY ──", ...lines].join("\n");
+    // Final guarantee for the b-36 invariant: a historical activity_log narrative
+    // replayed here can still carry a raw UUID ("created doc_member <uuid>") that
+    // the per-field guards above don't own — strip any surviving UUID token from
+    // the composed block so get_doc never emits one (the authed smoke's hard cut).
+    return stripUuids(["── ACTIVITY ──", ...lines].join("\n"));
   } catch {
     return null;
   }

--- a/packages/server/src/services/activity-log.test.ts
+++ b/packages/server/src/services/activity-log.test.ts
@@ -267,6 +267,28 @@ describe("listActivity — filters + pagination", () => {
     expect(rows.every((r) => r.memexId === memexId)).toBe(true);
   });
 
+  // b-36 (no raw UUIDs out): a historical activity_log row written before the
+  // narrative fix can still read "created doc_member <uuid>". listActivity strips
+  // it at the read boundary so the Pulse feed never renders a raw id, and drops a
+  // UUID-shaped actor_name. New rows are already clean (composeNarrative-guarded).
+  it("strips a raw UUID from a historical narrative + actor_name (b-36)", async () => {
+    const uuid = "322dda5d-b14c-4597-b106-c13b847905ac";
+    await persistEvent(
+      baseEvent({
+        entity: "doc_member",
+        action: "created",
+        channel: "server",
+        narrative: `created doc_member ${uuid}`,
+        actorName: uuid, // an actor_name that is itself a bare UUID
+      }),
+    );
+    const rows = await listActivity({ memexId });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].narrative).toBe("created doc_member");
+    expect(rows[0].narrative).not.toMatch(/[0-9a-f-]{36}/i);
+    expect(rows[0].actorName, "a UUID actor_name is dropped to null").toBeNull();
+  });
+
   it("filters by briefId", async () => {
     await persistEvent(baseEvent({ docId: briefId, narrative: "on-spec" }));
     await persistEvent(baseEvent({ narrative: "no-spec" })); // briefId null

--- a/packages/server/src/services/activity-log.ts
+++ b/packages/server/src/services/activity-log.ts
@@ -22,6 +22,7 @@ import { db, type Db } from "../db/connection.js";
 import { activityLog, documents } from "../db/schema.js";
 import type { ActivityLog, ActivityLogInsert } from "../db/schema.js";
 import { bus, type ChangeEvent, type Unsubscribe } from "./bus.js";
+import { stripUuids, containsUuid } from "./shared/identifiers.js";
 
 function log(...args: unknown[]): void {
   // eslint-disable-next-line no-console
@@ -265,7 +266,7 @@ export async function listActivity(
   // logic NULL only arises from the JOIN miss, already covered by the IS NULL arm.)
   conditions.push(or(isNull(activityLog.briefId), ne(documents.isDemo, true))!);
 
-  return conn
+  const rows = await conn
     // Project the activity_log columns explicitly so a joined SELECT still
     // returns a flat ActivityLog[] (a bare .select() over a join nests rows
     // under table keys).
@@ -291,4 +292,16 @@ export async function listActivity(
     // share a created_at (a burst of events in the same millisecond).
     .orderBy(desc(activityLog.createdAt), desc(activityLog.id))
     .limit(limit);
+
+  // b-36 (no raw UUIDs out): activity_log narratives are IMMUTABLE — a row
+  // written before the spec-122 narrative fix can still read "created doc_member
+  // <uuid>". Strip any surviving UUID at the read boundary so the Pulse feed
+  // never renders one, and drop a UUID-shaped actor_name (the feed falls back to
+  // a client label rather than showing a raw id). New rows are already clean
+  // (composeNarrative is UUID-guarded), so this only touches the historical tail.
+  return rows.map((r) => ({
+    ...r,
+    narrative: stripUuids(r.narrative),
+    actorName: r.actorName && containsUuid(r.actorName) ? null : r.actorName,
+  }));
 }

--- a/packages/server/src/services/shared/identifiers.test.ts
+++ b/packages/server/src/services/shared/identifiers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { isUuid, parseHandle } from "./identifiers.js";
+import { isUuid, parseHandle, containsUuid, stripUuids } from "./identifiers.js";
 
 describe("isUuid", () => {
   it("returns true for a valid lowercase UUID", () => {
@@ -71,5 +71,45 @@ describe("parseHandle", () => {
 
   it("returns null for UUID (not a handle)", () => {
     expect(parseHandle("550e8400-e29b-41d4-a716-446655440000", "dec-")).toBeNull();
+  });
+});
+
+describe("containsUuid", () => {
+  it("detects a UUID embedded in free text", () => {
+    expect(containsUuid("created doc_member 322dda5d-b14c-4597-b106-c13b847905ac")).toBe(true);
+  });
+  it("is false for handle-bearing narratives", () => {
+    expect(containsUuid("promoted Barrie to editor on spec-7")).toBe(false);
+  });
+  it("is false for empty / plain strings", () => {
+    expect(containsUuid("")).toBe(false);
+    expect(containsUuid("System")).toBe(false);
+  });
+  it("is stateless across calls (no global-regex lastIndex bug)", () => {
+    const s = "x 322dda5d-b14c-4597-b106-c13b847905ac";
+    expect(containsUuid(s)).toBe(true);
+    expect(containsUuid(s)).toBe(true); // would flip false on the 2nd call if /g were reused
+  });
+});
+
+describe("stripUuids", () => {
+  it("removes a UUID token and tidies the dangling separator/spaces", () => {
+    expect(stripUuids("created doc_member 322dda5d-b14c-4597-b106-c13b847905ac")).toBe(
+      "created doc_member",
+    );
+  });
+  it("removes a trailing ' — <uuid>' actor tail", () => {
+    expect(
+      stripUuids("recent: created document spec-3 — 322dda5d-b14c-4597-b106-c13b847905ac 2m ago"),
+    ).toBe("recent: created document spec-3 — 2m ago");
+  });
+  it("preserves newlines (only space runs collapse)", () => {
+    const out = stripUuids("line one 550e8400-e29b-41d4-a716-446655440000\nline two");
+    expect(out).toBe("line one\nline two");
+  });
+  it("leaves UUID-free text untouched", () => {
+    expect(stripUuids("promoted Barrie to editor on spec-7")).toBe(
+      "promoted Barrie to editor on spec-7",
+    );
   });
 });

--- a/packages/server/src/services/shared/identifiers.ts
+++ b/packages/server/src/services/shared/identifiers.ts
@@ -4,6 +4,36 @@ export function isUuid(s: string): boolean {
   return UUID_RE.test(s);
 }
 
+// An EMBEDDED uuid token (not anchored), for finding/removing a raw id inside
+// free text. Kept separate from the anchored UUID_RE so isUuid stays an
+// exact-match check. The `.test()` regex is non-global (stateless); the
+// `.replace()` regex is global.
+const UUID_TOKEN_ANY = /\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/i;
+const UUID_TOKEN_GLOBAL = /\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/gi;
+
+/** True when `s` contains a raw UUID token anywhere. */
+export function containsUuid(s: string): boolean {
+  return UUID_TOKEN_ANY.test(s);
+}
+
+/**
+ * Remove any raw UUID token from free text and tidy the doubled spaces / dangling
+ * separators left behind (newlines preserved — only runs of spaces collapse).
+ *
+ * The b-36 invariant — canonical refs in, NO raw UUIDs out — is a human-facing
+ * surface rule (enforced by the authed smoke). Activity narratives REPLAY
+ * immutable historical text: a row written before a narrative fix can still read
+ * "created doc_member <uuid>", and forward-only fixes can't rewrite it. So the
+ * display/read boundary strips defensively rather than trusting the stored value.
+ */
+export function stripUuids(text: string): string {
+  return text
+    .replace(UUID_TOKEN_GLOBAL, "")
+    .replace(/ {2,}/g, " ")
+    .replace(/ +—\s*$/gm, "")
+    .replace(/[ \t]+$/gm, "");
+}
+
 /**
  * Parse a handle like "dec-3" or "t-1" and return the sequence number,
  * or null if the string doesn't match the given prefix.


### PR DESCRIPTION
## Fix: raw UUIDs in activity display (Pulse feed + get_doc footer)

Follow-up to #119. #119 cleaned **new** narratives, but `activity_log` is immutable — rows written before that fix still read `created doc_member <uuid>`, and they replay in both the **Pulse feed** and the **get_doc ACTIVITY footer**.

This is the same "GUIDs not human-readable" the feed showed, **and** it tripped the **b-36 hard cut** (canonical refs in, no raw UUIDs out): the live `authed.smoke.test.ts` caught it on a `get_doc` call (the int deploys for #117/#118 went red on smoke before #119 landed).

### Why a read-boundary strip
Forward-only narrative fixes can't rewrite historical immutable rows. So the **read/display boundary** strips defensively rather than trusting stored text.

- **`shared/identifiers.ts`** — `stripUuids()` (remove embedded UUID tokens, tidy the spacing / dangling `—` separators, preserve newlines) + `containsUuid()`. One home next to `isUuid`; the `.test()` regex is non-global so it can't go stateful.
- **`activity-log.ts` `listActivity()`** — strips any surviving UUID from each narrative and drops a UUID-shaped `actor_name` (the feed then falls back to a client label). Covers the **Pulse REST feed**.
- **`tool-specs.ts` `craftActivityBlock()`** — sanitizes each actor name and `stripUuids()` the composed block before it ships. Covers the **get_doc footer**.

New rows are already clean (`composeNarrative` is UUID-guarded from #119), so this only touches the historical tail.

### Verification
- `stripUuids` / `containsUuid` unit table (incl. the stateless-`.test()` guard).
- `listActivity` strips a historical UUID narrative + UUID `actor_name`.
- The footer strips a seeded historical `activity_log` narrative (no UUID escapes; readable remainder survives).
- Full server suite green (**3772 passed**).

> Note: the **"System"** actor on these rows is still a separate, known follow-up (they emit through `mutate({})` with no `RequestCtx`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
