### PR TITLE
feat(qa-report): Build QA Report — persisted hand-off record, render seats, workspace feed + unread badge (spec-260)

### DIFF
--- a/packages/server/drizzle/0092_qa_report_views.sql
+++ b/packages/server/drizzle/0092_qa_report_views.sql
@@ -1,0 +1,42 @@
+-- spec-260 t-1 — per-user QA Reports read-state marker (dec-6).
+--
+-- The only net-new table for the QA Report feature. One row per (user, memex) holding
+-- the last time that user viewed the workspace QA Reports feed. Unread = count of
+-- qa_report* doc_sections in the memex created after last_viewed_at (computed in the
+-- service layer, NOT stored here). A NULL/absent marker means the user has never viewed
+-- the feed, so every report counts.
+--
+-- This is per-user state, NOT an activity-bearing doc table, so the std-32 activity-
+-- contract columns (actor_user_id / actor_name / channel) deliberately do NOT apply.
+--
+-- Tenancy (std-7): it carries a direct memex_id, so it takes the same memex_isolation
+-- RLS policy as the Phase-2 tenant tables (0081) — the app.memex_id GUC must be set and
+-- match the row. Per-user scoping (a user only ever reads/writes their OWN marker) is
+-- enforced at the service layer, which always operates on the authenticated user's row;
+-- RLS adds the cross-tenant 404 guarantee at the database level.
+
+CREATE TABLE IF NOT EXISTS "qa_report_views" (
+  "user_id" uuid NOT NULL REFERENCES "users" ("id") ON DELETE CASCADE,
+  "memex_id" uuid NOT NULL REFERENCES "memexes" ("id") ON DELETE CASCADE,
+  "last_viewed_at" timestamp with time zone NOT NULL DEFAULT now(),
+  CONSTRAINT "qa_report_views_pkey" PRIMARY KEY ("user_id", "memex_id")
+);
+
+ALTER TABLE "qa_report_views" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "qa_report_views" FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS qa_report_views_memex_isolation ON "qa_report_views";
+CREATE POLICY qa_report_views_memex_isolation ON "qa_report_views"
+  USING (
+    nullif(current_setting('app.memex_id', true), '') IS NOT NULL
+    AND memex_id = current_setting('app.memex_id', true)::uuid
+  )
+  WITH CHECK (
+    nullif(current_setting('app.memex_id', true), '') IS NOT NULL
+    AND memex_id = current_setting('app.memex_id', true)::uuid
+  );
+
+-- The restricted runtime role (memex_app, created in 0081) is the one RLS actually
+-- bites. ALTER DEFAULT PRIVILEGES set in 0081 already grants it on tables created
+-- afterwards, but this explicit grant is belt-and-braces for environments where the
+-- default-privileges grant didn't apply.
+GRANT SELECT, INSERT, UPDATE, DELETE ON "qa_report_views" TO memex_app;

--- a/packages/server/src/__regression__/mutate-coverage.endpoint.test.ts
+++ b/packages/server/src/__regression__/mutate-coverage.endpoint.test.ts
@@ -85,6 +85,9 @@ const MUTATING_MCP_TOOLS: Record<string, ToolMutation[]> = {
   update_section: [{ entity: "section", action: "updated" }],
   retitle_section: [{ entity: "section", action: "updated" }],
   delete_section: [{ entity: "section", action: "deleted" }],
+  // qa-reports.ts (spec-260) — appendQaReport rides addSection's mutate() path,
+  // so each versioned QA report lands as a section.created on the bus.
+  write_qa_report: [{ entity: "section", action: "created" }],
   // clauses.ts (spec-161) — every clause write dual-emits the clause key and the
   // owning section's `section.updated` (the section's derived content regenerates).
   add_clause: [

--- a/packages/server/src/__regression__/ref-emission.regression.test.ts
+++ b/packages/server/src/__regression__/ref-emission.regression.test.ts
@@ -413,6 +413,17 @@ describe("regression: every entity-acting MCP tool emits `ref:` and no raw UUID 
         },
       ],
       [
+        // spec-260: appends a versioned qa_report section; the terse response
+        // carries the new section's child ref.
+        "write_qa_report",
+        {
+          input: () => ({
+            ref: refForDoc(slugs, docHandle),
+            content: "Probe QA report body.",
+          }),
+        },
+      ],
+      [
         "update_section",
         {
           input: () => ({

--- a/packages/server/src/agent/tool-specs.audit.integration.test.ts
+++ b/packages/server/src/agent/tool-specs.audit.integration.test.ts
@@ -1009,6 +1009,17 @@ describe("audit: b-36 D-8 — every terse mutation/list response emits `ref:` an
         },
       ],
       [
+        // spec-260: appends a versioned qa_report section; the terse response
+        // carries the new section's child ref.
+        "write_qa_report",
+        {
+          input: () => ({
+            ref: docRef(slugs, docHandle),
+            content: "Probe QA report body.",
+          }),
+        },
+      ],
+      [
         "update_section",
         {
           input: () => ({

--- a/packages/server/src/agent/tool-specs.ts
+++ b/packages/server/src/agent/tool-specs.ts
@@ -43,6 +43,7 @@ import {
   deleteSection,
   resolveSectionWriteMode,
 } from "../services/sections.js";
+import { appendQaReport } from "../services/qa-reports.js";
 import {
   addClausesToSection,
   createClause,
@@ -2153,6 +2154,54 @@ export const toolSpecs: ToolSpec[] = [
       }
       const sectionRef = buildChildRef(slugs, doc, { type: "sections", seq: section.seq });
       return `Added "${section.title ?? section.sectionType}" section (ref: ${sectionRef}).`;
+    },
+  },
+  {
+    name: "write_qa_report",
+    annotations: { title: "Write QA report", readOnlyHint: false, destructiveHint: false },
+    description:
+      "Persist a QA Report on a Spec at the build→verify hand-off — a human-readable record of what THIS build session actually changed, written for a reviewer who was not in the session (including a non-developer owner). Organise it so each audience finds its part: (1) Front-end / user-affecting changes in plain language, (2) Back-end changes (routes, schema/migrations, services, auth/tenancy, agent behaviour), (3) Testing created and run (which tests, which suites, what passed, what was skipped or left red — tie back to the Spec's ACs), (4) Known gaps & follow-ups (also captured via register_issue todos), (5) Deviations from the plan, (6) Dependencies & integration points, (7) Migration/deployment notes, (8) Open questions. Ground every claim in the changes you made this session and the tests you ran — never restate the plan. Each call APPENDS a new dated version (qa_report, qa_report-2, …); it never overwrites a prior session's report. Read-only once written.",
+    schema: {
+      ref: z
+        .string()
+        .describe("Canonical ref to the Spec the report is for, e.g. `mindset/main/specs/spec-3`."),
+      content: z
+        .string()
+        .describe(
+          "Markdown body of the report, structured into the front-end / back-end / testing / gaps / deviations / dependencies / deploy-notes / open-questions sections described above. Grounded in this session's actual changes — not a restatement of the plan.",
+        ),
+      title: z
+        .string()
+        .optional()
+        .describe("Optional heading for the report row. Defaults to 'QA Report'."),
+      verbose: VERBOSE_FIELD,
+    },
+    async handler(input, ctx) {
+      const ref = input.ref as string;
+      const content = input.content as string;
+      const title = input.title as string | undefined;
+
+      const resolved = await resolveRefArg(ctx, ref);
+      if (!isDocLikeKind(resolved.entity.kind)) {
+        throw new ValidationError(
+          `write_qa_report expects a Spec ref; got ${resolved.entity.kind}.`,
+        );
+      }
+      const { memexId, doc, slugs } = resolved;
+      if (doc.docType !== "spec") {
+        throw new ValidationError(
+          "QA Reports attach to Specs only — pass a `spec-N` ref.",
+        );
+      }
+
+      const section = await appendQaReport(memexId, doc.id, content, title, reqCtx(ctx));
+      if (ctx.verbose) {
+        const state = await fullDocState(memexId, doc.id);
+        const url = await ctx.workspaceUrl(memexId);
+        return await formatState(url, state, ctx);
+      }
+      const sectionRef = buildChildRef(slugs, doc, { type: "sections", seq: section.seq });
+      return `Wrote QA Report "${section.sectionType}" (ref: ${sectionRef}) for ${doc.handle}. Each build session appends a new version — prior reports are preserved.`;
     },
   },
   {

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -23,6 +23,7 @@ import { createVoiceRouter } from "./routes/voice.js";
 import { createGuidePublicRouter } from "./routes/guide-public.js";
 import { docEventsRouter } from "./routes/doc-events.js";
 import { activity } from "./routes/activity.js";
+import { qaReports } from "./routes/qa-reports.js";
 import { presenceRouter } from "./routes/presence.js";
 import { analytics } from "./routes/analytics.js";
 import { telemetryRouter } from "./routes/telemetry.js";
@@ -243,6 +244,10 @@ app.route("/api/:namespace/:memex/issues-list", issuesList);
 // per-Memex, so there's no flat entity-keyed mount (a bare /api/activity has no
 // memex to scope to).
 app.route("/api/:namespace/:memex/activity", activity);
+// spec-260 (dec-5/dec-6) — the cross-Spec QA Reports feed + per-user unread
+// counter. Path-prefixed only — inherently per-Memex, same reasoning as
+// /activity above.
+app.route("/api/:namespace/:memex/qa-reports", qaReports);
 // spec-122 t-7 (dec-4) — the ephemeral PRESENCE plane ("who's here now"). The
 // browser heartbeat POSTs here; the UI reads who's present per spec. Inherently
 // per-Memex (every presence row is tenancy-scoped), so path-prefixed only.

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -1147,6 +1147,34 @@ export const users = pgTable("users", {
   unique("users_namespace_id_unique").on(table.namespaceId),
 ]);
 
+// spec-260 t-1 (dec-6): per-user QA Reports read-state marker — the only net-new table
+// for the QA Report feature. One row per (user, memex) holding the last time the user
+// viewed the workspace QA Reports feed. Unread = count of qa_report* doc_sections in the
+// memex created after `lastViewedAt` (computed in the service layer, not stored). A
+// missing row means "never viewed" → every report counts.
+//
+// This is per-user state, NOT an activity-bearing doc table, so the std-32 activity-
+// contract columns (actor_*, channel) deliberately do NOT apply. Tenancy: it carries a
+// direct memex_id, so migration 0092 puts the same memex_isolation RLS policy on it as
+// the Phase-2 tenant tables (0081); per-user scoping is enforced at the service layer,
+// which always reads/writes the authenticated user's own row.
+export const qaReportViews = pgTable(
+  "qa_report_views",
+  {
+    userId: uuid("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    memexId: uuid("memex_id")
+      .notNull()
+      .references(() => memexes.id, { onDelete: "cascade" }),
+    lastViewedAt: timestamp("last_viewed_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [primaryKey({ columns: [table.userId, table.memexId] })],
+);
+
+export type QaReportView = InferSelectModel<typeof qaReportViews>;
+export type NewQaReportView = InferInsertModel<typeof qaReportViews>;
+
 // Single-use tokens for email verification, magic-link login, and password reset.
 // Stored as a sha256 hash — the raw token is emailed and never persisted. `email` holds
 // the destination address so magic-link signups (user doesn't exist yet) still work.

--- a/packages/server/src/db/spec-260-qa-report-views.test.ts
+++ b/packages/server/src/db/spec-260-qa-report-views.test.ts
@@ -1,0 +1,161 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { and, eq, inArray, sql } from "drizzle-orm";
+import postgres from "postgres";
+import { db } from "./connection.js";
+import { memexes, namespaces, qaReportViews, users } from "./schema.js";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+// spec-260 t-1: the qa_report_views per-user read-state marker (dec-6) — table shape +
+// upsert (ac-21) and the memex_isolation RLS policy (ac-23, the cross-tenant 404
+// guarantee at the DB level, std-7).
+//
+// The RLS half mirrors spec-199-rls-schema.test.ts: the `db` singleton connects as
+// `postgres` (BYPASSRLS), so a second connection AS a NOSUPERUSER/NOBYPASSRLS role is
+// opened to see the policy bite. Per-user scoping (a user only ever touches their OWN
+// marker) is enforced in the service layer, which always operates on the authenticated
+// user's row; RLS here provides the tenant boundary.
+
+const AC_21 = "mindset-prod/memex-building-itself/specs/spec-260/acs/ac-21";
+const AC_23 = "mindset-prod/memex-building-itself/specs/spec-260/acs/ac-23";
+const RLS_ROLE = "qa_report_views_rls_tester";
+const RLS_PASS = "qa_report_views_rls_test_only";
+
+describe("spec-260: qa_report_views marker + RLS isolation", () => {
+  let restrictedSql: postgres.Sql;
+  let memexAId: string;
+  let memexBId: string;
+  let userId: string;
+
+  beforeAll(async () => {
+    await db.execute(sql.raw(`DROP OWNED BY ${RLS_ROLE} CASCADE`)).catch(() => {});
+    await db.execute(sql.raw(`DROP ROLE IF EXISTS ${RLS_ROLE}`));
+    await db.execute(
+      sql.raw(
+        `CREATE ROLE ${RLS_ROLE} LOGIN PASSWORD '${RLS_PASS}'` +
+          ` NOSUPERUSER NOINHERIT NOCREATEDB NOCREATEROLE NOREPLICATION NOBYPASSRLS`,
+      ),
+    );
+    await db.execute(sql.raw(`GRANT USAGE ON SCHEMA public TO ${RLS_ROLE}`));
+    await db.execute(
+      sql.raw(`GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO ${RLS_ROLE}`),
+    );
+    await db.execute(
+      sql.raw(`GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO ${RLS_ROLE}`),
+    );
+
+    // Seed two memexes (distinct tenants) + a user. Superuser path bypasses RLS.
+    const [nsA] = await db
+      .insert(namespaces)
+      .values({ slug: "qrv-test-ns-a", kind: "org" })
+      .returning({ id: namespaces.id });
+    const [nsB] = await db
+      .insert(namespaces)
+      .values({ slug: "qrv-test-ns-b", kind: "org" })
+      .returning({ id: namespaces.id });
+    const [mxA] = await db
+      .insert(memexes)
+      .values({ namespaceId: nsA!.id, slug: "qrv-mx-a", name: "QRV Memex A" })
+      .returning({ id: memexes.id });
+    const [mxB] = await db
+      .insert(memexes)
+      .values({ namespaceId: nsB!.id, slug: "qrv-mx-b", name: "QRV Memex B" })
+      .returning({ id: memexes.id });
+    const [u] = await db
+      .insert(users)
+      .values({ email: "qrv-test-user@example.com" })
+      .returning({ id: users.id });
+
+    memexAId = mxA!.id;
+    memexBId = mxB!.id;
+    userId = u!.id;
+
+    const dbUrl = new URL(
+      process.env.DATABASE_URL ?? "postgresql://postgres:postgres@localhost:5432/memex",
+    );
+    dbUrl.username = RLS_ROLE;
+    dbUrl.password = RLS_PASS;
+    restrictedSql = postgres(dbUrl.toString(), { max: 1 });
+  });
+
+  afterAll(async () => {
+    await restrictedSql?.end({ timeout: 5 });
+    await db.execute(sql.raw(`DROP OWNED BY ${RLS_ROLE} CASCADE`)).catch(() => {});
+    await db.execute(sql.raw(`DROP ROLE IF EXISTS ${RLS_ROLE}`));
+    const memexIds = [memexAId, memexBId].filter(Boolean);
+    if (memexIds.length) {
+      await db.delete(qaReportViews).where(inArray(qaReportViews.memexId, memexIds)).catch(() => {});
+      await db.delete(memexes).where(inArray(memexes.id, memexIds)).catch(() => {});
+    }
+    if (userId) await db.delete(users).where(eq(users.id, userId)).catch(() => {});
+    await db
+      .delete(namespaces)
+      .where(inArray(namespaces.slug, ["qrv-test-ns-a", "qrv-test-ns-b"]))
+      .catch(() => {});
+  });
+
+  it("ac-21: the marker is keyed (user_id, memex_id) and an upsert moves last_viewed_at without adding a row", async () => {
+    tagAc(AC_21);
+
+    const t0 = new Date("2026-01-01T00:00:00.000Z");
+    await db.insert(qaReportViews).values({ userId, memexId: memexAId, lastViewedAt: t0 });
+
+    // Re-viewing upserts onto the composite PK: same (user, memex) → updated timestamp,
+    // still exactly one row (the reset-on-view mechanism the endpoint relies on).
+    const t1 = new Date("2026-02-02T00:00:00.000Z");
+    await db
+      .insert(qaReportViews)
+      .values({ userId, memexId: memexAId, lastViewedAt: t1 })
+      .onConflictDoUpdate({
+        target: [qaReportViews.userId, qaReportViews.memexId],
+        set: { lastViewedAt: t1 },
+      });
+
+    const rows = await db
+      .select()
+      .from(qaReportViews)
+      .where(and(eq(qaReportViews.userId, userId), eq(qaReportViews.memexId, memexAId)));
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.lastViewedAt.toISOString()).toBe(t1.toISOString());
+  });
+
+  it("ac-23: no GUC → restricted role sees 0 marker rows", async () => {
+    tagAc(AC_23);
+
+    const rows = await restrictedSql`SELECT user_id FROM qa_report_views LIMIT 10`;
+    expect(rows).toHaveLength(0);
+  });
+
+  it("ac-23: correct GUC → only the current memex's marker is visible", async () => {
+    tagAc(AC_23);
+
+    // Seed a marker in each memex (superuser bypass), then read as the restricted role.
+    await db
+      .insert(qaReportViews)
+      .values({ userId, memexId: memexBId, lastViewedAt: new Date("2026-03-03T00:00:00.000Z") })
+      .onConflictDoNothing();
+
+    const rows = (await restrictedSql.begin(async (tx) => {
+      await tx.unsafe("SELECT set_config('app.memex_id', $1, true)", [memexAId]);
+      return tx.unsafe("SELECT memex_id::text AS memex_id FROM qa_report_views WHERE TRUE");
+    })) as Array<{ memex_id: string }>;
+
+    expect(rows.length).toBeGreaterThan(0);
+    for (const row of rows) expect(row.memex_id).toBe(memexAId);
+  });
+
+  it("ac-23: cross-tenant INSERT is rejected by WITH CHECK", async () => {
+    tagAc(AC_23);
+
+    // GUC = memexA, but the row names memexB → WITH CHECK violation.
+    await expect(
+      restrictedSql.begin(async (tx) => {
+        await tx.unsafe("SELECT set_config('app.memex_id', $1, true)", [memexAId]);
+        return tx.unsafe(
+          "INSERT INTO qa_report_views (user_id, memex_id, last_viewed_at) VALUES ($1, $2, now())",
+          [userId, memexBId],
+        );
+      }),
+    ).rejects.toThrow();
+  });
+});

--- a/packages/server/src/routes/qa-reports.integration.test.ts
+++ b/packages/server/src/routes/qa-reports.integration.test.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+import { eq, inArray } from "drizzle-orm";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+// Force dev-mode auth so app.request() can hit session-gated routes without
+// minting a JWT (same shape as activity.integration.test.ts).
+vi.hoisted(() => {
+  process.env.GOOGLE_CLIENT_ID = "";
+  return undefined;
+});
+
+import { db } from "../db/connection.js";
+import { docSections, documents, memexes, qaReportViews } from "../db/schema.js";
+import { app } from "../app.js";
+import { createDocDraft } from "../services/documents.js";
+import { appendQaReport } from "../services/qa-reports.js";
+import { makeTestMemexWithDevAdmin } from "../services/test-helpers.js";
+import { upsertUserByEmail } from "../services/users.js";
+
+// spec-260 t-3/t-4 — the QA Reports feed endpoint (dec-5) + unread counter (dec-6).
+//
+// ac-19: cross-Spec listing, newest-first, keyset `since` pagination.
+// ac-22: unread = count of reports newer than the viewer's marker, counting ALL
+//        reports regardless of generator; zero after viewing.
+
+const AC_19 = "mindset-prod/memex-building-itself/specs/spec-260/acs/ac-19";
+const AC_22 = "mindset-prod/memex-building-itself/specs/spec-260/acs/ac-22";
+
+type FeedRow = {
+  id: string;
+  docId: string;
+  docHandle: string;
+  docTitle: string;
+  sectionType: string;
+  version: number;
+  title: string | null;
+  content: string;
+  actorUserId: string | null;
+  actorName: string | null;
+  actorKind: string;
+  channel: string | null;
+  createdAt: string;
+};
+
+const createdDocIds: string[] = [];
+const memexIds: string[] = [];
+
+let memexA: string;
+let pathA: string;
+let memexB: string;
+let pathB: string;
+let devUserId: string;
+
+let specA1: { id: string; handle: string };
+let specA2: { id: string; handle: string };
+
+let r1: string; // oldest — specA1 qa_report
+let r2: string; //          specA2 qa_report
+let r3: string; // newest — specA1 qa_report-2
+let rB: string; // memex B — must never leak into A's feed
+
+function withApexHost(init: RequestInit = {}): RequestInit {
+  return { ...init, headers: { ...(init.headers ?? {}), Host: "memex.ai" } };
+}
+
+// Reports are written through the REAL write path (appendQaReport → addSection →
+// mutate) so the std-32 actor columns and version suffixes are genuine; only the
+// timestamps are then pinned so the ordering/keyset assertions are deterministic.
+async function seedReport(
+  memexId: string,
+  docId: string,
+  content: string,
+  createdAt: Date,
+  actor: { actorUserId?: string; actorName?: string },
+): Promise<string> {
+  const section = await appendQaReport(memexId, docId, content, undefined, {
+    ...actor,
+    channel: "mcp",
+  });
+  await db
+    .update(docSections)
+    .set({ createdAt })
+    .where(eq(docSections.id, section.id));
+  return section.id;
+}
+
+beforeAll(async () => {
+  const a = await makeTestMemexWithDevAdmin("qa-feed-a");
+  memexA = a.memexId;
+  pathA = `/api/${a.slug}/main`;
+  // makeTestMemexWithDevAdmin enrols dev@memex.ai — the user app.request()
+  // authenticates as under dev-mode auth, i.e. the viewer whose marker the
+  // unread tests exercise.
+  devUserId = (await upsertUserByEmail("dev@memex.ai")).id;
+  memexIds.push(a.memexId);
+
+  const b = await makeTestMemexWithDevAdmin("qa-feed-b");
+  memexB = b.memexId;
+  pathB = `/api/${b.slug}/main`;
+  memexIds.push(b.memexId);
+
+  const s1 = await createDocDraft(memexA, "QA Feed Spec One", "Purpose", "spec");
+  const s2 = await createDocDraft(memexA, "QA Feed Spec Two", "Purpose", "spec");
+  const sB = await createDocDraft(memexB, "QA Feed Spec B", "Purpose", "spec");
+  specA1 = { id: s1.id, handle: s1.handle };
+  specA2 = { id: s2.id, handle: s2.handle };
+  createdDocIds.push(s1.id, s2.id, sB.id);
+
+  const actor = { actorUserId: devUserId, actorName: "Dev Admin" };
+  r1 = await seedReport(memexA, specA1.id, "Session 1 on spec one", new Date("2026-01-01T00:00:00Z"), actor);
+  r2 = await seedReport(memexA, specA2.id, "Session 1 on spec two", new Date("2026-01-02T00:00:00Z"), actor);
+  r3 = await seedReport(memexA, specA1.id, "Session 2 on spec one", new Date("2026-01-03T00:00:00Z"), actor);
+  rB = await seedReport(memexB, sB.id, "Report in memex B", new Date("2026-01-04T00:00:00Z"), actor);
+});
+
+afterAll(async () => {
+  if (memexIds.length) {
+    await db.delete(qaReportViews).where(inArray(qaReportViews.memexId, memexIds)).catch(() => {});
+  }
+  for (const id of createdDocIds) {
+    await db.delete(documents).where(eq(documents.id, id)).catch(() => {});
+  }
+  if (memexIds.length) {
+    await db.delete(memexes).where(inArray(memexes.id, memexIds)).catch(() => {});
+  }
+});
+
+describe("GET /api/<ns>/<mx>/qa-reports (workspace feed — dec-5)", () => {
+  it("ac-19: lists qa_report sections across ALL the memex's Specs, newest-first", async () => {
+    tagAc(AC_19);
+
+    const res = await app.request(`${pathA}/qa-reports`, withApexHost());
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as FeedRow[];
+
+    // Cross-Spec: reports from both spec one and spec two, newest first.
+    expect(body.map((r) => r.id)).toEqual([r3, r2, r1]);
+    // Tenant-scoped: memex B's report never appears.
+    expect(body.map((r) => r.id)).not.toContain(rB);
+
+    // Each row carries WHEN / WHICH Spec / WHO (std-32 actor on the row).
+    const top = body[0]!;
+    expect(top.docHandle).toBe(specA1.handle);
+    expect(top.docTitle).toBe("QA Feed Spec One");
+    expect(top.sectionType).toBe("qa_report-2");
+    expect(top.version).toBe(2);
+    expect(top.createdAt).toBe("2026-01-03T00:00:00.000Z");
+    expect(top.actorName).toBe("Dev Admin");
+    expect(top.actorKind).toBe("mcp_agent");
+  });
+
+  it("ac-19: keyset `since` pagination — an initial page plus Load More fetching strictly older rows", async () => {
+    tagAc(AC_19);
+
+    // Initial page of 2 → the newest two.
+    const page1Res = await app.request(`${pathA}/qa-reports?limit=2`, withApexHost());
+    expect(page1Res.status).toBe(200);
+    const page1 = (await page1Res.json()) as FeedRow[];
+    expect(page1.map((r) => r.id)).toEqual([r3, r2]);
+
+    // Load More: since = last row's createdAt → strictly OLDER rows only.
+    const boundary = page1[page1.length - 1]!.createdAt;
+    const page2Res = await app.request(
+      `${pathA}/qa-reports?limit=2&since=${encodeURIComponent(boundary)}`,
+      withApexHost(),
+    );
+    expect(page2Res.status).toBe(200);
+    const page2 = (await page2Res.json()) as FeedRow[];
+    expect(page2.map((r) => r.id)).toEqual([r1]);
+  });
+
+  it("rejects a malformed `since` / `limit` with 400 rather than silently defaulting", async () => {
+    const badSince = await app.request(`${pathA}/qa-reports?since=yesterday`, withApexHost());
+    expect(badSince.status).toBe(400);
+    const badLimit = await app.request(`${pathA}/qa-reports?limit=-3`, withApexHost());
+    expect(badLimit.status).toBe(400);
+  });
+
+  it("cross-tenant access returns 404, not 403 (std-7) for an unknown namespace", async () => {
+    const res = await app.request(
+      "/api/this-namespace-does-not-exist-xyz/main/qa-reports",
+      withApexHost(),
+    );
+    expect(res.status).toBe(404);
+    expect(res.status).not.toBe(403);
+  });
+});
+
+describe("unread counter + view marker (dec-6)", () => {
+  it("ac-22: unread counts ALL reports newer than the marker (no marker → all), and viewing zeroes it", async () => {
+    tagAc(AC_22);
+
+    // Never viewed → every report in the memex counts (3 in memex A).
+    const before = await app.request(`${pathA}/qa-reports/unread`, withApexHost());
+    expect(before.status).toBe(200);
+    expect(await before.json()).toEqual({ count: 3 });
+
+    // Viewing the feed upserts last_viewed_at = now() → badge zeroes.
+    const view = await app.request(`${pathA}/qa-reports/view`, withApexHost({ method: "POST" }));
+    expect(view.status).toBe(200);
+
+    const after = await app.request(`${pathA}/qa-reports/unread`, withApexHost());
+    expect(await after.json()).toEqual({ count: 0 });
+
+    // A NEW report — generated by the viewer's own actor — still counts toward
+    // unread (count-everything semantics: no actor filter, own-agent included).
+    const r4 = await appendQaReport(memexA, specA2.id, "Session 2 on spec two", undefined, {
+      actorUserId: devUserId,
+      actorName: "Dev Admin",
+      channel: "mcp",
+    });
+    expect(r4.sectionType).toBe("qa_report-2");
+
+    const grown = await app.request(`${pathA}/qa-reports/unread`, withApexHost());
+    expect(await grown.json()).toEqual({ count: 1 });
+
+    // Re-viewing resets again (the upsert path, not a second insert).
+    const reView = await app.request(`${pathA}/qa-reports/view`, withApexHost({ method: "POST" }));
+    expect(reView.status).toBe(200);
+    const zeroed = await app.request(`${pathA}/qa-reports/unread`, withApexHost());
+    expect(await zeroed.json()).toEqual({ count: 0 });
+  });
+
+  it("the unread count is per-memex — memex B's reports never bleed into A's badge", async () => {
+    const resB = await app.request(`${pathB}/qa-reports/unread`, withApexHost());
+    expect(resB.status).toBe(200);
+    // Memex B has exactly one report and dev has never viewed B's feed.
+    expect(await resB.json()).toEqual({ count: 1 });
+  });
+});

--- a/packages/server/src/routes/qa-reports.ts
+++ b/packages/server/src/routes/qa-reports.ts
@@ -1,0 +1,102 @@
+import { Hono } from "hono";
+import {
+  countUnreadQaReports,
+  listQaReports,
+  recordQaReportsView,
+} from "../services/qa-reports.js";
+import { NotFoundError, ValidationError } from "../types/errors.js";
+import {
+  sessionMiddleware,
+  publicSessionMiddleware,
+  type SessionEnv,
+} from "../middleware/session.js";
+import type { MemexResolverEnv } from "../middleware/memex-resolver.js";
+import { resolveReadableMemexId } from "./shared.js";
+
+// ── QA Reports feed + unread counter (spec-260 dec-5 / dec-6) ─────────────────
+//
+// GET  /api/<ns>/<mx>/qa-reports          — cross-Spec feed, newest-first, keyset
+//                                           `since` pagination (the Pulse pattern).
+// GET  /api/<ns>/<mx>/qa-reports/unread   — the caller's per-user unread count.
+// POST /api/<ns>/<mx>/qa-reports/view     — record "viewed now": upserts the
+//                                           (user, memex) last_viewed_at marker,
+//                                           zeroing the badge.
+//
+// Tenancy mirrors routes/activity.ts: reads ride the permissive session (public
+// read / private 404 via resolveReadableMemexId, std-7); the mutating view-marker
+// verb stays strict. The per-user marker itself is additionally guarded by the
+// qa_report_views RLS policy (migration 0092).
+
+type Env = MemexResolverEnv & SessionEnv;
+const qaReports = new Hono<Env>();
+
+qaReports.on("GET", "/*", publicSessionMiddleware);
+qaReports.on(["POST", "PUT", "PATCH", "DELETE"], "/*", sessionMiddleware);
+
+// Same shape-validators as routes/activity.ts — present-but-invalid params 400
+// rather than silently defaulting.
+function parsePositiveInt(raw: string | undefined, field: string): number | undefined {
+  if (raw === undefined) return undefined;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || !Number.isInteger(n) || n <= 0) {
+    throw new ValidationError(`Query param '${field}' must be a positive integer`);
+  }
+  return n;
+}
+
+function parseSince(raw: string | undefined): Date | undefined {
+  if (raw === undefined) return undefined;
+  const d = new Date(raw);
+  if (Number.isNaN(d.getTime())) {
+    throw new ValidationError("Query param 'since' must be an ISO-8601 timestamp");
+  }
+  return d;
+}
+
+// GET /api/<ns>/<mx>/qa-reports — the feed.
+//
+// Query params (both optional):
+//   limit — page size (default 50, capped 200 by listQaReports)
+//   since — ISO-8601 keyset boundary; returns rows strictly OLDER ("Load More")
+qaReports.get("/", async (c) => {
+  const memexId = await resolveReadableMemexId(c);
+  const limit = parsePositiveInt(c.req.query("limit"), "limit");
+  const since = parseSince(c.req.query("since"));
+
+  const rows = await listQaReports({ memexId, limit, since });
+
+  // Anonymous / non-member projection (the routes/activity.ts convention):
+  // actor_user_id is PII and actor_name a display identity — both are dropped
+  // on the public-read path; actorKind keeps the row legible.
+  const accessLevel = c.get("currentAccessLevel");
+  if (accessLevel !== "write") {
+    return c.json(
+      rows.map(({ actorUserId: _u, actorName: _n, ...row }) => row),
+    );
+  }
+
+  return c.json(rows);
+});
+
+// GET /api/<ns>/<mx>/qa-reports/unread — the caller's unread count. Per-user by
+// definition, so an anonymous reader has no badge: count 0, not an error.
+qaReports.get("/unread", async (c) => {
+  const memexId = await resolveReadableMemexId(c);
+  const userId = (c.get("currentUserId") as string | null) ?? null;
+  if (!userId) return c.json({ count: 0 });
+  const count = await countUnreadQaReports(memexId, userId);
+  return c.json({ count });
+});
+
+// POST /api/<ns>/<mx>/qa-reports/view — "I viewed the feed now". Strict session
+// (anonymous callers never reach here); the memex must be readable by the caller
+// (std-7 → 404 otherwise).
+qaReports.post("/view", async (c) => {
+  const memexId = await resolveReadableMemexId(c);
+  const userId = (c.get("currentUserId") as string | null) ?? null;
+  if (!userId) throw new NotFoundError("Not found");
+  const lastViewedAt = await recordQaReportsView(memexId, userId);
+  return c.json({ lastViewedAt: lastViewedAt.toISOString() });
+});
+
+export { qaReports };

--- a/packages/server/src/services/bus.ts
+++ b/packages/server/src/services/bus.ts
@@ -74,6 +74,10 @@ export type ChangeEntity =
   | "cli_auth_request"
   | "invite_token"
   | "slack_user_cache"
+  // spec-260 (dec-6): per-user QA-Reports read-state marker (qa_report_views
+  // upsert). Memex-scoped, per-user, silent-allowed per std-8 §6 — viewing a
+  // feed is not collaborative content; the badge zeroes client-locally.
+  | "qa_report_view"
   // OAuth 2.1 token-lifecycle entities (b-31). User/Org-scoped infrastructure
   // with no memexId — silent-allowed per std-8 §6, same as the auth_token group.
   // They flow through mutate({silent:true}) so the Mutated<T> brand and the

--- a/packages/server/src/services/qa-reports.test.ts
+++ b/packages/server/src/services/qa-reports.test.ts
@@ -1,0 +1,101 @@
+// spec-260 t-2: the append-versioned QA report write path (dec-1, dec-2).
+//
+// ac-14: a Spec taken through more than one build session retains each session's
+// report as a distinct, dated version — an earlier session's report remains
+// retrievable after a later one is written (APPEND, not overwrite).
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { and, asc, eq } from "drizzle-orm";
+import { db } from "../db/connection.js";
+import { docSections, documents } from "../db/schema.js";
+import { makeTestMemex } from "./test-helpers.js";
+import { upsertUserByEmail } from "./users.js";
+import { actorCtx } from "./actor.js";
+import {
+  appendQaReport,
+  nextQaReportSectionType,
+  qaReportVersion,
+} from "./qa-reports.js";
+
+const AC_14 = "mindset-prod/memex-building-itself/specs/spec-260/acs/ac-14";
+
+describe("spec-260: append-versioned QA report write path", () => {
+  let memexId: string;
+  let docId: string;
+  let ctx: ReturnType<typeof actorCtx>;
+
+  beforeAll(async () => {
+    memexId = await makeTestMemex("qa");
+    const user = await upsertUserByEmail(`qa-report-${Date.now()}@memex.ai`);
+    ctx = actorCtx(user, "mcp");
+    const [doc] = await db
+      .insert(documents)
+      .values({
+        memexId,
+        handle: `spec-${Date.now().toString(36)}`,
+        title: "QA report append spec",
+        docType: "spec",
+      })
+      .returning();
+    docId = doc!.id;
+  });
+
+  afterAll(async () => {
+    await db.delete(documents).where(eq(documents.id, docId)).catch(() => {});
+  });
+
+  it("computes qa_report for the first session, then qa_report-2, qa_report-3 …", async () => {
+    expect(qaReportVersion("qa_report")).toBe(1);
+    expect(qaReportVersion("qa_report-2")).toBe(2);
+    expect(qaReportVersion("overview")).toBeNull();
+    // Fresh doc → first key is the bare prefix.
+    expect(await nextQaReportSectionType(docId)).toBe("qa_report");
+  });
+
+  it("ac-14: a second build session appends a new version; the first stays retrievable", async () => {
+    tagAc(AC_14);
+
+    const first = await appendQaReport(
+      memexId,
+      docId,
+      "## Front-end\nSession 1 FE changes.\n## Back-end\nSession 1 BE changes.",
+      undefined,
+      ctx,
+    );
+    expect(first.sectionType).toBe("qa_report");
+
+    // A later build session writes again — must NOT overwrite the first.
+    const second = await appendQaReport(
+      memexId,
+      docId,
+      "## Front-end\nSession 2 FE changes.",
+      undefined,
+      ctx,
+    );
+    expect(second.sectionType).toBe("qa_report-2");
+    expect(second.id).not.toBe(first.id);
+
+    // Both rows exist and are independently retrievable; the first session's
+    // content is untouched (append, not overwrite).
+    const rows = await db
+      .select()
+      .from(docSections)
+      .where(and(eq(docSections.docId, docId), eq(docSections.status, "active")))
+      .orderBy(asc(docSections.createdAt), asc(docSections.seq));
+
+    const reports = rows.filter((r) => qaReportVersion(r.sectionType) !== null);
+    expect(reports.map((r) => r.sectionType)).toEqual(["qa_report", "qa_report-2"]);
+
+    const firstRow = reports.find((r) => r.sectionType === "qa_report")!;
+    expect(firstRow.content).toContain("Session 1 FE changes.");
+    expect(firstRow.content).toContain("Session 1 BE changes.");
+
+    // The actor contract (std-32) is stamped — this is the "who executed it" the feed shows.
+    expect(firstRow.actorUserId).toBe(ctx.actorUserId);
+    expect(firstRow.channel).toBe("mcp");
+
+    // A third session continues the sequence.
+    expect(await nextQaReportSectionType(docId)).toBe("qa_report-3");
+  });
+});

--- a/packages/server/src/services/qa-reports.ts
+++ b/packages/server/src/services/qa-reports.ts
@@ -1,0 +1,224 @@
+import { and, desc, eq, gt, lt, ne, sql } from "drizzle-orm";
+import {
+  QA_REPORT_SECTION_PREFIX,
+  isQaReportSectionType,
+  qaReportVersion,
+} from "@memex/shared";
+import { db } from "../db/connection.js";
+import { docSections, documents, qaReportViews } from "../db/schema.js";
+import type { DocSection } from "../db/schema.js";
+import { mutate, type Mutated, type RequestCtx } from "./mutate.js";
+import { addSection } from "./sections.js";
+
+// spec-260 (dec-1, dec-2): a QA report is a read-only `doc_sections` row with
+// section_type='qa_report'. Each build session APPENDS a distinct, dated version
+// rather than overwriting, so history survives build→verify→reopen→build. Because
+// (doc_id, section_type) is unique per doc, each version gets its own key:
+//
+//   qa_report, qa_report-2, qa_report-3, …
+//
+// The latest version is the highest suffix (also the newest created_at). Every row
+// carries its own created_at + std-32 actor, which is what lets the workspace feed
+// (dec-5) list each session as its own entry and the unread counter (dec-6) count
+// per version. The version grammar itself lives in @memex/shared (one source for
+// the server paths and the UI render seats); re-exported here for the existing
+// service-layer call sites.
+export { QA_REPORT_SECTION_PREFIX, isQaReportSectionType, qaReportVersion };
+
+/**
+ * Compute the next qa_report section_type for a doc. We scan ALL existing rows
+ * (including soft-deleted — the (doc_id, section_type) unique constraint is
+ * unconditional, so a reused key would collide even with a deleted row) and pick
+ * one past the highest version present. The first ever report is `qa_report`.
+ */
+export async function nextQaReportSectionType(docId: string): Promise<string> {
+  const rows = await db
+    .select({ sectionType: docSections.sectionType })
+    .from(docSections)
+    .where(eq(docSections.docId, docId));
+
+  let maxVersion = 0;
+  for (const { sectionType } of rows) {
+    const v = qaReportVersion(sectionType);
+    if (v !== null) maxVersion = Math.max(maxVersion, v);
+  }
+
+  const next = maxVersion + 1;
+  return next === 1 ? QA_REPORT_SECTION_PREFIX : `${QA_REPORT_SECTION_PREFIX}-${next}`;
+}
+
+/**
+ * Append a QA report to a Spec as a new versioned `doc_sections` row. The write goes
+ * through addSection → mutate(), so the std-32 actor/channel columns are stamped (the
+ * "who executed it" the feed shows) and the std-8 bus fires (live panels + feed).
+ *
+ * APPEND, never overwrite (ac-14): a second call on the same Spec lands a fresh
+ * section_type (qa_report-2, …); the previous session's row stays retrievable. The
+ * caller never picks the version key — that's computed here so a build agent can't
+ * accidentally clobber a prior session by reusing `qa_report`.
+ */
+export async function appendQaReport(
+  memexId: string,
+  docId: string,
+  content: string,
+  title?: string,
+  ctx: RequestCtx = {},
+): Promise<Mutated<DocSection>> {
+  const sectionType = await nextQaReportSectionType(docId);
+  // addSection re-checks the doc belongs to memexId before mutating (tenancy gate).
+  return addSection(memexId, docId, sectionType, content, title ?? "QA Report", undefined, ctx);
+}
+
+// ── Workspace feed (dec-5) ─────────────────────────────────────────────────────
+//
+// The cross-Spec QA Reports feed: every qa_report* section across the memex's
+// Specs, newest-first, keyset-paginated via `since` (mirroring listActivity /
+// the Pulse "Load More" pattern). Each row carries its own created_at (WHEN),
+// the parent Spec's handle + title (WHICH), and the std-32 actor columns (WHO).
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 200;
+
+// SQL predicate matching exactly the version keys appendQaReport mints:
+// `qa_report` or `qa_report-N`. A plain LIKE 'qa_report%' would also match
+// unrelated keys like 'qa_report_notes', so the suffix is anchored.
+const qaReportSectionPredicate = () =>
+  sql`(${docSections.sectionType} = 'qa_report' OR ${docSections.sectionType} ~ '^qa_report-[0-9]+$')`;
+
+// doc_sections carries the std-32 channel; actor_kind is derived from it the
+// same way the activity-log sink derives it (services/activity-log.ts).
+const CHANNEL_TO_ACTOR_KIND: Record<string, QaReportFeedRow["actorKind"]> = {
+  rest_ui: "human",
+  mcp: "mcp_agent",
+  in_app_agent: "in_app_agent",
+  server: "system",
+};
+
+export interface QaReportFeedRow {
+  /** The qa_report doc_sections row id. */
+  id: string;
+  docId: string;
+  /** Parent Spec handle (`spec-N`) + title, for the WHICH-Spec column + link. */
+  docHandle: string;
+  docTitle: string;
+  /** `qa_report` / `qa_report-2` / … — encodes the build-session version. */
+  sectionType: string;
+  version: number;
+  title: string | null;
+  content: string;
+  /** std-32 WHO columns, stamped at write time. */
+  actorUserId: string | null;
+  actorName: string | null;
+  actorKind: "human" | "mcp_agent" | "in_app_agent" | "system";
+  channel: string | null;
+  createdAt: Date;
+}
+
+export interface ListQaReportsOptions {
+  memexId: string;
+  /** Page size — default 50, capped at 200 (the listActivity convention). */
+  limit?: number;
+  /** Keyset boundary: return rows strictly OLDER than this timestamp. */
+  since?: Date;
+}
+
+export async function listQaReports(opts: ListQaReportsOptions): Promise<QaReportFeedRow[]> {
+  const limit = Math.max(1, Math.min(MAX_LIMIT, Math.floor(opts.limit ?? DEFAULT_LIMIT)));
+
+  const conditions = [
+    eq(documents.memexId, opts.memexId),
+    // QA reports attach to Specs only (the write path enforces it); demo Specs
+    // are excluded from the feed like they are from the Pulse timeline.
+    eq(documents.docType, "spec"),
+    ne(documents.isDemo, true),
+    ne(docSections.status, "deleted"),
+    qaReportSectionPredicate(),
+  ];
+  if (opts.since !== undefined) conditions.push(lt(docSections.createdAt, opts.since));
+
+  const rows = await db
+    .select({
+      id: docSections.id,
+      docId: docSections.docId,
+      docHandle: documents.handle,
+      docTitle: documents.title,
+      sectionType: docSections.sectionType,
+      title: docSections.title,
+      content: docSections.content,
+      actorUserId: docSections.actorUserId,
+      actorName: docSections.actorName,
+      channel: docSections.channel,
+      createdAt: docSections.createdAt,
+    })
+    .from(docSections)
+    .innerJoin(documents, eq(docSections.docId, documents.id))
+    .where(and(...conditions))
+    // Newest-first with a deterministic tiebreaker (the listActivity convention).
+    .orderBy(desc(docSections.createdAt), desc(docSections.id))
+    .limit(limit);
+
+  return rows.map((row) => ({
+    ...row,
+    version: qaReportVersion(row.sectionType) ?? 1,
+    actorKind: CHANNEL_TO_ACTOR_KIND[row.channel ?? "server"] ?? "system",
+  }));
+}
+
+// ── Per-user unread counter (dec-6) ────────────────────────────────────────────
+//
+// Unread = the number of qa_report* rows in the memex created after the viewer's
+// last_viewed_at marker. Count-everything semantics: NO actor filter — the
+// viewer's own-agent reports count too (actor is display-only). A missing marker
+// means the user has never viewed the feed, so every report counts.
+
+export async function countUnreadQaReports(memexId: string, userId: string): Promise<number> {
+  const [marker] = await db
+    .select({ lastViewedAt: qaReportViews.lastViewedAt })
+    .from(qaReportViews)
+    .where(and(eq(qaReportViews.userId, userId), eq(qaReportViews.memexId, memexId)));
+
+  const conditions = [
+    eq(documents.memexId, memexId),
+    eq(documents.docType, "spec"),
+    ne(documents.isDemo, true),
+    ne(docSections.status, "deleted"),
+    qaReportSectionPredicate(),
+  ];
+  if (marker) conditions.push(gt(docSections.createdAt, marker.lastViewedAt));
+
+  const [row] = await db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(docSections)
+    .innerJoin(documents, eq(docSections.docId, documents.id))
+    .where(and(...conditions));
+
+  return row?.count ?? 0;
+}
+
+/**
+ * Record that `userId` viewed the memex's QA Reports feed NOW — upserts the
+ * (user, memex) marker, zeroing the unread badge. Returns the new marker time.
+ *
+ * Goes through mutate() per std-8, but SILENT: the marker is per-user
+ * read-state (an idempotent re-write of "when did I last look"), not
+ * collaborative content — broadcasting every view would be bus noise, and the
+ * badge's own zeroing is client-local (the page that posted the view already
+ * knows). std-32's activity columns don't apply to this table by design.
+ */
+export async function recordQaReportsView(memexId: string, userId: string): Promise<Date> {
+  const now = new Date();
+  await mutate(
+    {},
+    { memexId, entity: "qa_report_view", action: "updated" },
+    async () =>
+      db
+        .insert(qaReportViews)
+        .values({ userId, memexId, lastViewedAt: now })
+        .onConflictDoUpdate({
+          target: [qaReportViews.userId, qaReportViews.memexId],
+          set: { lastViewedAt: now },
+        }),
+    { silent: true },
+  );
+  return now;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -138,3 +138,11 @@ export {
   sanitizeUsageProps,
 } from './usage-events-registry.js';
 export type { UsageEventDef, UsageEventSource, RegisteredEventName } from './usage-events-registry.js';
+
+// spec-260: the QA-report section-type vocabulary (qa_report / qa_report-N) —
+// one grammar shared by the server write/read paths and the UI render seats.
+export {
+  QA_REPORT_SECTION_PREFIX,
+  isQaReportSectionType,
+  qaReportVersion,
+} from './qa-report.js';

--- a/packages/shared/src/qa-report.ts
+++ b/packages/shared/src/qa-report.ts
@@ -1,0 +1,27 @@
+// spec-260 (dec-1, dec-2): the QA-report section-type vocabulary, shared by the
+// server write/read paths and the React UI render seats so the version grammar
+// has exactly one source.
+//
+// A QA report is a `doc_sections` row whose section_type is `qa_report` (the
+// first build session) or `qa_report-N` (session N) — the per-doc-unique
+// section_type constraint is what makes each session's report a distinct,
+// dated, attributed row.
+
+export const QA_REPORT_SECTION_PREFIX = 'qa_report';
+
+// Matches qa_report (version 1) and qa_report-N (version N) — nothing else.
+// Deliberately anchored: a LIKE-style prefix match would also catch unrelated
+// keys such as `qa_report_notes`.
+const QA_REPORT_SECTION_RE = /^qa_report(?:-(\d+))?$/;
+
+/** True if a section_type names a QA report row (any version). */
+export function isQaReportSectionType(sectionType: string): boolean {
+  return QA_REPORT_SECTION_RE.test(sectionType);
+}
+
+/** The 1-based build-session version a qa_report section_type encodes, or null. */
+export function qaReportVersion(sectionType: string): number | null {
+  const m = QA_REPORT_SECTION_RE.exec(sectionType);
+  if (!m) return null;
+  return m[1] === undefined ? 1 : Number(m[1]);
+}

--- a/packages/shared/src/scaffold-data.spec-260-qa-report.test.ts
+++ b/packages/shared/src/scaffold-data.spec-260-qa-report.test.ts
@@ -1,0 +1,95 @@
+// spec-260 t-5 — the QA-report generation instruction in the build handoff.
+//
+// The build agent's STEP-5 closing summary used to evaporate into chat; spec-260
+// persists it as a versioned `qa_report` section written at the build→verify
+// hand-off (dec-2), grounded in the session's real changes (dec-3). These tests
+// pin the prompt contract:
+//
+//   ac-13 — the hand-off prompt itself instructs the agent to write the report as
+//           part of build completion (not a separate manual action).
+//   ac-15 — the generation prompt REQUIRES grounding: FE/BE sections in the
+//           session's actual code changes, the testing section in the tests run +
+//           test_events emitted, cross-referenced to ACs.
+//   ac-16 — the generation prompt is VCS-agnostic per std-22: no version-control
+//           literal; it says "the changes you made this session".
+//
+// House style: dependency-free assertions over the scaffold dataset.
+
+import { describe, expect, it } from 'vitest';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { BASE_SCAFFOLD, QA_REPORT_GENERATION_INSTRUCTION } from './scaffold-data.js';
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-260/acs/ac-${n}`;
+
+const handoff = BASE_SCAFFOLD.promptButtons.find((b) => b.id === 'opening-build-handoff');
+
+describe('spec-260: QA-report generation instruction (build handoff STEP 6)', () => {
+  it('ac-13: the build hand-off prompt instructs persisting the QA report as part of build completion', () => {
+    tagAc(AC(13));
+    expect(handoff, 'opening-build-handoff node must exist').toBeDefined();
+    // The generation instruction ships inside the hand-off prompt itself…
+    expect(handoff!.text).toContain('persist the QA Report');
+    expect(handoff!.text).toContain(QA_REPORT_GENERATION_INSTRUCTION);
+    // …as part of completing build, not a separate manual action.
+    expect(QA_REPORT_GENERATION_INSTRUCTION).toContain('write_qa_report');
+    expect(QA_REPORT_GENERATION_INSTRUCTION).toContain(
+      'IS part of completing build, not a separate request',
+    );
+    // The chat-driven agent path (the essence footer) carries the same directive.
+    expect(handoff!.essence).toContain('write_qa_report');
+  });
+
+  it('ac-13: each session appends a distinct version — the prompt forbids overwriting prior reports', () => {
+    tagAc(AC(13));
+    expect(QA_REPORT_GENERATION_INSTRUCTION).toContain('appended as a new dated version');
+    expect(QA_REPORT_GENERATION_INSTRUCTION).toContain('never overwrites');
+  });
+
+  it('ac-15: grounding is mandatory — FE/BE from the session\'s actual changes, testing from tests run + emitted test events, cross-referenced to ACs', () => {
+    tagAc(AC(15));
+    expect(QA_REPORT_GENERATION_INSTRUCTION).toContain('GROUNDING IS MANDATORY');
+    // FE/BE sections grounded in the session's actual changes…
+    expect(QA_REPORT_GENERATION_INSTRUCTION).toContain(
+      'base sections 1–2 on the changes you made this session',
+    );
+    // …and the testing section in what actually ran + what was emitted, tied to ACs.
+    expect(QA_REPORT_GENERATION_INSTRUCTION).toContain('tests you actually ran');
+    expect(QA_REPORT_GENERATION_INSTRUCTION).toContain('test events you emitted');
+    expect(QA_REPORT_GENERATION_INSTRUCTION).toContain(
+      'cross-referenced to their acceptance criteria',
+    );
+    // A report is a record of the session, never a re-statement of the plan.
+    expect(QA_REPORT_GENERATION_INSTRUCTION).toContain('never a restatement of the plan');
+  });
+
+  it('ac-15: the report structure covers all eight reviewer-facing parts', () => {
+    tagAc(AC(15));
+    for (const part of [
+      'Front-end / user-affecting changes',
+      'Back-end changes',
+      'Testing created and run',
+      'Known gaps & follow-ups',
+      'Deviations from the plan',
+      'Dependencies & integration points',
+      'Migration / deployment notes',
+      'Open questions',
+    ]) {
+      expect(QA_REPORT_GENERATION_INSTRUCTION, `missing report part: ${part}`).toContain(part);
+    }
+    // Gaps/follow-ups ride register_issue todos so an incomplete build is never
+    // read as complete (dec-3: issues, not the legacy question comment type).
+    expect(QA_REPORT_GENERATION_INSTRUCTION).toContain("register_issue({ type: 'todo' })");
+  });
+
+  it('ac-16: the generation prompt is VCS-agnostic per std-22 — no version-control literal, "the changes you made this session"', () => {
+    tagAc(AC(16));
+    // No version-control-specific literal anywhere in the generation prompt.
+    expect(QA_REPORT_GENERATION_INSTRUCTION).not.toMatch(/\bgit\b/i);
+    expect(QA_REPORT_GENERATION_INSTRUCTION).not.toMatch(/\bgit diff\b/i);
+    expect(QA_REPORT_GENERATION_INSTRUCTION).not.toMatch(/\b(svn|mercurial|version control)\b/i);
+    expect(QA_REPORT_GENERATION_INSTRUCTION).not.toMatch(/\bcommit(s|ted)?\b/i);
+    expect(QA_REPORT_GENERATION_INSTRUCTION).not.toMatch(/\bworking[- ]tree\b/i);
+    // The portable phrasing dec-3 mandates.
+    expect(QA_REPORT_GENERATION_INSTRUCTION).toContain('the changes you made this session');
+  });
+});

--- a/packages/shared/src/scaffold-data.ts
+++ b/packages/shared/src/scaffold-data.ts
@@ -768,6 +768,8 @@ const TOOL_RATIONALES: Record<string, string> = {
     'The omnibus task mutator: status, title, description, acceptanceCriteria, sectionRef, add/removeBlockerRef. One field or several per call.',
   delete_task:
     'Hard-delete a task. Cascades blockers and dependencies; prefer marking out-of-scope where the work was considered but dropped.',
+  write_qa_report:
+    "Persist the build→verify hand-off summary as a durable QA Report section on the Spec, instead of letting it evaporate into chat. Reviewer-facing, grounded in the session's real changes, appended as a new dated version each build session (spec-260).",
   flag_drift:
     "Flag drift on a standard section: post a typed `drift` comment (sourced 'agent') when the rule is right but the codebase has diverged from it. Surfaces in the Drift Inbox; use propose_standard_change instead when the rule itself is wrong.",
   propose_standard_change:
@@ -1631,6 +1633,27 @@ const TRANSITIONS: TransitionRubric[] = [
 // (dec-4: v1 reuses today's behaviours unchanged; spec-123 ac-11). Single-source
 // per std-15/std-16 — the inline component constants are now redundant copies of
 // these nodes.
+
+// spec-260 (dec-2, dec-3): the QA-report generation instruction — STEP 6 of the
+// build handoff. Persists the STEP-5 closing summary as a durable, versioned
+// `qa_report` section via write_qa_report instead of letting it evaporate into
+// chat. Exported so the spec-260 prompt tests can assert its contract directly:
+// it REQUIRES grounding in the session's actual changes + tests/test-events
+// (ac-15), and per std-22 it is VCS-agnostic — "the changes you made this
+// session", never a version-control-specific literal (ac-16). (The capability-
+// gated worktree mention in STEP 4 predates this and is std-22-compliant; this
+// constant is the QA-report generation prompt ac-16 scopes.)
+export const QA_REPORT_GENERATION_INSTRUCTION = `Persist that closing summary as the Spec's QA Report — call write_qa_report({ ref: '{namespace}/{memex}/specs/{handle}', content }) before you finish. Generating the report IS part of completing build, not a separate request: it is the record the verifier starts from, and it must survive this chat. Write it for a reviewer who was NOT in this session and may not read code — including a non-developer owner — and organise it as:
+  1. Front-end / user-affecting changes — what a user would now see or do differently (screens, flows, copy, interactions, states), in plain language a non-developer can speak to.
+  2. Back-end changes — routes, schema/migrations, services, data shape, auth/tenancy, agent behaviour, and anything with operational or security implications.
+  3. Testing created and run — which tests you added or changed, which suites you executed, what passed, and honestly what was skipped or left failing; tie back to the Spec's acceptance criteria where relevant.
+  4. Known gaps & follow-ups — what this session deliberately skipped or left incomplete; capture each as register_issue({ type: 'todo' }) and reference those issues from the report, so an incomplete build is never read as complete.
+  5. Deviations from the plan — where the implementation diverged from the Spec's sections or resolved decisions ("we resolved X for approach Y but ended up implementing Z").
+  6. Dependencies & integration points — new or changed packages, services, or external APIs, and any cross-spec / cross-system integration with coordination or breaking-change implications.
+  7. Migration / deployment notes — schema migrations to run, flags to toggle, manual steps, data backfills: the operational actions required to deploy this work safely (name THAT a step is needed; never embed secrets).
+  8. Open questions — knowledge gaps surfaced during build that the verifier should know about, captured as agent-sourced issues and referenced here.
+GROUNDING IS MANDATORY: base sections 1–2 on the changes you made this session — the actual files and behaviour you touched, re-read rather than recalled — and section 3 on the tests you actually ran and the test events you emitted, cross-referenced to their acceptance criteria. The report records what THIS session actually changed, never a restatement of the plan; where reality diverged from the plan, the report says so. Each build session's report is appended as a new dated version — write_qa_report never overwrites a prior session's record.`;
+
 const OPENING_TURN_PROMPT_BUTTONS: PromptButtonNode[] = [
   {
     kind: 'prompt_button',
@@ -1739,16 +1762,19 @@ PARALLELISE ONLY WHEN IT PAYS. If you can spawn sub-agents / run workflows AND t
   • Verify each AC in the shape of its claim: a mechanism AC via its tagged test; an outcome / scope AC via the broadest honest verification available (integration / e2e, or a real-use exercise for non-code artifacts). If an AC genuinely can't be pinned to an automated check, recommend \`verify\` with it flagged for manual sign-off rather than flipping its badge with a thin test.
   • Run assess_spec({ ref: '...', mode: 'phase', target: 'verify' }) and walk its fact sheet.
   • If everything is green or consciously signed off, recommend moving to \`verify\` — you do NOT move it, and you never move to \`done\`; both are the human's call. If anything is unverified, leave those tasks open and report exactly what remains and why.
-Finish with a summary: per-task outcome, AC verification state, any new decisions you surfaced, and any standards drift or decision-vs-code mismatches you found.`,
+Finish with a summary: per-task outcome, AC verification state, any new decisions you surfaced, and any standards drift or decision-vs-code mismatches you found.
+
+── STEP 6: persist the QA Report — the hand-off artifact ──
+${QA_REPORT_GENERATION_INSTRUCTION}`,
     surfaces: ['opening-turn'],
     // spec-203 dec-1: the compressed footer projection of this build handoff —
     // the in-chat essence a chat-driven agent gets on every spec-tool response.
     // spec-219 comb-through: de-jargoned + active. Orients the agent to the build
     // phase (its main home is now the doc_transition footer, on entry); the agent
     // MOVES the spec forward (update_doc), it doesn't just recommend. Token-free.
-    essence: `You are now in build. This is the phase where the actual creation happens: tasks get created and code gets written. The plan is settled, so build it end to end, don't sketch it. Starting with no tasks and untested acceptance criteria is normal; your job here is to break the work into tasks drawn from the narrative (create_task). When the plan names a specific function, file, or endpoint, check it still exists by that name in the current code before you touch it; if it has been renamed or moved, flag the mismatch rather than silently working on whatever is there now, because it means the plan and the code have drifted apart. Verify each task the way its claim demands: for behaviour, write the test first (watch it fail, then pass) and tag it to its acceptance criterion; for prose or config, exercise the actual artifact. Mark a task complete only when its verification actually ran clean. When every task is green (or consciously signed off), move the spec on with update_doc({status:'verify'}); don't jump to done, that's the user's call. Hit a fork the plan didn't settle? Raise it with create_decision rather than inventing the answer.`,
+    essence: `You are now in build. This is the phase where the actual creation happens: tasks get created and code gets written. The plan is settled, so build it end to end, don't sketch it. Starting with no tasks and untested acceptance criteria is normal; your job here is to break the work into tasks drawn from the narrative (create_task). When the plan names a specific function, file, or endpoint, check it still exists by that name in the current code before you touch it; if it has been renamed or moved, flag the mismatch rather than silently working on whatever is there now, because it means the plan and the code have drifted apart. Verify each task the way its claim demands: for behaviour, write the test first (watch it fail, then pass) and tag it to its acceptance criterion; for prose or config, exercise the actual artifact. Mark a task complete only when its verification actually ran clean. Before you hand off, persist your closing summary as the Spec's QA Report (write_qa_report) — what this session actually changed (front-end in plain language, back-end, testing run, gaps, deviations, deploy notes), grounded in the changes you made this session, written for a reviewer who wasn't here; each session appends a new version. When every task is green (or consciously signed off), move the spec on with update_doc({status:'verify'}); don't jump to done, that's the user's call. Hit a fork the plan didn't settle? Raise it with create_decision rather than inventing the answer.`,
     rationale:
-      'Hand a build-phase Spec to a coding agent to build it end-to-end: ground the resolved decisions against current source, derive the task graph from the narrative, implement and verify in the shape of each task, and recommend `verify` (never close — that is the human\'s call). Portable per std-22 — every tooling-specific step gated on "if the project has it". Authored and hardened via spec-149 across four read-only dry-runs. Rendered as the build "Build handoff" action on the opening turn.',
+      'Hand a build-phase Spec to a coding agent to build it end-to-end: ground the resolved decisions against current source, derive the task graph from the narrative, implement and verify in the shape of each task, persist the closing summary as the Spec\'s QA Report (write_qa_report, spec-260 — versioned per session, grounded in the session\'s real changes), and recommend `verify` (never close — that is the human\'s call). Portable per std-22 — every tooling-specific step gated on "if the project has it"; the QA-report instruction is VCS-agnostic ("the changes you made this session"). Authored and hardened via spec-149 across four read-only dry-runs; STEP 6 added by spec-260. Rendered as the build "Build handoff" action on the opening turn.',
   },
   {
     kind: 'prompt_button',

--- a/packages/shared/src/tool-manifest.ts
+++ b/packages/shared/src/tool-manifest.ts
@@ -327,6 +327,15 @@ export const toolManifest: ToolManifestEntry[] = [
     readOnlyHint: false,
     trafficClass: 'build',
   },
+  {
+    name: 'write_qa_report',
+    summary:
+      'Persist a QA Report on a Spec at the build→verify hand-off — a reviewer-facing record of what this build session changed (front-end, back-end, testing, gaps, deviations, deploy notes). Appends a new dated version; never overwrites.',
+    args: 'write_qa_report(ref, content, title?)',
+    group: 'build',
+    readOnlyHint: false,
+    trafficClass: null,
+  },
 
   // ── Standards protocol (build) ────────────────────────────
   // Restored by spec-143 dec-1 (the half of spec-63 dec-6 that was blocked on
@@ -477,7 +486,7 @@ export const toolManifest: ToolManifestEntry[] = [
     // up emission, it does not itself drive a Spec phase transition.
     name: 'provision_ac_emission',
     summary:
-      "Provision AC emission for the Spec you're working on, in one call: mints an ephemeral, spec-scoped emission key (use this session only, never persist it) AND returns the guidance to wire emission into whatever test runners the repo uses — native when no helper exists. No Settings detour, no install. CI keys are still human-minted.",
+      "Provision AC emission for this Spec in one call: mints an ephemeral, spec-scoped emission key (session-only, never persist) and returns the wiring guidance for the repo's test runners. No Settings detour; CI keys stay human-minted.",
     args: 'provision_ac_emission(ref)',
     group: 'build',
     readOnlyHint: false,

--- a/packages/ui/e2e/journey-29-spec-260-qa-reports.spec.ts
+++ b/packages/ui/e2e/journey-29-spec-260-qa-reports.spec.ts
@@ -1,0 +1,218 @@
+import { test, expect, tenantPath, emitAcEvents } from "./helpers/index.js";
+import {
+  seedOrgTenant,
+  seedSpec,
+  seedSection,
+  setDocStatus,
+} from "./helpers/retained.js";
+
+// Journey 29 — spec-260: the Build QA Report, end to end [per std-28].
+//
+// Two user-facing flows:
+//   1. The per-Spec artifact: a Spec carrying qa_report sections shows the
+//      report front-loaded as a collapsible card in Verify, as a secondary
+//      "QA Report" sub-tab in Build (default stays Tasks & Issues; quiet empty
+//      state before the first hand-off), behind a gated button on the Done
+//      screen — and never as plan prose in the Specify Narrative. Multiple
+//      build sessions stay legible through the version switcher (ac-4, ac-7).
+//   2. The workspace feed: the QA Reports nav page lists reports across Specs
+//      newest-first with WHEN / WHICH-Spec / WHO per row, and the nav item
+//      carries a per-user unread badge that zeroes on viewing (ac-8, ac-9,
+//      ac-10).
+//
+// Seeding rides the env-gated /api/__test__ surface (no raw SQL); navigation is
+// path-based [per std-2]. The qa_report sections are seeded through the REAL
+// addSection service — the same write path the agent's write_qa_report tool
+// appends through.
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-260/acs/ac-${n}`;
+
+// Per-test AC tagging, emitted pass AND fail in afterEach per the ac-emission
+// discipline (helpers/emit-ac.ts routes by the ref's namespace).
+const ACS_BY_TITLE: Record<string, string[]> = {
+  "per-Spec seats: Build sub-tab, Verify card + versions, Done button, not in Narrative": [
+    AC(4),
+    AC(7),
+  ],
+  "workspace feed: newest-first rows with when/which/who, unread badge zeroes on view": [
+    AC(8),
+    AC(9),
+    AC(10),
+  ],
+};
+
+test.afterEach(async ({}, testInfo) => {
+  if (testInfo.status === "skipped") return;
+  const refs = ACS_BY_TITLE[testInfo.title];
+  if (!refs) return;
+  await emitAcEvents(
+    refs,
+    testInfo.status === "passed" ? "pass" : "fail",
+    `packages/ui/e2e/journey-29-spec-260-qa-reports.spec.ts::${testInfo.title}`,
+    testInfo.duration,
+  );
+});
+
+const SESSION_ONE = "Front-end: session ONE user-visible changes.";
+const SESSION_TWO = "Front-end: session TWO user-visible changes.";
+
+test.describe("spec-260 — Build QA Report", () => {
+  test("per-Spec seats: Build sub-tab, Verify card + versions, Done button, not in Narrative", async ({
+    page,
+    resources,
+  }) => {
+    const slug = resources.slug("j29a");
+    const tenant = await seedOrgTenant({ slug });
+    const { docId } = await seedSpec({
+      memexId: tenant.memexId,
+      title: "QA Report Seats Spec",
+      purpose: "Spec exercising the QA report render seats.",
+    });
+
+    // ── Build, BEFORE any hand-off: the QA Report sub-tab exists with a quiet
+    // empty state; Tasks & Issues stays the default view. ──
+    await setDocStatus({ memexId: tenant.memexId, docId, status: "build" });
+    await page.goto(tenantPath(tenant.namespaceSlug, tenant.memexSlug, `/docs/${docId}`));
+    await expect(
+      page.getByRole("heading", { name: "QA Report Seats Spec", level: 1 }),
+    ).toBeVisible({ timeout: 15_000 });
+
+    // Default tab: the working two-column (Tasks panel present).
+    await expect(page.getByText("Tasks & Issues")).toBeVisible();
+    await page.getByText("QA Report", { exact: true }).click();
+    await expect(page.getByTestId("qa-report-empty")).toContainText(
+      "No QA report yet — generated when build hands off to verify",
+    );
+
+    // ── Two build sessions write their reports (the write path appendQaReport
+    // rides — version keys qa_report, then qa_report-2). ──
+    await seedSection({
+      memexId: tenant.memexId,
+      docId,
+      title: "QA Report",
+      content: SESSION_ONE,
+      sectionType: "qa_report",
+    });
+    await seedSection({
+      memexId: tenant.memexId,
+      docId,
+      title: "QA Report",
+      content: SESSION_TWO,
+      sectionType: "qa_report-2",
+    });
+
+    // ── Verify: the card is front-loaded above the ACs│Issues columns, shows
+    // the LATEST session, collapses, and prior sessions stay reachable. ──
+    await setDocStatus({ memexId: tenant.memexId, docId, status: "verify" });
+    await page.goto(tenantPath(tenant.namespaceSlug, tenant.memexSlug, `/docs/${docId}`));
+    const card = page.getByTestId("qa-report-card");
+    await expect(card).toBeVisible({ timeout: 15_000 });
+    await expect(card.getByTestId("qa-report-content")).toContainText(SESSION_TWO);
+
+    // History stays legible (ac-7): switch to the earlier session.
+    await card.getByTestId("qa-report-version-switcher").selectOption({ index: 1 });
+    await expect(card.getByTestId("qa-report-content")).toContainText(SESSION_ONE);
+
+    // Collapsible: folds away once read.
+    await card.getByTestId("qa-report-toggle").click();
+    await expect(page.getByTestId("qa-report-content")).toHaveCount(0);
+
+    // ── Specify: the report is NOT plan prose — the Narrative sub-tab never
+    // renders it. ──
+    await setDocStatus({ memexId: tenant.memexId, docId, status: "specify" });
+    await page.goto(tenantPath(tenant.namespaceSlug, tenant.memexSlug, `/docs/${docId}`));
+    await expect(page.getByText("Narrative")).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByText(SESSION_TWO)).toHaveCount(0);
+    await expect(page.getByText(SESSION_ONE)).toHaveCount(0);
+
+    // ── Done: the report sits behind a gated button (the "read spec" pattern)
+    // and the spec read view excludes it. ──
+    await setDocStatus({ memexId: tenant.memexId, docId, status: "done" });
+    await page.goto(tenantPath(tenant.namespaceSlug, tenant.memexSlug, `/docs/${docId}`));
+    const qaButton = page.getByTestId("done-qa-report");
+    await expect(qaButton).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByTestId("done-qa-report-body")).toHaveCount(0);
+    await qaButton.click();
+    await expect(page.getByTestId("done-qa-report-body")).toContainText(SESSION_TWO);
+  });
+
+  test("workspace feed: newest-first rows with when/which/who, unread badge zeroes on view", async ({
+    page,
+    resources,
+  }) => {
+    const slug = resources.slug("j29b");
+    const tenant = await seedOrgTenant({ slug });
+
+    const specA = await seedSpec({
+      memexId: tenant.memexId,
+      title: "Feed Spec Alpha",
+      purpose: "First spec with a QA report.",
+    });
+    const specB = await seedSpec({
+      memexId: tenant.memexId,
+      title: "Feed Spec Beta",
+      purpose: "Second spec with a QA report.",
+    });
+
+    // Sequential seeds → distinct created_at → deterministic newest-first.
+    await seedSection({
+      memexId: tenant.memexId,
+      docId: specA.docId,
+      title: "QA Report",
+      content: "Alpha build session report.",
+      sectionType: "qa_report",
+    });
+    await seedSection({
+      memexId: tenant.memexId,
+      docId: specB.docId,
+      title: "QA Report",
+      content: "Beta build session report.",
+      sectionType: "qa_report",
+    });
+
+    // ── The nav item carries the per-user unread badge (never viewed → 2). ──
+    await page.goto(tenantPath(tenant.namespaceSlug, tenant.memexSlug, "/specs"));
+    const badge = page.getByTestId("qa-reports-nav-badge");
+    await expect(badge).toHaveText("2", { timeout: 15_000 });
+
+    // ── Open the feed: newest-first, when / which-Spec / who per row. ──
+    await page.getByRole("link", { name: "QA Reports" }).click();
+    await expect(page).toHaveURL(/\/qa-reports$/);
+    const rows = page.getByTestId("qa-report-row");
+    await expect(rows).toHaveCount(2, { timeout: 15_000 });
+
+    // Newest-first: Beta (seeded second) leads.
+    await expect(rows.nth(0).getByTestId("qa-report-row-spec")).toContainText("Feed Spec Beta");
+    await expect(rows.nth(1).getByTestId("qa-report-row-spec")).toContainText("Feed Spec Alpha");
+
+    // WHEN + WHO render on every row; WHICH links to the parent Spec.
+    await expect(rows.nth(0).getByTestId("qa-report-row-when")).not.toBeEmpty();
+    await expect(rows.nth(0).getByTestId("qa-report-row-who")).not.toBeEmpty();
+    await expect(rows.nth(0).getByTestId("qa-report-row-spec")).toHaveAttribute(
+      "href",
+      new RegExp(`/specs/${specB.handle}$`),
+    );
+
+    // The report body opens on demand.
+    await rows.nth(0).getByTestId("qa-report-row-toggle").click();
+    await expect(rows.nth(0).getByTestId("qa-report-row-body")).toContainText(
+      "Beta build session report.",
+    );
+
+    // ── Viewing the feed zeroed the badge (count-everything → 0 after view). ──
+    await page.goto(tenantPath(tenant.namespaceSlug, tenant.memexSlug, "/specs"));
+    await expect(page.getByRole("link", { name: "QA Reports" })).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByTestId("qa-reports-nav-badge")).toHaveCount(0);
+
+    // A THIRD report lands (a new build session elsewhere) → the badge returns.
+    await seedSection({
+      memexId: tenant.memexId,
+      docId: specA.docId,
+      title: "QA Report",
+      content: "Alpha session two report.",
+      sectionType: "qa_report-2",
+    });
+    await page.goto(tenantPath(tenant.namespaceSlug, tenant.memexSlug, "/specs"));
+    await expect(page.getByTestId("qa-reports-nav-badge")).toHaveText("1", { timeout: 15_000 });
+  });
+});

--- a/packages/ui/src/App.spec-260.test.tsx
+++ b/packages/ui/src/App.spec-260.test.tsx
@@ -1,0 +1,125 @@
+// spec-260 t-7 — the /qa-reports route gate (ac-18), mirroring the spec-146
+// Option-B mechanism: the route is registered only when 'qa-reports' is absent
+// from the session's hiddenFeatures; hidden → the path falls through to the
+// catch-all RootRedirect. (The nav-link half of the gate is the same
+// PRIMARY_NAV_LINKS `feature` filter Pulse/Insights use.)
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom';
+import { tagAc } from '@memex-ai-ac/vitest';
+import type { ReactNode } from 'react';
+import type { SessionPayload } from './api/client';
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-260/acs/ac-${n}`;
+
+let mockSession: SessionPayload;
+function makeSession(hiddenFeatures: string[]): SessionPayload {
+  return {
+    user: {
+      id: 'u-1',
+      email: 'alice@example.com',
+      name: 'Alice',
+      status: 'active',
+      emailVerified: true,
+    },
+    memberships: [
+      {
+        memexId: 'mx-alice',
+        slug: 'alice',
+        memexSlug: 'personal',
+        name: 'Personal Memex',
+        kind: 'personal' as const,
+        role: 'administrator' as const,
+      },
+    ],
+    currentMemexId: 'mx-alice',
+    currentRole: 'administrator' as const,
+    needsOnboarding: false,
+    hiddenFeatures,
+  };
+}
+
+vi.mock('./components/AuthContext', async () => {
+  const real = await vi.importActual<typeof import('./components/AuthContext')>(
+    './components/AuthContext',
+  );
+  return {
+    ...real,
+    useAuth: () => ({
+      session: mockSession,
+      user: { name: 'Alice', email: 'alice@example.com', picture: '' },
+      token: 'fake-token',
+      isAuthenticated: true,
+      authError: null,
+      logout: vi.fn(),
+      updateSession: vi.fn(),
+      acceptSession: vi.fn(),
+    }),
+  };
+});
+
+vi.mock('./components/AppShell', () => ({
+  AppShell: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+vi.mock('./components/ChatContext', () => ({
+  ChatProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+vi.mock('./components/OrgConsentDialog', () => ({
+  OrgConsentDialog: () => null,
+}));
+
+// Sentinel for the gated page — the real QaReports fetches on mount, which is
+// irrelevant to the route gate.
+vi.mock('./pages/QaReports', () => ({
+  QaReports: () => <div data-testid="qa-reports-page">qa reports</div>,
+}));
+
+import { PostLoginRouter } from './App';
+
+function LocationProbe() {
+  const loc = useLocation();
+  return <div data-testid="probe" data-path={loc.pathname} />;
+}
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/*" element={<PostLoginRouter />} />
+        <Route path="/alice/personal/specs" element={<LocationProbe />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('spec-260 t-7: /qa-reports route gate (ac-18)', () => {
+  beforeEach(() => {
+    vi.stubEnv('VITE_GOOGLE_CLIENT_ID', 'test-client-id');
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("hidden → /qa-reports does not render the page and redirects to the default tenant", async () => {
+    tagAc(AC(18));
+    mockSession = makeSession(['qa-reports']);
+    renderAt('/alice/personal/qa-reports');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('probe').getAttribute('data-path')).toBe(
+        '/alice/personal/specs',
+      );
+    });
+    expect(screen.queryByTestId('qa-reports-page')).not.toBeInTheDocument();
+  });
+
+  it('not hidden → /qa-reports renders the QA Reports page', async () => {
+    tagAc(AC(18));
+    mockSession = makeSession([]);
+    renderAt('/alice/personal/qa-reports');
+
+    expect(await screen.findByTestId('qa-reports-page')).toBeInTheDocument();
+    expect(screen.queryByTestId('probe')).not.toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -2,6 +2,7 @@ import { Fragment, useState, useEffect, useRef, useMemo, type ReactNode } from '
 import { Routes, Route, useLocation, useParams, useNavigate, Navigate, Outlet } from 'react-router-dom';
 import { Pulse } from './pages/Pulse';
 import { Insights } from './pages/Insights';
+import { QaReports } from './pages/QaReports';
 import { Decisions } from './pages/Decisions';
 import { SpecList } from './pages/SpecList';
 import { IssuesList } from './pages/IssuesList';
@@ -384,6 +385,11 @@ export function PostLoginRouter() {
             server-driven gate mechanism as /pulse above. */}
         {!isFeatureHidden(session, 'insights') && (
           <Route path="insights" element={<Insights />} />
+        )}
+        {/* spec-260 (dec-5): QA Reports — the workspace feed of build-session
+            QA reports. Same server-driven hiddenFeatures gate as /pulse. */}
+        {!isFeatureHidden(session, 'qa-reports') && (
+          <Route path="qa-reports" element={<QaReports />} />
         )}
         <Route path="decisions" element={<Decisions />} />
         <Route path="specs" element={<SpecList />} />

--- a/packages/ui/src/components/AppShell.test.tsx
+++ b/packages/ui/src/components/AppShell.test.tsx
@@ -92,18 +92,37 @@ describe('AppShell sidebar navigation', () => {
     expect(within(nav).getByRole('link', { name: 'Standards' })).toBeInTheDocument();
   });
 
-  // spec-158 t-4: the primary nav order is Specs → Issues → Pulse (Issues sits
-  // directly under Specs; Pulse drops to the bottom of the primary group).
-  it('orders the primary nav Specs → Issues → Pulse', () => {
+  // spec-260 t-11 (supersedes spec-158 t-4's Specs → Issues → Pulse order): the
+  // sidebar is two labelled groups — PRINCIPLES (Specs, Pulse, Standards,
+  // Insights, Scaffold) then IN-BOXES (Drift, Issues, QA Reports — the
+  // badge-carrying attention surfaces). Specs still leads the nav.
+  it('groups the nav into Principles then In-boxes, in order', () => {
     tagAc('mindset-prod/memex-building-itself/specs/spec-158/acs/ac-1');
     renderShell(['/specs']);
 
     const nav = screen.getByTestId('primary-nav');
+    expect(within(nav).getByText('Principles')).toBeInTheDocument();
+    expect(within(nav).getByText('In-boxes')).toBeInTheDocument();
+
+    const GROUPED = [
+      'Specs',
+      'Pulse',
+      'Standards',
+      'Insights',
+      'Scaffold',
+      'Drift',
+      'Issues',
+      'QA Reports',
+    ];
     const labels = within(nav)
       .getAllByRole('link')
-      .map((a) => a.textContent?.trim())
-      .filter((l): l is string => l === 'Specs' || l === 'Issues' || l === 'Pulse');
-    expect(labels).toEqual(['Specs', 'Issues', 'Pulse']);
+      .map((a) => a.textContent?.trim() ?? '')
+      // Badge counts render inside the link text — strip trailing digits.
+      .map((l) => l.replace(/\d+$/, '').trim())
+      // The sidebar also hosts the logo + auth links; assert only the groups.
+      .filter((l) => GROUPED.includes(l));
+    // No features hidden in this fixture, so every group member renders.
+    expect(labels).toEqual(GROUPED);
   });
 
   it('marks Issues active on /issues', () => {

--- a/packages/ui/src/components/AppShell.tsx
+++ b/packages/ui/src/components/AppShell.tsx
@@ -5,6 +5,7 @@ import { Logo } from './Logo';
 import { useTheme } from './ThemeContext';
 import { useDriftInboxCount } from '../hooks/useDriftInboxCount';
 import { useMyIssuesCount } from '../hooks/useMyIssuesCount';
+import { useQaReportsUnreadCount } from '../hooks/useQaReports';
 import { useHiddenFeatures } from '../hooks/useIsFeatureHidden';
 import { MemexSwitcher } from './MemexSwitcher';
 import { InviteMembersDialog } from './InviteMembersDialog';
@@ -36,7 +37,7 @@ function stripTenantPrefix(pathname: string): string {
 // the user's default landing tenant when the URL is fully flat. Pure helper
 // so it can be exercised without rendering — `useNavTo` below is the React
 // wrapper that pulls session + location from context.
-const PRIMARY_NAV_LINKS: ReadonlyArray<{
+interface NavLinkDef {
   to: string;
   label: string;
   icon: ReactNode;
@@ -44,10 +45,13 @@ const PRIMARY_NAV_LINKS: ReadonlyArray<{
   // spec-146 t-3: when set, the link is hidden for every user whose session has
   // this slug in `hiddenFeatures` (server-driven feature-hide, dec-1 Option B).
   feature?: string;
-}> = [
-  // spec-158 t-4: nav order is Specs → Issues → Pulse. Specs leads (the primary
-  // surface), the cross-Spec Issues page sits directly beneath it, and Pulse —
-  // the activity dashboard — drops to the bottom of the primary group.
+}
+
+// spec-260 t-11: the sidebar is two labelled groups. PRINCIPLES holds the
+// working surfaces (Specs leads, then the dashboards and the standards/scaffold
+// references); IN-BOXES holds the three attention surfaces that carry unread /
+// open-count badges (Drift, Issues, QA Reports).
+const PRINCIPLES_NAV_LINKS: ReadonlyArray<NavLinkDef> = [
   {
     to: '/specs',
     label: 'Specs',
@@ -62,21 +66,21 @@ const PRIMARY_NAV_LINKS: ReadonlyArray<{
     ),
   },
   {
-    to: '/issues',
-    label: 'Issues',
-    icon: (
-      <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.75}>
-        <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z" />
-      </svg>
-    ),
-  },
-  {
     to: '/pulse',
     label: 'Pulse',
     feature: 'pulse',
     icon: (
       <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.75}>
         <path strokeLinecap="round" strokeLinejoin="round" d="M3 12h4l2 6 4-12 2 6h6" />
+      </svg>
+    ),
+  },
+  {
+    to: '/standards',
+    label: 'Standards',
+    icon: (
+      <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.75}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16l3.5-2 3.5 2 3.5-2 3.5 2z" />
       </svg>
     ),
   },
@@ -90,6 +94,16 @@ const PRIMARY_NAV_LINKS: ReadonlyArray<{
       <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.75}>
         <path strokeLinecap="round" strokeLinejoin="round" d="M4 20V10m6 10V4m6 16v-7" />
         <path strokeLinecap="round" d="M3 20h18" />
+      </svg>
+    ),
+  },
+  {
+    to: '/scaffold',
+    label: 'Scaffold',
+    feature: 'scaffold',
+    icon: (
+      <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.75}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16M4 18h16M8 3v18M16 3v18" />
       </svg>
     ),
   },
@@ -107,31 +121,38 @@ const PRIMARY_NAV_LINKS: ReadonlyArray<{
   // },
 ];
 
-const PRINCIPLES_NAV_LINKS: ReadonlyArray<{
-  to: string;
-  label: string;
-  icon: ReactNode;
-  altPaths?: readonly string[];
-  // spec-146 t-3: see PRIMARY_NAV_LINKS — hidden when this slug is in the
-  // session's `hiddenFeatures`.
-  feature?: string;
-}> = [
+// spec-260 t-11: the IN-BOXES group — every surface here carries a count badge
+// (open drift items, my open issues, unread QA reports).
+const INBOX_NAV_LINKS: ReadonlyArray<NavLinkDef> = [
   {
-    to: '/standards',
-    label: 'Standards',
+    to: '/drift',
+    label: 'Drift',
     icon: (
       <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.75}>
-        <path strokeLinecap="round" strokeLinejoin="round" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16l3.5-2 3.5 2 3.5-2 3.5 2z" />
+        <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z" />
       </svg>
     ),
   },
   {
-    to: '/scaffold',
-    label: 'Scaffold',
-    feature: 'scaffold',
+    to: '/issues',
+    label: 'Issues',
     icon: (
       <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.75}>
-        <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16M4 18h16M8 3v18M16 3v18" />
+        <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z" />
+      </svg>
+    ),
+  },
+  // spec-260 (dec-5): QA Reports — the workspace-wide feed of build-session QA
+  // reports, one row per session. Same server-driven hiddenFeatures gate as
+  // Pulse/Insights; carries the per-user unread badge (dec-6).
+  {
+    to: '/qa-reports',
+    label: 'QA Reports',
+    feature: 'qa-reports',
+    icon: (
+      <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.75}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M9 12h6m-6 4h6M9 8h1m4.5-5.5H7a2 2 0 00-2 2v15a2 2 0 002 2h10a2 2 0 002-2V8z" />
+        <path strokeLinecap="round" strokeLinejoin="round" d="M14 2.5V8h5.5" />
       </svg>
     ),
   },
@@ -435,6 +456,9 @@ export function AppShell({ children }: { children: ReactNode }) {
   const driftCount = useDriftInboxCount(!onDocPage);
   // spec-158: my open issues (Specs assigned to me) for the Issues nav badge.
   const myIssuesCount = useMyIssuesCount(!onDocPage);
+  // spec-260 (dec-6): per-user unread QA reports for the QA Reports nav badge —
+  // reports generated since this user last viewed the feed, all executors.
+  const qaReportsUnreadCount = useQaReportsUnreadCount(!onDocPage);
 
   // spec-146 t-3: server-driven feature-hide. A nav link tagged with `feature`
   // is dropped for every user whose session lists that slug in `hiddenFeatures`
@@ -548,43 +572,37 @@ export function AppShell({ children }: { children: ReactNode }) {
         </div>
 
         <nav className="flex-1 min-h-0 overflow-y-auto px-3 space-y-0.5">
-          {PRIMARY_NAV_LINKS.filter((link) => !isLinkHidden(link.feature)).map((link) => (
+          {/* spec-260 t-11: two labelled groups — PRINCIPLES (the working
+              surfaces) and IN-BOXES (the badge-carrying attention surfaces). */}
+          <div className="pt-1 pb-1 px-3 text-xs font-medium uppercase tracking-wider text-muted">
+            Principles
+          </div>
+          {PRINCIPLES_NAV_LINKS.filter((link) => !isLinkHidden(link.feature)).map((link) => (
+            <NavItem key={link.to} {...link} pathname={location.pathname} />
+          ))}
+
+          <div className="pt-4 pb-1 px-3 text-xs font-medium uppercase tracking-wider text-muted">
+            In-boxes
+          </div>
+          {INBOX_NAV_LINKS.filter((link) => !isLinkHidden(link.feature)).map((link) => (
             <NavItem
               key={link.to}
               {...link}
               pathname={location.pathname}
-              // spec-158: open-issue count on the Issues entry, scoped to MY
-              // issues (Specs assigned to me) — matches the page's Mine default.
-              badge={link.to === '/issues' ? myIssuesCount : undefined}
+              // Every in-box carries its count: open drift (b-63), MY open
+              // issues (spec-158, matches the page's Mine default), and unread
+              // QA reports (spec-260 dec-6).
+              badge={
+                link.to === '/drift'
+                  ? driftCount
+                  : link.to === '/issues'
+                    ? myIssuesCount
+                    : link.to === '/qa-reports'
+                      ? qaReportsUnreadCount
+                      : undefined
+              }
             />
           ))}
-
-          <div className="pt-4 pb-1 px-3 text-xs font-medium uppercase tracking-wider text-muted">
-            Principles
-          </div>
-          {PRINCIPLES_NAV_LINKS.filter((link) => !isLinkHidden(link.feature)).flatMap((link) => {
-            const item = <NavItem key={link.to} {...link} pathname={location.pathname} />;
-            // Drift Inbox sits directly under Standards (before Scaffold) — it's a
-            // standards-scoped surface, so it belongs next to Standards.
-            if (link.to === '/standards') {
-              return [
-                item,
-                <NavItem
-                  key="/drift"
-                  to="/drift"
-                  label="Drift Inbox"
-                  pathname={location.pathname}
-                  badge={driftCount}
-                  icon={
-                    <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.75}>
-                      <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z" />
-                    </svg>
-                  }
-                />,
-              ];
-            }
-            return [item];
-          })}
         </nav>
 
         {(user || access.isVisitedReadOnly) && (

--- a/packages/ui/src/components/DoneSummary.spec-260.test.tsx
+++ b/packages/ui/src/components/DoneSummary.spec-260.test.tsx
@@ -1,0 +1,112 @@
+// spec-260 t-6 — the Done seat: the QA report behind a gated button (dec-1),
+// modelled on the spec-196 "Read the spec" toggle. Asserts:
+//   • the "QA report" button renders only when a build session wrote one;
+//   • toggling reveals the read-only report (latest session) and hides it again;
+//   • qa_report sections never leak into the "Read the spec" narrative (ac-12's
+//     not-plan-prose rule, applied to the done record);
+//   • the report body carries no edit affordance (ac-11).
+
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { DoneSummary } from './DoneSummary';
+import type { DocWithGraph } from '../api/types';
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-260/acs/ac-${n}`;
+
+const CREATED_AT = '2026-06-02T12:00:00Z';
+const COMPLETED_AT = '2026-06-09T12:00:00Z';
+
+function makeDoc(withReport: boolean): DocWithGraph {
+  return {
+    id: 'doc-uuid',
+    handle: 'spec-260',
+    title: 'QA report done seat',
+    docType: 'spec',
+    status: 'done',
+    creator: { name: 'Barrie Hadfield', email: 'barrie@mindset.ai' },
+    createdAt: CREATED_AT,
+    statusChangedAt: COMPLETED_AT,
+    sections: [
+      {
+        id: 's-1',
+        sectionType: 'overview',
+        title: 'Overview',
+        content: 'The plan prose.',
+        seq: 1,
+        createdAt: CREATED_AT,
+        updatedAt: COMPLETED_AT,
+      },
+      ...(withReport
+        ? [
+            {
+              id: 's-2',
+              sectionType: 'qa_report',
+              title: 'QA Report',
+              content: 'The build session report body.',
+              seq: 2,
+              createdAt: COMPLETED_AT,
+              updatedAt: COMPLETED_AT,
+            },
+          ]
+        : []),
+    ],
+    decisions: [],
+    tasks: [],
+  } as unknown as DocWithGraph;
+}
+
+function renderDone(withReport: boolean) {
+  return render(
+    <DoneSummary doc={makeDoc(withReport)} decisions={[]} tasks={[]} acs={[]} issues={[]} />,
+  );
+}
+
+describe('spec-260 — QA report behind the Done-screen gated button', () => {
+  it('ac-12: the gated button reveals the report and hides it again', () => {
+    tagAc(AC(12));
+    renderDone(true);
+
+    // Gated: nothing shows until the button is pressed.
+    const button = screen.getByTestId('done-qa-report');
+    expect(button).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByTestId('done-qa-report-body')).not.toBeInTheDocument();
+
+    fireEvent.click(button);
+    const body = screen.getByTestId('done-qa-report-body');
+    expect(within(body).getByTestId('qa-report-content')).toHaveTextContent(
+      'The build session report body.',
+    );
+
+    fireEvent.click(button);
+    expect(screen.queryByTestId('done-qa-report-body')).not.toBeInTheDocument();
+  });
+
+  it('ac-12: no QA report → no button (the Done screen stays clean)', () => {
+    renderDone(false);
+    expect(screen.queryByTestId('done-qa-report')).not.toBeInTheDocument();
+  });
+
+  it('ac-12: the "Read the spec" narrative excludes qa_report sections', () => {
+    tagAc(AC(12));
+    renderDone(true);
+
+    fireEvent.click(screen.getByTestId('done-read-spec'));
+    const readBody = screen.getByTestId('done-read-spec-body');
+    const sections = within(readBody).getAllByTestId('done-read-section');
+    expect(sections).toHaveLength(1);
+    expect(sections[0]).toHaveTextContent('Overview');
+    expect(readBody).not.toHaveTextContent('The build session report body.');
+  });
+
+  it('ac-11: the revealed report is read-only — no edit affordance', () => {
+    tagAc(AC(11));
+    renderDone(true);
+
+    fireEvent.click(screen.getByTestId('done-qa-report'));
+    const body = screen.getByTestId('done-qa-report-body');
+    expect(body.querySelector('textarea')).toBeNull();
+    expect(body.querySelector('input')).toBeNull();
+    expect(body.querySelector('[contenteditable="true"]')).toBeNull();
+  });
+});

--- a/packages/ui/src/components/DoneSummary.tsx
+++ b/packages/ui/src/components/DoneSummary.tsx
@@ -30,9 +30,11 @@ import { useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeHighlight from 'rehype-highlight';
+import { isQaReportSectionType } from '@memex/shared';
 import type { Decision, Task, Issue, DocWithGraph } from '../api/types';
 import type { AcWithVerification, DocAssigneeView } from '../api/client';
 import { Button, Card } from './ui';
+import { QaReportCard, selectQaReports } from './QaReportCard';
 import { phaseDisplayName } from '../utils/phaseDisplay';
 
 interface DoneSummaryProps {
@@ -138,6 +140,10 @@ export function DoneSummary({
   // retrospective stays the landing state; expanding is pure presentation
   // (no fetch, no phase change).
   const [readOpen, setReadOpen] = useState(false);
+  // spec-260 (dec-1): the Done seat — the QA report sits behind a gated button
+  // modelled on the "Read the spec" toggle, keeping the Done screen clean while
+  // the full build record stays one click away.
+  const [qaOpen, setQaOpen] = useState(false);
 
   const handleReopenYes = async () => {
     setReopenState('submitting');
@@ -184,7 +190,12 @@ export function DoneSummary({
   const totalDays = daysBetween(doc.createdAt, completedAt);
 
   // spec-196 dec-4: the full record, from data already in hand.
-  const sortedSections = [...(doc.sections ?? [])].sort((a, b) => a.seq - b.seq);
+  // spec-260 ac-12: qa_report sections are build output, not plan prose — they
+  // render behind their own gated button below, never inside the spec read view.
+  const sortedSections = [...(doc.sections ?? [])]
+    .sort((a, b) => a.seq - b.seq)
+    .filter((s) => !isQaReportSectionType(s.sectionType));
+  const qaReports = selectQaReports(doc.sections ?? []);
   const recordHeading = 'text-sm font-semibold text-muted tracking-wide mb-3';
 
   return (
@@ -255,6 +266,21 @@ export function DoneSummary({
             {readOpen ? 'Hide the spec' : 'Read the spec'}
           </Button>
 
+          {/* spec-260: the QA report behind its own gated toggle — only offered
+              when a build session actually wrote one. */}
+          {qaReports.length > 0 && (
+            <Button
+              type="button"
+              variant="secondary"
+              size="sm"
+              data-testid="done-qa-report"
+              aria-expanded={qaOpen}
+              onClick={() => setQaOpen((v) => !v)}
+            >
+              {qaOpen ? 'Hide the QA report' : 'QA report'}
+            </Button>
+          )}
+
           {canReopen &&
             (reopenState === 'idle' ? (
               <Button
@@ -294,6 +320,12 @@ export function DoneSummary({
               </span>
             ))}
         </div>
+
+        {qaOpen && (
+          <div data-testid="done-qa-report-body" className="mt-6 text-left">
+            <QaReportCard reports={qaReports} bare />
+          </div>
+        )}
 
         {readOpen && (
           <div data-testid="done-read-spec-body" className="mt-6 space-y-8 text-left">

--- a/packages/ui/src/components/HeaderSlot.tsx
+++ b/packages/ui/src/components/HeaderSlot.tsx
@@ -1,32 +1,48 @@
 import { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
 
-type HeaderSlotContextValue = {
-  content: ReactNode;
-  setContent: (content: ReactNode) => void;
-};
+// Two contexts, deliberately split (spec-260 build finding):
+//
+// The original single-context shape ({ content, setContent } minted fresh each
+// provider render) made every useHeaderSlot PAGE a subscriber of the content it
+// was itself setting. Pages pass inline JSX — a new element identity every
+// render — so the effect re-fired each render: setContent → provider re-render
+// → page re-render (consumer) → new element → setContent → … an UNBOUNDED
+// passive-effect render loop on every page using the slot. Cheap renders kept
+// it invisible in the app; a heavier child (the spec-260 QA Report card) made
+// vitest runs exhaust the heap, which is how it surfaced.
+//
+// The fix is the standard split: pages depend only on the stable SETTER context
+// (so writing content never re-renders them), while the header sink alone
+// subscribes to the CONTENT context. A page render still pushes fresh content
+// (new JSX identity → effect refires), but that now re-renders only the header
+// sink — bounded by page renders instead of feeding back into them.
 
-const HeaderSlotContext = createContext<HeaderSlotContextValue | null>(null);
+const HeaderSlotContentContext = createContext<ReactNode>(null);
+const HeaderSlotSetterContext = createContext<((content: ReactNode) => void) | null>(null);
 
 export function HeaderSlotProvider({ children }: { children: ReactNode }) {
   const [content, setContent] = useState<ReactNode>(null);
   return (
-    <HeaderSlotContext.Provider value={{ content, setContent }}>
-      {children}
-    </HeaderSlotContext.Provider>
+    // setContent from useState is referentially stable, so the setter context
+    // value never changes — pages subscribed to it never re-render from here.
+    <HeaderSlotSetterContext.Provider value={setContent}>
+      <HeaderSlotContentContext.Provider value={content}>
+        {children}
+      </HeaderSlotContentContext.Provider>
+    </HeaderSlotSetterContext.Provider>
   );
 }
 
 export function useHeaderSlotContent(): ReactNode {
-  const ctx = useContext(HeaderSlotContext);
-  return ctx?.content ?? null;
+  return useContext(HeaderSlotContentContext);
 }
 
 // Pages render their global-header right-side actions by calling this hook with
 // a JSX node. Cleared automatically on unmount.
 export function useHeaderSlot(content: ReactNode): void {
-  const ctx = useContext(HeaderSlotContext);
+  const setContent = useContext(HeaderSlotSetterContext);
   useEffect(() => {
-    ctx?.setContent(content);
-    return () => ctx?.setContent(null);
-  }, [ctx, content]);
+    setContent?.(content);
+    return () => setContent?.(null);
+  }, [setContent, content]);
 }

--- a/packages/ui/src/components/QaReportCard.tsx
+++ b/packages/ui/src/components/QaReportCard.tsx
@@ -1,0 +1,118 @@
+// spec-260 (dec-1): the read-only QA Report card — the per-Spec render seat for
+// `qa_report` sections. One component, three seats:
+//
+//   • Verify — front-loaded full-width card ABOVE the ACs │ Issues columns,
+//     expanded by default (the cold verifier reads it first), collapsible so it
+//     folds away once read.
+//   • Build — the body of the "QA Report" sub-tab, with a quiet empty state
+//     until the first build→verify hand-off writes one.
+//   • Done — the body behind the gated "QA report" button on DoneSummary.
+//
+// READ-ONLY everywhere (ac-11): no inline-edit affordance, no comment gutter —
+// the report is a build *output*, not plan prose. Versioning display (dec-2):
+// the latest build session's report shows by default; prior sessions stay
+// reachable through the version switcher.
+
+import { useState } from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import { isQaReportSectionType, qaReportVersion } from '@memex/shared';
+import type { DocSection } from '../api/types';
+import { formatDate } from '../utils/format';
+
+/**
+ * The qa_report* rows of a Spec's sections, newest session first. Shared by
+ * every seat so "latest" means the same thing everywhere.
+ */
+export function selectQaReports(sections: DocSection[]): DocSection[] {
+  return sections
+    .filter((s) => isQaReportSectionType(s.sectionType))
+    .sort(
+      (a, b) => (qaReportVersion(b.sectionType) ?? 0) - (qaReportVersion(a.sectionType) ?? 0),
+    );
+}
+
+interface QaReportCardProps {
+  /** qa_report sections, newest-first (selectQaReports output). */
+  reports: DocSection[];
+  /** Collapsed on first render? Verify wants false (front-loaded), Build true-ish n/a. */
+  defaultCollapsed?: boolean;
+  /** Shown when no report exists yet. Omit to render nothing when empty. */
+  emptyState?: string;
+  /** Whether the card chrome (border/heading) renders. The Done seat supplies its own. */
+  bare?: boolean;
+}
+
+export function QaReportCard({ reports, defaultCollapsed = false, emptyState, bare = false }: QaReportCardProps) {
+  const [collapsed, setCollapsed] = useState(defaultCollapsed);
+  // Index into `reports` (0 = latest session). Reset is unnecessary — the list
+  // only ever grows by prepending a newer session.
+  const [versionIdx, setVersionIdx] = useState(0);
+
+  if (reports.length === 0) {
+    if (!emptyState) return null;
+    return (
+      <div data-testid="qa-report-empty" className="text-sm text-muted py-6 text-center">
+        {emptyState}
+      </div>
+    );
+  }
+
+  const current = reports[Math.min(versionIdx, reports.length - 1)];
+  const version = qaReportVersion(current.sectionType) ?? 1;
+
+  const body = (
+    <>
+      {reports.length > 1 && (
+        <div className="flex items-center gap-2 mb-3 text-xs text-muted">
+          <span>Build session:</span>
+          <select
+            data-testid="qa-report-version-switcher"
+            className="bg-transparent border border-edge rounded-md px-1.5 py-0.5 text-xs text-secondary"
+            value={versionIdx}
+            onChange={(e) => setVersionIdx(Number(e.target.value))}
+          >
+            {reports.map((r, i) => (
+              <option key={r.id} value={i}>
+                Session {qaReportVersion(r.sectionType) ?? 1} · {formatDate(r.createdAt)}
+                {i === 0 ? ' (latest)' : ''}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+      {/* Read-only prose — deliberately NO edit affordance (ac-11). */}
+      <div data-testid="qa-report-content" className="prose-dark overflow-hidden">
+        <ReactMarkdown remarkPlugins={[remarkGfm]}>{current.content}</ReactMarkdown>
+      </div>
+    </>
+  );
+
+  if (bare) {
+    return <div data-testid="qa-report-card">{body}</div>;
+  }
+
+  return (
+    <div
+      data-testid="qa-report-card"
+      className="mb-6 rounded-xl border border-edge bg-surface p-4"
+    >
+      <button
+        type="button"
+        data-testid="qa-report-toggle"
+        aria-expanded={!collapsed}
+        onClick={() => setCollapsed((v) => !v)}
+        className="w-full flex items-center justify-between text-left"
+      >
+        <span className="text-sm font-semibold text-heading">
+          QA Report
+          <span className="ml-2 font-normal text-muted">
+            Session {version} · {formatDate(current.createdAt)}
+          </span>
+        </span>
+        <span className="text-xs text-muted">{collapsed ? 'Show' : 'Hide'}</span>
+      </button>
+      {!collapsed && <div className="mt-3">{body}</div>}
+    </div>
+  );
+}

--- a/packages/ui/src/hooks/useQaReports.spec-260.test.tsx
+++ b/packages/ui/src/hooks/useQaReports.spec-260.test.tsx
@@ -1,0 +1,131 @@
+// spec-260 t-8 — the unread-badge hook (dec-6): count fetch, live SSE refresh,
+// zero-on-view, and the keyset Load More maths of the feed hook. api/http is
+// stubbed (the hook-test convention), so tenant resolution and retries are out
+// of scope here — the server integration tests own the endpoint behaviour.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { tagAc } from '@memex-ai-ac/vitest';
+import type { ReactNode } from 'react';
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-260/acs/ac-${n}`;
+
+const fetchMock = vi.hoisted(() => vi.fn());
+vi.mock('../api/http', () => ({
+  tenantBase: () => '/api/acme/main',
+  fetchWithRetry: (...a: unknown[]) => fetchMock(...a),
+}));
+
+// Capture the SSE subscription so tests can fire a live event.
+const streamCallbacks = vi.hoisted(() => ({ current: [] as Array<() => void> }));
+vi.mock('./useDocChangeStream', () => ({
+  useDocChangeStream: (_docId: string | null, onEvent: () => void) => {
+    streamCallbacks.current.push(onEvent);
+  },
+}));
+
+import {
+  QA_REPORTS_VIEWED_EVENT,
+  recordQaReportsView,
+  useQaReportsFeed,
+  useQaReportsUnreadCount,
+} from './useQaReports';
+
+function jsonResponse(body: unknown): Response {
+  return { ok: true, json: () => Promise.resolve(body) } as unknown as Response;
+}
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <MemoryRouter initialEntries={['/acme/main/qa-reports']}>{children}</MemoryRouter>
+);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  streamCallbacks.current = [];
+});
+
+describe('useQaReportsUnreadCount (dec-6 badge)', () => {
+  it('ac-10: fetches the per-user unread count and zeroes on the view broadcast', async () => {
+    tagAc(AC(10));
+    fetchMock.mockResolvedValue(jsonResponse({ count: 4 }));
+
+    const { result } = renderHook(() => useQaReportsUnreadCount(), { wrapper });
+    await waitFor(() => expect(result.current).toBe(4));
+    expect(fetchMock).toHaveBeenCalledWith('/api/acme/main/qa-reports/unread');
+
+    // The page records a view → the badge zeroes immediately (same tab),
+    // without waiting for a server round-trip.
+    act(() => {
+      window.dispatchEvent(new Event(QA_REPORTS_VIEWED_EVENT));
+    });
+    expect(result.current).toBe(0);
+  });
+
+  it('ac-10/ac-20: a live bus event refreshes the count without a reload', async () => {
+    tagAc(AC(10));
+    fetchMock.mockResolvedValueOnce(jsonResponse({ count: 0 }));
+
+    const { result } = renderHook(() => useQaReportsUnreadCount(), { wrapper });
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    // A new report rides the std-8 bus → the badge refetches and increments.
+    fetchMock.mockResolvedValueOnce(jsonResponse({ count: 1 }));
+    act(() => {
+      streamCallbacks.current.forEach((cb) => cb());
+    });
+    await waitFor(() => expect(result.current).toBe(1));
+  });
+
+  it('errors yield 0 — the badge hides rather than erroring in the chrome', async () => {
+    fetchMock.mockRejectedValue(new Error('boom'));
+    const { result } = renderHook(() => useQaReportsUnreadCount(), { wrapper });
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    expect(result.current).toBe(0);
+  });
+});
+
+describe('recordQaReportsView', () => {
+  it('ac-10: POSTs the view marker and broadcasts the zeroing event', async () => {
+    tagAc(AC(10));
+    fetchMock.mockResolvedValue(jsonResponse({ lastViewedAt: '2026-06-12T00:00:00Z' }));
+    const heard = vi.fn();
+    window.addEventListener(QA_REPORTS_VIEWED_EVENT, heard);
+    try {
+      await recordQaReportsView();
+      expect(fetchMock).toHaveBeenCalledWith('/api/acme/main/qa-reports/view', { method: 'POST' });
+      expect(heard).toHaveBeenCalledTimes(1);
+    } finally {
+      window.removeEventListener(QA_REPORTS_VIEWED_EVENT, heard);
+    }
+  });
+});
+
+describe('useQaReportsFeed (dec-5 keyset Load More)', () => {
+  it('ac-8: first page then loadOlder passes the oldest row createdAt as `since`', async () => {
+    tagAc(AC(8));
+    const page1 = [
+      { id: 'r-2', createdAt: '2026-06-02T00:00:00Z' },
+      { id: 'r-1', createdAt: '2026-06-01T00:00:00Z' },
+    ];
+    const page2 = [{ id: 'r-0', createdAt: '2026-05-30T00:00:00Z' }];
+    fetchMock.mockResolvedValueOnce(jsonResponse(page1));
+
+    const { result } = renderHook(() => useQaReportsFeed(2), { wrapper });
+    await waitFor(() => expect(result.current.rows).toHaveLength(2));
+    // A full page (length == limit) keeps Load More enabled.
+    expect(result.current.hasMore).toBe(true);
+
+    fetchMock.mockResolvedValueOnce(jsonResponse(page2));
+    await act(async () => {
+      await result.current.loadOlder();
+    });
+
+    // The keyset boundary is the OLDEST loaded row's createdAt.
+    const lastCall = fetchMock.mock.calls.at(-1)![0] as string;
+    expect(lastCall).toContain('since=2026-06-01T00%3A00%3A00Z');
+    expect(result.current.rows.map((r) => r.id)).toEqual(['r-2', 'r-1', 'r-0']);
+    // A short page means the tail was reached.
+    expect(result.current.hasMore).toBe(false);
+  });
+});

--- a/packages/ui/src/hooks/useQaReports.ts
+++ b/packages/ui/src/hooks/useQaReports.ts
@@ -1,0 +1,181 @@
+// spec-260 (dec-5, dec-6) — client data layer for the workspace QA Reports feed.
+//
+// useQaReportsFeed mirrors usePulseHistory's keyset "Load More" shape over
+// GET /api/<ns>/<mx>/qa-reports (newest-first; `since` = oldest loaded row's
+// createdAt → strictly older page). useQaReportsUnreadCount is the per-user nav
+// badge (GET …/qa-reports/unread), refreshed live off the SSE bus the way the
+// Issues / Drift badges are. recordQaReportsView POSTs the "viewed now" marker
+// (upserts last_viewed_at = now(), zeroing the badge) and announces it via a
+// window event so the AppShell badge — a different component tree — zeroes
+// without waiting for the next SSE tick.
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useLocation } from 'react-router-dom';
+import { tenantBase, fetchWithRetry } from '../api/http';
+import { useDocChangeStream } from './useDocChangeStream';
+
+const DEFAULT_LIMIT = 50;
+
+// Fired on window after a successful view-marker POST. The badge hook listens —
+// the POST emits nothing on the server bus (it's per-user read-state, not an
+// activity), so without this the badge would stay stale until the next event.
+export const QA_REPORTS_VIEWED_EVENT = 'memex:qa-reports-viewed';
+
+/** Wire shape of GET /api/<ns>/<mx>/qa-reports rows (server QaReportFeedRow). */
+export interface QaReportFeedRow {
+  id: string;
+  docId: string;
+  docHandle: string;
+  docTitle: string;
+  sectionType: string;
+  version: number;
+  title: string | null;
+  content: string;
+  actorUserId?: string | null;
+  actorName?: string | null;
+  actorKind: 'human' | 'mcp_agent' | 'in_app_agent' | 'system';
+  channel: string | null;
+  createdAt: string;
+}
+
+export interface UseQaReportsFeedResult {
+  rows: QaReportFeedRow[];
+  loading: boolean;
+  error: string | null;
+  hasMore: boolean;
+  loadOlder: () => Promise<void>;
+  refresh: () => Promise<void>;
+}
+
+export function useQaReportsFeed(limit = DEFAULT_LIMIT): UseQaReportsFeedResult {
+  const [rows, setRows] = useState<QaReportFeedRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [hasMore, setHasMore] = useState(false);
+
+  // Latest-fetch-wins token + a rows mirror so loadOlder keeps a stable identity
+  // (the usePulseHistory pattern).
+  const reqToken = useRef(0);
+  const rowsRef = useRef<QaReportFeedRow[]>([]);
+  rowsRef.current = rows;
+  const loadingOlderRef = useRef(false);
+
+  const fetchPage = useCallback(
+    async (since: string | undefined): Promise<QaReportFeedRow[]> => {
+      const base = tenantBase();
+      if (!base) {
+        throw new Error('QA Reports requires tenant context (no namespace/memex in the URL).');
+      }
+      const params = new URLSearchParams();
+      params.set('limit', String(limit));
+      if (since) params.set('since', since);
+      const res = await fetchWithRetry(`${base}/qa-reports?${params.toString()}`);
+      if (!res.ok) throw new Error(`Failed to load QA reports (${res.status})`);
+      return (await res.json()) as QaReportFeedRow[];
+    },
+    [limit],
+  );
+
+  const refresh = useCallback(async () => {
+    const myReq = ++reqToken.current;
+    setLoading(true);
+    setError(null);
+    try {
+      const page = await fetchPage(undefined);
+      if (myReq !== reqToken.current) return; // superseded
+      setRows(page);
+      setHasMore(page.length >= limit);
+    } catch (err) {
+      if (myReq !== reqToken.current) return;
+      setError(err instanceof Error ? err.message : 'Failed to load QA reports');
+    } finally {
+      if (myReq === reqToken.current) setLoading(false);
+    }
+  }, [fetchPage, limit]);
+
+  const loadOlder = useCallback(async () => {
+    if (loadingOlderRef.current) return;
+    const current = rowsRef.current;
+    const oldest = current[current.length - 1];
+    if (!oldest) return; // nothing loaded yet — refresh covers the first page
+    loadingOlderRef.current = true;
+    setError(null);
+    try {
+      const page = await fetchPage(oldest.createdAt);
+      setRows((prev) => [...prev, ...page]);
+      setHasMore(page.length >= limit);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load older QA reports');
+    } finally {
+      loadingOlderRef.current = false;
+    }
+  }, [fetchPage, limit]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  return { rows, loading, error, hasMore, loadOlder, refresh };
+}
+
+/**
+ * Record that the current user viewed the QA Reports feed now. Upserts the
+ * per-(user, memex) last_viewed_at marker server-side and broadcasts
+ * QA_REPORTS_VIEWED_EVENT so the nav badge zeroes immediately.
+ */
+export async function recordQaReportsView(): Promise<void> {
+  const base = tenantBase();
+  if (!base) return;
+  try {
+    const res = await fetchWithRetry(`${base}/qa-reports/view`, { method: 'POST' });
+    if (res.ok) window.dispatchEvent(new Event(QA_REPORTS_VIEWED_EVENT));
+  } catch {
+    // Best-effort: a failed marker write leaves the badge stale, never breaks the page.
+  }
+}
+
+/**
+ * Per-user unread QA-report count for the nav badge (dec-6): the number of
+ * reports generated since this user last viewed the feed — ALL reports,
+ * own-agent included. Best-effort like useDriftInboxCount: errors yield 0 so
+ * the badge hides rather than erroring in the chrome. Live via the SSE bus
+ * (a new qa_report section emits section.created), re-fetched on Memex switch
+ * (pathname), and zeroed on the page's view-marker broadcast.
+ */
+export function useQaReportsUnreadCount(enabled = true): number {
+  const [count, setCount] = useState(0);
+  const { pathname } = useLocation();
+
+  const reload = useCallback(() => {
+    if (!enabled) return;
+    const base = tenantBase();
+    if (!base) {
+      setCount(0);
+      return;
+    }
+    fetchWithRetry(`${base}/qa-reports/unread`)
+      .then(async (res) => {
+        if (!res.ok) throw new Error(String(res.status));
+        const body = (await res.json()) as { count: number };
+        setCount(body.count ?? 0);
+      })
+      .catch(() => setCount(0));
+  }, [enabled, pathname]);
+
+  useEffect(() => {
+    reload();
+  }, [reload]);
+
+  // Zero immediately when the QA Reports page records a view (same tab).
+  useEffect(() => {
+    const onViewed = () => setCount(0);
+    window.addEventListener(QA_REPORTS_VIEWED_EVENT, onViewed);
+    return () => window.removeEventListener(QA_REPORTS_VIEWED_EVENT, onViewed);
+  }, []);
+
+  // A freshly written report rides the std-8 bus as a section event — refresh
+  // the count without a reload (the Issues/Drift badge pattern).
+  useDocChangeStream(null, reload);
+
+  return count;
+}

--- a/packages/ui/src/pages/DocDocument.spec-159.test.tsx
+++ b/packages/ui/src/pages/DocDocument.spec-159.test.tsx
@@ -223,7 +223,12 @@ describe('spec-159 t-6 — DocDocument phase layouts', () => {
     expect(screen.getByTestId('all-comments')).toBeInTheDocument();
   });
 
-  it('Build renders Tasks | Issues with NO sub-tab bar (ac-5, ac-11)', async () => {
+  // spec-260 evolved this layout: Build now carries a secondary "QA Report"
+  // sub-tab (deliberate structural change, spec-260 dec-1). What survives of
+  // ac-11 here: the Tasks | Issues two-column stays Build's DEFAULT view and
+  // Specify's sub-tabs never leak into it. The QA-report tab itself is covered
+  // by DocDocument.spec-260.test.tsx.
+  it('Build defaults to Tasks | Issues; Specify sub-tabs never leak in (ac-5, ac-11)', async () => {
     tagAc(AC(5));
     tagAc(AC(11));
     renderAt('build');
@@ -232,7 +237,7 @@ describe('spec-159 t-6 — DocDocument phase layouts', () => {
     expect(screen.getByTestId('issue-panel')).toBeInTheDocument();
     expect(screen.queryByTestId('ac-panel')).not.toBeInTheDocument();
 
-    // No sub-tab bar: the Specify sub-tab labels are absent.
+    // The Specify sub-tab labels are absent.
     expect(screen.queryByText('Decisions & ACs')).not.toBeInTheDocument();
     // The only tablist on the page is the phase bar (4 tabs, spec-258), not a sub-tab bar.
     expect(screen.getAllByRole('tab')).toHaveLength(4);

--- a/packages/ui/src/pages/DocDocument.spec-260.test.tsx
+++ b/packages/ui/src/pages/DocDocument.spec-260.test.tsx
@@ -1,0 +1,253 @@
+// spec-260 t-6 — the QA Report render seats on the Spec page.
+//
+// Renders the REAL DocDocument (heavy panels stubbed to markers, the REAL
+// QaReportCard) with a doc whose sections include qa_report rows, and asserts:
+//
+//   ac-11 : the report renders READ-ONLY — no inline-edit affordance.
+//   ac-12 : three seats — a collapsible card above the ACs/Issues columns in
+//           Verify; a "QA Report" sub-tab in Build (default stays Tasks/Issues,
+//           quiet empty state before the first hand-off); and NOT in the
+//           Specify "Narrative" sub-tab. (The Done seat is covered in
+//           DoneSummary.spec-260.test.tsx — DoneSummary is stubbed here.)
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { tagAc } from '@memex-ai-ac/vitest';
+import type { DocWithGraph } from '../api/types';
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-260/acs/ac-${n}`;
+
+// ── Heavy children → identity markers (the spec-159 harness shape) ──────────
+vi.mock('../components/DecisionPanel', () => ({
+  DecisionPanel: () => <div data-testid="decision-panel" />,
+}));
+vi.mock('../components/AcPanel', () => ({
+  AcPanel: () => <div data-testid="ac-panel" />,
+}));
+vi.mock('../components/TaskPanel', () => ({
+  TaskPanel: () => <div data-testid="task-panel" />,
+}));
+vi.mock('../components/IssuePanel', () => ({
+  IssuePanel: () => <div data-testid="issue-panel" />,
+}));
+vi.mock('../components/AllComments', () => ({
+  AllComments: () => <div data-testid="all-comments" />,
+}));
+vi.mock('../components/SectionCard', () => ({
+  SectionCard: (props: { section: { sectionType: string } }) => (
+    <div data-testid="section-card" data-section-type={props.section.sectionType} />
+  ),
+}));
+vi.mock('../components/DocOutline', () => ({ DocOutline: () => <div data-testid="doc-outline" /> }));
+vi.mock('../components/TagPicker', () => ({ TagPicker: () => null }));
+vi.mock('../components/BylineAssignees', () => ({
+  BylineAssignees: () => <div data-testid="byline-assignees" />,
+}));
+vi.mock('../components/DoneSummary', () => ({
+  DoneSummary: () => <div data-testid="done-summary" />,
+}));
+
+vi.mock('../hooks/useMemexAccess', () => ({
+  useMemexAccess: () => ({ canWrite: true, isReadOnly: false }),
+}));
+vi.mock('../hooks/useDocRole', () => ({
+  useDocRole: () => ({ myRole: 'editor', editors: [], loading: false, refetch: vi.fn() }),
+}));
+vi.mock('../hooks/useDocChangeStream', () => ({ useDocChangeStream: () => {} }));
+vi.mock('../hooks/useOrgScaffoldBlocks', () => ({ useOrgScaffoldBlocks: () => [] }));
+const chat = {
+  setDocId: vi.fn(),
+  setDoc: vi.fn(),
+  setOpenCommentCount: vi.fn(),
+  sendMessage: vi.fn(),
+};
+vi.mock('../components/ChatContext', () => ({ useChat: () => chat }));
+
+let docStatus: DocWithGraph['status'] = 'verify';
+// Whether the doc carries QA report sections (the empty-state tests flip this).
+let withReports = true;
+
+function section(over: Record<string, unknown>) {
+  return {
+    id: `sec-${over.sectionType as string}`,
+    docId: 'doc-uuid',
+    title: null,
+    description: null,
+    content: 'body',
+    status: 'active',
+    createdAt: '2026-06-01T00:00:00Z',
+    updatedAt: '2026-06-01T00:00:00Z',
+    ...over,
+  };
+}
+
+function makeDoc(): DocWithGraph {
+  const sections = [
+    section({ sectionType: 'overview', seq: 1, title: 'Overview', content: 'The plan prose.' }),
+  ];
+  if (withReports) {
+    sections.push(
+      section({
+        sectionType: 'qa_report',
+        seq: 2,
+        title: 'QA Report',
+        content: 'Session ONE report body.',
+        createdAt: '2026-06-02T00:00:00Z',
+      }),
+      section({
+        sectionType: 'qa_report-2',
+        seq: 3,
+        title: 'QA Report',
+        content: 'Session TWO report body.',
+        createdAt: '2026-06-03T00:00:00Z',
+      }),
+    );
+  }
+  return {
+    id: 'doc-uuid',
+    handle: 'spec-260',
+    title: 'QA report seats',
+    docType: 'spec',
+    status: docStatus,
+    creator: { name: 'Barrie', email: 'barrie@mindset.ai' },
+    createdAt: '2026-06-01T00:00:00Z',
+    statusChangedAt: '2026-06-04T00:00:00Z',
+    narrativeLastConsolidatedAt: null,
+    sections,
+    decisions: [],
+    tasks: [],
+    tags: [],
+  } as unknown as DocWithGraph;
+}
+
+vi.mock('../api/client', () => ({
+  NotFoundError: class NotFoundError extends Error {},
+  fetchDoc: () => Promise.resolve(makeDoc()),
+  fetchDocComments: () => Promise.resolve({ sections: [], decisions: [], tasks: [] }),
+  fetchAcsForBrief: () => Promise.resolve([]),
+  fetchIssues: () => Promise.resolve([]),
+  fetchDocAssignees: () => Promise.resolve([]),
+  archiveDoc: vi.fn(),
+  pauseDoc: vi.fn(),
+  unpauseDoc: vi.fn(),
+  updateDocStatus: vi.fn(),
+  promoteToEditor: vi.fn(),
+  demoteToReviewer: vi.fn(),
+}));
+
+import { DocDocument } from './DocDocument';
+import { HeaderSlotProvider } from '../components/HeaderSlot';
+
+function renderAt(status: DocWithGraph['status']) {
+  docStatus = status;
+  return render(
+    <MemoryRouter initialEntries={['/n/m/specs/spec-260']}>
+      <HeaderSlotProvider>
+        <Routes>
+          <Route path="/:ns/:mx/specs/:id" element={<DocDocument />} />
+        </Routes>
+      </HeaderSlotProvider>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  withReports = true;
+});
+
+describe('spec-260 — QA Report render seats', () => {
+  it('ac-12: Verify front-loads a collapsible QA Report card ABOVE the ACs│Issues columns', async () => {
+    tagAc(AC(12));
+    renderAt('verify');
+
+    const card = await screen.findByTestId('qa-report-card');
+    const acPanel = await screen.findByTestId('ac-panel');
+    expect(screen.getByTestId('issue-panel')).toBeInTheDocument();
+
+    // Front-loaded: the card precedes the two-column area in document order.
+    expect(card.compareDocumentPosition(acPanel) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+
+    // Expanded by default (the cold verifier reads it first) — latest session shows.
+    expect(screen.getByTestId('qa-report-content')).toHaveTextContent('Session TWO report body.');
+
+    // Collapsible: it folds away once read.
+    fireEvent.click(screen.getByTestId('qa-report-toggle'));
+    expect(screen.queryByTestId('qa-report-content')).not.toBeInTheDocument();
+  });
+
+  it('ac-12 (dec-2 display): prior build sessions stay reachable through the version switcher', async () => {
+    tagAc(AC(12));
+    renderAt('verify');
+
+    await screen.findByTestId('qa-report-card');
+    const switcher = screen.getByTestId('qa-report-version-switcher');
+    fireEvent.change(switcher, { target: { value: '1' } }); // index 1 = the older session
+    expect(screen.getByTestId('qa-report-content')).toHaveTextContent('Session ONE report body.');
+  });
+
+  it('ac-12: Build carries a QA Report sub-tab; Tasks│Issues stays the default view', async () => {
+    tagAc(AC(12));
+    renderAt('build');
+
+    // Default tab: the working two-column, no report content.
+    await screen.findByTestId('task-panel');
+    expect(screen.getByTestId('issue-panel')).toBeInTheDocument();
+    expect(screen.queryByTestId('qa-report-content')).not.toBeInTheDocument();
+
+    // The secondary tab reveals the report.
+    fireEvent.click(screen.getByText('QA Report'));
+    expect(screen.getByTestId('qa-report-content')).toHaveTextContent('Session TWO report body.');
+    expect(screen.queryByTestId('task-panel')).not.toBeInTheDocument();
+  });
+
+  it('ac-12: before the first hand-off the Build tab shows a quiet empty state', async () => {
+    tagAc(AC(12));
+    withReports = false;
+    renderAt('build');
+
+    await screen.findByTestId('task-panel');
+    fireEvent.click(screen.getByText('QA Report'));
+    expect(screen.getByTestId('qa-report-empty')).toHaveTextContent(
+      'No QA report yet — generated when build hands off to verify',
+    );
+  });
+
+  it('ac-12: Verify renders no card at all when no report exists (nothing to front-load)', async () => {
+    withReports = false;
+    renderAt('verify');
+    await screen.findByTestId('ac-panel');
+    expect(screen.queryByTestId('qa-report-card')).not.toBeInTheDocument();
+  });
+
+  it('ac-12: qa_report sections are EXCLUDED from the Specify Narrative sub-tab', async () => {
+    tagAc(AC(12));
+    renderAt('specify');
+
+    await screen.findByText('Narrative');
+    await waitFor(() => expect(screen.getAllByTestId('section-card')).toHaveLength(1));
+    // Only the plan-prose section renders as a narrative card; neither qa_report
+    // row leaks in as frozen plan prose.
+    const types = screen
+      .getAllByTestId('section-card')
+      .map((el) => el.getAttribute('data-section-type'));
+    expect(types).toEqual(['overview']);
+  });
+
+  it('ac-11: the report renders read-only — no inline-edit affordance inside the card', async () => {
+    tagAc(AC(11));
+    renderAt('verify');
+
+    const card = await screen.findByTestId('qa-report-card');
+    // No editing surface of any kind inside the card: the only interactive
+    // elements are the collapse toggle and the version switcher.
+    expect(card.querySelector('textarea')).toBeNull();
+    expect(card.querySelector('input')).toBeNull();
+    expect(card.querySelector('[contenteditable="true"]')).toBeNull();
+    const buttons = Array.from(card.querySelectorAll('button')).map(
+      (b) => b.getAttribute('data-testid') ?? '',
+    );
+    expect(buttons).toEqual(['qa-report-toggle']);
+  });
+});

--- a/packages/ui/src/pages/DocDocument.tsx
+++ b/packages/ui/src/pages/DocDocument.tsx
@@ -40,7 +40,9 @@ import {
   toButtonPrompt,
   BASE_SCAFFOLD,
   HANDOFF_BUTTON_BY_PHASE,
+  isQaReportSectionType,
 } from '@memex/shared';
+import { QaReportCard, selectQaReports } from '../components/QaReportCard';
 import { useDocChangeStream } from '../hooks/useDocChangeStream';
 import { COMMENT_PARAM, parseCommentParam, commentAnchorId } from '../utils/commentDeepLink';
 import { phaseDisplayName } from '../utils/phaseDisplay';
@@ -141,8 +143,8 @@ export function DocDocument() {
   // (that's TransitionSentence's [Yes]); it only changes what's shown.
   // `null` defers to the doc's current phase, computed once the doc loads.
   const [selectedTab, setSelectedTab] = useState<PhaseTab | null>(null);
-  // Plan's sub-tab (Narrative / Decisions & ACs / Comments). Build and Verify
-  // have no sub-tabs. A deep-link to a decision/issue/comment picks the relevant
+  // Plan's sub-tab (Narrative / Decisions & ACs / Comments). Verify has no
+  // sub-tabs. A deep-link to a decision/issue/comment picks the relevant
   // landing point below once the doc resolves.
   const [planSubTab, setPlanSubTab] = useState<'narrative' | 'decisions' | 'comments'>(
     initialCommentSeq != null
@@ -151,6 +153,11 @@ export function DocDocument() {
         ? 'decisions'
         : 'narrative',
   );
+  // spec-260 (dec-1): Build's sub-tab — the Tasks │ Issues working view stays
+  // the default; "QA Report" is a secondary tab so the per-session report stays
+  // out of the builder's primary workspace. (An intentional evolution of the
+  // single-view Build layout spec-159/spec-164 set.)
+  const [buildSubTab, setBuildSubTab] = useState<'work' | 'qa-report'>('work');
   // spec-182 issue-3: for EDITORS the Specify review affordances sit behind a
   // collapsed-by-default "Review actions" disclosure — the reviewer workflow
   // shouldn't visually dominate the editor's page. Reviewers see them expanded
@@ -307,6 +314,13 @@ export function DocDocument() {
   const sortedSections = doc
     ? [...doc.sections].sort((a, b) => a.seq - b.seq)
     : [];
+
+  // spec-260 (dec-1): qa_report sections are a build OUTPUT, not plan prose —
+  // they render through the QaReportCard seats (Verify card / Build sub-tab /
+  // Done button) and are excluded from the Specify "Narrative" sub-tab so they
+  // never read as frozen plan intent (ac-12).
+  const qaReports = selectQaReports(sortedSections);
+  const narrativeSections = sortedSections.filter((s) => !isQaReportSectionType(s.sectionType));
 
   // Comment counts (across all entity types)
   const commentCounts: Record<string, number> = {};
@@ -886,7 +900,9 @@ export function DocDocument() {
     'done',
   );
 
-  // Plan's three sub-tabs. Build / Verify carry no sub-tab bar (ac-11).
+  // Plan's three sub-tabs. Verify carries no sub-tab bar; Build gained a
+  // secondary "QA Report" tab in spec-260 (an intentional evolution of
+  // spec-159 ac-11's single-view Build).
   const planSubTabs = [
     /* spec-233 dec-1 (supersedes spec-196 dec-1): the label reads "Narrative".
        Calling this single tab "Spec" misread as if it WERE the whole spec — the
@@ -914,7 +930,8 @@ export function DocDocument() {
             </button>
           </div>
         )}
-        {sortedSections.map((section, index) => (
+        {/* spec-260 ac-12: qa_report sections are excluded — build output, not plan prose. */}
+        {narrativeSections.map((section, index) => (
           <SectionCard
             key={section.id}
             section={section}
@@ -936,7 +953,7 @@ export function DocDocument() {
       <aside className="w-48 shrink-0 hidden lg:block sticky top-4 self-start max-h-[calc(100vh-6rem)] overflow-y-auto">
         <DocOutline
           doc={doc}
-          sections={sortedSections}
+          sections={narrativeSections}
           activeSectionId={selectedSectionId}
           commentCounts={commentCounts}
           onSectionClick={handleSelectSection}
@@ -1101,20 +1118,50 @@ export function DocDocument() {
       ),
     },
     build: {
-      hasSubTabs: false,
-      render: () => twoCol(taskPanel, issuePanel(true), buildDirective),
+      // spec-260 (dec-1): Build gains a tab bar — the Tasks │ Issues two-column
+      // stays the default tab; "QA Report" is a second tab, empty until the
+      // first build→verify hand-off writes one. (Intentional evolution of the
+      // single-view Build layout from spec-159/spec-164.)
+      hasSubTabs: true,
+      render: () => (
+        <>
+          <Tabs
+            tabs={[
+              { id: 'work', label: 'Tasks & Issues' },
+              { id: 'qa-report', label: 'QA Report', count: qaReports.length || undefined },
+            ]}
+            activeTab={buildSubTab}
+            onChange={(t) => setBuildSubTab(t as typeof buildSubTab)}
+            variant="underline"
+          />
+          {buildSubTab === 'work' && twoCol(taskPanel, issuePanel(true), buildDirective)}
+          {buildSubTab === 'qa-report' && (
+            <QaReportCard
+              reports={qaReports}
+              emptyState="No QA report yet — generated when build hands off to verify"
+            />
+          )}
+        </>
+      ),
     },
     verify: {
       hasSubTabs: false,
-      render: () =>
-        twoCol(
-          acPanel,
-          issuePanel(false),
-          <>
-            {verifyDirective}
-            {verifyTaskEcho}
-          </>,
-        ),
+      render: () => (
+        <>
+          {/* spec-260 (dec-1): the QA Report card is front-loaded ABOVE the
+              ACs │ Issues columns so a verifier arriving cold reads it first;
+              collapsible so it folds away once read. */}
+          <QaReportCard reports={qaReports} />
+          {twoCol(
+            acPanel,
+            issuePanel(false),
+            <>
+              {verifyDirective}
+              {verifyTaskEcho}
+            </>,
+          )}
+        </>
+      ),
     },
     // spec-258/dec-3: browsing the Done tab previews the retrospective the move
     // will produce — the same fetch-free DoneSummary, minus Reopen/mutation.

--- a/packages/ui/src/pages/QaReports.spec-260.test.tsx
+++ b/packages/ui/src/pages/QaReports.spec-260.test.tsx
@@ -1,0 +1,176 @@
+// spec-260 t-7 — the QA Reports feed page (dec-5), data hooks stubbed (the
+// Pulse page-test convention). Asserts:
+//   ac-8  : the list renders newest-first with an initial page + Load More.
+//   ac-9  : each row shows WHEN (generation time), WHICH Spec (linked), and
+//           WHO executed the session (std-32 actor).
+//   ac-20 : same row metadata, plus the live-update wiring — the page
+//           subscribes to the SSE bus and refetches when an event lands.
+//   ac-10 : opening the page records the per-user view (the marker upsert the
+//           badge zeroes on); the badge-side maths is covered in
+//           useQaReports.spec-260.test.ts and the server integration tests.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { tagAc } from '@memex-ai-ac/vitest';
+import type { QaReportFeedRow, UseQaReportsFeedResult } from '../hooks/useQaReports';
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-260/acs/ac-${n}`;
+
+const useQaReportsFeedMock = vi.hoisted(() => vi.fn());
+const recordViewMock = vi.hoisted(() => vi.fn());
+vi.mock('../hooks/useQaReports', () => ({
+  useQaReportsFeed: (...a: unknown[]) => useQaReportsFeedMock(...a),
+  recordQaReportsView: (...a: unknown[]) => recordViewMock(...a),
+  QA_REPORTS_VIEWED_EVENT: 'memex:qa-reports-viewed',
+}));
+
+// Capture the SSE subscription so the test can simulate a live event.
+const streamCallbacks = vi.hoisted(() => ({ current: [] as Array<() => void> }));
+vi.mock('../hooks/useDocChangeStream', () => ({
+  useDocChangeStream: (_docId: string | null, onEvent: () => void) => {
+    streamCallbacks.current.push(onEvent);
+  },
+}));
+
+vi.mock('../components/PageHeader', () => ({
+  PageHeader: ({ title }: { title: string }) => <h1>{title}</h1>,
+}));
+
+import { QaReports } from './QaReports';
+
+function row(over: Partial<QaReportFeedRow>): QaReportFeedRow {
+  return {
+    id: 'r-x',
+    docId: 'd-1',
+    docHandle: 'spec-1',
+    docTitle: 'Some Spec',
+    sectionType: 'qa_report',
+    version: 1,
+    title: 'QA Report',
+    content: 'report body',
+    actorName: 'Claude Code',
+    actorKind: 'mcp_agent',
+    channel: 'mcp',
+    createdAt: '2026-06-03T00:00:00Z',
+    ...over,
+  };
+}
+
+const ROWS: QaReportFeedRow[] = [
+  row({
+    id: 'r-3',
+    docHandle: 'spec-9',
+    docTitle: 'Newest Spec',
+    sectionType: 'qa_report-2',
+    version: 2,
+    content: 'NEWEST report body',
+    createdAt: '2026-06-03T00:00:00Z',
+  }),
+  row({
+    id: 'r-2',
+    docHandle: 'spec-4',
+    docTitle: 'Middle Spec',
+    actorName: 'Barrie',
+    actorKind: 'human',
+    channel: 'rest_ui',
+    createdAt: '2026-06-02T00:00:00Z',
+  }),
+  row({ id: 'r-1', docHandle: 'spec-9', docTitle: 'Newest Spec', createdAt: '2026-06-01T00:00:00Z' }),
+];
+
+let feed: UseQaReportsFeedResult;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  streamCallbacks.current = [];
+  feed = {
+    rows: ROWS,
+    loading: false,
+    error: null,
+    hasMore: true,
+    loadOlder: vi.fn().mockResolvedValue(undefined),
+    refresh: vi.fn().mockResolvedValue(undefined),
+  };
+  useQaReportsFeedMock.mockImplementation(() => feed);
+  recordViewMock.mockResolvedValue(undefined);
+});
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={['/acme/main/qa-reports']}>
+      <QaReports />
+    </MemoryRouter>,
+  );
+}
+
+describe('spec-260 — QA Reports feed page', () => {
+  it('ac-8: lists reports newest-first and Load More fetches older entries', () => {
+    tagAc(AC(8));
+    renderPage();
+
+    const rows = screen.getAllByTestId('qa-report-row');
+    expect(rows).toHaveLength(3);
+    // Newest-first: the order the hook returned is preserved.
+    expect(within(rows[0]).getByTestId('qa-report-row-spec')).toHaveTextContent('spec-9');
+    expect(within(rows[1]).getByTestId('qa-report-row-spec')).toHaveTextContent('spec-4');
+
+    // Load More rides the keyset loadOlder.
+    fireEvent.click(screen.getByTestId('qa-reports-load-more'));
+    expect(feed.loadOlder).toHaveBeenCalledTimes(1);
+  });
+
+  it('ac-9/ac-20: each row shows WHEN, WHICH Spec (linked), and WHO executed it', () => {
+    tagAc(AC(9));
+    tagAc(AC(20));
+    renderPage();
+
+    const rows = screen.getAllByTestId('qa-report-row');
+
+    // WHICH — the parent Spec, linked.
+    const specLink = within(rows[0]).getByTestId('qa-report-row-spec');
+    expect(specLink).toHaveTextContent('spec-9 · Newest Spec');
+    expect(specLink.closest('a')).toHaveAttribute('href', expect.stringContaining('/specs/spec-9'));
+
+    // WHEN — the report row's generation time.
+    expect(within(rows[0]).getByTestId('qa-report-row-when')).toHaveTextContent('3 Jun 2026');
+
+    // WHO — the std-32 actor; an mcp_agent executor is labelled as an agent,
+    // a human executor by name.
+    expect(within(rows[0]).getByTestId('qa-report-row-who')).toHaveTextContent('Claude Code (agent)');
+    expect(within(rows[1]).getByTestId('qa-report-row-who')).toHaveTextContent('Barrie');
+
+    // A versioned session is identified.
+    expect(rows[0]).toHaveTextContent('session 2');
+  });
+
+  it('ac-20: the page subscribes to the SSE bus and refetches on a live event', () => {
+    tagAc(AC(20));
+    renderPage();
+
+    // Subscribed to the whole-memex channel.
+    expect(streamCallbacks.current.length).toBeGreaterThan(0);
+    // A live event (a new qa_report section riding the std-8 bus) → refresh.
+    streamCallbacks.current.forEach((cb) => cb());
+    expect(feed.refresh).toHaveBeenCalled();
+  });
+
+  it('ac-10: opening the page records the per-user view (the badge-zeroing marker)', () => {
+    tagAc(AC(10));
+    renderPage();
+    expect(recordViewMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the row body on demand (read-only markdown)', () => {
+    renderPage();
+    const first = screen.getAllByTestId('qa-report-row')[0];
+    fireEvent.click(within(first).getByTestId('qa-report-row-toggle'));
+    expect(within(first).getByTestId('qa-report-row-body')).toHaveTextContent('NEWEST report body');
+  });
+
+  it('shows the quiet empty state when no reports exist', () => {
+    feed = { ...feed, rows: [], hasMore: false };
+    renderPage();
+    expect(screen.getByTestId('qa-reports-empty')).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/pages/QaReports.tsx
+++ b/packages/ui/src/pages/QaReports.tsx
@@ -1,0 +1,138 @@
+// QA Reports — the workspace-wide feed of build-session QA reports (spec-260
+// dec-5/dec-6). A Pulse-style top-level nav page: every `qa_report` section
+// across the memex's Specs, newest-first, an initial page + keyset "Load More",
+// live updates off the std-8 bus. Each row shows WHEN it was generated, WHICH
+// Spec it belongs to (linked), and WHO executed the build session (the std-32
+// actor on the row). Opening the page records the per-user view marker, zeroing
+// the nav badge (count-everything semantics — own-agent reports included).
+
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import { PageHeader } from '../components/PageHeader';
+import {
+  recordQaReportsView,
+  useQaReportsFeed,
+  type QaReportFeedRow,
+} from '../hooks/useQaReports';
+import { useDocChangeStream } from '../hooks/useDocChangeStream';
+import { tenantPath } from '../utils/tenantUrl';
+import { formatDate } from '../utils/format';
+
+const ACTOR_KIND_LABEL: Record<QaReportFeedRow['actorKind'], string> = {
+  human: '',
+  mcp_agent: 'agent',
+  in_app_agent: 'agent',
+  system: 'system',
+};
+
+function executorLabel(row: QaReportFeedRow): string {
+  const name = row.actorName?.trim();
+  const kind = ACTOR_KIND_LABEL[row.actorKind];
+  if (name && kind) return `${name} (${kind})`;
+  if (name) return name;
+  return kind || 'unknown';
+}
+
+function FeedRow({ row }: { row: QaReportFeedRow }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <li
+      data-testid="qa-report-row"
+      className="rounded-xl border border-edge bg-surface p-4"
+    >
+      <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1 text-sm">
+        <Link
+          data-testid="qa-report-row-spec"
+          to={tenantPath(`/specs/${row.docHandle}`)}
+          className="font-medium text-primary hover:underline"
+        >
+          {row.docHandle} · {row.docTitle}
+        </Link>
+        {row.version > 1 && (
+          <span className="text-xs text-muted">session {row.version}</span>
+        )}
+        <span className="ml-auto text-xs text-muted">
+          <span data-testid="qa-report-row-when">{formatDate(row.createdAt)}</span>
+          {' · '}
+          <span data-testid="qa-report-row-who">{executorLabel(row)}</span>
+        </span>
+      </div>
+      <button
+        type="button"
+        data-testid="qa-report-row-toggle"
+        aria-expanded={open}
+        onClick={() => setOpen((v) => !v)}
+        className="mt-2 text-xs text-secondary hover:text-primary"
+      >
+        {open ? 'Hide report' : 'Read report'}
+      </button>
+      {open && (
+        <div data-testid="qa-report-row-body" className="mt-3 prose-dark overflow-hidden">
+          <ReactMarkdown remarkPlugins={[remarkGfm]}>{row.content}</ReactMarkdown>
+        </div>
+      )}
+    </li>
+  );
+}
+
+export function QaReports() {
+  const { rows, loading, error, hasMore, loadOlder, refresh } = useQaReportsFeed();
+
+  // Opening the page = viewing the feed: upsert the per-user marker (dec-6),
+  // which zeroes the nav badge.
+  useEffect(() => {
+    void recordQaReportsView();
+  }, []);
+
+  // Live updates: a new report lands on the std-8 bus as a section event —
+  // refetch the first page so it appears without a reload (debounced upstream).
+  useDocChangeStream(null, refresh);
+
+  return (
+    <div className="px-6 py-4 max-w-3xl">
+      <PageHeader title="QA Reports" />
+      <p className="text-sm text-muted mb-4">
+        What each build session changed, written for a reviewer — one report per
+        session, newest first.
+      </p>
+
+      {error && (
+        <div data-testid="qa-reports-error" className="text-sm text-status-danger-text mb-4">
+          {error}
+        </div>
+      )}
+
+      {loading && rows.length === 0 ? (
+        <div data-testid="qa-reports-loading" className="text-sm text-muted py-8 text-center">
+          Loading…
+        </div>
+      ) : rows.length === 0 ? (
+        <div data-testid="qa-reports-empty" className="text-sm text-muted py-8 text-center">
+          No QA reports yet — one is generated each time a build session hands off to
+          verify.
+        </div>
+      ) : (
+        <ul data-testid="qa-reports-list" className="space-y-3">
+          {rows.map((row) => (
+            <FeedRow key={row.id} row={row} />
+          ))}
+        </ul>
+      )}
+
+      {hasMore && (
+        <div className="mt-4 text-center">
+          <button
+            type="button"
+            data-testid="qa-reports-load-more"
+            onClick={() => void loadOlder()}
+            className="text-sm text-secondary hover:text-primary px-3 py-1.5 rounded-md border border-edge hover:bg-overlay"
+          >
+            Load More
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## What

Realises **spec-260**: when a build session hands off to verify, the agent's closing summary persists as a versioned **QA Report** on the Spec — a human-readable record of what the session actually changed — and every report is aggregated into a workspace **QA Reports** feed with a per-user unread badge.

https://memex.ai/mindset-prod/memex-building-itself/specs/spec-260

### The per-Spec artifact
- `appendQaReport` service + **`write_qa_report` MCP tool** (contract in the `@memex/shared` manifest per std-16). Version keys are computed server-side (`qa_report`, `qa_report-2`, …) so a session can never overwrite a prior report; writes ride `addSection → mutate()` (std-32 actor stamped, std-8 bus emitted).
- The **build hand-off prompt gains STEP 6** (`opening-build-handoff`): persist the closing summary via `write_qa_report` — grounding in the session's real changes is mandatory; VCS-agnostic per std-22 (`QA_REPORT_GENERATION_INSTRUCTION`, exported + tested).
- **Three read-only render seats**: front-loaded collapsible card (+ session switcher) in Verify, a "QA Report" sub-tab in Build (quiet empty state pre-hand-off), a gated button on Done. Excluded from the Specify Narrative.

### The workspace feed
- `GET/POST /api/:ns/:mx/qa-reports[/unread|/view]` mirroring the `/activity` conventions (keyset `since` pagination, std-7 404 posture, anonymous PII projection).
- New **QA Reports** nav page (hiddenFeatures-gated, slug `qa-reports`) — newest-first rows showing when / which Spec (linked) / who executed, Load More, live SSE.
- **Per-user unread badge** backed by the only net-new schema: `qa_report_views(user_id, memex_id, last_viewed_at)` (migration `0092`, forced RLS `memex_isolation`). Count-everything semantics; viewing zeroes it.

### Nav regroup (owner-requested)
Sidebar is now **PRINCIPLES** (Specs, Pulse, Standards, Insights, Scaffold) + **IN-BOXES** (Drift, Issues, QA Reports — the badge-carrying surfaces).

### Fixes found en route
- **HeaderSlot unbounded render loop** on every page using `useHeaderSlot` (fresh context value per render + inline-JSX effect dep → setContent feedback loop; ~1,133 renders/500ms measured, 2 after). Fixed with split setter/content contexts. (spec-260 issue-1)
- `provision_ac_emission` manifest summary breached the b-67 ≤240-char bound (red on develop). (spec-234 issue-1)

## Testing

- **17/23 ACs verified by tagged emission** (the rest are declared manual/report-content acceptances for verify-phase sign-off; the real generated reports live on spec-260 itself).
- Server `make test`: 384 files / 3,936 tests green (incl. RLS isolation, keyset pagination, unread math, mutate-coverage/ref-emission/tool-audit guards for the new tool).
- UI: 162 files / 1,236 tests green. Shared: 674 green.
- **Playwright journey-29** [per std-28] covers both flows — green on the dev DB and `make e2e-cold`.

## Deploy notes

- Migration `0092_qa_report_views.sql` applies via the standard `db:migrate` path; no backfill.
- Add `qa-reports` to `HIDDEN_FEATURES` on any env that shouldn't show the page yet (fail-open otherwise).

🤖 Generated with [Claude Code](https://claude.com/claude-code)