### PR TITLE
spec-285: author + last-changed metadata on every search hit (agents + ⌘K palette)

### DIFF
--- a/packages/server/src/routes/search.integration.test.ts
+++ b/packages/server/src/routes/search.integration.test.ts
@@ -53,6 +53,9 @@ interface ContentHit {
   matchingSections: Array<{ id: string; sectionType: string }>;
   id?: unknown;
   parentDocId?: unknown;
+  // spec-285: WHO/WHEN ride through the Omit projection into the wire shape.
+  authorName?: string | null;
+  lastUpdatedAt?: string | null;
 }
 
 interface SearchEnvelope {
@@ -402,5 +405,48 @@ describe("spec-191 — number jump is additive to jumpTo; content tier unchanged
       h.path.endsWith(`/specs/${numSpec.handle}`),
     );
     expect(inContent).toBeUndefined();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// spec-285 ac-3: the WHO/WHEN metadata added to MemexSearchHit rides through
+// the REST route's `SearchContentHit = Omit<MemexSearchHit, "id"|"parentDocId">`
+// projection with NO route change — every content hit exposes `authorName` and
+// `lastUpdatedAt`, and a resolvable created_by surfaces a real name + ISO date.
+// ─────────────────────────────────────────────────────────────────────────
+const SPEC285_AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-285/acs/ac-${n}`;
+
+describe("spec-285 — REST search inherits author + timestamp (ac-3)", () => {
+  it("every content hit exposes authorName + lastUpdatedAt, populated from created_by", async () => {
+    tagAc(SPEC285_AC(3));
+    const devUser = await upsertUserByEmail("dev@memex.ai");
+    const expectedDisplay = devUser.name?.trim() || devUser.email;
+
+    // Stamp a resolvable author on the token-bearing docs so the resolution path
+    // (created_by_user_id → users.name ?? email) produces a concrete value.
+    await db
+      .update(documents)
+      .set({ createdByUserId: devUser.id })
+      .where(inArray(documents.id, createdDocIds));
+
+    const res = await req(searchUrl({ q: TOKEN }));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as SearchEnvelope & {
+      content: Array<ContentHit & { authorName?: unknown; lastUpdatedAt?: unknown }>;
+    };
+    expect(body.content.length).toBeGreaterThan(0);
+
+    for (const hit of body.content) {
+      // Inheritance through Omit: the new fields are present on the wire shape.
+      expect(hit).toHaveProperty("authorName");
+      expect(hit).toHaveProperty("lastUpdatedAt");
+    }
+
+    // At least one hit resolved the stamped author to a concrete display + ISO date.
+    const populated = body.content.find((h) => h.authorName === expectedDisplay);
+    expect(populated).toBeDefined();
+    expect(typeof populated!.lastUpdatedAt).toBe("string");
+    expect(() => new Date(populated!.lastUpdatedAt as string).toISOString()).not.toThrow();
   });
 });

--- a/packages/server/src/services/memex-search.integration.test.ts
+++ b/packages/server/src/services/memex-search.integration.test.ts
@@ -19,6 +19,7 @@ import { createDocDraft } from "./documents.js";
 import { addSection } from "./sections.js";
 import { createDecision, resolveDecision } from "./decisions.js";
 import { createIssue, type IssueType } from "./issues.js";
+import { upsertUserByEmail } from "./users.js";
 import {
   embedAndStoreDoc,
   embedAndStoreDecision,
@@ -605,6 +606,8 @@ describe("formatSearchResults — issue hit rendering (spec-112 t-4)", () => {
         status: "open",
         score: 0.27,
         strategies: ["fts"],
+        authorName: null,
+        lastUpdatedAt: null,
         matchingSections: [],
         issueSnippet: "Clicking the login button does nothing.",
         issueMatchedVia: "fts",
@@ -791,6 +794,8 @@ describe("formatSearchResults — b-34 D-4 spec", () => {
         status: "specify",
         score: 0.42,
         strategies: ["fts", "vector"],
+        authorName: null,
+        lastUpdatedAt: null,
         matchingSections: [
           {
             id: "00000000-0000-0000-0000-000000000010",
@@ -810,6 +815,8 @@ describe("formatSearchResults — b-34 D-4 spec", () => {
         status: "resolved",
         score: 0.31,
         strategies: ["fts"],
+        authorName: null,
+        lastUpdatedAt: null,
         matchingSections: [],
         decisionSnippet: "Resolved: do the thing.",
         decisionMatchedVia: "fts",
@@ -837,6 +844,8 @@ describe("formatSearchResults — b-34 D-4 spec", () => {
       status: "specify",
       score: 0.42,
       strategies: ["fts"],
+      authorName: null,
+      lastUpdatedAt: null,
       matchingSections: [],
     };
     expect(formatSearchResults("q", [hit])).not.toContain("score 0.420");
@@ -854,6 +863,8 @@ describe("formatSearchResults — b-34 D-4 spec", () => {
       status: "published",
       score: 0.1,
       strategies: ["fts"],
+      authorName: null,
+      lastUpdatedAt: null,
       matchingSections: [
         {
           id: "00000000-0000-0000-0000-000000000010",
@@ -980,6 +991,8 @@ describe("formatSearchResults — [current doc] tag (includeCurrentDoc opt-in)",
       status: "specify",
       score: 0.5,
       strategies: ["fts"],
+      authorName: null,
+      lastUpdatedAt: null,
       matchingSections: [
         {
           id: "00000000-0000-0000-0000-0000000000bb",
@@ -1009,6 +1022,8 @@ describe("formatSearchResults — [current doc] tag (includeCurrentDoc opt-in)",
       status: "resolved",
       score: 0.4,
       strategies: ["fts"],
+      authorName: null,
+      lastUpdatedAt: null,
       matchingSections: [],
       decisionSnippet: "Snippet.",
       decisionMatchedVia: "fts",
@@ -1029,6 +1044,8 @@ describe("formatSearchResults — [current doc] tag (includeCurrentDoc opt-in)",
       status: "specify",
       score: 0.3,
       strategies: ["fts"],
+      authorName: null,
+      lastUpdatedAt: null,
       matchingSections: [],
     };
 
@@ -1197,5 +1214,307 @@ describe("resolveJumpTo — number / short-handle jump (spec-191)", () => {
       (h) => h.id === specId && h.strategies.includes("handle"),
     );
     expect(handleHit).toBeUndefined();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// spec-285: author (WHO) + last-changed (WHEN) on every search hit.
+//   - dec-1: decision/section hits use the denormalised actor_name; document &
+//     issue hits resolve created_by_user_id → users.name ?? email.
+//   - dec-2: one timestamp per hit — last-modified where present, created_at
+//     fallback (decisions have no updated_at).
+//   - dec-3 / ac-8: formatSearchResults renders ` · <author>, <YYYY-MM-DD>` so
+//     the MCP tool AND the React agent (which reuse the same handler) see it.
+// ═══════════════════════════════════════════════════════════════════════════
+
+const SPEC285_AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-285/acs/ac-${n}`;
+
+const ISO_RE = /^\d{4}-\d{2}-\d{2}T/;
+
+describe("formatSearchResults — WHO/WHEN byline (spec-285 ac-8)", () => {
+  const base: MemexSearchHit = {
+    id: "00000000-0000-0000-0000-000000000001",
+    parentDocId: "00000000-0000-0000-0000-000000000001",
+    kind: "spec",
+    path: "ns/mx/specs/spec-7",
+    title: "A spec",
+    status: "build",
+    score: 0.5,
+    strategies: ["fts"],
+    matchingSections: [],
+    authorName: null,
+    lastUpdatedAt: null,
+  };
+
+  it("renders ` · <author>, <YYYY-MM-DD>` when both are present", () => {
+    tagAc(SPEC285_AC(8));
+    const out = formatSearchResults("q", [
+      { ...base, authorName: "Ada Lovelace", lastUpdatedAt: "2026-05-28T09:30:00.000Z" },
+    ]);
+    expect(out).toContain(`(spec, build) · Ada Lovelace, 2026-05-28`);
+    // No UUIDs in the rendered output (b-36 D-7 still holds).
+    const uuidRegex = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i;
+    expect(out).not.toMatch(uuidRegex);
+  });
+
+  it("renders author alone when there is no timestamp", () => {
+    tagAc(SPEC285_AC(8));
+    const out = formatSearchResults("q", [{ ...base, authorName: "Grace Hopper" }]);
+    expect(out).toContain(`(spec, build) · Grace Hopper`);
+    expect(out).not.toContain("Grace Hopper,"); // no trailing comma/date
+  });
+
+  it("renders the date alone when there is no author", () => {
+    tagAc(SPEC285_AC(8));
+    const out = formatSearchResults("q", [
+      { ...base, lastUpdatedAt: "2026-01-02T00:00:00.000Z" },
+    ]);
+    expect(out).toContain(`(spec, build) · 2026-01-02`);
+  });
+
+  it("emits NO byline when neither author nor timestamp is set", () => {
+    tagAc(SPEC285_AC(8));
+    const out = formatSearchResults("q", [base]);
+    const headingLine = out.split("\n").find((l) => l.startsWith("### "));
+    expect(headingLine).toBeDefined();
+    expect(headingLine).not.toContain(" · ");
+    expect(headingLine).toContain(`(spec, build)`);
+  });
+});
+
+describe("searchMemex — author + timestamp population (spec-285 ac-6/ac-7)", () => {
+  it("decision hits carry the denormalised actor_name + created_at (dec-1/dec-2)", async () => {
+    tagAc(SPEC285_AC(6));
+    tagAc(SPEC285_AC(7));
+    const provider = makeFakeProvider("fake-author-decision");
+    const spec = await seedSpec(memexId, "Author decision host", "Body.", [], provider);
+    const dec = await seedDecision(
+      memexId,
+      spec,
+      "authordecisionuniquetokenx approach",
+      "Context.",
+      "Resolved.",
+      provider,
+    );
+    // Stamp a denormalised WHO the way the write path would (std-32).
+    await db.execute(
+      sql`UPDATE decisions SET actor_name = 'Ada Lovelace', actor_user_id = NULL WHERE id = ${dec.id}`,
+    );
+
+    const hits = await searchMemex(memexId, "authordecisionuniquetokenx", {
+      provider,
+      kind: "decision",
+      disableVector: true,
+    });
+    const hit = hits.find((h) => h.id === dec.id);
+    expect(hit).toBeDefined();
+    expect(hit!.authorName).toBe("Ada Lovelace");
+    // WHEN is the decision's created_at (no updated_at column), as an ISO string.
+    expect(hit!.lastUpdatedAt).toMatch(ISO_RE);
+  });
+
+  it("section/doc hits prefer the section's denormalised actor_name (dec-1)", async () => {
+    tagAc(SPEC285_AC(6));
+    const provider = makeFakeProvider("fake-author-section");
+    const spec = await seedSpec(
+      memexId,
+      "Author section host",
+      "authorsectionuniquetokenx content here.",
+      [],
+      provider,
+    );
+    await db.execute(
+      sql`UPDATE doc_sections SET actor_name = 'Grace Hopper' WHERE doc_id = ${spec.id}`,
+    );
+
+    const hits = await searchMemex(memexId, "authorsectionuniquetokenx", {
+      provider,
+      disableVector: true,
+    });
+    const hit = hits.find((h) => h.id === spec.id);
+    expect(hit).toBeDefined();
+    expect(hit!.authorName).toBe("Grace Hopper");
+    expect(hit!.lastUpdatedAt).toMatch(ISO_RE);
+  });
+
+  it("doc hits with no section actor_name resolve created_by_user_id → name (dec-1)", async () => {
+    tagAc(SPEC285_AC(6));
+    const provider = makeFakeProvider("fake-author-docfallback");
+    const author = await upsertUserByEmail("ada.author@example.com");
+    const spec = await seedSpec(
+      memexId,
+      "Author doc-fallback host",
+      "authordocfallbackuniquetokenx content here.",
+      [],
+      provider,
+    );
+    // No section actor_name → fall back to the resolved document creator.
+    await db.execute(
+      sql`UPDATE doc_sections SET actor_name = NULL WHERE doc_id = ${spec.id}`,
+    );
+    await db.execute(
+      sql`UPDATE documents SET created_by_user_id = ${author.id} WHERE id = ${spec.id}`,
+    );
+
+    const hits = await searchMemex(memexId, "authordocfallbackuniquetokenx", {
+      provider,
+      disableVector: true,
+    });
+    const hit = hits.find((h) => h.id === spec.id);
+    expect(hit).toBeDefined();
+    // upsertUserByEmail sets no display name, so the resolver falls to email.
+    expect(hit!.authorName).toBe("ada.author@example.com");
+  });
+
+  it("issue hits resolve created_by_user_id → name + carry updated_at (dec-1/dec-2)", async () => {
+    tagAc(SPEC285_AC(6));
+    tagAc(SPEC285_AC(7));
+    const provider = makeFakeProvider("fake-author-issue");
+    const author = await upsertUserByEmail("grace.issue@example.com");
+    const spec = await seedSpec(memexId, "Author issue host", "Body.", [], provider);
+    const issue = await seedIssue(
+      memexId,
+      spec,
+      "authorissueuniquetokenx regression",
+      "An issue with a resolvable author.",
+      "bug",
+      provider,
+    );
+    await db.execute(
+      sql`UPDATE issues SET created_by_user_id = ${author.id} WHERE id = ${issue.id}`,
+    );
+
+    const hits = await searchMemex(memexId, "authorissueuniquetokenx", {
+      provider,
+      kind: "issue",
+      disableVector: true,
+    });
+    const hit = hits.find((h) => h.id === issue.id);
+    expect(hit).toBeDefined();
+    expect(hit!.authorName).toBe("grace.issue@example.com");
+    expect(hit!.lastUpdatedAt).toMatch(ISO_RE);
+  });
+});
+
+describe("searchMemex → formatSearchResults — end-to-end byline (spec-285 ac-1/ac-2)", () => {
+  it("a real decision search renders WHO/WHEN in the markdown the MCP + React agents read", async () => {
+    tagAc(SPEC285_AC(1));
+    tagAc(SPEC285_AC(2));
+    const provider = makeFakeProvider("fake-author-e2e");
+    const spec = await seedSpec(memexId, "E2E byline host", "Body.", [], provider);
+    const dec = await seedDecision(
+      memexId,
+      spec,
+      "authore2euniquetokenx approach",
+      "Context.",
+      "Resolved.",
+      provider,
+    );
+    await db.execute(
+      sql`UPDATE decisions SET actor_name = 'Ada Lovelace', actor_user_id = NULL WHERE id = ${dec.id}`,
+    );
+
+    // The exact path the MCP search_memex handler runs — and the React UI agent
+    // reuses this same handler via executeToolRemote (spec-285 Architecture
+    // finding 1), so a passing render here proves both agent surfaces (ac-2).
+    const hits = await searchMemex(memexId, "authore2euniquetokenx", {
+      provider,
+      kind: "decision",
+      disableVector: true,
+    });
+    const out = formatSearchResults("authore2euniquetokenx", hits);
+    expect(out).toContain("Ada Lovelace");
+    expect(out).toMatch(/· Ada Lovelace, \d{4}-\d{2}-\d{2}/);
+  });
+});
+
+describe("spec-285 — additive, non-breaking, single-source (ac-4)", () => {
+  it("a hit with no author/timestamp renders the exact legacy heading (no stray byline)", () => {
+    tagAc(SPEC285_AC(4));
+    // An existing consumer's hit (pre-285 shape, nulls for the new fields) must
+    // render byte-identically to before — additive change, no regression.
+    const legacy: MemexSearchHit = {
+      id: "00000000-0000-0000-0000-000000000001",
+      parentDocId: "00000000-0000-0000-0000-000000000001",
+      kind: "standard",
+      path: "ns/mx/standards/std-3",
+      title: "A standard",
+      status: "published",
+      score: 0.2,
+      strategies: ["fts"],
+      matchingSections: [
+        {
+          id: "00000000-0000-0000-0000-000000000010",
+          sectionType: "do",
+          title: "Do",
+          content: "Some rule.",
+          matchedVia: "fts",
+        },
+      ],
+      authorName: null,
+      lastUpdatedAt: null,
+    };
+    const out = formatSearchResults("q", [legacy]);
+    // Heading is the legacy format exactly — no ` · ` byline appended.
+    expect(out).toContain(`### ns/mx/standards/std-3 — "A standard" (standard, published)`);
+    const headingLine = out.split("\n").find((l) => l.startsWith("### "))!;
+    expect(headingLine.endsWith("(standard, published)")).toBe(true);
+    // Section rendering is untouched.
+    expect(out).toContain(`- Section "Do" (fts):`);
+    expect(out).toContain(`  > Some rule.`);
+  });
+
+  it("the new fields are part of MemexSearchHit (single source) so REST inherits them", () => {
+    tagAc(SPEC285_AC(4));
+    // Both new fields live on MemexSearchHit itself — the REST route's
+    // SearchContentHit = Omit<MemexSearchHit,"id"|"parentDocId"> therefore
+    // inherits them with no separate type to keep in sync (single source).
+    const hit: MemexSearchHit = {
+      id: "00000000-0000-0000-0000-000000000001",
+      parentDocId: "00000000-0000-0000-0000-000000000001",
+      kind: "spec",
+      path: "ns/mx/specs/spec-1",
+      title: "T",
+      status: "build",
+      score: 0.1,
+      strategies: ["fts"],
+      matchingSections: [],
+      authorName: "Ada Lovelace",
+      lastUpdatedAt: "2026-05-28T00:00:00.000Z",
+    };
+    // Structurally present on the hit shape that the REST projection spreads.
+    expect(Object.prototype.hasOwnProperty.call(hit, "authorName")).toBe(true);
+    expect(Object.prototype.hasOwnProperty.call(hit, "lastUpdatedAt")).toBe(true);
+  });
+});
+
+describe("spec-285 — legible in both surfaces: markdown AND structured (ac-5)", () => {
+  it("renders a human byline in markdown while keeping discrete structured fields", () => {
+    tagAc(SPEC285_AC(5));
+    const hit: MemexSearchHit = {
+      id: "00000000-0000-0000-0000-000000000001",
+      parentDocId: "00000000-0000-0000-0000-000000000001",
+      kind: "decision",
+      path: "ns/mx/specs/spec-1/decisions/dec-2",
+      title: "A decision",
+      status: "resolved",
+      score: 0.3,
+      strategies: ["fts"],
+      matchingSections: [],
+      decisionSnippet: "Resolved: do the thing.",
+      decisionMatchedVia: "fts",
+      authorName: "Ryan Soosayraj",
+      lastUpdatedAt: "2026-05-28T12:00:00.000Z",
+    };
+
+    // Surface 1 — the MCP/React-agent markdown: human-readable "name, date".
+    const md = formatSearchResults("q", [hit]);
+    expect(md).toMatch(/· Ryan Soosayraj, 2026-05-28/);
+
+    // Surface 2 — the structured field the React agent / REST consume: discrete,
+    // not buried in prose. An agent can cite "<name>, <date>" without parsing.
+    expect(hit.authorName).toBe("Ryan Soosayraj");
+    expect(hit.lastUpdatedAt!.slice(0, 10)).toBe("2026-05-28");
   });
 });

--- a/packages/server/src/services/memex-search.ts
+++ b/packages/server/src/services/memex-search.ts
@@ -186,6 +186,19 @@ export interface MemexSearchHit {
    *  used to detect self-hits when the caller passes `currentDocId` to the
    *  formatter. */
   parentDocId: string;
+  /** WHO — best-effort display name of who authored / last touched this hit
+   *  (spec-285 dec-1). For decision/section hits this is the denormalised
+   *  std-32 `actor_name` where present (rename-proof); for document and issue
+   *  hits, the `created_by_user_id` resolved to `users.name ?? users.email`.
+   *  null when nothing resolved (a system write, a deleted user, a legacy
+   *  unattributed row). Navigation-only lanes (jump / assigned) leave it null. */
+  authorName: string | null;
+  /** WHEN — ISO-8601 timestamp of when this hit was last changed (spec-285
+   *  dec-2): the row's last-modified where it has one (`doc_sections`/`issues`
+   *  `updated_at`), falling back to `created_at` where it does not (decisions
+   *  carry no `updated_at`). null only when no timestamp was selected
+   *  (navigation-only lanes). */
+  lastUpdatedAt: string | null;
 }
 
 export interface SearchMemexOptions {
@@ -225,6 +238,11 @@ interface SectionRow {
   doc_title: string;
   doc_status: string;
   doc_type: string;
+  // spec-285: WHO/WHEN. `author_name` is computed in SQL — the section's
+  // denormalised actor_name (std-32) preferred, else the parent doc's resolved
+  // creator. `updated_at` is the section's own last-modified.
+  author_name: string | null;
+  updated_at: string | Date;
   rank?: number; // FTS ts_rank
   distance?: number; // vector cosine distance
 }
@@ -240,6 +258,11 @@ interface DecisionRow {
   dec_context: string | null;
   dec_resolution: string | null;
   dec_status: string;
+  // spec-285: WHO/WHEN. `author_name` = decision's denormalised actor_name
+  // (std-32) preferred, else the actor_user_id resolved to a user. `created_at`
+  // is the only timestamp decisions carry (no updated_at — dec-2 fallback).
+  author_name: string | null;
+  created_at: string | Date;
   rank?: number;
   distance?: number;
 }
@@ -255,6 +278,11 @@ interface IssueRow {
   issue_body: string | null;
   issue_type: string;
   issue_status: string;
+  // spec-285: WHO/WHEN. Issues carry no actor_name (std-32 hasn't reached the
+  // issues table) — `author_name` is the created_by_user_id resolved to a user.
+  // `updated_at` is the issue's own last-modified.
+  author_name: string | null;
+  updated_at: string | Date;
   rank?: number;
   distance?: number;
 }
@@ -324,6 +352,15 @@ function inScopeDocTypes(kind: MemexSearchKind | undefined): string[] | null {
   // section query short-circuits to nothing.
   if (kind === "decision" || kind === "issue") return null;
   return DOC_TYPES_BY_KIND[kind];
+}
+
+// spec-285: normalise a timestamptz coming back from the driver (Date or ISO
+// string depending on the column path) to a stable ISO-8601 string for the hit
+// shape. null/invalid → null so the formatter and REST JSON degrade gracefully.
+function toIso(value: string | Date | null | undefined): string | null {
+  if (value == null) return null;
+  const d = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(d.getTime()) ? null : d.toISOString();
 }
 
 // ── Public entry point ─────────────────────────────────
@@ -459,23 +496,51 @@ async function lookupByHandle(
       s.section_type  AS section_type,
       s.title         AS section_title,
       s.content       AS section_content,
+      s.actor_name    AS section_actor_name,
+      s.updated_at    AS section_updated_at,
       s.doc_id        AS doc_id,
       d.handle        AS doc_handle,
       d.title         AS doc_title,
       d.status        AS doc_status,
-      d.doc_type      AS doc_type
+      d.doc_type      AS doc_type,
+      d.created_at        AS doc_created_at,
+      d.status_changed_at AS doc_status_changed_at,
+      du.name         AS doc_author_name,
+      du.email        AS doc_author_email
     FROM documents d
     LEFT JOIN doc_sections s ON s.doc_id = d.id
+    LEFT JOIN users du ON du.id = d.created_by_user_id
     WHERE d.memex_id = ${memexId}
       ${archivedClause}
       AND d.is_demo IS NOT TRUE
       AND d.handle = ${query.toLowerCase()}
     ORDER BY s.seq
-  `)) as unknown as SectionRow[];
+  `)) as unknown as HandleRow[];
 
   if (rows.length === 0) return null;
 
   const first = rows[0];
+
+  // WHO/WHEN for a handle hit (spec-285): the heading is the DOCUMENT, so
+  // attribute it from the most-recently-updated section (denormalised
+  // actor_name, std-32), falling back to the doc's resolved creator. WHEN is the
+  // latest section's updated_at, else the doc's own status_changed_at/created_at.
+  const sections = rows.filter((r) => r.section_id != null);
+  let latest: HandleRow | null = null;
+  for (const r of sections) {
+    if (!latest || toMillis(r.section_updated_at) > toMillis(latest.section_updated_at)) {
+      latest = r;
+    }
+  }
+  const docAuthorFallback =
+    first.doc_author_name?.trim() || first.doc_author_email?.trim() || null;
+  const sectionActor = latest?.section_actor_name?.trim() || null;
+  const authorName = sectionActor ?? docAuthorFallback;
+  const lastUpdatedAt =
+    toIso(latest?.section_updated_at) ??
+    toIso(first.doc_status_changed_at) ??
+    toIso(first.doc_created_at);
+
   return {
     id: first.doc_id,
     parentDocId: first.doc_id,
@@ -485,16 +550,44 @@ async function lookupByHandle(
     status: first.doc_status,
     score: 1,
     strategies: ["handle"],
-    matchingSections: rows
-      .filter((r) => r.section_id != null)
-      .map((r) => ({
-        id: r.section_id,
-        sectionType: r.section_type,
-        title: r.section_title,
-        content: r.section_content,
-        matchedVia: "handle",
-      })),
+    authorName,
+    lastUpdatedAt,
+    matchingSections: sections.map((r) => ({
+      id: r.section_id,
+      sectionType: r.section_type,
+      title: r.section_title,
+      content: r.section_content,
+      matchedVia: "handle",
+    })),
   };
+}
+
+// Row shape for lookupByHandle's documents⨝sections⨝users projection (spec-285).
+interface HandleRow {
+  section_id: string;
+  section_type: string;
+  section_title: string | null;
+  section_content: string;
+  section_actor_name: string | null;
+  section_updated_at: string | Date | null;
+  doc_id: string;
+  doc_handle: string;
+  doc_title: string;
+  doc_status: string;
+  doc_type: string;
+  doc_created_at: string | Date | null;
+  doc_status_changed_at: string | Date | null;
+  doc_author_name: string | null;
+  doc_author_email: string | null;
+}
+
+// spec-285: epoch millis for comparing two timestamptz values; missing/invalid
+// sorts oldest so a real timestamp always wins the "latest section" pick.
+function toMillis(value: string | Date | null | undefined): number {
+  if (value == null) return -Infinity;
+  const d = value instanceof Date ? value : new Date(value);
+  const t = d.getTime();
+  return Number.isNaN(t) ? -Infinity : t;
 }
 
 // ── Jump-to lane (spec-64 t-2) ─────────────────────────
@@ -636,6 +729,10 @@ export async function resolveJumpTo(
       // so it ranks below the handle hit but is still a deliberate jump target.
       score: 0.5,
       strategies: ["handle"],
+      // Navigation-only lane (⌘K jump tier) — WHO/WHEN isn't rendered here
+      // (spec-285 dec-3 defers palette metadata), so leave them null.
+      authorName: null,
+      lastUpdatedAt: null,
       matchingSections: [],
     });
   }
@@ -695,6 +792,9 @@ export async function resolveAssignedSpecs(
         // tier, so we reuse it rather than widening the SearchStrategy union for
         // a lane the formatter never renders.
         strategies: ["handle"],
+        // Navigation-only lane — WHO/WHEN unrendered here (spec-285 dec-3).
+        authorName: null,
+        lastUpdatedAt: null,
         matchingSections: [],
       });
     }
@@ -724,6 +824,8 @@ async function runSectionFts(
       s.title         AS section_title,
       s.content       AS section_content,
       s.doc_id        AS doc_id,
+      s.updated_at    AS updated_at,
+      COALESCE(NULLIF(TRIM(s.actor_name), ''), NULLIF(TRIM(du.name), ''), du.email) AS author_name,
       d.handle        AS doc_handle,
       d.title         AS doc_title,
       d.status        AS doc_status,
@@ -731,6 +833,7 @@ async function runSectionFts(
       ts_rank(s.content_tsv, plainto_tsquery('english', ${query})) AS rank
     FROM doc_sections s
     INNER JOIN documents d ON d.id = s.doc_id
+    LEFT JOIN users du ON du.id = d.created_by_user_id
     WHERE d.memex_id = ${memexId}
       AND d.doc_type IN ${sql.raw(`(${docTypes.map((t) => `'${t}'`).join(",")})`)}
       ${archivedClause}
@@ -778,6 +881,8 @@ async function runSectionVector(
       s.title         AS section_title,
       s.content       AS section_content,
       s.doc_id        AS doc_id,
+      s.updated_at    AS updated_at,
+      COALESCE(NULLIF(TRIM(s.actor_name), ''), NULLIF(TRIM(du.name), ''), du.email) AS author_name,
       d.handle        AS doc_handle,
       d.title         AS doc_title,
       d.status        AS doc_status,
@@ -785,6 +890,7 @@ async function runSectionVector(
       (s.embedding <=> ${literal}::vector) AS distance
     FROM doc_sections s
     INNER JOIN documents d ON d.id = s.doc_id
+    LEFT JOIN users du ON du.id = d.created_by_user_id
     WHERE d.memex_id = ${memexId}
       AND d.doc_type IN ${sql.raw(`(${docTypes.map((t) => `'${t}'`).join(",")})`)}
       ${archivedClause}
@@ -826,6 +932,8 @@ async function runDecisionFts(
       dec.context     AS dec_context,
       dec.resolution  AS dec_resolution,
       dec.status      AS dec_status,
+      dec.created_at  AS created_at,
+      COALESCE(NULLIF(TRIM(dec.actor_name), ''), NULLIF(TRIM(au.name), ''), au.email) AS author_name,
       d.handle        AS doc_handle,
       d.title         AS doc_title,
       d.doc_type      AS doc_type,
@@ -838,6 +946,7 @@ async function runDecisionFts(
       ) AS rank
     FROM decisions dec
     INNER JOIN documents d ON d.id = dec.doc_id
+    LEFT JOIN users au ON au.id = dec.actor_user_id
     WHERE dec.memex_id = ${memexId}
       ${archivedClause}
       AND d.is_demo IS NOT TRUE
@@ -888,12 +997,15 @@ async function runDecisionVector(
       dec.context     AS dec_context,
       dec.resolution  AS dec_resolution,
       dec.status      AS dec_status,
+      dec.created_at  AS created_at,
+      COALESCE(NULLIF(TRIM(dec.actor_name), ''), NULLIF(TRIM(au.name), ''), au.email) AS author_name,
       d.handle        AS doc_handle,
       d.title         AS doc_title,
       d.doc_type      AS doc_type,
       (dec.embedding <=> ${literal}::vector) AS distance
     FROM decisions dec
     INNER JOIN documents d ON d.id = dec.doc_id
+    LEFT JOIN users au ON au.id = dec.actor_user_id
     WHERE dec.memex_id = ${memexId}
       ${archivedClause}
       AND d.is_demo IS NOT TRUE
@@ -936,6 +1048,8 @@ async function runIssueFts(
       iss.body        AS issue_body,
       iss.type        AS issue_type,
       iss.status      AS issue_status,
+      iss.updated_at  AS updated_at,
+      COALESCE(NULLIF(TRIM(au.name), ''), au.email) AS author_name,
       d.handle        AS doc_handle,
       d.title         AS doc_title,
       d.doc_type      AS doc_type,
@@ -947,6 +1061,7 @@ async function runIssueFts(
       ) AS rank
     FROM issues iss
     INNER JOIN documents d ON d.id = iss.doc_id
+    LEFT JOIN users au ON au.id = iss.created_by_user_id
     WHERE iss.memex_id = ${memexId}
       ${archivedClause}
       AND d.is_demo IS NOT TRUE
@@ -996,12 +1111,15 @@ async function runIssueVector(
       iss.body        AS issue_body,
       iss.type        AS issue_type,
       iss.status      AS issue_status,
+      iss.updated_at  AS updated_at,
+      COALESCE(NULLIF(TRIM(au.name), ''), au.email) AS author_name,
       d.handle        AS doc_handle,
       d.title         AS doc_title,
       d.doc_type      AS doc_type,
       (iss.embedding <=> ${literal}::vector) AS distance
     FROM issues iss
     INNER JOIN documents d ON d.id = iss.doc_id
+    LEFT JOIN users au ON au.id = iss.created_by_user_id
     WHERE iss.memex_id = ${memexId}
       ${archivedClause}
       AND d.is_demo IS NOT TRUE
@@ -1032,6 +1150,14 @@ interface AccumulatorEntry {
   issueSnippet?: string;
   issueMatchedVia?: SearchStrategy;
   issueType?: string;
+  // spec-285 WHO/WHEN. For a doc hit these track the most-recently-updated
+  // matched section (so `authorAt` is the latest-section comparison key); for
+  // decision/issue hits they're set once from the atomic row.
+  authorName: string | null;
+  lastUpdatedAt: string | null;
+  /** Epoch millis of `lastUpdatedAt`, kept only to pick the latest matched
+   *  section across the FTS + vector arms. Not emitted. */
+  authorAtMillis: number;
 }
 
 function pickDecisionSnippet(r: DecisionRow): string {
@@ -1082,11 +1208,25 @@ function mergeWithRrf(
           score: 0,
           strategies: new Set<SearchStrategy>(),
           sectionsByVia: new Map(),
+          authorName: null,
+          lastUpdatedAt: null,
+          authorAtMillis: -Infinity,
         };
         acc.set(`doc:${r.doc_id}`, entry);
       }
       entry.score += rrfContribution;
       entry.strategies.add(via);
+
+      // WHO/WHEN (spec-285): a doc hit groups many matched sections (and arrives
+      // across the FTS + vector arms in rank order, not time order). Attribute
+      // the doc to its MOST-RECENTLY-UPDATED matched section, so authorName +
+      // lastUpdatedAt answer "who last changed this and when".
+      const rowMillis = toMillis(r.updated_at);
+      if (rowMillis > entry.authorAtMillis) {
+        entry.authorAtMillis = rowMillis;
+        entry.authorName = r.author_name?.trim() || null;
+        entry.lastUpdatedAt = toIso(r.updated_at);
+      }
 
       // Keep the FIRST `via` that surfaced each section so a section seen by
       // both FTS and vector reports the higher-confidence search method.
@@ -1120,6 +1260,12 @@ function mergeWithRrf(
           sectionsByVia: new Map(),
           decisionSnippet: pickDecisionSnippet(r),
           decisionMatchedVia: via,
+          // WHO/WHEN (spec-285): a decision is atomic, so set once. authorName =
+          // denormalised actor_name (or resolved actor), lastUpdatedAt =
+          // created_at (decisions carry no updated_at — dec-2 fallback).
+          authorName: r.author_name?.trim() || null,
+          lastUpdatedAt: toIso(r.created_at),
+          authorAtMillis: toMillis(r.created_at),
         };
         acc.set(`dec:${r.decision_id}`, entry);
       } else {
@@ -1150,6 +1296,11 @@ function mergeWithRrf(
           issueSnippet: pickIssueSnippet(r),
           issueMatchedVia: via,
           issueType: r.issue_type,
+          // WHO/WHEN (spec-285): atomic, set once. Issues have no actor_name, so
+          // authorName is the resolved created_by user; lastUpdatedAt = updated_at.
+          authorName: r.author_name?.trim() || null,
+          lastUpdatedAt: toIso(r.updated_at),
+          authorAtMillis: toMillis(r.updated_at),
         };
         acc.set(`iss:${r.issue_id}`, entry);
       } else {
@@ -1183,6 +1334,8 @@ function mergeWithRrf(
     issueSnippet: e.issueSnippet,
     issueMatchedVia: e.issueMatchedVia,
     issueType: e.issueType,
+    authorName: e.authorName,
+    lastUpdatedAt: e.lastUpdatedAt,
   }));
 
   results.sort((a, b) => b.score - a.score);
@@ -1225,6 +1378,20 @@ export interface FormatOptions {
   currentDocId?: string;
 }
 
+// spec-285: the WHO/WHEN byline appended to a hit's heading, e.g.
+// ` · Ryan Soosayraj, 2026-05-28`. Legible to a human and parseable by an agent
+// (` · <author>, <YYYY-MM-DD>`). Degrades gracefully: author-only, date-only, or
+// nothing at all when neither resolved. The date is the calendar day of the ISO
+// timestamp — enough for "when it last changed" without clock noise.
+function formatHitByline(hit: MemexSearchHit): string {
+  const author = hit.authorName?.trim() || null;
+  const date = hit.lastUpdatedAt ? hit.lastUpdatedAt.slice(0, 10) : null;
+  if (author && date) return ` · ${author}, ${date}`;
+  if (author) return ` · ${author}`;
+  if (date) return ` · ${date}`;
+  return "";
+}
+
 function isHitOnCurrentDoc(hit: MemexSearchHit, currentDocId: string): boolean {
   // parentDocId is the doc UUID for section/doc hits and the parent Spec's
   // UUID for decision hits. Matching here means the hit belongs to the
@@ -1254,7 +1421,11 @@ export function formatSearchResults(
     // so a reader can tell a bug from a todo at a glance (spec-112 t-4).
     const kindLabel =
       hit.kind === "issue" && hit.issueType ? `issue/${hit.issueType}` : hit.kind;
-    lines.push(`### ${hit.path} — "${hit.title}" (${kindLabel}, ${hit.status})${selfTag}${scoreSuffix}`);
+    // spec-285: WHO/WHEN byline sits after the (kind, status) segment and before
+    // the [current doc] / verbose-score suffixes, so an agent reading the result
+    // can attribute the hit ("who, when") without opening it.
+    const byline = formatHitByline(hit);
+    lines.push(`### ${hit.path} — "${hit.title}" (${kindLabel}, ${hit.status})${byline}${selfTag}${scoreSuffix}`);
     if (hit.kind === "decision") {
       const via = hit.decisionMatchedVia ?? "fts";
       const snippet = hit.decisionSnippet ?? "";

--- a/packages/ui/e2e/journey-18-global-search.spec.ts
+++ b/packages/ui/e2e/journey-18-global-search.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect, bareUrl } from "./helpers/index.js";
 import {
   getPersonalMemexByEmail,
+  ensureUser,
   setUserName,
   seedSpecInMemex,
   deleteDoc,
@@ -53,6 +54,9 @@ test.describe("Journey 18 — global ⌘K search palette", () => {
     // Give it a name so we land on the Specs board. (The shared account-based
     // fixture that normally does this writes to the dropped pre-0038 schema.)
     await setUserName("dev@memex.ai", "Dev User");
+    // spec-285: stamp the seeded Spec's author so the content row's WHO/WHEN
+    // byline resolves deterministically to "Dev User" (the name set just above).
+    const devUserId = await ensureUser("dev@memex.ai");
     // The seed service mints the handle (`spec-N`) via createDocDraft and returns
     // it — we navigate/assert against the SERVER-chosen handle rather than a
     // self-picked one (the new HTTP seed surface owns handle allocation, dec-2).
@@ -60,6 +64,7 @@ test.describe("Journey 18 — global ⌘K search palette", () => {
       memexId: memex.memexId,
       title: SPEC_TITLE,
       purpose: "Zephyr Quokka Search Beacon — purpose body for the global search journey.",
+      createdByUserId: devUserId,
     }));
   });
 
@@ -135,6 +140,18 @@ test.describe("Journey 18 — global ⌘K search palette", () => {
     // The hit's canonical path is built server-side from the memex slugs.
     const expectedPath = `/${nsSlug}/${mxSlug}/specs/${specHandle}`;
     await expect(specRow).toHaveAttribute("data-path", `${nsSlug}/${mxSlug}/specs/${specHandle}`);
+
+    // ── spec-285: the content-tier row carries a WHO/WHEN byline ─────────────
+    // The same Spec surfaces in the content tier (FTS on its title/body); that
+    // row renders "<author> · <YYYY-MM-DD>" from the author/timestamp the REST
+    // route now returns. We stamped created_by = Dev User in beforeEach, so the
+    // byline resolves to that name. (jumpTo rows carry no byline — content only.)
+    const byline = dialog
+      .locator('[data-testid="search-byline"]')
+      .filter({ hasText: "Dev User" })
+      .first();
+    await expect(byline).toBeVisible({ timeout: 10_000 });
+    await expect(byline).toContainText(/Dev User · \d{4}-\d{2}-\d{2}/);
 
     // ── ac-10: ArrowDown moves the roving selection, Enter navigates ─────────
     // cmdk auto-selects the first option; ArrowDown proves the roving selection

--- a/packages/ui/src/api/client.ts
+++ b/packages/ui/src/api/client.ts
@@ -125,6 +125,11 @@ export interface SearchHit {
   matchingSections: SearchMatchingSection[];
   decisionSnippet?: string;
   decisionMatchedVia?: SearchStrategy;
+  /** WHO — best-effort display name of who authored / last touched this hit
+   *  (spec-285). null/absent on navigation-only lanes (jumpTo/assigned). */
+  authorName?: string | null;
+  /** WHEN — ISO-8601 timestamp of when this hit was last changed (spec-285). */
+  lastUpdatedAt?: string | null;
 }
 
 /** The `{ jumpTo, assigned, content }` envelope (spec-64 t-1 ac-6). */

--- a/packages/ui/src/components/SearchPalette.test.tsx
+++ b/packages/ui/src/components/SearchPalette.test.tsx
@@ -35,6 +35,7 @@ vi.mock('react-router-dom', async () => {
 });
 
 const SPEC_64 = 'mindset-prod/memex-building-itself/specs/spec-64';
+const SPEC_285 = 'mindset-prod/memex-building-itself/specs/spec-285';
 
 function hit(over: Partial<SearchHit> = {}): SearchHit {
   return {
@@ -253,6 +254,83 @@ describe('SearchPalette', () => {
     expect((snippet as HTMLElement).querySelector('strong')).toBeNull();
     expect((snippet as HTMLElement).querySelector('a')).toBeNull();
     expect((snippet as HTMLElement).querySelector('img')).toBeNull();
+  });
+
+  it('content rows render a WHO/WHEN byline; navigation rows and metadata-less rows render none [spec-285]', async () => {
+    tagAc(`${SPEC_285}/acs/ac-9`);
+    const user = userEvent.setup();
+    renderOpen(
+      envelope({
+        jumpTo: [
+          hit({
+            kind: 'spec',
+            path: 'mindset-prod/memex-building-itself/specs/spec-64',
+            title: 'Jump spec',
+            status: 'build',
+            // A navigation hit may carry no metadata — and even if it did, the
+            // byline is content-lane only.
+            authorName: null,
+            lastUpdatedAt: null,
+          }),
+        ],
+        content: [
+          hit({
+            kind: 'spec',
+            path: 'mindset-prod/memex-building-itself/specs/spec-99',
+            title: 'Authored spec',
+            status: 'draft',
+            authorName: 'Ada Lovelace',
+            lastUpdatedAt: '2026-05-28T09:30:00.000Z',
+            matchingSections: [
+              {
+                id: 's1',
+                sectionType: 'purpose',
+                title: 'Purpose',
+                content: 'Body match.',
+                matchedVia: 'fts',
+              },
+            ],
+          }),
+          hit({
+            kind: 'standard',
+            path: 'mindset-prod/memex-building-itself/standards/std-7',
+            title: 'Metadata-less std',
+            status: 'active',
+            // No author/timestamp resolved → no byline.
+            matchingSections: [
+              {
+                id: 's2',
+                sectionType: 'rule',
+                title: 'Rule',
+                content: 'A rule.',
+                matchedVia: 'fts',
+              },
+            ],
+          }),
+        ],
+      }),
+    );
+
+    await user.type(screen.getByRole('combobox'), 'omni');
+    await screen.findByText('Authored spec');
+
+    // The content row shows "<author> · <YYYY-MM-DD>" — human-readable, derived
+    // from the structured authorName + lastUpdatedAt the REST route now carries.
+    const authoredRow = screen.getByText('Authored spec').closest('[cmdk-item]')!;
+    const byline = within(authoredRow as HTMLElement).getByTestId('search-byline');
+    expect(byline.textContent).toBe('Ada Lovelace · 2026-05-28');
+
+    // A content row with no resolved author/timestamp renders no byline element.
+    const bareRow = screen.getByText('Metadata-less std').closest('[cmdk-item]')!;
+    expect(
+      within(bareRow as HTMLElement).queryByTestId('search-byline'),
+    ).toBeNull();
+
+    // Navigation (jumpTo) rows never carry a byline.
+    const jumpRow = screen.getByText('Jump spec').closest('[cmdk-item]')!;
+    expect(
+      within(jumpRow as HTMLElement).queryByTestId('search-byline'),
+    ).toBeNull();
   });
 
   it('exposes role=dialog, role=listbox, and aria-selected on the active option [ac-15]', async () => {

--- a/packages/ui/src/components/SearchPalette.tsx
+++ b/packages/ui/src/components/SearchPalette.tsx
@@ -89,6 +89,18 @@ function handleFromPath(path: string): string {
   return path.split('/').filter((seg) => HANDLE_SEGMENT.test(seg)).join('/');
 }
 
+// spec-285: the WHO/WHEN byline for a content row — "<author> · <YYYY-MM-DD>".
+// Mirrors the agent-facing markdown byline (formatSearchResults) so the palette
+// tells a human who last touched a result and when, without opening it. Degrades
+// to author-only / date-only / nothing when a field is absent (navigation lanes
+// carry neither). The date is the calendar day of the ISO timestamp.
+function bylineText(hit: SearchHit): string | null {
+  const author = hit.authorName?.trim() || null;
+  const date = hit.lastUpdatedAt ? hit.lastUpdatedAt.slice(0, 10) : null;
+  if (author && date) return `${author} · ${date}`;
+  return author ?? date;
+}
+
 // spec-64 t-4 (ac-9): every row carries a kind badge + a status badge. The kind
 // badge reuses the neutral Badge styling with an explicit label so it reads
 // "Spec" / "Standard" / … rather than a status colour.
@@ -118,6 +130,10 @@ function ResultRow({
     lane === 'content' && hit.matchingSections.length > 0
       ? snippetText(hit.matchingSections[0].content, SNIPPET_MAX)
       : null;
+
+  // spec-285: content rows carry a WHO/WHEN byline (navigation lanes don't —
+  // their hits carry no author/timestamp).
+  const byline = lane === 'content' ? bylineText(hit) : null;
 
   // The handle (spec-N / std-N / …) renders next to the title so the user can
   // tell WHICH spec a row is without opening it — titles alone are ambiguous.
@@ -154,6 +170,11 @@ function ResultRow({
       {snippet && (
         <span className="truncate text-xs text-secondary" data-testid="search-snippet">
           {snippet}
+        </span>
+      )}
+      {byline && (
+        <span className="truncate text-xs text-muted" data-testid="search-byline">
+          {byline}
         </span>
       )}
     </Command.Item>


### PR DESCRIPTION
## What & why

When an agent (or a user at the ⌘K palette) searches the Memex, results now carry **WHO last touched a hit and WHEN** — so a `search_memex` caller can say *"that decision was made by Ryan on 2026-05-28"* and a palette user sees the same attribution inline, without opening anything. Spec: [spec-285](https://memex.ai/mindset-prod/memex-building-itself/specs/spec-285).

## How

The data already exists (std-32 activity contract) — this is a **read/projection** change, no migration, no write-path change.

**Engine + agent surfaces** (`packages/server/src/services/memex-search.ts`):
- `MemexSearchHit` gains `authorName` (WHO) + `lastUpdatedAt` (WHEN, ISO), populated across all six search arms + the handle short-circuit.
- Per dec-1/dec-2: decisions/sections use the denormalised `actor_name` (rename-proof); documents/issues resolve `created_by_user_id → users.name ?? email` via `LEFT JOIN`. One timestamp per hit — last-modified, `created_at` fallback where absent (decisions have no `updated_at`). A doc hit takes its most-recently-changed matched section's attribution.
- `formatSearchResults` renders a ` · <author>, <YYYY-MM-DD>` byline on each hit heading. The **MCP tool, REST route, and React agent are not edited** — they inherit it (shared formatter; REST via `Omit`; the React agent reuses the server handler).

**⌘K palette** (`packages/ui`, dec-3 re-resolved A→B mid-spec at request):
- `SearchHit` type + a muted `"<author> · <YYYY-MM-DD>"` byline on content rows; navigation lanes carry none.

## Scope boundary

`SearchPalette` rendering was originally deferred (dec-3-A) then pulled in (dec-3-B). No other behaviour changes.

## Testing

- **All 9 spec-285 ACs verified (100%).**
- Server: `memex-search.integration.test.ts`, `routes/search.integration.test.ts` (REST inheritance) — engine population per kind, byline rendering, REST passthrough, non-breakage, legibility. Regression sweep (demo-exclusion, issues-conversions, mcp/formatters) green. `tsc` clean on `tsconfig.json` (touched files) + `tsconfig.build.json` (prod gate).
- UI: `SearchPalette.test.tsx` (byline present/absent cases), `tsc -b` clean.
- e2e: `journey-18-global-search` extended to assert the byline in a real browser. **`make e2e-cold` runs as the required std-28 PR check** (not run in the build environment).

## Deploy notes

No migration, no flag — standard rollout. QA Reports (2 sessions) are on the Spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)