### PR TITLE
spec-306: attribute back-end outcome events to their document (doc_id/doc_type)

### DIFF
--- a/packages/server/src/services/conversations.ts
+++ b/packages/server/src/services/conversations.ts
@@ -5,19 +5,24 @@ import type { Conversation, Message } from "../db/schema.js";
 import { NotFoundError } from "../types/errors.js";
 import { mutate, type Mutated, type RequestCtx } from "./mutate.js";
 import { nextSeq } from "./shared/sequence.js";
+import { docAttribution } from "./shared/doc-attribution.js";
 import { bus, type ChangeAction, type ChangeEntity } from "./bus.js";
 
-// Resolve the memexId for a conversation by joining through its parent doc.
-// Cached at call-time; conversation FK to doc is immutable so this is safe to
-// memoise per-request but we keep it simple here.
-async function memexIdForConversation(conversationId: string): Promise<string | null> {
+// Resolve a conversation's doc scope (memexId + parent doc id/type) by joining
+// through its parent doc. conversation FK to doc is immutable so this is safe to
+// memoise per-request but we keep it simple here. spec-306: docId/docType are
+// returned so the conversation_message.created outcome can be attributed to its
+// Spec (the bus key itself omits docId — the chat consumer filters by memexId).
+async function docScopeForConversation(
+  conversationId: string,
+): Promise<{ memexId: string; docId: string; docType: string } | null> {
   const [row] = await db
-    .select({ memexId: documents.memexId })
+    .select({ memexId: documents.memexId, docId: documents.id, docType: documents.docType })
     .from(conversations)
     .innerJoin(documents, eq(conversations.docId, documents.id))
     .where(eq(conversations.id, conversationId))
     .limit(1);
-  return row?.memexId ?? null;
+  return row ?? null;
 }
 
 // Conversations inherit account scope from their doc. Service verifies doc → account
@@ -88,17 +93,19 @@ export async function appendMessage(
   content: unknown
 ): Promise<Mutated<Message>> {
   const seq = await nextSeq(messages, messages.seq, messages.conversationId, conversationId);
-  const memexId = await memexIdForConversation(conversationId);
+  const scope = await docScopeForConversation(conversationId);
 
   // Each persisted message fires `conversation_message.created` on the bus so
   // cross-tab chat subscribers (Wave 2) refetch the conversation. The bus key
-  // omits `docId` intentionally — the chat consumer filters by memexId only.
+  // omits `docId` intentionally — the chat consumer filters by memexId only —
+  // but spec-306 attributes the outcome to its Spec via the payload.
   return mutate(
     {},
     {
-      memexId: memexId ?? "",
+      memexId: scope?.memexId ?? "",
       entity: "conversation_message",
       action: "created",
+      ...(scope ? { payload: docAttribution(scope.docId, scope.docType) } : {}),
     },
     async () => {
       const [message] = await db
@@ -110,7 +117,7 @@ export async function appendMessage(
     // Skip emit if we couldn't resolve memexId — this only happens if the
     // conversation row was deleted in a race; the write below would FK-fail
     // anyway, so the silent path here is harmless.
-    memexId ? undefined : { silent: true },
+    scope ? undefined : { silent: true },
   );
 }
 
@@ -127,14 +134,15 @@ export async function replaceMessages(
   msgs: ReadonlyArray<{ role: string; content: unknown }>,
   ctx: RequestCtx = {},
 ): Promise<Mutated<number>> {
-  const memexId = await memexIdForConversation(conversationId);
+  const scope = await docScopeForConversation(conversationId);
 
   return mutate(
     ctx,
     {
-      memexId: memexId ?? "",
+      memexId: scope?.memexId ?? "",
       entity: "conversation_message",
       action: "created",
+      ...(scope ? { payload: docAttribution(scope.docId, scope.docType) } : {}),
     },
     async () => {
       await db.delete(messages).where(eq(messages.conversationId, conversationId));
@@ -150,19 +158,21 @@ export async function replaceMessages(
     },
     // Skip emit if we couldn't resolve memexId — same race rationale as
     // appendMessage: the FK insert below would fail anyway.
-    memexId ? undefined : { silent: true },
+    scope ? undefined : { silent: true },
   );
 }
 
 export async function clearConversation(
   conversationId: string
 ): Promise<Mutated<void>> {
-  const memexId = await memexIdForConversation(conversationId);
+  const scope = await docScopeForConversation(conversationId);
 
   return mutate(
     {},
     {
-      memexId: memexId ?? "",
+      // conversation_message.deleted is not a whitelisted outcome (spec-306), so
+      // no doc attribution is added here — only memexId is needed for the bus.
+      memexId: scope?.memexId ?? "",
       entity: "conversation_message",
       action: "deleted",
     },
@@ -176,7 +186,7 @@ export async function clearConversation(
         .set({ updatedAt: new Date() })
         .where(eq(conversations.id, conversationId));
     },
-    memexId ? undefined : { silent: true },
+    scope ? undefined : { silent: true },
   );
 }
 

--- a/packages/server/src/services/decisions.ts
+++ b/packages/server/src/services/decisions.ts
@@ -7,6 +7,7 @@ import { mutate, type Mutated, type RequestCtx } from "./mutate.js";
 import { resolveActorColumns } from "./actor.js";
 import { nextSeq, withSeqRetry } from "./shared/sequence.js";
 import { isUuid, parseHandle } from "./shared/identifiers.js";
+import { docAttribution } from "./shared/doc-attribution.js";
 import { embedAndStoreDecision } from "./memex-embeddings.js";
 
 // Fire-and-forget embed for a decision whose searchable text just changed.
@@ -724,6 +725,14 @@ export async function resolveDecision(
 
   const now = new Date();
 
+  // spec-306 dec-2: attribute the decision.resolved outcome to its parent Spec.
+  // resolveDecision only loads the decision row, so look up the parent doc's type
+  // (one small read on this rare path; dec-3 forbade a lookup only in the hot sink).
+  const parentDoc = await db.query.documents.findFirst({
+    columns: { docType: true },
+    where: and(eq(documents.id, decision.docId), eq(documents.memexId, memexId)),
+  });
+
   // The cascading docComments update is treated as part of the decision-resolution
   // logical action (not an independent invariant per dec-2): downstream subscribers
   // refetch the whole doc on the decision event, which pulls the new comment state too.
@@ -737,7 +746,13 @@ export async function resolveDecision(
       // activation funnel has an unambiguous "decision resolved" step. Only
       // 'decision.resolved' is whitelisted into usage_events; 'updated' (shared by
       // many decision mutations) stays bus-only.
-      { memexId, docId: decision.docId, entity: "decision", action: "resolved" },
+      {
+        memexId,
+        docId: decision.docId,
+        entity: "decision",
+        action: "resolved",
+        ...(parentDoc ? { payload: docAttribution(decision.docId, parentDoc.docType) } : {}),
+      },
     ],
     async () => {
       const [row] = await db

--- a/packages/server/src/services/doc-attribution.test.ts
+++ b/packages/server/src/services/doc-attribution.test.ts
@@ -1,0 +1,58 @@
+// spec-306 — unit coverage for the document-attribution prop shape and its
+// behaviour through the shared sanitiser. No DB: pure shape + sanitiser checks.
+//
+//  - ac-1/ac-2/ac-3 (scope): the props are an opaque UUID + doc_type enum, no
+//    handle / slug / ref, and survive sanitizeUsageProps unchanged.
+//  - ac-7 (impl): no handle / namespace / slug / qualified ref in the props.
+//  - ac-8 / ac-11 (impl): doc_id (UUID) and doc_type (enum) pass
+//    sanitizeUsageProps unchanged.
+
+import { describe, it, expect } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { sanitizeUsageProps } from "@memex/shared";
+import { docAttribution } from "./shared/doc-attribution.js";
+
+const AC = "mindset-prod/memex-building-itself/specs/spec-306/acs";
+
+const UUID = "3f1a2b3c-4d5e-6f70-8190-a1b2c3d4e5f6";
+
+describe("docAttribution — shape (spec-306 dec-1)", () => {
+  it("emits exactly { doc_id, doc_type } — UUID + enum, nothing else", () => {
+    tagAc(`${AC}/ac-7`);
+    const props = docAttribution(UUID, "spec");
+    expect(Object.keys(props).sort()).toEqual(["doc_id", "doc_type"]);
+    expect(props.doc_id).toBe(UUID);
+    expect(props.doc_type).toBe("spec");
+  });
+
+  it("carries no human handle, namespace, Memex slug, or qualified ref", () => {
+    tagAc(`${AC}/ac-7`);
+    tagAc(`${AC}/ac-2`); // scope: props obey the std-35 privacy rule (IDs/enums only, no titles/content/PII)
+    const props = docAttribution(UUID, "standard");
+    for (const v of Object.values(props)) {
+      const s = String(v);
+      expect(s).not.toMatch(/^[a-z]+-\d+$/i); // not a handle like spec-42
+      expect(s).not.toContain("/"); // not a slug / qualified ref
+    }
+  });
+});
+
+describe("docAttribution — survives sanitizeUsageProps (spec-306 ac-8/ac-11)", () => {
+  it("doc_id (UUID) and doc_type (enum) pass the sanitiser unchanged", () => {
+    tagAc(`${AC}/ac-8`);
+    tagAc(`${AC}/ac-11`);
+    const out = sanitizeUsageProps(docAttribution(UUID, "spec"));
+    expect(out).toEqual({ doc_id: UUID, doc_type: "spec" });
+  });
+
+  it("merges cleanly with sibling props (e.g. {from,to}, {spec_index})", () => {
+    tagAc(`${AC}/ac-11`);
+    const merged = { from: "draft", to: "specify", ...docAttribution(UUID, "spec") };
+    expect(sanitizeUsageProps(merged)).toEqual({
+      from: "draft",
+      to: "specify",
+      doc_id: UUID,
+      doc_type: "spec",
+    });
+  });
+});

--- a/packages/server/src/services/doc-events.integration.test.ts
+++ b/packages/server/src/services/doc-events.integration.test.ts
@@ -89,7 +89,8 @@ describe("document service events (via bus)", () => {
       entity: "document",
       action: "status_changed",
       narrative: expect.stringContaining("draft → review"),
-      payload: { from: "draft", to: "review" },
+      // spec-306: doc attribution rides alongside the {from,to} payload.
+      payload: { from: "draft", to: "review", doc_id: doc.id, doc_type: "spec" },
     });
   });
 });
@@ -228,6 +229,8 @@ describe("decision service events (via bus)", () => {
       entity: "decision",
       action: "resolved",
       narrative: expect.any(String),
+      // spec-306: decision.resolved attributes its parent Spec.
+      payload: { doc_id: docId, doc_type: "spec" },
     });
   });
 
@@ -271,6 +274,8 @@ describe("task service events (via bus)", () => {
       entity: "task",
       action: "created",
       narrative: expect.any(String),
+      // spec-306: task.created attributes its parent Spec.
+      payload: { doc_id: docId, doc_type: "spec" },
     });
   });
 

--- a/packages/server/src/services/documents.status-changed.spec-179.test.ts
+++ b/packages/server/src/services/documents.status-changed.spec-179.test.ts
@@ -108,7 +108,13 @@ describe("updateDocStatus — document/status_changed emission (spec-179 ac-5)",
     );
     const statusRows = rows.filter((r) => r.action === "status_changed");
     expect(statusRows).toHaveLength(1);
-    expect(statusRows[0].payload).toEqual({ from: "specify", to: "build" });
+    // spec-306: status_changed now also carries doc attribution alongside {from,to}.
+    expect(statusRows[0].payload).toEqual({
+      from: "specify",
+      to: "build",
+      doc_id: spec.id,
+      doc_type: "spec",
+    });
     expect(rows.filter((r) => r.action === "updated")).toHaveLength(1);
   });
 

--- a/packages/server/src/services/documents.ts
+++ b/packages/server/src/services/documents.ts
@@ -8,6 +8,7 @@ import { mutate, type ChangeKey, type Mutated, type RequestCtx } from "./mutate.
 import { resolveActorColumns } from "./actor.js";
 import { isUuid } from "./shared/identifiers.js";
 import { withSeqRetry } from "./shared/sequence.js";
+import { docAttribution } from "./shared/doc-attribution.js";
 import { embedAndStoreSection, embedAndStoreDecision } from "./memex-embeddings.js";
 import { aggregateAcHealthForBriefs } from "./acs.js";
 import { maybeAutoResolveIssuesForPromotedDoc } from "./issues.js";
@@ -154,7 +155,12 @@ export async function createDocDraft(
       docId: created.id,
       entity: "document",
       action: "created",
-      ...(specIndex !== undefined ? { payload: { spec_index: specIndex } } : {}),
+      // spec-306 dec-2: document.created attributes the NEW document itself
+      // (doc_id/doc_type), merged with the spec-297 funnel-depth prop.
+      payload: {
+        ...docAttribution(created.id, created.docType),
+        ...(specIndex !== undefined ? { spec_index: specIndex } : {}),
+      },
     }),
     async () => {
       // spec-187 (b-38 F-3 finally reaching documents): the handle mint is a
@@ -932,7 +938,8 @@ export async function updateDocStatus(
       entity: "document",
       action: "status_changed",
       narrative: opts.narrative ?? `moved ${doc.handle} ${doc.status} → ${status}`,
-      payload: { from: doc.status, to: status },
+      // spec-306 dec-2: attribute the phase flip to the Spec, alongside {from,to}.
+      payload: { from: doc.status, to: status, ...docAttribution(id, doc.docType) },
     });
   }
 

--- a/packages/server/src/services/event-doc-attribution.integration.test.ts
+++ b/packages/server/src/services/event-doc-attribution.integration.test.ts
@@ -1,0 +1,184 @@
+// spec-306 — document attribution on back-end outcome events, end to end.
+// REAL Postgres + REAL bus + the back-end usage sink + the activity-log sink.
+//
+// Exercises each of the five whitelisted outcomes through its real service and
+// asserts the resulting usage_events.props (and the activity_log payload) carry
+// { doc_id, doc_type } — the opaque UUID + enum, no handle/slug.
+//
+//  - ac-6  : a forwarded/persisted event row carries doc_id + doc_type.
+//  - ac-7  : no handle / namespace / slug / qualified ref in the props.
+//  - ac-9  : the 4 doc-child events attribute their PARENT Spec (event.docId).
+//  - ac-10 : document.created attributes the new document itself.
+//  - ac-12 : the same payload lands on the activity_log row for these events.
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { and, eq } from "drizzle-orm";
+import { db } from "../db/connection.js";
+import { usageEvents, activityLog } from "../db/schema.js";
+import { makeTestMemex } from "./test-helpers.js";
+import { upsertUserByEmail } from "./users.js";
+import { createDocDraft, updateDocStatus } from "./documents.js";
+import { createTask } from "./tasks.js";
+import { createDecision, resolveDecision } from "./decisions.js";
+import { getOrCreateConversation, appendMessage } from "./conversations.js";
+import { startUsageBackendSink, _stopUsageBackendSink } from "./usage-backend-sink.js";
+import { startActivityLogSink, _stopActivityLogSink } from "./activity-log.js";
+
+const AC = "mindset-prod/memex-building-itself/specs/spec-306/acs";
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+let memexId: string;
+let userId: string;
+
+beforeAll(async () => {
+  memexId = await makeTestMemex("docattr");
+  const u = await upsertUserByEmail(`docattr-${Date.now()}@example.com`);
+  userId = u.id;
+  startUsageBackendSink();
+  startActivityLogSink();
+});
+
+afterAll(async () => {
+  _stopUsageBackendSink();
+  _stopActivityLogSink();
+  await db.delete(usageEvents).where(eq(usageEvents.memexId, memexId));
+});
+
+// usage_events rows are written ASYNCHRONOUSLY by the bus sink — poll until the
+// row whose props.doc_id matches the doc we acted on has landed.
+async function waitForRow(
+  name: string,
+  docId: string,
+  timeoutMs = 2000,
+): Promise<Record<string, unknown> | undefined> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const rows = await db
+      .select()
+      .from(usageEvents)
+      .where(and(eq(usageEvents.memexId, memexId), eq(usageEvents.name, name)));
+    const hit = rows.find(
+      (r) => r.props && (r.props as Record<string, unknown>).doc_id === docId,
+    );
+    if (hit) return hit.props as Record<string, unknown>;
+    await new Promise((r) => setTimeout(r, 25));
+  }
+  return undefined;
+}
+
+// Every attribution prop must be an opaque id/enum — never a handle or slug (ac-7).
+function expectNoLeak(props: Record<string, unknown>): void {
+  expect(props.doc_id).toMatch(UUID_RE);
+  for (const v of Object.values(props)) {
+    const s = String(v);
+    expect(s).not.toMatch(/^[a-z]+-\d+$/i); // no handle like spec-42
+    expect(s).not.toContain("/"); // no namespace / Memex slug / qualified ref
+  }
+}
+
+describe("doc-child outcome events attribute their parent Spec (spec-306 ac-9/ac-6)", () => {
+  it("task.created carries the parent Spec's doc_id + doc_type", async () => {
+    tagAc(`${AC}/ac-9`);
+    tagAc(`${AC}/ac-6`);
+    tagAc(`${AC}/ac-7`);
+    // scope ACs this end-to-end check also evidences:
+    tagAc(`${AC}/ac-1`); // task.created carries a property identifying its Spec
+    tagAc(`${AC}/ac-4`); // attribution applied to a doc-child event (consistency)
+    tagAc(`${AC}/ac-5`); // the property lands in usage_events.props → Mixpanel-queryable
+    const doc = await createDocDraft(memexId, "Task parent", "p", "spec", undefined, undefined, userId, { actorUserId: userId, channel: "rest_ui" });
+    await createTask(memexId, doc.id, "T", "do it", undefined, undefined, { actorUserId: userId, channel: "rest_ui" });
+    const props = await waitForRow("task.created", doc.id);
+    expect(props, "task.created usage row with doc_id should land").toBeDefined();
+    expect(props!.doc_id).toBe(doc.id);
+    expect(props!.doc_type).toBe("spec");
+    expectNoLeak(props!);
+  });
+
+  it("decision.resolved carries the parent Spec's doc_id + doc_type", async () => {
+    tagAc(`${AC}/ac-9`);
+    tagAc(`${AC}/ac-6`);
+    const doc = await createDocDraft(memexId, "Decision parent", "p", "spec", undefined, undefined, userId, { actorUserId: userId, channel: "rest_ui" });
+    const dec = await createDecision(memexId, doc.id, "A choice", "ctx", "human", { actorUserId: userId, channel: "rest_ui" });
+    await resolveDecision(memexId, dec.id, "Chose the thing", undefined, { actorUserId: userId, channel: "rest_ui" });
+    const props = await waitForRow("decision.resolved", doc.id);
+    expect(props, "decision.resolved usage row with doc_id should land").toBeDefined();
+    expect(props!.doc_id).toBe(doc.id);
+    expect(props!.doc_type).toBe("spec");
+    expectNoLeak(props!);
+  });
+
+  it("document.status_changed carries doc_id + doc_type alongside {from,to}", async () => {
+    tagAc(`${AC}/ac-9`);
+    tagAc(`${AC}/ac-6`);
+    const doc = await createDocDraft(memexId, "Phase doc", "p", "spec", undefined, undefined, userId, { actorUserId: userId, channel: "rest_ui" });
+    await updateDocStatus(memexId, doc.id, "specify", { ctx: { actorUserId: userId, channel: "rest_ui" } });
+    const props = await waitForRow("document.status_changed", doc.id);
+    expect(props, "document.status_changed usage row with doc_id should land").toBeDefined();
+    expect(props!.doc_id).toBe(doc.id);
+    expect(props!.doc_type).toBe("spec");
+    expect(props!.to).toBe("specify"); // the existing {from,to} payload is preserved
+    expectNoLeak(props!);
+  });
+
+  it("conversation_message.created carries the parent Spec's doc_id + doc_type", async () => {
+    tagAc(`${AC}/ac-9`);
+    tagAc(`${AC}/ac-6`);
+    const doc = await createDocDraft(memexId, "Chat doc", "p", "spec", undefined, undefined, userId, { actorUserId: userId, channel: "rest_ui" });
+    const convo = await getOrCreateConversation(memexId, doc.id, userId);
+    await appendMessage(convo.id, "user", "hello");
+    const props = await waitForRow("conversation_message.created", doc.id);
+    expect(props, "conversation_message.created usage row with doc_id should land").toBeDefined();
+    expect(props!.doc_id).toBe(doc.id);
+    expect(props!.doc_type).toBe("spec");
+    expectNoLeak(props!);
+  });
+});
+
+describe("document.created attributes the new document itself (spec-306 ac-10)", () => {
+  it("carries doc_id = the new document's own id and its doc_type", async () => {
+    tagAc(`${AC}/ac-10`);
+    tagAc(`${AC}/ac-6`);
+    // scope ACs this also evidences:
+    tagAc(`${AC}/ac-3`); // additive — the event still fires, only gains props (no new event name)
+    tagAc(`${AC}/ac-4`); // attribution applied to document.created too (consistency across all in-scope events)
+    const doc = await createDocDraft(memexId, "Self doc", "p", "standard", undefined, undefined, userId, { actorUserId: userId, channel: "rest_ui" });
+    const props = await waitForRow("document.created", doc.id);
+    expect(props, "document.created usage row with its own doc_id should land").toBeDefined();
+    expect(props!.doc_id).toBe(doc.id);
+    expect(props!.doc_type).toBe("standard");
+    expectNoLeak(props!);
+  });
+});
+
+describe("the same attribution lands on the activity_log row (spec-306 ac-12)", () => {
+  it("task.created activity_log payload carries doc_id + doc_type, ID+enum only", async () => {
+    tagAc(`${AC}/ac-12`);
+    const doc = await createDocDraft(memexId, "Activity doc", "p", "spec", undefined, undefined, userId, { actorUserId: userId, channel: "rest_ui" });
+    await createTask(memexId, doc.id, "T2", "do it", undefined, undefined, { actorUserId: userId, channel: "rest_ui" });
+
+    let payload: Record<string, unknown> | undefined;
+    const deadline = Date.now() + 2000;
+    while (Date.now() < deadline) {
+      const rows = await db
+        .select()
+        .from(activityLog)
+        .where(
+          and(
+            eq(activityLog.memexId, memexId),
+            eq(activityLog.entity, "task"),
+            eq(activityLog.action, "created"),
+          ),
+        );
+      payload = rows
+        .map((r) => r.payload as Record<string, unknown> | null)
+        .find((p) => p && p.doc_id === doc.id) as Record<string, unknown> | undefined;
+      if (payload) break;
+      await new Promise((r) => setTimeout(r, 25));
+    }
+    expect(payload, "activity_log row should carry the doc_id payload").toBeDefined();
+    expect(payload!.doc_id).toBe(doc.id);
+    expect(payload!.doc_type).toBe("spec");
+    expectNoLeak(payload!);
+  });
+});

--- a/packages/server/src/services/shared/doc-attribution.ts
+++ b/packages/server/src/services/shared/doc-attribution.ts
@@ -1,0 +1,26 @@
+// Document-attribution props for back-end outcome usage events (spec-306).
+//
+// The whitelisted back-end Mixpanel events (task.created, decision.resolved,
+// document.status_changed, conversation_message.created, document.created) ride
+// the mutate() ChangeEvent.payload into usage_events.props and on to Mixpanel via
+// sanitizeUsageProps (std-35 Recipe B). This helper is the ONE place the property
+// shape lives so the five emit sites and their tests can't drift.
+//
+// dec-1: the identifier is the document's opaque UUID (`documents.id`) plus its
+// doc_type enum — never the human handle, namespace, or Memex slug. That keeps
+// spec-244's privacy posture (memex_id is still not forwarded) while staying
+// globally unique. Both values are scalars that pass sanitizeUsageProps unchanged
+// (UUID < 64 chars and not email-shaped; doc_type is a short enum).
+
+/**
+ * Build the `{ doc_id, doc_type }` attribution props for an outcome event.
+ * `id` is the attributed document's `documents.id`; for the doc-CHILD events
+ * (task / decision / conversation) that is the PARENT Spec, for document.created
+ * it is the new document itself (spec-306 dec-2).
+ *
+ * Returns `Record<string, unknown>` so it drops straight into a ChangeKey's
+ * `payload` (and merges with sibling props like {from,to} or {spec_index}).
+ */
+export function docAttribution(id: string, docType: string): Record<string, unknown> {
+  return { doc_id: id, doc_type: docType };
+}

--- a/packages/server/src/services/tasks.ts
+++ b/packages/server/src/services/tasks.ts
@@ -10,6 +10,7 @@ import { getBlockersForTask, getBlockingGraphForDoc } from "./dependencies.js";
 import type { Blockers } from "./dependencies.js";
 import { nextSeq, withSeqRetry } from "./shared/sequence.js";
 import { isUuid, parseHandle } from "./shared/identifiers.js";
+import { docAttribution } from "./shared/doc-attribution.js";
 import { updateDocStatus } from "./documents.js";
 import { maybeAutoResolveIssuesForTask } from "./issues.js";
 
@@ -35,11 +36,15 @@ export function qualifiedTaskHandle(
   return `${parentDocHandle}:T-${taskSeq}`;
 }
 
-async function assertDocInAccount(memexId: string, docId: string): Promise<void> {
+// Returns the parent doc's type (spec-306) so createTask can attribute the
+// task.created outcome event to its Spec without a second query — this assert
+// already loads the row.
+async function assertDocInAccount(memexId: string, docId: string): Promise<{ docType: string }> {
   const doc = await db.query.documents.findFirst({
     where: and(eq(documents.id, docId), eq(documents.memexId, memexId)),
   });
   if (!doc) throw new NotFoundError(`Document ${docId} not found`);
+  return { docType: doc.docType };
 }
 
 export interface TaskWithBlockers extends Task {
@@ -77,12 +82,13 @@ export async function createTask(
   sectionRef?: string,
   ctx: RequestCtx = {}
 ): Promise<Mutated<Task>> {
-  await assertDocInAccount(memexId, docId);
+  const { docType } = await assertDocInAccount(memexId, docId);
   // b-38 F-3 — wrap allocator + insert in withSeqRetry so concurrent createTask
   // calls under the same doc don't 23505 on `tasks_doc_id_seq_unique`.
   return mutate(
     ctx,
-    { memexId, docId, entity: "task", action: "created" },
+    // spec-306 dec-2: attribute the task.created outcome to its parent Spec.
+    { memexId, docId, entity: "task", action: "created", payload: docAttribution(docId, docType) },
     async () =>
       withSeqRetry(
         async () => {


### PR DESCRIPTION
## What & why

Follow-on to spec-244/297 (governed by std-35): the back-end outcome events reached Mixpanel with no document attribution, so `task.created` told us a task was created but not **which Spec**. This adds `{ doc_id, doc_type }` to the five whitelisted outcome events so the activation funnel can be sliced by document.

Spec: https://memex.ai/mindset-prod/memex-building-itself/specs/spec-306 (Wic-approved; 12/12 ACs verified)

## The change

Attach `{ doc_id, doc_type }` to `ChangeEvent.payload` at the `mutate()` emit sites (dec-3):

| Event | Attributed document |
|---|---|
| `task.created` | parent Spec (`event.docId`) |
| `decision.resolved` | parent Spec |
| `document.status_changed` | parent Spec (alongside the existing `{from,to}`) |
| `conversation_message.created` | parent Spec |
| `document.created` | the new document itself |

- `doc_id` = opaque `documents.id` UUID, `doc_type` = enum (dec-1) — **no handle / namespace / Memex slug**, preserving spec-244's privacy posture (`memex_id` is still not forwarded). Reading "which spec" in Mixpanel is a join back to `documents`.
- **No sink/forwarder/schema change, no migration.** `usage-backend-sink` already runs `sanitizeUsageProps(event.payload)` and `mixpanel-sink` spreads `row.props`, so the props flow end-to-end once on the payload.
- New shared helper `services/shared/doc-attribution.ts` is the single source of the prop shape. `tasks.ts` reuses its existing doc query (no extra round-trip); the conversations helper is broadened to return `docId`/`docType` from the same join; `decisions.ts` does one small parent-doc type lookup on the rare resolve path.

## Testing

- `doc-attribution.test.ts` (unit) — shape + sanitiser pass-through.
- `event-doc-attribution.integration.test.ts` (real Postgres + bus + back-end sink + activity-log sink) — all five events assert `usage_events.props` + `activity_log` payload carry the right `doc_id`/`doc_type`, plus a no-leak guard.
- Updated the existing exact-payload assertions the new props touched (`doc-events.integration.test.ts`, `documents.status-changed.spec-179.test.ts`).
- Full server suite green locally (the only failure is the pre-existing local `spec-199` BYPASSRLS env check, unrelated to this diff). **All 12 spec-306 ACs verified.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)