### PR TITLE
ci: unblock dependabot PRs — disable AC emission on secret-less runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,6 +87,14 @@ jobs:
       # never in this file; empty until set (harmless pre-enforcement), and what
       # greens the spec-129 ac-5 gate once configured.
       MEMEX_EMIT_KEY: ${{ secrets.MEMEX_EMIT_KEY }}
+      # Dependabot PR runs do NOT receive repo secrets, so MEMEX_EMIT_KEY is empty
+      # for them — which made spec-129-ci-emission-key.test.ts fail closed (emission
+      # ON + no key) and blocked EVERY dependabot PR on the required server-result
+      # check. Dependabot runs aren't an authoritative emission context anyway, so
+      # turn emission OFF for them: the spec-129 test then skips by design
+      # (it.skipIf(!isEmissionEnabled())) and no bogus unauthenticated emission is
+      # attempted. Non-dependabot runs are unchanged (emission on, real key).
+      MEMEX_EMIT: ${{ github.actor == 'dependabot[bot]' && 'false' || '' }}
 
     steps:
       - uses: actions/checkout@v6
@@ -458,6 +466,14 @@ jobs:
       # never in this file; empty until set (harmless pre-enforcement), and what
       # greens the spec-129 ac-5 gate once configured.
       MEMEX_EMIT_KEY: ${{ secrets.MEMEX_EMIT_KEY }}
+      # Dependabot PR runs do NOT receive repo secrets, so MEMEX_EMIT_KEY is empty
+      # for them — which made spec-129-ci-emission-key.test.ts fail closed (emission
+      # ON + no key) and blocked EVERY dependabot PR on the required server-result
+      # check. Dependabot runs aren't an authoritative emission context anyway, so
+      # turn emission OFF for them: the spec-129 test then skips by design
+      # (it.skipIf(!isEmissionEnabled())) and no bogus unauthenticated emission is
+      # attempted. Non-dependabot runs are unchanged (emission on, real key).
+      MEMEX_EMIT: ${{ github.actor == 'dependabot[bot]' && 'false' || '' }}
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

Fixes a **pre-existing CI gap that blocks every dependabot PR**.

Dependabot PR runs don't receive repository secrets (GitHub security default), so `MEMEX_EMIT_KEY` is empty for them. `spec-129-ci-emission-key.test.ts` runs whenever AC-emission is ON (the CI default via `isEmissionEnabled()`) and asserts the key is set — so it **failed closed** on every dependabot PR → failed `server (3)` → failed the **required** `server-result` check → no dependabot PR could merge.

Tell-tale: all 7 currently-open dependabot PRs fail the *identical* `server (3)` check, including pure github-actions version bumps that can't touch server tests.

## Fix
Set `MEMEX_EMIT=false` on dependabot runs (`server` + `perf` job envs):
```yaml
MEMEX_EMIT: ${{ github.actor == 'dependabot[bot]' && 'false' || '' }}
```
The spec-129 test then **skips by its own design** (`it.skipIf(!isEmissionEnabled())`), and dependabot runs — which have no key and aren't an authoritative emission context — stop attempting bogus unauthenticated emissions. **Non-dependabot runs are unchanged** (emission on, real key, test still validates).

No secret is exposed to dependabot (deliberately avoided the alternative of adding a Dependabot secret).

## Test plan
- [x] `test.yml` is valid YAML
- [ ] CI green on this PR (non-dependabot run → emission on → spec-129 still runs)
- [ ] After merge: rebase an open dependabot PR and confirm `server (3)` goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)