### PR TITLE
chore(dependabot): defer breaking migrations owned by Specs (tailwind v4, web-tree-sitter 0.26)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,17 @@ updates:
       # security updates still arrive individually + promptly.
       npm-minor-and-patch:
         update-types: ["minor", "patch"]
+    ignore:
+      # Deferred breaking migrations — each owned by a Spec, so dependabot must
+      # not re-propose them (a plain bump fails CI and churns the merge gate).
+      # Remove the matching ignore when its Spec lands, to resume normal bumps.
+      - dependency-name: "tailwindcss" # spec-290 owns the v3 → v4 migration
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "web-tree-sitter" # spec-292 owns the 0.25 → 0.26 ABI migration
+        # 0.x: dependabot classifies 0.25 → 0.26 as "minor" (which is why it slipped
+        # into npm-minor-and-patch), so ignore minor + major to keep it out until 292.
+        update-types:
+          ["version-update:semver-minor", "version-update:semver-major"]
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Summary

Stops dependabot from re-proposing two **breaking** bumps that are each owned by a Spec and can't merge as plain bumps — they fail CI and re-run the full matrix on every `develop` push.

- **tailwindcss v3 → v4** → owned by **spec-290** (ignore `semver-major`)
- **web-tree-sitter 0.25 → 0.26** → owned by **spec-292** (ABI migration; ignore `semver-minor` + `semver-major`)

`web-tree-sitter` is `0.x`, so dependabot classifies `0.25 → 0.26` as *minor* — which is exactly why it slipped into the `npm-minor-and-patch` group (PR #210 had to strip it out manually once already).

**typescript is intentionally NOT ignored** — `develop` is now on 6.0.3 (spec-291 / #214), so we want dependabot keeping us current within 6.x.

## Effect on the current open PRs
Once this merges, dependabot will **auto-close the matching open PRs (#203 tailwind, #219 web-tree-sitter)** on its next run, with a comment. Remove each `ignore` block when its Spec lands to resume normal bumps.

## Test plan
- [x] `dependabot.yml` is valid YAML (parsed locally)
- [ ] After merge: confirm dependabot closes #203 and #219 and stops re-opening them

🤖 Generated with [Claude Code](https://claude.com/claude-code)