### PR TITLE
fix(deploy): spec-244 — wire MIXPANEL_TOKEN into Cloud Run runtime

### DIFF
--- a/packages/server/deploy.sh
+++ b/packages/server/deploy.sh
@@ -91,6 +91,26 @@ else
   echo "  ⚠ elevenlabs-api-key not found — voice guide disabled (spec-190)"
   HAS_ELEVENLABS=0
 fi
+# MIXPANEL_TOKEN is optional (spec-244 analytics forwarder, dec-2/dec-9). Wired ONLY
+# if the secret exists, so a deploy never breaks before it's provisioned — the
+# forwarder simply stays in capture-only mode (events land in usage_events and are
+# queryable in SQL; nothing forwards) until the secret lands. Same two-step
+# provisioning as ELEVENLABS above (NO further code change): create the per-env
+# secret AND grant the Cloud Run runtime SA read access. The per-env separation
+# (dec-9) is the VALUE — the int secret holds the memex-int Mixpanel project token,
+# prod holds memex-prod's — so int events never reach the prod project.
+#   printf %s "<project-token>" | gcloud secrets create memex-mixpanel-token --data-file=- \
+#     --project "${GCP_PROJECT}" --replication-policy=user-managed --locations=us-east4
+#   gcloud secrets add-iam-policy-binding memex-mixpanel-token --project "${GCP_PROJECT}" \
+#     --member="serviceAccount:<cloud-run-runtime-SA>" \
+#     --role="roles/secretmanager.secretAccessor"
+if gcloud secrets describe memex-mixpanel-token --project "${GCP_PROJECT}" >/dev/null 2>&1; then
+  echo "  ✓ memex-mixpanel-token present — analytics forwarder enabled"
+  HAS_MIXPANEL=1
+else
+  echo "  ⚠ memex-mixpanel-token not found — analytics forwarder in capture-only mode (spec-244)"
+  HAS_MIXPANEL=0
+fi
 
 # ── KMS prerequisite ─────────────────────────────────────────
 # The Slack token encryption path (services/slack/crypto.ts) requires a
@@ -285,6 +305,9 @@ if [ "$HAS_COHERE" = "1" ]; then
 fi
 if [ "$HAS_ELEVENLABS" = "1" ]; then
   SECRETS_WIRING+=",ELEVENLABS_API_KEY=elevenlabs-api-key:latest"
+fi
+if [ "$HAS_MIXPANEL" = "1" ]; then
+  SECRETS_WIRING+=",MIXPANEL_TOKEN=memex-mixpanel-token:latest"
 fi
 
 # HIDDEN_FEATURES is appended to --update-env-vars ONLY when it is set (see

--- a/scripts/deploy.env.example
+++ b/scripts/deploy.env.example
@@ -55,13 +55,13 @@ SLACK_CLIENT_ID="your-slack-client-id"
 # See docs/feature-hiding.md for the runbook.
 # HIDDEN_FEATURES="scaffold,spec-pause,pulse"
 
-# spec-244 (dec-2 / dec-9) — Mixpanel project token for the usage-events forwarder.
-# OPTIONAL and the second rollout step: while UNSET, capture still works and events
-# are queryable in SQL, but nothing is forwarded (the forwarder logs "capture-only"
-# and idles). Set it to turn the analytics egress ON.
-#
-# PER-ENV SEPARATION (dec-9): the VALUE differs by environment so int never soils
-# prod — the int deploy-env carries the `memex-int` Mixpanel project token, the prod
-# deploy-env carries `memex-prod`'s. Same code, different token. The forwarder also
-# stamps a server-derived env property on every event as a second guard.
-# MIXPANEL_TOKEN="$(gcloud secrets versions access latest --secret=memex-mixpanel-token --project="${GCP_PROJECT}")"
+# spec-244 (dec-2 / dec-9) — the Mixpanel analytics forwarder token is NOT a
+# deploy-env var. Like every other credential (anthropic/openai/postmark/…), it is
+# wired into the Cloud Run service from Secret Manager via packages/server/deploy.sh
+# (--update-secrets MIXPANEL_TOKEN=memex-mixpanel-token:latest), gated on the secret
+# existing — so an env without it deploys fine and the forwarder stays capture-only.
+# Per-env separation (dec-9) is the secret's VALUE: each environment's
+# memex-mixpanel-token secret holds THAT environment's own Mixpanel project token,
+# so staging events never reach the production project. To turn it on in an env:
+# create the per-env secret + grant the Cloud Run runtime SA read access (see the
+# ELEVENLABS / MIXPANEL provisioning notes in deploy.sh) — no deploy-env change.


### PR DESCRIPTION
## Why
PR #137 shipped the telemetry forwarder, but it never forwarded on int despite the `memex-mixpanel-token` secret existing. Root cause: `packages/server/deploy.sh` injects a **curated** secrets list into Cloud Run via `--update-secrets`, and `MIXPANEL_TOKEN` wasn't in it — so the runtime never saw the token and the forwarder stayed in capture-only mode.

## Change
- `deploy.sh`: add `MIXPANEL_TOKEN=memex-mixpanel-token:latest` to `SECRETS_WIRING`, gated on the secret existing (mirrors the optional ELEVENLABS / Cohere pattern) — an env without the secret deploys fine and stays capture-only.
- `deploy.env.example`: correct the docs — the token is **not** a deploy-env var; it's wired from Secret Manager via `--update-secrets`, with per-env separation (dec-9) carried by the secret's value.

## Provisioning (the two-step pattern, like elevenlabs)
1. Create the per-env `memex-mixpanel-token` secret — **done** (int + prod).
2. Grant the Cloud Run runtime SA `secretAccessor` on it — **done for int** (`…-compute@…`); prod (`memex-api-runtime@memex-ai-prod`) granted at prod cut.

Once merged → int auto-deploys → forwarder flips on → events forward to the int Mixpanel project within ~30s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)