### PR TITLE
feat(ui): one state-pilled decisions list, no tabs (spec-247 dec-7)

### DIFF
--- a/packages/ui/e2e/journey-14-candidate-decision.spec.ts
+++ b/packages/ui/e2e/journey-14-candidate-decision.spec.ts
@@ -70,9 +70,10 @@ test("candidate decisions are view-only on the web; approval happens agent-side 
     timeout: 15_000,
   });
 
-  // Open the Decisions & ACs sub-tab and the Candidates sub-tab.
+  // Open the Decisions & ACs sub-tab. spec-247 dec-7: there are no longer
+  // Candidates/Open/Resolved tabs — every decision renders in one grouped list,
+  // so the candidate card is visible directly.
   await page.getByRole("button", { name: /^Decisions & ACs$/i }).click();
-  await page.getByRole("button", { name: /^Candidates 1$/i }).click();
 
   const panel = page.getByTestId("decision-panel");
 
@@ -116,10 +117,11 @@ test("candidate decisions are view-only on the web; approval happens agent-side 
 
   await sendChat(page, "yes, that's a real decision — approve it");
 
-  await expect(page.getByRole("button", { name: /^Open 1$/i })).toBeVisible({
-    timeout: 15_000,
-  });
-  await page.getByRole("button", { name: /^Open 1$/i }).click();
+  // spec-247 dec-7: no tabs — the approved decision surfaces directly as an
+  // open card in the unified list.
+  await expect(
+    page.locator('[data-decision-status="open"]').first(),
+  ).toBeVisible({ timeout: 15_000 });
   await expect(page.getByText("Pick database").first()).toBeVisible({
     timeout: 15_000,
   });

--- a/packages/ui/e2e/journey-16-reactivity.spec.ts
+++ b/packages/ui/e2e/journey-16-reactivity.spec.ts
@@ -176,12 +176,11 @@ test.describe("doc-16 Wave 1 reactivity journeys", () => {
     expect(resolveResp.ok()).toBeTruthy();
 
     // The decision panel should reflect the resolved state via SSE refetch.
-    // Wait for the Resolved sub-tab's count to land (SSE delivered the event),
-    // then click into it to read the resolution body.
-    await expect(tab.getByRole("button", { name: /^Resolved 1$/ })).toBeVisible({
-      timeout: 15_000,
-    });
-    await tab.getByRole("button", { name: /^Resolved 1$/ }).click();
+    // spec-247 dec-7: no tabs — the resolved decision surfaces directly as a
+    // resolved card whose compact row shows the resolution body.
+    await expect(
+      tab.locator('[data-decision-status="resolved"]').first(),
+    ).toBeVisible({ timeout: 15_000 });
     await expect(tab.getByText("Postgres it is.").first()).toBeVisible({ timeout: 15_000 });
 
     await ctx.close();

--- a/packages/ui/e2e/journey-19-lifecycle-spine.spec.ts
+++ b/packages/ui/e2e/journey-19-lifecycle-spine.spec.ts
@@ -192,13 +192,13 @@ test("lifecycle spine: org → memex → Spec → resolve decision → phase mov
 
   await panel.getByTestId("open-option-0").first().check();
 
-  // Resolved: the decision moves to the Resolved tray. The specify→Build Decisions
-  // blocker is now satisfied — but ACs still aren't created, so the Rubicon
-  // STILL blocks on ACs (the affordance reflects the remaining gate, proving the
-  // phase-gated state is live, not static).
-  await expect(panel.getByRole("button", { name: /^Resolved 1$/ })).toBeVisible({
-    timeout: 15_000,
-  });
+  // Resolved: the decision becomes a resolved card in the unified list (spec-247
+  // dec-7). The specify→Build Decisions blocker is now satisfied — but ACs still
+  // aren't created, so the Rubicon STILL blocks on ACs (the affordance reflects
+  // the remaining gate, proving the phase-gated state is live, not static).
+  await expect(
+    panel.locator('[data-decision-status="resolved"]').first(),
+  ).toBeVisible({ timeout: 15_000 });
   await expect(page.getByTestId("transition-sentence")).toContainText(
     /Acceptance Criteria \(ACs\)[\s\S]*must be created[\s\S]*before this spec can move to Build/i,
     { timeout: 15_000 }

--- a/packages/ui/e2e/journey-21-spec-196-narrative.spec.ts
+++ b/packages/ui/e2e/journey-21-spec-196-narrative.spec.ts
@@ -125,9 +125,10 @@ test("specify→build gate: stale narrative blocks the offer; consolidation rest
   // spec-247 dec-1/dec-5: picking an option IS the answer — the click persists
   // immediately (no Resolve button, no rationale step).
   await panel.getByTestId("open-option-1").first().check();
-  await expect(panel.getByRole("button", { name: /^Resolved 1$/ })).toBeVisible({
-    timeout: 15_000,
-  });
+  // spec-247 dec-7: the decision becomes a resolved card in the unified list.
+  await expect(
+    panel.locator('[data-decision-status="resolved"]').first(),
+  ).toBeVisible({ timeout: 15_000 });
 
   // All decisions resolved + AC present + never consolidated → the current-tab
   // Rubicon states the staleness condition WITH the how-to tail. spec-282/dec-4:

--- a/packages/ui/e2e/journey-27-spec-247-decision-surfaces.spec.ts
+++ b/packages/ui/e2e/journey-27-spec-247-decision-surfaces.spec.ts
@@ -103,19 +103,19 @@ test("answer-by-click persists across reload, re-select updates, discussion is t
   await panel.getByRole("button", { name: /Hide discussion/ }).click();
 
   // ── Answer by clicking an option — that IS the resolution ──
+  // spec-247 dec-7: no tabs — the decision becomes a resolved card in place.
   await panel.getByTestId("open-option-1").first().check();
-  await expect(panel.getByRole("button", { name: /^Resolved 1$/ })).toBeVisible({
-    timeout: 15_000,
-  });
+  await expect(
+    panel.locator('[data-decision-status="resolved"]').first(),
+  ).toBeVisible({ timeout: 15_000 });
 
   // ── The answer survives a full reload (the agent-craft prod scenario) ──
   await page.reload();
   await page.getByRole("button", { name: /Decisions & ACs/ }).click();
   const panelAfter = page.getByTestId("decision-panel");
-  await expect(panelAfter.getByRole("button", { name: /^Resolved 1$/ })).toBeVisible({
-    timeout: 15_000,
-  });
-  await panelAfter.getByRole("button", { name: /^Resolved 1$/ }).click();
+  await expect(
+    panelAfter.locator('[data-decision-status="resolved"]').first(),
+  ).toBeVisible({ timeout: 15_000 });
   await expect(panelAfter).toContainText(/Chose:/, { timeout: 15_000 });
   await expect(panelAfter).toContainText(/In-process LRU/);
 

--- a/packages/ui/src/components/DecisionPanel.test.tsx
+++ b/packages/ui/src/components/DecisionPanel.test.tsx
@@ -74,8 +74,7 @@ const TWO_OPTIONS = [
 beforeEach(() => vi.clearAllMocks());
 
 describe('DecisionPanel', () => {
-  it('renders open + resolved decisions with the right status attributes', async () => {
-    const user = userEvent.setup();
+  it('renders open + resolved decisions with the right status attributes', () => {
     const decisions = [
       makeDecision({ id: 'd-open', seq: 1, title: 'Which DB?', status: 'open' }),
       makeDecision({
@@ -94,20 +93,16 @@ describe('DecisionPanel', () => {
       />
     );
 
-    // Default tab is 'open' when no candidates exist; the open card is visible.
-    let cards = screen.getAllByTestId('decision-card');
-    expect(cards).toHaveLength(1);
+    // spec-247 dec-7: both cards render together in one list, grouped by state
+    // (open before resolved) — there is no tab to switch.
+    const cards = screen.getAllByTestId('decision-card');
+    expect(cards).toHaveLength(2);
     expect(cards[0].getAttribute('data-decision-status')).toBe('open');
     expect(cards[0].getAttribute('data-decision-seq')).toBe('D-1');
-
-    // Switch to the Resolved tab and check the resolved card.
-    await user.click(screen.getByRole('button', { name: /^Resolved/ }));
-    cards = screen.getAllByTestId('decision-card');
-    expect(cards).toHaveLength(1);
-    const resolvedCard = cards[0];
+    const resolvedCard = cards[1];
     expect(resolvedCard.getAttribute('data-decision-status')).toBe('resolved');
     expect(resolvedCard.getAttribute('data-decision-seq')).toBe('D-2');
-    // Resolution appears twice — once in the compact row, once in the expandable <details>.
+    // Resolution appears in the compact row (and again in the expandable <details>).
     expect(within(resolvedCard).getAllByText('Use HS256 JWT').length).toBeGreaterThan(0);
   });
 
@@ -166,30 +161,17 @@ describe('DecisionPanel', () => {
 
   it('shows agent-driven empty-state copy when the list is empty', () => {
     render(<DecisionPanel docId="doc-1" decisions={[]} onUpdate={vi.fn()} />);
-    // Default tab is 'open' when no candidates exist; the empty state explains
-    // where candidates are confirmed and that picking an option answers.
-    expect(screen.getByText(/No open decisions/i)).toBeInTheDocument();
-    expect(screen.getByText(/picking an option records your answer/i)).toBeInTheDocument();
-  });
-
-  it('Candidates tab empty state explains the agent-driven candidate flow', async () => {
-    const user = userEvent.setup();
-    render(<DecisionPanel docId="doc-1" decisions={[]} onUpdate={vi.fn()} />);
-    await user.click(screen.getByRole('button', { name: /Candidates/i }));
-    expect(screen.getByText(/No candidate decisions yet/i)).toBeInTheDocument();
+    // spec-247 dec-7: one unified invitation, not a per-tab empty lane.
+    expect(screen.getByTestId('decision-empty')).toBeInTheDocument();
+    expect(screen.getByText(/No decisions yet/i)).toBeInTheDocument();
     expect(screen.getByText(/agent watches for choices with multiple options/i)).toBeInTheDocument();
   });
 
-  it('Resolved tab empty state explains the resolution flow', async () => {
-    const user = userEvent.setup();
-    render(<DecisionPanel docId="doc-1" decisions={[]} onUpdate={vi.fn()} />);
-    await user.click(screen.getByRole('button', { name: /Resolved/i }));
-    expect(screen.getByText(/No resolved decisions yet/i)).toBeInTheDocument();
-    expect(screen.getByText(/durable .* record/i)).toBeInTheDocument();
-  });
-
-  it('defaults to the Candidates tab when any candidate exists', () => {
+  it('renders every decision in one list, grouped candidates → open → resolved, each pilled (spec-247 dec-7, ac-23)', () => {
+    tagAc(AC247(23));
+    // Passed in a deliberately jumbled order — the panel regroups by state.
     const decisions = [
+      makeDecision({ id: 'open-1', seq: 2, status: 'open', title: 'Other?' }),
       makeDecision({
         id: 'cand-1',
         seq: 1,
@@ -197,19 +179,25 @@ describe('DecisionPanel', () => {
         title: 'API style?',
         options: TWO_OPTIONS,
       }),
-      makeDecision({ id: 'open-1', seq: 2, status: 'open', title: 'Other?' }),
+      makeDecision({ id: 'res-1', seq: 3, status: 'resolved', title: 'Done?', resolution: 'Yes' }),
     ];
     render(<DecisionPanel docId="doc-1" decisions={decisions} onUpdate={vi.fn()} />);
 
+    // No tabs — every decision is visible at once, grouped by state.
+    expect(screen.queryByRole('button', { name: /^Candidates/ })).not.toBeInTheDocument();
     const cards = screen.getAllByTestId('decision-card');
-    expect(cards).toHaveLength(1);
-    expect(cards[0].getAttribute('data-decision-status')).toBe('candidate');
-    expect(cards[0].getAttribute('data-decision-seq')).toBe('D-1');
+    expect(cards.map((c) => c.getAttribute('data-decision-status'))).toEqual([
+      'candidate',
+      'open',
+      'resolved',
+    ]);
+    // Each card carries a state pill (the <Badge>).
+    expect(within(cards[0]).getByText('candidate')).toBeInTheDocument();
+    expect(within(cards[1]).getByText('open')).toBeInTheDocument();
+    expect(within(cards[2]).getByText('resolved')).toBeInTheDocument();
 
-    // Both options render with their trade-offs (informational, spec-247 dec-6).
+    // The candidate's options still render with their trade-offs (spec-247 dec-6).
     expect(screen.getByText('REST')).toBeInTheDocument();
-    expect(screen.getByText('Simple, well-known')).toBeInTheDocument();
-    expect(screen.getByText('gRPC')).toBeInTheDocument();
     expect(screen.getByText('Faster, harder tooling')).toBeInTheDocument();
   });
 
@@ -237,8 +225,7 @@ describe('DecisionPanel', () => {
     expect(onUpdate).toHaveBeenCalled();
   });
 
-  it('shows the chosen-option label on a resolved decision with options[]', async () => {
-    const user = userEvent.setup();
+  it('shows the chosen-option label on a resolved decision with options[]', () => {
     const decisions = [
       makeDecision({
         id: 'res-1',
@@ -255,8 +242,7 @@ describe('DecisionPanel', () => {
     ];
     render(<DecisionPanel docId="doc-1" decisions={decisions} onUpdate={vi.fn()} />);
 
-    // Switch to the Resolved tab.
-    await user.click(screen.getByRole('button', { name: /^Resolved/ }));
+    // The resolved card renders directly — no tab to switch.
     expect(screen.getByText(/Chose:/)).toBeInTheDocument();
     expect(screen.getAllByText(/^JWT$/).length).toBeGreaterThan(0);
   });
@@ -322,7 +308,6 @@ describe('DecisionPanel — one obvious place to answer (spec-247)', () => {
     ];
     render(<DecisionPanel docId="doc-1" decisions={decisions} onUpdate={onUpdate} />);
 
-    await user.click(screen.getByRole('button', { name: /^Resolved/ }));
     await user.click(screen.getByText('Context'));
     await user.click(screen.getByTestId('resolved-option-1'));
 
@@ -457,7 +442,6 @@ describe('DecisionPanel — one obvious place to answer (spec-247)', () => {
     ];
     render(<DecisionPanel docId="doc-1" decisions={decisions} onUpdate={vi.fn()} />);
 
-    await user.click(screen.getByRole('button', { name: /^Resolved/ }));
     await user.click(screen.getByText('Context'));
 
     // No reasoning affordance, expanded or otherwise.
@@ -502,12 +486,14 @@ describe('DecisionPanel — draft-phase gating (spec-164)', () => {
     expect(screen.getByText('Which DB?')).toBeInTheDocument();
   });
 
-  it('specify + zero decisions → behaviour unchanged (tabs scaffolding, no directive)', () => {
+  it('specify + zero decisions → behaviour unchanged (unified list scaffolding, no directive)', () => {
     tagAc(AC164(18));
     render(
       <DecisionPanel docId="doc-1" decisions={[]} onUpdate={vi.fn()} specPhase="specify" />,
     );
     expect(screen.queryByTestId('decision-draft-directive')).not.toBeInTheDocument();
-    expect(screen.getByText('No open decisions.')).toBeInTheDocument();
+    // spec-247 dec-7: specify renders the standard panel — its unified empty-state
+    // invitation (not the draft directive).
+    expect(screen.getByTestId('decision-empty')).toBeInTheDocument();
   });
 });

--- a/packages/ui/src/components/DecisionPanel.tsx
+++ b/packages/ui/src/components/DecisionPanel.tsx
@@ -14,7 +14,7 @@ import type { GuidanceBlock } from '@memex/shared';
 import { useAuth } from './AuthContext';
 import { useChat } from './ChatContext';
 import { CommentTray } from './CommentTray';
-import { Badge, Button, Tabs } from './ui';
+import { Badge, Button } from './ui';
 import { DecisionAcStrip } from './DecisionAcStrip';
 import { PromptButton } from './PromptButton';
 import { TextArea } from './ui/TextArea';
@@ -74,8 +74,6 @@ interface DecisionPanelProps {
   /** Org scaffold appends threaded into toButtonPrompt (spec-159 ac-17). */
   orgBlocks?: readonly GuidanceBlock[];
 }
-
-type TabId = 'candidates' | 'open' | 'resolved';
 
 export function DecisionPanel({ docId, decisions, commentsByDecision = {}, forceShowComments: _forceShowComments, onCommentsChange, onUpdate, highlightDecisionHandle, onJumpToAc, canWrite = true, canEdit = true, specPhase, isDemo = false, promptContext, orgBlocks }: DecisionPanelProps) {
   const panelRef = useRef<HTMLDivElement>(null);
@@ -190,17 +188,15 @@ export function DecisionPanel({ docId, decisions, commentsByDecision = {}, force
     [decisions],
   );
 
-  // Default the visible tab to Candidates when any exist (per t-16 AC), else
-  // Open. We re-evaluate on each render only via the initial state — once the
-  // user clicks a tab their selection wins.
-  const [activeTab, setActiveTab] = useState<TabId>(
-    candidates.length > 0 ? 'candidates' : 'open',
-  );
+  // spec-247 dec-7: the Candidates / Open / Resolved tabs are gone — every
+  // decision renders in one list grouped by state, each card pilled with its
+  // status. No active-tab state to track.
 
-  // ?decision=D-N (or legacy `dec-N` from standard content) — switch to the right
-  // tab for the matching decision's status, then scroll its card into view and
-  // pulse a highlight ring for ~2s. (t-19 W3.1; case-insensitive after doc-26
-  // rename so legacy `[per dec-N]` standard cites still deep-link.)
+  // ?decision=D-N (or legacy `dec-N` from standard content) — scroll the matching
+  // decision card into view and pulse a highlight ring for ~2s. (t-19 W3.1;
+  // case-insensitive after doc-26 rename so legacy `[per dec-N]` standard cites
+  // still deep-link.) Every card is always rendered now (spec-247 dec-7), so
+  // there is no tab to switch first.
   // Re-runs whenever the deep-link handle or the decisions array changes (e.g. SSE
   // refetch updates the list). The highlight clears itself; if the user's already
   // looking at the row, the short ring is the only visual change.
@@ -212,11 +208,7 @@ export function DecisionPanel({ docId, decisions, commentsByDecision = {}, force
     const target = decisions.find((d) => d.seq === seq);
     if (!target) return;
 
-    if (target.status === 'candidate') setActiveTab('candidates');
-    else if (target.status === 'open') setActiveTab('open');
-    else if (target.status === 'resolved') setActiveTab('resolved');
-
-    // Defer to next tick so the tab change has rendered the matching card.
+    // Defer to next tick so any state-driven re-render has settled the card.
     const handle = window.setTimeout(() => {
       const card = panelRef.current?.querySelector<HTMLElement>(
         `[data-decision-seq="D-${seq}"]`,
@@ -345,12 +337,6 @@ export function DecisionPanel({ docId, decisions, commentsByDecision = {}, force
     </div>
   );
 
-  const tabs: Array<{ id: TabId; label: string; count: number; countVariant?: 'default' | 'warning' | 'danger' }> = [
-    { id: 'candidates', label: 'Candidates', count: candidates.length, countVariant: 'warning' },
-    { id: 'open', label: 'Open', count: open.length, countVariant: 'warning' },
-    { id: 'resolved', label: 'Resolved', count: resolved.length },
-  ];
-
   // spec-164 dec-3: gate the invitation, never the content — a draft Spec
   // with zero decisions invites the move to Specify instead of presenting
   // empty tabs. Any existing decisions fall through to the normal render.
@@ -386,22 +372,24 @@ export function DecisionPanel({ docId, decisions, commentsByDecision = {}, force
         </span>
       </div>
 
-      <Tabs tabs={tabs} activeTab={activeTab} onChange={(id) => setActiveTab(id as TabId)} />
+      {/* spec-247 dec-7: ONE list, grouped by state (candidates → open →
+          resolved), each card pilled with its status — no Candidates / Open /
+          Resolved tabs. A truly empty Spec shows one invitation, not three
+          empty lanes. */}
+      {decisions.length === 0 && (
+        <div data-testid="decision-empty" className="text-sm text-muted space-y-1">
+          <p>No decisions yet.</p>
+          <p className="text-xs">While you discuss the spec in chat, the agent watches for choices with multiple options and trade-offs and proposes them as candidates for you to review.</p>
+        </div>
+      )}
 
-      {/* ── Candidates tab ─────────────────────────────────────── */}
-      {activeTab === 'candidates' && (
+      {/* ── Candidates ─────────────────────────────────────────── */}
+      {candidates.length > 0 && (
         <div className="space-y-2 mb-4">
-          {candidates.length === 0 && (
-            <div className="text-sm text-muted space-y-1">
-              <p>No candidate decisions yet.</p>
-              <p className="text-xs">Decisions surface here automatically. While you discuss the spec in chat, the agent watches for choices with multiple options and trade-offs and proposes them as candidates for you to review.</p>
-            </div>
-          )}
-
           {/* spec-247 dec-6 / ac-21 — the boundary marker: candidate review
               (approve / reject) is coding-agent work, and the surface says so
               instead of offering web buttons that half-implement it. */}
-          {candidates.length > 0 && promptContext && (
+          {promptContext && (
             <div data-testid="candidate-mcp-marker" className="rounded-md border border-edge-subtle bg-overlay/30 px-3 py-2">
               <PromptButton
                 buttonId="review-candidates"
@@ -527,15 +515,9 @@ export function DecisionPanel({ docId, decisions, commentsByDecision = {}, force
       )}
 
       {/* ── Open tab ───────────────────────────────────────────── */}
-      {activeTab === 'open' && (
+      {/* ── Open ───────────────────────────────────────────────── */}
+      {open.length > 0 && (
         <div className="space-y-2 mb-4">
-          {open.length === 0 && (
-            <div className="text-sm text-muted space-y-1">
-              <p>No open decisions.</p>
-              <p className="text-xs">Decisions move here once a candidate is confirmed from your coding agent. An open decision is an unresolved choice with options on the table — picking an option records your answer.</p>
-            </div>
-          )}
-
           {open.map((dec) => {
             const isExpanded = !collapsedOpen.has(dec.id);
             const isBusy = busyOpen === dec.id;
@@ -657,16 +639,9 @@ export function DecisionPanel({ docId, decisions, commentsByDecision = {}, force
         </div>
       )}
 
-      {/* ── Resolved tab ───────────────────────────────────────── */}
-      {activeTab === 'resolved' && (
+      {/* ── Resolved ───────────────────────────────────────────── */}
+      {resolved.length > 0 && (
         <div className="space-y-2 mb-4">
-          {resolved.length === 0 && (
-            <div className="text-sm text-muted space-y-1">
-              <p>No resolved decisions yet.</p>
-              <p className="text-xs">Resolved decisions land here once an open decision has been answered by picking an option (or in conversation). They become the durable "this is how we decided" record for the spec.</p>
-            </div>
-          )}
-
           {resolved.map((dec) => {
             const decOpenComments = openCommentCount(dec.id) > 0;
             const isBusy = busyResolved === dec.id;


### PR DESCRIPTION
Implements **spec-247 dec-7 / ac-23** — a follow-on to this Spec's thesis ("ONE obvious place to answer").

## What changed
The `DecisionPanel` no longer splits decisions across **Candidates / Open / Resolved** sub-tabs. Every decision renders in **one list, grouped by state** (candidates → open → resolved), each card keeping its existing **state pill** (`<Badge>`). The whole decision record is visible at once instead of one lane behind navigation.

- Resolved cards keep their compact row + collapsible **Context** + re-select; open cards keep their option radios; candidates stay view-only with the coding-agent boundary marker — card internals are unchanged.
- A zero-decision Spec shows **one** unified invitation (`decision-empty`) instead of three empty lanes.
- Deep-linking `?decision=D-N` no longer switches a tab — it scrolls the (always-rendered) card into view.

Removed: the `Tabs` instance, `activeTab`/`TabId` state, the `tabs` array, the per-tab empty states, and the highlight effect's tab-switch.

## Tests
- `DecisionPanel.test.tsx` — added the grouped-list + pills test (**ac-23**); removed the per-tab / default-tab tests and the obsolete tab-switch clicks; the spec-164 empty-state test now asserts `decision-empty`. **20/20.**
- Full UI unit suite **1278 passed** / 1 skipped; `tsc --noEmit` clean.
- e2e journeys **14 / 16 / 19 / 21 / 27** updated to read the card's `data-decision-status` instead of the removed count-tabs (run for real in `make e2e-cold`, std-28).

🤖 Generated with [Claude Code](https://claude.com/claude-code)