### PR TITLE
feat(spec-307): consent screen grants full live membership (no Org picker) + Claude.ai guidance

### DIFF
--- a/packages/server/src/__e2e__/oauth-flow.api.test.ts
+++ b/packages/server/src/__e2e__/oauth-flow.api.test.ts
@@ -16,16 +16,21 @@
 
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { createHash, randomBytes } from "node:crypto";
-import { inArray } from "drizzle-orm";
+import { inArray, eq } from "drizzle-orm";
 import { db } from "../db/connection.js";
 import {
   users,
   oauthClients,
   oauthAuthorizationCodes,
   oauthRefreshTokens,
+  namespaces,
+  orgs,
+  memexes,
+  orgMemberships,
 } from "../db/schema.js";
 import { upsertUserByEmail } from "../services/users.js";
 import { signSessionToken } from "../services/auth-jwt.js";
+import { verifyAccessToken } from "../services/oauth/access-tokens.js";
 import { tagAc } from "@memex-ai-ac/vitest";
 
 // spec-275 — the authorize redirect must MERGE params into a redirect_uri that
@@ -118,12 +123,12 @@ describe("OAuth e2e — full connector flow", () => {
     const preview = (await previewRes.json()) as {
       client_name: string;
       scopes: string[];
-      orgs: { id: string; name: string }[];
     };
     expect(preview.client_name).toBe("OAuth e2e test");
     expect(preview.scopes).toEqual(["memex.full"]);
-    // Test user has no Org memberships → personal-only flow.
-    expect(preview.orgs).toEqual([]);
+    // spec-307: the preview no longer carries an Org list — the grant covers the
+    // user's full live membership, so there is nothing to pick.
+    expect((preview as { orgs?: unknown }).orgs).toBeUndefined();
 
     // ── 3. POST /api/oauth/authorize { decision: "allow" } ───────────────
     const authRes = await app.fetch(
@@ -367,5 +372,106 @@ describe("OAuth e2e — query-bearing redirect_uri merge (spec-275)", () => {
     expect(u.searchParams.get("tenant")).toBe("acme");
     expect(u.searchParams.get("error")).toBe("access_denied");
     expect(u.searchParams.get("state")).toBe("test-state");
+  });
+});
+
+// spec-307 (dec-1/dec-2): an OAuth grant carries NO per-Org scope. The consent
+// endpoint neither requires nor stores an Org — even for a user in multiple Orgs,
+// authorize with no org_id succeeds and the minted token's `org` claim is null.
+// (Under the superseded b-31 dec-8 model this 400'd: "org_id is required".)
+describe("spec-307 — OAuth grant carries no per-Org scope (ac-9)", () => {
+  const ns307: string[] = [];
+  afterAll(async () => {
+    if (ns307.length)
+      await db.delete(namespaces).where(inArray(namespaces.id, ns307)).catch(() => {});
+  });
+
+  async function makeOrg(userId: string, name: string): Promise<void> {
+    const slug = `s307-${name}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 5)}`.toLowerCase();
+    const [ns] = await db.insert(namespaces).values({ slug, kind: "org" } as never).returning();
+    ns307.push(ns.id);
+    const [org] = await db.insert(orgs).values({ namespaceId: ns.id, name } as never).returning();
+    await db.update(namespaces).set({ ownerOrgId: org.id }).where(eq(namespaces.id, ns.id));
+    await db.insert(memexes).values({ name, slug: "main", namespaceId: ns.id } as never);
+    await db.insert(orgMemberships).values({ userId, orgId: org.id, role: "administrator" } as never);
+  }
+
+  it("a user in MULTIPLE Orgs authorizes with NO org_id → grant minted with org=null", async () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-307/acs/ac-9");
+    const { app } = await import("../app.js");
+
+    const user = await upsertUserByEmail(`s307-ac9-${Date.now()}-${Math.random()}@test.dev`);
+    userIds.push(user.id);
+    await makeOrg(user.id, "alpha");
+    await makeOrg(user.id, "beta");
+    const sessionJwt = signSessionToken(user.id);
+
+    const regRes = await app.fetch(
+      new Request("https://memex.ai/api/oauth/register", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          client_name: "spec-307 ac-9",
+          redirect_uris: ["https://test.example/cb"],
+        }),
+      }),
+    );
+    expect(regRes.status).toBe(201);
+    const reg = (await regRes.json()) as { client_id: string; client_secret: string };
+    const [client] = await db
+      .select()
+      .from(oauthClients)
+      .where(inArray(oauthClients.clientId, [reg.client_id]));
+    clientRowIds.push(client.id);
+
+    const { verifier, challenge } = makePkce();
+    const baseParams = {
+      response_type: "code",
+      client_id: reg.client_id,
+      redirect_uri: "https://test.example/cb",
+      code_challenge: challenge,
+      code_challenge_method: "S256",
+    };
+
+    // Preview carries NO Org list.
+    const qs = new URLSearchParams(baseParams).toString();
+    const prev = await app.fetch(
+      new Request(`https://memex.ai/api/oauth/authorize/preview?${qs}`, {
+        headers: { Authorization: `Bearer ${sessionJwt}` },
+      }),
+    );
+    expect(prev.status).toBe(200);
+    expect(((await prev.json()) as { orgs?: unknown }).orgs).toBeUndefined();
+
+    // Authorize with NO org_id → 200 (the superseded model 400'd for a multi-Org user).
+    const authRes = await app.fetch(
+      new Request("https://memex.ai/api/oauth/authorize", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Authorization: `Bearer ${sessionJwt}` },
+        body: JSON.stringify({ ...baseParams, decision: "allow" }),
+      }),
+    );
+    expect(authRes.status).toBe(200);
+    const code = new URL(((await authRes.json()) as { redirect: string }).redirect).searchParams.get("code");
+    expect(code).toBeTruthy();
+
+    // Exchange → the access token carries NO Org scope (org=null).
+    const tokRes = await app.fetch(
+      new Request("https://memex.ai/api/oauth/token", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          grant_type: "authorization_code",
+          code,
+          code_verifier: verifier,
+          redirect_uri: "https://test.example/cb",
+          client_id: reg.client_id,
+          client_secret: reg.client_secret,
+        }),
+      }),
+    );
+    expect(tokRes.status).toBe(200);
+    const { access_token } = (await tokRes.json()) as { access_token: string };
+    expect(verifyAccessToken(access_token).org).toBeNull();
   });
 });

--- a/packages/server/src/routes/__test__.ts
+++ b/packages/server/src/routes/__test__.ts
@@ -202,9 +202,11 @@ testOnlyRouter.post("/onboarding-greeted", async (c) => {
   return c.json({ ok: true });
 });
 
-// spec-305 — set/clear a user's identity_confirmed_at. needsOnboarding now keys off
-// this (not !name), so the onboarding journey UN-confirms the dev user to land on the
-// welcome step; the fixture re-confirms it afterwards so it can't leak into other journeys.
+// spec-305/307 — set/clear a user's identity state. needsOnboarding keys off
+// identity_confirmed_at; the journey identity MILESTONE keys off role_coords (spec-307:
+// did the user place themselves on the triangle). Confirm/un-confirm sets/clears BOTH so
+// they stay in lock-step — the onboarding journey un-confirms the dev user to land on the
+// welcome step, and the fixture re-confirms afterwards so it can't leak into other journeys.
 const identityConfirmedSchema = z.object({
   email: z.string().email(),
   confirmed: z.boolean(),
@@ -220,7 +222,11 @@ testOnlyRouter.post("/identity-confirmed", async (c) => {
   if (!user) return c.json({ error: `User ${email} not found` }, 404);
   await db
     .update(users)
-    .set({ identityConfirmedAt: confirmed ? new Date() : null, updatedAt: new Date() })
+    .set({
+      identityConfirmedAt: confirmed ? new Date() : null,
+      roleCoords: confirmed ? { dev: 0.34, design: 0.33, pm: 0.33 } : null,
+      updatedAt: new Date(),
+    })
     .where(eq(users.id, user.id));
   return c.json({ ok: true });
 });

--- a/packages/server/src/routes/journey.api.test.ts
+++ b/packages/server/src/routes/journey.api.test.ts
@@ -76,7 +76,16 @@ async function state(userId: string, query = ""): Promise<{ status: number; body
 
 // ── milestone seeders (each a USER-scoped fact the engine derives from) ──
 async function confirmIdentity(userId: string) {
-  await db.update(users).set({ identityConfirmedAt: new Date() }).where(eq(users.id, userId));
+  // spec-307: the identity milestone keys off role_coords (placing yourself on the
+  // triangle), NOT identity_confirmed_at. Mirror a real identity-step completion,
+  // which stamps both (updateUserProfile).
+  await db
+    .update(users)
+    .set({
+      identityConfirmedAt: new Date(),
+      roleCoords: { dev: 0.34, design: 0.33, pm: 0.33 },
+    })
+    .where(eq(users.id, userId));
 }
 async function connectMcp(userId: string) {
   await recordUsageEvent({ memexId: null, actorUserId: userId, name: "mcp.connected", source: "backend" });
@@ -135,6 +144,21 @@ describe("Home Canvas journey-state (ac-3 derived position)", () => {
       hasAc: false,
       acVerified: false,
     });
+  });
+
+  it("the identity tick reflects the triangle (role_coords), not the backfilled identity_confirmed_at (spec-307)", async () => {
+    tagAc(AC(3));
+    const user = await newUser();
+    // A spec-305-backfilled user: identity_confirmed_at set (so they were never
+    // force-onboarded) but they NEVER placed themselves on the triangle.
+    await db.update(users).set({ identityConfirmedAt: new Date() }).where(eq(users.id, user.id));
+    expect((await state(user.id)).body.milestones.identityConfirmed).toBe(false);
+    // Completing the identity step saves role_coords → the tick goes green.
+    await db
+      .update(users)
+      .set({ roleCoords: { dev: 0.5, design: 0.25, pm: 0.25 } })
+      .where(eq(users.id, user.id));
+    expect((await state(user.id)).body.milestones.identityConfirmed).toBe(true);
   });
 
   it("anonymous requests are rejected", async () => {

--- a/packages/server/src/routes/oauth/authorize.ts
+++ b/packages/server/src/routes/oauth/authorize.ts
@@ -10,27 +10,15 @@
 //          redirect_uri with ?error=access_denied&state=.
 
 import { Hono } from "hono";
-import { and, eq } from "drizzle-orm";
 import { sessionMiddleware, type SessionEnv } from "../../middleware/session.js";
 import { mintAuthCode } from "../../services/oauth/codes.js";
 import { getClientByClientId } from "../../services/oauth/clients.js";
 import { buildAppBaseUrl } from "../../services/shared/tenant-url.js";
-import { db } from "../../db/connection.js";
-import { orgMemberships, orgs } from "../../db/schema.js";
 
-// b-31 dec-8: list the user's Orgs (id + name) for the consent picker.
-// Only ACTIVE memberships — disabled/pending users see zero orgs and fall
-// through to the personal-only variant.
-async function listGrantableOrgs(userId: string): Promise<{ id: string; name: string }[]> {
-  const rows = await db
-    .select({ id: orgs.id, name: orgs.name })
-    .from(orgMemberships)
-    .innerJoin(orgs, eq(orgMemberships.orgId, orgs.id))
-    .where(
-      and(eq(orgMemberships.userId, userId), eq(orgMemberships.status, "active")),
-    );
-  return rows;
-}
+// spec-307 (dec-1/dec-2): an OAuth grant is the user's full LIVE membership, not a
+// frozen per-Org scope (supersedes b-31 dec-8). There is no Org to pick at consent,
+// so the consent screen has no Org picker and the grant stores no Org. The former
+// `listGrantableOrgs` helper (and its db/orgs imports) is gone with it.
 
 export const authorize = new Hono<SessionEnv>();
 
@@ -133,14 +121,13 @@ authorize.get("/", async (c) => {
 });
 
 // GET /api/oauth/authorize/preview?<params> — session-required. Returns the
-// client_name + scopes the consent UI needs to render, plus the user's Org
-// list so the consent screen can render an Org picker (per b-31 dec-8).
+// client_name + scopes the consent UI needs to render. spec-307: no Org list — the
+// grant covers the user's full live membership, so there is nothing to pick.
 //
 // Response shape:
 //   {
 //     client_name: string,
 //     scopes: ["memex.full"],
-//     orgs: [{ id, name }],            // empty array = personal-only flow
 //   }
 authorize.use("/preview", sessionMiddleware);
 authorize.get("/preview", async (c) => {
@@ -159,12 +146,10 @@ authorize.get("/preview", async (c) => {
       400,
     );
   }
-  const userOrgs = await listGrantableOrgs(user.id);
   return c.json({
     client_name: client.clientName,
     // Server always grants memex.full per dec-2, regardless of `scope` param.
     scopes: ["memex.full"],
-    orgs: userOrgs,
   });
 });
 
@@ -222,43 +207,12 @@ authorize.post("/", async (c) => {
     });
   }
 
-  // Org-scope per b-31 dec-8. Three branches:
-  //   - User in 0 Orgs: orgId = null (personal-only). org_id in body, if any,
-  //     is rejected — the user has nothing to grant against.
-  //   - User in 1 Org: orgId may be omitted (we use the sole Org) OR sent
-  //     explicitly; if sent, must match the membership.
-  //   - User in >1 Orgs: orgId IS required. Body must carry it and it must
-  //     be in the user's grantable list.
-  const userOrgs = await listGrantableOrgs(user.id);
-  const orgIdInput = typeof md.org_id === "string" ? md.org_id : undefined;
-  let orgId: string | null;
-  if (userOrgs.length === 0) {
-    if (orgIdInput) {
-      return c.json(
-        { error: "invalid_request", error_description: "user has no Org memberships; org_id must be omitted" },
-        400,
-      );
-    }
-    orgId = null;
-  } else if (userOrgs.length === 1 && !orgIdInput) {
-    orgId = userOrgs[0].id;
-  } else {
-    if (!orgIdInput) {
-      return c.json(
-        { error: "invalid_request", error_description: "org_id is required when user belongs to multiple Orgs" },
-        400,
-      );
-    }
-    const match = userOrgs.find((o) => o.id === orgIdInput);
-    if (!match) {
-      // Don't leak whether the Org exists — same 400 shape either way.
-      return c.json(
-        { error: "invalid_request", error_description: "org_id is not a grantable Org for this user" },
-        400,
-      );
-    }
-    orgId = match.id;
-  }
+  // spec-307 (dec-1/dec-2): a grant is the user's full LIVE membership, not a frozen
+  // per-Org scope. We no longer collect or store an Org on the grant — the minted
+  // token's `org` claim is null and the /mcp authorizer resolves live membership for
+  // every token. Supersedes b-31 dec-8's per-Org scoping. Any `org_id` an older
+  // client still sends is ignored.
+  const orgId: string | null = null;
 
   // Scopes — single 'memex.full' in v1 per dec-2. We always grant memex.full
   // regardless of what the client requested (no granular scopes yet).

--- a/packages/server/src/services/journey-state.ts
+++ b/packages/server/src/services/journey-state.ts
@@ -67,9 +67,16 @@ export async function getUserMilestones(
   userId: string,
   conn: Db = db,
 ): Promise<JourneyMilestones> {
-  // identityConfirmed (captured, dec-4): the user completed the identity step.
+  // identityConfirmed (captured, dec-4): the user completed the identity step —
+  // i.e. they placed themselves on the developer/designer/PM triangle. The signal is
+  // `role_coords` being set, NOT `identity_confirmed_at`: spec-305 backfilled
+  // identity_confirmed_at for every pre-existing user (so they were never force-routed
+  // through onboarding), which would light this tick green without the user ever doing
+  // the step. role_coords is null for those backfilled users and is written the moment
+  // the identity step is completed (placing yourself, or skipping to the centered
+  // default), so it faithfully means "I saved my role on the triangle" (spec-307).
   const [userRow] = await conn
-    .select({ confirmedAt: users.identityConfirmedAt })
+    .select({ roleCoords: users.roleCoords })
     .from(users)
     .where(eq(users.id, userId));
 
@@ -132,7 +139,7 @@ export async function getUserMilestones(
     .where(and(eq(acs.actorUserId, userId), eq(testEventLatest.latestStatus, "pass")));
 
   return {
-    identityConfirmed: !!userRow?.confirmedAt,
+    identityConfirmed: userRow?.roleCoords != null,
     mcpConnected: (connectedRow?.n ?? 0) > 0,
     mcpToolCalled: (toolRow?.n ?? 0) > 0,
     hasSpec: (specRow?.n ?? 0) > 0,

--- a/packages/ui/src/api/client.ts
+++ b/packages/ui/src/api/client.ts
@@ -2251,8 +2251,8 @@ export async function consumeDomainVerificationApi(verifyToken: string): Promise
 export interface OAuthAuthorizePreview {
   client_name: string;
   scopes: string[];
-  /** User's grantable Orgs (per b-31 dec-8). Empty array = personal-only flow. */
-  orgs: { id: string; name: string }[];
+  // spec-307: no per-grant Org scope — an OAuth grant covers the user's full live
+  // membership, so the preview no longer carries an Org list.
 }
 
 export interface OAuthAuthorizeParams {
@@ -2290,19 +2290,15 @@ export async function oauthAuthorizeDecisionApi(
   params: OAuthAuthorizeParams,
   decision: 'allow' | 'deny',
   token: string | null,
-  /** Chosen Org id (per b-31 dec-8); null for personal-only. */
-  orgId: string | null,
 ): Promise<{ redirect: string }> {
+  // spec-307: no Org scope on the grant — the body carries no org_id. The grant
+  // covers the user's full live membership.
   const res = await fetchWithRetry(`${BASE_URL}/oauth/authorize`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', ...authHeaders(token) },
     body: JSON.stringify({
       ...params,
       decision,
-      // Server only inspects org_id when present; omit it for null so the
-      // body shape stays clean. The auth route then treats absence as
-      // "personal-only" (and 400s on user-with-orgs without it).
-      ...(orgId ? { org_id: orgId } : {}),
     }),
   });
   const body = await res.json().catch(() => ({}));

--- a/packages/ui/src/components/CliInstallSection.tsx
+++ b/packages/ui/src/components/CliInstallSection.tsx
@@ -109,7 +109,18 @@ export function CliInstallSection() {
           <div>
             <h4 className="text-sm font-medium mb-2 text-heading">claude.ai (web)</h4>
             <ol className="list-decimal list-inside text-sm space-y-1 text-secondary">
-              <li>Open <strong>Settings → Connectors</strong>.</li>
+              <li>
+                Open <strong>Customize → Connectors</strong> (
+                <a
+                  href="https://claude.ai/customize/connectors?modal=add-custom-connector"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="underline hover:text-primary"
+                >
+                  jump straight there
+                </a>
+                ).
+              </li>
               <li>Click <strong>Add custom connector</strong>.</li>
               <li>Name it <InlineCode>Memex</InlineCode> and paste the MCP URL above.</li>
               <li>Save, then complete the sign-in in the popup.</li>

--- a/packages/ui/src/components/home/ConnectAgentStep.tsx
+++ b/packages/ui/src/components/home/ConnectAgentStep.tsx
@@ -82,7 +82,18 @@ function Instructions({ tool, os }: { tool: Tool; os: Os }) {
     return (
       <div className="space-y-2">
         <ol className="list-inside list-decimal space-y-1 text-sm text-secondary">
-          <li>Open <strong>Settings → Connectors</strong>.</li>
+          <li>
+            Open <strong>Customize → Connectors</strong> (
+            <a
+              href="https://claude.ai/customize/connectors?modal=add-custom-connector"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline hover:text-primary"
+            >
+              jump straight there
+            </a>
+            ).
+          </li>
           <li>Click <strong>Add custom connector</strong>.</li>
           <li>Name it <strong>Memex</strong> and paste the URL below.</li>
           <li>Save, then complete the sign-in in the popup.</li>

--- a/packages/ui/src/pages/OauthAuthorize.spec-307.test.tsx
+++ b/packages/ui/src/pages/OauthAuthorize.spec-307.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { tagAc } from '@memex-ai-ac/vitest';
+
+// spec-307 ac-9: the OAuth consent screen grants the user's FULL live membership.
+// There is no Org picker, the copy states all-Memexes access, and the decision is
+// submitted with no per-grant Org scope (no org_id arg). Supersedes b-31 dec-8.
+
+const AC_9 = 'mindset-prod/memex-building-itself/specs/spec-307/acs/ac-9';
+
+const decisionSpy = vi.fn(async () => ({ redirect: 'https://app.example/cb?code=abc' }));
+const previewSpy = vi.fn(async () => ({ client_name: 'Claude', scopes: ['memex.full'] }));
+
+vi.mock('../api/client', () => ({
+  oauthAuthorizePreviewApi: (...args: unknown[]) => previewSpy(...(args as [])),
+  oauthAuthorizeDecisionApi: (...args: unknown[]) => decisionSpy(...(args as [])),
+}));
+
+vi.mock('../components/AuthContext', async () => {
+  const real = await vi.importActual<typeof import('../components/AuthContext')>(
+    '../components/AuthContext',
+  );
+  return {
+    ...real,
+    useAuth: () => ({
+      token: 'tok-1',
+      isAuthenticated: true,
+      session: null,
+      user: null,
+      authError: null,
+      logout: vi.fn(),
+      updateSession: vi.fn(),
+      acceptSession: vi.fn(),
+    }),
+  };
+});
+
+import { OauthAuthorize } from './OauthAuthorize';
+
+const OAUTH_QS =
+  '?response_type=code&client_id=c-1&redirect_uri=https://app.example/cb' +
+  '&code_challenge=chal&code_challenge_method=S256&state=st';
+
+function renderConsent() {
+  return render(
+    <MemoryRouter initialEntries={[`/oauth/authorize${OAUTH_QS}`]}>
+      <Routes>
+        <Route path="/oauth/authorize" element={<OauthAuthorize />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('spec-307: OAuth consent screen grants full live membership (ac-9)', () => {
+  let originalLocation: Location;
+  beforeEach(() => {
+    decisionSpy.mockClear();
+    previewSpy.mockClear();
+    originalLocation = window.location;
+    // jsdom throws "Not implemented: navigation" on href assignment; stub it.
+    Object.defineProperty(window, 'location', { value: { href: '' }, writable: true });
+  });
+  afterEach(() => {
+    Object.defineProperty(window, 'location', { value: originalLocation, writable: true });
+  });
+
+  it('renders no Org picker and states all-Memexes access', async () => {
+    tagAc(AC_9);
+    renderConsent();
+    await screen.findByText('Claude');
+    // No Org picker (the superseded b-31 dec-8 UI).
+    expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+    expect(screen.queryByText(/Choose the Org/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/only grant one Org/i)).not.toBeInTheDocument();
+    // Honest copy: the grant is all your Memexes.
+    expect(screen.getByText(/all your Memexes/i)).toBeInTheDocument();
+    expect(screen.getByText(/every Org you're a member of/i)).toBeInTheDocument();
+  });
+
+  it('Allow submits the decision with no per-grant Org scope (no org_id arg)', async () => {
+    tagAc(AC_9);
+    renderConsent();
+    const allow = await screen.findByRole('button', { name: /allow/i });
+    fireEvent.click(allow);
+    await waitFor(() => expect(decisionSpy).toHaveBeenCalledTimes(1));
+    const callArgs = decisionSpy.mock.calls[0];
+    // (params, decision, token) — exactly three args, NO fourth orgId.
+    expect(callArgs).toHaveLength(3);
+    expect(callArgs[1]).toBe('allow');
+    expect(callArgs[2]).toBe('tok-1');
+  });
+});

--- a/packages/ui/src/pages/OauthAuthorize.tsx
+++ b/packages/ui/src/pages/OauthAuthorize.tsx
@@ -8,9 +8,10 @@ import {
   type OAuthAuthorizeParams,
 } from '../api/client';
 
-// b-31 dec-8: the Org picker UI. The preview endpoint returns the user's
-// grantable Orgs; we pre-select the first one when the user has exactly
-// one. Submit always carries an `org_id` (or null for personal-only).
+// spec-307: no Org picker. An OAuth grant covers the user's FULL live membership
+// (their personal Memex + every Org they belong to, now and in future), so the
+// consent screen just states what's granted and collects allow/deny — there is no
+// per-Org scope to choose.
 
 type Status =
   | 'loading'
@@ -58,9 +59,6 @@ export function OauthAuthorize() {
   const [status, setStatus] = useState<Status>('loading');
   const [preview, setPreview] = useState<OAuthAuthorizePreview | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  // Selected Org id (UUID) for the grant, or null for personal-only.
-  // Initialised from preview.orgs in the useEffect below.
-  const [selectedOrgId, setSelectedOrgId] = useState<string | null>(null);
 
   useEffect(() => {
     if (!params) {
@@ -82,10 +80,6 @@ export function OauthAuthorize() {
         const data = await oauthAuthorizePreviewApi(params, token);
         if (cancelled) return;
         setPreview(data);
-        // Pre-select the user's only Org when they have exactly one;
-        // otherwise leave null and let the user pick (or fall through
-        // to personal-only when orgs is empty).
-        if (data.orgs.length === 1) setSelectedOrgId(data.orgs[0].id);
         setStatus('pending');
       } catch (err) {
         if (cancelled) return;
@@ -105,17 +99,6 @@ export function OauthAuthorize() {
 
   async function submitDecision(decision: 'allow' | 'deny') {
     if (!params) return;
-    // When user has >1 Org and hasn't picked, refuse to submit — the server
-    // would 400 anyway, but a client-side guard gives a clearer message.
-    if (
-      decision === 'allow' &&
-      preview &&
-      preview.orgs.length > 1 &&
-      !selectedOrgId
-    ) {
-      setErrorMessage('Pick an Org before allowing.');
-      return;
-    }
     setStatus('submitting');
     setErrorMessage(null);
     try {
@@ -123,7 +106,6 @@ export function OauthAuthorize() {
         params,
         decision,
         token,
-        selectedOrgId,
       );
       setStatus('success');
       // Bounce the browser. The server has set ?code=&state= (on allow) or
@@ -179,38 +161,8 @@ export function OauthAuthorize() {
               <div className="text-base text-primary font-medium">{preview.client_name}</div>
             </div>
 
-            {/* Org picker (b-31 dec-8) — shown only when the user has >1 Org.
-                For 0 or 1 Org we skip the picker and show a fixed sentence. */}
-            {preview.orgs.length > 1 && (
-              <div className="mb-6">
-                <label
-                  htmlFor="oauth-org-picker"
-                  className="block text-muted uppercase tracking-wide text-xs mb-1"
-                >
-                  Org
-                </label>
-                <select
-                  id="oauth-org-picker"
-                  value={selectedOrgId ?? ''}
-                  onChange={(e) => setSelectedOrgId(e.target.value || null)}
-                  className="w-full border border-edge rounded-md bg-page text-primary px-3 py-2 text-sm"
-                >
-                  <option value="" disabled>
-                    Choose the Org to grant access to…
-                  </option>
-                  {preview.orgs.map((o) => (
-                    <option key={o.id} value={o.id}>
-                      {o.name}
-                    </option>
-                  ))}
-                </select>
-                <p className="text-xs text-muted mt-2">
-                  You can only grant one Org per OAuth flow. To connect another Org,
-                  authorise again from the same connector.
-                </p>
-              </div>
-            )}
-
+            {/* spec-307: no Org picker — the grant is the user's full live
+                membership, so there is nothing to scope. */}
             <div className="mb-8">
               <div className="text-muted uppercase tracking-wide text-xs mb-1">
                 Permissions requested
@@ -218,27 +170,10 @@ export function OauthAuthorize() {
               <ul className="text-sm text-primary list-disc pl-5">
                 {preview.scopes.includes('memex.full') && (
                   <li>
-                    Full access to{' '}
-                    {preview.orgs.length === 0 ? (
-                      <>your <strong>personal Memex</strong></>
-                    ) : preview.orgs.length === 1 ? (
-                      <>
-                        your <strong>{preview.orgs[0].name}</strong> Org and your{' '}
-                        <strong>personal Memex</strong>
-                      </>
-                    ) : selectedOrgId ? (
-                      <>
-                        your{' '}
-                        <strong>
-                          {preview.orgs.find((o) => o.id === selectedOrgId)?.name}
-                        </strong>{' '}
-                        Org and your <strong>personal Memex</strong>
-                      </>
-                    ) : (
-                      <>the Org you select above and your personal Memex</>
-                    )}
-                    {' '}— read &amp; write documents, decisions, tasks, and comments on
-                    your behalf.
+                    Full access to <strong>all your Memexes</strong> — your personal
+                    Memex and every Org you&apos;re a member of, now and in future —
+                    read &amp; write documents, decisions, tasks, and comments on your
+                    behalf.
                   </li>
                 )}
               </ul>


### PR DESCRIPTION
## Why

Follow-up to the spec-307 server change (PR #246, live-membership for OAuth tokens), **surfaced on int**: the OAuth consent screen still showed the now-vestigial **Org picker** and copy that **understated the grant**. It said *"Full access to the Org you select and your personal Memex"*, but post-spec-307 the token actually gets **all** your live memberships. A user approving *less than they receive* is a consent-accuracy gap, not cosmetic - so removing the picker is part of the same change, not a deferred cleanup.

## What changed

- **`OauthAuthorize.tsx`** - remove the Org picker + `selectedOrgId` state + the submit guard; rewrite the permission line to *"Full access to all your Memexes - your personal Memex and every Org you're a member of, now and in future"*; submit with no `org_id`.
- **`routes/oauth/authorize.ts`** - `/authorize` mints `org=null` always (no `org_id` required, even for multi-Org users); `/preview` no longer returns an Org list; `listGrantableOrgs` removed.
- **`client.ts`** - `OAuthAuthorizePreview` drops `orgs`; `oauthAuthorizeDecisionApi` drops the `orgId` param.

## Also: Claude.ai connection guidance refresh

Claude.ai renamed its nav, so the guidance moves **"Settings → Connectors" → "Customize → Connectors"**, plus a direct shortcut link to the add-custom-connector modal (with the text path kept as the durable fallback). Updated in **both** spots: the onboarding `ConnectAgentStep` journey and the Settings → Integrations `CliInstallSection` page.

## Tests (ac-9)

- `oauth-flow.api.test.ts`: a user in **multiple Orgs** authorizes with **no org_id** → 200, the minted access token's `org` claim is **null**, and the preview carries no Org list. (Under the superseded b-31 dec-8 model this 400'd.)
- `OauthAuthorize.spec-307.test.tsx`: consent renders **no Org picker**, copy states all-Memexes access, and **Allow** posts the decision with no `org_id` arg.

## Verified locally

Full server suite **4106 passed** (0 failed), full UI suite **1366 passed**, server build typecheck + UI typecheck clean, `make e2e-cold` **76 journeys passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)