### PR TITLE
fix(guide-refresh): grant id-token write — WIF auth was impossible in both corpus-refresh workflows

### DIFF
--- a/.github/workflows/guide-content-mindset-website-refresh.yml
+++ b/.github/workflows/guide-content-mindset-website-refresh.yml
@@ -36,6 +36,10 @@ concurrency:
   group: guide-content-mindset-website-refresh-${{ github.event.client_payload.env || inputs.env || 'prod' }}
   cancel-in-progress: false
 
+permissions:
+  contents: read
+  id-token: write # OIDC token for Workload Identity Federation
+
 jobs:
   refresh:
     runs-on: ubuntu-latest

--- a/.github/workflows/guide-content-website-refresh.yml
+++ b/.github/workflows/guide-content-website-refresh.yml
@@ -33,6 +33,13 @@ concurrency:
   group: guide-content-website-refresh-${{ github.event.client_payload.env || inputs.env || 'prod' }}
   cancel-in-progress: false
 
+# Without id-token: write the WIF auth step CANNOT mint an OIDC token and the
+# job fails at "Authenticate to GCP" (found 2026-06-11 by spec-251's first live
+# dispatch — this workflow had never actually run since spec-222 t-13 shipped it).
+permissions:
+  contents: read
+  id-token: write # OIDC token for Workload Identity Federation
+
 jobs:
   refresh:
     runs-on: ubuntu-latest

--- a/packages/server/src/__regression__/spec-251-mindset-website-surface.regression.test.ts
+++ b/packages/server/src/__regression__/spec-251-mindset-website-surface.regression.test.ts
@@ -75,6 +75,18 @@ describe("guide-content-mindset-website-refresh.yml (spec-251 t-5, dec-1)", () =
     // the public endpoint (the only /guide/v1 mention is the explanatory comment).
     expect(wf).not.toMatch(/curl[^\n]*\/guide\/v1/);
   });
+
+  it("BOTH refresh workflows grant id-token: write — WIF cannot mint an OIDC token without it", () => {
+    tagAc(AC7);
+    // Found by spec-251's first live dispatch: the spec-222 workflow shipped
+    // without a permissions block and had never run; every WIF auth failed.
+    for (const path of [MINDSET_WF, MEMEX_WF]) {
+      const wf = read(path);
+      expect(wf, `${path} must grant id-token: write for WIF`).toMatch(
+        /permissions:\s*\n\s*contents: read\s*\n\s*id-token: write/,
+      );
+    }
+  });
 });
 
 describe("the memex-website refresh path is untouched (spec-251 dec-1 → ac-9)", () => {


### PR DESCRIPTION
## What

spec-251's first live `workflow_dispatch` of the new mindset-website corpus refresh ([run 27345701646](https://github.com/mindset-ai/memex-ai/actions/runs/27345701646)) failed at **Authenticate to GCP**: GitHub never injects `$ACTIONS_ID_TOKEN_REQUEST_TOKEN`/`URL` unless the workflow grants `id-token: write`.

The surprise: the spec-222 `guide-content-website-refresh.yml` shipped without a permissions block and **has never run** (zero run history — the memex-website deploy-side dispatch has not fired yet), so the defect sat latent and the spec-251 sibling cloned it faithfully. The first real execution found it.

- Both refresh workflows now carry the same `permissions: { contents: read, id-token: write }` block `deploy.yml` uses
- The spec-251 regression suite pins the block in **both** files so it can't regress

## Verification

- `pnpm vitest run spec-251-mindset-website-surface` — 9 passed (new pin included)
- Post-merge: re-dispatch `guide-content mindset-website refresh` with `env=int` to complete the initial ingest (will do)

🤖 Generated with [Claude Code](https://claude.com/claude-code)