### PR TITLE
fix(guide): derive CLOUD_SQL_INSTANCE_CONN in corpus-refresh workflows (spec-251)

### DIFF
--- a/.github/workflows/guide-content-mindset-website-refresh.yml
+++ b/.github/workflows/guide-content-mindset-website-refresh.yml
@@ -103,10 +103,29 @@ jobs:
         # to import (never ingest an error page).
         run: |
           set -a; . "scripts/deploy.${ENV}.env"; set +a
+          # CLOUD_SQL_INSTANCE_CONN is a DERIVED value — scripts/deploy-config.sh
+          # composes it from these three parts; it is NOT a key in the deploy env
+          # body, so we must compose it here. Omitting this left it empty and the
+          # proxy failed with `connection name = ""`, which the non-gating import
+          # below swallowed into a false green (found 2026-06-12, spec-251 — the
+          # silent-success that masked an un-ingested mindset-website corpus).
+          if [ -z "${GCP_PROJECT}" ] || [ -z "${REGION}" ] || [ -z "${CLOUD_SQL_INSTANCE_NAME}" ]; then
+            echo "::error::deploy env is missing GCP_PROJECT/REGION/CLOUD_SQL_INSTANCE_NAME — cannot reach the DB"
+            exit 1
+          fi
+          CLOUD_SQL_INSTANCE_CONN="${GCP_PROJECT}:${REGION}:${CLOUD_SQL_INSTANCE_NAME}"
           PROXY_PORT=15432
           cloud-sql-proxy "${CLOUD_SQL_INSTANCE_CONN}" --port ${PROXY_PORT} &
           PROXY_PID=$!
-          sleep 5
+          # An unreachable DB is an INFRA failure and must fail LOUDLY (exit 1),
+          # unlike a content/network hiccup in the import below (deliberately
+          # non-gating). Wait for the proxy to actually accept connections; without
+          # this gate an unreachable DB rides the `|| echo` to a false green.
+          if ! timeout 30 bash -c "until (echo > /dev/tcp/localhost/${PROXY_PORT}) 2>/dev/null; do sleep 1; done"; then
+            echo "::error::cloud-sql-proxy never became reachable on localhost:${PROXY_PORT} (instance=${CLOUD_SQL_INSTANCE_CONN}) — DB unreachable, refusing to report success"
+            kill $PROXY_PID 2>/dev/null || true
+            exit 1
+          fi
           DB_PASS_ENC=$(python3 -c "import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1], safe=''))" "${DB_PASS}")
           DB_URL="postgresql://${DB_USER}:${DB_PASS_ENC}@localhost:${PROXY_PORT}/${DB_NAME}"
           SRC="https://www.mindset.ai/llms-full.txt"

--- a/.github/workflows/guide-content-website-refresh.yml
+++ b/.github/workflows/guide-content-website-refresh.yml
@@ -95,10 +95,30 @@ jobs:
         # swallowed so a hiccup never wedges the refresh — the next trigger resumes.
         run: |
           set -a; . "scripts/deploy.${ENV}.env"; set +a
+          # CLOUD_SQL_INSTANCE_CONN is a DERIVED value — scripts/deploy-config.sh
+          # composes it from these three parts; it is NOT a key in the deploy env
+          # body, so we must compose it here. Omitting this left it empty and the
+          # proxy failed with `connection name = ""`, which the non-gating import
+          # below swallowed into a false green (found 2026-06-12 via the spec-251
+          # sibling — this clone shared the defect; spec-222 t-13's path had in
+          # fact never ingested).
+          if [ -z "${GCP_PROJECT}" ] || [ -z "${REGION}" ] || [ -z "${CLOUD_SQL_INSTANCE_NAME}" ]; then
+            echo "::error::deploy env is missing GCP_PROJECT/REGION/CLOUD_SQL_INSTANCE_NAME — cannot reach the DB"
+            exit 1
+          fi
+          CLOUD_SQL_INSTANCE_CONN="${GCP_PROJECT}:${REGION}:${CLOUD_SQL_INSTANCE_NAME}"
           PROXY_PORT=15432
           cloud-sql-proxy "${CLOUD_SQL_INSTANCE_CONN}" --port ${PROXY_PORT} &
           PROXY_PID=$!
-          sleep 5
+          # An unreachable DB is an INFRA failure and must fail LOUDLY (exit 1),
+          # unlike a content/network hiccup in the import below (deliberately
+          # non-gating). Wait for the proxy to actually accept connections; without
+          # this gate an unreachable DB rides the `|| echo` to a false green.
+          if ! timeout 30 bash -c "until (echo > /dev/tcp/localhost/${PROXY_PORT}) 2>/dev/null; do sleep 1; done"; then
+            echo "::error::cloud-sql-proxy never became reachable on localhost:${PROXY_PORT} (instance=${CLOUD_SQL_INSTANCE_CONN}) — DB unreachable, refusing to report success"
+            kill $PROXY_PID 2>/dev/null || true
+            exit 1
+          fi
           DB_PASS_ENC=$(python3 -c "import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1], safe=''))" "${DB_PASS}")
           DB_URL="postgresql://${DB_USER}:${DB_PASS_ENC}@localhost:${PROXY_PORT}/${DB_NAME}"
           if [ "${ENV}" = "prod" ]; then SRC="https://memex.ai/llms-full.txt"; else SRC="https://int.memex.ai/llms-full.txt"; fi


### PR DESCRIPTION
## Problem

The cross-repo guide-content refresh workflows (`guide-content-mindset-website-refresh.yml` + its `guide-content-website-refresh.yml` sibling) sourced the raw deploy env body but referenced `CLOUD_SQL_INSTANCE_CONN` — a **derived** value that `scripts/deploy-config.sh` composes from `GCP_PROJECT:REGION:CLOUD_SQL_INSTANCE_NAME` and is **not** a key in that body.

It came through empty → the Cloud SQL proxy failed with `connection name = ""` → and the deliberately non-gating `|| echo` import swallowed it into a **false green**. The mindset-website corpus was never actually ingested on any env (mindset run 27389571354 reported success but wrote nothing).

## Fix

- **Compose `CLOUD_SQL_INSTANCE_CONN`** from its parts after sourcing the env file (the actual bug).
- **Guard** missing `GCP_PROJECT`/`REGION`/`CLOUD_SQL_INSTANCE_NAME` → loud `::error::` + exit 1.
- **Proxy readiness gate** → an unreachable DB now fails the job instead of riding the non-gating import to a false green. The import keeps its non-gating posture for genuine content/network/timeout hiccups; only infra unreachability is loud.

Applied to **both** workflows — the mindset one is a line-for-line clone of the memex-website one (spec-222 t-13), so the defect was shared; that path had in fact never successfully ingested either.

## Verification plan

- int (this PR on `develop`): dispatch `env=int`, confirm the import logs real chunk counts and no `connection name = ""`.
- prod (after FF to `main`): re-dispatch `env=prod`, then re-probe the `MOS` retrieval on the mindset-website surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)