### PR TITLE
fix(extractor): rename accountId → memexId to match server CreateRepoInput (spec-291 issue-1)

### DIFF
--- a/packages/extractor/src/index.ts
+++ b/packages/extractor/src/index.ts
@@ -5,7 +5,7 @@ import { closeDb } from "@memex/server/db/connection";
 
 function usage(): never {
   console.log("Usage:");
-  console.log("  tsx src/index.ts --account <accountId> <repo_name> <folder_path> [<folder_path2> ...]");
+  console.log("  tsx src/index.ts --memex <memexId> <repo_name> <folder_path> [<folder_path2> ...]");
   console.log("");
   console.log("Environment:");
   console.log("  DATABASE_URL   Memex Postgres connection string (required)");
@@ -16,19 +16,19 @@ async function main() {
   const argv = process.argv.slice(2);
   if (argv.length < 3) usage();
 
-  let accountId: string | null = null;
+  let memexId: string | null = null;
   const positional: string[] = [];
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i]!;
-    if (arg === "--account") {
-      accountId = argv[++i] ?? null;
+    if (arg === "--memex") {
+      memexId = argv[++i] ?? null;
     } else {
       positional.push(arg);
     }
   }
 
-  if (!accountId) {
-    console.error("Missing required --account <accountId>");
+  if (!memexId) {
+    console.error("Missing required --memex <memexId>");
     usage();
   }
 
@@ -45,7 +45,7 @@ async function main() {
     }
   }
 
-  await ingest({ accountId, repoName, folderPaths: folders });
+  await ingest({ memexId, repoName, folderPaths: folders });
 }
 
 main()

--- a/packages/extractor/src/ingest.ts
+++ b/packages/extractor/src/ingest.ts
@@ -58,7 +58,7 @@ const EXPORTED_KINDS: ReadonlySet<string> = new Set([
 ]);
 
 export interface IngestInput {
-  accountId: string;
+  memexId: string;
   repoName: string;
   folderPaths: string[];
   /** Optional progress callback. Fired at each phase boundary. */
@@ -98,7 +98,7 @@ interface FileSlot {
 }
 
 export async function ingest(input: IngestInput): Promise<void> {
-  const { accountId, repoName, folderPaths, onProgress } = input;
+  const { memexId, repoName, folderPaths, onProgress } = input;
   const startedAt = Date.now();
   const tick = (phase: ProgressEvent["phase"], message: string) =>
     onProgress?.({ phase, message, elapsedMs: Date.now() - startedAt });
@@ -174,7 +174,7 @@ export async function ingest(input: IngestInput): Promise<void> {
   // left in whatever state it was in before this call.
   await db.transaction(async (tx) => {
     const { repo, created } = await getOrCreateRepo(
-      { accountId, name: repoName, url: repoUrl },
+      { memexId, name: repoName, url: repoUrl },
       tx,
     );
     if (!created) await clearRepoData(repo.id, tx);


### PR DESCRIPTION
## Summary

Fixes **account→memex rename drift** in `packages/extractor` (std-1). The server side was migrated (`CreateRepoInput.memexId`, `repos.memex_id` NOT NULL), but the extractor still spoke the old `accountId` vocabulary and passed it into `getOrCreateRepo`.

Discovered while verifying spec-291 (TS 6.0 bump); tracked as **issue-1**. Independent of the TS upgrade — kept as its own PR.

### Why it mattered (not just a type error)
At runtime `input.memexId` was `undefined`, so `createRepo` would violate the NOT NULL `memex_id` constraint — the extractor's ingest path was **broken end-to-end**. It went unnoticed because extractor is a standalone CLI, never tsc-gated and not in `make typecheck`.

### Changes
- `index.ts` — CLI flag `--account` → `--memex`; variable + usage text
- `ingest.ts` — `IngestInput.accountId` → `memexId`; destructure; call site into `getOrCreateRepo`

## Test plan
- [x] `pnpm --filter @memex/extractor exec tsc --noEmit` — clean (the `ingest.ts:177` error is gone)
- [x] `pnpm --filter @memex/extractor test` — **62 passed**
- [ ] CI green on this PR

## Note
The `--account` CLI flag becomes `--memex` — a tiny interface change. Nothing else in the repo invokes it; update any external scripts/runbooks that ingest via `--account`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)