### PR TITLE
release: develop → main — RLS NO FORCE owner-bypass fix (spec-257) + QA Report unread polish (spec-260) + native-app OAuth redirect (spec-253)

### DIFF
--- a/packages/guide-sdk/src/bundle/engine.tsx
+++ b/packages/guide-sdk/src/bundle/engine.tsx
@@ -12,7 +12,7 @@
 // It REUSES the engine's existing exports (createVoiceOrchestratorFactory, the
 // session provider/pill, Specky) — no duplicated engine logic (dec-5).
 
-import { StrictMode, useEffect, useRef } from 'react';
+import { StrictMode, useEffect, useLayoutEffect, useRef } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { setGuideBackend } from '../backend';
 import { createVoiceOrchestratorFactory } from '../orchestrator/voiceGuideOrchestrator';
@@ -56,9 +56,15 @@ async function mintAnonGuideToken(config: GuideBundleConfig): Promise<string | n
 export async function mountEngine({
   shadow,
   config,
+  onFirstPaint,
 }: {
   shadow: ShadowRoot;
   config: GuideBundleConfig;
+  /** spec-264 t-1 (dec-1): fired after the engine commits its FIRST frame (its idle
+   *  Specky icon is now in the shadow DOM). The loader hides its hand-off doorway
+   *  here — not before mountEngine — so the two overlap in one paint and the launcher
+   *  never blinks out of existence between "doorway gone" and "engine painted". */
+  onFirstPaint?: () => void;
 }): Promise<MountedEngine> {
   // The injected backend: the public endpoint's leg paths differ from the app's
   // (the app authenticates the SSE leg with an Authorization header; the public
@@ -131,6 +137,9 @@ export async function mountEngine({
             so auto-start the session once on mount (the engine's icon doorway then
             re-appears if the user ends the session). */}
         <AutoStart />
+        {/* spec-264 t-1: signal first paint so the loader hides its doorway only once
+            the engine's affordance is on screen (no flicker). */}
+        <FirstPaintSignal onPainted={onFirstPaint} />
         <GuideOverlay />
       </VoiceSessionProvider>
     </StrictMode>,
@@ -156,6 +165,22 @@ function AutoStart(): null {
     // Run once; `session.start` identity is stable for the provider's lifetime.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+  return null;
+}
+
+/** spec-264 t-1 (dec-1): fire `onPainted` once, after the engine's first commit. A
+ *  `useLayoutEffect` runs synchronously after React mutates the DOM but BEFORE the
+ *  browser paints — so at this point the engine's idle Specky icon is already in the
+ *  shadow root. The loader hides its doorway in this callback, so the doorway removal
+ *  and the engine's appearance land in the SAME paint: no empty frame, no flicker.
+ *  Renders nothing. */
+function FirstPaintSignal({ onPainted }: { onPainted?: () => void }): null {
+  const fired = useRef(false);
+  useLayoutEffect(() => {
+    if (fired.current) return; // StrictMode double-invokes effects; fire only once
+    fired.current = true;
+    onPainted?.();
+  }, [onPainted]);
   return null;
 }
 

--- a/packages/guide-sdk/src/bundle/loader.hint.spec-264.test.ts
+++ b/packages/guide-sdk/src/bundle/loader.hint.spec-264.test.ts
@@ -1,0 +1,146 @@
+// spec-264 t-3 (dec-3) — the first-load "Click me to ask anything" hint. A yellow
+// speech bubble anchored to the doorway, shown ONCE per browser session, auto-
+// dismissed after 10s and on the first doorway click. "Once per session" is backed
+// by sessionStorage (dec-3): it survives in-tab page navigation on the multi-page
+// mindset-website (no re-nag while browsing) yet re-appears in a fresh tab. A
+// throwing/disabled store must degrade to "don't show" rather than crash the loader.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { tagAc } from '@memex-ai-ac/vitest';
+import type { NavigationAdapter } from '../navigation/NavigationAdapter';
+
+const SPEC = 'mindset-prod/memex-building-itself/specs/spec-264';
+const AC = (n: number) => `${SPEC}/acs/ac-${n}`;
+
+const HOST_ID = 'memex-guide-host';
+const HINT_SEL = '[data-guide-hint]';
+
+function fakeNavigation(): NavigationAdapter {
+  return {
+    resolveScreenKey: () => 'home',
+    currentScreenKey: () => 'home',
+    navigate: () => ({ ok: true, path: '/' }),
+    findElement: () => null,
+    elementsForScreen: () => [],
+  };
+}
+
+const cfg = () => ({
+  surface: 'mindset-website',
+  backend: 'https://memex.ai/guide/v1',
+  navigation: fakeNavigation(),
+  capabilities: {},
+});
+
+function freshDom() {
+  document.body.innerHTML = '';
+  document.getElementById(HOST_ID)?.remove();
+}
+
+describe('spec-264 t-3: first-load hint bubble (dec-3)', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+    freshDom();
+    window.sessionStorage.clear();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it('renders the yellow "Click me to ask anything" bubble in the shadow root on first load (ac-3, ac-10)', async () => {
+    tagAc(AC(3)); // scope: a yellow bubble appears on first load anchored to the launcher
+    tagAc(AC(10)); // impl: renders on first load when the session flag is unset
+    const { init } = await import('./loader');
+    const host = init(cfg());
+    const shadow = host.shadowRoot!;
+
+    const hint = shadow.querySelector(HINT_SEL);
+    expect(hint).not.toBeNull();
+    expect(hint!.textContent).toBe('Click me to ask anything');
+    // It lives in the shadow root, never the light DOM (host CSS can't reach it).
+    expect(document.querySelector(HINT_SEL)).toBeNull();
+    // Yellow treatment is defined in the shadow stylesheet.
+    const style = shadow.querySelector('style')!;
+    expect(style.textContent).toContain('.memex-guide-hint');
+    expect(style.textContent).toContain('#fde047'); // the yellow background
+    // Shown ⇒ the session flag is now set.
+    expect(window.sessionStorage.getItem('memex-guide-hint-shown')).not.toBeNull();
+  });
+
+  it('does NOT re-show on a second init within the same session (multi-page remount) (ac-3, ac-11)', async () => {
+    tagAc(AC(3));
+    tagAc(AC(11)); // impl: once shown, the session flag suppresses it
+    const { init } = await import('./loader');
+
+    const first = init(cfg());
+    expect(first.shadowRoot!.querySelector(HINT_SEL)).not.toBeNull();
+
+    // Simulate a fresh page load in the SAME tab/session: new host, new shadow root,
+    // but sessionStorage persists — the hint must not re-appear.
+    freshDom();
+    const second = init(cfg());
+    expect(second.shadowRoot!.querySelector(HINT_SEL)).toBeNull();
+  });
+
+  it('auto-dismisses after 10 seconds (ac-11)', async () => {
+    tagAc(AC(11));
+    vi.useFakeTimers();
+    const { init } = await import('./loader');
+    const host = init(cfg());
+    const shadow = host.shadowRoot!;
+    expect(shadow.querySelector(HINT_SEL)).not.toBeNull();
+
+    vi.advanceTimersByTime(9_999);
+    expect(shadow.querySelector(HINT_SEL)).not.toBeNull(); // still up just before 10s
+    vi.advanceTimersByTime(1);
+    expect(shadow.querySelector(HINT_SEL)).toBeNull(); // gone at 10s
+  });
+
+  it('dismisses immediately when the doorway is clicked (ac-11)', async () => {
+    tagAc(AC(11));
+    // Mock the engine so the click doesn't drag in the real React engine chunk.
+    vi.doMock('./engine', () => ({
+      mountEngine: vi.fn((args: { onFirstPaint?: () => void }) => {
+        args.onFirstPaint?.();
+        return { unmount: vi.fn() };
+      }),
+    }));
+    const { init } = await import('./loader');
+    const host = init(cfg());
+    const shadow = host.shadowRoot!;
+    const doorway = shadow.querySelector<HTMLButtonElement>('[data-guide-doorway]')!;
+    expect(shadow.querySelector(HINT_SEL)).not.toBeNull();
+
+    doorway.click();
+    expect(shadow.querySelector(HINT_SEL)).toBeNull(); // killed on open
+  });
+
+  it('a throwing/disabled sessionStorage degrades to "don\'t show" and never crashes the loader (ac-11)', async () => {
+    tagAc(AC(11));
+    // Private-mode / sandboxed iframe: storage access throws. Stub the whole global
+    // (jsdom's sessionStorage methods sit behind a proxy, so spying on them is
+    // unreliable — replacing the object is what a blocked store actually looks like).
+    const throwingStorage = {
+      getItem: () => {
+        throw new Error('storage blocked');
+      },
+      setItem: () => {
+        throw new Error('storage blocked');
+      },
+      removeItem: () => {},
+      clear: () => {},
+      key: () => null,
+      length: 0,
+    };
+    vi.stubGlobal('sessionStorage', throwingStorage);
+
+    const { init } = await import('./loader');
+    // The loader must still mount the doorway, just without a hint.
+    const host = init(cfg());
+    const shadow = host.shadowRoot!;
+    expect(shadow.querySelector('[data-guide-doorway]')).not.toBeNull();
+    expect(shadow.querySelector(HINT_SEL)).toBeNull();
+  });
+});

--- a/packages/guide-sdk/src/bundle/loader.lazy.spec-222.test.ts
+++ b/packages/guide-sdk/src/bundle/loader.lazy.spec-222.test.ts
@@ -89,7 +89,12 @@ describe('spec-222 t-5: engine is lazy-loaded (ac-8)', () => {
     tagAc(AC_8);
 
     // Mock the engine module so we can observe exactly when it is pulled in.
-    const mountEngine = vi.fn(() => ({ unmount: vi.fn() }));
+    // spec-264 t-1: the engine signals first paint; the loader hides the doorway in
+    // that callback (no flicker). Fire it synchronously so the hand-off completes.
+    const mountEngine = vi.fn((args: { onFirstPaint?: () => void }) => {
+      args.onFirstPaint?.();
+      return { unmount: vi.fn() };
+    });
     vi.doMock('./engine', () => ({ mountEngine }));
 
     const { init } = await import('./loader');
@@ -121,7 +126,12 @@ describe('spec-222 t-5: engine is lazy-loaded (ac-8)', () => {
 
   it('(b) the engine loads at most once — repeated clicks do not re-import it', async () => {
     tagAc(AC_8);
-    const mountEngine = vi.fn(() => ({ unmount: vi.fn() }));
+    // spec-264 t-1: the engine signals first paint; the loader hides the doorway in
+    // that callback (no flicker). Fire it synchronously so the hand-off completes.
+    const mountEngine = vi.fn((args: { onFirstPaint?: () => void }) => {
+      args.onFirstPaint?.();
+      return { unmount: vi.fn() };
+    });
     vi.doMock('./engine', () => ({ mountEngine }));
 
     const { init } = await import('./loader');

--- a/packages/guide-sdk/src/bundle/loader.noFlicker.spec-264.test.ts
+++ b/packages/guide-sdk/src/bundle/loader.noFlicker.spec-264.test.ts
@@ -1,0 +1,101 @@
+// spec-264 t-1 (dec-1) — the launcher→chat hand-off must not flicker. The thin
+// pre-React doorway is removed ONLY once the lazily-loaded engine commits its first
+// frame (its idle Specky icon is on screen), so there is never a paint with no
+// Specky affordance. Before this fix the loader hid the doorway the instant the
+// engine chunk's dynamic import resolved — i.e. BEFORE React mounted — leaving an
+// empty frame (the visible "disappears for a second" flicker).
+//
+// The mock engine here lets the test hold `onFirstPaint` and fire it on demand, so
+// it can assert the ordering: doorway still visible after mountEngine resolves, and
+// hidden only after the first-paint signal.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { tagAc } from '@memex-ai-ac/vitest';
+import type { NavigationAdapter } from '../navigation/NavigationAdapter';
+
+const SPEC = 'mindset-prod/memex-building-itself/specs/spec-264';
+const AC = (n: number) => `${SPEC}/acs/ac-${n}`;
+
+const HOST_ID = 'memex-guide-host';
+
+function fakeNavigation(): NavigationAdapter {
+  return {
+    resolveScreenKey: () => 'home',
+    currentScreenKey: () => 'home',
+    navigate: () => ({ ok: true, path: '/' }),
+    findElement: () => null,
+    elementsForScreen: () => [],
+  };
+}
+
+const cfg = () => ({
+  surface: 'memex-website',
+  backend: 'https://memex.ai/guide/v1',
+  navigation: fakeNavigation(),
+  capabilities: {},
+});
+
+describe('spec-264 t-1: launcher→chat hand-off does not flicker (dec-1)', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+    document.body.innerHTML = '';
+    document.getElementById(HOST_ID)?.remove();
+    try {
+      window.sessionStorage.clear();
+    } catch {
+      /* ignore */
+    }
+  });
+
+  it('keeps the doorway visible until the engine signals first paint, then hands off (ac-1, ac-6)', async () => {
+    tagAc(AC(1)); // scope: never a frame with no Specky affordance on screen
+    tagAc(AC(6)); // impl: doorway removed only after the first-paint signal
+
+    // Capture the loader's onFirstPaint instead of firing it, so we control timing.
+    let capturedOnFirstPaint: (() => void) | undefined;
+    const mountEngine = vi.fn((args: { onFirstPaint?: () => void }) => {
+      capturedOnFirstPaint = args.onFirstPaint;
+      return { unmount: vi.fn() };
+    });
+    vi.doMock('./engine', () => ({ mountEngine }));
+
+    const { init } = await import('./loader');
+    const host = init(cfg());
+    const doorway = host.shadowRoot!.querySelector<HTMLButtonElement>('[data-guide-doorway]')!;
+
+    doorway.click();
+    await vi.waitFor(() => expect(mountEngine).toHaveBeenCalledTimes(1));
+
+    // The engine has mounted but NOT yet painted → the doorway is STILL visible.
+    // (Hiding it here is exactly the old flicker.)
+    expect(capturedOnFirstPaint).toBeTypeOf('function');
+    expect(doorway.style.display).not.toBe('none');
+
+    // The engine commits its first frame → only NOW does the doorway hand off.
+    capturedOnFirstPaint!();
+    expect(doorway.style.display).toBe('none');
+  });
+
+  it('still loads the engine ONLY on first click — React is not on the initial paint path (ac-7)', async () => {
+    tagAc(AC(7)); // impl: engine imported only on click; lazy-load preserved
+    const mountEngine = vi.fn((args: { onFirstPaint?: () => void }) => {
+      args.onFirstPaint?.();
+      return { unmount: vi.fn() };
+    });
+    vi.doMock('./engine', () => ({ mountEngine }));
+
+    const { init } = await import('./loader');
+    const host = init(cfg());
+
+    // After init(): the doorway is present and the engine has NOT been mounted.
+    expect(mountEngine).not.toHaveBeenCalled();
+    const doorway = host.shadowRoot!.querySelector<HTMLButtonElement>('[data-guide-doorway]')!;
+    expect(doorway).not.toBeNull();
+
+    // First click crosses the lazy boundary → the engine mounts, then hands off.
+    doorway.click();
+    await vi.waitFor(() => expect(mountEngine).toHaveBeenCalledTimes(1));
+    expect(doorway.style.display).toBe('none');
+  });
+});

--- a/packages/guide-sdk/src/bundle/loader.ts
+++ b/packages/guide-sdk/src/bundle/loader.ts
@@ -103,10 +103,18 @@ export function init(config: GuideBundleConfig): HTMLElement {
       // interaction. Keeping this the ONLY reference to ./engine is what makes the
       // initial loader thin (ac-8). Do NOT convert this to a static import.
       const { mountEngine } = await import('./engine');
-      // The doorway has done its job — the engine owns the affordance from here.
-      doorway.style.display = 'none';
       // mountEngine is async (it mints the anon session token before starting).
-      engine = await mountEngine({ shadow, config });
+      // spec-264 t-1 (dec-1): hand off WITHOUT a flicker. The doorway is hidden ONLY
+      // from `onFirstPaint` — fired once the engine has committed its first frame, so
+      // its idle Specky icon is already on screen. Hiding the doorway before this (the
+      // old behaviour) left an empty frame between "doorway gone" and "engine painted".
+      engine = await mountEngine({
+        shadow,
+        config,
+        onFirstPaint: () => {
+          doorway.style.display = 'none';
+        },
+      });
     } finally {
       loading = false;
       doorway.removeAttribute('data-guide-loading');
@@ -114,7 +122,73 @@ export function init(config: GuideBundleConfig): HTMLElement {
   };
   doorway.addEventListener('click', () => void onFirstClick());
 
+  // spec-264 t-3 (dec-3): first-load "Click me to ask anything" hint, shown once per
+  // browser session (sessionStorage), auto-dismissed after 10s and on first click.
+  maybeShowHintBubble(shadow, doorway);
+
   return host;
+}
+
+/** sessionStorage key for the once-per-session first-load hint (spec-264 dec-3). */
+const HINT_SHOWN_KEY = 'memex-guide-hint-shown';
+/** How long the hint stays before auto-dismissing (dec-3: 10 seconds). */
+const HINT_TIMEOUT_MS = 10_000;
+
+/**
+ * Has the hint already been shown this browser session? Reads sessionStorage —
+ * chosen (dec-3) because it survives in-tab page navigation on the multi-page
+ * mindset-website (so the hint never re-nags as a visitor browses) yet re-appears in
+ * a fresh tab / after the tab closes. A throwing/disabled store (private mode,
+ * sandboxed iframe) DEGRADES TO "already shown" so we quietly skip the hint rather
+ * than crash the loader — never showing twice is the safe failure.
+ */
+function hintAlreadyShown(): boolean {
+  try {
+    return window.sessionStorage.getItem(HINT_SHOWN_KEY) !== null;
+  } catch {
+    return true;
+  }
+}
+
+/** Mark the hint shown for this session (best-effort; a throwing store is ignored). */
+function markHintShown(): void {
+  try {
+    window.sessionStorage.setItem(HINT_SHOWN_KEY, '1');
+  } catch {
+    /* storage disabled — the hint simply isn't suppressed across reloads */
+  }
+}
+
+/**
+ * Render the first-load hint bubble into the shadow root, anchored above the doorway
+ * (spec-264 t-3 / dec-3). Shows ONLY on the first init of a browser session; sets the
+ * session flag immediately so a per-page SDK remount (multi-page site) does not
+ * re-show it. Dismisses after HINT_TIMEOUT_MS, and immediately on the first doorway
+ * click. No-op when already shown this session (or when storage is unavailable).
+ */
+function maybeShowHintBubble(shadow: ShadowRoot, doorway: HTMLElement): void {
+  if (hintAlreadyShown()) return;
+  markHintShown();
+
+  const bubble = document.createElement('div');
+  bubble.className = 'memex-guide-hint';
+  bubble.setAttribute('data-guide-hint', '');
+  bubble.setAttribute('role', 'status');
+  bubble.textContent = 'Click me to ask anything';
+  shadow.appendChild(bubble);
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let dismissed = false;
+  const dismiss = () => {
+    if (dismissed) return;
+    dismissed = true;
+    if (timer !== undefined) clearTimeout(timer);
+    doorway.removeEventListener('click', dismiss);
+    bubble.remove();
+  };
+  timer = setTimeout(dismiss, HINT_TIMEOUT_MS);
+  // Opening the chat kills the hint instantly (it has served its purpose).
+  doorway.addEventListener('click', dismiss);
 }
 
 /**
@@ -161,6 +235,43 @@ const DOORWAY_CSS = `
   .memex-guide-doorway:hover { transform: scale(1.05); }
   .memex-guide-doorway[data-guide-loading] { cursor: progress; opacity: 0.7; }
   .memex-guide-doorway img { display: block; pointer-events: none; }
+
+  /* spec-264 t-3 (dec-3): the first-load hint — a yellow speech bubble sitting just
+     above the 64px doorway (bottom 24px + 64px + an 12px gap = 100px), with a small
+     downward tail pointing at it. ':host { all: initial }' wipes inherited type, so
+     the font is declared explicitly. */
+  .memex-guide-hint {
+    position: fixed;
+    right: 24px;
+    bottom: 100px;
+    z-index: 2147483000;
+    max-width: 220px;
+    padding: 8px 12px;
+    border-radius: 10px;
+    background: #fde047;
+    color: #1b1e24;
+    font: 500 14px/1.3 system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    box-shadow:
+      0 10px 15px -3px rgba(0, 0, 0, 0.35),
+      0 4px 6px -4px rgba(0, 0, 0, 0.35);
+    cursor: default;
+    animation: memex-guide-hint-in 200ms ease-out;
+  }
+  .memex-guide-hint::after {
+    content: "";
+    position: absolute;
+    right: 22px;
+    bottom: -5px;
+    width: 11px;
+    height: 11px;
+    background: #fde047;
+    transform: rotate(45deg);
+    border-bottom-right-radius: 2px;
+  }
+  @keyframes memex-guide-hint-in {
+    from { opacity: 0; transform: translateY(4px); }
+    to { opacity: 1; transform: translateY(0); }
+  }
 `;
 
 // The global the static site calls. Registered eagerly on load (this is the whole

--- a/packages/guide-sdk/src/bundle/types.ts
+++ b/packages/guide-sdk/src/bundle/types.ts
@@ -27,5 +27,11 @@ export interface MountedEngine {
 
 /** The engine chunk's public entry, resolved lazily by the loader (ac-8). */
 export interface EngineModule {
-  mountEngine: (args: { shadow: ShadowRoot; config: GuideBundleConfig }) => Promise<MountedEngine>;
+  mountEngine: (args: {
+    shadow: ShadowRoot;
+    config: GuideBundleConfig;
+    /** spec-264 t-1 (dec-1): fired after the engine's first paint so the loader can
+     *  hide its doorway without a flicker. */
+    onFirstPaint?: () => void;
+  }) => Promise<MountedEngine>;
 }

--- a/packages/guide-sdk/src/orchestrator/voiceGuideOrchestrator.spec-264.test.ts
+++ b/packages/guide-sdk/src/orchestrator/voiceGuideOrchestrator.spec-264.test.ts
@@ -1,0 +1,255 @@
+// spec-264 t-2 (dec-2) — Stop is a true hard-flush. Two failure modes the fix closes,
+// both exercised here against faked browser glue (no real audio):
+//   1. Residual TTS audio: after a Stop, chunks the server had already sent for the
+//      aborted request keep arriving over the WS and play out the tail of the
+//      previous answer. onAudio now drops any chunk whose requestId is not the
+//      current speakingRequestId (which interrupt() nulls). [ac-8 / ac-2]
+//   2. Dangling turn in history: an interrupt mid-turn must leave NO partial assistant
+//      turn AND no orphaned user turn behind, while preserving completed prior turns.
+//      The orchestrator owns the committed history and commits a turn only if it
+//      finished un-interrupted, so the next turn starts clean. [ac-9 / ac-2]
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { createVoiceOrchestratorFactory } from './voiceGuideOrchestrator';
+import type { SocketLike, SocketFactory } from './voiceWsClient';
+import type { VadEngine } from '../micVad';
+import type { OrchestratorHooks } from '../session/orchestrator';
+import type { NavigationAdapter } from '../navigation/NavigationAdapter';
+
+const SPEC = 'mindset-prod/memex-building-itself/specs/spec-264';
+const AC = (n: number) => `${SPEC}/acs/ac-${n}`;
+
+function fakeSocket() {
+  const sent: unknown[] = [];
+  let closed = false;
+  const sock: SocketLike = {
+    binaryType: '',
+    readyState: 1,
+    onopen: null,
+    onmessage: null,
+    onerror: null,
+    onclose: null,
+    send: (d) => sent.push(d),
+    close: () => {
+      closed = true;
+    },
+  };
+  return { sock, sent, factory: (() => sock) as SocketFactory, isClosed: () => closed };
+}
+
+function fakeVad() {
+  let onSpeech: ((s: boolean) => void) | null = null;
+  const engine: VadEngine = {
+    start: (_stream, cb) => {
+      onSpeech = cb;
+    },
+    stop: vi.fn(),
+  };
+  return { engine, speak: (s: boolean) => onSpeech?.(s) };
+}
+
+function fakePlayback() {
+  let drainCb: (() => void) | null = null;
+  return {
+    startTurn: vi.fn(),
+    enqueue: vi.fn(),
+    duck: vi.fn(),
+    restore: vi.fn(),
+    flush: vi.fn(() => {
+      drainCb = null;
+    }),
+    playedMs: () => 0,
+    onDrain: vi.fn((cb: () => void) => {
+      drainCb = cb;
+    }),
+    dispose: vi.fn(),
+    drain: () => {
+      const cb = drainCb;
+      drainCb = null;
+      cb?.();
+    },
+  };
+}
+
+function fakeCapture() {
+  let onFrame: ((pcm: ArrayBuffer) => void) | null = null;
+  return {
+    start: (_stream: MediaStream, cb: (pcm: ArrayBuffer) => void) => {
+      onFrame = cb;
+    },
+    stop: vi.fn(),
+    frame: () => onFrame?.(new ArrayBuffer(8)),
+  };
+}
+
+interface GraphCall {
+  messages: unknown;
+}
+
+/** A graph whose turns stay pending until completed/aborted, so a test can interrupt
+ *  a turn mid-flight. Records the `messages` input of every invoke for assertions. */
+function controllableGraph() {
+  const calls: GraphCall[] = [];
+  const pending: Array<{
+    config: { configurable: { callbacks: Record<string, (...a: never[]) => void>; signal?: AbortSignal } };
+    resolve: () => void;
+  }> = [];
+  const invoke = vi.fn((input: GraphCall, config: (typeof pending)[number]['config']) => {
+    calls.push({ messages: (input as { messages: unknown }).messages });
+    return new Promise<void>((resolve, reject) => {
+      pending.push({ config, resolve });
+      config.configurable.signal?.addEventListener('abort', () =>
+        reject(new DOMException('Aborted', 'AbortError')),
+      );
+    });
+  });
+  const complete = (i: number, text: string) => {
+    const e = pending[i];
+    e.config.configurable.callbacks.onTextDelta?.(text as never);
+    (e.config.configurable.callbacks.onAssistantTurnComplete as ((c: unknown) => void) | undefined)?.([
+      { type: 'text', text },
+    ]);
+    e.resolve();
+  };
+  return { graph: { invoke } as unknown as ReturnType<typeof import('../guideGraph').createGuideGraph>, calls, complete };
+}
+
+function hooks(): OrchestratorHooks & { states: string[] } {
+  const states: string[] = [];
+  return {
+    states,
+    setLoopState: (s) => states.push(s),
+    playEarcon: () => {},
+    onError: () => {},
+    onEnded: () => {},
+    onTurnComplete: () => {},
+  };
+}
+
+const adapter: NavigationAdapter = {
+  resolveScreenKey: () => null,
+  currentScreenKey: () => 'specs-list',
+  findElement: () => null,
+  navigate: () => ({ ok: true, path: '/ns/mx/specs' }),
+};
+
+const react = {
+  adapter,
+  advanceDemo: vi.fn(),
+  startWalkthrough: vi.fn(),
+  authToken: () => 'tok',
+  tenantBase: () => '/api/ns/mx',
+  origin: 'http://localhost',
+  getScreenContext: () => ({ screenKey: 'specs-list', screenRegistry: [], namespace: 'ns', memex: 'mx' }),
+};
+
+const fakeStream = {} as MediaStream;
+const ready = { data: JSON.stringify({ type: 'ready' }) };
+const transcript = (text: string) => ({ data: JSON.stringify({ type: 'transcript', text, isFinal: true }) });
+const audioFinal = (requestId: string) => ({ data: JSON.stringify({ type: 'audio', requestId, audio: '', isFinal: true }) });
+
+const flush = async () => {
+  for (let i = 0; i < 6; i++) await Promise.resolve();
+};
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('spec-264 t-2: Stop drops residual TTS audio (dec-2 / ac-8, ac-2)', () => {
+  it('ignores TTS chunks for a request that Stop has aborted — no tail of the previous answer', async () => {
+    tagAc(AC(8)); // impl: Stop aborts TTS + flushes immediately, not via a confirm gate
+    tagAc(AC(2)); // scope: cuts current audio, no leftover tail
+    const sock = fakeSocket();
+    const playback = fakePlayback();
+    const g = controllableGraph();
+    const h = hooks();
+    const orch = createVoiceOrchestratorFactory(react, {
+      socketFactory: sock.factory,
+      vadEngine: fakeVad().engine,
+      capture: fakeCapture(),
+      playback,
+      graph: g.graph,
+      newId: () => 'r1',
+    })(h);
+
+    await orch.start(fakeStream);
+    sock.sock.onmessage?.(ready);
+    sock.sock.onmessage?.(transcript('how do phases work?')); // turn 0
+    await flush;
+    g.complete(0, 'Phases run draft to done.'); // → speaking, speakingRequestId = 'r1'
+    await flush;
+    expect(h.states[h.states.length - 1]).toBe('speaking');
+
+    const enqueuedBeforeStop = playback.enqueue.mock.calls.length;
+
+    orch.interrupt(); // Stop
+    // Hard-flush primitives fired immediately (NOT routed through a confirm gate):
+    expect(sock.sent).toContainEqual(JSON.stringify({ type: 'abort', requestId: 'r1' }));
+    expect(playback.flush).toHaveBeenCalled();
+    expect(playback.duck).not.toHaveBeenCalled(); // no spec-246 duck-then-confirm
+    expect(h.states[h.states.length - 1]).toBe('listening');
+    expect(sock.isClosed()).toBe(false); // halt-and-stay: session + mic stay open
+
+    // A chunk the server had already sent for the aborted 'r1' now arrives — it must
+    // be DROPPED, not enqueued (else it plays the tail of the abandoned answer).
+    sock.sock.onmessage?.(audioFinal('r1'));
+    expect(playback.enqueue.mock.calls.length).toBe(enqueuedBeforeStop);
+  });
+});
+
+describe('spec-264 t-2: Stop drops the in-flight turn from history (dec-2 / ac-9, ac-2)', () => {
+  it('an interrupted turn leaves no dangling user/partial assistant; completed prior turns are preserved', async () => {
+    tagAc(AC(9)); // impl: in-flight/partial turn removed; completed prior turns intact
+    tagAc(AC(2)); // scope: next instruction acted on directly, with no tail
+    const sock = fakeSocket();
+    const playback = fakePlayback();
+    const g = controllableGraph();
+    const orch = createVoiceOrchestratorFactory(react, {
+      socketFactory: sock.factory,
+      vadEngine: fakeVad().engine,
+      capture: fakeCapture(),
+      playback,
+      graph: g.graph,
+      newId: () => 'r1',
+      now: () => 1000, // fixed clock; the self-echo guard is irrelevant to dissimilar turns
+    })(hooks());
+
+    await orch.start(fakeStream);
+    sock.sock.onmessage?.(ready);
+
+    // Turn 1 — completes cleanly → committed to history.
+    sock.sock.onmessage?.(transcript('what is a spec')); // invoke #0
+    await flush;
+    g.complete(0, 'A spec is a unit of work.');
+    await flush;
+    // Drain turn 1's speech back to listening.
+    sock.sock.onmessage?.(audioFinal('r1'));
+    playback.drain();
+
+    // Turn 2 — interrupted MID-flight (never completes) → must NOT be committed.
+    sock.sock.onmessage?.(transcript('tell me about phases')); // invoke #1
+    await flush;
+    orch.interrupt(); // Stop while the answer is still being produced
+    await flush;
+
+    // Turn 3 — the user's next instruction.
+    sock.sock.onmessage?.(transcript('how do I sign in')); // invoke #2
+    await flush;
+
+    // Turn 2's input still carried the completed turn 1 (history preserved).
+    expect(g.calls[1].messages).toEqual([
+      { role: 'user', content: 'what is a spec' },
+      { role: 'assistant', content: [{ type: 'text', text: 'A spec is a unit of work.' }] },
+      { role: 'user', content: 'tell me about phases' },
+    ]);
+
+    // Turn 3's input has turn 1 preserved but NO trace of the interrupted turn 2 —
+    // neither its user utterance nor a partial assistant reply. Specky goes straight
+    // to the new instruction instead of resuming the abandoned answer.
+    expect(g.calls[2].messages).toEqual([
+      { role: 'user', content: 'what is a spec' },
+      { role: 'assistant', content: [{ type: 'text', text: 'A spec is a unit of work.' }] },
+      { role: 'user', content: 'how do I sign in' },
+    ]);
+  });
+});

--- a/packages/guide-sdk/src/orchestrator/voiceGuideOrchestrator.ts
+++ b/packages/guide-sdk/src/orchestrator/voiceGuideOrchestrator.ts
@@ -34,6 +34,7 @@ import type { VadEngine } from '../micVad';
 import { WebAudioPlayback } from '../playbackQueue';
 import type { PlaybackSink } from '../bargeIn';
 import { createGuideGraph } from '../guideGraph';
+import type { MessageParam, ContentBlock } from '../agent-types';
 
 // spec-214 dec-3 — self-echo guard tuning. A committed transcript is dropped as the
 // agent's own echo ONLY when BOTH hold: it lands within the cooldown after speaking
@@ -132,6 +133,18 @@ class VoiceGuideOrchestrator implements VoiceOrchestrator {
   private turnAbort: AbortController | null = null;
   private speakingRequestId: string | null = null;
   private stopped = false;
+  // spec-264 t-2 (dec-2): the orchestrator OWNS the committed conversation history —
+  // the user+assistant of COMPLETED turns only. Each turn invokes the graph with a
+  // FRESH per-turn thread and this history as input, then commits the turn's messages
+  // only if it finished without being interrupted/superseded. So a Stop (or a fast
+  // follow-up) drops the in-flight turn entirely and the next utterance starts clean,
+  // with no dangling user turn left in a checkpoint for the model to keep answering.
+  private committedMessages: MessageParam[] = [];
+  // Monotonic turn id. runTurn stamps `currentTurnId` at entry; interrupt() clears it
+  // and a superseding runTurn replaces it, so an in-flight turn can detect (after its
+  // async graph.invoke resolves) that it was abandoned and neither speak nor commit.
+  private turnSeq = 0;
+  private currentTurnId: number | null = null;
   // spec-214 dec-1: the live loop state, tracked here so the mic→STT gate can read
   // it synchronously. Mic PCM is forwarded to STT ONLY while this is 'listening'.
   private loopState: VoiceLoopState = 'idle';
@@ -225,7 +238,7 @@ class VoiceGuideOrchestrator implements VoiceOrchestrator {
           // (re-opening the STT session for the next human turn — dec-2).
           else if (!this.stopped) this.beginListeningTurn();
         },
-        onAudio: (_requestId, audio, _alignment, isFinal) => this.onAudio(audio, isFinal),
+        onAudio: (requestId, audio, _alignment, isFinal) => this.onAudio(requestId, audio, isFinal),
         onError: (message) => this.hooks.onError(message),
         onClose: () => {
           if (!this.stopped) this.hooks.onEnded();
@@ -310,13 +323,25 @@ class VoiceGuideOrchestrator implements VoiceOrchestrator {
     }
     this.playback?.flush();
 
+    // spec-264 t-2 (dec-2): claim this turn. A later interrupt() (Stop) or a
+    // superseding runTurn moves `currentTurnId`, so when THIS invoke resolves we can
+    // tell it was abandoned and skip both speaking and committing it to history.
+    const turnId = ++this.turnSeq;
+    this.currentTurnId = turnId;
+    const userMessage: MessageParam = { role: 'user', content: transcript };
+
     const { screenKey, screenRegistry, screens } = this.react.getScreenContext();
     this.turnAbort = new AbortController();
     let assistantText = '';
+    let finalAssistantContent: ContentBlock[] | null = null;
     try {
       await this.graph.invoke(
         {
-          messages: [{ role: 'user', content: transcript }],
+          // spec-264 t-2 (dec-2): the orchestrator-owned history is the cross-turn
+          // source of truth — send prior COMPLETED turns + this user turn on a FRESH
+          // per-turn thread, so the graph checkpointer only carries this turn's own
+          // tool loop and an aborted turn can leave no dangling user message behind.
+          messages: [...this.committedMessages, userMessage],
           screenKey,
           screenRegistry,
           screens: screens ?? [],
@@ -324,11 +349,16 @@ class VoiceGuideOrchestrator implements VoiceOrchestrator {
         },
         {
           configurable: {
-            thread_id: this.threadId,
+            thread_id: `${this.threadId}-${turnId}`,
             signal: this.turnAbort.signal,
             callbacks: {
               onTextDelta: (t: string) => {
                 assistantText += t;
+              },
+              // The final assistant message (the loop only ends on __end__, so it
+              // carries no pending tool_use). Captured for the committed history.
+              onAssistantTurnComplete: (content: ContentBlock[]) => {
+                finalAssistantContent = content;
               },
               onUiTool: (name: string, _id: string, input: Record<string, unknown>) =>
                 // Returned so the graph can serialize the real outcome (e.g.
@@ -344,6 +374,10 @@ class VoiceGuideOrchestrator implements VoiceOrchestrator {
         },
       );
     } catch (err) {
+      // spec-264 t-2 (dec-2): an interrupt (Stop) or a superseding turn aborts the
+      // in-flight graph call. Drop that throw SILENTLY — the turn is abandoned, so we
+      // must not flip to an error state; interrupt()/the new turn owns what's next.
+      if (this.currentTurnId !== turnId) return;
       this.hooks.onError(err instanceof Error ? err.message : String(err));
       // spec-214 dec-1/dec-2: recover through beginListeningTurn so the internal
       // gate state (and a fresh STT session) follow the pill back to listening.
@@ -354,7 +388,18 @@ class VoiceGuideOrchestrator implements VoiceOrchestrator {
       return;
     }
 
-    if (assistantText.trim() && !this.stopped) {
+    // spec-264 t-2 (dec-2): a Stop (interrupt) or a superseding turn moved on while we
+    // awaited the reply — abandon this turn entirely. Do NOT speak its answer and do
+    // NOT commit it, so the next utterance is handled clean with no tail of this one.
+    if (this.currentTurnId !== turnId || this.stopped) return;
+
+    if (assistantText.trim()) {
+      // The turn completed cleanly: commit user + assistant to the owned history so
+      // the NEXT turn carries this exchange (completed prior turns are preserved).
+      this.committedMessages.push(userMessage, {
+        role: 'assistant',
+        content: finalAssistantContent ?? [{ type: 'text', text: assistantText }],
+      });
       const requestId = this.newId();
       this.speakingRequestId = requestId;
       // spec-214 dec-3: remember what we're about to say so the self-echo guard can
@@ -367,15 +412,20 @@ class VoiceGuideOrchestrator implements VoiceOrchestrator {
       this.enterState('speaking');
       this.ws?.speak(requestId, assistantText);
     } else {
-      // No speech to play (empty/aborted). spec-214 dec-2: re-open the STT session
-      // for the next human turn. spec-211 t-1: settle so an awaiting sequencer
-      // advances rather than hangs.
+      // No speech to play (empty). spec-214 dec-2: re-open the STT session for the
+      // next human turn. spec-211 t-1: settle so an awaiting sequencer advances.
       this.beginListeningTurn();
-      if (!this.stopped) this.hooks.onTurnComplete?.();
+      this.hooks.onTurnComplete?.();
     }
   }
 
-  private onAudio(audio: ArrayBuffer, isFinal: boolean): void {
+  private onAudio(requestId: string, audio: ArrayBuffer, isFinal: boolean): void {
+    // spec-264 t-2 (dec-2): drop audio from a turn we've moved on from. After a Stop
+    // (interrupt nulls speakingRequestId) or a superseding turn (a new requestId), TTS
+    // chunks the server had ALREADY sent for the old request keep arriving over the
+    // WS — without this guard they enqueue and play out the tail of the abandoned
+    // answer ("it finishes the previous sentence"). Only the current request plays.
+    if (requestId !== this.speakingRequestId) return;
     void this.playback?.enqueue(audio);
     // isFinal marks the last chunk RECEIVED, but the audio is still playing out of
     // the queue. Stay in 'speaking' — the Stop control visible — until playback
@@ -408,6 +458,11 @@ class VoiceGuideOrchestrator implements VoiceOrchestrator {
   // session + mic still open (halt-and-stay, NOT end-and-restart).
   interrupt(): void {
     if (this.stopped) return;
+    // spec-264 t-2 (dec-2): abandon the in-flight turn. Clearing currentTurnId means
+    // that when its graph.invoke resolves (or its abort throws) it neither speaks nor
+    // commits to history — the partial/aborted turn is dropped ENTIRELY, so the next
+    // utterance starts clean instead of the model resuming the interrupted answer.
+    this.currentTurnId = null;
     this.turnAbort?.abort();
     if (this.speakingRequestId) {
       this.ws?.abort(this.speakingRequestId);

--- a/packages/server/drizzle/0093_rls_no_force_owner_bypass.sql
+++ b/packages/server/drizzle/0093_rls_no_force_owner_bypass.sql
@@ -1,0 +1,68 @@
+-- spec-257 dec-1: drop FORCE on every tenant table — restore owner-bypass.
+--
+-- WHAT THIS CHANGES
+--   For each FORCE'd tenant table: ALTER TABLE ... NO FORCE ROW LEVEL SECURITY.
+--   RLS stays ENABLED and every memex_id isolation policy (0081/0086) stays in
+--   place. The ONLY change is removing FORCE.
+--
+-- WHY (the posture, settled in spec-257 dec-1 on verified grounding)
+--   Postgres RLS does not apply to a table's OWNER unless FORCE is set. On
+--   Cloud SQL the deploy/migration role connects as `postgres`, which — verified
+--   read-only on prod AND int 2026-06-11 — is NOT a superuser and does NOT hold
+--   BYPASSRLS (rolsuper=f, rolbypassrls=f). It owns all of these tables. So
+--   migration 0081's ENABLE+FORCE made RLS apply to the owner too, and every
+--   query the owner runs WITHOUT an app.memex_id GUC is filtered to zero rows.
+--
+--   Two production outages came from this single false assumption that the
+--   "superuser" deploy path bypasses RLS:
+--     * 2026-06-10 — emission outage: 0081's FORCE policy on memex_emission_keys
+--       filtered verifyEmissionKey() to 0 rows once the runtime cut to memex_app
+--       (fixed by 0087, which fully excluded that identity table).
+--     * 2026-06-11 — What's New ribbon dark on prod: deploy.sh step 1f
+--       (db:generate-whats-new) runs as `postgres` and read `documents` with no
+--       GUC → "judged 0 of 0 shippable specs" against ~70 eligible. Three sibling
+--       deploy scripts (1c handhold-demo, 1d default-standards, 1e guide-content)
+--       were silently failing the same way behind their `|| echo` wrappers.
+--
+--   NO FORCE puts RLS at the correct trust boundary:
+--     * `postgres` (table OWNER, the migration/admin/deploy identity) bypasses
+--       RLS as owner — so all migrations and deploy scripts work with no
+--       per-script changes. Granting BYPASSRLS instead is impossible on Cloud SQL
+--       (no superuser to grant it); wrapping every script in runWithMemexId was
+--       rejected as fragile (spec-257 dec-1 options B/C).
+--     * `memex_app` (runtime role, non-owner, NOBYPASSRLS — verified) remains
+--       SUBJECT to RLS, so runtime tenant isolation is unchanged. Confirm via the
+--       spec-199 cross-tenant regression tests run under the memex_app role.
+--
+-- LOAD-BEARING INVARIANT (spec-257 dec-1 caveat / Standard ac-5)
+--   This is safe ONLY while the runtime never connects as the owner role. RLS
+--   silently stops firing for any runtime path pointed at postgres/DB_USER
+--   credentials. The deploy split already enforces this (RUNTIME_DB_USER=memex_app
+--   vs DB_USER=postgres in deploy.sh); spec-257 dec-3 adds a structural guard.
+--
+-- Tables below = every table FORCE'd on develop as of 2026-06-12. The 14
+-- currently-FORCE'd tables on prod were verified by read-only query
+-- (relforcerowsecurity=true) 2026-06-11; `qa_report_views` was added with
+-- ENABLE+FORCE by 0092 (spec-260) AFTER that query and is included here — files
+-- run 0092→0093 in order, so the table exists by the time this applies.
+-- (`memex_emission_keys` already excluded by 0087; `activity_log` never FORCE'd.)
+--
+-- NOTE: spec-260's 0092 reintroduced the FORCE pattern days after the outages it
+-- causes — nothing prevented it. spec-257 dec-3 (a structural lint/CI guard) and
+-- ac-5 (the Standard) are what stop the next one; this migration only cleans up
+-- the 15 that exist today.
+ALTER TABLE acs             NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE clause_refs     NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE decisions       NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE doc_assignees   NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE doc_comments    NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE doc_members     NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE document_tags   NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE documents       NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE issues          NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE presence        NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE qa_report_views NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE repos           NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE standard_clauses NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE tags            NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE tasks           NO FORCE ROW LEVEL SECURITY;

--- a/packages/server/drizzle/reverts/0093_rls_no_force_owner_bypass.revert.sql
+++ b/packages/server/drizzle/reverts/0093_rls_no_force_owner_bypass.revert.sql
@@ -1,0 +1,23 @@
+-- Revert spec-257 dec-1: re-apply FORCE ROW LEVEL SECURITY on every tenant table.
+--
+-- WARNING: re-applying FORCE re-introduces the 2026-06-10 / 2026-06-11 outage
+-- class — the deploy/migration role (`postgres`, NOBYPASSRLS on Cloud SQL) will
+-- again be filtered to zero rows on any query without an app.memex_id GUC, so
+-- migrations and deploy scripts 1c/1d/1e/1f silently break. Only revert if the
+-- runtime/deploy role topology has changed such that the owner can bypass another
+-- way. See 0091_rls_no_force_owner_bypass.sql and spec-257 dec-1.
+ALTER TABLE acs             FORCE ROW LEVEL SECURITY;
+ALTER TABLE clause_refs     FORCE ROW LEVEL SECURITY;
+ALTER TABLE decisions       FORCE ROW LEVEL SECURITY;
+ALTER TABLE doc_assignees   FORCE ROW LEVEL SECURITY;
+ALTER TABLE doc_comments    FORCE ROW LEVEL SECURITY;
+ALTER TABLE doc_members     FORCE ROW LEVEL SECURITY;
+ALTER TABLE document_tags   FORCE ROW LEVEL SECURITY;
+ALTER TABLE documents       FORCE ROW LEVEL SECURITY;
+ALTER TABLE issues          FORCE ROW LEVEL SECURITY;
+ALTER TABLE presence        FORCE ROW LEVEL SECURITY;
+ALTER TABLE qa_report_views FORCE ROW LEVEL SECURITY;
+ALTER TABLE repos           FORCE ROW LEVEL SECURITY;
+ALTER TABLE standard_clauses FORCE ROW LEVEL SECURITY;
+ALTER TABLE tags            FORCE ROW LEVEL SECURITY;
+ALTER TABLE tasks           FORCE ROW LEVEL SECURITY;

--- a/packages/server/src/__regression__/oauth-authorize-redirect.regression.test.ts
+++ b/packages/server/src/__regression__/oauth-authorize-redirect.regression.test.ts
@@ -1,4 +1,11 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+// spec-253 ac-9 — custom-scheme redirect_uris match by strict (byte-identical)
+// equality at /authorize; the loopback set stays host- and port-insensitive.
+const AC_9 = "mindset-prod/memex-building-itself/specs/spec-253/acs/ac-9";
+// spec-253 scope ac-2 — existing https + loopback redirect shapes still authorize unchanged.
+const AC_2 = "mindset-prod/memex-building-itself/specs/spec-253/acs/ac-2";
 
 // Pins the absolute-Location contract on GET /api/oauth/authorize.
 //
@@ -170,6 +177,7 @@ describe("regression: GET /api/oauth/authorize loopback redirect_uri port flexib
   });
 
   it("loopback: registered localhost matches incoming 127.0.0.1 (hostname swap)", async () => {
+    tagAc(AC_2); // scope ac-2: loopback redirect_uri authorizes unchanged
     stubClientWithRedirect("http://localhost:11111/callback");
     const res = await getAuthorizeWithRedirect("http://127.0.0.1:33333/callback");
     expect(res.status).toBe(302);
@@ -205,8 +213,40 @@ describe("regression: GET /api/oauth/authorize loopback redirect_uri port flexib
   });
 
   it("non-loopback: strict exact-match still works (https registered = https requested)", async () => {
+    tagAc(AC_2); // scope ac-2: https redirect_uri authorizes unchanged
     stubClientWithRedirect("https://test.example/cb");
     const res = await getAuthorizeWithRedirect("https://test.example/cb");
+    expect(res.status).toBe(302);
+  });
+});
+
+// spec-253 ac-9: native-IDE private-use schemes are non-loopback, so they match
+// by strict (byte-identical) equality — there is no port/host flex for them —
+// while the loopback set remains host- and port-insensitive.
+describe("regression: custom-scheme + loopback redirect_uri matching (spec-253 ac-9)", () => {
+  beforeEach(() => {
+    process.env.APP_BASE_URL = "https://int.memex.ai";
+  });
+
+  it("ac-9: registered cursor:// matches a byte-identical incoming (302)", async () => {
+    tagAc(AC_9);
+    const uri = "cursor://anysphere.cursor-mcp/oauth/callback";
+    stubClientWithRedirect(uri);
+    const res = await getAuthorizeWithRedirect(uri);
+    expect(res.status).toBe(302);
+  });
+
+  it("ac-9: registered cursor:// rejects a non-identical incoming (400) — no flex outside loopback", async () => {
+    tagAc(AC_9);
+    stubClientWithRedirect("cursor://anysphere.cursor-mcp/oauth/callback");
+    const res = await getAuthorizeWithRedirect("cursor://anysphere.cursor-mcp/oauth/other");
+    expect(res.status).toBe(400);
+  });
+
+  it("ac-9: loopback localhost:P1 matches 127.0.0.1:P2 (host- and port-insensitive, 302)", async () => {
+    tagAc(AC_9);
+    stubClientWithRedirect("http://localhost:11111/callback");
+    const res = await getAuthorizeWithRedirect("http://127.0.0.1:22222/callback");
     expect(res.status).toBe(302);
   });
 });

--- a/packages/server/src/__security__/oauth-register-rate-limit.security.test.ts
+++ b/packages/server/src/__security__/oauth-register-rate-limit.security.test.ts
@@ -13,6 +13,13 @@ import { inArray } from "drizzle-orm";
 import { db } from "../db/connection.js";
 import { oauthClients } from "../db/schema.js";
 import { resetRateLimits } from "../services/auth-rate-limit.js";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+// spec-253 ac-11 — DCR abuse controls (IP rate-limit) stay enforced after the
+// validator was widened to accept custom-scheme redirect_uris.
+const AC_11 = "mindset-prod/memex-building-itself/specs/spec-253/acs/ac-11";
+// spec-253 scope ac-5 — the DCR rate-limit is part of the preserved security posture.
+const AC_5 = "mindset-prod/memex-building-itself/specs/spec-253/acs/ac-5";
 
 const originalFlag = process.env.OAUTH_ENABLED;
 
@@ -57,6 +64,8 @@ async function registerFromIp(ip: string, label: string): Promise<Response> {
 
 describe("security: POST /api/oauth/register rate-limit", () => {
   it("allows 10 registrations per hour per IP, blocks the 11th, isolates by IP", async () => {
+    tagAc(AC_11);
+    tagAc(AC_5); // scope ac-5: DCR rate-limit still holds (security posture preserved)
     const ipA = "203.0.113.10"; // RFC 5737 documentation range
     const ipB = "203.0.113.11";
 

--- a/packages/server/src/db/spec-199-rls-schema.test.ts
+++ b/packages/server/src/db/spec-199-rls-schema.test.ts
@@ -165,7 +165,7 @@ describe("spec-199 ac-16: RLS tenant isolation", () => {
     ).rejects.toThrow();
   });
 
-  it("ac-16: RLS is enabled and forced on all 13 tenant tables", async () => {
+  it("ac-16: RLS is enabled but NOT forced on all 13 tenant tables (owner-bypass posture, spec-257 dec-1)", async () => {
     tagAc(AC_15);
     tagAc(AC_16);
 
@@ -174,6 +174,15 @@ describe("spec-199 ac-16: RLS tenant isolation", () => {
     // and was excluded from RLS by migration 0087 after the 2026-06-10
     // emission outage. See 0087_emission_keys_rls_exclusion.sql and
     // __regression__/emission-key-contextless-verify.regression.test.ts.
+    //
+    // Posture: RLS is ENABLED (relrowsecurity=t) but NOT FORCED
+    // (relforcerowsecurity=f) — migration 0091 dropped FORCE per spec-257 dec-1.
+    // FORCE only affects the table OWNER; on Cloud SQL the deploy/migration role
+    // is `postgres` (the owner, NOBYPASSRLS), so FORCE filtered every contextless
+    // migration/deploy-script query to zero rows (the 2026-06-10 emission and
+    // 2026-06-11 What's New outages). NO FORCE lets the owner bypass while the
+    // non-owner runtime role `memex_app` stays subject to RLS — verified by the
+    // memex_app SET LOCAL ROLE test below, which still sees 0 rows without a GUC.
 
     // pg_class has relrowsecurity + relforcerowsecurity (pg_tables lacks the latter)
     const rows = (await db.execute(sql`
@@ -208,7 +217,10 @@ describe("spec-199 ac-16: RLS tenant isolation", () => {
       const row = byTable.get(table);
       expect(row, `${table}: not found in pg_class`).toBeDefined();
       expect(row!.rowsecurity, `${table}: rowsecurity not enabled`).toBe(true);
-      expect(row!.forcerowsecurity, `${table}: forcerowsecurity not enabled`).toBe(true);
+      expect(
+        row!.forcerowsecurity,
+        `${table}: FORCE must be OFF (owner-bypass posture, spec-257 dec-1 / migration 0091)`,
+      ).toBe(false);
     }
   });
 
@@ -216,11 +228,13 @@ describe("spec-199 ac-16: RLS tenant isolation", () => {
     tagAc(AC_15);
     tagAc(AC_16);
 
-    // Switch to memex_app within a transaction using SET LOCAL ROLE. This drops
-    // BYPASSRLS for the duration of the transaction (memex_app has NOBYPASSRLS),
-    // so FORCE ROW LEVEL SECURITY applies and the USING clause blocks every row
-    // because no app.memex_id GUC is set. This simulates the production runtime
-    // path before t-14 (DATABASE_URL cutover) runs.
+    // Switch to memex_app within a transaction using SET LOCAL ROLE. memex_app
+    // is a NON-OWNER role (postgres owns these tables) with NOBYPASSRLS, so
+    // ENABLE ROW LEVEL SECURITY alone subjects it to the policies — FORCE is NOT
+    // needed (FORCE only governs the table OWNER, which is why 0091 could drop it
+    // without weakening runtime isolation, spec-257 dec-1). With no app.memex_id
+    // GUC set, the USING clause blocks every row. This is the production runtime
+    // path (DATABASE_URL = memex_app since t-14).
     const dbUrl =
       process.env.DATABASE_URL ?? "postgresql://postgres:postgres@localhost:5432/memex";
     const superSql = postgres(dbUrl, { max: 1 });

--- a/packages/server/src/routes/qa-reports.integration.test.ts
+++ b/packages/server/src/routes/qa-reports.integration.test.ts
@@ -25,6 +25,7 @@ import { upsertUserByEmail } from "../services/users.js";
 
 const AC_19 = "mindset-prod/memex-building-itself/specs/spec-260/acs/ac-19";
 const AC_22 = "mindset-prod/memex-building-itself/specs/spec-260/acs/ac-22";
+const AC_24 = "mindset-prod/memex-building-itself/specs/spec-260/acs/ac-24";
 
 type FeedRow = {
   id: string;
@@ -189,15 +190,24 @@ describe("GET /api/<ns>/<mx>/qa-reports (workspace feed — dec-5)", () => {
 describe("unread counter + view marker (dec-6)", () => {
   it("ac-22: unread counts ALL reports newer than the marker (no marker → all), and viewing zeroes it", async () => {
     tagAc(AC_22);
+    tagAc(AC_24);
 
     // Never viewed → every report in the memex counts (3 in memex A).
     const before = await app.request(`${pathA}/qa-reports/unread`, withApexHost());
     expect(before.status).toBe(200);
     expect(await before.json()).toEqual({ count: 3 });
 
-    // Viewing the feed upserts last_viewed_at = now() → badge zeroes.
+    // Viewing the feed upserts last_viewed_at = now() → badge zeroes. The
+    // receipt carries the PREVIOUS marker (ac-24): null on first-ever view —
+    // the unread boundary the feed page uses to render unread rows expanded.
     const view = await app.request(`${pathA}/qa-reports/view`, withApexHost({ method: "POST" }));
     expect(view.status).toBe(200);
+    const firstReceipt = (await view.json()) as {
+      lastViewedAt: string;
+      previousLastViewedAt: string | null;
+    };
+    expect(firstReceipt.previousLastViewedAt).toBeNull();
+    expect(new Date(firstReceipt.lastViewedAt).getTime()).toBeGreaterThan(0);
 
     const after = await app.request(`${pathA}/qa-reports/unread`, withApexHost());
     expect(await after.json()).toEqual({ count: 0 });
@@ -214,9 +224,16 @@ describe("unread counter + view marker (dec-6)", () => {
     const grown = await app.request(`${pathA}/qa-reports/unread`, withApexHost());
     expect(await grown.json()).toEqual({ count: 1 });
 
-    // Re-viewing resets again (the upsert path, not a second insert).
+    // Re-viewing resets again (the upsert path, not a second insert) — and the
+    // receipt now carries the FIRST view's marker as the previous boundary
+    // (ac-24): a row created after it classifies as unread, one before it as read.
     const reView = await app.request(`${pathA}/qa-reports/view`, withApexHost({ method: "POST" }));
     expect(reView.status).toBe(200);
+    const secondReceipt = (await reView.json()) as {
+      lastViewedAt: string;
+      previousLastViewedAt: string | null;
+    };
+    expect(secondReceipt.previousLastViewedAt).toBe(firstReceipt.lastViewedAt);
     const zeroed = await app.request(`${pathA}/qa-reports/unread`, withApexHost());
     expect(await zeroed.json()).toEqual({ count: 0 });
   });

--- a/packages/server/src/routes/qa-reports.ts
+++ b/packages/server/src/routes/qa-reports.ts
@@ -90,13 +90,17 @@ qaReports.get("/unread", async (c) => {
 
 // POST /api/<ns>/<mx>/qa-reports/view — "I viewed the feed now". Strict session
 // (anonymous callers never reach here); the memex must be readable by the caller
-// (std-7 → 404 otherwise).
+// (std-7 → 404 otherwise). Returns the PREVIOUS marker too (null on first view)
+// — the unread boundary the page uses to render unread rows expanded (ac-24).
 qaReports.post("/view", async (c) => {
   const memexId = await resolveReadableMemexId(c);
   const userId = (c.get("currentUserId") as string | null) ?? null;
   if (!userId) throw new NotFoundError("Not found");
-  const lastViewedAt = await recordQaReportsView(memexId, userId);
-  return c.json({ lastViewedAt: lastViewedAt.toISOString() });
+  const receipt = await recordQaReportsView(memexId, userId);
+  return c.json({
+    lastViewedAt: receipt.lastViewedAt.toISOString(),
+    previousLastViewedAt: receipt.previousLastViewedAt?.toISOString() ?? null,
+  });
 });
 
 export { qaReports };

--- a/packages/server/src/services/oauth/clients.ts
+++ b/packages/server/src/services/oauth/clients.ts
@@ -20,6 +20,27 @@ function randomToken(byteLength = 32): string {
   return randomBytes(byteLength).toString("base64url");
 }
 
+// Schemes never permitted as a redirect_uri target — they can execute script in
+// our origin (javascript:), carry local-file/inline payloads (data/vbscript/
+// file/blob/filesystem), or invoke known-abusable OS handlers (ms-msdt: was the
+// Follina CVE-2022-30190 vector; intent: targets arbitrary Android components).
+// They're denied even though they're non-http(s). Everything else that isn't
+// http(s) is treated as an RFC 8252 §7.1 private-use URI scheme (cursor://,
+// vscode://, windsurf://, com.example.app:/…). This denylist is defence-in-depth,
+// NOT the primary control: the real guards are the browser's external-app prompt,
+// the on-origin consent screen, and mandatory PKCE S256 (codes.ts) — the RFC 8252
+// §8.6 control that makes custom-scheme redirects safe. spec-253 dec-1 / t-3.
+const DANGEROUS_REDIRECT_SCHEMES = new Set([
+  "javascript",
+  "data",
+  "vbscript",
+  "file",
+  "blob",
+  "filesystem",
+  "intent",
+  "ms-msdt",
+]);
+
 /** RFC 7591 metadata accepted at /oauth/register. */
 export interface RegisterClientInput {
   /** Required. URLs the IdP will redirect to after consent. */
@@ -60,9 +81,8 @@ export async function registerClient(input: RegisterClientInput): Promise<Regist
     if (typeof uri !== "string" || uri.length === 0) {
       throw new ValidationError("redirect_uris entries must be non-empty strings");
     }
-    // RFC 7591 §2: redirect_uris MUST be absolute URIs. Localhost variants
-    // (Claude Desktop's loopback flow) are http://; everything else must be
-    // https. Disallow URL fragments per RFC 6749 §3.1.2.
+    // RFC 7591 §2: redirect_uris MUST be absolute URIs. Disallow URL fragments
+    // per RFC 6749 §3.1.2.
     let parsed: URL;
     try {
       parsed = new URL(uri);
@@ -72,10 +92,22 @@ export async function registerClient(input: RegisterClientInput): Promise<Regist
     if (parsed.hash !== "") {
       throw new ValidationError(`redirect_uri must not contain a fragment: ${uri}`);
     }
+    // RFC 8252 native-app redirects, three accepted shapes (spec-253 dec-1):
+    //   1. https:// (any host)
+    //   2. http://{localhost,127.0.0.1} — loopback flow, §7.3 (Claude Desktop)
+    //   3. a private-use URI scheme — §7.1 (cursor://, vscode://, windsurf://, …)
+    // Bare http:// to a non-loopback host and the dangerous-scheme denylist stay
+    // rejected. PKCE S256 (codes.ts) is the safety control for shape 3.
     const isLoopback = parsed.hostname === "localhost" || parsed.hostname === "127.0.0.1";
-    if (parsed.protocol !== "https:" && !(parsed.protocol === "http:" && isLoopback)) {
+    const scheme = parsed.protocol.replace(/:$/, "");
+    const isWebScheme = scheme === "http" || scheme === "https";
+    const accepted =
+      parsed.protocol === "https:" ||
+      (parsed.protocol === "http:" && isLoopback) ||
+      (!isWebScheme && !DANGEROUS_REDIRECT_SCHEMES.has(scheme));
+    if (!accepted) {
       throw new ValidationError(
-        `redirect_uri must be https:// (or http://localhost for loopback flows): ${uri}`,
+        `redirect_uri must be https://, http://localhost, or a private-use URI scheme: ${uri}`,
       );
     }
   }

--- a/packages/server/src/services/oauth/oauth.integration.test.ts
+++ b/packages/server/src/services/oauth/oauth.integration.test.ts
@@ -25,6 +25,23 @@ import {
   __setRotateMintHook,
 } from "./refresh-tokens.js";
 import { createHash, randomBytes } from "node:crypto";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+// spec-253 dec-1 — DCR must accept RFC 8252 §7.1 private-use URI schemes
+// (cursor://, vscode://, …) while still rejecting dangerous web schemes.
+const AC_6 = "mindset-prod/memex-building-itself/specs/spec-253/acs/ac-6";
+const AC_7 = "mindset-prod/memex-building-itself/specs/spec-253/acs/ac-7";
+// spec-253 dec-3 — VS Code's https://vscode.dev/redirect relay registers unchanged.
+const AC_10 = "mindset-prod/memex-building-itself/specs/spec-253/acs/ac-10";
+// spec-253 dec-1/dec-4 — PKCE stays mandatory; DCR abuse controls hold for custom schemes.
+const AC_8 = "mindset-prod/memex-building-itself/specs/spec-253/acs/ac-8";
+const AC_11 = "mindset-prod/memex-building-itself/specs/spec-253/acs/ac-11";
+// spec-253 scope ACs — the manager-level outcomes these mechanism tests collectively
+// prove. A test may tag both its implementation AC and the scope AC it satisfies.
+const AC_1 = "mindset-prod/memex-building-itself/specs/spec-253/acs/ac-1";
+const AC_2 = "mindset-prod/memex-building-itself/specs/spec-253/acs/ac-2";
+const AC_3 = "mindset-prod/memex-building-itself/specs/spec-253/acs/ac-3";
+const AC_5 = "mindset-prod/memex-building-itself/specs/spec-253/acs/ac-5";
 
 // PKCE helpers (RFC 7636 §4).
 function makePkce(): { verifier: string; challenge: string } {
@@ -60,6 +77,7 @@ async function registerAndTrack(input: Parameters<typeof registerClient>[0]) {
 
 describe("OAuth integration: client registration (DCR)", () => {
   it("registers a confidential client and stores a hashed secret", async () => {
+    tagAc(AC_2); // scope ac-2: https:// registration unchanged
     const { reg, client } = await registerAndTrack({
       clientName: "Test client",
       redirectUris: ["https://example.com/cb"],
@@ -97,6 +115,7 @@ describe("OAuth integration: client registration (DCR)", () => {
   });
 
   it("accepts http://localhost loopback (Claude Desktop pattern)", async () => {
+    tagAc(AC_2); // scope ac-2: loopback registration unchanged
     await expect(
       registerAndTrack({
         clientName: "Loopback",
@@ -132,6 +151,133 @@ describe("OAuth integration: client registration (DCR)", () => {
         redirectUris: tooMany,
       }),
     ).rejects.toThrow(/maximum of 10/);
+  });
+
+  // spec-253 dec-1 / dec-3: native IDEs (Cursor, VS Code, Windsurf, Zed)
+  // register an RFC 8252 §7.1 private-use URI scheme as their OAuth callback.
+  // DCR must accept these (and VS Code's https relay) while still rejecting
+  // dangerous web schemes and malformed URIs.
+  const ACCEPTED_REDIRECTS: Array<[string, string]> = [
+    ["cursor (private-use scheme)", "cursor://anysphere.cursor-mcp/oauth/callback"],
+    ["vscode (private-use scheme)", "vscode://anysphere.augment/auth/callback"],
+    ["windsurf (private-use scheme)", "windsurf://codeium.windsurf/callback"],
+    ["reverse-DNS scheme", "com.example.app:/oauth/cb"],
+  ];
+  for (const [label, uri] of ACCEPTED_REDIRECTS) {
+    it(`ac-6: accepts ${label} at registration`, async () => {
+      tagAc(AC_6);
+      tagAc(AC_1); // scope ac-1: a native IDE's private-use scheme registers at DCR
+      const { reg } = await registerAndTrack({
+        clientName: `Native ${label}`,
+        redirectUris: [uri],
+        tokenEndpointAuthMethod: "none",
+      });
+      expect(reg.clientId).toBeTruthy();
+    });
+  }
+
+  it("ac-10: accepts VS Code's https://vscode.dev/redirect relay unchanged", async () => {
+    tagAc(AC_10);
+    const { reg } = await registerAndTrack({
+      clientName: "VS Code relay",
+      redirectUris: ["https://vscode.dev/redirect"],
+      tokenEndpointAuthMethod: "none",
+    });
+    expect(reg.clientId).toBeTruthy();
+  });
+
+  const REJECTED_REDIRECTS: Array<[string, string, RegExp]> = [
+    ["javascript: scheme", "javascript:alert(1)", /private-use URI scheme/],
+    ["data: scheme", "data:text/html,<b>x</b>", /private-use URI scheme/],
+    ["file: scheme", "file:///etc/passwd", /private-use URI scheme/],
+    ["vbscript: scheme", "vbscript:msgbox(1)", /private-use URI scheme/],
+    ["ms-msdt: scheme (Follina handler)", "ms-msdt:/id PCWDiagnostic", /private-use URI scheme/],
+    ["intent: scheme (Android)", "intent://evil/#Intent;scheme=x;end", /private-use URI scheme|fragment/],
+    ["bare http to non-loopback host", "http://evil.example.com/cb", /must be https/],
+    ["a non-absolute string", "/relative/callback", /absolute URI/],
+  ];
+  for (const [label, uri, matcher] of REJECTED_REDIRECTS) {
+    it(`ac-7: rejects ${label}`, async () => {
+      tagAc(AC_7);
+      tagAc(AC_3); // scope ac-3: dangerous/malformed redirect URIs rejected with a clear error
+      await expect(
+        registerClient({ clientName: `Bad ${label}`, redirectUris: [uri] }),
+      ).rejects.toThrow(matcher);
+    });
+  }
+
+  it("ac-6: new URL() parses a private-use scheme without throwing (parse-behaviour lock)", () => {
+    tagAc(AC_6);
+    const parsed = new URL("cursor://anysphere.cursor-mcp/oauth/callback");
+    expect(parsed.protocol).toBe("cursor:");
+    expect(parsed.hash).toBe("");
+  });
+
+  it("ac-11: the 10-redirect_uri cap still applies to custom-scheme URIs", async () => {
+    tagAc(AC_11);
+    tagAc(AC_5); // scope ac-5: the 10-redirect_uri cap still holds
+    const tooMany = Array.from({ length: 11 }, (_, i) => `cursor://anysphere.cursor-mcp/cb${i}`);
+    await expect(
+      registerClient({ clientName: "Too many custom schemes", redirectUris: tooMany }),
+    ).rejects.toThrow(/maximum of 10/);
+  });
+});
+
+// spec-253 ac-8: widening the redirect_uri validator must not weaken PKCE —
+// S256 stays mandatory at both mint and consume, which is the control that
+// makes custom-scheme redirects safe (RFC 8252 §8.6).
+describe("OAuth integration: PKCE stays mandatory after custom-scheme widening (spec-253 ac-8)", () => {
+  it("ac-8: mintAuthCode rejects a non-S256 (plain) code_challenge_method", async () => {
+    tagAc(AC_8);
+    tagAc(AC_5); // scope ac-5: PKCE S256 stays mandatory
+
+    const userId = await makeTestUser();
+    const { client } = await registerAndTrack({
+      clientName: "PKCE plain reject",
+      redirectUris: ["cursor://anysphere.cursor-mcp/oauth/callback"],
+      tokenEndpointAuthMethod: "none",
+    });
+    await expect(
+      mintAuthCode({
+        clientId: client.id,
+        userId,
+        orgId: null,
+        redirectUri: "cursor://anysphere.cursor-mcp/oauth/callback",
+        codeChallenge: "abc",
+        codeChallengeMethod: "plain",
+        scopes: ["memex.full"],
+      }),
+    ).rejects.toThrow(/S256/);
+  });
+
+  it("ac-8: consumeAuthCode rejects a mismatched PKCE verifier (custom-scheme client)", async () => {
+    tagAc(AC_8);
+    tagAc(AC_5); // scope ac-5: PKCE S256 verification stays mandatory
+
+    const userId = await makeTestUser();
+    const { client } = await registerAndTrack({
+      clientName: "PKCE verify custom",
+      redirectUris: ["cursor://anysphere.cursor-mcp/oauth/callback"],
+      tokenEndpointAuthMethod: "none",
+    });
+    const { challenge } = makePkce();
+    const minted = await mintAuthCode({
+      clientId: client.id,
+      userId,
+      orgId: null,
+      redirectUri: "cursor://anysphere.cursor-mcp/oauth/callback",
+      codeChallenge: challenge,
+      codeChallengeMethod: "S256",
+      scopes: ["memex.full"],
+    });
+    await expect(
+      consumeAuthCode({
+        code: minted.code,
+        codeVerifier: randomBytes(32).toString("base64url"),
+        expectedClientId: client.id,
+        expectedRedirectUri: "cursor://anysphere.cursor-mcp/oauth/callback",
+      }),
+    ).rejects.toThrow(/PKCE verifier mismatch/);
   });
 });
 

--- a/packages/server/src/services/qa-reports.ts
+++ b/packages/server/src/services/qa-reports.ts
@@ -195,9 +195,22 @@ export async function countUnreadQaReports(memexId: string, userId: string): Pro
   return row?.count ?? 0;
 }
 
+export interface QaReportsViewReceipt {
+  /** The marker just written — "now". */
+  lastViewedAt: Date;
+  /**
+   * The marker BEFORE this view, or null on first-ever view. This is the
+   * unread boundary the badge was counting against, returned so the feed page
+   * can render unread rows expanded (ac-24) even though opening the page is
+   * exactly what resets the marker.
+   */
+  previousLastViewedAt: Date | null;
+}
+
 /**
  * Record that `userId` viewed the memex's QA Reports feed NOW — upserts the
- * (user, memex) marker, zeroing the unread badge. Returns the new marker time.
+ * (user, memex) marker, zeroing the unread badge — and returns the PREVIOUS
+ * marker alongside, so the caller can still classify what was unread.
  *
  * Goes through mutate() per std-8, but SILENT: the marker is per-user
  * read-state (an idempotent re-write of "when did I last look"), not
@@ -205,8 +218,15 @@ export async function countUnreadQaReports(memexId: string, userId: string): Pro
  * badge's own zeroing is client-local (the page that posted the view already
  * knows). std-32's activity columns don't apply to this table by design.
  */
-export async function recordQaReportsView(memexId: string, userId: string): Promise<Date> {
+export async function recordQaReportsView(
+  memexId: string,
+  userId: string,
+): Promise<QaReportsViewReceipt> {
   const now = new Date();
+  const [prior] = await db
+    .select({ lastViewedAt: qaReportViews.lastViewedAt })
+    .from(qaReportViews)
+    .where(and(eq(qaReportViews.userId, userId), eq(qaReportViews.memexId, memexId)));
   await mutate(
     {},
     { memexId, entity: "qa_report_view", action: "updated" },
@@ -220,5 +240,5 @@ export async function recordQaReportsView(memexId: string, userId: string): Prom
         }),
     { silent: true },
   );
-  return now;
+  return { lastViewedAt: now, previousLastViewedAt: prior?.lastViewedAt ?? null };
 }

--- a/packages/ui/e2e/journey-29-spec-260-qa-reports.spec.ts
+++ b/packages/ui/e2e/journey-29-spec-260-qa-reports.spec.ts
@@ -38,6 +38,7 @@ const ACS_BY_TITLE: Record<string, string[]> = {
     AC(8),
     AC(9),
     AC(10),
+    AC(24),
   ],
 };
 
@@ -193,16 +194,31 @@ test.describe("spec-260 — Build QA Report", () => {
       new RegExp(`/specs/${specB.handle}$`),
     );
 
-    // The report body opens on demand.
-    await rows.nth(0).getByTestId("qa-report-row-toggle").click();
+    // ac-24: a first-ever view has no previous marker → EVERY row is unread and
+    // arrives expanded, no click needed.
     await expect(rows.nth(0).getByTestId("qa-report-row-body")).toContainText(
       "Beta build session report.",
+    );
+    await expect(rows.nth(1).getByTestId("qa-report-row-body")).toContainText(
+      "Alpha build session report.",
     );
 
     // ── Viewing the feed zeroed the badge (count-everything → 0 after view). ──
     await page.goto(tenantPath(tenant.namespaceSlug, tenant.memexSlug, "/specs"));
     await expect(page.getByRole("link", { name: "QA Reports" })).toBeVisible({ timeout: 15_000 });
     await expect(page.getByTestId("qa-reports-nav-badge")).toHaveCount(0);
+
+    // ac-24: revisiting — both reports are now READ → they render collapsed.
+    await page.getByRole("link", { name: "QA Reports" }).click();
+    const readRows = page.getByTestId("qa-report-row");
+    await expect(readRows).toHaveCount(2, { timeout: 15_000 });
+    await expect(readRows.nth(0).getByTestId("qa-report-row-body")).toHaveCount(0);
+    await expect(readRows.nth(1).getByTestId("qa-report-row-body")).toHaveCount(0);
+    // The toggle still opens a read row on demand.
+    await readRows.nth(0).getByTestId("qa-report-row-toggle").click();
+    await expect(readRows.nth(0).getByTestId("qa-report-row-body")).toContainText(
+      "Beta build session report.",
+    );
 
     // A THIRD report lands (a new build session elsewhere) → the badge returns.
     await seedSection({
@@ -214,5 +230,15 @@ test.describe("spec-260 — Build QA Report", () => {
     });
     await page.goto(tenantPath(tenant.namespaceSlug, tenant.memexSlug, "/specs"));
     await expect(page.getByTestId("qa-reports-nav-badge")).toHaveText("1", { timeout: 15_000 });
+
+    // ac-24: only the NEW report is unread → it alone arrives expanded.
+    await page.getByRole("link", { name: "QA Reports" }).click();
+    const mixedRows = page.getByTestId("qa-report-row");
+    await expect(mixedRows).toHaveCount(3, { timeout: 15_000 });
+    await expect(mixedRows.nth(0).getByTestId("qa-report-row-body")).toContainText(
+      "Alpha session two report.",
+    );
+    await expect(mixedRows.nth(1).getByTestId("qa-report-row-body")).toHaveCount(0);
+    await expect(mixedRows.nth(2).getByTestId("qa-report-row-body")).toHaveCount(0);
   });
 });

--- a/packages/ui/src/components/CliInstallSection.test.tsx
+++ b/packages/ui/src/components/CliInstallSection.test.tsx
@@ -40,3 +40,20 @@ describe('spec-201 ac-16: claude.ai web + Cursor connect steps', () => {
     expect(screen.getAllByRole('button', { name: 'Copy' }).length).toBeGreaterThanOrEqual(2);
   });
 });
+
+// spec-253 t-5 (dec-3): the connect panel covers native IDEs beyond Cursor —
+// VS Code gets its own block, and the framing names the OAuth-on-connect set.
+// Smoke check that the artifact actually renders the new content.
+describe('spec-253: native-IDE OAuth connect steps (VS Code)', () => {
+  it('includes a VS Code connect block with the derived URL in its config', () => {
+    render(<CliInstallSection />);
+    expect(screen.getByRole('heading', { name: 'VS Code' })).toBeInTheDocument();
+    const vscodeConfig = screen.getByText(/"servers"[\s\S]*"memex"[\s\S]*\/mcp/);
+    expect(vscodeConfig.textContent).toContain(`${installBase}/mcp`);
+  });
+
+  it('frames the OAuth-on-connect clients as native IDEs (Cursor, VS Code, Windsurf, Zed)', () => {
+    render(<CliInstallSection />);
+    expect(screen.getByText(/Cursor, VS Code, Windsurf, Zed/)).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/CliInstallSection.tsx
+++ b/packages/ui/src/components/CliInstallSection.tsx
@@ -20,10 +20,24 @@ const PS_COMMAND = `irm ${installBase}/install.ps1 | iex`;
 const MCP_URL = `${installBase}/mcp`;
 
 // Cursor MCP config — remote server over HTTP. url-only is correct for dynamic
-// OAuth (spec-31): Cursor runs the sign-in flow on connect (no static token).
+// OAuth (spec-31 / spec-253): Cursor runs the sign-in flow on connect (no static
+// token). Cursor's OAuth callback is a private-use scheme (cursor://…), which the
+// DCR endpoint accepts per spec-253.
 const CURSOR_CONFIG = `{
   "mcpServers": {
     "memex": {
+      "url": "${MCP_URL}"
+    }
+  }
+}`;
+
+// VS Code MCP config — `.vscode/mcp.json` uses `servers` (not `mcpServers`) with
+// an explicit `type`. url-only = OAuth on connect (spec-253). VS Code may use a
+// loopback (127.0.0.1), an https relay, or a vscode:// callback; all are accepted.
+const VSCODE_CONFIG = `{
+  "servers": {
+    "memex": {
+      "type": "http",
       "url": "${MCP_URL}"
     }
   }
@@ -52,7 +66,7 @@ export function CliInstallSection() {
       <p className="mb-8 text-secondary">
         Connect Memex to Claude Code and Claude Desktop. The installer opens your browser
         once to authorize this device — after that it works without ever expiring. Using
-        claude.ai (web) or Cursor instead? See <a href="#other-clients" className="underline hover:text-primary">Other clients</a> below.
+        claude.ai (web) or a native IDE like Cursor or VS Code instead? See <a href="#other-clients" className="underline hover:text-primary">Other clients</a> below.
       </p>
 
       <div className="mb-10">
@@ -85,8 +99,9 @@ export function CliInstallSection() {
       <div id="other-clients" className="mb-10">
         <h3 className="text-base font-medium mb-3 text-heading">Other clients</h3>
         <p className="text-sm mb-3 text-secondary">
-          claude.ai (web) and Cursor connect to the same endpoint and sign in over OAuth —
-          no token to paste. Your MCP URL:
+          claude.ai (web) and native IDEs — Cursor, VS Code, Windsurf, Zed — connect to the
+          same endpoint and sign in over OAuth, so there's no token to paste. Add the server
+          with the URL below, then complete the sign-in your client prompts for. Your MCP URL:
         </p>
         <CodeBlock code={MCP_URL} />
 
@@ -108,6 +123,21 @@ export function CliInstallSection() {
               complete the OAuth sign-in:
             </p>
             <CodeBlock code={CURSOR_CONFIG} />
+          </div>
+          <div>
+            <h4 className="text-sm font-medium mb-2 text-heading">VS Code</h4>
+            <p className="text-xs mb-2 text-secondary">
+              Add to <InlineCode>.vscode/mcp.json</InlineCode>, then run{' '}
+              <InlineCode>MCP: List Servers</InlineCode> → <strong>Start</strong> and complete the
+              sign-in. VS Code completes OAuth automatically over whichever callback it picks
+              (a loopback address, its <InlineCode>vscode.dev</InlineCode> relay, or a{' '}
+              <InlineCode>vscode://</InlineCode> handler) — all are accepted:
+            </p>
+            <CodeBlock code={VSCODE_CONFIG} />
+            <p className="text-xs mt-2 text-muted">
+              Windsurf and Zed use the same URL in their own MCP config and sign in over OAuth
+              the same way — no token required.
+            </p>
           </div>
         </div>
       </div>

--- a/packages/ui/src/hooks/useQaReports.spec-260.test.tsx
+++ b/packages/ui/src/hooks/useQaReports.spec-260.test.tsx
@@ -86,18 +86,54 @@ describe('useQaReportsUnreadCount (dec-6 badge)', () => {
 });
 
 describe('recordQaReportsView', () => {
-  it('ac-10: POSTs the view marker and broadcasts the zeroing event', async () => {
+  it('ac-10/ac-24: POSTs the view marker, broadcasts the zeroing event, and returns the receipt with the PREVIOUS marker', async () => {
     tagAc(AC(10));
-    fetchMock.mockResolvedValue(jsonResponse({ lastViewedAt: '2026-06-12T00:00:00Z' }));
+    tagAc(AC(24));
+    fetchMock.mockResolvedValue(
+      jsonResponse({
+        lastViewedAt: '2026-06-12T00:00:00Z',
+        previousLastViewedAt: '2026-06-10T00:00:00Z',
+      }),
+    );
     const heard = vi.fn();
     window.addEventListener(QA_REPORTS_VIEWED_EVENT, heard);
     try {
-      await recordQaReportsView();
+      const receipt = await recordQaReportsView();
       expect(fetchMock).toHaveBeenCalledWith('/api/acme/main/qa-reports/view', { method: 'POST' });
       expect(heard).toHaveBeenCalledTimes(1);
+      // ac-24: the previous marker is the unread boundary the feed page uses
+      // to render unread rows expanded.
+      expect(receipt).toEqual({
+        lastViewedAt: '2026-06-12T00:00:00Z',
+        previousLastViewedAt: '2026-06-10T00:00:00Z',
+      });
     } finally {
       window.removeEventListener(QA_REPORTS_VIEWED_EVENT, heard);
     }
+  });
+
+  it('returns null on a failed write — the page falls back to collapsed rows', async () => {
+    fetchMock.mockRejectedValue(new Error('boom'));
+    expect(await recordQaReportsView()).toBeNull();
+  });
+
+  it('ac-24: concurrent calls share one POST — StrictMode double-mount cannot burn the previous marker', async () => {
+    tagAc(AC(24));
+    // If the double-mounted effect fired two posts, the second would see the
+    // first's just-written marker as "previous" and collapse everything.
+    let resolveFetch!: (r: Response) => void;
+    fetchMock.mockReturnValue(new Promise<Response>((r) => (resolveFetch = r)));
+
+    const first = recordQaReportsView();
+    const second = recordQaReportsView();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    resolveFetch(
+      jsonResponse({ lastViewedAt: '2026-06-12T00:00:00Z', previousLastViewedAt: null }),
+    );
+    const [a, b] = await Promise.all([first, second]);
+    expect(a).toEqual(b);
+    expect(a?.previousLastViewedAt).toBeNull();
   });
 });
 

--- a/packages/ui/src/hooks/useQaReports.ts
+++ b/packages/ui/src/hooks/useQaReports.ts
@@ -118,20 +118,51 @@ export function useQaReportsFeed(limit = DEFAULT_LIMIT): UseQaReportsFeedResult 
   return { rows, loading, error, hasMore, loadOlder, refresh };
 }
 
+export interface QaReportsViewReceipt {
+  /** The marker just written. */
+  lastViewedAt: string;
+  /**
+   * The marker BEFORE this view (null = first-ever view). This is the unread
+   * boundary the badge was counting against — returned because opening the
+   * page is exactly what resets the marker, so the page couldn't otherwise
+   * know which rows were unread (ac-24).
+   */
+  previousLastViewedAt: string | null;
+}
+
+// One view-POST at a time. React StrictMode double-mounts effects in dev, so
+// the page would otherwise fire TWO immediate POSTs — and the second receipt's
+// "previous" marker would be the first POST's just-written now(), classifying
+// every row as read and collapsing the lot (ac-24). Concurrent callers share
+// the in-flight call; it clears on settle so a later real revisit POSTs fresh.
+let viewInFlight: Promise<QaReportsViewReceipt | null> | null = null;
+
 /**
  * Record that the current user viewed the QA Reports feed now. Upserts the
- * per-(user, memex) last_viewed_at marker server-side and broadcasts
- * QA_REPORTS_VIEWED_EVENT so the nav badge zeroes immediately.
+ * per-(user, memex) last_viewed_at marker server-side, broadcasts
+ * QA_REPORTS_VIEWED_EVENT so the nav badge zeroes immediately, and returns the
+ * view receipt (incl. the PREVIOUS marker). Returns null when the marker can't
+ * be written (no tenant context, anonymous viewer, network failure) — the
+ * caller falls back to collapsed rows.
  */
-export async function recordQaReportsView(): Promise<void> {
-  const base = tenantBase();
-  if (!base) return;
-  try {
-    const res = await fetchWithRetry(`${base}/qa-reports/view`, { method: 'POST' });
-    if (res.ok) window.dispatchEvent(new Event(QA_REPORTS_VIEWED_EVENT));
-  } catch {
-    // Best-effort: a failed marker write leaves the badge stale, never breaks the page.
-  }
+export function recordQaReportsView(): Promise<QaReportsViewReceipt | null> {
+  if (viewInFlight) return viewInFlight;
+  viewInFlight = (async () => {
+    const base = tenantBase();
+    if (!base) return null;
+    try {
+      const res = await fetchWithRetry(`${base}/qa-reports/view`, { method: 'POST' });
+      if (!res.ok) return null;
+      window.dispatchEvent(new Event(QA_REPORTS_VIEWED_EVENT));
+      return (await res.json()) as QaReportsViewReceipt;
+    } catch {
+      // Best-effort: a failed marker write leaves the badge stale, never breaks the page.
+      return null;
+    } finally {
+      viewInFlight = null;
+    }
+  })();
+  return viewInFlight;
 }
 
 /**

--- a/packages/ui/src/pages/QaReports.spec-260.test.tsx
+++ b/packages/ui/src/pages/QaReports.spec-260.test.tsx
@@ -93,7 +93,9 @@ beforeEach(() => {
     refresh: vi.fn().mockResolvedValue(undefined),
   };
   useQaReportsFeedMock.mockImplementation(() => feed);
-  recordViewMock.mockResolvedValue(undefined);
+  // Default: marker unavailable → all rows collapsed; the ac-24 tests
+  // override with a real receipt.
+  recordViewMock.mockResolvedValue(null);
 });
 
 function renderPage() {
@@ -105,11 +107,11 @@ function renderPage() {
 }
 
 describe('spec-260 — QA Reports feed page', () => {
-  it('ac-8: lists reports newest-first and Load More fetches older entries', () => {
+  it('ac-8: lists reports newest-first and Load More fetches older entries', async () => {
     tagAc(AC(8));
     renderPage();
 
-    const rows = screen.getAllByTestId('qa-report-row');
+    const rows = await screen.findAllByTestId('qa-report-row');
     expect(rows).toHaveLength(3);
     // Newest-first: the order the hook returned is preserved.
     expect(within(rows[0]).getByTestId('qa-report-row-spec')).toHaveTextContent('spec-9');
@@ -120,12 +122,12 @@ describe('spec-260 — QA Reports feed page', () => {
     expect(feed.loadOlder).toHaveBeenCalledTimes(1);
   });
 
-  it('ac-9/ac-20: each row shows WHEN, WHICH Spec (linked), and WHO executed it', () => {
+  it('ac-9/ac-20: each row shows WHEN, WHICH Spec (linked), and WHO executed it', async () => {
     tagAc(AC(9));
     tagAc(AC(20));
     renderPage();
 
-    const rows = screen.getAllByTestId('qa-report-row');
+    const rows = await screen.findAllByTestId('qa-report-row');
 
     // WHICH — the parent Spec, linked.
     const specLink = within(rows[0]).getByTestId('qa-report-row-spec');
@@ -161,16 +163,68 @@ describe('spec-260 — QA Reports feed page', () => {
     expect(recordViewMock).toHaveBeenCalledTimes(1);
   });
 
-  it('renders the row body on demand (read-only markdown)', () => {
+  it('renders the row body on demand (read-only markdown)', async () => {
     renderPage();
-    const first = screen.getAllByTestId('qa-report-row')[0];
+    const first = (await screen.findAllByTestId('qa-report-row'))[0];
     fireEvent.click(within(first).getByTestId('qa-report-row-toggle'));
     expect(within(first).getByTestId('qa-report-row-body')).toHaveTextContent('NEWEST report body');
   });
 
-  it('shows the quiet empty state when no reports exist', () => {
+  it('shows the quiet empty state when no reports exist', async () => {
     feed = { ...feed, rows: [], hasMore: false };
     renderPage();
-    expect(screen.getByTestId('qa-reports-empty')).toBeInTheDocument();
+    expect(await screen.findByTestId('qa-reports-empty')).toBeInTheDocument();
+  });
+
+  // ── ac-24: unread rows open, read rows closed ────────────────────────────
+  // The unread boundary is the PREVIOUS last_viewed_at from the view receipt
+  // (opening the page resets the marker, so the receipt is the only place the
+  // old value survives). Fixture times: r-3 = 03 Jun, r-2 = 02 Jun, r-1 = 01 Jun.
+
+  it('ac-24: rows newer than the previous marker render expanded; read rows collapsed', async () => {
+    tagAc(AC(24));
+    recordViewMock.mockResolvedValue({
+      lastViewedAt: '2026-06-12T00:00:00Z',
+      previousLastViewedAt: '2026-06-01T12:00:00Z', // after r-1, before r-2/r-3
+    });
+    renderPage();
+
+    const rows = await screen.findAllByTestId('qa-report-row');
+    // Unread (r-3, r-2): expanded on arrival.
+    expect(within(rows[0]).getByTestId('qa-report-row-body')).toHaveTextContent(
+      'NEWEST report body',
+    );
+    expect(within(rows[1]).queryByTestId('qa-report-row-body')).toBeInTheDocument();
+    // Read (r-1): collapsed.
+    expect(within(rows[2]).queryByTestId('qa-report-row-body')).not.toBeInTheDocument();
+
+    // The user's own toggle still wins: collapsing an unread row works.
+    fireEvent.click(within(rows[0]).getByTestId('qa-report-row-toggle'));
+    expect(within(rows[0]).queryByTestId('qa-report-row-body')).not.toBeInTheDocument();
+  });
+
+  it('ac-24: first-ever view (no previous marker) → every row is unread and expanded', async () => {
+    tagAc(AC(24));
+    recordViewMock.mockResolvedValue({
+      lastViewedAt: '2026-06-12T00:00:00Z',
+      previousLastViewedAt: null,
+    });
+    renderPage();
+
+    const rows = await screen.findAllByTestId('qa-report-row');
+    for (const row of rows) {
+      expect(within(row).queryByTestId('qa-report-row-body')).toBeInTheDocument();
+    }
+  });
+
+  it('ac-24: marker unavailable (anonymous / failed write) → all rows collapsed', async () => {
+    tagAc(AC(24));
+    recordViewMock.mockResolvedValue(null);
+    renderPage();
+
+    const rows = await screen.findAllByTestId('qa-report-row');
+    for (const row of rows) {
+      expect(within(row).queryByTestId('qa-report-row-body')).not.toBeInTheDocument();
+    }
   });
 });

--- a/packages/ui/src/pages/QaReports.tsx
+++ b/packages/ui/src/pages/QaReports.tsx
@@ -35,8 +35,10 @@ function executorLabel(row: QaReportFeedRow): string {
   return kind || 'unknown';
 }
 
-function FeedRow({ row }: { row: QaReportFeedRow }) {
-  const [open, setOpen] = useState(false);
+function FeedRow({ row, defaultOpen = false }: { row: QaReportFeedRow; defaultOpen?: boolean }) {
+  // ac-24: unread rows arrive expanded; read rows collapsed. Initial state
+  // only — the user's own toggling always wins afterwards.
+  const [open, setOpen] = useState(defaultOpen);
   return (
     <li
       data-testid="qa-report-row"
@@ -80,11 +82,37 @@ function FeedRow({ row }: { row: QaReportFeedRow }) {
 export function QaReports() {
   const { rows, loading, error, hasMore, loadOlder, refresh } = useQaReportsFeed();
 
+  // ac-24: the unread boundary — the viewer's PREVIOUS last_viewed_at, captured
+  // from the view receipt (opening the page is what resets the marker, so the
+  // receipt is the only place the old value survives).
+  //   undefined        → receipt still in flight (hold the list so rows don't
+  //                      initialise collapsed and then refuse to open)
+  //   { prev: null }   → first-ever view: everything is unread → all open
+  //   { prev: ISO }    → rows newer than it are unread → open
+  //   { prev: 'all' }  → marker unavailable (anonymous / failure): no per-user
+  //                      unread concept → all collapsed
+  const [boundary, setBoundary] = useState<{ prev: string | null | 'all' } | undefined>(undefined);
+
   // Opening the page = viewing the feed: upsert the per-user marker (dec-6),
-  // which zeroes the nav badge.
+  // which zeroes the nav badge, and keep its receipt as the unread boundary.
   useEffect(() => {
-    void recordQaReportsView();
+    let cancelled = false;
+    void recordQaReportsView().then((receipt) => {
+      if (cancelled) return;
+      setBoundary(receipt ? { prev: receipt.previousLastViewedAt } : { prev: 'all' });
+    });
+    return () => {
+      cancelled = true;
+    };
   }, []);
+
+  // Both ISO-8601 UTC strings from the same serializer, so lexicographic
+  // comparison is chronological.
+  const isUnread = (row: QaReportFeedRow): boolean => {
+    if (!boundary || boundary.prev === 'all') return false;
+    if (boundary.prev === null) return true;
+    return row.createdAt > boundary.prev;
+  };
 
   // Live updates: a new report lands on the std-8 bus as a section event —
   // refetch the first page so it appears without a reload (debounced upstream).
@@ -104,7 +132,7 @@ export function QaReports() {
         </div>
       )}
 
-      {loading && rows.length === 0 ? (
+      {(loading && rows.length === 0) || boundary === undefined ? (
         <div data-testid="qa-reports-loading" className="text-sm text-muted py-8 text-center">
           Loading…
         </div>
@@ -116,7 +144,7 @@ export function QaReports() {
       ) : (
         <ul data-testid="qa-reports-list" className="space-y-3">
           {rows.map((row) => (
-            <FeedRow key={row.id} row={row} />
+            <FeedRow key={row.id} row={row} defaultOpen={isUnread(row)} />
           ))}
         </ul>
       )}


### PR DESCRIPTION
## Release contents (develop → main)

- **#164 — `fix(rls)`: NO FORCE on tenant tables, restore owner-bypass (spec-257 dec-1)** ← the headline
  Migration **0093** drops `FORCE` (keeps `ENABLE` + policies) on all 15 currently-FORCE'd tenant tables. On Cloud SQL the deploy/migration role connects as `postgres` (verified `NOBYPASSRLS`, owns all tables), so `FORCE` was filtering every contextless deploy/migration query to zero rows — the cause of the 2026-06-10 emission outage and the 2026-06-11 What's New ribbon breakage, and the silent failure of deploy scripts 1c–1f. `NO FORCE` lets the owner bypass (migrations + deploy scripts work) while `memex_app` (runtime, non-owner) stays subject → runtime isolation unchanged. **This prod deploy will apply 0093, re-run the four backfills, and populate the What's New ribbon.**
- **#163 — spec-260** QA Report unread feed render polish
- **#146 — spec-253** accept native-app private-use redirect URIs at DCR

## std-21 release pre-flight (all green)
- [x] (a) develop CI green — deploy + test both success on the merged tip
- [x] (b) int smoke green — std-17 tail on the int deploy
- [x] (c) content invariant: `git log develop..main --no-merges` is **empty**

## 0093 verification ledger
- [x] Ownership of all 15 tables = `postgres` (so `ALTER … NO FORCE` can't fail on a non-owner)
- [x] Applied clean locally; targeted RLS tests 10/10; full `make test` green (one pre-existing unrelated Slack OAuth EE failure)
- [x] **Verified on INT**: `forced 15→0`, owner sees 1321 docs with no GUC (owner-bypass proven), `memex_app` still sees 0 (isolation intact)
- [ ] **PROD (this deploy)**: re-run `/tmp/rls-verify-prod.sh` → expect `forced 15→0`, `docs_visible_to_owner > 0`, `whats_new_entries > 0`; eyeball the ribbon at memex.ai

## Rollback
`reverts/0093_rls_no_force_owner_bypass.revert.sql` re-applies FORCE (re-introduces the outage class — see file header).

Merging this PR (as a merge commit, per std-21) auto-deploys prod, unattended.

Refs: spec-257 dec-1