### PR TITLE
feat(canary): Cloud Run Job + Cloud Scheduler runner (spec-243 dec-1 superseded)

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -1,30 +1,20 @@
-# spec-243: continuous canary — authenticated probes against the live envs
-# every 10 minutes, claxons to the per-env Slack channel on 2 consecutive
-# failures, all-clear on recovery (dec-1/dec-2/dec-4).
+# spec-243: continuous canary — authenticated probes against the live envs,
+# claxons to the per-env Slack channel on 2 consecutive failures, all-clear on
+# recovery (dec-1/dec-2/dec-4).
 #
-# NOTE: GitHub only evaluates `schedule:` triggers on the DEFAULT branch
-# (develop). The canary starts ticking when this file lands there; nothing is
-# deployed. `workflow_dispatch` exists so it can be fired manually (including
-# from a branch) to test the pipe.
+# ⚠ THE SCHEDULE IS DEAD — the real runner is Cloud Run (dec-1, superseded
+# 2026-06-11). GitHub's `schedule:` trigger never fired (0 of 6 slots over 67
+# minutes; best-effort by design). The canary now runs as a Cloud Run Job +
+# Cloud Scheduler in memex-ai-prod (scripts/canary/run-job.mjs, deploy-canary-job.sh).
+# This workflow is kept ONLY as a manually-dispatchable backup probe; it has no
+# `schedule:` trigger so it does nothing unless someone clicks "Run workflow".
 #
-# Cost posture (dec-1): ~6 runs/hour × ~1 billed minute ≈ $25-35/month for the
-# private repo. The 10-minute cadence was chosen over 5 specifically to halve
-# this; revisit alongside issue-1 (Cloud Run port) if it creeps.
-#
-# Required repo secrets:
-#   SLACK_WEBHOOK_PROD / SLACK_WEBHOOK_INT      incoming webhooks (#memex-prod-alerts / #memex-int-alerts)
-#   CANARY_EMIT_KEY_PROD / CANARY_EMIT_KEY_INT  emission keys minted in the canary Memex
-#   CANARY_MCP_TOKEN_PROD / CANARY_MCP_TOKEN_INT  mxt_ tokens for the canary Memex
-# Required repo variables:
-#   CANARY_AC_UID_PROD / CANARY_AC_UID_INT      ac_uid the hidden emission targets
-#   CANARY_VERBOSE                              'true' → post a success line on every
-#                                               green run (rollout proof); flip off in
-#                                               the UI, no code change.
-name: canary
+# Required repo secrets / variables (for the manual backup path only):
+#   SLACK_WEBHOOK_{PROD,INT}, CANARY_EMIT_KEY_{PROD,INT}, CANARY_MCP_TOKEN_{PROD,INT}
+#   CANARY_AC_UID_{PROD,INT}, CANARY_VERBOSE
+name: canary (manual backup — Cloud Run is the real runner)
 
 on:
-  schedule:
-    - cron: "*/10 * * * *"
   workflow_dispatch:
 
 permissions:

--- a/packages/server/src/__regression__/canary-notify-decision.regression.test.ts
+++ b/packages/server/src/__regression__/canary-notify-decision.regression.test.ts
@@ -1,0 +1,64 @@
+// spec-243 ac-2: the 2-consecutive-failure decision table (dec-4) is a pure
+// function shared by both runners (GitHub Actions + Cloud Run), so it's tested
+// directly. Runner-agnostic: the only difference between runners is where
+// prevStatus comes from (GitHub API vs GCS), which these tests inject.
+
+import { describe, it, expect } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import {
+  decideNotification,
+  statusFromSummary,
+} from "../../../../scripts/canary/notify.mjs";
+
+const SPEC = "mindset-prod/memex-building-itself/specs/spec-243";
+const RED = { env: "prod", ok: false, results: { emission: { ok: false, detail: "POST /api/test-events → 401", body: '{"error":"unauthorized"}' }, page: { ok: true, detail: "GET / → 200", body: "" } } };
+const GREEN = { env: "prod", ok: true, results: { page: { ok: true, detail: "GET / → 200", body: "" }, emission: { ok: true, detail: "→ 201", body: "" } } };
+const base = { host: "memex.ai", verbose: false, runUrl: "https://run/log" };
+
+describe("spec-243: canary notification decision table", () => {
+  it("ac-2: RED + previous RED → claxon naming the failed probe + response", () => {
+    tagAc(`${SPEC}/acs/ac-2`);
+    const { decision, text } = decideNotification({ ...base, summary: RED, prevStatus: "red" });
+    expect(decision).toBe("claxon");
+    expect(text).toContain("CANARY RED");
+    expect(text).toContain("emission");
+    expect(text).toContain("401");
+    expect(text).toContain("https://run/log");
+  });
+
+  it("ac-2: RED + previous GREEN → silent (the single-blip allowance)", () => {
+    tagAc(`${SPEC}/acs/ac-2`);
+    const { decision, text } = decideNotification({ ...base, summary: RED, prevStatus: "green" });
+    expect(decision).toBe("silent");
+    expect(text).toBeNull();
+  });
+
+  it("ac-2: first-ever RED (prev 'none') alerts immediately", () => {
+    tagAc(`${SPEC}/acs/ac-2`);
+    expect(decideNotification({ ...base, summary: RED, prevStatus: "none" }).decision).toBe("claxon");
+  });
+
+  it("ac-2: RED + prev 'unknown' (state unreadable) errs toward alerting", () => {
+    tagAc(`${SPEC}/acs/ac-2`);
+    expect(decideNotification({ ...base, summary: RED, prevStatus: "unknown" }).decision).toBe("claxon");
+  });
+
+  it("ac-2: GREEN + previous RED → all-clear", () => {
+    tagAc(`${SPEC}/acs/ac-2`);
+    const { decision, text } = decideNotification({ ...base, summary: GREEN, prevStatus: "red" });
+    expect(decision).toBe("all-clear");
+    expect(text).toContain("All clear");
+  });
+
+  it("ac-2: GREEN + previous GREEN → silent unless verbose", () => {
+    tagAc(`${SPEC}/acs/ac-2`);
+    expect(decideNotification({ ...base, summary: GREEN, prevStatus: "green" }).decision).toBe("silent");
+    expect(decideNotification({ ...base, summary: GREEN, prevStatus: "green", verbose: true }).decision).toBe("verbose");
+  });
+
+  it("ac-2: status persisted matches run outcome", () => {
+    tagAc(`${SPEC}/acs/ac-2`);
+    expect(statusFromSummary(GREEN)).toBe("green");
+    expect(statusFromSummary(RED)).toBe("red");
+  });
+});

--- a/packages/server/src/__regression__/canary-wiring.regression.test.ts
+++ b/packages/server/src/__regression__/canary-wiring.regression.test.ts
@@ -40,16 +40,32 @@ const NOTIFY_MJS = readFileSync(
   join(REPO_ROOT, "scripts", "canary", "notify.mjs"),
   "utf-8",
 );
+const DEPLOY_SH = readFileSync(
+  join(REPO_ROOT, "scripts", "canary", "deploy-canary-job.sh"),
+  "utf-8",
+);
+const RUN_JOB_MJS = readFileSync(
+  join(REPO_ROOT, "scripts", "canary", "run-job.mjs"),
+  "utf-8",
+);
 
 describe("spec-243: canary wiring", () => {
-  it("ac-1: canary runs on a 10-minute schedule against both envs", () => {
+  it("ac-1: canary runs on a 10-minute Cloud Scheduler cron against both envs", () => {
     tagAc(`${SPEC}/acs/ac-1`);
 
-    expect(CANARY_YML).toContain('cron: "*/10 * * * *"');
-    expect(CANARY_YML).toContain("env: [prod, int]");
-    expect(CANARY_YML).toContain("node scripts/canary/probe.mjs");
-    // Manual trigger stays available for pipe-testing from branches.
+    // The real runner is Cloud Run + Cloud Scheduler (dec-1, superseded): every
+    // 10 min, off-round minutes. The GitHub schedule was killed (it never fired).
+    expect(DEPLOY_SH).toContain('"2,12,22,32,42,52 * * * *"');
+    expect(DEPLOY_SH).toContain("gcloud scheduler jobs");
+    // One Cloud Run Job execution probes BOTH envs.
+    expect(RUN_JOB_MJS).toContain('handleEnv("prod"');
+    expect(RUN_JOB_MJS).toContain('handleEnv("int"');
+    // The GitHub workflow is a manual backup only — no schedule trigger. (The
+    // word "schedule" still appears in the header comment explaining why it's
+    // gone, so assert on the trigger syntax, not the bare word.)
     expect(CANARY_YML).toContain("workflow_dispatch");
+    expect(CANARY_YML).not.toContain("- cron:");
+    expect(CANARY_YML).toMatch(/on:\s*\n\s*workflow_dispatch:/);
   });
 
   it("ac-1: the probes are real authenticated operations, not pings", () => {
@@ -93,11 +109,15 @@ describe("spec-243: canary wiring", () => {
     expect(CANARY_YML).toContain("if: always()");
   });
 
-  it("ac-3: the canary runs on GitHub-hosted runners, outside GCP", () => {
+  it("ac-3: the canary runs on a reliable scheduler (Cloud Run Job in-project)", () => {
     tagAc(`${SPEC}/acs/ac-3`);
 
-    expect(CANARY_YML).toContain("runs-on: ubuntu-latest");
-    expect(CANARY_YML).not.toContain("self-hosted");
+    // ac-3 rewritten (dec-1 superseded): fate-isolation was traded away for a
+    // dependable trigger. The runner is a Cloud Run Job in memex-ai-prod driven
+    // by Cloud Scheduler — not GitHub's best-effort schedule.
+    expect(DEPLOY_SH).toContain("gcloud run jobs");
+    expect(DEPLOY_SH).toContain('PROJECT="${PROJECT:-memex-ai-prod}"');
+    expect(DEPLOY_SH).toContain("gcloud scheduler jobs");
   });
 
   it("ac-4: canary emissions are hidden and marked as canary traffic", () => {

--- a/packages/server/src/__regression__/canary-wiring.regression.test.ts
+++ b/packages/server/src/__regression__/canary-wiring.regression.test.ts
@@ -82,8 +82,9 @@ describe("spec-243: canary wiring", () => {
 
     expect(NOTIFY_MJS).toContain("CANARY RED");
     expect(NOTIFY_MJS).toContain("All clear");
-    // The blip allowance: a red run after a green one stays silent.
-    expect(NOTIFY_MJS).toContain("staying silent per dec-4");
+    // The blip allowance lives in the pure decideNotification function now
+    // (covered in detail by canary-notify-decision.regression.test.ts).
+    expect(NOTIFY_MJS).toContain("decideNotification");
     // Per-env webhook routing in the workflow.
     expect(CANARY_YML).toContain(
       "matrix.env == 'prod' && secrets.SLACK_WEBHOOK_PROD || secrets.SLACK_WEBHOOK_INT",

--- a/scripts/canary/Dockerfile.canary
+++ b/scripts/canary/Dockerfile.canary
@@ -1,0 +1,10 @@
+# spec-243 dec-1: the canary Cloud Run Job image. The probe scripts have ZERO
+# npm dependencies (built-in fetch / crypto / fs only), so the image is a stock
+# node:alpine with just the scripts copied in — no install step, tiny, fast.
+#
+# Built + pushed by scripts/canary/deploy-canary-job.sh. Entrypoint runs both
+# envs once and exits (Cloud Run Job semantics; Cloud Scheduler re-invokes).
+FROM node:22-alpine
+WORKDIR /app
+COPY scripts/canary/ ./scripts/canary/
+ENTRYPOINT ["node", "scripts/canary/run-job.mjs"]

--- a/scripts/canary/deploy-canary-job.sh
+++ b/scripts/canary/deploy-canary-job.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# spec-243 dec-1: provision + deploy the canary as a Cloud Run Job + Cloud
+# Scheduler in the Memex GCP project. Idempotent — safe to re-run; it creates
+# what's missing and updates the Job image otherwise.
+#
+# One execution probes BOTH memex.ai and int.memex.ai (the probes are public
+# HTTPS, so a single Job in one project monitors both). Cloud Scheduler fires
+# it every 10 minutes — a dependable cron, unlike the GitHub Actions schedule
+# this replaces.
+#
+# Prereqts: gcloud auth with rights in the target project; an active PAM grant
+# if the project requires it. Secret VALUES are seeded separately (see the
+# SECRETS section near the end) — this script creates the secret containers and
+# wires them, but never hardcodes a secret.
+#
+# Usage: PROJECT=memex-ai-prod ./scripts/canary/deploy-canary-job.sh
+set -euo pipefail
+
+PROJECT="${PROJECT:-memex-ai-prod}"
+REGION="${REGION:-us-east4}"
+REPO="${PROJECT}"                                   # Artifact Registry repo name 'memex'
+AR="us-east4-docker.pkg.dev/${PROJECT}/memex"
+IMAGE="${AR}/memex-canary:latest"
+JOB="memex-canary"
+SCHED="memex-canary-10min"
+SA="canary-job@${PROJECT}.iam.gserviceaccount.com"
+SCHED_SA="canary-scheduler@${PROJECT}.iam.gserviceaccount.com"
+BUCKET="${PROJECT}-canary-state"
+# AC the hidden emission targets, and the canary Memex (same slug both envs).
+AC_PROD="memex-ops/canary-tests/specs/spec-1/acs/ac-1"
+AC_INT="memex-ops/canary-tests/specs/spec-1/acs/ac-1"
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+echo "▸ project=${PROJECT} region=${REGION}"
+
+# ── Service accounts ────────────────────────────────────────────────────────
+gcloud iam service-accounts describe "$SA" --project "$PROJECT" >/dev/null 2>&1 || \
+  gcloud iam service-accounts create canary-job --project "$PROJECT" \
+    --display-name "spec-243 canary Cloud Run Job"
+gcloud iam service-accounts describe "$SCHED_SA" --project "$PROJECT" >/dev/null 2>&1 || \
+  gcloud iam service-accounts create canary-scheduler --project "$PROJECT" \
+    --display-name "spec-243 canary Cloud Scheduler invoker"
+
+# ── State bucket (consecutive-failure status) ───────────────────────────────
+gcloud storage buckets describe "gs://${BUCKET}" --project "$PROJECT" >/dev/null 2>&1 || \
+  gcloud storage buckets create "gs://${BUCKET}" --project "$PROJECT" \
+    --location "$REGION" --uniform-bucket-level-access
+gcloud storage buckets add-iam-policy-binding "gs://${BUCKET}" --project "$PROJECT" \
+  --member "serviceAccount:${SA}" --role roles/storage.objectAdmin >/dev/null
+
+# ── Secret containers (VALUES seeded separately — see SECRETS section) ───────
+for S in canary-emit-key-prod canary-emit-key-int \
+         canary-mcp-token-prod canary-mcp-token-int \
+         slack-webhook-prod slack-webhook-int; do
+  gcloud secrets describe "$S" --project "$PROJECT" >/dev/null 2>&1 || \
+    gcloud secrets create "$S" --project "$PROJECT" --replication-policy automatic
+  gcloud secrets add-iam-policy-binding "$S" --project "$PROJECT" \
+    --member "serviceAccount:${SA}" --role roles/secretmanager.secretAccessor >/dev/null
+done
+
+# ── Build + push the image ──────────────────────────────────────────────────
+echo "▸ building image ${IMAGE}"
+gcloud builds submit "$REPO_ROOT" --project "$PROJECT" \
+  --config /dev/stdin <<YAML
+steps:
+  - name: gcr.io/cloud-builders/docker
+    args: ['build','-f','scripts/canary/Dockerfile.canary','-t','${IMAGE}','.']
+images: ['${IMAGE}']
+YAML
+
+# ── Cloud Run Job ───────────────────────────────────────────────────────────
+SECRETS="CANARY_EMIT_KEY_PROD=canary-emit-key-prod:latest"
+SECRETS+=",CANARY_EMIT_KEY_INT=canary-emit-key-int:latest"
+SECRETS+=",CANARY_MCP_TOKEN_PROD=canary-mcp-token-prod:latest"
+SECRETS+=",CANARY_MCP_TOKEN_INT=canary-mcp-token-int:latest"
+SECRETS+=",SLACK_WEBHOOK_PROD=slack-webhook-prod:latest"
+SECRETS+=",SLACK_WEBHOOK_INT=slack-webhook-int:latest"
+ENVVARS="CANARY_AC_UID_PROD=${AC_PROD},CANARY_AC_UID_INT=${AC_INT}"
+ENVVARS+=",CANARY_STATE_BUCKET=${BUCKET},CANARY_VERBOSE=${CANARY_VERBOSE:-true}"
+
+JOB_ACTION=update
+gcloud run jobs describe "$JOB" --project "$PROJECT" --region "$REGION" >/dev/null 2>&1 || JOB_ACTION=create
+echo "▸ ${JOB_ACTION} Cloud Run Job ${JOB}"
+gcloud run jobs "$JOB_ACTION" "$JOB" --project "$PROJECT" --region "$REGION" \
+  --image "$IMAGE" \
+  --service-account "$SA" \
+  --max-retries 1 --task-timeout 120s \
+  --set-env-vars "$ENVVARS" \
+  --set-secrets "$SECRETS"
+
+# ── Cloud Scheduler → Job (every 10 min, off-round minutes to dodge load) ────
+gcloud run jobs add-iam-policy-binding "$JOB" --project "$PROJECT" --region "$REGION" \
+  --member "serviceAccount:${SCHED_SA}" --role roles/run.invoker >/dev/null
+RUN_URI="https://${REGION}-run.googleapis.com/apis/run.googleapis.com/v1/namespaces/${PROJECT}/jobs/${JOB}:run"
+SCHED_ACTION=update
+gcloud scheduler jobs describe "$SCHED" --project "$PROJECT" --location "$REGION" >/dev/null 2>&1 || SCHED_ACTION=create
+echo "▸ ${SCHED_ACTION} Cloud Scheduler ${SCHED}"
+gcloud scheduler jobs "$SCHED_ACTION" http "$SCHED" --project "$PROJECT" --location "$REGION" \
+  --schedule "2,12,22,32,42,52 * * * *" \
+  --uri "$RUN_URI" --http-method POST \
+  --oauth-service-account-email "$SCHED_SA"
+
+cat <<NOTE
+
+✅ Infra applied. SECRETS — seed values once (raw secrets never go in this repo):
+   printf '%s' "<value>" | gcloud secrets versions add canary-emit-key-prod  --project ${PROJECT} --data-file=-
+   printf '%s' "<value>" | gcloud secrets versions add canary-emit-key-int   --project ${PROJECT} --data-file=-
+   printf '%s' "<value>" | gcloud secrets versions add canary-mcp-token-prod --project ${PROJECT} --data-file=-
+   printf '%s' "<value>" | gcloud secrets versions add canary-mcp-token-int  --project ${PROJECT} --data-file=-
+   printf '%s' "<value>" | gcloud secrets versions add slack-webhook-prod    --project ${PROJECT} --data-file=-
+   printf '%s' "<value>" | gcloud secrets versions add slack-webhook-int     --project ${PROJECT} --data-file=-
+
+Then fire a manual run:
+   gcloud run jobs execute ${JOB} --project ${PROJECT} --region ${REGION}
+NOTE

--- a/scripts/canary/deploy-canary-job.sh
+++ b/scripts/canary/deploy-canary-job.sh
@@ -53,15 +53,22 @@ gcloud storage buckets add-iam-policy-binding "gs://${BUCKET}" --project "$PROJE
 for S in canary-emit-key-prod canary-emit-key-int \
          canary-mcp-token-prod canary-mcp-token-int \
          slack-webhook-prod slack-webhook-int; do
+  # Org policy (constraints/gcp.resourceLocations) forbids 'global' secrets, so
+  # pin replication to the project region with a user-managed policy.
   gcloud secrets describe "$S" --project "$PROJECT" >/dev/null 2>&1 || \
-    gcloud secrets create "$S" --project "$PROJECT" --replication-policy automatic
+    gcloud secrets create "$S" --project "$PROJECT" \
+      --replication-policy user-managed --locations "$REGION"
   gcloud secrets add-iam-policy-binding "$S" --project "$PROJECT" \
     --member "serviceAccount:${SA}" --role roles/secretmanager.secretAccessor >/dev/null
 done
 
 # ── Build + push the image ──────────────────────────────────────────────────
 echo "▸ building image ${IMAGE}"
-gcloud builds submit "$REPO_ROOT" --project "$PROJECT" \
+# --default-buckets-behavior=regional-user-owned-bucket forces a regional
+# staging bucket — the org policy constraints/gcp.resourceLocations blocks the
+# default multi-region 'us' Cloud Build bucket. Mirrors packages/server/deploy.sh.
+gcloud builds submit "$REPO_ROOT" --project "$PROJECT" --region "$REGION" \
+  --default-buckets-behavior=regional-user-owned-bucket \
   --config /dev/stdin <<YAML
 steps:
   - name: gcr.io/cloud-builders/docker
@@ -90,16 +97,23 @@ gcloud run jobs "$JOB_ACTION" "$JOB" --project "$PROJECT" --region "$REGION" \
   --set-secrets "$SECRETS"
 
 # ── Cloud Scheduler → Job (every 10 min, off-round minutes to dodge load) ────
-gcloud run jobs add-iam-policy-binding "$JOB" --project "$PROJECT" --region "$REGION" \
-  --member "serviceAccount:${SCHED_SA}" --role roles/run.invoker >/dev/null
-RUN_URI="https://${REGION}-run.googleapis.com/apis/run.googleapis.com/v1/namespaces/${PROJECT}/jobs/${JOB}:run"
-SCHED_ACTION=update
-gcloud scheduler jobs describe "$SCHED" --project "$PROJECT" --location "$REGION" >/dev/null 2>&1 || SCHED_ACTION=create
-echo "▸ ${SCHED_ACTION} Cloud Scheduler ${SCHED}"
-gcloud scheduler jobs "$SCHED_ACTION" http "$SCHED" --project "$PROJECT" --location "$REGION" \
-  --schedule "2,12,22,32,42,52 * * * *" \
-  --uri "$RUN_URI" --http-method POST \
-  --oauth-service-account-email "$SCHED_SA"
+# Skippable during first provisioning (SKIP_SCHEDULER=1) so the canary doesn't
+# start firing — and claxoning about half-seeded secrets — before a manual
+# execute has confirmed it green. Create the schedule once secrets are in.
+if [ "${SKIP_SCHEDULER:-0}" != "1" ]; then
+  gcloud run jobs add-iam-policy-binding "$JOB" --project "$PROJECT" --region "$REGION" \
+    --member "serviceAccount:${SCHED_SA}" --role roles/run.invoker >/dev/null
+  RUN_URI="https://${REGION}-run.googleapis.com/apis/run.googleapis.com/v1/namespaces/${PROJECT}/jobs/${JOB}:run"
+  SCHED_ACTION=update
+  gcloud scheduler jobs describe "$SCHED" --project "$PROJECT" --location "$REGION" >/dev/null 2>&1 || SCHED_ACTION=create
+  echo "▸ ${SCHED_ACTION} Cloud Scheduler ${SCHED}"
+  gcloud scheduler jobs "$SCHED_ACTION" http "$SCHED" --project "$PROJECT" --location "$REGION" \
+    --schedule "2,12,22,32,42,52 * * * *" \
+    --uri "$RUN_URI" --http-method POST \
+    --oauth-service-account-email "$SCHED_SA"
+else
+  echo "▸ SKIP_SCHEDULER=1 — scheduler not created (seed secrets + verify a manual execute first)"
+fi
 
 cat <<NOTE
 

--- a/scripts/canary/gcs-state.mjs
+++ b/scripts/canary/gcs-state.mjs
@@ -1,0 +1,72 @@
+// spec-243 dec-4: consecutive-failure state for the Cloud Run runner.
+//
+// Cloud Run has no "previous workflow run" to query, so the last status per env
+// is persisted as a tiny JSON object in GCS. Zero npm deps: we mint an access
+// token from the instance metadata server (the Job's service account) and call
+// the GCS JSON API over plain fetch — keeps the container image a stock
+// node:alpine with no @google-cloud/storage.
+//
+// Object layout: gs://$CANARY_STATE_BUCKET/canary-state/<env>.json → {"status":"green|red"}
+//
+// Fail-soft: any read error returns 'unknown' (treated as consecutive for a red,
+// so we err toward alerting, never toward silent). A write error is logged and
+// swallowed — a missed write only costs a slightly stale prevStatus next run.
+
+const METADATA_TOKEN_URL =
+  "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token";
+
+async function accessToken() {
+  const res = await fetch(METADATA_TOKEN_URL, {
+    headers: { "Metadata-Flavor": "Google" },
+  });
+  if (!res.ok) throw new Error(`metadata token ${res.status}`);
+  return (await res.json()).access_token;
+}
+
+function objectPath(env) {
+  return encodeURIComponent(`canary-state/${env}.json`);
+}
+
+// Returns 'red' | 'green' | 'none' | 'unknown'. 'none' = object doesn't exist
+// yet (first run); 'unknown' = a real error reaching GCS.
+export async function readPrevStatus(bucket, env) {
+  if (!bucket) return "unknown";
+  try {
+    const token = await accessToken();
+    const res = await fetch(
+      `https://storage.googleapis.com/storage/v1/b/${bucket}/o/${objectPath(env)}?alt=media`,
+      { headers: { Authorization: `Bearer ${token}` } },
+    );
+    if (res.status === 404) return "none";
+    if (!res.ok) {
+      console.error(`[canary-state] read ${env} → ${res.status}`);
+      return "unknown";
+    }
+    const body = await res.json();
+    return body.status === "red" || body.status === "green" ? body.status : "unknown";
+  } catch (err) {
+    console.error(`[canary-state] read ${env} failed: ${err}`);
+    return "unknown";
+  }
+}
+
+export async function writeStatus(bucket, env, status) {
+  if (!bucket) return;
+  try {
+    const token = await accessToken();
+    const res = await fetch(
+      `https://storage.googleapis.com/upload/storage/v1/b/${bucket}/o?uploadType=media&name=${objectPath(env)}`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ status }),
+      },
+    );
+    if (!res.ok) console.error(`[canary-state] write ${env} → ${res.status}`);
+  } catch (err) {
+    console.error(`[canary-state] write ${env} failed: ${err}`);
+  }
+}

--- a/scripts/canary/notify.mjs
+++ b/scripts/canary/notify.mjs
@@ -1,43 +1,108 @@
 #!/usr/bin/env node
-// spec-243: canary → Slack notifier. Runs as the workflow's `if: always()`
-// tail step, decides whether THIS run's outcome warrants a message, and posts
-// it to the environment's webhook.
+// spec-243: canary → Slack notifier.
+//
+// The DECISION (whether this run's outcome warrants a message, and which one)
+// is a pure function — `decideNotification` — so it's identical across runners
+// and unit-testable. Two callers feed it a normalized `prevStatus`:
+//   • GitHub Actions path (this file's main): prevStatus from the previous
+//     workflow run's job conclusion via the GitHub API.
+//   • Cloud Run path (run-job.mjs): prevStatus from a GCS state object.
 //
 // Decision table (dec-4: alert on 2 consecutive failures; single blips silent):
-//   this run RED   + previous RED    → claxon
-//   this run RED   + previous GREEN  → silent (the blip allowance)
-//   this run GREEN + previous RED    → all-clear
-//   this run GREEN + previous GREEN  → silent, unless CANARY_VERBOSE=true
+//   this run RED   + prev RED/none/unknown → claxon
+//   this run RED   + prev GREEN            → silent (the blip allowance)
+//   this run GREEN + prev RED              → all-clear
+//   this run GREEN + prev GREEN/none       → silent, unless verbose
 //
-// "Previous" is the same env's job conclusion in the most recent completed
-// run of this workflow — fetched via the GitHub API, so the consecutive rule
-// needs no state store. When no previous run exists (first ever run), a red
-// run alerts immediately: better one early claxon than a silent broken start.
-//
-// Required env: CANARY_ENV (prod|int), PROBE_RESULTS (JSON from probe.mjs),
-// SLACK_WEBHOOK, GITHUB_TOKEN, GITHUB_REPOSITORY, GITHUB_RUN_ID.
-// Optional: CANARY_VERBOSE=true.
+// On the very first run (prev 'none') a red alerts immediately: better one
+// early claxon than a silent broken start.
 
-const env = process.env.CANARY_ENV ?? "unknown";
-const webhook = process.env.SLACK_WEBHOOK;
-const verbose = process.env.CANARY_VERBOSE === "true";
-const repo = process.env.GITHUB_REPOSITORY;
-const runId = process.env.GITHUB_RUN_ID;
-const runUrl = `https://github.com/${repo}/actions/runs/${runId}`;
+export function failureLines(results) {
+  return Object.entries(results)
+    .filter(([, r]) => !r.ok)
+    .map(([name, r]) => `• *${name}*: ${r.detail}${r.body ? `\n  > ${r.body}` : ""}`)
+    .join("\n");
+}
 
-function parseResults() {
+function greenList(results) {
+  return Object.keys(results)
+    .map((name) => `${name} ✓`)
+    .join(", ");
+}
+
+// prevStatus ∈ 'red' | 'green' | 'none' | 'unknown'
+// returns { decision: 'claxon'|'all-clear'|'verbose'|'silent', text: string|null }
+export function decideNotification({ summary, prevStatus, host, verbose, runUrl }) {
+  const logs = runUrl ? ` <${runUrl}|Run log>` : "";
+  if (!summary.ok) {
+    const consecutive =
+      prevStatus === "red" || prevStatus === "none" || prevStatus === "unknown";
+    if (!consecutive) {
+      return { decision: "silent", text: null };
+    }
+    return {
+      decision: "claxon",
+      text:
+        `🚨 *CANARY RED — ${host}* 🚨\n` +
+        `${failureLines(summary.results)}\n` +
+        `Second consecutive failure (previous: ${prevStatus}).${logs}`,
+    };
+  }
+  if (prevStatus === "red") {
+    return {
+      decision: "all-clear",
+      text: `✅ *All clear — ${host}*: canary is green again.${logs}`,
+    };
+  }
+  if (verbose) {
+    return {
+      decision: "verbose",
+      text: `✅ canary green on ${host}: ${greenList(summary.results)}. _(verbose mode — disable CANARY_VERBOSE to silence)_`,
+    };
+  }
+  return { decision: "silent", text: null };
+}
+
+// The status to persist for next time.
+export function statusFromSummary(summary) {
+  return summary.ok ? "green" : "red";
+}
+
+export async function postToSlack(webhook, text) {
+  if (!webhook) {
+    console.error("[canary-notify] SLACK_WEBHOOK not set — cannot deliver:\n" + text);
+    return false;
+  }
+  const res = await fetch(webhook, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ text }),
+  });
+  if (!res.ok) {
+    console.error(`[canary-notify] Slack webhook returned ${res.status}`);
+    return false;
+  }
+  console.error("[canary-notify] posted to Slack");
+  return true;
+}
+
+// ── GitHub Actions path (kept as a manually-dispatchable backup until the
+// Cloud Run runner is proven; see dec-1) ────────────────────────────────────
+
+function parseResults(env) {
   try {
     return JSON.parse(process.env.PROBE_RESULTS ?? "");
   } catch {
-    // The probe step crashing before it could emit results is itself a red
-    // result — report it rather than dying silently.
-    return { env, ok: false, results: { probe_step: { ok: false, detail: "probe step produced no results (crashed or cancelled)", body: "" } } };
+    return {
+      env,
+      ok: false,
+      results: { probe_step: { ok: false, detail: "probe step produced no results (crashed or cancelled)", body: "" } },
+    };
   }
 }
 
-async function previousConclusion() {
-  // Most recent COMPLETED run of this workflow before this one, any trigger
-  // (schedule or manual) — then the conclusion of this env's job within it.
+// Map the previous GitHub job conclusion to a normalized prevStatus.
+async function gitHubPrevStatus(repo, runId, env) {
   const headers = {
     Authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
     Accept: "application/vnd.github+json",
@@ -53,68 +118,34 @@ async function previousConclusion() {
     const jobsRes = await fetch(prev.jobs_url, { headers });
     const jobs = (await jobsRes.json()).jobs ?? [];
     const job = jobs.find((j) => j.name.includes(env));
-    return job?.conclusion ?? "none";
+    if (job?.conclusion === "failure") return "red";
+    if (job?.conclusion === "success") return "green";
+    return "none";
   } catch (err) {
     console.error(`[canary-notify] previous-run lookup failed: ${err}`);
     return "unknown";
   }
 }
 
-function failureLines(results) {
-  return Object.entries(results)
-    .filter(([, r]) => !r.ok)
-    .map(([name, r]) => `• *${name}*: ${r.detail}${r.body ? `\n  > ${r.body}` : ""}`)
-    .join("\n");
-}
-
-async function post(text) {
-  if (!webhook) {
-    console.error("[canary-notify] SLACK_WEBHOOK not set — cannot deliver:");
-    console.error(text);
-    process.exit(1);
-  }
-  const res = await fetch(webhook, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ text }),
-  });
-  if (!res.ok) {
-    console.error(`[canary-notify] Slack webhook returned ${res.status}`);
-    process.exit(1);
-  }
-  console.error("[canary-notify] posted to Slack");
-}
-
 async function main() {
-  const summary = parseResults();
-  const prev = await previousConclusion();
+  const env = process.env.CANARY_ENV ?? "unknown";
+  const repo = process.env.GITHUB_REPOSITORY;
+  const runId = process.env.GITHUB_RUN_ID;
+  const summary = parseResults(env);
+  const prevStatus = await gitHubPrevStatus(repo, runId, env);
   const host = env === "prod" ? "memex.ai" : "int.memex.ai";
 
-  if (!summary.ok) {
-    const isConsecutive = prev === "failure" || prev === "none" || prev === "unknown";
-    if (!isConsecutive) {
-      console.error(`[canary-notify] single failure (previous=${prev}) — staying silent per dec-4`);
-      return;
-    }
-    await post(
-      `🚨 *CANARY RED — ${host}* 🚨\n` +
-        `${failureLines(summary.results)}\n` +
-        `Second consecutive failure (previous run: ${prev}). <${runUrl}|Run log>`,
-    );
-    return;
-  }
-
-  if (prev === "failure") {
-    await post(`✅ *All clear — ${host}*: canary is green again. <${runUrl}|Run log>`);
-    return;
-  }
-
-  if (verbose) {
-    const details = Object.entries(summary.results)
-      .map(([name, r]) => `${name} ✓`)
-      .join(", ");
-    await post(`✅ canary green on ${host}: ${details}. _(verbose mode — flip the CANARY_VERBOSE repo variable off to silence these)_`);
-  }
+  const { decision, text } = decideNotification({
+    summary,
+    prevStatus,
+    host,
+    verbose: process.env.CANARY_VERBOSE === "true",
+    runUrl: `https://github.com/${repo}/actions/runs/${runId}`,
+  });
+  console.error(`[canary-notify] decision=${decision} (prev=${prevStatus})`);
+  if (text) await postToSlack(process.env.SLACK_WEBHOOK, text);
 }
 
-main();
+if (process.argv[1] && process.argv[1].endsWith("notify.mjs")) {
+  main();
+}

--- a/scripts/canary/probe.mjs
+++ b/scripts/canary/probe.mjs
@@ -170,13 +170,11 @@ async function runProbe(name, fn, cfg, env) {
   }
 }
 
-async function main() {
-  const env = process.argv[2];
+// Run all probes for one env and return the summary. Reusable by both the CLI
+// (below) and the Cloud Run Job orchestrator (run-job.mjs).
+export async function runEnvProbes(env) {
   const cfg = ENVS[env];
-  if (!cfg) {
-    console.error(`usage: probe.mjs <${Object.keys(ENVS).join("|")}>`);
-    process.exit(2);
-  }
+  if (!cfg) throw new Error(`unknown env "${env}" (expected ${Object.keys(ENVS).join("|")})`);
 
   const results = {};
   for (const [name, fn] of PROBES) {
@@ -184,9 +182,20 @@ async function main() {
     results[name] = { ok: r.ok, detail: r.detail, body: r.body ?? "" };
     console.error(`[canary:${env}] ${r.ok ? "✅" : "❌"} ${name}: ${r.detail}`);
   }
-
   const allOk = Object.values(results).every((r) => r.ok);
-  const summary = { env, ok: allOk, results };
+  return { env, ok: allOk, results };
+}
+
+export { ENVS };
+
+async function main() {
+  const env = process.argv[2];
+  if (!ENVS[env]) {
+    console.error(`usage: probe.mjs <${Object.keys(ENVS).join("|")}>`);
+    process.exit(2);
+  }
+
+  const summary = await runEnvProbes(env);
   console.log(JSON.stringify(summary));
 
   if (process.env.GITHUB_OUTPUT) {
@@ -194,7 +203,11 @@ async function main() {
     appendFileSync(process.env.GITHUB_OUTPUT, `results=${JSON.stringify(summary)}\n`);
   }
 
-  process.exit(allOk ? 0 : 1);
+  process.exit(summary.ok ? 0 : 1);
 }
 
-main();
+// Only run the CLI when invoked directly, so run-job.mjs can import runEnvProbes
+// without triggering a probe pass + process.exit.
+if (process.argv[1] && process.argv[1].endsWith("probe.mjs")) {
+  main();
+}

--- a/scripts/canary/run-job.mjs
+++ b/scripts/canary/run-job.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+// spec-243 dec-1 (Cloud Run runner): the Cloud Run Job entrypoint. One execution
+// probes BOTH envs over public HTTPS, decides per-env whether to alert (using
+// GCS-persisted consecutive-failure state), posts to Slack, and persists the new
+// status. Triggered every 10 min by Cloud Scheduler.
+//
+// Env (wired by the Job; secrets via Secret Manager):
+//   CANARY_EMIT_KEY_{PROD,INT}, CANARY_MCP_TOKEN_{PROD,INT}   (secrets)
+//   CANARY_AC_UID_{PROD,INT}                                   (config)
+//   SLACK_WEBHOOK_{PROD,INT}                                   (secrets)
+//   CANARY_STATE_BUCKET                                        (GCS bucket for state)
+//   CANARY_VERBOSE = 'true' | unset
+//
+// Exit code reflects overall health (0 = both envs green) for Cloud Run Job
+// execution visibility, but alerting is independent of exit code.
+
+import { runEnvProbes } from "./probe.mjs";
+import { decideNotification, statusFromSummary, postToSlack } from "./notify.mjs";
+import { readPrevStatus, writeStatus } from "./gcs-state.mjs";
+
+const HOSTS = { prod: "memex.ai", int: "int.memex.ai" };
+const WEBHOOK_VAR = { prod: "SLACK_WEBHOOK_PROD", int: "SLACK_WEBHOOK_INT" };
+
+async function handleEnv(env, bucket, verbose) {
+  const summary = await runEnvProbes(env);
+  const prevStatus = await readPrevStatus(bucket, env);
+
+  const { decision, text } = decideNotification({
+    summary,
+    prevStatus,
+    host: HOSTS[env],
+    verbose,
+    runUrl: process.env.CANARY_RUN_URL ?? "",
+  });
+  console.error(`[canary:${env}] decision=${decision} (prev=${prevStatus}, now=${statusFromSummary(summary)})`);
+
+  if (text) await postToSlack(process.env[WEBHOOK_VAR[env]], text);
+  // Persist AFTER deciding, so this run's status is what the next run reads.
+  await writeStatus(bucket, env, statusFromSummary(summary));
+  return summary.ok;
+}
+
+async function main() {
+  const bucket = process.env.CANARY_STATE_BUCKET;
+  const verbose = process.env.CANARY_VERBOSE === "true";
+  if (!bucket) {
+    console.error("[canary] WARNING: CANARY_STATE_BUCKET unset — consecutive-failure tracking degraded to 'unknown' (will alert on every red).");
+  }
+
+  // Probe both envs even if one throws, so a prod problem can't mask int.
+  const results = await Promise.allSettled([
+    handleEnv("prod", bucket, verbose),
+    handleEnv("int", bucket, verbose),
+  ]);
+
+  const allOk = results.every((r) => r.status === "fulfilled" && r.value === true);
+  process.exit(allOk ? 0 : 1);
+}
+
+main();


### PR DESCRIPTION
## Why

The GitHub Actions `schedule` trigger **never fired** — 0 of 6 slots over 67 minutes, workflow active and on the default branch, valid cron, working manual dispatch. GitHub `schedule` is best-effort by design (their docs; recent platform-wide drop reports). For a canary, the reliability of the *trigger* is the product, so we move it to a real scheduler. (spec-243 dec-1, superseded 2026-06-11.)

## What

A **Cloud Run Job + Cloud Scheduler** in `memex-ai-prod` (us-east4). One Job execution probes **both** memex.ai and int.memex.ai over public HTTPS; Cloud Scheduler fires it every 10 min (off-round minutes to dodge top-of-hour load). The Job scales to zero between runs — no min-instances, cost is pennies.

- **probe.mjs / notify.mjs** refactored to extract runner-agnostic pure functions: `runEnvProbes()` and `decideNotification()` (the 2-consecutive-failure decision table from dec-4). Both now unit-tested directly (7 cases).
- **gcs-state.mjs** — consecutive-failure state in a GCS object, replacing the GitHub run-conclusion API. Zero-dep: metadata-server token + GCS REST, so the image stays a stock `node:alpine`.
- **run-job.mjs** — the Job entrypoint: probes both envs (Promise.allSettled so a prod problem can't mask int), per-env GCS state + Slack, exit code reflects health.
- **Dockerfile.canary** — node:22-alpine + scripts only (probes have no npm deps).
- **deploy-canary-job.sh** — idempotent provisioning: service accounts, state bucket + IAM, secret containers + IAM, image build, Cloud Run Job, Cloud Scheduler. Secret *values* are seeded separately (never in the repo).

## Unchanged / deliberately kept

- **deploy-notify.mjs stays in GitHub Actions** — it's deploy-triggered, not scheduled, and is proven working on both envs. Only the *scheduled* canary moves.
- **canary.yml kept** as a manually-dispatchable backup until the Cloud Run path is verified firing on schedule, then it can be retired.

## Accepted tradeoff (ac-3, rewritten)

The canary now runs **in** the Memex GCP project, sharing a failure domain with what it monitors. Conscious call: a `memex-ai-prod`-down state dwarfs a canary-down one, and the property that actually failed (a dependable trigger) is now fixed.

## Test plan

- [x] `canary-notify-decision.regression.test.ts` — the pure decision table, 7 cases (RED+prevRED→claxon, blip allowance, first-run, unknown-state, all-clear, verbose, status persistence), tagged spec-243 ac-2
- [x] `canary-wiring` + `deploy-notify` suites updated/green — 21 tests total
- [x] `run-job.mjs` local smoke: both envs probed, correct claxon decision, no crashes, GCS write safely skipped without a bucket
- [ ] Post-merge: run `deploy-canary-job.sh` against memex-ai-prod, seed secret values, `gcloud run jobs execute`, confirm scheduled firing + both channels

## Follow-ups (spec-243 issues)

issue-1 dead-man's switch (Cloud Scheduler failure → Cloud Monitoring alert is now a natural home) · issue-2 journey probe · issue-3 canary-bot identity.