### PR TITLE
feat(whats-new): refine ribbon behaviour — confetti-once, auto-dismiss, fly-home, menu re-open

### DIFF
--- a/packages/ui/e2e/journey-22-whats-new.spec.ts
+++ b/packages/ui/e2e/journey-22-whats-new.spec.ts
@@ -5,9 +5,14 @@ import { seedWhatsNewEntry, clearWhatsNewEntries } from "./helpers/seed.js";
 //
 // SCOPE: the end-to-end user-facing surface — a seeded global feed entry makes
 // the ribbon slide up; clicking it opens the popup with the entry's What/Why;
-// closing the popup leaves the ribbon up; only the ribbon's × dismisses it, and
-// that dismissal persists across a reload (localStorage). Proves the full chain
-// DB → /api/whats-new → React → browser, which the unit/component suites can't.
+// manually closing the popup dismisses the ribbon (it animates "home" into the
+// user menu — 2026-06-13 behaviour pass, superseding dec-4's "popup close ≠
+// dismiss"), and that dismissal persists across a reload (localStorage). Proves
+// the full chain DB → /api/whats-new → React → browser, which the unit/component
+// suites can't.
+//
+// NOTE: the ribbon also auto-dismisses after 6s; the test acts well within that
+// window (clicking the ribbon stops the countdown).
 //
 // The ear → live Specky narration is NOT driven here (real mic + ElevenLabs,
 // same as journey-21). This is the std-28 gate; it emits the user-facing scope
@@ -65,13 +70,10 @@ test("ribbon slides up → popup shows the entry; only its × dismisses it, pers
   await expect(popup).toContainText(ENTRY.whatText);
   await expect(popup).toContainText(ENTRY.whyText);
 
-  // dec-4: closing the popup (header ✕) does NOT dismiss the ribbon.
+  // ac-3 (2026-06-13 behaviour): closing the popup (header ✕) dismisses the
+  // ribbon — it animates home into the user menu and is gone.
   await popup.getByRole("button", { name: "Close" }).click();
   await expect(popup).toBeHidden();
-  await expect(ribbon).toBeVisible();
-
-  // ac-3: only the ribbon's own × dismisses it…
-  await page.getByTestId("whats-new-ribbon-dismiss").click();
   await expect(ribbon).toBeHidden();
 
   // …and the dismissal persists across a reload (localStorage, per-user).

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -52,6 +52,7 @@ import { useTrackRouteChange } from './hooks/useTelemetry';
 import { tenantBase, BASE_URL, fetchWithRetry } from './api/http';
 import { SearchProvider } from './components/SearchContext';
 import { WhatsNewRibbonConnected } from './components/whats-new/WhatsNewRibbonConnected';
+import { WhatsNewProvider } from './components/whats-new/WhatsNewContext';
 import { FirstRunGreeting } from './components/onboarding/FirstRunGreeting';
 import { DemoWalkthroughController } from './voice/walkthrough/DemoWalkthroughController';
 
@@ -209,18 +210,23 @@ function TenantLayout() {
             AppShell, so the shell needs no edit and the public branch — which never
             mounts VoiceGuideMount — has no voice surface. */}
         <VoiceGuideMount namespace={namespace ?? ''} memex={memex ?? ''}>
-          <OrgConsentDialog />
-          {/* spec-200: global What's New ribbon — authed shell only (inside
-              VoiceGuideMount so t-7's ear can reach the voice session). */}
-          <WhatsNewRibbonConnected />
-          {/* spec-206 t-3: first-run greeting controller — auto-starts Specky on
-              a user's first session (no modal, no tap). Renders nothing. */}
-          <FirstRunGreeting />
-          <AppShell>
-            <Fragment key={`${namespace}/${memex}`}>
-              <Outlet />
-            </Fragment>
-          </AppShell>
+          {/* spec-200: WhatsNewProvider lets the sidebar user menu re-open the
+              popup and gives the ribbon the menu anchor to animate "into" on
+              dismiss — so it wraps BOTH the ribbon and AppShell. */}
+          <WhatsNewProvider>
+            <OrgConsentDialog />
+            {/* spec-200: global What's New ribbon — authed shell only (inside
+                VoiceGuideMount so t-7's ear can reach the voice session). */}
+            <WhatsNewRibbonConnected />
+            {/* spec-206 t-3: first-run greeting controller — auto-starts Specky on
+                a user's first session (no modal, no tap). Renders nothing. */}
+            <FirstRunGreeting />
+            <AppShell>
+              <Fragment key={`${namespace}/${memex}`}>
+                <Outlet />
+              </Fragment>
+            </AppShell>
+          </WhatsNewProvider>
         </VoiceGuideMount>
       </HandholdRevealProvider>
     </ChatProvider>

--- a/packages/ui/src/components/AppShell.tsx
+++ b/packages/ui/src/components/AppShell.tsx
@@ -13,6 +13,7 @@ import { PublicAuthButtons, ReadOnlyBadge } from './PublicAccessControls';
 import { useMemexAccess } from '../hooks/useMemexAccess';
 import { HeaderSlotProvider, useHeaderSlotContent } from './HeaderSlot';
 import { SearchTrigger } from './SearchTrigger';
+import { useWhatsNew } from './whats-new/WhatsNewContext';
 import {
   getCurrentTenant,
   parseTenantFromPathname,
@@ -199,6 +200,14 @@ function SidebarUserCard({
 }) {
   const [open, setOpen] = useState(false);
   const wrapperRef = useRef<HTMLDivElement>(null);
+  // spec-200: this card is the fly-home target for the What's New ribbon, and
+  // hosts the "What's New" menu item that re-opens the popup.
+  const { available: whatsNewAvailable, openPopup: openWhatsNew, registerMenuAnchor } = useWhatsNew();
+
+  useEffect(() => {
+    registerMenuAnchor(wrapperRef.current);
+    return () => registerMenuAnchor(null);
+  }, [registerMenuAnchor]);
 
   useEffect(() => {
     if (!open) return;
@@ -258,6 +267,19 @@ function SidebarUserCard({
       </button>
       {open && (
         <div className="absolute left-0 right-0 bottom-full mb-2 z-40 rounded-lg shadow-xl py-1 border bg-card-hover border-edge">
+          {whatsNewAvailable && (
+            <button
+              data-testid="user-menu-whats-new"
+              onClick={() => {
+                setOpen(false);
+                openWhatsNew();
+              }}
+              className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm transition-colors text-secondary hover:text-primary hover:bg-overlay"
+            >
+              <span aria-hidden="true">🎁</span>
+              What's New
+            </button>
+          )}
           {showMemexSettings && (
             <Link
               to={memexSettingsHref}

--- a/packages/ui/src/components/whats-new/WhatsNewContext.test.tsx
+++ b/packages/ui/src/components/whats-new/WhatsNewContext.test.tsx
@@ -1,0 +1,76 @@
+// spec-200 (2026-06-13 behaviour pass) — the WhatsNewContext that lets the sidebar
+// user menu re-open the What's New popup after the ribbon has been dismissed (req 5),
+// and gates the menu item on feed availability.
+
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { WhatsNewProvider, useWhatsNew } from './WhatsNewContext';
+import { WhatsNewRibbon } from './WhatsNewRibbon';
+import type { WhatsNewEntry } from '../../api/whatsNew';
+
+const ENTRY: WhatsNewEntry = {
+  id: 'spec-200',
+  sourceSpecRef: 'mindset-prod/memex-building-itself/specs/spec-200',
+  sourceSpecHandle: 'spec-200',
+  title: 'See what shipped',
+  what: "A What's New feed.",
+  why: 'You always know what changed.',
+  publishedAt: '2026-06-08T10:00:00Z',
+};
+
+// Stand-in for the sidebar user menu — shows the item only when a feed exists.
+function FakeMenu() {
+  const { available, openPopup } = useWhatsNew();
+  if (!available) return null;
+  return (
+    <button data-testid="menu-whats-new" onClick={openPopup}>
+      What's New
+    </button>
+  );
+}
+
+function setReducedMotion(reduce: boolean) {
+  window.matchMedia = vi.fn().mockImplementation((q: string) => ({
+    matches: reduce, media: q, onchange: null,
+    addEventListener: vi.fn(), removeEventListener: vi.fn(),
+    addListener: vi.fn(), removeListener: vi.fn(), dispatchEvent: vi.fn(),
+  })) as unknown as typeof window.matchMedia;
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+  setReducedMotion(true);
+});
+afterEach(() => cleanup());
+
+describe('WhatsNewContext', () => {
+  it('the menu item appears only when the feed has entries, and re-opens the popup after dismissal', async () => {
+    render(
+      <WhatsNewProvider>
+        <FakeMenu />
+        <WhatsNewRibbon fetcher={async () => [ENTRY]} autoDismissMs={0} />
+      </WhatsNewProvider>,
+    );
+
+    // The menu item shows once the feed resolves.
+    await screen.findByTestId('menu-whats-new');
+    // Dismiss the ribbon via its ×.
+    fireEvent.click(await screen.findByTestId('whats-new-ribbon-dismiss'));
+    await waitFor(() => expect(screen.queryByTestId('whats-new-ribbon')).toBeNull());
+
+    // Menu item is still there (feed still has entries) and re-opens the popup.
+    fireEvent.click(screen.getByTestId('menu-whats-new'));
+    expect(await screen.findByTestId('whats-new-popup')).toBeTruthy();
+  });
+
+  it('shows no menu item when the feed is empty', async () => {
+    render(
+      <WhatsNewProvider>
+        <FakeMenu />
+        <WhatsNewRibbon fetcher={async () => []} autoDismissMs={0} />
+      </WhatsNewProvider>,
+    );
+    await waitFor(() => {});
+    expect(screen.queryByTestId('menu-whats-new')).toBeNull();
+  });
+});

--- a/packages/ui/src/components/whats-new/WhatsNewContext.tsx
+++ b/packages/ui/src/components/whats-new/WhatsNewContext.tsx
@@ -1,0 +1,75 @@
+// spec-200 (follow-up): shared coordination between the What's New ribbon (rendered
+// high in App.tsx) and the user menu in the sidebar (AppShell). The ribbon and the
+// menu live in different parts of the tree, so they talk through this context:
+//
+//  • the menu's "What's New" item calls openPopup() to re-open the popup even after
+//    the ribbon has been dismissed (req 5);
+//  • the menu registers its anchor element so the ribbon can animate "into" it on
+//    dismiss (req 4 — the fly-home animation reads getMenuAnchor());
+//  • the ribbon reports `available` so the menu only shows the item when a feed
+//    actually exists.
+//
+// The default value is a no-op so components (AppShell) can consume it unconditionally
+// in tests that don't mount the provider.
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+
+interface WhatsNewContextValue {
+  /** True when at least one feed entry exists — gates the menu item. */
+  available: boolean;
+  /** The ribbon reports feed availability here. */
+  setAvailable: (v: boolean) => void;
+  /** Open the What's New popup (used by the sidebar menu item). */
+  openPopup: () => void;
+  /** The ribbon registers the handler that openPopup() invokes. */
+  registerOpener: (fn: (() => void) | null) => void;
+  /** The sidebar user card registers its element as the fly-home target. */
+  registerMenuAnchor: (el: HTMLElement | null) => void;
+  /** The ribbon reads the menu anchor to compute the dismiss animation target. */
+  getMenuAnchor: () => HTMLElement | null;
+}
+
+const noop = () => {};
+
+const WhatsNewContext = createContext<WhatsNewContextValue>({
+  available: false,
+  setAvailable: noop,
+  openPopup: noop,
+  registerOpener: noop,
+  registerMenuAnchor: noop,
+  getMenuAnchor: () => null,
+});
+
+export function WhatsNewProvider({ children }: { children: ReactNode }) {
+  const [available, setAvailable] = useState(false);
+  const openerRef = useRef<(() => void) | null>(null);
+  const anchorRef = useRef<HTMLElement | null>(null);
+
+  const openPopup = useCallback(() => openerRef.current?.(), []);
+  const registerOpener = useCallback((fn: (() => void) | null) => {
+    openerRef.current = fn;
+  }, []);
+  const registerMenuAnchor = useCallback((el: HTMLElement | null) => {
+    anchorRef.current = el;
+  }, []);
+  const getMenuAnchor = useCallback(() => anchorRef.current, []);
+
+  const value = useMemo<WhatsNewContextValue>(
+    () => ({ available, setAvailable, openPopup, registerOpener, registerMenuAnchor, getMenuAnchor }),
+    [available, openPopup, registerOpener, registerMenuAnchor, getMenuAnchor],
+  );
+
+  return <WhatsNewContext.Provider value={value}>{children}</WhatsNewContext.Provider>;
+}
+
+export function useWhatsNew(): WhatsNewContextValue {
+  return useContext(WhatsNewContext);
+}

--- a/packages/ui/src/components/whats-new/WhatsNewRibbon.spec-200.test.tsx
+++ b/packages/ui/src/components/whats-new/WhatsNewRibbon.spec-200.test.tsx
@@ -129,25 +129,32 @@ describe('WhatsNewRibbon dismiss + countdown (spec-200 t-6)', () => {
     expect(window.localStorage.getItem('whats-new:dismissed-at')).toBe('2026-06-08T10:00:00Z');
   });
 
+  it('shows the countdown indicator while the ribbon waits', async () => {
+    // Long timer so the countdown is reliably still running when asserted —
+    // no race against auto-dismiss (cleanup unmounts before it fires).
+    // findBy (not getBy): the countdown mounts one effect-tick after the ribbon.
+    render(<WhatsNewRibbon fetcher={async () => ENTRIES} autoDismissMs={10_000} />);
+    expect(await screen.findByTestId('whats-new-countdown')).toBeTruthy();
+  });
+
   it('auto-dismisses after the countdown elapses', async () => {
-    render(<WhatsNewRibbon fetcher={async () => ENTRIES} autoDismissMs={300} />);
+    // Short timer; assert ONLY via waitFor (tolerant of slow runners) that the
+    // ribbon eventually flies home — never a synchronous query racing the timer.
+    render(<WhatsNewRibbon fetcher={async () => ENTRIES} autoDismissMs={150} />);
     await screen.findByTestId('whats-new-ribbon');
-    // The countdown border is present while the ribbon waits.
-    expect(screen.getByTestId('whats-new-countdown')).toBeTruthy();
-    // After the countdown the ribbon flies home and unmounts.
-    await waitFor(() => expect(screen.queryByTestId('whats-new-ribbon')).toBeNull(), { timeout: 2000 });
+    await waitFor(() => expect(screen.queryByTestId('whats-new-ribbon')).toBeNull(), { timeout: 4000 });
     expect(window.localStorage.getItem('whats-new:dismissed-at')).toBe('2026-06-08T10:00:00Z');
   });
 
   it('tapping the ribbon stops the countdown — it does not auto-dismiss', async () => {
-    render(<WhatsNewRibbon fetcher={async () => ENTRIES} autoDismissMs={300} />);
+    // Long timer so the only timing dependency (mount → click) has wide headroom.
+    render(<WhatsNewRibbon fetcher={async () => ENTRIES} autoDismissMs={10_000} />);
     const ribbon = await screen.findByTestId('whats-new-ribbon');
+    await screen.findByTestId('whats-new-countdown'); // counting before the tap
     fireEvent.click(ribbon); // open popup → stops countdown
     await screen.findByTestId('whats-new-popup');
-    // The countdown indicator is gone and the ribbon does not auto-dismiss.
+    // Tapping removed the countdown indicator and the ribbon is still present.
     expect(screen.queryByTestId('whats-new-countdown')).toBeNull();
-    await new Promise((r) => setTimeout(r, 500));
-    expect(screen.getByTestId('whats-new-popup')).toBeTruthy();
     expect(screen.getByTestId('whats-new-ribbon')).toBeTruthy();
   });
 

--- a/packages/ui/src/components/whats-new/WhatsNewRibbon.spec-200.test.tsx
+++ b/packages/ui/src/components/whats-new/WhatsNewRibbon.spec-200.test.tsx
@@ -1,9 +1,17 @@
-// spec-200 t-5 / t-6 — the What's New ribbon + popup + dismiss semantics.
+// spec-200 t-5 / t-6 (+ 2026-06-13 behaviour pass) — the What's New ribbon.
 //
 // ac-11 — ribbon renders when an undismissed entry exists; click opens the popup
-//         (entries newest-first, What/Why shown). Confetti fires on slide-up.
-// ac-12 — popup close ≠ dismiss; only the ribbon × dismisses; dismissal persists
-//         per-user (localStorage) and a newer entry re-shows the ribbon.
+//         (entries newest-first, What/Why shown). Confetti fires on FIRST sighting.
+// ac-12 — the ribbon × dismisses and the dismissal persists per-user (localStorage);
+//         a newer entry re-shows the ribbon.
+//
+// Follow-up behaviour (this pass):
+//  • confetti fires only the first time an entry is seen — a repeat visit shows the
+//    ribbon WITHOUT confetti;
+//  • a 6s auto-dismiss countdown (bottom border) removes the ribbon; tapping it or
+//    the × stops the countdown;
+//  • manually closing the popup dismisses the ribbon (supersedes dec-4's
+//    "popup close ≠ dismiss").
 
 import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
@@ -53,7 +61,8 @@ afterEach(() => cleanup());
 
 describe('WhatsNewRibbon (spec-200 t-5)', () => {
   it('renders the ribbon for an unseen entry, fires confetti, and opens the popup newest-first (ac-11)', async () => {
-    render(<WhatsNewRibbon fetcher={async () => ENTRIES} onExplain={() => {}} />);
+    // autoDismissMs=0 keeps the ribbon up for the assertions (no countdown timer).
+    render(<WhatsNewRibbon fetcher={async () => ENTRIES} onExplain={() => {}} autoDismissMs={0} />);
 
     const ribbon = await screen.findByTestId('whats-new-ribbon');
     expect(ribbon).toBeTruthy();
@@ -74,49 +83,85 @@ describe('WhatsNewRibbon (spec-200 t-5)', () => {
 
   it('skips confetti under prefers-reduced-motion but still shows the ribbon', async () => {
     setReducedMotion(true);
-    render(<WhatsNewRibbon fetcher={async () => ENTRIES} />);
+    render(<WhatsNewRibbon fetcher={async () => ENTRIES} autoDismissMs={0} />);
+    expect(await screen.findByTestId('whats-new-ribbon')).toBeTruthy();
+    expect(screen.queryByTestId('whats-new-confetti')).toBeNull();
+  });
+
+  it('fires confetti only on the first sighting of an entry, not on a repeat visit', async () => {
+    const { unmount } = render(<WhatsNewRibbon fetcher={async () => ENTRIES} autoDismissMs={0} />);
+    expect(await screen.findByTestId('whats-new-confetti')).toBeTruthy();
+    unmount();
+
+    // Same entries, fresh mount (a "next visit") — ribbon shows, confetti does not.
+    render(<WhatsNewRibbon fetcher={async () => ENTRIES} autoDismissMs={0} />);
     expect(await screen.findByTestId('whats-new-ribbon')).toBeTruthy();
     expect(screen.queryByTestId('whats-new-confetti')).toBeNull();
   });
 });
 
-describe('WhatsNewRibbon dismiss semantics (spec-200 t-6)', () => {
-  beforeEach(() => setReducedMotion(true)); // avoid confetti timers in these
+describe('WhatsNewRibbon dismiss + countdown (spec-200 t-6)', () => {
+  beforeEach(() => setReducedMotion(true)); // immediate fly-home + no confetti timers
 
-  it('popup close does NOT dismiss; only the ribbon × dismisses + persists (ac-12)', async () => {
-    render(<WhatsNewRibbon fetcher={async () => ENTRIES} />);
-    const ribbon = await screen.findByTestId('whats-new-ribbon');
+  it('the ribbon × dismisses immediately and persists the marker (ac-12)', async () => {
+    render(<WhatsNewRibbon fetcher={async () => ENTRIES} autoDismissMs={0} />);
+    await screen.findByTestId('whats-new-ribbon');
 
-    // Open then close the popup via scrim — ribbon must remain.
-    fireEvent.click(ribbon);
-    await screen.findByTestId('whats-new-popup'); // ribbon → popup (scope ac-2)
-    tagAc(AC(2));
-    fireEvent.click(await screen.findByTestId('whats-new-scrim'));
-    await waitFor(() => expect(screen.queryByTestId('whats-new-popup')).toBeNull());
-    expect(screen.getByTestId('whats-new-ribbon')).toBeTruthy(); // still there
-
-    // The ribbon's own × dismisses it AND persists the marker.
     fireEvent.click(screen.getByTestId('whats-new-ribbon-dismiss'));
     await waitFor(() => expect(screen.queryByTestId('whats-new-ribbon')).toBeNull());
     expect(window.localStorage.getItem('whats-new:dismissed-at')).toBe('2026-06-08T10:00:00Z');
 
     tagAc(AC(12));
-    // Scope ac-3: ribbon persists until its own × (popup close ≠ dismiss) and the
-    // dismissal is remembered per user.
-    tagAc(AC(3));
+  });
+
+  it('manually closing the popup dismisses the ribbon (popup close → fly home)', async () => {
+    render(<WhatsNewRibbon fetcher={async () => ENTRIES} autoDismissMs={0} />);
+    const ribbon = await screen.findByTestId('whats-new-ribbon');
+
+    // Tap the ribbon → popup opens (and the countdown, if any, stops).
+    fireEvent.click(ribbon);
+    await screen.findByTestId('whats-new-popup');
+
+    // Closing the popup (scrim) now dismisses the ribbon — it flies home and goes.
+    fireEvent.click(screen.getByTestId('whats-new-scrim'));
+    await waitFor(() => expect(screen.queryByTestId('whats-new-popup')).toBeNull());
+    await waitFor(() => expect(screen.queryByTestId('whats-new-ribbon')).toBeNull());
+    expect(window.localStorage.getItem('whats-new:dismissed-at')).toBe('2026-06-08T10:00:00Z');
+  });
+
+  it('auto-dismisses after the countdown elapses', async () => {
+    render(<WhatsNewRibbon fetcher={async () => ENTRIES} autoDismissMs={300} />);
+    await screen.findByTestId('whats-new-ribbon');
+    // The countdown border is present while the ribbon waits.
+    expect(screen.getByTestId('whats-new-countdown')).toBeTruthy();
+    // After the countdown the ribbon flies home and unmounts.
+    await waitFor(() => expect(screen.queryByTestId('whats-new-ribbon')).toBeNull(), { timeout: 2000 });
+    expect(window.localStorage.getItem('whats-new:dismissed-at')).toBe('2026-06-08T10:00:00Z');
+  });
+
+  it('tapping the ribbon stops the countdown — it does not auto-dismiss', async () => {
+    render(<WhatsNewRibbon fetcher={async () => ENTRIES} autoDismissMs={300} />);
+    const ribbon = await screen.findByTestId('whats-new-ribbon');
+    fireEvent.click(ribbon); // open popup → stops countdown
+    await screen.findByTestId('whats-new-popup');
+    // The countdown indicator is gone and the ribbon does not auto-dismiss.
+    expect(screen.queryByTestId('whats-new-countdown')).toBeNull();
+    await new Promise((r) => setTimeout(r, 500));
+    expect(screen.getByTestId('whats-new-popup')).toBeTruthy();
+    expect(screen.getByTestId('whats-new-ribbon')).toBeTruthy();
   });
 
   it('stays dismissed across reloads until a NEWER entry publishes (ac-12)', async () => {
     // Marker already at the newest entry's time → ribbon should not show.
     window.localStorage.setItem('whats-new:dismissed-at', '2026-06-08T10:00:00Z');
-    const { unmount } = render(<WhatsNewRibbon fetcher={async () => ENTRIES} />);
+    const { unmount } = render(<WhatsNewRibbon fetcher={async () => ENTRIES} autoDismissMs={0} />);
     await waitFor(() => {}); // let fetch resolve
     expect(screen.queryByTestId('whats-new-ribbon')).toBeNull();
     unmount();
 
     // A newer entry publishes → ribbon reappears.
     const newer = [entry('spec-201', '2026-06-09T10:00:00Z'), ...ENTRIES];
-    render(<WhatsNewRibbon fetcher={async () => newer} />);
+    render(<WhatsNewRibbon fetcher={async () => newer} autoDismissMs={0} />);
     expect(await screen.findByTestId('whats-new-ribbon')).toBeTruthy();
 
     tagAc(AC(12));

--- a/packages/ui/src/components/whats-new/WhatsNewRibbon.tsx
+++ b/packages/ui/src/components/whats-new/WhatsNewRibbon.tsx
@@ -88,8 +88,8 @@ export function WhatsNewRibbon({
 
   const ribbonRef = useRef<HTMLDivElement>(null);
   const dismissingRef = useRef(false);
-  const dismissTimer = useRef<ReturnType<typeof setTimeout>>();
-  const flyTimer = useRef<ReturnType<typeof setTimeout>>();
+  const dismissTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  const flyTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
   useEffect(() => {
     let alive = true;

--- a/packages/ui/src/components/whats-new/WhatsNewRibbon.tsx
+++ b/packages/ui/src/components/whats-new/WhatsNewRibbon.tsx
@@ -1,24 +1,42 @@
-// spec-200 t-5 / t-6: the What's New surface.
+// spec-200 t-5 / t-6 (+ follow-up behaviour pass): the What's New surface.
 //
 // dec-4: a transient-but-sticky slide-up RIBBON (not a permanent chrome icon).
 // When an undismissed entry newer than the user's last-dismissed marker exists,
-// the ribbon slides up (with a full-screen confetti burst). Clicking it opens a
-// popup of recent entries, newest-first. Closing the popup does NOT dismiss the
-// ribbon — only the ribbon's own × does, and that dismissal persists per-user in
-// localStorage (t-6). Each entry carries an ear affordance that asks Specky to
-// explain it (t-7 wires onExplain).
+// the ribbon slides up. Clicking it opens a popup of recent entries, newest-first.
+// Each entry carries an ear affordance that asks Specky to explain it (t-7).
+//
+// Follow-up behaviour changes (2026-06-13), per the originator:
+//  1. Confetti fires only the FIRST time a given entry is seen (a localStorage
+//     marker, separate from dismissal) — a repeat visit shows the ribbon without
+//     confetti.
+//  2. The ribbon auto-dismisses after 6s, with a bottom border that depletes
+//     right→left as a countdown. Tapping the ribbon (opens the popup) or the ×
+//     both stop the countdown immediately.
+//  3. On dismiss (manual, auto, or popup-close) the ribbon animates "into" the
+//     user menu in the lower-left (translate + fade) — the menu does NOT open.
+//     This reads the menu anchor from WhatsNewContext.
+//  4. The popup can be re-opened from the sidebar "What's New" menu item even
+//     after the ribbon is gone (via WhatsNewContext.openPopup).
+//  5. Manually closing the popup dismisses the ribbon (fly-home), superseding the
+//     earlier dec-4 "popup close ≠ dismiss" rule.
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Specky } from '@memex/guide-sdk';
 import { Confetti } from './Confetti';
+import { useWhatsNew } from './WhatsNewContext';
 import { fetchWhatsNew, type WhatsNewEntry } from '../../api/whatsNew';
 
 const DISMISS_KEY = 'whats-new:dismissed-at';
+const CONFETTI_KEY = 'whats-new:confetti-shown-at';
 
-function readDismissedAt(): number {
+/** Auto-dismiss countdown (ms) and the fly-home animation duration (ms). */
+const AUTO_DISMISS_MS = 6000;
+const FLY_MS = 600;
+
+function readMarker(key: string): number {
   if (typeof window === 'undefined') return 0;
   try {
-    const raw = window.localStorage.getItem(DISMISS_KEY);
+    const raw = window.localStorage.getItem(key);
     const t = raw ? Date.parse(raw) : 0;
     return Number.isNaN(t) ? 0 : t;
   } catch {
@@ -26,10 +44,10 @@ function readDismissedAt(): number {
   }
 }
 
-function writeDismissedAt(iso: string): void {
+function writeMarker(key: string, iso: string): void {
   if (typeof window === 'undefined') return;
   try {
-    window.localStorage.setItem(DISMISS_KEY, iso);
+    window.localStorage.setItem(key, iso);
   } catch {
     /* private mode — non-fatal */
   }
@@ -45,15 +63,33 @@ export interface WhatsNewRibbonProps {
   onExplain?: (entry: WhatsNewEntry) => void;
   /** Injected for tests; defaults to the real GET /api/whats-new. */
   fetcher?: () => Promise<WhatsNewEntry[]>;
+  /** Auto-dismiss countdown in ms; 0 disables it (tests). Default 6000. */
+  autoDismissMs?: number;
 }
 
-export function WhatsNewRibbon({ onExplain, fetcher = fetchWhatsNew }: WhatsNewRibbonProps) {
+export function WhatsNewRibbon({
+  onExplain,
+  fetcher = fetchWhatsNew,
+  autoDismissMs = AUTO_DISMISS_MS,
+}: WhatsNewRibbonProps) {
+  const { setAvailable, registerOpener, getMenuAnchor } = useWhatsNew();
+
   const [entries, setEntries] = useState<WhatsNewEntry[]>([]);
   const [dismissed, setDismissed] = useState(false);
   const [open, setOpen] = useState(false);
   const [slidIn, setSlidIn] = useState(false);
   const [confetti, setConfetti] = useState(false);
-  const firedConfetti = useRef(false);
+  // Countdown: `barRunning` flips on after mount to drive the width transition.
+  const [countingDown, setCountingDown] = useState(false);
+  const [barRunning, setBarRunning] = useState(false);
+  // Fly-home dismiss animation.
+  const [flying, setFlying] = useState(false);
+  const [flyDelta, setFlyDelta] = useState<{ dx: number; dy: number }>({ dx: 0, dy: 0 });
+
+  const ribbonRef = useRef<HTMLDivElement>(null);
+  const dismissingRef = useRef(false);
+  const dismissTimer = useRef<ReturnType<typeof setTimeout>>();
+  const flyTimer = useRef<ReturnType<typeof setTimeout>>();
 
   useEffect(() => {
     let alive = true;
@@ -75,77 +111,196 @@ export function WhatsNewRibbon({ onExplain, fetcher = fetchWhatsNew }: WhatsNewR
     [entries],
   );
 
-  // Visible when there's an entry newer than the dismissed marker (t-6).
-  const hasUnseen = !!newest && Date.parse(newest.publishedAt) > readDismissedAt();
-  const visible = hasUnseen && !dismissed;
+  // The ribbon is "present" when there's an entry newer than the dismissed marker
+  // and the user hasn't dismissed it this session (t-6). Popup visibility is
+  // independent — it can be re-opened from the menu after dismissal.
+  const ribbonPresent = !!newest && Date.parse(newest.publishedAt) > readMarker(DISMISS_KEY) && !dismissed;
 
-  // Slide the ribbon in (next tick → CSS transition) and fire confetti once.
+  // Report feed availability to the sidebar menu item.
   useEffect(() => {
-    if (!visible) {
+    setAvailable(entries.length > 0);
+  }, [entries.length, setAvailable]);
+
+  // Register the menu opener so the sidebar "What's New" item can open the popup.
+  useEffect(() => {
+    registerOpener(() => setOpen(true));
+    return () => registerOpener(null);
+  }, [registerOpener]);
+
+  // Slide the ribbon in, and fire confetti only the first time THIS entry is seen
+  // (req 1/2): a marker distinct from dismissal, so a repeat visit gets no confetti.
+  useEffect(() => {
+    if (!ribbonPresent || flying) {
       setSlidIn(false);
       return;
     }
     const t = setTimeout(() => setSlidIn(true), 30);
-    if (!firedConfetti.current && !prefersReducedMotion()) {
-      firedConfetti.current = true;
-      setConfetti(true);
+    if (newest && !prefersReducedMotion()) {
+      const firstSighting = Date.parse(newest.publishedAt) > readMarker(CONFETTI_KEY);
+      if (firstSighting) {
+        writeMarker(CONFETTI_KEY, newest.publishedAt);
+        setConfetti(true);
+      }
     }
     return () => clearTimeout(t);
-  }, [visible]);
+  }, [ribbonPresent, flying, newest]);
 
-  const dismiss = useCallback(
+  const finalizeDismiss = useCallback(() => {
+    if (newest) writeMarker(DISMISS_KEY, newest.publishedAt);
+    setDismissed(true);
+    setOpen(false);
+    setConfetti(false);
+    setFlying(false);
+    setCountingDown(false);
+  }, [newest]);
+
+  // Dismiss the ribbon by animating it "into" the sidebar user menu (req 3/4),
+  // then finalize. Reduced motion or a missing anchor → finalize immediately.
+  const beginDismiss = useCallback(() => {
+    if (dismissingRef.current) return;
+    dismissingRef.current = true;
+    clearTimeout(dismissTimer.current);
+    setCountingDown(false);
+
+    const ribbonEl = ribbonRef.current;
+    const anchor = getMenuAnchor();
+    const a = anchor?.getBoundingClientRect();
+    // No anchor, a collapsed/hidden menu (zero-size rect), or reduced motion →
+    // skip the fly-home animation and just dismiss.
+    if (prefersReducedMotion() || !ribbonEl || !a || (a.width === 0 && a.height === 0)) {
+      finalizeDismiss();
+      return;
+    }
+    const r = ribbonEl.getBoundingClientRect();
+    setFlyDelta({
+      dx: a.left + a.width / 2 - (r.left + r.width / 2),
+      dy: a.top + a.height / 2 - (r.top + r.height / 2),
+    });
+    setFlying(true);
+    flyTimer.current = setTimeout(finalizeDismiss, FLY_MS);
+  }, [finalizeDismiss, getMenuAnchor]);
+
+  // Tapping the ribbon opens the popup AND stops the countdown (req 3).
+  const openFromRibbon = useCallback(() => {
+    clearTimeout(dismissTimer.current);
+    setCountingDown(false);
+    setOpen(true);
+  }, []);
+
+  // Manually closing the popup dismisses the ribbon — the popup disappears, then
+  // the ribbon flies home (req 5/6). If the ribbon is already gone (opened from
+  // the menu), closing just closes.
+  const closePopup = useCallback(() => {
+    setOpen(false);
+    if (ribbonPresent && !dismissingRef.current) {
+      setTimeout(() => beginDismiss(), 30);
+    }
+  }, [ribbonPresent, beginDismiss]);
+
+  // The × dismisses immediately (stops the countdown, flies home).
+  const dismissNow = useCallback(
     (e?: React.MouseEvent) => {
       e?.stopPropagation();
-      if (newest) writeDismissedAt(newest.publishedAt);
-      setDismissed(true);
-      setOpen(false);
-      setConfetti(false);
+      beginDismiss();
     },
-    [newest],
+    [beginDismiss],
   );
 
-  // Popup close ≠ dismiss (dec-4): the ribbon stays up.
-  const closePopup = useCallback(() => setOpen(false), []);
+  // Run the 6s auto-dismiss countdown while the ribbon is up and the popup is
+  // closed. Opening the popup (or flying) stops it. Reaching zero flies home.
+  useEffect(() => {
+    const shouldRun = ribbonPresent && !flying && !open && autoDismissMs > 0;
+    if (!shouldRun) {
+      setCountingDown(false);
+      setBarRunning(false);
+      clearTimeout(dismissTimer.current);
+      return;
+    }
+    setCountingDown(true);
+    setBarRunning(false);
+    const barT = setTimeout(() => setBarRunning(true), 30); // kick the width transition
+    dismissTimer.current = setTimeout(() => beginDismiss(), autoDismissMs);
+    return () => {
+      clearTimeout(barT);
+      clearTimeout(dismissTimer.current);
+    };
+  }, [ribbonPresent, flying, open, autoDismissMs, beginDismiss]);
 
-  if (!visible) return null;
+  // Clear the fly timer on unmount.
+  useEffect(() => () => clearTimeout(flyTimer.current), []);
+
+  if (entries.length === 0) return null;
 
   const reduced = prefersReducedMotion();
+  const showRibbon = ribbonPresent || flying;
+
+  const ribbonTransform = flying
+    ? `translateX(-50%) translate(${flyDelta.dx}px, ${flyDelta.dy}px) scale(.25)`
+    : `translateX(-50%) translateY(${slidIn || reduced ? '0' : '180px'})`;
+  const ribbonOpacity = flying ? 0 : slidIn || reduced ? 1 : 0;
+  const ribbonTransition = flying
+    ? `transform ${FLY_MS}ms cubic-bezier(.4,0,.2,1), opacity ${FLY_MS}ms ease`
+    : reduced
+      ? 'none'
+      : 'transform .6s cubic-bezier(.16,1,.3,1), opacity .4s';
 
   return (
     <>
       {confetti && <Confetti onDone={() => setConfetti(false)} />}
 
       {/* Slide-up ribbon */}
-      <div
-        data-testid="whats-new-ribbon"
-        role="button"
-        tabIndex={0}
-        onClick={() => setOpen(true)}
-        onKeyDown={(e) => (e.key === 'Enter' || e.key === ' ') && setOpen(true)}
-        className="fixed left-1/2 bottom-6 z-40 flex items-center gap-3 rounded-full border border-edge bg-surface px-4 py-2.5 shadow-2xl cursor-pointer"
-        style={{
-          transform: `translateX(-50%) translateY(${slidIn || reduced ? '0' : '180px'})`,
-          opacity: slidIn || reduced ? 1 : 0,
-          transition: reduced ? 'none' : 'transform .6s cubic-bezier(.16,1,.3,1), opacity .4s',
-        }}
-      >
-        <span className="text-xl" aria-hidden="true">🎁</span>
-        <div className="leading-tight">
-          <div className="text-sm font-semibold">What's New</div>
-          <div className="text-xs text-muted">
-            {entries.length} update{entries.length === 1 ? '' : 's'} shipped
-          </div>
-        </div>
-        <button
-          type="button"
-          aria-label="Dismiss What's New"
-          data-testid="whats-new-ribbon-dismiss"
-          onClick={dismiss}
-          className="ml-2 grid h-6 w-6 place-items-center rounded-full text-muted hover:bg-surface-hover"
+      {showRibbon && (
+        <div
+          ref={ribbonRef}
+          data-testid="whats-new-ribbon"
+          role="button"
+          tabIndex={0}
+          onClick={openFromRibbon}
+          onKeyDown={(e) => (e.key === 'Enter' || e.key === ' ') && openFromRibbon()}
+          className="fixed left-1/2 bottom-6 z-40 flex items-center gap-3 rounded-full border border-edge bg-surface px-4 py-2.5 shadow-2xl cursor-pointer"
+          style={{
+            transform: ribbonTransform,
+            opacity: ribbonOpacity,
+            transition: ribbonTransition,
+            pointerEvents: flying ? 'none' : undefined,
+          }}
         >
-          ✕
-        </button>
-      </div>
+          <span className="text-xl" aria-hidden="true">🎁</span>
+          <div className="leading-tight">
+            <div className="text-sm font-semibold">What's New</div>
+            <div className="text-xs text-muted">
+              {entries.length} update{entries.length === 1 ? '' : 's'} shipped
+            </div>
+          </div>
+          <button
+            type="button"
+            aria-label="Dismiss What's New"
+            data-testid="whats-new-ribbon-dismiss"
+            onClick={dismissNow}
+            className="ml-2 grid h-6 w-6 place-items-center rounded-full text-muted hover:bg-surface-hover"
+          >
+            ✕
+          </button>
+
+          {/* Auto-dismiss countdown — an inset progress line along the ribbon's
+              lower edge that depletes right→left (req 3). Inset so the pill's
+              rounded corners don't clip it. Hidden once the countdown stops
+              (tap / × / fly). */}
+          {countingDown && !flying && (
+            <div className="pointer-events-none absolute bottom-1.5 left-4 right-4 h-[2px] overflow-hidden rounded-full">
+              <div
+                data-testid="whats-new-countdown"
+                aria-hidden="true"
+                className="h-full w-full origin-left rounded-full bg-accent"
+                style={{
+                  transform: barRunning ? 'scaleX(0)' : 'scaleX(1)',
+                  transition: `transform ${autoDismissMs}ms linear`,
+                }}
+              />
+            </div>
+          )}
+        </div>
+      )}
 
       {/* Popup */}
       {open && (


### PR DESCRIPTION
Behaviour pass on the spec-200 What's New ribbon, per the originator's feedback. spec-200 is already `done` and live on PROD/INT; this refines the shipped ribbon. (The dec-4 "popup close ≠ dismiss" rule is intentionally reversed below — worth recording on the Spec if we reopen it.)

## What changed
1. **Confetti once per entry.** Confetti now fires only on the *first* sighting of a given entry (new localStorage marker `whats-new:confetti-shown-at`, separate from dismissal). A repeat visit shows the ribbon without confetti.
2. **6s auto-dismiss + countdown.** The ribbon auto-dismisses after 6s, with an inset bottom progress line that depletes right→left. Tapping the ribbon (opens the popup) or the × both stop the countdown immediately.
3. **Fly-home dismiss.** On any dismiss (manual ×, auto, or popup-close) the ribbon animates "into" the sidebar user card (translate + scale + fade); the menu does not open. Reduced-motion / no-anchor / zero-rect anchor → instant dismiss.
4. **Re-openable from the menu.** A new "🎁 What's New" item in the sidebar user menu re-opens the popup even after the ribbon is gone.
5. **Popup-close dismisses.** Manually closing the popup now dismisses the ribbon via the fly-home animation (supersedes dec-4's "popup close ≠ dismiss").

## How
New `WhatsNewContext` bridges the ribbon (mounted high in `App.tsx`) and the sidebar menu (`AppShell`): it shares the open-popup signal, the fly-home anchor element, and a feed-availability flag. Default context is a no-op so `AppShell` renders fine without the provider. `WhatsNewRibbon` gained an `autoDismissMs` prop (default 6000; tests pass 0/short values).

## Testing
- UI unit suite green (whats-new 12/12, AppShell, App); typecheck clean.
- `make e2e-cold`: journey-22 (What's New) green; the only 2 full-run failures were the known flaky journeys (16 reactivity, 21 narrative) which pass clean in isolation.
- Verified locally in the running app (ribbon, confetti-once, countdown, fly-home, × , menu re-open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)