### PR TITLE
feat(spec-307): MCP access follows live membership, not a frozen Org grant

### DIFF
--- a/packages/server/src/__regression__/mcp-token-prefix-fork.regression.test.ts
+++ b/packages/server/src/__regression__/mcp-token-prefix-fork.regression.test.ts
@@ -1,4 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+// spec-307: the dispatch now passes orgFilter=undefined for OAuth callers too (live
+// membership), so the token's `org` claim is no longer the orgFilter. ac-5.
+const AC_307_5 = "mindset-prod/memex-building-itself/specs/spec-307/acs/ac-5";
 
 // b-31 W1 t-4 — the /mcp route accepts both `Bearer mxt_...` (existing) and
 // OAuth JWTs (when OAUTH_ENABLED=1). This regression test pins the four
@@ -118,7 +123,8 @@ describe("regression: /mcp token-prefix fork (b-31 t-4)", () => {
     expect(verifyAccessToken).not.toHaveBeenCalled();
   });
 
-  it("OAuth JWT with OAUTH_ENABLED on → verifyAccessToken; userId comes from claims.sub, claims.org flows through (b-31 dec-8)", async () => {
+  it("spec-307: OAuth JWT with OAUTH_ENABLED on → verifyAccessToken; userId from claims.sub, claims.org IGNORED (orgFilter=undefined, live membership)", async () => {
+    tagAc(AC_307_5);
     process.env.OAUTH_ENABLED = "1";
     verifyAccessToken.mockReturnValue({
       sub: "u-3",
@@ -134,11 +140,13 @@ describe("regression: /mcp token-prefix fork (b-31 t-4)", () => {
     expect(res.status).toBe(200);
     expect(verifyMcpToken).not.toHaveBeenCalled();
     expect(verifyAccessToken).toHaveBeenCalledWith("eyJ.something.valid");
-    // OAuth path: claims.org becomes the orgFilter — Org-scope filter is on.
-    expect(createMcpServer).toHaveBeenCalledWith("u-3", "org-acme", expect.any(String));
+    // spec-307: claims.org is NO LONGER the orgFilter — OAuth resolves live membership
+    // exactly like a PAT (orgFilter undefined). The frozen "org-acme" scope is inert.
+    expect(createMcpServer).toHaveBeenCalledWith("u-3", undefined, expect.any(String));
   });
 
-  it("OAuth JWT with org=null (personal-only grant) passes orgFilter=null", async () => {
+  it("spec-307: OAuth JWT with org=null (personal-only grant) also resolves live membership (orgFilter=undefined)", async () => {
+    tagAc(AC_307_5);
     process.env.OAUTH_ENABLED = "1";
     verifyAccessToken.mockReturnValue({
       sub: "u-4",
@@ -152,10 +160,10 @@ describe("regression: /mcp token-prefix fork (b-31 t-4)", () => {
     });
     const res = await postMcp("Bearer eyJ.personal.only");
     expect(res.status).toBe(200);
-    // Critical distinction: null !== undefined. Personal-only OAuth tokens
-    // get orgFilter=null (which scopes to personal Memex only); PAT tokens
-    // get orgFilter=undefined (full surface).
-    expect(createMcpServer).toHaveBeenCalledWith("u-4", null, expect.any(String));
+    // spec-307: a personal-only token (org=null) no longer scopes to personal only —
+    // it resolves the user's full live membership (orgFilter=undefined), the same
+    // surface a PAT gets. This is what lets an existing token survive Org graduation.
+    expect(createMcpServer).toHaveBeenCalledWith("u-4", undefined, expect.any(String));
   });
 
   it("invalid OAuth JWT → 401 + WWW-Authenticate with error=invalid_token", async () => {

--- a/packages/server/src/__regression__/tenant-isolation.regression.test.ts
+++ b/packages/server/src/__regression__/tenant-isolation.regression.test.ts
@@ -218,8 +218,10 @@ beforeAll(async () => {
   // Confirm Bob's memex is private (schema default, but state it explicitly).
   await db.update(memexes).set({ visibility: "private" }).where(eq(memexes.id, bob.memexId));
 
-  // Dave: member of BOTH org-A (Alice's) and org-B (Bob's), OAuth token scoped to org-A.
-  // Tests that orgFilter rejects org-B reads even when Dave has org-B membership.
+  // Dave: member of BOTH org-A (Alice's) and org-B (Bob's), OAuth token minted
+  // org-A-scoped. Under spec-307 the token's frozen Org scope is INERT — Dave's
+  // reach follows LIVE membership, so the same token reaches org-B because Dave is
+  // an active member (the widening this Spec introduces; the old model rejected it).
   // PAT tokens (mxt_ prefix) are matched first in app.ts, so enabling OAuth here
   // does not affect any of the existing PAT-based tests above.
   process.env.OAUTH_ENABLED = "1";
@@ -478,6 +480,8 @@ describe("regression: tenant-isolation — Carol intra-org memex switching", () 
 // ── spec-199 t-7: Cross-tenant read gate (canReadMemex / resolveWorkspaceForRead) ─
 
 const AC_7 = "mindset-prod/memex-building-itself/specs/spec-199/acs/ac-7";
+// spec-307: live membership supersedes the frozen Org scope (spec-31 dec-8).
+const AC_307_6 = "mindset-prod/memex-building-itself/specs/spec-307/acs/ac-6";
 
 describe("regression: tenant-isolation — read tools cross-tenant gate (spec-199 t-7)", () => {
   // ref-path tools: resolveMemexFromEntityForRead → assertReadAccessAndWriteFlag
@@ -529,11 +533,23 @@ describe("regression: tenant-isolation — read tools cross-tenant gate (spec-19
     expect(body.result?.isError, `Dave's org-A token should read Alice's memex: ${body.result?.content?.[0]?.text ?? ""}`).toBeFalsy();
   });
 
-  it("orgFilter: Dave's org-A token is rejected on Bob's org-B private memex despite org-B membership", async () => {
-    tagAc(AC_7);
-    // Dave IS a member of org-B (Bob's org), but orgFilter=alice.orgId !== bob.orgId → rejected.
-    await expectRejection(daveOAuthToken, "get_doc", {
-      ref: bobRef(`specs/${bobSpecHandle}`),
+  // spec-307: the frozen Org scope is inert — Dave's org-A-scoped token now reaches
+  // Bob's org-B memex BECAUSE Dave is an active member of org-B (connect once, survive
+  // graduation). True isolation is still proven above: non-members (Alice, Carol)
+  // remain rejected on Bob's memex.
+  it("spec-307: Dave's org-A-scoped token reads Bob's org-B memex (live membership, frozen scope inert)", async () => {
+    tagAc(AC_307_6);
+    const res = await mcpCall(daveOAuthToken, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/call",
+      params: { name: "get_doc", arguments: { ref: bobRef(`specs/${bobSpecHandle}`) } },
     });
+    expect(res.status).toBe(200);
+    const body = parseSse(await res.text());
+    expect(
+      body.result?.isError,
+      `Dave (org-B member) should now read Bob's memex under live membership: ${body.result?.content?.[0]?.text ?? ""}`,
+    ).toBeFalsy();
   });
 });

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -468,7 +468,19 @@ app.all("/mcp", async (c) => {
     try {
       const claims = verifyAccessToken(raw);
       userId = claims.sub;
-      orgFilter = claims.org; // null = personal-only; UUID = org-scoped
+      // spec-307 dec-1/dec-2: MCP access follows the user's LIVE membership, not the
+      // Org scope frozen into the token at consent (spec-31 dec-8, now superseded).
+      // Treat OAuth callers exactly like PATs — `orgFilter === undefined` resolves
+      // against every CURRENT active membership in mcp/auth.ts. The token's `org`
+      // claim is no longer enforced, so existing tokens widen to the user's own live
+      // memberships with no re-auth (connect once, survive Org graduation). No token
+      // is migrated or invalidated; the stored claim simply goes inert.
+      orgFilter = undefined;
+      // Rollout observability: a previously Org-scoped grant now resolving under live
+      // membership is the widening this Spec introduces — record it so it's auditable.
+      console.log(
+        `[mcp:live-membership] oauth token resolved under live membership user=${claims.sub} legacy_scope=${claims.org ?? "personal-only"}`,
+      );
     } catch {
       c.header(
         "WWW-Authenticate",

--- a/packages/server/src/mcp/endpoint.integration.test.ts
+++ b/packages/server/src/mcp/endpoint.integration.test.ts
@@ -2,6 +2,7 @@
 // real Hono app and exercises the auth path + a couple of representative tool calls.
 
 import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
 import { inArray, eq } from "drizzle-orm";
 import { db } from "../db/connection.js";
 import {
@@ -107,6 +108,9 @@ describe("/mcp endpoint", () => {
   });
 
   it("returns 401 for a revoked token", async () => {
+    // spec-307 ac-4: instant revocation is the safety net for the broadened
+    // (live-membership) access — a revoked connection is rejected at /mcp.
+    tagAc("mindset-prod/memex-building-itself/specs/spec-307/acs/ac-4");
     const { user } = await setup("revoked");
     const { raw, row } = await mintMcpToken(user.id, "TestDevice");
     await revokeMcpToken(row.id, user.id);

--- a/packages/server/src/mcp/live-membership.spec-307.integration.test.ts
+++ b/packages/server/src/mcp/live-membership.spec-307.integration.test.ts
@@ -1,0 +1,161 @@
+// spec-307 — MCP access follows the user's LIVE membership, not the Org scope frozen
+// into the token at consent (spec-31 dec-8, superseded). The single behavioural change
+// is in app.ts: the /mcp OAuth branch sets `orgFilter = undefined`, so OAuth callers
+// resolve against every CURRENT active membership exactly like PAT callers.
+//
+// These tests prove it end-to-end against the real /mcp endpoint, with an OAuth token
+// minted PERSONAL-ONLY (orgId null) — the shape a user gets before they have any Org.
+// The headline (ac-7): that same token, with no re-issue, reaches an Org the user joins
+// AFTER the token was minted. The frozen `org` claim is inert (ac-8); a non-member Memex
+// is still denied std-7-style (ac-6). True cross-tenant isolation is covered by
+// tenant-isolation.regression.test.ts.
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { eq, inArray } from "drizzle-orm";
+import { db } from "../db/connection.js";
+import { users, namespaces, orgs, memexes, orgMemberships } from "../db/schema.js";
+import { signAccessToken, verifyAccessToken } from "../services/oauth/access-tokens.js";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-307/acs/ac-${n}`;
+
+const originalOAuthEnabled = process.env.OAUTH_ENABLED;
+beforeAll(() => {
+  process.env.OAUTH_ENABLED = "1";
+});
+afterAll(() => {
+  if (originalOAuthEnabled !== undefined) process.env.OAUTH_ENABLED = originalOAuthEnabled;
+  else delete process.env.OAUTH_ENABLED;
+});
+
+const created = { users: [] as string[], namespaces: [] as string[] };
+afterAll(async () => {
+  // Namespaces cascade to memexes → docs; org_memberships cascade off the user/org.
+  if (created.namespaces.length)
+    await db.delete(namespaces).where(inArray(namespaces.id, created.namespaces)).catch(() => {});
+  if (created.users.length)
+    await db.delete(users).where(inArray(users.id, created.users)).catch(() => {});
+});
+
+function uniq(p: string): string {
+  return `${p}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 5)}`.toLowerCase().slice(0, 39);
+}
+
+async function makeUserWithPersonal(): Promise<{ userId: string; nsSlug: string; memexSlug: string }> {
+  const tag = uniq("lm-u");
+  const [u] = await db.insert(users).values({ email: `${tag}@memex.ai` } as never).returning();
+  created.users.push(u.id);
+  const [ns] = await db
+    .insert(namespaces)
+    .values({ slug: tag, kind: "user", ownerUserId: u.id } as never)
+    .returning();
+  created.namespaces.push(ns.id);
+  await db.insert(memexes).values({ name: "Personal", slug: "personal", namespaceId: ns.id } as never);
+  return { userId: u.id, nsSlug: tag, memexSlug: "personal" };
+}
+
+async function makeOrgWithMemex(name: string): Promise<{ orgId: string; nsSlug: string; memexSlug: string }> {
+  const tag = uniq(`lm-${name}`);
+  const [ns] = await db.insert(namespaces).values({ slug: tag, kind: "org" } as never).returning();
+  created.namespaces.push(ns.id);
+  const [org] = await db.insert(orgs).values({ namespaceId: ns.id, name } as never).returning();
+  await db.update(namespaces).set({ ownerOrgId: org.id }).where(eq(namespaces.id, ns.id));
+  await db.insert(memexes).values({ name, slug: "main", namespaceId: ns.id } as never);
+  return { orgId: org.id, nsSlug: tag, memexSlug: "main" };
+}
+
+async function addMember(userId: string, orgId: string): Promise<void> {
+  await db.insert(orgMemberships).values({ userId, orgId, role: "member" } as never);
+}
+
+async function mcpCall(token: string, toolName: string, args: unknown) {
+  const { app } = await import("../app.js");
+  const res = await app.request("/mcp", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json, text/event-stream",
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/call", params: { name: toolName, arguments: args } }),
+  });
+  const text = await res.text();
+  const dataLine = text.split("\n").find((l) => l.startsWith("data: "));
+  if (!dataLine) throw new Error(`No SSE data: ${text}`);
+  const body = JSON.parse(dataLine.slice(6)) as {
+    result?: { content?: Array<{ text: string }>; isError?: boolean };
+  };
+  return { status: res.status, isError: !!body.result?.isError, text: body.result?.content?.[0]?.text ?? "" };
+}
+
+// Fixture: user with a personal Memex. Token is minted PERSONAL-ONLY *before* any Org
+// exists for them. Org-A membership is then added AFTER the token was issued (the
+// graduation moment); Org-C is created with NO membership (the non-member control).
+let user: { userId: string; nsSlug: string; memexSlug: string };
+let personalOnlyToken: string;
+let orgA: { orgId: string; nsSlug: string; memexSlug: string };
+let orgC: { orgId: string; nsSlug: string; memexSlug: string };
+
+beforeAll(async () => {
+  user = await makeUserWithPersonal();
+
+  // Minted while the user has ONLY their personal Memex — orgId null, the pre-Org shape.
+  personalOnlyToken = signAccessToken({
+    userId: user.userId,
+    orgId: null,
+    clientId: "spec-307-test-client",
+    scopes: ["memex.full"],
+  });
+
+  // Graduation: the user gains Org-A AFTER the token was minted.
+  orgA = await makeOrgWithMemex("orgA");
+  await addMember(user.userId, orgA.orgId);
+
+  // Non-member control: Org-C exists but the user is not a member.
+  orgC = await makeOrgWithMemex("orgC");
+});
+
+describe("spec-307: MCP access follows live membership, not the frozen token scope", () => {
+  it("ac-7: a personal-only token reaches an Org joined AFTER it was minted — no re-issue (graduation)", async () => {
+    tagAc(AC(7));
+    tagAc(AC(1)); // scope: connect once survives Org graduation, no re-auth/reconfig
+    const r = await mcpCall(personalOnlyToken, "list_docs", { memex: `${orgA.nsSlug}/${orgA.memexSlug}` });
+    expect(r.status).toBe(200);
+    expect(r.isError, `personal-only token should reach Org-A gained after issuance: ${r.text}`).toBe(false);
+  });
+
+  it("ac-5: live membership — list_memexes returns the user's personal + Org memexes (not just personal)", async () => {
+    tagAc(AC(5));
+    const r = await mcpCall(personalOnlyToken, "list_memexes", {});
+    expect(r.status).toBe(200);
+    expect(r.isError, `list_memexes errored: ${r.text}`).toBe(false);
+    // The old frozen-scope model (orgId null) would have returned ONLY the personal
+    // Memex. Live membership includes Org-A.
+    expect(r.text).toContain(`${orgA.nsSlug}/${orgA.memexSlug}`);
+    expect(r.text).toContain(`${user.nsSlug}/${user.memexSlug}`);
+  });
+
+  it("ac-6: reaches a member Org's Memex and is denied a non-member Memex (std-7)", async () => {
+    tagAc(AC(6));
+    tagAc(AC(3)); // scope: reach exactly the owner's current memberships, never more
+    const member = await mcpCall(personalOnlyToken, "list_docs", { memex: `${orgA.nsSlug}/${orgA.memexSlug}` });
+    expect(member.isError, `member Org should be reachable: ${member.text}`).toBe(false);
+
+    const nonMember = await mcpCall(personalOnlyToken, "list_docs", { memex: `${orgC.nsSlug}/${orgC.memexSlug}` });
+    expect(nonMember.status).toBe(200);
+    expect(nonMember.isError, "non-member Org-C must be denied").toBe(true);
+    expect(nonMember.text.toLowerCase()).toMatch(/not a member|forbidden|permission|access|not found/);
+  });
+
+  it("ac-8: the existing token is untouched — its claims are intact (org=null) and it still works", async () => {
+    tagAc(AC(8));
+    tagAc(AC(2)); // scope: no existing connection is forced to reconnect/re-consent
+    // No migration / re-mint: the token's stored scope claim is exactly as issued.
+    const claims = verifyAccessToken(personalOnlyToken);
+    expect(claims.org).toBeNull();
+    expect(claims.sub).toBe(user.userId);
+    // And it still validates + resolves at /mcp despite the frozen scope being ignored.
+    const r = await mcpCall(personalOnlyToken, "list_memexes", {});
+    expect(r.isError, `existing token should still work post-change: ${r.text}`).toBe(false);
+  });
+});


### PR DESCRIPTION
## Why

Connecting an MCP coding agent to Memex should be a **one-time act**. Today an OAuth token's Org reach is frozen at consent (spec-31 dec-8: personal + one chosen Org) and preserved across every refresh, so a user who connects on their **personal** Memex and later **creates an Org** must redo the entire OAuth dance to reach it. That graduation re-dance is a major friction point right as onboarding ships to prod. PATs already follow live membership; OAuth was the outlier.

Implements **spec-307** (dec-1 + dec-2). Supersedes **spec-31 dec-8** and its mirror **spec-23 dec-5**.

## The change

One behavioural line in `app.ts`: the `/mcp` OAuth branch sets `orgFilter = undefined`, so OAuth callers resolve against their **current active memberships** exactly like PATs (`mcp/auth.ts` already treats `undefined` as the full live-membership surface). The token's `org` claim is no longer enforced.

- **No migration, no invalidation.** Existing OAuth access tokens keep validating and refresh tokens keep rotating (`token.ts` untouched). The frozen `org` claim simply goes inert. Nobody reconnects, re-consents, or re-adds the server. Existing connections silently widen to the user's own current memberships.
- **Graduation just works.** `createOrgWithOwner` already inserts the creator as an active `administrator`, so a new Org is an active membership the very next MCP call resolves.
- **Rollout observability.** An audit line records OAuth tokens now resolving under live membership.

## Security posture

We trade per-grant least-privilege for "the agent acts **as you**, never beyond your own live access" (data you can already open in the web UI). The safety net is **visibility + instant revocation** (`/settings/tokens`), not pre-scoping. Enterprise opt-in per-Org scoping (option C) and the now-vestigial consent Org-picker cleanup are **deferred** follow-ups.

## Tests (all 8 spec-307 ACs verified)

- New `mcp/live-membership.spec-307.integration.test.ts`: a personal-only-minted OAuth token reaches an Org joined **after** issuance with no new token (the headline, ac-7); live-membership breadth (ac-5); member-reach + non-member std-7 denial (ac-6); existing-token compatibility (ac-8). **Red→green verified** by reverting the one-line change (ac-5/6/7 fail on the old code, ac-8 holds).
- Flipped the frozen-scope assertions in `tenant-isolation` (Dave's org-A token now reaches org-B he's a member of) and `mcp-token-prefix-fork` (OAuth → `orgFilter=undefined`) regressions to the new model. **True cross-tenant isolation (non-members denied) stays green.**
- ac-4 (revocation safety net) tagged onto the existing revoked-token test.

## Verified locally

Full server suite 4105 passed (0 failed), full UI suite 1364 passed, server build typecheck + UI typecheck clean, `make e2e-cold` 76 journeys passed. No user-facing/UI change (server-side MCP authorization only), so no new Playwright journey.

🤖 Generated with [Claude Code](https://claude.com/claude-code)