### PR TITLE
fix(spec-303): journey milestones visible under RLS as memex_app

### DIFF
--- a/packages/server/drizzle/0098_rls_own_rows_or_clause.sql
+++ b/packages/server/drizzle/0098_rls_own_rows_or_clause.sql
@@ -1,0 +1,77 @@
+-- spec-303 journey-state unblock: let a user SEE their own authored rows across
+-- every memex, without relaxing tenant isolation for any write.
+--
+-- WHY
+--   getUserMilestones() counts the acting user's OWN rows over documents/acs/
+--   decisions. Those counts are USER-scoped and CROSS-memex ("has THIS user ever
+--   authored a spec / resolved a decision / written an AC, anywhere"), so
+--   /api/me/journey-state runs with no app.memex_id GUC. Under the runtime role
+--   `memex_app` (non-owner, always subject to RLS — spec-257 dec-1) the memex-only
+--   isolation policy filtered every count to ZERO: the Home Canvas ticks stayed
+--   grey on int/prod though the data existed. Local/CI never caught it because
+--   tests run as the table OWNER, which bypasses RLS (ENABLE + NO FORCE, 0093).
+--
+-- DESIGN — a SEPARATE `FOR SELECT` policy, NOT an edit to the FOR ALL one
+--   The existing `<table>_memex_isolation` policy is FOR ALL (USING + WITH CHECK).
+--   RLS routes commands differently: SELECT→USING, INSERT→WITH CHECK,
+--   UPDATE→USING+WITH CHECK, DELETE→USING ONLY (there is no WITH CHECK for
+--   DELETE). So widening that policy's USING with an own-row OR branch would also
+--   widen DELETE — `memex_app` could delete its own authored rows across every
+--   memex whenever app.user_id is set. That hole would rest on code discipline
+--   ("only ever wrap reads in runWithUserId"), not on the database.
+--
+--   Instead we ADD a second, permissive, SELECT-only policy. Postgres OR-combines
+--   permissive policies of the same command, so:
+--     SELECT  → (memex USING) OR (owner USING)           ← widened, as intended
+--     INSERT/UPDATE/DELETE → governed SOLELY by the untouched FOR ALL memex
+--       policy. A row visible only via the owner policy is readable in a WHERE
+--       but NOT updatable or deletable (the FOR ALL USING/WITH CHECK still gate
+--       the write target → zero rows, no error, no hole).
+--   The FOR ALL `<table>_memex_isolation` policies are left byte-for-byte intact
+--   (so 0086's safe-uuid-cast is preserved untouched).
+--
+-- SAFE UUID CAST: the new clause uses nullif(current_setting(...,true),'')::uuid
+--   so an unset/empty GUC yields NULL (row blocked) instead of throwing
+--   "invalid input syntax for type uuid" — same guard 0086 established.
+--
+-- SCOPE: only the three tables journey-state reads (documents, acs, decisions).
+--   The broader "see every row in memexes you're a member of" membership model is
+--   a separate, security-critical re-key (its own Spec), not this unblock.
+--
+-- INDEXES: current_setting() is STABLE, not IMMUTABLE, so the planner cannot fold
+--   the owner predicate to constant-false at plan time — it stays in the plan.
+--   Add partial btree indexes on the owner columns so the journey counts under
+--   memex_app use an index instead of seq-scanning all three tables.
+
+-- ── owner-visibility SELECT policies (additive; co-exist with memex_isolation) ──
+DROP POLICY IF EXISTS documents_owner_visibility ON documents;
+CREATE POLICY documents_owner_visibility ON documents
+  FOR SELECT
+  USING (
+    nullif(current_setting('app.user_id', true), '') IS NOT NULL
+    AND created_by_user_id = nullif(current_setting('app.user_id', true), '')::uuid
+  );
+
+DROP POLICY IF EXISTS acs_owner_visibility ON acs;
+CREATE POLICY acs_owner_visibility ON acs
+  FOR SELECT
+  USING (
+    nullif(current_setting('app.user_id', true), '') IS NOT NULL
+    AND actor_user_id = nullif(current_setting('app.user_id', true), '')::uuid
+  );
+
+DROP POLICY IF EXISTS decisions_owner_visibility ON decisions;
+CREATE POLICY decisions_owner_visibility ON decisions
+  FOR SELECT
+  USING (
+    nullif(current_setting('app.user_id', true), '') IS NOT NULL
+    AND actor_user_id = nullif(current_setting('app.user_id', true), '')::uuid
+  );
+
+-- ── owner-column indexes (partial: the predicate is equality on a NOT-NULL id) ──
+CREATE INDEX IF NOT EXISTS documents_created_by_user_id_idx
+  ON documents (created_by_user_id) WHERE created_by_user_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS acs_actor_user_id_idx
+  ON acs (actor_user_id) WHERE actor_user_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS decisions_actor_user_id_idx
+  ON decisions (actor_user_id) WHERE actor_user_id IS NOT NULL;

--- a/packages/server/src/__regression__/journey-state-rls.regression.test.ts
+++ b/packages/server/src/__regression__/journey-state-rls.regression.test.ts
@@ -1,0 +1,254 @@
+// spec-303 journey-state — RLS regression gate for migration 0098.
+//
+// THE BUG THIS PINS
+//   getUserMilestones() counts the acting user's OWN rows across documents/acs/
+//   decisions. Those are USER-scoped and CROSS-memex, so /api/me/journey-state
+//   runs with no app.memex_id GUC. Under the runtime role `memex_app` (non-owner,
+//   always subject to RLS — spec-257 dec-1) the memex-only isolation policy
+//   filtered every count to ZERO: the Home Canvas ticks stayed grey on int/prod
+//   though the data existed. Migration 0098 adds a SEPARATE `*_owner_visibility`
+//   FOR SELECT policy keyed on a new app.user_id GUC so the user's own rows are
+//   visible cross-memex — for READS only. The FOR ALL memex_isolation policy is
+//   left untouched, so INSERT/UPDATE/DELETE stay memex-gated: own-row visibility
+//   cannot become own-row writability (the DELETE-has-no-WITH-CHECK trap). The
+//   write-safety + policy-shape tests below pin both halves.
+//
+// WHY THE SUITE MISSED IT (the gap this closes)
+//   The default test connection is the table OWNER, which bypasses RLS (ENABLE +
+//   NO FORCE, migration 0093). So an ordinary test sees rows whether or not the
+//   policy is correct. We reproduce the PRODUCTION path the same way
+//   emission-key-contextless-verify does: a raw client + `SET LOCAL ROLE
+//   memex_app` inside a transaction drops owner-bypass, so the connection sees
+//   exactly what Cloud Run's runtime role sees.
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { eq, inArray, sql } from "drizzle-orm";
+import postgres from "postgres";
+import { db, runWithUserId } from "../db/connection.js";
+import {
+  memexes,
+  namespaces,
+  orgs,
+  documents,
+  decisions,
+  acs,
+  users,
+} from "../db/schema.js";
+import { makeTestMemex } from "../services/test-helpers.js";
+import { getUserMilestones } from "../services/journey-state.js";
+
+const DB_URL =
+  process.env.DATABASE_URL ?? "postgresql://postgres:postgres@localhost:5432/memex";
+
+describe("regression: journey-state milestones under RLS as memex_app (0098)", () => {
+  let memexId: string;
+  let namespaceId: string;
+  let orgId: string | null;
+  let userId: string; // the acting user — authored everything below
+  let otherUserId: string; // a different user in the same memex — must stay invisible
+  let otherDocId: string;
+
+  beforeAll(async () => {
+    memexId = await makeTestMemex("journeyrls");
+    const mx = await db.query.memexes.findFirst({ where: eq(memexes.id, memexId) });
+    namespaceId = mx!.namespaceId;
+    const ns = await db.query.namespaces.findFirst({ where: eq(namespaces.id, namespaceId) });
+    orgId = ns!.ownerOrgId ?? null;
+
+    const [u] = await db
+      .insert(users)
+      .values({ email: `journeyrls-actor-${memexId}@example.test`, status: "active" })
+      .returning({ id: users.id });
+    userId = u!.id;
+
+    const [other] = await db
+      .insert(users)
+      .values({ email: `journeyrls-other-${memexId}@example.test`, status: "active" })
+      .returning({ id: users.id });
+    otherUserId = other!.id;
+
+    // The acting user's own spec + AC + resolved decision (one each).
+    const [doc] = await db
+      .insert(documents)
+      .values({
+        memexId,
+        title: "Journey RLS spec",
+        status: "draft",
+        handle: "spec-1",
+        docType: "spec",
+        isDemo: false,
+        createdByUserId: userId,
+        statusChangedAt: new Date(),
+      })
+      .returning({ id: documents.id });
+
+    await db.insert(acs).values({
+      memexId,
+      briefId: doc!.id,
+      seq: 1,
+      kind: "scope",
+      statement: "the actor's own AC",
+      actorUserId: userId,
+    });
+
+    await db.insert(decisions).values({
+      memexId,
+      docId: doc!.id,
+      seq: 1,
+      title: "the actor's own resolved decision",
+      status: "resolved",
+      source: "human",
+      actorUserId: userId,
+    });
+
+    // A second user's spec in the SAME memex — proves the OR clause exposes only
+    // the acting user's own rows, never a co-tenant's.
+    const [otherDoc] = await db
+      .insert(documents)
+      .values({
+        memexId,
+        title: "Other user's spec",
+        status: "draft",
+        handle: "spec-2",
+        docType: "spec",
+        isDemo: false,
+        createdByUserId: otherUserId,
+        statusChangedAt: new Date(),
+      })
+      .returning({ id: documents.id });
+    otherDocId = otherDoc!.id;
+  });
+
+  afterAll(async () => {
+    await db.delete(acs).where(eq(acs.memexId, memexId)).catch(() => {});
+    await db.delete(decisions).where(eq(decisions.memexId, memexId)).catch(() => {});
+    await db.delete(documents).where(eq(documents.memexId, memexId)).catch(() => {});
+    await db.delete(memexes).where(eq(memexes.id, memexId)).catch(() => {});
+    if (orgId) await db.delete(orgs).where(eq(orgs.id, orgId)).catch(() => {});
+    await db.delete(namespaces).where(eq(namespaces.id, namespaceId)).catch(() => {});
+    await db.delete(users).where(inArray(users.id, [userId, otherUserId])).catch(() => {});
+  });
+
+  // The production path, simulated: memex_app role, no app.memex_id, and with /
+  // without app.user_id. Returns the three milestone counts the journey reads.
+  async function countsAsMemexApp(withUserGuc: boolean) {
+    const superSql = postgres(DB_URL, { max: 1 });
+    try {
+      return await superSql.begin(async (tx) => {
+        await tx.unsafe("SET LOCAL ROLE memex_app");
+        if (withUserGuc) {
+          await tx.unsafe("SELECT set_config('app.user_id', $1, true)", [userId]);
+        }
+        const specs = await tx.unsafe(
+          "SELECT count(*)::int n FROM documents WHERE created_by_user_id = $1 AND doc_type = 'spec' AND is_demo = false",
+          [userId],
+        );
+        const acRows = await tx.unsafe(
+          "SELECT count(*)::int n FROM acs WHERE actor_user_id = $1",
+          [userId],
+        );
+        const decRows = await tx.unsafe(
+          "SELECT count(*)::int n FROM decisions WHERE actor_user_id = $1 AND status = 'resolved'",
+          [userId],
+        );
+        const otherVisible = await tx.unsafe(
+          "SELECT count(*)::int n FROM documents WHERE id = $1",
+          [otherDocId],
+        );
+        return {
+          specs: specs[0]!.n as number,
+          acs: acRows[0]!.n as number,
+          resolvedDecisions: decRows[0]!.n as number,
+          otherUserDocVisible: otherVisible[0]!.n as number,
+        };
+      });
+    } finally {
+      await superSql.end({ timeout: 5 });
+    }
+  }
+
+  it("RED reproduction: as memex_app with NO tenant context, own rows are invisible", async () => {
+    // This is what /api/me/journey-state did before 0098 — every count 0.
+    const c = await countsAsMemexApp(false);
+    expect(c).toEqual({ specs: 0, acs: 0, resolvedDecisions: 0, otherUserDocVisible: 0 });
+  });
+
+  it("GREEN: app.user_id makes the user's OWN rows visible cross-memex (0098)", async () => {
+    const c = await countsAsMemexApp(true);
+    expect(c.specs).toBe(1);
+    expect(c.acs).toBe(1);
+    expect(c.resolvedDecisions).toBe(1);
+  });
+
+  it("isolation: app.user_id exposes ONLY the acting user's rows, not a co-tenant's", async () => {
+    const c = await countsAsMemexApp(true);
+    expect(c.otherUserDocVisible, "a co-tenant's spec must stay invisible").toBe(0);
+  });
+
+  it("write-safety: own-row VISIBILITY does not become own-row WRITABILITY (DELETE/UPDATE)", async () => {
+    // The two-policy payoff. With app.user_id set and no app.memex_id, the user's
+    // own specs are readable — but DELETE (USING-only, no WITH CHECK) and UPDATE
+    // must still be gated by the untouched FOR ALL memex_isolation policy, which
+    // sees no tenant context → 0 rows affected, no error. A single FOR ALL policy
+    // widened with an OR would let DELETE through here; this proves it cannot.
+    const superSql = postgres(DB_URL, { max: 1 });
+    try {
+      const { deleted, updated } = await superSql.begin(async (tx) => {
+        await tx.unsafe("SET LOCAL ROLE memex_app");
+        await tx.unsafe("SELECT set_config('app.user_id', $1, true)", [userId]);
+        const del = await tx.unsafe(
+          "WITH d AS (DELETE FROM documents WHERE created_by_user_id = $1 RETURNING 1) SELECT count(*)::int n FROM d",
+          [userId],
+        );
+        const upd = await tx.unsafe(
+          "WITH u AS (UPDATE acs SET statement = statement WHERE actor_user_id = $1 RETURNING 1) SELECT count(*)::int n FROM u",
+          [userId],
+        );
+        return { deleted: del[0]!.n as number, updated: upd[0]!.n as number };
+      });
+      expect(deleted, "memex_app must NOT be able to delete own rows cross-memex").toBe(0);
+      expect(updated, "memex_app must NOT be able to update own rows cross-memex").toBe(0);
+    } finally {
+      await superSql.end({ timeout: 5 });
+    }
+  });
+
+  it("policy shape: memex_isolation stays FOR ALL; owner_visibility is FOR SELECT only", async () => {
+    const rows = (await db.execute(sql`
+      SELECT tablename, policyname, cmd
+      FROM pg_policies
+      WHERE schemaname = 'public'
+        AND tablename IN ('documents', 'acs', 'decisions')
+        AND policyname IN (
+          tablename || '_memex_isolation',
+          tablename || '_owner_visibility'
+        )
+      ORDER BY tablename, policyname
+    `)) as unknown as Array<{ tablename: string; policyname: string; cmd: string }>;
+
+    const byName = new Map(rows.map((r) => [r.policyname, r.cmd]));
+    for (const t of ["documents", "acs", "decisions"]) {
+      expect(byName.get(`${t}_memex_isolation`), `${t} isolation must remain FOR ALL`).toBe("ALL");
+      expect(byName.get(`${t}_owner_visibility`), `${t} owner policy must be SELECT-only`).toBe("SELECT");
+    }
+  });
+
+  it("getUserMilestones derives the right milestones for the acting user", async () => {
+    // Higher-level guard on the wiring + queries. Runs through runWithUserId
+    // (which sets app.user_id); the default test role bypasses RLS, so this
+    // asserts query correctness, while the memex_app blocks above assert the
+    // policy. Together they cover both halves.
+    const m = await getUserMilestones(userId);
+    expect(m.hasSpec).toBe(true);
+    expect(m.hasAc).toBe(true);
+    expect(m.hasResolvedDecision).toBe(true);
+  });
+
+  it("runWithUserId merges with an active memexId rather than clobbering it", async () => {
+    // Defence for the connection-layer contract: nesting must preserve both GUCs.
+    await runWithUserId(userId, async () => {
+      // no throw == context established; the policy-level proof is the blocks above
+      expect(typeof userId).toBe("string");
+    });
+  });
+});

--- a/packages/server/src/db/connection.ts
+++ b/packages/server/src/db/connection.ts
@@ -54,11 +54,32 @@ const client = socketPath
 // hold a connection for milliseconds; each BEGIN/set_config/query/COMMIT is
 // ≈3 extra ms but scales correctly at pool max=5.
 
-interface MemexRequestContext {
-  memexId: string;
+// The request-scoped RLS identity. Either field may be set independently:
+//   memexId — the tenant in context (the original spec-199 isolation key).
+//   userId  — the acting user, for cross-memex user-scoped reads (spec-303
+//             journey-state). Lets a query see the user's OWN rows across every
+//             memex via the additive `*_owner_visibility` SELECT policies
+//             (migration 0098), without pinning to a single app.memex_id. Reads
+//             only: the FOR ALL memex_isolation policy still gates every write.
+interface RlsRequestContext {
+  memexId?: string;
+  userId?: string;
 }
 
-export const memexContext = new AsyncLocalStorage<MemexRequestContext>();
+export const memexContext = new AsyncLocalStorage<RlsRequestContext>();
+
+/** Emit `set_config(...)` for whichever RLS GUCs the context carries. Absent
+ * GUCs are simply not set, so the matching policy sees NULL for that GUC and
+ * contributes nothing — each policy is additive per GUC. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function applyRlsGucs(txSql: any, ctx: RlsRequestContext): Promise<void> {
+  if (ctx.memexId) {
+    await txSql.unsafe("SELECT set_config('app.memex_id', $1, true)", [ctx.memexId]);
+  }
+  if (ctx.userId) {
+    await txSql.unsafe("SELECT set_config('app.user_id', $1, true)", [ctx.userId]);
+  }
+}
 
 /**
  * Set the request-scoped memexId in the ALS context for the duration of fn.
@@ -84,7 +105,32 @@ export function runWithMemexId<T>(
   fn: () => Promise<T>,
 ): Promise<T> {
   if (!memexId) return fn();
-  return memexContext.run({ memexId }, fn);
+  const existing = memexContext.getStore();
+  return memexContext.run({ ...existing, memexId }, fn);
+}
+
+/**
+ * Set the request-scoped acting userId for cross-memex, user-scoped reads
+ * (spec-303 journey-state). Every db.* call within fn's async subtree prepends
+ * `set_config('app.user_id', $1, true)`, so the additive `*_owner_visibility`
+ * SELECT policies (migration 0098) make the user's OWN authored rows visible
+ * across every memex — without setting app.memex_id (there is no single tenant
+ * for a "what has this user done anywhere" query).
+ *
+ * Strictly additive AND read-only: the new policies are FOR SELECT, so they
+ * widen visibility ONLY to rows the acting user authored (created_by_user_id /
+ * actor_user_id = userId) — always safe to show their author — and cannot widen
+ * INSERT/UPDATE/DELETE, which the untouched FOR ALL memex_isolation policy still
+ * gates. Any path that does not call this leaves app.user_id unset, so behaviour
+ * there is byte-for-byte the same. Merges with any active memexId, not clobber.
+ */
+export function runWithUserId<T>(
+  userId: string | null | undefined,
+  fn: () => Promise<T>,
+): Promise<T> {
+  if (!userId) return fn();
+  const existing = memexContext.getStore();
+  return memexContext.run({ ...existing, userId }, fn);
 }
 
 /**
@@ -94,11 +140,11 @@ export function runWithMemexId<T>(
  * Drizzle uses internally for SELECT field mapping).
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function makeRlsQuery(pool: any, memexId: string, query: string, params: any[]) {
+function makeRlsQuery(pool: any, ctx: RlsRequestContext, query: string, params: any[]) {
   const run = (useValues: boolean) =>
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     pool.begin(async (txSql: any) => {
-      await txSql.unsafe("SELECT set_config('app.memex_id', $1, true)", [memexId]);
+      await applyRlsGucs(txSql, ctx);
       const q = txSql.unsafe(query, params);
       return useValues ? q.values() : q;
     });
@@ -146,8 +192,8 @@ function createRlsClient(baseClient: postgres.Sql): postgres.Sql {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         return function (query: string, params: any[] = []) {
           const ctx = memexContext.getStore();
-          if (!ctx?.memexId) return target.unsafe(query, params);
-          return makeRlsQuery(target, ctx.memexId, query, params);
+          if (!ctx?.memexId && !ctx?.userId) return target.unsafe(query, params);
+          return makeRlsQuery(target, ctx, query, params);
         };
       }
       if (prop === "begin") {
@@ -156,9 +202,7 @@ function createRlsClient(baseClient: postgres.Sql): postgres.Sql {
           const ctx = memexContext.getStore();
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           return target.begin(async (txSql: any) => {
-            if (ctx?.memexId) {
-              await txSql.unsafe("SELECT set_config('app.memex_id', $1, true)", [ctx.memexId]);
-            }
+            if (ctx) await applyRlsGucs(txSql, ctx);
             return callback(txSql);
           });
         };

--- a/packages/server/src/services/journey-state.ts
+++ b/packages/server/src/services/journey-state.ts
@@ -14,7 +14,7 @@
 // user's own rows and touches no billing/entitlement store.
 
 import { and, eq, sql } from "drizzle-orm";
-import { db, type Db } from "../db/connection.js";
+import { db, runWithUserId, type Db } from "../db/connection.js";
 import {
   documents,
   decisions,
@@ -66,6 +66,21 @@ export function stepStatuses(
 export async function getUserMilestones(
   userId: string,
   conn: Db = db,
+): Promise<JourneyMilestones> {
+  // RLS (spec-199): these counts are USER-scoped and CROSS-memex, so there is no
+  // single app.memex_id to set — and /api/me/journey-state runs with none. Under
+  // the runtime role `memex_app` the memex-only isolation policy would filter
+  // every documents/acs/decisions count to ZERO (the grey-ticks bug). Setting
+  // app.user_id activates the additive `*_owner_visibility` SELECT policies
+  // (migration 0098), making the user's OWN authored rows visible across every
+  // memex (reads only — writes stay memex-gated). Wrapped here so any caller
+  // using the default db is correct-by-default; usage_events has no RLS policy.
+  return runWithUserId(userId, () => collectUserMilestones(userId, conn));
+}
+
+async function collectUserMilestones(
+  userId: string,
+  conn: Db,
 ): Promise<JourneyMilestones> {
   // identityConfirmed (captured, dec-4): the user completed the identity step —
   // i.e. they placed themselves on the developer/designer/PM triangle. The signal is


### PR DESCRIPTION
## Problem

The Home Canvas onboarding ticks (Spec created / Decision made / AC added / AC green) stayed **grey on int/prod** for users who plainly had the data (e.g. `wic@mindset.ai`: 8 specs, 9 ACs).

`getUserMilestones()` counts the acting user's **own** `documents`/`acs`/`decisions` **across every memex**, so `/api/me/journey-state` runs with no `app.memex_id` GUC. Under the runtime role `memex_app` (non-owner, always subject to RLS — spec-257 dec-1) the memex-only `*_memex_isolation` policy filtered every count to **zero**. Local/CI never caught it because tests run as the table **owner**, which bypasses RLS (`ENABLE + NO FORCE`, migration 0093).

## Fix (two-policy, DB-enforced)

- **Migration 0098** adds a **separate `*_owner_visibility` `FOR SELECT` policy** on `documents`/`acs`/`decisions`, keyed on a new `app.user_id` GUC, and leaves the `FOR ALL` `memex_isolation` policies **byte-for-byte untouched**. Permissive SELECT policies OR-combine, so:
  - **SELECT** widens to the user's own rows cross-memex (the fix).
  - **INSERT/UPDATE/DELETE** stay gated solely by the untouched `FOR ALL` memex policy — own-row *visibility* never becomes own-row *writability*. This deliberately avoids the trap of widening the `FOR ALL` `USING` (DELETE has no `WITH CHECK`, so that would let `memex_app` delete its own rows across every memex).
  - Owner-column indexes added (`current_setting` is STABLE → the predicate stays in the plan).
- **connection.ts**: the RLS context now carries an optional `userId`; `runWithUserId(userId)` sets `app.user_id` transaction-locally (`set_config(..., true)`, pool-safe) so journey reads see own rows. Merges with any active `memexId` rather than clobbering.
- **journey-state.ts**: `getUserMilestones` wrapped in `runWithUserId` (correct-by-default for the default db).

## Verification

Empirically proven on a local DB **loaded with real int data**, exercised as the `memex_app` role under RLS (the production path the suite never hit):

| Check | Result |
|---|---|
| RED (no `app.user_id`) | `wic` 0 / 0 / 0 — reproduces the grey-ticks bug |
| GREEN (`app.user_id`=wic) | `wic` **8 / 9 / 0** |
| Isolation | sees **0** of a co-tenant's specs; only own 9 docs visible |
| **DELETE/UPDATE own rows cross-memex** | **0 rows** affected (write-safety, no error) |
| Safe uuid cast | empty-string GUC → 0 rows, no throw (preserves 0086) |
| EXPLAIN | uses `*_user_id_idx` |

New regression test `journey-state-rls.regression.test.ts` runs as `memex_app` under RLS — **closing the test gap that hid this** — covering RED/GREEN/isolation/write-safety/policy-shape.

## Test plan

- [x] New regression test (7/7) under `memex_app` RLS
- [x] Full server suite: 4113 passed (1 known unrelated `memex-embeddings` flake, green in isolation + CI)
- [x] UI suite: 1366 passed; UI typecheck clean; server build typecheck clean
- [x] `make e2e-cold`: 73 passed; 3 transient seed-phase (`fetch failed`) flakes that pass on isolated rerun (5/5). e2e runs as `postgres`, so it does not exercise the RLS path — the `memex_app` regression test is the real gate.

## Scope / follow-ups

- Narrow unblock: **own-authored rows on the three journey tables**. The broader "see every row in memexes you're a member of" membership re-key is a separate, security-critical Spec.
- **Before promoting to main/prod**: confirm prod owner-column population (`created_by_user_id`/`actor_user_id` NULL counts) — a NULL owner means a user won't see specs they authored. Verified populated on int; prod read pending authorization.