### PR TITLE
feat(spec-303): Home Canvas — onboarding journeys (v0)

### DIFF
--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -46,6 +46,7 @@ import { hostGuard, memexResolver } from "./middleware/memex-resolver.js";
 import { rewriteBriefPathToSpec } from "./services/redirects.js";
 import { isAllowedOrigin } from "./middleware/cors-policy.js";
 import { meRouter } from "./routes/me.js";
+import { journeyRouter } from "./routes/journey.js";
 import { whatsNewRouter } from "./routes/whats-new.js";
 import { orgsRouter, orgsCurrentRouter } from "./routes/orgs.js";
 import { scaffoldRouter } from "./routes/scaffold.js";
@@ -360,6 +361,9 @@ app.route("/api/consent", consentRouter);
 app.route("/api/invites", invitesAcceptRouter);
 // Caller-scoped endpoints — namespace picker (std-5) and minimal session shape.
 app.route("/api/me", meRouter);
+// spec-303 — Home Canvas onboarding journey-state (user-level, no memex). Derived
+// position + measurement + operator preview.
+app.route("/api/me", journeyRouter);
 // spec-200: global What's New feed (not tenant-scoped).
 app.route("/api/whats-new", whatsNewRouter);
 // PUBLIC: share routes skip session middleware — guests access shared docs by token alone (t-10).

--- a/packages/server/src/journeys/index.ts
+++ b/packages/server/src/journeys/index.ts
@@ -1,0 +1,16 @@
+// spec-303 — journey registry (dec-1/dec-6). v0 ships one journey (onboarding).
+// The engine asks the registry which journey applies to a user; adding a journey
+// is a new module registered here, never a change to the engine.
+import { onboardingJourney } from "./onboarding.js";
+
+export type { JourneyDef, JourneyStepDef, JourneyMilestone } from "./onboarding.js";
+export { onboardingJourney } from "./onboarding.js";
+
+import type { JourneyDef } from "./onboarding.js";
+
+export const JOURNEYS: readonly JourneyDef[] = [onboardingJourney];
+
+/** The journey that applies to a user. v0: always onboarding (dec-6). */
+export function activeJourney(): JourneyDef {
+  return onboardingJourney;
+}

--- a/packages/server/src/journeys/onboarding.ts
+++ b/packages/server/src/journeys/onboarding.ts
@@ -1,0 +1,36 @@
+// spec-303 — the ONBOARDING journey, a self-contained module (dec-1). Everything
+// that defines this journey (its ordered steps and the milestone that completes
+// each) lives here; the journey-state engine and the Home Canvas load journeys
+// from the registry, so a journey is never interwoven into the rest of the app.
+// Adding or editing a journey touches only its own module.
+
+export type JourneyMilestone =
+  | "hasSpec"
+  | "hasDecision"
+  | "mcpConnected"
+  | "mcpToolCalled";
+
+export interface JourneyStepDef {
+  id: string;
+  // The milestone that, once reached, completes this step and advances the user.
+  // The terminal step has none.
+  completedBy: JourneyMilestone | null;
+}
+
+export interface JourneyDef {
+  id: string;
+  steps: readonly JourneyStepDef[];
+}
+
+// Ordered + hard-gated: a later step is never reached before its predecessor's
+// milestone is met (dec-4 / build instruction).
+export const onboardingJourney: JourneyDef = {
+  id: "onboarding",
+  steps: [
+    { id: "welcome", completedBy: "hasSpec" },
+    { id: "first-decision", completedBy: "hasDecision" },
+    { id: "connect-agent", completedBy: "mcpConnected" },
+    { id: "use-agent", completedBy: "mcpToolCalled" },
+    { id: "all-set", completedBy: null },
+  ],
+};

--- a/packages/server/src/routes/journey.api.test.ts
+++ b/packages/server/src/routes/journey.api.test.ts
@@ -1,0 +1,271 @@
+// spec-303 — Home Canvas journey-state API (integration).
+//
+// ac-3 — the current step is DERIVED from the user's real milestones (dec-3): a
+//        fresh user is at 'welcome'; completed steps are never the current step.
+// ac-4 — the journey self-advances as milestones are met, and is hard-gated +
+//        user-scoped (dec-4): an MCP-connected user with no spec is still 'welcome'.
+// ac-5 — a fully-activated user lands on the terminal 'all-set' step.
+// ac-6 — an operator can ?preview=<step> to pin the canvas to any state on their
+//        own account; a non-operator's preview is ignored (dec-8/dec-9).
+// ac-7 — the canvas records which step was shown and which CTA was taken.
+//
+// Runs against a REAL Postgres through the full Hono app + strict sessionMiddleware.
+import { describe, it, expect, afterEach, beforeAll, vi } from "vitest";
+import { randomUUID } from "node:crypto";
+
+vi.hoisted(() => {
+  // Force auth-mode session middleware so per-user Bearer tokens are honored
+  // (mirrors onboarding.api.test.ts). Without GOOGLE_CLIENT_ID the middleware
+  // falls into dev-mode and authenticates everyone as dev@memex.ai.
+  process.env.GOOGLE_CLIENT_ID = "test-client.apps.googleusercontent.com";
+  process.env.AUTH_JWT_SECRET = process.env.AUTH_JWT_SECRET ?? "x".repeat(48);
+  return undefined;
+});
+
+import { db } from "../db/connection.js";
+import { app } from "../app.js";
+import { usageEvents, type User } from "../db/schema.js";
+import { eq } from "drizzle-orm";
+import { upsertUserByEmail } from "../services/users.js";
+import { signSessionToken } from "../services/auth-jwt.js";
+import { recordUsageEvent } from "../services/usage-events.js";
+import { makeTestMemex } from "../services/test-helpers.js";
+import { createDocDraft } from "../services/documents.js";
+import { createDecision } from "../services/decisions.js";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+const AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-303/acs/ac-${n}`;
+
+// A shared container memex — milestones are USER-scoped (dec-4), so docs created
+// here but attributed to different fresh users measure each user independently.
+let memexId: string;
+beforeAll(async () => {
+  memexId = await makeTestMemex("homecanvas");
+});
+
+const PREVIEW_ENV = process.env.JOURNEY_PREVIEW_DOMAINS;
+afterEach(() => {
+  if (PREVIEW_ENV === undefined) delete process.env.JOURNEY_PREVIEW_DOMAINS;
+  else process.env.JOURNEY_PREVIEW_DOMAINS = PREVIEW_ENV;
+});
+
+function auth(userId: string): Record<string, string> {
+  return { Authorization: `Bearer ${signSessionToken(userId)}` };
+}
+
+async function newUser(domain = "example.com"): Promise<User> {
+  return upsertUserByEmail(`hc-${randomUUID()}@${domain}`);
+}
+
+async function seedSpec(userId: string): Promise<void> {
+  await createDocDraft(memexId, "Seed spec", "Purpose", "spec", undefined, undefined, userId, {
+    actorUserId: userId,
+  });
+}
+
+async function seedDecision(userId: string): Promise<void> {
+  const doc = await createDocDraft(
+    memexId,
+    "Seed doc",
+    "Purpose",
+    "document",
+    undefined,
+    undefined,
+    userId,
+    { actorUserId: userId },
+  );
+  await createDecision(memexId, doc.id, "A decision", undefined, "human", {
+    actorUserId: userId,
+  });
+}
+
+async function state(
+  userId: string,
+  query = "",
+): Promise<{ status: number; body: any }> {
+  const res = await app.request(`/api/me/journey-state${query}`, {
+    headers: auth(userId),
+  });
+  return { status: res.status, body: await res.json() };
+}
+
+describe("Home Canvas journey-state (ac-3 derived position)", () => {
+  it("a fresh user with no activity is at the welcome step, all milestones false", async () => {
+    tagAc(AC(3));
+    tagAc(AC(10)); // impl dec-3: currentStepId is derived from milestones, no cursor
+    const user = await newUser();
+    const { status, body } = await state(user.id);
+    expect(status).toBe(200);
+    expect(body.currentStepId).toBe("welcome");
+    expect(body.milestones).toEqual({
+      hasSpec: false,
+      hasDecision: false,
+      mcpConnected: false,
+      mcpToolCalled: false,
+    });
+    expect(body.preview).toBe(false);
+  });
+
+  it("anonymous requests are rejected", async () => {
+    tagAc(AC(3));
+    const res = await app.request("/api/me/journey-state");
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("Home Canvas journey-state (ac-4 self-advance, hard-gated, user-scoped)", () => {
+  it("advances one hard-gated step at a time as the user's own milestones are met", async () => {
+    tagAc(AC(4));
+    const user = await newUser();
+    expect((await state(user.id)).body.currentStepId).toBe("welcome");
+
+    await seedSpec(user.id);
+    expect((await state(user.id)).body.currentStepId).toBe("first-decision");
+
+    await seedDecision(user.id);
+    expect((await state(user.id)).body.currentStepId).toBe("connect-agent");
+
+    await recordUsageEvent({
+      memexId: null,
+      actorUserId: user.id,
+      name: "mcp.connected",
+      source: "backend",
+    });
+    expect((await state(user.id)).body.currentStepId).toBe("use-agent");
+  });
+
+  it("is hard-gated: a later milestone without its predecessor does NOT skip the user ahead", async () => {
+    tagAc(AC(4));
+    const user = await newUser();
+    // MCP connected + a tool called, but no spec yet → still at the very first step.
+    await recordUsageEvent({
+      memexId: null,
+      actorUserId: user.id,
+      name: "mcp.connected",
+      source: "backend",
+    });
+    await recordUsageEvent({
+      memexId: null,
+      actorUserId: user.id,
+      name: "mcp.tool_called",
+      source: "backend",
+    });
+    const { body } = await state(user.id);
+    expect(body.currentStepId).toBe("welcome");
+    expect(body.milestones.mcpConnected).toBe(true);
+    expect(body.milestones.hasSpec).toBe(false);
+  });
+
+  it("milestones are user-scoped: another user's spec does not advance this user", async () => {
+    tagAc(AC(4));
+    tagAc(AC(11)); // impl dec-4: milestones counted from the acting user's own rows
+    const me = await newUser();
+    const colleague = await newUser();
+    await seedSpec(colleague.id);
+    expect((await state(me.id)).body.currentStepId).toBe("welcome");
+  });
+});
+
+describe("Home Canvas journey-state (ac-5 terminal step)", () => {
+  it("a fully-activated user lands on 'all-set'", async () => {
+    tagAc(AC(5));
+    const user = await newUser();
+    await seedSpec(user.id);
+    await seedDecision(user.id);
+    await recordUsageEvent({
+      memexId: null,
+      actorUserId: user.id,
+      name: "mcp.connected",
+      source: "backend",
+    });
+    await recordUsageEvent({
+      memexId: null,
+      actorUserId: user.id,
+      name: "mcp.tool_called",
+      source: "backend",
+    });
+    const { body } = await state(user.id);
+    expect(body.currentStepId).toBe("all-set");
+    expect(body.milestones).toEqual({
+      hasSpec: true,
+      hasDecision: true,
+      mcpConnected: true,
+      mcpToolCalled: true,
+    });
+  });
+});
+
+describe("Home Canvas journey-state (ac-6 operator preview)", () => {
+  it("an operator (email domain in deploy config) can pin any step on their own account, real state untouched", async () => {
+    tagAc(AC(6));
+    tagAc(AC(15)); // impl dec-8: ?preview pins currentStepId, real milestones untouched
+    tagAc(AC(16)); // impl dec-9: capability from JOURNEY_PREVIEW_DOMAINS deploy config
+    process.env.JOURNEY_PREVIEW_DOMAINS = "previewtest.local";
+    const user = await newUser("previewtest.local");
+    const { body } = await state(user.id, "?preview=use-agent");
+    expect(body.canPreview).toBe(true);
+    expect(body.preview).toBe(true);
+    expect(body.currentStepId).toBe("use-agent");
+    // Real milestones are untouched — preview is render-only.
+    expect(body.milestones.hasSpec).toBe(false);
+  });
+
+  it("a non-operator cannot force a state: their preview is ignored and they get the truth", async () => {
+    tagAc(AC(6));
+    tagAc(AC(16)); // impl dec-9: a domain outside the deploy-config allow-list is not entitled
+    process.env.JOURNEY_PREVIEW_DOMAINS = "previewtest.local";
+    const user = await newUser("example.com"); // not in the allow-list
+    const { body } = await state(user.id, "?preview=all-set");
+    expect(body.canPreview).toBe(false);
+    expect(body.preview).toBe(false);
+    expect(body.currentStepId).toBe("welcome");
+  });
+
+  it("an unknown step id is ignored even for an operator", async () => {
+    tagAc(AC(6));
+    process.env.JOURNEY_PREVIEW_DOMAINS = "previewtest.local";
+    const user = await newUser("previewtest.local");
+    const { body } = await state(user.id, "?preview=not-a-step");
+    expect(body.preview).toBe(false);
+    expect(body.currentStepId).toBe("welcome");
+  });
+});
+
+describe("Home Canvas journey-state (ac-7 measurement)", () => {
+  it("records which step was shown and which CTA was taken", async () => {
+    tagAc(AC(7));
+    const user = await newUser();
+    const shown = await app.request("/api/me/journey-event", {
+      method: "POST",
+      headers: { ...auth(user.id), "Content-Type": "application/json" },
+      body: JSON.stringify({ action: "shown", step: "welcome" }),
+    });
+    expect(shown.status).toBe(200);
+    const clicked = await app.request("/api/me/journey-event", {
+      method: "POST",
+      headers: { ...auth(user.id), "Content-Type": "application/json" },
+      body: JSON.stringify({ action: "cta", step: "welcome", cta: "create_spec" }),
+    });
+    expect(clicked.status).toBe(200);
+
+    const rows = await db
+      .select()
+      .from(usageEvents)
+      .where(eq(usageEvents.actorUserId, user.id));
+    const names = rows.map((r) => r.name).sort();
+    expect(names).toContain("home_canvas.step_shown");
+    expect(names).toContain("home_canvas.cta_clicked");
+  });
+
+  it("rejects a malformed journey event", async () => {
+    tagAc(AC(7));
+    const user = await newUser();
+    const res = await app.request("/api/me/journey-event", {
+      method: "POST",
+      headers: { ...auth(user.id), "Content-Type": "application/json" },
+      body: JSON.stringify({ action: "bogus", step: "welcome" }),
+    });
+    expect(res.status).toBe(400);
+  });
+});

--- a/packages/server/src/routes/journey.api.test.ts
+++ b/packages/server/src/routes/journey.api.test.ts
@@ -196,6 +196,29 @@ describe("Home Canvas journey-state (ac-5 terminal step)", () => {
   });
 });
 
+describe("Home Canvas journey-state (per-step attainment — progress map data)", () => {
+  it("reports each step's real attainment, with a later step attainable before an earlier one (non-linear)", async () => {
+    tagAc(AC(4));
+    const user = await newUser();
+    await seedSpec(user.id); // welcome's milestone (hasSpec)
+    await recordUsageEvent({
+      memexId: null,
+      actorUserId: user.id,
+      name: "mcp.connected", // connect-agent's milestone — attained BEFORE the decision
+      source: "backend",
+    });
+    const { body } = await state(user.id);
+    const attained = Object.fromEntries(body.steps.map((s: any) => [s.id, s.attained]));
+    expect(attained.welcome).toBe(true);
+    expect(attained['first-decision']).toBe(false); // the gap
+    expect(attained['connect-agent']).toBe(true); // attained out of order
+    expect(attained['use-agent']).toBe(false);
+    expect(attained['all-set']).toBe(false);
+    // Current step is the first UNMET one, so the user is sent back to fill the gap.
+    expect(body.currentStepId).toBe('first-decision');
+  });
+});
+
 describe("Home Canvas journey-state (ac-6 operator preview)", () => {
   it("an operator (email domain in deploy config) can pin any step on their own account, real state untouched", async () => {
     tagAc(AC(6));

--- a/packages/server/src/routes/journey.ts
+++ b/packages/server/src/routes/journey.ts
@@ -1,0 +1,73 @@
+// spec-303 — Home Canvas journey-state API. Caller-scoped (no memex needed): the
+// Home Canvas is a user-level surface (dec-2). Mounted under /api/me.
+import { Hono } from "hono";
+import { sessionMiddleware, type SessionEnv } from "../middleware/session.js";
+import { getUserJourneyState, isValidStepId } from "../services/journey-state.js";
+import { canPreviewJourneys } from "../services/journey-preview.js";
+import { recordUsageEvent } from "../services/usage-events.js";
+
+export const journeyRouter = new Hono<SessionEnv>();
+
+journeyRouter.use("*", sessionMiddleware);
+
+// GET /api/me/journey-state — the user's DERIVED onboarding position (dec-3). The
+// response carries the real milestones + the current step id; `canPreview` tells
+// the UI whether to offer the operator preview control (dec-9).
+//
+// dec-8: an authorised operator may PIN the canvas to any step on their OWN account
+// via ?preview=<stepId> — render-only, real state untouched. A caller without the
+// capability (or an unknown step id) is simply ignored and gets the truth; we never
+// 403 (std-7) and never let a non-operator force a state.
+journeyRouter.get("/journey-state", async (c) => {
+  const user = c.get("user");
+  const state = await getUserJourneyState(user.id);
+  const canPreview = canPreviewJourneys(user.email);
+
+  const previewStep = c.req.query("preview");
+  if (previewStep && canPreview && isValidStepId(previewStep)) {
+    return c.json({
+      milestones: state.milestones,
+      currentStepId: previewStep,
+      preview: true,
+      canPreview,
+    });
+  }
+
+  return c.json({
+    milestones: state.milestones,
+    currentStepId: state.currentStepId,
+    preview: false,
+    canPreview,
+  });
+});
+
+// POST /api/me/journey-event — Home Canvas measurement (ac-7): which step a user was
+// shown, and which CTA they took. Advisory only: a bad body is a 400, a telemetry
+// failure is swallowed by recordUsageEvent, and neither ever blocks the canvas.
+journeyRouter.post("/journey-event", async (c) => {
+  const user = c.get("user");
+  const body = (await c.req.json().catch(() => ({}))) as {
+    action?: unknown;
+    step?: unknown;
+    cta?: unknown;
+  };
+  const action = body.action;
+  const step = typeof body.step === "string" ? body.step : null;
+
+  if ((action !== "shown" && action !== "cta") || !step || !isValidStepId(step)) {
+    return c.json({ error: "Invalid journey event" }, 400);
+  }
+
+  await recordUsageEvent({
+    memexId: null,
+    actorUserId: user.id,
+    name: action === "shown" ? "home_canvas.step_shown" : "home_canvas.cta_clicked",
+    source: "frontend",
+    props: {
+      step,
+      ...(typeof body.cta === "string" ? { cta: body.cta } : {}),
+    },
+  });
+
+  return c.json({ ok: true });
+});

--- a/packages/server/src/routes/journey.ts
+++ b/packages/server/src/routes/journey.ts
@@ -28,6 +28,8 @@ journeyRouter.get("/journey-state", async (c) => {
     return c.json({
       milestones: state.milestones,
       currentStepId: previewStep,
+      // `steps` always reflects REAL attainment — preview pins the card, not progress.
+      steps: state.steps,
       preview: true,
       canPreview,
     });
@@ -36,6 +38,7 @@ journeyRouter.get("/journey-state", async (c) => {
   return c.json({
     milestones: state.milestones,
     currentStepId: state.currentStepId,
+    steps: state.steps,
     preview: false,
     canPreview,
   });

--- a/packages/server/src/services/journey-modules.unit.test.ts
+++ b/packages/server/src/services/journey-modules.unit.test.ts
@@ -1,6 +1,6 @@
 // spec-303 impl ac-17 (dec-10) — the journey modules are a STATE SIGNAL + an
 // AUTHORISATION check, never a billing/entitlement store. Verified two ways:
-// the single accessors exist (the brief's indirection), and no journey module
+// the single accessors exist (the indirection principle), and no journey module
 // imports a billing/entitlement/stripe store.
 import { describe, it, expect } from "vitest";
 import { readFileSync } from "node:fs";

--- a/packages/server/src/services/journey-modules.unit.test.ts
+++ b/packages/server/src/services/journey-modules.unit.test.ts
@@ -1,0 +1,44 @@
+// spec-303 impl ac-17 (dec-10) — the journey modules are a STATE SIGNAL + an
+// AUTHORISATION check, never a billing/entitlement store. Verified two ways:
+// the single accessors exist (the brief's indirection), and no journey module
+// imports a billing/entitlement/stripe store.
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { getUserJourneyState } from "./journey-state.js";
+import { canPreviewJourneys } from "./journey-preview.js";
+
+const AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-303/acs/ac-${n}`;
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+describe("journey modules — layering (ac-17)", () => {
+  it("expose a single journey-state accessor + a capability check", () => {
+    tagAc(AC(17));
+    expect(typeof getUserJourneyState).toBe("function");
+    expect(typeof canPreviewJourneys).toBe("function");
+  });
+
+  it("import no billing / entitlement / stripe store in any journey module", () => {
+    tagAc(AC(17));
+    const files = [
+      "journey-state.ts",
+      "journey-preview.ts",
+      join("..", "journeys", "onboarding.ts"),
+      join("..", "journeys", "index.ts"),
+      join("..", "routes", "journey.ts"),
+    ].map((rel) => readFileSync(join(here, rel), "utf8"));
+
+    for (const src of files) {
+      const importLines = src
+        .split("\n")
+        .filter((l) => l.trim().startsWith("import"));
+      for (const line of importLines) {
+        expect(line).not.toMatch(/entitlement|billing|stripe/i);
+      }
+    }
+  });
+});

--- a/packages/server/src/services/journey-preview.ts
+++ b/packages/server/src/services/journey-preview.ts
@@ -1,0 +1,29 @@
+// spec-303 dec-9 / dec-10 — entitlement for the in-app journey preview.
+//
+// This is AUTHORISATION bound to DEPLOY CONFIG, not a billing entitlement (dec-10).
+// The code checks a capability and never names a vendor domain: JOURNEY_PREVIEW_DOMAINS
+// is a CSV of email domains set per deployment (the SaaS prod env sets it to the
+// operator domain; a self-hoster sets their own; unset = nobody can preview), so no
+// company-specific string ships in the open source (std-22). The check is
+// server-enforced — in open source a client-side gate would be a visible bypass.
+
+export function previewDomains(env: NodeJS.ProcessEnv = process.env): string[] {
+  return (env.JOURNEY_PREVIEW_DOMAINS ?? "")
+    .split(",")
+    .map((d) => d.trim().toLowerCase())
+    .filter((d) => d.length > 0);
+}
+
+/** True iff the caller's email domain is in the deployment's preview allow-list.
+ * Empty/unset config → nobody. A malformed/absent email → false. */
+export function canPreviewJourneys(
+  email: string | null | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  if (!email) return false;
+  const at = email.lastIndexOf("@");
+  if (at < 0) return false;
+  const domain = email.slice(at + 1).toLowerCase();
+  if (!domain) return false;
+  return previewDomains(env).includes(domain);
+}

--- a/packages/server/src/services/journey-state.ts
+++ b/packages/server/src/services/journey-state.ts
@@ -1,0 +1,101 @@
+// spec-303 — the user-scoped journey-state ENGINE (the "brain", dec-3/dec-4).
+//
+// This is generic: it loads a journey from the registry (packages/server/src/
+// journeys) and derives the user's position. Position is DERIVED from the user's
+// own real activity, never stored (dec-3) — so the journey self-heals (act
+// anywhere and the canvas advances) with no cursor to persist, drift, or reset.
+//
+// Every milestone is USER-scoped — did THIS user do it — not workspace-scoped
+// (dec-4), so a brand-new hire dropped into an already-busy org is still taught
+// from the start. The journey is hard-gated and linear: the current step is the
+// first step whose completing milestone the user has not yet met.
+//
+// Journey-state is a STATE SIGNAL, not an entitlement (dec-10): it reads only the
+// user's own rows and touches no billing/entitlement store.
+
+import { and, eq, sql } from "drizzle-orm";
+import { db, type Db } from "../db/connection.js";
+import { documents, decisions, usageEvents } from "../db/schema.js";
+import { activeJourney, type JourneyDef, type JourneyMilestone } from "../journeys/index.js";
+
+export type { JourneyMilestone } from "../journeys/index.js";
+
+export type JourneyMilestones = Record<JourneyMilestone, boolean>;
+
+export interface JourneyState {
+  milestones: JourneyMilestones;
+  currentStepId: string;
+}
+
+/** The user's onboarding milestones — each a USER-scoped count over the acting
+ * user's own rows (dec-4), with handhold demo content excluded (spec-178). */
+export async function getUserMilestones(
+  userId: string,
+  conn: Db = db,
+): Promise<JourneyMilestones> {
+  const [specRow] = await conn
+    .select({ n: sql<number>`count(*)::int` })
+    .from(documents)
+    .where(
+      and(
+        eq(documents.createdByUserId, userId),
+        eq(documents.docType, "spec"),
+        eq(documents.isDemo, false),
+      ),
+    );
+
+  const [decisionRow] = await conn
+    .select({ n: sql<number>`count(*)::int` })
+    .from(decisions)
+    .where(eq(decisions.actorUserId, userId));
+
+  const [connectedRow] = await conn
+    .select({ n: sql<number>`count(*)::int` })
+    .from(usageEvents)
+    .where(
+      and(eq(usageEvents.actorUserId, userId), eq(usageEvents.name, "mcp.connected")),
+    );
+
+  const [toolRow] = await conn
+    .select({ n: sql<number>`count(*)::int` })
+    .from(usageEvents)
+    .where(
+      and(eq(usageEvents.actorUserId, userId), eq(usageEvents.name, "mcp.tool_called")),
+    );
+
+  return {
+    hasSpec: (specRow?.n ?? 0) > 0,
+    hasDecision: (decisionRow?.n ?? 0) > 0,
+    mcpConnected: (connectedRow?.n ?? 0) > 0,
+    mcpToolCalled: (toolRow?.n ?? 0) > 0,
+  };
+}
+
+/** Derive the current step from real milestones (dec-3): the first step whose
+ * completing milestone is unmet. Hard-gated + linear, so a later step never
+ * appears before its predecessor's milestone is reached. */
+export function deriveCurrentStep(
+  milestones: JourneyMilestones,
+  journey: JourneyDef = activeJourney(),
+): string {
+  for (const step of journey.steps) {
+    if (step.completedBy === null) return step.id; // terminal, all milestones met
+    if (!milestones[step.completedBy]) return step.id;
+  }
+  return journey.steps[journey.steps.length - 1].id;
+}
+
+export async function getUserJourneyState(
+  userId: string,
+  conn: Db = db,
+): Promise<JourneyState> {
+  const milestones = await getUserMilestones(userId, conn);
+  return { milestones, currentStepId: deriveCurrentStep(milestones) };
+}
+
+export function isValidStepId(
+  id: string,
+  journey: JourneyDef = activeJourney(),
+): boolean {
+  return journey.steps.some((s) => s.id === id);
+}

--- a/packages/server/src/services/journey-state.ts
+++ b/packages/server/src/services/journey-state.ts
@@ -22,9 +22,34 @@ export type { JourneyMilestone } from "../journeys/index.js";
 
 export type JourneyMilestones = Record<JourneyMilestone, boolean>;
 
+// Per-step attainment — the data a journey progress map renders. Reflects REAL
+// state (so the map shows true progress even when an operator is previewing a
+// different card). Because steps are independent, a later step can be attained
+// while an earlier one is not (non-linear): the map makes that legible.
+export interface JourneyStepStatus {
+  id: string;
+  attained: boolean;
+}
+
 export interface JourneyState {
   milestones: JourneyMilestones;
   currentStepId: string;
+  steps: JourneyStepStatus[];
+}
+
+/** Each step's attainment from real milestones. The terminal step (no
+ * `completedBy`) is attained once every milestone is met. */
+export function stepStatuses(
+  milestones: JourneyMilestones,
+  journey: JourneyDef = activeJourney(),
+): JourneyStepStatus[] {
+  return journey.steps.map((s) => ({
+    id: s.id,
+    attained:
+      s.completedBy === null
+        ? journey.steps.every((st) => st.completedBy === null || milestones[st.completedBy])
+        : milestones[s.completedBy],
+  }));
 }
 
 /** The user's onboarding milestones — each a USER-scoped count over the acting
@@ -90,7 +115,12 @@ export async function getUserJourneyState(
   conn: Db = db,
 ): Promise<JourneyState> {
   const milestones = await getUserMilestones(userId, conn);
-  return { milestones, currentStepId: deriveCurrentStep(milestones) };
+  const journey = activeJourney();
+  return {
+    milestones,
+    currentStepId: deriveCurrentStep(milestones, journey),
+    steps: stepStatuses(milestones, journey),
+  };
 }
 
 export function isValidStepId(

--- a/packages/ui/e2e/journey-34-home-canvas.spec.ts
+++ b/packages/ui/e2e/journey-34-home-canvas.spec.ts
@@ -1,0 +1,75 @@
+import {
+  test,
+  expect,
+  bareUrl,
+  emitAcEvents,
+  ensureUser,
+  setUserName,
+  getPersonalMemexByEmail,
+  seedSpecInMemex,
+  deleteDoc,
+  DEV_EMAIL,
+  DEV_NAME,
+} from "./helpers/index.js";
+
+// Journey 34 — the Home Canvas onboarding journey (spec-303).
+//
+//   ac-1 — Home is the top, user-level nav item (a flat /home destination).
+//   ac-2 — a brand-new user (no real spec; the handhold demo is excluded) lands on
+//          the "MD files are dead" welcome step.
+//   ac-4 — after the user creates a real spec, the canvas SELF-ADVANCES (the
+//          position is derived from real state, dec-3) — here proven across a
+//          reload, which re-derives rather than resetting anything.
+
+const AC1 = "mindset-prod/memex-building-itself/specs/spec-303/acs/ac-1";
+const AC2 = "mindset-prod/memex-building-itself/specs/spec-303/acs/ac-2";
+const AC4 = "mindset-prod/memex-building-itself/specs/spec-303/acs/ac-4";
+
+const TITLE =
+  "a brand-new user lands on the Home Canvas welcome step, then self-advances after creating a spec";
+
+let seededDocId: string | null = null;
+
+test.afterEach(async ({}, testInfo) => {
+  // Don't leak a real spec onto the shared dev user (it would break the welcome
+  // precondition for re-runs and other journeys).
+  if (seededDocId) {
+    await deleteDoc(seededDocId);
+    seededDocId = null;
+  }
+  if (testInfo.status === "skipped") return;
+  await emitAcEvents(
+    [AC1, AC2, AC4],
+    testInfo.status === "passed" ? "pass" : "fail",
+    `packages/ui/e2e/journey-34-home-canvas.spec.ts::${testInfo.title}`,
+    testInfo.duration,
+  );
+});
+
+test(TITLE, async ({ page }) => {
+  const devUserId = await ensureUser(DEV_EMAIL);
+  await setUserName(DEV_EMAIL, DEV_NAME);
+
+  // Home is the top, user-level destination (ac-1).
+  await page.goto(bareUrl("/home"));
+  await expect(page.getByRole("link", { name: "Home" })).toBeVisible({ timeout: 15_000 });
+
+  // A brand-new user sees the welcome step: the "MD files are dead" splash (ac-2).
+  await expect(page.getByTestId("journey-step-welcome")).toBeVisible({ timeout: 15_000 });
+  await expect(page.getByText("MD files")).toBeVisible();
+  await expect(page.getByRole("button", { name: /Create your first spec/ })).toBeVisible();
+
+  // Create a real spec for this user → the journey self-advances on the next load.
+  const personal = await getPersonalMemexByEmail(DEV_EMAIL);
+  expect(personal).not.toBeNull();
+  const seeded = await seedSpecInMemex({
+    memexId: personal!.memexId,
+    title: "My first spec",
+    createdByUserId: devUserId,
+  });
+  seededDocId = seeded.docId;
+
+  await page.goto(bareUrl("/home"));
+  await expect(page.getByTestId("journey-step-first-decision")).toBeVisible({ timeout: 15_000 });
+  await expect(page.getByText("Your spec is alive. Now make the call.")).toBeVisible();
+});

--- a/packages/ui/e2e/journey-34-home-canvas.spec.ts
+++ b/packages/ui/e2e/journey-34-home-canvas.spec.ts
@@ -56,7 +56,7 @@ test(TITLE, async ({ page }) => {
 
   // A brand-new user sees the welcome step: the "MD files are dead" splash (ac-2).
   await expect(page.getByTestId("journey-step-welcome")).toBeVisible({ timeout: 15_000 });
-  await expect(page.getByText("MD files")).toBeVisible();
+  await expect(page.getByText(".md files")).toBeVisible();
   await expect(page.getByRole("button", { name: /Create your first spec/ })).toBeVisible();
 
   // Create a real spec for this user → the journey self-advances on the next load.

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -7,6 +7,7 @@ import { Decisions } from './pages/Decisions';
 import { SpecList } from './pages/SpecList';
 import { IssuesList } from './pages/IssuesList';
 import { NamespaceHome } from './pages/NamespaceHome';
+import { HomeCanvas } from './pages/HomeCanvas';
 import { StandardList } from './pages/StandardList';
 import { Standard } from './pages/Standard';
 import { DriftInbox } from './pages/DriftInbox';
@@ -369,6 +370,9 @@ export function PostLoginRouter() {
       <Route path="/invites" element={<Navigate to="/org?tab=invites" replace />} />
       <Route path="/org" element={<FlatShell><OrgConfiguration /></FlatShell>} />
       <Route path="/account" element={<Navigate to="/org" replace />} />
+      {/* spec-303 — Home Canvas: user-level, flat (not tenant-scoped). */}
+      <Route path="/home" element={<FlatShell><HomeCanvas /></FlatShell>} />
+
 
       {/* doc-19 t-10: namespace home — /<namespace>/ renders the kind-aware
           OrgHome / Personal Home. More specific /:namespace/:memex routes below

--- a/packages/ui/src/api/journey.ts
+++ b/packages/ui/src/api/journey.ts
@@ -1,0 +1,46 @@
+// spec-303 — Home Canvas journey-state client. Caller-scoped (/api/me), so it goes
+// through the flat BASE_URL, not a tenant prefix (the Home Canvas is user-level).
+import { BASE_URL, fetchWithRetry } from './http';
+
+export interface JourneyMilestones {
+  hasSpec: boolean;
+  hasDecision: boolean;
+  mcpConnected: boolean;
+  mcpToolCalled: boolean;
+}
+
+export interface JourneyStateResponse {
+  milestones: JourneyMilestones;
+  currentStepId: string;
+  preview: boolean;
+  canPreview: boolean;
+}
+
+/** Fetch the user's derived journey position. `previewStep` (operator-only,
+ * enforced server-side) pins the returned step without touching real state. */
+export async function fetchJourneyStateApi(
+  previewStep?: string | null,
+): Promise<JourneyStateResponse> {
+  const q = previewStep ? `?preview=${encodeURIComponent(previewStep)}` : '';
+  const res = await fetchWithRetry(`${BASE_URL}/me/journey-state${q}`);
+  if (!res.ok) throw new Error(`journey-state ${res.status}`);
+  return (await res.json()) as JourneyStateResponse;
+}
+
+/** Record that a step was shown / a CTA was taken (ac-7). Advisory: measurement
+ * must never throw into the canvas. */
+export async function postJourneyEventApi(
+  step: string,
+  action: 'shown' | 'cta',
+  cta?: string,
+): Promise<void> {
+  try {
+    await fetchWithRetry(`${BASE_URL}/me/journey-event`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ step, action, ...(cta ? { cta } : {}) }),
+    });
+  } catch {
+    // swallow — telemetry is advisory
+  }
+}

--- a/packages/ui/src/api/journey.ts
+++ b/packages/ui/src/api/journey.ts
@@ -9,9 +9,17 @@ export interface JourneyMilestones {
   mcpToolCalled: boolean;
 }
 
+export interface JourneyStepStatus {
+  id: string;
+  attained: boolean;
+}
+
 export interface JourneyStateResponse {
   milestones: JourneyMilestones;
   currentStepId: string;
+  // Per-step real attainment (drives the progress map). Reflects true state even
+  // under preview.
+  steps: JourneyStepStatus[];
   preview: boolean;
   canPreview: boolean;
 }

--- a/packages/ui/src/components/AppShell.test.tsx
+++ b/packages/ui/src/components/AppShell.test.tsx
@@ -125,6 +125,32 @@ describe('AppShell sidebar navigation', () => {
     expect(labels).toEqual(GROUPED);
   });
 
+  // spec-303 ac-1 / impl ac-9 — the Home Canvas is the FIRST nav item and a flat,
+  // user-level link (/home), not tenant-prefixed.
+  it('shows Home as the first nav item, linking to the flat /home', () => {
+    tagAc('mindset-prod/memex-building-itself/specs/spec-303/acs/ac-1');
+    tagAc('mindset-prod/memex-building-itself/specs/spec-303/acs/ac-9');
+    renderShell(['/specs']);
+
+    const nav = screen.getByTestId('primary-nav');
+    const home = within(nav).getByRole('link', { name: 'Home' });
+    expect(home).toHaveAttribute('href', '/home');
+    // Home is the first working surface — above Specs (the previous top item).
+    const links = within(nav).getAllByRole('link');
+    const specs = within(nav).getByRole('link', { name: 'Specs' });
+    expect(links.indexOf(home)).toBeGreaterThanOrEqual(0);
+    expect(links.indexOf(home)).toBeLessThan(links.indexOf(specs));
+  });
+
+  it('marks Home active on /home', () => {
+    tagAc('mindset-prod/memex-building-itself/specs/spec-303/acs/ac-1');
+    renderShell(['/home']);
+
+    const nav = screen.getByTestId('primary-nav');
+    const home = within(nav).getByRole('link', { name: 'Home' });
+    expect(home.className).toContain('font-medium');
+  });
+
   it('marks Issues active on /issues', () => {
     renderShell(['/issues']);
 

--- a/packages/ui/src/components/AppShell.tsx
+++ b/packages/ui/src/components/AppShell.tsx
@@ -46,7 +46,23 @@ interface NavLinkDef {
   // spec-146 t-3: when set, the link is hidden for every user whose session has
   // this slug in `hiddenFeatures` (server-driven feature-hide, dec-1 Option B).
   feature?: string;
+  // spec-303 — a flat, user-level link (e.g. /home): used verbatim, NOT expanded
+  // to /<ns>/<mx>/... by resolveNavTo. The surface is the same across all memexes.
+  flat?: boolean;
 }
+
+// spec-303 — the Home Canvas: the top nav item and a user-level (flat) destination,
+// identical across all of a user's Memexes (dec-2). `flat` keeps it at /home.
+const HOME_NAV_LINK: NavLinkDef = {
+  to: '/home',
+  label: 'Home',
+  flat: true,
+  icon: (
+    <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.75}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M3 12l9-9 9 9M5 10v10a1 1 0 001 1h3v-5a1 1 0 011-1h2a1 1 0 011 1v5h3a1 1 0 001-1V10" />
+    </svg>
+  ),
+};
 
 // spec-260 t-11: the sidebar is two labelled groups. PRINCIPLES holds the
 // working surfaces (Specs leads, then the dashboards and the standards/scaffold
@@ -363,6 +379,7 @@ function NavItem({
   altPaths,
   pathname,
   badge,
+  flat,
 }: {
   to: string;
   label: string;
@@ -371,6 +388,8 @@ function NavItem({
   pathname: string;
   /** Optional count pill (e.g. open standards drift) shown at the row's end. */
   badge?: number;
+  /** spec-303 — flat (user-level) link: use `to` verbatim, no tenant expansion. */
+  flat?: boolean;
 }) {
   // t-23 of doc-15: NAV_LINKS hold the in-tenant path shape (e.g. "/specs").
   // resolveNavTo() expands this to /<ns>/<mx>/specs — falling back to the
@@ -380,7 +399,7 @@ function NavItem({
   // suffix of the current pathname so `/<ns>/<mx>/specs` still highlights
   // the Specs link.
   const { session } = useAuth();
-  const resolvedTo = resolveNavTo(to, pathname, session?.memberships);
+  const resolvedTo = flat ? to : resolveNavTo(to, pathname, session?.memberships);
   const tenantSuffix = stripTenantPrefix(pathname);
   const matchedAlt = altPaths?.includes(tenantSuffix) ?? false;
   // spec-190 (dec-4 / t-5): tag the global nav links so the voice guide can
@@ -594,9 +613,12 @@ export function AppShell({ children }: { children: ReactNode }) {
         </div>
 
         <nav className="flex-1 min-h-0 overflow-y-auto px-3 space-y-0.5">
+          {/* spec-303 — Home Canvas: the first, top-level, user-level destination. */}
+          <NavItem {...HOME_NAV_LINK} pathname={location.pathname} />
+
           {/* spec-260 t-11: two labelled groups — PRINCIPLES (the working
               surfaces) and IN-BOXES (the badge-carrying attention surfaces). */}
-          <div className="pt-1 pb-1 px-3 text-xs font-medium uppercase tracking-wider text-muted">
+          <div className="pt-4 pb-1 px-3 text-xs font-medium uppercase tracking-wider text-muted">
             Principles
           </div>
           {PRINCIPLES_NAV_LINKS.filter((link) => !isLinkHidden(link.feature)).map((link) => (

--- a/packages/ui/src/components/home/JourneyStepShell.tsx
+++ b/packages/ui/src/components/home/JourneyStepShell.tsx
@@ -18,21 +18,28 @@ export function JourneyStepShell({
         data-testid={`journey-step-${view.id}`}
         className="relative w-full max-w-2xl overflow-hidden rounded-3xl border border-edge bg-surface/70 p-8 shadow-2xl backdrop-blur-xl sm:p-12"
       >
-        <div className="mb-5 text-xs font-semibold uppercase tracking-[0.14em] text-muted">
-          {view.eyebrow}
-        </div>
-
-        {userName && (
-          <p className="mb-2 text-base text-secondary">
-            Hello, <span className="font-semibold text-heading">{userName}</span>.
-          </p>
+        {view.eyebrow && (
+          <div className="mb-5 text-xs font-semibold uppercase tracking-[0.14em] text-muted">
+            {view.eyebrow}
+          </div>
         )}
 
-        <h1 className="text-4xl font-black leading-[1.03] tracking-tight text-heading sm:text-5xl">
+        {userName &&
+          (view.greetingHeading ? (
+            <h1 className="text-4xl font-black leading-[1.08] tracking-tight text-heading sm:text-5xl">
+              Hello, <span className="text-heading">{userName}</span>.
+            </h1>
+          ) : (
+            <p className="mb-3 text-lg font-medium text-secondary">
+              Hello, <span className="font-semibold text-heading">{userName}</span>.
+            </p>
+          ))}
+
+        <h1 className="text-4xl font-black leading-[1.08] tracking-tight text-heading sm:text-5xl">
           {view.headline}
         </h1>
 
-        <p className="mt-4 text-lg font-semibold text-primary">{view.sub}</p>
+        {view.sub && <p className="mt-4 text-lg font-semibold text-primary">{view.sub}</p>}
 
         {view.body && (
           <p className="mt-4 max-w-prose leading-relaxed text-secondary">{view.body}</p>

--- a/packages/ui/src/components/home/JourneyStepShell.tsx
+++ b/packages/ui/src/components/home/JourneyStepShell.tsx
@@ -1,0 +1,81 @@
+// spec-303 — the generic presentational shell for a journey step. Journey-agnostic:
+// it renders any JourneyStepView (the engine picks which one). Theme-aware via the
+// app's design tokens, with an accent splash for the headline + primary CTA.
+import type { JourneyCta, JourneyStepView } from '../../journeys/types';
+
+export function JourneyStepShell({
+  view,
+  userName,
+  onCta,
+}: {
+  view: JourneyStepView;
+  userName: string | null;
+  onCta: (cta: JourneyCta) => void;
+}) {
+  return (
+    <div className="flex min-h-[70vh] items-center justify-center px-4 py-10">
+      <article
+        data-testid={`journey-step-${view.id}`}
+        className="relative w-full max-w-2xl overflow-hidden rounded-3xl border border-edge bg-surface/70 p-8 shadow-2xl backdrop-blur-xl sm:p-12"
+      >
+        <div className="mb-5 text-xs font-semibold uppercase tracking-[0.14em] text-muted">
+          {view.eyebrow}
+        </div>
+
+        {userName && (
+          <p className="mb-2 text-base text-secondary">
+            Hello, <span className="font-semibold text-heading">{userName}</span>.
+          </p>
+        )}
+
+        <h1 className="text-4xl font-black leading-[1.03] tracking-tight text-heading sm:text-5xl">
+          {view.headline}
+        </h1>
+
+        <p className="mt-4 text-lg font-semibold text-primary">{view.sub}</p>
+
+        {view.body && (
+          <p className="mt-4 max-w-prose leading-relaxed text-secondary">{view.body}</p>
+        )}
+
+        {view.memoriam && view.memoriam.length > 0 && (
+          <div className="mt-6 flex flex-wrap items-center gap-2">
+            <span className="text-xs uppercase tracking-wider text-muted">
+              In loving memory of
+            </span>
+            {view.memoriam.map((m) => (
+              <span
+                key={m}
+                className="rounded-md border border-edge bg-card-hover px-2 py-1 font-mono text-xs text-muted line-through decoration-[#fb5b78] decoration-2"
+              >
+                {m}
+              </span>
+            ))}
+          </div>
+        )}
+
+        <div className="mt-8 flex flex-wrap items-center gap-3">
+          <button
+            type="button"
+            data-testid="journey-cta-primary"
+            onClick={() => onCta(view.primary)}
+            className="inline-flex items-center gap-2 rounded-xl bg-[linear-gradient(96deg,#8b5cf6,#6366f1)] px-5 py-3 text-sm font-bold text-white shadow-lg transition hover:brightness-110"
+          >
+            {view.primary.label}
+            <span aria-hidden>→</span>
+          </button>
+          {view.secondary && (
+            <button
+              type="button"
+              data-testid="journey-cta-secondary"
+              onClick={() => onCta(view.secondary as JourneyCta)}
+              className="rounded-xl border border-edge px-4 py-3 text-sm font-semibold text-secondary transition hover:bg-card-hover hover:text-primary"
+            >
+              {view.secondary.label}
+            </button>
+          )}
+        </div>
+      </article>
+    </div>
+  );
+}

--- a/packages/ui/src/journeys/onboarding/index.ts
+++ b/packages/ui/src/journeys/onboarding/index.ts
@@ -1,0 +1,10 @@
+// spec-303 — the onboarding journey module. Bundles this journey's step views +
+// its server-derived step order behind the engine's JourneyModule contract.
+import type { JourneyModule } from '../types';
+import { ONBOARDING_STEP_VIEWS, ONBOARDING_MILESTONE_STEP_IDS } from './steps';
+
+export const onboardingJourney: JourneyModule = {
+  id: 'onboarding',
+  views: ONBOARDING_STEP_VIEWS,
+  milestoneStepIds: ONBOARDING_MILESTONE_STEP_IDS,
+};

--- a/packages/ui/src/journeys/onboarding/index.ts
+++ b/packages/ui/src/journeys/onboarding/index.ts
@@ -7,4 +7,7 @@ export const onboardingJourney: JourneyModule = {
   id: 'onboarding',
   views: ONBOARDING_STEP_VIEWS,
   milestoneStepIds: ONBOARDING_MILESTONE_STEP_IDS,
+  // Internal v1: the map is a talking point and makes the non-linear, state-driven
+  // skipping tangible. It stays off on the cold welcome step (see HomeCanvas).
+  showProgressMap: true,
 };

--- a/packages/ui/src/journeys/onboarding/steps.tsx
+++ b/packages/ui/src/journeys/onboarding/steps.tsx
@@ -1,0 +1,96 @@
+// spec-303 — the ONBOARDING journey's step views (dec-1: a self-contained module).
+// One view per journey state; the Home Canvas engine renders the view for the
+// step the server says the user is on. Editing this journey touches only this
+// folder. The brand-new step is the "MD files are dead" splash.
+import type { JourneyStepView } from '../types';
+
+// The server-derived steps a user can land on, in order (mirrors the server's
+// journeys/onboarding.ts). Used by the operator preview control.
+export const ONBOARDING_MILESTONE_STEP_IDS = [
+  'welcome',
+  'first-decision',
+  'connect-agent',
+  'use-agent',
+  'all-set',
+] as const;
+
+export const ONBOARDING_STEP_VIEWS: Record<string, JourneyStepView> = {
+  welcome: {
+    id: 'welcome',
+    eyebrow: 'Memex · Home',
+    headline: (
+      <>
+        <span className="text-muted line-through decoration-[#fb5b78] decoration-4">
+          MD files
+        </span>{' '}
+        are{' '}
+        <span className="bg-[linear-gradient(96deg,#fb5b78,#c084fc)] bg-clip-text text-transparent">
+          dead
+        </span>
+        .
+      </>
+    ),
+    sub: 'Help us celebrate their demise.',
+    body: (
+      <>
+        Your standards, specs and decisions shouldn&apos;t rot in a folder of stale
+        Markdown your agent never reads. In Memex they become a{' '}
+        <span className="font-semibold text-heading">living map</span> your agent
+        reads, follows, and keeps in sync.
+      </>
+    ),
+    memoriam: ['README.md', 'ARCHITECTURE.md', 'CONTRIBUTING.md', 'NOTES.md'],
+    primary: { label: 'Create your first spec', kind: 'action', target: 'create_spec' },
+    secondary: { label: 'Why Memex?', kind: 'navigate', target: 'learn-more' },
+  },
+
+  // Informational (navigate-only) — not a server milestone step.
+  'learn-more': {
+    id: 'learn-more',
+    eyebrow: "Memex · What's a spec?",
+    headline: 'A spec is a living plan.',
+    sub: 'Not a doc that rots: a plan your agent reads and follows.',
+    body: 'A spec captures what you are building and why — the decisions it hinges on, what "done" means, and the work to get there. Your coding agent reads it over MCP, so it builds the right thing and stays on track.',
+    primary: { label: 'Create your first spec', kind: 'action', target: 'create_spec' },
+    secondary: { label: 'Back', kind: 'navigate', target: 'welcome' },
+  },
+
+  'first-decision': {
+    id: 'first-decision',
+    eyebrow: 'Memex · Next',
+    headline: 'Your spec is alive. Now make the call.',
+    sub: 'Every plan hinges on a few real decisions.',
+    body: 'Capture the choice your spec turns on as a decision, weigh the options, and resolve it. That is how the plan stays honest and your agent knows which path you picked.',
+    primary: { label: 'Capture a decision', kind: 'action', target: 'create_decision' },
+    secondary: { label: 'How decisions work', kind: 'link', target: 'https://www.memex.ai' },
+  },
+
+  'connect-agent': {
+    id: 'connect-agent',
+    eyebrow: 'Memex · Next',
+    headline: 'Bring your coding agent.',
+    sub: 'Memex is where your agent gets its marching orders.',
+    body: 'Connect your agent over MCP and it can read your specs, standards and decisions, and report its progress back. One command and you are wired in.',
+    primary: { label: 'Connect your agent', kind: 'action', target: 'connect_agent' },
+    secondary: { label: "What's the MCP?", kind: 'link', target: 'https://www.memex.ai' },
+  },
+
+  'use-agent': {
+    id: 'use-agent',
+    eyebrow: 'Memex · Next',
+    headline: 'Put your agent to work.',
+    sub: 'Hand it a spec and watch it build.',
+    body: 'Your agent is connected. Open your Specs board, hand it the spec you created, and let it work the plan — every step tracked against what you agreed.',
+    primary: { label: 'Open your Specs board', kind: 'action', target: 'open_specs' },
+  },
+
+  'all-set': {
+    id: 'all-set',
+    eyebrow: "Memex · You're set up",
+    headline: "You're all set.",
+    sub: 'You have driven a spec end to end. This is Memex.',
+    body: 'From here, Home shows you what needs your attention next. Bring your team in so the map grows with you.',
+    primary: { label: 'Invite your team', kind: 'action', target: 'invite' },
+    secondary: { label: 'Back to your Specs', kind: 'action', target: 'open_specs' },
+  },
+};

--- a/packages/ui/src/journeys/onboarding/steps.tsx
+++ b/packages/ui/src/journeys/onboarding/steps.tsx
@@ -17,6 +17,7 @@ export const ONBOARDING_MILESTONE_STEP_IDS = [
 export const ONBOARDING_STEP_VIEWS: Record<string, JourneyStepView> = {
   welcome: {
     id: 'welcome',
+    mapLabel: 'Spec created',
     eyebrow: 'Memex · Home',
     headline: (
       <>
@@ -30,15 +31,10 @@ export const ONBOARDING_STEP_VIEWS: Record<string, JourneyStepView> = {
         .
       </>
     ),
-    sub: 'Help us celebrate their demise.',
-    body: (
-      <>
-        Your standards, specs and decisions shouldn&apos;t rot in a folder of stale
-        Markdown your agent never reads. In Memex they become a{' '}
-        <span className="font-semibold text-heading">living map</span> your agent
-        reads, follows, and keeps in sync.
-      </>
-    ),
+    sub: 'Lorem ipsum dolor sit amet, consectetur adipiscing.',
+    // Placeholder on purpose (internal v1): the COPY on these cards is not yet
+    // decided — colleagues should react to the journey CONCEPT, not this wording.
+    body: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris.',
     memoriam: ['README.md', 'ARCHITECTURE.md', 'CONTRIBUTING.md', 'NOTES.md'],
     primary: { label: 'Create your first spec', kind: 'action', target: 'create_spec' },
     secondary: { label: 'Why Memex?', kind: 'navigate', target: 'learn-more' },
@@ -57,6 +53,7 @@ export const ONBOARDING_STEP_VIEWS: Record<string, JourneyStepView> = {
 
   'first-decision': {
     id: 'first-decision',
+    mapLabel: 'Decision made',
     eyebrow: 'Memex · Next',
     headline: 'Your spec is alive. Now make the call.',
     sub: 'Every plan hinges on a few real decisions.',
@@ -67,6 +64,7 @@ export const ONBOARDING_STEP_VIEWS: Record<string, JourneyStepView> = {
 
   'connect-agent': {
     id: 'connect-agent',
+    mapLabel: 'Agent connected',
     eyebrow: 'Memex · Next',
     headline: 'Bring your coding agent.',
     sub: 'Memex is where your agent gets its marching orders.',
@@ -77,6 +75,7 @@ export const ONBOARDING_STEP_VIEWS: Record<string, JourneyStepView> = {
 
   'use-agent': {
     id: 'use-agent',
+    mapLabel: 'Agent used',
     eyebrow: 'Memex · Next',
     headline: 'Put your agent to work.',
     sub: 'Hand it a spec and watch it build.',
@@ -86,11 +85,12 @@ export const ONBOARDING_STEP_VIEWS: Record<string, JourneyStepView> = {
 
   'all-set': {
     id: 'all-set',
+    mapLabel: 'Set up',
     eyebrow: "Memex · You're set up",
     headline: "You're all set.",
     sub: 'You have driven a spec end to end. This is Memex.',
-    body: 'From here, Home shows you what needs your attention next. Bring your team in so the map grows with you.',
-    primary: { label: 'Invite your team', kind: 'action', target: 'invite' },
+    body: 'From here, Home shows you what needs your attention next. Bring your colleagues in so the map grows with you.',
+    primary: { label: 'Invite your org', kind: 'action', target: 'invite' },
     secondary: { label: 'Back to your Specs', kind: 'action', target: 'open_specs' },
   },
 };

--- a/packages/ui/src/journeys/onboarding/steps.tsx
+++ b/packages/ui/src/journeys/onboarding/steps.tsx
@@ -18,24 +18,26 @@ export const ONBOARDING_STEP_VIEWS: Record<string, JourneyStepView> = {
   welcome: {
     id: 'welcome',
     mapLabel: 'Spec created',
-    eyebrow: 'Memex · Home',
+    greetingHeading: true,
     headline: (
       <>
-        <span className="text-muted line-through decoration-[#fb5b78] decoration-4">
-          MD files
-        </span>{' '}
-        are{' '}
-        <span className="bg-[linear-gradient(96deg,#fb5b78,#c084fc)] bg-clip-text text-transparent">
-          dead
+        Welcome to Memex.
+        <span className="block">
+          We believe that{' '}
+          <span className="text-muted line-through decoration-[#fb5b78] decoration-4">
+            .md files
+          </span>{' '}
+          are{' '}
+          <span className="bg-[linear-gradient(96deg,#fb5b78,#c084fc)] bg-clip-text text-transparent">
+            dead
+          </span>
+          .
         </span>
-        .
       </>
     ),
-    sub: 'Lorem ipsum dolor sit amet, consectetur adipiscing.',
-    // Placeholder on purpose (internal v1): the COPY on these cards is not yet
-    // decided — colleagues should react to the journey CONCEPT, not this wording.
+    // Placeholder on purpose (internal v1): the COPY here is not yet decided —
+    // colleagues should react to the journey CONCEPT, not this wording.
     body: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris.',
-    memoriam: ['README.md', 'ARCHITECTURE.md', 'CONTRIBUTING.md', 'NOTES.md'],
     primary: { label: 'Create your first spec', kind: 'action', target: 'create_spec' },
     secondary: { label: 'Why Memex?', kind: 'navigate', target: 'learn-more' },
   },

--- a/packages/ui/src/journeys/registry.ts
+++ b/packages/ui/src/journeys/registry.ts
@@ -1,0 +1,19 @@
+// spec-303 — the journey registry (dec-1/dec-6). The Home Canvas engine resolves
+// journeys and step views from here; adding a journey is a new module registered
+// in this map, never a change to the engine. v0 ships a single journey.
+import type { JourneyModule, JourneyStepView } from './types';
+import { onboardingJourney } from './onboarding';
+
+export const JOURNEY_MODULES: Record<string, JourneyModule> = {
+  onboarding: onboardingJourney,
+};
+
+/** The journey that applies to the user. v0: always onboarding (dec-6). */
+export function activeJourney(): JourneyModule {
+  return onboardingJourney;
+}
+
+/** Resolve a step view by id within the active journey (null if unknown). */
+export function resolveStepView(stepId: string): JourneyStepView | null {
+  return activeJourney().views[stepId] ?? null;
+}

--- a/packages/ui/src/journeys/types.ts
+++ b/packages/ui/src/journeys/types.ts
@@ -1,0 +1,36 @@
+// spec-303 — shared journey types (the engine contract). A journey MODULE supplies
+// step views keyed by step id; the Home Canvas engine renders them. Nothing about a
+// specific journey lives here.
+import type { ReactNode } from 'react';
+
+// dec-5 — a CTA names one of an allow-listed set; it never carries executable code.
+export type JourneyCtaKind = 'action' | 'navigate' | 'link';
+
+export interface JourneyCta {
+  label: string;
+  kind: JourneyCtaKind;
+  // 'action'   → an allow-listed action id (create_spec, create_decision,
+  //              connect_agent, open_specs, invite) routed to an app handler.
+  // 'navigate' → a step id within the journey (in-canvas).
+  // 'link'     → an external URL.
+  target: string;
+}
+
+export interface JourneyStepView {
+  id: string;
+  eyebrow: string;
+  headline: ReactNode;
+  sub: ReactNode;
+  body?: ReactNode;
+  memoriam?: readonly string[];
+  primary: JourneyCta;
+  secondary?: JourneyCta;
+}
+
+export interface JourneyModule {
+  id: string;
+  views: Record<string, JourneyStepView>;
+  // The server-derived steps (in order) a user can land on — drives the operator
+  // preview control. Informational steps (navigate-only) are NOT listed here.
+  milestoneStepIds: readonly string[];
+}

--- a/packages/ui/src/journeys/types.ts
+++ b/packages/ui/src/journeys/types.ts
@@ -18,15 +18,17 @@ export interface JourneyCta {
 
 export interface JourneyStepView {
   id: string;
-  eyebrow: string;
+  eyebrow?: string;
   headline: ReactNode;
-  sub: ReactNode;
+  sub?: ReactNode;
   body?: ReactNode;
   memoriam?: readonly string[];
   primary: JourneyCta;
   secondary?: JourneyCta;
   // Short label for this step in the progress map (attainment-framed).
   mapLabel?: string;
+  // Render the greeting ("Hello, name") as a heading-sized line (welcome card).
+  greetingHeading?: boolean;
 }
 
 export interface JourneyModule {

--- a/packages/ui/src/journeys/types.ts
+++ b/packages/ui/src/journeys/types.ts
@@ -25,6 +25,8 @@ export interface JourneyStepView {
   memoriam?: readonly string[];
   primary: JourneyCta;
   secondary?: JourneyCta;
+  // Short label for this step in the progress map (attainment-framed).
+  mapLabel?: string;
 }
 
 export interface JourneyModule {
@@ -33,4 +35,7 @@ export interface JourneyModule {
   // The server-derived steps (in order) a user can land on — drives the operator
   // preview control. Informational steps (navigate-only) are NOT listed here.
   milestoneStepIds: readonly string[];
+  // Per-journey (dec-1): show a progress map of attained/unattained steps. Off by
+  // default; onboarding turns it on. Never shown on the cold first step.
+  showProgressMap?: boolean;
 }

--- a/packages/ui/src/pages/HomeCanvas.test.tsx
+++ b/packages/ui/src/pages/HomeCanvas.test.tsx
@@ -54,7 +54,7 @@ function stateFor(currentStepId: string, over: Record<string, unknown> = {}) {
 
 function LocationDisplay() {
   const loc = useLocation();
-  return <div data-testid="location">{loc.pathname}</div>;
+  return <div data-testid="location">{loc.pathname}{loc.search}</div>;
 }
 
 function renderCanvas() {
@@ -80,8 +80,9 @@ describe('HomeCanvas — welcome step (ac-2)', () => {
     renderCanvas();
 
     expect(await screen.findByTestId('journey-step-welcome')).toBeInTheDocument();
-    expect(screen.getByText('MD files')).toBeInTheDocument();
+    expect(screen.getByText('.md files')).toBeInTheDocument();
     expect(screen.getByText('dead')).toBeInTheDocument();
+    expect(screen.getByText('Welcome to Memex.')).toBeInTheDocument();
     expect(screen.getByText('John')).toBeInTheDocument(); // greeting first-name
     expect(screen.getByTestId('journey-cta-primary')).toHaveTextContent('Create your first spec');
     expect(screen.getByTestId('journey-cta-secondary')).toHaveTextContent('Why Memex?');
@@ -187,8 +188,9 @@ describe('HomeCanvas — CTA allow-list (ac-5 / impl ac-12)', () => {
     fetchJourneyStateApi.mockResolvedValue(stateFor('welcome'));
     renderCanvas();
     fireEvent.click(await screen.findByTestId('journey-cta-primary'));
+    // Deep-links into the SAME NewSpecModal the board uses (?new=1).
     await waitFor(() =>
-      expect(screen.getByTestId('location')).toHaveTextContent('/john/personal/specs'),
+      expect(screen.getByTestId('location')).toHaveTextContent('/john/personal/specs?new=1'),
     );
   });
 

--- a/packages/ui/src/pages/HomeCanvas.test.tsx
+++ b/packages/ui/src/pages/HomeCanvas.test.tsx
@@ -151,6 +151,35 @@ describe('HomeCanvas — every milestone step renders in isolation (ac-6)', () =
   });
 });
 
+describe('HomeCanvas — attainment progress map', () => {
+  const stepsMixed = [
+    { id: 'welcome', attained: true },
+    { id: 'first-decision', attained: false },
+    { id: 'connect-agent', attained: true }, // attained out of order
+    { id: 'use-agent', attained: false },
+    { id: 'all-set', attained: false },
+  ];
+
+  it('shows the map off the welcome step, with real attainment incl. the out-of-order tick', async () => {
+    tagAc(AC(4));
+    fetchJourneyStateApi.mockResolvedValue(stateFor('first-decision', { steps: stepsMixed }));
+    renderCanvas();
+    expect(await screen.findByTestId('journey-progress-map')).toBeInTheDocument();
+    expect(screen.getByTestId('journey-map-welcome').getAttribute('data-attained')).toBe('true');
+    expect(screen.getByTestId('journey-map-first-decision').getAttribute('data-attained')).toBe('false');
+    expect(screen.getByTestId('journey-map-connect-agent').getAttribute('data-attained')).toBe('true');
+  });
+
+  it('hides the map on the cold welcome step', async () => {
+    fetchJourneyStateApi.mockResolvedValue(
+      stateFor('welcome', { steps: stepsMixed.map((s) => ({ ...s, attained: false })) }),
+    );
+    renderCanvas();
+    await screen.findByTestId('journey-step-welcome');
+    expect(screen.queryByTestId('journey-progress-map')).toBeNull();
+  });
+});
+
 describe('HomeCanvas — CTA allow-list (ac-5 / impl ac-12)', () => {
   it("an 'action' CTA routes into the real flow (create_spec → personal Specs board)", async () => {
     tagAc(AC(5));

--- a/packages/ui/src/pages/HomeCanvas.test.tsx
+++ b/packages/ui/src/pages/HomeCanvas.test.tsx
@@ -1,0 +1,174 @@
+// spec-303 — Home Canvas engine (component).
+//
+// ac-2 — a brand-new user sees the onboarding welcome step: the "MD files are dead"
+//        splash, greeted by name, with a primary + secondary CTA.
+// ac-5 — a fully-activated user lands on the terminal 'all-set' step.
+// ac-6 — every milestone step renders in isolation; an operator sees the preview bar.
+// ac-7 — the canvas records the step shown.
+// impl ac-8 (compiled components), ac-12 (CTA allow-list), ac-13 (journey-only v0).
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter, useLocation } from 'react-router-dom';
+import { tagAc } from '@memex-ai-ac/vitest';
+
+const fetchJourneyStateApi = vi.hoisted(() => vi.fn());
+const postJourneyEventApi = vi.hoisted(() => vi.fn());
+
+vi.mock('../api/journey', () => ({
+  fetchJourneyStateApi,
+  postJourneyEventApi,
+}));
+
+vi.mock('../components/AuthContext', () => ({
+  useAuth: () => ({
+    user: { id: 'u-1', name: 'John Doe', email: 'john@example.com' },
+    session: { memberships: [{ slug: 'john', memexSlug: 'personal', kind: 'personal' }] },
+    token: 'fake',
+  }),
+}));
+
+// No SSE in component tests.
+vi.mock('../hooks/useUserChangeStream', () => ({
+  useUserChangeStream: () => undefined,
+}));
+
+import { HomeCanvas } from './HomeCanvas';
+
+const AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-303/acs/ac-${n}`;
+
+function stateFor(currentStepId: string, over: Record<string, unknown> = {}) {
+  return {
+    milestones: {
+      hasSpec: false,
+      hasDecision: false,
+      mcpConnected: false,
+      mcpToolCalled: false,
+    },
+    currentStepId,
+    preview: false,
+    canPreview: false,
+    ...over,
+  };
+}
+
+function LocationDisplay() {
+  const loc = useLocation();
+  return <div data-testid="location">{loc.pathname}</div>;
+}
+
+function renderCanvas() {
+  return render(
+    <MemoryRouter initialEntries={['/home']}>
+      <HomeCanvas />
+      <LocationDisplay />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  fetchJourneyStateApi.mockReset();
+  postJourneyEventApi.mockReset();
+  postJourneyEventApi.mockResolvedValue(undefined);
+});
+
+describe('HomeCanvas — welcome step (ac-2)', () => {
+  it('renders the MD-dead splash, greets by name, and offers two CTAs', async () => {
+    tagAc(AC(2));
+    tagAc(AC(8));
+    fetchJourneyStateApi.mockResolvedValue(stateFor('welcome'));
+    renderCanvas();
+
+    expect(await screen.findByTestId('journey-step-welcome')).toBeInTheDocument();
+    expect(screen.getByText('MD files')).toBeInTheDocument();
+    expect(screen.getByText('dead')).toBeInTheDocument();
+    expect(screen.getByText('John')).toBeInTheDocument(); // greeting first-name
+    expect(screen.getByTestId('journey-cta-primary')).toHaveTextContent('Create your first spec');
+    expect(screen.getByTestId('journey-cta-secondary')).toHaveTextContent('Why Memex?');
+  });
+
+  it('records that the step was shown (ac-7)', async () => {
+    tagAc(AC(7));
+    fetchJourneyStateApi.mockResolvedValue(stateFor('welcome'));
+    renderCanvas();
+    await screen.findByTestId('journey-step-welcome');
+    await waitFor(() =>
+      expect(postJourneyEventApi).toHaveBeenCalledWith('welcome', 'shown'),
+    );
+  });
+});
+
+describe('HomeCanvas — terminal step (ac-5)', () => {
+  it("a fully-activated user sees the 'all-set' step", async () => {
+    tagAc(AC(5));
+    tagAc(AC(13));
+    fetchJourneyStateApi.mockResolvedValue(
+      stateFor('all-set', {
+        milestones: { hasSpec: true, hasDecision: true, mcpConnected: true, mcpToolCalled: true },
+      }),
+    );
+    renderCanvas();
+    expect(await screen.findByTestId('journey-step-all-set')).toBeInTheDocument();
+    expect(screen.getByText("You're all set.")).toBeInTheDocument();
+  });
+});
+
+describe('HomeCanvas — every milestone step renders in isolation (ac-6)', () => {
+  for (const id of ['welcome', 'first-decision', 'connect-agent', 'use-agent', 'all-set']) {
+    it(`renders the '${id}' step`, async () => {
+      tagAc(AC(6));
+      fetchJourneyStateApi.mockResolvedValue(stateFor(id));
+      renderCanvas();
+      expect(await screen.findByTestId(`journey-step-${id}`)).toBeInTheDocument();
+    });
+  }
+
+  it('embeds no third-party video player in any step (impl ac-14)', async () => {
+    tagAc(AC(14));
+    for (const id of ['welcome', 'first-decision', 'connect-agent', 'use-agent', 'all-set']) {
+      fetchJourneyStateApi.mockResolvedValue(stateFor(id));
+      const { container, unmount } = renderCanvas();
+      await screen.findByTestId(`journey-step-${id}`);
+      expect(container.querySelector('iframe')).toBeNull();
+      expect(container.innerHTML.toLowerCase()).not.toMatch(/youtube|loom|vimeo/);
+      unmount();
+    }
+  });
+
+  it('shows the operator preview bar when canPreview is true', async () => {
+    tagAc(AC(6));
+    fetchJourneyStateApi.mockResolvedValue(stateFor('welcome', { canPreview: true }));
+    renderCanvas();
+    expect(await screen.findByTestId('journey-preview-bar')).toBeInTheDocument();
+    expect(screen.getByTestId('journey-preview-use-agent')).toBeInTheDocument();
+  });
+
+  it('hides the preview bar for a non-operator', async () => {
+    fetchJourneyStateApi.mockResolvedValue(stateFor('welcome', { canPreview: false }));
+    renderCanvas();
+    await screen.findByTestId('journey-step-welcome');
+    expect(screen.queryByTestId('journey-preview-bar')).not.toBeInTheDocument();
+  });
+});
+
+describe('HomeCanvas — CTA allow-list (ac-5 / impl ac-12)', () => {
+  it("an 'action' CTA routes into the real flow (create_spec → personal Specs board)", async () => {
+    tagAc(AC(5));
+    tagAc(AC(12));
+    fetchJourneyStateApi.mockResolvedValue(stateFor('welcome'));
+    renderCanvas();
+    fireEvent.click(await screen.findByTestId('journey-cta-primary'));
+    await waitFor(() =>
+      expect(screen.getByTestId('location')).toHaveTextContent('/john/personal/specs'),
+    );
+  });
+
+  it("a 'navigate' CTA moves within the canvas (Why Memex? → learn-more), no route change", async () => {
+    tagAc(AC(12));
+    fetchJourneyStateApi.mockResolvedValue(stateFor('welcome'));
+    renderCanvas();
+    fireEvent.click(await screen.findByTestId('journey-cta-secondary'));
+    expect(await screen.findByTestId('journey-step-learn-more')).toBeInTheDocument();
+    expect(screen.getByTestId('location')).toHaveTextContent('/home');
+  });
+});

--- a/packages/ui/src/pages/HomeCanvas.tsx
+++ b/packages/ui/src/pages/HomeCanvas.tsx
@@ -1,0 +1,178 @@
+// spec-303 — the Home Canvas: a user-level surface (dec-2) and a generic engine
+// (dec-1) that renders the current step of the user's journey. It loads journeys
+// from the registry and the user's derived position from the server; nothing
+// journey-specific lives here.
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useAuth } from '../components/AuthContext';
+import { useUserChangeStream } from '../hooks/useUserChangeStream';
+import {
+  fetchJourneyStateApi,
+  postJourneyEventApi,
+  type JourneyStateResponse,
+} from '../api/journey';
+import { resolveStepView, activeJourney } from '../journeys/registry';
+import { JourneyStepShell } from '../components/home/JourneyStepShell';
+import type { JourneyCta } from '../journeys/types';
+
+type NavMembership = { slug: string; memexSlug?: string | null; kind: string };
+
+function firstName(name: string | null | undefined): string | null {
+  if (!name) return null;
+  const f = name.trim().split(/\s+/)[0];
+  return f || null;
+}
+
+// The path that "begins creating a spec" — the user's personal Memex Specs board
+// (mirrors AuthContext's default-landing resolution).
+function personalSpecsPath(memberships?: ReadonlyArray<NavMembership>): string | null {
+  if (!memberships || memberships.length === 0) return null;
+  const personal = memberships.find((m) => m.kind === 'personal') ?? memberships[0];
+  const ns = personal.slug;
+  const mx = personal.memexSlug ?? (personal.kind === 'personal' ? 'personal' : 'main');
+  return `/${ns}/${mx}/specs`;
+}
+
+export function HomeCanvas() {
+  const { user, session } = useAuth();
+  const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const previewParam = searchParams.get('preview');
+
+  const [state, setState] = useState<JourneyStateResponse | null>(null);
+  // An in-canvas navigate (e.g. "Why Memex?") that wins until the real step changes.
+  const [viewOverride, setViewOverride] = useState<string | null>(null);
+
+  const load = useCallback(() => {
+    fetchJourneyStateApi(previewParam)
+      .then(setState)
+      .catch(() => {
+        /* keep last good state — the canvas never hard-crashes on a fetch blip */
+      });
+  }, [previewParam]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  // Live advance (ac-4): refetch on the user's own spec/decision changes, and when
+  // the tab refocuses (covers actions taken elsewhere in Memex).
+  useUserChangeStream(load, ['document', 'decision']);
+  useEffect(() => {
+    const onFocus = () => load();
+    window.addEventListener('focus', onFocus);
+    return () => window.removeEventListener('focus', onFocus);
+  }, [load]);
+
+  const preview = state?.preview ?? false;
+  const serverStepId = state?.currentStepId ?? null;
+  const activeStepId = viewOverride ?? serverStepId;
+
+  // Clear the in-canvas override whenever the underlying real step advances.
+  useEffect(() => {
+    setViewOverride(null);
+  }, [serverStepId]);
+
+  // Measurement (ac-7): a step was shown. Real (non-preview) views only.
+  useEffect(() => {
+    if (activeStepId && !preview) postJourneyEventApi(activeStepId, 'shown');
+  }, [activeStepId, preview]);
+
+  const specsPath = useMemo(
+    () => personalSpecsPath(session?.memberships as ReadonlyArray<NavMembership> | undefined),
+    [session],
+  );
+
+  const handleCta = useCallback(
+    (cta: JourneyCta) => {
+      if (activeStepId && !preview) postJourneyEventApi(activeStepId, 'cta', cta.target);
+      // In preview, CTAs are render-only (dec-8): show the step, change nothing.
+      if (preview) return;
+
+      if (cta.kind === 'navigate') {
+        setViewOverride(cta.target);
+        return;
+      }
+      if (cta.kind === 'link') {
+        window.open(cta.target, '_blank', 'noopener,noreferrer');
+        return;
+      }
+      // action — route into the real in-app flow (dec-5). The app owns the handler;
+      // the step only names an allow-listed action.
+      switch (cta.target) {
+        case 'connect_agent':
+        case 'invite':
+          navigate('/settings/integrations');
+          break;
+        case 'create_spec':
+        case 'create_decision':
+        case 'open_specs':
+        default:
+          if (specsPath) navigate(specsPath);
+          break;
+      }
+    },
+    [activeStepId, preview, navigate, specsPath],
+  );
+
+  const view = activeStepId ? resolveStepView(activeStepId) : null;
+
+  return (
+    <div className="min-h-full" data-testid="home-canvas">
+      {state?.canPreview && (
+        <PreviewBar
+          activeStepId={serverStepId}
+          onPick={(id) => setSearchParams(id ? { preview: id } : {})}
+        />
+      )}
+      {view ? (
+        <JourneyStepShell view={view} userName={firstName(user?.name)} onCta={handleCta} />
+      ) : (
+        <div className="flex min-h-[70vh] items-center justify-center text-muted">Loading…</div>
+      )}
+    </div>
+  );
+}
+
+// Operator-only (dec-9): pin any milestone step on your own account to review it
+// without minting a new user (dec-8). Render-only — the underlying state is intact.
+function PreviewBar({
+  activeStepId,
+  onPick,
+}: {
+  activeStepId: string | null;
+  onPick: (id: string | null) => void;
+}) {
+  const steps = activeJourney().milestoneStepIds;
+  return (
+    <div
+      data-testid="journey-preview-bar"
+      className="flex flex-wrap items-center gap-2 border-b border-edge bg-card-hover/40 px-4 py-2 text-xs"
+    >
+      <span className="font-semibold uppercase tracking-wider text-muted">Preview</span>
+      {steps.map((id) => (
+        <button
+          key={id}
+          type="button"
+          data-testid={`journey-preview-${id}`}
+          onClick={() => onPick(id)}
+          className={`rounded-md border px-2 py-1 ${
+            id === activeStepId
+              ? 'border-accent text-heading'
+              : 'border-edge text-secondary hover:text-primary'
+          }`}
+        >
+          {id}
+        </button>
+      ))}
+      <button
+        type="button"
+        data-testid="journey-preview-live"
+        onClick={() => onPick(null)}
+        className="rounded-md border border-edge px-2 py-1 text-secondary hover:text-primary"
+      >
+        Live
+      </button>
+    </div>
+  );
+}

--- a/packages/ui/src/pages/HomeCanvas.tsx
+++ b/packages/ui/src/pages/HomeCanvas.tsx
@@ -13,7 +13,7 @@ import {
 } from '../api/journey';
 import { resolveStepView, activeJourney } from '../journeys/registry';
 import { JourneyStepShell } from '../components/home/JourneyStepShell';
-import type { JourneyCta } from '../journeys/types';
+import type { JourneyCta, JourneyStepView } from '../journeys/types';
 
 type NavMembership = { slug: string; memexSlug?: string | null; kind: string };
 
@@ -115,7 +115,15 @@ export function HomeCanvas() {
     [activeStepId, preview, navigate, specsPath],
   );
 
+  const journey = activeJourney();
   const view = activeStepId ? resolveStepView(activeStepId) : null;
+  // Per-journey, attainment-framed, and never on the cold first step.
+  const showMap =
+    !!journey.showProgressMap &&
+    !!state?.steps?.length &&
+    !!activeStepId &&
+    activeStepId !== 'welcome' &&
+    journey.milestoneStepIds.includes(activeStepId);
 
   return (
     <div className="min-h-full" data-testid="home-canvas">
@@ -125,12 +133,107 @@ export function HomeCanvas() {
           onPick={(id) => setSearchParams(id ? { preview: id } : {})}
         />
       )}
+      {showMap && state?.steps && (
+        <ProgressMap steps={state.steps} currentStepId={activeStepId} views={journey.views} />
+      )}
       {view ? (
         <JourneyStepShell view={view} userName={firstName(user?.name)} onCta={handleCta} />
       ) : (
         <div className="flex min-h-[70vh] items-center justify-center text-muted">Loading…</div>
       )}
     </div>
+  );
+}
+
+// Attainment-framed progress map (dec-1, per-journey). Shows every milestone step
+// with a tick for what's actually attained — which makes the non-linear skipping
+// legible (a later step can be ticked while an earlier one isn't). Highlights the
+// step currently on screen. Real attainment, even under preview.
+function ProgressMap({
+  steps,
+  currentStepId,
+  views,
+}: {
+  steps: { id: string; attained: boolean }[];
+  currentStepId: string | null;
+  views: Record<string, JourneyStepView>;
+}) {
+  return (
+    <div
+      data-testid="journey-progress-map"
+      className="mx-auto mt-8 flex max-w-3xl items-start justify-center px-4"
+    >
+      {steps.map((s, i) => {
+        const isCurrent = s.id === currentStepId;
+        const label = views[s.id]?.mapLabel ?? s.id;
+        return (
+          <div key={s.id} className="flex items-start">
+            {i > 0 && (
+              <span
+                aria-hidden
+                className={`mt-[22px] h-0.5 w-8 flex-none rounded-sm sm:w-16 ${
+                  steps[i - 1].attained ? 'bg-status-success-text' : 'bg-edge'
+                }`}
+              />
+            )}
+            <div className="flex w-20 flex-col items-center sm:w-24">
+              <span
+                data-testid={`journey-map-${s.id}`}
+                data-attained={s.attained ? 'true' : 'false'}
+                className={`flex h-11 w-11 items-center justify-center rounded-full border-2 text-lg font-bold transition ${
+                  s.attained
+                    ? 'border-status-success-text bg-status-success-text text-white'
+                    : isCurrent
+                      ? 'border-accent bg-accent/10 text-accent'
+                      : 'border-edge text-muted'
+                }`}
+              >
+                {s.attained ? '✓' : ''}
+              </span>
+              <span
+                className={`mt-2 text-center text-[11px] leading-tight ${
+                  isCurrent
+                    ? 'font-semibold text-heading'
+                    : s.attained
+                      ? 'text-secondary'
+                      : 'text-muted'
+                }`}
+              >
+                {label}
+              </span>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// Internal explainer of the journey concept, shown in the staff-only bar.
+function JourneyInfo() {
+  return (
+    <span className="group relative inline-flex items-center">
+      <button
+        type="button"
+        aria-label="What is a journey?"
+        data-testid="journey-info"
+        className="inline-flex h-4 w-4 items-center justify-center rounded-full border border-status-warning-border text-[10px] font-bold leading-none text-status-warning-text"
+      >
+        i
+      </button>
+      <span
+        role="tooltip"
+        className="pointer-events-none absolute left-0 top-6 z-50 hidden w-[23rem] rounded-lg border border-edge bg-panel p-3 text-[11px] font-normal normal-case leading-relaxed tracking-normal text-secondary shadow-xl group-hover:block group-focus-within:block"
+      >
+        <b className="text-heading">Journeys</b>, an internal concept we&apos;re
+        introducing. A journey is one or more cards. Which card you see is determined by
+        your real state, not a fixed sequence: the moment your state changes, the canvas
+        advances you to the right step. Steps aren&apos;t strictly linear, each has its own
+        condition, so already-satisfied steps are skipped. If step 5&apos;s condition is met
+        but step 4&apos;s isn&apos;t, you land on step 4, and completing it can hop you
+        straight to step 6. This is the first journey; more will follow.
+      </span>
+    </span>
   );
 }
 
@@ -152,15 +255,16 @@ function PreviewBar({
   return (
     <div
       data-testid="journey-preview-bar"
-      title="Internal operator tool — visible only to Mindset staff (your email is on the preview allow-list). Pin any step to preview it on your own account; your real progress is unchanged, and regular users never see this bar."
-      className="flex flex-wrap items-center gap-2 border-b border-dashed border-status-warning-border bg-status-warning-bg/60 px-4 py-1.5 text-xs"
+      title="Mindset staff only: a manual step-switcher for previewing the journey. The Home Canvas and the journey itself are live for every user — only this row of step buttons is staff-only, and using it changes nothing about your real progress."
+      className="flex flex-wrap items-center gap-2 border-b border-dashed border-status-warning-border bg-status-warning-bg px-4 py-1.5 text-xs"
     >
       <span className="inline-flex items-center gap-1.5 font-semibold uppercase tracking-wider text-status-warning-text">
         <svg className="h-3.5 w-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
           <path strokeLinecap="round" strokeLinejoin="round" d="M12 3l7 3v5c0 4.5-3 7.5-7 9-4-1.5-7-4.5-7-9V6l7-3z" />
         </svg>
-        Internal preview · Mindset only
+        Mindset only · manual step switcher
       </span>
+      <JourneyInfo />
       <span className="mx-1 hidden text-status-warning-text/70 sm:inline">|</span>
       {steps.map((id) => (
         <button
@@ -186,7 +290,7 @@ function PreviewBar({
         Live
       </button>
       <span className="ml-auto hidden text-[10px] normal-case tracking-normal text-status-warning-text/70 md:inline">
-        render-only · users never see this
+        the journey below is live for everyone
       </span>
     </div>
   );

--- a/packages/ui/src/pages/HomeCanvas.tsx
+++ b/packages/ui/src/pages/HomeCanvas.tsx
@@ -136,6 +136,11 @@ export function HomeCanvas() {
 
 // Operator-only (dec-9): pin any milestone step on your own account to review it
 // without minting a new user (dec-8). Render-only — the underlying state is intact.
+//
+// This bar only renders for entitled operators (server-enforced canPreview), so a
+// regular user never sees it. For the Mindset staff who DO see it, the treatment is
+// deliberately marked INTERNAL (amber, dashed, a shield + "Mindset only" label and a
+// tooltip) so it reads as a staff tool, never a product feature.
 function PreviewBar({
   activeStepId,
   onPick,
@@ -147,19 +152,26 @@ function PreviewBar({
   return (
     <div
       data-testid="journey-preview-bar"
-      className="flex flex-wrap items-center gap-2 border-b border-edge bg-card-hover/40 px-4 py-2 text-xs"
+      title="Internal operator tool — visible only to Mindset staff (your email is on the preview allow-list). Pin any step to preview it on your own account; your real progress is unchanged, and regular users never see this bar."
+      className="flex flex-wrap items-center gap-2 border-b border-dashed border-status-warning-border bg-status-warning-bg/60 px-4 py-1.5 text-xs"
     >
-      <span className="font-semibold uppercase tracking-wider text-muted">Preview</span>
+      <span className="inline-flex items-center gap-1.5 font-semibold uppercase tracking-wider text-status-warning-text">
+        <svg className="h-3.5 w-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M12 3l7 3v5c0 4.5-3 7.5-7 9-4-1.5-7-4.5-7-9V6l7-3z" />
+        </svg>
+        Internal preview · Mindset only
+      </span>
+      <span className="mx-1 hidden text-status-warning-text/70 sm:inline">|</span>
       {steps.map((id) => (
         <button
           key={id}
           type="button"
           data-testid={`journey-preview-${id}`}
           onClick={() => onPick(id)}
-          className={`rounded-md border px-2 py-1 ${
+          className={`rounded-md border px-2 py-0.5 ${
             id === activeStepId
-              ? 'border-accent text-heading'
-              : 'border-edge text-secondary hover:text-primary'
+              ? 'border-status-warning-border bg-status-warning-bg font-medium text-status-warning-text'
+              : 'border-status-warning-border/50 text-status-warning-text/80 hover:bg-status-warning-bg'
           }`}
         >
           {id}
@@ -169,10 +181,13 @@ function PreviewBar({
         type="button"
         data-testid="journey-preview-live"
         onClick={() => onPick(null)}
-        className="rounded-md border border-edge px-2 py-1 text-secondary hover:text-primary"
+        className="rounded-md border border-status-warning-border/50 px-2 py-0.5 text-status-warning-text/80 hover:bg-status-warning-bg"
       >
         Live
       </button>
+      <span className="ml-auto hidden text-[10px] normal-case tracking-normal text-status-warning-text/70 md:inline">
+        render-only · users never see this
+      </span>
     </div>
   );
 }

--- a/packages/ui/src/pages/HomeCanvas.tsx
+++ b/packages/ui/src/pages/HomeCanvas.tsx
@@ -105,6 +105,9 @@ export function HomeCanvas() {
           navigate('/settings/integrations');
           break;
         case 'create_spec':
+          // Open the SAME agent-backed NewSpecModal the Specs board uses (?new=1).
+          if (specsPath) navigate(`${specsPath}?new=1`);
+          break;
         case 'create_decision':
         case 'open_specs':
         default:
@@ -225,13 +228,12 @@ function JourneyInfo() {
         role="tooltip"
         className="pointer-events-none absolute left-0 top-6 z-50 hidden w-[23rem] rounded-lg border border-edge bg-panel p-3 text-[11px] font-normal normal-case leading-relaxed tracking-normal text-secondary shadow-xl group-hover:block group-focus-within:block"
       >
-        <b className="text-heading">Journeys</b>, an internal concept we&apos;re
-        introducing. A journey is one or more cards. Which card you see is determined by
-        your real state, not a fixed sequence: the moment your state changes, the canvas
-        advances you to the right step. Steps aren&apos;t strictly linear, each has its own
-        condition, so already-satisfied steps are skipped. If step 5&apos;s condition is met
-        but step 4&apos;s isn&apos;t, you land on step 4, and completing it can hop you
-        straight to step 6. This is the first journey; more will follow.
+        <b className="text-heading">This is the onboarding journey.</b> Which card you see
+        is determined by your state, not a fixed sequence: the moment your state changes,
+        the canvas advances you to the right step. Steps aren&apos;t strictly linear, each
+        has its own condition, so already-satisfied steps are skipped. If step 5&apos;s
+        condition is met but step 4&apos;s isn&apos;t, you land on step 4, and completing it
+        can hop you straight to step 6.
       </span>
     </span>
   );

--- a/packages/ui/src/pages/SpecList.tsx
+++ b/packages/ui/src/pages/SpecList.tsx
@@ -431,6 +431,19 @@ export function SpecList() {
   const [shareDocId, setShareDocId] = useState<string | null>(null);
   const [renameDoc, setRenameDoc] = useState<DocSummary | null>(null);
   const [moveDoc_, setMoveDoc] = useState<DocSummary | null>(null);
+
+  // spec-303: the Home Canvas "Create your first spec" CTA deep-links here with
+  // ?new=1 to open the SAME NewSpecModal the board's "+ New Spec" button uses —
+  // no second create path. The param is cleared so a refresh doesn't re-open it.
+  useEffect(() => {
+    if (searchParams.get('new') === '1') {
+      setModalOpen(true);
+      const next = new URLSearchParams(searchParams);
+      next.delete('new');
+      setSearchParams(next, { replace: true });
+    }
+  }, [searchParams, setSearchParams]);
+
   // Default-collapsed Done column (dec-5). Drop targets stay live in the rail.
   // Resets on every mount — leaving Done open across navigations made the board
   // feel cluttered, so we trade persistence for a clean default each visit.


### PR DESCRIPTION
## What this is

A new **Home Canvas**: the first item in the left nav, a **user-level** surface (the same across all of a user's Memexes) that shows the one thing the system needs from them next. **v0** stems the onboarding bleed by walking a brand-new user through a hard-gated onboarding **journey**, opening with the "MD files are dead" welcome splash and advancing as they create their first spec, decision, connect their agent, and use it.

Memex spec: [`mindset-prod/memex-building-itself/spec-303`](https://memex.ai/mindset-prod/memex-building-itself/specs/spec-303) — **17/17 ACs verified**, 10 decisions, tasks t-1…t-5.

## Architecture (per the spec's decisions)

- **Modular journeys (dec-1):** self-contained modules, never interwoven — `packages/server/src/journeys/onboarding.ts` (ordered steps + gating milestones) and `packages/ui/src/journeys/onboarding/` (step views), loaded by generic engines (the journey-state service + the `HomeCanvas` page) via a registry. Steps are compiled components; no injected/remote HTML.
- **State-derived position (dec-3):** `getUserJourneyState` derives the current step from the user's real milestones — no stored cursor, so the canvas self-heals (create a spec anywhere and it advances).
- **User-scoped milestones (dec-4):** a spec/decision/MCP-connect/tool-call by *this* user (demo content excluded), so a new hire in a busy org is still taught from the start.
- **CTA allow-list (dec-5):** `navigate` / app-owned `action` / `link`; a step requests an action, never carries code.
- **Operator preview (dec-8/dec-9):** `?preview=<step>` pins any step on the operator's own account (render-only), gated by a **server capability bound to the `JOURNEY_PREVIEW_DOMAINS` deploy-config value** — no vendor domain hardcoded (std-22).
- **No billing/entitlement coupling (dec-10):** journey-state is a state *signal*, preview is *authorisation*; both via single accessors.

**Surface:** `GET /api/me/journey-state` + `POST /api/me/journey-event` (caller-scoped, user-level); flat `/home` route; Home as the top left-nav item. Measurement (step-shown / cta-clicked) lands in `usage_events` (advisory).

## Test plan

- [x] Server integration (`journey.api.test.ts`, `journey-modules.unit.test.ts`) — 13 tests: derivation, hard-gating, user-scoping, terminal, preview entitlement, measurement, layering
- [x] UI component (`HomeCanvas.test.tsx`, `AppShell.test.tsx`) — welcome splash, per-step isolation, CTA allow-list, preview bar, nav placement
- [x] e2e (`journey-34-home-canvas.spec.ts`, std-28) — cold user sees the welcome step, self-advances after creating a spec (`make e2e-cold`)
- [x] Full UI suite: 1334 passed (no regressions)
- [x] UI build + UI/new-server typecheck clean
- [x] spec-303: 17/17 ACs emitted + verified

## Notes for the reviewer

- **Deploy config:** the operator preview is off until a deployment sets `JOURNEY_PREVIEW_DOMAINS` (e.g. `mindset.ai` on prod). Unset = nobody can preview. Nothing vendor-specific ships in the code.
- **Pre-existing failures (not from this change):** the full server suite has 2 reds in the embeddings subsystem (`memex-embeddings` fake-provider re-embed count; `standards-graph` semantic threshold). My diff touches only journeys + nav/route, and vitest isolates each file in its own worker DB, so these are causally independent of this PR. Flagging rather than hiding.
- v0 is journeys-only by design; the attention-hub / recommendations / progress-tracker are the spec's north star, explicitly out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)