### PR TITLE
fix(ci): make sharded server failures visible in logs (spec-276/issue-2)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,12 +115,18 @@ jobs:
 
       - name: Server suite shard ${{ matrix.shard }}/3 (collect coverage, NO threshold gate)
         # --reporter=blob writes packages/server/.vitest-reports/blob-<shard>-3.json.
+        # --reporter=default ALSO prints the pass/fail test tree to the console:
+        # blob alone suppresses the console reporter, so a red shard would name no failing
+        # test in the logs — undiagnosable. The dual reporter restores that (the blob is
+        # still written for the merge; verified the two coexist). Do NOT drop the second
+        # reporter — spec-276 issue-2: the first develop flake was un-diagnosable from logs
+        # and only recovered by downloading + replaying the shard blob artifact.
         # The four --coverage.thresholds.*=0 flags make this shard collect-only — the
         # gate is enforced once, on merged coverage, in server-result (see header).
         run: |
           pnpm --filter @memex/server exec vitest run \
             --shard=${{ matrix.shard }}/3 \
-            --coverage --reporter=blob \
+            --coverage --reporter=blob --reporter=default \
             --coverage.thresholds.lines=0 \
             --coverage.thresholds.functions=0 \
             --coverage.thresholds.branches=0 \

--- a/packages/server/src/__regression__/spec-276-server-shard-gate.regression.test.ts
+++ b/packages/server/src/__regression__/spec-276-server-shard-gate.regression.test.ts
@@ -65,6 +65,13 @@ describe("spec-276 — the server suite is sharded but the coverage gate is inta
     const server = jobBlock("server");
     expect(server, "shard runs under coverage").toMatch(/--coverage\b/);
     expect(server, "shard emits a blob report").toMatch(/--reporter=blob\b/);
+    // Dual reporter: blob alone suppresses console output, so a red shard names no
+    // failing test in CI logs (spec-276 issue-2 — the first develop flake was only
+    // diagnosable by downloading + replaying the blob). A second console reporter
+    // restores in-log failures. Don't let it regress to blob-only.
+    expect(server, "shard also runs a console reporter (not blob-only)").toMatch(
+      /--reporter=blob\s+--reporter=\w/,
+    );
     // Collect-only: all four metric thresholds forced to 0 so a shard does NOT
     // gate on its partial coverage. (Drop any one and that shard reds out.)
     for (const metric of ["lines", "functions", "branches", "statements"]) {


### PR DESCRIPTION
## Problem

spec-276 sharded the server suite and runs each shard with `--reporter=blob` only. The blob reporter **replaces** vitest's console reporter, so when a shard fails the CI log shows only `pnpm … exit 1` plus Postgres/docker noise — **no failing test name, no assertion**.

First hit on develop run 27424302893: the real failure (`documents.status-changed.spec-179.test.ts`) was only identifiable by downloading the shard's blob artifact and replaying it with `vitest --merge-reports`. That archaeology would repeat on every shard failure. (e2e shards stayed diagnosable — Playwright's reporter prints failures; only the vitest blob shards went dark.)

Tracked as `spec-276/issue-2`.

## Fix

Shard step runs **`--reporter=blob --reporter=default`**:
- `blob` still written → the `server-result` merge + coverage gate is unchanged.
- `default` restores the pass/fail test tree in the console, so a red shard names the failing test inline.

Verified locally that the two reporters coexist (console output **and** `blob.json` written). Pinned in `spec-276-server-shard-gate.regression.test.ts` so it can't regress to blob-only.

## Test plan
- [x] Local: dual reporter prints test results + writes the blob (collect-only flags).
- [x] `spec-276-server-shard-gate.regression.test.ts` green (now asserts a second console reporter).
- [ ] CI: confirm a shard's log shows the test tree, and `server-result` still merges + gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)