### PR TITLE
fix(spec-304): malformed login-request id 404s instead of 500

### DIFF
--- a/packages/server/src/services/login-requests.integration.test.ts
+++ b/packages/server/src/services/login-requests.integration.test.ts
@@ -60,6 +60,14 @@ describe("login-requests service", () => {
     expect(await getLoginRequestStatus("")).toBeNull();
   });
 
+  it("returns null (not a thrown uuid-cast error) for a malformed id", async () => {
+    // Regression: the status route is unauthenticated, so a non-uuid :id must resolve to a
+    // clean 404 — never an uncaught Postgres "invalid input syntax for type uuid" → 500.
+    expect(await getLoginRequestStatus("not-a-uuid")).toBeNull();
+    expect(await getLoginRequestStatus("12345")).toBeNull();
+    expect(await getLoginRequestStatus("'; DROP TABLE login_requests;--")).toBeNull();
+  });
+
   it("markLoginRequestVerified stamps the row whose tokenId matches", async () => {
     const { loginRequestId, tokenId } = await seedTokenAndRequest("verify");
 

--- a/packages/server/src/services/login-requests.ts
+++ b/packages/server/src/services/login-requests.ts
@@ -52,10 +52,18 @@ export async function createLoginRequest(
   );
 }
 
-// Reads the surrogate by its capability id. Returns null for an unknown id so the route
-// can 404. No mutation — a plain read.
+// Canonical UUID shape. Postgres' `uuid` column rejects anything else with a hard
+// "invalid input syntax for type uuid" error, so we must screen the id BEFORE it reaches
+// the query — otherwise a malformed :id on the unauthenticated status route would surface
+// as an uncaught 500 (alert noise + a fuzzing/enumeration signal) instead of a clean 404.
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// Reads the surrogate by its capability id. Returns null for an unknown OR malformed id so
+// the route can 404 uniformly. No mutation — a plain read.
 export async function getLoginRequestStatus(id: string): Promise<LoginRequest | null> {
-  if (typeof id !== "string" || !id) return null;
+  // A non-uuid id can never match a row we issued — treat it exactly like "not found"
+  // rather than letting the uuid cast throw.
+  if (typeof id !== "string" || !UUID_RE.test(id)) return null;
   const row = await db.query.loginRequests.findFirst({
     where: eq(loginRequests.id, id),
   });


### PR DESCRIPTION
## Follow-up to #250

#250 merged at `7345355`, which did **not** include this fix — so the live defect below is still present in `develop`. This PR lands it.

## The defect (found live on int)

`GET /api/auth/magic-link/login-requests/:id/status` is unauthenticated and passed `:id` straight into the `uuid`-typed column. A non-uuid id (`eq(loginRequests.id, "not-a-uuid")`) makes Postgres throw `invalid input syntax for type uuid`, which nothing caught → **HTTP 500** instead of a clean 404.

The legitimate web UI always polls with a real uuid, but an unauthenticated endpoint 500-ing on malformed input is poor hygiene (alert noise + a fuzzing/enumeration signal).

## Fix

Screen the id against the canonical UUID shape in `getLoginRequestStatus` and return `null` for anything malformed — the route already 404s on `null`, so malformed and unknown ids behave identically (a non-uuid can never match a row we issued).

## Test

Regression test: non-uuid / short / SQLi-ish inputs resolve to `null` rather than throwing. Build typecheck clean; integration suite green (6/6).

> Live re-verification on int happens after this deploys (per std-17) — int currently runs the pre-fix code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)