### PR TITLE
feat: gate the Home Canvas behind HIDDEN_FEATURES (feature: 'home')

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -370,8 +370,25 @@ export function PostLoginRouter() {
       <Route path="/invites" element={<Navigate to="/org?tab=invites" replace />} />
       <Route path="/org" element={<FlatShell><OrgConfiguration /></FlatShell>} />
       <Route path="/account" element={<Navigate to="/org" replace />} />
-      {/* spec-303 — Home Canvas: user-level, flat (not tenant-scoped). */}
-      <Route path="/home" element={<FlatShell><HomeCanvas /></FlatShell>} />
+      {/* spec-303 — Home Canvas: user-level, flat (not tenant-scoped). Gated on
+          the server-driven hide list (feature: 'home') so the surface can be
+          hidden per-env (e.g. prod) while live on int — same mechanism as /pulse.
+          When hidden we REDIRECT rather than drop the route: /home is a flat,
+          single-segment path, so an unregistered route would otherwise be claimed
+          by /:namespace below (resolving "home" as a namespace). RootRedirect
+          sends the user to their default landing instead. */}
+      <Route
+        path="/home"
+        element={
+          isFeatureHidden(session, 'home') ? (
+            <RootRedirect />
+          ) : (
+            <FlatShell>
+              <HomeCanvas />
+            </FlatShell>
+          )
+        }
+      />
 
 
       {/* doc-19 t-10: namespace home — /<namespace>/ renders the kind-aware

--- a/packages/ui/src/components/AppShell.test.tsx
+++ b/packages/ui/src/components/AppShell.test.tsx
@@ -290,4 +290,25 @@ describe('AppShell feature-hide (spec-146 t-3)', () => {
     const visibleNav = screen.getByTestId('primary-nav');
     expect(within(visibleNav).getByRole('link', { name: 'Scaffold' })).toBeInTheDocument();
   });
+
+  // The Home Canvas (spec-303) is gated by the same mechanism: 'home' in the
+  // session hiddenFeatures drops the top nav link, so the whole surface can be
+  // hidden per-env (prod) while it stays live on int. The route is gated to
+  // match in App.tsx (redirect when hidden).
+  it("hides the Home nav link when 'home' is in the session hiddenFeatures", () => {
+    // Hidden: 'home' listed → no Home link for anyone on this env.
+    mockSession.value = sessionWith(['home']);
+    const hidden = renderShell(['/specs']);
+    const hiddenNav = screen.getByTestId('primary-nav');
+    expect(within(hiddenNav).queryByRole('link', { name: 'Home' })).not.toBeInTheDocument();
+    // Specs (a non-feature link) is untouched — only Home went away.
+    expect(within(hiddenNav).getByRole('link', { name: 'Specs' })).toBeInTheDocument();
+    hidden.unmount();
+
+    // Visible: empty hiddenFeatures → Home returns as the first nav item.
+    mockSession.value = sessionWith([]);
+    renderShell(['/specs']);
+    const visibleNav = screen.getByTestId('primary-nav');
+    expect(within(visibleNav).getByRole('link', { name: 'Home' })).toBeInTheDocument();
+  });
 });

--- a/packages/ui/src/components/AppShell.tsx
+++ b/packages/ui/src/components/AppShell.tsx
@@ -53,10 +53,14 @@ interface NavLinkDef {
 
 // spec-303 — the Home Canvas: the top nav item and a user-level (flat) destination,
 // identical across all of a user's Memexes (dec-2). `flat` keeps it at /home.
+// `feature: 'home'` plugs it into the server-driven hide list (HIDDEN_FEATURES)
+// so the whole surface can be hidden per-env (e.g. prod) while it's live on int —
+// the same mechanism as Pulse/Scaffold. The route is gated in App.tsx to match.
 const HOME_NAV_LINK: NavLinkDef = {
   to: '/home',
   label: 'Home',
   flat: true,
+  feature: 'home',
   icon: (
     <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.75}>
       <path strokeLinecap="round" strokeLinejoin="round" d="M3 12l9-9 9 9M5 10v10a1 1 0 001 1h3v-5a1 1 0 011-1h2a1 1 0 011 1v5h3a1 1 0 001-1V10" />
@@ -613,8 +617,12 @@ export function AppShell({ children }: { children: ReactNode }) {
         </div>
 
         <nav className="flex-1 min-h-0 overflow-y-auto px-3 space-y-0.5">
-          {/* spec-303 — Home Canvas: the first, top-level, user-level destination. */}
-          <NavItem {...HOME_NAV_LINK} pathname={location.pathname} />
+          {/* spec-303 — Home Canvas: the first, top-level, user-level destination.
+              Gated on the server-driven hide list (feature: 'home') so it can be
+              hidden per-env (e.g. prod) while live on int — same mechanism as Pulse. */}
+          {!isLinkHidden(HOME_NAV_LINK.feature) && (
+            <NavItem {...HOME_NAV_LINK} pathname={location.pathname} />
+          )}
 
           {/* spec-260 t-11: two labelled groups — PRINCIPLES (the working
               surfaces) and IN-BOXES (the badge-carrying attention surfaces). */}


### PR DESCRIPTION
## What
Makes the Home Canvas (spec-303) hideable per-environment by plugging it into the existing server-driven feature-hide deny-list (`HIDDEN_FEATURES` → `session.hiddenFeatures`), the same mechanism as Pulse / Scaffold / Insights / QA-Reports.

**This changes no behaviour on its own.** Home stays visible everywhere until an environment explicitly sets `HIDDEN_FEATURES=home`. It's the prerequisite that lets `develop` keep flowing to prod while the Home/journey work is hidden there and live on int.

## Changes
- **AppShell**: `HOME_NAV_LINK` carries `feature: 'home'`; the top nav link is dropped when `'home'` is in `session.hiddenFeatures`.
- **App.tsx**: the flat `/home` route **redirects** (`RootRedirect`) when hidden rather than dropping the route — `/home` is a single-segment flat path, so an unregistered route would otherwise be claimed by `/:namespace` and resolve "home" as a namespace.
- **Tests**: `AppShell.test.tsx` asserts the Home link hides with `['home']` and returns when empty. `featureFlags` already covers `isFeatureHidden`.

## Deny-list semantics (reminder)
`HIDDEN_FEATURES` is a blacklist: list slugs to hide; unset/empty = nothing hidden (fail-open). Per-env values live in the canonical `memex-<env>-deploy-env` secret; the Cloud Run env update is a merge (spec-168 dec-4).

## Rollout plan
1. Merge → develop → int.
2. Set `HIDDEN_FEATURES=home` on int, verify Home is hidden, then un-hide on int.
3. Set `HIDDEN_FEATURES=home` on prod.

## Test plan
- [x] `AppShell.test.tsx` + `featureFlags.test.ts` green
- [x] UI `tsc --noEmit` clean
- [ ] Verify on int after deploy (hide → confirm gone → un-hide)