### PR TITLE
feat(ui): Done tab + editor override on blocked phase moves (spec-258)

### DIFF
--- a/packages/ui/e2e/journey-19-lifecycle-spine.spec.ts
+++ b/packages/ui/e2e/journey-19-lifecycle-spine.spec.ts
@@ -204,17 +204,22 @@ test("lifecycle spine: org → memex → Spec → resolve decision → phase mov
     { timeout: 15_000 }
   );
 
-  // ── 6. Phase move specify → build, gate-aware ─────────────────────────────────
+  // ── 6. Phase move specify → build: gate holds, but the editor gets the override ─
   // specify→build is gated on Decisions resolved AND ACs created. We've resolved
   // the decision but deliberately have no ACs (AC authoring is the agent/MCP
-  // surface, out of this spine's scope) — so the rubric correctly REFUSES the
-  // forward move: NO Yes button on the current Specify tab. That refusal IS the
-  // phase-gated affordance — the spine asserts the gate holds. (Driving the move
-  // all the way to verify needs the AC-create + task-complete surfaces, which
-  // journey-11 and the build/verify journeys own.)
-  await expect(
-    page.getByTestId("transition-sentence").getByRole("button", { name: /^Yes$/ })
-  ).toHaveCount(0);
+  // surface, out of this spine's scope) — so the rubric still NAMES the open AC
+  // gate (it doesn't advance silently). spec-258/dec-5 amends spec-159/dec-4: on
+  // a blocked current tab an EDITOR additionally gets a "Move this spec to Build
+  // anyway?" override [Yes], because the move is already forceable from the
+  // kanban. So the affordance is no longer a dead end — the gate informs, and the
+  // editor has an escape hatch.
+  const rubicon = page.getByTestId("transition-sentence");
+  await expect(rubicon).toContainText(
+    /Acceptance Criteria \(ACs\)[\s\S]*must be created/i,
+    { timeout: 15_000 }
+  );
+  await expect(rubicon).toContainText(/Move this spec to Build anyway\?/i);
+  await expect(rubicon.getByRole("button", { name: /^Yes$/ })).toHaveCount(1);
 });
 
 // ── The signup-as-new-user leg (see file header) ─────────────────────────────

--- a/packages/ui/e2e/journey-21-spec-196-narrative.spec.ts
+++ b/packages/ui/e2e/journey-21-spec-196-narrative.spec.ts
@@ -130,12 +130,16 @@ test("specify→build gate: stale narrative blocks the offer; consolidation rest
   });
 
   // All decisions resolved + AC present + never consolidated → the Rubicon
-  // states the staleness condition WITH the how-to tail, and offers no move.
+  // states the staleness condition WITH the how-to tail. spec-258/dec-5: an
+  // editor also gets the "Move this spec to Build anyway?" override [Yes] — the
+  // staleness gate informs but no longer dead-ends the editor (consolidation is
+  // still the clean path, exercised next).
   await expect(rubicon).toContainText(
     /The spec narrative must be updated to reflect the resolved decisions before this spec can move to Build — use the refresh action to generate the update prompt\./,
     { timeout: 15_000 }
   );
-  await expect(rubicon.getByRole("button", { name: /^Yes$/ })).toHaveCount(0);
+  await expect(rubicon).toContainText(/Move this spec to Build anyway\?/i);
+  await expect(rubicon.getByRole("button", { name: /^Yes$/ })).toHaveCount(1);
 
   // Consolidate (what assess_spec({mode:'consolidate'}) stamps) → the live
   // change stream refreshes the doc and the advancement offer appears.

--- a/packages/ui/e2e/journey-29-spec-258-done-tab.spec.ts
+++ b/packages/ui/e2e/journey-29-spec-258-done-tab.spec.ts
@@ -1,0 +1,164 @@
+// Journey 29 — Web-UI phase moves: the Done tab + the editor override (spec-258,
+// std-28 PR-gate journey). The two user-facing flows surfaced by spec-164/issue-3
+// (Will, prod spec-61): a finished spec sat in verify with NO human path to close,
+// and a blocked forward move offered an editor nothing on the current tab.
+//
+//   1. CLOSE VIA THE DONE TAB — a human editor takes a clean verify spec, clicks
+//      the new Done tab (the pipeline now reads Specify → Build → Verify → Done),
+//      sees the read-only DoneSummary preview + the browse-confirm Rubicon
+//      ("Are you sure you want to move this spec to Done?"), confirms, and the
+//      page collapses into the done report. No in-app agent, no MCP. (ac-1/2/3/4/5)
+//   2. OVERRIDE A BLOCKED MOVE — on a blocked current tab (build with an
+//      incomplete task), the editor gets the dec-5 "Move this spec to Verify
+//      anyway?" override and forces the move the kanban already allows. (ac-8)
+//
+// Seeding is HTTP-only over the __test__ surface (spec-172 dec-2): seed-org,
+// seed-spec, set-doc-status, seed-ac, seed-test-event, seed-task. Navigation is
+// path-based [per std-2]. A seeded spec has no editor doc_member, so the dev
+// opens it as a REVIEWER — switchToEditing promotes before driving the
+// editor-gated affordances.
+
+import {
+  test,
+  expect,
+  tenantPath,
+  switchToEditing,
+  seedAc,
+  seedTestEvent,
+  seedTask,
+  emitAcEvents,
+} from "./helpers/index.js";
+import { seedOrgTenant, seedSpec, setDocStatus } from "./helpers/retained.js";
+
+const SPEC258 = "mindset-prod/memex-building-itself/specs/spec-258";
+
+const ACS_BY_TEST: Record<string, string[]> = {
+  "close via the Done tab: a human editor closes a clean verify spec, no agent/MCP": [
+    `${SPEC258}/acs/ac-1`,
+    `${SPEC258}/acs/ac-2`,
+    `${SPEC258}/acs/ac-3`,
+    `${SPEC258}/acs/ac-4`,
+    `${SPEC258}/acs/ac-5`,
+  ],
+  "editor override: a blocked forward move offers 'Move … anyway?' and forces it": [
+    `${SPEC258}/acs/ac-8`,
+  ],
+};
+
+test.afterEach(async ({}, testInfo) => {
+  if (testInfo.status === "skipped") return;
+  const refs = ACS_BY_TEST[testInfo.title];
+  if (!refs) return;
+  await emitAcEvents(
+    refs,
+    testInfo.status === "passed" ? "pass" : "fail",
+    `packages/ui/e2e/journey-29-spec-258-done-tab.spec.ts::${testInfo.title}`,
+    testInfo.duration
+  );
+});
+
+test("close via the Done tab: a human editor closes a clean verify spec, no agent/MCP", async ({
+  page,
+  resources,
+}) => {
+  // ── Seed a verify-phase spec whose single AC is verified → a CLEAN verify
+  //    rubric (the finished-spec state issue-3 is about). ─────────────────────
+  const tenant = await seedOrgTenant({ slug: resources.slug("j29a") });
+  const spec = await seedSpec({
+    memexId: tenant.memexId,
+    title: "Done-tab close journey",
+    purpose: "A finished spec with no path to close — until the Done tab.",
+  });
+  await setDocStatus({ memexId: tenant.memexId, docId: spec.docId, status: "verify" });
+  const ac = await seedAc({
+    memexId: tenant.memexId,
+    docId: spec.docId,
+    kind: "scope",
+    statement: "The close flow is reachable by a human.",
+  });
+  expect(ac.acUid, "seeded AC should carry a canonical acUid").not.toBeNull();
+  // A passing emission flips the AC to `verified` → unverifiedAcCount 0 → the
+  // verify→done rubric is clean, so the Done tab offers the ready confirm.
+  await seedTestEvent({ acUid: ac.acUid!, status: "pass", testIdentifier: "j29-seed" });
+
+  await page.goto(
+    tenantPath(tenant.namespaceSlug, tenant.memexSlug, `/specs/${spec.handle}`),
+    { waitUntil: "commit" }
+  );
+  await expect(
+    page.getByRole("heading", { level: 1, name: /Done-tab close journey/ })
+  ).toBeVisible({ timeout: 15_000 });
+  await switchToEditing(page);
+
+  // ── ac-1: the pipeline completes Specify → Build → Verify → Done. ──────────
+  await expect(page.locator('[role="tab"][data-tab="verify"][data-current="true"]')).toBeVisible({
+    timeout: 15_000,
+  });
+  const doneTab = page.locator('[role="tab"][data-tab="done"]');
+  await expect(doneTab).toBeVisible();
+  // dec-4: the Done tab is never the filled "current" pill while the bar is shown.
+  await expect(doneTab).not.toHaveAttribute("data-current", "true");
+
+  // ── ac-4: browsing Done previews the read-only DoneSummary (no Reopen). ────
+  await doneTab.click();
+  await expect(page.getByTestId("done-summary")).toBeVisible({ timeout: 15_000 });
+  // The preview carries NO Reopen affordance — that belongs to the post-close report.
+  await expect(page.getByTestId("done-reopen")).toHaveCount(0);
+
+  // ── ac-2 (ready): the browse-confirm Rubicon offers the move. ─────────────
+  const sentence = page.getByTestId("transition-sentence");
+  await expect(sentence).toContainText(/Are you sure you want to move this spec to Done\?/i);
+
+  // ── ac-3 / ac-5: confirm → the spec closes and the page collapses into the
+  //    done report (with its Reopen door); the tab bar is gone. ──────────────
+  await sentence.getByRole("button", { name: /^Yes$/ }).click();
+  await expect(page.getByTestId("done-reopen")).toBeVisible({ timeout: 15_000 });
+  await expect(page.locator('[role="tab"]')).toHaveCount(0);
+  await expect(page.getByTestId("done-summary")).toBeVisible();
+});
+
+test("editor override: a blocked forward move offers 'Move … anyway?' and forces it", async ({
+  page,
+  resources,
+}) => {
+  // ── Seed a BUILD-phase spec with an incomplete task → the build→verify rubric
+  //    blocks (open task), so the current Build tab is the button-less blocked
+  //    state — until the dec-5 editor override. ───────────────────────────────
+  const tenant = await seedOrgTenant({ slug: resources.slug("j29b") });
+  const spec = await seedSpec({
+    memexId: tenant.memexId,
+    title: "Blocked-move override journey",
+    purpose: "A blocked forward move an editor can still force from the spec page.",
+  });
+  await setDocStatus({ memexId: tenant.memexId, docId: spec.docId, status: "build" });
+  await seedTask({
+    memexId: tenant.memexId,
+    docId: spec.docId,
+    title: "Still in flight",
+    status: "in_progress",
+  });
+
+  await page.goto(
+    tenantPath(tenant.namespaceSlug, tenant.memexSlug, `/specs/${spec.handle}`),
+    { waitUntil: "commit" }
+  );
+  await expect(
+    page.getByRole("heading", { level: 1, name: /Blocked-move override journey/ })
+  ).toBeVisible({ timeout: 15_000 });
+  await switchToEditing(page);
+
+  // ── ac-8: the blocked current tab names what's open AND offers the editor the
+  //    "Move this spec to Verify anyway?" override. ───────────────────────────
+  const sentence = page.getByTestId("transition-sentence");
+  await expect(sentence).toContainText(
+    /Task must be completed[\s\S]*before this spec can move to Verify/i,
+    { timeout: 15_000 }
+  );
+  await expect(sentence).toContainText(/Move this spec to Verify anyway\?/i);
+
+  // Forcing it advances the spec the kanban already permits (soft gates).
+  await sentence.getByRole("button", { name: /^Yes$/ }).click();
+  await expect(
+    page.locator('[role="tab"][data-tab="verify"][data-current="true"]')
+  ).toBeVisible({ timeout: 15_000 });
+});

--- a/packages/ui/src/components/DoneSummary.test.tsx
+++ b/packages/ui/src/components/DoneSummary.test.tsx
@@ -181,6 +181,26 @@ describe('DoneSummary', () => {
     expect(people.textContent).toContain('Barrie Hadfield');
   });
 
+  it('reads forward as the Done-tab preview: "will be completed", no past date (spec-258/dec-3)', () => {
+    tagAc('mindset-prod/memex-building-itself/specs/spec-258/acs/ac-4');
+    render(
+      <DoneSummary
+        doc={makeDoc()}
+        decisions={DECISIONS}
+        tasks={TASKS}
+        acs={ACS}
+        issues={ISSUES}
+        preview
+      />,
+    );
+    const report = screen.getByTestId('done-summary');
+    // Preview (spec not yet closed) → forward tense, and NOT the retrospective
+    // "was completed on <date>".
+    expect(report.textContent).toContain('This spec will be completed');
+    expect(report.textContent).not.toContain('was completed');
+    expect(report.textContent).not.toMatch(/completed on .*2026/);
+  });
+
   it('shows assignees in the People row when passed (still no fetch)', () => {
     tagAc(AC(8));
     const people: DocAssigneeView[] = [

--- a/packages/ui/src/components/DoneSummary.tsx
+++ b/packages/ui/src/components/DoneSummary.tsx
@@ -66,6 +66,15 @@ interface DoneSummaryProps {
    * refetch) — DoneSummary itself still makes no network call (ac-9).
    */
   onReopen?: () => void | Promise<void>;
+  /**
+   * spec-258/dec-3: when DoneSummary is the Done-TAB preview (the spec is NOT
+   * yet closed — browsing Done before the move), the headline reads forward
+   * ("This spec will be completed") instead of the retrospective past tense, and
+   * carries no completion date — nothing has happened yet. The post-close report
+   * (default, `preview` false) reads "This spec was completed on …". Defaults to
+   * false.
+   */
+  preview?: boolean;
 }
 
 // One date, spelled the way the sketch shows it ("12 June 2026").
@@ -118,6 +127,7 @@ export function DoneSummary({
   people,
   canReopen = false,
   onReopen,
+  preview = false,
 }: DoneSummaryProps) {
   // spec-164 dec-5: two-step confirm, inline (mirrors the transition
   // sentence's no-modal posture). 'idle' → button; 'confirming' → question +
@@ -179,11 +189,15 @@ export function DoneSummary({
 
   return (
     <Card variant="panel" data-testid="done-summary" className="max-w-3xl mx-auto">
-      {/* Headline — the conclusion. ✓ + completion date + how long ago. */}
+      {/* Headline — the conclusion. As the post-close report: ✓ + completion
+          date + how long ago. As the Done-tab PREVIEW (spec-258/dec-3, not yet
+          closed): forward tense, no date — nothing has happened yet. */}
       <div className="text-center py-4">
         <p className="text-lg text-status-success-text">
           <span aria-hidden="true">✓ </span>
-          This spec was completed on {formatDate(completedAt)} ({relativeDays(completedAt)})
+          {preview
+            ? 'This spec will be completed'
+            : `This spec was completed on ${formatDate(completedAt)} (${relativeDays(completedAt)})`}
         </p>
       </div>
 

--- a/packages/ui/src/components/PhaseTabBar.test.tsx
+++ b/packages/ui/src/components/PhaseTabBar.test.tsx
@@ -19,15 +19,16 @@ function tab(name: string) {
 }
 
 describe('PhaseTabBar', () => {
-  it('renders three tabs in a tablist', () => {
+  it('renders four tabs in a tablist (spec-258: pipeline now ends in Done)', () => {
     tagAc(AC(2));
     render(<PhaseTabBar currentPhase="specify" selectedTab="specify" onSelect={onSelect} />);
     expect(screen.getByRole('tablist', { name: /Spec phase view/i })).toBeInTheDocument();
     const tabs = screen.getAllByRole('tab');
-    expect(tabs).toHaveLength(3);
+    expect(tabs).toHaveLength(4);
     expect(within(tab('specify')).getByText('Specify')).toBeInTheDocument();
     expect(within(tab('build')).getByText('Build')).toBeInTheDocument();
     expect(within(tab('verify')).getByText('Verify')).toBeInTheDocument();
+    expect(within(tab('done')).getByText('Done')).toBeInTheDocument();
   });
 
   it('marks the phase-matching tab as current with a ● dot and its phase colour', () => {
@@ -96,13 +97,13 @@ describe('PhaseTabBar', () => {
     }
   });
 
-  it("renders a ✓ Done marker and no current tab for phase 'done'", () => {
+  it("spec-258: the old ✓ Done marker no longer renders, and no tab is current at phase 'done'", () => {
     tagAc(AC(2));
     render(<PhaseTabBar currentPhase="done" selectedTab="verify" onSelect={onSelect} />);
-    const marker = screen.getByTestId('done-marker');
-    expect(marker).toBeInTheDocument();
-    expect(marker.textContent).toContain('Done');
-    for (const name of ['specify', 'build', 'verify']) {
+    // The dead ✓ Done marker block is removed — the Done tab supersedes it.
+    expect(screen.queryByTestId('done-marker')).not.toBeInTheDocument();
+    // `done` makes no tab current (in practice the bar is hidden at done anyway).
+    for (const name of ['specify', 'build', 'verify', 'done']) {
       expect(tab(name)).not.toHaveAttribute('data-current');
     }
   });
@@ -187,14 +188,79 @@ describe('PhaseTabBar', () => {
 describe('PhaseTabBar — flow arrows (spec-164)', () => {
   const AC_ARROWS = 'mindset-prod/memex-building-itself/specs/spec-164/acs/ac-2';
 
-  it('renders exactly two aria-hidden arrows between the three tabs', () => {
+  it('renders exactly three aria-hidden arrows between the four tabs (spec-258)', () => {
     tagAc(AC_ARROWS);
     render(<PhaseTabBar currentPhase="specify" selectedTab="specify" onSelect={() => {}} />);
     const arrows = screen.getAllByTestId('phase-arrow');
-    expect(arrows).toHaveLength(2);
+    expect(arrows).toHaveLength(3);
     for (const a of arrows) expect(a).toHaveAttribute('aria-hidden', 'true');
     // The tabs themselves are still the tablist's tabs, in pipeline order.
     const tabs = screen.getAllByRole('tab');
-    expect(tabs.map((t) => t.getAttribute('data-tab'))).toEqual(['specify', 'build', 'verify']);
+    expect(tabs.map((t) => t.getAttribute('data-tab'))).toEqual([
+      'specify',
+      'build',
+      'verify',
+      'done',
+    ]);
+  });
+});
+
+// spec-258 — the Done tab completes the pipeline (ac-1) and is coloured with
+// resting/selected treatment only, never the filled "current" pill (ac-7/dec-4).
+describe('PhaseTabBar — Done tab (spec-258)', () => {
+  const S258 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-258/acs/ac-${n}`;
+
+  it('renders the Done tab last, completing Specify → Build → Verify → Done (ac-1)', () => {
+    tagAc(S258(1));
+    render(<PhaseTabBar currentPhase="verify" selectedTab="verify" onSelect={onSelect} />);
+    const tabs = screen.getAllByRole('tab');
+    expect(tabs.map((t) => t.getAttribute('data-tab'))).toEqual([
+      'specify',
+      'build',
+      'verify',
+      'done',
+    ]);
+    // Same arrow-separated treatment as the other tabs: an arrow precedes Done.
+    expect(screen.getAllByTestId('phase-arrow')).toHaveLength(3);
+  });
+
+  it('never gives the Done tab a filled VARIANT_FILL pill across any phase (ac-7/dec-4)', () => {
+    tagAc(S258(7));
+    for (const phase of ['draft', 'specify', 'build', 'verify'] as const) {
+      const { unmount } = render(
+        <PhaseTabBar currentPhase={phase} selectedTab="specify" onSelect={onSelect} />,
+      );
+      const doneTab = tab('done');
+      // Resting only when unselected: no status-* fill, no current dot, not current.
+      expect(doneTab).not.toHaveAttribute('data-current');
+      expect(doneTab.className).not.toContain('bg-status-success-bg');
+      expect(doneTab.className).not.toMatch(/bg-status-\w+-bg/);
+      expect(doneTab.textContent).not.toContain('●');
+      unmount();
+    }
+  });
+
+  it('wears only the underline-selected accent when the Done tab is selected (ac-7)', () => {
+    tagAc(S258(7));
+    render(<PhaseTabBar currentPhase="verify" selectedTab="done" onSelect={onSelect} />);
+    const doneTab = tab('done');
+    expect(doneTab).toHaveAttribute('aria-selected', 'true');
+    expect(doneTab).not.toHaveAttribute('data-current');
+    // Underline accent present; still no filled pill.
+    expect(doneTab.querySelector('.h-0\\.5')).not.toBeNull();
+    expect(doneTab.className).not.toMatch(/bg-status-\w+-bg/);
+  });
+
+  it('reaches and activates the Done tab via keyboard nav (ac-1)', async () => {
+    tagAc(S258(1));
+    const user = userEvent.setup();
+    render(<PhaseTabBar currentPhase="verify" selectedTab="verify" onSelect={onSelect} />);
+    tab('verify').focus();
+    await user.keyboard('{ArrowRight}');
+    expect(onSelect).toHaveBeenCalledWith('done');
+    onSelect.mockClear();
+    // End jumps to the last tab — now Done.
+    await user.keyboard('{End}');
+    expect(onSelect).toHaveBeenCalledWith('done');
   });
 });

--- a/packages/ui/src/components/PhaseTabBar.tsx
+++ b/packages/ui/src/components/PhaseTabBar.tsx
@@ -8,7 +8,8 @@ import { phaseDisplayName } from '../utils/phaseDisplay';
 //   1. CURRENT PHASE — the filled pill driven by the Spec's actual phase. It
 //      persists regardless of what the user has clicked. `draft` lights up a
 //      dedicated grey Draft pill at the far left (NOT the Specify tab); `done`
-//      lights up no tab (a "✓ Done" marker renders beside the bar instead).
+//      lights up no tab — but the bar is hidden entirely once phase==='done'
+//      (DoneSummary takes over), so a Done tab, when shown, is never current.
 //   2. SELECTED — the underline accent driven by clicks. It renders ONLY when
 //      the selected tab differs from the current one (when they coincide the
 //      pill alone carries the state — stacking both reads as clutter).
@@ -25,7 +26,11 @@ import { phaseDisplayName } from '../utils/phaseDisplay';
 // (draft's home), exactly like clicking Specify. While in draft no Specify/Build/
 // Verify tab is current, so Specify may still wear the selected underline.
 
-const TABS = ['specify', 'build', 'verify'] as const;
+// spec-258: the bar completes the pipeline — Specify → Build → Verify → Done.
+// The Done tab is what lets a user SELECT `done` (the verify→done move's missing
+// affordance); it is never the *current* pill because the bar is gated out once
+// phase==='done' (DocDocument.tsx), so `done` only ever wears resting/selected.
+const TABS = ['specify', 'build', 'verify', 'done'] as const;
 export type PhaseTab = (typeof TABS)[number];
 
 // spec-181: labels come from the shared phase display-name layer, which is now a
@@ -35,6 +40,7 @@ const TAB_LABELS: Record<PhaseTab, string> = {
   specify: phaseDisplayName('specify'),
   build: phaseDisplayName('build'),
   verify: phaseDisplayName('verify'),
+  done: phaseDisplayName('done'),
 };
 
 // Per-tab fill, reusing the canonical statusVariant → status-* token classes
@@ -49,10 +55,10 @@ const VARIANT_FILL: Record<ReturnType<typeof statusVariant>, string> = {
   neutral: 'bg-status-neutral-bg text-status-neutral-text border-status-neutral-border',
 };
 
-/** The Specify/Build/Verify tab a given Spec phase makes "current". `draft` and
- * `done` make NO tab current — `draft` lights up the dedicated Draft pill,
- * `done` the ✓ Done marker (the two are told apart by the `isDraft` flag, not
- * by this null). */
+/** The tab a given Spec phase makes "current" (the filled pill). `draft` and
+ * `done` make NO tab current: `draft` lights up the dedicated Draft pill
+ * instead, and `done` is never seen here because the whole bar is hidden once
+ * phase==='done' — so the Done tab only ever renders resting/selected (dec-4). */
 function currentTabFor(phase: SpecStatus): PhaseTab | null {
   switch (phase) {
     case 'specify':
@@ -78,13 +84,14 @@ export interface PhaseTabBarProps {
 
 export function PhaseTabBar({ currentPhase, selectedTab, onSelect }: PhaseTabBarProps) {
   const currentTab = currentTabFor(currentPhase);
-  // `draft` and `done` both make no Plan/Build/Verify tab current — `isDraft`
-  // tells them apart so the Draft pill and the ✓ Done marker never collide.
+  // `draft` makes no tab current — it lights up the dedicated Draft pill. (`done`
+  // also makes none, but the bar is gated out at phase==='done' upstream.)
   const isDraft = currentPhase === 'draft';
   const tabRefs = useRef<Record<PhaseTab, HTMLButtonElement | null>>({
     specify: null,
     build: null,
     verify: null,
+    done: null,
   });
 
   // Roving keyboard nav mirroring ui/Tabs conventions: Arrow keys move focus
@@ -185,15 +192,6 @@ export function PhaseTabBar({ currentPhase, selectedTab, onSelect }: PhaseTabBar
           );
         })}
       </div>
-      {currentTab === null && !isDraft && (
-        <span
-          data-testid="done-marker"
-          className="inline-flex items-center gap-1 text-xs font-medium text-status-success-text"
-        >
-          <span aria-hidden="true">✓</span>
-          Done
-        </span>
-      )}
     </div>
   );
 }

--- a/packages/ui/src/components/TransitionSentence.spec-196.test.tsx
+++ b/packages/ui/src/components/TransitionSentence.spec-196.test.tsx
@@ -58,7 +58,10 @@ describe('spec-196 — Rubicon narrative-staleness blocker at specify→build', 
     tagAc(AC(8));
     tagAc(AC(9));
     tagAc(AC(10));
-    render(<TransitionSentence {...baseProps({ narrativeStale: true })} />);
+    // Non-editor view: the blocker sentence stands alone (the spec-258/dec-5
+    // editor override would otherwise append "Move … anyway?"). The dec-3
+    // sentence itself is posture-independent — this pins its exact text.
+    render(<TransitionSentence {...baseProps({ narrativeStale: true, canTransition: false })} />);
 
     // The exact dec-3 sentence.
     expect(text()).toBe(
@@ -91,9 +94,10 @@ describe('spec-196 — Rubicon narrative-staleness blocker at specify→build', 
 
   it('composes with the AC fragment under the shared renderer (ac-8)', () => {
     tagAc(AC(8));
+    // Non-editor view pins the exact composed sentence (see above re: dec-5).
     render(
       <TransitionSentence
-        {...baseProps({ narrativeStale: true, hasAcceptanceCriteria: false })}
+        {...baseProps({ narrativeStale: true, hasAcceptanceCriteria: false, canTransition: false })}
       />,
     );
     expect(text()).toBe(

--- a/packages/ui/src/components/TransitionSentence.test.tsx
+++ b/packages/ui/src/components/TransitionSentence.test.tsx
@@ -17,6 +17,7 @@ import type { SpecStatus } from '../api/types';
 //   ac-4 / ac-16: backward moves never gated; Yes is the only phase mutation.
 
 const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-159/acs/ac-${n}`;
+const S258 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-258/acs/ac-${n}`;
 
 const updateDocStatus = vi.fn();
 vi.mock('../api/client', () => ({
@@ -102,10 +103,16 @@ describe('Rubicon line — shape 1: current tab, rubric clean → offer + Yes', 
   });
 });
 
-describe('Rubicon line — shape 2: current tab, rubric blocked → exact status, NO buttons', () => {
-  it('specify with no decisions and no ACs → combined summary, no buttons', () => {
+// spec-258/dec-5 amended shape 2: the blocked current tab still states the exact
+// rubric condition (spec-159 ac-13), and now an EDITOR additionally gets a "Move
+// this spec to {Phase} anyway?" override [Yes]. A non-editor still sees the
+// blocker statement alone (spec-182/dec-2). The blocker-text assertions below
+// keep ac-13 covered; the override assertions cover spec-258 ac-9 / ac-8.
+describe('Rubicon line — shape 2: current tab, blocked → exact status + editor override (spec-258)', () => {
+  it('specify with no decisions and no ACs → combined summary + editor override', () => {
     tagAc(AC(3));
     tagAc(AC(13));
+    tagAc(S258(9));
     render(
       <TransitionSentence
         {...baseProps({ totalDecisionCount: 0, hasAcceptanceCriteria: false })}
@@ -114,14 +121,19 @@ describe('Rubicon line — shape 2: current tab, rubric blocked → exact status
     expect(text()).toContain(
       'Decisions and Acceptance Criteria (ACs) must be created before this spec can move to Build.',
     );
-    expect(screen.queryByRole('button')).toBeNull();
+    // dec-5: the editor override appears on the blocked current tab.
+    expect(text()).toContain('Move this spec to Build anyway?');
+    expect(screen.getByRole('button', { name: 'Yes' })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'No' })).toBeNull();
   });
 
-  it('specify with open decisions and ACs present → decisions-only summary', () => {
+  it('specify with open decisions and ACs present → decisions-only summary + override', () => {
     tagAc(AC(13));
+    tagAc(S258(9));
     render(<TransitionSentence {...baseProps({ openDecisionCount: 4 })} />);
     expect(text()).toContain('4 Decisions must be resolved before this spec can move to Build.');
-    expect(screen.queryByRole('button')).toBeNull();
+    expect(text()).toContain('Move this spec to Build anyway?');
+    expect(screen.getByRole('button', { name: 'Yes' })).toBeTruthy();
   });
 
   it('singular grammar: 1 open decision → "1 Decision must be resolved"', () => {
@@ -130,29 +142,33 @@ describe('Rubicon line — shape 2: current tab, rubric blocked → exact status
     expect(text()).toContain('1 Decision must be resolved before this spec can move to Build.');
   });
 
-  it('build with open tasks → "{N} Tasks must be completed before this spec can move to Verify."', () => {
+  it('build with open tasks → "{N} Tasks must be completed…" + override to Verify', () => {
     tagAc(AC(13));
+    tagAc(S258(9));
     render(
       <TransitionSentence
         {...baseProps({ currentPhase: 'build', viewedTab: 'build', openTaskCount: 2 })}
       />,
     );
     expect(text()).toContain('2 Tasks must be completed before this spec can move to Verify.');
-    expect(screen.queryByRole('button')).toBeNull();
+    expect(text()).toContain('Move this spec to Verify anyway?');
+    expect(screen.getByRole('button', { name: 'Yes' })).toBeTruthy();
   });
 
-  it('verify with unverified ACs → "{N} Acceptance Criteria (ACs) must be verified before this spec can move to Done."', () => {
+  it('verify with unverified ACs → "{N} Acceptance Criteria (ACs) must be verified…" + override to Done', () => {
     tagAc(AC(13));
+    tagAc(S258(9));
     render(
       <TransitionSentence
         {...baseProps({ currentPhase: 'verify', viewedTab: 'verify', unverifiedAcCount: 3 })}
       />,
     );
     expect(text()).toContain('3 Acceptance Criteria (ACs) must be verified before this spec can move to Done.');
-    expect(screen.queryByRole('button')).toBeNull();
+    expect(text()).toContain('Move this spec to Done anyway?');
+    expect(screen.getByRole('button', { name: 'Yes' })).toBeTruthy();
   });
 
-  it('build with ZERO tasks is blocked — an empty build never offers verify', () => {
+  it('build with ZERO tasks is blocked — an empty build still offers the editor override', () => {
     tagAc(AC(13));
     render(
       <TransitionSentence
@@ -165,7 +181,7 @@ describe('Rubicon line — shape 2: current tab, rubric blocked → exact status
       />,
     );
     expect(text()).toContain('Tasks must be created and completed before this spec can move to Verify.');
-    expect(screen.queryByRole('button')).toBeNull();
+    expect(text()).toContain('Move this spec to Verify anyway?');
   });
 
   it('verify with NO active ACs is blocked — nothing to verify against', () => {
@@ -183,7 +199,6 @@ describe('Rubicon line — shape 2: current tab, rubric blocked → exact status
     expect(text()).toContain(
       'Acceptance Criteria (ACs) must be created and verified before this spec can move to Done.',
     );
-    expect(screen.queryByRole('button')).toBeNull();
   });
 });
 
@@ -335,5 +350,78 @@ describe('no switch-to-Editing nag (spec-182 dec-6, amended)', () => {
     );
     expect(screen.queryByTestId('switch-to-editing')).not.toBeInTheDocument();
     expect(text()).not.toContain("You're reviewing");
+  });
+});
+
+// spec-258/dec-5 — the editor override on a blocked current tab, end to end. The
+// override is phase-generic, so it must work on every forward axis; pressing its
+// [Yes] forces the move through the existing updateDocStatus(target) call (the
+// move the server already accepts — soft gates, spec-12/dec-6). A non-editor's
+// blocked current tab stays status-only (spec-182/dec-2). Covers ac-9 / ac-8.
+describe('Rubicon line — editor override on a blocked current tab (spec-258 dec-5)', () => {
+  it('verify→done: blocked editor presses "Move … anyway?" → updateDocStatus(doc, "done") (the issue-3 close)', async () => {
+    tagAc(S258(9));
+    tagAc(S258(8));
+    const user = userEvent.setup();
+    const onTransitioned = vi.fn();
+    render(
+      <TransitionSentence
+        {...baseProps({
+          currentPhase: 'verify',
+          viewedTab: 'verify',
+          unverifiedAcCount: 3,
+          onTransitioned,
+        })}
+      />,
+    );
+    expect(text()).toContain('Move this spec to Done anyway?');
+    await user.click(screen.getByRole('button', { name: 'Yes' }));
+    await waitFor(() => expect(updateDocStatus).toHaveBeenCalledWith('doc-1', 'done'));
+    await waitFor(() => expect(onTransitioned).toHaveBeenCalledWith('done'));
+  });
+
+  it('build→verify: blocked editor override forces the move via updateDocStatus(doc, "verify")', async () => {
+    tagAc(S258(9));
+    const user = userEvent.setup();
+    render(
+      <TransitionSentence
+        {...baseProps({ currentPhase: 'build', viewedTab: 'build', openTaskCount: 2 })}
+      />,
+    );
+    await user.click(screen.getByRole('button', { name: 'Yes' }));
+    await waitFor(() => expect(updateDocStatus).toHaveBeenCalledWith('doc-1', 'verify'));
+  });
+
+  it('specify→build: blocked editor override forces the move via updateDocStatus(doc, "build")', async () => {
+    tagAc(S258(9));
+    const user = userEvent.setup();
+    render(<TransitionSentence {...baseProps({ openDecisionCount: 4 })} />);
+    await user.click(screen.getByRole('button', { name: 'Yes' }));
+    await waitFor(() => expect(updateDocStatus).toHaveBeenCalledWith('doc-1', 'build'));
+  });
+
+  it('non-editor blocked current tab stays status-only on every axis — no override (ac-8, spec-182/dec-2)', () => {
+    tagAc(S258(8));
+    const axes = [
+      { props: { openDecisionCount: 4 }, phase: 'Build' },
+      { props: { currentPhase: 'build' as SpecStatus, viewedTab: 'build' as SpecStatus, openTaskCount: 2 }, phase: 'Verify' },
+      {
+        props: {
+          currentPhase: 'verify' as SpecStatus,
+          viewedTab: 'verify' as SpecStatus,
+          unverifiedAcCount: 3,
+        },
+        phase: 'Done',
+      },
+    ];
+    for (const { props, phase } of axes) {
+      const { unmount } = render(
+        <TransitionSentence {...baseProps({ ...props, canTransition: false })} />,
+      );
+      expect(text()).toContain('must be');
+      expect(text()).not.toContain(`Move this spec to ${phase} anyway?`);
+      expect(screen.queryByRole('button')).toBeNull();
+      unmount();
+    }
   });
 });

--- a/packages/ui/src/components/TransitionSentence.tsx
+++ b/packages/ui/src/components/TransitionSentence.tsx
@@ -14,10 +14,13 @@ import { Button } from './ui';
 //
 //   1. CURRENT tab, rubric clean → the advancement offer + [Yes].
 //      "Do you wish to move this spec to Build?"
-//   2. CURRENT tab, rubric blocked → the outstanding work, stated plainly, NO
-//      buttons — when the work is obvious there is nothing to confirm.
+//   2. CURRENT tab, rubric blocked → the outstanding work, stated plainly.
 //      "**4 Decisions** must be resolved and **Acceptance Criteria (ACs)**
 //       must be created before this spec can move to Build."
+//      spec-258/dec-5 (amends spec-159/dec-4): for an EDITOR the line ALSO
+//      offers a "Move this spec to {Phase} anyway?" override [Yes] — the move is
+//      forceable from the kanban, so the spec page shouldn't withhold it. A
+//      non-editor still sees the blocker statement alone (no question, no button).
 //   3. BROWSING another tab → an explicit confirm: [Yes] [No]. Forward+blocked
 //      leads with the blocker summary (which names the target) and asks "Move
 //      this spec anyway?" — the deliberate-friction escape hatch. No returns
@@ -271,12 +274,24 @@ export function TransitionSentence({
   // Shape 1/2 — viewing the current phase's own tab.
   if (viewingCurrentTab) {
     if (blockers.length > 0) {
-      // Blocked: state the exact rubric condition. The work is obvious — no
-      // buttons to press.
+      // Blocked: always state the exact rubric condition. spec-258/dec-5: an
+      // EDITOR additionally gets a "Move … anyway?" override — phase gates are
+      // soft (spec-12/dec-6) and the move is already forceable from the kanban,
+      // so the spec page shouldn't be the lone surface that withholds it. The
+      // override is phase-generic, so it covers specify→build, build→verify and
+      // verify→done alike. A non-editor (canTransition === false) keeps the
+      // status-only blocker text — no question, no button (spec-182/dec-2).
       return (
         <p className="text-sm text-secondary" data-testid="transition-sentence">
           {renderBlockers(blockers)} before this spec can move to {phaseDisplayName(target)}
           {refreshTail}.
+          {canTransition && (
+            <>
+              {' '}
+              Move this spec to {phaseDisplayName(target)} anyway? {yesButton}
+              {errorNote}
+            </>
+          )}
         </p>
       );
     }

--- a/packages/ui/src/pages/DocDocument.spec-159-coverage.test.tsx
+++ b/packages/ui/src/pages/DocDocument.spec-159-coverage.test.tsx
@@ -128,9 +128,10 @@ beforeEach(() => {
 });
 
 describe('spec-159 — zero-state holes block at the page level (ac-3, ac-13)', () => {
-  it('build with ZERO tasks: in-situ ⚠ directive states the hole; Rubicon line blocks with no buttons', async () => {
+  it('build with ZERO tasks: in-situ ⚠ directive states the hole; Rubicon line blocks + editor override (spec-258)', async () => {
     tagAc(AC(3));
     tagAc(AC(13));
+    tagAc('mindset-prod/memex-building-itself/specs/spec-258/acs/ac-9');
     // No tasks at all — the zero-task hole (an empty build hasn't built anything).
     docTasks = [];
     renderAt('build');
@@ -142,17 +143,20 @@ describe('spec-159 — zero-state holes block at the page level (ac-3, ac-13)', 
         'Tasks must be created and completed before this spec can move to Verify.',
       ),
     );
-    // The Rubicon line states the same hole and offers nothing to press.
+    // The Rubicon line states the same hole and — spec-258/dec-5, editor — offers
+    // the "Move … anyway?" override [Yes].
     const sentence = screen.getByTestId('transition-sentence');
     expect(sentence.textContent).toContain(
       'Tasks must be created and completed before this spec can move to Verify.',
     );
-    expect(within(sentence).queryByRole('button')).not.toBeInTheDocument();
+    expect(sentence.textContent).toContain('Move this spec to Verify anyway?');
+    expect(within(sentence).getByRole('button', { name: 'Yes' })).toBeInTheDocument();
   });
 
-  it('verify with NO active ACs: in-situ ⚠ directive states the hole; Rubicon line blocks with no buttons', async () => {
+  it('verify with NO active ACs: in-situ ⚠ directive states the hole; Rubicon line blocks + editor override (spec-258)', async () => {
     tagAc(AC(3));
     tagAc(AC(13));
+    tagAc('mindset-prod/memex-building-itself/specs/spec-258/acs/ac-9');
     // No active ACs — nothing to verify against (the verify→done hole).
     docAcs = [];
     renderAt('verify');
@@ -167,7 +171,8 @@ describe('spec-159 — zero-state holes block at the page level (ac-3, ac-13)', 
     expect(sentence.textContent).toContain(
       'Acceptance Criteria (ACs) must be created and verified before this spec can move to Done.',
     );
-    expect(within(sentence).queryByRole('button')).not.toBeInTheDocument();
+    expect(sentence.textContent).toContain('Move this spec to Done anyway?');
+    expect(within(sentence).getByRole('button', { name: 'Yes' })).toBeInTheDocument();
   });
 
   it('an inactive (non-active) AC does NOT satisfy the verify hole — still blocked', async () => {
@@ -186,9 +191,14 @@ describe('spec-159 — zero-state holes block at the page level (ac-3, ac-13)', 
   });
 });
 
-describe('spec-159 — blocked current phase withholds Yes for an editor (ac-3)', () => {
-  it('editor on a dirty plan (open decision): the line states the blocker, no Yes', async () => {
+// spec-258/dec-5 amends spec-159/dec-4: a blocked current tab now offers the
+// EDITOR a "Move … anyway?" override (the move is forceable from the kanban, so
+// the spec page shouldn't be the lone surface that withholds it). A non-editor's
+// blocked state stays status-only (spec-182/dec-2) — covered in spec-258 specs.
+describe('spec-258 — blocked current phase offers an editor the override (dec-5)', () => {
+  it('editor on a dirty plan (open decision): the line states the blocker AND the "Move … anyway?" override', async () => {
     tagAc(AC(3));
+    tagAc('mindset-prod/memex-building-itself/specs/spec-258/acs/ac-9');
     mockRole = 'editor';
     docDecisions = [
       {
@@ -209,13 +219,14 @@ describe('spec-159 — blocked current phase withholds Yes for an editor (ac-3)'
     renderAt('specify');
 
     const sentence = await screen.findByTestId('transition-sentence');
-    // Even with an editor posture (canTransition true) a dirty rubric on the
-    // current tab shows the condition, never a Yes.
+    // Editor posture (canTransition true): the dirty rubric on the current tab
+    // shows the condition AND the dec-5 override [Yes].
     await waitFor(() =>
       expect(sentence.textContent).toContain(
         '1 Decision must be resolved before this spec can move to Build.',
       ),
     );
-    expect(within(sentence).queryByRole('button')).not.toBeInTheDocument();
+    expect(sentence.textContent).toContain('Move this spec to Build anyway?');
+    expect(within(sentence).getByRole('button', { name: 'Yes' })).toBeInTheDocument();
   });
 });

--- a/packages/ui/src/pages/DocDocument.spec-159.test.tsx
+++ b/packages/ui/src/pages/DocDocument.spec-159.test.tsx
@@ -234,8 +234,8 @@ describe('spec-159 t-6 — DocDocument phase layouts', () => {
 
     // No sub-tab bar: the Specify sub-tab labels are absent.
     expect(screen.queryByText('Decisions & ACs')).not.toBeInTheDocument();
-    // The only tablist on the page is the phase bar (3 tabs), not a sub-tab bar.
-    expect(screen.getAllByRole('tab')).toHaveLength(3);
+    // The only tablist on the page is the phase bar (4 tabs, spec-258), not a sub-tab bar.
+    expect(screen.getAllByRole('tab')).toHaveLength(4);
   });
 
   it('Verify renders AC | Issues with NO sub-tab bar (ac-5, ac-11)', async () => {
@@ -246,7 +246,7 @@ describe('spec-159 t-6 — DocDocument phase layouts', () => {
     await screen.findByTestId('ac-panel');
     expect(screen.getByTestId('issue-panel')).toBeInTheDocument();
     expect(screen.queryByTestId('task-panel')).not.toBeInTheDocument();
-    expect(screen.getAllByRole('tab')).toHaveLength(3);
+    expect(screen.getAllByRole('tab')).toHaveLength(4);
   });
 
   it('Done replaces the content area with the DoneSummary report (ac-5)', async () => {
@@ -303,7 +303,13 @@ describe('spec-159 t-6 — DocDocument phase layouts', () => {
     await screen.findByTestId('ac-panel');
 
     const sentence = screen.getByTestId('transition-sentence');
-    const yes = await within(sentence).findByRole('button', { name: 'Yes' });
+    // Wait for the async AC fetch to settle so verify is CLEAN and the line shows
+    // the ready advancement offer — not the transient spec-258/dec-5 blocked
+    // override (which renders a Yes during the pre-fetch unverified window).
+    await waitFor(() =>
+      expect(sentence).toHaveTextContent(/Do you want to move this spec to Done\?/),
+    );
+    const yes = within(sentence).getByRole('button', { name: 'Yes' });
     await user.click(yes);
 
     // Directly transitioned — no confirm dialog was ever mounted.
@@ -317,15 +323,17 @@ describe('spec-159 t-6 — DocDocument phase layouts', () => {
 // browsing forward → summary + Are-you-sure Yes/No. The in-situ ⚠ directives
 // above the lists are unchanged.
 describe('spec-159 — Rubicon line + in-situ directives', () => {
-  it('specify with open decisions: line states the blocker with no buttons; directive sits above Decisions (ac-3, ac-13)', async () => {
+  it('specify with open decisions: line states the blocker + editor override; directive sits above Decisions (ac-3, ac-13, spec-258)', async () => {
     tagAc(AC(3));
     tagAc(AC(13));
+    tagAc('mindset-prod/memex-building-itself/specs/spec-258/acs/ac-9');
     const user = userEvent.setup();
     docDecisions = [decision('d-1', 'open'), decision('d-2', 'open')];
     docAcs = [{ ac: { status: 'active' }, verificationState: 'untested' }];
     renderAt('specify');
 
-    // Current tab + blocked rubric → the exact condition, no Yes to press.
+    // Current tab + blocked rubric → the exact condition, plus the spec-258/dec-5
+    // editor override "Move … anyway?" [Yes] (canEdit is true in this render).
     // (waitFor: the AC fetch resolving flips `hasAcceptanceCriteria` async.)
     const sentence = await screen.findByTestId('transition-sentence');
     await waitFor(() =>
@@ -333,7 +341,8 @@ describe('spec-159 — Rubicon line + in-situ directives', () => {
         '2 Decisions must be resolved before this spec can move to Build.',
       ),
     );
-    expect(within(sentence).queryByRole('button')).not.toBeInTheDocument();
+    expect(sentence.textContent).toContain('Move this spec to Build anyway?');
+    expect(within(sentence).getByRole('button', { name: 'Yes' })).toBeInTheDocument();
 
     // The directive renders in-situ on the Decisions & ACs sub-tab.
     await user.click(screen.getByText('Decisions & ACs'));
@@ -401,8 +410,9 @@ describe('spec-159 — Rubicon line + in-situ directives', () => {
     expect(text).toContain('2 Decisions must be resolved before this spec can move to Build.');
   });
 
-  it('build with open tasks: directive above Tasks; Rubicon line states it with no buttons (ac-13)', async () => {
+  it('build with open tasks: directive above Tasks; Rubicon line states it + editor override (ac-13, spec-258)', async () => {
     tagAc(AC(13));
+    tagAc('mindset-prod/memex-building-itself/specs/spec-258/acs/ac-9');
     docTasks = [{ id: 't-1', status: 'in_progress' }, { id: 't-2', status: 'complete' }];
     renderAt('build');
 
@@ -414,12 +424,14 @@ describe('spec-159 — Rubicon line + in-situ directives', () => {
     expect(text).toContain(
       '1 Task must be completed (or kicked to Issues) before this spec can move to Verify.',
     );
-    // Current tab + open task → the Rubicon line states it, no buttons.
+    // Current tab + open task → the Rubicon line states it, plus the spec-258/dec-5
+    // editor override "Move … anyway?" [Yes].
     const sentence = screen.getByTestId('transition-sentence');
     expect(sentence.textContent).toContain(
       '1 Task must be completed before this spec can move to Verify.',
     );
-    expect(within(sentence).queryByRole('button')).not.toBeInTheDocument();
+    expect(sentence.textContent).toContain('Move this spec to Verify anyway?');
+    expect(within(sentence).getByRole('button', { name: 'Yes' })).toBeInTheDocument();
   });
 
   it('verify with unverified ACs: directive above the AC column (ac-13)', async () => {
@@ -496,7 +508,7 @@ describe('spec-159 — Rubicon line + in-situ directives', () => {
     await screen.findByText('Narrative');
 
     // Editors still get the PhaseTabBar (3 phase tabs) and the Rubicon line.
-    expect(screen.getAllByRole('tab')).toHaveLength(3);
+    expect(screen.getAllByRole('tab')).toHaveLength(4);
     expect(screen.getByTestId('transition-sentence')).toBeInTheDocument();
     // spec-182 dec-3 + issue-3: at Specify the editor keeps ACCESS to the
     // review actions, but behind a collapsed-by-default disclosure.
@@ -554,7 +566,7 @@ describe('spec-182 — unified reviewer phase block', () => {
 
     await screen.findByTestId('review-action-row');
     // The PhaseTabBar renders for reviewers too (dec-1) — browse-only.
-    expect(screen.getAllByRole('tab')).toHaveLength(3);
+    expect(screen.getAllByRole('tab')).toHaveLength(4);
     // The Rubicon line renders status-only: present, but no [Yes] (dec-2).
     const sentence = screen.getByTestId('transition-sentence');
     expect(within(sentence).queryByRole('button', { name: 'Yes' })).not.toBeInTheDocument();
@@ -672,7 +684,7 @@ describe('spec-182 — unified reviewer phase block', () => {
     await screen.findByTestId('task-panel');
     expect(screen.getByTestId('issue-panel')).toBeInTheDocument();
     // dec-1: the tab bar renders for reviewers; dec-3: no review row off-Specify.
-    expect(screen.getAllByRole('tab')).toHaveLength(3);
+    expect(screen.getAllByRole('tab')).toHaveLength(4);
     expect(screen.queryByTestId('review-action-row')).not.toBeInTheDocument();
     expect(screen.queryByTestId('review-handoff-line')).not.toBeInTheDocument();
   });

--- a/packages/ui/src/pages/DocDocument.spec-258.test.tsx
+++ b/packages/ui/src/pages/DocDocument.spec-258.test.tsx
@@ -1,0 +1,244 @@
+// spec-258 — the Done tab wired into DocDocument: browsing it previews the
+// retrospective (read-only DoneSummary, no Reopen), the Rubicon line above it
+// offers the verify→done move through the same browse-and-confirm pattern as
+// every other out-of-phase tab, and confirming closes the spec while declining
+// returns to the current phase's tab. Mirrors the spec-159 page harness exactly
+// (stable, module-level mock identities — unstable per-render mocks like
+// `refetch: vi.fn()` feed back through the header slot and loop the page).
+//
+//   ac-6 : PHASE_LAYOUTS.done renders the read-only DoneSummary preview (fed
+//          from on-page props, no Reopen/mutation); selecting Done never mutates.
+//   ac-2 : browsing Done offers the browse-confirm Rubicon (ready → "Are you
+//          sure…?"; blocked → blocker summary + "Move this spec anyway?").
+//   ac-3 : confirming [Yes] → updateDocStatus(doc, 'done'); [No] returns to the
+//          current phase's tab without mutating.
+//   ac-4 : the Done tab uses resting/selected treatment only — no filled pill.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { tagAc } from '@memex-ai-ac/vitest';
+import type { DocWithGraph } from '../api/types';
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-258/acs/ac-${n}`;
+
+vi.mock('../components/DecisionPanel', () => ({ DecisionPanel: () => <div data-testid="decision-panel" /> }));
+vi.mock('../components/AcPanel', () => ({ AcPanel: () => <div data-testid="ac-panel" /> }));
+vi.mock('../components/TaskPanel', () => ({ TaskPanel: () => <div data-testid="task-panel" /> }));
+vi.mock('../components/IssuePanel', () => ({ IssuePanel: () => <div data-testid="issue-panel" /> }));
+vi.mock('../components/AllComments', () => ({ AllComments: () => <div data-testid="all-comments" /> }));
+vi.mock('../components/SectionCard', () => ({ SectionCard: () => <div data-testid="section-card" /> }));
+vi.mock('../components/DocOutline', () => ({ DocOutline: () => <div data-testid="doc-outline" /> }));
+vi.mock('../components/TagPicker', () => ({ TagPicker: () => null }));
+vi.mock('../components/BylineAssignees', () => ({ BylineAssignees: () => <div data-testid="byline-assignees" /> }));
+// The DoneSummary stub surfaces whether DocDocument handed it the Reopen wiring
+// (canReopen) and how many ACs it was fed — so we can prove the Done-tab PREVIEW
+// is the read-only, on-page-fed variant (no Reopen), distinct from the post-close
+// report which DOES carry Reopen.
+vi.mock('../components/DoneSummary', () => ({
+  DoneSummary: (props: { canReopen?: boolean; onReopen?: () => void; acs?: unknown[] }) => (
+    <div
+      data-testid="done-summary"
+      data-can-reopen={props.canReopen ? 'true' : 'false'}
+      data-acs-count={(props.acs ?? []).length}
+    >
+      {props.canReopen && (
+        <button data-testid="stub-reopen" onClick={() => props.onReopen?.()}>
+          reopen
+        </button>
+      )}
+    </div>
+  ),
+}));
+
+// Stable module-level mock identities (mirrors spec-159) — a fresh function per
+// render here (e.g. refetch: vi.fn()) destabilises switchPosture → headerActions
+// → the header slot effect, looping the page.
+const refetchRole = vi.fn();
+vi.mock('../hooks/useMemexAccess', () => ({ useMemexAccess: () => ({ canWrite: true, isReadOnly: false }) }));
+vi.mock('../hooks/useDocRole', () => ({
+  useDocRole: () => ({ myRole: 'editor', editors: [], loading: false, refetch: refetchRole }),
+}));
+vi.mock('../hooks/useDocChangeStream', () => ({ useDocChangeStream: () => {} }));
+vi.mock('../hooks/useOrgScaffoldBlocks', () => ({ useOrgScaffoldBlocks: () => [] }));
+const chat = { setDocId: vi.fn(), setDoc: vi.fn(), setOpenCommentCount: vi.fn(), sendMessage: vi.fn() };
+vi.mock('../components/ChatContext', () => ({ useChat: () => chat }));
+
+const updateDocStatus = vi.fn();
+const promoteToEditor = vi.fn();
+const demoteToReviewer = vi.fn();
+let docStatus: DocWithGraph['status'] = 'verify';
+let docAcs: unknown[] = [];
+
+function makeDoc(): DocWithGraph {
+  return {
+    id: 'doc-uuid',
+    handle: 'spec-258',
+    title: 'Done tab',
+    docType: 'spec',
+    status: docStatus,
+    creator: { name: 'Barrie', email: 'barrie@mindset.ai' },
+    createdAt: '2026-06-01T00:00:00Z',
+    statusChangedAt: '2026-06-10T00:00:00Z',
+    narrativeLastConsolidatedAt: null,
+    sections: [{ id: 's-1', seq: 1, title: 'Intro', body: 'x' }],
+    decisions: [],
+    tasks: [{ id: 't-1', status: 'complete' }],
+    tags: [],
+  } as unknown as DocWithGraph;
+}
+
+vi.mock('../api/client', () => ({
+  NotFoundError: class NotFoundError extends Error {},
+  fetchDoc: () => Promise.resolve(makeDoc()),
+  fetchDocComments: () => Promise.resolve({ sections: [], decisions: [], tasks: [] }),
+  fetchAcsForBrief: () => Promise.resolve(docAcs),
+  fetchIssues: () => Promise.resolve([]),
+  fetchDocAssignees: () => Promise.resolve([]),
+  archiveDoc: vi.fn(),
+  pauseDoc: vi.fn(),
+  unpauseDoc: vi.fn(),
+  updateDocStatus: (...a: unknown[]) => updateDocStatus(...a),
+  promoteToEditor: (...a: unknown[]) => promoteToEditor(...a),
+  demoteToReviewer: (...a: unknown[]) => demoteToReviewer(...a),
+}));
+
+import { DocDocument } from './DocDocument';
+import { HeaderSlotProvider, useHeaderSlotContent } from '../components/HeaderSlot';
+
+function HeaderSink() {
+  return <div data-testid="header-slot">{useHeaderSlotContent()}</div>;
+}
+
+function renderAt(status: DocWithGraph['status']) {
+  docStatus = status;
+  return render(
+    <MemoryRouter initialEntries={['/n/m/specs/spec-258']}>
+      <HeaderSlotProvider>
+        <HeaderSink />
+        <Routes>
+          <Route path="/:ns/:mx/specs/:id" element={<DocDocument />} />
+        </Routes>
+      </HeaderSlotProvider>
+    </MemoryRouter>,
+  );
+}
+
+function phaseTab(name: string) {
+  return screen.getAllByRole('tab').find((t) => t.getAttribute('data-tab') === name)!;
+}
+
+// An active AC: verified → clean verify rubric; untested → blocked verify rubric.
+const activeAc = (state: 'verified' | 'untested') => ({ ac: { status: 'active' }, verificationState: state });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  updateDocStatus.mockResolvedValue(undefined);
+  promoteToEditor.mockResolvedValue(undefined);
+  demoteToReviewer.mockResolvedValue(undefined);
+  docAcs = [activeAc('verified')];
+});
+
+describe('spec-258 — Done tab in DocDocument', () => {
+  it('browsing Done renders the read-only DoneSummary preview (no Reopen) fed from on-page ACs; selecting it never mutates (ac-6, ac-4)', async () => {
+    tagAc(AC(6));
+    tagAc(AC(4));
+    const user = userEvent.setup();
+    renderAt('verify');
+
+    // Verify content shows first (current phase). No preview yet.
+    await screen.findByTestId('ac-panel');
+    expect(screen.queryByTestId('done-summary')).not.toBeInTheDocument();
+
+    await user.click(phaseTab('done'));
+
+    // The preview renders — and it is the READ-ONLY variant: no Reopen wiring,
+    // fed from the page's already-fetched ACs (1 active AC).
+    const preview = await screen.findByTestId('done-summary');
+    expect(preview).toHaveAttribute('data-can-reopen', 'false');
+    expect(preview).toHaveAttribute('data-acs-count', '1');
+    expect(screen.queryByTestId('stub-reopen')).not.toBeInTheDocument();
+
+    // dec-4: the Done tab is never the filled "current" pill.
+    expect(phaseTab('done')).not.toHaveAttribute('data-current');
+
+    // Browsing is not a mutation.
+    expect(updateDocStatus).not.toHaveBeenCalled();
+  });
+
+  it('browsing Done with a clean rubric offers "Are you sure you want to move this spec to Done?" + Yes/No (ac-2)', async () => {
+    tagAc(AC(2));
+    const user = userEvent.setup();
+    docAcs = [activeAc('verified')];
+    renderAt('verify');
+
+    await screen.findByTestId('ac-panel');
+    await user.click(phaseTab('done'));
+
+    const sentence = await screen.findByTestId('transition-sentence');
+    await waitFor(() =>
+      expect(sentence.textContent).toContain('Are you sure you want to move this spec to Done?'),
+    );
+    expect(within(sentence).getByRole('button', { name: 'Yes' })).toBeInTheDocument();
+    expect(within(sentence).getByRole('button', { name: 'No' })).toBeInTheDocument();
+  });
+
+  it('browsing Done with an unverified AC shows the blocker + "Move this spec anyway?" (ac-2)', async () => {
+    tagAc(AC(2));
+    const user = userEvent.setup();
+    docAcs = [activeAc('untested')];
+    renderAt('verify');
+
+    await screen.findByTestId('ac-panel');
+    await user.click(phaseTab('done'));
+
+    const sentence = await screen.findByTestId('transition-sentence');
+    await waitFor(() =>
+      expect(sentence.textContent).toContain(
+        '1 Acceptance Criterion (AC) must be verified before Done.',
+      ),
+    );
+    expect(sentence.textContent).toContain('Move this spec anyway?');
+    expect(within(sentence).getByRole('button', { name: 'Yes' })).toBeInTheDocument();
+  });
+
+  it('confirming [Yes] from the Done tab calls updateDocStatus(doc, "done") (ac-3)', async () => {
+    tagAc(AC(3));
+    const user = userEvent.setup();
+    docAcs = [activeAc('verified')];
+    renderAt('verify');
+
+    await screen.findByTestId('ac-panel');
+    await user.click(phaseTab('done'));
+    const sentence = await screen.findByTestId('transition-sentence');
+    await waitFor(() =>
+      expect(sentence.textContent).toContain('Are you sure you want to move this spec to Done?'),
+    );
+
+    await user.click(within(sentence).getByRole('button', { name: 'Yes' }));
+    await waitFor(() => expect(updateDocStatus).toHaveBeenCalledWith('doc-uuid', 'done'));
+  });
+
+  it('declining [No] from the Done tab returns to the current phase tab without mutating (ac-3)', async () => {
+    tagAc(AC(3));
+    const user = userEvent.setup();
+    docAcs = [activeAc('verified')];
+    renderAt('verify');
+
+    await screen.findByTestId('ac-panel');
+    await user.click(phaseTab('done'));
+    const sentence = await screen.findByTestId('transition-sentence');
+    await waitFor(() =>
+      expect(sentence.textContent).toContain('Are you sure you want to move this spec to Done?'),
+    );
+
+    await user.click(within(sentence).getByRole('button', { name: 'No' }));
+
+    // View snaps back to the current phase (verify): the AC panel returns and the
+    // Done preview is gone. Phase never changed.
+    await screen.findByTestId('ac-panel');
+    expect(screen.queryByTestId('done-summary')).not.toBeInTheDocument();
+    expect(updateDocStatus).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/pages/DocDocument.tsx
+++ b/packages/ui/src/pages/DocDocument.tsx
@@ -1070,10 +1070,17 @@ export function DocDocument() {
   );
 
   // ── The declarative phase → layout map (spec-159: explicitly a plain data
-  //    structure so the per-phase composition is cheap to rearrange). `done`
-  //    isn't here — DoneSummary replaces the whole content area below. `draft`
+  //    structure so the per-phase composition is cheap to rearrange). `draft`
   //    shares the `specify` layout (its home tab). Each entry says whether the
-  //    phase carries a sub-tab bar and what it renders. ──────────────────────
+  //    phase carries a sub-tab bar and what it renders.
+  //
+  //    spec-258/dec-3: the `done` entry is the Done TAB's content — a read-only
+  //    DoneSummary *preview* shown while browsing Done before the spec is closed.
+  //    It is fed from the same on-page props as the post-close report (doc /
+  //    decisions / tasks / acs / issues / people) but carries NO Reopen or
+  //    mutation affordance (canReopen omitted) — browsing never mutates phase.
+  //    Once the spec is actually `done`, the bar is hidden and the real
+  //    DoneSummary (with Reopen) takes over the whole area below. ─────────────
   const PHASE_LAYOUTS: Record<PhaseTab, { hasSubTabs: boolean; render: () => React.ReactNode }> = {
     specify: {
       hasSubTabs: true,
@@ -1108,6 +1115,22 @@ export function DocDocument() {
             {verifyTaskEcho}
           </>,
         ),
+    },
+    // spec-258/dec-3: browsing the Done tab previews the retrospective the move
+    // will produce — the same fetch-free DoneSummary, minus Reopen/mutation.
+    done: {
+      hasSubTabs: false,
+      render: () => (
+        <DoneSummary
+          doc={doc}
+          decisions={decs}
+          tasks={ts}
+          acs={acs}
+          issues={issues}
+          people={assignees}
+          preview
+        />
+      ),
     },
   };
 


### PR DESCRIPTION
## Summary
Closes spec-164/issue-3: an editor now always has a web-UI path to move a spec forward — the spec page was the lone surface that withheld it. Frontend-only (`packages/ui`); the transition endpoint and soft-gate behaviour are unchanged.

- **Done tab** — the phase bar completes the pipeline **Specify → Build → Verify → Done**, so `verify→done` is offered through the same browse-and-confirm Rubicon pattern as every other phase move. The Done tab only ever wears the resting/underline treatment, never the filled "current" pill (the bar is hidden once `phase==='done'`, dec-4); the dead `✓ Done` marker is removed.
- **Editor override on a blocked move** — a blocked current tab keeps naming what's open and additionally offers editors a **"Move this spec to {Phase} anyway?"** confirm (dec-5), uniformly across specify→build, build→verify, verify→done. Strictly editor-gated; a non-editor's blocked state stays status-only (spec-182/dec-2).
- **Done-tab preview (dec-3)** — browsing the Done tab before close renders the read-only `DoneSummary` as a preview (no Reopen/mutation). Its headline reads **"This spec will be completed"** (forward tense), distinct from the post-close report's "was completed on {date}".

## Spec
[spec-258](https://memex.ai/mindset-prod/memex-building-itself/specs/spec-258) — all 9 ACs verified (100%).

## Testing
- Unit (`PhaseTabBar`), component (`TransitionSentence`), integration (`DocDocument.spec-258`) — full UI suite green (1211 passed).
- **std-28 PR-gate Playwright journey**: `journey-29-spec-258-done-tab.spec.ts` (2 passed via `make e2e-cold`) — drives the human close via the Done tab and the editor override end-to-end.
- `tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)