### PR TITLE
feat(pulse): test signals as a live volume monitor, not Event-Log noise

### DIFF
--- a/packages/server/src/routes/analytics.integration.test.ts
+++ b/packages/server/src/routes/analytics.integration.test.ts
@@ -351,3 +351,55 @@ describe("GET /analytics/acs-over-time and /analytics/test-run-volume", () => {
     expect(vol.find((p) => p.day === "2026-06-03")).toMatchObject({ pass: 1, fail: 0, error: 0 });
   });
 });
+
+describe("GET /analytics/test-signal-pulse", () => {
+  it("returns gapless minute buckets + window totals for recent test emissions", async () => {
+    const m = await makeTestMemexWithDevAdmin("analyt-pulse");
+    memexIds.push(m.memexId);
+    const path = `/api/${m.slug}/main`;
+
+    const prefix = `${m.slug}/main/specs/spec-pulse/acs`;
+    // Emit a handful of recent events (default createdAt = now()), so they land
+    // in the current minute bucket of the rolling window.
+    const emitNow = (acN: number, status: string, hidden = false) =>
+      db.insert(testEvents).values({
+        acUid: `${prefix}/ac-${acN}`,
+        status,
+        testIdentifier: `t-${acN}`,
+        hidden,
+      });
+    await emitNow(1, "pass");
+    await emitNow(1, "pass");
+    await emitNow(2, "fail");
+    await emitNow(3, "error");
+    await emitNow(4, "pass", true); // hidden pass — still counts as volume
+
+    const res = await app.request(`${path}/analytics/test-signal-pulse?windowMinutes=15`, withApexHost());
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      windowMinutes: number;
+      buckets: Array<{ at: string; pass: number; fail: number; error: number }>;
+      totals: { pass: number; fail: number; error: number; total: number };
+    };
+    expect(body.windowMinutes).toBe(15);
+    expect(body.buckets).toHaveLength(15); // gapless, one per minute
+    // Totals across the window: 3 pass (2 visible + 1 hidden), 1 fail, 1 error.
+    expect(body.totals).toEqual({ pass: 3, fail: 1, error: 1, total: 5 });
+    // The window sum of bucket columns matches the totals (no row dropped).
+    const summed = body.buckets.reduce(
+      (a, b) => ({ pass: a.pass + b.pass, fail: a.fail + b.fail, error: a.error + b.error }),
+      { pass: 0, fail: 0, error: 0 },
+    );
+    expect(summed).toEqual({ pass: 3, fail: 1, error: 1 });
+  });
+
+  it("rejects a non-positive-integer windowMinutes with 400", async () => {
+    const m = await makeTestMemexWithDevAdmin("analyt-pulse-bad");
+    memexIds.push(m.memexId);
+    const res = await app.request(
+      `/api/${m.slug}/main/analytics/test-signal-pulse?windowMinutes=0`,
+      withApexHost(),
+    );
+    expect(res.status).toBe(400);
+  });
+});

--- a/packages/server/src/routes/analytics.ts
+++ b/packages/server/src/routes/analytics.ts
@@ -15,6 +15,7 @@ import {
   acVerification,
   acsOverTime,
   testRunVolume,
+  testSignalPulse,
 } from "../services/analytics.js";
 import { standardsGraph, DEFAULT_SEMANTIC_THRESHOLD } from "../services/standards-graph.js";
 import { ValidationError } from "../types/errors.js";
@@ -83,6 +84,23 @@ analytics.get("/acs-over-time", async (c) => {
 analytics.get("/test-run-volume", async (c) => {
   const memexId = await resolveReadableMemexId(c);
   return c.json({ points: await testRunVolume(memexId) });
+});
+
+// GET /analytics/test-signal-pulse?windowMinutes=60 — minute-bucketed test
+// emission volume over a short rolling window, for the Pulse test-signal
+// monitor. The live SSE test_event stream increments on top of this baseline.
+analytics.get("/test-signal-pulse", async (c) => {
+  const memexId = await resolveReadableMemexId(c);
+  const raw = c.req.query("windowMinutes");
+  let windowMinutes: number | undefined;
+  if (raw !== undefined) {
+    const n = Number(raw);
+    if (!Number.isFinite(n) || !Number.isInteger(n) || n <= 0) {
+      throw new ValidationError("Query param 'windowMinutes' must be a positive integer");
+    }
+    windowMinutes = n;
+  }
+  return c.json(await testSignalPulse(memexId, { windowMinutes }));
 });
 
 // GET /analytics/standards-graph — nodes + mention edges (clause_refs joins,

--- a/packages/server/src/routes/test-events.ts
+++ b/packages/server/src/routes/test-events.ts
@@ -290,6 +290,15 @@ testEventsRouter.post("/", async (c) => {
       memexId: targetMemexId,
       entity: TEST_EVENT_ENTITY,
       action: "created",
+      // Carry the outcome on the event so the Pulse test-signal volume monitor
+      // can colour the live tick (pass/fail/error) and surface failures in real
+      // time. test_event is NOT persisted to activity_log (it's the firehose),
+      // so this payload only ever rides the live SSE frame.
+      payload: {
+        status: insertValues.status,
+        acUid: insertValues.acUid,
+        hidden: insertValues.hidden,
+      },
     },
     // spec-162 dec-1: append the log row AND upsert the test_event_latest
     // summary in one transaction so the two can't diverge on a crash. The

--- a/packages/server/src/services/activity-log.test.ts
+++ b/packages/server/src/services/activity-log.test.ts
@@ -188,6 +188,23 @@ describe("persistEvent — real Postgres write", () => {
     expect(rows[0].actorKind).toBe("system");
   });
 
+  it("does NOT persist a test_event — the CI firehose is kept out of the timeline", async () => {
+    // test_event is emitted on the bus (live consumers wake) but never written
+    // to activity_log: it's high-volume telemetry whose system of record is the
+    // test_events table. Excluding it keeps the Pulse Event Log readable.
+    const row = await persistEvent(
+      baseEvent({
+        entity: "test_event",
+        action: "created",
+        channel: "server",
+        payload: { status: "pass", acUid: "ns/mx/specs/spec-1/acs/ac-1" },
+      }),
+    );
+    expect(row).toBeNull();
+    const rows = await db.select().from(activityLog).where(eq(activityLog.memexId, memexId));
+    expect(rows, "a test_event must write no activity_log row").toHaveLength(0);
+  });
+
   it("skips (writes no row, does not throw) when memexId is blank", async () => {
     const row = await persistEvent({ ...baseEvent(), memexId: "" });
     expect(row).toBeNull();

--- a/packages/server/src/services/activity-log.ts
+++ b/packages/server/src/services/activity-log.ts
@@ -144,6 +144,21 @@ function hasPersistableScope(event: ChangeEvent): boolean {
   return typeof event.memexId === "string" && event.memexId.length > 0;
 }
 
+// Entities whose bus events are deliberately NOT persisted to the activity_log
+// timeline. `test_event` is a high-volume CI telemetry firehose (one event per
+// AC per test run — thousands/day) whose system of record is already the
+// `test_events` table (+ test_event_latest summary). Mirroring it into the
+// human-readable activity_log floods the Pulse Event Log with unreadable line
+// noise and bloats the table for no benefit. The bus emission is KEPT (live SSE
+// subscribers — AC-health chips, and the Pulse "test signals" volume monitor —
+// still wake on it); only the durable activity_log row is suppressed. Test
+// signals surface in Pulse as an aggregate volume graphic, not per-line.
+// (Per-spec test outcomes still reach the agent's `── ACTIVITY ──` footer via
+// the activity_view's dedicated test_events arm, which reads the source table.)
+const NON_TIMELINE_ENTITIES: ReadonlySet<ChangeEvent["entity"]> = new Set([
+  "test_event",
+]);
+
 /**
  * Persist one event. Advisory: any failure is logged and swallowed so the
  * originating emitter is never affected. Returns the inserted row (or null when
@@ -154,6 +169,9 @@ export async function persistEvent(
   conn: Db = db,
 ): Promise<ActivityLog | null> {
   if (!hasPersistableScope(event)) return null;
+  // High-volume telemetry (test_event) is emitted on the bus for live consumers
+  // but never written to the activity_log timeline (see NON_TIMELINE_ENTITIES).
+  if (NON_TIMELINE_ENTITIES.has(event.entity)) return null;
   // ac-21 — surface a missing channel as a visible defect BEFORE the persist
   // step coerces it (the row is still written; the defect is no longer silent).
   flagAttributionDefect(event);

--- a/packages/server/src/services/analytics.ts
+++ b/packages/server/src/services/analytics.ts
@@ -449,3 +449,96 @@ export async function testRunVolume(memexId: string): Promise<TestRunVolumePoint
   `)) as unknown as TestRunVolumePoint[];
   return rows;
 }
+
+// ── Test-signal pulse (Pulse test-signal monitor) ────────────────────────────
+
+/** One minute-bucket of test-emission volume, split by outcome. */
+export interface TestSignalBucket {
+  /** ISO-8601 UTC start of the minute bucket (e.g. "2026-06-11T12:03:00Z"). */
+  at: string;
+  pass: number;
+  fail: number;
+  error: number;
+}
+
+export interface TestSignalPulse {
+  /** The rolling window, in minutes, the buckets cover (ending now). */
+  windowMinutes: number;
+  /** Gapless minute buckets, oldest→newest, exactly `windowMinutes` of them. */
+  buckets: TestSignalBucket[];
+  /** Window totals, for the headline counter + green%. */
+  totals: { pass: number; fail: number; error: number; total: number };
+}
+
+const PULSE_DEFAULT_WINDOW_MIN = 60;
+const PULSE_MAX_WINDOW_MIN = 240;
+
+/**
+ * "Are test signals flowing right now?" — minute-bucketed emission volume over a
+ * short rolling window, split pass/fail/error, prefix-scoped to this memex's
+ * ac_uids (the memex is encoded in every ac_uid; no test_events.memex_id column
+ * needed). Powers the Pulse test-signal monitor's historical baseline; the live
+ * SSE `test_event.created` stream increments the current bucket on top of this.
+ *
+ * Hidden emissions COUNT toward volume (they're real runs) — mirrors
+ * `testRunVolume`. The window is gapless (every minute present, zero-filled) so
+ * the sparkline has a stable x-axis. Capped at PULSE_MAX_WINDOW_MIN.
+ */
+export async function testSignalPulse(
+  memexId: string,
+  opts: { windowMinutes?: number } = {},
+): Promise<TestSignalPulse> {
+  const windowMinutes = Math.max(
+    1,
+    Math.min(PULSE_MAX_WINDOW_MIN, Math.floor(opts.windowMinutes ?? PULSE_DEFAULT_WINDOW_MIN)),
+  );
+
+  const [slugs] = (await db.execute(sql`
+    SELECT n.slug AS ns, m.slug AS mx
+    FROM memexes m JOIN namespaces n ON n.id = m.namespace_id
+    WHERE m.id = ${memexId}
+  `)) as unknown as Array<{ ns: string; mx: string }>;
+  if (!slugs) {
+    return { windowMinutes, buckets: [], totals: { pass: 0, fail: 0, error: 0, total: 0 } };
+  }
+  const prefix = `${slugs.ns}/${slugs.mx}/`;
+
+  const buckets = (await db.execute(sql`
+    WITH per_bucket AS (
+      SELECT date_trunc('minute', created_at) AS bucket, status, count(*)::int AS n
+      FROM test_events
+      WHERE ac_uid LIKE ${prefix + "%"}
+        AND created_at >= now() - make_interval(mins => ${windowMinutes})
+      GROUP BY 1, 2
+    ),
+    grid AS (
+      SELECT generate_series(
+        date_trunc('minute', now()) - make_interval(mins => ${windowMinutes - 1}),
+        date_trunc('minute', now()),
+        interval '1 minute'
+      ) AS bucket
+    )
+    SELECT
+      to_char(grid.bucket AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"') AS at,
+      COALESCE(sum(per_bucket.n) FILTER (WHERE per_bucket.status = 'pass'), 0)::int AS pass,
+      COALESCE(sum(per_bucket.n) FILTER (WHERE per_bucket.status = 'fail'), 0)::int AS fail,
+      COALESCE(sum(per_bucket.n) FILTER (WHERE per_bucket.status = 'error'), 0)::int AS error
+    FROM grid
+    LEFT JOIN per_bucket ON per_bucket.bucket = grid.bucket
+    GROUP BY grid.bucket
+    ORDER BY grid.bucket
+  `)) as unknown as TestSignalBucket[];
+
+  const totals = buckets.reduce(
+    (acc, b) => {
+      acc.pass += b.pass;
+      acc.fail += b.fail;
+      acc.error += b.error;
+      acc.total += b.pass + b.fail + b.error;
+      return acc;
+    },
+    { pass: 0, fail: 0, error: 0, total: 0 },
+  );
+
+  return { windowMinutes, buckets, totals };
+}

--- a/packages/server/src/services/bus.ts
+++ b/packages/server/src/services/bus.ts
@@ -45,6 +45,13 @@ export type ChangeEntity =
   // invocation fallback when no more specific entity applies.
   | "query"
   | "tool_call"
+  // CI test telemetry (spec-115/spec-162). A `test_event` created event fires on
+  // every accepted POST /api/test-events so live consumers (AC-health chips, the
+  // Pulse test-signal volume monitor) wake instantly. Memex-scoped (memexId set,
+  // no docId). Deliberately NOT persisted to activity_log — it's a high-volume
+  // firehose whose system of record is the test_events table (see
+  // services/activity-log.ts NON_TIMELINE_ENTITIES).
+  | "test_event"
   // Wave 3 — non-doc tenancy resources; `docId` is undefined for these
   | "org"
   | "org_membership"

--- a/packages/ui/src/components/pulse/TestSignalCounter.tsx
+++ b/packages/ui/src/components/pulse/TestSignalCounter.tsx
@@ -1,0 +1,48 @@
+// TestSignalCounter — the compact test-signal summary that sits in the
+// Working-now zone (spec). A one-line live counter of verification traffic: the
+// window total plus a "+N" badge that climbs as fresh SSE signals land between
+// baseline refetches, then resets. It's the heartbeat that says "tests are
+// flowing right now" next to who's working; the full sparkline lives in the
+// right-column TestSignalsMonitor.
+
+import { LiveDot } from './LiveDot';
+
+export interface TestSignalCounterProps {
+  /** Window total of test emissions (baseline + live). */
+  total: number;
+  /** Window length in minutes, for the label. */
+  windowMinutes: number;
+  /** fail + error across the window — surfaced inline when non-zero. */
+  failing: number;
+  /** Fresh live signals since the last baseline refetch — the "+N new" climb. */
+  liveDelta: number;
+}
+
+export function TestSignalCounter({ total, windowMinutes, failing, liveDelta }: TestSignalCounterProps) {
+  return (
+    <div
+      data-testid="test-signal-counter"
+      className="flex-none flex items-center gap-2 mb-4 rounded-lg border border-edge-subtle bg-surface/40 px-3 py-2 text-xs"
+    >
+      <LiveDot live={liveDelta > 0} size="sm" className="text-status-success-text" />
+      <span className="font-medium text-primary">Test signals</span>
+      <span className="opacity-40">&middot;</span>
+      <span className="tabular-nums text-secondary">
+        {total.toLocaleString()} in last {windowMinutes}m
+      </span>
+      {liveDelta > 0 && (
+        <span
+          data-testid="test-signal-delta"
+          className="inline-flex items-center rounded bg-status-success-text/10 px-1.5 py-0.5 font-semibold text-status-success-text tabular-nums animate-pulse-arrive"
+        >
+          +{liveDelta.toLocaleString()} new
+        </span>
+      )}
+      {failing > 0 && (
+        <span className="ml-auto inline-flex items-center gap-1 font-semibold text-status-danger-text tabular-nums">
+          ⚠ {failing.toLocaleString()} failing
+        </span>
+      )}
+    </div>
+  );
+}

--- a/packages/ui/src/components/pulse/TestSignalsMonitor.tsx
+++ b/packages/ui/src/components/pulse/TestSignalsMonitor.tsx
@@ -1,0 +1,128 @@
+// TestSignalsMonitor — the right-column "test signals" graphic (spec).
+//
+// Test emissions are a high-volume CI firehose (thousands/day) that used to
+// flood the Event Log with unreadable per-run lines. They no longer land in the
+// activity timeline at all; instead they surface HERE as an aggregate: a live
+// minute-bucketed volume sparkline over the last hour, split pass/fail/error,
+// with a headline rate + a loud failing callout. It gives the board a sense of
+// real verification activity happening without the line noise.
+//
+// PRESENTATIONAL. The merged baseline+live view arrives via props; the Pulse
+// page owns the hook + the live SSE buffer.
+
+import { LiveDot } from './LiveDot';
+import { useChartPalette } from '../insights/theme';
+import type { MergedTestSignals } from './testSignals';
+
+export interface TestSignalsMonitorProps {
+  signals: MergedTestSignals;
+  /** True until the first baseline fetch resolves. */
+  loading?: boolean;
+  /** A signal arrived very recently → breathe the live dot + pulse the last bar. */
+  live?: boolean;
+}
+
+const SPARK_HEIGHT = 44; // px — the bar track height.
+
+export function TestSignalsMonitor({ signals, loading = false, live = false }: TestSignalsMonitorProps) {
+  const palette = useChartPalette();
+  const { buckets, totals, failing, greenPct, ratePerMin, peak, windowMinutes } = signals;
+  const hasData = totals.total > 0;
+  const lastIdx = buckets.length - 1;
+
+  return (
+    <section
+      data-testid="test-signals-monitor"
+      className="flex-none rounded-lg border border-edge-subtle bg-surface/40 overflow-hidden mb-4"
+    >
+      {/* Header. */}
+      <div className="flex items-center gap-2 px-3 py-2 text-xs text-secondary border-b border-edge-subtle">
+        <LiveDot live={live && hasData} size="sm" className="text-status-success-text" />
+        <span className="font-medium text-primary">Test signals</span>
+        <span className="opacity-40">&middot;</span>
+        <span className="tabular-nums">~{Math.round(ratePerMin)}/min</span>
+        {failing > 0 ? (
+          <span
+            data-testid="test-signals-failing"
+            className="ml-auto inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[0.7rem] font-semibold text-status-danger-text bg-status-danger-text/10"
+          >
+            ⚠ {failing.toLocaleString()} failing
+          </span>
+        ) : hasData ? (
+          <span className="ml-auto text-[0.7rem] text-status-success-text tabular-nums">
+            {greenPct}% green
+          </span>
+        ) : null}
+      </div>
+
+      {/* Sparkline. */}
+      <div className="px-3 pt-3 pb-2">
+        {loading && !hasData ? (
+          <div
+            className="animate-pulse rounded bg-card-hover"
+            style={{ height: SPARK_HEIGHT }}
+            data-testid="test-signals-skeleton"
+          />
+        ) : !hasData ? (
+          <div
+            className="flex items-center justify-center text-xs text-muted"
+            style={{ height: SPARK_HEIGHT }}
+            data-testid="test-signals-empty"
+          >
+            No test signals in the last {windowMinutes} minutes.
+          </div>
+        ) : (
+          <div
+            className="flex items-end gap-px"
+            style={{ height: SPARK_HEIGHT }}
+            role="img"
+            aria-label={`${totals.total} test emissions over the last ${windowMinutes} minutes, ${greenPct}% passing`}
+          >
+            {buckets.map((b, i) => {
+              const total = b.pass + b.fail + b.error;
+              const h = peak > 0 ? Math.max(total === 0 ? 0 : 2, (total / peak) * SPARK_HEIGHT) : 0;
+              const seg = (n: number) => (total > 0 ? (n / total) * h : 0);
+              const isLast = i === lastIdx;
+              return (
+                <div
+                  key={b.at}
+                  className={`flex-1 flex flex-col justify-end ${isLast && live ? 'animate-pulse' : ''}`}
+                  style={{ minWidth: 1 }}
+                  title={`${new Date(b.at).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })} · ${b.pass}✓ ${b.fail}✗ ${b.error}!`}
+                >
+                  {/* Stack: errors (amber) + fails (rose) grounded at the base, passes (emerald) above. */}
+                  {b.pass > 0 && (
+                    <span style={{ height: seg(b.pass), background: palette.testRun.pass, borderTopLeftRadius: 1, borderTopRightRadius: 1 }} />
+                  )}
+                  {b.fail > 0 && <span style={{ height: seg(b.fail), background: palette.testRun.fail }} />}
+                  {b.error > 0 && <span style={{ height: seg(b.error), background: palette.testRun.error }} />}
+                  {total === 0 && <span style={{ height: 1 }} className="bg-edge-subtle/40" />}
+                </div>
+              );
+            })}
+          </div>
+        )}
+
+        {/* Footer legend / totals. */}
+        {hasData && (
+          <div className="mt-2 flex items-center gap-3 text-[0.7rem] text-muted tabular-nums">
+            <span className="inline-flex items-center gap-1">
+              <Swatch color={palette.testRun.pass} /> {totals.pass.toLocaleString()}
+            </span>
+            <span className="inline-flex items-center gap-1">
+              <Swatch color={palette.testRun.fail} /> {totals.fail.toLocaleString()}
+            </span>
+            <span className="inline-flex items-center gap-1">
+              <Swatch color={palette.testRun.error} /> {totals.error.toLocaleString()}
+            </span>
+            <span className="ml-auto">{totals.total.toLocaleString()} in {windowMinutes}m</span>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function Swatch({ color }: { color: string }) {
+  return <span className="inline-block h-2 w-2 rounded-sm" style={{ background: color }} />;
+}

--- a/packages/ui/src/components/pulse/testSignals.test.ts
+++ b/packages/ui/src/components/pulse/testSignals.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { mergeTestSignals, type TestSignalPulseDto, type LiveTestSignal } from './testSignals';
+
+function dto(over: Partial<TestSignalPulseDto> = {}): TestSignalPulseDto {
+  return {
+    windowMinutes: 3,
+    buckets: [
+      { at: '2026-06-11T12:00:00Z', pass: 1, fail: 0, error: 0 },
+      { at: '2026-06-11T12:01:00Z', pass: 0, fail: 0, error: 0 },
+      { at: '2026-06-11T12:02:00Z', pass: 2, fail: 1, error: 0 },
+    ],
+    totals: { pass: 3, fail: 1, error: 0, total: 4 },
+    ...over,
+  };
+}
+
+describe('mergeTestSignals', () => {
+  it('returns a safe empty view for a null baseline', () => {
+    const m = mergeTestSignals(null, []);
+    expect(m.buckets).toEqual([]);
+    expect(m.totals).toEqual({ pass: 0, fail: 0, error: 0, total: 0 });
+    expect(m.greenPct).toBe(100); // empty window reads as green, not 0%
+    expect(m.ratePerMin).toBe(0);
+    expect(m.failing).toBe(0);
+  });
+
+  it('passes the baseline through untouched when there are no live signals', () => {
+    const m = mergeTestSignals(dto(), []);
+    expect(m.totals).toEqual({ pass: 3, fail: 1, error: 0, total: 4 });
+    expect(m.failing).toBe(1);
+    expect(m.greenPct).toBe(75); // 3 of 4
+    expect(m.peak).toBe(3); // the 12:02 bucket (2 pass + 1 fail)
+  });
+
+  it('folds a live signal into its own minute bucket', () => {
+    const live: LiveTestSignal[] = [
+      { at: '2026-06-11T12:02:30Z', status: 'fail' }, // same minute as the last bucket
+    ];
+    const m = mergeTestSignals(dto(), live);
+    const last = m.buckets[m.buckets.length - 1];
+    expect(last.at).toBe('2026-06-11T12:02:00Z');
+    expect(last.fail).toBe(2); // 1 baseline + 1 live
+    expect(m.totals).toEqual({ pass: 3, fail: 2, error: 0, total: 5 });
+    expect(m.failing).toBe(2);
+  });
+
+  it('extends the window when a live signal rolls into a new minute, dropping the stalest bucket', () => {
+    const live: LiveTestSignal[] = [{ at: '2026-06-11T12:03:10Z', status: 'pass' }];
+    const m = mergeTestSignals(dto(), live);
+    // Width stays 3 (windowMinutes); the 12:00 bucket falls off the front.
+    expect(m.buckets).toHaveLength(3);
+    expect(m.buckets[0].at).toBe('2026-06-11T12:01:00Z');
+    expect(m.buckets[m.buckets.length - 1].at).toBe('2026-06-11T12:03:00Z');
+    // 12:00's single pass is dropped from totals; the new pass is added.
+    expect(m.totals).toEqual({ pass: 3, fail: 1, error: 0, total: 4 });
+  });
+
+  it('ignores live signals older than the baseline window (already covered)', () => {
+    const live: LiveTestSignal[] = [{ at: '2026-06-11T11:59:00Z', status: 'error' }];
+    const m = mergeTestSignals(dto(), live);
+    expect(m.totals).toEqual({ pass: 3, fail: 1, error: 0, total: 4 });
+    expect(m.buckets).toHaveLength(3);
+  });
+});

--- a/packages/ui/src/components/pulse/testSignals.ts
+++ b/packages/ui/src/components/pulse/testSignals.ts
@@ -1,0 +1,131 @@
+// Shared shapes + merge logic for the Pulse test-signal monitor (spec — test
+// signals as a volume graphic, not Event-Log line noise).
+//
+// The server's GET /analytics/test-signal-pulse returns a gapless minute-bucketed
+// baseline; the live SSE `test_event.created` stream tops it up between refetches.
+// Both the right-column monitor and the Working-now counter render off the SAME
+// merged view, so the merge lives here once.
+
+/** One minute-bucket of test-emission volume, split by outcome. Mirrors the server. */
+export interface TestSignalBucket {
+  /** ISO-8601 UTC start of the minute bucket. */
+  at: string;
+  pass: number;
+  fail: number;
+  error: number;
+}
+
+/** The server payload from GET /analytics/test-signal-pulse. */
+export interface TestSignalPulseDto {
+  windowMinutes: number;
+  buckets: TestSignalBucket[];
+  totals: { pass: number; fail: number; error: number; total: number };
+}
+
+/** A live test-event, as distilled from an SSE `test_event` ChangeEvent. */
+export interface LiveTestSignal {
+  /** Event time (ISO). For live frames this is ~now. */
+  at: string;
+  status: 'pass' | 'fail' | 'error';
+}
+
+/** The merged, render-ready view the components consume. */
+export interface MergedTestSignals {
+  windowMinutes: number;
+  /** Gapless minute buckets, oldest→newest, baseline + live folded in. */
+  buckets: TestSignalBucket[];
+  totals: { pass: number; fail: number; error: number; total: number };
+  /** fail + error across the window — the "needs a look" number. */
+  failing: number;
+  /** Whole-percent of non-failing emissions (100 when the window is empty). */
+  greenPct: number;
+  /** Mean emissions per minute across the window. */
+  ratePerMin: number;
+  /** The tallest bucket's total — for normalising bar heights. */
+  peak: number;
+}
+
+const EMPTY: TestSignalPulseDto = {
+  windowMinutes: 60,
+  buckets: [],
+  totals: { pass: 0, fail: 0, error: 0, total: 0 },
+};
+
+/** Truncate an ISO timestamp to its minute bucket key (matches the server's date_trunc). */
+function minuteKey(iso: string): string {
+  // "2026-06-11T12:03:47.123Z" → "2026-06-11T12:03:00Z"
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  d.setUTCSeconds(0, 0);
+  return d.toISOString().replace('.000Z', 'Z');
+}
+
+/**
+ * Fold the live SSE signals onto the server baseline. A live signal lands in its
+ * own minute bucket: an existing baseline bucket is incremented in place; a
+ * newer minute (rolled over since the fetch) extends the tail and an equal count
+ * of stale leading buckets is dropped so the window stays `windowMinutes` wide.
+ *
+ * Live events OLDER than the baseline's first bucket are ignored (the baseline
+ * already covers that span, and counting them would double up after a refetch).
+ */
+export function mergeTestSignals(
+  pulse: TestSignalPulseDto | null,
+  live: readonly LiveTestSignal[],
+): MergedTestSignals {
+  const base = pulse ?? EMPTY;
+  // Clone buckets so we never mutate the fetched payload.
+  const byKey = new Map<string, TestSignalBucket>();
+  const order: string[] = [];
+  for (const b of base.buckets) {
+    const copy = { ...b };
+    byKey.set(b.at, copy);
+    order.push(b.at);
+  }
+  const firstKey = order[0];
+
+  for (const ev of live) {
+    const key = minuteKey(ev.at);
+    // Ignore events the baseline already spans (before its first bucket).
+    if (firstKey && key < firstKey) continue;
+    let bucket = byKey.get(key);
+    if (!bucket) {
+      bucket = { at: key, pass: 0, fail: 0, error: 0 };
+      byKey.set(key, bucket);
+      order.push(key);
+    }
+    bucket[ev.status] += 1;
+  }
+
+  // Re-sort (new tail keys may be out of order) and clamp to the window width.
+  order.sort();
+  const width = base.windowMinutes || order.length;
+  const trimmed = order.slice(Math.max(0, order.length - width));
+  const buckets = trimmed.map((k) => byKey.get(k)!);
+
+  const totals = buckets.reduce(
+    (a, b) => {
+      a.pass += b.pass;
+      a.fail += b.fail;
+      a.error += b.error;
+      a.total += b.pass + b.fail + b.error;
+      return a;
+    },
+    { pass: 0, fail: 0, error: 0, total: 0 },
+  );
+
+  const failing = totals.fail + totals.error;
+  const greenPct = totals.total === 0 ? 100 : Math.round((totals.pass / totals.total) * 100);
+  const ratePerMin = buckets.length === 0 ? 0 : totals.total / buckets.length;
+  const peak = buckets.reduce((m, b) => Math.max(m, b.pass + b.fail + b.error), 0);
+
+  return {
+    windowMinutes: base.windowMinutes,
+    buckets,
+    totals,
+    failing,
+    greenPct,
+    ratePerMin,
+    peak,
+  };
+}

--- a/packages/ui/src/hooks/useTestSignalPulse.ts
+++ b/packages/ui/src/hooks/useTestSignalPulse.ts
@@ -1,0 +1,70 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { tenantBase, fetchWithRetry } from '../api/http';
+import type { TestSignalPulseDto } from '../components/pulse/testSignals';
+
+/**
+ * useTestSignalPulse — the historical baseline for the Pulse test-signal monitor.
+ *
+ * Fetches `GET /api/<ns>/<mx>/analytics/test-signal-pulse?windowMinutes=N` — a
+ * gapless minute-bucketed count of test emissions over the last N minutes, split
+ * pass/fail/error. The Pulse page tops this up live from the SSE `test_event`
+ * stream (mergeTestSignals); this hook owns ONLY the periodic baseline refetch
+ * that corrects drift and absorbs the live buffer.
+ *
+ * `fetchedAt` bumps on every successful refetch — the page watches it to clear
+ * its accumulated live buffer so a signal already folded into the new baseline
+ * isn't also counted live (no double-count).
+ */
+
+const REFRESH_INTERVAL_MS = 45_000;
+
+export interface UseTestSignalPulseResult {
+  pulse: TestSignalPulseDto | null;
+  loading: boolean;
+  error: string | null;
+  /** Monotonic marker (ms) of the latest successful fetch; changes → live buffer should reset. */
+  fetchedAt: number;
+  /** Force a baseline refetch (e.g. on SSE reconnect). */
+  refresh: () => Promise<void>;
+}
+
+export function useTestSignalPulse(windowMinutes = 60): UseTestSignalPulseResult {
+  const [pulse, setPulse] = useState<TestSignalPulseDto | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [fetchedAt, setFetchedAt] = useState(0);
+
+  // Only the latest request may write state (guards overlapping refetches).
+  const reqToken = useRef(0);
+
+  const refresh = useCallback(async () => {
+    const myReq = ++reqToken.current;
+    setError(null);
+    try {
+      const base = tenantBase();
+      if (!base) throw new Error('Test signals require tenant context.');
+      const res = await fetchWithRetry(
+        `${base}/analytics/test-signal-pulse?windowMinutes=${windowMinutes}`,
+      );
+      if (!res.ok) throw new Error(`Failed to load test signals (${res.status})`);
+      const dto = (await res.json()) as TestSignalPulseDto;
+      if (myReq !== reqToken.current) return; // superseded
+      setPulse(dto);
+      setFetchedAt(Date.now());
+    } catch (err) {
+      if (myReq !== reqToken.current) return;
+      setError(err instanceof Error ? err.message : 'Failed to load test signals');
+    } finally {
+      if (myReq === reqToken.current) setLoading(false);
+    }
+  }, [windowMinutes]);
+
+  // Initial fetch + periodic drift correction.
+  useEffect(() => {
+    void refresh();
+    const id = setInterval(() => void refresh(), REFRESH_INTERVAL_MS);
+    return () => clearInterval(id);
+  }, [refresh]);
+
+  return { pulse, loading, error, fetchedAt, refresh };
+}

--- a/packages/ui/src/pages/Pulse.test.tsx
+++ b/packages/ui/src/pages/Pulse.test.tsx
@@ -38,6 +38,13 @@ vi.mock('../hooks/usePresence', () => ({
   usePresence: (refs: unknown) => usePresenceMock(refs),
 }));
 
+// useTestSignalPulse: the test-signal monitor's baseline fetch. Stub it empty so
+// the monitor renders its "no signals" state and no real fetch fires.
+const useTestSignalPulseMock = vi.hoisted(() => vi.fn());
+vi.mock('../hooks/useTestSignalPulse', () => ({
+  useTestSignalPulse: (windowMinutes?: number) => useTestSignalPulseMock(windowMinutes),
+}));
+
 // The spec list the picker reads.
 const fetchDocsMock = vi.hoisted(() => vi.fn());
 vi.mock('../api/client', () => ({
@@ -176,12 +183,20 @@ beforeEach(() => {
   usePresenceMock.mockReset();
   fetchDocsMock.mockReset();
   useNeedsAttentionMock.mockReset();
+  useTestSignalPulseMock.mockReset();
 
   usePulseStreamMock.mockReturnValue({ latest: null, status: 'connected' });
   useNeedsAttentionMock.mockReturnValue(EMPTY_ATTENTION);
   usePresenceMock.mockReturnValue({ rows: [], loading: false });
   fetchDocsMock.mockResolvedValue([]);
   usePulseHistoryMock.mockReturnValue(history());
+  useTestSignalPulseMock.mockReturnValue({
+    pulse: null,
+    loading: false,
+    error: null,
+    fetchedAt: 0,
+    refresh: vi.fn(),
+  });
 });
 
 describe('Pulse page', () => {
@@ -205,24 +220,24 @@ describe('Pulse page', () => {
     expect(await screen.findByTestId('pulse-empty')).toBeInTheDocument();
   });
 
-  describe('ScopeToggle (dec-7)', () => {
-    it('defaults to "me" and pins the history filter to the current user', async () => {
+  describe('ScopeToggle', () => {
+    it('defaults to "everyone" and applies no actor filter', async () => {
       renderPulse();
 
-      // 'me' segment is selected by default.
-      const me = screen.getByRole('radio', { name: 'Just me' });
-      expect(me).toHaveAttribute('aria-checked', 'true');
+      // 'Everyone' segment is selected by default — the board is a shared view.
+      const everyone = screen.getByRole('radio', { name: 'Everyone' });
+      expect(everyone).toHaveAttribute('aria-checked', 'true');
 
-      // Under 'me', usePulseHistory is called with actorUserId = current user.
+      // Default scope applies no actorUserId filter (the whole Memex's activity).
       await waitFor(() => {
         const calls = usePulseHistoryMock.mock.calls;
         const last = calls[calls.length - 1][0] as { actorUserId?: string };
-        expect(last.actorUserId).toBe(CURRENT_USER);
+        expect(last.actorUserId).toBeUndefined();
       });
     });
 
-    it('clears the actorUserId filter when toggled to "everyone"', async () => {
-      // Seed a client-chip-eligible row so we can also assert chips disappear.
+    it('toggling to "me" pins the actor filter + shows client chips; back to "everyone" clears them', async () => {
+      // Seed a client-chip-eligible row so we can assert chips appear/disappear.
       usePulseHistoryMock.mockReturnValue(
         history({
           rows: [
@@ -238,24 +253,26 @@ describe('Pulse page', () => {
 
       renderPulse();
 
-      // The active-client chip is visible under 'me'.
-      expect(
-        await screen.findByRole('button', { name: /MCP/i }),
-      ).toBeInTheDocument();
+      // Default 'everyone' → no client chips.
+      expect(screen.queryByRole('button', { name: /MCP/i })).toBeNull();
 
+      // Toggle to 'me' → actorUserId pins to the current user and the chip shows.
+      await userEvent.click(screen.getByRole('radio', { name: 'Just me' }));
+      await waitFor(() => {
+        const calls = usePulseHistoryMock.mock.calls;
+        const last = calls[calls.length - 1][0] as { actorUserId?: string };
+        expect(last.actorUserId).toBe(CURRENT_USER);
+      });
+      expect(await screen.findByRole('button', { name: /MCP/i })).toBeInTheDocument();
+
+      // Back to 'everyone' → filter lifts and chips hide again.
       await userEvent.click(screen.getByRole('radio', { name: 'Everyone' }));
-
-      // actorUserId lifts to undefined under 'everyone'.
       await waitFor(() => {
         const calls = usePulseHistoryMock.mock.calls;
         const last = calls[calls.length - 1][0] as { actorUserId?: string };
         expect(last.actorUserId).toBeUndefined();
       });
-
-      // Client chips are hidden outside 'me'.
-      expect(
-        screen.queryByRole('button', { name: /MCP/i }),
-      ).toBeNull();
+      expect(screen.queryByRole('button', { name: /MCP/i })).toBeNull();
     });
   });
 
@@ -302,6 +319,9 @@ describe('Pulse page', () => {
       );
 
       renderPulse();
+
+      // Client chips render under 'me' scope only — switch to it first.
+      await userEvent.click(screen.getByRole('radio', { name: 'Just me' }));
 
       const chip = await screen.findByRole('button', { name: /MCP/i });
       expect(chip).toHaveAttribute('aria-pressed', 'false');

--- a/packages/ui/src/pages/Pulse.tsx
+++ b/packages/ui/src/pages/Pulse.tsx
@@ -205,10 +205,14 @@ export function Pulse() {
     // test_event is the CI firehose — route it to the signal monitor, never the
     // feed. It carries its outcome on payload.status (server emit).
     if (row.entity === 'test_event') {
-      const status = row.payload?.status;
-      if (status === 'pass' || status === 'fail' || status === 'error') {
+      const raw = row.payload?.status;
+      // Explicitly typed (not relying on flow-narrowing surviving into the
+      // setState closure — the production tsc widens it back to string).
+      const status: LiveTestSignal['status'] | null =
+        raw === 'pass' || raw === 'fail' || raw === 'error' ? raw : null;
+      if (status) {
         setLiveTestSignals((prev) => {
-          const next = [...prev, { at: row.createdAt, status }];
+          const next: LiveTestSignal[] = [...prev, { at: row.createdAt, status }];
           return next.length > TEST_SIGNAL_BUFFER_CAP ? next.slice(-TEST_SIGNAL_BUFFER_CAP) : next;
         });
       }

--- a/packages/ui/src/pages/Pulse.tsx
+++ b/packages/ui/src/pages/Pulse.tsx
@@ -39,6 +39,10 @@ import { clientLabel } from '../components/pulse/clientLabel';
 import { usePulseHistory } from '../hooks/usePulseHistory';
 import { usePulseStream } from '../hooks/usePulseStream';
 import { usePresence } from '../hooks/usePresence';
+import { useTestSignalPulse } from '../hooks/useTestSignalPulse';
+import { TestSignalsMonitor } from '../components/pulse/TestSignalsMonitor';
+import { TestSignalCounter } from '../components/pulse/TestSignalCounter';
+import { mergeTestSignals, type LiveTestSignal } from '../components/pulse/testSignals';
 import { isStateChanging } from '../components/pulse/types';
 import type { ActivityRow, PulseConnectionStatus } from '../components/pulse/types';
 
@@ -63,6 +67,9 @@ const CLIENT_LIVE_WINDOW_MS = 30 * 1000; // 30 seconds
 // unbounded. The feed only ever needs the most recent live rows; older ones
 // have long since been superseded by paged-in history.
 const LIVE_BUFFER_CAP = 200;
+// Live test-signal buffer cap — the firehose can be busy; we only need enough to
+// bridge the ~45s between baseline refetches. Older ones have been folded in.
+const TEST_SIGNAL_BUFFER_CAP = 1000;
 const ONE_HOUR_MS = 60 * 60 * 1000;
 
 function rowMs(row: ActivityRow): number {
@@ -82,8 +89,10 @@ export function Pulse() {
     return m?.memexName ?? m?.name ?? null;
   }, [session, namespace, memex]);
 
-  // ── Scope (dec-7): default 'me'. ────────────────────────────────────────────
-  const [scope, setScope] = useState<PulseScope>('me');
+  // ── Scope: default 'everyone'. The board is a shared situational picture —
+  // you want the whole Memex's activity first, then narrow to 'me' on demand
+  // (dec-7's 'me' default read as too narrow for a glance-at-the-board surface).
+  const [scope, setScope] = useState<PulseScope>('everyone');
 
   // ── Per-Spec filter (dec-9), reflected through `?spec=spec-N`. ───────────────
   const [searchParams, setSearchParams] = useSearchParams();
@@ -187,14 +196,56 @@ export function Pulse() {
   const selectedSpecIdRef = useRef<string | null>(null);
   selectedSpecIdRef.current = selectedSpec?.id ?? null;
 
+  // Live test-emission signals, distilled from the SSE `test_event` firehose.
+  // These NEVER enter the event-log feed (they're aggregate telemetry); they
+  // feed the test-signal monitor + counter only.
+  const [liveTestSignals, setLiveTestSignals] = useState<LiveTestSignal[]>([]);
+
   const handleRow = useCallback((row: ActivityRow) => {
+    // test_event is the CI firehose — route it to the signal monitor, never the
+    // feed. It carries its outcome on payload.status (server emit).
+    if (row.entity === 'test_event') {
+      const status = row.payload?.status;
+      if (status === 'pass' || status === 'fail' || status === 'error') {
+        setLiveTestSignals((prev) => {
+          const next = [...prev, { at: row.createdAt, status }];
+          return next.length > TEST_SIGNAL_BUFFER_CAP ? next.slice(-TEST_SIGNAL_BUFFER_CAP) : next;
+        });
+      }
+      return;
+    }
     setLiveRows((prev) => {
       const next = [row, ...prev];
       return next.length > LIVE_BUFFER_CAP ? next.slice(0, LIVE_BUFFER_CAP) : next;
     });
   }, []);
 
-  const { status } = usePulseStream({ onRow: handleRow, onReconnect: refresh });
+  // ── Test-signal monitor (right column) + counter (working-now). Baseline from
+  // the analytics endpoint; live SSE frames top it up between refetches. ────────
+  const {
+    pulse: testSignalPulse,
+    loading: testSignalsLoading,
+    fetchedAt: testSignalsFetchedAt,
+    refresh: refreshTestSignals,
+  } = useTestSignalPulse(60);
+  // Every successful baseline refetch already includes the signals we buffered
+  // live, so drop the buffer to avoid double-counting them (the "+N new" resets).
+  useEffect(() => {
+    setLiveTestSignals([]);
+  }, [testSignalsFetchedAt]);
+  const mergedTestSignals = useMemo(
+    () => mergeTestSignals(testSignalPulse, liveTestSignals),
+    [testSignalPulse, liveTestSignals],
+  );
+
+  // On SSE reconnect, refetch BOTH the activity history and the test-signal
+  // baseline so any gap during the outage converges.
+  const handleReconnect = useCallback(() => {
+    void refresh();
+    void refreshTestSignals();
+  }, [refresh, refreshTestSignals]);
+
+  const { status } = usePulseStream({ onRow: handleRow, onReconnect: handleReconnect });
 
   // Filter the accumulated live rows by the active scope/spec/client. Live rows
   // carry the same fields as history rows (changeEventToRow normalises them), so
@@ -264,8 +315,11 @@ export function Pulse() {
   // ── "What's moving" zone (ac-1): state-changing rows ONLY. The read actions
   // (viewed/searched/assessed/called) are the ambient firehose — a manager
   // glancing at the board shouldn't wade through them. ─────────────────────────
+  // test_event is routed to the signal monitor, never the feed — but historical
+  // test_event rows persisted BEFORE the sink stopped writing them still live in
+  // activity_log, so filter them out here too until they age off the window.
   const movingRows = useMemo(
-    () => mergedRows.filter((r) => isStateChanging(r)),
+    () => mergedRows.filter((r) => r.entity !== 'test_event' && isStateChanging(r)),
     [mergedRows],
   );
 
@@ -367,6 +421,13 @@ export function Pulse() {
           column; the Needs-attention tray keeps its place on the right. */}
       <div className="flex-1 min-h-0 grid grid-cols-1 lg:grid-cols-3 gap-6">
         <div className="lg:col-span-2 min-h-0 flex flex-col">
+          {/* Live test-signal heartbeat next to who's working. */}
+          <TestSignalCounter
+            total={mergedTestSignals.totals.total}
+            windowMinutes={mergedTestSignals.windowMinutes}
+            failing={mergedTestSignals.failing}
+            liveDelta={liveTestSignals.length}
+          />
           <WorkingNow
             present={displayedPresent}
             loading={presenceLoading}
@@ -390,6 +451,14 @@ export function Pulse() {
           </div>
         </div>
         <div className="lg:col-span-1 min-h-0 overflow-y-auto">
+          {/* Test-signal volume graphic — the firehose as a live sparkline,
+              sitting ABOVE the needs-attention tray so the column reads
+              "real-time pulse → things to look at". */}
+          <TestSignalsMonitor
+            signals={mergedTestSignals}
+            loading={testSignalsLoading}
+            live={liveTestSignals.length > 0}
+          />
           <NeedsAttentionTray briefId={selectedSpec?.id} />
         </div>
       </div>


### PR DESCRIPTION
## Problem

After Pulse went live, the Event Log was **flooded with thousands of per-test CI emissions** — every `test_event.created` was persisted to `activity_log` and rendered as a line (the `isStateChanging` filter treats `created` as "moving"). Unreadable for a human, and bloating the table.

## Reframe

The Event Log should be the **human-readable "what changed" timeline**. The per-test firehose is **telemetry** — high-volume, low individual meaning — so it belongs in an **aggregate visual**, not line-by-line. The `test_events` table is already the durable system of record, so nothing is lost by keeping it out of `activity_log`.

## Layout
```
┌──────────────────────────────────┬─────────────────────────┐
│ Test signals · 1,204 in 60m  +3◀ │ ⚡ Test signals ~42/min │ ← right col,
│ WORKING NOW                       │ ▁▂▅▇▆▃▂▅█▆  97% green    │   above tray
│ ● Barrie · spec-55 · 2m ago       │ ⚠ 31 failing            │
├──────────────────────────────────┼─────────────────────────┤
│ ··· EVENT LOG ··· (no test spam)  │ NEEDS ATTENTION         │
│ promoted Barrie to editor spec-55 │ • decisions / questions │
│ spec-55 verify → done (tests)     │ • drift / blocked       │
└──────────────────────────────────┴─────────────────────────┘
```

## Changes

**Server**
- Activity-log sink no longer persists `test_event` (`NON_TIMELINE_ENTITIES`). The **bus emission is kept** — AC-health chips and the new monitor still wake live; only the durable row is suppressed. Adds `test_event` to the `ChangeEntity` union.
- `test_event.created` now carries `payload {status, acUid, hidden}` so live SSE frames colour the monitor in real time.
- New `testSignalPulse()` aggregate + `GET /analytics/test-signal-pulse?windowMinutes=60` — gapless minute-bucketed emission volume, memex-scoped via the `ac_uid` prefix (**no schema change** — the memex is encoded in every `ac_uid`, same pattern as the existing `testRunVolume`).

**UI**
- Pulse scope now defaults to **`everyone`** (shared board first; `me` on demand).
- Live `test_event` frames are split out of the feed into a signal buffer; stale pre-existing `test_event` rows are filtered from the feed too.
- **TestSignalsMonitor** (right column, above the tray): live sparkline of emission volume, std-27 `testRun` palette, headline rate + a loud **failing** callout (failures surface here now, since a failing run advances no phase and so left no feed row).
- **TestSignalCounter** in Working-now: a live **"+N new"** counter that climbs as signals land.
- `mergeTestSignals` folds the live buffer onto the server baseline (clears on refetch → no double-count); shared by both components.

## What stays in the feed
Test-driven **phase moves** remain — those are `document.status_changed` rows (e.g. *"spec-55 verify → done (test event for ac-3)"*), low-volume and meaningful. The *outcome* stays in the log; the *firehose* moves to the graphic. (Per-spec test outcomes also still reach the agent's `── ACTIVITY ──` footer via the activity_view's `test_events` arm.)

## Tests
- bus + activity-log: `test_event` emitted but **not persisted**.
- analytics: `test-signal-pulse` gapless buckets + window totals + 400 on bad param.
- `mergeTestSignals` unit (fold/rollover/ignore-stale).
- Pulse page: `everyone` default + scope-toggle round-trip.
- All green; `tsc` clean both packages; no new dependencies (hand-rolled sparkline). No e2e journey asserts Pulse internals/scope.

## Note on existing data
This stops **new** test_event rows from entering `activity_log`. Historical ones (and the [relay-triplicates from #133](https://github.com/mindset-ai/memex-ai/pull/133)) remain until they age off the window — the feed filters `test_event` out client-side in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)