### PR TITLE
feat(deploy-notify): enrich deploy Slack notification with shipped specs + PRs (spec-243 ac-6)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -110,29 +110,18 @@ jobs:
           MEMEX_EMIT_KEY: ${{ secrets.MEMEX_EMIT_KEY }}
         run: bash deploy.sh
 
-      # spec-243 dec-2: every deploy posts a friendly note to the matching
+      # spec-243 dec-2 / ac-6: every deploy posts a friendly note to the matching
       # env's Slack channel (#memex-prod-alerts / #memex-int-alerts), so each
-      # channel is the single timeline of "what changed and what broke" for
-      # its environment. Friendly register on success; a short red line when
-      # the deploy job itself fails (the canary covers what happens after).
+      # channel is the single timeline of "what changed and what broke" for its
+      # environment. Enriched with the specs + PRs that shipped (Option B —
+      # clickable spec links derived from the commit list, zero API calls so a
+      # Memex outage can never slow or break this). Friendly on success, a short
+      # red line if the deploy job itself failed; never fails the deploy.
       - name: Notify Slack (deploy)
         if: always()
         env:
           SLACK_WEBHOOK: ${{ env.ENV == 'prod' && secrets.SLACK_WEBHOOK_PROD || secrets.SLACK_WEBHOOK_INT }}
           HOST: ${{ env.ENV == 'prod' && 'memex.ai' || 'int.memex.ai' }}
-          COMMIT_SUBJECT: ${{ github.event.head_commit.message }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           OUTCOME: ${{ job.status }}
-        run: |
-          if [ -z "$SLACK_WEBHOOK" ]; then
-            echo "::warning::SLACK_WEBHOOK_${ENV^^} not set — skipping deploy notification"
-            exit 0
-          fi
-          SUBJECT_FIRST_LINE="$(printf '%s' "$COMMIT_SUBJECT" | head -n 1)"
-          if [ "$OUTCOME" = "success" ]; then
-            TEXT="🚀 *${HOST}* just got a fresh deploy: \"${SUBJECT_FIRST_LINE}\" (by ${GITHUB_ACTOR}). Smoke is green. <${RUN_URL}|Details>"
-          else
-            TEXT="🛑 Deploy to *${HOST}* did not complete (\"${SUBJECT_FIRST_LINE}\", by ${GITHUB_ACTOR}). <${RUN_URL}|Run log>"
-          fi
-          jq -n --arg text "$TEXT" '{text: $text}' | \
-            curl -sS -X POST -H 'Content-type: application/json' -d @- "$SLACK_WEBHOOK"
+        run: node scripts/canary/deploy-notify.mjs

--- a/packages/server/src/__regression__/canary-wiring.regression.test.ts
+++ b/packages/server/src/__regression__/canary-wiring.regression.test.ts
@@ -124,8 +124,10 @@ describe("spec-243: canary wiring", () => {
     expect(DEPLOY_YML).toContain(
       "env.ENV == 'prod' && secrets.SLACK_WEBHOOK_PROD || secrets.SLACK_WEBHOOK_INT",
     );
-    // Friendly on success, short red line on a failed deploy, never skipped.
-    expect(DEPLOY_YML).toContain("🚀");
-    expect(DEPLOY_YML).toContain("🛑");
+    // The notifier always runs (even on a failed deploy) and delegates message
+    // composition to the enrichment script (message content is covered by
+    // deploy-notify.regression.test.ts).
+    expect(DEPLOY_YML).toContain("if: always()");
+    expect(DEPLOY_YML).toContain("node scripts/canary/deploy-notify.mjs");
   });
 });

--- a/packages/server/src/__regression__/deploy-notify.regression.test.ts
+++ b/packages/server/src/__regression__/deploy-notify.regression.test.ts
@@ -1,0 +1,96 @@
+// spec-243 ac-6: the deploy notification names the specs and PRs that shipped.
+// These exercise the pure parsing/message functions directly (the script's
+// main() is import-guarded, so importing it posts nothing).
+
+import { describe, it, expect } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+// scripts/ lives outside the package; import the .mjs by relative path.
+import {
+  extractSpecRefs,
+  extractPrNumbers,
+  buildDeployMessage,
+} from "../../../../scripts/canary/deploy-notify.mjs";
+
+const SPEC = "mindset-prod/memex-building-itself/specs/spec-243";
+
+// A realistic merge-commit set (shape of github.event.commits): the actual
+// subjects from the develop→main promotion earlier in this work.
+const COMMITS = [
+  { message: "Merge pull request #126 from mindset-ai/spec-230-overview-parity" },
+  { message: "feat: in-app Spec creation reaches web↔MCP parity (spec-230)" },
+  { message: "Merge pull request #124 from mindset-ai/spec-222-voice-latency" },
+  { message: "feat(voice): caching + latency logs + personas (spec-222)" },
+  { message: "Merge pull request #116 from mindset-ai/spec-122-pulse-board" },
+  { message: "feat(pulse): activity board (spec-122)" },
+  { message: "fix(rls): exclude memex_emission_keys from RLS (spec-243)" },
+];
+
+describe("spec-243: deploy notification enrichment", () => {
+  it("ac-6: extracts unique spec handles, sorted numerically", () => {
+    tagAc(`${SPEC}/acs/ac-6`);
+    expect(extractSpecRefs(COMMITS.map((c) => c.message).join("\n"))).toEqual([
+      "spec-122",
+      "spec-222",
+      "spec-230",
+      "spec-243",
+    ]);
+  });
+
+  it("ac-6: spec extraction is case-insensitive and de-duplicates", () => {
+    tagAc(`${SPEC}/acs/ac-6`);
+    expect(extractSpecRefs("SPEC-7 spec-7 Spec-7 spec-12")).toEqual([
+      "spec-7",
+      "spec-12",
+    ]);
+  });
+
+  it("ac-6: extracts merged PR numbers", () => {
+    tagAc(`${SPEC}/acs/ac-6`);
+    expect(extractPrNumbers(COMMITS.map((c) => c.message).join("\n"))).toEqual([
+      116, 124, 126,
+    ]);
+  });
+
+  it("ac-6: success message carries clickable spec links + PR list", () => {
+    tagAc(`${SPEC}/acs/ac-6`);
+    const msg = buildDeployMessage({
+      host: "memex.ai",
+      outcome: "success",
+      actor: "wic",
+      runUrl: "https://example/run",
+      commits: COMMITS,
+    });
+    expect(msg).toContain("🚀 *memex.ai* deployed (by wic)");
+    expect(msg).toContain("7 commits, 3 PRs (#116, #124, #126)");
+    // Clickable Slack link to the spec's page in the prod memex-building-itself.
+    expect(msg).toContain(
+      "<https://memex.ai/mindset-prod/memex-building-itself/specs/spec-122|spec-122>",
+    );
+    expect(msg).toContain("<https://example/run|Details>");
+  });
+
+  it("ac-6: failed deploy uses the red register but still lists specs", () => {
+    tagAc(`${SPEC}/acs/ac-6`);
+    const msg = buildDeployMessage({
+      host: "int.memex.ai",
+      outcome: "failure",
+      actor: "wic",
+      runUrl: "https://example/run",
+      commits: COMMITS,
+    });
+    expect(msg).toContain("🛑 Deploy to *int.memex.ai* did not complete");
+    expect(msg).toContain("spec-243");
+  });
+
+  it("ac-6: a deploy with no spec tags says so rather than lying", () => {
+    tagAc(`${SPEC}/acs/ac-6`);
+    const msg = buildDeployMessage({
+      host: "memex.ai",
+      outcome: "success",
+      actor: "wic",
+      runUrl: "https://example/run",
+      commits: [{ message: "chore: bump dependency" }],
+    });
+    expect(msg).toContain("_No spec-tagged commits in this release._");
+  });
+});

--- a/scripts/canary/deploy-notify.mjs
+++ b/scripts/canary/deploy-notify.mjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+// spec-243 dec-2 / ac-6: friendly per-env deploy notification to Slack, enriched
+// with the specs and PRs that shipped (Option B — clickable spec links, zero API
+// calls so a Memex outage can never slow or break a deploy notification).
+//
+// The spec/PR set is read from the push event's commit list ($GITHUB_EVENT_PATH,
+// the full webhook payload every Action run has on disk). For a PR merge that
+// list contains every commit the merge introduced, so the tags are all present.
+// This reads what the commits *claim* (the memex-app convention tags the spec in
+// each subject, e.g. "spec-122: …", "(spec-243)"); a mistagged or untagged commit
+// is invisible to it — same trust model as the rest of the convention.
+//
+// Required env: CANARY_ENV unused; SLACK_WEBHOOK, HOST, OUTCOME (job.status),
+// RUN_URL, GITHUB_ACTOR, GITHUB_EVENT_PATH.
+
+import { readFileSync } from "node:fs";
+
+// All memex-app dev specs live in the prod "memex building itself" Memex,
+// regardless of which env the code deployed to — so spec links always point
+// here. (spec-243 is at exactly this base.)
+const SPEC_BASE = "https://memex.ai/mindset-prod/memex-building-itself/specs";
+
+// Extract unique `spec-N` handles from text, sorted numerically. Case-insensitive
+// match, canonical lowercase output. (Briefs `b-N` are deliberately not linked —
+// their URL path differs and they're effectively absent from current deploys.)
+export function extractSpecRefs(text) {
+  const seen = new Map();
+  for (const m of text.matchAll(/\bspec-(\d+)\b/gi)) {
+    const n = Number(m[1]);
+    seen.set(n, `spec-${n}`);
+  }
+  return [...seen.keys()].sort((a, b) => a - b).map((n) => seen.get(n));
+}
+
+// Extract unique merged PR numbers from "Merge pull request #N" subjects.
+export function extractPrNumbers(text) {
+  const seen = new Set();
+  for (const m of text.matchAll(/Merge pull request #(\d+)/g)) {
+    seen.add(Number(m[1]));
+  }
+  return [...seen].sort((a, b) => a - b);
+}
+
+function specLink(ref) {
+  return `<${SPEC_BASE}/${ref}|${ref}>`;
+}
+
+export function buildDeployMessage({ host, outcome, actor, runUrl, commits }) {
+  const allText = commits.map((c) => c.message ?? "").join("\n");
+  const specs = extractSpecRefs(allText);
+  const prs = extractPrNumbers(allText);
+
+  const head =
+    outcome === "success"
+      ? `🚀 *${host}* deployed (by ${actor}). Smoke is green.`
+      : `🛑 Deploy to *${host}* did not complete (by ${actor}).`;
+
+  const stats =
+    `${commits.length} commit${commits.length === 1 ? "" : "s"}` +
+    (prs.length ? `, ${prs.length} PR${prs.length === 1 ? "" : "s"} (${prs.map((n) => `#${n}`).join(", ")})` : "");
+
+  const specsLine = specs.length
+    ? `Specs in this release: ${specs.map(specLink).join(", ")}`
+    : "_No spec-tagged commits in this release._";
+
+  return `${head}\n${stats}\n${specsLine}\n<${runUrl}|Details>`;
+}
+
+function readCommits() {
+  try {
+    const event = JSON.parse(readFileSync(process.env.GITHUB_EVENT_PATH, "utf8"));
+    return Array.isArray(event.commits) ? event.commits : [];
+  } catch {
+    return [];
+  }
+}
+
+async function main() {
+  const webhook = process.env.SLACK_WEBHOOK;
+  const text = buildDeployMessage({
+    host: process.env.HOST ?? "memex",
+    outcome: process.env.OUTCOME ?? "success",
+    actor: process.env.GITHUB_ACTOR ?? "someone",
+    runUrl: process.env.RUN_URL ?? "",
+    commits: readCommits(),
+  });
+
+  if (!webhook) {
+    console.error("[deploy-notify] SLACK_WEBHOOK not set — would have posted:");
+    console.error(text);
+    return; // never fail a deploy over a missing webhook
+  }
+  const res = await fetch(webhook, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ text }),
+  });
+  console.error(`[deploy-notify] Slack returned ${res.status}`);
+}
+
+// Only run when invoked directly, so the pure functions above stay importable
+// from tests without posting anything.
+if (process.argv[1] && process.argv[1].endsWith("deploy-notify.mjs")) {
+  main();
+}


### PR DESCRIPTION
## What

Follow-up to the canary (#115). Replaces the inline-bash deploy notification — which only showed the unhelpful merge-commit subject (`"Merge pull request #127 from …"`) — with **`scripts/canary/deploy-notify.mjs`**, which names the specs and PRs that actually shipped.

This is **Option B** from the spec-243 discussion: clickable spec links, derived purely from the push event's commit list, **zero API calls** so a Memex outage can never slow or break a deploy notification.

### Example output (rendered from a real commit set)
> 🚀 **memex.ai** deployed (by wic). Smoke is green.
> 5 commits, 2 PRs (#116, #126)
> Specs in this release: spec-122, spec-230, spec-243  ← each a clickable link to its spec page
> Details

## How

- Reads `$GITHUB_EVENT_PATH` (the push payload every Action run has on disk); for a PR merge its `commits` array carries every commit the merge introduced.
- `extractSpecRefs` / `extractPrNumbers` — pure, unit-tested functions: `spec-N` handles (case-insensitive, deduped, numerically sorted) and `Merge pull request #N` numbers.
- Spec links always point at `mindset-prod/memex-building-itself` (where all memex-app dev specs live), regardless of which env deployed.
- Friendly 🚀 register on success; 🛑 register on a failed deploy (still lists the specs — knowing what was in a failed deploy is useful). Never fails the deploy; a missing webhook degrades to a log line.

## Deliberately NOT in this PR

- **prod `@here` paging** — holding off a day to observe the channel volume first (user's call).
- **Spec titles** (Option C) — would need a Memex read per spec; a tidy fast-follow once this proves out, kept out of v1 so the notification stays API-free.

## Honest caveat

This reads what the commits *claim* (the memex-app convention tags the spec in each subject). A mistagged or untagged commit is invisible to it — same trust model as the rest of the convention. `b-N` briefs are not linked (different URL path, effectively absent from current deploys).

## Test plan

- [x] `deploy-notify.regression.test.ts` — 6 cases (extraction, dedup, success/failure message, no-spec fallback), tagged spec-243 ac-6
- [x] `canary-wiring.regression.test.ts` — updated ac-6 to the new step shape; 8/8 green
- [x] Rendered the real message from a simulated event payload (see example above)
- [ ] Post-merge: observe the next int deploy notification in #memex-int-alerts