### PR TITLE
feat(ui): magic-link login completes in originating tab via polling (spec-304 t-40)

### DIFF
--- a/packages/ui/src/api/client.ts
+++ b/packages/ui/src/api/client.ts
@@ -1118,7 +1118,16 @@ export async function resendVerificationApi(token: string | null): Promise<void>
   }
 }
 
-export async function magicLinkRequestApi(email: string): Promise<void> {
+/**
+ * spec-304 t-40 (ac-30): the issue response now carries a high-entropy
+ * `loginRequestId` (a `login_requests` surrogate row, TTL matching the
+ * magic-link token). The originating tab/webview keeps this id and polls
+ * `magicLinkStatusApi` so the session can complete IN PLACE once the link is
+ * verified in a different browser/context — no click-back required. The id is
+ * NOT the raw token; it only names the surrogate to poll. Callers that ignore
+ * the return value keep working unchanged.
+ */
+export async function magicLinkRequestApi(email: string): Promise<{ loginRequestId: string }> {
   const res = await fetchWithRetry(`${BASE_URL}/auth/magic-link`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -1132,6 +1141,32 @@ export async function magicLinkRequestApi(email: string): Promise<void> {
       body.message ?? body.error ?? `Magic link request failed: ${res.status}`,
     );
   }
+  return res.json();
+}
+
+/**
+ * spec-304 t-40 (ac-30): the originating-session poll target. Unauthenticated
+ * GET on the surrogate named by `magicLinkRequestApi`'s `loginRequestId`. The
+ * server returns one of:
+ *   - pending  → `{ verified: false, expired: false }`
+ *   - expired  → `{ verified: false, expired: true }`
+ *   - verified → `{ verified: true, ...SessionPayload }` (the same payload
+ *                `/consume` returns) — SINGLE-SHOT: the row is deleted on first
+ *                verified read, so a second poll 404s. Callers MUST stop polling
+ *                and hand the session to `acceptSession` in the same tick.
+ *   - unknown  → 404 `{ error: 'Unknown login request' }` → throws NotFoundError.
+ * Routed through `fetchJson` so 404 maps to `NotFoundError`; the poll loop
+ * treats that (and `expired: true`) as a dead surrogate and stops.
+ */
+export type MagicLinkStatus =
+  | { verified: false; expired: boolean }
+  | ({ verified: true } & SessionPayload);
+
+export async function magicLinkStatusApi(loginRequestId: string): Promise<MagicLinkStatus> {
+  return fetchJsonRaw<MagicLinkStatus>(
+    fetchWithRetry,
+    `${BASE_URL}/auth/magic-link/login-requests/${encodeURIComponent(loginRequestId)}/status`,
+  );
 }
 
 export async function magicLinkConsumeApi(token: string): Promise<SessionPayload> {

--- a/packages/ui/src/components/AuthContext.tsx
+++ b/packages/ui/src/components/AuthContext.tsx
@@ -344,8 +344,14 @@ export function RequireAuth({ children }: { children: ReactNode }) {
       }).then(() => undefined),
     [wrap, acceptSession],
   );
+  // spec-304 t-40 (ac-30): surface the issue response's `loginRequestId` to the
+  // LoginScreen so its "check your email" view can poll login-request status and
+  // complete the session IN PLACE when the link is verified elsewhere. The
+  // session, once polled verified, is adopted through the SAME `acceptSession`
+  // path that password/SSO/`/consume` login uses — see onMagicLinkVerified below.
   const handleMagicLink = useCallback(
-    (email: string) => wrap(async () => magicLinkRequestApi(email)).then(() => undefined),
+    (email: string): Promise<{ loginRequestId: string }> =>
+      wrap(async () => magicLinkRequestApi(email)) as Promise<{ loginRequestId: string }>,
     [wrap],
   );
   const handlePasswordReset = useCallback(
@@ -370,6 +376,7 @@ export function RequireAuth({ children }: { children: ReactNode }) {
       onSignup={handleSignup}
       onLogin={handleLogin}
       onMagicLink={handleMagicLink}
+      onMagicLinkVerified={acceptSession}
       onPasswordReset={handlePasswordReset}
       onGoogleCredential={handleGoogle}
     />

--- a/packages/ui/src/components/LoginScreen.test.tsx
+++ b/packages/ui/src/components/LoginScreen.test.tsx
@@ -1,0 +1,233 @@
+// spec-304 t-40 (ac-30) — the "check your email" view completes login IN PLACE.
+//
+// Component-level proof that the LoginScreen, once it shows the magic-sent view,
+// captures the issue response's loginRequestId, polls login-request status, and
+// — on verified — adopts the session through the SAME callback the rest of auth
+// uses (in the app that's AuthContext's `acceptSession`). We drive the full
+// identifier-first path: enter email → probe says "Google-only" → magic link
+// issued → poll pending → poll verified → onMagicLinkVerified fires once.
+//
+// The network is mocked at the api-client layer (same layer the app's other
+// component tests mock), keeping the real NotFoundError so the 404 branch hits
+// the actual error class. Fake timers drive the poll interval deterministically.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, act, fireEvent } from '@testing-library/react';
+import { tagAc } from '@memex-ai-ac/vitest';
+import type { ReactNode } from 'react';
+import type { SessionPayload } from '../api/client';
+
+vi.mock('@react-oauth/google', () => ({
+  GoogleOAuthProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+  GoogleLogin: () => <button data-testid="google-login">Mock Google Login</button>,
+}));
+
+const probeAuthApi = vi.fn();
+const magicLinkRequestApi = vi.fn();
+const magicLinkStatusApi = vi.fn();
+
+vi.mock('../api/client', async () => {
+  const actual = await vi.importActual<typeof import('../api/client')>('../api/client');
+  return {
+    ...actual,
+    probeAuthApi: (...a: unknown[]) => probeAuthApi(...a),
+    magicLinkRequestApi: (...a: unknown[]) => magicLinkRequestApi(...a),
+    magicLinkStatusApi: (...a: unknown[]) => magicLinkStatusApi(...a),
+  };
+});
+
+import { LoginScreen } from './LoginScreen';
+import { MAGIC_LINK_POLL_INTERVAL_MS } from '../hooks/useMagicLinkPoll';
+import { NotFoundError } from '../api/client';
+
+const AC = 'mindset-prod/memex-building-itself/specs/spec-304/acs/ac-30';
+const REQUEST_ID = 'lr_xyz789';
+const EMAIL = 'user@example.com';
+
+function fakeSession(): SessionPayload {
+  return {
+    user: { id: 'u-1', email: EMAIL, name: 'User', status: 'active', emailVerified: true },
+    memberships: [],
+    currentMemexId: null,
+    currentRole: null,
+    needsOnboarding: false,
+    hiddenFeatures: [],
+    token: 'jwt-from-poll',
+  };
+}
+
+function renderLogin(onMagicLinkVerified = vi.fn()) {
+  render(
+    <LoginScreen
+      authError={null}
+      googleClientId="test-client-id"
+      onSignup={vi.fn()}
+      onLogin={vi.fn()}
+      onMagicLink={(email) => magicLinkRequestApi(email)}
+      onMagicLinkVerified={onMagicLinkVerified}
+      onPasswordReset={vi.fn()}
+      onGoogleCredential={vi.fn()}
+    />,
+  );
+  return { onMagicLinkVerified };
+}
+
+async function flush(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+// Drive enter-email → magic-sent. probeAuthApi resolves "exists, no password" so
+// the Continue handler issues a magic link and lands on the magic-sent view.
+async function reachMagicSent(): Promise<void> {
+  probeAuthApi.mockResolvedValue({ exists: true, hasPassword: false });
+  magicLinkRequestApi.mockResolvedValue({ loginRequestId: REQUEST_ID });
+
+  const input = screen.getByPlaceholderText('you@company.com');
+  await act(async () => {
+    fireEvent.change(input, { target: { value: EMAIL } });
+  });
+  await act(async () => {
+    fireEvent.click(screen.getByRole('button', { name: /continue/i }));
+  });
+  await flush();
+}
+
+describe('LoginScreen magic-link polling [spec-304 t-40 / ac-30]', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    probeAuthApi.mockReset();
+    magicLinkRequestApi.mockReset();
+    magicLinkStatusApi.mockReset();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('issuing a link captures loginRequestId and the magic-sent view starts polling', async () => {
+    tagAc(AC);
+    magicLinkStatusApi.mockResolvedValue({ verified: false, expired: false });
+    renderLogin();
+
+    await reachMagicSent();
+
+    // The view tells the user to check their email…
+    expect(screen.getByText('Check your email')).toBeInTheDocument();
+    expect(
+      screen.getByText(`We sent a sign-in link to ${EMAIL}. It expires in 15 minutes.`),
+    ).toBeInTheDocument();
+    // …and the captured loginRequestId is being polled.
+    expect(magicLinkStatusApi).toHaveBeenCalledWith(REQUEST_ID);
+  });
+
+  it('poll pending → verified: adopts the session exactly once and shows the signed-in state', async () => {
+    tagAc(AC);
+    const session = fakeSession();
+    magicLinkStatusApi
+      .mockResolvedValueOnce({ verified: false, expired: false }) // immediate poll
+      .mockResolvedValueOnce({ verified: true, ...session }); // next tick → verified
+
+    const { onMagicLinkVerified } = renderLogin();
+    await reachMagicSent();
+
+    expect(onMagicLinkVerified).not.toHaveBeenCalled();
+    expect(screen.getByText('Check your email')).toBeInTheDocument();
+
+    await act(async () => {
+      vi.advanceTimersByTime(MAGIC_LINK_POLL_INTERVAL_MS);
+    });
+    await flush();
+
+    // Session adopted via the same callback as password/SSO/consume login, once,
+    // with the `verified` discriminator stripped.
+    expect(onMagicLinkVerified).toHaveBeenCalledTimes(1);
+    expect(onMagicLinkVerified).toHaveBeenCalledWith(
+      expect.objectContaining({ token: 'jwt-from-poll' }),
+    );
+    expect(onMagicLinkVerified.mock.calls[0][0]).not.toHaveProperty('verified');
+    expect(screen.getByText('Signed in')).toBeInTheDocument();
+  });
+
+  it('verified is single-shot: no further poll fires and onMagicLinkVerified stays at one call', async () => {
+    tagAc(AC);
+    const session = fakeSession();
+    magicLinkStatusApi.mockResolvedValue({ verified: true, ...session });
+
+    const { onMagicLinkVerified } = renderLogin();
+    await reachMagicSent();
+
+    expect(onMagicLinkVerified).toHaveBeenCalledTimes(1);
+    const callsAfterVerify = magicLinkStatusApi.mock.calls.length;
+
+    await act(async () => {
+      vi.advanceTimersByTime(MAGIC_LINK_POLL_INTERVAL_MS * 4);
+    });
+    await flush();
+
+    expect(magicLinkStatusApi).toHaveBeenCalledTimes(callsAfterVerify); // no extra polls
+    expect(onMagicLinkVerified).toHaveBeenCalledTimes(1);
+  });
+
+  it('expired surrogate → error state offering a new link, polling stops, no adoption', async () => {
+    tagAc(AC);
+    magicLinkStatusApi.mockResolvedValue({ verified: false, expired: true });
+
+    const { onMagicLinkVerified } = renderLogin();
+    await reachMagicSent();
+
+    expect(screen.getByText('Sign-in link expired')).toBeInTheDocument();
+    expect(screen.getByText(/request a new one/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /request a new link/i })).toBeInTheDocument();
+    expect(onMagicLinkVerified).not.toHaveBeenCalled();
+
+    const calls = magicLinkStatusApi.mock.calls.length;
+    await act(async () => {
+      vi.advanceTimersByTime(MAGIC_LINK_POLL_INTERVAL_MS * 3);
+    });
+    await flush();
+    expect(magicLinkStatusApi).toHaveBeenCalledTimes(calls); // stopped
+  });
+
+  it('404 from the status endpoint → expired error state, polling stops', async () => {
+    tagAc(AC);
+    magicLinkStatusApi.mockRejectedValue(new NotFoundError('Unknown login request'));
+
+    const { onMagicLinkVerified } = renderLogin();
+    await reachMagicSent();
+
+    expect(screen.getByText('Sign-in link expired')).toBeInTheDocument();
+    expect(onMagicLinkVerified).not.toHaveBeenCalled();
+
+    const calls = magicLinkStatusApi.mock.calls.length;
+    await act(async () => {
+      vi.advanceTimersByTime(MAGIC_LINK_POLL_INTERVAL_MS * 3);
+    });
+    await flush();
+    expect(magicLinkStatusApi).toHaveBeenCalledTimes(calls);
+  });
+
+  it('leaving the magic-sent view (Use a different email) tears the poll down — no poll after unmount', async () => {
+    tagAc(AC);
+    magicLinkStatusApi.mockResolvedValue({ verified: false, expired: false });
+
+    renderLogin();
+    await reachMagicSent();
+    const calls = magicLinkStatusApi.mock.calls.length;
+
+    // Click "Use a different email" → unmounts MagicSentScreen back to enter-email.
+    const back = screen.getByRole('button', { name: /use a different email/i });
+    await act(async () => {
+      fireEvent.click(back);
+    });
+    await flush();
+
+    await act(async () => {
+      vi.advanceTimersByTime(MAGIC_LINK_POLL_INTERVAL_MS * 5);
+    });
+    await flush();
+    expect(magicLinkStatusApi).toHaveBeenCalledTimes(calls); // interval cleared
+  });
+});

--- a/packages/ui/src/components/LoginScreen.tsx
+++ b/packages/ui/src/components/LoginScreen.tsx
@@ -3,7 +3,8 @@ import { GoogleOAuthProvider, GoogleLogin, type CredentialResponse } from '@reac
 import { Input } from './ui/Input';
 import { Button } from './ui/Button';
 import { Logo } from './Logo';
-import { probeAuthApi, AuthApiError } from '../api/client';
+import { probeAuthApi, AuthApiError, type SessionPayload } from '../api/client';
+import { useMagicLinkPoll } from '../hooks/useMagicLinkPoll';
 // t-23 of doc-15: Google SSO is on a single origin under the path-based
 // router. The previous cross-subdomain bounce (sign in on memex.ai then return
 // here with a JWT in the URL fragment) is no longer needed — everything is
@@ -25,7 +26,10 @@ type View =
   | { kind: 'enter-email' }
   | { kind: 'password'; email: string }
   | { kind: 'create-password'; email: string }
-  | { kind: 'magic-sent'; email: string }
+  // spec-304 t-40 (ac-30): the magic-sent view carries the `loginRequestId` from
+  // the issue response so it can poll login-request status and complete the
+  // session IN PLACE when the link is verified in another browser/context.
+  | { kind: 'magic-sent'; email: string; loginRequestId: string }
   | { kind: 'reset-sent'; email: string }
   | { kind: 'forgot' };
 
@@ -34,7 +38,17 @@ interface LoginScreenProps {
   googleClientId: string | null;
   onSignup: (email: string, password: string) => Promise<void>;
   onLogin: (email: string, password: string) => Promise<void>;
-  onMagicLink: (email: string) => Promise<void>;
+  /**
+   * Issue a magic link. spec-304 t-40 (ac-30): resolves to the surrogate
+   * `loginRequestId` the magic-sent view polls so login can complete in place.
+   */
+  onMagicLink: (email: string) => Promise<{ loginRequestId: string }>;
+  /**
+   * spec-304 t-40 (ac-30): adopt the session once polling sees it verified —
+   * wire to the SAME path password/SSO/`/consume` login uses (`acceptSession`)
+   * so the polled login truly completes (token persisted, redirect into the app).
+   */
+  onMagicLinkVerified: (session: SessionPayload) => void;
   onPasswordReset: (email: string) => Promise<void>;
   onGoogleCredential: (credential: string) => Promise<void>;
 }
@@ -69,8 +83,8 @@ function LoginCard(props: LoginScreenProps) {
             if (!probe.exists) setView({ kind: 'create-password', email });
             else if (probe.hasPassword) setView({ kind: 'password', email });
             else {
-              await props.onMagicLink(email);
-              setView({ kind: 'magic-sent', email });
+              const { loginRequestId } = await props.onMagicLink(email);
+              setView({ kind: 'magic-sent', email, loginRequestId });
             }
           }}
         />
@@ -85,8 +99,8 @@ function LoginCard(props: LoginScreenProps) {
           onSubmit={(password) => props.onLogin(view.email, password)}
           onForgot={() => setView({ kind: 'forgot' })}
           onMagicLink={async () => {
-            await props.onMagicLink(view.email);
-            setView({ kind: 'magic-sent', email: view.email });
+            const { loginRequestId } = await props.onMagicLink(view.email);
+            setView({ kind: 'magic-sent', email: view.email, loginRequestId });
           }}
           onBack={() => setView({ kind: 'enter-email' })}
         />
@@ -100,8 +114,8 @@ function LoginCard(props: LoginScreenProps) {
           authError={props.authError}
           onSubmit={(password) => props.onSignup(view.email, password)}
           onMagicLink={async () => {
-            await props.onMagicLink(view.email);
-            setView({ kind: 'magic-sent', email: view.email });
+            const { loginRequestId } = await props.onMagicLink(view.email);
+            setView({ kind: 'magic-sent', email: view.email, loginRequestId });
           }}
           onBack={() => setView({ kind: 'enter-email' })}
         />
@@ -109,9 +123,10 @@ function LoginCard(props: LoginScreenProps) {
 
     case 'magic-sent':
       return (
-        <ConfirmCard
-          title="Check your email"
-          body={`We sent a sign-in link to ${view.email}. It expires in 15 minutes.`}
+        <MagicSentScreen
+          email={view.email}
+          loginRequestId={view.loginRequestId}
+          onMagicLinkVerified={props.onMagicLinkVerified}
           onBack={() => setView({ kind: 'enter-email' })}
         />
       );
@@ -426,14 +441,74 @@ function ForgotPasswordForm({
   );
 }
 
-function ConfirmCard({ title, body, onBack }: { title: string; body: string; onBack: () => void }) {
+// spec-304 t-40 (ac-30): the "check your email" view. While shown it polls the
+// login-request surrogate so the session completes IN THIS TAB/WEBVIEW the moment
+// the link is verified anywhere — the user never has to click back here. The poll
+// runs ONLY while this component is mounted (cleanup tears the interval down on
+// unmount / "Use a different email"). On verified it adopts the session via the
+// passed-down `acceptSession`; on expiry/404 it offers a fresh link.
+function MagicSentScreen({
+  email,
+  loginRequestId,
+  onMagicLinkVerified,
+  onBack,
+}: {
+  email: string;
+  loginRequestId: string;
+  onMagicLinkVerified: (session: SessionPayload) => void;
+  onBack: () => void;
+}) {
+  const phase = useMagicLinkPoll(loginRequestId, onMagicLinkVerified);
+
+  if (phase === 'verified') {
+    return (
+      <ConfirmCard
+        title="Signed in"
+        body="You're signed in — taking you to your Memex…"
+      />
+    );
+  }
+
+  if (phase === 'expired') {
+    return (
+      <ConfirmCard
+        title="Sign-in link expired"
+        body="Your sign-in link expired — request a new one."
+        onBack={onBack}
+        backLabel="← Request a new link"
+      />
+    );
+  }
+
+  return (
+    <ConfirmCard
+      title="Check your email"
+      body={`We sent a sign-in link to ${email}. It expires in 15 minutes.`}
+      onBack={onBack}
+    />
+  );
+}
+
+function ConfirmCard({
+  title,
+  body,
+  onBack,
+  backLabel = '← Use a different email',
+}: {
+  title: string;
+  body: string;
+  onBack?: () => void;
+  backLabel?: string;
+}) {
   return (
     <div className="rounded-xl border border-edge bg-card p-6 space-y-4 text-center">
       <h2 className="text-base font-semibold text-heading">{title}</h2>
       <p className="text-sm text-secondary">{body}</p>
-      <button onClick={onBack} className="text-xs text-muted hover:text-secondary">
-        ← Use a different email
-      </button>
+      {onBack && (
+        <button onClick={onBack} className="text-xs text-muted hover:text-secondary">
+          {backLabel}
+        </button>
+      )}
     </div>
   );
 }

--- a/packages/ui/src/hooks/useMagicLinkPoll.test.ts
+++ b/packages/ui/src/hooks/useMagicLinkPoll.test.ts
@@ -1,0 +1,231 @@
+// spec-304 t-40 (ac-30) — originating-session magic-link polling hook.
+//
+// These tests prove the WEB-SIDE mechanism behind ac-30: a magic-link login that
+// completes in the originating tab/webview via polling. The cross-platform
+// in-webview runtime leg of ac-30 (macOS/WKWebView + Windows/WebView2) is the
+// manual sign-off part — see t-41.
+//
+// We mock only `magicLinkStatusApi` (the network) and keep the real
+// `NotFoundError` so the 404 branch is exercised against the actual error class
+// the api-client throws. Fake timers drive the interval / TTL deterministically.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { tagAc } from '@memex-ai-ac/vitest';
+import type { SessionPayload } from '../api/client';
+
+const magicLinkStatusApi = vi.fn();
+
+vi.mock('../api/client', async () => {
+  const actual = await vi.importActual<typeof import('../api/client')>('../api/client');
+  return {
+    ...actual,
+    magicLinkStatusApi: (...args: unknown[]) => magicLinkStatusApi(...args),
+  };
+});
+
+import { useMagicLinkPoll, MAGIC_LINK_POLL_INTERVAL_MS, MAGIC_LINK_POLL_TTL_MS } from './useMagicLinkPoll';
+import { NotFoundError } from '../api/client';
+
+const AC = 'mindset-prod/memex-building-itself/specs/spec-304/acs/ac-30';
+const REQUEST_ID = 'lr_abc123';
+
+function fakeSession(): SessionPayload {
+  return {
+    user: { id: 'u-1', email: 'a@b.com', name: 'A', status: 'active', emailVerified: true },
+    memberships: [],
+    currentMemexId: null,
+    currentRole: null,
+    needsOnboarding: false,
+    hiddenFeatures: [],
+    token: 'jwt-from-poll',
+  };
+}
+
+// Flush the microtask queue so an awaited mocked fetch resolves before we assert.
+async function flush(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+describe('useMagicLinkPoll [spec-304 t-40 / ac-30]', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    magicLinkStatusApi.mockReset();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('starts polling the surrogate as soon as a loginRequestId is present', async () => {
+    tagAc(AC);
+    magicLinkStatusApi.mockResolvedValue({ verified: false, expired: false });
+
+    renderHook(() => useMagicLinkPoll(REQUEST_ID, vi.fn()));
+
+    // An immediate poll fires on mount (so a link verified <2.5s lands fast).
+    await flush();
+    expect(magicLinkStatusApi).toHaveBeenCalledWith(REQUEST_ID);
+    expect(magicLinkStatusApi).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT poll when loginRequestId is null', () => {
+    tagAc(AC);
+    renderHook(() => useMagicLinkPoll(null, vi.fn()));
+    expect(magicLinkStatusApi).not.toHaveBeenCalled();
+  });
+
+  it('pending then verified → adopts the session exactly once and stops polling', async () => {
+    tagAc(AC);
+    const session = fakeSession();
+    magicLinkStatusApi
+      .mockResolvedValueOnce({ verified: false, expired: false }) // immediate poll
+      .mockResolvedValueOnce({ verified: true, ...session }) // next tick → verified
+      .mockResolvedValue({ verified: false, expired: false }); // any later poll (should not happen)
+
+    const onVerified = vi.fn();
+    const { result } = renderHook(() => useMagicLinkPoll(REQUEST_ID, onVerified));
+
+    await flush();
+    expect(result.current).toBe('polling');
+    expect(onVerified).not.toHaveBeenCalled();
+
+    // Advance one interval → the verified poll resolves.
+    await act(async () => {
+      vi.advanceTimersByTime(MAGIC_LINK_POLL_INTERVAL_MS);
+    });
+    await flush();
+
+    expect(result.current).toBe('verified');
+    // Adoption happens through the passed-down callback, with the session minus
+    // the `verified` discriminator (the same payload /consume returns).
+    expect(onVerified).toHaveBeenCalledTimes(1);
+    expect(onVerified).toHaveBeenCalledWith(expect.objectContaining({ token: 'jwt-from-poll' }));
+    expect(onVerified.mock.calls[0][0]).not.toHaveProperty('verified');
+
+    // Single-shot: no further polls fire after verified — advancing time is a no-op.
+    const callsAtVerify = magicLinkStatusApi.mock.calls.length;
+    await act(async () => {
+      vi.advanceTimersByTime(MAGIC_LINK_POLL_INTERVAL_MS * 4);
+    });
+    await flush();
+    expect(magicLinkStatusApi).toHaveBeenCalledTimes(callsAtVerify);
+    expect(onVerified).toHaveBeenCalledTimes(1);
+  });
+
+  it('verified is handled single-shot — onVerified never fires twice even if a poll is mid-flight', async () => {
+    tagAc(AC);
+    const session = fakeSession();
+    // Every call returns verified; a correct single-shot loop must still only
+    // adopt once and stop, never re-handing the (now-deleted) surrogate.
+    magicLinkStatusApi.mockResolvedValue({ verified: true, ...session });
+
+    const onVerified = vi.fn();
+    const { result } = renderHook(() => useMagicLinkPoll(REQUEST_ID, onVerified));
+
+    await flush();
+    expect(result.current).toBe('verified');
+
+    await act(async () => {
+      vi.advanceTimersByTime(MAGIC_LINK_POLL_INTERVAL_MS * 3);
+    });
+    await flush();
+
+    expect(onVerified).toHaveBeenCalledTimes(1);
+  });
+
+  it('expired surrogate → phase becomes expired and polling stops', async () => {
+    tagAc(AC);
+    magicLinkStatusApi.mockResolvedValue({ verified: false, expired: true });
+
+    const onVerified = vi.fn();
+    const { result } = renderHook(() => useMagicLinkPoll(REQUEST_ID, onVerified));
+
+    await flush();
+    expect(result.current).toBe('expired');
+    expect(onVerified).not.toHaveBeenCalled();
+
+    const calls = magicLinkStatusApi.mock.calls.length;
+    await act(async () => {
+      vi.advanceTimersByTime(MAGIC_LINK_POLL_INTERVAL_MS * 3);
+    });
+    await flush();
+    expect(magicLinkStatusApi).toHaveBeenCalledTimes(calls); // stopped
+  });
+
+  it('404 (unknown / already picked-up surrogate) → expired phase, polling stops', async () => {
+    tagAc(AC);
+    magicLinkStatusApi.mockRejectedValue(new NotFoundError('Unknown login request'));
+
+    const onVerified = vi.fn();
+    const { result } = renderHook(() => useMagicLinkPoll(REQUEST_ID, onVerified));
+
+    await flush();
+    expect(result.current).toBe('expired');
+
+    const calls = magicLinkStatusApi.mock.calls.length;
+    await act(async () => {
+      vi.advanceTimersByTime(MAGIC_LINK_POLL_INTERVAL_MS * 3);
+    });
+    await flush();
+    expect(magicLinkStatusApi).toHaveBeenCalledTimes(calls);
+  });
+
+  it('a transient (non-404) network error does NOT kill the loop — it keeps polling', async () => {
+    tagAc(AC);
+    magicLinkStatusApi
+      .mockRejectedValueOnce(new Error('network blip')) // immediate poll fails
+      .mockResolvedValue({ verified: false, expired: false }); // recovers
+
+    const { result } = renderHook(() => useMagicLinkPoll(REQUEST_ID, vi.fn()));
+
+    await flush();
+    expect(result.current).toBe('polling');
+
+    await act(async () => {
+      vi.advanceTimersByTime(MAGIC_LINK_POLL_INTERVAL_MS);
+    });
+    await flush();
+    expect(magicLinkStatusApi.mock.calls.length).toBeGreaterThanOrEqual(2);
+    expect(result.current).toBe('polling');
+  });
+
+  it('stops after the 15-minute TTL even if the surrogate never resolves', async () => {
+    tagAc(AC);
+    magicLinkStatusApi.mockResolvedValue({ verified: false, expired: false });
+
+    const { result } = renderHook(() => useMagicLinkPoll(REQUEST_ID, vi.fn()));
+    await flush();
+
+    await act(async () => {
+      vi.advanceTimersByTime(MAGIC_LINK_POLL_TTL_MS);
+    });
+    await flush();
+    expect(result.current).toBe('expired');
+
+    const calls = magicLinkStatusApi.mock.calls.length;
+    await act(async () => {
+      vi.advanceTimersByTime(MAGIC_LINK_POLL_INTERVAL_MS * 5);
+    });
+    await flush();
+    expect(magicLinkStatusApi).toHaveBeenCalledTimes(calls); // no polls after TTL stop
+  });
+
+  it('clears the interval on unmount — no poll fires after teardown', async () => {
+    tagAc(AC);
+    magicLinkStatusApi.mockResolvedValue({ verified: false, expired: false });
+
+    const { unmount } = renderHook(() => useMagicLinkPoll(REQUEST_ID, vi.fn()));
+    await flush();
+    const calls = magicLinkStatusApi.mock.calls.length;
+
+    unmount();
+    await act(async () => {
+      vi.advanceTimersByTime(MAGIC_LINK_POLL_INTERVAL_MS * 5);
+    });
+    await flush();
+    expect(magicLinkStatusApi).toHaveBeenCalledTimes(calls);
+  });
+});

--- a/packages/ui/src/hooks/useMagicLinkPoll.ts
+++ b/packages/ui/src/hooks/useMagicLinkPoll.ts
@@ -1,0 +1,126 @@
+import { useEffect, useRef, useState } from 'react';
+import { magicLinkStatusApi, NotFoundError, type SessionPayload } from '../api/client';
+
+// spec-304 t-40 (ac-30): poll the login-request surrogate so a magic-link login
+// completes IN THE ORIGINATING TAB/WEBVIEW. The user requests a link here, then
+// verifies it in a DIFFERENT browser/context (e.g. the external system browser
+// the desktop webview hands the link to); this hook notices the surrogate flip
+// to verified and adopts the session in place — no click-back, no native
+// deep-link handling.
+//
+// Contract (server, already live):
+//   pending  → { verified: false, expired: false }
+//   expired  → { verified: false, expired: true }
+//   verified → { verified: true, ...SessionPayload }  (SINGLE-SHOT — the row is
+//              deleted on first verified read; a second poll 404s)
+//   unknown  → 404 (NotFoundError)
+//
+// The verified read is single-shot, so the loop MUST stop the instant it sees
+// verified:true and hand the session off in that same tick — otherwise the very
+// next poll 404s and we'd lose the session. We guard the whole loop with a
+// `done` ref so neither a verified pickup nor a terminal error can be raced by
+// an in-flight poll, and so React StrictMode's double-invoke can't spawn two
+// live intervals.
+
+/** Poll cadence — fast enough to feel instant, slow enough to stay cheap. */
+export const MAGIC_LINK_POLL_INTERVAL_MS = 2_500;
+/** Hard stop — matches the magic-link / surrogate TTL ("expires in 15 minutes"). */
+export const MAGIC_LINK_POLL_TTL_MS = 15 * 60 * 1_000;
+
+export type MagicLinkPollPhase = 'polling' | 'verified' | 'expired';
+
+/**
+ * Drive the originating-session poll for one `loginRequestId`.
+ *
+ * @param loginRequestId  the surrogate id from `magicLinkRequestApi`; `null`
+ *                        disables polling (no id yet / not on the magic-sent view).
+ * @param onVerified      session-adoption callback — wire it to the SAME path the
+ *                        rest of auth uses (`acceptSession`) so the polled login
+ *                        truly completes (token persisted, context set, redirect).
+ *                        Invoked AT MOST ONCE.
+ * @returns the current phase: 'polling' until a terminal outcome, then 'verified'
+ *          (handed off) or 'expired' (404 / TTL lapse / expired surrogate).
+ */
+export function useMagicLinkPoll(
+  loginRequestId: string | null,
+  onVerified: (session: SessionPayload) => void,
+): MagicLinkPollPhase {
+  const [phase, setPhase] = useState<MagicLinkPollPhase>('polling');
+
+  // Keep the latest callback in a ref so re-creating it across renders doesn't
+  // tear down and re-install the interval (which would also reset `done`).
+  const onVerifiedRef = useRef(onVerified);
+  onVerifiedRef.current = onVerified;
+
+  useEffect(() => {
+    if (!loginRequestId) return;
+
+    // Reset for a fresh surrogate (e.g. the user requested a new link).
+    setPhase('polling');
+
+    // The single source of "this loop is over". Set before any terminal action
+    // so a poll that is still in flight when we resolve can't double-fire, and
+    // so a StrictMode re-mount's cleanup leaves the old loop dead.
+    let done = false;
+    let interval: ReturnType<typeof setInterval> | null = null;
+    let ttl: ReturnType<typeof setTimeout> | null = null;
+
+    const stop = (): void => {
+      done = true;
+      if (interval !== null) {
+        clearInterval(interval);
+        interval = null;
+      }
+      if (ttl !== null) {
+        clearTimeout(ttl);
+        ttl = null;
+      }
+    };
+
+    const poll = async (): Promise<void> => {
+      if (done) return;
+      try {
+        const status = await magicLinkStatusApi(loginRequestId);
+        if (done) return;
+        if (status.verified) {
+          // SINGLE-SHOT: stop BEFORE the hand-off so no later poll can race the
+          // now-deleted surrogate, then adopt the session in this same tick.
+          stop();
+          setPhase('verified');
+          const { verified: _verified, ...session } = status;
+          onVerifiedRef.current(session as SessionPayload);
+          return;
+        }
+        if (status.expired) {
+          stop();
+          setPhase('expired');
+        }
+        // pending → keep polling.
+      } catch (err) {
+        if (done) return;
+        // 404 ⇒ the surrogate is gone (already picked up / never existed) — a
+        // dead capability. Treat as expired and stop. Transient network errors
+        // (anything else) are swallowed so a blip doesn't kill the loop.
+        if (err instanceof NotFoundError) {
+          stop();
+          setPhase('expired');
+        }
+      }
+    };
+
+    interval = setInterval(() => void poll(), MAGIC_LINK_POLL_INTERVAL_MS);
+    ttl = setTimeout(() => {
+      if (done) return;
+      stop();
+      setPhase('expired');
+    }, MAGIC_LINK_POLL_TTL_MS);
+
+    // Kick one poll immediately so a link verified before the first tick still
+    // lands fast (the verified-elsewhere flow can complete in well under 2.5s).
+    void poll();
+
+    return stop;
+  }, [loginRequestId]);
+
+  return phase;
+}


### PR DESCRIPTION
## What & why
Email magic-link login was a dead-end in the embedded desktop webview (and any tab): you'd request a link, get "Check your email", click it in your **external** browser — which logged *that* browser in — and the originating tab/webview would sit forever, since nothing watched for completion.

This wires the **originating-session polling** the backend already supports (deployed + verified live on int). The "check your email" screen now polls the login-request surrogate and completes the session **in place** when the link is verified elsewhere — no click-back, no native deep-link handling. One web-side change; both desktop targets (WKWebView/WebView2) inherit it.

Resolves spec-304 dec-10 / t-40. Backend = PR #250 (merged).

## Changes
- `api/client.ts` — `magicLinkRequestApi` now returns `{ loginRequestId }` (was `void`); new `magicLinkStatusApi` (unauthenticated GET, 404→`NotFoundError`) + `MagicLinkStatus` type.
- `hooks/useMagicLinkPoll.ts` (new) — the poll loop: 2.5s cadence + immediate first poll, 15-min TTL stop, **single-shot** (stops before hand-off so it can't race the now-deleted surrogate), 404/expired→error, transient-error resilient, StrictMode-safe via a `done` ref, full cleanup on unmount.
- `components/LoginScreen.tsx` — `magic-sent` view carries `loginRequestId` and renders polling / verified / expired states.
- `components/AuthContext.tsx` — surfaces `loginRequestId`; passes `onMagicLinkVerified={acceptSession}` so the polled session is adopted via the **same** path password/SSO/`/consume` use (JWT persisted, context set, redirect) — a real login, not a half-login.

## Testing
- New: `useMagicLinkPoll.test.ts` (9) + `LoginScreen.test.tsx` (6) — pending→verified adopts exactly once & stops, single-shot, expired/404→error, TTL stop, unmount cleanup, transient-error resilience.
- `vitest run` (full UI suite): **1381 passed / 1 skipped (188 files)**.
- `tsc -b`: clean.
- Backend contract exercised live on int earlier (issue→pending→consume→`verified:true` session→single-shot 404).

## Not covered here
- **t-41**: manual in-webview runtime sign-off on macOS/WKWebView + Windows/WebView2 (confirm the webview keeps polling while backgrounded during the email trip). Mechanism is proven; real-webview runtime is the remaining leg.
- Desktop status-URL wiring is a separate task (t-42).

🤖 Generated with [Claude Code](https://claude.com/claude-code)