### PR TITLE
fix(deps): revert @hono/node-server to 1.x — 2.x unsupported by voice WS adapter (spec-292 issue-1)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,6 +29,11 @@ updates:
         # into npm-minor-and-patch), so ignore minor + major to keep it out until 292.
         update-types:
           ["version-update:semver-minor", "version-update:semver-major"]
+      - dependency-name: "@hono/node-server" # 2.x unsupported by @hono/node-ws (voice WS adapter)
+        # #221 over-bumped node-server to 2.0 ahead of its WS adapter (no @hono/node-ws
+        # release peers node-server@2 yet). Reverted to 1.x; ignore major re-proposals
+        # until @hono/node-ws ships 2.x support, then remove this. (spec-292 issue-1)
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -54,7 +54,7 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.104.1",
     "@google-cloud/kms": "^5.5.1",
-    "@hono/node-server": "^2.0.4",
+    "@hono/node-server": "^1.19.14",
     "@hono/node-ws": "^1.3.1",
     "@memex/shared": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.27.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -151,11 +151,11 @@ importers:
         specifier: ^5.5.1
         version: 5.5.1
       '@hono/node-server':
-        specifier: ^2.0.4
-        version: 2.0.4(hono@4.12.25)
+        specifier: ^1.19.14
+        version: 1.19.14(hono@4.12.25)
       '@hono/node-ws':
         specifier: ^1.3.1
-        version: 1.3.1(@hono/node-server@2.0.4(hono@4.12.25))(hono@4.12.25)
+        version: 1.3.1(@hono/node-server@1.19.14(hono@4.12.25))(hono@4.12.25)
       '@memex/shared':
         specifier: workspace:*
         version: link:../shared
@@ -1203,12 +1203,6 @@ packages:
   '@hono/node-server@1.19.14':
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
     engines: {node: '>=18.14.1'}
-    peerDependencies:
-      hono: ^4
-
-  '@hono/node-server@2.0.4':
-    resolution: {integrity: sha512-Ut3y0dMMPWy6bZ2kVfx25EOVbZlm15dhF4mOsezMlhpNHy+4MkU1qN9Y6lnruYi4wPmFzimGX2X7LF/FwHli4A==}
-    engines: {node: '>=20'}
     peerDependencies:
       hono: ^4
 
@@ -5276,13 +5270,9 @@ snapshots:
     dependencies:
       hono: 4.12.25
 
-  '@hono/node-server@2.0.4(hono@4.12.25)':
+  '@hono/node-ws@1.3.1(@hono/node-server@1.19.14(hono@4.12.25))(hono@4.12.25)':
     dependencies:
-      hono: 4.12.25
-
-  '@hono/node-ws@1.3.1(@hono/node-server@2.0.4(hono@4.12.25))(hono@4.12.25)':
-    dependencies:
-      '@hono/node-server': 2.0.4(hono@4.12.25)
+      '@hono/node-server': 1.19.14(hono@4.12.25)
       hono: 4.12.25
       ws: 8.21.0
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary

Reverts `@hono/node-server` from **2.0.4 → ^1.19.14**, undoing dependabot #221, because the WebSocket adapter the **voice** path depends on can't support 2.x yet.

## Why
`@hono/node-ws` (latest `1.3.1`) declares `peerDependencies: { "@hono/node-server": "^1.19.11" }` — **no published version supports node-server 2.x**. #221 (an unsupervised auto-merge) moved node-server ahead of its adapter, leaving an **officially-unsupported combination on a critical path**. It happened to pass the int smoke, but on back-compat luck, not support — and node-server 2.0's only stated gain was performance.

## Changes
- `packages/server`: `@hono/node-server ^2.0.4 → ^1.19.14` (satisfies the adapter's `^1.19.11` peer)
- `.github/dependabot.yml`: ignore `@hono/node-server` semver-major so 2.x isn't re-proposed until `@hono/node-ws` ships 2.x support (same pattern as #224)

## Test plan
- [x] `pnpm install` clean — peer warning gone, single `@hono/node-server@1.19.14`
- [x] `pnpm build` green (server tsc + ui)
- [ ] CI green (incl. int deploy + voice-WS smoke on the reverted version — the known-good config)

## Forward action
Re-adopt node-server 2.x and remove the ignore once a `@hono/node-ws` release peers `node-server@^2`. Tracked: spec-292 issue-1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)