### PR TITLE
Release: develop → main — spec-293 (cross-tenant Spec move + personal-Memex dedupe)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+# Dependabot version updates. Pairs with Dependabot alerts + security updates
+# (already active on this repo) for the dependency-vuln half. The npm ecosystem
+# covers the pnpm workspace; weekly cadence + grouping keeps PR volume manageable.
+#
+# Note std-24: shared libraries are single-versioned across the workspace via
+# pnpm.overrides in the root package.json — when a grouped bump touches one of
+# those families (vitest, @vitest/coverage-v8, @types/node), the override must be
+# updated too or the bump won't take effect. Review those PRs with that in mind.
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      # Batch routine minor/patch bumps into one PR to cut review churn;
+      # security updates still arrive individually + promptly.
+      npm-minor-and-patch:
+        update-types: ["minor", "patch"]
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           sparse-checkout: scripts/canary
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,6 +27,11 @@ concurrency:
   group: codeql-${{ github.ref }}
   cancel-in-progress: true
 
+# Least-privilege default for every job's GITHUB_TOKEN; the analyze job widens it
+# to what CodeQL upload needs. (Flagged by CodeQL's own actions query otherwise.)
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,72 @@
+# CodeQL — advanced setup (replaces GitHub default setup).
+#
+# Why advanced, not default: default setup can't restrict its triggers, so it
+# also ran on push to `main` — too late, since merging develop→main auto-deploys
+# to prod (std-21). This runs on `develop` (push + PRs into it) so the security
+# gate fires at integration, BEFORE work can be promoted to main/prod. The
+# `codeql-result` aggregate is the single required status check (same pattern as
+# test.yml's server-result / e2e-result); require THAT on the develop branch so a
+# CodeQL failure blocks the merge into develop.
+#
+# Languages are pinned to what the repo actually contains (TS/JS, Python, GitHub
+# Actions). Ruby is deliberately absent — default setup had a stale `language:ruby`
+# config that failed with "No Ruby code found"; there is no Ruby in this repo.
+name: CodeQL
+
+on:
+  push:
+    branches: [develop]
+  pull_request:
+    branches: [develop]
+  schedule:
+    # Weekly baseline so alerts stay fresh even without merges.
+    - cron: "27 3 * * 1"
+
+# One run per ref; supersede an in-flight run when a newer commit lands.
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        # All three are interpreted / no-compile, so build-mode: none is correct.
+        language: [actions, javascript-typescript, python]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"
+
+  # Single, stable status context to require on the develop branch — green only
+  # when every language analysis succeeded.
+  codeql-result:
+    needs: [analyze]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail unless all CodeQL analyses succeeded
+        if: needs.analyze.result != 'success'
+        run: |
+          echo "CodeQL analyze result: ${{ needs.analyze.result }}"
+          exit 1
+      - name: All CodeQL analyses green
+        run: echo "CodeQL passed for all languages."

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -48,7 +48,7 @@ jobs:
         language: [actions, javascript-typescript, python]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3

--- a/.github/workflows/db-schema-drift.yml
+++ b/.github/workflows/db-schema-drift.yml
@@ -47,7 +47,7 @@ jobs:
       # MEMEX_EMIT_KEY repo secret; empty until set (harmless pre-enforcement).
       MEMEX_EMIT_KEY: ${{ secrets.MEMEX_EMIT_KEY }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,7 +49,7 @@ jobs:
       ENV: ${{ github.ref_name == 'main' && 'prod' || 'int' }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # No `version:` here — pnpm/action-setup@v4 reads the pinned version from
       # the root package.json `packageManager` field and errors if both are set.
@@ -64,7 +64,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Authenticate to GCP (Workload Identity Federation)
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ vars.GCP_DEPLOYER_SERVICE_ACCOUNT }}

--- a/.github/workflows/guide-content-mindset-website-refresh.yml
+++ b/.github/workflows/guide-content-mindset-website-refresh.yml
@@ -52,7 +52,7 @@ jobs:
       ENV: ${{ github.event.client_payload.env || inputs.env || 'prod' }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: pnpm/action-setup@v4
 
@@ -65,7 +65,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Authenticate to GCP (Workload Identity Federation)
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ vars.GCP_DEPLOYER_SERVICE_ACCOUNT }}

--- a/.github/workflows/guide-content-website-refresh.yml
+++ b/.github/workflows/guide-content-website-refresh.yml
@@ -52,7 +52,7 @@ jobs:
       ENV: ${{ github.event.client_payload.env || inputs.env || 'prod' }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: pnpm/action-setup@v4
 
@@ -65,7 +65,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Authenticate to GCP (Workload Identity Federation)
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ vars.GCP_DEPLOYER_SERVICE_ACCOUNT }}

--- a/.github/workflows/publish-db-schema.yml
+++ b/.github/workflows/publish-db-schema.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -2,16 +2,16 @@
 #
 # Complements CodeQL (codeql.yml): CodeQL is the deep dataflow engine, Semgrep
 # adds fast pattern-based rules (incl. a broad secrets pack) from the public
-# registry. Both gate `develop` — the integration branch — so issues are caught
-# before work is promoted to main/prod (std-21), not after.
+# registry. Gates `develop` so issues are caught before promotion to main/prod.
 #
-# Semgrep runs on source only (no pnpm install needed); --error fails the job on
-# a finding, surfaced in the Actions log.
+# RATCHET, not big-bang: the repo has pre-existing findings (tracked separately).
+# We scan diff-aware against the PR base (--baseline-commit) so the check fails
+# only on findings a PR *introduces* — new security debt is blocked, legacy debt
+# is burned down on its own track without holding every PR hostage. Semgrep runs
+# on source only (no pnpm install needed); findings surface in the Actions log.
 name: Security
 
 on:
-  push:
-    branches: [develop]
   pull_request:
     branches: [develop]
   workflow_dispatch:
@@ -20,7 +20,6 @@ on:
 permissions:
   contents: read
 
-# One run per ref; supersede an in-flight run when a newer commit lands.
 concurrency:
   group: security-${{ github.ref }}
   cancel-in-progress: true
@@ -31,6 +30,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Full history so --baseline-commit can diff against the PR base.
+          fetch-depth: 0
 
       # pipx is preinstalled on GitHub-hosted ubuntu runners; isolates semgrep
       # from system Python (avoids PEP-668 "externally managed" errors).
@@ -39,11 +41,18 @@ jobs:
 
       # Public registry packs for this repo's stack (TS/JS/React/Node + GitHub
       # Actions) plus generic security + secret detection. --error fails on a
-      # finding; --metrics off keeps it offline-friendly. node_modules and
-      # .gitignored paths are skipped automatically; generated/output dirs and
-      # the e2e fixtures are excluded to cut noise.
-      - name: Semgrep scan (gate on findings)
+      # NEW finding (relative to the baseline); --metrics off keeps it offline.
+      # The base SHA goes through an env var, never inline ${{…}} in run: (that's
+      # the very shell-injection pattern these rules flag).
+      - name: Semgrep diff scan (gate on new findings)
+        env:
+          SEMGREP_BASELINE: ${{ github.event.pull_request.base.sha }}
         run: |
+          BASELINE_ARG=""
+          if [ -n "$SEMGREP_BASELINE" ]; then
+            git fetch --no-tags --depth=1 origin "$SEMGREP_BASELINE" 2>/dev/null || true
+            BASELINE_ARG="--baseline-commit $SEMGREP_BASELINE"
+          fi
           semgrep scan \
             --config p/security-audit \
             --config p/secrets \
@@ -56,4 +65,5 @@ jobs:
             --metrics off \
             --exclude dist \
             --exclude coverage \
-            --exclude '**/drizzle/**'
+            --exclude '**/drizzle/**' \
+            $BASELINE_ARG

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,59 @@
+# Security — Semgrep OSS static-analysis gate on develop.
+#
+# Complements CodeQL (codeql.yml): CodeQL is the deep dataflow engine, Semgrep
+# adds fast pattern-based rules (incl. a broad secrets pack) from the public
+# registry. Both gate `develop` — the integration branch — so issues are caught
+# before work is promoted to main/prod (std-21), not after.
+#
+# Semgrep runs on source only (no pnpm install needed); --error fails the job on
+# a finding, surfaced in the Actions log.
+name: Security
+
+on:
+  push:
+    branches: [develop]
+  pull_request:
+    branches: [develop]
+  workflow_dispatch:
+
+# Least-privilege default for GITHUB_TOKEN.
+permissions:
+  contents: read
+
+# One run per ref; supersede an in-flight run when a newer commit lands.
+concurrency:
+  group: security-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  semgrep:
+    name: semgrep
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # pipx is preinstalled on GitHub-hosted ubuntu runners; isolates semgrep
+      # from system Python (avoids PEP-668 "externally managed" errors).
+      - name: Install Semgrep (OSS)
+        run: pipx install semgrep
+
+      # Public registry packs for this repo's stack (TS/JS/React/Node + GitHub
+      # Actions) plus generic security + secret detection. --error fails on a
+      # finding; --metrics off keeps it offline-friendly. node_modules and
+      # .gitignored paths are skipped automatically; generated/output dirs and
+      # the e2e fixtures are excluded to cut noise.
+      - name: Semgrep scan (gate on findings)
+        run: |
+          semgrep scan \
+            --config p/security-audit \
+            --config p/secrets \
+            --config p/javascript \
+            --config p/typescript \
+            --config p/react \
+            --config p/nodejs \
+            --config p/github-actions \
+            --error \
+            --metrics off \
+            --exclude dist \
+            --exclude coverage \
+            --exclude '**/drizzle/**'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -29,7 +29,7 @@ jobs:
     name: semgrep
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # Full history so --baseline-commit can diff against the PR base.
           fetch-depth: 0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,7 +89,7 @@ jobs:
       MEMEX_EMIT_KEY: ${{ secrets.MEMEX_EMIT_KEY }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # No `version:` here — pnpm/action-setup@v4 reads the pinned version from
       # the root package.json `packageManager` field and errors if both are set.
@@ -135,7 +135,7 @@ jobs:
       - name: Upload coverage blob (shard ${{ matrix.shard }})
         # Always upload so server-result can merge; a missing blob fails that job closed.
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: server-coverage-blob-${{ matrix.shard }}
           path: packages/server/.vitest-reports/
@@ -168,7 +168,7 @@ jobs:
           echo "server shards result: ${{ needs.server.result }}"
           exit 1
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
@@ -177,7 +177,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Download all shard coverage blobs
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: server-coverage-blob-*
           path: /tmp/server-blobs
@@ -205,7 +205,7 @@ jobs:
 
       - name: Upload merged coverage report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: server-coverage
           path: packages/server/coverage/
@@ -240,7 +240,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
@@ -255,7 +255,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       # No `version:` here — pnpm/action-setup@v4 reads the pinned version from
       # the root package.json `packageManager` field and errors if both are set.
       - uses: pnpm/action-setup@v4
@@ -268,7 +268,7 @@ jobs:
         run: pnpm --filter @memex/ui test:coverage
       - name: Upload UI coverage report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ui-coverage
           path: packages/ui/coverage/
@@ -280,7 +280,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       # No `version:` here — pnpm/action-setup@v4 reads the pinned version from
       # the root package.json `packageManager` field and errors if both are set.
       - uses: pnpm/action-setup@v4
@@ -354,7 +354,7 @@ jobs:
       MEMEX_ANTHROPIC_FAKE: "1"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       # No `version:` here — pnpm/action-setup@v4 reads the pinned version from
       # the root package.json `packageManager` field and errors if both are set.
       - uses: pnpm/action-setup@v4
@@ -370,7 +370,7 @@ jobs:
       # Playwright version is pinned there, so a version bump busts the cache.
       - name: Cache Playwright browsers
         id: playwright-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
@@ -384,7 +384,7 @@ jobs:
         run: pnpm --filter @memex/ui test:e2e --shard=${{ matrix.shard }}/3
       - name: Upload Playwright trace on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-traces-shard-${{ matrix.shard }}
           path: packages/ui/test-results/
@@ -460,7 +460,7 @@ jobs:
       MEMEX_EMIT_KEY: ${{ secrets.MEMEX_EMIT_KEY }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       # No `version:` here — pnpm/action-setup@v4 reads the pinned version from
       # the root package.json `packageManager` field and errors if both are set.
       - uses: pnpm/action-setup@v4

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
   "pnpm": {
     "onlyBuiltDependencies": ["esbuild", "protobufjs"],
     "overrides": {
-      "vitest": "4.1.1",
-      "@vitest/coverage-v8": "4.1.1",
-      "@types/node": "22.19.15",
+      "vitest": "4.1.8",
+      "@vitest/coverage-v8": "4.1.8",
+      "@types/node": "25.9.3",
       "react": "19.2.7",
       "react-dom": "19.2.7"
     }

--- a/packages/ac-emit-vitest/package.json
+++ b/packages/ac-emit-vitest/package.json
@@ -48,9 +48,9 @@
     "vitest": ">=2.0.0"
   },
   "devDependencies": {
-    "@types/node": "22.19.15",
+    "@types/node": "25.9.3",
     "typescript": "^5.7.0",
-    "vitest": "4.1.1"
+    "vitest": "4.1.8"
   },
   "engines": {
     "node": ">=20"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -30,6 +30,6 @@
     "node": ">=18"
   },
   "devDependencies": {
-    "vitest": "^4.1.4"
+    "vitest": "^4.1.8"
   }
 }

--- a/packages/db-schema/package.json
+++ b/packages/db-schema/package.json
@@ -32,14 +32,14 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "drizzle-orm": "^0.39.0"
+    "drizzle-orm": "^0.45.2"
   },
   "devDependencies": {
     "@memex-ai-ac/vitest": "workspace:*",
-    "@types/node": "22.19.15",
+    "@types/node": "25.9.3",
     "postgres": "^3.4.5",
     "tsup": "^8.3.5",
     "typescript": "^5.7.0",
-    "vitest": "4.1.1"
+    "vitest": "4.1.8"
   }
 }

--- a/packages/extractor/package.json
+++ b/packages/extractor/package.json
@@ -14,15 +14,15 @@
   "dependencies": {
     "@memex/server": "workspace:*",
     "dotenv": "^16.4.7",
-    "drizzle-orm": "^0.39.0",
+    "drizzle-orm": "^0.45.2",
     "postgres": "^3.4.5",
     "tree-sitter-wasms": "^0.1.12",
     "web-tree-sitter": "^0.25.1"
   },
   "devDependencies": {
-    "@types/node": "^22.0.0",
+    "@types/node": "^25.9.3",
     "tsx": "^4.19.0",
     "typescript": "^5.7.0",
-    "vitest": "^4.1.1"
+    "vitest": "^4.1.8"
   }
 }

--- a/packages/guide-sdk/package.json
+++ b/packages/guide-sdk/package.json
@@ -21,8 +21,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@langchain/core": "^1.1.38",
-    "@langchain/langgraph": "^1.2.6",
+    "@langchain/core": "^1.1.49",
+    "@langchain/langgraph": "^1.4.2",
     "@ricky0123/vad-web": "^0.0.30",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
@@ -31,12 +31,12 @@
     "@memex-ai-ac/vitest": "workspace:*",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
-    "@types/react": "^19.0.0",
+    "@types/react": "^19.2.17",
     "@types/react-dom": "^19.0.0",
-    "@vitejs/plugin-react": "^4.3.4",
+    "@vitejs/plugin-react": "^6.0.2",
     "jsdom": "^29.0.1",
     "typescript": "~5.7.2",
-    "vite": "^6.0.5",
-    "vitest": "^4.1.1"
+    "vite": "^8.0.16",
+    "vitest": "^4.1.8"
   }
 }

--- a/packages/guide-sdk/src/__release__/dispatchWorkflow.spec-222.test.ts
+++ b/packages/guide-sdk/src/__release__/dispatchWorkflow.spec-222.test.ts
@@ -42,7 +42,7 @@ describe('spec-222 t-13: cross-repo corpus refresh workflow (ac-21)', () => {
     expect(yaml).toMatch(/repository_dispatch:/);
     expect(yaml).toMatch(/website-content-changed/);
     // Privileged auth (CI/WIF), exactly like deploy.yml.
-    expect(yaml).toMatch(/google-github-actions\/auth@v2/);
+    expect(yaml).toMatch(/google-github-actions\/auth@v3/);
     expect(yaml).toMatch(/workload_identity_provider/);
     // It must NOT call the public anonymous routes (dec-4) — it refreshes via the
     // privileged import script over the Cloud SQL proxy, not an HTTP hit on the endpoint.

--- a/packages/server/drizzle/0094_move_doc_function.sql
+++ b/packages/server/drizzle/0094_move_doc_function.sql
@@ -1,0 +1,192 @@
+-- spec-293 t-1 (dec-1): RLS-sanctioned cross-tenant Spec move via a SECURITY
+-- DEFINER function.
+--
+-- WHY A FUNCTION (the prod 500)
+--   Moving a Spec re-points memex_id from tenant A to tenant B. The runtime role
+--   `memex_app` is NOBYPASSRLS and every request is scoped to ONE app.memex_id
+--   GUC (db/connection.ts), so the `*_memex_isolation` WITH CHECK (0081) rejects
+--   `UPDATE … SET memex_id = <other tenant>` — that is the prod-only Internal
+--   Server Error (it passes locally only because dev/tests connect as the table
+--   OWNER, which bypasses RLS under ENABLE+NO FORCE, std-36 / 0093).
+--
+--   `move_doc` is owned by the table owner and marked SECURITY DEFINER, so its
+--   body executes with owner privileges and bypasses RLS for this one sanctioned,
+--   audited operation. memex_app gets EXECUTE on this function ONLY (below) — it
+--   gains no general cross-tenant power. The authorization guard lives INSIDE the
+--   function so privilege and guard cannot drift apart (dec-1).
+--
+-- WHAT MOVES (dec-2 / dec-3): the whole Spec. Every doc-scoped artifact that
+--   carries a denormalised memex_id is re-pointed; the rest follow by FK:
+--     re-pointed (memex_id):  documents, doc_comments (ALL targets — dec-3),
+--       decisions, tasks, acs (brief_id), issues, doc_members, doc_assignees,
+--       document_tags (document_id), clause_refs (source_doc_id)
+--     follow by FK (no memex_id): doc_sections (doc_id), conversations (doc_id),
+--       messages (conversation_id), ac_parent_links (ac_id), task_satisfies_ac
+--     not tenant-scoped: test_events / test_event_latest are keyed by the AC's
+--       text uid (the AC keeps its handle on move), so verification history
+--       follows the AC with no row change.
+--   Deliberately NOT touched (per-user / per-Memex read-state, not Spec content):
+--     qa_report_views, presence, user_memex_access, mcp_tool_calls.
+--
+-- Errors (mapped to HTTP by services/doc-move.ts):
+--   MX001 — document not found in source memex          → 404 (std-7)
+--   MX002 — caller not authorized in source/target       → 404 (std-7, never 403)
+--   MX003 — source and target memex are the same         → 400
+
+-- Authorization helper: is p_user_id allowed in the memex p_memex_id? Owns the
+-- namespace (personal) or holds an active org_membership in the owning org
+-- (mirrors services/doc-move.ts:108-126). SECURITY DEFINER + owner so it reads
+-- the tenancy tables regardless of RLS; STABLE (no writes).
+CREATE OR REPLACE FUNCTION _memex_member(p_memex_id uuid, p_user_id uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+      FROM memexes m
+      JOIN namespaces n ON n.id = m.namespace_id
+     WHERE m.id = p_memex_id
+       AND (
+         (n.kind = 'user' AND n.owner_user_id = p_user_id)
+         OR (n.kind = 'org' AND n.owner_org_id IS NOT NULL AND EXISTS (
+              SELECT 1 FROM org_memberships om
+               WHERE om.user_id = p_user_id
+                 AND om.org_id = n.owner_org_id
+                 AND om.status = 'active'
+            ))
+       )
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION move_doc(
+  p_doc_id        uuid,
+  p_from_memex_id uuid,
+  p_to_memex_id   uuid,
+  p_user_id       uuid
+)
+RETURNS TABLE (
+  new_handle            text,
+  revoked_share_tokens  integer,
+  removed_decision_deps integer,
+  removed_task_deps     integer
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_doc_type   text;
+  v_handle     text;
+  v_prefix     text;
+  v_attempt    integer := 0;
+  v_done       boolean := false;
+BEGIN
+  IF p_from_memex_id = p_to_memex_id THEN
+    RAISE EXCEPTION 'source and target memex must differ' USING ERRCODE = 'MX003';
+  END IF;
+
+  -- Lock the doc in the source memex; 404 if it isn't there.
+  SELECT doc_type INTO v_doc_type
+    FROM documents
+   WHERE id = p_doc_id AND memex_id = p_from_memex_id
+   FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'document % not found in source memex', p_doc_id USING ERRCODE = 'MX001';
+  END IF;
+
+  -- Authorization: the caller must be allowed in BOTH source and target Memex.
+  -- (memexes / namespaces / org_memberships are not RLS-scoped tables.)
+  IF NOT _memex_member(p_from_memex_id, p_user_id) THEN
+    RAISE EXCEPTION 'not authorized in source memex' USING ERRCODE = 'MX002';
+  END IF;
+  IF NOT _memex_member(p_to_memex_id, p_user_id) THEN
+    RAISE EXCEPTION 'not authorized in target memex' USING ERRCODE = 'MX002';
+  END IF;
+
+  -- Per doc-30 / spec-105: specs → spec-N, standards → std-N, everything else → doc-N.
+  v_prefix := CASE v_doc_type WHEN 'spec' THEN 'spec' WHEN 'standard' THEN 'std' ELSE 'doc' END;
+
+  -- Re-mint the handle in the TARGET memex. The MAX+1 read is racy against a
+  -- concurrent create/move into the same memex; retry on the unique violation
+  -- (documents_memex_id_handle_unique). Owner-context read sees the real target
+  -- rows (the app role would be RLS-filtered to the source and mint wrong).
+  WHILE NOT v_done LOOP
+    v_attempt := v_attempt + 1;
+    SELECT v_prefix || '-' || (
+             coalesce(max(cast(substring(handle from (v_prefix || '-([0-9]+)')) as integer)), 0) + 1
+           )
+      INTO v_handle
+      FROM documents
+     WHERE memex_id = p_to_memex_id;
+    BEGIN
+      UPDATE documents
+         SET memex_id = p_to_memex_id, handle = v_handle
+       WHERE id = p_doc_id;
+      v_done := true;
+    EXCEPTION WHEN unique_violation THEN
+      IF v_attempt >= 25 THEN
+        RAISE;  -- give up after persistent contention rather than spin forever
+      END IF;
+    END;
+  END LOOP;
+
+  -- Re-point every doc-scoped artifact carrying a denormalised memex_id (dec-2).
+  -- doc_comments covers ALL comment targets via the denormalised doc_id (dec-3).
+  -- standard_clauses holds a Standard doc's body (matters for the dedupe merge,
+  -- where personal Memexes carry seeded default Standards).
+  UPDATE standard_clauses SET memex_id = p_to_memex_id WHERE doc_id     = p_doc_id;
+  UPDATE doc_comments  SET memex_id = p_to_memex_id WHERE doc_id        = p_doc_id;
+  UPDATE decisions     SET memex_id = p_to_memex_id WHERE doc_id        = p_doc_id;
+  UPDATE tasks         SET memex_id = p_to_memex_id WHERE doc_id        = p_doc_id;
+  UPDATE acs           SET memex_id = p_to_memex_id WHERE brief_id      = p_doc_id;
+  UPDATE issues        SET memex_id = p_to_memex_id WHERE doc_id        = p_doc_id;
+  UPDATE doc_members   SET memex_id = p_to_memex_id WHERE doc_id        = p_doc_id;
+  UPDATE doc_assignees SET memex_id = p_to_memex_id WHERE doc_id        = p_doc_id;
+  UPDATE document_tags SET memex_id = p_to_memex_id WHERE document_id   = p_doc_id;
+  UPDATE clause_refs   SET memex_id = p_to_memex_id WHERE source_doc_id = p_doc_id;
+  -- doc_sections, conversations, messages, ac_parent_links, task_satisfies_ac
+  -- carry no memex_id — they follow via their FK chain to the moved rows.
+
+  -- Any dep edge that now straddles two memexes is structurally invalid (the
+  -- blocked party can't see the blocker across the tenant wall). Silent-delete,
+  -- return the counts so the UI can surface a toast. Whole-Spec moves keep
+  -- intra-Spec edges intact; only edges to OTHER specs left behind can straddle.
+  WITH del AS (
+    DELETE FROM decision_deps dd
+     USING tasks w, decisions d
+     WHERE dd.task_id = w.id AND dd.decision_id = d.id
+       AND w.memex_id <> d.memex_id
+       AND (w.doc_id = p_doc_id OR d.doc_id = p_doc_id)
+    RETURNING 1
+  ) SELECT count(*) INTO removed_decision_deps FROM del;
+
+  WITH del AS (
+    DELETE FROM task_deps wd
+     USING tasks w1, tasks w2
+     WHERE wd.task_id = w1.id AND wd.depends_on_id = w2.id
+       AND w1.memex_id <> w2.memex_id
+       AND (w1.doc_id = p_doc_id OR w2.doc_id = p_doc_id)
+    RETURNING 1
+  ) SELECT count(*) INTO removed_task_deps FROM del;
+
+  -- Public share URLs are source-scoped and would break after the move; revoke them.
+  WITH upd AS (
+    UPDATE share_tokens SET revoked = TRUE
+     WHERE document_id = p_doc_id AND revoked = FALSE
+    RETURNING 1
+  ) SELECT count(*) INTO revoked_share_tokens FROM upd;
+
+  new_handle := v_handle;
+  RETURN NEXT;
+END;
+$$;
+
+-- memex_app may CALL the move, nothing more. Revoke the implicit PUBLIC EXECUTE
+-- so the cross-tenant seam is reachable only through this one granted path.
+REVOKE ALL ON FUNCTION move_doc(uuid, uuid, uuid, uuid) FROM PUBLIC;
+REVOKE ALL ON FUNCTION _memex_member(uuid, uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION move_doc(uuid, uuid, uuid, uuid) TO memex_app;
+GRANT EXECUTE ON FUNCTION _memex_member(uuid, uuid) TO memex_app;

--- a/packages/server/drizzle/0095_dedupe_personal_memexes.sql
+++ b/packages/server/drizzle/0095_dedupe_personal_memexes.sql
@@ -1,0 +1,108 @@
+-- spec-293 t-4 (dec-4): one-time data backfill — collapse duplicate personal
+-- Memexes left behind by the pre-fix signup race.
+--
+-- BACKGROUND. The concurrent-signup race that minted a second (and third)
+-- personal Memex per user is already closed in code (spec-177:
+-- services/user-namespaces.ts, ownership-first resolution + onConflictDoNothing).
+-- This migration only cleans up the rows that race left on prod. The creation
+-- path is not touched here.
+--
+-- POLICY (dec-4).
+--   * Canonical = the personal Memex in the namespace users.namespaceId points at
+--     (the one the user actually sees). Fallback to the OLDEST personal Memex if
+--     that pointer is null or has no personal Memex.
+--   * MERGE every duplicate's content INTO the canonical — no user content is ever
+--     deleted. We reuse move_doc() (migration 0094) per document, so each doc and
+--     ALL its doc-scoped artifacts travel and its handle is re-minted on collision
+--     (documents_memex_id_handle_unique). move_doc is SECURITY DEFINER; this
+--     migration runs as the table OWNER, which bypasses RLS — no GUC needed.
+--   * Then DELETE the now-empty duplicate Memex (FK cascade clears its per-user
+--     read-state: qa_report_views, user_memex_access, presence, …) and its orphaned
+--     user-namespace (guarded: only if nothing else references it).
+--
+-- IDEMPOTENT. The driving query selects only users who still have >1 personal
+-- Memex, so a second run is a no-op. Safe to re-run.
+--
+-- ROLLOUT (std-17). Ships int-first, green there before prod; capture a PITR
+-- marker before the prod run (precedent spec-65). Post-migration invariant
+-- (ac-14): zero users with >1 personal Memex — the SELECT at the bottom must
+-- return 0 (also asserted by the integration test).
+
+DO $$
+DECLARE
+  r_user      record;
+  v_canonical uuid;
+  r_dup       record;
+  r_doc       record;
+BEGIN
+  FOR r_user IN
+    SELECT n.owner_user_id AS user_id
+      FROM namespaces n
+      JOIN memexes m ON m.namespace_id = n.id AND m.slug = 'personal'
+     WHERE n.kind = 'user' AND n.owner_user_id IS NOT NULL
+     GROUP BY n.owner_user_id
+    HAVING count(*) > 1
+  LOOP
+    -- Canonical: personal Memex in the namespace users.namespaceId references.
+    SELECT m.id INTO v_canonical
+      FROM users u
+      JOIN namespaces n ON n.id = u.namespace_id
+      JOIN memexes m ON m.namespace_id = n.id AND m.slug = 'personal'
+     WHERE u.id = r_user.user_id;
+
+    -- Fallback: the oldest personal Memex the user owns.
+    IF v_canonical IS NULL THEN
+      SELECT m.id INTO v_canonical
+        FROM namespaces n
+        JOIN memexes m ON m.namespace_id = n.id AND m.slug = 'personal'
+       WHERE n.kind = 'user' AND n.owner_user_id = r_user.user_id
+       ORDER BY m.created_at ASC, m.id ASC
+       LIMIT 1;
+    END IF;
+
+    -- Merge every NON-canonical personal Memex into the canonical, then remove it.
+    FOR r_dup IN
+      SELECT m.id AS memex_id, m.namespace_id
+        FROM namespaces n
+        JOIN memexes m ON m.namespace_id = n.id AND m.slug = 'personal'
+       WHERE n.kind = 'user' AND n.owner_user_id = r_user.user_id
+         AND m.id <> v_canonical
+    LOOP
+      -- Move each doc whole (handle re-minted in canonical by move_doc).
+      FOR r_doc IN SELECT id FROM documents WHERE memex_id = r_dup.memex_id LOOP
+        PERFORM move_doc(r_doc.id, r_dup.memex_id, v_canonical, r_user.user_id);
+      END LOOP;
+
+      -- The duplicate now holds no documents. Delete it; FK cascade clears its
+      -- per-user read-state rows.
+      DELETE FROM memexes WHERE id = r_dup.memex_id;
+
+      -- Delete the orphaned user-namespace, but only if nothing else points at it.
+      DELETE FROM namespaces n2
+       WHERE n2.id = r_dup.namespace_id
+         AND NOT EXISTS (SELECT 1 FROM memexes mm WHERE mm.namespace_id = n2.id)
+         AND NOT EXISTS (SELECT 1 FROM users uu WHERE uu.namespace_id = n2.id)
+         AND NOT EXISTS (SELECT 1 FROM orgs o WHERE o.namespace_id = n2.id);
+    END LOOP;
+  END LOOP;
+END $$;
+
+-- Post-migration invariant (ac-14): must be 0. (psql prints the count; the
+-- integration test asserts it programmatically.)
+DO $$
+DECLARE
+  v_remaining integer;
+BEGIN
+  SELECT count(*) INTO v_remaining FROM (
+    SELECT n.owner_user_id
+      FROM namespaces n
+      JOIN memexes m ON m.namespace_id = n.id AND m.slug = 'personal'
+     WHERE n.kind = 'user' AND n.owner_user_id IS NOT NULL
+     GROUP BY n.owner_user_id
+    HAVING count(*) > 1
+  ) offenders;
+  RAISE NOTICE 'spec-293 dedupe: % user(s) still with >1 personal Memex (expect 0)', v_remaining;
+  IF v_remaining <> 0 THEN
+    RAISE EXCEPTION 'spec-293 dedupe left % user(s) with >1 personal Memex', v_remaining;
+  END IF;
+END $$;

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -52,31 +52,31 @@
     "smoke": "vitest run --config vitest.smoke.config.ts"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.80.0",
-    "@google-cloud/kms": "^5.5.0",
+    "@anthropic-ai/sdk": "^0.104.1",
+    "@google-cloud/kms": "^5.5.1",
     "@hono/node-server": "^1.13.0",
     "@hono/node-ws": "^1.3.1",
     "@memex/shared": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.27.1",
-    "@slack/web-api": "^7.16.0",
+    "@slack/web-api": "^7.17.0",
     "cohere-ai": "^7.21.0",
     "dotenv": "^16.4.7",
-    "drizzle-orm": "^0.39.0",
-    "google-auth-library": "^10.6.2",
-    "hono": "^4.7.0",
-    "openai": "^4.104.0",
+    "drizzle-orm": "^0.45.2",
+    "google-auth-library": "^10.7.0",
+    "hono": "^4.12.25",
+    "openai": "^6.42.0",
     "postgres": "^3.4.5",
     "ws": "^8.21.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {
     "@memex-ai-ac/vitest": "workspace:*",
-    "@types/node": "^22.0.0",
+    "@types/node": "^25.9.3",
     "@types/ws": "^8.18.1",
-    "@vitest/coverage-v8": "^4.1.4",
-    "drizzle-kit": "^0.30.0",
+    "@vitest/coverage-v8": "^4.1.8",
+    "drizzle-kit": "^0.31.10",
     "tsx": "^4.19.0",
     "typescript": "^5.7.0",
-    "vitest": "^4.1.1"
+    "vitest": "^4.1.8"
   }
 }

--- a/packages/server/src/__regression__/mutate-coverage.service.test.ts
+++ b/packages/server/src/__regression__/mutate-coverage.service.test.ts
@@ -246,17 +246,25 @@ describe("doc-16 t-12: service coverage — every Mutated<T> service emits on th
     const toMemex = await makeTestMemex("mvto");
     const doc = await documentsSvc.createDocDraft(fromMemex, "To move", "Move me", "spec");
 
-    // Enrol the dev user as administrator on the target org so the permission check passes.
+    // Enrol the dev user on BOTH org(s) — spec-293's move_doc checks membership in
+    // the source AND target memex (the request path gates source via session
+    // middleware, but the service contract enforces both).
     const { upsertUserByEmail } = await import("../services/users.js");
     const { orgMemberships, memexes, namespaces } = await import("../db/schema.js");
-    const targetMemexRow = await db.query.memexes.findFirst({ where: eq(memexes.id, toMemex) });
-    const targetNs = await db.query.namespaces.findFirst({
-      where: eq(namespaces.id, targetMemexRow!.namespaceId),
-    });
+    const orgIdOf = async (memexId: string): Promise<string> => {
+      const m = await db.query.memexes.findFirst({ where: eq(memexes.id, memexId) });
+      const ns = await db.query.namespaces.findFirst({
+        where: eq(namespaces.id, m!.namespaceId),
+      });
+      return ns!.ownerOrgId!;
+    };
     const dev = await upsertUserByEmail("dev@memex.ai");
     await db
       .insert(orgMemberships)
-      .values({ userId: dev.id, orgId: targetNs!.ownerOrgId!, role: "administrator" })
+      .values([
+        { userId: dev.id, orgId: await orgIdOf(fromMemex), role: "administrator" },
+        { userId: dev.id, orgId: await orgIdOf(toMemex), role: "administrator" },
+      ])
       .onConflictDoNothing();
 
     const seen: { memexId: string; entity: ChangeEntity; action: ChangeAction }[] = [];
@@ -266,10 +274,10 @@ describe("doc-16 t-12: service coverage — every Mutated<T> service emits on th
       }
     });
     try {
-      await docMoveSvc.moveDoc(fromMemex, doc.id, toMemex, dev.id, {
-        includeDecisions: false,
-        includeTasks: false,
-        includeSectionComments: false,
+      await docMoveSvc.moveDoc(fromMemex, doc.id, toMemex, {
+        actorUserId: dev.id,
+        actorName: "dev",
+        channel: "rest_ui",
       });
     } finally {
       unsubscribe();

--- a/packages/server/src/__regression__/spec-251-mindset-website-surface.regression.test.ts
+++ b/packages/server/src/__regression__/spec-251-mindset-website-surface.regression.test.ts
@@ -68,7 +68,7 @@ describe("guide-content-mindset-website-refresh.yml (spec-251 t-5, dec-1)", () =
   it("authenticates like the sibling: WIF + cloud-sql-proxy, never the public endpoint (ac-7)", () => {
     tagAc(AC7);
     const wf = read(MINDSET_WF);
-    expect(wf).toContain("google-github-actions/auth@v2");
+    expect(wf).toContain("google-github-actions/auth@v3");
     expect(wf).toContain("GCP_WORKLOAD_IDENTITY_PROVIDER");
     expect(wf).toContain("cloud-sql-proxy");
     // The import goes straight to Postgres via the proxy — no step ever curls

--- a/packages/server/src/__regression__/spec-276-server-shard-gate.regression.test.ts
+++ b/packages/server/src/__regression__/spec-276-server-shard-gate.regression.test.ts
@@ -84,7 +84,7 @@ describe("spec-276 — the server suite is sharded but the coverage gate is inta
     expect(server, "shard uploads its coverage blob").toMatch(/upload-artifact/);
     expect(server).toMatch(/\.vitest-reports/);
     // MUST include hidden files: vitest writes the blob into `.vitest-reports/`
-    // (a dot-dir) and upload-artifact@v4 excludes hidden files by default — without
+    // (a dot-dir) and upload-artifact excludes hidden files by default — without
     // this the upload finds nothing and server-result fails closed on 0 blobs.
     // (Caught by PR #169's first CI run; this assertion pins the fix.)
     expect(server, "blob upload includes hidden files").toMatch(/include-hidden-files:\s*true/);

--- a/packages/server/src/agent/tool-specs.ts
+++ b/packages/server/src/agent/tool-specs.ts
@@ -201,6 +201,8 @@ import {
   toButtonPrompt,
   toHandoffEssence,
   GET_PROMPT_PROSE,
+  timeAgo,
+  capitalizeDisplayName,
   type Phase,
   type GuidanceBlock,
 } from "@memex/shared";
@@ -4233,7 +4235,7 @@ export const toolSpecs: ToolSpec[] = [
         );
       }
       const { memexId, doc, slugs, entity } = resolved;
-      const comment = await resolveComment(memexId, entity.row.id, resolution);
+      const comment = await resolveComment(memexId, entity.row.id, resolution, reqCtx(ctx));
       if (ctx.verbose) {
         return `${formatDocStatusHeader(doc)}\n\nComment resolved.\n${formatComment(comment)}`;
       }
@@ -4341,7 +4343,7 @@ export const toolSpecs: ToolSpec[] = [
           for (const c of status.comments) {
             const targetTitle = c.target.title ? ` "${c.target.title}"` : "";
             lines.push(
-              `- [${c.type}] on ${c.target.kind} ${c.target.handle}${targetTitle} by ${c.author} (${c.createdAt.toISOString()}): ${c.contentSnippet}`,
+              `- [${c.type}] on ${c.target.kind} ${c.target.handle}${targetTitle} by ${capitalizeDisplayName(c.author)} (${timeAgo(c.createdAt)}): ${c.contentSnippet}`,
             );
           }
         }

--- a/packages/server/src/mcp/formatters.ts
+++ b/packages/server/src/mcp/formatters.ts
@@ -22,6 +22,8 @@ import {
   GET_PROMPT_PROSE,
   toNudge,
   toHandoffEssence,
+  timeAgo,
+  capitalizeDisplayName,
   type GuidanceBlock,
   type PhaseNode,
 } from "@memex/shared";
@@ -476,7 +478,10 @@ export function formatComment(
     headerLines.push(`ref: ${ref}`);
   }
   headerLines.push(
-    `${status}${badge} **${comment.authorName}** (${formatDate(comment.createdAt)}):`,
+    // spec-259 t-3: comment byline shows WHO (title-cased) + WHEN (relative) —
+    // `timeAgo` surfaces staleness at a glance; `formatDate` stays for the
+    // non-comment callers above.
+    `${status}${badge} **${capitalizeDisplayName(comment.authorName)}** (${timeAgo(comment.createdAt)}):`,
     comment.content,
   );
   const refLine = commentReferenceLine(comment, lookup);

--- a/packages/server/src/routes/__test__.ts
+++ b/packages/server/src/routes/__test__.ts
@@ -45,7 +45,7 @@ import { createIssue } from "../services/issues.js";
 import { testEvents } from "../db/schema.js";
 import { applyEmissionToSummary } from "../services/test-event-latest.js";
 import { createExecutionPlan } from "../services/execution_plans.js";
-import { addTaskComment } from "../services/comments.js";
+import { addTaskComment, addComment, addDecisionComment } from "../services/comments.js";
 import { createShareToken, listShareTokensForDoc } from "../services/share-tokens.js";
 import { addSection } from "../services/sections.js";
 import { applyTagStrings } from "../services/tags.js";
@@ -778,6 +778,38 @@ testOnlyRouter.post("/seed-section", async (c) => {
   const { memexId, docId, title, content = "", sectionType = "context" } = parsed.data;
   const section = await addSection(memexId, docId, sectionType, content, title);
   return c.json({ sectionId: section.id, seq: section.seq });
+});
+
+// spec-259 t-5: seed an OPEN comment on a section / decision / task through the
+// real comment services (so it emits on the bus [per std-8] and the
+// SSE-reactive UI under test sees it like a real comment). Backs the
+// Specify-phase open-comment parity journey, which asserts the open-comment
+// summary + per-comment WHO/WHEN byline render on the Comments surface.
+const seedCommentSchema = z.object({
+  memexId: z.string().uuid(),
+  target: z.enum(["section", "decision", "task"]),
+  targetId: z.string().uuid(),
+  authorName: z.string().default("Casey Reviewer"),
+  content: z.string().default("Please double-check this before we advance."),
+  commentType: z.string().optional(),
+});
+testOnlyRouter.post("/seed-comment", async (c) => {
+  const body = await c.req.json().catch(() => null);
+  const parsed = seedCommentSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: "Invalid request", details: parsed.error.issues }, 400);
+  }
+  const { memexId, target, targetId, authorName, content, commentType } = parsed.data;
+  const extras = commentType
+    ? ({ type: commentType } as Parameters<typeof addComment>[4])
+    : undefined;
+  const comment =
+    target === "section"
+      ? await addComment(memexId, targetId, authorName, content, extras)
+      : target === "decision"
+        ? await addDecisionComment(memexId, targetId, authorName, content, extras)
+        : await addTaskComment(memexId, targetId, authorName, content, extras);
+  return c.json({ commentId: comment.id, seq: comment.seq });
 });
 
 // spec-286: apply `scope::value`/flat tags to a Spec through the real

--- a/packages/server/src/routes/comments.test.ts
+++ b/packages/server/src/routes/comments.test.ts
@@ -8,6 +8,10 @@ import { testMutate } from "../services/__test__/mutate-helpers.js";
 // and Resolve ('resolved') are distinguishable in history.
 const AC_RESOLUTION_THREADING =
   "mindset-prod/memex-building-itself/specs/spec-143/acs/ac-12";
+// spec-259 ac-4: the resolve route threads the acting user's RequestCtx so the
+// resolution carries WHO (proven end-to-end in comment-resolution-attribution.spec-259).
+const AC_RESOLVE_ATTRIBUTION =
+  "mindset-prod/memex-building-itself/specs/spec-259/acs/ac-4";
 
 // Mock session middleware (t-13) so the route's `.use()` is a pass-through and the stubbed
 // currentAccount/user from `makeTestAppWithTenant` reach the handler intact.
@@ -310,6 +314,7 @@ describe("POST /api/comments/:commentId/resolve", () => {
 
   it("resolves a comment without resolution", async () => {
     tagAc(AC_RESOLUTION_THREADING);
+    tagAc(AC_RESOLVE_ATTRIBUTION);
     vi.mocked(resolveComment).mockResolvedValue(testMutate({
       id: "c1",
       memexId: "test-account",
@@ -344,11 +349,19 @@ describe("POST /api/comments/:commentId/resolve", () => {
 
     const body = await res.json();
     expect(body.resolvedAt).toBeTruthy();
-    expect(resolveComment).toHaveBeenCalledWith(TEST_MEMEX_ID, "c1", undefined);
+    // spec-259 ac-4: the route threads the acting user's ctx (restCtx) as the 4th
+    // arg so the resolution carries WHO (channel rest_ui + actorUserId).
+    expect(resolveComment).toHaveBeenCalledWith(
+      TEST_MEMEX_ID,
+      "c1",
+      undefined,
+      expect.objectContaining({ channel: "rest_ui" }),
+    );
   });
 
   it("resolves a comment with resolution", async () => {
     tagAc(AC_RESOLUTION_THREADING);
+    tagAc(AC_RESOLVE_ATTRIBUTION);
     vi.mocked(resolveComment).mockResolvedValue(testMutate({
       id: "c1",
       memexId: "test-account",
@@ -385,7 +398,12 @@ describe("POST /api/comments/:commentId/resolve", () => {
 
     const body = await res.json();
     expect(body.resolution).toBe("Added details");
-    expect(resolveComment).toHaveBeenCalledWith(TEST_MEMEX_ID, "c1", "Added details");
+    expect(resolveComment).toHaveBeenCalledWith(
+      TEST_MEMEX_ID,
+      "c1",
+      "Added details",
+      expect.objectContaining({ channel: "rest_ui" }),
+    );
   });
 });
 

--- a/packages/server/src/routes/comments.ts
+++ b/packages/server/src/routes/comments.ts
@@ -27,6 +27,7 @@ import {
 } from "../middleware/session.js";
 import type { MemexResolverEnv } from "../middleware/memex-resolver.js";
 import { requireMemexId, resolveReadableMemexId } from "./shared.js";
+import { restCtx } from "./_actor-ctx.js";
 
 type Env = MemexResolverEnv & SessionEnv;
 const comments = new Hono<Env>();
@@ -191,7 +192,7 @@ comments.post("/:commentId/resolve", async (c) => {
   const memexId = requireMemexId(c);
   const commentId = c.req.param("commentId");
   const body = await c.req.json().catch(() => ({}));
-  const comment = await resolveComment(memexId, commentId, body.resolution);
+  const comment = await resolveComment(memexId, commentId, body.resolution, restCtx(c));
   return c.json(comment);
 });
 

--- a/packages/server/src/routes/documents.ts
+++ b/packages/server/src/routes/documents.ts
@@ -1,7 +1,7 @@
 import { Hono } from "hono";
 import { listDocs, getDoc, updateDocStatus, updateDocTitle, archiveDoc, pauseDoc, unpauseDoc } from "../services/documents.js";
 import { restCtx } from "./_actor-ctx.js";
-import { moveDoc, ForbiddenError } from "../services/doc-move.js";
+import { moveDoc } from "../services/doc-move.js";
 import { splitSection, updateSection } from "../services/sections.js";
 import { listDecisions } from "../services/decisions.js";
 import { listTasks } from "../services/tasks.js";
@@ -261,13 +261,9 @@ docs.post("/:id/unpause", async (c) => {
 
 docs.post("/:id/move", async (c) => {
   const memexId = requireMemexId(c);
-  const user = c.get("user");
   const id = c.req.param("id");
   const body = (await c.req.json().catch(() => null)) as {
     targetMemexId?: unknown;
-    includeDecisions?: unknown;
-    includeTasks?: unknown;
-    includeSectionComments?: unknown;
   } | null;
 
   const targetMemexId = body?.targetMemexId;
@@ -275,19 +271,12 @@ docs.post("/:id/move", async (c) => {
     throw new ValidationError("Body must include a 'targetMemexId' string");
   }
 
-  try {
-    const result = await moveDoc(memexId, id, targetMemexId, user.id, {
-      includeDecisions: Boolean(body?.includeDecisions),
-      includeTasks: Boolean(body?.includeTasks),
-      includeSectionComments: Boolean(body?.includeSectionComments),
-    });
-    return c.json(result);
-  } catch (err) {
-    if (err instanceof ForbiddenError) {
-      return c.json({ error: "Forbidden", message: err.message }, 403);
-    }
-    throw err;
-  }
+  // spec-293 dec-2/dec-3: a move is always whole — no per-artifact opt-out. The
+  // RequestCtx carries the actor + rest_ui channel onto both emitted events
+  // (dec-5). Authorization/not-found are raised inside move_doc and surfaced as
+  // 404 (std-7) by moveDoc's translation — no special-casing here.
+  const result = await moveDoc(memexId, id, targetMemexId, restCtx(c));
+  return c.json(result);
 });
 
 docs.post("/:id/title", async (c) => {

--- a/packages/server/src/routes/drift.ts
+++ b/packages/server/src/routes/drift.ts
@@ -23,6 +23,7 @@ import { docComments } from "../db/schema.js";
 import { sessionMiddleware, type SessionEnv } from "../middleware/session.js";
 import type { MemexResolverEnv } from "../middleware/memex-resolver.js";
 import { requireMemexId } from "./shared.js";
+import { restCtx } from "./_actor-ctx.js";
 import { listDriftInbox } from "../services/drift-inbox.js";
 import { parseProposedChangeBody } from "../services/standards.js";
 import { updateSection } from "../services/sections.js";
@@ -83,7 +84,7 @@ drift.post("/proposals/:commentId/accept", async (c) => {
   }
 
   await updateSection(memexId, comment.sectionId, parsed.proposed);
-  const resolved = await resolveComment(memexId, comment.id, "accepted");
+  const resolved = await resolveComment(memexId, comment.id, "accepted", restCtx(c));
 
   return c.json({ ok: true, comment: resolved });
 });

--- a/packages/server/src/services/comment-actions.ts
+++ b/packages/server/src/services/comment-actions.ts
@@ -30,7 +30,7 @@ import type { CommentAction } from "../types/roles.js";
 import { NotFoundError, ValidationError } from "../types/errors.js";
 import { resolveComment, unresolveComment } from "./comments.js";
 import { updateSection } from "./sections.js";
-import { mutate } from "./mutate.js";
+import { mutate, type RequestCtx } from "./mutate.js";
 import { hasAnchorMarker, extractMarkerSeqs, stripMarkersForSeq } from "./geo-anchor.js";
 
 // What the side agent is handed for an edit, and what it must return (new
@@ -46,6 +46,9 @@ export type AgentEditFn = (input: AgentEditInput) => Promise<string>;
 export interface ApplyActionDeps {
   runEdit: AgentEditFn;
   agentName?: string;
+  // spec-259 ac-4: the acting user, threaded to resolveComment so the ack/dismiss
+  // resolution carries WHO (std-32). Optional — defaults to unattributed.
+  ctx?: RequestCtx;
 }
 
 export interface ApplyActionResult {
@@ -115,7 +118,7 @@ export async function applyCommentAction(
   const action = findAction(comment, actionLabel);
 
   if (action.kind === "dismiss") {
-    const resolved = await resolveComment(memexId, commentId, `Dismissed via "${actionLabel}".`);
+    const resolved = await resolveComment(memexId, commentId, `Dismissed via "${actionLabel}".`, deps.ctx ?? {});
     return { kind: "dismiss", comment: resolved };
   }
 
@@ -167,6 +170,7 @@ export async function applyCommentAction(
       memexId,
       commentId,
       `Addressed via "${actionLabel}" by ${agentName}.`,
+      deps.ctx ?? {},
     );
 
     // Audit + undo record (spec §3 / ac-8). Wrapped in mutate({ silent: true })

--- a/packages/server/src/services/comment-assessment.grouping.spec-259.test.ts
+++ b/packages/server/src/services/comment-assessment.grouping.spec-259.test.ts
@@ -1,0 +1,101 @@
+// spec-259 t-3 — pure unit tests for the anchor-kind grouping of open comments.
+//
+// No DB: exercises `groupCommentsByAnchorKind` / `anchorKindForTarget` directly
+// against synthetic OpenComment lists. The DB-backed end-to-end (open-set basis
+// = resolved_at IS NULL) lives in comment-assessment.integration.test.ts.
+
+import { describe, it, expect } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import {
+  anchorKindForTarget,
+  groupCommentsByAnchorKind,
+  type OpenComment,
+} from "./comment-assessment.js";
+
+const AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-259/acs/ac-${n}`;
+
+function mkComment(
+  overrides: Partial<OpenComment> & {
+    targetKind: OpenComment["target"]["kind"];
+    createdAt: Date;
+  },
+): OpenComment {
+  const { targetKind, createdAt, ...rest } = overrides;
+  return {
+    commentId: rest.commentId ?? `c-${createdAt.getTime()}`,
+    type: rest.type ?? "discussion",
+    target: rest.target ?? {
+      kind: targetKind,
+      handle: targetKind === "decision" ? "dec-1" : "approach",
+      title: "T",
+    },
+    author: rest.author ?? "jane doe",
+    contentSnippet: rest.contentSnippet ?? "snippet",
+    createdAt,
+  };
+}
+
+describe("spec-259: open comments grouped by anchor kind (ac-1)", () => {
+  it("decision targets are decision-anchored; section + task targets are section-anchored", () => {
+    tagAc(AC(1));
+    expect(anchorKindForTarget("decision")).toBe("decision");
+    expect(anchorKindForTarget("section")).toBe("section");
+    // Tasks collapse into the section-anchored (narrative) group.
+    expect(anchorKindForTarget("task")).toBe("section");
+  });
+
+  it("groups oldest-first comments and reports the oldest createdAt per group", () => {
+    tagAc(AC(1));
+    // Oldest-first input (as assessCommentsStatus produces).
+    const comments: OpenComment[] = [
+      mkComment({ targetKind: "decision", createdAt: new Date("2026-06-01T00:00:00Z") }),
+      mkComment({ targetKind: "section", createdAt: new Date("2026-06-05T00:00:00Z") }),
+      mkComment({ targetKind: "task", createdAt: new Date("2026-06-08T00:00:00Z") }),
+      mkComment({ targetKind: "decision", createdAt: new Date("2026-06-10T00:00:00Z") }),
+    ];
+
+    const grouped = groupCommentsByAnchorKind(comments);
+
+    expect(grouped.decision.count).toBe(2);
+    expect(grouped.section.count).toBe(2); // section + task
+
+    // Oldest per group = the first (oldest-first order preserved).
+    expect(grouped.decision.oldestCreatedAt).toEqual(new Date("2026-06-01T00:00:00Z"));
+    expect(grouped.section.oldestCreatedAt).toEqual(new Date("2026-06-05T00:00:00Z"));
+
+    // Member order is preserved within each group.
+    expect(grouped.decision.comments.map((c) => c.createdAt.toISOString())).toEqual([
+      "2026-06-01T00:00:00.000Z",
+      "2026-06-10T00:00:00.000Z",
+    ]);
+    expect(grouped.section.comments.map((c) => c.target.kind)).toEqual([
+      "section",
+      "task",
+    ]);
+  });
+
+  it("an empty group reports count 0 and null oldest age", () => {
+    tagAc(AC(1));
+    const grouped = groupCommentsByAnchorKind([
+      mkComment({ targetKind: "decision", createdAt: new Date("2026-06-01T00:00:00Z") }),
+    ]);
+    expect(grouped.section.count).toBe(0);
+    expect(grouped.section.oldestCreatedAt).toBeNull();
+    expect(grouped.section.comments).toEqual([]);
+  });
+
+  it("operates on whatever it is given — it has no notion of resolved state (ac-10)", () => {
+    // ac-10: the open-set basis (resolved_at IS NULL) is the SOLE filter, applied
+    // by assessCommentsStatus's query. The grouper holds no second model — it
+    // groups every comment handed to it, so there is no place for a divergent
+    // 'open' definition to creep in.
+    tagAc(AC(10));
+    const all = [
+      mkComment({ targetKind: "decision", createdAt: new Date("2026-06-01T00:00:00Z") }),
+      mkComment({ targetKind: "section", createdAt: new Date("2026-06-02T00:00:00Z") }),
+    ];
+    const grouped = groupCommentsByAnchorKind(all);
+    expect(grouped.decision.count + grouped.section.count).toBe(all.length);
+  });
+});

--- a/packages/server/src/services/comment-assessment.ts
+++ b/packages/server/src/services/comment-assessment.ts
@@ -24,6 +24,27 @@ export interface OpenComment {
   createdAt: Date;
 }
 
+/**
+ * spec-259 t-3 — open comments grouped by ANCHOR KIND for the specify→build
+ * readiness surface. Comments are XOR-targeted at a section / decision / task;
+ * for the readiness view we collapse to two anchor groups the human cares
+ * about: decision-anchored (the comment hangs off a `dec-N`) and
+ * section-anchored (everything else — sections and tasks). Each group carries
+ * its member comments (oldest-first, inherited from the parent sort) plus the
+ * OLDEST createdAt across the group so a caller can render a "oldest Nd ago"
+ * age per group without re-walking the list.
+ */
+export type AnchorGroupKind = "decision" | "section";
+
+export interface CommentAnchorGroup {
+  kind: AnchorGroupKind;
+  count: number;
+  /** Oldest open-comment createdAt in this group, or null when empty. */
+  oldestCreatedAt: Date | null;
+  /** Member comments, oldest-first (same order as `comments`). */
+  comments: OpenComment[];
+}
+
 export interface CommentsStatus {
   briefId: string;
   specHandle: string;
@@ -40,6 +61,49 @@ export interface CommentsStatus {
   };
   /** Open comments, oldest-first. */
   comments: OpenComment[];
+  /**
+   * spec-259 t-3: the same open comments collapsed to two anchor groups
+   * (decision-anchored vs section-anchored), each with its member comments and
+   * the group's oldest createdAt. Backward-compatible add — existing callers
+   * that read `comments` / `byType` are untouched.
+   */
+  byAnchorKind: {
+    decision: CommentAnchorGroup;
+    section: CommentAnchorGroup;
+  };
+}
+
+/**
+ * spec-259 t-3: collapse a target kind to its anchor group. Decision targets
+ * are "decision-anchored"; sections and tasks are "section-anchored" (the
+ * narrative surface the human reviews). Pure — exported for unit testing.
+ */
+export function anchorKindForTarget(kind: CommentTargetKind): AnchorGroupKind {
+  return kind === "decision" ? "decision" : "section";
+}
+
+/**
+ * spec-259 t-3: group an oldest-first list of open comments by anchor kind,
+ * carrying per-group oldest createdAt. Input order is preserved within each
+ * group, so the first member of each group IS its oldest comment. Pure —
+ * exported for unit testing.
+ */
+export function groupCommentsByAnchorKind(
+  comments: readonly OpenComment[],
+): CommentsStatus["byAnchorKind"] {
+  const decisionComments = comments.filter((c) => anchorKindForTarget(c.target.kind) === "decision");
+  const sectionComments = comments.filter((c) => anchorKindForTarget(c.target.kind) === "section");
+  const group = (kind: AnchorGroupKind, members: OpenComment[]): CommentAnchorGroup => ({
+    kind,
+    count: members.length,
+    // Members inherit the parent oldest-first sort, so [0] is the oldest.
+    oldestCreatedAt: members.length > 0 ? members[0].createdAt : null,
+    comments: members,
+  });
+  return {
+    decision: group("decision", decisionComments),
+    section: group("section", sectionComments),
+  };
 }
 
 const SNIPPET_MAX = 120;
@@ -251,5 +315,6 @@ export async function assessCommentsStatus(
     totalOpen: comments.length,
     byType,
     comments,
+    byAnchorKind: groupCommentsByAnchorKind(comments),
   };
 }

--- a/packages/server/src/services/comment-resolution-attribution.spec-259.integration.test.ts
+++ b/packages/server/src/services/comment-resolution-attribution.spec-259.integration.test.ts
@@ -1,0 +1,99 @@
+// spec-259 ac-4 / dec-1 — comment resolution carries WHO + WHEN. REAL Postgres +
+// REAL bus + sink, patterned on attribution.spec-244.integration.test.ts.
+//
+// ac-4 asks the resolution model audit "who resolved, when". Build grounding found
+// resolveComment hardcoded mutate({}) — so WHO was dropped (activity_log row landed
+// actor_user_id = null). t-6 threaded an explicit RequestCtx through resolveComment
+// and the routed call sites (restCtx(c) / reqCtx(ctx)) per std-32. This test is the
+// guard: resolve a comment with a rest_ui ctx and assert the activity_log row for
+// the resolution carries the acting user (WHO) and the comment row carries
+// resolved_at (WHEN). The denormalized doc_comments.resolved_by_user_id column is
+// deferred (a follow-up Issue) — attribution rides the activity contract.
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { and, eq } from "drizzle-orm";
+import { db } from "../db/connection.js";
+import { activityLog, documents, decisions, tasks, docComments } from "../db/schema.js";
+import { createDocDraft } from "./documents.js";
+import { addComment, resolveComment } from "./comments.js";
+import { upsertUserByEmail } from "./users.js";
+import { actorCtx } from "./actor.js";
+import { makeTestMemex } from "./test-helpers.js";
+import {
+  startActivityLogSink,
+  _stopActivityLogSink,
+} from "./activity-log.js";
+
+const AC4 = "mindset-prod/memex-building-itself/specs/spec-259/acs/ac-4";
+
+let memexId: string;
+let userId: string;
+let docId: string;
+let user: Awaited<ReturnType<typeof upsertUserByEmail>>;
+
+beforeAll(async () => {
+  memexId = await makeTestMemex("comment-resolve-attrib");
+  user = await upsertUserByEmail(`resolver-${Date.now()}@memex.ai`);
+  userId = user.id;
+  const spec = await createDocDraft(memexId, "Resolution attribution spec", "Purpose", "spec");
+  docId = spec.id;
+  startActivityLogSink();
+});
+
+afterAll(async () => {
+  _stopActivityLogSink();
+  await db.delete(activityLog).where(eq(activityLog.memexId, memexId)).catch(() => {});
+  await db.delete(docComments).where(eq(docComments.memexId, memexId)).catch(() => {});
+  await db.delete(tasks).where(eq(tasks.docId, docId)).catch(() => {});
+  await db.delete(decisions).where(eq(decisions.docId, docId)).catch(() => {});
+  await db.delete(documents).where(eq(documents.id, docId)).catch(() => {});
+});
+
+async function waitForResolveActivity(timeoutMs = 1500) {
+  const start = Date.now();
+  for (;;) {
+    const rows = await db
+      .select()
+      .from(activityLog)
+      .where(
+        and(
+          eq(activityLog.memexId, memexId),
+          eq(activityLog.entity, "comment"),
+          eq(activityLog.action, "updated"),
+        ),
+      );
+    if (rows.length > 0 || Date.now() - start > timeoutMs) return rows;
+    await new Promise((r) => setTimeout(r, 25));
+  }
+}
+
+describe("comment resolution attribution (spec-259 ac-4)", () => {
+  it("resolveComment with a rest_ui ctx records WHO (actor_user_id) and WHEN (resolved_at)", async () => {
+    tagAc(AC4);
+    // createDocDraft seeds the overview section; anchor an open comment to it.
+    const sections = await db.query.docSections.findMany({
+      where: (s, { eq: eqs }) => eqs(s.docId, docId),
+    });
+    expect(sections.length).toBeGreaterThan(0);
+    const created = await addComment(memexId, sections[0].id, "barrie hadfield", "please address", {
+      type: "question",
+    });
+    expect(created.resolvedAt).toBeNull();
+
+    // Resolve it as an authenticated REST user.
+    const ctx = actorCtx(user, "rest_ui");
+    const resolved = await resolveComment(memexId, created.id, "acknowledged", ctx);
+
+    // WHEN: resolved_at stamped.
+    expect(resolved.resolvedAt).not.toBeNull();
+    expect(resolved.resolvedAt).toBeInstanceOf(Date);
+
+    // WHO: the resolution's activity_log row carries the acting user + human kind.
+    const rows = await waitForResolveActivity();
+    expect(rows.length).toBeGreaterThan(0);
+    const resolveRow = rows[rows.length - 1];
+    expect(resolveRow.actorUserId).toBe(userId);
+    expect(resolveRow.actorKind).toBe("human");
+  });
+});

--- a/packages/server/src/services/comments.ts
+++ b/packages/server/src/services/comments.ts
@@ -15,7 +15,7 @@ import {
 } from "../types/roles.js";
 import { isUuid, parseHandle } from "./shared/identifiers.js";
 import { nextSeq, withSeqRetry } from "./shared/sequence.js";
-import { mutate, type Mutated } from "./mutate.js";
+import { mutate, type Mutated, type RequestCtx } from "./mutate.js";
 import {
   hasAnchorMarker,
   insertMarkerAt,
@@ -779,6 +779,12 @@ export async function resolveComment(
   memexId: string,
   commentId: string,
   resolution?: string,
+  // spec-259 dec-1 / ac-4: resolution is an activity-bearing mutation, so it must
+  // carry WHO (std-32). The acting user rides the explicit RequestCtx through
+  // mutate() — the route/MCP caller passes restCtx(c)/reqCtx(ctx). It defaults to
+  // an empty ctx so unattributed/system callers still resolve (degrading to no
+  // actor rather than throwing), matching the rest of the activity contract.
+  ctx: RequestCtx = {},
 ): Promise<Mutated<DocComment>> {
   // Pre-load to fail fast on the FK lookup before opening the mutate transaction.
   const existing = await db.query.docComments.findFirst({
@@ -790,7 +796,7 @@ export async function resolveComment(
   const docId = (await getDocIdForComment(existing)) ?? undefined;
 
   return mutate(
-    {},
+    ctx,
     { memexId, docId, entity: "comment", action: "updated" },
     async () => {
       const [updated] = await db

--- a/packages/server/src/services/dedupe-personal-memexes.integration.test.ts
+++ b/packages/server/src/services/dedupe-personal-memexes.integration.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { readFileSync } from "node:fs";
+import { and, eq, inArray, sql } from "drizzle-orm";
+import { db } from "../db/connection.js";
+import { memexes, namespaces, documents, decisions, users } from "../db/schema.js";
+import { upsertUserByEmail } from "./users.js";
+import { createDecision } from "./decisions.js";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+// spec-293 t-4 (dec-4): the prod personal-Memex dedupe data migration. Seeds a
+// user with THREE personal Memexes (the pre-fix race outcome), with colliding
+// handles + content in the duplicates, then runs the real migration SQL and
+// asserts: content merged into the canonical with no loss, empties removed, the
+// ≤1-personal-Memex invariant holds, and a second run is a no-op.
+
+const SPEC = "mindset-prod/memex-building-itself/specs/spec-293";
+const ac = (n: number) => `${SPEC}/acs/ac-${n}`;
+
+const MIGRATION_SQL = readFileSync(
+  new URL("../../drizzle/0095_dedupe_personal_memexes.sql", import.meta.url),
+  "utf8",
+);
+
+async function runMigration(): Promise<void> {
+  await db.execute(sql.raw(MIGRATION_SQL));
+}
+
+// How many users currently have >1 personal Memex.
+async function offenderCount(): Promise<number> {
+  const rows = (await db.execute(sql`
+    SELECT count(*)::int AS n FROM (
+      SELECT n.owner_user_id
+        FROM namespaces n
+        JOIN memexes m ON m.namespace_id = n.id AND m.slug = 'personal'
+       WHERE n.kind = 'user' AND n.owner_user_id IS NOT NULL
+       GROUP BY n.owner_user_id
+      HAVING count(*) > 1
+    ) o
+  `)) as unknown as Array<{ n: number }>;
+  return rows[0]!.n;
+}
+
+let userId: string;
+let nsA: string;
+let nsB: string;
+let nsC: string;
+let mxA: string;
+let mxB: string;
+let mxC: string;
+let docA: string;
+let docB: string;
+let docC: string;
+
+beforeAll(async () => {
+  const user = await upsertUserByEmail(`dedupe-${Date.now()}@memex.ai`);
+  userId = user.id;
+
+  // Three user-namespaces owned by the same user, each with a 'personal' Memex.
+  const stamp = Date.now();
+  const [a, b, c] = await db
+    .insert(namespaces)
+    .values([
+      { slug: `dedupe-a-${stamp}`, kind: "user", ownerUserId: userId },
+      { slug: `dedupe-b-${stamp}`, kind: "user", ownerUserId: userId },
+      { slug: `dedupe-c-${stamp}`, kind: "user", ownerUserId: userId },
+    ])
+    .returning({ id: namespaces.id });
+  nsA = a!.id;
+  nsB = b!.id;
+  nsC = c!.id;
+
+  const [ma, mb, mc] = await db
+    .insert(memexes)
+    .values([
+      { namespaceId: nsA, slug: "personal", name: "Personal Memex" },
+      { namespaceId: nsB, slug: "personal", name: "Personal Memex" },
+      { namespaceId: nsC, slug: "personal", name: "Personal Memex" },
+    ])
+    .returning({ id: memexes.id });
+  mxA = ma!.id;
+  mxB = mb!.id;
+  mxC = mc!.id;
+
+  // users.namespaceId → nsA makes mxA the canonical.
+  await db.update(users).set({ namespaceId: nsA }).where(eq(users.id, userId));
+
+  // Content. All three use handle 'spec-1' to force handle re-mint on merge.
+  const [da] = await db
+    .insert(documents)
+    .values({ memexId: mxA, handle: "spec-1", title: "Canonical doc", docType: "spec", status: "draft" })
+    .returning({ id: documents.id });
+  const [dbb] = await db
+    .insert(documents)
+    .values({ memexId: mxB, handle: "spec-1", title: "Dup B doc", docType: "spec", status: "draft" })
+    .returning({ id: documents.id });
+  const [dc] = await db
+    .insert(documents)
+    .values({ memexId: mxC, handle: "spec-1", title: "Dup C doc", docType: "spec", status: "draft" })
+    .returning({ id: documents.id });
+  docA = da!.id;
+  docB = dbb!.id;
+  docC = dc!.id;
+
+  // A decision under the dup-B doc — must travel to the canonical with its doc.
+  await createDecision(mxB, docB, "Decision that must survive");
+});
+
+afterAll(async () => {
+  await db.delete(documents).where(inArray(documents.id, [docA, docB, docC])).catch(() => {});
+  await db.delete(memexes).where(inArray(memexes.id, [mxA, mxB, mxC])).catch(() => {});
+  await db.delete(namespaces).where(inArray(namespaces.id, [nsA, nsB, nsC])).catch(() => {});
+});
+
+describe("dedupe personal Memexes (dec-4)", () => {
+  it("ac-14/ac-15: merges duplicates into the canonical, deletes empties, loses nothing, is idempotent", async () => {
+    tagAc(ac(14));
+    tagAc(ac(15));
+    tagAc(ac(4)); // scope: idempotent, no-content-loss dedupe migration
+
+    // Precondition: this user has 3 personal Memexes.
+    const before = (await db.execute(sql`
+      SELECT count(*)::int AS n FROM memexes m
+        JOIN namespaces n ON n.id = m.namespace_id
+       WHERE m.slug = 'personal' AND n.kind = 'user' AND n.owner_user_id = ${userId}
+    `)) as unknown as Array<{ n: number }>;
+    expect(before[0]!.n).toBe(3);
+    expect(await offenderCount()).toBeGreaterThanOrEqual(1);
+
+    const docCountBefore = (await db.execute(sql`
+      SELECT count(*)::int AS n FROM documents WHERE id IN (${docA}, ${docB}, ${docC})
+    `)) as unknown as Array<{ n: number }>;
+    expect(docCountBefore[0]!.n).toBe(3);
+
+    await runMigration();
+
+    // The two duplicate Memexes are gone; the canonical remains.
+    const remaining = await db
+      .select({ id: memexes.id })
+      .from(memexes)
+      .where(inArray(memexes.id, [mxA, mxB, mxC]));
+    expect(remaining.map((r) => r.id)).toEqual([mxA]);
+
+    // No content lost: all three docs still exist…
+    const docsAfter = await db
+      .select({ id: documents.id, memexId: documents.memexId, handle: documents.handle })
+      .from(documents)
+      .where(inArray(documents.id, [docA, docB, docC]));
+    expect(docsAfter).toHaveLength(3);
+    // …and all now live in the canonical Memex…
+    expect(docsAfter.every((d) => d.memexId === mxA)).toBe(true);
+    // …with distinct (re-minted) handles — no unique-constraint violation.
+    const handles = docsAfter.map((d) => d.handle);
+    expect(new Set(handles).size).toBe(3);
+
+    // The dup-B decision travelled to the canonical.
+    const decRows = await db.select().from(decisions).where(eq(decisions.docId, docB));
+    expect(decRows.length).toBeGreaterThanOrEqual(1);
+    expect(decRows.every((d) => d.memexId === mxA)).toBe(true);
+
+    // Invariant (ac-14): no user has >1 personal Memex.
+    expect(await offenderCount()).toBe(0);
+
+    // Idempotent (ac-15): re-running raises nothing and changes nothing.
+    await expect(runMigration()).resolves.not.toThrow();
+    const stillOne = await db
+      .select({ id: memexes.id })
+      .from(memexes)
+      .where(and(inArray(memexes.id, [mxA, mxB, mxC])));
+    expect(stillOne.map((r) => r.id)).toEqual([mxA]);
+  });
+});

--- a/packages/server/src/services/doc-move.integration.test.ts
+++ b/packages/server/src/services/doc-move.integration.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, afterAll, beforeAll } from "vitest";
-import { and, eq, inArray } from "drizzle-orm";
+import { eq, inArray, sql } from "drizzle-orm";
+import postgres from "postgres";
 import { db } from "../db/connection.js";
 import {
   memexes,
@@ -9,30 +10,43 @@ import {
   docComments,
   decisions,
   tasks,
-  decisionDeps,
-  taskDeps,
+  acs,
+  issues,
+  docMembers,
+  docAssignees,
+  qaReportViews,
   shareTokens,
 } from "../db/schema.js";
 import { NotFoundError, ValidationError } from "../types/errors.js";
 import { makeTestMemex } from "./test-helpers.js";
-import { createDocDraft, getDoc, listDocs } from "./documents.js";
+import { createDocDraft, getDoc } from "./documents.js";
 import { createDecision } from "./decisions.js";
 import { createTask } from "./tasks.js";
-import { addDecisionDep, addTaskDep } from "./dependencies.js";
 import { addComment, addDecisionComment, addTaskComment } from "./comments.js";
 import { upsertUserByEmail } from "./users.js";
 import { createShareToken } from "./share-tokens.js";
-import { moveDoc, ForbiddenError } from "./doc-move.js";
+import { moveDoc } from "./doc-move.js";
+import { bus } from "./bus.js";
+import type { RequestCtx } from "./mutate.js";
+import { tagAc } from "@memex-ai-ac/vitest";
 
-// doc-move: cross-account spec relocation. Tests both the data plane (child rows'
-// account_id updates on the options flags) and the structural invariants (orphans remain,
-// cross-account deps are pruned, share tokens revoked, reversibility).
+// spec-293: cross-tenant Spec move. The move re-points memex_id ACROSS the RLS
+// tenant wall (the prod-only 500 this Spec fixes) via the SECURITY DEFINER
+// move_doc() function (migration 0094). A Spec now moves WHOLE (dec-2) and ALL
+// comments travel with it (dec-3); there are no per-artifact opt-outs.
 
-let accountA: string;
-let accountB: string;
-let accountC: string;
+const SPEC = "mindset-prod/memex-building-itself/specs/spec-293";
+const ac = (n: number) => `${SPEC}/acs/ac-${n}`;
+
+let memexA: string;
+let memexB: string;
+let memexC: string;
 let userId: string;
 let outsiderUserId: string;
+
+function ctxFor(uid: string): RequestCtx {
+  return { actorUserId: uid, actorName: "Mover", channel: "rest_ui" };
+}
 
 async function orgIdForMemex(memexId: string): Promise<string> {
   const m = await db.query.memexes.findFirst({ where: eq(memexes.id, memexId) });
@@ -43,9 +57,9 @@ async function orgIdForMemex(memexId: string): Promise<string> {
 }
 
 beforeAll(async () => {
-  accountA = await makeTestMemex("mva");
-  accountB = await makeTestMemex("mvb");
-  accountC = await makeTestMemex("mvc");
+  memexA = await makeTestMemex("mva");
+  memexB = await makeTestMemex("mvb");
+  memexC = await makeTestMemex("mvc");
 
   const user = await upsertUserByEmail(`doc-move-member-${Date.now()}@memex.ai`);
   userId = user.id;
@@ -53,9 +67,8 @@ beforeAll(async () => {
   outsiderUserId = outsider.id;
 
   // Member of A and B, NOT C. outsider isn't a member of anything relevant.
-  // org_memberships keys on org.id (not memex.id) post-doc-15.
-  const orgIdA = await orgIdForMemex(accountA);
-  const orgIdB = await orgIdForMemex(accountB);
+  const orgIdA = await orgIdForMemex(memexA);
+  const orgIdB = await orgIdForMemex(memexB);
   await db
     .insert(orgMemberships)
     .values([
@@ -68,192 +81,91 @@ beforeAll(async () => {
 afterAll(async () => {
   await db
     .delete(memexes)
-    .where(inArray(memexes.id, [accountA, accountB, accountC]))
+    .where(inArray(memexes.id, [memexA, memexB, memexC]))
     .catch(() => {});
 });
 
-describe("moveDoc — happy path", () => {
-  it("moves the doc + all children when every flag is on", async () => {
-    const doc = await createDocDraft(accountA, "Full Move", "Purpose");
+describe("moveDoc — whole-Spec move (dec-2 / dec-3)", () => {
+  it("ac-2/ac-10/ac-11/ac-12: every doc-scoped artifact lands in the target; read-state stays", async () => {
+    tagAc(ac(2));
+    tagAc(ac(10));
+    tagAc(ac(11));
+    tagAc(ac(12));
+
+    const doc = await createDocDraft(memexA, "Whole Move", "Purpose");
     const section = doc.sections[0];
-    const dec = await createDecision(accountA, doc.id, "Decision 1");
-    const task = await createTask(accountA, doc.id, "Task 1", "");
-    await addComment(accountA, section.id, "u", "sec comment");
-    await addDecisionComment(accountA, dec.id, "u", "dec comment");
-    await addTaskComment(accountA, task.id, "u", "task comment");
+    const dec = await createDecision(memexA, doc.id, "Decision 1");
+    const task = await createTask(memexA, doc.id, "Task 1", "");
+    const secComment = await addComment(memexA, section.id, "u", "section comment");
+    const decComment = await addDecisionComment(memexA, dec.id, "u", "decision comment");
+    const taskComment = await addTaskComment(memexA, task.id, "u", "task comment");
 
-    const result = await moveDoc(accountA, doc.id, accountB, userId, {
-      includeDecisions: true,
-      includeTasks: true,
-      includeSectionComments: true,
-    });
+    // Artifacts with no convenient creation service — seeded directly in A.
+    const [acRow] = await db
+      .insert(acs)
+      .values({ memexId: memexA, briefId: doc.id, seq: 1, kind: "scope", statement: "must move" })
+      .returning({ id: acs.id });
+    const [issueRow] = await db
+      .insert(issues)
+      .values({ memexId: memexA, docId: doc.id, seq: 1, title: "Bug", body: "b", type: "bug" })
+      .returning({ id: issues.id });
+    await db.insert(docMembers).values({ memexId: memexA, docId: doc.id, userId, role: "editor" });
+    await db.insert(docAssignees).values({ memexId: memexA, docId: doc.id, userId });
 
-    expect(result.doc.memexId).toBe(accountB);
-    // createDocDraft defaults to docType="spec" (b-105) → spec-N handles.
+    // Per-user / per-Memex read-state — must NOT move (dec-2 / ac-11).
+    await db
+      .insert(qaReportViews)
+      .values({ userId, memexId: memexA })
+      .onConflictDoNothing();
+
+    const result = await moveDoc(memexA, doc.id, memexB, ctxFor(userId));
+
+    expect(result.docId).toBe(doc.id);
     expect(result.newHandle).toMatch(/^spec-\d+$/);
 
-    // Everything should now be findable in B and invisible in A.
-    await expect(getDoc(accountA, doc.id)).rejects.toThrow(NotFoundError);
-    const fetched = await getDoc(accountB, doc.id);
+    // The doc is gone from A and present in B at its new handle.
+    await expect(getDoc(memexA, doc.id)).rejects.toThrow(NotFoundError);
+    const fetched = await getDoc(memexB, doc.id);
     expect(fetched.id).toBe(doc.id);
     expect(fetched.handle).toBe(result.newHandle);
 
-    const decRows = await db.select().from(decisions).where(eq(decisions.docId, doc.id));
-    expect(decRows.every((d) => d.memexId === accountB)).toBe(true);
+    // Every memex_id-bearing doc-scoped artifact now reads memex_id = B.
+    const [decRow] = await db.select().from(decisions).where(eq(decisions.id, dec.id));
+    expect(decRow.memexId).toBe(memexB);
+    const [taskRow] = await db.select().from(tasks).where(eq(tasks.id, task.id));
+    expect(taskRow.memexId).toBe(memexB);
+    const [acAfter] = await db.select().from(acs).where(eq(acs.id, acRow!.id));
+    expect(acAfter.memexId).toBe(memexB);
+    const [issueAfter] = await db.select().from(issues).where(eq(issues.id, issueRow!.id));
+    expect(issueAfter.memexId).toBe(memexB);
+    const memberRows = await db.select().from(docMembers).where(eq(docMembers.docId, doc.id));
+    expect(memberRows.every((m) => m.memexId === memexB)).toBe(true);
+    const assigneeRows = await db.select().from(docAssignees).where(eq(docAssignees.docId, doc.id));
+    expect(assigneeRows.every((a) => a.memexId === memexB)).toBe(true);
 
-    const taskRows = await db.select().from(tasks).where(eq(tasks.docId, doc.id));
-    expect(taskRows.every((t) => t.memexId === accountB)).toBe(true);
-
+    // dec-3: ALL comments move — section, decision AND task — unconditionally.
     const commentRows = await db
       .select()
       .from(docComments)
-      .where(
-        inArray(
-          docComments.id,
-          (
-            await db
-              .select({ id: docComments.id })
-              .from(docComments)
-              .leftJoin(decisions, eq(docComments.decisionId, decisions.id))
-              .leftJoin(tasks, eq(docComments.taskId, tasks.id))
-              .where(
-                // Any comment attached (directly or via decision/task) to this doc.
-                // We just want to eyeball account_id on all of them.
-                eq(decisions.docId, doc.id),
-              )
-          ).map((r) => r.id),
-        ),
-      );
-    // Coarse check: all comments that reference this doc via decision are in B.
-    expect(commentRows.every((c) => c.memexId === accountB)).toBe(true);
-  });
-});
+      .where(inArray(docComments.id, [secComment.id, decComment.id, taskComment.id]));
+    expect(commentRows).toHaveLength(3);
+    expect(commentRows.every((c) => c.memexId === memexB)).toBe(true);
 
-describe("moveDoc — selective flags leave orphans", () => {
-  it("includeDecisions=false leaves decisions + decision-comments in the source account", async () => {
-    const doc = await createDocDraft(accountA, "Leave Decisions", "Purpose");
-    const dec = await createDecision(accountA, doc.id, "Stay behind");
-    await addDecisionComment(accountA, dec.id, "u", "dec stays");
-
-    await moveDoc(accountA, doc.id, accountB, userId, {
-      includeDecisions: false,
-      includeTasks: true,
-      includeSectionComments: true,
-    });
-
-    const decRow = await db.query.decisions.findFirst({ where: eq(decisions.id, dec.id) });
-    expect(decRow?.memexId).toBe(accountA);
-
-    const comment = await db.query.docComments.findFirst({
-      where: eq(docComments.decisionId, dec.id),
-    });
-    expect(comment?.memexId).toBe(accountA);
-  });
-
-  it("includeTasks=false leaves tasks + task-comments in the source account", async () => {
-    const doc = await createDocDraft(accountA, "Leave Tasks", "Purpose");
-    const task = await createTask(accountA, doc.id, "Stay", "");
-    await addTaskComment(accountA, task.id, "u", "task stays");
-
-    await moveDoc(accountA, doc.id, accountB, userId, {
-      includeDecisions: true,
-      includeTasks: false,
-      includeSectionComments: true,
-    });
-
-    const taskRow = await db.query.tasks.findFirst({ where: eq(tasks.id, task.id) });
-    expect(taskRow?.memexId).toBe(accountA);
-    const comment = await db.query.docComments.findFirst({
-      where: eq(docComments.taskId, task.id),
-    });
-    expect(comment?.memexId).toBe(accountA);
-  });
-
-  it("includeSectionComments=false leaves section-comments in the source account", async () => {
-    const doc = await createDocDraft(accountA, "Leave Comments", "Purpose");
-    const section = doc.sections[0];
-    const added = await addComment(accountA, section.id, "u", "sec stays");
-
-    await moveDoc(accountA, doc.id, accountB, userId, {
-      includeDecisions: true,
-      includeTasks: true,
-      includeSectionComments: false,
-    });
-
-    const comment = await db.query.docComments.findFirst({ where: eq(docComments.id, added.id) });
-    expect(comment?.memexId).toBe(accountA);
-  });
-});
-
-describe("moveDoc — cross-account deps are pruned", () => {
-  it("deletes decision_deps when the task moves but the decision doesn't", async () => {
-    const doc = await createDocDraft(accountA, "Dep Pruning Dec", "Purpose");
-    const dec = await createDecision(accountA, doc.id, "Blocker");
-    const task = await createTask(accountA, doc.id, "Blocked", "");
-    await addDecisionDep(accountA, task.id, dec.id);
-
-    // Move doc + tasks but leave decisions behind → decision_deps now cross accounts.
-    const result = await moveDoc(accountA, doc.id, accountB, userId, {
-      includeDecisions: false,
-      includeTasks: true,
-      includeSectionComments: true,
-    });
-
-    expect(result.removedDecisionDeps).toBeGreaterThanOrEqual(1);
-    const deps = await db
+    // ac-11: the read-state row stays in A (not Spec content).
+    const [view] = await db
       .select()
-      .from(decisionDeps)
-      .where(and(eq(decisionDeps.taskId, task.id), eq(decisionDeps.decisionId, dec.id)));
-    expect(deps.length).toBe(0);
+      .from(qaReportViews)
+      .where(eq(qaReportViews.userId, userId));
+    expect(view.memexId).toBe(memexA);
   });
 
-  it("deletes task_deps that straddle memexes after a partial move", async () => {
-    const doc = await createDocDraft(accountA, "Dep Pruning Task", "Purpose");
-    const t1 = await createTask(accountA, doc.id, "A", "");
-    const t2 = await createTask(accountA, doc.id, "B", "");
-    await addTaskDep(accountA, t1.id, t2.id);
-
-    // Sanity precondition — the dep exists.
-    const before = await db.select().from(taskDeps).where(eq(taskDeps.taskId, t1.id));
-    expect(before.length).toBe(1);
-
-    // Move t2 over to B manually by simulating a previous "partial" move wouldn't really
-    // happen via our API — but we want to prove the DELETE query kicks in when memexes
-    // diverge. So: move the doc WITH tasks to B, then flip t2 back to A manually to
-    // construct a cross-account state, then re-run a no-op move (doc already in B, so we
-    // just directly run the DELETE query via a hand-wired ad-hoc move won't apply).
-    //
-    // Simpler: move the doc WITH decisions only, leaving tasks in A. The doc now lives in
-    // B while both tasks + their dep stay in A — that's intra-account, not cross, so no
-    // prune expected. That doesn't test what I want.
-    //
-    // Actually to get cross-account task_deps we can: move the doc with tasks=true; the
-    // dep rows follow implicitly because they're just (taskId, dependsOnId) with no
-    // account_id. So they never straddle. The straddle case only arises if someone wires
-    // a dep across docs that live in different memexes — not a scenario we build here.
-    //
-    // Keep this as a no-prune assertion: dep survives when both tasks move together.
-    await moveDoc(accountA, doc.id, accountB, userId, {
-      includeDecisions: true,
-      includeTasks: true,
-      includeSectionComments: true,
-    });
-    const after = await db.select().from(taskDeps).where(eq(taskDeps.taskId, t1.id));
-    expect(after.length).toBe(1);
-  });
-});
-
-describe("moveDoc — share tokens revoked", () => {
-  it("marks active share tokens revoked on move", async () => {
-    const doc = await createDocDraft(accountA, "Share Revoke", "Purpose");
-    const token = await createShareToken(accountA, doc.id);
+  it("ac-2: active share tokens are revoked on move", async () => {
+    tagAc(ac(2));
+    const doc = await createDocDraft(memexA, "Share Revoke", "Purpose");
+    const token = await createShareToken(memexA, doc.id);
     expect(token.revoked).toBe(false);
 
-    const result = await moveDoc(accountA, doc.id, accountB, userId, {
-      includeDecisions: true,
-      includeTasks: true,
-      includeSectionComments: true,
-    });
+    const result = await moveDoc(memexA, doc.id, memexB, ctxFor(userId));
     expect(result.revokedShareTokens).toBe(1);
 
     const reread = await db.query.shareTokens.findFirst({ where: eq(shareTokens.id, token.id) });
@@ -261,81 +173,160 @@ describe("moveDoc — share tokens revoked", () => {
   });
 });
 
-describe("moveDoc — reversibility (orphans re-attach)", () => {
-  it("moving back to the source restores orphaned children", async () => {
-    const doc = await createDocDraft(accountA, "Round Trip", "Purpose");
-    const dec = await createDecision(accountA, doc.id, "Sticks");
+describe("moveDoc — attribution (dec-5 / std-32)", () => {
+  it("ac-16: both emitted events carry channel='rest_ui' and the actor", async () => {
+    tagAc(ac(16));
+    tagAc(ac(6)); // scope: move writes are attributed (channel + actor), never empty ctx
+    const doc = await createDocDraft(memexA, "Attributed Move", "Purpose");
 
-    // A → B, leaving decisions behind.
-    await moveDoc(accountA, doc.id, accountB, userId, {
-      includeDecisions: false,
-      includeTasks: true,
-      includeSectionComments: true,
+    const seen: { memexId: string; channel?: string; actorUserId?: string }[] = [];
+    const unsubscribe = bus.subscribe({}, (event) => {
+      if (
+        event.entity === "document" &&
+        (event.memexId === memexA || event.memexId === memexB)
+      ) {
+        seen.push({
+          memexId: event.memexId,
+          channel: event.channel,
+          actorUserId: event.actorUserId,
+        });
+      }
     });
+    try {
+      await moveDoc(memexA, doc.id, memexB, ctxFor(userId));
+    } finally {
+      unsubscribe();
+    }
 
-    // While doc lives in B, the orphan decision shouldn't show up via B's listDocs flow.
-    const decStillInA = await db.query.decisions.findFirst({ where: eq(decisions.id, dec.id) });
-    expect(decStillInA?.memexId).toBe(accountA);
-
-    // B → A moves the doc back. The orphan decision is still in A, so it re-attaches by
-    // virtue of (doc.memexId == dec.memexId) returning true.
-    await moveDoc(accountB, doc.id, accountA, userId, {
-      includeDecisions: true,
-      includeTasks: true,
-      includeSectionComments: true,
-    });
-
-    const restored = await db.query.decisions.findFirst({ where: eq(decisions.id, dec.id) });
-    expect(restored?.memexId).toBe(accountA);
-
-    // listDocs in A now includes the doc again.
-    const list = await listDocs(accountA);
-    expect(list.some((d) => d.id === doc.id)).toBe(true);
+    const source = seen.find((e) => e.memexId === memexA);
+    const target = seen.find((e) => e.memexId === memexB);
+    expect(source, `expected source emit; saw ${JSON.stringify(seen)}`).toBeDefined();
+    expect(target, `expected target emit; saw ${JSON.stringify(seen)}`).toBeDefined();
+    for (const e of [source!, target!]) {
+      expect(e.channel).toBe("rest_ui");
+      expect(e.actorUserId).toBe(userId);
+    }
   });
 });
 
-describe("moveDoc — errors", () => {
-  it("rejects same-account moves", async () => {
-    const doc = await createDocDraft(accountA, "Same Account", "Purpose");
-    await expect(
-      moveDoc(accountA, doc.id, accountA, userId, {
-        includeDecisions: true,
-        includeTasks: true,
-        includeSectionComments: true,
-      }),
-    ).rejects.toThrow(ValidationError);
+describe("moveDoc — errors (std-7)", () => {
+  it("rejects same-memex moves", async () => {
+    const doc = await createDocDraft(memexA, "Same Memex", "Purpose");
+    await expect(moveDoc(memexA, doc.id, memexA, ctxFor(userId))).rejects.toThrow(ValidationError);
   });
 
-  it("404s when the doc isn't in the source account", async () => {
-    const doc = await createDocDraft(accountA, "Wrong Source", "Purpose");
-    await expect(
-      moveDoc(accountB, doc.id, accountA, userId, {
-        includeDecisions: true,
-        includeTasks: true,
-        includeSectionComments: true,
-      }),
-    ).rejects.toThrow(NotFoundError);
+  it("404s when the doc isn't in the source memex", async () => {
+    const doc = await createDocDraft(memexA, "Wrong Source", "Purpose");
+    await expect(moveDoc(memexB, doc.id, memexA, ctxFor(userId))).rejects.toThrow(NotFoundError);
   });
 
-  it("403s when the user isn't an active member of the target", async () => {
-    const doc = await createDocDraft(accountA, "Forbidden Target", "Purpose");
-    await expect(
-      moveDoc(accountA, doc.id, accountC, userId, {
-        includeDecisions: true,
-        includeTasks: true,
-        includeSectionComments: true,
-      }),
-    ).rejects.toThrow(ForbiddenError);
+  it("ac-9: 404s (not 403) when the caller isn't authorized in the target", async () => {
+    tagAc(ac(9));
+    const doc = await createDocDraft(memexA, "Forbidden Target", "Purpose");
+    // memexC: the user is NOT a member. std-7 → 404, never 403.
+    await expect(moveDoc(memexA, doc.id, memexC, ctxFor(userId))).rejects.toThrow(NotFoundError);
+    // The doc must NOT have moved.
+    const [row] = await db.select().from(documents).where(eq(documents.id, doc.id));
+    expect(row.memexId).toBe(memexA);
   });
 
-  it("403s when a non-member tries to move", async () => {
-    const doc = await createDocDraft(accountA, "Non Member", "Purpose");
-    await expect(
-      moveDoc(accountA, doc.id, accountB, outsiderUserId, {
-        includeDecisions: true,
-        includeTasks: true,
-        includeSectionComments: true,
-      }),
-    ).rejects.toThrow(ForbiddenError);
+  it("ac-9: 404s when a non-member tries to move", async () => {
+    tagAc(ac(9));
+    const doc = await createDocDraft(memexA, "Non Member", "Purpose");
+    await expect(moveDoc(memexA, doc.id, memexB, ctxFor(outsiderUserId))).rejects.toThrow(
+      NotFoundError,
+    );
+  });
+});
+
+// The regression anchor: prove the move works under the PROD runtime posture.
+// The whole suite + local dev connect as the table OWNER (RLS-exempt under
+// NO FORCE, std-36), so the original bug never reproduced. Here we drop into the
+// non-owner `memex_app` role (NOBYPASSRLS, the Cloud Run runtime) and show:
+//   (a) the naive cross-tenant UPDATE is rejected by the memex_isolation
+//       WITH CHECK — this IS the prod-only 500 (ac-1's failure mode), and
+//   (b) move_doc() (SECURITY DEFINER, owner-owned) succeeds where it cannot.
+describe("moveDoc — cross-tenant RLS regression (NOBYPASSRLS runtime role)", () => {
+  it("ac-1/ac-7: naive UPDATE is RLS-rejected; move_doc() succeeds under memex_app", async () => {
+    tagAc(ac(1));
+    tagAc(ac(7));
+    tagAc(ac(5)); // scope: the test that would have caught the prod bug exists & runs
+
+    const dbUrl =
+      process.env.DATABASE_URL ?? "postgresql://postgres:postgres@localhost:5432/memex";
+    const appSql = postgres(dbUrl, { max: 1 });
+    try {
+      // (a) The bug: as memex_app, scoped to A, re-pointing memex_id → B trips
+      // the WITH CHECK. This is exactly what 500'd on prod before this Spec.
+      const naive = await createDocDraft(memexA, "RLS Naive", "Purpose");
+      await expect(
+        appSql.begin(async (tx) => {
+          await tx.unsafe("SET LOCAL ROLE memex_app");
+          await tx.unsafe("SELECT set_config('app.memex_id', $1, true)", [memexA]);
+          return tx.unsafe("UPDATE documents SET memex_id = $1 WHERE id = $2", [memexB, naive.id]);
+        }),
+      ).rejects.toThrow();
+
+      // It did not move.
+      const [stillA] = await db.select().from(documents).where(eq(documents.id, naive.id));
+      expect(stillA.memexId).toBe(memexA);
+
+      // (b) The fix: the SECURITY DEFINER function moves it cleanly under the
+      // very same restricted role.
+      const moved = await createDocDraft(memexA, "RLS Via Function", "Purpose");
+      const rows = (await appSql.begin(async (tx) => {
+        await tx.unsafe("SET LOCAL ROLE memex_app");
+        await tx.unsafe("SELECT set_config('app.memex_id', $1, true)", [memexA]);
+        return tx.unsafe(
+          "SELECT new_handle FROM move_doc($1::uuid, $2::uuid, $3::uuid, $4::uuid)",
+          [moved.id, memexA, memexB, userId],
+        );
+      })) as unknown as Array<{ new_handle: string }>;
+
+      expect(rows[0]?.new_handle).toMatch(/^spec-\d+$/);
+      const [nowB] = await db.select().from(documents).where(eq(documents.id, moved.id));
+      expect(nowB.memexId).toBe(memexB);
+    } finally {
+      await appSql.end({ timeout: 5 });
+    }
+  });
+
+  it("ac-8: move_doc is SECURITY DEFINER, owned by the documents table owner, and memex_app holds only EXECUTE", async () => {
+    tagAc(ac(8));
+
+    // SECURITY DEFINER + owner == the owner of `documents` (the role RLS exempts
+    // under NO FORCE). Comparing to documents' owner avoids hardcoding 'postgres'.
+    const [meta] = (await db.execute(sql`
+      SELECT p.prosecdef AS security_definer,
+             pg_get_userbyid(p.proowner) AS fn_owner,
+             pg_get_userbyid(c.relowner) AS table_owner
+        FROM pg_proc p
+        JOIN pg_namespace n ON n.oid = p.pronamespace
+        CROSS JOIN pg_class c
+        JOIN pg_namespace cn ON cn.oid = c.relnamespace
+       WHERE p.proname = 'move_doc' AND n.nspname = 'public'
+         AND c.relname = 'documents' AND cn.nspname = 'public'
+    `)) as unknown as Array<{ security_definer: boolean; fn_owner: string; table_owner: string }>;
+    expect(meta.security_definer).toBe(true);
+    expect(meta.fn_owner).toBe(meta.table_owner);
+
+    // memex_app may EXECUTE move_doc…
+    const [priv] = (await db.execute(sql`
+      SELECT has_function_privilege('memex_app', 'move_doc(uuid,uuid,uuid,uuid)', 'EXECUTE') AS app_execute,
+             has_function_privilege('public',    'move_doc(uuid,uuid,uuid,uuid)', 'EXECUTE') AS public_execute,
+             (SELECT rolbypassrls FROM pg_roles WHERE rolname = 'memex_app') AS app_bypassrls,
+             (SELECT rolsuper      FROM pg_roles WHERE rolname = 'memex_app') AS app_super
+    `)) as unknown as Array<{
+      app_execute: boolean;
+      public_execute: boolean;
+      app_bypassrls: boolean;
+      app_super: boolean;
+    }>;
+    expect(priv.app_execute).toBe(true);
+    // …and gains no general cross-tenant power: PUBLIC can't call it, and the
+    // runtime role neither bypasses RLS nor is a superuser.
+    expect(priv.public_execute).toBe(false);
+    expect(priv.app_bypassrls).toBe(false);
+    expect(priv.app_super).toBe(false);
   });
 });

--- a/packages/server/src/services/doc-move.ts
+++ b/packages/server/src/services/doc-move.ts
@@ -1,23 +1,12 @@
-import { and, eq, sql } from "drizzle-orm";
+import { sql } from "drizzle-orm";
 import { db } from "../db/connection.js";
-import {
-  documents,
-  docSections,
-  docComments,
-  decisions,
-  tasks,
-  shareTokens,
-  orgMemberships,
-  memexes,
-  namespaces,
-} from "../db/schema.js";
-import type { Doc } from "../db/schema.js";
 import { NotFoundError, ValidationError } from "../types/errors.js";
-import { mutate, type Mutated } from "./mutate.js";
-import { nextSpecHandle, nextDocHandle } from "./documents.js";
-import { withSeqRetry } from "./shared/sequence.js";
+import { mutate, type Mutated, type RequestCtx } from "./mutate.js";
 
-// Error surfaced when the caller isn't a member of the target memex.
+// Retained for backward compatibility with existing importers. The cross-tenant
+// authorization failure is now raised inside the move_doc() DB function as
+// SQLSTATE 'MX002' and surfaced as a 404 per std-7 (unauthorized → 404, never
+// 403) — see moveDoc()'s catch below. No code path throws this anymore.
 export class ForbiddenError extends Error {
   constructor(message: string) {
     super(message);
@@ -25,218 +14,104 @@ export class ForbiddenError extends Error {
   }
 }
 
-export interface MoveDocOptions {
-  includeDecisions: boolean;
-  includeTasks: boolean;
-  includeSectionComments: boolean;
-}
-
 export interface MoveDocResult {
-  doc: Doc;
+  docId: string;
   fromMemexId: string;
   toMemexId: string;
   newHandle: string;
-  // Counts of dep rows that were deleted because they straddled two accounts after the move.
+  // Counts of dep rows deleted because they straddled two memexes after the move.
   removedDecisionDeps: number;
   removedTaskDeps: number;
-  // Count of share tokens revoked on move (public URLs are subdomain-scoped by convention,
-  // so they'd effectively stop working anyway once the doc leaves the source subdomain).
+  // Count of share tokens revoked on move.
   revokedShareTokens: number;
 }
 
-// Moves a Spec from one memex to another. The doc's UUID is preserved so anything
-// FK-linked (sections, decisions, tasks, comments, conversations, share tokens) stays
-// attached — the user chooses via opts whether children also change their account scope.
+interface MoveDocRow {
+  new_handle: string;
+  revoked_share_tokens: number;
+  removed_decision_deps: number;
+  removed_task_deps: number;
+}
+
+// Moves a Spec from one Memex to another, whole (spec-293 dec-2/dec-3): the doc
+// and every doc-scoped artifact (sections, all comments, decisions, tasks, ACs,
+// test events, issues, members, assignees, tags, conversations, clause refs)
+// travel together. The doc's UUID is preserved; its handle is re-minted in the
+// target.
 //
-// Children whose memex_id is not updated remain "orphaned" in the source memex: they
-// still FK to the moved doc, so if the doc is moved back later they re-appear.
-//
-// Semantic rules that aren't configurable:
-//   - Sections always follow the doc (they don't carry memex_id — scoped via doc_id).
-//   - Decision-comments follow their decisions; task-comments follow their tasks. Only
-//     section-comments have an independent checkbox (includeSectionComments).
-//   - Any decision/task dep edges whose endpoints end up in different accounts are
-//     deleted after the move (silent per product decision). Counts are returned so the
-//     UI can surface a toast.
-//   - All share tokens for the doc are revoked on move.
+// The row-touching work lives in the SECURITY DEFINER `move_doc` DB function
+// (migration 0094): the move re-points memex_id ACROSS the RLS tenant wall, which
+// the runtime `memex_app` role cannot do directly (the memex_isolation WITH CHECK
+// rejects it — the prod-only 500 this Spec fixes). The function executes as the
+// table owner, so its writes bypass RLS for this one sanctioned, audited op;
+// `memex_app` holds only EXECUTE on it (std-36, dec-1). This wrapper keeps the
+// request-side concerns: validation, attribution (RequestCtx → mutate), and the
+// cross-tenant bus emission on BOTH memexes.
 export async function moveDoc(
   fromMemexId: string,
   docId: string,
   toMemexId: string,
-  userId: string,
-  opts: MoveDocOptions,
+  ctx: RequestCtx,
 ): Promise<Mutated<MoveDocResult>> {
   if (fromMemexId === toMemexId) {
     throw new ValidationError("Source and target memex must differ");
   }
+  const userId = ctx.actorUserId;
+  if (!userId) {
+    // A move is an authorization-bearing operation; we must know WHO is moving.
+    throw new ValidationError("A resolved user is required to move a Spec");
+  }
 
-  // Cross-tenant emit: notify both the source and target memex so list views in
-  // either tenant refetch. mutate() runs the transaction once and emits both
-  // events on success (the two keys are independent invariants per dec-2).
+  // Cross-tenant emit: notify BOTH the source and target memex so list views in
+  // either tenant refetch (dec-2 of the reactivity contract). mutate() runs fn
+  // once and, on success, emits one 'document updated' event per key, now carrying
+  // the channel + actor from ctx (spec-293 dec-5 / std-32).
   return mutate(
-    {},
+    ctx,
     [
       { memexId: fromMemexId, docId, entity: "document", action: "updated" },
       { memexId: toMemexId, docId, entity: "document", action: "updated" },
     ],
     async () => {
-  // spec-187: the handle re-mint inside this tx is the racy MAX+1 read — a
-  // concurrent create/move into the target memex can collide on
-  // `documents_memex_id_handle_unique`. The tx is pure-DB, so retrying it
-  // wholesale re-mints cleanly (same shape as createDocDraft's wrap).
-  const result = await withSeqRetry(() => db.transaction(async (tx) => {
-    // Lock the row so concurrent writes (agent/MCP/REST) serialize against the move.
-    const [doc] = await tx
-      .select()
-      .from(documents)
-      .where(and(eq(documents.id, docId), eq(documents.memexId, fromMemexId)))
-      .for("update");
+      let rows: MoveDocRow[];
+      try {
+        rows = (await db.execute(sql`
+          SELECT new_handle, revoked_share_tokens, removed_decision_deps, removed_task_deps
+            FROM move_doc(${docId}::uuid, ${fromMemexId}::uuid, ${toMemexId}::uuid, ${userId}::uuid)
+        `)) as unknown as MoveDocRow[];
+      } catch (err) {
+        // Translate the function's domain SQLSTATEs into HTTP-shaped errors.
+        // Drizzle wraps driver errors (DrizzleQueryError) with the PostgresError
+        // on `.cause`, so check both the error and its cause for the SQLSTATE.
+        const code =
+          (err as { code?: string } | null)?.code ??
+          ((err as { cause?: { code?: string } } | null)?.cause?.code);
+        if (code === "MX001" || code === "MX002") {
+          // Doc not found in source, or caller not authorized in source/target.
+          // std-7: unauthorized → 404, never 403 (don't leak existence).
+          throw new NotFoundError("Document not found");
+        }
+        if (code === "MX003") {
+          throw new ValidationError("Source and target memex must differ");
+        }
+        throw err;
+      }
 
-    if (!doc) {
-      throw new NotFoundError(`Document ${docId} not found`);
-    }
+      const row = rows[0];
+      if (!row) {
+        // move_doc always RETURN NEXTs exactly one row on success.
+        throw new NotFoundError("Document not found");
+      }
 
-    // Caller must be allowed to write to the target memex: either they own its
-    // namespace (personal memex) or have an active org_membership in the org that
-    // owns its namespace.
-    const targetMemex = await tx.query.memexes.findFirst({
-      where: eq(memexes.id, toMemexId),
-    });
-    if (!targetMemex) {
-      throw new NotFoundError(`Memex ${toMemexId} not found`);
-    }
-    const targetNs = await tx.query.namespaces.findFirst({
-      where: eq(namespaces.id, targetMemex.namespaceId),
-    });
-    let allowed = false;
-    if (targetNs?.kind === "user" && targetNs.ownerUserId === userId) {
-      allowed = true;
-    } else if (targetNs?.kind === "org" && targetNs.ownerOrgId) {
-      const membership = await tx.query.orgMemberships.findFirst({
-        where: and(
-          eq(orgMemberships.userId, userId),
-          eq(orgMemberships.orgId, targetNs.ownerOrgId),
-          eq(orgMemberships.status, "active"),
-        ),
-      });
-      if (membership) allowed = true;
-    }
-    if (!allowed) {
-      throw new ForbiddenError("You are not a member of the target Memex");
-    }
-
-    // Per doc-30 dec-1 + dec-3: specs get a `spec-N` handle on move; everything
-    // else (free-form documents, execution-plans, legacy docTypes) keeps `doc-N`.
-    const newHandle = doc.docType === "spec"
-      ? await nextSpecHandle(toMemexId, tx)
-      : await nextDocHandle(toMemexId, tx);
-
-    const [updatedDoc] = await tx
-      .update(documents)
-      .set({ memexId: toMemexId, handle: newHandle })
-      .where(eq(documents.id, docId))
-      .returning();
-
-    // Sections have no memex_id — they follow the doc via doc_id FK.
-
-    // Section comments: move iff includeSectionComments. Resolved via doc_sections ⇒ doc.
-    if (opts.includeSectionComments) {
-      await tx.execute(sql`
-        UPDATE doc_comments
-           SET memex_id = ${toMemexId}
-         WHERE section_id IN (SELECT id FROM doc_sections WHERE doc_id = ${docId})
-      `);
-    }
-
-    // Decisions + their comments travel as a unit. If includeDecisions=false, both stay
-    // behind with memex_id = fromMemexId and orphan in the source.
-    if (opts.includeDecisions) {
-      await tx
-        .update(decisions)
-        .set({ memexId: toMemexId })
-        .where(eq(decisions.docId, docId));
-
-      await tx.execute(sql`
-        UPDATE doc_comments
-           SET memex_id = ${toMemexId}
-         WHERE decision_id IN (SELECT id FROM decisions WHERE doc_id = ${docId})
-      `);
-    }
-
-    // Tasks + their comments travel as a unit (same logic). includeTasks keeps its
-    // legacy name on the option since it's the user-visible "Tasks" checkbox.
-    if (opts.includeTasks) {
-      await tx
-        .update(tasks)
-        .set({ memexId: toMemexId })
-        .where(eq(tasks.docId, docId));
-
-      await tx.execute(sql`
-        UPDATE doc_comments
-           SET memex_id = ${toMemexId}
-         WHERE task_id IN (SELECT id FROM tasks WHERE doc_id = ${docId})
-      `);
-    }
-
-    // After the ownership updates, any dep row that now straddles two accounts is
-    // structurally invalid (the blocking/blocked entities live in different memexes and
-    // the blocked user can no longer see the blocker). Silent-delete per product decision;
-    // return the count so the UI can surface a toast.
-    //
-    // Note: cross-account is the structural guard here even though dec-11 dropped the
-    // intra-doc constraint. Cross-doc is fine; cross-account isn't.
-    //
-    // Using `RETURNING 1` and counting the result array avoids relying on driver-specific
-    // rowCount shape (postgres-js via Drizzle returns the rows, not a pg-style result).
-    const decisionDepResult = (await tx.execute(sql`
-      DELETE FROM decision_deps dd
-       USING tasks w, decisions d
-       WHERE dd.task_id = w.id
-         AND dd.decision_id = d.id
-         AND w.memex_id <> d.memex_id
-         AND (w.doc_id = ${docId} OR d.doc_id = ${docId})
-      RETURNING 1
-    `)) as unknown as unknown[];
-
-    const taskDepResult = (await tx.execute(sql`
-      DELETE FROM task_deps wd
-       USING tasks w1, tasks w2
-       WHERE wd.task_id = w1.id
-         AND wd.depends_on_id = w2.id
-         AND w1.memex_id <> w2.memex_id
-         AND (w1.doc_id = ${docId} OR w2.doc_id = ${docId})
-      RETURNING 1
-    `)) as unknown as unknown[];
-
-    // Revoke all active share tokens for the doc. Public share URLs are served from the
-    // source subdomain and would stop resolving after the move; mark them revoked to make
-    // the state explicit (and audit-friendly) rather than silently broken.
-    const revokeResult = (await tx.execute(sql`
-      UPDATE share_tokens
-         SET revoked = TRUE
-       WHERE document_id = ${docId}
-         AND revoked = FALSE
-      RETURNING 1
-    `)) as unknown as unknown[];
-
-    return {
-      doc: updatedDoc,
-      newHandle,
-      removedDecisionDeps: decisionDepResult.length,
-      removedTaskDeps: taskDepResult.length,
-      revokedShareTokens: revokeResult.length,
-    };
-  }), "documents_memex_id_handle_unique");
-
-  return {
-    doc: result.doc,
-    fromMemexId,
-    toMemexId,
-    newHandle: result.newHandle,
-    removedDecisionDeps: result.removedDecisionDeps,
-    removedTaskDeps: result.removedTaskDeps,
-    revokedShareTokens: result.revokedShareTokens,
-  };
+      return {
+        docId,
+        fromMemexId,
+        toMemexId,
+        newHandle: row.new_handle,
+        removedDecisionDeps: Number(row.removed_decision_deps),
+        removedTaskDeps: Number(row.removed_task_deps),
+        revokedShareTokens: Number(row.revoked_share_tokens),
+      };
     },
   );
 }

--- a/packages/server/src/services/memex-search-byline.test.ts
+++ b/packages/server/src/services/memex-search-byline.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import {
+  formatSearchResults,
+  type MemexSearchHit,
+} from "./memex-search.js";
+
+// spec-259 t-4 — PURE unit tests of the search-result formatter. No DB: we hand
+// `formatSearchResults` synthetic MemexSearchHit objects plus a fixed `now`, so
+// timeAgo() output is deterministic. Covers:
+//   ac-9  — per-section WHO/WHEN on multi-section doc hits; capitalizeDisplayName
+//           applied to authors; rendered timestamp moved to relative timeAgo()
+//           (dec-5), while the structured object keeps absolute ISO.
+//   ac-12 — the lightweight open-comment indicator line (count + oldest age,
+//           no comment content); rendered only when open comments exist.
+
+// Fixed clock: 2026-06-14T12:00:00Z. timeAgo() ages everything against this.
+const NOW = new Date("2026-06-14T12:00:00.000Z");
+
+// ISO helpers anchored to NOW so the relative ages are stable.
+const THREE_DAYS_AGO = "2026-06-11T12:00:00.000Z"; // "3d ago"
+const FIVE_DAYS_AGO = "2026-06-09T12:00:00.000Z"; // "5d ago"
+const SIX_DAYS_AGO = "2026-06-08T12:00:00.000Z"; // "6d ago" (still < 1 week)
+
+function docHit(overrides: Partial<MemexSearchHit> = {}): MemexSearchHit {
+  return {
+    id: "doc-uuid-1",
+    kind: "document",
+    path: "ns/mx/docs/doc-1",
+    title: "Some Doc",
+    status: "active",
+    score: 0.5,
+    strategies: ["fts"],
+    matchingSections: [],
+    parentDocId: "doc-uuid-1",
+    authorName: null,
+    lastUpdatedAt: null,
+    ...overrides,
+  };
+}
+
+describe("formatSearchResults — per-section WHO/WHEN (spec-259 ac-9)", () => {
+  it("renders each matched section's own author + relative age (section creators surface, not just the latest)", () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-259/acs/ac-9");
+    const hit = docHit({
+      authorName: "ada lovelace",
+      lastUpdatedAt: THREE_DAYS_AGO,
+      matchingSections: [
+        {
+          id: "s1",
+          sectionType: "prose",
+          title: "Intro",
+          content: "intro body",
+          matchedVia: "fts",
+          authorName: "grace hopper",
+          lastUpdatedAt: FIVE_DAYS_AGO,
+        },
+        {
+          id: "s2",
+          sectionType: "prose",
+          title: "Details",
+          content: "details body",
+          matchedVia: "vector",
+          authorName: "alan turing",
+          lastUpdatedAt: SIX_DAYS_AGO,
+        },
+      ],
+    });
+
+    const out = formatSearchResults("q", [hit], { now: NOW });
+
+    // Each section line carries ITS OWN author + age, not the doc-level latest.
+    expect(out).toContain(`- Section "Intro" (fts) · Grace Hopper, 5d ago:`);
+    expect(out).toContain(`- Section "Details" (vector) · Alan Turing, 6d ago:`);
+  });
+
+  it("applies capitalizeDisplayName to the heading author and uses relative timeAgo (dec-5)", () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-259/acs/ac-9");
+    const hit = docHit({ authorName: "ada lovelace", lastUpdatedAt: THREE_DAYS_AGO });
+
+    const out = formatSearchResults("q", [hit], { now: NOW });
+
+    // Capitalized author + relative age in the heading byline.
+    expect(out).toContain("· Ada Lovelace, 3d ago");
+    // No absolute YYYY-MM-DD in the rendered output (dec-5 moved it to relative).
+    expect(out).not.toContain("2026-06-11");
+  });
+
+  it("keeps the structured object's authorName/lastUpdatedAt as absolute ISO (wire fields unchanged)", () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-259/acs/ac-9");
+    const hit = docHit({
+      authorName: "ada lovelace",
+      lastUpdatedAt: THREE_DAYS_AGO,
+      matchingSections: [
+        {
+          id: "s1",
+          sectionType: "prose",
+          title: "Intro",
+          content: "body",
+          matchedVia: "fts",
+          authorName: "grace hopper",
+          lastUpdatedAt: FIVE_DAYS_AGO,
+        },
+      ],
+    });
+
+    // Formatting does not mutate the structured object — ISO + raw casing survive.
+    formatSearchResults("q", [hit], { now: NOW });
+    expect(hit.lastUpdatedAt).toBe(THREE_DAYS_AGO);
+    expect(hit.authorName).toBe("ada lovelace");
+    expect(hit.matchingSections[0].lastUpdatedAt).toBe(FIVE_DAYS_AGO);
+    expect(hit.matchingSections[0].authorName).toBe("grace hopper");
+  });
+
+  it("degrades gracefully when a section has no author or timestamp", () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-259/acs/ac-9");
+    const hit = docHit({
+      matchingSections: [
+        {
+          id: "s1",
+          sectionType: "prose",
+          title: "Intro",
+          content: "body",
+          matchedVia: "fts",
+          authorName: null,
+          lastUpdatedAt: null,
+        },
+      ],
+    });
+
+    const out = formatSearchResults("q", [hit], { now: NOW });
+    // No byline appended — line ends right after the (via) segment.
+    expect(out).toContain(`- Section "Intro" (fts):`);
+  });
+});
+
+describe("formatSearchResults — open-comment indicator (spec-259 ac-12)", () => {
+  it("renders one indicator line with count + oldest age, no comment content", () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-259/acs/ac-12");
+    const hit = docHit({
+      openComments: { count: 2, oldestCreatedAt: THREE_DAYS_AGO },
+    });
+
+    const out = formatSearchResults("q", [hit], { now: NOW });
+    expect(out).toContain("- (2 open comments, oldest 3d ago)");
+  });
+
+  it("singularises the noun for a single open comment", () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-259/acs/ac-12");
+    const hit = docHit({
+      openComments: { count: 1, oldestCreatedAt: FIVE_DAYS_AGO },
+    });
+
+    const out = formatSearchResults("q", [hit], { now: NOW });
+    expect(out).toContain("- (1 open comment, oldest 5d ago)");
+  });
+
+  it("renders NO indicator line when the hit has zero open comments", () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-259/acs/ac-12");
+    const hit = docHit({ openComments: undefined });
+
+    const out = formatSearchResults("q", [hit], { now: NOW });
+    expect(out).not.toContain("open comment");
+  });
+
+  it("attaches the indicator to a decision hit (doc-scoped) without its content", () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-259/acs/ac-12");
+    const hit = docHit({
+      kind: "decision",
+      path: "ns/mx/specs/spec-1/decisions/dec-1",
+      decisionSnippet: "the decision body",
+      decisionMatchedVia: "fts",
+      openComments: { count: 3, oldestCreatedAt: SIX_DAYS_AGO },
+    });
+
+    const out = formatSearchResults("q", [hit], { now: NOW });
+    expect(out).toContain("- (3 open comments, oldest 6d ago)");
+  });
+});

--- a/packages/server/src/services/memex-search.integration.test.ts
+++ b/packages/server/src/services/memex-search.integration.test.ts
@@ -13,12 +13,13 @@
 import { describe, it, expect, afterAll, beforeAll } from "vitest";
 import { inArray, sql, eq } from "drizzle-orm";
 import { db } from "../db/connection.js";
-import { documents } from "../db/schema.js";
+import { documents, docSections } from "../db/schema.js";
 import { createStandard } from "./standards.js";
 import { createDocDraft } from "./documents.js";
 import { addSection } from "./sections.js";
 import { createDecision, resolveDecision } from "./decisions.js";
 import { createIssue, type IssueType } from "./issues.js";
+import { addComment, resolveComment } from "./comments.js";
 import { upsertUserByEmail } from "./users.js";
 import {
   embedAndStoreDoc,
@@ -803,6 +804,8 @@ describe("formatSearchResults — b-34 D-4 spec", () => {
             title: "Overview",
             content: "Some matching content goes here.",
             matchedVia: "vector",
+            authorName: null,
+            lastUpdatedAt: null,
           },
         ],
       },
@@ -872,6 +875,8 @@ describe("formatSearchResults — b-34 D-4 spec", () => {
           title: null,
           content: long,
           matchedVia: "fts",
+          authorName: null,
+          lastUpdatedAt: null,
         },
       ],
     };
@@ -1000,6 +1005,8 @@ describe("formatSearchResults — [current doc] tag (includeCurrentDoc opt-in)",
           title: "Overview",
           content: "Content.",
           matchedVia: "fts",
+          authorName: null,
+          lastUpdatedAt: null,
         },
       ],
     };
@@ -1247,12 +1254,19 @@ describe("formatSearchResults — WHO/WHEN byline (spec-285 ac-8)", () => {
     lastUpdatedAt: null,
   };
 
-  it("renders ` · <author>, <YYYY-MM-DD>` when both are present", () => {
+  // spec-259 dec-5 moved the RENDERED timestamp from absolute YYYY-MM-DD to a
+  // relative `timeAgo()` ("Nd ago"). A fixed `now` keeps the age deterministic;
+  // the structured `lastUpdatedAt` stays absolute ISO (asserted in ac-6/ac-7).
+  const NOW_285 = new Date("2026-05-31T09:30:00.000Z");
+
+  it("renders ` · <author>, <relative-age>` when both are present (dec-5)", () => {
     tagAc(SPEC285_AC(8));
-    const out = formatSearchResults("q", [
-      { ...base, authorName: "Ada Lovelace", lastUpdatedAt: "2026-05-28T09:30:00.000Z" },
-    ]);
-    expect(out).toContain(`(spec, build) · Ada Lovelace, 2026-05-28`);
+    const out = formatSearchResults(
+      "q",
+      [{ ...base, authorName: "Ada Lovelace", lastUpdatedAt: "2026-05-28T09:30:00.000Z" }],
+      { now: NOW_285 },
+    );
+    expect(out).toContain(`(spec, build) · Ada Lovelace, 3d ago`);
     // No UUIDs in the rendered output (b-36 D-7 still holds).
     const uuidRegex = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i;
     expect(out).not.toMatch(uuidRegex);
@@ -1262,15 +1276,17 @@ describe("formatSearchResults — WHO/WHEN byline (spec-285 ac-8)", () => {
     tagAc(SPEC285_AC(8));
     const out = formatSearchResults("q", [{ ...base, authorName: "Grace Hopper" }]);
     expect(out).toContain(`(spec, build) · Grace Hopper`);
-    expect(out).not.toContain("Grace Hopper,"); // no trailing comma/date
+    expect(out).not.toContain("Grace Hopper,"); // no trailing comma/age
   });
 
-  it("renders the date alone when there is no author", () => {
+  it("renders the relative age alone when there is no author (dec-5)", () => {
     tagAc(SPEC285_AC(8));
-    const out = formatSearchResults("q", [
-      { ...base, lastUpdatedAt: "2026-01-02T00:00:00.000Z" },
-    ]);
-    expect(out).toContain(`(spec, build) · 2026-01-02`);
+    const out = formatSearchResults(
+      "q",
+      [{ ...base, lastUpdatedAt: "2026-05-28T09:30:00.000Z" }],
+      { now: NOW_285 },
+    );
+    expect(out).toContain(`(spec, build) · 3d ago`);
   });
 
   it("emits NO byline when neither author nor timestamp is set", () => {
@@ -1425,7 +1441,9 @@ describe("searchMemex → formatSearchResults — end-to-end byline (spec-285 ac
     });
     const out = formatSearchResults("authore2euniquetokenx", hits);
     expect(out).toContain("Ada Lovelace");
-    expect(out).toMatch(/· Ada Lovelace, \d{4}-\d{2}-\d{2}/);
+    // spec-259 dec-5: rendered timestamp is now a relative age ("just now" /
+    // "Nm ago" / "Nh ago" / "Nd ago"), not an absolute YYYY-MM-DD.
+    expect(out).toMatch(/· Ada Lovelace, (just now|\d+[mhd] ago)/);
   });
 });
 
@@ -1450,6 +1468,8 @@ describe("spec-285 — additive, non-breaking, single-source (ac-4)", () => {
           title: "Do",
           content: "Some rule.",
           matchedVia: "fts",
+          authorName: null,
+          lastUpdatedAt: null,
         },
       ],
       authorName: null,
@@ -1508,13 +1528,95 @@ describe("spec-285 — legible in both surfaces: markdown AND structured (ac-5)"
       lastUpdatedAt: "2026-05-28T12:00:00.000Z",
     };
 
-    // Surface 1 — the MCP/React-agent markdown: human-readable "name, date".
-    const md = formatSearchResults("q", [hit]);
-    expect(md).toMatch(/· Ryan Soosayraj, 2026-05-28/);
+    // Surface 1 — the MCP/React-agent markdown: human-readable "name, age".
+    // spec-259 dec-5: the rendered timestamp is now a relative age, with a fixed
+    // `now` for determinism (2026-05-31 → "3d ago").
+    const md = formatSearchResults("q", [hit], { now: new Date("2026-05-31T12:00:00.000Z") });
+    expect(md).toMatch(/· Ryan Soosayraj, 3d ago/);
 
     // Surface 2 — the structured field the React agent / REST consume: discrete,
-    // not buried in prose. An agent can cite "<name>, <date>" without parsing.
+    // not buried in prose, and STILL absolute ISO (the wire field is unchanged).
     expect(hit.authorName).toBe("Ryan Soosayraj");
     expect(hit.lastUpdatedAt!.slice(0, 10)).toBe("2026-05-28");
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// spec-259 ac-12 — open-comment indicator (DB-backed). Exercises the grouped
+// doc_comments query (loadOpenCommentSummaries via searchMemex → attachOpenComments):
+//   - only UNRESOLVED comments (resolved_at IS NULL) count
+//   - the count + oldest open comment surface on the hit's `openComments`
+//   - a hit with zero open comments leaves `openComments` undefined
+//   - the indicator renders in the markdown formatter (no comment content)
+// DB-NEEDED: run serially by the orchestrator (creates docs/sections/comments).
+// ═══════════════════════════════════════════════════════════════════════════
+describe("searchMemex — open-comment indicator (spec-259 ac-12)", () => {
+  it("counts only UNRESOLVED comments and surfaces the oldest open one", async () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-259/acs/ac-12");
+    const provider = makeFakeProvider("fake-open-comments");
+    const spec = await seedSpec(
+      memexId,
+      "Open comment host",
+      "opencommentuniquetokenx overview body.",
+      [],
+      provider,
+    );
+    // Grab a section to anchor comments on (the overview seed creates one).
+    const section = await db.query.docSections.findFirst({
+      where: eq(docSections.docId, spec.id),
+    });
+    expect(section).toBeDefined();
+
+    // Two open comments + one that we then resolve (must NOT count).
+    await addComment(memexId, section!.id, "Ada", "first open");
+    await addComment(memexId, section!.id, "Grace", "second open");
+    const toResolve = await addComment(memexId, section!.id, "Alan", "will resolve");
+    await resolveComment(memexId, toResolve.id, "done");
+
+    const hits = await searchMemex(memexId, "opencommentuniquetokenx", {
+      provider,
+      kind: "spec",
+      disableVector: true,
+    });
+    const hit = hits.find((h) => h.id === spec.id);
+    expect(hit).toBeDefined();
+    expect(hit!.openComments).toBeDefined();
+    expect(hit!.openComments!.count).toBe(2); // the resolved one is excluded
+    // oldestCreatedAt is absolute ISO on the structured object.
+    expect(hit!.openComments!.oldestCreatedAt).toMatch(ISO_RE);
+
+    // Markdown renders the indicator line — count + relative age, no content.
+    // (Freshly-seeded comments render "just now"; the exact "Nd ago" formatting is
+    // proven deterministically with an injected `now` in memex-search-byline.test.ts.)
+    const out = formatSearchResults("opencommentuniquetokenx", [hit!]);
+    expect(out).toMatch(/- \(2 open comments, oldest .+\)/);
+    expect(out).not.toContain("first open");
+    expect(out).not.toContain("second open");
+  });
+
+  it("leaves openComments undefined when the doc has no open comments", async () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-259/acs/ac-12");
+    const provider = makeFakeProvider("fake-no-open-comments");
+    const spec = await seedSpec(
+      memexId,
+      "No open comment host",
+      "nocommentuniquetokenx overview body.",
+      [],
+      provider,
+    );
+
+    const hits = await searchMemex(memexId, "nocommentuniquetokenx", {
+      provider,
+      kind: "spec",
+      disableVector: true,
+    });
+    const hit = hits.find((h) => h.id === spec.id);
+    expect(hit).toBeDefined();
+    expect(hit!.openComments).toBeUndefined();
+
+    // No indicator line in the rendered markdown. (Match the indicator PATTERN, not
+    // the bare substring "open comment" — this hit's title is "No open comment host".)
+    const out = formatSearchResults("nocommentuniquetokenx", [hit!]);
+    expect(out).not.toMatch(/\(\d+ open comments?, oldest/);
   });
 });

--- a/packages/server/src/services/memex-search.ts
+++ b/packages/server/src/services/memex-search.ts
@@ -50,6 +50,7 @@
 // but IS NOT TRUE is robust against any legacy NULL and reads as the intent).
 
 import { sql } from "drizzle-orm";
+import { timeAgo, capitalizeDisplayName } from "@memex/shared";
 import { db } from "../db/connection.js";
 import {
   resolveEmbeddingProvider,
@@ -151,6 +152,15 @@ export interface MatchingSection {
   content: string;
   /** Which search method surfaced this section first. */
   matchedVia: SearchStrategy;
+  /** WHO — best-effort display name of who last touched THIS section (spec-259
+   *  ac-9). Carried per-section so a multi-section doc hit surfaces each
+   *  matched section's own creator, not just the doc-level latest. Same SQL
+   *  COALESCE(actor_name, users.name, users.email) resolution as the doc-level
+   *  WHO. null when nothing resolved. Wire/structured value — kept absolute. */
+  authorName: string | null;
+  /** WHEN — ISO-8601 last-modified of THIS section (spec-259 ac-9). Absolute
+   *  ISO on the structured object; rendered relative via timeAgo(). */
+  lastUpdatedAt: string | null;
 }
 
 export interface MemexSearchHit {
@@ -199,6 +209,12 @@ export interface MemexSearchHit {
    *  carry no `updated_at`). null only when no timestamp was selected
    *  (navigation-only lanes). */
   lastUpdatedAt: string | null;
+  /** Open (unresolved) comments anchored on this hit's doc (spec-259 ac-12). A
+   *  lightweight indicator only — count + oldest open comment's age — never the
+   *  comment content. `oldestCreatedAt` is absolute ISO on the structured
+   *  object; rendered relative via timeAgo(). Omitted (undefined) when the hit
+   *  has zero open comments, so the formatter renders no indicator line. */
+  openComments?: { count: number; oldestCreatedAt: string };
 }
 
 export interface SearchMemexOptions {
@@ -363,6 +379,64 @@ function toIso(value: string | Date | null | undefined): string | null {
   return Number.isNaN(d.getTime()) ? null : d.toISOString();
 }
 
+// spec-259 ac-12: batch-load the open (unresolved) comment count + oldest open
+// comment timestamp for a set of doc ids, in ONE grouped query (no N+1). Keyed
+// by doc_id — a comment transitively belongs to a doc via its section/decision/
+// task target, but doc_id is denormalised on the row (schema comment), so we
+// group on it directly. `resolved_at IS NULL` is the open predicate. Returns a
+// Map doc_id → { count, oldestCreatedAt(ISO) }; absent keys have zero open
+// comments. No comment CONTENT is selected — indicator only.
+interface OpenCommentRow {
+  doc_id: string;
+  open_count: number | string;
+  oldest_created_at: string | Date;
+}
+
+async function loadOpenCommentSummaries(
+  docIds: string[],
+): Promise<Map<string, { count: number; oldestCreatedAt: string }>> {
+  const summaries = new Map<string, { count: number; oldestCreatedAt: string }>();
+  if (docIds.length === 0) return summaries;
+  // De-dupe the id set (decision/section hits can share a parent doc) so the
+  // IN-list is minimal.
+  const uniqueIds = Array.from(new Set(docIds));
+  const idList = sql.join(
+    uniqueIds.map((id) => sql`${id}::uuid`),
+    sql`, `,
+  );
+  const rows = (await db.execute(sql`
+    SELECT
+      doc_id                AS doc_id,
+      COUNT(*)              AS open_count,
+      MIN(created_at)       AS oldest_created_at
+    FROM doc_comments
+    WHERE doc_id IN (${idList})
+      AND resolved_at IS NULL
+    GROUP BY doc_id
+  `)) as unknown as OpenCommentRow[];
+  for (const r of rows) {
+    const count = Number(r.open_count);
+    const oldestCreatedAt = toIso(r.oldest_created_at);
+    if (count > 0 && oldestCreatedAt) {
+      summaries.set(r.doc_id, { count, oldestCreatedAt });
+    }
+  }
+  return summaries;
+}
+
+// spec-259 ac-12: attach the open-comment indicator to each hit by its parent
+// doc. Mutates in place and returns the same array. A decision/section hit
+// inherits its parent doc's open-comment summary (the indicator is doc-scoped).
+async function attachOpenComments(hits: MemexSearchHit[]): Promise<MemexSearchHit[]> {
+  if (hits.length === 0) return hits;
+  const summaries = await loadOpenCommentSummaries(hits.map((h) => h.parentDocId));
+  for (const hit of hits) {
+    const summary = summaries.get(hit.parentDocId);
+    if (summary) hit.openComments = summary;
+  }
+  return hits;
+}
+
 // ── Public entry point ─────────────────────────────────
 
 export async function searchMemex(
@@ -386,7 +460,7 @@ export async function searchMemex(
   //    through to FTS/vector.)
   if (HANDLE_REGEX.test(trimmed)) {
     const direct = await lookupByHandle(memexId, slugs, trimmed, includeArchived);
-    if (direct) return [direct];
+    if (direct) return attachOpenComments([direct]);
     // Fall through to fuzzy search if nothing matched (the user might have
     // typed a handle that doesn't exist; better to show paraphrase candidates
     // than an empty result).
@@ -469,7 +543,7 @@ export async function searchMemex(
     issueTasks[1],
   ]);
 
-  return mergeWithRrf(
+  const merged = mergeWithRrf(
     sectionFts as SectionRow[],
     sectionVector as SectionRow[],
     decisionFts as DecisionRow[],
@@ -479,6 +553,10 @@ export async function searchMemex(
     slugs,
     limit,
   );
+
+  // spec-259 ac-12: enrich the (already-capped) result set with open-comment
+  // indicators in one grouped query — batched over the result docs, never N+1.
+  return attachOpenComments(merged);
 }
 
 // ── Direct lookup ──────────────────────────────────────
@@ -558,6 +636,11 @@ async function lookupByHandle(
       title: r.section_title,
       content: r.section_content,
       matchedVia: "handle",
+      // spec-259 ac-9: per-section WHO/WHEN. The handle row has no resolved
+      // creator fallback per-section, so use the section's denormalised
+      // actor_name (std-32), else the doc-level resolved creator fallback.
+      authorName: r.section_actor_name?.trim() || docAuthorFallback,
+      lastUpdatedAt: toIso(r.section_updated_at),
     })),
   };
 }
@@ -1237,6 +1320,10 @@ function mergeWithRrf(
           title: r.section_title,
           content: r.section_content,
           matchedVia: via,
+          // spec-259 ac-9: per-section WHO/WHEN so each matched section's own
+          // creator surfaces, not just the doc-level most-recent one.
+          authorName: r.author_name?.trim() || null,
+          lastUpdatedAt: toIso(r.updated_at),
         });
       }
     }
@@ -1376,20 +1463,48 @@ export interface FormatOptions {
    *  `includeCurrentDoc: true` (the default excludes the current doc from
    *  results entirely, so this never fires). */
   currentDocId?: string;
+  /** Injectable "now" for relative-age rendering (spec-259 dec-5). Tests pass a
+   *  fixed clock so `timeAgo()` output is deterministic; production omits it and
+   *  the helpers default to the real wall clock. */
+  now?: Date;
 }
 
-// spec-285: the WHO/WHEN byline appended to a hit's heading, e.g.
-// ` · Ryan Soosayraj, 2026-05-28`. Legible to a human and parseable by an agent
-// (` · <author>, <YYYY-MM-DD>`). Degrades gracefully: author-only, date-only, or
-// nothing at all when neither resolved. The date is the calendar day of the ISO
-// timestamp — enough for "when it last changed" without clock noise.
-function formatHitByline(hit: MemexSearchHit): string {
-  const author = hit.authorName?.trim() || null;
-  const date = hit.lastUpdatedAt ? hit.lastUpdatedAt.slice(0, 10) : null;
-  if (author && date) return ` · ${author}, ${date}`;
+// spec-285 + spec-259: the WHO/WHEN byline appended to a hit's heading, e.g.
+// ` · Ryan Soosayraj, 3d ago`. Legible to a human and parseable by an agent
+// (` · <author>, <relative-age>`). Degrades gracefully: author-only, age-only,
+// or nothing at all when neither resolved. spec-259 dec-5 moved the RENDERED
+// timestamp from an absolute YYYY-MM-DD to a relative `timeAgo()` ("Nd ago");
+// the structured `hit.lastUpdatedAt`/`hit.authorName` stay absolute ISO. The
+// author is run through capitalizeDisplayName (spec-259 ac-9) because the SQL
+// WHO-resolver returns raw names that bypass the shared who-resolver. `now` is
+// injectable so unit tests are deterministic.
+function formatWhoWhenByline(
+  authorName: string | null,
+  lastUpdatedAt: string | null,
+  now?: Date,
+): string {
+  const raw = authorName?.trim() || null;
+  const author = raw ? capitalizeDisplayName(raw) : null;
+  const age = lastUpdatedAt ? timeAgo(lastUpdatedAt, now) : null;
+  if (author && age) return ` · ${author}, ${age}`;
   if (author) return ` · ${author}`;
-  if (date) return ` · ${date}`;
+  if (age) return ` · ${age}`;
   return "";
+}
+
+function formatHitByline(hit: MemexSearchHit, now?: Date): string {
+  return formatWhoWhenByline(hit.authorName, hit.lastUpdatedAt, now);
+}
+
+// spec-259 ac-12: the open-comment indicator appended as its own line under a
+// hit, e.g. `- (2 open comments, oldest 3d ago)`. Indicator only — no comment
+// content. Returns null when the hit has zero open comments so the caller emits
+// no line. `now` injectable for deterministic tests.
+function formatOpenCommentsLine(hit: MemexSearchHit, now?: Date): string | null {
+  const oc = hit.openComments;
+  if (!oc || oc.count <= 0) return null;
+  const noun = oc.count === 1 ? "open comment" : "open comments";
+  return `- (${oc.count} ${noun}, oldest ${timeAgo(oc.oldestCreatedAt, now)})`;
 }
 
 function isHitOnCurrentDoc(hit: MemexSearchHit, currentDocId: string): boolean {
@@ -1410,6 +1525,7 @@ export function formatSearchResults(
 
   const verbose = options.verbose === true;
   const currentDocId = options.currentDocId;
+  const now = options.now;
   const lines: string[] = [`## Search results for "${query}" (${hits.length} hit${hits.length === 1 ? "" : "s"})`];
 
   for (const hit of hits) {
@@ -1424,7 +1540,7 @@ export function formatSearchResults(
     // spec-285: WHO/WHEN byline sits after the (kind, status) segment and before
     // the [current doc] / verbose-score suffixes, so an agent reading the result
     // can attribute the hit ("who, when") without opening it.
-    const byline = formatHitByline(hit);
+    const byline = formatHitByline(hit, now);
     lines.push(`### ${hit.path} — "${hit.title}" (${kindLabel}, ${hit.status})${byline}${selfTag}${scoreSuffix}`);
     if (hit.kind === "decision") {
       const via = hit.decisionMatchedVia ?? "fts";
@@ -1438,10 +1554,18 @@ export function formatSearchResults(
       for (const sec of hit.matchingSections) {
         const titleSeg = sec.title ? `"${sec.title}"` : `(${sec.sectionType})`;
         const snippet = truncate((sec.content ?? "").trim(), SNIPPET_MAX_CHARS);
-        lines.push(`- Section ${titleSeg} (${sec.matchedVia}):`);
+        // spec-259 ac-9: per-section WHO/WHEN so a multi-section doc hit surfaces
+        // each matched section's own creator + relative age, not just the
+        // doc-level latest. Same capitalize + timeAgo treatment as the heading.
+        const secByline = formatWhoWhenByline(sec.authorName, sec.lastUpdatedAt, now);
+        lines.push(`- Section ${titleSeg} (${sec.matchedVia})${secByline}:`);
         lines.push(`  > ${snippet}`);
       }
     }
+    // spec-259 ac-12: one lightweight open-comment indicator line per hit (after
+    // the snippet block). Rendered only when the hit has open comments.
+    const openCommentsLine = formatOpenCommentsLine(hit, now);
+    if (openCommentsLine) lines.push(openCommentsLine);
   }
 
   return lines.join("\n");

--- a/packages/server/src/services/memexes.ts
+++ b/packages/server/src/services/memexes.ts
@@ -9,6 +9,7 @@ import { db } from "../db/connection.js";
 import { memexes, namespaces } from "../db/schema.js";
 import type { Memex } from "../db/schema.js";
 import { validateSlugFormat, type SlugFormatError } from "./shared/slug.js";
+import { pgError } from "./shared/pg-error.js";
 import { ConflictError, ValidationError } from "../types/errors.js";
 import { mutate, type Mutated, type RequestCtx } from "./mutate.js";
 
@@ -194,10 +195,7 @@ export async function createMemex(
       },
     );
   } catch (err) {
-    if (
-      err && typeof err === "object" && "code" in err &&
-      (err as { code?: string }).code === "23505"
-    ) {
+    if (pgError(err)?.code === "23505") {
       throw new ConflictError(`Slug '${slug}' is already taken in this namespace`);
     }
     throw err;

--- a/packages/server/src/services/orgs.ts
+++ b/packages/server/src/services/orgs.ts
@@ -27,6 +27,7 @@ import {
   validateSlugFormat,
 } from "./shared/slug.js";
 import { ConflictError, ValidationError } from "../types/errors.js";
+import { pgError } from "./shared/pg-error.js";
 import { isFreeEmailDomain } from "./free-email-domains.js";
 import { mutate, type Mutated } from "./mutate.js";
 import { primaryMemexIdForOrg } from "./shared/memex-ownership.js";
@@ -137,7 +138,7 @@ export async function createOrgWithOwner(
           return { org, namespace: updatedNamespace, membership };
         });
       } catch (err) {
-        if (err && typeof err === "object" && "code" in err && (err as { code?: string }).code === "23505") {
+        if (pgError(err)?.code === "23505") {
           throw new ConflictError(`Slug '${slug}' is already taken`);
         }
         throw err;

--- a/packages/server/src/services/phase-assessment.comments-build.spec-259.integration.test.ts
+++ b/packages/server/src/services/phase-assessment.comments-build.spec-259.integration.test.ts
@@ -1,0 +1,123 @@
+// spec-259 t-3 — DB-backed end-to-end for the specify→build open-comment
+// surface. REQUIRES Postgres. The orchestrator runs the DB suite serially —
+// DO NOT run this concurrently with the other DB integration tests.
+//
+// Covers:
+//   ac-1  — assessPhaseTransition(target:'build') surfaces the grouped block.
+//   ac-6  — the SOFT build nudge fires (count + oldest age) when comments exist.
+//   ac-10 — the open-set basis is resolved_at IS NULL: a resolved comment drops
+//           out of the grouping (no second model).
+//   ac-11 — the build transition is NOT gated: updateDocStatus to 'build'
+//           succeeds with open comments present.
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { eq } from "drizzle-orm";
+import { db } from "../db/connection.js";
+import { documents, decisions, tasks, docComments } from "../db/schema.js";
+import { createDocDraft, updateDocStatus } from "./documents.js";
+import { createDecision } from "./decisions.js";
+import { createTask } from "./tasks.js";
+import { addComment, addDecisionComment, addTaskComment, resolveComment } from "./comments.js";
+import { assessPhaseTransition, formatPhaseAssessment, _clearRecentAssessments } from "./phase-assessment.js";
+import { makeTestMemex } from "./test-helpers.js";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+const AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-259/acs/ac-${n}`;
+
+const createdDocIds: string[] = [];
+let memexId: string;
+
+beforeAll(async () => {
+  memexId = await makeTestMemex();
+});
+
+afterAll(async () => {
+  for (const id of createdDocIds) {
+    await db.delete(docComments).where(eq(docComments.memexId, memexId)).catch(() => {});
+    await db.delete(tasks).where(eq(tasks.docId, id)).catch(() => {});
+    await db.delete(decisions).where(eq(decisions.docId, id)).catch(() => {});
+    await db.delete(documents).where(eq(documents.id, id)).catch(() => {});
+  }
+});
+
+describe("spec-259: specify→build open comments end-to-end", () => {
+  it("groups open comments by anchor kind, fires the soft nudge, and does NOT gate (ac-1, ac-6, ac-11)", async () => {
+    tagAc(AC(1));
+    tagAc(AC(6));
+    tagAc(AC(11));
+    _clearRecentAssessments();
+
+    const spec = await createDocDraft(memexId, "Build with open comments", "Purpose", "spec");
+    createdDocIds.push(spec.id);
+    await updateDocStatus(memexId, spec.id, "specify");
+
+    const dec = await createDecision(memexId, spec.id, "Pick storage");
+    const task = await createTask(memexId, spec.id, "Wire gate", "Do it");
+
+    await addDecisionComment(memexId, dec.id, "ada lovelace", "decision question", {
+      type: "question",
+      source: "agent",
+    });
+    await new Promise((r) => setTimeout(r, 5));
+    await addComment(memexId, spec.sections[0].id, "grace hopper", "section note");
+    await new Promise((r) => setTimeout(r, 5));
+    await addTaskComment(memexId, task.id, "alan turing", "task note", { source: "agent" });
+
+    const assessment = await assessPhaseTransition(memexId, spec.id, "build", "not_applicable");
+
+    // ac-1: grouping populated.
+    expect(assessment.openCommentsDetail).toBeDefined();
+    expect(assessment.openCommentsDetail!.totalOpen).toBe(3);
+    expect(assessment.openCommentsDetail!.byAnchorKind.decision.count).toBe(1);
+    expect(assessment.openCommentsDetail!.byAnchorKind.section.count).toBe(2); // section + task
+
+    const rendered = formatPhaseAssessment(assessment);
+    expect(rendered).toContain("Decision-anchored: 1");
+    expect(rendered).toContain("Section-anchored: 2");
+    expect(rendered).toContain("Ada Lovelace");
+
+    // ac-6: soft nudge fires, naming the count.
+    const commentNudge = assessment.nudges.find((n) => n.includes("open comment"));
+    expect(commentNudge).toBeDefined();
+    expect(commentNudge).toMatch(/3 open comments/);
+    // Freshly-seeded → "oldest just now"; the "Nd ago" format is proven with an
+    // injected `now` in the pure phase-assessment.comments-build.spec-259.test.ts.
+    expect(commentNudge).toMatch(/oldest (just now|.*ago)/);
+
+    // ac-11: the nudge is advisory — the transition still succeeds with comments open.
+    const moved = await updateDocStatus(memexId, spec.id, "build");
+    expect(moved.status).toBe("build");
+  });
+
+  it("the open-set basis is resolved_at IS NULL — a resolved comment drops out of the grouping (ac-10)", async () => {
+    tagAc(AC(10));
+    _clearRecentAssessments();
+
+    const spec = await createDocDraft(memexId, "Resolved drops out", "Purpose", "spec");
+    createdDocIds.push(spec.id);
+    await updateDocStatus(memexId, spec.id, "specify");
+
+    const dec = await createDecision(memexId, spec.id, "Pick lib");
+    const openC = await addDecisionComment(memexId, dec.id, "ada", "still open", {
+      type: "question",
+      source: "agent",
+    });
+    const toResolve = await addComment(memexId, spec.sections[0].id, "grace", "will resolve");
+
+    // Before resolution: 2 open (1 decision-anchored, 1 section-anchored).
+    let a = await assessPhaseTransition(memexId, spec.id, "build", "not_applicable");
+    expect(a.openCommentsDetail!.totalOpen).toBe(2);
+    expect(a.openCommentsDetail!.byAnchorKind.section.count).toBe(1);
+
+    await resolveComment(memexId, toResolve.id, "resolved");
+
+    // After resolution: the resolved comment is gone; only the open one remains.
+    _clearRecentAssessments();
+    a = await assessPhaseTransition(memexId, spec.id, "build", "not_applicable");
+    expect(a.openCommentsDetail!.totalOpen).toBe(1);
+    expect(a.openCommentsDetail!.byAnchorKind.section.count).toBe(0);
+    expect(a.openCommentsDetail!.byAnchorKind.decision.count).toBe(1);
+    expect(a.openCommentsDetail!.comments[0].commentId).toBe(openC.id);
+  });
+});

--- a/packages/server/src/services/phase-assessment.comments-build.spec-259.test.ts
+++ b/packages/server/src/services/phase-assessment.comments-build.spec-259.test.ts
@@ -42,7 +42,7 @@ function mkComment(o: {
 
 function mkCommentsStatus(comments: OpenComment[]): CommentsStatus {
   return {
-    briefId: "brief-uuid",
+    briefId: "doc-uuid",
     specHandle: "spec-259",
     specTitle: "Surface open comments",
     totalOpen: comments.length,
@@ -54,7 +54,7 @@ function mkCommentsStatus(comments: OpenComment[]): CommentsStatus {
 
 function mkBuildAssessment(over: Partial<PhaseAssessment> = {}): PhaseAssessment {
   return {
-    briefId: "brief-uuid",
+    briefId: "doc-uuid",
     specHandle: "spec-259",
     specTitle: "Surface open comments",
     currentPhase: "specify",

--- a/packages/server/src/services/phase-assessment.comments-build.spec-259.test.ts
+++ b/packages/server/src/services/phase-assessment.comments-build.spec-259.test.ts
@@ -1,0 +1,214 @@
+// spec-259 t-3 — pure render + nudge tests for the specify→build open-comment
+// surface.
+//
+// No DB: builds a synthetic PhaseAssessment and runs it through the pure
+// `formatPhaseAssessment`, asserting the enriched "Open comments" block
+// (anchor-kind grouping + oldest age + per-comment WHO/WHEN) and the SOFT build
+// nudge. The DB-backed assessPhaseTransition path (that the nudge actually fires
+// and the transition still succeeds end-to-end) is exercised in
+// phase-assessment.integration.test.ts.
+
+import { describe, it, expect } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { formatPhaseAssessment, type PhaseAssessment } from "./phase-assessment.js";
+import type { CommentsStatus, OpenComment } from "./comment-assessment.js";
+import { groupCommentsByAnchorKind } from "./comment-assessment.js";
+
+const AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-259/acs/ac-${n}`;
+
+// A few days back from "now" so timeAgo renders a stable "Nd ago"-shaped string
+// regardless of when the suite runs.
+const daysAgo = (n: number): Date => new Date(Date.now() - n * 24 * 60 * 60 * 1000);
+
+function mkComment(o: {
+  targetKind: OpenComment["target"]["kind"];
+  handle: string;
+  title: string | null;
+  author: string;
+  type?: string;
+  snippet: string;
+  createdAt: Date;
+}): OpenComment {
+  return {
+    commentId: `c-${o.createdAt.getTime()}`,
+    type: o.type ?? "discussion",
+    target: { kind: o.targetKind, handle: o.handle, title: o.title },
+    author: o.author,
+    contentSnippet: o.snippet,
+    createdAt: o.createdAt,
+  };
+}
+
+function mkCommentsStatus(comments: OpenComment[]): CommentsStatus {
+  return {
+    briefId: "brief-uuid",
+    specHandle: "spec-259",
+    specTitle: "Surface open comments",
+    totalOpen: comments.length,
+    byType: { note: comments.length, question: 0, drift: 0, plan_revision: 0, other: 0 },
+    comments,
+    byAnchorKind: groupCommentsByAnchorKind(comments),
+  };
+}
+
+function mkBuildAssessment(over: Partial<PhaseAssessment> = {}): PhaseAssessment {
+  return {
+    briefId: "brief-uuid",
+    specHandle: "spec-259",
+    specTitle: "Surface open comments",
+    currentPhase: "specify",
+    targetPhase: "build",
+    transition: "specify → build",
+    rubricNote: null,
+    rubricProse: "## How to use this\n- proceed-with-caveats — transition is fine but flag <list>.",
+    facts: {
+      openDecisionsCount: 0,
+      openDecisions: [],
+      incompleteTasksCount: 0,
+      readyTasksCount: 0,
+      blockedTasksCount: 0,
+      incompleteTasks: [],
+      unresolvedDriftCount: 0,
+      unresolvedPlanRevisionCount: 0,
+      openCommentsCount: 0,
+      openCommentsByType: {},
+      acVerification: {
+        totalActive: 0,
+        covered: 0,
+        verified: 0,
+        failing: 0,
+        stale: 0,
+        untested: 0,
+        accepted: 0,
+        failingHandles: [],
+        staleHandles: [],
+      },
+      openIssuesCount: 0,
+      sections: [],
+      resolvedDecisionCoverage: [],
+      resolvedDecisionAcCoverage: [],
+    },
+    readiness: { outstandingItems: [], isClean: true },
+    nudges: [],
+    ...over,
+  };
+}
+
+describe("spec-259: specify→build open-comment render (ac-1)", () => {
+  it("renders comments grouped by anchor kind, with per-group oldest age + per-comment WHO/WHEN", () => {
+    tagAc(AC(1));
+
+    const comments = [
+      mkComment({
+        targetKind: "decision",
+        handle: "dec-2",
+        title: "Storage engine",
+        author: "ada lovelace",
+        type: "question",
+        snippet: "are we sure about postgres here?",
+        createdAt: daysAgo(9),
+      }),
+      mkComment({
+        targetKind: "section",
+        handle: "approach",
+        title: "Approach",
+        author: "grace hopper",
+        snippet: "this needs a rollback plan",
+        createdAt: daysAgo(4),
+      }),
+      mkComment({
+        targetKind: "task",
+        handle: "t-1",
+        title: "Wire the gate",
+        author: "alan turing",
+        snippet: "blocked on the migration",
+        createdAt: daysAgo(2),
+      }),
+    ];
+
+    const a = mkBuildAssessment({
+      facts: {
+        ...mkBuildAssessment().facts,
+        openCommentsCount: 3,
+        openCommentsByType: { discussion: 2, question: 1 },
+      },
+      openCommentsDetail: mkCommentsStatus(comments),
+    });
+
+    const out = formatPhaseAssessment(a);
+
+    // Grouping headers.
+    expect(out).toContain("Decision-anchored: 1");
+    expect(out).toContain("Section-anchored: 2"); // section + task collapse
+
+    // Oldest age per group is surfaced via timeAgo (relative, "ago"-shaped).
+    expect(out).toMatch(/Decision-anchored: 1 \(oldest .*ago\)/);
+    expect(out).toMatch(/Section-anchored: 2 \(oldest .*ago\)/);
+
+    // Per-comment WHO (title-cased) / WHEN (relative) / anchor / snippet.
+    expect(out).toContain("Ada Lovelace");
+    expect(out).toContain("Grace Hopper");
+    expect(out).toContain("Alan Turing");
+    expect(out).toMatch(/Ada Lovelace .*ago on decision dec-2 "Storage engine" \[question\]/);
+    expect(out).toContain("are we sure about postgres here?");
+    expect(out).toContain('on section approach "Approach"');
+    expect(out).toContain('on task t-1 "Wire the gate"');
+  });
+
+  it("renders counts-only (no grouping block) when openCommentsDetail is absent (non-build targets)", () => {
+    tagAc(AC(1));
+    const a = mkBuildAssessment({
+      targetPhase: "verify",
+      transition: "build → verify",
+      currentPhase: "build",
+      facts: {
+        ...mkBuildAssessment().facts,
+        openCommentsCount: 2,
+        openCommentsByType: { discussion: 2 },
+      },
+      // openCommentsDetail intentionally undefined.
+    });
+    const out = formatPhaseAssessment(a);
+    expect(out).toContain("Open comments: 2");
+    expect(out).not.toContain("Decision-anchored");
+    expect(out).not.toContain("Section-anchored");
+  });
+});
+
+describe("spec-259: specify→build open-comment SOFT nudge (ac-6, ac-11)", () => {
+  it("renders the soft nudge naming count + oldest age, alongside a proceed-with-caveats rubric", () => {
+    tagAc(AC(6));
+    // The nudge string itself is produced by assessPhaseTransition; here we
+    // assert formatPhaseAssessment surfaces it under ## Nudges and that the
+    // build rubric offers the proceed-with-caveats verdict it feeds.
+    const nudge =
+      "There are 3 open comments on this Spec (oldest 9d ago). Walk the user through them before build — " +
+      "answer the questions, fold accepted notes into the narrative, and resolve them — or proceed if they're not blockers.";
+    const a = mkBuildAssessment({ nudges: [nudge] });
+    const out = formatPhaseAssessment(a);
+
+    expect(out).toContain("## Nudges");
+    expect(out).toContain("3 open comments on this Spec");
+    expect(out).toContain("oldest 9d ago");
+    // The verdict the nudge drives toward is available in the rubric.
+    expect(out).toContain("proceed-with-caveats");
+  });
+
+  it("the soft nudge is purely advisory — it does not add a transition-blocking outstanding item (ac-11)", () => {
+    tagAc(AC(11));
+    // A build assessment carrying the comment nudge keeps an EMPTY readiness
+    // (isClean) — the nudge never manufactures a hold. (The end-to-end proof
+    // that updateDocStatus still succeeds with open comments lives in the DB
+    // integration test; updateDocStatus gates on nothing here.)
+    const nudge = "There is 1 open comment on this Spec (oldest 2d ago). Walk the user through them before build — answer the questions, fold accepted notes into the narrative, and resolve them — or proceed if they're not blockers.";
+    const a = mkBuildAssessment({ nudges: [nudge] });
+
+    expect(a.readiness.isClean).toBe(true);
+    expect(a.readiness.outstandingItems).toEqual([]);
+
+    const out = formatPhaseAssessment(a);
+    // No "Outstanding work" section is forced by the comment nudge.
+    expect(out).not.toContain("## Outstanding work");
+  });
+});

--- a/packages/server/src/services/phase-assessment.ts
+++ b/packages/server/src/services/phase-assessment.ts
@@ -11,6 +11,7 @@ import {
   STALE_THRESHOLD_DAYS,
 } from "./acs.js";
 import { NotFoundError, ValidationError } from "../types/errors.js";
+import { assessCommentsStatus, type CommentsStatus } from "./comment-assessment.js";
 import { getReadyTasks } from "./tasks.js";
 import { parsePhaseDescriptions } from "../mcp/phase-descriptions.js";
 import { listOrgScaffoldAdditionsCached } from "./scaffold-additions-cache.js";
@@ -23,6 +24,8 @@ import {
   computeSpecReadiness,
   isForwardTransition,
   toRubric,
+  timeAgo,
+  capitalizeDisplayName,
   type SpecPhase,
   type SpecReadiness,
   type GuidanceBlock,
@@ -324,6 +327,16 @@ export interface PhaseAssessment {
    * verbatim prompt under `## Code grounding`.
    */
   codeGroundingPromptPending?: boolean;
+  /**
+   * spec-259 t-3: the open-comment survey for this Spec (anchor-kind grouping +
+   * per-comment WHO/WHEN), populated ONLY on the specify→build transition so
+   * `formatPhaseAssessment` can render an enriched "## Open comments" block
+   * (grouped by anchor kind, oldest age per group, per-comment author + age +
+   * anchor + snippet) without a second DB call. `undefined` for other targets,
+   * keeping their fact sheet counts-only. The render is purely a function of
+   * this snapshot, so the formatter stays DB-free and unit-testable.
+   */
+  openCommentsDetail?: CommentsStatus;
 }
 
 // spec-120 ac-3: open-comments on a Spec, both as a total AND broken down by
@@ -628,6 +641,17 @@ export async function assessPhaseTransition(
     taskIdSet,
   );
 
+  // spec-259 t-3: on the specify→build gate, pull the full open-comment survey
+  // (anchor-kind grouping + per-comment WHO/WHEN) so the rendered block can
+  // surface WHO raised WHAT and HOW STALE it is, not just a count. Scoped to
+  // `build` so other transitions keep their counts-only fact sheet and skip the
+  // extra query. The total here matches `openComments.total` (same open-set
+  // basis: resolved_at IS NULL).
+  const openCommentsDetail =
+    targetPhase === "build"
+      ? await assessCommentsStatus(memexId, briefId)
+      : undefined;
+
   // spec-120 ac-1: AC verification roll-up drawn from the same `test_events`
   // derivation `list_acs` uses, so the gate and `list_acs` can never silently
   // disagree. Drives the `done` hold signal below (ac-2) and the fact sheet.
@@ -761,6 +785,26 @@ export async function assessPhaseTransition(
     }
   }
 
+  // spec-259 t-3: open-comment SOFT nudge on the specify→build gate (ac-6).
+  // Advancing into build while comments are still open means unanswered
+  // questions / unresolved notes ride into execution unseen. SOFT only — it
+  // adds a nudge that NAMES the count + oldest age but NEVER holds the
+  // transition (update_doc({status:'build'}) still succeeds, ac-11), mirroring
+  // the firmness of the open-Issues-at-done and missing-core-lens warnings, NOT
+  // the naked-decision hold. Fires only when open comments exist; 0 open → no
+  // nudge. specDrift's hard verify-scope is left untouched — this is the
+  // build-phase analogue.
+  if (targetPhase === "build" && openCommentsDetail && openCommentsDetail.totalOpen > 0) {
+    const n = openCommentsDetail.totalOpen;
+    const oldest = openCommentsDetail.comments[0]?.createdAt ?? null;
+    const oldestAge = oldest ? timeAgo(oldest) : "unknown age";
+    nudges.push(
+      `There ${n === 1 ? "is" : "are"} ${n} open comment${n === 1 ? "" : "s"} on this Spec ` +
+        `(oldest ${oldestAge}). Walk the user through them before build — answer the questions, ` +
+        `fold accepted notes into the narrative, and resolve them — or proceed if they're not blockers.`,
+    );
+  }
+
   // Code-grounding self-classification (doc-27). Only applies on the
   // specify→build transition (`target === 'build'`). On other targets the
   // parameter is silently ignored — no prompt, no nudge, no behaviour change.
@@ -838,6 +882,7 @@ export async function assessPhaseTransition(
     nudges,
     codeGrounding: effectiveCodeGrounding,
     codeGroundingPromptPending: codeGroundingPromptPending || undefined,
+    openCommentsDetail,
   };
 }
 
@@ -887,6 +932,28 @@ export function formatPhaseAssessment(assessment: PhaseAssessment): string {
     for (const [type, count] of byType) {
       lines.push(`  - ${type}: ${count}`);
     }
+  }
+  // spec-259 t-3: on the specify→build gate, enrich the open-comment block —
+  // grouped by anchor kind (decision-anchored vs section-anchored), oldest age
+  // per group via timeAgo, and a per-comment WHO/WHEN list (author + age +
+  // anchor handle/title + snippet). Rendered ONLY when `openCommentsDetail` is
+  // present (build target) and there are open comments; other targets keep the
+  // counts-only view above (ac-1).
+  if (assessment.openCommentsDetail && assessment.openCommentsDetail.totalOpen > 0) {
+    const groups = assessment.openCommentsDetail.byAnchorKind;
+    const renderGroup = (label: string, g: typeof groups.decision): void => {
+      if (g.count === 0) return;
+      const age = g.oldestCreatedAt ? timeAgo(g.oldestCreatedAt) : "unknown age";
+      lines.push(`  - ${label}: ${g.count} (oldest ${age})`);
+      for (const c of g.comments) {
+        const targetTitle = c.target.title ? ` "${c.target.title}"` : "";
+        lines.push(
+          `    - ${capitalizeDisplayName(c.author)} ${timeAgo(c.createdAt)} on ${c.target.kind} ${c.target.handle}${targetTitle} [${c.type}]: ${c.contentSnippet}`,
+        );
+      }
+    };
+    renderGroup("Decision-anchored", groups.decision);
+    renderGroup("Section-anchored", groups.section);
   }
   lines.push(`- Open/converted Issues: ${f.openIssuesCount}`);
   // spec-120 ac-1: AC verification state, from the same test_events derivation

--- a/packages/server/src/services/sections.ts
+++ b/packages/server/src/services/sections.ts
@@ -6,6 +6,7 @@ import { NotFoundError, ValidationError } from "../types/errors.js";
 import { mutate, type Mutated, type RequestCtx } from "./mutate.js";
 import { resolveActorColumns } from "./actor.js";
 import { nextSeq, withSeqRetry } from "./shared/sequence.js";
+import { pgError } from "./shared/pg-error.js";
 import { embedAndStoreSection } from "./memex-embeddings.js";
 
 // b-36 T-2: doc_sections's per-doc seq unique constraint was renamed from
@@ -15,8 +16,8 @@ import { embedAndStoreSection } from "./memex-embeddings.js";
 const DOC_SECTIONS_SEQ_CONSTRAINT = "doc_sections_doc_seq_unique";
 
 function isDocSeqConflict(err: unknown): boolean {
-  if (!err || typeof err !== "object") return false;
-  const e = err as { constraint_name?: string; message?: string };
+  const e = pgError(err);
+  if (!e) return false;
   if (e.constraint_name === DOC_SECTIONS_SEQ_CONSTRAINT) return true;
   return typeof e.message === "string" && e.message.includes(DOC_SECTIONS_SEQ_CONSTRAINT);
 }
@@ -139,10 +140,7 @@ export async function addSection(
             // can pick a different sectionType instead of seeing a raw Postgres message.
             // (We let `doc_sections_doc_seq_unique` 23505s bubble up — withSeqRetry handles them.)
             if (
-              err &&
-              typeof err === "object" &&
-              "code" in err &&
-              (err as { code?: string }).code === "23505" &&
+              pgError(err)?.code === "23505" &&
               !isDocSeqConflict(err)
             ) {
               throw new ValidationError(
@@ -356,12 +354,7 @@ export async function updateSection(
         // (docId, sectionType) unique violation → surface the same readable
         // message addSection/retitleSection use so the agent picks a different
         // identifier instead of seeing a raw Postgres 23505.
-        if (
-          err &&
-          typeof err === "object" &&
-          "code" in err &&
-          (err as { code?: string }).code === "23505"
-        ) {
+        if (pgError(err)?.code === "23505") {
           throw new ValidationError(
             `Section type '${sectionType}' already exists on this document. Pick a different identifier (e.g. '${sectionType}-2', or a more specific name).`,
           );
@@ -436,12 +429,7 @@ export async function retitleSection(
       } catch (err) {
         // (docId, sectionType) unique violation → surface the same readable
         // message addSection uses so the agent picks a different identifier.
-        if (
-          err &&
-          typeof err === "object" &&
-          "code" in err &&
-          (err as { code?: string }).code === "23505"
-        ) {
+        if (pgError(err)?.code === "23505") {
           throw new ValidationError(
             `Section type '${sectionType}' already exists on this document. Pick a different identifier (e.g. '${sectionType}-2', or a more specific name).`,
           );

--- a/packages/server/src/services/shared/pg-error.ts
+++ b/packages/server/src/services/shared/pg-error.ts
@@ -1,0 +1,31 @@
+/**
+ * Recover the underlying postgres-js driver error from whatever drizzle throws.
+ *
+ * drizzle-orm ≥0.44 wraps every failed query in a `DrizzleQueryError` and stashes
+ * the original driver error (the object carrying `.code` / `.constraint_name`) on
+ * `.cause`. Before that — drizzle 0.39, which this repo ran until the 0.45 bump —
+ * the driver error was thrown directly, so our conflict handlers read `.code` off
+ * the caught value. Walk the `.cause` chain so 23505 / constraint-name
+ * introspection keeps working across both shapes.
+ */
+export interface PgError {
+  code?: string;
+  constraint_name?: string;
+  message?: string;
+}
+
+export function pgError(err: unknown): PgError | undefined {
+  let cur: unknown = err;
+  // Bounded walk: DrizzleQueryError → driver error is one hop; cap to be safe.
+  for (let depth = 0; depth < 5 && cur && typeof cur === "object"; depth++) {
+    const e = cur as PgError & { cause?: unknown };
+    if (typeof e.code === "string") return e;
+    cur = e.cause;
+  }
+  return undefined;
+}
+
+/** True when the (possibly drizzle-wrapped) error is a Postgres unique violation. */
+export function isUniqueViolation(err: unknown): boolean {
+  return pgError(err)?.code === "23505";
+}

--- a/packages/server/src/services/shared/sequence.ts
+++ b/packages/server/src/services/shared/sequence.ts
@@ -1,6 +1,7 @@
 import { eq, sql } from "drizzle-orm";
 import type { PgTable, PgColumn } from "drizzle-orm/pg-core";
 import { db } from "../../db/connection.js";
+import { pgError } from "./pg-error.js";
 
 /**
  * Returns the next sequence number for a given table/column,
@@ -68,9 +69,8 @@ export async function withSeqRetry<T>(
 }
 
 function isSeqConflict(err: unknown, constraint: string): boolean {
-  if (!err || typeof err !== "object") return false;
-  const e = err as { code?: string; constraint_name?: string; message?: string };
-  if (e.code !== "23505") return false;
+  const e = pgError(err);
+  if (!e || e.code !== "23505") return false;
   if (e.constraint_name === constraint) return true;
   // postgres-js exposes the constraint via `constraint_name`; if missing fall
   // back to a string match on the message so we don't accidentally swallow

--- a/packages/server/src/services/specify-comments-walkthrough.spec-259.test.ts
+++ b/packages/server/src/services/specify-comments-walkthrough.spec-259.test.ts
@@ -1,0 +1,51 @@
+// spec-259 t-3 — ac-3: the specify-phase prompt instructs the agent to walk the
+// user through open comments BEFORE advancing specify→build.
+//
+// The specify-phase prompt prose is the `phase-specify-intent` PromptBlock in
+// `@memex/shared`'s scaffold-data.ts (the single owner of phase prompt prose
+// per std-15 / b-68 dec-6). We assert against the SOURCE file so the test is
+// robust to the @memex/shared dist rebuild timing — it must hold the
+// walkthrough instruction in the existing freshness-walkthrough voice.
+
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it, expect } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+const AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-259/acs/ac-${n}`;
+
+const here = dirname(fileURLToPath(import.meta.url));
+const SCAFFOLD_DATA = resolve(
+  here,
+  "..",
+  "..",
+  "..",
+  "shared",
+  "src",
+  "scaffold-data.ts",
+);
+
+describe("spec-259: specify prompt instructs the open-comment walkthrough (ac-3)", () => {
+  it("the specify-phase intent block tells the agent to walk open comments before specify→build", () => {
+    tagAc(AC(3));
+    const src = readFileSync(SCAFFOLD_DATA, "utf8");
+
+    // The instruction lives in the phase-specify-intent block.
+    const intentIdx = src.indexOf("id: 'phase-specify-intent'");
+    expect(intentIdx).toBeGreaterThan(-1);
+    // Bound the assertion to that block (up to the next prompt-block id).
+    const after = src.slice(intentIdx);
+    const block = after.slice(0, after.indexOf("id: 'phase-specify-discipline'"));
+
+    expect(block).toMatch(/before advancing specify.+build/i);
+    expect(block).toMatch(/walk the user through .*open comments/i);
+    // Mirrors the assess_spec comments survey it should lean on. (Source escapes
+    // the inner single quotes, so match on the tool + mode tokens.)
+    expect(block).toContain("assess_spec");
+    expect(block).toMatch(/mode:.{0,2}comments/);
+    // States plainly that open comments do not gate the transition.
+    expect(block).toMatch(/do not block|not blocked/i);
+  });
+});

--- a/packages/server/src/services/waitlist.ts
+++ b/packages/server/src/services/waitlist.ts
@@ -2,6 +2,7 @@ import { db } from "../db/connection.js";
 import { waitlistEntries } from "../db/schema.js";
 import type { WaitlistEntry } from "../db/schema.js";
 import { ConflictError, ValidationError } from "../types/errors.js";
+import { isUniqueViolation } from "./shared/pg-error.js";
 import { mutate, type Mutated, type RequestCtx } from "./mutate.js";
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
@@ -58,14 +59,5 @@ export async function addWaitlistEntry(
         throw err;
       }
     },
-  );
-}
-
-function isUniqueViolation(err: unknown): boolean {
-  return (
-    typeof err === "object" &&
-    err !== null &&
-    "code" in err &&
-    (err as { code?: string }).code === "23505"
   );
 }

--- a/packages/server/src/services/who-resolver.integration.test.ts
+++ b/packages/server/src/services/who-resolver.integration.test.ts
@@ -26,6 +26,10 @@ const AC = "mindset-prod/memex-building-itself/specs/spec-122/acs";
 const created = { users: [] as string[], sessions: [] as string[] };
 const tag = `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
 const christineEmail = `christine-${tag}@memex.ai`;
+// spec-259 dec-4: the resolver now title-cases a RESOLVED user's display name. The
+// seed name is "Christine <tag>" with a lowercase tag, so the rendered display
+// capitalises the tag's leading letter too (digits are unaffected by toUpperCase).
+const christineDisplay = `Christine ${tag.charAt(0).toUpperCase()}${tag.slice(1)}`;
 let christineId: string;
 let twinAId: string;
 let twinBId: string;
@@ -63,14 +67,14 @@ describe("WHO resolver [spec-122 t-5]", () => {
     tagAc(`${AC}/ac-25`);
     const r = await resolveTestEventActor(christineEmail.toUpperCase()); // case-insensitive
     expect(r.userId).toBe(christineId);
-    expect(r.display).toBe(`Christine ${tag}`);
+    expect(r.display).toBe(christineDisplay);
   });
 
   it("ac-25: a test_events.actor matching a user's (unambiguous) name resolves + unifies", async () => {
     tagAc(`${AC}/ac-25`);
     const r = await resolveTestEventActor(`Christine ${tag}`);
     expect(r.userId).toBe(christineId);
-    expect(r.display).toBe(`Christine ${tag}`);
+    expect(r.display).toBe(christineDisplay);
   });
 
   it("ac-25: the batch resolver unifies email + name hits in one pass", async () => {
@@ -100,7 +104,7 @@ describe("WHO resolver [spec-122 t-5]", () => {
   it("ac-27: an agent clientId resolves \"<user name>'s <clientName>\"", async () => {
     tagAc(`${AC}/ac-27`);
     const label = await resolveAgentClientLabel(sessionId);
-    expect(label).toBe(`Christine ${tag}'s Claude Code`);
+    expect(label).toBe(`${christineDisplay}'s Claude Code`);
   });
 
   it("ac-27: an unknown clientId resolves to null (no fabricated label)", async () => {
@@ -122,6 +126,6 @@ describe("WHO resolver [spec-122 t-5]", () => {
     const byEmail = await resolveTestEventActor(christineEmail);
     expect(byEmail.userId).toBe(christineId);
     const label = await resolveAgentClientLabel(sessionId);
-    expect(label).toBe(`Christine ${tag}'s Claude Code`);
+    expect(label).toBe(`${christineDisplay}'s Claude Code`);
   });
 });

--- a/packages/server/src/services/who-resolver.ts
+++ b/packages/server/src/services/who-resolver.ts
@@ -14,6 +14,7 @@
 //  3. Agent client labels → resolveAgentClientLabel (ac-27).
 
 import { eq, or, sql, inArray } from "drizzle-orm";
+import { capitalizeDisplayName } from "@memex/shared";
 import { db } from "../db/connection.js";
 import { users, mcpSessions } from "../db/schema.js";
 import { actorName } from "./actor.js";
@@ -50,7 +51,7 @@ export async function resolveTestEventActor(actor: string | null | undefined): P
     .where(sql`lower(${users.email}) = ${raw.toLowerCase()}`)
     .limit(1);
   if (byEmail.length === 1) {
-    return { display: actorName(byEmail[0]), userId: byEmail[0].id };
+    return { display: capitalizeDisplayName(actorName(byEmail[0])), userId: byEmail[0].id };
   }
 
   // Exact name match — only when unambiguous (exactly one user).
@@ -60,10 +61,12 @@ export async function resolveTestEventActor(actor: string | null | undefined): P
     .where(eq(users.name, raw))
     .limit(2);
   if (byName.length === 1) {
-    return { display: actorName(byName[0]), userId: byName[0].id };
+    return { display: capitalizeDisplayName(actorName(byName[0])), userId: byName[0].id };
   }
 
-  // Miss (or ambiguous) → verbatim, unattributed.
+  // Miss (or ambiguous) → verbatim, unattributed. NOT capitalized: a free-form /
+  // CI identity string ("CI · abc123") is not a person name — spec-259 dec-4 scopes
+  // capitalization to resolved user names, and ac-26 requires the miss render verbatim.
   return { display: raw, userId: null };
 }
 
@@ -93,7 +96,7 @@ export async function resolveAgentClientLabel(clientId: string | null | undefine
   const { clientName, userName, userEmail } = rows[0];
   const client = clientName?.trim() || "client";
   const who = userName?.trim() || userEmail?.trim() || null;
-  return who ? `${who}'s ${client}` : client;
+  return who ? `${capitalizeDisplayName(who)}'s ${client}` : client;
 }
 
 /**
@@ -123,9 +126,10 @@ export async function resolveTestEventActors(
 
   for (const raw of distinct) {
     const e = byEmail.get(raw.toLowerCase());
-    if (e) { out.set(raw, { display: actorName(e), userId: e.id }); continue; }
+    if (e) { out.set(raw, { display: capitalizeDisplayName(actorName(e)), userId: e.id }); continue; }
     const n = byName.get(raw);
-    if (n) { out.set(raw, { display: actorName(n), userId: n.id }); continue; }
+    if (n) { out.set(raw, { display: capitalizeDisplayName(actorName(n)), userId: n.id }); continue; }
+    // Miss → verbatim (NOT capitalized; spec-259 dec-4 / ac-26).
     out.set(raw, { display: raw, userId: null });
   }
   return out;

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -22,6 +22,6 @@
   "devDependencies": {
     "@memex-ai-ac/vitest": "workspace:*",
     "typescript": "^5.7.0",
-    "vitest": "^4.1.1"
+    "vitest": "^4.1.8"
   }
 }

--- a/packages/shared/src/display-name.test.ts
+++ b/packages/shared/src/display-name.test.ts
@@ -1,0 +1,46 @@
+// spec-259 dec-4 (ac-7, ac-13): the conservative display-name capitalization helper.
+// It uppercases only a leading lowercase letter per token, preserves interior casing,
+// and leaves email fallbacks and agent labels untouched.
+import { describe, it, expect } from 'vitest';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { capitalizeDisplayName } from './display-name.js';
+
+const AC7 = 'mindset-prod/memex-building-itself/specs/spec-259/acs/ac-7';
+const AC13 = 'mindset-prod/memex-building-itself/specs/spec-259/acs/ac-13';
+
+describe('capitalizeDisplayName (spec-259 dec-4)', () => {
+  it('title-cases a plain lowercase name', () => {
+    tagAc(AC13);
+    tagAc(AC7);
+    expect(capitalizeDisplayName('barrie hadfield')).toBe('Barrie Hadfield');
+  });
+
+  it('preserves interior casing — never lowercases an interior capital', () => {
+    tagAc(AC13);
+    // Leading letter already uppercase → untouched; interior capitals kept.
+    expect(capitalizeDisplayName('McDonald')).toBe('McDonald');
+    expect(capitalizeDisplayName('DeShawn')).toBe('DeShawn');
+    // Apostrophe is not a token boundary, so the interior letter is left as-is.
+    expect(capitalizeDisplayName("o'brien")).toBe("O'brien");
+    expect(capitalizeDisplayName("O'Brien")).toBe("O'Brien");
+  });
+
+  it('leaves email-derived fallbacks (containing "@") untouched', () => {
+    tagAc(AC13);
+    tagAc(AC7);
+    expect(capitalizeDisplayName('barrie@mindset.ai')).toBe('barrie@mindset.ai');
+  });
+
+  it('leaves known agent labels untouched', () => {
+    tagAc(AC13);
+    expect(capitalizeDisplayName('Memex agent')).toBe('Memex agent');
+    expect(capitalizeDisplayName('memex agent')).toBe('memex agent');
+  });
+
+  it('is a no-op on empty / nullish input', () => {
+    tagAc(AC13);
+    expect(capitalizeDisplayName('')).toBe('');
+    expect(capitalizeDisplayName(null)).toBe('');
+    expect(capitalizeDisplayName(undefined)).toBe('');
+  });
+});

--- a/packages/shared/src/display-name.ts
+++ b/packages/shared/src/display-name.ts
@@ -1,0 +1,43 @@
+// spec-259 dec-4 — conservative display-name capitalization for presentation.
+//
+// Author/actor names render verbatim today — lowercase or email-derived (e.g.
+// "barrie hadfield", "barrie@mindset.ai"). This helper title-cases them for DISPLAY
+// only. It is applied at every render site that emits a name: the spec-122:dec-8 WHO
+// resolver (who-resolver.ts) and — because search resolves WHO inline in SQL and
+// bypasses that resolver — the search formatter (memex-search.ts formatHitByline +
+// per-section lines).
+//
+// It NEVER mutates stored author_name / actor_name: std-32 makes those the immutable
+// audit record, stamped at write so a rename can't rewrite history. Capitalization is
+// strictly a read/render transform.
+//
+// The algorithm is deliberately conservative — it uppercases ONLY a leading lowercase
+// letter of each whitespace-separated token and never touches interior casing, so
+// real names survive intact:
+//   "barrie hadfield" → "Barrie Hadfield"
+//   "McDonald"        → "McDonald"   (interior capital preserved)
+//   "o'brien"         → "O'brien"    (apostrophe is not a token boundary)
+//   "DeShawn"         → "DeShawn"    (already-correct interior capital preserved)
+// and two classes are returned untouched:
+//   - any value containing "@" (the user.name ?? user.email fallback — emails must
+//     not be title-cased: "barrie@…" → "Barrie@…" is wrong)
+//   - known agent labels (e.g. "Memex agent") — not people.
+
+const AGENT_LABELS = new Set(['memex agent', 'memex ai', 'memex']);
+
+/**
+ * Title-case a display name for presentation, preserving interior casing and leaving
+ * email-derived fallbacks and agent labels untouched. Render-layer only — never feed
+ * the result back into a stored column.
+ */
+export function capitalizeDisplayName(raw: string | null | undefined): string {
+  if (raw == null) return '';
+  const trimmed = raw.trim();
+  if (trimmed === '') return raw;
+  if (trimmed.includes('@')) return raw; // email fallback — leave verbatim
+  if (AGENT_LABELS.has(trimmed.toLowerCase())) return raw; // agent label — not a person
+
+  // Uppercase only a leading lowercase letter of each whitespace-delimited token.
+  // Interior characters and the original whitespace are preserved exactly.
+  return raw.replace(/(^|\s)([a-z])/g, (_match, boundary: string, ch: string) => boundary + ch.toUpperCase());
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -147,3 +147,9 @@ export {
   isQaReportSectionType,
   qaReportVersion,
 } from './qa-report.js';
+
+// spec-259 dec-5: the one canonical relative-age helper (server MCP/agent surfaces
+// + UI), injectable `now` for deterministic output. Wire forms keep absolute ISO.
+export { timeAgo } from './relative-time.js';
+// spec-259 dec-4: conservative display-name capitalization, render-layer only.
+export { capitalizeDisplayName } from './display-name.js';

--- a/packages/shared/src/relative-time.test.ts
+++ b/packages/shared/src/relative-time.test.ts
@@ -1,0 +1,44 @@
+// spec-259 dec-5 (ac-8, ac-14): the one canonical relative-age helper renders
+// "Nd ago" deterministically against an INJECTED reference-now, and accepts both
+// ISO strings and Date objects. Determinism is the property that lets MCP/agent
+// output be asserted exactly under test.
+import { describe, it, expect } from 'vitest';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { timeAgo } from './relative-time.js';
+
+const AC8 = 'mindset-prod/memex-building-itself/specs/spec-259/acs/ac-8';
+const AC14 = 'mindset-prod/memex-building-itself/specs/spec-259/acs/ac-14';
+
+describe('timeAgo — shared relative-age helper (spec-259 dec-5)', () => {
+  // A fixed reference instant so every assertion is reproducible.
+  const NOW = new Date('2026-06-14T12:00:00.000Z');
+
+  it('renders the relative ladder deterministically against an injected now', () => {
+    tagAc(AC14);
+    tagAc(AC8);
+    expect(timeAgo(new Date('2026-06-14T11:59:30.000Z'), NOW)).toBe('just now');
+    expect(timeAgo(new Date('2026-06-14T11:45:00.000Z'), NOW)).toBe('15m ago');
+    expect(timeAgo(new Date('2026-06-14T09:00:00.000Z'), NOW)).toBe('3h ago');
+    expect(timeAgo(new Date('2026-06-11T12:00:00.000Z'), NOW)).toBe('3d ago');
+    expect(timeAgo(new Date('2026-05-24T12:00:00.000Z'), NOW)).toBe('3w ago');
+  });
+
+  it('accepts ISO strings as well as Date objects (server carries Date, UI carries ISO)', () => {
+    tagAc(AC14);
+    expect(timeAgo('2026-06-11T12:00:00.000Z', NOW)).toBe('3d ago');
+    expect(timeAgo(new Date('2026-06-11T12:00:00.000Z'), NOW)).toBe('3d ago');
+  });
+
+  it('clamps a clock-skew future instant to "just now" and is empty for bad/null input', () => {
+    tagAc(AC14);
+    expect(timeAgo(new Date('2026-06-14T12:05:00.000Z'), NOW)).toBe('just now');
+    expect(timeAgo(null, NOW)).toBe('');
+    expect(timeAgo('not-a-date', NOW)).toBe('');
+  });
+
+  it('falls back to an absolute date beyond ~8 weeks so "63w ago" never appears', () => {
+    tagAc(AC8);
+    // ~10 weeks before NOW.
+    expect(timeAgo(new Date('2026-04-05T12:00:00.000Z'), NOW)).toMatch(/\d{1,2} \w{3} 2026/);
+  });
+});

--- a/packages/shared/src/relative-time.ts
+++ b/packages/shared/src/relative-time.ts
@@ -1,0 +1,50 @@
+// spec-259 dec-5 — the ONE canonical relative-age helper, shared by server (MCP /
+// agent surfaces) and the React UI. Before this, "time ago" was reimplemented ad
+// hoc in ≥4 UI components and never existed server-side, while comments rendered
+// three divergent absolute formats (formatDate YYYY-MM-DD, raw .toISOString(), and
+// none). dec-5 rationalises every human/agent-facing WHEN to one relative rendering
+// through this helper, while structured/wire forms keep absolute ISO-8601.
+//
+// `now` is INJECTABLE so MCP/agent output is deterministic under test (a fixed
+// reference instant), while live calls default to the current time.
+//
+// Granularity ladder (coarsening as it ages): just now → Nm → Nh → Nd → Nw, then it
+// falls back to an absolute date so "63w ago" never appears. Always past-tense — a
+// row's timestamp is in the past; a (clock-skew) future instant clamps to "just now".
+//
+// Lifted from the spec-286 UI helper (packages/ui/src/utils/timeAgo.ts), which the
+// UI now re-exports from here so there is one implementation.
+
+const MINUTE = 60_000;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+const WEEK = 7 * DAY;
+
+function absoluteDate(date: Date): string {
+  return date.toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' });
+}
+
+/**
+ * Format a timestamp as a short relative time from `now` (default: current time).
+ * Accepts an ISO-8601 string or a `Date` (the server carries `Date` objects, the
+ * UI carries ISO strings). `now` is injectable so tests are deterministic.
+ *
+ * Examples: "just now", "5m ago", "3h ago", "2d ago", "5w ago", then "12 Jun 2026".
+ * Returns "" for an unparseable / null input (callers omit the byline rather than
+ * render a broken one).
+ */
+export function timeAgo(value: string | Date | null | undefined, now: Date = new Date()): string {
+  if (value == null) return '';
+  const then = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(then.getTime())) return '';
+
+  const diff = now.getTime() - then.getTime();
+  if (diff < MINUTE) return 'just now'; // includes small future skew (diff < 0)
+
+  if (diff < HOUR) return `${Math.floor(diff / MINUTE)}m ago`;
+  if (diff < DAY) return `${Math.floor(diff / HOUR)}h ago`;
+  if (diff < WEEK) return `${Math.floor(diff / DAY)}d ago`;
+  // Up to ~8 weeks stays relative; beyond that an absolute date is more legible.
+  if (diff < 8 * WEEK) return `${Math.floor(diff / WEEK)}w ago`;
+  return absoluteDate(then);
+}

--- a/packages/shared/src/scaffold-data.ts
+++ b/packages/shared/src/scaffold-data.ts
@@ -354,9 +354,10 @@ const PHASE_PLAN_INTENT: PromptBlockNode = {
     'What to do next depends on the decision state:\n' +
     '- **No decisions yet** — surface the decisions this work hinges on; capture the choices that have been hand-waved as `create_decision`.\n' +
     '- **Open decisions remain** — drive each unresolved decision to resolution: summarise its context, options and trade-offs, recommend where you can, and resolve it on the user\'s call.\n' +
-    '- **All decisions resolved** — the spec is settled. Make sure each resolution is reflected in the narrative, then point the user at a team review (share the Spec) or moving into `build`.',
+    '- **All decisions resolved** — the spec is settled. Make sure each resolution is reflected in the narrative, then point the user at a team review (share the Spec) or moving into `build`.\n\n' +
+    'Before advancing specify→build, walk the user through any open comments (`assess_spec({mode:\'comments\'})` lists them oldest-first, with WHO raised each and how stale it is) — answer the questions, fold accepted notes into the narrative, and resolve them, just as you walk decision/narrative freshness before a forward move. Open comments do not block the build transition; flag them and let the human decide.',
   rationale:
-    'What the specify phase IS for. Tells the agent that draft+specify share semantics and the work is decision resolution + narrative shaping. Mirrors the opening "## Phase: specify (and draft)" block of `specify/system.md`.',
+    'What the specify phase IS for. Tells the agent that draft+specify share semantics and the work is decision resolution + narrative shaping, and (spec-259 t-3) to walk the user through open comments before specify→build — mirroring the mode=\'narrative\' freshness walkthrough. Mirrors the opening "## Phase: specify (and draft)" block of `specify/system.md`.',
 };
 
 const PHASE_PLAN_DISCIPLINE: PromptBlockNode = {

--- a/packages/ui/e2e/helpers/retained.ts
+++ b/packages/ui/e2e/helpers/retained.ts
@@ -126,6 +126,21 @@ export async function seedSection(opts: {
   return call("POST", "/seed-section", opts);
 }
 
+/** spec-259 t-5: seed an OPEN comment on a section / decision / task through the
+ *  real comment services (emits on the bus). Backs the Specify-phase
+ *  open-comment parity journey — the summary band + per-comment WHO/WHEN byline
+ *  render off comments seeded this way. */
+export async function seedComment(opts: {
+  memexId: string;
+  target: "section" | "decision" | "task";
+  targetId: string;
+  authorName?: string;
+  content?: string;
+  commentType?: string;
+}): Promise<{ commentId: string; seq: number }> {
+  return call("POST", "/seed-comment", opts);
+}
+
 /** spec-286: apply `scope::value`/flat tags to a Spec through applyTagStrings —
  *  the tags the QA Reports feed rail filters + counts on. */
 export async function seedTags(opts: {

--- a/packages/ui/e2e/helpers/seed.ts
+++ b/packages/ui/e2e/helpers/seed.ts
@@ -103,8 +103,12 @@ export async function seedSpecInMemex(opts: {
   title: string;
   purpose?: string;
   createdByUserId?: string;
-}): Promise<{ docId: string; handle: string }> {
-  return call<{ docId: string; handle: string }>("POST", "/seed-spec", opts);
+}): Promise<{ docId: string; handle: string; sectionId: string | null }> {
+  return call<{ docId: string; handle: string; sectionId: string | null }>(
+    "POST",
+    "/seed-spec",
+    opts,
+  );
 }
 
 /**
@@ -396,4 +400,21 @@ export async function seedTask(opts: {
   status?: "not_started" | "in_progress" | "complete";
 }): Promise<{ taskId: string; seq: number }> {
   return call("POST", "/seed-task", opts);
+}
+
+/**
+ * spec-259 t-5: seed an OPEN comment on a section / decision / task through the
+ * real comment services (so it emits on the bus [per std-8]). Backs the
+ * Specify-phase open-comment parity journey — the open-comment summary and the
+ * per-comment WHO/WHEN byline render off comments seeded this way.
+ */
+export async function seedComment(opts: {
+  memexId: string;
+  target: "section" | "decision" | "task";
+  targetId: string;
+  authorName?: string;
+  content?: string;
+  commentType?: string;
+}): Promise<{ commentId: string; seq: number }> {
+  return call("POST", "/seed-comment", opts);
 }

--- a/packages/ui/e2e/journey-33-spec-259-open-comment-parity.spec.ts
+++ b/packages/ui/e2e/journey-33-spec-259-open-comment-parity.spec.ts
@@ -1,0 +1,147 @@
+import {
+  test,
+  expect,
+  tenantPath,
+  switchToEditing,
+  emitAcEvents,
+} from "./helpers/index.js";
+import {
+  seedOrgTenant,
+  seedSpec,
+  setDocStatus,
+  seedOpenDecision,
+  seedComment,
+} from "./helpers/retained.js";
+
+// Journey 33 — spec-259 ac-5: the web Specify phase surfaces open-comment
+// status CONSISTENTLY with the MCP agent's view, and the specify→build Rubicon
+// sentence is comments-aware ADVISORY guidance (the web does NOT hard-gate —
+// spec-247 / std-34: the web is for viewing + minimum-friction input).
+//
+//   • The Comments sub-tab shows the same open-comment picture the agent sees:
+//     counts, anchor-kind split (decision-anchored vs section-anchored, where
+//     tasks fold into section-anchored), and the oldest open comment's relative
+//     age — all via the SHARED timeAgo so the phrasing matches.
+//   • Every comment row carries a WHO/WHEN byline (author + relative time).
+//   • The Rubicon sentence reads the exact spec-259 copy and the advance-to-Build
+//     affordance stays reachable WITH open comments present (guidance, not lock).
+//
+// ac-5 has the component-level AllComments tests as its unit proof; this journey
+// is the end-to-end proof that the seeded open comments actually render this
+// picture in the running app.
+const AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-259/acs/ac-${n}`;
+const ACS = [AC(5)];
+
+test.afterEach(async ({}, testInfo) => {
+  await emitAcEvents(
+    ACS,
+    testInfo.status === "passed" ? "pass" : "fail",
+    `packages/ui/e2e/journey-33-spec-259-open-comment-parity.spec.ts::${testInfo.title}`,
+    testInfo.duration,
+  );
+});
+
+test("specify Comments surface shows the open-comment summary + WHO/WHEN byline; advance-to-Build stays reachable", async ({
+  page,
+  resources,
+}) => {
+  const tenant = await seedOrgTenant({ slug: resources.slug("j33") });
+  const spec = await seedSpec({
+    memexId: tenant.memexId,
+    title: "Open Comment Parity Spec",
+    purpose: "Exercise the Specify-phase open-comment parity surface.",
+  });
+  await setDocStatus({
+    memexId: tenant.memexId,
+    docId: spec.docId,
+    status: "specify",
+  });
+
+  // An open DECISION (so we can hang a decision-anchored comment off it).
+  const decision = await seedOpenDecision({
+    memexId: tenant.memexId,
+    docId: spec.docId,
+    title: "Pick the cache layer",
+    context: "Two options on the table.",
+    options: [
+      { label: "Redis", trade_offs: "Battle-tested; another box." },
+      { label: "In-process LRU", trade_offs: "Zero-ops; per-instance only." },
+    ],
+  });
+
+  // One section-anchored open comment (on the overview section) + one
+  // decision-anchored open comment → the summary should read 2 open, split 1/1.
+  await seedComment({
+    memexId: tenant.memexId,
+    target: "section",
+    targetId: spec.sectionId,
+    authorName: "Sam Section",
+    content: "This section needs another pass before we build.",
+  });
+  await seedComment({
+    memexId: tenant.memexId,
+    target: "decision",
+    targetId: decision.decisionId,
+    authorName: "Dana Decision",
+    content: "Have we considered the cold-start cost of Redis?",
+  });
+
+  await page.goto(
+    tenantPath(tenant.namespaceSlug, tenant.memexSlug, `/specs/${spec.handle}`),
+    { waitUntil: "commit" },
+  );
+  await expect(
+    page.getByRole("heading", { level: 1, name: /Open Comment Parity Spec/ }),
+  ).toBeVisible({ timeout: 15_000 });
+
+  // ── The Rubicon is ADDITIVE (spec-259 ac-5 reconciled with spec-282/196) ──
+  // This spec has an OPEN decision, so the current-tab Rubicon leads with the
+  // spec-282 blocker statement (NOT a lock — status only, no button). The
+  // comments-aware advisory ("You can advance to Build when all open decisions
+  // are resolved and all comments are addressed.") is the CLEAN-state form, pinned
+  // in the TransitionSentence unit tests. Here we assert the blocker coexists with
+  // the open-comment surface below.
+  await expect(page.getByTestId("transition-sentence")).toContainText(
+    /Decision.*must be resolved/i,
+    { timeout: 15_000 },
+  );
+  await expect(page.getByRole("button", { name: "Yes" })).toHaveCount(0);
+
+  // ── Open the Comments sub-tab ──
+  await page.getByRole("button", { name: /^Comments\b/ }).click();
+
+  // ── The open-comment summary mirrors the agent's picture ──
+  const summary = page.getByTestId("open-comments-summary");
+  await expect(summary).toBeVisible({ timeout: 15_000 });
+  await expect(summary).toContainText("2 open comments");
+  await expect(summary).toContainText("1 decision-anchored");
+  await expect(summary).toContainText("1 section-anchored");
+  // Oldest age is a relative phrase from the shared timeAgo helper (freshly-seeded
+  // comments render "just now"; older ones "Nd ago").
+  await expect(page.getByTestId("open-comments-oldest")).toContainText(/just now|ago/);
+
+  // ── Every comment row carries a WHO + WHEN byline ──
+  await expect(
+    page.getByTestId("comment-byline-author").first(),
+  ).toBeVisible();
+  await expect(page.getByText("Sam Section")).toBeVisible();
+  await expect(page.getByText("Dana Decision")).toBeVisible();
+  // WHEN is a relative phrase (matching the agent), not an absolute date.
+  await expect(page.getByTestId("comment-byline-when").first()).toContainText(
+    /just now|ago/,
+  );
+
+  // ── No hard gate: advancing to Build stays reachable WITH open comments ──
+  // The web doesn't move the phase from the current tab (spec-282) — the move
+  // lives on the browse-forward Build-tab confirm. An editor browsing the Build
+  // tab still gets a working "Move this spec anyway? [Yes]" even though open
+  // comments + decisions remain: the Rubicon is guidance, never a lock.
+  await switchToEditing(page);
+  await page.locator('[role="tab"][data-tab="build"]').click();
+  const sentence = page.getByTestId("transition-sentence");
+  await expect(sentence).toBeVisible({ timeout: 15_000 });
+  await expect(
+    sentence.getByRole("button", { name: "Yes" }),
+  ).toBeEnabled();
+});

--- a/packages/ui/e2e/journey-33-spec-293-move-spec.spec.ts
+++ b/packages/ui/e2e/journey-33-spec-293-move-spec.spec.ts
@@ -1,0 +1,90 @@
+import { test, expect, ensureUser, tenantPath, DEV_EMAIL, emitAcEvents, type TestResources } from "./helpers/index.js";
+import { seedOrgTenant, seedSpec, type SeededOrgTenant } from "./helpers/retained.js";
+import type { Page } from "@playwright/test";
+
+// Journey 33 — spec-293: move a Spec between two Memexes.
+//
+// The end-to-end proof of the fix: dev owns two org Memexes; we seed a Spec in
+// the first, open the redesigned Move dialog (dec-2/dec-3: whole-Spec move, no
+// per-artifact checkboxes, "Comments" not "Section comments"), pick the second
+// Memex, and confirm the Spec lands there at its new handle. All seeding goes
+// through the env-gated test surface (real services → bus, std-8); navigation is
+// path-based (std-2).
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-293/acs/ac-${n}`;
+
+const ACS_BY_TITLE: Record<string, string[]> = {
+  "the Move dialog moves the whole Spec to another Memex": [AC(1), AC(2), AC(13)],
+};
+
+test.afterEach(async ({}, testInfo) => {
+  if (testInfo.status === "skipped") return;
+  const refs = ACS_BY_TITLE[testInfo.title];
+  if (!refs) return;
+  await emitAcEvents(
+    refs,
+    testInfo.status === "passed" ? "pass" : "fail",
+    `packages/ui/e2e/journey-33-spec-293-move-spec.spec.ts::${testInfo.title}`,
+    testInfo.duration,
+  );
+});
+
+interface MoveSeed {
+  source: SeededOrgTenant;
+  target: SeededOrgTenant;
+  docId: string;
+  title: string;
+}
+
+const test2 = test.extend<{ seed: MoveSeed }>({
+  seed: async ({ resources }: { resources: TestResources }, use) => {
+    await ensureUser(DEV_EMAIL);
+    // Two org Memexes the dev user owns → both are valid move destinations.
+    const source = await seedOrgTenant({ slug: resources.slug("j33-src") });
+    const target = await seedOrgTenant({ slug: resources.slug("j33-dst") });
+    const title = `Movable Spec ${resources.slug("j33")}`;
+    const { docId } = await seedSpec({ memexId: source.memexId, title });
+    await use({ source, target, docId, title });
+  },
+});
+
+async function gotoSpec(page: Page, seed: MoveSeed): Promise<void> {
+  await page.goto(tenantPath(seed.source.namespaceSlug, seed.source.memexSlug, `/docs/${seed.docId}`));
+  await expect(page.getByRole("heading", { name: seed.title, level: 1 })).toBeVisible({
+    timeout: 15_000,
+  });
+}
+
+test2.describe("spec-293 — Move spec between Memexes", () => {
+  test2("the Move dialog moves the whole Spec to another Memex", async ({ page, seed }) => {
+    await gotoSpec(page, seed);
+
+    // Open the spec actions menu → Move.
+    await page.getByRole("button", { name: `Actions for ${seed.title}` }).click();
+    await page.getByRole("menuitem", { name: "Move to another memex" }).click();
+
+    // The redesigned dialog (dec-2/dec-3): a read-only "what moves" summary,
+    // no per-artifact opt-out checkboxes, and "Comments" — never "Section comments".
+    // Scope every assertion to the dialog: the spec page behind it also has a
+    // "Comments" tab, so page-wide text locators are ambiguous.
+    const dialog = page.getByTestId("move-spec-dialog");
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toContainText(/What moves/i);
+    await expect(dialog.locator('input[type="checkbox"]')).toHaveCount(0);
+    await expect(dialog).toContainText("Comments");
+    await expect(dialog).not.toContainText(/Section comments/i);
+
+    // Pick the target Memex and move.
+    await dialog.getByRole("combobox").selectOption(seed.target.memexId);
+    await dialog.getByRole("button", { name: /^Move$/ }).click();
+
+    // We land on the moved Spec in the TARGET Memex, at its new handle.
+    await page.waitForURL(
+      new RegExp(`/${seed.target.namespaceSlug}/${seed.target.memexSlug}/specs/spec-\\d+`),
+      { timeout: 20_000 },
+    );
+    await expect(page.getByRole("heading", { name: seed.title, level: 1 })).toBeVisible({
+      timeout: 15_000,
+    });
+  });
+});

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -17,8 +17,8 @@
     "test:e2e": "playwright test"
   },
   "dependencies": {
-    "@langchain/core": "^1.1.38",
-    "@langchain/langgraph": "^1.2.6",
+    "@langchain/core": "^1.1.49",
+    "@langchain/langgraph": "^1.4.2",
     "@memex/guide-sdk": "workspace:*",
     "@memex/shared": "workspace:*",
     "@nivo/bar": "0.99.0",
@@ -35,9 +35,9 @@
     "pixi.js": "8.19.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-markdown": "^9.0.1",
+    "react-markdown": "^10.1.0",
     "react-resizable-panels": "^4.8.0",
-    "react-router-dom": "^7.1.0",
+    "react-router-dom": "^7.17.0",
     "rehype-highlight": "^7.0.1",
     "rehype-raw": "^7.0.0",
     "remark-breaks": "^4.0.0",
@@ -50,16 +50,16 @@
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
     "@types/d3-force": "3.0.10",
-    "@types/react": "^19.0.0",
+    "@types/react": "^19.2.17",
     "@types/react-dom": "^19.0.0",
-    "@vitejs/plugin-react": "^4.3.4",
-    "@vitest/coverage-v8": "^4.1.4",
+    "@vitejs/plugin-react": "^6.0.2",
+    "@vitest/coverage-v8": "^4.1.8",
     "autoprefixer": "^10.4.20",
     "jsdom": "^29.0.1",
     "postcss": "^8.4.49",
     "tailwindcss": "^3.4.17",
     "typescript": "~5.7.2",
-    "vite": "^6.0.5",
-    "vitest": "^4.1.1"
+    "vite": "^8.0.16",
+    "vitest": "^4.1.8"
   }
 }

--- a/packages/ui/src/api/client.ts
+++ b/packages/ui/src/api/client.ts
@@ -411,15 +411,13 @@ export async function stampGreeting(): Promise<void> {
   if (!res.ok) throw new Error(`Failed to stamp greeting: ${res.status}`);
 }
 
+// spec-293 dec-2/dec-3: a move is always whole — no per-artifact opt-out flags.
 export interface MoveDocInput {
   targetMemexId: string;
-  includeDecisions: boolean;
-  includeTasks: boolean;
-  includeSectionComments: boolean;
 }
 
 export interface MoveDocResponse {
-  doc: { id: string; handle: string; memexId: string; title: string };
+  docId: string;
   fromMemexId: string;
   toMemexId: string;
   newHandle: string;

--- a/packages/ui/src/components/AllComments.test.tsx
+++ b/packages/ui/src/components/AllComments.test.tsx
@@ -361,4 +361,103 @@ describe('AllComments', () => {
     expect(writeText).toHaveBeenCalledTimes(1);
     expect(writeText.mock.calls[0][0]).toContain('comment=c-7');
   });
+
+  // spec-259 ac-5 — the web Specify Comments surface shows the SAME open-comment
+  // picture the MCP agent renders: counts, anchor-kind split (decision-anchored
+  // vs section-anchored, where tasks fold into section-anchored), the oldest
+  // relative age, and a per-comment WHO/WHEN byline (via the shared timeAgo).
+  const AC259_5 = 'mindset-prod/memex-building-itself/specs/spec-259/acs/ac-5';
+  // Recent timestamps so the shared `timeAgo` stays in its relative window
+  // ("Nd ago") rather than falling back to an absolute date (>8w).
+  const HOUR_MS = 60 * 60 * 1000;
+  const hoursAgo = (h: number) => new Date(Date.now() - h * HOUR_MS).toISOString();
+
+  it('renders the open-comment summary: counts + anchor-kind split + oldest age', () => {
+    tagAc(AC259_5);
+    const section = makeSection();
+    const decision = makeDecision();
+    const task = makeTask();
+    render(
+      <AllComments
+        sections={[section]}
+        decisions={[decision]}
+        tasks={[task]}
+        // 1 decision-anchored; 2 section-anchored (1 section + 1 task). The
+        // section comment is the oldest open one.
+        commentsBySection={{
+          [section.id]: [
+            makeComment({ id: 'c-sec', content: 'section comment', createdAt: hoursAgo(50) }),
+          ],
+        }}
+        commentsByDecision={{
+          [decision.id]: [makeComment({ id: 'c-dec', content: 'decision comment', createdAt: hoursAgo(2) })],
+        }}
+        commentsByTask={{
+          [task.id]: [makeComment({ id: 'c-task', content: 'task comment', createdAt: hoursAgo(3) })],
+        }}
+        onNavigateToSection={vi.fn()}
+      />
+    );
+
+    const summary = screen.getByTestId('open-comments-summary');
+    expect(summary.textContent).toContain('3 open comments');
+    expect(summary.textContent).toContain('1 decision-anchored');
+    expect(summary.textContent).toContain('2 section-anchored');
+    // Oldest age is a relative phrase from the shared helper (the 50h-old one).
+    expect(screen.getByTestId('open-comments-oldest').textContent).toContain('ago');
+  });
+
+  it('the summary counts OPEN comments only and is singular for one', () => {
+    tagAc(AC259_5);
+    const section = makeSection();
+    render(
+      <AllComments
+        sections={[section]}
+        commentsBySection={{
+          [section.id]: [
+            makeComment({ id: 'c-open', content: 'open' }),
+            makeComment({ id: 'c-done', content: 'done', resolvedAt: '2025-02-01T00:00:00Z' }),
+          ],
+        }}
+        onNavigateToSection={vi.fn()}
+      />
+    );
+    expect(screen.getByTestId('open-comments-summary').textContent).toContain(
+      '1 open comment'
+    );
+    // No summary band when there are zero open comments.
+  });
+
+  it('omits the summary band when there are no open comments', () => {
+    tagAc(AC259_5);
+    const section = makeSection();
+    render(
+      <AllComments
+        sections={[section]}
+        commentsBySection={{
+          [section.id]: [makeComment({ id: 'c-done', resolvedAt: '2025-02-01T00:00:00Z' })],
+        }}
+        onNavigateToSection={vi.fn()}
+      />
+    );
+    expect(screen.queryByTestId('open-comments-summary')).not.toBeInTheDocument();
+  });
+
+  it('each comment row carries a WHO + WHEN byline (author + relative time)', () => {
+    tagAc(AC259_5);
+    const section = makeSection();
+    render(
+      <AllComments
+        sections={[section]}
+        commentsBySection={{
+          [section.id]: [
+            makeComment({ id: 'c-1', authorName: 'Alice', content: 'hi', createdAt: hoursAgo(5) }),
+          ],
+        }}
+        onNavigateToSection={vi.fn()}
+      />
+    );
+    expect(screen.getByTestId('comment-byline-author').textContent).toBe('Alice');
+    expect(screen.getByTestId('comment-byline-when').textContent).toContain('ago');
+  });
 });

--- a/packages/ui/src/components/AllComments.tsx
+++ b/packages/ui/src/components/AllComments.tsx
@@ -3,6 +3,11 @@ import type { Comment, DocSection, Decision, Task } from '../api/types';
 import { CommentBubble } from './CommentTray';
 import { filterComments, type AuthorKindFilter, type StatusFilter } from '../utils/filterComments';
 import { commentAnchorId, buildCommentLink } from '../utils/commentDeepLink';
+// spec-259 ac-5: surface the SAME open-comment picture the MCP agent shows at
+// specify→build — counts, anchor-kind split (decision-anchored vs
+// section-anchored), and the oldest open comment's relative age. `timeAgo` is
+// the shared helper so the web phrasing matches the agent's.
+import { timeAgo } from '../utils/timeAgo';
 
 // spec-100 ac-6: wrap a comment with a stable scroll anchor (`comment-c-{seq}`)
 // and a copy-link button so a viewer can be taken straight to it.
@@ -157,8 +162,56 @@ export function AllComments({
     decisionEntries.reduce((n, e) => n + e.comments.length, 0) +
     taskEntries.reduce((n, e) => n + e.comments.length, 0);
 
+  // spec-259 ac-5: the readiness SUMMARY mirrors the agent's `assess_spec`
+  // ({mode:'comments'}) picture and is independent of the local filter chips —
+  // it always counts OPEN comments (no resolvedAt) across the doc and splits
+  // them by anchor kind. Per the server's `anchorKindForTarget`, decision
+  // comments are "decision-anchored"; sections AND tasks are "section-anchored"
+  // (the narrative surface the human reviews). The oldest open comment's
+  // createdAt drives the relative-age phrase.
+  const isOpen = (c: Comment) => !c.resolvedAt;
+  const openDecisionComments = Object.values(commentsByDecision)
+    .flat()
+    .filter(isOpen);
+  const openSectionAnchored = [
+    ...Object.values(commentsBySection).flat(),
+    ...Object.values(commentsByTask).flat(),
+  ].filter(isOpen);
+  const decisionAnchoredCount = openDecisionComments.length;
+  const sectionAnchoredCount = openSectionAnchored.length;
+  const totalOpenCount = decisionAnchoredCount + sectionAnchoredCount;
+  const oldestOpenAt = [...openDecisionComments, ...openSectionAnchored].reduce<
+    string | null
+  >((oldest, c) => {
+    if (!oldest) return c.createdAt;
+    return new Date(c.createdAt).getTime() < new Date(oldest).getTime()
+      ? c.createdAt
+      : oldest;
+  }, null);
+
   return (
     <div className="space-y-6 ml-8">
+      {totalOpenCount > 0 && (
+        <div
+          data-testid="open-comments-summary"
+          className="rounded-md border border-divider bg-overlay px-3 py-2 text-xs text-secondary"
+        >
+          <span className="font-medium text-primary">
+            {totalOpenCount} open comment{totalOpenCount === 1 ? '' : 's'}
+          </span>
+          <span className="text-muted">
+            {' '}— {decisionAnchoredCount} decision-anchored,{' '}
+            {sectionAnchoredCount} section-anchored
+          </span>
+          {oldestOpenAt && (
+            <span className="text-muted">
+              {' '}· oldest{' '}
+              <span data-testid="open-comments-oldest">{timeAgo(oldestOpenAt)}</span>
+            </span>
+          )}
+        </div>
+      )}
+
       {hasAnyComments && (
         <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5">
           <SegmentedFilter

--- a/packages/ui/src/components/CommentTray.tsx
+++ b/packages/ui/src/components/CommentTray.tsx
@@ -15,6 +15,9 @@ import { CommentTypePill } from './CommentTypePill';
 import { CommentSourceAvatar } from './CommentSourceAvatar';
 import { DecisionLink, TaskLink, parseEntityRefs } from './DecisionLink';
 import { commentTypeAccentBorder } from '../utils/commentStyles';
+// spec-259 ac-5: render WHEN as the SAME relative phrase the MCP/agent surface
+// uses ("3d ago") so the web Specify readiness picture matches the agent's.
+import { timeAgo } from '../utils/timeAgo';
 
 interface CommentTrayProps {
   targetType: CommentTargetType;
@@ -213,12 +216,15 @@ export function CommentBubble({
   const isResolved = !!comment.resolvedAt;
   const isAgent = comment.source === 'agent';
   const accent = isAgent ? `border-l-2 ${commentTypeAccentBorder(comment.commentType)}` : '';
-  const date = new Date(comment.createdAt).toLocaleDateString('en-US', {
+  const absoluteDate = new Date(comment.createdAt).toLocaleDateString('en-US', {
     month: 'short',
     day: 'numeric',
     hour: 'numeric',
     minute: '2-digit',
   });
+  // spec-259 ac-5: WHEN is a relative phrase matching the agent surface; the
+  // exact timestamp stays available on hover.
+  const relative = timeAgo(comment.createdAt);
 
   return (
     <div
@@ -242,10 +248,21 @@ export function CommentBubble({
       <div className="flex items-center justify-between mb-1">
         <div className="flex items-center gap-1.5 min-w-0">
           <CommentSourceAvatar source={comment.source} authorName={comment.authorName} />
-          <span className="text-xs font-medium text-primary truncate">{comment.authorName}</span>
+          <span
+            className="text-xs font-medium text-primary truncate"
+            data-testid="comment-byline-author"
+          >
+            {comment.authorName}
+          </span>
           <CommentTypePill type={comment.commentType} hideForDiscussion />
         </div>
-        <span className="text-xs text-muted shrink-0">{date}</span>
+        <span
+          className="text-xs text-muted shrink-0"
+          title={absoluteDate}
+          data-testid="comment-byline-when"
+        >
+          {relative}
+        </span>
       </div>
       <p className="text-sm text-primary whitespace-pre-wrap">
         {parseEntityRefs(comment.content).map((seg, i) =>

--- a/packages/ui/src/components/MoveSpecDialog.spec-293.test.tsx
+++ b/packages/ui/src/components/MoveSpecDialog.spec-293.test.tsx
@@ -1,0 +1,97 @@
+// spec-293 dec-2/dec-3 (ac-13): the Move-spec dialog no longer offers per-artifact
+// opt-out checkboxes (a Spec moves whole) and refers to "Comments", never
+// "Section comments".
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { tagAc } from '@memex-ai-ac/vitest';
+import type { MembershipSummary, SessionPayload } from '../api/client';
+
+const AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-293/acs/ac-${n}`;
+
+let mockSession: SessionPayload | null = null;
+
+vi.mock('./AuthContext', async () => {
+  const real = await vi.importActual<typeof import('./AuthContext')>('./AuthContext');
+  return {
+    ...real,
+    useAuth: () => ({
+      session: mockSession,
+      user: { name: 'Alice', email: 'alice@example.com', picture: '' },
+      token: 'fake-token',
+      isAuthenticated: true,
+      authError: null,
+      logout: vi.fn(),
+      updateSession: vi.fn(),
+      acceptSession: vi.fn(),
+    }),
+  };
+});
+
+vi.mock('../utils/tenantUrl', async () => {
+  const real = await vi.importActual<typeof import('../utils/tenantUrl')>('../utils/tenantUrl');
+  return {
+    ...real,
+    getCurrentTenant: () => ({ namespace: 'acme', memex: 'memex-one' }),
+  };
+});
+
+import { MoveSpecDialog } from './MoveSpecDialog';
+
+function session(): SessionPayload {
+  const dest: MembershipSummary = {
+    memexId: 'mx-two',
+    slug: 'acme',
+    memexSlug: 'memex-two',
+    name: 'Acme Inc',
+    kind: 'team',
+    role: 'administrator',
+  };
+  return {
+    user: { id: 'u-1', email: 'alice@example.com', name: 'Alice', status: 'active', emailVerified: true },
+    memberships: [
+      { ...dest, memexId: 'mx-one', memexSlug: 'memex-one' },
+      dest,
+    ],
+    currentMemexId: 'mx-one',
+    currentRole: 'administrator',
+    needsOnboarding: false,
+    hiddenFeatures: [],
+  };
+}
+
+describe('MoveSpecDialog whole-move shape (spec-293)', () => {
+  beforeEach(() => {
+    mockSession = session();
+  });
+  afterEach(() => {
+    cleanup();
+    mockSession = null;
+  });
+
+  it('ac-13: renders no opt-out checkboxes and says "Comments", not "Section comments"', () => {
+    tagAc(AC(13));
+    tagAc(AC(3)); // scope: dialog reads "Comments" and treats all comments uniformly
+    render(
+      <MoveSpecDialog
+        docId="doc-1"
+        title="Publish the DB schema"
+        decisionCount={1}
+        taskCount={4}
+        commentCount={2}
+        onClose={() => {}}
+      />,
+    );
+
+    // No per-artifact opt-out checkboxes.
+    expect(screen.queryAllByRole('checkbox')).toHaveLength(0);
+
+    // "Comments" present; "Section comments" gone.
+    expect(screen.getByText(/Comments/)).toBeTruthy();
+    expect(screen.queryByText(/Section comments/i)).toBeNull();
+
+    // The read-only "what moves" summary is shown.
+    expect(screen.getByText(/What moves/i)).toBeTruthy();
+  });
+});

--- a/packages/ui/src/components/MoveSpecDialog.tsx
+++ b/packages/ui/src/components/MoveSpecDialog.tsx
@@ -8,10 +8,10 @@ import { getCurrentTenant, tenantPathFor } from '../utils/tenantUrl';
 interface MoveSpecDialogProps {
   docId: string;
   title: string;
-  // Optional pre-computed counts so the dialog can show what will move.
+  // Optional pre-computed counts so the dialog can show what will travel.
   decisionCount?: number;
   taskCount?: number;
-  sectionCommentCount?: number;
+  commentCount?: number;
   onClose: () => void;
   // Called after a successful move, before the window redirects. Lets the caller clear
   // local state (e.g. remove the card from the kanban) in case the navigation is delayed.
@@ -19,15 +19,15 @@ interface MoveSpecDialogProps {
 }
 
 // Dialog for moving a Spec to a different Memex. Destination is any Memex the user
-// is an active member of besides the current one. Checkboxes let the user leave decisions,
-// tasks, and section-comments behind as orphans in the source Memex; unchecked items stay
-// on their old memex_id and re-attach if the spec is ever moved back.
+// is an active member of besides the current one. spec-293 (dec-2/dec-3): a Spec moves
+// WHOLE — every artifact and ALL comments travel with it — so there are no per-artifact
+// opt-outs; the dialog just shows what will move. Public share links are revoked.
 export function MoveSpecDialog({
   docId,
   title,
   decisionCount,
   taskCount,
-  sectionCommentCount,
+  commentCount,
   onClose,
   onMoved,
 }: MoveSpecDialogProps) {
@@ -61,9 +61,6 @@ export function MoveSpecDialog({
   const [targetMemexId, setTargetMemexId] = useState<string>(
     destinations[0]?.memexId ?? '',
   );
-  const [includeDecisions, setIncludeDecisions] = useState(true);
-  const [includeTasks, setIncludeTasks] = useState(true);
-  const [includeSectionComments, setIncludeSectionComments] = useState(true);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -93,9 +90,6 @@ export function MoveSpecDialog({
     try {
       const result = await moveDocApi(docId, {
         targetMemexId: chosen.memexId,
-        includeDecisions,
-        includeTasks,
-        includeSectionComments,
       });
 
       // Compose a toast-worthy message if deps were pruned or share tokens revoked. We
@@ -142,7 +136,10 @@ export function MoveSpecDialog({
         if (e.target === e.currentTarget && !submitting) onClose();
       }}
     >
-      <div className="w-full max-w-lg rounded-xl border border-edge bg-panel shadow-2xl">
+      <div
+        data-testid="move-spec-dialog"
+        className="w-full max-w-lg rounded-xl border border-edge bg-panel shadow-2xl"
+      >
         <div className="px-6 py-4 border-b border-edge flex items-center justify-between">
           <h2 className="text-base font-semibold text-heading">Move spec</h2>
           <button
@@ -190,37 +187,25 @@ export function MoveSpecDialog({
 
               <div className="space-y-2">
                 <div className="text-xs font-medium uppercase tracking-wider text-muted">
-                  Also move
+                  What moves
                 </div>
-                <CheckboxRow
-                  checked={includeDecisions}
-                  onChange={setIncludeDecisions}
-                  disabled={submitting}
-                  label="Decisions"
-                  hint={typeof decisionCount === 'number' ? `${decisionCount} total` : undefined}
-                />
-                <CheckboxRow
-                  checked={includeTasks}
-                  onChange={setIncludeTasks}
-                  disabled={submitting}
-                  label="Tasks"
-                  hint={typeof taskCount === 'number' ? `${taskCount} total` : undefined}
-                />
-                <CheckboxRow
-                  checked={includeSectionComments}
-                  onChange={setIncludeSectionComments}
-                  disabled={submitting}
-                  label="Section comments"
-                  hint={
-                    typeof sectionCommentCount === 'number'
-                      ? `${sectionCommentCount} unresolved`
-                      : undefined
-                  }
-                />
+                <ul className="text-sm text-secondary space-y-1">
+                  <li>
+                    The whole Spec — its sections, ACs, QA report, issues, members and
+                    assignees.
+                  </li>
+                  <li>
+                    <MovePart label="Decisions" count={decisionCount} />
+                    {', '}
+                    <MovePart label="Tasks" count={taskCount} />
+                    {' and '}
+                    <MovePart label="Comments" count={commentCount} />
+                    {' travel with it.'}
+                  </li>
+                </ul>
                 <p className="text-xs text-muted pt-1">
-                  Unchecked items stay in this memex. They&apos;ll re-attach if the spec is
-                  moved back. Any blocker links between moved and unmoved items are removed.
-                  Public share links are revoked.
+                  The Spec&apos;s handle changes in the destination, and public share links
+                  are revoked.
                 </p>
               </div>
             </>
@@ -252,30 +237,13 @@ export function MoveSpecDialog({
   );
 }
 
-function CheckboxRow({
-  checked,
-  onChange,
-  disabled,
-  label,
-  hint,
-}: {
-  checked: boolean;
-  onChange: (v: boolean) => void;
-  disabled?: boolean;
-  label: string;
-  hint?: string;
-}) {
+// Renders "<count> <label>" when a count is known, else just the label — used in
+// the read-only "what moves" summary.
+function MovePart({ label, count }: { label: string; count?: number }) {
   return (
-    <label className={`flex items-center gap-2 text-sm ${disabled ? 'opacity-60' : ''}`}>
-      <input
-        type="checkbox"
-        checked={checked}
-        onChange={(e) => onChange(e.target.checked)}
-        disabled={disabled}
-        className="h-4 w-4 rounded border-edge bg-input text-accent focus:ring-0 focus:ring-offset-0"
-      />
-      <span className="text-primary">{label}</span>
-      {hint && <span className="text-muted">· {hint}</span>}
-    </label>
+    <span className="text-primary">
+      {typeof count === 'number' ? `${count} ` : ''}
+      {label}
+    </span>
   );
 }

--- a/packages/ui/src/components/TransitionSentence.spec-282.test.tsx
+++ b/packages/ui/src/components/TransitionSentence.spec-282.test.tsx
@@ -50,8 +50,12 @@ function text() {
 }
 
 describe('spec-282 ac-5/ac-11 — the current phase tab carries no advance offer', () => {
-  // Ready state: every current-phase tab renders nothing — no question, no button.
-  for (const phase of ['specify', 'build', 'verify'] as const) {
+  // Ready state: build/verify current tabs render nothing — no question, no
+  // button. (spec-259 ac-5: a clean specify current tab now carries a
+  // comments-aware ADVISORY sentence — still no question and no button, so the
+  // spec-282 "no advance offer on the current tab" invariant holds; its own case
+  // below.)
+  for (const phase of ['build', 'verify'] as const) {
     it(`${phase} ready, current tab → nothing renders (no offer, no button)`, () => {
       tagAc(AC(5));
       tagAc(AC(11));
@@ -60,6 +64,17 @@ describe('spec-282 ac-5/ac-11 — the current phase tab carries no advance offer
       expect(screen.queryByRole('button')).toBeNull();
     });
   }
+
+  it('specify ready, current tab → comments-aware advisory, but NO question and NO button (spec-259 ac-5)', () => {
+    tagAc(AC(5));
+    tagAc(AC(11));
+    render(<TransitionSentence {...baseProps({ currentPhase: 'specify', viewedTab: 'specify' })} />);
+    expect(text()).toBe(
+      'You can advance to Build when all open decisions are resolved and all comments are addressed.',
+    );
+    expect(text()).not.toContain('?');
+    expect(screen.queryByRole('button')).toBeNull();
+  });
 
   // Blocked state: the rubric statement renders, but there is NO question and NO
   // button — status-only — for editors and non-editors alike.

--- a/packages/ui/src/components/TransitionSentence.test.tsx
+++ b/packages/ui/src/components/TransitionSentence.test.tsx
@@ -71,9 +71,13 @@ describe('Rubicon line — current tab is status-only (spec-282/dec-4); draft ke
     expect(screen.queryByRole('button', { name: 'No' })).toBeNull();
   });
 
-  it('specify (clean, current tab) → renders nothing (no standing offer)', () => {
+  it('specify (clean, current tab) → comments-aware advisory, no button (spec-259 ac-5)', () => {
+    // spec-259 ac-5 (additive): a CLEAN specify current tab carries the
+    // comments-aware advisory (no standing offer/button — still status-only).
     render(<TransitionSentence {...baseProps()} />);
-    expect(screen.queryByTestId('transition-sentence')).toBeNull();
+    expect(screen.getByTestId('transition-sentence').textContent).toContain(
+      'You can advance to Build when all open decisions are resolved and all comments are addressed.',
+    );
     expect(screen.queryByRole('button')).toBeNull();
   });
 
@@ -243,10 +247,15 @@ describe('Rubicon line — posture (i-1) and the Yes mutation', () => {
     expect(screen.queryByRole('button')).toBeNull();
   });
 
-  it('canTransition=false on the current tab with a clean rubric renders NOTHING — no offer', () => {
+  it('canTransition=false on a clean specify current tab → comments-aware advisory (status-only), no buttons', () => {
     tagAc(AC182_9);
+    // spec-259 ac-5 (additive): the clean specify advisory is STATUS, not an
+    // offer, so it shows for non-editors too — but never a button.
     render(<TransitionSentence {...baseProps({ canTransition: false })} />);
-    expect(screen.queryByTestId('transition-sentence')).toBeNull();
+    expect(screen.getByTestId('transition-sentence').textContent).toContain(
+      'You can advance to Build when all open decisions are resolved and all comments are addressed.',
+    );
+    expect(screen.queryByRole('button')).toBeNull();
   });
 
   it('canTransition=false on the current tab, blocked → the rubric condition, no buttons', () => {
@@ -313,11 +322,11 @@ describe('no switch-to-Editing nag (spec-182 dec-6, amended)', () => {
   it('a non-transitioning viewer sees a clean status line — no nag in any sentence shape', () => {
     tagAc(AC182(14));
     tagAc(AC182(6));
-    // Clean offer shape — renders nothing at all for a non-editor
-    // (spec-182 issue-1), so trivially no nag.
+    // Clean specify shape — a non-editor sees the spec-259 comments-aware
+    // advisory (status-only), and crucially NO switch-to-Editing nag.
     const { unmount } = render(<TransitionSentence {...baseProps()} canTransition={false} />);
     expect(screen.queryByTestId('switch-to-editing')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('transition-sentence')).toBeNull();
+    expect(text()).not.toContain("You're reviewing");
     unmount();
 
     // Blocked shape — the status line renders, nag-free.

--- a/packages/ui/src/components/TransitionSentence.tsx
+++ b/packages/ui/src/components/TransitionSentence.tsx
@@ -286,8 +286,24 @@ export function TransitionSentence({
     // anyway? [Yes]" still forces a blocked move.
     if (currentPhase !== 'draft') {
       if (blockers.length === 0) {
+        // spec-259 ac-5 (additive): with a CLEAN rubric at specify, the standing
+        // line is the comments-aware ADVISORY — the web is a viewing + low-friction
+        // surface and does NOT hard-gate the specify→build move (spec-247 / std-34;
+        // comments flag, never gate, per dec-1/ac-6). It reflects comments as a
+        // rubric item without overriding the spec-282/196 blocker reporting, which
+        // still leads while the rubric is blocked (below). Other phases keep the
+        // spec-282 "nothing when clean".
+        if (currentPhase === 'specify') {
+          return (
+            <p className="text-sm text-secondary" data-testid="transition-sentence">
+              You can advance to Build when all open decisions are resolved and all
+              comments are addressed.
+            </p>
+          );
+        }
         return null;
       }
+      // Blocked: spec-282/196 status-only blocker reporting (unchanged).
       return (
         <p className="text-sm text-secondary" data-testid="transition-sentence">
           {renderBlockers(blockers)} before this spec can move to {phaseDisplayName(target)}

--- a/packages/ui/src/pages/DocDocument.tsx
+++ b/packages/ui/src/pages/DocDocument.tsx
@@ -1272,7 +1272,7 @@ export function DocDocument() {
           title={doc.title}
           decisionCount={decs.length}
           taskCount={ts.length}
-          sectionCommentCount={sectionCommentCount}
+          commentCount={totalCommentCount}
           onClose={() => setMoveOpen(false)}
         />
       )}

--- a/packages/ui/src/utils/timeAgo.ts
+++ b/packages/ui/src/utils/timeAgo.ts
@@ -1,39 +1,4 @@
-// spec-286: a compact relative-time helper for the QA Reports feed metadata line.
-//
-// The existing utils stop short of what the feed needs: `formatDate` (utils/format)
-// is an absolute date and `relativeDays` (DoneSummary) only has day granularity.
-// A QA report generated "2h ago" should read that way, not "today" or "12 Jun 2026".
-//
-// Granularity ladder (coarsening as it ages): just now → Nm → Nh → Nd → Nw, then it
-// falls back to an absolute date so "63w ago" never appears. Always past-tense — a
-// report's createdAt is in the past; a (clock-skew) future instant clamps to "just now".
-
-const MINUTE = 60_000;
-const HOUR = 60 * MINUTE;
-const DAY = 24 * HOUR;
-const WEEK = 7 * DAY;
-
-function absoluteDate(date: Date): string {
-  return date.toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' });
-}
-
-/**
- * Format `iso` as a short relative time from `now` (default: the current time).
- * `now` is injectable so tests are deterministic without faking the clock.
- *
- * Examples: "just now", "5m ago", "3h ago", "2d ago", "5w ago", then "12 Jun 2026".
- */
-export function timeAgo(iso: string, now: Date = new Date()): string {
-  const then = new Date(iso);
-  if (Number.isNaN(then.getTime())) return '';
-
-  const diff = now.getTime() - then.getTime();
-  if (diff < MINUTE) return 'just now'; // includes small future skew (diff < 0)
-
-  if (diff < HOUR) return `${Math.floor(diff / MINUTE)}m ago`;
-  if (diff < DAY) return `${Math.floor(diff / HOUR)}h ago`;
-  if (diff < WEEK) return `${Math.floor(diff / DAY)}d ago`;
-  // Up to ~8 weeks stays relative; beyond that an absolute date is more legible.
-  if (diff < 8 * WEEK) return `${Math.floor(diff / WEEK)}w ago`;
-  return absoluteDate(then);
-}
+// spec-259 dec-5: the relative-time helper now lives once in @memex/shared so the
+// server (MCP/agent) and the UI render WHEN identically. This module re-exports it
+// to keep the existing `utils/timeAgo` import path stable for spec-286's consumers.
+export { timeAgo } from '@memex/shared';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,9 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  vitest: 4.1.1
-  '@vitest/coverage-v8': 4.1.1
-  '@types/node': 22.19.15
+  vitest: 4.1.8
+  '@vitest/coverage-v8': 4.1.8
+  '@types/node': 25.9.3
   react: 19.2.7
   react-dom: 19.2.7
 
@@ -18,33 +18,33 @@ importers:
   packages/ac-emit-vitest:
     devDependencies:
       '@types/node':
-        specifier: 22.19.15
-        version: 22.19.15
+        specifier: 25.9.3
+        version: 25.9.3
       typescript:
         specifier: ^5.7.0
         version: 5.7.3
       vitest:
-        specifier: 4.1.1
-        version: 4.1.1(@types/node@22.19.15)(jsdom@29.1.1)(vite@6.4.3(@types/node@22.19.15)(jiti@1.21.7)(tsx@4.22.4))
+        specifier: 4.1.8
+        version: 4.1.8(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@1.21.7)(tsx@4.22.4))
 
   packages/cli:
     devDependencies:
       vitest:
-        specifier: 4.1.1
-        version: 4.1.1(@types/node@22.19.15)(jsdom@29.1.1)(vite@6.4.3(@types/node@22.19.15)(jiti@1.21.7)(tsx@4.22.4))
+        specifier: 4.1.8
+        version: 4.1.8(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@1.21.7)(tsx@4.22.4))
 
   packages/db-schema:
     dependencies:
       drizzle-orm:
-        specifier: ^0.39.0
-        version: 0.39.3(postgres@3.4.9)
+        specifier: ^0.45.2
+        version: 0.45.2(gel@2.2.0)(postgres@3.4.9)
     devDependencies:
       '@memex-ai-ac/vitest':
         specifier: workspace:*
         version: link:../ac-emit-vitest
       '@types/node':
-        specifier: 22.19.15
-        version: 22.19.15
+        specifier: 25.9.3
+        version: 25.9.3
       postgres:
         specifier: ^3.4.5
         version: 3.4.9
@@ -55,8 +55,8 @@ importers:
         specifier: ^5.7.0
         version: 5.7.3
       vitest:
-        specifier: 4.1.1
-        version: 4.1.1(@types/node@22.19.15)(jsdom@29.1.1)(vite@6.4.3(@types/node@22.19.15)(jiti@1.21.7)(tsx@4.22.4))
+        specifier: 4.1.8
+        version: 4.1.8(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(jiti@1.21.7)(tsx@4.22.4))
 
   packages/extractor:
     dependencies:
@@ -67,8 +67,8 @@ importers:
         specifier: ^16.4.7
         version: 16.6.1
       drizzle-orm:
-        specifier: ^0.39.0
-        version: 0.39.3(postgres@3.4.9)
+        specifier: ^0.45.2
+        version: 0.45.2(gel@2.2.0)(postgres@3.4.9)
       postgres:
         specifier: ^3.4.5
         version: 3.4.9
@@ -80,8 +80,8 @@ importers:
         version: 0.25.10
     devDependencies:
       '@types/node':
-        specifier: 22.19.15
-        version: 22.19.15
+        specifier: 25.9.3
+        version: 25.9.3
       tsx:
         specifier: ^4.19.0
         version: 4.22.4
@@ -89,17 +89,17 @@ importers:
         specifier: ^5.7.0
         version: 5.7.3
       vitest:
-        specifier: 4.1.1
-        version: 4.1.1(@types/node@22.19.15)(jsdom@29.1.1)(vite@6.4.3(@types/node@22.19.15)(jiti@1.21.7)(tsx@4.22.4))
+        specifier: 4.1.8
+        version: 4.1.8(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@1.21.7)(tsx@4.22.4))
 
   packages/guide-sdk:
     dependencies:
       '@langchain/core':
-        specifier: ^1.1.38
-        version: 1.1.48(openai@4.104.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)
+        specifier: ^1.1.49
+        version: 1.1.49(openai@6.42.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)
       '@langchain/langgraph':
-        specifier: ^1.2.6
-        version: 1.3.3(@langchain/core@1.1.48(openai@4.104.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3)
+        specifier: ^1.4.2
+        version: 1.4.2(@langchain/core@1.1.49(openai@6.42.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3)
       '@ricky0123/vad-web':
         specifier: ^0.0.30
         version: 0.0.30
@@ -118,16 +118,16 @@ importers:
         version: 6.9.1
       '@testing-library/react':
         specifier: ^16.3.2
-        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@types/react':
-        specifier: ^19.0.0
-        version: 19.2.16
+        specifier: ^19.2.17
+        version: 19.2.17
       '@types/react-dom':
         specifier: ^19.0.0
-        version: 19.2.3(@types/react@19.2.16)
+        version: 19.2.3(@types/react@19.2.17)
       '@vitejs/plugin-react':
-        specifier: ^4.3.4
-        version: 4.7.0(vite@6.4.3(@types/node@22.19.15)(jiti@1.21.7)(tsx@4.22.4))
+        specifier: ^6.0.2
+        version: 6.0.2(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@1.21.7)(tsx@4.22.4))
       jsdom:
         specifier: ^29.0.1
         version: 29.1.1
@@ -135,26 +135,26 @@ importers:
         specifier: ~5.7.2
         version: 5.7.3
       vite:
-        specifier: ^6.0.5
-        version: 6.4.3(@types/node@22.19.15)(jiti@1.21.7)(tsx@4.22.4)
+        specifier: ^8.0.16
+        version: 8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@1.21.7)(tsx@4.22.4)
       vitest:
-        specifier: 4.1.1
-        version: 4.1.1(@types/node@22.19.15)(jsdom@29.1.1)(vite@6.4.3(@types/node@22.19.15)(jiti@1.21.7)(tsx@4.22.4))
+        specifier: 4.1.8
+        version: 4.1.8(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@1.21.7)(tsx@4.22.4))
 
   packages/server:
     dependencies:
       '@anthropic-ai/sdk':
-        specifier: ^0.80.0
-        version: 0.80.0(zod@4.4.3)
+        specifier: ^0.104.1
+        version: 0.104.1(zod@4.4.3)
       '@google-cloud/kms':
-        specifier: ^5.5.0
-        version: 5.5.0
+        specifier: ^5.5.1
+        version: 5.5.1
       '@hono/node-server':
         specifier: ^1.13.0
-        version: 1.19.14(hono@4.12.23)
+        version: 1.19.14(hono@4.12.25)
       '@hono/node-ws':
         specifier: ^1.3.1
-        version: 1.3.1(@hono/node-server@1.19.14(hono@4.12.23))(hono@4.12.23)
+        version: 1.3.1(@hono/node-server@1.19.14(hono@4.12.25))(hono@4.12.25)
       '@memex/shared':
         specifier: workspace:*
         version: link:../shared
@@ -162,8 +162,8 @@ importers:
         specifier: ^1.27.1
         version: 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)
       '@slack/web-api':
-        specifier: ^7.16.0
-        version: 7.16.0
+        specifier: ^7.17.0
+        version: 7.17.0
       cohere-ai:
         specifier: ^7.21.0
         version: 7.21.0
@@ -171,17 +171,17 @@ importers:
         specifier: ^16.4.7
         version: 16.6.1
       drizzle-orm:
-        specifier: ^0.39.0
-        version: 0.39.3(postgres@3.4.9)
+        specifier: ^0.45.2
+        version: 0.45.2(gel@2.2.0)(postgres@3.4.9)
       google-auth-library:
-        specifier: ^10.6.2
-        version: 10.6.2
+        specifier: ^10.7.0
+        version: 10.7.0
       hono:
-        specifier: ^4.7.0
-        version: 4.12.23
+        specifier: ^4.12.25
+        version: 4.12.25
       openai:
-        specifier: ^4.104.0
-        version: 4.104.0(ws@8.21.0)(zod@4.4.3)
+        specifier: ^6.42.0
+        version: 6.42.0(ws@8.21.0)(zod@4.4.3)
       postgres:
         specifier: ^3.4.5
         version: 3.4.9
@@ -196,17 +196,17 @@ importers:
         specifier: workspace:*
         version: link:../ac-emit-vitest
       '@types/node':
-        specifier: 22.19.15
-        version: 22.19.15
+        specifier: 25.9.3
+        version: 25.9.3
       '@types/ws':
         specifier: ^8.18.1
         version: 8.18.1
       '@vitest/coverage-v8':
-        specifier: 4.1.1
-        version: 4.1.1(vitest@4.1.1(@types/node@22.19.15)(jsdom@29.1.1)(vite@6.4.3(@types/node@22.19.15)(jiti@1.21.7)(tsx@4.22.4)))
+        specifier: 4.1.8
+        version: 4.1.8(vitest@4.1.8)
       drizzle-kit:
-        specifier: ^0.30.0
-        version: 0.30.6
+        specifier: ^0.31.10
+        version: 0.31.10
       tsx:
         specifier: ^4.19.0
         version: 4.22.4
@@ -214,8 +214,8 @@ importers:
         specifier: ^5.7.0
         version: 5.7.3
       vitest:
-        specifier: 4.1.1
-        version: 4.1.1(@types/node@22.19.15)(jsdom@29.1.1)(vite@6.4.3(@types/node@22.19.15)(jiti@1.21.7)(tsx@4.22.4))
+        specifier: 4.1.8
+        version: 4.1.8(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@1.21.7)(tsx@4.22.4))
 
   packages/shared:
     devDependencies:
@@ -226,17 +226,17 @@ importers:
         specifier: ^5.7.0
         version: 5.7.3
       vitest:
-        specifier: 4.1.1
-        version: 4.1.1(@types/node@22.19.15)(jsdom@29.1.1)(vite@6.4.3(@types/node@22.19.15)(jiti@1.21.7)(tsx@4.22.4))
+        specifier: 4.1.8
+        version: 4.1.8(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@1.21.7)(tsx@4.22.4))
 
   packages/ui:
     dependencies:
       '@langchain/core':
-        specifier: ^1.1.38
-        version: 1.1.48(openai@4.104.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)
+        specifier: ^1.1.49
+        version: 1.1.49(openai@6.42.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)
       '@langchain/langgraph':
-        specifier: ^1.2.6
-        version: 1.3.3(@langchain/core@1.1.48(openai@4.104.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3)
+        specifier: ^1.4.2
+        version: 1.4.2(@langchain/core@1.1.49(openai@6.42.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3)
       '@memex/guide-sdk':
         specifier: workspace:*
         version: link:../guide-sdk
@@ -272,7 +272,7 @@ importers:
         version: 0.0.30
       cmdk:
         specifier: 1.1.1
-        version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       d3-force:
         specifier: 3.0.0
         version: 3.0.0
@@ -286,14 +286,14 @@ importers:
         specifier: 19.2.7
         version: 19.2.7(react@19.2.7)
       react-markdown:
-        specifier: ^9.0.1
-        version: 9.1.0(@types/react@19.2.16)(react@19.2.7)
+        specifier: ^10.1.0
+        version: 10.1.0(@types/react@19.2.17)(react@19.2.7)
       react-resizable-panels:
         specifier: ^4.8.0
         version: 4.11.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react-router-dom:
-        specifier: ^7.1.0
-        version: 7.16.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        specifier: ^7.17.0
+        version: 7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       rehype-highlight:
         specifier: ^7.0.1
         version: 7.0.2
@@ -318,7 +318,7 @@ importers:
         version: 6.9.1
       '@testing-library/react':
         specifier: ^16.3.2
-        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@testing-library/user-event':
         specifier: ^14.6.1
         version: 14.6.1(@testing-library/dom@10.4.1)
@@ -326,17 +326,17 @@ importers:
         specifier: 3.0.10
         version: 3.0.10
       '@types/react':
-        specifier: ^19.0.0
-        version: 19.2.16
+        specifier: ^19.2.17
+        version: 19.2.17
       '@types/react-dom':
         specifier: ^19.0.0
-        version: 19.2.3(@types/react@19.2.16)
+        version: 19.2.3(@types/react@19.2.17)
       '@vitejs/plugin-react':
-        specifier: ^4.3.4
-        version: 4.7.0(vite@6.4.3(@types/node@22.19.15)(jiti@1.21.7)(tsx@4.22.4))
+        specifier: ^6.0.2
+        version: 6.0.2(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@1.21.7)(tsx@4.22.4))
       '@vitest/coverage-v8':
-        specifier: 4.1.1
-        version: 4.1.1(vitest@4.1.1(@types/node@22.19.15)(jsdom@29.1.1)(vite@6.4.3(@types/node@22.19.15)(jiti@1.21.7)(tsx@4.22.4)))
+        specifier: 4.1.8
+        version: 4.1.8(vitest@4.1.8)
       autoprefixer:
         specifier: ^10.4.20
         version: 10.5.0(postcss@8.5.15)
@@ -353,11 +353,11 @@ importers:
         specifier: ~5.7.2
         version: 5.7.3
       vite:
-        specifier: ^6.0.5
-        version: 6.4.3(@types/node@22.19.15)(jiti@1.21.7)(tsx@4.22.4)
+        specifier: ^8.0.16
+        version: 8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@1.21.7)(tsx@4.22.4)
       vitest:
-        specifier: 4.1.1
-        version: 4.1.1(@types/node@22.19.15)(jsdom@29.1.1)(vite@6.4.3(@types/node@22.19.15)(jiti@1.21.7)(tsx@4.22.4))
+        specifier: 4.1.8
+        version: 4.1.8(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@1.21.7)(tsx@4.22.4))
 
 packages:
 
@@ -368,8 +368,8 @@ packages:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
 
-  '@anthropic-ai/sdk@0.80.0':
-    resolution: {integrity: sha512-WeXLn7zNVk3yjeshn+xZHvld6AoFUOR3Sep6pSoHho5YbSi6HwcirqgPA5ccFuW8QTVJAAU7N8uQQC6Wa9TG+g==}
+  '@anthropic-ai/sdk@0.104.1':
+    resolution: {integrity: sha512-gGACa/+IaiXzRRmF96aOhamoBgapKRBiFWbmmTFP8aMkpaEcuStF+Q61bjo4vPxBM7gqWJNZqsngslRdnLHv0Q==}
     hasBin: true
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
@@ -493,40 +493,6 @@ packages:
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/compat-data@7.29.7':
-    resolution: {integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/core@7.29.7':
-    resolution: {integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/generator@7.29.7':
-    resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-compilation-targets@7.29.7':
-    resolution: {integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-globals@7.29.7':
-    resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-module-imports@7.29.7':
-    resolution: {integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-module-transforms@7.29.7':
-    resolution: {integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-
-  '@babel/helper-plugin-utils@7.29.7':
-    resolution: {integrity: sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-string-parser@7.29.7':
     resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
     engines: {node: '>=6.9.0'}
@@ -535,41 +501,13 @@ packages:
     resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-validator-option@7.29.7':
-    resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helpers@7.29.7':
-    resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/parser@7.29.7':
     resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  '@babel/plugin-transform-react-jsx-self@7.29.7':
-    resolution: {integrity: sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-react-jsx-source@7.29.7':
-    resolution: {integrity: sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
   '@babel/runtime@7.29.7':
     resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/template@7.29.7':
-    resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/traverse@7.29.7':
-    resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.7':
@@ -626,6 +564,15 @@ packages:
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
 
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
+
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
   '@esbuild-kit/core-utils@3.3.2':
     resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
     deprecated: 'Merged into tsx: https://tsx.is'
@@ -633,12 +580,6 @@ packages:
   '@esbuild-kit/esm-loader@2.6.5':
     resolution: {integrity: sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==}
     deprecated: 'Merged into tsx: https://tsx.is'
-
-  '@esbuild/aix-ppc64@0.19.12':
-    resolution: {integrity: sha512-bmoCYyWdEL3wDQIVbcyzRyeKLgk2WtWLTWz1ZIAZF/EGbNOwSA6ew3PftJ1PqMiOOGu0OyFMzG53L0zqIpPeNA==}
-    engines: {node: '>=12'}
-    cpu: [ppc64]
-    os: [aix]
 
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
@@ -660,12 +601,6 @@ packages:
 
   '@esbuild/android-arm64@0.18.20':
     resolution: {integrity: sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [android]
-
-  '@esbuild/android-arm64@0.19.12':
-    resolution: {integrity: sha512-P0UVNGIienjZv3f5zq0DP3Nt2IE/3plFzuaS96vihvD0Hd6H/q4WXUGpCxD/E8YrSXfNyRPbpTq+T8ZQioSuPA==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [android]
@@ -694,12 +629,6 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-arm@0.19.12':
-    resolution: {integrity: sha512-qg/Lj1mu3CdQlDEEiWrlC4eaPZ1KztwGJ9B6J+/6G+/4ewxJg7gqj8eVYWvao1bXrqGiW2rsBZFSX3q2lcW05w==}
-    engines: {node: '>=12'}
-    cpu: [arm]
-    os: [android]
-
   '@esbuild/android-arm@0.25.12':
     resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
     engines: {node: '>=18'}
@@ -720,12 +649,6 @@ packages:
 
   '@esbuild/android-x64@0.18.20':
     resolution: {integrity: sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [android]
-
-  '@esbuild/android-x64@0.19.12':
-    resolution: {integrity: sha512-3k7ZoUW6Q6YqhdhIaq/WZ7HwBpnFBlW905Fa4s4qWJyiNOgT1dOqDiVAQFwBH7gBRZr17gLrlFCRzF6jFh7Kew==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [android]
@@ -754,12 +677,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-arm64@0.19.12':
-    resolution: {integrity: sha512-B6IeSgZgtEzGC42jsI+YYu9Z3HKRxp8ZT3cqhvliEHovq8HSX2YX8lNocDn79gCKJXOSaEot9MVYky7AKjCs8g==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [darwin]
-
   '@esbuild/darwin-arm64@0.25.12':
     resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
     engines: {node: '>=18'}
@@ -780,12 +697,6 @@ packages:
 
   '@esbuild/darwin-x64@0.18.20':
     resolution: {integrity: sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@esbuild/darwin-x64@0.19.12':
-    resolution: {integrity: sha512-hKoVkKzFiToTgn+41qGhsUJXFlIjxI/jSYeZf3ugemDYZldIXIxhvwN6erJGlX4t5h417iFuheZ7l+YVn05N3A==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [darwin]
@@ -814,12 +725,6 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-arm64@0.19.12':
-    resolution: {integrity: sha512-4aRvFIXmwAcDBw9AueDQ2YnGmz5L6obe5kmPT8Vd+/+x/JMVKCgdcRwH6APrbpNXsPz+K653Qg8HB/oXvXVukA==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [freebsd]
-
   '@esbuild/freebsd-arm64@0.25.12':
     resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
     engines: {node: '>=18'}
@@ -840,12 +745,6 @@ packages:
 
   '@esbuild/freebsd-x64@0.18.20':
     resolution: {integrity: sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-x64@0.19.12':
-    resolution: {integrity: sha512-EYoXZ4d8xtBoVN7CEwWY2IN4ho76xjYXqSXMNccFSx2lgqOG/1TBPW0yPx1bJZk94qu3tX0fycJeeQsKovA8gg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [freebsd]
@@ -874,12 +773,6 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm64@0.19.12':
-    resolution: {integrity: sha512-EoTjyYyLuVPfdPLsGVVVC8a0p1BFFvtpQDB/YLEhaXyf/5bczaGeN15QkR+O4S5LeJ92Tqotve7i1jn35qwvdA==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [linux]
-
   '@esbuild/linux-arm64@0.25.12':
     resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
     engines: {node: '>=18'}
@@ -900,12 +793,6 @@ packages:
 
   '@esbuild/linux-arm@0.18.20':
     resolution: {integrity: sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==}
-    engines: {node: '>=12'}
-    cpu: [arm]
-    os: [linux]
-
-  '@esbuild/linux-arm@0.19.12':
-    resolution: {integrity: sha512-J5jPms//KhSNv+LO1S1TX1UWp1ucM6N6XuL6ITdKWElCu8wXP72l9MM0zDTzzeikVyqFE6U8YAV9/tFyj0ti+w==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [linux]
@@ -934,12 +821,6 @@ packages:
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.19.12':
-    resolution: {integrity: sha512-Thsa42rrP1+UIGaWz47uydHSBOgTUnwBwNq59khgIwktK6x60Hivfbux9iNR0eHCHzOLjLMLfUMLCypBkZXMHA==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [linux]
-
   '@esbuild/linux-ia32@0.25.12':
     resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
     engines: {node: '>=18'}
@@ -960,12 +841,6 @@ packages:
 
   '@esbuild/linux-loong64@0.18.20':
     resolution: {integrity: sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==}
-    engines: {node: '>=12'}
-    cpu: [loong64]
-    os: [linux]
-
-  '@esbuild/linux-loong64@0.19.12':
-    resolution: {integrity: sha512-LiXdXA0s3IqRRjm6rV6XaWATScKAXjI4R4LoDlvO7+yQqFdlr1Bax62sRwkVvRIrwXxvtYEHHI4dm50jAXkuAA==}
     engines: {node: '>=12'}
     cpu: [loong64]
     os: [linux]
@@ -994,12 +869,6 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.19.12':
-    resolution: {integrity: sha512-fEnAuj5VGTanfJ07ff0gOA6IPsvrVHLVb6Lyd1g2/ed67oU1eFzL0r9WL7ZzscD+/N6i3dWumGE1Un4f7Amf+w==}
-    engines: {node: '>=12'}
-    cpu: [mips64el]
-    os: [linux]
-
   '@esbuild/linux-mips64el@0.25.12':
     resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
     engines: {node: '>=18'}
@@ -1020,12 +889,6 @@ packages:
 
   '@esbuild/linux-ppc64@0.18.20':
     resolution: {integrity: sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==}
-    engines: {node: '>=12'}
-    cpu: [ppc64]
-    os: [linux]
-
-  '@esbuild/linux-ppc64@0.19.12':
-    resolution: {integrity: sha512-nYJA2/QPimDQOh1rKWedNOe3Gfc8PabU7HT3iXWtNUbRzXS9+vgB0Fjaqr//XNbd82mCxHzik2qotuI89cfixg==}
     engines: {node: '>=12'}
     cpu: [ppc64]
     os: [linux]
@@ -1054,12 +917,6 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.19.12':
-    resolution: {integrity: sha512-2MueBrlPQCw5dVJJpQdUYgeqIzDQgw3QtiAHUC4RBz9FXPrskyyU3VI1hw7C0BSKB9OduwSJ79FTCqtGMWqJHg==}
-    engines: {node: '>=12'}
-    cpu: [riscv64]
-    os: [linux]
-
   '@esbuild/linux-riscv64@0.25.12':
     resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
     engines: {node: '>=18'}
@@ -1084,12 +941,6 @@ packages:
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.19.12':
-    resolution: {integrity: sha512-+Pil1Nv3Umes4m3AZKqA2anfhJiVmNCYkPchwFJNEJN5QxmTs1uzyy4TvmDrCRNT2ApwSari7ZIgrPeUx4UZDg==}
-    engines: {node: '>=12'}
-    cpu: [s390x]
-    os: [linux]
-
   '@esbuild/linux-s390x@0.25.12':
     resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
     engines: {node: '>=18'}
@@ -1110,12 +961,6 @@ packages:
 
   '@esbuild/linux-x64@0.18.20':
     resolution: {integrity: sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [linux]
-
-  '@esbuild/linux-x64@0.19.12':
-    resolution: {integrity: sha512-B71g1QpxfwBvNrfyJdVDexenDIt1CiDN1TIXLbhOw0KhJzE78KIFGX6OJ9MrtC0oOqMWf+0xop4qEU8JrJTwCg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [linux]
@@ -1162,12 +1007,6 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.19.12':
-    resolution: {integrity: sha512-3ltjQ7n1owJgFbuC61Oj++XhtzmymoCihNFgT84UAmJnxJfm4sYCiSLTXZtE00VWYpPMYc+ZQmB6xbSdVh0JWA==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [netbsd]
-
   '@esbuild/netbsd-x64@0.25.12':
     resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
     engines: {node: '>=18'}
@@ -1206,12 +1045,6 @@ packages:
 
   '@esbuild/openbsd-x64@0.18.20':
     resolution: {integrity: sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [openbsd]
-
-  '@esbuild/openbsd-x64@0.19.12':
-    resolution: {integrity: sha512-RbrfTB9SWsr0kWmb9srfF+L933uMDdu9BIzdA7os2t0TXhCRjrQyCeOt6wVxr79CKD4c+p+YhCj31HBkYcXebw==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [openbsd]
@@ -1258,12 +1091,6 @@ packages:
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/sunos-x64@0.19.12':
-    resolution: {integrity: sha512-HKjJwRrW8uWtCQnQOz9qcU3mUZhTUQvi56Q8DPTLLB+DawoiQdjsYq+j+D3s9I8VFtDr+F9CjgXKKC4ss89IeA==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [sunos]
-
   '@esbuild/sunos-x64@0.25.12':
     resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
     engines: {node: '>=18'}
@@ -1284,12 +1111,6 @@ packages:
 
   '@esbuild/win32-arm64@0.18.20':
     resolution: {integrity: sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@esbuild/win32-arm64@0.19.12':
-    resolution: {integrity: sha512-URgtR1dJnmGvX864pn1B2YUYNzjmXkuJOIqG2HdU62MVS4EHpU2946OZoTMnRUHklGtJdJZ33QfzdjGACXhn1A==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [win32]
@@ -1318,12 +1139,6 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.19.12':
-    resolution: {integrity: sha512-+ZOE6pUkMOJfmxmBZElNOx72NKpIa/HFOMGzu8fqzQJ5kgf6aTGrcJaFsNiVMH4JKpMipyK+7k0n2UXN7a8YKQ==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [win32]
-
   '@esbuild/win32-ia32@0.25.12':
     resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
     engines: {node: '>=18'}
@@ -1344,12 +1159,6 @@ packages:
 
   '@esbuild/win32-x64@0.18.20':
     resolution: {integrity: sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [win32]
-
-  '@esbuild/win32-x64@0.19.12':
-    resolution: {integrity: sha512-T1QyPSDCyMXaO3pzBkF96E8xMkiRYbUEZADd29SyPGabqxMViNoii+NcK7eWJAEoU6RZyEm5lVSIjTmcdoB9HA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [win32]
@@ -1381,8 +1190,8 @@ packages:
       '@noble/hashes':
         optional: true
 
-  '@google-cloud/kms@5.5.0':
-    resolution: {integrity: sha512-feaZLZ0G64gxejaemMUSliBkbzEicgXP+AFxt8DRUjRBTbP8qpHlZcGQxC+J+YF1pg0sTcV+WNy2syGW23irpA==}
+  '@google-cloud/kms@5.5.1':
+    resolution: {integrity: sha512-7O3mnspIlotzToIsSrv+YfnGhGdncOyZmjI0gG/r+jcsYN0t8WCa8v9YGuZ0F1VRa+49p/hUT/6ZQh9/s79PfA==}
     engines: {node: '>=18'}
 
   '@grpc/grpc-js@1.14.4':
@@ -1414,9 +1223,6 @@ packages:
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
-  '@jridgewell/remapping@2.3.5':
-    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
-
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
     engines: {node: '>=6.0.0'}
@@ -1430,20 +1236,20 @@ packages:
   '@js-sdsl/ordered-map@4.4.2':
     resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
 
-  '@langchain/core@1.1.48':
-    resolution: {integrity: sha512-fQU6Guyb1pwc2fEplmA8FPbKfOMAofjnyJzExevro0FxEiuGHE18Ov/ZHmT9trWCDTZRI9eW1VIc6aChxV8pAQ==}
+  '@langchain/core@1.1.49':
+    resolution: {integrity: sha512-7wkN3Qv/qZqsY0p3h48CNu6E6y5GMYatYxj+JrX4uVNBiqIVQm1Z528QrmayJWVW9SQTQicqRNoyTCzl+K9F8Q==}
     engines: {node: '>=20'}
 
-  '@langchain/langgraph-checkpoint@1.0.4':
-    resolution: {integrity: sha512-1y5MgZ0gXXrtmoy56e3kaBChI3GwFPIKl27xkrHwN+VE/3iUsyr9gO3Jtp7kdKAe6diZGbcas5bdC/r0yUwTZA==}
+  '@langchain/langgraph-checkpoint@1.1.1':
+    resolution: {integrity: sha512-gHqhO6e2dyZ7TTfyaFy25yjcRsavURc9XMGT4q+LUBTc0hT4JxKe3qvrMX2OFTzW8W/0kjV59haHmSRFZIGkvg==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@langchain/core': ^1.1.44
+      '@langchain/core': ^1.1.48
 
-  '@langchain/langgraph-sdk@1.9.11':
-    resolution: {integrity: sha512-mhadkZy4LQ97NJwvATiVIkSxVfOnauXNhrVHFgGnzyqr5zzPLS0VIKJW9xKT+pM8yLqW8Qj6+nPPNhwGUaxoRw==}
+  '@langchain/langgraph-sdk@1.9.22':
+    resolution: {integrity: sha512-DBKs9R2SGivlGqK/ZRTOUu39Q7Z+yRrG4PoTYLIWn7pqrLNhyZ4yZI/tEEEi/J0inpCuKfg/eydSwnRmPV/q3w==}
     peerDependencies:
-      '@langchain/core': ^1.1.44
+      '@langchain/core': ^1.1.48
       react: 19.2.7
       react-dom: 19.2.7
       svelte: ^4.0.0 || ^5.0.0
@@ -1458,11 +1264,11 @@ packages:
       vue:
         optional: true
 
-  '@langchain/langgraph@1.3.3':
-    resolution: {integrity: sha512-8xbpGUQNBcWua7ivT5vUvDnQ+6Qbt0JO8RisgXZ8guPXNqh8plGVvrODW68S4AlJbOYY2yi0ROKtrL/1yN3MBQ==}
+  '@langchain/langgraph@1.4.2':
+    resolution: {integrity: sha512-ivhYwbEKW4i/x2JfHcrTrToEE9EXZnwr4dPj7GC5974xEYeLgHYzii3GAYo1kgU5A0ZAd7rIxTpMOfcbycxliQ==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@langchain/core': ^1.1.44
+      '@langchain/core': ^1.1.48
       zod: ^3.25.32 || ^4.2.0
       zod-to-json-schema: ^3.x
     peerDependenciesMeta:
@@ -1481,6 +1287,12 @@ packages:
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
+
+  '@napi-rs/wasm-runtime@1.1.5':
+    resolution: {integrity: sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
 
   '@nivo/annotations@0.99.0':
     resolution: {integrity: sha512-jCuuXPbvpaqaz4xF7k5dv0OT2ubn5Nt0gWryuTe/8oVsC/9bzSuK8bM9vBty60m9tfO+X8vUYliuaCDwGksC2g==}
@@ -1577,6 +1389,9 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@oxc-project/types@0.133.0':
+    resolution: {integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==}
 
   '@petamoriken/float16@3.9.3':
     resolution: {integrity: sha512-8awtpHXCx/bNpFt4mt2xdkgtgVvKqty8VbjHI/WWWQuEw+KLzFot3f4+LkQY9YmOtq7A5GdOnqoIC8Pdygjk2g==}
@@ -1852,8 +1667,103 @@ packages:
   '@ricky0123/vad-web@0.0.30':
     resolution: {integrity: sha512-cJyYrh4YeeUBJcbR9Bic/bFDyB9qBkAepvpuWM3vLxnAi7bC3VHzf51UeNdT+OtY4D7MLAgV8iJMc4z41ZnaWg==}
 
-  '@rolldown/pluginutils@1.0.0-beta.27':
-    resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
+  '@rolldown/binding-android-arm64@1.0.3':
+    resolution: {integrity: sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.3':
+    resolution: {integrity: sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.3':
+    resolution: {integrity: sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.3':
+    resolution: {integrity: sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.3':
+    resolution: {integrity: sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.3':
+    resolution: {integrity: sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.3':
+    resolution: {integrity: sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.3':
+    resolution: {integrity: sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.3':
+    resolution: {integrity: sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.3':
+    resolution: {integrity: sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-musl@1.0.3':
+    resolution: {integrity: sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-openharmony-arm64@1.0.3':
+    resolution: {integrity: sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.3':
+    resolution: {integrity: sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.3':
+    resolution: {integrity: sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.3':
+    resolution: {integrity: sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
   '@rollup/rollup-android-arm-eabi@4.61.0':
     resolution: {integrity: sha512-dnxczajOqt0gesZlN5pGQ1s1imQVrsmCw5G2Ci4oM+0WvNz3pyRnlWrT7McoZIb8VlFwCawdmbWRmxRn7HI+VQ==}
@@ -2001,8 +1911,8 @@ packages:
     resolution: {integrity: sha512-I8vmSjNYWsaxuWPx6dz4yeh0h7vRBWbgAMK14LEmblbZ404BtrPbXs6jDPx4cYgGf8msDGF4A9opLZBu21FViQ==}
     engines: {node: '>= 12.13.0', npm: '>= 6.12.0'}
 
-  '@slack/web-api@7.16.0':
-    resolution: {integrity: sha512-68SAV77uuGKuhyyaRytX8UijVnqSLsTSKslGXw17cjQYXn+jtNl7gbaEjHgC5x2rhCuFdahBrEC2VCLppbzReg==}
+  '@slack/web-api@7.17.0':
+    resolution: {integrity: sha512-jejr34a8B4L5AS713wOAx1LAqNkW16HVMDEa6sYBvFDc/llUBl8hXaiI4BwF+Al+Sug19Vn2O7iokTVIhVvZ1Q==}
     engines: {node: '>= 18', npm: '>= 8.6.0'}
 
   '@smithy/core@3.24.6':
@@ -2045,6 +1955,9 @@ packages:
     resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
     engines: {node: '>=14.0.0'}
 
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -2077,20 +1990,11 @@ packages:
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
 
+  '@tybys/wasm-util@0.10.2':
+    resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
+
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
-
-  '@types/babel__core@7.20.5':
-    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
-
-  '@types/babel__generator@7.27.0':
-    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
-
-  '@types/babel__template@7.4.4':
-    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
-
-  '@types/babel__traverse@7.28.0':
-    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
@@ -2161,19 +2065,16 @@ packages:
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
-  '@types/node-fetch@2.6.13':
-    resolution: {integrity: sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==}
-
-  '@types/node@22.19.15':
-    resolution: {integrity: sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==}
+  '@types/node@25.9.3':
+    resolution: {integrity: sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==}
 
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
       '@types/react': ^19.2.0
 
-  '@types/react@19.2.16':
-    resolution: {integrity: sha512-esJiCAnl0kfpNdE69f3So4WJUXy95dLZydX0KwK46riIHDzHM7O9Vtf9xCHW0PXIqvgqNrswl522kA/5yx+F4w==}
+  '@types/react@19.2.17':
+    resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
 
   '@types/retry@0.12.0':
     resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
@@ -2190,26 +2091,33 @@ packages:
   '@ungap/structured-clone@1.3.1':
     resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
 
-  '@vitejs/plugin-react@4.7.0':
-    resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
-    engines: {node: ^14.18.0 || >=16.0.0}
+  '@vitejs/plugin-react@6.0.2':
+    resolution: {integrity: sha512-DlSMqo4WhThw4vB8Mpn0Woe9J+Jfq1geJ61AKW0QEgLzGMNwtIMdxbDUzLxcun8W7NbJO0e2Jg/Nxm3cCSVzzg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
-      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+      '@rolldown/plugin-babel': ^0.1.7 || ^0.2.0
+      babel-plugin-react-compiler: ^1.0.0
+      vite: ^8.0.0
+    peerDependenciesMeta:
+      '@rolldown/plugin-babel':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
 
-  '@vitest/coverage-v8@4.1.1':
-    resolution: {integrity: sha512-nZ4RWwGCoGOQRMmU/Q9wlUY540RVRxJZ9lxFsFfy0QV7Zmo5VVBhB6Sl9Xa0KIp2iIs3zWfPlo9LcY1iqbpzCw==}
+  '@vitest/coverage-v8@4.1.8':
+    resolution: {integrity: sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw==}
     peerDependencies:
-      '@vitest/browser': 4.1.1
-      vitest: 4.1.1
+      '@vitest/browser': 4.1.8
+      vitest: 4.1.8
     peerDependenciesMeta:
       '@vitest/browser':
         optional: true
 
-  '@vitest/expect@4.1.1':
-    resolution: {integrity: sha512-xAV0fqBTk44Rn6SjJReEQkHP3RrqbJo6JQ4zZ7/uVOiJZRarBtblzrOfFIZeYUrukp2YD6snZG6IBqhOoHTm+A==}
+  '@vitest/expect@4.1.8':
+    resolution: {integrity: sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==}
 
-  '@vitest/mocker@4.1.1':
-    resolution: {integrity: sha512-h3BOylsfsCLPeceuCPAAJ+BvNwSENgJa4hXoXu4im0bs9Lyp4URc4JYK4pWLZ4pG/UQn7AT92K6IByi6rE6g3A==}
+  '@vitest/mocker@4.1.8':
+    resolution: {integrity: sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -2219,20 +2127,20 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@4.1.1':
-    resolution: {integrity: sha512-GM+TEQN5WhOygr1lp7skeVjdLPqqWMHsfzXrcHAqZJi/lIVh63H0kaRCY8MDhNWikx19zBUK8ceaLB7X5AH9NQ==}
+  '@vitest/pretty-format@4.1.8':
+    resolution: {integrity: sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==}
 
-  '@vitest/runner@4.1.1':
-    resolution: {integrity: sha512-f7+FPy75vN91QGWsITueq0gedwUZy1fLtHOCMeQpjs8jTekAHeKP80zfDEnhrleviLHzVSDXIWuCIOFn3D3f8A==}
+  '@vitest/runner@4.1.8':
+    resolution: {integrity: sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==}
 
-  '@vitest/snapshot@4.1.1':
-    resolution: {integrity: sha512-kMVSgcegWV2FibXEx9p9WIKgje58lcTbXgnJixfcg15iK8nzCXhmalL0ZLtTWLW9PH1+1NEDShiFFedB3tEgWg==}
+  '@vitest/snapshot@4.1.8':
+    resolution: {integrity: sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==}
 
-  '@vitest/spy@4.1.1':
-    resolution: {integrity: sha512-6Ti/KT5OVaiupdIZEuZN7l3CZcR0cxnxt70Z0//3CtwgObwA6jZhmVBA3yrXSVN3gmwjgd7oDNLlsXz526gpRA==}
+  '@vitest/spy@4.1.8':
+    resolution: {integrity: sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==}
 
-  '@vitest/utils@4.1.1':
-    resolution: {integrity: sha512-cNxAlaB3sHoCdL6pj6yyUXv9Gry1NHNg0kFTXdvSIZXLHsqKH7chiWOkwJ5s5+d/oMwcoG9T0bKU38JZWKusrQ==}
+  '@vitest/utils@4.1.8':
+    resolution: {integrity: sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==}
 
   '@webgpu/types@0.1.70':
     resolution: {integrity: sha512-LFiNHHKMvmAEvwVew3JLJmTdShhbdwRFSImUshGhE2mGE8ybQzIo63l5uRp+YKnNx+8Qno8Kf6gN+DKMreIJCA==}
@@ -2261,10 +2169,6 @@ packages:
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
-
-  agentkeepalive@4.6.0:
-    resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
-    engines: {node: '>= 8.0.0'}
 
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
@@ -2644,6 +2548,10 @@ packages:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
 
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
 
@@ -2666,12 +2574,12 @@ packages:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
     engines: {node: '>=12'}
 
-  drizzle-kit@0.30.6:
-    resolution: {integrity: sha512-U4wWit0fyZuGuP7iNmRleQyK2V8wCuv57vf5l3MnG4z4fzNTjY/U13M8owyQ5RavqvqxBifWORaR3wIUzlN64g==}
+  drizzle-kit@0.31.10:
+    resolution: {integrity: sha512-7OZcmQUrdGI+DUNNsKBn1aW8qSoKuTH7d0mYgSP8bAzdFzKoovxEFnoGQp2dVs82EOJeYycqRtciopszwUf8bw==}
     hasBin: true
 
-  drizzle-orm@0.39.3:
-    resolution: {integrity: sha512-EZ8ZpYvDIvKU9C56JYLOmUskazhad+uXZCTCRN4OnRMsL+xAJ05dv1eCpAG5xzhsm1hqiuC5kAZUCS924u2DTw==}
+  drizzle-orm@0.45.2:
+    resolution: {integrity: sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q==}
     peerDependencies:
       '@aws-sdk/client-rds-data': '>=3'
       '@cloudflare/workers-types': '>=4'
@@ -2681,17 +2589,19 @@ packages:
       '@neondatabase/serverless': '>=0.10.0'
       '@op-engineering/op-sqlite': '>=2'
       '@opentelemetry/api': ^1.4.1
-      '@planetscale/database': '>=1'
+      '@planetscale/database': '>=1.13'
       '@prisma/client': '*'
       '@tidbcloud/serverless': '*'
       '@types/better-sqlite3': '*'
       '@types/pg': '*'
       '@types/sql.js': '*'
+      '@upstash/redis': '>=1.34.7'
       '@vercel/postgres': '>=0.8.0'
       '@xata.io/client': '*'
       better-sqlite3: '>=7'
       bun-types: '*'
       expo-sqlite: '>=14.0.0'
+      gel: '>=2'
       knex: '*'
       kysely: '*'
       mysql2: '>=2'
@@ -2729,6 +2639,8 @@ packages:
         optional: true
       '@types/sql.js':
         optional: true
+      '@upstash/redis':
+        optional: true
       '@vercel/postgres':
         optional: true
       '@xata.io/client':
@@ -2738,6 +2650,8 @@ packages:
       bun-types:
         optional: true
       expo-sqlite:
+        optional: true
+      gel:
         optional: true
       knex:
         optional: true
@@ -2822,18 +2736,8 @@ packages:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
 
-  esbuild-register@3.6.0:
-    resolution: {integrity: sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==}
-    peerDependencies:
-      esbuild: '>=0.12 <1'
-
   esbuild@0.18.20:
     resolution: {integrity: sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==}
-    engines: {node: '>=12'}
-    hasBin: true
-
-  esbuild@0.19.12:
-    resolution: {integrity: sha512-aARqgq8roFBj054KvQr5f1sFu0D65G+miZRCuJyJ0G13Zwx7vRar5Zhn2tkQNzIXcBrNVsv/8stehpj+GAjgbg==}
     engines: {node: '>=12'}
     hasBin: true
 
@@ -2919,6 +2823,9 @@ packages:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
 
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
+
   fast-uri@3.1.2:
     resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
@@ -2972,9 +2879,6 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
-  form-data-encoder@1.7.2:
-    resolution: {integrity: sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==}
-
   form-data-encoder@4.1.0:
     resolution: {integrity: sha512-G6NsmEW15s0Uw9XnCg+33H3ViYRyiM0hMrMhhqQOR8NFc5GhYrI+6I3u7OTw7b91J2g8rtvMBZJDbcGb2YUniw==}
     engines: {node: '>= 18'}
@@ -2982,10 +2886,6 @@ packages:
   form-data@4.0.5:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
-
-  formdata-node@4.4.1:
-    resolution: {integrity: sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==}
-    engines: {node: '>= 12.20'}
 
   formdata-node@6.0.3:
     resolution: {integrity: sha512-8e1++BCiTzUno9v5IZ2J6bv4RU+3UKDmqWUQD0MIMVCd9AdhWkO1gw57oo1mNEX1dMq2EGI+FbWz4B92pscSQg==}
@@ -3032,10 +2932,6 @@ packages:
     engines: {node: '>= 18.0.0'}
     hasBin: true
 
-  gensync@1.0.0-beta.2:
-    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
-    engines: {node: '>=6.9.0'}
-
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
@@ -3071,8 +2967,8 @@ packages:
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
-  google-auth-library@10.6.2:
-    resolution: {integrity: sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==}
+  google-auth-library@10.7.0:
+    resolution: {integrity: sha512-QpTAbNJ36TliZLx3TTtahR8HG0hN9RllL1e3FymOvQSIKK8JmgV58H924ub2wa2DsS3ANjjP1Aw1N+Ramc8hqQ==}
     engines: {node: '>=18'}
 
   google-gax@5.0.6:
@@ -3137,8 +3033,8 @@ packages:
     resolution: {integrity: sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==}
     engines: {node: '>=12.0.0'}
 
-  hono@4.12.23:
-    resolution: {integrity: sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==}
+  hono@4.12.25:
+    resolution: {integrity: sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==}
     engines: {node: '>=16.9.0'}
 
   html-encoding-sniffer@6.0.0:
@@ -3169,9 +3065,6 @@ packages:
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
-
-  humanize-ms@1.2.1:
-    resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
 
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
@@ -3319,11 +3212,6 @@ packages:
       canvas:
         optional: true
 
-  jsesc@3.1.0:
-    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
-    engines: {node: '>=6'}
-    hasBin: true
-
   json-bigint@1.0.0:
     resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
 
@@ -3336,11 +3224,6 @@ packages:
 
   json-schema-typed@8.0.2:
     resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
-
-  json5@2.2.3:
-    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
-    engines: {node: '>=6'}
-    hasBin: true
 
   jwa@2.0.1:
     resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
@@ -3367,6 +3250,80 @@ packages:
         optional: true
       ws:
         optional: true
+
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
 
   lilconfig@3.1.3:
     resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
@@ -3403,9 +3360,6 @@ packages:
   lru-cache@11.5.1:
     resolution: {integrity: sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==}
     engines: {node: 20 || >=22}
-
-  lru-cache@5.1.1:
-    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
@@ -3634,15 +3588,6 @@ packages:
     engines: {node: '>=10.5.0'}
     deprecated: Use your platform's native DOMException instead
 
-  node-fetch@2.7.0:
-    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
-    engines: {node: 4.x || >=6.0.0}
-    peerDependencies:
-      encoding: ^0.1.0
-    peerDependenciesMeta:
-      encoding:
-        optional: true
-
   node-fetch@3.3.2:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -3683,12 +3628,11 @@ packages:
   onnxruntime-web@1.26.0:
     resolution: {integrity: sha512-LbRr/8zZt2xilI2smrVQGGKINo0U46i8qJp+UXyMBGfqN7KjnH1BiwCwLwyNIVV4i9CKFv7Sf4PwLKWnT8/bEA==}
 
-  openai@4.104.0:
-    resolution: {integrity: sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==}
-    hasBin: true
+  openai@6.42.0:
+    resolution: {integrity: sha512-1WFEt/uXMXOLhYRNkgJWo08Y2YNvNwpVU72K7ibrWgWpNOXd4VojXLbe6SQ4bLiUQ3Y8jz4IiyVkylJCL1DtZg==}
     peerDependencies:
       ws: ^8.18.0
-      zod: ^3.23.8
+      zod: ^3.25 || ^4.0
     peerDependenciesMeta:
       ws:
         optional: true
@@ -3910,15 +3854,11 @@ packages:
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
-  react-markdown@9.1.0:
-    resolution: {integrity: sha512-xaijuJB0kzGiUdG7nc2MOMDUDBWPyGAjZtUrow9XxUeua8IqeP+VlIfAZ3bphpcLTnSZXz6z9jcVC/TCwbfgdw==}
+  react-markdown@10.1.0:
+    resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
     peerDependencies:
       '@types/react': '>=18'
       react: 19.2.7
-
-  react-refresh@0.17.0:
-    resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
-    engines: {node: '>=0.10.0'}
 
   react-remove-scroll-bar@2.3.8:
     resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
@@ -3946,15 +3886,15 @@ packages:
       react: 19.2.7
       react-dom: 19.2.7
 
-  react-router-dom@7.16.0:
-    resolution: {integrity: sha512-kMUAbimWB5FVbF4Bce4bJsiKJWLIUHq/mEG8+CFDnCSgltptBiG5nguducmsJeGKytlCvQud9Qhzpn49iduTlA==}
+  react-router-dom@7.17.0:
+    resolution: {integrity: sha512-fyU2yjGups/hE6Xz0I5ZYbVL8Gx29eCjgpHaRaTaVU+OOAdfRX05KsvyRm0GO8YQwOkhpU3MurW1jyMUJn+zSw==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: 19.2.7
       react-dom: 19.2.7
 
-  react-router@7.16.0:
-    resolution: {integrity: sha512-wArC8lVyJb3+jM9OpDyW6hLCizACWkvQR/sSGqSs+o5uEXEtGlqdZ4v8hENR3Jad6i+LRkK93q/+bQAcvl6V1A==}
+  react-router@7.17.0:
+    resolution: {integrity: sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: 19.2.7
@@ -4066,6 +4006,11 @@ packages:
   robust-predicates@3.0.3:
     resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
 
+  rolldown@1.0.3:
+    resolution: {integrity: sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   rollup@4.61.0:
     resolution: {integrity: sha512-T9mWdbWfQtp0B5lv/HX+wrhYsmXRlcWnXXmJbXqKJhlRaoS6KMhq0gpyzW4UJfclcxrEdLnTgjT2NjruLONu0g==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -4090,10 +4035,6 @@ packages:
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
-
-  semver@6.3.1:
-    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
-    hasBin: true
 
   semver@7.8.1:
     resolution: {integrity: sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==}
@@ -4169,6 +4110,9 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
 
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
@@ -4294,9 +4238,6 @@ packages:
     resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
     engines: {node: '>=16'}
 
-  tr46@0.0.3:
-    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
-
   tr46@6.0.0:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
     engines: {node: '>=20'}
@@ -4359,8 +4300,8 @@ packages:
   ufo@1.6.4:
     resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
 
-  undici-types@6.21.0:
-    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+  undici-types@7.24.6:
+    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
   undici@7.27.0:
     resolution: {integrity: sha512-+t2Z/GwkZQDtu00813aP66ygViGtPHKhhoFZpQKpKrE+9jIgES+Zw+mFNaDWOVRKiuJjuqKHzD3B1sfGg8+ZOQ==}
@@ -4426,10 +4367,6 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
-  uuid@14.0.0:
-    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
-    hasBin: true
-
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
@@ -4443,30 +4380,33 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
-  vite@6.4.3:
-    resolution: {integrity: sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+  vite@8.0.16:
+    resolution: {integrity: sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
-      '@types/node': 22.19.15
+      '@types/node': 25.9.3
+      '@vitejs/devtools': ^0.1.18
+      esbuild: ^0.27.0 || ^0.28.0
       jiti: '>=1.21.0'
-      less: '*'
-      lightningcss: ^1.21.0
-      sass: '*'
-      sass-embedded: '*'
-      stylus: '*'
-      sugarss: '*'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
       terser: ^5.16.0
       tsx: ^4.8.1
       yaml: ^2.4.2
     peerDependenciesMeta:
       '@types/node':
         optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
       jiti:
         optional: true
       less:
-        optional: true
-      lightningcss:
         optional: true
       sass:
         optional: true
@@ -4483,18 +4423,20 @@ packages:
       yaml:
         optional: true
 
-  vitest@4.1.1:
-    resolution: {integrity: sha512-yF+o4POL41rpAzj5KVILUxm1GCjKnELvaqmU9TLLUbMfDzuN0UpUR9uaDs+mCtjPe+uYPksXDRLQGGPvj1cTmA==}
+  vitest@4.1.8:
+    resolution: {integrity: sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
-      '@types/node': 22.19.15
-      '@vitest/browser-playwright': 4.1.1
-      '@vitest/browser-preview': 4.1.1
-      '@vitest/browser-webdriverio': 4.1.1
-      '@vitest/ui': 4.1.1
+      '@types/node': 25.9.3
+      '@vitest/browser-playwright': 4.1.8
+      '@vitest/browser-preview': 4.1.8
+      '@vitest/browser-webdriverio': 4.1.8
+      '@vitest/coverage-istanbul': 4.1.8
+      '@vitest/coverage-v8': 4.1.8
+      '@vitest/ui': 4.1.8
       happy-dom: '*'
       jsdom: '*'
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -4510,6 +4452,10 @@ packages:
       '@vitest/browser-preview':
         optional: true
       '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
         optional: true
       '@vitest/ui':
         optional: true
@@ -4529,10 +4475,6 @@ packages:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
 
-  web-streams-polyfill@4.0.0-beta.3:
-    resolution: {integrity: sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==}
-    engines: {node: '>= 14'}
-
   web-tree-sitter@0.25.10:
     resolution: {integrity: sha512-Y09sF44/13XvgVKgO2cNDw5rGk6s26MgoZPXLESvMXeefBf7i6/73eFurre0IsTW6E14Y0ArIzhUMmjoc7xyzA==}
     peerDependencies:
@@ -4540,9 +4482,6 @@ packages:
     peerDependenciesMeta:
       '@types/emscripten':
         optional: true
-
-  webidl-conversions@3.0.1:
-    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
   webidl-conversions@8.0.1:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
@@ -4555,9 +4494,6 @@ packages:
   whatwg-url@16.0.1:
     resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
-
-  whatwg-url@5.0.0:
-    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -4612,9 +4548,6 @@ packages:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
 
-  yallist@3.1.1:
-    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
-
   yargs-parser@20.2.9:
     resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
     engines: {node: '>=10'}
@@ -4644,9 +4577,10 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
-  '@anthropic-ai/sdk@0.80.0(zod@4.4.3)':
+  '@anthropic-ai/sdk@0.104.1(zod@4.4.3)':
     dependencies:
       json-schema-to-ts: 3.1.1
+      standardwebhooks: 1.0.0
     optionalDependencies:
       zod: 4.4.3
 
@@ -4903,108 +4837,15 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
-  '@babel/compat-data@7.29.7': {}
-
-  '@babel/core@7.29.7':
-    dependencies:
-      '@babel/code-frame': 7.29.7
-      '@babel/generator': 7.29.7
-      '@babel/helper-compilation-targets': 7.29.7
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
-      '@babel/helpers': 7.29.7
-      '@babel/parser': 7.29.7
-      '@babel/template': 7.29.7
-      '@babel/traverse': 7.29.7
-      '@babel/types': 7.29.7
-      '@jridgewell/remapping': 2.3.5
-      convert-source-map: 2.0.0
-      debug: 4.4.3
-      gensync: 1.0.0-beta.2
-      json5: 2.2.3
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/generator@7.29.7':
-    dependencies:
-      '@babel/parser': 7.29.7
-      '@babel/types': 7.29.7
-      '@jridgewell/gen-mapping': 0.3.13
-      '@jridgewell/trace-mapping': 0.3.31
-      jsesc: 3.1.0
-
-  '@babel/helper-compilation-targets@7.29.7':
-    dependencies:
-      '@babel/compat-data': 7.29.7
-      '@babel/helper-validator-option': 7.29.7
-      browserslist: 4.28.2
-      lru-cache: 5.1.1
-      semver: 6.3.1
-
-  '@babel/helper-globals@7.29.7': {}
-
-  '@babel/helper-module-imports@7.29.7':
-    dependencies:
-      '@babel/traverse': 7.29.7
-      '@babel/types': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
-    dependencies:
-      '@babel/core': 7.29.7
-      '@babel/helper-module-imports': 7.29.7
-      '@babel/helper-validator-identifier': 7.29.7
-      '@babel/traverse': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/helper-plugin-utils@7.29.7': {}
-
   '@babel/helper-string-parser@7.29.7': {}
 
   '@babel/helper-validator-identifier@7.29.7': {}
-
-  '@babel/helper-validator-option@7.29.7': {}
-
-  '@babel/helpers@7.29.7':
-    dependencies:
-      '@babel/template': 7.29.7
-      '@babel/types': 7.29.7
 
   '@babel/parser@7.29.7':
     dependencies:
       '@babel/types': 7.29.7
 
-  '@babel/plugin-transform-react-jsx-self@7.29.7(@babel/core@7.29.7)':
-    dependencies:
-      '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-transform-react-jsx-source@7.29.7(@babel/core@7.29.7)':
-    dependencies:
-      '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-
   '@babel/runtime@7.29.7': {}
-
-  '@babel/template@7.29.7':
-    dependencies:
-      '@babel/code-frame': 7.29.7
-      '@babel/parser': 7.29.7
-      '@babel/types': 7.29.7
-
-  '@babel/traverse@7.29.7':
-    dependencies:
-      '@babel/code-frame': 7.29.7
-      '@babel/generator': 7.29.7
-      '@babel/helper-globals': 7.29.7
-      '@babel/parser': 7.29.7
-      '@babel/template': 7.29.7
-      '@babel/types': 7.29.7
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/types@7.29.7':
     dependencies:
@@ -5045,6 +4886,22 @@ snapshots:
 
   '@drizzle-team/brocli@0.10.2': {}
 
+  '@emnapi/core@1.10.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@esbuild-kit/core-utils@3.3.2':
     dependencies:
       esbuild: 0.18.20
@@ -5054,9 +4911,6 @@ snapshots:
     dependencies:
       '@esbuild-kit/core-utils': 3.3.2
       get-tsconfig: 4.14.0
-
-  '@esbuild/aix-ppc64@0.19.12':
-    optional: true
 
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
@@ -5068,9 +4922,6 @@ snapshots:
     optional: true
 
   '@esbuild/android-arm64@0.18.20':
-    optional: true
-
-  '@esbuild/android-arm64@0.19.12':
     optional: true
 
   '@esbuild/android-arm64@0.25.12':
@@ -5085,9 +4936,6 @@ snapshots:
   '@esbuild/android-arm@0.18.20':
     optional: true
 
-  '@esbuild/android-arm@0.19.12':
-    optional: true
-
   '@esbuild/android-arm@0.25.12':
     optional: true
 
@@ -5098,9 +4946,6 @@ snapshots:
     optional: true
 
   '@esbuild/android-x64@0.18.20':
-    optional: true
-
-  '@esbuild/android-x64@0.19.12':
     optional: true
 
   '@esbuild/android-x64@0.25.12':
@@ -5115,9 +4960,6 @@ snapshots:
   '@esbuild/darwin-arm64@0.18.20':
     optional: true
 
-  '@esbuild/darwin-arm64@0.19.12':
-    optional: true
-
   '@esbuild/darwin-arm64@0.25.12':
     optional: true
 
@@ -5128,9 +4970,6 @@ snapshots:
     optional: true
 
   '@esbuild/darwin-x64@0.18.20':
-    optional: true
-
-  '@esbuild/darwin-x64@0.19.12':
     optional: true
 
   '@esbuild/darwin-x64@0.25.12':
@@ -5145,9 +4984,6 @@ snapshots:
   '@esbuild/freebsd-arm64@0.18.20':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.19.12':
-    optional: true
-
   '@esbuild/freebsd-arm64@0.25.12':
     optional: true
 
@@ -5158,9 +4994,6 @@ snapshots:
     optional: true
 
   '@esbuild/freebsd-x64@0.18.20':
-    optional: true
-
-  '@esbuild/freebsd-x64@0.19.12':
     optional: true
 
   '@esbuild/freebsd-x64@0.25.12':
@@ -5175,9 +5008,6 @@ snapshots:
   '@esbuild/linux-arm64@0.18.20':
     optional: true
 
-  '@esbuild/linux-arm64@0.19.12':
-    optional: true
-
   '@esbuild/linux-arm64@0.25.12':
     optional: true
 
@@ -5188,9 +5018,6 @@ snapshots:
     optional: true
 
   '@esbuild/linux-arm@0.18.20':
-    optional: true
-
-  '@esbuild/linux-arm@0.19.12':
     optional: true
 
   '@esbuild/linux-arm@0.25.12':
@@ -5205,9 +5032,6 @@ snapshots:
   '@esbuild/linux-ia32@0.18.20':
     optional: true
 
-  '@esbuild/linux-ia32@0.19.12':
-    optional: true
-
   '@esbuild/linux-ia32@0.25.12':
     optional: true
 
@@ -5218,9 +5042,6 @@ snapshots:
     optional: true
 
   '@esbuild/linux-loong64@0.18.20':
-    optional: true
-
-  '@esbuild/linux-loong64@0.19.12':
     optional: true
 
   '@esbuild/linux-loong64@0.25.12':
@@ -5235,9 +5056,6 @@ snapshots:
   '@esbuild/linux-mips64el@0.18.20':
     optional: true
 
-  '@esbuild/linux-mips64el@0.19.12':
-    optional: true
-
   '@esbuild/linux-mips64el@0.25.12':
     optional: true
 
@@ -5248,9 +5066,6 @@ snapshots:
     optional: true
 
   '@esbuild/linux-ppc64@0.18.20':
-    optional: true
-
-  '@esbuild/linux-ppc64@0.19.12':
     optional: true
 
   '@esbuild/linux-ppc64@0.25.12':
@@ -5265,9 +5080,6 @@ snapshots:
   '@esbuild/linux-riscv64@0.18.20':
     optional: true
 
-  '@esbuild/linux-riscv64@0.19.12':
-    optional: true
-
   '@esbuild/linux-riscv64@0.25.12':
     optional: true
 
@@ -5280,9 +5092,6 @@ snapshots:
   '@esbuild/linux-s390x@0.18.20':
     optional: true
 
-  '@esbuild/linux-s390x@0.19.12':
-    optional: true
-
   '@esbuild/linux-s390x@0.25.12':
     optional: true
 
@@ -5293,9 +5102,6 @@ snapshots:
     optional: true
 
   '@esbuild/linux-x64@0.18.20':
-    optional: true
-
-  '@esbuild/linux-x64@0.19.12':
     optional: true
 
   '@esbuild/linux-x64@0.25.12':
@@ -5319,9 +5125,6 @@ snapshots:
   '@esbuild/netbsd-x64@0.18.20':
     optional: true
 
-  '@esbuild/netbsd-x64@0.19.12':
-    optional: true
-
   '@esbuild/netbsd-x64@0.25.12':
     optional: true
 
@@ -5341,9 +5144,6 @@ snapshots:
     optional: true
 
   '@esbuild/openbsd-x64@0.18.20':
-    optional: true
-
-  '@esbuild/openbsd-x64@0.19.12':
     optional: true
 
   '@esbuild/openbsd-x64@0.25.12':
@@ -5367,9 +5167,6 @@ snapshots:
   '@esbuild/sunos-x64@0.18.20':
     optional: true
 
-  '@esbuild/sunos-x64@0.19.12':
-    optional: true
-
   '@esbuild/sunos-x64@0.25.12':
     optional: true
 
@@ -5380,9 +5177,6 @@ snapshots:
     optional: true
 
   '@esbuild/win32-arm64@0.18.20':
-    optional: true
-
-  '@esbuild/win32-arm64@0.19.12':
     optional: true
 
   '@esbuild/win32-arm64@0.25.12':
@@ -5397,9 +5191,6 @@ snapshots:
   '@esbuild/win32-ia32@0.18.20':
     optional: true
 
-  '@esbuild/win32-ia32@0.19.12':
-    optional: true
-
   '@esbuild/win32-ia32@0.25.12':
     optional: true
 
@@ -5410,9 +5201,6 @@ snapshots:
     optional: true
 
   '@esbuild/win32-x64@0.18.20':
-    optional: true
-
-  '@esbuild/win32-x64@0.19.12':
     optional: true
 
   '@esbuild/win32-x64@0.25.12':
@@ -5426,7 +5214,7 @@ snapshots:
 
   '@exodus/bytes@1.15.1': {}
 
-  '@google-cloud/kms@5.5.0':
+  '@google-cloud/kms@5.5.1':
     dependencies:
       google-gax: 5.0.6
     transitivePeerDependencies:
@@ -5444,14 +5232,14 @@ snapshots:
       protobufjs: 7.6.2
       yargs: 17.7.2
 
-  '@hono/node-server@1.19.14(hono@4.12.23)':
+  '@hono/node-server@1.19.14(hono@4.12.25)':
     dependencies:
-      hono: 4.12.23
+      hono: 4.12.25
 
-  '@hono/node-ws@1.3.1(@hono/node-server@1.19.14(hono@4.12.23))(hono@4.12.23)':
+  '@hono/node-ws@1.3.1(@hono/node-server@1.19.14(hono@4.12.25))(hono@4.12.25)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.23)
-      hono: 4.12.23
+      '@hono/node-server': 1.19.14(hono@4.12.25)
+      hono: 4.12.25
       ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
@@ -5471,11 +5259,6 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
       '@jridgewell/trace-mapping': 0.3.31
 
-  '@jridgewell/remapping@2.3.5':
-    dependencies:
-      '@jridgewell/gen-mapping': 0.3.13
-      '@jridgewell/trace-mapping': 0.3.31
-
   '@jridgewell/resolve-uri@3.1.2': {}
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
@@ -5487,12 +5270,12 @@ snapshots:
 
   '@js-sdsl/ordered-map@4.4.2': {}
 
-  '@langchain/core@1.1.48(openai@4.104.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)':
+  '@langchain/core@1.1.49(openai@6.42.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)':
     dependencies:
       '@cfworker/json-schema': 4.1.1
       '@standard-schema/spec': 1.1.0
       js-tiktoken: 1.0.21
-      langsmith: 0.7.3(openai@4.104.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)
+      langsmith: 0.7.3(openai@6.42.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)
       mustache: 4.2.0
       p-queue: 6.6.2
       zod: 4.4.3
@@ -5503,31 +5286,28 @@ snapshots:
       - openai
       - ws
 
-  '@langchain/langgraph-checkpoint@1.0.4(@langchain/core@1.1.48(openai@4.104.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))':
+  '@langchain/langgraph-checkpoint@1.1.1(@langchain/core@1.1.49(openai@6.42.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))':
     dependencies:
-      '@langchain/core': 1.1.48(openai@4.104.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)
-      uuid: 14.0.0
+      '@langchain/core': 1.1.49(openai@6.42.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)
 
-  '@langchain/langgraph-sdk@1.9.11(@langchain/core@1.1.48(openai@4.104.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@langchain/langgraph-sdk@1.9.22(@langchain/core@1.1.49(openai@6.42.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@langchain/core': 1.1.48(openai@4.104.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)
+      '@langchain/core': 1.1.49(openai@6.42.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)
       '@langchain/protocol': 0.0.16
       '@types/json-schema': 7.0.15
       p-queue: 9.3.0
       p-retry: 7.1.1
-      uuid: 14.0.0
     optionalDependencies:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
-  '@langchain/langgraph@1.3.3(@langchain/core@1.1.48(openai@4.104.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3)':
+  '@langchain/langgraph@1.4.2(@langchain/core@1.1.49(openai@6.42.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3)':
     dependencies:
-      '@langchain/core': 1.1.48(openai@4.104.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)
-      '@langchain/langgraph-checkpoint': 1.0.4(@langchain/core@1.1.48(openai@4.104.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))
-      '@langchain/langgraph-sdk': 1.9.11(@langchain/core@1.1.48(openai@4.104.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@langchain/core': 1.1.49(openai@6.42.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)
+      '@langchain/langgraph-checkpoint': 1.1.1(@langchain/core@1.1.49(openai@6.42.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))
+      '@langchain/langgraph-sdk': 1.9.22(@langchain/core@1.1.49(openai@6.42.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@langchain/protocol': 0.0.16
       '@standard-schema/spec': 1.1.0
-      uuid: 14.0.0
       zod: 4.4.3
     optionalDependencies:
       zod-to-json-schema: 3.25.2(zod@4.4.3)
@@ -5541,7 +5321,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.23)
+      '@hono/node-server': 1.19.14(hono@4.12.25)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -5551,7 +5331,7 @@ snapshots:
       eventsource-parser: 3.1.0
       express: 5.2.1
       express-rate-limit: 8.5.2(express@5.2.1)
-      hono: 4.12.23
+      hono: 4.12.25
       jose: 6.2.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -5562,6 +5342,13 @@ snapshots:
       '@cfworker/json-schema': 4.1.1
     transitivePeerDependencies:
       - supports-color
+
+  '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.2
+    optional: true
 
   '@nivo/annotations@0.99.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
@@ -5801,7 +5588,10 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@petamoriken/float16@3.9.3': {}
+  '@oxc-project/types@0.133.0': {}
+
+  '@petamoriken/float16@3.9.3':
+    optional: true
 
   '@pixi/colord@2.9.6': {}
 
@@ -5836,162 +5626,162 @@ snapshots:
 
   '@radix-ui/primitive@1.1.3': {}
 
-  '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.16)(react@19.2.7)':
+  '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
       react: 19.2.7
     optionalDependencies:
-      '@types/react': 19.2.16
+      '@types/react': 19.2.17
 
-  '@radix-ui/react-context@1.1.2(@types/react@19.2.16)(react@19.2.7)':
+  '@radix-ui/react-context@1.1.2(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
       react: 19.2.7
     optionalDependencies:
-      '@types/react': 19.2.16
+      '@types/react': 19.2.17
 
-  '@radix-ui/react-dialog@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@radix-ui/react-dialog@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.16)(react@19.2.7)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.16)(react@19.2.7)
-      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.16)(react@19.2.7)
-      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.16)(react@19.2.7)
-      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.16)(react@19.2.7)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.16)(react@19.2.7)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.17)(react@19.2.7)
       aria-hidden: 1.2.6
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      react-remove-scroll: 2.7.2(@types/react@19.2.16)(react@19.2.7)
+      react-remove-scroll: 2.7.2(@types/react@19.2.17)(react@19.2.7)
     optionalDependencies:
-      '@types/react': 19.2.16
-      '@types/react-dom': 19.2.3(@types/react@19.2.16)
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
-  '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.16)(react@19.2.7)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.16)(react@19.2.7)
-      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.16)(react@19.2.7)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.17)(react@19.2.7)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      '@types/react': 19.2.16
-      '@types/react-dom': 19.2.3(@types/react@19.2.16)
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
-  '@radix-ui/react-focus-guards@1.1.3(@types/react@19.2.16)(react@19.2.7)':
+  '@radix-ui/react-focus-guards@1.1.3(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
       react: 19.2.7
     optionalDependencies:
-      '@types/react': 19.2.16
+      '@types/react': 19.2.17
 
-  '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.16)(react@19.2.7)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.16)(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-    optionalDependencies:
-      '@types/react': 19.2.16
-      '@types/react-dom': 19.2.3(@types/react@19.2.16)
-
-  '@radix-ui/react-id@1.1.1(@types/react@19.2.16)(react@19.2.7)':
-    dependencies:
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.16)(react@19.2.7)
-      react: 19.2.7
-    optionalDependencies:
-      '@types/react': 19.2.16
-
-  '@radix-ui/react-portal@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.16)(react@19.2.7)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.17)(react@19.2.7)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      '@types/react': 19.2.16
-      '@types/react-dom': 19.2.3(@types/react@19.2.16)
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
-  '@radix-ui/react-presence@1.1.5(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@radix-ui/react-id@1.1.1(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.16)(react@19.2.7)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.16)(react@19.2.7)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@radix-ui/react-portal@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.17)(react@19.2.7)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      '@types/react': 19.2.16
-      '@types/react-dom': 19.2.3(@types/react@19.2.16)
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
-  '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@radix-ui/react-presence@1.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.16)(react@19.2.7)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.17)(react@19.2.7)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      '@types/react': 19.2.16
-      '@types/react-dom': 19.2.3(@types/react@19.2.16)
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
-  '@radix-ui/react-primitive@2.1.4(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@radix-ui/react-slot': 1.2.4(@types/react@19.2.16)(react@19.2.7)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.17)(react@19.2.7)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      '@types/react': 19.2.16
-      '@types/react-dom': 19.2.3(@types/react@19.2.16)
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
-  '@radix-ui/react-slot@1.2.3(@types/react@19.2.16)(react@19.2.7)':
+  '@radix-ui/react-primitive@2.1.4(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.16)(react@19.2.7)
+      '@radix-ui/react-slot': 1.2.4(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-slot@1.2.3(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.17)(react@19.2.7)
       react: 19.2.7
     optionalDependencies:
-      '@types/react': 19.2.16
+      '@types/react': 19.2.17
 
-  '@radix-ui/react-slot@1.2.4(@types/react@19.2.16)(react@19.2.7)':
+  '@radix-ui/react-slot@1.2.4(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.16)(react@19.2.7)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.17)(react@19.2.7)
       react: 19.2.7
     optionalDependencies:
-      '@types/react': 19.2.16
+      '@types/react': 19.2.17
 
-  '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.2.16)(react@19.2.7)':
-    dependencies:
-      react: 19.2.7
-    optionalDependencies:
-      '@types/react': 19.2.16
-
-  '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.2.16)(react@19.2.7)':
-    dependencies:
-      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.16)(react@19.2.7)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.16)(react@19.2.7)
-      react: 19.2.7
-    optionalDependencies:
-      '@types/react': 19.2.16
-
-  '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.2.16)(react@19.2.7)':
-    dependencies:
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.16)(react@19.2.7)
-      react: 19.2.7
-    optionalDependencies:
-      '@types/react': 19.2.16
-
-  '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@19.2.16)(react@19.2.7)':
-    dependencies:
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.16)(react@19.2.7)
-      react: 19.2.7
-    optionalDependencies:
-      '@types/react': 19.2.16
-
-  '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.2.16)(react@19.2.7)':
+  '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
       react: 19.2.7
     optionalDependencies:
-      '@types/react': 19.2.16
+      '@types/react': 19.2.17
+
+  '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
 
   '@react-oauth/google@0.13.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
@@ -6035,7 +5825,56 @@ snapshots:
     dependencies:
       onnxruntime-web: 1.26.0
 
-  '@rolldown/pluginutils@1.0.0-beta.27': {}
+  '@rolldown/binding-android-arm64@1.0.3':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.3':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.3':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.3':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.3':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.3':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.3':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.3':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.3':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.3':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.3':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.3':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.3':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.3':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.3':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.1': {}
 
   '@rollup/rollup-android-arm-eabi@4.61.0':
     optional: true
@@ -6114,15 +5953,15 @@ snapshots:
 
   '@slack/logger@4.0.1':
     dependencies:
-      '@types/node': 22.19.15
+      '@types/node': 25.9.3
 
   '@slack/types@2.21.1': {}
 
-  '@slack/web-api@7.16.0':
+  '@slack/web-api@7.17.0':
     dependencies:
       '@slack/logger': 4.0.1
       '@slack/types': 2.21.1
-      '@types/node': 22.19.15
+      '@types/node': 25.9.3
       '@types/retry': 0.12.0
       axios: 1.16.1
       eventemitter3: 5.0.4
@@ -6189,6 +6028,8 @@ snapshots:
       '@smithy/util-buffer-from': 2.2.0
       tslib: 2.8.1
 
+  '@stablelib/base64@1.0.1': {}
+
   '@standard-schema/spec@1.1.0': {}
 
   '@testing-library/dom@10.4.1':
@@ -6211,42 +6052,26 @@ snapshots:
       picocolors: 1.1.1
       redent: 3.0.0
 
-  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@testing-library/dom': 10.4.1
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      '@types/react': 19.2.16
-      '@types/react-dom': 19.2.3(@types/react@19.2.16)
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
   '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
     dependencies:
       '@testing-library/dom': 10.4.1
 
+  '@tybys/wasm-util@0.10.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@types/aria-query@5.0.4': {}
-
-  '@types/babel__core@7.20.5':
-    dependencies:
-      '@babel/parser': 7.29.7
-      '@babel/types': 7.29.7
-      '@types/babel__generator': 7.27.0
-      '@types/babel__template': 7.4.4
-      '@types/babel__traverse': 7.28.0
-
-  '@types/babel__generator@7.27.0':
-    dependencies:
-      '@babel/types': 7.29.7
-
-  '@types/babel__template@7.4.4':
-    dependencies:
-      '@babel/parser': 7.29.7
-      '@babel/types': 7.29.7
-
-  '@types/babel__traverse@7.28.0':
-    dependencies:
-      '@babel/types': 7.29.7
 
   '@types/chai@5.2.3':
     dependencies:
@@ -6311,20 +6136,15 @@ snapshots:
 
   '@types/ms@2.1.0': {}
 
-  '@types/node-fetch@2.6.13':
+  '@types/node@25.9.3':
     dependencies:
-      '@types/node': 22.19.15
-      form-data: 4.0.5
+      undici-types: 7.24.6
 
-  '@types/node@22.19.15':
+  '@types/react-dom@19.2.3(@types/react@19.2.17)':
     dependencies:
-      undici-types: 6.21.0
+      '@types/react': 19.2.17
 
-  '@types/react-dom@19.2.3(@types/react@19.2.16)':
-    dependencies:
-      '@types/react': 19.2.16
-
-  '@types/react@19.2.16':
+  '@types/react@19.2.17':
     dependencies:
       csstype: 3.2.3
 
@@ -6336,26 +6156,19 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 22.19.15
+      '@types/node': 25.9.3
 
   '@ungap/structured-clone@1.3.1': {}
 
-  '@vitejs/plugin-react@4.7.0(vite@6.4.3(@types/node@22.19.15)(jiti@1.21.7)(tsx@4.22.4))':
+  '@vitejs/plugin-react@6.0.2(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@1.21.7)(tsx@4.22.4))':
     dependencies:
-      '@babel/core': 7.29.7
-      '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-transform-react-jsx-source': 7.29.7(@babel/core@7.29.7)
-      '@rolldown/pluginutils': 1.0.0-beta.27
-      '@types/babel__core': 7.20.5
-      react-refresh: 0.17.0
-      vite: 6.4.3(@types/node@22.19.15)(jiti@1.21.7)(tsx@4.22.4)
-    transitivePeerDependencies:
-      - supports-color
+      '@rolldown/pluginutils': 1.0.1
+      vite: 8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@1.21.7)(tsx@4.22.4)
 
-  '@vitest/coverage-v8@4.1.1(vitest@4.1.1(@types/node@22.19.15)(jsdom@29.1.1)(vite@6.4.3(@types/node@22.19.15)(jiti@1.21.7)(tsx@4.22.4)))':
+  '@vitest/coverage-v8@4.1.8(vitest@4.1.8)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
-      '@vitest/utils': 4.1.1
+      '@vitest/utils': 4.1.8
       ast-v8-to-istanbul: 1.0.3
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
@@ -6364,46 +6177,54 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.1(@types/node@22.19.15)(jsdom@29.1.1)(vite@6.4.3(@types/node@22.19.15)(jiti@1.21.7)(tsx@4.22.4))
+      vitest: 4.1.8(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@1.21.7)(tsx@4.22.4))
 
-  '@vitest/expect@4.1.1':
+  '@vitest/expect@4.1.8':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 4.1.1
-      '@vitest/utils': 4.1.1
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.1(vite@6.4.3(@types/node@22.19.15)(jiti@1.21.7)(tsx@4.22.4))':
+  '@vitest/mocker@4.1.8(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(jiti@1.21.7)(tsx@4.22.4))':
     dependencies:
-      '@vitest/spy': 4.1.1
+      '@vitest/spy': 4.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 6.4.3(@types/node@22.19.15)(jiti@1.21.7)(tsx@4.22.4)
+      vite: 8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(jiti@1.21.7)(tsx@4.22.4)
 
-  '@vitest/pretty-format@4.1.1':
+  '@vitest/mocker@4.1.8(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@1.21.7)(tsx@4.22.4))':
+    dependencies:
+      '@vitest/spy': 4.1.8
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@1.21.7)(tsx@4.22.4)
+
+  '@vitest/pretty-format@4.1.8':
     dependencies:
       tinyrainbow: 3.1.0
 
-  '@vitest/runner@4.1.1':
+  '@vitest/runner@4.1.8':
     dependencies:
-      '@vitest/utils': 4.1.1
+      '@vitest/utils': 4.1.8
       pathe: 2.0.3
 
-  '@vitest/snapshot@4.1.1':
+  '@vitest/snapshot@4.1.8':
     dependencies:
-      '@vitest/pretty-format': 4.1.1
-      '@vitest/utils': 4.1.1
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/utils': 4.1.8
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@4.1.1': {}
+  '@vitest/spy@4.1.8': {}
 
-  '@vitest/utils@4.1.1':
+  '@vitest/utils@4.1.8':
     dependencies:
-      '@vitest/pretty-format': 4.1.1
+      '@vitest/pretty-format': 4.1.8
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
@@ -6429,10 +6250,6 @@ snapshots:
       - supports-color
 
   agent-base@7.1.4: {}
-
-  agentkeepalive@4.6.0:
-    dependencies:
-      humanize-ms: 1.2.1
 
   ajv-formats@3.0.1(ajv@8.20.0):
     optionalDependencies:
@@ -6619,12 +6436,12 @@ snapshots:
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
 
-  cmdk@1.1.1(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  cmdk@1.1.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.16)(react@19.2.7)
-      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.16)(react@19.2.7)
-      '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
     transitivePeerDependencies:
@@ -6797,6 +6614,8 @@ snapshots:
 
   dequal@2.0.3: {}
 
+  detect-libc@2.1.2: {}
+
   detect-node-es@1.1.0: {}
 
   devlop@1.1.0:
@@ -6813,18 +6632,16 @@ snapshots:
 
   dotenv@16.6.1: {}
 
-  drizzle-kit@0.30.6:
+  drizzle-kit@0.31.10:
     dependencies:
       '@drizzle-team/brocli': 0.10.2
       '@esbuild-kit/esm-loader': 2.6.5
-      esbuild: 0.19.12
-      esbuild-register: 3.6.0(esbuild@0.19.12)
-      gel: 2.2.0
-    transitivePeerDependencies:
-      - supports-color
+      esbuild: 0.25.12
+      tsx: 4.22.4
 
-  drizzle-orm@0.39.3(postgres@3.4.9):
+  drizzle-orm@0.45.2(gel@2.2.0)(postgres@3.4.9):
     optionalDependencies:
+      gel: 2.2.0
       postgres: 3.4.9
 
   dunder-proto@1.0.1:
@@ -6866,7 +6683,8 @@ snapshots:
 
   entities@8.0.0: {}
 
-  env-paths@3.0.0: {}
+  env-paths@3.0.0:
+    optional: true
 
   es-define-property@1.0.1: {}
 
@@ -6884,13 +6702,6 @@ snapshots:
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
       hasown: 2.0.4
-
-  esbuild-register@3.6.0(esbuild@0.19.12):
-    dependencies:
-      debug: 4.4.3
-      esbuild: 0.19.12
-    transitivePeerDependencies:
-      - supports-color
 
   esbuild@0.18.20:
     optionalDependencies:
@@ -6916,32 +6727,6 @@ snapshots:
       '@esbuild/win32-arm64': 0.18.20
       '@esbuild/win32-ia32': 0.18.20
       '@esbuild/win32-x64': 0.18.20
-
-  esbuild@0.19.12:
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.19.12
-      '@esbuild/android-arm': 0.19.12
-      '@esbuild/android-arm64': 0.19.12
-      '@esbuild/android-x64': 0.19.12
-      '@esbuild/darwin-arm64': 0.19.12
-      '@esbuild/darwin-x64': 0.19.12
-      '@esbuild/freebsd-arm64': 0.19.12
-      '@esbuild/freebsd-x64': 0.19.12
-      '@esbuild/linux-arm': 0.19.12
-      '@esbuild/linux-arm64': 0.19.12
-      '@esbuild/linux-ia32': 0.19.12
-      '@esbuild/linux-loong64': 0.19.12
-      '@esbuild/linux-mips64el': 0.19.12
-      '@esbuild/linux-ppc64': 0.19.12
-      '@esbuild/linux-riscv64': 0.19.12
-      '@esbuild/linux-s390x': 0.19.12
-      '@esbuild/linux-x64': 0.19.12
-      '@esbuild/netbsd-x64': 0.19.12
-      '@esbuild/openbsd-x64': 0.19.12
-      '@esbuild/sunos-x64': 0.19.12
-      '@esbuild/win32-arm64': 0.19.12
-      '@esbuild/win32-ia32': 0.19.12
-      '@esbuild/win32-x64': 0.19.12
 
   esbuild@0.25.12:
     optionalDependencies:
@@ -7110,6 +6895,8 @@ snapshots:
       merge2: 1.4.1
       micromatch: 4.0.8
 
+  fast-sha256@1.3.0: {}
+
   fast-uri@3.1.2: {}
 
   fast-xml-builder@1.2.0:
@@ -7167,8 +6954,6 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  form-data-encoder@1.7.2: {}
-
   form-data-encoder@4.1.0: {}
 
   form-data@4.0.5:
@@ -7178,11 +6963,6 @@ snapshots:
       es-set-tostringtag: 2.1.0
       hasown: 2.0.4
       mime-types: 2.1.35
-
-  formdata-node@4.4.1:
-    dependencies:
-      node-domexception: 1.0.0
-      web-streams-polyfill: 4.0.0-beta.3
 
   formdata-node@6.0.3: {}
 
@@ -7230,8 +7010,7 @@ snapshots:
       which: 4.0.0
     transitivePeerDependencies:
       - supports-color
-
-  gensync@1.0.0-beta.2: {}
+    optional: true
 
   get-caller-file@2.0.5: {}
 
@@ -7280,7 +7059,7 @@ snapshots:
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
 
-  google-auth-library@10.6.2:
+  google-auth-library@10.7.0:
     dependencies:
       base64-js: 1.5.1
       ecdsa-sig-formatter: 1.0.11
@@ -7296,7 +7075,7 @@ snapshots:
       '@grpc/grpc-js': 1.14.4
       '@grpc/proto-loader': 0.8.1
       duplexify: 4.1.3
-      google-auth-library: 10.6.2
+      google-auth-library: 10.7.0
       google-logging-utils: 1.1.3
       node-fetch: 3.3.2
       object-hash: 3.0.0
@@ -7411,7 +7190,7 @@ snapshots:
 
   highlight.js@11.11.1: {}
 
-  hono@4.12.23: {}
+  hono@4.12.25: {}
 
   html-encoding-sniffer@6.0.0:
     dependencies:
@@ -7453,10 +7232,6 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
-
-  humanize-ms@1.2.1:
-    dependencies:
-      ms: 2.1.3
 
   iconv-lite@0.7.2:
     dependencies:
@@ -7521,7 +7296,8 @@ snapshots:
 
   isexe@2.0.0: {}
 
-  isexe@3.1.5: {}
+  isexe@3.1.5:
+    optional: true
 
   ismobilejs@1.1.1: {}
 
@@ -7586,8 +7362,6 @@ snapshots:
     transitivePeerDependencies:
       - '@noble/hashes'
 
-  jsesc@3.1.0: {}
-
   json-bigint@1.0.0:
     dependencies:
       bignumber.js: 9.3.1
@@ -7601,8 +7375,6 @@ snapshots:
 
   json-schema-typed@8.0.2: {}
 
-  json5@2.2.3: {}
-
   jwa@2.0.1:
     dependencies:
       buffer-equal-constant-time: 1.0.1
@@ -7614,12 +7386,61 @@ snapshots:
       jwa: 2.0.1
       safe-buffer: 5.2.1
 
-  langsmith@0.7.3(openai@4.104.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0):
+  langsmith@0.7.3(openai@6.42.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0):
     dependencies:
       p-queue: 6.6.2
     optionalDependencies:
-      openai: 4.104.0(ws@8.21.0)(zod@4.4.3)
+      openai: 6.42.0(ws@8.21.0)(zod@4.4.3)
       ws: 8.21.0
+
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
 
   lilconfig@3.1.3: {}
 
@@ -7646,10 +7467,6 @@ snapshots:
   lru-cache@10.4.3: {}
 
   lru-cache@11.5.1: {}
-
-  lru-cache@5.1.1:
-    dependencies:
-      yallist: 3.1.1
 
   lz-string@1.5.0: {}
 
@@ -8076,10 +7893,6 @@ snapshots:
 
   node-domexception@1.0.0: {}
 
-  node-fetch@2.7.0:
-    dependencies:
-      whatwg-url: 5.0.0
-
   node-fetch@3.3.2:
     dependencies:
       data-uri-to-buffer: 4.0.1
@@ -8117,20 +7930,10 @@ snapshots:
       platform: 1.3.6
       protobufjs: 7.6.2
 
-  openai@4.104.0(ws@8.21.0)(zod@4.4.3):
-    dependencies:
-      '@types/node': 22.19.15
-      '@types/node-fetch': 2.6.13
-      abort-controller: 3.0.0
-      agentkeepalive: 4.6.0
-      form-data-encoder: 1.7.2
-      formdata-node: 4.4.1
-      node-fetch: 2.7.0
+  openai@6.42.0(ws@8.21.0)(zod@4.4.3):
     optionalDependencies:
       ws: 8.21.0
       zod: 4.4.3
-    transitivePeerDependencies:
-      - encoding
 
   p-finally@1.0.0: {}
 
@@ -8305,7 +8108,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.1
-      '@types/node': 22.19.15
+      '@types/node': 25.9.3
       long: 5.3.2
 
   proxy-addr@2.0.7:
@@ -8339,11 +8142,11 @@ snapshots:
 
   react-is@17.0.2: {}
 
-  react-markdown@9.1.0(@types/react@19.2.16)(react@19.2.7):
+  react-markdown@10.1.0(@types/react@19.2.17)(react@19.2.7):
     dependencies:
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
-      '@types/react': 19.2.16
+      '@types/react': 19.2.17
       devlop: 1.1.0
       hast-util-to-jsx-runtime: 2.3.6
       html-url-attributes: 3.0.1
@@ -8357,39 +8160,37 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  react-refresh@0.17.0: {}
-
-  react-remove-scroll-bar@2.3.8(@types/react@19.2.16)(react@19.2.7):
+  react-remove-scroll-bar@2.3.8(@types/react@19.2.17)(react@19.2.7):
     dependencies:
       react: 19.2.7
-      react-style-singleton: 2.2.3(@types/react@19.2.16)(react@19.2.7)
+      react-style-singleton: 2.2.3(@types/react@19.2.17)(react@19.2.7)
       tslib: 2.8.1
     optionalDependencies:
-      '@types/react': 19.2.16
+      '@types/react': 19.2.17
 
-  react-remove-scroll@2.7.2(@types/react@19.2.16)(react@19.2.7):
+  react-remove-scroll@2.7.2(@types/react@19.2.17)(react@19.2.7):
     dependencies:
       react: 19.2.7
-      react-remove-scroll-bar: 2.3.8(@types/react@19.2.16)(react@19.2.7)
-      react-style-singleton: 2.2.3(@types/react@19.2.16)(react@19.2.7)
+      react-remove-scroll-bar: 2.3.8(@types/react@19.2.17)(react@19.2.7)
+      react-style-singleton: 2.2.3(@types/react@19.2.17)(react@19.2.7)
       tslib: 2.8.1
-      use-callback-ref: 1.3.3(@types/react@19.2.16)(react@19.2.7)
-      use-sidecar: 1.1.3(@types/react@19.2.16)(react@19.2.7)
+      use-callback-ref: 1.3.3(@types/react@19.2.17)(react@19.2.7)
+      use-sidecar: 1.1.3(@types/react@19.2.17)(react@19.2.7)
     optionalDependencies:
-      '@types/react': 19.2.16
+      '@types/react': 19.2.17
 
   react-resizable-panels@4.11.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
-  react-router-dom@7.16.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  react-router-dom@7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      react-router: 7.16.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react-router: 7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
 
-  react-router@7.16.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  react-router@7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       cookie: 1.1.1
       react: 19.2.7
@@ -8397,13 +8198,13 @@ snapshots:
     optionalDependencies:
       react-dom: 19.2.7(react@19.2.7)
 
-  react-style-singleton@2.2.3(@types/react@19.2.16)(react@19.2.7):
+  react-style-singleton@2.2.3(@types/react@19.2.17)(react@19.2.7):
     dependencies:
       get-nonce: 1.0.1
       react: 19.2.7
       tslib: 2.8.1
     optionalDependencies:
-      '@types/react': 19.2.16
+      '@types/react': 19.2.17
 
   react-virtualized-auto-sizer@1.0.26(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
@@ -8527,6 +8328,27 @@ snapshots:
 
   robust-predicates@3.0.3: {}
 
+  rolldown@1.0.3:
+    dependencies:
+      '@oxc-project/types': 0.133.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.3
+      '@rolldown/binding-darwin-arm64': 1.0.3
+      '@rolldown/binding-darwin-x64': 1.0.3
+      '@rolldown/binding-freebsd-x64': 1.0.3
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.3
+      '@rolldown/binding-linux-arm64-gnu': 1.0.3
+      '@rolldown/binding-linux-arm64-musl': 1.0.3
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.3
+      '@rolldown/binding-linux-s390x-gnu': 1.0.3
+      '@rolldown/binding-linux-x64-gnu': 1.0.3
+      '@rolldown/binding-linux-x64-musl': 1.0.3
+      '@rolldown/binding-openharmony-arm64': 1.0.3
+      '@rolldown/binding-wasm32-wasi': 1.0.3
+      '@rolldown/binding-win32-arm64-msvc': 1.0.3
+      '@rolldown/binding-win32-x64-msvc': 1.0.3
+
   rollup@4.61.0:
     dependencies:
       '@types/estree': 1.0.9
@@ -8582,8 +8404,6 @@ snapshots:
 
   scheduler@0.27.0: {}
 
-  semver@6.3.1: {}
-
   semver@7.8.1: {}
 
   send@1.2.1:
@@ -8621,7 +8441,8 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.4: {}
+  shell-quote@1.8.4:
+    optional: true
 
   side-channel-list@1.0.1:
     dependencies:
@@ -8669,6 +8490,11 @@ snapshots:
   space-separated-tokens@2.0.2: {}
 
   stackback@0.0.2: {}
+
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
 
   statuses@2.0.2: {}
 
@@ -8819,8 +8645,6 @@ snapshots:
     dependencies:
       tldts: 7.4.2
 
-  tr46@0.0.3: {}
-
   tr46@6.0.0:
     dependencies:
       punycode: 2.3.1
@@ -8883,7 +8707,7 @@ snapshots:
 
   ufo@1.6.4: {}
 
-  undici-types@6.21.0: {}
+  undici-types@7.24.6: {}
 
   undici@7.27.0: {}
 
@@ -8933,28 +8757,26 @@ snapshots:
       escalade: 3.2.0
       picocolors: 1.1.1
 
-  use-callback-ref@1.3.3(@types/react@19.2.16)(react@19.2.7):
+  use-callback-ref@1.3.3(@types/react@19.2.17)(react@19.2.7):
     dependencies:
       react: 19.2.7
       tslib: 2.8.1
     optionalDependencies:
-      '@types/react': 19.2.16
+      '@types/react': 19.2.17
 
   use-debounce@10.1.1(react@19.2.7):
     dependencies:
       react: 19.2.7
 
-  use-sidecar@1.1.3(@types/react@19.2.16)(react@19.2.7):
+  use-sidecar@1.1.3(@types/react@19.2.17)(react@19.2.7):
     dependencies:
       detect-node-es: 1.1.0
       react: 19.2.7
       tslib: 2.8.1
     optionalDependencies:
-      '@types/react': 19.2.16
+      '@types/react': 19.2.17
 
   util-deprecate@1.0.2: {}
-
-  uuid@14.0.0: {}
 
   vary@1.1.2: {}
 
@@ -8973,29 +8795,43 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite@6.4.3(@types/node@22.19.15)(jiti@1.21.7)(tsx@4.22.4):
+  vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(jiti@1.21.7)(tsx@4.22.4):
     dependencies:
-      esbuild: 0.25.12
-      fdir: 6.5.0(picomatch@4.0.4)
+      lightningcss: 1.32.0
       picomatch: 4.0.4
       postcss: 8.5.15
-      rollup: 4.61.0
+      rolldown: 1.0.3
       tinyglobby: 0.2.17
     optionalDependencies:
-      '@types/node': 22.19.15
+      '@types/node': 25.9.3
+      esbuild: 0.27.7
       fsevents: 2.3.3
       jiti: 1.21.7
       tsx: 4.22.4
 
-  vitest@4.1.1(@types/node@22.19.15)(jsdom@29.1.1)(vite@6.4.3(@types/node@22.19.15)(jiti@1.21.7)(tsx@4.22.4)):
+  vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@1.21.7)(tsx@4.22.4):
     dependencies:
-      '@vitest/expect': 4.1.1
-      '@vitest/mocker': 4.1.1(vite@6.4.3(@types/node@22.19.15)(jiti@1.21.7)(tsx@4.22.4))
-      '@vitest/pretty-format': 4.1.1
-      '@vitest/runner': 4.1.1
-      '@vitest/snapshot': 4.1.1
-      '@vitest/spy': 4.1.1
-      '@vitest/utils': 4.1.1
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.15
+      rolldown: 1.0.3
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 25.9.3
+      esbuild: 0.28.0
+      fsevents: 2.3.3
+      jiti: 1.21.7
+      tsx: 4.22.4
+
+  vitest@4.1.8(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(jiti@1.21.7)(tsx@4.22.4)):
+    dependencies:
+      '@vitest/expect': 4.1.8
+      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(jiti@1.21.7)(tsx@4.22.4))
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/runner': 4.1.8
+      '@vitest/snapshot': 4.1.8
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
       es-module-lexer: 2.1.0
       expect-type: 1.3.0
       magic-string: 0.30.21
@@ -9007,10 +8843,40 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 6.4.3(@types/node@22.19.15)(jiti@1.21.7)(tsx@4.22.4)
+      vite: 8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(jiti@1.21.7)(tsx@4.22.4)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 22.19.15
+      '@types/node': 25.9.3
+      '@vitest/coverage-v8': 4.1.8(vitest@4.1.8)
+      jsdom: 29.1.1
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.8(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@1.21.7)(tsx@4.22.4)):
+    dependencies:
+      '@vitest/expect': 4.1.8
+      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@1.21.7)(tsx@4.22.4))
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/runner': 4.1.8
+      '@vitest/snapshot': 4.1.8
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@1.21.7)(tsx@4.22.4)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.9.3
+      '@vitest/coverage-v8': 4.1.8(vitest@4.1.8)
       jsdom: 29.1.1
     transitivePeerDependencies:
       - msw
@@ -9023,11 +8889,7 @@ snapshots:
 
   web-streams-polyfill@3.3.3: {}
 
-  web-streams-polyfill@4.0.0-beta.3: {}
-
   web-tree-sitter@0.25.10: {}
-
-  webidl-conversions@3.0.1: {}
 
   webidl-conversions@8.0.1: {}
 
@@ -9041,11 +8903,6 @@ snapshots:
     transitivePeerDependencies:
       - '@noble/hashes'
 
-  whatwg-url@5.0.0:
-    dependencies:
-      tr46: 0.0.3
-      webidl-conversions: 3.0.1
-
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
@@ -9053,6 +8910,7 @@ snapshots:
   which@4.0.0:
     dependencies:
       isexe: 3.1.5
+    optional: true
 
   why-is-node-running@2.3.0:
     dependencies:
@@ -9082,8 +8940,6 @@ snapshots:
   xmlchars@2.2.0: {}
 
   y18n@5.0.8: {}
-
-  yallist@3.1.1: {}
 
   yargs-parser@20.2.9: {}
 


### PR DESCRIPTION
Promote `develop` → `main` (prod). Merge = **unattended prod deploy + smoke** (std-21 cl-42).

## Headline: spec-293 — Move spec between Memexes (fixes the prod 500)
- `move_doc()` SECURITY DEFINER fn (migration **0094**) crosses the per-Memex RLS wall the runtime role can't; whole-Spec transfer; "Comments" dialog redesign; real RequestCtx attribution.
- **Migration 0095 — personal-Memex dedupe (mutates prod data):** collapses duplicate personal Memexes into the `users.namespaceId` canonical, deletes emptied duplicates. Idempotent; no content rows deleted.

## Also in this release
- spec-259 — surface open comments in specify→build readiness (MCP + web).
- build(deps): consolidated dependabot bumps (drop TS6 / Tailwind4 / web-tree-sitter).
- ci(security): Semgrep OSS gate + Dependabot; CodeQL advanced setup.

## Pre-merge checklist (std-21 cl-42 / std-17)
- [ ] `develop` CI green
- [ ] int deploy + smoke green (auto-run on the #212 merge)
- [x] `git log origin/develop..origin/main --no-merges` empty (verified)
- [ ] **⚠ Capture a PITR marker on the prod Cloud SQL instance BEFORE merging** — migration 0095 deletes emptied duplicate personal Memexes (precedent spec-65). Safe to re-run, but the delete is the irreversible step.
- [ ] After deploy: confirm prod smoke green; verify "zero users with >1 personal Memex" on prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)