### PR TITLE
chore: upgrade TypeScript 5.7 → 6.0.3 across the pnpm workspace (spec-291)

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
       "@vitest/coverage-v8": "4.1.8",
       "@types/node": "25.9.3",
       "react": "19.2.7",
-      "react-dom": "19.2.7"
+      "react-dom": "19.2.7",
+      "typescript": "6.0.3"
     }
   }
 }

--- a/packages/ac-emit-vitest/package.json
+++ b/packages/ac-emit-vitest/package.json
@@ -49,7 +49,7 @@
   },
   "devDependencies": {
     "@types/node": "25.9.3",
-    "typescript": "^5.7.0",
+    "typescript": "6.0.3",
     "vitest": "4.1.8"
   },
   "engines": {

--- a/packages/ac-emit-vitest/tsconfig.json
+++ b/packages/ac-emit-vitest/tsconfig.json
@@ -12,7 +12,8 @@
     "declarationMap": true,
     "sourceMap": true,
     "isolatedModules": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node"]
   },
   "include": ["src/**/*.ts"],
   "exclude": ["node_modules", "dist", "src/**/*.test.ts"]

--- a/packages/db-schema/package.json
+++ b/packages/db-schema/package.json
@@ -39,7 +39,7 @@
     "@types/node": "25.9.3",
     "postgres": "^3.4.5",
     "tsup": "^8.3.5",
-    "typescript": "^5.7.0",
+    "typescript": "6.0.3",
     "vitest": "4.1.8"
   }
 }

--- a/packages/db-schema/tsconfig.json
+++ b/packages/db-schema/tsconfig.json
@@ -11,7 +11,8 @@
     "forceConsistentCasingInFileNames": true,
     "isolatedModules": true,
     "noEmit": true,
-    "types": ["node"]
+    "types": ["node"],
+    "ignoreDeprecations": "6.0"
   },
   "include": ["src/**/*.ts", "test/**/*.ts", "tsup.config.ts", "vitest.config.ts"]
 }

--- a/packages/extractor/package.json
+++ b/packages/extractor/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@types/node": "^25.9.3",
     "tsx": "^4.19.0",
-    "typescript": "^5.7.0",
+    "typescript": "6.0.3",
     "vitest": "^4.1.8"
   }
 }

--- a/packages/guide-sdk/package.json
+++ b/packages/guide-sdk/package.json
@@ -35,7 +35,7 @@
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^6.0.2",
     "jsdom": "^29.0.1",
-    "typescript": "~5.7.2",
+    "typescript": "6.0.3",
     "vite": "^8.0.16",
     "vitest": "^4.1.8"
   }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -76,7 +76,7 @@
     "@vitest/coverage-v8": "^4.1.8",
     "drizzle-kit": "^0.31.10",
     "tsx": "^4.19.0",
-    "typescript": "^5.7.0",
+    "typescript": "6.0.3",
     "vitest": "^4.1.8"
   }
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@memex-ai-ac/vitest": "workspace:*",
-    "typescript": "^5.7.0",
+    "typescript": "6.0.3",
     "vitest": "^4.1.8"
   }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -58,7 +58,7 @@
     "jsdom": "^29.0.1",
     "postcss": "^8.4.49",
     "tailwindcss": "^3.4.17",
-    "typescript": "~5.7.2",
+    "typescript": "6.0.3",
     "vite": "^8.0.16",
     "vitest": "^4.1.8"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,7 @@ overrides:
   '@types/node': 25.9.3
   react: 19.2.7
   react-dom: 19.2.7
+  typescript: 6.0.3
 
 importers:
 
@@ -21,8 +22,8 @@ importers:
         specifier: 25.9.3
         version: 25.9.3
       typescript:
-        specifier: ^5.7.0
-        version: 5.7.3
+        specifier: 6.0.3
+        version: 6.0.3
       vitest:
         specifier: 4.1.8
         version: 4.1.8(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@1.21.7)(tsx@4.22.4))
@@ -50,10 +51,10 @@ importers:
         version: 3.4.9
       tsup:
         specifier: ^8.3.5
-        version: 8.5.1(jiti@1.21.7)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.7.3)
+        version: 8.5.1(jiti@1.21.7)(postcss@8.5.15)(tsx@4.22.4)(typescript@6.0.3)
       typescript:
-        specifier: ^5.7.0
-        version: 5.7.3
+        specifier: 6.0.3
+        version: 6.0.3
       vitest:
         specifier: 4.1.8
         version: 4.1.8(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(jiti@1.21.7)(tsx@4.22.4))
@@ -86,8 +87,8 @@ importers:
         specifier: ^4.19.0
         version: 4.22.4
       typescript:
-        specifier: ^5.7.0
-        version: 5.7.3
+        specifier: 6.0.3
+        version: 6.0.3
       vitest:
         specifier: 4.1.8
         version: 4.1.8(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@1.21.7)(tsx@4.22.4))
@@ -132,8 +133,8 @@ importers:
         specifier: ^29.0.1
         version: 29.1.1
       typescript:
-        specifier: ~5.7.2
-        version: 5.7.3
+        specifier: 6.0.3
+        version: 6.0.3
       vite:
         specifier: ^8.0.16
         version: 8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@1.21.7)(tsx@4.22.4)
@@ -211,8 +212,8 @@ importers:
         specifier: ^4.19.0
         version: 4.22.4
       typescript:
-        specifier: ^5.7.0
-        version: 5.7.3
+        specifier: 6.0.3
+        version: 6.0.3
       vitest:
         specifier: 4.1.8
         version: 4.1.8(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@1.21.7)(tsx@4.22.4))
@@ -223,8 +224,8 @@ importers:
         specifier: workspace:*
         version: link:../ac-emit-vitest
       typescript:
-        specifier: ^5.7.0
-        version: 5.7.3
+        specifier: 6.0.3
+        version: 6.0.3
       vitest:
         specifier: 4.1.8
         version: 4.1.8(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@1.21.7)(tsx@4.22.4))
@@ -350,8 +351,8 @@ importers:
         specifier: ^3.4.17
         version: 3.4.19(tsx@4.22.4)
       typescript:
-        specifier: ~5.7.2
-        version: 5.7.3
+        specifier: 6.0.3
+        version: 6.0.3
       vite:
         specifier: ^8.0.16
         version: 8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@1.21.7)(tsx@4.22.4)
@@ -4272,7 +4273,7 @@ packages:
       '@microsoft/api-extractor': ^7.36.0
       '@swc/core': ^1
       postcss: ^8.4.12
-      typescript: '>=4.5.0'
+      typescript: 6.0.3
     peerDependenciesMeta:
       '@microsoft/api-extractor':
         optional: true
@@ -4292,8 +4293,8 @@ packages:
     resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
     engines: {node: '>= 18'}
 
-  typescript@5.7.3:
-    resolution: {integrity: sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==}
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -8663,7 +8664,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.5.1(jiti@1.21.7)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.7.3):
+  tsup@8.5.1(jiti@1.21.7)(postcss@8.5.15)(tsx@4.22.4)(typescript@6.0.3):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.7)
       cac: 6.7.14
@@ -8684,7 +8685,7 @@ snapshots:
       tree-kill: 1.2.2
     optionalDependencies:
       postcss: 8.5.15
-      typescript: 5.7.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - jiti
       - supports-color
@@ -8703,7 +8704,7 @@ snapshots:
       media-typer: 1.1.0
       mime-types: 3.0.2
 
-  typescript@5.7.3: {}
+  typescript@6.0.3: {}
 
   ufo@1.6.4: {}
 


### PR DESCRIPTION
## Summary

Upgrades the workspace from **TypeScript 5.7 → 6.0.3** and fixes everything 6.0 breaks. Build-toolchain only — no runtime/product behaviour change. Supersedes the deferred dependabot PR #207.

Implements **spec-291** ([memex](https://memex.ai/mindset-prod/memex-building-itself/specs/spec-291)).

### Changes
- **Root `package.json`** — add `"typescript": "6.0.3"` to `pnpm.overrides`; align all 7 per-package pins to exact `6.0.3` (std-24: exact per-package pins + override). `cli` excluded (no TypeScript).
- **`ac-emit-vitest/tsconfig.json`** — add `"types": ["node"]` to fix TS2591 `Cannot find name 'process'`. Also resolves the `metadata.ts` TS2322 inference error (a symptom of untyped `process.env`). This was the *only* package that needed it; `shared`/`guide-sdk` were already clean.
- **`db-schema/tsconfig.json`** — add `"ignoreDeprecations": "6.0"` to silence TS5101 `baseUrl` deprecation in tsup's DTS build. `baseUrl` is injected by tsup itself (8.5.1, latest), not by our config.

### Why these specific fixes
The fix set was confirmed **empirically** by running the build on a 6.0 branch, not from the spec's prose. Decisions dec-1/dec-2/dec-3 on the spec record the reasoning.

## Test plan
- [x] `pnpm install` completes clean (all `prepare` builds pass)
- [x] `pnpm build` green (server `tsc` + ui `tsc -b && vite build` — deploy gate)
- [x] `make typecheck` — 10 errors, **identical to pre-bump baseline, zero new**
- [x] Single `typescript@6.0.3` resolved workspace-wide; no `5.7` specifiers remain
- [x] `@memex-ai-ac/vitest` 69 tests pass · `@memex/shared` 690 tests pass
- [ ] CI green on this PR
- [ ] Close dependabot PR #207 as superseded (manual)

## Notes / follow-ups
- ⚠️ **Baseline gotcha:** `make typecheck` only reads as the 10-error baseline *after* `pnpm --filter @memex/shared build` — a stale `@memex/shared` dist injects phantom "no exported member" errors.
- ⏳ **TS-7.0 timebomb:** `ignoreDeprecations: "6.0"` only silences `baseUrl` through TS 6.x; the future 6→7 migration must revisit (tsup fix or db-schema DTS-tooling change).
- 🐞 **Out of scope:** a pre-existing `extractor` type error (`ingest.ts:177`) reproduces on TS 5.7.3 — unrelated to this bump, tracked as spec-291 issue-1. Not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)