### PR TITLE
fix(smoke): warm the host before post-deploy smoke + retry once (std-17)

### DIFF
--- a/packages/server/src/__smoke__/warmup.global-setup.ts
+++ b/packages/server/src/__smoke__/warmup.global-setup.ts
@@ -1,0 +1,64 @@
+// Post-deploy smoke warm-up (std-17 / spec-243 smoke robustness).
+//
+// The smoke suite runs immediately after a new Cloud Run revision rolls. The
+// FIRST real request hits a cold instance and can take well over the 30s test
+// timeout — which is exactly how the authed MCP journeys (create→read→delete,
+// section lifecycle over /mcp) intermittently timed out and reddened an
+// otherwise-fine deploy (e.g. the spec-278 merge: tests green, deploy red purely
+// on cold-start smoke timeouts).
+//
+// This globalSetup runs ONCE before any smoke test: it wakes the instance and
+// waits until it answers fast, so the timed journeys don't pay the cold start.
+// `retry: 1` in vitest.smoke.config.ts is the backstop for the rare case where a
+// single warm-up pass isn't enough (or the instance scaled back down).
+
+import { SMOKE_BASE_URL } from "./smoke-env.js";
+
+const WARMUP_BUDGET_MS = 120_000; // total time we'll spend waking + warming
+const PER_REQUEST_MS = 35_000; // generous: a cold instance can take >30s to first-respond
+const WARM_THRESHOLD_MS = 3_000; // a health response under this = instance is hot
+const POLL_GAP_MS = 2_000;
+
+async function probe(path: string): Promise<{ ok: boolean; ms: number; status: number }> {
+  const t0 = Date.now();
+  try {
+    const res = await fetch(`${SMOKE_BASE_URL}${path}`, {
+      signal: AbortSignal.timeout(PER_REQUEST_MS),
+    });
+    return { ok: true, ms: Date.now() - t0, status: res.status };
+  } catch {
+    return { ok: false, ms: Date.now() - t0, status: 0 };
+  }
+}
+
+export default async function warmup(): Promise<void> {
+  // Targeting a local dev server has no cold start — skip so a bare
+  // `vitest --config vitest.smoke.config.ts` against localhost stays instant.
+  if (/localhost|127\.0\.0\.1/.test(SMOKE_BASE_URL)) return;
+
+  const deadline = Date.now() + WARMUP_BUDGET_MS;
+  let warm = false;
+  while (Date.now() < deadline) {
+    // The first call may be the slow cold one (it wakes the instance); a later
+    // call returning fast confirms the instance is hot for the imminent journeys.
+    const health = await probe("/api/health");
+    if (health.ok && health.status === 200 && health.ms < WARM_THRESHOLD_MS) {
+      warm = true;
+      console.log(`[smoke-warmup] ${SMOKE_BASE_URL} warm (health 200 in ${health.ms}ms) — running smoke.`);
+      break;
+    }
+    console.log(
+      `[smoke-warmup] ${SMOKE_BASE_URL} not hot yet (health ${health.status} in ${health.ms}ms) — waiting…`,
+    );
+    await new Promise((r) => setTimeout(r, POLL_GAP_MS));
+  }
+  // Also nudge the /mcp route — an unauthenticated 401 is fine; it still warms
+  // that handler/SSE path, which the authed MCP journeys exercise next.
+  await probe("/mcp");
+  if (!warm) {
+    console.log(
+      `[smoke-warmup] ${SMOKE_BASE_URL} did not confirm hot within ${WARMUP_BUDGET_MS}ms — ` +
+        `running smoke anyway (retry:1 is the backstop). A persistently slow host is a real signal.`,
+    );
+  }
+}

--- a/packages/server/vitest.smoke.config.ts
+++ b/packages/server/vitest.smoke.config.ts
@@ -18,6 +18,10 @@ export default defineConfig({
     // default vitest.config.ts. Needs MEMEX_EMIT_KEY in env to actually land —
     // the default smoke run (no key) just no-ops the emission per the helper.
     setupFiles: ["@memex-ai-ac/vitest/setup"],
+    // Wake + warm the freshly-deployed host ONCE before any test, so the timed
+    // MCP journeys don't pay Cloud Run cold-start latency (>30s) and time out.
+    // See warmup.global-setup.ts (std-17 / spec-243 smoke robustness).
+    globalSetup: ["./src/__smoke__/warmup.global-setup.ts"],
     // Live HTTP round-trips against a shared host — keep ordering deterministic
     // (the authed tier's create→read→delete journey is sequential).
     fileParallelism: false,
@@ -26,5 +30,9 @@ export default defineConfig({
     // The live host can be slow on a cold Cloud Run instance right after deploy.
     testTimeout: 30_000,
     hookTimeout: 30_000,
+    // Backstop to the warm-up: if a single test still trips the timeout on a cold
+    // first hit, retry once — by then the instance is warm. A genuine outage fails
+    // both attempts and still reds the smoke (no masking).
+    retry: 1,
   },
 });


### PR DESCRIPTION
## Why

Post-deploy smoke (std-17) runs immediately after a new Cloud Run revision rolls. The **first** real request hits a cold instance and can exceed the 30s test timeout — so the authed MCP journeys (`create→read→delete`, `section lifecycle over /mcp`) intermittently time out and **red an otherwise-green deploy**. Concrete case: the spec-278 merge — `test` workflow green, `deploy` red purely on cold-start smoke timeouts; int was healthy minutes later and the smoke passed clean on re-run.

## Fix

- **`warmup.global-setup.ts`** — runs ONCE before any smoke test: wakes the host and polls `/api/health` until it answers fast (`< 3s`, budget 120s), then nudges `/mcp` (a 401 still warms that handler). Skips for `localhost` targets so a local `vitest --config vitest.smoke.config.ts` stays instant.
- **`retry: 1`** in `vitest.smoke.config.ts` — backstop if a single test still trips a cold first hit; by the retry the instance is warm. A genuine outage fails **both** attempts and still reds the smoke — no masking.

## Verification

- `node --experimental-strip-types --check` on the new globalSetup — clean.
- ⚠️ **Not exercised by per-PR CI** — the smoke suite is post-deploy only (excluded from the default vitest run). Real verification is the **next deploy's smoke** against int. Low-risk: harness-only, no product code.

## Notes
- std-17 / spec-243 smoke robustness; independent of any feature work.
- `testTimeout` left at 30s deliberately — the warm-up removes the cold-start cause rather than masking slowness with a bigger timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)