### PR TITLE
fix(onboarding): don't soft-lock new signups when the Home Canvas is hidden

### DIFF
--- a/packages/ui/src/App.onboarding-home-gate.test.tsx
+++ b/packages/ui/src/App.onboarding-home-gate.test.tsx
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom';
+import type { ReactNode } from 'react';
+import type { SessionPayload } from './api/client';
+
+// Regression — the onboarding destination must respect the Home Canvas feature gate.
+//
+// THE BUG: spec-305 routes every `needsOnboarding` user to /home (the Home Canvas
+// journey). But /home is gated per-env: when 'home' is in HIDDEN_FEATURES (e.g. prod,
+// before the journey is ready) the /home route renders <RootRedirect/> instead of the
+// journey. RootRedirect's FIRST check sends `needsOnboarding` users straight back to
+// /home — so a brand-new signup is trapped in an infinite /home ⇄ RootRedirect loop and
+// can never reach the app. Hiding the tab silently soft-locks every new prod signup.
+//
+// THE FIX: when 'home' is hidden, onboarding falls back to the still-present legacy
+// /onboarding page (which stamps identity_confirmed_at and clears needsOnboarding just
+// the same). When 'home' is visible, the journey at /home is used exactly as today.
+//
+// We mount the real PostLoginRouter so the gate + RootRedirect resolve through genuine
+// react-router; the journey page, legacy page, and tenant chrome are stubbed to sentinels
+// so the test isolates the routing decision, not the screens.
+
+let mockSession: SessionPayload;
+function makeSession(opts: { needsOnboarding: boolean; hiddenFeatures: string[] }): SessionPayload {
+  return {
+    user: {
+      id: 'u-1',
+      email: 'alice@example.com',
+      name: 'Alice',
+      status: 'active',
+      emailVerified: true,
+    },
+    memberships: [
+      {
+        memexId: 'mx-alice',
+        slug: 'alice',
+        memexSlug: 'personal',
+        name: 'Personal Memex',
+        kind: 'personal' as const,
+        role: 'administrator' as const,
+      },
+    ],
+    currentMemexId: 'mx-alice',
+    currentRole: 'administrator' as const,
+    needsOnboarding: opts.needsOnboarding,
+    hiddenFeatures: opts.hiddenFeatures,
+  };
+}
+
+vi.mock('./components/AuthContext', async () => {
+  const real = await vi.importActual<typeof import('./components/AuthContext')>(
+    './components/AuthContext',
+  );
+  return {
+    ...real,
+    useAuth: () => ({
+      session: mockSession,
+      user: { name: 'Alice', email: 'alice@example.com', picture: '' },
+      token: 'fake-token',
+      isAuthenticated: true,
+      authError: null,
+      logout: vi.fn(),
+      updateSession: vi.fn(),
+      acceptSession: vi.fn(),
+    }),
+  };
+});
+
+vi.mock('./components/AppShell', () => ({
+  AppShell: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+vi.mock('./components/ChatContext', () => ({
+  ChatProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+vi.mock('./components/OrgConsentDialog', () => ({ OrgConsentDialog: () => null }));
+vi.mock('./pages/HomeCanvas', () => ({
+  HomeCanvas: () => <div data-testid="home-canvas-page">home journey</div>,
+}));
+vi.mock('./pages/Onboarding', () => ({
+  Onboarding: () => <div data-testid="onboarding-page">legacy name page</div>,
+}));
+
+import { PostLoginRouter } from './App';
+
+function LocationProbe() {
+  const loc = useLocation();
+  return <div data-testid="probe" data-path={loc.pathname} />;
+}
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/*" element={<PostLoginRouter />} />
+        {/* Probe the default-landing tenant path so we can assert RootRedirect's
+            non-onboarding target without dragging in TenantLayout/SpecList. */}
+        <Route path="/alice/personal/specs" element={<LocationProbe />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('onboarding destination respects the Home Canvas feature gate', () => {
+  beforeEach(() => {
+    vi.stubEnv('VITE_GOOGLE_CLIENT_ID', 'test-client-id');
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('home VISIBLE: a needs-onboarding user lands on the Home Canvas journey', async () => {
+    mockSession = makeSession({ needsOnboarding: true, hiddenFeatures: [] });
+    renderAt('/');
+    expect(await screen.findByTestId('home-canvas-page')).toBeInTheDocument();
+    expect(screen.queryByTestId('onboarding-page')).not.toBeInTheDocument();
+  });
+
+  it('home HIDDEN: a needs-onboarding user lands on the legacy /onboarding page (no /home loop)', async () => {
+    mockSession = makeSession({ needsOnboarding: true, hiddenFeatures: ['home'] });
+    renderAt('/');
+    // Before the fix this renders nothing (the /home ⇄ RootRedirect loop); after the
+    // fix the user lands on the working legacy onboarding page.
+    expect(await screen.findByTestId('onboarding-page')).toBeInTheDocument();
+    expect(screen.queryByTestId('home-canvas-page')).not.toBeInTheDocument();
+  });
+
+  it('home HIDDEN, already onboarded: a deliberate /home visit still bounces to the default tenant', async () => {
+    mockSession = makeSession({ needsOnboarding: false, hiddenFeatures: ['home'] });
+    renderAt('/home');
+    await waitFor(() => {
+      expect(screen.getByTestId('probe').getAttribute('data-path')).toBe(
+        '/alice/personal/specs',
+      );
+    });
+    expect(screen.queryByTestId('home-canvas-page')).not.toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -39,7 +39,7 @@ import { DocumentShell } from './components/DocumentShell';
 import { OrgConsentDialog } from './components/OrgConsentDialog';
 import { parseTenantFromPathname } from './utils/tenantUrl';
 import { isFeatureHidden } from './utils/featureFlags';
-import { probePublicMemex, type PublicMemexProbe } from './api/client';
+import { probePublicMemex, type PublicMemexProbe, type SessionPayload } from './api/client';
 import { PublicMemexProvider } from './components/PublicMemexContext';
 import {
   VoiceSessionProvider,
@@ -170,8 +170,9 @@ function TenantLayout() {
     return <VerifyEmailGate />;
   }
   if (session.needsOnboarding) {
-    // spec-305 dec-2: onboarding now lives in the Home Canvas journey (/home).
-    return <Navigate to="/home" replace />;
+    // spec-305 dec-2: onboarding lives in the Home Canvas journey (/home), with a
+    // legacy /onboarding fallback when 'home' is hidden per-env (see onboardingPath).
+    return <Navigate to={onboardingPath(session)} replace />;
   }
 
   // Membership check: redirect to the user's default tenant when they aren't
@@ -323,6 +324,18 @@ function VoiceGuideMount({
   );
 }
 
+// Where a `needsOnboarding` user is sent. Onboarding normally lives in the Home
+// Canvas journey at /home (spec-305 dec-2). But /home is gated per-env: when 'home'
+// is in HIDDEN_FEATURES (e.g. prod, before the journey is ready) the /home route
+// renders RootRedirect — which would bounce a needs-onboarding user straight back to
+// /home, an infinite loop that soft-locks every new signup. In that case we fall back
+// to the legacy standalone /onboarding page, which stamps identity_confirmed_at and
+// clears needsOnboarding all the same. Un-hiding 'home' restores the journey with no
+// code change. Keep this in lock-step with the /home gate (the route element below).
+function onboardingPath(session: SessionPayload | null): string {
+  return isFeatureHidden(session, 'home') ? '/onboarding' : '/home';
+}
+
 // `/` lands the authenticated user on their default tenant's specs page.
 // Pre-auth users won't reach this (RequireAuth intercepts), but if the
 // session loads with zero memberships we render the specs board behind
@@ -332,7 +345,7 @@ function RootRedirect() {
   const { session } = useAuth();
   if (!session) return null; // session bootstrap still pending
   if (session && !session.user.emailVerified) return <VerifyEmailGate />;
-  if (session?.needsOnboarding) return <Navigate to="/home" replace />; // spec-305 dec-2
+  if (session?.needsOnboarding) return <Navigate to={onboardingPath(session)} replace />; // spec-305 dec-2 (+ /home-hidden fallback)
   const target = computeDefaultLanding(session);
   if (target) return <Navigate to={target} replace />;
   return null;
@@ -516,11 +529,12 @@ function FlatShell({ children }: { children: React.ReactNode }) {
   const { session } = useAuth();
   const location = useLocation();
   if (session && !session.user.emailVerified) return <VerifyEmailGate />;
-  // spec-305 dec-2: needs-onboarding users belong on the Home Canvas journey.
-  // Exempt /home itself so the journey renders there (its identity step clears
-  // needsOnboarding); every other flat route bounces them to /home.
-  if (session?.needsOnboarding && location.pathname !== '/home') {
-    return <Navigate to="/home" replace />;
+  // spec-305 dec-2: needs-onboarding users belong on the active onboarding surface —
+  // the Home Canvas journey at /home, or the legacy /onboarding page when 'home' is
+  // hidden per-env (onboardingPath). Exempt that surface so it renders; every other
+  // flat route bounces them to it.
+  if (session?.needsOnboarding && location.pathname !== onboardingPath(session)) {
+    return <Navigate to={onboardingPath(session)} replace />;
   }
   return (
     <ChatProvider>


### PR DESCRIPTION
## The bug (prod ship-blocker)

The Home Canvas onboarding journey is gated off prod via `HIDDEN_FEATURES=home` until it's ready. But hiding it doesn't just hide the nav tab: it **soft-locks every new signup**.

spec-305 rewired onboarding to *be* `/home`: a `needsOnboarding` user is redirected to `/home` (in `RequireAuth`, `RootRedirect`, and `FlatShell`). When `home` is hidden, the `/home` route renders `<RootRedirect/>` instead of the journey, and `RootRedirect`'s **first** check is `if (needsOnboarding) → /home`. So:

```
/home  →  (home hidden) RootRedirect  →  needsOnboarding → /home  →  …
```

A new user never reaches onboarding and never reaches the app (blank page / "too many redirects"). This is latent on develop today (dormant on int, where `home` is live) and would arm the moment we deploy to prod with `home` hidden.

## The fix

A single `onboardingPath(session)` helper picks the onboarding destination:

- `home` **visible** → `/home` (the journey, exactly as today)
- `home` **hidden** → the legacy standalone `/onboarding` page

The legacy page is still routed and fully functional: `PATCH /auth/profile` always passes `confirmIdentity: true`, which stamps `identity_confirmed_at` and clears `needsOnboarding` identically. So new prod users get a working name-entry onboarding while the journey stays off prod; un-hiding `home` restores the journey with **no code change**. Applied at all three `needsOnboarding` redirect sites.

## Tests

`App.onboarding-home-gate.test.tsx` mounts the **real** `PostLoginRouter` (real `RootRedirect` / `FlatShell` / `isFeatureHidden`):

- home **hidden** + needsOnboarding → lands on `/onboarding` (this test was RED before the fix: the user was trapped on a dead `/home`)
- home **visible** + needsOnboarding → still lands on the Home Canvas journey
- home **hidden** + already onboarded → a deliberate `/home` visit still bounces to the default tenant (gate intact)

## Verified locally (full suite, all green)

- Server suite: 406 files, 4101 passed, 0 failed
- UI suite: 185 files, 1364 passed
- UI typecheck + server build typecheck: clean
- `make e2e-cold`: 76 journeys passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)