### PR TITLE
fix(guide): embed website corpus on refresh — fetch openai-api-key (spec-251)

### DIFF
--- a/.github/workflows/guide-content-mindset-website-refresh.yml
+++ b/.github/workflows/guide-content-mindset-website-refresh.yml
@@ -126,6 +126,22 @@ jobs:
             kill $PROXY_PID 2>/dev/null || true
             exit 1
           fi
+          # Embedding provider — fetch openai-api-key from Secret Manager (same
+          # identity that already reads the deploy-env + DB_PASS secrets) so the
+          # import EMBEDS rather than landing vectorless. OpenAI specifically (not
+          # Cohere): the running server resolves OpenAI at query time and the
+          # vector arm filters `embedding_model = provider.name`, so the corpus
+          # MUST be embedded with the same provider or the vectors never match.
+          # A missing/unreadable key is a config error → fail LOUDLY (the whole
+          # point of this run is to produce vectors). A transient OpenAI API error
+          # mid-import stays non-gating: upsertGuideChunk upserts vectorless and a
+          # re-run backfills (FTS covers in the meantime).
+          if ! OPENAI_API_KEY="$(gcloud secrets versions access latest --secret=openai-api-key --project="${GCP_PROJECT}")"; then
+            echo "::error::could not read openai-api-key from Secret Manager (project=${GCP_PROJECT}) — refusing a vectorless import"
+            kill $PROXY_PID 2>/dev/null || true
+            exit 1
+          fi
+          export OPENAI_API_KEY
           DB_PASS_ENC=$(python3 -c "import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1], safe=''))" "${DB_PASS}")
           DB_URL="postgresql://${DB_USER}:${DB_PASS_ENC}@localhost:${PROXY_PORT}/${DB_NAME}"
           SRC="https://www.mindset.ai/llms-full.txt"

--- a/.github/workflows/guide-content-website-refresh.yml
+++ b/.github/workflows/guide-content-website-refresh.yml
@@ -119,6 +119,22 @@ jobs:
             kill $PROXY_PID 2>/dev/null || true
             exit 1
           fi
+          # Embedding provider — fetch openai-api-key from Secret Manager (same
+          # identity that already reads the deploy-env + DB_PASS secrets) so the
+          # import EMBEDS rather than landing vectorless. OpenAI specifically (not
+          # Cohere): the running server resolves OpenAI at query time and the
+          # vector arm filters `embedding_model = provider.name`, so the corpus
+          # MUST be embedded with the same provider or the vectors never match.
+          # A missing/unreadable key is a config error → fail LOUDLY (the whole
+          # point of this run is to produce vectors). A transient OpenAI API error
+          # mid-import stays non-gating: upsertGuideChunk upserts vectorless and a
+          # re-run backfills (FTS covers in the meantime).
+          if ! OPENAI_API_KEY="$(gcloud secrets versions access latest --secret=openai-api-key --project="${GCP_PROJECT}")"; then
+            echo "::error::could not read openai-api-key from Secret Manager (project=${GCP_PROJECT}) — refusing a vectorless import"
+            kill $PROXY_PID 2>/dev/null || true
+            exit 1
+          fi
+          export OPENAI_API_KEY
           DB_PASS_ENC=$(python3 -c "import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1], safe=''))" "${DB_PASS}")
           DB_URL="postgresql://${DB_USER}:${DB_PASS_ENC}@localhost:${PROXY_PORT}/${DB_NAME}"
           if [ "${ENV}" = "prod" ]; then SRC="https://memex.ai/llms-full.txt"; else SRC="https://int.memex.ai/llms-full.txt"; fi


### PR DESCRIPTION
## Problem (follow-up to #156)

#156 fixed the silent proxy failure so the refresh actually writes — but the import ran with **no embedding provider** in the GH runner, so all chunks land `embedding = NULL`. The retrieval vector arm (`guide-content.ts:418-428`) filters `embedding IS NOT NULL AND embedding_model = provider.name`, so a vectorless corpus is invisible to semantic search. Combined with `screen_key = NULL` on flat `llms-full.txt` (which disables Layer-1 per-screen prefetch), the result is **rows present, retrieval empty** — exactly what live testing of the mindset-website surface showed.

## Fix

Fetch `openai-api-key` from Secret Manager (the WIF identity already reads the deploy-env + `DB_PASS` secrets the same way) and `export OPENAI_API_KEY` before the import, so chunks get embedded.

**OpenAI specifically, not Cohere:** the running server resolves OpenAI at query time (provider precedence), and the vector arm matches on `embedding_model` — so the corpus must be embedded with the *same* provider or the vectors won't match even when present.

Backfill is safe: `upsertGuideChunk` (lines 202-212) re-embeds vectorless rows on a provider-enabled re-run. A missing/unreadable key fails **loudly** (the run exists to produce vectors); a transient OpenAI error mid-import stays non-gating (vectorless upsert + FTS cover, next run backfills).

Applied to both the mindset-website and memex-website refresh workflows.

## Verify
- int: dispatch `env=int`, expect `270 embedded` (not `270 without vector`), then a live MOS retrieval probe returns grounded content.
- prod: after FF to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)