### PR TITLE
Promote to prod: spec-281 deploy speedups (batch migration check + layer-cache build)

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,45 @@
+# spec-281 Fix 2 — layer-cached server image build.
+#
+# `gcloud builds submit --tag "${IMAGE}"` runs on a clean Cloud Build worker with
+# no Docker layer cache, so the expensive `deps` stage (`pnpm install` of the whole
+# workspace) re-ran on every deploy even when only source files changed — ~2min of
+# pure waste on BOTH int and prod. The root Dockerfile is already staged so that
+# `deps` stays cacheable when only source changes (see its comments); this config
+# is what finally gives the build a cache to reuse.
+#
+# How it works: pull the previously-pushed image to seed BuildKit's layer cache
+# (`--cache-from`), build with `BUILDKIT_INLINE_CACHE=1` so THIS image carries the
+# cache metadata the NEXT deploy will pull, then push. The first build after this
+# lands (or any build where no prior image exists) finds nothing to pull and builds
+# cold — `|| echo` keeps that non-fatal.
+#
+# Env-agnostic: invoked from the shared packages/server/deploy.sh with `_IMAGE`
+# substituted per environment, so int and prod build identically (spec-281 ac-5).
+# `${IMAGE}` (deploy-config.sh) is the untagged Artifact Registry repo path, so
+# `:latest` is the stable cache tag, matching what Cloud Run deploys (`--image
+# "${IMAGE}"` resolves `:latest`).
+
+steps:
+  # 1. Seed the cache from the last image (cold/first build: nothing to pull).
+  - name: gcr.io/cloud-builders/docker
+    entrypoint: bash
+    args:
+      - -c
+      - docker pull "${_IMAGE}:latest" || echo "no prior image — building cold"
+
+  # 2. Build, reusing unchanged layers from the pulled image and stamping inline
+  #    cache metadata so the next deploy can reuse THIS build's layers in turn.
+  - name: gcr.io/cloud-builders/docker
+    args:
+      - build
+      - --tag=${_IMAGE}:latest
+      - --cache-from=${_IMAGE}:latest
+      - --build-arg=BUILDKIT_INLINE_CACHE=1
+      - --file=Dockerfile
+      - .
+    env:
+      - DOCKER_BUILDKIT=1
+
+# Push the freshly-built (cache-stamped) image.
+images:
+  - ${_IMAGE}:latest

--- a/packages/server/deploy.sh
+++ b/packages/server/deploy.sh
@@ -280,8 +280,15 @@ echo "Building container image (${IMAGE})..."
 # Submit from the repo root so the build context includes packages/shared
 # (workspace dep of @memex/server). The Dockerfile at the repo root is
 # workspace-aware; .gcloudignore there keeps the upload lean.
+#
+# spec-281 Fix 2: build via cloudbuild.yaml (not bare `--tag`) so the build reuses
+# cached layers from the previously-pushed image (`--cache-from` + BuildKit inline
+# cache). `--tag` gives the clean Cloud Build worker no cache, so the pnpm-install
+# `deps` layer rebuilt every deploy even when only source changed (~2min wasted on
+# int + prod). `_IMAGE` is env-keyed, so this lands identically on both.
 ( cd "${REPO_ROOT}" && gcloud builds submit \
-  --tag "${IMAGE}" \
+  --config cloudbuild.yaml \
+  --substitutions "_IMAGE=${IMAGE}" \
   --project "${GCP_PROJECT}" \
   --region "${REGION}" \
   --default-buckets-behavior=regional-user-owned-bucket )

--- a/packages/server/scripts/apply-hand-migrations.sh
+++ b/packages/server/scripts/apply-hand-migrations.sh
@@ -82,6 +82,19 @@ for e in j['entries']:
     print(e['tag'])
 " "$JOURNAL_FILE_NATIVE")
 
+# Read the applied set ONCE, up front (spec-281 Fix 1). The collection loop below
+# only asks "is this file already applied?" — a pure set-membership test. The old
+# loop opened a fresh psql process + DB connection PER FILE to ask it (one
+# `SELECT 1 ... WHERE filename = $tag` each), so the number of round-trips scaled
+# with the count of .sql files on disk (~105 hand-written files → ~105 connections
+# every deploy). Through cloud-sql-proxy on prod each connection costs several×
+# int's latency, so that loop ballooned the prod migration phase to ~5min even
+# when nothing was pending. Pulling the whole applied set in a single query and
+# comparing in memory (`grep -qFx`) collapses ~105 connections to 1, with
+# byte-identical skip behaviour. The guard against reintroducing the per-file
+# query lives in src/__regression__/apply-hand-migrations-batch.regression.test.ts.
+APPLIED=$(psql "$DATABASE_URL" -tAc "SELECT filename FROM manual_migrations")
+
 # Collect applied + pending in deterministic filename order.
 PENDING=()
 for f in "$DRIZZLE_DIR"/*.sql; do
@@ -93,8 +106,9 @@ for f in "$DRIZZLE_DIR"/*.sql; do
     continue
   fi
 
-  already=$(psql "$DATABASE_URL" -tAc "SELECT 1 FROM manual_migrations WHERE filename = '$tag' LIMIT 1")
-  if [[ -n "$already" ]]; then
+  # Skip already-applied files — in-memory membership test against the set read
+  # once above (no per-file DB round-trip).
+  if grep -qFx "$tag" <<<"$APPLIED"; then
     continue
   fi
 

--- a/packages/server/src/__regression__/apply-hand-migrations-batch.regression.test.ts
+++ b/packages/server/src/__regression__/apply-hand-migrations-batch.regression.test.ts
@@ -1,0 +1,224 @@
+// spec-281 Fix 1 — the hand-migration applied-check is BATCHED: the script reads
+// the applied set ONCE up front and compares in memory, instead of opening one
+// psql process + DB connection per .sql file. On prod, where each connection rides
+// cloud-sql-proxy at several× int's latency, the old per-file loop ballooned the
+// migration phase to ~5m16s (observed 2026-06-13) even with nothing pending; this
+// collapses ~105 connections to 1.
+//
+// Two layers of proof, mirroring the repo's split (deploy-wiring guards as static
+// assertions + behaviour as a real-DB exercise):
+//   • STATIC GUARD — fails if the per-file `WHERE filename = $tag` query is ever
+//     reintroduced inside the collection loop, or the single up-front read removed
+//     (covers ac-1's structure + ac-5's anti-regression guard).
+//   • BEHAVIOURAL — runs the ACTUAL script against a throwaway local Postgres with
+//     a psql-call-counting shim on PATH, proving (ac-1) the connection count is a
+//     small constant regardless of how many files are on disk — the mechanism that
+//     turns the prod migration phase from minutes to seconds (ac-3) — and (ac-2)
+//     that journal files are excluded, applied files skipped, and a genuinely
+//     pending file still applies its DDL + tracking INSERT in a single transaction.
+//     Skips cleanly where `psql`/`python3` aren't on PATH (never a false failure).
+
+import { describe, it, expect } from "vitest";
+import { readFileSync, mkdtempSync, mkdirSync, writeFileSync, rmSync, chmodSync, copyFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+const SPEC = "mindset-prod/memex-building-itself/specs/spec-281";
+const AC1 = `${SPEC}/acs/ac-1`;
+const AC2 = `${SPEC}/acs/ac-2`;
+const AC3 = `${SPEC}/acs/ac-3`;
+const AC5 = `${SPEC}/acs/ac-5`;
+
+const REPO_ROOT = join(__dirname, "..", "..", "..", "..");
+const SCRIPT = join(REPO_ROOT, "packages", "server", "scripts", "apply-hand-migrations.sh");
+const script = readFileSync(SCRIPT, "utf-8");
+
+// The body of the collection `for f in "$DRIZZLE_DIR"/*.sql; do ... done` loop —
+// the place the per-file connection used to live.
+function collectionLoopBody(src: string): string {
+  const start = src.indexOf('for f in "$DRIZZLE_DIR"/*.sql; do');
+  expect(start).toBeGreaterThanOrEqual(0);
+  const end = src.indexOf("\ndone", start);
+  expect(end).toBeGreaterThan(start);
+  return src.slice(start, end);
+}
+
+describe("spec-281 ac-1/ac-5: applied-check is read once up front, never per file (static guard)", () => {
+  it("reads the whole applied set in a SINGLE up-front query before the loop", () => {
+    tagAc(AC1);
+    // One batched read: SELECT filename FROM manual_migrations (no WHERE/LIMIT per file).
+    expect(script).toMatch(/APPLIED=\$\(psql\s+"\$DATABASE_URL"\s+-tAc\s+"SELECT filename FROM manual_migrations"\)/);
+  });
+
+  it("the collection loop contains NO psql call — membership is an in-memory grep", () => {
+    tagAc(AC5);
+    const body = collectionLoopBody(script);
+    // The guard: a future edit that reintroduces a per-file DB round-trip fails here.
+    expect(body).not.toMatch(/psql/);
+    expect(body).not.toMatch(/SELECT 1 FROM manual_migrations WHERE filename/);
+    // Skip already-applied via in-memory set membership against $APPLIED.
+    expect(body).toMatch(/grep -qFx "\$tag" <<<"\$APPLIED"/);
+  });
+
+  it("preserves the journal-skip and the single-transaction apply + tracking insert (ac-2 structure)", () => {
+    tagAc(AC2);
+    expect(script).toMatch(/grep -qFx "\$tag" <<<"\$JOURNAL_TAGS"/); // drizzle-owned files excluded
+    // genuinely-pending file: DDL + tracking INSERT in one --single-transaction psql.
+    expect(script).toMatch(/--single-transaction[\s\S]*-f "\$f"[\s\S]*INSERT INTO manual_migrations/);
+  });
+});
+
+// ── Behavioural: run the real script against a throwaway DB ──────────────────
+function have(bin: string): boolean {
+  try {
+    execFileSync("sh", ["-c", `command -v ${bin}`], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+const CAN_RUN = have("psql") && have("python3") && !!process.env.DATABASE_URL;
+
+// Admin (maintenance) URL + a uniquely-named throwaway DB on the same host, so we
+// never touch the per-worker ORM clone that DATABASE_URL points at.
+function urls() {
+  const u = new URL(process.env.DATABASE_URL!);
+  const probeName = `memex_spec281_ac_${process.pid}`;
+  const admin = new URL(u.toString());
+  admin.pathname = "/postgres";
+  const probe = new URL(u.toString());
+  probe.pathname = `/${probeName}`;
+  return { admin: admin.toString(), probe: probe.toString(), probeName };
+}
+
+describe.skipIf(!CAN_RUN)(
+  "spec-281 ac-1/ac-2/ac-3: behaviour against a real throwaway Postgres",
+  () => {
+    const { admin, probe, probeName } = urls();
+    let work = "";
+    const shimCount = () => join(work, "count.txt");
+
+    // Build a temp tree: copy of the real script + a fixture drizzle dir + a
+    // psql shim that counts every invocation (connection) then execs real psql.
+    function setup(handFileCount: number) {
+      work = mkdtempSync(join(tmpdir(), "spec281-"));
+      mkdirSync(join(work, "scripts"));
+      mkdirSync(join(work, "drizzle", "meta"), { recursive: true });
+      mkdirSync(join(work, "bin"));
+      copyFileSync(SCRIPT, join(work, "scripts", "apply.sh"));
+
+      // Journal: 0000..0008 are drizzle-owned (must be skipped without a DB hit).
+      const entries = Array.from({ length: 9 }, (_, i) => ({
+        idx: i,
+        tag: `${String(i).padStart(4, "0")}_journal`,
+      }));
+      writeFileSync(
+        join(work, "drizzle", "meta", "_journal.json"),
+        JSON.stringify({ version: "7", dialect: "postgresql", entries }),
+      );
+      // journal files on disk + N hand-written files.
+      for (let i = 0; i < 9; i++) {
+        writeFileSync(join(work, "drizzle", `${String(i).padStart(4, "0")}_journal.sql`), "SELECT 1;\n");
+      }
+      for (let i = 1; i <= handFileCount; i++) {
+        const n = 9000 + i;
+        writeFileSync(join(work, "drizzle", `${n}_hand.sql`), `CREATE TABLE IF NOT EXISTS probe_${n}();\n`);
+      }
+
+      const realPsql = execFileSync("sh", ["-c", "command -v psql"], { encoding: "utf-8" }).trim();
+      writeFileSync(
+        join(work, "bin", "psql"),
+        `#!/usr/bin/env bash\necho 1 >> "$PSQL_COUNT_FILE"\nexec "${realPsql}" "$@"\n`,
+      );
+      chmodSync(join(work, "bin", "psql"), 0o755);
+    }
+
+    // Run the copied script; return how many times psql (a DB connection) was opened.
+    function run(mode: string[] = []): number {
+      writeFileSync(shimCount(), "");
+      execFileSync("bash", [join(work, "scripts", "apply.sh"), ...mode], {
+        env: {
+          ...process.env,
+          PATH: `${join(work, "bin")}:${process.env.PATH}`,
+          DATABASE_URL: probe,
+          PSQL_COUNT_FILE: shimCount(),
+        },
+        stdio: "pipe",
+      });
+      return readFileSync(shimCount(), "utf-8").trim().split("\n").filter(Boolean).length;
+    }
+
+    function psqlAdmin(sql: string) {
+      execFileSync("psql", [admin, "-v", "ON_ERROR_STOP=1", "-qc", sql], { stdio: "pipe" });
+    }
+    function psqlProbe(sql: string): string {
+      return execFileSync("psql", [probe, "-tAc", sql], { encoding: "utf-8" }).trim();
+    }
+
+    function freshDb() {
+      psqlAdmin(`DROP DATABASE IF EXISTS ${probeName} WITH (FORCE)`);
+      psqlAdmin(`CREATE DATABASE ${probeName}`);
+    }
+    function teardown() {
+      try {
+        psqlAdmin(`DROP DATABASE IF EXISTS ${probeName} WITH (FORCE)`);
+      } catch {
+        /* best effort */
+      }
+      if (work) rmSync(work, { recursive: true, force: true });
+    }
+
+    it("ac-1/ac-3: connection count is a small constant — it does NOT scale with file count", () => {
+      tagAc(AC1);
+      tagAc(AC3);
+      try {
+        // 3 hand files, all already applied → 0 pending.
+        freshDb();
+        setup(3);
+        run(["--seed"]); // mark all 3 as applied
+        const small = run(); // count connections on the no-pending path
+        teardown();
+
+        // 30 hand files, all already applied → 0 pending.
+        freshDb();
+        setup(30);
+        run(["--seed"]);
+        const large = run();
+
+        // The whole point: identical, tiny, independent of file count.
+        // (1 CREATE-TABLE-IF-NOT-EXISTS + 1 batched applied-set read = 2.)
+        expect(small).toBe(large);
+        expect(small).toBeLessThanOrEqual(2);
+      } finally {
+        teardown();
+      }
+    });
+
+    it("ac-2: journal excluded, applied skipped, pending applies DDL + tracking insert", () => {
+      tagAc(AC2);
+      try {
+        freshDb();
+        setup(2); // 9001_hand, 9002_hand pending; 0000..0008 journal on disk
+        run(); // apply
+
+        // Only the two hand-written tags are tracked — NO journal tags leaked in.
+        const tracked = psqlProbe("SELECT filename FROM manual_migrations ORDER BY 1");
+        expect(tracked.split("\n").filter(Boolean)).toEqual(["9001_hand", "9002_hand"]);
+
+        // The pending file's DDL actually ran (probe table exists).
+        expect(psqlProbe("SELECT count(*) FROM information_schema.tables WHERE table_name='probe_9001'")).toBe("1");
+
+        // Re-run is a clean no-op — already-applied files are skipped.
+        const out = execFileSync("bash", [join(work, "scripts", "apply.sh")], {
+          env: { ...process.env, DATABASE_URL: probe },
+          encoding: "utf-8",
+        });
+        expect(out).toMatch(/No hand-written migrations to apply\./);
+      } finally {
+        teardown();
+      }
+    });
+  },
+);

--- a/packages/server/src/__regression__/spec-281-build-cache.regression.test.ts
+++ b/packages/server/src/__regression__/spec-281-build-cache.regression.test.ts
@@ -1,0 +1,95 @@
+// spec-281 Fix 2 + ac-5 — the server container build is layer-cached, and both
+// spec-281 fixes ride the SHARED, env-keyed deploy path (so int + prod get them
+// identically). Static assertions in the shape of the repo's other deploy-wiring
+// guards (handhold-backfill, default-standards, cicd-deploy-config): they fail if
+// the wiring that makes the scope ACs true is ever removed.
+//
+// ac-4: the build pulls the previous image and builds `--cache-from` it with
+//       BuildKit inline cache, so an unchanged-deps build reuses the pnpm-install
+//       layers instead of rebuilding from scratch. The root Dockerfile is already
+//       staged so the `deps` layer stays cacheable when only source changes — this
+//       guard pins both halves (the cloudbuild wiring AND the Dockerfile staging
+//       the cache depends on). Actual layer reuse is additionally demonstrated with
+//       a local `docker build` twice in the build session, and confirmed live on the
+//       next deploy.
+// ac-5: both fixes live in the shared, non-env-conditional deploy path
+//       (apply-hand-migrations.sh + cloudbuild.yaml/deploy.sh build step), and CI
+//       runs the same `bash deploy.sh` — no environment-specific divergence.
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+const SPEC = "mindset-prod/memex-building-itself/specs/spec-281";
+const AC4 = `${SPEC}/acs/ac-4`;
+const AC5 = `${SPEC}/acs/ac-5`;
+
+const REPO_ROOT = join(__dirname, "..", "..", "..", "..");
+const read = (...p: string[]) => readFileSync(join(REPO_ROOT, ...p), "utf-8");
+
+const cloudbuild = read("cloudbuild.yaml");
+const serverDeploy = read("packages", "server", "deploy.sh");
+const rootDockerfile = read("Dockerfile");
+const deployWorkflow = read(".github", "workflows", "deploy.yml");
+
+describe("spec-281 ac-4: the server container build reuses cached layers", () => {
+  it("cloudbuild.yaml seeds the cache from the previously-pushed image (--cache-from)", () => {
+    tagAc(AC4);
+    // Pull the prior image first (non-fatal on a cold/first build)...
+    expect(cloudbuild).toMatch(/docker pull "\$\{_IMAGE\}:latest"\s*\|\|/);
+    // ...and build using it as the cache source.
+    expect(cloudbuild).toMatch(/--cache-from=\$\{_IMAGE\}:latest/);
+  });
+
+  it("stamps BuildKit inline-cache metadata so the NEXT deploy can reuse these layers", () => {
+    tagAc(AC4);
+    expect(cloudbuild).toMatch(/BUILDKIT_INLINE_CACHE=1/);
+    expect(cloudbuild).toMatch(/DOCKER_BUILDKIT=1/);
+    // The built, cache-stamped image is actually pushed.
+    expect(cloudbuild).toMatch(/images:[\s\S]*\$\{_IMAGE\}:latest/);
+    // Builds the workspace-aware root Dockerfile.
+    expect(cloudbuild).toMatch(/--file=Dockerfile/);
+  });
+
+  it("deploy.sh builds via the cache config, not the cacheless bare `--tag`", () => {
+    tagAc(AC4);
+    expect(serverDeploy).toMatch(/gcloud builds submit\s+\\\s*\n\s*--config cloudbuild\.yaml/);
+    expect(serverDeploy).toMatch(/--substitutions "_IMAGE=\$\{IMAGE\}"/);
+    // The old cacheless invocation is gone — `gcloud builds submit --tag "${IMAGE}"`.
+    expect(serverDeploy).not.toMatch(/gcloud builds submit\s+\\\s*\n\s*--tag "\$\{IMAGE\}"/);
+  });
+
+  it("the Dockerfile's deps stage is staged for cache reuse: manifests + lockfile copied and installed BEFORE source", () => {
+    tagAc(AC4);
+    // The cache only helps if `pnpm install` sits in a layer keyed on the lockfile /
+    // package.jsons, ABOVE the source copy — so a source-only change leaves it cached.
+    const depsInstall = rootDockerfile.search(/RUN pnpm install --frozen-lockfile --ignore-scripts/);
+    const srcCopy = rootDockerfile.search(/COPY packages\/server\/src/);
+    expect(depsInstall).toBeGreaterThanOrEqual(0);
+    expect(srcCopy).toBeGreaterThan(depsInstall); // source copied after the install layer
+  });
+});
+
+describe("spec-281 ac-5: both fixes ride the shared env-keyed deploy path", () => {
+  it("the batched applied-check lives in the shared, non-env-conditional migration script", () => {
+    tagAc(AC5);
+    const migrate = read("packages", "server", "scripts", "apply-hand-migrations.sh");
+    expect(migrate).toMatch(/SELECT filename FROM manual_migrations/);
+    // No environment branching in the script — one code path for int + prod.
+    expect(migrate).not.toMatch(/\$\{?ENV\b/);
+  });
+
+  it("the cache config is env-agnostic — parameterised only by the env-keyed _IMAGE substitution", () => {
+    tagAc(AC5);
+    // No hardcoded int/prod project, host, or region baked into the build config.
+    expect(cloudbuild).not.toMatch(/memex-ai-(int|prod)/);
+    expect(cloudbuild).not.toMatch(/int\.memex\.ai/);
+    expect(cloudbuild).toMatch(/\$\{_IMAGE\}/);
+  });
+
+  it("CI runs the same bash deploy.sh, so both fixes execute on every int + prod deploy", () => {
+    tagAc(AC5);
+    expect(deployWorkflow).toMatch(/bash deploy\.sh/);
+  });
+});


### PR DESCRIPTION
Promotes **spec-281** to prod. Verified green on int (Smoke passed, ENV=int; deploy 3m40s) at https://int.memex.ai.

Carries only the spec-281 commits (deploy tooling + tests — **no app/runtime code**, so the running container is behaviourally identical):
- **Fix 1** — `apply-hand-migrations.sh` reads the applied set once up front instead of one psql connection per file (~105/deploy). int log confirmed the hand-migration check now completes in ~0.6s.
- **Fix 2** — server image builds via `cloudbuild.yaml` with `--cache-from` + BuildKit inline cache. int log confirmed `Pulling …/memex-api` + `importing cache manifest` + `exporting cache`.

The **prod migration phase baseline was ~5m16s (observed 2026-06-13)** — this promotion is where that drop should show (spec-281 issue-1).

Revert plan if prod problems: revert this promotion merge on `main` (redeploys prior code) or roll back the Cloud Run revision; deploy.sh smoke tail flags a bad deploy non-gating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)