### PR TITLE
spec-242: Specky first-run dialogue — mic priming + value intro

### DIFF
--- a/packages/ui/e2e/journey-23-first-run-greeting.spec.ts
+++ b/packages/ui/e2e/journey-23-first-run-greeting.spec.ts
@@ -1,18 +1,24 @@
 import { test, expect, bareUrl, emitAcEvents, setOnboardingGreeted, DEV_EMAIL } from "./helpers/index.js";
+import { seedWhatsNewEntry, clearWhatsNewEntries } from "./helpers/seed.js";
 import { clearAnthropicQueue, queueAnthropicResponse } from "./helpers/anthropic-fake.js";
 
-// Journey 23 — first-run Specky greeting (spec-206 t-5).
+// Journey 23 — first-run one-shot + the walkthrough tour (spec-206 / spec-211).
 //
-// SCOPE: the user-facing first-run surface — there is NO welcome modal (ac-17),
-// the voice greeting auto-starts on a first session with no tap (ac-1), and a
-// user who has already been greeted is NOT greeted again (ac-5 / ac-14). The
-// spoken greeting itself (mic → STT → graph → TTS) is NOT driven here — it can't
-// be made deterministic headless (same gate as journey-21); the opening-context
-// content + stamp-on-active are covered by the unit suites (t-3). This journey is
-// the std-28 gate for the surface and emits the user-facing scope ACs.
+// REWORKED by spec-242: the spec-206 voice AUTO-START is superseded (spec-242
+// dec-2) — Specky now opens in TEXT via the docked dialogue card (journey-28 is
+// that surface's std-28 gate), and the spoken greeting moves behind the explicit
+// Turn on Mic press (spec-229). What survives of spec-206 here:
+//   - the once-per-user one-shot: an already-greeted user is NOT greeted again
+//     (ac-5 / ac-14) — now asserted as "no dialogue card, no auto session";
+//   - spec-206 ac-1 ("auto-starts with no tap") and ac-17 ("no welcome modal")
+//     are no longer emitted — the behaviours they named are superseded; their
+//     last emissions go stale by design. spec-229 restores the spoken-greeting
+//     journey behind Turn on Mic.
 //
-// Like journey-21, voice runs against the fake provider with a fake mic device and
-// an auto-accepted permission prompt, so the auto-start can actually reach `active`.
+// The spec-211 walkthrough test now drives the tour from the What's New ear —
+// the surviving seeded-session surface (session.start(openingContext) fires a
+// proactive turn, exactly the seam the greeting used). The fake model returns
+// start_walkthrough, which hands control to the spec-211 sequencer.
 
 test.use({
   launchOptions: {
@@ -21,18 +27,15 @@ test.use({
   permissions: ["microphone"],
 });
 
-const AC1 = "mindset-prod/memex-building-itself/specs/spec-206/acs/ac-1";
 const AC5 = "mindset-prod/memex-building-itself/specs/spec-206/acs/ac-5";
 const AC14 = "mindset-prod/memex-building-itself/specs/spec-206/acs/ac-14";
-const AC17 = "mindset-prod/memex-building-itself/specs/spec-206/acs/ac-17";
 // spec-211: accepting the walkthrough opens the demo spec (the tour begins).
 const AC211_1 = "mindset-prod/memex-building-itself/specs/spec-211/acs/ac-1";
 
 // Which ACs each test proves (emit on pass AND fail per the discipline).
 const ACS_BY_TITLE: Record<string, string[]> = {
-  "first session auto-starts the greeting with no tap, and no welcome modal (ac-1 / ac-17)": [AC1, AC17],
-  "a user who has already been greeted is not greeted again (ac-5 / ac-14)": [AC5, AC14],
-  "accepting the walkthrough starts the guided tour and opens the demo spec (spec-211 ac-1)": [AC211_1],
+  "a user who has already been greeted sees no dialogue and no auto session (ac-5 / ac-14)": [AC5, AC14],
+  "a seeded proactive turn returning start_walkthrough starts the tour and opens the demo spec (spec-211 ac-1)": [AC211_1],
 };
 
 test.afterEach(async ({}, testInfo) => {
@@ -47,24 +50,7 @@ test.afterEach(async ({}, testInfo) => {
   );
 });
 
-test("first session auto-starts the greeting with no tap, and no welcome modal (ac-1 / ac-17)", async ({
-  page,
-}) => {
-  // Un-greet the dev user so this IS a first session (the fixture pre-stamped it).
-  await setOnboardingGreeted(DEV_EMAIL, false);
-
-  await page.goto(bareUrl("/"));
-  await expect(page.getByRole("heading", { name: "Specs" })).toBeVisible({ timeout: 15_000 });
-
-  // ac-17: the first-run experience is voice-only — NO welcome modal/dialog.
-  await expect(page.getByRole("dialog")).toHaveCount(0);
-
-  // ac-1: Specky initiates the session ITSELF — the active-session pill appears
-  // with no click on the affordance. (The pill is how an active session renders.)
-  await expect(page.locator("[data-voice-pill]")).toBeVisible({ timeout: 15_000 });
-});
-
-test("a user who has already been greeted is not greeted again (ac-5 / ac-14)", async ({
+test("a user who has already been greeted sees no dialogue and no auto session (ac-5 / ac-14)", async ({
   page,
 }) => {
   // Mark the dev user already-greeted (the once-per-user flag is set).
@@ -73,24 +59,23 @@ test("a user who has already been greeted is not greeted again (ac-5 / ac-14)", 
   await page.goto(bareUrl("/"));
   await expect(page.getByRole("heading", { name: "Specs" })).toBeVisible({ timeout: 15_000 });
 
-  // Give the first-run controller the same window it had above to (not) auto-start.
+  // Give the first-run controller the same window journey-28 gives it.
   await page.waitForTimeout(3_000);
 
-  // ac-5 / ac-14: no auto-greeting — the idle in-view affordance is shown, not an
-  // auto-started session pill. (The user can still start one manually; it just
-  // isn't forced on them again.)
+  // ac-5 / ac-14: nothing first-run fires again — no dialogue card, no
+  // auto-started session; just the idle in-view affordance.
+  await expect(page.getByTestId("specky-dialogue")).toHaveCount(0);
   await expect(page.locator("[data-voice-pill]")).toHaveCount(0);
   await expect(page.locator("[data-voice-affordance]")).toBeVisible();
 });
 
-test("accepting the walkthrough starts the guided tour and opens the demo spec (spec-211 ac-1)", async ({
+test("a seeded proactive turn returning start_walkthrough starts the tour and opens the demo spec (spec-211 ac-1)", async ({
   page,
 }) => {
-  // Drive acceptance deterministically: the guide's first (proactive) turn returns
-  // the start_walkthrough tool — exactly what it emits when the user says "yes".
-  // That hands control to the client sequencer (spec-211), which OPENS the draft
-  // demo spec before any narration. (The live voice→LLM→narration timing + the
-  // per-phase board progression are unit-tested + verified live on INT.)
+  // Drive acceptance deterministically: the session's first (proactive) turn
+  // returns the start_walkthrough tool — exactly what the model emits when the
+  // user says "yes". That hands control to the client sequencer (spec-211),
+  // which OPENS the draft demo spec before any narration.
   await clearAnthropicQueue();
   await queueAnthropicResponse({
     textDeltas: [],
@@ -104,12 +89,32 @@ test("accepting the walkthrough starts the guided tour and opens the demo spec (
     stopReason: "end_turn",
   });
 
-  await setOnboardingGreeted(DEV_EMAIL, false);
-  await page.goto(bareUrl("/"));
-  await expect(page.getByRole("heading", { name: "Specs" })).toBeVisible({ timeout: 15_000 });
+  // Already-greeted so the first-run dialogue stays out of the way; the seeded
+  // What's New ear is the surviving entry point that starts a session WITH an
+  // opening context (the proactive-turn seam the old auto-greeting used).
+  await setOnboardingGreeted(DEV_EMAIL, true);
+  await clearWhatsNewEntries();
+  await seedWhatsNewEntry({
+    sourceSpecRef: "mindset-prod/memex-building-itself/specs/spec-journey23",
+    sourceSpecHandle: "spec-journey23",
+    title: "Walkthrough seed",
+    whatText: "A seeded entry to start a guided session.",
+    whyText: "Drives the proactive turn deterministically.",
+  });
 
-  // The greeting auto-starts → its opening turn emits start_walkthrough → the
-  // sequencer opens the demo spec's detail view (/specs/<handle>), leaving the board.
-  await page.waitForURL(/\/specs\/spec-\d+(\?|#|$)/, { timeout: 20_000 });
-  expect(page.url()).toMatch(/\/specs\/spec-\d+/);
+  try {
+    await page.goto(bareUrl("/"));
+    await expect(page.getByRole("heading", { name: "Specs" })).toBeVisible({ timeout: 15_000 });
+
+    // Ribbon → popup → the entry's ear starts the seeded session.
+    await page.getByTestId("whats-new-ribbon").click();
+    await page.getByTestId("whats-new-ear-spec-journey23").click();
+
+    // The proactive turn emits start_walkthrough → the sequencer opens the demo
+    // spec's detail view (/specs/<handle>), leaving the board.
+    await page.waitForURL(/\/specs\/spec-\d+(\?|#|$)/, { timeout: 20_000 });
+    expect(page.url()).toMatch(/\/specs\/spec-\d+/);
+  } finally {
+    await clearWhatsNewEntries();
+  }
 });

--- a/packages/ui/e2e/journey-28-specky-dialogue.spec.ts
+++ b/packages/ui/e2e/journey-28-specky-dialogue.spec.ts
@@ -1,0 +1,140 @@
+import { test, expect, bareUrl, emitAcEvents, setOnboardingGreeted, DEV_EMAIL } from "./helpers/index.js";
+
+// Journey 28 — first-run Specky dialogue (spec-242, std-28 gate).
+//
+// SCOPE: the two-page first-run sequence. Specky opens in TEXT (no cold mic
+// popup): page 1 is the mic-priming card — Specky introduces herself with a
+// "Turn on Mic" + "Not now" (the card is NOT a modal; the board stays live
+// behind it). "Turn on Mic" fires getUserMedia on the press and starts the
+// session; "Not now" skips voice. "Next" advances to page 2, the "get the most
+// out of Memex AI" value panel; "Close" consumes the server-side one-shot, leaves
+// the Specky avatar tappable, and the dialogue never re-shows.
+//
+// Mic permission is GRANTED in this context (fake device) so the Turn-on-Mic
+// path can reach `active`. Crucially, nothing auto-starts on LOAD — the pill
+// only appears AFTER the explicit Turn on Mic press, which is the proof that
+// getUserMedia isn't fired on load.
+
+// NB: we deliberately do NOT pre-grant `permissions: ["microphone"]`. The mic
+// must read as not-yet-granted so the "Turn on Mic" button renders (it's hidden
+// once granted — ac-16). The fake-UI flag still auto-accepts the real
+// getUserMedia prompt when the button is pressed, so the session can reach
+// `active` without a pre-grant.
+test.use({
+  launchOptions: {
+    args: ["--use-fake-ui-for-media-stream", "--use-fake-device-for-media-stream"],
+  },
+});
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-242/acs/ac-${n}`;
+
+// Which ACs each test proves (emit on pass AND fail per the discipline).
+const ACS_BY_TITLE: Record<string, string[]> = {
+  "first run opens on the mic-priming page in text — no mic prompt on load, board stays live":
+    [AC(1), AC(2), AC(14)],
+  "Turn on Mic starts the session, then Next → value panel → Close consumes the one-shot":
+    [AC(15), AC(18), AC(3), AC(4), AC(5)],
+  "Not now skips voice and is no dead end; the value panel still shows":
+    [AC(17), AC(6)],
+};
+
+test.afterEach(async ({}, testInfo) => {
+  if (testInfo.status === "skipped") return;
+  const acs = ACS_BY_TITLE[testInfo.title] ?? [];
+  if (acs.length === 0) return;
+  await emitAcEvents(
+    acs,
+    testInfo.status === "passed" ? "pass" : "fail",
+    `packages/ui/e2e/journey-28-specky-dialogue.spec.ts::${testInfo.title}`,
+    testInfo.duration,
+  );
+});
+
+test("first run opens on the mic-priming page in text — no mic prompt on load, board stays live", async ({
+  page,
+}) => {
+  await setOnboardingGreeted(DEV_EMAIL, false);
+
+  await page.goto(bareUrl("/"));
+  await expect(page.getByRole("heading", { name: "Specs" })).toBeVisible({ timeout: 15_000 });
+
+  // Page 1 — Specky introduces herself in text, with Turn on Mic + Not now (ac-14).
+  const card = page.getByTestId("specky-dialogue");
+  await expect(card).toBeVisible({ timeout: 15_000 });
+  await expect(card).toContainText("Hi, I'm Specky");
+  await expect(page.getByTestId("turn-on-mic")).toBeVisible();
+  await expect(page.getByTestId("mic-not-now")).toBeVisible();
+
+  // NOT a modal: no dialog role, and the board behind stays interactive — the
+  // New Spec composer opens while the card is up (it has no role=dialog, so we
+  // assert via its placeholder, as journey-26 does).
+  await expect(page.getByRole("dialog")).toHaveCount(0);
+  await page.getByRole("button", { name: "+ New Spec" }).click();
+  await expect(page.getByPlaceholder(/Describe the spec/i)).toBeVisible();
+  await page.keyboard.press("Escape");
+
+  // No voice auto-started on load (ac-1): the active-session pill is absent until
+  // an explicit Turn on Mic press.
+  await page.waitForTimeout(2_000);
+  await expect(page.locator("[data-voice-pill]")).toHaveCount(0);
+});
+
+test("Turn on Mic starts the session, then Next → value panel → Close consumes the one-shot", async ({
+  page,
+}) => {
+  await setOnboardingGreeted(DEV_EMAIL, false);
+
+  await page.goto(bareUrl("/"));
+  const card = page.getByTestId("specky-dialogue");
+  await expect(card).toBeVisible({ timeout: 15_000 });
+
+  // Press Turn on Mic → getUserMedia fires (fake-granted) → session reaches
+  // active → the pill appears (ac-15).
+  await page.getByTestId("turn-on-mic").click();
+  await expect(page.locator("[data-voice-pill]")).toBeVisible({ timeout: 15_000 });
+
+  // Next advances to the value panel (ac-18 / ac-3 / ac-4).
+  const footer = page.getByTestId("specky-dialogue-footer");
+  await expect(footer).toHaveText("Next");
+  await footer.click();
+  await expect(card).toContainText("Here's how you get the most out of Memex AI");
+  await expect(card).toContainText("1. Connect your coding agent");
+  await expect(card).toContainText("If you write code, do this first.");
+  await expect(card).toContainText("2. Walk through the demo spec");
+  await expect(card).toContainText("3. Work with your team");
+  await expect(card.locator('input[type="checkbox"]')).toHaveCount(0);
+
+  // Close ends + stamps the one-shot (ac-18 / ac-5): a reload never re-shows.
+  const closer = page.getByTestId("specky-dialogue-footer");
+  await expect(closer).toHaveText("Close");
+  await closer.click();
+  await expect(card).toHaveCount(0);
+
+  await page.reload();
+  await expect(page.getByRole("heading", { name: "Specs" })).toBeVisible({ timeout: 15_000 });
+  await page.waitForTimeout(2_000);
+  await expect(page.getByTestId("specky-dialogue")).toHaveCount(0);
+});
+
+test("Not now skips voice and is no dead end; the value panel still shows", async ({ page }) => {
+  await setOnboardingGreeted(DEV_EMAIL, false);
+
+  await page.goto(bareUrl("/"));
+  const card = page.getByTestId("specky-dialogue");
+  await expect(card).toBeVisible({ timeout: 15_000 });
+
+  // Decline the mic → no voice session starts (no pill), and the buttons clear
+  // (no nagging), but the dialogue is no dead end (ac-17 / ac-6).
+  await page.getByTestId("mic-not-now").click();
+  await page.waitForTimeout(2_000);
+  await expect(page.locator("[data-voice-pill]")).toHaveCount(0);
+  await expect(page.getByTestId("turn-on-mic")).toHaveCount(0);
+
+  // Next still advances to the value panel — the reviewer (text-only) path.
+  await page.getByTestId("specky-dialogue-footer").click();
+  await expect(card).toContainText("Here's how you get the most out of Memex AI");
+
+  // Closing leaves the Specky avatar available (no dead end).
+  await page.getByTestId("specky-dialogue-footer").click();
+  await expect(page.locator("[data-voice-affordance]")).toBeVisible();
+});

--- a/packages/ui/src/components/onboarding/FirstRunGreeting.spec-242.test.tsx
+++ b/packages/ui/src/components/onboarding/FirstRunGreeting.spec-242.test.tsx
@@ -1,0 +1,208 @@
+// spec-242 — the two-page first-run sequence + the value panel.
+//
+// Proves: Specky opens in TEXT with the mic-priming page and NEVER calls
+// getUserMedia on load (dec-2 / ac-1 / ac-9 / ac-11 / ac-14); "Turn on Mic"
+// fires session.start → getUserMedia only on the press (dec-5 / ac-15); the
+// button renders only when the mic isn't already granted (ac-16); "Not now"
+// starts no voice (ac-17); the sequence pages mic → value and stamps the
+// one-shot on the final Close (dec-6 / ac-18 / ac-10 / ac-5); and the value
+// panel is three static info cards, not a checklist (ac-13 / ac-3 / ac-4).
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+
+const fetchGreetingGate = vi.fn();
+const stampGreeting = vi.fn();
+vi.mock('../../api/client', () => ({
+  fetchGreetingGate: () => fetchGreetingGate(),
+  stampGreeting: () => stampGreeting(),
+}));
+
+const isMicAlreadyGranted = vi.fn();
+vi.mock('./micPermission', () => ({
+  isMicAlreadyGranted: () => isMicAlreadyGranted(),
+}));
+
+import { FirstRunGreeting } from './FirstRunGreeting';
+import { ValueIntroPanel, VALUE_INTRO_HEADING, VALUE_INTRO_ITEMS } from './ValueIntroPanel';
+import {
+  VoiceSessionProvider,
+  noopEarconPlayer,
+  type OrchestratorFactory,
+} from '@memex/guide-sdk';
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-242/acs/ac-${n}`;
+
+let orchestratorStarted = false;
+const recordingFactory: OrchestratorFactory = () => ({
+  start: async () => {
+    orchestratorStarted = true;
+  },
+  interrupt: () => {},
+  stop: () => {},
+});
+
+const getUserMediaSpy = vi.fn(async () => ({ getTracks: () => [] }) as unknown as MediaStream);
+
+function renderController() {
+  return render(
+    <VoiceSessionProvider
+      orchestratorFactory={recordingFactory}
+      earcons={noopEarconPlayer}
+      detectMic={() => true}
+      getUserMedia={getUserMediaSpy}
+    >
+      <FirstRunGreeting />
+    </VoiceSessionProvider>,
+  );
+}
+
+beforeEach(() => {
+  fetchGreetingGate.mockReset();
+  stampGreeting.mockReset();
+  getUserMediaSpy.mockClear();
+  isMicAlreadyGranted.mockReset();
+  isMicAlreadyGranted.mockResolvedValue(false);
+  orchestratorStarted = false;
+});
+
+describe('FirstRunGreeting — first-run sequence (spec-242 dec-2/dec-5/dec-6)', () => {
+  it('opens on the mic-priming page in text, with no getUserMedia / voice on load (ac-9 / ac-11 / ac-14)', async () => {
+    fetchGreetingGate.mockResolvedValue({ greet: true, firstName: 'Ryan' });
+
+    renderController();
+
+    // Page 1 is the mic-priming page — Specky introduces herself in text.
+    await waitFor(() => expect(screen.getByTestId('specky-dialogue')).toBeInTheDocument());
+    expect(screen.getByText(/Hi, I'm Specky/)).toBeInTheDocument();
+    expect(screen.getByTestId('turn-on-mic')).toBeInTheDocument();
+    expect(screen.getByTestId('mic-not-now')).toBeInTheDocument();
+
+    // Mic is available, yet nothing auto-started: no getUserMedia, no orchestrator.
+    await new Promise((r) => setTimeout(r, 30));
+    expect(getUserMediaSpy).not.toHaveBeenCalled();
+    expect(orchestratorStarted).toBe(false);
+
+    tagAc(AC(9));
+    tagAc(AC(11));
+    tagAc(AC(1)); // scope: no mic prompt fires on load
+    tagAc(AC(14)); // scope: Specky introduces herself + Turn on Mic / Not now
+  });
+
+  it('"Turn on Mic" fires session.start → getUserMedia, only on the press (ac-15)', async () => {
+    fetchGreetingGate.mockResolvedValue({ greet: true, firstName: 'Ryan' });
+
+    renderController();
+    await waitFor(() => expect(screen.getByTestId('turn-on-mic')).toBeInTheDocument());
+
+    expect(getUserMediaSpy).not.toHaveBeenCalled(); // not before the press
+    fireEvent.click(screen.getByTestId('turn-on-mic'));
+
+    // start() requests the mic and, on grant, runs the seeded opening turn.
+    await waitFor(() => expect(getUserMediaSpy).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(orchestratorStarted).toBe(true));
+
+    tagAc(AC(15));
+  });
+
+  it('renders "Turn on Mic" only when the mic is not already granted (ac-16)', async () => {
+    fetchGreetingGate.mockResolvedValue({ greet: true, firstName: 'Ryan' });
+    isMicAlreadyGranted.mockResolvedValue(true);
+
+    renderController();
+    await waitFor(() => expect(screen.getByTestId('specky-dialogue')).toBeInTheDocument());
+    // Already granted → the button never appears.
+    await new Promise((r) => setTimeout(r, 30));
+    expect(screen.queryByTestId('turn-on-mic')).toBeNull();
+    expect(screen.queryByTestId('mic-not-now')).toBeNull();
+
+    tagAc(AC(16));
+  });
+
+  it('"Not now" dismisses the ask without starting voice — no dead end (ac-17)', async () => {
+    fetchGreetingGate.mockResolvedValue({ greet: true, firstName: 'Ryan' });
+
+    renderController();
+    await waitFor(() => expect(screen.getByTestId('mic-not-now')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('mic-not-now'));
+
+    // No voice started; the buttons clear (no nagging) but the dialogue stays.
+    await new Promise((r) => setTimeout(r, 30));
+    expect(getUserMediaSpy).not.toHaveBeenCalled();
+    expect(orchestratorStarted).toBe(false);
+    expect(screen.queryByTestId('turn-on-mic')).toBeNull();
+    expect(screen.getByTestId('specky-dialogue')).toBeInTheDocument();
+
+    tagAc(AC(17));
+    tagAc(AC(6)); // scope: never a dead end
+  });
+
+  it('pages mic → value, then Close ends the sequence and stamps the one-shot once (ac-18 / ac-10)', async () => {
+    fetchGreetingGate.mockResolvedValue({ greet: true, firstName: 'Ryan' });
+    stampGreeting.mockResolvedValue(undefined);
+
+    renderController();
+    await waitFor(() => expect(screen.getByText(/Hi, I'm Specky/)).toBeInTheDocument());
+
+    // Page 1 footer is Next (not the final page) → advancing shows the value panel.
+    const footer = screen.getByTestId('specky-dialogue-footer');
+    expect(footer).toHaveTextContent('Next');
+    expect(stampGreeting).not.toHaveBeenCalled();
+    fireEvent.click(footer);
+
+    await waitFor(() => expect(screen.getByText(VALUE_INTRO_HEADING)).toBeInTheDocument());
+
+    // Page 2 footer is Close → ends + stamps exactly once.
+    const closer = screen.getByTestId('specky-dialogue-footer');
+    expect(closer).toHaveTextContent('Close');
+    fireEvent.click(closer);
+    expect(screen.queryByTestId('specky-dialogue')).toBeNull();
+    await waitFor(() => expect(stampGreeting).toHaveBeenCalledTimes(1));
+
+    tagAc(AC(18));
+    tagAc(AC(10));
+    tagAc(AC(5)); // scope: one-shot consumed on close
+  });
+
+  it('does not show the sequence (and never stamps) for an already-greeted user', async () => {
+    fetchGreetingGate.mockResolvedValue({ greet: false, firstName: 'Ryan' });
+
+    renderController();
+    await waitFor(() => expect(fetchGreetingGate).toHaveBeenCalledTimes(1));
+    await new Promise((r) => setTimeout(r, 30));
+    expect(screen.queryByTestId('specky-dialogue')).toBeNull();
+    expect(stampGreeting).not.toHaveBeenCalled();
+
+    tagAc(AC(5));
+  });
+});
+
+describe('ValueIntroPanel (spec-242 dec-4)', () => {
+  it('renders exactly three numbered info cards with the design copy, and nothing interactive (ac-13 / ac-3)', () => {
+    render(<ValueIntroPanel />);
+    const panel = screen.getByTestId('value-intro-panel');
+
+    const headings = within(panel).getAllByRole('heading');
+    expect(headings).toHaveLength(3);
+    expect(headings[0]).toHaveTextContent('1. Connect your coding agent');
+    expect(headings[1]).toHaveTextContent('2. Walk through the demo spec');
+    expect(headings[2]).toHaveTextContent('3. Work with your team');
+    expect(panel).toHaveTextContent('ready and waiting for you to try in the draft column');
+    expect(panel.querySelectorAll('a, button, input')).toHaveLength(0);
+
+    tagAc(AC(13));
+    tagAc(AC(3));
+  });
+
+  it('frames the MCP card builder-first: it opens with "If you write code, do this first." (ac-4)', () => {
+    expect(VALUE_INTRO_ITEMS[0].body.startsWith('If you write code, do this first.')).toBe(true);
+    render(<ValueIntroPanel />);
+    expect(screen.getByTestId('value-intro-panel')).toHaveTextContent(
+      'If you write code, do this first.',
+    );
+
+    tagAc(AC(4));
+  });
+});

--- a/packages/ui/src/components/onboarding/FirstRunGreeting.test.tsx
+++ b/packages/ui/src/components/onboarding/FirstRunGreeting.test.tsx
@@ -1,65 +1,23 @@
-// spec-206 t-3 — the first-run greeting controller.
+// spec-206 t-3 — the onboarding opening-context builder.
 //
 // Unit: the opening-context builder carries the required beats (ac-2/3/10/11).
-// Integration: against a REAL VoiceSessionProvider (injected mic/orchestrator), the
-// controller auto-starts on a first session with no tap (ac-1), stamps only once the
-// session reaches `active` (ac-16), and no-ops when audio is unavailable (ac-15).
+// The builder survives the spec-242 rework unchanged — spec-229 hands it to
+// `session.start()` when the user presses Turn on Mic, so these beats are still
+// exactly what the guide speaks.
+//
+// The spec-206 CONTROLLER tests that lived here (auto-start on first session /
+// no-op without audio / stamp-on-active — ac-1, ac-15, ac-16) are GONE with the
+// behaviour they proved: spec-242 dec-2 superseded the auto-start (Specky now
+// opens in text via the SpeckyDialogue card; voice begins only on the explicit
+// Turn on Mic press). The replacement behaviour is proven in
+// FirstRunGreeting.spec-242.test.tsx.
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { tagAc } from '@memex-ai-ac/vitest';
-import { render, waitFor } from '@testing-library/react';
 
-// Mock the user-level greeting API the controller calls.
-const fetchGreetingGate = vi.fn();
-const stampGreeting = vi.fn();
-vi.mock('../../api/client', () => ({
-  fetchGreetingGate: () => fetchGreetingGate(),
-  stampGreeting: () => stampGreeting(),
-}));
-
-import { FirstRunGreeting, buildOnboardingOpeningContext } from './FirstRunGreeting';
-import {
-  VoiceSessionProvider,
-  noopEarconPlayer,
-  type OrchestratorFactory,
-} from '@memex/guide-sdk';
+import { buildOnboardingOpeningContext } from './FirstRunGreeting';
 
 const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-206/acs/ac-${n}`;
-
-// Records the opening context the provider hands the orchestrator on start().
-let recordedOpening: string | undefined;
-const recordingFactory: OrchestratorFactory = (hooks) => ({
-  start: async (_stream, opening) => {
-    recordedOpening = opening;
-  },
-  interrupt: () => {},
-  stop: () => {},
-  narratePhase: () => hooks.onTurnComplete?.(),
-});
-
-const fakeStream = { getTracks: () => [] } as unknown as MediaStream;
-
-function renderController(opts: { micAvailable: boolean; grant?: boolean }) {
-  return render(
-    <VoiceSessionProvider
-      orchestratorFactory={recordingFactory}
-      earcons={noopEarconPlayer}
-      detectMic={() => opts.micAvailable}
-      getUserMedia={async () => {
-        if (opts.grant === false) throw new Error('denied');
-        return fakeStream;
-      }}
-    >
-      <FirstRunGreeting />
-    </VoiceSessionProvider>,
-  );
-}
-
-beforeEach(() => {
-  fetchGreetingGate.mockReset();
-  stampGreeting.mockReset();
-  recordedOpening = undefined;
-});
 
 describe('buildOnboardingOpeningContext (spec-206 ac-2/3/10/11)', () => {
   it('greets by first name and carries the value prop, orientation, invite, and offer', () => {
@@ -81,57 +39,5 @@ describe('buildOnboardingOpeningContext (spec-206 ac-2/3/10/11)', () => {
     expect(ctx).not.toMatch(/\bnull\b/); // never a placeholder/empty name
     expect(ctx).not.toContain('undefined');
     tagAc(AC(11));
-  });
-});
-
-describe('FirstRunGreeting controller', () => {
-  it('auto-starts the greeting on a first session (no tap) and stamps once active', async () => {
-    fetchGreetingGate.mockResolvedValue({ greet: true, firstName: 'Ryan' });
-    stampGreeting.mockResolvedValue(undefined);
-
-    renderController({ micAvailable: true, grant: true });
-
-    // No user interaction — the controller drives it (ac-1).
-    await waitFor(() => expect(fetchGreetingGate).toHaveBeenCalledTimes(1));
-    await waitFor(() => expect(recordedOpening).toContain('Ryan'));
-    // Session reached `active` → the flag is stamped exactly once (ac-16).
-    await waitFor(() => expect(stampGreeting).toHaveBeenCalledTimes(1));
-    tagAc(AC(1));
-    tagAc(AC(16));
-  });
-
-  it('no-ops when audio is unavailable — never greets, never stamps (ac-15)', async () => {
-    fetchGreetingGate.mockResolvedValue({ greet: true, firstName: 'Ryan' });
-
-    renderController({ micAvailable: false });
-
-    // Give any async effects a chance to (not) run.
-    await new Promise((r) => setTimeout(r, 20));
-    expect(fetchGreetingGate).not.toHaveBeenCalled(); // gate not even hit
-    expect(recordedOpening).toBeUndefined(); // session never started
-    expect(stampGreeting).not.toHaveBeenCalled(); // one-shot preserved
-    tagAc(AC(15));
-  });
-
-  it('does not greet a returning user (greet=false) and does not stamp', async () => {
-    fetchGreetingGate.mockResolvedValue({ greet: false, firstName: 'Ryan' });
-
-    renderController({ micAvailable: true, grant: true });
-
-    await waitFor(() => expect(fetchGreetingGate).toHaveBeenCalledTimes(1));
-    await new Promise((r) => setTimeout(r, 20));
-    expect(recordedOpening).toBeUndefined();
-    expect(stampGreeting).not.toHaveBeenCalled();
-  });
-
-  it('does not stamp the one-shot when mic permission is denied (ac-16)', async () => {
-    fetchGreetingGate.mockResolvedValue({ greet: true, firstName: 'Ryan' });
-
-    renderController({ micAvailable: true, grant: false });
-
-    await waitFor(() => expect(fetchGreetingGate).toHaveBeenCalledTimes(1));
-    await new Promise((r) => setTimeout(r, 20));
-    // start() was attempted but permission was denied → never `active` → no stamp.
-    expect(stampGreeting).not.toHaveBeenCalled();
   });
 });

--- a/packages/ui/src/components/onboarding/FirstRunGreeting.tsx
+++ b/packages/ui/src/components/onboarding/FirstRunGreeting.tsx
@@ -1,30 +1,34 @@
-// spec-206 t-3 — the first-run greeting controller.
+// spec-242 — the first-run controller. Specky opens in TEXT (no cold mic popup),
+// running a two-page Specky dialogue sequence over the board:
 //
-// On a user's first session, Specky initiates the conversation ITSELF — no modal,
-// no tap (ac-1). This component (mounted inside VoiceGuideMount, so it has the
-// voice session + the shared reveal pointer in scope) does four things:
+//   Page 1 — mic priming: Specky introduces herself and explains why she needs
+//     the mic. "Turn on Mic" fires getUserMedia DIRECTLY (via session.start),
+//     and on grant Specky starts speaking; the button only renders if the mic
+//     isn't already granted for this browser session. "Not now" is a graceful
+//     skip — no voice, no dead end (the Specky avatar stays tappable). The cold
+//     browser permission popup never fires on load — only on this explicit press
+//     (dec-2 / dec-5; supersedes spec-206's auto-start).
+//   Page 2 — "Here's how you get the most out of Memex AI": three info cards
+//     (dec-4). Footer "Close" ends the sequence and stamps the one-shot.
 //
-//   1. On board mount, asks the server whether to greet (GET /api/onboarding/greeting).
-//   2. If greet && audio is available, auto-starts the voice session seeded with the
-//      onboarding opening context — Specky opens by greeting + explaining (dec-1/dec-2).
-//   3. If audio is unavailable (no mic / denied / no key), it no-ops — the user just
-//      lands on the board (dec-4 / ac-15). The flag is left null so a later session
-//      can still greet.
-//   4. Stamps onboarding_greeted_at ONLY once the session actually reaches `active`
-//      (dec-4 / ac-16) — a blocked/denied start never consumes the one-shot.
-//
-// Renders nothing — it's a behavioural controller, like WhatsNewRibbonConnected.
+// The first-run gate is spec-206's server-side one-shot (users.onboarding_greeted_at,
+// GET/POST /api/onboarding/greeting). Stamp happens on the final Close (dec-2), so
+// a mid-sequence reload re-shows the dialogue.
 
-import { useEffect, useRef } from 'react';
-import { useVoiceSession, isAffordanceDisabled } from '@memex/guide-sdk';
+import { useEffect, useRef, useState } from 'react';
+import { useVoiceSession } from '@memex/guide-sdk';
 import { fetchGreetingGate, stampGreeting } from '../../api/client';
+import { SpeckyDialogue, type SpeckyDialoguePage } from '../specky-dialogue/SpeckyDialogue';
+import { ValueIntroPanel, VALUE_INTRO_HEADING } from './ValueIntroPanel';
+import { isMicAlreadyGranted } from './micPermission';
+import { MicGlyph } from './MicGlyph';
 
 /**
- * The seed context handed to the guide for its proactive opening turn (dec-2).
- * The guide LLM produces the actual spoken greeting from this seed. Encodes:
- * a warm first-name greeting (or a nameless fallback), the value prop, on-screen
- * orientation, the open invitation, and the demo-walkthrough offer — all "under a
- * minute" (ac-2 / ac-3 / ac-10 / ac-11).
+ * The seed context handed to the guide for its proactive opening turn. The guide
+ * LLM produces the actual spoken greeting from this seed once the mic is granted
+ * (the "Turn on Mic" press calls session.start with it). Carries a warm first-name
+ * greeting (or a nameless fallback), the value prop, on-screen orientation, the
+ * open invitation, and the demo-walkthrough offer — all "under a minute".
  */
 export function buildOnboardingOpeningContext(firstName: string | null): string {
   const greeting = firstName
@@ -42,23 +46,26 @@ export function buildOnboardingOpeningContext(firstName: string | null): string 
   ].join('\n');
 }
 
-export function FirstRunGreeting(): null {
+export function FirstRunGreeting(): React.JSX.Element | null {
   const session = useVoiceSession();
-  const { start, status, micAvailable } = session;
-  // Guard one-shots: we auto-start at most once, and stamp at most once — and only
-  // for a greeting WE initiated (a user-started session must never stamp the flag).
-  const startedRef = useRef(false);
+  const [show, setShow] = useState(false);
+  const [firstName, setFirstName] = useState<string | null>(null);
+  // The "Turn on Mic" button only renders if the mic isn't already granted
+  // (dec-5). Probed once on mount; defaults to showing the button.
+  const [micAlreadyGranted, setMicAlreadyGranted] = useState(false);
+  // Once the user has resolved the mic ask (granted or declined), the action
+  // row goes away — Specky doesn't nag (ac-6).
+  const [micResolved, setMicResolved] = useState(false);
+
+  // Stamp the one-shot at most once per sequence. (We deliberately DON'T guard the
+  // gate fetch with a ref: the GET is idempotent, and a one-shot ref would let
+  // StrictMode's first mount cancel mid-fetch while the second mount short-circuits
+  // — leaving the dialogue stuck hidden. Mirror WhatsNewRibbon: an `alive` flag and
+  // a re-fetch on remount.)
   const stampedRef = useRef(false);
 
-  // 1–3: check the gate once on mount and auto-start when eligible + audible.
   useEffect(() => {
-    if (startedRef.current) return;
-    // Audio can't run → no-op, land on board (ac-15). Don't even hit the gate, so
-    // the one-shot is preserved for a later session that does have a mic.
-    if (isAffordanceDisabled({ status, micAvailable } as Parameters<typeof isAffordanceDisabled>[0])) {
-      return;
-    }
-    let cancelled = false;
+    let alive = true;
     void (async () => {
       let gate;
       try {
@@ -66,31 +73,74 @@ export function FirstRunGreeting(): null {
       } catch {
         return; // gate unreachable → silently skip; never block the board
       }
-      if (cancelled || !gate.greet || startedRef.current) return;
-      startedRef.current = true;
-      // start() itself requests mic permission; a denial routes to permission_denied
-      // (not active), so the stamp effect below won't fire — the one-shot survives.
-      void start(buildOnboardingOpeningContext(gate.firstName));
+      if (!alive || !gate.greet) return;
+      setFirstName(gate.firstName);
+      setShow(true);
+      void isMicAlreadyGranted().then((granted) => alive && setMicAlreadyGranted(granted));
     })();
     return () => {
-      cancelled = true;
+      alive = false;
     };
-    // Mount-once: live status is read by the stamp effect below.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // 4: stamp only once the greeting actually starts speaking (status → active).
-  useEffect(() => {
-    if (!startedRef.current || stampedRef.current) return;
-    if (status === 'active') {
-      stampedRef.current = true;
-      void stampGreeting().catch(() => {
-        // Stamp failed — allow a retry on a later 'active' transition rather than
-        // burning the one-shot on a network blip.
-        stampedRef.current = false;
-      });
-    }
-  }, [status]);
+  if (!show) return null;
 
-  return null;
+  // "Turn on Mic" fires getUserMedia directly (session.start → acquireMic →
+  // navigator.mediaDevices.getUserMedia); on grant the orchestrator opens with
+  // the seeded greeting, so Specky starts speaking. start() is idempotent and
+  // routes a denial to permission_denied without consuming the one-shot.
+  const turnOnMic = () => {
+    setMicResolved(true);
+    void session.start(buildOnboardingOpeningContext(firstName));
+  };
+
+  const notNow = () => {
+    setMicResolved(true); // graceful skip — no voice; the avatar stays available
+  };
+
+  const close = () => {
+    setShow(false);
+    if (stampedRef.current) return;
+    stampedRef.current = true;
+    void stampGreeting().catch(() => {
+      // Stamp failed — the one-shot survives a network blip; the dialogue may
+      // show once more next session rather than being silently lost.
+      stampedRef.current = false;
+    });
+  };
+
+  const showMicAsk = !micAlreadyGranted && !micResolved;
+
+  const pages: SpeckyDialoguePage[] = [
+    {
+      key: 'mic-priming',
+      heading: "Hi, I'm Specky 👋",
+      body: (
+        <p>
+          Your guide inside Memex AI. Ask me anything: where things live, what a status
+          means, what to do next. I'll talk you through it. To do any of that, I need your
+          mic. Worth it, I promise.
+        </p>
+      ),
+      actions: showMicAsk
+        ? [
+            {
+              label: 'Turn on Mic',
+              onSelect: turnOnMic,
+              kind: 'primary',
+              icon: <MicGlyph />,
+              testId: 'turn-on-mic',
+            },
+            { label: 'Not now', onSelect: notNow, kind: 'quiet', testId: 'mic-not-now' },
+          ]
+        : undefined,
+    },
+    {
+      key: 'value-intro',
+      heading: VALUE_INTRO_HEADING,
+      body: <ValueIntroPanel />,
+    },
+  ];
+
+  return <SpeckyDialogue pages={pages} onClose={close} />;
 }

--- a/packages/ui/src/components/onboarding/MicGlyph.tsx
+++ b/packages/ui/src/components/onboarding/MicGlyph.tsx
@@ -1,0 +1,22 @@
+// spec-242 — the mic glyph on the "Turn on Mic" button (design: keyboard_voice).
+// Inline SVG to match the repo's icon convention (no icon library in packages/ui).
+
+export function MicGlyph({ size = 18 }: { size?: number }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <rect x="9" y="2" width="6" height="12" rx="3" />
+      <path d="M5 10v1a7 7 0 0 0 14 0v-1" />
+      <line x1="12" y1="19" x2="12" y2="22" />
+    </svg>
+  );
+}

--- a/packages/ui/src/components/onboarding/ValueIntroPanel.tsx
+++ b/packages/ui/src/components/onboarding/ValueIntroPanel.tsx
@@ -1,0 +1,45 @@
+// spec-242 t-3 (dec-4) — "Here's how you get the most out of Memex AI".
+//
+// The final page of the first-run Specky dialogue: three numbered, tinted info
+// cards, copy verbatim from the design (Figma 590-1855, one typo fixed — "for
+// you to try"). Explicitly NOT a checklist (ac-3/ac-13): static text only — no
+// links, buttons, checkboxes, state detection, or completion ticks. The
+// builder-vs-reviewer call rides the MCP card's opening line ("If you write
+// code, do this first.") rather than any persona picker (dec-4 / ac-4).
+//
+// std-34 note: the MCP card points the user at the in-browser setup page
+// (Settings → Integrations, route /settings/integrations) — it names no MCP
+// tool and describes no MCP-only action as in-browser; the handoff affordances
+// live on that page.
+
+export const VALUE_INTRO_HEADING = "Here's how you get the most out of Memex AI";
+
+export const VALUE_INTRO_ITEMS: ReadonlyArray<{ title: string; body: string }> = [
+  {
+    title: 'Connect your coding agent',
+    body: 'If you write code, do this first. Connect your agent via MCP to create and work on specs directly from your coding environment. Find the setup in your profile under Integrations.',
+  },
+  {
+    title: 'Walk through the demo spec',
+    body: "We've set up a demo spec in your personal Memex, ready and waiting for you to try in the draft column.",
+  },
+  {
+    title: 'Work with your team',
+    body: 'Set up your own org, or ask your Memex admin to invite you to theirs.',
+  },
+];
+
+export function ValueIntroPanel() {
+  return (
+    <div data-testid="value-intro-panel" className="flex flex-col gap-3">
+      {VALUE_INTRO_ITEMS.map((item, i) => (
+        <div key={item.title} className="rounded-lg bg-accent/10 p-4">
+          <h3 className="text-sm font-semibold text-heading">
+            {i + 1}. {item.title}
+          </h3>
+          <p className="mt-1.5 text-sm text-secondary">{item.body}</p>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/packages/ui/src/components/onboarding/micPermission.ts
+++ b/packages/ui/src/components/onboarding/micPermission.ts
@@ -1,0 +1,21 @@
+// spec-242 — does this browser session already hold microphone permission?
+//
+// Used to decide whether the mic-priming page shows the "Turn on Mic" button: a
+// user who has already granted the mic never sees it. We query the Permissions
+// API (not getUserMedia — that would itself trigger the prompt we're trying to
+// pre-empt). The API is absent / unreliable on some browsers (notably Safari),
+// so any failure resolves to `false` (assume not-granted → show the button),
+// which is the safe default: the worst case is offering a button to a user who
+// could also have started voice another way.
+
+export async function isMicAlreadyGranted(): Promise<boolean> {
+  if (typeof navigator === 'undefined' || !navigator.permissions?.query) return false;
+  try {
+    const status = await navigator.permissions.query({
+      name: 'microphone' as PermissionName,
+    });
+    return status.state === 'granted';
+  } catch {
+    return false;
+  }
+}

--- a/packages/ui/src/components/specky-dialogue/SpeckyDialogue.spec-242.test.tsx
+++ b/packages/ui/src/components/specky-dialogue/SpeckyDialogue.spec-242.test.tsx
@@ -1,0 +1,111 @@
+// spec-242 t-1 — the reusable Specky text-dialogue surface (dec-1, dec-3).
+//
+// Proves: the card is NON-modal (no scrim, no dialog role, board content stays
+// reachable — ac-7), the pages[] model pages with Next and ends with Close
+// (ac-8), at most two actions render with the primary/quiet treatment (dec-1),
+// and the card renders no second Specky (dec-3 / ac-12 — the VoiceLayer avatar
+// is the face, and it renders independently of this surface).
+
+import { describe, it, expect, vi } from 'vitest';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+
+import { SpeckyDialogue, type SpeckyDialoguePage } from './SpeckyDialogue';
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-242/acs/ac-${n}`;
+
+const twoPages: SpeckyDialoguePage[] = [
+  { key: 'one', heading: 'Page one', body: 'First body' },
+  { key: 'two', heading: 'Page two', body: 'Second body' },
+];
+
+describe('SpeckyDialogue surface (spec-242 dec-1)', () => {
+  it('renders a non-modal docked card: no scrim, no dialog role, content behind stays reachable (ac-7)', () => {
+    const { container } = render(
+      <>
+        <button type="button" data-testid="board-button">
+          board
+        </button>
+        <SpeckyDialogue pages={twoPages} onClose={() => {}} />
+      </>,
+    );
+
+    const card = screen.getByTestId('specky-dialogue');
+    // Docked above the VoiceLayer avatar anchor, fixed — not centered, not portal'd.
+    expect(card.className).toContain('fixed');
+    expect(card.className).toContain('bottom-20');
+    expect(card.className).toContain('right-6');
+    // Non-modal: complementary landmark, never a dialog, and NO scrim element —
+    // nothing covers the viewport, so the board behind stays interactive.
+    expect(card).toHaveAttribute('role', 'complementary');
+    expect(screen.queryByRole('dialog')).toBeNull();
+    expect(container.querySelector('[class*="inset-0"]')).toBeNull();
+    // The board content is still reachable and clickable.
+    const boardButton = screen.getByTestId('board-button');
+    const clicked = vi.fn();
+    boardButton.addEventListener('click', clicked);
+    fireEvent.click(boardButton);
+    expect(clicked).toHaveBeenCalledTimes(1);
+
+    tagAc(AC(7));
+    tagAc(AC(2)); // scope: the reusable non-modal Specky dialogue surface exists
+  });
+
+  it('pages with Next on non-final pages and Close on the final page, which fires onClose (ac-8)', () => {
+    const onClose = vi.fn();
+    const onPageChange = vi.fn();
+    render(<SpeckyDialogue pages={twoPages} onClose={onClose} onPageChange={onPageChange} />);
+
+    // Page one: footer reads Next, not Close.
+    expect(screen.getByText('Page one')).toBeInTheDocument();
+    const footer = screen.getByTestId('specky-dialogue-footer');
+    expect(footer).toHaveTextContent('Next');
+
+    // Next advances — the sequence does not end.
+    fireEvent.click(footer);
+    expect(onClose).not.toHaveBeenCalled();
+    expect(onPageChange).toHaveBeenCalledWith(1);
+    expect(screen.getByText('Page two')).toBeInTheDocument();
+
+    // Final page: footer reads Close and ends the sequence.
+    expect(screen.getByTestId('specky-dialogue-footer')).toHaveTextContent('Close');
+    fireEvent.click(screen.getByTestId('specky-dialogue-footer'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    tagAc(AC(8));
+    tagAc(AC(2));
+  });
+
+  it('renders at most two actions, with primary and quiet treatments (dec-1)', () => {
+    const pages: SpeckyDialoguePage[] = [
+      {
+        key: 'actions',
+        heading: 'Actions',
+        body: 'body',
+        actions: [
+          { label: 'Do it', onSelect: () => {}, kind: 'primary', testId: 'primary-action' },
+          { label: 'Not now', onSelect: () => {}, kind: 'quiet', testId: 'quiet-action' },
+          { label: 'A third', onSelect: () => {}, testId: 'third-action' },
+        ],
+      },
+    ];
+    render(<SpeckyDialogue pages={pages} onClose={() => {}} />);
+
+    expect(screen.getByTestId('primary-action')).toBeInTheDocument();
+    expect(screen.getByTestId('quiet-action')).toBeInTheDocument();
+    expect(screen.queryByTestId('third-action')).toBeNull(); // two max
+    expect(screen.getByTestId('primary-action').className).toContain('bg-btn-primary');
+    expect(screen.getByTestId('quiet-action').className).not.toContain('bg-btn-primary');
+  });
+
+  it('renders no second Specky inside the card — the VoiceLayer avatar is the face (ac-12)', () => {
+    render(<SpeckyDialogue pages={twoPages} onClose={() => {}} />);
+    const card = screen.getByTestId('specky-dialogue');
+    // The Specky character renders as an <img> (guide-sdk Specky.tsx); the card
+    // must contain none — one Specky on screen, owned by VoiceLayer (dec-3).
+    expect(within(card).queryAllByRole('img')).toHaveLength(0);
+    expect(card.querySelector('img')).toBeNull();
+
+    tagAc(AC(12));
+  });
+});

--- a/packages/ui/src/components/specky-dialogue/SpeckyDialogue.tsx
+++ b/packages/ui/src/components/specky-dialogue/SpeckyDialogue.tsx
@@ -1,0 +1,109 @@
+// spec-242 t-1 (dec-1) — the reusable Specky text-dialogue surface.
+//
+// Specky's "text voice": a NON-modal rounded card docked bottom-right, directly
+// above the VoiceLayer Specky avatar (which stays the face, in its idle loop —
+// dec-3; this card renders no second Specky). No scrim, no portal — the board
+// behind stays fully interactive (ac-7). The design is Figma "Specky Dialog",
+// node 590-1855.
+//
+// It takes a pages[] model and runs them as a paged sequence: non-final pages
+// show a footer "Next" link, the final page shows "Close", which ends the
+// sequence (ac-8). Each page carries a heading in Specky's voice, short body
+// content, and at most two actions — one dark primary, one quiet secondary
+// (dec-1). First consumers: the first-run sequence here (spec-242) and the
+// mic-priming page (spec-229).
+
+import { useCallback, useState, type ReactNode } from 'react';
+
+export interface SpeckyDialogueAction {
+  label: string;
+  onSelect: () => void;
+  /** Optional leading icon (e.g. the mic glyph on spec-229's Turn on Mic). */
+  icon?: ReactNode;
+  /** 'primary' (dark filled button) | 'quiet' (text button). Default 'primary'. */
+  kind?: 'primary' | 'quiet';
+  testId?: string;
+}
+
+export interface SpeckyDialoguePage {
+  /** Stable key for the page (also used in test ids). */
+  key: string;
+  heading: ReactNode;
+  body: ReactNode;
+  /** At most two actions render (dec-1); extras are dropped. */
+  actions?: SpeckyDialogueAction[];
+}
+
+export interface SpeckyDialogueProps {
+  pages: SpeckyDialoguePage[];
+  /** Fired when the final page's Close is pressed — ends the sequence. */
+  onClose: () => void;
+  /** Optional observer for page advances (0-based index of the new page). */
+  onPageChange?: (index: number) => void;
+}
+
+export function SpeckyDialogue({ pages, onClose, onPageChange }: SpeckyDialogueProps) {
+  const [index, setIndex] = useState(0);
+  const page = pages[index];
+  const isFinal = index >= pages.length - 1;
+
+  const advance = useCallback(() => {
+    if (isFinal) {
+      onClose();
+      return;
+    }
+    const next = index + 1;
+    setIndex(next);
+    onPageChange?.(next);
+  }, [index, isFinal, onClose, onPageChange]);
+
+  if (!page) return null;
+
+  return (
+    // Non-modal by design (dec-1): role=complementary, NOT role=dialog — there is
+    // no focus trap and nothing behind it is inert. Docked above the bottom-6
+    // VoiceLayer avatar (24px + 40px icon + gap → bottom-20).
+    <section
+      role="complementary"
+      aria-label="Specky"
+      data-testid="specky-dialogue"
+      data-specky-dialogue-page={page.key}
+      className="fixed bottom-20 right-6 z-50 w-[min(480px,calc(100vw-3rem))] rounded-2xl border border-edge bg-surface p-8 shadow-2xl"
+    >
+      <h2 className="text-lg font-semibold text-heading">{page.heading}</h2>
+      <div className="mt-4 text-sm text-primary">{page.body}</div>
+
+      {page.actions && page.actions.length > 0 && (
+        <div className="mt-5 flex items-center gap-3">
+          {page.actions.slice(0, 2).map((action) => (
+            <button
+              key={action.label}
+              type="button"
+              data-testid={action.testId}
+              onClick={action.onSelect}
+              className={
+                action.kind === 'quiet'
+                  ? 'rounded-lg px-3 py-2 text-sm font-medium text-secondary hover:bg-card-hover'
+                  : 'inline-flex items-center gap-2 rounded-lg bg-btn-primary px-3 py-2 text-sm font-medium text-white hover:bg-btn-primary-hover'
+              }
+            >
+              {action.icon}
+              {action.label}
+            </button>
+          ))}
+        </div>
+      )}
+
+      <div className="mt-6 flex justify-end">
+        <button
+          type="button"
+          data-testid="specky-dialogue-footer"
+          onClick={advance}
+          className="text-sm font-medium text-secondary hover:text-heading"
+        >
+          {isFinal ? 'Close' : 'Next'}
+        </button>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## What

The first-run Specky **text** dialogue, replacing spec-206's cold `getUserMedia` auto-start. On first sign-in Specky opens a two-page, non-modal card docked over the board (Figma ["Specky Dialog", node 590-1855](https://www.figma.com/design/sgDyQJunJ33piMeSCXFp4x/Memex-2.0?node-id=590-1855)):

1. **Mic priming** — "Hi, I'm Specky 👋", **Turn on Mic** (fires `getUserMedia` via `session.start`; on grant she speaks; hidden if already granted) + a graceful **Not now**.
2. **"Get the most out of Memex AI"** — three static info cards (MCP / demo spec / team), builder-first framing, not a checklist.

This Spec now owns the whole experience: it **absorbs the retired spec-229** (mic priming) and **supersedes spec-206's voice auto-start** (the cold popup the design exists to remove). First-run gating reuses spec-206's server one-shot (`onboarding_greeted_at`), stamped on the final Close.

## How it's verified
- **18/18 ACs verified** (scope + implementation), 6/6 decisions resolved.
- Full UI vitest green; `tsc -b` clean.
- New **`journey-28`** e2e (3 tests: mic page + no-prompt-on-load, Turn-on-Mic→Next→value→Close + one-shot, Not-now path); **`journey-23`** reworked (spec-206 auto-start ACs retired as superseded). Full `make e2e-cold` green (the lone red, journey-26-logo-theme, is a pre-existing flaky on spec-223, untouched here).

## Notes for review
- No new server/API/MCP surface — read-only reuse of the spec-206 gate, so no migration and std-17 smoke is n/a.
- Value-panel MCP copy points to the in-browser `/settings/integrations` (names no MCP tool) — std-34 compliant.
- The live **spoken** greeting (mic → STT → TTS) stays untestable headless (ElevenLabs + real mic), same gate as spec-190/206; the text dialogue + the Turn-on-Mic→getUserMedia seam are fully covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)