### PR TITLE
feat(oauth): accept native-app private-use redirect URIs at DCR (spec-253)

### DIFF
--- a/packages/server/src/__regression__/oauth-authorize-redirect.regression.test.ts
+++ b/packages/server/src/__regression__/oauth-authorize-redirect.regression.test.ts
@@ -1,4 +1,11 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+// spec-253 ac-9 — custom-scheme redirect_uris match by strict (byte-identical)
+// equality at /authorize; the loopback set stays host- and port-insensitive.
+const AC_9 = "mindset-prod/memex-building-itself/specs/spec-253/acs/ac-9";
+// spec-253 scope ac-2 — existing https + loopback redirect shapes still authorize unchanged.
+const AC_2 = "mindset-prod/memex-building-itself/specs/spec-253/acs/ac-2";
 
 // Pins the absolute-Location contract on GET /api/oauth/authorize.
 //
@@ -170,6 +177,7 @@ describe("regression: GET /api/oauth/authorize loopback redirect_uri port flexib
   });
 
   it("loopback: registered localhost matches incoming 127.0.0.1 (hostname swap)", async () => {
+    tagAc(AC_2); // scope ac-2: loopback redirect_uri authorizes unchanged
     stubClientWithRedirect("http://localhost:11111/callback");
     const res = await getAuthorizeWithRedirect("http://127.0.0.1:33333/callback");
     expect(res.status).toBe(302);
@@ -205,8 +213,40 @@ describe("regression: GET /api/oauth/authorize loopback redirect_uri port flexib
   });
 
   it("non-loopback: strict exact-match still works (https registered = https requested)", async () => {
+    tagAc(AC_2); // scope ac-2: https redirect_uri authorizes unchanged
     stubClientWithRedirect("https://test.example/cb");
     const res = await getAuthorizeWithRedirect("https://test.example/cb");
+    expect(res.status).toBe(302);
+  });
+});
+
+// spec-253 ac-9: native-IDE private-use schemes are non-loopback, so they match
+// by strict (byte-identical) equality — there is no port/host flex for them —
+// while the loopback set remains host- and port-insensitive.
+describe("regression: custom-scheme + loopback redirect_uri matching (spec-253 ac-9)", () => {
+  beforeEach(() => {
+    process.env.APP_BASE_URL = "https://int.memex.ai";
+  });
+
+  it("ac-9: registered cursor:// matches a byte-identical incoming (302)", async () => {
+    tagAc(AC_9);
+    const uri = "cursor://anysphere.cursor-mcp/oauth/callback";
+    stubClientWithRedirect(uri);
+    const res = await getAuthorizeWithRedirect(uri);
+    expect(res.status).toBe(302);
+  });
+
+  it("ac-9: registered cursor:// rejects a non-identical incoming (400) — no flex outside loopback", async () => {
+    tagAc(AC_9);
+    stubClientWithRedirect("cursor://anysphere.cursor-mcp/oauth/callback");
+    const res = await getAuthorizeWithRedirect("cursor://anysphere.cursor-mcp/oauth/other");
+    expect(res.status).toBe(400);
+  });
+
+  it("ac-9: loopback localhost:P1 matches 127.0.0.1:P2 (host- and port-insensitive, 302)", async () => {
+    tagAc(AC_9);
+    stubClientWithRedirect("http://localhost:11111/callback");
+    const res = await getAuthorizeWithRedirect("http://127.0.0.1:22222/callback");
     expect(res.status).toBe(302);
   });
 });

--- a/packages/server/src/__security__/oauth-register-rate-limit.security.test.ts
+++ b/packages/server/src/__security__/oauth-register-rate-limit.security.test.ts
@@ -13,6 +13,13 @@ import { inArray } from "drizzle-orm";
 import { db } from "../db/connection.js";
 import { oauthClients } from "../db/schema.js";
 import { resetRateLimits } from "../services/auth-rate-limit.js";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+// spec-253 ac-11 — DCR abuse controls (IP rate-limit) stay enforced after the
+// validator was widened to accept custom-scheme redirect_uris.
+const AC_11 = "mindset-prod/memex-building-itself/specs/spec-253/acs/ac-11";
+// spec-253 scope ac-5 — the DCR rate-limit is part of the preserved security posture.
+const AC_5 = "mindset-prod/memex-building-itself/specs/spec-253/acs/ac-5";
 
 const originalFlag = process.env.OAUTH_ENABLED;
 
@@ -57,6 +64,8 @@ async function registerFromIp(ip: string, label: string): Promise<Response> {
 
 describe("security: POST /api/oauth/register rate-limit", () => {
   it("allows 10 registrations per hour per IP, blocks the 11th, isolates by IP", async () => {
+    tagAc(AC_11);
+    tagAc(AC_5); // scope ac-5: DCR rate-limit still holds (security posture preserved)
     const ipA = "203.0.113.10"; // RFC 5737 documentation range
     const ipB = "203.0.113.11";
 

--- a/packages/server/src/services/oauth/clients.ts
+++ b/packages/server/src/services/oauth/clients.ts
@@ -20,6 +20,27 @@ function randomToken(byteLength = 32): string {
   return randomBytes(byteLength).toString("base64url");
 }
 
+// Schemes never permitted as a redirect_uri target — they can execute script in
+// our origin (javascript:), carry local-file/inline payloads (data/vbscript/
+// file/blob/filesystem), or invoke known-abusable OS handlers (ms-msdt: was the
+// Follina CVE-2022-30190 vector; intent: targets arbitrary Android components).
+// They're denied even though they're non-http(s). Everything else that isn't
+// http(s) is treated as an RFC 8252 §7.1 private-use URI scheme (cursor://,
+// vscode://, windsurf://, com.example.app:/…). This denylist is defence-in-depth,
+// NOT the primary control: the real guards are the browser's external-app prompt,
+// the on-origin consent screen, and mandatory PKCE S256 (codes.ts) — the RFC 8252
+// §8.6 control that makes custom-scheme redirects safe. spec-253 dec-1 / t-3.
+const DANGEROUS_REDIRECT_SCHEMES = new Set([
+  "javascript",
+  "data",
+  "vbscript",
+  "file",
+  "blob",
+  "filesystem",
+  "intent",
+  "ms-msdt",
+]);
+
 /** RFC 7591 metadata accepted at /oauth/register. */
 export interface RegisterClientInput {
   /** Required. URLs the IdP will redirect to after consent. */
@@ -60,9 +81,8 @@ export async function registerClient(input: RegisterClientInput): Promise<Regist
     if (typeof uri !== "string" || uri.length === 0) {
       throw new ValidationError("redirect_uris entries must be non-empty strings");
     }
-    // RFC 7591 §2: redirect_uris MUST be absolute URIs. Localhost variants
-    // (Claude Desktop's loopback flow) are http://; everything else must be
-    // https. Disallow URL fragments per RFC 6749 §3.1.2.
+    // RFC 7591 §2: redirect_uris MUST be absolute URIs. Disallow URL fragments
+    // per RFC 6749 §3.1.2.
     let parsed: URL;
     try {
       parsed = new URL(uri);
@@ -72,10 +92,22 @@ export async function registerClient(input: RegisterClientInput): Promise<Regist
     if (parsed.hash !== "") {
       throw new ValidationError(`redirect_uri must not contain a fragment: ${uri}`);
     }
+    // RFC 8252 native-app redirects, three accepted shapes (spec-253 dec-1):
+    //   1. https:// (any host)
+    //   2. http://{localhost,127.0.0.1} — loopback flow, §7.3 (Claude Desktop)
+    //   3. a private-use URI scheme — §7.1 (cursor://, vscode://, windsurf://, …)
+    // Bare http:// to a non-loopback host and the dangerous-scheme denylist stay
+    // rejected. PKCE S256 (codes.ts) is the safety control for shape 3.
     const isLoopback = parsed.hostname === "localhost" || parsed.hostname === "127.0.0.1";
-    if (parsed.protocol !== "https:" && !(parsed.protocol === "http:" && isLoopback)) {
+    const scheme = parsed.protocol.replace(/:$/, "");
+    const isWebScheme = scheme === "http" || scheme === "https";
+    const accepted =
+      parsed.protocol === "https:" ||
+      (parsed.protocol === "http:" && isLoopback) ||
+      (!isWebScheme && !DANGEROUS_REDIRECT_SCHEMES.has(scheme));
+    if (!accepted) {
       throw new ValidationError(
-        `redirect_uri must be https:// (or http://localhost for loopback flows): ${uri}`,
+        `redirect_uri must be https://, http://localhost, or a private-use URI scheme: ${uri}`,
       );
     }
   }

--- a/packages/server/src/services/oauth/oauth.integration.test.ts
+++ b/packages/server/src/services/oauth/oauth.integration.test.ts
@@ -25,6 +25,23 @@ import {
   __setRotateMintHook,
 } from "./refresh-tokens.js";
 import { createHash, randomBytes } from "node:crypto";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+// spec-253 dec-1 — DCR must accept RFC 8252 §7.1 private-use URI schemes
+// (cursor://, vscode://, …) while still rejecting dangerous web schemes.
+const AC_6 = "mindset-prod/memex-building-itself/specs/spec-253/acs/ac-6";
+const AC_7 = "mindset-prod/memex-building-itself/specs/spec-253/acs/ac-7";
+// spec-253 dec-3 — VS Code's https://vscode.dev/redirect relay registers unchanged.
+const AC_10 = "mindset-prod/memex-building-itself/specs/spec-253/acs/ac-10";
+// spec-253 dec-1/dec-4 — PKCE stays mandatory; DCR abuse controls hold for custom schemes.
+const AC_8 = "mindset-prod/memex-building-itself/specs/spec-253/acs/ac-8";
+const AC_11 = "mindset-prod/memex-building-itself/specs/spec-253/acs/ac-11";
+// spec-253 scope ACs — the manager-level outcomes these mechanism tests collectively
+// prove. A test may tag both its implementation AC and the scope AC it satisfies.
+const AC_1 = "mindset-prod/memex-building-itself/specs/spec-253/acs/ac-1";
+const AC_2 = "mindset-prod/memex-building-itself/specs/spec-253/acs/ac-2";
+const AC_3 = "mindset-prod/memex-building-itself/specs/spec-253/acs/ac-3";
+const AC_5 = "mindset-prod/memex-building-itself/specs/spec-253/acs/ac-5";
 
 // PKCE helpers (RFC 7636 §4).
 function makePkce(): { verifier: string; challenge: string } {
@@ -60,6 +77,7 @@ async function registerAndTrack(input: Parameters<typeof registerClient>[0]) {
 
 describe("OAuth integration: client registration (DCR)", () => {
   it("registers a confidential client and stores a hashed secret", async () => {
+    tagAc(AC_2); // scope ac-2: https:// registration unchanged
     const { reg, client } = await registerAndTrack({
       clientName: "Test client",
       redirectUris: ["https://example.com/cb"],
@@ -97,6 +115,7 @@ describe("OAuth integration: client registration (DCR)", () => {
   });
 
   it("accepts http://localhost loopback (Claude Desktop pattern)", async () => {
+    tagAc(AC_2); // scope ac-2: loopback registration unchanged
     await expect(
       registerAndTrack({
         clientName: "Loopback",
@@ -132,6 +151,133 @@ describe("OAuth integration: client registration (DCR)", () => {
         redirectUris: tooMany,
       }),
     ).rejects.toThrow(/maximum of 10/);
+  });
+
+  // spec-253 dec-1 / dec-3: native IDEs (Cursor, VS Code, Windsurf, Zed)
+  // register an RFC 8252 §7.1 private-use URI scheme as their OAuth callback.
+  // DCR must accept these (and VS Code's https relay) while still rejecting
+  // dangerous web schemes and malformed URIs.
+  const ACCEPTED_REDIRECTS: Array<[string, string]> = [
+    ["cursor (private-use scheme)", "cursor://anysphere.cursor-mcp/oauth/callback"],
+    ["vscode (private-use scheme)", "vscode://anysphere.augment/auth/callback"],
+    ["windsurf (private-use scheme)", "windsurf://codeium.windsurf/callback"],
+    ["reverse-DNS scheme", "com.example.app:/oauth/cb"],
+  ];
+  for (const [label, uri] of ACCEPTED_REDIRECTS) {
+    it(`ac-6: accepts ${label} at registration`, async () => {
+      tagAc(AC_6);
+      tagAc(AC_1); // scope ac-1: a native IDE's private-use scheme registers at DCR
+      const { reg } = await registerAndTrack({
+        clientName: `Native ${label}`,
+        redirectUris: [uri],
+        tokenEndpointAuthMethod: "none",
+      });
+      expect(reg.clientId).toBeTruthy();
+    });
+  }
+
+  it("ac-10: accepts VS Code's https://vscode.dev/redirect relay unchanged", async () => {
+    tagAc(AC_10);
+    const { reg } = await registerAndTrack({
+      clientName: "VS Code relay",
+      redirectUris: ["https://vscode.dev/redirect"],
+      tokenEndpointAuthMethod: "none",
+    });
+    expect(reg.clientId).toBeTruthy();
+  });
+
+  const REJECTED_REDIRECTS: Array<[string, string, RegExp]> = [
+    ["javascript: scheme", "javascript:alert(1)", /private-use URI scheme/],
+    ["data: scheme", "data:text/html,<b>x</b>", /private-use URI scheme/],
+    ["file: scheme", "file:///etc/passwd", /private-use URI scheme/],
+    ["vbscript: scheme", "vbscript:msgbox(1)", /private-use URI scheme/],
+    ["ms-msdt: scheme (Follina handler)", "ms-msdt:/id PCWDiagnostic", /private-use URI scheme/],
+    ["intent: scheme (Android)", "intent://evil/#Intent;scheme=x;end", /private-use URI scheme|fragment/],
+    ["bare http to non-loopback host", "http://evil.example.com/cb", /must be https/],
+    ["a non-absolute string", "/relative/callback", /absolute URI/],
+  ];
+  for (const [label, uri, matcher] of REJECTED_REDIRECTS) {
+    it(`ac-7: rejects ${label}`, async () => {
+      tagAc(AC_7);
+      tagAc(AC_3); // scope ac-3: dangerous/malformed redirect URIs rejected with a clear error
+      await expect(
+        registerClient({ clientName: `Bad ${label}`, redirectUris: [uri] }),
+      ).rejects.toThrow(matcher);
+    });
+  }
+
+  it("ac-6: new URL() parses a private-use scheme without throwing (parse-behaviour lock)", () => {
+    tagAc(AC_6);
+    const parsed = new URL("cursor://anysphere.cursor-mcp/oauth/callback");
+    expect(parsed.protocol).toBe("cursor:");
+    expect(parsed.hash).toBe("");
+  });
+
+  it("ac-11: the 10-redirect_uri cap still applies to custom-scheme URIs", async () => {
+    tagAc(AC_11);
+    tagAc(AC_5); // scope ac-5: the 10-redirect_uri cap still holds
+    const tooMany = Array.from({ length: 11 }, (_, i) => `cursor://anysphere.cursor-mcp/cb${i}`);
+    await expect(
+      registerClient({ clientName: "Too many custom schemes", redirectUris: tooMany }),
+    ).rejects.toThrow(/maximum of 10/);
+  });
+});
+
+// spec-253 ac-8: widening the redirect_uri validator must not weaken PKCE —
+// S256 stays mandatory at both mint and consume, which is the control that
+// makes custom-scheme redirects safe (RFC 8252 §8.6).
+describe("OAuth integration: PKCE stays mandatory after custom-scheme widening (spec-253 ac-8)", () => {
+  it("ac-8: mintAuthCode rejects a non-S256 (plain) code_challenge_method", async () => {
+    tagAc(AC_8);
+    tagAc(AC_5); // scope ac-5: PKCE S256 stays mandatory
+
+    const userId = await makeTestUser();
+    const { client } = await registerAndTrack({
+      clientName: "PKCE plain reject",
+      redirectUris: ["cursor://anysphere.cursor-mcp/oauth/callback"],
+      tokenEndpointAuthMethod: "none",
+    });
+    await expect(
+      mintAuthCode({
+        clientId: client.id,
+        userId,
+        orgId: null,
+        redirectUri: "cursor://anysphere.cursor-mcp/oauth/callback",
+        codeChallenge: "abc",
+        codeChallengeMethod: "plain",
+        scopes: ["memex.full"],
+      }),
+    ).rejects.toThrow(/S256/);
+  });
+
+  it("ac-8: consumeAuthCode rejects a mismatched PKCE verifier (custom-scheme client)", async () => {
+    tagAc(AC_8);
+    tagAc(AC_5); // scope ac-5: PKCE S256 verification stays mandatory
+
+    const userId = await makeTestUser();
+    const { client } = await registerAndTrack({
+      clientName: "PKCE verify custom",
+      redirectUris: ["cursor://anysphere.cursor-mcp/oauth/callback"],
+      tokenEndpointAuthMethod: "none",
+    });
+    const { challenge } = makePkce();
+    const minted = await mintAuthCode({
+      clientId: client.id,
+      userId,
+      orgId: null,
+      redirectUri: "cursor://anysphere.cursor-mcp/oauth/callback",
+      codeChallenge: challenge,
+      codeChallengeMethod: "S256",
+      scopes: ["memex.full"],
+    });
+    await expect(
+      consumeAuthCode({
+        code: minted.code,
+        codeVerifier: randomBytes(32).toString("base64url"),
+        expectedClientId: client.id,
+        expectedRedirectUri: "cursor://anysphere.cursor-mcp/oauth/callback",
+      }),
+    ).rejects.toThrow(/PKCE verifier mismatch/);
   });
 });
 

--- a/packages/ui/src/components/CliInstallSection.test.tsx
+++ b/packages/ui/src/components/CliInstallSection.test.tsx
@@ -40,3 +40,20 @@ describe('spec-201 ac-16: claude.ai web + Cursor connect steps', () => {
     expect(screen.getAllByRole('button', { name: 'Copy' }).length).toBeGreaterThanOrEqual(2);
   });
 });
+
+// spec-253 t-5 (dec-3): the connect panel covers native IDEs beyond Cursor —
+// VS Code gets its own block, and the framing names the OAuth-on-connect set.
+// Smoke check that the artifact actually renders the new content.
+describe('spec-253: native-IDE OAuth connect steps (VS Code)', () => {
+  it('includes a VS Code connect block with the derived URL in its config', () => {
+    render(<CliInstallSection />);
+    expect(screen.getByRole('heading', { name: 'VS Code' })).toBeInTheDocument();
+    const vscodeConfig = screen.getByText(/"servers"[\s\S]*"memex"[\s\S]*\/mcp/);
+    expect(vscodeConfig.textContent).toContain(`${installBase}/mcp`);
+  });
+
+  it('frames the OAuth-on-connect clients as native IDEs (Cursor, VS Code, Windsurf, Zed)', () => {
+    render(<CliInstallSection />);
+    expect(screen.getByText(/Cursor, VS Code, Windsurf, Zed/)).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/CliInstallSection.tsx
+++ b/packages/ui/src/components/CliInstallSection.tsx
@@ -20,10 +20,24 @@ const PS_COMMAND = `irm ${installBase}/install.ps1 | iex`;
 const MCP_URL = `${installBase}/mcp`;
 
 // Cursor MCP config — remote server over HTTP. url-only is correct for dynamic
-// OAuth (spec-31): Cursor runs the sign-in flow on connect (no static token).
+// OAuth (spec-31 / spec-253): Cursor runs the sign-in flow on connect (no static
+// token). Cursor's OAuth callback is a private-use scheme (cursor://…), which the
+// DCR endpoint accepts per spec-253.
 const CURSOR_CONFIG = `{
   "mcpServers": {
     "memex": {
+      "url": "${MCP_URL}"
+    }
+  }
+}`;
+
+// VS Code MCP config — `.vscode/mcp.json` uses `servers` (not `mcpServers`) with
+// an explicit `type`. url-only = OAuth on connect (spec-253). VS Code may use a
+// loopback (127.0.0.1), an https relay, or a vscode:// callback; all are accepted.
+const VSCODE_CONFIG = `{
+  "servers": {
+    "memex": {
+      "type": "http",
       "url": "${MCP_URL}"
     }
   }
@@ -52,7 +66,7 @@ export function CliInstallSection() {
       <p className="mb-8 text-secondary">
         Connect Memex to Claude Code and Claude Desktop. The installer opens your browser
         once to authorize this device — after that it works without ever expiring. Using
-        claude.ai (web) or Cursor instead? See <a href="#other-clients" className="underline hover:text-primary">Other clients</a> below.
+        claude.ai (web) or a native IDE like Cursor or VS Code instead? See <a href="#other-clients" className="underline hover:text-primary">Other clients</a> below.
       </p>
 
       <div className="mb-10">
@@ -85,8 +99,9 @@ export function CliInstallSection() {
       <div id="other-clients" className="mb-10">
         <h3 className="text-base font-medium mb-3 text-heading">Other clients</h3>
         <p className="text-sm mb-3 text-secondary">
-          claude.ai (web) and Cursor connect to the same endpoint and sign in over OAuth —
-          no token to paste. Your MCP URL:
+          claude.ai (web) and native IDEs — Cursor, VS Code, Windsurf, Zed — connect to the
+          same endpoint and sign in over OAuth, so there's no token to paste. Add the server
+          with the URL below, then complete the sign-in your client prompts for. Your MCP URL:
         </p>
         <CodeBlock code={MCP_URL} />
 
@@ -108,6 +123,21 @@ export function CliInstallSection() {
               complete the OAuth sign-in:
             </p>
             <CodeBlock code={CURSOR_CONFIG} />
+          </div>
+          <div>
+            <h4 className="text-sm font-medium mb-2 text-heading">VS Code</h4>
+            <p className="text-xs mb-2 text-secondary">
+              Add to <InlineCode>.vscode/mcp.json</InlineCode>, then run{' '}
+              <InlineCode>MCP: List Servers</InlineCode> → <strong>Start</strong> and complete the
+              sign-in. VS Code completes OAuth automatically over whichever callback it picks
+              (a loopback address, its <InlineCode>vscode.dev</InlineCode> relay, or a{' '}
+              <InlineCode>vscode://</InlineCode> handler) — all are accepted:
+            </p>
+            <CodeBlock code={VSCODE_CONFIG} />
+            <p className="text-xs mt-2 text-muted">
+              Windsurf and Zed use the same URL in their own MCP config and sign in over OAuth
+              the same way — no token required.
+            </p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Why

Native IDEs (**Cursor, VS Code, Windsurf, Zed**) register an [RFC 8252 §7.1](https://datatracker.ietf.org/doc/html/rfc8252#section-7.1) **private-use URI scheme** as their OAuth callback — e.g. `cursor://anysphere.cursor-mcp/oauth/callback`. Our DCR endpoint only allowed `https://` and `http://localhost`, so registration was rejected **before the user ever saw the consent screen**. Observed live in Cursor:

```
redirect_uri must be https:// (or http://localhost for loopback flows): cursor://anysphere.cursor-mcp/oauth/callback
Connection failed.
```

This blocked every native-MCP IDE from the OAuth "click to authenticate" flow and forced users onto hand-copied long-lived `mxt_` PATs. It also narrows the client surface for the Anthropic Connectors directory (spec-31).

## What changed

- **`services/oauth/clients.ts`** — `registerClient()` now accepts three shapes (spec-253 dec-1): `https://`, `http://{localhost,127.0.0.1}`, and any **private-use URI scheme**, except a denylist `{javascript, data, vbscript, file, blob, filesystem, intent, ms-msdt}` and bare `http://` to a non-loopback host. PKCE S256 — already mandatory at mint **and** consume — is the RFC 8252 §8.6 control that keeps custom-scheme redirects safe; this only widens registration, nothing else.
- **`ui/components/CliInstallSection.tsx`** — Settings → Integrations connect panel now frames OAuth-on-connect as native IDEs (Cursor/VS Code/Windsurf/Zed) and adds a VS Code block with its three callback modes (dec-3).

No change to the `mxt_` PAT path; no `.ee.` files touched.

## Security

`security-reviewer` pass: **🟢 LOW — approve** (0 critical/high/medium). Confirmed: redirect_uri is never fetched server-side (client-side `window.location.href`, not a `302 Location` → no SSRF); strict-equality match for custom schemes; PKCE S256 mandatory both ends; denylist is case/whitespace-safe via `new URL()` normalization. Hardened the denylist with `blob/filesystem/intent/ms-msdt` (Follina) per the LOW finding.

## Test plan

- [x] DCR accept matrix: `cursor://`, `vscode://`, `windsurf://`, reverse-DNS, `https://vscode.dev/redirect`
- [x] DCR reject matrix: `javascript:`/`data:`/`file:`/`vbscript:`/`ms-msdt:`/`intent:`/bare-http-nonloopback/non-absolute
- [x] Authorize matching: custom-scheme byte-exact; loopback `localhost`↔`127.0.0.1` port-insensitive
- [x] PKCE S256 mandatory (mint + consume); DCR rate-limit + 10-cap regressions green
- [x] In-product panel renders VS Code block + native-IDE framing
- [x] **10/11 ACs verified** on Memex (ac-1, ac-2, ac-3, ac-5, ac-6…ac-11)
- [ ] **ac-4 — live Cursor OAuth e2e against int** (gated on this deploying to int; human-in-the-loop). std-17 smoke + std-28 journey to follow.

## Follow-ups (parked)

- spec-253 `issue-1` — `authorize.ts` appends `?code=` unconditionally → double-query on a query-bearing redirect_uri (pre-existing, correctness, not security).
- spec-31 `issue-1` — fold native-IDE content into `docs/connectors-claude.md` when it publishes at W7.

Memex: https://memex.ai/mindset-prod/memex-building-itself/specs/spec-253