### PR TITLE
fix(telemetry): spec-244 — detect Mixpanel /track status:0 rejections (retry, don't drop)

### DIFF
--- a/packages/server/src/services/mixpanel-sink.test.ts
+++ b/packages/server/src/services/mixpanel-sink.test.ts
@@ -44,16 +44,17 @@ describe("toMixpanelEvent — mapping (ac-13)", () => {
 });
 
 describe("MixpanelSink.send — server-side HTTP, US host (ac-2 / ac-13)", () => {
-  it("POSTs a JSON batch to the US /track endpoint with the token in the body", async () => {
+  it("POSTs a JSON batch to the US /track (verbose) endpoint with the token in the body", async () => {
     tagAc(`${AC}/ac-13`);
     tagAc(`${AC}/ac-5`); // the curated forward set reaches Mixpanel in the default config
-    const fetchImpl = vi.fn(async () => new Response("1", { status: 200 }));
+    const fetchImpl = vi.fn(async () => new Response(JSON.stringify({ status: 1, error: null }), { status: 200 }));
     const sink = new MixpanelSink("PROD_TOKEN", fetchImpl as unknown as typeof fetch);
     await sink.send([row(), row({ id: "row-2", name: "cta.clicked" })]);
 
     expect(fetchImpl).toHaveBeenCalledTimes(1);
     const [url, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
-    expect(url).toBe("https://api.mixpanel.com/track"); // US host (dec-9)
+    expect(url).toContain("api.mixpanel.com/track"); // US host (dec-9)
+    expect(url).toContain("verbose=1"); // so a status:0 rejection is detectable
     expect(init.method).toBe("POST");
     const body = JSON.parse(init.body as string);
     expect(Array.isArray(body)).toBe(true);
@@ -67,6 +68,17 @@ describe("MixpanelSink.send — server-side HTTP, US host (ac-2 / ac-13)", () =>
     const sink = new MixpanelSink("T", fetchImpl as unknown as typeof fetch);
     await expect(sink.send([row()])).rejects.toThrow(/503/);
   });
+
+  it("throws on HTTP 200 with status:0 (Mixpanel REJECTED the batch) so it retries, not silently drops (ac-6)", async () => {
+    tagAc(`${AC}/ac-6`);
+    // /track returns 200 even on rejection — the silent-loss trap. The verbose body
+    // carries status:0 + an error; send() must throw so forwarded_at stays NULL.
+    const fetchImpl = vi.fn(async () =>
+      new Response(JSON.stringify({ status: 0, error: "invalid token" }), { status: 200 }),
+    );
+    const sink = new MixpanelSink("BAD", fetchImpl as unknown as typeof fetch);
+    await expect(sink.send([row()])).rejects.toThrow(/rejected the batch.*invalid token/);
+  });
 });
 
 describe("per-env project separation (ac-19)", () => {
@@ -76,7 +88,7 @@ describe("per-env project separation (ac-19)", () => {
     const fetchImpl = vi.fn(async (_url: string, init: RequestInit) => {
       const body = JSON.parse(init.body as string);
       calls.push(body[0].properties.token);
-      return new Response("1", { status: 200 });
+      return new Response(JSON.stringify({ status: 1, error: null }), { status: 200 });
     });
     // The int service carries the memex-int token; prod carries memex-prod's. Same
     // code, different MIXPANEL_TOKEN value per env — the dec-9 separation mechanism.

--- a/packages/server/src/services/mixpanel-sink.ts
+++ b/packages/server/src/services/mixpanel-sink.ts
@@ -51,14 +51,28 @@ export class MixpanelSink implements AnalyticsSink {
   async send(events: readonly UsageEvent[]): Promise<void> {
     if (events.length === 0) return;
     const payload = events.map((e) => toMixpanelEvent(e, this.token));
-    const res = await this.fetchImpl(MIXPANEL_TRACK_URL, {
+    // verbose=1 makes /track return a JSON {status, error} body instead of bare
+    // "1"/"0" text. This is load-bearing: /track signals an APPLICATION-level
+    // rejection (bad token, malformed property, rate limit) with HTTP 200 + a
+    // status:0 body — NOT a non-2xx. Without parsing the body, a rejected batch
+    // looks like success and is silently dropped (forwarded_at stamped, events lost).
+    const res = await this.fetchImpl(`${MIXPANEL_TRACK_URL}?verbose=1`, {
       method: "POST",
-      headers: { "Content-Type": "application/json", Accept: "text/plain" },
+      headers: { "Content-Type": "application/json", Accept: "application/json" },
       body: JSON.stringify(payload),
     });
+    // Transport-level failure (non-2xx).
     if (!res.ok) {
-      // Throw so the forwarder leaves forwarded_at unset and retries (dec-3).
-      throw new Error(`Mixpanel /track returned ${res.status}`);
+      throw new Error(`Mixpanel /track returned HTTP ${res.status}`);
+    }
+    // Application-level failure: throw on a non-1 status so the forwarder leaves
+    // forwarded_at NULL and retries (dec-3), rather than stamping a lost batch as
+    // delivered.
+    const body = (await res.json().catch(() => null)) as { status?: number; error?: string } | null;
+    if (!body || body.status !== 1) {
+      throw new Error(
+        `Mixpanel /track rejected the batch (status ${body?.status ?? "?"}): ${body?.error ?? "unknown"}`,
+      );
     }
   }
 }


### PR DESCRIPTION
## Why
While debugging "no events in memex-prod" (which turned out to be Mixpanel ingestion lag — the pipe was fine), this latent trap surfaced: `MixpanelSink.send` only checked `res.ok`. But Mixpanel's `/track` returns **HTTP 200 even on rejection**, signalling failure with a `status:0` body (bad token, malformed property, rate limit). So a rejected batch was silently stamped `forwarded_at` and **lost — no error, no retry**. Had the prod token actually been wrong, this bug would have made it undiagnosable.

## Change
- POST to `/track?verbose=1` (JSON `{status,error}` body instead of bare `"1"`/`"0"`).
- Throw on a non-1 status, so the forwarder leaves `forwarded_at` NULL and **retries** on the next tick instead of dropping the batch.
- New test for the HTTP 200 + `status:0` case; updated existing send tests to the verbose contract.

## Test plan
- `mixpanel-sink` + `usage-forwarder` suites green locally (9 tests).
- No behaviour change on the happy path (status:1 → resolves as before); the forwarder's at-least-once retry now actually triggers on application-level rejections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)