### PR TITLE
fix(spec-319): dismiss the comment composer on click-outside / new selection

### DIFF
--- a/packages/ui/e2e/journey-40-spec-319-composer-dismiss.spec.ts
+++ b/packages/ui/e2e/journey-40-spec-319-composer-dismiss.spec.ts
@@ -1,0 +1,68 @@
+import { test, expect, tenantPath, emitAcEvents } from "./helpers/index.js";
+import { seedOrgTenant, seedSpec } from "./helpers/retained.js";
+
+// Journey 40 — spec-319 issue C (ac-8): the comment composer must dismiss when
+// you click outside it or start a new selection; clicks inside it are spared.
+// Before the fix, the composer only closed on Escape/Cancel/Submit, so it
+// lingered over the doc. e2e is the tier — the composer opens via the real
+// selection → toolbar → composer flow, which needs selection geometry jsdom lacks.
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-319/acs/ac-${n}`;
+
+const PASSAGE =
+  "The quick brown fox jumps over the lazy dog and the comment composer should close when you click away from it or start a new selection.";
+
+test.afterEach(async ({}, testInfo) => {
+  await emitAcEvents(
+    [AC(8)],
+    testInfo.status === "passed" ? "pass" : "fail",
+    `packages/ui/e2e/journey-40-spec-319-composer-dismiss.spec.ts::${testInfo.title}`,
+    testInfo.duration,
+  );
+});
+
+async function openSpecBody(page, resources) {
+  const tenant = await seedOrgTenant({ slug: resources.slug("j40") });
+  const spec = await seedSpec({ memexId: tenant.memexId, title: "Composer Dismiss Spec", purpose: PASSAGE });
+  await page.goto(tenantPath(tenant.namespaceSlug, tenant.memexSlug, `/specs/${spec.handle}`), { waitUntil: "commit" });
+  await expect(page.getByRole("heading", { level: 1, name: /Composer Dismiss Spec/ })).toBeVisible({ timeout: 15_000 });
+  return page.getByTestId("section-body").first();
+}
+
+async function selectAndOpenComposer(page, body, f0: number, f1: number) {
+  const box = (await body.boundingBox())!;
+  await page.mouse.move(box.x + box.width * f0, box.y + 8);
+  await page.mouse.down();
+  await page.mouse.move(box.x + box.width * f1, box.y + 8, { steps: 10 });
+  await page.mouse.up();
+  await expect(page.getByTestId("selection-toolbar")).toBeVisible({ timeout: 5000 });
+  await page.getByTestId("selection-toolbar-comment").click();
+  await expect(page.getByTestId("comment-composer")).toBeVisible();
+}
+
+test("the composer dismisses on a click outside it", async ({ page, resources }) => {
+  const body = await openSpecBody(page, resources);
+  await selectAndOpenComposer(page, body, 0.05, 0.45);
+  const box = (await body.boundingBox())!;
+  await page.mouse.click(box.x + box.width * 0.2, box.y + box.height - 6);
+  await expect(page.getByTestId("comment-composer")).toBeHidden();
+});
+
+test("the composer dismisses when a new passage is highlighted", async ({ page, resources }) => {
+  const body = await openSpecBody(page, resources);
+  await selectAndOpenComposer(page, body, 0.05, 0.45);
+  const box = (await body.boundingBox())!;
+  await page.mouse.move(box.x + box.width * 0.5, box.y + box.height - 10);
+  await page.mouse.down();
+  await page.mouse.move(box.x + box.width * 0.9, box.y + box.height - 10, { steps: 8 });
+  await page.mouse.up();
+  await expect(page.getByTestId("comment-composer")).toBeHidden();
+});
+
+test("clicks INSIDE the composer do not dismiss it", async ({ page, resources }) => {
+  const body = await openSpecBody(page, resources);
+  await selectAndOpenComposer(page, body, 0.05, 0.45);
+  await page.getByTestId("comment-composer-text").click();
+  await page.getByTestId("comment-composer-text").fill("still here");
+  await expect(page.getByTestId("comment-composer")).toBeVisible();
+  await expect(page.getByTestId("comment-composer-text")).toHaveValue("still here");
+});

--- a/packages/ui/src/components/SectionCard.tsx
+++ b/packages/ui/src/components/SectionCard.tsx
@@ -152,6 +152,23 @@ export const SectionCard = memo(function SectionCard({
     setToolbar(null);
   };
 
+  // spec-319: the comment composer must dismiss when you click away from it (or
+  // start a new selection), like the toolbar and the pinned card do. Without
+  // this the draft popover lingers over the doc — you click elsewhere, even
+  // highlight another passage, and the original composer stays open. Clicks
+  // INSIDE the composer (typing, the send button) are spared; anything else
+  // closes it and discards the in-progress draft.
+  useEffect(() => {
+    if (!anchorDraft) return;
+    const onDown = (e: MouseEvent) => {
+      if ((e.target as HTMLElement)?.closest?.('[data-testid="comment-composer"]')) return;
+      setAnchorDraft(null);
+      setDraftText('');
+    };
+    document.addEventListener('mousedown', onDown);
+    return () => document.removeEventListener('mousedown', onDown);
+  }, [anchorDraft]);
+
   // spec-100 (redesign): comments live as light indicators at the body's right
   // edge, each aligned to its anchored line. Hover an indicator to PEEK the
   // comment; click to PIN it so its actions become reachable. One open at a

--- a/packages/ui/src/components/SectionCard.tsx
+++ b/packages/ui/src/components/SectionCard.tsx
@@ -156,12 +156,22 @@ export const SectionCard = memo(function SectionCard({
   // start a new selection), like the toolbar and the pinned card do. Without
   // this the draft popover lingers over the doc — you click elsewhere, even
   // highlight another passage, and the original composer stays open. Clicks
-  // INSIDE the composer (typing, the send button) are spared; anything else
-  // closes it and discards the in-progress draft.
+  // INSIDE the composer (typing, the send button, picking an @-mention) are
+  // spared; anything else closes it and discards the in-progress draft.
+  //
+  // Containment is tested via composedPath(), NOT target.closest(): the mention
+  // typeahead selects on mousedown and React flushes that discrete update
+  // synchronously, so the clicked option is already DETACHED from the DOM by the
+  // time this document-level listener runs — closest() on a detached node returns
+  // null and would wrongly close the composer (spec-320 regression). composedPath
+  // is snapshotted at dispatch, so it still contains the composer.
   useEffect(() => {
     if (!anchorDraft) return;
     const onDown = (e: MouseEvent) => {
-      if ((e.target as HTMLElement)?.closest?.('[data-testid="comment-composer"]')) return;
+      const insideComposer = e
+        .composedPath()
+        .some((n) => n instanceof HTMLElement && n.dataset.testid === 'comment-composer');
+      if (insideComposer) return;
       setAnchorDraft(null);
       setDraftText('');
     };


### PR DESCRIPTION
Next slice of spec-319 (comment interaction), found while testing after #258.

## Bug

The comment composer (`anchorDraft` → `CommentComposerPopover`) only closed on Escape / Cancel / Submit — there was **no click-outside closer**. So clicking elsewhere, or highlighting another passage, left the original composer open over the doc. (The selection toolbar's mousedown-closer never covered the composer, and dec-1/#255 removed the toolbar's own closer.)

## Fix

A document `mousedown` listener, active only while the composer is open, closes it and discards the draft when the click lands outside `[data-testid="comment-composer"]`. Clicks **inside** (typing, the send button) are spared. No design fork — it mirrors how the selection toolbar and the pinned comment card already dismiss.

## Tests

- **e2e `journey-40`** (the emitting tier): dismiss on click-away, dismiss on a new selection, and clicks-inside-keep-it-open. Tags **ac-8**. (e2e is the tier — the composer opens via the real selection → toolbar → composer flow, which needs selection geometry jsdom lacks.)

## Verified

- **User-verified locally** before build (ran the dev stack from this worktree; confirmed the composer now dismisses).
- UI suite: **1409 passed**; `pnpm build`: green; full server suite: clean in isolation (the parallel reds are the pre-existing cross-file DB-clone pollution); `make e2e-cold`: **87 passed**.

## Note on the flicker

The hover-peek flicker you reported on INT is **not reproducible locally on this same code** (this branch is off develop, which includes #258's hover-bridge fix). User confirmed it's clean locally — the INT sighting was almost certainly a stale bundle from testing as the #258 deploy landed. No code change needed for it here.

## Memex

spec-319: dec-3 already resolved; this adds scope **ac-8** + task **t-4**. Symptom 2 (visible marking) stays split out in spec-321.

🤖 Generated with [Claude Code](https://claude.com/claude-code)