### PR TITLE
fix: harden AC emission against fetch-stub interception (spec-302)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -300,6 +300,32 @@ jobs:
       - name: CLI installer tests
         run: pnpm --filter memex-ai test
 
+  # @memex-ai-ac/vitest — the AC-emission helper package. Runs its own suite so
+  # the package is CI-gated AND its tagged tests EMIT on every PR, keeping the
+  # helper-side ACs fresh (spec-302, plus spec-129's ac-16/ac-3). Before this job
+  # the package ran in no CI suite, so those ACs emitted only via manual local
+  # runs and went stale (spec-302 issue-1). Pure unit tests — no DB side-car.
+  ac-emit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      # spec-129: authenticate AC-emission to the prod Memex (same wiring as the
+      # server job). Value lives in the MEMEX_EMIT_KEY repo secret, never here.
+      MEMEX_EMIT_KEY: ${{ secrets.MEMEX_EMIT_KEY }}
+      # Dependabot PRs receive no repo secrets — turn emission OFF for them so no
+      # bogus unauthenticated emission is attempted (mirrors the server job).
+      MEMEX_EMIT: ${{ github.actor == 'dependabot[bot]' && 'false' || '' }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: AC-emit helper tests
+        run: pnpm --filter @memex-ai-ac/vitest test
+
   # UI E2E (Playwright). Runs against a freshly migrated DB via the webServer block
   # in playwright.config.ts — the same setup a developer uses locally.
   #

--- a/packages/ac-emit-vitest/src/emit-network.test.ts
+++ b/packages/ac-emit-vitest/src/emit-network.test.ts
@@ -273,6 +273,9 @@ const AC_302 = "mindset-prod/memex-building-itself/specs/spec-302/acs";
 describe("emit() — transport injection & module-load capture (spec-302)", () => {
   it("routes through its transport argument, never the live globalThis.fetch (ac-5)", async () => {
     tagAc(`${AC_302}/ac-5`);
+    // ac-2: the guarantee is enforced by the emitter itself (transport routing),
+    // not by each test author remembering to restore the global.
+    tagAc(`${AC_302}/ac-2`);
     const transportSpy = vi
       .fn()
       .mockResolvedValue({ ok: true, status: 204, headers: new Headers() });
@@ -290,6 +293,12 @@ describe("emit() — transport injection & module-load capture (spec-302)", () =
 
   it("capturedFetch is bound at module load and survives a later unrestored global stub (ac-6, spec-138 regression)", () => {
     tagAc(`${AC_302}/ac-6`);
+    // ac-3: this IS the regression test demonstrating the failure mode is closed.
+    tagAc(`${AC_302}/ac-3`);
+    // ac-1: the capture's stability is exactly what makes emission reliable when a
+    // test has mocked fetch — and this very test (which stubs the global below)
+    // still emits its own AC events in CI, dogfooding the guarantee.
+    tagAc(`${AC_302}/ac-1`);
     const before = capturedFetch;
 
     // Reproduce the spec-138 leak: a consumer test replaces globalThis.fetch and

--- a/packages/ac-emit-vitest/src/emit-network.test.ts
+++ b/packages/ac-emit-vitest/src/emit-network.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, afterEach, beforeEach, vi } from "vitest";
 import { emit, tagAc } from "./index.js";
+import { capturedFetch } from "./emit.js";
 
 const AC = "mindset-prod/memex-building-itself/specs/spec-115/acs";
 
@@ -261,5 +262,45 @@ describe("emit() — fail-safe on rejection (spec-129 ac-16)", () => {
     await expect(emit(baseArgs)).resolves.toBeUndefined();
     expect(warnSpy).toHaveBeenCalled();
     warnSpy.mockRestore();
+  });
+});
+
+// spec-302 — emission is immune to a test that replaces globalThis.fetch and
+// never restores it (the spec-138 silent-loss class). Production emission goes
+// through `capturedFetch` (a module-load reference passed by setup.ts to emit).
+const AC_302 = "mindset-prod/memex-building-itself/specs/spec-302/acs";
+
+describe("emit() — transport injection & module-load capture (spec-302)", () => {
+  it("routes through its transport argument, never the live globalThis.fetch (ac-5)", async () => {
+    tagAc(`${AC_302}/ac-5`);
+    const transportSpy = vi
+      .fn()
+      .mockResolvedValue({ ok: true, status: 204, headers: new Headers() });
+    const globalStub = vi
+      .fn()
+      .mockResolvedValue({ ok: true, status: 204, headers: new Headers() });
+    vi.stubGlobal("fetch", globalStub);
+
+    await emit(baseArgs, transportSpy);
+
+    // The injected transport handled the POST; the (stubbed) global was bypassed.
+    expect(transportSpy).toHaveBeenCalledOnce();
+    expect(globalStub).not.toHaveBeenCalled();
+  });
+
+  it("capturedFetch is bound at module load and survives a later unrestored global stub (ac-6, spec-138 regression)", () => {
+    tagAc(`${AC_302}/ac-6`);
+    const before = capturedFetch;
+
+    // Reproduce the spec-138 leak: a consumer test replaces globalThis.fetch and
+    // (within this test) never restores it.
+    const leakyStub = vi.fn();
+    vi.stubGlobal("fetch", leakyStub);
+
+    // The module-load capture is unaffected. setup.ts emits through THIS ref, so
+    // the leaky stub cannot intercept production emissions.
+    expect(capturedFetch).toBe(before);
+    expect(capturedFetch).not.toBe(globalThis.fetch);
+    expect(capturedFetch).not.toBe(leakyStub);
   });
 });

--- a/packages/ac-emit-vitest/src/emit.ts
+++ b/packages/ac-emit-vitest/src/emit.ts
@@ -4,6 +4,21 @@ import { buildMetadata } from "./metadata.js";
 import type { AcEventPayload, TagAcOptions } from "./types.js";
 
 /**
+ * A reference to `fetch` bound ONCE at module load — before any test can replace
+ * the global (spec-302). Production emissions (driven from `setup.ts`) send
+ * through this, so a consumer test that stubs `globalThis.fetch` and never
+ * restores it cannot silently swallow the emission POST. The setupFile that
+ * imports this module is loaded once at worker init, before any `it()` runs, so
+ * the capture is guaranteed to be the genuine `fetch`.
+ *
+ * `emit()`'s `transport` parameter defaults to the *live* `globalThis.fetch` (not
+ * this captured ref) so the emitter's own unit tests keep mocking via
+ * `vi.stubGlobal('fetch', …)`; production opts into immunity by passing
+ * `capturedFetch` explicitly.
+ */
+export const capturedFetch: typeof fetch = globalThis.fetch.bind(globalThis);
+
+/**
  * Should the helper emit at all? Controlled by MEMEX_EMIT.
  *
  * Default: true (emit). When MEMEX_EMIT is `false`, `0`, `no`, or `off`
@@ -106,8 +121,17 @@ export function buildPayload({
   return payload;
 }
 
-/** POST one emission to the Memex test-events endpoint. */
-export async function emit(args: EmitArgs): Promise<void> {
+/**
+ * POST one emission to the Memex test-events endpoint.
+ *
+ * `transport` is the HTTP sender, defaulting to the live `globalThis.fetch` so
+ * unit tests can mock it via `vi.stubGlobal`. Production callers (`setup.ts`)
+ * pass `capturedFetch` to be immune to later global-fetch replacement (spec-302).
+ */
+export async function emit(
+  args: EmitArgs,
+  transport: typeof fetch = globalThis.fetch,
+): Promise<void> {
   if (!isEmissionEnabled()) return;
 
   const url = deriveEventsUrl(args.ac_uid);
@@ -132,7 +156,7 @@ export async function emit(args: EmitArgs): Promise<void> {
   }
 
   try {
-    const res = await fetch(url, {
+    const res = await transport(url, {
       method: "POST",
       headers,
       body: JSON.stringify(payload),

--- a/packages/ac-emit-vitest/src/metadata.test.ts
+++ b/packages/ac-emit-vitest/src/metadata.test.ts
@@ -5,12 +5,39 @@ const AC = "mindset-prod/memex-building-itself/specs/spec-115/acs";
 
 describe("buildMetadata — CI auto-population", () => {
   beforeEach(() => {
-    // Clear platform signals so each test starts from a known baseline.
-    vi.stubEnv("CI", "");
-    vi.stubEnv("GITHUB_ACTIONS", "");
-    vi.stubEnv("GITLAB_CI", "");
-    vi.stubEnv("BUILDKITE", "");
-    vi.stubEnv("CIRCLECI", "");
+    // Clear platform signals AND their value-carrying vars so the ambient CI
+    // environment cannot leak into the auto-population assertions. This suite now
+    // runs in real GitHub Actions (spec-302 issue-1), where e.g. GITHUB_HEAD_REF
+    // is set to the PR branch and — because buildMetadata prefers it over
+    // GITHUB_REF_NAME — would otherwise override a stubbed branch. Each test then
+    // stubs exactly the vars it needs from a known-empty baseline.
+    for (const v of [
+      "CI",
+      "GITHUB_ACTIONS",
+      "GITLAB_CI",
+      "BUILDKITE",
+      "CIRCLECI",
+      "GITHUB_HEAD_REF",
+      "GITHUB_REF_NAME",
+      "GITHUB_SHA",
+      "GITHUB_RUN_ID",
+      "GITHUB_SERVER_URL",
+      "GITHUB_REPOSITORY",
+      "CI_COMMIT_REF_NAME",
+      "CI_COMMIT_SHA",
+      "CI_JOB_ID",
+      "CI_JOB_URL",
+      "BUILDKITE_BRANCH",
+      "BUILDKITE_COMMIT",
+      "BUILDKITE_BUILD_ID",
+      "BUILDKITE_BUILD_URL",
+      "CIRCLE_BRANCH",
+      "CIRCLE_SHA1",
+      "CIRCLE_BUILD_NUM",
+      "CIRCLE_BUILD_URL",
+    ]) {
+      vi.stubEnv(v, "");
+    }
   });
 
   afterEach(() => {

--- a/packages/ac-emit-vitest/src/setup.ts
+++ b/packages/ac-emit-vitest/src/setup.ts
@@ -12,7 +12,7 @@
  */
 import { beforeEach, afterEach } from "vitest";
 import { _setCurrentTask, _readCurrentEntries, type TaskLike } from "./index.js";
-import { emit } from "./emit.js";
+import { emit, capturedFetch } from "./emit.js";
 
 beforeEach(({ task }) => {
   _setCurrentTask(task as unknown as TaskLike);
@@ -35,9 +35,11 @@ afterEach(async ({ task }) => {
   const test_identifier = `${task.file?.name ?? "<unknown>"}::${task.name}`;
   const duration_ms = task.result?.duration ?? 0;
 
+  // Emit through the module-load-captured fetch (spec-302): immune to any test
+  // that replaced globalThis.fetch and didn't restore it.
   await Promise.all(
     entries.map(({ ac_uid, options }) =>
-      emit({ ac_uid, status: state, test_identifier, duration_ms, options }),
+      emit({ ac_uid, status: state, test_identifier, duration_ms, options }, capturedFetch),
     ),
   );
 

--- a/packages/server/src/__regression__/ci-ac-emit-job.regression.test.ts
+++ b/packages/server/src/__regression__/ci-ac-emit-job.regression.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+// spec-302 t-3 / ac-7 — the @memex-ai-ac/vitest package must have its own CI job
+// so its tagged tests EMIT on every PR. Without it the package's helper-side ACs
+// (spec-302's, and spec-129's ac-16/ac-3) emit only via manual local runs and go
+// stale (spec-302 issue-1).
+//
+// This guard deliberately lives in the SERVER suite — which IS run in CI with
+// MEMEX_EMIT_KEY — so it itself emits reliably (a guard in the un-run package
+// would have the very problem it checks for).
+const AC_7 = "mindset-prod/memex-building-itself/specs/spec-302/acs/ac-7";
+
+describe("CI runs the @memex-ai-ac/vitest package (spec-302 issue-1)", () => {
+  it("test.yml has an ac-emit job that runs the package suite, wired with the emission key (ac-7)", () => {
+    tagAc(AC_7);
+
+    const wf = readFileSync(
+      join(__dirname, "../../../../.github/workflows/test.yml"),
+      "utf8",
+    );
+
+    // A dedicated top-level job exists.
+    expect(wf).toMatch(/^ {2}ac-emit:/m);
+
+    // Bound the assertions to the ac-emit job block (up to the next job comment).
+    const start = wf.indexOf("ac-emit:");
+    const end = wf.indexOf("# UI E2E", start);
+    expect(end).toBeGreaterThan(start);
+    const jobBlock = wf.slice(start, end);
+
+    // It runs the emitter package's own suite…
+    expect(jobBlock).toContain("pnpm --filter @memex-ai-ac/vitest test");
+    // …wired with the emission key so its tagged tests actually emit.
+    expect(jobBlock).toContain("MEMEX_EMIT_KEY: ${{ secrets.MEMEX_EMIT_KEY }}");
+  });
+});


### PR DESCRIPTION
## What

Closes the silent-emission-loss class found while verifying spec-138: the AC emitter (`@memex-ai-ac/vitest`) POSTs results through **global `fetch`** in an `afterEach`, so any test that replaces `globalThis.fetch` and doesn't restore it intercepts the emission — and the fail-safe design swallows it silently, leaving the AC `untested`, **indistinguishable from "no test written."** That's exactly what hid spec-138's core ACs for its entire life.

Implements **spec-302 / dec-1 option A** (harden the emitter), realized as an **injectable transport**:

- `emit.ts` — export `capturedFetch` (a reference to `fetch` bound **once at module load**, before any test can stub the global) and add a `transport: typeof fetch = globalThis.fetch` parameter; POST via `transport`.
- `setup.ts` (the only production caller) passes `capturedFetch` → production emission is immune to later `globalThis.fetch` replacement, restored or not.
- `emit()`'s default stays the **live** global, so the package's ~12 existing fetch-stubbing unit tests pass **unchanged** — no migration, no real-network risk.

## Why this shape (vs a setter-in-emit default = captured)
Defaulting `emit()` to the captured ref would force migrating all ~12 existing tests (they'd stop being able to mock and would hit the network). Putting the capture at the production injection point (`setup.ts`) gives the identical immunity guarantee with zero test churn and less machinery. Full rationale in spec-302 §Architecture.

## Changes
- `packages/ac-emit-vitest/src/emit.ts` — `capturedFetch` export + `transport` param.
- `packages/ac-emit-vitest/src/setup.ts` — emit through `capturedFetch`.
- `packages/ac-emit-vitest/src/emit-network.test.ts` — +2 tests: ac-5 (transport routing beats the global), ac-6 (capture stability / spec-138 regression).

## Test plan
- [x] `vitest run` — 71/71 green (2 new + 12 existing fetch-stub tests unchanged)
- [x] `tsc --noEmit` clean
- [x] Wire protocol unchanged (method/headers/`Authorization: Bearer`/fail-safe identical) → `ac-emission-bootstrap` PROTOCOL CONTRACT topic needs no update
- [x] Public `index` exports unchanged; `emit()` gained an optional param (backward compatible)
- [ ] **CI emits** ac-5/ac-6 to prod (needs `MEMEX_EMIT_KEY`) — confirm the dashboard greens after this lands on a keyed run
- [ ] `dist` rebuilds on install (gitignored, `prepare`=tsc) so consumers pick up the fix — no committed dist

## Out of scope
External npm publish (0.2.0 → 0.3.0) stays **manual** per spec-302 c-1. In-repo consumers get the fix immediately via `workspace:*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)