### PR TITLE
fix: stabilize two flaky tests taxing the CI gate (spec-278)

### DIFF
--- a/packages/server/src/services/documents.status-changed.spec-179.test.ts
+++ b/packages/server/src/services/documents.status-changed.spec-179.test.ts
@@ -7,7 +7,7 @@
 
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
 import { tagAc } from "@memex-ai-ac/vitest";
-import { eq, inArray } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import { db } from "../db/connection.js";
 import { activityLog, documents, memexes, namespaces } from "../db/schema.js";
 import { makeTestMemex } from "./test-helpers.js";
@@ -45,19 +45,27 @@ beforeEach(async () => {
   await db.delete(activityLog).where(eq(activityLog.memexId, memexId));
 });
 
-// Poll until at least `expected` matching rows land (the sink persists on a
-// detached promise off the synchronous emit path), or time out.
-async function waitForStatusRows(expected: number, timeoutMs = 2000) {
+// Poll until THIS document's rows satisfy `ready`, then return only that
+// document's rows. The activity sink persists on a detached promise off the
+// synchronous emit path (async), so two failure modes lurk if you filter by
+// memexId alone (spec-179/issue-1, the flake this scoping fixes):
+//   1. a PRIOR test's detached write can land after beforeEach's delete and
+//      inflate a memexId-wide count;
+//   2. this op's own row may not have landed yet when the assertion runs.
+// Scoping every query by briefId (each test uses a fresh, unique doc id) makes a
+// test immune to (1), and gating on a per-doc `ready` predicate handles (2).
+async function waitForDocRows(
+  briefId: string,
+  ready: (rows: (typeof activityLog.$inferSelect)[]) => boolean,
+  timeoutMs = 2000,
+) {
   const start = Date.now();
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const rows = await db
-      .select()
-      .from(activityLog)
-      .where(eq(activityLog.memexId, memexId));
-    const statusRows = rows.filter((r) => r.action === "status_changed");
-    if (statusRows.length >= expected) return { rows, statusRows };
-    if (Date.now() - start > timeoutMs) return { rows, statusRows };
+    const rows = (
+      await db.select().from(activityLog).where(eq(activityLog.memexId, memexId))
+    ).filter((r) => r.briefId === briefId);
+    if (ready(rows) || Date.now() - start > timeoutMs) return rows;
     await new Promise((r) => setTimeout(r, 25));
   }
 }
@@ -69,7 +77,10 @@ describe("updateDocStatus — document/status_changed emission (spec-179 ac-5)",
 
     await updateDocStatus(memexId, spec.id, "specify");
 
-    const { statusRows } = await waitForStatusRows(1);
+    const rows = await waitForDocRows(spec.id, (rs) =>
+      rs.some((r) => r.action === "status_changed"),
+    );
+    const statusRows = rows.filter((r) => r.action === "status_changed");
     expect(statusRows).toHaveLength(1);
     expect(statusRows[0]).toMatchObject({
       memexId,
@@ -87,7 +98,15 @@ describe("updateDocStatus — document/status_changed emission (spec-179 ac-5)",
 
     await updateDocStatus(memexId, spec.id, "build");
 
-    const { rows, statusRows } = await waitForStatusRows(1);
+    // A spec flip emits BOTH an `updated` and a `status_changed` row (two detached
+    // writes); wait for both to land for THIS doc before asserting their counts.
+    const rows = await waitForDocRows(
+      spec.id,
+      (rs) =>
+        rs.some((r) => r.action === "status_changed") &&
+        rs.some((r) => r.action === "updated"),
+    );
+    const statusRows = rows.filter((r) => r.action === "status_changed");
     expect(statusRows).toHaveLength(1);
     expect(statusRows[0].payload).toEqual({ from: "specify", to: "build" });
     expect(rows.filter((r) => r.action === "updated")).toHaveLength(1);
@@ -99,14 +118,9 @@ describe("updateDocStatus — document/status_changed emission (spec-179 ac-5)",
 
     await updateDocStatus(memexId, doc.id, "approved");
 
-    // Wait for the guaranteed "updated" row, then confirm no status_changed.
-    const start = Date.now();
-    let rows: (typeof activityLog.$inferSelect)[] = [];
-    while (Date.now() - start < 2000) {
-      rows = await db.select().from(activityLog).where(eq(activityLog.memexId, memexId));
-      if (rows.some((r) => r.action === "updated")) break;
-      await new Promise((r) => setTimeout(r, 25));
-    }
+    // Wait for THIS doc's guaranteed "updated" row, then confirm no status_changed
+    // for it — scoped by briefId so a sibling test's late detached write can't bleed in.
+    const rows = await waitForDocRows(doc.id, (rs) => rs.some((r) => r.action === "updated"));
     expect(rows.some((r) => r.action === "updated")).toBe(true);
     expect(rows.filter((r) => r.action === "status_changed")).toHaveLength(0);
   });
@@ -117,13 +131,9 @@ describe("updateDocStatus — document/status_changed emission (spec-179 ac-5)",
 
     await updateDocStatus(memexId, spec.id, "build");
 
-    const start = Date.now();
-    let rows: (typeof activityLog.$inferSelect)[] = [];
-    while (Date.now() - start < 2000) {
-      rows = await db.select().from(activityLog).where(eq(activityLog.memexId, memexId));
-      if (rows.some((r) => r.action === "updated")) break;
-      await new Promise((r) => setTimeout(r, 25));
-    }
+    // Same-status write still emits `updated`; wait for THIS doc's updated row, then
+    // confirm no status_changed for it — scoped by briefId to stay sibling-immune.
+    const rows = await waitForDocRows(spec.id, (rs) => rs.some((r) => r.action === "updated"));
     expect(rows.some((r) => r.action === "updated")).toBe(true);
     expect(rows.filter((r) => r.action === "status_changed")).toHaveLength(0);
   });

--- a/packages/ui/e2e/journey-26-logo-theme.spec.ts
+++ b/packages/ui/e2e/journey-26-logo-theme.spec.ts
@@ -50,7 +50,13 @@ test("the logo fill inverts between dark and light theme (ac-2)", async ({ page 
   await expect(page.getByRole("heading", { name: "Specs" })).toBeVisible({ timeout: 15_000 });
   await expect(page.getByTestId("memex-logo").first()).toBeVisible();
 
-  const darkFill = await computedLogoFill(page);
+  // Poll, don't sample once: the logo can be visible a frame before its path fill
+  // resolves the --color-logo CSS variable, so getComputedStyle().fill reads "" for
+  // a moment (spec-278/issue-1 — the journey reddened on that empty read, all 3
+  // Playwright retries). expect.poll retries until the dark token settles. Asserting
+  // each theme resolves to its own distinct token also proves the recolour inverts
+  // (DARK_FILL !== LIGHT_FILL by construction) — stronger than a bare not-equal.
+  await expect.poll(() => computedLogoFill(page), { timeout: 10_000 }).toBe(DARK_FILL);
 
   // Switch to light and re-read.
   await page.evaluate(() => localStorage.setItem("memex-theme", "light"));
@@ -58,12 +64,6 @@ test("the logo fill inverts between dark and light theme (ac-2)", async ({ page 
   await expect(page.getByRole("heading", { name: "Specs" })).toBeVisible({ timeout: 15_000 });
   await expect(page.getByTestId("memex-logo").first()).toBeVisible();
 
-  const lightFill = await computedLogoFill(page);
-
-  // The recolour is real: the two themes resolve different fills...
-  expect(darkFill).not.toBe(lightFill);
-  // ...and each matches its theme token (so dark is the legible near-white, never
-  // the old #0E112B navy that was invisible on the dark surface).
-  expect(darkFill).toBe(DARK_FILL);
-  expect(lightFill).toBe(LIGHT_FILL);
+  // ...and the light token settles to the navy (#0E112B was the old invisible-on-dark bug).
+  await expect.poll(() => computedLogoFill(page), { timeout: 10_000 }).toBe(LIGHT_FILL);
 });


### PR DESCRIPTION
## Why

Two pre-existing flaky tests randomly redden `develop` and force re-runs (first hit: run 27424302893, where both fired at once). Neither was caused by the spec-276 sharding — sharding just surfaced them. Spec: `spec-278`.

## Fix 1 — server: `documents.status-changed.spec-179.test.ts` (spec-179/issue-1)

All four tests queried the activity log by **memexId only** and asserted on counts. The sink persists on a **detached (async)** promise, so two races could redden any of them: (1) a prior test's late write landing after `beforeEach`'s delete inflated a memexId-wide count; (2) this op's own row not yet landed when the assertion ran. (This was the *real* failure — the earlier RLS-role-race theory was a misdiagnosis; spec-260/issue-3 → wont_fix.)

Fix: a `waitForDocRows(briefId, ready)` helper scopes every query to the **document under test** (each test uses a unique doc id → immune to any sibling's late detached write) and gates on a per-doc readiness predicate before asserting. Fixes the whole class — the two negative tests had the same vulnerability.

Verified **12/12 + 4/4 green** locally; the race isn't reproducible on 8-core hardware (timing-dependent, CI 2-core only) — the fix removes both modes by construction.

## Fix 2 — e2e: `journey-26-logo-theme.spec.ts` (spec-278/issue-1)

Sampled `getComputedStyle(path).fill` **once** right after the logo became visible, but visibility precedes the `--color-logo` CSS variable resolving into the computed fill → read `""` for a frame (all 3 retries red). Replace with `expect.poll().toBe(token)` per theme; asserting each theme resolves to its own distinct token proves the inversion more strongly than the old not-equal. Compiles + discovered locally; CI e2e (cold DB) is the behavioral verifier per std-28.

## Test plan
- [x] spec-179 file: 12/12 + 4/4 green locally (looped).
- [x] journey-26: compiles + discovered (`playwright test --list`).
- [ ] CI: full server suite green (shard logs now also readable — depends on #170), e2e green.

## Related
- Depends conceptually on #170 (shard failure visibility) but is independent to merge.
- Resolves spec-179/issue-1 and spec-278/issue-1 on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)