### PR TITLE
spec-247: one obvious place to answer a decision — persist-on-select, honest CTA, web↔MCP boundary

### DIFF
--- a/packages/server/src/agent/tool-specs.ts
+++ b/packages/server/src/agent/tool-specs.ts
@@ -2654,14 +2654,19 @@ export const toolSpecs: ToolSpec[] = [
     name: "resolve_decision",
     annotations: { title: "Resolve decision", readOnlyHint: false, destructiveHint: false },
     description:
-      "Resolve a decision with an explanation of the choice made. May unblock tasks waiting on it. Resolving the last open decision on a Spec in 'specify' unblocks the move to 'build'. If the decision has structured options, pass `chosenOptionIndex` to mark which one was selected.",
+      "Resolve a decision with an explanation of the choice made. May unblock tasks waiting on it. Resolving the last open decision on a Spec in 'specify' unblocks the move to 'build'. If the decision has structured options, pass `chosenOptionIndex` to mark which one was selected — `resolution` is then optional and defaults to that option's label. Re-resolving an already-resolved decision updates the choice in place (spec-247 dec-5).",
     schema: {
       ref: z
         .string()
         .describe(
           "Canonical ref to the decision, e.g. `mindset/main/specs/spec-3/decisions/dec-2`.",
         ),
-      resolution: z.string().describe("The resolution — what was decided and why"),
+      resolution: z
+        .string()
+        .optional()
+        .describe(
+          "The resolution — what was decided and why. Optional when chosenOptionIndex is supplied (defaults to the chosen option's label); required otherwise.",
+        ),
       chosenOptionIndex: z
         .number()
         .int()

--- a/packages/server/src/routes/decisions.ts
+++ b/packages/server/src/routes/decisions.ts
@@ -126,16 +126,14 @@ decisionsRouter.post("/doc/:docId", async (c) => {
 decisionsRouter.post("/:id/resolve", async (c) => {
   const memexId = requireMemexId(c);
   const id = c.req.param("id");
+  // spec-247 dec-5: `resolution` is optional — when omitted alongside a
+  // chosenOptionIndex, the service defaults the prose to the chosen option's
+  // label (persist-on-select sends only the index).
   const { resolution, chosenOptionIndex } = await c.req.json<{
-    resolution: string;
+    resolution?: string;
     chosenOptionIndex?: number;
   }>();
-  // Pass chosenOptionIndex only when supplied — preserves the existing 3-arg call shape
-  // for clients that don't use multi-option decisions.
-  const result =
-    chosenOptionIndex !== undefined
-      ? await resolveDecision(memexId, id, resolution, chosenOptionIndex, restCtx(c))
-      : await resolveDecision(memexId, id, resolution, undefined, restCtx(c));
+  const result = await resolveDecision(memexId, id, resolution, chosenOptionIndex, restCtx(c));
   return c.json(result);
 });
 

--- a/packages/server/src/services/decisions.integration.test.ts
+++ b/packages/server/src/services/decisions.integration.test.ts
@@ -462,19 +462,109 @@ describe("resolveDecision", () => {
     expect(resolved.resolvedAt).toBeTruthy();
   });
 
-  it("throws ValidationError when already resolved", async () => {
+  it("re-resolving an already-resolved decision updates it in place (spec-247 dec-5)", async () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-247/acs/ac-17");
     const dec = await createDecision(memexId, docId, "Double resolve");
     await resolveDecision(memexId, dec.id, "First resolution");
 
-    await expect(
-      resolveDecision(memexId, dec.id, "Second resolution")
-    ).rejects.toThrow(ValidationError);
+    const reResolved = await resolveDecision(memexId, dec.id, "Second resolution");
+    expect(reResolved.status).toBe("resolved");
+    expect(reResolved.resolution).toBe("Second resolution");
   });
 
   it("throws NotFoundError for non-existent id", async () => {
     await expect(
       resolveDecision(memexId, "00000000-0000-0000-0000-000000000000", "Resolution")
     ).rejects.toThrow(NotFoundError);
+  });
+});
+
+// ── spec-247 dec-5: persist-on-select mechanics ─────────────────────────────
+// resolution becomes optional when chosenOptionIndex picks an option (prose
+// defaults to that option's label); a later click on a different option
+// re-resolves in place, no reopen round-trip. Prose-only resolves (no index)
+// still require text.
+describe("resolveDecision — persist-on-select (spec-247 dec-5)", () => {
+  const AC17 = "mindset-prod/memex-building-itself/specs/spec-247/acs/ac-17";
+  let docId: string;
+  const OPTIONS: DecisionOption[] = [
+    { label: "Postgres", trade_offs: "Familiar; SQL." },
+    { label: "DynamoDB", trade_offs: "Scales; weaker queries." },
+  ];
+
+  beforeAll(async () => {
+    const doc = await createDocDraft(memexId, "Persist-on-select Doc", "Purpose");
+    docId = doc.id;
+    createdDocIds.push(doc.id);
+  });
+
+  async function makeOptionedDecision() {
+    const dec = await createDecision(memexId, docId, "Which database?");
+    await setDecisionOptions(memexId, dec.id, OPTIONS);
+    return dec;
+  }
+
+  it("resolves on a bare chosenOptionIndex — resolution defaults to the chosen option's label", async () => {
+    tagAc(AC17);
+    const dec = await makeOptionedDecision();
+    const resolved = await resolveDecision(memexId, dec.id, undefined, 1);
+
+    expect(resolved.status).toBe("resolved");
+    expect(resolved.chosenOptionIndex).toBe(1);
+    expect(resolved.resolution).toBe("DynamoDB");
+  });
+
+  it("a later click on a different option updates chosenOptionIndex in place (re-select)", async () => {
+    tagAc(AC17);
+    const dec = await makeOptionedDecision();
+    await resolveDecision(memexId, dec.id, undefined, 0);
+
+    const reSelected = await resolveDecision(memexId, dec.id, undefined, 1);
+    expect(reSelected.status).toBe("resolved");
+    expect(reSelected.chosenOptionIndex).toBe(1);
+    expect(reSelected.resolution).toBe("DynamoDB");
+  });
+
+  it("explicit resolution prose wins over the label default", async () => {
+    tagAc(AC17);
+    const dec = await makeOptionedDecision();
+    const resolved = await resolveDecision(memexId, dec.id, "Postgres — team knows it", 0);
+
+    expect(resolved.chosenOptionIndex).toBe(0);
+    expect(resolved.resolution).toBe("Postgres — team knows it");
+  });
+
+  it("adding reasoning after the fact re-resolves with prose, keeping the chosen option", async () => {
+    tagAc(AC17);
+    const dec = await makeOptionedDecision();
+    await resolveDecision(memexId, dec.id, undefined, 0);
+
+    const withReasoning = await resolveDecision(
+      memexId,
+      dec.id,
+      "Postgres: the team runs it in prod already",
+      0,
+    );
+    expect(withReasoning.chosenOptionIndex).toBe(0);
+    expect(withReasoning.resolution).toBe("Postgres: the team runs it in prod already");
+  });
+
+  it("rejects a resolve with neither resolution nor a chosen option", async () => {
+    tagAc(AC17);
+    const dec = await createDecision(memexId, docId, "Optionless decision");
+    await expect(resolveDecision(memexId, dec.id)).rejects.toThrow(ValidationError);
+    await expect(resolveDecision(memexId, dec.id, "   ")).rejects.toThrow(ValidationError);
+  });
+
+  it("still rejects re-resolve on candidate and rejected statuses", async () => {
+    tagAc(AC17);
+    const cand = await proposeDecision(memexId, docId, { title: "Candidate stays gated" });
+    await expect(resolveDecision(memexId, cand.id, undefined, 0)).rejects.toThrow(
+      ValidationError,
+    );
+    const toReject = await proposeDecision(memexId, docId, { title: "Rejected stays terminal" });
+    await rejectDecision(memexId, toReject.id, "noise");
+    await expect(resolveDecision(memexId, toReject.id, "x")).rejects.toThrow(ValidationError);
   });
 });
 

--- a/packages/server/src/services/decisions.ts
+++ b/packages/server/src/services/decisions.ts
@@ -678,17 +678,18 @@ export async function setDecisionOptions(
 export async function resolveDecision(
   memexId: string,
   id: string,
-  resolution: string,
+  resolution?: string,
   chosenOptionIndex?: number,
   ctx: RequestCtx = {},
 ): Promise<Mutated<Decision>> {
   const decision = await loadOwnedDecision(memexId, id);
-  // Strict transition: only `open` decisions can be resolved. Candidates need approval
-  // first; rejected/resolved decisions can't transition into resolved without going via
-  // reopen → open.
-  if (decision.status !== "open") {
+  // spec-247 dec-5 (persist-on-select): `open` AND `resolved` decisions accept
+  // resolve — re-resolving updates chosenOptionIndex/resolution in place so a
+  // later option click is a one-step correction, no reopen round-trip.
+  // Candidates still need approval first; rejected stays terminal-until-restore.
+  if (decision.status !== "open" && decision.status !== "resolved") {
     throw new ValidationError(
-      `Only open decisions can be resolved (current status: ${decision.status})`,
+      `Only open or resolved decisions can be resolved (current status: ${decision.status})`,
     );
   }
 
@@ -705,6 +706,22 @@ export async function resolveDecision(
     validateChosenIndex(decision.options as DecisionOption[] | null, effectiveChosenIndex);
   }
 
+  // spec-247 dec-5: resolution is optional when an option is being picked —
+  // the prose defaults to the chosen option's label so a bare option click is
+  // a complete resolution. Prose-only resolves (no index) still require text:
+  // with neither an option nor prose there is no resolution content at all.
+  const trimmedResolution = typeof resolution === "string" ? resolution.trim() : "";
+  let effectiveResolution = trimmedResolution;
+  if (!effectiveResolution) {
+    if (effectiveChosenIndex !== undefined) {
+      effectiveResolution = (decision.options as DecisionOption[])[effectiveChosenIndex].label;
+    } else {
+      throw new ValidationError(
+        "resolution is required unless chosenOptionIndex picks an option (then it defaults to that option's label)",
+      );
+    }
+  }
+
   const now = new Date();
 
   // The cascading docComments update is treated as part of the decision-resolution
@@ -719,7 +736,7 @@ export async function resolveDecision(
         .update(decisions)
         .set({
           status: "resolved",
-          resolution,
+          resolution: effectiveResolution,
           resolvedAt: now,
           // spec-122 dec-2/dec-5 — record who resolved it, through which surface.
           ...(await resolveActorColumns(ctx)),

--- a/packages/shared/src/scaffold-data.ts
+++ b/packages/shared/src/scaffold-data.ts
@@ -2027,20 +2027,6 @@ Walk me through this Spec's CANDIDATE decisions — choices an agent extracted t
       'MCP-side — the web candidate cards are view-only and hand off here. ' +
       'The prompt forbids resolution so curation and answering stay separate.',
   },
-  {
-    kind: 'prompt_button',
-    id: 'decision-explain',
-    label: 'Explain this decision',
-    text: `Explain decision {decision} on this Spec to me. Summarise the question it asks, then walk through each option and its trade-offs in plain language, and say what you would recommend and why. Do NOT resolve the decision, and do NOT create or modify anything — I will pick an option myself on the decision card.`,
-    surfaces: ['decision-card'],
-    rationale:
-      'spec-247 dec-2 / ac-10: the decision card\'s "Ask for more ' +
-      'explanation" affordance. Seeded into the in-app spec assistant (the ' +
-      'opening-turn delivery mode) with the decision pre-scoped via context ' +
-      'chip. Explanation only — the prompt explicitly forbids resolving, so ' +
-      'the agent never answers on the answering path (dec-1: the option row ' +
-      'is the only answering affordance).',
-  },
 ];
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/packages/shared/src/scaffold-data.ts
+++ b/packages/shared/src/scaffold-data.ts
@@ -1983,6 +1983,64 @@ Give a verdict per chosen lens and an overall read, and list the comments and Is
       'std-22. Rendered as the reviewer handoff line on the Spec page ' +
       '(spec-159 ac-19).',
   },
+  // ── spec-247 dec-4 — web↔MCP boundary handoffs ─────────────────────────
+  // Surfaces whose NEXT STEP is MCP-only carry a PromptButton instead of copy
+  // that names MCP tools at a human (spec-157's leak, generalised). The
+  // get_information / tool mentions live HERE, agent-facing; the human-facing
+  // copy around the button stays tool-free. Portable per std-22.
+  {
+    kind: 'prompt_button',
+    id: 'wire-ac-tests',
+    label: 'Wire the AC tests',
+    text: `You are working in Memex ({namespace}/{memex}), with this project checked out and the Memex MCP tools available.
+
+Spec {handle} "{title}"
+URL: {url}
+
+Wire this Spec's acceptance criteria to real tests in this codebase. ACs are committed but unverified until a tagged test asserts each one — your job is to close that gap, using THIS project's own language, test runner, and conventions (discover them from the project; assume nothing).
+
+1. list_acs({ ref: '{namespace}/{memex}/specs/{handle}' }) — read every active AC (scope + implementation).
+2. Call get_information(topic='ac-emission') to learn how tests in this project tag ACs and emit verification events.
+3. For each AC, find or write the test that asserts its claim, tag it to the AC's canonical ref, and run it so the verification event lands.
+4. Re-read list_acs and report which ACs went green and which still need work (and why).`,
+    surfaces: ['ac-panel'],
+    rationale:
+      'spec-247 dec-4 / ac-14: the AC coverage panel boundary handoff. Wiring ' +
+      'tests is exclusively coding-agent work; the old panel copy told the ' +
+      'HUMAN to call get_information (an MCP tool a human cannot call — the ' +
+      'spec-157 leak). The MCP mentions now live in this prompt, behind the ' +
+      'PromptButton; the on-screen copy stays human-actionable.',
+  },
+  {
+    kind: 'prompt_button',
+    id: 'review-candidates',
+    label: 'Review candidate decisions',
+    text: `You are working in Memex ({namespace}/{memex}), with this project checked out and the Memex MCP tools available.
+
+Spec {handle} "{title}"
+URL: {url}
+
+Walk me through this Spec's CANDIDATE decisions — choices an agent extracted that need human confirmation before they become real, open decisions. For each candidate: summarise the question, the options and their trade-offs, ground it against the current code where it names code shape, and recommend whether it is a genuine decision worth keeping. Then, on my explicit call per candidate, either approve_candidate (it becomes an open decision) or reject_candidate with my reason. Do NOT resolve anything in this pass — confirming a decision exists and answering it are separate steps, and I answer open decisions myself on the Spec page.`,
+    surfaces: ['decision-panel'],
+    rationale:
+      'spec-247 dec-6 / ac-21: candidate curation (approve/reject) is ' +
+      'MCP-side — the web candidate cards are view-only and hand off here. ' +
+      'The prompt forbids resolution so curation and answering stay separate.',
+  },
+  {
+    kind: 'prompt_button',
+    id: 'decision-explain',
+    label: 'Explain this decision',
+    text: `Explain decision {decision} on this Spec to me. Summarise the question it asks, then walk through each option and its trade-offs in plain language, and say what you would recommend and why. Do NOT resolve the decision, and do NOT create or modify anything — I will pick an option myself on the decision card.`,
+    surfaces: ['decision-card'],
+    rationale:
+      'spec-247 dec-2 / ac-10: the decision card\'s "Ask for more ' +
+      'explanation" affordance. Seeded into the in-app spec assistant (the ' +
+      'opening-turn delivery mode) with the decision pre-scoped via context ' +
+      'chip. Explanation only — the prompt explicitly forbids resolving, so ' +
+      'the agent never answers on the answering path (dec-1: the option row ' +
+      'is the only answering affordance).',
+  },
 ];
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/packages/shared/src/tool-manifest.ts
+++ b/packages/shared/src/tool-manifest.ts
@@ -257,8 +257,8 @@ export const toolManifest: ToolManifestEntry[] = [
   {
     name: 'resolve_decision',
     summary:
-      'Resolve a decision with an explanation; may unblock waiting tasks. chosenOptionIndex marks a structured option.',
-    args: 'resolve_decision(ref, resolution, chosenOptionIndex?)',
+      'Resolve a decision; may unblock waiting tasks. chosenOptionIndex marks a structured option — resolution is then optional (defaults to its label). Re-resolving updates the choice in place.',
+    args: 'resolve_decision(ref, resolution?, chosenOptionIndex?)',
     group: 'planning',
     readOnlyHint: false,
     trafficClass: 'specify',

--- a/packages/ui/e2e/journey-14-candidate-decision.spec.ts
+++ b/packages/ui/e2e/journey-14-candidate-decision.spec.ts
@@ -5,12 +5,15 @@ import {
   queueAnthropicResponse,
 } from "./helpers/anthropic-fake.js";
 
-// Journey 14 (t-19 W5): Candidate decision approve/reject (covers t-16). The
-// agent extracts a decision via propose_decision; the UI shows the candidate
-// with options; the user clicks Approve; status flips to open and the panel
-// updates live via SSE.
+// Journey 14 (t-19 W5, rewritten under spec-247 dec-6): the candidate-decision
+// flow. The agent extracts a decision via create_decision(status:'candidate');
+// the UI shows the candidate VIEW-ONLY — options render as information (no
+// radios), there are no web Approve/Reject controls, and the card list carries
+// the coding-agent boundary marker (ac-20 / ac-21). Approval happens
+// agent-side (approve_candidate over the shared tool catalog); the panel
+// updates live via SSE when it does.
 
-test("agent proposes a candidate decision, user approves, status flips to open", async ({
+test("candidate decisions are view-only on the web; approval happens agent-side and the panel updates live", async ({
   page,
   resources,
 }) => {
@@ -63,31 +66,56 @@ test("agent proposes a candidate decision, user approves, status flips to open",
 
   await sendChat(page, "postgres or dynamodb for the catalog?");
 
-  // Two messages stream into the chat (user prompt + agent reply); the
-  // assistant's reply is the last chat-markdown node.
   await expect(page.getByTestId("chat-markdown").last()).toHaveText(/Candidate filed/i, {
     timeout: 15_000,
   });
 
-  // Open the Decisions & ACs sub-tab (the plan/Specify phase's second sub-tab,
-  // post spec-164 phase-tab redesign — was a bare "Decisions" tab pre-rebase).
-  // Rendered as a <button> by Tabs, not the ARIA `tab` role.
+  // Open the Decisions & ACs sub-tab and the Candidates sub-tab.
   await page.getByRole("button", { name: /^Decisions & ACs$/i }).click();
-
-  // DecisionPanel's `activeTab` initialises before the SSE-driven decisions
-  // refetch lands, so when the candidate arrives after the first paint the
-  // panel may still be on Open. Click into the Candidates sub-tab explicitly.
   await page.getByRole("button", { name: /^Candidates 1$/i }).click();
 
-  // Approve the candidate. Per t-16 the Approve button has data-testid="candidate-approve".
-  await page.getByTestId("candidate-approve").click();
+  const panel = page.getByTestId("decision-panel");
 
-  // The approval flips the decision candidate → open. The DecisionPanel re-fetches
-  // on the SSE `decision updated` event and auto-switches to the Open tab; the
-  // decision now renders there. The old raw-SQL status poll is dropped (the e2e
-  // package has no Postgres dependency, dec-2) — the UI surfacing the decision
-  // under Open is the server-backed proof the status flipped (the panel reads the
-  // API, not local state).
+  // spec-247 ac-20 — view-only: the options render as information…
+  await expect(panel.getByText("Postgres")).toBeVisible({ timeout: 15_000 });
+  await expect(panel.getByText(/Familiar; SQL/)).toBeVisible();
+  // …with NO selectable radios and NO web approval controls.
+  await expect(panel.getByRole("radio")).toHaveCount(0);
+  await expect(panel.getByTestId("candidate-approve")).toHaveCount(0);
+  await expect(panel.getByTestId("candidate-reject")).toHaveCount(0);
+
+  // spec-247 ac-21 — the boundary marker says where approval DOES happen.
+  const marker = panel.getByTestId("candidate-mcp-marker");
+  await expect(marker).toBeVisible();
+  await expect(marker).toContainText(/Review the candidate decisions/);
+  await expect(marker).toContainText(/not in the browser/i);
+
+  // Approval happens agent-side: the spec assistant (same tool catalog as the
+  // MCP coding agents, spec-14 dec-4) calls approve_candidate; the panel
+  // refetches on the SSE `decision updated` event and the decision surfaces
+  // under Open — the server-backed proof the status flipped.
+  await clearAnthropicQueue();
+  await queueAnthropicResponse({
+    textDeltas: ["Approving."],
+    content: [
+      { type: "text", text: "Approving." },
+      {
+        type: "tool_use",
+        id: "toolu_j14_appr",
+        name: "approve_candidate",
+        input: { ref: `${docRef}/decisions/dec-1` },
+      },
+    ],
+    stopReason: "tool_use",
+  });
+  await queueAnthropicResponse({
+    textDeltas: ["Approved — it's an open decision now."],
+    content: [{ type: "text", text: "Approved — it's an open decision now." }],
+    stopReason: "end_turn",
+  });
+
+  await sendChat(page, "yes, that's a real decision — approve it");
+
   await expect(page.getByRole("button", { name: /^Open 1$/i })).toBeVisible({
     timeout: 15_000,
   });

--- a/packages/ui/e2e/journey-19-lifecycle-spine.spec.ts
+++ b/packages/ui/e2e/journey-19-lifecycle-spine.spec.ts
@@ -185,18 +185,12 @@ test("lifecycle spine: org → memex → Spec → resolve decision → phase mov
   // Open the Decisions & ACs sub-tab (sub-tabs render as <button> with the label).
   await page.getByRole("button", { name: /Decisions & ACs/ }).click();
   // DecisionPanel defaults to the Open tab when no candidates exist; the seeded
-  // decision arrives over SSE. Pick option 0, open the resolve tray, write a
-  // rationale, and save.
+  // decision arrives over SSE. spec-247 dec-1/dec-5: picking an option IS the
+  // answer — the click persists immediately (no Resolve button, no rationale).
   const panel = page.getByTestId("decision-panel");
   await expect(panel).toContainText(/Pick the spine's datastore/, { timeout: 15_000 });
 
   await panel.getByTestId("open-option-0").first().check();
-  await panel.getByTestId("decision-resolve").first().click();
-  await panel
-    .getByTestId("open-resolution-text")
-    .first()
-    .fill("Postgres — it matches the rest of the stack.");
-  await panel.getByTestId("open-resolve-confirm").first().click();
 
   // Resolved: the decision moves to the Resolved tray. The specify→Build Decisions
   // blocker is now satisfied — but ACs still aren't created, so the Rubicon

--- a/packages/ui/e2e/journey-21-spec-196-narrative.spec.ts
+++ b/packages/ui/e2e/journey-21-spec-196-narrative.spec.ts
@@ -122,10 +122,9 @@ test("specify→build gate: stale narrative blocks the offer; consolidation rest
   await page.getByRole("button", { name: /Decisions & ACs/ }).click();
   const panel = page.getByTestId("decision-panel");
   await expect(panel).toContainText(/Pick the gate's colour/, { timeout: 15_000 });
+  // spec-247 dec-1/dec-5: picking an option IS the answer — the click persists
+  // immediately (no Resolve button, no rationale step).
   await panel.getByTestId("open-option-1").first().check();
-  await panel.getByTestId("decision-resolve").first().click();
-  await panel.getByTestId("open-resolution-text").first().fill("Green — we're confident.");
-  await panel.getByTestId("open-resolve-confirm").first().click();
   await expect(panel.getByRole("button", { name: /^Resolved 1$/ })).toBeVisible({
     timeout: 15_000,
   });

--- a/packages/ui/e2e/journey-27-spec-247-decision-surfaces.spec.ts
+++ b/packages/ui/e2e/journey-27-spec-247-decision-surfaces.spec.ts
@@ -1,10 +1,34 @@
-import { test, expect, tenantPath, switchToEditing } from "./helpers/index.js";
+import {
+  test,
+  expect,
+  tenantPath,
+  switchToEditing,
+  emitAcEvents,
+} from "./helpers/index.js";
 import {
   seedOrgTenant,
   seedSpec,
   setDocStatus,
   seedOpenDecision,
 } from "./helpers/retained.js";
+
+// The ACs this end-to-end journey genuinely exercises against the running app.
+// Behaviour units (DecisionPanel/ChatPanel) also cover ac-6/7/9/11/12; the
+// reload-survival path (ac-18, ac-22) and the scope-level "one obvious place /
+// honest labels / grounded panel" outcomes (ac-1, ac-2, ac-3) have NO other
+// verifying test — this journey is their only proof, so it must emit.
+const AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-247/acs/ac-${n}`;
+const ACS = [1, 2, 3, 6, 7, 9, 11, 12, 18, 22].map(AC);
+
+test.afterEach(async ({}, testInfo) => {
+  await emitAcEvents(
+    ACS,
+    testInfo.status === "passed" ? "pass" : "fail",
+    `packages/ui/e2e/journey-27-spec-247-decision-surfaces.spec.ts::${testInfo.title}`,
+    testInfo.duration,
+  );
+});
 
 // Journey 27 — spec-247: resolving a decision has ONE obvious place to answer.
 //

--- a/packages/ui/e2e/journey-27-spec-247-decision-surfaces.spec.ts
+++ b/packages/ui/e2e/journey-27-spec-247-decision-surfaces.spec.ts
@@ -1,0 +1,104 @@
+import { test, expect, tenantPath, switchToEditing } from "./helpers/index.js";
+import {
+  seedOrgTenant,
+  seedSpec,
+  setDocStatus,
+  seedOpenDecision,
+} from "./helpers/retained.js";
+
+// Journey 27 — spec-247: resolving a decision has ONE obvious place to answer.
+//
+//   • The open-decision card carries NO CTA button and NO inline comment box —
+//     the option rows are the only answering affordance (ac-6, ac-9).
+//   • Clicking an option records the answer immediately and it SURVIVES a full
+//     page reload — the prod failure (answers silently dropped on navigation)
+//     is unreproducible (ac-7, ac-18, ac-22).
+//   • Re-selecting a different option on the resolved card updates the choice
+//     in place (ac-7).
+//   • Discussion sits behind a labelled toggle that says it never resolves
+//     anything (ac-9).
+//   • The left panel introduces itself as the Spec assistant and discloses
+//     its grounding without any interaction (ac-11, ac-12).
+
+test("answer-by-click persists across reload, re-select updates, discussion is toggled, assistant discloses grounding", async ({
+  page,
+  resources,
+}) => {
+  const slug = resources.slug("j27");
+  const tenant = await seedOrgTenant({ slug });
+  const seeded = await seedSpec({
+    memexId: tenant.memexId,
+    title: "Decision Surface Spec",
+    purpose: "Exercise the one-obvious-place-to-answer surface.",
+  });
+  await setDocStatus({ memexId: tenant.memexId, docId: seeded.docId, status: "specify" });
+  await seedOpenDecision({
+    memexId: tenant.memexId,
+    docId: seeded.docId,
+    title: "Pick the cache layer",
+    context: "Two options on the table.",
+    options: [
+      { label: "Redis", trade_offs: "Battle-tested; another box." },
+      { label: "In-process LRU", trade_offs: "Zero-ops; per-instance only." },
+    ],
+  });
+
+  await page.goto(
+    tenantPath(tenant.namespaceSlug, tenant.memexSlug, `/specs/${seeded.handle}`)
+  );
+
+  // ── The assistant names itself and discloses grounding (ac-11 / ac-12) ──
+  await expect(page.getByText("Spec assistant")).toBeVisible({ timeout: 15_000 });
+  await expect(page.getByText("Private Agent")).toHaveCount(0);
+  const grounding = page.getByTestId("chat-grounding-line");
+  await expect(grounding).toBeVisible();
+  await expect(grounding).toContainText(/Hasn't read your code/);
+  await expect(
+    grounding.getByRole("link", { name: /connect a coding agent/i })
+  ).toBeVisible();
+
+  await switchToEditing(page);
+
+  // ── The decision card: options only, no CTA, no inline comment box ──
+  await page.getByRole("button", { name: /Decisions & ACs/ }).click();
+  const panel = page.getByTestId("decision-panel");
+  await expect(panel).toContainText(/Pick the cache layer/, { timeout: 15_000 });
+
+  await expect(panel.getByTestId("decision-resolve")).toHaveCount(0);
+  await expect(panel.getByRole("button", { name: /^Resolve$/ })).toHaveCount(0);
+  await expect(panel.getByTestId("comment-textarea")).toHaveCount(0);
+  await expect(panel.getByTestId("persist-on-select-hint")).toContainText(
+    /records your answer/i
+  );
+
+  // Discussion is reachable but collapsed, and labelled as never resolving.
+  await panel.getByTestId("decision-discussion-toggle").first().click();
+  await expect(panel.getByTestId("discussion-disclaimer")).toContainText(
+    /never resolve/i
+  );
+  await panel.getByRole("button", { name: /Hide discussion/ }).click();
+
+  // ── Answer by clicking an option — that IS the resolution ──
+  await panel.getByTestId("open-option-1").first().check();
+  await expect(panel.getByRole("button", { name: /^Resolved 1$/ })).toBeVisible({
+    timeout: 15_000,
+  });
+
+  // ── The answer survives a full reload (the agent-craft prod scenario) ──
+  await page.reload();
+  await page.getByRole("button", { name: /Decisions & ACs/ }).click();
+  const panelAfter = page.getByTestId("decision-panel");
+  await expect(panelAfter.getByRole("button", { name: /^Resolved 1$/ })).toBeVisible({
+    timeout: 15_000,
+  });
+  await panelAfter.getByRole("button", { name: /^Resolved 1$/ }).click();
+  await expect(panelAfter).toContainText(/Chose:/, { timeout: 15_000 });
+  await expect(panelAfter).toContainText(/In-process LRU/);
+
+  // ── Re-select: a different option click updates the recorded choice ──
+  await panelAfter.getByText("Context", { exact: true }).first().click();
+  await panelAfter.getByTestId("resolved-option-0").first().check();
+  await expect(panelAfter.getByText(/Chose:/).locator("..")).toContainText("Redis", {
+    timeout: 15_000,
+  });
+});

--- a/packages/ui/src/api/client.ts
+++ b/packages/ui/src/api/client.ts
@@ -723,15 +723,18 @@ export async function createDecision(docId: string, title: string): Promise<Deci
 /**
  * Resolve a decision. When the decision carries `options[]`, pass
  * `chosenOptionIndex` to record which option was selected — the server
- * persists it on the row (per t-5 / dec-8). Omit the index for free-text
- * resolutions on decisions without options.
+ * persists it on the row (per t-5 / dec-8). `resolution` is optional when an
+ * index is supplied (spec-247 dec-5: persist-on-select — the server defaults
+ * the prose to the chosen option's label). Re-resolving an already-resolved
+ * decision updates the choice in place.
  */
 export async function resolveDecisionApi(
   id: string,
-  resolution: string,
+  resolution?: string,
   chosenOptionIndex?: number,
 ): Promise<Decision> {
-  const body: { resolution: string; chosenOptionIndex?: number } = { resolution };
+  const body: { resolution?: string; chosenOptionIndex?: number } = {};
+  if (resolution !== undefined) body.resolution = resolution;
   if (chosenOptionIndex !== undefined) body.chosenOptionIndex = chosenOptionIndex;
   const res = await fetchWithRetry(`${tBase()}/decisions/${id}/resolve`, {
     method: 'POST',

--- a/packages/ui/src/components/AcPanel.test.tsx
+++ b/packages/ui/src/components/AcPanel.test.tsx
@@ -601,8 +601,11 @@ describe('AcPanel — coding-agent boundary markers (spec-247)', () => {
     url: 'https://memex.ai/acme/main/specs/spec-1',
   };
 
-  it('the all-untested explainer is human-actionable and hands off via the Wire-the-AC-tests PromptButton (ac-14)', async () => {
+  it('the all-untested explainer is human-actionable and hands off via the Wire-the-AC-tests PromptButton (ac-14, ac-4)', async () => {
     tagAc(AC247(14));
+    // ac-4 (scope): this AC coverage rail is the named starting surface for the
+    // "every MCP-only next step carries a coding-agent handoff marker" rule.
+    tagAc(AC247(4));
     vi.mocked(fetchAcsForBrief).mockResolvedValue([
       makeAc(1, 'scope', 'untested'),
       makeAc(2, 'implementation', 'untested'),
@@ -641,8 +644,9 @@ describe('AcPanel — coding-agent boundary markers (spec-247)', () => {
     expect(dialog.textContent).toMatch(/acme\/main\/specs\/spec-1/);
   });
 
-  it('a partially-covered panel still offers the handoff for the uncovered ACs (ac-14)', async () => {
+  it('a partially-covered panel still offers the handoff for the uncovered ACs (ac-14, ac-4)', async () => {
     tagAc(AC247(14));
+    tagAc(AC247(4));
     vi.mocked(fetchAcsForBrief).mockResolvedValue([
       makeAc(1, 'scope', 'verified'),
       makeAc(2, 'implementation', 'untested'),

--- a/packages/ui/src/components/AcPanel.test.tsx
+++ b/packages/ui/src/components/AcPanel.test.tsx
@@ -589,3 +589,96 @@ describe('AcPanel — draft-phase gating (spec-164)', () => {
     expect(screen.queryByTestId('ac-draft-directive')).not.toBeInTheDocument();
   });
 });
+
+// ── spec-247 dec-4: the web↔MCP boundary markers on the AC surfaces ─────────
+describe('AcPanel — coding-agent boundary markers (spec-247)', () => {
+  const AC247 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-247/acs/ac-${n}`;
+  const PROMPT_CONTEXT = {
+    namespace: 'acme',
+    memex: 'main',
+    handle: 'spec-1',
+    title: 'A Spec',
+    url: 'https://memex.ai/acme/main/specs/spec-1',
+  };
+
+  it('the all-untested explainer is human-actionable and hands off via the Wire-the-AC-tests PromptButton (ac-14)', async () => {
+    tagAc(AC247(14));
+    vi.mocked(fetchAcsForBrief).mockResolvedValue([
+      makeAc(1, 'scope', 'untested'),
+      makeAc(2, 'implementation', 'untested'),
+    ]);
+    vi.mocked(fetchAcAlignmentHistory).mockResolvedValue([]);
+
+    render(<AcPanel docId="doc-1" promptContext={PROMPT_CONTEXT} />);
+
+    const copy = await screen.findByTestId('ac-untested-copy');
+    // No MCP tool names at the human — that mention moved into the prompt.
+    expect(copy.textContent).not.toMatch(/get_information/);
+    expect(copy.textContent).toMatch(/coding agent/i);
+
+    const marker = screen.getByTestId('ac-wire-tests-marker');
+    expect(
+      within(marker).getByRole('button', { name: /Wire the AC tests/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('the action-first link opens the handoff dialog whose prompt carries the MCP steps (ac-15)', async () => {
+    tagAc(AC247(15));
+    const user = userEvent.setup();
+    vi.mocked(fetchAcsForBrief).mockResolvedValue([makeAc(1, 'scope', 'untested')]);
+    vi.mocked(fetchAcAlignmentHistory).mockResolvedValue([]);
+
+    render(<AcPanel docId="doc-1" promptContext={PROMPT_CONTEXT} />);
+
+    const marker = await screen.findByTestId('ac-wire-tests-marker');
+    // The highlighted link text names the ACTION (c-3), not "copy the prompt".
+    await user.click(within(marker).getByRole('button', { name: /Wire the AC tests/i }));
+
+    // The dialog shows the agent-facing prompt — the get_information mention
+    // lives THERE, behind the marker, never on the panel itself.
+    const dialog = await screen.findByRole('dialog');
+    expect(dialog.textContent).toMatch(/get_information\(topic='ac-emission'\)/);
+    expect(dialog.textContent).toMatch(/acme\/main\/specs\/spec-1/);
+  });
+
+  it('a partially-covered panel still offers the handoff for the uncovered ACs (ac-14)', async () => {
+    tagAc(AC247(14));
+    vi.mocked(fetchAcsForBrief).mockResolvedValue([
+      makeAc(1, 'scope', 'verified'),
+      makeAc(2, 'implementation', 'untested'),
+    ]);
+    vi.mocked(fetchAcAlignmentHistory).mockResolvedValue(makeHistory());
+
+    render(<AcPanel docId="doc-1" promptContext={PROMPT_CONTEXT} />);
+
+    const marker = await screen.findByTestId('ac-coverage-marker');
+    expect(marker.textContent).toMatch(/1 AC has no test yet/);
+    expect(
+      within(marker).getByRole('button', { name: /Wire the remaining AC tests/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('without promptContext the markers are simply omitted (isolated render sites)', async () => {
+    vi.mocked(fetchAcsForBrief).mockResolvedValue([makeAc(1, 'scope', 'untested')]);
+    vi.mocked(fetchAcAlignmentHistory).mockResolvedValue([]);
+
+    render(<AcPanel docId="doc-1" />);
+
+    await screen.findByTestId('ac-untested-copy');
+    expect(screen.queryByTestId('ac-wire-tests-marker')).not.toBeInTheDocument();
+  });
+
+  it('"Mark as accepted" is visually marked as the human action beside test-fed states (ac-14)', async () => {
+    tagAc(AC247(14));
+    vi.mocked(fetchAcsForBrief).mockResolvedValue([makeAc(1, 'scope', 'verified')]);
+    vi.mocked(fetchAcAlignmentHistory).mockResolvedValue(makeHistory());
+
+    render(<AcPanel docId="doc-1" promptContext={PROMPT_CONTEXT} />);
+
+    const accept = await screen.findByTestId('ac-accept-button');
+    expect(accept.getAttribute('title')).toMatch(/Human action/i);
+    expect(accept.getAttribute('title')).toMatch(/coding agent/i);
+    // The person glyph marks the human-side affordance.
+    expect(accept.querySelector('svg')).not.toBeNull();
+  });
+});

--- a/packages/ui/src/components/AcPanel.tsx
+++ b/packages/ui/src/components/AcPanel.tsx
@@ -41,8 +41,10 @@ import { useChat } from './ChatContext';
 import { AcSparkline } from './AcSparkline';
 import { AcAboutDialog } from './AcAboutDialog';
 import { AcMatrixCollapsible } from './AcMatrixCollapsible';
+import { PromptButton } from './PromptButton';
 import { phaseDisplayName } from '../utils/phaseDisplay';
 import { Metric, type BarSegment } from './MetricBar';
+import type { GuidanceBlock } from '@memex/shared';
 
 interface AcPanelProps {
   docId: string;
@@ -59,6 +61,15 @@ interface AcPanelProps {
    * zero-AC teaching card. ACs that already exist always render.
    */
   specPhase?: string;
+  /**
+   * spec-247 dec-4: interpolation context ({namespace}/{memex}/{handle}/…) for
+   * the "Wire the AC tests" boundary PromptButton. Wiring tests is
+   * coding-agent work; the panel hands off instead of naming MCP tools at the
+   * human. Absent (isolated tests), the marker is omitted.
+   */
+  promptContext?: Record<string, unknown>;
+  /** Org scaffold appends threaded into toButtonPrompt (spec-159 ac-17). */
+  orgBlocks?: readonly GuidanceBlock[];
 }
 
 const POLL_INTERVAL_MS = 3_000;
@@ -149,9 +160,13 @@ function mergeAlignmentHistory(history: AcAlignmentDay[]): AcAlignmentDay[] {
 function UnifiedAcHeader({
   rows,
   history,
+  promptContext,
+  orgBlocks,
 }: {
   rows: AcWithVerification[];
   history: AcAlignmentDay[];
+  promptContext?: Record<string, unknown>;
+  orgBlocks?: readonly GuidanceBlock[];
 }) {
   const verified = rows.filter((r) => r.verificationState === 'verified');
   const failing = rows.filter((r) => r.verificationState === 'failing');
@@ -195,16 +210,32 @@ function UnifiedAcHeader({
         // normal starting state right after ACs are committed. Frame it
         // accordingly, encouragingly, so the manager sees the next action
         // (wire up tests) rather than a system breakage.
+        //
+        // spec-247 dec-4 / ac-14: wiring tests is coding-agent work, so the
+        // copy says where it happens and the PromptButton hands it off. The
+        // old copy told the HUMAN to call get_information (an MCP tool) —
+        // that mention now lives inside the prompt, agent-facing.
         <div>
           <div className="text-2xl font-semibold text-amber-600 dark:text-amber-400 mb-1">
             {total} committed · 0 covered
           </div>
-          <p className="text-sm text-body">
+          <p data-testid="ac-untested-copy" className="text-sm text-body">
             ACs are written but no test yet asserts any of them. This is the
-            normal starting state — the next step is wiring tests in the
-            codebase to each AC. Ask the embedded agent for help, or consult
-            the <code>ac-emission</code> topic via <code>get_information</code>.
+            normal starting state — the next step is wiring tests to each AC,
+            and that happens from your coding agent, not in the browser.
           </p>
+          {promptContext && (
+            <div data-testid="ac-wire-tests-marker" className="mt-2">
+              <PromptButton
+                buttonId="wire-ac-tests"
+                context={promptContext}
+                orgBlocks={orgBlocks}
+                linkText="Wire the AC tests"
+                sentence="— copy this prompt into your coding agent to connect each AC to a real test."
+                sentenceLabel="Wire the AC tests — copy this prompt into your coding agent to connect each AC to a real test."
+              />
+            </div>
+          )}
         </div>
       ) : (
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-5">
@@ -254,6 +285,21 @@ function UnifiedAcHeader({
             extra={
               lastVerified ? `last verified ${relativeTime(lastVerified)}` : undefined
             }
+          />
+        </div>
+      )}
+      {/* spec-247 dec-4 / ac-14: the partially-covered state still has an
+          MCP-only next step (the uncovered ACs need tests wired) — same
+          handoff, scoped to the gap. */}
+      {!allUntested && untested.length > 0 && promptContext && (
+        <div data-testid="ac-coverage-marker" className="mt-3">
+          <PromptButton
+            buttonId="wire-ac-tests"
+            context={promptContext}
+            orgBlocks={orgBlocks}
+            linkText="Wire the remaining AC tests"
+            sentence={`— ${untested.length} AC${untested.length === 1 ? ' has' : 's have'} no test yet; copy this prompt into your coding agent.`}
+            sentenceLabel="Wire the remaining AC tests — copy this prompt into your coding agent."
           />
         </div>
       )}
@@ -450,6 +496,10 @@ function AcAcceptToggle({
 
   return (
     <div className="mt-2 shrink-0 text-right">
+      {/* spec-247 dec-4 / ac-14: this is the one HUMAN-clickable state change
+          on an AC row — everything else (verified / failing / stale) is fed by
+          tests from the coding agent and can't be changed here. The person
+          glyph marks the boundary visually; the title says it in words. */}
       <button
         type="button"
         onClick={() => void handleClick()}
@@ -457,11 +507,24 @@ function AcAcceptToggle({
         data-testid={hasAcceptance ? 'ac-unaccept-button' : 'ac-accept-button'}
         title={
           hasAcceptance
-            ? 'Revoke the manual acceptance and restore the test-derived state'
-            : "Record a human acceptance for a criterion a digital test can't verify"
+            ? 'Human action: revoke the manual acceptance and restore the test-derived state (test states themselves are set by tests from your coding agent)'
+            : "Human action: record an acceptance for a criterion a digital test can't verify. Test-derived states (verified / failing / stale) are set by tests from your coding agent, not here."
         }
-        className="text-xs text-sky-600 dark:text-sky-400 hover:underline disabled:opacity-50"
+        className="inline-flex items-center gap-1 text-xs text-sky-600 dark:text-sky-400 hover:underline disabled:opacity-50"
       >
+        <svg
+          className="w-3 h-3"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={2}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2" />
+          <circle cx="12" cy="7" r="4" />
+        </svg>
         {busy ? '…' : hasAcceptance ? 'Un-accept' : 'Mark as accepted'}
       </button>
       {error && (
@@ -540,7 +603,7 @@ function AcRowMeta({
   );
 }
 
-export function AcPanel({ docId, focusedAcId, onFocusConsumed, specPhase }: AcPanelProps) {
+export function AcPanel({ docId, focusedAcId, onFocusConsumed, specPhase, promptContext, orgBlocks }: AcPanelProps) {
   const [rows, setRows] = useState<AcWithVerification[] | null>(null);
   const [history, setHistory] = useState<AcAlignmentDay[]>([]);
   const [error, setError] = useState<string | null>(null);
@@ -814,7 +877,12 @@ export function AcPanel({ docId, focusedAcId, onFocusConsumed, specPhase }: AcPa
         </div>
       )}
 
-      <UnifiedAcHeader rows={rows} history={mergeAlignmentHistory(history)} />
+      <UnifiedAcHeader
+        rows={rows}
+        history={mergeAlignmentHistory(history)}
+        promptContext={promptContext}
+        orgBlocks={orgBlocks}
+      />
       <UnifiedAcList
         rows={rows}
         onInvestigate={handleInvestigate}

--- a/packages/ui/src/components/ChatPanel.spec-111.test.tsx
+++ b/packages/ui/src/components/ChatPanel.spec-111.test.tsx
@@ -1,7 +1,14 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render as rtlRender, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import type { ReactElement } from 'react';
 import { tagAc } from "@memex-ai-ac/vitest";
 import { ChatPanel } from './ChatPanel';
+
+// spec-247: the grounding line's "connect a coding agent" link needs a router.
+function render(ui: ReactElement) {
+  return rtlRender(<MemoryRouter>{ui}</MemoryRouter>);
+}
 import type { ChatMessage } from '../api/types';
 
 // spec-111 t-9 — agent panel access states (dec-2):
@@ -90,9 +97,9 @@ describe('ChatPanel access states (spec-111 t-9)', () => {
 
       // No sign-in placeholder — the agent is active.
       expect(screen.queryByTestId('chat-signin-placeholder')).not.toBeInTheDocument();
-      // Header is the standardized "Private Agent"; read-only is surfaced by the
+      // Header is the standardized "Spec assistant" (spec-247 dec-3); read-only is surfaced by the
       // banner (not the header), so this state still reads as read-only.
-      expect(screen.getByText('Private Agent')).toBeInTheDocument();
+      expect(screen.getByText('Spec assistant')).toBeInTheDocument();
       expect(screen.getByTestId('chat-readonly-banner')).toBeInTheDocument();
       // The agent still works — input + send are present and enabled
       // (reads/questions succeed; mutations are blocked server-side by t-4).
@@ -109,7 +116,7 @@ describe('ChatPanel access states (spec-111 t-9)', () => {
 
       expect(screen.queryByTestId('chat-signin-placeholder')).not.toBeInTheDocument();
       expect(screen.queryByTestId('chat-readonly-banner')).not.toBeInTheDocument();
-      expect(screen.getByText('Private Agent')).toBeInTheDocument();
+      expect(screen.getByText('Spec assistant')).toBeInTheDocument();
       expect(screen.getByTestId('chat-input')).toBeInTheDocument();
     });
   });

--- a/packages/ui/src/components/ChatPanel.test.tsx
+++ b/packages/ui/src/components/ChatPanel.test.tsx
@@ -208,6 +208,7 @@ describe('ChatPanel — Spec assistant naming + grounding (spec-247)', () => {
     const line = screen.getByTestId('chat-grounding-line');
     expect(line).toHaveTextContent(/Works on this spec/);
     expect(line).toHaveTextContent(/Hasn't read your code/);
+    expect(line).toHaveTextContent(/over MCP/);
     const link = within(line).getByRole('link', { name: /connect a coding agent/i });
     expect(link).toHaveAttribute('href', '/settings/integrations');
   });

--- a/packages/ui/src/components/ChatPanel.test.tsx
+++ b/packages/ui/src/components/ChatPanel.test.tsx
@@ -1,9 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render as rtlRender, screen, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import userEvent from '@testing-library/user-event';
 import { tagAc } from '@memex-ai-ac/vitest';
-import { ChatPanel } from './ChatPanel';
+import { ChatPanel, makesCodeShapedClaims } from './ChatPanel';
 import type { ChatMessage } from '../api/types';
+import type { ReactElement } from 'react';
 
 // Mock useChat to control ChatPanel state
 const mockSendMessage = vi.fn();
@@ -47,6 +49,11 @@ vi.mock('./chat/ui-tools', () => ({
   UiToolRenderer: ({ toolName }: { toolName: string }) => <div data-testid="ui-tool">{toolName}</div>,
 }));
 
+// The grounding line's "connect a coding agent" link needs a router context.
+function render(ui: ReactElement) {
+  return rtlRender(<MemoryRouter>{ui}</MemoryRouter>);
+}
+
 describe('ChatPanel', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -69,7 +76,11 @@ describe('ChatPanel', () => {
 
     mockChatState.docId = null;
     mockChatState.contextChips = [];
-    rerender(<ChatPanel />);
+    rerender(
+      <MemoryRouter>
+        <ChatPanel />
+      </MemoryRouter>,
+    );
     expect(screen.getByText('Open a Spec to start chatting')).toBeInTheDocument();
   });
 
@@ -145,7 +156,93 @@ describe('ChatPanel', () => {
 
     // Stop streaming
     mockChatState.isStreaming = false;
-    rerender(<ChatPanel />);
+    rerender(
+      <MemoryRouter>
+        <ChatPanel />
+      </MemoryRouter>,
+    );
     expect(screen.queryByTitle('Stop generating')).not.toBeInTheDocument();
+  });
+});
+
+// ── spec-247 dec-3: the assistant names itself and discloses its grounding ──
+describe('ChatPanel — Spec assistant naming + grounding (spec-247)', () => {
+  const AC247 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-247/acs/ac-${n}`;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockChatState = {
+      messages: [],
+      isStreaming: false,
+      error: null,
+      docId: 'doc-1',
+      doc: null,
+      openCommentCount: 0,
+      contextChips: [],
+      respondedToolIds: new Set(),
+      isDriftMode: false,
+    };
+  });
+
+  it('the header reads "Spec assistant · private chat" and "Private Agent" is gone (ac-11)', () => {
+    tagAc(AC247(11));
+    render(<ChatPanel />);
+
+    expect(screen.getByText('Spec assistant')).toBeInTheDocument();
+    expect(screen.getByText(/private chat/)).toBeInTheDocument();
+    expect(screen.queryByText('Private Agent')).not.toBeInTheDocument();
+  });
+
+  it('the signed-out placeholder uses the same heading — no "Private Agent" anywhere (ac-11)', () => {
+    tagAc(AC247(11));
+    render(<ChatPanel isAuthenticated={false} />);
+
+    expect(screen.getByText('Spec assistant')).toBeInTheDocument();
+    expect(screen.queryByText('Private Agent')).not.toBeInTheDocument();
+  });
+
+  it('a permanent grounding line is visible without interaction and links to the connect flow (ac-12)', () => {
+    tagAc(AC247(12));
+    render(<ChatPanel />);
+
+    const line = screen.getByTestId('chat-grounding-line');
+    expect(line).toHaveTextContent(/Works on this spec/);
+    expect(line).toHaveTextContent(/Hasn't read your code/);
+    const link = within(line).getByRole('link', { name: /connect a coding agent/i });
+    expect(link).toHaveAttribute('href', '/settings/integrations');
+  });
+
+  it('code-shaped assistant output carries an adjacent grounding disclosure (ac-13)', () => {
+    tagAc(AC247(13));
+    mockChatState.messages = [
+      {
+        id: '1',
+        role: 'assistant',
+        content: 'You should change `packages/server/src/services/decisions.ts` at the resolve guard.',
+        timestamp: new Date(),
+      },
+      {
+        id: '2',
+        role: 'assistant',
+        content: 'Sounds good — let me know if you want anything else.',
+        timestamp: new Date(),
+      },
+    ];
+
+    render(<ChatPanel />);
+
+    // Exactly one disclosure: adjacent to the code-shaped message only.
+    const disclosures = screen.getAllByTestId('code-claim-disclosure');
+    expect(disclosures).toHaveLength(1);
+    expect(disclosures[0]).toHaveTextContent(/hasn't read your code/i);
+  });
+
+  it('makesCodeShapedClaims: code fences, file paths and implementation-AC talk trigger; prose does not (ac-13)', () => {
+    tagAc(AC247(13));
+    expect(makesCodeShapedClaims('Here:\n```ts\nconst a = 1;\n```')).toBe(true);
+    expect(makesCodeShapedClaims('Edit src/components/AcPanel.tsx please')).toBe(true);
+    expect(makesCodeShapedClaims('The file decisions.ts holds the guard')).toBe(true);
+    expect(makesCodeShapedClaims('I created three implementation ACs for this decision')).toBe(true);
+    expect(makesCodeShapedClaims('The overview section could be clearer about scope.')).toBe(false);
   });
 });

--- a/packages/ui/src/components/ChatPanel.tsx
+++ b/packages/ui/src/components/ChatPanel.tsx
@@ -49,14 +49,14 @@ function GroundingLine() {
       data-testid="chat-grounding-line"
       className="flex-none px-4 py-1.5 border-b border-edge text-[11px] leading-snug text-muted"
     >
-      Works on this spec. Hasn't read your code —{' '}
+      Works on this spec. Hasn't read your code.{' '}
       <Link
         to="/settings/integrations"
         className="underline underline-offset-2 hover:text-primary"
       >
-        connect a coding agent
+        Connect a coding agent
       </Link>{' '}
-      for code-grounded answers.
+      over MCP for code-grounded answers.
     </div>
   );
 }

--- a/packages/ui/src/components/ChatPanel.tsx
+++ b/packages/ui/src/components/ChatPanel.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect, type KeyboardEvent } from 'react';
+import { Link } from 'react-router-dom';
 import { useChat } from './ChatContext';
 import { ChatMarkdown } from './chat/ChatMarkdown';
 import { ContextChipBar } from './chat/ContextChipBar';
@@ -24,6 +25,54 @@ export interface ChatPanelProps {
   isAuthenticated?: boolean;
   /** True → signed-in non-member; agent runs read-only. Default false. */
   readOnly?: boolean;
+}
+
+// spec-247 dec-3 (ac-11): the panel header. "Spec assistant" names the job;
+// the "private chat" qualifier keeps the old name's privacy connotation.
+function AssistantHeading() {
+  return (
+    <h3 className="text-sm font-medium text-secondary">
+      Spec assistant{' '}
+      <span className="text-xs font-normal text-muted">· private chat</span>
+    </h3>
+  );
+}
+
+// spec-247 dec-3 (ac-12): the permanent grounding line — visible without any
+// interaction, under the header. Discloses GROUNDING, not capability (the web
+// agent shares the MCP tool catalog per spec-14 dec-4): it works on this spec
+// and has not read the user's code; code-grounded answers come from a
+// connected coding agent (the spec-201 setup surface).
+function GroundingLine() {
+  return (
+    <div
+      data-testid="chat-grounding-line"
+      className="flex-none px-4 py-1.5 border-b border-edge text-[11px] leading-snug text-muted"
+    >
+      Works on this spec. Hasn't read your code —{' '}
+      <Link
+        to="/settings/integrations"
+        className="underline underline-offset-2 hover:text-primary"
+      >
+        connect a coding agent
+      </Link>{' '}
+      for code-grounded answers.
+    </div>
+  );
+}
+
+// spec-247 dec-3 (ac-13): detect code-shaped claims in assistant output so the
+// grounding disclosure can sit ADJACENT to exactly the messages that make
+// them. Deliberately conservative: fenced code blocks, file-extension paths,
+// or talk of implementation ACs — the moments a reader might take a code claim
+// on authority.
+export function makesCodeShapedClaims(content: string): boolean {
+  if (/```/.test(content)) return true;
+  // A path-like token ending in a code-file extension (src/foo/bar.ts, a.py).
+  if (/\b[\w.-]+(?:\/[\w.-]+)+\.[a-z]{1,8}\b/i.test(content)) return true;
+  if (/\b[\w-]+\.(ts|tsx|js|jsx|mjs|cjs|py|go|rb|java|rs|c|cpp|cs|php|swift|kt|sql|sh|yml|yaml|toml)\b/.test(content)) return true;
+  if (/implementation ac/i.test(content)) return true;
+  return false;
 }
 
 export function ChatPanel({ isAuthenticated = true, readOnly = false }: ChatPanelProps = {}) {
@@ -86,8 +135,9 @@ export function ChatPanel({ isAuthenticated = true, readOnly = false }: ChatPane
     return (
       <div className="flex flex-col h-full bg-surface" data-testid="chat-signin-placeholder">
         <div className="flex-none px-4 py-3 border-b border-edge flex items-center justify-between">
-          <h3 className="text-sm font-medium text-secondary">Private Agent</h3>
+          <AssistantHeading />
         </div>
+        <GroundingLine />
         <div className="flex-1 flex flex-col items-center justify-center px-6 text-center gap-3">
           <p className="text-sm font-medium text-primary">Sign in to chat</p>
           <p className="text-sm text-muted">
@@ -106,7 +156,7 @@ export function ChatPanel({ isAuthenticated = true, readOnly = false }: ChatPane
     <div className="flex flex-col h-full bg-surface">
       {/* Header */}
       <div className="flex-none px-4 py-3 border-b border-edge flex items-center justify-between">
-        <h3 className="text-sm font-medium text-secondary">Private Agent</h3>
+        <AssistantHeading />
         {messages.length > 0 && (
           <button
             onClick={clearChat}
@@ -116,6 +166,7 @@ export function ChatPanel({ isAuthenticated = true, readOnly = false }: ChatPane
           </button>
         )}
       </div>
+      <GroundingLine />
 
       {/* Messages */}
       <div
@@ -167,6 +218,18 @@ export function ChatPanel({ isAuthenticated = true, readOnly = false }: ChatPane
             return (
               <div key={msg.id} className="max-w-[95%]">
                 <ChatMarkdown content={msg.content} />
+                {/* spec-247 dec-3 (ac-13): when the answer makes code-shaped
+                    claims, the grounding disclosure sits next to THAT output,
+                    not only in the header. */}
+                {makesCodeShapedClaims(msg.content) && (
+                  <p
+                    data-testid="code-claim-disclosure"
+                    className="mt-1 text-[11px] italic text-muted"
+                  >
+                    Doc-grounded answer — this assistant hasn't read your code.
+                    Verify code specifics with your coding agent.
+                  </p>
+                )}
               </div>
             );
           }

--- a/packages/ui/src/components/CommentTray.tsx
+++ b/packages/ui/src/components/CommentTray.tsx
@@ -261,12 +261,14 @@ export function CommentBubble({
         )}
       </p>
       <div className="mt-1.5 opacity-0 group-hover:opacity-100 transition-opacity">
+        {/* spec-247: "Resolve" alone reads as resolving the DECISION the
+            comment sits on — name the actual effect. */}
         {!isResolved && onResolve && (
           <button
             onClick={onResolve}
             className="text-xs text-status-success-text hover:text-status-success-text/80 transition-colors"
           >
-            Resolve
+            Resolve Comment
           </button>
         )}
         {isResolved && onUnresolve && (

--- a/packages/ui/src/components/DecisionPanel.test.tsx
+++ b/packages/ui/src/components/DecisionPanel.test.tsx
@@ -409,8 +409,11 @@ describe('DecisionPanel — one obvious place to answer (spec-247)', () => {
     expect(screen.queryByRole('button', { name: /^reject$/i })).not.toBeInTheDocument();
   });
 
-  it('candidate list carries the coding-agent boundary marker (ac-21)', () => {
+  it('candidate list carries the coding-agent boundary marker (ac-21, ac-4)', () => {
     tagAc(AC247(21));
+    // ac-4 (scope): the decision panel is the other named MCP-only surface — its
+    // candidate-review next step carries the coding-agent handoff marker.
+    tagAc(AC247(4));
     const decisions = [
       makeDecision({
         id: 'cand-1',

--- a/packages/ui/src/components/DecisionPanel.test.tsx
+++ b/packages/ui/src/components/DecisionPanel.test.tsx
@@ -365,9 +365,8 @@ describe('DecisionPanel — one obvious place to answer (spec-247)', () => {
     expect(screen.getByTestId('comment-tray-stub')).toBeInTheDocument();
   });
 
-  it('"Ask for more explanation" pre-scopes the assistant to the decision and only explains (ac-10)', async () => {
+  it('the open card offers NO explanation affordance and never messages the agent (ac-10)', () => {
     tagAc(AC247(10));
-    const user = userEvent.setup();
     const decisions = [
       makeDecision({ id: 'open-1', seq: 5, status: 'open', title: 'API?', options: TWO_OPTIONS }),
     ];
@@ -380,19 +379,11 @@ describe('DecisionPanel — one obvious place to answer (spec-247)', () => {
       />,
     );
 
-    await user.click(screen.getByTestId('decision-explain'));
-
-    expect(mockAddContextChip).toHaveBeenCalledWith({
-      type: 'decision',
-      id: 'open-1',
-      label: 'Decision D-5',
-    });
-    expect(mockSendMessage).toHaveBeenCalledTimes(1);
-    const prompt = mockSendMessage.mock.calls[0][0] as string;
-    expect(prompt).toMatch(/Explain decision D-5/);
-    expect(prompt).toMatch(/Do NOT resolve/i);
-    // Explanation never resolves.
-    expect(mockResolveDecisionApi).not.toHaveBeenCalled();
+    // The card is question + context + options + discussion toggle — nothing else.
+    expect(screen.queryByTestId('decision-explain')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /explanation/i })).not.toBeInTheDocument();
+    expect(mockSendMessage).not.toHaveBeenCalled();
+    expect(mockAddContextChip).not.toHaveBeenCalled();
   });
 
   it('candidate cards are view-only: no radios, no Approve, no Reject (ac-20)', () => {
@@ -444,18 +435,16 @@ describe('DecisionPanel — one obvious place to answer (spec-247)', () => {
     expect(marker).toHaveTextContent(/not in the browser/i);
   });
 
-  it('"Add reasoning" on a resolved decision saves optional prose via re-resolve (ac-19)', async () => {
+  it('no reasoning input exists anywhere on a resolved decision — comments are the only web text action (ac-19)', async () => {
     tagAc(AC247(19));
     const user = userEvent.setup();
-    const onUpdate = vi.fn();
-    mockResolveDecisionApi.mockResolvedValue({});
     const decisions = [
       makeDecision({
         id: 'res-1',
         seq: 9,
         status: 'resolved',
         title: 'Auth?',
-        resolution: 'JWT', // equals the chosen option's label → "Add reasoning"
+        resolution: 'JWT',
         options: [
           { label: 'JWT', trade_offs: 'Stateless' },
           { label: 'Sessions', trade_offs: 'Server load' },
@@ -463,23 +452,18 @@ describe('DecisionPanel — one obvious place to answer (spec-247)', () => {
         chosenOptionIndex: 0,
       }),
     ];
-    render(<DecisionPanel docId="doc-1" decisions={decisions} onUpdate={onUpdate} />);
+    render(<DecisionPanel docId="doc-1" decisions={decisions} onUpdate={vi.fn()} />);
 
     await user.click(screen.getByRole('button', { name: /^Resolved/ }));
     await user.click(screen.getByText('Context'));
-    await user.click(screen.getByTestId('decision-add-reasoning'));
-    await user.clear(screen.getByTestId('reasoning-text'));
-    await user.type(screen.getByTestId('reasoning-text'), 'Stateless wins for our edge nodes');
-    await user.click(screen.getByTestId('reasoning-save'));
 
-    await waitFor(() =>
-      expect(mockResolveDecisionApi).toHaveBeenCalledWith(
-        'res-1',
-        'Stateless wins for our edge nodes',
-        0,
-      ),
-    );
-    expect(onUpdate).toHaveBeenCalled();
+    // No reasoning affordance, expanded or otherwise.
+    expect(screen.queryByTestId('decision-add-reasoning')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('reasoning-text')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('reasoning-save')).not.toBeInTheDocument();
+    expect(screen.queryByText(/reasoning/i)).not.toBeInTheDocument();
+    // Re-select (the answering affordance) is still live.
+    expect(screen.getByTestId('resolved-option-0')).toBeInTheDocument();
   });
 });
 

--- a/packages/ui/src/components/DecisionPanel.test.tsx
+++ b/packages/ui/src/components/DecisionPanel.test.tsx
@@ -6,12 +6,11 @@ import type { Decision } from '../api/types';
 import { tagAc } from '@memex-ai-ac/vitest';
 
 const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-118/acs/ac-${n}`;
+const AC247 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-247/acs/ac-${n}`;
 
 const mockAddContextChip = vi.fn();
 const mockSendMessage = vi.fn();
 const mockCreateDecision = vi.fn();
-const mockApproveDecisionApi = vi.fn();
-const mockRejectDecisionApi = vi.fn();
 const mockResolveDecisionApi = vi.fn();
 const mockCreateDecisionComment = vi.fn();
 
@@ -32,8 +31,6 @@ vi.mock('./AuthContext', () => ({
 
 vi.mock('../api/client', () => ({
   createDecision: (...args: unknown[]) => mockCreateDecision(...args),
-  approveDecisionApi: (...args: unknown[]) => mockApproveDecisionApi(...args),
-  rejectDecisionApi: (...args: unknown[]) => mockRejectDecisionApi(...args),
   resolveDecisionApi: (...args: unknown[]) => mockResolveDecisionApi(...args),
   createDecisionComment: (...args: unknown[]) => mockCreateDecisionComment(...args),
 }));
@@ -43,6 +40,14 @@ vi.mock('./CommentTray', () => ({
     <div data-testid="comment-tray-stub" data-target-id={targetId} />
   ),
 }));
+
+const PROMPT_CONTEXT = {
+  namespace: 'acme',
+  memex: 'main',
+  handle: 'spec-1',
+  title: 'A Spec',
+  url: 'https://memex.ai/acme/main/specs/spec-1',
+};
 
 function makeDecision(overrides: Partial<Decision> = {}): Decision {
   return {
@@ -60,6 +65,11 @@ function makeDecision(overrides: Partial<Decision> = {}): Decision {
     ...overrides,
   } as Decision;
 }
+
+const TWO_OPTIONS = [
+  { label: 'REST', trade_offs: 'Simple, well-known' },
+  { label: 'gRPC', trade_offs: 'Faster, harder tooling' },
+];
 
 beforeEach(() => vi.clearAllMocks());
 
@@ -101,12 +111,10 @@ describe('DecisionPanel', () => {
     expect(within(resolvedCard).getAllByText('Use HS256 JWT').length).toBeGreaterThan(0);
   });
 
-  it('a reviewer (canWrite true, canEdit false) sees the decision + its comment tray but no forward-driving controls (ac-9)', () => {
+  it('a reviewer (canWrite true, canEdit false) sees the decision but the option picker is disabled (ac-9)', () => {
     tagAc(AC(9));
-    // A single open decision so the panel defaults to the Open tab and the card
-    // (plus its forward-driving Resolve control) is on screen for a reviewer.
     const decisions = [
-      makeDecision({ id: 'd1', seq: 7, status: 'open', title: 'What stack?' }),
+      makeDecision({ id: 'd1', seq: 7, status: 'open', title: 'What stack?', options: TWO_OPTIONS }),
     ];
     render(
       <DecisionPanel
@@ -120,13 +128,10 @@ describe('DecisionPanel', () => {
 
     // The Spec content is fully readable — the decision card is present…
     expect(screen.getByText('What stack?')).toBeInTheDocument();
-    // …and the comment affordance (a tray) remains available to the reviewer
-    // because comments gate on canWrite, not canEdit.
-    expect(screen.getAllByTestId('comment-tray-stub').length).toBeGreaterThan(0);
-
-    // But the forward-driving control is suppressed: no Resolve on the open
-    // decision.
+    // …but the answering affordance (the option radios) is disabled for a
+    // reviewer, and there is no resolve CTA for anyone (spec-247 dec-1).
     expect(screen.queryByTestId('decision-resolve')).not.toBeInTheDocument();
+    expect((screen.getByTestId('open-option-0') as HTMLInputElement).disabled).toBe(true);
   });
 
   it('counts candidates / open / resolved in the header', () => {
@@ -146,32 +151,9 @@ describe('DecisionPanel', () => {
     expect(screen.getByText('1 candidate, 2 open, 1 resolved')).toBeInTheDocument();
   });
 
-  it('resolve button on an open decision (without options) sends a "Resolve decision …" chat message', async () => {
-    const user = userEvent.setup();
-    const decisions = [
-      makeDecision({ id: 'd1', seq: 7, status: 'open', title: 'What stack?' }),
-    ];
-    render(
-      <DecisionPanel
-        docId="doc-1"
-        decisions={decisions}
-        onUpdate={vi.fn()}
-      />
-    );
-
-    await user.click(screen.getByTestId('decision-resolve'));
-    expect(mockAddContextChip).toHaveBeenCalledWith({
-      type: 'decision',
-      id: 'd1',
-      label: 'Decision D-7',
-    });
-    expect(mockSendMessage).toHaveBeenCalledWith('Resolve decision D-7');
-  });
-
   // t-21 Issue 5: the manual "Add decision" UI is gone — decisions are agent-driven
-  // through the candidate flow (propose_decision → approve → resolve). REST/MCP
-  // power-user paths still create decisions for scripting, but the panel doesn't
-  // expose a button.
+  // through the candidate flow. REST/MCP power-user paths still create decisions
+  // for scripting, but the panel doesn't expose a button.
   it('does NOT render a manual "Add decision" button (per t-21 Issue 5)', () => {
     render(<DecisionPanel docId="doc-1" decisions={[]} onUpdate={vi.fn()} />);
     expect(
@@ -185,9 +167,9 @@ describe('DecisionPanel', () => {
   it('shows agent-driven empty-state copy when the list is empty', () => {
     render(<DecisionPanel docId="doc-1" decisions={[]} onUpdate={vi.fn()} />);
     // Default tab is 'open' when no candidates exist; the empty state explains
-    // the agent-driven flow (candidate → approve → open → resolve).
+    // where candidates are confirmed and that picking an option answers.
     expect(screen.getByText(/No open decisions/i)).toBeInTheDocument();
-    expect(screen.getByText(/approve a candidate raised by the agent/i)).toBeInTheDocument();
+    expect(screen.getByText(/picking an option records your answer/i)).toBeInTheDocument();
   });
 
   it('Candidates tab empty state explains the agent-driven candidate flow', async () => {
@@ -206,8 +188,6 @@ describe('DecisionPanel', () => {
     expect(screen.getByText(/durable .* record/i)).toBeInTheDocument();
   });
 
-  // ── Candidate workflow (t-16) ─────────────────────────────────
-
   it('defaults to the Candidates tab when any candidate exists', () => {
     const decisions = [
       makeDecision({
@@ -215,10 +195,7 @@ describe('DecisionPanel', () => {
         seq: 1,
         status: 'candidate',
         title: 'API style?',
-        options: [
-          { label: 'REST', trade_offs: 'Simple, well-known' },
-          { label: 'gRPC', trade_offs: 'Faster, harder tooling' },
-        ],
+        options: TWO_OPTIONS,
       }),
       makeDecision({ id: 'open-1', seq: 2, status: 'open', title: 'Other?' }),
     ];
@@ -229,50 +206,11 @@ describe('DecisionPanel', () => {
     expect(cards[0].getAttribute('data-decision-status')).toBe('candidate');
     expect(cards[0].getAttribute('data-decision-seq')).toBe('D-1');
 
-    // Both options render with their trade-offs.
+    // Both options render with their trade-offs (informational, spec-247 dec-6).
     expect(screen.getByText('REST')).toBeInTheDocument();
     expect(screen.getByText('Simple, well-known')).toBeInTheDocument();
     expect(screen.getByText('gRPC')).toBeInTheDocument();
     expect(screen.getByText('Faster, harder tooling')).toBeInTheDocument();
-  });
-
-  it('Approve button on a candidate calls approveDecisionApi and refreshes', async () => {
-    const user = userEvent.setup();
-    const onUpdate = vi.fn();
-    mockApproveDecisionApi.mockResolvedValue({});
-    const decisions = [
-      makeDecision({ id: 'cand-1', seq: 1, status: 'candidate', options: [] }),
-    ];
-    render(<DecisionPanel docId="doc-1" decisions={decisions} onUpdate={onUpdate} />);
-
-    await user.click(screen.getByTestId('candidate-approve'));
-    await waitFor(() => expect(mockApproveDecisionApi).toHaveBeenCalledWith('cand-1'));
-    expect(onUpdate).toHaveBeenCalled();
-  });
-
-  it('Reject flow requires a reason and calls rejectDecisionApi with it', async () => {
-    const user = userEvent.setup();
-    const onUpdate = vi.fn();
-    mockRejectDecisionApi.mockResolvedValue({});
-    const decisions = [
-      makeDecision({ id: 'cand-1', seq: 1, status: 'candidate', options: [] }),
-    ];
-    render(<DecisionPanel docId="doc-1" decisions={decisions} onUpdate={onUpdate} />);
-
-    await user.click(screen.getByTestId('candidate-reject'));
-    const reason = screen.getByTestId('candidate-reject-reason');
-    const confirm = screen.getByTestId('candidate-reject-confirm') as HTMLButtonElement;
-    // Empty reason disables the confirm button.
-    expect(confirm.disabled).toBe(true);
-
-    await user.type(reason, 'Out of scope for this spec');
-    expect((screen.getByTestId('candidate-reject-confirm') as HTMLButtonElement).disabled).toBe(false);
-    await user.click(screen.getByTestId('candidate-reject-confirm'));
-
-    await waitFor(() =>
-      expect(mockRejectDecisionApi).toHaveBeenCalledWith('cand-1', 'Out of scope for this spec'),
-    );
-    expect(onUpdate).toHaveBeenCalled();
   });
 
   it('"Flag for discussion" creates a question-typed comment on the candidate', async () => {
@@ -299,72 +237,6 @@ describe('DecisionPanel', () => {
     expect(onUpdate).toHaveBeenCalled();
   });
 
-  it('Resolve picker on an open decision with options persists chosenOptionIndex', async () => {
-    const user = userEvent.setup();
-    const onUpdate = vi.fn();
-    mockResolveDecisionApi.mockResolvedValue({});
-    const decisions = [
-      makeDecision({
-        id: 'open-1',
-        seq: 5,
-        status: 'open',
-        title: 'API?',
-        options: [
-          { label: 'REST', trade_offs: 'Simple' },
-          { label: 'gRPC', trade_offs: 'Faster' },
-        ],
-      }),
-    ];
-    render(<DecisionPanel docId="doc-1" decisions={decisions} onUpdate={onUpdate} />);
-
-    // Toggle the resolve picker on the open card.
-    await user.click(screen.getByTestId('decision-resolve'));
-
-    // Pick the second option.
-    await user.click(screen.getByTestId('open-option-1'));
-    await user.type(screen.getByTestId('open-resolution-text'), 'Going with gRPC for the perf');
-    await user.click(screen.getByTestId('open-resolve-confirm'));
-
-    await waitFor(() =>
-      expect(mockResolveDecisionApi).toHaveBeenCalledWith(
-        'open-1',
-        'Going with gRPC for the perf',
-        1,
-      ),
-    );
-    expect(onUpdate).toHaveBeenCalled();
-    // The chat-based resolve flow should NOT fire when options are present.
-    expect(mockSendMessage).not.toHaveBeenCalled();
-  });
-
-  it('Resolve picker requires both an option and a non-empty resolution', async () => {
-    const user = userEvent.setup();
-    const decisions = [
-      makeDecision({
-        id: 'open-1',
-        seq: 5,
-        status: 'open',
-        title: 'API?',
-        options: [
-          { label: 'REST', trade_offs: 'Simple' },
-          { label: 'gRPC', trade_offs: 'Faster' },
-        ],
-      }),
-    ];
-    render(<DecisionPanel docId="doc-1" decisions={decisions} onUpdate={vi.fn()} />);
-
-    await user.click(screen.getByTestId('decision-resolve'));
-    const confirm = screen.getByTestId('open-resolve-confirm') as HTMLButtonElement;
-    expect(confirm.disabled).toBe(true);
-
-    // Selecting an option alone is not enough — text is still required.
-    await user.click(screen.getByTestId('open-option-0'));
-    expect((screen.getByTestId('open-resolve-confirm') as HTMLButtonElement).disabled).toBe(true);
-
-    await user.type(screen.getByTestId('open-resolution-text'), 'REST it is');
-    expect((screen.getByTestId('open-resolve-confirm') as HTMLButtonElement).disabled).toBe(false);
-  });
-
   it('shows the chosen-option label on a resolved decision with options[]', async () => {
     const user = userEvent.setup();
     const decisions = [
@@ -386,7 +258,228 @@ describe('DecisionPanel', () => {
     // Switch to the Resolved tab.
     await user.click(screen.getByRole('button', { name: /^Resolved/ }));
     expect(screen.getByText(/Chose:/)).toBeInTheDocument();
-    expect(screen.getByText(/^JWT$/)).toBeInTheDocument();
+    expect(screen.getAllByText(/^JWT$/).length).toBeGreaterThan(0);
+  });
+});
+
+// ── spec-247: the decision card answers; everything else explains ──────────
+describe('DecisionPanel — one obvious place to answer (spec-247)', () => {
+  it('renders NO CTA button on an open decision card — the option rows are the only answering control (ac-6)', () => {
+    tagAc(AC247(6));
+    const decisions = [
+      makeDecision({ id: 'open-1', seq: 5, status: 'open', title: 'API?', options: TWO_OPTIONS }),
+    ];
+    render(<DecisionPanel docId="doc-1" decisions={decisions} onUpdate={vi.fn()} />);
+
+    expect(screen.queryByTestId('decision-resolve')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /^resolve$/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /save resolution/i })).not.toBeInTheDocument();
+    // The options are present and enabled — the answering affordance.
+    expect(screen.getByTestId('open-option-0')).toBeInTheDocument();
+    expect(screen.getByTestId('persist-on-select-hint')).toHaveTextContent(
+      /records your answer/i,
+    );
+  });
+
+  it('clicking an option records the answer immediately via the resolve API (ac-7)', async () => {
+    tagAc(AC247(7));
+    const user = userEvent.setup();
+    const onUpdate = vi.fn();
+    mockResolveDecisionApi.mockResolvedValue({});
+    const decisions = [
+      makeDecision({ id: 'open-1', seq: 5, status: 'open', title: 'API?', options: TWO_OPTIONS }),
+    ];
+    render(<DecisionPanel docId="doc-1" decisions={decisions} onUpdate={onUpdate} />);
+
+    await user.click(screen.getByTestId('open-option-1'));
+
+    await waitFor(() =>
+      expect(mockResolveDecisionApi).toHaveBeenCalledWith('open-1', undefined, 1),
+    );
+    expect(onUpdate).toHaveBeenCalled();
+    // No prose was demanded, no agent involved.
+    expect(mockSendMessage).not.toHaveBeenCalled();
+  });
+
+  it('re-selecting a different option on a RESOLVED decision updates the choice (ac-7)', async () => {
+    tagAc(AC247(7));
+    const user = userEvent.setup();
+    const onUpdate = vi.fn();
+    mockResolveDecisionApi.mockResolvedValue({});
+    const decisions = [
+      makeDecision({
+        id: 'res-1',
+        seq: 9,
+        status: 'resolved',
+        title: 'Auth?',
+        resolution: 'JWT',
+        options: [
+          { label: 'JWT', trade_offs: 'Stateless' },
+          { label: 'Sessions', trade_offs: 'Server load' },
+        ],
+        chosenOptionIndex: 0,
+      }),
+    ];
+    render(<DecisionPanel docId="doc-1" decisions={decisions} onUpdate={onUpdate} />);
+
+    await user.click(screen.getByRole('button', { name: /^Resolved/ }));
+    await user.click(screen.getByText('Context'));
+    await user.click(screen.getByTestId('resolved-option-1'));
+
+    await waitFor(() =>
+      expect(mockResolveDecisionApi).toHaveBeenCalledWith('res-1', undefined, 1),
+    );
+    expect(onUpdate).toHaveBeenCalled();
+  });
+
+  it('an optionless open decision has NO resolve control and NEVER dispatches an agent message (ac-8)', () => {
+    tagAc(AC247(8));
+    const decisions = [
+      makeDecision({ id: 'd1', seq: 7, status: 'open', title: 'What stack?', options: null }),
+    ];
+    render(<DecisionPanel docId="doc-1" decisions={decisions} onUpdate={vi.fn()} />);
+
+    expect(screen.queryByTestId('decision-resolve')).not.toBeInTheDocument();
+    expect(screen.getByTestId('optionless-hint')).toHaveTextContent(/coding agent/i);
+    expect(mockSendMessage).not.toHaveBeenCalled();
+    expect(mockResolveDecisionApi).not.toHaveBeenCalled();
+  });
+
+  it('no text input renders on the answering path; discussion sits behind a labelled toggle (ac-9)', async () => {
+    tagAc(AC247(9));
+    const user = userEvent.setup();
+    const decisions = [
+      makeDecision({ id: 'open-1', seq: 5, status: 'open', title: 'API?', options: TWO_OPTIONS }),
+    ];
+    render(<DecisionPanel docId="doc-1" decisions={decisions} onUpdate={vi.fn()} />);
+
+    // No textarea / comment composer inside the open card by default.
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('comment-tray-stub')).not.toBeInTheDocument();
+
+    // The Discussion toggle reveals the tray, labelled as never resolving.
+    await user.click(screen.getByTestId('decision-discussion-toggle'));
+    expect(screen.getByTestId('discussion-disclaimer')).toHaveTextContent(
+      /never resolve/i,
+    );
+    expect(screen.getByTestId('comment-tray-stub')).toBeInTheDocument();
+  });
+
+  it('"Ask for more explanation" pre-scopes the assistant to the decision and only explains (ac-10)', async () => {
+    tagAc(AC247(10));
+    const user = userEvent.setup();
+    const decisions = [
+      makeDecision({ id: 'open-1', seq: 5, status: 'open', title: 'API?', options: TWO_OPTIONS }),
+    ];
+    render(
+      <DecisionPanel
+        docId="doc-1"
+        decisions={decisions}
+        onUpdate={vi.fn()}
+        promptContext={PROMPT_CONTEXT}
+      />,
+    );
+
+    await user.click(screen.getByTestId('decision-explain'));
+
+    expect(mockAddContextChip).toHaveBeenCalledWith({
+      type: 'decision',
+      id: 'open-1',
+      label: 'Decision D-5',
+    });
+    expect(mockSendMessage).toHaveBeenCalledTimes(1);
+    const prompt = mockSendMessage.mock.calls[0][0] as string;
+    expect(prompt).toMatch(/Explain decision D-5/);
+    expect(prompt).toMatch(/Do NOT resolve/i);
+    // Explanation never resolves.
+    expect(mockResolveDecisionApi).not.toHaveBeenCalled();
+  });
+
+  it('candidate cards are view-only: no radios, no Approve, no Reject (ac-20)', () => {
+    tagAc(AC247(20));
+    const decisions = [
+      makeDecision({
+        id: 'cand-1',
+        seq: 1,
+        status: 'candidate',
+        title: 'API style?',
+        options: TWO_OPTIONS,
+      }),
+    ];
+    render(<DecisionPanel docId="doc-1" decisions={decisions} onUpdate={vi.fn()} />);
+
+    // Options render as information — nothing selectable, nothing droppable.
+    expect(screen.getByText('REST')).toBeInTheDocument();
+    expect(screen.queryByRole('radio')).not.toBeInTheDocument();
+    // The approval process is not actionable on the web.
+    expect(screen.queryByTestId('candidate-approve')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('candidate-reject')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /approve/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /^reject$/i })).not.toBeInTheDocument();
+  });
+
+  it('candidate list carries the coding-agent boundary marker (ac-21)', () => {
+    tagAc(AC247(21));
+    const decisions = [
+      makeDecision({
+        id: 'cand-1',
+        seq: 1,
+        status: 'candidate',
+        title: 'API style?',
+        options: TWO_OPTIONS,
+      }),
+    ];
+    render(
+      <DecisionPanel
+        docId="doc-1"
+        decisions={decisions}
+        onUpdate={vi.fn()}
+        promptContext={PROMPT_CONTEXT}
+      />,
+    );
+
+    const marker = screen.getByTestId('candidate-mcp-marker');
+    expect(marker).toHaveTextContent(/Review the candidate decisions/);
+    expect(marker).toHaveTextContent(/coding agent/i);
+    expect(marker).toHaveTextContent(/not in the browser/i);
+  });
+
+  it('"Add reasoning" on a resolved decision saves optional prose via re-resolve (ac-19)', async () => {
+    tagAc(AC247(19));
+    const user = userEvent.setup();
+    const onUpdate = vi.fn();
+    mockResolveDecisionApi.mockResolvedValue({});
+    const decisions = [
+      makeDecision({
+        id: 'res-1',
+        seq: 9,
+        status: 'resolved',
+        title: 'Auth?',
+        resolution: 'JWT', // equals the chosen option's label → "Add reasoning"
+        options: [
+          { label: 'JWT', trade_offs: 'Stateless' },
+          { label: 'Sessions', trade_offs: 'Server load' },
+        ],
+        chosenOptionIndex: 0,
+      }),
+    ];
+    render(<DecisionPanel docId="doc-1" decisions={decisions} onUpdate={onUpdate} />);
+
+    await user.click(screen.getByRole('button', { name: /^Resolved/ }));
+    await user.click(screen.getByText('Context'));
+    await user.click(screen.getByTestId('decision-add-reasoning'));
+    await user.clear(screen.getByTestId('reasoning-text'));
+    await user.type(screen.getByTestId('reasoning-text'), 'Stateless wins for our edge nodes');
+    await user.click(screen.getByTestId('reasoning-save'));
+
+    await waitFor(() =>
+      expect(mockResolveDecisionApi).toHaveBeenCalledWith(
+        'res-1',
+        'Stateless wins for our edge nodes',
+        0,
+      ),
+    );
+    expect(onUpdate).toHaveBeenCalled();
   });
 });
 

--- a/packages/ui/src/components/DecisionPanel.tsx
+++ b/packages/ui/src/components/DecisionPanel.tsx
@@ -5,18 +5,18 @@ import { rehypeRefLinkifier } from './chat/refLinkifier';
 import { phaseDisplayName } from '../utils/phaseDisplay';
 import type { Decision, Comment } from '../api/types';
 import {
-  approveDecisionApi,
-  rejectDecisionApi,
   resolveDecisionApi,
   createDecisionComment,
   fetchAcsForBrief,
   type AcWithVerification,
 } from '../api/client';
+import { BASE_SCAFFOLD, toButtonPrompt, type GuidanceBlock } from '@memex/shared';
 import { useAuth } from './AuthContext';
 import { useChat } from './ChatContext';
 import { CommentTray } from './CommentTray';
 import { Badge, Button, Tabs } from './ui';
 import { DecisionAcStrip } from './DecisionAcStrip';
+import { PromptButton } from './PromptButton';
 import { TextArea } from './ui/TextArea';
 
 interface DecisionPanelProps {
@@ -35,20 +35,18 @@ interface DecisionPanelProps {
   onJumpToAc?: (acId: string) => void;
   /**
    * spec-111 t-8: when false (non-member reading a public Memex), every
-   * mutation control is suppressed — approve/reject/flag on candidates, the
-   * resolve action on open decisions, and the comment composer in each tray.
-   * The decision content stays fully readable. Defaults to true so member
-   * call sites are unchanged.
+   * mutation control is suppressed — the option picker on open decisions and
+   * the comment composer in each tray. The decision content stays fully
+   * readable. Defaults to true so member call sites are unchanged.
    */
   canWrite?: boolean;
   /**
    * spec-118 t-6: when false (a reviewer — write access to the Memex but a
    * reviewer posture on this Spec), the forward-driving controls are
-   * suppressed (approve/reject/flag on candidates, resolve on open decisions,
-   * and the resolution textareas) while the comment composer in each tray —
-   * gated on `canWrite`, not `canEdit` — stays available so reviewers can
-   * still comment and @mention. Defaults to true so existing editor call
-   * sites are unchanged.
+   * suppressed (the answering option picker, re-select, Add reasoning) while
+   * the comment composer in each tray — gated on `canWrite`, not `canEdit` —
+   * stays available so reviewers can still comment and @mention. Defaults to
+   * true so existing editor call sites are unchanged.
    */
   canEdit?: boolean;
   /**
@@ -67,11 +65,21 @@ interface DecisionPanelProps {
    * them would dead-end. Defaults to false (real specs keep auto-linking).
    */
   isDemo?: boolean;
+  /**
+   * spec-247 dec-4: interpolation context ({namespace}/{memex}/{handle}/…) for
+   * the boundary-handoff PromptButtons (candidate review) and the chat-seeded
+   * "Ask for more explanation" prompt. Absent (e.g. in isolated tests) the
+   * marker lines are omitted and the explain affordance falls back to the
+   * decision handle alone.
+   */
+  promptContext?: Record<string, unknown>;
+  /** Org scaffold appends threaded into toButtonPrompt (spec-159 ac-17). */
+  orgBlocks?: readonly GuidanceBlock[];
 }
 
 type TabId = 'candidates' | 'open' | 'resolved';
 
-export function DecisionPanel({ docId, decisions, commentsByDecision = {}, forceShowComments: _forceShowComments, onCommentsChange, onUpdate, highlightDecisionHandle, onJumpToAc, canWrite = true, canEdit = true, specPhase, isDemo = false }: DecisionPanelProps) {
+export function DecisionPanel({ docId, decisions, commentsByDecision = {}, forceShowComments: _forceShowComments, onCommentsChange, onUpdate, highlightDecisionHandle, onJumpToAc, canWrite = true, canEdit = true, specPhase, isDemo = false, promptContext, orgBlocks }: DecisionPanelProps) {
   const panelRef = useRef<HTMLDivElement>(null);
   // spec-178 ac-24: suppress handle auto-linking inside a frozen demo spec's
   // decision prose. Mirrors SectionCard's rehypePlugins switch.
@@ -84,26 +92,35 @@ export function DecisionPanel({ docId, decisions, commentsByDecision = {}, force
   const [showCommentsFor, setShowCommentsFor] = useState<string | null>(null);
   const [collapsedOpen, setCollapsedOpen] = useState<Set<string>>(new Set());
 
-  // Per-candidate UI state for the Candidates tab. Each candidate may have a
-  // selected radio option, a pending reject reason, a pending flag-for-discussion
-  // body, plus a "busy" flag while the API call is in flight. Keeping these
-  // keyed by decision id (not in a single object) keeps the rerender surface
-  // tight when only one candidate's state changes.
-  const [chosenByCandidate, setChosenByCandidate] = useState<Record<string, number>>({});
-  const [rejectReasonByCandidate, setRejectReasonByCandidate] = useState<Record<string, string>>({});
-  const [showRejectFor, setShowRejectFor] = useState<string | null>(null);
+  // Per-candidate UI state. spec-247 dec-6: candidates are VIEW-ONLY on the
+  // web — no option radios, no Approve/Reject. The only candidate-side write
+  // left is "Flag for discussion" (a question-typed comment, not part of the
+  // approval process — approving/rejecting happens from the coding agent).
   const [flagBodyByCandidate, setFlagBodyByCandidate] = useState<Record<string, string>>({});
   const [showFlagFor, setShowFlagFor] = useState<string | null>(null);
   const [busyCandidate, setBusyCandidate] = useState<string | null>(null);
 
-  // Per-open-decision UI state for the resolution option picker (only relevant
-  // when `decision.options` is non-null). Selecting a radio captures
-  // `chosenOptionIndex`; clicking Resolve persists it via resolveDecisionApi
-  // and refreshes the doc through onUpdate().
+  // spec-247 dec-1/dec-5 (persist-on-select): clicking an option on an open
+  // decision IS the resolution — the click immediately calls the resolve API
+  // with that chosenOptionIndex (resolution prose defaults server-side to the
+  // option's label). `chosenByOpen` only carries the optimistic checked state
+  // while the call is in flight; the persisted truth arrives via onUpdate().
   const [chosenByOpen, setChosenByOpen] = useState<Record<string, number>>({});
-  const [resolutionDraftByOpen, setResolutionDraftByOpen] = useState<Record<string, string>>({});
-  const [showResolveFor, setShowResolveFor] = useState<string | null>(null);
   const [busyOpen, setBusyOpen] = useState<string | null>(null);
+  const [selectError, setSelectError] = useState<Record<string, string>>({});
+
+  // spec-247 dec-2: discussion comments live behind a per-card toggle on the
+  // answering path — never inline next to the picker.
+  const [discussionFor, setDiscussionFor] = useState<Set<string>>(new Set());
+
+  // spec-247 dec-5: optional, editable-after rationale on resolved decisions
+  // ("Add reasoning"), plus re-select busy state.
+  const [reasoningFor, setReasoningFor] = useState<string | null>(null);
+  const [reasoningDraft, setReasoningDraft] = useState<Record<string, string>>({});
+  const [busyResolved, setBusyResolved] = useState<string | null>(null);
+  // Optimistic checked state for re-select, mirroring chosenByOpen — the radio
+  // flips on click, not after the refetch round-trip.
+  const [reselectByResolved, setReselectByResolved] = useState<Record<string, number>>({});
 
   // ACs for the Spec — polled every 3s while the tab is visible so a new
   // test_event lands in the strip within ~3s without requiring tab nav.
@@ -216,34 +233,6 @@ export function DecisionPanel({ docId, decisions, commentsByDecision = {}, force
     return () => window.clearTimeout(handle);
   }, [highlightDecisionHandle, decisions]);
 
-  const handleApprove = async (decId: string) => {
-    setBusyCandidate(decId);
-    try {
-      await approveDecisionApi(decId);
-      onUpdate();
-    } finally {
-      setBusyCandidate(null);
-    }
-  };
-
-  const handleReject = async (decId: string) => {
-    const reason = (rejectReasonByCandidate[decId] ?? '').trim();
-    if (!reason) return;
-    setBusyCandidate(decId);
-    try {
-      await rejectDecisionApi(decId, reason);
-      setRejectReasonByCandidate((prev) => {
-        const next = { ...prev };
-        delete next[decId];
-        return next;
-      });
-      setShowRejectFor(null);
-      onUpdate();
-    } finally {
-      setBusyCandidate(null);
-    }
-  };
-
   const handleFlag = async (decId: string) => {
     const content = (flagBodyByCandidate[decId] ?? '').trim();
     if (!content) return;
@@ -265,30 +254,147 @@ export function DecisionPanel({ docId, decisions, commentsByDecision = {}, force
     }
   };
 
-  const handleResolveWithOption = async (decId: string) => {
-    const resolution = (resolutionDraftByOpen[decId] ?? '').trim();
-    if (!resolution) return;
-    const idx = chosenByOpen[decId];
-    setBusyOpen(decId);
+  // spec-247 dec-1/dec-5 — the option row is the only answering affordance:
+  // clicking persists immediately (no Save, no required prose, re-selectable).
+  const handleSelectOption = async (dec: Decision, idx: number) => {
+    if (!canEdit || busyOpen === dec.id) return;
+    setChosenByOpen((prev) => ({ ...prev, [dec.id]: idx }));
+    setSelectError((prev) => {
+      const next = { ...prev };
+      delete next[dec.id];
+      return next;
+    });
+    setBusyOpen(dec.id);
     try {
-      // resolveDecisionApi accepts an optional chosenOptionIndex; only pass it
-      // when a radio is selected, so decisions without options keep the
-      // existing 2-arg call shape.
-      await resolveDecisionApi(decId, resolution, idx);
-      setShowResolveFor(null);
-      setResolutionDraftByOpen((prev) => {
+      await resolveDecisionApi(dec.id, undefined, idx);
+      onUpdate();
+    } catch (err) {
+      // Roll the optimistic pick back and surface the failure on the card —
+      // a silent failure here would be the very silent-drop this Spec kills.
+      setChosenByOpen((prev) => {
         const next = { ...prev };
-        delete next[decId];
+        delete next[dec.id];
         return next;
       });
-      onUpdate();
+      setSelectError((prev) => ({
+        ...prev,
+        [dec.id]: err instanceof Error ? err.message : 'Failed to record the answer',
+      }));
     } finally {
       setBusyOpen(null);
     }
   };
 
+  // spec-247 dec-5 — re-select on an already-resolved decision updates the
+  // choice in place (the server allows re-resolve).
+  const handleReselect = async (dec: Decision, idx: number) => {
+    if (!canEdit || busyResolved === dec.id || dec.chosenOptionIndex === idx) return;
+    setReselectByResolved((prev) => ({ ...prev, [dec.id]: idx }));
+    setBusyResolved(dec.id);
+    try {
+      await resolveDecisionApi(dec.id, undefined, idx);
+      onUpdate();
+    } catch (err) {
+      console.error('Failed to re-select option:', err);
+      setReselectByResolved((prev) => {
+        const next = { ...prev };
+        delete next[dec.id];
+        return next;
+      });
+    } finally {
+      setBusyResolved(null);
+    }
+  };
+
+  // spec-247 dec-5 — optional rationale, editable after the fact. Saving rides
+  // the same resolve path (re-resolve with prose + the current option index).
+  const handleSaveReasoning = async (dec: Decision) => {
+    const text = (reasoningDraft[dec.id] ?? '').trim();
+    if (!text) return;
+    setBusyResolved(dec.id);
+    try {
+      await resolveDecisionApi(dec.id, text, dec.chosenOptionIndex ?? undefined);
+      setReasoningFor(null);
+      setReasoningDraft((prev) => {
+        const next = { ...prev };
+        delete next[dec.id];
+        return next;
+      });
+      onUpdate();
+    } catch (err) {
+      console.error('Failed to save reasoning:', err);
+    } finally {
+      setBusyResolved(null);
+    }
+  };
+
+  // spec-247 dec-2 — "Ask for more explanation": routes to the spec assistant
+  // with the decision pre-scoped (context chip) and seeds the Scaffold's
+  // explanation prompt (std-15: prose lives in scaffold-data, not here).
+  // Explanation only — the prompt forbids resolving.
+  const handleExplain = (dec: Decision) => {
+    chat.addContextChip({
+      type: 'decision',
+      id: dec.id,
+      label: `Decision D-${dec.seq}`,
+    });
+    const prompt = toButtonPrompt({
+      dataset: BASE_SCAFFOLD,
+      buttonId: 'decision-explain',
+      context: { ...(promptContext ?? {}), decision: `D-${dec.seq}` },
+      orgBlocks,
+    });
+    if (prompt === null) {
+      const message = 'DecisionPanel: no PromptButtonNode found for buttonId="decision-explain"';
+      if (import.meta.env.DEV) throw new Error(message);
+      // eslint-disable-next-line no-console
+      console.error(message);
+      return;
+    }
+    chat.sendMessage(prompt);
+  };
+
+  const toggleDiscussion = (decId: string) =>
+    setDiscussionFor((prev) => {
+      const next = new Set(prev);
+      if (next.has(decId)) next.delete(decId);
+      else next.add(decId);
+      return next;
+    });
+
   const openCommentCount = (decId: string) =>
     commentsByDecision[decId]?.filter((c) => !c.resolvedAt).length ?? 0;
+
+  const allCommentCount = (decId: string) => commentsByDecision[decId]?.length ?? 0;
+
+  // spec-247 dec-2 — the Discussion toggle + tray. The label states the one
+  // thing the old inline box never said: comments never resolve a decision.
+  const discussionBlock = (dec: Decision) => (
+    <div className="mt-2 pt-2 border-t border-edge">
+      <button
+        type="button"
+        data-testid="decision-discussion-toggle"
+        onClick={() => toggleDiscussion(dec.id)}
+        className="text-xs text-muted hover:text-secondary transition-colors"
+      >
+        {discussionFor.has(dec.id) ? 'Hide discussion' : `Discussion (${allCommentCount(dec.id)})`}
+      </button>
+      {discussionFor.has(dec.id) && (
+        <div className="mt-2">
+          <p data-testid="discussion-disclaimer" className="text-[11px] text-muted mb-2">
+            Discussion only — comments never resolve a decision.
+          </p>
+          <CommentTray
+            targetType="decision"
+            targetId={dec.id}
+            comments={commentsByDecision[dec.id] ?? []}
+            onCommentsChange={onCommentsChange}
+            canWrite={canWrite}
+          />
+        </div>
+      )}
+    </div>
+  );
 
   const tabs: Array<{ id: TabId; label: string; count: number; countVariant?: 'default' | 'warning' | 'danger' }> = [
     { id: 'candidates', label: 'Candidates', count: candidates.length, countVariant: 'warning' },
@@ -343,9 +449,24 @@ export function DecisionPanel({ docId, decisions, commentsByDecision = {}, force
             </div>
           )}
 
+          {/* spec-247 dec-6 / ac-21 — the boundary marker: candidate review
+              (approve / reject) is coding-agent work, and the surface says so
+              instead of offering web buttons that half-implement it. */}
+          {candidates.length > 0 && promptContext && (
+            <div data-testid="candidate-mcp-marker" className="rounded-md border border-edge-subtle bg-overlay/30 px-3 py-2">
+              <PromptButton
+                buttonId="review-candidates"
+                context={promptContext}
+                orgBlocks={orgBlocks}
+                linkText="Review the candidate decisions"
+                sentence="— copy this prompt into your coding agent. Approving or rejecting candidates happens there, not in the browser."
+                sentenceLabel="Review the candidate decisions — copy this prompt into your coding agent. Approving or rejecting candidates happens there, not in the browser."
+              />
+            </div>
+          )}
+
           {candidates.map((dec) => {
             const isBusy = busyCandidate === dec.id;
-            const chosenIdx = chosenByCandidate[dec.id];
             return (
               <div
                 key={dec.id}
@@ -372,53 +493,36 @@ export function DecisionPanel({ docId, decisions, commentsByDecision = {}, force
                   </div>
                 )}
 
+                {/* spec-247 dec-6 — options render as INFORMATION on a
+                    candidate. No radios: nothing selectable means nothing can
+                    be silently dropped (the spec-93 Failure 1 bug class). */}
                 {dec.options && dec.options.length > 0 && (
-                  <fieldset
-                    className="mt-3 space-y-1.5"
-                    data-testid="candidate-options"
-                  >
-                    <legend className="text-[10px] uppercase tracking-wider text-muted font-medium">Options</legend>
+                  <div className="mt-3 space-y-1.5" data-testid="candidate-options">
+                    <div className="text-[10px] uppercase tracking-wider text-muted font-medium">Options</div>
                     {dec.options.map((opt, idx) => (
-                      <label
+                      <div
                         key={idx}
-                        className={`flex gap-2 items-start rounded-md border px-2 py-1.5 cursor-pointer transition-colors ${
-                          chosenIdx === idx
-                            ? 'border-edge-strong bg-overlay'
-                            : 'border-edge-subtle hover:bg-card-hover'
-                        }`}
+                        data-testid={`candidate-option-${idx}`}
+                        className="rounded-md border border-edge-subtle px-2 py-1.5"
                       >
-                        <input
-                          type="radio"
-                          name={`candidate-${dec.id}`}
-                          value={idx}
-                          checked={chosenIdx === idx}
-                          onChange={() =>
-                            setChosenByCandidate((prev) => ({ ...prev, [dec.id]: idx }))
-                          }
-                          data-testid={`candidate-option-${idx}`}
-                          className="mt-1"
-                        />
-                        <div className="flex-1 min-w-0">
-                          <div className="text-sm font-medium text-primary">{opt.label}</div>
-                          {opt.trade_offs && (
-                            <div className="text-xs text-muted mt-0.5 whitespace-pre-wrap">{opt.trade_offs}</div>
-                          )}
-                        </div>
-                      </label>
+                        <div className="text-sm font-medium text-primary">{opt.label}</div>
+                        {opt.trade_offs && (
+                          <div className="text-xs text-muted mt-0.5 whitespace-pre-wrap">{opt.trade_offs}</div>
+                        )}
+                      </div>
                     ))}
-                  </fieldset>
+                  </div>
                 )}
 
-                {/* Action row: Approve / Reject / Flag for discussion.
-                    Suppressed for read-only non-members (spec-111 t-8) and for
-                    reviewers (spec-118 t-6 — forward-driving, gated on canEdit). */}
+                {/* spec-247 dec-6: no Approve / Reject on the web — the
+                    approval process is MCP-only. The one remaining card
+                    action is Flag for discussion (a question comment). */}
                 {canEdit && (
                 <div className="mt-3 pt-2 border-t border-edge flex flex-wrap gap-2 justify-end">
                   <Button
                     data-testid="candidate-flag"
                     onClick={() => {
                       setShowFlagFor(showFlagFor === dec.id ? null : dec.id);
-                      setShowRejectFor(null);
                     }}
                     variant="ghost"
                     size="sm"
@@ -426,66 +530,7 @@ export function DecisionPanel({ docId, decisions, commentsByDecision = {}, force
                   >
                     Flag for discussion
                   </Button>
-                  <Button
-                    data-testid="candidate-reject"
-                    onClick={() => {
-                      setShowRejectFor(showRejectFor === dec.id ? null : dec.id);
-                      setShowFlagFor(null);
-                    }}
-                    variant="danger"
-                    size="sm"
-                    disabled={isBusy}
-                  >
-                    Reject
-                  </Button>
-                  <Button
-                    data-testid="candidate-approve"
-                    onClick={() => handleApprove(dec.id)}
-                    variant="success"
-                    size="sm"
-                    disabled={isBusy}
-                  >
-                    Approve
-                  </Button>
                 </div>
-                )}
-
-                {canEdit && showRejectFor === dec.id && (
-                  <div className="mt-2 pt-2 border-t border-edge space-y-2">
-                    <TextArea
-                      data-testid="candidate-reject-reason"
-                      value={rejectReasonByCandidate[dec.id] ?? ''}
-                      onChange={(e) =>
-                        setRejectReasonByCandidate((prev) => ({
-                          ...prev,
-                          [dec.id]: e.target.value,
-                        }))
-                      }
-                      placeholder="Reason for rejecting this candidate..."
-                      rows={2}
-                      textAreaSize="compact"
-                    />
-                    <div className="flex gap-2 justify-end">
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="sm"
-                        onClick={() => setShowRejectFor(null)}
-                      >
-                        Cancel
-                      </Button>
-                      <Button
-                        data-testid="candidate-reject-confirm"
-                        type="button"
-                        variant="danger"
-                        size="sm"
-                        disabled={isBusy || !(rejectReasonByCandidate[dec.id] ?? '').trim()}
-                        onClick={() => handleReject(dec.id)}
-                      >
-                        Confirm reject
-                      </Button>
-                    </div>
-                  </div>
                 )}
 
                 {canEdit && showFlagFor === dec.id && (
@@ -525,15 +570,7 @@ export function DecisionPanel({ docId, decisions, commentsByDecision = {}, force
                   </div>
                 )}
 
-                <div className="mt-2 pt-2 border-t border-edge">
-                  <CommentTray
-                    targetType="decision"
-                    targetId={dec.id}
-                    comments={commentsByDecision[dec.id] ?? []}
-                    onCommentsChange={onCommentsChange}
-                    canWrite={canWrite}
-                  />
-                </div>
+                {discussionBlock(dec)}
               </div>
             );
           })}
@@ -546,7 +583,7 @@ export function DecisionPanel({ docId, decisions, commentsByDecision = {}, force
           {open.length === 0 && (
             <div className="text-sm text-muted space-y-1">
               <p>No open decisions.</p>
-              <p className="text-xs">Decisions move here when you approve a candidate raised by the agent. An open decision is an unresolved choice with options on the table — pick one with a rationale to resolve it.</p>
+              <p className="text-xs">Decisions move here once a candidate is confirmed from your coding agent. An open decision is an unresolved choice with options on the table — picking an option records your answer.</p>
             </div>
           )}
 
@@ -554,7 +591,6 @@ export function DecisionPanel({ docId, decisions, commentsByDecision = {}, force
             const isExpanded = !collapsedOpen.has(dec.id);
             const isBusy = busyOpen === dec.id;
             const chosenIdx = chosenByOpen[dec.id];
-            const showResolve = showResolveFor === dec.id;
             const hasOptions = dec.options !== null && dec.options.length > 0;
             return (
               <div
@@ -597,29 +633,34 @@ export function DecisionPanel({ docId, decisions, commentsByDecision = {}, force
                       </div>
                     )}
 
+                    {/* spec-247 dec-1/dec-5 — the option rows ARE the
+                        answering affordance. Clicking one records the answer
+                        immediately; there is no Resolve button, and the hint
+                        names the actual effect (ac-2: every control labelled
+                        by what it does). */}
                     {hasOptions && (
                       <fieldset
                         className="mt-3 space-y-1.5"
                         data-testid="open-options"
+                        disabled={!canEdit || isBusy}
                       >
                         <legend className="text-[10px] uppercase tracking-wider text-muted font-medium">Options</legend>
                         {dec.options!.map((opt, idx) => (
                           <label
                             key={idx}
-                            className={`flex gap-2 items-start rounded-md border px-2 py-1.5 cursor-pointer transition-colors ${
+                            className={`flex gap-2 items-start rounded-md border px-2 py-1.5 transition-colors ${
                               chosenIdx === idx
                                 ? 'border-edge-strong bg-overlay'
                                 : 'border-edge-subtle hover:bg-card-hover'
-                            }`}
+                            } ${canEdit ? 'cursor-pointer' : 'cursor-default'}`}
                           >
                             <input
                               type="radio"
                               name={`open-${dec.id}`}
                               value={idx}
                               checked={chosenIdx === idx}
-                              onChange={() =>
-                                setChosenByOpen((prev) => ({ ...prev, [dec.id]: idx }))
-                              }
+                              disabled={!canEdit || isBusy}
+                              onChange={() => void handleSelectOption(dec, idx)}
                               data-testid={`open-option-${idx}`}
                               className="mt-1"
                             />
@@ -631,88 +672,49 @@ export function DecisionPanel({ docId, decisions, commentsByDecision = {}, force
                             </div>
                           </label>
                         ))}
+                        {canEdit && (
+                          <p data-testid="persist-on-select-hint" className="text-[11px] text-muted">
+                            {isBusy
+                              ? 'Recording your answer…'
+                              : 'Picking an option records your answer — you can change it later.'}
+                          </p>
+                        )}
                       </fieldset>
                     )}
 
-                    <div className="mt-2 pt-2 border-t border-edge">
-                      <CommentTray
-                        targetType="decision"
-                        targetId={dec.id}
-                        comments={commentsByDecision[dec.id] ?? []}
-                        onCommentsChange={onCommentsChange}
-                        canWrite={canWrite}
-                      />
+                    {selectError[dec.id] && (
+                      <p data-testid="select-error" className="mt-1 text-xs text-status-danger-text">
+                        {selectError[dec.id]}
+                      </p>
+                    )}
+
+                    {/* spec-247 dec-1 — optionless decisions have NO resolve
+                        control on the web: answering happens in conversation
+                        with the spec assistant or from the coding agent. */}
+                    {!hasOptions && (
+                      <p data-testid="optionless-hint" className="mt-3 text-xs text-muted">
+                        This decision has no structured options. Answer it in
+                        conversation with the Spec assistant, or resolve it from
+                        your coding agent.
+                      </p>
+                    )}
+
+                    {/* spec-247 dec-2 — the explanation route: pre-scopes the
+                        spec assistant to this decision and asks it to explain
+                        the choice. It never resolves. */}
+                    <div className="mt-2 flex justify-end">
+                      <Button
+                        data-testid="decision-explain"
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => handleExplain(dec)}
+                      >
+                        Ask for more explanation
+                      </Button>
                     </div>
 
-                    {canEdit && (
-                    <>
-                    <div className="mt-2 pt-2 border-t border-edge flex justify-end gap-2">
-                      {hasOptions ? (
-                        <Button
-                          data-testid="decision-resolve"
-                          onClick={() => {
-                            setShowResolveFor(showResolve ? null : dec.id);
-                          }}
-                          variant="success"
-                          size="sm"
-                          disabled={isBusy}
-                        >
-                          {showResolve ? 'Cancel' : 'Resolve'}
-                        </Button>
-                      ) : (
-                        <Button
-                          data-testid="decision-resolve"
-                          onClick={() => {
-                            chat.addContextChip({
-                              type: 'decision',
-                              id: dec.id,
-                              label: `Decision D-${dec.seq}`,
-                            });
-                            chat.sendMessage(`Resolve decision D-${dec.seq}`);
-                          }}
-                          variant="success"
-                          size="sm"
-                        >
-                          Resolve
-                        </Button>
-                      )}
-                    </div>
-
-                    {hasOptions && showResolve && (
-                      <div className="mt-2 pt-2 border-t border-edge space-y-2">
-                        <TextArea
-                          data-testid="open-resolution-text"
-                          value={resolutionDraftByOpen[dec.id] ?? ''}
-                          onChange={(e) =>
-                            setResolutionDraftByOpen((prev) => ({
-                              ...prev,
-                              [dec.id]: e.target.value,
-                            }))
-                          }
-                          placeholder="Why this option? (Required)"
-                          rows={2}
-                          textAreaSize="compact"
-                        />
-                        <div className="flex gap-2 justify-end">
-                          <Button
-                            data-testid="open-resolve-confirm"
-                            type="button"
-                            variant="success"
-                            size="sm"
-                            disabled={
-                              isBusy ||
-                              chosenIdx === undefined ||
-                              !(resolutionDraftByOpen[dec.id] ?? '').trim()
-                            }
-                            onClick={() => handleResolveWithOption(dec.id)}
-                          >
-                            Save resolution
-                          </Button>
-                        </div>
-                      </div>
-                    )}
-                    </>
-                    )}
+                    {discussionBlock(dec)}
                   </>
                 )}
               </div>
@@ -727,12 +729,14 @@ export function DecisionPanel({ docId, decisions, commentsByDecision = {}, force
           {resolved.length === 0 && (
             <div className="text-sm text-muted space-y-1">
               <p>No resolved decisions yet.</p>
-              <p className="text-xs">Resolved decisions land here once an open decision has been answered with a chosen option and a rationale. They become the durable "this is how we decided" record for the spec.</p>
+              <p className="text-xs">Resolved decisions land here once an open decision has been answered by picking an option (or in conversation). They become the durable "this is how we decided" record for the spec.</p>
             </div>
           )}
 
           {resolved.map((dec) => {
             const decOpenComments = openCommentCount(dec.id) > 0;
+            const isBusy = busyResolved === dec.id;
+            const shownChosenIdx = reselectByResolved[dec.id] ?? dec.chosenOptionIndex;
             return (
               <div
                 key={dec.id}
@@ -795,14 +799,14 @@ export function DecisionPanel({ docId, decisions, commentsByDecision = {}, force
                   <span className="flex-none text-xs font-mono text-muted">dec-{dec.seq}</span>
                 </div>
 
-                {dec.options && dec.chosenOptionIndex !== null && dec.options[dec.chosenOptionIndex] && (
+                {dec.options && shownChosenIdx !== null && dec.options[shownChosenIdx] && (
                   <div className="mt-1 pl-6 text-xs text-muted">
                     <span className="font-medium text-status-success-text">Chose:</span>{' '}
-                    {dec.options[dec.chosenOptionIndex].label}
+                    {dec.options[shownChosenIdx].label}
                   </div>
                 )}
 
-                {(dec.context || dec.resolution) && (
+                {(dec.context || dec.resolution || (dec.options && dec.options.length > 0)) && (
                   <details className="mt-2 pl-2 border-l-2 border-edge-subtle" onClick={(e) => e.stopPropagation()}>
                     <summary className="text-[10px] uppercase tracking-wider text-muted font-medium cursor-pointer select-none hover:text-secondary">Context</summary>
                     <div className="mt-1 space-y-2">
@@ -819,9 +823,108 @@ export function DecisionPanel({ docId, decisions, commentsByDecision = {}, force
                           </div>
                         </div>
                       )}
-                      {dec.context && (
-                        <div className="prose-dark prose-sm opacity-80 [&>*]:my-1 [&_h1]:text-sm [&_h2]:text-sm [&_h3]:text-xs [&_h1]:font-semibold [&_h2]:font-semibold [&_h3]:font-medium">
-                          <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={decisionRehypePlugins}>{dec.context}</ReactMarkdown>
+
+                      {/* spec-247 dec-5 — re-select: the options stay live on a
+                          resolved decision; clicking a different one updates
+                          the recorded choice in place. */}
+                      {dec.options && dec.options.length > 0 && (
+                        <fieldset
+                          className="space-y-1.5"
+                          data-testid="resolved-options"
+                          disabled={!canEdit || isBusy}
+                        >
+                          <legend className="text-[10px] uppercase tracking-wider text-muted font-medium">
+                            Options{canEdit ? ' — pick another to change the answer' : ''}
+                          </legend>
+                          {dec.options.map((opt, idx) => (
+                            <label
+                              key={idx}
+                              className={`flex gap-2 items-start rounded-md border px-2 py-1.5 transition-colors ${
+                                shownChosenIdx === idx
+                                  ? 'border-edge-strong bg-overlay'
+                                  : 'border-edge-subtle hover:bg-card-hover'
+                              } ${canEdit ? 'cursor-pointer' : 'cursor-default'}`}
+                            >
+                              <input
+                                type="radio"
+                                name={`resolved-${dec.id}`}
+                                value={idx}
+                                checked={shownChosenIdx === idx}
+                                disabled={!canEdit || isBusy}
+                                onChange={() => void handleReselect(dec, idx)}
+                                data-testid={`resolved-option-${idx}`}
+                                className="mt-1"
+                              />
+                              <div className="flex-1 min-w-0">
+                                <div className="text-sm font-medium text-primary">{opt.label}</div>
+                                {opt.trade_offs && (
+                                  <div className="text-xs text-muted mt-0.5 whitespace-pre-wrap">{opt.trade_offs}</div>
+                                )}
+                              </div>
+                            </label>
+                          ))}
+                        </fieldset>
+                      )}
+
+                      {/* spec-247 dec-5 — optional, editable-after rationale. */}
+                      {canEdit && (
+                        <div>
+                          {reasoningFor === dec.id ? (
+                            <div className="space-y-2">
+                              <TextArea
+                                data-testid="reasoning-text"
+                                value={reasoningDraft[dec.id] ?? ''}
+                                onChange={(e) =>
+                                  setReasoningDraft((prev) => ({
+                                    ...prev,
+                                    [dec.id]: e.target.value,
+                                  }))
+                                }
+                                placeholder="Why this option? (Optional — the answer is already recorded.)"
+                                rows={2}
+                                textAreaSize="compact"
+                              />
+                              <div className="flex gap-2 justify-end">
+                                <Button
+                                  type="button"
+                                  variant="ghost"
+                                  size="sm"
+                                  onClick={() => setReasoningFor(null)}
+                                >
+                                  Cancel
+                                </Button>
+                                <Button
+                                  data-testid="reasoning-save"
+                                  type="button"
+                                  size="sm"
+                                  disabled={isBusy || !(reasoningDraft[dec.id] ?? '').trim()}
+                                  onClick={() => void handleSaveReasoning(dec)}
+                                >
+                                  Save reasoning
+                                </Button>
+                              </div>
+                            </div>
+                          ) : (
+                            <button
+                              type="button"
+                              data-testid="decision-add-reasoning"
+                              onClick={() => {
+                                setReasoningDraft((prev) => ({
+                                  ...prev,
+                                  [dec.id]: prev[dec.id] ?? dec.resolution ?? '',
+                                }));
+                                setReasoningFor(dec.id);
+                              }}
+                              className="text-xs text-muted hover:text-secondary underline underline-offset-2 transition-colors"
+                            >
+                              {dec.resolution &&
+                              dec.options &&
+                              dec.chosenOptionIndex !== null &&
+                              dec.resolution !== dec.options[dec.chosenOptionIndex]?.label
+                                ? 'Edit reasoning'
+                                : 'Add reasoning'}
+                            </button>
+                          )}
                         </div>
                       )}
                     </div>

--- a/packages/ui/src/components/DecisionPanel.tsx
+++ b/packages/ui/src/components/DecisionPanel.tsx
@@ -10,7 +10,7 @@ import {
   fetchAcsForBrief,
   type AcWithVerification,
 } from '../api/client';
-import { BASE_SCAFFOLD, toButtonPrompt, type GuidanceBlock } from '@memex/shared';
+import type { GuidanceBlock } from '@memex/shared';
 import { useAuth } from './AuthContext';
 import { useChat } from './ChatContext';
 import { CommentTray } from './CommentTray';
@@ -43,7 +43,7 @@ interface DecisionPanelProps {
   /**
    * spec-118 t-6: when false (a reviewer — write access to the Memex but a
    * reviewer posture on this Spec), the forward-driving controls are
-   * suppressed (the answering option picker, re-select, Add reasoning) while
+   * suppressed (the answering option picker and re-select) while
    * the comment composer in each tray — gated on `canWrite`, not `canEdit` —
    * stays available so reviewers can still comment and @mention. Defaults to
    * true so existing editor call sites are unchanged.
@@ -67,10 +67,8 @@ interface DecisionPanelProps {
   isDemo?: boolean;
   /**
    * spec-247 dec-4: interpolation context ({namespace}/{memex}/{handle}/…) for
-   * the boundary-handoff PromptButtons (candidate review) and the chat-seeded
-   * "Ask for more explanation" prompt. Absent (e.g. in isolated tests) the
-   * marker lines are omitted and the explain affordance falls back to the
-   * decision handle alone.
+   * the boundary-handoff PromptButtons (candidate review). Absent (e.g. in
+   * isolated tests) the marker lines are omitted.
    */
   promptContext?: Record<string, unknown>;
   /** Org scaffold appends threaded into toButtonPrompt (spec-159 ac-17). */
@@ -113,10 +111,9 @@ export function DecisionPanel({ docId, decisions, commentsByDecision = {}, force
   // answering path — never inline next to the picker.
   const [discussionFor, setDiscussionFor] = useState<Set<string>>(new Set());
 
-  // spec-247 dec-5: optional, editable-after rationale on resolved decisions
-  // ("Add reasoning"), plus re-select busy state.
-  const [reasoningFor, setReasoningFor] = useState<string | null>(null);
-  const [reasoningDraft, setReasoningDraft] = useState<Record<string, string>>({});
+  // spec-247 dec-5: re-select busy state on resolved decisions. There is NO
+  // reasoning input on the web — rationale, when wanted, comes from the agent
+  // side; the only web text action on a decision is a discussion comment.
   const [busyResolved, setBusyResolved] = useState<string | null>(null);
   // Optimistic checked state for re-select, mirroring chosenByOpen — the radio
   // flips on click, not after the refetch round-trip.
@@ -304,54 +301,6 @@ export function DecisionPanel({ docId, decisions, commentsByDecision = {}, force
     } finally {
       setBusyResolved(null);
     }
-  };
-
-  // spec-247 dec-5 — optional rationale, editable after the fact. Saving rides
-  // the same resolve path (re-resolve with prose + the current option index).
-  const handleSaveReasoning = async (dec: Decision) => {
-    const text = (reasoningDraft[dec.id] ?? '').trim();
-    if (!text) return;
-    setBusyResolved(dec.id);
-    try {
-      await resolveDecisionApi(dec.id, text, dec.chosenOptionIndex ?? undefined);
-      setReasoningFor(null);
-      setReasoningDraft((prev) => {
-        const next = { ...prev };
-        delete next[dec.id];
-        return next;
-      });
-      onUpdate();
-    } catch (err) {
-      console.error('Failed to save reasoning:', err);
-    } finally {
-      setBusyResolved(null);
-    }
-  };
-
-  // spec-247 dec-2 — "Ask for more explanation": routes to the spec assistant
-  // with the decision pre-scoped (context chip) and seeds the Scaffold's
-  // explanation prompt (std-15: prose lives in scaffold-data, not here).
-  // Explanation only — the prompt forbids resolving.
-  const handleExplain = (dec: Decision) => {
-    chat.addContextChip({
-      type: 'decision',
-      id: dec.id,
-      label: `Decision D-${dec.seq}`,
-    });
-    const prompt = toButtonPrompt({
-      dataset: BASE_SCAFFOLD,
-      buttonId: 'decision-explain',
-      context: { ...(promptContext ?? {}), decision: `D-${dec.seq}` },
-      orgBlocks,
-    });
-    if (prompt === null) {
-      const message = 'DecisionPanel: no PromptButtonNode found for buttonId="decision-explain"';
-      if (import.meta.env.DEV) throw new Error(message);
-      // eslint-disable-next-line no-console
-      console.error(message);
-      return;
-    }
-    chat.sendMessage(prompt);
   };
 
   const toggleDiscussion = (decId: string) =>
@@ -699,21 +648,6 @@ export function DecisionPanel({ docId, decisions, commentsByDecision = {}, force
                       </p>
                     )}
 
-                    {/* spec-247 dec-2 — the explanation route: pre-scopes the
-                        spec assistant to this decision and asks it to explain
-                        the choice. It never resolves. */}
-                    <div className="mt-2 flex justify-end">
-                      <Button
-                        data-testid="decision-explain"
-                        type="button"
-                        variant="ghost"
-                        size="sm"
-                        onClick={() => handleExplain(dec)}
-                      >
-                        Ask for more explanation
-                      </Button>
-                    </div>
-
                     {discussionBlock(dec)}
                   </>
                 )}
@@ -866,67 +800,6 @@ export function DecisionPanel({ docId, decisions, commentsByDecision = {}, force
                         </fieldset>
                       )}
 
-                      {/* spec-247 dec-5 — optional, editable-after rationale. */}
-                      {canEdit && (
-                        <div>
-                          {reasoningFor === dec.id ? (
-                            <div className="space-y-2">
-                              <TextArea
-                                data-testid="reasoning-text"
-                                value={reasoningDraft[dec.id] ?? ''}
-                                onChange={(e) =>
-                                  setReasoningDraft((prev) => ({
-                                    ...prev,
-                                    [dec.id]: e.target.value,
-                                  }))
-                                }
-                                placeholder="Why this option? (Optional — the answer is already recorded.)"
-                                rows={2}
-                                textAreaSize="compact"
-                              />
-                              <div className="flex gap-2 justify-end">
-                                <Button
-                                  type="button"
-                                  variant="ghost"
-                                  size="sm"
-                                  onClick={() => setReasoningFor(null)}
-                                >
-                                  Cancel
-                                </Button>
-                                <Button
-                                  data-testid="reasoning-save"
-                                  type="button"
-                                  size="sm"
-                                  disabled={isBusy || !(reasoningDraft[dec.id] ?? '').trim()}
-                                  onClick={() => void handleSaveReasoning(dec)}
-                                >
-                                  Save reasoning
-                                </Button>
-                              </div>
-                            </div>
-                          ) : (
-                            <button
-                              type="button"
-                              data-testid="decision-add-reasoning"
-                              onClick={() => {
-                                setReasoningDraft((prev) => ({
-                                  ...prev,
-                                  [dec.id]: prev[dec.id] ?? dec.resolution ?? '',
-                                }));
-                                setReasoningFor(dec.id);
-                              }}
-                              className="text-xs text-muted hover:text-secondary underline underline-offset-2 transition-colors"
-                            >
-                              {dec.resolution &&
-                              dec.options &&
-                              dec.chosenOptionIndex !== null &&
-                              dec.resolution !== dec.options[dec.chosenOptionIndex]?.label
-                                ? 'Edit reasoning'
-                                : 'Add reasoning'}
-                            </button>
-                          )}
-                        </div>
-                      )}
                     </div>
                   </details>
                 )}

--- a/packages/ui/src/components/McpTokensSection.tsx
+++ b/packages/ui/src/components/McpTokensSection.tsx
@@ -1,26 +1,17 @@
 // spec-141 dec-3: MCP-token management, extracted from the standalone
 // `pages/SettingsTokens.tsx` into a section so the consolidated Integrations
-// page can compose it. Open core. Behaviour (banner, realtime refresh,
-// revoke) is unchanged; only the outer page wrapper became a <section> and
+// page can compose it. Open core. Behaviour (realtime refresh, revoke) is
+// unchanged; only the outer page wrapper became a <section> and
 // the cross-links to the installer now point at the in-page CLI section.
 
 import { useCallback, useEffect, useState } from 'react';
 import { useAuth } from './AuthContext';
 import { useUserChangeStream } from '../hooks/useUserChangeStream';
-import { Alert } from './ui/Alert';
 import {
   listMcpTokensApi,
   revokeMcpTokenApi,
   type McpTokenSummary,
 } from '../api/client';
-
-// b-36 — one-time notice for the canonical-refs hard switch. The MCP tool
-// surface now takes single `ref` args and rejects UUID inputs; tests look for
-// "UUID inputs no longer accepted" in the structured error. The banner nudges
-// active token holders to reload their MCP client so they pick up the new
-// tool definitions. Dismissed flag persists in localStorage so we don't nag
-// after the user has acknowledged.
-const CANONICAL_REFS_BANNER_KEY = 'mcp-canonical-refs-banner-dismissed';
 
 function formatRelative(iso: string | null): string {
   if (!iso) return 'never';
@@ -45,14 +36,6 @@ export function McpTokensSection() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [revoking, setRevoking] = useState<string | null>(null);
-  const [bannerDismissed, setBannerDismissed] = useState<boolean>(() => {
-    if (typeof window === 'undefined') return false;
-    try {
-      return window.localStorage.getItem(CANONICAL_REFS_BANNER_KEY) === '1';
-    } catch {
-      return false;
-    }
-  });
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -90,47 +73,8 @@ export function McpTokensSection() {
   const active = tokens.filter((t) => !t.revokedAt);
   const revoked = tokens.filter((t) => t.revokedAt);
 
-  function dismissBanner() {
-    try {
-      window.localStorage.setItem(CANONICAL_REFS_BANNER_KEY, '1');
-    } catch {
-      // Ignore — banner reappears next session if persistence fails.
-    }
-    setBannerDismissed(true);
-  }
-
   return (
     <section id="mcp-tokens" aria-labelledby="mcp-tokens-heading">
-      {!bannerDismissed && (
-        <Alert variant="info" size="md" className="mb-6">
-          <div className="flex items-start justify-between gap-3">
-            <div>
-              <p className="font-medium mb-1">
-                Heads up — MCP tool surface updated.
-              </p>
-              <p>
-                The MCP server has switched to canonical refs. Reload your MCP
-                client to pick up the new tool definitions.{' '}
-                <code className="font-mono text-xs">mcp-remote</code> reconnects
-                automatically on next request. Native HTTP clients (Claude Code,
-                Claude Desktop) pick up new schemas on next session start. UUID-shaped
-                inputs will return a structured error.
-              </p>
-            </div>
-            <button
-              type="button"
-              aria-label="Dismiss"
-              className="shrink-0 text-muted hover:text-primary transition-colors"
-              onClick={dismissBanner}
-            >
-              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-              </svg>
-            </button>
-          </div>
-        </Alert>
-      )}
-
       <h2 id="mcp-tokens-heading" className="text-xl font-semibold mb-2 text-heading">MCP Tokens</h2>
       <p className="text-sm mb-6 text-secondary">
         Long-lived tokens that authorize the Memex installer / MCP clients on a device.

--- a/packages/ui/src/components/PromptButton.tsx
+++ b/packages/ui/src/components/PromptButton.tsx
@@ -211,7 +211,15 @@ export function PromptButton({
             onClick={() => setOpen(true)}
             className="font-medium text-accent underline underline-offset-2 hover:text-accent-hover disabled:opacity-50 disabled:no-underline"
           >
-            {linkText}
+            {/* spec-247 ac-15 (c-4): the terminal glyph rides the link text so
+                every copy-prompt affordance is recognisable as one, even
+                mid-sentence. */}
+            <span className="inline-flex items-baseline gap-1">
+              <span className="self-center" aria-hidden="true">
+                <TerminalIcon />
+              </span>
+              {linkText}
+            </span>
           </button>{' '}
           {sentence}
         </p>

--- a/packages/ui/src/pages/DocDocument.tsx
+++ b/packages/ui/src/pages/DocDocument.tsx
@@ -959,6 +959,10 @@ export function DocDocument() {
       canEdit={canEdit}
       /* spec-178 ac-24: same handle auto-linking suppression for demo decisions. */
       isDemo={doc.isDemo ?? false}
+      /* spec-247 dec-4: context for the candidate-review handoff PromptButton
+         and the chat-seeded "Ask for more explanation" prompt. */
+      promptContext={handoffContext}
+      orgBlocks={orgBlocks}
     />
   );
 
@@ -976,6 +980,9 @@ export function DocDocument() {
         specPhase={phase}
         focusedAcId={focusedAcId}
         onFocusConsumed={() => setFocusedAcId(null)}
+        /* spec-247 dec-4: context for the "Wire the AC tests" handoff. */
+        promptContext={handoffContext}
+        orgBlocks={orgBlocks}
       />
     </div>
   );


### PR DESCRIPTION
## What & why

Resolving a decision on the Spec page had **three** input surfaces competing for the same job (the decision-card comment box, the in-app agent chat, the MCP coding agent) and a "Resolve" CTA that silently dispatched agent analysis instead of saving the answer. A prod customer (Mark, agentcraft) answered ~8 decisions by clicking options — none persisted, because clicking only set local React state. spec-247 (which now absorbs archived spec-93's decision work) collapses this to **one obvious place to answer** and marks the web↔MCP boundary honestly.

Governing principle (dec-1/dec-6): **the web is for viewing plus the one minimum-friction answering click; the MCP/coding-agent is for action; comments are discussion and never resolution.**

Spec: https://memex.ai/mindset-prod/memex-building-itself/specs/spec-247

## Changes

- **Persist-on-select (dec-5).** Clicking an option on an open decision calls the resolve API immediately — no Save button, no required prose, no confirmation; the selection survives navigation because it *is* the persisted resolution. Re-selecting updates the choice. Server `resolveDecision` relaxes the `status === 'open'` guard (re-resolve in place) and makes `resolution` optional (defaults to the chosen option's label) across REST + MCP; the tool-contract change rides the single-sourced manifest [per std-16].
- **Honest decision card (dec-1/dec-2).** No CTA button, no reasoning input, no agent affordance. The card is: question, context, option rows, and a collapsed "Discussion (n)" toggle labelled "comments never resolve a decision". The old dual-path Resolve button — including the optionless `chat.sendMessage("Resolve decision D-N")` agent handoff — is removed.
- **Candidate cards view-only (dec-6).** Options render as information (no radios — nothing to silently drop); web Approve/Reject removed; `approve_candidate`/`reject_candidate` stay MCP-only with a coding-agent handoff marker.
- **Spec assistant grounding (dec-3).** "Private Agent" → "Spec assistant · private chat" with a permanent grounding line ("Works on this spec. Hasn't read your code. Connect a coding agent over MCP for code-grounded answers" → /settings/integrations), plus an adjacent disclosure on code-shaped output. Discloses **grounding, not capability** (the web agent shares the MCP tool catalog per spec-14 dec-4).
- **web↔MCP boundary markers (dec-4).** PromptButton [per std-23] handoffs on every MCP-only next step — the AC coverage rail, the all-untested explainer (the `get_information` copy moved into the prompt, off the human surface), and "Mark as accepted" (now glyph + "Human action"). Rule recorded as **std-34**; one-time audit recorded as the spec's new Surface-audit section (ac-5).
- **CommentTray.** The per-comment "Resolve" action is relabelled "Resolve Comment" — "Resolve" alone read as resolving the decision.

## Tests

- **Server** — `decisions.integration.test.ts`: re-resolve, optional resolution, default-prose (ac-17). 80 pass.
- **UI units** — DecisionPanel / ChatPanel / AcPanel / CommentTray / PromptButton (ac-6…ac-15, ac-19/20/21, ac-4). 94 pass.
- **E2E** — journey-27 (new): answer-by-click persists across reload, re-select, Discussion toggle, grounded panel; journey-14 rewritten (view-only candidates); journeys 19/21 moved to answer-by-click [per std-28]. journey-27 emits for ac-1/2/3/18/22.
- Production typecheck clean (shared + ui + server build configs). The dev-tsconfig errors in unrelated develop test files (telemetry/mixpanel/guide/discord/canary/share-tokens) are pre-existing on develop and untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)