### PR TITLE
feat(extractor): upgrade web-tree-sitter 0.25 → 0.26 with per-grammar wasm (spec-292)

### DIFF
--- a/packages/extractor/package.json
+++ b/packages/extractor/package.json
@@ -16,8 +16,9 @@
     "dotenv": "^17.4.2",
     "drizzle-orm": "^0.45.2",
     "postgres": "^3.4.5",
-    "tree-sitter-wasms": "^0.1.12",
-    "web-tree-sitter": "^0.25.1"
+    "tree-sitter-python": "^0.25.0",
+    "tree-sitter-typescript": "^0.23.2",
+    "web-tree-sitter": "^0.26.9"
   },
   "devDependencies": {
     "@types/node": "^25.9.3",

--- a/packages/extractor/src/parsers.ts
+++ b/packages/extractor/src/parsers.ts
@@ -13,15 +13,27 @@ async function ensureInitialized(): Promise<void> {
   if (initialized) return;
   // Point the runtime at the WASM binary shipped with the npm package so
   // we don't rely on the default (which assumes a browser/Emscripten path).
-  const wasmPath = require.resolve("web-tree-sitter/tree-sitter.wasm");
+  // web-tree-sitter 0.26 renamed this binary (tree-sitter.wasm → web-tree-sitter.wasm).
+  const wasmPath = require.resolve("web-tree-sitter/web-tree-sitter.wasm");
   await Parser.init({
     locateFile: () => wasmPath,
   });
   initialized = true;
 }
 
+// Grammar wasm is sourced from the official per-grammar packages, which ship
+// prebuilt .wasm that is ABI-compatible with web-tree-sitter 0.26 (the legacy
+// `tree-sitter-wasms` bundle is built against the 0.25-era ABI and fails
+// Language.load on 0.26 — spec-292 dec-1).
+const GRAMMAR_WASM: Record<string, string> = {
+  python: "tree-sitter-python/tree-sitter-python.wasm",
+  typescript: "tree-sitter-typescript/tree-sitter-typescript.wasm",
+};
+
 function grammarPath(name: string): string {
-  return require.resolve(`tree-sitter-wasms/out/tree-sitter-${name}.wasm`);
+  const subpath = GRAMMAR_WASM[name];
+  if (!subpath) throw new Error(`No grammar wasm registered for '${name}'`);
+  return require.resolve(subpath);
 }
 
 let pyLanguage: Language | null = null;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,12 +73,15 @@ importers:
       postgres:
         specifier: ^3.4.5
         version: 3.4.9
-      tree-sitter-wasms:
-        specifier: ^0.1.12
-        version: 0.1.13
+      tree-sitter-python:
+        specifier: ^0.25.0
+        version: 0.25.0
+      tree-sitter-typescript:
+        specifier: ^0.23.2
+        version: 0.23.2
       web-tree-sitter:
-        specifier: ^0.25.1
-        version: 0.25.10
+        specifier: ^0.26.9
+        version: 0.26.9
     devDependencies:
       '@types/node':
         specifier: 25.9.3
@@ -3607,6 +3610,10 @@ packages:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
 
+  node-addon-api@8.8.0:
+    resolution: {integrity: sha512-c5Ko1fZJIJmzhFIkhRN76WTq+fC6tWnGy9CXA0fA+XygsWZmEwG8vmbkNqxMyoaa0Tin4djul49NzdVcJJcjeA==}
+    engines: {node: ^18 || ^20 || >= 21}
+
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
     engines: {node: '>=10.5.0'}
@@ -3615,6 +3622,10 @@ packages:
   node-fetch@3.3.2:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  node-gyp-build@4.8.4:
+    resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
+    hasBin: true
 
   node-releases@2.0.47:
     resolution: {integrity: sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==}
@@ -4275,8 +4286,29 @@ packages:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
 
-  tree-sitter-wasms@0.1.13:
-    resolution: {integrity: sha512-wT+cR6DwaIz80/vho3AvSF0N4txuNx/5bcRKoXouOfClpxh/qqrF4URNLQXbbt8MaAxeksZcZd1j8gcGjc+QxQ==}
+  tree-sitter-javascript@0.23.1:
+    resolution: {integrity: sha512-/bnhbrTD9frUYHQTiYnPcxyHORIw157ERBa6dqzaKxvR/x3PC4Yzd+D1pZIMS6zNg2v3a8BZ0oK7jHqsQo9fWA==}
+    peerDependencies:
+      tree-sitter: ^0.21.1
+    peerDependenciesMeta:
+      tree-sitter:
+        optional: true
+
+  tree-sitter-python@0.25.0:
+    resolution: {integrity: sha512-eCmJx6zQa35GxaCtQD+wXHOhYqBxEL+bp71W/s3fcDMu06MrtzkVXR437dRrCrbrDbyLuUDJpAgycs7ncngLXw==}
+    peerDependencies:
+      tree-sitter: ^0.25.0
+    peerDependenciesMeta:
+      tree-sitter:
+        optional: true
+
+  tree-sitter-typescript@0.23.2:
+    resolution: {integrity: sha512-e04JUUKxTT53/x3Uq1zIL45DoYKVfHH4CZqwgZhPg5qYROl5nQjV+85ruFzFGZxu+QeFVbRTPDRnqL9UbU4VeA==}
+    peerDependencies:
+      tree-sitter: ^0.21.0
+    peerDependenciesMeta:
+      tree-sitter:
+        optional: true
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -4504,13 +4536,8 @@ packages:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
 
-  web-tree-sitter@0.25.10:
-    resolution: {integrity: sha512-Y09sF44/13XvgVKgO2cNDw5rGk6s26MgoZPXLESvMXeefBf7i6/73eFurre0IsTW6E14Y0ArIzhUMmjoc7xyzA==}
-    peerDependencies:
-      '@types/emscripten': ^1.40.0
-    peerDependenciesMeta:
-      '@types/emscripten':
-        optional: true
+  web-tree-sitter@0.26.9:
+    resolution: {integrity: sha512-YJwSHANl6XFgeEjB8nitgj0qZYt5gkIesJ4w2srS2wcLB4GUa4xcOkM0YaMsU6WNR53YVIkDSY7Ej4pf3IXtCA==}
 
   webidl-conversions@8.0.1:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
@@ -7960,6 +7987,8 @@ snapshots:
 
   negotiator@1.0.0: {}
 
+  node-addon-api@8.8.0: {}
+
   node-domexception@1.0.0: {}
 
   node-fetch@3.3.2:
@@ -7967,6 +7996,8 @@ snapshots:
       data-uri-to-buffer: 4.0.1
       fetch-blob: 3.2.0
       formdata-polyfill: 4.0.10
+
+  node-gyp-build@4.8.4: {}
 
   node-releases@2.0.47: {}
 
@@ -8727,7 +8758,21 @@ snapshots:
 
   tree-kill@1.2.2: {}
 
-  tree-sitter-wasms@0.1.13: {}
+  tree-sitter-javascript@0.23.1:
+    dependencies:
+      node-addon-api: 8.8.0
+      node-gyp-build: 4.8.4
+
+  tree-sitter-python@0.25.0:
+    dependencies:
+      node-addon-api: 8.8.0
+      node-gyp-build: 4.8.4
+
+  tree-sitter-typescript@0.23.2:
+    dependencies:
+      node-addon-api: 8.8.0
+      node-gyp-build: 4.8.4
+      tree-sitter-javascript: 0.23.1
 
   trim-lines@3.0.1: {}
 
@@ -8965,7 +9010,7 @@ snapshots:
 
   web-streams-polyfill@3.3.3: {}
 
-  web-tree-sitter@0.25.10: {}
+  web-tree-sitter@0.26.9: {}
 
   webidl-conversions@8.0.1: {}
 


### PR DESCRIPTION
## Summary

Upgrades `packages/extractor` to **web-tree-sitter 0.26**, resolving the coordinated ABI migration that kept it out of PR #210. Implements **spec-292**.

### The problem (re-confirmed empirically)
0.26 broke two things:
1. **Renamed binary** — `tree-sitter.wasm` → `web-tree-sitter.wasm`.
2. **Grammar ABI break** — `Language.load` fails in `getDylinkMetadata` on the `tree-sitter-wasms` blobs (built for the 0.25-era Emscripten ABI). The latest `tree-sitter-wasms@0.1.13` *still* uses `tree-sitter-cli@0.20.8`, so bumping it is a dead end.

### The fix (spec-292 dec-1)
Drop the `tree-sitter-wasms` bundle; source grammars from the **official per-grammar packages** `tree-sitter-python@0.25` + `tree-sitter-typescript@0.23`, which ship prebuilt `.wasm` that **is** ABI-compatible with 0.26 (proven in an isolated spike: both `Language.load` *and* a real parse succeed). `parsers.ts` updated for the renamed runtime binary + new grammar paths; `Parser.init`/`Language.load` call sites unchanged.

### Changes
- `web-tree-sitter ^0.25.1 → ^0.26.9`
- `- tree-sitter-wasms` / `+ tree-sitter-python ^0.25.0` `+ tree-sitter-typescript ^0.23.2`
- `parsers.ts`: runtime wasm subpath + grammar-path mapping

## Test plan
- [x] `pnpm --filter @memex/extractor test` → **62 passed** (parses real python + typescript, no skips)
- [x] `pnpm --filter @memex/extractor exec tsc --noEmit` → clean
- [x] `pnpm build` → green (unaffected)
- [x] pnpm consumes only prebuilt `.wasm` — grammar native build scripts stay un-allowlisted (no node-gyp)
- [ ] CI green on this PR

## Notes
- **Unrelated pre-existing peer mismatch surfaced** (not from this PR): `@hono/node-ws@1.3.1` expects `@hono/node-server@^1.19.11`, but develop now has `2.0.4` (from the merged Hono bump #221). Worth a follow-up bump of `@hono/node-ws`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)