### PR TITLE
fix(spec-319): reliable highlight-to-comment via document-level selection capture

### DIFF
--- a/packages/ui/e2e/journey-36-spec-319-comment-selection.spec.ts
+++ b/packages/ui/e2e/journey-36-spec-319-comment-selection.spec.ts
@@ -1,0 +1,106 @@
+import { test, expect, tenantPath, emitAcEvents } from "./helpers/index.js";
+import { seedOrgTenant, seedSpec } from "./helpers/retained.js";
+
+// Journey 36 — spec-319 (dec-1): selecting a passage in a spec section must
+// reliably surface the add-comment affordance (the SelectionToolbar), invariant
+// to WHERE the mouse gesture ends.
+//
+// The bug: detection was wired to an element-scoped `onMouseUp` on the section
+// body, so a drag that RELEASES OUTSIDE the body (an everyday overshoot past or
+// below the text) never fired the handler and the toolbar never appeared — while
+// the identical selection released INSIDE the body did show it. That is the
+// "I cannot bank on it" coin-flip. The fix makes detection document-level
+// (selectionchange), so it is independent of the release point.
+//
+// This is the std-28 e2e proof: a real browser selection with a real release
+// point — exactly the DOM/selection coverage gap that mocked jsdom unit tests
+// miss (the unit suite covers the pure offset/range mapping). The control case
+// (release INSIDE) guards against regressing the path that already worked.
+const AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-319/acs/ac-${n}`;
+
+const PASSAGE =
+  "The quick brown fox jumps over the lazy dog while the selection toolbar should appear above this very passage every single time.";
+
+test.afterEach(async ({}, testInfo) => {
+  // ac-1 (reliable on every attempt) + ac-2 (invariant to where the gesture
+  // ends) are both proven by the release-OUTSIDE case; the control case also
+  // backs ac-1 (the working path stays working).
+  await emitAcEvents(
+    [AC(1), AC(2)],
+    testInfo.status === "passed" ? "pass" : "fail",
+    `packages/ui/e2e/journey-36-spec-319-comment-selection.spec.ts::${testInfo.title}`,
+    testInfo.duration,
+  );
+});
+
+/** Open a freshly-seeded one-section spec and return the section body locator. */
+async function openSpecBody(page, resources) {
+  const tenant = await seedOrgTenant({ slug: resources.slug("j36") });
+  const spec = await seedSpec({
+    memexId: tenant.memexId,
+    title: "Comment Selection Spec",
+    purpose: PASSAGE,
+  });
+  await page.goto(
+    tenantPath(tenant.namespaceSlug, tenant.memexSlug, `/specs/${spec.handle}`),
+    { waitUntil: "commit" },
+  );
+  await expect(
+    page.getByRole("heading", { level: 1, name: /Comment Selection Spec/ }),
+  ).toBeVisible({ timeout: 15_000 });
+  const body = page.getByTestId("section-body").first();
+  await expect(body).toBeVisible({ timeout: 15_000 });
+  // The passage must have rendered before we try to select it.
+  await expect(body).toContainText("quick brown fox", { timeout: 15_000 });
+  return body;
+}
+
+/**
+ * Drag-select across the first rendered line of `body`, releasing the mouse at
+ * `release`: "inside" ends the gesture within the body box; "outside" ends it
+ * well below the body box (the overshoot the bug dropped). Asserts a non-empty
+ * selection actually landed, so a geometry miss fails loudly rather than masking
+ * the toolbar assertion.
+ */
+async function dragSelect(page, body, release: "inside" | "outside") {
+  const box = (await body.boundingBox())!;
+  const startX = box.x + 6;
+  const startY = box.y + 8;
+  const endX = box.x + box.width * 0.7;
+  const insideY = box.y + 8;
+  await page.mouse.move(startX, startY);
+  await page.mouse.down();
+  // Extend across the first line.
+  await page.mouse.move(endX, insideY, { steps: 12 });
+  if (release === "outside") {
+    // Keep extending and release BELOW the body's border-box (outside it).
+    await page.mouse.move(endX, box.y + box.height + 60, { steps: 8 });
+  }
+  await page.mouse.up();
+
+  const selected = await page.evaluate(() =>
+    (window.getSelection()?.toString() ?? "").trim(),
+  );
+  expect(selected.length, "a non-empty text selection should have landed").toBeGreaterThan(0);
+}
+
+test("a drag that releases OUTSIDE the section body still surfaces the add-comment toolbar (dec-1)", async ({
+  page,
+  resources,
+}) => {
+  const body = await openSpecBody(page, resources);
+  await dragSelect(page, body, "outside");
+  // The whole point of the fix: release point is irrelevant; the toolbar shows.
+  await expect(page.getByTestId("selection-toolbar")).toBeVisible({ timeout: 5_000 });
+  await expect(page.getByTestId("selection-toolbar-comment")).toBeVisible();
+});
+
+test("a drag that releases INSIDE the section body surfaces the toolbar (regression guard)", async ({
+  page,
+  resources,
+}) => {
+  const body = await openSpecBody(page, resources);
+  await dragSelect(page, body, "inside");
+  await expect(page.getByTestId("selection-toolbar")).toBeVisible({ timeout: 5_000 });
+});

--- a/packages/ui/src/components/SectionCard.tsx
+++ b/packages/ui/src/components/SectionCard.tsx
@@ -9,8 +9,8 @@ import { CommentSourceAvatar } from './CommentSourceAvatar';
 import { rehypeRefLinkifier } from './chat/refLinkifier';
 import { createComment, resolveComment, deleteComment } from '../api/client';
 import { buildCommentLink } from '../utils/commentDeepLink';
-import { renderedOffsetToSource, resolveRenderedOffset } from '../utils/anchorOffset';
 import { buildAnchorRange } from '../utils/anchorHighlight';
+import { computeAnchorFromRange } from '../utils/sectionSelection';
 import { SelectionToolbar } from './SelectionToolbar';
 import { CommentComposerPopover } from './CommentComposerPopover';
 
@@ -112,59 +112,39 @@ export const SectionCard = memo(function SectionCard({
   const [draftText, setDraftText] = useState('');
   const [submitting, setSubmitting] = useState(false);
 
-  const handleSelection = () => {
-    if (!canWrite) return;
-    const sel = window.getSelection();
-    if (!sel || sel.isCollapsed) { setToolbar(null); return; }
-    const text = sel.toString().trim();
-    if (!text) { setToolbar(null); return; }
-    // Only react to selections inside this section's body.
-    if (!bodyRef.current || !sel.anchorNode || !bodyRef.current.contains(sel.anchorNode)) return;
-    const range = sel.getRangeAt(0);
-    // Anchor by POSITION, both ends: flatten the body's rendered text (skipping
-    // marker badges) into one string while recording each text node's start
-    // index, then resolve the selection's start and end boundaries to rendered
-    // offsets and map each to the markdown source. Handles inline formatting +
-    // repeated words unambiguously, and yields a RANGE, not a point.
-    const walker = document.createTreeWalker(bodyRef.current, NodeFilter.SHOW_TEXT, {
-      acceptNode: (n) =>
-        n.parentElement?.closest('[data-marker-seq],[data-marker-start]')
-          ? NodeFilter.FILTER_REJECT
-          : NodeFilter.FILTER_ACCEPT,
-    });
-    let rendered = '';
-    const starts: { node: Node; start: number }[] = [];
-    let wn: Node | null;
-    while ((wn = walker.nextNode())) {
-      starts.push({ node: wn, start: rendered.length });
-      rendered += wn.textContent ?? '';
-    }
-    const renderedStart = resolveRenderedOffset(range.startContainer, range.startOffset, starts, rendered.length);
-    const renderedEnd = resolveRenderedOffset(range.endContainer, range.endOffset, starts, rendered.length);
-    if (renderedStart < 0 || renderedEnd < 0 || renderedEnd <= renderedStart) return;
-    const startSrc = renderedOffsetToSource(section.content, rendered, renderedStart);
-    const endSrc = renderedOffsetToSource(section.content, rendered, renderedEnd);
-    const rect = range.getBoundingClientRect();
-    setToolbar({
-      start: startSrc,
-      end: endSrc,
-      quote: text.slice(0, 60),
-      top: rect.top - 40, // float just above the selection
-      left: rect.left + rect.width / 2,
-    });
-  };
-
-  // Dismiss the toolbar on any click that isn't on it (mirrors Docs).
+  // spec-319 dec-1: detect the comment-anchor selection at the DOCUMENT level so
+  // the affordance is independent of WHERE the gesture ends. The old wiring read
+  // window.getSelection() inside an onMouseUp on the body, so any drag that
+  // released outside the body (an everyday overshoot past/below the text) never
+  // fired the handler — the "can't bank on it" bug. `selectionchange` fires for
+  // every way a selection settles; we coalesce to one read per animation frame,
+  // scope it to THIS section's body by containment, and map it with the shared
+  // pure helper (which reads the normalized Range, so backward selections work
+  // too). A selection that collapses or leaves this body clears the toolbar —
+  // this also subsumes the old mousedown click-outside closer.
   useEffect(() => {
-    if (!toolbar) return;
-    const onDown = (e: MouseEvent) => {
-      if (!(e.target as HTMLElement)?.closest?.('[data-testid="selection-toolbar"]')) {
-        setToolbar(null);
-      }
+    if (!canWrite) return;
+    let raf = 0;
+    const recompute = () => {
+      const body = bodyRef.current;
+      const sel = window.getSelection();
+      if (!body || !sel || sel.isCollapsed || sel.rangeCount === 0) { setToolbar(null); return; }
+      const range = sel.getRangeAt(0);
+      const anchor = computeAnchorFromRange(range, body, section.content);
+      if (!anchor) { setToolbar(null); return; }
+      const rect = range.getBoundingClientRect();
+      setToolbar({ ...anchor, top: rect.top - 40, left: rect.left + rect.width / 2 });
     };
-    document.addEventListener('mousedown', onDown);
-    return () => document.removeEventListener('mousedown', onDown);
-  }, [toolbar]);
+    const onSelectionChange = () => {
+      cancelAnimationFrame(raf);
+      raf = requestAnimationFrame(recompute);
+    };
+    document.addEventListener('selectionchange', onSelectionChange);
+    return () => {
+      cancelAnimationFrame(raf);
+      document.removeEventListener('selectionchange', onSelectionChange);
+    };
+  }, [canWrite, section.content]);
 
   const openComposerFromToolbar = () => {
     if (!toolbar) return;
@@ -414,7 +394,6 @@ export const SectionCard = memo(function SectionCard({
         <div ref={cardRef} className="relative">
           <div
             ref={bodyRef}
-            onMouseUp={handleSelection}
             data-testid="section-body"
             className="min-w-0 pr-8"
           >

--- a/packages/ui/src/utils/sectionSelection.test.ts
+++ b/packages/ui/src/utils/sectionSelection.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { computeAnchorFromRange } from './sectionSelection';
+
+// spec-319 dec-1: the selection→anchor mapping is scoped by CONTAINMENT and reads
+// the normalized Range, so a valid in-body selection always resolves to a source
+// anchor regardless of how the gesture ended. (The release-point invariance
+// itself is proven in the browser by journey-36; here we pin the pure logic.)
+const AC_RELIABLE = 'mindset-prod/memex-building-itself/specs/spec-319/acs/ac-1';
+
+function bodyWith(html: string): HTMLElement {
+  const el = document.createElement('div');
+  el.innerHTML = html;
+  document.body.appendChild(el);
+  return el;
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('computeAnchorFromRange', () => {
+  it('maps an in-body selection to its source offsets (rendered == source)', () => {
+    tagAc(AC_RELIABLE);
+    const source = 'The quick brown fox';
+    const body = bodyWith(`<p>${source}</p>`);
+    const tn = body.querySelector('p')!.firstChild!;
+    const range = document.createRange();
+    range.setStart(tn, 4); // 'q' of quick
+    range.setEnd(tn, 15); // just after 'brown'
+
+    const anchor = computeAnchorFromRange(range, body, source);
+    expect(anchor).not.toBeNull();
+    expect(anchor!.quote).toBe('quick brown');
+    expect(anchor!.start).toBe(4);
+    expect(anchor!.end).toBe(15);
+  });
+
+  it('maps across inline markdown (rendered is a subsequence of source)', () => {
+    tagAc(AC_RELIABLE);
+    // Source carries `**` around "bold"; the rendered text the user selects does
+    // not. The mapping must still land the source offsets on the right chars.
+    const source = 'a **bold** word';
+    const body = bodyWith('<p>a <strong>bold</strong> word</p>');
+    const strongText = body.querySelector('strong')!.firstChild!;
+    const range = document.createRange();
+    range.setStart(strongText, 0); // 'b'
+    range.setEnd(strongText, 4); // after 'bold'
+
+    const anchor = computeAnchorFromRange(range, body, source);
+    expect(anchor).not.toBeNull();
+    expect(anchor!.quote).toBe('bold');
+    // The rendered "bold" maps back onto the source span covering "bold" (the
+    // exact markup-boundary landing — start may sit just before the opening `**`
+    // — is renderedOffsetToSource's existing semantics; the contract here is that
+    // the span is non-empty and contains the selected word).
+    expect(anchor!.start).toBeLessThan(anchor!.end);
+    expect(source.slice(anchor!.start, anchor!.end)).toContain('bold');
+  });
+
+  it('returns null when the selection lives OUTSIDE this body', () => {
+    tagAc(AC_RELIABLE);
+    const body = bodyWith('<p>Inside text</p>');
+    const outside = document.createElement('p');
+    outside.textContent = 'Outside text';
+    document.body.appendChild(outside);
+    const tn = outside.firstChild!;
+    const range = document.createRange();
+    range.setStart(tn, 0);
+    range.setEnd(tn, 7);
+
+    expect(computeAnchorFromRange(range, body, 'Inside text')).toBeNull();
+  });
+
+  it('returns null for a collapsed (empty) selection', () => {
+    tagAc(AC_RELIABLE);
+    const source = 'The quick brown fox';
+    const body = bodyWith(`<p>${source}</p>`);
+    const tn = body.querySelector('p')!.firstChild!;
+    const range = document.createRange();
+    range.setStart(tn, 4);
+    range.setEnd(tn, 4);
+
+    expect(computeAnchorFromRange(range, body, source)).toBeNull();
+  });
+});

--- a/packages/ui/src/utils/sectionSelection.ts
+++ b/packages/ui/src/utils/sectionSelection.ts
@@ -1,0 +1,67 @@
+// spec-319 dec-1: the pure half of detecting a comment-anchor selection inside a
+// section body. Given a live DOM Range, the section's body element, and the
+// markdown source, resolve the selection's two boundaries to SOURCE offsets and
+// return the anchor descriptor — or null when the selection isn't a usable
+// in-body anchor.
+//
+// This is split out of SectionCard so it is unit-testable in jsdom (no rect / no
+// CSS): the WHERE-the-gesture-ends robustness is proven at the e2e tier, while
+// the offset mapping + scoping live here where they can be exercised directly.
+// Only the TRIGGER changed in dec-1 (onMouseUp → document selectionchange); this
+// mapping is the same logic the old handleSelection ran, hardened to read the
+// normalized Range (not sel.anchorNode), so backward selections resolve too.
+
+import { renderedOffsetToSource, resolveRenderedOffset } from './anchorOffset';
+
+export interface SelectionAnchor {
+  /** Source-offset start of the selection (where `[^c-Ns]` will sit). */
+  start: number;
+  /** Source-offset end of the selection (where `[^c-Ne]` will sit). */
+  end: number;
+  /** Short rendered-text preview of the selection (≤60 chars). */
+  quote: string;
+}
+
+/**
+ * Resolve a selection Range to a section-source anchor, or null when it is not a
+ * usable in-body selection (collapsed, empty, outside this body, or a boundary
+ * that maps into stripped marker content).
+ */
+export function computeAnchorFromRange(
+  range: Range,
+  bodyEl: HTMLElement,
+  source: string,
+): SelectionAnchor | null {
+  // Scope by CONTAINMENT, not by where the pointer was released: the selection
+  // must live inside THIS section's body. This is what makes detection
+  // independent of the gesture's end point (dec-1).
+  if (!bodyEl.contains(range.commonAncestorContainer)) return null;
+
+  const quote = range.toString().trim();
+  if (!quote) return null;
+
+  // Flatten the body's rendered text (skipping marker badges) into one string,
+  // recording each text node's cumulative start index, then map the Range's
+  // start and end boundaries to rendered offsets and on into the markdown source.
+  const walker = document.createTreeWalker(bodyEl, NodeFilter.SHOW_TEXT, {
+    acceptNode: (n) =>
+      n.parentElement?.closest('[data-marker-seq],[data-marker-start]')
+        ? NodeFilter.FILTER_REJECT
+        : NodeFilter.FILTER_ACCEPT,
+  });
+  let rendered = '';
+  const starts: { node: Node; start: number }[] = [];
+  let wn: Node | null;
+  while ((wn = walker.nextNode())) {
+    starts.push({ node: wn, start: rendered.length });
+    rendered += wn.textContent ?? '';
+  }
+
+  const renderedStart = resolveRenderedOffset(range.startContainer, range.startOffset, starts, rendered.length);
+  const renderedEnd = resolveRenderedOffset(range.endContainer, range.endOffset, starts, rendered.length);
+  if (renderedStart < 0 || renderedEnd < 0 || renderedEnd <= renderedStart) return null;
+
+  const start = renderedOffsetToSource(source, rendered, renderedStart);
+  const end = renderedOffsetToSource(source, rendered, renderedEnd);
+  return { start, end, quote: quote.slice(0, 60) };
+}


### PR DESCRIPTION
## What & why

spec-319 symptom 1: selecting a passage in a spec section must reliably surface the **add-comment toolbar**. Today it's a coin-flip — Wic: *"currently I cannot bank on it."*

**Root cause (grounded in source).** Detection was wired to an element-scoped `onMouseUp` on the section body (`SectionCard.tsx`), reading `window.getSelection()`. `onMouseUp` fires only when the pointer is released **over the body element**, so any drag that releases *outside* it — an everyday overshoot past or below the text — never fired the handler and the toolbar never appeared. When the gesture happened to end inside the body it worked, hence "sometimes."

**Premise correction.** dec-1 originally blamed an "edit (contenteditable) vs review mode" difference. That was a once-seen, unreplicable hunch: there is **no contenteditable section editor** — both editor and reviewer postures render the identical `SectionCard` via the identical selection path. The spec narrative, dec-1, and ac-2 were corrected to the real axis (gesture type + release location). See [spec-319](https://memex.ai/mindset-prod/memex-building-itself/specs/spec-319).

## The fix

Replace the element-scoped `onMouseUp` with a **document-level `selectionchange`** detector:
- coalesced per animation frame,
- scoped to this section's body by **containment** (`commonAncestorContainer`), not by where the pointer was released,
- reading the **normalized Range** (so backward / right-to-left selections resolve too).

A collapsed or out-of-body selection clears the toolbar, which subsumes the old mousedown click-outside closer. The pure offset→source mapping is extracted to [`utils/sectionSelection.ts`](packages/ui/src/utils/sectionSelection.ts) (`computeAnchorFromRange`) so it's unit-testable in jsdom. **Only the trigger changed** — the `[^c-Ns]…[^c-Ne]` anchor model (spec-100 dec-1/dec-6) is untouched.

## Tests (TDD: RED → GREEN)

- **e2e** [`journey-36-spec-319-comment-selection`](packages/ui/e2e/journey-36-spec-319-comment-selection.spec.ts): a real browser drag that **releases OUTSIDE the body** surfaces the toolbar (was RED on `develop`, now GREEN) + a **release-INSIDE regression guard**. This is the std-28 tier where the DOM/selection coverage gap actually lives — mocked jsdom unit tests can't see it.
- **unit** [`sectionSelection.test.ts`](packages/ui/src/utils/sectionSelection.test.ts): containment scoping + offset mapping (inline markdown, outside-body, collapsed).

Tagged to **spec-319 ac-1** (reliable on every attempt) and **ac-2** (invariant to where the gesture ends).

## Verification (local, before push)

- UI suite: **1398 passed**, 1 skipped
- `pnpm build` (CI tsc+vite gate): **green**
- Full server suite (clean run): **green**
- `make e2e-cold` (full CI-parity e2e): **79 passed**

## Scope

This PR delivers **symptom 1 (dec-1)** only. **Symptom 2 (dec-2** — persistent visible marking of commented text) remains open on spec-319 and is a separate follow-up, to keep this PR focused and reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)