### PR TITLE
feat: shard server CI suite across 3 runners (spec-276)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,15 +36,33 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Full server suite (unit + integration + security + regression + api) with
-  # the t-17 coverage thresholds enforced in the same run.
+  # Full server suite (unit + integration + security + regression + api), SHARDED
+  # across 3 runners (spec-276). The single un-sharded job was the merge-gate long
+  # pole (~6m17s; ~72% of it module-import under v8 coverage instrumentation, and
+  # core-starved at ~2 workers on a 2-core runner). Three shards each run ~1/3 of
+  # the files, so import + test time divide → ~2.5min, and total CI drops to ~3min
+  # (now gated by ui/e2e). The t-17 coverage gate is NOT weakened: it moves intact
+  # to the `server-result` merge job below, which enforces 80/80/70/80 on the
+  # MERGED full-suite coverage. Mirrors the e2e matrix + e2e-result aggregator.
+  #
+  # WHY the shard step forces every coverage threshold to 0: in vitest 4.1.1 the
+  # blob reporter does NOT defer threshold evaluation (verified empirically,
+  # spec-276 — confirmed in @vitest/coverage-v8 generateReports→reportThresholds).
+  # A shard running --coverage with the config thresholds live would run
+  # checkThresholds against its OWN partial ~1/3 coverage and exit 1. So shards are
+  # collect-only (thresholds 0); the merge job is the SOLE place the real gate fires.
   server:
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
     # Postgres side-car. Same major version we run locally (schema.ts uses features
     # introduced in 13+; production is Cloud SQL 16). Health check blocks `steps` from
-    # starting until the server is ready.
+    # starting until the server is ready. Each shard gets its OWN service, so the
+    # per-worker DB clones (vitest.worker-db.setup.ts) never collide across shards.
     services:
       postgres:
         # pgvector-bundled Postgres 16 — migration 0023 (codebase intelligence)
@@ -95,17 +113,112 @@ jobs:
             psql -v ON_ERROR_STOP=1 "$DATABASE_URL" -f "$f"
           done
 
-      - name: Server suite + coverage gate (fails if services drop below threshold)
-        run: pnpm --filter @memex/server test:coverage
+      - name: Server suite shard ${{ matrix.shard }}/3 (collect coverage, NO threshold gate)
+        # --reporter=blob writes packages/server/.vitest-reports/blob-<shard>-3.json.
+        # The four --coverage.thresholds.*=0 flags make this shard collect-only — the
+        # gate is enforced once, on merged coverage, in server-result (see header).
+        run: |
+          pnpm --filter @memex/server exec vitest run \
+            --shard=${{ matrix.shard }}/3 \
+            --coverage --reporter=blob \
+            --coverage.thresholds.lines=0 \
+            --coverage.thresholds.functions=0 \
+            --coverage.thresholds.branches=0 \
+            --coverage.thresholds.statements=0
 
-      - name: Upload coverage report
-        # Always upload — even on failure — so reviewers can diagnose threshold breaches.
+      - name: Upload coverage blob (shard ${{ matrix.shard }})
+        # Always upload so server-result can merge; a missing blob fails that job closed.
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: server-coverage-blob-${{ matrix.shard }}
+          path: packages/server/.vitest-reports/
+          retention-days: 14
+
+  # Merge the 3 shard coverage blobs and enforce the t-17 thresholds on the MERGED
+  # full-suite coverage (spec-276 dec-2). This job's name is the STABLE required
+  # check for branch protection — the matrix leg names ("server (1)" …) shift with
+  # the shard count and must NOT be required directly (the e2e-result precedent).
+  # Fail-closed: a cancelled/failed shard (needs.server.result != success) or a
+  # missing blob fails the gate rather than passing on partial coverage.
+  server-result:
+    needs: [server]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      MEMEX_EMIT_KEY: ${{ secrets.MEMEX_EMIT_KEY }}
+
+    steps:
+      # Fail closed FIRST: if any shard was cancelled or failed, never merge — a
+      # partial shard set must not produce a green coverage gate.
+      - name: Fail if any server shard did not succeed
+        if: needs.server.result != 'success'
+        run: |
+          echo "server shards result: ${{ needs.server.result }}"
+          exit 1
+
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+
+      - name: Download all shard coverage blobs
+        uses: actions/download-artifact@v4
+        with:
+          pattern: server-coverage-blob-*
+          path: /tmp/server-blobs
+          merge-multiple: true
+
+      - name: Stage blobs and fail closed on a missing shard
+        # vitest --merge-reports reads .vitest-reports/ relative to CWD (= the server
+        # package under the pnpm filter), so stage the downloaded blobs there.
+        run: |
+          mkdir -p packages/server/.vitest-reports
+          cp /tmp/server-blobs/*.json packages/server/.vitest-reports/ 2>/dev/null || true
+          count=$(ls packages/server/.vitest-reports/blob-*.json 2>/dev/null | wc -l)
+          echo "shard blobs found: $count"
+          if [ "$count" -ne 3 ]; then
+            echo "Expected 3 shard coverage blobs, found $count — failing closed (partial coverage must not pass the gate)."
+            exit 1
+          fi
+
+      - name: Merge coverage + enforce t-17 thresholds on the MERGED suite
+        id: merge
+        # No --reporter=blob here: vitest errors "Cannot merge reports when
+        # --reporter=blob is used". The config thresholds (80/80/70/80) apply to the
+        # merged coverage map — this is the one and only coverage gate.
+        run: pnpm --filter @memex/server exec vitest --merge-reports --coverage run
+
+      - name: Upload merged coverage report
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: server-coverage
           path: packages/server/coverage/
           retention-days: 14
+
+      # spec-276: self-report the runtime-only AC from the live run — the structural
+      # regression test asserts the workflow INVOKES the merge gate, but only the
+      # real run proves the threshold fired on merged coverage. Mirrors how
+      # e2e-result emits spec-172 ac-1: pass AND fail alike, non-blocking (|| true),
+      # skipped silently when no key is configured.
+      - name: Emit spec-276 ac-3 (threshold enforced on merged coverage)
+        if: always()
+        run: |
+          STATUS=$([ "${{ steps.merge.outcome }}" = "success" ] && echo pass || echo fail)
+          if [ -z "$MEMEX_EMIT_KEY" ]; then
+            echo "MEMEX_EMIT_KEY unset — skipping ac-3 emission (status would be: $STATUS)"
+          else
+            curl -sS -X POST "https://memex.ai/api/test-events" \
+              -H "Authorization: Bearer $MEMEX_EMIT_KEY" \
+              -H "Content-Type: application/json" \
+              -d "{\"ac_uid\":\"mindset-prod/memex-building-itself/specs/spec-276/acs/ac-3\",\"status\":\"$STATUS\",\"test_identifier\":\".github/workflows/test.yml::server-result\",\"actor\":\"${{ github.actor }}\",\"metadata\":{\"branch\":\"${{ github.ref_name }}\",\"commit\":\"${{ github.sha }}\",\"run_id\":\"${{ github.run_id }}\"}}" \
+              && echo "ac-3 emitted: $STATUS" || echo "ac-3 emission failed (non-blocking)"
+          fi
 
   # Production build gate (std-17 §6 / cl-55): `make build` is what the deploy
   # actually runs, and vitest does NOT typecheck — a green test matrix can hide

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -133,6 +133,10 @@ jobs:
         with:
           name: server-coverage-blob-${{ matrix.shard }}
           path: packages/server/.vitest-reports/
+          # REQUIRED: vitest writes the blob to `.vitest-reports/` (a dot-dir), and
+          # upload-artifact@v4 excludes hidden files by default — without this the
+          # upload silently finds nothing and server-result fails closed on 0 blobs.
+          include-hidden-files: true
           retention-days: 14
 
   # Merge the 3 shard coverage blobs and enforce the t-17 thresholds on the MERGED

--- a/packages/server/src/__regression__/spec-276-server-shard-gate.regression.test.ts
+++ b/packages/server/src/__regression__/spec-276-server-shard-gate.regression.test.ts
@@ -76,6 +76,11 @@ describe("spec-276 — the server suite is sharded but the coverage gate is inta
     // The blob is uploaded as an artifact for the merge job to pick up.
     expect(server, "shard uploads its coverage blob").toMatch(/upload-artifact/);
     expect(server).toMatch(/\.vitest-reports/);
+    // MUST include hidden files: vitest writes the blob into `.vitest-reports/`
+    // (a dot-dir) and upload-artifact@v4 excludes hidden files by default — without
+    // this the upload finds nothing and server-result fails closed on 0 blobs.
+    // (Caught by PR #169's first CI run; this assertion pins the fix.)
+    expect(server, "blob upload includes hidden files").toMatch(/include-hidden-files:\s*true/);
   });
 
   it("ac-8: server-result merges the blobs and enforces the threshold on MERGED coverage", () => {

--- a/packages/server/src/__regression__/spec-276-server-shard-gate.regression.test.ts
+++ b/packages/server/src/__regression__/spec-276-server-shard-gate.regression.test.ts
@@ -1,0 +1,108 @@
+// spec-276 — the server suite is SHARDED across CI runners to cut merge-gate
+// wall-clock, WITHOUT weakening the t-17 coverage gate. These are static
+// assertions on `.github/workflows/test.yml` (the same shape as the spec-172
+// e2e-pipeline guards and the spec-168 cicd-deploy-config guards). They pin the
+// load-bearing structure so a future edit can't silently:
+//
+//   1. collapse the shard matrix (ac-6) — losing the parallelism;
+//   2. drop the collect-only coverage flags on a shard (ac-7) — which would make
+//      every shard exit 1 on its partial coverage (verified: vitest 4.1.1's blob
+//      reporter does NOT defer threshold checks), OR drop blob/coverage entirely;
+//   3. stop enforcing the threshold on the MERGED coverage (ac-8) — turning the
+//      gate into a no-op;
+//   4. make the aggregator fail-OPEN (ac-9) — letting a cancelled/failed shard or
+//      a missing blob pass as green on partial coverage.
+//
+// What these CANNOT assert (verified only by the live CI run, self-reported from
+// the server-result job per the e2e-result precedent): the ~3min wall-clock
+// (ac-1), the merged test count (ac-2), and that the threshold actually fires on
+// merged coverage (ac-3). A green structural test means "the workflow invokes the
+// right commands", NOT "the coverage math is correct".
+//
+// Branch protection (requiring `server-result` on develop + main, dropping the
+// old `server` check) is a repo-settings surface GitHub doesn't let repo contents
+// assert — that is ac-5, verified manually at flip time (t-4).
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+const SPEC = "mindset-prod/memex-building-itself/specs/spec-276";
+const REPO_ROOT = join(__dirname, "..", "..", "..", "..");
+const TEST_YML = readFileSync(
+  join(REPO_ROOT, ".github", "workflows", "test.yml"),
+  "utf-8",
+);
+
+// Extract one top-level job block: from `\n  <name>:` to the next 2-space-indented
+// `\n  <other>:` key (or EOF). Mirrors the helper in spec-172-e2e-pipeline-gate.
+function jobBlock(name: string): string {
+  const start = TEST_YML.search(new RegExp(`^  ${name}:\\s*$`, "m"));
+  expect(start, `job "${name}" exists in test.yml`).toBeGreaterThan(-1);
+  const rest = TEST_YML.slice(start + 1);
+  const next = rest.search(/^  [A-Za-z0-9_-]+:\s*$/m);
+  return next === -1 ? TEST_YML.slice(start) : TEST_YML.slice(start, start + 1 + next);
+}
+
+describe("spec-276 — the server suite is sharded but the coverage gate is intact", () => {
+  it("ac-6: the server job is a 3-way shard matrix, each leg with its own Postgres", () => {
+    tagAc(`${SPEC}/acs/ac-6`);
+    const server = jobBlock("server");
+    // 3-way matrix on `shard`.
+    expect(server, "server job declares a matrix").toMatch(/^\s*matrix:\s*$/m);
+    expect(server, "matrix shards over [1, 2, 3]").toMatch(/shard:\s*\[\s*1\s*,\s*2\s*,\s*3\s*\]/);
+    // Each leg runs only its 1/3 slice.
+    expect(server).toMatch(/--shard=\$\{\{\s*matrix\.shard\s*\}\}\/3/);
+    // Own Postgres side-car (pgvector pg16), so the per-worker DB clones don't collide.
+    expect(server, "server shard has its own pgvector pg16 service").toMatch(
+      /services:[\s\S]*postgres:[\s\S]*pgvector\/pgvector:pg16/,
+    );
+  });
+
+  it("ac-7: each shard collects coverage into a blob WITHOUT enforcing thresholds, and uploads it", () => {
+    tagAc(`${SPEC}/acs/ac-7`);
+    const server = jobBlock("server");
+    expect(server, "shard runs under coverage").toMatch(/--coverage\b/);
+    expect(server, "shard emits a blob report").toMatch(/--reporter=blob\b/);
+    // Collect-only: all four metric thresholds forced to 0 so a shard does NOT
+    // gate on its partial coverage. (Drop any one and that shard reds out.)
+    for (const metric of ["lines", "functions", "branches", "statements"]) {
+      expect(
+        server,
+        `shard disables the ${metric} threshold (collect-only)`,
+      ).toMatch(new RegExp(`--coverage\\.thresholds\\.${metric}=0\\b`));
+    }
+    // The blob is uploaded as an artifact for the merge job to pick up.
+    expect(server, "shard uploads its coverage blob").toMatch(/upload-artifact/);
+    expect(server).toMatch(/\.vitest-reports/);
+  });
+
+  it("ac-8: server-result merges the blobs and enforces the threshold on MERGED coverage", () => {
+    tagAc(`${SPEC}/acs/ac-8`);
+    const agg = jobBlock("server-result");
+    expect(agg, "merges the shard blobs under coverage").toMatch(
+      /vitest\s+--merge-reports\s+--coverage|--merge-reports[\s\S]*--coverage/,
+    );
+    // The merge step must NOT carry a blob reporter — vitest hard-errors
+    // ("Cannot merge reports when --reporter=blob is used").
+    const mergeLine = agg
+      .split("\n")
+      .find((l) => l.includes("--merge-reports")) ?? "";
+    expect(mergeLine, "merge step does not pass --reporter=blob").not.toMatch(/--reporter=blob/);
+  });
+
+  it("ac-9: server-result fails CLOSED on a cancelled/failed shard or a missing blob", () => {
+    tagAc(`${SPEC}/acs/ac-9`);
+    const agg = jobBlock("server-result");
+    expect(agg, "depends on the server matrix").toMatch(/^    needs:\s*\[?\s*server\s*\]?\s*$/m);
+    // `if: always()` is what makes a SKIPPED/CANCELLED server read as RED here
+    // rather than a green-ish skip.
+    expect(agg).toMatch(/^    if:\s*always\(\)\s*$/m);
+    expect(agg, "guards on the matrix result").toMatch(/needs\.server\.result/);
+    expect(agg).toMatch(/!=\s*['"]success['"]/);
+    expect(agg).toMatch(/exit 1/);
+    // Fail on a missing blob — a partial blob set must not merge to a green gate.
+    expect(agg, "asserts the expected blob count (fail on missing)").toMatch(/-ne 3|!= 3|-lt 3/);
+  });
+});


### PR DESCRIPTION
## Why

The `server` job is the merge-gate **long pole** — ~6m17s while every other job (ui, e2e×3, build, cli) finishes by ~3 min. Measured breakdown (develop run 27408415056): of the 321s vitest run, **import = 232s (72%)** — v8 coverage instrumentation at module-load across 386 files — and the suite is **core-starved** (`maxWorkers = min(8, cores-1)` → ~2 workers on the 2-core runner vs 7 locally). Every PR and every `develop`→`main` FF waits on this.

Spec: `mindset-prod/memex-building-itself/specs/spec-276`.

## What

Split `server` into a **3-shard matrix** + a **`server-result`** merge aggregator (the same shape as the existing `e2e` + `e2e-result`):

- Each shard runs ~1/3 of the files **collect-only** — `--coverage --reporter=blob` with all four `--coverage.thresholds.*=0` — and uploads its coverage blob.
- `server-result` fails closed on a cancelled/failed shard or a missing blob, then runs `vitest --merge-reports --coverage`, enforcing the **t-17 80/80/70/80 gate on the MERGED full-suite coverage**.

**The coverage gate is not weakened** — it stays a blocking, pre-merge, full-suite check; it's just computed in parallel. ~5m20s → ~2.5min server wall-clock; total CI ~3min.

### The non-obvious bit (verified empirically, vitest 4.1.1)
The blob reporter does **not** defer coverage-threshold evaluation (confirmed in `@vitest/coverage-v8` `generateReports → reportThresholds`, and reproduced: a 50%-covered shard exits 1). So a naive `--coverage --reporter=blob` shard would red out on its partial coverage. Hence the collect-only `thresholds=0` flags; the merge step is the **sole** place the gate fires. Two merge-step gotchas: it must **not** pass `--reporter=blob` (vitest hard-errors), and `--merge-reports` reads `.vitest-reports/` relative to **CWD**.

## Tests

- New `spec-276-server-shard-gate.regression.test.ts` — static assertions pinning the workflow shape (matrix, collect-only flags, merge gate, fail-closed guard). RED → GREEN locally; sibling spec-172/spec-168 workflow tests still green.
- `server-result` self-reports spec-276 ac-3 from the live run (mirrors `e2e-result`).

## Verified on this PR's CI run (runtime-only ACs)
- [ ] ac-1 — server wall-clock ≈ 2.5min, total CI ≈ 3min (server no longer the long pole)
- [ ] ac-2 — merged test count matches the pre-sharding suite (no test silently dropped)
- [ ] ac-3 — coverage gate fires on **merged** coverage (passes at current %, would fail below threshold)

## ⚠️ Owner action AFTER this merges (t-4 / ac-5)
Branch protection on **develop + main**: add **`server-result`** as a required status check and **remove the old `server`** check. The matrix leg names (`server (1)`…) shift with the shard count and must not be required directly. Until this flip, the new gate isn't enforced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)