### PR TITLE
fix(guide-sdk): doorway animates from first paint (no dead static frame)

### DIFF
--- a/packages/guide-sdk/src/bundle/doorwayParity.test.ts
+++ b/packages/guide-sdk/src/bundle/doorwayParity.test.ts
@@ -107,6 +107,15 @@ describe('doorway parity: the loader doorway mirrors the engine idle treatment',
     }
   });
 
+  it('uses the ANIMATED Specky for the first paint (idle loop, not the static frame)', () => {
+    // The engine's idle VoiceIcon renders the animated Specky (default frame).
+    // The loader must match from first paint: specky.svg's idle animation is
+    // CSS keyframes inside the SVG, which play in an <img>, so no React is
+    // needed. A static first frame reads as "dead" next to the engine's icon.
+    expect(loaderSrc).toContain("from '../assets/specky.svg'");
+    expect(loaderSrc).not.toContain('specky-static.svg');
+  });
+
   it('renders the Specky mark at the engine idle mark size (40px wide)', () => {
     // The engine's idle mark width...
     const engineMark = engineSrc.match(/<VoiceIcon mark=\{<Specky size=\{(\d+)\} \/>\} \/>/)?.[1];

--- a/packages/guide-sdk/src/bundle/loader.lazy.spec-222.test.ts
+++ b/packages/guide-sdk/src/bundle/loader.lazy.spec-222.test.ts
@@ -81,7 +81,7 @@ describe('spec-222 t-5: engine is lazy-loaded (ac-8)', () => {
     // Sanity: our scanner DOES see the legitimate static imports the loader keeps
     // (so a green result above isn't a parser miss). The svg + the nav adapter
     // + the type module are all static and engine-free.
-    expect(staticSpecs).toContain('../assets/specky-static.svg');
+    expect(staticSpecs).toContain('../assets/specky.svg');
     expect(staticSpecs).toContain('../navigation/staticSiteNavigation');
   });
 

--- a/packages/guide-sdk/src/bundle/loader.ts
+++ b/packages/guide-sdk/src/bundle/loader.ts
@@ -21,13 +21,17 @@
 // static import of './engine', React, or the orchestrator anywhere below; the
 // engine dependency-cut guard for this file is the ac-8 structural test.
 
-import speckyStatic from '../assets/specky-static.svg';
+// The ANIMATED Specky (idle bob/sway/blink loop) — its animation is CSS
+// keyframes INSIDE the SVG, which play in an <img> context, so the no-React
+// loader gets the same living mark the engine renders. The static frame made
+// the first paint look dead next to the engine's idle icon.
+import speckyAnimated from '../assets/specky.svg';
 import { staticSiteNavigation } from '../navigation/staticSiteNavigation';
 import type { GuideBundleConfig, MountedEngine } from './types';
 
 /** The doorway's host element id (so a double-init can't stack two doorways). */
 const HOST_ID = 'memex-guide-host';
-/** Intrinsic aspect ratio of specky-static.svg (viewBox "0 0 240 330"). */
+/** Intrinsic aspect ratio of specky.svg (viewBox "0 0 240 330"). */
 const SPECKY_ASPECT = 330 / 240;
 /**
  * DOORWAY PARITY CONTRACT (see doorwayParity.test.ts): the doorway is the
@@ -78,7 +82,7 @@ export function init(config: GuideBundleConfig): HTMLElement {
   doorway.title = 'Ask Specky';
 
   const img = document.createElement('img');
-  img.src = speckyStatic;
+  img.src = speckyAnimated;
   img.alt = '';
   img.width = MARK_PX;
   img.height = Math.round(MARK_PX * SPECKY_ASPECT);


### PR DESCRIPTION
On the live website the doorway's Specky is static until the engine loads, then animates during/after a session. The idle loop (bob/sway/blink) is CSS keyframes inside `specky.svg`, and CSS animations in an SVG **do** play when loaded via `<img>` — verified with a headless-Chromium pixel-diff (frames 700ms apart differ). So the loader simply uses the animated asset instead of `specky-static.svg`.

- Loader: 7.18 → 8.96 kB raw (3.52 kB gzip) — well under the 50 kB ac-8 gate.
- `doorwayParity.test.ts` gains a guard pinning the animated asset; the lazy-loader structural test updated for the new import.
- guide-sdk suite: 127 green; typecheck + bundle build clean.

Ship note: needs a `release:sdk` re-vendor + website deploy after merge (I'll run it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)