### PR TITLE
fix(guide-sdk): engine CSS reset must not out-rank utility classes (transparent idle icon on the website)

### DIFF
--- a/packages/guide-sdk/src/bundle/doorwayParity.test.ts
+++ b/packages/guide-sdk/src/bundle/doorwayParity.test.ts
@@ -119,6 +119,25 @@ describe('doorway parity: the loader doorway mirrors the engine idle treatment',
     expect(loaderSrc).toContain('img.height = Math.round(MARK_PX * SPECKY_ASPECT)');
   });
 
+  it('engine resets are zero-specificity — utilities must win the cascade', () => {
+    // Live bug (spec-222): a bare [data-memex-guide='engine'] button reset is
+    // (0,1,1) and its `background: none` beats every single-class utility like
+    // .bg-surface (0,1,0) — the idle icon and pill painted transparent on the
+    // website (doorway dark on load, see-through after a session). Every reset
+    // selector that targets engine descendants must be wrapped in :where() so
+    // utility classes always out-rank it.
+    const noComments = ENGINE_CSS.replace(/\/\*[\s\S]*?\*\//g, '');
+    const resetSelectors = noComments.match(/^[^@{}]*\[data-memex-guide='engine'\][^{}]*(?={)/gm) ?? [];
+    expect(resetSelectors.length).toBeGreaterThan(0);
+    for (const sel of resetSelectors) {
+      for (const part of sel.split(',')) {
+        expect(part.trim(), `engine reset selector must be :where()-wrapped: ${part.trim()}`).toMatch(
+          /^:where\(/,
+        );
+      }
+    }
+  });
+
   it('mirrors the engine transition + anchor position', () => {
     // ENGINE_CSS `.transition`: 150ms cubic-bezier(0.4, 0, 0.2, 1); the loader
     // applies the same curve (transform-only — that is all the doorway animates).

--- a/packages/guide-sdk/src/bundle/engineStyles.ts
+++ b/packages/guide-sdk/src/bundle/engineStyles.ts
@@ -40,15 +40,19 @@ export const ENGINE_CSS = `
 }
 
 /* Reset the engine container's inherited box model (host pages vary wildly). */
-[data-memex-guide='engine'] *,
-[data-memex-guide='engine'] *::before,
-[data-memex-guide='engine'] *::after {
+:where([data-memex-guide='engine'] *),
+:where([data-memex-guide='engine'] *)::before,
+:where([data-memex-guide='engine'] *)::after {
   box-sizing: border-box;
 }
 
 /* Buttons inside the engine shed the host page's button chrome before our
-   utility classes paint them (background/border/font come from the classes). */
-[data-memex-guide='engine'] button {
+   utility classes paint them (background/border/font come from the classes).
+   :where() zeroes the reset's specificity — bare, this selector is (0,1,1)
+   and its background: none beats every single-class utility like .bg-surface
+   (0,1,0), leaving the idle icon and pill transparent on the host page (the
+   doorway-dark-then-light bug seen live on www.memex.ai). */
+:where([data-memex-guide='engine'] button) {
   margin: 0;
   font: inherit;
   color: inherit;


### PR DESCRIPTION
## What

Live bug on www.memex.ai: the round doorway is dark on page load but light/transparent after using the guide.

Probed the live page with Playwright: after a session ends, the engine's idle `[data-voice-affordance]` button computes `background: rgba(0,0,0,0)` even though the host carries `--color-surface: 27 30 36` and `.bg-surface` parses fine. Root cause is the cascade: the engine stylesheet's button reset

```css
[data-memex-guide='engine'] button { background: none; ... }  /* (0,1,1) */
.bg-surface { background-color: rgb(var(--color-surface)); }  /* (0,1,0) — loses */
```

The reset's own comment says "background/border/font come from the classes", but its specificity beats every single-class utility — the idle icon and the session pill render transparent on the host page (the loader's first-paint doorway has its own CSS, hence the dark→light mismatch).

Fix: wrap the engine resets in `:where()` (zero specificity — the standard preflight pattern), plus a `doorwayParity` test guard asserting every engine reset selector is `:where()`-wrapped.

## Verification
- guide-sdk: 126 tests green (incl. new cascade guard), typecheck clean, bundle builds (loader unchanged at 7.18 kB, new engine chunk hash)
- ui: 1133 green (app parity — the app never loads ENGINE_CSS)

## Ship note
Needs a `release:sdk` re-vendor + website deploy after merge to reach www.memex.ai.

🤖 Generated with [Claude Code](https://claude.com/claude-code)