### PR TITLE
fix(rls): NO FORCE on tenant tables — restore owner-bypass for deploy/migration role (spec-257)

### DIFF
--- a/packages/server/drizzle/0093_rls_no_force_owner_bypass.sql
+++ b/packages/server/drizzle/0093_rls_no_force_owner_bypass.sql
@@ -1,0 +1,68 @@
+-- spec-257 dec-1: drop FORCE on every tenant table — restore owner-bypass.
+--
+-- WHAT THIS CHANGES
+--   For each FORCE'd tenant table: ALTER TABLE ... NO FORCE ROW LEVEL SECURITY.
+--   RLS stays ENABLED and every memex_id isolation policy (0081/0086) stays in
+--   place. The ONLY change is removing FORCE.
+--
+-- WHY (the posture, settled in spec-257 dec-1 on verified grounding)
+--   Postgres RLS does not apply to a table's OWNER unless FORCE is set. On
+--   Cloud SQL the deploy/migration role connects as `postgres`, which — verified
+--   read-only on prod AND int 2026-06-11 — is NOT a superuser and does NOT hold
+--   BYPASSRLS (rolsuper=f, rolbypassrls=f). It owns all of these tables. So
+--   migration 0081's ENABLE+FORCE made RLS apply to the owner too, and every
+--   query the owner runs WITHOUT an app.memex_id GUC is filtered to zero rows.
+--
+--   Two production outages came from this single false assumption that the
+--   "superuser" deploy path bypasses RLS:
+--     * 2026-06-10 — emission outage: 0081's FORCE policy on memex_emission_keys
+--       filtered verifyEmissionKey() to 0 rows once the runtime cut to memex_app
+--       (fixed by 0087, which fully excluded that identity table).
+--     * 2026-06-11 — What's New ribbon dark on prod: deploy.sh step 1f
+--       (db:generate-whats-new) runs as `postgres` and read `documents` with no
+--       GUC → "judged 0 of 0 shippable specs" against ~70 eligible. Three sibling
+--       deploy scripts (1c handhold-demo, 1d default-standards, 1e guide-content)
+--       were silently failing the same way behind their `|| echo` wrappers.
+--
+--   NO FORCE puts RLS at the correct trust boundary:
+--     * `postgres` (table OWNER, the migration/admin/deploy identity) bypasses
+--       RLS as owner — so all migrations and deploy scripts work with no
+--       per-script changes. Granting BYPASSRLS instead is impossible on Cloud SQL
+--       (no superuser to grant it); wrapping every script in runWithMemexId was
+--       rejected as fragile (spec-257 dec-1 options B/C).
+--     * `memex_app` (runtime role, non-owner, NOBYPASSRLS — verified) remains
+--       SUBJECT to RLS, so runtime tenant isolation is unchanged. Confirm via the
+--       spec-199 cross-tenant regression tests run under the memex_app role.
+--
+-- LOAD-BEARING INVARIANT (spec-257 dec-1 caveat / Standard ac-5)
+--   This is safe ONLY while the runtime never connects as the owner role. RLS
+--   silently stops firing for any runtime path pointed at postgres/DB_USER
+--   credentials. The deploy split already enforces this (RUNTIME_DB_USER=memex_app
+--   vs DB_USER=postgres in deploy.sh); spec-257 dec-3 adds a structural guard.
+--
+-- Tables below = every table FORCE'd on develop as of 2026-06-12. The 14
+-- currently-FORCE'd tables on prod were verified by read-only query
+-- (relforcerowsecurity=true) 2026-06-11; `qa_report_views` was added with
+-- ENABLE+FORCE by 0092 (spec-260) AFTER that query and is included here — files
+-- run 0092→0093 in order, so the table exists by the time this applies.
+-- (`memex_emission_keys` already excluded by 0087; `activity_log` never FORCE'd.)
+--
+-- NOTE: spec-260's 0092 reintroduced the FORCE pattern days after the outages it
+-- causes — nothing prevented it. spec-257 dec-3 (a structural lint/CI guard) and
+-- ac-5 (the Standard) are what stop the next one; this migration only cleans up
+-- the 15 that exist today.
+ALTER TABLE acs             NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE clause_refs     NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE decisions       NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE doc_assignees   NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE doc_comments    NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE doc_members     NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE document_tags   NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE documents       NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE issues          NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE presence        NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE qa_report_views NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE repos           NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE standard_clauses NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE tags            NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE tasks           NO FORCE ROW LEVEL SECURITY;

--- a/packages/server/drizzle/reverts/0093_rls_no_force_owner_bypass.revert.sql
+++ b/packages/server/drizzle/reverts/0093_rls_no_force_owner_bypass.revert.sql
@@ -1,0 +1,23 @@
+-- Revert spec-257 dec-1: re-apply FORCE ROW LEVEL SECURITY on every tenant table.
+--
+-- WARNING: re-applying FORCE re-introduces the 2026-06-10 / 2026-06-11 outage
+-- class — the deploy/migration role (`postgres`, NOBYPASSRLS on Cloud SQL) will
+-- again be filtered to zero rows on any query without an app.memex_id GUC, so
+-- migrations and deploy scripts 1c/1d/1e/1f silently break. Only revert if the
+-- runtime/deploy role topology has changed such that the owner can bypass another
+-- way. See 0091_rls_no_force_owner_bypass.sql and spec-257 dec-1.
+ALTER TABLE acs             FORCE ROW LEVEL SECURITY;
+ALTER TABLE clause_refs     FORCE ROW LEVEL SECURITY;
+ALTER TABLE decisions       FORCE ROW LEVEL SECURITY;
+ALTER TABLE doc_assignees   FORCE ROW LEVEL SECURITY;
+ALTER TABLE doc_comments    FORCE ROW LEVEL SECURITY;
+ALTER TABLE doc_members     FORCE ROW LEVEL SECURITY;
+ALTER TABLE document_tags   FORCE ROW LEVEL SECURITY;
+ALTER TABLE documents       FORCE ROW LEVEL SECURITY;
+ALTER TABLE issues          FORCE ROW LEVEL SECURITY;
+ALTER TABLE presence        FORCE ROW LEVEL SECURITY;
+ALTER TABLE qa_report_views FORCE ROW LEVEL SECURITY;
+ALTER TABLE repos           FORCE ROW LEVEL SECURITY;
+ALTER TABLE standard_clauses FORCE ROW LEVEL SECURITY;
+ALTER TABLE tags            FORCE ROW LEVEL SECURITY;
+ALTER TABLE tasks           FORCE ROW LEVEL SECURITY;

--- a/packages/server/src/db/spec-199-rls-schema.test.ts
+++ b/packages/server/src/db/spec-199-rls-schema.test.ts
@@ -165,7 +165,7 @@ describe("spec-199 ac-16: RLS tenant isolation", () => {
     ).rejects.toThrow();
   });
 
-  it("ac-16: RLS is enabled and forced on all 13 tenant tables", async () => {
+  it("ac-16: RLS is enabled but NOT forced on all 13 tenant tables (owner-bypass posture, spec-257 dec-1)", async () => {
     tagAc(AC_15);
     tagAc(AC_16);
 
@@ -174,6 +174,15 @@ describe("spec-199 ac-16: RLS tenant isolation", () => {
     // and was excluded from RLS by migration 0087 after the 2026-06-10
     // emission outage. See 0087_emission_keys_rls_exclusion.sql and
     // __regression__/emission-key-contextless-verify.regression.test.ts.
+    //
+    // Posture: RLS is ENABLED (relrowsecurity=t) but NOT FORCED
+    // (relforcerowsecurity=f) — migration 0091 dropped FORCE per spec-257 dec-1.
+    // FORCE only affects the table OWNER; on Cloud SQL the deploy/migration role
+    // is `postgres` (the owner, NOBYPASSRLS), so FORCE filtered every contextless
+    // migration/deploy-script query to zero rows (the 2026-06-10 emission and
+    // 2026-06-11 What's New outages). NO FORCE lets the owner bypass while the
+    // non-owner runtime role `memex_app` stays subject to RLS — verified by the
+    // memex_app SET LOCAL ROLE test below, which still sees 0 rows without a GUC.
 
     // pg_class has relrowsecurity + relforcerowsecurity (pg_tables lacks the latter)
     const rows = (await db.execute(sql`
@@ -208,7 +217,10 @@ describe("spec-199 ac-16: RLS tenant isolation", () => {
       const row = byTable.get(table);
       expect(row, `${table}: not found in pg_class`).toBeDefined();
       expect(row!.rowsecurity, `${table}: rowsecurity not enabled`).toBe(true);
-      expect(row!.forcerowsecurity, `${table}: forcerowsecurity not enabled`).toBe(true);
+      expect(
+        row!.forcerowsecurity,
+        `${table}: FORCE must be OFF (owner-bypass posture, spec-257 dec-1 / migration 0091)`,
+      ).toBe(false);
     }
   });
 
@@ -216,11 +228,13 @@ describe("spec-199 ac-16: RLS tenant isolation", () => {
     tagAc(AC_15);
     tagAc(AC_16);
 
-    // Switch to memex_app within a transaction using SET LOCAL ROLE. This drops
-    // BYPASSRLS for the duration of the transaction (memex_app has NOBYPASSRLS),
-    // so FORCE ROW LEVEL SECURITY applies and the USING clause blocks every row
-    // because no app.memex_id GUC is set. This simulates the production runtime
-    // path before t-14 (DATABASE_URL cutover) runs.
+    // Switch to memex_app within a transaction using SET LOCAL ROLE. memex_app
+    // is a NON-OWNER role (postgres owns these tables) with NOBYPASSRLS, so
+    // ENABLE ROW LEVEL SECURITY alone subjects it to the policies — FORCE is NOT
+    // needed (FORCE only governs the table OWNER, which is why 0091 could drop it
+    // without weakening runtime isolation, spec-257 dec-1). With no app.memex_id
+    // GUC set, the USING clause blocks every row. This is the production runtime
+    // path (DATABASE_URL = memex_app since t-14).
     const dbUrl =
       process.env.DATABASE_URL ?? "postgresql://postgres:postgres@localhost:5432/memex";
     const superSql = postgres(dbUrl, { max: 1 });


### PR DESCRIPTION
## Why

Migration 0081 set `ENABLE + FORCE ROW LEVEL SECURITY` on the tenant tables. On Cloud SQL the deploy/migration role connects as **`postgres`**, which — verified read-only on **prod + int** (2026-06-11/12) — is **not** a superuser and **does not** hold `BYPASSRLS` (`rolsuper=f, rolbypassrls=f`). Because `FORCE` makes RLS apply even to the table owner, every query the deploy role runs **without** an `app.memex_id` GUC is filtered to **zero rows**.

This single false assumption ("the superuser deploy path bypasses RLS") caused two production incidents:

- **2026-06-10 — emission outage:** 0081's FORCE policy on `memex_emission_keys` filtered `verifyEmissionKey()` (which runs *before* tenant context exists) to 0 rows once the runtime cut to `memex_app`. Platform-wide AC emission down ~12h. Hotfixed narrowly by 0087.
- **2026-06-11 — What's New ribbon dark on prod:** `deploy.sh` step 1f (`db:generate-whats-new`) runs as `postgres`, read `documents` with no GUC → "judged 0 of 0 shippable specs" against ~70 eligible. Its three sibling deploy scripts (1c handhold-demo, 1d default-standards, 1e guide-content) were silently failing the same way behind their `|| echo` wrappers.

## What

Migration **0093** drops `FORCE` (keeps `ENABLE` + every `memex_id` policy) on all **15** currently-FORCE'd tenant tables. This puts RLS at the correct trust boundary:

- **`postgres`** (table **owner** = the migration/admin/deploy identity) bypasses RLS as owner → all migrations and deploy scripts 1c–1f work, no per-script changes.
- **`memex_app`** (runtime role, **non-owner**, `NOBYPASSRLS`) stays **subject** to RLS → runtime tenant isolation is **unchanged** (`FORCE` only ever governed the owner).

Rejected alternatives (spec-257 dec-1): granting `BYPASSRLS` is impossible on Cloud SQL (no superuser to grant it); wrapping every script/migration in `runWithMemexId` is fragile (the failure mode that produced four silent breakages).

Also includes **`qa_report_views`**, which spec-260 (0092) added with `ENABLE + FORCE` days after these outages — the same pattern, reintroduced because no guard prevents it. The durable fix (a structural lint/CI guard + a Standard) is tracked in **spec-257 dec-3 / ac-5**.

## Files
- `0093_rls_no_force_owner_bypass.sql` (+ revert) — `NO FORCE` on the 15 tables
- `spec-199-rls-schema.test.ts` — updated to assert the new posture (`forced=false`, `enabled=true`); the `memex_app` SET LOCAL ROLE isolation test confirms non-owner subjection is unchanged

## Verification

- [x] Ownership of **all 15** tables verified `= postgres` on prod (so `ALTER … NO FORCE` cannot fail on a non-owner)
- [x] Migration applies clean locally (15 `ALTER TABLE`)
- [x] Targeted RLS tests green (10/10): posture flag flipped **and** `memex_app` still sees 0 rows without a GUC (isolation preserved)
- [x] Full `make test` green except one **pre-existing** Slack OAuth EE test that fails identically on `develop` (unrelated)
- [ ] **INT (the real gate):** local `postgres` is a superuser so local cannot exercise owner-bypass — confirm on int that `db:generate-whats-new` reports `judged N>0` (not "0 of 0") after the deploy applies 0093
- [ ] INT: backfills 1c/1d/1e run real work, not silent no-ops
- [ ] PROD: same checks after promotion

## Rollback
`reverts/0093_rls_no_force_owner_bypass.revert.sql` re-applies `FORCE` (re-introduces the outage class — see file header).

Refs: spec-257 dec-1