### PR TITLE
fix(oauth): merge params into redirect_uri at authorize, don't concat ?code= (spec-275)

### DIFF
--- a/packages/server/src/__e2e__/oauth-flow.api.test.ts
+++ b/packages/server/src/__e2e__/oauth-flow.api.test.ts
@@ -26,6 +26,12 @@ import {
 } from "../db/schema.js";
 import { upsertUserByEmail } from "../services/users.js";
 import { signSessionToken } from "../services/auth-jwt.js";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+// spec-275 — the authorize redirect must MERGE params into a redirect_uri that
+// already carries a query string, not blindly concatenate `?code=`.
+const SPEC275_AC_1 = "mindset-prod/memex-building-itself/specs/spec-275/acs/ac-1";
+const SPEC275_AC_2 = "mindset-prod/memex-building-itself/specs/spec-275/acs/ac-2";
 
 const originalFlag = process.env.OAUTH_ENABLED;
 
@@ -293,5 +299,73 @@ describe("OAuth e2e — full connector flow", () => {
     const refreshes = await db.select().from(oauthRefreshTokens).limit(1);
     expect(Array.isArray(codes)).toBe(true);
     expect(Array.isArray(refreshes)).toBe(true);
+  });
+});
+
+describe("OAuth e2e — query-bearing redirect_uri merge (spec-275)", () => {
+  // A redirect_uri with an existing query string is legal (RFC 6749 §3.1.2 bans
+  // only fragments). The authorize handler must MERGE code/state/error into it,
+  // not concat `?code=` (which produced `…?tenant=acme?code=…` and broke parsing).
+  async function registerAndAuthorize(redirectUri: string, decision: "allow" | "deny"): Promise<string> {
+    const { app } = await import("../app.js");
+    const user = await upsertUserByEmail(`oauth-q-${decision}-${Date.now()}-${Math.random()}@test.dev`);
+    userIds.push(user.id);
+    const sessionJwt = signSessionToken(user.id);
+
+    const regRes = await app.fetch(
+      new Request("https://memex.ai/api/oauth/register", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ client_name: "spec-275 query redirect", redirect_uris: [redirectUri] }),
+      }),
+    );
+    expect(regRes.status).toBe(201);
+    const reg = (await regRes.json()) as { client_id: string };
+    const [client] = await db
+      .select()
+      .from(oauthClients)
+      .where(inArray(oauthClients.clientId, [reg.client_id]));
+    clientRowIds.push(client.id);
+
+    const { challenge } = makePkce();
+    const authRes = await app.fetch(
+      new Request("https://memex.ai/api/oauth/authorize", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Authorization: `Bearer ${sessionJwt}` },
+        body: JSON.stringify({
+          response_type: "code",
+          client_id: reg.client_id,
+          redirect_uri: redirectUri,
+          code_challenge: challenge,
+          code_challenge_method: "S256",
+          state: "test-state",
+          decision,
+        }),
+      }),
+    );
+    expect(authRes.status).toBe(200);
+    const { redirect } = (await authRes.json()) as { redirect: string };
+    return redirect;
+  }
+
+  it("ac-1/ac-2: grant merges code+state into an existing query string (no double-?)", async () => {
+    tagAc(SPEC275_AC_1);
+    tagAc(SPEC275_AC_2);
+    const redirect = await registerAndAuthorize("https://test.example/callback?tenant=acme", "allow");
+    expect(redirect.split("?").length).toBe(2); // exactly one '?' — merged, not concatenated
+    const u = new URL(redirect);
+    expect(u.searchParams.get("tenant")).toBe("acme"); // original param preserved, intact
+    expect(u.searchParams.get("code")).toBeTruthy(); // merged & individually parseable
+    expect(u.searchParams.get("state")).toBe("test-state");
+  });
+
+  it("ac-1: deny merges error+state into an existing query string (no double-?)", async () => {
+    tagAc(SPEC275_AC_1);
+    const redirect = await registerAndAuthorize("https://test.example/callback?tenant=acme", "deny");
+    expect(redirect.split("?").length).toBe(2);
+    const u = new URL(redirect);
+    expect(u.searchParams.get("tenant")).toBe("acme");
+    expect(u.searchParams.get("error")).toBe("access_denied");
+    expect(u.searchParams.get("state")).toBe("test-state");
   });
 });

--- a/packages/server/src/routes/oauth/authorize.ts
+++ b/packages/server/src/routes/oauth/authorize.ts
@@ -202,11 +202,23 @@ authorize.post("/", async (c) => {
   }
 
   const state = typeof md.state === "string" ? md.state : "";
-  const stateParam = state ? `&state=${encodeURIComponent(state)}` : "";
+
+  // Build the callback by MERGING params into the registered redirect_uri via
+  // URLSearchParams — never string-concat `?…`. A redirect_uri may legally carry
+  // its own query string (RFC 6749 §3.1.2 forbids only fragments, which DCR
+  // already rejects), so a naive `${uri}?code=` produced `…?tenant=acme?code=…`
+  // and broke the client's parse (spec-275). `md.redirect_uri` is already
+  // validated (clientRedirectAllowed + absolute-URI at registration), so
+  // `new URL()` cannot throw here.
+  const buildRedirect = (params: Record<string, string>): string => {
+    const url = new URL(md.redirect_uri as string);
+    for (const [key, value] of Object.entries(params)) url.searchParams.set(key, value);
+    return url.toString();
+  };
 
   if (md.decision === "deny") {
     return c.json({
-      redirect: `${md.redirect_uri}?error=access_denied${stateParam}`,
+      redirect: buildRedirect({ error: "access_denied", ...(state ? { state } : {}) }),
     });
   }
 
@@ -263,6 +275,6 @@ authorize.post("/", async (c) => {
   });
 
   return c.json({
-    redirect: `${md.redirect_uri}?code=${encodeURIComponent(minted.code)}${stateParam}`,
+    redirect: buildRedirect({ code: minted.code, ...(state ? { state } : {}) }),
   });
 });


### PR DESCRIPTION
## Why

The OAuth `authorize` consent handler built the post-consent redirect by **string-concatenating** `?code=…` (grant) / `?error=…` (deny) onto the registered `redirect_uri`. The `?` was prepended **unconditionally**, so a redirect_uri that already carries a query string was corrupted into a double-query:

```
https://app/cb?foo=1   →   https://app/cb?foo=1?code=…   ❌  (client can't parse `code`)
```

A query string in a redirect_uri is **legal** — RFC 6749 §3.1.2 forbids only *fragments*, which DCR already rejects — so Memex accepted these at registration and then mangled them at callback. Verified clients are safe (Cursor `cursor://…`, loopback — all query-less), but the plausible victims are **VS Code's `https://vscode.dev/redirect` relay** (which spec-253 advertises support for) and any provider-style `…/cb?tenant=x` redirect.

Surfaced by spec-253's t-3 security review (**INFO-2**). Pre-existing; **not** a security issue (the URI is handed to the browser, never fetched server-side) — a correctness defect.

## What changed

`packages/server/src/routes/oauth/authorize.ts` — both grant and deny redirects now build via a `buildRedirect()` helper using `new URL()` + `searchParams.set()`, which chooses `?`/`&` correctly and **preserves any existing query**. Removed the manual `stateParam` concat + `encodeURIComponent` (URL handles encoding). `md.redirect_uri` is already validated (`clientRedirectAllowed` + absolute-URI at registration), so `new URL()` can't throw.

## Test plan

- [x] e2e (`oauth-flow.api.test.ts`): register `https://test.example/callback?tenant=acme` → `POST /authorize {allow}` and `{deny}` → assert callback is `…?tenant=acme&code=…&state=…` / `…&error=access_denied&state=…` — **single `?`**, every param individually parseable. **RED** before (`expected 3 to be 2`), **GREEN** after.
- [x] Full 20-test OAuth e2e flow + `oauth-authorize-redirect` regression stay green.
- [x] Typecheck clean.
- [x] spec-275 ac-1 + ac-2 verified (100%).
- [ ] Post-deploy on int: register a `cursor://cb?x=1` client, walk authorize, confirm merged callback (quick curl).

## Lineage

Resolves **spec-253 issue-1** (auto-resolves on spec-275 → done). Child of spec-253.

Memex: https://memex.ai/mindset-prod/memex-building-itself/specs/spec-275