### PR TITLE
feat(db-schema): publish standalone @mindset-ai/db-schema package (spec-279)

### DIFF
--- a/.github/workflows/db-schema-drift.yml
+++ b/.github/workflows/db-schema-drift.yml
@@ -1,0 +1,67 @@
+name: db-schema-drift
+
+# Drift gate: fail CI when @mindset-ai/db-schema no longer matches the real
+# migrated database, so a pinned consumer (Backstage, spec-280) can never
+# silently run against a stale schema (std-20). Migrates a cold DB, then diffs
+# every table/column the package declares against it. spec-279 ac-3/ac-10.
+on:
+  push:
+    branches: [main, develop]
+    paths: &drift_paths
+      - "packages/server/src/db/schema.ts"
+      - "packages/server/drizzle/**"
+      - "packages/db-schema/**"
+      - ".github/workflows/db-schema-drift.yml"
+  pull_request:
+    branches: [main, develop]
+    paths: *drift_paths
+  workflow_dispatch:
+
+concurrency:
+  group: db-schema-drift-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  drift:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    services:
+      postgres:
+        # pgvector-bundled Postgres 16 — the hand migrations CREATE EXTENSION
+        # vector, absent from the stock postgres image (mirrors test.yml).
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: memex
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/memex
+      # AC emission to the prod Memex (spec-129). Value lives in the
+      # MEMEX_EMIT_KEY repo secret; empty until set (harmless pre-enforcement).
+      MEMEX_EMIT_KEY: ${{ secrets.MEMEX_EMIT_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Build the schema package
+        run: pnpm --filter @mindset-ai/db-schema build
+      - name: Migrate a cold database
+        working-directory: packages/server
+        run: pnpm db:migrate
+      - name: Run the drift gate
+        run: node packages/db-schema/scripts/drift-gate.mjs
+      # The package's own suite (build/publish-guard/drift/consumer). The
+      # integration tests create + migrate their own throwaway databases.
+      - name: Run the db-schema package tests
+        run: pnpm --filter @mindset-ai/db-schema test

--- a/.github/workflows/publish-db-schema.yml
+++ b/.github/workflows/publish-db-schema.yml
@@ -1,0 +1,47 @@
+name: publish-db-schema
+
+# Publishes @mindset-ai/db-schema to GitHub Packages on the release line (push
+# to main, per std-21/std-26). The publish script's content-hash guard means an
+# unchanged packages/server/src/db/schema.ts produces NO new version, so this is
+# safe to run on every main push. Auth is the built-in GITHUB_TOKEN only — no
+# extra registry secret. Consumed only by the in-org Backstage repo. spec-279.
+on:
+  push:
+    branches: [main]
+    paths:
+      - "packages/server/src/db/schema.ts"
+      - "packages/db-schema/**"
+      - ".github/workflows/publish-db-schema.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: publish-db-schema
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: write # GITHUB_TOKEN needs this to publish to GitHub Packages
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          # Writes an .npmrc scoping @mindset-ai to GitHub Packages and reading
+          # the token from NODE_AUTH_TOKEN (set below to the built-in token).
+          registry-url: "https://npm.pkg.github.com"
+          scope: "@mindset-ai"
+      - run: pnpm install --frozen-lockfile
+      - name: Build the package
+        run: pnpm --filter @mindset-ai/db-schema build
+      - name: Publish if the schema changed
+        run: node packages/db-schema/scripts/publish.mjs
+        env:
+          # The built-in token — no PAT, no NPM_TOKEN, no org secret.
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/db-schema/README.md
+++ b/packages/db-schema/README.md
@@ -1,0 +1,82 @@
+# @mindset-ai/db-schema
+
+The Memex production database schema, as a **standalone, typed Drizzle package** —
+the single cross-repo artifact the **Backstage** operator control plane (spec-280)
+consumes. It is built from the one source of truth, `packages/server/src/db/schema.ts`,
+and published to **private GitHub Packages** (spec-279).
+
+It is **not** on public npm and **not** `@memex/*` (that scope is unavailable, spec-89).
+Building or running the open-source `memex-ai` repo never requires installing it —
+this package is outbound-only, consumed solely by in-org repos.
+
+## Install (from an in-org repo, e.g. Backstage)
+
+`@mindset-ai/db-schema` lives on GitHub Packages. Point the `@mindset-ai` scope at
+that registry and authenticate with a `GITHUB_TOKEN` (the built-in Actions token in
+CI, or a `read:packages` PAT locally). Add to the consumer repo's `.npmrc`:
+
+```ini
+@mindset-ai:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}
+```
+
+Then:
+
+```bash
+npm install @mindset-ai/db-schema drizzle-orm postgres
+```
+
+Pin an exact version — the publish workflow bumps the version only when the schema
+actually changes (a content-hash guard), and the [drift gate](#drift-gate) guarantees
+a pinned version still matches the real database.
+
+## Use
+
+```ts
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import { documents, type Doc } from "@mindset-ai/db-schema";
+
+const sql = postgres(process.env.DATABASE_URL!, { max: 1 });
+const db = drizzle(sql);
+
+const rows: Doc[] = await db.select().from(documents).limit(10);
+```
+
+The package exports the Drizzle table objects **and** their inferred row/insert
+types (`Doc`, `NewDoc`, …), with zero workspace dependencies — `drizzle-orm` is the
+only runtime dependency.
+
+## Cross-tenant role posture (read before you connect)
+
+Tenant isolation is enforced in Postgres via **RLS** (row-level security). The app
+connects with a tenant-scoped role that RLS confines to one tenant. Backstage is an
+operator console that must read **across** tenants, so it connects as a dedicated
+**`BYPASSRLS` role (`memex_admin`)** — distinct from the app's role. Treat that
+credential as privileged and audited.
+
+Backstage **owns its own control-plane tables** in a separate **`admin` Postgres
+schema** with its own migration history, and **never writes `public.*` directly** —
+tenant mutations go through the core API / `mutate()` bus (std-8). This package gives
+Backstage typed **read** access to `public.*`; it does not grant or imply write access.
+
+## Typed subset
+
+The package is an intentional **typed subset** of the database. The real DB carries a
+few columns the schema deliberately does not model — pgvector `embedding*`, tsvector
+`content_tsv`, and bookkeeping tables (`manual_migrations`) — because Drizzle doesn't
+first-class those Postgres types. The drift gate accounts for this (see below).
+
+## Drift gate
+
+CI migrates a cold database and runs `scripts/drift-gate.mjs`, which diffs every
+table/column the package **declares** against the live DB. It fails the build when the
+DB is **missing** anything the package declares (the stale-package danger), so a pinned
+consumer can never silently run against a schema that has moved on. DB objects the
+package doesn't model are reported as info, never failures.
+
+## Build
+
+```bash
+pnpm --filter @mindset-ai/db-schema build   # tsup → dist/index.js (ESM) + dist/index.d.ts
+```

--- a/packages/db-schema/package.json
+++ b/packages/db-schema/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@mindset-ai/db-schema",
+  "version": "0.1.0",
+  "description": "Standalone Drizzle schema for the Memex database — the single cross-repo artifact the Backstage operator control plane consumes (spec-279).",
+  "license": "SEE LICENSE IN LICENSE.md",
+  "type": "module",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mindset-ai/memex-ai.git",
+    "directory": "packages/db-schema"
+  },
+  "scripts": {
+    "build": "tsup",
+    "prepare": "tsup",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "drizzle-orm": "^0.39.0"
+  },
+  "devDependencies": {
+    "@memex-ai-ac/vitest": "workspace:*",
+    "@types/node": "22.19.15",
+    "postgres": "^3.4.5",
+    "tsup": "^8.3.5",
+    "typescript": "^5.7.0",
+    "vitest": "4.1.1"
+  }
+}

--- a/packages/db-schema/scripts/drift-gate.mjs
+++ b/packages/db-schema/scripts/drift-gate.mjs
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+// Drift gate: introspect a (freshly-migrated, cold) database and diff it
+// against THIS package's published schema. Exits non-zero on divergence so a
+// pinned consumer can never silently run against a stale schema. spec-279
+// ac-3/ac-10. The pure diff core is exported for unit tests.
+import postgres from "postgres";
+import { is } from "drizzle-orm";
+import { PgTable, getTableConfig } from "drizzle-orm/pg-core";
+import * as schema from "../dist/index.js";
+
+// Objects the schema doesn't model as first-class tables — never count as drift.
+const IGNORED_TABLES = new Set(["__drizzle_migrations"]);
+
+/** Expected shape from the package schema: Map<table, Set<column>> (public schema only). */
+export function expectedFromSchema(mod) {
+  const expected = new Map();
+  for (const value of Object.values(mod)) {
+    if (!is(value, PgTable)) continue;
+    const cfg = getTableConfig(value);
+    if (cfg.schema && cfg.schema !== "public") continue;
+    expected.set(cfg.name, new Set(cfg.columns.map((c) => c.name)));
+  }
+  return expected;
+}
+
+/** Actual shape introspected from the DB: Map<table, Set<column>> (base tables, public schema). */
+export async function introspectDb(sql) {
+  const rows = await sql`
+    select c.table_name, c.column_name
+    from information_schema.columns c
+    join information_schema.tables t
+      on t.table_schema = c.table_schema and t.table_name = c.table_name
+    where c.table_schema = 'public' and t.table_type = 'BASE TABLE'
+  `;
+  const actual = new Map();
+  for (const { table_name, column_name } of rows) {
+    if (IGNORED_TABLES.has(table_name)) continue;
+    if (!actual.has(table_name)) actual.set(table_name, new Set());
+    actual.get(table_name).add(column_name);
+  }
+  return actual;
+}
+
+/**
+ * Pure diff between the package schema (expected) and the live DB (actual).
+ *
+ * The package schema is an intentional TYPED SUBSET of the database: the real
+ * DB carries columns the schema deliberately does not model (pgvector
+ * `embedding*`, tsvector `content_tsv`, and bookkeeping tables like
+ * `manual_migrations`), because Drizzle doesn't first-class those Postgres
+ * types and they're managed by hand migrations. So the two directions are NOT
+ * symmetric:
+ *   - `failures` — something the package DECLARES that the DB LACKS (a missing
+ *     table or column). This is the stale-package danger: a pinned consumer
+ *     would query a table/column that no longer exists → runtime error. CI red.
+ *   - `info` — something the DB has that the package doesn't model. Harmless to
+ *     a consumer (they simply don't see it). Logged, never fails the gate.
+ *
+ * Returns { failures, info }; empty `failures` = the package is safe to pin.
+ */
+export function diffSchemas(expected, actual) {
+  const failures = [];
+  const info = [];
+  for (const [table, cols] of expected) {
+    const actualCols = actual.get(table);
+    if (!actualCols) {
+      failures.push(`missing table in DB: ${table}`);
+      continue;
+    }
+    for (const col of cols) {
+      if (!actualCols.has(col)) failures.push(`missing column in DB: ${table}.${col}`);
+    }
+  }
+  for (const [table, cols] of actual) {
+    if (!expected.has(table)) {
+      info.push(`extra table in DB (not modelled by the package): ${table}`);
+      continue;
+    }
+    for (const col of cols) {
+      if (!expected.get(table).has(col)) info.push(`extra column in DB (not modelled): ${table}.${col}`);
+    }
+  }
+  return { failures, info };
+}
+
+async function main() {
+  const url = process.env.DATABASE_URL;
+  if (!url) {
+    console.error("DATABASE_URL is required");
+    process.exit(2);
+  }
+  const sql = postgres(url, { max: 1, onnotice: () => {} });
+  try {
+    const { failures, info } = diffSchemas(expectedFromSchema(schema), await introspectDb(sql));
+    if (info.length > 0) {
+      console.log(`ℹ ${info.length} DB object(s) not modelled by the package (allowed):`);
+      for (const i of info) console.log(`  - ${i}`);
+    }
+    if (failures.length === 0) {
+      console.log("✓ db-schema drift gate: every table/column the package declares exists in the DB");
+      process.exit(0);
+    }
+    console.error(`✗ db-schema drift gate: ${failures.length} divergence(s) — the package is stale vs the DB:`);
+    for (const f of failures) console.error(`  - ${f}`);
+    process.exit(1);
+  } finally {
+    await sql.end({ timeout: 5 });
+  }
+}
+
+// Run main() only when invoked directly (not when imported by tests).
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(2);
+  });
+}

--- a/packages/db-schema/scripts/publish-guard.mjs
+++ b/packages/db-schema/scripts/publish-guard.mjs
@@ -1,0 +1,35 @@
+import { createHash } from "node:crypto";
+
+// Pure, unit-testable core of the publish step. Kept free of I/O so the no-op
+// guard (ac-9) and the pinnable-version logic (ac-2) can be tested directly,
+// without a live registry. spec-279.
+
+/** Stable short content hash of the schema source. */
+export function computeSchemaHash(source) {
+  return createHash("sha256").update(source, "utf8").digest("hex").slice(0, 12);
+}
+
+/**
+ * The no-op guard. Publish only when the schema content actually changed since
+ * the last published version. `publishedHash` is the `schemaHash` recorded on
+ * the latest registry version (null if never published).
+ */
+export function decidePublish({ publishedHash, currentHash }) {
+  if (!currentHash) throw new Error("currentHash is required");
+  if (publishedHash && publishedHash === currentHash) {
+    return { publish: false, reason: `schema unchanged (hash ${currentHash}) — skipping publish` };
+  }
+  return {
+    publish: true,
+    reason: publishedHash
+      ? `schema changed (${publishedHash} → ${currentHash}) — publishing`
+      : `first publish (hash ${currentHash})`,
+  };
+}
+
+/** Next pinnable version: bump the patch of a plain x.y.z semver. */
+export function bumpPatch(version) {
+  const m = /^(\d+)\.(\d+)\.(\d+)$/.exec(version ?? "");
+  if (!m) throw new Error(`not a plain semver: ${version}`);
+  return `${m[1]}.${m[2]}.${Number(m[3]) + 1}`;
+}

--- a/packages/db-schema/scripts/publish.mjs
+++ b/packages/db-schema/scripts/publish.mjs
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+// CI publish entrypoint for @mindset-ai/db-schema. Assumes the dist is already
+// built. Computes the schema content hash, asks the registry what's published,
+// and publishes a NEW pinnable version only when the schema actually changed —
+// the no-op guard. Auth comes from NODE_AUTH_TOKEN (the workflow wires it to
+// the built-in GITHUB_TOKEN). spec-279 ac-2/ac-8/ac-9.
+import { execFileSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { computeSchemaHash, decidePublish, bumpPatch } from "./publish-guard.mjs";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const pkgDir = join(here, "..");
+const schemaPath = join(pkgDir, "..", "server", "src", "db", "schema.ts");
+const manifestPath = join(pkgDir, "package.json");
+
+const currentHash = computeSchemaHash(readFileSync(schemaPath, "utf8"));
+
+// What's published now? `schemaHash` is a custom field we stamp on each publish.
+function viewPublished() {
+  try {
+    const out = execFileSync("npm", ["view", "@mindset-ai/db-schema", "--json"], { encoding: "utf8" });
+    return JSON.parse(out);
+  } catch {
+    return null; // never published
+  }
+}
+const published = viewPublished();
+const decision = decidePublish({ publishedHash: published?.schemaHash ?? null, currentHash });
+console.log(decision.reason);
+if (!decision.publish) process.exit(0); // unchanged schema → no new version
+
+// Stamp the new pinnable version + the schema hash that justifies it.
+const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+manifest.version = published?.version ? bumpPatch(published.version) : manifest.version;
+manifest.schemaHash = currentHash;
+writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + "\n");
+console.log(`publishing @mindset-ai/db-schema@${manifest.version} (schemaHash ${currentHash})`);
+
+const args = process.env.DRY_RUN === "1" ? ["publish", "--dry-run"] : ["publish"];
+execFileSync("npm", args, { cwd: pkgDir, stdio: "inherit" });

--- a/packages/db-schema/src/index.ts
+++ b/packages/db-schema/src/index.ts
@@ -1,0 +1,13 @@
+// Single source of truth: the server's Drizzle schema.
+//
+// This package exists so an out-of-workspace repo (Backstage, the operator
+// control plane — spec-280) can consume the production DB schema with full
+// types WITHOUT forking `schema.ts` or depending on the monorepo. We do NOT
+// copy the schema here; we re-export it and let the build (tsup/esbuild) bundle
+// the schema source — and inline the few type-only cross-file imports it makes
+// (`CommentAction`, `CommentAudience`) — into a self-contained dist with zero
+// `workspace:*` / `@memex/*` dependencies. The only runtime dep that survives
+// is `drizzle-orm` itself, which the consumer uses directly anyway.
+//
+// spec-279 dec-1: published to private GitHub Packages as `@mindset-ai/db-schema`.
+export * from "../../server/src/db/schema.js";

--- a/packages/db-schema/test/consumer.test.ts
+++ b/packages/db-schema/test/consumer.test.ts
@@ -25,10 +25,12 @@ beforeAll(() => {
   const ping = spawnSync("pg_isready", ["-h", "localhost", "-p", "5432"]);
   if (ping.status !== 0) throw new Error("Postgres must be running on localhost:5432 for the consumer integration test");
 
-  // Build + pack the real artifact.
-  execFileSync("pnpm", ["build"], { cwd: PKG_DIR, stdio: "ignore" });
-  const packed = JSON.parse(execFileSync("npm", ["pack", "--json", "--ignore-scripts"], { cwd: PKG_DIR, encoding: "utf8" }));
-  tarball = join(PKG_DIR, packed[0].filename);
+  // Pack the real artifact. `npm pack` runs `prepare` (tsup) to build a fresh
+  // dist; we derive the deterministic tarball name rather than parsing pack's
+  // stdout (tsup's banner pollutes it).
+  execFileSync("npm", ["pack"], { cwd: PKG_DIR, stdio: "ignore" });
+  const pkgJson = JSON.parse(readFileSync(join(PKG_DIR, "package.json"), "utf8"));
+  tarball = join(PKG_DIR, `${pkgJson.name.replace(/^@/, "").replace("/", "-")}-${pkgJson.version}.tgz`);
 
   // Fresh out-of-workspace consumer project; install the tarball + its peers.
   proj = mkdtempSync(join(tmpdir(), "db-schema-consumer-"));

--- a/packages/db-schema/test/consumer.test.ts
+++ b/packages/db-schema/test/consumer.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { spawnSync, execFileSync } from "node:child_process";
+import { mkdtempSync, writeFileSync, readFileSync, rmSync, existsSync, readdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+// spec-279 t-4 — the consumer contract. A standalone harness OUTSIDE this pnpm
+// workspace installs the packed tarball, type-checks against its exported types,
+// and opens a Drizzle + postgres connection that queries through the imported
+// schema — proving Backstage can consume the package as published.
+
+const PKG_DIR = resolve(__dirname, "..");
+const SERVER_DIR = resolve(__dirname, "..", "..", "server");
+const ADMIN_URL = "postgresql://postgres:postgres@localhost:5432/postgres";
+const TEST_DB = "memex_consumer_itest";
+const TEST_URL = `postgresql://postgres:postgres@localhost:5432/${TEST_DB}`;
+
+// A temp project that is NOT part of the workspace (lives under the OS tmpdir,
+// outside packages/*), so node/tsc resolution can't reach into the monorepo.
+let proj: string;
+let tarball: string;
+
+beforeAll(() => {
+  const ping = spawnSync("pg_isready", ["-h", "localhost", "-p", "5432"]);
+  if (ping.status !== 0) throw new Error("Postgres must be running on localhost:5432 for the consumer integration test");
+
+  // Build + pack the real artifact.
+  execFileSync("pnpm", ["build"], { cwd: PKG_DIR, stdio: "ignore" });
+  const packed = JSON.parse(execFileSync("npm", ["pack", "--json", "--ignore-scripts"], { cwd: PKG_DIR, encoding: "utf8" }));
+  tarball = join(PKG_DIR, packed[0].filename);
+
+  // Fresh out-of-workspace consumer project; install the tarball + its peers.
+  proj = mkdtempSync(join(tmpdir(), "db-schema-consumer-"));
+  execFileSync("npm", ["init", "-y"], { cwd: proj, stdio: "ignore" });
+  execFileSync("npm", ["pkg", "set", "type=module"], { cwd: proj, stdio: "ignore" });
+  execFileSync("npm", ["install", tarball, "drizzle-orm@^0.39.0", "postgres@^3.4.5", "typescript@^5.7.0"], { cwd: proj, stdio: "ignore" });
+
+  // A cold, migrated DB for the live query.
+  execFileSync("psql", [ADMIN_URL, "-q", "-c", `DROP DATABASE IF EXISTS ${TEST_DB} WITH (FORCE);`, "-c", `CREATE DATABASE ${TEST_DB};`]);
+  execFileSync("pnpm", ["db:migrate"], { cwd: SERVER_DIR, env: { ...process.env, DATABASE_URL: TEST_URL }, stdio: "ignore" });
+}, 180_000);
+
+afterAll(() => {
+  if (proj) rmSync(proj, { recursive: true, force: true });
+  execFileSync("psql", [ADMIN_URL, "-q", "-c", `DROP DATABASE IF EXISTS ${TEST_DB} WITH (FORCE);`]);
+  for (const f of readdirSync(PKG_DIR)) {
+    if (f.startsWith("mindset-ai-db-schema-") && f.endsWith(".tgz")) rmSync(join(PKG_DIR, f), { force: true });
+  }
+});
+
+describe("ac-11 — standalone harness installs the tarball, type-checks, and queries via Drizzle", () => {
+  it("the installed package resolves and type-checks against its exported types", () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-279/acs/ac-11");
+
+    // A consumer .ts that uses both a value export (table) and a type export (Doc).
+    const consumerTs = join(proj, "consumer.ts");
+    writeFileSync(
+      consumerTs,
+      `import { documents, type Doc } from "@mindset-ai/db-schema";\n` +
+        `export const table = documents;\n` +
+        `export function firstTitle(rows: Doc[]): string | undefined { return rows[0]?.title; }\n`,
+    );
+    // Type-check with the consumer project's OWN tsc, resolving modules from
+    // its node_modules — exactly as a real out-of-workspace consumer would.
+    const tscBin = join(proj, "node_modules", ".bin", "tsc");
+    const tsc = spawnSync(
+      tscBin,
+      ["--noEmit", "--strict", "--skipLibCheck", "--module", "nodenext", "--moduleResolution", "nodenext", "--target", "es2022", "consumer.ts"],
+      { cwd: proj, encoding: "utf8" },
+    );
+    expect(tsc.status, tsc.stdout + tsc.stderr).toBe(0);
+  });
+
+  it("opens a Drizzle postgres connection and runs a query through the imported schema", () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-279/acs/ac-11");
+
+    const probe = join(proj, "probe.mjs");
+    writeFileSync(
+      probe,
+      `import { drizzle } from "drizzle-orm/postgres-js";\n` +
+        `import postgres from "postgres";\n` +
+        `import { documents } from "@mindset-ai/db-schema";\n` +
+        `const sql = postgres(process.env.DATABASE_URL, { max: 1 });\n` +
+        `const db = drizzle(sql);\n` +
+        `const rows = await db.select().from(documents).limit(1);\n` +
+        `await sql.end();\n` +
+        `process.stdout.write("QUERY_OK:" + Array.isArray(rows));\n`,
+    );
+    const run = spawnSync("node", [probe], { cwd: proj, env: { ...process.env, DATABASE_URL: TEST_URL }, encoding: "utf8" });
+    expect(run.status, run.stdout + run.stderr).toBe(0);
+    expect(run.stdout).toContain("QUERY_OK:true");
+  });
+});
+
+describe("ac-5 — consuming is documented and demonstrably sufficient, incl. the RLS posture", () => {
+  it("the README documents the install recipe, the drizzle usage, and the BYPASSRLS posture", () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-279/acs/ac-5");
+    const readme = readFileSync(join(PKG_DIR, "README.md"), "utf8");
+    // Install recipe: scoped registry + GITHUB_TOKEN auth.
+    expect(readme).toContain("@mindset-ai:registry=https://npm.pkg.github.com");
+    expect(readme).toMatch(/GITHUB_TOKEN/);
+    // Drizzle usage.
+    expect(readme).toContain('from "@mindset-ai/db-schema"');
+    expect(readme).toContain("drizzle(sql)");
+    // The cross-tenant posture a consumer must understand.
+    expect(readme).toMatch(/BYPASSRLS/);
+    expect(readme).toMatch(/memex_admin/);
+    expect(readme).toMatch(/admin.*schema|`admin`/);
+  });
+});

--- a/packages/db-schema/test/drift-gate.test.ts
+++ b/packages/db-schema/test/drift-gate.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { spawnSync, execFileSync } from "node:child_process";
+import { resolve } from "node:path";
+import { readFileSync } from "node:fs";
+// @ts-expect-error — plain .mjs, no types needed.
+import { diffSchemas } from "../scripts/drift-gate.mjs";
+
+// spec-279 t-3 — the drift gate.
+
+const GATE = resolve(__dirname, "..", "scripts", "drift-gate.mjs");
+const SERVER_DIR = resolve(__dirname, "..", "..", "server");
+const ADMIN_URL = "postgresql://postgres:postgres@localhost:5432/postgres";
+const TEST_DB = "memex_driftgate_itest";
+const TEST_URL = `postgresql://postgres:postgres@localhost:5432/${TEST_DB}`;
+
+const map = (obj: Record<string, string[]>) =>
+  new Map(Object.entries(obj).map(([t, cols]) => [t, new Set(cols)]));
+
+describe("ac-10 — diff core: red on a schema→DB divergence, green/info otherwise", () => {
+  it("reports no failures when the package schema is fully present in the DB", () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-279/acs/ac-10");
+    const { failures } = diffSchemas(
+      map({ documents: ["id", "title"] }),
+      map({ documents: ["id", "title"] }),
+    );
+    expect(failures).toEqual([]);
+  });
+
+  it("FAILS when the DB is missing a table or column the package declares", () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-279/acs/ac-10");
+
+    const missingTable = diffSchemas(map({ documents: ["id"], acs: ["id"] }), map({ documents: ["id"] }));
+    expect(missingTable.failures).toContain("missing table in DB: acs");
+
+    const missingCol = diffSchemas(map({ documents: ["id", "title"] }), map({ documents: ["id"] }));
+    expect(missingCol.failures).toContain("missing column in DB: documents.title");
+  });
+
+  it("treats DB-only tables/columns as info, never as failures (typed-subset contract)", () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-279/acs/ac-10");
+    const { failures, info } = diffSchemas(
+      map({ documents: ["id"] }),
+      map({ documents: ["id", "embedding"], manual_migrations: ["id"] }),
+    );
+    expect(failures).toEqual([]);
+    expect(info).toContain("extra column in DB (not modelled): documents.embedding");
+    expect(info).toContain("extra table in DB (not modelled by the package): manual_migrations");
+  });
+});
+
+describe("ac-3 / ac-10 — the gate runs against a freshly-migrated cold DB", () => {
+  beforeAll(() => {
+    // Fail loudly (not skip) if Postgres is unreachable — a real prerequisite.
+    const ping = spawnSync("pg_isready", ["-h", "localhost", "-p", "5432"]);
+    if (ping.status !== 0) throw new Error("Postgres must be running on localhost:5432 for the drift-gate integration test");
+
+    // Cold database, fully migrated (drizzle journal + hand migrations).
+    execFileSync("psql", [ADMIN_URL, "-q", "-c", `DROP DATABASE IF EXISTS ${TEST_DB} WITH (FORCE);`, "-c", `CREATE DATABASE ${TEST_DB};`]);
+    execFileSync("pnpm", ["db:migrate"], { cwd: SERVER_DIR, env: { ...process.env, DATABASE_URL: TEST_URL }, stdio: "ignore" });
+  }, 120_000);
+
+  afterAll(() => {
+    execFileSync("psql", [ADMIN_URL, "-q", "-c", `DROP DATABASE IF EXISTS ${TEST_DB} WITH (FORCE);`]);
+  });
+
+  const runGate = () => spawnSync("node", [GATE], { env: { ...process.env, DATABASE_URL: TEST_URL }, encoding: "utf8" });
+
+  it("passes (exit 0) when the package matches the migrated DB", () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-279/acs/ac-3");
+    const res = runGate();
+    expect(res.stdout).toContain("every table/column the package declares exists in the DB");
+    expect(res.status, res.stderr).toBe(0);
+  });
+
+  it("fails (non-zero exit) on a deliberately-diverged DB", () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-279/acs/ac-10");
+    // Drop a column the package's schema declares → the package is now stale vs the DB.
+    execFileSync("psql", [TEST_URL, "-q", "-c", "ALTER TABLE documents DROP COLUMN title;"]);
+    const res = runGate();
+    expect(res.status).not.toBe(0);
+    expect(res.stderr).toContain("missing column in DB: documents.title");
+  });
+});
+
+// The drift gate must exist as a CI check (ac-3): assert the workflow runs it.
+describe("ac-3 — a CI drift gate exists", () => {
+  it("the db-schema-drift workflow migrates a cold DB and runs the gate", () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-279/acs/ac-3");
+    const wf = readFileSync(resolve(__dirname, "..", "..", "..", ".github", "workflows", "db-schema-drift.yml"), "utf8");
+    expect(wf).toContain("pgvector/pgvector:pg16");
+    expect(wf).toContain("pnpm db:migrate");
+    expect(wf).toContain("node packages/db-schema/scripts/drift-gate.mjs");
+  });
+});

--- a/packages/db-schema/test/package.build.test.ts
+++ b/packages/db-schema/test/package.build.test.ts
@@ -21,14 +21,19 @@ const pkgJson = JSON.parse(readFileSync(join(PKG_DIR, "package.json"), "utf8"));
 let tarballPath: string;
 
 beforeAll(() => {
-  // Build a fresh dist first, then pack with --ignore-scripts so the tsup build
-  // logs don't pollute the --json stdout we parse for the produced filename.
-  execFileSync("pnpm", ["build"], { cwd: PKG_DIR, stdio: "ignore" });
-  const out = execFileSync("npm", ["pack", "--json", "--ignore-scripts"], { cwd: PKG_DIR, encoding: "utf8" });
-  const filename = JSON.parse(out)[0].filename;
-  tarballPath = join(PKG_DIR, filename);
-  expect(existsSync(tarballPath), `tarball ${filename} should exist`).toBe(true);
+  // `npm pack` runs `prepare` (tsup), which builds a fresh dist into the
+  // tarball. We do NOT parse its stdout (tsup's CLI banner pollutes it, and
+  // --ignore-scripts isn't honoured uniformly across npm versions); instead we
+  // derive the deterministic tarball name from name@version.
+  execFileSync("npm", ["pack"], { cwd: PKG_DIR, stdio: "ignore" });
+  tarballPath = join(PKG_DIR, tarballName(pkgJson));
+  expect(existsSync(tarballPath), `tarball ${tarballName(pkgJson)} should exist`).toBe(true);
 }, 120_000);
+
+/** npm's tarball name for a (scoped) package: `@scope/name@x.y.z` → `scope-name-x.y.z.tgz`. */
+function tarballName(manifest: { name: string; version: string }): string {
+  return `${manifest.name.replace(/^@/, "").replace("/", "-")}-${manifest.version}.tgz`;
+}
 
 describe("ac-7 — built from schema.ts (single source), exports tables + inferred types as ESM + d.ts", () => {
   it("re-exports the single source (no second schema copy) and emits ESM + d.ts", async () => {

--- a/packages/db-schema/test/package.build.test.ts
+++ b/packages/db-schema/test/package.build.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, existsSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+// spec-279 t-1 — the standalone @mindset-ai/db-schema package.
+//
+// These tests verify the PUBLISHED shape, not just the source: they build a
+// real tarball with `npm pack` (which runs the `prepare`/tsup build) and prove
+// it is self-contained and installable outside the workspace.
+
+const PKG_DIR = resolve(__dirname, "..");
+const DIST_JS = join(PKG_DIR, "dist", "index.js");
+const DIST_DTS = join(PKG_DIR, "dist", "index.d.ts");
+const pkgJson = JSON.parse(readFileSync(join(PKG_DIR, "package.json"), "utf8"));
+
+// A single packed tarball shared across the install-shaped assertions.
+let tarballPath: string;
+
+beforeAll(() => {
+  // Build a fresh dist first, then pack with --ignore-scripts so the tsup build
+  // logs don't pollute the --json stdout we parse for the produced filename.
+  execFileSync("pnpm", ["build"], { cwd: PKG_DIR, stdio: "ignore" });
+  const out = execFileSync("npm", ["pack", "--json", "--ignore-scripts"], { cwd: PKG_DIR, encoding: "utf8" });
+  const filename = JSON.parse(out)[0].filename;
+  tarballPath = join(PKG_DIR, filename);
+  expect(existsSync(tarballPath), `tarball ${filename} should exist`).toBe(true);
+}, 120_000);
+
+describe("ac-7 — built from schema.ts (single source), exports tables + inferred types as ESM + d.ts", () => {
+  it("re-exports the single source (no second schema copy) and emits ESM + d.ts", async () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-279/acs/ac-7");
+
+    // Single source: src/index.ts re-exports the server schema, it does not copy it.
+    const srcIndex = readFileSync(join(PKG_DIR, "src", "index.ts"), "utf8");
+    expect(srcIndex).toMatch(/export \* from "\.\.\/\.\.\/server\/src\/db\/schema\.js"/);
+
+    // ESM js + a declaration file are both emitted.
+    expect(existsSync(DIST_JS), "dist/index.js emitted").toBe(true);
+    expect(existsSync(DIST_DTS), "dist/index.d.ts emitted").toBe(true);
+
+    // The built module exports the Drizzle table objects.
+    const mod = await import(pathToFileURL(DIST_JS).href);
+    for (const table of ["documents", "acs", "tasks", "decisions", "testEvents"]) {
+      expect(mod[table], `table export ${table}`).toBeDefined();
+    }
+
+    // The d.ts carries the inferred row/insert types derived from those tables.
+    const dts = readFileSync(DIST_DTS, "utf8");
+    expect(dts).toMatch(/type Doc\b/);
+    expect(dts).toMatch(/InferSelectModel|InferInsertModel/);
+  });
+});
+
+describe("ac-1 / ac-6 — self-contained: zero workspace/@memex deps, installs in an empty project", () => {
+  it("declares no workspace:* or @memex/* dependency, and the built js imports only drizzle-orm", () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-279/acs/ac-1");
+
+    // No workspace/@memex deps in anything a consumer would resolve.
+    for (const field of ["dependencies", "peerDependencies"] as const) {
+      const deps: Record<string, string> = pkgJson[field] ?? {};
+      for (const [name, range] of Object.entries(deps)) {
+        expect(name.startsWith("@memex/"), `${field} key ${name}`).toBe(false);
+        expect(String(range).includes("workspace:"), `${field} ${name} range`).toBe(false);
+      }
+    }
+    // The only runtime dependency is drizzle-orm.
+    expect(Object.keys(pkgJson.dependencies ?? {})).toEqual(["drizzle-orm"]);
+
+    // The bundled js must import nothing but drizzle-orm — the schema source is inlined.
+    const js = readFileSync(DIST_JS, "utf8");
+    const specifiers = [...js.matchAll(/^\s*import\s+[^'"]*from\s+['"]([^'"]+)['"]/gm)].map((m) => m[1]);
+    expect(specifiers.length).toBeGreaterThan(0);
+    for (const spec of specifiers) {
+      expect(spec.startsWith("drizzle-orm"), `import specifier ${spec}`).toBe(true);
+    }
+  });
+
+  it("installs into a fresh empty project and the package resolves by name", () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-279/acs/ac-6");
+
+    const proj = mkdtempSync(join(tmpdir(), "db-schema-consumer-"));
+    try {
+      // A bare project with no monorepo around it.
+      execFileSync("npm", ["init", "-y"], { cwd: proj, stdio: "ignore" });
+      // Install the packed tarball; drizzle-orm resolves from the public registry.
+      execFileSync("npm", ["install", tarballPath], { cwd: proj, stdio: "ignore" });
+
+      const installed = join(proj, "node_modules", "@mindset-ai", "db-schema", "dist", "index.js");
+      expect(existsSync(installed), "package installed into node_modules").toBe(true);
+      expect(existsSync(join(proj, "node_modules", "drizzle-orm")), "drizzle-orm dep resolved").toBe(true);
+
+      // It imports cleanly by name from inside the empty project.
+      const probe = `import('@mindset-ai/db-schema').then(m => { if (!m.documents) { process.exit(7); } process.stdout.write('OK'); }).catch(e => { console.error(e); process.exit(8); });`;
+      const result = execFileSync("node", ["-e", probe], { cwd: proj, encoding: "utf8" });
+      expect(result).toContain("OK");
+    } finally {
+      rmSync(proj, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("ac-4 — no external/OSS user must authenticate to a registry to build the repo", () => {
+  it("the published artifact is outbound-only: no workspace package depends on @mindset-ai/*", () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-279/acs/ac-4");
+
+    // The new package is consumed ONLY by the out-of-repo Backstage app. Building
+    // THIS repo from source must never require pulling an @mindset-ai/* package
+    // from a registry — so nothing in the workspace may depend on one.
+    const packagesDir = resolve(__dirname, "..", "..");
+    const offenders: string[] = [];
+    for (const entry of readdirSync(packagesDir, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      const manifestPath = join(packagesDir, entry.name, "package.json");
+      if (!existsSync(manifestPath)) continue;
+      const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+      for (const field of ["dependencies", "devDependencies", "peerDependencies"] as const) {
+        for (const dep of Object.keys(manifest[field] ?? {})) {
+          if (dep.startsWith("@mindset-ai/")) offenders.push(`${entry.name}:${field}:${dep}`);
+        }
+      }
+    }
+    expect(offenders, "no workspace package may depend on @mindset-ai/*").toEqual([]);
+
+    // And the db-schema package itself pulls nothing from the workspace.
+    for (const field of ["dependencies", "peerDependencies"] as const) {
+      for (const range of Object.values((pkgJson[field] ?? {}) as Record<string, string>)) {
+        expect(String(range).includes("workspace:")).toBe(false);
+      }
+    }
+  });
+});
+
+// Housekeeping: remove the tarball(s) this suite produced so the package dir
+// stays clean (and they never accidentally get committed).
+import { afterAll } from "vitest";
+afterAll(() => {
+  for (const f of readdirSync(PKG_DIR)) {
+    if (f.startsWith("mindset-ai-db-schema-") && f.endsWith(".tgz")) {
+      rmSync(join(PKG_DIR, f), { force: true });
+    }
+  }
+});

--- a/packages/db-schema/test/publish.test.ts
+++ b/packages/db-schema/test/publish.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+// @ts-expect-error — plain .mjs module, no types needed for a test.
+import { computeSchemaHash, decidePublish, bumpPatch } from "../scripts/publish-guard.mjs";
+
+// spec-279 t-2 — the GitHub Actions publish workflow + its guard logic.
+
+const WORKFLOW_PATH = resolve(__dirname, "..", "..", "..", ".github", "workflows", "publish-db-schema.yml");
+const workflow = readFileSync(WORKFLOW_PATH, "utf8");
+const pkgJson = JSON.parse(readFileSync(resolve(__dirname, "..", "package.json"), "utf8"));
+
+describe("ac-8 — publishes to GitHub Packages authenticating with GITHUB_TOKEN only", () => {
+  it("targets the @mindset-ai GitHub Packages registry and references no secret but GITHUB_TOKEN", () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-279/acs/ac-8");
+
+    // Right registry + scope.
+    expect(workflow).toContain("https://npm.pkg.github.com");
+    expect(workflow).toContain('scope: "@mindset-ai"');
+
+    // Auth is wired to the built-in token via NODE_AUTH_TOKEN.
+    expect(workflow).toMatch(/NODE_AUTH_TOKEN:\s*\$\{\{\s*secrets\.GITHUB_TOKEN\s*\}\}/);
+
+    // The ONLY secret referenced anywhere is GITHUB_TOKEN — no PAT / NPM_TOKEN / org secret.
+    const secretsUsed = new Set([...workflow.matchAll(/secrets\.([A-Z0-9_]+)/g)].map((m) => m[1]));
+    expect([...secretsUsed]).toEqual(["GITHUB_TOKEN"]);
+
+    // And the package itself is configured to publish to that registry.
+    expect(pkgJson.publishConfig?.registry).toBe("https://npm.pkg.github.com");
+  });
+});
+
+describe("ac-9 — no-op guard: unchanged schema produces no new version", () => {
+  it("decidePublish skips when the published hash matches, publishes otherwise", () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-279/acs/ac-9");
+
+    const currentHash = "abc123def456";
+
+    // Two consecutive runs with the same schema → second run does not publish.
+    expect(decidePublish({ publishedHash: currentHash, currentHash }).publish).toBe(false);
+
+    // Changed schema → publish.
+    expect(decidePublish({ publishedHash: "0000deadbeef", currentHash }).publish).toBe(true);
+
+    // Never published before → first publish.
+    expect(decidePublish({ publishedHash: null, currentHash }).publish).toBe(true);
+  });
+
+  it("computeSchemaHash is deterministic and content-sensitive", () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-279/acs/ac-9");
+
+    const a = computeSchemaHash("export const documents = pgTable('documents', {});");
+    const b = computeSchemaHash("export const documents = pgTable('documents', {});");
+    const c = computeSchemaHash("export const acs = pgTable('acs', {});");
+    expect(a).toBe(b); // same input → same hash
+    expect(a).not.toBe(c); // different input → different hash
+    expect(a).toMatch(/^[0-9a-f]{12}$/);
+  });
+});
+
+describe("ac-2 — fires on the release line and publishes a pinnable, claimable version", () => {
+  it("triggers on push to main + workflow_dispatch and runs the publish script", () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-279/acs/ac-2");
+
+    expect(workflow).toMatch(/branches:\s*\[main\]/);
+    expect(workflow).toContain("workflow_dispatch:");
+    expect(workflow).toContain("packages/db-schema/scripts/publish.mjs");
+  });
+
+  it("uses a claimable scoped name (NOT @memex) and bumps to a valid pinnable semver", () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-279/acs/ac-2");
+
+    // Name is the claimable @mindset-ai scope, not the unavailable @memex (spec-89).
+    expect(pkgJson.name).toBe("@mindset-ai/db-schema");
+    expect(pkgJson.name.startsWith("@memex/")).toBe(false);
+
+    // The version the script publishes is an exact, pinnable semver.
+    expect(bumpPatch("0.1.0")).toBe("0.1.1");
+    expect(bumpPatch("0.1.9")).toBe("0.1.10");
+    expect(() => bumpPatch("not-semver")).toThrow();
+    expect(pkgJson.version).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+});

--- a/packages/db-schema/tsconfig.json
+++ b/packages/db-schema/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts", "tsup.config.ts", "vitest.config.ts"]
+}

--- a/packages/db-schema/tsup.config.ts
+++ b/packages/db-schema/tsup.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from "tsup";
+
+// Build the standalone schema package. esbuild bundles the re-exported schema
+// source (src/index.ts → ../../server/src/db/schema.ts) and rollup-plugin-dts
+// (via `dts: true`) bundles + inlines its type-only cross-file imports, so the
+// emitted dist depends on nothing in the workspace. `drizzle-orm` is the only
+// import kept external — it is a real runtime dependency declared in
+// package.json, not bundled in. spec-279 ac-1/ac-6/ac-7.
+export default defineConfig({
+  entry: { index: "src/index.ts" },
+  format: ["esm"],
+  dts: true,
+  clean: true,
+  sourcemap: true,
+  treeshake: true,
+  // Everything under the drizzle-orm umbrella stays external (drizzle-orm,
+  // drizzle-orm/pg-core, …). Nothing else should be external — the schema
+  // source must be inlined for the package to stand alone.
+  external: [/^drizzle-orm/],
+});

--- a/packages/db-schema/vitest.config.ts
+++ b/packages/db-schema/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "vitest/config";
+
+// AC emission: the setup file wires @memex-ai-ac/vitest so tagAc(...) calls in
+// tests POST pass/fail events to the canonical Memex (mindset-prod → memex.ai).
+// Needs MEMEX_EMIT_KEY in the env; without it emissions are skipped (warn), the
+// suite still runs. spec-279.
+export default defineConfig({
+  test: {
+    setupFiles: ["@memex-ai-ac/vitest/setup"],
+    // Package-build assertions shell out to npm pack/install; give them room.
+    testTimeout: 120_000,
+    hookTimeout: 120_000,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,31 @@ importers:
         specifier: 4.1.1
         version: 4.1.1(@types/node@22.19.15)(jsdom@29.1.1)(vite@6.4.3(@types/node@22.19.15)(jiti@1.21.7)(tsx@4.22.4))
 
+  packages/db-schema:
+    dependencies:
+      drizzle-orm:
+        specifier: ^0.39.0
+        version: 0.39.3(postgres@3.4.9)
+    devDependencies:
+      '@memex-ai-ac/vitest':
+        specifier: workspace:*
+        version: link:../ac-emit-vitest
+      '@types/node':
+        specifier: 22.19.15
+        version: 22.19.15
+      postgres:
+        specifier: ^3.4.5
+        version: 3.4.9
+      tsup:
+        specifier: ^8.3.5
+        version: 8.5.1(jiti@1.21.7)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.7.3)
+      typescript:
+        specifier: ^5.7.0
+        version: 5.7.3
+      vitest:
+        specifier: 4.1.1
+        version: 4.1.1(@types/node@22.19.15)(jsdom@29.1.1)(vite@6.4.3(@types/node@22.19.15)(jiti@1.21.7)(tsx@4.22.4))
+
   packages/extractor:
     dependencies:
       '@memex/server':
@@ -621,6 +646,12 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.28.0':
     resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
     engines: {node: '>=18'}
@@ -641,6 +672,12 @@ packages:
 
   '@esbuild/android-arm64@0.25.12':
     resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -669,6 +706,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-arm@0.28.0':
     resolution: {integrity: sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==}
     engines: {node: '>=18'}
@@ -689,6 +732,12 @@ packages:
 
   '@esbuild/android-x64@0.25.12':
     resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -717,6 +766,12 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.28.0':
     resolution: {integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==}
     engines: {node: '>=18'}
@@ -737,6 +792,12 @@ packages:
 
   '@esbuild/darwin-x64@0.25.12':
     resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -765,6 +826,12 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.28.0':
     resolution: {integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==}
     engines: {node: '>=18'}
@@ -785,6 +852,12 @@ packages:
 
   '@esbuild/freebsd-x64@0.25.12':
     resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -813,6 +886,12 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.28.0':
     resolution: {integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==}
     engines: {node: '>=18'}
@@ -833,6 +912,12 @@ packages:
 
   '@esbuild/linux-arm@0.25.12':
     resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -861,6 +946,12 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.28.0':
     resolution: {integrity: sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==}
     engines: {node: '>=18'}
@@ -881,6 +972,12 @@ packages:
 
   '@esbuild/linux-loong64@0.25.12':
     resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -909,6 +1006,12 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.28.0':
     resolution: {integrity: sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==}
     engines: {node: '>=18'}
@@ -929,6 +1032,12 @@ packages:
 
   '@esbuild/linux-ppc64@0.25.12':
     resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -957,6 +1066,12 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.28.0':
     resolution: {integrity: sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==}
     engines: {node: '>=18'}
@@ -977,6 +1092,12 @@ packages:
 
   '@esbuild/linux-s390x@0.25.12':
     resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -1005,6 +1126,12 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/linux-x64@0.28.0':
     resolution: {integrity: sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==}
     engines: {node: '>=18'}
@@ -1013,6 +1140,12 @@ packages:
 
   '@esbuild/netbsd-arm64@0.25.12':
     resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -1041,6 +1174,12 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.28.0':
     resolution: {integrity: sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==}
     engines: {node: '>=18'}
@@ -1049,6 +1188,12 @@ packages:
 
   '@esbuild/openbsd-arm64@0.25.12':
     resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -1077,6 +1222,12 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openbsd-x64@0.28.0':
     resolution: {integrity: sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==}
     engines: {node: '>=18'}
@@ -1085,6 +1236,12 @@ packages:
 
   '@esbuild/openharmony-arm64@0.25.12':
     resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -1113,6 +1270,12 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/sunos-x64@0.28.0':
     resolution: {integrity: sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==}
     engines: {node: '>=18'}
@@ -1133,6 +1296,12 @@ packages:
 
   '@esbuild/win32-arm64@0.25.12':
     resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -1161,6 +1330,12 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.28.0':
     resolution: {integrity: sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==}
     engines: {node: '>=18'}
@@ -1181,6 +1356,12 @@ packages:
 
   '@esbuild/win32-x64@0.25.12':
     resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -2068,6 +2249,11 @@ packages:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
 
+  acorn@8.17.0:
+    resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
@@ -2204,9 +2390,19 @@ packages:
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
+  bundle-require@5.1.0:
+    resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    peerDependencies:
+      esbuild: '>=0.18'
+
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
@@ -2246,6 +2442,10 @@ packages:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
 
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
+
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
@@ -2277,6 +2477,13 @@ packages:
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
+
+  confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
 
   content-disposition@1.1.0:
     resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
@@ -2635,6 +2842,11 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   esbuild@0.28.0:
     resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
     engines: {node: '>=18'}
@@ -2740,6 +2952,9 @@ packages:
   finalhandler@2.1.1:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
     engines: {node: '>= 18.0.0'}
+
+  fix-dts-default-cjs-exports@1.0.1:
+    resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
 
   flatbuffers@25.9.23:
     resolution: {integrity: sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==}
@@ -3079,6 +3294,10 @@ packages:
   jose@6.2.3:
     resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
 
+  joycon@3.1.1:
+    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
+    engines: {node: '>=10'}
+
   js-binary-schema-parser@2.0.3:
     resolution: {integrity: sha512-xezGJmOb4lk/M1ZZLTR/jaBHQ4gG/lqQnJqdIv4721DMggsa1bDVlHXNeHYogaIEHD9vCRv0fcL4hMA+Coarkg==}
 
@@ -3155,6 +3374,10 @@ packages:
 
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  load-tsconfig@0.2.5:
+    resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   lodash.camelcase@4.3.0:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
@@ -3384,6 +3607,9 @@ packages:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
 
+  mlly@1.8.2:
+    resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -3562,6 +3788,9 @@ packages:
   pkce-challenge@5.0.1:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
     engines: {node: '>=16.20.0'}
+
+  pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
   platform@1.3.6:
     resolution: {integrity: sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==}
@@ -3769,6 +3998,10 @@ packages:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
 
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
+
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
@@ -3801,6 +4034,10 @@ packages:
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
+
+  resolve-from@5.0.0:
+    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
+    engines: {node: '>=8'}
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
@@ -3923,6 +4160,10 @@ packages:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
+  source-map@0.7.6:
+    resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
+    engines: {node: '>= 12'}
+
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
@@ -4019,6 +4260,9 @@ packages:
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
   tinyexec@1.2.4:
     resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
     engines: {node: '>=18'}
@@ -4057,6 +4301,10 @@ packages:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
     engines: {node: '>=20'}
 
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
+
   tree-sitter-wasms@0.1.13:
     resolution: {integrity: sha512-wT+cR6DwaIz80/vho3AvSF0N4txuNx/5bcRKoXouOfClpxh/qqrF4URNLQXbbt8MaAxeksZcZd1j8gcGjc+QxQ==}
 
@@ -4075,6 +4323,25 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  tsup@8.5.1:
+    resolution: {integrity: sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      '@microsoft/api-extractor': ^7.36.0
+      '@swc/core': ^1
+      postcss: ^8.4.12
+      typescript: '>=4.5.0'
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      '@swc/core':
+        optional: true
+      postcss:
+        optional: true
+      typescript:
+        optional: true
+
   tsx@4.22.4:
     resolution: {integrity: sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==}
     engines: {node: '>=18.0.0'}
@@ -4088,6 +4355,9 @@ packages:
     resolution: {integrity: sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  ufo@1.6.4:
+    resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
@@ -4791,6 +5061,9 @@ snapshots:
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
 
+  '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
   '@esbuild/aix-ppc64@0.28.0':
     optional: true
 
@@ -4801,6 +5074,9 @@ snapshots:
     optional: true
 
   '@esbuild/android-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.7':
     optional: true
 
   '@esbuild/android-arm64@0.28.0':
@@ -4815,6 +5091,9 @@ snapshots:
   '@esbuild/android-arm@0.25.12':
     optional: true
 
+  '@esbuild/android-arm@0.27.7':
+    optional: true
+
   '@esbuild/android-arm@0.28.0':
     optional: true
 
@@ -4825,6 +5104,9 @@ snapshots:
     optional: true
 
   '@esbuild/android-x64@0.25.12':
+    optional: true
+
+  '@esbuild/android-x64@0.27.7':
     optional: true
 
   '@esbuild/android-x64@0.28.0':
@@ -4839,6 +5121,9 @@ snapshots:
   '@esbuild/darwin-arm64@0.25.12':
     optional: true
 
+  '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
   '@esbuild/darwin-arm64@0.28.0':
     optional: true
 
@@ -4849,6 +5134,9 @@ snapshots:
     optional: true
 
   '@esbuild/darwin-x64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.7':
     optional: true
 
   '@esbuild/darwin-x64@0.28.0':
@@ -4863,6 +5151,9 @@ snapshots:
   '@esbuild/freebsd-arm64@0.25.12':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.28.0':
     optional: true
 
@@ -4873,6 +5164,9 @@ snapshots:
     optional: true
 
   '@esbuild/freebsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.7':
     optional: true
 
   '@esbuild/freebsd-x64@0.28.0':
@@ -4887,6 +5181,9 @@ snapshots:
   '@esbuild/linux-arm64@0.25.12':
     optional: true
 
+  '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
   '@esbuild/linux-arm64@0.28.0':
     optional: true
 
@@ -4897,6 +5194,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-arm@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.7':
     optional: true
 
   '@esbuild/linux-arm@0.28.0':
@@ -4911,6 +5211,9 @@ snapshots:
   '@esbuild/linux-ia32@0.25.12':
     optional: true
 
+  '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
   '@esbuild/linux-ia32@0.28.0':
     optional: true
 
@@ -4921,6 +5224,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-loong64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.7':
     optional: true
 
   '@esbuild/linux-loong64@0.28.0':
@@ -4935,6 +5241,9 @@ snapshots:
   '@esbuild/linux-mips64el@0.25.12':
     optional: true
 
+  '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
   '@esbuild/linux-mips64el@0.28.0':
     optional: true
 
@@ -4945,6 +5254,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.7':
     optional: true
 
   '@esbuild/linux-ppc64@0.28.0':
@@ -4959,6 +5271,9 @@ snapshots:
   '@esbuild/linux-riscv64@0.25.12':
     optional: true
 
+  '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
   '@esbuild/linux-riscv64@0.28.0':
     optional: true
 
@@ -4969,6 +5284,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-s390x@0.25.12':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.7':
     optional: true
 
   '@esbuild/linux-s390x@0.28.0':
@@ -4983,10 +5301,16 @@ snapshots:
   '@esbuild/linux-x64@0.25.12':
     optional: true
 
+  '@esbuild/linux-x64@0.27.7':
+    optional: true
+
   '@esbuild/linux-x64@0.28.0':
     optional: true
 
   '@esbuild/netbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.7':
     optional: true
 
   '@esbuild/netbsd-arm64@0.28.0':
@@ -5001,10 +5325,16 @@ snapshots:
   '@esbuild/netbsd-x64@0.25.12':
     optional: true
 
+  '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
   '@esbuild/netbsd-x64@0.28.0':
     optional: true
 
   '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.7':
     optional: true
 
   '@esbuild/openbsd-arm64@0.28.0':
@@ -5019,10 +5349,16 @@ snapshots:
   '@esbuild/openbsd-x64@0.25.12':
     optional: true
 
+  '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
   '@esbuild/openbsd-x64@0.28.0':
     optional: true
 
   '@esbuild/openharmony-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.7':
     optional: true
 
   '@esbuild/openharmony-arm64@0.28.0':
@@ -5037,6 +5373,9 @@ snapshots:
   '@esbuild/sunos-x64@0.25.12':
     optional: true
 
+  '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
   '@esbuild/sunos-x64@0.28.0':
     optional: true
 
@@ -5047,6 +5386,9 @@ snapshots:
     optional: true
 
   '@esbuild/win32-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.7':
     optional: true
 
   '@esbuild/win32-arm64@0.28.0':
@@ -5061,6 +5403,9 @@ snapshots:
   '@esbuild/win32-ia32@0.25.12':
     optional: true
 
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
   '@esbuild/win32-ia32@0.28.0':
     optional: true
 
@@ -5071,6 +5416,9 @@ snapshots:
     optional: true
 
   '@esbuild/win32-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
     optional: true
 
   '@esbuild/win32-x64@0.28.0':
@@ -6072,6 +6420,8 @@ snapshots:
       mime-types: 3.0.2
       negotiator: 1.0.0
 
+  acorn@8.17.0: {}
+
   agent-base@6.0.2:
     dependencies:
       debug: 4.4.3
@@ -6212,7 +6562,14 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
+  bundle-require@5.1.0(esbuild@0.27.7):
+    dependencies:
+      esbuild: 0.27.7
+      load-tsconfig: 0.2.5
+
   bytes@3.1.2: {}
+
+  cac@6.7.14: {}
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -6251,6 +6608,10 @@ snapshots:
       readdirp: 3.6.0
     optionalDependencies:
       fsevents: 2.3.3
+
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
 
   cliui@8.0.1:
     dependencies:
@@ -6296,6 +6657,10 @@ snapshots:
   comma-separated-tokens@2.0.3: {}
 
   commander@4.1.1: {}
+
+  confbox@0.1.8: {}
+
+  consola@3.4.2: {}
 
   content-disposition@1.1.0: {}
 
@@ -6607,6 +6972,35 @@ snapshots:
       '@esbuild/win32-ia32': 0.25.12
       '@esbuild/win32-x64': 0.25.12
 
+  esbuild@0.27.7:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
+
   esbuild@0.28.0:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.28.0
@@ -6757,6 +7151,12 @@ snapshots:
       statuses: 2.0.2
     transitivePeerDependencies:
       - supports-color
+
+  fix-dts-default-cjs-exports@1.0.1:
+    dependencies:
+      magic-string: 0.30.21
+      mlly: 1.8.2
+      rollup: 4.61.0
 
   flatbuffers@25.9.23: {}
 
@@ -7148,6 +7548,8 @@ snapshots:
 
   jose@6.2.3: {}
 
+  joycon@3.1.1: {}
+
   js-binary-schema-parser@2.0.3: {}
 
   js-tiktoken@1.0.21:
@@ -7222,6 +7624,8 @@ snapshots:
   lilconfig@3.1.3: {}
 
   lines-and-columns@1.2.4: {}
+
+  load-tsconfig@0.2.5: {}
 
   lodash.camelcase@4.3.0: {}
 
@@ -7649,6 +8053,13 @@ snapshots:
 
   minipass@7.1.3: {}
 
+  mlly@1.8.2:
+    dependencies:
+      acorn: 8.17.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.4
+
   ms@2.1.3: {}
 
   mustache@4.2.0: {}
@@ -7811,6 +8222,12 @@ snapshots:
       tiny-lru: 11.4.7
 
   pkce-challenge@5.0.1: {}
+
+  pkg-types@1.3.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.8.2
+      pathe: 2.0.3
 
   platform@1.3.6: {}
 
@@ -8017,6 +8434,8 @@ snapshots:
     dependencies:
       picomatch: 2.3.2
 
+  readdirp@4.1.2: {}
+
   redent@3.0.0:
     dependencies:
       indent-string: 4.0.0
@@ -8079,6 +8498,8 @@ snapshots:
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
+
+  resolve-from@5.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
 
@@ -8243,6 +8664,8 @@ snapshots:
 
   source-map@0.6.1: {}
 
+  source-map@0.7.6: {}
+
   space-separated-tokens@2.0.2: {}
 
   stackback@0.0.2: {}
@@ -8369,6 +8792,8 @@ snapshots:
 
   tinybench@2.9.0: {}
 
+  tinyexec@0.3.2: {}
+
   tinyexec@1.2.4: {}
 
   tinyglobby@0.2.17:
@@ -8400,6 +8825,8 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  tree-kill@1.2.2: {}
+
   tree-sitter-wasms@0.1.13: {}
 
   trim-lines@3.0.1: {}
@@ -8411,6 +8838,34 @@ snapshots:
   ts-interface-checker@0.1.13: {}
 
   tslib@2.8.1: {}
+
+  tsup@8.5.1(jiti@1.21.7)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.7.3):
+    dependencies:
+      bundle-require: 5.1.0(esbuild@0.27.7)
+      cac: 6.7.14
+      chokidar: 4.0.3
+      consola: 3.4.2
+      debug: 4.4.3
+      esbuild: 0.27.7
+      fix-dts-default-cjs-exports: 1.0.1
+      joycon: 3.1.1
+      picocolors: 1.1.1
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.15)(tsx@4.22.4)
+      resolve-from: 5.0.0
+      rollup: 4.61.0
+      source-map: 0.7.6
+      sucrase: 3.35.1
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.17
+      tree-kill: 1.2.2
+    optionalDependencies:
+      postcss: 8.5.15
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - jiti
+      - supports-color
+      - tsx
+      - yaml
 
   tsx@4.22.4:
     dependencies:
@@ -8425,6 +8880,8 @@ snapshots:
       mime-types: 3.0.2
 
   typescript@5.7.3: {}
+
+  ufo@1.6.4: {}
 
   undici-types@6.21.0: {}
 


### PR DESCRIPTION
## Spec
[spec-279 — Publish the DB schema as a standalone package so the Backstage admin app can consume it](https://memex.ai/mindset-prod/memex-building-itself/specs/spec-279)

## What this does
Builds the production Drizzle schema into a standalone, publishable package (`@mindset-ai/db-schema`) so the out-of-workspace **Backstage** control plane (spec-280) can consume the schema with full types **without forking `schema.ts` or depending on the monorepo**.

The mechanism (dec-1): publish-and-pin to **private GitHub Packages** under the `@mindset-ai` scope, with a CI drift gate so a pinned consumer can never silently run against a stale schema.

## Changes
- **`packages/db-schema`** — re-exports the single source `packages/server/src/db/schema.ts`; **tsup** bundles it (inlining the two cross-file role types) into a self-contained ESM `dist` + `.d.ts` with **zero workspace deps** (only `drizzle-orm`). `schema.ts` is unchanged.
- **`publish-db-schema.yml`** — publishes to GitHub Packages on `main`, authenticating with the **built-in `GITHUB_TOKEN` only** (no extra secret). Content-hash **no-op guard** (`publish-guard.mjs`): unchanged `schema.ts` → no new version.
- **`db-schema-drift.yml` + `drift-gate.mjs`** — migrate a cold pgvector DB, introspect, and **fail CI** when the package declares anything the DB lacks. DB-only objects (pgvector `embedding*`, tsvector `content_tsv`, `manual_migrations`) are an allowed *typed-subset*, not drift.
- **README** — `.npmrc`/`GITHUB_TOKEN` install recipe + the cross-tenant **BYPASSRLS (`memex_admin`)** posture for the consumer.

## Verification — all 11 ACs verified (18 tagged tests, green)
| Task | ACs | Proof |
|---|---|---|
| package | ac-1/4/6/7 | `npm pack` + real install in an empty out-of-workspace project |
| publish | ac-2/8/9 | workflow static-scan (`GITHUB_TOKEN`-only) + guard unit tests |
| drift gate | ac-3/10 | cold-DB migrate → green; dropped schema column → red |
| consumer | ac-5/11 | out-of-workspace install + `tsc` typecheck + live Drizzle query |

Package typecheck clean. The package's full suite is PR-gated via `db-schema-drift.yml`.

## Notes
- **First real publish hasn't run** — the guard/version logic is unit-tested; `npm publish` fires on the first `main` merge. A human still mints the long-lived CI `MEMEX_EMIT_KEY` secret.
- Adds `tsup` + `postgres` as devDeps of the new package only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)