### PR TITLE
fix(server): graceful SIGTERM shutdown — stop instance teardown from severing in-flight SSE (/guide/v1/chat ERR_CONNECTION_CLOSED)

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -84,3 +84,50 @@ setInterval(async () => {
 // Bounded (10k rows/pass), idempotent across instances; self-scheduling hourly. The
 // timer is .unref()'d so it never blocks shutdown.
 startActivityLogSweep().unref();
+
+// Graceful shutdown (spec-251 follow-up, found 2026-06-12).
+//
+// Cloud Run sends SIGTERM on every instance teardown — deploy rollover (old
+// revision drained as traffic shifts) and scale-in — then waits a termination
+// grace period (~10s) before SIGKILL. Node's DEFAULT SIGTERM behaviour is to
+// exit the process IMMEDIATELY, which severs every in-flight response mid-write.
+// For the guide's streaming SSE `/chat` turns that means the browser sees
+// `net::ERR_CONNECTION_CLOSED` ("Failed to fetch") with no HTTP status and no
+// app-level error — exactly the symptom a live mindset-website visitor hit when
+// this release's rollout recycled the instance their turn was pinned to.
+//
+// Drain instead: stop accepting new connections, close idle keep-alives so only
+// ACTIVE requests keep us alive, let those finish (guide turns are ~2-3s, well
+// inside the grace window), then exit cleanly. A hard backstop force-closes
+// anything still streaming just before SIGKILL so shutdown never hangs.
+const SHUTDOWN_GRACE_MS = parseInt(process.env.SHUTDOWN_GRACE_MS ?? "8000", 10);
+let shuttingDown = false;
+function gracefulShutdown(signal: NodeJS.Signals): void {
+  if (shuttingDown) return; // a second signal must not race two close()/exit paths
+  shuttingDown = true;
+  console.log(
+    `[shutdown] ${signal} received — draining in-flight requests (grace ${SHUTDOWN_GRACE_MS}ms)`,
+  );
+  // serve() returns a union (http/http2); we run plain http, so narrow to
+  // http.Server for the connection-draining methods (Node 18.2+ / 22 here).
+  const httpServer = server as import("node:http").Server;
+  // close() stops the listener and fires its callback once all connections end.
+  httpServer.close(() => {
+    console.log("[shutdown] all connections drained — exiting cleanly");
+    process.exit(0);
+  });
+  // Idle keep-alive sockets would otherwise hold close() open indefinitely; drop
+  // them now so close() is gated only on requests actually in flight.
+  httpServer.closeIdleConnections?.();
+  // Backstop: anything still streaming past the grace window gets force-closed so
+  // we exit before Cloud Run's SIGKILL (a clean exit beats an abrupt kill).
+  setTimeout(() => {
+    console.warn(
+      "[shutdown] grace window elapsed — force-closing remaining connections",
+    );
+    httpServer.closeAllConnections?.();
+    process.exit(0);
+  }, SHUTDOWN_GRACE_MS).unref();
+}
+process.on("SIGTERM", () => gracefulShutdown("SIGTERM"));
+process.on("SIGINT", () => gracefulShutdown("SIGINT"));


### PR DESCRIPTION
## Symptom
Live on mindset.ai (surface=mindset-website, prod guide backend): a guide `/chat` turn died with `net::ERR_CONNECTION_CLOSED` → UI "The voice guide hit an error: Failed to fetch." Intermittent; Retry recovered. Reported on a navigate tool-loop turn.

## Root cause (from prod Cloud Run logs, memex-ai-prod / memex-api)
- **Not an app error.** `severity>=ERROR` was empty in the window; every *completed* `/guide/v1/chat` returned 200/204. The `streamSSE` try/catch in `voice.ts` already emits a clean `event: error` for in-stream failures — so this was never an uncaught throw.
- **Connection-level drops.** Cloud Run logged bursts of ~25 `Truncated response body — the application exited before the response was finished` within seconds — one instance dropping all its in-flight streams at once.
- **Coincided with this release's rollout.** Prod cutover ~03:30; the user hit it ~03:34. Cloud Run SIGTERMs draining old-revision instances (and on scale-in), then SIGKILLs after a ~10s grace.
- **No SIGTERM handler existed.** `index.ts` calls `serve()` and registers no signal handler, so Node's default fired: immediate process exit, severing every in-flight response mid-write → ERR_CONNECTION_CLOSED with no HTTP status. The navigate-turn correlation is coincidental — it drops whatever turn is in flight at teardown (hence intermittent; the reporter's "6/6 raw repros passed").

## Fix
Graceful drain on `SIGTERM`/`SIGINT`: stop the listener, `closeIdleConnections()` so only active requests hold us open, let in-flight turns finish (~2-3s, inside the grace window), then exit. A configurable backstop (`SHUTDOWN_GRACE_MS`, default 8000ms — under Cloud Run's ~10s SIGKILL) force-closes anything still streaming. Converts rollover/scale-in drops into clean completions.

## Scope / limits
- Handles **SIGTERM** (deploy rollover, scale-in) — the confirmed cause.
- Cannot help an uncatchable **SIGKILL/OOM**. No memory-limit log appeared, so OOM is unlikely, but `--memory 512Mi` / `--max-instances 3` headroom (deploy.sh) is worth a follow-up if truncated-body bursts persist after this ships. Optionally `--min-instances 1` to reduce scale-to-zero churn. **Not bundled here** — cost/posture decision.

## Verification
- `index.ts` type-checks under `tsconfig.build.json`; chat-path tests green (`guide-public-mindset-website`, `voice.integration` — 12 tests).
- Behavior is standard Node graceful shutdown; the real proof is prod — after this is live, the **next** rollover/scale-in should drain in-flight `/chat` streams instead of dropping them. (The deploy that ships this fix is the last ungraceful rollover.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)