### PR TITLE
feat(qa-report): unread feed rows render expanded; read rows collapsed (spec-260 ac-24)

### DIFF
--- a/packages/server/src/routes/qa-reports.integration.test.ts
+++ b/packages/server/src/routes/qa-reports.integration.test.ts
@@ -25,6 +25,7 @@ import { upsertUserByEmail } from "../services/users.js";
 
 const AC_19 = "mindset-prod/memex-building-itself/specs/spec-260/acs/ac-19";
 const AC_22 = "mindset-prod/memex-building-itself/specs/spec-260/acs/ac-22";
+const AC_24 = "mindset-prod/memex-building-itself/specs/spec-260/acs/ac-24";
 
 type FeedRow = {
   id: string;
@@ -189,15 +190,24 @@ describe("GET /api/<ns>/<mx>/qa-reports (workspace feed — dec-5)", () => {
 describe("unread counter + view marker (dec-6)", () => {
   it("ac-22: unread counts ALL reports newer than the marker (no marker → all), and viewing zeroes it", async () => {
     tagAc(AC_22);
+    tagAc(AC_24);
 
     // Never viewed → every report in the memex counts (3 in memex A).
     const before = await app.request(`${pathA}/qa-reports/unread`, withApexHost());
     expect(before.status).toBe(200);
     expect(await before.json()).toEqual({ count: 3 });
 
-    // Viewing the feed upserts last_viewed_at = now() → badge zeroes.
+    // Viewing the feed upserts last_viewed_at = now() → badge zeroes. The
+    // receipt carries the PREVIOUS marker (ac-24): null on first-ever view —
+    // the unread boundary the feed page uses to render unread rows expanded.
     const view = await app.request(`${pathA}/qa-reports/view`, withApexHost({ method: "POST" }));
     expect(view.status).toBe(200);
+    const firstReceipt = (await view.json()) as {
+      lastViewedAt: string;
+      previousLastViewedAt: string | null;
+    };
+    expect(firstReceipt.previousLastViewedAt).toBeNull();
+    expect(new Date(firstReceipt.lastViewedAt).getTime()).toBeGreaterThan(0);
 
     const after = await app.request(`${pathA}/qa-reports/unread`, withApexHost());
     expect(await after.json()).toEqual({ count: 0 });
@@ -214,9 +224,16 @@ describe("unread counter + view marker (dec-6)", () => {
     const grown = await app.request(`${pathA}/qa-reports/unread`, withApexHost());
     expect(await grown.json()).toEqual({ count: 1 });
 
-    // Re-viewing resets again (the upsert path, not a second insert).
+    // Re-viewing resets again (the upsert path, not a second insert) — and the
+    // receipt now carries the FIRST view's marker as the previous boundary
+    // (ac-24): a row created after it classifies as unread, one before it as read.
     const reView = await app.request(`${pathA}/qa-reports/view`, withApexHost({ method: "POST" }));
     expect(reView.status).toBe(200);
+    const secondReceipt = (await reView.json()) as {
+      lastViewedAt: string;
+      previousLastViewedAt: string | null;
+    };
+    expect(secondReceipt.previousLastViewedAt).toBe(firstReceipt.lastViewedAt);
     const zeroed = await app.request(`${pathA}/qa-reports/unread`, withApexHost());
     expect(await zeroed.json()).toEqual({ count: 0 });
   });

--- a/packages/server/src/routes/qa-reports.ts
+++ b/packages/server/src/routes/qa-reports.ts
@@ -90,13 +90,17 @@ qaReports.get("/unread", async (c) => {
 
 // POST /api/<ns>/<mx>/qa-reports/view — "I viewed the feed now". Strict session
 // (anonymous callers never reach here); the memex must be readable by the caller
-// (std-7 → 404 otherwise).
+// (std-7 → 404 otherwise). Returns the PREVIOUS marker too (null on first view)
+// — the unread boundary the page uses to render unread rows expanded (ac-24).
 qaReports.post("/view", async (c) => {
   const memexId = await resolveReadableMemexId(c);
   const userId = (c.get("currentUserId") as string | null) ?? null;
   if (!userId) throw new NotFoundError("Not found");
-  const lastViewedAt = await recordQaReportsView(memexId, userId);
-  return c.json({ lastViewedAt: lastViewedAt.toISOString() });
+  const receipt = await recordQaReportsView(memexId, userId);
+  return c.json({
+    lastViewedAt: receipt.lastViewedAt.toISOString(),
+    previousLastViewedAt: receipt.previousLastViewedAt?.toISOString() ?? null,
+  });
 });
 
 export { qaReports };

--- a/packages/server/src/services/qa-reports.ts
+++ b/packages/server/src/services/qa-reports.ts
@@ -195,9 +195,22 @@ export async function countUnreadQaReports(memexId: string, userId: string): Pro
   return row?.count ?? 0;
 }
 
+export interface QaReportsViewReceipt {
+  /** The marker just written — "now". */
+  lastViewedAt: Date;
+  /**
+   * The marker BEFORE this view, or null on first-ever view. This is the
+   * unread boundary the badge was counting against, returned so the feed page
+   * can render unread rows expanded (ac-24) even though opening the page is
+   * exactly what resets the marker.
+   */
+  previousLastViewedAt: Date | null;
+}
+
 /**
  * Record that `userId` viewed the memex's QA Reports feed NOW — upserts the
- * (user, memex) marker, zeroing the unread badge. Returns the new marker time.
+ * (user, memex) marker, zeroing the unread badge — and returns the PREVIOUS
+ * marker alongside, so the caller can still classify what was unread.
  *
  * Goes through mutate() per std-8, but SILENT: the marker is per-user
  * read-state (an idempotent re-write of "when did I last look"), not
@@ -205,8 +218,15 @@ export async function countUnreadQaReports(memexId: string, userId: string): Pro
  * badge's own zeroing is client-local (the page that posted the view already
  * knows). std-32's activity columns don't apply to this table by design.
  */
-export async function recordQaReportsView(memexId: string, userId: string): Promise<Date> {
+export async function recordQaReportsView(
+  memexId: string,
+  userId: string,
+): Promise<QaReportsViewReceipt> {
   const now = new Date();
+  const [prior] = await db
+    .select({ lastViewedAt: qaReportViews.lastViewedAt })
+    .from(qaReportViews)
+    .where(and(eq(qaReportViews.userId, userId), eq(qaReportViews.memexId, memexId)));
   await mutate(
     {},
     { memexId, entity: "qa_report_view", action: "updated" },
@@ -220,5 +240,5 @@ export async function recordQaReportsView(memexId: string, userId: string): Prom
         }),
     { silent: true },
   );
-  return now;
+  return { lastViewedAt: now, previousLastViewedAt: prior?.lastViewedAt ?? null };
 }

--- a/packages/ui/e2e/journey-29-spec-260-qa-reports.spec.ts
+++ b/packages/ui/e2e/journey-29-spec-260-qa-reports.spec.ts
@@ -38,6 +38,7 @@ const ACS_BY_TITLE: Record<string, string[]> = {
     AC(8),
     AC(9),
     AC(10),
+    AC(24),
   ],
 };
 
@@ -193,16 +194,31 @@ test.describe("spec-260 — Build QA Report", () => {
       new RegExp(`/specs/${specB.handle}$`),
     );
 
-    // The report body opens on demand.
-    await rows.nth(0).getByTestId("qa-report-row-toggle").click();
+    // ac-24: a first-ever view has no previous marker → EVERY row is unread and
+    // arrives expanded, no click needed.
     await expect(rows.nth(0).getByTestId("qa-report-row-body")).toContainText(
       "Beta build session report.",
+    );
+    await expect(rows.nth(1).getByTestId("qa-report-row-body")).toContainText(
+      "Alpha build session report.",
     );
 
     // ── Viewing the feed zeroed the badge (count-everything → 0 after view). ──
     await page.goto(tenantPath(tenant.namespaceSlug, tenant.memexSlug, "/specs"));
     await expect(page.getByRole("link", { name: "QA Reports" })).toBeVisible({ timeout: 15_000 });
     await expect(page.getByTestId("qa-reports-nav-badge")).toHaveCount(0);
+
+    // ac-24: revisiting — both reports are now READ → they render collapsed.
+    await page.getByRole("link", { name: "QA Reports" }).click();
+    const readRows = page.getByTestId("qa-report-row");
+    await expect(readRows).toHaveCount(2, { timeout: 15_000 });
+    await expect(readRows.nth(0).getByTestId("qa-report-row-body")).toHaveCount(0);
+    await expect(readRows.nth(1).getByTestId("qa-report-row-body")).toHaveCount(0);
+    // The toggle still opens a read row on demand.
+    await readRows.nth(0).getByTestId("qa-report-row-toggle").click();
+    await expect(readRows.nth(0).getByTestId("qa-report-row-body")).toContainText(
+      "Beta build session report.",
+    );
 
     // A THIRD report lands (a new build session elsewhere) → the badge returns.
     await seedSection({
@@ -214,5 +230,15 @@ test.describe("spec-260 — Build QA Report", () => {
     });
     await page.goto(tenantPath(tenant.namespaceSlug, tenant.memexSlug, "/specs"));
     await expect(page.getByTestId("qa-reports-nav-badge")).toHaveText("1", { timeout: 15_000 });
+
+    // ac-24: only the NEW report is unread → it alone arrives expanded.
+    await page.getByRole("link", { name: "QA Reports" }).click();
+    const mixedRows = page.getByTestId("qa-report-row");
+    await expect(mixedRows).toHaveCount(3, { timeout: 15_000 });
+    await expect(mixedRows.nth(0).getByTestId("qa-report-row-body")).toContainText(
+      "Alpha session two report.",
+    );
+    await expect(mixedRows.nth(1).getByTestId("qa-report-row-body")).toHaveCount(0);
+    await expect(mixedRows.nth(2).getByTestId("qa-report-row-body")).toHaveCount(0);
   });
 });

--- a/packages/ui/src/hooks/useQaReports.spec-260.test.tsx
+++ b/packages/ui/src/hooks/useQaReports.spec-260.test.tsx
@@ -86,18 +86,54 @@ describe('useQaReportsUnreadCount (dec-6 badge)', () => {
 });
 
 describe('recordQaReportsView', () => {
-  it('ac-10: POSTs the view marker and broadcasts the zeroing event', async () => {
+  it('ac-10/ac-24: POSTs the view marker, broadcasts the zeroing event, and returns the receipt with the PREVIOUS marker', async () => {
     tagAc(AC(10));
-    fetchMock.mockResolvedValue(jsonResponse({ lastViewedAt: '2026-06-12T00:00:00Z' }));
+    tagAc(AC(24));
+    fetchMock.mockResolvedValue(
+      jsonResponse({
+        lastViewedAt: '2026-06-12T00:00:00Z',
+        previousLastViewedAt: '2026-06-10T00:00:00Z',
+      }),
+    );
     const heard = vi.fn();
     window.addEventListener(QA_REPORTS_VIEWED_EVENT, heard);
     try {
-      await recordQaReportsView();
+      const receipt = await recordQaReportsView();
       expect(fetchMock).toHaveBeenCalledWith('/api/acme/main/qa-reports/view', { method: 'POST' });
       expect(heard).toHaveBeenCalledTimes(1);
+      // ac-24: the previous marker is the unread boundary the feed page uses
+      // to render unread rows expanded.
+      expect(receipt).toEqual({
+        lastViewedAt: '2026-06-12T00:00:00Z',
+        previousLastViewedAt: '2026-06-10T00:00:00Z',
+      });
     } finally {
       window.removeEventListener(QA_REPORTS_VIEWED_EVENT, heard);
     }
+  });
+
+  it('returns null on a failed write — the page falls back to collapsed rows', async () => {
+    fetchMock.mockRejectedValue(new Error('boom'));
+    expect(await recordQaReportsView()).toBeNull();
+  });
+
+  it('ac-24: concurrent calls share one POST — StrictMode double-mount cannot burn the previous marker', async () => {
+    tagAc(AC(24));
+    // If the double-mounted effect fired two posts, the second would see the
+    // first's just-written marker as "previous" and collapse everything.
+    let resolveFetch!: (r: Response) => void;
+    fetchMock.mockReturnValue(new Promise<Response>((r) => (resolveFetch = r)));
+
+    const first = recordQaReportsView();
+    const second = recordQaReportsView();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    resolveFetch(
+      jsonResponse({ lastViewedAt: '2026-06-12T00:00:00Z', previousLastViewedAt: null }),
+    );
+    const [a, b] = await Promise.all([first, second]);
+    expect(a).toEqual(b);
+    expect(a?.previousLastViewedAt).toBeNull();
   });
 });
 

--- a/packages/ui/src/hooks/useQaReports.ts
+++ b/packages/ui/src/hooks/useQaReports.ts
@@ -118,20 +118,51 @@ export function useQaReportsFeed(limit = DEFAULT_LIMIT): UseQaReportsFeedResult 
   return { rows, loading, error, hasMore, loadOlder, refresh };
 }
 
+export interface QaReportsViewReceipt {
+  /** The marker just written. */
+  lastViewedAt: string;
+  /**
+   * The marker BEFORE this view (null = first-ever view). This is the unread
+   * boundary the badge was counting against — returned because opening the
+   * page is exactly what resets the marker, so the page couldn't otherwise
+   * know which rows were unread (ac-24).
+   */
+  previousLastViewedAt: string | null;
+}
+
+// One view-POST at a time. React StrictMode double-mounts effects in dev, so
+// the page would otherwise fire TWO immediate POSTs — and the second receipt's
+// "previous" marker would be the first POST's just-written now(), classifying
+// every row as read and collapsing the lot (ac-24). Concurrent callers share
+// the in-flight call; it clears on settle so a later real revisit POSTs fresh.
+let viewInFlight: Promise<QaReportsViewReceipt | null> | null = null;
+
 /**
  * Record that the current user viewed the QA Reports feed now. Upserts the
- * per-(user, memex) last_viewed_at marker server-side and broadcasts
- * QA_REPORTS_VIEWED_EVENT so the nav badge zeroes immediately.
+ * per-(user, memex) last_viewed_at marker server-side, broadcasts
+ * QA_REPORTS_VIEWED_EVENT so the nav badge zeroes immediately, and returns the
+ * view receipt (incl. the PREVIOUS marker). Returns null when the marker can't
+ * be written (no tenant context, anonymous viewer, network failure) — the
+ * caller falls back to collapsed rows.
  */
-export async function recordQaReportsView(): Promise<void> {
-  const base = tenantBase();
-  if (!base) return;
-  try {
-    const res = await fetchWithRetry(`${base}/qa-reports/view`, { method: 'POST' });
-    if (res.ok) window.dispatchEvent(new Event(QA_REPORTS_VIEWED_EVENT));
-  } catch {
-    // Best-effort: a failed marker write leaves the badge stale, never breaks the page.
-  }
+export function recordQaReportsView(): Promise<QaReportsViewReceipt | null> {
+  if (viewInFlight) return viewInFlight;
+  viewInFlight = (async () => {
+    const base = tenantBase();
+    if (!base) return null;
+    try {
+      const res = await fetchWithRetry(`${base}/qa-reports/view`, { method: 'POST' });
+      if (!res.ok) return null;
+      window.dispatchEvent(new Event(QA_REPORTS_VIEWED_EVENT));
+      return (await res.json()) as QaReportsViewReceipt;
+    } catch {
+      // Best-effort: a failed marker write leaves the badge stale, never breaks the page.
+      return null;
+    } finally {
+      viewInFlight = null;
+    }
+  })();
+  return viewInFlight;
 }
 
 /**

--- a/packages/ui/src/pages/QaReports.spec-260.test.tsx
+++ b/packages/ui/src/pages/QaReports.spec-260.test.tsx
@@ -93,7 +93,9 @@ beforeEach(() => {
     refresh: vi.fn().mockResolvedValue(undefined),
   };
   useQaReportsFeedMock.mockImplementation(() => feed);
-  recordViewMock.mockResolvedValue(undefined);
+  // Default: marker unavailable → all rows collapsed; the ac-24 tests
+  // override with a real receipt.
+  recordViewMock.mockResolvedValue(null);
 });
 
 function renderPage() {
@@ -105,11 +107,11 @@ function renderPage() {
 }
 
 describe('spec-260 — QA Reports feed page', () => {
-  it('ac-8: lists reports newest-first and Load More fetches older entries', () => {
+  it('ac-8: lists reports newest-first and Load More fetches older entries', async () => {
     tagAc(AC(8));
     renderPage();
 
-    const rows = screen.getAllByTestId('qa-report-row');
+    const rows = await screen.findAllByTestId('qa-report-row');
     expect(rows).toHaveLength(3);
     // Newest-first: the order the hook returned is preserved.
     expect(within(rows[0]).getByTestId('qa-report-row-spec')).toHaveTextContent('spec-9');
@@ -120,12 +122,12 @@ describe('spec-260 — QA Reports feed page', () => {
     expect(feed.loadOlder).toHaveBeenCalledTimes(1);
   });
 
-  it('ac-9/ac-20: each row shows WHEN, WHICH Spec (linked), and WHO executed it', () => {
+  it('ac-9/ac-20: each row shows WHEN, WHICH Spec (linked), and WHO executed it', async () => {
     tagAc(AC(9));
     tagAc(AC(20));
     renderPage();
 
-    const rows = screen.getAllByTestId('qa-report-row');
+    const rows = await screen.findAllByTestId('qa-report-row');
 
     // WHICH — the parent Spec, linked.
     const specLink = within(rows[0]).getByTestId('qa-report-row-spec');
@@ -161,16 +163,68 @@ describe('spec-260 — QA Reports feed page', () => {
     expect(recordViewMock).toHaveBeenCalledTimes(1);
   });
 
-  it('renders the row body on demand (read-only markdown)', () => {
+  it('renders the row body on demand (read-only markdown)', async () => {
     renderPage();
-    const first = screen.getAllByTestId('qa-report-row')[0];
+    const first = (await screen.findAllByTestId('qa-report-row'))[0];
     fireEvent.click(within(first).getByTestId('qa-report-row-toggle'));
     expect(within(first).getByTestId('qa-report-row-body')).toHaveTextContent('NEWEST report body');
   });
 
-  it('shows the quiet empty state when no reports exist', () => {
+  it('shows the quiet empty state when no reports exist', async () => {
     feed = { ...feed, rows: [], hasMore: false };
     renderPage();
-    expect(screen.getByTestId('qa-reports-empty')).toBeInTheDocument();
+    expect(await screen.findByTestId('qa-reports-empty')).toBeInTheDocument();
+  });
+
+  // ── ac-24: unread rows open, read rows closed ────────────────────────────
+  // The unread boundary is the PREVIOUS last_viewed_at from the view receipt
+  // (opening the page resets the marker, so the receipt is the only place the
+  // old value survives). Fixture times: r-3 = 03 Jun, r-2 = 02 Jun, r-1 = 01 Jun.
+
+  it('ac-24: rows newer than the previous marker render expanded; read rows collapsed', async () => {
+    tagAc(AC(24));
+    recordViewMock.mockResolvedValue({
+      lastViewedAt: '2026-06-12T00:00:00Z',
+      previousLastViewedAt: '2026-06-01T12:00:00Z', // after r-1, before r-2/r-3
+    });
+    renderPage();
+
+    const rows = await screen.findAllByTestId('qa-report-row');
+    // Unread (r-3, r-2): expanded on arrival.
+    expect(within(rows[0]).getByTestId('qa-report-row-body')).toHaveTextContent(
+      'NEWEST report body',
+    );
+    expect(within(rows[1]).queryByTestId('qa-report-row-body')).toBeInTheDocument();
+    // Read (r-1): collapsed.
+    expect(within(rows[2]).queryByTestId('qa-report-row-body')).not.toBeInTheDocument();
+
+    // The user's own toggle still wins: collapsing an unread row works.
+    fireEvent.click(within(rows[0]).getByTestId('qa-report-row-toggle'));
+    expect(within(rows[0]).queryByTestId('qa-report-row-body')).not.toBeInTheDocument();
+  });
+
+  it('ac-24: first-ever view (no previous marker) → every row is unread and expanded', async () => {
+    tagAc(AC(24));
+    recordViewMock.mockResolvedValue({
+      lastViewedAt: '2026-06-12T00:00:00Z',
+      previousLastViewedAt: null,
+    });
+    renderPage();
+
+    const rows = await screen.findAllByTestId('qa-report-row');
+    for (const row of rows) {
+      expect(within(row).queryByTestId('qa-report-row-body')).toBeInTheDocument();
+    }
+  });
+
+  it('ac-24: marker unavailable (anonymous / failed write) → all rows collapsed', async () => {
+    tagAc(AC(24));
+    recordViewMock.mockResolvedValue(null);
+    renderPage();
+
+    const rows = await screen.findAllByTestId('qa-report-row');
+    for (const row of rows) {
+      expect(within(row).queryByTestId('qa-report-row-body')).not.toBeInTheDocument();
+    }
   });
 });

--- a/packages/ui/src/pages/QaReports.tsx
+++ b/packages/ui/src/pages/QaReports.tsx
@@ -35,8 +35,10 @@ function executorLabel(row: QaReportFeedRow): string {
   return kind || 'unknown';
 }
 
-function FeedRow({ row }: { row: QaReportFeedRow }) {
-  const [open, setOpen] = useState(false);
+function FeedRow({ row, defaultOpen = false }: { row: QaReportFeedRow; defaultOpen?: boolean }) {
+  // ac-24: unread rows arrive expanded; read rows collapsed. Initial state
+  // only — the user's own toggling always wins afterwards.
+  const [open, setOpen] = useState(defaultOpen);
   return (
     <li
       data-testid="qa-report-row"
@@ -80,11 +82,37 @@ function FeedRow({ row }: { row: QaReportFeedRow }) {
 export function QaReports() {
   const { rows, loading, error, hasMore, loadOlder, refresh } = useQaReportsFeed();
 
+  // ac-24: the unread boundary — the viewer's PREVIOUS last_viewed_at, captured
+  // from the view receipt (opening the page is what resets the marker, so the
+  // receipt is the only place the old value survives).
+  //   undefined        → receipt still in flight (hold the list so rows don't
+  //                      initialise collapsed and then refuse to open)
+  //   { prev: null }   → first-ever view: everything is unread → all open
+  //   { prev: ISO }    → rows newer than it are unread → open
+  //   { prev: 'all' }  → marker unavailable (anonymous / failure): no per-user
+  //                      unread concept → all collapsed
+  const [boundary, setBoundary] = useState<{ prev: string | null | 'all' } | undefined>(undefined);
+
   // Opening the page = viewing the feed: upsert the per-user marker (dec-6),
-  // which zeroes the nav badge.
+  // which zeroes the nav badge, and keep its receipt as the unread boundary.
   useEffect(() => {
-    void recordQaReportsView();
+    let cancelled = false;
+    void recordQaReportsView().then((receipt) => {
+      if (cancelled) return;
+      setBoundary(receipt ? { prev: receipt.previousLastViewedAt } : { prev: 'all' });
+    });
+    return () => {
+      cancelled = true;
+    };
   }, []);
+
+  // Both ISO-8601 UTC strings from the same serializer, so lexicographic
+  // comparison is chronological.
+  const isUnread = (row: QaReportFeedRow): boolean => {
+    if (!boundary || boundary.prev === 'all') return false;
+    if (boundary.prev === null) return true;
+    return row.createdAt > boundary.prev;
+  };
 
   // Live updates: a new report lands on the std-8 bus as a section event —
   // refetch the first page so it appears without a reload (debounced upstream).
@@ -104,7 +132,7 @@ export function QaReports() {
         </div>
       )}
 
-      {loading && rows.length === 0 ? (
+      {(loading && rows.length === 0) || boundary === undefined ? (
         <div data-testid="qa-reports-loading" className="text-sm text-muted py-8 text-center">
           Loading…
         </div>
@@ -116,7 +144,7 @@ export function QaReports() {
       ) : (
         <ul data-testid="qa-reports-list" className="space-y-3">
           {rows.map((row) => (
-            <FeedRow key={row.id} row={row} />
+            <FeedRow key={row.id} row={row} defaultOpen={isUnread(row)} />
           ))}
         </ul>
       )}


### PR DESCRIPTION
## What

Owner enhancement after using the live QA Reports feed: rows you haven't read should arrive **open**; rows you've already read should arrive **collapsed**. Previously everything rendered collapsed.

## How

- **`POST /qa-reports/view` now returns the previous `last_viewed_at`** alongside the new marker. Opening the page is exactly what resets the marker, so the view receipt is the only place the unread boundary survives.
- The feed page holds the list until the receipt lands, then renders rows **newer than the previous marker expanded** — the same boundary the unread badge counts:
  - first-ever view (no marker) → everything is unread → all open
  - anonymous viewer / failed marker write → no per-user unread concept → all collapsed
  - the user's own toggling always wins afterwards
- **StrictMode guard:** `recordQaReportsView` dedupes concurrent calls — React dev double-mounts effects, and a second immediate POST would see the first's just-written `now()` as "previous" and collapse everything (caught by the cold-DB journey run).

## Testing

- New implementation AC **ac-24** (parent dec-6), green via tagged tests at three tiers:
  - server integration: the receipt carries `null` on first view, then the prior marker on re-view
  - UI unit: boundary classification (unread open / read closed / first-view all open / unavailable all closed), toggle-still-wins, in-flight dedupe
  - **journey-29 extended** (cold DB green): first visit arrives expanded, revisit collapsed, a post-view report arrives expanded alone
- Full suites green: server 3,936 · UI 1,241 · production build gates pass.

No schema or deploy steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)