### PR TITLE
fix(spec-293): RLS-safe cross-tenant Spec move + whole-Spec transfer + personal-Memex dedupe

### DIFF
--- a/packages/server/drizzle/0094_move_doc_function.sql
+++ b/packages/server/drizzle/0094_move_doc_function.sql
@@ -1,0 +1,192 @@
+-- spec-293 t-1 (dec-1): RLS-sanctioned cross-tenant Spec move via a SECURITY
+-- DEFINER function.
+--
+-- WHY A FUNCTION (the prod 500)
+--   Moving a Spec re-points memex_id from tenant A to tenant B. The runtime role
+--   `memex_app` is NOBYPASSRLS and every request is scoped to ONE app.memex_id
+--   GUC (db/connection.ts), so the `*_memex_isolation` WITH CHECK (0081) rejects
+--   `UPDATE … SET memex_id = <other tenant>` — that is the prod-only Internal
+--   Server Error (it passes locally only because dev/tests connect as the table
+--   OWNER, which bypasses RLS under ENABLE+NO FORCE, std-36 / 0093).
+--
+--   `move_doc` is owned by the table owner and marked SECURITY DEFINER, so its
+--   body executes with owner privileges and bypasses RLS for this one sanctioned,
+--   audited operation. memex_app gets EXECUTE on this function ONLY (below) — it
+--   gains no general cross-tenant power. The authorization guard lives INSIDE the
+--   function so privilege and guard cannot drift apart (dec-1).
+--
+-- WHAT MOVES (dec-2 / dec-3): the whole Spec. Every doc-scoped artifact that
+--   carries a denormalised memex_id is re-pointed; the rest follow by FK:
+--     re-pointed (memex_id):  documents, doc_comments (ALL targets — dec-3),
+--       decisions, tasks, acs (brief_id), issues, doc_members, doc_assignees,
+--       document_tags (document_id), clause_refs (source_doc_id)
+--     follow by FK (no memex_id): doc_sections (doc_id), conversations (doc_id),
+--       messages (conversation_id), ac_parent_links (ac_id), task_satisfies_ac
+--     not tenant-scoped: test_events / test_event_latest are keyed by the AC's
+--       text uid (the AC keeps its handle on move), so verification history
+--       follows the AC with no row change.
+--   Deliberately NOT touched (per-user / per-Memex read-state, not Spec content):
+--     qa_report_views, presence, user_memex_access, mcp_tool_calls.
+--
+-- Errors (mapped to HTTP by services/doc-move.ts):
+--   MX001 — document not found in source memex          → 404 (std-7)
+--   MX002 — caller not authorized in source/target       → 404 (std-7, never 403)
+--   MX003 — source and target memex are the same         → 400
+
+-- Authorization helper: is p_user_id allowed in the memex p_memex_id? Owns the
+-- namespace (personal) or holds an active org_membership in the owning org
+-- (mirrors services/doc-move.ts:108-126). SECURITY DEFINER + owner so it reads
+-- the tenancy tables regardless of RLS; STABLE (no writes).
+CREATE OR REPLACE FUNCTION _memex_member(p_memex_id uuid, p_user_id uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+      FROM memexes m
+      JOIN namespaces n ON n.id = m.namespace_id
+     WHERE m.id = p_memex_id
+       AND (
+         (n.kind = 'user' AND n.owner_user_id = p_user_id)
+         OR (n.kind = 'org' AND n.owner_org_id IS NOT NULL AND EXISTS (
+              SELECT 1 FROM org_memberships om
+               WHERE om.user_id = p_user_id
+                 AND om.org_id = n.owner_org_id
+                 AND om.status = 'active'
+            ))
+       )
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION move_doc(
+  p_doc_id        uuid,
+  p_from_memex_id uuid,
+  p_to_memex_id   uuid,
+  p_user_id       uuid
+)
+RETURNS TABLE (
+  new_handle            text,
+  revoked_share_tokens  integer,
+  removed_decision_deps integer,
+  removed_task_deps     integer
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_doc_type   text;
+  v_handle     text;
+  v_prefix     text;
+  v_attempt    integer := 0;
+  v_done       boolean := false;
+BEGIN
+  IF p_from_memex_id = p_to_memex_id THEN
+    RAISE EXCEPTION 'source and target memex must differ' USING ERRCODE = 'MX003';
+  END IF;
+
+  -- Lock the doc in the source memex; 404 if it isn't there.
+  SELECT doc_type INTO v_doc_type
+    FROM documents
+   WHERE id = p_doc_id AND memex_id = p_from_memex_id
+   FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'document % not found in source memex', p_doc_id USING ERRCODE = 'MX001';
+  END IF;
+
+  -- Authorization: the caller must be allowed in BOTH source and target Memex.
+  -- (memexes / namespaces / org_memberships are not RLS-scoped tables.)
+  IF NOT _memex_member(p_from_memex_id, p_user_id) THEN
+    RAISE EXCEPTION 'not authorized in source memex' USING ERRCODE = 'MX002';
+  END IF;
+  IF NOT _memex_member(p_to_memex_id, p_user_id) THEN
+    RAISE EXCEPTION 'not authorized in target memex' USING ERRCODE = 'MX002';
+  END IF;
+
+  -- Per doc-30 / spec-105: specs → spec-N, standards → std-N, everything else → doc-N.
+  v_prefix := CASE v_doc_type WHEN 'spec' THEN 'spec' WHEN 'standard' THEN 'std' ELSE 'doc' END;
+
+  -- Re-mint the handle in the TARGET memex. The MAX+1 read is racy against a
+  -- concurrent create/move into the same memex; retry on the unique violation
+  -- (documents_memex_id_handle_unique). Owner-context read sees the real target
+  -- rows (the app role would be RLS-filtered to the source and mint wrong).
+  WHILE NOT v_done LOOP
+    v_attempt := v_attempt + 1;
+    SELECT v_prefix || '-' || (
+             coalesce(max(cast(substring(handle from (v_prefix || '-([0-9]+)')) as integer)), 0) + 1
+           )
+      INTO v_handle
+      FROM documents
+     WHERE memex_id = p_to_memex_id;
+    BEGIN
+      UPDATE documents
+         SET memex_id = p_to_memex_id, handle = v_handle
+       WHERE id = p_doc_id;
+      v_done := true;
+    EXCEPTION WHEN unique_violation THEN
+      IF v_attempt >= 25 THEN
+        RAISE;  -- give up after persistent contention rather than spin forever
+      END IF;
+    END;
+  END LOOP;
+
+  -- Re-point every doc-scoped artifact carrying a denormalised memex_id (dec-2).
+  -- doc_comments covers ALL comment targets via the denormalised doc_id (dec-3).
+  -- standard_clauses holds a Standard doc's body (matters for the dedupe merge,
+  -- where personal Memexes carry seeded default Standards).
+  UPDATE standard_clauses SET memex_id = p_to_memex_id WHERE doc_id     = p_doc_id;
+  UPDATE doc_comments  SET memex_id = p_to_memex_id WHERE doc_id        = p_doc_id;
+  UPDATE decisions     SET memex_id = p_to_memex_id WHERE doc_id        = p_doc_id;
+  UPDATE tasks         SET memex_id = p_to_memex_id WHERE doc_id        = p_doc_id;
+  UPDATE acs           SET memex_id = p_to_memex_id WHERE brief_id      = p_doc_id;
+  UPDATE issues        SET memex_id = p_to_memex_id WHERE doc_id        = p_doc_id;
+  UPDATE doc_members   SET memex_id = p_to_memex_id WHERE doc_id        = p_doc_id;
+  UPDATE doc_assignees SET memex_id = p_to_memex_id WHERE doc_id        = p_doc_id;
+  UPDATE document_tags SET memex_id = p_to_memex_id WHERE document_id   = p_doc_id;
+  UPDATE clause_refs   SET memex_id = p_to_memex_id WHERE source_doc_id = p_doc_id;
+  -- doc_sections, conversations, messages, ac_parent_links, task_satisfies_ac
+  -- carry no memex_id — they follow via their FK chain to the moved rows.
+
+  -- Any dep edge that now straddles two memexes is structurally invalid (the
+  -- blocked party can't see the blocker across the tenant wall). Silent-delete,
+  -- return the counts so the UI can surface a toast. Whole-Spec moves keep
+  -- intra-Spec edges intact; only edges to OTHER specs left behind can straddle.
+  WITH del AS (
+    DELETE FROM decision_deps dd
+     USING tasks w, decisions d
+     WHERE dd.task_id = w.id AND dd.decision_id = d.id
+       AND w.memex_id <> d.memex_id
+       AND (w.doc_id = p_doc_id OR d.doc_id = p_doc_id)
+    RETURNING 1
+  ) SELECT count(*) INTO removed_decision_deps FROM del;
+
+  WITH del AS (
+    DELETE FROM task_deps wd
+     USING tasks w1, tasks w2
+     WHERE wd.task_id = w1.id AND wd.depends_on_id = w2.id
+       AND w1.memex_id <> w2.memex_id
+       AND (w1.doc_id = p_doc_id OR w2.doc_id = p_doc_id)
+    RETURNING 1
+  ) SELECT count(*) INTO removed_task_deps FROM del;
+
+  -- Public share URLs are source-scoped and would break after the move; revoke them.
+  WITH upd AS (
+    UPDATE share_tokens SET revoked = TRUE
+     WHERE document_id = p_doc_id AND revoked = FALSE
+    RETURNING 1
+  ) SELECT count(*) INTO revoked_share_tokens FROM upd;
+
+  new_handle := v_handle;
+  RETURN NEXT;
+END;
+$$;
+
+-- memex_app may CALL the move, nothing more. Revoke the implicit PUBLIC EXECUTE
+-- so the cross-tenant seam is reachable only through this one granted path.
+REVOKE ALL ON FUNCTION move_doc(uuid, uuid, uuid, uuid) FROM PUBLIC;
+REVOKE ALL ON FUNCTION _memex_member(uuid, uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION move_doc(uuid, uuid, uuid, uuid) TO memex_app;
+GRANT EXECUTE ON FUNCTION _memex_member(uuid, uuid) TO memex_app;

--- a/packages/server/drizzle/0095_dedupe_personal_memexes.sql
+++ b/packages/server/drizzle/0095_dedupe_personal_memexes.sql
@@ -1,0 +1,108 @@
+-- spec-293 t-4 (dec-4): one-time data backfill — collapse duplicate personal
+-- Memexes left behind by the pre-fix signup race.
+--
+-- BACKGROUND. The concurrent-signup race that minted a second (and third)
+-- personal Memex per user is already closed in code (spec-177:
+-- services/user-namespaces.ts, ownership-first resolution + onConflictDoNothing).
+-- This migration only cleans up the rows that race left on prod. The creation
+-- path is not touched here.
+--
+-- POLICY (dec-4).
+--   * Canonical = the personal Memex in the namespace users.namespaceId points at
+--     (the one the user actually sees). Fallback to the OLDEST personal Memex if
+--     that pointer is null or has no personal Memex.
+--   * MERGE every duplicate's content INTO the canonical — no user content is ever
+--     deleted. We reuse move_doc() (migration 0094) per document, so each doc and
+--     ALL its doc-scoped artifacts travel and its handle is re-minted on collision
+--     (documents_memex_id_handle_unique). move_doc is SECURITY DEFINER; this
+--     migration runs as the table OWNER, which bypasses RLS — no GUC needed.
+--   * Then DELETE the now-empty duplicate Memex (FK cascade clears its per-user
+--     read-state: qa_report_views, user_memex_access, presence, …) and its orphaned
+--     user-namespace (guarded: only if nothing else references it).
+--
+-- IDEMPOTENT. The driving query selects only users who still have >1 personal
+-- Memex, so a second run is a no-op. Safe to re-run.
+--
+-- ROLLOUT (std-17). Ships int-first, green there before prod; capture a PITR
+-- marker before the prod run (precedent spec-65). Post-migration invariant
+-- (ac-14): zero users with >1 personal Memex — the SELECT at the bottom must
+-- return 0 (also asserted by the integration test).
+
+DO $$
+DECLARE
+  r_user      record;
+  v_canonical uuid;
+  r_dup       record;
+  r_doc       record;
+BEGIN
+  FOR r_user IN
+    SELECT n.owner_user_id AS user_id
+      FROM namespaces n
+      JOIN memexes m ON m.namespace_id = n.id AND m.slug = 'personal'
+     WHERE n.kind = 'user' AND n.owner_user_id IS NOT NULL
+     GROUP BY n.owner_user_id
+    HAVING count(*) > 1
+  LOOP
+    -- Canonical: personal Memex in the namespace users.namespaceId references.
+    SELECT m.id INTO v_canonical
+      FROM users u
+      JOIN namespaces n ON n.id = u.namespace_id
+      JOIN memexes m ON m.namespace_id = n.id AND m.slug = 'personal'
+     WHERE u.id = r_user.user_id;
+
+    -- Fallback: the oldest personal Memex the user owns.
+    IF v_canonical IS NULL THEN
+      SELECT m.id INTO v_canonical
+        FROM namespaces n
+        JOIN memexes m ON m.namespace_id = n.id AND m.slug = 'personal'
+       WHERE n.kind = 'user' AND n.owner_user_id = r_user.user_id
+       ORDER BY m.created_at ASC, m.id ASC
+       LIMIT 1;
+    END IF;
+
+    -- Merge every NON-canonical personal Memex into the canonical, then remove it.
+    FOR r_dup IN
+      SELECT m.id AS memex_id, m.namespace_id
+        FROM namespaces n
+        JOIN memexes m ON m.namespace_id = n.id AND m.slug = 'personal'
+       WHERE n.kind = 'user' AND n.owner_user_id = r_user.user_id
+         AND m.id <> v_canonical
+    LOOP
+      -- Move each doc whole (handle re-minted in canonical by move_doc).
+      FOR r_doc IN SELECT id FROM documents WHERE memex_id = r_dup.memex_id LOOP
+        PERFORM move_doc(r_doc.id, r_dup.memex_id, v_canonical, r_user.user_id);
+      END LOOP;
+
+      -- The duplicate now holds no documents. Delete it; FK cascade clears its
+      -- per-user read-state rows.
+      DELETE FROM memexes WHERE id = r_dup.memex_id;
+
+      -- Delete the orphaned user-namespace, but only if nothing else points at it.
+      DELETE FROM namespaces n2
+       WHERE n2.id = r_dup.namespace_id
+         AND NOT EXISTS (SELECT 1 FROM memexes mm WHERE mm.namespace_id = n2.id)
+         AND NOT EXISTS (SELECT 1 FROM users uu WHERE uu.namespace_id = n2.id)
+         AND NOT EXISTS (SELECT 1 FROM orgs o WHERE o.namespace_id = n2.id);
+    END LOOP;
+  END LOOP;
+END $$;
+
+-- Post-migration invariant (ac-14): must be 0. (psql prints the count; the
+-- integration test asserts it programmatically.)
+DO $$
+DECLARE
+  v_remaining integer;
+BEGIN
+  SELECT count(*) INTO v_remaining FROM (
+    SELECT n.owner_user_id
+      FROM namespaces n
+      JOIN memexes m ON m.namespace_id = n.id AND m.slug = 'personal'
+     WHERE n.kind = 'user' AND n.owner_user_id IS NOT NULL
+     GROUP BY n.owner_user_id
+    HAVING count(*) > 1
+  ) offenders;
+  RAISE NOTICE 'spec-293 dedupe: % user(s) still with >1 personal Memex (expect 0)', v_remaining;
+  IF v_remaining <> 0 THEN
+    RAISE EXCEPTION 'spec-293 dedupe left % user(s) with >1 personal Memex', v_remaining;
+  END IF;
+END $$;

--- a/packages/server/src/__regression__/mutate-coverage.service.test.ts
+++ b/packages/server/src/__regression__/mutate-coverage.service.test.ts
@@ -246,17 +246,25 @@ describe("doc-16 t-12: service coverage — every Mutated<T> service emits on th
     const toMemex = await makeTestMemex("mvto");
     const doc = await documentsSvc.createDocDraft(fromMemex, "To move", "Move me", "spec");
 
-    // Enrol the dev user as administrator on the target org so the permission check passes.
+    // Enrol the dev user on BOTH org(s) — spec-293's move_doc checks membership in
+    // the source AND target memex (the request path gates source via session
+    // middleware, but the service contract enforces both).
     const { upsertUserByEmail } = await import("../services/users.js");
     const { orgMemberships, memexes, namespaces } = await import("../db/schema.js");
-    const targetMemexRow = await db.query.memexes.findFirst({ where: eq(memexes.id, toMemex) });
-    const targetNs = await db.query.namespaces.findFirst({
-      where: eq(namespaces.id, targetMemexRow!.namespaceId),
-    });
+    const orgIdOf = async (memexId: string): Promise<string> => {
+      const m = await db.query.memexes.findFirst({ where: eq(memexes.id, memexId) });
+      const ns = await db.query.namespaces.findFirst({
+        where: eq(namespaces.id, m!.namespaceId),
+      });
+      return ns!.ownerOrgId!;
+    };
     const dev = await upsertUserByEmail("dev@memex.ai");
     await db
       .insert(orgMemberships)
-      .values({ userId: dev.id, orgId: targetNs!.ownerOrgId!, role: "administrator" })
+      .values([
+        { userId: dev.id, orgId: await orgIdOf(fromMemex), role: "administrator" },
+        { userId: dev.id, orgId: await orgIdOf(toMemex), role: "administrator" },
+      ])
       .onConflictDoNothing();
 
     const seen: { memexId: string; entity: ChangeEntity; action: ChangeAction }[] = [];
@@ -266,10 +274,10 @@ describe("doc-16 t-12: service coverage — every Mutated<T> service emits on th
       }
     });
     try {
-      await docMoveSvc.moveDoc(fromMemex, doc.id, toMemex, dev.id, {
-        includeDecisions: false,
-        includeTasks: false,
-        includeSectionComments: false,
+      await docMoveSvc.moveDoc(fromMemex, doc.id, toMemex, {
+        actorUserId: dev.id,
+        actorName: "dev",
+        channel: "rest_ui",
       });
     } finally {
       unsubscribe();

--- a/packages/server/src/routes/documents.ts
+++ b/packages/server/src/routes/documents.ts
@@ -1,7 +1,7 @@
 import { Hono } from "hono";
 import { listDocs, getDoc, updateDocStatus, updateDocTitle, archiveDoc, pauseDoc, unpauseDoc } from "../services/documents.js";
 import { restCtx } from "./_actor-ctx.js";
-import { moveDoc, ForbiddenError } from "../services/doc-move.js";
+import { moveDoc } from "../services/doc-move.js";
 import { splitSection, updateSection } from "../services/sections.js";
 import { listDecisions } from "../services/decisions.js";
 import { listTasks } from "../services/tasks.js";
@@ -261,13 +261,9 @@ docs.post("/:id/unpause", async (c) => {
 
 docs.post("/:id/move", async (c) => {
   const memexId = requireMemexId(c);
-  const user = c.get("user");
   const id = c.req.param("id");
   const body = (await c.req.json().catch(() => null)) as {
     targetMemexId?: unknown;
-    includeDecisions?: unknown;
-    includeTasks?: unknown;
-    includeSectionComments?: unknown;
   } | null;
 
   const targetMemexId = body?.targetMemexId;
@@ -275,19 +271,12 @@ docs.post("/:id/move", async (c) => {
     throw new ValidationError("Body must include a 'targetMemexId' string");
   }
 
-  try {
-    const result = await moveDoc(memexId, id, targetMemexId, user.id, {
-      includeDecisions: Boolean(body?.includeDecisions),
-      includeTasks: Boolean(body?.includeTasks),
-      includeSectionComments: Boolean(body?.includeSectionComments),
-    });
-    return c.json(result);
-  } catch (err) {
-    if (err instanceof ForbiddenError) {
-      return c.json({ error: "Forbidden", message: err.message }, 403);
-    }
-    throw err;
-  }
+  // spec-293 dec-2/dec-3: a move is always whole — no per-artifact opt-out. The
+  // RequestCtx carries the actor + rest_ui channel onto both emitted events
+  // (dec-5). Authorization/not-found are raised inside move_doc and surfaced as
+  // 404 (std-7) by moveDoc's translation — no special-casing here.
+  const result = await moveDoc(memexId, id, targetMemexId, restCtx(c));
+  return c.json(result);
 });
 
 docs.post("/:id/title", async (c) => {

--- a/packages/server/src/services/dedupe-personal-memexes.integration.test.ts
+++ b/packages/server/src/services/dedupe-personal-memexes.integration.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { readFileSync } from "node:fs";
+import { and, eq, inArray, sql } from "drizzle-orm";
+import { db } from "../db/connection.js";
+import { memexes, namespaces, documents, decisions, users } from "../db/schema.js";
+import { upsertUserByEmail } from "./users.js";
+import { createDecision } from "./decisions.js";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+// spec-293 t-4 (dec-4): the prod personal-Memex dedupe data migration. Seeds a
+// user with THREE personal Memexes (the pre-fix race outcome), with colliding
+// handles + content in the duplicates, then runs the real migration SQL and
+// asserts: content merged into the canonical with no loss, empties removed, the
+// ≤1-personal-Memex invariant holds, and a second run is a no-op.
+
+const SPEC = "mindset-prod/memex-building-itself/specs/spec-293";
+const ac = (n: number) => `${SPEC}/acs/ac-${n}`;
+
+const MIGRATION_SQL = readFileSync(
+  new URL("../../drizzle/0095_dedupe_personal_memexes.sql", import.meta.url),
+  "utf8",
+);
+
+async function runMigration(): Promise<void> {
+  await db.execute(sql.raw(MIGRATION_SQL));
+}
+
+// How many users currently have >1 personal Memex.
+async function offenderCount(): Promise<number> {
+  const rows = (await db.execute(sql`
+    SELECT count(*)::int AS n FROM (
+      SELECT n.owner_user_id
+        FROM namespaces n
+        JOIN memexes m ON m.namespace_id = n.id AND m.slug = 'personal'
+       WHERE n.kind = 'user' AND n.owner_user_id IS NOT NULL
+       GROUP BY n.owner_user_id
+      HAVING count(*) > 1
+    ) o
+  `)) as unknown as Array<{ n: number }>;
+  return rows[0]!.n;
+}
+
+let userId: string;
+let nsA: string;
+let nsB: string;
+let nsC: string;
+let mxA: string;
+let mxB: string;
+let mxC: string;
+let docA: string;
+let docB: string;
+let docC: string;
+
+beforeAll(async () => {
+  const user = await upsertUserByEmail(`dedupe-${Date.now()}@memex.ai`);
+  userId = user.id;
+
+  // Three user-namespaces owned by the same user, each with a 'personal' Memex.
+  const stamp = Date.now();
+  const [a, b, c] = await db
+    .insert(namespaces)
+    .values([
+      { slug: `dedupe-a-${stamp}`, kind: "user", ownerUserId: userId },
+      { slug: `dedupe-b-${stamp}`, kind: "user", ownerUserId: userId },
+      { slug: `dedupe-c-${stamp}`, kind: "user", ownerUserId: userId },
+    ])
+    .returning({ id: namespaces.id });
+  nsA = a!.id;
+  nsB = b!.id;
+  nsC = c!.id;
+
+  const [ma, mb, mc] = await db
+    .insert(memexes)
+    .values([
+      { namespaceId: nsA, slug: "personal", name: "Personal Memex" },
+      { namespaceId: nsB, slug: "personal", name: "Personal Memex" },
+      { namespaceId: nsC, slug: "personal", name: "Personal Memex" },
+    ])
+    .returning({ id: memexes.id });
+  mxA = ma!.id;
+  mxB = mb!.id;
+  mxC = mc!.id;
+
+  // users.namespaceId → nsA makes mxA the canonical.
+  await db.update(users).set({ namespaceId: nsA }).where(eq(users.id, userId));
+
+  // Content. All three use handle 'spec-1' to force handle re-mint on merge.
+  const [da] = await db
+    .insert(documents)
+    .values({ memexId: mxA, handle: "spec-1", title: "Canonical doc", docType: "spec", status: "draft" })
+    .returning({ id: documents.id });
+  const [dbb] = await db
+    .insert(documents)
+    .values({ memexId: mxB, handle: "spec-1", title: "Dup B doc", docType: "spec", status: "draft" })
+    .returning({ id: documents.id });
+  const [dc] = await db
+    .insert(documents)
+    .values({ memexId: mxC, handle: "spec-1", title: "Dup C doc", docType: "spec", status: "draft" })
+    .returning({ id: documents.id });
+  docA = da!.id;
+  docB = dbb!.id;
+  docC = dc!.id;
+
+  // A decision under the dup-B doc — must travel to the canonical with its doc.
+  await createDecision(mxB, docB, "Decision that must survive");
+});
+
+afterAll(async () => {
+  await db.delete(documents).where(inArray(documents.id, [docA, docB, docC])).catch(() => {});
+  await db.delete(memexes).where(inArray(memexes.id, [mxA, mxB, mxC])).catch(() => {});
+  await db.delete(namespaces).where(inArray(namespaces.id, [nsA, nsB, nsC])).catch(() => {});
+});
+
+describe("dedupe personal Memexes (dec-4)", () => {
+  it("ac-14/ac-15: merges duplicates into the canonical, deletes empties, loses nothing, is idempotent", async () => {
+    tagAc(ac(14));
+    tagAc(ac(15));
+    tagAc(ac(4)); // scope: idempotent, no-content-loss dedupe migration
+
+    // Precondition: this user has 3 personal Memexes.
+    const before = (await db.execute(sql`
+      SELECT count(*)::int AS n FROM memexes m
+        JOIN namespaces n ON n.id = m.namespace_id
+       WHERE m.slug = 'personal' AND n.kind = 'user' AND n.owner_user_id = ${userId}
+    `)) as unknown as Array<{ n: number }>;
+    expect(before[0]!.n).toBe(3);
+    expect(await offenderCount()).toBeGreaterThanOrEqual(1);
+
+    const docCountBefore = (await db.execute(sql`
+      SELECT count(*)::int AS n FROM documents WHERE id IN (${docA}, ${docB}, ${docC})
+    `)) as unknown as Array<{ n: number }>;
+    expect(docCountBefore[0]!.n).toBe(3);
+
+    await runMigration();
+
+    // The two duplicate Memexes are gone; the canonical remains.
+    const remaining = await db
+      .select({ id: memexes.id })
+      .from(memexes)
+      .where(inArray(memexes.id, [mxA, mxB, mxC]));
+    expect(remaining.map((r) => r.id)).toEqual([mxA]);
+
+    // No content lost: all three docs still exist…
+    const docsAfter = await db
+      .select({ id: documents.id, memexId: documents.memexId, handle: documents.handle })
+      .from(documents)
+      .where(inArray(documents.id, [docA, docB, docC]));
+    expect(docsAfter).toHaveLength(3);
+    // …and all now live in the canonical Memex…
+    expect(docsAfter.every((d) => d.memexId === mxA)).toBe(true);
+    // …with distinct (re-minted) handles — no unique-constraint violation.
+    const handles = docsAfter.map((d) => d.handle);
+    expect(new Set(handles).size).toBe(3);
+
+    // The dup-B decision travelled to the canonical.
+    const decRows = await db.select().from(decisions).where(eq(decisions.docId, docB));
+    expect(decRows.length).toBeGreaterThanOrEqual(1);
+    expect(decRows.every((d) => d.memexId === mxA)).toBe(true);
+
+    // Invariant (ac-14): no user has >1 personal Memex.
+    expect(await offenderCount()).toBe(0);
+
+    // Idempotent (ac-15): re-running raises nothing and changes nothing.
+    await expect(runMigration()).resolves.not.toThrow();
+    const stillOne = await db
+      .select({ id: memexes.id })
+      .from(memexes)
+      .where(and(inArray(memexes.id, [mxA, mxB, mxC])));
+    expect(stillOne.map((r) => r.id)).toEqual([mxA]);
+  });
+});

--- a/packages/server/src/services/doc-move.integration.test.ts
+++ b/packages/server/src/services/doc-move.integration.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, afterAll, beforeAll } from "vitest";
-import { and, eq, inArray } from "drizzle-orm";
+import { eq, inArray, sql } from "drizzle-orm";
+import postgres from "postgres";
 import { db } from "../db/connection.js";
 import {
   memexes,
@@ -9,30 +10,43 @@ import {
   docComments,
   decisions,
   tasks,
-  decisionDeps,
-  taskDeps,
+  acs,
+  issues,
+  docMembers,
+  docAssignees,
+  qaReportViews,
   shareTokens,
 } from "../db/schema.js";
 import { NotFoundError, ValidationError } from "../types/errors.js";
 import { makeTestMemex } from "./test-helpers.js";
-import { createDocDraft, getDoc, listDocs } from "./documents.js";
+import { createDocDraft, getDoc } from "./documents.js";
 import { createDecision } from "./decisions.js";
 import { createTask } from "./tasks.js";
-import { addDecisionDep, addTaskDep } from "./dependencies.js";
 import { addComment, addDecisionComment, addTaskComment } from "./comments.js";
 import { upsertUserByEmail } from "./users.js";
 import { createShareToken } from "./share-tokens.js";
-import { moveDoc, ForbiddenError } from "./doc-move.js";
+import { moveDoc } from "./doc-move.js";
+import { bus } from "./bus.js";
+import type { RequestCtx } from "./mutate.js";
+import { tagAc } from "@memex-ai-ac/vitest";
 
-// doc-move: cross-account spec relocation. Tests both the data plane (child rows'
-// account_id updates on the options flags) and the structural invariants (orphans remain,
-// cross-account deps are pruned, share tokens revoked, reversibility).
+// spec-293: cross-tenant Spec move. The move re-points memex_id ACROSS the RLS
+// tenant wall (the prod-only 500 this Spec fixes) via the SECURITY DEFINER
+// move_doc() function (migration 0094). A Spec now moves WHOLE (dec-2) and ALL
+// comments travel with it (dec-3); there are no per-artifact opt-outs.
 
-let accountA: string;
-let accountB: string;
-let accountC: string;
+const SPEC = "mindset-prod/memex-building-itself/specs/spec-293";
+const ac = (n: number) => `${SPEC}/acs/ac-${n}`;
+
+let memexA: string;
+let memexB: string;
+let memexC: string;
 let userId: string;
 let outsiderUserId: string;
+
+function ctxFor(uid: string): RequestCtx {
+  return { actorUserId: uid, actorName: "Mover", channel: "rest_ui" };
+}
 
 async function orgIdForMemex(memexId: string): Promise<string> {
   const m = await db.query.memexes.findFirst({ where: eq(memexes.id, memexId) });
@@ -43,9 +57,9 @@ async function orgIdForMemex(memexId: string): Promise<string> {
 }
 
 beforeAll(async () => {
-  accountA = await makeTestMemex("mva");
-  accountB = await makeTestMemex("mvb");
-  accountC = await makeTestMemex("mvc");
+  memexA = await makeTestMemex("mva");
+  memexB = await makeTestMemex("mvb");
+  memexC = await makeTestMemex("mvc");
 
   const user = await upsertUserByEmail(`doc-move-member-${Date.now()}@memex.ai`);
   userId = user.id;
@@ -53,9 +67,8 @@ beforeAll(async () => {
   outsiderUserId = outsider.id;
 
   // Member of A and B, NOT C. outsider isn't a member of anything relevant.
-  // org_memberships keys on org.id (not memex.id) post-doc-15.
-  const orgIdA = await orgIdForMemex(accountA);
-  const orgIdB = await orgIdForMemex(accountB);
+  const orgIdA = await orgIdForMemex(memexA);
+  const orgIdB = await orgIdForMemex(memexB);
   await db
     .insert(orgMemberships)
     .values([
@@ -68,192 +81,91 @@ beforeAll(async () => {
 afterAll(async () => {
   await db
     .delete(memexes)
-    .where(inArray(memexes.id, [accountA, accountB, accountC]))
+    .where(inArray(memexes.id, [memexA, memexB, memexC]))
     .catch(() => {});
 });
 
-describe("moveDoc — happy path", () => {
-  it("moves the doc + all children when every flag is on", async () => {
-    const doc = await createDocDraft(accountA, "Full Move", "Purpose");
+describe("moveDoc — whole-Spec move (dec-2 / dec-3)", () => {
+  it("ac-2/ac-10/ac-11/ac-12: every doc-scoped artifact lands in the target; read-state stays", async () => {
+    tagAc(ac(2));
+    tagAc(ac(10));
+    tagAc(ac(11));
+    tagAc(ac(12));
+
+    const doc = await createDocDraft(memexA, "Whole Move", "Purpose");
     const section = doc.sections[0];
-    const dec = await createDecision(accountA, doc.id, "Decision 1");
-    const task = await createTask(accountA, doc.id, "Task 1", "");
-    await addComment(accountA, section.id, "u", "sec comment");
-    await addDecisionComment(accountA, dec.id, "u", "dec comment");
-    await addTaskComment(accountA, task.id, "u", "task comment");
+    const dec = await createDecision(memexA, doc.id, "Decision 1");
+    const task = await createTask(memexA, doc.id, "Task 1", "");
+    const secComment = await addComment(memexA, section.id, "u", "section comment");
+    const decComment = await addDecisionComment(memexA, dec.id, "u", "decision comment");
+    const taskComment = await addTaskComment(memexA, task.id, "u", "task comment");
 
-    const result = await moveDoc(accountA, doc.id, accountB, userId, {
-      includeDecisions: true,
-      includeTasks: true,
-      includeSectionComments: true,
-    });
+    // Artifacts with no convenient creation service — seeded directly in A.
+    const [acRow] = await db
+      .insert(acs)
+      .values({ memexId: memexA, briefId: doc.id, seq: 1, kind: "scope", statement: "must move" })
+      .returning({ id: acs.id });
+    const [issueRow] = await db
+      .insert(issues)
+      .values({ memexId: memexA, docId: doc.id, seq: 1, title: "Bug", body: "b", type: "bug" })
+      .returning({ id: issues.id });
+    await db.insert(docMembers).values({ memexId: memexA, docId: doc.id, userId, role: "editor" });
+    await db.insert(docAssignees).values({ memexId: memexA, docId: doc.id, userId });
 
-    expect(result.doc.memexId).toBe(accountB);
-    // createDocDraft defaults to docType="spec" (b-105) → spec-N handles.
+    // Per-user / per-Memex read-state — must NOT move (dec-2 / ac-11).
+    await db
+      .insert(qaReportViews)
+      .values({ userId, memexId: memexA })
+      .onConflictDoNothing();
+
+    const result = await moveDoc(memexA, doc.id, memexB, ctxFor(userId));
+
+    expect(result.docId).toBe(doc.id);
     expect(result.newHandle).toMatch(/^spec-\d+$/);
 
-    // Everything should now be findable in B and invisible in A.
-    await expect(getDoc(accountA, doc.id)).rejects.toThrow(NotFoundError);
-    const fetched = await getDoc(accountB, doc.id);
+    // The doc is gone from A and present in B at its new handle.
+    await expect(getDoc(memexA, doc.id)).rejects.toThrow(NotFoundError);
+    const fetched = await getDoc(memexB, doc.id);
     expect(fetched.id).toBe(doc.id);
     expect(fetched.handle).toBe(result.newHandle);
 
-    const decRows = await db.select().from(decisions).where(eq(decisions.docId, doc.id));
-    expect(decRows.every((d) => d.memexId === accountB)).toBe(true);
+    // Every memex_id-bearing doc-scoped artifact now reads memex_id = B.
+    const [decRow] = await db.select().from(decisions).where(eq(decisions.id, dec.id));
+    expect(decRow.memexId).toBe(memexB);
+    const [taskRow] = await db.select().from(tasks).where(eq(tasks.id, task.id));
+    expect(taskRow.memexId).toBe(memexB);
+    const [acAfter] = await db.select().from(acs).where(eq(acs.id, acRow!.id));
+    expect(acAfter.memexId).toBe(memexB);
+    const [issueAfter] = await db.select().from(issues).where(eq(issues.id, issueRow!.id));
+    expect(issueAfter.memexId).toBe(memexB);
+    const memberRows = await db.select().from(docMembers).where(eq(docMembers.docId, doc.id));
+    expect(memberRows.every((m) => m.memexId === memexB)).toBe(true);
+    const assigneeRows = await db.select().from(docAssignees).where(eq(docAssignees.docId, doc.id));
+    expect(assigneeRows.every((a) => a.memexId === memexB)).toBe(true);
 
-    const taskRows = await db.select().from(tasks).where(eq(tasks.docId, doc.id));
-    expect(taskRows.every((t) => t.memexId === accountB)).toBe(true);
-
+    // dec-3: ALL comments move — section, decision AND task — unconditionally.
     const commentRows = await db
       .select()
       .from(docComments)
-      .where(
-        inArray(
-          docComments.id,
-          (
-            await db
-              .select({ id: docComments.id })
-              .from(docComments)
-              .leftJoin(decisions, eq(docComments.decisionId, decisions.id))
-              .leftJoin(tasks, eq(docComments.taskId, tasks.id))
-              .where(
-                // Any comment attached (directly or via decision/task) to this doc.
-                // We just want to eyeball account_id on all of them.
-                eq(decisions.docId, doc.id),
-              )
-          ).map((r) => r.id),
-        ),
-      );
-    // Coarse check: all comments that reference this doc via decision are in B.
-    expect(commentRows.every((c) => c.memexId === accountB)).toBe(true);
-  });
-});
+      .where(inArray(docComments.id, [secComment.id, decComment.id, taskComment.id]));
+    expect(commentRows).toHaveLength(3);
+    expect(commentRows.every((c) => c.memexId === memexB)).toBe(true);
 
-describe("moveDoc — selective flags leave orphans", () => {
-  it("includeDecisions=false leaves decisions + decision-comments in the source account", async () => {
-    const doc = await createDocDraft(accountA, "Leave Decisions", "Purpose");
-    const dec = await createDecision(accountA, doc.id, "Stay behind");
-    await addDecisionComment(accountA, dec.id, "u", "dec stays");
-
-    await moveDoc(accountA, doc.id, accountB, userId, {
-      includeDecisions: false,
-      includeTasks: true,
-      includeSectionComments: true,
-    });
-
-    const decRow = await db.query.decisions.findFirst({ where: eq(decisions.id, dec.id) });
-    expect(decRow?.memexId).toBe(accountA);
-
-    const comment = await db.query.docComments.findFirst({
-      where: eq(docComments.decisionId, dec.id),
-    });
-    expect(comment?.memexId).toBe(accountA);
-  });
-
-  it("includeTasks=false leaves tasks + task-comments in the source account", async () => {
-    const doc = await createDocDraft(accountA, "Leave Tasks", "Purpose");
-    const task = await createTask(accountA, doc.id, "Stay", "");
-    await addTaskComment(accountA, task.id, "u", "task stays");
-
-    await moveDoc(accountA, doc.id, accountB, userId, {
-      includeDecisions: true,
-      includeTasks: false,
-      includeSectionComments: true,
-    });
-
-    const taskRow = await db.query.tasks.findFirst({ where: eq(tasks.id, task.id) });
-    expect(taskRow?.memexId).toBe(accountA);
-    const comment = await db.query.docComments.findFirst({
-      where: eq(docComments.taskId, task.id),
-    });
-    expect(comment?.memexId).toBe(accountA);
-  });
-
-  it("includeSectionComments=false leaves section-comments in the source account", async () => {
-    const doc = await createDocDraft(accountA, "Leave Comments", "Purpose");
-    const section = doc.sections[0];
-    const added = await addComment(accountA, section.id, "u", "sec stays");
-
-    await moveDoc(accountA, doc.id, accountB, userId, {
-      includeDecisions: true,
-      includeTasks: true,
-      includeSectionComments: false,
-    });
-
-    const comment = await db.query.docComments.findFirst({ where: eq(docComments.id, added.id) });
-    expect(comment?.memexId).toBe(accountA);
-  });
-});
-
-describe("moveDoc — cross-account deps are pruned", () => {
-  it("deletes decision_deps when the task moves but the decision doesn't", async () => {
-    const doc = await createDocDraft(accountA, "Dep Pruning Dec", "Purpose");
-    const dec = await createDecision(accountA, doc.id, "Blocker");
-    const task = await createTask(accountA, doc.id, "Blocked", "");
-    await addDecisionDep(accountA, task.id, dec.id);
-
-    // Move doc + tasks but leave decisions behind → decision_deps now cross accounts.
-    const result = await moveDoc(accountA, doc.id, accountB, userId, {
-      includeDecisions: false,
-      includeTasks: true,
-      includeSectionComments: true,
-    });
-
-    expect(result.removedDecisionDeps).toBeGreaterThanOrEqual(1);
-    const deps = await db
+    // ac-11: the read-state row stays in A (not Spec content).
+    const [view] = await db
       .select()
-      .from(decisionDeps)
-      .where(and(eq(decisionDeps.taskId, task.id), eq(decisionDeps.decisionId, dec.id)));
-    expect(deps.length).toBe(0);
+      .from(qaReportViews)
+      .where(eq(qaReportViews.userId, userId));
+    expect(view.memexId).toBe(memexA);
   });
 
-  it("deletes task_deps that straddle memexes after a partial move", async () => {
-    const doc = await createDocDraft(accountA, "Dep Pruning Task", "Purpose");
-    const t1 = await createTask(accountA, doc.id, "A", "");
-    const t2 = await createTask(accountA, doc.id, "B", "");
-    await addTaskDep(accountA, t1.id, t2.id);
-
-    // Sanity precondition — the dep exists.
-    const before = await db.select().from(taskDeps).where(eq(taskDeps.taskId, t1.id));
-    expect(before.length).toBe(1);
-
-    // Move t2 over to B manually by simulating a previous "partial" move wouldn't really
-    // happen via our API — but we want to prove the DELETE query kicks in when memexes
-    // diverge. So: move the doc WITH tasks to B, then flip t2 back to A manually to
-    // construct a cross-account state, then re-run a no-op move (doc already in B, so we
-    // just directly run the DELETE query via a hand-wired ad-hoc move won't apply).
-    //
-    // Simpler: move the doc WITH decisions only, leaving tasks in A. The doc now lives in
-    // B while both tasks + their dep stay in A — that's intra-account, not cross, so no
-    // prune expected. That doesn't test what I want.
-    //
-    // Actually to get cross-account task_deps we can: move the doc with tasks=true; the
-    // dep rows follow implicitly because they're just (taskId, dependsOnId) with no
-    // account_id. So they never straddle. The straddle case only arises if someone wires
-    // a dep across docs that live in different memexes — not a scenario we build here.
-    //
-    // Keep this as a no-prune assertion: dep survives when both tasks move together.
-    await moveDoc(accountA, doc.id, accountB, userId, {
-      includeDecisions: true,
-      includeTasks: true,
-      includeSectionComments: true,
-    });
-    const after = await db.select().from(taskDeps).where(eq(taskDeps.taskId, t1.id));
-    expect(after.length).toBe(1);
-  });
-});
-
-describe("moveDoc — share tokens revoked", () => {
-  it("marks active share tokens revoked on move", async () => {
-    const doc = await createDocDraft(accountA, "Share Revoke", "Purpose");
-    const token = await createShareToken(accountA, doc.id);
+  it("ac-2: active share tokens are revoked on move", async () => {
+    tagAc(ac(2));
+    const doc = await createDocDraft(memexA, "Share Revoke", "Purpose");
+    const token = await createShareToken(memexA, doc.id);
     expect(token.revoked).toBe(false);
 
-    const result = await moveDoc(accountA, doc.id, accountB, userId, {
-      includeDecisions: true,
-      includeTasks: true,
-      includeSectionComments: true,
-    });
+    const result = await moveDoc(memexA, doc.id, memexB, ctxFor(userId));
     expect(result.revokedShareTokens).toBe(1);
 
     const reread = await db.query.shareTokens.findFirst({ where: eq(shareTokens.id, token.id) });
@@ -261,81 +173,160 @@ describe("moveDoc — share tokens revoked", () => {
   });
 });
 
-describe("moveDoc — reversibility (orphans re-attach)", () => {
-  it("moving back to the source restores orphaned children", async () => {
-    const doc = await createDocDraft(accountA, "Round Trip", "Purpose");
-    const dec = await createDecision(accountA, doc.id, "Sticks");
+describe("moveDoc — attribution (dec-5 / std-32)", () => {
+  it("ac-16: both emitted events carry channel='rest_ui' and the actor", async () => {
+    tagAc(ac(16));
+    tagAc(ac(6)); // scope: move writes are attributed (channel + actor), never empty ctx
+    const doc = await createDocDraft(memexA, "Attributed Move", "Purpose");
 
-    // A → B, leaving decisions behind.
-    await moveDoc(accountA, doc.id, accountB, userId, {
-      includeDecisions: false,
-      includeTasks: true,
-      includeSectionComments: true,
+    const seen: { memexId: string; channel?: string; actorUserId?: string }[] = [];
+    const unsubscribe = bus.subscribe({}, (event) => {
+      if (
+        event.entity === "document" &&
+        (event.memexId === memexA || event.memexId === memexB)
+      ) {
+        seen.push({
+          memexId: event.memexId,
+          channel: event.channel,
+          actorUserId: event.actorUserId,
+        });
+      }
     });
+    try {
+      await moveDoc(memexA, doc.id, memexB, ctxFor(userId));
+    } finally {
+      unsubscribe();
+    }
 
-    // While doc lives in B, the orphan decision shouldn't show up via B's listDocs flow.
-    const decStillInA = await db.query.decisions.findFirst({ where: eq(decisions.id, dec.id) });
-    expect(decStillInA?.memexId).toBe(accountA);
-
-    // B → A moves the doc back. The orphan decision is still in A, so it re-attaches by
-    // virtue of (doc.memexId == dec.memexId) returning true.
-    await moveDoc(accountB, doc.id, accountA, userId, {
-      includeDecisions: true,
-      includeTasks: true,
-      includeSectionComments: true,
-    });
-
-    const restored = await db.query.decisions.findFirst({ where: eq(decisions.id, dec.id) });
-    expect(restored?.memexId).toBe(accountA);
-
-    // listDocs in A now includes the doc again.
-    const list = await listDocs(accountA);
-    expect(list.some((d) => d.id === doc.id)).toBe(true);
+    const source = seen.find((e) => e.memexId === memexA);
+    const target = seen.find((e) => e.memexId === memexB);
+    expect(source, `expected source emit; saw ${JSON.stringify(seen)}`).toBeDefined();
+    expect(target, `expected target emit; saw ${JSON.stringify(seen)}`).toBeDefined();
+    for (const e of [source!, target!]) {
+      expect(e.channel).toBe("rest_ui");
+      expect(e.actorUserId).toBe(userId);
+    }
   });
 });
 
-describe("moveDoc — errors", () => {
-  it("rejects same-account moves", async () => {
-    const doc = await createDocDraft(accountA, "Same Account", "Purpose");
-    await expect(
-      moveDoc(accountA, doc.id, accountA, userId, {
-        includeDecisions: true,
-        includeTasks: true,
-        includeSectionComments: true,
-      }),
-    ).rejects.toThrow(ValidationError);
+describe("moveDoc — errors (std-7)", () => {
+  it("rejects same-memex moves", async () => {
+    const doc = await createDocDraft(memexA, "Same Memex", "Purpose");
+    await expect(moveDoc(memexA, doc.id, memexA, ctxFor(userId))).rejects.toThrow(ValidationError);
   });
 
-  it("404s when the doc isn't in the source account", async () => {
-    const doc = await createDocDraft(accountA, "Wrong Source", "Purpose");
-    await expect(
-      moveDoc(accountB, doc.id, accountA, userId, {
-        includeDecisions: true,
-        includeTasks: true,
-        includeSectionComments: true,
-      }),
-    ).rejects.toThrow(NotFoundError);
+  it("404s when the doc isn't in the source memex", async () => {
+    const doc = await createDocDraft(memexA, "Wrong Source", "Purpose");
+    await expect(moveDoc(memexB, doc.id, memexA, ctxFor(userId))).rejects.toThrow(NotFoundError);
   });
 
-  it("403s when the user isn't an active member of the target", async () => {
-    const doc = await createDocDraft(accountA, "Forbidden Target", "Purpose");
-    await expect(
-      moveDoc(accountA, doc.id, accountC, userId, {
-        includeDecisions: true,
-        includeTasks: true,
-        includeSectionComments: true,
-      }),
-    ).rejects.toThrow(ForbiddenError);
+  it("ac-9: 404s (not 403) when the caller isn't authorized in the target", async () => {
+    tagAc(ac(9));
+    const doc = await createDocDraft(memexA, "Forbidden Target", "Purpose");
+    // memexC: the user is NOT a member. std-7 → 404, never 403.
+    await expect(moveDoc(memexA, doc.id, memexC, ctxFor(userId))).rejects.toThrow(NotFoundError);
+    // The doc must NOT have moved.
+    const [row] = await db.select().from(documents).where(eq(documents.id, doc.id));
+    expect(row.memexId).toBe(memexA);
   });
 
-  it("403s when a non-member tries to move", async () => {
-    const doc = await createDocDraft(accountA, "Non Member", "Purpose");
-    await expect(
-      moveDoc(accountA, doc.id, accountB, outsiderUserId, {
-        includeDecisions: true,
-        includeTasks: true,
-        includeSectionComments: true,
-      }),
-    ).rejects.toThrow(ForbiddenError);
+  it("ac-9: 404s when a non-member tries to move", async () => {
+    tagAc(ac(9));
+    const doc = await createDocDraft(memexA, "Non Member", "Purpose");
+    await expect(moveDoc(memexA, doc.id, memexB, ctxFor(outsiderUserId))).rejects.toThrow(
+      NotFoundError,
+    );
+  });
+});
+
+// The regression anchor: prove the move works under the PROD runtime posture.
+// The whole suite + local dev connect as the table OWNER (RLS-exempt under
+// NO FORCE, std-36), so the original bug never reproduced. Here we drop into the
+// non-owner `memex_app` role (NOBYPASSRLS, the Cloud Run runtime) and show:
+//   (a) the naive cross-tenant UPDATE is rejected by the memex_isolation
+//       WITH CHECK — this IS the prod-only 500 (ac-1's failure mode), and
+//   (b) move_doc() (SECURITY DEFINER, owner-owned) succeeds where it cannot.
+describe("moveDoc — cross-tenant RLS regression (NOBYPASSRLS runtime role)", () => {
+  it("ac-1/ac-7: naive UPDATE is RLS-rejected; move_doc() succeeds under memex_app", async () => {
+    tagAc(ac(1));
+    tagAc(ac(7));
+    tagAc(ac(5)); // scope: the test that would have caught the prod bug exists & runs
+
+    const dbUrl =
+      process.env.DATABASE_URL ?? "postgresql://postgres:postgres@localhost:5432/memex";
+    const appSql = postgres(dbUrl, { max: 1 });
+    try {
+      // (a) The bug: as memex_app, scoped to A, re-pointing memex_id → B trips
+      // the WITH CHECK. This is exactly what 500'd on prod before this Spec.
+      const naive = await createDocDraft(memexA, "RLS Naive", "Purpose");
+      await expect(
+        appSql.begin(async (tx) => {
+          await tx.unsafe("SET LOCAL ROLE memex_app");
+          await tx.unsafe("SELECT set_config('app.memex_id', $1, true)", [memexA]);
+          return tx.unsafe("UPDATE documents SET memex_id = $1 WHERE id = $2", [memexB, naive.id]);
+        }),
+      ).rejects.toThrow();
+
+      // It did not move.
+      const [stillA] = await db.select().from(documents).where(eq(documents.id, naive.id));
+      expect(stillA.memexId).toBe(memexA);
+
+      // (b) The fix: the SECURITY DEFINER function moves it cleanly under the
+      // very same restricted role.
+      const moved = await createDocDraft(memexA, "RLS Via Function", "Purpose");
+      const rows = (await appSql.begin(async (tx) => {
+        await tx.unsafe("SET LOCAL ROLE memex_app");
+        await tx.unsafe("SELECT set_config('app.memex_id', $1, true)", [memexA]);
+        return tx.unsafe(
+          "SELECT new_handle FROM move_doc($1::uuid, $2::uuid, $3::uuid, $4::uuid)",
+          [moved.id, memexA, memexB, userId],
+        );
+      })) as unknown as Array<{ new_handle: string }>;
+
+      expect(rows[0]?.new_handle).toMatch(/^spec-\d+$/);
+      const [nowB] = await db.select().from(documents).where(eq(documents.id, moved.id));
+      expect(nowB.memexId).toBe(memexB);
+    } finally {
+      await appSql.end({ timeout: 5 });
+    }
+  });
+
+  it("ac-8: move_doc is SECURITY DEFINER, owned by the documents table owner, and memex_app holds only EXECUTE", async () => {
+    tagAc(ac(8));
+
+    // SECURITY DEFINER + owner == the owner of `documents` (the role RLS exempts
+    // under NO FORCE). Comparing to documents' owner avoids hardcoding 'postgres'.
+    const [meta] = (await db.execute(sql`
+      SELECT p.prosecdef AS security_definer,
+             pg_get_userbyid(p.proowner) AS fn_owner,
+             pg_get_userbyid(c.relowner) AS table_owner
+        FROM pg_proc p
+        JOIN pg_namespace n ON n.oid = p.pronamespace
+        CROSS JOIN pg_class c
+        JOIN pg_namespace cn ON cn.oid = c.relnamespace
+       WHERE p.proname = 'move_doc' AND n.nspname = 'public'
+         AND c.relname = 'documents' AND cn.nspname = 'public'
+    `)) as unknown as Array<{ security_definer: boolean; fn_owner: string; table_owner: string }>;
+    expect(meta.security_definer).toBe(true);
+    expect(meta.fn_owner).toBe(meta.table_owner);
+
+    // memex_app may EXECUTE move_doc…
+    const [priv] = (await db.execute(sql`
+      SELECT has_function_privilege('memex_app', 'move_doc(uuid,uuid,uuid,uuid)', 'EXECUTE') AS app_execute,
+             has_function_privilege('public',    'move_doc(uuid,uuid,uuid,uuid)', 'EXECUTE') AS public_execute,
+             (SELECT rolbypassrls FROM pg_roles WHERE rolname = 'memex_app') AS app_bypassrls,
+             (SELECT rolsuper      FROM pg_roles WHERE rolname = 'memex_app') AS app_super
+    `)) as unknown as Array<{
+      app_execute: boolean;
+      public_execute: boolean;
+      app_bypassrls: boolean;
+      app_super: boolean;
+    }>;
+    expect(priv.app_execute).toBe(true);
+    // …and gains no general cross-tenant power: PUBLIC can't call it, and the
+    // runtime role neither bypasses RLS nor is a superuser.
+    expect(priv.public_execute).toBe(false);
+    expect(priv.app_bypassrls).toBe(false);
+    expect(priv.app_super).toBe(false);
   });
 });

--- a/packages/server/src/services/doc-move.ts
+++ b/packages/server/src/services/doc-move.ts
@@ -1,23 +1,12 @@
-import { and, eq, sql } from "drizzle-orm";
+import { sql } from "drizzle-orm";
 import { db } from "../db/connection.js";
-import {
-  documents,
-  docSections,
-  docComments,
-  decisions,
-  tasks,
-  shareTokens,
-  orgMemberships,
-  memexes,
-  namespaces,
-} from "../db/schema.js";
-import type { Doc } from "../db/schema.js";
 import { NotFoundError, ValidationError } from "../types/errors.js";
-import { mutate, type Mutated } from "./mutate.js";
-import { nextSpecHandle, nextDocHandle } from "./documents.js";
-import { withSeqRetry } from "./shared/sequence.js";
+import { mutate, type Mutated, type RequestCtx } from "./mutate.js";
 
-// Error surfaced when the caller isn't a member of the target memex.
+// Retained for backward compatibility with existing importers. The cross-tenant
+// authorization failure is now raised inside the move_doc() DB function as
+// SQLSTATE 'MX002' and surfaced as a 404 per std-7 (unauthorized → 404, never
+// 403) — see moveDoc()'s catch below. No code path throws this anymore.
 export class ForbiddenError extends Error {
   constructor(message: string) {
     super(message);
@@ -25,218 +14,104 @@ export class ForbiddenError extends Error {
   }
 }
 
-export interface MoveDocOptions {
-  includeDecisions: boolean;
-  includeTasks: boolean;
-  includeSectionComments: boolean;
-}
-
 export interface MoveDocResult {
-  doc: Doc;
+  docId: string;
   fromMemexId: string;
   toMemexId: string;
   newHandle: string;
-  // Counts of dep rows that were deleted because they straddled two accounts after the move.
+  // Counts of dep rows deleted because they straddled two memexes after the move.
   removedDecisionDeps: number;
   removedTaskDeps: number;
-  // Count of share tokens revoked on move (public URLs are subdomain-scoped by convention,
-  // so they'd effectively stop working anyway once the doc leaves the source subdomain).
+  // Count of share tokens revoked on move.
   revokedShareTokens: number;
 }
 
-// Moves a Spec from one memex to another. The doc's UUID is preserved so anything
-// FK-linked (sections, decisions, tasks, comments, conversations, share tokens) stays
-// attached — the user chooses via opts whether children also change their account scope.
+interface MoveDocRow {
+  new_handle: string;
+  revoked_share_tokens: number;
+  removed_decision_deps: number;
+  removed_task_deps: number;
+}
+
+// Moves a Spec from one Memex to another, whole (spec-293 dec-2/dec-3): the doc
+// and every doc-scoped artifact (sections, all comments, decisions, tasks, ACs,
+// test events, issues, members, assignees, tags, conversations, clause refs)
+// travel together. The doc's UUID is preserved; its handle is re-minted in the
+// target.
 //
-// Children whose memex_id is not updated remain "orphaned" in the source memex: they
-// still FK to the moved doc, so if the doc is moved back later they re-appear.
-//
-// Semantic rules that aren't configurable:
-//   - Sections always follow the doc (they don't carry memex_id — scoped via doc_id).
-//   - Decision-comments follow their decisions; task-comments follow their tasks. Only
-//     section-comments have an independent checkbox (includeSectionComments).
-//   - Any decision/task dep edges whose endpoints end up in different accounts are
-//     deleted after the move (silent per product decision). Counts are returned so the
-//     UI can surface a toast.
-//   - All share tokens for the doc are revoked on move.
+// The row-touching work lives in the SECURITY DEFINER `move_doc` DB function
+// (migration 0094): the move re-points memex_id ACROSS the RLS tenant wall, which
+// the runtime `memex_app` role cannot do directly (the memex_isolation WITH CHECK
+// rejects it — the prod-only 500 this Spec fixes). The function executes as the
+// table owner, so its writes bypass RLS for this one sanctioned, audited op;
+// `memex_app` holds only EXECUTE on it (std-36, dec-1). This wrapper keeps the
+// request-side concerns: validation, attribution (RequestCtx → mutate), and the
+// cross-tenant bus emission on BOTH memexes.
 export async function moveDoc(
   fromMemexId: string,
   docId: string,
   toMemexId: string,
-  userId: string,
-  opts: MoveDocOptions,
+  ctx: RequestCtx,
 ): Promise<Mutated<MoveDocResult>> {
   if (fromMemexId === toMemexId) {
     throw new ValidationError("Source and target memex must differ");
   }
+  const userId = ctx.actorUserId;
+  if (!userId) {
+    // A move is an authorization-bearing operation; we must know WHO is moving.
+    throw new ValidationError("A resolved user is required to move a Spec");
+  }
 
-  // Cross-tenant emit: notify both the source and target memex so list views in
-  // either tenant refetch. mutate() runs the transaction once and emits both
-  // events on success (the two keys are independent invariants per dec-2).
+  // Cross-tenant emit: notify BOTH the source and target memex so list views in
+  // either tenant refetch (dec-2 of the reactivity contract). mutate() runs fn
+  // once and, on success, emits one 'document updated' event per key, now carrying
+  // the channel + actor from ctx (spec-293 dec-5 / std-32).
   return mutate(
-    {},
+    ctx,
     [
       { memexId: fromMemexId, docId, entity: "document", action: "updated" },
       { memexId: toMemexId, docId, entity: "document", action: "updated" },
     ],
     async () => {
-  // spec-187: the handle re-mint inside this tx is the racy MAX+1 read — a
-  // concurrent create/move into the target memex can collide on
-  // `documents_memex_id_handle_unique`. The tx is pure-DB, so retrying it
-  // wholesale re-mints cleanly (same shape as createDocDraft's wrap).
-  const result = await withSeqRetry(() => db.transaction(async (tx) => {
-    // Lock the row so concurrent writes (agent/MCP/REST) serialize against the move.
-    const [doc] = await tx
-      .select()
-      .from(documents)
-      .where(and(eq(documents.id, docId), eq(documents.memexId, fromMemexId)))
-      .for("update");
+      let rows: MoveDocRow[];
+      try {
+        rows = (await db.execute(sql`
+          SELECT new_handle, revoked_share_tokens, removed_decision_deps, removed_task_deps
+            FROM move_doc(${docId}::uuid, ${fromMemexId}::uuid, ${toMemexId}::uuid, ${userId}::uuid)
+        `)) as unknown as MoveDocRow[];
+      } catch (err) {
+        // Translate the function's domain SQLSTATEs into HTTP-shaped errors.
+        // Drizzle wraps driver errors (DrizzleQueryError) with the PostgresError
+        // on `.cause`, so check both the error and its cause for the SQLSTATE.
+        const code =
+          (err as { code?: string } | null)?.code ??
+          ((err as { cause?: { code?: string } } | null)?.cause?.code);
+        if (code === "MX001" || code === "MX002") {
+          // Doc not found in source, or caller not authorized in source/target.
+          // std-7: unauthorized → 404, never 403 (don't leak existence).
+          throw new NotFoundError("Document not found");
+        }
+        if (code === "MX003") {
+          throw new ValidationError("Source and target memex must differ");
+        }
+        throw err;
+      }
 
-    if (!doc) {
-      throw new NotFoundError(`Document ${docId} not found`);
-    }
+      const row = rows[0];
+      if (!row) {
+        // move_doc always RETURN NEXTs exactly one row on success.
+        throw new NotFoundError("Document not found");
+      }
 
-    // Caller must be allowed to write to the target memex: either they own its
-    // namespace (personal memex) or have an active org_membership in the org that
-    // owns its namespace.
-    const targetMemex = await tx.query.memexes.findFirst({
-      where: eq(memexes.id, toMemexId),
-    });
-    if (!targetMemex) {
-      throw new NotFoundError(`Memex ${toMemexId} not found`);
-    }
-    const targetNs = await tx.query.namespaces.findFirst({
-      where: eq(namespaces.id, targetMemex.namespaceId),
-    });
-    let allowed = false;
-    if (targetNs?.kind === "user" && targetNs.ownerUserId === userId) {
-      allowed = true;
-    } else if (targetNs?.kind === "org" && targetNs.ownerOrgId) {
-      const membership = await tx.query.orgMemberships.findFirst({
-        where: and(
-          eq(orgMemberships.userId, userId),
-          eq(orgMemberships.orgId, targetNs.ownerOrgId),
-          eq(orgMemberships.status, "active"),
-        ),
-      });
-      if (membership) allowed = true;
-    }
-    if (!allowed) {
-      throw new ForbiddenError("You are not a member of the target Memex");
-    }
-
-    // Per doc-30 dec-1 + dec-3: specs get a `spec-N` handle on move; everything
-    // else (free-form documents, execution-plans, legacy docTypes) keeps `doc-N`.
-    const newHandle = doc.docType === "spec"
-      ? await nextSpecHandle(toMemexId, tx)
-      : await nextDocHandle(toMemexId, tx);
-
-    const [updatedDoc] = await tx
-      .update(documents)
-      .set({ memexId: toMemexId, handle: newHandle })
-      .where(eq(documents.id, docId))
-      .returning();
-
-    // Sections have no memex_id — they follow the doc via doc_id FK.
-
-    // Section comments: move iff includeSectionComments. Resolved via doc_sections ⇒ doc.
-    if (opts.includeSectionComments) {
-      await tx.execute(sql`
-        UPDATE doc_comments
-           SET memex_id = ${toMemexId}
-         WHERE section_id IN (SELECT id FROM doc_sections WHERE doc_id = ${docId})
-      `);
-    }
-
-    // Decisions + their comments travel as a unit. If includeDecisions=false, both stay
-    // behind with memex_id = fromMemexId and orphan in the source.
-    if (opts.includeDecisions) {
-      await tx
-        .update(decisions)
-        .set({ memexId: toMemexId })
-        .where(eq(decisions.docId, docId));
-
-      await tx.execute(sql`
-        UPDATE doc_comments
-           SET memex_id = ${toMemexId}
-         WHERE decision_id IN (SELECT id FROM decisions WHERE doc_id = ${docId})
-      `);
-    }
-
-    // Tasks + their comments travel as a unit (same logic). includeTasks keeps its
-    // legacy name on the option since it's the user-visible "Tasks" checkbox.
-    if (opts.includeTasks) {
-      await tx
-        .update(tasks)
-        .set({ memexId: toMemexId })
-        .where(eq(tasks.docId, docId));
-
-      await tx.execute(sql`
-        UPDATE doc_comments
-           SET memex_id = ${toMemexId}
-         WHERE task_id IN (SELECT id FROM tasks WHERE doc_id = ${docId})
-      `);
-    }
-
-    // After the ownership updates, any dep row that now straddles two accounts is
-    // structurally invalid (the blocking/blocked entities live in different memexes and
-    // the blocked user can no longer see the blocker). Silent-delete per product decision;
-    // return the count so the UI can surface a toast.
-    //
-    // Note: cross-account is the structural guard here even though dec-11 dropped the
-    // intra-doc constraint. Cross-doc is fine; cross-account isn't.
-    //
-    // Using `RETURNING 1` and counting the result array avoids relying on driver-specific
-    // rowCount shape (postgres-js via Drizzle returns the rows, not a pg-style result).
-    const decisionDepResult = (await tx.execute(sql`
-      DELETE FROM decision_deps dd
-       USING tasks w, decisions d
-       WHERE dd.task_id = w.id
-         AND dd.decision_id = d.id
-         AND w.memex_id <> d.memex_id
-         AND (w.doc_id = ${docId} OR d.doc_id = ${docId})
-      RETURNING 1
-    `)) as unknown as unknown[];
-
-    const taskDepResult = (await tx.execute(sql`
-      DELETE FROM task_deps wd
-       USING tasks w1, tasks w2
-       WHERE wd.task_id = w1.id
-         AND wd.depends_on_id = w2.id
-         AND w1.memex_id <> w2.memex_id
-         AND (w1.doc_id = ${docId} OR w2.doc_id = ${docId})
-      RETURNING 1
-    `)) as unknown as unknown[];
-
-    // Revoke all active share tokens for the doc. Public share URLs are served from the
-    // source subdomain and would stop resolving after the move; mark them revoked to make
-    // the state explicit (and audit-friendly) rather than silently broken.
-    const revokeResult = (await tx.execute(sql`
-      UPDATE share_tokens
-         SET revoked = TRUE
-       WHERE document_id = ${docId}
-         AND revoked = FALSE
-      RETURNING 1
-    `)) as unknown as unknown[];
-
-    return {
-      doc: updatedDoc,
-      newHandle,
-      removedDecisionDeps: decisionDepResult.length,
-      removedTaskDeps: taskDepResult.length,
-      revokedShareTokens: revokeResult.length,
-    };
-  }), "documents_memex_id_handle_unique");
-
-  return {
-    doc: result.doc,
-    fromMemexId,
-    toMemexId,
-    newHandle: result.newHandle,
-    removedDecisionDeps: result.removedDecisionDeps,
-    removedTaskDeps: result.removedTaskDeps,
-    revokedShareTokens: result.revokedShareTokens,
-  };
+      return {
+        docId,
+        fromMemexId,
+        toMemexId,
+        newHandle: row.new_handle,
+        removedDecisionDeps: Number(row.removed_decision_deps),
+        removedTaskDeps: Number(row.removed_task_deps),
+        revokedShareTokens: Number(row.revoked_share_tokens),
+      };
     },
   );
 }

--- a/packages/ui/e2e/journey-33-spec-293-move-spec.spec.ts
+++ b/packages/ui/e2e/journey-33-spec-293-move-spec.spec.ts
@@ -1,0 +1,90 @@
+import { test, expect, ensureUser, tenantPath, DEV_EMAIL, emitAcEvents, type TestResources } from "./helpers/index.js";
+import { seedOrgTenant, seedSpec, type SeededOrgTenant } from "./helpers/retained.js";
+import type { Page } from "@playwright/test";
+
+// Journey 33 — spec-293: move a Spec between two Memexes.
+//
+// The end-to-end proof of the fix: dev owns two org Memexes; we seed a Spec in
+// the first, open the redesigned Move dialog (dec-2/dec-3: whole-Spec move, no
+// per-artifact checkboxes, "Comments" not "Section comments"), pick the second
+// Memex, and confirm the Spec lands there at its new handle. All seeding goes
+// through the env-gated test surface (real services → bus, std-8); navigation is
+// path-based (std-2).
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-293/acs/ac-${n}`;
+
+const ACS_BY_TITLE: Record<string, string[]> = {
+  "the Move dialog moves the whole Spec to another Memex": [AC(1), AC(2), AC(13)],
+};
+
+test.afterEach(async ({}, testInfo) => {
+  if (testInfo.status === "skipped") return;
+  const refs = ACS_BY_TITLE[testInfo.title];
+  if (!refs) return;
+  await emitAcEvents(
+    refs,
+    testInfo.status === "passed" ? "pass" : "fail",
+    `packages/ui/e2e/journey-33-spec-293-move-spec.spec.ts::${testInfo.title}`,
+    testInfo.duration,
+  );
+});
+
+interface MoveSeed {
+  source: SeededOrgTenant;
+  target: SeededOrgTenant;
+  docId: string;
+  title: string;
+}
+
+const test2 = test.extend<{ seed: MoveSeed }>({
+  seed: async ({ resources }: { resources: TestResources }, use) => {
+    await ensureUser(DEV_EMAIL);
+    // Two org Memexes the dev user owns → both are valid move destinations.
+    const source = await seedOrgTenant({ slug: resources.slug("j33-src") });
+    const target = await seedOrgTenant({ slug: resources.slug("j33-dst") });
+    const title = `Movable Spec ${resources.slug("j33")}`;
+    const { docId } = await seedSpec({ memexId: source.memexId, title });
+    await use({ source, target, docId, title });
+  },
+});
+
+async function gotoSpec(page: Page, seed: MoveSeed): Promise<void> {
+  await page.goto(tenantPath(seed.source.namespaceSlug, seed.source.memexSlug, `/docs/${seed.docId}`));
+  await expect(page.getByRole("heading", { name: seed.title, level: 1 })).toBeVisible({
+    timeout: 15_000,
+  });
+}
+
+test2.describe("spec-293 — Move spec between Memexes", () => {
+  test2("the Move dialog moves the whole Spec to another Memex", async ({ page, seed }) => {
+    await gotoSpec(page, seed);
+
+    // Open the spec actions menu → Move.
+    await page.getByRole("button", { name: `Actions for ${seed.title}` }).click();
+    await page.getByRole("menuitem", { name: "Move to another memex" }).click();
+
+    // The redesigned dialog (dec-2/dec-3): a read-only "what moves" summary,
+    // no per-artifact opt-out checkboxes, and "Comments" — never "Section comments".
+    // Scope every assertion to the dialog: the spec page behind it also has a
+    // "Comments" tab, so page-wide text locators are ambiguous.
+    const dialog = page.getByTestId("move-spec-dialog");
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toContainText(/What moves/i);
+    await expect(dialog.locator('input[type="checkbox"]')).toHaveCount(0);
+    await expect(dialog).toContainText("Comments");
+    await expect(dialog).not.toContainText(/Section comments/i);
+
+    // Pick the target Memex and move.
+    await dialog.getByRole("combobox").selectOption(seed.target.memexId);
+    await dialog.getByRole("button", { name: /^Move$/ }).click();
+
+    // We land on the moved Spec in the TARGET Memex, at its new handle.
+    await page.waitForURL(
+      new RegExp(`/${seed.target.namespaceSlug}/${seed.target.memexSlug}/specs/spec-\\d+`),
+      { timeout: 20_000 },
+    );
+    await expect(page.getByRole("heading", { name: seed.title, level: 1 })).toBeVisible({
+      timeout: 15_000,
+    });
+  });
+});

--- a/packages/ui/src/api/client.ts
+++ b/packages/ui/src/api/client.ts
@@ -411,15 +411,13 @@ export async function stampGreeting(): Promise<void> {
   if (!res.ok) throw new Error(`Failed to stamp greeting: ${res.status}`);
 }
 
+// spec-293 dec-2/dec-3: a move is always whole — no per-artifact opt-out flags.
 export interface MoveDocInput {
   targetMemexId: string;
-  includeDecisions: boolean;
-  includeTasks: boolean;
-  includeSectionComments: boolean;
 }
 
 export interface MoveDocResponse {
-  doc: { id: string; handle: string; memexId: string; title: string };
+  docId: string;
   fromMemexId: string;
   toMemexId: string;
   newHandle: string;

--- a/packages/ui/src/components/MoveSpecDialog.spec-293.test.tsx
+++ b/packages/ui/src/components/MoveSpecDialog.spec-293.test.tsx
@@ -1,0 +1,97 @@
+// spec-293 dec-2/dec-3 (ac-13): the Move-spec dialog no longer offers per-artifact
+// opt-out checkboxes (a Spec moves whole) and refers to "Comments", never
+// "Section comments".
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { tagAc } from '@memex-ai-ac/vitest';
+import type { MembershipSummary, SessionPayload } from '../api/client';
+
+const AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-293/acs/ac-${n}`;
+
+let mockSession: SessionPayload | null = null;
+
+vi.mock('./AuthContext', async () => {
+  const real = await vi.importActual<typeof import('./AuthContext')>('./AuthContext');
+  return {
+    ...real,
+    useAuth: () => ({
+      session: mockSession,
+      user: { name: 'Alice', email: 'alice@example.com', picture: '' },
+      token: 'fake-token',
+      isAuthenticated: true,
+      authError: null,
+      logout: vi.fn(),
+      updateSession: vi.fn(),
+      acceptSession: vi.fn(),
+    }),
+  };
+});
+
+vi.mock('../utils/tenantUrl', async () => {
+  const real = await vi.importActual<typeof import('../utils/tenantUrl')>('../utils/tenantUrl');
+  return {
+    ...real,
+    getCurrentTenant: () => ({ namespace: 'acme', memex: 'memex-one' }),
+  };
+});
+
+import { MoveSpecDialog } from './MoveSpecDialog';
+
+function session(): SessionPayload {
+  const dest: MembershipSummary = {
+    memexId: 'mx-two',
+    slug: 'acme',
+    memexSlug: 'memex-two',
+    name: 'Acme Inc',
+    kind: 'team',
+    role: 'administrator',
+  };
+  return {
+    user: { id: 'u-1', email: 'alice@example.com', name: 'Alice', status: 'active', emailVerified: true },
+    memberships: [
+      { ...dest, memexId: 'mx-one', memexSlug: 'memex-one' },
+      dest,
+    ],
+    currentMemexId: 'mx-one',
+    currentRole: 'administrator',
+    needsOnboarding: false,
+    hiddenFeatures: [],
+  };
+}
+
+describe('MoveSpecDialog whole-move shape (spec-293)', () => {
+  beforeEach(() => {
+    mockSession = session();
+  });
+  afterEach(() => {
+    cleanup();
+    mockSession = null;
+  });
+
+  it('ac-13: renders no opt-out checkboxes and says "Comments", not "Section comments"', () => {
+    tagAc(AC(13));
+    tagAc(AC(3)); // scope: dialog reads "Comments" and treats all comments uniformly
+    render(
+      <MoveSpecDialog
+        docId="doc-1"
+        title="Publish the DB schema"
+        decisionCount={1}
+        taskCount={4}
+        commentCount={2}
+        onClose={() => {}}
+      />,
+    );
+
+    // No per-artifact opt-out checkboxes.
+    expect(screen.queryAllByRole('checkbox')).toHaveLength(0);
+
+    // "Comments" present; "Section comments" gone.
+    expect(screen.getByText(/Comments/)).toBeTruthy();
+    expect(screen.queryByText(/Section comments/i)).toBeNull();
+
+    // The read-only "what moves" summary is shown.
+    expect(screen.getByText(/What moves/i)).toBeTruthy();
+  });
+});

--- a/packages/ui/src/components/MoveSpecDialog.tsx
+++ b/packages/ui/src/components/MoveSpecDialog.tsx
@@ -8,10 +8,10 @@ import { getCurrentTenant, tenantPathFor } from '../utils/tenantUrl';
 interface MoveSpecDialogProps {
   docId: string;
   title: string;
-  // Optional pre-computed counts so the dialog can show what will move.
+  // Optional pre-computed counts so the dialog can show what will travel.
   decisionCount?: number;
   taskCount?: number;
-  sectionCommentCount?: number;
+  commentCount?: number;
   onClose: () => void;
   // Called after a successful move, before the window redirects. Lets the caller clear
   // local state (e.g. remove the card from the kanban) in case the navigation is delayed.
@@ -19,15 +19,15 @@ interface MoveSpecDialogProps {
 }
 
 // Dialog for moving a Spec to a different Memex. Destination is any Memex the user
-// is an active member of besides the current one. Checkboxes let the user leave decisions,
-// tasks, and section-comments behind as orphans in the source Memex; unchecked items stay
-// on their old memex_id and re-attach if the spec is ever moved back.
+// is an active member of besides the current one. spec-293 (dec-2/dec-3): a Spec moves
+// WHOLE — every artifact and ALL comments travel with it — so there are no per-artifact
+// opt-outs; the dialog just shows what will move. Public share links are revoked.
 export function MoveSpecDialog({
   docId,
   title,
   decisionCount,
   taskCount,
-  sectionCommentCount,
+  commentCount,
   onClose,
   onMoved,
 }: MoveSpecDialogProps) {
@@ -61,9 +61,6 @@ export function MoveSpecDialog({
   const [targetMemexId, setTargetMemexId] = useState<string>(
     destinations[0]?.memexId ?? '',
   );
-  const [includeDecisions, setIncludeDecisions] = useState(true);
-  const [includeTasks, setIncludeTasks] = useState(true);
-  const [includeSectionComments, setIncludeSectionComments] = useState(true);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -93,9 +90,6 @@ export function MoveSpecDialog({
     try {
       const result = await moveDocApi(docId, {
         targetMemexId: chosen.memexId,
-        includeDecisions,
-        includeTasks,
-        includeSectionComments,
       });
 
       // Compose a toast-worthy message if deps were pruned or share tokens revoked. We
@@ -142,7 +136,10 @@ export function MoveSpecDialog({
         if (e.target === e.currentTarget && !submitting) onClose();
       }}
     >
-      <div className="w-full max-w-lg rounded-xl border border-edge bg-panel shadow-2xl">
+      <div
+        data-testid="move-spec-dialog"
+        className="w-full max-w-lg rounded-xl border border-edge bg-panel shadow-2xl"
+      >
         <div className="px-6 py-4 border-b border-edge flex items-center justify-between">
           <h2 className="text-base font-semibold text-heading">Move spec</h2>
           <button
@@ -190,37 +187,25 @@ export function MoveSpecDialog({
 
               <div className="space-y-2">
                 <div className="text-xs font-medium uppercase tracking-wider text-muted">
-                  Also move
+                  What moves
                 </div>
-                <CheckboxRow
-                  checked={includeDecisions}
-                  onChange={setIncludeDecisions}
-                  disabled={submitting}
-                  label="Decisions"
-                  hint={typeof decisionCount === 'number' ? `${decisionCount} total` : undefined}
-                />
-                <CheckboxRow
-                  checked={includeTasks}
-                  onChange={setIncludeTasks}
-                  disabled={submitting}
-                  label="Tasks"
-                  hint={typeof taskCount === 'number' ? `${taskCount} total` : undefined}
-                />
-                <CheckboxRow
-                  checked={includeSectionComments}
-                  onChange={setIncludeSectionComments}
-                  disabled={submitting}
-                  label="Section comments"
-                  hint={
-                    typeof sectionCommentCount === 'number'
-                      ? `${sectionCommentCount} unresolved`
-                      : undefined
-                  }
-                />
+                <ul className="text-sm text-secondary space-y-1">
+                  <li>
+                    The whole Spec — its sections, ACs, QA report, issues, members and
+                    assignees.
+                  </li>
+                  <li>
+                    <MovePart label="Decisions" count={decisionCount} />
+                    {', '}
+                    <MovePart label="Tasks" count={taskCount} />
+                    {' and '}
+                    <MovePart label="Comments" count={commentCount} />
+                    {' travel with it.'}
+                  </li>
+                </ul>
                 <p className="text-xs text-muted pt-1">
-                  Unchecked items stay in this memex. They&apos;ll re-attach if the spec is
-                  moved back. Any blocker links between moved and unmoved items are removed.
-                  Public share links are revoked.
+                  The Spec&apos;s handle changes in the destination, and public share links
+                  are revoked.
                 </p>
               </div>
             </>
@@ -252,30 +237,13 @@ export function MoveSpecDialog({
   );
 }
 
-function CheckboxRow({
-  checked,
-  onChange,
-  disabled,
-  label,
-  hint,
-}: {
-  checked: boolean;
-  onChange: (v: boolean) => void;
-  disabled?: boolean;
-  label: string;
-  hint?: string;
-}) {
+// Renders "<count> <label>" when a count is known, else just the label — used in
+// the read-only "what moves" summary.
+function MovePart({ label, count }: { label: string; count?: number }) {
   return (
-    <label className={`flex items-center gap-2 text-sm ${disabled ? 'opacity-60' : ''}`}>
-      <input
-        type="checkbox"
-        checked={checked}
-        onChange={(e) => onChange(e.target.checked)}
-        disabled={disabled}
-        className="h-4 w-4 rounded border-edge bg-input text-accent focus:ring-0 focus:ring-offset-0"
-      />
-      <span className="text-primary">{label}</span>
-      {hint && <span className="text-muted">· {hint}</span>}
-    </label>
+    <span className="text-primary">
+      {typeof count === 'number' ? `${count} ` : ''}
+      {label}
+    </span>
   );
 }

--- a/packages/ui/src/pages/DocDocument.tsx
+++ b/packages/ui/src/pages/DocDocument.tsx
@@ -1272,7 +1272,7 @@ export function DocDocument() {
           title={doc.title}
           decisionCount={decs.length}
           taskCount={ts.length}
-          sectionCommentCount={sectionCommentCount}
+          commentCount={totalCommentCount}
           onClose={() => setMoveOpen(false)}
         />
       )}


### PR DESCRIPTION
## Why

The **Move spec** dialog returns `{"error":"Internal server error"}` on **prod**. Root cause (grounded): moving a Spec re-points `memex_id` across the **per-Memex RLS wall**. The runtime `memex_app` role is NOBYPASSRLS and each request is scoped to one `app.memex_id`, so `UPDATE … SET memex_id = <other tenant>` is rejected by the `memex_isolation` WITH CHECK (migration 0081). It only ever passed locally because dev/tests connect as the table **owner**, which bypasses RLS under NO FORCE (std-36 / 0093). Same-org moves fail too — the wall is per-Memex, not per-Org.

Spec: **spec-293** (`mindset-prod/memex-building-itself`). All 16 ACs verified.

## What changed

**Back end**
- `drizzle/0094_move_doc_function.sql` — `SECURITY DEFINER` `move_doc()` owned by the table owner (so it crosses the RLS wall for this one sanctioned op); `memex_app` gets EXECUTE only (REVOKE FROM PUBLIC). Moves the **whole Spec**: re-points `memex_id` on every doc-scoped table (`documents, standard_clauses, doc_comments, decisions, tasks, acs, issues, doc_members, doc_assignees, document_tags, clause_refs`); sections/conversations/messages/links follow by FK; `test_events` are text-keyed so history follows the AC. Read-state (`qa_report_views, presence, user_memex_access, mcp_tool_calls`) deliberately not moved. Both-Memex auth inside the function (404 per std-7); handle re-minted on collision.
- `services/doc-move.ts` — thin wrapper delegating to `move_doc`, threading a real `RequestCtx` (`channel:'rest_ui'` + actor) into `mutate()` (std-32; was `mutate({}, …)`). `routes/documents.ts` `/move` takes only `targetMemexId`.
- `drizzle/0095_dedupe_personal_memexes.sql` — idempotent, `manual_migrations`-tracked data backfill collapsing duplicate personal Memexes into the `users.namespaceId` canonical (no content loss; reuses `move_doc` per doc).

**Front end**
- `MoveSpecDialog.tsx` — a Spec moves whole, so the per-artifact **checkboxes are gone**; replaced by a read-only "What moves" summary. Says **"Comments"** (never "Section comments").

**Tests** (16/16 ACs verified)
- NOBYPASSRLS **regression anchor** reproducing the prod 500 then proving the fix under `SET LOCAL ROLE memex_app`; whole-move / all-comments / attribution / auth-404 / SECURITY-DEFINER-introspection coverage; dedupe migration test (merge / no-loss / idempotent); dialog test.
- `e2e/journey-33-spec-293-move-spec.spec.ts` — Playwright journey for the full Move flow.

## Verification
- `pnpm --filter @memex/server test` → **4037 passed**, 0 failed.
- `pnpm --filter @memex/ui test` → **1309 passed**, 0 failed.
- e2e journey authored + `playwright --list` validated; **run `make e2e-cold` in CI** (not executed locally).

## Deploy notes (std-17)
- Two hand migrations (0094, 0095) via `db:migrate`. **Ship int-first, green before prod.**
- **0095 mutates prod data** — capture a PITR marker before the prod run (precedent spec-65). Safe to re-run (no-op once every user has ≤1 personal Memex).

🤖 Generated with [Claude Code](https://claude.com/claude-code)