### PR TITLE
feat(ui): move Spec review actions into the agent idle state (spec-283)

### DIFF
--- a/packages/ui/e2e/journey-31-spec-283-review-actions-in-agent.spec.ts
+++ b/packages/ui/e2e/journey-31-spec-283-review-actions-in-agent.spec.ts
@@ -1,0 +1,103 @@
+import { test, expect, tenantPath } from "./helpers/index.js";
+import { seedOrgTenant, seedSpec, setDocStatus } from "./helpers/retained.js";
+import { emitAcEvents } from "./helpers/emit-ac.js";
+import {
+  clearAnthropicQueue,
+  queueAnthropicResponse,
+} from "./helpers/anthropic-fake.js";
+
+// Journey 31 (spec-283): the four Spec review actions have moved OFF the Spec
+// page and INTO the agent's idle/empty state.
+//
+// This journey exercises the relocation end-to-end on a Specify-phase Spec
+// (std-28): the four buttons live in the ChatPanel idle state under the lead
+// "Ask a question, or start with a review:"; clicking one starts the
+// conversation and the buttons vanish with the empty state. The Spec page no
+// longer carries the "Review actions" disclosure or the button row, while the
+// coding-agent review-handoff copy line still renders in Specify.
+
+const SPEC283 = "mindset-prod/memex-building-itself/specs/spec-283";
+
+const ACS_BY_TEST: Record<string, string[]> = {
+  "review actions live in the agent idle state, not on the Spec page": [
+    `${SPEC283}/acs/ac-5`, // relocation preserves coverage + ships an e2e journey
+    `${SPEC283}/acs/ac-1`, // buttons appear in the idle state; clicking starts the review
+    `${SPEC283}/acs/ac-2`, // idle-only — they disappear once a conversation starts
+    `${SPEC283}/acs/ac-3`, // the page no longer shows the row; handoff line stays
+  ],
+};
+
+test.afterEach(async ({}, testInfo) => {
+  if (testInfo.status === "skipped") return;
+  const refs = ACS_BY_TEST[testInfo.title];
+  if (!refs) return;
+  await emitAcEvents(
+    refs,
+    testInfo.status === "passed" ? "pass" : "fail",
+    `packages/ui/e2e/journey-31-spec-283-review-actions-in-agent.spec.ts::${testInfo.title}`,
+    testInfo.duration
+  );
+});
+
+test("review actions live in the agent idle state, not on the Spec page", async ({
+  page,
+  resources,
+}) => {
+  const tenant = await seedOrgTenant({ slug: resources.slug("j31") });
+  const spec = await seedSpec({
+    memexId: tenant.memexId,
+    title: "Review actions relocation",
+    purpose: "Exercise the relocated review actions in the agent idle state.",
+  });
+  await setDocStatus({ memexId: tenant.memexId, docId: spec.docId, status: "specify" });
+
+  // Clicking a review button fires an agent turn — prime the fake so the turn
+  // completes cleanly rather than erroring.
+  await clearAnthropicQueue();
+  await queueAnthropicResponse({
+    textDeltas: ["Here ", "is ", "the ", "summary."],
+    content: [{ type: "text", text: "Here is the summary." }],
+    stopReason: "end_turn",
+    deltaDelayMs: 10,
+  });
+
+  await page.goto(
+    tenantPath(tenant.namespaceSlug, tenant.memexSlug, `/specs/${spec.handle}`)
+  );
+
+  // The agent panel has mounted (its heading is always present). The Specify
+  // overview prose sits behind the Narrative sub-tab, so it's not a reliable
+  // page-load anchor — the panel heading is.
+  await expect(page.getByText("Spec assistant")).toBeVisible({ timeout: 15_000 });
+
+  // ── The agent idle state carries the four review buttons (ac-1) ──
+  // The block only renders once the bound doc is a Spec in Specify with an idle
+  // conversation, so its visibility also proves ChatContext's doc is bound.
+  const reviewBlock = page.getByTestId("agent-review-actions");
+  await expect(reviewBlock).toBeVisible({ timeout: 15_000 });
+  await expect(reviewBlock).toContainText("Ask a question, or start with a review:");
+  for (const label of [
+    "Summarise Spec",
+    "Security review",
+    "Design review",
+    "Architecture review",
+  ]) {
+    await expect(reviewBlock.getByRole("button", { name: label })).toBeVisible();
+  }
+
+  // ── The Spec page no longer carries the disclosure or the button row, but the
+  //    review-handoff copy line stays (ac-3, dec-4) ──
+  await expect(page.getByTestId("review-actions-toggle")).toHaveCount(0);
+  await expect(page.getByTestId("review-action-row")).toHaveCount(0);
+  await expect(page.getByTestId("review-handoff-line")).toBeVisible({ timeout: 15_000 });
+
+  // ── Clicking one starts the review; the idle buttons vanish (ac-1, ac-2) ──
+  await reviewBlock.getByRole("button", { name: "Summarise Spec" }).click();
+
+  // The conversation has started: the assistant's streamed reply renders and the
+  // idle review block is gone (it only shows while messages.length === 0).
+  await expect(page.getByTestId("chat-markdown")).toHaveText(/Here is the summary\./, {
+    timeout: 10_000,
+  });
+  await expect(page.getByTestId("agent-review-actions")).toHaveCount(0);
+});

--- a/packages/ui/src/components/ChatPanel.spec-111.test.tsx
+++ b/packages/ui/src/components/ChatPanel.spec-111.test.tsx
@@ -41,6 +41,13 @@ vi.mock('./ChatContext', () => ({
   }),
 }));
 
+// spec-283: ChatPanel now resolves Org scaffold appends for the idle review
+// block via useOrgScaffoldBlocks (which calls useAuth). These access-state tests
+// render ChatPanel without an AuthProvider, so mock the hook to an empty array.
+vi.mock('../hooks/useOrgScaffoldBlocks', () => ({
+  useOrgScaffoldBlocks: () => [],
+}));
+
 vi.mock('./chat/ChatMarkdown', () => ({
   ChatMarkdown: ({ content }: { content: string }) => <div>{content}</div>,
 }));

--- a/packages/ui/src/components/ChatPanel.test.tsx
+++ b/packages/ui/src/components/ChatPanel.test.tsx
@@ -18,7 +18,9 @@ let mockChatState: {
   isStreaming: boolean;
   error: string | null;
   docId: string | null;
-  doc: null;
+  // spec-283: ChatPanel reads `doc.status` (the Spec phase) to gate the idle
+  // review-action block. Only the status field is exercised here.
+  doc: { status: string } | null;
   openCommentCount: number;
   contextChips: { type: string; id: string; label: string }[];
   respondedToolIds: Set<string>;
@@ -34,6 +36,14 @@ vi.mock('./ChatContext', () => ({
     clearChat: mockClearChat,
     respondToUiTool: mockRespondToUiTool,
   }),
+}));
+
+// spec-283: the idle review block composes its prompts through the real
+// scaffold (toButtonPrompt + BASE_SCAFFOLD), but the Org-append fetch is mocked
+// to an empty array so no network is touched (the hook's live path is covered
+// by useOrgScaffoldBlocks.test.tsx).
+vi.mock('../hooks/useOrgScaffoldBlocks', () => ({
+  useOrgScaffoldBlocks: () => [],
 }));
 
 // Mock child components to avoid rendering full markdown/UI tool trees
@@ -245,5 +255,111 @@ describe('ChatPanel — Spec assistant naming + grounding (spec-247)', () => {
     expect(makesCodeShapedClaims('The file decisions.ts holds the guard')).toBe(true);
     expect(makesCodeShapedClaims('I created three implementation ACs for this decision')).toBe(true);
     expect(makesCodeShapedClaims('The overview section could be clearer about scope.')).toBe(false);
+  });
+});
+
+// ── spec-283: the four review actions live in the agent idle state ──────────
+// Re-homed off the Spec page (DocDocument) into the ChatPanel empty state.
+// Gated purely on the Spec phase (doc.status==='specify') + an idle
+// conversation (messages.length===0), with no posture input (dec-1), no
+// posture-specific chrome (dec-2), and shown to every viewer incl. read-only
+// non-members (dec-3).
+describe('ChatPanel — review actions in the agent idle state (spec-283)', () => {
+  const AC283 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-283/acs/ac-${n}`;
+  const REVIEW_LABELS = ['Summarise Spec', 'Security review', 'Design review', 'Architecture review'];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockChatState = {
+      messages: [],
+      isStreaming: false,
+      error: null,
+      docId: 'doc-1',
+      doc: { status: 'specify' },
+      openCommentCount: 0,
+      contextChips: [],
+      respondedToolIds: new Set(),
+      isDriftMode: false,
+    };
+  });
+
+  it('in Specify, idle: the four review buttons render under the lead; clicking one sends a real scaffold prompt (ac-1)', async () => {
+    tagAc(AC283(1));
+    const user = userEvent.setup();
+    render(<ChatPanel />);
+
+    const block = screen.getByTestId('agent-review-actions');
+    expect(within(block).getByText('Ask a question, or start with a review:')).toBeInTheDocument();
+    for (const label of REVIEW_LABELS) {
+      expect(within(block).getByRole('button', { name: label })).toBeInTheDocument();
+    }
+
+    await user.click(within(block).getByRole('button', { name: 'Security review' }));
+    expect(mockSendMessage).toHaveBeenCalledTimes(1);
+    const prompt = mockSendMessage.mock.calls[0][0] as string;
+    expect(typeof prompt).toBe('string');
+    expect(prompt.length).toBeGreaterThan(20);
+    expect(prompt).toContain('security');
+  });
+
+  it('the block is absent outside Specify and once a conversation has started (ac-2)', () => {
+    tagAc(AC283(2));
+    // Other phase → no block, plain placeholder instead.
+    mockChatState.doc = { status: 'build' };
+    const { rerender } = render(<ChatPanel />);
+    expect(screen.queryByTestId('agent-review-actions')).not.toBeInTheDocument();
+    expect(screen.getByText('Ask a question about this Spec...')).toBeInTheDocument();
+
+    // Back in Specify but with messages → block disappears with the empty state.
+    mockChatState.doc = { status: 'specify' };
+    mockChatState.messages = [{ id: '1', role: 'user', content: 'hi', timestamp: new Date() }];
+    rerender(
+      <MemoryRouter>
+        <ChatPanel />
+      </MemoryRouter>,
+    );
+    expect(screen.queryByTestId('agent-review-actions')).not.toBeInTheDocument();
+  });
+
+  it('gating needs no posture: default-props ChatPanel (no canEdit) renders the block from doc.status + idle alone (ac-6)', () => {
+    tagAc(AC283(6));
+    // No posture/canEdit prop exists on ChatPanel — rendering with defaults and
+    // only the mocked doc.status + empty messages must be enough to show it.
+    render(<ChatPanel />);
+    expect(screen.getByTestId('agent-review-actions')).toBeInTheDocument();
+  });
+
+  it('no posture-specific copy: read-only and writable viewers see an identical block, no "switch to Editing" note (ac-7, ac-4)', () => {
+    tagAc(AC283(7));
+    tagAc(AC283(4));
+    const { unmount } = render(<ChatPanel />);
+    const writableButtons = screen
+      .getByTestId('agent-review-actions')
+      .querySelectorAll('button');
+    const writableLabels = Array.from(writableButtons).map((b) => b.textContent);
+    expect(screen.queryByText(/switch to editing/i)).not.toBeInTheDocument();
+    unmount();
+
+    render(<ChatPanel readOnly />);
+    const readonlyButtons = screen
+      .getByTestId('agent-review-actions')
+      .querySelectorAll('button');
+    const readonlyLabels = Array.from(readonlyButtons).map((b) => b.textContent);
+    // Identical button set regardless of posture, and still no reviewer nudge.
+    expect(readonlyLabels).toEqual(writableLabels);
+    expect(readonlyLabels).toEqual(REVIEW_LABELS);
+    expect(screen.queryByText(/switch to editing/i)).not.toBeInTheDocument();
+  });
+
+  it('a read-only viewer sees the buttons and clicking one fires sendMessage (ac-8)', async () => {
+    tagAc(AC283(8));
+    const user = userEvent.setup();
+    render(<ChatPanel readOnly />);
+
+    const block = screen.getByTestId('agent-review-actions');
+    expect(within(block).getByRole('button', { name: 'Summarise Spec' })).toBeInTheDocument();
+    await user.click(within(block).getByRole('button', { name: 'Summarise Spec' }));
+    expect(mockSendMessage).toHaveBeenCalledTimes(1);
+    expect(typeof mockSendMessage.mock.calls[0][0]).toBe('string');
   });
 });

--- a/packages/ui/src/components/ChatPanel.tsx
+++ b/packages/ui/src/components/ChatPanel.tsx
@@ -1,12 +1,27 @@
 import { useState, useRef, useEffect, type KeyboardEvent } from 'react';
 import { Link } from 'react-router-dom';
+import { toButtonPrompt, BASE_SCAFFOLD } from '@memex/shared';
 import { useChat } from './ChatContext';
+import { useOrgScaffoldBlocks } from '../hooks/useOrgScaffoldBlocks';
 import { ChatMarkdown } from './chat/ChatMarkdown';
 import { ContextChipBar } from './chat/ContextChipBar';
 import { UiToolRenderer } from './chat/ui-tools';
 import { TextArea } from './ui/TextArea';
 import { Button } from './ui';
 import { PublicAuthButtons } from './PublicAccessControls';
+
+// spec-283: the four Spec review actions, re-homed from the Spec page into the
+// agent's idle/empty state (dec-1…dec-4). The prompts are STATIC scaffold text
+// (no `{placeholder}` interpolation — see `opening-review-*` in
+// scaffold-data.ts), so the agent fires them with `context: {}` and no doc
+// context beyond the Org appends, mirroring DocDocument's `sendReviewPrompt`
+// direct-injection path. Labels/ids match the page's old REVIEW_ACTIONS.
+const REVIEW_ACTIONS: { label: string; buttonId: string }[] = [
+  { label: 'Summarise Spec', buttonId: 'opening-review-summarise' },
+  { label: 'Security review', buttonId: 'opening-review-security' },
+  { label: 'Design review', buttonId: 'opening-review-design' },
+  { label: 'Architecture review', buttonId: 'opening-review-architecture' },
+];
 
 /**
  * spec-111 t-9 — agent panel access states (dec-2):
@@ -76,7 +91,27 @@ export function makesCodeShapedClaims(content: string): boolean {
 }
 
 export function ChatPanel({ isAuthenticated = true, readOnly = false }: ChatPanelProps = {}) {
-  const { messages, isStreaming, error, sendMessage, stopStreaming, clearChat, respondedToolIds, respondToUiTool, docId, contextChips, isDriftMode } = useChat();
+  const { messages, isStreaming, error, sendMessage, stopStreaming, clearChat, respondedToolIds, respondToUiTool, docId, doc, contextChips, isDriftMode } = useChat();
+  // spec-283 dec-1: the review buttons are POSTURE-INDEPENDENT — gated solely on
+  // the Spec's phase (`doc.status==='specify'`, already exposed by useChat) and
+  // an idle conversation (`messages.length===0`). No `canEdit`/posture is
+  // threaded in; ChatContext stays untouched.
+  const orgBlocks = useOrgScaffoldBlocks();
+  const showReviewActions = doc?.status === 'specify' && messages.length === 0;
+
+  const sendReviewPrompt = (buttonId: string) => {
+    // The four review prompts carry no `{placeholder}` tokens, so an empty
+    // context resolves them fully; orgBlocks splice in any Org appends.
+    const prompt = toButtonPrompt({ dataset: BASE_SCAFFOLD, buttonId, context: {}, orgBlocks });
+    if (prompt === null) {
+      const message = `ChatPanel: no PromptButtonNode found for buttonId="${buttonId}"`;
+      if (import.meta.env.DEV) throw new Error(message);
+      // eslint-disable-next-line no-console
+      console.error(message);
+      return;
+    }
+    sendMessage(prompt);
+  };
   // spec-143 t-4 (dec-6): in drift mode the agent is LIVE on arrival (the Drift
   // Inbox has no bound doc), so the input is enabled before any context chip.
   const canChat = !!docId || contextChips.length > 0 || isDriftMode;
@@ -185,10 +220,39 @@ export function ChatPanel({ isAuthenticated = true, readOnly = false }: ChatPane
         )}
 
         {/* spec-159: opening a Spec no longer auto-activates the agent. The
-            page itself carries phase, readiness, the Rubicon line, handoff
-            prompts, and the reviewer block — so the chat sits idle until the
-            user types or clicks a prompt. */}
-        {messages.length === 0 && (
+            page itself carries phase, readiness, the Rubicon line, and handoff
+            prompts — so the chat sits idle until the user types or clicks a
+            prompt.
+            spec-283: in the Specify phase the idle state also offers the four
+            review actions (dec-1…dec-4). They render for EVERY viewer — editor,
+            reviewer, and read-only non-member alike (dec-3) — with no
+            posture-specific copy (dec-2). Clicking one injects that review
+            prompt straight into the chat; the block disappears the moment a
+            conversation starts (messages.length > 0). */}
+        {messages.length === 0 && showReviewActions && (
+          <div
+            data-testid="agent-review-actions"
+            className="flex flex-col items-center gap-3 py-8"
+          >
+            <p className="text-sm text-muted text-center">
+              Ask a question, or start with a review:
+            </p>
+            <div className="flex flex-wrap items-center justify-center gap-2">
+              {REVIEW_ACTIONS.map((action) => (
+                <Button
+                  key={action.buttonId}
+                  type="button"
+                  variant="secondary"
+                  size="sm"
+                  onClick={() => sendReviewPrompt(action.buttonId)}
+                >
+                  {action.label}
+                </Button>
+              ))}
+            </div>
+          </div>
+        )}
+        {messages.length === 0 && !showReviewActions && (
           <div className="text-sm text-muted text-center py-8">
             {canChat ? 'Ask a question about this Spec...' : 'Open a Spec to start chatting'}
           </div>

--- a/packages/ui/src/pages/DocDocument.spec-159.test.tsx
+++ b/packages/ui/src/pages/DocDocument.spec-159.test.tsx
@@ -23,6 +23,9 @@ import type { DocWithGraph } from '../api/types';
 
 const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-159/acs/ac-${n}`;
 const AC252 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-252/acs/ac-${n}`;
+// spec-283 relocates the review actions off the page; these tests verify the
+// page-side removal (ac-3/ac-9) — the agent-side arrival is in ChatPanel.test.tsx.
+const AC283 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-283/acs/ac-${n}`;
 
 // ── Heavy children → identity markers so we can see which panel rendered ────
 vi.mock('../components/DecisionPanel', () => ({
@@ -532,38 +535,31 @@ describe('spec-159 — Rubicon line + in-situ directives', () => {
     // Editors still get the PhaseTabBar (3 phase tabs) and the Rubicon line.
     expect(screen.getAllByRole('tab')).toHaveLength(4);
     expect(screen.getByTestId('transition-sentence')).toBeInTheDocument();
-    // spec-182 dec-3 + issue-3: at Specify the editor keeps ACCESS to the
-    // review actions, but behind a collapsed-by-default disclosure.
-    expect(screen.getByTestId('review-actions-toggle')).toBeInTheDocument();
+    // spec-283 dec-4: the "Review actions" disclosure + button row are GONE
+    // from the page (relocated to the agent's idle state). The editor sees
+    // neither the toggle nor the row; the review-handoff line stays, ungated.
+    expect(screen.queryByTestId('review-actions-toggle')).not.toBeInTheDocument();
     expect(screen.queryByTestId('review-action-row')).not.toBeInTheDocument();
+    expect(screen.getByTestId('review-handoff-line')).toBeInTheDocument();
   });
 
-  // spec-182 issue-3 — the editor's Specify view was visually dominated by the
-  // reviewer workflow (four review buttons + two handoff lines). The user's
-  // call (2026-06-05): collapse, don't remove — editors keep dec-3's access
-  // behind a "Review actions" disclosure; reviewers see it expanded, no chrome.
-  it('editor at Specify: the disclosure expands to the review row + review handoff, and collapses again (issue-3)', async () => {
-    tagAc(AC182(10));
-    tagAc(AC182(11));
+  // spec-283 dec-4 — the "Review actions" disclosure (spec-182 ac-10/ac-11) is
+  // RETIRED: the toggle and the four-button row are deleted from the page (the
+  // actions moved to the agent's idle state). For the editor the review-handoff
+  // line is no longer behind a disclosure — it renders ungated in Specify
+  // alongside the phase handoff, with no expand step.
+  it('editor at Specify: no review disclosure or row; the review-handoff line renders ungated (spec-283 ac-9, retires spec-182 ac-10/ac-11)', async () => {
+    tagAc(AC283(9));
     mockRole = 'editor';
-    const user = userEvent.setup();
     renderAt('specify');
 
-    const toggle = await screen.findByTestId('review-actions-toggle');
-    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    await screen.findByText('Narrative');
+    expect(screen.queryByTestId('review-actions-toggle')).not.toBeInTheDocument();
     expect(screen.queryByTestId('review-action-row')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('review-handoff-line')).not.toBeInTheDocument();
-    // The editor's own phase handoff is NOT behind the disclosure.
-    expect(screen.getByTestId('phase-handoff-line')).toBeInTheDocument();
-
-    await user.click(toggle);
-    expect(toggle).toHaveAttribute('aria-expanded', 'true');
-    expect(screen.getByTestId('review-action-row')).toBeInTheDocument();
+    // The review-handoff line is present immediately — no expand needed.
     expect(screen.getByTestId('review-handoff-line')).toBeInTheDocument();
-
-    await user.click(toggle);
-    expect(screen.queryByTestId('review-action-row')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('review-handoff-line')).not.toBeInTheDocument();
+    // The editor's own phase handoff still renders.
+    expect(screen.getByTestId('phase-handoff-line')).toBeInTheDocument();
   });
 });
 
@@ -586,14 +582,15 @@ describe('spec-182 — unified reviewer phase block', () => {
     tagAc('mindset-prod/memex-building-itself/specs/spec-182/acs/ac-2');
     renderAt('specify');
 
-    await screen.findByTestId('review-action-row');
+    // spec-283: the review-action row is gone; the review-handoff line is the
+    // stable Specify-phase reviewer affordance to anchor on.
+    await screen.findByTestId('review-handoff-line');
     // The PhaseTabBar renders for reviewers too (dec-1) — browse-only.
     expect(screen.getAllByRole('tab')).toHaveLength(4);
     // The Rubicon line renders status-only: present, but no [Yes] (dec-2).
     const sentence = screen.getByTestId('transition-sentence');
     expect(within(sentence).queryByRole('button', { name: 'Yes' })).not.toBeInTheDocument();
-    // issue-3: the collapse disclosure is editor chrome — reviewers get the
-    // row expanded directly, no toggle.
+    // spec-283 dec-4: the "Review actions" disclosure toggle is deleted.
     expect(screen.queryByTestId('review-actions-toggle')).not.toBeInTheDocument();
   });
 
@@ -603,7 +600,7 @@ describe('spec-182 — unified reviewer phase block', () => {
     tagAc(AC252(10)); // spec-252: this header-slot assertion updated to the new location
     const user = userEvent.setup();
     renderAt('specify');
-    await screen.findByTestId('review-action-row');
+    await screen.findByTestId('review-handoff-line');
 
     // spec-252 dec-2: the pill moved OUT of the header slot INTO the in-page
     // phase container, left of the phase bar. It is no longer in the header
@@ -640,27 +637,18 @@ describe('spec-182 — unified reviewer phase block', () => {
     expect(refetchRole).toHaveBeenCalled();
   });
 
-  it('renders the four review-action buttons; clicking one sends the scaffold prompt through chat', async () => {
-    tagAc(AC182(10));
-    tagAc(AC182(11));
-    tagAc(AC182(3));
-    const user = userEvent.setup();
+  // spec-283 ac-3 (retires spec-182 ac-3): the four review buttons are gone
+  // from the page — their behaviour ("clicking one sends the scaffold prompt
+  // through chat") is re-verified on the AGENT surface in ChatPanel.test.tsx.
+  it('reviewer at Specify: no review buttons remain on the page; only the review-handoff line (spec-283 ac-3)', async () => {
+    tagAc(AC283(3));
     renderAt('specify');
 
-    const row = await screen.findByTestId('review-action-row');
+    await screen.findByTestId('review-handoff-line');
+    expect(screen.queryByTestId('review-action-row')).not.toBeInTheDocument();
     for (const label of ['Summarise Spec', 'Security review', 'Design review', 'Architecture review']) {
-      expect(within(row).getByRole('button', { name: label })).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: label })).not.toBeInTheDocument();
     }
-
-    await user.click(within(row).getByRole('button', { name: 'Security review' }));
-    expect(chat.sendMessage).toHaveBeenCalledTimes(1);
-    const prompt = chat.sendMessage.mock.calls[0][0] as string;
-    // Non-empty prose resolved from the scaffold, interpolated with the Spec's
-    // own context (the handle appears in the security-review prompt's body? it
-    // references the Spec generically — assert it's a real, non-trivial string).
-    expect(typeof prompt).toBe('string');
-    expect(prompt.length).toBeGreaterThan(20);
-    expect(prompt).toContain('security');
   });
 
   it('renders the reviewer handoff line — "Copy the review prompt …conduct the review from there."', async () => {
@@ -933,9 +921,9 @@ describe('spec-252 — coloured phase container', () => {
     expect(screen.queryByTestId('phase-container')).not.toBeInTheDocument();
   });
 
-  it('wraps exactly the phase block (pill, bar, transition, review actions) and excludes the title + content Tabs (ac-11)', async () => {
+  it('wraps exactly the phase block (pill, bar, transition, review handoff) and excludes the title + content Tabs (ac-11)', async () => {
     tagAc(AC252(11));
-    renderAt('specify'); // default role = reviewer (canWrite, !canEdit) → review row expanded
+    renderAt('specify'); // default role = reviewer (canWrite, !canEdit)
     const container = await screen.findByTestId('phase-container');
     await within(container).findByTestId('review-handoff-line');
 
@@ -943,7 +931,9 @@ describe('spec-252 — coloured phase container', () => {
     expect(within(container).getByRole('button', { name: /You are reviewing/ })).toBeInTheDocument();
     expect(within(container).getByRole('tablist', { name: /Spec phase view/i })).toBeInTheDocument();
     expect(within(container).getByTestId('transition-sentence')).toBeInTheDocument();
-    expect(within(container).getByTestId('review-action-row')).toBeInTheDocument();
+    // spec-283 dec-4: the review-action row left the page; the review-handoff
+    // line remains inside the phase container.
+    expect(within(container).queryByTestId('review-action-row')).not.toBeInTheDocument();
     expect(within(container).getByTestId('review-handoff-line')).toBeInTheDocument();
 
     // OUTSIDE: the doc title (no heading inside) and the content Tabs row.
@@ -967,11 +957,10 @@ describe('spec-252 — coloured phase container', () => {
     ).toBeTruthy();
   });
 
-  it('introduces no new functionality — phase indicator, review actions, and CTAs are intact and still work (ac-5)', async () => {
+  it('introduces no new functionality — phase indicator and the review-handoff CTA are intact (ac-5)', async () => {
     tagAc(AC252(5));
-    const user = userEvent.setup();
-    renderAt('specify'); // reviewer: review row + handoff render expanded
-    await screen.findByTestId('review-action-row');
+    renderAt('specify'); // reviewer: the review-handoff line renders
+    await screen.findByTestId('review-handoff-line');
 
     // Phase progress indicator — unchanged: the four-tab pipeline, specify
     // current with its ● dot, browse-only behaviour preserved.
@@ -979,16 +968,11 @@ describe('spec-252 — coloured phase container', () => {
     expect(phaseTab('specify')).toHaveAttribute('data-current', 'true');
     expect(phaseTab('specify').textContent).toContain('●');
 
-    // Review actions — unchanged: the four review buttons still render…
-    const row = screen.getByTestId('review-action-row');
-    for (const label of ['Summarise Spec', 'Security review', 'Design review', 'Architecture review']) {
-      expect(within(row).getByRole('button', { name: label })).toBeInTheDocument();
-    }
-    // …and still behave: clicking one sends its scaffold prompt through chat.
-    await user.click(within(row).getByRole('button', { name: 'Summarise Spec' }));
-    await waitFor(() => expect(chat.sendMessage).toHaveBeenCalled());
-
-    // Calls-to-action — unchanged: the review handoff "copy prompt" line is present.
+    // spec-283 dec-4: the four review BUTTONS moved to the agent's idle state —
+    // they no longer render on the page. Their click-sends-a-prompt behaviour is
+    // re-verified on the agent surface (ChatPanel.test.tsx). The review-handoff
+    // "copy prompt" CTA stays on the page.
+    expect(screen.queryByTestId('review-action-row')).not.toBeInTheDocument();
     expect(screen.getByTestId('review-handoff-line')).toBeInTheDocument();
   });
 });

--- a/packages/ui/src/pages/DocDocument.tsx
+++ b/packages/ui/src/pages/DocDocument.tsx
@@ -29,7 +29,7 @@ import { PhaseTabBar, type PhaseTab } from '../components/PhaseTabBar';
 import { phaseColors } from '../components/phaseColors';
 import { TransitionSentence } from '../components/TransitionSentence';
 import { DoneSummary } from '../components/DoneSummary';
-import { Badge, Button, Tabs } from '../components/ui';
+import { Badge, Tabs } from '../components/ui';
 import { DownloadMdDialog } from '../components/DownloadMdDialog';
 import { InitPromptDialog } from '../components/InitPromptDialog';
 import { useChat } from '../components/ChatContext';
@@ -38,8 +38,6 @@ import { PostureDropdown, HEADER_PILL_CLASS } from '../components/PostureDropdow
 import {
   countUnresolvedDecisions,
   isSpecNarrativeStale,
-  toButtonPrompt,
-  BASE_SCAFFOLD,
   HANDOFF_BUTTON_BY_PHASE,
   isQaReportSectionType,
 } from '@memex/shared';
@@ -186,11 +184,6 @@ export function DocDocument() {
           ? 'work'
           : null,
   );
-  // spec-182 issue-3: for EDITORS the Specify review affordances sit behind a
-  // collapsed-by-default "Review actions" disclosure — the reviewer workflow
-  // shouldn't visually dominate the editor's page. Reviewers see them expanded
-  // (no disclosure chrome): it's their workflow.
-  const [reviewActionsOpen, setReviewActionsOpen] = useState(false);
   const [shareOpen, setShareOpen] = useState(false);
   const [shareLinkOpen, setShareLinkOpen] = useState(false);
   const [renameOpen, setRenameOpen] = useState(false);
@@ -666,34 +659,11 @@ export function DocDocument() {
     navigate(tenantPath('/specs'));
   };
 
-  // ── spec-159 ac-19: the writable reviewer's review-action row ──────────────
-  // The same four scaffold chat prompts the OpeningTurn reviewer set surfaces
-  // (Summarise / Security / Design / Architecture). Each resolves its prose from
-  // BASE_SCAFFOLD via toButtonPrompt (interpolating the same context the handoff
-  // line uses) and sends it through the existing chat — mirroring how
-  // OpeningTurn's chat_prompt arm threads onSendPrompt → sendMessage.
-  const REVIEW_ACTIONS: { label: string; buttonId: string }[] = [
-    { label: 'Summarise Spec', buttonId: 'opening-review-summarise' },
-    { label: 'Security review', buttonId: 'opening-review-security' },
-    { label: 'Design review', buttonId: 'opening-review-design' },
-    { label: 'Architecture review', buttonId: 'opening-review-architecture' },
-  ];
-  const sendReviewPrompt = (buttonId: string) => {
-    const prompt = toButtonPrompt({
-      dataset: BASE_SCAFFOLD,
-      buttonId,
-      context: handoffContext,
-      orgBlocks,
-    });
-    if (prompt === null) {
-      const message = `DocDocument: no PromptButtonNode found for buttonId="${buttonId}"`;
-      if (import.meta.env.DEV) throw new Error(message);
-      // eslint-disable-next-line no-console
-      console.error(message);
-      return;
-    }
-    chat.sendMessage(prompt);
-  };
+  // spec-283 dec-4: the four review-ACTION buttons (Summarise / Security /
+  // Design / Architecture) that used to live here have moved into the agent's
+  // idle/empty state (ChatPanel) — they're static scaffold prompts that need no
+  // page context, so the agent fires them directly. Only the review-HANDOFF
+  // line (below) stays on the page, because it interpolates page-level context.
 
   // spec-203 dec-1: the handoff node id is sourced from the single shared
   // HANDOFF_BUTTON_BY_PHASE map — the SAME map the in-chat footer projection
@@ -1365,72 +1335,27 @@ export function DocDocument() {
               }}
               onCancelBrowse={() => setSelectedTab(null)}
             />
-            {/* spec-182 dec-3: the review actions are a SPECIFY-phase fixture
-                for BOTH postures — review is a planning act (you review the
-                decisions and narrative before they harden), so the row keys on
-                the Spec's phase, not the viewer's posture. No other phase
-                (draft included) shows it. The four buttons resolve their
-                prompts from the Scaffold (std-23) and send through the chat.
-                spec-182 issue-3: for EDITORS the row + review handoff sit
-                behind a collapsed-by-default disclosure — access survives,
-                but the reviewer workflow no longer dominates the editor's
-                page. Reviewers get them expanded, no chrome. */}
+            {/* spec-283 dec-4: the four review ACTIONS have moved off the page
+                into the agent's idle/empty state (ChatPanel) — the page no
+                longer carries the "Review actions" disclosure or the button
+                row. What STAYS is the coding-agent review-HANDOFF line: it
+                interpolates {namespace}/{memex}/{handle}/{title}/{url} — page
+                context the generic agent panel doesn't carry — and serves the
+                distinct "conduct the review in your own coding agent" workflow.
+                It renders in Specify for BOTH postures, ungated (no longer
+                behind the deleted editor disclosure). spec-182 issue-4: the
+                link leads each line and names its prompt. */}
             {phase === 'specify' && (
-              <>
-                {canEdit && (
-                  <button
-                    type="button"
-                    data-testid="review-actions-toggle"
-                    aria-expanded={reviewActionsOpen}
-                    onClick={() => setReviewActionsOpen((v) => !v)}
-                    className="flex items-center gap-1 pt-1 text-sm text-secondary hover:text-heading transition-colors"
-                  >
-                    <svg
-                      className={`w-3 h-3 transition-transform ${reviewActionsOpen ? 'rotate-90' : ''}`}
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
-                      strokeWidth={2}
-                    >
-                      <path strokeLinecap="round" strokeLinejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
-                    </svg>
-                    Review actions
-                  </button>
-                )}
-                {(!canEdit || reviewActionsOpen) && (
-                  <>
-                    <div
-                      data-testid="review-action-row"
-                      className="flex flex-wrap items-center gap-2 pt-1"
-                    >
-                      {REVIEW_ACTIONS.map((action) => (
-                        <Button
-                          key={action.buttonId}
-                          type="button"
-                          variant="secondary"
-                          size="sm"
-                          onClick={() => sendReviewPrompt(action.buttonId)}
-                        >
-                          {action.label}
-                        </Button>
-                      ))}
-                    </div>
-                    {/* Review handoff line — copy a coding-agent prompt to conduct
-                        the review from there. Specify-only, like the row (dec-3).
-                        The link leads and names the prompt (issue-4). */}
-                    <div data-testid="review-handoff-line">
-                      <PromptButton
-                        buttonId="review-handoff"
-                        context={handoffContext}
-                        orgBlocks={orgBlocks}
-                        linkText="Copy the review prompt"
-                        sentence="into your coding agent if you prefer to conduct the review from there."
-                        sentenceLabel="Copy the review prompt into your coding agent if you prefer to conduct the review from there."
-                      />
-                    </div>
-                  </>
-                )}
-              </>
+              <div data-testid="review-handoff-line">
+                <PromptButton
+                  buttonId="review-handoff"
+                  context={handoffContext}
+                  orgBlocks={orgBlocks}
+                  linkText="Copy the review prompt"
+                  sentence="into your coding agent if you prefer to conduct the review from there."
+                  sentenceLabel="Copy the review prompt into your coding agent if you prefer to conduct the review from there."
+                />
+              </div>
             )}
             {/* spec-159 ac-17: the next-action handoff line — a "Copy a prompt
                 to …" sentence keyed to the CURRENT phase; absent at `done`.


### PR DESCRIPTION
## Summary
Re-homes the four Spec **review actions** — *Summarise Spec, Security review, Design review, Architecture review* — off the Spec page and into the **agent (chat) panel's idle/empty state** ([spec-283](https://memex.ai/mindset-prod/memex-building-itself/specs/spec-283)). Frontend-only; no server, schema, MCP, or auth changes.

- **ChatPanel** now renders the four buttons in its empty state under *"Ask a question, or start with a review:"*, gated solely on `doc.status==='specify'` + `messages.length===0` — for **every** viewer (editor, reviewer, read-only), with no posture chrome and no "switch to Editing" nudge (dec-1/2/3). Clicking one injects the static scaffold prompt via `sendMessage`; the buttons vanish once a conversation starts.
- **DocDocument** loses the *"Review actions"* disclosure + four-button row (and the dead `REVIEW_ACTIONS` / `sendReviewPrompt` / `reviewActionsOpen` + now-unused imports). The coding-agent **review-handoff** copy line **stays** on the page, ungated, in Specify for both postures — it interpolates page context the agent panel doesn't carry (dec-4).

## Tests
- New `spec-283` block in `ChatPanel.test.tsx` (ac-1/2/4/6/7/8); updated spec-159/182/252 tests in `DocDocument.spec-159.test.tsx` to the relocated reality (ac-3/9); `useOrgScaffoldBlocks` mock added to `ChatPanel.spec-111.test.tsx`.
- New Playwright **journey-31** exercising the relocated buttons end-to-end (std-28; ac-5).
- **All 9 spec-283 ACs verified.** Full `@memex/ui` unit suite green (1285 passed, 1 skipped); `tsc -b` clean.

## Notes
- e2e verified via `journey-31` against the dev DB on isolated ports; `make e2e-cold` (cold-DB CI parity) was **not** run locally — relying on the per-PR CI gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)