### PR TITLE
Release: develop → main — specs 247, 282, 283, 285, 286, 287

### DIFF
--- a/packages/server/src/routes/__test__.ts
+++ b/packages/server/src/routes/__test__.ts
@@ -48,6 +48,7 @@ import { createExecutionPlan } from "../services/execution_plans.js";
 import { addTaskComment } from "../services/comments.js";
 import { createShareToken, listShareTokensForDoc } from "../services/share-tokens.js";
 import { addSection } from "../services/sections.js";
+import { applyTagStrings } from "../services/tags.js";
 import { resolveRole } from "../services/doc-members.js";
 import { listAssignees, assign } from "../services/doc-assignees.js";
 import { updateMemexVisibility } from "../services/memexes.js";
@@ -777,6 +778,25 @@ testOnlyRouter.post("/seed-section", async (c) => {
   const { memexId, docId, title, content = "", sectionType = "context" } = parsed.data;
   const section = await addSection(memexId, docId, sectionType, content, title);
   return c.json({ sectionId: section.id, seq: section.seq });
+});
+
+// spec-286: apply `scope::value`/flat tags to a Spec through the real
+// applyTagStrings service (create-or-pick + per-scope exclusivity), so the QA
+// Reports feed journey can seed the tags its rail filters on without raw SQL.
+const seedTagsSchema = z.object({
+  memexId: z.string().uuid(),
+  docId: z.string().uuid(),
+  tags: z.array(z.string()).min(1),
+});
+testOnlyRouter.post("/seed-tags", async (c) => {
+  const body = await c.req.json().catch(() => null);
+  const parsed = seedTagsSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: "Invalid request", details: parsed.error.issues }, 400);
+  }
+  const { memexId, docId, tags } = parsed.data;
+  const applied = await applyTagStrings({ channel: "rest_ui" }, memexId, docId, tags, null);
+  return c.json({ applied: applied.map((t) => ({ id: t.id, scope: t.scope, value: t.value })) });
 });
 
 // Resolve a user's role on a doc (editor / reviewer) through resolveRole — the

--- a/packages/server/src/routes/qa-reports.integration.test.ts
+++ b/packages/server/src/routes/qa-reports.integration.test.ts
@@ -272,6 +272,7 @@ type Facets = {
 
 describe("spec-286: enriched feed + tag/date filters + facets", () => {
   let path: string;
+  let authorUserId: string;
   let frontendTagId: string;
   let bugTagId: string;
   // specT (frontend + bug) reports, specU (frontend) report.
@@ -287,6 +288,7 @@ describe("spec-286: enriched feed + tag/date filters + facets", () => {
     // A distinct AUTHOR with a known name — different from the build IMPLEMENTER,
     // so the author≠implementer distinction is observable.
     const author = await upsertUserByEmail("author286@memex.ai");
+    authorUserId = author.id;
     await db.update(users).set({ name: "Ada Author" }).where(eq(users.id, author.id));
 
     const specT = await createDocDraft(
@@ -306,6 +308,14 @@ describe("spec-286: enriched feed + tag/date filters + facets", () => {
     rT1 = await seedReport(m.memexId, specT.id, "T session 1", new Date("2026-03-01T00:00:00Z"), builder);
     rU1 = await seedReport(m.memexId, specU.id, "U session 1", new Date("2026-03-02T00:00:00Z"), builder);
     rT2 = await seedReport(m.memexId, specT.id, "T session 2", new Date("2026-03-03T00:00:00Z"), builder);
+  });
+
+  // upsertUserByEmail inserts this author WITHOUT a namespace (it leaves that to
+  // the auth service), so leaving it behind would trip migration-smoke's
+  // "every active user has namespace_id" invariant on a shared worker clone.
+  // The docs that reference it are dropped by the file-level afterAll (FK SET NULL).
+  afterAll(async () => {
+    await db.delete(users).where(eq(users.id, authorUserId)).catch(() => {});
   });
 
   it("ac-6: each row carries phase, author (creator), and the owning Spec's tags", async () => {

--- a/packages/server/src/routes/qa-reports.integration.test.ts
+++ b/packages/server/src/routes/qa-reports.integration.test.ts
@@ -10,10 +10,11 @@ vi.hoisted(() => {
 });
 
 import { db } from "../db/connection.js";
-import { docSections, documents, memexes, qaReportViews } from "../db/schema.js";
+import { docSections, documents, memexes, qaReportViews, users } from "../db/schema.js";
 import { app } from "../app.js";
 import { createDocDraft } from "../services/documents.js";
 import { appendQaReport } from "../services/qa-reports.js";
+import { applyTagString } from "../services/tags.js";
 import { makeTestMemexWithDevAdmin } from "../services/test-helpers.js";
 import { upsertUserByEmail } from "../services/users.js";
 
@@ -243,5 +244,169 @@ describe("unread counter + view marker (dec-6)", () => {
     expect(resB.status).toBe(200);
     // Memex B has exactly one report and dev has never viewed B's feed.
     expect(await resB.json()).toEqual({ count: 1 });
+  });
+});
+
+// ─── spec-286: feed enrichment (phase/author/tags) + tag/date filters + facets ───
+//
+// A DEDICATED memex so the spec-260 ordering/count assertions above stay intact.
+// ac-6: each row enriched with phase, author (creator), and tags.
+// ac-8: tag + date-range query params, composing with the keyset `since` cursor.
+// ac-9: /facets returns whole-corpus per-tag counts + the "All" total.
+
+const AC_286_6 = "mindset-prod/memex-building-itself/specs/spec-286/acs/ac-6";
+const AC_286_8 = "mindset-prod/memex-building-itself/specs/spec-286/acs/ac-8";
+const AC_286_9 = "mindset-prod/memex-building-itself/specs/spec-286/acs/ac-9";
+
+type FeedRow286 = FeedRow & {
+  phase: string;
+  authorUserId: string | null;
+  authorName: string | null;
+  tags: { id: string; scope: string | null; value: string }[];
+};
+
+type Facets = {
+  total: number;
+  tags: { id: string; scope: string | null; value: string; count: number }[];
+};
+
+describe("spec-286: enriched feed + tag/date filters + facets", () => {
+  let path: string;
+  let frontendTagId: string;
+  let bugTagId: string;
+  // specT (frontend + bug) reports, specU (frontend) report.
+  let rT1: string; // 2026-03-01 — specT
+  let rU1: string; // 2026-03-02 — specU
+  let rT2: string; // 2026-03-03 — specT (newest)
+
+  beforeAll(async () => {
+    const m = await makeTestMemexWithDevAdmin("qa-feed-286");
+    path = `/api/${m.slug}/main`;
+    memexIds.push(m.memexId);
+
+    // A distinct AUTHOR with a known name — different from the build IMPLEMENTER,
+    // so the author≠implementer distinction is observable.
+    const author = await upsertUserByEmail("author286@memex.ai");
+    await db.update(users).set({ name: "Ada Author" }).where(eq(users.id, author.id));
+
+    const specT = await createDocDraft(
+      m.memexId, "Spec T", "Purpose", "spec", undefined, undefined, author.id,
+    );
+    const specU = await createDocDraft(
+      m.memexId, "Spec U", "Purpose", "spec", undefined, undefined, author.id,
+    );
+    createdDocIds.push(specT.id, specU.id);
+
+    const frontend = await applyTagString({}, m.memexId, specT.id, "area::frontend", author.id);
+    bugTagId = (await applyTagString({}, m.memexId, specT.id, "bug", author.id)).id;
+    frontendTagId = frontend.id;
+    await applyTagString({}, m.memexId, specU.id, "area::frontend", author.id);
+
+    const builder = { actorUserId: undefined, actorName: "Builder Bot" };
+    rT1 = await seedReport(m.memexId, specT.id, "T session 1", new Date("2026-03-01T00:00:00Z"), builder);
+    rU1 = await seedReport(m.memexId, specU.id, "U session 1", new Date("2026-03-02T00:00:00Z"), builder);
+    rT2 = await seedReport(m.memexId, specT.id, "T session 2", new Date("2026-03-03T00:00:00Z"), builder);
+  });
+
+  it("ac-6: each row carries phase, author (creator), and the owning Spec's tags", async () => {
+    tagAc(AC_286_6);
+
+    const res = await app.request(`${path}/qa-reports`, withApexHost());
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as FeedRow286[];
+    expect(body.map((r) => r.id)).toEqual([rT2, rU1, rT1]);
+
+    const top = body[0]!; // rT2 on specT
+    expect(top.phase).toBe("draft"); // createDocDraft → draft
+    expect(top.authorName).toBe("Ada Author"); // the creator
+    expect(top.actorName).toBe("Builder Bot"); // the implementer — distinct from author
+    expect(top.tags.map((t) => (t.scope ? `${t.scope}::${t.value}` : t.value)).sort()).toEqual(
+      ["area::frontend", "bug"],
+    );
+
+    // specU's report carries only the frontend tag.
+    const uRow = body.find((r) => r.id === rU1)!;
+    expect(uRow.tags.map((t) => `${t.scope}::${t.value}`)).toEqual(["area::frontend"]);
+  });
+
+  it("ac-8: tag filter narrows to reports whose Spec carries the tag, and composes with keyset `since`", async () => {
+    tagAc(AC_286_8);
+
+    // Filter by `bug` → only specT's two reports, newest-first.
+    const bugRes = await app.request(`${path}/qa-reports?tag=${bugTagId}`, withApexHost());
+    expect(bugRes.status).toBe(200);
+    expect(((await bugRes.json()) as FeedRow286[]).map((r) => r.id)).toEqual([rT2, rT1]);
+
+    // Filtered Load More: limit=1 then since=boundary stays within the filter.
+    const page1 = (await (
+      await app.request(`${path}/qa-reports?tag=${bugTagId}&limit=1`, withApexHost())
+    ).json()) as FeedRow286[];
+    expect(page1.map((r) => r.id)).toEqual([rT2]);
+    const since = page1[0]!.createdAt;
+    const page2 = (await (
+      await app.request(
+        `${path}/qa-reports?tag=${bugTagId}&limit=1&since=${encodeURIComponent(since)}`,
+        withApexHost(),
+      )
+    ).json()) as FeedRow286[];
+    expect(page2.map((r) => r.id)).toEqual([rT1]);
+
+    // Frontend tag spans both Specs → all three reports.
+    const feRes = await app.request(`${path}/qa-reports?tag=${frontendTagId}`, withApexHost());
+    expect(((await feRes.json()) as FeedRow286[]).map((r) => r.id)).toEqual([rT2, rU1, rT1]);
+  });
+
+  it("ac-8: date window (from/to) narrows the feed and ANDs with the tag filter", async () => {
+    tagAc(AC_286_8);
+
+    // from = 2026-03-02 → drops rT1 (03-01).
+    const fromRes = await app.request(
+      `${path}/qa-reports?from=${encodeURIComponent("2026-03-02T00:00:00Z")}`,
+      withApexHost(),
+    );
+    expect(((await fromRes.json()) as FeedRow286[]).map((r) => r.id)).toEqual([rT2, rU1]);
+
+    // tag=bug AND from=2026-03-02 → only rT2 (rT1 is bug but pre-window; rU1 in window but not bug).
+    const andRes = await app.request(
+      `${path}/qa-reports?tag=${bugTagId}&from=${encodeURIComponent("2026-03-02T00:00:00Z")}`,
+      withApexHost(),
+    );
+    expect(((await andRes.json()) as FeedRow286[]).map((r) => r.id)).toEqual([rT2]);
+  });
+
+  it("ac-9: /facets returns whole-corpus per-tag counts and the All total", async () => {
+    tagAc(AC_286_9);
+
+    const res = await app.request(`${path}/qa-reports/facets`, withApexHost());
+    expect(res.status).toBe(200);
+    const facets = (await res.json()) as Facets;
+
+    // All = every report in the corpus (3), independent of pagination.
+    expect(facets.total).toBe(3);
+
+    const byKey = new Map(
+      facets.tags.map((t) => [t.scope ? `${t.scope}::${t.value}` : t.value, t.count]),
+    );
+    // frontend on specT(2)+specU(1) = 3; bug on specT(2) = 2.
+    expect(byKey.get("area::frontend")).toBe(3);
+    expect(byKey.get("bug")).toBe(2);
+    // Ordered by count desc → frontend before bug.
+    expect(facets.tags[0]!.value).toBe("frontend");
+  });
+
+  it("ac-9: facet counts honour the date window (consistent with an active date filter)", async () => {
+    tagAc(AC_286_9);
+
+    const res = await app.request(
+      `${path}/qa-reports/facets?from=${encodeURIComponent("2026-03-02T00:00:00Z")}`,
+      withApexHost(),
+    );
+    const facets = (await res.json()) as Facets;
+    expect(facets.total).toBe(2); // rU1 + rT2
+    const byKey = new Map(
+      facets.tags.map((t) => [t.scope ? `${t.scope}::${t.value}` : t.value, t.count]),
+    );
+    expect(byKey.get("area::frontend")).toBe(2); // rU1 + rT2
+    expect(byKey.get("bug")).toBe(1); // rT2 only
   });
 });

--- a/packages/server/src/routes/qa-reports.ts
+++ b/packages/server/src/routes/qa-reports.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import {
   countUnreadQaReports,
   listQaReports,
+  qaReportTagFacets,
   recordQaReportsView,
 } from "../services/qa-reports.js";
 import { NotFoundError, ValidationError } from "../types/errors.js";
@@ -44,38 +45,64 @@ function parsePositiveInt(raw: string | undefined, field: string): number | unde
   return n;
 }
 
-function parseSince(raw: string | undefined): Date | undefined {
+function parseTimestamp(raw: string | undefined, field: string): Date | undefined {
   if (raw === undefined) return undefined;
   const d = new Date(raw);
   if (Number.isNaN(d.getTime())) {
-    throw new ValidationError("Query param 'since' must be an ISO-8601 timestamp");
+    throw new ValidationError(`Query param '${field}' must be an ISO-8601 timestamp`);
   }
   return d;
 }
 
 // GET /api/<ns>/<mx>/qa-reports — the feed.
 //
-// Query params (both optional):
-//   limit — page size (default 50, capped 200 by listQaReports)
-//   since — ISO-8601 keyset boundary; returns rows strictly OLDER ("Load More")
+// Query params (all optional):
+//   limit      — page size (default 50, capped 200 by listQaReports)
+//   since      — ISO-8601 keyset boundary; returns rows strictly OLDER ("Load More")
+//   tag        — tag id; restrict to reports whose owning Spec carries it (spec-286)
+//   from / to  — ISO-8601 date window; restrict to reports generated within it
+//                (spec-286). tag + (from/to) compose with AND.
 qaReports.get("/", async (c) => {
   const memexId = await resolveReadableMemexId(c);
   const limit = parsePositiveInt(c.req.query("limit"), "limit");
-  const since = parseSince(c.req.query("since"));
+  const since = parseTimestamp(c.req.query("since"), "since");
+  const tagId = c.req.query("tag") || undefined;
+  const from = parseTimestamp(c.req.query("from"), "from");
+  const to = parseTimestamp(c.req.query("to"), "to");
 
-  const rows = await listQaReports({ memexId, limit, since });
+  const rows = await listQaReports({ memexId, limit, since, tagId, from, to });
 
   // Anonymous / non-member projection (the routes/activity.ts convention):
-  // actor_user_id is PII and actor_name a display identity — both are dropped
-  // on the public-read path; actorKind keeps the row legible.
+  // actor_*/author_* are PII / display identity — dropped on the public-read path;
+  // actorKind, phase, and tags stay so the row is still legible + filterable.
   const accessLevel = c.get("currentAccessLevel");
   if (accessLevel !== "write") {
     return c.json(
-      rows.map(({ actorUserId: _u, actorName: _n, ...row }) => row),
+      rows.map(
+        ({
+          actorUserId: _au,
+          actorName: _an,
+          authorUserId: _ru,
+          authorName: _rn,
+          ...row
+        }) => row,
+      ),
     );
   }
 
   return c.json(rows);
+});
+
+// GET /api/<ns>/<mx>/qa-reports/facets — the filter rail's tag tree (spec-286).
+// Returns { total, tags: [{ id, scope, value, count }] } over the WHOLE corpus
+// (not the loaded page), honouring an optional from/to window so the counts stay
+// consistent with an active date filter (AND semantics).
+qaReports.get("/facets", async (c) => {
+  const memexId = await resolveReadableMemexId(c);
+  const from = parseTimestamp(c.req.query("from"), "from");
+  const to = parseTimestamp(c.req.query("to"), "to");
+  const facets = await qaReportTagFacets({ memexId, from, to });
+  return c.json(facets);
 });
 
 // GET /api/<ns>/<mx>/qa-reports/unread — the caller's unread count. Per-user by

--- a/packages/server/src/routes/search.integration.test.ts
+++ b/packages/server/src/routes/search.integration.test.ts
@@ -53,6 +53,9 @@ interface ContentHit {
   matchingSections: Array<{ id: string; sectionType: string }>;
   id?: unknown;
   parentDocId?: unknown;
+  // spec-285: WHO/WHEN ride through the Omit projection into the wire shape.
+  authorName?: string | null;
+  lastUpdatedAt?: string | null;
 }
 
 interface SearchEnvelope {
@@ -402,5 +405,48 @@ describe("spec-191 — number jump is additive to jumpTo; content tier unchanged
       h.path.endsWith(`/specs/${numSpec.handle}`),
     );
     expect(inContent).toBeUndefined();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// spec-285 ac-3: the WHO/WHEN metadata added to MemexSearchHit rides through
+// the REST route's `SearchContentHit = Omit<MemexSearchHit, "id"|"parentDocId">`
+// projection with NO route change — every content hit exposes `authorName` and
+// `lastUpdatedAt`, and a resolvable created_by surfaces a real name + ISO date.
+// ─────────────────────────────────────────────────────────────────────────
+const SPEC285_AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-285/acs/ac-${n}`;
+
+describe("spec-285 — REST search inherits author + timestamp (ac-3)", () => {
+  it("every content hit exposes authorName + lastUpdatedAt, populated from created_by", async () => {
+    tagAc(SPEC285_AC(3));
+    const devUser = await upsertUserByEmail("dev@memex.ai");
+    const expectedDisplay = devUser.name?.trim() || devUser.email;
+
+    // Stamp a resolvable author on the token-bearing docs so the resolution path
+    // (created_by_user_id → users.name ?? email) produces a concrete value.
+    await db
+      .update(documents)
+      .set({ createdByUserId: devUser.id })
+      .where(inArray(documents.id, createdDocIds));
+
+    const res = await req(searchUrl({ q: TOKEN }));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as SearchEnvelope & {
+      content: Array<ContentHit & { authorName?: unknown; lastUpdatedAt?: unknown }>;
+    };
+    expect(body.content.length).toBeGreaterThan(0);
+
+    for (const hit of body.content) {
+      // Inheritance through Omit: the new fields are present on the wire shape.
+      expect(hit).toHaveProperty("authorName");
+      expect(hit).toHaveProperty("lastUpdatedAt");
+    }
+
+    // At least one hit resolved the stamped author to a concrete display + ISO date.
+    const populated = body.content.find((h) => h.authorName === expectedDisplay);
+    expect(populated).toBeDefined();
+    expect(typeof populated!.lastUpdatedAt).toBe("string");
+    expect(() => new Date(populated!.lastUpdatedAt as string).toISOString()).not.toThrow();
   });
 });

--- a/packages/server/src/services/memex-search.integration.test.ts
+++ b/packages/server/src/services/memex-search.integration.test.ts
@@ -19,6 +19,7 @@ import { createDocDraft } from "./documents.js";
 import { addSection } from "./sections.js";
 import { createDecision, resolveDecision } from "./decisions.js";
 import { createIssue, type IssueType } from "./issues.js";
+import { upsertUserByEmail } from "./users.js";
 import {
   embedAndStoreDoc,
   embedAndStoreDecision,
@@ -605,6 +606,8 @@ describe("formatSearchResults — issue hit rendering (spec-112 t-4)", () => {
         status: "open",
         score: 0.27,
         strategies: ["fts"],
+        authorName: null,
+        lastUpdatedAt: null,
         matchingSections: [],
         issueSnippet: "Clicking the login button does nothing.",
         issueMatchedVia: "fts",
@@ -791,6 +794,8 @@ describe("formatSearchResults — b-34 D-4 spec", () => {
         status: "specify",
         score: 0.42,
         strategies: ["fts", "vector"],
+        authorName: null,
+        lastUpdatedAt: null,
         matchingSections: [
           {
             id: "00000000-0000-0000-0000-000000000010",
@@ -810,6 +815,8 @@ describe("formatSearchResults — b-34 D-4 spec", () => {
         status: "resolved",
         score: 0.31,
         strategies: ["fts"],
+        authorName: null,
+        lastUpdatedAt: null,
         matchingSections: [],
         decisionSnippet: "Resolved: do the thing.",
         decisionMatchedVia: "fts",
@@ -837,6 +844,8 @@ describe("formatSearchResults — b-34 D-4 spec", () => {
       status: "specify",
       score: 0.42,
       strategies: ["fts"],
+      authorName: null,
+      lastUpdatedAt: null,
       matchingSections: [],
     };
     expect(formatSearchResults("q", [hit])).not.toContain("score 0.420");
@@ -854,6 +863,8 @@ describe("formatSearchResults — b-34 D-4 spec", () => {
       status: "published",
       score: 0.1,
       strategies: ["fts"],
+      authorName: null,
+      lastUpdatedAt: null,
       matchingSections: [
         {
           id: "00000000-0000-0000-0000-000000000010",
@@ -980,6 +991,8 @@ describe("formatSearchResults — [current doc] tag (includeCurrentDoc opt-in)",
       status: "specify",
       score: 0.5,
       strategies: ["fts"],
+      authorName: null,
+      lastUpdatedAt: null,
       matchingSections: [
         {
           id: "00000000-0000-0000-0000-0000000000bb",
@@ -1009,6 +1022,8 @@ describe("formatSearchResults — [current doc] tag (includeCurrentDoc opt-in)",
       status: "resolved",
       score: 0.4,
       strategies: ["fts"],
+      authorName: null,
+      lastUpdatedAt: null,
       matchingSections: [],
       decisionSnippet: "Snippet.",
       decisionMatchedVia: "fts",
@@ -1029,6 +1044,8 @@ describe("formatSearchResults — [current doc] tag (includeCurrentDoc opt-in)",
       status: "specify",
       score: 0.3,
       strategies: ["fts"],
+      authorName: null,
+      lastUpdatedAt: null,
       matchingSections: [],
     };
 
@@ -1197,5 +1214,307 @@ describe("resolveJumpTo — number / short-handle jump (spec-191)", () => {
       (h) => h.id === specId && h.strategies.includes("handle"),
     );
     expect(handleHit).toBeUndefined();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// spec-285: author (WHO) + last-changed (WHEN) on every search hit.
+//   - dec-1: decision/section hits use the denormalised actor_name; document &
+//     issue hits resolve created_by_user_id → users.name ?? email.
+//   - dec-2: one timestamp per hit — last-modified where present, created_at
+//     fallback (decisions have no updated_at).
+//   - dec-3 / ac-8: formatSearchResults renders ` · <author>, <YYYY-MM-DD>` so
+//     the MCP tool AND the React agent (which reuse the same handler) see it.
+// ═══════════════════════════════════════════════════════════════════════════
+
+const SPEC285_AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-285/acs/ac-${n}`;
+
+const ISO_RE = /^\d{4}-\d{2}-\d{2}T/;
+
+describe("formatSearchResults — WHO/WHEN byline (spec-285 ac-8)", () => {
+  const base: MemexSearchHit = {
+    id: "00000000-0000-0000-0000-000000000001",
+    parentDocId: "00000000-0000-0000-0000-000000000001",
+    kind: "spec",
+    path: "ns/mx/specs/spec-7",
+    title: "A spec",
+    status: "build",
+    score: 0.5,
+    strategies: ["fts"],
+    matchingSections: [],
+    authorName: null,
+    lastUpdatedAt: null,
+  };
+
+  it("renders ` · <author>, <YYYY-MM-DD>` when both are present", () => {
+    tagAc(SPEC285_AC(8));
+    const out = formatSearchResults("q", [
+      { ...base, authorName: "Ada Lovelace", lastUpdatedAt: "2026-05-28T09:30:00.000Z" },
+    ]);
+    expect(out).toContain(`(spec, build) · Ada Lovelace, 2026-05-28`);
+    // No UUIDs in the rendered output (b-36 D-7 still holds).
+    const uuidRegex = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i;
+    expect(out).not.toMatch(uuidRegex);
+  });
+
+  it("renders author alone when there is no timestamp", () => {
+    tagAc(SPEC285_AC(8));
+    const out = formatSearchResults("q", [{ ...base, authorName: "Grace Hopper" }]);
+    expect(out).toContain(`(spec, build) · Grace Hopper`);
+    expect(out).not.toContain("Grace Hopper,"); // no trailing comma/date
+  });
+
+  it("renders the date alone when there is no author", () => {
+    tagAc(SPEC285_AC(8));
+    const out = formatSearchResults("q", [
+      { ...base, lastUpdatedAt: "2026-01-02T00:00:00.000Z" },
+    ]);
+    expect(out).toContain(`(spec, build) · 2026-01-02`);
+  });
+
+  it("emits NO byline when neither author nor timestamp is set", () => {
+    tagAc(SPEC285_AC(8));
+    const out = formatSearchResults("q", [base]);
+    const headingLine = out.split("\n").find((l) => l.startsWith("### "));
+    expect(headingLine).toBeDefined();
+    expect(headingLine).not.toContain(" · ");
+    expect(headingLine).toContain(`(spec, build)`);
+  });
+});
+
+describe("searchMemex — author + timestamp population (spec-285 ac-6/ac-7)", () => {
+  it("decision hits carry the denormalised actor_name + created_at (dec-1/dec-2)", async () => {
+    tagAc(SPEC285_AC(6));
+    tagAc(SPEC285_AC(7));
+    const provider = makeFakeProvider("fake-author-decision");
+    const spec = await seedSpec(memexId, "Author decision host", "Body.", [], provider);
+    const dec = await seedDecision(
+      memexId,
+      spec,
+      "authordecisionuniquetokenx approach",
+      "Context.",
+      "Resolved.",
+      provider,
+    );
+    // Stamp a denormalised WHO the way the write path would (std-32).
+    await db.execute(
+      sql`UPDATE decisions SET actor_name = 'Ada Lovelace', actor_user_id = NULL WHERE id = ${dec.id}`,
+    );
+
+    const hits = await searchMemex(memexId, "authordecisionuniquetokenx", {
+      provider,
+      kind: "decision",
+      disableVector: true,
+    });
+    const hit = hits.find((h) => h.id === dec.id);
+    expect(hit).toBeDefined();
+    expect(hit!.authorName).toBe("Ada Lovelace");
+    // WHEN is the decision's created_at (no updated_at column), as an ISO string.
+    expect(hit!.lastUpdatedAt).toMatch(ISO_RE);
+  });
+
+  it("section/doc hits prefer the section's denormalised actor_name (dec-1)", async () => {
+    tagAc(SPEC285_AC(6));
+    const provider = makeFakeProvider("fake-author-section");
+    const spec = await seedSpec(
+      memexId,
+      "Author section host",
+      "authorsectionuniquetokenx content here.",
+      [],
+      provider,
+    );
+    await db.execute(
+      sql`UPDATE doc_sections SET actor_name = 'Grace Hopper' WHERE doc_id = ${spec.id}`,
+    );
+
+    const hits = await searchMemex(memexId, "authorsectionuniquetokenx", {
+      provider,
+      disableVector: true,
+    });
+    const hit = hits.find((h) => h.id === spec.id);
+    expect(hit).toBeDefined();
+    expect(hit!.authorName).toBe("Grace Hopper");
+    expect(hit!.lastUpdatedAt).toMatch(ISO_RE);
+  });
+
+  it("doc hits with no section actor_name resolve created_by_user_id → name (dec-1)", async () => {
+    tagAc(SPEC285_AC(6));
+    const provider = makeFakeProvider("fake-author-docfallback");
+    const author = await upsertUserByEmail("ada.author@example.com");
+    const spec = await seedSpec(
+      memexId,
+      "Author doc-fallback host",
+      "authordocfallbackuniquetokenx content here.",
+      [],
+      provider,
+    );
+    // No section actor_name → fall back to the resolved document creator.
+    await db.execute(
+      sql`UPDATE doc_sections SET actor_name = NULL WHERE doc_id = ${spec.id}`,
+    );
+    await db.execute(
+      sql`UPDATE documents SET created_by_user_id = ${author.id} WHERE id = ${spec.id}`,
+    );
+
+    const hits = await searchMemex(memexId, "authordocfallbackuniquetokenx", {
+      provider,
+      disableVector: true,
+    });
+    const hit = hits.find((h) => h.id === spec.id);
+    expect(hit).toBeDefined();
+    // upsertUserByEmail sets no display name, so the resolver falls to email.
+    expect(hit!.authorName).toBe("ada.author@example.com");
+  });
+
+  it("issue hits resolve created_by_user_id → name + carry updated_at (dec-1/dec-2)", async () => {
+    tagAc(SPEC285_AC(6));
+    tagAc(SPEC285_AC(7));
+    const provider = makeFakeProvider("fake-author-issue");
+    const author = await upsertUserByEmail("grace.issue@example.com");
+    const spec = await seedSpec(memexId, "Author issue host", "Body.", [], provider);
+    const issue = await seedIssue(
+      memexId,
+      spec,
+      "authorissueuniquetokenx regression",
+      "An issue with a resolvable author.",
+      "bug",
+      provider,
+    );
+    await db.execute(
+      sql`UPDATE issues SET created_by_user_id = ${author.id} WHERE id = ${issue.id}`,
+    );
+
+    const hits = await searchMemex(memexId, "authorissueuniquetokenx", {
+      provider,
+      kind: "issue",
+      disableVector: true,
+    });
+    const hit = hits.find((h) => h.id === issue.id);
+    expect(hit).toBeDefined();
+    expect(hit!.authorName).toBe("grace.issue@example.com");
+    expect(hit!.lastUpdatedAt).toMatch(ISO_RE);
+  });
+});
+
+describe("searchMemex → formatSearchResults — end-to-end byline (spec-285 ac-1/ac-2)", () => {
+  it("a real decision search renders WHO/WHEN in the markdown the MCP + React agents read", async () => {
+    tagAc(SPEC285_AC(1));
+    tagAc(SPEC285_AC(2));
+    const provider = makeFakeProvider("fake-author-e2e");
+    const spec = await seedSpec(memexId, "E2E byline host", "Body.", [], provider);
+    const dec = await seedDecision(
+      memexId,
+      spec,
+      "authore2euniquetokenx approach",
+      "Context.",
+      "Resolved.",
+      provider,
+    );
+    await db.execute(
+      sql`UPDATE decisions SET actor_name = 'Ada Lovelace', actor_user_id = NULL WHERE id = ${dec.id}`,
+    );
+
+    // The exact path the MCP search_memex handler runs — and the React UI agent
+    // reuses this same handler via executeToolRemote (spec-285 Architecture
+    // finding 1), so a passing render here proves both agent surfaces (ac-2).
+    const hits = await searchMemex(memexId, "authore2euniquetokenx", {
+      provider,
+      kind: "decision",
+      disableVector: true,
+    });
+    const out = formatSearchResults("authore2euniquetokenx", hits);
+    expect(out).toContain("Ada Lovelace");
+    expect(out).toMatch(/· Ada Lovelace, \d{4}-\d{2}-\d{2}/);
+  });
+});
+
+describe("spec-285 — additive, non-breaking, single-source (ac-4)", () => {
+  it("a hit with no author/timestamp renders the exact legacy heading (no stray byline)", () => {
+    tagAc(SPEC285_AC(4));
+    // An existing consumer's hit (pre-285 shape, nulls for the new fields) must
+    // render byte-identically to before — additive change, no regression.
+    const legacy: MemexSearchHit = {
+      id: "00000000-0000-0000-0000-000000000001",
+      parentDocId: "00000000-0000-0000-0000-000000000001",
+      kind: "standard",
+      path: "ns/mx/standards/std-3",
+      title: "A standard",
+      status: "published",
+      score: 0.2,
+      strategies: ["fts"],
+      matchingSections: [
+        {
+          id: "00000000-0000-0000-0000-000000000010",
+          sectionType: "do",
+          title: "Do",
+          content: "Some rule.",
+          matchedVia: "fts",
+        },
+      ],
+      authorName: null,
+      lastUpdatedAt: null,
+    };
+    const out = formatSearchResults("q", [legacy]);
+    // Heading is the legacy format exactly — no ` · ` byline appended.
+    expect(out).toContain(`### ns/mx/standards/std-3 — "A standard" (standard, published)`);
+    const headingLine = out.split("\n").find((l) => l.startsWith("### "))!;
+    expect(headingLine.endsWith("(standard, published)")).toBe(true);
+    // Section rendering is untouched.
+    expect(out).toContain(`- Section "Do" (fts):`);
+    expect(out).toContain(`  > Some rule.`);
+  });
+
+  it("the new fields are part of MemexSearchHit (single source) so REST inherits them", () => {
+    tagAc(SPEC285_AC(4));
+    // Both new fields live on MemexSearchHit itself — the REST route's
+    // SearchContentHit = Omit<MemexSearchHit,"id"|"parentDocId"> therefore
+    // inherits them with no separate type to keep in sync (single source).
+    const hit: MemexSearchHit = {
+      id: "00000000-0000-0000-0000-000000000001",
+      parentDocId: "00000000-0000-0000-0000-000000000001",
+      kind: "spec",
+      path: "ns/mx/specs/spec-1",
+      title: "T",
+      status: "build",
+      score: 0.1,
+      strategies: ["fts"],
+      matchingSections: [],
+      authorName: "Ada Lovelace",
+      lastUpdatedAt: "2026-05-28T00:00:00.000Z",
+    };
+    // Structurally present on the hit shape that the REST projection spreads.
+    expect(Object.prototype.hasOwnProperty.call(hit, "authorName")).toBe(true);
+    expect(Object.prototype.hasOwnProperty.call(hit, "lastUpdatedAt")).toBe(true);
+  });
+});
+
+describe("spec-285 — legible in both surfaces: markdown AND structured (ac-5)", () => {
+  it("renders a human byline in markdown while keeping discrete structured fields", () => {
+    tagAc(SPEC285_AC(5));
+    const hit: MemexSearchHit = {
+      id: "00000000-0000-0000-0000-000000000001",
+      parentDocId: "00000000-0000-0000-0000-000000000001",
+      kind: "decision",
+      path: "ns/mx/specs/spec-1/decisions/dec-2",
+      title: "A decision",
+      status: "resolved",
+      score: 0.3,
+      strategies: ["fts"],
+      matchingSections: [],
+      decisionSnippet: "Resolved: do the thing.",
+      decisionMatchedVia: "fts",
+      authorName: "Ryan Soosayraj",
+      lastUpdatedAt: "2026-05-28T12:00:00.000Z",
+    };
+
+    // Surface 1 — the MCP/React-agent markdown: human-readable "name, date".
+    const md = formatSearchResults("q", [hit]);
+    expect(md).toMatch(/· Ryan Soosayraj, 2026-05-28/);
+
+    // Surface 2 — the structured field the React agent / REST consume: discrete,
+    // not buried in prose. An agent can cite "<name>, <date>" without parsing.
+    expect(hit.authorName).toBe("Ryan Soosayraj");
+    expect(hit.lastUpdatedAt!.slice(0, 10)).toBe("2026-05-28");
   });
 });

--- a/packages/server/src/services/memex-search.ts
+++ b/packages/server/src/services/memex-search.ts
@@ -186,6 +186,19 @@ export interface MemexSearchHit {
    *  used to detect self-hits when the caller passes `currentDocId` to the
    *  formatter. */
   parentDocId: string;
+  /** WHO — best-effort display name of who authored / last touched this hit
+   *  (spec-285 dec-1). For decision/section hits this is the denormalised
+   *  std-32 `actor_name` where present (rename-proof); for document and issue
+   *  hits, the `created_by_user_id` resolved to `users.name ?? users.email`.
+   *  null when nothing resolved (a system write, a deleted user, a legacy
+   *  unattributed row). Navigation-only lanes (jump / assigned) leave it null. */
+  authorName: string | null;
+  /** WHEN — ISO-8601 timestamp of when this hit was last changed (spec-285
+   *  dec-2): the row's last-modified where it has one (`doc_sections`/`issues`
+   *  `updated_at`), falling back to `created_at` where it does not (decisions
+   *  carry no `updated_at`). null only when no timestamp was selected
+   *  (navigation-only lanes). */
+  lastUpdatedAt: string | null;
 }
 
 export interface SearchMemexOptions {
@@ -225,6 +238,11 @@ interface SectionRow {
   doc_title: string;
   doc_status: string;
   doc_type: string;
+  // spec-285: WHO/WHEN. `author_name` is computed in SQL — the section's
+  // denormalised actor_name (std-32) preferred, else the parent doc's resolved
+  // creator. `updated_at` is the section's own last-modified.
+  author_name: string | null;
+  updated_at: string | Date;
   rank?: number; // FTS ts_rank
   distance?: number; // vector cosine distance
 }
@@ -240,6 +258,11 @@ interface DecisionRow {
   dec_context: string | null;
   dec_resolution: string | null;
   dec_status: string;
+  // spec-285: WHO/WHEN. `author_name` = decision's denormalised actor_name
+  // (std-32) preferred, else the actor_user_id resolved to a user. `created_at`
+  // is the only timestamp decisions carry (no updated_at — dec-2 fallback).
+  author_name: string | null;
+  created_at: string | Date;
   rank?: number;
   distance?: number;
 }
@@ -255,6 +278,11 @@ interface IssueRow {
   issue_body: string | null;
   issue_type: string;
   issue_status: string;
+  // spec-285: WHO/WHEN. Issues carry no actor_name (std-32 hasn't reached the
+  // issues table) — `author_name` is the created_by_user_id resolved to a user.
+  // `updated_at` is the issue's own last-modified.
+  author_name: string | null;
+  updated_at: string | Date;
   rank?: number;
   distance?: number;
 }
@@ -324,6 +352,15 @@ function inScopeDocTypes(kind: MemexSearchKind | undefined): string[] | null {
   // section query short-circuits to nothing.
   if (kind === "decision" || kind === "issue") return null;
   return DOC_TYPES_BY_KIND[kind];
+}
+
+// spec-285: normalise a timestamptz coming back from the driver (Date or ISO
+// string depending on the column path) to a stable ISO-8601 string for the hit
+// shape. null/invalid → null so the formatter and REST JSON degrade gracefully.
+function toIso(value: string | Date | null | undefined): string | null {
+  if (value == null) return null;
+  const d = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(d.getTime()) ? null : d.toISOString();
 }
 
 // ── Public entry point ─────────────────────────────────
@@ -459,23 +496,51 @@ async function lookupByHandle(
       s.section_type  AS section_type,
       s.title         AS section_title,
       s.content       AS section_content,
+      s.actor_name    AS section_actor_name,
+      s.updated_at    AS section_updated_at,
       s.doc_id        AS doc_id,
       d.handle        AS doc_handle,
       d.title         AS doc_title,
       d.status        AS doc_status,
-      d.doc_type      AS doc_type
+      d.doc_type      AS doc_type,
+      d.created_at        AS doc_created_at,
+      d.status_changed_at AS doc_status_changed_at,
+      du.name         AS doc_author_name,
+      du.email        AS doc_author_email
     FROM documents d
     LEFT JOIN doc_sections s ON s.doc_id = d.id
+    LEFT JOIN users du ON du.id = d.created_by_user_id
     WHERE d.memex_id = ${memexId}
       ${archivedClause}
       AND d.is_demo IS NOT TRUE
       AND d.handle = ${query.toLowerCase()}
     ORDER BY s.seq
-  `)) as unknown as SectionRow[];
+  `)) as unknown as HandleRow[];
 
   if (rows.length === 0) return null;
 
   const first = rows[0];
+
+  // WHO/WHEN for a handle hit (spec-285): the heading is the DOCUMENT, so
+  // attribute it from the most-recently-updated section (denormalised
+  // actor_name, std-32), falling back to the doc's resolved creator. WHEN is the
+  // latest section's updated_at, else the doc's own status_changed_at/created_at.
+  const sections = rows.filter((r) => r.section_id != null);
+  let latest: HandleRow | null = null;
+  for (const r of sections) {
+    if (!latest || toMillis(r.section_updated_at) > toMillis(latest.section_updated_at)) {
+      latest = r;
+    }
+  }
+  const docAuthorFallback =
+    first.doc_author_name?.trim() || first.doc_author_email?.trim() || null;
+  const sectionActor = latest?.section_actor_name?.trim() || null;
+  const authorName = sectionActor ?? docAuthorFallback;
+  const lastUpdatedAt =
+    toIso(latest?.section_updated_at) ??
+    toIso(first.doc_status_changed_at) ??
+    toIso(first.doc_created_at);
+
   return {
     id: first.doc_id,
     parentDocId: first.doc_id,
@@ -485,16 +550,44 @@ async function lookupByHandle(
     status: first.doc_status,
     score: 1,
     strategies: ["handle"],
-    matchingSections: rows
-      .filter((r) => r.section_id != null)
-      .map((r) => ({
-        id: r.section_id,
-        sectionType: r.section_type,
-        title: r.section_title,
-        content: r.section_content,
-        matchedVia: "handle",
-      })),
+    authorName,
+    lastUpdatedAt,
+    matchingSections: sections.map((r) => ({
+      id: r.section_id,
+      sectionType: r.section_type,
+      title: r.section_title,
+      content: r.section_content,
+      matchedVia: "handle",
+    })),
   };
+}
+
+// Row shape for lookupByHandle's documents⨝sections⨝users projection (spec-285).
+interface HandleRow {
+  section_id: string;
+  section_type: string;
+  section_title: string | null;
+  section_content: string;
+  section_actor_name: string | null;
+  section_updated_at: string | Date | null;
+  doc_id: string;
+  doc_handle: string;
+  doc_title: string;
+  doc_status: string;
+  doc_type: string;
+  doc_created_at: string | Date | null;
+  doc_status_changed_at: string | Date | null;
+  doc_author_name: string | null;
+  doc_author_email: string | null;
+}
+
+// spec-285: epoch millis for comparing two timestamptz values; missing/invalid
+// sorts oldest so a real timestamp always wins the "latest section" pick.
+function toMillis(value: string | Date | null | undefined): number {
+  if (value == null) return -Infinity;
+  const d = value instanceof Date ? value : new Date(value);
+  const t = d.getTime();
+  return Number.isNaN(t) ? -Infinity : t;
 }
 
 // ── Jump-to lane (spec-64 t-2) ─────────────────────────
@@ -636,6 +729,10 @@ export async function resolveJumpTo(
       // so it ranks below the handle hit but is still a deliberate jump target.
       score: 0.5,
       strategies: ["handle"],
+      // Navigation-only lane (⌘K jump tier) — WHO/WHEN isn't rendered here
+      // (spec-285 dec-3 defers palette metadata), so leave them null.
+      authorName: null,
+      lastUpdatedAt: null,
       matchingSections: [],
     });
   }
@@ -695,6 +792,9 @@ export async function resolveAssignedSpecs(
         // tier, so we reuse it rather than widening the SearchStrategy union for
         // a lane the formatter never renders.
         strategies: ["handle"],
+        // Navigation-only lane — WHO/WHEN unrendered here (spec-285 dec-3).
+        authorName: null,
+        lastUpdatedAt: null,
         matchingSections: [],
       });
     }
@@ -724,6 +824,8 @@ async function runSectionFts(
       s.title         AS section_title,
       s.content       AS section_content,
       s.doc_id        AS doc_id,
+      s.updated_at    AS updated_at,
+      COALESCE(NULLIF(TRIM(s.actor_name), ''), NULLIF(TRIM(du.name), ''), du.email) AS author_name,
       d.handle        AS doc_handle,
       d.title         AS doc_title,
       d.status        AS doc_status,
@@ -731,6 +833,7 @@ async function runSectionFts(
       ts_rank(s.content_tsv, plainto_tsquery('english', ${query})) AS rank
     FROM doc_sections s
     INNER JOIN documents d ON d.id = s.doc_id
+    LEFT JOIN users du ON du.id = d.created_by_user_id
     WHERE d.memex_id = ${memexId}
       AND d.doc_type IN ${sql.raw(`(${docTypes.map((t) => `'${t}'`).join(",")})`)}
       ${archivedClause}
@@ -778,6 +881,8 @@ async function runSectionVector(
       s.title         AS section_title,
       s.content       AS section_content,
       s.doc_id        AS doc_id,
+      s.updated_at    AS updated_at,
+      COALESCE(NULLIF(TRIM(s.actor_name), ''), NULLIF(TRIM(du.name), ''), du.email) AS author_name,
       d.handle        AS doc_handle,
       d.title         AS doc_title,
       d.status        AS doc_status,
@@ -785,6 +890,7 @@ async function runSectionVector(
       (s.embedding <=> ${literal}::vector) AS distance
     FROM doc_sections s
     INNER JOIN documents d ON d.id = s.doc_id
+    LEFT JOIN users du ON du.id = d.created_by_user_id
     WHERE d.memex_id = ${memexId}
       AND d.doc_type IN ${sql.raw(`(${docTypes.map((t) => `'${t}'`).join(",")})`)}
       ${archivedClause}
@@ -826,6 +932,8 @@ async function runDecisionFts(
       dec.context     AS dec_context,
       dec.resolution  AS dec_resolution,
       dec.status      AS dec_status,
+      dec.created_at  AS created_at,
+      COALESCE(NULLIF(TRIM(dec.actor_name), ''), NULLIF(TRIM(au.name), ''), au.email) AS author_name,
       d.handle        AS doc_handle,
       d.title         AS doc_title,
       d.doc_type      AS doc_type,
@@ -838,6 +946,7 @@ async function runDecisionFts(
       ) AS rank
     FROM decisions dec
     INNER JOIN documents d ON d.id = dec.doc_id
+    LEFT JOIN users au ON au.id = dec.actor_user_id
     WHERE dec.memex_id = ${memexId}
       ${archivedClause}
       AND d.is_demo IS NOT TRUE
@@ -888,12 +997,15 @@ async function runDecisionVector(
       dec.context     AS dec_context,
       dec.resolution  AS dec_resolution,
       dec.status      AS dec_status,
+      dec.created_at  AS created_at,
+      COALESCE(NULLIF(TRIM(dec.actor_name), ''), NULLIF(TRIM(au.name), ''), au.email) AS author_name,
       d.handle        AS doc_handle,
       d.title         AS doc_title,
       d.doc_type      AS doc_type,
       (dec.embedding <=> ${literal}::vector) AS distance
     FROM decisions dec
     INNER JOIN documents d ON d.id = dec.doc_id
+    LEFT JOIN users au ON au.id = dec.actor_user_id
     WHERE dec.memex_id = ${memexId}
       ${archivedClause}
       AND d.is_demo IS NOT TRUE
@@ -936,6 +1048,8 @@ async function runIssueFts(
       iss.body        AS issue_body,
       iss.type        AS issue_type,
       iss.status      AS issue_status,
+      iss.updated_at  AS updated_at,
+      COALESCE(NULLIF(TRIM(au.name), ''), au.email) AS author_name,
       d.handle        AS doc_handle,
       d.title         AS doc_title,
       d.doc_type      AS doc_type,
@@ -947,6 +1061,7 @@ async function runIssueFts(
       ) AS rank
     FROM issues iss
     INNER JOIN documents d ON d.id = iss.doc_id
+    LEFT JOIN users au ON au.id = iss.created_by_user_id
     WHERE iss.memex_id = ${memexId}
       ${archivedClause}
       AND d.is_demo IS NOT TRUE
@@ -996,12 +1111,15 @@ async function runIssueVector(
       iss.body        AS issue_body,
       iss.type        AS issue_type,
       iss.status      AS issue_status,
+      iss.updated_at  AS updated_at,
+      COALESCE(NULLIF(TRIM(au.name), ''), au.email) AS author_name,
       d.handle        AS doc_handle,
       d.title         AS doc_title,
       d.doc_type      AS doc_type,
       (iss.embedding <=> ${literal}::vector) AS distance
     FROM issues iss
     INNER JOIN documents d ON d.id = iss.doc_id
+    LEFT JOIN users au ON au.id = iss.created_by_user_id
     WHERE iss.memex_id = ${memexId}
       ${archivedClause}
       AND d.is_demo IS NOT TRUE
@@ -1032,6 +1150,14 @@ interface AccumulatorEntry {
   issueSnippet?: string;
   issueMatchedVia?: SearchStrategy;
   issueType?: string;
+  // spec-285 WHO/WHEN. For a doc hit these track the most-recently-updated
+  // matched section (so `authorAt` is the latest-section comparison key); for
+  // decision/issue hits they're set once from the atomic row.
+  authorName: string | null;
+  lastUpdatedAt: string | null;
+  /** Epoch millis of `lastUpdatedAt`, kept only to pick the latest matched
+   *  section across the FTS + vector arms. Not emitted. */
+  authorAtMillis: number;
 }
 
 function pickDecisionSnippet(r: DecisionRow): string {
@@ -1082,11 +1208,25 @@ function mergeWithRrf(
           score: 0,
           strategies: new Set<SearchStrategy>(),
           sectionsByVia: new Map(),
+          authorName: null,
+          lastUpdatedAt: null,
+          authorAtMillis: -Infinity,
         };
         acc.set(`doc:${r.doc_id}`, entry);
       }
       entry.score += rrfContribution;
       entry.strategies.add(via);
+
+      // WHO/WHEN (spec-285): a doc hit groups many matched sections (and arrives
+      // across the FTS + vector arms in rank order, not time order). Attribute
+      // the doc to its MOST-RECENTLY-UPDATED matched section, so authorName +
+      // lastUpdatedAt answer "who last changed this and when".
+      const rowMillis = toMillis(r.updated_at);
+      if (rowMillis > entry.authorAtMillis) {
+        entry.authorAtMillis = rowMillis;
+        entry.authorName = r.author_name?.trim() || null;
+        entry.lastUpdatedAt = toIso(r.updated_at);
+      }
 
       // Keep the FIRST `via` that surfaced each section so a section seen by
       // both FTS and vector reports the higher-confidence search method.
@@ -1120,6 +1260,12 @@ function mergeWithRrf(
           sectionsByVia: new Map(),
           decisionSnippet: pickDecisionSnippet(r),
           decisionMatchedVia: via,
+          // WHO/WHEN (spec-285): a decision is atomic, so set once. authorName =
+          // denormalised actor_name (or resolved actor), lastUpdatedAt =
+          // created_at (decisions carry no updated_at — dec-2 fallback).
+          authorName: r.author_name?.trim() || null,
+          lastUpdatedAt: toIso(r.created_at),
+          authorAtMillis: toMillis(r.created_at),
         };
         acc.set(`dec:${r.decision_id}`, entry);
       } else {
@@ -1150,6 +1296,11 @@ function mergeWithRrf(
           issueSnippet: pickIssueSnippet(r),
           issueMatchedVia: via,
           issueType: r.issue_type,
+          // WHO/WHEN (spec-285): atomic, set once. Issues have no actor_name, so
+          // authorName is the resolved created_by user; lastUpdatedAt = updated_at.
+          authorName: r.author_name?.trim() || null,
+          lastUpdatedAt: toIso(r.updated_at),
+          authorAtMillis: toMillis(r.updated_at),
         };
         acc.set(`iss:${r.issue_id}`, entry);
       } else {
@@ -1183,6 +1334,8 @@ function mergeWithRrf(
     issueSnippet: e.issueSnippet,
     issueMatchedVia: e.issueMatchedVia,
     issueType: e.issueType,
+    authorName: e.authorName,
+    lastUpdatedAt: e.lastUpdatedAt,
   }));
 
   results.sort((a, b) => b.score - a.score);
@@ -1225,6 +1378,20 @@ export interface FormatOptions {
   currentDocId?: string;
 }
 
+// spec-285: the WHO/WHEN byline appended to a hit's heading, e.g.
+// ` · Ryan Soosayraj, 2026-05-28`. Legible to a human and parseable by an agent
+// (` · <author>, <YYYY-MM-DD>`). Degrades gracefully: author-only, date-only, or
+// nothing at all when neither resolved. The date is the calendar day of the ISO
+// timestamp — enough for "when it last changed" without clock noise.
+function formatHitByline(hit: MemexSearchHit): string {
+  const author = hit.authorName?.trim() || null;
+  const date = hit.lastUpdatedAt ? hit.lastUpdatedAt.slice(0, 10) : null;
+  if (author && date) return ` · ${author}, ${date}`;
+  if (author) return ` · ${author}`;
+  if (date) return ` · ${date}`;
+  return "";
+}
+
 function isHitOnCurrentDoc(hit: MemexSearchHit, currentDocId: string): boolean {
   // parentDocId is the doc UUID for section/doc hits and the parent Spec's
   // UUID for decision hits. Matching here means the hit belongs to the
@@ -1254,7 +1421,11 @@ export function formatSearchResults(
     // so a reader can tell a bug from a todo at a glance (spec-112 t-4).
     const kindLabel =
       hit.kind === "issue" && hit.issueType ? `issue/${hit.issueType}` : hit.kind;
-    lines.push(`### ${hit.path} — "${hit.title}" (${kindLabel}, ${hit.status})${selfTag}${scoreSuffix}`);
+    // spec-285: WHO/WHEN byline sits after the (kind, status) segment and before
+    // the [current doc] / verbose-score suffixes, so an agent reading the result
+    // can attribute the hit ("who, when") without opening it.
+    const byline = formatHitByline(hit);
+    lines.push(`### ${hit.path} — "${hit.title}" (${kindLabel}, ${hit.status})${byline}${selfTag}${scoreSuffix}`);
     if (hit.kind === "decision") {
       const via = hit.decisionMatchedVia ?? "fts";
       const snippet = hit.decisionSnippet ?? "";

--- a/packages/server/src/services/qa-reports.ts
+++ b/packages/server/src/services/qa-reports.ts
@@ -1,14 +1,22 @@
-import { and, desc, eq, gt, lt, ne, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gt, gte, inArray, lt, lte, ne, sql } from "drizzle-orm";
 import {
   QA_REPORT_SECTION_PREFIX,
   isQaReportSectionType,
   qaReportVersion,
 } from "@memex/shared";
 import { db } from "../db/connection.js";
-import { docSections, documents, qaReportViews } from "../db/schema.js";
+import {
+  docSections,
+  documents,
+  documentTags,
+  qaReportViews,
+  tags,
+  users,
+} from "../db/schema.js";
 import type { DocSection } from "../db/schema.js";
 import { mutate, type Mutated, type RequestCtx } from "./mutate.js";
 import { addSection } from "./sections.js";
+import { listDocTagsForDocs } from "./tags.js";
 
 // spec-260 (dec-1, dec-2): a QA report is a read-only `doc_sections` row with
 // section_type='qa_report'. Each build session APPENDS a distinct, dated version
@@ -94,6 +102,13 @@ const CHANNEL_TO_ACTOR_KIND: Record<string, QaReportFeedRow["actorKind"]> = {
   server: "system",
 };
 
+/** A tag carried on a feed row's owning Spec — the rail-facing subset (spec-286). */
+export interface QaReportTagRef {
+  id: string;
+  scope: string | null;
+  value: string;
+}
+
 export interface QaReportFeedRow {
   /** The qa_report doc_sections row id. */
   id: string;
@@ -101,16 +116,27 @@ export interface QaReportFeedRow {
   /** Parent Spec handle (`spec-N`) + title, for the WHICH-Spec column + link. */
   docHandle: string;
   docTitle: string;
+  /** The owning Spec's current phase (documents.status) — drives the phase pill (spec-286). */
+  phase: string;
   /** `qa_report` / `qa_report-2` / … — encodes the build-session version. */
   sectionType: string;
   version: number;
   title: string | null;
   content: string;
-  /** std-32 WHO columns, stamped at write time. */
+  /**
+   * The Spec's AUTHOR (spec-286 dec-1): the creator (documents.created_by_user_id,
+   * seeded as the editor — there is no distinct owner role). Distinct from the
+   * IMPLEMENTER below, which is whoever ran this build session.
+   */
+  authorUserId: string | null;
+  authorName: string | null;
+  /** std-32 WHO columns, stamped at write time — the IMPLEMENTER of this session. */
   actorUserId: string | null;
   actorName: string | null;
   actorKind: "human" | "mcp_agent" | "in_app_agent" | "system";
   channel: string | null;
+  /** The owning Spec's tags — feeds the rail filter chips (spec-286). */
+  tags: QaReportTagRef[];
   createdAt: Date;
 }
 
@@ -120,21 +146,49 @@ export interface ListQaReportsOptions {
   limit?: number;
   /** Keyset boundary: return rows strictly OLDER than this timestamp. */
   since?: Date;
+  /** spec-286: restrict to reports whose owning Spec carries this tag (by id). */
+  tagId?: string;
+  /** spec-286: restrict to reports generated at/after this instant (date filter). */
+  from?: Date;
+  /** spec-286: restrict to reports generated at/before this instant (date filter). */
+  to?: Date;
 }
 
-export async function listQaReports(opts: ListQaReportsOptions): Promise<QaReportFeedRow[]> {
-  const limit = Math.max(1, Math.min(MAX_LIMIT, Math.floor(opts.limit ?? DEFAULT_LIMIT)));
-
-  const conditions = [
-    eq(documents.memexId, opts.memexId),
-    // QA reports attach to Specs only (the write path enforces it); demo Specs
-    // are excluded from the feed like they are from the Pulse timeline.
+// The conditions shared by the feed, the unread counter, and the facets: a
+// qa_report* section on a non-demo Spec in this memex, not soft-deleted. Factored
+// out (spec-286) so the feed query, the facet counts, and the total all scope an
+// identical corpus — the rail counts can't drift from what the feed actually lists.
+function feedBaseConditions(memexId: string) {
+  return [
+    eq(documents.memexId, memexId),
     eq(documents.docType, "spec"),
     ne(documents.isDemo, true),
     ne(docSections.status, "deleted"),
     qaReportSectionPredicate(),
   ];
+}
+
+export async function listQaReports(opts: ListQaReportsOptions): Promise<QaReportFeedRow[]> {
+  const limit = Math.max(1, Math.min(MAX_LIMIT, Math.floor(opts.limit ?? DEFAULT_LIMIT)));
+
+  const conditions = feedBaseConditions(opts.memexId);
+  // Keyset boundary ("Load More") + the spec-286 filters, all ANDed so a filtered
+  // page is itself keyset-paginated correctly (the cursor composes with the filters).
   if (opts.since !== undefined) conditions.push(lt(docSections.createdAt, opts.since));
+  if (opts.from !== undefined) conditions.push(gte(docSections.createdAt, opts.from));
+  if (opts.to !== undefined) conditions.push(lte(docSections.createdAt, opts.to));
+  if (opts.tagId !== undefined) {
+    // Restrict to reports whose owning Spec carries the tag — an EXISTS-style
+    // subquery on the bridge, tenant-scoped. A semijoin (not an inner join on
+    // documentTags) so a Spec with the tag still yields exactly one row per report.
+    const taggedDocIds = db
+      .select({ id: documentTags.docId })
+      .from(documentTags)
+      .where(
+        and(eq(documentTags.memexId, opts.memexId), eq(documentTags.tagId, opts.tagId)),
+      );
+    conditions.push(inArray(documents.id, taggedDocIds));
+  }
 
   const rows = await db
     .select({
@@ -142,9 +196,14 @@ export async function listQaReports(opts: ListQaReportsOptions): Promise<QaRepor
       docId: docSections.docId,
       docHandle: documents.handle,
       docTitle: documents.title,
+      phase: documents.status,
       sectionType: docSections.sectionType,
       title: docSections.title,
       content: docSections.content,
+      // The Spec author (creator → seeded editor); LEFT-joined so a legacy Spec
+      // with a null creator still lists (authorName just renders empty).
+      authorUserId: documents.createdByUserId,
+      authorName: users.name,
       actorUserId: docSections.actorUserId,
       actorName: docSections.actorName,
       channel: docSections.channel,
@@ -152,16 +211,92 @@ export async function listQaReports(opts: ListQaReportsOptions): Promise<QaRepor
     })
     .from(docSections)
     .innerJoin(documents, eq(docSections.docId, documents.id))
+    .leftJoin(users, eq(users.id, documents.createdByUserId))
     .where(and(...conditions))
     // Newest-first with a deterministic tiebreaker (the listActivity convention).
     .orderBy(desc(docSections.createdAt), desc(docSections.id))
     .limit(limit);
 
+  // Attach each owning Spec's tags in one batched round-trip (no N+1), reusing the
+  // same query the Specs board uses. Docs absent from the map carry no tags.
+  const tagsByDoc = await listDocTagsForDocs(
+    opts.memexId,
+    [...new Set(rows.map((r) => r.docId))],
+  );
+
   return rows.map((row) => ({
     ...row,
     version: qaReportVersion(row.sectionType) ?? 1,
     actorKind: CHANNEL_TO_ACTOR_KIND[row.channel ?? "server"] ?? "system",
+    tags: (tagsByDoc.get(row.docId) ?? []).map(({ id, scope, value }) => ({
+      id,
+      scope,
+      value,
+    })),
   }));
+}
+
+// ── Tag facets for the filter rail (spec-286 dec-2) ────────────────────────────
+//
+// The rail's tag tree shows every tag carried by a Spec with at least one QA
+// report, each with the COUNT of reports under it, plus an "All" total. Computed
+// server-side across the WHOLE corpus (not the loaded page) so the counts are
+// correct regardless of how far the client has paged. Honours the date window so
+// the counts stay consistent with an active date filter (AND semantics, dec-3).
+
+export interface QaReportTagFacet extends QaReportTagRef {
+  /** Number of qa_report* sections whose owning Spec carries this tag. */
+  count: number;
+}
+
+export interface QaReportFacets {
+  /** Total qa_report* sections in the corpus (the "All" node count). */
+  total: number;
+  tags: QaReportTagFacet[];
+}
+
+export interface QaReportFacetsOptions {
+  memexId: string;
+  from?: Date;
+  to?: Date;
+}
+
+export async function qaReportTagFacets(
+  opts: QaReportFacetsOptions,
+): Promise<QaReportFacets> {
+  const conditions = feedBaseConditions(opts.memexId);
+  if (opts.from !== undefined) conditions.push(gte(docSections.createdAt, opts.from));
+  if (opts.to !== undefined) conditions.push(lte(docSections.createdAt, opts.to));
+
+  // The "All" total: every matching report section, tag or not.
+  const [totalRow] = await db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(docSections)
+    .innerJoin(documents, eq(docSections.docId, documents.id))
+    .where(and(...conditions));
+
+  // Per-tag counts: one report can sit under several tags (its Spec's tags), so a
+  // report is counted once per tag it carries — that's the intended "reports under
+  // this tag" semantic, and the per-tag counts can sum to more than `total`.
+  const tagRows = await db
+    .select({
+      id: tags.id,
+      scope: tags.scope,
+      value: tags.value,
+      count: sql<number>`count(*)::int`,
+    })
+    .from(docSections)
+    .innerJoin(documents, eq(docSections.docId, documents.id))
+    .innerJoin(
+      documentTags,
+      and(eq(documentTags.docId, documents.id), eq(documentTags.memexId, opts.memexId)),
+    )
+    .innerJoin(tags, eq(tags.id, documentTags.tagId))
+    .where(and(...conditions))
+    .groupBy(tags.id, tags.scope, tags.value)
+    .orderBy(desc(sql`count(*)`), asc(tags.scope), asc(tags.value));
+
+  return { total: totalRow?.count ?? 0, tags: tagRows };
 }
 
 // ── Per-user unread counter (dec-6) ────────────────────────────────────────────

--- a/packages/ui/e2e/helpers/retained.ts
+++ b/packages/ui/e2e/helpers/retained.ts
@@ -124,6 +124,16 @@ export async function seedSection(opts: {
   return call("POST", "/seed-section", opts);
 }
 
+/** spec-286: apply `scope::value`/flat tags to a Spec through applyTagStrings —
+ *  the tags the QA Reports feed rail filters + counts on. */
+export async function seedTags(opts: {
+  memexId: string;
+  docId: string;
+  tags: string[];
+}): Promise<{ applied: { id: string; scope: string | null; value: string }[] }> {
+  return call("POST", "/seed-tags", opts);
+}
+
 /** Seed an OPEN decision (with options) onto a doc through createDecision.
  *  Returns the decision id + its per-doc seq (the N in the `dec-N` handle). */
 export async function seedOpenDecision(opts: {

--- a/packages/ui/e2e/helpers/retained.ts
+++ b/packages/ui/e2e/helpers/retained.ts
@@ -60,6 +60,8 @@ export async function seedSpec(opts: {
   memexId: string;
   title: string;
   purpose?: string;
+  /** Attribute the spec to a creator — surfaces as the QA Reports author (spec-286). */
+  createdByUserId?: string;
 }): Promise<{ docId: string; handle: string; sectionId: string }> {
   return call("POST", "/seed-spec", opts);
 }

--- a/packages/ui/e2e/journey-14-candidate-decision.spec.ts
+++ b/packages/ui/e2e/journey-14-candidate-decision.spec.ts
@@ -70,9 +70,10 @@ test("candidate decisions are view-only on the web; approval happens agent-side 
     timeout: 15_000,
   });
 
-  // Open the Decisions & ACs sub-tab and the Candidates sub-tab.
+  // Open the Decisions & ACs sub-tab. spec-247 dec-7: there are no longer
+  // Candidates/Open/Resolved tabs — every decision renders in one grouped list,
+  // so the candidate card is visible directly.
   await page.getByRole("button", { name: /^Decisions & ACs$/i }).click();
-  await page.getByRole("button", { name: /^Candidates 1$/i }).click();
 
   const panel = page.getByTestId("decision-panel");
 
@@ -116,10 +117,11 @@ test("candidate decisions are view-only on the web; approval happens agent-side 
 
   await sendChat(page, "yes, that's a real decision — approve it");
 
-  await expect(page.getByRole("button", { name: /^Open 1$/i })).toBeVisible({
-    timeout: 15_000,
-  });
-  await page.getByRole("button", { name: /^Open 1$/i }).click();
+  // spec-247 dec-7: no tabs — the approved decision surfaces directly as an
+  // open card in the unified list.
+  await expect(
+    page.locator('[data-decision-status="open"]').first(),
+  ).toBeVisible({ timeout: 15_000 });
   await expect(page.getByText("Pick database").first()).toBeVisible({
     timeout: 15_000,
   });

--- a/packages/ui/e2e/journey-16-reactivity.spec.ts
+++ b/packages/ui/e2e/journey-16-reactivity.spec.ts
@@ -176,12 +176,11 @@ test.describe("doc-16 Wave 1 reactivity journeys", () => {
     expect(resolveResp.ok()).toBeTruthy();
 
     // The decision panel should reflect the resolved state via SSE refetch.
-    // Wait for the Resolved sub-tab's count to land (SSE delivered the event),
-    // then click into it to read the resolution body.
-    await expect(tab.getByRole("button", { name: /^Resolved 1$/ })).toBeVisible({
-      timeout: 15_000,
-    });
-    await tab.getByRole("button", { name: /^Resolved 1$/ }).click();
+    // spec-247 dec-7: no tabs — the resolved decision surfaces directly as a
+    // resolved card whose compact row shows the resolution body.
+    await expect(
+      tab.locator('[data-decision-status="resolved"]').first(),
+    ).toBeVisible({ timeout: 15_000 });
     await expect(tab.getByText("Postgres it is.").first()).toBeVisible({ timeout: 15_000 });
 
     await ctx.close();

--- a/packages/ui/e2e/journey-18-global-search.spec.ts
+++ b/packages/ui/e2e/journey-18-global-search.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect, bareUrl } from "./helpers/index.js";
 import {
   getPersonalMemexByEmail,
+  ensureUser,
   setUserName,
   seedSpecInMemex,
   deleteDoc,
@@ -53,6 +54,9 @@ test.describe("Journey 18 — global ⌘K search palette", () => {
     // Give it a name so we land on the Specs board. (The shared account-based
     // fixture that normally does this writes to the dropped pre-0038 schema.)
     await setUserName("dev@memex.ai", "Dev User");
+    // spec-285: stamp the seeded Spec's author so the content row's WHO/WHEN
+    // byline resolves deterministically to "Dev User" (the name set just above).
+    const devUserId = await ensureUser("dev@memex.ai");
     // The seed service mints the handle (`spec-N`) via createDocDraft and returns
     // it — we navigate/assert against the SERVER-chosen handle rather than a
     // self-picked one (the new HTTP seed surface owns handle allocation, dec-2).
@@ -60,6 +64,7 @@ test.describe("Journey 18 — global ⌘K search palette", () => {
       memexId: memex.memexId,
       title: SPEC_TITLE,
       purpose: "Zephyr Quokka Search Beacon — purpose body for the global search journey.",
+      createdByUserId: devUserId,
     }));
   });
 
@@ -135,6 +140,18 @@ test.describe("Journey 18 — global ⌘K search palette", () => {
     // The hit's canonical path is built server-side from the memex slugs.
     const expectedPath = `/${nsSlug}/${mxSlug}/specs/${specHandle}`;
     await expect(specRow).toHaveAttribute("data-path", `${nsSlug}/${mxSlug}/specs/${specHandle}`);
+
+    // ── spec-285: the content-tier row carries a WHO/WHEN byline ─────────────
+    // The same Spec surfaces in the content tier (FTS on its title/body); that
+    // row renders "<author> · <YYYY-MM-DD>" from the author/timestamp the REST
+    // route now returns. We stamped created_by = Dev User in beforeEach, so the
+    // byline resolves to that name. (jumpTo rows carry no byline — content only.)
+    const byline = dialog
+      .locator('[data-testid="search-byline"]')
+      .filter({ hasText: "Dev User" })
+      .first();
+    await expect(byline).toBeVisible({ timeout: 10_000 });
+    await expect(byline).toContainText(/Dev User · \d{4}-\d{2}-\d{2}/);
 
     // ── ac-10: ArrowDown moves the roving selection, Enter navigates ─────────
     // cmdk auto-selects the first option; ArrowDown proves the roving selection

--- a/packages/ui/e2e/journey-19-lifecycle-spine.spec.ts
+++ b/packages/ui/e2e/journey-19-lifecycle-spine.spec.ts
@@ -192,13 +192,13 @@ test("lifecycle spine: org → memex → Spec → resolve decision → phase mov
 
   await panel.getByTestId("open-option-0").first().check();
 
-  // Resolved: the decision moves to the Resolved tray. The specify→Build Decisions
-  // blocker is now satisfied — but ACs still aren't created, so the Rubicon
-  // STILL blocks on ACs (the affordance reflects the remaining gate, proving the
-  // phase-gated state is live, not static).
-  await expect(panel.getByRole("button", { name: /^Resolved 1$/ })).toBeVisible({
-    timeout: 15_000,
-  });
+  // Resolved: the decision becomes a resolved card in the unified list (spec-247
+  // dec-7). The specify→Build Decisions blocker is now satisfied — but ACs still
+  // aren't created, so the Rubicon STILL blocks on ACs (the affordance reflects
+  // the remaining gate, proving the phase-gated state is live, not static).
+  await expect(
+    panel.locator('[data-decision-status="resolved"]').first(),
+  ).toBeVisible({ timeout: 15_000 });
   await expect(page.getByTestId("transition-sentence")).toContainText(
     /Acceptance Criteria \(ACs\)[\s\S]*must be created[\s\S]*before this spec can move to Build/i,
     { timeout: 15_000 }

--- a/packages/ui/e2e/journey-21-spec-196-narrative.spec.ts
+++ b/packages/ui/e2e/journey-21-spec-196-narrative.spec.ts
@@ -125,9 +125,10 @@ test("specify→build gate: stale narrative blocks the offer; consolidation rest
   // spec-247 dec-1/dec-5: picking an option IS the answer — the click persists
   // immediately (no Resolve button, no rationale step).
   await panel.getByTestId("open-option-1").first().check();
-  await expect(panel.getByRole("button", { name: /^Resolved 1$/ })).toBeVisible({
-    timeout: 15_000,
-  });
+  // spec-247 dec-7: the decision becomes a resolved card in the unified list.
+  await expect(
+    panel.locator('[data-decision-status="resolved"]').first(),
+  ).toBeVisible({ timeout: 15_000 });
 
   // All decisions resolved + AC present + never consolidated → the current-tab
   // Rubicon states the staleness condition WITH the how-to tail. spec-282/dec-4:

--- a/packages/ui/e2e/journey-27-spec-247-decision-surfaces.spec.ts
+++ b/packages/ui/e2e/journey-27-spec-247-decision-surfaces.spec.ts
@@ -103,19 +103,19 @@ test("answer-by-click persists across reload, re-select updates, discussion is t
   await panel.getByRole("button", { name: /Hide discussion/ }).click();
 
   // ── Answer by clicking an option — that IS the resolution ──
+  // spec-247 dec-7: no tabs — the decision becomes a resolved card in place.
   await panel.getByTestId("open-option-1").first().check();
-  await expect(panel.getByRole("button", { name: /^Resolved 1$/ })).toBeVisible({
-    timeout: 15_000,
-  });
+  await expect(
+    panel.locator('[data-decision-status="resolved"]').first(),
+  ).toBeVisible({ timeout: 15_000 });
 
   // ── The answer survives a full reload (the agent-craft prod scenario) ──
   await page.reload();
   await page.getByRole("button", { name: /Decisions & ACs/ }).click();
   const panelAfter = page.getByTestId("decision-panel");
-  await expect(panelAfter.getByRole("button", { name: /^Resolved 1$/ })).toBeVisible({
-    timeout: 15_000,
-  });
-  await panelAfter.getByRole("button", { name: /^Resolved 1$/ }).click();
+  await expect(
+    panelAfter.locator('[data-decision-status="resolved"]').first(),
+  ).toBeVisible({ timeout: 15_000 });
   await expect(panelAfter).toContainText(/Chose:/, { timeout: 15_000 });
   await expect(panelAfter).toContainText(/In-process LRU/);
 

--- a/packages/ui/e2e/journey-29-spec-260-qa-reports.spec.ts
+++ b/packages/ui/e2e/journey-29-spec-260-qa-reports.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, tenantPath, emitAcEvents } from "./helpers/index.js";
+import { test, expect, tenantPath, emitAcEvents, ensureUser } from "./helpers/index.js";
 import {
   seedOrgTenant,
   seedSpec,
@@ -145,16 +145,21 @@ test.describe("spec-260 — Build QA Report", () => {
   }) => {
     const slug = resources.slug("j29b");
     const tenant = await seedOrgTenant({ slug });
+    // Attribute the specs to the dev user so the redesigned card's author renders
+    // (spec-286 shows the author; the std-260 "WHO" coverage moves onto it).
+    const devUserId = await ensureUser("dev@memex.ai");
 
     const specA = await seedSpec({
       memexId: tenant.memexId,
       title: "Feed Spec Alpha",
       purpose: "First spec with a QA report.",
+      createdByUserId: devUserId,
     });
     const specB = await seedSpec({
       memexId: tenant.memexId,
       title: "Feed Spec Beta",
       purpose: "Second spec with a QA report.",
+      createdByUserId: devUserId,
     });
 
     // Sequential seeds → distinct created_at → deterministic newest-first.
@@ -188,9 +193,10 @@ test.describe("spec-260 — Build QA Report", () => {
     await expect(rows.nth(0).getByTestId("qa-report-row-spec")).toContainText("Feed Spec Beta");
     await expect(rows.nth(1).getByTestId("qa-report-row-spec")).toContainText("Feed Spec Alpha");
 
-    // WHEN + WHO render on every row; WHICH links to the parent Spec.
+    // WHEN + WHO render on every row; WHICH links to the parent Spec. (spec-286
+    // renders WHO as the author/implementer attribution — here the seeded author.)
     await expect(rows.nth(0).getByTestId("qa-report-row-when")).not.toBeEmpty();
-    await expect(rows.nth(0).getByTestId("qa-report-row-who")).not.toBeEmpty();
+    await expect(rows.nth(0).getByTestId("qa-report-row-author")).not.toBeEmpty();
     await expect(rows.nth(0).getByTestId("qa-report-row-spec")).toHaveAttribute(
       "href",
       new RegExp(`/specs/${specB.handle}$`),

--- a/packages/ui/e2e/journey-30-spec-286-qa-reports-redesign.spec.ts
+++ b/packages/ui/e2e/journey-30-spec-286-qa-reports-redesign.spec.ts
@@ -1,0 +1,162 @@
+import { test, expect, tenantPath, emitAcEvents } from "./helpers/index.js";
+import {
+  seedOrgTenant,
+  seedSpec,
+  seedSection,
+  seedTags,
+  setDocStatus,
+} from "./helpers/retained.js";
+
+// Journey 30 — spec-286: the redesigned QA Reports feed, end to end [per std-28].
+//
+// The feed now leads each report with the spec as a heading, shows the owning
+// spec's phase as a coloured pill, and carries a STICKY left rail that filters
+// the feed by tag (with whole-corpus counts) and by date range. This journey
+// seeds two tagged specs in different phases, each with a QA report, then drives
+// the rail: a tag node narrows the feed to that tag's reports, the per-tag counts
+// match the corpus, and a date window narrows the feed too (AND with the tag).
+//
+// Seeding rides the env-gated /api/__test__ surface (no raw SQL); navigation is
+// path-based [per std-2]. Reports + tags are seeded through the REAL services.
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-286/acs/ac-${n}`;
+
+const ACS_BY_TITLE: Record<string, string[]> = {
+  "enriched cards: spec heading + phase pill; rail filters by tag with corpus counts": [
+    AC(2),
+    AC(4),
+    AC(11),
+  ],
+  "date filter narrows the feed (and ANDs with a tag)": [AC(5)],
+};
+
+test.afterEach(async ({}, testInfo) => {
+  if (testInfo.status === "skipped") return;
+  const refs = ACS_BY_TITLE[testInfo.title];
+  if (!refs) return;
+  await emitAcEvents(
+    refs,
+    testInfo.status === "passed" ? "pass" : "fail",
+    `packages/ui/e2e/journey-30-spec-286-qa-reports-redesign.spec.ts::${testInfo.title}`,
+    testInfo.duration,
+  );
+});
+
+test.describe("spec-286 — QA Reports feed redesign", () => {
+  test("enriched cards: spec heading + phase pill; rail filters by tag with corpus counts", async ({
+    page,
+    resources,
+  }) => {
+    const slug = resources.slug("j30a");
+    const tenant = await seedOrgTenant({ slug });
+
+    // Alpha → tagged area::frontend + bug, in Verify.
+    const alpha = await seedSpec({
+      memexId: tenant.memexId,
+      title: "Redesign Alpha",
+      purpose: "Alpha spec.",
+    });
+    await seedTags({ memexId: tenant.memexId, docId: alpha.docId, tags: ["area::frontend", "bug"] });
+    await setDocStatus({ memexId: tenant.memexId, docId: alpha.docId, status: "verify" });
+
+    // Beta → tagged area::frontend only, in Build.
+    const beta = await seedSpec({
+      memexId: tenant.memexId,
+      title: "Redesign Beta",
+      purpose: "Beta spec.",
+    });
+    await seedTags({ memexId: tenant.memexId, docId: beta.docId, tags: ["area::frontend"] });
+    await setDocStatus({ memexId: tenant.memexId, docId: beta.docId, status: "build" });
+
+    // Sequential seeds → distinct created_at → Beta (second) leads newest-first.
+    await seedSection({
+      memexId: tenant.memexId,
+      docId: alpha.docId,
+      title: "QA Report",
+      content: "Alpha build session report.",
+      sectionType: "qa_report",
+    });
+    await seedSection({
+      memexId: tenant.memexId,
+      docId: beta.docId,
+      title: "QA Report",
+      content: "Beta build session report.",
+      sectionType: "qa_report",
+    });
+
+    await page.goto(tenantPath(tenant.namespaceSlug, tenant.memexSlug, "/qa-reports"));
+
+    const rows = page.getByTestId("qa-report-row");
+    await expect(rows).toHaveCount(2, { timeout: 15_000 });
+
+    // ac-2: each card leads with the spec and shows the phase as a coloured pill.
+    await expect(rows.nth(0).getByTestId("qa-report-row-spec")).toContainText("Redesign Beta");
+    await expect(rows.nth(0).getByTestId("qa-report-phase-pill")).toHaveAttribute(
+      "data-phase",
+      "build",
+    );
+    await expect(rows.nth(0).getByTestId("qa-report-phase-pill")).toContainText("Build");
+    await expect(rows.nth(1).getByTestId("qa-report-phase-pill")).toHaveAttribute(
+      "data-phase",
+      "verify",
+    );
+
+    // ac-4: the rail stays in place and roots the tree at "All" with the corpus
+    // total; each tag node carries its whole-corpus report count.
+    const rail = page.getByTestId("qa-reports-rail");
+    await expect(rail).toBeVisible();
+    await expect(page.getByTestId("qa-reports-tag-all")).toContainText("2");
+
+    const frontendNode = page
+      .getByTestId("qa-reports-tag-node")
+      .filter({ hasText: "frontend" });
+    const bugNode = page.getByTestId("qa-reports-tag-node").filter({ hasText: "bug" });
+    await expect(frontendNode.getByTestId("qa-reports-tag-count")).toHaveText("2");
+    await expect(bugNode.getByTestId("qa-reports-tag-count")).toHaveText("1");
+
+    // ac-4 + ac-11: selecting `bug` filters the feed to Alpha's single report.
+    await bugNode.click();
+    await expect(rows).toHaveCount(1, { timeout: 15_000 });
+    await expect(rows.nth(0).getByTestId("qa-report-row-spec")).toContainText("Redesign Alpha");
+
+    // `frontend` spans both specs → both reports.
+    await frontendNode.click();
+    await expect(rows).toHaveCount(2, { timeout: 15_000 });
+
+    // "All" clears the tag → the full feed returns.
+    await page.getByTestId("qa-reports-tag-all").click();
+    await expect(rows).toHaveCount(2, { timeout: 15_000 });
+  });
+
+  test("date filter narrows the feed (and ANDs with a tag)", async ({ page, resources }) => {
+    const slug = resources.slug("j30b");
+    const tenant = await seedOrgTenant({ slug });
+
+    const spec = await seedSpec({
+      memexId: tenant.memexId,
+      title: "Dated Spec",
+      purpose: "Spec with a recent report.",
+    });
+    await seedTags({ memexId: tenant.memexId, docId: spec.docId, tags: ["area::frontend"] });
+    await seedSection({
+      memexId: tenant.memexId,
+      docId: spec.docId,
+      title: "QA Report",
+      content: "Recent report.",
+      sectionType: "qa_report",
+    });
+
+    await page.goto(tenantPath(tenant.namespaceSlug, tenant.memexSlug, "/qa-reports"));
+    const rows = page.getByTestId("qa-report-row");
+    await expect(rows).toHaveCount(1, { timeout: 15_000 });
+
+    // ac-5: a "from" date in the future excludes the just-seeded report → empty.
+    const future = "2099-01-01";
+    await page.getByTestId("qa-reports-range-from").fill(future);
+    await expect(page.getByTestId("qa-reports-empty")).toBeVisible({ timeout: 15_000 });
+
+    // Clearing the window back to "All time" restores the report.
+    await page.getByTestId("qa-reports-range-all").click();
+    await expect(rows).toHaveCount(1, { timeout: 15_000 });
+  });
+});

--- a/packages/ui/e2e/journey-31-spec-283-review-actions-in-agent.spec.ts
+++ b/packages/ui/e2e/journey-31-spec-283-review-actions-in-agent.spec.ts
@@ -1,0 +1,103 @@
+import { test, expect, tenantPath } from "./helpers/index.js";
+import { seedOrgTenant, seedSpec, setDocStatus } from "./helpers/retained.js";
+import { emitAcEvents } from "./helpers/emit-ac.js";
+import {
+  clearAnthropicQueue,
+  queueAnthropicResponse,
+} from "./helpers/anthropic-fake.js";
+
+// Journey 31 (spec-283): the four Spec review actions have moved OFF the Spec
+// page and INTO the agent's idle/empty state.
+//
+// This journey exercises the relocation end-to-end on a Specify-phase Spec
+// (std-28): the four buttons live in the ChatPanel idle state under the lead
+// "Ask a question, or start with a review:"; clicking one starts the
+// conversation and the buttons vanish with the empty state. The Spec page no
+// longer carries the "Review actions" disclosure or the button row, while the
+// coding-agent review-handoff copy line still renders in Specify.
+
+const SPEC283 = "mindset-prod/memex-building-itself/specs/spec-283";
+
+const ACS_BY_TEST: Record<string, string[]> = {
+  "review actions live in the agent idle state, not on the Spec page": [
+    `${SPEC283}/acs/ac-5`, // relocation preserves coverage + ships an e2e journey
+    `${SPEC283}/acs/ac-1`, // buttons appear in the idle state; clicking starts the review
+    `${SPEC283}/acs/ac-2`, // idle-only — they disappear once a conversation starts
+    `${SPEC283}/acs/ac-3`, // the page no longer shows the row; handoff line stays
+  ],
+};
+
+test.afterEach(async ({}, testInfo) => {
+  if (testInfo.status === "skipped") return;
+  const refs = ACS_BY_TEST[testInfo.title];
+  if (!refs) return;
+  await emitAcEvents(
+    refs,
+    testInfo.status === "passed" ? "pass" : "fail",
+    `packages/ui/e2e/journey-31-spec-283-review-actions-in-agent.spec.ts::${testInfo.title}`,
+    testInfo.duration
+  );
+});
+
+test("review actions live in the agent idle state, not on the Spec page", async ({
+  page,
+  resources,
+}) => {
+  const tenant = await seedOrgTenant({ slug: resources.slug("j31") });
+  const spec = await seedSpec({
+    memexId: tenant.memexId,
+    title: "Review actions relocation",
+    purpose: "Exercise the relocated review actions in the agent idle state.",
+  });
+  await setDocStatus({ memexId: tenant.memexId, docId: spec.docId, status: "specify" });
+
+  // Clicking a review button fires an agent turn — prime the fake so the turn
+  // completes cleanly rather than erroring.
+  await clearAnthropicQueue();
+  await queueAnthropicResponse({
+    textDeltas: ["Here ", "is ", "the ", "summary."],
+    content: [{ type: "text", text: "Here is the summary." }],
+    stopReason: "end_turn",
+    deltaDelayMs: 10,
+  });
+
+  await page.goto(
+    tenantPath(tenant.namespaceSlug, tenant.memexSlug, `/specs/${spec.handle}`)
+  );
+
+  // The agent panel has mounted (its heading is always present). The Specify
+  // overview prose sits behind the Narrative sub-tab, so it's not a reliable
+  // page-load anchor — the panel heading is.
+  await expect(page.getByText("Spec assistant")).toBeVisible({ timeout: 15_000 });
+
+  // ── The agent idle state carries the four review buttons (ac-1) ──
+  // The block only renders once the bound doc is a Spec in Specify with an idle
+  // conversation, so its visibility also proves ChatContext's doc is bound.
+  const reviewBlock = page.getByTestId("agent-review-actions");
+  await expect(reviewBlock).toBeVisible({ timeout: 15_000 });
+  await expect(reviewBlock).toContainText("Ask a question, or start with a review:");
+  for (const label of [
+    "Summarise Spec",
+    "Security review",
+    "Design review",
+    "Architecture review",
+  ]) {
+    await expect(reviewBlock.getByRole("button", { name: label })).toBeVisible();
+  }
+
+  // ── The Spec page no longer carries the disclosure or the button row, but the
+  //    review-handoff copy line stays (ac-3, dec-4) ──
+  await expect(page.getByTestId("review-actions-toggle")).toHaveCount(0);
+  await expect(page.getByTestId("review-action-row")).toHaveCount(0);
+  await expect(page.getByTestId("review-handoff-line")).toBeVisible({ timeout: 15_000 });
+
+  // ── Clicking one starts the review; the idle buttons vanish (ac-1, ac-2) ──
+  await reviewBlock.getByRole("button", { name: "Summarise Spec" }).click();
+
+  // The conversation has started: the assistant's streamed reply renders and the
+  // idle review block is gone (it only shows while messages.length === 0).
+  await expect(page.getByTestId("chat-markdown")).toHaveText(/Here is the summary\./, {
+    timeout: 10_000,
+  });
+  await expect(page.getByTestId("agent-review-actions")).toHaveCount(0);
+});

--- a/packages/ui/e2e/journey-31-spec-283-review-actions-in-agent.spec.ts
+++ b/packages/ui/e2e/journey-31-spec-283-review-actions-in-agent.spec.ts
@@ -87,6 +87,10 @@ test("review actions live in the agent idle state, not on the Spec page", async 
 
   // ── The Spec page no longer carries the disclosure or the button row, but the
   //    review-handoff copy line stays (ac-3, dec-4) ──
+  // A freshly-seeded spec is viewed in the default REVIEWING posture, so under
+  // spec-287's per-posture gating (dec-2) the reviewer still sees the review
+  // handoff — this assertion holds unchanged. (spec-287's own per-posture e2e,
+  // covering the editor side, is journey-32.)
   await expect(page.getByTestId("review-actions-toggle")).toHaveCount(0);
   await expect(page.getByTestId("review-action-row")).toHaveCount(0);
   await expect(page.getByTestId("review-handoff-line")).toBeVisible({ timeout: 15_000 });

--- a/packages/ui/e2e/journey-32-spec-287-one-prompt-per-posture.spec.ts
+++ b/packages/ui/e2e/journey-32-spec-287-one-prompt-per-posture.spec.ts
@@ -1,0 +1,78 @@
+import { test, expect, tenantPath } from "./helpers/index.js";
+import { seedOrgTenant, seedSpec, setDocStatus } from "./helpers/retained.js";
+import { emitAcEvents } from "./helpers/emit-ac.js";
+
+// Journey 32 (spec-287): one coding-agent prompt per posture in Specify.
+//
+// On a Specify-phase Spec the page offers exactly ONE handoff prompt, keyed to
+// the viewer's posture (dec-2):
+//   • reviewer (and read-only) → the Review handoff ("Copy the Review prompt")
+//   • editor                   → the phase handoff ("Copy the Specify prompt")
+// Neither posture sees both. The review link is Title Case (dec-1). A freshly
+// seeded Spec is viewed in the default REVIEWING posture; promoting via the
+// PostureDropdown pill flips which single prompt shows.
+
+const SPEC287 = "mindset-prod/memex-building-itself/specs/spec-287";
+
+const ACS_BY_TEST: Record<string, string[]> = {
+  "one coding-agent prompt per posture in Specify": [
+    `${SPEC287}/acs/ac-1`, // editor sees the Specify prompt only
+    `${SPEC287}/acs/ac-2`, // reviewer sees the Review prompt only
+    `${SPEC287}/acs/ac-3`, // the review link is Title Case
+    `${SPEC287}/acs/ac-5`, // per-posture single-prompt rule, shipped with an e2e journey
+    `${SPEC287}/acs/ac-6`, // std-28 journey asserts editor→Specify-only, reviewer→Review-only
+  ],
+};
+
+test.afterEach(async ({}, testInfo) => {
+  if (testInfo.status === "skipped") return;
+  const refs = ACS_BY_TEST[testInfo.title];
+  if (!refs) return;
+  await emitAcEvents(
+    refs,
+    testInfo.status === "passed" ? "pass" : "fail",
+    `packages/ui/e2e/journey-32-spec-287-one-prompt-per-posture.spec.ts::${testInfo.title}`,
+    testInfo.duration
+  );
+});
+
+test("one coding-agent prompt per posture in Specify", async ({ page, resources }) => {
+  const tenant = await seedOrgTenant({ slug: resources.slug("j32") });
+  const spec = await seedSpec({
+    memexId: tenant.memexId,
+    title: "One prompt per posture",
+    purpose: "Exercise the per-posture single-prompt handoff in Specify.",
+  });
+  await setDocStatus({ memexId: tenant.memexId, docId: spec.docId, status: "specify" });
+
+  await page.goto(
+    tenantPath(tenant.namespaceSlug, tenant.memexSlug, `/specs/${spec.handle}`)
+  );
+
+  // The agent panel heading is the reliable page-load anchor (per journey-31).
+  await expect(page.getByText("Spec assistant")).toBeVisible({ timeout: 15_000 });
+
+  // ── Default REVIEWING posture: the Review handoff shows, the Specify
+  //    phase handoff does NOT (ac-2). The link is Title Case (ac-3). ──
+  await expect(page.getByRole("button", { name: /You are reviewing/i })).toBeVisible({
+    timeout: 15_000,
+  });
+  const reviewLine = page.getByTestId("review-handoff-line");
+  await expect(reviewLine).toBeVisible({ timeout: 15_000 });
+  await expect(reviewLine).toContainText("Copy the Review prompt");
+  await expect(page.getByTestId("phase-handoff-line")).toHaveCount(0);
+
+  // ── Promote to EDITING via the PostureDropdown pill ──
+  await page.getByRole("button", { name: /You are reviewing/i }).click();
+  await page.getByRole("menuitemradio", { name: /Editing/i }).click();
+  await expect(page.getByRole("button", { name: /You are editing/i })).toBeVisible({
+    timeout: 15_000,
+  });
+
+  // ── Editor posture: the Specify phase handoff shows, the Review handoff
+  //    does NOT (ac-1). One prompt per posture. ──
+  const phaseLine = page.getByTestId("phase-handoff-line");
+  await expect(phaseLine).toBeVisible({ timeout: 15_000 });
+  await expect(phaseLine).toContainText("Copy the Specify prompt");
+  await expect(page.getByTestId("review-handoff-line")).toHaveCount(0);
+});

--- a/packages/ui/src/api/client.ts
+++ b/packages/ui/src/api/client.ts
@@ -125,6 +125,11 @@ export interface SearchHit {
   matchingSections: SearchMatchingSection[];
   decisionSnippet?: string;
   decisionMatchedVia?: SearchStrategy;
+  /** WHO — best-effort display name of who authored / last touched this hit
+   *  (spec-285). null/absent on navigation-only lanes (jumpTo/assigned). */
+  authorName?: string | null;
+  /** WHEN — ISO-8601 timestamp of when this hit was last changed (spec-285). */
+  lastUpdatedAt?: string | null;
 }
 
 /** The `{ jumpTo, assigned, content }` envelope (spec-64 t-1 ac-6). */

--- a/packages/ui/src/components/ChatPanel.spec-111.test.tsx
+++ b/packages/ui/src/components/ChatPanel.spec-111.test.tsx
@@ -41,6 +41,13 @@ vi.mock('./ChatContext', () => ({
   }),
 }));
 
+// spec-283: ChatPanel now resolves Org scaffold appends for the idle review
+// block via useOrgScaffoldBlocks (which calls useAuth). These access-state tests
+// render ChatPanel without an AuthProvider, so mock the hook to an empty array.
+vi.mock('../hooks/useOrgScaffoldBlocks', () => ({
+  useOrgScaffoldBlocks: () => [],
+}));
+
 vi.mock('./chat/ChatMarkdown', () => ({
   ChatMarkdown: ({ content }: { content: string }) => <div>{content}</div>,
 }));

--- a/packages/ui/src/components/ChatPanel.test.tsx
+++ b/packages/ui/src/components/ChatPanel.test.tsx
@@ -18,7 +18,9 @@ let mockChatState: {
   isStreaming: boolean;
   error: string | null;
   docId: string | null;
-  doc: null;
+  // spec-283: ChatPanel reads `doc.status` (the Spec phase) to gate the idle
+  // review-action block. Only the status field is exercised here.
+  doc: { status: string } | null;
   openCommentCount: number;
   contextChips: { type: string; id: string; label: string }[];
   respondedToolIds: Set<string>;
@@ -34,6 +36,14 @@ vi.mock('./ChatContext', () => ({
     clearChat: mockClearChat,
     respondToUiTool: mockRespondToUiTool,
   }),
+}));
+
+// spec-283: the idle review block composes its prompts through the real
+// scaffold (toButtonPrompt + BASE_SCAFFOLD), but the Org-append fetch is mocked
+// to an empty array so no network is touched (the hook's live path is covered
+// by useOrgScaffoldBlocks.test.tsx).
+vi.mock('../hooks/useOrgScaffoldBlocks', () => ({
+  useOrgScaffoldBlocks: () => [],
 }));
 
 // Mock child components to avoid rendering full markdown/UI tool trees
@@ -245,5 +255,111 @@ describe('ChatPanel — Spec assistant naming + grounding (spec-247)', () => {
     expect(makesCodeShapedClaims('The file decisions.ts holds the guard')).toBe(true);
     expect(makesCodeShapedClaims('I created three implementation ACs for this decision')).toBe(true);
     expect(makesCodeShapedClaims('The overview section could be clearer about scope.')).toBe(false);
+  });
+});
+
+// ── spec-283: the four review actions live in the agent idle state ──────────
+// Re-homed off the Spec page (DocDocument) into the ChatPanel empty state.
+// Gated purely on the Spec phase (doc.status==='specify') + an idle
+// conversation (messages.length===0), with no posture input (dec-1), no
+// posture-specific chrome (dec-2), and shown to every viewer incl. read-only
+// non-members (dec-3).
+describe('ChatPanel — review actions in the agent idle state (spec-283)', () => {
+  const AC283 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-283/acs/ac-${n}`;
+  const REVIEW_LABELS = ['Summarise Spec', 'Security review', 'Design review', 'Architecture review'];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockChatState = {
+      messages: [],
+      isStreaming: false,
+      error: null,
+      docId: 'doc-1',
+      doc: { status: 'specify' },
+      openCommentCount: 0,
+      contextChips: [],
+      respondedToolIds: new Set(),
+      isDriftMode: false,
+    };
+  });
+
+  it('in Specify, idle: the four review buttons render under the lead; clicking one sends a real scaffold prompt (ac-1)', async () => {
+    tagAc(AC283(1));
+    const user = userEvent.setup();
+    render(<ChatPanel />);
+
+    const block = screen.getByTestId('agent-review-actions');
+    expect(within(block).getByText('Ask a question, or start with a review:')).toBeInTheDocument();
+    for (const label of REVIEW_LABELS) {
+      expect(within(block).getByRole('button', { name: label })).toBeInTheDocument();
+    }
+
+    await user.click(within(block).getByRole('button', { name: 'Security review' }));
+    expect(mockSendMessage).toHaveBeenCalledTimes(1);
+    const prompt = mockSendMessage.mock.calls[0][0] as string;
+    expect(typeof prompt).toBe('string');
+    expect(prompt.length).toBeGreaterThan(20);
+    expect(prompt).toContain('security');
+  });
+
+  it('the block is absent outside Specify and once a conversation has started (ac-2)', () => {
+    tagAc(AC283(2));
+    // Other phase → no block, plain placeholder instead.
+    mockChatState.doc = { status: 'build' };
+    const { rerender } = render(<ChatPanel />);
+    expect(screen.queryByTestId('agent-review-actions')).not.toBeInTheDocument();
+    expect(screen.getByText('Ask a question about this Spec...')).toBeInTheDocument();
+
+    // Back in Specify but with messages → block disappears with the empty state.
+    mockChatState.doc = { status: 'specify' };
+    mockChatState.messages = [{ id: '1', role: 'user', content: 'hi', timestamp: new Date() }];
+    rerender(
+      <MemoryRouter>
+        <ChatPanel />
+      </MemoryRouter>,
+    );
+    expect(screen.queryByTestId('agent-review-actions')).not.toBeInTheDocument();
+  });
+
+  it('gating needs no posture: default-props ChatPanel (no canEdit) renders the block from doc.status + idle alone (ac-6)', () => {
+    tagAc(AC283(6));
+    // No posture/canEdit prop exists on ChatPanel — rendering with defaults and
+    // only the mocked doc.status + empty messages must be enough to show it.
+    render(<ChatPanel />);
+    expect(screen.getByTestId('agent-review-actions')).toBeInTheDocument();
+  });
+
+  it('no posture-specific copy: read-only and writable viewers see an identical block, no "switch to Editing" note (ac-7, ac-4)', () => {
+    tagAc(AC283(7));
+    tagAc(AC283(4));
+    const { unmount } = render(<ChatPanel />);
+    const writableButtons = screen
+      .getByTestId('agent-review-actions')
+      .querySelectorAll('button');
+    const writableLabels = Array.from(writableButtons).map((b) => b.textContent);
+    expect(screen.queryByText(/switch to editing/i)).not.toBeInTheDocument();
+    unmount();
+
+    render(<ChatPanel readOnly />);
+    const readonlyButtons = screen
+      .getByTestId('agent-review-actions')
+      .querySelectorAll('button');
+    const readonlyLabels = Array.from(readonlyButtons).map((b) => b.textContent);
+    // Identical button set regardless of posture, and still no reviewer nudge.
+    expect(readonlyLabels).toEqual(writableLabels);
+    expect(readonlyLabels).toEqual(REVIEW_LABELS);
+    expect(screen.queryByText(/switch to editing/i)).not.toBeInTheDocument();
+  });
+
+  it('a read-only viewer sees the buttons and clicking one fires sendMessage (ac-8)', async () => {
+    tagAc(AC283(8));
+    const user = userEvent.setup();
+    render(<ChatPanel readOnly />);
+
+    const block = screen.getByTestId('agent-review-actions');
+    expect(within(block).getByRole('button', { name: 'Summarise Spec' })).toBeInTheDocument();
+    await user.click(within(block).getByRole('button', { name: 'Summarise Spec' }));
+    expect(mockSendMessage).toHaveBeenCalledTimes(1);
+    expect(typeof mockSendMessage.mock.calls[0][0]).toBe('string');
   });
 });

--- a/packages/ui/src/components/ChatPanel.tsx
+++ b/packages/ui/src/components/ChatPanel.tsx
@@ -1,12 +1,27 @@
 import { useState, useRef, useEffect, type KeyboardEvent } from 'react';
 import { Link } from 'react-router-dom';
+import { toButtonPrompt, BASE_SCAFFOLD } from '@memex/shared';
 import { useChat } from './ChatContext';
+import { useOrgScaffoldBlocks } from '../hooks/useOrgScaffoldBlocks';
 import { ChatMarkdown } from './chat/ChatMarkdown';
 import { ContextChipBar } from './chat/ContextChipBar';
 import { UiToolRenderer } from './chat/ui-tools';
 import { TextArea } from './ui/TextArea';
 import { Button } from './ui';
 import { PublicAuthButtons } from './PublicAccessControls';
+
+// spec-283: the four Spec review actions, re-homed from the Spec page into the
+// agent's idle/empty state (dec-1…dec-4). The prompts are STATIC scaffold text
+// (no `{placeholder}` interpolation — see `opening-review-*` in
+// scaffold-data.ts), so the agent fires them with `context: {}` and no doc
+// context beyond the Org appends, mirroring DocDocument's `sendReviewPrompt`
+// direct-injection path. Labels/ids match the page's old REVIEW_ACTIONS.
+const REVIEW_ACTIONS: { label: string; buttonId: string }[] = [
+  { label: 'Summarise Spec', buttonId: 'opening-review-summarise' },
+  { label: 'Security review', buttonId: 'opening-review-security' },
+  { label: 'Design review', buttonId: 'opening-review-design' },
+  { label: 'Architecture review', buttonId: 'opening-review-architecture' },
+];
 
 /**
  * spec-111 t-9 — agent panel access states (dec-2):
@@ -76,7 +91,27 @@ export function makesCodeShapedClaims(content: string): boolean {
 }
 
 export function ChatPanel({ isAuthenticated = true, readOnly = false }: ChatPanelProps = {}) {
-  const { messages, isStreaming, error, sendMessage, stopStreaming, clearChat, respondedToolIds, respondToUiTool, docId, contextChips, isDriftMode } = useChat();
+  const { messages, isStreaming, error, sendMessage, stopStreaming, clearChat, respondedToolIds, respondToUiTool, docId, doc, contextChips, isDriftMode } = useChat();
+  // spec-283 dec-1: the review buttons are POSTURE-INDEPENDENT — gated solely on
+  // the Spec's phase (`doc.status==='specify'`, already exposed by useChat) and
+  // an idle conversation (`messages.length===0`). No `canEdit`/posture is
+  // threaded in; ChatContext stays untouched.
+  const orgBlocks = useOrgScaffoldBlocks();
+  const showReviewActions = doc?.status === 'specify' && messages.length === 0;
+
+  const sendReviewPrompt = (buttonId: string) => {
+    // The four review prompts carry no `{placeholder}` tokens, so an empty
+    // context resolves them fully; orgBlocks splice in any Org appends.
+    const prompt = toButtonPrompt({ dataset: BASE_SCAFFOLD, buttonId, context: {}, orgBlocks });
+    if (prompt === null) {
+      const message = `ChatPanel: no PromptButtonNode found for buttonId="${buttonId}"`;
+      if (import.meta.env.DEV) throw new Error(message);
+      // eslint-disable-next-line no-console
+      console.error(message);
+      return;
+    }
+    sendMessage(prompt);
+  };
   // spec-143 t-4 (dec-6): in drift mode the agent is LIVE on arrival (the Drift
   // Inbox has no bound doc), so the input is enabled before any context chip.
   const canChat = !!docId || contextChips.length > 0 || isDriftMode;
@@ -185,10 +220,39 @@ export function ChatPanel({ isAuthenticated = true, readOnly = false }: ChatPane
         )}
 
         {/* spec-159: opening a Spec no longer auto-activates the agent. The
-            page itself carries phase, readiness, the Rubicon line, handoff
-            prompts, and the reviewer block — so the chat sits idle until the
-            user types or clicks a prompt. */}
-        {messages.length === 0 && (
+            page itself carries phase, readiness, the Rubicon line, and handoff
+            prompts — so the chat sits idle until the user types or clicks a
+            prompt.
+            spec-283: in the Specify phase the idle state also offers the four
+            review actions (dec-1…dec-4). They render for EVERY viewer — editor,
+            reviewer, and read-only non-member alike (dec-3) — with no
+            posture-specific copy (dec-2). Clicking one injects that review
+            prompt straight into the chat; the block disappears the moment a
+            conversation starts (messages.length > 0). */}
+        {messages.length === 0 && showReviewActions && (
+          <div
+            data-testid="agent-review-actions"
+            className="flex flex-col items-center gap-3 py-8"
+          >
+            <p className="text-sm text-muted text-center">
+              Ask a question, or start with a review:
+            </p>
+            <div className="flex flex-wrap items-center justify-center gap-2">
+              {REVIEW_ACTIONS.map((action) => (
+                <Button
+                  key={action.buttonId}
+                  type="button"
+                  variant="secondary"
+                  size="sm"
+                  onClick={() => sendReviewPrompt(action.buttonId)}
+                >
+                  {action.label}
+                </Button>
+              ))}
+            </div>
+          </div>
+        )}
+        {messages.length === 0 && !showReviewActions && (
           <div className="text-sm text-muted text-center py-8">
             {canChat ? 'Ask a question about this Spec...' : 'Open a Spec to start chatting'}
           </div>

--- a/packages/ui/src/components/DecisionPanel.test.tsx
+++ b/packages/ui/src/components/DecisionPanel.test.tsx
@@ -74,8 +74,7 @@ const TWO_OPTIONS = [
 beforeEach(() => vi.clearAllMocks());
 
 describe('DecisionPanel', () => {
-  it('renders open + resolved decisions with the right status attributes', async () => {
-    const user = userEvent.setup();
+  it('renders open + resolved decisions with the right status attributes', () => {
     const decisions = [
       makeDecision({ id: 'd-open', seq: 1, title: 'Which DB?', status: 'open' }),
       makeDecision({
@@ -94,20 +93,16 @@ describe('DecisionPanel', () => {
       />
     );
 
-    // Default tab is 'open' when no candidates exist; the open card is visible.
-    let cards = screen.getAllByTestId('decision-card');
-    expect(cards).toHaveLength(1);
+    // spec-247 dec-7: both cards render together in one list, grouped by state
+    // (open before resolved) — there is no tab to switch.
+    const cards = screen.getAllByTestId('decision-card');
+    expect(cards).toHaveLength(2);
     expect(cards[0].getAttribute('data-decision-status')).toBe('open');
     expect(cards[0].getAttribute('data-decision-seq')).toBe('D-1');
-
-    // Switch to the Resolved tab and check the resolved card.
-    await user.click(screen.getByRole('button', { name: /^Resolved/ }));
-    cards = screen.getAllByTestId('decision-card');
-    expect(cards).toHaveLength(1);
-    const resolvedCard = cards[0];
+    const resolvedCard = cards[1];
     expect(resolvedCard.getAttribute('data-decision-status')).toBe('resolved');
     expect(resolvedCard.getAttribute('data-decision-seq')).toBe('D-2');
-    // Resolution appears twice — once in the compact row, once in the expandable <details>.
+    // Resolution appears in the compact row (and again in the expandable <details>).
     expect(within(resolvedCard).getAllByText('Use HS256 JWT').length).toBeGreaterThan(0);
   });
 
@@ -166,30 +161,17 @@ describe('DecisionPanel', () => {
 
   it('shows agent-driven empty-state copy when the list is empty', () => {
     render(<DecisionPanel docId="doc-1" decisions={[]} onUpdate={vi.fn()} />);
-    // Default tab is 'open' when no candidates exist; the empty state explains
-    // where candidates are confirmed and that picking an option answers.
-    expect(screen.getByText(/No open decisions/i)).toBeInTheDocument();
-    expect(screen.getByText(/picking an option records your answer/i)).toBeInTheDocument();
-  });
-
-  it('Candidates tab empty state explains the agent-driven candidate flow', async () => {
-    const user = userEvent.setup();
-    render(<DecisionPanel docId="doc-1" decisions={[]} onUpdate={vi.fn()} />);
-    await user.click(screen.getByRole('button', { name: /Candidates/i }));
-    expect(screen.getByText(/No candidate decisions yet/i)).toBeInTheDocument();
+    // spec-247 dec-7: one unified invitation, not a per-tab empty lane.
+    expect(screen.getByTestId('decision-empty')).toBeInTheDocument();
+    expect(screen.getByText(/No decisions yet/i)).toBeInTheDocument();
     expect(screen.getByText(/agent watches for choices with multiple options/i)).toBeInTheDocument();
   });
 
-  it('Resolved tab empty state explains the resolution flow', async () => {
-    const user = userEvent.setup();
-    render(<DecisionPanel docId="doc-1" decisions={[]} onUpdate={vi.fn()} />);
-    await user.click(screen.getByRole('button', { name: /Resolved/i }));
-    expect(screen.getByText(/No resolved decisions yet/i)).toBeInTheDocument();
-    expect(screen.getByText(/durable .* record/i)).toBeInTheDocument();
-  });
-
-  it('defaults to the Candidates tab when any candidate exists', () => {
+  it('renders every decision in one list, grouped candidates → open → resolved, each pilled (spec-247 dec-7, ac-23)', () => {
+    tagAc(AC247(23));
+    // Passed in a deliberately jumbled order — the panel regroups by state.
     const decisions = [
+      makeDecision({ id: 'open-1', seq: 2, status: 'open', title: 'Other?' }),
       makeDecision({
         id: 'cand-1',
         seq: 1,
@@ -197,19 +179,25 @@ describe('DecisionPanel', () => {
         title: 'API style?',
         options: TWO_OPTIONS,
       }),
-      makeDecision({ id: 'open-1', seq: 2, status: 'open', title: 'Other?' }),
+      makeDecision({ id: 'res-1', seq: 3, status: 'resolved', title: 'Done?', resolution: 'Yes' }),
     ];
     render(<DecisionPanel docId="doc-1" decisions={decisions} onUpdate={vi.fn()} />);
 
+    // No tabs — every decision is visible at once, grouped by state.
+    expect(screen.queryByRole('button', { name: /^Candidates/ })).not.toBeInTheDocument();
     const cards = screen.getAllByTestId('decision-card');
-    expect(cards).toHaveLength(1);
-    expect(cards[0].getAttribute('data-decision-status')).toBe('candidate');
-    expect(cards[0].getAttribute('data-decision-seq')).toBe('D-1');
+    expect(cards.map((c) => c.getAttribute('data-decision-status'))).toEqual([
+      'candidate',
+      'open',
+      'resolved',
+    ]);
+    // Each card carries a state pill (the <Badge>).
+    expect(within(cards[0]).getByText('candidate')).toBeInTheDocument();
+    expect(within(cards[1]).getByText('open')).toBeInTheDocument();
+    expect(within(cards[2]).getByText('resolved')).toBeInTheDocument();
 
-    // Both options render with their trade-offs (informational, spec-247 dec-6).
+    // The candidate's options still render with their trade-offs (spec-247 dec-6).
     expect(screen.getByText('REST')).toBeInTheDocument();
-    expect(screen.getByText('Simple, well-known')).toBeInTheDocument();
-    expect(screen.getByText('gRPC')).toBeInTheDocument();
     expect(screen.getByText('Faster, harder tooling')).toBeInTheDocument();
   });
 
@@ -237,8 +225,7 @@ describe('DecisionPanel', () => {
     expect(onUpdate).toHaveBeenCalled();
   });
 
-  it('shows the chosen-option label on a resolved decision with options[]', async () => {
-    const user = userEvent.setup();
+  it('shows the chosen-option label on a resolved decision with options[]', () => {
     const decisions = [
       makeDecision({
         id: 'res-1',
@@ -255,8 +242,7 @@ describe('DecisionPanel', () => {
     ];
     render(<DecisionPanel docId="doc-1" decisions={decisions} onUpdate={vi.fn()} />);
 
-    // Switch to the Resolved tab.
-    await user.click(screen.getByRole('button', { name: /^Resolved/ }));
+    // The resolved card renders directly — no tab to switch.
     expect(screen.getByText(/Chose:/)).toBeInTheDocument();
     expect(screen.getAllByText(/^JWT$/).length).toBeGreaterThan(0);
   });
@@ -322,7 +308,6 @@ describe('DecisionPanel — one obvious place to answer (spec-247)', () => {
     ];
     render(<DecisionPanel docId="doc-1" decisions={decisions} onUpdate={onUpdate} />);
 
-    await user.click(screen.getByRole('button', { name: /^Resolved/ }));
     await user.click(screen.getByText('Context'));
     await user.click(screen.getByTestId('resolved-option-1'));
 
@@ -457,7 +442,6 @@ describe('DecisionPanel — one obvious place to answer (spec-247)', () => {
     ];
     render(<DecisionPanel docId="doc-1" decisions={decisions} onUpdate={vi.fn()} />);
 
-    await user.click(screen.getByRole('button', { name: /^Resolved/ }));
     await user.click(screen.getByText('Context'));
 
     // No reasoning affordance, expanded or otherwise.
@@ -502,12 +486,14 @@ describe('DecisionPanel — draft-phase gating (spec-164)', () => {
     expect(screen.getByText('Which DB?')).toBeInTheDocument();
   });
 
-  it('specify + zero decisions → behaviour unchanged (tabs scaffolding, no directive)', () => {
+  it('specify + zero decisions → behaviour unchanged (unified list scaffolding, no directive)', () => {
     tagAc(AC164(18));
     render(
       <DecisionPanel docId="doc-1" decisions={[]} onUpdate={vi.fn()} specPhase="specify" />,
     );
     expect(screen.queryByTestId('decision-draft-directive')).not.toBeInTheDocument();
-    expect(screen.getByText('No open decisions.')).toBeInTheDocument();
+    // spec-247 dec-7: specify renders the standard panel — its unified empty-state
+    // invitation (not the draft directive).
+    expect(screen.getByTestId('decision-empty')).toBeInTheDocument();
   });
 });

--- a/packages/ui/src/components/DecisionPanel.tsx
+++ b/packages/ui/src/components/DecisionPanel.tsx
@@ -14,7 +14,7 @@ import type { GuidanceBlock } from '@memex/shared';
 import { useAuth } from './AuthContext';
 import { useChat } from './ChatContext';
 import { CommentTray } from './CommentTray';
-import { Badge, Button, Tabs } from './ui';
+import { Badge, Button } from './ui';
 import { DecisionAcStrip } from './DecisionAcStrip';
 import { PromptButton } from './PromptButton';
 import { TextArea } from './ui/TextArea';
@@ -74,8 +74,6 @@ interface DecisionPanelProps {
   /** Org scaffold appends threaded into toButtonPrompt (spec-159 ac-17). */
   orgBlocks?: readonly GuidanceBlock[];
 }
-
-type TabId = 'candidates' | 'open' | 'resolved';
 
 export function DecisionPanel({ docId, decisions, commentsByDecision = {}, forceShowComments: _forceShowComments, onCommentsChange, onUpdate, highlightDecisionHandle, onJumpToAc, canWrite = true, canEdit = true, specPhase, isDemo = false, promptContext, orgBlocks }: DecisionPanelProps) {
   const panelRef = useRef<HTMLDivElement>(null);
@@ -190,17 +188,15 @@ export function DecisionPanel({ docId, decisions, commentsByDecision = {}, force
     [decisions],
   );
 
-  // Default the visible tab to Candidates when any exist (per t-16 AC), else
-  // Open. We re-evaluate on each render only via the initial state — once the
-  // user clicks a tab their selection wins.
-  const [activeTab, setActiveTab] = useState<TabId>(
-    candidates.length > 0 ? 'candidates' : 'open',
-  );
+  // spec-247 dec-7: the Candidates / Open / Resolved tabs are gone — every
+  // decision renders in one list grouped by state, each card pilled with its
+  // status. No active-tab state to track.
 
-  // ?decision=D-N (or legacy `dec-N` from standard content) — switch to the right
-  // tab for the matching decision's status, then scroll its card into view and
-  // pulse a highlight ring for ~2s. (t-19 W3.1; case-insensitive after doc-26
-  // rename so legacy `[per dec-N]` standard cites still deep-link.)
+  // ?decision=D-N (or legacy `dec-N` from standard content) — scroll the matching
+  // decision card into view and pulse a highlight ring for ~2s. (t-19 W3.1;
+  // case-insensitive after doc-26 rename so legacy `[per dec-N]` standard cites
+  // still deep-link.) Every card is always rendered now (spec-247 dec-7), so
+  // there is no tab to switch first.
   // Re-runs whenever the deep-link handle or the decisions array changes (e.g. SSE
   // refetch updates the list). The highlight clears itself; if the user's already
   // looking at the row, the short ring is the only visual change.
@@ -212,11 +208,7 @@ export function DecisionPanel({ docId, decisions, commentsByDecision = {}, force
     const target = decisions.find((d) => d.seq === seq);
     if (!target) return;
 
-    if (target.status === 'candidate') setActiveTab('candidates');
-    else if (target.status === 'open') setActiveTab('open');
-    else if (target.status === 'resolved') setActiveTab('resolved');
-
-    // Defer to next tick so the tab change has rendered the matching card.
+    // Defer to next tick so any state-driven re-render has settled the card.
     const handle = window.setTimeout(() => {
       const card = panelRef.current?.querySelector<HTMLElement>(
         `[data-decision-seq="D-${seq}"]`,
@@ -345,12 +337,6 @@ export function DecisionPanel({ docId, decisions, commentsByDecision = {}, force
     </div>
   );
 
-  const tabs: Array<{ id: TabId; label: string; count: number; countVariant?: 'default' | 'warning' | 'danger' }> = [
-    { id: 'candidates', label: 'Candidates', count: candidates.length, countVariant: 'warning' },
-    { id: 'open', label: 'Open', count: open.length, countVariant: 'warning' },
-    { id: 'resolved', label: 'Resolved', count: resolved.length },
-  ];
-
   // spec-164 dec-3: gate the invitation, never the content — a draft Spec
   // with zero decisions invites the move to Specify instead of presenting
   // empty tabs. Any existing decisions fall through to the normal render.
@@ -386,22 +372,24 @@ export function DecisionPanel({ docId, decisions, commentsByDecision = {}, force
         </span>
       </div>
 
-      <Tabs tabs={tabs} activeTab={activeTab} onChange={(id) => setActiveTab(id as TabId)} />
+      {/* spec-247 dec-7: ONE list, grouped by state (candidates → open →
+          resolved), each card pilled with its status — no Candidates / Open /
+          Resolved tabs. A truly empty Spec shows one invitation, not three
+          empty lanes. */}
+      {decisions.length === 0 && (
+        <div data-testid="decision-empty" className="text-sm text-muted space-y-1">
+          <p>No decisions yet.</p>
+          <p className="text-xs">While you discuss the spec in chat, the agent watches for choices with multiple options and trade-offs and proposes them as candidates for you to review.</p>
+        </div>
+      )}
 
-      {/* ── Candidates tab ─────────────────────────────────────── */}
-      {activeTab === 'candidates' && (
+      {/* ── Candidates ─────────────────────────────────────────── */}
+      {candidates.length > 0 && (
         <div className="space-y-2 mb-4">
-          {candidates.length === 0 && (
-            <div className="text-sm text-muted space-y-1">
-              <p>No candidate decisions yet.</p>
-              <p className="text-xs">Decisions surface here automatically. While you discuss the spec in chat, the agent watches for choices with multiple options and trade-offs and proposes them as candidates for you to review.</p>
-            </div>
-          )}
-
           {/* spec-247 dec-6 / ac-21 — the boundary marker: candidate review
               (approve / reject) is coding-agent work, and the surface says so
               instead of offering web buttons that half-implement it. */}
-          {candidates.length > 0 && promptContext && (
+          {promptContext && (
             <div data-testid="candidate-mcp-marker" className="rounded-md border border-edge-subtle bg-overlay/30 px-3 py-2">
               <PromptButton
                 buttonId="review-candidates"
@@ -527,15 +515,9 @@ export function DecisionPanel({ docId, decisions, commentsByDecision = {}, force
       )}
 
       {/* ── Open tab ───────────────────────────────────────────── */}
-      {activeTab === 'open' && (
+      {/* ── Open ───────────────────────────────────────────────── */}
+      {open.length > 0 && (
         <div className="space-y-2 mb-4">
-          {open.length === 0 && (
-            <div className="text-sm text-muted space-y-1">
-              <p>No open decisions.</p>
-              <p className="text-xs">Decisions move here once a candidate is confirmed from your coding agent. An open decision is an unresolved choice with options on the table — picking an option records your answer.</p>
-            </div>
-          )}
-
           {open.map((dec) => {
             const isExpanded = !collapsedOpen.has(dec.id);
             const isBusy = busyOpen === dec.id;
@@ -657,16 +639,9 @@ export function DecisionPanel({ docId, decisions, commentsByDecision = {}, force
         </div>
       )}
 
-      {/* ── Resolved tab ───────────────────────────────────────── */}
-      {activeTab === 'resolved' && (
+      {/* ── Resolved ───────────────────────────────────────────── */}
+      {resolved.length > 0 && (
         <div className="space-y-2 mb-4">
-          {resolved.length === 0 && (
-            <div className="text-sm text-muted space-y-1">
-              <p>No resolved decisions yet.</p>
-              <p className="text-xs">Resolved decisions land here once an open decision has been answered by picking an option (or in conversation). They become the durable "this is how we decided" record for the spec.</p>
-            </div>
-          )}
-
           {resolved.map((dec) => {
             const decOpenComments = openCommentCount(dec.id) > 0;
             const isBusy = busyResolved === dec.id;

--- a/packages/ui/src/components/PromptButton.test.tsx
+++ b/packages/ui/src/components/PromptButton.test.tsx
@@ -181,7 +181,8 @@ describe('PromptButton sentence form (spec-159 ac-17)', () => {
 // dismiss); the prompt itself sits on its own bordered canvas, not the guidance.
 describe('PromptButton stub mode + copy feedback (spec-282 dec-5, ac-12)', () => {
   const AC12 = 'mindset-prod/memex-building-itself/specs/spec-282/acs/ac-12';
-  // verify-spec → "Verify handoff" label → phase word "verify".
+  // The phase word is the canonical phase name from HANDOFF_BUTTON_BY_PHASE
+  // (inverted) — verify-spec → 'verify'. NOT the node label.
   const STUB =
     'Use memex spec: https://memex.ai/mindset-prod/memex-building-itself/specs/spec-103\n' +
     'Get the verify prompt from memex and ask the user how they want to proceed.';
@@ -199,6 +200,24 @@ describe('PromptButton stub mode + copy feedback (spec-282 dec-5, ac-12)', () =>
     expect(writeText).not.toHaveBeenCalledWith(full);
     // The stub is meaningfully shorter than the full scaffold payload.
     expect(STUB.length).toBeLessThan(full.length);
+  });
+
+  it('the specify handoff names the "specify" phase, not "plan" (the label says "Plan handoff")', async () => {
+    tagAc(AC12);
+    // Regression: deriving the phase word from the node label gave "plan" for
+    // the specify handoff (labelled "Plan handoff"); it must be the canonical
+    // phase name "specify".
+    const OPEN_PLAN = 'Show the Plan handoff prompt to copy into a coding agent';
+    render(<PromptButton buttonId="plan-handoff" context={CTX} stub />);
+
+    fireEvent.click(screen.getByRole('button', { name: OPEN_PLAN }));
+    fireEvent.click(screen.getByRole('button', { name: 'Copy prompt' }));
+
+    const expected =
+      'Use memex spec: https://memex.ai/mindset-prod/memex-building-itself/specs/spec-103\n' +
+      'Get the specify prompt from memex and ask the user how they want to proceed.';
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith(expected));
+    expect(writeText).not.toHaveBeenCalledWith(expect.stringContaining('Get the plan prompt'));
   });
 
   it('without stub the full scaffold prompt is still copied (get_prompt parity preserved)', async () => {

--- a/packages/ui/src/components/PromptButton.tsx
+++ b/packages/ui/src/components/PromptButton.tsx
@@ -10,7 +10,7 @@
 
 import { useState } from 'react';
 import { createPortal } from 'react-dom';
-import { BASE_SCAFFOLD, toButtonPrompt, type GuidanceBlock } from '@memex/shared';
+import { BASE_SCAFFOLD, toButtonPrompt, HANDOFF_BUTTON_BY_PHASE, type GuidanceBlock } from '@memex/shared';
 import { Button } from './ui';
 
 export interface PromptButtonProps {
@@ -89,11 +89,17 @@ function TerminalIcon() {
 // calls `get_prompt` to fetch the full scaffold (Org appends included), so this
 // stays a UI-layer projection and the scaffold node text is never edited
 // (get_prompt byte-parity, spec-263). The second line is PHASE-SPECIFIC: the
-// phase word is the lowercased first word of the handoff node `label` (e.g.
-// "Build handoff" → "build"), so each of the three handoffs names its own prompt.
-function buildHandoffStub(context: Record<string, unknown>, label: string): string {
+// phase word is the CANONICAL phase name, looked up from HANDOFF_BUTTON_BY_PHASE
+// (phase→buttonId) inverted. It must NOT come from the node `label`: the specify
+// handoff is historically labelled "Plan handoff", so a label-first-word
+// derivation mislabels the specify phase as "plan" — the phase is `specify`.
+const PHASE_BY_HANDOFF_BUTTON: Readonly<Record<string, string>> = Object.fromEntries(
+  Object.entries(HANDOFF_BUTTON_BY_PHASE).map(([phase, id]) => [id, phase]),
+);
+
+function buildHandoffStub(context: Record<string, unknown>, buttonId: string): string {
   const str = (k: string) => String(context[k] ?? '');
-  const phase = (label.trim().split(/\s+/)[0] ?? '').toLowerCase();
+  const phase = PHASE_BY_HANDOFF_BUTTON[buttonId] ?? '';
   return [
     `Use memex spec: ${str('url')}`,
     `Get the ${phase} prompt from memex and ask the user how they want to proceed.`,
@@ -251,7 +257,7 @@ export function PromptButton({
 
   // spec-282 dec-5(A): in stub mode the dialog shows + copies the short
   // get_prompt stub; otherwise the full scaffold prompt.
-  const dialogPrompt = stub ? buildHandoffStub(context, node.label) : prompt;
+  const dialogPrompt = stub ? buildHandoffStub(context, buttonId) : prompt;
 
   // spec-159 ac-17 — the sentence form. The clickable words (`linkText`, default
   // "Copy") render as a hyperlink-styled <button> (it performs an action, not

--- a/packages/ui/src/components/QaReportsFilterRail.test.tsx
+++ b/packages/ui/src/components/QaReportsFilterRail.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { QaReportsFilterRail, ALL_TIME, type DateRangeState } from './QaReportsFilterRail';
+import type { QaReportFacets } from '../hooks/useQaReports';
+
+const AC_4 = 'mindset-prod/memex-building-itself/specs/spec-286/acs/ac-4';
+const AC_5 = 'mindset-prod/memex-building-itself/specs/spec-286/acs/ac-5';
+
+const FACETS: QaReportFacets = {
+  total: 7,
+  tags: [
+    { id: 't-frontend', scope: 'area', value: 'frontend', count: 4 },
+    { id: 't-bug', scope: null, value: 'bug', count: 3 },
+  ],
+};
+
+function renderRail(overrides: Partial<Parameters<typeof QaReportsFilterRail>[0]> = {}) {
+  const onSelectTag = vi.fn();
+  const onChangeRange = vi.fn();
+  render(
+    <QaReportsFilterRail
+      facets={FACETS}
+      loading={false}
+      selectedTagId={null}
+      onSelectTag={onSelectTag}
+      range={ALL_TIME}
+      onChangeRange={onChangeRange}
+      {...overrides}
+    />,
+  );
+  return { onSelectTag, onChangeRange };
+}
+
+describe('QaReportsFilterRail (spec-286)', () => {
+  it('ac-4: roots the tree at "All" with the corpus total and one counted node per tag', () => {
+    tagAc(AC_4);
+    renderRail();
+
+    const all = screen.getByTestId('qa-reports-tag-all');
+    expect(all).toHaveTextContent('All');
+    expect(all).toHaveTextContent('7');
+
+    const nodes = screen.getAllByTestId('qa-reports-tag-node');
+    expect(nodes).toHaveLength(2);
+    expect(nodes[0]).toHaveTextContent('frontend');
+    const counts = screen.getAllByTestId('qa-reports-tag-count').map((n) => n.textContent);
+    expect(counts).toEqual(['4', '3']);
+  });
+
+  it('ac-4: clicking a tag selects it; clicking All clears the selection', () => {
+    tagAc(AC_4);
+    const { onSelectTag } = renderRail({ selectedTagId: 't-frontend' });
+
+    // The selected node is marked pressed.
+    const frontend = screen
+      .getAllByTestId('qa-reports-tag-node')
+      .find((n) => n.getAttribute('data-tag-id') === 't-frontend')!;
+    expect(frontend).toHaveAttribute('aria-pressed', 'true');
+
+    fireEvent.click(
+      screen
+        .getAllByTestId('qa-reports-tag-node')
+        .find((n) => n.getAttribute('data-tag-id') === 't-bug')!,
+    );
+    expect(onSelectTag).toHaveBeenCalledWith('t-bug');
+
+    fireEvent.click(screen.getByTestId('qa-reports-tag-all'));
+    expect(onSelectTag).toHaveBeenCalledWith(null);
+  });
+
+  it('ac-5: quick ranges emit a preset + lower bound; "All time" clears the window', () => {
+    tagAc(AC_5);
+    const { onChangeRange } = renderRail({ range: { preset: 'week', from: '2026-06-06T00:00:00.000Z' } });
+
+    fireEvent.click(screen.getByTestId('qa-reports-range-month'));
+    const monthArg = onChangeRange.mock.calls.at(-1)![0] as DateRangeState;
+    expect(monthArg.preset).toBe('month');
+    expect(typeof monthArg.from).toBe('string');
+    expect(monthArg.to).toBeUndefined();
+
+    fireEvent.click(screen.getByTestId('qa-reports-range-all'));
+    expect(onChangeRange).toHaveBeenLastCalledWith(ALL_TIME);
+  });
+
+  it('ac-5: a custom from/to range emits inclusive ISO bounds', () => {
+    tagAc(AC_5);
+    const { onChangeRange } = renderRail();
+
+    fireEvent.change(screen.getByTestId('qa-reports-range-from'), {
+      target: { value: '2026-01-15' },
+    });
+    const arg = onChangeRange.mock.calls.at(-1)![0] as DateRangeState;
+    expect(arg.preset).toBe('custom');
+    expect(arg.from).toBe('2026-01-15T00:00:00.000Z');
+
+    fireEvent.change(screen.getByTestId('qa-reports-range-to'), {
+      target: { value: '2026-01-31' },
+    });
+    const arg2 = onChangeRange.mock.calls.at(-1)![0] as DateRangeState;
+    // End-of-day so the chosen day is inclusive.
+    expect(arg2.to).toBe('2026-01-31T23:59:59.999Z');
+  });
+});

--- a/packages/ui/src/components/QaReportsFilterRail.tsx
+++ b/packages/ui/src/components/QaReportsFilterRail.tsx
@@ -1,0 +1,173 @@
+// spec-286: the QA Reports feed's left-hand filter rail. It STAYS IN PLACE while
+// the report list scrolls (sticky) and offers two stacked filter groups:
+//
+//   1. A tag tree rooted at "All" (every report) with one node per tag carrying
+//      its whole-corpus report count. Selecting a node filters the feed.
+//   2. Date filters — quick "Last week" / "Last month" ranges, an "All time"
+//      reset, and a custom from/to range.
+//
+// A tag selection and a date range compose with AND in the page (dec-3); the rail
+// just reports the user's intent up via callbacks. Counts come from the server
+// facet endpoint (dec-2), so they are correct across the whole corpus regardless
+// of how far the feed has paged.
+
+import { TagChip } from './TagChip';
+import type { QaReportFacets } from '../hooks/useQaReports';
+
+export type DateRangePreset = 'all' | 'week' | 'month' | 'custom';
+
+export interface DateRangeState {
+  preset: DateRangePreset;
+  /** ISO-8601 lower bound (inclusive). */
+  from?: string;
+  /** ISO-8601 upper bound (inclusive). */
+  to?: string;
+}
+
+export const ALL_TIME: DateRangeState = { preset: 'all' };
+
+/** ISO instant `days` before `now` — the lower bound for a quick range. */
+function daysAgoIso(days: number, now: Date = new Date()): string {
+  return new Date(now.getTime() - days * 86_400_000).toISOString();
+}
+
+interface QaReportsFilterRailProps {
+  facets: QaReportFacets;
+  loading: boolean;
+  /** Currently selected tag id, or null for "All". */
+  selectedTagId: string | null;
+  onSelectTag: (tagId: string | null) => void;
+  range: DateRangeState;
+  onChangeRange: (range: DateRangeState) => void;
+}
+
+export function QaReportsFilterRail({
+  facets,
+  loading,
+  selectedTagId,
+  onSelectTag,
+  range,
+  onChangeRange,
+}: QaReportsFilterRailProps) {
+  // `<input type="date">` wants a bare YYYY-MM-DD; our state carries full ISO.
+  const fromDate = range.from ? range.from.slice(0, 10) : '';
+  const toDate = range.to ? range.to.slice(0, 10) : '';
+
+  const setCustom = (next: { from?: string; to?: string }) => {
+    const from = next.from !== undefined ? next.from : fromDate;
+    const to = next.to !== undefined ? next.to : toDate;
+    onChangeRange({
+      preset: 'custom',
+      // End-of-day on `to` so the chosen day is inclusive.
+      from: from ? `${from}T00:00:00.000Z` : undefined,
+      to: to ? `${to}T23:59:59.999Z` : undefined,
+    });
+  };
+
+  return (
+    <aside
+      data-testid="qa-reports-rail"
+      // sticky + self-start keeps the rail in place while the feed column scrolls.
+      className="sticky top-4 self-start w-56 shrink-0 max-h-[calc(100vh-2rem)] overflow-y-auto pr-2"
+    >
+      <div data-testid="qa-reports-tag-tree">
+        <h2 className="px-2 text-xs font-semibold uppercase tracking-wide text-muted">Tags</h2>
+        <ul className="mt-1 space-y-0.5">
+          <li>
+            <button
+              type="button"
+              data-testid="qa-reports-tag-all"
+              aria-pressed={selectedTagId === null}
+              onClick={() => onSelectTag(null)}
+              className={`flex w-full items-center justify-between rounded-md px-2 py-1 text-sm ${
+                selectedTagId === null
+                  ? 'bg-overlay text-primary font-medium'
+                  : 'text-secondary hover:bg-overlay hover:text-primary'
+              }`}
+            >
+              <span>All</span>
+              <span className="text-xs text-muted tabular-nums">{facets.total}</span>
+            </button>
+          </li>
+          {facets.tags.map((tag) => (
+            <li key={tag.id}>
+              <button
+                type="button"
+                data-testid="qa-reports-tag-node"
+                data-tag-id={tag.id}
+                aria-pressed={selectedTagId === tag.id}
+                onClick={() => onSelectTag(tag.id)}
+                className={`flex w-full items-center justify-between gap-1 rounded-md px-2 py-1 ${
+                  selectedTagId === tag.id ? 'bg-overlay' : 'hover:bg-overlay'
+                }`}
+              >
+                <TagChip tag={tag} />
+                <span
+                  data-testid="qa-reports-tag-count"
+                  className="text-xs text-muted tabular-nums"
+                >
+                  {tag.count}
+                </span>
+              </button>
+            </li>
+          ))}
+          {!loading && facets.tags.length === 0 && (
+            <li className="px-2 py-1 text-xs text-muted">No tags yet</li>
+          )}
+        </ul>
+      </div>
+
+      <div data-testid="qa-reports-date-filters" className="mt-5">
+        <h2 className="px-2 text-xs font-semibold uppercase tracking-wide text-muted">When</h2>
+        <div className="mt-1 flex flex-wrap gap-1 px-2">
+          {(
+            [
+              { key: 'all', label: 'All time', build: (): DateRangeState => ALL_TIME },
+              { key: 'week', label: 'Last week', build: (): DateRangeState => ({ preset: 'week', from: daysAgoIso(7) }) },
+              { key: 'month', label: 'Last month', build: (): DateRangeState => ({ preset: 'month', from: daysAgoIso(30) }) },
+            ] as const
+          ).map((opt) => (
+            <button
+              key={opt.key}
+              type="button"
+              data-testid={`qa-reports-range-${opt.key}`}
+              aria-pressed={range.preset === opt.key}
+              onClick={() => onChangeRange(opt.build())}
+              className={`rounded-full border px-2 py-0.5 text-xs ${
+                range.preset === opt.key
+                  ? 'border-accent text-accent'
+                  : 'border-edge-subtle text-secondary hover:text-primary'
+              }`}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+        <div className="mt-2 flex flex-col gap-1 px-2 text-xs text-secondary">
+          <label className="flex items-center justify-between gap-2">
+            <span>From</span>
+            <input
+              type="date"
+              data-testid="qa-reports-range-from"
+              value={fromDate}
+              max={toDate || undefined}
+              onChange={(e) => setCustom({ from: e.target.value })}
+              className="qa-date-input w-36 rounded border border-edge-subtle bg-surface px-1 py-0.5 text-primary"
+            />
+          </label>
+          <label className="flex items-center justify-between gap-2">
+            <span>To</span>
+            <input
+              type="date"
+              data-testid="qa-reports-range-to"
+              value={toDate}
+              min={fromDate || undefined}
+              onChange={(e) => setCustom({ to: e.target.value })}
+              className="qa-date-input w-36 rounded border border-edge-subtle bg-surface px-1 py-0.5 text-primary"
+            />
+          </label>
+        </div>
+      </div>
+    </aside>
+  );
+}

--- a/packages/ui/src/components/SearchPalette.test.tsx
+++ b/packages/ui/src/components/SearchPalette.test.tsx
@@ -35,6 +35,7 @@ vi.mock('react-router-dom', async () => {
 });
 
 const SPEC_64 = 'mindset-prod/memex-building-itself/specs/spec-64';
+const SPEC_285 = 'mindset-prod/memex-building-itself/specs/spec-285';
 
 function hit(over: Partial<SearchHit> = {}): SearchHit {
   return {
@@ -253,6 +254,83 @@ describe('SearchPalette', () => {
     expect((snippet as HTMLElement).querySelector('strong')).toBeNull();
     expect((snippet as HTMLElement).querySelector('a')).toBeNull();
     expect((snippet as HTMLElement).querySelector('img')).toBeNull();
+  });
+
+  it('content rows render a WHO/WHEN byline; navigation rows and metadata-less rows render none [spec-285]', async () => {
+    tagAc(`${SPEC_285}/acs/ac-9`);
+    const user = userEvent.setup();
+    renderOpen(
+      envelope({
+        jumpTo: [
+          hit({
+            kind: 'spec',
+            path: 'mindset-prod/memex-building-itself/specs/spec-64',
+            title: 'Jump spec',
+            status: 'build',
+            // A navigation hit may carry no metadata — and even if it did, the
+            // byline is content-lane only.
+            authorName: null,
+            lastUpdatedAt: null,
+          }),
+        ],
+        content: [
+          hit({
+            kind: 'spec',
+            path: 'mindset-prod/memex-building-itself/specs/spec-99',
+            title: 'Authored spec',
+            status: 'draft',
+            authorName: 'Ada Lovelace',
+            lastUpdatedAt: '2026-05-28T09:30:00.000Z',
+            matchingSections: [
+              {
+                id: 's1',
+                sectionType: 'purpose',
+                title: 'Purpose',
+                content: 'Body match.',
+                matchedVia: 'fts',
+              },
+            ],
+          }),
+          hit({
+            kind: 'standard',
+            path: 'mindset-prod/memex-building-itself/standards/std-7',
+            title: 'Metadata-less std',
+            status: 'active',
+            // No author/timestamp resolved → no byline.
+            matchingSections: [
+              {
+                id: 's2',
+                sectionType: 'rule',
+                title: 'Rule',
+                content: 'A rule.',
+                matchedVia: 'fts',
+              },
+            ],
+          }),
+        ],
+      }),
+    );
+
+    await user.type(screen.getByRole('combobox'), 'omni');
+    await screen.findByText('Authored spec');
+
+    // The content row shows "<author> · <YYYY-MM-DD>" — human-readable, derived
+    // from the structured authorName + lastUpdatedAt the REST route now carries.
+    const authoredRow = screen.getByText('Authored spec').closest('[cmdk-item]')!;
+    const byline = within(authoredRow as HTMLElement).getByTestId('search-byline');
+    expect(byline.textContent).toBe('Ada Lovelace · 2026-05-28');
+
+    // A content row with no resolved author/timestamp renders no byline element.
+    const bareRow = screen.getByText('Metadata-less std').closest('[cmdk-item]')!;
+    expect(
+      within(bareRow as HTMLElement).queryByTestId('search-byline'),
+    ).toBeNull();
+
+    // Navigation (jumpTo) rows never carry a byline.
+    const jumpRow = screen.getByText('Jump spec').closest('[cmdk-item]')!;
+    expect(
+      within(jumpRow as HTMLElement).queryByTestId('search-byline'),
+    ).toBeNull();
   });
 
   it('exposes role=dialog, role=listbox, and aria-selected on the active option [ac-15]', async () => {

--- a/packages/ui/src/components/SearchPalette.tsx
+++ b/packages/ui/src/components/SearchPalette.tsx
@@ -89,6 +89,18 @@ function handleFromPath(path: string): string {
   return path.split('/').filter((seg) => HANDLE_SEGMENT.test(seg)).join('/');
 }
 
+// spec-285: the WHO/WHEN byline for a content row — "<author> · <YYYY-MM-DD>".
+// Mirrors the agent-facing markdown byline (formatSearchResults) so the palette
+// tells a human who last touched a result and when, without opening it. Degrades
+// to author-only / date-only / nothing when a field is absent (navigation lanes
+// carry neither). The date is the calendar day of the ISO timestamp.
+function bylineText(hit: SearchHit): string | null {
+  const author = hit.authorName?.trim() || null;
+  const date = hit.lastUpdatedAt ? hit.lastUpdatedAt.slice(0, 10) : null;
+  if (author && date) return `${author} · ${date}`;
+  return author ?? date;
+}
+
 // spec-64 t-4 (ac-9): every row carries a kind badge + a status badge. The kind
 // badge reuses the neutral Badge styling with an explicit label so it reads
 // "Spec" / "Standard" / … rather than a status colour.
@@ -118,6 +130,10 @@ function ResultRow({
     lane === 'content' && hit.matchingSections.length > 0
       ? snippetText(hit.matchingSections[0].content, SNIPPET_MAX)
       : null;
+
+  // spec-285: content rows carry a WHO/WHEN byline (navigation lanes don't —
+  // their hits carry no author/timestamp).
+  const byline = lane === 'content' ? bylineText(hit) : null;
 
   // The handle (spec-N / std-N / …) renders next to the title so the user can
   // tell WHICH spec a row is without opening it — titles alone are ambiguous.
@@ -154,6 +170,11 @@ function ResultRow({
       {snippet && (
         <span className="truncate text-xs text-secondary" data-testid="search-snippet">
           {snippet}
+        </span>
+      )}
+      {byline && (
+        <span className="truncate text-xs text-muted" data-testid="search-byline">
+          {byline}
         </span>
       )}
     </Command.Item>

--- a/packages/ui/src/components/phaseColors.spec-252.test.tsx
+++ b/packages/ui/src/components/phaseColors.spec-252.test.tsx
@@ -119,8 +119,11 @@ describe('phase colour palette (spec-252 dec-1)', () => {
     expect(phaseColors('verify')!.pill).toContain('bg-phase-verify-bg');
     // draft has no Figma hue yet → keeps the neutral status token.
     expect(phaseColors('draft')!.pill).toContain('bg-status-neutral-bg');
-    // done keeps its current treatment — no phase colour.
-    expect(phaseColors('done')).toBeNull();
+    // spec-286 gave `done` a neutral GREY pill (no longer null), but spec-252's
+    // guarantee still holds: done gets no coloured CONTAINER wash — its container
+    // stays empty, so the DocDocument header surface is unchanged at done.
+    expect(phaseColors('done')!.pill).toContain('bg-status-neutral-bg');
+    expect(phaseColors('done')!.container).toBe('');
     // The shared statusVariant is untouched: specify/review/open stay amber, so
     // board column headers and issue badges do not recolour.
     expect(statusVariant('specify')).toBe('warning');

--- a/packages/ui/src/components/phaseColors.spec-286.test.ts
+++ b/packages/ui/src/components/phaseColors.spec-286.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { phaseColors } from './phaseColors';
+
+const AC_10 = 'mindset-prod/memex-building-itself/specs/spec-286/acs/ac-10';
+
+// spec-286 dec-3 / ac-10: `done` is no longer null — it returns a neutral grey
+// pill (the status-neutral tokens), distinct from build (blue) and verify (teal).
+describe('phaseColors — done pill (spec-286)', () => {
+  it('ac-10: returns a neutral grey pill for done, distinct from build/verify', () => {
+    tagAc(AC_10);
+
+    const done = phaseColors('done');
+    expect(done).not.toBeNull();
+    expect(done!.pill).toContain('status-neutral');
+
+    // Distinct from the live phases.
+    expect(done!.pill).not.toBe(phaseColors('build')!.pill);
+    expect(done!.pill).not.toBe(phaseColors('verify')!.pill);
+
+    // Container stays empty so the DocDocument header wash is unaffected at done.
+    expect(done!.container).toBe('');
+  });
+});

--- a/packages/ui/src/components/phaseColors.ts
+++ b/packages/ui/src/components/phaseColors.ts
@@ -24,7 +24,7 @@ export interface PhaseColor {
   container: string;
 }
 
-const PALETTE: Record<'draft' | 'specify' | 'build' | 'verify', PhaseColor> = {
+const PALETTE: Record<'draft' | 'specify' | 'build' | 'verify' | 'done', PhaseColor> = {
   draft: {
     pill: 'bg-status-neutral-bg text-status-neutral-text border-status-neutral-border',
     container: 'bg-phase-draft-container',
@@ -41,11 +41,22 @@ const PALETTE: Record<'draft' | 'specify' | 'build' | 'verify', PhaseColor> = {
     pill: 'bg-phase-verify-bg text-phase-verify-text border-phase-verify-border',
     container: 'bg-phase-verify-container',
   },
+  // spec-286 dec-3: `done` is terminal, so it gets a calm NEUTRAL GREY pill
+  // (reusing the same status-neutral tokens as draft) — distinct from the live
+  // build (blue) / verify (teal) hues. The container stays EMPTY: the only
+  // pre-spec-286 caller that reads `.container` is the DocDocument header wash,
+  // where done is handled by DoneSummary, so '' preserves that surface's existing
+  // no-wash behaviour. The feed (spec-286) uses `.pill` only.
+  done: {
+    pill: 'bg-status-neutral-bg text-status-neutral-text border-status-neutral-border',
+    container: '',
+  },
 };
 
 /**
- * The phase's pill + container colours, or `null` for `done` — which keeps its
- * current treatment (the phase bar is hidden at done; DoneSummary takes over).
+ * The phase's pill + container colours. Returns a value for every spec phase
+ * including `done` (spec-286 added the neutral grey done pill); `null` only for
+ * an unknown / non-spec status.
  */
 export function phaseColors(phase: SpecStatus): PhaseColor | null {
   return PALETTE[phase as keyof typeof PALETTE] ?? null;

--- a/packages/ui/src/hooks/useQaReports.spec-260.test.tsx
+++ b/packages/ui/src/hooks/useQaReports.spec-260.test.tsx
@@ -147,7 +147,8 @@ describe('useQaReportsFeed (dec-5 keyset Load More)', () => {
     const page2 = [{ id: 'r-0', createdAt: '2026-05-30T00:00:00Z' }];
     fetchMock.mockResolvedValueOnce(jsonResponse(page1));
 
-    const { result } = renderHook(() => useQaReportsFeed(2), { wrapper });
+    // spec-286 moved the page-size to the 2nd arg (1st is now the filter object).
+    const { result } = renderHook(() => useQaReportsFeed({}, 2), { wrapper });
     await waitFor(() => expect(result.current.rows).toHaveLength(2));
     // A full page (length == limit) keeps Load More enabled.
     expect(result.current.hasMore).toBe(true);

--- a/packages/ui/src/hooks/useQaReports.ts
+++ b/packages/ui/src/hooks/useQaReports.ts
@@ -21,21 +21,48 @@ const DEFAULT_LIMIT = 50;
 // activity), so without this the badge would stay stale until the next event.
 export const QA_REPORTS_VIEWED_EVENT = 'memex:qa-reports-viewed';
 
+/** A tag carried on a report's owning Spec — feeds the rail chips (spec-286). */
+export interface QaReportTagRef {
+  id: string;
+  scope: string | null;
+  value: string;
+}
+
 /** Wire shape of GET /api/<ns>/<mx>/qa-reports rows (server QaReportFeedRow). */
 export interface QaReportFeedRow {
   id: string;
   docId: string;
   docHandle: string;
   docTitle: string;
+  /** Owning Spec's current phase — drives the phase pill (spec-286). */
+  phase: string;
   sectionType: string;
   version: number;
   title: string | null;
   content: string;
+  /** The Spec author (creator). Absent on the public-read projection (spec-286). */
+  authorUserId?: string | null;
+  authorName?: string | null;
+  /** std-32 actor = the implementer of this build session. */
   actorUserId?: string | null;
   actorName?: string | null;
   actorKind: 'human' | 'mcp_agent' | 'in_app_agent' | 'system';
   channel: string | null;
+  /** Owning Spec's tags — the rail filter chips (spec-286). */
+  tags: QaReportTagRef[];
   createdAt: string;
+}
+
+/**
+ * Server-parameterised feed filters (spec-286 dec-2). A tag id and a date window,
+ * composing with AND. Undefined fields are omitted from the query → unfiltered.
+ */
+export interface QaReportFilters {
+  tagId?: string;
+  /** ISO-8601 lower bound (inclusive) on report createdAt. */
+  from?: string;
+  /** ISO-8601 upper bound (inclusive) on report createdAt. */
+  to?: string;
 }
 
 export interface UseQaReportsFeedResult {
@@ -47,7 +74,10 @@ export interface UseQaReportsFeedResult {
   refresh: () => Promise<void>;
 }
 
-export function useQaReportsFeed(limit = DEFAULT_LIMIT): UseQaReportsFeedResult {
+export function useQaReportsFeed(
+  filters: QaReportFilters = {},
+  limit = DEFAULT_LIMIT,
+): UseQaReportsFeedResult {
   const [rows, setRows] = useState<QaReportFeedRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -60,6 +90,10 @@ export function useQaReportsFeed(limit = DEFAULT_LIMIT): UseQaReportsFeedResult 
   rowsRef.current = rows;
   const loadingOlderRef = useRef(false);
 
+  // Destructure so the fetch callback depends on primitive values, not the object
+  // identity — a caller passing a fresh `{}` each render must not re-trigger fetches.
+  const { tagId, from, to } = filters;
+
   const fetchPage = useCallback(
     async (since: string | undefined): Promise<QaReportFeedRow[]> => {
       const base = tenantBase();
@@ -69,11 +103,16 @@ export function useQaReportsFeed(limit = DEFAULT_LIMIT): UseQaReportsFeedResult 
       const params = new URLSearchParams();
       params.set('limit', String(limit));
       if (since) params.set('since', since);
+      // The spec-286 filters ride alongside the keyset cursor, so a filtered
+      // "Load More" returns the strictly-older filtered page.
+      if (tagId) params.set('tag', tagId);
+      if (from) params.set('from', from);
+      if (to) params.set('to', to);
       const res = await fetchWithRetry(`${base}/qa-reports?${params.toString()}`);
       if (!res.ok) throw new Error(`Failed to load QA reports (${res.status})`);
       return (await res.json()) as QaReportFeedRow[];
     },
-    [limit],
+    [limit, tagId, from, to],
   );
 
   const refresh = useCallback(async () => {
@@ -116,6 +155,81 @@ export function useQaReportsFeed(limit = DEFAULT_LIMIT): UseQaReportsFeedResult 
   }, [refresh]);
 
   return { rows, loading, error, hasMore, loadOlder, refresh };
+}
+
+// ── Tag facets for the filter rail (spec-286 dec-2) ────────────────────────────
+
+export interface QaReportTagFacet extends QaReportTagRef {
+  count: number;
+}
+
+export interface QaReportFacets {
+  /** Total reports in the corpus (the "All" node count). */
+  total: number;
+  tags: QaReportTagFacet[];
+}
+
+export interface UseQaReportTagFacetsResult {
+  facets: QaReportFacets;
+  loading: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+}
+
+const EMPTY_FACETS: QaReportFacets = { total: 0, tags: [] };
+
+/**
+ * The rail's tag tree (spec-286): every tag carried by a Spec with reports, each
+ * with its whole-corpus report count, plus the "All" total. Honours an optional
+ * date window so the counts stay consistent with an active date filter. Refreshes
+ * live off the std-8 bus the way the feed does — a new report changes the counts.
+ */
+export function useQaReportTagFacets(
+  window: { from?: string; to?: string } = {},
+): UseQaReportTagFacetsResult {
+  const [facets, setFacets] = useState<QaReportFacets>(EMPTY_FACETS);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const reqToken = useRef(0);
+
+  const { from, to } = window;
+
+  const refresh = useCallback(async () => {
+    const myReq = ++reqToken.current;
+    const base = tenantBase();
+    if (!base) {
+      setError('QA Reports requires tenant context (no namespace/memex in the URL).');
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      const params = new URLSearchParams();
+      if (from) params.set('from', from);
+      if (to) params.set('to', to);
+      const qs = params.toString();
+      const res = await fetchWithRetry(`${base}/qa-reports/facets${qs ? `?${qs}` : ''}`);
+      if (!res.ok) throw new Error(`Failed to load tag facets (${res.status})`);
+      const body = (await res.json()) as QaReportFacets;
+      if (myReq !== reqToken.current) return; // superseded
+      setFacets(body);
+    } catch (err) {
+      if (myReq !== reqToken.current) return;
+      setError(err instanceof Error ? err.message : 'Failed to load tag facets');
+    } finally {
+      if (myReq === reqToken.current) setLoading(false);
+    }
+  }, [from, to]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  // Live: a freshly written report rides the std-8 bus → recompute counts.
+  useDocChangeStream(null, refresh);
+
+  return { facets, loading, error, refresh };
 }
 
 export interface QaReportsViewReceipt {

--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -286,6 +286,31 @@
 .prose-content em, .prose-dark em { color: rgb(var(--color-text-primary)); }
 .prose-content img, .prose-dark img { @apply rounded-lg my-4 max-w-full; }
 
+/*
+ * spec-286: subordinate prose for the QA Reports feed. `.prose-qa` layers ON TOP
+ * of `.prose-dark` (use both classes together) and DEMOTES the markdown heading
+ * scale so a report's internal headings sit BELOW the card's spec-name heading
+ * (which is text-lg) instead of dwarfing it — `.prose-dark h1` is text-3xl, larger
+ * than the card title, which was the inverted-hierarchy bug. Headings here cap at
+ * text-base and tighten their vertical rhythm; everything else inherits prose-dark.
+ */
+.prose-qa h1 { @apply text-base font-semibold mt-4 mb-2; }
+.prose-qa h2 { @apply text-sm font-semibold mt-3 mb-1.5; }
+.prose-qa h3 { @apply text-sm font-medium mt-3 mb-1; }
+.prose-qa h4 { @apply text-xs font-semibold uppercase tracking-wide mt-2 mb-1; }
+.prose-qa h5, .prose-qa h6 { @apply text-xs font-medium mt-2 mb-1; }
+/* Body copy a touch smaller than the card chrome so the heading still leads. */
+.prose-qa p, .prose-qa li { @apply text-sm; }
+
+/*
+ * spec-286: the QA Reports rail date inputs. In dark mode the browser's native
+ * `<input type="date">` calendar-picker glyph defaults to a dark icon that
+ * disappears against the dark surface. Adopting the dark `color-scheme` under the
+ * `.dark` theme makes the UA paint that glyph (and the input's internals) light —
+ * the idiomatic, cross-browser fix. Light theme keeps the default dark glyph.
+ */
+.dark .qa-date-input { color-scheme: dark; }
+
 @keyframes slide-in-right {
   from {
     transform: translateX(100%);

--- a/packages/ui/src/pages/DocDocument.spec-159.test.tsx
+++ b/packages/ui/src/pages/DocDocument.spec-159.test.tsx
@@ -26,6 +26,10 @@ const AC252 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-252/
 // spec-283 relocates the review actions off the page; these tests verify the
 // page-side removal (ac-3/ac-9) — the agent-side arrival is in ChatPanel.test.tsx.
 const AC283 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-283/acs/ac-${n}`;
+// spec-287: one prompt per posture in Specify — the review handoff is re-gated
+// to non-editors (!canEdit), and its link is Title Case ("Copy the Review
+// prompt"). Supersedes spec-283 dec-4's "ungated, both postures" clause.
+const AC287 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-287/acs/ac-${n}`;
 
 // ── Heavy children → identity markers so we can see which panel rendered ────
 vi.mock('../components/DecisionPanel', () => ({
@@ -70,9 +74,13 @@ vi.mock('../components/DoneSummary', () => ({
 // ── Hooks: write access + a configurable posture (i-1: the sentence renders
 //    for reviewers too; only the Yes gates on editor posture) ────────────────
 let mockRole: 'editor' | 'reviewer' = 'editor';
+// spec-287: a read-only (non-member) viewer has canWrite=false → canEdit=false,
+// so they fall on the non-editor side of the review-handoff gate. Mutable so a
+// test can drop write access without re-mocking the module.
+let mockCanWrite = true;
 const refetchRole = vi.fn();
 vi.mock('../hooks/useMemexAccess', () => ({
-  useMemexAccess: () => ({ canWrite: true, isReadOnly: false }),
+  useMemexAccess: () => ({ canWrite: mockCanWrite, isReadOnly: !mockCanWrite }),
 }));
 vi.mock('../hooks/useDocRole', () => ({
   useDocRole: () => ({ myRole: mockRole, editors: [], loading: false, refetch: refetchRole }),
@@ -187,6 +195,7 @@ beforeEach(() => {
   promoteToEditor.mockResolvedValue(undefined);
   demoteToReviewer.mockResolvedValue(undefined);
   mockRole = 'editor';
+  mockCanWrite = true;
   docDecisions = [];
   docTasks = [];
   docAcs = [];
@@ -528,6 +537,7 @@ describe('spec-159 — Rubicon line + in-situ directives', () => {
 
   it('editor keeps the phase block — tabs + the Rubicon transition sentence (ac-19)', async () => {
     tagAc(AC(19));
+    tagAc(AC287(1));
     mockRole = 'editor';
     renderAt('specify');
     await screen.findByText('Narrative');
@@ -536,29 +546,36 @@ describe('spec-159 — Rubicon line + in-situ directives', () => {
     expect(screen.getAllByRole('tab')).toHaveLength(4);
     expect(screen.getByTestId('transition-sentence')).toBeInTheDocument();
     // spec-283 dec-4: the "Review actions" disclosure + button row are GONE
-    // from the page (relocated to the agent's idle state). The editor sees
-    // neither the toggle nor the row; the review-handoff line stays, ungated.
+    // from the page (relocated to the agent's idle state). spec-287 dec-2: the
+    // review-handoff line is now NON-editor-only — an editor sees neither the
+    // toggle, the row, NOR the review handoff. One prompt per posture: the
+    // editor's single Specify-phase prompt is the phase handoff below.
     expect(screen.queryByTestId('review-actions-toggle')).not.toBeInTheDocument();
     expect(screen.queryByTestId('review-action-row')).not.toBeInTheDocument();
-    expect(screen.getByTestId('review-handoff-line')).toBeInTheDocument();
+    expect(screen.queryByTestId('review-handoff-line')).not.toBeInTheDocument();
   });
 
   // spec-283 dec-4 — the "Review actions" disclosure (spec-182 ac-10/ac-11) is
   // RETIRED: the toggle and the four-button row are deleted from the page (the
-  // actions moved to the agent's idle state). For the editor the review-handoff
-  // line is no longer behind a disclosure — it renders ungated in Specify
-  // alongside the phase handoff, with no expand step.
-  it('editor at Specify: no review disclosure or row; the review-handoff line renders ungated (spec-283 ac-9, retires spec-182 ac-10/ac-11)', async () => {
+  // actions moved to the agent's idle state). spec-287 dec-2 then SUPERSEDES
+  // spec-283's "review handoff ungated for both postures": one prompt per
+  // posture. For the editor that single prompt is the phase handoff — the
+  // review handoff is NOT shown. (The toggle/row-gone half of spec-283 ac-9
+  // still holds and is still tagged here.)
+  it('editor at Specify: no review disclosure/row, and the review-handoff line is NOT shown — only the phase handoff (spec-287 ac-1/ac-8, supersedes spec-283 dec-4 for editors)', async () => {
     tagAc(AC283(9));
+    tagAc(AC287(1));
+    tagAc(AC287(8));
+    tagAc(AC287(9)); // the editor's phase handoff still renders (canEdit && handoff)
     mockRole = 'editor';
     renderAt('specify');
 
     await screen.findByText('Narrative');
     expect(screen.queryByTestId('review-actions-toggle')).not.toBeInTheDocument();
     expect(screen.queryByTestId('review-action-row')).not.toBeInTheDocument();
-    // The review-handoff line is present immediately — no expand needed.
-    expect(screen.getByTestId('review-handoff-line')).toBeInTheDocument();
-    // The editor's own phase handoff still renders.
+    // spec-287: the review handoff is non-editor-only — absent for the editor.
+    expect(screen.queryByTestId('review-handoff-line')).not.toBeInTheDocument();
+    // The editor's single Specify-phase prompt: the phase handoff.
     expect(screen.getByTestId('phase-handoff-line')).toBeInTheDocument();
   });
 });
@@ -651,23 +668,26 @@ describe('spec-182 — unified reviewer phase block', () => {
     }
   });
 
-  it('renders the reviewer handoff line — "Copy the review prompt …conduct the review from there."', async () => {
+  it('renders the reviewer handoff line — "Copy the Review prompt …conduct the review from there." (spec-287 ac-2/ac-3/ac-7)', async () => {
     tagAc(AC182(11));
+    tagAc(AC287(2));
+    tagAc(AC287(3));
+    tagAc(AC287(7));
     renderAt('specify');
 
     const line = await screen.findByTestId('review-handoff-line');
+    // spec-287 dec-1: Title Case, matching the Specify/Build/Verify family.
     expect(line.textContent).toContain(
-      'Copy the review prompt into your coding agent if you prefer to conduct the review from there.',
+      'Copy the Review prompt into your coding agent if you prefer to conduct the review from there.',
     );
     // issue-4: the clickable words LEAD the line and NAME the prompt, so
     // adjacent handoff lines are distinguishable from the link text alone.
     const copyButton = within(line).getByRole('button', {
-      name: /^Copy the review prompt/,
+      name: /^Copy the Review prompt/,
     });
-    expect(copyButton.textContent).toBe('Copy the review prompt');
-    // spec-182 issue-2: the phase handoff is an editor affordance — its prompt
-    // drives state changes and building. A reviewer gets the review handoff
-    // ONLY (amends ac-17's "renders for every viewer").
+    expect(copyButton.textContent).toBe('Copy the Review prompt');
+    // spec-182 issue-2 + spec-287 dec-2: a reviewer gets the review handoff
+    // ONLY — one prompt per posture, so the editor's phase handoff is absent.
     expect(screen.queryByTestId('phase-handoff-line')).not.toBeInTheDocument();
   });
 
@@ -811,18 +831,35 @@ describe('spec-159 ac-17 — next-action handoff line', () => {
     expect(screen.queryByTestId('phase-handoff-line')).not.toBeInTheDocument();
   });
 
-  it('a writable reviewer at Specify gets the review handoff ONLY — no phase handoff (spec-182 issue-2)', async () => {
+  it('a writable reviewer at Specify gets the review handoff ONLY — no phase handoff (spec-182 issue-2, spec-287 ac-2)', async () => {
     tagAc(AC182(17));
     tagAc(AC182(11));
+    tagAc(AC287(2));
+    tagAc(AC287(9)); // reviewer sees review-handoff, NOT phase-handoff
     mockRole = 'reviewer';
     renderAt('specify');
 
-    // spec-182 issue-2: the phase handoff is canEdit-gated — the reviewer
-    // keeps dec-3's review handoff at Specify and nothing else.
+    // spec-182 issue-2 + spec-287 dec-2: the phase handoff is canEdit-gated —
+    // the reviewer keeps the review handoff at Specify and nothing else.
     const line = await screen.findByTestId('review-handoff-line');
     expect(line.textContent).toContain(
-      'Copy the review prompt into your coding agent if you prefer to conduct the review from there.',
+      'Copy the Review prompt into your coding agent if you prefer to conduct the review from there.',
     );
+    expect(screen.queryByTestId('phase-handoff-line')).not.toBeInTheDocument();
+  });
+
+  // spec-287 ac-2: a READ-ONLY viewer (non-member: canWrite=false → canEdit=
+  // false) falls on the non-editor side of the gate — they see the review
+  // handoff and NOT the editor's phase handoff, same as a reviewer.
+  it('a read-only viewer at Specify sees the review handoff ONLY — no phase handoff (spec-287 ac-2/ac-9)', async () => {
+    tagAc(AC287(2));
+    tagAc(AC287(9));
+    mockCanWrite = false;
+    mockRole = 'reviewer';
+    renderAt('specify');
+
+    const line = await screen.findByTestId('review-handoff-line');
+    expect(line.textContent).toContain('Copy the Review prompt');
     expect(screen.queryByTestId('phase-handoff-line')).not.toBeInTheDocument();
   });
 });

--- a/packages/ui/src/pages/DocDocument.spec-159.test.tsx
+++ b/packages/ui/src/pages/DocDocument.spec-159.test.tsx
@@ -23,6 +23,9 @@ import type { DocWithGraph } from '../api/types';
 
 const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-159/acs/ac-${n}`;
 const AC252 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-252/acs/ac-${n}`;
+// spec-283 relocates the review actions off the page; these tests verify the
+// page-side removal (ac-3/ac-9) — the agent-side arrival is in ChatPanel.test.tsx.
+const AC283 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-283/acs/ac-${n}`;
 
 // ── Heavy children → identity markers so we can see which panel rendered ────
 vi.mock('../components/DecisionPanel', () => ({
@@ -532,38 +535,31 @@ describe('spec-159 — Rubicon line + in-situ directives', () => {
     // Editors still get the PhaseTabBar (3 phase tabs) and the Rubicon line.
     expect(screen.getAllByRole('tab')).toHaveLength(4);
     expect(screen.getByTestId('transition-sentence')).toBeInTheDocument();
-    // spec-182 dec-3 + issue-3: at Specify the editor keeps ACCESS to the
-    // review actions, but behind a collapsed-by-default disclosure.
-    expect(screen.getByTestId('review-actions-toggle')).toBeInTheDocument();
+    // spec-283 dec-4: the "Review actions" disclosure + button row are GONE
+    // from the page (relocated to the agent's idle state). The editor sees
+    // neither the toggle nor the row; the review-handoff line stays, ungated.
+    expect(screen.queryByTestId('review-actions-toggle')).not.toBeInTheDocument();
     expect(screen.queryByTestId('review-action-row')).not.toBeInTheDocument();
+    expect(screen.getByTestId('review-handoff-line')).toBeInTheDocument();
   });
 
-  // spec-182 issue-3 — the editor's Specify view was visually dominated by the
-  // reviewer workflow (four review buttons + two handoff lines). The user's
-  // call (2026-06-05): collapse, don't remove — editors keep dec-3's access
-  // behind a "Review actions" disclosure; reviewers see it expanded, no chrome.
-  it('editor at Specify: the disclosure expands to the review row + review handoff, and collapses again (issue-3)', async () => {
-    tagAc(AC182(10));
-    tagAc(AC182(11));
+  // spec-283 dec-4 — the "Review actions" disclosure (spec-182 ac-10/ac-11) is
+  // RETIRED: the toggle and the four-button row are deleted from the page (the
+  // actions moved to the agent's idle state). For the editor the review-handoff
+  // line is no longer behind a disclosure — it renders ungated in Specify
+  // alongside the phase handoff, with no expand step.
+  it('editor at Specify: no review disclosure or row; the review-handoff line renders ungated (spec-283 ac-9, retires spec-182 ac-10/ac-11)', async () => {
+    tagAc(AC283(9));
     mockRole = 'editor';
-    const user = userEvent.setup();
     renderAt('specify');
 
-    const toggle = await screen.findByTestId('review-actions-toggle');
-    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    await screen.findByText('Narrative');
+    expect(screen.queryByTestId('review-actions-toggle')).not.toBeInTheDocument();
     expect(screen.queryByTestId('review-action-row')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('review-handoff-line')).not.toBeInTheDocument();
-    // The editor's own phase handoff is NOT behind the disclosure.
-    expect(screen.getByTestId('phase-handoff-line')).toBeInTheDocument();
-
-    await user.click(toggle);
-    expect(toggle).toHaveAttribute('aria-expanded', 'true');
-    expect(screen.getByTestId('review-action-row')).toBeInTheDocument();
+    // The review-handoff line is present immediately — no expand needed.
     expect(screen.getByTestId('review-handoff-line')).toBeInTheDocument();
-
-    await user.click(toggle);
-    expect(screen.queryByTestId('review-action-row')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('review-handoff-line')).not.toBeInTheDocument();
+    // The editor's own phase handoff still renders.
+    expect(screen.getByTestId('phase-handoff-line')).toBeInTheDocument();
   });
 });
 
@@ -586,14 +582,15 @@ describe('spec-182 — unified reviewer phase block', () => {
     tagAc('mindset-prod/memex-building-itself/specs/spec-182/acs/ac-2');
     renderAt('specify');
 
-    await screen.findByTestId('review-action-row');
+    // spec-283: the review-action row is gone; the review-handoff line is the
+    // stable Specify-phase reviewer affordance to anchor on.
+    await screen.findByTestId('review-handoff-line');
     // The PhaseTabBar renders for reviewers too (dec-1) — browse-only.
     expect(screen.getAllByRole('tab')).toHaveLength(4);
     // The Rubicon line renders status-only: present, but no [Yes] (dec-2).
     const sentence = screen.getByTestId('transition-sentence');
     expect(within(sentence).queryByRole('button', { name: 'Yes' })).not.toBeInTheDocument();
-    // issue-3: the collapse disclosure is editor chrome — reviewers get the
-    // row expanded directly, no toggle.
+    // spec-283 dec-4: the "Review actions" disclosure toggle is deleted.
     expect(screen.queryByTestId('review-actions-toggle')).not.toBeInTheDocument();
   });
 
@@ -603,7 +600,7 @@ describe('spec-182 — unified reviewer phase block', () => {
     tagAc(AC252(10)); // spec-252: this header-slot assertion updated to the new location
     const user = userEvent.setup();
     renderAt('specify');
-    await screen.findByTestId('review-action-row');
+    await screen.findByTestId('review-handoff-line');
 
     // spec-252 dec-2: the pill moved OUT of the header slot INTO the in-page
     // phase container, left of the phase bar. It is no longer in the header
@@ -640,27 +637,18 @@ describe('spec-182 — unified reviewer phase block', () => {
     expect(refetchRole).toHaveBeenCalled();
   });
 
-  it('renders the four review-action buttons; clicking one sends the scaffold prompt through chat', async () => {
-    tagAc(AC182(10));
-    tagAc(AC182(11));
-    tagAc(AC182(3));
-    const user = userEvent.setup();
+  // spec-283 ac-3 (retires spec-182 ac-3): the four review buttons are gone
+  // from the page — their behaviour ("clicking one sends the scaffold prompt
+  // through chat") is re-verified on the AGENT surface in ChatPanel.test.tsx.
+  it('reviewer at Specify: no review buttons remain on the page; only the review-handoff line (spec-283 ac-3)', async () => {
+    tagAc(AC283(3));
     renderAt('specify');
 
-    const row = await screen.findByTestId('review-action-row');
+    await screen.findByTestId('review-handoff-line');
+    expect(screen.queryByTestId('review-action-row')).not.toBeInTheDocument();
     for (const label of ['Summarise Spec', 'Security review', 'Design review', 'Architecture review']) {
-      expect(within(row).getByRole('button', { name: label })).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: label })).not.toBeInTheDocument();
     }
-
-    await user.click(within(row).getByRole('button', { name: 'Security review' }));
-    expect(chat.sendMessage).toHaveBeenCalledTimes(1);
-    const prompt = chat.sendMessage.mock.calls[0][0] as string;
-    // Non-empty prose resolved from the scaffold, interpolated with the Spec's
-    // own context (the handle appears in the security-review prompt's body? it
-    // references the Spec generically — assert it's a real, non-trivial string).
-    expect(typeof prompt).toBe('string');
-    expect(prompt.length).toBeGreaterThan(20);
-    expect(prompt).toContain('security');
   });
 
   it('renders the reviewer handoff line — "Copy the review prompt …conduct the review from there."', async () => {
@@ -933,9 +921,9 @@ describe('spec-252 — coloured phase container', () => {
     expect(screen.queryByTestId('phase-container')).not.toBeInTheDocument();
   });
 
-  it('wraps exactly the phase block (pill, bar, transition, review actions) and excludes the title + content Tabs (ac-11)', async () => {
+  it('wraps exactly the phase block (pill, bar, transition, review handoff) and excludes the title + content Tabs (ac-11)', async () => {
     tagAc(AC252(11));
-    renderAt('specify'); // default role = reviewer (canWrite, !canEdit) → review row expanded
+    renderAt('specify'); // default role = reviewer (canWrite, !canEdit)
     const container = await screen.findByTestId('phase-container');
     await within(container).findByTestId('review-handoff-line');
 
@@ -943,7 +931,9 @@ describe('spec-252 — coloured phase container', () => {
     expect(within(container).getByRole('button', { name: /You are reviewing/ })).toBeInTheDocument();
     expect(within(container).getByRole('tablist', { name: /Spec phase view/i })).toBeInTheDocument();
     expect(within(container).getByTestId('transition-sentence')).toBeInTheDocument();
-    expect(within(container).getByTestId('review-action-row')).toBeInTheDocument();
+    // spec-283 dec-4: the review-action row left the page; the review-handoff
+    // line remains inside the phase container.
+    expect(within(container).queryByTestId('review-action-row')).not.toBeInTheDocument();
     expect(within(container).getByTestId('review-handoff-line')).toBeInTheDocument();
 
     // OUTSIDE: the doc title (no heading inside) and the content Tabs row.
@@ -967,11 +957,10 @@ describe('spec-252 — coloured phase container', () => {
     ).toBeTruthy();
   });
 
-  it('introduces no new functionality — phase indicator, review actions, and CTAs are intact and still work (ac-5)', async () => {
+  it('introduces no new functionality — phase indicator and the review-handoff CTA are intact (ac-5)', async () => {
     tagAc(AC252(5));
-    const user = userEvent.setup();
-    renderAt('specify'); // reviewer: review row + handoff render expanded
-    await screen.findByTestId('review-action-row');
+    renderAt('specify'); // reviewer: the review-handoff line renders
+    await screen.findByTestId('review-handoff-line');
 
     // Phase progress indicator — unchanged: the four-tab pipeline, specify
     // current with its ● dot, browse-only behaviour preserved.
@@ -979,16 +968,11 @@ describe('spec-252 — coloured phase container', () => {
     expect(phaseTab('specify')).toHaveAttribute('data-current', 'true');
     expect(phaseTab('specify').textContent).toContain('●');
 
-    // Review actions — unchanged: the four review buttons still render…
-    const row = screen.getByTestId('review-action-row');
-    for (const label of ['Summarise Spec', 'Security review', 'Design review', 'Architecture review']) {
-      expect(within(row).getByRole('button', { name: label })).toBeInTheDocument();
-    }
-    // …and still behave: clicking one sends its scaffold prompt through chat.
-    await user.click(within(row).getByRole('button', { name: 'Summarise Spec' }));
-    await waitFor(() => expect(chat.sendMessage).toHaveBeenCalled());
-
-    // Calls-to-action — unchanged: the review handoff "copy prompt" line is present.
+    // spec-283 dec-4: the four review BUTTONS moved to the agent's idle state —
+    // they no longer render on the page. Their click-sends-a-prompt behaviour is
+    // re-verified on the agent surface (ChatPanel.test.tsx). The review-handoff
+    // "copy prompt" CTA stays on the page.
+    expect(screen.queryByTestId('review-action-row')).not.toBeInTheDocument();
     expect(screen.getByTestId('review-handoff-line')).toBeInTheDocument();
   });
 });

--- a/packages/ui/src/pages/DocDocument.tsx
+++ b/packages/ui/src/pages/DocDocument.tsx
@@ -29,7 +29,7 @@ import { PhaseTabBar, type PhaseTab } from '../components/PhaseTabBar';
 import { phaseColors } from '../components/phaseColors';
 import { TransitionSentence } from '../components/TransitionSentence';
 import { DoneSummary } from '../components/DoneSummary';
-import { Badge, Button, Tabs } from '../components/ui';
+import { Badge, Tabs } from '../components/ui';
 import { DownloadMdDialog } from '../components/DownloadMdDialog';
 import { InitPromptDialog } from '../components/InitPromptDialog';
 import { useChat } from '../components/ChatContext';
@@ -38,8 +38,6 @@ import { PostureDropdown, HEADER_PILL_CLASS } from '../components/PostureDropdow
 import {
   countUnresolvedDecisions,
   isSpecNarrativeStale,
-  toButtonPrompt,
-  BASE_SCAFFOLD,
   HANDOFF_BUTTON_BY_PHASE,
   isQaReportSectionType,
 } from '@memex/shared';
@@ -186,11 +184,6 @@ export function DocDocument() {
           ? 'work'
           : null,
   );
-  // spec-182 issue-3: for EDITORS the Specify review affordances sit behind a
-  // collapsed-by-default "Review actions" disclosure — the reviewer workflow
-  // shouldn't visually dominate the editor's page. Reviewers see them expanded
-  // (no disclosure chrome): it's their workflow.
-  const [reviewActionsOpen, setReviewActionsOpen] = useState(false);
   const [shareOpen, setShareOpen] = useState(false);
   const [shareLinkOpen, setShareLinkOpen] = useState(false);
   const [renameOpen, setRenameOpen] = useState(false);
@@ -666,34 +659,11 @@ export function DocDocument() {
     navigate(tenantPath('/specs'));
   };
 
-  // ── spec-159 ac-19: the writable reviewer's review-action row ──────────────
-  // The same four scaffold chat prompts the OpeningTurn reviewer set surfaces
-  // (Summarise / Security / Design / Architecture). Each resolves its prose from
-  // BASE_SCAFFOLD via toButtonPrompt (interpolating the same context the handoff
-  // line uses) and sends it through the existing chat — mirroring how
-  // OpeningTurn's chat_prompt arm threads onSendPrompt → sendMessage.
-  const REVIEW_ACTIONS: { label: string; buttonId: string }[] = [
-    { label: 'Summarise Spec', buttonId: 'opening-review-summarise' },
-    { label: 'Security review', buttonId: 'opening-review-security' },
-    { label: 'Design review', buttonId: 'opening-review-design' },
-    { label: 'Architecture review', buttonId: 'opening-review-architecture' },
-  ];
-  const sendReviewPrompt = (buttonId: string) => {
-    const prompt = toButtonPrompt({
-      dataset: BASE_SCAFFOLD,
-      buttonId,
-      context: handoffContext,
-      orgBlocks,
-    });
-    if (prompt === null) {
-      const message = `DocDocument: no PromptButtonNode found for buttonId="${buttonId}"`;
-      if (import.meta.env.DEV) throw new Error(message);
-      // eslint-disable-next-line no-console
-      console.error(message);
-      return;
-    }
-    chat.sendMessage(prompt);
-  };
+  // spec-283 dec-4: the four review-ACTION buttons (Summarise / Security /
+  // Design / Architecture) that used to live here have moved into the agent's
+  // idle/empty state (ChatPanel) — they're static scaffold prompts that need no
+  // page context, so the agent fires them directly. Only the review-HANDOFF
+  // line (below) stays on the page, because it interpolates page-level context.
 
   // spec-203 dec-1: the handoff node id is sourced from the single shared
   // HANDOFF_BUTTON_BY_PHASE map — the SAME map the in-chat footer projection
@@ -1365,72 +1335,27 @@ export function DocDocument() {
               }}
               onCancelBrowse={() => setSelectedTab(null)}
             />
-            {/* spec-182 dec-3: the review actions are a SPECIFY-phase fixture
-                for BOTH postures — review is a planning act (you review the
-                decisions and narrative before they harden), so the row keys on
-                the Spec's phase, not the viewer's posture. No other phase
-                (draft included) shows it. The four buttons resolve their
-                prompts from the Scaffold (std-23) and send through the chat.
-                spec-182 issue-3: for EDITORS the row + review handoff sit
-                behind a collapsed-by-default disclosure — access survives,
-                but the reviewer workflow no longer dominates the editor's
-                page. Reviewers get them expanded, no chrome. */}
+            {/* spec-283 dec-4: the four review ACTIONS have moved off the page
+                into the agent's idle/empty state (ChatPanel) — the page no
+                longer carries the "Review actions" disclosure or the button
+                row. What STAYS is the coding-agent review-HANDOFF line: it
+                interpolates {namespace}/{memex}/{handle}/{title}/{url} — page
+                context the generic agent panel doesn't carry — and serves the
+                distinct "conduct the review in your own coding agent" workflow.
+                It renders in Specify for BOTH postures, ungated (no longer
+                behind the deleted editor disclosure). spec-182 issue-4: the
+                link leads each line and names its prompt. */}
             {phase === 'specify' && (
-              <>
-                {canEdit && (
-                  <button
-                    type="button"
-                    data-testid="review-actions-toggle"
-                    aria-expanded={reviewActionsOpen}
-                    onClick={() => setReviewActionsOpen((v) => !v)}
-                    className="flex items-center gap-1 pt-1 text-sm text-secondary hover:text-heading transition-colors"
-                  >
-                    <svg
-                      className={`w-3 h-3 transition-transform ${reviewActionsOpen ? 'rotate-90' : ''}`}
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
-                      strokeWidth={2}
-                    >
-                      <path strokeLinecap="round" strokeLinejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
-                    </svg>
-                    Review actions
-                  </button>
-                )}
-                {(!canEdit || reviewActionsOpen) && (
-                  <>
-                    <div
-                      data-testid="review-action-row"
-                      className="flex flex-wrap items-center gap-2 pt-1"
-                    >
-                      {REVIEW_ACTIONS.map((action) => (
-                        <Button
-                          key={action.buttonId}
-                          type="button"
-                          variant="secondary"
-                          size="sm"
-                          onClick={() => sendReviewPrompt(action.buttonId)}
-                        >
-                          {action.label}
-                        </Button>
-                      ))}
-                    </div>
-                    {/* Review handoff line — copy a coding-agent prompt to conduct
-                        the review from there. Specify-only, like the row (dec-3).
-                        The link leads and names the prompt (issue-4). */}
-                    <div data-testid="review-handoff-line">
-                      <PromptButton
-                        buttonId="review-handoff"
-                        context={handoffContext}
-                        orgBlocks={orgBlocks}
-                        linkText="Copy the review prompt"
-                        sentence="into your coding agent if you prefer to conduct the review from there."
-                        sentenceLabel="Copy the review prompt into your coding agent if you prefer to conduct the review from there."
-                      />
-                    </div>
-                  </>
-                )}
-              </>
+              <div data-testid="review-handoff-line">
+                <PromptButton
+                  buttonId="review-handoff"
+                  context={handoffContext}
+                  orgBlocks={orgBlocks}
+                  linkText="Copy the review prompt"
+                  sentence="into your coding agent if you prefer to conduct the review from there."
+                  sentenceLabel="Copy the review prompt into your coding agent if you prefer to conduct the review from there."
+                />
+              </div>
             )}
             {/* spec-159 ac-17: the next-action handoff line — a "Copy a prompt
                 to …" sentence keyed to the CURRENT phase; absent at `done`.

--- a/packages/ui/src/pages/DocDocument.tsx
+++ b/packages/ui/src/pages/DocDocument.tsx
@@ -1342,18 +1342,23 @@ export function DocDocument() {
                 interpolates {namespace}/{memex}/{handle}/{title}/{url} — page
                 context the generic agent panel doesn't carry — and serves the
                 distinct "conduct the review in your own coding agent" workflow.
-                It renders in Specify for BOTH postures, ungated (no longer
-                behind the deleted editor disclosure). spec-182 issue-4: the
-                link leads each line and names its prompt. */}
-            {phase === 'specify' && (
+                spec-287 dec-2 SUPERSEDES spec-283 dec-4's "ungated, both
+                postures" clause: one prompt per posture in Specify. The review
+                handoff is now gated to NON-editors (!canEdit) — reviewers and
+                read-only viewers — while the editor sees the phase handoff
+                below (canEdit) and NOT this line. spec-287 dec-1: the link is
+                Title Case ("Copy the Review prompt"), matching the
+                Specify/Build/Verify family. spec-182 issue-4: the link leads
+                each line and names its prompt. */}
+            {phase === 'specify' && !canEdit && (
               <div data-testid="review-handoff-line">
                 <PromptButton
                   buttonId="review-handoff"
                   context={handoffContext}
                   orgBlocks={orgBlocks}
-                  linkText="Copy the review prompt"
+                  linkText="Copy the Review prompt"
                   sentence="into your coding agent if you prefer to conduct the review from there."
-                  sentenceLabel="Copy the review prompt into your coding agent if you prefer to conduct the review from there."
+                  sentenceLabel="Copy the Review prompt into your coding agent if you prefer to conduct the review from there."
                 />
               </div>
             )}

--- a/packages/ui/src/pages/QaReports.spec-260.test.tsx
+++ b/packages/ui/src/pages/QaReports.spec-260.test.tsx
@@ -22,6 +22,13 @@ const recordViewMock = vi.hoisted(() => vi.fn());
 vi.mock('../hooks/useQaReports', () => ({
   useQaReportsFeed: (...a: unknown[]) => useQaReportsFeedMock(...a),
   recordQaReportsView: (...a: unknown[]) => recordViewMock(...a),
+  // spec-286: the redesigned page also reads the tag facets for the rail.
+  useQaReportTagFacets: () => ({
+    facets: { total: 0, tags: [] },
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+  }),
   QA_REPORTS_VIEWED_EVENT: 'memex:qa-reports-viewed',
 }));
 
@@ -45,6 +52,7 @@ function row(over: Partial<QaReportFeedRow>): QaReportFeedRow {
     docId: 'd-1',
     docHandle: 'spec-1',
     docTitle: 'Some Spec',
+    phase: 'verify',
     sectionType: 'qa_report',
     version: 1,
     title: 'QA Report',
@@ -52,6 +60,7 @@ function row(over: Partial<QaReportFeedRow>): QaReportFeedRow {
     actorName: 'Claude Code',
     actorKind: 'mcp_agent',
     channel: 'mcp',
+    tags: [],
     createdAt: '2026-06-03T00:00:00Z',
     ...over,
   };
@@ -129,18 +138,23 @@ describe('spec-260 — QA Reports feed page', () => {
 
     const rows = await screen.findAllByTestId('qa-report-row');
 
-    // WHICH — the parent Spec, linked.
+    // WHICH — the parent Spec, linked. (spec-286 dropped the `·` separator; the
+    // handle + title now lead as the card heading.)
     const specLink = within(rows[0]).getByTestId('qa-report-row-spec');
-    expect(specLink).toHaveTextContent('spec-9 · Newest Spec');
+    expect(specLink).toHaveTextContent('spec-9');
+    expect(specLink).toHaveTextContent('Newest Spec');
     expect(specLink.closest('a')).toHaveAttribute('href', expect.stringContaining('/specs/spec-9'));
 
-    // WHEN — the report row's generation time.
-    expect(within(rows[0]).getByTestId('qa-report-row-when')).toHaveTextContent('3 Jun 2026');
+    // WHEN — the report row's generation time, now shown as relative time (spec-286).
+    expect(within(rows[0]).getByTestId('qa-report-row-when')).toHaveTextContent(/ago|just now|\d{4}/);
 
-    // WHO — the std-32 actor; an mcp_agent executor is labelled as an agent,
-    // a human executor by name.
-    expect(within(rows[0]).getByTestId('qa-report-row-who')).toHaveTextContent('Claude Code (agent)');
-    expect(within(rows[1]).getByTestId('qa-report-row-who')).toHaveTextContent('Barrie');
+    // WHO executed it — the std-32 actor, now the IMPLEMENTER (spec-286). These
+    // fixtures carry no author, so the implementer (the actor) is shown: an
+    // mcp_agent labelled as an agent, a human by name.
+    expect(within(rows[0]).getByTestId('qa-report-row-implementer')).toHaveTextContent(
+      'Claude Code (agent)',
+    );
+    expect(within(rows[1]).getByTestId('qa-report-row-implementer')).toHaveTextContent('Barrie');
 
     // A versioned session is identified.
     expect(rows[0]).toHaveTextContent('session 2');

--- a/packages/ui/src/pages/QaReports.spec-286.test.tsx
+++ b/packages/ui/src/pages/QaReports.spec-286.test.tsx
@@ -1,0 +1,220 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { tagAc } from '@memex-ai-ac/vitest';
+
+import { QaReports } from './QaReports';
+import {
+  useQaReportsFeed,
+  useQaReportTagFacets,
+  recordQaReportsView,
+  type QaReportFeedRow,
+  type QaReportFacets,
+} from '../hooks/useQaReports';
+
+const AC_1 = 'mindset-prod/memex-building-itself/specs/spec-286/acs/ac-1';
+const AC_2 = 'mindset-prod/memex-building-itself/specs/spec-286/acs/ac-2';
+const AC_3 = 'mindset-prod/memex-building-itself/specs/spec-286/acs/ac-3';
+const AC_7 = 'mindset-prod/memex-building-itself/specs/spec-286/acs/ac-7';
+const AC_11 = 'mindset-prod/memex-building-itself/specs/spec-286/acs/ac-11';
+const AC_12 = 'mindset-prod/memex-building-itself/specs/spec-286/acs/ac-12';
+
+vi.mock('../hooks/useDocChangeStream', () => ({ useDocChangeStream: () => {} }));
+// PageHeader pulls in the auth/tenant chain — not under test here; stub it.
+vi.mock('../components/PageHeader', () => ({
+  PageHeader: ({ title }: { title: string }) => <h1>{title}</h1>,
+}));
+vi.mock('../hooks/useQaReports', () => ({
+  useQaReportsFeed: vi.fn(),
+  useQaReportTagFacets: vi.fn(),
+  recordQaReportsView: vi.fn(),
+}));
+
+const ROWS: QaReportFeedRow[] = [
+  {
+    id: 'r1',
+    docId: 'd1',
+    docHandle: 'spec-100',
+    docTitle: 'Alpha feature',
+    phase: 'build',
+    sectionType: 'qa_report',
+    version: 1,
+    title: 'QA Report',
+    content: '# Inner heading\n\nSome report body.',
+    authorName: 'Ada Author',
+    actorName: 'Builder Bot',
+    actorKind: 'mcp_agent',
+    channel: 'mcp',
+    tags: [{ id: 't-frontend', scope: 'area', value: 'frontend' }],
+    createdAt: '2026-06-13T10:00:00.000Z',
+  },
+  {
+    id: 'r2',
+    docId: 'd2',
+    docHandle: 'spec-101',
+    docTitle: 'Beta cleanup',
+    phase: 'done',
+    sectionType: 'qa_report',
+    version: 1,
+    title: 'QA Report',
+    content: 'Body only.',
+    authorName: 'Cy Coder',
+    actorName: 'Cy Coder', // author built it themselves → implementer hidden
+    actorKind: 'human',
+    channel: 'rest_ui',
+    tags: [],
+    createdAt: '2026-06-12T10:00:00.000Z',
+  },
+];
+
+const FACETS: QaReportFacets = {
+  total: 5,
+  tags: [
+    { id: 't-frontend', scope: 'area', value: 'frontend', count: 3 },
+    { id: 't-bug', scope: null, value: 'bug', count: 2 },
+  ],
+};
+
+const mockedFeed = vi.mocked(useQaReportsFeed);
+const mockedFacets = vi.mocked(useQaReportTagFacets);
+const mockedView = vi.mocked(recordQaReportsView);
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <QaReports />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  mockedFeed.mockReset();
+  mockedFeed.mockImplementation(() => ({
+    rows: ROWS,
+    loading: false,
+    error: null,
+    hasMore: false,
+    loadOlder: vi.fn(),
+    refresh: vi.fn(),
+  }));
+  mockedFacets.mockReset();
+  mockedFacets.mockReturnValue({ facets: FACETS, loading: false, error: null, refresh: vi.fn() });
+  mockedView.mockReset();
+  // null receipt → boundary 'all' → rows render collapsed (deterministic).
+  mockedView.mockResolvedValue(null);
+});
+
+describe('QaReports card (spec-286)', () => {
+  it('ac-3 + ac-1: the spec is the dominant accent-coloured heading above the report', async () => {
+    tagAc(AC_3);
+    tagAc(AC_1);
+    renderPage();
+
+    const rows = await screen.findAllByTestId('qa-report-row');
+    const link = within(rows[0]).getByTestId('qa-report-row-spec');
+    expect(link).toHaveTextContent('spec-100');
+    expect(link).toHaveTextContent('Alpha feature');
+    // ac-3: rendered in the accent colour.
+    expect(link.className).toContain('text-accent');
+    // ac-1: the heading is the dominant element (h3, text-lg) …
+    const heading = link.closest('h3');
+    expect(heading).not.toBeNull();
+    expect(heading!.className).toContain('text-lg');
+
+    // … and the report body renders with the subordinate `.prose-qa` scale.
+    fireEvent.click(within(rows[0]).getByTestId('qa-report-row-toggle'));
+    const body = within(rows[0]).getByTestId('qa-report-row-body');
+    expect(body.className).toContain('prose-qa');
+  });
+
+  it('ac-2: metadata shows a phase pill coloured to the phase, plus author and relative time', async () => {
+    tagAc(AC_2);
+    renderPage();
+    const rows = await screen.findAllByTestId('qa-report-row');
+
+    // build → blue phase tokens; done → neutral grey.
+    const buildPill = within(rows[0]).getByTestId('qa-report-phase-pill');
+    expect(buildPill).toHaveAttribute('data-phase', 'build');
+    expect(buildPill).toHaveTextContent('Build');
+    expect(buildPill.className).toContain('phase-build');
+
+    const donePill = within(rows[1]).getByTestId('qa-report-phase-pill');
+    expect(donePill).toHaveTextContent('Done');
+    expect(donePill.className).toContain('status-neutral');
+
+    expect(within(rows[0]).getByTestId('qa-report-row-author')).toHaveTextContent('Ada Author');
+    // relative time, not an absolute date.
+    expect(within(rows[0]).getByTestId('qa-report-row-when')).toHaveTextContent(/ago|just now|\d/);
+  });
+
+  it('ac-7: implementer shows only when different from the author', async () => {
+    tagAc(AC_7);
+    renderPage();
+    const rows = await screen.findAllByTestId('qa-report-row');
+
+    // r1: Builder Bot ≠ Ada Author → implementer shown.
+    expect(within(rows[0]).getByTestId('qa-report-row-implementer')).toHaveTextContent('Builder Bot');
+    // r2: author built it themselves → no separate implementer line.
+    expect(within(rows[1]).queryByTestId('qa-report-row-implementer')).toBeNull();
+  });
+});
+
+describe('QaReports bulk expand/collapse (spec-286)', () => {
+  it('ac-12: one control opens every report, then collapses them all', async () => {
+    tagAc(AC_12);
+    renderPage();
+    const rows = await screen.findAllByTestId('qa-report-row');
+
+    // Rows start collapsed (boundary 'all').
+    expect(within(rows[0]).queryByTestId('qa-report-row-body')).toBeNull();
+    expect(within(rows[1]).queryByTestId('qa-report-row-body')).toBeNull();
+
+    // Expand all → every report body is shown.
+    const toggle = screen.getByTestId('qa-reports-expand-all');
+    expect(toggle).toHaveTextContent('Expand all');
+    fireEvent.click(toggle);
+    expect(within(rows[0]).getByTestId('qa-report-row-body')).toBeInTheDocument();
+    expect(within(rows[1]).getByTestId('qa-report-row-body')).toBeInTheDocument();
+    expect(toggle).toHaveTextContent('Collapse all');
+
+    // Collapse all → every report body is hidden again.
+    fireEvent.click(toggle);
+    expect(within(rows[0]).queryByTestId('qa-report-row-body')).toBeNull();
+    expect(within(rows[1]).queryByTestId('qa-report-row-body')).toBeNull();
+  });
+});
+
+describe('QaReports filter wiring (spec-286)', () => {
+  it('ac-11: tag + date filters compose with AND, and "All" clears the tag', async () => {
+    tagAc(AC_11);
+    renderPage();
+    await screen.findAllByTestId('qa-report-row');
+
+    const lastFilters = () => mockedFeed.mock.calls.at(-1)![0] as {
+      tagId?: string;
+      from?: string;
+      to?: string;
+    };
+
+    // Initial: unfiltered.
+    expect(lastFilters()).toMatchObject({ tagId: undefined, from: undefined, to: undefined });
+
+    // Select a tag → feed filtered by it.
+    fireEvent.click(
+      screen.getAllByTestId('qa-reports-tag-node').find((n) => n.getAttribute('data-tag-id') === 't-frontend')!,
+    );
+    expect(lastFilters().tagId).toBe('t-frontend');
+
+    // Add a date range → BOTH apply (AND): tag stays, from is set.
+    fireEvent.click(screen.getByTestId('qa-reports-range-week'));
+    const both = lastFilters();
+    expect(both.tagId).toBe('t-frontend');
+    expect(typeof both.from).toBe('string');
+
+    // Click "All" → tag cleared; the date window persists (it's a separate axis).
+    fireEvent.click(screen.getByTestId('qa-reports-tag-all'));
+    const cleared = lastFilters();
+    expect(cleared.tagId).toBeUndefined();
+    expect(typeof cleared.from).toBe('string');
+  });
+});

--- a/packages/ui/src/pages/QaReports.tsx
+++ b/packages/ui/src/pages/QaReports.tsx
@@ -1,12 +1,16 @@
 // QA Reports — the workspace-wide feed of build-session QA reports (spec-260
-// dec-5/dec-6). A Pulse-style top-level nav page: every `qa_report` section
-// across the memex's Specs, newest-first, an initial page + keyset "Load More",
-// live updates off the std-8 bus. Each row shows WHEN it was generated, WHICH
-// Spec it belongs to (linked), and WHO executed the build session (the std-32
-// actor on the row). Opening the page records the per-user view marker, zeroing
-// the nav badge (count-everything semantics — own-agent reports included).
+// dec-5/dec-6, redesigned in spec-286). A Pulse-style top-level nav page: every
+// `qa_report` section across the memex's Specs, newest-first, an initial page +
+// keyset "Load More", live updates off the std-8 bus.
+//
+// spec-286 reshapes each row into a CARD whose dominant heading is the spec
+// (accent-coloured link), with a metadata line (author, implementer-if-different,
+// relative time, phase pill) above a subordinate-scale markdown body — and adds a
+// STICKY left rail to filter by tag and date range (server-parameterised, so the
+// counts + filtering are correct across the whole corpus, not just loaded rows).
+// Opening the page still records the per-user view marker (zeroing the nav badge).
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -14,11 +18,20 @@ import { PageHeader } from '../components/PageHeader';
 import {
   recordQaReportsView,
   useQaReportsFeed,
+  useQaReportTagFacets,
   type QaReportFeedRow,
 } from '../hooks/useQaReports';
 import { useDocChangeStream } from '../hooks/useDocChangeStream';
+import {
+  QaReportsFilterRail,
+  ALL_TIME,
+  type DateRangeState,
+} from '../components/QaReportsFilterRail';
+import { phaseColors } from '../components/phaseColors';
+import { phaseDisplayName } from '../utils/phaseDisplay';
 import { tenantPath } from '../utils/tenantUrl';
-import { formatDate } from '../utils/format';
+import { timeAgo } from '../utils/timeAgo';
+import type { SpecStatus } from '../api/types';
 
 const ACTOR_KIND_LABEL: Record<QaReportFeedRow['actorKind'], string> = {
   human: '',
@@ -27,7 +40,7 @@ const ACTOR_KIND_LABEL: Record<QaReportFeedRow['actorKind'], string> = {
   system: 'system',
 };
 
-function executorLabel(row: QaReportFeedRow): string {
+function implementerLabel(row: QaReportFeedRow): string {
   const name = row.actorName?.trim();
   const kind = ACTOR_KIND_LABEL[row.actorKind];
   if (name && kind) return `${name} (${kind})`;
@@ -35,32 +48,84 @@ function executorLabel(row: QaReportFeedRow): string {
   return kind || 'unknown';
 }
 
-function FeedRow({ row, defaultOpen = false }: { row: QaReportFeedRow; defaultOpen?: boolean }) {
-  // ac-24: unread rows arrive expanded; read rows collapsed. Initial state
-  // only — the user's own toggling always wins afterwards.
+function PhasePill({ phase }: { phase: string }) {
+  const colors = phaseColors(phase as SpecStatus);
+  return (
+    <span
+      data-testid="qa-report-phase-pill"
+      data-phase={phase}
+      className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[11px] font-medium leading-none ${
+        colors?.pill ?? 'border-edge-subtle text-secondary'
+      }`}
+    >
+      {phaseDisplayName(phase)}
+    </span>
+  );
+}
+
+function FeedRow({
+  row,
+  defaultOpen = false,
+  bulk,
+}: {
+  row: QaReportFeedRow;
+  defaultOpen?: boolean;
+  // ac-12: a bumped nonce drives a bulk expand/collapse from the page-level
+  // control; per-row toggling still wins afterwards until the next bulk action.
+  bulk: { open: boolean; nonce: number };
+}) {
+  // ac-24: unread rows arrive expanded; read rows collapsed. Initial state only —
+  // the user's own toggling always wins afterwards.
   const [open, setOpen] = useState(defaultOpen);
+
+  useEffect(() => {
+    // nonce 0 = no bulk action yet → leave the unread-driven initial state alone.
+    if (bulk.nonce > 0) setOpen(bulk.open);
+  }, [bulk.nonce, bulk.open]);
+
+  const author = row.authorName?.trim() || null;
+  const implementerName = row.actorName?.trim() || null;
+  // ac-7: show the implementer only when it differs from the author. When the
+  // author ran their own build (same name) we show a single attribution.
+  const showImplementer = implementerName !== null && implementerName !== author;
+
   return (
     <li
       data-testid="qa-report-row"
       className="rounded-xl border border-edge bg-surface p-4"
     >
-      <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1 text-sm">
+      {/* Heading: the spec is the card's identity — accent-coloured link, sized
+          ABOVE the report body's headings (.prose-qa demotes those). */}
+      <h3 className="text-lg font-semibold leading-snug">
         <Link
           data-testid="qa-report-row-spec"
           to={tenantPath(`/specs/${row.docHandle}`)}
-          className="font-medium text-primary hover:underline"
+          className="text-accent hover:text-accent-hover hover:underline"
         >
-          {row.docHandle} · {row.docTitle}
+          <span className="text-accent/70">{row.docHandle}</span> {row.docTitle}
         </Link>
-        {row.version > 1 && (
-          <span className="text-xs text-muted">session {row.version}</span>
+      </h3>
+
+      {/* Metadata line — subordinate to the heading. */}
+      <div
+        data-testid="qa-report-row-meta"
+        className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted"
+      >
+        <PhasePill phase={row.phase} />
+        {author && (
+          <span data-testid="qa-report-row-author">
+            by <span className="text-secondary">{author}</span>
+          </span>
         )}
-        <span className="ml-auto text-xs text-muted">
-          <span data-testid="qa-report-row-when">{formatDate(row.createdAt)}</span>
-          {' · '}
-          <span data-testid="qa-report-row-who">{executorLabel(row)}</span>
-        </span>
+        {showImplementer && (
+          <span data-testid="qa-report-row-implementer">
+            · built by <span className="text-secondary">{implementerLabel(row)}</span>
+          </span>
+        )}
+        {row.version > 1 && <span>· session {row.version}</span>}
+        <span data-testid="qa-report-row-when">· {timeAgo(row.createdAt)}</span>
       </div>
+
       <button
         type="button"
         data-testid="qa-report-row-toggle"
@@ -71,7 +136,10 @@ function FeedRow({ row, defaultOpen = false }: { row: QaReportFeedRow; defaultOp
         {open ? 'Hide report' : 'Read report'}
       </button>
       {open && (
-        <div data-testid="qa-report-row-body" className="mt-3 prose-dark overflow-hidden">
+        <div
+          data-testid="qa-report-row-body"
+          className="mt-3 prose-dark prose-qa overflow-hidden"
+        >
           <ReactMarkdown remarkPlugins={[remarkGfm]}>{row.content}</ReactMarkdown>
         </div>
       )}
@@ -80,21 +148,32 @@ function FeedRow({ row, defaultOpen = false }: { row: QaReportFeedRow; defaultOp
 }
 
 export function QaReports() {
-  const { rows, loading, error, hasMore, loadOlder, refresh } = useQaReportsFeed();
+  // ── Filter state (spec-286) ────────────────────────────────────────────────
+  // tagId = null → "All". range carries concrete ISO bounds, computed once at
+  // selection time (NOT per render) so the values are stable and don't churn the
+  // feed/facets fetches. A tag + a date range compose with AND (dec-3).
+  const [selectedTagId, setSelectedTagId] = useState<string | null>(null);
+  const [range, setRange] = useState<DateRangeState>(ALL_TIME);
+
+  // ac-12: bulk expand/collapse. The nonce bumps on every click so each row's
+  // effect re-applies `open`; per-row toggling still wins until the next click.
+  const [bulk, setBulk] = useState<{ open: boolean; nonce: number }>({ open: false, nonce: 0 });
+  const toggleAll = () => setBulk((b) => ({ open: !b.open, nonce: b.nonce + 1 }));
+
+  const filters = useMemo(
+    () => ({ tagId: selectedTagId ?? undefined, from: range.from, to: range.to }),
+    [selectedTagId, range.from, range.to],
+  );
+  const facetWindow = useMemo(() => ({ from: range.from, to: range.to }), [range.from, range.to]);
+
+  const { rows, loading, error, hasMore, loadOlder, refresh } = useQaReportsFeed(filters);
+  const { facets, loading: facetsLoading } = useQaReportTagFacets(facetWindow);
 
   // ac-24: the unread boundary — the viewer's PREVIOUS last_viewed_at, captured
-  // from the view receipt (opening the page is what resets the marker, so the
-  // receipt is the only place the old value survives).
-  //   undefined        → receipt still in flight (hold the list so rows don't
-  //                      initialise collapsed and then refuse to open)
-  //   { prev: null }   → first-ever view: everything is unread → all open
-  //   { prev: ISO }    → rows newer than it are unread → open
-  //   { prev: 'all' }  → marker unavailable (anonymous / failure): no per-user
-  //                      unread concept → all collapsed
+  // from the view receipt (opening the page resets the marker, so the receipt is
+  // the only place the old value survives). See the hook for the sentinel meanings.
   const [boundary, setBoundary] = useState<{ prev: string | null | 'all' } | undefined>(undefined);
 
-  // Opening the page = viewing the feed: upsert the per-user marker (dec-6),
-  // which zeroes the nav badge, and keep its receipt as the unread boundary.
   useEffect(() => {
     let cancelled = false;
     void recordQaReportsView().then((receipt) => {
@@ -114,12 +193,12 @@ export function QaReports() {
     return row.createdAt > boundary.prev;
   };
 
-  // Live updates: a new report lands on the std-8 bus as a section event —
-  // refetch the first page so it appears without a reload (debounced upstream).
+  // Live updates: a new report lands on the std-8 bus as a section event — refetch
+  // the first page so it appears without a reload (debounced upstream).
   useDocChangeStream(null, refresh);
 
   return (
-    <div className="px-6 py-4 max-w-3xl">
+    <div className="px-6 py-4">
       <PageHeader title="QA Reports" />
       <p className="text-sm text-muted mb-4">
         What each build session changed, written for a reviewer — one report per
@@ -132,35 +211,62 @@ export function QaReports() {
         </div>
       )}
 
-      {(loading && rows.length === 0) || boundary === undefined ? (
-        <div data-testid="qa-reports-loading" className="text-sm text-muted py-8 text-center">
-          Loading…
-        </div>
-      ) : rows.length === 0 ? (
-        <div data-testid="qa-reports-empty" className="text-sm text-muted py-8 text-center">
-          No QA reports yet — one is generated each time a build session hands off to
-          verify.
-        </div>
-      ) : (
-        <ul data-testid="qa-reports-list" className="space-y-3">
-          {rows.map((row) => (
-            <FeedRow key={row.id} row={row} defaultOpen={isUnread(row)} />
-          ))}
-        </ul>
-      )}
+      <div className="flex items-start gap-6">
+        <QaReportsFilterRail
+          facets={facets}
+          loading={facetsLoading}
+          selectedTagId={selectedTagId}
+          onSelectTag={setSelectedTagId}
+          range={range}
+          onChangeRange={setRange}
+        />
 
-      {hasMore && (
-        <div className="mt-4 text-center">
-          <button
-            type="button"
-            data-testid="qa-reports-load-more"
-            onClick={() => void loadOlder()}
-            className="text-sm text-secondary hover:text-primary px-3 py-1.5 rounded-md border border-edge hover:bg-overlay"
-          >
-            Load More
-          </button>
+        <div className="min-w-0 flex-1 max-w-3xl">
+          {(loading && rows.length === 0) || boundary === undefined ? (
+            <div data-testid="qa-reports-loading" className="text-sm text-muted py-8 text-center">
+              Loading…
+            </div>
+          ) : rows.length === 0 ? (
+            <div data-testid="qa-reports-empty" className="text-sm text-muted py-8 text-center">
+              {selectedTagId !== null || range.preset !== 'all'
+                ? 'No QA reports match the current filter.'
+                : 'No QA reports yet — one is generated each time a build session hands off to verify.'}
+            </div>
+          ) : (
+            <>
+              <div className="mb-2 flex justify-end">
+                <button
+                  type="button"
+                  data-testid="qa-reports-expand-all"
+                  aria-pressed={bulk.open}
+                  onClick={toggleAll}
+                  className="text-xs text-secondary hover:text-primary"
+                >
+                  {bulk.open ? 'Collapse all' : 'Expand all'}
+                </button>
+              </div>
+              <ul data-testid="qa-reports-list" className="space-y-3">
+                {rows.map((row) => (
+                  <FeedRow key={row.id} row={row} defaultOpen={isUnread(row)} bulk={bulk} />
+                ))}
+              </ul>
+            </>
+          )}
+
+          {hasMore && (
+            <div className="mt-4 text-center">
+              <button
+                type="button"
+                data-testid="qa-reports-load-more"
+                onClick={() => void loadOlder()}
+                className="text-sm text-secondary hover:text-primary px-3 py-1.5 rounded-md border border-edge hover:bg-overlay"
+              >
+                Load More
+              </button>
+            </div>
+          )}
         </div>
-      )}
+      </div>
     </div>
   );
 }

--- a/packages/ui/src/utils/timeAgo.test.ts
+++ b/packages/ui/src/utils/timeAgo.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { timeAgo } from './timeAgo';
+
+// spec-286: the feed's relative-time helper. `now` is injected so the ladder is
+// deterministic without faking the clock.
+const NOW = new Date('2026-06-13T12:00:00Z');
+const ago = (ms: number) => new Date(NOW.getTime() - ms).toISOString();
+
+const MIN = 60_000;
+const HOUR = 60 * MIN;
+const DAY = 24 * HOUR;
+const WEEK = 7 * DAY;
+
+describe('timeAgo', () => {
+  it('reads "just now" under a minute (and clamps small future skew)', () => {
+    expect(timeAgo(ago(30_000), NOW)).toBe('just now');
+    expect(timeAgo(new Date(NOW.getTime() + 5_000).toISOString(), NOW)).toBe('just now');
+  });
+
+  it('coarsens through minutes, hours, days, weeks', () => {
+    expect(timeAgo(ago(5 * MIN), NOW)).toBe('5m ago');
+    expect(timeAgo(ago(3 * HOUR), NOW)).toBe('3h ago');
+    expect(timeAgo(ago(2 * DAY), NOW)).toBe('2d ago');
+    expect(timeAgo(ago(5 * WEEK), NOW)).toBe('5w ago');
+  });
+
+  it('falls back to an absolute date beyond ~8 weeks', () => {
+    expect(timeAgo(ago(10 * WEEK), NOW)).toMatch(/\d{4}$/); // ends in a year
+  });
+
+  it('returns empty string for an unparseable input', () => {
+    expect(timeAgo('not-a-date', NOW)).toBe('');
+  });
+});

--- a/packages/ui/src/utils/timeAgo.ts
+++ b/packages/ui/src/utils/timeAgo.ts
@@ -1,0 +1,39 @@
+// spec-286: a compact relative-time helper for the QA Reports feed metadata line.
+//
+// The existing utils stop short of what the feed needs: `formatDate` (utils/format)
+// is an absolute date and `relativeDays` (DoneSummary) only has day granularity.
+// A QA report generated "2h ago" should read that way, not "today" or "12 Jun 2026".
+//
+// Granularity ladder (coarsening as it ages): just now → Nm → Nh → Nd → Nw, then it
+// falls back to an absolute date so "63w ago" never appears. Always past-tense — a
+// report's createdAt is in the past; a (clock-skew) future instant clamps to "just now".
+
+const MINUTE = 60_000;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+const WEEK = 7 * DAY;
+
+function absoluteDate(date: Date): string {
+  return date.toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' });
+}
+
+/**
+ * Format `iso` as a short relative time from `now` (default: the current time).
+ * `now` is injectable so tests are deterministic without faking the clock.
+ *
+ * Examples: "just now", "5m ago", "3h ago", "2d ago", "5w ago", then "12 Jun 2026".
+ */
+export function timeAgo(iso: string, now: Date = new Date()): string {
+  const then = new Date(iso);
+  if (Number.isNaN(then.getTime())) return '';
+
+  const diff = now.getTime() - then.getTime();
+  if (diff < MINUTE) return 'just now'; // includes small future skew (diff < 0)
+
+  if (diff < HOUR) return `${Math.floor(diff / MINUTE)}m ago`;
+  if (diff < DAY) return `${Math.floor(diff / HOUR)}h ago`;
+  if (diff < WEEK) return `${Math.floor(diff / DAY)}d ago`;
+  // Up to ~8 weeks stays relative; beyond that an absolute date is more legible.
+  if (diff < 8 * WEEK) return `${Math.floor(diff / WEEK)}w ago`;
+  return absoluteDate(then);
+}


### PR DESCRIPTION
Promote `develop` to `main` (production). Payload since the last release (#183):

- **spec-286** — QA Reports feed redesign: hierarchy fix, phase pills, author/implementer attribution, sticky tag/date filter rail, expand-all (#189)
- **spec-287** — one coding-agent prompt per posture in Specify (#188)
- **spec-285** — author + last-changed metadata on search hits; WHO/WHEN byline on ⌘K rows (#187)
- **spec-283** — move Spec review actions into the agent idle state (#186)
- **spec-247** — collapse DecisionPanel tabs into one state-pilled list (dec-7) (#185)
- **spec-282** — handoff stub names the "specify" phase, not "plan" (dec-5 fix) (#184)

All component PRs merged to `develop` with CI green. No schema migrations in spec-286; check the other specs' PRs for any migration/deploy notes. Post-merge: std-17 smoke runs against the deployed host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)