### PR TITLE
fix(pulse): attribute member/assignee events to the human, not "System"

### DIFF
--- a/packages/server/src/agent/tool-specs.ts
+++ b/packages/server/src/agent/tool-specs.ts
@@ -4507,13 +4507,13 @@ export const toolSpecs: ToolSpec[] = [
       const who = target.email ?? "(unknown)";
       const specRef = buildDocRef(slugs, doc);
       if (role === "editor") {
-        await promoteToEditor(memexId, doc.id, target.id);
+        await promoteToEditor(memexId, doc.id, target.id, reqCtx(ctx));
         if (ctx.verbose) {
           return `Promoted ${who} to editor on ${specRef}.`;
         }
         return `ref: ${specRef} user=${who} role=editor`;
       }
-      await demoteToReviewer(memexId, doc.id, target.id);
+      await demoteToReviewer(memexId, doc.id, target.id, reqCtx(ctx));
       if (ctx.verbose) {
         return `Demoted ${who} to reviewer on ${specRef} (editor row removed; falls back to the reviewer default).`;
       }
@@ -4595,7 +4595,7 @@ export const toolSpecs: ToolSpec[] = [
         ? await resolveUserArg(userArg, "user")
         : { id: ctx.userId, email: null };
       const who = target.email ?? "(you)";
-      await assign(memexId, doc.id, target.id, ctx.userId);
+      await assign(memexId, doc.id, target.id, ctx.userId, reqCtx(ctx));
       const specRef = buildDocRef(slugs, doc);
       if (ctx.verbose) {
         return `Assigned ${who} to ${specRef}.`;
@@ -4628,7 +4628,7 @@ export const toolSpecs: ToolSpec[] = [
       const { memexId, doc, slugs } = resolved;
       const target = await resolveUserArg(input.user as string, "user");
       const who = target.email ?? "(unknown)";
-      await unassign(memexId, doc.id, target.id);
+      await unassign(memexId, doc.id, target.id, reqCtx(ctx));
       const specRef = buildDocRef(slugs, doc);
       if (ctx.verbose) {
         return `Unassigned ${who} from ${specRef}.`;

--- a/packages/server/src/routes/doc-assignees.ts
+++ b/packages/server/src/routes/doc-assignees.ts
@@ -3,6 +3,7 @@ import { assign, unassign, listAssignees } from "../services/doc-assignees.js";
 import { sessionMiddleware, publicSessionMiddleware, type SessionEnv } from "../middleware/session.js";
 import type { MemexResolverEnv } from "../middleware/memex-resolver.js";
 import { requireMemexId, resolveReadableMemexId } from "./shared.js";
+import { restCtx } from "./_actor-ctx.js";
 
 // Thin REST mirror of the assignment service (spec-118 t-4). Assignment is the
 // live responsibility pointer the board shows (dec-3); GET is permissive (the
@@ -30,7 +31,7 @@ docAssigneesRouter.post("/doc/:docId/assign", async (c) => {
   // Self-assign when userId is omitted ("Assign me" needs no client-side id).
   const userId = body.userId ?? assignedBy;
   if (!userId) return c.json({ error: "userId required" }, 400);
-  const result = await assign(memexId, docId, userId, assignedBy);
+  const result = await assign(memexId, docId, userId, assignedBy, restCtx(c));
   return c.json(result, 201);
 });
 
@@ -39,7 +40,7 @@ docAssigneesRouter.post("/doc/:docId/unassign", async (c) => {
   const docId = c.req.param("docId");
   const { userId } = await c.req.json<{ userId: string }>();
   if (!userId) return c.json({ error: "userId required" }, 400);
-  const result = await unassign(memexId, docId, userId);
+  const result = await unassign(memexId, docId, userId, restCtx(c));
   return c.json(result);
 });
 

--- a/packages/server/src/routes/doc-members.ts
+++ b/packages/server/src/routes/doc-members.ts
@@ -8,6 +8,7 @@ import {
 import { sessionMiddleware, publicSessionMiddleware, type SessionEnv } from "../middleware/session.js";
 import type { MemexResolverEnv } from "../middleware/memex-resolver.js";
 import { requireMemexId, resolveReadableMemexId } from "./shared.js";
+import { restCtx } from "./_actor-ctx.js";
 
 // Thin REST mirror of the per-Spec role service (spec-118 t-3). Roles gate
 // CAPABILITY + UI posture, never read access (dec-2) — so GET is permissive (the
@@ -43,7 +44,7 @@ docMembersRouter.post("/doc/:docId/promote", async (c) => {
   const body = await c.req.json<{ userId?: string }>().catch(() => ({}) as { userId?: string });
   const userId = body.userId ?? (c.get("currentUserId") as string | null);
   if (!userId) return c.json({ error: "userId required" }, 400);
-  const result = await promoteToEditor(memexId, docId, userId);
+  const result = await promoteToEditor(memexId, docId, userId, restCtx(c));
   return c.json(result);
 });
 
@@ -54,7 +55,7 @@ docMembersRouter.post("/doc/:docId/demote", async (c) => {
   const body = await c.req.json<{ userId?: string }>().catch(() => ({}) as { userId?: string });
   const userId = body.userId ?? (c.get("currentUserId") as string | null);
   if (!userId) return c.json({ error: "userId required" }, 400);
-  const result = await demoteToReviewer(memexId, docId, userId);
+  const result = await demoteToReviewer(memexId, docId, userId, restCtx(c));
   return c.json(result);
 });
 

--- a/packages/server/src/services/doc-assignees.integration.test.ts
+++ b/packages/server/src/services/doc-assignees.integration.test.ts
@@ -96,8 +96,13 @@ describe("spec-118 assignment emits on the unified bus (ac-20)", () => {
     createdDocIds.push(doc.id);
 
     const events = await captureEvents(memexId, async () => {
-      await assign(memexId, doc.id, bob.id, actor.id);
-      await unassign(memexId, doc.id, bob.id);
+      // ctx carries WHO (the assigner) + HOW (rest_ui). assignedBy is a separate
+      // column; the activity contract rides ctx.
+      await assign(memexId, doc.id, bob.id, actor.id, {
+        actorUserId: actor.id,
+        channel: "rest_ui",
+      });
+      await unassign(memexId, doc.id, bob.id, { actorUserId: actor.id, channel: "rest_ui" });
     });
     const mine = events.filter((e) => e.docId === doc.id && e.entity === "doc_assignee");
     expect(mine.map((e) => e.action)).toEqual(["created", "deleted"]);
@@ -110,6 +115,15 @@ describe("spec-118 assignment emits on the unified bus (ac-20)", () => {
     expect(deleted.narrative).toBe(`unassigned spec118-assignee-b@example.com from ${doc.handle}`);
     for (const e of mine) {
       expect(e.narrative, "narrative must not contain the raw doc UUID").not.toContain(doc.id);
+    }
+
+    // spec-122 dec-5: the events are ATTRIBUTED to the acting human + surface —
+    // not "System". channel is set (no fallback to 'server') and actor_name is
+    // resolved at write (the assigner has no name → his email).
+    for (const e of mine) {
+      expect(e.channel).toBe("rest_ui");
+      expect(e.actorUserId).toBe(actor.id);
+      expect(e.actorName).toBe("spec118-assigner@example.com");
     }
   });
 });

--- a/packages/server/src/services/doc-assignees.ts
+++ b/packages/server/src/services/doc-assignees.ts
@@ -22,8 +22,8 @@ import { db } from "../db/connection.js";
 import { docAssignees, documents, users } from "../db/schema.js";
 import type { DocAssignee } from "../db/schema.js";
 import { NotFoundError } from "../types/errors.js";
-import { mutate, type Mutated } from "./mutate.js";
-import { actorName } from "./actor.js";
+import { mutate, type Mutated, type RequestCtx } from "./mutate.js";
+import { actorName, resolveActorColumns } from "./actor.js";
 
 export type { DocAssignee };
 
@@ -172,11 +172,15 @@ export async function assign(
   docId: string,
   userId: string,
   assignedBy: string | null,
+  // spec-122 dec-5: WHO performed it + HOW, so the assign event is attributed to
+  // the acting human (not "System") with their resolved name. Defaults empty.
+  ctx: RequestCtx = {},
 ): Promise<Mutated<DocAssignee>> {
   const handle = await assertSpecInMemex(memexId, docId);
   const who = await assigneeDisplayName(userId);
+  const actor = await resolveActorColumns(ctx);
   return mutate(
-    {},
+    { ...ctx, actorUserId: actor.actorUserId ?? undefined, actorName: actor.actorName ?? undefined },
     {
       memexId,
       docId,
@@ -213,11 +217,13 @@ export async function unassign(
   memexId: string,
   docId: string,
   userId: string,
+  ctx: RequestCtx = {},
 ): Promise<Mutated<UnassignResult>> {
   const handle = await assertSpecInMemex(memexId, docId);
   const who = await assigneeDisplayName(userId);
+  const actor = await resolveActorColumns(ctx);
   return mutate(
-    {},
+    { ...ctx, actorUserId: actor.actorUserId ?? undefined, actorName: actor.actorName ?? undefined },
     {
       memexId,
       docId,

--- a/packages/server/src/services/doc-members.integration.test.ts
+++ b/packages/server/src/services/doc-members.integration.test.ts
@@ -156,8 +156,15 @@ describe("spec-118 promote / demote (frictionless, reversible, no last-editor lo
     createdDocIds.push(doc.id);
 
     const events = await captureEvents(memexId, async () => {
-      await promoteToEditor(memexId, doc.id, other.id);
-      await demoteToReviewer(memexId, doc.id, other.id);
+      // `human` performs the role change; ctx carries WHO + HOW (rest_ui).
+      await promoteToEditor(memexId, doc.id, other.id, {
+        actorUserId: human.id,
+        channel: "rest_ui",
+      });
+      await demoteToReviewer(memexId, doc.id, other.id, {
+        actorUserId: human.id,
+        channel: "rest_ui",
+      });
     });
     const mine = events.filter((e) => e.docId === doc.id && e.entity === "doc_member");
     expect(mine.map((e) => e.action)).toEqual(["created", "deleted"]);
@@ -170,6 +177,15 @@ describe("spec-118 promote / demote (frictionless, reversible, no last-editor lo
     expect(deleted.narrative).toBe(`demoted spec118-other@example.com to reviewer on ${doc.handle}`);
     for (const e of mine) {
       expect(e.narrative, "narrative must not contain the raw doc UUID").not.toContain(doc.id);
+    }
+
+    // spec-122 dec-5: ATTRIBUTED to the acting human + surface, not "System".
+    // channel is set and actor_name is resolved at write (creator has no name →
+    // his email).
+    for (const e of mine) {
+      expect(e.channel).toBe("rest_ui");
+      expect(e.actorUserId).toBe(human.id);
+      expect(e.actorName).toBe("spec118-creator@example.com");
     }
   });
 

--- a/packages/server/src/services/doc-members.ts
+++ b/packages/server/src/services/doc-members.ts
@@ -23,8 +23,8 @@ import { db } from "../db/connection.js";
 import { docMembers, documents, users } from "../db/schema.js";
 import type { DocMember } from "../db/schema.js";
 import { NotFoundError } from "../types/errors.js";
-import { mutate, type Mutated } from "./mutate.js";
-import { actorName } from "./actor.js";
+import { mutate, type Mutated, type RequestCtx } from "./mutate.js";
+import { actorName, resolveActorColumns } from "./actor.js";
 
 export type { DocMember };
 
@@ -148,11 +148,17 @@ export async function promoteToEditor(
   memexId: string,
   docId: string,
   userId: string,
+  // spec-122 dec-5: the activity contract (WHO performed it + HOW). Without it
+  // the event reaches the sink with no channel → 'server' → actor "System".
+  // resolveActorColumns denormalises the actor's name at write so the Pulse feed
+  // names the human, not a client label. Defaults empty for unattributed callers.
+  ctx: RequestCtx = {},
 ): Promise<Mutated<DocMember>> {
   const handle = await assertSpecInMemex(memexId, docId);
   const who = await memberDisplayName(userId);
+  const actor = await resolveActorColumns(ctx);
   return mutate(
-    {},
+    { ...ctx, actorUserId: actor.actorUserId ?? undefined, actorName: actor.actorName ?? undefined },
     {
       memexId,
       docId,
@@ -191,11 +197,13 @@ export async function demoteToReviewer(
   memexId: string,
   docId: string,
   userId: string,
+  ctx: RequestCtx = {},
 ): Promise<Mutated<DemoteResult>> {
   const handle = await assertSpecInMemex(memexId, docId);
   const who = await memberDisplayName(userId);
+  const actor = await resolveActorColumns(ctx);
   return mutate(
-    {},
+    { ...ctx, actorUserId: actor.actorUserId ?? undefined, actorName: actor.actorName ?? undefined },
     {
       memexId,
       docId,

--- a/packages/server/src/services/spec-traffic.ts
+++ b/packages/server/src/services/spec-traffic.ts
@@ -91,8 +91,12 @@ export async function observeSpecTraffic(event: SpecTrafficEvent): Promise<void>
     // ── Auto-assignment + editor role (dec-6) ─────────────────────────
     if (entry.autoAssignExempt !== true) {
       try {
-        await assign(event.memexId, event.docId, event.userId, event.userId);
-        await promoteToEditor(event.memexId, event.docId, event.userId);
+        // spec-122 dec-5: attribute the traffic-driven assign/promote to the
+        // human who made the triggering call, on the surface it came in on
+        // (mcp / in_app_agent — guarded above) so Pulse shows them, not "System".
+        const trafficCtx = { actorUserId: event.userId, channel: event.channel };
+        await assign(event.memexId, event.docId, event.userId, event.userId, trafficCtx);
+        await promoteToEditor(event.memexId, event.docId, event.userId, trafficCtx);
       } catch (err) {
         console.warn(
           `[spec-traffic] auto-assign failed for ${event.toolName} on ${doc.handle}:`,


### PR DESCRIPTION
## Fix: member/assignee activity shows "System" instead of the human

Follow-up in the spec-122 Pulse series. `doc_member` (promote/demote) and `doc_assignee` (assign/unassign) events emitted through `mutate({})` — no `RequestCtx` — so they reached the activity sink with **no channel**, which `mapEventToRow` defaults to `'server'` → `actor_kind 'system'` → the Pulse feed rendered the actor as **"System"**.

### Fix — thread the activity contract (std-32) end-to-end
- `promoteToEditor` / `demoteToReviewer` / `assign` / `unassign` take a `RequestCtx` and, like `createDocDraft`, `resolveActorColumns(ctx)` to **denormalise the actor's name at write** (one PK lookup) so the feed names the human, not a client label.
- **REST routes** pass `restCtx(c)` (channel `rest_ui`).
- **Agent tools** (`set_spec_role`, `assign_spec`, `unassign_spec`) pass `reqCtx(ctx)` (`mcp` / `in_app_agent`).
- **Traffic-driven auto-assign** (`spec-traffic.ts`) attributes to the triggering user on the surface the call came in on.
- Callers that pass nothing still default to `{}` → unattributed, which the sink surfaces as a **visible defect** (a `'server'` channel), never masked.

### Verification
- The doc-members / doc-assignees bus tests now assert each event carries `channel` + `actor_user_id` + the resolved `actor_name`.
- Full server suite green (**3772 passed**).

> Independent of #121 (UUID-strip) — both are on develop and can merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
