### PR TITLE
Set memex_known cookie on successful auth (spec-15)

### DIFF
--- a/packages/server/src/routes/auth-signup.integration.test.ts
+++ b/packages/server/src/routes/auth-signup.integration.test.ts
@@ -492,3 +492,74 @@ describe("Google SSO (dev-mode fallback)", () => {
     expect(typeof body.token).toBe("string");
   });
 });
+
+// Endpoint-level coverage for the memex_known hint cookie (mindset-prod/memex-website
+// spec-15 ac-1): every successful auth endpoint must emit it. The cookie's *attributes*
+// (Domain=.memex.ai etc.) are unit-tested against a memex.ai host in
+// auth/known-cookie.test.ts; here APP_BASE_URL is the test default (localhost), so we
+// only assert the cookie is set — the marketing site's signal that the user is known.
+describe("memex_known cookie is set on successful auth (spec-15 ac-1)", () => {
+  const AC15_1 = "mindset-prod/memex-website/specs/spec-15/acs/ac-1";
+  const knownCookieSet = (res: Response) =>
+    /(^|[,;\s])memex_known=1(;|$)/.test(res.headers.get("set-cookie") ?? "");
+
+  it("password signup sets it", async () => {
+    tagAc(AC15_1);
+    const res = await app.request("/api/auth/signup", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: uniqueEmail("known-signup"), password: "correctbattery" }),
+    });
+    expect(res.status).toBe(201);
+    expect(knownCookieSet(res)).toBe(true);
+  });
+
+  it("password login sets it", async () => {
+    tagAc(AC15_1);
+    const email = uniqueEmail("known-login");
+    await app.request("/api/auth/signup", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email, password: "correctbattery" }),
+    });
+    const res = await app.request("/api/auth/login", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email, password: "correctbattery" }),
+    });
+    expect(res.status).toBe(200);
+    expect(knownCookieSet(res)).toBe(true);
+  });
+
+  it("magic-link consume sets it", async () => {
+    tagAc(AC15_1);
+    const email = uniqueEmail("known-magic");
+    await app.request("/api/auth/magic-link", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email }),
+    });
+    const res = await app.request("/api/auth/magic-link/consume", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token: extractLinkToken(sender.sent[0].text)! }),
+    });
+    expect(res.status).toBe(200);
+    expect(knownCookieSet(res)).toBe(true);
+  });
+
+  it("Google SSO (dev fallback) sets it", async () => {
+    tagAc(AC15_1);
+    await markEmailVerified(
+      (await db.insert(users).values({ email: "dev@memex.ai" } as any).onConflictDoNothing().returning())[0]?.id ??
+        (await getUserByEmail("dev@memex.ai"))!.id,
+    ).catch(() => {});
+    const res = await app.request("/api/auth/sso/google", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ idToken: "" }),
+    });
+    expect(res.status).toBe(200);
+    expect(knownCookieSet(res)).toBe(true);
+  });
+});

--- a/packages/server/src/routes/auth/helpers.ts
+++ b/packages/server/src/routes/auth/helpers.ts
@@ -3,6 +3,7 @@
 // rate-limit/IP/token-attachment helpers without circular dependencies.
 
 import type { Context } from "hono";
+import { setCookie } from "hono/cookie";
 import { OAuth2Client } from "google-auth-library";
 import { signSessionToken } from "../../services/auth-jwt.js";
 import type { SessionPayload } from "../../services/auth.js";
@@ -32,4 +33,34 @@ export function clientIp(c: Context): string {
 // `memex-auth-token` and the session middleware verifies it on subsequent requests.
 export function withToken(session: SessionPayload): SessionPayload {
   return { ...session, token: signSessionToken(session.user.id) };
+}
+
+// memex_known: a JS-readable hint cookie consumed by the marketing site (www.memex.ai)
+// so it can render "Login" instead of "Signup" for visitors who have authenticated
+// before (mindset-prod/memex-website spec-15). It is deliberately NOT a session/auth
+// token: its value is the constant "1", it carries no identity, and nothing in this
+// server may read it to make an authorization decision (spec-15 ac-4) — it is written
+// here and never read back. Set on every successful auth alongside withToken().
+//
+// Domain scope: on a memex.ai host the cookie is pinned to Domain=.memex.ai so it is
+// shared across the www/int/prod subdomains (the marketing site is a different host
+// from the app). On any other host (local dev, previews) the Domain attribute is
+// omitted — a Domain the browser can't match is silently dropped, which would break
+// dev login — and Secure is relaxed so the cookie survives http://localhost.
+export function setKnownCookie(c: Context): void {
+  let host = "";
+  try {
+    host = new URL(process.env.APP_BASE_URL ?? APP_BASE_URL).hostname;
+  } catch {
+    host = "";
+  }
+  const onMemexDomain = host === "memex.ai" || host.endsWith(".memex.ai");
+  setCookie(c, "memex_known", "1", {
+    domain: onMemexDomain ? ".memex.ai" : undefined,
+    path: "/",
+    maxAge: 60 * 60 * 24 * 365, // ~1 year — the "returning user" hint persists (spec-15 dec-1)
+    httpOnly: false, // the marketing site reads it from document.cookie
+    secure: onMemexDomain,
+    sameSite: "Lax",
+  });
 }

--- a/packages/server/src/routes/auth/known-cookie.test.ts
+++ b/packages/server/src/routes/auth/known-cookie.test.ts
@@ -1,0 +1,132 @@
+// Unit tests for the memex_known hint cookie (mindset-prod/memex-website spec-15).
+//
+// These are pure HTTP-surface tests: a tiny Hono app whose only route calls
+// setKnownCookie, driven with app.request(). No database is touched, so this file
+// runs under `make test-unit` even with no Postgres available.
+
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { Hono } from "hono";
+import { readFileSync, readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { setKnownCookie } from "./helpers.js";
+
+const AC = (n: number) => `mindset-prod/memex-website/specs/spec-15/acs/ac-${n}`;
+
+// Build a throwaway app that sets the cookie and returns 200, then read the
+// Set-Cookie header it emits for the given APP_BASE_URL host.
+async function setCookieHeaderFor(appBaseUrl: string | undefined): Promise<string> {
+  if (appBaseUrl === undefined) {
+    vi.stubEnv("APP_BASE_URL", "");
+    // empty string is falsy → helper falls back to its localhost default
+  } else {
+    vi.stubEnv("APP_BASE_URL", appBaseUrl);
+  }
+  const app = new Hono();
+  app.get("/probe", (c) => {
+    setKnownCookie(c);
+    return c.text("ok");
+  });
+  const res = await app.request("/probe");
+  return res.headers.get("set-cookie") ?? "";
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("setKnownCookie — attributes on a memex.ai host (spec-15 ac-1, ac-6, ac-7)", () => {
+  it("emits memex_known=1 with Domain=.memex.ai, Secure, SameSite=Lax, ~1yr Max-Age, and no HttpOnly", async () => {
+    tagAc(AC(1)); // memex_known=1 scoped to Domain=.memex.ai
+    tagAc(AC(6)); // ~1yr Max-Age
+    tagAc(AC(7)); // Secure, SameSite=Lax, HttpOnly unset
+    const header = await setCookieHeaderFor("https://prod.memex.ai");
+
+    expect(header).toMatch(/(^|[,;\s])memex_known=1(;|$)/);
+    expect(header).toMatch(/Domain=\.memex\.ai/i);
+    expect(header).toMatch(/Secure/i);
+    expect(header).toMatch(/SameSite=Lax/i);
+    // ~1 year, allowing for any future rounding.
+    const maxAge = Number(header.match(/Max-Age=(\d+)/i)?.[1]);
+    expect(maxAge).toBeGreaterThanOrEqual(60 * 60 * 24 * 364);
+    // It must NOT be HttpOnly — the marketing site reads it from document.cookie.
+    expect(header).not.toMatch(/HttpOnly/i);
+  });
+
+  it("also pins Domain=.memex.ai on the bare apex host", async () => {
+    tagAc(AC(7));
+    const header = await setCookieHeaderFor("https://memex.ai");
+    expect(header).toMatch(/Domain=\.memex\.ai/i);
+  });
+});
+
+describe("setKnownCookie — non-memex.ai host gating (spec-15 ac-8)", () => {
+  it("omits the Domain attribute on localhost so dev login still works", async () => {
+    tagAc(AC(8));
+    const header = await setCookieHeaderFor("http://localhost:5173");
+    expect(header).toMatch(/memex_known=1/);
+    expect(header).not.toMatch(/Domain=/i);
+    // Secure is relaxed off the memex.ai domain so the cookie survives http://localhost.
+    expect(header).not.toMatch(/Secure/i);
+  });
+
+  it("falls back to the localhost default when APP_BASE_URL is unset (no Domain)", async () => {
+    tagAc(AC(8));
+    const header = await setCookieHeaderFor(undefined);
+    expect(header).toMatch(/memex_known=1/);
+    expect(header).not.toMatch(/Domain=/i);
+  });
+
+  it("omits Domain on an unrelated host (e.g. a preview deployment)", async () => {
+    tagAc(AC(8));
+    const header = await setCookieHeaderFor("https://memex-preview.example.com");
+    expect(header).not.toMatch(/Domain=/i);
+  });
+});
+
+describe("memex_known is write-only — never read for authz (spec-15 ac-4, ac-6)", () => {
+  it("no server source reads the cookie; helpers.ts is the only place it appears", () => {
+    tagAc(AC(4));
+    // ac-6: nothing (e.g. a logout route) ever deletes/expires the cookie — proven by
+    // the cookie name appearing in exactly one non-test source, the writer below.
+    const authDir = dirname(fileURLToPath(import.meta.url));
+    const serverSrc = join(authDir, "..", "..");
+
+    // Walk every .ts file under packages/server/src (excluding test files) and
+    // collect references to the cookie name.
+    const hits: string[] = [];
+    const walk = (dir: string) => {
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const full = join(dir, entry.name);
+        if (entry.isDirectory()) {
+          if (entry.name === "node_modules") continue;
+          walk(full);
+          continue;
+        }
+        if (!entry.name.endsWith(".ts")) continue;
+        if (entry.name.includes(".test.")) continue;
+        const text = readFileSync(full, "utf8");
+        if (text.includes("memex_known")) hits.push(full);
+      }
+    };
+    walk(serverSrc);
+
+    // The ONLY non-test source that may mention the cookie is the writer in
+    // auth/helpers.ts. Any other hit means something is reading it back — which
+    // would risk it being used in an auth decision.
+    const offenders = hits.filter((f) => !f.endsWith(join("auth", "helpers.ts")));
+    expect(offenders).toEqual([]);
+
+    // And the one allowed hit must only ever SET the cookie (getCookie would be a read).
+    const helpers = readFileSync(
+      join(authDir, "helpers.ts"),
+      "utf8",
+    );
+    expect(helpers).toContain("setCookie");
+    expect(helpers).not.toMatch(/getCookie\s*\(\s*[^,]*,\s*["'`]memex_known/);
+    // ac-6: the writer never deletes/expires it either.
+    tagAc(AC(6));
+    expect(helpers).not.toMatch(/deleteCookie\s*\(\s*[^,]*,\s*["'`]memex_known/);
+  });
+});

--- a/packages/server/src/routes/auth/magic-link.ts
+++ b/packages/server/src/routes/auth/magic-link.ts
@@ -9,7 +9,7 @@ import { rateLimit, AUTH_LIMITS } from "../../services/auth-rate-limit.js";
 import type { SessionEnv } from "../../middleware/session.js";
 import type { MemexResolverEnv } from "../../middleware/memex-resolver.js";
 import { readJsonBody, requireString } from "../validation.js";
-import { APP_BASE_URL, withToken } from "./helpers.js";
+import { APP_BASE_URL, setKnownCookie, withToken } from "./helpers.js";
 
 export const magicLink = new Hono<MemexResolverEnv & SessionEnv>();
 
@@ -79,5 +79,6 @@ magicLink.post("/consume", async (c) => {
       session = { ...session, currentMemexId: match.memexId, currentRole: match.role };
     }
   }
+  setKnownCookie(c);
   return c.json(withToken(session));
 });

--- a/packages/server/src/routes/auth/password.ts
+++ b/packages/server/src/routes/auth/password.ts
@@ -15,7 +15,7 @@ import { sessionMiddleware, type SessionEnv } from "../../middleware/session.js"
 import type { MemexResolverEnv } from "../../middleware/memex-resolver.js";
 import { ValidationError } from "../../types/errors.js";
 import { readJsonBody, requireString } from "../validation.js";
-import { APP_BASE_URL, clientIp, withToken } from "./helpers.js";
+import { APP_BASE_URL, clientIp, setKnownCookie, withToken } from "./helpers.js";
 
 export const password = new Hono<MemexResolverEnv & SessionEnv>();
 
@@ -86,6 +86,7 @@ password.post("/signup", async (c) => {
   }
 
   const session = await resolveSession(user.id, null);
+  setKnownCookie(c);
   return c.json(withToken(session), 201);
 });
 
@@ -158,6 +159,7 @@ password.post("/login", async (c) => {
       session = { ...session, currentMemexId: match.memexId, currentRole: match.role };
     }
   }
+  setKnownCookie(c);
   return c.json(withToken(session));
 });
 
@@ -185,6 +187,7 @@ password.post("/verify-email", async (c) => {
 
   await markEmailVerified(row.userId);
   const session = await resolveSession(row.userId, null);
+  setKnownCookie(c);
   return c.json(withToken(session));
 });
 

--- a/packages/server/src/routes/auth/sso.ts
+++ b/packages/server/src/routes/auth/sso.ts
@@ -13,6 +13,7 @@ import {
   oauthClient,
   googleClientId,
   DEV_USER_EMAIL,
+  setKnownCookie,
   withToken,
 } from "./helpers.js";
 
@@ -85,6 +86,7 @@ sso.post("/google", async (c) => {
         }
       }
     }
+    setKnownCookie(c);
     return c.json(withToken(session));
   } catch (err) {
     if (err instanceof DisabledUserError) {


### PR DESCRIPTION
## What

Sets a JS-readable `memex_known=1` cookie on every successful authentication so the marketing site (`www.memex.ai`) can render **"Login"** instead of **"Signup"** for returning visitors. This is the load-bearing half of spec-15 — the marketing change is inert without it.

## How

- **New** `setKnownCookie(c)` in `packages/server/src/routes/auth/helpers.ts` (Hono `setCookie`).
  - `Max-Age` ~1yr, `SameSite=Lax`, `HttpOnly=false` (the marketing site reads it in JS).
  - Host derived from `APP_BASE_URL`: on a `memex.ai` host → `Domain=.memex.ai` + `Secure` (shared across www/int/prod); on any other host (localhost/previews) `Domain` is omitted and `Secure` relaxed so **dev login still works**.
- Called at all five `withToken` success sites: password signup / login / verify-email, Google SSO, magic-link consume.
- **Not an auth token** — value is a constant `1`, carries no identity, and is **never read for authorization** (enforced by a source-scan test).

## Tests

- `auth/known-cookie.test.ts` (node, no DB) — attributes on a memex.ai host, `Domain` omitted off-domain, write-only guard
- `auth-signup.integration.test.ts` — new block asserts every auth endpoint emits `memex_known=1`
- Auth suites **30/30**, `tsc -p tsconfig.build.json` clean

## Pairs with

**mindset-ai/memex-website** PR (reads the cookie, flips the CTA). Deploy order doesn't matter for safety; the feature is visible once both ship.

Spec: mindset-prod/memex-website spec-15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)