### PR TITLE
Release: develop → main (spec-297 activation funnel Mixpanel events)

### DIFF
--- a/packages/server/drizzle/0096_usage_events_memex_id_nullable.sql
+++ b/packages/server/drizzle/0096_usage_events_memex_id_nullable.sql
@@ -1,0 +1,16 @@
+-- spec-297 dec-1 (ac-11): usage_events.memex_id becomes NULLABLE.
+--
+-- User-scoped funnel events have no Memex by nature and now carry an honest NULL
+-- instead of a fabricated attribution: account.created (pre-Memex signup),
+-- mcp.connected (the handshake, before any tool names a Memex), and mcp.tool_called
+-- for the two Memex-agnostic tools (list_memexes / get_information). Every other
+-- mcp.tool_called still carries its real resolved memex_id.
+--
+-- This extends spec-244's original NOT NULL invariant (written before user-scoped
+-- events existed) rather than contradicting it. The FK to memexes and the
+-- ON DELETE CASCADE are unchanged; only the NOT NULL constraint is dropped.
+-- memex_id is never forwarded to Mixpanel (toMixpanelEvent omits it), so this has
+-- zero Mixpanel-side effect; the funnel keys on distinct_id throughout.
+--
+-- Additive + backward-compatible: existing rows are unaffected, no backfill needed.
+ALTER TABLE usage_events ALTER COLUMN memex_id DROP NOT NULL;

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -33,6 +33,7 @@
     "db:seed-smoke": "tsx src/db/seed-smoke.ts",
     "db:backfill-handhold": "tsx scripts/backfill-handhold-demo.ts",
     "db:backfill-default-standards": "tsx scripts/backfill-default-standards.ts",
+    "db:backfill-mixpanel-profiles": "tsx scripts/backfill-mixpanel-profiles.ts",
     "db:import-guide-content": "tsx scripts/import-guide-content.ts",
     "db:generate-whats-new": "tsx scripts/generate-whats-new.ts",
     "oauth:smoke": "node scripts/oauth-smoke.mjs",

--- a/packages/server/scripts/backfill-mixpanel-profiles.ts
+++ b/packages/server/scripts/backfill-mixpanel-profiles.ts
@@ -1,0 +1,38 @@
+// One-off backfill of Mixpanel user PROFILES (spec-297 dec-7 / ac-25).
+//
+// Sets email_domain (domain only) + org link(s) on the Mixpanel People profile for
+// EVERY existing user via /engage, so the Users tab is complete from day one — not
+// only for users active after the profile slice shipped.
+//
+// Usage:
+//   pnpm --filter @memex/server tsx scripts/backfill-mixpanel-profiles.ts
+//
+// Prereqs: same env as the server. MIXPANEL_TOKEN must be set (the same per-env
+// secret the forwarder uses) — without it this is a no-op (self-hosted instances
+// never forward; dec-5). Idempotent ($engage $set is an upsert), so safe to re-run.
+//
+// Why a script (not a route): backfill is operator-grade and touches every user, so
+// we want it triggered explicitly from a dev/prod shell, not a button click.
+
+import { backfillAllUserProfiles } from "../src/services/mixpanel-profile.js";
+
+async function main(): Promise<void> {
+  const { total, sent } = await backfillAllUserProfiles();
+  if (total === 0 && sent === 0) {
+    // eslint-disable-next-line no-console
+    console.log(
+      "[backfill-mixpanel-profiles] no MIXPANEL_TOKEN configured (or no users) — nothing forwarded.",
+    );
+    return;
+  }
+  // eslint-disable-next-line no-console
+  console.log(`[backfill-mixpanel-profiles] set profiles for ${sent}/${total} user(s) via /engage.`);
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    // eslint-disable-next-line no-console
+    console.error("[backfill-mixpanel-profiles] failed:", err);
+    process.exit(1);
+  });

--- a/packages/server/src/__regression__/apply-hand-migrations-batch.regression.test.ts
+++ b/packages/server/src/__regression__/apply-hand-migrations-batch.regression.test.ts
@@ -194,7 +194,7 @@ describe.skipIf(!CAN_RUN)(
       } finally {
         teardown();
       }
-    });
+    }, 30_000); // DB-heavy: multiple DROP/CREATE DATABASE + script runs — the 5s default is too tight (esp. under full-suite parallel load).
 
     it("ac-2: journal excluded, applied skipped, pending applies DDL + tracking insert", () => {
       tagAc(AC2);
@@ -219,6 +219,6 @@ describe.skipIf(!CAN_RUN)(
       } finally {
         teardown();
       }
-    });
+    }, 30_000); // DB-heavy: multiple DROP/CREATE DATABASE + script runs — the 5s default is too tight (esp. under full-suite parallel load).
   },
 );

--- a/packages/server/src/__regression__/mutate-coverage.endpoint.test.ts
+++ b/packages/server/src/__regression__/mutate-coverage.endpoint.test.ts
@@ -106,7 +106,11 @@ const MUTATING_MCP_TOOLS: Record<string, ToolMutation[]> = {
   create_decision: [{ entity: "decision", action: "created" }],
   update_decision: [{ entity: "decision", action: "updated" }],
   delete_decision: [{ entity: "decision", action: "updated" }], // soft-delete → status update
-  resolve_decision: [{ entity: "decision", action: "updated" }],
+  // spec-297 dec-2: resolve also emits a DISTINCT 'resolved' funnel event.
+  resolve_decision: [
+    { entity: "decision", action: "updated" },
+    { entity: "decision", action: "resolved" },
+  ],
   approve_candidate: [{ entity: "decision", action: "updated" }],
   reject_candidate: [{ entity: "decision", action: "updated" }],
   // tasks.ts

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -63,6 +63,7 @@ import { verifyAccessToken } from "./services/oauth/access-tokens.js";
 import { isDevMode, ensureDevMemberships } from "./middleware/session.js";
 import { upsertUserByEmail } from "./services/users.js";
 import { upsertSession, parseClientIp } from "./services/mcp-telemetry.js";
+import { recordMcpConnected } from "./services/funnel-events.js";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
 import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
@@ -584,6 +585,7 @@ app.all("/mcp", async (c) => {
   const userAgent = c.req.header("User-Agent") ?? null;
   const ipAddress = parseClientIp(c.req.header("X-Forwarded-For"));
   let clientInfo: unknown = null;
+  let isInitialize = false;
   if (c.req.method === "POST") {
     try {
       const cloned = c.req.raw.clone();
@@ -592,6 +594,7 @@ app.all("/mcp", async (c) => {
         params?: { clientInfo?: unknown };
       };
       if (body.method === "initialize") {
+        isInitialize = true;
         clientInfo = body.params?.clientInfo ?? null;
       }
     } catch {
@@ -612,6 +615,13 @@ app.all("/mcp", async (c) => {
     clientInfo,
     ipAddress,
   });
+
+  // spec-297 (funnel stage 3, agent connected): the MCP `initialize` handshake is
+  // the "agent connected" moment — before any tool names a Memex. Direct, advisory
+  // emission with a NULL memex_id; fired only on the handshake, not every request.
+  if (isInitialize) {
+    void recordMcpConnected(userId);
+  }
 
   const mcpServer = createMcpServer(userId, orgFilter, sessionId);
   const transport = new WebStandardStreamableHTTPServerTransport({

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -2437,9 +2437,15 @@ export const usageEvents = pgTable(
   "usage_events",
   {
     id: uuid("id").primaryKey().defaultRandom(),
-    memexId: uuid("memex_id")
-      .notNull()
-      .references(() => memexes.id, { onDelete: "cascade" }),
+    // Tenancy scope. NULLABLE (spec-297 dec-1): most rows carry their real Memex,
+    // but user-scoped funnel events that have no Memex by nature — account.created
+    // (pre-Memex signup), mcp.connected (the handshake, before any tool names a
+    // Memex), and mcp.tool_called for the Memex-agnostic tools (list_memexes /
+    // get_information) — carry an honest NULL rather than a fabricated attribution.
+    // memex_id is never forwarded to Mixpanel (toMixpanelEvent omits it), so this is
+    // purely internal bookkeeping; the funnel keys on distinct_id. Extends spec-244's
+    // original NOT NULL invariant, written before user-scoped events existed.
+    memexId: uuid("memex_id").references(() => memexes.id, { onDelete: "cascade" }),
     // WHO (the acting Memex user). Nullable: anonymous capture is a no-op so a
     // null actor only arises for system-originated backend events.
     actorUserId: uuid("actor_user_id").references(() => users.id, { onDelete: "set null" }),

--- a/packages/server/src/mcp/tools.ts
+++ b/packages/server/src/mcp/tools.ts
@@ -38,6 +38,7 @@ import { applyPhaseDescriptionOverrides } from "./phase-descriptions.js";
 import { resolveRef as resolveCanonicalRef } from "../services/resolver.js";
 import { parseRef } from "../services/refs.js";
 import { logToolCall } from "../services/mcp-telemetry.js";
+import { recordMcpToolCalled } from "../services/funnel-events.js";
 import { runToolWithSpecTraffic } from "../services/spec-traffic.js";
 import { memexContext } from "../db/connection.js";
 import { bus } from "../services/bus.js";
@@ -264,6 +265,12 @@ export function createMcpServer(
         errorMessage = formatErrorForTelemetry(err);
         return handleError(err);
       } finally {
+        // spec-297 (funnel stage 4): one mcp.tool_called usage_event per invocation
+        // (dec-3 — every call, not deduped). Direct, advisory emission, independent
+        // of the mcp_sessions audit row above. memex_id is the resolved Memex (NULL
+        // for the Memex-agnostic tools list_memexes / get_information); tool_name
+        // rides as a low-cardinality, non-PII prop. distinct_id is the acting user.
+        void recordMcpToolCalled(userId, toolName, getMemexId?.());
         if (sessionId) {
           void logToolCall({
             sessionId,

--- a/packages/server/src/routes/auth/password.ts
+++ b/packages/server/src/routes/auth/password.ts
@@ -6,6 +6,7 @@ import {
   markEmailVerified,
 } from "../../services/users.js";
 import { ensureUserMemex } from "../../services/user-namespaces.js";
+import { syncUserProfile } from "../../services/mixpanel-profile.js";
 import { hashPassword, verifyPassword, validatePasswordStrength } from "../../services/passwords.js";
 import { issueAuthToken, consumeAuthToken, AuthTokenError } from "../../services/auth-tokens.js";
 import { getEmailSender } from "../../services/email/sender.js";
@@ -70,6 +71,12 @@ password.post("/signup", async (c) => {
   // Provision the personal memex. Idempotent — safe even if createUserWithPassword was
   // called for a pre-existing SSO user (returning the same row).
   await ensureUserMemex(user.id);
+
+  // spec-297 dec-7: set the user's Mixpanel profile (email_domain + org links) so
+  // the Users tab is populated and internal users are filterable from day one.
+  // Advisory + idempotent ($engage $set is an upsert); a no-op on self-hosted
+  // instances with no MIXPANEL_TOKEN.
+  void syncUserProfile(user.id);
 
   // Issue a verification token unless the email is already verified (e.g. the user was
   // previously created via Google SSO and is now adding a password).

--- a/packages/server/src/services/bus.ts
+++ b/packages/server/src/services/bus.ts
@@ -101,7 +101,11 @@ export type ChangeAction =
   // Spec's status flips, carrying `payload: {from, to}`. Persisted by the
   // activity-log sink so per-phase durations are exactly computable from
   // transition history (documents.statusChangedAt only keeps the latest).
-  | "status_changed";
+  | "status_changed"
+  // spec-297 dec-2 — emitted alongside the generic "updated" when a decision is
+  // RESOLVED, so the activation funnel has an unambiguous step ('decision.resolved'
+  // is whitelisted into usage_events; 'decision.updated' is not).
+  | "resolved";
 
 export interface ChangeEvent {
   memexId: string;

--- a/packages/server/src/services/decision-resolved-funnel.integration.test.ts
+++ b/packages/server/src/services/decision-resolved-funnel.integration.test.ts
@@ -1,0 +1,75 @@
+// spec-297 dec-2 (ac-16 / ac-17): resolving a decision emits a DISTINCT
+// 'decision.resolved' bus action, which the back-end sink mirrors into
+// usage_events as a clean, unambiguous funnel step — separate from the generic
+// 'decision.updated' that many decision mutations share. REAL Postgres + REAL bus.
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { and, eq } from "drizzle-orm";
+import { db } from "../db/connection.js";
+import { usageEvents } from "../db/schema.js";
+import { makeTestMemex } from "./test-helpers.js";
+import { upsertUserByEmail } from "./users.js";
+import { createDocDraft } from "./documents.js";
+import { createDecision, resolveDecision } from "./decisions.js";
+import { startUsageBackendSink, _stopUsageBackendSink, isWhitelistedOutcome } from "./usage-backend-sink.js";
+
+const AC = "mindset-prod/memex-building-itself/specs/spec-297/acs";
+
+let memexId: string;
+let userId: string;
+
+beforeAll(async () => {
+  memexId = await makeTestMemex("decres");
+  const u = await upsertUserByEmail(`decres-${Date.now()}@example.com`);
+  userId = u.id;
+  startUsageBackendSink();
+});
+
+afterAll(async () => {
+  _stopUsageBackendSink();
+  await db.delete(usageEvents).where(eq(usageEvents.memexId, memexId));
+});
+
+async function waitForRows(name: string, timeoutMs = 1500) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const rows = await db
+      .select()
+      .from(usageEvents)
+      .where(and(eq(usageEvents.memexId, memexId), eq(usageEvents.name, name)));
+    if (rows.length > 0) return rows;
+    await new Promise((r) => setTimeout(r, 25));
+  }
+  return [];
+}
+
+describe("decision.resolved — distinct funnel step (spec-297 dec-2)", () => {
+  it("'decision.resolved' is whitelisted; 'decision.updated' is not (ac-17)", () => {
+    tagAc(`${AC}/ac-17`);
+    expect(isWhitelistedOutcome({ memexId, entity: "decision", action: "resolved" })).toBe(true);
+    expect(isWhitelistedOutcome({ memexId, entity: "decision", action: "updated" })).toBe(false);
+  });
+
+  it("resolving a decision lands a usage_events row named exactly 'decision.resolved' (ac-16, ac-17)", async () => {
+    tagAc(`${AC}/ac-16`);
+    tagAc(`${AC}/ac-17`);
+    const doc = await createDocDraft(memexId, "Decision funnel doc", "Purpose");
+    const dec = await createDecision(memexId, doc.id, "Ship it?");
+    await resolveDecision(memexId, dec.id, "Yes — ship it.", undefined, { actorUserId: userId });
+
+    const resolvedRows = await waitForRows("decision.resolved");
+    expect(resolvedRows.length).toBe(1);
+    expect(resolvedRows[0].name).toBe("decision.resolved");
+    expect(resolvedRows[0].source).toBe("backend");
+    expect(resolvedRows[0].actorUserId).toBe(userId);
+
+    // The shared 'decision.updated' is NOT mirrored (not whitelisted), so the
+    // funnel step is unambiguous — exactly the point of dec-2.
+    const updatedRows = await db
+      .select()
+      .from(usageEvents)
+      .where(and(eq(usageEvents.memexId, memexId), eq(usageEvents.name, "decision.updated")));
+    expect(updatedRows.length).toBe(0);
+  });
+});

--- a/packages/server/src/services/decisions.ts
+++ b/packages/server/src/services/decisions.ts
@@ -730,7 +730,15 @@ export async function resolveDecision(
   // Both writes run in one mutate() so a failure in either path emits nothing.
   const updated = await mutate(
     ctx,
-    { memexId, docId: decision.docId, entity: "decision", action: "updated" },
+    [
+      { memexId, docId: decision.docId, entity: "decision", action: "updated" },
+      // spec-297 dec-2: a DISTINCT 'resolved' action alongside the generic
+      // 'updated' (mirrors the document status_changed two-key pattern), so the
+      // activation funnel has an unambiguous "decision resolved" step. Only
+      // 'decision.resolved' is whitelisted into usage_events; 'updated' (shared by
+      // many decision mutations) stays bus-only.
+      { memexId, docId: decision.docId, entity: "decision", action: "resolved" },
+    ],
     async () => {
       const [row] = await db
         .update(decisions)

--- a/packages/server/src/services/doc-events.integration.test.ts
+++ b/packages/server/src/services/doc-events.integration.test.ts
@@ -204,19 +204,29 @@ describe("decision service events (via bus)", () => {
     });
   });
 
-  it("emits decision:updated on resolveDecision", async () => {
+  it("emits decision:updated AND a distinct decision:resolved on resolveDecision (spec-297 dec-2)", async () => {
     const dec = await createDecision(memexId, docId, "Which DB?");
 
     const events = await collectEvents(memexId, async () => {
       await resolveDecision(memexId, dec.id, "PostgreSQL");
     });
 
-    expect(events).toHaveLength(1);
+    // Two events now: the generic 'updated' (shared by many decision mutations,
+    // bus-only) PLUS a distinct 'resolved' (whitelisted into usage_events as the
+    // unambiguous funnel step). Mirrors the document status_changed two-key pattern.
+    expect(events).toHaveLength(2);
     expect(events[0]).toEqual({
       memexId: memexId,
       docId,
       entity: "decision",
       action: "updated",
+      narrative: expect.any(String),
+    });
+    expect(events[1]).toEqual({
+      memexId: memexId,
+      docId,
+      entity: "decision",
+      action: "resolved",
       narrative: expect.any(String),
     });
   });

--- a/packages/server/src/services/documents.ts
+++ b/packages/server/src/services/documents.ts
@@ -125,6 +125,23 @@ export async function createDocDraft(
   // `resolveRef`). Standards created through the dedicated React-UI flow
   // (`createStandard → nextStandardHandle`) were unaffected; MCP creates
   // route through this function and need the explicit branch.
+  // spec-297 (funnel stage 5/10, depth): tag the document.created event for SPEC
+  // docs with the Nth-spec ordinal for the acting user, so Mixpanel can build
+  // "first spec / 2nd / Nth spec" depth funnels from one event via a property
+  // filter. Counted by the same user the event keys on (distinct_id). Omitted when
+  // there's no human actor (seed / system creates) — a system spec has no funnel.
+  const funnelActor = ctx.actorUserId ?? createdByUserId ?? null;
+  let specIndex: number | undefined;
+  if (docType === "spec" && funnelActor) {
+    const [{ n }] = await db
+      .select({ n: count() })
+      .from(documents)
+      .where(and(eq(documents.createdByUserId, funnelActor), eq(documents.docType, "spec")));
+    // +1: this create will be the (existing + 1)th spec for the user. A small
+    // read-then-create race is acceptable for telemetry depth.
+    specIndex = Number(n) + 1;
+  }
+
   return mutate(
     // Attribute the create to the human (ctx.actorUserId, else the legacy
     // createdByUserId) and the surface (ctx.channel). Without this the event
@@ -132,7 +149,13 @@ export async function createDocDraft(
     { ...ctx, actorUserId: ctx.actorUserId ?? createdByUserId },
     // The new doc's id isn't known until the insert returns, so use a key
     // factory that reads it off the resolved result.
-    (created) => ({ memexId, docId: created.id, entity: "document", action: "created" }),
+    (created) => ({
+      memexId,
+      docId: created.id,
+      entity: "document",
+      action: "created",
+      ...(specIndex !== undefined ? { payload: { spec_index: specIndex } } : {}),
+    }),
     async () => {
       // spec-187 (b-38 F-3 finally reaching documents): the handle mint is a
       // racy COALESCE(MAX(...))+1 read — two concurrent creates in the same

--- a/packages/server/src/services/funnel-document-task.integration.test.ts
+++ b/packages/server/src/services/funnel-document-task.integration.test.ts
@@ -1,0 +1,110 @@
+// spec-297 (ac-3 / ac-7): the two registry/payload funnel additions.
+//  - task.created is now whitelisted, so creating a task mirrors into usage_events.
+//  - document.created carries props.spec_index — the Nth-spec ordinal for the
+//    acting user — so depth funnels come from one event via a property filter.
+// REAL Postgres + REAL bus.
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { and, eq } from "drizzle-orm";
+import { db } from "../db/connection.js";
+import { usageEvents } from "../db/schema.js";
+import { makeTestMemex } from "./test-helpers.js";
+import { upsertUserByEmail } from "./users.js";
+import { createDocDraft } from "./documents.js";
+import { createTask } from "./tasks.js";
+import { startUsageBackendSink, _stopUsageBackendSink } from "./usage-backend-sink.js";
+
+const AC = "mindset-prod/memex-building-itself/specs/spec-297/acs";
+
+let memexId: string;
+let userId: string;
+
+beforeAll(async () => {
+  memexId = await makeTestMemex("functask");
+  const u = await upsertUserByEmail(`functask-${Date.now()}@example.com`);
+  userId = u.id;
+  startUsageBackendSink();
+});
+
+afterAll(async () => {
+  _stopUsageBackendSink();
+  await db.delete(usageEvents).where(eq(usageEvents.memexId, memexId));
+});
+
+async function waitForRows(name: string, timeoutMs = 1500) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const rows = await db
+      .select()
+      .from(usageEvents)
+      .where(and(eq(usageEvents.memexId, memexId), eq(usageEvents.name, name)));
+    if (rows.length > 0) return rows;
+    await new Promise((r) => setTimeout(r, 25));
+  }
+  return [];
+}
+
+describe("task.created mirrors into usage_events (ac-3, ac-7)", () => {
+  it("creating a task lands a 'task.created' usage_events row", async () => {
+    tagAc(`${AC}/ac-3`);
+    tagAc(`${AC}/ac-7`);
+    const doc = await createDocDraft(memexId, "Task funnel doc", "Purpose", "spec", undefined, undefined, userId, { actorUserId: userId });
+    await createTask(memexId, doc.id, "First task", "Do the thing", undefined, undefined, {
+      actorUserId: userId,
+    });
+    const rows = await waitForRows("task.created");
+    expect(rows.length).toBeGreaterThanOrEqual(1);
+    expect(rows[0].source).toBe("backend");
+    expect(rows[0].actorUserId).toBe(userId);
+  });
+});
+
+describe("document.created carries spec_index = Nth spec for the user (ac-3)", () => {
+  it("the index increments per spec the user creates", async () => {
+    tagAc(`${AC}/ac-3`);
+    // Fresh user → no prior specs, so the first spec is #1, the second #2.
+    const u = await upsertUserByEmail(`specidx-${Date.now()}@example.com`);
+    const m = await makeTestMemex("specidx");
+
+    const first = await createDocDraft(m, "Spec one", "p", "spec", undefined, undefined, u.id, { actorUserId: u.id });
+    const second = await createDocDraft(m, "Spec two", "p", "spec", undefined, undefined, u.id, { actorUserId: u.id });
+
+    const firstRow = (
+      await db
+        .select()
+        .from(usageEvents)
+        .where(and(eq(usageEvents.memexId, m), eq(usageEvents.name, "document.created")))
+    ).find((r) => r.props && (r.props as Record<string, unknown>).spec_index === 1);
+    const secondRow = (
+      await db
+        .select()
+        .from(usageEvents)
+        .where(and(eq(usageEvents.memexId, m), eq(usageEvents.name, "document.created")))
+    ).find((r) => r.props && (r.props as Record<string, unknown>).spec_index === 2);
+
+    expect(firstRow, "first spec should carry spec_index 1").toBeDefined();
+    expect(secondRow, "second spec should carry spec_index 2").toBeDefined();
+    expect(firstRow?.actorUserId).toBe(u.id);
+
+    void first;
+    void second;
+    await db.delete(usageEvents).where(eq(usageEvents.memexId, m));
+  });
+
+  it("a non-spec document carries no spec_index", async () => {
+    tagAc(`${AC}/ac-3`);
+    const u = await upsertUserByEmail(`nospecidx-${Date.now()}@example.com`);
+    const doc = await createDocDraft(memexId, "A free doc", "p", "document", undefined, undefined, u.id, { actorUserId: u.id });
+    const rows = await db
+      .select()
+      .from(usageEvents)
+      .where(and(eq(usageEvents.memexId, memexId), eq(usageEvents.name, "document.created")));
+    const mine = rows.find((r) => r.actorUserId === u.id && r.props !== null);
+    // Either no props at all, or props without spec_index.
+    if (mine?.props) {
+      expect((mine.props as Record<string, unknown>).spec_index).toBeUndefined();
+    }
+    void doc;
+  });
+});

--- a/packages/server/src/services/funnel-events.integration.test.ts
+++ b/packages/server/src/services/funnel-events.integration.test.ts
@@ -1,0 +1,167 @@
+// Integration tests for the direct-path activation-funnel emitters (spec-297 dec-1)
+// — REAL Postgres + REAL bus. account.created / mcp.connected / mcp.tool_called are
+// emitted by a DIRECT recordUsageEvent() call, NOT the mutate() bus, so they must
+// land a usage_events row WITHOUT a bus ChangeEvent or an activity_log row.
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { and, count, eq, isNull } from "drizzle-orm";
+import { db } from "../db/connection.js";
+import { usageEvents, activityLog } from "../db/schema.js";
+import { makeTestMemex } from "./test-helpers.js";
+import { upsertUserByEmail, createUserWithPassword } from "./users.js";
+import { bus, type ChangeEvent } from "./bus.js";
+import {
+  recordAccountCreated,
+  recordMcpConnected,
+  recordMcpToolCalled,
+} from "./funnel-events.js";
+
+const AC = "mindset-prod/memex-building-itself/specs/spec-297/acs";
+
+let memexId: string;
+let userId: string;
+
+beforeAll(async () => {
+  memexId = await makeTestMemex("funnel");
+  const u = await upsertUserByEmail(`funnel-${Date.now()}@example.com`);
+  userId = u.id;
+});
+
+afterAll(async () => {
+  // These rows mostly carry a NULL memex_id, so delete by actor instead.
+  await db.delete(usageEvents).where(eq(usageEvents.actorUserId, userId));
+});
+
+describe("account.created + mcp.connected — NULL memex (ac-13)", () => {
+  it("records account.created with memex_id NULL, keyed on the user", async () => {
+    tagAc(`${AC}/ac-13`);
+    const row = await recordAccountCreated(userId);
+    expect(row).not.toBeNull();
+    expect(row?.name).toBe("account.created");
+    expect(row?.memexId).toBeNull();
+    expect(row?.actorUserId).toBe(userId);
+    expect(row?.source).toBe("backend");
+  });
+
+  it("records mcp.connected with memex_id NULL, keyed on the user", async () => {
+    tagAc(`${AC}/ac-13`);
+    tagAc(`${AC}/ac-2`); // scope: handshake → mcp.connected, keyed on the user UUID
+    const row = await recordMcpConnected(userId);
+    expect(row?.name).toBe("mcp.connected");
+    expect(row?.memexId).toBeNull();
+    expect(row?.actorUserId).toBe(userId);
+  });
+
+  it("records mcp.tool_called for a Memex-agnostic tool with memex_id NULL", async () => {
+    tagAc(`${AC}/ac-13`);
+    const row = await recordMcpToolCalled(userId, "list_memexes", undefined);
+    expect(row?.name).toBe("mcp.tool_called");
+    expect(row?.memexId).toBeNull();
+    expect(row?.props).toEqual({ tool_name: "list_memexes" });
+  });
+});
+
+describe("mcp.tool_called for a Memex-scoped tool carries the resolved memex_id (ac-14)", () => {
+  it("records the resolved non-null memex_id", async () => {
+    tagAc(`${AC}/ac-14`);
+    const row = await recordMcpToolCalled(userId, "get_doc", memexId);
+    expect(row?.name).toBe("mcp.tool_called");
+    expect(row?.memexId).toBe(memexId);
+    expect(row?.props).toEqual({ tool_name: "get_doc" });
+  });
+});
+
+describe("mcp.tool_called carries tool_name as a low-cardinality non-PII prop (ac-19)", () => {
+  it("sets props.tool_name to exactly the tool name", async () => {
+    tagAc(`${AC}/ac-19`);
+    const row = await recordMcpToolCalled(userId, "create_ac", memexId);
+    expect(row?.props).toEqual({ tool_name: "create_ac" });
+  });
+});
+
+describe("per-call cadence — not deduped to first-per-user (ac-18)", () => {
+  it("each invocation produces its own mcp.tool_called row", async () => {
+    tagAc(`${AC}/ac-18`);
+    tagAc(`${AC}/ac-2`); // scope: each tool call → mcp.tool_called, keyed on the user
+    const before = await db
+      .select({ n: count() })
+      .from(usageEvents)
+      .where(and(eq(usageEvents.actorUserId, userId), eq(usageEvents.name, "mcp.tool_called")));
+    await recordMcpToolCalled(userId, "get_doc", memexId);
+    await recordMcpToolCalled(userId, "get_doc", memexId);
+    await recordMcpToolCalled(userId, "get_doc", memexId);
+    const after = await db
+      .select({ n: count() })
+      .from(usageEvents)
+      .where(and(eq(usageEvents.actorUserId, userId), eq(usageEvents.name, "mcp.tool_called")));
+    expect(after[0].n - before[0].n).toBe(3);
+  });
+});
+
+describe("signup wiring — createUserWithPassword emits account.created (ac-1)", () => {
+  async function accountCreatedRows(uid: string) {
+    return db
+      .select()
+      .from(usageEvents)
+      .where(and(eq(usageEvents.actorUserId, uid), eq(usageEvents.name, "account.created")));
+  }
+
+  it("fires account.created when a brand-new user row is created", async () => {
+    tagAc(`${AC}/ac-1`);
+    const email = `signup-new-${Date.now()}@example.com`;
+    const u = await createUserWithPassword({ email, passwordHash: "x".repeat(60) });
+    const rows = await accountCreatedRows(u.id);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].memexId).toBeNull();
+    expect(rows[0].actorUserId).toBe(u.id);
+    await db.delete(usageEvents).where(eq(usageEvents.actorUserId, u.id));
+  });
+
+  it("does NOT fire account.created on the passwordless-upgrade branch", async () => {
+    tagAc(`${AC}/ac-1`);
+    // Pre-create a passwordless user (the SSO / magic-link shape), then add a password.
+    const email = `upgrade-${Date.now()}@example.com`;
+    const existing = await upsertUserByEmail(email);
+    const upgraded = await createUserWithPassword({ email, passwordHash: "y".repeat(60) });
+    expect(upgraded.id).toBe(existing.id); // same row, just a password added
+    const rows = await accountCreatedRows(existing.id);
+    expect(rows).toHaveLength(0); // upgrading an existing account is not a signup
+  });
+});
+
+describe("direct path — no bus ChangeEvent, no activity_log row (ac-15)", () => {
+  it("emits nothing on the bus and writes no activity_log row", async () => {
+    tagAc(`${AC}/ac-15`);
+    const seen: ChangeEvent[] = [];
+    const unsubscribe = bus.subscribe({}, (e) => seen.push(e));
+    const alBefore = await db.select({ n: count() }).from(activityLog);
+
+    await recordAccountCreated(userId);
+    await recordMcpConnected(userId);
+    await recordMcpToolCalled(userId, "get_doc", memexId);
+
+    // Give any (incorrectly) emitted bus event a tick to arrive.
+    await new Promise((r) => setTimeout(r, 50));
+    unsubscribe();
+
+    const alAfter = await db.select({ n: count() }).from(activityLog);
+    expect(seen, "direct-path funnel events must NOT touch the bus").toEqual([]);
+    expect(alAfter[0].n, "direct-path funnel events must NOT write activity_log").toBe(
+      alBefore[0].n,
+    );
+
+    // ...yet the usage_events rows DID land.
+    const landed = await db
+      .select({ n: count() })
+      .from(usageEvents)
+      .where(
+        and(
+          eq(usageEvents.actorUserId, userId),
+          eq(usageEvents.name, "account.created"),
+          isNull(usageEvents.memexId),
+        ),
+      );
+    expect(landed[0].n).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/packages/server/src/services/funnel-events.ts
+++ b/packages/server/src/services/funnel-events.ts
@@ -1,0 +1,64 @@
+// Activation-funnel emitters (spec-297 dec-1) — the DIRECT-path user-scoped events.
+//
+// account.created / mcp.connected / mcp.tool_called are not mutations and have no
+// Memex by nature, so they do NOT go through the mutate() bus (which would also
+// forge a memex-scoped activity_log row). They are written by a DIRECT
+// recordUsageEvent({ source:'backend' }) call instead:
+//   - account.created  — fired when a brand-new user row is created (signup).
+//   - mcp.connected     — fired on the MCP `initialize` handshake.
+//   - mcp.tool_called   — fired once per MCP tool invocation (dec-3, not deduped).
+//
+// memex_id is NULL for the first two (pre-Memex / pre-tool) and the RESOLVED Memex
+// for tool calls (NULL only for the Memex-agnostic tools list_memexes /
+// get_information). memex_id is never forwarded to Mixpanel; the funnel keys on
+// distinct_id (the user UUID). Each call is advisory — recordUsageEvent swallows
+// its own failures, so a telemetry hiccup can never disturb signup, the handshake,
+// or a tool call.
+
+import type { UsageEvent } from "../db/schema.js";
+import { recordUsageEvent } from "./usage-events.js";
+
+/**
+ * Funnel stage 1 — signup. Direct emission with a NULL Memex (the personal Memex
+ * is provisioned lazily afterwards, so at account-creation time there is none).
+ */
+export async function recordAccountCreated(userId: string): Promise<UsageEvent | null> {
+  return recordUsageEvent({
+    memexId: null,
+    actorUserId: userId,
+    name: "account.created",
+    source: "backend",
+  });
+}
+
+/**
+ * Funnel stage 3 — agent connected. Fired on the MCP `initialize` handshake, which
+ * authenticates the user before any tool names a Memex, so memex_id is NULL.
+ */
+export async function recordMcpConnected(userId: string): Promise<UsageEvent | null> {
+  return recordUsageEvent({
+    memexId: null,
+    actorUserId: userId,
+    name: "mcp.connected",
+    source: "backend",
+  });
+}
+
+/**
+ * Funnel stage 4 — first tool call. One event per invocation (dec-3). `toolName`
+ * rides as a low-cardinality, non-PII property; `memexId` is the resolved Memex
+ * (NULL only for the Memex-agnostic tools list_memexes / get_information).
+ */
+export async function recordMcpToolCalled(
+  userId: string,
+  toolName: string,
+  memexId: string | null | undefined,
+): Promise<UsageEvent | null> {
+  return recordUsageEvent({
+    memexId: memexId ?? null,
+    actorUserId: userId,
+    name: "mcp.tool_called",
+    source: "backend",
+    props: { tool_name: toolName },
+  });
+}

--- a/packages/server/src/services/mixpanel-profile.integration.test.ts
+++ b/packages/server/src/services/mixpanel-profile.integration.test.ts
@@ -1,0 +1,108 @@
+// Integration tests for the /engage profile slice (spec-297 dec-7) — REAL Postgres,
+// a fake ProfileSink (no network). Proves org-link resolution, the per-user sync,
+// and the all-users backfill.
+
+import { describe, it, expect, beforeAll } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { eq } from "drizzle-orm";
+import { db } from "../db/connection.js";
+import { namespaces, orgs, orgMemberships } from "../db/schema.js";
+import { upsertUserByEmail } from "./users.js";
+import {
+  type EngageProfile,
+  type ProfileSink,
+  getUserOrgIds,
+  syncUserProfile,
+  backfillAllUserProfiles,
+} from "./mixpanel-profile.js";
+
+const AC = "mindset-prod/memex-building-itself/specs/spec-297/acs";
+
+class FakeProfileSink implements ProfileSink {
+  readonly name = "fake-profile";
+  readonly received: EngageProfile[] = [];
+  async setProfiles(profiles: readonly EngageProfile[]): Promise<void> {
+    this.received.push(...profiles);
+  }
+}
+
+async function makeOrg(slugPrefix: string): Promise<string> {
+  const slug = `${slugPrefix}-${Date.now()}-${Math.floor(performance.now())}`;
+  const [ns] = await db.insert(namespaces).values({ slug, kind: "org" }).returning();
+  const [org] = await db.insert(orgs).values({ namespaceId: ns.id, name: "Test Org" }).returning();
+  // Set the namespace owner so it honours the owner-XOR invariant (an org
+  // namespace must have owner_org_id set) — mirrors makeTestMemexWithDevAdmin.
+  await db.update(namespaces).set({ ownerOrgId: org.id }).where(eq(namespaces.id, ns.id));
+  return org.id;
+}
+
+let orgUserId: string;
+let orgId: string;
+
+beforeAll(async () => {
+  // Use an excluded test domain (@example.com) so this namespace-less test user
+  // never trips the migration-smoke "every active user has a namespace" invariant.
+  // The mindset.ai internal-user-filter case is covered by the unit test.
+  const u = await upsertUserByEmail(`proforg-${Date.now()}@example.com`);
+  orgUserId = u.id;
+  orgId = await makeOrg("proforg");
+  await db
+    .insert(orgMemberships)
+    .values({ userId: orgUserId, orgId, role: "administrator" })
+    .onConflictDoNothing();
+});
+
+describe("getUserOrgIds — opaque active-org links (ac-24)", () => {
+  it("returns the user's active org ids", async () => {
+    tagAc(`${AC}/ac-24`);
+    const ids = await getUserOrgIds(orgUserId);
+    expect(ids).toContain(orgId);
+  });
+
+  it("returns [] for a personal-only user", async () => {
+    tagAc(`${AC}/ac-24`);
+    const u = await upsertUserByEmail(`personal-${Date.now()}@example.com`);
+    expect(await getUserOrgIds(u.id)).toEqual([]);
+  });
+});
+
+describe("syncUserProfile — sends email_domain + org links (ac-23, ac-24, ac-8, ac-9)", () => {
+  it("builds and sends the profile for a user with an org", async () => {
+    tagAc(`${AC}/ac-23`);
+    tagAc(`${AC}/ac-24`);
+    tagAc(`${AC}/ac-8`); // email_domain is the internal-user filter
+    tagAc(`${AC}/ac-9`); // org links enable per-org cohorting
+    const sink = new FakeProfileSink();
+    const payload = await syncUserProfile(orgUserId, { sink });
+    expect(payload).not.toBeNull();
+    expect(payload?.$distinct_id).toBe(orgUserId);
+    expect(payload?.$set.email_domain).toBe("example.com");
+    expect(payload?.$set.org_ids).toContain(orgId);
+    expect(sink.received).toHaveLength(1);
+  });
+
+  it("is a no-op (returns null) when no sink is configured (self-hosted)", async () => {
+    tagAc(`${AC}/ac-23`);
+    const payload = await syncUserProfile(orgUserId, { sink: null });
+    expect(payload).toBeNull();
+  });
+});
+
+describe("backfillAllUserProfiles — one profile per existing user (ac-25, ac-9)", () => {
+  it("sends a profile for every user, including our org user", async () => {
+    tagAc(`${AC}/ac-25`);
+    tagAc(`${AC}/ac-9`);
+    const sink = new FakeProfileSink();
+    const { total, sent } = await backfillAllUserProfiles({ sink });
+    expect(total).toBeGreaterThan(0);
+    expect(sent).toBe(total); // every user got a profile sent
+    const mine = sink.received.find((p) => p.$distinct_id === orgUserId);
+    expect(mine, "backfill must cover the pre-existing org user").toBeDefined();
+    expect(mine?.$set.org_ids).toContain(orgId);
+  });
+
+  it("is a no-op when no sink is configured (self-hosted)", async () => {
+    tagAc(`${AC}/ac-25`);
+    expect(await backfillAllUserProfiles({ sink: null })).toEqual({ total: 0, sent: 0 });
+  });
+});

--- a/packages/server/src/services/mixpanel-profile.test.ts
+++ b/packages/server/src/services/mixpanel-profile.test.ts
@@ -1,0 +1,98 @@
+// Unit tests for the Mixpanel /engage profile slice (spec-297 dec-7) — no network.
+
+import { describe, it, expect, vi } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import {
+  extractEmailDomain,
+  toEngagePayload,
+  configuredProfileSink,
+  MixpanelProfileSink,
+} from "./mixpanel-profile.js";
+
+const AC = "mindset-prod/memex-building-itself/specs/spec-297/acs";
+
+describe("extractEmailDomain — domain only, never the local part (ac-23)", () => {
+  it("returns the lowercased domain", () => {
+    tagAc(`${AC}/ac-23`);
+    expect(extractEmailDomain("wic@mindset.ai")).toBe("mindset.ai");
+    expect(extractEmailDomain("Someone@MEMEX.AI")).toBe("memex.ai");
+    expect(extractEmailDomain("a.b+tag@sub.example.com")).toBe("sub.example.com");
+  });
+  it("returns null for malformed addresses (never a junk property)", () => {
+    tagAc(`${AC}/ac-23`);
+    expect(extractEmailDomain("")).toBeNull();
+    expect(extractEmailDomain("noatsign")).toBeNull();
+    expect(extractEmailDomain("@nolocal.com")).toBeNull();
+    expect(extractEmailDomain("trailing@")).toBeNull();
+    expect(extractEmailDomain(null)).toBeNull();
+  });
+});
+
+describe("toEngagePayload — opaque, no PII (ac-23, ac-24)", () => {
+  it("sets email_domain (domain only) and org_ids, with no full email and no name", () => {
+    tagAc(`${AC}/ac-23`);
+    tagAc(`${AC}/ac-24`);
+    const p = toEngagePayload({
+      userId: "user-uuid-1",
+      emailDomain: "mindset.ai",
+      orgIds: ["org-1", "org-2"],
+    });
+    expect(p.$distinct_id).toBe("user-uuid-1");
+    expect(p.$ip).toBe("0"); // dec-4: no IP geolocation
+    expect(p.$set.email_domain).toBe("mindset.ai");
+    expect(p.$set.org_ids).toEqual(["org-1", "org-2"]); // ac-24: opaque org links
+
+    // ac-23 PII line: no full email address, no name anywhere in the payload.
+    const serialized = JSON.stringify(p);
+    expect(serialized).not.toContain("@");
+    expect(p.$set).not.toHaveProperty("$email");
+    expect(p.$set).not.toHaveProperty("$name");
+    expect(p.$set).not.toHaveProperty("name");
+    expect(p.$set).not.toHaveProperty("email");
+  });
+
+  it("omits email_domain when unknown but still sets org_ids (even empty)", () => {
+    tagAc(`${AC}/ac-24`);
+    const p = toEngagePayload({ userId: "u", emailDomain: null, orgIds: [] });
+    expect(p.$set).not.toHaveProperty("email_domain");
+    expect(p.$set.org_ids).toEqual([]);
+  });
+});
+
+describe("configuredProfileSink — gated solely on MIXPANEL_TOKEN (dec-5)", () => {
+  it("returns null with no/blank token, a sink with one", () => {
+    tagAc(`${AC}/ac-23`);
+    expect(configuredProfileSink({} as NodeJS.ProcessEnv)).toBeNull();
+    expect(configuredProfileSink({ MIXPANEL_TOKEN: "   " } as NodeJS.ProcessEnv)).toBeNull();
+    expect(configuredProfileSink({ MIXPANEL_TOKEN: "tok" } as NodeJS.ProcessEnv)?.name).toBe(
+      "mixpanel-profile",
+    );
+  });
+});
+
+describe("MixpanelProfileSink.send — US /engage host, token stamped (ac-24)", () => {
+  it("POSTs profiles to the US /engage endpoint with $token stamped per profile", async () => {
+    tagAc(`${AC}/ac-24`);
+    const fetchImpl = vi.fn(async () => new Response("1", { status: 200 }));
+    const sink = new MixpanelProfileSink("PROD_TOKEN", fetchImpl as unknown as typeof fetch);
+    await sink.setProfiles([
+      toEngagePayload({ userId: "u1", emailDomain: "mindset.ai", orgIds: ["o1"] }),
+    ]);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://api.mixpanel.com/engage");
+    const body = JSON.parse(init.body as string);
+    expect(body[0].$token).toBe("PROD_TOKEN");
+    expect(body[0].$distinct_id).toBe("u1");
+    expect(body[0].$set.org_ids).toEqual(["o1"]);
+  });
+
+  it("throws on non-2xx", async () => {
+    tagAc(`${AC}/ac-24`);
+    const fetchImpl = vi.fn(async () => new Response("0", { status: 500 }));
+    const sink = new MixpanelProfileSink("T", fetchImpl as unknown as typeof fetch);
+    await expect(
+      sink.setProfiles([toEngagePayload({ userId: "u", emailDomain: null, orgIds: [] })]),
+    ).rejects.toThrow(/500/);
+  });
+});

--- a/packages/server/src/services/mixpanel-profile.ts
+++ b/packages/server/src/services/mixpanel-profile.ts
@@ -1,0 +1,188 @@
+// Mixpanel People (/engage) profile slice (spec-297 dec-7).
+//
+// The platform only ever called /track before this (events, not people), so the
+// Mixpanel Users tab was empty. This module sets a small, opaque user PROFILE per
+// user so internal users are filterable and per-org cohorting works:
+//   - email_domain — the DOMAIN ONLY (never the full email, never the name —
+//     std-35 cl-31). "Real users" = exclude email_domain = 'mindset.ai'.
+//   - org_ids      — the user's org link(s) as opaque org ids (never PII).
+//
+// Same PII line and gating as the /track sink: opaque distinct_id (user UUID),
+// no PII in any property, server-side only, US host, $ip='0' (no IP geo, dec-4),
+// and forwarding gated SOLELY on the Mindset-only MIXPANEL_TOKEN — a self-hosted
+// instance with no token sends nothing (dec-5). Every send is advisory.
+
+import { and, eq } from "drizzle-orm";
+import { db, type Db } from "../db/connection.js";
+import { orgMemberships, users } from "../db/schema.js";
+
+// US ingestion host (dec-9 — EU is deliberately out of scope), People endpoint.
+const MIXPANEL_ENGAGE_URL = "https://api.mixpanel.com/engage";
+
+function log(...args: unknown[]): void {
+  // eslint-disable-next-line no-console
+  console.error("[mixpanel-profile]", ...args);
+}
+
+/**
+ * The DOMAIN part of an email, lowercased — never the local part, never the whole
+ * address. Returns null for a malformed address so we never set a junk property.
+ */
+export function extractEmailDomain(email: string | null | undefined): string | null {
+  if (!email) return null;
+  const at = email.lastIndexOf("@");
+  if (at <= 0 || at === email.length - 1) return null;
+  const domain = email.slice(at + 1).trim().toLowerCase();
+  return domain.length > 0 ? domain : null;
+}
+
+export interface UserProfileInput {
+  /** Opaque user UUID — the Mixpanel distinct_id. */
+  userId: string;
+  /** Domain only (from extractEmailDomain). Omitted from $set when null. */
+  emailDomain: string | null;
+  /** Opaque org ids. May be empty. */
+  orgIds: readonly string[];
+}
+
+/**
+ * A Mixpanel /engage profile update WITHOUT the token — the sink stamps $token at
+ * send time (mirrors how the /track sink owns the token). Carries ONLY opaque,
+ * non-PII properties: email_domain (domain only) and org_ids. No $email, no $name,
+ * no full address ever. $ip='0' suppresses IP geolocation (dec-4).
+ */
+export interface EngageProfile {
+  $distinct_id: string;
+  $ip: "0";
+  $set: Record<string, unknown>;
+}
+
+/** Map a user to a Mixpanel /engage $set payload (token-free). Pure — unit-tested. */
+export function toEngagePayload(input: UserProfileInput): EngageProfile {
+  const $set: Record<string, unknown> = {};
+  if (input.emailDomain) $set.email_domain = input.emailDomain;
+  // Always set org_ids (even empty) so a user who left every org is updated to [].
+  $set.org_ids = [...input.orgIds];
+  return {
+    $distinct_id: input.userId,
+    $ip: "0",
+    $set,
+  };
+}
+
+export interface ProfileSink {
+  readonly name: string;
+  setProfiles(profiles: readonly EngageProfile[]): Promise<void>;
+}
+
+export class MixpanelProfileSink implements ProfileSink {
+  readonly name = "mixpanel-profile";
+
+  constructor(
+    private readonly token: string,
+    private readonly fetchImpl: typeof fetch = fetch,
+  ) {}
+
+  async setProfiles(profiles: readonly EngageProfile[]): Promise<void> {
+    if (profiles.length === 0) return;
+    // Stamp the token onto each profile at send time — the wire object Mixpanel
+    // expects is { $token, $distinct_id, $ip, $set }.
+    const payload = profiles.map((p) => ({ $token: this.token, ...p }));
+    const res = await this.fetchImpl(MIXPANEL_ENGAGE_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "text/plain" },
+      body: JSON.stringify(payload),
+    });
+    if (!res.ok) {
+      throw new Error(`Mixpanel /engage returned ${res.status}`);
+    }
+  }
+}
+
+/**
+ * The configured profile sink, or null when forwarding is disabled. Gated SOLELY
+ * on MIXPANEL_TOKEN (dec-5) — no token ⇒ no sink ⇒ a self-hosted instance forwards
+ * no profiles. Mirrors usage-forwarder.configuredSink.
+ */
+export function configuredProfileSink(
+  env: NodeJS.ProcessEnv = process.env,
+  fetchImpl: typeof fetch = fetch,
+): ProfileSink | null {
+  const token = env.MIXPANEL_TOKEN?.trim();
+  if (!token) return null;
+  return new MixpanelProfileSink(token, fetchImpl);
+}
+
+/** A user's distinct active-org ids (opaque). Empty for personal-only users. */
+export async function getUserOrgIds(userId: string, conn: Db = db): Promise<string[]> {
+  const rows = await conn
+    .selectDistinct({ orgId: orgMemberships.orgId })
+    .from(orgMemberships)
+    .where(and(eq(orgMemberships.userId, userId), eq(orgMemberships.status, "active")));
+  return rows.map((r) => r.orgId);
+}
+
+/**
+ * Build + send one user's Mixpanel profile. Advisory: any failure (lookup, gate,
+ * network) is logged and swallowed so it never disturbs the calling path. No-op
+ * when no token is configured (self-hosted). Returns the payload that was sent, or
+ * null when skipped — handy for tests.
+ */
+export async function syncUserProfile(
+  userId: string,
+  opts: { sink?: ProfileSink | null; conn?: Db } = {},
+): Promise<EngageProfile | null> {
+  try {
+    const sink = opts.sink !== undefined ? opts.sink : configuredProfileSink();
+    if (!sink) return null; // capture-only / self-hosted — nothing to forward
+    const conn = opts.conn ?? db;
+    const [user] = await conn.select().from(users).where(eq(users.id, userId)).limit(1);
+    if (!user) return null;
+    const orgIds = await getUserOrgIds(userId, conn);
+    const payload = toEngagePayload({
+      userId,
+      emailDomain: extractEmailDomain(user.email),
+      orgIds,
+    });
+    await sink.setProfiles([payload]);
+    return payload;
+  } catch (err) {
+    log("syncUserProfile failed (advisory — swallowed):", err instanceof Error ? err.message : err);
+    return null;
+  }
+}
+
+/**
+ * One-off backfill (dec-7): set email_domain + org links for ALL existing users so
+ * the Mixpanel Users tab is complete from day one, not only for users active after
+ * the slice ships. Idempotent ($engage $set is an upsert) — safe to re-run. No-op
+ * when no token is configured (self-hosted). Batches the /engage sends.
+ */
+export async function backfillAllUserProfiles(
+  opts: { sink?: ProfileSink | null; conn?: Db; batchSize?: number } = {},
+): Promise<{ total: number; sent: number }> {
+  const sink = opts.sink !== undefined ? opts.sink : configuredProfileSink();
+  if (!sink) {
+    log("no MIXPANEL_TOKEN configured — capture-only, backfill is a no-op");
+    return { total: 0, sent: 0 };
+  }
+  const conn = opts.conn ?? db;
+  const allUsers = await conn.select({ id: users.id, email: users.email }).from(users);
+  const profiles = await Promise.all(
+    allUsers.map(async (u) =>
+      toEngagePayload({
+        userId: u.id,
+        emailDomain: extractEmailDomain(u.email),
+        orgIds: await getUserOrgIds(u.id, conn),
+      }),
+    ),
+  );
+  const batchSize = opts.batchSize ?? 200;
+  let sent = 0;
+  for (let i = 0; i < profiles.length; i += batchSize) {
+    const batch = profiles.slice(i, i + batchSize);
+    await sink.setProfiles(batch);
+    sent += batch.length;
+  }
+  return { total: allUsers.length, sent };
+}

--- a/packages/server/src/services/mixpanel-sink.test.ts
+++ b/packages/server/src/services/mixpanel-sink.test.ts
@@ -6,6 +6,7 @@ import type { UsageEvent } from "../db/schema.js";
 import { MixpanelSink, toMixpanelEvent } from "./mixpanel-sink.js";
 
 const AC = "mindset-prod/memex-building-itself/specs/spec-244/acs";
+const AC297 = "mindset-prod/memex-building-itself/specs/spec-297/acs";
 
 function row(over: Partial<UsageEvent> = {}): UsageEvent {
   return {
@@ -40,6 +41,19 @@ describe("toMixpanelEvent — mapping (ac-13)", () => {
     tagAc(`${AC}/ac-13`);
     const ev = toMixpanelEvent(row({ actorUserId: null }), "T");
     expect(ev.properties.distinct_id).toBeUndefined();
+  });
+
+  it("sets ip='0' so Mixpanel does not geolocate from the Cloud Run egress IP (spec-297 ac-20)", () => {
+    tagAc(`${AC297}/ac-20`);
+    tagAc(`${AC297}/ac-4`); // scope PII line: ip=0 + opaque distinct_id (user UUID), no PII
+    const ev = toMixpanelEvent(row(), "T");
+    expect(ev.properties.ip).toBe("0");
+    expect(ev.properties.distinct_id).toBe("user-1"); // opaque user id, never email/name
+    expect(JSON.stringify(ev.properties)).not.toContain("@"); // no email anywhere
+    // Holds even when the event carries props of its own (props merge after).
+    const ev2 = toMixpanelEvent(row({ props: { spec_index: 3 } }), "T");
+    expect(ev2.properties.ip).toBe("0");
+    expect(ev2.properties.spec_index).toBe(3);
   });
 });
 

--- a/packages/server/src/services/mixpanel-sink.ts
+++ b/packages/server/src/services/mixpanel-sink.ts
@@ -31,6 +31,10 @@ export function toMixpanelEvent(row: UsageEvent, token: string): MixpanelEvent {
     time: Math.floor(row.occurredAt.getTime() / 1000),
     // dec-9: server-stamped env, so int is filterable even inside a project.
     env: row.env,
+    // spec-297 dec-4: suppress Mixpanel's IP-based geolocation. We emit
+    // server-side, so the request IP is our Cloud Run egress IP — meaningless geo
+    // and incidental location data we don't want. ip="0" tells Mixpanel to skip it.
+    ip: "0",
     ...(row.props ?? {}),
   };
   // Authenticated-only capture (anonymous is a no-op), so distinct_id is the

--- a/packages/server/src/services/usage-backend-sink.integration.test.ts
+++ b/packages/server/src/services/usage-backend-sink.integration.test.ts
@@ -56,8 +56,12 @@ describe("isWhitelistedOutcome — derived from the registry (dec-8)", () => {
     expect(isWhitelistedOutcome({ memexId, entity: "document", action: "status_changed" })).toBe(
       true,
     );
-    // Not on the whitelist: a task create, or a read.
-    expect(isWhitelistedOutcome({ memexId, entity: "task", action: "created" })).toBe(false);
+    // spec-297: task.created and decision.resolved are now whitelisted funnel events.
+    expect(isWhitelistedOutcome({ memexId, entity: "task", action: "created" })).toBe(true);
+    expect(isWhitelistedOutcome({ memexId, entity: "decision", action: "resolved" })).toBe(true);
+    // Not on the whitelist: a task UPDATE, a generic decision update, or a read.
+    expect(isWhitelistedOutcome({ memexId, entity: "task", action: "updated" })).toBe(false);
+    expect(isWhitelistedOutcome({ memexId, entity: "decision", action: "updated" })).toBe(false);
     expect(isWhitelistedOutcome({ memexId, entity: "document", action: "viewed" })).toBe(false);
   });
 });
@@ -86,15 +90,16 @@ describe("back-end sink — mirrors whitelisted outcomes into usage_events (ac-1
     expect(rows[0].props).toEqual({ from: "draft", to: "specify" });
   });
 
-  it("never mirrors a non-whitelisted event (a task create)", async () => {
+  it("never mirrors a non-whitelisted event (a task UPDATE)", async () => {
     tagAc(`${AC}/ac-18`);
-    emit({ entity: "task", action: "created", docId: "spec-x" });
+    // task.created is whitelisted (spec-297); task.updated is not — use it here.
+    emit({ entity: "task", action: "updated", docId: "spec-x" });
     // Give the (would-be) async write time to land, then assert nothing did.
     await new Promise((r) => setTimeout(r, 250));
     const rows = await db
       .select()
       .from(usageEvents)
-      .where(and(eq(usageEvents.memexId, memexId), eq(usageEvents.name, "task.created")));
+      .where(and(eq(usageEvents.memexId, memexId), eq(usageEvents.name, "task.updated")));
     expect(rows.length).toBe(0);
   });
 });

--- a/packages/server/src/services/usage-events.integration.test.ts
+++ b/packages/server/src/services/usage-events.integration.test.ts
@@ -15,6 +15,7 @@ import { upsertUserByEmail } from "./users.js";
 import { recordUsageEvent } from "./usage-events.js";
 
 const AC = "mindset-prod/memex-building-itself/specs/spec-244/acs";
+const AC297 = "mindset-prod/memex-building-itself/specs/spec-297/acs";
 
 let memexId: string;
 let userId: string;
@@ -60,6 +61,44 @@ describe("recordUsageEvent — durable store, separate from the audit log (ac-1)
     });
     expect(row?.source).toBe("backend");
     expect(row?.name).toBe("document.created");
+  });
+});
+
+describe("user-scoped events with a null Memex (spec-297 dec-1)", () => {
+  it("records a null-memex event instead of silently dropping it (ac-11, ac-12)", async () => {
+    tagAc(`${AC297}/ac-11`); // migration dropped NOT NULL → a null-memex insert succeeds
+    tagAc(`${AC297}/ac-12`); // the skip-guard no longer discards intentional-null user-scoped events
+    const row = await recordUsageEvent({
+      memexId: null,
+      actorUserId: userId,
+      name: "account.created",
+      source: "backend",
+    });
+    expect(row).not.toBeNull();
+    expect(row?.memexId).toBeNull();
+    expect(row?.name).toBe("account.created");
+    expect(row?.actorUserId).toBe(userId);
+
+    // And it is a real, queryable row.
+    const found = await db
+      .select()
+      .from(usageEvents)
+      .where(and(eq(usageEvents.id, row!.id), isNull(usageEvents.memexId)));
+    expect(found).toHaveLength(1);
+
+    // Clean up — the afterAll deletes by memexId, which can't match a null row.
+    await db.delete(usageEvents).where(eq(usageEvents.id, row!.id));
+  });
+
+  it("still drops the accidental empty-string memexId (a missing required id, not a user-scoped null)", async () => {
+    tagAc(`${AC297}/ac-12`);
+    const row = await recordUsageEvent({
+      memexId: "",
+      actorUserId: userId,
+      name: "account.created",
+      source: "backend",
+    });
+    expect(row).toBeNull();
   });
 });
 

--- a/packages/server/src/services/usage-events.ts
+++ b/packages/server/src/services/usage-events.ts
@@ -41,8 +41,12 @@ export function resolveEnv(env: NodeJS.ProcessEnv = process.env): UsageEnv {
 export type UsageEventSource = "frontend" | "backend";
 
 export interface RecordUsageEventInput {
-  /** REQUIRED tenancy scope. */
-  memexId: string;
+  /**
+   * Tenancy scope. Usually the real Memex id; NULL for user-scoped funnel events
+   * that have no Memex by nature (account.created, mcp.connected, and
+   * mcp.tool_called for list_memexes / get_information) — spec-297 dec-1.
+   */
+  memexId: string | null;
   /** WHO acted (resolved Memex user id). Null for system-originated backend events. */
   actorUserId?: string | null;
   /** The registered event name, e.g. 'spec.create_clicked' or 'document.created'. */
@@ -62,19 +66,23 @@ export interface RecordUsageEventInput {
  * originating request / bus dispatch is never affected. Returns the inserted row
  * (or null when skipped / failed) — handy for tests; production callers ignore it.
  *
- * Rows with no memexId are skipped: memex_id is NOT NULL + an FK, so a blank one
- * can never produce a valid row.
+ * memex_id is nullable (spec-297 dec-1): a user-scoped event passes memexId=null
+ * explicitly and is RECORDED, not dropped. The skip-guard only rejects the
+ * accidental empty-string case (a missing-but-required id), never an intentional
+ * null — so the small, principled set of genuinely Memex-less funnel events lands.
  */
 export async function recordUsageEvent(
   input: RecordUsageEventInput,
   conn: Db = db,
 ): Promise<UsageEvent | null> {
-  if (typeof input.memexId !== "string" || input.memexId.length === 0) return null;
+  // Reject only the accidental empty string (a required id that came through
+  // blank). A deliberate null is a user-scoped event and is recorded.
+  if (input.memexId === "") return null;
   try {
     const [row] = await conn
       .insert(usageEvents)
       .values({
-        memexId: input.memexId,
+        memexId: input.memexId ?? null,
         actorUserId: input.actorUserId ?? null,
         name: input.name,
         source: input.source,

--- a/packages/server/src/services/usage-forwarder.integration.test.ts
+++ b/packages/server/src/services/usage-forwarder.integration.test.ts
@@ -2,7 +2,7 @@
 // Postgres + a FakeSink (no network). Proves the pluggable interface, at-least-once
 // delivery via the forwarded_at cursor, and no double-send.
 
-import { describe, it, expect, beforeAll, afterEach, afterAll } from "vitest";
+import { describe, it, expect, beforeAll, afterEach, afterAll, vi } from "vitest";
 import { tagAc } from "@memex-ai-ac/vitest";
 import { eq } from "drizzle-orm";
 import { db } from "../db/connection.js";
@@ -12,9 +12,15 @@ import { makeTestMemex } from "./test-helpers.js";
 import { upsertUserByEmail } from "./users.js";
 import { recordUsageEvent } from "./usage-events.js";
 import type { AnalyticsSink } from "./analytics-sink.js";
-import { drainOnce, configuredSink } from "./usage-forwarder.js";
+import {
+  drainOnce,
+  configuredSink,
+  startUsageForwarder,
+  stopUsageForwarder,
+} from "./usage-forwarder.js";
 
 const AC = "mindset-prod/memex-building-itself/specs/spec-244/acs";
+const AC297 = "mindset-prod/memex-building-itself/specs/spec-297/acs";
 
 let memexId: string;
 let userId: string;
@@ -73,6 +79,39 @@ describe("configuredSink — Mixpanel default, capture-only when unset (ac-2 / a
     expect(configuredSink({} as NodeJS.ProcessEnv)).toBeNull();
     const sink = configuredSink({ MIXPANEL_TOKEN: "tok" } as NodeJS.ProcessEnv);
     expect(sink?.name).toBe("mixpanel");
+  });
+});
+
+describe("self-hosted instances never forward to Mindset's Mixpanel (spec-297 dec-5)", () => {
+  it("no MIXPANEL_TOKEN → configuredSink null → forwarder capture-only, zero outbound /track (ac-21, ac-5)", async () => {
+    tagAc(`${AC297}/ac-21`);
+    tagAc(`${AC297}/ac-5`);
+    const fetchSpy = vi.fn(async () => new Response("1", { status: 200 }));
+
+    // The token is the SOLE gate (no hardcoded token, no phone-home default):
+    // absent or blank → no sink is constructed at all, so nothing can call fetch.
+    expect(
+      configuredSink({} as NodeJS.ProcessEnv, fetchSpy as unknown as typeof fetch),
+    ).toBeNull();
+    expect(
+      configuredSink({ MIXPANEL_TOKEN: "   " } as NodeJS.ProcessEnv, fetchSpy as unknown as typeof fetch),
+    ).toBeNull();
+
+    // With captured rows queued, starting the forwarder in the self-hosted config
+    // forwards nothing and never touches the network — capture-only.
+    await seed(3);
+    try {
+      startUsageForwarder({
+        sink: configuredSink({} as NodeJS.ProcessEnv, fetchSpy as unknown as typeof fetch),
+        intervalMs: 10,
+      });
+      await new Promise((r) => setTimeout(r, 50));
+    } finally {
+      stopUsageForwarder();
+    }
+    expect(fetchSpy, "a tokenless instance must make zero outbound /track calls").not.toHaveBeenCalled();
+    // ...yet the rows are still captured locally (undrained) — capture without forward.
+    expect((await myRows()).every((r) => r.forwardedAt === null)).toBe(true);
   });
 });
 

--- a/packages/server/src/services/users.ts
+++ b/packages/server/src/services/users.ts
@@ -4,6 +4,7 @@ import { users, orgMemberships, namespaces, orgs, memexes, userMemexAccess } fro
 import type { User } from "../db/schema.js";
 import { ForbiddenError, ValidationError } from "../types/errors.js";
 import { mutate, type Mutated } from "./mutate.js";
+import { recordAccountCreated } from "./funnel-events.js";
 
 export interface MembershipSummary {
   // Memex id (the "current memex" in tenancy contexts).
@@ -162,6 +163,10 @@ export async function createUserWithPassword(input: {
     .insert(users)
     .values({ email: normalized, passwordHash: input.passwordHash } as typeof users.$inferInsert)
     .returning();
+  // spec-297 (funnel stage 1): a brand-new account row was just created. Direct,
+  // advisory emission — only on this NEW-user branch, never on the passwordless-
+  // upgrade branch above (an existing SSO user adding a password is not a signup).
+  void recordAccountCreated(created.id);
   return created;
 }
 

--- a/packages/shared/EVENT-STANDARD.md
+++ b/packages/shared/EVENT-STANDARD.md
@@ -36,6 +36,20 @@ versa.
 
 ## Back-end outcomes (whitelisted `mutate()` events, dec-8)
 
-- `document.created` — A document (spec / standard / free-doc) was created. The confirmed outcome behind spec.create_clicked.
+- `document.created` — A document (spec / standard / free-doc) was created. The confirmed outcome behind spec.create_clicked. For `spec` docs, props.spec_index carries the Nth-spec ordinal for the acting user (spec-297), so depth funnels (2nd, 3rd, Nth spec) come from one event via a property filter.
 - `document.status_changed` — A document advanced to a new phase. props.from / props.to carry the phase handles (e.g. draft → specify).
 - `conversation_message.created` — A message was added to an in-app agent conversation.
+- `task.created` — A task was created on a Spec (funnel stage 7). Already on the bus; whitelisted into usage_events (spec-297).
+- `decision.resolved` — A decision was resolved (funnel stage 6). A distinct bus action, separate from the shared `decision.updated`, so the funnel step is unambiguous (spec-297 dec-2).
+
+## Direct-path user-scoped funnel events (spec-297 dec-1)
+
+These are emitted by a DIRECT `recordUsageEvent()` call rather than the bus, because
+they are not mutations and have no Memex by nature — so they never write an
+`activity_log` row, and they carry a NULL `memex_id` (or, for tool calls, the
+resolved one). They key on the acting user's UUID (`distinct_id`); `memex_id` is
+never forwarded to Mixpanel.
+
+- `account.created` — A new user account was created (funnel stage 1, signup). memex_id NULL (pre-Memex).
+- `mcp.connected` — An MCP client completed the `initialize` handshake (funnel stage 3, agent connected). memex_id NULL.
+- `mcp.tool_called` — An MCP tool was invoked (funnel stage 4). One event per call. props.tool_name names the tool; memex_id is the resolved Memex, NULL only for the Memex-agnostic tools (list_memexes / get_information).

--- a/packages/shared/src/usage-events-registry.ts
+++ b/packages/shared/src/usage-events-registry.ts
@@ -30,6 +30,19 @@ export interface UsageEventDef {
   readonly description: string;
   /** Where the event is born. */
   readonly source: UsageEventSource;
+  /**
+   * How a back-end event reaches usage_events (ignored for front-end events):
+   *  - 'bus' (default) — a whitelisted mutate() ChangeEvent the back-end sink
+   *    mirrors. Its name is EXACTLY `${entity}.${action}` so the dec-8 whitelist
+   *    maps 1:1, and it carries a real memex_id.
+   *  - 'direct' (spec-297 dec-1) — a DIRECT recordUsageEvent() call, NOT on the
+   *    bus, for user-scoped funnel events that are not mutations and have no Memex
+   *    by nature (account.created, mcp.connected, mcp.tool_called for the
+   *    Memex-agnostic tools). These are registered here for the source-of-truth +
+   *    Standard parity, but deliberately EXCLUDED from BACKEND_EVENT_NAMES so the
+   *    bus whitelist stays precise (a name no mutate() emits would be a dead entry).
+   */
+  readonly delivery?: "bus" | "direct";
 }
 
 // The v1 floor (spec-244 §Design — a floor, not a ceiling). Sharpened during build
@@ -92,6 +105,44 @@ export const USAGE_EVENT_REGISTRY = [
     description: "A message was added to an in-app agent conversation.",
     source: "backend",
   },
+  {
+    name: "task.created",
+    description:
+      "A task was created on a Spec (funnel stage 7). Already on the bus from the task service ({entity:'task',action:'created'}); whitelisted here so it mirrors into usage_events (spec-297).",
+    source: "backend",
+  },
+  {
+    name: "decision.resolved",
+    description:
+      "A decision was resolved (funnel stage 6). A DISTINCT bus action emitted by resolveDecision alongside the generic 'updated', so the funnel step is unambiguous (spec-297 dec-2).",
+    source: "backend",
+  },
+  // ── Direct-path user-scoped funnel events (spec-297 dec-1) ───────────────────
+  // Emitted by a DIRECT recordUsageEvent() call, NOT the bus — they are not
+  // mutations and have no Memex by nature, so they carry a NULL memex_id (account
+  // / handshake) or the resolved one (tool calls). delivery:'direct' keeps them
+  // out of the bus whitelist (BACKEND_EVENT_NAMES) while still source-of-truth.
+  {
+    name: "account.created",
+    description:
+      "A new user account was created (funnel stage 1, signup). Direct emission at user-row creation; memex_id is NULL (pre-Memex). Keyed on the new user's UUID.",
+    source: "backend",
+    delivery: "direct",
+  },
+  {
+    name: "mcp.connected",
+    description:
+      "An MCP client completed the `initialize` handshake (funnel stage 3, agent connected). Direct emission; memex_id is NULL (no tool has named a Memex yet). Keyed on the acting user's UUID.",
+    source: "backend",
+    delivery: "direct",
+  },
+  {
+    name: "mcp.tool_called",
+    description:
+      "An MCP tool was invoked (funnel stage 4). One event per call (not deduped). props.tool_name is the tool name (low-cardinality, non-PII). memex_id is the resolved Memex, NULL only for the Memex-agnostic tools (list_memexes / get_information).",
+    source: "backend",
+    delivery: "direct",
+  },
 ] as const satisfies readonly UsageEventDef[];
 
 export type RegisteredEventName = (typeof USAGE_EVENT_REGISTRY)[number]["name"];
@@ -115,9 +166,15 @@ export function isFrontendEvent(name: string): boolean {
   return BY_NAME.get(name)?.source === "frontend";
 }
 
-/** Every registered back-end outcome name (consumed by the t-3 whitelist). */
+/**
+ * Every registered back-end BUS outcome name (consumed by the t-3 whitelist).
+ * Direct-delivery events (spec-297 dec-1) are excluded — they never ride the bus,
+ * so whitelisting them would be a dead entry that could only mis-fire.
+ */
 export const BACKEND_EVENT_NAMES: readonly string[] = USAGE_EVENT_REGISTRY.filter(
-  (e) => e.source === "backend",
+  // `as const satisfies` narrows each entry to a literal type that omits the
+  // optional `delivery` field, so read it through the interface to access it.
+  (e: UsageEventDef) => e.source === "backend" && e.delivery !== "direct",
 ).map((e) => e.name);
 
 // ── Prop sanitisation (spec-244 §open-source-safe) ──────────────────────────


### PR DESCRIPTION
## Release: develop → main

Ships the queued develop work to the production line (std-21). This release contains **one feature**:

### spec-297 — instrument the activation funnel as server-side Mixpanel events (PR #233)
Emits the missing user-activation funnel stages as server-side Mixpanel events through the existing spec-244 pipeline, so soft-launch drop-off (signup → agent connected → first tool call → first Spec → decision resolved → return-day) is visible in Mixpanel:
- `account.created`, `mcp.connected`, `mcp.tool_called` (direct emission, null/resolved memex), `decision.resolved` (distinct bus action), `task.created` (whitelist), `document.created` + `spec_index`.
- `ip="0"` to suppress IP geolocation; `/engage` profile slice (`email_domain` + opaque org links) gated solely on `MIXPANEL_TOKEN` so self-hosted instances never forward; one-off backfill script.
- One additive migration (`0096`) makes `usage_events.memex_id` nullable.

## Verification already done on the develop line
- Full server suite (4085) + shared (692) green; typecheck clean. 22/25 ACs test-verified (ac-10/ac-22 deferred per dec-6).
- Deployed to **int**, post-deploy smoke green.
- int profile backfill run (27/27 users).
- ac-6 evidence chain on int: 5/6 events confirmed landing + forwarding to `/track`; `decision.resolved` mechanism-proven (same bus path as the verified `task.created`/`document.created`).

## Post-merge (prod) checklist
- [ ] Prod deploy completes + smoke green (auto on merge to main).
- [ ] Run the prod profile backfill once: `pnpm --filter @memex/server db:backfill-mixpanel-profiles` (needs prod `MIXPANEL_TOKEN`).
- [ ] Walk the std-35 evidence chain in the memex-**prod** Mixpanel project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
