### PR TITLE
test: fix funnel spec_index flake — poll for async usage_events (spec-278)

### DIFF
--- a/packages/server/src/services/funnel-document-task.integration.test.ts
+++ b/packages/server/src/services/funnel-document-task.integration.test.ts
@@ -63,25 +63,41 @@ describe("task.created mirrors into usage_events (ac-3, ac-7)", () => {
 describe("document.created carries spec_index = Nth spec for the user (ac-3)", () => {
   it("the index increments per spec the user creates", async () => {
     tagAc(`${AC}/ac-3`);
-    // Fresh user → no prior specs, so the first spec is #1, the second #2.
-    const u = await upsertUserByEmail(`specidx-${Date.now()}@example.com`);
+    // spec-278 issue-1 / ac-5: stabilise this flake.
+    tagAc("mindset-prod/memex-building-itself/specs/spec-278/acs/ac-5");
+    // Fresh user → no prior specs, so the first spec is #1, the second #2. The
+    // email carries per-call randomness (not just Date.now()) so it can't alias
+    // another test's user and pollute the per-user spec count.
+    const u = await upsertUserByEmail(
+      `specidx-${Date.now()}-${Math.random().toString(36).slice(2, 8)}@example.com`,
+    );
     const m = await makeTestMemex("specidx");
 
     const first = await createDocDraft(m, "Spec one", "p", "spec", undefined, undefined, u.id, { actorUserId: u.id });
     const second = await createDocDraft(m, "Spec two", "p", "spec", undefined, undefined, u.id, { actorUserId: u.id });
 
-    const firstRow = (
-      await db
+    // usage_events rows are written ASYNCHRONOUSLY by the backend sink (a bus
+    // subscriber). Poll until both spec rows have landed rather than reading
+    // immediately — the read-too-early race is what intermittently left
+    // `secondRow` undefined and reddened the merge gate (spec-278 issue-1).
+    const findByIndex = (
+      rows: (typeof usageEvents.$inferSelect)[],
+      idx: number,
+    ) => rows.find((r) => r.props && (r.props as Record<string, unknown>).spec_index === idx);
+
+    let firstRow: typeof usageEvents.$inferSelect | undefined;
+    let secondRow: typeof usageEvents.$inferSelect | undefined;
+    const deadline = Date.now() + 2000;
+    while (Date.now() < deadline) {
+      const rows = await db
         .select()
         .from(usageEvents)
-        .where(and(eq(usageEvents.memexId, m), eq(usageEvents.name, "document.created")))
-    ).find((r) => r.props && (r.props as Record<string, unknown>).spec_index === 1);
-    const secondRow = (
-      await db
-        .select()
-        .from(usageEvents)
-        .where(and(eq(usageEvents.memexId, m), eq(usageEvents.name, "document.created")))
-    ).find((r) => r.props && (r.props as Record<string, unknown>).spec_index === 2);
+        .where(and(eq(usageEvents.memexId, m), eq(usageEvents.name, "document.created")));
+      firstRow = findByIndex(rows, 1);
+      secondRow = findByIndex(rows, 2);
+      if (firstRow && secondRow) break;
+      await new Promise((r) => setTimeout(r, 25));
+    }
 
     expect(firstRow, "first spec should carry spec_index 1").toBeDefined();
     expect(secondRow, "second spec should carry spec_index 2").toBeDefined();


### PR DESCRIPTION
## What

Fixes the flaky test that reddened the `develop` merge gate after #241 (run 27753458213) — confirmed a flake (re-run of the same commit went green). Resolves **spec-278 issue-1**.

`funnel-document-task.integration.test.ts` → "the index increments per spec the user creates" intermittently failed with `second spec should carry spec_index 2: expected undefined to be defined`.

## Root cause (corrected from the issue's initial hypothesis)

Not a namespace-slug collision — `uniqueSlug` already mixes `Date.now()` + `Math.random()`, and per-worker DB clones run in-file tests serially, so that can't collide here (the `namespaces_slug_unique` log spam is red-herring noise from a different conflict-handling test).

The real cause is an **async-write race**: `usage_events` rows are written asynchronously by `startUsageBackendSink` (a bus subscriber), but this test queried them **synchronously** right after `createDocDraft` — unlike its sibling `task.created` test, which polls via `waitForRows`. Under CI load the second spec's `document.created` row hadn't been flushed yet. `firstRow` found / `secondRow` undefined is the exact signature.

## Fix
- Poll until both `spec_index` 1 and 2 rows are present (or 2s timeout) before asserting.
- Add per-call randomness to the fresh-user email so it can't alias another test's user and pollute the per-user spec count.
- Tagged `spec-278/ac-5`.

## Test plan
- [x] tsc clean for the file
- [x] 3× consecutive green locally; emitted (spec-278 ac-5 → verified)
- [ ] CI green on this PR (server shards in particular)

## Note
The flake couldn't be reproduced deterministically red (it's timing-dependent), so there's no red→green emission pair — the fix removes the race by construction (waiting for the async write the assertion depends on).

🤖 Generated with [Claude Code](https://claude.com/claude-code)