### PR TITLE
feat(guide): SPA-host fixes from the mindset.ai embed — tool-turn integrity, screen-keyed website corpus, navigate-by-name

### DIFF
--- a/packages/guide-sdk/src/bundle/engine.tsx
+++ b/packages/guide-sdk/src/bundle/engine.tsx
@@ -95,6 +95,10 @@ export async function mountEngine({
       return {
         screenKey,
         screenRegistry: adapter.elementsForScreen?.(screenKey) ?? [],
+        // The complete site map (key + title + description per page) — sent
+        // every turn so the model knows definitively what pages exist and
+        // where it can navigate, instead of relying on retrieval.
+        screens: adapter.allScreens?.() ?? [],
         // The static site is not tenant-scoped; surface identifies the host.
         namespace: config.surface,
         memex: '',

--- a/packages/guide-sdk/src/guideGraph.ts
+++ b/packages/guide-sdk/src/guideGraph.ts
@@ -14,7 +14,11 @@
 
 import { Annotation, StateGraph, MemorySaver } from '@langchain/langgraph';
 import type { RunnableConfig } from '@langchain/core/runnables';
-import { callGuideLlmProxy, type GuideScreenElement } from './guideLlmClient';
+import {
+  callGuideLlmProxy,
+  type GuideScreenElement,
+  type GuideScreenSummary,
+} from './guideLlmClient';
 import type { MessageParam, ContentBlock, ToolUseBlock } from './agent-types';
 
 /** Tools the guide executes CLIENT-side (React performs them): highlight a
@@ -45,6 +49,12 @@ export const GuideState = Annotation.Root({
     reducer: (_, update) => update,
     default: () => [],
   }),
+  /** The host's complete navigable-screen list (site map). Static per session;
+   *  sent every turn so the model knows what pages exist. */
+  screens: Annotation<GuideScreenSummary[]>({
+    reducer: (_, update) => update,
+    default: () => [],
+  }),
   /** Current screen's pre-fetched guide-content chunks (dec-6). Replaced on change. */
   guideContext: Annotation<string[]>({
     reducer: (_, update) => update,
@@ -56,8 +66,12 @@ export type GuideStateType = typeof GuideState.State;
 
 export interface GuideCallbacks {
   onTextDelta?: (text: string) => void;
-  /** A client-executed UI tool the React layer must perform (highlight/navigate). */
-  onUiTool?: (toolName: string, toolId: string, input: Record<string, unknown>) => void;
+  /** A client-executed UI tool the React layer must perform (highlight/navigate).
+   *  The return value (e.g. a NavigateOutcome) is serialized into the tool_result
+   *  so the model knows whether the action actually happened — a bare 'executed'
+   *  let it believe a navigation failed when the (stale) screen context still
+   *  named the old screen. */
+  onUiTool?: (toolName: string, toolId: string, input: Record<string, unknown>) => unknown;
   onToolResult?: (toolId: string, result: string) => void;
   onAssistantTurnComplete?: (content: ContentBlock[]) => void;
 }
@@ -68,6 +82,10 @@ export interface GuideConfig {
 }
 
 export interface GuideGraphDeps {
+  /** Live screen-context reader. After a client tool runs (navigate changes the
+   *  route mid-turn), the post-tool LLM call must carry the NEW screen's key and
+   *  elements — re-read here rather than trusting the turn-start snapshot. */
+  getScreenContext?: () => { screenKey: string | null; screenRegistry: GuideScreenElement[] };
   /** Server-tool executor (search_guide). Injected so the graph is testable and
    *  so t-5/t-6 can wire the real implementation without touching the graph. */
   executeServerTool?: (
@@ -99,6 +117,7 @@ async function guideAgentNode(
       // about the screen the user is actually on.
       screenKey: state.screenKey,
       screenRegistry: state.screenRegistry,
+      screens: state.screens,
       guideContext: state.guideContext,
     },
     signal,
@@ -129,18 +148,34 @@ async function guideToolsNode(
   state: GuideStateType,
   config: RunnableConfig,
   executeServerTool: NonNullable<GuideGraphDeps['executeServerTool']>,
+  getScreenContext?: GuideGraphDeps['getScreenContext'],
 ): Promise<Partial<GuideStateType>> {
   const { callbacks, signal } = (config.configurable ?? {}) as GuideConfig;
   const last = state.messages[state.messages.length - 1];
   const toolBlocks = getToolUseBlocks(last);
   const results: ContentBlock[] = [];
+  let clientToolRan = false;
 
   for (const block of toolBlocks) {
     if (GUIDE_CLIENT_TOOLS.has(block.name)) {
-      // highlight / navigate — React performs it (dec-4, t-5). The graph records
-      // it executed and the loop continues so the guide can keep talking.
-      callbacks?.onUiTool?.(block.name, block.id, block.input);
-      results.push({ type: 'tool_result', tool_use_id: block.id, content: 'executed' });
+      // highlight / navigate — React performs it (dec-4, t-5). The dispatch
+      // outcome (e.g. navigate's { ok, path }) goes into the tool_result so the
+      // model knows the action's real result; the loop continues so the guide
+      // can keep talking.
+      clientToolRan = true;
+      let outcome: unknown;
+      try {
+        outcome = callbacks?.onUiTool?.(block.name, block.id, block.input);
+      } catch {
+        outcome = { ok: false, reason: 'tool dispatch threw' };
+      }
+      const content =
+        typeof outcome === 'string'
+          ? outcome
+          : outcome !== undefined
+            ? JSON.stringify(outcome)
+            : 'executed';
+      results.push({ type: 'tool_result', tool_use_id: block.id, content });
       continue;
     }
     // search_guide — server tool (dec-6, t-6).
@@ -160,6 +195,19 @@ async function guideToolsNode(
     }
   }
 
+  // A client tool may have changed the screen (navigate soft-navs an SPA host
+  // mid-turn). Refresh the screen state so the post-tool LLM call carries the
+  // NEW screen's key + elements instead of the turn-start snapshot — otherwise
+  // the injected context contradicts the tool_result and the model concludes
+  // the navigation never happened.
+  if (clientToolRan && getScreenContext) {
+    const fresh = getScreenContext();
+    return {
+      messages: [{ role: 'user' as const, content: results }],
+      screenKey: fresh.screenKey,
+      screenRegistry: fresh.screenRegistry,
+    };
+  }
   return { messages: [{ role: 'user' as const, content: results }] };
 }
 
@@ -174,7 +222,7 @@ export function createGuideGraph(deps: GuideGraphDeps = {}) {
   return new StateGraph(GuideState)
     .addNode('guideAgent', guideAgentNode)
     .addNode('tools', (s: GuideStateType, c: RunnableConfig) =>
-      guideToolsNode(s, c, executeServerTool),
+      guideToolsNode(s, c, executeServerTool, deps.getScreenContext),
     )
     .addEdge('__start__', 'guideAgent')
     .addConditionalEdges('guideAgent', shouldContinue, {

--- a/packages/guide-sdk/src/guideLlmClient.ts
+++ b/packages/guide-sdk/src/guideLlmClient.ts
@@ -16,6 +16,9 @@
 // behaviour is preserved app-side.
 import { getGuideBackend, DEFAULT_CHAT_PATH } from './backend';
 import type { MessageParam, LlmProxyEvent } from './agent-types';
+import type { GuideScreenSummary } from './navigation/NavigationAdapter';
+
+export type { GuideScreenSummary } from './navigation/NavigationAdapter';
 
 /** A highlightable element on the current screen (subset of the dec-3 registry;
  *  t-4 provides the canonical type in @memex/shared). */
@@ -30,6 +33,11 @@ export interface GuideLlmInput {
   screenKey: string | null;
   /** The current screen's highlightable elements (dec-3). */
   screenRegistry: GuideScreenElement[];
+  /** The COMPLETE navigable-screen list (site map) when the host's adapter
+   *  supplies allScreens() — the server renders it into the turn context so the
+   *  model knows definitively what pages exist and where it can navigate,
+   *  instead of relying on retrieval to discover the site's shape. */
+  screens?: GuideScreenSummary[];
   /** Pre-fetched guide-content chunks for the current screen (dec-6, t-6). */
   guideContext: string[];
 }

--- a/packages/guide-sdk/src/guideTools.ts
+++ b/packages/guide-sdk/src/guideTools.ts
@@ -11,26 +11,69 @@ import { findGuideElement } from './guideElements';
 import type { NavigationAdapter, NavigateOutcome } from './navigation/NavigationAdapter';
 
 const HIGHLIGHT_CLASS = 'guide-highlight';
-const DEFAULT_HIGHLIGHT_MS = 2500;
+const PULSE_MS = 1000;
+const PULSE_COUNT = 3;
+/** High-contrast violet, visible on light and dark hosts alike. */
+const HIGHLIGHT_RGB = '124, 58, 237';
+
+/**
+ * The highlight visual must be SELF-SUFFICIENT: the highlighted node lives in
+ * the HOST light DOM, where the engine's shadow-root CSS cannot reach, and
+ * host sites ship no `.guide-highlight` rule — a class alone renders NOTHING
+ * there (observed on mindset.ai: the model highlighted, the visitor saw only
+ * the scroll). So the visual is a pronounced pulsing ring driven inline + via
+ * the Web Animations API; the class still applies so hosts that DO define a
+ * rule (the Memex app) can layer their own styling on top.
+ *
+ * The highlight PERSISTS: it stays on the element until the guide highlights
+ * something else (the new highlight replaces the old one) or the element
+ * unmounts. A timed flash proved too easy to miss.
+ */
+let clearActiveHighlight: (() => void) | null = null;
+
+function applyHighlight(node: HTMLElement): void {
+  clearActiveHighlight?.();
+
+  const prevOutline = node.style.outline;
+  const prevOffset = node.style.outlineOffset;
+  node.classList.add(HIGHLIGHT_CLASS);
+  node.style.outline = `3px solid rgba(${HIGHLIGHT_RGB}, 0.9)`;
+  node.style.outlineOffset = '3px';
+
+  // Pronounced expanding/fading ring to catch the eye, then the solid outline
+  // stays. WAAPI is absent in jsdom and very old browsers; the static outline
+  // above still shows there.
+  const pulse = node.animate?.(
+    [
+      { boxShadow: `0 0 0 0 rgba(${HIGHLIGHT_RGB}, 0.85)` },
+      { boxShadow: `0 0 0 18px rgba(${HIGHLIGHT_RGB}, 0)` },
+    ],
+    { duration: PULSE_MS, iterations: PULSE_COUNT },
+  );
+
+  clearActiveHighlight = () => {
+    clearActiveHighlight = null;
+    pulse?.cancel();
+    node.classList.remove(HIGHLIGHT_CLASS);
+    node.style.outline = prevOutline;
+    node.style.outlineOffset = prevOffset;
+  };
+}
 
 export interface HighlightResult {
   ok: boolean;
 }
 
-/** Flash a highlight on the current screen's element. Best-effort: a missing
- *  element (not currently rendered) is a no-op, never a throw. */
-export function executeHighlight(
-  input: { elementId?: string },
-  opts: { durationMs?: number } = {},
-): HighlightResult {
+/** Highlight the current screen's element — persistently, replacing any prior
+ *  highlight. Best-effort: a missing element (not currently rendered) is a
+ *  no-op, never a throw. */
+export function executeHighlight(input: { elementId?: string }): HighlightResult {
   const id = input?.elementId;
   if (!id) return { ok: false };
   const node = findGuideElement(id);
   if (!node) return { ok: false };
-  node.classList.add(HIGHLIGHT_CLASS);
+  applyHighlight(node);
   node.scrollIntoView?.({ behavior: 'smooth', block: 'center' });
-  const ms = opts.durationMs ?? DEFAULT_HIGHLIGHT_MS;
-  setTimeout(() => node.classList.remove(HIGHLIGHT_CLASS), ms);
   return { ok: true };
 }
 

--- a/packages/guide-sdk/src/navigation/NavigationAdapter.ts
+++ b/packages/guide-sdk/src/navigation/NavigationAdapter.ts
@@ -29,6 +29,19 @@ export interface GuideLocation {
   pathname: string;
 }
 
+/**
+ * One navigable screen, summarized for the model's prompt: the stable key the
+ * navigate tool accepts plus a human title/description. Hosts that supply
+ * `allScreens()` give the model a complete site map every turn, so "what pages
+ * exist / where can you take me" is answered from the prompt — not left to
+ * retrieval luck.
+ */
+export interface GuideScreenSummary {
+  key: string;
+  title: string;
+  description: string;
+}
+
 /** The outcome of a navigate request, preserving the engine's existing
  *  validate-then-navigate contract (guideTools.executeNavigate): an unregistered
  *  / non-navigable destination is rejected WITHOUT navigating. */
@@ -76,6 +89,14 @@ export interface NavigationAdapter {
    * that drive the registry through engine state may omit it.
    */
   elementsForScreen?(screenKey: string | null): GuideElement[];
+
+  /**
+   * The COMPLETE list of navigable screens (config-data), summarized for the
+   * model. Optional; when present the engine sends it with every turn so the
+   * prompt carries a definitive site map (key + title + description per page)
+   * instead of relying on retrieval to know what pages exist.
+   */
+  allScreens?(): GuideScreenSummary[];
 
   /**
    * spec-222 dec-8 (t-4) — the engine calls this when the spoken turn has fully

--- a/packages/guide-sdk/src/orchestrator/voiceGuideOrchestrator.ts
+++ b/packages/guide-sdk/src/orchestrator/voiceGuideOrchestrator.ts
@@ -24,7 +24,11 @@
 // the Silero engine are. All browser glue is injectable so the orchestration logic
 // is exercised without real Web Audio / sockets.
 
-import type { GuideElement, NavigationAdapter } from '../navigation/NavigationAdapter';
+import type {
+  GuideElement,
+  GuideScreenSummary,
+  NavigationAdapter,
+} from '../navigation/NavigationAdapter';
 import { SileroWorkletVadEngine } from '../micVad';
 import type { VadEngine } from '../micVad';
 import { WebAudioPlayback } from '../playbackQueue';
@@ -63,6 +67,9 @@ import type { VoiceLoopState } from '../session/voiceSessionModel';
 export interface ScreenContext {
   screenKey: string | null;
   screenRegistry: GuideElement[];
+  /** The host's complete navigable-screen list (site map), when the adapter
+   *  supplies allScreens(). Optional — the in-app host omits it. */
+  screens?: GuideScreenSummary[];
   namespace: string;
   memex: string;
 }
@@ -151,7 +158,13 @@ class VoiceGuideOrchestrator implements VoiceOrchestrator {
     // search_guide call is rarely needed; return a benign note rather than throw.
     this.graph =
       glue.graph ??
-      createGuideGraph({ executeServerTool: async () => '(guide content already retrieved for this turn)' });
+      createGuideGraph({
+        executeServerTool: async () => '(guide content already retrieved for this turn)',
+        // After a client tool runs (navigate can soft-nav an SPA host mid-turn),
+        // the graph re-reads the live screen so the post-tool LLM call carries
+        // the NEW screen's context, not the turn-start snapshot.
+        getScreenContext: () => this.react.getScreenContext(),
+      });
   }
 
   async start(stream: MediaStream, openingContext?: string): Promise<void> {
@@ -297,12 +310,18 @@ class VoiceGuideOrchestrator implements VoiceOrchestrator {
     }
     this.playback?.flush();
 
-    const { screenKey, screenRegistry } = this.react.getScreenContext();
+    const { screenKey, screenRegistry, screens } = this.react.getScreenContext();
     this.turnAbort = new AbortController();
     let assistantText = '';
     try {
       await this.graph.invoke(
-        { messages: [{ role: 'user', content: transcript }], screenKey, screenRegistry, guideContext },
+        {
+          messages: [{ role: 'user', content: transcript }],
+          screenKey,
+          screenRegistry,
+          screens: screens ?? [],
+          guideContext,
+        },
         {
           configurable: {
             thread_id: this.threadId,
@@ -311,14 +330,15 @@ class VoiceGuideOrchestrator implements VoiceOrchestrator {
               onTextDelta: (t: string) => {
                 assistantText += t;
               },
-              onUiTool: (name: string, _id: string, input: Record<string, unknown>) => {
+              onUiTool: (name: string, _id: string, input: Record<string, unknown>) =>
+                // Returned so the graph can serialize the real outcome (e.g.
+                // navigate's { ok, path }) into the tool_result.
                 dispatchGuideUiTool(name, input, {
                   adapter: this.react.adapter,
                   capabilities: this.react.capabilities,
                   advanceDemo: this.react.advanceDemo,
                   startWalkthrough: this.react.startWalkthrough,
-                });
-              },
+                }),
             },
           },
         },

--- a/packages/server/scripts/import-guide-content.ts
+++ b/packages/server/scripts/import-guide-content.ts
@@ -13,8 +13,12 @@
 //     --surface=memex-website --source=https://memex.ai/llms-full.txt
 //   …--surface=mindset-website --source=https://www.mindset.ai/llms-full.txt
 //   …--surface=memex-website --source=/path/to/llms-full.txt   # local file
-// Each website import prunes orphans SCOPED to its own surface + source_path
-// only — it never touches the app corpus or another website surface.
+//   …--surface=mindset-website --source=https://www.mindset.ai/guide-corpus.json
+// A guide-corpus.json source (screen-keyed: { screens: [{ key, path, title,
+// content }] }) is ingested PER SCREEN — every chunk carries that screen's
+// screen_key so Layer-1 prefetch serves the current page's content.
+// Each website import prunes orphans SCOPED to its own surface only — it never
+// touches the app corpus or another website surface.
 //
 // Idempotent + non-destructive on content: upsertGuideChunk skips re-embedding
 // any chunk whose content_hash is unchanged, and orphan rows (whose source file
@@ -63,8 +67,10 @@ async function runWebsiteImport(
     surface,
     check,
   });
+  const screensNote =
+    summary.screensSeen !== undefined ? `${summary.screensSeen} screen(s), ` : "";
   console.log(
-    `[guide-content-import] ${surface} done — ${summary.chunksSeen} chunk(s): ` +
+    `[guide-content-import] ${surface} done — ${screensNote}${summary.chunksSeen} chunk(s): ` +
       `${summary.chunksEmbedded} embedded, ${summary.chunksReused} reused, ` +
       `${summary.chunksWithoutVector} without vector; ${summary.rowsPruned} orphan row(s) pruned.`,
   );

--- a/packages/server/src/agent/voice/guide-prompt.ts
+++ b/packages/server/src/agent/voice/guide-prompt.ts
@@ -78,6 +78,12 @@ export interface GuidePromptInput {
   screenKey: string | null;
   /** Highlightable elements on the current screen (dec-3 registry subset). */
   screenRegistry: GuideElement[];
+  /** The host's COMPLETE navigable-screen list (site map): key + title +
+   *  description per page. When present, rendered into the turn context so
+   *  "what pages exist / where can you take me" is answered from the prompt,
+   *  never left to retrieval. Config-data like screenRegistry, schema-capped
+   *  at the route. */
+  screens?: Array<{ key: string; title: string; description: string }>;
   /** Pre-fetched + per-turn retrieved guide-content chunks (dec-6). */
   guideContext: string[];
 }
@@ -99,6 +105,19 @@ export function renderScreenContext(input: Omit<GuidePromptInput, "surface">): s
       ? `The user is on the **${input.screenKey}** screen.`
       : "The current screen is not yet resolved.",
   );
+
+  if (input.screens && input.screens.length > 0) {
+    lines.push(
+      "",
+      "## Site map — every page on this site",
+      "",
+      "This is the COMPLETE list of pages. Use the `key` with the navigate tool to take the visitor there. If something isn't listed here, it isn't a separate page — answer from the guide content instead, and never claim a listed page doesn't exist.",
+      "",
+    );
+    for (const s of input.screens) {
+      lines.push(`- \`${s.key}\` — ${s.title}: ${s.description}`);
+    }
+  }
 
   if (input.screenRegistry.length > 0) {
     lines.push("", "Highlightable elements on this screen (use these ids with the highlight tool):");

--- a/packages/server/src/agent/voice/guide-prompt.ts
+++ b/packages/server/src/agent/voice/guide-prompt.ts
@@ -100,9 +100,14 @@ export interface GuidePromptInput {
 export function renderScreenContext(input: Omit<GuidePromptInput, "surface">): string {
   const lines: string[] = ["## Current screen context"];
 
+  // When the host supplies a site map (page NAMES), the model never sees the
+  // machine screen keys at all — spoken keys come out as gibberish through TTS
+  // ("the lets-talk screen"), and a model can't speak tokens it was never
+  // given. The host's NavigationAdapter resolves navigate-by-name.
+  const currentTitle = input.screens?.find((s) => s.key === input.screenKey)?.title;
   lines.push(
     input.screenKey
-      ? `The user is on the **${input.screenKey}** screen.`
+      ? `The user is on the "${currentTitle ?? input.screenKey}" ${input.screens ? "page" : "screen"}.`
       : "The current screen is not yet resolved.",
   );
 
@@ -111,11 +116,11 @@ export function renderScreenContext(input: Omit<GuidePromptInput, "surface">): s
       "",
       "## Site map — every page on this site",
       "",
-      "This is the COMPLETE list of pages. Use the `key` with the navigate tool to take the visitor there. If something isn't listed here, it isn't a separate page — answer from the guide content instead, and never claim a listed page doesn't exist.",
+      'This is the COMPLETE list of pages, by name. To take the visitor to one, call the navigate tool with the page name EXACTLY as listed (e.g. navigate with "Pricing"). If something isn\'t listed here, it isn\'t a separate page — answer from the guide content instead, and never claim a listed page doesn\'t exist. Refer to pages by these names when you speak.',
       "",
     );
     for (const s of input.screens) {
-      lines.push(`- \`${s.key}\` — ${s.title}: ${s.description}`);
+      lines.push(`- "${s.title}" — ${s.description}`);
     }
   }
 
@@ -131,7 +136,7 @@ export function renderScreenContext(input: Omit<GuidePromptInput, "surface">): s
   if (input.guideContext.length > 0) {
     lines.push(
       "",
-      "Relevant guide content (this is product documentation — answer from it; it is NOT the user's data):",
+      "Relevant guide content (this is product documentation — answer from it; it is NOT the user's data). Chunks labeled [from page: …] live on that page — offer to navigate there (pass that page name to the navigate tool) when the visitor wants to see it:",
       "",
       ...input.guideContext.map((chunk) => `---\n${chunk}`),
     );

--- a/packages/server/src/routes/voice.ts
+++ b/packages/server/src/routes/voice.ts
@@ -71,6 +71,19 @@ export const guideChatSchema = z.object({
   screenRegistry: z
     .array(z.object({ id: z.string(), description: z.string() }))
     .optional(),
+  // The host's complete navigable-screen list (site map) — rendered into the
+  // turn context so the model knows what pages exist. Hard-capped (anonymous
+  // endpoint): at most 200 screens, strings bounded.
+  screens: z
+    .array(
+      z.object({
+        key: z.string().max(200),
+        title: z.string().max(300),
+        description: z.string().max(500),
+      }),
+    )
+    .max(200)
+    .optional(),
   guideContext: z.array(z.string()).optional(),
 });
 
@@ -84,12 +97,16 @@ export function latestUserUtterance(messages: Array<{ role: string; content: unk
     if (m.role !== "user") continue;
     if (typeof m.content === "string") return m.content;
     if (Array.isArray(m.content)) {
-      return m.content
+      const text = m.content
         .filter((b): b is { type: string; text: string } => !!b && (b as { type?: string }).type === "text")
         .map((b) => b.text)
         .join(" ");
+      // Mid tool-loop the final user message is tool_result blocks with no
+      // text — keep scanning back to the visitor's actual utterance so the
+      // per-turn retrieval query isn't empty on tool turns.
+      if (text) return text;
+      continue;
     }
-    return "";
   }
   return "";
 }
@@ -129,9 +146,24 @@ export function injectTurnContext(
 
   return messages.map((m, i) => {
     if (i === lastUser) {
+      // Anthropic requires tool_result blocks to be the FIRST content of the
+      // user message that answers a tool_use — text before them 400s
+      // ("tool_use ids were found without tool_result blocks immediately
+      // after"). Mid tool-loop the final user message IS the tool_result
+      // carrier, so the per-turn context slots in AFTER any leading
+      // tool_result blocks, not at the front.
+      const blocks = toBlocks(m.content);
+      const firstNonToolResult = blocks.findIndex(
+        (b) => (b as { type?: string }).type !== "tool_result",
+      );
+      const insertAt = firstNonToolResult === -1 ? blocks.length : firstNonToolResult;
       return {
         role: m.role,
-        content: [{ type: "text", text: contextText }, ...toBlocks(m.content)],
+        content: [
+          ...blocks.slice(0, insertAt),
+          { type: "text", text: contextText },
+          ...blocks.slice(insertAt),
+        ],
       };
     }
     if (i === lastUser - 1) {
@@ -576,7 +608,7 @@ export async function handleGuideChat(
   if (!parsed.success) {
     return c.json({ error: "Invalid request" }, 400);
   }
-  const { messages, screenKey, screenRegistry, guideContext } = parsed.data;
+  const { messages, screenKey, screenRegistry, screens, guideContext } = parsed.data;
 
   let anthropic: Anthropic;
   try {
@@ -616,6 +648,7 @@ export async function handleGuideChat(
   const contextText = renderScreenContext({
     screenKey: screenKey ?? null,
     screenRegistry: screenRegistry ?? [],
+    screens,
     guideContext: retrievedContext,
   });
   const outMessages = injectTurnContext(messages, contextText);

--- a/packages/server/src/routes/voice.ts
+++ b/packages/server/src/routes/voice.ts
@@ -51,6 +51,7 @@ import { logVoiceLatency } from "../agent/voice/latency-log.js";
 import {
   prefetchScreenContent,
   searchGuideContent,
+  type GuideSearchHit,
   type GuideSurface,
 } from "../services/guide-content.js";
 import { GUIDE_TOOLS } from "@memex/shared";
@@ -79,7 +80,9 @@ export const guideChatSchema = z.object({
       z.object({
         key: z.string().max(200),
         title: z.string().max(300),
-        description: z.string().max(500),
+        // Generous: descriptions carry SEO blurb + content outline + steering
+        // notes (~670 chars on the mindset site today). Hosts truncate at 900.
+        description: z.string().max(1000),
       }),
     )
     .max(200)
@@ -198,21 +201,36 @@ export async function assembleGuideContext(
   // signed session token. Either way the surface is a SERVER-supplied argument,
   // NEVER client free input.
   surface: GuideSurface = "memex-app",
+  /** Optional screen_key → human page name lookup (from the host's site map).
+   *  When provided, retrieval labels use the SPEAKABLE page name instead of
+   *  the machine key — spoken keys come out as gibberish through TTS. */
+  pageNameByKey?: Map<string, string>,
 ): Promise<string[]> {
   const [screenChunks, searchHits] = await Promise.all([
     screenKey ? prefetchScreenContent(screenKey, surface).catch(() => []) : Promise.resolve<string[]>([]),
     utterance.trim()
-      ? searchGuideContent(utterance, { surface, limit: 4 }).then((h) => h.map((x) => x.content)).catch(() => [])
-      : Promise.resolve<string[]>([]),
+      ? searchGuideContent(utterance, { surface, limit: 4 }).catch(() => [] as GuideSearchHit[])
+      : Promise.resolve<GuideSearchHit[]>([]),
   ]);
+  // Source-tag each chunk with where it lives, so the model can offer to
+  // navigate to a retrieved chunk's page (the screen_key doubles as the navigate
+  // key). Layer-1 chunks ARE the current page; Layer-2 hits carry their origin
+  // screen_key when one exists (concept / flat-corpus chunks have none). Dedup
+  // runs on the RAW chunk text, so a chunk that is both prefetched and searched
+  // appears once — with the Layer-1 label, by ordering.
   const seen = new Set<string>();
   const out: string[] = [];
-  for (const chunk of [...(clientContext ?? []), ...screenChunks, ...searchHits]) {
+  const push = (chunk: string, label: string | null): void => {
     const key = chunk.trim();
-    if (key && !seen.has(key)) {
-      seen.add(key);
-      out.push(chunk);
-    }
+    if (!key || seen.has(key)) return;
+    seen.add(key);
+    out.push(label ? `${label}\n${chunk}` : chunk);
+  };
+  for (const chunk of clientContext ?? []) push(chunk, null);
+  for (const chunk of screenChunks) push(chunk, "[this page]");
+  for (const hit of searchHits) {
+    const name = hit.screenKey ? (pageNameByKey?.get(hit.screenKey) ?? hit.screenKey) : null;
+    push(hit.content, name ? `[from page: "${name}"]` : null);
   }
   return out;
 }
@@ -628,6 +646,7 @@ export async function handleGuideChat(
     latestUserUtterance(messages),
     guideContext,
     surface,
+    screens ? new Map(screens.map((s) => [s.key, s.title])) : undefined,
   );
   const retrievalMs = Date.now() - tStart;
 

--- a/packages/server/src/services/guide-content-import.ts
+++ b/packages/server/src/services/guide-content-import.ts
@@ -422,6 +422,206 @@ export interface WebsiteImportSummary {
   rowsPruned: number;
   /** True when check mode ran (fetch + chunk only, no DB writes). */
   checkOnly: boolean;
+  /** Screen count when the source was a screen-keyed guide-corpus JSON artifact
+   *  (absent for the flat llms-full.txt path). */
+  screensSeen?: number;
+}
+
+// ── Screen-keyed guide-corpus JSON ingestion ─────────────────────────────────
+//
+// A host site may publish a SCREEN-KEYED guide-corpus.json instead of (or
+// alongside) the flat llms-full.txt:
+//
+//   { "surface": "mindset-website", "generatedAt": "<ISO>",
+//     "screens": [{ "key": "<screen-key>", "path": "/...", "title": "...",
+//                   "content": "<page text>" }] }
+//
+// Each screen's content is chunked with the SAME chunker and every chunk is
+// tagged screen_key = <screen.key>, so the voice guide's Layer-1 prefetch
+// (prefetchScreenContent — a surface + screen_key lookup) puts the CURRENT
+// page's content in every prompt, and Layer-2 hits carry the page they live on.
+// Each screen gets its own source_path (`<surface>/screens/<key>`) because the
+// upsert key is (source_path, chunk_index) WITHOUT surface — see the
+// WEBSITE_CORPUS_SOURCE_PATH_BY_SURFACE note above.
+
+export interface GuideCorpusScreen {
+  key: string;
+  path?: string;
+  title?: string;
+  content: string;
+}
+
+export interface GuideCorpus {
+  surface?: string;
+  generatedAt?: string;
+  screens: GuideCorpusScreen[];
+}
+
+/**
+ * Parse a raw artifact as guide-corpus JSON. Returns null when the text is not
+ * JSON or carries no `screens` array — the caller then falls back to the flat
+ * llms-full.txt path, which keeps every existing host artifact working. A
+ * document that IS a corpus but has malformed screen entries throws (a published
+ * artifact violating its own contract should fail loudly, not half-ingest).
+ */
+export function parseGuideCorpus(raw: string): GuideCorpus | null {
+  const trimmed = raw.trim();
+  if (!trimmed.startsWith("{")) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null) return null;
+  const obj = parsed as { surface?: unknown; generatedAt?: unknown; screens?: unknown };
+  if (!Array.isArray(obj.screens)) return null;
+
+  const screens: GuideCorpusScreen[] = [];
+  const bad: number[] = [];
+  obj.screens.forEach((entry, i) => {
+    const s = entry as Partial<GuideCorpusScreen> | null;
+    if (
+      !s ||
+      typeof s !== "object" ||
+      typeof s.key !== "string" ||
+      s.key.trim().length === 0 ||
+      typeof s.content !== "string"
+    ) {
+      bad.push(i);
+      return;
+    }
+    screens.push({
+      key: s.key.trim(),
+      path: typeof s.path === "string" ? s.path : undefined,
+      title: typeof s.title === "string" ? s.title : undefined,
+      content: s.content,
+    });
+  });
+  if (bad.length > 0) {
+    throw new Error(
+      `guide-corpus JSON: screens[${bad.join(", ")}] must each carry a non-empty ` +
+        `string \`key\` and a string \`content\`.`,
+    );
+  }
+  return {
+    surface: typeof obj.surface === "string" ? obj.surface : undefined,
+    generatedAt: typeof obj.generatedAt === "string" ? obj.generatedAt : undefined,
+    screens,
+  };
+}
+
+/** Stable per-screen source_path for a screen-keyed corpus row (the upsert key,
+ *  with chunk_index — distinct per surface AND per screen, see the unique-index
+ *  note on WEBSITE_CORPUS_SOURCE_PATH_BY_SURFACE). */
+export function guideCorpusScreenSourcePath(
+  surface: WebsiteCorpusSurface,
+  screenKey: string,
+): string {
+  return `${surface}/screens/${screenKey}`;
+}
+
+/**
+ * Ingest a screen-keyed guide-corpus into guide_content under `surface`: each
+ * screen's content is heading-chunked and every chunk lands with
+ * screen_key = <screen.key>. Same idempotency (content_hash → "reused") and
+ * pruning semantics as the flat path, except the prune covers the WHOLE surface:
+ * screens dropped from the artifact — and any legacy flat llms-full.txt rows
+ * from before the host switched to the screen-keyed artifact — are removed,
+ * then per-screen stale tail chunks are pruned. Never touches other surfaces.
+ */
+async function importGuideCorpusScreens(opts: {
+  corpus: GuideCorpus;
+  surface: WebsiteCorpusSurface;
+  origin: string;
+  check?: boolean;
+  provider?: EmbeddingProvider | null;
+}): Promise<WebsiteImportSummary> {
+  const { corpus, surface, origin } = opts;
+
+  if (corpus.screens.length === 0) {
+    // An empty screens array would prune the surface's ENTIRE corpus — far more
+    // likely a broken publish than an intentional wipe. Refuse.
+    throw new Error(
+      `guide-corpus JSON from ${origin} has an empty \`screens\` array — refusing ` +
+        `to wipe the ${surface} corpus.`,
+    );
+  }
+  if (corpus.surface && corpus.surface !== surface) {
+    console.warn(
+      `[guide-content-import] guide-corpus from ${origin} declares surface ` +
+        `"${corpus.surface}" but is being imported under "${surface}".`,
+    );
+  }
+
+  // Dedupe by key (first occurrence wins) — duplicate keys would otherwise fight
+  // over the same (source_path, chunk_index) rows.
+  const byKey = new Map<string, GuideCorpusScreen>();
+  for (const screen of corpus.screens) {
+    if (!byKey.has(screen.key)) byKey.set(screen.key, screen);
+  }
+
+  const files = [...byKey.values()].map((screen) => ({
+    screen,
+    sourcePath: guideCorpusScreenSourcePath(surface, screen.key),
+    chunks: chunkMarkdown(screen.content),
+  }));
+
+  const summary: WebsiteImportSummary = {
+    source: origin,
+    chunksSeen: files.reduce((n, f) => n + f.chunks.length, 0),
+    chunksEmbedded: 0,
+    chunksReused: 0,
+    chunksWithoutVector: 0,
+    rowsPruned: 0,
+    checkOnly: !!opts.check,
+    screensSeen: files.length,
+  };
+
+  if (opts.check) return summary;
+
+  // Lazy DB import — mirrors the other importers so check mode needs no DATABASE_URL.
+  const { upsertGuideChunk, pruneGuideContent, pruneGuideContentChunks } = await import(
+    "./guide-content.js"
+  );
+
+  for (const file of files) {
+    for (let index = 0; index < file.chunks.length; index++) {
+      const chunk = file.chunks[index];
+      const input: GuideChunkInput = {
+        surface,
+        // THE point of the screen-keyed artifact: Layer-1 prefetch is a
+        // (surface, screen_key) lookup, so the chunk must carry its page's key.
+        screenKey: file.screen.key,
+        sourcePath: file.sourcePath,
+        chunkIndex: index,
+        heading: chunk.heading ?? file.screen.title ?? null,
+        contentHash: hashContent(chunk.content),
+        content: chunk.content,
+      };
+      const res = await upsertGuideChunk(input, { provider: opts.provider });
+      if (res.status === "embedded") summary.chunksEmbedded += 1;
+      else if (res.status === "reused") summary.chunksReused += 1;
+      else if (res.status === "skipped-no-provider") summary.chunksWithoutVector += 1;
+    }
+  }
+
+  // Prune stale rows of THIS surface not in this import: first whole source_paths
+  // (screens removed from the artifact + any legacy flat-artifact rows), then
+  // per-screen stale tail chunks (a screen whose content SHRANK keeps its
+  // source_path but loses high chunk_indexes). Both prunes are surface-scoped.
+  summary.rowsPruned = await pruneGuideContent(
+    surface,
+    files.map((f) => f.sourcePath),
+  );
+  for (const file of files) {
+    summary.rowsPruned += await pruneGuideContentChunks(
+      surface,
+      file.sourcePath,
+      file.chunks.length,
+    );
+  }
+  return summary;
 }
 
 /** Resolve the website artifact's raw markdown from a string, local path, or URL. */
@@ -447,12 +647,17 @@ async function loadWebsiteCorpus(
 }
 
 /**
- * Ingest a host site's flat `llms-full.txt` into guide_content under that
- * site's surface (spec-222 t-8, dec-3 → ac-13; generalised for spec-251).
+ * Ingest a host site's published artifact into guide_content under that site's
+ * surface (spec-222 t-8, dec-3 → ac-13; generalised for spec-251). Two artifact
+ * shapes are accepted:
+ *   * flat `llms-full.txt` markdown — chunked as one document, screen_key NULL
+ *     (search-only), pruning scoped to (surface, source_path);
+ *   * screen-keyed `guide-corpus.json` (detected by .json suffix or JSON shape)
+ *     — chunked per screen with screen_key set, enabling Layer-1 prefetch;
+ *     pruning covers the whole surface (see importGuideCorpusScreens).
  * Defaults to `memex-website` so existing callers keep their behaviour.
- * Idempotent via content_hash; prunes orphans scoped to (surface, source_path)
- * only. In check mode it fetches + chunks but writes nothing (a bounded,
- * non-gating freshness probe).
+ * Idempotent via content_hash either way. In check mode it fetches + chunks but
+ * writes nothing (a bounded, non-gating freshness probe).
  */
 export async function importWebsiteCorpus(opts: {
   source: WebsiteCorpusSource;
@@ -468,6 +673,28 @@ export async function importWebsiteCorpus(opts: {
     );
   }
   const { raw, origin } = await loadWebsiteCorpus(opts.source);
+
+  // Screen-keyed guide-corpus JSON path: detected by a .json source suffix or by
+  // the document parsing as JSON with a `screens` array. Anything else falls
+  // through to the flat llms-full.txt path below, unchanged.
+  const expectsJson = /\.json($|[?#])/i.test(opts.source.url ?? opts.source.path ?? "");
+  const corpus = parseGuideCorpus(raw);
+  if (expectsJson && !corpus) {
+    throw new Error(
+      `importWebsiteCorpus: ${origin} has a .json suffix but does not parse as a ` +
+        `guide-corpus document (JSON object with a \`screens\` array).`,
+    );
+  }
+  if (corpus) {
+    return importGuideCorpusScreens({
+      corpus,
+      surface,
+      origin,
+      check: opts.check,
+      provider: opts.provider,
+    });
+  }
+
   const sourcePath =
     opts.source.sourcePath ?? WEBSITE_CORPUS_SOURCE_PATH_BY_SURFACE[surface];
 

--- a/packages/shared/src/guide-tools.ts
+++ b/packages/shared/src/guide-tools.ts
@@ -43,11 +43,15 @@ export const GUIDE_TOOLS: GuideToolDefinition[] = [
   {
     name: 'navigate',
     description:
-      'Take the user to another screen of the app. Only registered screen keys are allowed. For a specific entity the user names by description, do NOT try to open it directly — navigate to the relevant list screen and highlight its search affordance so they can find it.',
+      'Take the user to another screen/page. Only destinations listed in your screen context are allowed — pass the target EXACTLY as it is listed there (the screen key, or on sites whose context lists page names, the page name). For a specific entity the user names by description, do NOT try to open it directly — navigate to the relevant list screen and highlight its search affordance so they can find it.',
     input_schema: {
       type: 'object',
       properties: {
-        screen: { type: 'string', description: 'A registered, navigable screen key (e.g. specs-list, standards-list).' },
+        screen: {
+          type: 'string',
+          description:
+            'The target, exactly as listed in your screen context (a screen key such as specs-list, or a page name such as "Pricing" when your context lists names).',
+        },
       },
       required: ['screen'],
     },


### PR DESCRIPTION
## What

Fixes and capabilities surfaced by live-testing the guide SDK's first external React-SPA host (the mindset.ai website, `mindset-prod/mindset-website` spec-2 / `memex-building-itself` spec-251). Two commits:

### Tool-turn integrity (closes spec-222 issue-4)
- **`injectTurnContext` corrupted every client tool turn**: the per-turn screen context was prepended to the final user message — mid tool-loop that message is the tool_result carrier, and Anthropic requires tool_results first, so every navigate/highlight 400'd. Context now slots in after leading tool_result blocks. `latestUserUtterance` also skips tool_result-only messages so retrieval isn't empty on tool turns. (Masked on memex-website because MPA navigation kills the conversation before the follow-up request.)
- **Tool results tell the truth**: `onUiTool`'s dispatch outcome (e.g. navigate's `{ ok, path }`) is serialized into the tool_result instead of a bare `'executed'`, and the graph re-reads the live screen context after a client tool runs — an SPA soft-navs mid-turn, and the stale turn-start snapshot made the model insist the navigation never happened.
- **Highlight is self-sufficient + persistent**: the `.guide-highlight` class renders nothing on hosts without the app's CSS; the visual is now an inline pulsing ring (WAAPI) + outline, persisting until the next highlight replaces it.

### Site knowledge without RAG roulette
- **Site map channel**: hosts can supply `NavigationAdapter.allScreens()` (name + description per page) — sent every turn (`GuideLlmInput.screens`, schema-capped) and rendered into the turn context, so "what pages exist / where can you take me" never depends on retrieval. In-app host unaffected (sends none).
- **Screen-keyed website corpus**: `importWebsiteCorpus` accepts the host-published `guide-corpus.json` (`{ surface, screens: [{ key, path, title, content }] }`), tagging chunks with `screen_key` — Layer-1 prefetch now works on website surfaces. Flat llms-full.txt path unchanged; empty-corpus guard, surface-scoped pruning.
- **Speakable prompt**: with a site map present, pages are listed by NAME, the navigate tool takes the name (host adapter resolves it), and retrieval hits are labeled `[from page: "Name"]` — spoken machine keys came out as TTS gibberish ("the chan lets-talk"), and a model can't speak tokens it never sees.

## Testing
- guide-sdk: 24 files / 127 tests green
- server guide suites (voice-guide-chat, guide-public, guide-public-mindset-website, guide-prompt-surface): 57 green; importer smoke-tested against local Postgres incl. idempotent re-run and shrunk-corpus pruning
- shared: 648 green
- `tsc -p packages/server --noEmit`: no new errors (13 pre-existing in unrelated test files)
- Exercised end-to-end locally: mindset.ai dev site → local server → voice session with navigate + highlight + corpus answers

## Notes
- Sibling website PR (mindset-ai/mindset-website) vendors the bundle built from this branch (provenance `34b7d23b090a`) and publishes `/guide-corpus.json`.
- After merge to develop/int: re-run the mindset-website corpus refresh with the new JSON source (the workflow picks it up once the website deploy publishes the artifact).
- Complements #141-adjacent persona work on `feat/mindset-guide-persona`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)