### PR TITLE
feat(ui): one coding-agent prompt per posture in Specify (spec-287)

### DIFF
--- a/packages/ui/e2e/journey-31-spec-283-review-actions-in-agent.spec.ts
+++ b/packages/ui/e2e/journey-31-spec-283-review-actions-in-agent.spec.ts
@@ -87,6 +87,10 @@ test("review actions live in the agent idle state, not on the Spec page", async 
 
   // ── The Spec page no longer carries the disclosure or the button row, but the
   //    review-handoff copy line stays (ac-3, dec-4) ──
+  // A freshly-seeded spec is viewed in the default REVIEWING posture, so under
+  // spec-287's per-posture gating (dec-2) the reviewer still sees the review
+  // handoff — this assertion holds unchanged. (spec-287's own per-posture e2e,
+  // covering the editor side, is journey-32.)
   await expect(page.getByTestId("review-actions-toggle")).toHaveCount(0);
   await expect(page.getByTestId("review-action-row")).toHaveCount(0);
   await expect(page.getByTestId("review-handoff-line")).toBeVisible({ timeout: 15_000 });

--- a/packages/ui/e2e/journey-32-spec-287-one-prompt-per-posture.spec.ts
+++ b/packages/ui/e2e/journey-32-spec-287-one-prompt-per-posture.spec.ts
@@ -1,0 +1,78 @@
+import { test, expect, tenantPath } from "./helpers/index.js";
+import { seedOrgTenant, seedSpec, setDocStatus } from "./helpers/retained.js";
+import { emitAcEvents } from "./helpers/emit-ac.js";
+
+// Journey 32 (spec-287): one coding-agent prompt per posture in Specify.
+//
+// On a Specify-phase Spec the page offers exactly ONE handoff prompt, keyed to
+// the viewer's posture (dec-2):
+//   • reviewer (and read-only) → the Review handoff ("Copy the Review prompt")
+//   • editor                   → the phase handoff ("Copy the Specify prompt")
+// Neither posture sees both. The review link is Title Case (dec-1). A freshly
+// seeded Spec is viewed in the default REVIEWING posture; promoting via the
+// PostureDropdown pill flips which single prompt shows.
+
+const SPEC287 = "mindset-prod/memex-building-itself/specs/spec-287";
+
+const ACS_BY_TEST: Record<string, string[]> = {
+  "one coding-agent prompt per posture in Specify": [
+    `${SPEC287}/acs/ac-1`, // editor sees the Specify prompt only
+    `${SPEC287}/acs/ac-2`, // reviewer sees the Review prompt only
+    `${SPEC287}/acs/ac-3`, // the review link is Title Case
+    `${SPEC287}/acs/ac-5`, // per-posture single-prompt rule, shipped with an e2e journey
+    `${SPEC287}/acs/ac-6`, // std-28 journey asserts editor→Specify-only, reviewer→Review-only
+  ],
+};
+
+test.afterEach(async ({}, testInfo) => {
+  if (testInfo.status === "skipped") return;
+  const refs = ACS_BY_TEST[testInfo.title];
+  if (!refs) return;
+  await emitAcEvents(
+    refs,
+    testInfo.status === "passed" ? "pass" : "fail",
+    `packages/ui/e2e/journey-32-spec-287-one-prompt-per-posture.spec.ts::${testInfo.title}`,
+    testInfo.duration
+  );
+});
+
+test("one coding-agent prompt per posture in Specify", async ({ page, resources }) => {
+  const tenant = await seedOrgTenant({ slug: resources.slug("j32") });
+  const spec = await seedSpec({
+    memexId: tenant.memexId,
+    title: "One prompt per posture",
+    purpose: "Exercise the per-posture single-prompt handoff in Specify.",
+  });
+  await setDocStatus({ memexId: tenant.memexId, docId: spec.docId, status: "specify" });
+
+  await page.goto(
+    tenantPath(tenant.namespaceSlug, tenant.memexSlug, `/specs/${spec.handle}`)
+  );
+
+  // The agent panel heading is the reliable page-load anchor (per journey-31).
+  await expect(page.getByText("Spec assistant")).toBeVisible({ timeout: 15_000 });
+
+  // ── Default REVIEWING posture: the Review handoff shows, the Specify
+  //    phase handoff does NOT (ac-2). The link is Title Case (ac-3). ──
+  await expect(page.getByRole("button", { name: /You are reviewing/i })).toBeVisible({
+    timeout: 15_000,
+  });
+  const reviewLine = page.getByTestId("review-handoff-line");
+  await expect(reviewLine).toBeVisible({ timeout: 15_000 });
+  await expect(reviewLine).toContainText("Copy the Review prompt");
+  await expect(page.getByTestId("phase-handoff-line")).toHaveCount(0);
+
+  // ── Promote to EDITING via the PostureDropdown pill ──
+  await page.getByRole("button", { name: /You are reviewing/i }).click();
+  await page.getByRole("menuitemradio", { name: /Editing/i }).click();
+  await expect(page.getByRole("button", { name: /You are editing/i })).toBeVisible({
+    timeout: 15_000,
+  });
+
+  // ── Editor posture: the Specify phase handoff shows, the Review handoff
+  //    does NOT (ac-1). One prompt per posture. ──
+  const phaseLine = page.getByTestId("phase-handoff-line");
+  await expect(phaseLine).toBeVisible({ timeout: 15_000 });
+  await expect(phaseLine).toContainText("Copy the Specify prompt");
+  await expect(page.getByTestId("review-handoff-line")).toHaveCount(0);
+});

--- a/packages/ui/src/pages/DocDocument.spec-159.test.tsx
+++ b/packages/ui/src/pages/DocDocument.spec-159.test.tsx
@@ -26,6 +26,10 @@ const AC252 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-252/
 // spec-283 relocates the review actions off the page; these tests verify the
 // page-side removal (ac-3/ac-9) — the agent-side arrival is in ChatPanel.test.tsx.
 const AC283 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-283/acs/ac-${n}`;
+// spec-287: one prompt per posture in Specify — the review handoff is re-gated
+// to non-editors (!canEdit), and its link is Title Case ("Copy the Review
+// prompt"). Supersedes spec-283 dec-4's "ungated, both postures" clause.
+const AC287 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-287/acs/ac-${n}`;
 
 // ── Heavy children → identity markers so we can see which panel rendered ────
 vi.mock('../components/DecisionPanel', () => ({
@@ -70,9 +74,13 @@ vi.mock('../components/DoneSummary', () => ({
 // ── Hooks: write access + a configurable posture (i-1: the sentence renders
 //    for reviewers too; only the Yes gates on editor posture) ────────────────
 let mockRole: 'editor' | 'reviewer' = 'editor';
+// spec-287: a read-only (non-member) viewer has canWrite=false → canEdit=false,
+// so they fall on the non-editor side of the review-handoff gate. Mutable so a
+// test can drop write access without re-mocking the module.
+let mockCanWrite = true;
 const refetchRole = vi.fn();
 vi.mock('../hooks/useMemexAccess', () => ({
-  useMemexAccess: () => ({ canWrite: true, isReadOnly: false }),
+  useMemexAccess: () => ({ canWrite: mockCanWrite, isReadOnly: !mockCanWrite }),
 }));
 vi.mock('../hooks/useDocRole', () => ({
   useDocRole: () => ({ myRole: mockRole, editors: [], loading: false, refetch: refetchRole }),
@@ -187,6 +195,7 @@ beforeEach(() => {
   promoteToEditor.mockResolvedValue(undefined);
   demoteToReviewer.mockResolvedValue(undefined);
   mockRole = 'editor';
+  mockCanWrite = true;
   docDecisions = [];
   docTasks = [];
   docAcs = [];
@@ -528,6 +537,7 @@ describe('spec-159 — Rubicon line + in-situ directives', () => {
 
   it('editor keeps the phase block — tabs + the Rubicon transition sentence (ac-19)', async () => {
     tagAc(AC(19));
+    tagAc(AC287(1));
     mockRole = 'editor';
     renderAt('specify');
     await screen.findByText('Narrative');
@@ -536,29 +546,36 @@ describe('spec-159 — Rubicon line + in-situ directives', () => {
     expect(screen.getAllByRole('tab')).toHaveLength(4);
     expect(screen.getByTestId('transition-sentence')).toBeInTheDocument();
     // spec-283 dec-4: the "Review actions" disclosure + button row are GONE
-    // from the page (relocated to the agent's idle state). The editor sees
-    // neither the toggle nor the row; the review-handoff line stays, ungated.
+    // from the page (relocated to the agent's idle state). spec-287 dec-2: the
+    // review-handoff line is now NON-editor-only — an editor sees neither the
+    // toggle, the row, NOR the review handoff. One prompt per posture: the
+    // editor's single Specify-phase prompt is the phase handoff below.
     expect(screen.queryByTestId('review-actions-toggle')).not.toBeInTheDocument();
     expect(screen.queryByTestId('review-action-row')).not.toBeInTheDocument();
-    expect(screen.getByTestId('review-handoff-line')).toBeInTheDocument();
+    expect(screen.queryByTestId('review-handoff-line')).not.toBeInTheDocument();
   });
 
   // spec-283 dec-4 — the "Review actions" disclosure (spec-182 ac-10/ac-11) is
   // RETIRED: the toggle and the four-button row are deleted from the page (the
-  // actions moved to the agent's idle state). For the editor the review-handoff
-  // line is no longer behind a disclosure — it renders ungated in Specify
-  // alongside the phase handoff, with no expand step.
-  it('editor at Specify: no review disclosure or row; the review-handoff line renders ungated (spec-283 ac-9, retires spec-182 ac-10/ac-11)', async () => {
+  // actions moved to the agent's idle state). spec-287 dec-2 then SUPERSEDES
+  // spec-283's "review handoff ungated for both postures": one prompt per
+  // posture. For the editor that single prompt is the phase handoff — the
+  // review handoff is NOT shown. (The toggle/row-gone half of spec-283 ac-9
+  // still holds and is still tagged here.)
+  it('editor at Specify: no review disclosure/row, and the review-handoff line is NOT shown — only the phase handoff (spec-287 ac-1/ac-8, supersedes spec-283 dec-4 for editors)', async () => {
     tagAc(AC283(9));
+    tagAc(AC287(1));
+    tagAc(AC287(8));
+    tagAc(AC287(9)); // the editor's phase handoff still renders (canEdit && handoff)
     mockRole = 'editor';
     renderAt('specify');
 
     await screen.findByText('Narrative');
     expect(screen.queryByTestId('review-actions-toggle')).not.toBeInTheDocument();
     expect(screen.queryByTestId('review-action-row')).not.toBeInTheDocument();
-    // The review-handoff line is present immediately — no expand needed.
-    expect(screen.getByTestId('review-handoff-line')).toBeInTheDocument();
-    // The editor's own phase handoff still renders.
+    // spec-287: the review handoff is non-editor-only — absent for the editor.
+    expect(screen.queryByTestId('review-handoff-line')).not.toBeInTheDocument();
+    // The editor's single Specify-phase prompt: the phase handoff.
     expect(screen.getByTestId('phase-handoff-line')).toBeInTheDocument();
   });
 });
@@ -651,23 +668,26 @@ describe('spec-182 — unified reviewer phase block', () => {
     }
   });
 
-  it('renders the reviewer handoff line — "Copy the review prompt …conduct the review from there."', async () => {
+  it('renders the reviewer handoff line — "Copy the Review prompt …conduct the review from there." (spec-287 ac-2/ac-3/ac-7)', async () => {
     tagAc(AC182(11));
+    tagAc(AC287(2));
+    tagAc(AC287(3));
+    tagAc(AC287(7));
     renderAt('specify');
 
     const line = await screen.findByTestId('review-handoff-line');
+    // spec-287 dec-1: Title Case, matching the Specify/Build/Verify family.
     expect(line.textContent).toContain(
-      'Copy the review prompt into your coding agent if you prefer to conduct the review from there.',
+      'Copy the Review prompt into your coding agent if you prefer to conduct the review from there.',
     );
     // issue-4: the clickable words LEAD the line and NAME the prompt, so
     // adjacent handoff lines are distinguishable from the link text alone.
     const copyButton = within(line).getByRole('button', {
-      name: /^Copy the review prompt/,
+      name: /^Copy the Review prompt/,
     });
-    expect(copyButton.textContent).toBe('Copy the review prompt');
-    // spec-182 issue-2: the phase handoff is an editor affordance — its prompt
-    // drives state changes and building. A reviewer gets the review handoff
-    // ONLY (amends ac-17's "renders for every viewer").
+    expect(copyButton.textContent).toBe('Copy the Review prompt');
+    // spec-182 issue-2 + spec-287 dec-2: a reviewer gets the review handoff
+    // ONLY — one prompt per posture, so the editor's phase handoff is absent.
     expect(screen.queryByTestId('phase-handoff-line')).not.toBeInTheDocument();
   });
 
@@ -811,18 +831,35 @@ describe('spec-159 ac-17 — next-action handoff line', () => {
     expect(screen.queryByTestId('phase-handoff-line')).not.toBeInTheDocument();
   });
 
-  it('a writable reviewer at Specify gets the review handoff ONLY — no phase handoff (spec-182 issue-2)', async () => {
+  it('a writable reviewer at Specify gets the review handoff ONLY — no phase handoff (spec-182 issue-2, spec-287 ac-2)', async () => {
     tagAc(AC182(17));
     tagAc(AC182(11));
+    tagAc(AC287(2));
+    tagAc(AC287(9)); // reviewer sees review-handoff, NOT phase-handoff
     mockRole = 'reviewer';
     renderAt('specify');
 
-    // spec-182 issue-2: the phase handoff is canEdit-gated — the reviewer
-    // keeps dec-3's review handoff at Specify and nothing else.
+    // spec-182 issue-2 + spec-287 dec-2: the phase handoff is canEdit-gated —
+    // the reviewer keeps the review handoff at Specify and nothing else.
     const line = await screen.findByTestId('review-handoff-line');
     expect(line.textContent).toContain(
-      'Copy the review prompt into your coding agent if you prefer to conduct the review from there.',
+      'Copy the Review prompt into your coding agent if you prefer to conduct the review from there.',
     );
+    expect(screen.queryByTestId('phase-handoff-line')).not.toBeInTheDocument();
+  });
+
+  // spec-287 ac-2: a READ-ONLY viewer (non-member: canWrite=false → canEdit=
+  // false) falls on the non-editor side of the gate — they see the review
+  // handoff and NOT the editor's phase handoff, same as a reviewer.
+  it('a read-only viewer at Specify sees the review handoff ONLY — no phase handoff (spec-287 ac-2/ac-9)', async () => {
+    tagAc(AC287(2));
+    tagAc(AC287(9));
+    mockCanWrite = false;
+    mockRole = 'reviewer';
+    renderAt('specify');
+
+    const line = await screen.findByTestId('review-handoff-line');
+    expect(line.textContent).toContain('Copy the Review prompt');
     expect(screen.queryByTestId('phase-handoff-line')).not.toBeInTheDocument();
   });
 });

--- a/packages/ui/src/pages/DocDocument.tsx
+++ b/packages/ui/src/pages/DocDocument.tsx
@@ -1342,18 +1342,23 @@ export function DocDocument() {
                 interpolates {namespace}/{memex}/{handle}/{title}/{url} — page
                 context the generic agent panel doesn't carry — and serves the
                 distinct "conduct the review in your own coding agent" workflow.
-                It renders in Specify for BOTH postures, ungated (no longer
-                behind the deleted editor disclosure). spec-182 issue-4: the
-                link leads each line and names its prompt. */}
-            {phase === 'specify' && (
+                spec-287 dec-2 SUPERSEDES spec-283 dec-4's "ungated, both
+                postures" clause: one prompt per posture in Specify. The review
+                handoff is now gated to NON-editors (!canEdit) — reviewers and
+                read-only viewers — while the editor sees the phase handoff
+                below (canEdit) and NOT this line. spec-287 dec-1: the link is
+                Title Case ("Copy the Review prompt"), matching the
+                Specify/Build/Verify family. spec-182 issue-4: the link leads
+                each line and names its prompt. */}
+            {phase === 'specify' && !canEdit && (
               <div data-testid="review-handoff-line">
                 <PromptButton
                   buttonId="review-handoff"
                   context={handoffContext}
                   orgBlocks={orgBlocks}
-                  linkText="Copy the review prompt"
+                  linkText="Copy the Review prompt"
                   sentence="into your coding agent if you prefer to conduct the review from there."
-                  sentenceLabel="Copy the review prompt into your coding agent if you prefer to conduct the review from there."
+                  sentenceLabel="Copy the Review prompt into your coding agent if you prefer to conduct the review from there."
                 />
               </div>
             )}


### PR DESCRIPTION
## What & why

Spec: [spec-287](https://memex.ai/mindset-prod/memex-building-itself/specs/spec-287) — *One prompt per posture in Specify*.

On a Spec in the **Specify** phase the page was offering an **editor two** coding-agent prompts at once (the post-spec-283 state): the review handoff *and* the Specify phase handoff. We shouldn't show two prompts to one posture. This PR makes it **one prompt per posture**:

| Posture | Sees |
|---|---|
| **Editor** | *"Copy the Specify prompt …"* only |
| **Reviewer / read-only** | *"Copy the Review prompt …"* only |

It also **normalises the link capitalisation**: the lower-cased *"Copy the review prompt"* becomes Title Case **"Copy the Review prompt"**, matching the Specify/Build/Verify family.

## How

- `DocDocument.tsx`: the `review-handoff-line` wrapper changes from `phase === 'specify'` to `phase === 'specify' && !canEdit` (reviewers + read-only viewers), and the link/sentence become Title Case. The `phase-handoff-line` stays `canEdit && handoff` (editor-only), unchanged. Reuses the existing `canEdit` value — no new plumbing.
- **Drift control (std-20):** spec-287 dec-2 **supersedes the "ungated, both postures" clause of spec-283 dec-4** for the editor case. The review handoff stays on the page (it interpolates `{namespace}/{memex}/{handle}/{title}/{url}` the agent panel can't carry) but is now non-editor-only.

## Scope

Frontend-only — all changed files are under `packages/ui/`. No server, schema, migration, MCP, or auth/posture-semantics change.

## Tests

- **Unit** (`DocDocument.spec-159.test.tsx`): flipped the two editor handoff tests (editor → phase handoff only), updated the reviewer handoff-text tests to Title Case, added a **read-only viewer** case. Full `@memex/ui` suite green (166 files, 1285 passed, 1 skipped); `tsc -b` clean.
- **e2e (std-28):** new `journey-32-spec-287-one-prompt-per-posture` asserts reviewer→Review-only then promotes to Editing and asserts editor→Specify-only. `journey-31` left functionally unchanged (its default-Reviewing viewer still sees the review handoff). Both pass under `make e2e-cold`.
- **ACs:** 8/9 verified via tagged emissions; ac-4 (frontend-only scope) is a guard judged by the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)