### PR TITLE
fix: v4 on-accent smoke test (spec-290 follow-up)

### DIFF
--- a/packages/server/src/__smoke__/oauth-consent-allow-button.smoke.test.ts
+++ b/packages/server/src/__smoke__/oauth-consent-allow-button.smoke.test.ts
@@ -41,13 +41,18 @@ describe(`oauth consent Allow-button legibility smoke @ ${SMOKE_BASE_URL}`, () =
     expect(cssRes.status).toBe(200);
     const css = await cssRes.text();
 
-    // 3. The token must be defined for BOTH themes (dark slate-900 / light white).
-    expect(css).toMatch(/--color-on-accent:\s*15\s+23\s+42/); // dark / slate-900
-    expect(css).toMatch(/--color-on-accent:\s*255\s+255\s+255/); // light / white
+    // 3. The on-accent colour must be defined for BOTH themes (dark slate-900 /
+    //    light white). Since spec-290 (Tailwind v4, CSS-first), the per-theme
+    //    value lives on the `--ch-on-accent` CHANNEL var and the `@theme` layer
+    //    maps the token to it (`--color-on-accent: rgb(var(--ch-on-accent))`).
+    expect(css).toMatch(/--ch-on-accent:\s*15\s+23\s+42/); // dark / slate-900
+    expect(css).toMatch(/--ch-on-accent:\s*255\s+255\s+255/); // light / white
+    expect(css).toMatch(/--color-on-accent:\s*rgb\(var\(--ch-on-accent\)\)/); // token → channel
 
     // 4. Tailwind must have GENERATED the utility (the bug was that it hadn't).
+    //    v4 emits the base colour utility as `color:var(--color-on-accent)`.
     expect(css).toMatch(
-      /\.text-on-accent\{[^}]*color:rgb\(var\(--color-on-accent\)/,
+      /\.text-on-accent\{[^}]*color:var\(--color-on-accent\)/,
     );
   });
 });


### PR DESCRIPTION
Fixes the **deploy failure** after #236 merged.

## What broke
The post-deploy smoke `oauth-consent-allow-button.smoke.test.ts` asserts the deployed UI CSS defines the `on-accent` colour. spec-290 (#236) re-namespaced the channel var `--color-on-accent` → `--ch-on-accent` (the `@theme` token now maps to it) and v4 emits `.text-on-accent` as `color:var(--color-on-accent)`. The smoke still matched the v3 strings → red on the develop deploy.

The PR checks were green because they ran against the still-v3 int deployment; the deploy then pushed v4 CSS, and the smoke tail caught the stale assertion.

## Fix
Updated all four assertions to the v4 forms:
- `--ch-on-accent: 15 23 42` (dark) / `255 255 255` (light)
- `--color-on-accent: rgb(var(--ch-on-accent))` (token→channel)
- `.text-on-accent{…color:var(--color-on-accent)}`

Each verified to match the built CSS bundle locally.

## Why it was missed
The t-2 blast-radius audit was scoped to `packages/ui`; this consumer lives in `packages/server`. The only other cross-package token consumer — the guide-sdk — is self-contained (its own `--color-*` copy on `:host`) and unaffected.

## Note on the other develop failure
The `server (3)` unit-suite failure on the #236 merge is **not** from this change: my diff touches zero `packages/server` files, the `__smoke__` suite is excluded from the unit shards, and the same shard passed on the #236 PR check with the identical lockfile — a flake signature. Re-running to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)