### PR TITLE
QA Reports feed redesign — hierarchy, phase pills, attribution, tag/date rail (spec-286)

### DIFF
--- a/packages/server/src/routes/__test__.ts
+++ b/packages/server/src/routes/__test__.ts
@@ -48,6 +48,7 @@ import { createExecutionPlan } from "../services/execution_plans.js";
 import { addTaskComment } from "../services/comments.js";
 import { createShareToken, listShareTokensForDoc } from "../services/share-tokens.js";
 import { addSection } from "../services/sections.js";
+import { applyTagStrings } from "../services/tags.js";
 import { resolveRole } from "../services/doc-members.js";
 import { listAssignees, assign } from "../services/doc-assignees.js";
 import { updateMemexVisibility } from "../services/memexes.js";
@@ -777,6 +778,25 @@ testOnlyRouter.post("/seed-section", async (c) => {
   const { memexId, docId, title, content = "", sectionType = "context" } = parsed.data;
   const section = await addSection(memexId, docId, sectionType, content, title);
   return c.json({ sectionId: section.id, seq: section.seq });
+});
+
+// spec-286: apply `scope::value`/flat tags to a Spec through the real
+// applyTagStrings service (create-or-pick + per-scope exclusivity), so the QA
+// Reports feed journey can seed the tags its rail filters on without raw SQL.
+const seedTagsSchema = z.object({
+  memexId: z.string().uuid(),
+  docId: z.string().uuid(),
+  tags: z.array(z.string()).min(1),
+});
+testOnlyRouter.post("/seed-tags", async (c) => {
+  const body = await c.req.json().catch(() => null);
+  const parsed = seedTagsSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: "Invalid request", details: parsed.error.issues }, 400);
+  }
+  const { memexId, docId, tags } = parsed.data;
+  const applied = await applyTagStrings({ channel: "rest_ui" }, memexId, docId, tags, null);
+  return c.json({ applied: applied.map((t) => ({ id: t.id, scope: t.scope, value: t.value })) });
 });
 
 // Resolve a user's role on a doc (editor / reviewer) through resolveRole — the

--- a/packages/server/src/routes/qa-reports.integration.test.ts
+++ b/packages/server/src/routes/qa-reports.integration.test.ts
@@ -272,6 +272,7 @@ type Facets = {
 
 describe("spec-286: enriched feed + tag/date filters + facets", () => {
   let path: string;
+  let authorUserId: string;
   let frontendTagId: string;
   let bugTagId: string;
   // specT (frontend + bug) reports, specU (frontend) report.
@@ -287,6 +288,7 @@ describe("spec-286: enriched feed + tag/date filters + facets", () => {
     // A distinct AUTHOR with a known name — different from the build IMPLEMENTER,
     // so the author≠implementer distinction is observable.
     const author = await upsertUserByEmail("author286@memex.ai");
+    authorUserId = author.id;
     await db.update(users).set({ name: "Ada Author" }).where(eq(users.id, author.id));
 
     const specT = await createDocDraft(
@@ -306,6 +308,14 @@ describe("spec-286: enriched feed + tag/date filters + facets", () => {
     rT1 = await seedReport(m.memexId, specT.id, "T session 1", new Date("2026-03-01T00:00:00Z"), builder);
     rU1 = await seedReport(m.memexId, specU.id, "U session 1", new Date("2026-03-02T00:00:00Z"), builder);
     rT2 = await seedReport(m.memexId, specT.id, "T session 2", new Date("2026-03-03T00:00:00Z"), builder);
+  });
+
+  // upsertUserByEmail inserts this author WITHOUT a namespace (it leaves that to
+  // the auth service), so leaving it behind would trip migration-smoke's
+  // "every active user has namespace_id" invariant on a shared worker clone.
+  // The docs that reference it are dropped by the file-level afterAll (FK SET NULL).
+  afterAll(async () => {
+    await db.delete(users).where(eq(users.id, authorUserId)).catch(() => {});
   });
 
   it("ac-6: each row carries phase, author (creator), and the owning Spec's tags", async () => {

--- a/packages/server/src/routes/qa-reports.integration.test.ts
+++ b/packages/server/src/routes/qa-reports.integration.test.ts
@@ -10,10 +10,11 @@ vi.hoisted(() => {
 });
 
 import { db } from "../db/connection.js";
-import { docSections, documents, memexes, qaReportViews } from "../db/schema.js";
+import { docSections, documents, memexes, qaReportViews, users } from "../db/schema.js";
 import { app } from "../app.js";
 import { createDocDraft } from "../services/documents.js";
 import { appendQaReport } from "../services/qa-reports.js";
+import { applyTagString } from "../services/tags.js";
 import { makeTestMemexWithDevAdmin } from "../services/test-helpers.js";
 import { upsertUserByEmail } from "../services/users.js";
 
@@ -243,5 +244,169 @@ describe("unread counter + view marker (dec-6)", () => {
     expect(resB.status).toBe(200);
     // Memex B has exactly one report and dev has never viewed B's feed.
     expect(await resB.json()).toEqual({ count: 1 });
+  });
+});
+
+// ─── spec-286: feed enrichment (phase/author/tags) + tag/date filters + facets ───
+//
+// A DEDICATED memex so the spec-260 ordering/count assertions above stay intact.
+// ac-6: each row enriched with phase, author (creator), and tags.
+// ac-8: tag + date-range query params, composing with the keyset `since` cursor.
+// ac-9: /facets returns whole-corpus per-tag counts + the "All" total.
+
+const AC_286_6 = "mindset-prod/memex-building-itself/specs/spec-286/acs/ac-6";
+const AC_286_8 = "mindset-prod/memex-building-itself/specs/spec-286/acs/ac-8";
+const AC_286_9 = "mindset-prod/memex-building-itself/specs/spec-286/acs/ac-9";
+
+type FeedRow286 = FeedRow & {
+  phase: string;
+  authorUserId: string | null;
+  authorName: string | null;
+  tags: { id: string; scope: string | null; value: string }[];
+};
+
+type Facets = {
+  total: number;
+  tags: { id: string; scope: string | null; value: string; count: number }[];
+};
+
+describe("spec-286: enriched feed + tag/date filters + facets", () => {
+  let path: string;
+  let frontendTagId: string;
+  let bugTagId: string;
+  // specT (frontend + bug) reports, specU (frontend) report.
+  let rT1: string; // 2026-03-01 — specT
+  let rU1: string; // 2026-03-02 — specU
+  let rT2: string; // 2026-03-03 — specT (newest)
+
+  beforeAll(async () => {
+    const m = await makeTestMemexWithDevAdmin("qa-feed-286");
+    path = `/api/${m.slug}/main`;
+    memexIds.push(m.memexId);
+
+    // A distinct AUTHOR with a known name — different from the build IMPLEMENTER,
+    // so the author≠implementer distinction is observable.
+    const author = await upsertUserByEmail("author286@memex.ai");
+    await db.update(users).set({ name: "Ada Author" }).where(eq(users.id, author.id));
+
+    const specT = await createDocDraft(
+      m.memexId, "Spec T", "Purpose", "spec", undefined, undefined, author.id,
+    );
+    const specU = await createDocDraft(
+      m.memexId, "Spec U", "Purpose", "spec", undefined, undefined, author.id,
+    );
+    createdDocIds.push(specT.id, specU.id);
+
+    const frontend = await applyTagString({}, m.memexId, specT.id, "area::frontend", author.id);
+    bugTagId = (await applyTagString({}, m.memexId, specT.id, "bug", author.id)).id;
+    frontendTagId = frontend.id;
+    await applyTagString({}, m.memexId, specU.id, "area::frontend", author.id);
+
+    const builder = { actorUserId: undefined, actorName: "Builder Bot" };
+    rT1 = await seedReport(m.memexId, specT.id, "T session 1", new Date("2026-03-01T00:00:00Z"), builder);
+    rU1 = await seedReport(m.memexId, specU.id, "U session 1", new Date("2026-03-02T00:00:00Z"), builder);
+    rT2 = await seedReport(m.memexId, specT.id, "T session 2", new Date("2026-03-03T00:00:00Z"), builder);
+  });
+
+  it("ac-6: each row carries phase, author (creator), and the owning Spec's tags", async () => {
+    tagAc(AC_286_6);
+
+    const res = await app.request(`${path}/qa-reports`, withApexHost());
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as FeedRow286[];
+    expect(body.map((r) => r.id)).toEqual([rT2, rU1, rT1]);
+
+    const top = body[0]!; // rT2 on specT
+    expect(top.phase).toBe("draft"); // createDocDraft → draft
+    expect(top.authorName).toBe("Ada Author"); // the creator
+    expect(top.actorName).toBe("Builder Bot"); // the implementer — distinct from author
+    expect(top.tags.map((t) => (t.scope ? `${t.scope}::${t.value}` : t.value)).sort()).toEqual(
+      ["area::frontend", "bug"],
+    );
+
+    // specU's report carries only the frontend tag.
+    const uRow = body.find((r) => r.id === rU1)!;
+    expect(uRow.tags.map((t) => `${t.scope}::${t.value}`)).toEqual(["area::frontend"]);
+  });
+
+  it("ac-8: tag filter narrows to reports whose Spec carries the tag, and composes with keyset `since`", async () => {
+    tagAc(AC_286_8);
+
+    // Filter by `bug` → only specT's two reports, newest-first.
+    const bugRes = await app.request(`${path}/qa-reports?tag=${bugTagId}`, withApexHost());
+    expect(bugRes.status).toBe(200);
+    expect(((await bugRes.json()) as FeedRow286[]).map((r) => r.id)).toEqual([rT2, rT1]);
+
+    // Filtered Load More: limit=1 then since=boundary stays within the filter.
+    const page1 = (await (
+      await app.request(`${path}/qa-reports?tag=${bugTagId}&limit=1`, withApexHost())
+    ).json()) as FeedRow286[];
+    expect(page1.map((r) => r.id)).toEqual([rT2]);
+    const since = page1[0]!.createdAt;
+    const page2 = (await (
+      await app.request(
+        `${path}/qa-reports?tag=${bugTagId}&limit=1&since=${encodeURIComponent(since)}`,
+        withApexHost(),
+      )
+    ).json()) as FeedRow286[];
+    expect(page2.map((r) => r.id)).toEqual([rT1]);
+
+    // Frontend tag spans both Specs → all three reports.
+    const feRes = await app.request(`${path}/qa-reports?tag=${frontendTagId}`, withApexHost());
+    expect(((await feRes.json()) as FeedRow286[]).map((r) => r.id)).toEqual([rT2, rU1, rT1]);
+  });
+
+  it("ac-8: date window (from/to) narrows the feed and ANDs with the tag filter", async () => {
+    tagAc(AC_286_8);
+
+    // from = 2026-03-02 → drops rT1 (03-01).
+    const fromRes = await app.request(
+      `${path}/qa-reports?from=${encodeURIComponent("2026-03-02T00:00:00Z")}`,
+      withApexHost(),
+    );
+    expect(((await fromRes.json()) as FeedRow286[]).map((r) => r.id)).toEqual([rT2, rU1]);
+
+    // tag=bug AND from=2026-03-02 → only rT2 (rT1 is bug but pre-window; rU1 in window but not bug).
+    const andRes = await app.request(
+      `${path}/qa-reports?tag=${bugTagId}&from=${encodeURIComponent("2026-03-02T00:00:00Z")}`,
+      withApexHost(),
+    );
+    expect(((await andRes.json()) as FeedRow286[]).map((r) => r.id)).toEqual([rT2]);
+  });
+
+  it("ac-9: /facets returns whole-corpus per-tag counts and the All total", async () => {
+    tagAc(AC_286_9);
+
+    const res = await app.request(`${path}/qa-reports/facets`, withApexHost());
+    expect(res.status).toBe(200);
+    const facets = (await res.json()) as Facets;
+
+    // All = every report in the corpus (3), independent of pagination.
+    expect(facets.total).toBe(3);
+
+    const byKey = new Map(
+      facets.tags.map((t) => [t.scope ? `${t.scope}::${t.value}` : t.value, t.count]),
+    );
+    // frontend on specT(2)+specU(1) = 3; bug on specT(2) = 2.
+    expect(byKey.get("area::frontend")).toBe(3);
+    expect(byKey.get("bug")).toBe(2);
+    // Ordered by count desc → frontend before bug.
+    expect(facets.tags[0]!.value).toBe("frontend");
+  });
+
+  it("ac-9: facet counts honour the date window (consistent with an active date filter)", async () => {
+    tagAc(AC_286_9);
+
+    const res = await app.request(
+      `${path}/qa-reports/facets?from=${encodeURIComponent("2026-03-02T00:00:00Z")}`,
+      withApexHost(),
+    );
+    const facets = (await res.json()) as Facets;
+    expect(facets.total).toBe(2); // rU1 + rT2
+    const byKey = new Map(
+      facets.tags.map((t) => [t.scope ? `${t.scope}::${t.value}` : t.value, t.count]),
+    );
+    expect(byKey.get("area::frontend")).toBe(2); // rU1 + rT2
+    expect(byKey.get("bug")).toBe(1); // rT2 only
   });
 });

--- a/packages/server/src/routes/qa-reports.ts
+++ b/packages/server/src/routes/qa-reports.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import {
   countUnreadQaReports,
   listQaReports,
+  qaReportTagFacets,
   recordQaReportsView,
 } from "../services/qa-reports.js";
 import { NotFoundError, ValidationError } from "../types/errors.js";
@@ -44,38 +45,64 @@ function parsePositiveInt(raw: string | undefined, field: string): number | unde
   return n;
 }
 
-function parseSince(raw: string | undefined): Date | undefined {
+function parseTimestamp(raw: string | undefined, field: string): Date | undefined {
   if (raw === undefined) return undefined;
   const d = new Date(raw);
   if (Number.isNaN(d.getTime())) {
-    throw new ValidationError("Query param 'since' must be an ISO-8601 timestamp");
+    throw new ValidationError(`Query param '${field}' must be an ISO-8601 timestamp`);
   }
   return d;
 }
 
 // GET /api/<ns>/<mx>/qa-reports — the feed.
 //
-// Query params (both optional):
-//   limit — page size (default 50, capped 200 by listQaReports)
-//   since — ISO-8601 keyset boundary; returns rows strictly OLDER ("Load More")
+// Query params (all optional):
+//   limit      — page size (default 50, capped 200 by listQaReports)
+//   since      — ISO-8601 keyset boundary; returns rows strictly OLDER ("Load More")
+//   tag        — tag id; restrict to reports whose owning Spec carries it (spec-286)
+//   from / to  — ISO-8601 date window; restrict to reports generated within it
+//                (spec-286). tag + (from/to) compose with AND.
 qaReports.get("/", async (c) => {
   const memexId = await resolveReadableMemexId(c);
   const limit = parsePositiveInt(c.req.query("limit"), "limit");
-  const since = parseSince(c.req.query("since"));
+  const since = parseTimestamp(c.req.query("since"), "since");
+  const tagId = c.req.query("tag") || undefined;
+  const from = parseTimestamp(c.req.query("from"), "from");
+  const to = parseTimestamp(c.req.query("to"), "to");
 
-  const rows = await listQaReports({ memexId, limit, since });
+  const rows = await listQaReports({ memexId, limit, since, tagId, from, to });
 
   // Anonymous / non-member projection (the routes/activity.ts convention):
-  // actor_user_id is PII and actor_name a display identity — both are dropped
-  // on the public-read path; actorKind keeps the row legible.
+  // actor_*/author_* are PII / display identity — dropped on the public-read path;
+  // actorKind, phase, and tags stay so the row is still legible + filterable.
   const accessLevel = c.get("currentAccessLevel");
   if (accessLevel !== "write") {
     return c.json(
-      rows.map(({ actorUserId: _u, actorName: _n, ...row }) => row),
+      rows.map(
+        ({
+          actorUserId: _au,
+          actorName: _an,
+          authorUserId: _ru,
+          authorName: _rn,
+          ...row
+        }) => row,
+      ),
     );
   }
 
   return c.json(rows);
+});
+
+// GET /api/<ns>/<mx>/qa-reports/facets — the filter rail's tag tree (spec-286).
+// Returns { total, tags: [{ id, scope, value, count }] } over the WHOLE corpus
+// (not the loaded page), honouring an optional from/to window so the counts stay
+// consistent with an active date filter (AND semantics).
+qaReports.get("/facets", async (c) => {
+  const memexId = await resolveReadableMemexId(c);
+  const from = parseTimestamp(c.req.query("from"), "from");
+  const to = parseTimestamp(c.req.query("to"), "to");
+  const facets = await qaReportTagFacets({ memexId, from, to });
+  return c.json(facets);
 });
 
 // GET /api/<ns>/<mx>/qa-reports/unread — the caller's unread count. Per-user by

--- a/packages/server/src/services/qa-reports.ts
+++ b/packages/server/src/services/qa-reports.ts
@@ -1,14 +1,22 @@
-import { and, desc, eq, gt, lt, ne, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gt, gte, inArray, lt, lte, ne, sql } from "drizzle-orm";
 import {
   QA_REPORT_SECTION_PREFIX,
   isQaReportSectionType,
   qaReportVersion,
 } from "@memex/shared";
 import { db } from "../db/connection.js";
-import { docSections, documents, qaReportViews } from "../db/schema.js";
+import {
+  docSections,
+  documents,
+  documentTags,
+  qaReportViews,
+  tags,
+  users,
+} from "../db/schema.js";
 import type { DocSection } from "../db/schema.js";
 import { mutate, type Mutated, type RequestCtx } from "./mutate.js";
 import { addSection } from "./sections.js";
+import { listDocTagsForDocs } from "./tags.js";
 
 // spec-260 (dec-1, dec-2): a QA report is a read-only `doc_sections` row with
 // section_type='qa_report'. Each build session APPENDS a distinct, dated version
@@ -94,6 +102,13 @@ const CHANNEL_TO_ACTOR_KIND: Record<string, QaReportFeedRow["actorKind"]> = {
   server: "system",
 };
 
+/** A tag carried on a feed row's owning Spec — the rail-facing subset (spec-286). */
+export interface QaReportTagRef {
+  id: string;
+  scope: string | null;
+  value: string;
+}
+
 export interface QaReportFeedRow {
   /** The qa_report doc_sections row id. */
   id: string;
@@ -101,16 +116,27 @@ export interface QaReportFeedRow {
   /** Parent Spec handle (`spec-N`) + title, for the WHICH-Spec column + link. */
   docHandle: string;
   docTitle: string;
+  /** The owning Spec's current phase (documents.status) — drives the phase pill (spec-286). */
+  phase: string;
   /** `qa_report` / `qa_report-2` / … — encodes the build-session version. */
   sectionType: string;
   version: number;
   title: string | null;
   content: string;
-  /** std-32 WHO columns, stamped at write time. */
+  /**
+   * The Spec's AUTHOR (spec-286 dec-1): the creator (documents.created_by_user_id,
+   * seeded as the editor — there is no distinct owner role). Distinct from the
+   * IMPLEMENTER below, which is whoever ran this build session.
+   */
+  authorUserId: string | null;
+  authorName: string | null;
+  /** std-32 WHO columns, stamped at write time — the IMPLEMENTER of this session. */
   actorUserId: string | null;
   actorName: string | null;
   actorKind: "human" | "mcp_agent" | "in_app_agent" | "system";
   channel: string | null;
+  /** The owning Spec's tags — feeds the rail filter chips (spec-286). */
+  tags: QaReportTagRef[];
   createdAt: Date;
 }
 
@@ -120,21 +146,49 @@ export interface ListQaReportsOptions {
   limit?: number;
   /** Keyset boundary: return rows strictly OLDER than this timestamp. */
   since?: Date;
+  /** spec-286: restrict to reports whose owning Spec carries this tag (by id). */
+  tagId?: string;
+  /** spec-286: restrict to reports generated at/after this instant (date filter). */
+  from?: Date;
+  /** spec-286: restrict to reports generated at/before this instant (date filter). */
+  to?: Date;
 }
 
-export async function listQaReports(opts: ListQaReportsOptions): Promise<QaReportFeedRow[]> {
-  const limit = Math.max(1, Math.min(MAX_LIMIT, Math.floor(opts.limit ?? DEFAULT_LIMIT)));
-
-  const conditions = [
-    eq(documents.memexId, opts.memexId),
-    // QA reports attach to Specs only (the write path enforces it); demo Specs
-    // are excluded from the feed like they are from the Pulse timeline.
+// The conditions shared by the feed, the unread counter, and the facets: a
+// qa_report* section on a non-demo Spec in this memex, not soft-deleted. Factored
+// out (spec-286) so the feed query, the facet counts, and the total all scope an
+// identical corpus — the rail counts can't drift from what the feed actually lists.
+function feedBaseConditions(memexId: string) {
+  return [
+    eq(documents.memexId, memexId),
     eq(documents.docType, "spec"),
     ne(documents.isDemo, true),
     ne(docSections.status, "deleted"),
     qaReportSectionPredicate(),
   ];
+}
+
+export async function listQaReports(opts: ListQaReportsOptions): Promise<QaReportFeedRow[]> {
+  const limit = Math.max(1, Math.min(MAX_LIMIT, Math.floor(opts.limit ?? DEFAULT_LIMIT)));
+
+  const conditions = feedBaseConditions(opts.memexId);
+  // Keyset boundary ("Load More") + the spec-286 filters, all ANDed so a filtered
+  // page is itself keyset-paginated correctly (the cursor composes with the filters).
   if (opts.since !== undefined) conditions.push(lt(docSections.createdAt, opts.since));
+  if (opts.from !== undefined) conditions.push(gte(docSections.createdAt, opts.from));
+  if (opts.to !== undefined) conditions.push(lte(docSections.createdAt, opts.to));
+  if (opts.tagId !== undefined) {
+    // Restrict to reports whose owning Spec carries the tag — an EXISTS-style
+    // subquery on the bridge, tenant-scoped. A semijoin (not an inner join on
+    // documentTags) so a Spec with the tag still yields exactly one row per report.
+    const taggedDocIds = db
+      .select({ id: documentTags.docId })
+      .from(documentTags)
+      .where(
+        and(eq(documentTags.memexId, opts.memexId), eq(documentTags.tagId, opts.tagId)),
+      );
+    conditions.push(inArray(documents.id, taggedDocIds));
+  }
 
   const rows = await db
     .select({
@@ -142,9 +196,14 @@ export async function listQaReports(opts: ListQaReportsOptions): Promise<QaRepor
       docId: docSections.docId,
       docHandle: documents.handle,
       docTitle: documents.title,
+      phase: documents.status,
       sectionType: docSections.sectionType,
       title: docSections.title,
       content: docSections.content,
+      // The Spec author (creator → seeded editor); LEFT-joined so a legacy Spec
+      // with a null creator still lists (authorName just renders empty).
+      authorUserId: documents.createdByUserId,
+      authorName: users.name,
       actorUserId: docSections.actorUserId,
       actorName: docSections.actorName,
       channel: docSections.channel,
@@ -152,16 +211,92 @@ export async function listQaReports(opts: ListQaReportsOptions): Promise<QaRepor
     })
     .from(docSections)
     .innerJoin(documents, eq(docSections.docId, documents.id))
+    .leftJoin(users, eq(users.id, documents.createdByUserId))
     .where(and(...conditions))
     // Newest-first with a deterministic tiebreaker (the listActivity convention).
     .orderBy(desc(docSections.createdAt), desc(docSections.id))
     .limit(limit);
 
+  // Attach each owning Spec's tags in one batched round-trip (no N+1), reusing the
+  // same query the Specs board uses. Docs absent from the map carry no tags.
+  const tagsByDoc = await listDocTagsForDocs(
+    opts.memexId,
+    [...new Set(rows.map((r) => r.docId))],
+  );
+
   return rows.map((row) => ({
     ...row,
     version: qaReportVersion(row.sectionType) ?? 1,
     actorKind: CHANNEL_TO_ACTOR_KIND[row.channel ?? "server"] ?? "system",
+    tags: (tagsByDoc.get(row.docId) ?? []).map(({ id, scope, value }) => ({
+      id,
+      scope,
+      value,
+    })),
   }));
+}
+
+// ── Tag facets for the filter rail (spec-286 dec-2) ────────────────────────────
+//
+// The rail's tag tree shows every tag carried by a Spec with at least one QA
+// report, each with the COUNT of reports under it, plus an "All" total. Computed
+// server-side across the WHOLE corpus (not the loaded page) so the counts are
+// correct regardless of how far the client has paged. Honours the date window so
+// the counts stay consistent with an active date filter (AND semantics, dec-3).
+
+export interface QaReportTagFacet extends QaReportTagRef {
+  /** Number of qa_report* sections whose owning Spec carries this tag. */
+  count: number;
+}
+
+export interface QaReportFacets {
+  /** Total qa_report* sections in the corpus (the "All" node count). */
+  total: number;
+  tags: QaReportTagFacet[];
+}
+
+export interface QaReportFacetsOptions {
+  memexId: string;
+  from?: Date;
+  to?: Date;
+}
+
+export async function qaReportTagFacets(
+  opts: QaReportFacetsOptions,
+): Promise<QaReportFacets> {
+  const conditions = feedBaseConditions(opts.memexId);
+  if (opts.from !== undefined) conditions.push(gte(docSections.createdAt, opts.from));
+  if (opts.to !== undefined) conditions.push(lte(docSections.createdAt, opts.to));
+
+  // The "All" total: every matching report section, tag or not.
+  const [totalRow] = await db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(docSections)
+    .innerJoin(documents, eq(docSections.docId, documents.id))
+    .where(and(...conditions));
+
+  // Per-tag counts: one report can sit under several tags (its Spec's tags), so a
+  // report is counted once per tag it carries — that's the intended "reports under
+  // this tag" semantic, and the per-tag counts can sum to more than `total`.
+  const tagRows = await db
+    .select({
+      id: tags.id,
+      scope: tags.scope,
+      value: tags.value,
+      count: sql<number>`count(*)::int`,
+    })
+    .from(docSections)
+    .innerJoin(documents, eq(docSections.docId, documents.id))
+    .innerJoin(
+      documentTags,
+      and(eq(documentTags.docId, documents.id), eq(documentTags.memexId, opts.memexId)),
+    )
+    .innerJoin(tags, eq(tags.id, documentTags.tagId))
+    .where(and(...conditions))
+    .groupBy(tags.id, tags.scope, tags.value)
+    .orderBy(desc(sql`count(*)`), asc(tags.scope), asc(tags.value));
+
+  return { total: totalRow?.count ?? 0, tags: tagRows };
 }
 
 // ── Per-user unread counter (dec-6) ────────────────────────────────────────────

--- a/packages/ui/e2e/helpers/retained.ts
+++ b/packages/ui/e2e/helpers/retained.ts
@@ -124,6 +124,16 @@ export async function seedSection(opts: {
   return call("POST", "/seed-section", opts);
 }
 
+/** spec-286: apply `scope::value`/flat tags to a Spec through applyTagStrings —
+ *  the tags the QA Reports feed rail filters + counts on. */
+export async function seedTags(opts: {
+  memexId: string;
+  docId: string;
+  tags: string[];
+}): Promise<{ applied: { id: string; scope: string | null; value: string }[] }> {
+  return call("POST", "/seed-tags", opts);
+}
+
 /** Seed an OPEN decision (with options) onto a doc through createDecision.
  *  Returns the decision id + its per-doc seq (the N in the `dec-N` handle). */
 export async function seedOpenDecision(opts: {

--- a/packages/ui/e2e/helpers/retained.ts
+++ b/packages/ui/e2e/helpers/retained.ts
@@ -60,6 +60,8 @@ export async function seedSpec(opts: {
   memexId: string;
   title: string;
   purpose?: string;
+  /** Attribute the spec to a creator — surfaces as the QA Reports author (spec-286). */
+  createdByUserId?: string;
 }): Promise<{ docId: string; handle: string; sectionId: string }> {
   return call("POST", "/seed-spec", opts);
 }

--- a/packages/ui/e2e/journey-29-spec-260-qa-reports.spec.ts
+++ b/packages/ui/e2e/journey-29-spec-260-qa-reports.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, tenantPath, emitAcEvents } from "./helpers/index.js";
+import { test, expect, tenantPath, emitAcEvents, ensureUser } from "./helpers/index.js";
 import {
   seedOrgTenant,
   seedSpec,
@@ -145,16 +145,21 @@ test.describe("spec-260 — Build QA Report", () => {
   }) => {
     const slug = resources.slug("j29b");
     const tenant = await seedOrgTenant({ slug });
+    // Attribute the specs to the dev user so the redesigned card's author renders
+    // (spec-286 shows the author; the std-260 "WHO" coverage moves onto it).
+    const devUserId = await ensureUser("dev@memex.ai");
 
     const specA = await seedSpec({
       memexId: tenant.memexId,
       title: "Feed Spec Alpha",
       purpose: "First spec with a QA report.",
+      createdByUserId: devUserId,
     });
     const specB = await seedSpec({
       memexId: tenant.memexId,
       title: "Feed Spec Beta",
       purpose: "Second spec with a QA report.",
+      createdByUserId: devUserId,
     });
 
     // Sequential seeds → distinct created_at → deterministic newest-first.
@@ -188,9 +193,10 @@ test.describe("spec-260 — Build QA Report", () => {
     await expect(rows.nth(0).getByTestId("qa-report-row-spec")).toContainText("Feed Spec Beta");
     await expect(rows.nth(1).getByTestId("qa-report-row-spec")).toContainText("Feed Spec Alpha");
 
-    // WHEN + WHO render on every row; WHICH links to the parent Spec.
+    // WHEN + WHO render on every row; WHICH links to the parent Spec. (spec-286
+    // renders WHO as the author/implementer attribution — here the seeded author.)
     await expect(rows.nth(0).getByTestId("qa-report-row-when")).not.toBeEmpty();
-    await expect(rows.nth(0).getByTestId("qa-report-row-who")).not.toBeEmpty();
+    await expect(rows.nth(0).getByTestId("qa-report-row-author")).not.toBeEmpty();
     await expect(rows.nth(0).getByTestId("qa-report-row-spec")).toHaveAttribute(
       "href",
       new RegExp(`/specs/${specB.handle}$`),

--- a/packages/ui/e2e/journey-30-spec-286-qa-reports-redesign.spec.ts
+++ b/packages/ui/e2e/journey-30-spec-286-qa-reports-redesign.spec.ts
@@ -1,0 +1,162 @@
+import { test, expect, tenantPath, emitAcEvents } from "./helpers/index.js";
+import {
+  seedOrgTenant,
+  seedSpec,
+  seedSection,
+  seedTags,
+  setDocStatus,
+} from "./helpers/retained.js";
+
+// Journey 30 — spec-286: the redesigned QA Reports feed, end to end [per std-28].
+//
+// The feed now leads each report with the spec as a heading, shows the owning
+// spec's phase as a coloured pill, and carries a STICKY left rail that filters
+// the feed by tag (with whole-corpus counts) and by date range. This journey
+// seeds two tagged specs in different phases, each with a QA report, then drives
+// the rail: a tag node narrows the feed to that tag's reports, the per-tag counts
+// match the corpus, and a date window narrows the feed too (AND with the tag).
+//
+// Seeding rides the env-gated /api/__test__ surface (no raw SQL); navigation is
+// path-based [per std-2]. Reports + tags are seeded through the REAL services.
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-286/acs/ac-${n}`;
+
+const ACS_BY_TITLE: Record<string, string[]> = {
+  "enriched cards: spec heading + phase pill; rail filters by tag with corpus counts": [
+    AC(2),
+    AC(4),
+    AC(11),
+  ],
+  "date filter narrows the feed (and ANDs with a tag)": [AC(5)],
+};
+
+test.afterEach(async ({}, testInfo) => {
+  if (testInfo.status === "skipped") return;
+  const refs = ACS_BY_TITLE[testInfo.title];
+  if (!refs) return;
+  await emitAcEvents(
+    refs,
+    testInfo.status === "passed" ? "pass" : "fail",
+    `packages/ui/e2e/journey-30-spec-286-qa-reports-redesign.spec.ts::${testInfo.title}`,
+    testInfo.duration,
+  );
+});
+
+test.describe("spec-286 — QA Reports feed redesign", () => {
+  test("enriched cards: spec heading + phase pill; rail filters by tag with corpus counts", async ({
+    page,
+    resources,
+  }) => {
+    const slug = resources.slug("j30a");
+    const tenant = await seedOrgTenant({ slug });
+
+    // Alpha → tagged area::frontend + bug, in Verify.
+    const alpha = await seedSpec({
+      memexId: tenant.memexId,
+      title: "Redesign Alpha",
+      purpose: "Alpha spec.",
+    });
+    await seedTags({ memexId: tenant.memexId, docId: alpha.docId, tags: ["area::frontend", "bug"] });
+    await setDocStatus({ memexId: tenant.memexId, docId: alpha.docId, status: "verify" });
+
+    // Beta → tagged area::frontend only, in Build.
+    const beta = await seedSpec({
+      memexId: tenant.memexId,
+      title: "Redesign Beta",
+      purpose: "Beta spec.",
+    });
+    await seedTags({ memexId: tenant.memexId, docId: beta.docId, tags: ["area::frontend"] });
+    await setDocStatus({ memexId: tenant.memexId, docId: beta.docId, status: "build" });
+
+    // Sequential seeds → distinct created_at → Beta (second) leads newest-first.
+    await seedSection({
+      memexId: tenant.memexId,
+      docId: alpha.docId,
+      title: "QA Report",
+      content: "Alpha build session report.",
+      sectionType: "qa_report",
+    });
+    await seedSection({
+      memexId: tenant.memexId,
+      docId: beta.docId,
+      title: "QA Report",
+      content: "Beta build session report.",
+      sectionType: "qa_report",
+    });
+
+    await page.goto(tenantPath(tenant.namespaceSlug, tenant.memexSlug, "/qa-reports"));
+
+    const rows = page.getByTestId("qa-report-row");
+    await expect(rows).toHaveCount(2, { timeout: 15_000 });
+
+    // ac-2: each card leads with the spec and shows the phase as a coloured pill.
+    await expect(rows.nth(0).getByTestId("qa-report-row-spec")).toContainText("Redesign Beta");
+    await expect(rows.nth(0).getByTestId("qa-report-phase-pill")).toHaveAttribute(
+      "data-phase",
+      "build",
+    );
+    await expect(rows.nth(0).getByTestId("qa-report-phase-pill")).toContainText("Build");
+    await expect(rows.nth(1).getByTestId("qa-report-phase-pill")).toHaveAttribute(
+      "data-phase",
+      "verify",
+    );
+
+    // ac-4: the rail stays in place and roots the tree at "All" with the corpus
+    // total; each tag node carries its whole-corpus report count.
+    const rail = page.getByTestId("qa-reports-rail");
+    await expect(rail).toBeVisible();
+    await expect(page.getByTestId("qa-reports-tag-all")).toContainText("2");
+
+    const frontendNode = page
+      .getByTestId("qa-reports-tag-node")
+      .filter({ hasText: "frontend" });
+    const bugNode = page.getByTestId("qa-reports-tag-node").filter({ hasText: "bug" });
+    await expect(frontendNode.getByTestId("qa-reports-tag-count")).toHaveText("2");
+    await expect(bugNode.getByTestId("qa-reports-tag-count")).toHaveText("1");
+
+    // ac-4 + ac-11: selecting `bug` filters the feed to Alpha's single report.
+    await bugNode.click();
+    await expect(rows).toHaveCount(1, { timeout: 15_000 });
+    await expect(rows.nth(0).getByTestId("qa-report-row-spec")).toContainText("Redesign Alpha");
+
+    // `frontend` spans both specs → both reports.
+    await frontendNode.click();
+    await expect(rows).toHaveCount(2, { timeout: 15_000 });
+
+    // "All" clears the tag → the full feed returns.
+    await page.getByTestId("qa-reports-tag-all").click();
+    await expect(rows).toHaveCount(2, { timeout: 15_000 });
+  });
+
+  test("date filter narrows the feed (and ANDs with a tag)", async ({ page, resources }) => {
+    const slug = resources.slug("j30b");
+    const tenant = await seedOrgTenant({ slug });
+
+    const spec = await seedSpec({
+      memexId: tenant.memexId,
+      title: "Dated Spec",
+      purpose: "Spec with a recent report.",
+    });
+    await seedTags({ memexId: tenant.memexId, docId: spec.docId, tags: ["area::frontend"] });
+    await seedSection({
+      memexId: tenant.memexId,
+      docId: spec.docId,
+      title: "QA Report",
+      content: "Recent report.",
+      sectionType: "qa_report",
+    });
+
+    await page.goto(tenantPath(tenant.namespaceSlug, tenant.memexSlug, "/qa-reports"));
+    const rows = page.getByTestId("qa-report-row");
+    await expect(rows).toHaveCount(1, { timeout: 15_000 });
+
+    // ac-5: a "from" date in the future excludes the just-seeded report → empty.
+    const future = "2099-01-01";
+    await page.getByTestId("qa-reports-range-from").fill(future);
+    await expect(page.getByTestId("qa-reports-empty")).toBeVisible({ timeout: 15_000 });
+
+    // Clearing the window back to "All time" restores the report.
+    await page.getByTestId("qa-reports-range-all").click();
+    await expect(rows).toHaveCount(1, { timeout: 15_000 });
+  });
+});

--- a/packages/ui/src/components/QaReportsFilterRail.test.tsx
+++ b/packages/ui/src/components/QaReportsFilterRail.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { QaReportsFilterRail, ALL_TIME, type DateRangeState } from './QaReportsFilterRail';
+import type { QaReportFacets } from '../hooks/useQaReports';
+
+const AC_4 = 'mindset-prod/memex-building-itself/specs/spec-286/acs/ac-4';
+const AC_5 = 'mindset-prod/memex-building-itself/specs/spec-286/acs/ac-5';
+
+const FACETS: QaReportFacets = {
+  total: 7,
+  tags: [
+    { id: 't-frontend', scope: 'area', value: 'frontend', count: 4 },
+    { id: 't-bug', scope: null, value: 'bug', count: 3 },
+  ],
+};
+
+function renderRail(overrides: Partial<Parameters<typeof QaReportsFilterRail>[0]> = {}) {
+  const onSelectTag = vi.fn();
+  const onChangeRange = vi.fn();
+  render(
+    <QaReportsFilterRail
+      facets={FACETS}
+      loading={false}
+      selectedTagId={null}
+      onSelectTag={onSelectTag}
+      range={ALL_TIME}
+      onChangeRange={onChangeRange}
+      {...overrides}
+    />,
+  );
+  return { onSelectTag, onChangeRange };
+}
+
+describe('QaReportsFilterRail (spec-286)', () => {
+  it('ac-4: roots the tree at "All" with the corpus total and one counted node per tag', () => {
+    tagAc(AC_4);
+    renderRail();
+
+    const all = screen.getByTestId('qa-reports-tag-all');
+    expect(all).toHaveTextContent('All');
+    expect(all).toHaveTextContent('7');
+
+    const nodes = screen.getAllByTestId('qa-reports-tag-node');
+    expect(nodes).toHaveLength(2);
+    expect(nodes[0]).toHaveTextContent('frontend');
+    const counts = screen.getAllByTestId('qa-reports-tag-count').map((n) => n.textContent);
+    expect(counts).toEqual(['4', '3']);
+  });
+
+  it('ac-4: clicking a tag selects it; clicking All clears the selection', () => {
+    tagAc(AC_4);
+    const { onSelectTag } = renderRail({ selectedTagId: 't-frontend' });
+
+    // The selected node is marked pressed.
+    const frontend = screen
+      .getAllByTestId('qa-reports-tag-node')
+      .find((n) => n.getAttribute('data-tag-id') === 't-frontend')!;
+    expect(frontend).toHaveAttribute('aria-pressed', 'true');
+
+    fireEvent.click(
+      screen
+        .getAllByTestId('qa-reports-tag-node')
+        .find((n) => n.getAttribute('data-tag-id') === 't-bug')!,
+    );
+    expect(onSelectTag).toHaveBeenCalledWith('t-bug');
+
+    fireEvent.click(screen.getByTestId('qa-reports-tag-all'));
+    expect(onSelectTag).toHaveBeenCalledWith(null);
+  });
+
+  it('ac-5: quick ranges emit a preset + lower bound; "All time" clears the window', () => {
+    tagAc(AC_5);
+    const { onChangeRange } = renderRail({ range: { preset: 'week', from: '2026-06-06T00:00:00.000Z' } });
+
+    fireEvent.click(screen.getByTestId('qa-reports-range-month'));
+    const monthArg = onChangeRange.mock.calls.at(-1)![0] as DateRangeState;
+    expect(monthArg.preset).toBe('month');
+    expect(typeof monthArg.from).toBe('string');
+    expect(monthArg.to).toBeUndefined();
+
+    fireEvent.click(screen.getByTestId('qa-reports-range-all'));
+    expect(onChangeRange).toHaveBeenLastCalledWith(ALL_TIME);
+  });
+
+  it('ac-5: a custom from/to range emits inclusive ISO bounds', () => {
+    tagAc(AC_5);
+    const { onChangeRange } = renderRail();
+
+    fireEvent.change(screen.getByTestId('qa-reports-range-from'), {
+      target: { value: '2026-01-15' },
+    });
+    const arg = onChangeRange.mock.calls.at(-1)![0] as DateRangeState;
+    expect(arg.preset).toBe('custom');
+    expect(arg.from).toBe('2026-01-15T00:00:00.000Z');
+
+    fireEvent.change(screen.getByTestId('qa-reports-range-to'), {
+      target: { value: '2026-01-31' },
+    });
+    const arg2 = onChangeRange.mock.calls.at(-1)![0] as DateRangeState;
+    // End-of-day so the chosen day is inclusive.
+    expect(arg2.to).toBe('2026-01-31T23:59:59.999Z');
+  });
+});

--- a/packages/ui/src/components/QaReportsFilterRail.tsx
+++ b/packages/ui/src/components/QaReportsFilterRail.tsx
@@ -1,0 +1,173 @@
+// spec-286: the QA Reports feed's left-hand filter rail. It STAYS IN PLACE while
+// the report list scrolls (sticky) and offers two stacked filter groups:
+//
+//   1. A tag tree rooted at "All" (every report) with one node per tag carrying
+//      its whole-corpus report count. Selecting a node filters the feed.
+//   2. Date filters — quick "Last week" / "Last month" ranges, an "All time"
+//      reset, and a custom from/to range.
+//
+// A tag selection and a date range compose with AND in the page (dec-3); the rail
+// just reports the user's intent up via callbacks. Counts come from the server
+// facet endpoint (dec-2), so they are correct across the whole corpus regardless
+// of how far the feed has paged.
+
+import { TagChip } from './TagChip';
+import type { QaReportFacets } from '../hooks/useQaReports';
+
+export type DateRangePreset = 'all' | 'week' | 'month' | 'custom';
+
+export interface DateRangeState {
+  preset: DateRangePreset;
+  /** ISO-8601 lower bound (inclusive). */
+  from?: string;
+  /** ISO-8601 upper bound (inclusive). */
+  to?: string;
+}
+
+export const ALL_TIME: DateRangeState = { preset: 'all' };
+
+/** ISO instant `days` before `now` — the lower bound for a quick range. */
+function daysAgoIso(days: number, now: Date = new Date()): string {
+  return new Date(now.getTime() - days * 86_400_000).toISOString();
+}
+
+interface QaReportsFilterRailProps {
+  facets: QaReportFacets;
+  loading: boolean;
+  /** Currently selected tag id, or null for "All". */
+  selectedTagId: string | null;
+  onSelectTag: (tagId: string | null) => void;
+  range: DateRangeState;
+  onChangeRange: (range: DateRangeState) => void;
+}
+
+export function QaReportsFilterRail({
+  facets,
+  loading,
+  selectedTagId,
+  onSelectTag,
+  range,
+  onChangeRange,
+}: QaReportsFilterRailProps) {
+  // `<input type="date">` wants a bare YYYY-MM-DD; our state carries full ISO.
+  const fromDate = range.from ? range.from.slice(0, 10) : '';
+  const toDate = range.to ? range.to.slice(0, 10) : '';
+
+  const setCustom = (next: { from?: string; to?: string }) => {
+    const from = next.from !== undefined ? next.from : fromDate;
+    const to = next.to !== undefined ? next.to : toDate;
+    onChangeRange({
+      preset: 'custom',
+      // End-of-day on `to` so the chosen day is inclusive.
+      from: from ? `${from}T00:00:00.000Z` : undefined,
+      to: to ? `${to}T23:59:59.999Z` : undefined,
+    });
+  };
+
+  return (
+    <aside
+      data-testid="qa-reports-rail"
+      // sticky + self-start keeps the rail in place while the feed column scrolls.
+      className="sticky top-4 self-start w-56 shrink-0 max-h-[calc(100vh-2rem)] overflow-y-auto pr-2"
+    >
+      <div data-testid="qa-reports-tag-tree">
+        <h2 className="px-2 text-xs font-semibold uppercase tracking-wide text-muted">Tags</h2>
+        <ul className="mt-1 space-y-0.5">
+          <li>
+            <button
+              type="button"
+              data-testid="qa-reports-tag-all"
+              aria-pressed={selectedTagId === null}
+              onClick={() => onSelectTag(null)}
+              className={`flex w-full items-center justify-between rounded-md px-2 py-1 text-sm ${
+                selectedTagId === null
+                  ? 'bg-overlay text-primary font-medium'
+                  : 'text-secondary hover:bg-overlay hover:text-primary'
+              }`}
+            >
+              <span>All</span>
+              <span className="text-xs text-muted tabular-nums">{facets.total}</span>
+            </button>
+          </li>
+          {facets.tags.map((tag) => (
+            <li key={tag.id}>
+              <button
+                type="button"
+                data-testid="qa-reports-tag-node"
+                data-tag-id={tag.id}
+                aria-pressed={selectedTagId === tag.id}
+                onClick={() => onSelectTag(tag.id)}
+                className={`flex w-full items-center justify-between gap-1 rounded-md px-2 py-1 ${
+                  selectedTagId === tag.id ? 'bg-overlay' : 'hover:bg-overlay'
+                }`}
+              >
+                <TagChip tag={tag} />
+                <span
+                  data-testid="qa-reports-tag-count"
+                  className="text-xs text-muted tabular-nums"
+                >
+                  {tag.count}
+                </span>
+              </button>
+            </li>
+          ))}
+          {!loading && facets.tags.length === 0 && (
+            <li className="px-2 py-1 text-xs text-muted">No tags yet</li>
+          )}
+        </ul>
+      </div>
+
+      <div data-testid="qa-reports-date-filters" className="mt-5">
+        <h2 className="px-2 text-xs font-semibold uppercase tracking-wide text-muted">When</h2>
+        <div className="mt-1 flex flex-wrap gap-1 px-2">
+          {(
+            [
+              { key: 'all', label: 'All time', build: (): DateRangeState => ALL_TIME },
+              { key: 'week', label: 'Last week', build: (): DateRangeState => ({ preset: 'week', from: daysAgoIso(7) }) },
+              { key: 'month', label: 'Last month', build: (): DateRangeState => ({ preset: 'month', from: daysAgoIso(30) }) },
+            ] as const
+          ).map((opt) => (
+            <button
+              key={opt.key}
+              type="button"
+              data-testid={`qa-reports-range-${opt.key}`}
+              aria-pressed={range.preset === opt.key}
+              onClick={() => onChangeRange(opt.build())}
+              className={`rounded-full border px-2 py-0.5 text-xs ${
+                range.preset === opt.key
+                  ? 'border-accent text-accent'
+                  : 'border-edge-subtle text-secondary hover:text-primary'
+              }`}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+        <div className="mt-2 flex flex-col gap-1 px-2 text-xs text-secondary">
+          <label className="flex items-center justify-between gap-2">
+            <span>From</span>
+            <input
+              type="date"
+              data-testid="qa-reports-range-from"
+              value={fromDate}
+              max={toDate || undefined}
+              onChange={(e) => setCustom({ from: e.target.value })}
+              className="qa-date-input w-36 rounded border border-edge-subtle bg-surface px-1 py-0.5 text-primary"
+            />
+          </label>
+          <label className="flex items-center justify-between gap-2">
+            <span>To</span>
+            <input
+              type="date"
+              data-testid="qa-reports-range-to"
+              value={toDate}
+              min={fromDate || undefined}
+              onChange={(e) => setCustom({ to: e.target.value })}
+              className="qa-date-input w-36 rounded border border-edge-subtle bg-surface px-1 py-0.5 text-primary"
+            />
+          </label>
+        </div>
+      </div>
+    </aside>
+  );
+}

--- a/packages/ui/src/components/phaseColors.spec-252.test.tsx
+++ b/packages/ui/src/components/phaseColors.spec-252.test.tsx
@@ -119,8 +119,11 @@ describe('phase colour palette (spec-252 dec-1)', () => {
     expect(phaseColors('verify')!.pill).toContain('bg-phase-verify-bg');
     // draft has no Figma hue yet → keeps the neutral status token.
     expect(phaseColors('draft')!.pill).toContain('bg-status-neutral-bg');
-    // done keeps its current treatment — no phase colour.
-    expect(phaseColors('done')).toBeNull();
+    // spec-286 gave `done` a neutral GREY pill (no longer null), but spec-252's
+    // guarantee still holds: done gets no coloured CONTAINER wash — its container
+    // stays empty, so the DocDocument header surface is unchanged at done.
+    expect(phaseColors('done')!.pill).toContain('bg-status-neutral-bg');
+    expect(phaseColors('done')!.container).toBe('');
     // The shared statusVariant is untouched: specify/review/open stay amber, so
     // board column headers and issue badges do not recolour.
     expect(statusVariant('specify')).toBe('warning');

--- a/packages/ui/src/components/phaseColors.spec-286.test.ts
+++ b/packages/ui/src/components/phaseColors.spec-286.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { phaseColors } from './phaseColors';
+
+const AC_10 = 'mindset-prod/memex-building-itself/specs/spec-286/acs/ac-10';
+
+// spec-286 dec-3 / ac-10: `done` is no longer null — it returns a neutral grey
+// pill (the status-neutral tokens), distinct from build (blue) and verify (teal).
+describe('phaseColors — done pill (spec-286)', () => {
+  it('ac-10: returns a neutral grey pill for done, distinct from build/verify', () => {
+    tagAc(AC_10);
+
+    const done = phaseColors('done');
+    expect(done).not.toBeNull();
+    expect(done!.pill).toContain('status-neutral');
+
+    // Distinct from the live phases.
+    expect(done!.pill).not.toBe(phaseColors('build')!.pill);
+    expect(done!.pill).not.toBe(phaseColors('verify')!.pill);
+
+    // Container stays empty so the DocDocument header wash is unaffected at done.
+    expect(done!.container).toBe('');
+  });
+});

--- a/packages/ui/src/components/phaseColors.ts
+++ b/packages/ui/src/components/phaseColors.ts
@@ -24,7 +24,7 @@ export interface PhaseColor {
   container: string;
 }
 
-const PALETTE: Record<'draft' | 'specify' | 'build' | 'verify', PhaseColor> = {
+const PALETTE: Record<'draft' | 'specify' | 'build' | 'verify' | 'done', PhaseColor> = {
   draft: {
     pill: 'bg-status-neutral-bg text-status-neutral-text border-status-neutral-border',
     container: 'bg-phase-draft-container',
@@ -41,11 +41,22 @@ const PALETTE: Record<'draft' | 'specify' | 'build' | 'verify', PhaseColor> = {
     pill: 'bg-phase-verify-bg text-phase-verify-text border-phase-verify-border',
     container: 'bg-phase-verify-container',
   },
+  // spec-286 dec-3: `done` is terminal, so it gets a calm NEUTRAL GREY pill
+  // (reusing the same status-neutral tokens as draft) — distinct from the live
+  // build (blue) / verify (teal) hues. The container stays EMPTY: the only
+  // pre-spec-286 caller that reads `.container` is the DocDocument header wash,
+  // where done is handled by DoneSummary, so '' preserves that surface's existing
+  // no-wash behaviour. The feed (spec-286) uses `.pill` only.
+  done: {
+    pill: 'bg-status-neutral-bg text-status-neutral-text border-status-neutral-border',
+    container: '',
+  },
 };
 
 /**
- * The phase's pill + container colours, or `null` for `done` — which keeps its
- * current treatment (the phase bar is hidden at done; DoneSummary takes over).
+ * The phase's pill + container colours. Returns a value for every spec phase
+ * including `done` (spec-286 added the neutral grey done pill); `null` only for
+ * an unknown / non-spec status.
  */
 export function phaseColors(phase: SpecStatus): PhaseColor | null {
   return PALETTE[phase as keyof typeof PALETTE] ?? null;

--- a/packages/ui/src/hooks/useQaReports.spec-260.test.tsx
+++ b/packages/ui/src/hooks/useQaReports.spec-260.test.tsx
@@ -147,7 +147,8 @@ describe('useQaReportsFeed (dec-5 keyset Load More)', () => {
     const page2 = [{ id: 'r-0', createdAt: '2026-05-30T00:00:00Z' }];
     fetchMock.mockResolvedValueOnce(jsonResponse(page1));
 
-    const { result } = renderHook(() => useQaReportsFeed(2), { wrapper });
+    // spec-286 moved the page-size to the 2nd arg (1st is now the filter object).
+    const { result } = renderHook(() => useQaReportsFeed({}, 2), { wrapper });
     await waitFor(() => expect(result.current.rows).toHaveLength(2));
     // A full page (length == limit) keeps Load More enabled.
     expect(result.current.hasMore).toBe(true);

--- a/packages/ui/src/hooks/useQaReports.ts
+++ b/packages/ui/src/hooks/useQaReports.ts
@@ -21,21 +21,48 @@ const DEFAULT_LIMIT = 50;
 // activity), so without this the badge would stay stale until the next event.
 export const QA_REPORTS_VIEWED_EVENT = 'memex:qa-reports-viewed';
 
+/** A tag carried on a report's owning Spec — feeds the rail chips (spec-286). */
+export interface QaReportTagRef {
+  id: string;
+  scope: string | null;
+  value: string;
+}
+
 /** Wire shape of GET /api/<ns>/<mx>/qa-reports rows (server QaReportFeedRow). */
 export interface QaReportFeedRow {
   id: string;
   docId: string;
   docHandle: string;
   docTitle: string;
+  /** Owning Spec's current phase — drives the phase pill (spec-286). */
+  phase: string;
   sectionType: string;
   version: number;
   title: string | null;
   content: string;
+  /** The Spec author (creator). Absent on the public-read projection (spec-286). */
+  authorUserId?: string | null;
+  authorName?: string | null;
+  /** std-32 actor = the implementer of this build session. */
   actorUserId?: string | null;
   actorName?: string | null;
   actorKind: 'human' | 'mcp_agent' | 'in_app_agent' | 'system';
   channel: string | null;
+  /** Owning Spec's tags — the rail filter chips (spec-286). */
+  tags: QaReportTagRef[];
   createdAt: string;
+}
+
+/**
+ * Server-parameterised feed filters (spec-286 dec-2). A tag id and a date window,
+ * composing with AND. Undefined fields are omitted from the query → unfiltered.
+ */
+export interface QaReportFilters {
+  tagId?: string;
+  /** ISO-8601 lower bound (inclusive) on report createdAt. */
+  from?: string;
+  /** ISO-8601 upper bound (inclusive) on report createdAt. */
+  to?: string;
 }
 
 export interface UseQaReportsFeedResult {
@@ -47,7 +74,10 @@ export interface UseQaReportsFeedResult {
   refresh: () => Promise<void>;
 }
 
-export function useQaReportsFeed(limit = DEFAULT_LIMIT): UseQaReportsFeedResult {
+export function useQaReportsFeed(
+  filters: QaReportFilters = {},
+  limit = DEFAULT_LIMIT,
+): UseQaReportsFeedResult {
   const [rows, setRows] = useState<QaReportFeedRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -60,6 +90,10 @@ export function useQaReportsFeed(limit = DEFAULT_LIMIT): UseQaReportsFeedResult 
   rowsRef.current = rows;
   const loadingOlderRef = useRef(false);
 
+  // Destructure so the fetch callback depends on primitive values, not the object
+  // identity — a caller passing a fresh `{}` each render must not re-trigger fetches.
+  const { tagId, from, to } = filters;
+
   const fetchPage = useCallback(
     async (since: string | undefined): Promise<QaReportFeedRow[]> => {
       const base = tenantBase();
@@ -69,11 +103,16 @@ export function useQaReportsFeed(limit = DEFAULT_LIMIT): UseQaReportsFeedResult 
       const params = new URLSearchParams();
       params.set('limit', String(limit));
       if (since) params.set('since', since);
+      // The spec-286 filters ride alongside the keyset cursor, so a filtered
+      // "Load More" returns the strictly-older filtered page.
+      if (tagId) params.set('tag', tagId);
+      if (from) params.set('from', from);
+      if (to) params.set('to', to);
       const res = await fetchWithRetry(`${base}/qa-reports?${params.toString()}`);
       if (!res.ok) throw new Error(`Failed to load QA reports (${res.status})`);
       return (await res.json()) as QaReportFeedRow[];
     },
-    [limit],
+    [limit, tagId, from, to],
   );
 
   const refresh = useCallback(async () => {
@@ -116,6 +155,81 @@ export function useQaReportsFeed(limit = DEFAULT_LIMIT): UseQaReportsFeedResult 
   }, [refresh]);
 
   return { rows, loading, error, hasMore, loadOlder, refresh };
+}
+
+// ── Tag facets for the filter rail (spec-286 dec-2) ────────────────────────────
+
+export interface QaReportTagFacet extends QaReportTagRef {
+  count: number;
+}
+
+export interface QaReportFacets {
+  /** Total reports in the corpus (the "All" node count). */
+  total: number;
+  tags: QaReportTagFacet[];
+}
+
+export interface UseQaReportTagFacetsResult {
+  facets: QaReportFacets;
+  loading: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+}
+
+const EMPTY_FACETS: QaReportFacets = { total: 0, tags: [] };
+
+/**
+ * The rail's tag tree (spec-286): every tag carried by a Spec with reports, each
+ * with its whole-corpus report count, plus the "All" total. Honours an optional
+ * date window so the counts stay consistent with an active date filter. Refreshes
+ * live off the std-8 bus the way the feed does — a new report changes the counts.
+ */
+export function useQaReportTagFacets(
+  window: { from?: string; to?: string } = {},
+): UseQaReportTagFacetsResult {
+  const [facets, setFacets] = useState<QaReportFacets>(EMPTY_FACETS);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const reqToken = useRef(0);
+
+  const { from, to } = window;
+
+  const refresh = useCallback(async () => {
+    const myReq = ++reqToken.current;
+    const base = tenantBase();
+    if (!base) {
+      setError('QA Reports requires tenant context (no namespace/memex in the URL).');
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      const params = new URLSearchParams();
+      if (from) params.set('from', from);
+      if (to) params.set('to', to);
+      const qs = params.toString();
+      const res = await fetchWithRetry(`${base}/qa-reports/facets${qs ? `?${qs}` : ''}`);
+      if (!res.ok) throw new Error(`Failed to load tag facets (${res.status})`);
+      const body = (await res.json()) as QaReportFacets;
+      if (myReq !== reqToken.current) return; // superseded
+      setFacets(body);
+    } catch (err) {
+      if (myReq !== reqToken.current) return;
+      setError(err instanceof Error ? err.message : 'Failed to load tag facets');
+    } finally {
+      if (myReq === reqToken.current) setLoading(false);
+    }
+  }, [from, to]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  // Live: a freshly written report rides the std-8 bus → recompute counts.
+  useDocChangeStream(null, refresh);
+
+  return { facets, loading, error, refresh };
 }
 
 export interface QaReportsViewReceipt {

--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -286,6 +286,31 @@
 .prose-content em, .prose-dark em { color: rgb(var(--color-text-primary)); }
 .prose-content img, .prose-dark img { @apply rounded-lg my-4 max-w-full; }
 
+/*
+ * spec-286: subordinate prose for the QA Reports feed. `.prose-qa` layers ON TOP
+ * of `.prose-dark` (use both classes together) and DEMOTES the markdown heading
+ * scale so a report's internal headings sit BELOW the card's spec-name heading
+ * (which is text-lg) instead of dwarfing it — `.prose-dark h1` is text-3xl, larger
+ * than the card title, which was the inverted-hierarchy bug. Headings here cap at
+ * text-base and tighten their vertical rhythm; everything else inherits prose-dark.
+ */
+.prose-qa h1 { @apply text-base font-semibold mt-4 mb-2; }
+.prose-qa h2 { @apply text-sm font-semibold mt-3 mb-1.5; }
+.prose-qa h3 { @apply text-sm font-medium mt-3 mb-1; }
+.prose-qa h4 { @apply text-xs font-semibold uppercase tracking-wide mt-2 mb-1; }
+.prose-qa h5, .prose-qa h6 { @apply text-xs font-medium mt-2 mb-1; }
+/* Body copy a touch smaller than the card chrome so the heading still leads. */
+.prose-qa p, .prose-qa li { @apply text-sm; }
+
+/*
+ * spec-286: the QA Reports rail date inputs. In dark mode the browser's native
+ * `<input type="date">` calendar-picker glyph defaults to a dark icon that
+ * disappears against the dark surface. Adopting the dark `color-scheme` under the
+ * `.dark` theme makes the UA paint that glyph (and the input's internals) light —
+ * the idiomatic, cross-browser fix. Light theme keeps the default dark glyph.
+ */
+.dark .qa-date-input { color-scheme: dark; }
+
 @keyframes slide-in-right {
   from {
     transform: translateX(100%);

--- a/packages/ui/src/pages/QaReports.spec-260.test.tsx
+++ b/packages/ui/src/pages/QaReports.spec-260.test.tsx
@@ -22,6 +22,13 @@ const recordViewMock = vi.hoisted(() => vi.fn());
 vi.mock('../hooks/useQaReports', () => ({
   useQaReportsFeed: (...a: unknown[]) => useQaReportsFeedMock(...a),
   recordQaReportsView: (...a: unknown[]) => recordViewMock(...a),
+  // spec-286: the redesigned page also reads the tag facets for the rail.
+  useQaReportTagFacets: () => ({
+    facets: { total: 0, tags: [] },
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+  }),
   QA_REPORTS_VIEWED_EVENT: 'memex:qa-reports-viewed',
 }));
 
@@ -45,6 +52,7 @@ function row(over: Partial<QaReportFeedRow>): QaReportFeedRow {
     docId: 'd-1',
     docHandle: 'spec-1',
     docTitle: 'Some Spec',
+    phase: 'verify',
     sectionType: 'qa_report',
     version: 1,
     title: 'QA Report',
@@ -52,6 +60,7 @@ function row(over: Partial<QaReportFeedRow>): QaReportFeedRow {
     actorName: 'Claude Code',
     actorKind: 'mcp_agent',
     channel: 'mcp',
+    tags: [],
     createdAt: '2026-06-03T00:00:00Z',
     ...over,
   };
@@ -129,18 +138,23 @@ describe('spec-260 — QA Reports feed page', () => {
 
     const rows = await screen.findAllByTestId('qa-report-row');
 
-    // WHICH — the parent Spec, linked.
+    // WHICH — the parent Spec, linked. (spec-286 dropped the `·` separator; the
+    // handle + title now lead as the card heading.)
     const specLink = within(rows[0]).getByTestId('qa-report-row-spec');
-    expect(specLink).toHaveTextContent('spec-9 · Newest Spec');
+    expect(specLink).toHaveTextContent('spec-9');
+    expect(specLink).toHaveTextContent('Newest Spec');
     expect(specLink.closest('a')).toHaveAttribute('href', expect.stringContaining('/specs/spec-9'));
 
-    // WHEN — the report row's generation time.
-    expect(within(rows[0]).getByTestId('qa-report-row-when')).toHaveTextContent('3 Jun 2026');
+    // WHEN — the report row's generation time, now shown as relative time (spec-286).
+    expect(within(rows[0]).getByTestId('qa-report-row-when')).toHaveTextContent(/ago|just now|\d{4}/);
 
-    // WHO — the std-32 actor; an mcp_agent executor is labelled as an agent,
-    // a human executor by name.
-    expect(within(rows[0]).getByTestId('qa-report-row-who')).toHaveTextContent('Claude Code (agent)');
-    expect(within(rows[1]).getByTestId('qa-report-row-who')).toHaveTextContent('Barrie');
+    // WHO executed it — the std-32 actor, now the IMPLEMENTER (spec-286). These
+    // fixtures carry no author, so the implementer (the actor) is shown: an
+    // mcp_agent labelled as an agent, a human by name.
+    expect(within(rows[0]).getByTestId('qa-report-row-implementer')).toHaveTextContent(
+      'Claude Code (agent)',
+    );
+    expect(within(rows[1]).getByTestId('qa-report-row-implementer')).toHaveTextContent('Barrie');
 
     // A versioned session is identified.
     expect(rows[0]).toHaveTextContent('session 2');

--- a/packages/ui/src/pages/QaReports.spec-286.test.tsx
+++ b/packages/ui/src/pages/QaReports.spec-286.test.tsx
@@ -1,0 +1,220 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { tagAc } from '@memex-ai-ac/vitest';
+
+import { QaReports } from './QaReports';
+import {
+  useQaReportsFeed,
+  useQaReportTagFacets,
+  recordQaReportsView,
+  type QaReportFeedRow,
+  type QaReportFacets,
+} from '../hooks/useQaReports';
+
+const AC_1 = 'mindset-prod/memex-building-itself/specs/spec-286/acs/ac-1';
+const AC_2 = 'mindset-prod/memex-building-itself/specs/spec-286/acs/ac-2';
+const AC_3 = 'mindset-prod/memex-building-itself/specs/spec-286/acs/ac-3';
+const AC_7 = 'mindset-prod/memex-building-itself/specs/spec-286/acs/ac-7';
+const AC_11 = 'mindset-prod/memex-building-itself/specs/spec-286/acs/ac-11';
+const AC_12 = 'mindset-prod/memex-building-itself/specs/spec-286/acs/ac-12';
+
+vi.mock('../hooks/useDocChangeStream', () => ({ useDocChangeStream: () => {} }));
+// PageHeader pulls in the auth/tenant chain — not under test here; stub it.
+vi.mock('../components/PageHeader', () => ({
+  PageHeader: ({ title }: { title: string }) => <h1>{title}</h1>,
+}));
+vi.mock('../hooks/useQaReports', () => ({
+  useQaReportsFeed: vi.fn(),
+  useQaReportTagFacets: vi.fn(),
+  recordQaReportsView: vi.fn(),
+}));
+
+const ROWS: QaReportFeedRow[] = [
+  {
+    id: 'r1',
+    docId: 'd1',
+    docHandle: 'spec-100',
+    docTitle: 'Alpha feature',
+    phase: 'build',
+    sectionType: 'qa_report',
+    version: 1,
+    title: 'QA Report',
+    content: '# Inner heading\n\nSome report body.',
+    authorName: 'Ada Author',
+    actorName: 'Builder Bot',
+    actorKind: 'mcp_agent',
+    channel: 'mcp',
+    tags: [{ id: 't-frontend', scope: 'area', value: 'frontend' }],
+    createdAt: '2026-06-13T10:00:00.000Z',
+  },
+  {
+    id: 'r2',
+    docId: 'd2',
+    docHandle: 'spec-101',
+    docTitle: 'Beta cleanup',
+    phase: 'done',
+    sectionType: 'qa_report',
+    version: 1,
+    title: 'QA Report',
+    content: 'Body only.',
+    authorName: 'Cy Coder',
+    actorName: 'Cy Coder', // author built it themselves → implementer hidden
+    actorKind: 'human',
+    channel: 'rest_ui',
+    tags: [],
+    createdAt: '2026-06-12T10:00:00.000Z',
+  },
+];
+
+const FACETS: QaReportFacets = {
+  total: 5,
+  tags: [
+    { id: 't-frontend', scope: 'area', value: 'frontend', count: 3 },
+    { id: 't-bug', scope: null, value: 'bug', count: 2 },
+  ],
+};
+
+const mockedFeed = vi.mocked(useQaReportsFeed);
+const mockedFacets = vi.mocked(useQaReportTagFacets);
+const mockedView = vi.mocked(recordQaReportsView);
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <QaReports />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  mockedFeed.mockReset();
+  mockedFeed.mockImplementation(() => ({
+    rows: ROWS,
+    loading: false,
+    error: null,
+    hasMore: false,
+    loadOlder: vi.fn(),
+    refresh: vi.fn(),
+  }));
+  mockedFacets.mockReset();
+  mockedFacets.mockReturnValue({ facets: FACETS, loading: false, error: null, refresh: vi.fn() });
+  mockedView.mockReset();
+  // null receipt → boundary 'all' → rows render collapsed (deterministic).
+  mockedView.mockResolvedValue(null);
+});
+
+describe('QaReports card (spec-286)', () => {
+  it('ac-3 + ac-1: the spec is the dominant accent-coloured heading above the report', async () => {
+    tagAc(AC_3);
+    tagAc(AC_1);
+    renderPage();
+
+    const rows = await screen.findAllByTestId('qa-report-row');
+    const link = within(rows[0]).getByTestId('qa-report-row-spec');
+    expect(link).toHaveTextContent('spec-100');
+    expect(link).toHaveTextContent('Alpha feature');
+    // ac-3: rendered in the accent colour.
+    expect(link.className).toContain('text-accent');
+    // ac-1: the heading is the dominant element (h3, text-lg) …
+    const heading = link.closest('h3');
+    expect(heading).not.toBeNull();
+    expect(heading!.className).toContain('text-lg');
+
+    // … and the report body renders with the subordinate `.prose-qa` scale.
+    fireEvent.click(within(rows[0]).getByTestId('qa-report-row-toggle'));
+    const body = within(rows[0]).getByTestId('qa-report-row-body');
+    expect(body.className).toContain('prose-qa');
+  });
+
+  it('ac-2: metadata shows a phase pill coloured to the phase, plus author and relative time', async () => {
+    tagAc(AC_2);
+    renderPage();
+    const rows = await screen.findAllByTestId('qa-report-row');
+
+    // build → blue phase tokens; done → neutral grey.
+    const buildPill = within(rows[0]).getByTestId('qa-report-phase-pill');
+    expect(buildPill).toHaveAttribute('data-phase', 'build');
+    expect(buildPill).toHaveTextContent('Build');
+    expect(buildPill.className).toContain('phase-build');
+
+    const donePill = within(rows[1]).getByTestId('qa-report-phase-pill');
+    expect(donePill).toHaveTextContent('Done');
+    expect(donePill.className).toContain('status-neutral');
+
+    expect(within(rows[0]).getByTestId('qa-report-row-author')).toHaveTextContent('Ada Author');
+    // relative time, not an absolute date.
+    expect(within(rows[0]).getByTestId('qa-report-row-when')).toHaveTextContent(/ago|just now|\d/);
+  });
+
+  it('ac-7: implementer shows only when different from the author', async () => {
+    tagAc(AC_7);
+    renderPage();
+    const rows = await screen.findAllByTestId('qa-report-row');
+
+    // r1: Builder Bot ≠ Ada Author → implementer shown.
+    expect(within(rows[0]).getByTestId('qa-report-row-implementer')).toHaveTextContent('Builder Bot');
+    // r2: author built it themselves → no separate implementer line.
+    expect(within(rows[1]).queryByTestId('qa-report-row-implementer')).toBeNull();
+  });
+});
+
+describe('QaReports bulk expand/collapse (spec-286)', () => {
+  it('ac-12: one control opens every report, then collapses them all', async () => {
+    tagAc(AC_12);
+    renderPage();
+    const rows = await screen.findAllByTestId('qa-report-row');
+
+    // Rows start collapsed (boundary 'all').
+    expect(within(rows[0]).queryByTestId('qa-report-row-body')).toBeNull();
+    expect(within(rows[1]).queryByTestId('qa-report-row-body')).toBeNull();
+
+    // Expand all → every report body is shown.
+    const toggle = screen.getByTestId('qa-reports-expand-all');
+    expect(toggle).toHaveTextContent('Expand all');
+    fireEvent.click(toggle);
+    expect(within(rows[0]).getByTestId('qa-report-row-body')).toBeInTheDocument();
+    expect(within(rows[1]).getByTestId('qa-report-row-body')).toBeInTheDocument();
+    expect(toggle).toHaveTextContent('Collapse all');
+
+    // Collapse all → every report body is hidden again.
+    fireEvent.click(toggle);
+    expect(within(rows[0]).queryByTestId('qa-report-row-body')).toBeNull();
+    expect(within(rows[1]).queryByTestId('qa-report-row-body')).toBeNull();
+  });
+});
+
+describe('QaReports filter wiring (spec-286)', () => {
+  it('ac-11: tag + date filters compose with AND, and "All" clears the tag', async () => {
+    tagAc(AC_11);
+    renderPage();
+    await screen.findAllByTestId('qa-report-row');
+
+    const lastFilters = () => mockedFeed.mock.calls.at(-1)![0] as {
+      tagId?: string;
+      from?: string;
+      to?: string;
+    };
+
+    // Initial: unfiltered.
+    expect(lastFilters()).toMatchObject({ tagId: undefined, from: undefined, to: undefined });
+
+    // Select a tag → feed filtered by it.
+    fireEvent.click(
+      screen.getAllByTestId('qa-reports-tag-node').find((n) => n.getAttribute('data-tag-id') === 't-frontend')!,
+    );
+    expect(lastFilters().tagId).toBe('t-frontend');
+
+    // Add a date range → BOTH apply (AND): tag stays, from is set.
+    fireEvent.click(screen.getByTestId('qa-reports-range-week'));
+    const both = lastFilters();
+    expect(both.tagId).toBe('t-frontend');
+    expect(typeof both.from).toBe('string');
+
+    // Click "All" → tag cleared; the date window persists (it's a separate axis).
+    fireEvent.click(screen.getByTestId('qa-reports-tag-all'));
+    const cleared = lastFilters();
+    expect(cleared.tagId).toBeUndefined();
+    expect(typeof cleared.from).toBe('string');
+  });
+});

--- a/packages/ui/src/pages/QaReports.tsx
+++ b/packages/ui/src/pages/QaReports.tsx
@@ -1,12 +1,16 @@
 // QA Reports — the workspace-wide feed of build-session QA reports (spec-260
-// dec-5/dec-6). A Pulse-style top-level nav page: every `qa_report` section
-// across the memex's Specs, newest-first, an initial page + keyset "Load More",
-// live updates off the std-8 bus. Each row shows WHEN it was generated, WHICH
-// Spec it belongs to (linked), and WHO executed the build session (the std-32
-// actor on the row). Opening the page records the per-user view marker, zeroing
-// the nav badge (count-everything semantics — own-agent reports included).
+// dec-5/dec-6, redesigned in spec-286). A Pulse-style top-level nav page: every
+// `qa_report` section across the memex's Specs, newest-first, an initial page +
+// keyset "Load More", live updates off the std-8 bus.
+//
+// spec-286 reshapes each row into a CARD whose dominant heading is the spec
+// (accent-coloured link), with a metadata line (author, implementer-if-different,
+// relative time, phase pill) above a subordinate-scale markdown body — and adds a
+// STICKY left rail to filter by tag and date range (server-parameterised, so the
+// counts + filtering are correct across the whole corpus, not just loaded rows).
+// Opening the page still records the per-user view marker (zeroing the nav badge).
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -14,11 +18,20 @@ import { PageHeader } from '../components/PageHeader';
 import {
   recordQaReportsView,
   useQaReportsFeed,
+  useQaReportTagFacets,
   type QaReportFeedRow,
 } from '../hooks/useQaReports';
 import { useDocChangeStream } from '../hooks/useDocChangeStream';
+import {
+  QaReportsFilterRail,
+  ALL_TIME,
+  type DateRangeState,
+} from '../components/QaReportsFilterRail';
+import { phaseColors } from '../components/phaseColors';
+import { phaseDisplayName } from '../utils/phaseDisplay';
 import { tenantPath } from '../utils/tenantUrl';
-import { formatDate } from '../utils/format';
+import { timeAgo } from '../utils/timeAgo';
+import type { SpecStatus } from '../api/types';
 
 const ACTOR_KIND_LABEL: Record<QaReportFeedRow['actorKind'], string> = {
   human: '',
@@ -27,7 +40,7 @@ const ACTOR_KIND_LABEL: Record<QaReportFeedRow['actorKind'], string> = {
   system: 'system',
 };
 
-function executorLabel(row: QaReportFeedRow): string {
+function implementerLabel(row: QaReportFeedRow): string {
   const name = row.actorName?.trim();
   const kind = ACTOR_KIND_LABEL[row.actorKind];
   if (name && kind) return `${name} (${kind})`;
@@ -35,32 +48,84 @@ function executorLabel(row: QaReportFeedRow): string {
   return kind || 'unknown';
 }
 
-function FeedRow({ row, defaultOpen = false }: { row: QaReportFeedRow; defaultOpen?: boolean }) {
-  // ac-24: unread rows arrive expanded; read rows collapsed. Initial state
-  // only — the user's own toggling always wins afterwards.
+function PhasePill({ phase }: { phase: string }) {
+  const colors = phaseColors(phase as SpecStatus);
+  return (
+    <span
+      data-testid="qa-report-phase-pill"
+      data-phase={phase}
+      className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[11px] font-medium leading-none ${
+        colors?.pill ?? 'border-edge-subtle text-secondary'
+      }`}
+    >
+      {phaseDisplayName(phase)}
+    </span>
+  );
+}
+
+function FeedRow({
+  row,
+  defaultOpen = false,
+  bulk,
+}: {
+  row: QaReportFeedRow;
+  defaultOpen?: boolean;
+  // ac-12: a bumped nonce drives a bulk expand/collapse from the page-level
+  // control; per-row toggling still wins afterwards until the next bulk action.
+  bulk: { open: boolean; nonce: number };
+}) {
+  // ac-24: unread rows arrive expanded; read rows collapsed. Initial state only —
+  // the user's own toggling always wins afterwards.
   const [open, setOpen] = useState(defaultOpen);
+
+  useEffect(() => {
+    // nonce 0 = no bulk action yet → leave the unread-driven initial state alone.
+    if (bulk.nonce > 0) setOpen(bulk.open);
+  }, [bulk.nonce, bulk.open]);
+
+  const author = row.authorName?.trim() || null;
+  const implementerName = row.actorName?.trim() || null;
+  // ac-7: show the implementer only when it differs from the author. When the
+  // author ran their own build (same name) we show a single attribution.
+  const showImplementer = implementerName !== null && implementerName !== author;
+
   return (
     <li
       data-testid="qa-report-row"
       className="rounded-xl border border-edge bg-surface p-4"
     >
-      <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1 text-sm">
+      {/* Heading: the spec is the card's identity — accent-coloured link, sized
+          ABOVE the report body's headings (.prose-qa demotes those). */}
+      <h3 className="text-lg font-semibold leading-snug">
         <Link
           data-testid="qa-report-row-spec"
           to={tenantPath(`/specs/${row.docHandle}`)}
-          className="font-medium text-primary hover:underline"
+          className="text-accent hover:text-accent-hover hover:underline"
         >
-          {row.docHandle} · {row.docTitle}
+          <span className="text-accent/70">{row.docHandle}</span> {row.docTitle}
         </Link>
-        {row.version > 1 && (
-          <span className="text-xs text-muted">session {row.version}</span>
+      </h3>
+
+      {/* Metadata line — subordinate to the heading. */}
+      <div
+        data-testid="qa-report-row-meta"
+        className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted"
+      >
+        <PhasePill phase={row.phase} />
+        {author && (
+          <span data-testid="qa-report-row-author">
+            by <span className="text-secondary">{author}</span>
+          </span>
         )}
-        <span className="ml-auto text-xs text-muted">
-          <span data-testid="qa-report-row-when">{formatDate(row.createdAt)}</span>
-          {' · '}
-          <span data-testid="qa-report-row-who">{executorLabel(row)}</span>
-        </span>
+        {showImplementer && (
+          <span data-testid="qa-report-row-implementer">
+            · built by <span className="text-secondary">{implementerLabel(row)}</span>
+          </span>
+        )}
+        {row.version > 1 && <span>· session {row.version}</span>}
+        <span data-testid="qa-report-row-when">· {timeAgo(row.createdAt)}</span>
       </div>
+
       <button
         type="button"
         data-testid="qa-report-row-toggle"
@@ -71,7 +136,10 @@ function FeedRow({ row, defaultOpen = false }: { row: QaReportFeedRow; defaultOp
         {open ? 'Hide report' : 'Read report'}
       </button>
       {open && (
-        <div data-testid="qa-report-row-body" className="mt-3 prose-dark overflow-hidden">
+        <div
+          data-testid="qa-report-row-body"
+          className="mt-3 prose-dark prose-qa overflow-hidden"
+        >
           <ReactMarkdown remarkPlugins={[remarkGfm]}>{row.content}</ReactMarkdown>
         </div>
       )}
@@ -80,21 +148,32 @@ function FeedRow({ row, defaultOpen = false }: { row: QaReportFeedRow; defaultOp
 }
 
 export function QaReports() {
-  const { rows, loading, error, hasMore, loadOlder, refresh } = useQaReportsFeed();
+  // ── Filter state (spec-286) ────────────────────────────────────────────────
+  // tagId = null → "All". range carries concrete ISO bounds, computed once at
+  // selection time (NOT per render) so the values are stable and don't churn the
+  // feed/facets fetches. A tag + a date range compose with AND (dec-3).
+  const [selectedTagId, setSelectedTagId] = useState<string | null>(null);
+  const [range, setRange] = useState<DateRangeState>(ALL_TIME);
+
+  // ac-12: bulk expand/collapse. The nonce bumps on every click so each row's
+  // effect re-applies `open`; per-row toggling still wins until the next click.
+  const [bulk, setBulk] = useState<{ open: boolean; nonce: number }>({ open: false, nonce: 0 });
+  const toggleAll = () => setBulk((b) => ({ open: !b.open, nonce: b.nonce + 1 }));
+
+  const filters = useMemo(
+    () => ({ tagId: selectedTagId ?? undefined, from: range.from, to: range.to }),
+    [selectedTagId, range.from, range.to],
+  );
+  const facetWindow = useMemo(() => ({ from: range.from, to: range.to }), [range.from, range.to]);
+
+  const { rows, loading, error, hasMore, loadOlder, refresh } = useQaReportsFeed(filters);
+  const { facets, loading: facetsLoading } = useQaReportTagFacets(facetWindow);
 
   // ac-24: the unread boundary — the viewer's PREVIOUS last_viewed_at, captured
-  // from the view receipt (opening the page is what resets the marker, so the
-  // receipt is the only place the old value survives).
-  //   undefined        → receipt still in flight (hold the list so rows don't
-  //                      initialise collapsed and then refuse to open)
-  //   { prev: null }   → first-ever view: everything is unread → all open
-  //   { prev: ISO }    → rows newer than it are unread → open
-  //   { prev: 'all' }  → marker unavailable (anonymous / failure): no per-user
-  //                      unread concept → all collapsed
+  // from the view receipt (opening the page resets the marker, so the receipt is
+  // the only place the old value survives). See the hook for the sentinel meanings.
   const [boundary, setBoundary] = useState<{ prev: string | null | 'all' } | undefined>(undefined);
 
-  // Opening the page = viewing the feed: upsert the per-user marker (dec-6),
-  // which zeroes the nav badge, and keep its receipt as the unread boundary.
   useEffect(() => {
     let cancelled = false;
     void recordQaReportsView().then((receipt) => {
@@ -114,12 +193,12 @@ export function QaReports() {
     return row.createdAt > boundary.prev;
   };
 
-  // Live updates: a new report lands on the std-8 bus as a section event —
-  // refetch the first page so it appears without a reload (debounced upstream).
+  // Live updates: a new report lands on the std-8 bus as a section event — refetch
+  // the first page so it appears without a reload (debounced upstream).
   useDocChangeStream(null, refresh);
 
   return (
-    <div className="px-6 py-4 max-w-3xl">
+    <div className="px-6 py-4">
       <PageHeader title="QA Reports" />
       <p className="text-sm text-muted mb-4">
         What each build session changed, written for a reviewer — one report per
@@ -132,35 +211,62 @@ export function QaReports() {
         </div>
       )}
 
-      {(loading && rows.length === 0) || boundary === undefined ? (
-        <div data-testid="qa-reports-loading" className="text-sm text-muted py-8 text-center">
-          Loading…
-        </div>
-      ) : rows.length === 0 ? (
-        <div data-testid="qa-reports-empty" className="text-sm text-muted py-8 text-center">
-          No QA reports yet — one is generated each time a build session hands off to
-          verify.
-        </div>
-      ) : (
-        <ul data-testid="qa-reports-list" className="space-y-3">
-          {rows.map((row) => (
-            <FeedRow key={row.id} row={row} defaultOpen={isUnread(row)} />
-          ))}
-        </ul>
-      )}
+      <div className="flex items-start gap-6">
+        <QaReportsFilterRail
+          facets={facets}
+          loading={facetsLoading}
+          selectedTagId={selectedTagId}
+          onSelectTag={setSelectedTagId}
+          range={range}
+          onChangeRange={setRange}
+        />
 
-      {hasMore && (
-        <div className="mt-4 text-center">
-          <button
-            type="button"
-            data-testid="qa-reports-load-more"
-            onClick={() => void loadOlder()}
-            className="text-sm text-secondary hover:text-primary px-3 py-1.5 rounded-md border border-edge hover:bg-overlay"
-          >
-            Load More
-          </button>
+        <div className="min-w-0 flex-1 max-w-3xl">
+          {(loading && rows.length === 0) || boundary === undefined ? (
+            <div data-testid="qa-reports-loading" className="text-sm text-muted py-8 text-center">
+              Loading…
+            </div>
+          ) : rows.length === 0 ? (
+            <div data-testid="qa-reports-empty" className="text-sm text-muted py-8 text-center">
+              {selectedTagId !== null || range.preset !== 'all'
+                ? 'No QA reports match the current filter.'
+                : 'No QA reports yet — one is generated each time a build session hands off to verify.'}
+            </div>
+          ) : (
+            <>
+              <div className="mb-2 flex justify-end">
+                <button
+                  type="button"
+                  data-testid="qa-reports-expand-all"
+                  aria-pressed={bulk.open}
+                  onClick={toggleAll}
+                  className="text-xs text-secondary hover:text-primary"
+                >
+                  {bulk.open ? 'Collapse all' : 'Expand all'}
+                </button>
+              </div>
+              <ul data-testid="qa-reports-list" className="space-y-3">
+                {rows.map((row) => (
+                  <FeedRow key={row.id} row={row} defaultOpen={isUnread(row)} bulk={bulk} />
+                ))}
+              </ul>
+            </>
+          )}
+
+          {hasMore && (
+            <div className="mt-4 text-center">
+              <button
+                type="button"
+                data-testid="qa-reports-load-more"
+                onClick={() => void loadOlder()}
+                className="text-sm text-secondary hover:text-primary px-3 py-1.5 rounded-md border border-edge hover:bg-overlay"
+              >
+                Load More
+              </button>
+            </div>
+          )}
         </div>
-      )}
+      </div>
     </div>
   );
 }

--- a/packages/ui/src/utils/timeAgo.test.ts
+++ b/packages/ui/src/utils/timeAgo.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { timeAgo } from './timeAgo';
+
+// spec-286: the feed's relative-time helper. `now` is injected so the ladder is
+// deterministic without faking the clock.
+const NOW = new Date('2026-06-13T12:00:00Z');
+const ago = (ms: number) => new Date(NOW.getTime() - ms).toISOString();
+
+const MIN = 60_000;
+const HOUR = 60 * MIN;
+const DAY = 24 * HOUR;
+const WEEK = 7 * DAY;
+
+describe('timeAgo', () => {
+  it('reads "just now" under a minute (and clamps small future skew)', () => {
+    expect(timeAgo(ago(30_000), NOW)).toBe('just now');
+    expect(timeAgo(new Date(NOW.getTime() + 5_000).toISOString(), NOW)).toBe('just now');
+  });
+
+  it('coarsens through minutes, hours, days, weeks', () => {
+    expect(timeAgo(ago(5 * MIN), NOW)).toBe('5m ago');
+    expect(timeAgo(ago(3 * HOUR), NOW)).toBe('3h ago');
+    expect(timeAgo(ago(2 * DAY), NOW)).toBe('2d ago');
+    expect(timeAgo(ago(5 * WEEK), NOW)).toBe('5w ago');
+  });
+
+  it('falls back to an absolute date beyond ~8 weeks', () => {
+    expect(timeAgo(ago(10 * WEEK), NOW)).toMatch(/\d{4}$/); // ends in a year
+  });
+
+  it('returns empty string for an unparseable input', () => {
+    expect(timeAgo('not-a-date', NOW)).toBe('');
+  });
+});

--- a/packages/ui/src/utils/timeAgo.ts
+++ b/packages/ui/src/utils/timeAgo.ts
@@ -1,0 +1,39 @@
+// spec-286: a compact relative-time helper for the QA Reports feed metadata line.
+//
+// The existing utils stop short of what the feed needs: `formatDate` (utils/format)
+// is an absolute date and `relativeDays` (DoneSummary) only has day granularity.
+// A QA report generated "2h ago" should read that way, not "today" or "12 Jun 2026".
+//
+// Granularity ladder (coarsening as it ages): just now → Nm → Nh → Nd → Nw, then it
+// falls back to an absolute date so "63w ago" never appears. Always past-tense — a
+// report's createdAt is in the past; a (clock-skew) future instant clamps to "just now".
+
+const MINUTE = 60_000;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+const WEEK = 7 * DAY;
+
+function absoluteDate(date: Date): string {
+  return date.toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' });
+}
+
+/**
+ * Format `iso` as a short relative time from `now` (default: the current time).
+ * `now` is injectable so tests are deterministic without faking the clock.
+ *
+ * Examples: "just now", "5m ago", "3h ago", "2d ago", "5w ago", then "12 Jun 2026".
+ */
+export function timeAgo(iso: string, now: Date = new Date()): string {
+  const then = new Date(iso);
+  if (Number.isNaN(then.getTime())) return '';
+
+  const diff = now.getTime() - then.getTime();
+  if (diff < MINUTE) return 'just now'; // includes small future skew (diff < 0)
+
+  if (diff < HOUR) return `${Math.floor(diff / MINUTE)}m ago`;
+  if (diff < DAY) return `${Math.floor(diff / HOUR)}h ago`;
+  if (diff < WEEK) return `${Math.floor(diff / DAY)}d ago`;
+  // Up to ~8 weeks stays relative; beyond that an absolute date is more legible.
+  if (diff < 8 * WEEK) return `${Math.floor(diff / WEEK)}w ago`;
+  return absoluteDate(then);
+}


### PR DESCRIPTION
## What & why

The workspace **QA Reports feed** (`/:namespace/:memex/qa-reports`, spec-260) read as a wall of text: each report's own markdown headings (`.prose-dark h1` = `text-3xl`) were visually larger than the name of the spec they belonged to — an inverted hierarchy with no attribution, no phase signal, and no way to navigate. This redesign (**spec-286**) fixes the hierarchy and adds a filter rail.

## Front-end

- **Spec leads each card** as an accent-coloured heading; the report body renders at a new **subordinate `.prose-qa` scale** below it (`.prose-dark` is untouched, so every other markdown surface is unchanged).
- **Metadata line:** phase pill (build = blue, verify = teal, **done = neutral grey**), **author**, **implementer** (only when different from author), relative **"time ago"**.
- **Sticky left rail** that stays put while the feed scrolls: a **tag tree rooted at "All"** with whole-corpus report counts (click to filter), plus **date filters** (last week / last month / custom from–to). Tag + date **compose with AND**; "All" + no date = unfiltered.
- **Expand all / Collapse all** control over the feed.

## Back-end

- `GET /qa-reports` rows **enriched** with `phase` (spec status), `author` (spec creator → name), and `tags[]`.
- `GET /qa-reports` accepts `tag` / `from` / `to`, **composing with the existing keyset `since` cursor** (filtered "Load More" stays correct).
- New **`GET /qa-reports/facets`** → `{ total, tags: [{id, scope, value, count}] }`, computed across the whole corpus (honours the date window).
- New env-gated **`/seed-tags`** test-surface endpoint (real `applyTagStrings`, no raw SQL).

No schema change, no migration, no new env. Backward-compatible: an un-parameterised feed request behaves as before (plus the new row fields).

## Decisions

- dec-1 / dec-2 / dec-3 resolved on the spec. **Refinement of dec-1:** "author = owner role" is realised as the **spec creator** (`documents.created_by_user_id`), since the schema has no distinct owner role — the creator is seeded as the sole `editor`.

## Testing

- **ACs ac-1…ac-12** each backed by an AC-tagged test (server integration, UI unit, e2e).
- Full **UI unit suite: 1292 passed** / 1 skipped. Full **server suite: 4003 passed**. Server + UI typecheck clean.
- New Playwright **journey-30** (enriched card + phase pill + tag filter with corpus counts + date filter) — green under `make e2e-cold`.
- Updated three spec-260/spec-252 tests for the intentional presentation/signature changes (relative time, no `·` separator, `who`→`implementer`, `useQaReportsFeed({}, 2)`, done now returns a grey pill).

🤖 Generated with [Claude Code](https://claude.com/claude-code)