### PR TITLE
feat(ui): coloured phase container with relocated edit/review selector (spec-252)

### DIFF
--- a/packages/ui/src/components/PhaseTabBar.test.tsx
+++ b/packages/ui/src/components/PhaseTabBar.test.tsx
@@ -37,24 +37,27 @@ describe('PhaseTabBar', () => {
     const buildTab = tab('build');
     expect(buildTab).toHaveAttribute('data-current', 'true');
     expect(buildTab).toHaveAttribute('aria-current', 'step');
-    // build → info blue token fill.
-    expect(buildTab.className).toContain('bg-status-info-bg');
+    // build → dedicated phase blue token fill (spec-252).
+    expect(buildTab.className).toContain('bg-phase-build-bg');
     // ● current-dot present only on the current tab.
     expect(buildTab.textContent).toContain('●');
     expect(tab('specify').textContent).not.toContain('●');
     expect(tab('specify')).not.toHaveAttribute('data-current');
   });
 
-  it('uses the amber warning fill for the specify tab when current', () => {
+  it('uses the dedicated purple phase fill for the specify tab when current (spec-252)', () => {
     tagAc(AC(2));
     render(<PhaseTabBar currentPhase="specify" selectedTab="specify" onSelect={onSelect} />);
-    expect(tab('specify').className).toContain('bg-status-warning-bg');
+    // spec-252 dec-1: specify is purple via its own token, NOT the shared
+    // `warning` variant (which still colours open/review amber).
+    expect(tab('specify').className).toContain('bg-phase-specify-bg');
+    expect(tab('specify').className).not.toContain('bg-status-warning-bg');
   });
 
-  it('uses the green success fill for the verify tab when current', () => {
+  it('uses the dedicated green phase fill for the verify tab when current (spec-252)', () => {
     tagAc(AC(2));
     render(<PhaseTabBar currentPhase="verify" selectedTab="verify" onSelect={onSelect} />);
-    expect(tab('verify').className).toContain('bg-status-success-bg');
+    expect(tab('verify').className).toContain('bg-phase-verify-bg');
   });
 
   it("renders a grey Draft pill as current for phase 'draft'; Specify is NOT current", () => {
@@ -161,7 +164,7 @@ describe('PhaseTabBar', () => {
     // verify carries the CURRENT treatment (filled pill + dot) but is NOT selected.
     const verifyTab = tab('verify');
     expect(verifyTab).toHaveAttribute('data-current', 'true');
-    expect(verifyTab.className).toContain('bg-status-success-bg');
+    expect(verifyTab.className).toContain('bg-phase-verify-bg');
     expect(verifyTab.textContent).toContain('●');
     expect(verifyTab).toHaveAttribute('aria-selected', 'false');
 

--- a/packages/ui/src/components/PhaseTabBar.tsx
+++ b/packages/ui/src/components/PhaseTabBar.tsx
@@ -1,6 +1,6 @@
 import { Fragment, useRef } from 'react';
 import type { SpecStatus } from '../api/types';
-import { statusVariant } from '../utils/statusStyles';
+import { phaseColors } from './phaseColors';
 import { phaseDisplayName } from '../utils/phaseDisplay';
 
 // The phase tab bar carries TWO independent visual states (spec-159 ac-2 / ac-15):
@@ -43,17 +43,11 @@ const TAB_LABELS: Record<PhaseTab, string> = {
   done: phaseDisplayName('done'),
 };
 
-// Per-tab fill, reusing the canonical statusVariant → status-* token classes
-// (specify→warning amber, build→info blue, verify→success green). statusVariant
-// already maps each phase string to its variant, so we route through it rather
-// than hardcoding a second colour table.
-const VARIANT_FILL: Record<ReturnType<typeof statusVariant>, string> = {
-  warning: 'bg-status-warning-bg text-status-warning-text border-status-warning-border',
-  info: 'bg-status-info-bg text-status-info-text border-status-info-border',
-  success: 'bg-status-success-bg text-status-success-text border-status-success-border',
-  danger: 'bg-status-danger-bg text-status-danger-text border-status-danger-border',
-  neutral: 'bg-status-neutral-bg text-status-neutral-text border-status-neutral-border',
-};
+// Per-tab fill comes from the dedicated phase palette (spec-252 dec-1):
+// draft→grey, specify→PURPLE, build→blue, verify→green. specify is purple via
+// its own tokens rather than the shared `warning` variant, so colouring it here
+// never recolours open/review elsewhere. draft/build/verify reuse the status
+// tokens under the hood (see phaseColors).
 
 /** The tab a given Spec phase makes "current" (the filled pill). `draft` and
  * `done` make NO tab current: `draft` lights up the dedicated Draft pill
@@ -110,7 +104,9 @@ export function PhaseTabBar({ currentPhase, selectedTab, onSelect }: PhaseTabBar
   }
 
   return (
-    <div className="flex items-center gap-2 mb-4">
+    // spec-252: spacing is owned by the phase container in DocDocument now, so
+    // the bar carries no bottom margin of its own.
+    <div className="flex items-center gap-2">
       {isDraft && (
         // Draft is the current STATUS, not a browsable view: a grey filled pill
         // outside the tablist. Clicking it selects the Specify view (draft's home),
@@ -124,7 +120,7 @@ export function PhaseTabBar({ currentPhase, selectedTab, onSelect }: PhaseTabBar
           className={`
             relative inline-flex items-center gap-1.5 rounded-full border px-3 py-1
             text-xs font-medium uppercase tracking-wider transition-colors
-            ${VARIANT_FILL.neutral}
+            ${phaseColors('draft')!.pill}
           `}
         >
           <span aria-hidden="true" className="text-[10px] leading-none">
@@ -171,7 +167,7 @@ export function PhaseTabBar({ currentPhase, selectedTab, onSelect }: PhaseTabBar
                 relative inline-flex items-center gap-1.5 rounded-full border px-3 py-1
                 text-xs font-medium uppercase tracking-wider transition-colors
                 ${isCurrent
-                  ? VARIANT_FILL[statusVariant(tab)]
+                  ? (phaseColors(tab)?.pill ?? '')
                   : isSelected
                     ? 'border-transparent text-primary'
                     : 'border-transparent text-secondary hover:text-primary hover:bg-overlay'

--- a/packages/ui/src/components/PostureDropdown.tsx
+++ b/packages/ui/src/components/PostureDropdown.tsx
@@ -7,6 +7,12 @@ import type { DocRole } from '../api/client';
 export const HEADER_PILL_CLASS =
   'inline-flex items-center gap-1.5 h-7 px-2.5 rounded-md bg-btn-secondary hover:bg-btn-secondary-hover text-sm text-primary transition-colors';
 
+// spec-252: the posture trigger now sits inside the coloured phase container,
+// so it uses a transparent fill with a subtle outline (matching the Figma mock)
+// rather than the filled header pill — it reads as a selector over the tint.
+const POSTURE_TRIGGER_CLASS =
+  'inline-flex items-center gap-1.5 h-7 px-2.5 rounded-md bg-transparent border border-edge hover:bg-overlay text-sm text-primary transition-colors';
+
 interface PostureDropdownProps {
   /** The viewer's current posture on this Spec (from useDocRole). */
   myRole: DocRole;
@@ -129,7 +135,7 @@ export function PostureDropdown({ myRole, onSelect }: PostureDropdownProps) {
           e.stopPropagation();
           setOpen((v) => !v);
         }}
-        className={HEADER_PILL_CLASS}
+        className={POSTURE_TRIGGER_CLASS}
       >
         {editing ? <PencilIcon className="w-3.5 h-3.5" /> : <EyeIcon className="w-3.5 h-3.5" />}
         {editing ? 'You are editing' : 'You are reviewing'}

--- a/packages/ui/src/components/phaseColors.spec-252.test.tsx
+++ b/packages/ui/src/components/phaseColors.spec-252.test.tsx
@@ -1,0 +1,170 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { phaseColors } from './phaseColors';
+import { statusVariant } from '../utils/statusStyles';
+import { PhaseTabBar } from './PhaseTabBar';
+
+// spec-252 dec-1 — the Spec-view header phase palette. A DEDICATED token set
+// (not the shared statusVariant): specify renders purple, decoupled so the
+// shared `warning` consumers (open/review) never recolour. Header-only scope.
+
+const AC_TOKENS = 'mindset-prod/memex-building-itself/specs/spec-252/acs/ac-6';
+const AC_PURPLE = 'mindset-prod/memex-building-itself/specs/spec-252/acs/ac-7';
+const AC_CONTRAST = 'mindset-prod/memex-building-itself/specs/spec-252/acs/ac-8';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const indexCss = readFileSync(join(HERE, '../index.css'), 'utf8');
+const tailwindCfg = readFileSync(join(HERE, '../../tailwind.config.js'), 'utf8');
+const phaseColorsSrc = readFileSync(join(HERE, './phaseColors.ts'), 'utf8');
+const phaseTabBarSrc = readFileSync(join(HERE, './PhaseTabBar.tsx'), 'utf8');
+
+// The four phase container-bg tints + the new specify pill tokens.
+const CONTAINER_TOKENS = [
+  'phase-draft-container',
+  'phase-specify-container',
+  'phase-build-container',
+  'phase-verify-container',
+];
+const SPECIFY_PILL_TOKENS = ['phase-specify-bg', 'phase-specify-text', 'phase-specify-border'];
+
+/** Extract the body of a top-level `.light {…}` / `.dark {…}` rule. */
+function themeBlock(theme: 'light' | 'dark'): string {
+  const m = indexCss.match(new RegExp(`\\.${theme}\\s*\\{([\\s\\S]*?)\\n\\}`));
+  if (!m) throw new Error(`could not find .${theme} block in index.css`);
+  return m[1];
+}
+
+/** Read a `--color-<name>:` value from a theme block. */
+function tokenValue(block: string, name: string): string {
+  const m = block.match(new RegExp(`--color-${name}:\\s*([^;]+);`));
+  if (!m) throw new Error(`token --color-${name} not found`);
+  return m[1].trim();
+}
+
+interface RGBA {
+  r: number;
+  g: number;
+  b: number;
+  a: number;
+}
+
+/** Parse `rgba(r, g, b, a)` or a bare `r g b` triplet into RGBA. */
+function parseColor(value: string): RGBA {
+  const rgba = value.match(/rgba?\(([^)]+)\)/);
+  if (rgba) {
+    const parts = rgba[1].split(',').map((p) => parseFloat(p.trim()));
+    return { r: parts[0], g: parts[1], b: parts[2], a: parts[3] ?? 1 };
+  }
+  const triplet = value.trim().split(/\s+/).map((p) => parseFloat(p));
+  return { r: triplet[0], g: triplet[1], b: triplet[2], a: 1 };
+}
+
+/** Alpha-composite a (possibly translucent) colour over an opaque background. */
+function composite(fg: RGBA, bg: RGBA): RGBA {
+  return {
+    r: fg.r * fg.a + bg.r * (1 - fg.a),
+    g: fg.g * fg.a + bg.g * (1 - fg.a),
+    b: fg.b * fg.a + bg.b * (1 - fg.a),
+    a: 1,
+  };
+}
+
+/** WCAG relative luminance. */
+function luminance({ r, g, b }: RGBA): number {
+  const lin = (c: number) => {
+    const cs = c / 255;
+    return cs <= 0.03928 ? cs / 12.92 : ((cs + 0.055) / 1.055) ** 2.4;
+  };
+  return 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b);
+}
+
+/** WCAG contrast ratio between two opaque colours. */
+function contrast(c1: RGBA, c2: RGBA): number {
+  const l1 = luminance(c1);
+  const l2 = luminance(c2);
+  const [hi, lo] = l1 >= l2 ? [l1, l2] : [l2, l1];
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+describe('phase colour palette (spec-252 dec-1)', () => {
+  it('defines the specify pill + per-phase container-bg tokens in BOTH .light and .dark, with no theme.ts import (ac-6)', () => {
+    tagAc(AC_TOKENS);
+    const light = themeBlock('light');
+    const dark = themeBlock('dark');
+    for (const token of [...CONTAINER_TOKENS, ...SPECIFY_PILL_TOKENS]) {
+      expect(light, `--color-${token} missing from .light`).toContain(`--color-${token}:`);
+      expect(dark, `--color-${token} missing from .dark`).toContain(`--color-${token}:`);
+    }
+    // Tailwind wires each token so components consume it via the token class.
+    for (const token of [...CONTAINER_TOKENS, ...SPECIFY_PILL_TOKENS]) {
+      expect(tailwindCfg, `tailwind.config missing ${token}`).toContain(`--color-${token}`);
+    }
+    // No hardcoded hex in the helper, and the charts-only insights palette
+    // (std-27) is not pulled into the header colour path.
+    expect(phaseColorsSrc).not.toMatch(/#[0-9a-fA-F]{3,8}\b/);
+    expect(phaseColorsSrc).not.toContain('insights/theme');
+    expect(phaseTabBarSrc).not.toContain('insights/theme');
+  });
+
+  it('routes specify→purple and build→blue, verify→green, draft→grey — without touching the shared statusVariant (ac-7)', () => {
+    tagAc(AC_PURPLE);
+    // The pill reading is purple → blue → green; draft stays grey.
+    expect(phaseColors('specify')!.pill).toContain('bg-phase-specify-bg');
+    expect(phaseColors('specify')!.pill).not.toContain('warning');
+    expect(phaseColors('build')!.pill).toContain('bg-phase-build-bg');
+    expect(phaseColors('verify')!.pill).toContain('bg-phase-verify-bg');
+    // draft has no Figma hue yet → keeps the neutral status token.
+    expect(phaseColors('draft')!.pill).toContain('bg-status-neutral-bg');
+    // done keeps its current treatment — no phase colour.
+    expect(phaseColors('done')).toBeNull();
+    // The shared statusVariant is untouched: specify/review/open stay amber, so
+    // board column headers and issue badges do not recolour.
+    expect(statusVariant('specify')).toBe('warning');
+    expect(statusVariant('open')).toBe('warning');
+    // Rendered: the current specify pill wears the purple token.
+    render(<PhaseTabBar currentPhase="specify" selectedTab="specify" onSelect={() => {}} />);
+    const specifyTab = screen
+      .getAllByRole('tab')
+      .find((t) => t.getAttribute('data-tab') === 'specify')!;
+    expect(specifyTab).toHaveAttribute('data-current', 'true');
+    expect(specifyTab.className).toContain('bg-phase-specify-bg');
+    expect(specifyTab.className).not.toContain('bg-status-warning-bg');
+  });
+
+  it('meets WCAG AA contrast for every coloured pill and container in both modes (ac-8)', () => {
+    tagAc(AC_CONTRAST);
+    // The hue-bearing pills (draft keeps the AA-safe neutral status token).
+    const PILL_PHASES = ['specify', 'build', 'verify'] as const;
+    for (const theme of ['light', 'dark'] as const) {
+      const block = themeBlock(theme);
+      const page = parseColor(tokenValue(block, 'page'));
+      const textPrimary = parseColor(tokenValue(block, 'text-primary'));
+
+      // Each pill: pill text on the (translucent) pill bg, composited over the
+      // page. Small uppercase text → AA threshold 4.5. A hue @ 80% over the dark
+      // page is a mid-tone, so this is the binding check in dark mode.
+      for (const phase of PILL_PHASES) {
+        const pillBg = composite(parseColor(tokenValue(block, `phase-${phase}-bg`)), page);
+        const pillText = composite(parseColor(tokenValue(block, `phase-${phase}-text`)), pillBg);
+        expect(
+          contrast(pillText, pillBg),
+          `${phase} pill text/bg contrast in ${theme}`,
+        ).toBeGreaterThanOrEqual(4.5);
+      }
+
+      // Each container tint: body text (text-primary) on the container
+      // composited over the page. AA 4.5.
+      for (const token of CONTAINER_TOKENS) {
+        const containerBg = composite(parseColor(tokenValue(block, token)), page);
+        expect(
+          contrast(textPrimary, containerBg),
+          `${token} vs text-primary contrast in ${theme}`,
+        ).toBeGreaterThanOrEqual(4.5);
+      }
+    }
+  });
+});

--- a/packages/ui/src/components/phaseColors.ts
+++ b/packages/ui/src/components/phaseColors.ts
@@ -1,0 +1,52 @@
+import type { SpecStatus } from '../api/types';
+
+/**
+ * Spec-view header phase palette (spec-252 dec-1).
+ *
+ * A DEDICATED phase-colour set, deliberately decoupled from `statusVariant`:
+ * `specify`/`review`/`open` all share the `warning` variant, so recolouring
+ * `warning` to make specify purple would also recolour open-decision / issue
+ * badges and review docs. Instead, specify gets its own purple tokens here.
+ *
+ * Header-only scope (confirmed 2026-06-12): this drives the phase-bar current
+ * pill (PhaseTabBar) and the coloured header container (DocDocument). Board /
+ * list surfaces that colour specify via `statusVariant` stay amber — see
+ * spec-252 issue-1 for the follow-up.
+ *
+ * specify / build / verify each use the dedicated phase tokens (exact Figma
+ * hue @ 80% pill + @ 10% container). draft has no Figma hue yet, so it keeps the
+ * neutral status token for the pill.
+ */
+export interface PhaseColor {
+  /** Current-phase pill fill — bg + text + border classes. */
+  pill: string;
+  /** Pale container-bg wash for the coloured header container. */
+  container: string;
+}
+
+const PALETTE: Record<'draft' | 'specify' | 'build' | 'verify', PhaseColor> = {
+  draft: {
+    pill: 'bg-status-neutral-bg text-status-neutral-text border-status-neutral-border',
+    container: 'bg-phase-draft-container',
+  },
+  specify: {
+    pill: 'bg-phase-specify-bg text-phase-specify-text border-phase-specify-border',
+    container: 'bg-phase-specify-container',
+  },
+  build: {
+    pill: 'bg-phase-build-bg text-phase-build-text border-phase-build-border',
+    container: 'bg-phase-build-container',
+  },
+  verify: {
+    pill: 'bg-phase-verify-bg text-phase-verify-text border-phase-verify-border',
+    container: 'bg-phase-verify-container',
+  },
+};
+
+/**
+ * The phase's pill + container colours, or `null` for `done` — which keeps its
+ * current treatment (the phase bar is hidden at done; DoneSummary takes over).
+ */
+export function phaseColors(phase: SpecStatus): PhaseColor | null {
+  return PALETTE[phase as keyof typeof PALETTE] ?? null;
+}

--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -94,6 +94,29 @@
   --color-status-neutral-bg:     rgba(62, 68, 81, 0.5);   /* #3e4451/50 */
   --color-status-neutral-text:   148 163 184;              /* slate-400 */
   --color-status-neutral-border: 75 82 95;                 /* #4b525f */
+
+  /* Phase palette (spec-252 dec-1) — Spec-view header only: phase-bar current
+     pill + coloured container. Dedicated tokens, decoupled from statusVariant
+     so the phase hues never recolour the shared `warning`/status consumers.
+     Each phase = ONE base hue at two opacities (pill = hue @ 80%, container =
+     hue @ 10%, exact Figma values), composited live over the page so the same
+     values serve both themes. 950-level dark text keeps every pill clear of
+     WCAG AA in both modes (a hue @ 80% over the dark page is a mid-tone, so the
+     text must be near-black). draft has no Figma hue yet → keeps the neutral
+     pill + a per-mode container. */
+  --color-phase-specify-bg:        rgba(228, 165, 245, 0.8); /* #E4A5F5 @ 80% */
+  --color-phase-specify-text:      46 16 101;                /* purple-950 */
+  --color-phase-specify-border:    228 165 245;
+  --color-phase-specify-container: rgba(228, 165, 245, 0.1); /* #E4A5F5 @ 10% */
+  --color-phase-build-bg:          rgba(123, 198, 252, 0.8); /* #7BC6FC @ 80% */
+  --color-phase-build-text:        8 47 73;                  /* sky-950 */
+  --color-phase-build-border:      123 198 252;
+  --color-phase-build-container:   rgba(123, 198, 252, 0.1); /* #7BC6FC @ 10% */
+  --color-phase-verify-bg:         rgba(93, 192, 166, 0.8);  /* #5DC0A6 @ 80% */
+  --color-phase-verify-text:       2 44 34;                  /* emerald-950 */
+  --color-phase-verify-border:     93 192 166;
+  --color-phase-verify-container:  rgba(93, 192, 166, 0.1);  /* #5DC0A6 @ 10% */
+  --color-phase-draft-container:   rgba(148, 163, 184, 0.10);/* slate wash — draft keeps the neutral pill */
 }
 
 .light {
@@ -164,6 +187,23 @@
   --color-status-neutral-bg:     rgba(226, 232, 240, 1);  /* slate-200 */
   --color-status-neutral-text:   71 85 105;                /* slate-600 */
   --color-status-neutral-border: 203 213 225;              /* slate-300 */
+
+  /* Phase palette (spec-252) — see the .dark block for the rationale. The phase
+     hues use the same hue-at-opacity values in both themes (composited over the
+     page live); only draft's neutral container differs per mode. */
+  --color-phase-specify-bg:        rgba(228, 165, 245, 0.8); /* #E4A5F5 @ 80% */
+  --color-phase-specify-text:      46 16 101;               /* purple-950 */
+  --color-phase-specify-border:    228 165 245;
+  --color-phase-specify-container: rgba(228, 165, 245, 0.1);/* #E4A5F5 @ 10% */
+  --color-phase-build-bg:          rgba(123, 198, 252, 0.8);/* #7BC6FC @ 80% */
+  --color-phase-build-text:        8 47 73;                 /* sky-950 */
+  --color-phase-build-border:      123 198 252;
+  --color-phase-build-container:   rgba(123, 198, 252, 0.1);/* #7BC6FC @ 10% */
+  --color-phase-verify-bg:         rgba(93, 192, 166, 0.8); /* #5DC0A6 @ 80% */
+  --color-phase-verify-text:       2 44 34;                 /* emerald-950 */
+  --color-phase-verify-border:     93 192 166;
+  --color-phase-verify-container:  rgba(93, 192, 166, 0.1); /* #5DC0A6 @ 10% */
+  --color-phase-draft-container:   rgba(241, 245, 249, 1);  /* slate-100 — draft keeps the neutral pill */
 }
 
 @layer base {

--- a/packages/ui/src/pages/DocDocument.spec-159.test.tsx
+++ b/packages/ui/src/pages/DocDocument.spec-159.test.tsx
@@ -14,7 +14,7 @@
 //   ac-6  : the transition flow mounts no modal — Yes transitions directly.
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor, within } from '@testing-library/react';
+import { render, screen, waitFor, within, cleanup } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import { tagAc } from '@memex-ai-ac/vitest';
@@ -22,6 +22,7 @@ import type { ReactNode } from 'react';
 import type { DocWithGraph } from '../api/types';
 
 const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-159/acs/ac-${n}`;
+const AC252 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-252/acs/ac-${n}`;
 
 // ── Heavy children → identity markers so we can see which panel rendered ────
 vi.mock('../components/DecisionPanel', () => ({
@@ -580,18 +581,21 @@ describe('spec-182 — unified reviewer phase block', () => {
     expect(screen.queryByTestId('review-actions-toggle')).not.toBeInTheDocument();
   });
 
-  it('header pill reads "You are reviewing"; picking Editing promotes to editor', async () => {
+  it('posture pill reads "You are reviewing"; picking Editing promotes to editor', async () => {
     tagAc(AC(19));
+    tagAc(AC252(9)); // spec-252 dec-2: pill relocated into the phase container
+    tagAc(AC252(10)); // spec-252: this header-slot assertion updated to the new location
     const user = userEvent.setup();
     renderAt('specify');
     await screen.findByTestId('review-action-row');
 
-    // The pill renders in the header slot, not the page body — and the old
-    // posture sentence is gone. findByRole: the slot populates via a
-    // useHeaderSlot effect a tick after the body renders (same async class
-    // as i-2 / the editor-pill variant below).
+    // spec-252 dec-2: the pill moved OUT of the header slot INTO the in-page
+    // phase container, left of the phase bar. It is no longer in the header
+    // slot, and sits inside data-testid="phase-container".
     const header = screen.getByTestId('header-slot');
-    const pill = await within(header).findByRole('button', { name: /You are reviewing/ });
+    const container = screen.getByTestId('phase-container');
+    const pill = await within(container).findByRole('button', { name: /You are reviewing/ });
+    expect(within(header).queryByRole('button', { name: /You are reviewing/ })).not.toBeInTheDocument();
     expect(screen.queryByText(/You are a reviewer of this spec/)).not.toBeInTheDocument();
 
     await user.click(pill);
@@ -602,18 +606,17 @@ describe('spec-182 — unified reviewer phase block', () => {
     expect(refetchRole).toHaveBeenCalled();
   });
 
-  it('editor: header pill reads "You are editing"; picking Reviewing demotes to reviewer', async () => {
+  it('editor: posture pill reads "You are editing"; picking Reviewing demotes to reviewer', async () => {
     tagAc(AC(19));
+    tagAc(AC252(10)); // spec-252: header-slot assertion updated to the in-container location
     mockRole = 'editor';
     const user = userEvent.setup();
     renderAt('specify');
     await screen.findByText('Narrative');
 
-    const header = screen.getByTestId('header-slot');
-    // findByRole: the header slot populates via a useHeaderSlot effect a tick
-    // after the page body renders — under full-suite load the pill can land
-    // after 'Spec' is already visible (same async class as i-2).
-    await user.click(await within(header).findByRole('button', { name: /You are editing/ }));
+    // spec-252 dec-2: the pill is in the in-page phase container, not the header.
+    const container = screen.getByTestId('phase-container');
+    await user.click(await within(container).findByRole('button', { name: /You are editing/ }));
     await user.click(screen.getByRole('menuitemradio', { name: /Reviewing/ }));
     // useSwitchPosture → demoteToReviewer(docId) then a role refetch.
     await waitFor(() => expect(demoteToReviewer).toHaveBeenCalledWith('doc-uuid'));
@@ -866,5 +869,107 @@ describe('spec-164 issue-1 — draft hides the create-Decisions-and-ACs handoff'
     expect(line.textContent).toContain(
       'Copy the Specify prompt into your coding agent to create Decisions and ACs.',
     );
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// spec-252 — coloured phase container + relocated posture pill. Reuses this
+// file's DocDocument harness (renderAt / HeaderSink).
+// ───────────────────────────────────────────────────────────────────────────
+describe('spec-252 — coloured phase container', () => {
+  // Reviewer posture: canWrite (pill shows) but !canEdit, so the review-action
+  // row + handoff render expanded (no collapse toggle) — the ac-11 wrap check
+  // needs them visible. The global beforeEach otherwise defaults to editor.
+  beforeEach(() => {
+    mockRole = 'reviewer';
+  });
+
+  it('wraps the phase block in a container carrying the current phase colour, per phase (ac-1, ac-2, ac-4)', async () => {
+    tagAc(AC252(1));
+    tagAc(AC252(2));
+    tagAc(AC252(4)); // theme-aware token class → both modes; contrast proven by ac-8
+    const cases = [
+      ['draft', 'bg-phase-draft-container'],
+      ['specify', 'bg-phase-specify-container'],
+      ['build', 'bg-phase-build-container'],
+      ['verify', 'bg-phase-verify-container'],
+    ] as const;
+    for (const [status, cls] of cases) {
+      renderAt(status);
+      const container = await screen.findByTestId('phase-container');
+      // ac-1: the phase bar lives inside the container.
+      expect(
+        within(container).getByRole('tablist', { name: /Spec phase view/i }),
+      ).toBeInTheDocument();
+      // ac-2 / ac-4: the bg is this phase's theme-aware token.
+      expect(container.className, `${status} container colour`).toContain(cls);
+      cleanup();
+    }
+  });
+
+  it('renders NO phase container at done — the done treatment is unchanged (ac-2)', async () => {
+    tagAc(AC252(2));
+    renderAt('done');
+    await screen.findByTestId('done-summary');
+    expect(screen.queryByTestId('phase-container')).not.toBeInTheDocument();
+  });
+
+  it('wraps exactly the phase block (pill, bar, transition, review actions) and excludes the title + content Tabs (ac-11)', async () => {
+    tagAc(AC252(11));
+    renderAt('specify'); // default role = reviewer (canWrite, !canEdit) → review row expanded
+    const container = await screen.findByTestId('phase-container');
+    await within(container).findByTestId('review-handoff-line');
+
+    // INSIDE the container.
+    expect(within(container).getByRole('button', { name: /You are reviewing/ })).toBeInTheDocument();
+    expect(within(container).getByRole('tablist', { name: /Spec phase view/i })).toBeInTheDocument();
+    expect(within(container).getByTestId('transition-sentence')).toBeInTheDocument();
+    expect(within(container).getByTestId('review-action-row')).toBeInTheDocument();
+    expect(within(container).getByTestId('review-handoff-line')).toBeInTheDocument();
+
+    // OUTSIDE: the doc title (no heading inside) and the content Tabs row.
+    expect(within(container).queryByRole('heading')).not.toBeInTheDocument();
+    expect(within(container).queryByText('Decisions & ACs')).not.toBeInTheDocument();
+  });
+
+  it('places the posture pill LEFT of the phase bar, as the only posture switch (ac-3, ac-9, ac-11)', async () => {
+    tagAc(AC252(3)); // scope: edit/review dropdown sits inside the container, left of the phase bar
+    tagAc(AC252(9));
+    tagAc(AC252(11));
+    renderAt('specify');
+    const container = await screen.findByTestId('phase-container');
+    const pill = await within(container).findByRole('button', { name: /You are reviewing/ });
+    const tablist = within(container).getByRole('tablist', { name: /Spec phase view/i });
+    // Exactly one posture switch on the page (spec-182/dec-6 preserved).
+    expect(screen.getAllByRole('button', { name: /You are (reviewing|editing)/ })).toHaveLength(1);
+    // DOM order: the pill precedes (sits left of) the phase bar on the shared row.
+    expect(
+      pill.compareDocumentPosition(tablist) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  it('introduces no new functionality — phase indicator, review actions, and CTAs are intact and still work (ac-5)', async () => {
+    tagAc(AC252(5));
+    const user = userEvent.setup();
+    renderAt('specify'); // reviewer: review row + handoff render expanded
+    await screen.findByTestId('review-action-row');
+
+    // Phase progress indicator — unchanged: the four-tab pipeline, specify
+    // current with its ● dot, browse-only behaviour preserved.
+    expect(screen.getAllByRole('tab')).toHaveLength(4);
+    expect(phaseTab('specify')).toHaveAttribute('data-current', 'true');
+    expect(phaseTab('specify').textContent).toContain('●');
+
+    // Review actions — unchanged: the four review buttons still render…
+    const row = screen.getByTestId('review-action-row');
+    for (const label of ['Summarise Spec', 'Security review', 'Design review', 'Architecture review']) {
+      expect(within(row).getByRole('button', { name: label })).toBeInTheDocument();
+    }
+    // …and still behave: clicking one sends its scaffold prompt through chat.
+    await user.click(within(row).getByRole('button', { name: 'Summarise Spec' }));
+    await waitFor(() => expect(chat.sendMessage).toHaveBeenCalled());
+
+    // Calls-to-action — unchanged: the review handoff "copy prompt" line is present.
+    expect(screen.getByTestId('review-handoff-line')).toBeInTheDocument();
   });
 });

--- a/packages/ui/src/pages/DocDocument.tsx
+++ b/packages/ui/src/pages/DocDocument.tsx
@@ -26,6 +26,7 @@ import { IssuePanel } from '../components/IssuePanel';
 import { AllComments } from '../components/AllComments';
 import { AcPanel } from '../components/AcPanel';
 import { PhaseTabBar, type PhaseTab } from '../components/PhaseTabBar';
+import { phaseColors } from '../components/phaseColors';
 import { TransitionSentence } from '../components/TransitionSentence';
 import { DoneSummary } from '../components/DoneSummary';
 import { Badge, Button, Tabs } from '../components/ui';
@@ -451,16 +452,11 @@ export function DocDocument() {
             phase-control affordance no longer live in the header. The PhaseDropdown
             is gone, replaced by the in-page PhaseTabBar + TransitionSentence below
             the role controls; the page itself carries readiness + handoffs. The
-            header keeps the posture pill + Share / Download / menu (all on
-            canWrite). */}
-        {/* spec-159 ac-19 (amended): MY posture on this Spec — a Google-Docs-
-            style Editing / Reviewing mode pill. Page-global (it gates decision
-            resolution, phase moves, AC mutations on every tab), hence header
-            chrome rather than the phase block. Gated on the role having
-            resolved so the pill never flashes the wrong mode. */}
-        {doc.docType === 'spec' && !roleLoading && (
-          <PostureDropdown myRole={myRole} onSelect={(target) => switchPosture(target)} />
-        )}
+            header keeps Share / Download / menu (all on canWrite). The posture
+            pill moved OUT of the header into the in-page phase container
+            (spec-252 dec-2): it now sits left of the phase bar and scrolls with
+            the page. spec-182/dec-6 is preserved — still the only posture
+            switch, it just relocated. */}
         {/* Share — the Spec's canonical URL with a Copy button. Pill chrome
             shared with the posture dropdown so the header controls match. */}
         <button type="button" className={HEADER_PILL_CLASS} onClick={() => setShareLinkOpen(true)}>
@@ -514,7 +510,7 @@ export function DocDocument() {
         />
       </>
     );
-  }, [doc, reloadDoc, navigate, totalCommentCount, canWrite, canEdit, myRole, roleLoading, switchPosture]);
+  }, [doc, reloadDoc, navigate, totalCommentCount, canWrite, canEdit]);
 
   useHeaderSlot(headerActions);
 
@@ -1306,12 +1302,23 @@ export function DocDocument() {
           was removed). `done` collapses both into the DoneSummary for everyone. */}
       {doc.docType === 'spec' &&
         phase !== 'done' && (
-          <div className="mb-4 space-y-2">
-            <PhaseTabBar
-              currentPhase={phase}
-              selectedTab={viewedTab}
-              onSelect={(t) => setSelectedTab(t)}
-            />
+          <div
+            data-testid="phase-container"
+            className={`mb-4 rounded-lg p-3 space-y-2 ${phaseColors(phase)?.container ?? ''}`}
+          >
+            {/* spec-252 dec-2/dec-3: the posture pill sits inside the container,
+                left of the phase bar, on a shared row (it moved out of the app
+                header). Gated on canWrite — read-only viewers can't switch. */}
+            <div className="flex items-center gap-3">
+              {canWrite && !roleLoading && (
+                <PostureDropdown myRole={myRole} onSelect={(target) => switchPosture(target)} />
+              )}
+              <PhaseTabBar
+                currentPhase={phase}
+                selectedTab={viewedTab}
+                onSelect={(t) => setSelectedTab(t)}
+              />
+            </div>
             <TransitionSentence
               doc={{ id: doc.id }}
               currentPhase={phase}

--- a/packages/ui/tailwind.config.js
+++ b/packages/ui/tailwind.config.js
@@ -69,6 +69,21 @@ export default {
         'status-neutral-bg':     'var(--color-status-neutral-bg)',
         'status-neutral-text':   'rgb(var(--color-status-neutral-text) / <alpha-value>)',
         'status-neutral-border': 'rgb(var(--color-status-neutral-border) / <alpha-value>)',
+
+        /* ── Phase palette (spec-252) — Spec-view header pill + container ── */
+        'phase-specify-bg':        'var(--color-phase-specify-bg)',          /* baked opacity */
+        'phase-specify-text':      'rgb(var(--color-phase-specify-text) / <alpha-value>)',
+        'phase-specify-border':    'rgb(var(--color-phase-specify-border) / <alpha-value>)',
+        'phase-build-bg':          'var(--color-phase-build-bg)',            /* baked opacity */
+        'phase-build-text':        'rgb(var(--color-phase-build-text) / <alpha-value>)',
+        'phase-build-border':      'rgb(var(--color-phase-build-border) / <alpha-value>)',
+        'phase-verify-bg':         'var(--color-phase-verify-bg)',           /* baked opacity */
+        'phase-verify-text':       'rgb(var(--color-phase-verify-text) / <alpha-value>)',
+        'phase-verify-border':     'rgb(var(--color-phase-verify-border) / <alpha-value>)',
+        'phase-draft-container':   'var(--color-phase-draft-container)',     /* baked opacity */
+        'phase-specify-container': 'var(--color-phase-specify-container)',   /* baked opacity */
+        'phase-build-container':   'var(--color-phase-build-container)',     /* baked opacity */
+        'phase-verify-container':  'var(--color-phase-verify-container)',    /* baked opacity */
       },
     },
   },


### PR DESCRIPTION
## Summary
Spec-view header refinement ([spec-252](https://memex.ai/mindset-prod/memex-building-itself/specs/spec-252)). Two presentation/relocation changes — **no new functionality**:

1. **Coloured phase container** — the phase block is wrapped in a rounded container whose background tracks the current phase, so the phase reads at a glance:
   - Draft → grey · **Specify → purple `#E4A5F5`** · **Build → blue `#7BC6FC`** · **Verify → green `#5DC0A6`** · Done → unchanged.
   - One base hue at two opacities (pill `@80%`, container `@10%`, exact Figma values), theme-aware CSS vars, **WCAG AA in both light + dark**.
   - Uses a dedicated `phaseColors()` token set **decoupled from the shared `statusVariant`** — so making specify purple never recolours `open`/`review` badges elsewhere (header-only scope).

2. **Relocated edit/review selector** — the posture pill moved out of the sticky app-shell header into the container, left of the phase bar. It now **scrolls with the page** (intended) and reads as a transparent outlined selector. Remains the only posture-switch affordance (preserves spec-182/dec-6). `HEADER_PILL_CLASS` untouched, so the header Share button is unchanged.

## Changes (all `packages/ui`, no backend)
- `index.css`, `tailwind.config.js` — phase colour tokens (pill + container, light + dark)
- `phaseColors.ts` *(new)* — single source for pill + container classes (consumed by `PhaseTabBar` and `DocDocument`)
- `PhaseTabBar.tsx` — current-pill fill routed through `phaseColors()`
- `DocDocument.tsx` — phase container + posture dropdown relocated into it
- `PostureDropdown.tsx` — transparent outlined trigger
- 3 test files (1 new) — all 11 ACs tagged

## Test plan
- [x] `phaseColors.spec-252.test.tsx` — tokens both themes, purple routing without touching `statusVariant`, WCAG AA contrast for all pills + containers in both modes (ac-6/7/8)
- [x] `DocDocument.spec-159.test.tsx` — container colour per phase, none at done, exact wrap scope, pill left-of-bar as the only switch, header-slot tests updated, ac-5 regression guard (ac-1/2/3/4/5/9/10/11)
- [x] `PhaseTabBar.test.tsx` — pill assertions updated to dedicated phase tokens
- [x] **11/11 ACs verified** in Memex
- [x] Full `packages/ui` pages+components suite: **934 passed, 1 skipped, 0 failed**
- [x] `tsc --noEmit` clean

## Follow-ups (tracked)
- **issue-1**: board/list `specify` chips stay amber (header-only scope) — decide whether to unify.
- Draft has no Figma base hue yet → keeps the neutral pill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)