### PR TITLE
feat(spec-312): everyone lands on Home, and Home graduates with the user

### DIFF
--- a/packages/ui/e2e/helpers/fixtures.ts
+++ b/packages/ui/e2e/helpers/fixtures.ts
@@ -14,6 +14,7 @@ import {
   setIdentityConfirmed,
   clearOrgMemberships,
   cleanup,
+  getPersonalMemexByEmail,
 } from "./seed.js";
 
 export const DEV_EMAIL = "dev@memex.ai";
@@ -117,6 +118,26 @@ export function tenantPath(
 /** A bare (non-tenant) URL on the single origin — login, signup, invite-accept, etc. */
 export function bareUrl(path: string = "/"): string {
   return new URL(path, BASE_URL).toString();
+}
+
+/**
+ * Navigate to a user's personal-memex Specs board and wait for it to render.
+ *
+ * spec-312: the bare origin `/` now lands every authenticated user on `/home` (the
+ * universal landing), not the default-tenant Specs board. Journeys that need to start
+ * ON the Specs board navigate to it explicitly via this helper instead of relying on
+ * the old `/` → Specs hop. Defaults to the shared dev user.
+ */
+export async function gotoSpecsBoard(
+  page: Page,
+  email: string = DEV_EMAIL,
+): Promise<void> {
+  const memex = await getPersonalMemexByEmail(email);
+  if (!memex) throw new Error(`gotoSpecsBoard: no personal memex for ${email}`);
+  await page.goto(tenantPath(memex.namespaceSlug, memex.memexSlug, "/specs"));
+  await page
+    .getByRole("heading", { name: "Specs" })
+    .waitFor({ state: "visible", timeout: 15_000 });
 }
 
 /**

--- a/packages/ui/e2e/helpers/index.ts
+++ b/packages/ui/e2e/helpers/index.ts
@@ -6,6 +6,7 @@ export {
   expect,
   tenantPath,
   bareUrl,
+  gotoSpecsBoard,
   switchToEditing,
   sendChat,
   DEV_EMAIL,

--- a/packages/ui/e2e/journey-10-primary-nav.spec.ts
+++ b/packages/ui/e2e/journey-10-primary-nav.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, bareUrl } from "./helpers/index.js";
+import { test, expect, gotoSpecsBoard } from "./helpers/index.js";
 
 // Journey 10 — primary navigation (re-based onto the post-0038 product, spec-172 t-5).
 //
@@ -10,7 +10,7 @@ import { test, expect, bareUrl } from "./helpers/index.js";
 // (PageHeader). We assert the always-present three are present and route.
 
 test("primary nav routes to the always-present list pages", async ({ page }) => {
-  await page.goto(bareUrl("/"));
+  await gotoSpecsBoard(page);
 
   // Bare-domain landing auto-resolves to the dev user's personal-memex Specs
   // board. Wait for the Specs heading before clicking around.
@@ -58,7 +58,7 @@ test("primary nav is hidden when viewing a single Spec", async ({
   });
   resources.docIds.push(docId);
 
-  await page.goto(bareUrl("/"));
+  await gotoSpecsBoard(page);
   await expect(page.getByRole("heading", { name: "Specs" })).toBeVisible({
     timeout: 15_000,
   });

--- a/packages/ui/e2e/journey-18-global-search.spec.ts
+++ b/packages/ui/e2e/journey-18-global-search.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, bareUrl } from "./helpers/index.js";
+import { test, expect, bareUrl, gotoSpecsBoard } from "./helpers/index.js";
 import {
   getPersonalMemexByEmail,
   ensureUser,
@@ -107,7 +107,7 @@ test.describe("Journey 18 — global ⌘K search palette", () => {
   test("⌘K opens the palette, a typed Spec title surfaces a result, Enter navigates, Esc restores focus", async ({
     page,
   }) => {
-    await page.goto(bareUrl("/"));
+    await gotoSpecsBoard(page);
     // Land on the dev tenant's Specs board before touching the palette so we're
     // demonstrably on an authenticated tenant page (ac-16 reachable-from-anywhere).
     await expect(page.getByRole("heading", { name: "Specs" })).toBeVisible({
@@ -207,7 +207,7 @@ test.describe("Journey 18 — global ⌘K search palette", () => {
   test("typing the bare Spec number surfaces it under 'Jump to' and navigates (spec-191 ac-1)", async ({
     page,
   }) => {
-    await page.goto(bareUrl("/"));
+    await gotoSpecsBoard(page);
     await expect(page.getByRole("heading", { name: "Specs" })).toBeVisible({
       timeout: 15_000,
     });
@@ -253,7 +253,7 @@ test.describe("Journey 18 — global ⌘K search palette", () => {
   test("clicking the Specs-board search trigger opens the palette (spec-192 ac-8)", async ({
     page,
   }) => {
-    await page.goto(bareUrl("/"));
+    await gotoSpecsBoard(page);
     await expect(page.getByRole("heading", { name: "Specs" })).toBeVisible({
       timeout: 15_000,
     });

--- a/packages/ui/e2e/journey-19-lifecycle-spine.spec.ts
+++ b/packages/ui/e2e/journey-19-lifecycle-spine.spec.ts
@@ -39,6 +39,7 @@ import {
   expect,
   tenantPath,
   bareUrl,
+  gotoSpecsBoard,
   switchToEditing,
   DEV_EMAIL,
   getPersonalMemexByEmail,
@@ -279,12 +280,10 @@ test(
     // proof onboarding completed AS the new user, on the new flow.
     await expect(page.getByTestId("journey-step-connect-agent")).toBeVisible({ timeout: 10_000 });
 
-    // The new user can now reach their personal-memex Specs board (needsOnboarding
-    // cleared) — as the NEW user (sidebar identity shows `email`), never dev@memex.ai.
-    await page.goto(bareUrl("/"));
-    await expect(page.getByRole("heading", { name: "Specs" })).toBeVisible({
-      timeout: 15_000,
-    });
+    // The new user can now reach their personal-memex Specs board (the onboarding wall
+    // is gone, spec-312) — as the NEW user (sidebar identity shows `email`), never
+    // dev@memex.ai. `/` lands on /home now, so navigate to the Specs board explicitly.
+    await gotoSpecsBoard(page, email);
     await expect(page.getByText(email)).toBeVisible();
     await expect(page.getByText(DEV_EMAIL)).toHaveCount(0);
   }

--- a/packages/ui/e2e/journey-21-voice-guide.spec.ts
+++ b/packages/ui/e2e/journey-21-voice-guide.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, bareUrl, emitAcEvents } from "./helpers/index.js";
+import { test, expect, gotoSpecsBoard, emitAcEvents } from "./helpers/index.js";
 
 // Journey 21 — voice guide session surface + lifecycle (spec-190 t-9).
 //
@@ -37,7 +37,7 @@ test.afterEach(async ({}, testInfo) => {
 test("voice affordance is in-view on a registered screen, not in the global nav (ac-1)", async ({
   page,
 }) => {
-  await page.goto(bareUrl("/"));
+  await gotoSpecsBoard(page);
   // Bare-domain landing auto-resolves to the dev user's personal-memex Specs board.
   await expect(page.getByRole("heading", { name: "Specs" })).toBeVisible({ timeout: 15_000 });
 
@@ -51,7 +51,7 @@ test("voice affordance is in-view on a registered screen, not in the global nav 
 test("start → pill → end, and an active session never blocks the app (ac-1 / ac-5)", async ({
   page,
 }) => {
-  await page.goto(bareUrl("/"));
+  await gotoSpecsBoard(page);
   await expect(page.getByRole("heading", { name: "Specs" })).toBeVisible({ timeout: 15_000 });
 
   // Start a session from the in-view affordance (this is what triggers the mic

--- a/packages/ui/e2e/journey-22-whats-new.spec.ts
+++ b/packages/ui/e2e/journey-22-whats-new.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, bareUrl, emitAcEvents } from "./helpers/index.js";
+import { test, expect, gotoSpecsBoard, emitAcEvents } from "./helpers/index.js";
 import { seedWhatsNewEntry, clearWhatsNewEntries } from "./helpers/seed.js";
 
 // Journey 22 — What's New ribbon → popup → dismiss (spec-200, std-28 gate).
@@ -55,7 +55,7 @@ test.afterEach(async ({}, testInfo) => {
 test("ribbon slides up → popup shows the entry; only its × dismisses it, persisting across reload (ac-2 / ac-3)", async ({
   page,
 }) => {
-  await page.goto(bareUrl("/"));
+  await gotoSpecsBoard(page);
   // Bare-domain landing auto-resolves to the dev user's personal-memex Specs board.
   await expect(page.getByRole("heading", { name: "Specs" })).toBeVisible({ timeout: 15_000 });
 

--- a/packages/ui/e2e/journey-23-first-run-greeting.spec.ts
+++ b/packages/ui/e2e/journey-23-first-run-greeting.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, bareUrl, emitAcEvents, setOnboardingGreeted, DEV_EMAIL } from "./helpers/index.js";
+import { test, expect, gotoSpecsBoard, emitAcEvents, setOnboardingGreeted, DEV_EMAIL } from "./helpers/index.js";
 import { seedWhatsNewEntry, clearWhatsNewEntries } from "./helpers/seed.js";
 import { clearAnthropicQueue, queueAnthropicResponse } from "./helpers/anthropic-fake.js";
 
@@ -56,7 +56,7 @@ test("a user who has already been greeted sees no dialogue and no auto session (
   // Mark the dev user already-greeted (the once-per-user flag is set).
   await setOnboardingGreeted(DEV_EMAIL, true);
 
-  await page.goto(bareUrl("/"));
+  await gotoSpecsBoard(page);
   await expect(page.getByRole("heading", { name: "Specs" })).toBeVisible({ timeout: 15_000 });
 
   // Give the first-run controller the same window journey-28 gives it.
@@ -103,7 +103,7 @@ test("a seeded proactive turn returning start_walkthrough starts the tour and op
   });
 
   try {
-    await page.goto(bareUrl("/"));
+    await gotoSpecsBoard(page);
     await expect(page.getByRole("heading", { name: "Specs" })).toBeVisible({ timeout: 15_000 });
 
     // Ribbon → popup → the entry's ear starts the seeded session.

--- a/packages/ui/e2e/journey-26-logo-theme.spec.ts
+++ b/packages/ui/e2e/journey-26-logo-theme.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, bareUrl, emitAcEvents } from "./helpers/index.js";
+import { test, expect, gotoSpecsBoard, emitAcEvents } from "./helpers/index.js";
 
 // Journey 26 — the Memex wordmark recolours with the theme (spec-223 ac-2).
 //
@@ -39,7 +39,7 @@ async function computedLogoFill(page: import("@playwright/test").Page) {
 
 test("the logo fill inverts between dark and light theme (ac-2)", async ({ page }) => {
   // Force dark, then read the computed fill of the header wordmark.
-  await page.goto(bareUrl("/"));
+  await gotoSpecsBoard(page);
   // "/" client-redirects to the default memex's specs page. Wait for that
   // redirect to SETTLE before evaluating, otherwise the localStorage write
   // races the navigation and Playwright throws "Execution context was

--- a/packages/ui/e2e/journey-35-spec-312-home-landing.spec.ts
+++ b/packages/ui/e2e/journey-35-spec-312-home-landing.spec.ts
@@ -1,0 +1,64 @@
+import {
+  test,
+  expect,
+  bareUrl,
+  emitAcEvents,
+  ensureUser,
+  setUserName,
+  setIdentityConfirmed,
+  DEV_EMAIL,
+  DEV_NAME,
+} from "./helpers/index.js";
+
+// Journey 35 — spec-312: everyone lands on Home, and the onboarding wall is gone.
+//
+//   ac-2 — a user who has CONFIRMED identity but not finished onboarding, navigating to
+//          `/`, lands on /home and is shown the onboarding journey (NOT the Specs board).
+//          This is the exact "abandoned after one trivial click" bug spec-312 fixes:
+//          under the old routing, identity-confirmed ⇒ needsOnboarding=false ⇒ the user
+//          was sent to computeDefaultLanding (their empty Specs board) with no guidance.
+//   ac-3 — the wall is gone: from Home the user can navigate to the Specs board and is
+//          NOT force-redirected back to onboarding/Home.
+
+const AC2 = "mindset-prod/memex-building-itself/specs/spec-312/acs/ac-2";
+const AC3 = "mindset-prod/memex-building-itself/specs/spec-312/acs/ac-3";
+
+const TITLE =
+  "an identity-confirmed, not-yet-onboarded user lands on Home with the journey, and is free to roam";
+
+test.afterEach(async ({}, testInfo) => {
+  // Leave the shared dev user identity-confirmed so other journeys land on their board.
+  await setIdentityConfirmed(DEV_EMAIL, true);
+  if (testInfo.status === "skipped") return;
+  await emitAcEvents(
+    [AC2, AC3],
+    testInfo.status === "passed" ? "pass" : "fail",
+    `packages/ui/e2e/journey-35-spec-312-home-landing.spec.ts::${testInfo.title}`,
+    testInfo.duration,
+  );
+});
+
+test(TITLE, async ({ page }) => {
+  await ensureUser(DEV_EMAIL);
+  await setUserName(DEV_EMAIL, DEV_NAME);
+  // Identity CONFIRMED (needsOnboarding=false) but onboarding NOT finished — the case
+  // the old routing abandoned on the Specs board.
+  await setIdentityConfirmed(DEV_EMAIL, true);
+
+  // Land on `/` (the root) so RootRedirect makes the routing decision under test.
+  await page.goto(bareUrl("/"));
+
+  // ac-2: RootRedirect sends them to /home (the universal landing), not the Specs board.
+  await expect(page).toHaveURL(/\/home(\?|#|$)/, { timeout: 15_000 });
+  await expect(page.getByTestId("home-canvas")).toBeVisible({ timeout: 15_000 });
+  // The onboarding journey is shown on Home: the persistent "Your Journeys" pearls
+  // surface (always present) is the unmistakable signal we're on the journey, not Specs.
+  await expect(page.getByTestId("your-journeys")).toBeVisible({ timeout: 15_000 });
+
+  // ac-3: the wall is gone — navigating to the Specs board is allowed and is NOT bounced
+  // back to Home/onboarding. Scope to the primary nav (the home-of-value surface also has
+  // an "Open your Specs board" link, so an unscoped name match is ambiguous).
+  await page.getByTestId("primary-nav").getByRole("link", { name: "Specs" }).click();
+  await expect(page).toHaveURL(/\/specs(\?|#|$)/, { timeout: 15_000 });
+  await expect(page).not.toHaveURL(/\/home(\?|#|$)/);
+});

--- a/packages/ui/e2e/verify-spec-172-setup.spec.ts
+++ b/packages/ui/e2e/verify-spec-172-setup.spec.ts
@@ -30,20 +30,19 @@ test.afterEach(async ({}, testInfo) => {
   );
 });
 
-test("globalSetup leaves dev@memex.ai named so a cold-DB journey lands on Specs, not Onboarding", async ({
+test("globalSetup leaves dev@memex.ai named so a cold-DB journey lands on Home, not Onboarding", async ({
   page,
 }) => {
   // globalSetup provisioned the personal memex; it must resolve.
   const memex = await getPersonalMemexByEmail(DEV_EMAIL);
   expect(memex, "globalSetup should have provisioned dev@memex.ai's personal memex").not.toBeNull();
 
-  // Bare origin → PostLoginRouter resolves the named dev user into its personal
-  // memex's Specs board. A nameless user would render the Onboarding profile
-  // screen instead; assert the Specs heading appears and the onboarding name
-  // prompt does not.
-  // waitUntil: "commit" — PostLoginRouter may client-redirect mid-load.
+  // Bare origin → spec-312: every authenticated user lands on /home (the universal
+  // landing), where the Home Canvas renders. The point of ac-10 holds: a cold-DB
+  // journey for the named dev user is NOT dropped into a blocking onboarding screen —
+  // it reaches the real app surface (now /home, the Home Canvas) directly.
+  // waitUntil: "commit" — RootRedirect may client-redirect mid-load.
   await page.goto("/", { waitUntil: "commit" });
-  await expect(page.getByRole("heading", { name: "Specs" })).toBeVisible({
-    timeout: 15_000,
-  });
+  await expect(page).toHaveURL(/\/home(\?|#|$)/, { timeout: 15_000 });
+  await expect(page.getByTestId("home-canvas")).toBeVisible({ timeout: 15_000 });
 });

--- a/packages/ui/src/App.onboarding-home-gate.test.tsx
+++ b/packages/ui/src/App.onboarding-home-gate.test.tsx
@@ -4,22 +4,22 @@ import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom';
 import type { ReactNode } from 'react';
 import type { SessionPayload } from './api/client';
 
-// Regression — the onboarding destination must respect the Home Canvas feature gate.
+// Regression — the universal /home landing must respect the Home Canvas feature gate.
 //
-// THE BUG: spec-305 routes every `needsOnboarding` user to /home (the Home Canvas
-// journey). But /home is gated per-env: when 'home' is in HIDDEN_FEATURES (e.g. prod,
-// before the journey is ready) the /home route renders <RootRedirect/> instead of the
-// journey. RootRedirect's FIRST check sends `needsOnboarding` users straight back to
-// /home — so a brand-new signup is trapped in an infinite /home ⇄ RootRedirect loop and
-// can never reach the app. Hiding the tab silently soft-locks every new prod signup.
+// spec-312 dec-1/dec-3: RootRedirect now sends EVERY authenticated, email-verified user
+// to /home (the universal landing) — needsOnboarding no longer routes. But /home is
+// gated per-env: when 'home' is in HIDDEN_FEATURES (e.g. prod, before the journey is
+// ready) the /home route renders <RootRedirect/>. If RootRedirect sent everyone to
+// /home unconditionally, a hidden-home env would trap every signup in an infinite
+// /home ⇄ RootRedirect loop. So RootRedirect's ONLY remaining branch is loop-avoidance:
+// when 'home' is hidden it falls back to the default-tenant landing (computeDefaultLanding,
+// the Specs board); when 'home' is visible everyone lands on the journey at /home.
 //
-// THE FIX: when 'home' is hidden, onboarding falls back to the still-present legacy
-// /onboarding page (which stamps identity_confirmed_at and clears needsOnboarding just
-// the same). When 'home' is visible, the journey at /home is used exactly as today.
+// (The legacy standalone /onboarding fallback that spec-305 used is gone with the wall.)
 //
 // We mount the real PostLoginRouter so the gate + RootRedirect resolve through genuine
-// react-router; the journey page, legacy page, and tenant chrome are stubbed to sentinels
-// so the test isolates the routing decision, not the screens.
+// react-router; the journey page and tenant chrome are stubbed to sentinels so the test
+// isolates the routing decision, not the screens.
 
 let mockSession: SessionPayload;
 function makeSession(opts: { needsOnboarding: boolean; hiddenFeatures: string[] }): SessionPayload {
@@ -109,20 +109,25 @@ describe('onboarding destination respects the Home Canvas feature gate', () => {
     vi.unstubAllEnvs();
   });
 
-  it('home VISIBLE: a needs-onboarding user lands on the Home Canvas journey', async () => {
+  it('home VISIBLE: an authenticated user lands on the Home Canvas (needsOnboarding is irrelevant now)', async () => {
     mockSession = makeSession({ needsOnboarding: true, hiddenFeatures: [] });
     renderAt('/');
     expect(await screen.findByTestId('home-canvas-page')).toBeInTheDocument();
     expect(screen.queryByTestId('onboarding-page')).not.toBeInTheDocument();
   });
 
-  it('home HIDDEN: a needs-onboarding user lands on the legacy /onboarding page (no /home loop)', async () => {
+  it('home HIDDEN: lands on the default-tenant Specs board, never a /home loop', async () => {
     mockSession = makeSession({ needsOnboarding: true, hiddenFeatures: ['home'] });
     renderAt('/');
-    // Before the fix this renders nothing (the /home ⇄ RootRedirect loop); after the
-    // fix the user lands on the working legacy onboarding page.
-    expect(await screen.findByTestId('onboarding-page')).toBeInTheDocument();
+    // spec-312: with 'home' hidden RootRedirect falls back to the default tenant (no
+    // loop), and there is no legacy /onboarding wall to land on anymore.
+    await waitFor(() => {
+      expect(screen.getByTestId('probe').getAttribute('data-path')).toBe(
+        '/alice/personal/specs',
+      );
+    });
     expect(screen.queryByTestId('home-canvas-page')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('onboarding-page')).not.toBeInTheDocument();
   });
 
   it('home HIDDEN, already onboarded: a deliberate /home visit still bounces to the default tenant', async () => {

--- a/packages/ui/src/App.spec-146.test.tsx
+++ b/packages/ui/src/App.spec-146.test.tsx
@@ -96,14 +96,16 @@ function LocationProbe() {
   return <div data-testid="probe" data-path={loc.pathname} />;
 }
 
-// Render the real route tree at `path`, plus a probe at the default landing so we
-// can assert where the catch-all redirect lands.
+// Render the real route tree at `path`, plus a probe at the universal landing so we
+// can assert where the catch-all redirect lands. spec-312: RootRedirect now sends
+// every authenticated user to /home (the universal landing), so the fallthrough
+// target is /home, not the default-tenant Specs board.
 function renderAt(path: string) {
   return render(
     <MemoryRouter initialEntries={[path]}>
       <Routes>
         <Route path="/*" element={<PostLoginRouter />} />
-        <Route path="/alice/personal/specs" element={<LocationProbe />} />
+        <Route path="/home" element={<LocationProbe />} />
       </Routes>
     </MemoryRouter>,
   );
@@ -117,7 +119,7 @@ describe('spec-146 t-4: /scaffold route gate', () => {
     vi.unstubAllEnvs();
   });
 
-  it('ac-10: hidden → /scaffold does not render ScaffoldInspect and redirects to the default tenant', async () => {
+  it('ac-10: hidden → /scaffold does not render ScaffoldInspect and redirects to the universal landing', async () => {
     tagAc(AC(10));
     // ac-2 (scope) — the route is gated, not merely missing from the nav: a direct
     // /scaffold visit does not render ScaffoldInspect.
@@ -126,11 +128,9 @@ describe('spec-146 t-4: /scaffold route gate', () => {
     renderAt('/alice/personal/scaffold');
 
     // The route was never registered, so the path falls through to the catch-all
-    // RootRedirect → default landing (/alice/personal/specs).
+    // RootRedirect → universal landing (/home, spec-312 dec-1).
     await waitFor(() => {
-      expect(screen.getByTestId('probe').getAttribute('data-path')).toBe(
-        '/alice/personal/specs',
-      );
+      expect(screen.getByTestId('probe').getAttribute('data-path')).toBe('/home');
     });
     expect(screen.queryByTestId('scaffold-inspect-page')).not.toBeInTheDocument();
   });

--- a/packages/ui/src/App.spec-148.test.tsx
+++ b/packages/ui/src/App.spec-148.test.tsx
@@ -111,15 +111,16 @@ function LocationProbe() {
   return <div data-testid="probe" data-path={loc.pathname} />;
 }
 
-// Render the real route tree at `path`, plus a probe at the default landing so we
-// can assert where the catch-all redirect lands.
+// Render the real route tree at `path`, plus a probe at the universal landing so we
+// can assert where the catch-all redirect lands. spec-312: RootRedirect now sends
+// every authenticated user to /home, so the fallthrough target is /home.
 function renderAt(path: string) {
   return render(
     <ThemeProvider>
       <MemoryRouter initialEntries={[path]}>
         <Routes>
           <Route path="/*" element={<PostLoginRouter />} />
-          <Route path="/alice/personal/specs" element={<LocationProbe />} />
+          <Route path="/home" element={<LocationProbe />} />
         </Routes>
       </MemoryRouter>
     </ThemeProvider>,
@@ -163,17 +164,15 @@ describe('spec-148 t-1: Pulse feature-hide', () => {
     expect(within(nav).getByRole('link', { name: 'Specs' })).toBeInTheDocument();
   });
 
-  it('ac-7: hidden → /pulse does not render Pulse and redirects to the default tenant', async () => {
+  it('ac-7: hidden → /pulse does not render Pulse and redirects to the universal landing', async () => {
     tagAc(AC(7));
     mockSession = makeSession(['pulse']);
     renderAt('/alice/personal/pulse');
 
     // The route was never registered, so the path falls through to the catch-all
-    // RootRedirect → default landing (/alice/personal/specs).
+    // RootRedirect → universal landing (/home, spec-312 dec-1).
     await waitFor(() => {
-      expect(screen.getByTestId('probe').getAttribute('data-path')).toBe(
-        '/alice/personal/specs',
-      );
+      expect(screen.getByTestId('probe').getAttribute('data-path')).toBe('/home');
     });
     expect(screen.queryByTestId('pulse-page')).not.toBeInTheDocument();
   });

--- a/packages/ui/src/App.spec-260.test.tsx
+++ b/packages/ui/src/App.spec-260.test.tsx
@@ -82,12 +82,14 @@ function LocationProbe() {
   return <div data-testid="probe" data-path={loc.pathname} />;
 }
 
+// spec-312: RootRedirect now sends every authenticated user to /home (the universal
+// landing), so the catch-all fallthrough lands on /home, not the Specs board.
 function renderAt(path: string) {
   return render(
     <MemoryRouter initialEntries={[path]}>
       <Routes>
         <Route path="/*" element={<PostLoginRouter />} />
-        <Route path="/alice/personal/specs" element={<LocationProbe />} />
+        <Route path="/home" element={<LocationProbe />} />
       </Routes>
     </MemoryRouter>,
   );
@@ -101,15 +103,13 @@ describe('spec-260 t-7: /qa-reports route gate (ac-18)', () => {
     vi.unstubAllEnvs();
   });
 
-  it("hidden → /qa-reports does not render the page and redirects to the default tenant", async () => {
+  it("hidden → /qa-reports does not render the page and redirects to the universal landing", async () => {
     tagAc(AC(18));
     mockSession = makeSession(['qa-reports']);
     renderAt('/alice/personal/qa-reports');
 
     await waitFor(() => {
-      expect(screen.getByTestId('probe').getAttribute('data-path')).toBe(
-        '/alice/personal/specs',
-      );
+      expect(screen.getByTestId('probe').getAttribute('data-path')).toBe('/home');
     });
     expect(screen.queryByTestId('qa-reports-page')).not.toBeInTheDocument();
   });

--- a/packages/ui/src/App.spec-312.test.tsx
+++ b/packages/ui/src/App.spec-312.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import { tagAc } from '@memex-ai-ac/vitest';
 import type { ReactNode } from 'react';

--- a/packages/ui/src/App.spec-312.test.tsx
+++ b/packages/ui/src/App.spec-312.test.tsx
@@ -1,0 +1,192 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { tagAc } from '@memex-ai-ac/vitest';
+import type { ReactNode } from 'react';
+import type { SessionPayload } from './api/client';
+
+// spec-312 t-1 — the universal /home landing and the removal of the needsOnboarding
+// wall (dec-1, dec-3). We mount the real `PostLoginRouter` so RootRedirect, the
+// tenant-route gate and FlatShell all resolve through genuine react-router. The heavy
+// chrome and data-fetching pages are stubbed to sentinels so the test isolates the
+// routing decision, not the screens.
+//
+//   ac-1  (scope) — / routes an authenticated, email-verified user to /home regardless
+//                   of onboarding/identity state.
+//   ac-3  (scope) — an incomplete-onboarding user is never force-redirected back to
+//                   onboarding when navigating to Specs or elsewhere.
+//   ac-6  (scope) — an unverified user is still blocked by the email gate.
+//   ac-7  (impl)  — RootRedirect, needsOnboarding=true → /home.
+//   ac-8  (impl)  — RootRedirect, needsOnboarding=false → /home.
+//   ac-9  (impl)  — a needsOnboarding user reaches a tenant route (gate at 172 gone).
+//   ac-10 (impl)  — a needsOnboarding user reaches a FlatShell flat route (bounce gone).
+//   ac-14 (impl)  — needsOnboarding does not change routing (true and false land same).
+//   ac-15 (impl)  — the email gate fires before any landing redirect.
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-312/acs/ac-${n}`;
+
+let mockSession: SessionPayload;
+function makeSession(opts: {
+  needsOnboarding: boolean;
+  emailVerified?: boolean;
+  hiddenFeatures?: string[];
+}): SessionPayload {
+  return {
+    user: {
+      id: 'u-1',
+      email: 'alice@example.com',
+      name: 'Alice',
+      status: 'active',
+      emailVerified: opts.emailVerified ?? true,
+    },
+    memberships: [
+      {
+        memexId: 'mx-alice',
+        slug: 'alice',
+        memexSlug: 'personal',
+        name: 'Personal Memex',
+        kind: 'personal' as const,
+        role: 'administrator' as const,
+      },
+    ],
+    currentMemexId: 'mx-alice',
+    currentRole: 'administrator' as const,
+    needsOnboarding: opts.needsOnboarding,
+    hiddenFeatures: opts.hiddenFeatures ?? [],
+  };
+}
+
+vi.mock('./components/AuthContext', async () => {
+  const real = await vi.importActual<typeof import('./components/AuthContext')>(
+    './components/AuthContext',
+  );
+  return {
+    ...real,
+    useAuth: () => ({
+      session: mockSession,
+      user: { name: 'Alice', email: 'alice@example.com', picture: '' },
+      token: 'fake-token',
+      isAuthenticated: true,
+      authError: null,
+      logout: vi.fn(),
+      updateSession: vi.fn(),
+      acceptSession: vi.fn(),
+    }),
+  };
+});
+
+// Tenant chrome → passthroughs so TenantLayout/FlatShell render their content
+// without the AppShell + chat/consent providers.
+vi.mock('./components/AppShell', () => ({
+  AppShell: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+vi.mock('./components/ChatContext', () => ({
+  ChatProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+vi.mock('./components/OrgConsentDialog', () => ({ OrgConsentDialog: () => null }));
+
+// Sentinels for the landing surfaces — presence/absence of the testid is the signal.
+vi.mock('./pages/HomeCanvas', () => ({
+  HomeCanvas: () => <div data-testid="home-canvas-page">home</div>,
+}));
+vi.mock('./pages/SpecList', () => ({
+  SpecList: () => <div data-testid="specs-page">specs</div>,
+}));
+vi.mock('./pages/SettingsIntegrations', () => ({
+  SettingsIntegrations: () => <div data-testid="integrations-page">integrations</div>,
+}));
+vi.mock('./pages/VerifyEmailGate', () => ({
+  VerifyEmailGate: () => <div data-testid="verify-email-gate">verify your email</div>,
+}));
+vi.mock('./pages/Onboarding', () => ({
+  Onboarding: () => <div data-testid="onboarding-page">legacy onboarding</div>,
+}));
+
+import { PostLoginRouter } from './App';
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/*" element={<PostLoginRouter />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.stubEnv('VITE_GOOGLE_CLIENT_ID', 'test-client-id');
+});
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('spec-312 t-1: universal /home landing (dec-1)', () => {
+  it('ac-1 / ac-8: an email-verified, already-onboarded user visiting / lands on /home', async () => {
+    tagAc(AC(1));
+    tagAc(AC(8));
+    mockSession = makeSession({ needsOnboarding: false });
+    renderAt('/');
+    expect(await screen.findByTestId('home-canvas-page')).toBeInTheDocument();
+    expect(screen.queryByTestId('specs-page')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('onboarding-page')).not.toBeInTheDocument();
+  });
+
+  it('ac-1 / ac-7: an email-verified, NOT-yet-onboarded user visiting / lands on /home', async () => {
+    tagAc(AC(1));
+    tagAc(AC(7));
+    mockSession = makeSession({ needsOnboarding: true });
+    renderAt('/');
+    expect(await screen.findByTestId('home-canvas-page')).toBeInTheDocument();
+    expect(screen.queryByTestId('onboarding-page')).not.toBeInTheDocument();
+  });
+
+  it('ac-14: needsOnboarding does not change where / lands (true and false both → /home)', async () => {
+    tagAc(AC(14));
+    for (const needsOnboarding of [true, false]) {
+      mockSession = makeSession({ needsOnboarding });
+      const { unmount } = renderAt('/');
+      expect(await screen.findByTestId('home-canvas-page')).toBeInTheDocument();
+      unmount();
+    }
+  });
+});
+
+describe('spec-312 t-1: the needsOnboarding wall is gone (dec-1 / dec-3)', () => {
+  it('ac-3 / ac-9: a NOT-yet-onboarded user reaches a tenant route, not bounced to onboarding/home', async () => {
+    tagAc(AC(3));
+    tagAc(AC(9));
+    mockSession = makeSession({ needsOnboarding: true });
+    renderAt('/alice/personal/specs');
+    expect(await screen.findByTestId('specs-page')).toBeInTheDocument();
+    expect(screen.queryByTestId('home-canvas-page')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('onboarding-page')).not.toBeInTheDocument();
+  });
+
+  it('ac-10: a NOT-yet-onboarded user reaches a FlatShell flat route, not bounced', async () => {
+    tagAc(AC(10));
+    mockSession = makeSession({ needsOnboarding: true });
+    renderAt('/settings/integrations');
+    expect(await screen.findByTestId('integrations-page')).toBeInTheDocument();
+    expect(screen.queryByTestId('onboarding-page')).not.toBeInTheDocument();
+  });
+});
+
+describe('spec-312 t-1: the email-verification gate is unchanged (dec-3)', () => {
+  it('ac-6 / ac-15: an unverified user visiting / hits the email gate before any landing', async () => {
+    tagAc(AC(6));
+    tagAc(AC(15));
+    mockSession = makeSession({ needsOnboarding: false, emailVerified: false });
+    renderAt('/');
+    expect(await screen.findByTestId('verify-email-gate')).toBeInTheDocument();
+    expect(screen.queryByTestId('home-canvas-page')).not.toBeInTheDocument();
+  });
+
+  it('ac-15: an unverified user on a FlatShell route hits the email gate', async () => {
+    tagAc(AC(15));
+    mockSession = makeSession({ needsOnboarding: false, emailVerified: false });
+    renderAt('/settings/integrations');
+    expect(await screen.findByTestId('verify-email-gate')).toBeInTheDocument();
+    expect(screen.queryByTestId('integrations-page')).not.toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -39,7 +39,7 @@ import { DocumentShell } from './components/DocumentShell';
 import { OrgConsentDialog } from './components/OrgConsentDialog';
 import { parseTenantFromPathname } from './utils/tenantUrl';
 import { isFeatureHidden } from './utils/featureFlags';
-import { probePublicMemex, type PublicMemexProbe, type SessionPayload } from './api/client';
+import { probePublicMemex, type PublicMemexProbe } from './api/client';
 import { PublicMemexProvider } from './components/PublicMemexContext';
 import {
   VoiceSessionProvider,
@@ -164,15 +164,13 @@ function TenantLayout() {
   // tick; the AuthContext useEffect runs synchronously after mount.
   if (!session) return null;
 
-  // Onboarding/verification gates take precedence — even with a valid tenant
-  // URL, an unverified user can't actually do anything yet.
+  // The email-verification gate takes precedence — even with a valid tenant URL, an
+  // unverified user can't actually do anything yet. spec-312 dec-3: this gate stays
+  // exactly as is; the needsOnboarding wall that used to sit here is gone — an
+  // incomplete-onboarding user is free to navigate anywhere (the journey lives on
+  // /home as a recede-able layer, not a wall).
   if (!session.user.emailVerified) {
     return <VerifyEmailGate />;
-  }
-  if (session.needsOnboarding) {
-    // spec-305 dec-2: onboarding lives in the Home Canvas journey (/home), with a
-    // legacy /onboarding fallback when 'home' is hidden per-env (see onboardingPath).
-    return <Navigate to={onboardingPath(session)} replace />;
   }
 
   // Membership check: redirect to the user's default tenant when they aren't
@@ -221,8 +219,8 @@ function TenantLayout() {
                 VoiceGuideMount so t-7's ear can reach the voice session). */}
             <WhatsNewRibbonConnected />
             {/* spec-305 dec-2: the Specky first-run greeting (FirstRunGreeting,
-                spec-206/242) is retired — onboarding is now the Home Canvas journey,
-                reached via the needsOnboarding → /home redirect in RequireAuth. */}
+                spec-206/242) is retired — onboarding is now the Home Canvas journey.
+                spec-312: it's a recede-able layer on /home, no longer a routing wall. */}
             <AppShell>
               <Fragment key={`${namespace}/${memex}`}>
                 <Outlet />
@@ -324,29 +322,18 @@ function VoiceGuideMount({
   );
 }
 
-// Where a `needsOnboarding` user is sent. Onboarding normally lives in the Home
-// Canvas journey at /home (spec-305 dec-2). But /home is gated per-env: when 'home'
-// is in HIDDEN_FEATURES (e.g. prod, before the journey is ready) the /home route
-// renders RootRedirect — which would bounce a needs-onboarding user straight back to
-// /home, an infinite loop that soft-locks every new signup. In that case we fall back
-// to the legacy standalone /onboarding page, which stamps identity_confirmed_at and
-// clears needsOnboarding all the same. Un-hiding 'home' restores the journey with no
-// code change. Keep this in lock-step with the /home gate (the route element below).
-function onboardingPath(session: SessionPayload | null): string {
-  return isFeatureHidden(session, 'home') ? '/onboarding' : '/home';
-}
-
-// `/` lands the authenticated user on their default tenant's specs page.
-// Pre-auth users won't reach this (RequireAuth intercepts), but if the
-// session loads with zero memberships we render the specs board behind
-// no tenant (a legitimately rare case — every user has exactly one personal
-// Memex by invariant; only stale local sessions hit this).
+// spec-312 dec-1: `/` lands every authenticated, email-verified user on /home — the
+// universal landing, regardless of onboarding/identity state. Pre-auth users won't
+// reach this (RequireAuth intercepts). When 'home' is hidden per-env the /home route
+// itself renders RootRedirect, so there we fall back to the default tenant landing to
+// avoid a redirect loop (and a session with zero memberships falls back to null → /).
 function RootRedirect() {
   const { session } = useAuth();
   if (!session) return null; // session bootstrap still pending
   if (session && !session.user.emailVerified) return <VerifyEmailGate />;
-  if (session?.needsOnboarding) return <Navigate to={onboardingPath(session)} replace />; // spec-305 dec-2 (+ /home-hidden fallback)
-  const target = computeDefaultLanding(session);
+  // spec-312 dec-3: needsOnboarding / identity_confirmed_at no longer participate in
+  // routing. The only branch left is the per-env 'home' hide (loop-avoidance above).
+  const target = isFeatureHidden(session, 'home') ? computeDefaultLanding(session) : '/home';
   if (target) return <Navigate to={target} replace />;
   return null;
 }
@@ -527,15 +514,10 @@ export function PostLoginRouter() {
 // routes; flat routes that want chrome get them here.
 function FlatShell({ children }: { children: React.ReactNode }) {
   const { session } = useAuth();
-  const location = useLocation();
   if (session && !session.user.emailVerified) return <VerifyEmailGate />;
-  // spec-305 dec-2: needs-onboarding users belong on the active onboarding surface —
-  // the Home Canvas journey at /home, or the legacy /onboarding page when 'home' is
-  // hidden per-env (onboardingPath). Exempt that surface so it renders; every other
-  // flat route bounces them to it.
-  if (session?.needsOnboarding && location.pathname !== onboardingPath(session)) {
-    return <Navigate to={onboardingPath(session)} replace />;
-  }
+  // spec-312 dec-3: the needsOnboarding bounce-back that used to live here is gone —
+  // flat routes render for everyone past the email gate. Onboarding is a layer on
+  // /home, never a wall that ejects you from other surfaces.
   return (
     <ChatProvider>
       <OrgConsentDialog />

--- a/packages/ui/src/components/AuthContext.tsx
+++ b/packages/ui/src/components/AuthContext.tsx
@@ -17,6 +17,7 @@ import {
   type SessionPayload,
 } from '../api/client';
 import { LoginScreen } from './LoginScreen';
+import { isFeatureHidden } from '../utils/featureFlags';
 import { buildBareDomainUrl } from '../utils/tenantUrl';
 import { useUserChangeStreamWithToken } from '../hooks/useUserChangeStream';
 
@@ -157,12 +158,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
     // t-23 of doc-15: same-origin path-based routing means we no longer need a
     // cross-subdomain handoff. After a successful login we route the user to
-    // their default tenant's /specs page. The default is the personal
-    // membership (every signed-in user has exactly one).
+    // /home — the universal landing (spec-312 dec-1) — falling back to the
+    // default-tenant Specs board only when 'home' is hidden per-env.
     //
     // If the URL carries a `?returnTo=…` (legacy SSO bounce parameter), we
-    // honour it when it points at our own host. Otherwise pick the personal
-    // membership, falling back to the first available membership.
+    // honour it when it points at our own host.
     if (s.token && typeof window !== 'undefined') {
       const params = new URLSearchParams(window.location.search);
       const raw = params.get('returnTo');
@@ -176,7 +176,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         }
       }
 
-      const landing = computeDefaultLanding(s);
+      // spec-312 dec-1: the post-login landing is /home (the universal landing), not the
+      // default-tenant Specs board. Fall back to computeDefaultLanding only when 'home'
+      // is hidden per-env (mirrors RootRedirect's loop-avoidance).
+      const landing = isFeatureHidden(s, 'home') ? computeDefaultLanding(s) : '/home';
       if (landing && window.location.pathname === '/') {
         window.location.href = landing;
       }

--- a/packages/ui/src/components/home/HomeValue.tsx
+++ b/packages/ui/src/components/home/HomeValue.tsx
@@ -1,0 +1,30 @@
+// spec-312 dec-2 — the home-of-value surface.
+//
+// This is the real "home of value" that is ALWAYS the page: it renders for every user
+// regardless of journey-graduation state (the journey is a layer on top, not a gate in
+// front). spec-312 owns this SURFACE and the graduated-vs-not branch; the richer
+// content design of the graduated home is separate, later work — so this is a modest
+// but real surface (a heading plus the primary way back into work), not a placeholder.
+
+export function HomeValue({ specsPath }: { specsPath: string | null }) {
+  return (
+    <section
+      data-testid="home-of-value"
+      className="mx-auto mt-8 w-full max-w-3xl px-4"
+    >
+      <h2 className="text-lg font-semibold text-heading">Your work hub</h2>
+      <p className="mt-1 text-sm text-secondary">
+        Everything you are building, in one place. Pick up where you left off.
+      </p>
+      {specsPath && (
+        <a
+          href={specsPath}
+          data-testid="home-value-specs"
+          className="mt-3 inline-flex items-center rounded-lg border border-edge bg-panel px-4 py-2 text-sm font-medium text-heading transition hover:border-accent/50"
+        >
+          Open your Specs board
+        </a>
+      )}
+    </section>
+  );
+}

--- a/packages/ui/src/components/home/YourJourneys.tsx
+++ b/packages/ui/src/components/home/YourJourneys.tsx
@@ -1,0 +1,66 @@
+// spec-312 dec-4 — the "Your Journeys" pearls surface on Home.
+//
+// One row of pearls per journey: green for an earned step, grey for an unearned one.
+// Pearl state is derived entirely from the user's real activity (the journey-state the
+// server returns) — there is no separate stored journey-progress, so the same activity
+// yields the same pearls across reloads and sessions. The surface is the permanent,
+// escapable-but-never-erasable re-entry point: clicking a journey re-opens it.
+//
+// Built for N journeys; v0 ships with one (onboarding). The shape stays multi-row.
+
+export interface JourneyPearl {
+  id: string;
+  label: string;
+  attained: boolean;
+}
+
+export interface PearlJourney {
+  id: string;
+  title: string;
+  steps: JourneyPearl[];
+}
+
+export function YourJourneys({
+  journeys,
+  onOpen,
+}: {
+  journeys: PearlJourney[];
+  // Re-open a journey from its pearls (collapse is escapable; the pearls never vanish).
+  onOpen: (journeyId: string) => void;
+}) {
+  if (journeys.length === 0) return null;
+  return (
+    <section data-testid="your-journeys" className="mx-auto mt-8 w-full max-w-3xl px-4">
+      <h2 className="mb-3 text-xs font-semibold uppercase tracking-wider text-muted">
+        Your journeys
+      </h2>
+      <ul className="flex flex-col gap-2">
+        {journeys.map((j) => (
+          <li key={j.id}>
+            <button
+              type="button"
+              data-testid={`journey-pearls-${j.id}`}
+              onClick={() => onOpen(j.id)}
+              className="flex w-full items-center gap-3 rounded-lg border border-edge bg-panel px-4 py-3 text-left transition hover:border-accent/50"
+            >
+              <span className="flex-none text-sm font-medium text-heading">{j.title}</span>
+              <span className="ml-auto flex items-center gap-1.5" aria-hidden>
+                {j.steps.map((s) => (
+                  <span
+                    key={s.id}
+                    title={s.label}
+                    data-testid={`pearl-${j.id}-${s.id}`}
+                    data-earned={s.attained ? 'true' : 'false'}
+                    className={`h-2.5 w-2.5 flex-none rounded-full ${
+                      s.attained ? 'bg-status-success-text' : 'bg-edge'
+                    }`}
+                  />
+                ))}
+              </span>
+            </button>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/packages/ui/src/journeys/graduation.ts
+++ b/packages/ui/src/journeys/graduation.ts
@@ -1,0 +1,21 @@
+// spec-312 dec-2 — the `graduated` signal seam.
+//
+// Home shows the journey layer EXPANDED while a user has not graduated their journey,
+// and COLLAPSED (to pearls) once they have. The real per-journey graduation predicate
+// is owned by the sibling journey-engine spec (spec-313). Until that lands, this is a
+// deliberate STUB: a journey is "graduated" when every one of its derived steps is
+// attained ("every milestone met").
+//
+// This is the single seam HomeCanvas consumes — when spec-313 ships its predicate,
+// swap the body here and nothing else in the UI changes. It must never decide whether
+// the home-of-value content renders (that is always on the page); it only governs the
+// journey layer's prominence.
+import type { JourneyStateResponse } from '../api/journey';
+
+/** STUB (spec-312): graduated ⇔ every derived step is attained. A state with no steps
+ * yet (still loading, or no journey) is treated as not-graduated so the journey layer
+ * shows by default. */
+export function isJourneyGraduated(state: JourneyStateResponse | null): boolean {
+  if (!state?.steps?.length) return false;
+  return state.steps.every((s) => s.attained);
+}

--- a/packages/ui/src/pages/HomeCanvas.spec-312.test.tsx
+++ b/packages/ui/src/pages/HomeCanvas.spec-312.test.tsx
@@ -1,0 +1,182 @@
+// spec-312 t-2 + t-3 — the layered Home (dec-2) and the "Your Journeys" pearls
+// surface (dec-4).
+//
+//   ac-4  (scope) — graduated user sees the home-of-value surface; not-graduated sees
+//                   the journey layer.
+//   ac-5  (scope) — the "Your Journeys" pearls surface: one row per journey, green/grey
+//                   per step, re-opens the journey when clicked.
+//   ac-11 (impl)  — the home-of-value surface renders for every user regardless of
+//                   graduation.
+//   ac-12 (impl)  — not graduated → journey layer expanded; graduated → collapsed; both
+//                   render home content.
+//   ac-13 (impl)  — graduated (via the stub seam) governs only the journey layer, never
+//                   whether the home content renders.
+//   ac-16 (impl)  — one pearl row per journey from the registry.
+//   ac-17 (impl)  — pearls map attained → green, unattained → grey.
+//   ac-18 (impl)  — pearls derive from activity (state.steps); stable across remount.
+//   ac-19 (impl)  — collapse + re-open from the pearls; collapse never erases the row.
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { tagAc } from '@memex-ai-ac/vitest';
+
+const fetchJourneyStateApi = vi.hoisted(() => vi.fn());
+const postJourneyEventApi = vi.hoisted(() => vi.fn());
+
+vi.mock('../api/journey', () => ({
+  fetchJourneyStateApi,
+  postJourneyEventApi,
+}));
+
+vi.mock('../components/AuthContext', () => ({
+  useAuth: () => ({
+    user: { id: 'u-1', name: 'John Doe', email: 'john@example.com' },
+    session: { memberships: [{ slug: 'john', memexSlug: 'personal', kind: 'personal' }] },
+    token: 'fake',
+  }),
+}));
+
+vi.mock('../hooks/useUserChangeStream', () => ({
+  useUserChangeStream: () => undefined,
+}));
+
+import { HomeCanvas } from './HomeCanvas';
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-312/acs/ac-${n}`;
+
+type Step = { id: string; attained: boolean };
+
+function stateFor(currentStepId: string, steps: Step[], over: Record<string, unknown> = {}) {
+  return {
+    milestones: {
+      identityConfirmed: false,
+      mcpConnected: false,
+      mcpToolCalled: false,
+      hasSpec: false,
+      hasResolvedDecision: false,
+      hasAc: false,
+      acVerified: false,
+    },
+    currentStepId,
+    steps,
+    preview: false,
+    canPreview: false,
+    ...over,
+  };
+}
+
+const MIXED: Step[] = [
+  { id: 'connect-agent', attained: true },
+  { id: 'create-spec', attained: false },
+  { id: 'see-green', attained: false },
+];
+const ALL_ATTAINED: Step[] = [
+  { id: 'connect-agent', attained: true },
+  { id: 'create-spec', attained: true },
+  { id: 'see-green', attained: true },
+];
+
+function renderCanvas() {
+  return render(
+    <MemoryRouter initialEntries={['/home']}>
+      <HomeCanvas />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  fetchJourneyStateApi.mockReset();
+  postJourneyEventApi.mockReset();
+  postJourneyEventApi.mockResolvedValue(undefined);
+});
+
+describe('spec-312 t-2: layered Home (dec-2)', () => {
+  it('ac-11 / ac-13: the home-of-value surface renders regardless of graduation', async () => {
+    tagAc(AC(11));
+    tagAc(AC(13));
+    // not graduated
+    fetchJourneyStateApi.mockResolvedValue(stateFor('create-spec', MIXED));
+    const { unmount } = renderCanvas();
+    expect(await screen.findByTestId('home-of-value')).toBeInTheDocument();
+    unmount();
+    // graduated (every step attained) — home content still on the page
+    fetchJourneyStateApi.mockResolvedValue(stateFor('all-set', ALL_ATTAINED));
+    renderCanvas();
+    expect(await screen.findByTestId('home-of-value')).toBeInTheDocument();
+  });
+
+  it('ac-4 / ac-12: not graduated → journey layer expanded; graduated → collapsed (both keep home content)', async () => {
+    tagAc(AC(4));
+    tagAc(AC(12));
+    // not graduated → the journey layer is shown
+    fetchJourneyStateApi.mockResolvedValue(stateFor('create-spec', MIXED));
+    const { unmount } = renderCanvas();
+    expect(await screen.findByTestId('journey-layer')).toBeInTheDocument();
+    expect(screen.getByTestId('home-of-value')).toBeInTheDocument();
+    unmount();
+    // graduated → the journey layer recedes (collapsed to pearls); home content prominent
+    fetchJourneyStateApi.mockResolvedValue(stateFor('all-set', ALL_ATTAINED));
+    renderCanvas();
+    expect(await screen.findByTestId('home-of-value')).toBeInTheDocument();
+    expect(screen.getByTestId('your-journeys')).toBeInTheDocument();
+    expect(screen.queryByTestId('journey-layer')).not.toBeInTheDocument();
+  });
+});
+
+describe('spec-312 t-3: "Your Journeys" pearls (dec-4)', () => {
+  it('ac-5 / ac-16: one pearl row per journey, sourced from the registry', async () => {
+    tagAc(AC(5));
+    tagAc(AC(16));
+    fetchJourneyStateApi.mockResolvedValue(stateFor('create-spec', MIXED));
+    renderCanvas();
+    expect(await screen.findByTestId('your-journeys')).toBeInTheDocument();
+    // v0 ships exactly one journey: onboarding (from activeJourney() in the registry).
+    expect(screen.getByTestId('journey-pearls-onboarding')).toBeInTheDocument();
+    expect(screen.getAllByTestId(/^journey-pearls-/)).toHaveLength(1);
+  });
+
+  it('ac-17: pearls map attained → green (earned), unattained → grey', async () => {
+    tagAc(AC(17));
+    fetchJourneyStateApi.mockResolvedValue(stateFor('create-spec', MIXED));
+    renderCanvas();
+    const earned = await screen.findByTestId('pearl-onboarding-connect-agent');
+    const unearned = screen.getByTestId('pearl-onboarding-create-spec');
+    expect(earned.getAttribute('data-earned')).toBe('true');
+    expect(earned.className).toContain('bg-status-success-text');
+    expect(unearned.getAttribute('data-earned')).toBe('false');
+    expect(unearned.className).toContain('bg-edge');
+  });
+
+  it('ac-18: pearls derive from activity (state.steps) and are stable across a remount', async () => {
+    tagAc(AC(18));
+    const read = () =>
+      screen.getAllByTestId(/^pearl-onboarding-/).map((el) => el.getAttribute('data-earned'));
+    fetchJourneyStateApi.mockResolvedValue(stateFor('create-spec', MIXED));
+    const { unmount } = renderCanvas();
+    await screen.findByTestId('your-journeys');
+    const first = read();
+    expect(first).toEqual(['true', 'false', 'false']);
+    unmount();
+    // A reload = a fresh mount against the same server activity → identical pearls.
+    fetchJourneyStateApi.mockResolvedValue(stateFor('create-spec', MIXED));
+    renderCanvas();
+    await screen.findByTestId('your-journeys');
+    expect(read()).toEqual(first);
+  });
+
+  it('ac-19: collapse, then re-open from the pearls; the row is never erased', async () => {
+    tagAc(AC(19));
+    fetchJourneyStateApi.mockResolvedValue(stateFor('create-spec', MIXED));
+    renderCanvas();
+    // Expanded by default (not graduated).
+    expect(await screen.findByTestId('journey-layer')).toBeInTheDocument();
+    expect(screen.getByTestId('your-journeys')).toBeInTheDocument();
+    // Collapse → the layer goes, the pearls remain (escapable, never erasable).
+    fireEvent.click(screen.getByTestId('journey-collapse'));
+    await waitFor(() => expect(screen.queryByTestId('journey-layer')).not.toBeInTheDocument());
+    expect(screen.getByTestId('your-journeys')).toBeInTheDocument();
+    // Re-open from the pearls.
+    fireEvent.click(screen.getByTestId('journey-pearls-onboarding'));
+    expect(await screen.findByTestId('journey-layer')).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/pages/HomeCanvas.tsx
+++ b/packages/ui/src/pages/HomeCanvas.tsx
@@ -12,6 +12,9 @@ import {
   type JourneyStateResponse,
 } from '../api/journey';
 import { resolveStepView, activeJourney } from '../journeys/registry';
+import { isJourneyGraduated } from '../journeys/graduation';
+import { YourJourneys, type PearlJourney } from '../components/home/YourJourneys';
+import { HomeValue } from '../components/home/HomeValue';
 import { JourneyStepShell } from '../components/home/JourneyStepShell';
 import { IdentityStep } from '../components/home/IdentityStep';
 import { ConnectAgentStep } from '../components/home/ConnectAgentStep';
@@ -144,6 +147,33 @@ export function HomeCanvas() {
     displayStepId !== 'welcome' &&
     journey.milestoneStepIds.includes(displayStepId);
 
+  // spec-312 dec-2: Home is LAYERED. The journey is a layer that recedes as the user
+  // progresses — expanded while not graduated, collapsed (to pearls) once graduated.
+  // `graduated` is consumed only through this seam (isJourneyGraduated) and never
+  // decides whether the home-of-value content renders; that is always the page.
+  const graduated = isJourneyGraduated(state);
+  // Collapse defaults to the graduated signal but is user-overridable — collapsing is
+  // escapable (the pearls re-open it) and never erases the journey (dec-4).
+  const [collapsedOverride, setCollapsedOverride] = useState<boolean | null>(null);
+  const collapsed = collapsedOverride ?? graduated;
+
+  // spec-312 dec-4: one pearl row per journey, derived from real activity (state.steps).
+  // Built for N journeys; v0 ships with the single active journey.
+  const pearlJourneys: PearlJourney[] = useMemo(() => {
+    if (!state?.steps?.length) return [];
+    return [
+      {
+        id: journey.id,
+        title: 'Getting started',
+        steps: state.steps.map((s) => ({
+          id: s.id,
+          label: journey.views[s.id]?.mapLabel ?? s.id,
+          attained: s.attained,
+        })),
+      },
+    ];
+  }, [state, journey]);
+
   return (
     <div className="min-h-full" data-testid="home-canvas">
       {state?.canPreview && (
@@ -152,10 +182,38 @@ export function HomeCanvas() {
           onPick={(id) => setSearchParams(id ? { preview: id } : {})}
         />
       )}
-      {showMap && state?.steps && (
-        <ProgressMap steps={state.steps} currentStepId={displayStepId} views={journey.views} />
+
+      {/* dec-4: the persistent, escapable-but-never-erasable re-entry point. */}
+      <YourJourneys journeys={pearlJourneys} onOpen={() => setCollapsedOverride(false)} />
+
+      {/* dec-2: the journey LAYER — shown expanded while not collapsed. Collapsing it
+          (or being graduated) leaves the pearls above and the home-of-value below. */}
+      {!collapsed && (
+        <section data-testid="journey-layer" className="relative">
+          <div className="mx-auto flex max-w-3xl justify-end px-4 pt-4">
+            <button
+              type="button"
+              data-testid="journey-collapse"
+              onClick={() => setCollapsedOverride(true)}
+              className="text-xs font-medium text-muted hover:text-secondary"
+            >
+              Collapse
+            </button>
+          </div>
+          {showMap && state?.steps && (
+            <ProgressMap steps={state.steps} currentStepId={displayStepId} views={journey.views} />
+          )}
+          {renderJourneyStep()}
+        </section>
       )}
-      {displayStepId === 'welcome' ? (
+
+      {/* dec-2: the home-of-value surface is ALWAYS the page, under the journey layer. */}
+      <HomeValue specsPath={specsPath} />
+    </div>
+  );
+
+  function renderJourneyStep() {
+    return displayStepId === 'welcome' ? (
         // spec-305 — the welcome card; "Why Memex?" grows it in place into a short lesson.
         <WelcomeStep onNavigate={(t) => setViewOverride(t)} />
       ) : displayStepId === 'identity' ? (
@@ -198,9 +256,8 @@ export function HomeCanvas() {
         <JourneyStepShell view={view} userName={firstName(user?.name)} onCta={handleCta} />
       ) : (
         <div className="flex min-h-[70vh] items-center justify-center text-muted">Loading…</div>
-      )}
-    </div>
-  );
+      );
+  }
 }
 
 // Attainment-framed progress map (dec-1, per-journey). Shows every milestone step

--- a/packages/ui/src/pages/MagicLinkConsume.tsx
+++ b/packages/ui/src/pages/MagicLinkConsume.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import { useAuth, computeDefaultLanding } from '../components/AuthContext';
+import { isFeatureHidden } from '../utils/featureFlags';
 import { magicLinkConsumeApi, AuthApiError } from '../api/client';
 import { Spinner } from '../components/Spinner';
 
@@ -32,7 +33,11 @@ export function MagicLinkConsume() {
       .then((session) => {
         acceptSession(session);
         setStage('success');
-        const landing = computeDefaultLanding(session) ?? '/login';
+        // spec-312 dec-1: land on /home (the universal landing); fall back to the
+        // default tenant only when 'home' is hidden per-env.
+        const landing = isFeatureHidden(session, 'home')
+          ? (computeDefaultLanding(session) ?? '/login')
+          : '/home';
         window.setTimeout(() => {
           window.location.href = landing;
         }, 400);

--- a/packages/ui/src/pages/ResetPassword.tsx
+++ b/packages/ui/src/pages/ResetPassword.tsx
@@ -1,6 +1,7 @@
 import { useState, type FormEvent } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import { useAuth, computeDefaultLanding } from '../components/AuthContext';
+import { isFeatureHidden } from '../utils/featureFlags';
 import { passwordResetConfirmApi, AuthApiError } from '../api/client';
 import { Input } from '../components/ui/Input';
 import { Logo } from '../components/Logo';
@@ -35,7 +36,11 @@ export function ResetPassword() {
       const session = await passwordResetConfirmApi(token, password);
       acceptSession(session);
       setDone(true);
-      const landing = computeDefaultLanding(session) ?? '/login';
+      // spec-312 dec-1: land on /home (the universal landing); fall back to the default
+      // tenant only when 'home' is hidden per-env.
+      const landing = isFeatureHidden(session, 'home')
+        ? (computeDefaultLanding(session) ?? '/login')
+        : '/home';
       window.setTimeout(() => {
         window.location.href = landing;
       }, 800);

--- a/packages/ui/src/pages/VerifyEmail.tsx
+++ b/packages/ui/src/pages/VerifyEmail.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import { useAuth, computeDefaultLanding } from '../components/AuthContext';
+import { isFeatureHidden } from '../utils/featureFlags';
 import { Logo } from '../components/Logo';
 import { verifyEmailApi, AuthApiError } from '../api/client';
 import { Spinner } from '../components/Spinner';
@@ -44,10 +45,15 @@ export function VerifyEmail() {
   }, [token, acceptSession]);
 
   if (stage === 'success') {
-    // After verification the session is set client-side; compute the user's
-    // home (`/<ns>/<mx>/specs`) so the Continue button skips the apex `/`
-    // (which 301s to www.memex.ai marketing per b-9 dec-2).
-    const landing = session ? computeDefaultLanding(session) : null;
+    // After verification the session is set client-side; the Continue button lands the
+    // user on /home — the universal landing (spec-312 dec-1) — skipping the apex `/`
+    // (which 301s to www.memex.ai marketing per b-9 dec-2). Fall back to the default
+    // tenant only when 'home' is hidden per-env (mirrors RootRedirect's loop-avoidance).
+    const landing = session
+      ? isFeatureHidden(session, 'home')
+        ? computeDefaultLanding(session)
+        : '/home'
+      : null;
     return <VerifySuccess email={session?.user.email} landing={landing} />;
   }
 


### PR DESCRIPTION
## Spec
[spec-312 — Everyone lands on Home, and Home graduates with the user](https://memex.ai/mindset-prod/memex-building-itself/specs/spec-312)

Makes `/home` the **universal landing** for every authenticated user, removes the onboarding **wall**, and makes Home **layered**: a persistent home-of-value surface with the onboarding journey as a recede-able layer on top. Adds a persistent **"Your Journeys"** pearls surface. UI-only change.

## What changed

**Routing (dec-1 / dec-3)** — every authenticated, email-verified user lands on `/home`:
- All four generic post-auth landing sites now go to `/home` (falling back to the default-tenant Specs board only when the `home` feature is hidden per-env): `RootRedirect`, `AuthContext.acceptSession`, `VerifyEmail`, `ResetPassword`, `MagicLinkConsume`.
- The three `needsOnboarding` routing reads in `App.tsx` (172/348/536 — force-route, bounce-back, tenant gate) are removed. No routing path reads `needsOnboarding` / `identityConfirmedAt`.
- The email-verification gate is untouched.

**Layered Home (dec-2)** — `HomeCanvas` always renders the home-of-value surface; the journey layer expands/collapses on a `graduated` signal consumed via a single stub seam (`journeys/graduation.ts`, swapped for sibling **spec-313**'s real predicate later). `graduated` never gates whether home content renders.

**Your Journeys (dec-4)** — a persistent, multi-journey-ready pearls surface derived from `/api/me/journey-state` (green = earned, grey = unearned), escapable but never erasable.

## Acceptance criteria
All **19 ACs verified (100%)** in Memex (6 scope + 13 implementation), tagged across unit + e2e tests.

## Test plan
- [x] New unit tests: `App.spec-312.test.tsx`, `HomeCanvas.spec-312.test.tsx`
- [x] New PR-gate Playwright journey: `journey-35-spec-312-home-landing.spec.ts` (caught a real AuthContext+VerifyEmail landing bug the mocked unit tests missed)
- [x] Updated catch-all landing assertions (`App.spec-146/148/260`, `App.onboarding-home-gate`) and e2e journeys that used `/` as a Specs-board shortcut (new `gotoSpecsBoard()` helper)
- [x] Full UI unit suite green (1379 passed, 1 skipped)
- [x] UI typecheck clean
- [x] `make e2e-cold` green (77 passed)
- [x] Server suite: unchanged from develop (UI-only diff); local failures were DB-state pollution, green on a clean DB

## Deploy note
The universal `/home` landing takes effect only where `home` is NOT in that env's `HIDDEN_FEATURES`; where hidden, the loop-avoidance fallback keeps users on the default-tenant Specs board.

## Follow-ups
- Graduated home-of-value content design is intentionally minimal here (separate, later work).
- `graduated` is stubbed until spec-313 lands its predicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)