### PR TITLE
feat(spec-259): surface open comments in specify→build readiness (MCP + web)

### DIFF
--- a/packages/server/src/agent/tool-specs.ts
+++ b/packages/server/src/agent/tool-specs.ts
@@ -201,6 +201,8 @@ import {
   toButtonPrompt,
   toHandoffEssence,
   GET_PROMPT_PROSE,
+  timeAgo,
+  capitalizeDisplayName,
   type Phase,
   type GuidanceBlock,
 } from "@memex/shared";
@@ -4233,7 +4235,7 @@ export const toolSpecs: ToolSpec[] = [
         );
       }
       const { memexId, doc, slugs, entity } = resolved;
-      const comment = await resolveComment(memexId, entity.row.id, resolution);
+      const comment = await resolveComment(memexId, entity.row.id, resolution, reqCtx(ctx));
       if (ctx.verbose) {
         return `${formatDocStatusHeader(doc)}\n\nComment resolved.\n${formatComment(comment)}`;
       }
@@ -4341,7 +4343,7 @@ export const toolSpecs: ToolSpec[] = [
           for (const c of status.comments) {
             const targetTitle = c.target.title ? ` "${c.target.title}"` : "";
             lines.push(
-              `- [${c.type}] on ${c.target.kind} ${c.target.handle}${targetTitle} by ${c.author} (${c.createdAt.toISOString()}): ${c.contentSnippet}`,
+              `- [${c.type}] on ${c.target.kind} ${c.target.handle}${targetTitle} by ${capitalizeDisplayName(c.author)} (${timeAgo(c.createdAt)}): ${c.contentSnippet}`,
             );
           }
         }

--- a/packages/server/src/mcp/formatters.ts
+++ b/packages/server/src/mcp/formatters.ts
@@ -22,6 +22,8 @@ import {
   GET_PROMPT_PROSE,
   toNudge,
   toHandoffEssence,
+  timeAgo,
+  capitalizeDisplayName,
   type GuidanceBlock,
   type PhaseNode,
 } from "@memex/shared";
@@ -476,7 +478,10 @@ export function formatComment(
     headerLines.push(`ref: ${ref}`);
   }
   headerLines.push(
-    `${status}${badge} **${comment.authorName}** (${formatDate(comment.createdAt)}):`,
+    // spec-259 t-3: comment byline shows WHO (title-cased) + WHEN (relative) —
+    // `timeAgo` surfaces staleness at a glance; `formatDate` stays for the
+    // non-comment callers above.
+    `${status}${badge} **${capitalizeDisplayName(comment.authorName)}** (${timeAgo(comment.createdAt)}):`,
     comment.content,
   );
   const refLine = commentReferenceLine(comment, lookup);

--- a/packages/server/src/routes/__test__.ts
+++ b/packages/server/src/routes/__test__.ts
@@ -45,7 +45,7 @@ import { createIssue } from "../services/issues.js";
 import { testEvents } from "../db/schema.js";
 import { applyEmissionToSummary } from "../services/test-event-latest.js";
 import { createExecutionPlan } from "../services/execution_plans.js";
-import { addTaskComment } from "../services/comments.js";
+import { addTaskComment, addComment, addDecisionComment } from "../services/comments.js";
 import { createShareToken, listShareTokensForDoc } from "../services/share-tokens.js";
 import { addSection } from "../services/sections.js";
 import { applyTagStrings } from "../services/tags.js";
@@ -778,6 +778,38 @@ testOnlyRouter.post("/seed-section", async (c) => {
   const { memexId, docId, title, content = "", sectionType = "context" } = parsed.data;
   const section = await addSection(memexId, docId, sectionType, content, title);
   return c.json({ sectionId: section.id, seq: section.seq });
+});
+
+// spec-259 t-5: seed an OPEN comment on a section / decision / task through the
+// real comment services (so it emits on the bus [per std-8] and the
+// SSE-reactive UI under test sees it like a real comment). Backs the
+// Specify-phase open-comment parity journey, which asserts the open-comment
+// summary + per-comment WHO/WHEN byline render on the Comments surface.
+const seedCommentSchema = z.object({
+  memexId: z.string().uuid(),
+  target: z.enum(["section", "decision", "task"]),
+  targetId: z.string().uuid(),
+  authorName: z.string().default("Casey Reviewer"),
+  content: z.string().default("Please double-check this before we advance."),
+  commentType: z.string().optional(),
+});
+testOnlyRouter.post("/seed-comment", async (c) => {
+  const body = await c.req.json().catch(() => null);
+  const parsed = seedCommentSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: "Invalid request", details: parsed.error.issues }, 400);
+  }
+  const { memexId, target, targetId, authorName, content, commentType } = parsed.data;
+  const extras = commentType
+    ? ({ type: commentType } as Parameters<typeof addComment>[4])
+    : undefined;
+  const comment =
+    target === "section"
+      ? await addComment(memexId, targetId, authorName, content, extras)
+      : target === "decision"
+        ? await addDecisionComment(memexId, targetId, authorName, content, extras)
+        : await addTaskComment(memexId, targetId, authorName, content, extras);
+  return c.json({ commentId: comment.id, seq: comment.seq });
 });
 
 // spec-286: apply `scope::value`/flat tags to a Spec through the real

--- a/packages/server/src/routes/comments.test.ts
+++ b/packages/server/src/routes/comments.test.ts
@@ -8,6 +8,10 @@ import { testMutate } from "../services/__test__/mutate-helpers.js";
 // and Resolve ('resolved') are distinguishable in history.
 const AC_RESOLUTION_THREADING =
   "mindset-prod/memex-building-itself/specs/spec-143/acs/ac-12";
+// spec-259 ac-4: the resolve route threads the acting user's RequestCtx so the
+// resolution carries WHO (proven end-to-end in comment-resolution-attribution.spec-259).
+const AC_RESOLVE_ATTRIBUTION =
+  "mindset-prod/memex-building-itself/specs/spec-259/acs/ac-4";
 
 // Mock session middleware (t-13) so the route's `.use()` is a pass-through and the stubbed
 // currentAccount/user from `makeTestAppWithTenant` reach the handler intact.
@@ -310,6 +314,7 @@ describe("POST /api/comments/:commentId/resolve", () => {
 
   it("resolves a comment without resolution", async () => {
     tagAc(AC_RESOLUTION_THREADING);
+    tagAc(AC_RESOLVE_ATTRIBUTION);
     vi.mocked(resolveComment).mockResolvedValue(testMutate({
       id: "c1",
       memexId: "test-account",
@@ -344,11 +349,19 @@ describe("POST /api/comments/:commentId/resolve", () => {
 
     const body = await res.json();
     expect(body.resolvedAt).toBeTruthy();
-    expect(resolveComment).toHaveBeenCalledWith(TEST_MEMEX_ID, "c1", undefined);
+    // spec-259 ac-4: the route threads the acting user's ctx (restCtx) as the 4th
+    // arg so the resolution carries WHO (channel rest_ui + actorUserId).
+    expect(resolveComment).toHaveBeenCalledWith(
+      TEST_MEMEX_ID,
+      "c1",
+      undefined,
+      expect.objectContaining({ channel: "rest_ui" }),
+    );
   });
 
   it("resolves a comment with resolution", async () => {
     tagAc(AC_RESOLUTION_THREADING);
+    tagAc(AC_RESOLVE_ATTRIBUTION);
     vi.mocked(resolveComment).mockResolvedValue(testMutate({
       id: "c1",
       memexId: "test-account",
@@ -385,7 +398,12 @@ describe("POST /api/comments/:commentId/resolve", () => {
 
     const body = await res.json();
     expect(body.resolution).toBe("Added details");
-    expect(resolveComment).toHaveBeenCalledWith(TEST_MEMEX_ID, "c1", "Added details");
+    expect(resolveComment).toHaveBeenCalledWith(
+      TEST_MEMEX_ID,
+      "c1",
+      "Added details",
+      expect.objectContaining({ channel: "rest_ui" }),
+    );
   });
 });
 

--- a/packages/server/src/routes/comments.ts
+++ b/packages/server/src/routes/comments.ts
@@ -27,6 +27,7 @@ import {
 } from "../middleware/session.js";
 import type { MemexResolverEnv } from "../middleware/memex-resolver.js";
 import { requireMemexId, resolveReadableMemexId } from "./shared.js";
+import { restCtx } from "./_actor-ctx.js";
 
 type Env = MemexResolverEnv & SessionEnv;
 const comments = new Hono<Env>();
@@ -191,7 +192,7 @@ comments.post("/:commentId/resolve", async (c) => {
   const memexId = requireMemexId(c);
   const commentId = c.req.param("commentId");
   const body = await c.req.json().catch(() => ({}));
-  const comment = await resolveComment(memexId, commentId, body.resolution);
+  const comment = await resolveComment(memexId, commentId, body.resolution, restCtx(c));
   return c.json(comment);
 });
 

--- a/packages/server/src/routes/drift.ts
+++ b/packages/server/src/routes/drift.ts
@@ -23,6 +23,7 @@ import { docComments } from "../db/schema.js";
 import { sessionMiddleware, type SessionEnv } from "../middleware/session.js";
 import type { MemexResolverEnv } from "../middleware/memex-resolver.js";
 import { requireMemexId } from "./shared.js";
+import { restCtx } from "./_actor-ctx.js";
 import { listDriftInbox } from "../services/drift-inbox.js";
 import { parseProposedChangeBody } from "../services/standards.js";
 import { updateSection } from "../services/sections.js";
@@ -83,7 +84,7 @@ drift.post("/proposals/:commentId/accept", async (c) => {
   }
 
   await updateSection(memexId, comment.sectionId, parsed.proposed);
-  const resolved = await resolveComment(memexId, comment.id, "accepted");
+  const resolved = await resolveComment(memexId, comment.id, "accepted", restCtx(c));
 
   return c.json({ ok: true, comment: resolved });
 });

--- a/packages/server/src/services/comment-actions.ts
+++ b/packages/server/src/services/comment-actions.ts
@@ -30,7 +30,7 @@ import type { CommentAction } from "../types/roles.js";
 import { NotFoundError, ValidationError } from "../types/errors.js";
 import { resolveComment, unresolveComment } from "./comments.js";
 import { updateSection } from "./sections.js";
-import { mutate } from "./mutate.js";
+import { mutate, type RequestCtx } from "./mutate.js";
 import { hasAnchorMarker, extractMarkerSeqs, stripMarkersForSeq } from "./geo-anchor.js";
 
 // What the side agent is handed for an edit, and what it must return (new
@@ -46,6 +46,9 @@ export type AgentEditFn = (input: AgentEditInput) => Promise<string>;
 export interface ApplyActionDeps {
   runEdit: AgentEditFn;
   agentName?: string;
+  // spec-259 ac-4: the acting user, threaded to resolveComment so the ack/dismiss
+  // resolution carries WHO (std-32). Optional — defaults to unattributed.
+  ctx?: RequestCtx;
 }
 
 export interface ApplyActionResult {
@@ -115,7 +118,7 @@ export async function applyCommentAction(
   const action = findAction(comment, actionLabel);
 
   if (action.kind === "dismiss") {
-    const resolved = await resolveComment(memexId, commentId, `Dismissed via "${actionLabel}".`);
+    const resolved = await resolveComment(memexId, commentId, `Dismissed via "${actionLabel}".`, deps.ctx ?? {});
     return { kind: "dismiss", comment: resolved };
   }
 
@@ -167,6 +170,7 @@ export async function applyCommentAction(
       memexId,
       commentId,
       `Addressed via "${actionLabel}" by ${agentName}.`,
+      deps.ctx ?? {},
     );
 
     // Audit + undo record (spec §3 / ac-8). Wrapped in mutate({ silent: true })

--- a/packages/server/src/services/comment-assessment.grouping.spec-259.test.ts
+++ b/packages/server/src/services/comment-assessment.grouping.spec-259.test.ts
@@ -1,0 +1,101 @@
+// spec-259 t-3 — pure unit tests for the anchor-kind grouping of open comments.
+//
+// No DB: exercises `groupCommentsByAnchorKind` / `anchorKindForTarget` directly
+// against synthetic OpenComment lists. The DB-backed end-to-end (open-set basis
+// = resolved_at IS NULL) lives in comment-assessment.integration.test.ts.
+
+import { describe, it, expect } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import {
+  anchorKindForTarget,
+  groupCommentsByAnchorKind,
+  type OpenComment,
+} from "./comment-assessment.js";
+
+const AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-259/acs/ac-${n}`;
+
+function mkComment(
+  overrides: Partial<OpenComment> & {
+    targetKind: OpenComment["target"]["kind"];
+    createdAt: Date;
+  },
+): OpenComment {
+  const { targetKind, createdAt, ...rest } = overrides;
+  return {
+    commentId: rest.commentId ?? `c-${createdAt.getTime()}`,
+    type: rest.type ?? "discussion",
+    target: rest.target ?? {
+      kind: targetKind,
+      handle: targetKind === "decision" ? "dec-1" : "approach",
+      title: "T",
+    },
+    author: rest.author ?? "jane doe",
+    contentSnippet: rest.contentSnippet ?? "snippet",
+    createdAt,
+  };
+}
+
+describe("spec-259: open comments grouped by anchor kind (ac-1)", () => {
+  it("decision targets are decision-anchored; section + task targets are section-anchored", () => {
+    tagAc(AC(1));
+    expect(anchorKindForTarget("decision")).toBe("decision");
+    expect(anchorKindForTarget("section")).toBe("section");
+    // Tasks collapse into the section-anchored (narrative) group.
+    expect(anchorKindForTarget("task")).toBe("section");
+  });
+
+  it("groups oldest-first comments and reports the oldest createdAt per group", () => {
+    tagAc(AC(1));
+    // Oldest-first input (as assessCommentsStatus produces).
+    const comments: OpenComment[] = [
+      mkComment({ targetKind: "decision", createdAt: new Date("2026-06-01T00:00:00Z") }),
+      mkComment({ targetKind: "section", createdAt: new Date("2026-06-05T00:00:00Z") }),
+      mkComment({ targetKind: "task", createdAt: new Date("2026-06-08T00:00:00Z") }),
+      mkComment({ targetKind: "decision", createdAt: new Date("2026-06-10T00:00:00Z") }),
+    ];
+
+    const grouped = groupCommentsByAnchorKind(comments);
+
+    expect(grouped.decision.count).toBe(2);
+    expect(grouped.section.count).toBe(2); // section + task
+
+    // Oldest per group = the first (oldest-first order preserved).
+    expect(grouped.decision.oldestCreatedAt).toEqual(new Date("2026-06-01T00:00:00Z"));
+    expect(grouped.section.oldestCreatedAt).toEqual(new Date("2026-06-05T00:00:00Z"));
+
+    // Member order is preserved within each group.
+    expect(grouped.decision.comments.map((c) => c.createdAt.toISOString())).toEqual([
+      "2026-06-01T00:00:00.000Z",
+      "2026-06-10T00:00:00.000Z",
+    ]);
+    expect(grouped.section.comments.map((c) => c.target.kind)).toEqual([
+      "section",
+      "task",
+    ]);
+  });
+
+  it("an empty group reports count 0 and null oldest age", () => {
+    tagAc(AC(1));
+    const grouped = groupCommentsByAnchorKind([
+      mkComment({ targetKind: "decision", createdAt: new Date("2026-06-01T00:00:00Z") }),
+    ]);
+    expect(grouped.section.count).toBe(0);
+    expect(grouped.section.oldestCreatedAt).toBeNull();
+    expect(grouped.section.comments).toEqual([]);
+  });
+
+  it("operates on whatever it is given — it has no notion of resolved state (ac-10)", () => {
+    // ac-10: the open-set basis (resolved_at IS NULL) is the SOLE filter, applied
+    // by assessCommentsStatus's query. The grouper holds no second model — it
+    // groups every comment handed to it, so there is no place for a divergent
+    // 'open' definition to creep in.
+    tagAc(AC(10));
+    const all = [
+      mkComment({ targetKind: "decision", createdAt: new Date("2026-06-01T00:00:00Z") }),
+      mkComment({ targetKind: "section", createdAt: new Date("2026-06-02T00:00:00Z") }),
+    ];
+    const grouped = groupCommentsByAnchorKind(all);
+    expect(grouped.decision.count + grouped.section.count).toBe(all.length);
+  });
+});

--- a/packages/server/src/services/comment-assessment.ts
+++ b/packages/server/src/services/comment-assessment.ts
@@ -24,6 +24,27 @@ export interface OpenComment {
   createdAt: Date;
 }
 
+/**
+ * spec-259 t-3 — open comments grouped by ANCHOR KIND for the specify→build
+ * readiness surface. Comments are XOR-targeted at a section / decision / task;
+ * for the readiness view we collapse to two anchor groups the human cares
+ * about: decision-anchored (the comment hangs off a `dec-N`) and
+ * section-anchored (everything else — sections and tasks). Each group carries
+ * its member comments (oldest-first, inherited from the parent sort) plus the
+ * OLDEST createdAt across the group so a caller can render a "oldest Nd ago"
+ * age per group without re-walking the list.
+ */
+export type AnchorGroupKind = "decision" | "section";
+
+export interface CommentAnchorGroup {
+  kind: AnchorGroupKind;
+  count: number;
+  /** Oldest open-comment createdAt in this group, or null when empty. */
+  oldestCreatedAt: Date | null;
+  /** Member comments, oldest-first (same order as `comments`). */
+  comments: OpenComment[];
+}
+
 export interface CommentsStatus {
   briefId: string;
   specHandle: string;
@@ -40,6 +61,49 @@ export interface CommentsStatus {
   };
   /** Open comments, oldest-first. */
   comments: OpenComment[];
+  /**
+   * spec-259 t-3: the same open comments collapsed to two anchor groups
+   * (decision-anchored vs section-anchored), each with its member comments and
+   * the group's oldest createdAt. Backward-compatible add — existing callers
+   * that read `comments` / `byType` are untouched.
+   */
+  byAnchorKind: {
+    decision: CommentAnchorGroup;
+    section: CommentAnchorGroup;
+  };
+}
+
+/**
+ * spec-259 t-3: collapse a target kind to its anchor group. Decision targets
+ * are "decision-anchored"; sections and tasks are "section-anchored" (the
+ * narrative surface the human reviews). Pure — exported for unit testing.
+ */
+export function anchorKindForTarget(kind: CommentTargetKind): AnchorGroupKind {
+  return kind === "decision" ? "decision" : "section";
+}
+
+/**
+ * spec-259 t-3: group an oldest-first list of open comments by anchor kind,
+ * carrying per-group oldest createdAt. Input order is preserved within each
+ * group, so the first member of each group IS its oldest comment. Pure —
+ * exported for unit testing.
+ */
+export function groupCommentsByAnchorKind(
+  comments: readonly OpenComment[],
+): CommentsStatus["byAnchorKind"] {
+  const decisionComments = comments.filter((c) => anchorKindForTarget(c.target.kind) === "decision");
+  const sectionComments = comments.filter((c) => anchorKindForTarget(c.target.kind) === "section");
+  const group = (kind: AnchorGroupKind, members: OpenComment[]): CommentAnchorGroup => ({
+    kind,
+    count: members.length,
+    // Members inherit the parent oldest-first sort, so [0] is the oldest.
+    oldestCreatedAt: members.length > 0 ? members[0].createdAt : null,
+    comments: members,
+  });
+  return {
+    decision: group("decision", decisionComments),
+    section: group("section", sectionComments),
+  };
 }
 
 const SNIPPET_MAX = 120;
@@ -251,5 +315,6 @@ export async function assessCommentsStatus(
     totalOpen: comments.length,
     byType,
     comments,
+    byAnchorKind: groupCommentsByAnchorKind(comments),
   };
 }

--- a/packages/server/src/services/comment-resolution-attribution.spec-259.integration.test.ts
+++ b/packages/server/src/services/comment-resolution-attribution.spec-259.integration.test.ts
@@ -1,0 +1,99 @@
+// spec-259 ac-4 / dec-1 — comment resolution carries WHO + WHEN. REAL Postgres +
+// REAL bus + sink, patterned on attribution.spec-244.integration.test.ts.
+//
+// ac-4 asks the resolution model audit "who resolved, when". Build grounding found
+// resolveComment hardcoded mutate({}) — so WHO was dropped (activity_log row landed
+// actor_user_id = null). t-6 threaded an explicit RequestCtx through resolveComment
+// and the routed call sites (restCtx(c) / reqCtx(ctx)) per std-32. This test is the
+// guard: resolve a comment with a rest_ui ctx and assert the activity_log row for
+// the resolution carries the acting user (WHO) and the comment row carries
+// resolved_at (WHEN). The denormalized doc_comments.resolved_by_user_id column is
+// deferred (a follow-up Issue) — attribution rides the activity contract.
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { and, eq } from "drizzle-orm";
+import { db } from "../db/connection.js";
+import { activityLog, documents, decisions, tasks, docComments } from "../db/schema.js";
+import { createDocDraft } from "./documents.js";
+import { addComment, resolveComment } from "./comments.js";
+import { upsertUserByEmail } from "./users.js";
+import { actorCtx } from "./actor.js";
+import { makeTestMemex } from "./test-helpers.js";
+import {
+  startActivityLogSink,
+  _stopActivityLogSink,
+} from "./activity-log.js";
+
+const AC4 = "mindset-prod/memex-building-itself/specs/spec-259/acs/ac-4";
+
+let memexId: string;
+let userId: string;
+let docId: string;
+let user: Awaited<ReturnType<typeof upsertUserByEmail>>;
+
+beforeAll(async () => {
+  memexId = await makeTestMemex("comment-resolve-attrib");
+  user = await upsertUserByEmail(`resolver-${Date.now()}@memex.ai`);
+  userId = user.id;
+  const spec = await createDocDraft(memexId, "Resolution attribution spec", "Purpose", "spec");
+  docId = spec.id;
+  startActivityLogSink();
+});
+
+afterAll(async () => {
+  _stopActivityLogSink();
+  await db.delete(activityLog).where(eq(activityLog.memexId, memexId)).catch(() => {});
+  await db.delete(docComments).where(eq(docComments.memexId, memexId)).catch(() => {});
+  await db.delete(tasks).where(eq(tasks.docId, docId)).catch(() => {});
+  await db.delete(decisions).where(eq(decisions.docId, docId)).catch(() => {});
+  await db.delete(documents).where(eq(documents.id, docId)).catch(() => {});
+});
+
+async function waitForResolveActivity(timeoutMs = 1500) {
+  const start = Date.now();
+  for (;;) {
+    const rows = await db
+      .select()
+      .from(activityLog)
+      .where(
+        and(
+          eq(activityLog.memexId, memexId),
+          eq(activityLog.entity, "comment"),
+          eq(activityLog.action, "updated"),
+        ),
+      );
+    if (rows.length > 0 || Date.now() - start > timeoutMs) return rows;
+    await new Promise((r) => setTimeout(r, 25));
+  }
+}
+
+describe("comment resolution attribution (spec-259 ac-4)", () => {
+  it("resolveComment with a rest_ui ctx records WHO (actor_user_id) and WHEN (resolved_at)", async () => {
+    tagAc(AC4);
+    // createDocDraft seeds the overview section; anchor an open comment to it.
+    const sections = await db.query.docSections.findMany({
+      where: (s, { eq: eqs }) => eqs(s.docId, docId),
+    });
+    expect(sections.length).toBeGreaterThan(0);
+    const created = await addComment(memexId, sections[0].id, "barrie hadfield", "please address", {
+      type: "question",
+    });
+    expect(created.resolvedAt).toBeNull();
+
+    // Resolve it as an authenticated REST user.
+    const ctx = actorCtx(user, "rest_ui");
+    const resolved = await resolveComment(memexId, created.id, "acknowledged", ctx);
+
+    // WHEN: resolved_at stamped.
+    expect(resolved.resolvedAt).not.toBeNull();
+    expect(resolved.resolvedAt).toBeInstanceOf(Date);
+
+    // WHO: the resolution's activity_log row carries the acting user + human kind.
+    const rows = await waitForResolveActivity();
+    expect(rows.length).toBeGreaterThan(0);
+    const resolveRow = rows[rows.length - 1];
+    expect(resolveRow.actorUserId).toBe(userId);
+    expect(resolveRow.actorKind).toBe("human");
+  });
+});

--- a/packages/server/src/services/comments.ts
+++ b/packages/server/src/services/comments.ts
@@ -15,7 +15,7 @@ import {
 } from "../types/roles.js";
 import { isUuid, parseHandle } from "./shared/identifiers.js";
 import { nextSeq, withSeqRetry } from "./shared/sequence.js";
-import { mutate, type Mutated } from "./mutate.js";
+import { mutate, type Mutated, type RequestCtx } from "./mutate.js";
 import {
   hasAnchorMarker,
   insertMarkerAt,
@@ -779,6 +779,12 @@ export async function resolveComment(
   memexId: string,
   commentId: string,
   resolution?: string,
+  // spec-259 dec-1 / ac-4: resolution is an activity-bearing mutation, so it must
+  // carry WHO (std-32). The acting user rides the explicit RequestCtx through
+  // mutate() — the route/MCP caller passes restCtx(c)/reqCtx(ctx). It defaults to
+  // an empty ctx so unattributed/system callers still resolve (degrading to no
+  // actor rather than throwing), matching the rest of the activity contract.
+  ctx: RequestCtx = {},
 ): Promise<Mutated<DocComment>> {
   // Pre-load to fail fast on the FK lookup before opening the mutate transaction.
   const existing = await db.query.docComments.findFirst({
@@ -790,7 +796,7 @@ export async function resolveComment(
   const docId = (await getDocIdForComment(existing)) ?? undefined;
 
   return mutate(
-    {},
+    ctx,
     { memexId, docId, entity: "comment", action: "updated" },
     async () => {
       const [updated] = await db

--- a/packages/server/src/services/memex-search-byline.test.ts
+++ b/packages/server/src/services/memex-search-byline.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import {
+  formatSearchResults,
+  type MemexSearchHit,
+} from "./memex-search.js";
+
+// spec-259 t-4 — PURE unit tests of the search-result formatter. No DB: we hand
+// `formatSearchResults` synthetic MemexSearchHit objects plus a fixed `now`, so
+// timeAgo() output is deterministic. Covers:
+//   ac-9  — per-section WHO/WHEN on multi-section doc hits; capitalizeDisplayName
+//           applied to authors; rendered timestamp moved to relative timeAgo()
+//           (dec-5), while the structured object keeps absolute ISO.
+//   ac-12 — the lightweight open-comment indicator line (count + oldest age,
+//           no comment content); rendered only when open comments exist.
+
+// Fixed clock: 2026-06-14T12:00:00Z. timeAgo() ages everything against this.
+const NOW = new Date("2026-06-14T12:00:00.000Z");
+
+// ISO helpers anchored to NOW so the relative ages are stable.
+const THREE_DAYS_AGO = "2026-06-11T12:00:00.000Z"; // "3d ago"
+const FIVE_DAYS_AGO = "2026-06-09T12:00:00.000Z"; // "5d ago"
+const SIX_DAYS_AGO = "2026-06-08T12:00:00.000Z"; // "6d ago" (still < 1 week)
+
+function docHit(overrides: Partial<MemexSearchHit> = {}): MemexSearchHit {
+  return {
+    id: "doc-uuid-1",
+    kind: "document",
+    path: "ns/mx/docs/doc-1",
+    title: "Some Doc",
+    status: "active",
+    score: 0.5,
+    strategies: ["fts"],
+    matchingSections: [],
+    parentDocId: "doc-uuid-1",
+    authorName: null,
+    lastUpdatedAt: null,
+    ...overrides,
+  };
+}
+
+describe("formatSearchResults — per-section WHO/WHEN (spec-259 ac-9)", () => {
+  it("renders each matched section's own author + relative age (section creators surface, not just the latest)", () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-259/acs/ac-9");
+    const hit = docHit({
+      authorName: "ada lovelace",
+      lastUpdatedAt: THREE_DAYS_AGO,
+      matchingSections: [
+        {
+          id: "s1",
+          sectionType: "prose",
+          title: "Intro",
+          content: "intro body",
+          matchedVia: "fts",
+          authorName: "grace hopper",
+          lastUpdatedAt: FIVE_DAYS_AGO,
+        },
+        {
+          id: "s2",
+          sectionType: "prose",
+          title: "Details",
+          content: "details body",
+          matchedVia: "vector",
+          authorName: "alan turing",
+          lastUpdatedAt: SIX_DAYS_AGO,
+        },
+      ],
+    });
+
+    const out = formatSearchResults("q", [hit], { now: NOW });
+
+    // Each section line carries ITS OWN author + age, not the doc-level latest.
+    expect(out).toContain(`- Section "Intro" (fts) · Grace Hopper, 5d ago:`);
+    expect(out).toContain(`- Section "Details" (vector) · Alan Turing, 6d ago:`);
+  });
+
+  it("applies capitalizeDisplayName to the heading author and uses relative timeAgo (dec-5)", () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-259/acs/ac-9");
+    const hit = docHit({ authorName: "ada lovelace", lastUpdatedAt: THREE_DAYS_AGO });
+
+    const out = formatSearchResults("q", [hit], { now: NOW });
+
+    // Capitalized author + relative age in the heading byline.
+    expect(out).toContain("· Ada Lovelace, 3d ago");
+    // No absolute YYYY-MM-DD in the rendered output (dec-5 moved it to relative).
+    expect(out).not.toContain("2026-06-11");
+  });
+
+  it("keeps the structured object's authorName/lastUpdatedAt as absolute ISO (wire fields unchanged)", () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-259/acs/ac-9");
+    const hit = docHit({
+      authorName: "ada lovelace",
+      lastUpdatedAt: THREE_DAYS_AGO,
+      matchingSections: [
+        {
+          id: "s1",
+          sectionType: "prose",
+          title: "Intro",
+          content: "body",
+          matchedVia: "fts",
+          authorName: "grace hopper",
+          lastUpdatedAt: FIVE_DAYS_AGO,
+        },
+      ],
+    });
+
+    // Formatting does not mutate the structured object — ISO + raw casing survive.
+    formatSearchResults("q", [hit], { now: NOW });
+    expect(hit.lastUpdatedAt).toBe(THREE_DAYS_AGO);
+    expect(hit.authorName).toBe("ada lovelace");
+    expect(hit.matchingSections[0].lastUpdatedAt).toBe(FIVE_DAYS_AGO);
+    expect(hit.matchingSections[0].authorName).toBe("grace hopper");
+  });
+
+  it("degrades gracefully when a section has no author or timestamp", () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-259/acs/ac-9");
+    const hit = docHit({
+      matchingSections: [
+        {
+          id: "s1",
+          sectionType: "prose",
+          title: "Intro",
+          content: "body",
+          matchedVia: "fts",
+          authorName: null,
+          lastUpdatedAt: null,
+        },
+      ],
+    });
+
+    const out = formatSearchResults("q", [hit], { now: NOW });
+    // No byline appended — line ends right after the (via) segment.
+    expect(out).toContain(`- Section "Intro" (fts):`);
+  });
+});
+
+describe("formatSearchResults — open-comment indicator (spec-259 ac-12)", () => {
+  it("renders one indicator line with count + oldest age, no comment content", () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-259/acs/ac-12");
+    const hit = docHit({
+      openComments: { count: 2, oldestCreatedAt: THREE_DAYS_AGO },
+    });
+
+    const out = formatSearchResults("q", [hit], { now: NOW });
+    expect(out).toContain("- (2 open comments, oldest 3d ago)");
+  });
+
+  it("singularises the noun for a single open comment", () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-259/acs/ac-12");
+    const hit = docHit({
+      openComments: { count: 1, oldestCreatedAt: FIVE_DAYS_AGO },
+    });
+
+    const out = formatSearchResults("q", [hit], { now: NOW });
+    expect(out).toContain("- (1 open comment, oldest 5d ago)");
+  });
+
+  it("renders NO indicator line when the hit has zero open comments", () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-259/acs/ac-12");
+    const hit = docHit({ openComments: undefined });
+
+    const out = formatSearchResults("q", [hit], { now: NOW });
+    expect(out).not.toContain("open comment");
+  });
+
+  it("attaches the indicator to a decision hit (doc-scoped) without its content", () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-259/acs/ac-12");
+    const hit = docHit({
+      kind: "decision",
+      path: "ns/mx/specs/spec-1/decisions/dec-1",
+      decisionSnippet: "the decision body",
+      decisionMatchedVia: "fts",
+      openComments: { count: 3, oldestCreatedAt: SIX_DAYS_AGO },
+    });
+
+    const out = formatSearchResults("q", [hit], { now: NOW });
+    expect(out).toContain("- (3 open comments, oldest 6d ago)");
+  });
+});

--- a/packages/server/src/services/memex-search.integration.test.ts
+++ b/packages/server/src/services/memex-search.integration.test.ts
@@ -13,12 +13,13 @@
 import { describe, it, expect, afterAll, beforeAll } from "vitest";
 import { inArray, sql, eq } from "drizzle-orm";
 import { db } from "../db/connection.js";
-import { documents } from "../db/schema.js";
+import { documents, docSections } from "../db/schema.js";
 import { createStandard } from "./standards.js";
 import { createDocDraft } from "./documents.js";
 import { addSection } from "./sections.js";
 import { createDecision, resolveDecision } from "./decisions.js";
 import { createIssue, type IssueType } from "./issues.js";
+import { addComment, resolveComment } from "./comments.js";
 import { upsertUserByEmail } from "./users.js";
 import {
   embedAndStoreDoc,
@@ -803,6 +804,8 @@ describe("formatSearchResults — b-34 D-4 spec", () => {
             title: "Overview",
             content: "Some matching content goes here.",
             matchedVia: "vector",
+            authorName: null,
+            lastUpdatedAt: null,
           },
         ],
       },
@@ -872,6 +875,8 @@ describe("formatSearchResults — b-34 D-4 spec", () => {
           title: null,
           content: long,
           matchedVia: "fts",
+          authorName: null,
+          lastUpdatedAt: null,
         },
       ],
     };
@@ -1000,6 +1005,8 @@ describe("formatSearchResults — [current doc] tag (includeCurrentDoc opt-in)",
           title: "Overview",
           content: "Content.",
           matchedVia: "fts",
+          authorName: null,
+          lastUpdatedAt: null,
         },
       ],
     };
@@ -1247,12 +1254,19 @@ describe("formatSearchResults — WHO/WHEN byline (spec-285 ac-8)", () => {
     lastUpdatedAt: null,
   };
 
-  it("renders ` · <author>, <YYYY-MM-DD>` when both are present", () => {
+  // spec-259 dec-5 moved the RENDERED timestamp from absolute YYYY-MM-DD to a
+  // relative `timeAgo()` ("Nd ago"). A fixed `now` keeps the age deterministic;
+  // the structured `lastUpdatedAt` stays absolute ISO (asserted in ac-6/ac-7).
+  const NOW_285 = new Date("2026-05-31T09:30:00.000Z");
+
+  it("renders ` · <author>, <relative-age>` when both are present (dec-5)", () => {
     tagAc(SPEC285_AC(8));
-    const out = formatSearchResults("q", [
-      { ...base, authorName: "Ada Lovelace", lastUpdatedAt: "2026-05-28T09:30:00.000Z" },
-    ]);
-    expect(out).toContain(`(spec, build) · Ada Lovelace, 2026-05-28`);
+    const out = formatSearchResults(
+      "q",
+      [{ ...base, authorName: "Ada Lovelace", lastUpdatedAt: "2026-05-28T09:30:00.000Z" }],
+      { now: NOW_285 },
+    );
+    expect(out).toContain(`(spec, build) · Ada Lovelace, 3d ago`);
     // No UUIDs in the rendered output (b-36 D-7 still holds).
     const uuidRegex = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i;
     expect(out).not.toMatch(uuidRegex);
@@ -1262,15 +1276,17 @@ describe("formatSearchResults — WHO/WHEN byline (spec-285 ac-8)", () => {
     tagAc(SPEC285_AC(8));
     const out = formatSearchResults("q", [{ ...base, authorName: "Grace Hopper" }]);
     expect(out).toContain(`(spec, build) · Grace Hopper`);
-    expect(out).not.toContain("Grace Hopper,"); // no trailing comma/date
+    expect(out).not.toContain("Grace Hopper,"); // no trailing comma/age
   });
 
-  it("renders the date alone when there is no author", () => {
+  it("renders the relative age alone when there is no author (dec-5)", () => {
     tagAc(SPEC285_AC(8));
-    const out = formatSearchResults("q", [
-      { ...base, lastUpdatedAt: "2026-01-02T00:00:00.000Z" },
-    ]);
-    expect(out).toContain(`(spec, build) · 2026-01-02`);
+    const out = formatSearchResults(
+      "q",
+      [{ ...base, lastUpdatedAt: "2026-05-28T09:30:00.000Z" }],
+      { now: NOW_285 },
+    );
+    expect(out).toContain(`(spec, build) · 3d ago`);
   });
 
   it("emits NO byline when neither author nor timestamp is set", () => {
@@ -1425,7 +1441,9 @@ describe("searchMemex → formatSearchResults — end-to-end byline (spec-285 ac
     });
     const out = formatSearchResults("authore2euniquetokenx", hits);
     expect(out).toContain("Ada Lovelace");
-    expect(out).toMatch(/· Ada Lovelace, \d{4}-\d{2}-\d{2}/);
+    // spec-259 dec-5: rendered timestamp is now a relative age ("just now" /
+    // "Nm ago" / "Nh ago" / "Nd ago"), not an absolute YYYY-MM-DD.
+    expect(out).toMatch(/· Ada Lovelace, (just now|\d+[mhd] ago)/);
   });
 });
 
@@ -1450,6 +1468,8 @@ describe("spec-285 — additive, non-breaking, single-source (ac-4)", () => {
           title: "Do",
           content: "Some rule.",
           matchedVia: "fts",
+          authorName: null,
+          lastUpdatedAt: null,
         },
       ],
       authorName: null,
@@ -1508,13 +1528,95 @@ describe("spec-285 — legible in both surfaces: markdown AND structured (ac-5)"
       lastUpdatedAt: "2026-05-28T12:00:00.000Z",
     };
 
-    // Surface 1 — the MCP/React-agent markdown: human-readable "name, date".
-    const md = formatSearchResults("q", [hit]);
-    expect(md).toMatch(/· Ryan Soosayraj, 2026-05-28/);
+    // Surface 1 — the MCP/React-agent markdown: human-readable "name, age".
+    // spec-259 dec-5: the rendered timestamp is now a relative age, with a fixed
+    // `now` for determinism (2026-05-31 → "3d ago").
+    const md = formatSearchResults("q", [hit], { now: new Date("2026-05-31T12:00:00.000Z") });
+    expect(md).toMatch(/· Ryan Soosayraj, 3d ago/);
 
     // Surface 2 — the structured field the React agent / REST consume: discrete,
-    // not buried in prose. An agent can cite "<name>, <date>" without parsing.
+    // not buried in prose, and STILL absolute ISO (the wire field is unchanged).
     expect(hit.authorName).toBe("Ryan Soosayraj");
     expect(hit.lastUpdatedAt!.slice(0, 10)).toBe("2026-05-28");
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// spec-259 ac-12 — open-comment indicator (DB-backed). Exercises the grouped
+// doc_comments query (loadOpenCommentSummaries via searchMemex → attachOpenComments):
+//   - only UNRESOLVED comments (resolved_at IS NULL) count
+//   - the count + oldest open comment surface on the hit's `openComments`
+//   - a hit with zero open comments leaves `openComments` undefined
+//   - the indicator renders in the markdown formatter (no comment content)
+// DB-NEEDED: run serially by the orchestrator (creates docs/sections/comments).
+// ═══════════════════════════════════════════════════════════════════════════
+describe("searchMemex — open-comment indicator (spec-259 ac-12)", () => {
+  it("counts only UNRESOLVED comments and surfaces the oldest open one", async () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-259/acs/ac-12");
+    const provider = makeFakeProvider("fake-open-comments");
+    const spec = await seedSpec(
+      memexId,
+      "Open comment host",
+      "opencommentuniquetokenx overview body.",
+      [],
+      provider,
+    );
+    // Grab a section to anchor comments on (the overview seed creates one).
+    const section = await db.query.docSections.findFirst({
+      where: eq(docSections.docId, spec.id),
+    });
+    expect(section).toBeDefined();
+
+    // Two open comments + one that we then resolve (must NOT count).
+    await addComment(memexId, section!.id, "Ada", "first open");
+    await addComment(memexId, section!.id, "Grace", "second open");
+    const toResolve = await addComment(memexId, section!.id, "Alan", "will resolve");
+    await resolveComment(memexId, toResolve.id, "done");
+
+    const hits = await searchMemex(memexId, "opencommentuniquetokenx", {
+      provider,
+      kind: "spec",
+      disableVector: true,
+    });
+    const hit = hits.find((h) => h.id === spec.id);
+    expect(hit).toBeDefined();
+    expect(hit!.openComments).toBeDefined();
+    expect(hit!.openComments!.count).toBe(2); // the resolved one is excluded
+    // oldestCreatedAt is absolute ISO on the structured object.
+    expect(hit!.openComments!.oldestCreatedAt).toMatch(ISO_RE);
+
+    // Markdown renders the indicator line — count + relative age, no content.
+    // (Freshly-seeded comments render "just now"; the exact "Nd ago" formatting is
+    // proven deterministically with an injected `now` in memex-search-byline.test.ts.)
+    const out = formatSearchResults("opencommentuniquetokenx", [hit!]);
+    expect(out).toMatch(/- \(2 open comments, oldest .+\)/);
+    expect(out).not.toContain("first open");
+    expect(out).not.toContain("second open");
+  });
+
+  it("leaves openComments undefined when the doc has no open comments", async () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-259/acs/ac-12");
+    const provider = makeFakeProvider("fake-no-open-comments");
+    const spec = await seedSpec(
+      memexId,
+      "No open comment host",
+      "nocommentuniquetokenx overview body.",
+      [],
+      provider,
+    );
+
+    const hits = await searchMemex(memexId, "nocommentuniquetokenx", {
+      provider,
+      kind: "spec",
+      disableVector: true,
+    });
+    const hit = hits.find((h) => h.id === spec.id);
+    expect(hit).toBeDefined();
+    expect(hit!.openComments).toBeUndefined();
+
+    // No indicator line in the rendered markdown. (Match the indicator PATTERN, not
+    // the bare substring "open comment" — this hit's title is "No open comment host".)
+    const out = formatSearchResults("nocommentuniquetokenx", [hit!]);
+    expect(out).not.toMatch(/\(\d+ open comments?, oldest/);
   });
 });

--- a/packages/server/src/services/memex-search.ts
+++ b/packages/server/src/services/memex-search.ts
@@ -50,6 +50,7 @@
 // but IS NOT TRUE is robust against any legacy NULL and reads as the intent).
 
 import { sql } from "drizzle-orm";
+import { timeAgo, capitalizeDisplayName } from "@memex/shared";
 import { db } from "../db/connection.js";
 import {
   resolveEmbeddingProvider,
@@ -151,6 +152,15 @@ export interface MatchingSection {
   content: string;
   /** Which search method surfaced this section first. */
   matchedVia: SearchStrategy;
+  /** WHO — best-effort display name of who last touched THIS section (spec-259
+   *  ac-9). Carried per-section so a multi-section doc hit surfaces each
+   *  matched section's own creator, not just the doc-level latest. Same SQL
+   *  COALESCE(actor_name, users.name, users.email) resolution as the doc-level
+   *  WHO. null when nothing resolved. Wire/structured value — kept absolute. */
+  authorName: string | null;
+  /** WHEN — ISO-8601 last-modified of THIS section (spec-259 ac-9). Absolute
+   *  ISO on the structured object; rendered relative via timeAgo(). */
+  lastUpdatedAt: string | null;
 }
 
 export interface MemexSearchHit {
@@ -199,6 +209,12 @@ export interface MemexSearchHit {
    *  carry no `updated_at`). null only when no timestamp was selected
    *  (navigation-only lanes). */
   lastUpdatedAt: string | null;
+  /** Open (unresolved) comments anchored on this hit's doc (spec-259 ac-12). A
+   *  lightweight indicator only — count + oldest open comment's age — never the
+   *  comment content. `oldestCreatedAt` is absolute ISO on the structured
+   *  object; rendered relative via timeAgo(). Omitted (undefined) when the hit
+   *  has zero open comments, so the formatter renders no indicator line. */
+  openComments?: { count: number; oldestCreatedAt: string };
 }
 
 export interface SearchMemexOptions {
@@ -363,6 +379,64 @@ function toIso(value: string | Date | null | undefined): string | null {
   return Number.isNaN(d.getTime()) ? null : d.toISOString();
 }
 
+// spec-259 ac-12: batch-load the open (unresolved) comment count + oldest open
+// comment timestamp for a set of doc ids, in ONE grouped query (no N+1). Keyed
+// by doc_id — a comment transitively belongs to a doc via its section/decision/
+// task target, but doc_id is denormalised on the row (schema comment), so we
+// group on it directly. `resolved_at IS NULL` is the open predicate. Returns a
+// Map doc_id → { count, oldestCreatedAt(ISO) }; absent keys have zero open
+// comments. No comment CONTENT is selected — indicator only.
+interface OpenCommentRow {
+  doc_id: string;
+  open_count: number | string;
+  oldest_created_at: string | Date;
+}
+
+async function loadOpenCommentSummaries(
+  docIds: string[],
+): Promise<Map<string, { count: number; oldestCreatedAt: string }>> {
+  const summaries = new Map<string, { count: number; oldestCreatedAt: string }>();
+  if (docIds.length === 0) return summaries;
+  // De-dupe the id set (decision/section hits can share a parent doc) so the
+  // IN-list is minimal.
+  const uniqueIds = Array.from(new Set(docIds));
+  const idList = sql.join(
+    uniqueIds.map((id) => sql`${id}::uuid`),
+    sql`, `,
+  );
+  const rows = (await db.execute(sql`
+    SELECT
+      doc_id                AS doc_id,
+      COUNT(*)              AS open_count,
+      MIN(created_at)       AS oldest_created_at
+    FROM doc_comments
+    WHERE doc_id IN (${idList})
+      AND resolved_at IS NULL
+    GROUP BY doc_id
+  `)) as unknown as OpenCommentRow[];
+  for (const r of rows) {
+    const count = Number(r.open_count);
+    const oldestCreatedAt = toIso(r.oldest_created_at);
+    if (count > 0 && oldestCreatedAt) {
+      summaries.set(r.doc_id, { count, oldestCreatedAt });
+    }
+  }
+  return summaries;
+}
+
+// spec-259 ac-12: attach the open-comment indicator to each hit by its parent
+// doc. Mutates in place and returns the same array. A decision/section hit
+// inherits its parent doc's open-comment summary (the indicator is doc-scoped).
+async function attachOpenComments(hits: MemexSearchHit[]): Promise<MemexSearchHit[]> {
+  if (hits.length === 0) return hits;
+  const summaries = await loadOpenCommentSummaries(hits.map((h) => h.parentDocId));
+  for (const hit of hits) {
+    const summary = summaries.get(hit.parentDocId);
+    if (summary) hit.openComments = summary;
+  }
+  return hits;
+}
+
 // ── Public entry point ─────────────────────────────────
 
 export async function searchMemex(
@@ -386,7 +460,7 @@ export async function searchMemex(
   //    through to FTS/vector.)
   if (HANDLE_REGEX.test(trimmed)) {
     const direct = await lookupByHandle(memexId, slugs, trimmed, includeArchived);
-    if (direct) return [direct];
+    if (direct) return attachOpenComments([direct]);
     // Fall through to fuzzy search if nothing matched (the user might have
     // typed a handle that doesn't exist; better to show paraphrase candidates
     // than an empty result).
@@ -469,7 +543,7 @@ export async function searchMemex(
     issueTasks[1],
   ]);
 
-  return mergeWithRrf(
+  const merged = mergeWithRrf(
     sectionFts as SectionRow[],
     sectionVector as SectionRow[],
     decisionFts as DecisionRow[],
@@ -479,6 +553,10 @@ export async function searchMemex(
     slugs,
     limit,
   );
+
+  // spec-259 ac-12: enrich the (already-capped) result set with open-comment
+  // indicators in one grouped query — batched over the result docs, never N+1.
+  return attachOpenComments(merged);
 }
 
 // ── Direct lookup ──────────────────────────────────────
@@ -558,6 +636,11 @@ async function lookupByHandle(
       title: r.section_title,
       content: r.section_content,
       matchedVia: "handle",
+      // spec-259 ac-9: per-section WHO/WHEN. The handle row has no resolved
+      // creator fallback per-section, so use the section's denormalised
+      // actor_name (std-32), else the doc-level resolved creator fallback.
+      authorName: r.section_actor_name?.trim() || docAuthorFallback,
+      lastUpdatedAt: toIso(r.section_updated_at),
     })),
   };
 }
@@ -1237,6 +1320,10 @@ function mergeWithRrf(
           title: r.section_title,
           content: r.section_content,
           matchedVia: via,
+          // spec-259 ac-9: per-section WHO/WHEN so each matched section's own
+          // creator surfaces, not just the doc-level most-recent one.
+          authorName: r.author_name?.trim() || null,
+          lastUpdatedAt: toIso(r.updated_at),
         });
       }
     }
@@ -1376,20 +1463,48 @@ export interface FormatOptions {
    *  `includeCurrentDoc: true` (the default excludes the current doc from
    *  results entirely, so this never fires). */
   currentDocId?: string;
+  /** Injectable "now" for relative-age rendering (spec-259 dec-5). Tests pass a
+   *  fixed clock so `timeAgo()` output is deterministic; production omits it and
+   *  the helpers default to the real wall clock. */
+  now?: Date;
 }
 
-// spec-285: the WHO/WHEN byline appended to a hit's heading, e.g.
-// ` · Ryan Soosayraj, 2026-05-28`. Legible to a human and parseable by an agent
-// (` · <author>, <YYYY-MM-DD>`). Degrades gracefully: author-only, date-only, or
-// nothing at all when neither resolved. The date is the calendar day of the ISO
-// timestamp — enough for "when it last changed" without clock noise.
-function formatHitByline(hit: MemexSearchHit): string {
-  const author = hit.authorName?.trim() || null;
-  const date = hit.lastUpdatedAt ? hit.lastUpdatedAt.slice(0, 10) : null;
-  if (author && date) return ` · ${author}, ${date}`;
+// spec-285 + spec-259: the WHO/WHEN byline appended to a hit's heading, e.g.
+// ` · Ryan Soosayraj, 3d ago`. Legible to a human and parseable by an agent
+// (` · <author>, <relative-age>`). Degrades gracefully: author-only, age-only,
+// or nothing at all when neither resolved. spec-259 dec-5 moved the RENDERED
+// timestamp from an absolute YYYY-MM-DD to a relative `timeAgo()` ("Nd ago");
+// the structured `hit.lastUpdatedAt`/`hit.authorName` stay absolute ISO. The
+// author is run through capitalizeDisplayName (spec-259 ac-9) because the SQL
+// WHO-resolver returns raw names that bypass the shared who-resolver. `now` is
+// injectable so unit tests are deterministic.
+function formatWhoWhenByline(
+  authorName: string | null,
+  lastUpdatedAt: string | null,
+  now?: Date,
+): string {
+  const raw = authorName?.trim() || null;
+  const author = raw ? capitalizeDisplayName(raw) : null;
+  const age = lastUpdatedAt ? timeAgo(lastUpdatedAt, now) : null;
+  if (author && age) return ` · ${author}, ${age}`;
   if (author) return ` · ${author}`;
-  if (date) return ` · ${date}`;
+  if (age) return ` · ${age}`;
   return "";
+}
+
+function formatHitByline(hit: MemexSearchHit, now?: Date): string {
+  return formatWhoWhenByline(hit.authorName, hit.lastUpdatedAt, now);
+}
+
+// spec-259 ac-12: the open-comment indicator appended as its own line under a
+// hit, e.g. `- (2 open comments, oldest 3d ago)`. Indicator only — no comment
+// content. Returns null when the hit has zero open comments so the caller emits
+// no line. `now` injectable for deterministic tests.
+function formatOpenCommentsLine(hit: MemexSearchHit, now?: Date): string | null {
+  const oc = hit.openComments;
+  if (!oc || oc.count <= 0) return null;
+  const noun = oc.count === 1 ? "open comment" : "open comments";
+  return `- (${oc.count} ${noun}, oldest ${timeAgo(oc.oldestCreatedAt, now)})`;
 }
 
 function isHitOnCurrentDoc(hit: MemexSearchHit, currentDocId: string): boolean {
@@ -1410,6 +1525,7 @@ export function formatSearchResults(
 
   const verbose = options.verbose === true;
   const currentDocId = options.currentDocId;
+  const now = options.now;
   const lines: string[] = [`## Search results for "${query}" (${hits.length} hit${hits.length === 1 ? "" : "s"})`];
 
   for (const hit of hits) {
@@ -1424,7 +1540,7 @@ export function formatSearchResults(
     // spec-285: WHO/WHEN byline sits after the (kind, status) segment and before
     // the [current doc] / verbose-score suffixes, so an agent reading the result
     // can attribute the hit ("who, when") without opening it.
-    const byline = formatHitByline(hit);
+    const byline = formatHitByline(hit, now);
     lines.push(`### ${hit.path} — "${hit.title}" (${kindLabel}, ${hit.status})${byline}${selfTag}${scoreSuffix}`);
     if (hit.kind === "decision") {
       const via = hit.decisionMatchedVia ?? "fts";
@@ -1438,10 +1554,18 @@ export function formatSearchResults(
       for (const sec of hit.matchingSections) {
         const titleSeg = sec.title ? `"${sec.title}"` : `(${sec.sectionType})`;
         const snippet = truncate((sec.content ?? "").trim(), SNIPPET_MAX_CHARS);
-        lines.push(`- Section ${titleSeg} (${sec.matchedVia}):`);
+        // spec-259 ac-9: per-section WHO/WHEN so a multi-section doc hit surfaces
+        // each matched section's own creator + relative age, not just the
+        // doc-level latest. Same capitalize + timeAgo treatment as the heading.
+        const secByline = formatWhoWhenByline(sec.authorName, sec.lastUpdatedAt, now);
+        lines.push(`- Section ${titleSeg} (${sec.matchedVia})${secByline}:`);
         lines.push(`  > ${snippet}`);
       }
     }
+    // spec-259 ac-12: one lightweight open-comment indicator line per hit (after
+    // the snippet block). Rendered only when the hit has open comments.
+    const openCommentsLine = formatOpenCommentsLine(hit, now);
+    if (openCommentsLine) lines.push(openCommentsLine);
   }
 
   return lines.join("\n");

--- a/packages/server/src/services/phase-assessment.comments-build.spec-259.integration.test.ts
+++ b/packages/server/src/services/phase-assessment.comments-build.spec-259.integration.test.ts
@@ -1,0 +1,123 @@
+// spec-259 t-3 — DB-backed end-to-end for the specify→build open-comment
+// surface. REQUIRES Postgres. The orchestrator runs the DB suite serially —
+// DO NOT run this concurrently with the other DB integration tests.
+//
+// Covers:
+//   ac-1  — assessPhaseTransition(target:'build') surfaces the grouped block.
+//   ac-6  — the SOFT build nudge fires (count + oldest age) when comments exist.
+//   ac-10 — the open-set basis is resolved_at IS NULL: a resolved comment drops
+//           out of the grouping (no second model).
+//   ac-11 — the build transition is NOT gated: updateDocStatus to 'build'
+//           succeeds with open comments present.
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { eq } from "drizzle-orm";
+import { db } from "../db/connection.js";
+import { documents, decisions, tasks, docComments } from "../db/schema.js";
+import { createDocDraft, updateDocStatus } from "./documents.js";
+import { createDecision } from "./decisions.js";
+import { createTask } from "./tasks.js";
+import { addComment, addDecisionComment, addTaskComment, resolveComment } from "./comments.js";
+import { assessPhaseTransition, formatPhaseAssessment, _clearRecentAssessments } from "./phase-assessment.js";
+import { makeTestMemex } from "./test-helpers.js";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+const AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-259/acs/ac-${n}`;
+
+const createdDocIds: string[] = [];
+let memexId: string;
+
+beforeAll(async () => {
+  memexId = await makeTestMemex();
+});
+
+afterAll(async () => {
+  for (const id of createdDocIds) {
+    await db.delete(docComments).where(eq(docComments.memexId, memexId)).catch(() => {});
+    await db.delete(tasks).where(eq(tasks.docId, id)).catch(() => {});
+    await db.delete(decisions).where(eq(decisions.docId, id)).catch(() => {});
+    await db.delete(documents).where(eq(documents.id, id)).catch(() => {});
+  }
+});
+
+describe("spec-259: specify→build open comments end-to-end", () => {
+  it("groups open comments by anchor kind, fires the soft nudge, and does NOT gate (ac-1, ac-6, ac-11)", async () => {
+    tagAc(AC(1));
+    tagAc(AC(6));
+    tagAc(AC(11));
+    _clearRecentAssessments();
+
+    const spec = await createDocDraft(memexId, "Build with open comments", "Purpose", "spec");
+    createdDocIds.push(spec.id);
+    await updateDocStatus(memexId, spec.id, "specify");
+
+    const dec = await createDecision(memexId, spec.id, "Pick storage");
+    const task = await createTask(memexId, spec.id, "Wire gate", "Do it");
+
+    await addDecisionComment(memexId, dec.id, "ada lovelace", "decision question", {
+      type: "question",
+      source: "agent",
+    });
+    await new Promise((r) => setTimeout(r, 5));
+    await addComment(memexId, spec.sections[0].id, "grace hopper", "section note");
+    await new Promise((r) => setTimeout(r, 5));
+    await addTaskComment(memexId, task.id, "alan turing", "task note", { source: "agent" });
+
+    const assessment = await assessPhaseTransition(memexId, spec.id, "build", "not_applicable");
+
+    // ac-1: grouping populated.
+    expect(assessment.openCommentsDetail).toBeDefined();
+    expect(assessment.openCommentsDetail!.totalOpen).toBe(3);
+    expect(assessment.openCommentsDetail!.byAnchorKind.decision.count).toBe(1);
+    expect(assessment.openCommentsDetail!.byAnchorKind.section.count).toBe(2); // section + task
+
+    const rendered = formatPhaseAssessment(assessment);
+    expect(rendered).toContain("Decision-anchored: 1");
+    expect(rendered).toContain("Section-anchored: 2");
+    expect(rendered).toContain("Ada Lovelace");
+
+    // ac-6: soft nudge fires, naming the count.
+    const commentNudge = assessment.nudges.find((n) => n.includes("open comment"));
+    expect(commentNudge).toBeDefined();
+    expect(commentNudge).toMatch(/3 open comments/);
+    // Freshly-seeded → "oldest just now"; the "Nd ago" format is proven with an
+    // injected `now` in the pure phase-assessment.comments-build.spec-259.test.ts.
+    expect(commentNudge).toMatch(/oldest (just now|.*ago)/);
+
+    // ac-11: the nudge is advisory — the transition still succeeds with comments open.
+    const moved = await updateDocStatus(memexId, spec.id, "build");
+    expect(moved.status).toBe("build");
+  });
+
+  it("the open-set basis is resolved_at IS NULL — a resolved comment drops out of the grouping (ac-10)", async () => {
+    tagAc(AC(10));
+    _clearRecentAssessments();
+
+    const spec = await createDocDraft(memexId, "Resolved drops out", "Purpose", "spec");
+    createdDocIds.push(spec.id);
+    await updateDocStatus(memexId, spec.id, "specify");
+
+    const dec = await createDecision(memexId, spec.id, "Pick lib");
+    const openC = await addDecisionComment(memexId, dec.id, "ada", "still open", {
+      type: "question",
+      source: "agent",
+    });
+    const toResolve = await addComment(memexId, spec.sections[0].id, "grace", "will resolve");
+
+    // Before resolution: 2 open (1 decision-anchored, 1 section-anchored).
+    let a = await assessPhaseTransition(memexId, spec.id, "build", "not_applicable");
+    expect(a.openCommentsDetail!.totalOpen).toBe(2);
+    expect(a.openCommentsDetail!.byAnchorKind.section.count).toBe(1);
+
+    await resolveComment(memexId, toResolve.id, "resolved");
+
+    // After resolution: the resolved comment is gone; only the open one remains.
+    _clearRecentAssessments();
+    a = await assessPhaseTransition(memexId, spec.id, "build", "not_applicable");
+    expect(a.openCommentsDetail!.totalOpen).toBe(1);
+    expect(a.openCommentsDetail!.byAnchorKind.section.count).toBe(0);
+    expect(a.openCommentsDetail!.byAnchorKind.decision.count).toBe(1);
+    expect(a.openCommentsDetail!.comments[0].commentId).toBe(openC.id);
+  });
+});

--- a/packages/server/src/services/phase-assessment.comments-build.spec-259.test.ts
+++ b/packages/server/src/services/phase-assessment.comments-build.spec-259.test.ts
@@ -42,7 +42,7 @@ function mkComment(o: {
 
 function mkCommentsStatus(comments: OpenComment[]): CommentsStatus {
   return {
-    briefId: "brief-uuid",
+    briefId: "doc-uuid",
     specHandle: "spec-259",
     specTitle: "Surface open comments",
     totalOpen: comments.length,
@@ -54,7 +54,7 @@ function mkCommentsStatus(comments: OpenComment[]): CommentsStatus {
 
 function mkBuildAssessment(over: Partial<PhaseAssessment> = {}): PhaseAssessment {
   return {
-    briefId: "brief-uuid",
+    briefId: "doc-uuid",
     specHandle: "spec-259",
     specTitle: "Surface open comments",
     currentPhase: "specify",

--- a/packages/server/src/services/phase-assessment.comments-build.spec-259.test.ts
+++ b/packages/server/src/services/phase-assessment.comments-build.spec-259.test.ts
@@ -1,0 +1,214 @@
+// spec-259 t-3 — pure render + nudge tests for the specify→build open-comment
+// surface.
+//
+// No DB: builds a synthetic PhaseAssessment and runs it through the pure
+// `formatPhaseAssessment`, asserting the enriched "Open comments" block
+// (anchor-kind grouping + oldest age + per-comment WHO/WHEN) and the SOFT build
+// nudge. The DB-backed assessPhaseTransition path (that the nudge actually fires
+// and the transition still succeeds end-to-end) is exercised in
+// phase-assessment.integration.test.ts.
+
+import { describe, it, expect } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { formatPhaseAssessment, type PhaseAssessment } from "./phase-assessment.js";
+import type { CommentsStatus, OpenComment } from "./comment-assessment.js";
+import { groupCommentsByAnchorKind } from "./comment-assessment.js";
+
+const AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-259/acs/ac-${n}`;
+
+// A few days back from "now" so timeAgo renders a stable "Nd ago"-shaped string
+// regardless of when the suite runs.
+const daysAgo = (n: number): Date => new Date(Date.now() - n * 24 * 60 * 60 * 1000);
+
+function mkComment(o: {
+  targetKind: OpenComment["target"]["kind"];
+  handle: string;
+  title: string | null;
+  author: string;
+  type?: string;
+  snippet: string;
+  createdAt: Date;
+}): OpenComment {
+  return {
+    commentId: `c-${o.createdAt.getTime()}`,
+    type: o.type ?? "discussion",
+    target: { kind: o.targetKind, handle: o.handle, title: o.title },
+    author: o.author,
+    contentSnippet: o.snippet,
+    createdAt: o.createdAt,
+  };
+}
+
+function mkCommentsStatus(comments: OpenComment[]): CommentsStatus {
+  return {
+    briefId: "brief-uuid",
+    specHandle: "spec-259",
+    specTitle: "Surface open comments",
+    totalOpen: comments.length,
+    byType: { note: comments.length, question: 0, drift: 0, plan_revision: 0, other: 0 },
+    comments,
+    byAnchorKind: groupCommentsByAnchorKind(comments),
+  };
+}
+
+function mkBuildAssessment(over: Partial<PhaseAssessment> = {}): PhaseAssessment {
+  return {
+    briefId: "brief-uuid",
+    specHandle: "spec-259",
+    specTitle: "Surface open comments",
+    currentPhase: "specify",
+    targetPhase: "build",
+    transition: "specify → build",
+    rubricNote: null,
+    rubricProse: "## How to use this\n- proceed-with-caveats — transition is fine but flag <list>.",
+    facts: {
+      openDecisionsCount: 0,
+      openDecisions: [],
+      incompleteTasksCount: 0,
+      readyTasksCount: 0,
+      blockedTasksCount: 0,
+      incompleteTasks: [],
+      unresolvedDriftCount: 0,
+      unresolvedPlanRevisionCount: 0,
+      openCommentsCount: 0,
+      openCommentsByType: {},
+      acVerification: {
+        totalActive: 0,
+        covered: 0,
+        verified: 0,
+        failing: 0,
+        stale: 0,
+        untested: 0,
+        accepted: 0,
+        failingHandles: [],
+        staleHandles: [],
+      },
+      openIssuesCount: 0,
+      sections: [],
+      resolvedDecisionCoverage: [],
+      resolvedDecisionAcCoverage: [],
+    },
+    readiness: { outstandingItems: [], isClean: true },
+    nudges: [],
+    ...over,
+  };
+}
+
+describe("spec-259: specify→build open-comment render (ac-1)", () => {
+  it("renders comments grouped by anchor kind, with per-group oldest age + per-comment WHO/WHEN", () => {
+    tagAc(AC(1));
+
+    const comments = [
+      mkComment({
+        targetKind: "decision",
+        handle: "dec-2",
+        title: "Storage engine",
+        author: "ada lovelace",
+        type: "question",
+        snippet: "are we sure about postgres here?",
+        createdAt: daysAgo(9),
+      }),
+      mkComment({
+        targetKind: "section",
+        handle: "approach",
+        title: "Approach",
+        author: "grace hopper",
+        snippet: "this needs a rollback plan",
+        createdAt: daysAgo(4),
+      }),
+      mkComment({
+        targetKind: "task",
+        handle: "t-1",
+        title: "Wire the gate",
+        author: "alan turing",
+        snippet: "blocked on the migration",
+        createdAt: daysAgo(2),
+      }),
+    ];
+
+    const a = mkBuildAssessment({
+      facts: {
+        ...mkBuildAssessment().facts,
+        openCommentsCount: 3,
+        openCommentsByType: { discussion: 2, question: 1 },
+      },
+      openCommentsDetail: mkCommentsStatus(comments),
+    });
+
+    const out = formatPhaseAssessment(a);
+
+    // Grouping headers.
+    expect(out).toContain("Decision-anchored: 1");
+    expect(out).toContain("Section-anchored: 2"); // section + task collapse
+
+    // Oldest age per group is surfaced via timeAgo (relative, "ago"-shaped).
+    expect(out).toMatch(/Decision-anchored: 1 \(oldest .*ago\)/);
+    expect(out).toMatch(/Section-anchored: 2 \(oldest .*ago\)/);
+
+    // Per-comment WHO (title-cased) / WHEN (relative) / anchor / snippet.
+    expect(out).toContain("Ada Lovelace");
+    expect(out).toContain("Grace Hopper");
+    expect(out).toContain("Alan Turing");
+    expect(out).toMatch(/Ada Lovelace .*ago on decision dec-2 "Storage engine" \[question\]/);
+    expect(out).toContain("are we sure about postgres here?");
+    expect(out).toContain('on section approach "Approach"');
+    expect(out).toContain('on task t-1 "Wire the gate"');
+  });
+
+  it("renders counts-only (no grouping block) when openCommentsDetail is absent (non-build targets)", () => {
+    tagAc(AC(1));
+    const a = mkBuildAssessment({
+      targetPhase: "verify",
+      transition: "build → verify",
+      currentPhase: "build",
+      facts: {
+        ...mkBuildAssessment().facts,
+        openCommentsCount: 2,
+        openCommentsByType: { discussion: 2 },
+      },
+      // openCommentsDetail intentionally undefined.
+    });
+    const out = formatPhaseAssessment(a);
+    expect(out).toContain("Open comments: 2");
+    expect(out).not.toContain("Decision-anchored");
+    expect(out).not.toContain("Section-anchored");
+  });
+});
+
+describe("spec-259: specify→build open-comment SOFT nudge (ac-6, ac-11)", () => {
+  it("renders the soft nudge naming count + oldest age, alongside a proceed-with-caveats rubric", () => {
+    tagAc(AC(6));
+    // The nudge string itself is produced by assessPhaseTransition; here we
+    // assert formatPhaseAssessment surfaces it under ## Nudges and that the
+    // build rubric offers the proceed-with-caveats verdict it feeds.
+    const nudge =
+      "There are 3 open comments on this Spec (oldest 9d ago). Walk the user through them before build — " +
+      "answer the questions, fold accepted notes into the narrative, and resolve them — or proceed if they're not blockers.";
+    const a = mkBuildAssessment({ nudges: [nudge] });
+    const out = formatPhaseAssessment(a);
+
+    expect(out).toContain("## Nudges");
+    expect(out).toContain("3 open comments on this Spec");
+    expect(out).toContain("oldest 9d ago");
+    // The verdict the nudge drives toward is available in the rubric.
+    expect(out).toContain("proceed-with-caveats");
+  });
+
+  it("the soft nudge is purely advisory — it does not add a transition-blocking outstanding item (ac-11)", () => {
+    tagAc(AC(11));
+    // A build assessment carrying the comment nudge keeps an EMPTY readiness
+    // (isClean) — the nudge never manufactures a hold. (The end-to-end proof
+    // that updateDocStatus still succeeds with open comments lives in the DB
+    // integration test; updateDocStatus gates on nothing here.)
+    const nudge = "There is 1 open comment on this Spec (oldest 2d ago). Walk the user through them before build — answer the questions, fold accepted notes into the narrative, and resolve them — or proceed if they're not blockers.";
+    const a = mkBuildAssessment({ nudges: [nudge] });
+
+    expect(a.readiness.isClean).toBe(true);
+    expect(a.readiness.outstandingItems).toEqual([]);
+
+    const out = formatPhaseAssessment(a);
+    // No "Outstanding work" section is forced by the comment nudge.
+    expect(out).not.toContain("## Outstanding work");
+  });
+});

--- a/packages/server/src/services/phase-assessment.ts
+++ b/packages/server/src/services/phase-assessment.ts
@@ -11,6 +11,7 @@ import {
   STALE_THRESHOLD_DAYS,
 } from "./acs.js";
 import { NotFoundError, ValidationError } from "../types/errors.js";
+import { assessCommentsStatus, type CommentsStatus } from "./comment-assessment.js";
 import { getReadyTasks } from "./tasks.js";
 import { parsePhaseDescriptions } from "../mcp/phase-descriptions.js";
 import { listOrgScaffoldAdditionsCached } from "./scaffold-additions-cache.js";
@@ -23,6 +24,8 @@ import {
   computeSpecReadiness,
   isForwardTransition,
   toRubric,
+  timeAgo,
+  capitalizeDisplayName,
   type SpecPhase,
   type SpecReadiness,
   type GuidanceBlock,
@@ -324,6 +327,16 @@ export interface PhaseAssessment {
    * verbatim prompt under `## Code grounding`.
    */
   codeGroundingPromptPending?: boolean;
+  /**
+   * spec-259 t-3: the open-comment survey for this Spec (anchor-kind grouping +
+   * per-comment WHO/WHEN), populated ONLY on the specify→build transition so
+   * `formatPhaseAssessment` can render an enriched "## Open comments" block
+   * (grouped by anchor kind, oldest age per group, per-comment author + age +
+   * anchor + snippet) without a second DB call. `undefined` for other targets,
+   * keeping their fact sheet counts-only. The render is purely a function of
+   * this snapshot, so the formatter stays DB-free and unit-testable.
+   */
+  openCommentsDetail?: CommentsStatus;
 }
 
 // spec-120 ac-3: open-comments on a Spec, both as a total AND broken down by
@@ -628,6 +641,17 @@ export async function assessPhaseTransition(
     taskIdSet,
   );
 
+  // spec-259 t-3: on the specify→build gate, pull the full open-comment survey
+  // (anchor-kind grouping + per-comment WHO/WHEN) so the rendered block can
+  // surface WHO raised WHAT and HOW STALE it is, not just a count. Scoped to
+  // `build` so other transitions keep their counts-only fact sheet and skip the
+  // extra query. The total here matches `openComments.total` (same open-set
+  // basis: resolved_at IS NULL).
+  const openCommentsDetail =
+    targetPhase === "build"
+      ? await assessCommentsStatus(memexId, briefId)
+      : undefined;
+
   // spec-120 ac-1: AC verification roll-up drawn from the same `test_events`
   // derivation `list_acs` uses, so the gate and `list_acs` can never silently
   // disagree. Drives the `done` hold signal below (ac-2) and the fact sheet.
@@ -761,6 +785,26 @@ export async function assessPhaseTransition(
     }
   }
 
+  // spec-259 t-3: open-comment SOFT nudge on the specify→build gate (ac-6).
+  // Advancing into build while comments are still open means unanswered
+  // questions / unresolved notes ride into execution unseen. SOFT only — it
+  // adds a nudge that NAMES the count + oldest age but NEVER holds the
+  // transition (update_doc({status:'build'}) still succeeds, ac-11), mirroring
+  // the firmness of the open-Issues-at-done and missing-core-lens warnings, NOT
+  // the naked-decision hold. Fires only when open comments exist; 0 open → no
+  // nudge. specDrift's hard verify-scope is left untouched — this is the
+  // build-phase analogue.
+  if (targetPhase === "build" && openCommentsDetail && openCommentsDetail.totalOpen > 0) {
+    const n = openCommentsDetail.totalOpen;
+    const oldest = openCommentsDetail.comments[0]?.createdAt ?? null;
+    const oldestAge = oldest ? timeAgo(oldest) : "unknown age";
+    nudges.push(
+      `There ${n === 1 ? "is" : "are"} ${n} open comment${n === 1 ? "" : "s"} on this Spec ` +
+        `(oldest ${oldestAge}). Walk the user through them before build — answer the questions, ` +
+        `fold accepted notes into the narrative, and resolve them — or proceed if they're not blockers.`,
+    );
+  }
+
   // Code-grounding self-classification (doc-27). Only applies on the
   // specify→build transition (`target === 'build'`). On other targets the
   // parameter is silently ignored — no prompt, no nudge, no behaviour change.
@@ -838,6 +882,7 @@ export async function assessPhaseTransition(
     nudges,
     codeGrounding: effectiveCodeGrounding,
     codeGroundingPromptPending: codeGroundingPromptPending || undefined,
+    openCommentsDetail,
   };
 }
 
@@ -887,6 +932,28 @@ export function formatPhaseAssessment(assessment: PhaseAssessment): string {
     for (const [type, count] of byType) {
       lines.push(`  - ${type}: ${count}`);
     }
+  }
+  // spec-259 t-3: on the specify→build gate, enrich the open-comment block —
+  // grouped by anchor kind (decision-anchored vs section-anchored), oldest age
+  // per group via timeAgo, and a per-comment WHO/WHEN list (author + age +
+  // anchor handle/title + snippet). Rendered ONLY when `openCommentsDetail` is
+  // present (build target) and there are open comments; other targets keep the
+  // counts-only view above (ac-1).
+  if (assessment.openCommentsDetail && assessment.openCommentsDetail.totalOpen > 0) {
+    const groups = assessment.openCommentsDetail.byAnchorKind;
+    const renderGroup = (label: string, g: typeof groups.decision): void => {
+      if (g.count === 0) return;
+      const age = g.oldestCreatedAt ? timeAgo(g.oldestCreatedAt) : "unknown age";
+      lines.push(`  - ${label}: ${g.count} (oldest ${age})`);
+      for (const c of g.comments) {
+        const targetTitle = c.target.title ? ` "${c.target.title}"` : "";
+        lines.push(
+          `    - ${capitalizeDisplayName(c.author)} ${timeAgo(c.createdAt)} on ${c.target.kind} ${c.target.handle}${targetTitle} [${c.type}]: ${c.contentSnippet}`,
+        );
+      }
+    };
+    renderGroup("Decision-anchored", groups.decision);
+    renderGroup("Section-anchored", groups.section);
   }
   lines.push(`- Open/converted Issues: ${f.openIssuesCount}`);
   // spec-120 ac-1: AC verification state, from the same test_events derivation

--- a/packages/server/src/services/specify-comments-walkthrough.spec-259.test.ts
+++ b/packages/server/src/services/specify-comments-walkthrough.spec-259.test.ts
@@ -1,0 +1,51 @@
+// spec-259 t-3 — ac-3: the specify-phase prompt instructs the agent to walk the
+// user through open comments BEFORE advancing specify→build.
+//
+// The specify-phase prompt prose is the `phase-specify-intent` PromptBlock in
+// `@memex/shared`'s scaffold-data.ts (the single owner of phase prompt prose
+// per std-15 / b-68 dec-6). We assert against the SOURCE file so the test is
+// robust to the @memex/shared dist rebuild timing — it must hold the
+// walkthrough instruction in the existing freshness-walkthrough voice.
+
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it, expect } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+const AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-259/acs/ac-${n}`;
+
+const here = dirname(fileURLToPath(import.meta.url));
+const SCAFFOLD_DATA = resolve(
+  here,
+  "..",
+  "..",
+  "..",
+  "shared",
+  "src",
+  "scaffold-data.ts",
+);
+
+describe("spec-259: specify prompt instructs the open-comment walkthrough (ac-3)", () => {
+  it("the specify-phase intent block tells the agent to walk open comments before specify→build", () => {
+    tagAc(AC(3));
+    const src = readFileSync(SCAFFOLD_DATA, "utf8");
+
+    // The instruction lives in the phase-specify-intent block.
+    const intentIdx = src.indexOf("id: 'phase-specify-intent'");
+    expect(intentIdx).toBeGreaterThan(-1);
+    // Bound the assertion to that block (up to the next prompt-block id).
+    const after = src.slice(intentIdx);
+    const block = after.slice(0, after.indexOf("id: 'phase-specify-discipline'"));
+
+    expect(block).toMatch(/before advancing specify.+build/i);
+    expect(block).toMatch(/walk the user through .*open comments/i);
+    // Mirrors the assess_spec comments survey it should lean on. (Source escapes
+    // the inner single quotes, so match on the tool + mode tokens.)
+    expect(block).toContain("assess_spec");
+    expect(block).toMatch(/mode:.{0,2}comments/);
+    // States plainly that open comments do not gate the transition.
+    expect(block).toMatch(/do not block|not blocked/i);
+  });
+});

--- a/packages/server/src/services/who-resolver.integration.test.ts
+++ b/packages/server/src/services/who-resolver.integration.test.ts
@@ -26,6 +26,10 @@ const AC = "mindset-prod/memex-building-itself/specs/spec-122/acs";
 const created = { users: [] as string[], sessions: [] as string[] };
 const tag = `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
 const christineEmail = `christine-${tag}@memex.ai`;
+// spec-259 dec-4: the resolver now title-cases a RESOLVED user's display name. The
+// seed name is "Christine <tag>" with a lowercase tag, so the rendered display
+// capitalises the tag's leading letter too (digits are unaffected by toUpperCase).
+const christineDisplay = `Christine ${tag.charAt(0).toUpperCase()}${tag.slice(1)}`;
 let christineId: string;
 let twinAId: string;
 let twinBId: string;
@@ -63,14 +67,14 @@ describe("WHO resolver [spec-122 t-5]", () => {
     tagAc(`${AC}/ac-25`);
     const r = await resolveTestEventActor(christineEmail.toUpperCase()); // case-insensitive
     expect(r.userId).toBe(christineId);
-    expect(r.display).toBe(`Christine ${tag}`);
+    expect(r.display).toBe(christineDisplay);
   });
 
   it("ac-25: a test_events.actor matching a user's (unambiguous) name resolves + unifies", async () => {
     tagAc(`${AC}/ac-25`);
     const r = await resolveTestEventActor(`Christine ${tag}`);
     expect(r.userId).toBe(christineId);
-    expect(r.display).toBe(`Christine ${tag}`);
+    expect(r.display).toBe(christineDisplay);
   });
 
   it("ac-25: the batch resolver unifies email + name hits in one pass", async () => {
@@ -100,7 +104,7 @@ describe("WHO resolver [spec-122 t-5]", () => {
   it("ac-27: an agent clientId resolves \"<user name>'s <clientName>\"", async () => {
     tagAc(`${AC}/ac-27`);
     const label = await resolveAgentClientLabel(sessionId);
-    expect(label).toBe(`Christine ${tag}'s Claude Code`);
+    expect(label).toBe(`${christineDisplay}'s Claude Code`);
   });
 
   it("ac-27: an unknown clientId resolves to null (no fabricated label)", async () => {
@@ -122,6 +126,6 @@ describe("WHO resolver [spec-122 t-5]", () => {
     const byEmail = await resolveTestEventActor(christineEmail);
     expect(byEmail.userId).toBe(christineId);
     const label = await resolveAgentClientLabel(sessionId);
-    expect(label).toBe(`Christine ${tag}'s Claude Code`);
+    expect(label).toBe(`${christineDisplay}'s Claude Code`);
   });
 });

--- a/packages/server/src/services/who-resolver.ts
+++ b/packages/server/src/services/who-resolver.ts
@@ -14,6 +14,7 @@
 //  3. Agent client labels → resolveAgentClientLabel (ac-27).
 
 import { eq, or, sql, inArray } from "drizzle-orm";
+import { capitalizeDisplayName } from "@memex/shared";
 import { db } from "../db/connection.js";
 import { users, mcpSessions } from "../db/schema.js";
 import { actorName } from "./actor.js";
@@ -50,7 +51,7 @@ export async function resolveTestEventActor(actor: string | null | undefined): P
     .where(sql`lower(${users.email}) = ${raw.toLowerCase()}`)
     .limit(1);
   if (byEmail.length === 1) {
-    return { display: actorName(byEmail[0]), userId: byEmail[0].id };
+    return { display: capitalizeDisplayName(actorName(byEmail[0])), userId: byEmail[0].id };
   }
 
   // Exact name match — only when unambiguous (exactly one user).
@@ -60,10 +61,12 @@ export async function resolveTestEventActor(actor: string | null | undefined): P
     .where(eq(users.name, raw))
     .limit(2);
   if (byName.length === 1) {
-    return { display: actorName(byName[0]), userId: byName[0].id };
+    return { display: capitalizeDisplayName(actorName(byName[0])), userId: byName[0].id };
   }
 
-  // Miss (or ambiguous) → verbatim, unattributed.
+  // Miss (or ambiguous) → verbatim, unattributed. NOT capitalized: a free-form /
+  // CI identity string ("CI · abc123") is not a person name — spec-259 dec-4 scopes
+  // capitalization to resolved user names, and ac-26 requires the miss render verbatim.
   return { display: raw, userId: null };
 }
 
@@ -93,7 +96,7 @@ export async function resolveAgentClientLabel(clientId: string | null | undefine
   const { clientName, userName, userEmail } = rows[0];
   const client = clientName?.trim() || "client";
   const who = userName?.trim() || userEmail?.trim() || null;
-  return who ? `${who}'s ${client}` : client;
+  return who ? `${capitalizeDisplayName(who)}'s ${client}` : client;
 }
 
 /**
@@ -123,9 +126,10 @@ export async function resolveTestEventActors(
 
   for (const raw of distinct) {
     const e = byEmail.get(raw.toLowerCase());
-    if (e) { out.set(raw, { display: actorName(e), userId: e.id }); continue; }
+    if (e) { out.set(raw, { display: capitalizeDisplayName(actorName(e)), userId: e.id }); continue; }
     const n = byName.get(raw);
-    if (n) { out.set(raw, { display: actorName(n), userId: n.id }); continue; }
+    if (n) { out.set(raw, { display: capitalizeDisplayName(actorName(n)), userId: n.id }); continue; }
+    // Miss → verbatim (NOT capitalized; spec-259 dec-4 / ac-26).
     out.set(raw, { display: raw, userId: null });
   }
   return out;

--- a/packages/shared/src/display-name.test.ts
+++ b/packages/shared/src/display-name.test.ts
@@ -1,0 +1,46 @@
+// spec-259 dec-4 (ac-7, ac-13): the conservative display-name capitalization helper.
+// It uppercases only a leading lowercase letter per token, preserves interior casing,
+// and leaves email fallbacks and agent labels untouched.
+import { describe, it, expect } from 'vitest';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { capitalizeDisplayName } from './display-name.js';
+
+const AC7 = 'mindset-prod/memex-building-itself/specs/spec-259/acs/ac-7';
+const AC13 = 'mindset-prod/memex-building-itself/specs/spec-259/acs/ac-13';
+
+describe('capitalizeDisplayName (spec-259 dec-4)', () => {
+  it('title-cases a plain lowercase name', () => {
+    tagAc(AC13);
+    tagAc(AC7);
+    expect(capitalizeDisplayName('barrie hadfield')).toBe('Barrie Hadfield');
+  });
+
+  it('preserves interior casing — never lowercases an interior capital', () => {
+    tagAc(AC13);
+    // Leading letter already uppercase → untouched; interior capitals kept.
+    expect(capitalizeDisplayName('McDonald')).toBe('McDonald');
+    expect(capitalizeDisplayName('DeShawn')).toBe('DeShawn');
+    // Apostrophe is not a token boundary, so the interior letter is left as-is.
+    expect(capitalizeDisplayName("o'brien")).toBe("O'brien");
+    expect(capitalizeDisplayName("O'Brien")).toBe("O'Brien");
+  });
+
+  it('leaves email-derived fallbacks (containing "@") untouched', () => {
+    tagAc(AC13);
+    tagAc(AC7);
+    expect(capitalizeDisplayName('barrie@mindset.ai')).toBe('barrie@mindset.ai');
+  });
+
+  it('leaves known agent labels untouched', () => {
+    tagAc(AC13);
+    expect(capitalizeDisplayName('Memex agent')).toBe('Memex agent');
+    expect(capitalizeDisplayName('memex agent')).toBe('memex agent');
+  });
+
+  it('is a no-op on empty / nullish input', () => {
+    tagAc(AC13);
+    expect(capitalizeDisplayName('')).toBe('');
+    expect(capitalizeDisplayName(null)).toBe('');
+    expect(capitalizeDisplayName(undefined)).toBe('');
+  });
+});

--- a/packages/shared/src/display-name.ts
+++ b/packages/shared/src/display-name.ts
@@ -1,0 +1,43 @@
+// spec-259 dec-4 — conservative display-name capitalization for presentation.
+//
+// Author/actor names render verbatim today — lowercase or email-derived (e.g.
+// "barrie hadfield", "barrie@mindset.ai"). This helper title-cases them for DISPLAY
+// only. It is applied at every render site that emits a name: the spec-122:dec-8 WHO
+// resolver (who-resolver.ts) and — because search resolves WHO inline in SQL and
+// bypasses that resolver — the search formatter (memex-search.ts formatHitByline +
+// per-section lines).
+//
+// It NEVER mutates stored author_name / actor_name: std-32 makes those the immutable
+// audit record, stamped at write so a rename can't rewrite history. Capitalization is
+// strictly a read/render transform.
+//
+// The algorithm is deliberately conservative — it uppercases ONLY a leading lowercase
+// letter of each whitespace-separated token and never touches interior casing, so
+// real names survive intact:
+//   "barrie hadfield" → "Barrie Hadfield"
+//   "McDonald"        → "McDonald"   (interior capital preserved)
+//   "o'brien"         → "O'brien"    (apostrophe is not a token boundary)
+//   "DeShawn"         → "DeShawn"    (already-correct interior capital preserved)
+// and two classes are returned untouched:
+//   - any value containing "@" (the user.name ?? user.email fallback — emails must
+//     not be title-cased: "barrie@…" → "Barrie@…" is wrong)
+//   - known agent labels (e.g. "Memex agent") — not people.
+
+const AGENT_LABELS = new Set(['memex agent', 'memex ai', 'memex']);
+
+/**
+ * Title-case a display name for presentation, preserving interior casing and leaving
+ * email-derived fallbacks and agent labels untouched. Render-layer only — never feed
+ * the result back into a stored column.
+ */
+export function capitalizeDisplayName(raw: string | null | undefined): string {
+  if (raw == null) return '';
+  const trimmed = raw.trim();
+  if (trimmed === '') return raw;
+  if (trimmed.includes('@')) return raw; // email fallback — leave verbatim
+  if (AGENT_LABELS.has(trimmed.toLowerCase())) return raw; // agent label — not a person
+
+  // Uppercase only a leading lowercase letter of each whitespace-delimited token.
+  // Interior characters and the original whitespace are preserved exactly.
+  return raw.replace(/(^|\s)([a-z])/g, (_match, boundary: string, ch: string) => boundary + ch.toUpperCase());
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -147,3 +147,9 @@ export {
   isQaReportSectionType,
   qaReportVersion,
 } from './qa-report.js';
+
+// spec-259 dec-5: the one canonical relative-age helper (server MCP/agent surfaces
+// + UI), injectable `now` for deterministic output. Wire forms keep absolute ISO.
+export { timeAgo } from './relative-time.js';
+// spec-259 dec-4: conservative display-name capitalization, render-layer only.
+export { capitalizeDisplayName } from './display-name.js';

--- a/packages/shared/src/relative-time.test.ts
+++ b/packages/shared/src/relative-time.test.ts
@@ -1,0 +1,44 @@
+// spec-259 dec-5 (ac-8, ac-14): the one canonical relative-age helper renders
+// "Nd ago" deterministically against an INJECTED reference-now, and accepts both
+// ISO strings and Date objects. Determinism is the property that lets MCP/agent
+// output be asserted exactly under test.
+import { describe, it, expect } from 'vitest';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { timeAgo } from './relative-time.js';
+
+const AC8 = 'mindset-prod/memex-building-itself/specs/spec-259/acs/ac-8';
+const AC14 = 'mindset-prod/memex-building-itself/specs/spec-259/acs/ac-14';
+
+describe('timeAgo — shared relative-age helper (spec-259 dec-5)', () => {
+  // A fixed reference instant so every assertion is reproducible.
+  const NOW = new Date('2026-06-14T12:00:00.000Z');
+
+  it('renders the relative ladder deterministically against an injected now', () => {
+    tagAc(AC14);
+    tagAc(AC8);
+    expect(timeAgo(new Date('2026-06-14T11:59:30.000Z'), NOW)).toBe('just now');
+    expect(timeAgo(new Date('2026-06-14T11:45:00.000Z'), NOW)).toBe('15m ago');
+    expect(timeAgo(new Date('2026-06-14T09:00:00.000Z'), NOW)).toBe('3h ago');
+    expect(timeAgo(new Date('2026-06-11T12:00:00.000Z'), NOW)).toBe('3d ago');
+    expect(timeAgo(new Date('2026-05-24T12:00:00.000Z'), NOW)).toBe('3w ago');
+  });
+
+  it('accepts ISO strings as well as Date objects (server carries Date, UI carries ISO)', () => {
+    tagAc(AC14);
+    expect(timeAgo('2026-06-11T12:00:00.000Z', NOW)).toBe('3d ago');
+    expect(timeAgo(new Date('2026-06-11T12:00:00.000Z'), NOW)).toBe('3d ago');
+  });
+
+  it('clamps a clock-skew future instant to "just now" and is empty for bad/null input', () => {
+    tagAc(AC14);
+    expect(timeAgo(new Date('2026-06-14T12:05:00.000Z'), NOW)).toBe('just now');
+    expect(timeAgo(null, NOW)).toBe('');
+    expect(timeAgo('not-a-date', NOW)).toBe('');
+  });
+
+  it('falls back to an absolute date beyond ~8 weeks so "63w ago" never appears', () => {
+    tagAc(AC8);
+    // ~10 weeks before NOW.
+    expect(timeAgo(new Date('2026-04-05T12:00:00.000Z'), NOW)).toMatch(/\d{1,2} \w{3} 2026/);
+  });
+});

--- a/packages/shared/src/relative-time.ts
+++ b/packages/shared/src/relative-time.ts
@@ -1,0 +1,50 @@
+// spec-259 dec-5 — the ONE canonical relative-age helper, shared by server (MCP /
+// agent surfaces) and the React UI. Before this, "time ago" was reimplemented ad
+// hoc in ≥4 UI components and never existed server-side, while comments rendered
+// three divergent absolute formats (formatDate YYYY-MM-DD, raw .toISOString(), and
+// none). dec-5 rationalises every human/agent-facing WHEN to one relative rendering
+// through this helper, while structured/wire forms keep absolute ISO-8601.
+//
+// `now` is INJECTABLE so MCP/agent output is deterministic under test (a fixed
+// reference instant), while live calls default to the current time.
+//
+// Granularity ladder (coarsening as it ages): just now → Nm → Nh → Nd → Nw, then it
+// falls back to an absolute date so "63w ago" never appears. Always past-tense — a
+// row's timestamp is in the past; a (clock-skew) future instant clamps to "just now".
+//
+// Lifted from the spec-286 UI helper (packages/ui/src/utils/timeAgo.ts), which the
+// UI now re-exports from here so there is one implementation.
+
+const MINUTE = 60_000;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+const WEEK = 7 * DAY;
+
+function absoluteDate(date: Date): string {
+  return date.toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' });
+}
+
+/**
+ * Format a timestamp as a short relative time from `now` (default: current time).
+ * Accepts an ISO-8601 string or a `Date` (the server carries `Date` objects, the
+ * UI carries ISO strings). `now` is injectable so tests are deterministic.
+ *
+ * Examples: "just now", "5m ago", "3h ago", "2d ago", "5w ago", then "12 Jun 2026".
+ * Returns "" for an unparseable / null input (callers omit the byline rather than
+ * render a broken one).
+ */
+export function timeAgo(value: string | Date | null | undefined, now: Date = new Date()): string {
+  if (value == null) return '';
+  const then = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(then.getTime())) return '';
+
+  const diff = now.getTime() - then.getTime();
+  if (diff < MINUTE) return 'just now'; // includes small future skew (diff < 0)
+
+  if (diff < HOUR) return `${Math.floor(diff / MINUTE)}m ago`;
+  if (diff < DAY) return `${Math.floor(diff / HOUR)}h ago`;
+  if (diff < WEEK) return `${Math.floor(diff / DAY)}d ago`;
+  // Up to ~8 weeks stays relative; beyond that an absolute date is more legible.
+  if (diff < 8 * WEEK) return `${Math.floor(diff / WEEK)}w ago`;
+  return absoluteDate(then);
+}

--- a/packages/shared/src/scaffold-data.ts
+++ b/packages/shared/src/scaffold-data.ts
@@ -354,9 +354,10 @@ const PHASE_PLAN_INTENT: PromptBlockNode = {
     'What to do next depends on the decision state:\n' +
     '- **No decisions yet** — surface the decisions this work hinges on; capture the choices that have been hand-waved as `create_decision`.\n' +
     '- **Open decisions remain** — drive each unresolved decision to resolution: summarise its context, options and trade-offs, recommend where you can, and resolve it on the user\'s call.\n' +
-    '- **All decisions resolved** — the spec is settled. Make sure each resolution is reflected in the narrative, then point the user at a team review (share the Spec) or moving into `build`.',
+    '- **All decisions resolved** — the spec is settled. Make sure each resolution is reflected in the narrative, then point the user at a team review (share the Spec) or moving into `build`.\n\n' +
+    'Before advancing specify→build, walk the user through any open comments (`assess_spec({mode:\'comments\'})` lists them oldest-first, with WHO raised each and how stale it is) — answer the questions, fold accepted notes into the narrative, and resolve them, just as you walk decision/narrative freshness before a forward move. Open comments do not block the build transition; flag them and let the human decide.',
   rationale:
-    'What the specify phase IS for. Tells the agent that draft+specify share semantics and the work is decision resolution + narrative shaping. Mirrors the opening "## Phase: specify (and draft)" block of `specify/system.md`.',
+    'What the specify phase IS for. Tells the agent that draft+specify share semantics and the work is decision resolution + narrative shaping, and (spec-259 t-3) to walk the user through open comments before specify→build — mirroring the mode=\'narrative\' freshness walkthrough. Mirrors the opening "## Phase: specify (and draft)" block of `specify/system.md`.',
 };
 
 const PHASE_PLAN_DISCIPLINE: PromptBlockNode = {

--- a/packages/ui/e2e/helpers/retained.ts
+++ b/packages/ui/e2e/helpers/retained.ts
@@ -126,6 +126,21 @@ export async function seedSection(opts: {
   return call("POST", "/seed-section", opts);
 }
 
+/** spec-259 t-5: seed an OPEN comment on a section / decision / task through the
+ *  real comment services (emits on the bus). Backs the Specify-phase
+ *  open-comment parity journey — the summary band + per-comment WHO/WHEN byline
+ *  render off comments seeded this way. */
+export async function seedComment(opts: {
+  memexId: string;
+  target: "section" | "decision" | "task";
+  targetId: string;
+  authorName?: string;
+  content?: string;
+  commentType?: string;
+}): Promise<{ commentId: string; seq: number }> {
+  return call("POST", "/seed-comment", opts);
+}
+
 /** spec-286: apply `scope::value`/flat tags to a Spec through applyTagStrings —
  *  the tags the QA Reports feed rail filters + counts on. */
 export async function seedTags(opts: {

--- a/packages/ui/e2e/helpers/seed.ts
+++ b/packages/ui/e2e/helpers/seed.ts
@@ -103,8 +103,12 @@ export async function seedSpecInMemex(opts: {
   title: string;
   purpose?: string;
   createdByUserId?: string;
-}): Promise<{ docId: string; handle: string }> {
-  return call<{ docId: string; handle: string }>("POST", "/seed-spec", opts);
+}): Promise<{ docId: string; handle: string; sectionId: string | null }> {
+  return call<{ docId: string; handle: string; sectionId: string | null }>(
+    "POST",
+    "/seed-spec",
+    opts,
+  );
 }
 
 /**
@@ -396,4 +400,21 @@ export async function seedTask(opts: {
   status?: "not_started" | "in_progress" | "complete";
 }): Promise<{ taskId: string; seq: number }> {
   return call("POST", "/seed-task", opts);
+}
+
+/**
+ * spec-259 t-5: seed an OPEN comment on a section / decision / task through the
+ * real comment services (so it emits on the bus [per std-8]). Backs the
+ * Specify-phase open-comment parity journey — the open-comment summary and the
+ * per-comment WHO/WHEN byline render off comments seeded this way.
+ */
+export async function seedComment(opts: {
+  memexId: string;
+  target: "section" | "decision" | "task";
+  targetId: string;
+  authorName?: string;
+  content?: string;
+  commentType?: string;
+}): Promise<{ commentId: string; seq: number }> {
+  return call("POST", "/seed-comment", opts);
 }

--- a/packages/ui/e2e/journey-33-spec-259-open-comment-parity.spec.ts
+++ b/packages/ui/e2e/journey-33-spec-259-open-comment-parity.spec.ts
@@ -1,0 +1,147 @@
+import {
+  test,
+  expect,
+  tenantPath,
+  switchToEditing,
+  emitAcEvents,
+} from "./helpers/index.js";
+import {
+  seedOrgTenant,
+  seedSpec,
+  setDocStatus,
+  seedOpenDecision,
+  seedComment,
+} from "./helpers/retained.js";
+
+// Journey 33 — spec-259 ac-5: the web Specify phase surfaces open-comment
+// status CONSISTENTLY with the MCP agent's view, and the specify→build Rubicon
+// sentence is comments-aware ADVISORY guidance (the web does NOT hard-gate —
+// spec-247 / std-34: the web is for viewing + minimum-friction input).
+//
+//   • The Comments sub-tab shows the same open-comment picture the agent sees:
+//     counts, anchor-kind split (decision-anchored vs section-anchored, where
+//     tasks fold into section-anchored), and the oldest open comment's relative
+//     age — all via the SHARED timeAgo so the phrasing matches.
+//   • Every comment row carries a WHO/WHEN byline (author + relative time).
+//   • The Rubicon sentence reads the exact spec-259 copy and the advance-to-Build
+//     affordance stays reachable WITH open comments present (guidance, not lock).
+//
+// ac-5 has the component-level AllComments tests as its unit proof; this journey
+// is the end-to-end proof that the seeded open comments actually render this
+// picture in the running app.
+const AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-259/acs/ac-${n}`;
+const ACS = [AC(5)];
+
+test.afterEach(async ({}, testInfo) => {
+  await emitAcEvents(
+    ACS,
+    testInfo.status === "passed" ? "pass" : "fail",
+    `packages/ui/e2e/journey-33-spec-259-open-comment-parity.spec.ts::${testInfo.title}`,
+    testInfo.duration,
+  );
+});
+
+test("specify Comments surface shows the open-comment summary + WHO/WHEN byline; advance-to-Build stays reachable", async ({
+  page,
+  resources,
+}) => {
+  const tenant = await seedOrgTenant({ slug: resources.slug("j33") });
+  const spec = await seedSpec({
+    memexId: tenant.memexId,
+    title: "Open Comment Parity Spec",
+    purpose: "Exercise the Specify-phase open-comment parity surface.",
+  });
+  await setDocStatus({
+    memexId: tenant.memexId,
+    docId: spec.docId,
+    status: "specify",
+  });
+
+  // An open DECISION (so we can hang a decision-anchored comment off it).
+  const decision = await seedOpenDecision({
+    memexId: tenant.memexId,
+    docId: spec.docId,
+    title: "Pick the cache layer",
+    context: "Two options on the table.",
+    options: [
+      { label: "Redis", trade_offs: "Battle-tested; another box." },
+      { label: "In-process LRU", trade_offs: "Zero-ops; per-instance only." },
+    ],
+  });
+
+  // One section-anchored open comment (on the overview section) + one
+  // decision-anchored open comment → the summary should read 2 open, split 1/1.
+  await seedComment({
+    memexId: tenant.memexId,
+    target: "section",
+    targetId: spec.sectionId,
+    authorName: "Sam Section",
+    content: "This section needs another pass before we build.",
+  });
+  await seedComment({
+    memexId: tenant.memexId,
+    target: "decision",
+    targetId: decision.decisionId,
+    authorName: "Dana Decision",
+    content: "Have we considered the cold-start cost of Redis?",
+  });
+
+  await page.goto(
+    tenantPath(tenant.namespaceSlug, tenant.memexSlug, `/specs/${spec.handle}`),
+    { waitUntil: "commit" },
+  );
+  await expect(
+    page.getByRole("heading", { level: 1, name: /Open Comment Parity Spec/ }),
+  ).toBeVisible({ timeout: 15_000 });
+
+  // ── The Rubicon is ADDITIVE (spec-259 ac-5 reconciled with spec-282/196) ──
+  // This spec has an OPEN decision, so the current-tab Rubicon leads with the
+  // spec-282 blocker statement (NOT a lock — status only, no button). The
+  // comments-aware advisory ("You can advance to Build when all open decisions
+  // are resolved and all comments are addressed.") is the CLEAN-state form, pinned
+  // in the TransitionSentence unit tests. Here we assert the blocker coexists with
+  // the open-comment surface below.
+  await expect(page.getByTestId("transition-sentence")).toContainText(
+    /Decision.*must be resolved/i,
+    { timeout: 15_000 },
+  );
+  await expect(page.getByRole("button", { name: "Yes" })).toHaveCount(0);
+
+  // ── Open the Comments sub-tab ──
+  await page.getByRole("button", { name: /^Comments\b/ }).click();
+
+  // ── The open-comment summary mirrors the agent's picture ──
+  const summary = page.getByTestId("open-comments-summary");
+  await expect(summary).toBeVisible({ timeout: 15_000 });
+  await expect(summary).toContainText("2 open comments");
+  await expect(summary).toContainText("1 decision-anchored");
+  await expect(summary).toContainText("1 section-anchored");
+  // Oldest age is a relative phrase from the shared timeAgo helper (freshly-seeded
+  // comments render "just now"; older ones "Nd ago").
+  await expect(page.getByTestId("open-comments-oldest")).toContainText(/just now|ago/);
+
+  // ── Every comment row carries a WHO + WHEN byline ──
+  await expect(
+    page.getByTestId("comment-byline-author").first(),
+  ).toBeVisible();
+  await expect(page.getByText("Sam Section")).toBeVisible();
+  await expect(page.getByText("Dana Decision")).toBeVisible();
+  // WHEN is a relative phrase (matching the agent), not an absolute date.
+  await expect(page.getByTestId("comment-byline-when").first()).toContainText(
+    /just now|ago/,
+  );
+
+  // ── No hard gate: advancing to Build stays reachable WITH open comments ──
+  // The web doesn't move the phase from the current tab (spec-282) — the move
+  // lives on the browse-forward Build-tab confirm. An editor browsing the Build
+  // tab still gets a working "Move this spec anyway? [Yes]" even though open
+  // comments + decisions remain: the Rubicon is guidance, never a lock.
+  await switchToEditing(page);
+  await page.locator('[role="tab"][data-tab="build"]').click();
+  const sentence = page.getByTestId("transition-sentence");
+  await expect(sentence).toBeVisible({ timeout: 15_000 });
+  await expect(
+    sentence.getByRole("button", { name: "Yes" }),
+  ).toBeEnabled();
+});

--- a/packages/ui/src/components/AllComments.test.tsx
+++ b/packages/ui/src/components/AllComments.test.tsx
@@ -361,4 +361,103 @@ describe('AllComments', () => {
     expect(writeText).toHaveBeenCalledTimes(1);
     expect(writeText.mock.calls[0][0]).toContain('comment=c-7');
   });
+
+  // spec-259 ac-5 — the web Specify Comments surface shows the SAME open-comment
+  // picture the MCP agent renders: counts, anchor-kind split (decision-anchored
+  // vs section-anchored, where tasks fold into section-anchored), the oldest
+  // relative age, and a per-comment WHO/WHEN byline (via the shared timeAgo).
+  const AC259_5 = 'mindset-prod/memex-building-itself/specs/spec-259/acs/ac-5';
+  // Recent timestamps so the shared `timeAgo` stays in its relative window
+  // ("Nd ago") rather than falling back to an absolute date (>8w).
+  const HOUR_MS = 60 * 60 * 1000;
+  const hoursAgo = (h: number) => new Date(Date.now() - h * HOUR_MS).toISOString();
+
+  it('renders the open-comment summary: counts + anchor-kind split + oldest age', () => {
+    tagAc(AC259_5);
+    const section = makeSection();
+    const decision = makeDecision();
+    const task = makeTask();
+    render(
+      <AllComments
+        sections={[section]}
+        decisions={[decision]}
+        tasks={[task]}
+        // 1 decision-anchored; 2 section-anchored (1 section + 1 task). The
+        // section comment is the oldest open one.
+        commentsBySection={{
+          [section.id]: [
+            makeComment({ id: 'c-sec', content: 'section comment', createdAt: hoursAgo(50) }),
+          ],
+        }}
+        commentsByDecision={{
+          [decision.id]: [makeComment({ id: 'c-dec', content: 'decision comment', createdAt: hoursAgo(2) })],
+        }}
+        commentsByTask={{
+          [task.id]: [makeComment({ id: 'c-task', content: 'task comment', createdAt: hoursAgo(3) })],
+        }}
+        onNavigateToSection={vi.fn()}
+      />
+    );
+
+    const summary = screen.getByTestId('open-comments-summary');
+    expect(summary.textContent).toContain('3 open comments');
+    expect(summary.textContent).toContain('1 decision-anchored');
+    expect(summary.textContent).toContain('2 section-anchored');
+    // Oldest age is a relative phrase from the shared helper (the 50h-old one).
+    expect(screen.getByTestId('open-comments-oldest').textContent).toContain('ago');
+  });
+
+  it('the summary counts OPEN comments only and is singular for one', () => {
+    tagAc(AC259_5);
+    const section = makeSection();
+    render(
+      <AllComments
+        sections={[section]}
+        commentsBySection={{
+          [section.id]: [
+            makeComment({ id: 'c-open', content: 'open' }),
+            makeComment({ id: 'c-done', content: 'done', resolvedAt: '2025-02-01T00:00:00Z' }),
+          ],
+        }}
+        onNavigateToSection={vi.fn()}
+      />
+    );
+    expect(screen.getByTestId('open-comments-summary').textContent).toContain(
+      '1 open comment'
+    );
+    // No summary band when there are zero open comments.
+  });
+
+  it('omits the summary band when there are no open comments', () => {
+    tagAc(AC259_5);
+    const section = makeSection();
+    render(
+      <AllComments
+        sections={[section]}
+        commentsBySection={{
+          [section.id]: [makeComment({ id: 'c-done', resolvedAt: '2025-02-01T00:00:00Z' })],
+        }}
+        onNavigateToSection={vi.fn()}
+      />
+    );
+    expect(screen.queryByTestId('open-comments-summary')).not.toBeInTheDocument();
+  });
+
+  it('each comment row carries a WHO + WHEN byline (author + relative time)', () => {
+    tagAc(AC259_5);
+    const section = makeSection();
+    render(
+      <AllComments
+        sections={[section]}
+        commentsBySection={{
+          [section.id]: [
+            makeComment({ id: 'c-1', authorName: 'Alice', content: 'hi', createdAt: hoursAgo(5) }),
+          ],
+        }}
+        onNavigateToSection={vi.fn()}
+      />
+    );
+    expect(screen.getByTestId('comment-byline-author').textContent).toBe('Alice');
+    expect(screen.getByTestId('comment-byline-when').textContent).toContain('ago');
+  });
 });

--- a/packages/ui/src/components/AllComments.tsx
+++ b/packages/ui/src/components/AllComments.tsx
@@ -3,6 +3,11 @@ import type { Comment, DocSection, Decision, Task } from '../api/types';
 import { CommentBubble } from './CommentTray';
 import { filterComments, type AuthorKindFilter, type StatusFilter } from '../utils/filterComments';
 import { commentAnchorId, buildCommentLink } from '../utils/commentDeepLink';
+// spec-259 ac-5: surface the SAME open-comment picture the MCP agent shows at
+// specify→build — counts, anchor-kind split (decision-anchored vs
+// section-anchored), and the oldest open comment's relative age. `timeAgo` is
+// the shared helper so the web phrasing matches the agent's.
+import { timeAgo } from '../utils/timeAgo';
 
 // spec-100 ac-6: wrap a comment with a stable scroll anchor (`comment-c-{seq}`)
 // and a copy-link button so a viewer can be taken straight to it.
@@ -157,8 +162,56 @@ export function AllComments({
     decisionEntries.reduce((n, e) => n + e.comments.length, 0) +
     taskEntries.reduce((n, e) => n + e.comments.length, 0);
 
+  // spec-259 ac-5: the readiness SUMMARY mirrors the agent's `assess_spec`
+  // ({mode:'comments'}) picture and is independent of the local filter chips —
+  // it always counts OPEN comments (no resolvedAt) across the doc and splits
+  // them by anchor kind. Per the server's `anchorKindForTarget`, decision
+  // comments are "decision-anchored"; sections AND tasks are "section-anchored"
+  // (the narrative surface the human reviews). The oldest open comment's
+  // createdAt drives the relative-age phrase.
+  const isOpen = (c: Comment) => !c.resolvedAt;
+  const openDecisionComments = Object.values(commentsByDecision)
+    .flat()
+    .filter(isOpen);
+  const openSectionAnchored = [
+    ...Object.values(commentsBySection).flat(),
+    ...Object.values(commentsByTask).flat(),
+  ].filter(isOpen);
+  const decisionAnchoredCount = openDecisionComments.length;
+  const sectionAnchoredCount = openSectionAnchored.length;
+  const totalOpenCount = decisionAnchoredCount + sectionAnchoredCount;
+  const oldestOpenAt = [...openDecisionComments, ...openSectionAnchored].reduce<
+    string | null
+  >((oldest, c) => {
+    if (!oldest) return c.createdAt;
+    return new Date(c.createdAt).getTime() < new Date(oldest).getTime()
+      ? c.createdAt
+      : oldest;
+  }, null);
+
   return (
     <div className="space-y-6 ml-8">
+      {totalOpenCount > 0 && (
+        <div
+          data-testid="open-comments-summary"
+          className="rounded-md border border-divider bg-overlay px-3 py-2 text-xs text-secondary"
+        >
+          <span className="font-medium text-primary">
+            {totalOpenCount} open comment{totalOpenCount === 1 ? '' : 's'}
+          </span>
+          <span className="text-muted">
+            {' '}— {decisionAnchoredCount} decision-anchored,{' '}
+            {sectionAnchoredCount} section-anchored
+          </span>
+          {oldestOpenAt && (
+            <span className="text-muted">
+              {' '}· oldest{' '}
+              <span data-testid="open-comments-oldest">{timeAgo(oldestOpenAt)}</span>
+            </span>
+          )}
+        </div>
+      )}
+
       {hasAnyComments && (
         <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5">
           <SegmentedFilter

--- a/packages/ui/src/components/CommentTray.tsx
+++ b/packages/ui/src/components/CommentTray.tsx
@@ -15,6 +15,9 @@ import { CommentTypePill } from './CommentTypePill';
 import { CommentSourceAvatar } from './CommentSourceAvatar';
 import { DecisionLink, TaskLink, parseEntityRefs } from './DecisionLink';
 import { commentTypeAccentBorder } from '../utils/commentStyles';
+// spec-259 ac-5: render WHEN as the SAME relative phrase the MCP/agent surface
+// uses ("3d ago") so the web Specify readiness picture matches the agent's.
+import { timeAgo } from '../utils/timeAgo';
 
 interface CommentTrayProps {
   targetType: CommentTargetType;
@@ -213,12 +216,15 @@ export function CommentBubble({
   const isResolved = !!comment.resolvedAt;
   const isAgent = comment.source === 'agent';
   const accent = isAgent ? `border-l-2 ${commentTypeAccentBorder(comment.commentType)}` : '';
-  const date = new Date(comment.createdAt).toLocaleDateString('en-US', {
+  const absoluteDate = new Date(comment.createdAt).toLocaleDateString('en-US', {
     month: 'short',
     day: 'numeric',
     hour: 'numeric',
     minute: '2-digit',
   });
+  // spec-259 ac-5: WHEN is a relative phrase matching the agent surface; the
+  // exact timestamp stays available on hover.
+  const relative = timeAgo(comment.createdAt);
 
   return (
     <div
@@ -242,10 +248,21 @@ export function CommentBubble({
       <div className="flex items-center justify-between mb-1">
         <div className="flex items-center gap-1.5 min-w-0">
           <CommentSourceAvatar source={comment.source} authorName={comment.authorName} />
-          <span className="text-xs font-medium text-primary truncate">{comment.authorName}</span>
+          <span
+            className="text-xs font-medium text-primary truncate"
+            data-testid="comment-byline-author"
+          >
+            {comment.authorName}
+          </span>
           <CommentTypePill type={comment.commentType} hideForDiscussion />
         </div>
-        <span className="text-xs text-muted shrink-0">{date}</span>
+        <span
+          className="text-xs text-muted shrink-0"
+          title={absoluteDate}
+          data-testid="comment-byline-when"
+        >
+          {relative}
+        </span>
       </div>
       <p className="text-sm text-primary whitespace-pre-wrap">
         {parseEntityRefs(comment.content).map((seg, i) =>

--- a/packages/ui/src/components/TransitionSentence.spec-282.test.tsx
+++ b/packages/ui/src/components/TransitionSentence.spec-282.test.tsx
@@ -50,8 +50,12 @@ function text() {
 }
 
 describe('spec-282 ac-5/ac-11 — the current phase tab carries no advance offer', () => {
-  // Ready state: every current-phase tab renders nothing — no question, no button.
-  for (const phase of ['specify', 'build', 'verify'] as const) {
+  // Ready state: build/verify current tabs render nothing — no question, no
+  // button. (spec-259 ac-5: a clean specify current tab now carries a
+  // comments-aware ADVISORY sentence — still no question and no button, so the
+  // spec-282 "no advance offer on the current tab" invariant holds; its own case
+  // below.)
+  for (const phase of ['build', 'verify'] as const) {
     it(`${phase} ready, current tab → nothing renders (no offer, no button)`, () => {
       tagAc(AC(5));
       tagAc(AC(11));
@@ -60,6 +64,17 @@ describe('spec-282 ac-5/ac-11 — the current phase tab carries no advance offer
       expect(screen.queryByRole('button')).toBeNull();
     });
   }
+
+  it('specify ready, current tab → comments-aware advisory, but NO question and NO button (spec-259 ac-5)', () => {
+    tagAc(AC(5));
+    tagAc(AC(11));
+    render(<TransitionSentence {...baseProps({ currentPhase: 'specify', viewedTab: 'specify' })} />);
+    expect(text()).toBe(
+      'You can advance to Build when all open decisions are resolved and all comments are addressed.',
+    );
+    expect(text()).not.toContain('?');
+    expect(screen.queryByRole('button')).toBeNull();
+  });
 
   // Blocked state: the rubric statement renders, but there is NO question and NO
   // button — status-only — for editors and non-editors alike.

--- a/packages/ui/src/components/TransitionSentence.test.tsx
+++ b/packages/ui/src/components/TransitionSentence.test.tsx
@@ -71,9 +71,13 @@ describe('Rubicon line — current tab is status-only (spec-282/dec-4); draft ke
     expect(screen.queryByRole('button', { name: 'No' })).toBeNull();
   });
 
-  it('specify (clean, current tab) → renders nothing (no standing offer)', () => {
+  it('specify (clean, current tab) → comments-aware advisory, no button (spec-259 ac-5)', () => {
+    // spec-259 ac-5 (additive): a CLEAN specify current tab carries the
+    // comments-aware advisory (no standing offer/button — still status-only).
     render(<TransitionSentence {...baseProps()} />);
-    expect(screen.queryByTestId('transition-sentence')).toBeNull();
+    expect(screen.getByTestId('transition-sentence').textContent).toContain(
+      'You can advance to Build when all open decisions are resolved and all comments are addressed.',
+    );
     expect(screen.queryByRole('button')).toBeNull();
   });
 
@@ -243,10 +247,15 @@ describe('Rubicon line — posture (i-1) and the Yes mutation', () => {
     expect(screen.queryByRole('button')).toBeNull();
   });
 
-  it('canTransition=false on the current tab with a clean rubric renders NOTHING — no offer', () => {
+  it('canTransition=false on a clean specify current tab → comments-aware advisory (status-only), no buttons', () => {
     tagAc(AC182_9);
+    // spec-259 ac-5 (additive): the clean specify advisory is STATUS, not an
+    // offer, so it shows for non-editors too — but never a button.
     render(<TransitionSentence {...baseProps({ canTransition: false })} />);
-    expect(screen.queryByTestId('transition-sentence')).toBeNull();
+    expect(screen.getByTestId('transition-sentence').textContent).toContain(
+      'You can advance to Build when all open decisions are resolved and all comments are addressed.',
+    );
+    expect(screen.queryByRole('button')).toBeNull();
   });
 
   it('canTransition=false on the current tab, blocked → the rubric condition, no buttons', () => {
@@ -313,11 +322,11 @@ describe('no switch-to-Editing nag (spec-182 dec-6, amended)', () => {
   it('a non-transitioning viewer sees a clean status line — no nag in any sentence shape', () => {
     tagAc(AC182(14));
     tagAc(AC182(6));
-    // Clean offer shape — renders nothing at all for a non-editor
-    // (spec-182 issue-1), so trivially no nag.
+    // Clean specify shape — a non-editor sees the spec-259 comments-aware
+    // advisory (status-only), and crucially NO switch-to-Editing nag.
     const { unmount } = render(<TransitionSentence {...baseProps()} canTransition={false} />);
     expect(screen.queryByTestId('switch-to-editing')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('transition-sentence')).toBeNull();
+    expect(text()).not.toContain("You're reviewing");
     unmount();
 
     // Blocked shape — the status line renders, nag-free.

--- a/packages/ui/src/components/TransitionSentence.tsx
+++ b/packages/ui/src/components/TransitionSentence.tsx
@@ -286,8 +286,24 @@ export function TransitionSentence({
     // anyway? [Yes]" still forces a blocked move.
     if (currentPhase !== 'draft') {
       if (blockers.length === 0) {
+        // spec-259 ac-5 (additive): with a CLEAN rubric at specify, the standing
+        // line is the comments-aware ADVISORY — the web is a viewing + low-friction
+        // surface and does NOT hard-gate the specify→build move (spec-247 / std-34;
+        // comments flag, never gate, per dec-1/ac-6). It reflects comments as a
+        // rubric item without overriding the spec-282/196 blocker reporting, which
+        // still leads while the rubric is blocked (below). Other phases keep the
+        // spec-282 "nothing when clean".
+        if (currentPhase === 'specify') {
+          return (
+            <p className="text-sm text-secondary" data-testid="transition-sentence">
+              You can advance to Build when all open decisions are resolved and all
+              comments are addressed.
+            </p>
+          );
+        }
         return null;
       }
+      // Blocked: spec-282/196 status-only blocker reporting (unchanged).
       return (
         <p className="text-sm text-secondary" data-testid="transition-sentence">
           {renderBlockers(blockers)} before this spec can move to {phaseDisplayName(target)}

--- a/packages/ui/src/utils/timeAgo.ts
+++ b/packages/ui/src/utils/timeAgo.ts
@@ -1,39 +1,4 @@
-// spec-286: a compact relative-time helper for the QA Reports feed metadata line.
-//
-// The existing utils stop short of what the feed needs: `formatDate` (utils/format)
-// is an absolute date and `relativeDays` (DoneSummary) only has day granularity.
-// A QA report generated "2h ago" should read that way, not "today" or "12 Jun 2026".
-//
-// Granularity ladder (coarsening as it ages): just now → Nm → Nh → Nd → Nw, then it
-// falls back to an absolute date so "63w ago" never appears. Always past-tense — a
-// report's createdAt is in the past; a (clock-skew) future instant clamps to "just now".
-
-const MINUTE = 60_000;
-const HOUR = 60 * MINUTE;
-const DAY = 24 * HOUR;
-const WEEK = 7 * DAY;
-
-function absoluteDate(date: Date): string {
-  return date.toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' });
-}
-
-/**
- * Format `iso` as a short relative time from `now` (default: the current time).
- * `now` is injectable so tests are deterministic without faking the clock.
- *
- * Examples: "just now", "5m ago", "3h ago", "2d ago", "5w ago", then "12 Jun 2026".
- */
-export function timeAgo(iso: string, now: Date = new Date()): string {
-  const then = new Date(iso);
-  if (Number.isNaN(then.getTime())) return '';
-
-  const diff = now.getTime() - then.getTime();
-  if (diff < MINUTE) return 'just now'; // includes small future skew (diff < 0)
-
-  if (diff < HOUR) return `${Math.floor(diff / MINUTE)}m ago`;
-  if (diff < DAY) return `${Math.floor(diff / HOUR)}h ago`;
-  if (diff < WEEK) return `${Math.floor(diff / DAY)}d ago`;
-  // Up to ~8 weeks stays relative; beyond that an absolute date is more legible.
-  if (diff < 8 * WEEK) return `${Math.floor(diff / WEEK)}w ago`;
-  return absoluteDate(then);
-}
+// spec-259 dec-5: the relative-time helper now lives once in @memex/shared so the
+// server (MCP/agent) and the UI render WHEN identically. This module re-exports it
+// to keep the existing `utils/timeAgo` import path stable for spec-286's consumers.
+export { timeAgo } from '@memex/shared';


### PR DESCRIPTION
Implements **spec-259** — the specify-phase MCP agent (and the web Specify surface) now surface and consider all open comments when assessing specify→build readiness.

Memex: https://memex.ai/mindset-prod/memex-building-itself/specs/spec-259

## What changed
- **`assess_spec(mode='phase', target='build')`** lists open comments (decision- and section-anchored) with per-comment WHO/WHEN, anchor-kind grouping, and oldest-age-per-group, plus a **soft build nudge** → *proceed-with-caveats* that **never gates** the move (dec-1 / ac-6).
- **Shared helpers** (`@memex/shared`): one canonical relative-age helper (`timeAgo`, injectable `now`) and a conservative display-name capitalizer (`capitalizeDisplayName`). UI `utils/timeAgo` re-exports the shared one.
- **`search_memex`**: per-section WHO/WHEN on multi-section hits, capitalized + relative bylines (absolute ISO retained on the wire), and a per-hit `(N open comments, oldest Xd ago)` indicator (dec-3 / ac-9 / ac-12).
- **WHO resolver**: resolved-user displays run through the capitalizer; unmatched/CI strings stay verbatim (preserves spec-122 ac-26).
- **Comment resolution attribution (ac-4)**: build grounding found `resolveComment` dropped WHO (`mutate({})`); it now threads `RequestCtx` and all call sites pass the acting user (std-32). The denormalized `resolved_by` column is deferred (issue-1).
- **Web**: Specify-phase open-comment summary band + per-comment bylines. The Rubicon sentence is **additive** — spec-282/196 dynamic blockers when blocked, the comments-aware advisory when clean (reconciliation decided with the spec owner).
- Specify prompt instructs the agent to walk comments before build (ac-3).

## Verification
- **9** shared + **276** server (incl. integration + the attribution guard) + **1308** UI unit tests green; **77** cold e2e journeys green (`make e2e-cold`), including new **journey-33**.
- **13/14 ACs verified** via tagged tests; ac-2 is an artifact AC (a documented resolution decision exists), consciously signed off.

## Follow-ups
- **issue-1** (todo): optional denormalized `resolved_by_user_id` column on `doc_comments` — deferred; ac-4 holds via the activity contract without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)