### PR TITLE
fix(pulse): live-feed the bands, Working Now above Live, continuous AC bar

### DIFF
--- a/packages/ui/src/components/pulse/AcCells.tsx
+++ b/packages/ui/src/components/pulse/AcCells.tsx
@@ -1,49 +1,34 @@
-// AcCells — spec-255: one cell per acceptance criterion, mirroring the mockup's
-// "████████░░" bar. green = verified, red = failing, amber = stale, grey =
-// exists-but-untested. Derived from the AcHealth COUNTS (no per-AC detail
-// needed). Renders nothing when the spec has no ACs (absence is not a warning).
+// AcCells — spec-255: the AC-health bar on a Hot Spec card. A single CONTINUOUS
+// full-width bar filled PROPORTIONALLY (not one segment per AC — the count is
+// unbounded). Three states only:
+//   green  = ACs whose tests pass (verified; stale counts here — it did pass)
+//   red    = ACs whose tests fail
+//   yellow = ACs that exist but have NO tests yet (untested)
+// No bar at all = the spec has no ACs.
 
 import type { AcHealth } from '../../api/types';
-
-// Cap so a spec with a huge AC count doesn't blow the card width; the count
-// label still reads the true totals.
-const MAX_CELLS = 22;
-
-type Cell = 'verified' | 'failing' | 'stale' | 'untested';
-
-const CELL_CLASS: Record<Cell, string> = {
-  verified: 'bg-green-500',
-  failing: 'bg-rose-500',
-  stale: 'bg-amber-400',
-  untested: 'bg-zinc-300 dark:bg-zinc-600',
-};
 
 export function AcCells({ health }: { health: AcHealth | undefined }) {
   if (!health || health.totalActive === 0) return null;
   const { totalActive, verified, failing, stale } = health;
-  const untested = Math.max(0, totalActive - verified - failing - stale);
-
-  const cells: Cell[] = [
-    ...Array<Cell>(verified).fill('verified'),
-    ...Array<Cell>(failing).fill('failing'),
-    ...Array<Cell>(stale).fill('stale'),
-    ...Array<Cell>(untested).fill('untested'),
-  ];
-  const shown = cells.slice(0, MAX_CELLS);
+  const passing = verified + stale; // stale tests did pass, just aged → green
+  const untested = Math.max(0, totalActive - passing - failing);
+  const pct = (n: number) => `${(n / totalActive) * 100}%`;
 
   return (
     <div className="flex items-center gap-2" data-testid="ac-cells">
+      {/* One continuous bar; coloured regions are proportional widths. */}
       <div
-        className="flex gap-[2px]"
+        className="flex flex-1 h-2 rounded-sm overflow-hidden"
         role="img"
-        aria-label={`${verified} of ${totalActive} acceptance criteria verified${failing ? `, ${failing} failing` : ''}`}
+        aria-label={`${passing} of ${totalActive} acceptance criteria passing${failing ? `, ${failing} failing` : ''}${untested ? `, ${untested} untested` : ''}`}
       >
-        {shown.map((c, i) => (
-          <span key={i} data-cell={c} className={`h-2 w-3 rounded-[1px] ${CELL_CLASS[c]}`} />
-        ))}
+        {passing > 0 && <span data-cell="verified" className="h-full bg-green-500" style={{ width: pct(passing) }} />}
+        {failing > 0 && <span data-cell="failing" className="h-full bg-rose-500" style={{ width: pct(failing) }} />}
+        {untested > 0 && <span data-cell="untested" className="h-full bg-amber-400" style={{ width: pct(untested) }} />}
       </div>
-      <span className="font-mono text-[10px] tabular-nums text-muted">
-        {verified}/{totalActive}
+      <span className="shrink-0 font-mono text-[10px] tabular-nums text-muted">
+        {passing}/{totalActive}
       </span>
     </div>
   );

--- a/packages/ui/src/components/pulse/HotSpecs.spec-255.test.tsx
+++ b/packages/ui/src/components/pulse/HotSpecs.spec-255.test.tsx
@@ -88,11 +88,11 @@ describe('HotSpecs band (spec-255)', () => {
     expect(first.getByTestId('hot-spec-avatars')).toBeInTheDocument();
     // per-spec line sparkline present.
     expect(first.getByTestId('sparkline')).toBeInTheDocument();
-    // live AC cells — one per AC: HEALTH has 8 verified, 1 failing, 1 untested.
+    // live AC bar — one continuous proportional bar (HEALTH: 8 verified, 1 failing, 1 untested).
     const cells = first.getByTestId('ac-cells');
-    expect(cells.querySelectorAll('[data-cell="verified"]')).toHaveLength(8);
-    expect(cells.querySelectorAll('[data-cell="failing"]')).toHaveLength(1);
-    expect(cells.querySelectorAll('[data-cell="untested"]')).toHaveLength(1);
+    expect(cells.querySelector('[data-cell="verified"]')).toBeTruthy();
+    expect(cells.querySelector('[data-cell="failing"]')).toBeTruthy();
+    expect(cells).toHaveTextContent('8/10');
   });
 
   it('clicking a card navigates to that spec via its path-based route', () => {

--- a/packages/ui/src/pages/Pulse.spec-255.test.tsx
+++ b/packages/ui/src/pages/Pulse.spec-255.test.tsx
@@ -148,7 +148,7 @@ function follows(a: HTMLElement, b: HTMLElement): boolean {
 }
 
 describe('Pulse enhancement layout (spec-255)', () => {
-  it('orders the bands Vitals -> Hot Specs -> Live -> Working Now', async () => {
+  it('orders the bands Vitals -> Hot Specs -> Working Now -> Live', async () => {
     tagAc(AC(7));
     fetchDocsMock.mockResolvedValue([spec({ id: 'sb-1', handle: 'spec-1' })]);
     usePresenceMock.mockReturnValue({ rows: [present({ docId: 'sb-1' })], loading: false });
@@ -158,11 +158,11 @@ describe('Pulse enhancement layout (spec-255)', () => {
     renderPulse();
     const vitals = await screen.findByTestId('vitals-strip');
     const hot = screen.getByTestId('hot-specs');
-    const live = screen.getByTestId('live-band');
     const working = screen.getByTestId('working-now');
+    const live = screen.getByTestId('live-band');
     expect(follows(vitals, hot)).toBe(true);
-    expect(follows(hot, live)).toBe(true);
-    expect(follows(live, working)).toBe(true);
+    expect(follows(hot, working)).toBe(true);
+    expect(follows(working, live)).toBe(true);
   });
 
   it('shows BOTH bands at once, with no lens toggle (two bands, dec-6)', async () => {
@@ -183,15 +183,18 @@ describe('Pulse enhancement layout (spec-255)', () => {
     expect(screen.getByTestId('working-now')).toBeInTheDocument();
   });
 
-  it('demotes + shrinks the Live log (bounded height, not the page-filling band)', async () => {
+  it('puts the Live log at the bottom, allowed to grow tall (not capped)', async () => {
     tagAc(AC(2));
     renderPulse();
     const live = await screen.findByTestId('live-band');
-    expect(live.className).toMatch(/max-h-/);
-    expect(live.className).not.toMatch(/flex-1/);
+    // Live is the LAST band, below Working Now...
+    expect(follows(screen.getByTestId('working-now'), live)).toBe(true);
+    // ...and grows to fill the remaining height (flex-1), not capped small.
+    expect(live.className).toMatch(/flex-1/);
+    expect(live.className).not.toMatch(/max-h-/);
   });
 
-  it('ranks Hot Specs from PERSISTED history, not the live SSE buffer', async () => {
+  it('reflects LIVE events in Hot Specs immediately (merged live + history)', async () => {
     tagAc(AC(17));
     fetchDocsMock.mockResolvedValue([
       spec({ id: 'sb-H', handle: 'spec-h' }),
@@ -202,19 +205,17 @@ describe('Pulse enhancement layout (spec-255)', () => {
     );
     renderPulse();
     await screen.findByTestId('hot-specs');
-    // Persisted spec is a card.
-    expect(screen.getByTestId('hot-spec-card')).toHaveAttribute('data-doc-id', 'sb-H');
+    expect(screen.getAllByTestId('hot-spec-card').map((c) => c.getAttribute('data-doc-id'))).toEqual(['sb-H']);
 
-    // Push a LIVE-only row for a different spec through the stream callback.
+    // A live event for a DIFFERENT spec must surface it immediately — a live
+    // board reflects what is happening now, not only the last history fetch.
     act(() => {
       capturedOnRow?.(row({ id: 'live-L', briefId: 'sb-L', createdAt: new Date().toISOString() }));
     });
 
-    // Hot Specs still ranks only the persisted spec — the live buffer did not
-    // create a card (heat reads activity_log, not the SSE buffer).
-    const cards = screen.getAllByTestId('hot-spec-card');
-    expect(cards).toHaveLength(1);
-    expect(cards[0]).toHaveAttribute('data-doc-id', 'sb-H');
+    const ids = screen.getAllByTestId('hot-spec-card').map((c) => c.getAttribute('data-doc-id'));
+    expect(ids).toContain('sb-H');
+    expect(ids).toContain('sb-L');
   });
 
   it('surfaces a quiet spec as "quiet Nm" and counts only meaningful events', async () => {
@@ -227,7 +228,7 @@ describe('Pulse enhancement layout (spec-255)', () => {
     usePulseHistoryMock.mockReturnValue(
       history({
         rows: [
-          // sb-Q: last meaningful event 7 min ago → quiet, still in band.
+          // sb-Q: last meaningful event 7 min ago → quiet, still inside the 10-min band.
           row({ briefId: 'sb-Q', entity: 'task', action: 'updated', createdAt: new Date(Date.now() - 7 * 60_000).toISOString() }),
           // sb-R: only a READ action → not meaningful → must NOT become a hot spec.
           row({ briefId: 'sb-R', entity: 'document', action: 'viewed', createdAt: new Date(Date.now() - 30_000).toISOString() }),

--- a/packages/ui/src/pages/Pulse.tsx
+++ b/packages/ui/src/pages/Pulse.tsx
@@ -454,11 +454,14 @@ export function Pulse() {
           column; the Needs-attention tray keeps its place on the right. */}
       <div className="flex-1 min-h-0 grid grid-cols-1 lg:grid-cols-3 gap-6">
         <div className="lg:col-span-2 min-h-0 flex flex-col">
-          {/* spec-255 — Vitals strip (graphics) then the Hot Specs hero band. */}
-          <VitalsStrip present={presentRows} activity={historyRows} />
+          {/* spec-255 — Vitals strip (graphics) then the Hot Specs hero band.
+              Fed from the MERGED live+history stream (movingRows) so live events
+              move the sparklines and keep a spec hot the instant they land —
+              not only after a periodic history refetch. */}
+          <VitalsStrip present={presentRows} activity={movingRows} />
           <HotSpecs
             present={presentRows}
-            activity={historyRows}
+            activity={movingRows}
             specHandle={specHandleByDocId}
             specTitle={specTitleByDocId}
             specPhase={specPhaseByDocId}
@@ -473,11 +476,20 @@ export function Pulse() {
             failing={mergedTestSignals.failing}
             liveDelta={liveTestSignals.length}
           />
-          {/* Live event log — demoted directly under Hot Specs and shrunk so it
-              proves liveness without dominating the page (spec-255 dec-1 / ac-2). */}
+          {/* Working Now — by person, ABOVE the Live log. */}
+          <WorkingNow
+            present={displayedPresent}
+            loading={presenceLoading}
+            specHandle={specHandleByDocId}
+            specTitle={specTitleByDocId}
+            lastActivityAt={lastActivityAt}
+            lastNarrative={specNarrativeByDocId}
+          />
+          {/* Live event log — the BOTTOM band, allowed to grow tall (off-screen
+              is fine): it fills the remaining height and scrolls internally. */}
           <div
             data-testid="live-band"
-            className="flex-none max-h-72 min-h-0 mb-4 flex flex-col rounded-lg border border-edge-subtle bg-surface/40 overflow-hidden"
+            className="flex-1 min-h-0 flex flex-col rounded-lg border border-edge-subtle bg-surface/40 overflow-hidden"
           >
             <ActivityFeed
               rows={movingRows}
@@ -492,15 +504,6 @@ export function Pulse() {
               specHasActiveWorker={specHasActiveWorker}
             />
           </div>
-          {/* Working Now — by person, demoted to the bottom (spec-255 dec-1). */}
-          <WorkingNow
-            present={displayedPresent}
-            loading={presenceLoading}
-            specHandle={specHandleByDocId}
-            specTitle={specTitleByDocId}
-            lastActivityAt={lastActivityAt}
-            lastNarrative={specNarrativeByDocId}
-          />
         </div>
         <div className="lg:col-span-1 min-h-0 overflow-y-auto">
           {/* Test-signal volume graphic — the firehose as a live sparkline,


### PR DESCRIPTION
Follow-up to int review of the spec-255 Pulse work (merged in #145).

- **Live-feed the bands** — Vitals tempo + per-spec sparklines + heat now read the merged live+history stream (`movingRows`), not the periodically-fetched history. So every event in the Live view immediately moves the sparklines, and a spec stays hot while events are actually landing (it was dropping after ~1 min because heat read stale history; the 5-min quiet / 10-min drop constants are unchanged).
- **Layout** — Working Now moved ABOVE the Live log; Live is the bottom band and grows tall (fills remaining height; off-screen is fine).
- **Continuous AC bar** — one proportional bar instead of per-AC segments (which don't scale to an unbounded AC count): green = passing (verified, incl. stale), red = failing, yellow = untested; no bar = no ACs.

Full UI suite green (1181); `tsc -b` + vite build clean; spec-255 ACs re-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
