### PR TITLE
feat(guide-sdk): no-flicker launch, true Stop-flush, first-load hint (spec-264)

### DIFF
--- a/packages/guide-sdk/src/bundle/engine.tsx
+++ b/packages/guide-sdk/src/bundle/engine.tsx
@@ -12,7 +12,7 @@
 // It REUSES the engine's existing exports (createVoiceOrchestratorFactory, the
 // session provider/pill, Specky) — no duplicated engine logic (dec-5).
 
-import { StrictMode, useEffect, useRef } from 'react';
+import { StrictMode, useEffect, useLayoutEffect, useRef } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { setGuideBackend } from '../backend';
 import { createVoiceOrchestratorFactory } from '../orchestrator/voiceGuideOrchestrator';
@@ -56,9 +56,15 @@ async function mintAnonGuideToken(config: GuideBundleConfig): Promise<string | n
 export async function mountEngine({
   shadow,
   config,
+  onFirstPaint,
 }: {
   shadow: ShadowRoot;
   config: GuideBundleConfig;
+  /** spec-264 t-1 (dec-1): fired after the engine commits its FIRST frame (its idle
+   *  Specky icon is now in the shadow DOM). The loader hides its hand-off doorway
+   *  here — not before mountEngine — so the two overlap in one paint and the launcher
+   *  never blinks out of existence between "doorway gone" and "engine painted". */
+  onFirstPaint?: () => void;
 }): Promise<MountedEngine> {
   // The injected backend: the public endpoint's leg paths differ from the app's
   // (the app authenticates the SSE leg with an Authorization header; the public
@@ -131,6 +137,9 @@ export async function mountEngine({
             so auto-start the session once on mount (the engine's icon doorway then
             re-appears if the user ends the session). */}
         <AutoStart />
+        {/* spec-264 t-1: signal first paint so the loader hides its doorway only once
+            the engine's affordance is on screen (no flicker). */}
+        <FirstPaintSignal onPainted={onFirstPaint} />
         <GuideOverlay />
       </VoiceSessionProvider>
     </StrictMode>,
@@ -156,6 +165,22 @@ function AutoStart(): null {
     // Run once; `session.start` identity is stable for the provider's lifetime.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+  return null;
+}
+
+/** spec-264 t-1 (dec-1): fire `onPainted` once, after the engine's first commit. A
+ *  `useLayoutEffect` runs synchronously after React mutates the DOM but BEFORE the
+ *  browser paints — so at this point the engine's idle Specky icon is already in the
+ *  shadow root. The loader hides its doorway in this callback, so the doorway removal
+ *  and the engine's appearance land in the SAME paint: no empty frame, no flicker.
+ *  Renders nothing. */
+function FirstPaintSignal({ onPainted }: { onPainted?: () => void }): null {
+  const fired = useRef(false);
+  useLayoutEffect(() => {
+    if (fired.current) return; // StrictMode double-invokes effects; fire only once
+    fired.current = true;
+    onPainted?.();
+  }, [onPainted]);
   return null;
 }
 

--- a/packages/guide-sdk/src/bundle/loader.hint.spec-264.test.ts
+++ b/packages/guide-sdk/src/bundle/loader.hint.spec-264.test.ts
@@ -1,0 +1,146 @@
+// spec-264 t-3 (dec-3) — the first-load "Click me to ask anything" hint. A yellow
+// speech bubble anchored to the doorway, shown ONCE per browser session, auto-
+// dismissed after 10s and on the first doorway click. "Once per session" is backed
+// by sessionStorage (dec-3): it survives in-tab page navigation on the multi-page
+// mindset-website (no re-nag while browsing) yet re-appears in a fresh tab. A
+// throwing/disabled store must degrade to "don't show" rather than crash the loader.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { tagAc } from '@memex-ai-ac/vitest';
+import type { NavigationAdapter } from '../navigation/NavigationAdapter';
+
+const SPEC = 'mindset-prod/memex-building-itself/specs/spec-264';
+const AC = (n: number) => `${SPEC}/acs/ac-${n}`;
+
+const HOST_ID = 'memex-guide-host';
+const HINT_SEL = '[data-guide-hint]';
+
+function fakeNavigation(): NavigationAdapter {
+  return {
+    resolveScreenKey: () => 'home',
+    currentScreenKey: () => 'home',
+    navigate: () => ({ ok: true, path: '/' }),
+    findElement: () => null,
+    elementsForScreen: () => [],
+  };
+}
+
+const cfg = () => ({
+  surface: 'mindset-website',
+  backend: 'https://memex.ai/guide/v1',
+  navigation: fakeNavigation(),
+  capabilities: {},
+});
+
+function freshDom() {
+  document.body.innerHTML = '';
+  document.getElementById(HOST_ID)?.remove();
+}
+
+describe('spec-264 t-3: first-load hint bubble (dec-3)', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+    freshDom();
+    window.sessionStorage.clear();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it('renders the yellow "Click me to ask anything" bubble in the shadow root on first load (ac-3, ac-10)', async () => {
+    tagAc(AC(3)); // scope: a yellow bubble appears on first load anchored to the launcher
+    tagAc(AC(10)); // impl: renders on first load when the session flag is unset
+    const { init } = await import('./loader');
+    const host = init(cfg());
+    const shadow = host.shadowRoot!;
+
+    const hint = shadow.querySelector(HINT_SEL);
+    expect(hint).not.toBeNull();
+    expect(hint!.textContent).toBe('Click me to ask anything');
+    // It lives in the shadow root, never the light DOM (host CSS can't reach it).
+    expect(document.querySelector(HINT_SEL)).toBeNull();
+    // Yellow treatment is defined in the shadow stylesheet.
+    const style = shadow.querySelector('style')!;
+    expect(style.textContent).toContain('.memex-guide-hint');
+    expect(style.textContent).toContain('#fde047'); // the yellow background
+    // Shown ⇒ the session flag is now set.
+    expect(window.sessionStorage.getItem('memex-guide-hint-shown')).not.toBeNull();
+  });
+
+  it('does NOT re-show on a second init within the same session (multi-page remount) (ac-3, ac-11)', async () => {
+    tagAc(AC(3));
+    tagAc(AC(11)); // impl: once shown, the session flag suppresses it
+    const { init } = await import('./loader');
+
+    const first = init(cfg());
+    expect(first.shadowRoot!.querySelector(HINT_SEL)).not.toBeNull();
+
+    // Simulate a fresh page load in the SAME tab/session: new host, new shadow root,
+    // but sessionStorage persists — the hint must not re-appear.
+    freshDom();
+    const second = init(cfg());
+    expect(second.shadowRoot!.querySelector(HINT_SEL)).toBeNull();
+  });
+
+  it('auto-dismisses after 10 seconds (ac-11)', async () => {
+    tagAc(AC(11));
+    vi.useFakeTimers();
+    const { init } = await import('./loader');
+    const host = init(cfg());
+    const shadow = host.shadowRoot!;
+    expect(shadow.querySelector(HINT_SEL)).not.toBeNull();
+
+    vi.advanceTimersByTime(9_999);
+    expect(shadow.querySelector(HINT_SEL)).not.toBeNull(); // still up just before 10s
+    vi.advanceTimersByTime(1);
+    expect(shadow.querySelector(HINT_SEL)).toBeNull(); // gone at 10s
+  });
+
+  it('dismisses immediately when the doorway is clicked (ac-11)', async () => {
+    tagAc(AC(11));
+    // Mock the engine so the click doesn't drag in the real React engine chunk.
+    vi.doMock('./engine', () => ({
+      mountEngine: vi.fn((args: { onFirstPaint?: () => void }) => {
+        args.onFirstPaint?.();
+        return { unmount: vi.fn() };
+      }),
+    }));
+    const { init } = await import('./loader');
+    const host = init(cfg());
+    const shadow = host.shadowRoot!;
+    const doorway = shadow.querySelector<HTMLButtonElement>('[data-guide-doorway]')!;
+    expect(shadow.querySelector(HINT_SEL)).not.toBeNull();
+
+    doorway.click();
+    expect(shadow.querySelector(HINT_SEL)).toBeNull(); // killed on open
+  });
+
+  it('a throwing/disabled sessionStorage degrades to "don\'t show" and never crashes the loader (ac-11)', async () => {
+    tagAc(AC(11));
+    // Private-mode / sandboxed iframe: storage access throws. Stub the whole global
+    // (jsdom's sessionStorage methods sit behind a proxy, so spying on them is
+    // unreliable — replacing the object is what a blocked store actually looks like).
+    const throwingStorage = {
+      getItem: () => {
+        throw new Error('storage blocked');
+      },
+      setItem: () => {
+        throw new Error('storage blocked');
+      },
+      removeItem: () => {},
+      clear: () => {},
+      key: () => null,
+      length: 0,
+    };
+    vi.stubGlobal('sessionStorage', throwingStorage);
+
+    const { init } = await import('./loader');
+    // The loader must still mount the doorway, just without a hint.
+    const host = init(cfg());
+    const shadow = host.shadowRoot!;
+    expect(shadow.querySelector('[data-guide-doorway]')).not.toBeNull();
+    expect(shadow.querySelector(HINT_SEL)).toBeNull();
+  });
+});

--- a/packages/guide-sdk/src/bundle/loader.lazy.spec-222.test.ts
+++ b/packages/guide-sdk/src/bundle/loader.lazy.spec-222.test.ts
@@ -89,7 +89,12 @@ describe('spec-222 t-5: engine is lazy-loaded (ac-8)', () => {
     tagAc(AC_8);
 
     // Mock the engine module so we can observe exactly when it is pulled in.
-    const mountEngine = vi.fn(() => ({ unmount: vi.fn() }));
+    // spec-264 t-1: the engine signals first paint; the loader hides the doorway in
+    // that callback (no flicker). Fire it synchronously so the hand-off completes.
+    const mountEngine = vi.fn((args: { onFirstPaint?: () => void }) => {
+      args.onFirstPaint?.();
+      return { unmount: vi.fn() };
+    });
     vi.doMock('./engine', () => ({ mountEngine }));
 
     const { init } = await import('./loader');
@@ -121,7 +126,12 @@ describe('spec-222 t-5: engine is lazy-loaded (ac-8)', () => {
 
   it('(b) the engine loads at most once — repeated clicks do not re-import it', async () => {
     tagAc(AC_8);
-    const mountEngine = vi.fn(() => ({ unmount: vi.fn() }));
+    // spec-264 t-1: the engine signals first paint; the loader hides the doorway in
+    // that callback (no flicker). Fire it synchronously so the hand-off completes.
+    const mountEngine = vi.fn((args: { onFirstPaint?: () => void }) => {
+      args.onFirstPaint?.();
+      return { unmount: vi.fn() };
+    });
     vi.doMock('./engine', () => ({ mountEngine }));
 
     const { init } = await import('./loader');

--- a/packages/guide-sdk/src/bundle/loader.noFlicker.spec-264.test.ts
+++ b/packages/guide-sdk/src/bundle/loader.noFlicker.spec-264.test.ts
@@ -1,0 +1,101 @@
+// spec-264 t-1 (dec-1) — the launcher→chat hand-off must not flicker. The thin
+// pre-React doorway is removed ONLY once the lazily-loaded engine commits its first
+// frame (its idle Specky icon is on screen), so there is never a paint with no
+// Specky affordance. Before this fix the loader hid the doorway the instant the
+// engine chunk's dynamic import resolved — i.e. BEFORE React mounted — leaving an
+// empty frame (the visible "disappears for a second" flicker).
+//
+// The mock engine here lets the test hold `onFirstPaint` and fire it on demand, so
+// it can assert the ordering: doorway still visible after mountEngine resolves, and
+// hidden only after the first-paint signal.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { tagAc } from '@memex-ai-ac/vitest';
+import type { NavigationAdapter } from '../navigation/NavigationAdapter';
+
+const SPEC = 'mindset-prod/memex-building-itself/specs/spec-264';
+const AC = (n: number) => `${SPEC}/acs/ac-${n}`;
+
+const HOST_ID = 'memex-guide-host';
+
+function fakeNavigation(): NavigationAdapter {
+  return {
+    resolveScreenKey: () => 'home',
+    currentScreenKey: () => 'home',
+    navigate: () => ({ ok: true, path: '/' }),
+    findElement: () => null,
+    elementsForScreen: () => [],
+  };
+}
+
+const cfg = () => ({
+  surface: 'memex-website',
+  backend: 'https://memex.ai/guide/v1',
+  navigation: fakeNavigation(),
+  capabilities: {},
+});
+
+describe('spec-264 t-1: launcher→chat hand-off does not flicker (dec-1)', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+    document.body.innerHTML = '';
+    document.getElementById(HOST_ID)?.remove();
+    try {
+      window.sessionStorage.clear();
+    } catch {
+      /* ignore */
+    }
+  });
+
+  it('keeps the doorway visible until the engine signals first paint, then hands off (ac-1, ac-6)', async () => {
+    tagAc(AC(1)); // scope: never a frame with no Specky affordance on screen
+    tagAc(AC(6)); // impl: doorway removed only after the first-paint signal
+
+    // Capture the loader's onFirstPaint instead of firing it, so we control timing.
+    let capturedOnFirstPaint: (() => void) | undefined;
+    const mountEngine = vi.fn((args: { onFirstPaint?: () => void }) => {
+      capturedOnFirstPaint = args.onFirstPaint;
+      return { unmount: vi.fn() };
+    });
+    vi.doMock('./engine', () => ({ mountEngine }));
+
+    const { init } = await import('./loader');
+    const host = init(cfg());
+    const doorway = host.shadowRoot!.querySelector<HTMLButtonElement>('[data-guide-doorway]')!;
+
+    doorway.click();
+    await vi.waitFor(() => expect(mountEngine).toHaveBeenCalledTimes(1));
+
+    // The engine has mounted but NOT yet painted → the doorway is STILL visible.
+    // (Hiding it here is exactly the old flicker.)
+    expect(capturedOnFirstPaint).toBeTypeOf('function');
+    expect(doorway.style.display).not.toBe('none');
+
+    // The engine commits its first frame → only NOW does the doorway hand off.
+    capturedOnFirstPaint!();
+    expect(doorway.style.display).toBe('none');
+  });
+
+  it('still loads the engine ONLY on first click — React is not on the initial paint path (ac-7)', async () => {
+    tagAc(AC(7)); // impl: engine imported only on click; lazy-load preserved
+    const mountEngine = vi.fn((args: { onFirstPaint?: () => void }) => {
+      args.onFirstPaint?.();
+      return { unmount: vi.fn() };
+    });
+    vi.doMock('./engine', () => ({ mountEngine }));
+
+    const { init } = await import('./loader');
+    const host = init(cfg());
+
+    // After init(): the doorway is present and the engine has NOT been mounted.
+    expect(mountEngine).not.toHaveBeenCalled();
+    const doorway = host.shadowRoot!.querySelector<HTMLButtonElement>('[data-guide-doorway]')!;
+    expect(doorway).not.toBeNull();
+
+    // First click crosses the lazy boundary → the engine mounts, then hands off.
+    doorway.click();
+    await vi.waitFor(() => expect(mountEngine).toHaveBeenCalledTimes(1));
+    expect(doorway.style.display).toBe('none');
+  });
+});

--- a/packages/guide-sdk/src/bundle/loader.ts
+++ b/packages/guide-sdk/src/bundle/loader.ts
@@ -103,10 +103,18 @@ export function init(config: GuideBundleConfig): HTMLElement {
       // interaction. Keeping this the ONLY reference to ./engine is what makes the
       // initial loader thin (ac-8). Do NOT convert this to a static import.
       const { mountEngine } = await import('./engine');
-      // The doorway has done its job — the engine owns the affordance from here.
-      doorway.style.display = 'none';
       // mountEngine is async (it mints the anon session token before starting).
-      engine = await mountEngine({ shadow, config });
+      // spec-264 t-1 (dec-1): hand off WITHOUT a flicker. The doorway is hidden ONLY
+      // from `onFirstPaint` — fired once the engine has committed its first frame, so
+      // its idle Specky icon is already on screen. Hiding the doorway before this (the
+      // old behaviour) left an empty frame between "doorway gone" and "engine painted".
+      engine = await mountEngine({
+        shadow,
+        config,
+        onFirstPaint: () => {
+          doorway.style.display = 'none';
+        },
+      });
     } finally {
       loading = false;
       doorway.removeAttribute('data-guide-loading');
@@ -114,7 +122,73 @@ export function init(config: GuideBundleConfig): HTMLElement {
   };
   doorway.addEventListener('click', () => void onFirstClick());
 
+  // spec-264 t-3 (dec-3): first-load "Click me to ask anything" hint, shown once per
+  // browser session (sessionStorage), auto-dismissed after 10s and on first click.
+  maybeShowHintBubble(shadow, doorway);
+
   return host;
+}
+
+/** sessionStorage key for the once-per-session first-load hint (spec-264 dec-3). */
+const HINT_SHOWN_KEY = 'memex-guide-hint-shown';
+/** How long the hint stays before auto-dismissing (dec-3: 10 seconds). */
+const HINT_TIMEOUT_MS = 10_000;
+
+/**
+ * Has the hint already been shown this browser session? Reads sessionStorage —
+ * chosen (dec-3) because it survives in-tab page navigation on the multi-page
+ * mindset-website (so the hint never re-nags as a visitor browses) yet re-appears in
+ * a fresh tab / after the tab closes. A throwing/disabled store (private mode,
+ * sandboxed iframe) DEGRADES TO "already shown" so we quietly skip the hint rather
+ * than crash the loader — never showing twice is the safe failure.
+ */
+function hintAlreadyShown(): boolean {
+  try {
+    return window.sessionStorage.getItem(HINT_SHOWN_KEY) !== null;
+  } catch {
+    return true;
+  }
+}
+
+/** Mark the hint shown for this session (best-effort; a throwing store is ignored). */
+function markHintShown(): void {
+  try {
+    window.sessionStorage.setItem(HINT_SHOWN_KEY, '1');
+  } catch {
+    /* storage disabled — the hint simply isn't suppressed across reloads */
+  }
+}
+
+/**
+ * Render the first-load hint bubble into the shadow root, anchored above the doorway
+ * (spec-264 t-3 / dec-3). Shows ONLY on the first init of a browser session; sets the
+ * session flag immediately so a per-page SDK remount (multi-page site) does not
+ * re-show it. Dismisses after HINT_TIMEOUT_MS, and immediately on the first doorway
+ * click. No-op when already shown this session (or when storage is unavailable).
+ */
+function maybeShowHintBubble(shadow: ShadowRoot, doorway: HTMLElement): void {
+  if (hintAlreadyShown()) return;
+  markHintShown();
+
+  const bubble = document.createElement('div');
+  bubble.className = 'memex-guide-hint';
+  bubble.setAttribute('data-guide-hint', '');
+  bubble.setAttribute('role', 'status');
+  bubble.textContent = 'Click me to ask anything';
+  shadow.appendChild(bubble);
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let dismissed = false;
+  const dismiss = () => {
+    if (dismissed) return;
+    dismissed = true;
+    if (timer !== undefined) clearTimeout(timer);
+    doorway.removeEventListener('click', dismiss);
+    bubble.remove();
+  };
+  timer = setTimeout(dismiss, HINT_TIMEOUT_MS);
+  // Opening the chat kills the hint instantly (it has served its purpose).
+  doorway.addEventListener('click', dismiss);
 }
 
 /**
@@ -161,6 +235,43 @@ const DOORWAY_CSS = `
   .memex-guide-doorway:hover { transform: scale(1.05); }
   .memex-guide-doorway[data-guide-loading] { cursor: progress; opacity: 0.7; }
   .memex-guide-doorway img { display: block; pointer-events: none; }
+
+  /* spec-264 t-3 (dec-3): the first-load hint — a yellow speech bubble sitting just
+     above the 64px doorway (bottom 24px + 64px + an 12px gap = 100px), with a small
+     downward tail pointing at it. ':host { all: initial }' wipes inherited type, so
+     the font is declared explicitly. */
+  .memex-guide-hint {
+    position: fixed;
+    right: 24px;
+    bottom: 100px;
+    z-index: 2147483000;
+    max-width: 220px;
+    padding: 8px 12px;
+    border-radius: 10px;
+    background: #fde047;
+    color: #1b1e24;
+    font: 500 14px/1.3 system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    box-shadow:
+      0 10px 15px -3px rgba(0, 0, 0, 0.35),
+      0 4px 6px -4px rgba(0, 0, 0, 0.35);
+    cursor: default;
+    animation: memex-guide-hint-in 200ms ease-out;
+  }
+  .memex-guide-hint::after {
+    content: "";
+    position: absolute;
+    right: 22px;
+    bottom: -5px;
+    width: 11px;
+    height: 11px;
+    background: #fde047;
+    transform: rotate(45deg);
+    border-bottom-right-radius: 2px;
+  }
+  @keyframes memex-guide-hint-in {
+    from { opacity: 0; transform: translateY(4px); }
+    to { opacity: 1; transform: translateY(0); }
+  }
 `;
 
 // The global the static site calls. Registered eagerly on load (this is the whole

--- a/packages/guide-sdk/src/bundle/types.ts
+++ b/packages/guide-sdk/src/bundle/types.ts
@@ -27,5 +27,11 @@ export interface MountedEngine {
 
 /** The engine chunk's public entry, resolved lazily by the loader (ac-8). */
 export interface EngineModule {
-  mountEngine: (args: { shadow: ShadowRoot; config: GuideBundleConfig }) => Promise<MountedEngine>;
+  mountEngine: (args: {
+    shadow: ShadowRoot;
+    config: GuideBundleConfig;
+    /** spec-264 t-1 (dec-1): fired after the engine's first paint so the loader can
+     *  hide its doorway without a flicker. */
+    onFirstPaint?: () => void;
+  }) => Promise<MountedEngine>;
 }

--- a/packages/guide-sdk/src/orchestrator/voiceGuideOrchestrator.spec-264.test.ts
+++ b/packages/guide-sdk/src/orchestrator/voiceGuideOrchestrator.spec-264.test.ts
@@ -1,0 +1,255 @@
+// spec-264 t-2 (dec-2) — Stop is a true hard-flush. Two failure modes the fix closes,
+// both exercised here against faked browser glue (no real audio):
+//   1. Residual TTS audio: after a Stop, chunks the server had already sent for the
+//      aborted request keep arriving over the WS and play out the tail of the
+//      previous answer. onAudio now drops any chunk whose requestId is not the
+//      current speakingRequestId (which interrupt() nulls). [ac-8 / ac-2]
+//   2. Dangling turn in history: an interrupt mid-turn must leave NO partial assistant
+//      turn AND no orphaned user turn behind, while preserving completed prior turns.
+//      The orchestrator owns the committed history and commits a turn only if it
+//      finished un-interrupted, so the next turn starts clean. [ac-9 / ac-2]
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { createVoiceOrchestratorFactory } from './voiceGuideOrchestrator';
+import type { SocketLike, SocketFactory } from './voiceWsClient';
+import type { VadEngine } from '../micVad';
+import type { OrchestratorHooks } from '../session/orchestrator';
+import type { NavigationAdapter } from '../navigation/NavigationAdapter';
+
+const SPEC = 'mindset-prod/memex-building-itself/specs/spec-264';
+const AC = (n: number) => `${SPEC}/acs/ac-${n}`;
+
+function fakeSocket() {
+  const sent: unknown[] = [];
+  let closed = false;
+  const sock: SocketLike = {
+    binaryType: '',
+    readyState: 1,
+    onopen: null,
+    onmessage: null,
+    onerror: null,
+    onclose: null,
+    send: (d) => sent.push(d),
+    close: () => {
+      closed = true;
+    },
+  };
+  return { sock, sent, factory: (() => sock) as SocketFactory, isClosed: () => closed };
+}
+
+function fakeVad() {
+  let onSpeech: ((s: boolean) => void) | null = null;
+  const engine: VadEngine = {
+    start: (_stream, cb) => {
+      onSpeech = cb;
+    },
+    stop: vi.fn(),
+  };
+  return { engine, speak: (s: boolean) => onSpeech?.(s) };
+}
+
+function fakePlayback() {
+  let drainCb: (() => void) | null = null;
+  return {
+    startTurn: vi.fn(),
+    enqueue: vi.fn(),
+    duck: vi.fn(),
+    restore: vi.fn(),
+    flush: vi.fn(() => {
+      drainCb = null;
+    }),
+    playedMs: () => 0,
+    onDrain: vi.fn((cb: () => void) => {
+      drainCb = cb;
+    }),
+    dispose: vi.fn(),
+    drain: () => {
+      const cb = drainCb;
+      drainCb = null;
+      cb?.();
+    },
+  };
+}
+
+function fakeCapture() {
+  let onFrame: ((pcm: ArrayBuffer) => void) | null = null;
+  return {
+    start: (_stream: MediaStream, cb: (pcm: ArrayBuffer) => void) => {
+      onFrame = cb;
+    },
+    stop: vi.fn(),
+    frame: () => onFrame?.(new ArrayBuffer(8)),
+  };
+}
+
+interface GraphCall {
+  messages: unknown;
+}
+
+/** A graph whose turns stay pending until completed/aborted, so a test can interrupt
+ *  a turn mid-flight. Records the `messages` input of every invoke for assertions. */
+function controllableGraph() {
+  const calls: GraphCall[] = [];
+  const pending: Array<{
+    config: { configurable: { callbacks: Record<string, (...a: never[]) => void>; signal?: AbortSignal } };
+    resolve: () => void;
+  }> = [];
+  const invoke = vi.fn((input: GraphCall, config: (typeof pending)[number]['config']) => {
+    calls.push({ messages: (input as { messages: unknown }).messages });
+    return new Promise<void>((resolve, reject) => {
+      pending.push({ config, resolve });
+      config.configurable.signal?.addEventListener('abort', () =>
+        reject(new DOMException('Aborted', 'AbortError')),
+      );
+    });
+  });
+  const complete = (i: number, text: string) => {
+    const e = pending[i];
+    e.config.configurable.callbacks.onTextDelta?.(text as never);
+    (e.config.configurable.callbacks.onAssistantTurnComplete as ((c: unknown) => void) | undefined)?.([
+      { type: 'text', text },
+    ]);
+    e.resolve();
+  };
+  return { graph: { invoke } as unknown as ReturnType<typeof import('../guideGraph').createGuideGraph>, calls, complete };
+}
+
+function hooks(): OrchestratorHooks & { states: string[] } {
+  const states: string[] = [];
+  return {
+    states,
+    setLoopState: (s) => states.push(s),
+    playEarcon: () => {},
+    onError: () => {},
+    onEnded: () => {},
+    onTurnComplete: () => {},
+  };
+}
+
+const adapter: NavigationAdapter = {
+  resolveScreenKey: () => null,
+  currentScreenKey: () => 'specs-list',
+  findElement: () => null,
+  navigate: () => ({ ok: true, path: '/ns/mx/specs' }),
+};
+
+const react = {
+  adapter,
+  advanceDemo: vi.fn(),
+  startWalkthrough: vi.fn(),
+  authToken: () => 'tok',
+  tenantBase: () => '/api/ns/mx',
+  origin: 'http://localhost',
+  getScreenContext: () => ({ screenKey: 'specs-list', screenRegistry: [], namespace: 'ns', memex: 'mx' }),
+};
+
+const fakeStream = {} as MediaStream;
+const ready = { data: JSON.stringify({ type: 'ready' }) };
+const transcript = (text: string) => ({ data: JSON.stringify({ type: 'transcript', text, isFinal: true }) });
+const audioFinal = (requestId: string) => ({ data: JSON.stringify({ type: 'audio', requestId, audio: '', isFinal: true }) });
+
+const flush = async () => {
+  for (let i = 0; i < 6; i++) await Promise.resolve();
+};
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('spec-264 t-2: Stop drops residual TTS audio (dec-2 / ac-8, ac-2)', () => {
+  it('ignores TTS chunks for a request that Stop has aborted — no tail of the previous answer', async () => {
+    tagAc(AC(8)); // impl: Stop aborts TTS + flushes immediately, not via a confirm gate
+    tagAc(AC(2)); // scope: cuts current audio, no leftover tail
+    const sock = fakeSocket();
+    const playback = fakePlayback();
+    const g = controllableGraph();
+    const h = hooks();
+    const orch = createVoiceOrchestratorFactory(react, {
+      socketFactory: sock.factory,
+      vadEngine: fakeVad().engine,
+      capture: fakeCapture(),
+      playback,
+      graph: g.graph,
+      newId: () => 'r1',
+    })(h);
+
+    await orch.start(fakeStream);
+    sock.sock.onmessage?.(ready);
+    sock.sock.onmessage?.(transcript('how do phases work?')); // turn 0
+    await flush;
+    g.complete(0, 'Phases run draft to done.'); // → speaking, speakingRequestId = 'r1'
+    await flush;
+    expect(h.states[h.states.length - 1]).toBe('speaking');
+
+    const enqueuedBeforeStop = playback.enqueue.mock.calls.length;
+
+    orch.interrupt(); // Stop
+    // Hard-flush primitives fired immediately (NOT routed through a confirm gate):
+    expect(sock.sent).toContainEqual(JSON.stringify({ type: 'abort', requestId: 'r1' }));
+    expect(playback.flush).toHaveBeenCalled();
+    expect(playback.duck).not.toHaveBeenCalled(); // no spec-246 duck-then-confirm
+    expect(h.states[h.states.length - 1]).toBe('listening');
+    expect(sock.isClosed()).toBe(false); // halt-and-stay: session + mic stay open
+
+    // A chunk the server had already sent for the aborted 'r1' now arrives — it must
+    // be DROPPED, not enqueued (else it plays the tail of the abandoned answer).
+    sock.sock.onmessage?.(audioFinal('r1'));
+    expect(playback.enqueue.mock.calls.length).toBe(enqueuedBeforeStop);
+  });
+});
+
+describe('spec-264 t-2: Stop drops the in-flight turn from history (dec-2 / ac-9, ac-2)', () => {
+  it('an interrupted turn leaves no dangling user/partial assistant; completed prior turns are preserved', async () => {
+    tagAc(AC(9)); // impl: in-flight/partial turn removed; completed prior turns intact
+    tagAc(AC(2)); // scope: next instruction acted on directly, with no tail
+    const sock = fakeSocket();
+    const playback = fakePlayback();
+    const g = controllableGraph();
+    const orch = createVoiceOrchestratorFactory(react, {
+      socketFactory: sock.factory,
+      vadEngine: fakeVad().engine,
+      capture: fakeCapture(),
+      playback,
+      graph: g.graph,
+      newId: () => 'r1',
+      now: () => 1000, // fixed clock; the self-echo guard is irrelevant to dissimilar turns
+    })(hooks());
+
+    await orch.start(fakeStream);
+    sock.sock.onmessage?.(ready);
+
+    // Turn 1 — completes cleanly → committed to history.
+    sock.sock.onmessage?.(transcript('what is a spec')); // invoke #0
+    await flush;
+    g.complete(0, 'A spec is a unit of work.');
+    await flush;
+    // Drain turn 1's speech back to listening.
+    sock.sock.onmessage?.(audioFinal('r1'));
+    playback.drain();
+
+    // Turn 2 — interrupted MID-flight (never completes) → must NOT be committed.
+    sock.sock.onmessage?.(transcript('tell me about phases')); // invoke #1
+    await flush;
+    orch.interrupt(); // Stop while the answer is still being produced
+    await flush;
+
+    // Turn 3 — the user's next instruction.
+    sock.sock.onmessage?.(transcript('how do I sign in')); // invoke #2
+    await flush;
+
+    // Turn 2's input still carried the completed turn 1 (history preserved).
+    expect(g.calls[1].messages).toEqual([
+      { role: 'user', content: 'what is a spec' },
+      { role: 'assistant', content: [{ type: 'text', text: 'A spec is a unit of work.' }] },
+      { role: 'user', content: 'tell me about phases' },
+    ]);
+
+    // Turn 3's input has turn 1 preserved but NO trace of the interrupted turn 2 —
+    // neither its user utterance nor a partial assistant reply. Specky goes straight
+    // to the new instruction instead of resuming the abandoned answer.
+    expect(g.calls[2].messages).toEqual([
+      { role: 'user', content: 'what is a spec' },
+      { role: 'assistant', content: [{ type: 'text', text: 'A spec is a unit of work.' }] },
+      { role: 'user', content: 'how do I sign in' },
+    ]);
+  });
+});

--- a/packages/guide-sdk/src/orchestrator/voiceGuideOrchestrator.ts
+++ b/packages/guide-sdk/src/orchestrator/voiceGuideOrchestrator.ts
@@ -34,6 +34,7 @@ import type { VadEngine } from '../micVad';
 import { WebAudioPlayback } from '../playbackQueue';
 import type { PlaybackSink } from '../bargeIn';
 import { createGuideGraph } from '../guideGraph';
+import type { MessageParam, ContentBlock } from '../agent-types';
 
 // spec-214 dec-3 — self-echo guard tuning. A committed transcript is dropped as the
 // agent's own echo ONLY when BOTH hold: it lands within the cooldown after speaking
@@ -132,6 +133,18 @@ class VoiceGuideOrchestrator implements VoiceOrchestrator {
   private turnAbort: AbortController | null = null;
   private speakingRequestId: string | null = null;
   private stopped = false;
+  // spec-264 t-2 (dec-2): the orchestrator OWNS the committed conversation history —
+  // the user+assistant of COMPLETED turns only. Each turn invokes the graph with a
+  // FRESH per-turn thread and this history as input, then commits the turn's messages
+  // only if it finished without being interrupted/superseded. So a Stop (or a fast
+  // follow-up) drops the in-flight turn entirely and the next utterance starts clean,
+  // with no dangling user turn left in a checkpoint for the model to keep answering.
+  private committedMessages: MessageParam[] = [];
+  // Monotonic turn id. runTurn stamps `currentTurnId` at entry; interrupt() clears it
+  // and a superseding runTurn replaces it, so an in-flight turn can detect (after its
+  // async graph.invoke resolves) that it was abandoned and neither speak nor commit.
+  private turnSeq = 0;
+  private currentTurnId: number | null = null;
   // spec-214 dec-1: the live loop state, tracked here so the mic→STT gate can read
   // it synchronously. Mic PCM is forwarded to STT ONLY while this is 'listening'.
   private loopState: VoiceLoopState = 'idle';
@@ -225,7 +238,7 @@ class VoiceGuideOrchestrator implements VoiceOrchestrator {
           // (re-opening the STT session for the next human turn — dec-2).
           else if (!this.stopped) this.beginListeningTurn();
         },
-        onAudio: (_requestId, audio, _alignment, isFinal) => this.onAudio(audio, isFinal),
+        onAudio: (requestId, audio, _alignment, isFinal) => this.onAudio(requestId, audio, isFinal),
         onError: (message) => this.hooks.onError(message),
         onClose: () => {
           if (!this.stopped) this.hooks.onEnded();
@@ -310,13 +323,25 @@ class VoiceGuideOrchestrator implements VoiceOrchestrator {
     }
     this.playback?.flush();
 
+    // spec-264 t-2 (dec-2): claim this turn. A later interrupt() (Stop) or a
+    // superseding runTurn moves `currentTurnId`, so when THIS invoke resolves we can
+    // tell it was abandoned and skip both speaking and committing it to history.
+    const turnId = ++this.turnSeq;
+    this.currentTurnId = turnId;
+    const userMessage: MessageParam = { role: 'user', content: transcript };
+
     const { screenKey, screenRegistry, screens } = this.react.getScreenContext();
     this.turnAbort = new AbortController();
     let assistantText = '';
+    let finalAssistantContent: ContentBlock[] | null = null;
     try {
       await this.graph.invoke(
         {
-          messages: [{ role: 'user', content: transcript }],
+          // spec-264 t-2 (dec-2): the orchestrator-owned history is the cross-turn
+          // source of truth — send prior COMPLETED turns + this user turn on a FRESH
+          // per-turn thread, so the graph checkpointer only carries this turn's own
+          // tool loop and an aborted turn can leave no dangling user message behind.
+          messages: [...this.committedMessages, userMessage],
           screenKey,
           screenRegistry,
           screens: screens ?? [],
@@ -324,11 +349,16 @@ class VoiceGuideOrchestrator implements VoiceOrchestrator {
         },
         {
           configurable: {
-            thread_id: this.threadId,
+            thread_id: `${this.threadId}-${turnId}`,
             signal: this.turnAbort.signal,
             callbacks: {
               onTextDelta: (t: string) => {
                 assistantText += t;
+              },
+              // The final assistant message (the loop only ends on __end__, so it
+              // carries no pending tool_use). Captured for the committed history.
+              onAssistantTurnComplete: (content: ContentBlock[]) => {
+                finalAssistantContent = content;
               },
               onUiTool: (name: string, _id: string, input: Record<string, unknown>) =>
                 // Returned so the graph can serialize the real outcome (e.g.
@@ -344,6 +374,10 @@ class VoiceGuideOrchestrator implements VoiceOrchestrator {
         },
       );
     } catch (err) {
+      // spec-264 t-2 (dec-2): an interrupt (Stop) or a superseding turn aborts the
+      // in-flight graph call. Drop that throw SILENTLY — the turn is abandoned, so we
+      // must not flip to an error state; interrupt()/the new turn owns what's next.
+      if (this.currentTurnId !== turnId) return;
       this.hooks.onError(err instanceof Error ? err.message : String(err));
       // spec-214 dec-1/dec-2: recover through beginListeningTurn so the internal
       // gate state (and a fresh STT session) follow the pill back to listening.
@@ -354,7 +388,18 @@ class VoiceGuideOrchestrator implements VoiceOrchestrator {
       return;
     }
 
-    if (assistantText.trim() && !this.stopped) {
+    // spec-264 t-2 (dec-2): a Stop (interrupt) or a superseding turn moved on while we
+    // awaited the reply — abandon this turn entirely. Do NOT speak its answer and do
+    // NOT commit it, so the next utterance is handled clean with no tail of this one.
+    if (this.currentTurnId !== turnId || this.stopped) return;
+
+    if (assistantText.trim()) {
+      // The turn completed cleanly: commit user + assistant to the owned history so
+      // the NEXT turn carries this exchange (completed prior turns are preserved).
+      this.committedMessages.push(userMessage, {
+        role: 'assistant',
+        content: finalAssistantContent ?? [{ type: 'text', text: assistantText }],
+      });
       const requestId = this.newId();
       this.speakingRequestId = requestId;
       // spec-214 dec-3: remember what we're about to say so the self-echo guard can
@@ -367,15 +412,20 @@ class VoiceGuideOrchestrator implements VoiceOrchestrator {
       this.enterState('speaking');
       this.ws?.speak(requestId, assistantText);
     } else {
-      // No speech to play (empty/aborted). spec-214 dec-2: re-open the STT session
-      // for the next human turn. spec-211 t-1: settle so an awaiting sequencer
-      // advances rather than hangs.
+      // No speech to play (empty). spec-214 dec-2: re-open the STT session for the
+      // next human turn. spec-211 t-1: settle so an awaiting sequencer advances.
       this.beginListeningTurn();
-      if (!this.stopped) this.hooks.onTurnComplete?.();
+      this.hooks.onTurnComplete?.();
     }
   }
 
-  private onAudio(audio: ArrayBuffer, isFinal: boolean): void {
+  private onAudio(requestId: string, audio: ArrayBuffer, isFinal: boolean): void {
+    // spec-264 t-2 (dec-2): drop audio from a turn we've moved on from. After a Stop
+    // (interrupt nulls speakingRequestId) or a superseding turn (a new requestId), TTS
+    // chunks the server had ALREADY sent for the old request keep arriving over the
+    // WS — without this guard they enqueue and play out the tail of the abandoned
+    // answer ("it finishes the previous sentence"). Only the current request plays.
+    if (requestId !== this.speakingRequestId) return;
     void this.playback?.enqueue(audio);
     // isFinal marks the last chunk RECEIVED, but the audio is still playing out of
     // the queue. Stay in 'speaking' — the Stop control visible — until playback
@@ -408,6 +458,11 @@ class VoiceGuideOrchestrator implements VoiceOrchestrator {
   // session + mic still open (halt-and-stay, NOT end-and-restart).
   interrupt(): void {
     if (this.stopped) return;
+    // spec-264 t-2 (dec-2): abandon the in-flight turn. Clearing currentTurnId means
+    // that when its graph.invoke resolves (or its abort throws) it neither speaks nor
+    // commits to history — the partial/aborted turn is dropped ENTIRELY, so the next
+    // utterance starts clean instead of the model resuming the interrupted answer.
+    this.currentTurnId = null;
     this.turnAbort?.abort();
     if (this.speakingRequestId) {
       this.ws?.abort(this.speakingRequestId);


### PR DESCRIPTION
Three UX fixes to the embeddable Specky voice guide (`@memex/guide-sdk`), split out of spec-264's original 4-item scope. Conversation capture (the 4th item) is now **spec-265** (build-ready).

Spec: https://memex.ai/mindset-prod/memex-building-itself/specs/spec-264

## What changed
1. **No-flicker launch (dec-1)** — the pre-React doorway is hidden only once the engine commits its first paint (`onFirstPaint` via `useLayoutEffect`), so the launcher never blinks out between "doorway gone" and "engine painted". Lazy-load preserved (React stays off the initial paint path; loader bundle stays 10.7 kB).
2. **Stop = true hard-flush (dec-2)** — two root causes fixed in `voiceGuideOrchestrator`:
   - `onAudio` now drops TTS chunks whose `requestId` ≠ the current `speakingRequestId`, so audio the server had already sent for an aborted turn no longer plays out the tail of the previous answer.
   - the orchestrator owns the committed history and invokes the graph on a fresh per-turn thread with a turn-epoch guard, so an interrupted/superseded turn commits nothing — no dangling user turn / partial assistant turn for the model to resume.
   - Not routed through spec-246's duck-then-confirm gate. No server change (`/chat` is stateless per turn).
3. **First-load hint (dec-3)** — a yellow "Click me to ask anything" bubble shown once per browser session (`sessionStorage` — survives in-tab nav on the multi-page mindset-website, re-shows in a new tab), auto-dismissed after 10s and on click. A throwing/disabled store degrades to "don't show".

## Files
- `bundle/loader.ts`, `bundle/engine.tsx`, `bundle/types.ts` — items 1 & 3
- `orchestrator/voiceGuideOrchestrator.ts` — item 2
- new tagged tests: `loader.noFlicker.spec-264.test.ts`, `loader.hint.spec-264.test.ts`, `voiceGuideOrchestrator.spec-264.test.ts`; updated `loader.lazy.spec-222.test.ts` mock

## Verification
- 136/136 guide-sdk tests pass (27 files); **9/9 spec-264 ACs verified**
- `tsc --noEmit` clean; `build:bundle` clean (engine stays a separate lazy chunk)

## Follow-ups (not in this PR)
- On-device (Path 2) verification on the live surfaces — spec-264 issue-1
- Rebuild + re-vendor the bundle into the website repos & redeploy — spec-264 issue-2

🤖 Generated with [Claude Code](https://claude.com/claude-code)