### PR TITLE
Deploy to prod: develop → main

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,15 +36,33 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Full server suite (unit + integration + security + regression + api) with
-  # the t-17 coverage thresholds enforced in the same run.
+  # Full server suite (unit + integration + security + regression + api), SHARDED
+  # across 3 runners (spec-276). The single un-sharded job was the merge-gate long
+  # pole (~6m17s; ~72% of it module-import under v8 coverage instrumentation, and
+  # core-starved at ~2 workers on a 2-core runner). Three shards each run ~1/3 of
+  # the files, so import + test time divide → ~2.5min, and total CI drops to ~3min
+  # (now gated by ui/e2e). The t-17 coverage gate is NOT weakened: it moves intact
+  # to the `server-result` merge job below, which enforces 80/80/70/80 on the
+  # MERGED full-suite coverage. Mirrors the e2e matrix + e2e-result aggregator.
+  #
+  # WHY the shard step forces every coverage threshold to 0: in vitest 4.1.1 the
+  # blob reporter does NOT defer threshold evaluation (verified empirically,
+  # spec-276 — confirmed in @vitest/coverage-v8 generateReports→reportThresholds).
+  # A shard running --coverage with the config thresholds live would run
+  # checkThresholds against its OWN partial ~1/3 coverage and exit 1. So shards are
+  # collect-only (thresholds 0); the merge job is the SOLE place the real gate fires.
   server:
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
     # Postgres side-car. Same major version we run locally (schema.ts uses features
     # introduced in 13+; production is Cloud SQL 16). Health check blocks `steps` from
-    # starting until the server is ready.
+    # starting until the server is ready. Each shard gets its OWN service, so the
+    # per-worker DB clones (vitest.worker-db.setup.ts) never collide across shards.
     services:
       postgres:
         # pgvector-bundled Postgres 16 — migration 0023 (codebase intelligence)
@@ -95,17 +113,112 @@ jobs:
             psql -v ON_ERROR_STOP=1 "$DATABASE_URL" -f "$f"
           done
 
-      - name: Server suite + coverage gate (fails if services drop below threshold)
-        run: pnpm --filter @memex/server test:coverage
+      - name: Server suite shard ${{ matrix.shard }}/3 (collect coverage, NO threshold gate)
+        # --reporter=blob writes packages/server/.vitest-reports/blob-<shard>-3.json.
+        # The four --coverage.thresholds.*=0 flags make this shard collect-only — the
+        # gate is enforced once, on merged coverage, in server-result (see header).
+        run: |
+          pnpm --filter @memex/server exec vitest run \
+            --shard=${{ matrix.shard }}/3 \
+            --coverage --reporter=blob \
+            --coverage.thresholds.lines=0 \
+            --coverage.thresholds.functions=0 \
+            --coverage.thresholds.branches=0 \
+            --coverage.thresholds.statements=0
 
-      - name: Upload coverage report
-        # Always upload — even on failure — so reviewers can diagnose threshold breaches.
+      - name: Upload coverage blob (shard ${{ matrix.shard }})
+        # Always upload so server-result can merge; a missing blob fails that job closed.
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: server-coverage-blob-${{ matrix.shard }}
+          path: packages/server/.vitest-reports/
+          retention-days: 14
+
+  # Merge the 3 shard coverage blobs and enforce the t-17 thresholds on the MERGED
+  # full-suite coverage (spec-276 dec-2). This job's name is the STABLE required
+  # check for branch protection — the matrix leg names ("server (1)" …) shift with
+  # the shard count and must NOT be required directly (the e2e-result precedent).
+  # Fail-closed: a cancelled/failed shard (needs.server.result != success) or a
+  # missing blob fails the gate rather than passing on partial coverage.
+  server-result:
+    needs: [server]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      MEMEX_EMIT_KEY: ${{ secrets.MEMEX_EMIT_KEY }}
+
+    steps:
+      # Fail closed FIRST: if any shard was cancelled or failed, never merge — a
+      # partial shard set must not produce a green coverage gate.
+      - name: Fail if any server shard did not succeed
+        if: needs.server.result != 'success'
+        run: |
+          echo "server shards result: ${{ needs.server.result }}"
+          exit 1
+
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+
+      - name: Download all shard coverage blobs
+        uses: actions/download-artifact@v4
+        with:
+          pattern: server-coverage-blob-*
+          path: /tmp/server-blobs
+          merge-multiple: true
+
+      - name: Stage blobs and fail closed on a missing shard
+        # vitest --merge-reports reads .vitest-reports/ relative to CWD (= the server
+        # package under the pnpm filter), so stage the downloaded blobs there.
+        run: |
+          mkdir -p packages/server/.vitest-reports
+          cp /tmp/server-blobs/*.json packages/server/.vitest-reports/ 2>/dev/null || true
+          count=$(ls packages/server/.vitest-reports/blob-*.json 2>/dev/null | wc -l)
+          echo "shard blobs found: $count"
+          if [ "$count" -ne 3 ]; then
+            echo "Expected 3 shard coverage blobs, found $count — failing closed (partial coverage must not pass the gate)."
+            exit 1
+          fi
+
+      - name: Merge coverage + enforce t-17 thresholds on the MERGED suite
+        id: merge
+        # No --reporter=blob here: vitest errors "Cannot merge reports when
+        # --reporter=blob is used". The config thresholds (80/80/70/80) apply to the
+        # merged coverage map — this is the one and only coverage gate.
+        run: pnpm --filter @memex/server exec vitest --merge-reports --coverage run
+
+      - name: Upload merged coverage report
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: server-coverage
           path: packages/server/coverage/
           retention-days: 14
+
+      # spec-276: self-report the runtime-only AC from the live run — the structural
+      # regression test asserts the workflow INVOKES the merge gate, but only the
+      # real run proves the threshold fired on merged coverage. Mirrors how
+      # e2e-result emits spec-172 ac-1: pass AND fail alike, non-blocking (|| true),
+      # skipped silently when no key is configured.
+      - name: Emit spec-276 ac-3 (threshold enforced on merged coverage)
+        if: always()
+        run: |
+          STATUS=$([ "${{ steps.merge.outcome }}" = "success" ] && echo pass || echo fail)
+          if [ -z "$MEMEX_EMIT_KEY" ]; then
+            echo "MEMEX_EMIT_KEY unset — skipping ac-3 emission (status would be: $STATUS)"
+          else
+            curl -sS -X POST "https://memex.ai/api/test-events" \
+              -H "Authorization: Bearer $MEMEX_EMIT_KEY" \
+              -H "Content-Type: application/json" \
+              -d "{\"ac_uid\":\"mindset-prod/memex-building-itself/specs/spec-276/acs/ac-3\",\"status\":\"$STATUS\",\"test_identifier\":\".github/workflows/test.yml::server-result\",\"actor\":\"${{ github.actor }}\",\"metadata\":{\"branch\":\"${{ github.ref_name }}\",\"commit\":\"${{ github.sha }}\",\"run_id\":\"${{ github.run_id }}\"}}" \
+              && echo "ac-3 emitted: $STATUS" || echo "ac-3 emission failed (non-blocking)"
+          fi
 
   # Production build gate (std-17 §6 / cl-55): `make build` is what the deploy
   # actually runs, and vitest does NOT typecheck — a green test matrix can hide

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,12 +115,18 @@ jobs:
 
       - name: Server suite shard ${{ matrix.shard }}/3 (collect coverage, NO threshold gate)
         # --reporter=blob writes packages/server/.vitest-reports/blob-<shard>-3.json.
+        # --reporter=default ALSO prints the pass/fail test tree to the console:
+        # blob alone suppresses the console reporter, so a red shard would name no failing
+        # test in the logs — undiagnosable. The dual reporter restores that (the blob is
+        # still written for the merge; verified the two coexist). Do NOT drop the second
+        # reporter — spec-276 issue-2: the first develop flake was un-diagnosable from logs
+        # and only recovered by downloading + replaying the shard blob artifact.
         # The four --coverage.thresholds.*=0 flags make this shard collect-only — the
         # gate is enforced once, on merged coverage, in server-result (see header).
         run: |
           pnpm --filter @memex/server exec vitest run \
             --shard=${{ matrix.shard }}/3 \
-            --coverage --reporter=blob \
+            --coverage --reporter=blob --reporter=default \
             --coverage.thresholds.lines=0 \
             --coverage.thresholds.functions=0 \
             --coverage.thresholds.branches=0 \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -133,6 +133,10 @@ jobs:
         with:
           name: server-coverage-blob-${{ matrix.shard }}
           path: packages/server/.vitest-reports/
+          # REQUIRED: vitest writes the blob to `.vitest-reports/` (a dot-dir), and
+          # upload-artifact@v4 excludes hidden files by default — without this the
+          # upload silently finds nothing and server-result fails closed on 0 blobs.
+          include-hidden-files: true
           retention-days: 14
 
   # Merge the 3 shard coverage blobs and enforce the t-17 thresholds on the MERGED

--- a/packages/server/drizzle/0081_rls_phase2_tenant_tables.sql
+++ b/packages/server/drizzle/0081_rls_phase2_tenant_tables.sql
@@ -1,5 +1,12 @@
 -- spec-199 t-12: Row Level Security — Phase 2 tenant table policies
 --
+-- ⚠️ SUPERSEDED IN PART by migration 0093 (spec-257 dec-1 / std-36): the FORCE
+-- below was the bug. On Cloud SQL `postgres` is NOT a real superuser and has no
+-- BYPASSRLS, so FORCE filtered the deploy/migration role to zero rows (the
+-- 2026-06-10 emission + 2026-06-11 What's New outages). 0093 drops FORCE on all
+-- these tables; the header text below ("superuser postgres bypasses RLS
+-- unconditionally") is FALSE on Cloud SQL — kept only as the historical record.
+--
 -- Enables ENABLE + FORCE ROW LEVEL SECURITY on every primary tenant table
 -- (tables with a direct `memex_id NOT NULL` column). Each policy enforces
 -- that the `app.memex_id` GUC is set AND matches the row's memex_id. The

--- a/packages/server/src/__e2e__/oauth-flow.api.test.ts
+++ b/packages/server/src/__e2e__/oauth-flow.api.test.ts
@@ -26,6 +26,12 @@ import {
 } from "../db/schema.js";
 import { upsertUserByEmail } from "../services/users.js";
 import { signSessionToken } from "../services/auth-jwt.js";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+// spec-275 — the authorize redirect must MERGE params into a redirect_uri that
+// already carries a query string, not blindly concatenate `?code=`.
+const SPEC275_AC_1 = "mindset-prod/memex-building-itself/specs/spec-275/acs/ac-1";
+const SPEC275_AC_2 = "mindset-prod/memex-building-itself/specs/spec-275/acs/ac-2";
 
 const originalFlag = process.env.OAUTH_ENABLED;
 
@@ -293,5 +299,73 @@ describe("OAuth e2e — full connector flow", () => {
     const refreshes = await db.select().from(oauthRefreshTokens).limit(1);
     expect(Array.isArray(codes)).toBe(true);
     expect(Array.isArray(refreshes)).toBe(true);
+  });
+});
+
+describe("OAuth e2e — query-bearing redirect_uri merge (spec-275)", () => {
+  // A redirect_uri with an existing query string is legal (RFC 6749 §3.1.2 bans
+  // only fragments). The authorize handler must MERGE code/state/error into it,
+  // not concat `?code=` (which produced `…?tenant=acme?code=…` and broke parsing).
+  async function registerAndAuthorize(redirectUri: string, decision: "allow" | "deny"): Promise<string> {
+    const { app } = await import("../app.js");
+    const user = await upsertUserByEmail(`oauth-q-${decision}-${Date.now()}-${Math.random()}@test.dev`);
+    userIds.push(user.id);
+    const sessionJwt = signSessionToken(user.id);
+
+    const regRes = await app.fetch(
+      new Request("https://memex.ai/api/oauth/register", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ client_name: "spec-275 query redirect", redirect_uris: [redirectUri] }),
+      }),
+    );
+    expect(regRes.status).toBe(201);
+    const reg = (await regRes.json()) as { client_id: string };
+    const [client] = await db
+      .select()
+      .from(oauthClients)
+      .where(inArray(oauthClients.clientId, [reg.client_id]));
+    clientRowIds.push(client.id);
+
+    const { challenge } = makePkce();
+    const authRes = await app.fetch(
+      new Request("https://memex.ai/api/oauth/authorize", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Authorization: `Bearer ${sessionJwt}` },
+        body: JSON.stringify({
+          response_type: "code",
+          client_id: reg.client_id,
+          redirect_uri: redirectUri,
+          code_challenge: challenge,
+          code_challenge_method: "S256",
+          state: "test-state",
+          decision,
+        }),
+      }),
+    );
+    expect(authRes.status).toBe(200);
+    const { redirect } = (await authRes.json()) as { redirect: string };
+    return redirect;
+  }
+
+  it("ac-1/ac-2: grant merges code+state into an existing query string (no double-?)", async () => {
+    tagAc(SPEC275_AC_1);
+    tagAc(SPEC275_AC_2);
+    const redirect = await registerAndAuthorize("https://test.example/callback?tenant=acme", "allow");
+    expect(redirect.split("?").length).toBe(2); // exactly one '?' — merged, not concatenated
+    const u = new URL(redirect);
+    expect(u.searchParams.get("tenant")).toBe("acme"); // original param preserved, intact
+    expect(u.searchParams.get("code")).toBeTruthy(); // merged & individually parseable
+    expect(u.searchParams.get("state")).toBe("test-state");
+  });
+
+  it("ac-1: deny merges error+state into an existing query string (no double-?)", async () => {
+    tagAc(SPEC275_AC_1);
+    const redirect = await registerAndAuthorize("https://test.example/callback?tenant=acme", "deny");
+    expect(redirect.split("?").length).toBe(2);
+    const u = new URL(redirect);
+    expect(u.searchParams.get("tenant")).toBe("acme");
+    expect(u.searchParams.get("error")).toBe("access_denied");
+    expect(u.searchParams.get("state")).toBe("test-state");
   });
 });

--- a/packages/server/src/__regression__/spec-276-server-shard-gate.regression.test.ts
+++ b/packages/server/src/__regression__/spec-276-server-shard-gate.regression.test.ts
@@ -65,6 +65,13 @@ describe("spec-276 — the server suite is sharded but the coverage gate is inta
     const server = jobBlock("server");
     expect(server, "shard runs under coverage").toMatch(/--coverage\b/);
     expect(server, "shard emits a blob report").toMatch(/--reporter=blob\b/);
+    // Dual reporter: blob alone suppresses console output, so a red shard names no
+    // failing test in CI logs (spec-276 issue-2 — the first develop flake was only
+    // diagnosable by downloading + replaying the blob). A second console reporter
+    // restores in-log failures. Don't let it regress to blob-only.
+    expect(server, "shard also runs a console reporter (not blob-only)").toMatch(
+      /--reporter=blob\s+--reporter=\w/,
+    );
     // Collect-only: all four metric thresholds forced to 0 so a shard does NOT
     // gate on its partial coverage. (Drop any one and that shard reds out.)
     for (const metric of ["lines", "functions", "branches", "statements"]) {

--- a/packages/server/src/__regression__/spec-276-server-shard-gate.regression.test.ts
+++ b/packages/server/src/__regression__/spec-276-server-shard-gate.regression.test.ts
@@ -76,6 +76,11 @@ describe("spec-276 — the server suite is sharded but the coverage gate is inta
     // The blob is uploaded as an artifact for the merge job to pick up.
     expect(server, "shard uploads its coverage blob").toMatch(/upload-artifact/);
     expect(server).toMatch(/\.vitest-reports/);
+    // MUST include hidden files: vitest writes the blob into `.vitest-reports/`
+    // (a dot-dir) and upload-artifact@v4 excludes hidden files by default — without
+    // this the upload finds nothing and server-result fails closed on 0 blobs.
+    // (Caught by PR #169's first CI run; this assertion pins the fix.)
+    expect(server, "blob upload includes hidden files").toMatch(/include-hidden-files:\s*true/);
   });
 
   it("ac-8: server-result merges the blobs and enforces the threshold on MERGED coverage", () => {

--- a/packages/server/src/__regression__/spec-276-server-shard-gate.regression.test.ts
+++ b/packages/server/src/__regression__/spec-276-server-shard-gate.regression.test.ts
@@ -1,0 +1,108 @@
+// spec-276 — the server suite is SHARDED across CI runners to cut merge-gate
+// wall-clock, WITHOUT weakening the t-17 coverage gate. These are static
+// assertions on `.github/workflows/test.yml` (the same shape as the spec-172
+// e2e-pipeline guards and the spec-168 cicd-deploy-config guards). They pin the
+// load-bearing structure so a future edit can't silently:
+//
+//   1. collapse the shard matrix (ac-6) — losing the parallelism;
+//   2. drop the collect-only coverage flags on a shard (ac-7) — which would make
+//      every shard exit 1 on its partial coverage (verified: vitest 4.1.1's blob
+//      reporter does NOT defer threshold checks), OR drop blob/coverage entirely;
+//   3. stop enforcing the threshold on the MERGED coverage (ac-8) — turning the
+//      gate into a no-op;
+//   4. make the aggregator fail-OPEN (ac-9) — letting a cancelled/failed shard or
+//      a missing blob pass as green on partial coverage.
+//
+// What these CANNOT assert (verified only by the live CI run, self-reported from
+// the server-result job per the e2e-result precedent): the ~3min wall-clock
+// (ac-1), the merged test count (ac-2), and that the threshold actually fires on
+// merged coverage (ac-3). A green structural test means "the workflow invokes the
+// right commands", NOT "the coverage math is correct".
+//
+// Branch protection (requiring `server-result` on develop + main, dropping the
+// old `server` check) is a repo-settings surface GitHub doesn't let repo contents
+// assert — that is ac-5, verified manually at flip time (t-4).
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+const SPEC = "mindset-prod/memex-building-itself/specs/spec-276";
+const REPO_ROOT = join(__dirname, "..", "..", "..", "..");
+const TEST_YML = readFileSync(
+  join(REPO_ROOT, ".github", "workflows", "test.yml"),
+  "utf-8",
+);
+
+// Extract one top-level job block: from `\n  <name>:` to the next 2-space-indented
+// `\n  <other>:` key (or EOF). Mirrors the helper in spec-172-e2e-pipeline-gate.
+function jobBlock(name: string): string {
+  const start = TEST_YML.search(new RegExp(`^  ${name}:\\s*$`, "m"));
+  expect(start, `job "${name}" exists in test.yml`).toBeGreaterThan(-1);
+  const rest = TEST_YML.slice(start + 1);
+  const next = rest.search(/^  [A-Za-z0-9_-]+:\s*$/m);
+  return next === -1 ? TEST_YML.slice(start) : TEST_YML.slice(start, start + 1 + next);
+}
+
+describe("spec-276 — the server suite is sharded but the coverage gate is intact", () => {
+  it("ac-6: the server job is a 3-way shard matrix, each leg with its own Postgres", () => {
+    tagAc(`${SPEC}/acs/ac-6`);
+    const server = jobBlock("server");
+    // 3-way matrix on `shard`.
+    expect(server, "server job declares a matrix").toMatch(/^\s*matrix:\s*$/m);
+    expect(server, "matrix shards over [1, 2, 3]").toMatch(/shard:\s*\[\s*1\s*,\s*2\s*,\s*3\s*\]/);
+    // Each leg runs only its 1/3 slice.
+    expect(server).toMatch(/--shard=\$\{\{\s*matrix\.shard\s*\}\}\/3/);
+    // Own Postgres side-car (pgvector pg16), so the per-worker DB clones don't collide.
+    expect(server, "server shard has its own pgvector pg16 service").toMatch(
+      /services:[\s\S]*postgres:[\s\S]*pgvector\/pgvector:pg16/,
+    );
+  });
+
+  it("ac-7: each shard collects coverage into a blob WITHOUT enforcing thresholds, and uploads it", () => {
+    tagAc(`${SPEC}/acs/ac-7`);
+    const server = jobBlock("server");
+    expect(server, "shard runs under coverage").toMatch(/--coverage\b/);
+    expect(server, "shard emits a blob report").toMatch(/--reporter=blob\b/);
+    // Collect-only: all four metric thresholds forced to 0 so a shard does NOT
+    // gate on its partial coverage. (Drop any one and that shard reds out.)
+    for (const metric of ["lines", "functions", "branches", "statements"]) {
+      expect(
+        server,
+        `shard disables the ${metric} threshold (collect-only)`,
+      ).toMatch(new RegExp(`--coverage\\.thresholds\\.${metric}=0\\b`));
+    }
+    // The blob is uploaded as an artifact for the merge job to pick up.
+    expect(server, "shard uploads its coverage blob").toMatch(/upload-artifact/);
+    expect(server).toMatch(/\.vitest-reports/);
+  });
+
+  it("ac-8: server-result merges the blobs and enforces the threshold on MERGED coverage", () => {
+    tagAc(`${SPEC}/acs/ac-8`);
+    const agg = jobBlock("server-result");
+    expect(agg, "merges the shard blobs under coverage").toMatch(
+      /vitest\s+--merge-reports\s+--coverage|--merge-reports[\s\S]*--coverage/,
+    );
+    // The merge step must NOT carry a blob reporter — vitest hard-errors
+    // ("Cannot merge reports when --reporter=blob is used").
+    const mergeLine = agg
+      .split("\n")
+      .find((l) => l.includes("--merge-reports")) ?? "";
+    expect(mergeLine, "merge step does not pass --reporter=blob").not.toMatch(/--reporter=blob/);
+  });
+
+  it("ac-9: server-result fails CLOSED on a cancelled/failed shard or a missing blob", () => {
+    tagAc(`${SPEC}/acs/ac-9`);
+    const agg = jobBlock("server-result");
+    expect(agg, "depends on the server matrix").toMatch(/^    needs:\s*\[?\s*server\s*\]?\s*$/m);
+    // `if: always()` is what makes a SKIPPED/CANCELLED server read as RED here
+    // rather than a green-ish skip.
+    expect(agg).toMatch(/^    if:\s*always\(\)\s*$/m);
+    expect(agg, "guards on the matrix result").toMatch(/needs\.server\.result/);
+    expect(agg).toMatch(/!=\s*['"]success['"]/);
+    expect(agg).toMatch(/exit 1/);
+    // Fail on a missing blob — a partial blob set must not merge to a green gate.
+    expect(agg, "asserts the expected blob count (fail on missing)").toMatch(/-ne 3|!= 3|-lt 3/);
+  });
+});

--- a/packages/server/src/db/connection.ts
+++ b/packages/server/src/db/connection.ts
@@ -68,8 +68,16 @@ export const memexContext = new AsyncLocalStorage<MemexRequestContext>();
  *
  * When memexId is null/undefined (anonymous public read, no resolved tenant),
  * fn runs without an ALS context — the IS NOT NULL guard in each RLS policy
- * blocks cross-tenant reads on the restricted role, and the superuser role
- * bypasses RLS unconditionally.
+ * blocks cross-tenant reads on the restricted runtime role `memex_app`.
+ *
+ * NOTE (spec-257 dec-1 / std-36): the OWNER role bypasses RLS only because the
+ * tenant tables are `ENABLE` + `NO FORCE` (migration 0093) — NOT via a BYPASSRLS
+ * attribute. On Cloud SQL `postgres` is not a real superuser and has neither
+ * `rolsuper` nor `rolbypassrls` (verified prod+int 2026-06-11); under the old
+ * `FORCE` it was filtered to zero rows, which caused the 2026-06-10 emission and
+ * 2026-06-11 What's New outages. The runtime connects as the non-owner `memex_app`
+ * and is always subject to RLS; only owner-role paths (migrations, deploy/admin
+ * scripts) bypass.
  */
 export function runWithMemexId<T>(
   memexId: string | null | undefined,

--- a/packages/server/src/db/spec-199-rls-schema.test.ts
+++ b/packages/server/src/db/spec-199-rls-schema.test.ts
@@ -27,6 +27,15 @@ const AC_16 = "mindset-prod/memex-building-itself/specs/spec-199/acs/ac-16";
 // spec-257 dec-3: the dynamic FORCE guard — no RLS-enabled table may be FORCE'd.
 const AC_257_FORCE_GUARD =
   "mindset-prod/memex-building-itself/specs/spec-257/acs/ac-11";
+// spec-257 dec-1: the NO-FORCE posture (RLS enabled, FORCE off) is spec-257's
+// contract now — it inverts spec-199's original "enabled AND forced", so the
+// posture assertion below re-tags here rather than emitting a contradictory
+// pass to the done spec-199 ACs (the pure cross-tenant isolation/policy tests
+// keep AC_15/AC_16 — those claims are unchanged).
+const AC_257_POSTURE =
+  "mindset-prod/memex-building-itself/specs/spec-257/acs/ac-7";
+const AC_257_MEMEX_APP_SUBJECT =
+  "mindset-prod/memex-building-itself/specs/spec-257/acs/ac-9";
 const RLS_ROLE = "memex_rls_tester";
 const RLS_PASS = "memex_rls_test_only";
 
@@ -168,9 +177,8 @@ describe("spec-199 ac-16: RLS tenant isolation", () => {
     ).rejects.toThrow();
   });
 
-  it("ac-16: RLS is enabled but NOT forced on all 13 tenant tables (owner-bypass posture, spec-257 dec-1)", async () => {
-    tagAc(AC_15);
-    tagAc(AC_16);
+  it("ac-7: RLS is enabled but NOT forced on all 13 tenant tables (owner-bypass posture, spec-257 dec-1)", async () => {
+    tagAc(AC_257_POSTURE);
 
     // memex_emission_keys is deliberately absent: it is an identity-
     // establishment table (verifyEmissionKey runs before ALS context exists)
@@ -286,9 +294,8 @@ describe("spec-199 ac-16: RLS tenant isolation", () => {
     }
   });
 
-  it("ac-16: memex_app role without GUC sees 0 rows (SET LOCAL ROLE production path)", async () => {
-    tagAc(AC_15);
-    tagAc(AC_16);
+  it("ac-9: memex_app role without GUC sees 0 rows (SET LOCAL ROLE production path)", async () => {
+    tagAc(AC_257_MEMEX_APP_SUBJECT);
 
     // Switch to memex_app within a transaction using SET LOCAL ROLE. memex_app
     // is a NON-OWNER role (postgres owns these tables) with NOBYPASSRLS, so

--- a/packages/server/src/db/spec-199-rls-schema.test.ts
+++ b/packages/server/src/db/spec-199-rls-schema.test.ts
@@ -24,6 +24,9 @@ import { tagAc } from "@memex-ai-ac/vitest";
 
 const AC_15 = "mindset-prod/memex-building-itself/specs/spec-199/acs/ac-15";
 const AC_16 = "mindset-prod/memex-building-itself/specs/spec-199/acs/ac-16";
+// spec-257 dec-3: the dynamic FORCE guard — no RLS-enabled table may be FORCE'd.
+const AC_257_FORCE_GUARD =
+  "mindset-prod/memex-building-itself/specs/spec-257/acs/ac-11";
 const RLS_ROLE = "memex_rls_tester";
 const RLS_PASS = "memex_rls_test_only";
 
@@ -176,7 +179,7 @@ describe("spec-199 ac-16: RLS tenant isolation", () => {
     // __regression__/emission-key-contextless-verify.regression.test.ts.
     //
     // Posture: RLS is ENABLED (relrowsecurity=t) but NOT FORCED
-    // (relforcerowsecurity=f) — migration 0091 dropped FORCE per spec-257 dec-1.
+    // (relforcerowsecurity=f) — migration 0093 dropped FORCE per spec-257 dec-1.
     // FORCE only affects the table OWNER; on Cloud SQL the deploy/migration role
     // is `postgres` (the owner, NOBYPASSRLS), so FORCE filtered every contextless
     // migration/deploy-script query to zero rows (the 2026-06-10 emission and
@@ -219,8 +222,67 @@ describe("spec-199 ac-16: RLS tenant isolation", () => {
       expect(row!.rowsecurity, `${table}: rowsecurity not enabled`).toBe(true);
       expect(
         row!.forcerowsecurity,
-        `${table}: FORCE must be OFF (owner-bypass posture, spec-257 dec-1 / migration 0091)`,
+        `${table}: FORCE must be OFF (owner-bypass posture, spec-257 dec-1 / migration 0093)`,
       ).toBe(false);
+    }
+  });
+
+  // spec-257 dec-3 / ac-11 — the DYNAMIC FORCE guard. The test above pins the
+  // known set; this one is the structural backstop: it queries pg_class for
+  // EVERY RLS-enabled table (no hardcoded list) and fails if any is FORCE'd —
+  // so a future ENABLE+FORCE on a brand-new tenant table (exactly what spec-260's
+  // 0092 did days after the outages) trips CI immediately, with no test edit.
+  it("ac-11: NO RLS-enabled table is FORCE'd — dynamic guard against future ENABLE+FORCE", async () => {
+    tagAc(AC_257_FORCE_GUARD);
+
+    const forced = (await db.execute(sql`
+      SELECT c.relname AS tablename
+      FROM pg_class c
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+      WHERE n.nspname = 'public'
+        AND c.relkind = 'r'
+        AND c.relrowsecurity
+        AND c.relforcerowsecurity
+      ORDER BY c.relname
+    `)) as unknown as Array<{ tablename: string }>;
+
+    expect(
+      forced.map((r) => r.tablename),
+      "tables with FORCE ROW LEVEL SECURITY (must be none — spec-257 dec-1: " +
+        "owner-bypass requires NO FORCE; add an ALTER TABLE … NO FORCE migration " +
+        "for any table listed here)",
+    ).toEqual([]);
+  });
+
+  // Red-proof: the guard query is not vacuous — it actually detects a FORCE'd
+  // table. Creates a throwaway table with ENABLE+FORCE, asserts the guard query
+  // surfaces it, then drops it. If this passed with an empty result the guard
+  // above would be meaningless.
+  it("ac-11: the FORCE guard is not vacuous — a FORCE'd table IS detected", async () => {
+    tagAc(AC_257_FORCE_GUARD);
+
+    const probe = "rls_force_guard_probe";
+    try {
+      await db.execute(sql.raw(`CREATE TABLE IF NOT EXISTS ${probe} (id int)`));
+      await db.execute(sql.raw(`ALTER TABLE ${probe} ENABLE ROW LEVEL SECURITY`));
+      await db.execute(sql.raw(`ALTER TABLE ${probe} FORCE ROW LEVEL SECURITY`));
+
+      const forced = (await db.execute(sql`
+        SELECT c.relname AS tablename
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'public'
+          AND c.relkind = 'r'
+          AND c.relrowsecurity
+          AND c.relforcerowsecurity
+      `)) as unknown as Array<{ tablename: string }>;
+
+      expect(
+        forced.map((r) => r.tablename),
+        "guard query failed to detect a deliberately FORCE'd table",
+      ).toContain(probe);
+    } finally {
+      await db.execute(sql.raw(`DROP TABLE IF EXISTS ${probe}`));
     }
   });
 

--- a/packages/server/src/db/spec-199-rls-schema.test.ts
+++ b/packages/server/src/db/spec-199-rls-schema.test.ts
@@ -36,6 +36,14 @@ const AC_257_POSTURE =
   "mindset-prod/memex-building-itself/specs/spec-257/acs/ac-7";
 const AC_257_MEMEX_APP_SUBJECT =
   "mindset-prod/memex-building-itself/specs/spec-257/acs/ac-9";
+// spec-257 dec-1: owner-bypass mechanism (ac-8), the scope isolation outcome
+// (ac-1), and the structural-guard scope outcome (ac-4).
+const AC_257_OWNER_BYPASS =
+  "mindset-prod/memex-building-itself/specs/spec-257/acs/ac-8";
+const AC_257_SCOPE_ISOLATION =
+  "mindset-prod/memex-building-itself/specs/spec-257/acs/ac-1";
+const AC_257_SCOPE_GUARD =
+  "mindset-prod/memex-building-itself/specs/spec-257/acs/ac-4";
 const RLS_ROLE = "memex_rls_tester";
 const RLS_PASS = "memex_rls_test_only";
 
@@ -242,6 +250,7 @@ describe("spec-199 ac-16: RLS tenant isolation", () => {
   // 0092 did days after the outages) trips CI immediately, with no test edit.
   it("ac-11: NO RLS-enabled table is FORCE'd — dynamic guard against future ENABLE+FORCE", async () => {
     tagAc(AC_257_FORCE_GUARD);
+    tagAc(AC_257_SCOPE_GUARD);
 
     const forced = (await db.execute(sql`
       SELECT c.relname AS tablename
@@ -294,8 +303,73 @@ describe("spec-199 ac-16: RLS tenant isolation", () => {
     }
   });
 
+  // spec-257 dec-1 / ac-8 + ac-1 — the OWNER-BYPASS mechanism, reproduced
+  // locally. The whole fix rests on: a table OWNER bypasses RLS under NO FORCE
+  // but is subject under FORCE. CI's `postgres` is a real superuser (bypasses
+  // regardless), which is exactly why this never reproduced in CI before — so we
+  // make a dedicated NON-superuser role OWN a probe table (mirroring Cloud SQL,
+  // where `postgres` is not a superuser) and assert both branches of the matrix.
+  it("ac-8: a non-superuser table OWNER bypasses RLS under NO FORCE, is filtered under FORCE", async () => {
+    tagAc(AC_257_OWNER_BYPASS);
+    tagAc(AC_257_SCOPE_ISOLATION);
+
+    const ownerRole = "rls_owner_probe_role";
+    const ownerPass = "rls_owner_probe_only";
+    const tbl = "rls_owner_probe_tbl";
+    // Setup as the privileged `db` connection: create the non-super role + table,
+    // hand OWNERSHIP to that role, enable RLS with a policy that blocks rows when
+    // no app.memex_id GUC is set.
+    await db.execute(sql.raw(`DROP TABLE IF EXISTS ${tbl}`));
+    await db.execute(sql.raw(`DROP OWNED BY ${ownerRole} CASCADE`)).catch(() => {});
+    await db.execute(sql.raw(`DROP ROLE IF EXISTS ${ownerRole}`));
+    await db.execute(
+      sql.raw(
+        `CREATE ROLE ${ownerRole} LOGIN PASSWORD '${ownerPass}' NOSUPERUSER NOBYPASSRLS`,
+      ),
+    );
+    await db.execute(sql.raw(`GRANT USAGE ON SCHEMA public TO ${ownerRole}`));
+    await db.execute(sql.raw(`CREATE TABLE ${tbl} (id int)`));
+    await db.execute(sql.raw(`INSERT INTO ${tbl} VALUES (1)`));
+    await db.execute(sql.raw(`ALTER TABLE ${tbl} OWNER TO ${ownerRole}`));
+    await db.execute(sql.raw(`ALTER TABLE ${tbl} ENABLE ROW LEVEL SECURITY`));
+    await db.execute(
+      sql.raw(
+        `CREATE POLICY ${tbl}_iso ON ${tbl} USING (current_setting('app.memex_id', true) IS NOT NULL)`,
+      ),
+    );
+
+    const dbUrl =
+      process.env.DATABASE_URL ?? "postgresql://postgres:postgres@localhost:5432/memex";
+    const ownerUrl = new URL(dbUrl);
+    ownerUrl.username = ownerRole;
+    ownerUrl.password = ownerPass;
+    const ownerSql = postgres(ownerUrl.toString(), { max: 1 });
+    try {
+      // NO FORCE (the 0093 posture): the owner bypasses → sees the row with no GUC.
+      const noForce = await ownerSql.unsafe(`SELECT id FROM ${tbl}`);
+      expect(
+        noForce,
+        "non-super OWNER under NO FORCE must bypass RLS and see the row (this is what 0093 restored)",
+      ).toHaveLength(1);
+
+      // FORCE (the 0081 bug): the owner becomes subject → filtered to 0 rows with no GUC.
+      await db.execute(sql.raw(`ALTER TABLE ${tbl} FORCE ROW LEVEL SECURITY`));
+      const forced = await ownerSql.unsafe(`SELECT id FROM ${tbl}`);
+      expect(
+        forced,
+        "non-super OWNER under FORCE must be filtered to 0 rows (this is the 2026-06-10/06-11 outage mechanism)",
+      ).toHaveLength(0);
+    } finally {
+      await ownerSql.end({ timeout: 5 });
+      await db.execute(sql.raw(`DROP TABLE IF EXISTS ${tbl}`));
+      await db.execute(sql.raw(`DROP OWNED BY ${ownerRole} CASCADE`)).catch(() => {});
+      await db.execute(sql.raw(`DROP ROLE IF EXISTS ${ownerRole}`));
+    }
+  });
+
   it("ac-9: memex_app role without GUC sees 0 rows (SET LOCAL ROLE production path)", async () => {
     tagAc(AC_257_MEMEX_APP_SUBJECT);
+    tagAc(AC_257_SCOPE_ISOLATION);
 
     // Switch to memex_app within a transaction using SET LOCAL ROLE. memex_app
     // is a NON-OWNER role (postgres owns these tables) with NOBYPASSRLS, so

--- a/packages/server/src/routes/oauth/authorize.ts
+++ b/packages/server/src/routes/oauth/authorize.ts
@@ -202,11 +202,23 @@ authorize.post("/", async (c) => {
   }
 
   const state = typeof md.state === "string" ? md.state : "";
-  const stateParam = state ? `&state=${encodeURIComponent(state)}` : "";
+
+  // Build the callback by MERGING params into the registered redirect_uri via
+  // URLSearchParams — never string-concat `?…`. A redirect_uri may legally carry
+  // its own query string (RFC 6749 §3.1.2 forbids only fragments, which DCR
+  // already rejects), so a naive `${uri}?code=` produced `…?tenant=acme?code=…`
+  // and broke the client's parse (spec-275). `md.redirect_uri` is already
+  // validated (clientRedirectAllowed + absolute-URI at registration), so
+  // `new URL()` cannot throw here.
+  const buildRedirect = (params: Record<string, string>): string => {
+    const url = new URL(md.redirect_uri as string);
+    for (const [key, value] of Object.entries(params)) url.searchParams.set(key, value);
+    return url.toString();
+  };
 
   if (md.decision === "deny") {
     return c.json({
-      redirect: `${md.redirect_uri}?error=access_denied${stateParam}`,
+      redirect: buildRedirect({ error: "access_denied", ...(state ? { state } : {}) }),
     });
   }
 
@@ -263,6 +275,6 @@ authorize.post("/", async (c) => {
   });
 
   return c.json({
-    redirect: `${md.redirect_uri}?code=${encodeURIComponent(minted.code)}${stateParam}`,
+    redirect: buildRedirect({ code: minted.code, ...(state ? { state } : {}) }),
   });
 });

--- a/packages/server/src/services/documents.status-changed.spec-179.test.ts
+++ b/packages/server/src/services/documents.status-changed.spec-179.test.ts
@@ -7,7 +7,7 @@
 
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
 import { tagAc } from "@memex-ai-ac/vitest";
-import { eq, inArray } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import { db } from "../db/connection.js";
 import { activityLog, documents, memexes, namespaces } from "../db/schema.js";
 import { makeTestMemex } from "./test-helpers.js";
@@ -45,19 +45,27 @@ beforeEach(async () => {
   await db.delete(activityLog).where(eq(activityLog.memexId, memexId));
 });
 
-// Poll until at least `expected` matching rows land (the sink persists on a
-// detached promise off the synchronous emit path), or time out.
-async function waitForStatusRows(expected: number, timeoutMs = 2000) {
+// Poll until THIS document's rows satisfy `ready`, then return only that
+// document's rows. The activity sink persists on a detached promise off the
+// synchronous emit path (async), so two failure modes lurk if you filter by
+// memexId alone (spec-179/issue-1, the flake this scoping fixes):
+//   1. a PRIOR test's detached write can land after beforeEach's delete and
+//      inflate a memexId-wide count;
+//   2. this op's own row may not have landed yet when the assertion runs.
+// Scoping every query by briefId (each test uses a fresh, unique doc id) makes a
+// test immune to (1), and gating on a per-doc `ready` predicate handles (2).
+async function waitForDocRows(
+  briefId: string,
+  ready: (rows: (typeof activityLog.$inferSelect)[]) => boolean,
+  timeoutMs = 2000,
+) {
   const start = Date.now();
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const rows = await db
-      .select()
-      .from(activityLog)
-      .where(eq(activityLog.memexId, memexId));
-    const statusRows = rows.filter((r) => r.action === "status_changed");
-    if (statusRows.length >= expected) return { rows, statusRows };
-    if (Date.now() - start > timeoutMs) return { rows, statusRows };
+    const rows = (
+      await db.select().from(activityLog).where(eq(activityLog.memexId, memexId))
+    ).filter((r) => r.briefId === briefId);
+    if (ready(rows) || Date.now() - start > timeoutMs) return rows;
     await new Promise((r) => setTimeout(r, 25));
   }
 }
@@ -69,7 +77,10 @@ describe("updateDocStatus — document/status_changed emission (spec-179 ac-5)",
 
     await updateDocStatus(memexId, spec.id, "specify");
 
-    const { statusRows } = await waitForStatusRows(1);
+    const rows = await waitForDocRows(spec.id, (rs) =>
+      rs.some((r) => r.action === "status_changed"),
+    );
+    const statusRows = rows.filter((r) => r.action === "status_changed");
     expect(statusRows).toHaveLength(1);
     expect(statusRows[0]).toMatchObject({
       memexId,
@@ -87,7 +98,15 @@ describe("updateDocStatus — document/status_changed emission (spec-179 ac-5)",
 
     await updateDocStatus(memexId, spec.id, "build");
 
-    const { rows, statusRows } = await waitForStatusRows(1);
+    // A spec flip emits BOTH an `updated` and a `status_changed` row (two detached
+    // writes); wait for both to land for THIS doc before asserting their counts.
+    const rows = await waitForDocRows(
+      spec.id,
+      (rs) =>
+        rs.some((r) => r.action === "status_changed") &&
+        rs.some((r) => r.action === "updated"),
+    );
+    const statusRows = rows.filter((r) => r.action === "status_changed");
     expect(statusRows).toHaveLength(1);
     expect(statusRows[0].payload).toEqual({ from: "specify", to: "build" });
     expect(rows.filter((r) => r.action === "updated")).toHaveLength(1);
@@ -99,14 +118,9 @@ describe("updateDocStatus — document/status_changed emission (spec-179 ac-5)",
 
     await updateDocStatus(memexId, doc.id, "approved");
 
-    // Wait for the guaranteed "updated" row, then confirm no status_changed.
-    const start = Date.now();
-    let rows: (typeof activityLog.$inferSelect)[] = [];
-    while (Date.now() - start < 2000) {
-      rows = await db.select().from(activityLog).where(eq(activityLog.memexId, memexId));
-      if (rows.some((r) => r.action === "updated")) break;
-      await new Promise((r) => setTimeout(r, 25));
-    }
+    // Wait for THIS doc's guaranteed "updated" row, then confirm no status_changed
+    // for it — scoped by briefId so a sibling test's late detached write can't bleed in.
+    const rows = await waitForDocRows(doc.id, (rs) => rs.some((r) => r.action === "updated"));
     expect(rows.some((r) => r.action === "updated")).toBe(true);
     expect(rows.filter((r) => r.action === "status_changed")).toHaveLength(0);
   });
@@ -117,13 +131,9 @@ describe("updateDocStatus — document/status_changed emission (spec-179 ac-5)",
 
     await updateDocStatus(memexId, spec.id, "build");
 
-    const start = Date.now();
-    let rows: (typeof activityLog.$inferSelect)[] = [];
-    while (Date.now() - start < 2000) {
-      rows = await db.select().from(activityLog).where(eq(activityLog.memexId, memexId));
-      if (rows.some((r) => r.action === "updated")) break;
-      await new Promise((r) => setTimeout(r, 25));
-    }
+    // Same-status write still emits `updated`; wait for THIS doc's updated row, then
+    // confirm no status_changed for it — scoped by briefId to stay sibling-immune.
+    const rows = await waitForDocRows(spec.id, (rs) => rs.some((r) => r.action === "updated"));
     expect(rows.some((r) => r.action === "updated")).toBe(true);
     expect(rows.filter((r) => r.action === "status_changed")).toHaveLength(0);
   });

--- a/packages/ui/e2e/journey-26-logo-theme.spec.ts
+++ b/packages/ui/e2e/journey-26-logo-theme.spec.ts
@@ -50,7 +50,13 @@ test("the logo fill inverts between dark and light theme (ac-2)", async ({ page 
   await expect(page.getByRole("heading", { name: "Specs" })).toBeVisible({ timeout: 15_000 });
   await expect(page.getByTestId("memex-logo").first()).toBeVisible();
 
-  const darkFill = await computedLogoFill(page);
+  // Poll, don't sample once: the logo can be visible a frame before its path fill
+  // resolves the --color-logo CSS variable, so getComputedStyle().fill reads "" for
+  // a moment (spec-278/issue-1 — the journey reddened on that empty read, all 3
+  // Playwright retries). expect.poll retries until the dark token settles. Asserting
+  // each theme resolves to its own distinct token also proves the recolour inverts
+  // (DARK_FILL !== LIGHT_FILL by construction) — stronger than a bare not-equal.
+  await expect.poll(() => computedLogoFill(page), { timeout: 10_000 }).toBe(DARK_FILL);
 
   // Switch to light and re-read.
   await page.evaluate(() => localStorage.setItem("memex-theme", "light"));
@@ -58,12 +64,6 @@ test("the logo fill inverts between dark and light theme (ac-2)", async ({ page 
   await expect(page.getByRole("heading", { name: "Specs" })).toBeVisible({ timeout: 15_000 });
   await expect(page.getByTestId("memex-logo").first()).toBeVisible();
 
-  const lightFill = await computedLogoFill(page);
-
-  // The recolour is real: the two themes resolve different fills...
-  expect(darkFill).not.toBe(lightFill);
-  // ...and each matches its theme token (so dark is the legible near-white, never
-  // the old #0E112B navy that was invisible on the dark surface).
-  expect(darkFill).toBe(DARK_FILL);
-  expect(lightFill).toBe(LIGHT_FILL);
+  // ...and the light token settles to the navy (#0E112B was the old invisible-on-dark bug).
+  await expect.poll(() => computedLogoFill(page), { timeout: 10_000 }).toBe(LIGHT_FILL);
 });

--- a/packages/ui/src/components/PhaseTabBar.test.tsx
+++ b/packages/ui/src/components/PhaseTabBar.test.tsx
@@ -37,24 +37,27 @@ describe('PhaseTabBar', () => {
     const buildTab = tab('build');
     expect(buildTab).toHaveAttribute('data-current', 'true');
     expect(buildTab).toHaveAttribute('aria-current', 'step');
-    // build → info blue token fill.
-    expect(buildTab.className).toContain('bg-status-info-bg');
+    // build → dedicated phase blue token fill (spec-252).
+    expect(buildTab.className).toContain('bg-phase-build-bg');
     // ● current-dot present only on the current tab.
     expect(buildTab.textContent).toContain('●');
     expect(tab('specify').textContent).not.toContain('●');
     expect(tab('specify')).not.toHaveAttribute('data-current');
   });
 
-  it('uses the amber warning fill for the specify tab when current', () => {
+  it('uses the dedicated purple phase fill for the specify tab when current (spec-252)', () => {
     tagAc(AC(2));
     render(<PhaseTabBar currentPhase="specify" selectedTab="specify" onSelect={onSelect} />);
-    expect(tab('specify').className).toContain('bg-status-warning-bg');
+    // spec-252 dec-1: specify is purple via its own token, NOT the shared
+    // `warning` variant (which still colours open/review amber).
+    expect(tab('specify').className).toContain('bg-phase-specify-bg');
+    expect(tab('specify').className).not.toContain('bg-status-warning-bg');
   });
 
-  it('uses the green success fill for the verify tab when current', () => {
+  it('uses the dedicated green phase fill for the verify tab when current (spec-252)', () => {
     tagAc(AC(2));
     render(<PhaseTabBar currentPhase="verify" selectedTab="verify" onSelect={onSelect} />);
-    expect(tab('verify').className).toContain('bg-status-success-bg');
+    expect(tab('verify').className).toContain('bg-phase-verify-bg');
   });
 
   it("renders a grey Draft pill as current for phase 'draft'; Specify is NOT current", () => {
@@ -161,7 +164,7 @@ describe('PhaseTabBar', () => {
     // verify carries the CURRENT treatment (filled pill + dot) but is NOT selected.
     const verifyTab = tab('verify');
     expect(verifyTab).toHaveAttribute('data-current', 'true');
-    expect(verifyTab.className).toContain('bg-status-success-bg');
+    expect(verifyTab.className).toContain('bg-phase-verify-bg');
     expect(verifyTab.textContent).toContain('●');
     expect(verifyTab).toHaveAttribute('aria-selected', 'false');
 

--- a/packages/ui/src/components/PhaseTabBar.tsx
+++ b/packages/ui/src/components/PhaseTabBar.tsx
@@ -1,6 +1,6 @@
 import { Fragment, useRef } from 'react';
 import type { SpecStatus } from '../api/types';
-import { statusVariant } from '../utils/statusStyles';
+import { phaseColors } from './phaseColors';
 import { phaseDisplayName } from '../utils/phaseDisplay';
 
 // The phase tab bar carries TWO independent visual states (spec-159 ac-2 / ac-15):
@@ -43,17 +43,11 @@ const TAB_LABELS: Record<PhaseTab, string> = {
   done: phaseDisplayName('done'),
 };
 
-// Per-tab fill, reusing the canonical statusVariant → status-* token classes
-// (specify→warning amber, build→info blue, verify→success green). statusVariant
-// already maps each phase string to its variant, so we route through it rather
-// than hardcoding a second colour table.
-const VARIANT_FILL: Record<ReturnType<typeof statusVariant>, string> = {
-  warning: 'bg-status-warning-bg text-status-warning-text border-status-warning-border',
-  info: 'bg-status-info-bg text-status-info-text border-status-info-border',
-  success: 'bg-status-success-bg text-status-success-text border-status-success-border',
-  danger: 'bg-status-danger-bg text-status-danger-text border-status-danger-border',
-  neutral: 'bg-status-neutral-bg text-status-neutral-text border-status-neutral-border',
-};
+// Per-tab fill comes from the dedicated phase palette (spec-252 dec-1):
+// draft→grey, specify→PURPLE, build→blue, verify→green. specify is purple via
+// its own tokens rather than the shared `warning` variant, so colouring it here
+// never recolours open/review elsewhere. draft/build/verify reuse the status
+// tokens under the hood (see phaseColors).
 
 /** The tab a given Spec phase makes "current" (the filled pill). `draft` and
  * `done` make NO tab current: `draft` lights up the dedicated Draft pill
@@ -110,7 +104,9 @@ export function PhaseTabBar({ currentPhase, selectedTab, onSelect }: PhaseTabBar
   }
 
   return (
-    <div className="flex items-center gap-2 mb-4">
+    // spec-252: spacing is owned by the phase container in DocDocument now, so
+    // the bar carries no bottom margin of its own.
+    <div className="flex items-center gap-2">
       {isDraft && (
         // Draft is the current STATUS, not a browsable view: a grey filled pill
         // outside the tablist. Clicking it selects the Specify view (draft's home),
@@ -124,7 +120,7 @@ export function PhaseTabBar({ currentPhase, selectedTab, onSelect }: PhaseTabBar
           className={`
             relative inline-flex items-center gap-1.5 rounded-full border px-3 py-1
             text-xs font-medium uppercase tracking-wider transition-colors
-            ${VARIANT_FILL.neutral}
+            ${phaseColors('draft')!.pill}
           `}
         >
           <span aria-hidden="true" className="text-[10px] leading-none">
@@ -171,7 +167,7 @@ export function PhaseTabBar({ currentPhase, selectedTab, onSelect }: PhaseTabBar
                 relative inline-flex items-center gap-1.5 rounded-full border px-3 py-1
                 text-xs font-medium uppercase tracking-wider transition-colors
                 ${isCurrent
-                  ? VARIANT_FILL[statusVariant(tab)]
+                  ? (phaseColors(tab)?.pill ?? '')
                   : isSelected
                     ? 'border-transparent text-primary'
                     : 'border-transparent text-secondary hover:text-primary hover:bg-overlay'

--- a/packages/ui/src/components/PostureDropdown.tsx
+++ b/packages/ui/src/components/PostureDropdown.tsx
@@ -7,6 +7,12 @@ import type { DocRole } from '../api/client';
 export const HEADER_PILL_CLASS =
   'inline-flex items-center gap-1.5 h-7 px-2.5 rounded-md bg-btn-secondary hover:bg-btn-secondary-hover text-sm text-primary transition-colors';
 
+// spec-252: the posture trigger now sits inside the coloured phase container,
+// so it uses a transparent fill with a subtle outline (matching the Figma mock)
+// rather than the filled header pill — it reads as a selector over the tint.
+const POSTURE_TRIGGER_CLASS =
+  'inline-flex items-center gap-1.5 h-7 px-2.5 rounded-md bg-transparent border border-edge hover:bg-overlay text-sm text-primary transition-colors';
+
 interface PostureDropdownProps {
   /** The viewer's current posture on this Spec (from useDocRole). */
   myRole: DocRole;
@@ -129,7 +135,7 @@ export function PostureDropdown({ myRole, onSelect }: PostureDropdownProps) {
           e.stopPropagation();
           setOpen((v) => !v);
         }}
-        className={HEADER_PILL_CLASS}
+        className={POSTURE_TRIGGER_CLASS}
       >
         {editing ? <PencilIcon className="w-3.5 h-3.5" /> : <EyeIcon className="w-3.5 h-3.5" />}
         {editing ? 'You are editing' : 'You are reviewing'}

--- a/packages/ui/src/components/phaseColors.spec-252.test.tsx
+++ b/packages/ui/src/components/phaseColors.spec-252.test.tsx
@@ -1,0 +1,170 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { phaseColors } from './phaseColors';
+import { statusVariant } from '../utils/statusStyles';
+import { PhaseTabBar } from './PhaseTabBar';
+
+// spec-252 dec-1 — the Spec-view header phase palette. A DEDICATED token set
+// (not the shared statusVariant): specify renders purple, decoupled so the
+// shared `warning` consumers (open/review) never recolour. Header-only scope.
+
+const AC_TOKENS = 'mindset-prod/memex-building-itself/specs/spec-252/acs/ac-6';
+const AC_PURPLE = 'mindset-prod/memex-building-itself/specs/spec-252/acs/ac-7';
+const AC_CONTRAST = 'mindset-prod/memex-building-itself/specs/spec-252/acs/ac-8';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const indexCss = readFileSync(join(HERE, '../index.css'), 'utf8');
+const tailwindCfg = readFileSync(join(HERE, '../../tailwind.config.js'), 'utf8');
+const phaseColorsSrc = readFileSync(join(HERE, './phaseColors.ts'), 'utf8');
+const phaseTabBarSrc = readFileSync(join(HERE, './PhaseTabBar.tsx'), 'utf8');
+
+// The four phase container-bg tints + the new specify pill tokens.
+const CONTAINER_TOKENS = [
+  'phase-draft-container',
+  'phase-specify-container',
+  'phase-build-container',
+  'phase-verify-container',
+];
+const SPECIFY_PILL_TOKENS = ['phase-specify-bg', 'phase-specify-text', 'phase-specify-border'];
+
+/** Extract the body of a top-level `.light {…}` / `.dark {…}` rule. */
+function themeBlock(theme: 'light' | 'dark'): string {
+  const m = indexCss.match(new RegExp(`\\.${theme}\\s*\\{([\\s\\S]*?)\\n\\}`));
+  if (!m) throw new Error(`could not find .${theme} block in index.css`);
+  return m[1];
+}
+
+/** Read a `--color-<name>:` value from a theme block. */
+function tokenValue(block: string, name: string): string {
+  const m = block.match(new RegExp(`--color-${name}:\\s*([^;]+);`));
+  if (!m) throw new Error(`token --color-${name} not found`);
+  return m[1].trim();
+}
+
+interface RGBA {
+  r: number;
+  g: number;
+  b: number;
+  a: number;
+}
+
+/** Parse `rgba(r, g, b, a)` or a bare `r g b` triplet into RGBA. */
+function parseColor(value: string): RGBA {
+  const rgba = value.match(/rgba?\(([^)]+)\)/);
+  if (rgba) {
+    const parts = rgba[1].split(',').map((p) => parseFloat(p.trim()));
+    return { r: parts[0], g: parts[1], b: parts[2], a: parts[3] ?? 1 };
+  }
+  const triplet = value.trim().split(/\s+/).map((p) => parseFloat(p));
+  return { r: triplet[0], g: triplet[1], b: triplet[2], a: 1 };
+}
+
+/** Alpha-composite a (possibly translucent) colour over an opaque background. */
+function composite(fg: RGBA, bg: RGBA): RGBA {
+  return {
+    r: fg.r * fg.a + bg.r * (1 - fg.a),
+    g: fg.g * fg.a + bg.g * (1 - fg.a),
+    b: fg.b * fg.a + bg.b * (1 - fg.a),
+    a: 1,
+  };
+}
+
+/** WCAG relative luminance. */
+function luminance({ r, g, b }: RGBA): number {
+  const lin = (c: number) => {
+    const cs = c / 255;
+    return cs <= 0.03928 ? cs / 12.92 : ((cs + 0.055) / 1.055) ** 2.4;
+  };
+  return 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b);
+}
+
+/** WCAG contrast ratio between two opaque colours. */
+function contrast(c1: RGBA, c2: RGBA): number {
+  const l1 = luminance(c1);
+  const l2 = luminance(c2);
+  const [hi, lo] = l1 >= l2 ? [l1, l2] : [l2, l1];
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+describe('phase colour palette (spec-252 dec-1)', () => {
+  it('defines the specify pill + per-phase container-bg tokens in BOTH .light and .dark, with no theme.ts import (ac-6)', () => {
+    tagAc(AC_TOKENS);
+    const light = themeBlock('light');
+    const dark = themeBlock('dark');
+    for (const token of [...CONTAINER_TOKENS, ...SPECIFY_PILL_TOKENS]) {
+      expect(light, `--color-${token} missing from .light`).toContain(`--color-${token}:`);
+      expect(dark, `--color-${token} missing from .dark`).toContain(`--color-${token}:`);
+    }
+    // Tailwind wires each token so components consume it via the token class.
+    for (const token of [...CONTAINER_TOKENS, ...SPECIFY_PILL_TOKENS]) {
+      expect(tailwindCfg, `tailwind.config missing ${token}`).toContain(`--color-${token}`);
+    }
+    // No hardcoded hex in the helper, and the charts-only insights palette
+    // (std-27) is not pulled into the header colour path.
+    expect(phaseColorsSrc).not.toMatch(/#[0-9a-fA-F]{3,8}\b/);
+    expect(phaseColorsSrc).not.toContain('insights/theme');
+    expect(phaseTabBarSrc).not.toContain('insights/theme');
+  });
+
+  it('routes specify→purple and build→blue, verify→green, draft→grey — without touching the shared statusVariant (ac-7)', () => {
+    tagAc(AC_PURPLE);
+    // The pill reading is purple → blue → green; draft stays grey.
+    expect(phaseColors('specify')!.pill).toContain('bg-phase-specify-bg');
+    expect(phaseColors('specify')!.pill).not.toContain('warning');
+    expect(phaseColors('build')!.pill).toContain('bg-phase-build-bg');
+    expect(phaseColors('verify')!.pill).toContain('bg-phase-verify-bg');
+    // draft has no Figma hue yet → keeps the neutral status token.
+    expect(phaseColors('draft')!.pill).toContain('bg-status-neutral-bg');
+    // done keeps its current treatment — no phase colour.
+    expect(phaseColors('done')).toBeNull();
+    // The shared statusVariant is untouched: specify/review/open stay amber, so
+    // board column headers and issue badges do not recolour.
+    expect(statusVariant('specify')).toBe('warning');
+    expect(statusVariant('open')).toBe('warning');
+    // Rendered: the current specify pill wears the purple token.
+    render(<PhaseTabBar currentPhase="specify" selectedTab="specify" onSelect={() => {}} />);
+    const specifyTab = screen
+      .getAllByRole('tab')
+      .find((t) => t.getAttribute('data-tab') === 'specify')!;
+    expect(specifyTab).toHaveAttribute('data-current', 'true');
+    expect(specifyTab.className).toContain('bg-phase-specify-bg');
+    expect(specifyTab.className).not.toContain('bg-status-warning-bg');
+  });
+
+  it('meets WCAG AA contrast for every coloured pill and container in both modes (ac-8)', () => {
+    tagAc(AC_CONTRAST);
+    // The hue-bearing pills (draft keeps the AA-safe neutral status token).
+    const PILL_PHASES = ['specify', 'build', 'verify'] as const;
+    for (const theme of ['light', 'dark'] as const) {
+      const block = themeBlock(theme);
+      const page = parseColor(tokenValue(block, 'page'));
+      const textPrimary = parseColor(tokenValue(block, 'text-primary'));
+
+      // Each pill: pill text on the (translucent) pill bg, composited over the
+      // page. Small uppercase text → AA threshold 4.5. A hue @ 80% over the dark
+      // page is a mid-tone, so this is the binding check in dark mode.
+      for (const phase of PILL_PHASES) {
+        const pillBg = composite(parseColor(tokenValue(block, `phase-${phase}-bg`)), page);
+        const pillText = composite(parseColor(tokenValue(block, `phase-${phase}-text`)), pillBg);
+        expect(
+          contrast(pillText, pillBg),
+          `${phase} pill text/bg contrast in ${theme}`,
+        ).toBeGreaterThanOrEqual(4.5);
+      }
+
+      // Each container tint: body text (text-primary) on the container
+      // composited over the page. AA 4.5.
+      for (const token of CONTAINER_TOKENS) {
+        const containerBg = composite(parseColor(tokenValue(block, token)), page);
+        expect(
+          contrast(textPrimary, containerBg),
+          `${token} vs text-primary contrast in ${theme}`,
+        ).toBeGreaterThanOrEqual(4.5);
+      }
+    }
+  });
+});

--- a/packages/ui/src/components/phaseColors.ts
+++ b/packages/ui/src/components/phaseColors.ts
@@ -1,0 +1,52 @@
+import type { SpecStatus } from '../api/types';
+
+/**
+ * Spec-view header phase palette (spec-252 dec-1).
+ *
+ * A DEDICATED phase-colour set, deliberately decoupled from `statusVariant`:
+ * `specify`/`review`/`open` all share the `warning` variant, so recolouring
+ * `warning` to make specify purple would also recolour open-decision / issue
+ * badges and review docs. Instead, specify gets its own purple tokens here.
+ *
+ * Header-only scope (confirmed 2026-06-12): this drives the phase-bar current
+ * pill (PhaseTabBar) and the coloured header container (DocDocument). Board /
+ * list surfaces that colour specify via `statusVariant` stay amber — see
+ * spec-252 issue-1 for the follow-up.
+ *
+ * specify / build / verify each use the dedicated phase tokens (exact Figma
+ * hue @ 80% pill + @ 10% container). draft has no Figma hue yet, so it keeps the
+ * neutral status token for the pill.
+ */
+export interface PhaseColor {
+  /** Current-phase pill fill — bg + text + border classes. */
+  pill: string;
+  /** Pale container-bg wash for the coloured header container. */
+  container: string;
+}
+
+const PALETTE: Record<'draft' | 'specify' | 'build' | 'verify', PhaseColor> = {
+  draft: {
+    pill: 'bg-status-neutral-bg text-status-neutral-text border-status-neutral-border',
+    container: 'bg-phase-draft-container',
+  },
+  specify: {
+    pill: 'bg-phase-specify-bg text-phase-specify-text border-phase-specify-border',
+    container: 'bg-phase-specify-container',
+  },
+  build: {
+    pill: 'bg-phase-build-bg text-phase-build-text border-phase-build-border',
+    container: 'bg-phase-build-container',
+  },
+  verify: {
+    pill: 'bg-phase-verify-bg text-phase-verify-text border-phase-verify-border',
+    container: 'bg-phase-verify-container',
+  },
+};
+
+/**
+ * The phase's pill + container colours, or `null` for `done` — which keeps its
+ * current treatment (the phase bar is hidden at done; DoneSummary takes over).
+ */
+export function phaseColors(phase: SpecStatus): PhaseColor | null {
+  return PALETTE[phase as keyof typeof PALETTE] ?? null;
+}

--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -94,6 +94,29 @@
   --color-status-neutral-bg:     rgba(62, 68, 81, 0.5);   /* #3e4451/50 */
   --color-status-neutral-text:   148 163 184;              /* slate-400 */
   --color-status-neutral-border: 75 82 95;                 /* #4b525f */
+
+  /* Phase palette (spec-252 dec-1) — Spec-view header only: phase-bar current
+     pill + coloured container. Dedicated tokens, decoupled from statusVariant
+     so the phase hues never recolour the shared `warning`/status consumers.
+     Each phase = ONE base hue at two opacities (pill = hue @ 80%, container =
+     hue @ 10%, exact Figma values), composited live over the page so the same
+     values serve both themes. 950-level dark text keeps every pill clear of
+     WCAG AA in both modes (a hue @ 80% over the dark page is a mid-tone, so the
+     text must be near-black). draft has no Figma hue yet → keeps the neutral
+     pill + a per-mode container. */
+  --color-phase-specify-bg:        rgba(228, 165, 245, 0.8); /* #E4A5F5 @ 80% */
+  --color-phase-specify-text:      46 16 101;                /* purple-950 */
+  --color-phase-specify-border:    228 165 245;
+  --color-phase-specify-container: rgba(228, 165, 245, 0.1); /* #E4A5F5 @ 10% */
+  --color-phase-build-bg:          rgba(123, 198, 252, 0.8); /* #7BC6FC @ 80% */
+  --color-phase-build-text:        8 47 73;                  /* sky-950 */
+  --color-phase-build-border:      123 198 252;
+  --color-phase-build-container:   rgba(123, 198, 252, 0.1); /* #7BC6FC @ 10% */
+  --color-phase-verify-bg:         rgba(93, 192, 166, 0.8);  /* #5DC0A6 @ 80% */
+  --color-phase-verify-text:       2 44 34;                  /* emerald-950 */
+  --color-phase-verify-border:     93 192 166;
+  --color-phase-verify-container:  rgba(93, 192, 166, 0.1);  /* #5DC0A6 @ 10% */
+  --color-phase-draft-container:   rgba(148, 163, 184, 0.10);/* slate wash — draft keeps the neutral pill */
 }
 
 .light {
@@ -164,6 +187,23 @@
   --color-status-neutral-bg:     rgba(226, 232, 240, 1);  /* slate-200 */
   --color-status-neutral-text:   71 85 105;                /* slate-600 */
   --color-status-neutral-border: 203 213 225;              /* slate-300 */
+
+  /* Phase palette (spec-252) — see the .dark block for the rationale. The phase
+     hues use the same hue-at-opacity values in both themes (composited over the
+     page live); only draft's neutral container differs per mode. */
+  --color-phase-specify-bg:        rgba(228, 165, 245, 0.8); /* #E4A5F5 @ 80% */
+  --color-phase-specify-text:      46 16 101;               /* purple-950 */
+  --color-phase-specify-border:    228 165 245;
+  --color-phase-specify-container: rgba(228, 165, 245, 0.1);/* #E4A5F5 @ 10% */
+  --color-phase-build-bg:          rgba(123, 198, 252, 0.8);/* #7BC6FC @ 80% */
+  --color-phase-build-text:        8 47 73;                 /* sky-950 */
+  --color-phase-build-border:      123 198 252;
+  --color-phase-build-container:   rgba(123, 198, 252, 0.1);/* #7BC6FC @ 10% */
+  --color-phase-verify-bg:         rgba(93, 192, 166, 0.8); /* #5DC0A6 @ 80% */
+  --color-phase-verify-text:       2 44 34;                 /* emerald-950 */
+  --color-phase-verify-border:     93 192 166;
+  --color-phase-verify-container:  rgba(93, 192, 166, 0.1); /* #5DC0A6 @ 10% */
+  --color-phase-draft-container:   rgba(241, 245, 249, 1);  /* slate-100 — draft keeps the neutral pill */
 }
 
 @layer base {

--- a/packages/ui/src/pages/DocDocument.spec-159.test.tsx
+++ b/packages/ui/src/pages/DocDocument.spec-159.test.tsx
@@ -14,7 +14,7 @@
 //   ac-6  : the transition flow mounts no modal — Yes transitions directly.
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor, within } from '@testing-library/react';
+import { render, screen, waitFor, within, cleanup } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import { tagAc } from '@memex-ai-ac/vitest';
@@ -22,6 +22,7 @@ import type { ReactNode } from 'react';
 import type { DocWithGraph } from '../api/types';
 
 const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-159/acs/ac-${n}`;
+const AC252 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-252/acs/ac-${n}`;
 
 // ── Heavy children → identity markers so we can see which panel rendered ────
 vi.mock('../components/DecisionPanel', () => ({
@@ -580,18 +581,21 @@ describe('spec-182 — unified reviewer phase block', () => {
     expect(screen.queryByTestId('review-actions-toggle')).not.toBeInTheDocument();
   });
 
-  it('header pill reads "You are reviewing"; picking Editing promotes to editor', async () => {
+  it('posture pill reads "You are reviewing"; picking Editing promotes to editor', async () => {
     tagAc(AC(19));
+    tagAc(AC252(9)); // spec-252 dec-2: pill relocated into the phase container
+    tagAc(AC252(10)); // spec-252: this header-slot assertion updated to the new location
     const user = userEvent.setup();
     renderAt('specify');
     await screen.findByTestId('review-action-row');
 
-    // The pill renders in the header slot, not the page body — and the old
-    // posture sentence is gone. findByRole: the slot populates via a
-    // useHeaderSlot effect a tick after the body renders (same async class
-    // as i-2 / the editor-pill variant below).
+    // spec-252 dec-2: the pill moved OUT of the header slot INTO the in-page
+    // phase container, left of the phase bar. It is no longer in the header
+    // slot, and sits inside data-testid="phase-container".
     const header = screen.getByTestId('header-slot');
-    const pill = await within(header).findByRole('button', { name: /You are reviewing/ });
+    const container = screen.getByTestId('phase-container');
+    const pill = await within(container).findByRole('button', { name: /You are reviewing/ });
+    expect(within(header).queryByRole('button', { name: /You are reviewing/ })).not.toBeInTheDocument();
     expect(screen.queryByText(/You are a reviewer of this spec/)).not.toBeInTheDocument();
 
     await user.click(pill);
@@ -602,18 +606,17 @@ describe('spec-182 — unified reviewer phase block', () => {
     expect(refetchRole).toHaveBeenCalled();
   });
 
-  it('editor: header pill reads "You are editing"; picking Reviewing demotes to reviewer', async () => {
+  it('editor: posture pill reads "You are editing"; picking Reviewing demotes to reviewer', async () => {
     tagAc(AC(19));
+    tagAc(AC252(10)); // spec-252: header-slot assertion updated to the in-container location
     mockRole = 'editor';
     const user = userEvent.setup();
     renderAt('specify');
     await screen.findByText('Narrative');
 
-    const header = screen.getByTestId('header-slot');
-    // findByRole: the header slot populates via a useHeaderSlot effect a tick
-    // after the page body renders — under full-suite load the pill can land
-    // after 'Spec' is already visible (same async class as i-2).
-    await user.click(await within(header).findByRole('button', { name: /You are editing/ }));
+    // spec-252 dec-2: the pill is in the in-page phase container, not the header.
+    const container = screen.getByTestId('phase-container');
+    await user.click(await within(container).findByRole('button', { name: /You are editing/ }));
     await user.click(screen.getByRole('menuitemradio', { name: /Reviewing/ }));
     // useSwitchPosture → demoteToReviewer(docId) then a role refetch.
     await waitFor(() => expect(demoteToReviewer).toHaveBeenCalledWith('doc-uuid'));
@@ -866,5 +869,107 @@ describe('spec-164 issue-1 — draft hides the create-Decisions-and-ACs handoff'
     expect(line.textContent).toContain(
       'Copy the Specify prompt into your coding agent to create Decisions and ACs.',
     );
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// spec-252 — coloured phase container + relocated posture pill. Reuses this
+// file's DocDocument harness (renderAt / HeaderSink).
+// ───────────────────────────────────────────────────────────────────────────
+describe('spec-252 — coloured phase container', () => {
+  // Reviewer posture: canWrite (pill shows) but !canEdit, so the review-action
+  // row + handoff render expanded (no collapse toggle) — the ac-11 wrap check
+  // needs them visible. The global beforeEach otherwise defaults to editor.
+  beforeEach(() => {
+    mockRole = 'reviewer';
+  });
+
+  it('wraps the phase block in a container carrying the current phase colour, per phase (ac-1, ac-2, ac-4)', async () => {
+    tagAc(AC252(1));
+    tagAc(AC252(2));
+    tagAc(AC252(4)); // theme-aware token class → both modes; contrast proven by ac-8
+    const cases = [
+      ['draft', 'bg-phase-draft-container'],
+      ['specify', 'bg-phase-specify-container'],
+      ['build', 'bg-phase-build-container'],
+      ['verify', 'bg-phase-verify-container'],
+    ] as const;
+    for (const [status, cls] of cases) {
+      renderAt(status);
+      const container = await screen.findByTestId('phase-container');
+      // ac-1: the phase bar lives inside the container.
+      expect(
+        within(container).getByRole('tablist', { name: /Spec phase view/i }),
+      ).toBeInTheDocument();
+      // ac-2 / ac-4: the bg is this phase's theme-aware token.
+      expect(container.className, `${status} container colour`).toContain(cls);
+      cleanup();
+    }
+  });
+
+  it('renders NO phase container at done — the done treatment is unchanged (ac-2)', async () => {
+    tagAc(AC252(2));
+    renderAt('done');
+    await screen.findByTestId('done-summary');
+    expect(screen.queryByTestId('phase-container')).not.toBeInTheDocument();
+  });
+
+  it('wraps exactly the phase block (pill, bar, transition, review actions) and excludes the title + content Tabs (ac-11)', async () => {
+    tagAc(AC252(11));
+    renderAt('specify'); // default role = reviewer (canWrite, !canEdit) → review row expanded
+    const container = await screen.findByTestId('phase-container');
+    await within(container).findByTestId('review-handoff-line');
+
+    // INSIDE the container.
+    expect(within(container).getByRole('button', { name: /You are reviewing/ })).toBeInTheDocument();
+    expect(within(container).getByRole('tablist', { name: /Spec phase view/i })).toBeInTheDocument();
+    expect(within(container).getByTestId('transition-sentence')).toBeInTheDocument();
+    expect(within(container).getByTestId('review-action-row')).toBeInTheDocument();
+    expect(within(container).getByTestId('review-handoff-line')).toBeInTheDocument();
+
+    // OUTSIDE: the doc title (no heading inside) and the content Tabs row.
+    expect(within(container).queryByRole('heading')).not.toBeInTheDocument();
+    expect(within(container).queryByText('Decisions & ACs')).not.toBeInTheDocument();
+  });
+
+  it('places the posture pill LEFT of the phase bar, as the only posture switch (ac-3, ac-9, ac-11)', async () => {
+    tagAc(AC252(3)); // scope: edit/review dropdown sits inside the container, left of the phase bar
+    tagAc(AC252(9));
+    tagAc(AC252(11));
+    renderAt('specify');
+    const container = await screen.findByTestId('phase-container');
+    const pill = await within(container).findByRole('button', { name: /You are reviewing/ });
+    const tablist = within(container).getByRole('tablist', { name: /Spec phase view/i });
+    // Exactly one posture switch on the page (spec-182/dec-6 preserved).
+    expect(screen.getAllByRole('button', { name: /You are (reviewing|editing)/ })).toHaveLength(1);
+    // DOM order: the pill precedes (sits left of) the phase bar on the shared row.
+    expect(
+      pill.compareDocumentPosition(tablist) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  it('introduces no new functionality — phase indicator, review actions, and CTAs are intact and still work (ac-5)', async () => {
+    tagAc(AC252(5));
+    const user = userEvent.setup();
+    renderAt('specify'); // reviewer: review row + handoff render expanded
+    await screen.findByTestId('review-action-row');
+
+    // Phase progress indicator — unchanged: the four-tab pipeline, specify
+    // current with its ● dot, browse-only behaviour preserved.
+    expect(screen.getAllByRole('tab')).toHaveLength(4);
+    expect(phaseTab('specify')).toHaveAttribute('data-current', 'true');
+    expect(phaseTab('specify').textContent).toContain('●');
+
+    // Review actions — unchanged: the four review buttons still render…
+    const row = screen.getByTestId('review-action-row');
+    for (const label of ['Summarise Spec', 'Security review', 'Design review', 'Architecture review']) {
+      expect(within(row).getByRole('button', { name: label })).toBeInTheDocument();
+    }
+    // …and still behave: clicking one sends its scaffold prompt through chat.
+    await user.click(within(row).getByRole('button', { name: 'Summarise Spec' }));
+    await waitFor(() => expect(chat.sendMessage).toHaveBeenCalled());
+
+    // Calls-to-action — unchanged: the review handoff "copy prompt" line is present.
+    expect(screen.getByTestId('review-handoff-line')).toBeInTheDocument();
   });
 });

--- a/packages/ui/src/pages/DocDocument.tsx
+++ b/packages/ui/src/pages/DocDocument.tsx
@@ -26,6 +26,7 @@ import { IssuePanel } from '../components/IssuePanel';
 import { AllComments } from '../components/AllComments';
 import { AcPanel } from '../components/AcPanel';
 import { PhaseTabBar, type PhaseTab } from '../components/PhaseTabBar';
+import { phaseColors } from '../components/phaseColors';
 import { TransitionSentence } from '../components/TransitionSentence';
 import { DoneSummary } from '../components/DoneSummary';
 import { Badge, Button, Tabs } from '../components/ui';
@@ -451,16 +452,11 @@ export function DocDocument() {
             phase-control affordance no longer live in the header. The PhaseDropdown
             is gone, replaced by the in-page PhaseTabBar + TransitionSentence below
             the role controls; the page itself carries readiness + handoffs. The
-            header keeps the posture pill + Share / Download / menu (all on
-            canWrite). */}
-        {/* spec-159 ac-19 (amended): MY posture on this Spec — a Google-Docs-
-            style Editing / Reviewing mode pill. Page-global (it gates decision
-            resolution, phase moves, AC mutations on every tab), hence header
-            chrome rather than the phase block. Gated on the role having
-            resolved so the pill never flashes the wrong mode. */}
-        {doc.docType === 'spec' && !roleLoading && (
-          <PostureDropdown myRole={myRole} onSelect={(target) => switchPosture(target)} />
-        )}
+            header keeps Share / Download / menu (all on canWrite). The posture
+            pill moved OUT of the header into the in-page phase container
+            (spec-252 dec-2): it now sits left of the phase bar and scrolls with
+            the page. spec-182/dec-6 is preserved — still the only posture
+            switch, it just relocated. */}
         {/* Share — the Spec's canonical URL with a Copy button. Pill chrome
             shared with the posture dropdown so the header controls match. */}
         <button type="button" className={HEADER_PILL_CLASS} onClick={() => setShareLinkOpen(true)}>
@@ -514,7 +510,7 @@ export function DocDocument() {
         />
       </>
     );
-  }, [doc, reloadDoc, navigate, totalCommentCount, canWrite, canEdit, myRole, roleLoading, switchPosture]);
+  }, [doc, reloadDoc, navigate, totalCommentCount, canWrite, canEdit]);
 
   useHeaderSlot(headerActions);
 
@@ -1306,12 +1302,23 @@ export function DocDocument() {
           was removed). `done` collapses both into the DoneSummary for everyone. */}
       {doc.docType === 'spec' &&
         phase !== 'done' && (
-          <div className="mb-4 space-y-2">
-            <PhaseTabBar
-              currentPhase={phase}
-              selectedTab={viewedTab}
-              onSelect={(t) => setSelectedTab(t)}
-            />
+          <div
+            data-testid="phase-container"
+            className={`mb-4 rounded-lg p-3 space-y-2 ${phaseColors(phase)?.container ?? ''}`}
+          >
+            {/* spec-252 dec-2/dec-3: the posture pill sits inside the container,
+                left of the phase bar, on a shared row (it moved out of the app
+                header). Gated on canWrite — read-only viewers can't switch. */}
+            <div className="flex items-center gap-3">
+              {canWrite && !roleLoading && (
+                <PostureDropdown myRole={myRole} onSelect={(target) => switchPosture(target)} />
+              )}
+              <PhaseTabBar
+                currentPhase={phase}
+                selectedTab={viewedTab}
+                onSelect={(t) => setSelectedTab(t)}
+              />
+            </div>
             <TransitionSentence
               doc={{ id: doc.id }}
               currentPhase={phase}

--- a/packages/ui/tailwind.config.js
+++ b/packages/ui/tailwind.config.js
@@ -69,6 +69,21 @@ export default {
         'status-neutral-bg':     'var(--color-status-neutral-bg)',
         'status-neutral-text':   'rgb(var(--color-status-neutral-text) / <alpha-value>)',
         'status-neutral-border': 'rgb(var(--color-status-neutral-border) / <alpha-value>)',
+
+        /* ── Phase palette (spec-252) — Spec-view header pill + container ── */
+        'phase-specify-bg':        'var(--color-phase-specify-bg)',          /* baked opacity */
+        'phase-specify-text':      'rgb(var(--color-phase-specify-text) / <alpha-value>)',
+        'phase-specify-border':    'rgb(var(--color-phase-specify-border) / <alpha-value>)',
+        'phase-build-bg':          'var(--color-phase-build-bg)',            /* baked opacity */
+        'phase-build-text':        'rgb(var(--color-phase-build-text) / <alpha-value>)',
+        'phase-build-border':      'rgb(var(--color-phase-build-border) / <alpha-value>)',
+        'phase-verify-bg':         'var(--color-phase-verify-bg)',           /* baked opacity */
+        'phase-verify-text':       'rgb(var(--color-phase-verify-text) / <alpha-value>)',
+        'phase-verify-border':     'rgb(var(--color-phase-verify-border) / <alpha-value>)',
+        'phase-draft-container':   'var(--color-phase-draft-container)',     /* baked opacity */
+        'phase-specify-container': 'var(--color-phase-specify-container)',   /* baked opacity */
+        'phase-build-container':   'var(--color-phase-build-container)',     /* baked opacity */
+        'phase-verify-container':  'var(--color-phase-verify-container)',    /* baked opacity */
       },
     },
   },


### PR DESCRIPTION
Promote `develop` to `main` for production deploy.

## What's shipping (17 commits)

- **spec-252** — coloured phase container with relocated edit/review selector
- **spec-278** — stabilize flaky tests (journey-26 logo fill polling; spec-179 status-changed assertion scoping)
- **spec-276** — shard server CI suite across 3 runners + shard reporter visibility (console reporter, hidden-files coverage upload)
- **spec-275** — oauth: merge params into `redirect_uri` at authorize instead of concatenating `?code=`
- **spec-257** — RLS owner-bypass mechanism test, dynamic FORCE guard, posture re-tagging + doc corrections

## Deploy

Per std-17, smoke tests run against int after deploy and must be green before prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)