### PR TITLE
fix(ui): handoff stub names the "specify" phase, not "plan" (spec-282 dec-5)

### DIFF
--- a/packages/ui/src/components/PromptButton.test.tsx
+++ b/packages/ui/src/components/PromptButton.test.tsx
@@ -181,7 +181,8 @@ describe('PromptButton sentence form (spec-159 ac-17)', () => {
 // dismiss); the prompt itself sits on its own bordered canvas, not the guidance.
 describe('PromptButton stub mode + copy feedback (spec-282 dec-5, ac-12)', () => {
   const AC12 = 'mindset-prod/memex-building-itself/specs/spec-282/acs/ac-12';
-  // verify-spec → "Verify handoff" label → phase word "verify".
+  // The phase word is the canonical phase name from HANDOFF_BUTTON_BY_PHASE
+  // (inverted) — verify-spec → 'verify'. NOT the node label.
   const STUB =
     'Use memex spec: https://memex.ai/mindset-prod/memex-building-itself/specs/spec-103\n' +
     'Get the verify prompt from memex and ask the user how they want to proceed.';
@@ -199,6 +200,24 @@ describe('PromptButton stub mode + copy feedback (spec-282 dec-5, ac-12)', () =>
     expect(writeText).not.toHaveBeenCalledWith(full);
     // The stub is meaningfully shorter than the full scaffold payload.
     expect(STUB.length).toBeLessThan(full.length);
+  });
+
+  it('the specify handoff names the "specify" phase, not "plan" (the label says "Plan handoff")', async () => {
+    tagAc(AC12);
+    // Regression: deriving the phase word from the node label gave "plan" for
+    // the specify handoff (labelled "Plan handoff"); it must be the canonical
+    // phase name "specify".
+    const OPEN_PLAN = 'Show the Plan handoff prompt to copy into a coding agent';
+    render(<PromptButton buttonId="plan-handoff" context={CTX} stub />);
+
+    fireEvent.click(screen.getByRole('button', { name: OPEN_PLAN }));
+    fireEvent.click(screen.getByRole('button', { name: 'Copy prompt' }));
+
+    const expected =
+      'Use memex spec: https://memex.ai/mindset-prod/memex-building-itself/specs/spec-103\n' +
+      'Get the specify prompt from memex and ask the user how they want to proceed.';
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith(expected));
+    expect(writeText).not.toHaveBeenCalledWith(expect.stringContaining('Get the plan prompt'));
   });
 
   it('without stub the full scaffold prompt is still copied (get_prompt parity preserved)', async () => {

--- a/packages/ui/src/components/PromptButton.tsx
+++ b/packages/ui/src/components/PromptButton.tsx
@@ -10,7 +10,7 @@
 
 import { useState } from 'react';
 import { createPortal } from 'react-dom';
-import { BASE_SCAFFOLD, toButtonPrompt, type GuidanceBlock } from '@memex/shared';
+import { BASE_SCAFFOLD, toButtonPrompt, HANDOFF_BUTTON_BY_PHASE, type GuidanceBlock } from '@memex/shared';
 import { Button } from './ui';
 
 export interface PromptButtonProps {
@@ -89,11 +89,17 @@ function TerminalIcon() {
 // calls `get_prompt` to fetch the full scaffold (Org appends included), so this
 // stays a UI-layer projection and the scaffold node text is never edited
 // (get_prompt byte-parity, spec-263). The second line is PHASE-SPECIFIC: the
-// phase word is the lowercased first word of the handoff node `label` (e.g.
-// "Build handoff" → "build"), so each of the three handoffs names its own prompt.
-function buildHandoffStub(context: Record<string, unknown>, label: string): string {
+// phase word is the CANONICAL phase name, looked up from HANDOFF_BUTTON_BY_PHASE
+// (phase→buttonId) inverted. It must NOT come from the node `label`: the specify
+// handoff is historically labelled "Plan handoff", so a label-first-word
+// derivation mislabels the specify phase as "plan" — the phase is `specify`.
+const PHASE_BY_HANDOFF_BUTTON: Readonly<Record<string, string>> = Object.fromEntries(
+  Object.entries(HANDOFF_BUTTON_BY_PHASE).map(([phase, id]) => [id, phase]),
+);
+
+function buildHandoffStub(context: Record<string, unknown>, buttonId: string): string {
   const str = (k: string) => String(context[k] ?? '');
-  const phase = (label.trim().split(/\s+/)[0] ?? '').toLowerCase();
+  const phase = PHASE_BY_HANDOFF_BUTTON[buttonId] ?? '';
   return [
     `Use memex spec: ${str('url')}`,
     `Get the ${phase} prompt from memex and ask the user how they want to proceed.`,
@@ -251,7 +257,7 @@ export function PromptButton({
 
   // spec-282 dec-5(A): in stub mode the dialog shows + copies the short
   // get_prompt stub; otherwise the full scaffold prompt.
-  const dialogPrompt = stub ? buildHandoffStub(context, node.label) : prompt;
+  const dialogPrompt = stub ? buildHandoffStub(context, buttonId) : prompt;
 
   // spec-159 ac-17 — the sentence form. The clickable words (`linkText`, default
   // "Copy") render as a hyperlink-styled <button> (it performs an action, not


### PR DESCRIPTION
## The bug
The phase-handoff copy stub (spec-282 dec-5) read **"Get the plan prompt from memex"** on a Spec in the **specify** phase — it should say **"specify"**. Reported live on the spec-283 handoff dialog; shipped to prod in the last release.

## Cause
The stub derived its phase word from the handoff node's *label* (lowercased first word): "Build handoff" → "build", "Verify handoff" → "verify" — but the specify handoff is historically labelled **"Plan handoff"**, so it produced "plan".

## Fix
Derive the phase word from the canonical `HANDOFF_BUTTON_BY_PHASE` map (phase→buttonId), inverted, so it is always the real phase name. `build`/`verify` were already correct; this corrects `specify`. Added a regression test asserting `plan-handoff` → "specify" (and not "plan").

- `tsc --noEmit` clean; `PromptButton.test.tsx` 16/16 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)