### PR TITLE
feat(spec-320): @-mention typeahead on the inline section comment composer

### DIFF
--- a/packages/ui/e2e/journey-37-spec-320-comment-mentions.spec.ts
+++ b/packages/ui/e2e/journey-37-spec-320-comment-mentions.spec.ts
@@ -32,6 +32,20 @@ const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-320/acs
 const COLLEAGUE_EMAIL = "harriet.spec320@example.com";
 const COLLEAGUE_NAME = "Harriet";
 
+// A selectable passage for the inline-section-composer test (drag-select → toolbar →
+// composer), long enough that the first line is comfortably draggable.
+const PASSAGE =
+  "We cannot measure who is using our admin product, so mention a colleague right here to pull them into this discussion.";
+
+async function seedSpecWithMember(slug: string, purpose: string) {
+  const tenant = await seedOrgTenant({ slug });
+  await ensureUser(COLLEAGUE_EMAIL);
+  await setUserName(COLLEAGUE_EMAIL, COLLEAGUE_NAME);
+  await addOrgMember({ orgId: tenant.orgId, email: COLLEAGUE_EMAIL, role: "member" });
+  const spec = await seedSpec({ memexId: tenant.memexId, title: "Mentions Spec", purpose });
+  return { tenant, spec };
+}
+
 async function seedSpecWithOpenDecision(slug: string) {
   const tenant = await seedOrgTenant({ slug });
   // /org-add-member resolves an EXISTING user by email — create the colleague first.
@@ -148,6 +162,59 @@ test("typing @ opens the member typeahead; selecting a colleague mentions them (
       [AC(5), AC(1)],
       passed ? "pass" : "fail",
       `packages/ui/e2e/journey-37-spec-320-comment-mentions.spec.ts::typeahead`,
+      0,
+    );
+  }
+});
+
+test("the INLINE section comment composer offers the @-mention typeahead (ac-12, ac-5)", async ({
+  page,
+  resources,
+}) => {
+  let passed = false;
+  try {
+    const { tenant, spec } = await seedSpecWithMember(resources.slug("j37c"), PASSAGE);
+    await page.goto(tenantPath(tenant.namespaceSlug, tenant.memexSlug, `/specs/${spec.handle}`));
+    await expect(page.getByRole("heading", { level: 1, name: /Mentions Spec/ })).toBeVisible({
+      timeout: 15_000,
+    });
+    const body = page.getByTestId("section-body").first();
+    await expect(body).toContainText("mention a colleague", { timeout: 15_000 });
+
+    // Drag-select the first line to raise the add-comment toolbar (cf. journey-36).
+    const box = (await body.boundingBox())!;
+    await page.mouse.move(box.x + 6, box.y + 8);
+    await page.mouse.down();
+    await page.mouse.move(box.x + box.width * 0.7, box.y + 8, { steps: 12 });
+    await page.mouse.up();
+    const selected = await page.evaluate(() => (window.getSelection()?.toString() ?? "").trim());
+    expect(selected.length, "a non-empty selection should have landed").toBeGreaterThan(0);
+
+    await page.getByTestId("selection-toolbar-comment").click();
+    const composer = page.getByTestId("comment-composer");
+    await expect(composer).toBeVisible({ timeout: 10_000 });
+
+    // The whole point of this fix: typing `@` in the INLINE composer opens the
+    // member typeahead (it previously did nothing here — only the discussion tray).
+    const textarea = composer.getByTestId("comment-composer-text");
+    await textarea.click();
+    await textarea.fill("Take a look @Harr");
+    const option = composer.getByTestId("mention-option").filter({ hasText: COLLEAGUE_NAME }).first();
+    await expect(option).toBeVisible({ timeout: 10_000 });
+    await option.click();
+
+    // Selection becomes a tracked mention chip; sending closes the composer.
+    await expect(composer.getByTestId("mention-chip").filter({ hasText: COLLEAGUE_NAME })).toBeVisible({
+      timeout: 5_000,
+    });
+    await composer.getByTestId("comment-composer-send").click();
+    await expect(composer).toBeHidden({ timeout: 10_000 });
+    passed = true;
+  } finally {
+    await emitAcEvents(
+      [AC(12), AC(5)],
+      passed ? "pass" : "fail",
+      `packages/ui/e2e/journey-37-spec-320-comment-mentions.spec.ts::inline-composer`,
       0,
     );
   }

--- a/packages/ui/src/components/CommentComposerPopover.tsx
+++ b/packages/ui/src/components/CommentComposerPopover.tsx
@@ -1,8 +1,17 @@
-import { useRef, useEffect } from 'react';
+import { useRef, useEffect, useState } from 'react';
+import { useMentionSearch } from '../hooks/useMentionSearch';
+import { activeMentionToken, replaceMentionToken } from '../utils/mentionToken';
+import type { MentionableMember } from '../api/client';
 
 // spec-100: the comment composer, shown as a floating popover anchored at the
 // selection (replaces the old gutter-card composer). Enter sends; Shift+Enter
 // inserts a newline. Theme-aware via semantic tokens.
+//
+// spec-320 (dec-4): this is the PRINCIPAL place comments are added (inline on a
+// section passage), so it carries the @-mention typeahead. Typing `@` opens a live
+// dropdown of active org members (substring on name / email); selecting one inserts
+// the mention and tracks the user, and the chosen mentions ride the submit so the
+// comment notifies them.
 
 interface CommentComposerPopoverProps {
   top: number;
@@ -11,8 +20,13 @@ interface CommentComposerPopoverProps {
   submitting: boolean;
   error: string | null;
   onChange: (v: string) => void;
-  onSubmit: () => void;
+  /** Reports the @-mentioned user ids alongside the submit (spec-320). */
+  onSubmit: (mentionUserIds: string[]) => void;
   onCancel: () => void;
+}
+
+function personLabel(m: { name: string | null; email: string }): string {
+  return m.name?.trim() || m.email;
 }
 
 export function CommentComposerPopover({
@@ -26,6 +40,19 @@ export function CommentComposerPopover({
   onCancel,
 }: CommentComposerPopoverProps) {
   const ref = useRef<HTMLTextAreaElement>(null);
+
+  // spec-320 typeahead state. `caret` locates the active `@`-token; `mentions` are
+  // the selected members reported on submit; `dismissed` lets Escape close the
+  // dropdown without cancelling the whole composer.
+  const [caret, setCaret] = useState(0);
+  const [mentions, setMentions] = useState<MentionableMember[]>([]);
+  const [activeIdx, setActiveIdx] = useState(0);
+  const [dismissed, setDismissed] = useState(false);
+
+  const token = activeMentionToken(value, caret);
+  const chosen = new Set(mentions.map((m) => m.userId));
+  const results = useMentionSearch(token ? token.query : null).filter((m) => !chosen.has(m.userId));
+  const open = token !== null && results.length > 0 && !dismissed;
 
   // Focus on open and grow the textarea to fit (so long comments wrap, design #3).
   useEffect(() => {
@@ -42,6 +69,59 @@ export function CommentComposerPopover({
 
   const canSend = !submitting && value.trim().length > 0;
 
+  const selectMember = (m: MentionableMember) => {
+    const tok = activeMentionToken(value, caret);
+    if (tok) {
+      const { text, caret: nextCaret } = replaceMentionToken(value, tok.start, caret, personLabel(m));
+      onChange(text);
+      setCaret(nextCaret);
+      requestAnimationFrame(() => {
+        const el = ref.current;
+        if (el) {
+          el.focus();
+          el.setSelectionRange(nextCaret, nextCaret);
+        }
+      });
+    }
+    setMentions((prev) => (prev.some((p) => p.userId === m.userId) ? prev : [...prev, m]));
+    setActiveIdx(0);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (open) {
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        setActiveIdx((i) => (i + 1) % results.length);
+        return;
+      }
+      if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        setActiveIdx((i) => (i - 1 + results.length) % results.length);
+        return;
+      }
+      if (e.key === 'Enter') {
+        // While the typeahead is open, Enter picks the active member — it does NOT
+        // send (so an @-mention can't accidentally submit a half-typed comment).
+        e.preventDefault();
+        selectMember(results[activeIdx]!);
+        return;
+      }
+      if (e.key === 'Escape') {
+        // Close the dropdown but keep the composer open + the draft intact.
+        e.preventDefault();
+        setDismissed(true);
+        return;
+      }
+    }
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      if (canSend) onSubmit(mentions.map((m) => m.userId));
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      onCancel();
+    }
+  };
+
   return (
     <div
       data-testid="comment-composer"
@@ -49,40 +129,93 @@ export function CommentComposerPopover({
       style={{ position: 'fixed', top, left, transform: 'translateX(-50%)', zIndex: 50, width: 320 }}
       className="rounded-xl border border-edge-subtle bg-surface shadow-lg px-3 py-2"
     >
-      <div className="flex items-center gap-2">
-        <textarea
-          ref={ref}
-          data-testid="comment-composer-text"
-          rows={1}
-          value={value}
-          onChange={(e) => onChange(e.target.value)}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter' && !e.shiftKey) {
-              e.preventDefault();
-              if (canSend) onSubmit();
-            } else if (e.key === 'Escape') {
-              e.preventDefault();
-              onCancel();
-            }
-          }}
-          placeholder="Add a comment…"
-          className="flex-1 resize-none bg-transparent text-sm text-primary placeholder:text-muted focus:outline-hidden leading-6 max-h-[200px]"
-        />
-        <button
-          type="button"
-          data-testid="comment-composer-send"
-          onClick={onSubmit}
-          disabled={!canSend}
-          aria-label="Send comment"
-          title="Send comment"
-          className="shrink-0 inline-flex items-center justify-center w-8 h-8 rounded-lg text-accent hover:bg-card-hover disabled:text-muted disabled:hover:bg-transparent transition-colors"
-        >
-          {/* paper-plane send */}
-          <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.7}>
-            <path strokeLinecap="round" strokeLinejoin="round" d="M6 12L3.75 5.25l16.5 6.75-16.5 6.75L6 12zm0 0h6" />
-          </svg>
-        </button>
+      <div className="relative">
+        <div className="flex items-center gap-2">
+          <textarea
+            ref={ref}
+            data-testid="comment-composer-text"
+            rows={1}
+            value={value}
+            onChange={(e) => {
+              onChange(e.target.value);
+              setCaret(e.target.selectionStart ?? e.target.value.length);
+              setDismissed(false);
+            }}
+            onSelect={(e) => setCaret((e.target as HTMLTextAreaElement).selectionStart ?? 0)}
+            onKeyDown={handleKeyDown}
+            placeholder="Add a comment… use @ to mention"
+            className="flex-1 resize-none bg-transparent text-sm text-primary placeholder:text-muted focus:outline-hidden leading-6 max-h-[200px]"
+          />
+          <button
+            type="button"
+            data-testid="comment-composer-send"
+            onClick={() => onSubmit(mentions.map((m) => m.userId))}
+            disabled={!canSend}
+            aria-label="Send comment"
+            title="Send comment"
+            className="shrink-0 inline-flex items-center justify-center w-8 h-8 rounded-lg text-accent hover:bg-card-hover disabled:text-muted disabled:hover:bg-transparent transition-colors"
+          >
+            {/* paper-plane send */}
+            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.7}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 12L3.75 5.25l16.5 6.75-16.5 6.75L6 12zm0 0h6" />
+            </svg>
+          </button>
+        </div>
+
+        {open && (
+          <div
+            role="listbox"
+            data-testid="mention-typeahead"
+            className="absolute left-0 right-0 top-full z-20 mt-1 max-h-56 overflow-y-auto rounded-md border border-edge bg-panel py-1 shadow-lg"
+          >
+            {results.map((m, i) => (
+              <button
+                key={m.userId}
+                type="button"
+                role="option"
+                aria-selected={i === activeIdx}
+                data-testid="mention-option"
+                data-user-id={m.userId}
+                onMouseDown={(e) => {
+                  // mousedown (not click) so the textarea doesn't blur first.
+                  e.preventDefault();
+                  selectMember(m);
+                }}
+                className={`flex w-full flex-col items-start px-3 py-1.5 text-left text-xs ${
+                  i === activeIdx ? 'bg-overlay' : ''
+                } hover:bg-overlay`}
+              >
+                <span className="text-heading">{personLabel(m)}</span>
+                {m.name && <span className="text-[10px] text-muted">{m.email}</span>}
+              </button>
+            ))}
+          </div>
+        )}
       </div>
+
+      {mentions.length > 0 && (
+        <div className="mt-1 flex flex-wrap gap-1" data-testid="mention-chips">
+          {mentions.map((m) => (
+            <span
+              key={m.userId}
+              data-testid="mention-chip"
+              data-user-id={m.userId}
+              className="inline-flex h-5 items-center gap-1 rounded-full border border-edge bg-overlay pl-2 pr-1 text-[10px] text-heading"
+            >
+              @{personLabel(m)}
+              <button
+                type="button"
+                aria-label={`Remove ${personLabel(m)}`}
+                onClick={() => setMentions((prev) => prev.filter((x) => x.userId !== m.userId))}
+                className="text-muted hover:text-primary"
+              >
+                ×
+              </button>
+            </span>
+          ))}
+        </div>
+      )}
+
       {error && <p className="mt-1 text-[11px] text-status-danger-text">{error}</p>}
     </div>
   );

--- a/packages/ui/src/components/SectionCard.tsx
+++ b/packages/ui/src/components/SectionCard.tsx
@@ -7,7 +7,7 @@ import { useChat } from './ChatContext';
 import { useAuth } from './AuthContext';
 import { CommentSourceAvatar } from './CommentSourceAvatar';
 import { rehypeRefLinkifier } from './chat/refLinkifier';
-import { createComment, resolveComment, deleteComment } from '../api/client';
+import { createComment, resolveComment, deleteComment, addCommentMentions } from '../api/client';
 import { buildCommentLink } from '../utils/commentDeepLink';
 import { buildAnchorRange } from '../utils/anchorHighlight';
 import { computeAnchorFromRange } from '../utils/sectionSelection';
@@ -330,7 +330,7 @@ export const SectionCard = memo(function SectionCard({
     });
 
   const [saveError, setSaveError] = useState<string | null>(null);
-  const submitAnchored = async () => {
+  const submitAnchored = async (mentionUserIds: string[] = []) => {
     if (!anchorDraft || !draftText.trim()) return;
     setSubmitting(true);
     setSaveError(null);
@@ -344,6 +344,14 @@ export const SectionCard = memo(function SectionCard({
         createComment(section.id, user?.name ?? 'You', draftText.trim(), { type: 'issue' }, anchorDraft.end, anchorDraft.start),
         timeout,
       ])) as Awaited<ReturnType<typeof createComment>>;
+      // spec-320: attach the @-mentions to the just-created comment (adds them to
+      // the discussion + notifies them by email). The comment is already saved, so
+      // a mention failure must not lose it — best-effort, logged, never blocks close.
+      if (mentionUserIds.length > 0) {
+        await addCommentMentions(created.id, mentionUserIds).catch((err) =>
+          console.error('Failed to attach @mentions to comment:', err),
+        );
+      }
       onCommentsChange?.(section.id, [...comments, created]);
       setAnchorDraft(null);
       setDraftText('');

--- a/packages/ui/src/hooks/useMentionSearch.ts
+++ b/packages/ui/src/hooks/useMentionSearch.ts
@@ -1,0 +1,30 @@
+import { useEffect, useRef, useState } from 'react';
+import { searchMentionableMembers, type MentionableMember } from '../api/client';
+
+const DEBOUNCE_MS = 150;
+
+// spec-320 (dec-4): the shared, debounced data source for the @-mention typeahead.
+// Given the active `@`-token's query (or null when the caret isn't in a token),
+// returns the matching ACTIVE org members (substring on name / email). A null query
+// clears the results; stale responses are dropped via a sequence guard. Used by
+// both the inline section comment composer (CommentComposerPopover) and the
+// discussion-tray composer (MentionComposer) so there is ONE search implementation.
+export function useMentionSearch(query: string | null): MentionableMember[] {
+  const [results, setResults] = useState<MentionableMember[]>([]);
+  const seqRef = useRef(0);
+
+  useEffect(() => {
+    if (query === null) {
+      setResults([]);
+      return;
+    }
+    const seq = ++seqRef.current;
+    const handle = window.setTimeout(async () => {
+      const members = await searchMentionableMembers(query);
+      if (seqRef.current === seq) setResults(members);
+    }, DEBOUNCE_MS);
+    return () => window.clearTimeout(handle);
+  }, [query]);
+
+  return results;
+}


### PR DESCRIPTION
## spec-320 follow-up — @-mention typeahead on the **inline section comment composer**

The @-mention typeahead shipped in #257 was wired only into the discussion-tray composer (`MentionComposer`), **not** the inline section comment composer (`CommentComposerPopover`) — which is the principal place comments are added. So typing `@` on a section passage did nothing (the gap found while dogfooding on int). This adds it to that surface.

### Changes
- **`useMentionSearch` hook** — one shared, debounced active-member search backing the typeahead (the inline composer uses it; `MentionComposer` left untouched to avoid destabilising the merged + e2e-tested path).
- **`CommentComposerPopover`** — typing `@` opens the active-org-member dropdown (substring on name/email), selecting inserts the mention + tracks it as a chip, keyboard nav (↑/↓/Enter/Escape), and the chosen mentions ride the submit.
- **`SectionCard.submitAnchored`** — attaches the mentions to the just-created comment via `addCommentMentions` (best-effort: the comment is already saved, so a mention failure is logged, never loses the comment).
- **`ac-12`** on spec-320 (under dec-4) tracks this: the typeahead is present on the inline composer, not only the discussion tray.

### Test plan
- [x] `journey-37` gains a third test driving the real inline flow (select passage → toolbar → `@Harr` → pick → chip → send) — **`make e2e-cold`: 85 passed, 0 failed**.
- [x] UI vitest suite green (1409); UI typecheck clean.
- [x] UI-only change — no server/schema impact.

### Known follow-up (not in this PR)
Section comments in the **read view** render via `SectionCard`'s own popover (not `CommentBubble`), so a mention added on a section doesn't yet show a chip *on the comment afterward* there. The input-side typeahead (this PR) works; read-side chip rendering on section comments is a separate surface — happy to add it if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
