### PR TITLE
fix(test): repoint db-schema AC refs to memex-backstage/spec-1

### DIFF
--- a/packages/db-schema/test/consumer.test.ts
+++ b/packages/db-schema/test/consumer.test.ts
@@ -53,7 +53,7 @@ afterAll(() => {
 
 describe("ac-11 — standalone harness installs the tarball, type-checks, and queries via Drizzle", () => {
   it("the installed package resolves and type-checks against its exported types", () => {
-    tagAc("mindset-prod/memex-building-itself/specs/spec-279/acs/ac-11");
+    tagAc("mindset-prod/memex-backstage/specs/spec-1/acs/ac-11");
 
     // A consumer .ts that uses both a value export (table) and a type export (Doc).
     const consumerTs = join(proj, "consumer.ts");
@@ -75,7 +75,7 @@ describe("ac-11 — standalone harness installs the tarball, type-checks, and qu
   });
 
   it("opens a Drizzle postgres connection and runs a query through the imported schema", () => {
-    tagAc("mindset-prod/memex-building-itself/specs/spec-279/acs/ac-11");
+    tagAc("mindset-prod/memex-backstage/specs/spec-1/acs/ac-11");
 
     const probe = join(proj, "probe.mjs");
     writeFileSync(
@@ -97,7 +97,7 @@ describe("ac-11 — standalone harness installs the tarball, type-checks, and qu
 
 describe("ac-5 — consuming is documented and demonstrably sufficient, incl. the RLS posture", () => {
   it("the README documents the install recipe, the drizzle usage, and the BYPASSRLS posture", () => {
-    tagAc("mindset-prod/memex-building-itself/specs/spec-279/acs/ac-5");
+    tagAc("mindset-prod/memex-backstage/specs/spec-1/acs/ac-5");
     const readme = readFileSync(join(PKG_DIR, "README.md"), "utf8");
     // Install recipe: scoped registry + GITHUB_TOKEN auth.
     expect(readme).toContain("@mindset-ai:registry=https://npm.pkg.github.com");

--- a/packages/db-schema/test/drift-gate.test.ts
+++ b/packages/db-schema/test/drift-gate.test.ts
@@ -19,7 +19,7 @@ const map = (obj: Record<string, string[]>) =>
 
 describe("ac-10 — diff core: red on a schema→DB divergence, green/info otherwise", () => {
   it("reports no failures when the package schema is fully present in the DB", () => {
-    tagAc("mindset-prod/memex-building-itself/specs/spec-279/acs/ac-10");
+    tagAc("mindset-prod/memex-backstage/specs/spec-1/acs/ac-10");
     const { failures } = diffSchemas(
       map({ documents: ["id", "title"] }),
       map({ documents: ["id", "title"] }),
@@ -28,7 +28,7 @@ describe("ac-10 — diff core: red on a schema→DB divergence, green/info other
   });
 
   it("FAILS when the DB is missing a table or column the package declares", () => {
-    tagAc("mindset-prod/memex-building-itself/specs/spec-279/acs/ac-10");
+    tagAc("mindset-prod/memex-backstage/specs/spec-1/acs/ac-10");
 
     const missingTable = diffSchemas(map({ documents: ["id"], acs: ["id"] }), map({ documents: ["id"] }));
     expect(missingTable.failures).toContain("missing table in DB: acs");
@@ -38,7 +38,7 @@ describe("ac-10 — diff core: red on a schema→DB divergence, green/info other
   });
 
   it("treats DB-only tables/columns as info, never as failures (typed-subset contract)", () => {
-    tagAc("mindset-prod/memex-building-itself/specs/spec-279/acs/ac-10");
+    tagAc("mindset-prod/memex-backstage/specs/spec-1/acs/ac-10");
     const { failures, info } = diffSchemas(
       map({ documents: ["id"] }),
       map({ documents: ["id", "embedding"], manual_migrations: ["id"] }),
@@ -67,14 +67,14 @@ describe("ac-3 / ac-10 — the gate runs against a freshly-migrated cold DB", ()
   const runGate = () => spawnSync("node", [GATE], { env: { ...process.env, DATABASE_URL: TEST_URL }, encoding: "utf8" });
 
   it("passes (exit 0) when the package matches the migrated DB", () => {
-    tagAc("mindset-prod/memex-building-itself/specs/spec-279/acs/ac-3");
+    tagAc("mindset-prod/memex-backstage/specs/spec-1/acs/ac-3");
     const res = runGate();
     expect(res.stdout).toContain("every table/column the package declares exists in the DB");
     expect(res.status, res.stderr).toBe(0);
   });
 
   it("fails (non-zero exit) on a deliberately-diverged DB", () => {
-    tagAc("mindset-prod/memex-building-itself/specs/spec-279/acs/ac-10");
+    tagAc("mindset-prod/memex-backstage/specs/spec-1/acs/ac-10");
     // Drop a column the package's schema declares → the package is now stale vs the DB.
     execFileSync("psql", [TEST_URL, "-q", "-c", "ALTER TABLE documents DROP COLUMN title;"]);
     const res = runGate();
@@ -86,7 +86,7 @@ describe("ac-3 / ac-10 — the gate runs against a freshly-migrated cold DB", ()
 // The drift gate must exist as a CI check (ac-3): assert the workflow runs it.
 describe("ac-3 — a CI drift gate exists", () => {
   it("the db-schema-drift workflow migrates a cold DB and runs the gate", () => {
-    tagAc("mindset-prod/memex-building-itself/specs/spec-279/acs/ac-3");
+    tagAc("mindset-prod/memex-backstage/specs/spec-1/acs/ac-3");
     const wf = readFileSync(resolve(__dirname, "..", "..", "..", ".github", "workflows", "db-schema-drift.yml"), "utf8");
     expect(wf).toContain("pgvector/pgvector:pg16");
     expect(wf).toContain("pnpm db:migrate");

--- a/packages/db-schema/test/package.build.test.ts
+++ b/packages/db-schema/test/package.build.test.ts
@@ -37,7 +37,7 @@ function tarballName(manifest: { name: string; version: string }): string {
 
 describe("ac-7 — built from schema.ts (single source), exports tables + inferred types as ESM + d.ts", () => {
   it("re-exports the single source (no second schema copy) and emits ESM + d.ts", async () => {
-    tagAc("mindset-prod/memex-building-itself/specs/spec-279/acs/ac-7");
+    tagAc("mindset-prod/memex-backstage/specs/spec-1/acs/ac-7");
 
     // Single source: src/index.ts re-exports the server schema, it does not copy it.
     const srcIndex = readFileSync(join(PKG_DIR, "src", "index.ts"), "utf8");
@@ -62,7 +62,7 @@ describe("ac-7 — built from schema.ts (single source), exports tables + inferr
 
 describe("ac-1 / ac-6 — self-contained: zero workspace/@memex deps, installs in an empty project", () => {
   it("declares no workspace:* or @memex/* dependency, and the built js imports only drizzle-orm", () => {
-    tagAc("mindset-prod/memex-building-itself/specs/spec-279/acs/ac-1");
+    tagAc("mindset-prod/memex-backstage/specs/spec-1/acs/ac-1");
 
     // No workspace/@memex deps in anything a consumer would resolve.
     for (const field of ["dependencies", "peerDependencies"] as const) {
@@ -85,7 +85,7 @@ describe("ac-1 / ac-6 — self-contained: zero workspace/@memex deps, installs i
   });
 
   it("installs into a fresh empty project and the package resolves by name", () => {
-    tagAc("mindset-prod/memex-building-itself/specs/spec-279/acs/ac-6");
+    tagAc("mindset-prod/memex-backstage/specs/spec-1/acs/ac-6");
 
     const proj = mkdtempSync(join(tmpdir(), "db-schema-consumer-"));
     try {
@@ -110,7 +110,7 @@ describe("ac-1 / ac-6 — self-contained: zero workspace/@memex deps, installs i
 
 describe("ac-4 — no external/OSS user must authenticate to a registry to build the repo", () => {
   it("the published artifact is outbound-only: no workspace package depends on @mindset-ai/*", () => {
-    tagAc("mindset-prod/memex-building-itself/specs/spec-279/acs/ac-4");
+    tagAc("mindset-prod/memex-backstage/specs/spec-1/acs/ac-4");
 
     // The new package is consumed ONLY by the out-of-repo Backstage app. Building
     // THIS repo from source must never require pulling an @mindset-ai/* package

--- a/packages/db-schema/test/publish.test.ts
+++ b/packages/db-schema/test/publish.test.ts
@@ -13,7 +13,7 @@ const pkgJson = JSON.parse(readFileSync(resolve(__dirname, "..", "package.json")
 
 describe("ac-8 — publishes to GitHub Packages authenticating with GITHUB_TOKEN only", () => {
   it("targets the @mindset-ai GitHub Packages registry and references no secret but GITHUB_TOKEN", () => {
-    tagAc("mindset-prod/memex-building-itself/specs/spec-279/acs/ac-8");
+    tagAc("mindset-prod/memex-backstage/specs/spec-1/acs/ac-8");
 
     // Right registry + scope.
     expect(workflow).toContain("https://npm.pkg.github.com");
@@ -33,7 +33,7 @@ describe("ac-8 — publishes to GitHub Packages authenticating with GITHUB_TOKEN
 
 describe("ac-9 — no-op guard: unchanged schema produces no new version", () => {
   it("decidePublish skips when the published hash matches, publishes otherwise", () => {
-    tagAc("mindset-prod/memex-building-itself/specs/spec-279/acs/ac-9");
+    tagAc("mindset-prod/memex-backstage/specs/spec-1/acs/ac-9");
 
     const currentHash = "abc123def456";
 
@@ -48,7 +48,7 @@ describe("ac-9 — no-op guard: unchanged schema produces no new version", () =>
   });
 
   it("computeSchemaHash is deterministic and content-sensitive", () => {
-    tagAc("mindset-prod/memex-building-itself/specs/spec-279/acs/ac-9");
+    tagAc("mindset-prod/memex-backstage/specs/spec-1/acs/ac-9");
 
     const a = computeSchemaHash("export const documents = pgTable('documents', {});");
     const b = computeSchemaHash("export const documents = pgTable('documents', {});");
@@ -61,7 +61,7 @@ describe("ac-9 — no-op guard: unchanged schema produces no new version", () =>
 
 describe("ac-2 — fires on the release line and publishes a pinnable, claimable version", () => {
   it("triggers on push to main + workflow_dispatch and runs the publish script", () => {
-    tagAc("mindset-prod/memex-building-itself/specs/spec-279/acs/ac-2");
+    tagAc("mindset-prod/memex-backstage/specs/spec-1/acs/ac-2");
 
     expect(workflow).toMatch(/branches:\s*\[main\]/);
     expect(workflow).toContain("workflow_dispatch:");
@@ -69,7 +69,7 @@ describe("ac-2 — fires on the release line and publishes a pinnable, claimable
   });
 
   it("uses a claimable scoped name (NOT @memex) and bumps to a valid pinnable semver", () => {
-    tagAc("mindset-prod/memex-building-itself/specs/spec-279/acs/ac-2");
+    tagAc("mindset-prod/memex-backstage/specs/spec-1/acs/ac-2");
 
     // Name is the claimable @mindset-ai scope, not the unavailable @memex (spec-89).
     expect(pkgJson.name).toBe("@mindset-ai/db-schema");


### PR DESCRIPTION
## What

The `@mindset-ai/db-schema` spec moved from `memex-building-itself` (spec-279) into the `memex-backstage` Memex (spec-1), but the `tagAc` refs in `packages/db-schema/test/*` were left pointing at the now-nonexistent `mindset-prod/memex-building-itself/specs/spec-279`. Every test emission was hitting a dead ref, so spec-1 sat at **0/11 verified** despite all 18 tests passing.

## Fix

Repoint all 18 refs across the 4 db-schema test files to `mindset-prod/memex-backstage/specs/spec-1`. Test logic unchanged — only the AC tag targets.

## Verification

Ran the full db-schema suite (18 tests, incl. the cold-DB drift-gate + out-of-workspace consumer) with a spec-1-scoped emission key: **spec-1 is now 11/11 verified (100%)** in `mindset-prod/memex-backstage`.

Sibling fix for spec-2 landed directly on the memex-backstage repo's `main`.