### PR TITLE
feat(journey): onboarding card copy + visuals on-brand, glossary plumbing

### DIFF
--- a/packages/ui/e2e/journey-34-home-canvas.spec.ts
+++ b/packages/ui/e2e/journey-34-home-canvas.spec.ts
@@ -49,7 +49,7 @@ test(TITLE, async ({ page }) => {
 
   // A brand-new user lands on the welcome step: the universal Beat-1 cold open (ac-1).
   await expect(page.getByTestId("journey-step-welcome")).toBeVisible({ timeout: 15_000 });
-  await expect(page.getByText("drift apart")).toBeVisible();
+  await expect(page.getByText(/vibe coding viable/)).toBeVisible();
   await page.getByTestId("journey-cta-primary").click(); // Get started → identity
 
   // The identity step: name confirm (pre-filled from SSO) + the role triangle (ac-2).

--- a/packages/ui/src/components/GlossaryTerm.tsx
+++ b/packages/ui/src/components/GlossaryTerm.tsx
@@ -1,0 +1,81 @@
+import { useId, useRef, useState, type ReactNode } from 'react';
+import { createPortal } from 'react-dom';
+
+// The journey glossary: friendly, plain-English definitions for the nouns the
+// onboarding journey introduces, anchored to a familiar construct where one fits.
+// Built as reusable plumbing so the same terms can light up anywhere in the
+// journey (and, sparingly, elsewhere in the product). Definitions are always a
+// BONUS: the surrounding copy must read fine without ever opening the pop-up, so
+// no load-bearing information lives here.
+export const GLOSSARY = {
+  spec: `Like a blueprint or spec doc, except it doesn't rot: your agent reads it, builds to it, and the tests keep it honest.`,
+  standard: `Your team's house rules: set once, followed everywhere, including by your agent.`,
+  decision: `A call you've made, written down with the why, so it stops getting re-argued. Think "we chose X because Y."`,
+  ac: `The finish line in plain words: exactly what "done" means, and a passing test crosses it for you.`,
+} as const;
+
+export type GlossaryKey = keyof typeof GLOSSARY;
+
+/**
+ * GlossaryTerm — wraps a jargon noun with a dotted underline and a friendly
+ * pop-up definition. Reveals on hover, on keyboard focus, and on tap (toggle),
+ * so it works on desktop and touch. Accessible: focusable, described-by the
+ * tooltip, and Escape-dismissable.
+ *
+ * The pop-up is rendered through a PORTAL to document.body and positioned
+ * `fixed` off the trigger, so it can extend beyond the journey card (whose
+ * `overflow-hidden` would otherwise clip it) and is never illegible behind it.
+ * The definition is decoration over meaning — the sentence stands on its own.
+ */
+export function GlossaryTerm({ term, children }: { term: GlossaryKey; children: ReactNode }) {
+  const [open, setOpen] = useState(false);
+  const [pos, setPos] = useState<{ top: number; left: number } | null>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const id = useId();
+
+  const show = () => {
+    const el = triggerRef.current;
+    if (el) {
+      const r = el.getBoundingClientRect();
+      setPos({ top: r.bottom + 8, left: r.left + r.width / 2 });
+    }
+    setOpen(true);
+  };
+  const hide = () => setOpen(false);
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        data-testid={`glossary-term-${term}`}
+        aria-describedby={open ? id : undefined}
+        onMouseEnter={show}
+        onMouseLeave={hide}
+        onFocus={show}
+        onBlur={hide}
+        onClick={() => (open ? hide() : show())}
+        onKeyDown={(e) => {
+          if (e.key === 'Escape') hide();
+        }}
+        className="cursor-help bg-transparent p-0 align-baseline font-[inherit] text-[inherit] underline decoration-dotted underline-offset-4 transition-colors hover:text-primary"
+      >
+        {children}
+      </button>
+      {open &&
+        pos &&
+        typeof document !== 'undefined' &&
+        createPortal(
+          <span
+            id={id}
+            role="tooltip"
+            style={{ position: 'fixed', top: pos.top, left: pos.left, transform: 'translateX(-50%)' }}
+            className="pointer-events-none z-[60] w-64 max-w-[calc(100vw-1rem)] rounded-lg border border-edge-subtle bg-surface p-3 text-left text-xs font-normal leading-relaxed text-secondary shadow-lg"
+          >
+            {GLOSSARY[term]}
+          </span>,
+          document.body,
+        )}
+    </>
+  );
+}

--- a/packages/ui/src/components/home/AgentPromptStep.tsx
+++ b/packages/ui/src/components/home/AgentPromptStep.tsx
@@ -20,7 +20,7 @@ interface StepConfig {
 
 export const AGENT_PROMPT_STEPS: Record<string, StepConfig> = {
   'resolve-decision': {
-    eyebrow: 'Memex · Next',
+    eyebrow: '// 03 · first decision',
     headline: 'Make the first real call.',
     sub: 'Every plan hinges on a few decisions.',
     body: 'Have your agent capture the choice your spec turns on as a decision, weigh the options, and resolve it. That is how the plan stays honest and your agent knows which path you picked.',
@@ -35,7 +35,7 @@ Tell me which decision you resolved (dec-N).`,
     waitingLabel: 'Waiting for your agent to resolve a decision — this advances the moment it does.',
   },
   'add-ac': {
-    eyebrow: 'Memex · Next',
+    eyebrow: '// 04 · define "done"',
     headline: 'Pin down what "done" means.',
     sub: 'An acceptance criterion turns intent into something testable.',
     body: 'Have your agent add an acceptance criterion to your decision — a plain statement of what the code must do. This is the promise your tests will hold the build to.',
@@ -96,7 +96,7 @@ export function AgentPromptStep({
         data-testid={`journey-step-${stepId}`}
         className="relative w-full max-w-2xl overflow-hidden rounded-3xl border border-edge bg-surface/70 p-8 shadow-2xl backdrop-blur-xl sm:p-12"
       >
-        <div className="mb-5 text-xs font-semibold uppercase tracking-[0.14em] text-muted">{cfg.eyebrow}</div>
+        <div className="mb-5 font-mono text-xs lowercase tracking-tight text-muted">{cfg.eyebrow}</div>
         <h1 className="text-4xl font-black leading-[1.08] tracking-tight text-heading sm:text-5xl">{cfg.headline}</h1>
         <p className="mt-4 text-lg font-semibold text-primary">{cfg.sub}</p>
         <p className="mt-4 max-w-prose leading-relaxed text-secondary">{cfg.body}</p>

--- a/packages/ui/src/components/home/ConnectAgentStep.tsx
+++ b/packages/ui/src/components/home/ConnectAgentStep.tsx
@@ -207,13 +207,13 @@ export function ConnectAgentStep({
           </div>
         ) : (
           <>
-            <div className="mb-5 text-xs font-semibold uppercase tracking-[0.14em] text-muted">
-              Memex · First, the big one
+            <div className="mb-5 font-mono text-xs lowercase tracking-tight text-muted">
+              // 01 · connect your agent
             </div>
             <h1 className="text-4xl font-black leading-[1.08] tracking-tight text-heading sm:text-5xl">
               Bring your coding agent.
             </h1>
-            <p className="mt-4 text-lg font-semibold text-primary">This is the one that unlocks everything else.</p>
+            <p className="mt-4 text-lg font-semibold text-primary">Nothing else moves until your agent&apos;s in.</p>
             <p className="mt-4 max-w-prose leading-relaxed text-secondary">
               Connect your agent over MCP and it can read your specs, standards and decisions, and report progress
               back. From here, your agent does the work while you watch it land.

--- a/packages/ui/src/components/home/ConnectAgentStep.tsx
+++ b/packages/ui/src/components/home/ConnectAgentStep.tsx
@@ -6,6 +6,7 @@
 // user's first tool call (or a manual Next). Reuses the portable installBase/mcpUrl
 // derivation + the CodeBlock primitive (DRY with the Settings install section).
 import { useEffect, useRef, useState } from 'react';
+import { GlossaryTerm } from '../GlossaryTerm';
 import { CodeBlock } from '../CodeBlock';
 import { installBase, mcpUrl } from '../../utils/mcpUrl';
 import { fetchJourneyStateApi } from '../../api/journey';
@@ -213,10 +214,12 @@ export function ConnectAgentStep({
             <h1 className="text-4xl font-black leading-[1.08] tracking-tight text-heading sm:text-5xl">
               Bring your coding agent.
             </h1>
-            <p className="mt-4 text-lg font-semibold text-primary">Nothing else moves until your agent&apos;s in.</p>
+            <p className="mt-4 text-lg font-semibold text-primary">One connection, and your agent works straight from your plan.</p>
             <p className="mt-4 max-w-prose leading-relaxed text-secondary">
-              Connect your agent over MCP and it can read your specs, standards and decisions, and report progress
-              back. From here, your agent does the work while you watch it land.
+              Connect your agent over MCP and it can read your <GlossaryTerm term="spec">specs</GlossaryTerm>,{' '}
+              <GlossaryTerm term="standard">standards</GlossaryTerm> and{' '}
+              <GlossaryTerm term="decision">decisions</GlossaryTerm>, and report progress back. From here, your
+              agent does the work while you watch it land.
             </p>
 
             {osMatters && (

--- a/packages/ui/src/components/home/CreateSpecStep.tsx
+++ b/packages/ui/src/components/home/CreateSpecStep.tsx
@@ -71,7 +71,7 @@ export function CreateSpecStep({
         data-testid="journey-step-create-spec"
         className="relative w-full max-w-2xl overflow-hidden rounded-3xl border border-edge bg-surface/70 p-8 shadow-2xl backdrop-blur-xl sm:p-12"
       >
-        <div className="mb-5 text-xs font-semibold uppercase tracking-[0.14em] text-muted">Memex · Next</div>
+        <div className="mb-5 font-mono text-xs lowercase tracking-tight text-muted">// 02 · first spec</div>
         <h1 className="text-4xl font-black leading-[1.08] tracking-tight text-heading sm:text-5xl">
           Hand your agent its first spec.
         </h1>

--- a/packages/ui/src/components/home/CreateSpecStep.tsx
+++ b/packages/ui/src/components/home/CreateSpecStep.tsx
@@ -4,6 +4,7 @@
 // exists (hasSpec milestone). The agent reads the source locally — no Memex-side upload.
 import { useEffect, useRef, useState } from 'react';
 import { CodeBlock } from '../CodeBlock';
+import { GlossaryTerm } from '../GlossaryTerm';
 import { fetchJourneyStateApi } from '../../api/journey';
 
 type Source = 'prd' | 'sample';
@@ -31,9 +32,11 @@ acceptance criterion next.`;
 export function CreateSpecStep({
   preview = false,
   onComplete,
+  onCreateInApp,
 }: {
   preview?: boolean;
   onComplete?: () => void;
+  onCreateInApp?: () => void;
 } = {}) {
   const [source, setSource] = useState<Source>('sample');
   const [done, setDone] = useState(false);
@@ -75,10 +78,10 @@ export function CreateSpecStep({
         <h1 className="text-4xl font-black leading-[1.08] tracking-tight text-heading sm:text-5xl">
           Hand your agent its first spec.
         </h1>
-        <p className="mt-4 text-lg font-semibold text-primary">No blank page — bring a PRD, or use ours.</p>
+        <p className="mt-4 text-lg font-semibold text-primary">No blank page: bring a PRD, or use ours.</p>
         <p className="mt-4 max-w-prose leading-relaxed text-secondary">
-          Paste this into your connected agent. It reads your source locally and creates the spec in your
-          personal Memex over MCP — nothing to upload here.
+          Paste this into your connected agent. It reads your source locally and creates the{' '}
+          <GlossaryTerm term="spec">spec</GlossaryTerm> in your personal Memex over MCP, nothing to upload here.
         </p>
 
         <div className="mt-7">
@@ -129,10 +132,20 @@ export function CreateSpecStep({
           ) : (
             <div className="flex items-center gap-2 text-sm text-muted">
               <span className="h-2.5 w-2.5 animate-pulse rounded-full bg-accent" />
-              Waiting for your agent to create the spec — this advances the moment it does.
+              Waiting for your agent to create the spec, this advances the moment it does.
             </div>
           )}
         </div>
+
+        <button
+          type="button"
+          data-testid="create-spec-in-app"
+          onClick={() => onCreateInApp?.()}
+          className="mt-6 inline-flex items-center gap-1 text-sm text-muted underline-offset-4 transition-colors hover:text-secondary hover:underline"
+        >
+          Rather click than paste? Create one in the app
+          <span aria-hidden>→</span>
+        </button>
       </article>
     </div>
   );

--- a/packages/ui/src/components/home/IdentityStep.tsx
+++ b/packages/ui/src/components/home/IdentityStep.tsx
@@ -63,6 +63,7 @@ export function IdentityStep({
         data-testid="journey-step-identity"
         className="relative w-full max-w-2xl overflow-hidden rounded-3xl border border-edge bg-surface/70 p-8 shadow-2xl backdrop-blur-xl sm:p-12"
       >
+        <div className="mb-5 font-mono text-xs lowercase tracking-tight text-muted">// 00 · who you are and what you do</div>
         <h1 className="text-3xl font-black tracking-tight text-heading sm:text-4xl">
           {greeting ? `Good to meet you, ${greeting}.` : 'Good to meet you.'}
         </h1>

--- a/packages/ui/src/components/home/IdentityStep.tsx
+++ b/packages/ui/src/components/home/IdentityStep.tsx
@@ -53,7 +53,9 @@ export function IdentityStep({
     [name, token, user, updateSession, preview, onComplete],
   );
 
-  const greeting = firstName(user?.name);
+  // Greeting tracks the live name field (not the stored SSO name) so the H1 updates
+  // as the user edits their name.
+  const greeting = firstName(name);
 
   return (
     <div className="flex min-h-[70vh] items-center justify-center px-4 py-10">
@@ -65,13 +67,10 @@ export function IdentityStep({
           {greeting ? `Good to meet you, ${greeting}.` : 'Good to meet you.'}
         </h1>
         <p className="mt-3 text-secondary">
-          A couple of quick things, then we&apos;ll get you to your first win.
+          That&apos;s the name from your login, swap it below if it&apos;s not quite you.
         </p>
 
         <label className="mt-6 block">
-          <span className="mb-1 block text-sm font-medium text-secondary">
-            We&apos;ll call you this — change it if you&apos;d rather.
-          </span>
           <input
             data-testid="identity-name"
             value={name}
@@ -82,8 +81,12 @@ export function IdentityStep({
         </label>
 
         <div className="mt-6">
-          <span className="mb-8 block text-sm font-medium text-secondary">
-            Where do you sit? No one&apos;s just one thing — place yourself anywhere.
+          <p className="text-secondary">
+            {greeting ? `Now, ${greeting}, nobody's just one thing anymore` : "Nobody's just one thing anymore"}: not
+            just a developer, not just a designer, not just a PM.
+          </p>
+          <span className="mt-2 mb-8 block text-sm font-medium text-secondary">
+            Drag the dot to where you fit. Most people land somewhere in between.
           </span>
           <RoleTriangle value={role} onChange={setRole} />
           <p data-testid="persona-label" className="mt-2 text-center text-sm font-semibold text-heading">

--- a/packages/ui/src/components/home/JourneyStepShell.tsx
+++ b/packages/ui/src/components/home/JourneyStepShell.tsx
@@ -19,7 +19,7 @@ export function JourneyStepShell({
         className="relative w-full max-w-2xl overflow-hidden rounded-3xl border border-edge bg-surface/70 p-8 shadow-2xl backdrop-blur-xl sm:p-12"
       >
         {view.eyebrow && (
-          <div className="mb-5 text-xs font-semibold uppercase tracking-[0.14em] text-muted">
+          <div className="mb-5 font-mono text-xs lowercase tracking-tight text-muted">
             {view.eyebrow}
           </div>
         )}

--- a/packages/ui/src/components/home/RoleTriangle.tsx
+++ b/packages/ui/src/components/home/RoleTriangle.tsx
@@ -78,6 +78,9 @@ export function RoleTriangle({
 }) {
   const svgRef = useRef<SVGSVGElement>(null);
   const [dragging, setDragging] = useState(false);
+  // One-time interaction flag: the pulse + "drag me" hint show until the first move,
+  // so it's immediately clear the dot is the thing to grab.
+  const [touched, setTouched] = useState(false);
   const blob = toPoint(value);
 
   function pointerToCoords(e: ReactPointerEvent) {
@@ -103,6 +106,7 @@ export function RoleTriangle({
               : {};
     if (Object.keys(bias).length === 0) return;
     e.preventDefault();
+    setTouched(true);
     const next = {
       dev: Math.max(0, value.dev + (bias.dev ?? 0)),
       design: Math.max(0, value.design + (bias.design ?? 0)),
@@ -121,10 +125,11 @@ export function RoleTriangle({
       aria-valuetext={personaLabel(value)}
       tabIndex={0}
       data-testid="role-triangle"
-      className="mx-auto block w-full max-w-[22rem] cursor-pointer touch-none select-none rounded-2xl focus:outline-hidden focus-visible:ring-2 focus-visible:ring-accent"
+      className={`mx-auto block w-full max-w-[22rem] touch-none select-none rounded-2xl focus:outline-hidden focus-visible:ring-2 focus-visible:ring-accent ${dragging ? 'cursor-grabbing' : 'cursor-grab'}`}
       onPointerDown={(e) => {
         (e.target as Element).setPointerCapture?.(e.pointerId);
         setDragging(true);
+        setTouched(true);
         pointerToCoords(e);
       }}
       onPointerMove={(e) => dragging && pointerToCoords(e)}
@@ -150,13 +155,24 @@ export function RoleTriangle({
       <text x={VERT.pm.x} y={VERT.pm.y + 22} textAnchor="middle" className="fill-secondary text-[12px] font-semibold">
         PM
       </text>
+      {/* Until the first interaction: a soft pulse + a "drag me" hint so the dot
+          reads as the grabbable thing. Both vanish the moment the user moves it. */}
+      {!touched && (
+        <>
+          <circle cx={blob.x} cy={blob.y} r={20} fill="#8b5cf6" fillOpacity={0.18} className="animate-pulse" />
+          <text x={blob.x} y={blob.y - 27} textAnchor="middle" className="fill-secondary text-[11px] font-semibold">
+            drag me
+          </text>
+        </>
+      )}
+      {/* The grabbable knob: a larger gradient dot with a white ring (the handle). */}
       <circle
         data-testid="role-triangle-blob"
         cx={blob.x}
         cy={blob.y}
-        r={11}
+        r={16}
         className="fill-[url(#roleBlob)] stroke-white"
-        strokeWidth={2}
+        strokeWidth={3}
       />
       <defs>
         <radialGradient id="roleBlob">

--- a/packages/ui/src/components/home/SeeGreenStep.tsx
+++ b/packages/ui/src/components/home/SeeGreenStep.tsx
@@ -70,7 +70,7 @@ export function SeeGreenStep({
           </div>
         ) : (
           <div className="text-left">
-            <div className="mb-5 text-xs font-semibold uppercase tracking-[0.14em] text-muted">Memex · The moment</div>
+            <div className="mb-5 font-mono text-xs lowercase tracking-tight text-muted">// 05 · the moment</div>
             <h1 className="text-4xl font-black leading-[1.08] tracking-tight text-heading sm:text-5xl">
               Watch it go green.
             </h1>

--- a/packages/ui/src/components/home/WelcomeStep.tsx
+++ b/packages/ui/src/components/home/WelcomeStep.tsx
@@ -21,6 +21,7 @@ export function WelcomeStep({ onNavigate }: { onNavigate: (stepId: string) => vo
         data-testid="journey-step-welcome"
         className="relative w-full max-w-2xl overflow-hidden rounded-3xl border border-edge bg-surface/70 p-8 shadow-2xl backdrop-blur-xl sm:p-12"
       >
+        <div className="mb-5 font-mono text-xs lowercase tracking-tight text-muted">// memex makes vibe coding viable</div>
         {first && (
           <h1 className="text-4xl font-black leading-[1.08] tracking-tight text-heading sm:text-5xl">
             Hello, <span>{first}</span>.
@@ -30,9 +31,6 @@ export function WelcomeStep({ onNavigate }: { onNavigate: (stepId: string) => vo
           Welcome to Memex.
           <span className="block">Let&apos;s get you up and running.</span>
         </h1>
-        <p className="mt-3 bg-[linear-gradient(96deg,#fb5b78,#c084fc)] bg-clip-text text-2xl font-black leading-tight tracking-tight text-transparent sm:text-3xl">
-          Memex makes vibe coding viable.
-        </p>
         <p className="mt-4 max-w-prose leading-relaxed text-secondary">
           A few short steps from here and your agent is building from a plan it can&apos;t drift from, and proving
           the code matches it.

--- a/packages/ui/src/components/home/WelcomeStep.tsx
+++ b/packages/ui/src/components/home/WelcomeStep.tsx
@@ -28,17 +28,14 @@ export function WelcomeStep({ onNavigate }: { onNavigate: (stepId: string) => vo
         )}
         <h1 className="text-4xl font-black leading-[1.08] tracking-tight text-heading sm:text-5xl">
           Welcome to Memex.
-          <span className="block">
-            Your plan and your build{' '}
-            <span className="bg-[linear-gradient(96deg,#fb5b78,#c084fc)] bg-clip-text text-transparent">
-              drift apart
-            </span>{' '}
-            the moment you write them.
-          </span>
+          <span className="block">Let&apos;s get you up and running.</span>
         </h1>
+        <p className="mt-3 bg-[linear-gradient(96deg,#fb5b78,#c084fc)] bg-clip-text text-2xl font-black leading-tight tracking-tight text-transparent sm:text-3xl">
+          Memex makes vibe coding viable.
+        </p>
         <p className="mt-4 max-w-prose leading-relaxed text-secondary">
-          Memex keeps intent and code in lockstep: one living source your agent reads, follows, and proves it
-          honoured.
+          A few short steps from here and your agent is building from a plan it can&apos;t drift from, and proving
+          the code matches it.
         </p>
 
         <div className="mt-8 flex flex-wrap items-center gap-3">
@@ -72,7 +69,7 @@ export function WelcomeStep({ onNavigate }: { onNavigate: (stepId: string) => vo
             <div className="mt-5 space-y-4">
               <p className="leading-relaxed text-secondary">
                 <span className="font-semibold text-heading">The docs rotted.</span> Every markdown file was right
-                the day we wrote it and quietly wrong a week later — a heap of them, no way to tell which still
+                the day we wrote it and quietly wrong a week later. A heap of them, no way to tell which still
                 held.
               </p>
               <p className="leading-relaxed text-secondary">
@@ -87,7 +84,7 @@ export function WelcomeStep({ onNavigate }: { onNavigate: (stepId: string) => vo
             </div>
             <p className="mt-6 leading-relaxed text-primary">
               Memex is what fell out of fixing that for ourselves: the spec stops being a doc that rots and becomes
-              something the tests keep honest — so <span className="italic">is it right</span> is a question you
+              something the tests keep honest, so <span className="italic">is it right</span> is a question you
               answer, not feel.
             </p>
           </div>

--- a/packages/ui/src/journeys/onboarding/steps.tsx
+++ b/packages/ui/src/journeys/onboarding/steps.tsx
@@ -68,7 +68,7 @@ export const ONBOARDING_STEP_VIEWS: Record<string, JourneyStepView> = {
     mapLabel: 'Agent connected',
     eyebrow: '// 01 · connect your agent',
     headline: 'Bring your coding agent.',
-    sub: "Nothing else moves until your agent's in.",
+    sub: 'One connection, and your agent works straight from your plan.',
     body: 'Connect your agent over MCP and it can read your specs, standards and decisions, and report progress back. One command and you are wired in — from here, your agent does the work while you watch it land.',
     primary: { label: 'Connect your agent', kind: 'action', target: 'connect_agent' },
     secondary: { label: "What's the MCP?", kind: 'link', target: 'https://www.memex.ai' },

--- a/packages/ui/src/journeys/onboarding/steps.tsx
+++ b/packages/ui/src/journeys/onboarding/steps.tsx
@@ -55,7 +55,7 @@ export const ONBOARDING_STEP_VIEWS: Record<string, JourneyStepView> = {
   // Informational (navigate-only) — not a server milestone step.
   'learn-more': {
     id: 'learn-more',
-    eyebrow: "Memex · What's a spec?",
+    eyebrow: "// what's a spec?",
     headline: 'A spec is a living plan.',
     sub: 'Not a doc that rots: a plan your agent reads and follows.',
     body: 'A spec captures what you are building and why — the decisions it hinges on, what "done" means, and the work to get there. Your coding agent reads it over MCP, so it builds the right thing and stays on track.',
@@ -66,9 +66,9 @@ export const ONBOARDING_STEP_VIEWS: Record<string, JourneyStepView> = {
   'connect-agent': {
     id: 'connect-agent',
     mapLabel: 'Agent connected',
-    eyebrow: 'Memex · First, the big one',
+    eyebrow: '// 01 · connect your agent',
     headline: 'Bring your coding agent.',
-    sub: 'This is the one that unlocks everything else.',
+    sub: "Nothing else moves until your agent's in.",
     body: 'Connect your agent over MCP and it can read your specs, standards and decisions, and report progress back. One command and you are wired in — from here, your agent does the work while you watch it land.',
     primary: { label: 'Connect your agent', kind: 'action', target: 'connect_agent' },
     secondary: { label: "What's the MCP?", kind: 'link', target: 'https://www.memex.ai' },
@@ -77,7 +77,7 @@ export const ONBOARDING_STEP_VIEWS: Record<string, JourneyStepView> = {
   'create-spec': {
     id: 'create-spec',
     mapLabel: 'Spec created',
-    eyebrow: 'Memex · Next',
+    eyebrow: '// 02 · first spec',
     headline: 'Hand your agent its first spec.',
     sub: 'Bring a PRD, or use ours and follow along.',
     body: 'Paste the prompt into your connected agent and it creates a spec in your personal Memex — point it at a real PRD/markdown file, or use our sample to learn the ropes.',
@@ -88,7 +88,7 @@ export const ONBOARDING_STEP_VIEWS: Record<string, JourneyStepView> = {
   'resolve-decision': {
     id: 'resolve-decision',
     mapLabel: 'Decision made',
-    eyebrow: 'Memex · Next',
+    eyebrow: '// 03 · first decision',
     headline: 'Make the first real call.',
     sub: 'Every plan hinges on a few decisions.',
     body: 'Capture the choice your spec turns on, weigh the options, and resolve it. That is how the plan stays honest and your agent knows which path you picked.',
@@ -99,7 +99,7 @@ export const ONBOARDING_STEP_VIEWS: Record<string, JourneyStepView> = {
   'add-ac': {
     id: 'add-ac',
     mapLabel: 'AC added',
-    eyebrow: 'Memex · Next',
+    eyebrow: '// 04 · define "done"',
     headline: 'Pin down what "done" means.',
     sub: 'An acceptance criterion turns intent into something testable.',
     body: 'Add an acceptance criterion to your decision — a plain statement of what the code must do. This is the promise your tests will hold the build to.',
@@ -109,7 +109,7 @@ export const ONBOARDING_STEP_VIEWS: Record<string, JourneyStepView> = {
   'see-green': {
     id: 'see-green',
     mapLabel: 'AC green',
-    eyebrow: 'Memex · The moment',
+    eyebrow: '// 05 · the moment',
     headline: 'Watch it go green.',
     sub: 'Your agent emits a test result, and the AC lights up.',
     body: 'Have your agent run the test that backs your acceptance criterion. When it passes, the AC turns green right here — provable alignment between what you intended and what the code does. This is Memex.',
@@ -119,7 +119,7 @@ export const ONBOARDING_STEP_VIEWS: Record<string, JourneyStepView> = {
   'all-set': {
     id: 'all-set',
     mapLabel: 'Set up',
-    eyebrow: "Memex · You're set up",
+    eyebrow: '// done',
     headline: "You're all set.",
     sub: 'You drove a spec from intent to a green AC. That is the whole loop.',
     body: 'From here, Home shows what needs your attention next. When you are ready, bring your colleagues in — set up an organisation (free) so the map grows with the people you work with.',

--- a/packages/ui/src/pages/HomeCanvas.test.tsx
+++ b/packages/ui/src/pages/HomeCanvas.test.tsx
@@ -84,7 +84,7 @@ describe('HomeCanvas — welcome step (ac-2)', () => {
 
     expect(await screen.findByTestId('journey-step-welcome')).toBeInTheDocument();
     expect(screen.getByText('Welcome to Memex.')).toBeInTheDocument();
-    expect(screen.getByText('drift apart')).toBeInTheDocument();
+    expect(screen.getByText(/drift apart/)).toBeInTheDocument();
     // The coder-specific ".md files" line is a Beat-2 reward, never the cold open.
     expect(screen.queryByText('.md files')).not.toBeInTheDocument();
     expect(screen.getByText('John')).toBeInTheDocument(); // greeting first-name

--- a/packages/ui/src/pages/HomeCanvas.test.tsx
+++ b/packages/ui/src/pages/HomeCanvas.test.tsx
@@ -84,7 +84,7 @@ describe('HomeCanvas — welcome step (ac-2)', () => {
 
     expect(await screen.findByTestId('journey-step-welcome')).toBeInTheDocument();
     expect(screen.getByText('Welcome to Memex.')).toBeInTheDocument();
-    expect(screen.getByText(/drift apart/)).toBeInTheDocument();
+    expect(screen.getByText(/vibe coding viable/)).toBeInTheDocument();
     // The coder-specific ".md files" line is a Beat-2 reward, never the cold open.
     expect(screen.queryByText('.md files')).not.toBeInTheDocument();
     expect(screen.getByText('John')).toBeInTheDocument(); // greeting first-name

--- a/packages/ui/src/pages/HomeCanvas.tsx
+++ b/packages/ui/src/pages/HomeCanvas.tsx
@@ -178,7 +178,16 @@ export function HomeCanvas() {
       ) : displayStepId === 'create-spec' ? (
         // spec-305 dec-9: copy-paste prompt + bring-your-own-PRD or sample; advances
         // the moment the agent creates the spec (hasSpec).
-        <CreateSpecStep preview={preview} onComplete={load} />
+        <CreateSpecStep
+          preview={preview}
+          onComplete={load}
+          onCreateInApp={() => {
+            // Pure navigation to the New Spec modal (?new=1) — writes nothing, so like any
+            // 'navigate' CTA it works even in operator preview. Keeps the link from being a
+            // dead end when colleagues preview the card.
+            if (specsPath) navigate(`${specsPath}?new=1`);
+          }}
+        />
       ) : displayStepId === 'resolve-decision' || displayStepId === 'add-ac' ? (
         // spec-305 dec-8: paste-a-prompt cards; advance on the step's milestone.
         <AgentPromptStep stepId={displayStepId} preview={preview} onComplete={load} />


### PR DESCRIPTION
## What this is

A pass over the onboarding journey cards (the Home Canvas) to tighten copy, get the visuals on-brand, and add reusable glossary plumbing. Worked card-by-card with Wic; this is everything reviewed and approved so far.

## Per-card changes

- **Welcome** — leads with `// memex makes vibe coding viable` as a mono eyebrow, then "Welcome to Memex. Let's get you up and running." and a value-first body. "Why Memex?" lesson em-dashes purged.
- **Identity / role triangle** — the H1 greeting and a name→role pivot both track the **live** name field (edit your name, both update). A tongue-in-cheek "that's the name from your login, swap it below" replaces the old sub-line + the name label; the "nobody's just one thing" belief moves down to frame the triangle. New `// 00 · who you are and what you do` eyebrow. **RoleTriangle**: a bigger gradient knob with a white ring + grab cursor, and a one-time pulse + "drag me" hint that clears on first move, so it's immediately clear the dot is the thing to grab.
- **Connect-agent** — sub becomes "One connection, and your agent works straight from your plan." (the old "nothing else moves" is false once peek/skip lands). `specs` / `standards` / `decisions` wired to the glossary.
- **Create-spec** — makes the two ways explicit: the agent paste-prompt stays the hero, plus a quiet "Rather click than paste? Create one in the app" link that opens the New Spec modal (`?new=1`). The link navigates directly (not via the write-guarded `handleCta`), so it works in operator preview too and is never a dead end. Glossary-wires "spec".

## Reusable plumbing

- **`GlossaryTerm`** — a dotted-underline term with a friendly pop-up definition (hover / focus / tap). Rendered through a **portal** to `document.body`, `fixed`-positioned off the trigger, so it escapes the card's `overflow-hidden` and reads on a solid `bg-surface` (the app's house popover surface). Ships a journey-wide `GLOSSARY` (spec / standard / decision / AC), each anchored to a familiar construct where one fits. The pop-up is always a bonus, the copy reads fine without it.

## Cross-cutting

- **On-brand eyebrows**: every card eyebrow is now a lowercase `//` mono code-comment (was UPPERCASE middot).
- **Em-dashes purged** from every card touched.
- Welcome's off-brand text-gradient on the old drift headline dropped; the coral→purple gradient now lives (sanctioned) on the welcome eyebrow line.

## Test plan

- [x] Full UI suite: 1366 passed; UI typecheck clean.
- [x] Unit + e2e assertions updated for the new copy (HomeCanvas welcome assertion; journey-34 cold-open assertion).
- [x] `make e2e-cold`: 76 passed (journey-34 welcome→identity→connect-agent flow green).
- [x] Full server suite: 4113 passed — **zero server files changed**; the only failure is the documented `memex-embeddings` env-only-local flake (CI-green).

## Scope notes

- UI-only (12 files under `packages/ui`); no server, schema, or routing changes.
- Two follow-up specs were filed in `memex-building-itself` and are **not** in this PR: spec-312/spec-313 (everyone-to-Home + journey graduation/peek) and spec-314 (spec-assistant first-run intro). Mixpanel funnel instrumentation on the journey clickables is still to come.