### PR TITLE
feat(spec-304): magic-link polling surrogate for embedded-webview login

### DIFF
--- a/packages/server/drizzle/0099_add_login_requests.sql
+++ b/packages/server/drizzle/0099_add_login_requests.sql
@@ -1,0 +1,22 @@
+-- spec-304: originating-session surrogate for the magic-link flow (embedded webview).
+--
+-- A Flutter desktop app embeds the live web UI in a webview. The user requests a magic
+-- link but clicks it in their EXTERNAL browser (a different cookie jar), so the requesting
+-- webview never becomes authenticated. `login_requests` is a polling handle: the requesting
+-- client holds `id` (a high-entropy capability — it never sees the raw token) and polls the
+-- status endpoint. When the magic-link token is consumed elsewhere, `verified_at` is stamped
+-- against the row whose `token_id` matches, and the next poll hands the webview a session.
+--
+-- Security: `id` yields a session, so it is treated like a single-use token — short TTL
+-- (mirrors the magic_link token's `expires_at`) and only honoured while genuinely verified
+-- AND unexpired. ON DELETE CASCADE on token_id ties its lifetime to the auth_tokens row.
+CREATE TABLE IF NOT EXISTS login_requests (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  token_id uuid NOT NULL REFERENCES auth_tokens(id) ON DELETE CASCADE,
+  email text NOT NULL,
+  verified_at timestamptz,
+  expires_at timestamptz NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS login_requests_token_id_idx ON login_requests (token_id);

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -1204,6 +1204,33 @@ export const authTokens = pgTable("auth_tokens", {
   ),
 ]);
 
+// Originating-session surrogate for the magic-link flow (spec-304 / embedded webview).
+// When a magic link is requested from an embedded webview, the link is clicked in an
+// EXTERNAL browser (different cookie jar), so the requesting webview never becomes
+// authenticated. This row is a polling handle: the requesting client holds `id` (a
+// high-entropy capability — it never sees the raw token) and polls the status endpoint.
+// When the link is consumed elsewhere, `verifiedAt` is stamped against the row whose
+// `tokenId` matches, and the next poll hands the requesting webview a session in-place.
+//
+// `id` yields a session once verified, so it is treated like a single-use token: short
+// TTL (mirrors the magic_link token), only honoured while genuinely verified AND unexpired.
+export const loginRequests = pgTable("login_requests", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  // The auth_tokens row this poll-handle is the surrogate for. CASCADE so token cleanup
+  // takes the surrogate with it.
+  tokenId: uuid("token_id")
+    .notNull()
+    .references(() => authTokens.id, { onDelete: "cascade" }),
+  email: text("email").notNull(),
+  // Stamped when the magic link is consumed (in the external browser). NULL until then.
+  verifiedAt: timestamp("verified_at", { withTimezone: true }),
+  // Mirrors the magic_link token TTL — the capability is dead once this passes.
+  expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+}, (table) => [
+  index("login_requests_token_id_idx").on(table.tokenId),
+]);
+
 export const orgMemberships = pgTable(
   "org_memberships",
   {
@@ -2629,6 +2656,7 @@ export type DomainVerificationToken = InferSelectModel<typeof domainVerification
 export type NamespaceSlugReservation = InferSelectModel<typeof namespaceSlugReservations>;
 export type OrgConsentResponse = InferSelectModel<typeof orgConsentResponses>;
 export type AuthToken = InferSelectModel<typeof authTokens>;
+export type LoginRequest = InferSelectModel<typeof loginRequests>;
 export type McpToken = InferSelectModel<typeof mcpTokens>;
 export type MemexEmissionKey = InferSelectModel<typeof memexEmissionKeys>;
 export type MemexEmissionKeyInsert = InferInsertModel<typeof memexEmissionKeys>;

--- a/packages/server/src/routes/auth/magic-link-login-request.test.ts
+++ b/packages/server/src/routes/auth/magic-link-login-request.test.ts
@@ -1,0 +1,271 @@
+// spec-304: originating-session surrogate for the magic-link flow (embedded webview).
+// Exercises the real magic-link route against mocked service + token layers — the same
+// mocking posture as routes/auth.test.ts — so the route logic (response shapes, the
+// surrogate create/verify/poll handshake, expiry + unknown-id branches) is covered without
+// a live DB.
+
+import { describe, it, expect, vi, beforeEach, afterAll } from "vitest";
+
+const ORIGINAL_JWT_SECRET = vi.hoisted(() => {
+  const v = process.env.AUTH_JWT_SECRET;
+  process.env.AUTH_JWT_SECRET = "x".repeat(48);
+  return v;
+});
+
+// --- token layer ---------------------------------------------------------------
+const issueAuthToken = vi.hoisted(() => vi.fn());
+const consumeAuthToken = vi.hoisted(() => vi.fn());
+const AuthTokenErrorMock = vi.hoisted(
+  () =>
+    class AuthTokenError extends Error {
+      constructor(
+        public readonly reason: string,
+        message: string,
+      ) {
+        super(message);
+        this.name = "AuthTokenError";
+      }
+    },
+);
+vi.mock("../../services/auth-tokens.js", () => ({
+  issueAuthToken,
+  consumeAuthToken,
+  AuthTokenError: AuthTokenErrorMock,
+}));
+
+// --- login-request surrogate layer --------------------------------------------
+const createLoginRequest = vi.hoisted(() => vi.fn());
+const getLoginRequestStatus = vi.hoisted(() => vi.fn());
+const markLoginRequestVerified = vi.hoisted(() => vi.fn());
+const deleteLoginRequest = vi.hoisted(() => vi.fn());
+vi.mock("../../services/login-requests.js", () => ({
+  createLoginRequest,
+  getLoginRequestStatus,
+  markLoginRequestVerified,
+  deleteLoginRequest,
+}));
+
+// --- session/user layer --------------------------------------------------------
+const resolveSession = vi.hoisted(() => vi.fn());
+vi.mock("../../services/auth.js", () => ({ resolveSession }));
+
+const getUserByEmail = vi.hoisted(() => vi.fn());
+const upsertUserByEmail = vi.hoisted(() => vi.fn());
+const markEmailVerified = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+vi.mock("../../services/users.js", () => ({
+  getUserByEmail,
+  upsertUserByEmail,
+  markEmailVerified,
+}));
+
+vi.mock("../../services/user-namespaces.js", () => ({
+  ensureUserMemex: vi.fn().mockResolvedValue({ id: "personal-acc" }),
+}));
+
+// Email sender is fire-and-forget in the route; stub it so no real send is attempted.
+const send = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+vi.mock("../../services/email/sender.js", () => ({
+  getEmailSender: () => ({ send }),
+}));
+vi.mock("../../services/email/templates.js", () => ({
+  buildMagicLinkEmail: (args: unknown) => args,
+}));
+
+// Disable rate-limiting so repeated issues in a test don't 429.
+vi.mock("../../services/auth-rate-limit.js", () => ({
+  rateLimit: () => ({ ok: true }),
+  AUTH_LIMITS: { magicLink: { max: 100, windowSec: 60 } },
+}));
+
+import { Hono } from "hono";
+import { magicLink } from "./magic-link.js";
+import { errorHandler } from "../../middleware/error-handler.js";
+
+afterAll(() => {
+  if (ORIGINAL_JWT_SECRET !== undefined) process.env.AUTH_JWT_SECRET = ORIGINAL_JWT_SECRET;
+});
+
+const app = new Hono();
+app.onError(errorHandler);
+app.route("/api/auth/magic-link", magicLink);
+
+const EMAIL = "alice@example.com";
+const TOKEN_ID = "tok-1";
+const LR_ID = "lr-cap-123";
+
+const sampleSession = {
+  user: {
+    id: "user-1",
+    email: EMAIL,
+    name: null,
+    status: "active" as const,
+    emailVerified: true,
+  },
+  memberships: [],
+  currentMemexId: null,
+  currentRole: null,
+  needsOnboarding: false,
+};
+
+function future(): Date {
+  return new Date(Date.now() + 15 * 60 * 1000);
+}
+function past(): Date {
+  return new Date(Date.now() - 1000);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  markEmailVerified.mockResolvedValue(undefined);
+});
+
+const JSON_HEADERS = { "Content-Type": "application/json" };
+
+describe("POST /api/auth/magic-link (issue)", () => {
+  it("returns a loginRequestId and never leaks the raw token", async () => {
+    getUserByEmail.mockResolvedValue({ id: "user-1", email: EMAIL });
+    issueAuthToken.mockResolvedValue({
+      raw: "RAW-SECRET-TOKEN",
+      row: { id: TOKEN_ID, expiresAt: future() },
+    });
+    createLoginRequest.mockResolvedValue({ id: LR_ID });
+
+    const res = await app.request("/api/auth/magic-link", {
+      method: "POST",
+      headers: JSON_HEADERS,
+      body: JSON.stringify({ email: EMAIL }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ ok: true, loginRequestId: LR_ID });
+    // The raw token must not appear anywhere in the response.
+    expect(JSON.stringify(body)).not.toContain("RAW-SECRET-TOKEN");
+
+    // The surrogate is created against the issued token with the token's own TTL.
+    expect(createLoginRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ tokenId: TOKEN_ID, email: EMAIL }),
+    );
+  });
+});
+
+describe("POST /api/auth/magic-link/consume", () => {
+  it("flips the surrogate verified after consuming the token", async () => {
+    consumeAuthToken.mockResolvedValue({ id: TOKEN_ID, email: EMAIL, userId: "user-1" });
+    upsertUserByEmail.mockResolvedValue({ id: "user-1", email: EMAIL });
+    resolveSession.mockResolvedValue(sampleSession);
+
+    const res = await app.request("/api/auth/magic-link/consume", {
+      method: "POST",
+      headers: JSON_HEADERS,
+      body: JSON.stringify({ token: "RAW-SECRET-TOKEN" }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.user.email).toBe(EMAIL);
+    expect(typeof body.token).toBe("string");
+    // The surrogate for THIS token id is flipped verified.
+    expect(markLoginRequestVerified).toHaveBeenCalledWith(TOKEN_ID);
+  });
+
+  it("still requires the raw token (invalid token → 400, no verify)", async () => {
+    consumeAuthToken.mockRejectedValue(new AuthTokenErrorMock("unknown", "Invalid"));
+
+    const res = await app.request("/api/auth/magic-link/consume", {
+      method: "POST",
+      headers: JSON_HEADERS,
+      body: JSON.stringify({ token: "garbage" }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(markLoginRequestVerified).not.toHaveBeenCalled();
+  });
+});
+
+describe("GET /api/auth/magic-link/login-requests/:id/status", () => {
+  it("404s for an unknown id", async () => {
+    getLoginRequestStatus.mockResolvedValue(null);
+    const res = await app.request(`/api/auth/magic-link/login-requests/${LR_ID}/status`);
+    expect(res.status).toBe(404);
+  });
+
+  it("returns not-verified before the link is consumed", async () => {
+    getLoginRequestStatus.mockResolvedValue({
+      id: LR_ID,
+      email: EMAIL,
+      verifiedAt: null,
+      expiresAt: future(),
+    });
+    const res = await app.request(`/api/auth/magic-link/login-requests/${LR_ID}/status`);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ verified: false, expired: false });
+  });
+
+  it("returns expired for an unverified, lapsed request", async () => {
+    getLoginRequestStatus.mockResolvedValue({
+      id: LR_ID,
+      email: EMAIL,
+      verifiedAt: null,
+      expiresAt: past(),
+    });
+    const res = await app.request(`/api/auth/magic-link/login-requests/${LR_ID}/status`);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ verified: false, expired: true });
+  });
+
+  it("returns a verified session payload after consume, and single-shots the row", async () => {
+    getLoginRequestStatus.mockResolvedValue({
+      id: LR_ID,
+      email: EMAIL,
+      verifiedAt: new Date(),
+      expiresAt: future(),
+    });
+    getUserByEmail.mockResolvedValue({ id: "user-1", email: EMAIL });
+    resolveSession.mockResolvedValue(sampleSession);
+    // The claiming delete returns the row it removed — the route mints the session from it.
+    deleteLoginRequest.mockResolvedValue({ id: LR_ID, email: EMAIL });
+
+    const res = await app.request(`/api/auth/magic-link/login-requests/${LR_ID}/status`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.verified).toBe(true);
+    expect(body.user.email).toBe(EMAIL);
+    expect(typeof body.token).toBe("string"); // same authenticated shape as /consume
+    // Single-shot: the surrogate is deleted (claimed) BEFORE the session is handed over.
+    expect(deleteLoginRequest).toHaveBeenCalledWith(LR_ID);
+  });
+
+  it("hands out exactly one session under a concurrent-poll race (delete is the gate)", async () => {
+    // Both polls read the same verified, unexpired row...
+    getLoginRequestStatus.mockResolvedValue({
+      id: LR_ID,
+      email: EMAIL,
+      verifiedAt: new Date(),
+      expiresAt: future(),
+    });
+    getUserByEmail.mockResolvedValue({ id: "user-1", email: EMAIL });
+    resolveSession.mockResolvedValue(sampleSession);
+    // ...but the atomic DELETE only returns a row to the winner; the loser gets null.
+    deleteLoginRequest.mockResolvedValue(null);
+
+    const res = await app.request(`/api/auth/magic-link/login-requests/${LR_ID}/status`);
+    expect(res.status).toBe(200);
+    // The losing poll mints NO session — it never minted a second token from one capability.
+    expect(await res.json()).toEqual({ verified: false, expired: false });
+    expect(resolveSession).not.toHaveBeenCalled();
+  });
+
+  it("refuses to mint a session for a verified-but-expired request", async () => {
+    getLoginRequestStatus.mockResolvedValue({
+      id: LR_ID,
+      email: EMAIL,
+      verifiedAt: new Date(),
+      expiresAt: past(),
+    });
+    const res = await app.request(`/api/auth/magic-link/login-requests/${LR_ID}/status`);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ verified: false, expired: true });
+    expect(deleteLoginRequest).not.toHaveBeenCalled();
+  });
+});

--- a/packages/server/src/routes/auth/magic-link.ts
+++ b/packages/server/src/routes/auth/magic-link.ts
@@ -1,8 +1,15 @@
 import { Hono } from "hono";
+import type { Context } from "hono";
 import { resolveSession } from "../../services/auth.js";
 import { getUserByEmail, markEmailVerified, upsertUserByEmail } from "../../services/users.js";
 import { ensureUserMemex } from "../../services/user-namespaces.js";
 import { issueAuthToken, consumeAuthToken, AuthTokenError } from "../../services/auth-tokens.js";
+import {
+  createLoginRequest,
+  getLoginRequestStatus,
+  markLoginRequestVerified,
+  deleteLoginRequest,
+} from "../../services/login-requests.js";
 import { getEmailSender } from "../../services/email/sender.js";
 import { buildMagicLinkEmail } from "../../services/email/templates.js";
 import { rateLimit, AUTH_LIMITS } from "../../services/auth-rate-limit.js";
@@ -13,10 +20,35 @@ import { APP_BASE_URL, setKnownCookie, withToken } from "./helpers.js";
 
 export const magicLink = new Hono<MemexResolverEnv & SessionEnv>();
 
+// Builds the authenticated session payload for a magic-link sign-in, applying the tenant
+// override (parity with sso.ts / password.ts login): when the request carries a resolved
+// team memex the user belongs to, surface it as currentMemexId so the link clicked on a
+// team subdomain lands them in that team rather than their personal memex. Shared by the
+// /consume route and the originating-session /status poll so both return the same shape.
+async function buildMagicLinkSession(
+  c: Context<MemexResolverEnv & SessionEnv>,
+  userId: string,
+) {
+  let session = await resolveSession(userId, null);
+  const tenantMemex = c.get("memex");
+  if (tenantMemex) {
+    const match = session.memberships.find((m) => m.memexId === tenantMemex.id);
+    if (match) {
+      session = { ...session, currentMemexId: match.memexId, currentRole: match.role };
+    }
+  }
+  return session;
+}
+
 // POST /api/auth/magic-link
 // Body: { email }
-// Sends a sign-in link to the given email. Always returns { ok: true } (doesn't leak
-// whether the email has an account). Rate-limited per email.
+// Sends a sign-in link to the given email. Always returns { ok: true, loginRequestId }
+// (doesn't leak whether the email has an account). `loginRequestId` is an
+// originating-session poll handle (spec-304): the requesting client (e.g. an embedded
+// webview, whose cookie jar differs from where the link is clicked) polls
+// GET /magic-link/login-requests/:id/status and becomes authenticated in-place once the
+// link is consumed elsewhere. It is NOT the raw token — the raw token is emailed only.
+// Rate-limited per email.
 magicLink.post("/", async (c) => {
   const body = await readJsonBody<{ email?: unknown }>(c);
   const email = requireString(body?.email, "email");
@@ -42,7 +74,15 @@ magicLink.post("/", async (c) => {
     .send(buildMagicLinkEmail({ to: email, loginUrl }))
     .catch((err) => console.error("Failed to send magic link:", err));
 
-  return c.json({ ok: true });
+  // Originating-session surrogate (spec-304): a poll handle the requesting client holds.
+  // Same TTL as the token so the capability dies with it. Never leaks the raw token.
+  const loginRequest = await createLoginRequest({
+    tokenId: issued.row.id,
+    email,
+    expiresAt: issued.row.expiresAt,
+  });
+
+  return c.json({ ok: true, loginRequestId: loginRequest.id });
 });
 
 // POST /api/auth/magic-link/consume
@@ -68,17 +108,68 @@ magicLink.post("/consume", async (c) => {
   await markEmailVerified(user.id);
   await ensureUserMemex(user.id);
 
-  // Tenant override (parity with sso.ts / password.ts login): surface the URL's team account
-  // as currentMemexId when the user is a member, so a magic-link clicked on a team subdomain
-  // lands the user in that team rather than their personal memex.
-  let session = await resolveSession(user.id, null);
-  const tenantMemex = c.get("memex");
-  if (tenantMemex) {
-    const match = session.memberships.find((m) => m.memexId === tenantMemex.id);
-    if (match) {
-      session = { ...session, currentMemexId: match.memexId, currentRole: match.role };
-    }
-  }
+  // Flip the originating-session surrogate (spec-304): stamps verifiedAt on the
+  // login_requests row for this token, so the webview that requested the link picks up a
+  // session on its next poll. Best-effort — a magic link issued before this feature shipped
+  // (no surrogate row) consumes exactly as before.
+  await markLoginRequestVerified(row.id);
+
+  const session = await buildMagicLinkSession(c, user.id);
   setKnownCookie(c);
   return c.json(withToken(session));
+});
+
+// GET /api/auth/magic-link/login-requests/:id/status
+// UNAUTHENTICATED — the originating client (e.g. an embedded webview) isn't logged in yet;
+// it holds only the loginRequestId from POST /magic-link and polls here. spec-304.
+//   unknown id                 → 404
+//   verified (and not expired) → 200 { verified: true, ...session } + memex_known cookie,
+//                                the SAME authenticated payload POST /consume returns, so
+//                                the webview becomes logged in in-place. Single-shot: the
+//                                surrogate is deleted after handing over the session, so the
+//                                capability can't be replayed for a second session.
+//   expired & not verified     → 200 { verified: false, expired: true }
+//   not yet verified           → 200 { verified: false, expired: false }
+magicLink.get("/login-requests/:id/status", async (c) => {
+  const id = c.req.param("id");
+  const row = await getLoginRequestStatus(id);
+  if (!row) {
+    return c.json({ error: "Unknown login request" }, 404);
+  }
+
+  const expired = row.expiresAt.getTime() < Date.now();
+
+  if (!row.verifiedAt) {
+    return c.json({ verified: false, expired });
+  }
+
+  // Verified — but a verified row whose TTL has lapsed must NOT mint a session (the
+  // capability is dead). Treat it as expired rather than handing over auth.
+  if (expired) {
+    return c.json({ verified: false, expired: true });
+  }
+
+  // Claim the surrogate FIRST: the atomic DELETE ... RETURNING is the one-shot gate, not a
+  // post-hoc cleanup. Under concurrent polling two requests can both read a verified row, so
+  // gating session-mint on the read would hand out two sessions from one capability. Whichever
+  // poll wins the delete (RETURNING a row) mints the session; the loser sees null and is told
+  // the request is no longer pending — exactly one session per loginRequestId, even racing.
+  const claimed = await deleteLoginRequest(row.id);
+  if (!claimed) {
+    return c.json({ verified: false, expired: false });
+  }
+
+  // The token was consumed → the user exists and email is verified. Resolve the user from the
+  // claimed surrogate's email and return the same authenticated payload /consume returns. The
+  // originating webview never held the raw token.
+  const user = await getUserByEmail(claimed.email);
+  if (!user) {
+    // Should not happen (consume upserts before stamping verifiedAt), but never 500.
+    return c.json({ verified: false, expired: false });
+  }
+
+  const session = await buildMagicLinkSession(c, user.id);
+
+  setKnownCookie(c);
+  return c.json({ verified: true, ...withToken(session) });
 });

--- a/packages/server/src/routes/auth/magic-link.ts
+++ b/packages/server/src/routes/auth/magic-link.ts
@@ -123,8 +123,8 @@ magicLink.post("/consume", async (c) => {
 // UNAUTHENTICATED — the originating client (e.g. an embedded webview) isn't logged in yet;
 // it holds only the loginRequestId from POST /magic-link and polls here. spec-304.
 //   unknown id                 → 404
-//   verified (and not expired) → 200 { verified: true, ...session } + memex_known cookie,
-//                                the SAME authenticated payload POST /consume returns, so
+//   verified (and not expired) → 200 { verified: true, ...session } + the known-hint cookie
+//                                (setKnownCookie), the SAME authenticated payload /consume returns, so
 //                                the webview becomes logged in in-place. Single-shot: the
 //                                surrogate is deleted after handing over the session, so the
 //                                capability can't be replayed for a second session.

--- a/packages/server/src/services/bus.ts
+++ b/packages/server/src/services/bus.ts
@@ -71,6 +71,7 @@ export type ChangeEntity =
   // mutate({silent:true}) so the wrapper invariant holds even though no SSE
   // consumer subscribes — the brand and the coverage scanner stay structural.
   | "auth_token"
+  | "login_request"
   | "cli_auth_request"
   | "invite_token"
   | "slack_user_cache"

--- a/packages/server/src/services/login-requests.integration.test.ts
+++ b/packages/server/src/services/login-requests.integration.test.ts
@@ -5,7 +5,7 @@
 import { describe, it, expect, afterAll } from "vitest";
 import { eq, inArray } from "drizzle-orm";
 import { db } from "../db/connection.js";
-import { loginRequests, users } from "../db/schema.js";
+import { users } from "../db/schema.js";
 import { upsertUserByEmail } from "./users.js";
 import { issueAuthToken } from "./auth-tokens.js";
 import {

--- a/packages/server/src/services/login-requests.integration.test.ts
+++ b/packages/server/src/services/login-requests.integration.test.ts
@@ -1,0 +1,89 @@
+// spec-304: the login_requests surrogate service against a live DB. Mirrors the posture of
+// auth-tokens.integration.test.ts — real inserts/updates/deletes, cleaned up via the user
+// CASCADE chain (login_requests → auth_tokens → users).
+
+import { describe, it, expect, afterAll } from "vitest";
+import { eq, inArray } from "drizzle-orm";
+import { db } from "../db/connection.js";
+import { loginRequests, users } from "../db/schema.js";
+import { upsertUserByEmail } from "./users.js";
+import { issueAuthToken } from "./auth-tokens.js";
+import {
+  createLoginRequest,
+  getLoginRequestStatus,
+  markLoginRequestVerified,
+  deleteLoginRequest,
+} from "./login-requests.js";
+
+const createdUserIds: string[] = [];
+
+afterAll(async () => {
+  if (createdUserIds.length) {
+    // CASCADE: users → auth_tokens → login_requests.
+    await db
+      .delete(users)
+      .where(inArray(users.id, createdUserIds))
+      .catch(() => {});
+  }
+});
+
+function uniqueEmail(prefix: string): string {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}@example.com`;
+}
+
+async function seedTokenAndRequest(prefix: string) {
+  const user = await upsertUserByEmail(uniqueEmail(prefix));
+  createdUserIds.push(user.id);
+  const issued = await issueAuthToken({ purpose: "magic_link", email: user.email, userId: user.id });
+  const created = await createLoginRequest({
+    tokenId: issued.row.id,
+    email: user.email,
+    expiresAt: issued.row.expiresAt,
+  });
+  return { user, tokenId: issued.row.id, loginRequestId: created.id };
+}
+
+describe("login-requests service", () => {
+  it("creates a pollable surrogate that starts unverified", async () => {
+    const { loginRequestId, tokenId, user } = await seedTokenAndRequest("create");
+
+    const row = await getLoginRequestStatus(loginRequestId);
+    expect(row).not.toBeNull();
+    expect(row!.tokenId).toBe(tokenId);
+    expect(row!.email).toBe(user.email);
+    expect(row!.verifiedAt).toBeNull();
+    expect(row!.expiresAt.getTime()).toBeGreaterThan(Date.now());
+  });
+
+  it("returns null for an unknown id", async () => {
+    expect(await getLoginRequestStatus("00000000-0000-0000-0000-000000000000")).toBeNull();
+    expect(await getLoginRequestStatus("")).toBeNull();
+  });
+
+  it("markLoginRequestVerified stamps the row whose tokenId matches", async () => {
+    const { loginRequestId, tokenId } = await seedTokenAndRequest("verify");
+
+    const updated = await markLoginRequestVerified(tokenId);
+    expect(updated).not.toBeNull();
+
+    const row = await getLoginRequestStatus(loginRequestId);
+    expect(row!.verifiedAt).not.toBeNull();
+  });
+
+  it("deleteLoginRequest single-shots the surrogate", async () => {
+    const { loginRequestId } = await seedTokenAndRequest("delete");
+
+    const deleted = await deleteLoginRequest(loginRequestId);
+    expect(deleted).not.toBeNull();
+    expect(await getLoginRequestStatus(loginRequestId)).toBeNull();
+    // Second delete is a no-op (idempotent under double-poll).
+    expect(await deleteLoginRequest(loginRequestId)).toBeNull();
+  });
+
+  it("cascades away when the auth token is deleted", async () => {
+    const { loginRequestId, tokenId } = await seedTokenAndRequest("cascade");
+    const { authTokens } = await import("../db/schema.js");
+    await db.delete(authTokens).where(eq(authTokens.id, tokenId));
+    expect(await getLoginRequestStatus(loginRequestId)).toBeNull();
+  });
+});

--- a/packages/server/src/services/login-requests.ts
+++ b/packages/server/src/services/login-requests.ts
@@ -18,8 +18,7 @@
 
 import { and, eq, isNull } from "drizzle-orm";
 import { db } from "../db/connection.js";
-import { loginRequests } from "../db/schema.js";
-import type { LoginRequest } from "../db/schema.js";
+import { loginRequests, type LoginRequest } from "../db/schema.js";
 import { mutate, type Mutated } from "./mutate.js";
 
 export interface CreateLoginRequestInput {

--- a/packages/server/src/services/login-requests.ts
+++ b/packages/server/src/services/login-requests.ts
@@ -1,0 +1,105 @@
+// Originating-session surrogate for the magic-link flow (spec-304 / embedded webview).
+//
+// Problem: a Flutter desktop app embeds the live web UI in a webview. The user requests a
+// magic link, but clicks it in their EXTERNAL browser (a different cookie jar), so the
+// webview that asked for the link never becomes authenticated. A login_requests row is a
+// polling handle the originating webview holds (its `id`, a high-entropy capability) and
+// polls on; when the link is consumed elsewhere we stamp `verifiedAt`, and the next poll
+// hands the originating webview a session in-place — without it ever seeing the raw token.
+//
+// Security posture mirrors auth_tokens: `id` yields a session, so it is short-lived (TTL
+// mirrors the magic_link token) and the status endpoint only returns a session for a row
+// that is genuinely verified AND not expired.
+//
+// silent: login_requests is silent-allowed per std-8 §6 — same family as auth_tokens. The
+// originating client polls; there is no SSE subscriber on the surrogate's lifecycle. The
+// mutate() wrap is the structural guarantee (Mutated<T> brand + coverage scanner), not an
+// SSE-facing event.
+
+import { and, eq, isNull } from "drizzle-orm";
+import { db } from "../db/connection.js";
+import { loginRequests } from "../db/schema.js";
+import type { LoginRequest } from "../db/schema.js";
+import { mutate, type Mutated } from "./mutate.js";
+
+export interface CreateLoginRequestInput {
+  /** The auth_tokens row this surrogate stands in for. */
+  tokenId: string;
+  email: string;
+  /** Mirror the magic_link token's expiry so the capability dies with the token. */
+  expiresAt: Date;
+}
+
+// Creates the poll-handle row and returns its id — the high-entropy capability the
+// originating client polls on. The raw token is never threaded through here.
+export async function createLoginRequest(
+  input: CreateLoginRequestInput,
+): Promise<Mutated<{ id: string }>> {
+  return mutate(
+    {},
+    { memexId: "", entity: "login_request", action: "created" },
+    async () => {
+      const [row] = await db
+        .insert(loginRequests)
+        .values({
+          tokenId: input.tokenId,
+          email: input.email.trim().toLowerCase(),
+          expiresAt: input.expiresAt,
+        })
+        .returning({ id: loginRequests.id });
+      return { id: row.id };
+    },
+    { silent: true },
+  );
+}
+
+// Reads the surrogate by its capability id. Returns null for an unknown id so the route
+// can 404. No mutation — a plain read.
+export async function getLoginRequestStatus(id: string): Promise<LoginRequest | null> {
+  if (typeof id !== "string" || !id) return null;
+  const row = await db.query.loginRequests.findFirst({
+    where: eq(loginRequests.id, id),
+  });
+  return row ?? null;
+}
+
+// Stamps verifiedAt on the (not-yet-verified) surrogate whose tokenId matches. Called from
+// the consume path once the magic-link token is consumed in the external browser, so the
+// originating client's next poll flips to verified. Idempotent: the isNull guard means a
+// second consume (which can't happen — tokens are single-use) is a no-op.
+export async function markLoginRequestVerified(
+  tokenId: string,
+): Promise<Mutated<LoginRequest | null>> {
+  return mutate(
+    {},
+    { memexId: "", entity: "login_request", action: "updated" },
+    async () => {
+      const [updated] = await db
+        .update(loginRequests)
+        .set({ verifiedAt: new Date() })
+        .where(and(eq(loginRequests.tokenId, tokenId), isNull(loginRequests.verifiedAt)))
+        .returning();
+      return updated ?? null;
+    },
+    { silent: true },
+  );
+}
+
+// Single-shot pickup: removes the surrogate after the originating client has collected its
+// session, so the loginRequestId capability yields exactly one session and can't be
+// replayed. Returns the deleted row (or null if already gone — a concurrent poll won the
+// race), which lets the route stay idempotent under double-polling.
+export async function deleteLoginRequest(id: string): Promise<Mutated<LoginRequest | null>> {
+  return mutate(
+    {},
+    { memexId: "", entity: "login_request", action: "deleted" },
+    async () => {
+      const [deleted] = await db
+        .delete(loginRequests)
+        .where(eq(loginRequests.id, id))
+        .returning();
+      return deleted ?? null;
+    },
+    { silent: true },
+  );
+}


### PR DESCRIPTION
## What & why (spec-304 · dec-10 / t-39)

A magic link requested inside the desktop app's **embedded webview** is clicked in the user's **external browser** (a different cookie jar), so the webview that asked for the link never becomes authenticated. This adds an **originating-session surrogate** the webview can poll to log in *in-place*, without ever holding the raw token.

## Changes

- **`login_requests` table** (migration `0099`): high-entropy `id` capability, `tokenId` FK (CASCADE off `auth_tokens`), `email`, `verifiedAt`, `expiresAt` mirroring the token TTL.
- **`services/login-requests.ts`**: create / read-status / mark-verified (isNull-guarded, idempotent) / delete (single-shot), all `mutate({silent:true})` per std-8 §6 (same family as `auth_tokens`). `bus.ts` adds the `login_request` silent entity.
- **`POST /api/auth/magic-link`** → `{ ok, loginRequestId }`; never leaks the raw token.
- **`POST /api/auth/magic-link/consume`** stamps `verifiedAt` — raw-token requirement unchanged.
- **`GET /api/auth/magic-link/login-requests/:id/status`** (unauthenticated): `404` unknown · `{verified:false,expired}` pending/expired · once verified+unexpired returns the **same** authenticated payload `/consume` returns, then claims the row.

## Security

- **One-shot is race-safe**: the atomic `DELETE … RETURNING` is the *gate* (claim-before-mint), not post-hoc cleanup — a concurrent-poll race yields **exactly one session per capability** instead of two.
- **Verified-but-expired is refused** — never mints a dead-capability session.
- **No CSRF surface**: the session rides as a JWT in the response body (`withToken`), not a cookie; `setKnownCookie` only sets the non-auth `memex_known` hint.
- `loginRequestId` is high-entropy, short-TTL (== token TTL), and never exposes the raw token.

## Path note (drift flagged on the Spec)

The status route is namespaced under the magic-link sub-router, so the real path is `/api/auth/magic-link/login-requests/:id/status` — **not** `/api/auth/login-requests/:id/status` as dec-10/t-39 prose say. Downstream wiring (web t-40, app build **t-42**) must use the namespaced path. Recommend updating the Spec prose rather than moving the route.

## Tests

- Route unit suite + live-DB integration suite — **14 tests**, including the concurrent-poll race-loser path.
- Broader auth suites green (44). Build typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)