### PR TITLE
test(spec-319): tag dec-1 implementation ACs (ac-3, ac-4) in journey-36

### DIFF
--- a/packages/ui/e2e/journey-36-spec-319-comment-selection.spec.ts
+++ b/packages/ui/e2e/journey-36-spec-319-comment-selection.spec.ts
@@ -23,11 +23,14 @@ const PASSAGE =
   "The quick brown fox jumps over the lazy dog while the selection toolbar should appear above this very passage every single time.";
 
 test.afterEach(async ({}, testInfo) => {
-  // ac-1 (reliable on every attempt) + ac-2 (invariant to where the gesture
-  // ends) are both proven by the release-OUTSIDE case; the control case also
-  // backs ac-1 (the working path stays working).
+  // Scope ACs: ac-1 (reliable on every attempt) + ac-2 (invariant to where the
+  // gesture ends). dec-1 implementation ACs: ac-3 (a gesture ending OUTSIDE the
+  // body still surfaces the toolbar) + ac-4 (a gesture ending INSIDE still does —
+  // the working path preserved under the document-level detector). This journey
+  // exercises both ends, so it is the emitting tier for all four (the UI unit
+  // job carries no emission key; e2e is where coverage lands).
   await emitAcEvents(
-    [AC(1), AC(2)],
+    [AC(1), AC(2), AC(3), AC(4)],
     testInfo.status === "passed" ? "pass" : "fail",
     `packages/ui/e2e/journey-36-spec-319-comment-selection.spec.ts::${testInfo.title}`,
     testInfo.duration,


### PR DESCRIPTION
Follow-up to #255 (merged). Retrofits the Memex verification path for spec-319 dec-1.

## What

journey-36 already proves dec-1's two behavioural commitments; this tags them so the e2e job emits their coverage:
- **ac-3** — a selection whose mouse gesture ends **outside** the section body still surfaces the add-comment toolbar (release-point independence — the bug #255 fixed).
- **ac-4** — a selection that ends **inside** still surfaces it (regression guard under the document-level `selectionchange` detector).

## Why a separate PR

dec-1's implementation ACs were authored during the post-merge Memex reconciliation (spec-319 went `specify → build`). The verification path belongs in the repo, so the tags ship here rather than being back-dated into the merged PR.

## Note on tiers

The `ui` CI job carries no `MEMEX_EMIT_KEY`, so UI unit tests don't emit — the **e2e journey is the emitting tier** for this UI feature. The pure offset/range logic stays covered by `sectionSelection.test.ts` as fast supporting tests (no behaviour change here, only the emitted AC set).

No production code changes; one e2e file, emit-array only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)