### PR TITLE
release: promote develop → main (spec-282 UI + spec-200 ribbon + smoke fix)

### DIFF
--- a/packages/server/src/__smoke__/warmup.global-setup.ts
+++ b/packages/server/src/__smoke__/warmup.global-setup.ts
@@ -1,0 +1,64 @@
+// Post-deploy smoke warm-up (std-17 / spec-243 smoke robustness).
+//
+// The smoke suite runs immediately after a new Cloud Run revision rolls. The
+// FIRST real request hits a cold instance and can take well over the 30s test
+// timeout — which is exactly how the authed MCP journeys (create→read→delete,
+// section lifecycle over /mcp) intermittently timed out and reddened an
+// otherwise-fine deploy (e.g. the spec-278 merge: tests green, deploy red purely
+// on cold-start smoke timeouts).
+//
+// This globalSetup runs ONCE before any smoke test: it wakes the instance and
+// waits until it answers fast, so the timed journeys don't pay the cold start.
+// `retry: 1` in vitest.smoke.config.ts is the backstop for the rare case where a
+// single warm-up pass isn't enough (or the instance scaled back down).
+
+import { SMOKE_BASE_URL } from "./smoke-env.js";
+
+const WARMUP_BUDGET_MS = 120_000; // total time we'll spend waking + warming
+const PER_REQUEST_MS = 35_000; // generous: a cold instance can take >30s to first-respond
+const WARM_THRESHOLD_MS = 3_000; // a health response under this = instance is hot
+const POLL_GAP_MS = 2_000;
+
+async function probe(path: string): Promise<{ ok: boolean; ms: number; status: number }> {
+  const t0 = Date.now();
+  try {
+    const res = await fetch(`${SMOKE_BASE_URL}${path}`, {
+      signal: AbortSignal.timeout(PER_REQUEST_MS),
+    });
+    return { ok: true, ms: Date.now() - t0, status: res.status };
+  } catch {
+    return { ok: false, ms: Date.now() - t0, status: 0 };
+  }
+}
+
+export default async function warmup(): Promise<void> {
+  // Targeting a local dev server has no cold start — skip so a bare
+  // `vitest --config vitest.smoke.config.ts` against localhost stays instant.
+  if (/localhost|127\.0\.0\.1/.test(SMOKE_BASE_URL)) return;
+
+  const deadline = Date.now() + WARMUP_BUDGET_MS;
+  let warm = false;
+  while (Date.now() < deadline) {
+    // The first call may be the slow cold one (it wakes the instance); a later
+    // call returning fast confirms the instance is hot for the imminent journeys.
+    const health = await probe("/api/health");
+    if (health.ok && health.status === 200 && health.ms < WARM_THRESHOLD_MS) {
+      warm = true;
+      console.log(`[smoke-warmup] ${SMOKE_BASE_URL} warm (health 200 in ${health.ms}ms) — running smoke.`);
+      break;
+    }
+    console.log(
+      `[smoke-warmup] ${SMOKE_BASE_URL} not hot yet (health ${health.status} in ${health.ms}ms) — waiting…`,
+    );
+    await new Promise((r) => setTimeout(r, POLL_GAP_MS));
+  }
+  // Also nudge the /mcp route — an unauthenticated 401 is fine; it still warms
+  // that handler/SSE path, which the authed MCP journeys exercise next.
+  await probe("/mcp");
+  if (!warm) {
+    console.log(
+      `[smoke-warmup] ${SMOKE_BASE_URL} did not confirm hot within ${WARMUP_BUDGET_MS}ms — ` +
+        `running smoke anyway (retry:1 is the backstop). A persistently slow host is a real signal.`,
+    );
+  }
+}

--- a/packages/server/vitest.smoke.config.ts
+++ b/packages/server/vitest.smoke.config.ts
@@ -18,6 +18,10 @@ export default defineConfig({
     // default vitest.config.ts. Needs MEMEX_EMIT_KEY in env to actually land —
     // the default smoke run (no key) just no-ops the emission per the helper.
     setupFiles: ["@memex-ai-ac/vitest/setup"],
+    // Wake + warm the freshly-deployed host ONCE before any test, so the timed
+    // MCP journeys don't pay Cloud Run cold-start latency (>30s) and time out.
+    // See warmup.global-setup.ts (std-17 / spec-243 smoke robustness).
+    globalSetup: ["./src/__smoke__/warmup.global-setup.ts"],
     // Live HTTP round-trips against a shared host — keep ordering deterministic
     // (the authed tier's create→read→delete journey is sequential).
     fileParallelism: false,
@@ -26,5 +30,9 @@ export default defineConfig({
     // The live host can be slow on a cold Cloud Run instance right after deploy.
     testTimeout: 30_000,
     hookTimeout: 30_000,
+    // Backstop to the warm-up: if a single test still trips the timeout on a cold
+    // first hit, retry once — by then the instance is warm. A genuine outage fails
+    // both attempts and still reds the smoke (no masking).
+    retry: 1,
   },
 });

--- a/packages/ui/e2e/journey-11-plan-submit-approve.spec.ts
+++ b/packages/ui/e2e/journey-11-plan-submit-approve.spec.ts
@@ -43,10 +43,11 @@ test("user opens plan from task panel, approves, plan status flips to approved",
   await page.goto(tenantPath(tenant.namespaceSlug, tenant.memexSlug, `/docs/${docId}`));
   await expect(page.getByText(/We need a plan first/)).toBeVisible({ timeout: 15_000 });
 
-  // Tasks live under the Build phase (post spec-164 phase-tab redesign — there is
-  // no standalone "Tasks" tab anymore). Click the Build phase tab (role="tab",
-  // PhaseTabBar) to surface the TaskPanel.
+  // Tasks live under the Build phase. spec-282: the Build view now lands on the
+  // Decisions & ACs sub-tab, so after the Build phase tab click open the unified
+  // "Agent Tasks & Issues" sub-tab to surface the TaskPanel.
   await page.getByRole("tab", { name: "Build" }).click();
+  await page.getByRole("button", { name: /Agent Tasks & Issues/ }).click();
 
   // The plan trigger is rendered by TaskPanel for any task with an
   // executionPlanDocId. With a 'READY — all green' readiness comment its label

--- a/packages/ui/e2e/journey-16-reactivity.spec.ts
+++ b/packages/ui/e2e/journey-16-reactivity.spec.ts
@@ -203,9 +203,11 @@ test.describe("doc-16 Wave 1 reactivity journeys", () => {
     await tab.goto(tenantPath(tenant, `docs/${spec.docId}`));
     // Wait for the page to mount before driving the phase tab.
     await expect(tab.getByText("Reactive tasks").first()).toBeVisible({ timeout: 15_000 });
-    // Tasks live under the Build PHASE (post spec-164 redesign — no standalone
-    // "Tasks" tab). Click the Build phase tab to mount the TaskPanel.
+    // Tasks live under the Build PHASE. spec-282: the Build view lands on the
+    // Decisions & ACs sub-tab, so open the unified "Agent Tasks & Issues" sub-tab
+    // to mount the TaskPanel.
     await tab.getByRole("tab", { name: "Build" }).click();
+    await tab.getByRole("button", { name: /Agent Tasks & Issues/ }).click();
 
     // Create a task via the REST surface (the agent's `create_task` tool calls
     // the same `services/tasks.ts::createTask` function — the bus emission is identical).

--- a/packages/ui/e2e/journey-19-lifecycle-spine.spec.ts
+++ b/packages/ui/e2e/journey-19-lifecycle-spine.spec.ts
@@ -204,21 +204,26 @@ test("lifecycle spine: org → memex → Spec → resolve decision → phase mov
     { timeout: 15_000 }
   );
 
-  // ── 6. Phase move specify → build: gate holds, but the editor gets the override ─
+  // ── 6. Phase move specify → build: the gate holds; the editor's escape hatch
+  // relocates to the browse-forward confirm (spec-282/dec-4) ──────────────────
   // specify→build is gated on Decisions resolved AND ACs created. We've resolved
   // the decision but deliberately have no ACs (AC authoring is the agent/MCP
   // surface, out of this spine's scope) — so the rubric still NAMES the open AC
-  // gate (it doesn't advance silently). spec-258/dec-5 amends spec-159/dec-4: on
-  // a blocked current tab an EDITOR additionally gets a "Move this spec to Build
-  // anyway?" override [Yes], because the move is already forceable from the
-  // kanban. So the affordance is no longer a dead end — the gate informs, and the
-  // editor has an escape hatch.
+  // gate (it doesn't advance silently). spec-282/dec-4: the current tab is
+  // STATUS-ONLY (no override button); the editor forces a blocked forward move
+  // by browsing the Build tab and confirming "Move this spec anyway?".
   const rubicon = page.getByTestId("transition-sentence");
   await expect(rubicon).toContainText(
     /Acceptance Criteria \(ACs\)[\s\S]*must be created/i,
     { timeout: 15_000 }
   );
-  await expect(rubicon).toContainText(/Move this spec to Build anyway\?/i);
+  await expect(rubicon).not.toContainText(/anyway\?/i);
+  await expect(rubicon.getByRole("button", { name: /^Yes$/ })).toHaveCount(0);
+
+  // The escape hatch lives on the browse-forward confirm: browse Build → the
+  // "Move this spec anyway?" override [Yes].
+  await page.locator('[role="tab"][data-tab="build"]').click();
+  await expect(rubicon).toContainText(/Move this spec anyway\?/i, { timeout: 15_000 });
   await expect(rubicon.getByRole("button", { name: /^Yes$/ })).toHaveCount(1);
 });
 

--- a/packages/ui/e2e/journey-20-verify-acceptance-issues.spec.ts
+++ b/packages/ui/e2e/journey-20-verify-acceptance-issues.spec.ts
@@ -167,6 +167,8 @@ test("Issue resolution: progress bar, Resolve + won't-fix menu, resolved vocabul
     tenantPath(tenant.namespaceSlug, tenant.memexSlug, `/specs/${spec.handle}`)
   );
   await page.locator('[data-tab="verify"]').click();
+  // spec-282: Issues live under the unified "Agent Tasks & Issues" sub-tab.
+  await page.getByRole("button", { name: /Agent Tasks & Issues/ }).click();
   const panel = page.getByTestId("issue-panel");
   await expect(panel).toBeVisible({ timeout: 15_000 });
 
@@ -246,6 +248,8 @@ test("Task completion: Build-tab metric and Verify-tab echo", async ({
 
   // ── Build tab: the full Metric tile (ac-14) ────────────────────────────────
   await page.locator('[data-tab="build"]').click();
+  // spec-282: Tasks live under the unified "Agent Tasks & Issues" sub-tab.
+  await page.getByRole("button", { name: /Agent Tasks & Issues/ }).click();
   const metric = page.getByTestId("task-completion-header");
   await expect(metric).toBeVisible({ timeout: 15_000 });
   await expect(metric.getByText("67%")).toBeVisible();
@@ -254,6 +258,8 @@ test("Task completion: Build-tab metric and Verify-tab echo", async ({
 
   // ── Verify tab: the amber exception echo (ac-15) ───────────────────────────
   await page.locator('[data-tab="verify"]').click();
+  // spec-282: the verify task echo rides the "Agent Tasks & Issues" sub-tab.
+  await page.getByRole("button", { name: /Agent Tasks & Issues/ }).click();
   const echo = page.getByTestId("verify-task-echo");
   await expect(echo).toBeVisible();
   await expect(echo).toContainText("1 of 3 tasks incomplete");
@@ -271,6 +277,7 @@ test("Task completion: Build-tab metric and Verify-tab echo", async ({
     tenantPath(tenant.namespaceSlug, tenant.memexSlug, `/specs/${done.handle}`)
   );
   await page.locator('[data-tab="verify"]').click();
+  await page.getByRole("button", { name: /Agent Tasks & Issues/ }).click();
   const calmEcho = page.getByTestId("verify-task-echo");
   await expect(calmEcho).toBeVisible({ timeout: 15_000 });
   await expect(calmEcho).toContainText("2/2 tasks complete");

--- a/packages/ui/e2e/journey-21-spec-196-narrative.spec.ts
+++ b/packages/ui/e2e/journey-21-spec-196-narrative.spec.ts
@@ -129,22 +129,22 @@ test("specify→build gate: stale narrative blocks the offer; consolidation rest
     timeout: 15_000,
   });
 
-  // All decisions resolved + AC present + never consolidated → the Rubicon
-  // states the staleness condition WITH the how-to tail. spec-258/dec-5: an
-  // editor also gets the "Move this spec to Build anyway?" override [Yes] — the
-  // staleness gate informs but no longer dead-ends the editor (consolidation is
-  // still the clean path, exercised next).
+  // All decisions resolved + AC present + never consolidated → the current-tab
+  // Rubicon states the staleness condition WITH the how-to tail. spec-282/dec-4:
+  // the current tab is STATUS-ONLY — the blocker informs but carries no button.
   await expect(rubicon).toContainText(
     /The spec narrative must be updated to reflect the resolved decisions before this spec can move to Build — use the refresh action to generate the update prompt\./,
     { timeout: 15_000 }
   );
-  await expect(rubicon).toContainText(/Move this spec to Build anyway\?/i);
-  await expect(rubicon.getByRole("button", { name: /^Yes$/ })).toHaveCount(1);
+  await expect(rubicon.getByRole("button", { name: /^Yes$/ })).toHaveCount(0);
 
-  // Consolidate (what assess_spec({mode:'consolidate'}) stamps) → the live
-  // change stream refreshes the doc and the advancement offer appears.
+  // Consolidate (what assess_spec({mode:'consolidate'}) stamps) → the live change
+  // stream refreshes the doc and the staleness clears. The advance is reachable
+  // on the browse-forward confirm (spec-282/dec-4): browse the Build tab → the
+  // clean "Are you sure…?", with no staleness text.
   await consolidateNarrative({ memexId: tenant.memexId, docId: spec.docId });
-  await expect(rubicon).toContainText(/Do you wish to move this spec to Build\?/, {
+  await page.locator('[role="tab"][data-tab="build"]').click();
+  await expect(rubicon).toContainText(/Are you sure you want to move this spec to Build\?/, {
     timeout: 15_000,
   });
   await expect(rubicon).not.toContainText(/spec narrative/i);

--- a/packages/ui/e2e/journey-22-whats-new.spec.ts
+++ b/packages/ui/e2e/journey-22-whats-new.spec.ts
@@ -5,9 +5,14 @@ import { seedWhatsNewEntry, clearWhatsNewEntries } from "./helpers/seed.js";
 //
 // SCOPE: the end-to-end user-facing surface — a seeded global feed entry makes
 // the ribbon slide up; clicking it opens the popup with the entry's What/Why;
-// closing the popup leaves the ribbon up; only the ribbon's × dismisses it, and
-// that dismissal persists across a reload (localStorage). Proves the full chain
-// DB → /api/whats-new → React → browser, which the unit/component suites can't.
+// manually closing the popup dismisses the ribbon (it animates "home" into the
+// user menu — 2026-06-13 behaviour pass, superseding dec-4's "popup close ≠
+// dismiss"), and that dismissal persists across a reload (localStorage). Proves
+// the full chain DB → /api/whats-new → React → browser, which the unit/component
+// suites can't.
+//
+// NOTE: the ribbon also auto-dismisses after 6s; the test acts well within that
+// window (clicking the ribbon stops the countdown).
 //
 // The ear → live Specky narration is NOT driven here (real mic + ElevenLabs,
 // same as journey-21). This is the std-28 gate; it emits the user-facing scope
@@ -65,13 +70,10 @@ test("ribbon slides up → popup shows the entry; only its × dismisses it, pers
   await expect(popup).toContainText(ENTRY.whatText);
   await expect(popup).toContainText(ENTRY.whyText);
 
-  // dec-4: closing the popup (header ✕) does NOT dismiss the ribbon.
+  // ac-3 (2026-06-13 behaviour): closing the popup (header ✕) dismisses the
+  // ribbon — it animates home into the user menu and is gone.
   await popup.getByRole("button", { name: "Close" }).click();
   await expect(popup).toBeHidden();
-  await expect(ribbon).toBeVisible();
-
-  // ac-3: only the ribbon's own × dismisses it…
-  await page.getByTestId("whats-new-ribbon-dismiss").click();
   await expect(ribbon).toBeHidden();
 
   // …and the dismissal persists across a reload (localStorage, per-user).

--- a/packages/ui/e2e/journey-29-spec-258-done-tab.spec.ts
+++ b/packages/ui/e2e/journey-29-spec-258-done-tab.spec.ts
@@ -147,16 +147,22 @@ test("editor override: a blocked forward move offers 'Move … anyway?' and forc
   ).toBeVisible({ timeout: 15_000 });
   await switchToEditing(page);
 
-  // ── ac-8: the blocked current tab names what's open AND offers the editor the
-  //    "Move this spec to Verify anyway?" override. ───────────────────────────
+  // ── ac-8 (via spec-282/dec-4): the blocked CURRENT tab is status-only — it
+  //    names what's open but offers NO override button. The editor's force-
+  //    forward capability relocates to the browse-forward confirm. ────────────
   const sentence = page.getByTestId("transition-sentence");
   await expect(sentence).toContainText(
     /Task must be completed[\s\S]*before this spec can move to Verify/i,
     { timeout: 15_000 }
   );
-  await expect(sentence).toContainText(/Move this spec to Verify anyway\?/i);
+  await expect(sentence).not.toContainText(/anyway\?/i);
+  await expect(sentence.getByRole("button", { name: /^Yes$/ })).toHaveCount(0);
 
-  // Forcing it advances the spec the kanban already permits (soft gates).
+  // Browse the Verify phase tab → the dec-5 capability lives here now: the
+  // forward+blocked confirm offers "Move this spec anyway?" and forces the move
+  // the kanban already permits (soft gates).
+  await page.locator('[role="tab"][data-tab="verify"]').click();
+  await expect(sentence).toContainText(/Move this spec anyway\?/i, { timeout: 15_000 });
   await sentence.getByRole("button", { name: /^Yes$/ }).click();
   await expect(
     page.locator('[role="tab"][data-tab="verify"][data-current="true"]')

--- a/packages/ui/e2e/journey-29-spec-260-qa-reports.spec.ts
+++ b/packages/ui/e2e/journey-29-spec-260-qa-reports.spec.ts
@@ -71,15 +71,17 @@ test.describe("spec-260 — Build QA Report", () => {
     });
 
     // ── Build, BEFORE any hand-off: the QA Report sub-tab exists with a quiet
-    // empty state; Tasks & Issues stays the default view. ──
+    // empty state (spec-282: it's one tab in the unified control, reachable in
+    // every phase). ──
     await setDocStatus({ memexId: tenant.memexId, docId, status: "build" });
     await page.goto(tenantPath(tenant.namespaceSlug, tenant.memexSlug, `/docs/${docId}`));
     await expect(
       page.getByRole("heading", { name: "QA Report Seats Spec", level: 1 }),
     ).toBeVisible({ timeout: 15_000 });
 
-    // Default tab: the working two-column (Tasks panel present).
-    await expect(page.getByText("Tasks & Issues")).toBeVisible();
+    // spec-282 dec-2: the work view is now "Agent Tasks & Issues"; the QA Report
+    // tab is present alongside it (build lands on Decisions & ACs by default).
+    await expect(page.getByText("Agent Tasks & Issues")).toBeVisible();
     await page.getByText("QA Report", { exact: true }).click();
     await expect(page.getByTestId("qa-report-empty")).toContainText(
       "No QA report yet — generated when build hands off to verify",

--- a/packages/ui/e2e/journey-30-spec-282-subtabs.spec.ts
+++ b/packages/ui/e2e/journey-30-spec-282-subtabs.spec.ts
@@ -1,0 +1,165 @@
+// Journey 30 — One persistent sub-tab control + a browse-only advance offer
+// (spec-282, std-28 PR-gate journey). Covers the two user-facing flows:
+//
+//   1. PERSISTENT SUB-TABS — one control carries the same five tabs (Narrative ·
+//      Comments · Decisions & ACs · Agent Tasks & Issues · QA Report) in every
+//      phase view; Narrative & Comments stay reachable in Build and Verify
+//      (accretion never removes an earlier tab), and the QA Report tab shows an
+//      honest empty-state placeholder before a report exists. (ac-1/2/3/7)
+//   2. BROWSE-ONLY ADVANCE — on the current phase tab there is NO advance
+//      question or [Yes] button (status-only); the advance confirm appears only
+//      when browsing a non-current phase tab, where the editor can still force a
+//      blocked forward move. (ac-5/6/7)
+//
+// Seeding is HTTP-only over the __test__ surface (spec-172 dec-2): seed-org,
+// seed-spec, set-doc-status. Navigation is path-based [per std-2]. A seeded spec
+// opens as a REVIEWER, so switchToEditing promotes before the editor-gated
+// advance affordances are exercised.
+
+import {
+  test,
+  expect,
+  tenantPath,
+  switchToEditing,
+  emitAcEvents,
+} from "./helpers/index.js";
+import { seedOrgTenant, seedSpec, setDocStatus } from "./helpers/retained.js";
+
+const SPEC282 = "mindset-prod/memex-building-itself/specs/spec-282";
+
+const SUB_TABS = [
+  "Narrative",
+  "Comments",
+  "Decisions & ACs",
+  "Agent Tasks & Issues",
+  "QA Report",
+];
+
+const ACS_BY_TEST: Record<string, string[]> = {
+  "one persistent sub-tab control: the same five tabs in every phase; QA Report placeholder": [
+    `${SPEC282}/acs/ac-1`,
+    `${SPEC282}/acs/ac-2`,
+    `${SPEC282}/acs/ac-3`,
+    `${SPEC282}/acs/ac-7`,
+  ],
+  "browse-only advance: no offer on the current tab; the confirm appears only when browsing forward": [
+    `${SPEC282}/acs/ac-5`,
+    `${SPEC282}/acs/ac-6`,
+    `${SPEC282}/acs/ac-7`,
+  ],
+};
+
+test.afterEach(async ({}, testInfo) => {
+  if (testInfo.status === "skipped") return;
+  const refs = ACS_BY_TEST[testInfo.title];
+  if (!refs) return;
+  await emitAcEvents(
+    refs,
+    testInfo.status === "passed" ? "pass" : "fail",
+    `packages/ui/e2e/journey-30-spec-282-subtabs.spec.ts::${testInfo.title}`,
+    testInfo.duration
+  );
+});
+
+// Every sub-tab button is present (and therefore reachable) in the current view.
+async function expectAllSubTabs(page: import("@playwright/test").Page) {
+  for (const label of SUB_TABS) {
+    await expect(
+      page.getByRole("button", { name: new RegExp(`^${label}\\b`) })
+    ).toBeVisible({ timeout: 15_000 });
+  }
+}
+
+test("one persistent sub-tab control: the same five tabs in every phase; QA Report placeholder", async ({
+  page,
+  resources,
+}) => {
+  const tenant = await seedOrgTenant({ slug: resources.slug("j30a") });
+  const spec = await seedSpec({
+    memexId: tenant.memexId,
+    title: "Persistent sub-tabs journey",
+    purpose: "One control, every phase.",
+  });
+  await setDocStatus({ memexId: tenant.memexId, docId: spec.docId, status: "build" });
+
+  await page.goto(
+    tenantPath(tenant.namespaceSlug, tenant.memexSlug, `/specs/${spec.handle}`),
+    { waitUntil: "commit" }
+  );
+  await expect(
+    page.getByRole("heading", { level: 1, name: /Persistent sub-tabs journey/ })
+  ).toBeVisible({ timeout: 15_000 });
+
+  // ── ac-1/ac-2: Build view shows all five sub-tabs; it lands on Decisions & ACs. ──
+  await expect(
+    page.locator('[role="tab"][data-tab="build"][data-current="true"]')
+  ).toBeVisible({ timeout: 15_000 });
+  await expectAllSubTabs(page);
+
+  // ── ac-3: the QA Report tab shows its honest empty-state placeholder. ──
+  await page.getByRole("button", { name: /^QA Report\b/ }).click();
+  await expect(page.getByTestId("qa-report-empty")).toContainText(
+    "No QA report yet — generated when build hands off to verify"
+  );
+
+  // ── ac-2: browse Specify — the same five tabs persist (Narrative & Comments
+  //    remain present, so the control is never swapped out). ──
+  await page.locator('[role="tab"][data-tab="specify"]').click();
+  await expectAllSubTabs(page);
+
+  // ── ac-2: browse Verify — still all five tabs; an earlier-phase tab
+  //    (Narrative) is still reachable and renders its content. ──
+  await page.locator('[role="tab"][data-tab="verify"]').click();
+  await expectAllSubTabs(page);
+  await page.getByRole("button", { name: /^Narrative\b/ }).click();
+  await expect(page.getByText("Segments", { exact: true })).toBeVisible({
+    timeout: 15_000,
+  });
+});
+
+test("browse-only advance: no offer on the current tab; the confirm appears only when browsing forward", async ({
+  page,
+  resources,
+}) => {
+  // A build-phase spec with NO tasks → the build→verify rubric blocks.
+  const tenant = await seedOrgTenant({ slug: resources.slug("j30b") });
+  const spec = await seedSpec({
+    memexId: tenant.memexId,
+    title: "Browse-only advance journey",
+    purpose: "The advance offer lives on the browse-forward confirm only.",
+  });
+  await setDocStatus({ memexId: tenant.memexId, docId: spec.docId, status: "build" });
+
+  await page.goto(
+    tenantPath(tenant.namespaceSlug, tenant.memexSlug, `/specs/${spec.handle}`),
+    { waitUntil: "commit" }
+  );
+  await expect(
+    page.getByRole("heading", { level: 1, name: /Browse-only advance journey/ })
+  ).toBeVisible({ timeout: 15_000 });
+  await switchToEditing(page);
+
+  // ── ac-5: on the current Build tab the line is STATUS-ONLY — it names the
+  //    open rubric work but carries NO advance question and NO button. ──
+  const sentence = page.getByTestId("transition-sentence");
+  await expect(sentence).toContainText(
+    /Tasks must be created and completed[\s\S]*before this spec can move to Verify/i,
+    { timeout: 15_000 }
+  );
+  await expect(sentence).not.toContainText(/anyway\?/i);
+  await expect(sentence).not.toContainText(/Do you (want|wish)/i);
+  await expect(sentence.getByRole("button", { name: /^Yes$/ })).toHaveCount(0);
+
+  // ── ac-6: browsing the (non-current) Verify tab surfaces the advance confirm
+  //    — the editor's force-forward path: "Move this spec anyway?" [Yes] [No]. ──
+  await page.locator('[role="tab"][data-tab="verify"]').click();
+  await expect(sentence).toContainText(/Move this spec anyway\?/i, { timeout: 15_000 });
+  await expect(sentence.getByRole("button", { name: /^Yes$/ })).toHaveCount(1);
+  await expect(sentence.getByRole("button", { name: /^No$/ })).toHaveCount(1);
+
+  // [No] returns to the current tab without mutating the phase.
+  await sentence.getByRole("button", { name: /^No$/ }).click();
+  await expect(
+    page.locator('[role="tab"][data-tab="build"][data-current="true"]')
+  ).toBeVisible();
+});

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -52,6 +52,7 @@ import { useTrackRouteChange } from './hooks/useTelemetry';
 import { tenantBase, BASE_URL, fetchWithRetry } from './api/http';
 import { SearchProvider } from './components/SearchContext';
 import { WhatsNewRibbonConnected } from './components/whats-new/WhatsNewRibbonConnected';
+import { WhatsNewProvider } from './components/whats-new/WhatsNewContext';
 import { FirstRunGreeting } from './components/onboarding/FirstRunGreeting';
 import { DemoWalkthroughController } from './voice/walkthrough/DemoWalkthroughController';
 
@@ -209,18 +210,23 @@ function TenantLayout() {
             AppShell, so the shell needs no edit and the public branch — which never
             mounts VoiceGuideMount — has no voice surface. */}
         <VoiceGuideMount namespace={namespace ?? ''} memex={memex ?? ''}>
-          <OrgConsentDialog />
-          {/* spec-200: global What's New ribbon — authed shell only (inside
-              VoiceGuideMount so t-7's ear can reach the voice session). */}
-          <WhatsNewRibbonConnected />
-          {/* spec-206 t-3: first-run greeting controller — auto-starts Specky on
-              a user's first session (no modal, no tap). Renders nothing. */}
-          <FirstRunGreeting />
-          <AppShell>
-            <Fragment key={`${namespace}/${memex}`}>
-              <Outlet />
-            </Fragment>
-          </AppShell>
+          {/* spec-200: WhatsNewProvider lets the sidebar user menu re-open the
+              popup and gives the ribbon the menu anchor to animate "into" on
+              dismiss — so it wraps BOTH the ribbon and AppShell. */}
+          <WhatsNewProvider>
+            <OrgConsentDialog />
+            {/* spec-200: global What's New ribbon — authed shell only (inside
+                VoiceGuideMount so t-7's ear can reach the voice session). */}
+            <WhatsNewRibbonConnected />
+            {/* spec-206 t-3: first-run greeting controller — auto-starts Specky on
+                a user's first session (no modal, no tap). Renders nothing. */}
+            <FirstRunGreeting />
+            <AppShell>
+              <Fragment key={`${namespace}/${memex}`}>
+                <Outlet />
+              </Fragment>
+            </AppShell>
+          </WhatsNewProvider>
         </VoiceGuideMount>
       </HandholdRevealProvider>
     </ChatProvider>

--- a/packages/ui/src/components/AppShell.tsx
+++ b/packages/ui/src/components/AppShell.tsx
@@ -13,6 +13,7 @@ import { PublicAuthButtons, ReadOnlyBadge } from './PublicAccessControls';
 import { useMemexAccess } from '../hooks/useMemexAccess';
 import { HeaderSlotProvider, useHeaderSlotContent } from './HeaderSlot';
 import { SearchTrigger } from './SearchTrigger';
+import { useWhatsNew } from './whats-new/WhatsNewContext';
 import {
   getCurrentTenant,
   parseTenantFromPathname,
@@ -199,6 +200,14 @@ function SidebarUserCard({
 }) {
   const [open, setOpen] = useState(false);
   const wrapperRef = useRef<HTMLDivElement>(null);
+  // spec-200: this card is the fly-home target for the What's New ribbon, and
+  // hosts the "What's New" menu item that re-opens the popup.
+  const { available: whatsNewAvailable, openPopup: openWhatsNew, registerMenuAnchor } = useWhatsNew();
+
+  useEffect(() => {
+    registerMenuAnchor(wrapperRef.current);
+    return () => registerMenuAnchor(null);
+  }, [registerMenuAnchor]);
 
   useEffect(() => {
     if (!open) return;
@@ -258,6 +267,19 @@ function SidebarUserCard({
       </button>
       {open && (
         <div className="absolute left-0 right-0 bottom-full mb-2 z-40 rounded-lg shadow-xl py-1 border bg-card-hover border-edge">
+          {whatsNewAvailable && (
+            <button
+              data-testid="user-menu-whats-new"
+              onClick={() => {
+                setOpen(false);
+                openWhatsNew();
+              }}
+              className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm transition-colors text-secondary hover:text-primary hover:bg-overlay"
+            >
+              <span aria-hidden="true">🎁</span>
+              What's New
+            </button>
+          )}
           {showMemexSettings && (
             <Link
               to={memexSettingsHref}

--- a/packages/ui/src/components/PromptButton.test.tsx
+++ b/packages/ui/src/components/PromptButton.test.tsx
@@ -84,8 +84,9 @@ describe('PromptButton copy (ac-4, ac-8)', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Copy prompt' }));
 
     await waitFor(() => expect(writeText).toHaveBeenCalledWith(expected));
-    // visible confirmation, not a silent write
-    await waitFor(() => expect(screen.getByRole('button', { name: /Copied/ })).toBeTruthy());
+    // visible confirmation, not a silent write — the copy action resolves into
+    // a "Copied. Now go and paste" message beside a Close button.
+    await waitFor(() => expect(screen.getByTestId('copy-confirmation')).toBeTruthy());
   });
 
   it('performs exactly one action — copy — with no execute-here control (ac-8)', async () => {
@@ -169,6 +170,68 @@ describe('PromptButton sentence form (spec-159 ac-17)', () => {
     fireEvent.click(screen.getByRole('button', { name: `Copy ${SENTENCE}` }));
     fireEvent.click(screen.getByRole('button', { name: 'Copy prompt' }));
     await waitFor(() => expect(screen.getByRole('alert')).toBeTruthy());
+  });
+});
+
+// spec-282 dec-5 — (A) the three phase handoffs copy a SHORT get_prompt stub
+// instead of the full scaffold (the coding agent fetches the full prompt via
+// get_prompt; the scaffold node text is untouched so get_prompt parity holds);
+// (B) after a successful copy the dialog shows clear paste guidance beside the
+// action and the copy button BECOMES a Close button (one obvious click to
+// dismiss); the prompt itself sits on its own bordered canvas, not the guidance.
+describe('PromptButton stub mode + copy feedback (spec-282 dec-5, ac-12)', () => {
+  const AC12 = 'mindset-prod/memex-building-itself/specs/spec-282/acs/ac-12';
+  // verify-spec → "Verify handoff" label → phase word "verify".
+  const STUB =
+    'Use memex spec: https://memex.ai/mindset-prod/memex-building-itself/specs/spec-103\n' +
+    'Get the verify prompt from memex and ask the user how they want to proceed.';
+
+  it('stub mode copies the short get_prompt stub, NOT the full scaffold prompt', async () => {
+    tagAc(AC12);
+    const full = toButtonPrompt({ dataset: BASE_SCAFFOLD, buttonId: 'verify-spec', context: CTX });
+    render(<PromptButton buttonId="verify-spec" context={CTX} stub />);
+
+    fireEvent.click(screen.getByRole('button', { name: OPEN_LABEL }));
+    fireEvent.click(screen.getByRole('button', { name: 'Copy prompt' }));
+
+    // The clipboard receives the short stub verbatim — not the long scaffold.
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith(STUB));
+    expect(writeText).not.toHaveBeenCalledWith(full);
+    // The stub is meaningfully shorter than the full scaffold payload.
+    expect(STUB.length).toBeLessThan(full.length);
+  });
+
+  it('without stub the full scaffold prompt is still copied (get_prompt parity preserved)', async () => {
+    tagAc(AC12);
+    const full = toButtonPrompt({ dataset: BASE_SCAFFOLD, buttonId: 'verify-spec', context: CTX });
+    render(<PromptButton buttonId="verify-spec" context={CTX} />);
+
+    fireEvent.click(screen.getByRole('button', { name: OPEN_LABEL }));
+    fireEvent.click(screen.getByRole('button', { name: 'Copy prompt' }));
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith(full));
+  });
+
+  it('after copy the confirmation shows and the copy button becomes Close', async () => {
+    tagAc(AC12);
+    render(<PromptButton buttonId="verify-spec" context={CTX} stub />);
+
+    fireEvent.click(screen.getByRole('button', { name: OPEN_LABEL }));
+    fireEvent.click(screen.getByRole('button', { name: 'Copy prompt' }));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('copy-confirmation')).toHaveTextContent(
+        'Copied. Now go to your coding agent and paste.',
+      ),
+    );
+    // The copy action is gone — the copy button has become a Close button, so
+    // dismissing is a single obvious click (the header X also reads "Close").
+    expect(screen.queryByRole('button', { name: /Copy prompt/ })).toBeNull();
+    expect(screen.getAllByRole('button', { name: 'Close' }).length).toBeGreaterThan(0);
+
+    // And clicking that footer Close actually dismisses the dialog.
+    const footerClose = screen.getAllByRole('button', { name: 'Close' }).at(-1)!;
+    fireEvent.click(footerClose);
+    await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull());
   });
 });
 

--- a/packages/ui/src/components/PromptButton.tsx
+++ b/packages/ui/src/components/PromptButton.tsx
@@ -43,6 +43,18 @@ export interface PromptButtonProps {
   sentenceLabel?: string;
   /** Enabled Org appends for this button (delivered with the session; t-4). */
   orgBlocks?: readonly GuidanceBlock[];
+  /**
+   * spec-282 dec-5(A): stub mode for the three phase handoffs. When true the
+   * dialog shows + the clipboard receives a SHORT, human-readable stub (the Spec
+   * URL + a phase-specific "Get the <phase> prompt from memex…" instruction)
+   * instead of the full scaffold payload — the coding agent fetches the full
+   * prompt itself via the `get_prompt` MCP tool. The scaffold node
+   * `text` is deliberately untouched: `get_prompt` (spec-263) projects that same
+   * node and must keep serving the full prompt with byte-parity, so the stub is
+   * a UI-layer projection only. The canonical ref + title + URL are read from
+   * `context` (the handoff context already carries namespace/memex/handle/...).
+   */
+  stub?: boolean;
   disabled?: boolean;
   variant?: 'primary' | 'secondary' | 'ghost' | 'agent';
   /** Fired with the composed prompt after a successful copy. */
@@ -69,6 +81,25 @@ function TerminalIcon() {
   );
 }
 
+// spec-282 dec-5(A): the short get_prompt stub that the three phase-handoff copy
+// actions place on the clipboard. Deliberately human-readable — a person reading
+// it learns how to drive Memex from their coding agent: point the agent at the
+// Spec URL and tell it to fetch the phase prompt from Memex (which the agent does
+// via the `get_prompt` MCP tool, deriving the ref from the URL path). The agent
+// calls `get_prompt` to fetch the full scaffold (Org appends included), so this
+// stays a UI-layer projection and the scaffold node text is never edited
+// (get_prompt byte-parity, spec-263). The second line is PHASE-SPECIFIC: the
+// phase word is the lowercased first word of the handoff node `label` (e.g.
+// "Build handoff" → "build"), so each of the three handoffs names its own prompt.
+function buildHandoffStub(context: Record<string, unknown>, label: string): string {
+  const str = (k: string) => String(context[k] ?? '');
+  const phase = (label.trim().split(/\s+/)[0] ?? '').toLowerCase();
+  return [
+    `Use memex spec: ${str('url')}`,
+    `Get the ${phase} prompt from memex and ask the user how they want to proceed.`,
+  ].join('\n');
+}
+
 function PromptDialog({
   label,
   prompt,
@@ -87,8 +118,11 @@ function PromptDialog({
     try {
       await navigator.clipboard.writeText(prompt);
       setCopyFailed(false);
+      // spec-282 dec-5(B): the copied state is STICKY (no auto-reset) — once the
+      // clipboard is loaded the dialog stays in its "Copied. Now go and paste"
+      // state: the confirmation sits next to the action and the copy button has
+      // become a Close button (one obvious click to dismiss).
       setCopied(true);
-      window.setTimeout(() => setCopied(false), 2500);
       onCopy?.(prompt);
     } catch {
       // Clipboard blocked (NotAllowedError / non-HTTPS): the prompt is already
@@ -127,13 +161,14 @@ function PromptDialog({
           </button>
         </div>
 
-        {/* Guidance — the whole point of the dialog: copy this, paste into a
-            coding agent. */}
-        <div className="mx-5 mt-4 rounded-md border border-edge bg-overlay/40 px-3 py-2 text-xs text-secondary">
+        {/* Guidance — plain prose, deliberately NOT boxed (spec-282 dec-5): the
+            bordered "canvas" treatment is reserved for the prompt artifact
+            below, so the thing you copy is the thing that looks liftable. */}
+        <p className="mx-5 mt-4 text-xs text-secondary">
           <span className="font-medium text-heading">Copy this prompt and paste it into a coding-agent session</span>{' '}
           (e.g. Claude Code) to hand the work off. It's also a template — read it to learn the
           prompting pattern.
-        </div>
+        </p>
 
         {copyFailed && (
           <p role="alert" className="px-5 pt-3 text-xs text-status-danger-text">
@@ -141,19 +176,41 @@ function PromptDialog({
           </p>
         )}
 
-        {/* Read-only (D-1): the prompt is shown verbatim and is selectable, but
-            not editable — Copy emits exactly this text. */}
-        <pre className="flex-1 overflow-auto mx-5 my-4 p-3 rounded-md bg-overlay/30 text-xs text-secondary whitespace-pre-wrap break-words select-text">
+        {/* The prompt sits on its own canvas — a bordered, inset surface
+            distinct from the dialog chrome — so it reads as the artifact to
+            copy (spec-282 dec-5). Read-only (D-1): shown verbatim and selectable
+            but not editable; Copy emits exactly this text. */}
+        <pre className="flex-1 overflow-auto mx-5 my-4 p-4 rounded-lg border border-edge bg-surface text-xs text-secondary whitespace-pre-wrap break-words select-text">
           {prompt}
         </pre>
 
-        <div className="flex justify-end gap-2 px-5 py-3 border-t border-edge">
-          <Button type="button" variant="secondary" size="sm" onClick={onClose}>
-            Close
-          </Button>
-          <Button type="button" variant="agent" size="sm" onClick={handleCopy}>
-            {copied ? 'Copied ✓' : 'Copy prompt'}
-          </Button>
+        {/* spec-282 dec-5(B): once copied, the confirmation sits right next to
+            the action and the copy button has BECOME the Close button — one
+            obvious click to dismiss and get back to the coding agent. */}
+        <div className="flex items-center justify-end gap-3 px-5 py-3 border-t border-edge">
+          {copied ? (
+            <>
+              <p
+                role="status"
+                data-testid="copy-confirmation"
+                className="text-xs font-medium text-heading"
+              >
+                Copied. Now go to your coding agent and paste.
+              </p>
+              <Button type="button" variant="agent" size="sm" onClick={onClose} autoFocus>
+                Close
+              </Button>
+            </>
+          ) : (
+            <>
+              <Button type="button" variant="secondary" size="sm" onClick={onClose}>
+                Close
+              </Button>
+              <Button type="button" variant="agent" size="sm" onClick={handleCopy}>
+                Copy prompt
+              </Button>
+            </>
+          )}
         </div>
       </div>
     </div>,
@@ -170,6 +227,7 @@ export function PromptButton({
   linkText = 'Copy',
   sentenceLabel,
   orgBlocks,
+  stub = false,
   disabled = false,
   variant = 'agent',
   onCopy,
@@ -180,7 +238,9 @@ export function PromptButton({
   const prompt = node ? toButtonPrompt({ dataset: BASE_SCAFFOLD, buttonId, context, orgBlocks }) : null;
 
   // Missing-node policy (D-4): a typo'd buttonId is a wiring bug — loud in
-  // dev/test, invisible in prod.
+  // dev/test, invisible in prod. (We still resolve the node in stub mode — it
+  // supplies the dialog label — even though the stub, not the node's full text,
+  // is what the clipboard receives.)
   if (!node || prompt === null) {
     const message = `<PromptButton>: no PromptButtonNode found for buttonId="${buttonId}"`;
     if (import.meta.env.DEV) throw new Error(message);
@@ -188,6 +248,10 @@ export function PromptButton({
     console.error(message);
     return null;
   }
+
+  // spec-282 dec-5(A): in stub mode the dialog shows + copies the short
+  // get_prompt stub; otherwise the full scaffold prompt.
+  const dialogPrompt = stub ? buildHandoffStub(context, node.label) : prompt;
 
   // spec-159 ac-17 — the sentence form. The clickable words (`linkText`, default
   // "Copy") render as a hyperlink-styled <button> (it performs an action, not
@@ -227,7 +291,7 @@ export function PromptButton({
         {open && (
           <PromptDialog
             label={node.label}
-            prompt={prompt}
+            prompt={dialogPrompt}
             onCopy={onCopy}
             onClose={() => setOpen(false)}
           />
@@ -258,7 +322,7 @@ export function PromptButton({
       {open && (
         <PromptDialog
           label={node.label}
-          prompt={prompt}
+          prompt={dialogPrompt}
           onCopy={onCopy}
           onClose={() => setOpen(false)}
         />

--- a/packages/ui/src/components/TransitionSentence.spec-196.test.tsx
+++ b/packages/ui/src/components/TransitionSentence.spec-196.test.tsx
@@ -76,10 +76,15 @@ describe('spec-196 — Rubicon narrative-staleness blocker at specify→build', 
     expect(screen.queryByRole('button')).not.toBeInTheDocument();
   });
 
-  it('narrative fresh → the advancement offer renders (ac-9)', () => {
+  it('narrative fresh → advancement is reachable, not blocked (ac-9)', () => {
     tagAc(AC(9));
-    render(<TransitionSentence {...baseProps({ narrativeStale: false })} />);
-    expect(text()).toContain('Do you wish to move this spec to Build?');
+    // spec-282/dec-4: the current-tab standing offer is gone — a fresh, clean
+    // rubric renders nothing on the current tab. The "fresh unblocks advance"
+    // property now reads on the browse-forward confirm: no blocker text, the
+    // plain "Are you sure…?" + [Yes].
+    render(<TransitionSentence {...baseProps({ narrativeStale: false, viewedTab: 'build' })} />);
+    expect(text()).toContain('Are you sure you want to move this spec to Build?');
+    expect(text()).not.toContain('spec narrative');
     expect(screen.getByRole('button', { name: 'Yes' })).toBeInTheDocument();
   });
 
@@ -133,17 +138,19 @@ describe('spec-196 — Rubicon narrative-staleness blocker at specify→build', 
 
   it('staleness is a specify-axis condition only — build→verify ignores it (ac-8)', () => {
     tagAc(AC(8));
+    // Browse Verify from a clean Build (spec-282/dec-4 removed the current-tab
+    // offer): no narrative blocker on the build→verify axis.
     render(
       <TransitionSentence
         {...baseProps({
           currentPhase: 'build',
-          viewedTab: 'build',
+          viewedTab: 'verify',
           narrativeStale: true,
           totalTaskCount: 2,
         })}
       />,
     );
-    expect(text()).toContain('Do you want to move this spec to Verify?');
+    expect(text()).toContain('Are you sure you want to move this spec to Verify?');
     expect(text()).not.toContain('spec narrative');
   });
 });

--- a/packages/ui/src/components/TransitionSentence.spec-282.test.tsx
+++ b/packages/ui/src/components/TransitionSentence.spec-282.test.tsx
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { TransitionSentence } from './TransitionSentence';
+import type { SpecStatus } from '../api/types';
+
+// spec-282 t-2 / dec-4 — trim the Rubicon's standing advance offer to browse-only.
+//
+//   ac-5  : on the current specify/build/verify tab no advance question/button
+//           renders — status-only in both the ready and the blocked state.
+//   ac-6  : the advance affordance ([Yes]/[No]) appears ONLY when browsing a
+//           non-current phase tab; the editor's force-forward path is reachable
+//           there (spec-258/dec-5 preserved by relocation).
+//   ac-11 : the implementation shape — draft keeps its publish offer; the
+//           current tab is status-only; browsing forward shows the confirm.
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-282/acs/ac-${n}`;
+
+const updateDocStatus = vi.fn();
+vi.mock('../api/client', () => ({
+  updateDocStatus: (...a: unknown[]) => updateDocStatus(...a),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  updateDocStatus.mockResolvedValue(undefined);
+});
+
+const DOC = { id: 'doc-1' };
+
+function baseProps(overrides: Partial<React.ComponentProps<typeof TransitionSentence>> = {}) {
+  return {
+    doc: DOC,
+    currentPhase: 'specify' as SpecStatus,
+    viewedTab: 'specify' as SpecStatus,
+    canTransition: true,
+    totalDecisionCount: 2,
+    openDecisionCount: 0,
+    hasAcceptanceCriteria: true,
+    totalTaskCount: 2,
+    openTaskCount: 0,
+    unverifiedAcCount: 0,
+    ...overrides,
+  };
+}
+
+function text() {
+  return (screen.getByTestId('transition-sentence').textContent ?? '').trim();
+}
+
+describe('spec-282 ac-5/ac-11 — the current phase tab carries no advance offer', () => {
+  // Ready state: every current-phase tab renders nothing — no question, no button.
+  for (const phase of ['specify', 'build', 'verify'] as const) {
+    it(`${phase} ready, current tab → nothing renders (no offer, no button)`, () => {
+      tagAc(AC(5));
+      tagAc(AC(11));
+      render(<TransitionSentence {...baseProps({ currentPhase: phase, viewedTab: phase })} />);
+      expect(screen.queryByTestId('transition-sentence')).toBeNull();
+      expect(screen.queryByRole('button')).toBeNull();
+    });
+  }
+
+  // Blocked state: the rubric statement renders, but there is NO question and NO
+  // button — status-only — for editors and non-editors alike.
+  for (const canTransition of [true, false]) {
+    it(`specify blocked, current tab (canTransition=${canTransition}) → blocker text only, no button`, () => {
+      tagAc(AC(5));
+      tagAc(AC(11));
+      render(
+        <TransitionSentence
+          {...baseProps({ openDecisionCount: 3, canTransition })}
+        />,
+      );
+      expect(text()).toContain('3 Decisions must be resolved before this spec can move to Build.');
+      expect(text()).not.toContain('?');
+      expect(screen.queryByRole('button')).toBeNull();
+    });
+  }
+
+  it('build blocked, current tab (editor) → tasks statement only, no "anyway?" button', () => {
+    tagAc(AC(5));
+    render(
+      <TransitionSentence
+        {...baseProps({ currentPhase: 'build', viewedTab: 'build', openTaskCount: 2 })}
+      />,
+    );
+    expect(text()).toContain('2 Tasks must be completed before this spec can move to Verify.');
+    expect(text()).not.toContain('anyway?');
+    expect(screen.queryByRole('button')).toBeNull();
+  });
+});
+
+describe('spec-282 ac-11 — draft keeps the publish offer', () => {
+  it('draft (editor) → "Do you wish to move this spec to Specify?" + [Yes]', () => {
+    tagAc(AC(11));
+    render(
+      <TransitionSentence
+        {...baseProps({
+          currentPhase: 'draft',
+          viewedTab: 'specify',
+          totalDecisionCount: 0,
+          hasAcceptanceCriteria: false,
+        })}
+      />,
+    );
+    expect(text()).toContain('Do you wish to move this spec to Specify?');
+    expect(screen.getByRole('button', { name: 'Yes' })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'No' })).toBeNull();
+  });
+
+  it('draft (non-editor) → nothing to act on, renders nothing', () => {
+    tagAc(AC(11));
+    render(
+      <TransitionSentence
+        {...baseProps({
+          currentPhase: 'draft',
+          viewedTab: 'specify',
+          canTransition: false,
+          totalDecisionCount: 0,
+          hasAcceptanceCriteria: false,
+        })}
+      />,
+    );
+    expect(screen.queryByTestId('transition-sentence')).toBeNull();
+  });
+});
+
+describe('spec-282 ac-6/ac-11 — the advance affordance lives on the browse-forward confirm', () => {
+  it('browsing the forward phase tab (clean) → "Are you sure…?" + [Yes] [No]', () => {
+    tagAc(AC(6));
+    tagAc(AC(11));
+    render(<TransitionSentence {...baseProps({ currentPhase: 'build', viewedTab: 'verify' })} />);
+    expect(text()).toContain('Are you sure you want to move this spec to Verify?');
+    expect(screen.getByRole('button', { name: 'Yes' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'No' })).toBeTruthy();
+  });
+
+  it('editor force-forward: browse the forward tab while blocked → "Move this spec anyway?" forces the move', async () => {
+    tagAc(AC(6));
+    const user = userEvent.setup();
+    render(
+      <TransitionSentence
+        {...baseProps({ currentPhase: 'build', viewedTab: 'verify', openTaskCount: 2 })}
+      />,
+    );
+    expect(text()).toContain('Move this spec anyway?');
+    await user.click(screen.getByRole('button', { name: 'Yes' }));
+    await waitFor(() => expect(updateDocStatus).toHaveBeenCalledWith('doc-1', 'verify'));
+  });
+
+  it('the [No] on the browse confirm returns to the current tab and never mutates', async () => {
+    tagAc(AC(6));
+    const user = userEvent.setup();
+    const onCancelBrowse = vi.fn();
+    render(
+      <TransitionSentence
+        {...baseProps({ currentPhase: 'build', viewedTab: 'verify', onCancelBrowse })}
+      />,
+    );
+    await user.click(screen.getByRole('button', { name: 'No' }));
+    expect(onCancelBrowse).toHaveBeenCalled();
+    expect(updateDocStatus).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/components/TransitionSentence.test.tsx
+++ b/packages/ui/src/components/TransitionSentence.test.tsx
@@ -52,15 +52,8 @@ function text() {
   return (screen.getByTestId('transition-sentence').textContent ?? '').trim();
 }
 
-describe('Rubicon line — shape 1: current tab, rubric clean → offer + Yes', () => {
-  it('carries NO status lead — the tab bar already names the current phase', () => {
-    tagAc(AC(3));
-    render(<TransitionSentence {...baseProps({ currentPhase: 'build', viewedTab: 'build' })} />);
-    expect(text()).not.toContain('currently in');
-    expect(text()).toContain('Do you want to move this spec to Verify?');
-  });
-
-  it('draft → offers specify (draft is never gated)', () => {
+describe('Rubicon line — current tab is status-only (spec-282/dec-4); draft keeps its publish offer', () => {
+  it('draft → offers specify (the single publish moment, never gated)', () => {
     tagAc(AC(3));
     tagAc(AC(13));
     render(
@@ -78,41 +71,30 @@ describe('Rubicon line — shape 1: current tab, rubric clean → offer + Yes', 
     expect(screen.queryByRole('button', { name: 'No' })).toBeNull();
   });
 
-  it('specify (clean) → "Do you wish to move this spec to Build?" + Yes', () => {
-    tagAc(AC(3));
-    tagAc(AC(13));
+  it('specify (clean, current tab) → renders nothing (no standing offer)', () => {
     render(<TransitionSentence {...baseProps()} />);
-    expect(text()).toContain('Do you wish to move this spec to Build?');
-    expect(screen.getByRole('button', { name: 'Yes' })).toBeTruthy();
+    expect(screen.queryByTestId('transition-sentence')).toBeNull();
+    expect(screen.queryByRole('button')).toBeNull();
   });
 
-  it('build (clean) → "Do you want to move this spec to Verify?" + Yes', () => {
-    tagAc(AC(3));
-    tagAc(AC(13));
+  it('build (clean, current tab) → renders nothing', () => {
     render(<TransitionSentence {...baseProps({ currentPhase: 'build', viewedTab: 'build' })} />);
-    expect(text()).toContain('Do you want to move this spec to Verify?');
-    expect(screen.getByRole('button', { name: 'Yes' })).toBeTruthy();
+    expect(screen.queryByTestId('transition-sentence')).toBeNull();
   });
 
-  it('verify (clean) → "Do you want to move this spec to Done?" + Yes', () => {
-    tagAc(AC(3));
-    tagAc(AC(13));
+  it('verify (clean, current tab) → renders nothing', () => {
     render(<TransitionSentence {...baseProps({ currentPhase: 'verify', viewedTab: 'verify' })} />);
-    expect(text()).toContain('Do you want to move this spec to Done?');
-    expect(screen.getByRole('button', { name: 'Yes' })).toBeTruthy();
+    expect(screen.queryByTestId('transition-sentence')).toBeNull();
   });
 });
 
-// spec-258/dec-5 amended shape 2: the blocked current tab still states the exact
-// rubric condition (spec-159 ac-13), and now an EDITOR additionally gets a "Move
-// this spec to {Phase} anyway?" override [Yes]. A non-editor still sees the
-// blocker statement alone (spec-182/dec-2). The blocker-text assertions below
-// keep ac-13 covered; the override assertions cover spec-258 ac-9 / ac-8.
-describe('Rubicon line — shape 2: current tab, blocked → exact status + editor override (spec-258)', () => {
-  it('specify with no decisions and no ACs → combined summary + editor override', () => {
-    tagAc(AC(3));
+// spec-282/dec-4: the blocked current tab is STATUS-ONLY — it states the exact
+// rubric condition (spec-159 ac-13) but carries NO advance question and NO
+// button (the spec-258/dec-5 editor override relocates to the browse-forward
+// confirm — see the relocated describe block at the end of this file).
+describe('Rubicon line — current tab, blocked → status-only rubric statement (no offer; spec-282/dec-4)', () => {
+  it('specify with no decisions and no ACs → combined summary, no question, no button', () => {
     tagAc(AC(13));
-    tagAc(S258(9));
     render(
       <TransitionSentence
         {...baseProps({ totalDecisionCount: 0, hasAcceptanceCriteria: false })}
@@ -121,19 +103,16 @@ describe('Rubicon line — shape 2: current tab, blocked → exact status + edit
     expect(text()).toContain(
       'Decisions and Acceptance Criteria (ACs) must be created before this spec can move to Build.',
     );
-    // dec-5: the editor override appears on the blocked current tab.
-    expect(text()).toContain('Move this spec to Build anyway?');
-    expect(screen.getByRole('button', { name: 'Yes' })).toBeTruthy();
-    expect(screen.queryByRole('button', { name: 'No' })).toBeNull();
+    expect(text()).not.toContain('anyway?');
+    expect(screen.queryByRole('button')).toBeNull();
   });
 
-  it('specify with open decisions and ACs present → decisions-only summary + override', () => {
+  it('specify with open decisions and ACs present → decisions-only summary, no button', () => {
     tagAc(AC(13));
-    tagAc(S258(9));
     render(<TransitionSentence {...baseProps({ openDecisionCount: 4 })} />);
     expect(text()).toContain('4 Decisions must be resolved before this spec can move to Build.');
-    expect(text()).toContain('Move this spec to Build anyway?');
-    expect(screen.getByRole('button', { name: 'Yes' })).toBeTruthy();
+    expect(text()).not.toContain('anyway?');
+    expect(screen.queryByRole('button')).toBeNull();
   });
 
   it('singular grammar: 1 open decision → "1 Decision must be resolved"', () => {
@@ -142,33 +121,29 @@ describe('Rubicon line — shape 2: current tab, blocked → exact status + edit
     expect(text()).toContain('1 Decision must be resolved before this spec can move to Build.');
   });
 
-  it('build with open tasks → "{N} Tasks must be completed…" + override to Verify', () => {
+  it('build with open tasks → "{N} Tasks must be completed…", no button', () => {
     tagAc(AC(13));
-    tagAc(S258(9));
     render(
       <TransitionSentence
         {...baseProps({ currentPhase: 'build', viewedTab: 'build', openTaskCount: 2 })}
       />,
     );
     expect(text()).toContain('2 Tasks must be completed before this spec can move to Verify.');
-    expect(text()).toContain('Move this spec to Verify anyway?');
-    expect(screen.getByRole('button', { name: 'Yes' })).toBeTruthy();
+    expect(screen.queryByRole('button')).toBeNull();
   });
 
-  it('verify with unverified ACs → "{N} Acceptance Criteria (ACs) must be verified…" + override to Done', () => {
+  it('verify with unverified ACs → "{N} Acceptance Criteria (ACs) must be verified…", no button', () => {
     tagAc(AC(13));
-    tagAc(S258(9));
     render(
       <TransitionSentence
         {...baseProps({ currentPhase: 'verify', viewedTab: 'verify', unverifiedAcCount: 3 })}
       />,
     );
     expect(text()).toContain('3 Acceptance Criteria (ACs) must be verified before this spec can move to Done.');
-    expect(text()).toContain('Move this spec to Done anyway?');
-    expect(screen.getByRole('button', { name: 'Yes' })).toBeTruthy();
+    expect(screen.queryByRole('button')).toBeNull();
   });
 
-  it('build with ZERO tasks is blocked — an empty build still offers the editor override', () => {
+  it('build with ZERO tasks is blocked — status statement, no button', () => {
     tagAc(AC(13));
     render(
       <TransitionSentence
@@ -181,7 +156,7 @@ describe('Rubicon line — shape 2: current tab, blocked → exact status + edit
       />,
     );
     expect(text()).toContain('Tasks must be created and completed before this spec can move to Verify.');
-    expect(text()).toContain('Move this spec to Verify anyway?');
+    expect(screen.queryByRole('button')).toBeNull();
   });
 
   it('verify with NO active ACs is blocked — nothing to verify against', () => {
@@ -312,12 +287,13 @@ describe('Rubicon line — posture (i-1) and the Yes mutation', () => {
 
   it('pressing Yes calls updateDocStatus(docId, target) immediately, no dialog (ac-6)', async () => {
     tagAc(AC(6));
-    tagAc(AC(13));
     const user = userEvent.setup();
     const onTransitioned = vi.fn();
+    // spec-282/dec-4: the advance [Yes] now lives on the browse-forward confirm,
+    // not the current tab. Browse Verify from Build (clean) → "Are you sure…?".
     render(
       <TransitionSentence
-        {...baseProps({ currentPhase: 'build', viewedTab: 'build', onTransitioned })}
+        {...baseProps({ currentPhase: 'build', viewedTab: 'verify', onTransitioned })}
       />,
     );
     expect(screen.queryByRole('dialog')).toBeNull();
@@ -353,13 +329,15 @@ describe('no switch-to-Editing nag (spec-182 dec-6, amended)', () => {
   });
 });
 
-// spec-258/dec-5 — the editor override on a blocked current tab, end to end. The
-// override is phase-generic, so it must work on every forward axis; pressing its
-// [Yes] forces the move through the existing updateDocStatus(target) call (the
-// move the server already accepts — soft gates, spec-12/dec-6). A non-editor's
-// blocked current tab stays status-only (spec-182/dec-2). Covers ac-9 / ac-8.
-describe('Rubicon line — editor override on a blocked current tab (spec-258 dec-5)', () => {
-  it('verify→done: blocked editor presses "Move … anyway?" → updateDocStatus(doc, "done") (the issue-3 close)', async () => {
+// spec-258/dec-5 via spec-282/dec-4 — the editor's force-forward capability is
+// PRESERVED but RELOCATED: it no longer sits on the blocked current tab, it
+// lives on the browse-forward confirm. An editor advances a blocked spec by
+// clicking the forward phase pill and pressing "Move this spec anyway? [Yes]",
+// which forces the move through the existing updateDocStatus(target) call (the
+// move the server already accepts — soft gates, spec-12/dec-6). A non-editor
+// browsing forward while blocked stays status-only. Covers ac-9 / ac-8.
+describe('Rubicon line — editor force-forward relocates to the browse-forward confirm (spec-258 dec-5 / spec-282 dec-4)', () => {
+  it('verify→done: editor browses the Done tab while blocked → "Move … anyway?" → updateDocStatus(doc, "done")', async () => {
     tagAc(S258(9));
     tagAc(S258(8));
     const user = userEvent.setup();
@@ -368,58 +346,59 @@ describe('Rubicon line — editor override on a blocked current tab (spec-258 de
       <TransitionSentence
         {...baseProps({
           currentPhase: 'verify',
-          viewedTab: 'verify',
+          viewedTab: 'done',
           unverifiedAcCount: 3,
           onTransitioned,
         })}
       />,
     );
-    expect(text()).toContain('Move this spec to Done anyway?');
+    expect(text()).toContain('Move this spec anyway?');
     await user.click(screen.getByRole('button', { name: 'Yes' }));
     await waitFor(() => expect(updateDocStatus).toHaveBeenCalledWith('doc-1', 'done'));
     await waitFor(() => expect(onTransitioned).toHaveBeenCalledWith('done'));
   });
 
-  it('build→verify: blocked editor override forces the move via updateDocStatus(doc, "verify")', async () => {
+  it('build→verify: editor browses Verify while blocked → updateDocStatus(doc, "verify")', async () => {
     tagAc(S258(9));
     const user = userEvent.setup();
     render(
       <TransitionSentence
-        {...baseProps({ currentPhase: 'build', viewedTab: 'build', openTaskCount: 2 })}
+        {...baseProps({ currentPhase: 'build', viewedTab: 'verify', openTaskCount: 2 })}
       />,
     );
+    expect(text()).toContain('Move this spec anyway?');
     await user.click(screen.getByRole('button', { name: 'Yes' }));
     await waitFor(() => expect(updateDocStatus).toHaveBeenCalledWith('doc-1', 'verify'));
   });
 
-  it('specify→build: blocked editor override forces the move via updateDocStatus(doc, "build")', async () => {
+  it('specify→build: editor browses Build while blocked → updateDocStatus(doc, "build")', async () => {
     tagAc(S258(9));
     const user = userEvent.setup();
-    render(<TransitionSentence {...baseProps({ openDecisionCount: 4 })} />);
+    render(<TransitionSentence {...baseProps({ viewedTab: 'build', openDecisionCount: 4 })} />);
+    expect(text()).toContain('Move this spec anyway?');
     await user.click(screen.getByRole('button', { name: 'Yes' }));
     await waitFor(() => expect(updateDocStatus).toHaveBeenCalledWith('doc-1', 'build'));
   });
 
-  it('non-editor blocked current tab stays status-only on every axis — no override (ac-8, spec-182/dec-2)', () => {
+  it('non-editor browsing forward while blocked stays status-only on every axis — no override (ac-8)', () => {
     tagAc(S258(8));
     const axes = [
-      { props: { openDecisionCount: 4 }, phase: 'Build' },
-      { props: { currentPhase: 'build' as SpecStatus, viewedTab: 'build' as SpecStatus, openTaskCount: 2 }, phase: 'Verify' },
+      { props: { viewedTab: 'build' as SpecStatus, openDecisionCount: 4 } },
+      { props: { currentPhase: 'build' as SpecStatus, viewedTab: 'verify' as SpecStatus, openTaskCount: 2 } },
       {
         props: {
           currentPhase: 'verify' as SpecStatus,
-          viewedTab: 'verify' as SpecStatus,
+          viewedTab: 'done' as SpecStatus,
           unverifiedAcCount: 3,
         },
-        phase: 'Done',
       },
     ];
-    for (const { props, phase } of axes) {
+    for (const { props } of axes) {
       const { unmount } = render(
         <TransitionSentence {...baseProps({ ...props, canTransition: false })} />,
       );
       expect(text()).toContain('must be');
-      expect(text()).not.toContain(`Move this spec to ${phase} anyway?`);
+      expect(text()).not.toContain('anyway?');
       expect(screen.queryByRole('button')).toBeNull();
       unmount();
     }

--- a/packages/ui/src/components/TransitionSentence.tsx
+++ b/packages/ui/src/components/TransitionSentence.tsx
@@ -12,20 +12,24 @@ import { Button } from './ui';
 //
 // Three shapes, keyed on what the user is viewing:
 //
-//   1. CURRENT tab, rubric clean → the advancement offer + [Yes].
-//      "Do you wish to move this spec to Build?"
-//   2. CURRENT tab, rubric blocked → the outstanding work, stated plainly.
+//   1. CURRENT tab → STATUS-ONLY (spec-282/dec-4). The standing advancement
+//      offer is GONE from the current phase tab: a clean rubric renders nothing,
+//      and a blocked rubric renders the outstanding work as a plain statement —
+//      no question, no button.
 //      "**4 Decisions** must be resolved and **Acceptance Criteria (ACs)**
 //       must be created before this spec can move to Build."
-//      spec-258/dec-5 (amends spec-159/dec-4): for an EDITOR the line ALSO
-//      offers a "Move this spec to {Phase} anyway?" override [Yes] — the move is
-//      forceable from the kanban, so the spec page shouldn't withhold it. A
-//      non-editor still sees the blocker statement alone (no question, no button).
+//      The ONE current-tab offer that survives is the DRAFT publish moment:
+//      draft has no tab of its own, so viewing the Specify tab while in draft is
+//      the single "publish this spec to Specify?" gate and keeps its [Yes].
+//   2. (folded into 1) — there is no longer a distinct clean-vs-blocked OFFER on
+//      the current tab; both are status-only for specify/build/verify.
 //   3. BROWSING another tab → an explicit confirm: [Yes] [No]. Forward+blocked
 //      leads with the blocker summary (which names the target) and asks "Move
-//      this spec anyway?" — the deliberate-friction escape hatch. No returns
-//      the view to the current phase's tab. Backward moves never carry
-//      blockers (dec-5).
+//      this spec anyway?" — the deliberate-friction escape hatch AND the
+//      relocated home of the editor's force-forward capability (spec-258/dec-5):
+//      an editor advances a blocked spec by clicking the forward phase pill and
+//      pressing [Yes] here. No returns the view to the current phase's tab.
+//      Backward moves never carry blockers.
 //
 // Posture (spec-182 issue-1): the Rubicon is STATUS-ONLY for non-editors.
 // When `canTransition` is false the blocker statements still render — they are
@@ -271,33 +275,29 @@ export function TransitionSentence({
     return null;
   }
 
-  // Shape 1/2 — viewing the current phase's own tab.
+  // Shape 1 — viewing the current phase's own tab.
   if (viewingCurrentTab) {
-    if (blockers.length > 0) {
-      // Blocked: always state the exact rubric condition. spec-258/dec-5: an
-      // EDITOR additionally gets a "Move … anyway?" override — phase gates are
-      // soft (spec-12/dec-6) and the move is already forceable from the kanban,
-      // so the spec page shouldn't be the lone surface that withholds it. The
-      // override is phase-generic, so it covers specify→build, build→verify and
-      // verify→done alike. A non-editor (canTransition === false) keeps the
-      // status-only blocker text — no question, no button (spec-182/dec-2).
+    // spec-282/dec-4: the standing advance offer is removed from the current
+    // phase tab. For specify/build/verify the current-tab line is STATUS-ONLY —
+    // blocked → the rubric statement alone (no question, no button); clean →
+    // nothing (the filled phase pill already carries the phase). The editor's
+    // force-forward capability (spec-258/dec-5) is NOT lost: it relocates to
+    // browsing the forward phase tab (Shape 3 below), where "Move this spec
+    // anyway? [Yes]" still forces a blocked move.
+    if (currentPhase !== 'draft') {
+      if (blockers.length === 0) {
+        return null;
+      }
       return (
         <p className="text-sm text-secondary" data-testid="transition-sentence">
           {renderBlockers(blockers)} before this spec can move to {phaseDisplayName(target)}
           {refreshTail}.
-          {canTransition && (
-            <>
-              {' '}
-              Move this spec to {phaseDisplayName(target)} anyway? {yesButton}
-              {errorNote}
-            </>
-          )}
         </p>
       );
     }
-    // Ready: the advancement offer — editors only. A non-editor has nothing
-    // to act on, and the tab bar's filled pill already carries the phase
-    // (spec-182 issue-1).
+    // The draft → specify publish moment — the single current-tab offer that
+    // survives. draft → specify is never gated, so there is no blocker branch.
+    // Editors only: a non-editor has nothing to act on (spec-182 issue-1).
     if (!canTransition) {
       return null;
     }

--- a/packages/ui/src/components/whats-new/WhatsNewContext.test.tsx
+++ b/packages/ui/src/components/whats-new/WhatsNewContext.test.tsx
@@ -1,0 +1,76 @@
+// spec-200 (2026-06-13 behaviour pass) — the WhatsNewContext that lets the sidebar
+// user menu re-open the What's New popup after the ribbon has been dismissed (req 5),
+// and gates the menu item on feed availability.
+
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { WhatsNewProvider, useWhatsNew } from './WhatsNewContext';
+import { WhatsNewRibbon } from './WhatsNewRibbon';
+import type { WhatsNewEntry } from '../../api/whatsNew';
+
+const ENTRY: WhatsNewEntry = {
+  id: 'spec-200',
+  sourceSpecRef: 'mindset-prod/memex-building-itself/specs/spec-200',
+  sourceSpecHandle: 'spec-200',
+  title: 'See what shipped',
+  what: "A What's New feed.",
+  why: 'You always know what changed.',
+  publishedAt: '2026-06-08T10:00:00Z',
+};
+
+// Stand-in for the sidebar user menu — shows the item only when a feed exists.
+function FakeMenu() {
+  const { available, openPopup } = useWhatsNew();
+  if (!available) return null;
+  return (
+    <button data-testid="menu-whats-new" onClick={openPopup}>
+      What's New
+    </button>
+  );
+}
+
+function setReducedMotion(reduce: boolean) {
+  window.matchMedia = vi.fn().mockImplementation((q: string) => ({
+    matches: reduce, media: q, onchange: null,
+    addEventListener: vi.fn(), removeEventListener: vi.fn(),
+    addListener: vi.fn(), removeListener: vi.fn(), dispatchEvent: vi.fn(),
+  })) as unknown as typeof window.matchMedia;
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+  setReducedMotion(true);
+});
+afterEach(() => cleanup());
+
+describe('WhatsNewContext', () => {
+  it('the menu item appears only when the feed has entries, and re-opens the popup after dismissal', async () => {
+    render(
+      <WhatsNewProvider>
+        <FakeMenu />
+        <WhatsNewRibbon fetcher={async () => [ENTRY]} autoDismissMs={0} />
+      </WhatsNewProvider>,
+    );
+
+    // The menu item shows once the feed resolves.
+    await screen.findByTestId('menu-whats-new');
+    // Dismiss the ribbon via its ×.
+    fireEvent.click(await screen.findByTestId('whats-new-ribbon-dismiss'));
+    await waitFor(() => expect(screen.queryByTestId('whats-new-ribbon')).toBeNull());
+
+    // Menu item is still there (feed still has entries) and re-opens the popup.
+    fireEvent.click(screen.getByTestId('menu-whats-new'));
+    expect(await screen.findByTestId('whats-new-popup')).toBeTruthy();
+  });
+
+  it('shows no menu item when the feed is empty', async () => {
+    render(
+      <WhatsNewProvider>
+        <FakeMenu />
+        <WhatsNewRibbon fetcher={async () => []} autoDismissMs={0} />
+      </WhatsNewProvider>,
+    );
+    await waitFor(() => {});
+    expect(screen.queryByTestId('menu-whats-new')).toBeNull();
+  });
+});

--- a/packages/ui/src/components/whats-new/WhatsNewContext.tsx
+++ b/packages/ui/src/components/whats-new/WhatsNewContext.tsx
@@ -1,0 +1,75 @@
+// spec-200 (follow-up): shared coordination between the What's New ribbon (rendered
+// high in App.tsx) and the user menu in the sidebar (AppShell). The ribbon and the
+// menu live in different parts of the tree, so they talk through this context:
+//
+//  • the menu's "What's New" item calls openPopup() to re-open the popup even after
+//    the ribbon has been dismissed (req 5);
+//  • the menu registers its anchor element so the ribbon can animate "into" it on
+//    dismiss (req 4 — the fly-home animation reads getMenuAnchor());
+//  • the ribbon reports `available` so the menu only shows the item when a feed
+//    actually exists.
+//
+// The default value is a no-op so components (AppShell) can consume it unconditionally
+// in tests that don't mount the provider.
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+
+interface WhatsNewContextValue {
+  /** True when at least one feed entry exists — gates the menu item. */
+  available: boolean;
+  /** The ribbon reports feed availability here. */
+  setAvailable: (v: boolean) => void;
+  /** Open the What's New popup (used by the sidebar menu item). */
+  openPopup: () => void;
+  /** The ribbon registers the handler that openPopup() invokes. */
+  registerOpener: (fn: (() => void) | null) => void;
+  /** The sidebar user card registers its element as the fly-home target. */
+  registerMenuAnchor: (el: HTMLElement | null) => void;
+  /** The ribbon reads the menu anchor to compute the dismiss animation target. */
+  getMenuAnchor: () => HTMLElement | null;
+}
+
+const noop = () => {};
+
+const WhatsNewContext = createContext<WhatsNewContextValue>({
+  available: false,
+  setAvailable: noop,
+  openPopup: noop,
+  registerOpener: noop,
+  registerMenuAnchor: noop,
+  getMenuAnchor: () => null,
+});
+
+export function WhatsNewProvider({ children }: { children: ReactNode }) {
+  const [available, setAvailable] = useState(false);
+  const openerRef = useRef<(() => void) | null>(null);
+  const anchorRef = useRef<HTMLElement | null>(null);
+
+  const openPopup = useCallback(() => openerRef.current?.(), []);
+  const registerOpener = useCallback((fn: (() => void) | null) => {
+    openerRef.current = fn;
+  }, []);
+  const registerMenuAnchor = useCallback((el: HTMLElement | null) => {
+    anchorRef.current = el;
+  }, []);
+  const getMenuAnchor = useCallback(() => anchorRef.current, []);
+
+  const value = useMemo<WhatsNewContextValue>(
+    () => ({ available, setAvailable, openPopup, registerOpener, registerMenuAnchor, getMenuAnchor }),
+    [available, openPopup, registerOpener, registerMenuAnchor, getMenuAnchor],
+  );
+
+  return <WhatsNewContext.Provider value={value}>{children}</WhatsNewContext.Provider>;
+}
+
+export function useWhatsNew(): WhatsNewContextValue {
+  return useContext(WhatsNewContext);
+}

--- a/packages/ui/src/components/whats-new/WhatsNewRibbon.spec-200.test.tsx
+++ b/packages/ui/src/components/whats-new/WhatsNewRibbon.spec-200.test.tsx
@@ -129,25 +129,32 @@ describe('WhatsNewRibbon dismiss + countdown (spec-200 t-6)', () => {
     expect(window.localStorage.getItem('whats-new:dismissed-at')).toBe('2026-06-08T10:00:00Z');
   });
 
+  it('shows the countdown indicator while the ribbon waits', async () => {
+    // Long timer so the countdown is reliably still running when asserted —
+    // no race against auto-dismiss (cleanup unmounts before it fires).
+    // findBy (not getBy): the countdown mounts one effect-tick after the ribbon.
+    render(<WhatsNewRibbon fetcher={async () => ENTRIES} autoDismissMs={10_000} />);
+    expect(await screen.findByTestId('whats-new-countdown')).toBeTruthy();
+  });
+
   it('auto-dismisses after the countdown elapses', async () => {
-    render(<WhatsNewRibbon fetcher={async () => ENTRIES} autoDismissMs={300} />);
+    // Short timer; assert ONLY via waitFor (tolerant of slow runners) that the
+    // ribbon eventually flies home — never a synchronous query racing the timer.
+    render(<WhatsNewRibbon fetcher={async () => ENTRIES} autoDismissMs={150} />);
     await screen.findByTestId('whats-new-ribbon');
-    // The countdown border is present while the ribbon waits.
-    expect(screen.getByTestId('whats-new-countdown')).toBeTruthy();
-    // After the countdown the ribbon flies home and unmounts.
-    await waitFor(() => expect(screen.queryByTestId('whats-new-ribbon')).toBeNull(), { timeout: 2000 });
+    await waitFor(() => expect(screen.queryByTestId('whats-new-ribbon')).toBeNull(), { timeout: 4000 });
     expect(window.localStorage.getItem('whats-new:dismissed-at')).toBe('2026-06-08T10:00:00Z');
   });
 
   it('tapping the ribbon stops the countdown — it does not auto-dismiss', async () => {
-    render(<WhatsNewRibbon fetcher={async () => ENTRIES} autoDismissMs={300} />);
+    // Long timer so the only timing dependency (mount → click) has wide headroom.
+    render(<WhatsNewRibbon fetcher={async () => ENTRIES} autoDismissMs={10_000} />);
     const ribbon = await screen.findByTestId('whats-new-ribbon');
+    await screen.findByTestId('whats-new-countdown'); // counting before the tap
     fireEvent.click(ribbon); // open popup → stops countdown
     await screen.findByTestId('whats-new-popup');
-    // The countdown indicator is gone and the ribbon does not auto-dismiss.
+    // Tapping removed the countdown indicator and the ribbon is still present.
     expect(screen.queryByTestId('whats-new-countdown')).toBeNull();
-    await new Promise((r) => setTimeout(r, 500));
-    expect(screen.getByTestId('whats-new-popup')).toBeTruthy();
     expect(screen.getByTestId('whats-new-ribbon')).toBeTruthy();
   });
 

--- a/packages/ui/src/components/whats-new/WhatsNewRibbon.spec-200.test.tsx
+++ b/packages/ui/src/components/whats-new/WhatsNewRibbon.spec-200.test.tsx
@@ -1,9 +1,17 @@
-// spec-200 t-5 / t-6 — the What's New ribbon + popup + dismiss semantics.
+// spec-200 t-5 / t-6 (+ 2026-06-13 behaviour pass) — the What's New ribbon.
 //
 // ac-11 — ribbon renders when an undismissed entry exists; click opens the popup
-//         (entries newest-first, What/Why shown). Confetti fires on slide-up.
-// ac-12 — popup close ≠ dismiss; only the ribbon × dismisses; dismissal persists
-//         per-user (localStorage) and a newer entry re-shows the ribbon.
+//         (entries newest-first, What/Why shown). Confetti fires on FIRST sighting.
+// ac-12 — the ribbon × dismisses and the dismissal persists per-user (localStorage);
+//         a newer entry re-shows the ribbon.
+//
+// Follow-up behaviour (this pass):
+//  • confetti fires only the first time an entry is seen — a repeat visit shows the
+//    ribbon WITHOUT confetti;
+//  • a 6s auto-dismiss countdown (bottom border) removes the ribbon; tapping it or
+//    the × stops the countdown;
+//  • manually closing the popup dismisses the ribbon (supersedes dec-4's
+//    "popup close ≠ dismiss").
 
 import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
@@ -53,7 +61,8 @@ afterEach(() => cleanup());
 
 describe('WhatsNewRibbon (spec-200 t-5)', () => {
   it('renders the ribbon for an unseen entry, fires confetti, and opens the popup newest-first (ac-11)', async () => {
-    render(<WhatsNewRibbon fetcher={async () => ENTRIES} onExplain={() => {}} />);
+    // autoDismissMs=0 keeps the ribbon up for the assertions (no countdown timer).
+    render(<WhatsNewRibbon fetcher={async () => ENTRIES} onExplain={() => {}} autoDismissMs={0} />);
 
     const ribbon = await screen.findByTestId('whats-new-ribbon');
     expect(ribbon).toBeTruthy();
@@ -74,49 +83,85 @@ describe('WhatsNewRibbon (spec-200 t-5)', () => {
 
   it('skips confetti under prefers-reduced-motion but still shows the ribbon', async () => {
     setReducedMotion(true);
-    render(<WhatsNewRibbon fetcher={async () => ENTRIES} />);
+    render(<WhatsNewRibbon fetcher={async () => ENTRIES} autoDismissMs={0} />);
+    expect(await screen.findByTestId('whats-new-ribbon')).toBeTruthy();
+    expect(screen.queryByTestId('whats-new-confetti')).toBeNull();
+  });
+
+  it('fires confetti only on the first sighting of an entry, not on a repeat visit', async () => {
+    const { unmount } = render(<WhatsNewRibbon fetcher={async () => ENTRIES} autoDismissMs={0} />);
+    expect(await screen.findByTestId('whats-new-confetti')).toBeTruthy();
+    unmount();
+
+    // Same entries, fresh mount (a "next visit") — ribbon shows, confetti does not.
+    render(<WhatsNewRibbon fetcher={async () => ENTRIES} autoDismissMs={0} />);
     expect(await screen.findByTestId('whats-new-ribbon')).toBeTruthy();
     expect(screen.queryByTestId('whats-new-confetti')).toBeNull();
   });
 });
 
-describe('WhatsNewRibbon dismiss semantics (spec-200 t-6)', () => {
-  beforeEach(() => setReducedMotion(true)); // avoid confetti timers in these
+describe('WhatsNewRibbon dismiss + countdown (spec-200 t-6)', () => {
+  beforeEach(() => setReducedMotion(true)); // immediate fly-home + no confetti timers
 
-  it('popup close does NOT dismiss; only the ribbon × dismisses + persists (ac-12)', async () => {
-    render(<WhatsNewRibbon fetcher={async () => ENTRIES} />);
-    const ribbon = await screen.findByTestId('whats-new-ribbon');
+  it('the ribbon × dismisses immediately and persists the marker (ac-12)', async () => {
+    render(<WhatsNewRibbon fetcher={async () => ENTRIES} autoDismissMs={0} />);
+    await screen.findByTestId('whats-new-ribbon');
 
-    // Open then close the popup via scrim — ribbon must remain.
-    fireEvent.click(ribbon);
-    await screen.findByTestId('whats-new-popup'); // ribbon → popup (scope ac-2)
-    tagAc(AC(2));
-    fireEvent.click(await screen.findByTestId('whats-new-scrim'));
-    await waitFor(() => expect(screen.queryByTestId('whats-new-popup')).toBeNull());
-    expect(screen.getByTestId('whats-new-ribbon')).toBeTruthy(); // still there
-
-    // The ribbon's own × dismisses it AND persists the marker.
     fireEvent.click(screen.getByTestId('whats-new-ribbon-dismiss'));
     await waitFor(() => expect(screen.queryByTestId('whats-new-ribbon')).toBeNull());
     expect(window.localStorage.getItem('whats-new:dismissed-at')).toBe('2026-06-08T10:00:00Z');
 
     tagAc(AC(12));
-    // Scope ac-3: ribbon persists until its own × (popup close ≠ dismiss) and the
-    // dismissal is remembered per user.
-    tagAc(AC(3));
+  });
+
+  it('manually closing the popup dismisses the ribbon (popup close → fly home)', async () => {
+    render(<WhatsNewRibbon fetcher={async () => ENTRIES} autoDismissMs={0} />);
+    const ribbon = await screen.findByTestId('whats-new-ribbon');
+
+    // Tap the ribbon → popup opens (and the countdown, if any, stops).
+    fireEvent.click(ribbon);
+    await screen.findByTestId('whats-new-popup');
+
+    // Closing the popup (scrim) now dismisses the ribbon — it flies home and goes.
+    fireEvent.click(screen.getByTestId('whats-new-scrim'));
+    await waitFor(() => expect(screen.queryByTestId('whats-new-popup')).toBeNull());
+    await waitFor(() => expect(screen.queryByTestId('whats-new-ribbon')).toBeNull());
+    expect(window.localStorage.getItem('whats-new:dismissed-at')).toBe('2026-06-08T10:00:00Z');
+  });
+
+  it('auto-dismisses after the countdown elapses', async () => {
+    render(<WhatsNewRibbon fetcher={async () => ENTRIES} autoDismissMs={300} />);
+    await screen.findByTestId('whats-new-ribbon');
+    // The countdown border is present while the ribbon waits.
+    expect(screen.getByTestId('whats-new-countdown')).toBeTruthy();
+    // After the countdown the ribbon flies home and unmounts.
+    await waitFor(() => expect(screen.queryByTestId('whats-new-ribbon')).toBeNull(), { timeout: 2000 });
+    expect(window.localStorage.getItem('whats-new:dismissed-at')).toBe('2026-06-08T10:00:00Z');
+  });
+
+  it('tapping the ribbon stops the countdown — it does not auto-dismiss', async () => {
+    render(<WhatsNewRibbon fetcher={async () => ENTRIES} autoDismissMs={300} />);
+    const ribbon = await screen.findByTestId('whats-new-ribbon');
+    fireEvent.click(ribbon); // open popup → stops countdown
+    await screen.findByTestId('whats-new-popup');
+    // The countdown indicator is gone and the ribbon does not auto-dismiss.
+    expect(screen.queryByTestId('whats-new-countdown')).toBeNull();
+    await new Promise((r) => setTimeout(r, 500));
+    expect(screen.getByTestId('whats-new-popup')).toBeTruthy();
+    expect(screen.getByTestId('whats-new-ribbon')).toBeTruthy();
   });
 
   it('stays dismissed across reloads until a NEWER entry publishes (ac-12)', async () => {
     // Marker already at the newest entry's time → ribbon should not show.
     window.localStorage.setItem('whats-new:dismissed-at', '2026-06-08T10:00:00Z');
-    const { unmount } = render(<WhatsNewRibbon fetcher={async () => ENTRIES} />);
+    const { unmount } = render(<WhatsNewRibbon fetcher={async () => ENTRIES} autoDismissMs={0} />);
     await waitFor(() => {}); // let fetch resolve
     expect(screen.queryByTestId('whats-new-ribbon')).toBeNull();
     unmount();
 
     // A newer entry publishes → ribbon reappears.
     const newer = [entry('spec-201', '2026-06-09T10:00:00Z'), ...ENTRIES];
-    render(<WhatsNewRibbon fetcher={async () => newer} />);
+    render(<WhatsNewRibbon fetcher={async () => newer} autoDismissMs={0} />);
     expect(await screen.findByTestId('whats-new-ribbon')).toBeTruthy();
 
     tagAc(AC(12));

--- a/packages/ui/src/components/whats-new/WhatsNewRibbon.tsx
+++ b/packages/ui/src/components/whats-new/WhatsNewRibbon.tsx
@@ -88,8 +88,8 @@ export function WhatsNewRibbon({
 
   const ribbonRef = useRef<HTMLDivElement>(null);
   const dismissingRef = useRef(false);
-  const dismissTimer = useRef<ReturnType<typeof setTimeout>>();
-  const flyTimer = useRef<ReturnType<typeof setTimeout>>();
+  const dismissTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  const flyTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
   useEffect(() => {
     let alive = true;

--- a/packages/ui/src/components/whats-new/WhatsNewRibbon.tsx
+++ b/packages/ui/src/components/whats-new/WhatsNewRibbon.tsx
@@ -1,24 +1,42 @@
-// spec-200 t-5 / t-6: the What's New surface.
+// spec-200 t-5 / t-6 (+ follow-up behaviour pass): the What's New surface.
 //
 // dec-4: a transient-but-sticky slide-up RIBBON (not a permanent chrome icon).
 // When an undismissed entry newer than the user's last-dismissed marker exists,
-// the ribbon slides up (with a full-screen confetti burst). Clicking it opens a
-// popup of recent entries, newest-first. Closing the popup does NOT dismiss the
-// ribbon — only the ribbon's own × does, and that dismissal persists per-user in
-// localStorage (t-6). Each entry carries an ear affordance that asks Specky to
-// explain it (t-7 wires onExplain).
+// the ribbon slides up. Clicking it opens a popup of recent entries, newest-first.
+// Each entry carries an ear affordance that asks Specky to explain it (t-7).
+//
+// Follow-up behaviour changes (2026-06-13), per the originator:
+//  1. Confetti fires only the FIRST time a given entry is seen (a localStorage
+//     marker, separate from dismissal) — a repeat visit shows the ribbon without
+//     confetti.
+//  2. The ribbon auto-dismisses after 6s, with a bottom border that depletes
+//     right→left as a countdown. Tapping the ribbon (opens the popup) or the ×
+//     both stop the countdown immediately.
+//  3. On dismiss (manual, auto, or popup-close) the ribbon animates "into" the
+//     user menu in the lower-left (translate + fade) — the menu does NOT open.
+//     This reads the menu anchor from WhatsNewContext.
+//  4. The popup can be re-opened from the sidebar "What's New" menu item even
+//     after the ribbon is gone (via WhatsNewContext.openPopup).
+//  5. Manually closing the popup dismisses the ribbon (fly-home), superseding the
+//     earlier dec-4 "popup close ≠ dismiss" rule.
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Specky } from '@memex/guide-sdk';
 import { Confetti } from './Confetti';
+import { useWhatsNew } from './WhatsNewContext';
 import { fetchWhatsNew, type WhatsNewEntry } from '../../api/whatsNew';
 
 const DISMISS_KEY = 'whats-new:dismissed-at';
+const CONFETTI_KEY = 'whats-new:confetti-shown-at';
 
-function readDismissedAt(): number {
+/** Auto-dismiss countdown (ms) and the fly-home animation duration (ms). */
+const AUTO_DISMISS_MS = 6000;
+const FLY_MS = 600;
+
+function readMarker(key: string): number {
   if (typeof window === 'undefined') return 0;
   try {
-    const raw = window.localStorage.getItem(DISMISS_KEY);
+    const raw = window.localStorage.getItem(key);
     const t = raw ? Date.parse(raw) : 0;
     return Number.isNaN(t) ? 0 : t;
   } catch {
@@ -26,10 +44,10 @@ function readDismissedAt(): number {
   }
 }
 
-function writeDismissedAt(iso: string): void {
+function writeMarker(key: string, iso: string): void {
   if (typeof window === 'undefined') return;
   try {
-    window.localStorage.setItem(DISMISS_KEY, iso);
+    window.localStorage.setItem(key, iso);
   } catch {
     /* private mode — non-fatal */
   }
@@ -45,15 +63,33 @@ export interface WhatsNewRibbonProps {
   onExplain?: (entry: WhatsNewEntry) => void;
   /** Injected for tests; defaults to the real GET /api/whats-new. */
   fetcher?: () => Promise<WhatsNewEntry[]>;
+  /** Auto-dismiss countdown in ms; 0 disables it (tests). Default 6000. */
+  autoDismissMs?: number;
 }
 
-export function WhatsNewRibbon({ onExplain, fetcher = fetchWhatsNew }: WhatsNewRibbonProps) {
+export function WhatsNewRibbon({
+  onExplain,
+  fetcher = fetchWhatsNew,
+  autoDismissMs = AUTO_DISMISS_MS,
+}: WhatsNewRibbonProps) {
+  const { setAvailable, registerOpener, getMenuAnchor } = useWhatsNew();
+
   const [entries, setEntries] = useState<WhatsNewEntry[]>([]);
   const [dismissed, setDismissed] = useState(false);
   const [open, setOpen] = useState(false);
   const [slidIn, setSlidIn] = useState(false);
   const [confetti, setConfetti] = useState(false);
-  const firedConfetti = useRef(false);
+  // Countdown: `barRunning` flips on after mount to drive the width transition.
+  const [countingDown, setCountingDown] = useState(false);
+  const [barRunning, setBarRunning] = useState(false);
+  // Fly-home dismiss animation.
+  const [flying, setFlying] = useState(false);
+  const [flyDelta, setFlyDelta] = useState<{ dx: number; dy: number }>({ dx: 0, dy: 0 });
+
+  const ribbonRef = useRef<HTMLDivElement>(null);
+  const dismissingRef = useRef(false);
+  const dismissTimer = useRef<ReturnType<typeof setTimeout>>();
+  const flyTimer = useRef<ReturnType<typeof setTimeout>>();
 
   useEffect(() => {
     let alive = true;
@@ -75,77 +111,196 @@ export function WhatsNewRibbon({ onExplain, fetcher = fetchWhatsNew }: WhatsNewR
     [entries],
   );
 
-  // Visible when there's an entry newer than the dismissed marker (t-6).
-  const hasUnseen = !!newest && Date.parse(newest.publishedAt) > readDismissedAt();
-  const visible = hasUnseen && !dismissed;
+  // The ribbon is "present" when there's an entry newer than the dismissed marker
+  // and the user hasn't dismissed it this session (t-6). Popup visibility is
+  // independent — it can be re-opened from the menu after dismissal.
+  const ribbonPresent = !!newest && Date.parse(newest.publishedAt) > readMarker(DISMISS_KEY) && !dismissed;
 
-  // Slide the ribbon in (next tick → CSS transition) and fire confetti once.
+  // Report feed availability to the sidebar menu item.
   useEffect(() => {
-    if (!visible) {
+    setAvailable(entries.length > 0);
+  }, [entries.length, setAvailable]);
+
+  // Register the menu opener so the sidebar "What's New" item can open the popup.
+  useEffect(() => {
+    registerOpener(() => setOpen(true));
+    return () => registerOpener(null);
+  }, [registerOpener]);
+
+  // Slide the ribbon in, and fire confetti only the first time THIS entry is seen
+  // (req 1/2): a marker distinct from dismissal, so a repeat visit gets no confetti.
+  useEffect(() => {
+    if (!ribbonPresent || flying) {
       setSlidIn(false);
       return;
     }
     const t = setTimeout(() => setSlidIn(true), 30);
-    if (!firedConfetti.current && !prefersReducedMotion()) {
-      firedConfetti.current = true;
-      setConfetti(true);
+    if (newest && !prefersReducedMotion()) {
+      const firstSighting = Date.parse(newest.publishedAt) > readMarker(CONFETTI_KEY);
+      if (firstSighting) {
+        writeMarker(CONFETTI_KEY, newest.publishedAt);
+        setConfetti(true);
+      }
     }
     return () => clearTimeout(t);
-  }, [visible]);
+  }, [ribbonPresent, flying, newest]);
 
-  const dismiss = useCallback(
+  const finalizeDismiss = useCallback(() => {
+    if (newest) writeMarker(DISMISS_KEY, newest.publishedAt);
+    setDismissed(true);
+    setOpen(false);
+    setConfetti(false);
+    setFlying(false);
+    setCountingDown(false);
+  }, [newest]);
+
+  // Dismiss the ribbon by animating it "into" the sidebar user menu (req 3/4),
+  // then finalize. Reduced motion or a missing anchor → finalize immediately.
+  const beginDismiss = useCallback(() => {
+    if (dismissingRef.current) return;
+    dismissingRef.current = true;
+    clearTimeout(dismissTimer.current);
+    setCountingDown(false);
+
+    const ribbonEl = ribbonRef.current;
+    const anchor = getMenuAnchor();
+    const a = anchor?.getBoundingClientRect();
+    // No anchor, a collapsed/hidden menu (zero-size rect), or reduced motion →
+    // skip the fly-home animation and just dismiss.
+    if (prefersReducedMotion() || !ribbonEl || !a || (a.width === 0 && a.height === 0)) {
+      finalizeDismiss();
+      return;
+    }
+    const r = ribbonEl.getBoundingClientRect();
+    setFlyDelta({
+      dx: a.left + a.width / 2 - (r.left + r.width / 2),
+      dy: a.top + a.height / 2 - (r.top + r.height / 2),
+    });
+    setFlying(true);
+    flyTimer.current = setTimeout(finalizeDismiss, FLY_MS);
+  }, [finalizeDismiss, getMenuAnchor]);
+
+  // Tapping the ribbon opens the popup AND stops the countdown (req 3).
+  const openFromRibbon = useCallback(() => {
+    clearTimeout(dismissTimer.current);
+    setCountingDown(false);
+    setOpen(true);
+  }, []);
+
+  // Manually closing the popup dismisses the ribbon — the popup disappears, then
+  // the ribbon flies home (req 5/6). If the ribbon is already gone (opened from
+  // the menu), closing just closes.
+  const closePopup = useCallback(() => {
+    setOpen(false);
+    if (ribbonPresent && !dismissingRef.current) {
+      setTimeout(() => beginDismiss(), 30);
+    }
+  }, [ribbonPresent, beginDismiss]);
+
+  // The × dismisses immediately (stops the countdown, flies home).
+  const dismissNow = useCallback(
     (e?: React.MouseEvent) => {
       e?.stopPropagation();
-      if (newest) writeDismissedAt(newest.publishedAt);
-      setDismissed(true);
-      setOpen(false);
-      setConfetti(false);
+      beginDismiss();
     },
-    [newest],
+    [beginDismiss],
   );
 
-  // Popup close ≠ dismiss (dec-4): the ribbon stays up.
-  const closePopup = useCallback(() => setOpen(false), []);
+  // Run the 6s auto-dismiss countdown while the ribbon is up and the popup is
+  // closed. Opening the popup (or flying) stops it. Reaching zero flies home.
+  useEffect(() => {
+    const shouldRun = ribbonPresent && !flying && !open && autoDismissMs > 0;
+    if (!shouldRun) {
+      setCountingDown(false);
+      setBarRunning(false);
+      clearTimeout(dismissTimer.current);
+      return;
+    }
+    setCountingDown(true);
+    setBarRunning(false);
+    const barT = setTimeout(() => setBarRunning(true), 30); // kick the width transition
+    dismissTimer.current = setTimeout(() => beginDismiss(), autoDismissMs);
+    return () => {
+      clearTimeout(barT);
+      clearTimeout(dismissTimer.current);
+    };
+  }, [ribbonPresent, flying, open, autoDismissMs, beginDismiss]);
 
-  if (!visible) return null;
+  // Clear the fly timer on unmount.
+  useEffect(() => () => clearTimeout(flyTimer.current), []);
+
+  if (entries.length === 0) return null;
 
   const reduced = prefersReducedMotion();
+  const showRibbon = ribbonPresent || flying;
+
+  const ribbonTransform = flying
+    ? `translateX(-50%) translate(${flyDelta.dx}px, ${flyDelta.dy}px) scale(.25)`
+    : `translateX(-50%) translateY(${slidIn || reduced ? '0' : '180px'})`;
+  const ribbonOpacity = flying ? 0 : slidIn || reduced ? 1 : 0;
+  const ribbonTransition = flying
+    ? `transform ${FLY_MS}ms cubic-bezier(.4,0,.2,1), opacity ${FLY_MS}ms ease`
+    : reduced
+      ? 'none'
+      : 'transform .6s cubic-bezier(.16,1,.3,1), opacity .4s';
 
   return (
     <>
       {confetti && <Confetti onDone={() => setConfetti(false)} />}
 
       {/* Slide-up ribbon */}
-      <div
-        data-testid="whats-new-ribbon"
-        role="button"
-        tabIndex={0}
-        onClick={() => setOpen(true)}
-        onKeyDown={(e) => (e.key === 'Enter' || e.key === ' ') && setOpen(true)}
-        className="fixed left-1/2 bottom-6 z-40 flex items-center gap-3 rounded-full border border-edge bg-surface px-4 py-2.5 shadow-2xl cursor-pointer"
-        style={{
-          transform: `translateX(-50%) translateY(${slidIn || reduced ? '0' : '180px'})`,
-          opacity: slidIn || reduced ? 1 : 0,
-          transition: reduced ? 'none' : 'transform .6s cubic-bezier(.16,1,.3,1), opacity .4s',
-        }}
-      >
-        <span className="text-xl" aria-hidden="true">🎁</span>
-        <div className="leading-tight">
-          <div className="text-sm font-semibold">What's New</div>
-          <div className="text-xs text-muted">
-            {entries.length} update{entries.length === 1 ? '' : 's'} shipped
-          </div>
-        </div>
-        <button
-          type="button"
-          aria-label="Dismiss What's New"
-          data-testid="whats-new-ribbon-dismiss"
-          onClick={dismiss}
-          className="ml-2 grid h-6 w-6 place-items-center rounded-full text-muted hover:bg-surface-hover"
+      {showRibbon && (
+        <div
+          ref={ribbonRef}
+          data-testid="whats-new-ribbon"
+          role="button"
+          tabIndex={0}
+          onClick={openFromRibbon}
+          onKeyDown={(e) => (e.key === 'Enter' || e.key === ' ') && openFromRibbon()}
+          className="fixed left-1/2 bottom-6 z-40 flex items-center gap-3 rounded-full border border-edge bg-surface px-4 py-2.5 shadow-2xl cursor-pointer"
+          style={{
+            transform: ribbonTransform,
+            opacity: ribbonOpacity,
+            transition: ribbonTransition,
+            pointerEvents: flying ? 'none' : undefined,
+          }}
         >
-          ✕
-        </button>
-      </div>
+          <span className="text-xl" aria-hidden="true">🎁</span>
+          <div className="leading-tight">
+            <div className="text-sm font-semibold">What's New</div>
+            <div className="text-xs text-muted">
+              {entries.length} update{entries.length === 1 ? '' : 's'} shipped
+            </div>
+          </div>
+          <button
+            type="button"
+            aria-label="Dismiss What's New"
+            data-testid="whats-new-ribbon-dismiss"
+            onClick={dismissNow}
+            className="ml-2 grid h-6 w-6 place-items-center rounded-full text-muted hover:bg-surface-hover"
+          >
+            ✕
+          </button>
+
+          {/* Auto-dismiss countdown — an inset progress line along the ribbon's
+              lower edge that depletes right→left (req 3). Inset so the pill's
+              rounded corners don't clip it. Hidden once the countdown stops
+              (tap / × / fly). */}
+          {countingDown && !flying && (
+            <div className="pointer-events-none absolute bottom-1.5 left-4 right-4 h-[2px] overflow-hidden rounded-full">
+              <div
+                data-testid="whats-new-countdown"
+                aria-hidden="true"
+                className="h-full w-full origin-left rounded-full bg-accent"
+                style={{
+                  transform: barRunning ? 'scaleX(0)' : 'scaleX(1)',
+                  transition: `transform ${autoDismissMs}ms linear`,
+                }}
+              />
+            </div>
+          )}
+        </div>
+      )}
 
       {/* Popup */}
       {open && (

--- a/packages/ui/src/pages/DocDocument.spec-159-coverage.test.tsx
+++ b/packages/ui/src/pages/DocDocument.spec-159-coverage.test.tsx
@@ -14,6 +14,7 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import { tagAc } from '@memex-ai-ac/vitest';
 import type { DocWithGraph } from '../api/types';
@@ -128,40 +129,41 @@ beforeEach(() => {
 });
 
 describe('spec-159 — zero-state holes block at the page level (ac-3, ac-13)', () => {
-  it('build with ZERO tasks: in-situ ⚠ directive states the hole; Rubicon line blocks + editor override (spec-258)', async () => {
+  it('build with ZERO tasks: in-situ ⚠ directive states the hole; current-tab line is status-only (ac-3, ac-13)', async () => {
     tagAc(AC(3));
     tagAc(AC(13));
-    tagAc('mindset-prod/memex-building-itself/specs/spec-258/acs/ac-9');
+    const user = userEvent.setup();
     // No tasks at all — the zero-task hole (an empty build hasn't built anything).
     docTasks = [];
     renderAt('build');
 
+    // The in-situ directive sits above the work view (Agent Tasks & Issues tab).
+    await screen.findByTestId('decision-panel'); // build lands on Decisions & ACs
+    await user.click(screen.getByText('Agent Tasks & Issues'));
     await screen.findByTestId('task-panel');
-    // The in-situ directive sits above the Tasks column.
     await waitFor(() =>
       expect(directiveText()).toContain(
         'Tasks must be created and completed before this spec can move to Verify.',
       ),
     );
-    // The Rubicon line states the same hole and — spec-258/dec-5, editor — offers
-    // the "Move … anyway?" override [Yes].
+    // spec-282/dec-4: the Rubicon states the same hole but is status-only — no
+    // override, no button on the current tab.
     const sentence = screen.getByTestId('transition-sentence');
     expect(sentence.textContent).toContain(
       'Tasks must be created and completed before this spec can move to Verify.',
     );
-    expect(sentence.textContent).toContain('Move this spec to Verify anyway?');
-    expect(within(sentence).getByRole('button', { name: 'Yes' })).toBeInTheDocument();
+    expect(sentence.textContent).not.toContain('anyway?');
+    expect(within(sentence).queryByRole('button')).not.toBeInTheDocument();
   });
 
-  it('verify with NO active ACs: in-situ ⚠ directive states the hole; Rubicon line blocks + editor override (spec-258)', async () => {
+  it('verify with NO active ACs: in-situ ⚠ directive states the hole; current-tab line is status-only (ac-3, ac-13)', async () => {
     tagAc(AC(3));
     tagAc(AC(13));
-    tagAc('mindset-prod/memex-building-itself/specs/spec-258/acs/ac-9');
     // No active ACs — nothing to verify against (the verify→done hole).
     docAcs = [];
     renderAt('verify');
 
-    await screen.findByTestId('ac-panel');
+    await screen.findByTestId('ac-panel'); // verify lands on Decisions & ACs (no report)
     await waitFor(() =>
       expect(directiveText()).toContain(
         'Acceptance Criteria (ACs) must be created and verified before this spec can move to Done.',
@@ -171,8 +173,8 @@ describe('spec-159 — zero-state holes block at the page level (ac-3, ac-13)', 
     expect(sentence.textContent).toContain(
       'Acceptance Criteria (ACs) must be created and verified before this spec can move to Done.',
     );
-    expect(sentence.textContent).toContain('Move this spec to Done anyway?');
-    expect(within(sentence).getByRole('button', { name: 'Yes' })).toBeInTheDocument();
+    expect(sentence.textContent).not.toContain('anyway?');
+    expect(within(sentence).queryByRole('button')).not.toBeInTheDocument();
   });
 
   it('an inactive (non-active) AC does NOT satisfy the verify hole — still blocked', async () => {
@@ -191,14 +193,13 @@ describe('spec-159 — zero-state holes block at the page level (ac-3, ac-13)', 
   });
 });
 
-// spec-258/dec-5 amends spec-159/dec-4: a blocked current tab now offers the
-// EDITOR a "Move … anyway?" override (the move is forceable from the kanban, so
-// the spec page shouldn't be the lone surface that withholds it). A non-editor's
-// blocked state stays status-only (spec-182/dec-2) — covered in spec-258 specs.
-describe('spec-258 — blocked current phase offers an editor the override (dec-5)', () => {
-  it('editor on a dirty plan (open decision): the line states the blocker AND the "Move … anyway?" override', async () => {
+// spec-282/dec-4 supersedes spec-258/dec-5's CURRENT-TAB override: a blocked
+// current tab is status-only (no override, no button) for editors and reviewers
+// alike. The editor's force-forward capability relocates to the browse-forward
+// confirm (covered in TransitionSentence.spec-282.test.tsx).
+describe('spec-282 — blocked current phase is status-only (dec-4)', () => {
+  it('editor on a dirty plan (open decision): the line states the blocker, no override, no button', async () => {
     tagAc(AC(3));
-    tagAc('mindset-prod/memex-building-itself/specs/spec-258/acs/ac-9');
     mockRole = 'editor';
     docDecisions = [
       {
@@ -220,13 +221,13 @@ describe('spec-258 — blocked current phase offers an editor the override (dec-
 
     const sentence = await screen.findByTestId('transition-sentence');
     // Editor posture (canTransition true): the dirty rubric on the current tab
-    // shows the condition AND the dec-5 override [Yes].
+    // shows the condition but is status-only — no override, no button (dec-4).
     await waitFor(() =>
       expect(sentence.textContent).toContain(
         '1 Decision must be resolved before this spec can move to Build.',
       ),
     );
-    expect(sentence.textContent).toContain('Move this spec to Build anyway?');
-    expect(within(sentence).getByRole('button', { name: 'Yes' })).toBeInTheDocument();
+    expect(sentence.textContent).not.toContain('anyway?');
+    expect(within(sentence).queryByRole('button')).not.toBeInTheDocument();
   });
 });

--- a/packages/ui/src/pages/DocDocument.spec-159.test.tsx
+++ b/packages/ui/src/pages/DocDocument.spec-159.test.tsx
@@ -224,35 +224,50 @@ describe('spec-159 t-6 — DocDocument phase layouts', () => {
     expect(screen.getByTestId('all-comments')).toBeInTheDocument();
   });
 
-  // spec-260 evolved this layout: Build now carries a secondary "QA Report"
-  // sub-tab (deliberate structural change, spec-260 dec-1). What survives of
-  // ac-11 here: the Tasks | Issues two-column stays Build's DEFAULT view and
-  // Specify's sub-tabs never leak into it. The QA-report tab itself is covered
-  // by DocDocument.spec-260.test.tsx.
-  it('Build defaults to Tasks | Issues; Specify sub-tabs never leak in (ac-5, ac-11)', async () => {
+  // spec-282 (dec-1/dec-2/dec-3) supersedes the spec-159/spec-260 per-phase
+  // layouts: ONE persistent sub-tab control carries the full inventory in every
+  // phase. Build LANDS on Decisions & ACs (dec-3); the Agent Tasks & Issues tab
+  // reveals the work view. (The old "Build/Verify carry no sub-tab bar" ac-11 is
+  // superseded; the QA-report tab is covered in DocDocument.spec-260.test.tsx.)
+  it('Build lands on Decisions & ACs; the full sub-tab inventory is present (ac-5)', async () => {
     tagAc(AC(5));
-    tagAc(AC(11));
+    const user = userEvent.setup();
     renderAt('build');
 
-    await screen.findByTestId('task-panel');
-    expect(screen.getByTestId('issue-panel')).toBeInTheDocument();
-    expect(screen.queryByTestId('ac-panel')).not.toBeInTheDocument();
+    // The unified control carries the full inventory.
+    await screen.findByText('Narrative');
+    expect(screen.getByText('Comments')).toBeInTheDocument();
+    expect(screen.getByText('Decisions & ACs')).toBeInTheDocument();
+    expect(screen.getByText('Agent Tasks & Issues')).toBeInTheDocument();
+    expect(screen.getByText('QA Report')).toBeInTheDocument();
 
-    // The Specify sub-tab labels are absent.
-    expect(screen.queryByText('Decisions & ACs')).not.toBeInTheDocument();
-    // The only tablist on the page is the phase bar (4 tabs, spec-258), not a sub-tab bar.
+    // Build's default landing is Decisions & ACs (decision + AC panels).
+    expect(screen.getByTestId('decision-panel')).toBeInTheDocument();
+    expect(screen.getByTestId('ac-panel')).toBeInTheDocument();
+
+    // The work view is one click away.
+    await user.click(screen.getByText('Agent Tasks & Issues'));
+    expect(screen.getByTestId('task-panel')).toBeInTheDocument();
+    expect(screen.getByTestId('issue-panel')).toBeInTheDocument();
+
+    // The phase bar is still the only role=tab tablist (4 phase tabs).
     expect(screen.getAllByRole('tab')).toHaveLength(4);
   });
 
-  it('Verify renders AC | Issues with NO sub-tab bar (ac-5, ac-11)', async () => {
+  it('Verify lands on Decisions & ACs when no report exists; the work tab stays reachable (ac-5)', async () => {
     tagAc(AC(5));
-    tagAc(AC(11));
+    const user = userEvent.setup();
     renderAt('verify');
 
+    // No QA report seeded → verify falls back to Decisions & ACs (dec-3).
     await screen.findByTestId('ac-panel');
-    expect(screen.getByTestId('issue-panel')).toBeInTheDocument();
-    expect(screen.queryByTestId('task-panel')).not.toBeInTheDocument();
+    expect(screen.getByText('QA Report')).toBeInTheDocument();
     expect(screen.getAllByRole('tab')).toHaveLength(4);
+
+    // Agent Tasks & Issues remains reachable in verify (accretion never removes it).
+    await user.click(screen.getByText('Agent Tasks & Issues'));
+    expect(screen.getByTestId('task-panel')).toBeInTheDocument();
+    expect(screen.getByTestId('issue-panel')).toBeInTheDocument();
   });
 
   it('Done replaces the content area with the DoneSummary report (ac-5)', async () => {
@@ -271,16 +286,15 @@ describe('spec-159 t-6 — DocDocument phase layouts', () => {
     const user = userEvent.setup();
     renderAt('build');
 
-    await screen.findByTestId('task-panel');
+    await screen.findByTestId('decision-panel'); // build lands on Decisions & ACs
     // build is the current phase.
     expect(phaseTab('build')).toHaveAttribute('data-current', 'true');
 
     // Browse the Verify view.
     await user.click(phaseTab('verify'));
 
-    // The view switched (AC | Issues now render)…
-    expect(screen.getByTestId('ac-panel')).toBeInTheDocument();
-    // …but the current-phase highlight is STILL on build, and no status mutation fired.
+    // The current-phase highlight is STILL on build; verify is only selected,
+    // and no status mutation fired.
     expect(phaseTab('build')).toHaveAttribute('data-current', 'true');
     expect(phaseTab('verify')).not.toHaveAttribute('data-current');
     expect(phaseTab('verify')).toHaveAttribute('data-selected', 'true');
@@ -302,18 +316,18 @@ describe('spec-159 t-6 — DocDocument phase layouts', () => {
   it('the transition flow mounts no modal — Yes calls updateDocStatus directly (ac-6)', async () => {
     tagAc(AC(6));
     const user = userEvent.setup();
-    // verify → done is a forward step; with every active AC verified it offers
-    // Yes (an AC-less verify is blocked — covered in the Rubicon describe).
+    // verify → done is a forward step; with every active AC verified the browse-
+    // forward confirm offers Yes (an AC-less verify is blocked).
     docAcs = [{ ac: { status: 'active' }, verificationState: 'verified' }];
     renderAt('verify');
     await screen.findByTestId('ac-panel');
 
+    // spec-282/dec-4: the advance [Yes] lives on the browse-forward confirm, not
+    // the current tab. Browse the Done tab; verify is clean → "Are you sure…?".
+    await user.click(phaseTab('done'));
     const sentence = screen.getByTestId('transition-sentence');
-    // Wait for the async AC fetch to settle so verify is CLEAN and the line shows
-    // the ready advancement offer — not the transient spec-258/dec-5 blocked
-    // override (which renders a Yes during the pre-fetch unverified window).
     await waitFor(() =>
-      expect(sentence).toHaveTextContent(/Do you want to move this spec to Done\?/),
+      expect(sentence).toHaveTextContent(/Are you sure you want to move this spec to Done\?/),
     );
     const yes = within(sentence).getByRole('button', { name: 'Yes' });
     await user.click(yes);
@@ -329,26 +343,25 @@ describe('spec-159 t-6 — DocDocument phase layouts', () => {
 // browsing forward → summary + Are-you-sure Yes/No. The in-situ ⚠ directives
 // above the lists are unchanged.
 describe('spec-159 — Rubicon line + in-situ directives', () => {
-  it('specify with open decisions: line states the blocker + editor override; directive sits above Decisions (ac-3, ac-13, spec-258)', async () => {
+  it('specify with open decisions: the current-tab line is status-only; directive sits above Decisions (ac-3, ac-13)', async () => {
     tagAc(AC(3));
     tagAc(AC(13));
-    tagAc('mindset-prod/memex-building-itself/specs/spec-258/acs/ac-9');
     const user = userEvent.setup();
     docDecisions = [decision('d-1', 'open'), decision('d-2', 'open')];
     docAcs = [{ ac: { status: 'active' }, verificationState: 'untested' }];
     renderAt('specify');
 
-    // Current tab + blocked rubric → the exact condition, plus the spec-258/dec-5
-    // editor override "Move … anyway?" [Yes] (canEdit is true in this render).
-    // (waitFor: the AC fetch resolving flips `hasAcceptanceCriteria` async.)
+    // spec-282/dec-4: the current tab states the exact rubric condition but is
+    // STATUS-ONLY — no override, no button. (waitFor: the AC fetch resolving
+    // flips `hasAcceptanceCriteria` async.)
     const sentence = await screen.findByTestId('transition-sentence');
     await waitFor(() =>
       expect(sentence.textContent).toContain(
         '2 Decisions must be resolved before this spec can move to Build.',
       ),
     );
-    expect(sentence.textContent).toContain('Move this spec to Build anyway?');
-    expect(within(sentence).getByRole('button', { name: 'Yes' })).toBeInTheDocument();
+    expect(sentence.textContent).not.toContain('anyway?');
+    expect(within(sentence).queryByRole('button')).not.toBeInTheDocument();
 
     // The directive renders in-situ on the Decisions & ACs sub-tab.
     await user.click(screen.getByText('Decisions & ACs'));
@@ -416,12 +429,15 @@ describe('spec-159 — Rubicon line + in-situ directives', () => {
     expect(text).toContain('2 Decisions must be resolved before this spec can move to Build.');
   });
 
-  it('build with open tasks: directive above Tasks; Rubicon line states it + editor override (ac-13, spec-258)', async () => {
+  it('build with open tasks: directive above the work view; current-tab line is status-only (ac-13)', async () => {
     tagAc(AC(13));
-    tagAc('mindset-prod/memex-building-itself/specs/spec-258/acs/ac-9');
+    const user = userEvent.setup();
     docTasks = [{ id: 't-1', status: 'in_progress' }, { id: 't-2', status: 'complete' }];
     renderAt('build');
 
+    // The build directive renders on the Agent Tasks & Issues tab.
+    await screen.findByTestId('decision-panel'); // build landing
+    await user.click(screen.getByText('Agent Tasks & Issues'));
     await screen.findByTestId('task-panel');
     const text = screen
       .getAllByTestId('phase-directive')
@@ -430,14 +446,14 @@ describe('spec-159 — Rubicon line + in-situ directives', () => {
     expect(text).toContain(
       '1 Task must be completed (or kicked to Issues) before this spec can move to Verify.',
     );
-    // Current tab + open task → the Rubicon line states it, plus the spec-258/dec-5
-    // editor override "Move … anyway?" [Yes].
+    // spec-282/dec-4: the current-tab line states the condition but is status-only
+    // — no override, no button.
     const sentence = screen.getByTestId('transition-sentence');
     expect(sentence.textContent).toContain(
       '1 Task must be completed before this spec can move to Verify.',
     );
-    expect(sentence.textContent).toContain('Move this spec to Verify anyway?');
-    expect(within(sentence).getByRole('button', { name: 'Yes' })).toBeInTheDocument();
+    expect(sentence.textContent).not.toContain('anyway?');
+    expect(within(sentence).queryByRole('button')).not.toBeInTheDocument();
   });
 
   it('verify with unverified ACs: directive above the AC column (ac-13)', async () => {
@@ -463,18 +479,18 @@ describe('spec-159 — Rubicon line + in-situ directives', () => {
     });
   });
 
-  it('directives belong to the CURRENT phase only — browsing another layout shows none (ac-13)', async () => {
+  it("directives are keyed to the spec's actual phase, not the browsed tab — the build directive stays silent in specify (ac-13)", async () => {
     tagAc(AC(13));
     const user = userEvent.setup();
-    // Current phase specify (with open decisions); browse the Build layout —
-    // the build directive must NOT fire (its gate is about specify→build, not
-    // the browsed view).
+    // Current phase specify (with open decisions + tasks); the Agent Tasks &
+    // Issues tab must NOT show the build→verify directive (its gate is the build
+    // phase, not the browsed sub-tab).
     docDecisions = [decision('d-1', 'open')];
     docTasks = [{ id: 't-1', status: 'in_progress' }];
     renderAt('specify');
     await screen.findByText('Narrative');
 
-    await user.click(phaseTab('build'));
+    await user.click(screen.getByText('Agent Tasks & Issues'));
     await screen.findByTestId('task-panel');
     expect(screen.queryAllByTestId('phase-directive')).toHaveLength(0);
   });
@@ -487,7 +503,7 @@ describe('spec-159 — Rubicon line + in-situ directives', () => {
     // current phase's home tab and the layout shows Specify's content — not the
     // stale browsed pin.
     renderAt('build');
-    await screen.findByTestId('task-panel');
+    await screen.findByTestId('decision-panel'); // build lands on Decisions & ACs
 
     await user.click(phaseTab('specify'));
     await screen.findByText('Narrative');
@@ -671,7 +687,7 @@ describe('spec-182 — unified reviewer phase block', () => {
     tagAc(AC182(17));
     renderAt('build');
 
-    await screen.findByTestId('task-panel');
+    await screen.findByTestId('decision-panel'); // build lands on Decisions & ACs
     expect(screen.queryByTestId('phase-handoff-line')).not.toBeInTheDocument();
     expect(screen.queryByTestId('review-handoff-line')).not.toBeInTheDocument();
   });
@@ -687,9 +703,12 @@ describe('spec-182 — unified reviewer phase block', () => {
   it('build: tabs render, panels render, and NO review actions outside Specify', async () => {
     tagAc(AC182(10));
     tagAc(AC182(3));
+    const user = userEvent.setup();
     renderAt('build');
 
-    await screen.findByTestId('task-panel');
+    await screen.findByTestId('decision-panel'); // build lands on Decisions & ACs
+    await user.click(screen.getByText('Agent Tasks & Issues'));
+    expect(screen.getByTestId('task-panel')).toBeInTheDocument();
     expect(screen.getByTestId('issue-panel')).toBeInTheDocument();
     // dec-1: the tab bar renders for reviewers; dec-3: no review row off-Specify.
     expect(screen.getAllByRole('tab')).toHaveLength(4);
@@ -712,8 +731,8 @@ describe('spec-182 — unified reviewer phase block', () => {
     const user = userEvent.setup();
     renderAt('build');
 
-    await screen.findByTestId('task-panel');
-    // Click the Verify tab — the verify layout renders, the phase is untouched.
+    await screen.findByTestId('decision-panel'); // build lands on Decisions & ACs
+    // Click the Verify tab — the verify view renders, the phase is untouched.
     await user.click(screen.getAllByRole('tab').find((t) => t.getAttribute('data-tab') === 'verify')!);
     await screen.findByTestId('ac-panel');
     expect(updateDocStatus).not.toHaveBeenCalled();
@@ -778,7 +797,7 @@ describe('spec-159 ac-17 — next-action handoff line', () => {
     tagAc(AC(17));
     renderAt('build');
 
-    await screen.findByTestId('task-panel');
+    await screen.findByTestId('decision-panel'); // build lands on Decisions & ACs
     const line = screen.getByTestId('phase-handoff-line');
     expect(line.textContent).toContain(
       'Copy the Build prompt into your coding agent to complete the Tasks and build this spec.',

--- a/packages/ui/src/pages/DocDocument.spec-196.test.tsx
+++ b/packages/ui/src/pages/DocDocument.spec-196.test.tsx
@@ -222,16 +222,22 @@ describe('spec-233 t-1 — prose sub-tab reads "Narrative", id stays narrative',
     );
     unmount();
 
-    // Consolidation refreshed past the decision → the advancement offer.
-    // waitFor (not a bare findByTestId assertion): the offer only appears once
-    // the async fetchAcsForBrief settles — until then hasAcceptanceCriteria is
-    // false and the AC blocker transiently shares the line. Asserting on the
-    // first render tick races that fetch (green locally, flaky under CI load).
+    // Consolidation refreshed past the decision → advancement is no longer
+    // blocked. spec-282/dec-4: the current tab carries no standing offer, so the
+    // "fresh unblocks advance" property reads on the browse-forward confirm — no
+    // narrative blocker, the plain "Are you sure…?". waitFor: the offer only
+    // settles once the async fetchAcsForBrief resolves.
     docNarrativeConsolidatedAt = '2026-06-06T00:00:00Z';
     renderAt();
-    const fresh = await screen.findByTestId('transition-sentence');
+    await screen.findByText('Narrative');
+    const buildTab = screen
+      .getAllByRole('tab')
+      .find((t) => t.getAttribute('data-tab') === 'build')!;
+    await userEvent.setup().click(buildTab);
     await waitFor(() =>
-      expect(fresh.textContent).toContain('Do you wish to move this spec to Build?'),
+      expect(screen.getByTestId('transition-sentence').textContent).toContain(
+        'Are you sure you want to move this spec to Build?',
+      ),
     );
   });
 

--- a/packages/ui/src/pages/DocDocument.spec-260.test.tsx
+++ b/packages/ui/src/pages/DocDocument.spec-260.test.tsx
@@ -158,23 +158,23 @@ beforeEach(() => {
 });
 
 describe('spec-260 — QA Report render seats', () => {
-  it('ac-12: Verify front-loads a collapsible QA Report card ABOVE the ACs│Issues columns', async () => {
+  it('ac-12 (spec-282 dec-3): Verify lands on the QA Report tab; the card shows the latest session', async () => {
     tagAc(AC(12));
     renderAt('verify');
 
-    const card = await screen.findByTestId('qa-report-card');
-    const acPanel = await screen.findByTestId('ac-panel');
-    expect(screen.getByTestId('issue-panel')).toBeInTheDocument();
-
-    // Front-loaded: the card precedes the two-column area in document order.
-    expect(card.compareDocumentPosition(acPanel) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
-
-    // Expanded by default (the cold verifier reads it first) — latest session shows.
+    // spec-282 dec-3: Verify's default landing IS the QA Report (replaces
+    // spec-260's front-loaded card) — the card renders with the latest session
+    // expanded for the cold verifier.
+    await screen.findByTestId('qa-report-card');
     expect(screen.getByTestId('qa-report-content')).toHaveTextContent('Session TWO report body.');
 
     // Collapsible: it folds away once read.
     fireEvent.click(screen.getByTestId('qa-report-toggle'));
     expect(screen.queryByTestId('qa-report-content')).not.toBeInTheDocument();
+
+    // The ACs view lives one tab away (Decisions & ACs).
+    fireEvent.click(screen.getByText('Decisions & ACs'));
+    expect(screen.getByTestId('ac-panel')).toBeInTheDocument();
   });
 
   it('ac-12 (dec-2 display): prior build sessions stay reachable through the version switcher', async () => {
@@ -187,27 +187,26 @@ describe('spec-260 — QA Report render seats', () => {
     expect(screen.getByTestId('qa-report-content')).toHaveTextContent('Session ONE report body.');
   });
 
-  it('ac-12: Build carries a QA Report sub-tab; Tasks│Issues stays the default view', async () => {
+  it('ac-12: the QA Report tab is reachable in Build and shows the latest report', async () => {
     tagAc(AC(12));
     renderAt('build');
 
-    // Default tab: the working two-column, no report content.
-    await screen.findByTestId('task-panel');
-    expect(screen.getByTestId('issue-panel')).toBeInTheDocument();
+    // Build lands on Decisions & ACs (spec-282 dec-3), not the report.
+    await screen.findByTestId('decision-panel');
     expect(screen.queryByTestId('qa-report-content')).not.toBeInTheDocument();
 
-    // The secondary tab reveals the report.
+    // The QA Report tab reveals the report.
     fireEvent.click(screen.getByText('QA Report'));
     expect(screen.getByTestId('qa-report-content')).toHaveTextContent('Session TWO report body.');
-    expect(screen.queryByTestId('task-panel')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('decision-panel')).not.toBeInTheDocument();
   });
 
-  it('ac-12: before the first hand-off the Build tab shows a quiet empty state', async () => {
+  it('ac-12: before the first hand-off the QA Report tab shows a quiet empty state', async () => {
     tagAc(AC(12));
     withReports = false;
     renderAt('build');
 
-    await screen.findByTestId('task-panel');
+    await screen.findByTestId('decision-panel'); // build lands on Decisions & ACs
     fireEvent.click(screen.getByText('QA Report'));
     expect(screen.getByTestId('qa-report-empty')).toHaveTextContent(
       'No QA report yet — generated when build hands off to verify',

--- a/packages/ui/src/pages/DocDocument.spec-282.test.tsx
+++ b/packages/ui/src/pages/DocDocument.spec-282.test.tsx
@@ -1,0 +1,268 @@
+// spec-282 t-1 — ONE persistent, all-tabs-present sub-tab control across phases.
+//
+// Renders the REAL DocDocument (heavy panels stubbed to markers, the REAL
+// QaReportCard so the QA Report empty-state is exercised) and asserts the
+// unified sub-tab control:
+//
+//   ac-8 / ac-9 : one <Tabs> carrying the exact ordered inventory —
+//                 Narrative · Comments · Decisions & ACs · Agent Tasks & Issues ·
+//                 QA Report — in every phase.
+//   ac-1 / ac-2 : the same control persists across Specify/Build/Verify and the
+//                 set never shrinks (Narrative & Comments reachable in Build and
+//                 Verify).
+//   ac-3        : the QA Report tab shows an honest empty-state placeholder
+//                 before a report exists.
+//   ac-4 / ac-10: each phase lands on its default sub-tab (Specify→Narrative,
+//                 Build→Decisions & ACs, Verify→QA Report w/ Decisions & ACs
+//                 fallback); an explicit selection is respected until the next
+//                 phase navigation resets it to the new phase's default.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { tagAc } from '@memex-ai-ac/vitest';
+import type { DocWithGraph } from '../api/types';
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-282/acs/ac-${n}`;
+
+vi.mock('../components/DecisionPanel', () => ({
+  DecisionPanel: () => <div data-testid="decision-panel" />,
+}));
+vi.mock('../components/AcPanel', () => ({ AcPanel: () => <div data-testid="ac-panel" /> }));
+vi.mock('../components/TaskPanel', () => ({ TaskPanel: () => <div data-testid="task-panel" /> }));
+vi.mock('../components/IssuePanel', () => ({ IssuePanel: () => <div data-testid="issue-panel" /> }));
+vi.mock('../components/AllComments', () => ({ AllComments: () => <div data-testid="all-comments" /> }));
+vi.mock('../components/SectionCard', () => ({
+  SectionCard: (props: { section: { sectionType: string } }) => (
+    <div data-testid="section-card" data-section-type={props.section.sectionType} />
+  ),
+}));
+vi.mock('../components/DocOutline', () => ({ DocOutline: () => <div data-testid="doc-outline" /> }));
+vi.mock('../components/TagPicker', () => ({ TagPicker: () => null }));
+vi.mock('../components/BylineAssignees', () => ({
+  BylineAssignees: () => <div data-testid="byline-assignees" />,
+}));
+vi.mock('../components/DoneSummary', () => ({ DoneSummary: () => <div data-testid="done-summary" /> }));
+
+vi.mock('../hooks/useMemexAccess', () => ({
+  useMemexAccess: () => ({ canWrite: true, isReadOnly: false }),
+}));
+vi.mock('../hooks/useDocRole', () => ({
+  useDocRole: () => ({ myRole: 'editor', editors: [], loading: false, refetch: vi.fn() }),
+}));
+vi.mock('../hooks/useDocChangeStream', () => ({ useDocChangeStream: () => {} }));
+vi.mock('../hooks/useOrgScaffoldBlocks', () => ({ useOrgScaffoldBlocks: () => [] }));
+const chat = {
+  setDocId: vi.fn(),
+  setDoc: vi.fn(),
+  setOpenCommentCount: vi.fn(),
+  sendMessage: vi.fn(),
+};
+vi.mock('../components/ChatContext', () => ({ useChat: () => chat }));
+
+let docStatus: DocWithGraph['status'] = 'specify';
+let withReports = false;
+
+function section(over: Record<string, unknown>) {
+  return {
+    id: `sec-${over.sectionType as string}`,
+    docId: 'doc-uuid',
+    title: null,
+    description: null,
+    content: 'body',
+    status: 'active',
+    createdAt: '2026-06-01T00:00:00Z',
+    updatedAt: '2026-06-01T00:00:00Z',
+    ...over,
+  };
+}
+
+function makeDoc(): DocWithGraph {
+  const sections = [
+    section({ sectionType: 'overview', seq: 1, title: 'Overview', content: 'The plan prose.' }),
+  ];
+  if (withReports) {
+    sections.push(
+      section({
+        sectionType: 'qa_report',
+        seq: 2,
+        title: 'QA Report',
+        content: 'The latest session report.',
+        createdAt: '2026-06-02T00:00:00Z',
+      }),
+    );
+  }
+  return {
+    id: 'doc-uuid',
+    handle: 'spec-282',
+    title: 'Unified sub-tabs',
+    docType: 'spec',
+    status: docStatus,
+    creator: { name: 'Barrie', email: 'barrie@mindset.ai' },
+    createdAt: '2026-06-01T00:00:00Z',
+    statusChangedAt: '2026-06-13T00:00:00Z',
+    narrativeLastConsolidatedAt: null,
+    sections,
+    decisions: [],
+    tasks: [],
+    tags: [],
+  } as unknown as DocWithGraph;
+}
+
+vi.mock('../api/client', () => ({
+  NotFoundError: class NotFoundError extends Error {},
+  fetchDoc: () => Promise.resolve(makeDoc()),
+  fetchDocComments: () => Promise.resolve({ sections: [], decisions: [], tasks: [] }),
+  fetchAcsForBrief: () => Promise.resolve([]),
+  fetchIssues: () => Promise.resolve([]),
+  fetchDocAssignees: () => Promise.resolve([]),
+  archiveDoc: vi.fn(),
+  pauseDoc: vi.fn(),
+  unpauseDoc: vi.fn(),
+  updateDocStatus: vi.fn(),
+  promoteToEditor: vi.fn(),
+  demoteToReviewer: vi.fn(),
+}));
+
+import { DocDocument } from './DocDocument';
+import { HeaderSlotProvider } from '../components/HeaderSlot';
+
+function renderAt(status: DocWithGraph['status']) {
+  docStatus = status;
+  return render(
+    <MemoryRouter initialEntries={['/n/m/specs/spec-282']}>
+      <HeaderSlotProvider>
+        <Routes>
+          <Route path="/:ns/:mx/specs/:id" element={<DocDocument />} />
+        </Routes>
+      </HeaderSlotProvider>
+    </MemoryRouter>,
+  );
+}
+
+const SUB_TABS = ['Narrative', 'Comments', 'Decisions & ACs', 'Agent Tasks & Issues', 'QA Report'];
+
+// The sub-tab bar is the Tabs underline row; anchor on the Narrative button and
+// read its sibling buttons in DOM order.
+function subTabLabels(): string[] {
+  const bar = screen.getByRole('button', { name: 'Narrative' }).parentElement!;
+  return Array.from(bar.querySelectorAll('button')).map((b) => (b.textContent ?? '').trim());
+}
+
+function phaseTab(name: string) {
+  return screen.getAllByRole('tab').find((t) => t.getAttribute('data-tab') === name)!;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  withReports = false;
+});
+
+describe('spec-282 — unified sub-tab inventory & ordering (ac-8, ac-9)', () => {
+  it('renders exactly Narrative · Comments · Decisions & ACs · Agent Tasks & Issues · QA Report, in order', async () => {
+    tagAc(AC(8));
+    tagAc(AC(9));
+    renderAt('specify');
+    await screen.findByText('Narrative');
+    expect(subTabLabels()).toEqual(SUB_TABS);
+  });
+
+  it('the SAME inventory is present in Specify, Build AND Verify — one control, never swapped (ac-1, ac-2)', async () => {
+    tagAc(AC(1));
+    tagAc(AC(2));
+    for (const phase of ['specify', 'build', 'verify'] as const) {
+      const { unmount } = renderAt(phase);
+      await screen.findByText('Narrative');
+      expect(subTabLabels()).toEqual(SUB_TABS);
+      // Narrative AND Comments stay reachable in Build and Verify (accretion
+      // never removes an earlier tab).
+      expect(screen.getByRole('button', { name: 'Narrative' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Comments' })).toBeInTheDocument();
+      unmount();
+    }
+  });
+});
+
+describe('spec-282 — per-phase default landing (ac-4, ac-10)', () => {
+  it('Specify lands on Narrative', async () => {
+    tagAc(AC(4));
+    tagAc(AC(10));
+    renderAt('specify');
+    expect(await screen.findByTestId('section-card')).toBeInTheDocument();
+  });
+
+  it('Build lands on Decisions & ACs', async () => {
+    tagAc(AC(4));
+    tagAc(AC(10));
+    renderAt('build');
+    expect(await screen.findByTestId('decision-panel')).toBeInTheDocument();
+    expect(screen.getByTestId('ac-panel')).toBeInTheDocument();
+  });
+
+  it('Verify lands on QA Report when a report exists', async () => {
+    tagAc(AC(4));
+    tagAc(AC(10));
+    withReports = true;
+    renderAt('verify');
+    expect(await screen.findByTestId('qa-report-card')).toBeInTheDocument();
+    expect(screen.getByTestId('qa-report-content')).toBeInTheDocument();
+  });
+
+  it('Verify falls back to Decisions & ACs when no report exists', async () => {
+    tagAc(AC(4));
+    tagAc(AC(10));
+    withReports = false;
+    renderAt('verify');
+    expect(await screen.findByTestId('ac-panel')).toBeInTheDocument();
+    expect(screen.queryByTestId('qa-report-card')).not.toBeInTheDocument();
+  });
+
+  it('an explicit selection is respected over the default, then phase navigation resets to the new default (ac-4, ac-10)', async () => {
+    tagAc(AC(4));
+    tagAc(AC(10));
+    const user = userEvent.setup();
+    renderAt('build');
+
+    // Build's default is Decisions & ACs.
+    await screen.findByTestId('decision-panel');
+
+    // Pick Comments — the selection is respected (no default snap-back).
+    await user.click(screen.getByRole('button', { name: 'Comments' }));
+    expect(screen.getByTestId('all-comments')).toBeInTheDocument();
+    expect(screen.queryByTestId('decision-panel')).not.toBeInTheDocument();
+
+    // Browse the Verify phase pill — landing resets to Verify's default
+    // (Decisions & ACs here, since no report), NOT the carried-over Comments.
+    await user.click(phaseTab('verify'));
+    expect(screen.getByTestId('ac-panel')).toBeInTheDocument();
+    expect(screen.queryByTestId('all-comments')).not.toBeInTheDocument();
+  });
+});
+
+describe('spec-282 — honest empty state for absent artifacts (ac-3)', () => {
+  it('the QA Report tab shows the explanatory placeholder before a report exists', async () => {
+    tagAc(AC(3));
+    const user = userEvent.setup();
+    withReports = false;
+    renderAt('build');
+    await screen.findByTestId('decision-panel');
+
+    await user.click(screen.getByRole('button', { name: 'QA Report' }));
+    expect(screen.getByTestId('qa-report-empty')).toHaveTextContent(
+      'No QA report yet — generated when build hands off to verify',
+    );
+  });
+
+  it('the QA Report tab is reachable in Specify too, with the same placeholder (ac-2, ac-3)', async () => {
+    tagAc(AC(2));
+    tagAc(AC(3));
+    const user = userEvent.setup();
+    withReports = false;
+    renderAt('specify');
+    await screen.findByText('Narrative');
+
+    await user.click(screen.getByRole('button', { name: 'QA Report' }));
+    expect(screen.getByTestId('qa-report-empty')).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/pages/DocDocument.tsx
+++ b/packages/ui/src/pages/DocDocument.tsx
@@ -68,6 +68,32 @@ import { usePresenceHeartbeat } from '../hooks/usePresenceHeartbeat';
 import { usePresence } from '../hooks/usePresence';
 import { SpecPresenceIndicator } from '../components/pulse/SpecPresenceIndicator';
 
+// spec-282 (dec-1/dec-2): the SINGLE, ordered inventory of sub-tabs the unified
+// control carries in EVERY phase (Narrative · Comments · Decisions & ACs · Agent
+// Tasks & Issues · QA Report). One constant set means the control is never
+// swapped out as the phase changes (ac-1) and the set never shrinks (ac-2);
+// tabs whose artifact doesn't exist yet render an honest empty state (ac-3).
+type SubTab = 'narrative' | 'comments' | 'decisions' | 'work' | 'qa-report';
+
+// spec-282 (dec-3): each phase's preferred LANDING sub-tab. Selecting any other
+// tab is always free — this is only the default applied when the user navigates
+// to a phase. Verify prefers the QA Report (what a cold verifier reads first),
+// falling back to Decisions & ACs when no report exists yet. `done` has no
+// sub-tab control (it renders the DoneSummary), so it returns null.
+function defaultSubTabForTab(tab: PhaseTab, hasQaReport: boolean): SubTab | null {
+  switch (tab) {
+    case 'specify':
+      return 'narrative';
+    case 'build':
+      return 'decisions';
+    case 'verify':
+      return hasQaReport ? 'qa-report' : 'decisions';
+    case 'done':
+    default:
+      return null;
+  }
+}
+
 export function DocDocument() {
   // spec-64 i-3: the Spec page is also mounted at the canonical Decision / Issue
   // deep-links `specs/:id/decisions/:decId` and `specs/:id/issues/:issueId` (the
@@ -144,21 +170,22 @@ export function DocDocument() {
   // (that's TransitionSentence's [Yes]); it only changes what's shown.
   // `null` defers to the doc's current phase, computed once the doc loads.
   const [selectedTab, setSelectedTab] = useState<PhaseTab | null>(null);
-  // Plan's sub-tab (Narrative / Decisions & ACs / Comments). Verify has no
-  // sub-tabs. A deep-link to a decision/issue/comment picks the relevant
-  // landing point below once the doc resolves.
-  const [planSubTab, setPlanSubTab] = useState<'narrative' | 'decisions' | 'comments'>(
+  // spec-282 (dec-1/dec-2/dec-3): ONE sub-tab state for the unified control that
+  // persists across Specify/Build/Verify (it replaces the old disjoint
+  // `planSubTab` + `buildSubTab`). `null` means "use the current phase's default
+  // landing tab" (defaultSubTabForTab) — so navigating to a phase lands on its
+  // default, and an explicit selection (non-null) is respected until the next
+  // phase navigation resets it to null. A deep-link to a decision/issue/comment
+  // sets the relevant landing tab up front.
+  const [subTab, setSubTab] = useState<SubTab | null>(
     initialCommentSeq != null
       ? 'comments'
       : initialDecisionHandle
         ? 'decisions'
-        : 'narrative',
+        : initialIssueHandle
+          ? 'work'
+          : null,
   );
-  // spec-260 (dec-1): Build's sub-tab — the Tasks │ Issues working view stays
-  // the default; "QA Report" is a secondary tab so the per-session report stays
-  // out of the builder's primary workspace. (An intentional evolution of the
-  // single-view Build layout spec-159/spec-164 set.)
-  const [buildSubTab, setBuildSubTab] = useState<'work' | 'qa-report'>('work');
   // spec-182 issue-3: for EDITORS the Specify review affordances sit behind a
   // collapsed-by-default "Review actions" disclosure — the reviewer workflow
   // shouldn't visually dominate the editor's page. Reviewers see them expanded
@@ -211,14 +238,14 @@ export function DocDocument() {
   // — if the target is filtered out (e.g. resolved under the default open
   // filter) it simply won't be found.
   useEffect(() => {
-    if (initialCommentSeq == null || planSubTab !== 'comments') return;
+    if (initialCommentSeq == null || subTab !== 'comments') return;
     const el = document.getElementById(commentAnchorId(initialCommentSeq));
     if (!el) return;
     el.scrollIntoView({ behavior: 'smooth', block: 'center' });
     el.classList.add('ring-2', 'ring-accent', 'rounded-md');
     const t = setTimeout(() => el.classList.remove('ring-2', 'ring-accent', 'rounded-md'), 2000);
     return () => clearTimeout(t);
-  }, [initialCommentSeq, planSubTab, commentsBySection, commentsByDecision, commentsByTask]);
+  }, [initialCommentSeq, subTab, commentsBySection, commentsByDecision, commentsByTask]);
 
   useEffect(() => {
     if (!id) return;
@@ -348,7 +375,7 @@ export function DocDocument() {
   const handleSelectSection = useCallback((sectionId: string) => {
     // The Narrative lives under the Specify view's first sub-tab.
     setSelectedTab('specify');
-    setPlanSubTab('narrative');
+    setSubTab('narrative');
     setSelectedSectionId(sectionId);
     const index = sortedSections.findIndex((s) => s.id === sectionId);
     if (index >= 0) {
@@ -363,8 +390,8 @@ export function DocDocument() {
   // route them there (Narrative for sections, Decisions & ACs for decisions).
   const handleTabChange = useCallback((tab: string) => {
     setSelectedTab('specify');
-    if (tab === 'decisions') setPlanSubTab('decisions');
-    else if (tab === 'document') setPlanSubTab('narrative');
+    if (tab === 'decisions') setSubTab('decisions');
+    else if (tab === 'document') setSubTab('narrative');
   }, []);
 
   // Cross-view nav for the DecisionAcStrip pills: when a pill is clicked in the
@@ -375,7 +402,7 @@ export function DocDocument() {
   const handleJumpToAc = useCallback((acId: string) => {
     setFocusedAcId(acId);
     setSelectedTab('specify');
-    setPlanSubTab('decisions');
+    setSubTab('decisions');
   }, []);
 
   const handleSectionCommentsChange = useCallback(
@@ -896,18 +923,28 @@ export function DocDocument() {
     'done',
   );
 
-  // Plan's three sub-tabs. Verify carries no sub-tab bar; Build gained a
-  // secondary "QA Report" tab in spec-260 (an intentional evolution of
-  // spec-159 ac-11's single-view Build).
-  const planSubTabs = [
+  // spec-282 (dec-2): the ONE ordered sub-tab inventory the unified control
+  // carries in every phase — Narrative · Comments · Decisions & ACs · Agent
+  // Tasks & Issues · QA Report. (Supersedes the disjoint spec-260 per-phase sets:
+  // the old `planSubTabs` Narrative/Decisions/Comments AND the Build
+  // Tasks&Issues/QA-Report tabs collapse into this single bar.)
+  const subTabs = [
     /* spec-233 dec-1 (supersedes spec-196 dec-1): the label reads "Narrative".
        Calling this single tab "Spec" misread as if it WERE the whole spec — the
        whole object is the Spec; this tab is the prose lens within it. The id
        stays 'narrative' — internal vocabulary, deep links and comment routing
        are deliberately unchanged (display-label-only). */
     { id: 'narrative', label: 'Narrative', count: sectionCommentCount, countVariant: 'warning' as const },
-    { id: 'decisions', label: 'Decisions & ACs', count: decisionCommentCount, countVariant: 'warning' as const },
+    /* spec-282 dec-2: Comments placed second (after Narrative) as a persistent
+       companion view, not an end-of-line afterthought. */
     { id: 'comments', label: 'Comments', count: totalCommentCount, countVariant: 'warning' as const },
+    { id: 'decisions', label: 'Decisions & ACs', count: decisionCommentCount, countVariant: 'warning' as const },
+    /* spec-282 dec-2: "Agent Tasks & Issues" preserves the spec-260 Tasks │
+       Issues two-column and names the agent's execution layer explicitly. */
+    { id: 'work', label: 'Agent Tasks & Issues' },
+    /* spec-282 dec-1: QA Report is present in every phase; before a report
+       exists it renders an honest empty-state placeholder (ac-3). */
+    { id: 'qa-report', label: 'QA Report', count: qaReports.length || undefined },
   ];
 
   // ── Reusable content fragments — each phase layout below composes these ─────
@@ -1082,100 +1119,80 @@ export function DocDocument() {
     </>
   );
 
-  // ── The declarative phase → layout map (spec-159: explicitly a plain data
-  //    structure so the per-phase composition is cheap to rearrange). `draft`
-  //    shares the `specify` layout (its home tab). Each entry says whether the
-  //    phase carries a sub-tab bar and what it renders.
-  //
-  //    spec-258/dec-3: the `done` entry is the Done TAB's content — a read-only
-  //    DoneSummary *preview* shown while browsing Done before the spec is closed.
-  //    It is fed from the same on-page props as the post-close report (doc /
-  //    decisions / tasks / acs / issues / people) but carries NO Reopen or
-  //    mutation affordance (canReopen omitted) — browsing never mutates phase.
-  //    Once the spec is actually `done`, the bar is hidden and the real
-  //    DoneSummary (with Reopen) takes over the whole area below. ─────────────
-  const PHASE_LAYOUTS: Record<PhaseTab, { hasSubTabs: boolean; render: () => React.ReactNode }> = {
-    specify: {
-      hasSubTabs: true,
-      render: () => (
-        <>
-          {/* Classic underline tabs (full-width baseline + active bar) — the
-              pill variant read as buttons, not tabs. */}
-          <Tabs
-            tabs={planSubTabs}
-            activeTab={planSubTab}
-            onChange={(t) => setPlanSubTab(t as typeof planSubTab)}
-            variant="underline"
-          />
-          {planSubTab === 'narrative' && narrativeView}
-          {planSubTab === 'decisions' && twoCol(decisionPanel, acPanel, planDirective)}
-          {planSubTab === 'comments' && allCommentsView}
-        </>
-      ),
-    },
-    build: {
-      // spec-260 (dec-1): Build gains a tab bar — the Tasks │ Issues two-column
-      // stays the default tab; "QA Report" is a second tab, empty until the
-      // first build→verify hand-off writes one. (Intentional evolution of the
-      // single-view Build layout from spec-159/spec-164.)
-      hasSubTabs: true,
-      render: () => (
-        <>
-          <Tabs
-            tabs={[
-              { id: 'work', label: 'Tasks & Issues' },
-              { id: 'qa-report', label: 'QA Report', count: qaReports.length || undefined },
-            ]}
-            activeTab={buildSubTab}
-            onChange={(t) => setBuildSubTab(t as typeof buildSubTab)}
-            variant="underline"
-          />
-          {buildSubTab === 'work' && twoCol(taskPanel, issuePanel(true), buildDirective)}
-          {buildSubTab === 'qa-report' && (
-            <QaReportCard
-              reports={qaReports}
-              emptyState="No QA report yet — generated when build hands off to verify"
-            />
-          )}
-        </>
-      ),
-    },
-    verify: {
-      hasSubTabs: false,
-      render: () => (
-        <>
-          {/* spec-260 (dec-1): the QA Report card is front-loaded ABOVE the
-              ACs │ Issues columns so a verifier arriving cold reads it first;
-              collapsible so it folds away once read. */}
-          <QaReportCard reports={qaReports} />
-          {twoCol(
-            acPanel,
-            issuePanel(false),
-            <>
-              {verifyDirective}
-              {verifyTaskEcho}
-            </>,
-          )}
-        </>
-      ),
-    },
-    // spec-258/dec-3: browsing the Done tab previews the retrospective the move
-    // will produce — the same fetch-free DoneSummary, minus Reopen/mutation.
-    done: {
-      hasSubTabs: false,
-      render: () => (
-        <DoneSummary
-          doc={doc}
-          decisions={decs}
-          tasks={ts}
-          acs={acs}
-          issues={issues}
-          people={assignees}
-          preview
+  // ── spec-282: ONE persistent sub-tab control for Specify/Build/Verify ──────
+  //    (dec-1/dec-2/dec-3, supersedes the spec-159/spec-260 per-phase PHASE_LAYOUTS
+  //    map). The control's tab inventory is CONSTANT across phases, so it is never
+  //    swapped out as the phase changes (ac-1) and the set never shrinks (ac-2).
+  //    `effectiveSubTab` is the explicit selection (`subTab`) when set, else the
+  //    current viewed phase's default landing tab (dec-3) — `null` collapses to
+  //    Narrative, which only matters for `done` (which renders its own view).
+  const effectiveSubTab: SubTab =
+    subTab ?? defaultSubTabForTab(viewedTab, qaReports.length > 0) ?? 'narrative';
+
+  const unifiedSubTabView = (
+    <>
+      {/* Classic underline tabs (full-width baseline + active bar). */}
+      <Tabs
+        tabs={subTabs}
+        activeTab={effectiveSubTab}
+        onChange={(t) => setSubTab(t as SubTab)}
+        variant="underline"
+      />
+      {effectiveSubTab === 'narrative' && narrativeView}
+      {effectiveSubTab === 'comments' && allCommentsView}
+      {effectiveSubTab === 'decisions' &&
+        // planDirective / verifyDirective are each phase-gated (null off-phase),
+        // so at most one renders above the Decisions & ACs two-column.
+        twoCol(
+          decisionPanel,
+          acPanel,
+          <>
+            {planDirective}
+            {verifyDirective}
+          </>,
+        )}
+      {effectiveSubTab === 'work' &&
+        // spec-188 dec-4: convert-to-task is a BUILD affordance only (it mints an
+        // incomplete build-phase task), gated on the Spec's actual phase, not the
+        // viewed tab. The verify-phase task-completion echo only shows in verify.
+        twoCol(
+          taskPanel,
+          issuePanel(phase === 'build'),
+          <>
+            {buildDirective}
+            {/* The verify task-completion echo is a verify-VIEW element (it shows
+                whenever the verify tab is browsed, as the old verify layout did),
+                so it keys on the viewed tab, not the Spec's actual phase. */}
+            {viewedTab === 'verify' && verifyTaskEcho}
+          </>,
+        )}
+      {effectiveSubTab === 'qa-report' && (
+        // spec-282 dec-1/ac-3: present in every phase; before a report exists the
+        // empty-state names when it's produced. (spec-260 front-loaded it in
+        // verify; here it's one tab in the persistent control.)
+        <QaReportCard
+          reports={qaReports}
+          emptyState="No QA report yet — generated when build hands off to verify"
         />
-      ),
-    },
-  };
+      )}
+    </>
+  );
+
+  // spec-258/dec-3: browsing the Done tab previews the retrospective the move
+  // will produce — the same fetch-free DoneSummary, minus Reopen/mutation. Shown
+  // while browsing Done before the spec is closed; once the spec is actually
+  // `done` the real DoneSummary (with Reopen) takes over the whole area below.
+  const doneTabView = (
+    <DoneSummary
+      doc={doc}
+      decisions={decs}
+      tasks={ts}
+      acs={acs}
+      issues={issues}
+      people={assignees}
+      preview
+    />
+  );
 
   return (
     <div className="px-6 py-4">
@@ -1316,7 +1333,13 @@ export function DocDocument() {
               <PhaseTabBar
                 currentPhase={phase}
                 selectedTab={viewedTab}
-                onSelect={(t) => setSelectedTab(t)}
+                onSelect={(t) => {
+                  // spec-282 dec-3: landing on a phase applies that phase's
+                  // default sub-tab — reset the explicit selection to null so
+                  // `effectiveSubTab` falls back to defaultSubTabForTab(t).
+                  setSelectedTab(t);
+                  setSubTab(null);
+                }}
               />
             </div>
             <TransitionSentence
@@ -1334,8 +1357,10 @@ export function DocDocument() {
               onTransitioned={() => {
                 // The view follows the move: clear the browsed-tab pin so
                 // `viewedTab` falls back to the (re-fetched) current phase's
-                // home tab.
+                // home tab, and reset the sub-tab to that phase's default
+                // landing tab (spec-282 dec-3).
                 setSelectedTab(null);
+                setSubTab(null);
                 reloadDoc();
               }}
               onCancelBrowse={() => setSelectedTab(null)}
@@ -1420,6 +1445,10 @@ export function DocDocument() {
                   buttonId={handoff.buttonId}
                   context={handoffContext}
                   orgBlocks={orgBlocks}
+                  /* spec-282 dec-5(A): the three phase handoffs copy a short
+                     get_prompt stub — the coding agent fetches the full prompt
+                     itself. The review handoff above is NOT stubbed. */
+                  stub
                   sentence={handoff.sentence}
                   linkText={handoff.linkText}
                   sentenceLabel={handoff.sentenceLabel}
@@ -1430,9 +1459,10 @@ export function DocDocument() {
         )}
 
       {/* Content area. `done` → the retrospective report replaces it entirely;
-          every other phase renders its declarative layout. Non-Spec docs (no
-          phase layer) fall back to the Narrative view. Every posture browses
-          via the tab bar above (spec-182 dec-1). */}
+          browsing the Done tab (while not yet done) shows its read-only preview;
+          every other phase view renders the ONE persistent sub-tab control
+          (spec-282). Non-Spec docs (no phase layer) fall back to the Narrative
+          view. Every posture browses via the tab bar above (spec-182 dec-1). */}
       {doc.docType === 'spec' && phase === 'done' ? (
         <DoneSummary
           doc={doc}
@@ -1456,8 +1486,10 @@ export function DocDocument() {
         />
       ) : doc.docType !== 'spec' ? (
         narrativeView
+      ) : viewedTab === 'done' ? (
+        doneTabView
       ) : (
-        PHASE_LAYOUTS[viewedTab].render()
+        unifiedSubTabView
       )}
 
       {showDownloadDialog && (


### PR DESCRIPTION
**Release PR — `develop` → `main`** (per std-21: merge as a **merge commit**; merging auto-deploys to prod at `memex.ai`, unattended).

## What ships
- **#180 — spec-282**: Spec page UI refresh — unified sub-tabs (Narrative · Comments · Decisions & ACs · Agent Tasks & Issues · QA Report) in every phase with empty-state placeholders; status-only current-phase Rubicon with browse-only advance confirm; human-readable phase-handoff copy stub + reworked copy dialog.
- **#181 — spec-200**: ribbon behaviour — confetti-once, auto-dismiss, fly-home, menu re-open (+ de-flaked countdown assertions).
- **#182**: smoke — warm the deployed host before the suite + retry once (std-17).

## std-21 pre-flight (all green)
- (a) `develop` CI (`test`) green on tip `216561d`.
- (b) int deploy + smoke green on `216561d` (smoke runs at the int-deploy tail, std-17).
- (c) `git log origin/develop..origin/main --no-merges` is empty — content invariant holds (cl-52).

🤖 Generated with [Claude Code](https://claude.com/claude-code)