### PR TITLE
feat(keys): widen the Memex keys page + add a CI/Agent type filter (spec-308, spec-309)

### DIFF
--- a/packages/ui/e2e/journey-28-spec-234-emission-key-types.spec.ts
+++ b/packages/ui/e2e/journey-28-spec-234-emission-key-types.spec.ts
@@ -10,13 +10,15 @@ import {
 import { seedOrgTenant, type SeededOrgTenant } from "./helpers/retained.js";
 import { emitAcEvents } from "./helpers/emit-ac.js";
 
-// Journey 28 (spec-234) — Settings → Emission Keys differentiates the two key types.
+// Journey 28 (spec-234) — the keys page differentiates the two key types.
 //
 // A permanent (CI) key and an ephemeral (agent) key are seeded into a tenant the dev user
 // is a member of, then the member-visible keys page (/<ns>/<mx>/keys) is asserted to render
-// them distinctly: the CI key marked "CI", the agent key marked "Agent" with its scoped
-// Spec and expiry. Ephemeral keys have no UI mint path (they come from the
-// provision_ac_emission MCP tool), so both are seeded through the test-only surface.
+// them distinctly. Per spec-309 (dec-5) the differentiation moved from a per-row "Type"
+// cell to the CI/Agent type toggle + type-aware columns: the CI key lives in the (default)
+// CI view, the agent key in the Agent view where its scoped Spec and expiry are their own
+// columns. Ephemeral keys have no UI mint path (they come from the provision_ac_emission
+// MCP tool), so both are seeded through the test-only surface.
 // Verifies ac-8 (differentiation) and ac-20 (expiry shown).
 
 const AC_8 = "mindset-prod/memex-building-itself/specs/spec-234/acs/ac-8";
@@ -59,29 +61,31 @@ test2.describe("spec-234 — emission key type differentiation", () => {
     );
   });
 
-  test2("the keys page marks a CI key and an Agent key distinctly, with expiry", async ({
+  test2("CI and Agent keys render in distinct views, the agent key showing its Spec + expiry", async ({
     page,
     seed,
   }) => {
     await page.goto(tenantPath(seed.tenant.namespaceSlug, seed.tenant.memexSlug, "/keys"));
 
-    const typeCells = page.getByTestId("emission-key-type");
-    await expect(typeCells.first()).toBeVisible({ timeout: 15_000 });
+    // The two types are surfaced as separately-counted toggle segments (CI 1 / Agent 1).
+    const ciSeg = page.getByRole("radio", { name: /CI/ });
+    const agentSeg = page.getByRole("radio", { name: /Agent/ });
+    await expect(ciSeg).toBeVisible({ timeout: 15_000 });
+    await expect(ciSeg).toHaveText(/1/);
+    await expect(agentSeg).toHaveText(/1/);
 
-    const permanent = page.locator(
-      '[data-testid="emission-key-type"][data-kind="permanent"]',
+    // Default CI view shows the CI key, not the agent key (ac-8 — distinguishable).
+    await expect(page.getByText("pythonia CI")).toBeVisible();
+    await expect(ciSeg).toHaveAttribute("aria-checked", "true");
+
+    // Switch to the Agent view: the agent key's scoped Spec and expiry are surfaced
+    // under their own columns (ac-20), no longer crammed into a Type cell.
+    await agentSeg.click();
+    await expect(page.getByTestId("emission-keys-table")).toHaveAttribute(
+      "data-view",
+      "ephemeral",
     );
-    const ephemeral = page.locator(
-      '[data-testid="emission-key-type"][data-kind="ephemeral"]',
-    );
-
-    await expect(permanent).toHaveCount(1);
-    await expect(ephemeral).toHaveCount(1);
-
-    // CI key is labelled CI; agent key is labelled Agent and shows its Spec + expiry.
-    await expect(permanent).toContainText("CI");
-    await expect(ephemeral).toContainText("Agent");
-    await expect(ephemeral).toContainText("spec-234");
-    await expect(ephemeral).toContainText(/expires/);
+    await expect(page.getByTestId("emission-key-spec")).toContainText("spec-234");
+    await expect(page.getByTestId("emission-key-expires")).toContainText(/in \d|expired/);
   });
 });

--- a/packages/ui/e2e/journey-35-spec-308-309-keys-layout.spec.ts
+++ b/packages/ui/e2e/journey-35-spec-308-309-keys-layout.spec.ts
@@ -1,0 +1,134 @@
+import {
+  test,
+  expect,
+  ensureUser,
+  tenantPath,
+  DEV_EMAIL,
+  seedEmissionKey,
+  type TestResources,
+} from "./helpers/index.js";
+import { seedOrgTenant, type SeededOrgTenant } from "./helpers/retained.js";
+import { emitAcEvents } from "./helpers/emit-ac.js";
+
+// Journey 35 (spec-308 + spec-309) — the Memex keys page layout & type filter.
+//
+// spec-308 widened the page to max-w-5xl so the emission-keys table stops wrapping.
+// spec-309 added a CI/Agent type toggle (CI by default, per-type counts) and type-aware
+// columns: the Agent view promotes Spec + Expires to their own columns and drops the
+// redundant Type column; the CI view stays lean. Both surfaces are exercised here against
+// a seeded tenant the dev user owns, via path-based nav and the test-only seed surface.
+
+const REFS: Record<string, string[]> = {
+  // spec-309: default-CI + counts + filtering + type-aware columns.
+  "filters the keys table by type, with type-aware columns": [
+    "mindset-prod/memex-building-itself/specs/spec-309/acs/ac-1",
+    "mindset-prod/memex-building-itself/specs/spec-309/acs/ac-2",
+    "mindset-prod/memex-building-itself/specs/spec-309/acs/ac-3",
+    "mindset-prod/memex-building-itself/specs/spec-309/acs/ac-9",
+    "mindset-prod/memex-building-itself/specs/spec-309/acs/ac-12",
+    "mindset-prod/memex-building-itself/specs/spec-309/acs/ac-13",
+    "mindset-prod/memex-building-itself/specs/spec-309/acs/ac-15",
+  ],
+  // spec-309: per-type empty state.
+  "shows a per-type empty state for a type with no keys": [
+    "mindset-prod/memex-building-itself/specs/spec-309/acs/ac-4",
+  ],
+  // spec-308: the page uses the widened layout.
+  "renders the keys page at the widened (max-w-5xl) layout": [
+    "mindset-prod/memex-building-itself/specs/spec-308/acs/ac-1",
+  ],
+};
+
+interface KeysCtx {
+  tenant: SeededOrgTenant;
+  devId: string;
+}
+
+const test2 = test.extend<{ ctx: KeysCtx }>({
+  ctx: async ({ resources }: { resources: TestResources }, use) => {
+    const devId = await ensureUser(DEV_EMAIL);
+    const tenant = await seedOrgTenant({ slug: resources.slug("j35") });
+    await use({ tenant, devId });
+  },
+});
+
+test2.describe("spec-308 + spec-309 — keys page layout & type filter", () => {
+  test2.afterEach(async ({}, testInfo) => {
+    if (testInfo.status === "skipped") return;
+    const refs = REFS[testInfo.title];
+    if (!refs) return;
+    await emitAcEvents(
+      refs,
+      testInfo.status === "passed" ? "pass" : "fail",
+      `packages/ui/e2e/journey-35-spec-308-309-keys-layout.spec.ts::${testInfo.title}`,
+      testInfo.duration,
+    );
+  });
+
+  test2("filters the keys table by type, with type-aware columns", async ({ page, ctx }) => {
+    // Two CI keys + one agent key → counts CI 2 / Agent 1.
+    await seedEmissionKey({ memexId: ctx.tenant.memexId, createdByUserId: ctx.devId, kind: "permanent", name: "pythonia CI" });
+    await seedEmissionKey({ memexId: ctx.tenant.memexId, createdByUserId: ctx.devId, kind: "permanent", name: "github actions" });
+    await seedEmissionKey({ memexId: ctx.tenant.memexId, createdByUserId: ctx.devId, kind: "ephemeral", specHandle: "spec-80" });
+
+    await page.goto(tenantPath(ctx.tenant.namespaceSlug, ctx.tenant.memexSlug, "/keys"));
+
+    const ciSeg = page.getByRole("radio", { name: /CI/ });
+    const agentSeg = page.getByRole("radio", { name: /Agent/ });
+
+    // The toggle sits above the table, CI selected by default, with per-type counts.
+    await expect(ciSeg).toBeVisible({ timeout: 15_000 });
+    await expect(ciSeg).toHaveAttribute("aria-checked", "true");
+    await expect(ciSeg).toHaveText(/2/);
+    await expect(agentSeg).toHaveText(/1/);
+
+    // CI view: the CI keys show; the agent key does not; columns are the lean CI set
+    // (no Spec / Expires / Type).
+    const table = page.getByTestId("emission-keys-table");
+    await expect(table).toHaveAttribute("data-view", "permanent");
+    await expect(page.getByText("pythonia CI")).toBeVisible();
+    await expect(page.getByRole("columnheader", { name: "Spec" })).toHaveCount(0);
+    await expect(page.getByRole("columnheader", { name: "Expires" })).toHaveCount(0);
+    await expect(page.getByRole("columnheader", { name: "Type" })).toHaveCount(0);
+
+    // Switch to Agent: filtering is instant (no nav), Spec + Expires become real
+    // columns, the agent key's Spec shows, and there's still no Type column.
+    await agentSeg.click();
+    await expect(table).toHaveAttribute("data-view", "ephemeral");
+    await expect(page.getByRole("columnheader", { name: "Spec" })).toBeVisible();
+    await expect(page.getByRole("columnheader", { name: "Expires" })).toBeVisible();
+    await expect(page.getByRole("columnheader", { name: "Type" })).toHaveCount(0);
+    await expect(page.getByTestId("emission-key-spec")).toContainText("spec-80");
+    await expect(page.getByText("pythonia CI")).toHaveCount(0);
+  });
+
+  test2("shows a per-type empty state for a type with no keys", async ({ page, ctx }) => {
+    // Only a CI key → the Agent view is empty.
+    await seedEmissionKey({ memexId: ctx.tenant.memexId, createdByUserId: ctx.devId, kind: "permanent", name: "pythonia CI" });
+
+    await page.goto(tenantPath(ctx.tenant.namespaceSlug, ctx.tenant.memexSlug, "/keys"));
+
+    const agentSeg = page.getByRole("radio", { name: /Agent/ });
+    await expect(agentSeg).toBeVisible({ timeout: 15_000 });
+    await expect(agentSeg).toHaveText(/0/);
+
+    await agentSeg.click();
+    // A type-specific empty state, not a blank table or the generic "no keys yet".
+    const empty = page.getByTestId("emission-keys-empty-ephemeral");
+    await expect(empty).toBeVisible();
+    await expect(empty).toContainText(/created automatically/i);
+    await expect(page.getByTestId("emission-keys-table")).toHaveCount(0);
+  });
+
+  test2("renders the keys page at the widened (max-w-5xl) layout", async ({ page, ctx }) => {
+    await seedEmissionKey({ memexId: ctx.tenant.memexId, createdByUserId: ctx.devId, kind: "permanent", name: "pythonia CI" });
+
+    await page.goto(tenantPath(ctx.tenant.namespaceSlug, ctx.tenant.memexSlug, "/keys"));
+
+    // The page content sits in the data-rich max-w-5xl container (spec-308 dec-1),
+    // not the old narrow max-w-2xl column.
+    await expect(page.getByRole("heading", { name: "Emission Keys" })).toBeVisible({ timeout: 15_000 });
+    const widePage = page.locator(".max-w-5xl").filter({ hasText: "Emission Keys" });
+    await expect(widePage.first()).toBeVisible();
+  });
+});

--- a/packages/ui/src/components/EmissionKeyTypeToggle.tsx
+++ b/packages/ui/src/components/EmissionKeyTypeToggle.tsx
@@ -1,0 +1,76 @@
+// spec-309 dec-2 — the `[CI n] / [Agent n]` segmented control above the emission-keys
+// Active table. Picks which key type the table shows: permanent CI keys or short-lived
+// agent keys. Modelled on pulse/ScopeToggle (dec-2): a two-segment radiogroup, not a
+// dropdown — exactly two mutually-exclusive options, one keystroke to flip.
+//
+// PRESENTATIONAL. The default selection (dec-1: 'permanent'/CI) is the caller's concern;
+// this control is fully driven by `value`/`onChange` and holds no state of its own.
+// Arrow keys move between segments; Enter/Space selects the focused one (native <button>
+// + roving aria-checked). Each segment shows its active-key count (dec-3).
+
+export type KeyTypeFilter = 'permanent' | 'ephemeral';
+
+export interface EmissionKeyTypeToggleProps {
+  /** Currently selected key type. */
+  value: KeyTypeFilter;
+  /** Fired when the user picks a different type. */
+  onChange: (value: KeyTypeFilter) => void;
+  /** Active-key counts per type, rendered alongside each segment label (dec-3). */
+  counts: Record<KeyTypeFilter, number>;
+}
+
+const OPTIONS: { value: KeyTypeFilter; label: string }[] = [
+  { value: 'permanent', label: 'CI' },
+  { value: 'ephemeral', label: 'Agent' },
+];
+
+export function EmissionKeyTypeToggle({ value, onChange, counts }: EmissionKeyTypeToggleProps) {
+  function onKeyDown(e: React.KeyboardEvent<HTMLDivElement>) {
+    if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') return;
+    e.preventDefault();
+    const idx = OPTIONS.findIndex((o) => o.value === value);
+    const nextIdx =
+      e.key === 'ArrowRight'
+        ? Math.min(idx + 1, OPTIONS.length - 1)
+        : Math.max(idx - 1, 0);
+    const next = OPTIONS[nextIdx];
+    if (next && next.value !== value) onChange(next.value);
+  }
+
+  return (
+    <div
+      role="radiogroup"
+      aria-label="Emission key type"
+      onKeyDown={onKeyDown}
+      className="inline-flex items-center rounded-full border border-edge bg-input p-0.5 text-xs"
+    >
+      {OPTIONS.map((opt) => {
+        const selected = opt.value === value;
+        return (
+          <button
+            key={opt.value}
+            type="button"
+            role="radio"
+            aria-checked={selected}
+            // Only the selected segment is a tab stop; arrow keys move within.
+            tabIndex={selected ? 0 : -1}
+            onClick={() => {
+              if (!selected) onChange(opt.value);
+            }}
+            // Selected segment uses bg-edge-strong (slate-300 / #4b525f) — a clearly
+            // visible grey against the lighter toggle container, in both themes. The
+            // near-invisible white/overlay default read as "nothing selected".
+            className={`rounded-full px-2.5 py-0.5 font-medium transition-colors focus:outline-hidden focus-visible:ring-1 focus-visible:ring-edge-strong ${
+              selected
+                ? 'bg-edge-strong text-primary shadow-xs'
+                : 'text-muted hover:text-primary'
+            }`}
+          >
+            {opt.label}{' '}
+            <span className={selected ? 'text-secondary' : 'text-muted'}>{counts[opt.value]}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/ui/src/components/EmissionKeysSection.spec-234.test.tsx
+++ b/packages/ui/src/components/EmissionKeysSection.spec-234.test.tsx
@@ -1,9 +1,14 @@
-// spec-234 t-3 — Settings → Emission Keys differentiates the two key types.
-// A permanent (CI) key and an ephemeral (agent) key render distinguishably, and the
-// ephemeral key shows its expiry + the Spec it is scoped to.
+// spec-234 — Emission Keys differentiates the two key types: a permanent (CI) key and
+// an ephemeral (agent) key, and the ephemeral key shows its expiry + the Spec it is
+// scoped to.
+//
+// UPDATED by spec-309 (dec-5): the differentiation moved from a per-row "Type" cell to
+// the CI/Agent type toggle + type-aware columns. ac-8 (the two types render
+// distinguishably) and ac-20 (the agent key shows its expiry + scoped Spec) still hold —
+// they're now verified against the toggle + the Agent view's Spec/Expires columns.
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, within } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 import { tagAc } from '@memex-ai-ac/vitest';
 import { EmissionKeysSection } from './EmissionKeysSection';
 import type { EmissionKeySummary } from '../api/client';
@@ -43,13 +48,13 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
-describe('EmissionKeysSection — two-key differentiation (spec-234)', () => {
+describe('EmissionKeysSection — two-key differentiation (spec-234, via spec-309 toggle)', () => {
   it('renders a permanent CI key and an ephemeral agent key distinguishably [ac-8]', async () => {
     tagAc(AC_8);
     mockList.mockResolvedValue([
       key({ name: 'pythonia CI' }), // permanent: expiresAt null
       key({
-        name: 'agent · spec-234 · 2026-06-11',
+        name: 'agent key',
         expiresAt: new Date(Date.now() + 2 * 60 * 60 * 1000).toISOString(),
         scopedSpecHandle: 'spec-234',
       }),
@@ -57,23 +62,28 @@ describe('EmissionKeysSection — two-key differentiation (spec-234)', () => {
 
     render(<EmissionKeysSection />);
 
-    // Both type cells render, with distinct kinds.
-    const cells = await screen.findAllByTestId('emission-key-type');
-    const kinds = cells.map((c) => c.getAttribute('data-kind')).sort();
-    expect(kinds).toEqual(['ephemeral', 'permanent']);
+    // The two types are surfaced as distinct, separately-counted segments — CI 1 / Agent 1.
+    const ci = await screen.findByRole('radio', { name: /CI/ });
+    const agent = screen.getByRole('radio', { name: /Agent/ });
+    expect(ci).toHaveTextContent('1');
+    expect(agent).toHaveTextContent('1');
 
-    // The permanent key is labelled CI; the ephemeral one Agent.
-    const permanent = cells.find((c) => c.getAttribute('data-kind') === 'permanent')!;
-    const ephemeral = cells.find((c) => c.getAttribute('data-kind') === 'ephemeral')!;
-    expect(within(permanent).getByText('CI')).toBeInTheDocument();
-    expect(within(ephemeral).getByText('Agent')).toBeInTheDocument();
+    // Default CI view shows the permanent key, not the agent key.
+    expect(screen.getByText('pythonia CI')).toBeInTheDocument();
+    expect(screen.queryByText('agent key')).not.toBeInTheDocument();
+
+    // Switching to Agent shows the agent key and hides the CI key — the two render
+    // in distinct, type-appropriate views.
+    fireEvent.click(agent);
+    expect(await screen.findByText('agent key')).toBeInTheDocument();
+    expect(screen.queryByText('pythonia CI')).not.toBeInTheDocument();
   });
 
   it('shows the ephemeral key’s expiry and the Spec it is scoped to [ac-20]', async () => {
     tagAc(AC_20);
     mockList.mockResolvedValue([
       key({
-        name: 'agent · spec-234 · 2026-06-11',
+        name: 'agent key',
         expiresAt: new Date(Date.now() + 2 * 60 * 60 * 1000).toISOString(),
         scopedSpecHandle: 'spec-234',
       }),
@@ -81,11 +91,14 @@ describe('EmissionKeysSection — two-key differentiation (spec-234)', () => {
 
     render(<EmissionKeysSection />);
 
-    const cell = (await screen.findAllByTestId('emission-key-type')).find(
-      (c) => c.getAttribute('data-kind') === 'ephemeral',
-    )!;
-    // Expiry is surfaced (relative, ~2h) and the scoped Spec is named.
-    expect(within(cell).getByText(/expires in \d+h/)).toBeInTheDocument();
-    expect(within(cell).getByText(/spec-234/)).toBeInTheDocument();
+    // Move to the Agent view (the only place these columns exist).
+    fireEvent.click(await screen.findByRole('radio', { name: /Agent/ }));
+
+    // Expiry is surfaced (relative, ~2h) under its own Expires column…
+    const expires = await screen.findByTestId('emission-key-expires');
+    expect(within(expires).getByText(/in \d+h/)).toBeInTheDocument();
+    // …and the scoped Spec under its own Spec column.
+    const spec = screen.getByTestId('emission-key-spec');
+    expect(within(spec).getByText('spec-234')).toBeInTheDocument();
   });
 });

--- a/packages/ui/src/components/EmissionKeysSection.spec-308.test.tsx
+++ b/packages/ui/src/components/EmissionKeysSection.spec-308.test.tsx
@@ -1,0 +1,93 @@
+// spec-308 ac-6 — even though the Memex keys page widens to max-w-5xl (dec-1),
+// the explanatory intro prose stays at a readable measure (max-w-2xl), while the
+// Active key table is free to use the full widened width.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, within, fireEvent } from '@testing-library/react';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { EmissionKeysSection } from './EmissionKeysSection';
+import type { EmissionKeySummary } from '../api/client';
+
+const AC_6 = 'mindset-prod/memex-building-itself/specs/spec-308/acs/ac-6';
+const AC_3 = 'mindset-prod/memex-building-itself/specs/spec-308/acs/ac-3'; // scope: prose stays at a readable measure
+const AC_2 = 'mindset-prod/memex-building-itself/specs/spec-308/acs/ac-2'; // scope: cells don't wrap
+
+const mockList = vi.fn();
+
+vi.mock('../api/client', async () => {
+  const actual = await vi.importActual<typeof import('../api/client')>('../api/client');
+  return {
+    ...actual,
+    listEmissionKeysApi: (...args: unknown[]) => mockList(...args),
+  };
+});
+
+vi.mock('./AuthContext', () => ({
+  useAuth: () => ({ token: 'tok-1' }),
+}));
+
+function key(over: Partial<EmissionKeySummary> = {}): EmissionKeySummary {
+  return {
+    id: crypto.randomUUID(),
+    name: 'pythonia CI',
+    prefix: 'mxk_abcd1234',
+    lastUsedAt: null,
+    revokedAt: null,
+    createdAt: new Date().toISOString(),
+    expiresAt: null,
+    scopedSpecHandle: null,
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('EmissionKeysSection prose measure (spec-308 ac-6)', () => {
+  it('constrains the intro prose, but not the Active table [ac-6]', async () => {
+    tagAc(AC_6);
+    tagAc(AC_3); // scope: explanatory prose stays at a comfortable reading measure
+    mockList.mockResolvedValue([key()]);
+
+    render(<EmissionKeysSection />);
+
+    // The intro prose block is capped at a readable measure.
+    const intro = await screen.findByTestId('emission-keys-intro');
+    expect(intro.className).toContain('max-w-2xl');
+
+    // The Active key table renders and is NOT nested inside that narrow measure,
+    // so it can fill the full widened page width.
+    const table = await screen.findByRole('table');
+    expect(table).toBeInTheDocument();
+    expect(within(intro).queryByRole('table')).toBeNull();
+  });
+
+  it('keeps table cells on a single line and lets the table scroll, not crush [ac-2]', async () => {
+    tagAc(AC_2);
+    // An agent key carries the long metadata ("spec-50", expiry) that previously
+    // stacked word-by-word in the narrow column. spec-309 surfaces these under the
+    // Agent view, so select it before asserting the table's no-wrap treatment.
+    mockList.mockResolvedValue([
+      key({
+        name: 'agent · spec-50 · 2026-06-19',
+        expiresAt: new Date(Date.now() + 3 * 60 * 60 * 1000).toISOString(),
+        scopedSpecHandle: 'spec-50',
+      }),
+    ]);
+
+    render(<EmissionKeysSection />);
+    fireEvent.click(await screen.findByRole('radio', { name: /Agent/ }));
+
+    const table = await screen.findByTestId('emission-keys-table');
+    // whitespace-nowrap makes wrapping physically impossible for every cell
+    // (inherited): "Last used"/"Created" headers and the agent metadata stay on
+    // one line regardless of column width.
+    expect(table.className).toContain('whitespace-nowrap');
+
+    // The table sits inside an overflow-x-auto wrapper, so a too-narrow viewport
+    // scrolls horizontally instead of crushing cells into multiple lines.
+    const scroller = table.closest('.overflow-x-auto');
+    expect(scroller).not.toBeNull();
+  });
+});

--- a/packages/ui/src/components/EmissionKeysSection.spec-309.test.tsx
+++ b/packages/ui/src/components/EmissionKeysSection.spec-309.test.tsx
@@ -1,0 +1,222 @@
+// spec-309 — filter the emission-keys Active table by type (CI vs Agent), CI by default,
+// with per-type counts, per-type empty states, and type-aware columns (Agent view
+// promotes Spec + Expires to their own columns and drops Type).
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { EmissionKeysSection } from './EmissionKeysSection';
+import type { EmissionKeySummary } from '../api/client';
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-309/acs/ac-${n}`;
+
+const mockList = vi.fn();
+
+vi.mock('../api/client', async () => {
+  const actual = await vi.importActual<typeof import('../api/client')>('../api/client');
+  return {
+    ...actual,
+    listEmissionKeysApi: (...args: unknown[]) => mockList(...args),
+  };
+});
+
+vi.mock('./AuthContext', () => ({
+  useAuth: () => ({ token: 'tok-1' }),
+}));
+
+function key(over: Partial<EmissionKeySummary> = {}): EmissionKeySummary {
+  return {
+    id: crypto.randomUUID(),
+    name: 'a key',
+    prefix: 'mxk_abcd1234',
+    lastUsedAt: null,
+    revokedAt: null,
+    createdAt: new Date().toISOString(),
+    expiresAt: null,
+    scopedSpecHandle: null,
+    ...over,
+  };
+}
+
+const ci = (name: string) => key({ name });
+const agent = (name: string, spec: string) =>
+  key({
+    name,
+    scopedSpecHandle: spec,
+    expiresAt: new Date(Date.now() + 3 * 60 * 60 * 1000).toISOString(),
+  });
+
+function headerLabels(): string[] {
+  const table = screen.getByTestId('emission-keys-table');
+  return within(table)
+    .getAllByRole('columnheader')
+    .map((th) => th.textContent?.trim() ?? '');
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('spec-309 — type filter toggle', () => {
+  it('defaults to CI, shows per-type counts, and marks the selection [ac-6, ac-9, ac-10, ac-1, ac-3]', async () => {
+    tagAc(AC(6));
+    tagAc(AC(9));
+    tagAc(AC(10));
+    tagAc(AC(1));
+    tagAc(AC(3));
+    mockList.mockResolvedValue([ci('ci-a'), ci('ci-b'), agent('ag-a', 'spec-50')]);
+
+    render(<EmissionKeysSection />);
+
+    // A radiogroup with CI / Agent segments sits above the table.
+    const group = await screen.findByRole('radiogroup', { name: /key type/i });
+    expect(group).toBeInTheDocument();
+    const ciSeg = within(group).getByRole('radio', { name: /CI/ });
+    const agentSeg = within(group).getByRole('radio', { name: /Agent/ });
+
+    // CI is the default selection (and it's conveyed, not just coloured).
+    expect(ciSeg).toHaveAttribute('aria-checked', 'true');
+    expect(agentSeg).toHaveAttribute('aria-checked', 'false');
+
+    // Per-type counts (CI 2 / Agent 1).
+    expect(ciSeg).toHaveTextContent('2');
+    expect(agentSeg).toHaveTextContent('1');
+
+    // The default CI view is what renders.
+    expect(screen.getByTestId('emission-keys-table')).toHaveAttribute('data-view', 'permanent');
+  });
+
+  it('filters to the selected type client-side with no extra API call [ac-7, ac-2, ac-8, ac-5]', async () => {
+    tagAc(AC(7));
+    tagAc(AC(2));
+    tagAc(AC(8));
+    tagAc(AC(5));
+    mockList.mockResolvedValue([ci('ci-only'), agent('agent-only', 'spec-80')]);
+
+    render(<EmissionKeysSection />);
+
+    // Default CI view: CI key visible, agent key hidden.
+    expect(await screen.findByText('ci-only')).toBeInTheDocument();
+    expect(screen.queryByText('agent-only')).not.toBeInTheDocument();
+    expect(mockList).toHaveBeenCalledTimes(1);
+
+    // Switch to Agent — the rows swap, and NO new fetch happens (client-side filter).
+    fireEvent.click(screen.getByRole('radio', { name: /Agent/ }));
+    expect(await screen.findByText('agent-only')).toBeInTheDocument();
+    expect(screen.queryByText('ci-only')).not.toBeInTheDocument();
+    expect(mockList).toHaveBeenCalledTimes(1);
+
+    // Generate form + a revoke control remain available regardless of filter.
+    expect(screen.getByRole('button', { name: /Generate key/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Revoke/i })).toBeInTheDocument();
+  });
+
+  it('moves selection with arrow keys [ac-5, ac-7]', async () => {
+    tagAc(AC(5));
+    tagAc(AC(7));
+    mockList.mockResolvedValue([ci('ci-a'), agent('ag-a', 'spec-50')]);
+
+    render(<EmissionKeysSection />);
+    const group = await screen.findByRole('radiogroup', { name: /key type/i });
+
+    fireEvent.keyDown(group, { key: 'ArrowRight' });
+    expect(within(group).getByRole('radio', { name: /Agent/ })).toHaveAttribute(
+      'aria-checked',
+      'true',
+    );
+
+    fireEvent.keyDown(group, { key: 'ArrowLeft' });
+    expect(within(group).getByRole('radio', { name: /CI/ })).toHaveAttribute(
+      'aria-checked',
+      'true',
+    );
+  });
+});
+
+describe('spec-309 — type-aware columns', () => {
+  it('CI view shows only the permanent-key columns [ac-15]', async () => {
+    tagAc(AC(15));
+    mockList.mockResolvedValue([ci('ci-a'), agent('ag-a', 'spec-50')]);
+
+    render(<EmissionKeysSection />);
+    await screen.findByTestId('emission-keys-table');
+
+    // Name · Key · Last used · Created · (revoke) — no Type, Spec, or Expires.
+    const labels = headerLabels();
+    expect(labels).toEqual(['Name', 'Key', 'Last used', 'Created', '']);
+  });
+
+  it('Agent view promotes Spec + Expires to columns and drops Type [ac-13, ac-12]', async () => {
+    tagAc(AC(13));
+    tagAc(AC(12));
+    mockList.mockResolvedValue([ci('ci-a'), agent('ag-a', 'spec-50')]);
+
+    render(<EmissionKeysSection />);
+    fireEvent.click(await screen.findByRole('radio', { name: /Agent/ }));
+
+    const labels = headerLabels();
+    expect(labels).toEqual(['Name', 'Spec', 'Key', 'Expires', 'Last used', 'Created', '']);
+    expect(labels).not.toContain('Type');
+  });
+
+  it('Agent view renders the scoped Spec and formatted expiry in their columns [ac-14]', async () => {
+    tagAc(AC(14));
+    mockList.mockResolvedValue([agent('ag-a', 'spec-99')]);
+
+    render(<EmissionKeysSection />);
+    fireEvent.click(await screen.findByRole('radio', { name: /Agent/ }));
+
+    expect(within(await screen.findByTestId('emission-key-spec')).getByText('spec-99')).toBeInTheDocument();
+    expect(within(screen.getByTestId('emission-key-expires')).getByText(/in \d+h/)).toBeInTheDocument();
+  });
+});
+
+describe('spec-309 — revoked section + counts [ac-11]', () => {
+  it('leaves the Revoked section unfiltered and excludes revoked keys from the counts', async () => {
+    tagAc(AC(11));
+    mockList.mockResolvedValue([
+      ci('ci-a'),
+      agent('ag-a', 'spec-50'),
+      key({ name: 'old-revoked-key', revokedAt: new Date().toISOString() }),
+    ]);
+
+    render(<EmissionKeysSection />);
+
+    // Counts reflect ONLY active keys (revoked excluded): CI 1 / Agent 1.
+    const group = await screen.findByRole('radiogroup', { name: /key type/i });
+    expect(within(group).getByRole('radio', { name: /CI/ })).toHaveTextContent('1');
+    expect(within(group).getByRole('radio', { name: /Agent/ })).toHaveTextContent('1');
+
+    // The revoked key shows in the CI (default) view…
+    expect(screen.getByText('old-revoked-key')).toBeInTheDocument();
+    // …and still shows after switching to Agent — the filter doesn't touch Revoked.
+    fireEvent.click(within(group).getByRole('radio', { name: /Agent/ }));
+    expect(screen.getByText('old-revoked-key')).toBeInTheDocument();
+  });
+});
+
+describe('spec-309 — per-type empty states [ac-4]', () => {
+  it('shows the CI empty state when there are only agent keys', async () => {
+    tagAc(AC(4));
+    mockList.mockResolvedValue([agent('ag-a', 'spec-50')]); // 0 CI, 1 agent
+
+    render(<EmissionKeysSection />);
+
+    // Default CI view is empty → CI-specific empty copy, not a blank table.
+    const empty = await screen.findByTestId('emission-keys-empty-permanent');
+    expect(empty).toHaveTextContent(/No CI keys yet/i);
+    expect(screen.queryByTestId('emission-keys-table')).not.toBeInTheDocument();
+  });
+
+  it('shows the Agent empty state when there are only CI keys', async () => {
+    tagAc(AC(4));
+    mockList.mockResolvedValue([ci('ci-a')]); // 1 CI, 0 agent
+
+    render(<EmissionKeysSection />);
+    fireEvent.click(await screen.findByRole('radio', { name: /Agent/ }));
+
+    const empty = await screen.findByTestId('emission-keys-empty-ephemeral');
+    expect(empty).toHaveTextContent(/created automatically/i);
+    expect(screen.queryByTestId('emission-keys-table')).not.toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/EmissionKeysSection.test.tsx
+++ b/packages/ui/src/components/EmissionKeysSection.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor, within } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { tagAc } from '@memex-ai-ac/vitest';
 import { EmissionKeysSection } from './EmissionKeysSection';
@@ -104,8 +104,9 @@ describe('EmissionKeysSection (spec-129)', () => {
     render(<EmissionKeysSection />);
     await screen.findByText('pythonia CI');
 
-    const activeTable = screen.getByText(/Active \(/).closest('div')!;
-    await user.click(within(activeTable).getByRole('button', { name: 'Revoke' }));
+    // spec-309 restructured the Active header (the type toggle now sits beside the
+    // "Active (N)" heading), so scope to the unique Revoke button directly.
+    await user.click(screen.getByRole('button', { name: 'Revoke' }));
 
     await waitFor(() => expect(mockRevoke).toHaveBeenCalledWith('k1', 'tok-1'));
   });

--- a/packages/ui/src/components/EmissionKeysSection.tsx
+++ b/packages/ui/src/components/EmissionKeysSection.tsx
@@ -15,6 +15,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { useAuth } from './AuthContext';
 import { Alert } from './ui/Alert';
 import { Button, Input } from './ui';
+import { EmissionKeyTypeToggle, type KeyTypeFilter } from './EmissionKeyTypeToggle';
 import {
   listEmissionKeysApi,
   generateEmissionKeyApi,
@@ -69,6 +70,9 @@ export function EmissionKeysSection() {
   const [generated, setGenerated] = useState<GeneratedEmissionKey | null>(null);
   const [copied, setCopied] = useState(false);
   const [revoking, setRevoking] = useState<string | null>(null);
+  // spec-309 dec-1: the Active table is filtered to one key type at a time,
+  // defaulting to CI (permanent). Agent (ephemeral) keys live behind the toggle.
+  const [selectedType, setSelectedType] = useState<KeyTypeFilter>('permanent');
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -138,9 +142,24 @@ export function EmissionKeysSection() {
   const active = keys.filter((k) => !k.revokedAt);
   const revoked = keys.filter((k) => k.revokedAt);
 
+  // spec-309: partition the active keys by type for the toggle (dec-2), its
+  // per-type counts (dec-3), and the filtered/type-aware table (dec-1, dec-5).
+  const activeByType: Record<KeyTypeFilter, EmissionKeySummary[]> = {
+    permanent: active.filter((k) => keyKind(k) === 'permanent'),
+    ephemeral: active.filter((k) => keyKind(k) === 'ephemeral'),
+  };
+  const counts: Record<KeyTypeFilter, number> = {
+    permanent: activeByType.permanent.length,
+    ephemeral: activeByType.ephemeral.length,
+  };
+  const visible = activeByType[selectedType];
+  const isAgentView = selectedType === 'ephemeral';
+
   return (
     <section id="emission-keys" aria-labelledby="emission-keys-heading" className="space-y-4">
-      <div>
+      {/* spec-308 dec-1: keep the explanatory prose at a readable measure even though
+          the page (and the table below) widens to max-w-5xl. */}
+      <div className="max-w-2xl" data-testid="emission-keys-intro">
         <h2 id="emission-keys-heading" className="text-xl font-semibold mb-2 text-heading">
           Emission Keys
         </h2>
@@ -226,69 +245,106 @@ export function EmissionKeysSection() {
         </div>
       )}
 
-      {active.length > 0 && (
+      {!loading && active.length > 0 && (
         <div>
-          <h3 className="text-sm font-medium uppercase tracking-wide mb-3 text-muted">
-            Active ({active.length})
-          </h3>
-          <div className="border rounded-lg overflow-hidden bg-overlay border-edge">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="border-b border-edge">
-                  <th className="text-left px-4 py-2.5 font-medium text-secondary">Name</th>
-                  <th className="text-left px-4 py-2.5 font-medium text-secondary">Type</th>
-                  <th className="text-left px-4 py-2.5 font-medium text-secondary">Key</th>
-                  <th className="text-left px-4 py-2.5 font-medium text-secondary">Last used</th>
-                  <th className="text-left px-4 py-2.5 font-medium text-secondary">Created</th>
-                  <th className="px-4 py-2.5"></th>
-                </tr>
-              </thead>
-              <tbody>
-                {active.map((k) => {
-                  const kind = keyKind(k);
-                  return (
-                  <tr key={k.id} className="border-b last:border-0 border-edge-subtle">
-                    <td className="px-4 py-2.5 text-primary">{k.name}</td>
-                    <td className="px-4 py-2.5" data-testid="emission-key-type" data-kind={kind}>
-                      {kind === 'ephemeral' ? (
-                        <span className="inline-flex items-center gap-1.5">
-                          <span className="px-1.5 py-0.5 rounded-sm text-xs font-medium bg-warning-subtle text-warning">
-                            Agent
-                          </span>
-                          <span className="text-xs text-muted">
-                            {k.scopedSpecHandle ? `${k.scopedSpecHandle} · ` : ''}
-                            expires {formatExpiry(k.expiresAt)}
-                          </span>
-                        </span>
-                      ) : (
-                        <span className="px-1.5 py-0.5 rounded-sm text-xs font-medium bg-info-subtle text-info">
-                          CI
-                        </span>
-                      )}
-                    </td>
-                    <td className="px-4 py-2.5 font-mono text-xs text-muted">{k.prefix}…</td>
-                    <td className="px-4 py-2.5 text-secondary" title={formatAbsolute(k.lastUsedAt)}>
-                      {formatRelative(k.lastUsedAt)}
-                    </td>
-                    <td className="px-4 py-2.5 text-secondary" title={formatAbsolute(k.createdAt)}>
-                      {formatRelative(k.createdAt)}
-                    </td>
-                    <td className="px-4 py-2.5 text-right">
-                      <Button
-                        variant="danger"
-                        size="sm"
-                        onClick={() => handleRevoke(k.id)}
-                        disabled={revoking === k.id}
-                      >
-                        {revoking === k.id ? 'Revoking…' : 'Revoke'}
-                      </Button>
-                    </td>
-                  </tr>
-                  );
-                })}
-              </tbody>
-            </table>
+          {/* spec-309 dec-2/dec-3: the type toggle sits under the Active title (CI
+              default), each segment showing its active-key count. */}
+          <div className="mb-3 space-y-2">
+            <h3 className="text-sm font-medium uppercase tracking-wide text-muted">
+              Active ({active.length})
+            </h3>
+            <EmissionKeyTypeToggle
+              value={selectedType}
+              onChange={setSelectedType}
+              counts={counts}
+            />
           </div>
+
+          {visible.length === 0 ? (
+            // spec-309 dec-4: per-type empty state — CI keeps the generate-oriented
+            // copy; Agent explains these keys appear automatically.
+            <div
+              className="border rounded-lg p-6 text-sm bg-surface border-edge text-secondary"
+              data-testid={`emission-keys-empty-${selectedType}`}
+            >
+              {isAgentView ? (
+                'No agent keys. These are created automatically when a coding agent runs a build against a Spec.'
+              ) : (
+                <>
+                  No CI keys yet. Generate one above, then set it as{' '}
+                  <code className="font-mono text-xs">MEMEX_EMIT_KEY</code> where your tests run.
+                </>
+              )}
+            </div>
+          ) : (
+            // spec-308 ac-2: whitespace-nowrap keeps every cell on a single line and
+            // overflow-x-auto lets the table scroll rather than crush.
+            // spec-309 dec-5: columns are type-aware — the Agent view promotes Spec +
+            // Expires to their own columns and drops the (now-redundant) Type column;
+            // the CI view shows only the columns that apply to permanent keys.
+            <div className="border rounded-lg overflow-hidden bg-overlay border-edge">
+              <div className="overflow-x-auto">
+                <table
+                  className="w-full text-sm whitespace-nowrap"
+                  data-testid="emission-keys-table"
+                  data-view={selectedType}
+                >
+                  <thead>
+                    <tr className="border-b border-edge">
+                      <th className="text-left px-4 py-2.5 font-medium text-secondary">Name</th>
+                      {isAgentView && (
+                        <th className="text-left px-4 py-2.5 font-medium text-secondary">Spec</th>
+                      )}
+                      <th className="text-left px-4 py-2.5 font-medium text-secondary">Key</th>
+                      {isAgentView && (
+                        <th className="text-left px-4 py-2.5 font-medium text-secondary">Expires</th>
+                      )}
+                      <th className="text-left px-4 py-2.5 font-medium text-secondary">Last used</th>
+                      <th className="text-left px-4 py-2.5 font-medium text-secondary">Created</th>
+                      <th className="px-4 py-2.5"></th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {visible.map((k) => (
+                      <tr key={k.id} className="border-b last:border-0 border-edge-subtle">
+                        <td className="px-4 py-2.5 text-primary">{k.name}</td>
+                        {isAgentView && (
+                          <td className="px-4 py-2.5 text-secondary" data-testid="emission-key-spec">
+                            {k.scopedSpecHandle ?? '—'}
+                          </td>
+                        )}
+                        <td className="px-4 py-2.5 font-mono text-xs text-muted">{k.prefix}…</td>
+                        {isAgentView && (
+                          <td
+                            className="px-4 py-2.5 text-secondary"
+                            data-testid="emission-key-expires"
+                          >
+                            {formatExpiry(k.expiresAt)}
+                          </td>
+                        )}
+                        <td className="px-4 py-2.5 text-secondary" title={formatAbsolute(k.lastUsedAt)}>
+                          {formatRelative(k.lastUsedAt)}
+                        </td>
+                        <td className="px-4 py-2.5 text-secondary" title={formatAbsolute(k.createdAt)}>
+                          {formatRelative(k.createdAt)}
+                        </td>
+                        <td className="px-4 py-2.5 text-right">
+                          <Button
+                            variant="danger"
+                            size="sm"
+                            onClick={() => handleRevoke(k.id)}
+                            disabled={revoking === k.id}
+                          >
+                            {revoking === k.id ? 'Revoking…' : 'Revoke'}
+                          </Button>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
         </div>
       )}
 

--- a/packages/ui/src/pages/MemexKeys.spec-308.test.tsx
+++ b/packages/ui/src/pages/MemexKeys.spec-308.test.tsx
@@ -1,0 +1,67 @@
+// spec-308 — the Memex keys page widens to max-w-5xl (dec-1) so the 6-column
+// emission-keys table stops wrapping. ac-5: both render paths use max-w-5xl.
+// (ac-6 — the intro prose stays at a readable measure — lives in
+// EmissionKeysSection.spec-308.test.tsx, where the real component renders.)
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { tagAc } from '@memex-ai-ac/vitest';
+
+const AC_5 = 'mindset-prod/memex-building-itself/specs/spec-308/acs/ac-5';
+// Scope ACs verified by the same page-level assertions:
+const AC_1 = 'mindset-prod/memex-building-itself/specs/spec-308/acs/ac-1'; // page uses available width
+const AC_4 = 'mindset-prod/memex-building-itself/specs/spec-308/acs/ac-4'; // read-only notice still renders
+
+let mockCanWrite = true;
+vi.mock('../hooks/useMemexAccess', () => ({
+  useMemexAccess: () => ({ canWrite: mockCanWrite }),
+}));
+
+// Stub the keys tool for the page-level layout test (ac-5) — no network.
+vi.mock('../components/EmissionKeysSection', () => ({
+  EmissionKeysSection: () => <div data-testid="emission-keys-section">keys tool</div>,
+}));
+
+vi.mock('../components/PageHeader', () => ({
+  PageHeader: ({ title }: { title: string }) => <h1>{title}</h1>,
+}));
+
+import { MemexKeys } from './MemexKeys';
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={['/acme/team/keys']}>
+      <MemexKeys />
+    </MemoryRouter>,
+  );
+}
+
+describe('MemexKeys page width (spec-308 ac-5)', () => {
+  it('uses max-w-5xl (not max-w-2xl) for a writing member', () => {
+    tagAc(AC_5);
+    tagAc(AC_1); // scope: page uses the available horizontal width
+    mockCanWrite = true;
+    const { container } = renderPage();
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.className).toContain('max-w-5xl');
+    expect(root.className).not.toContain('max-w-2xl');
+    // The key tool still renders on the writing-member path (behaviour intact).
+    expect(screen.getByTestId('emission-keys-section')).toBeInTheDocument();
+  });
+
+  it('uses max-w-5xl on the read-only path and still renders the member notice', () => {
+    tagAc(AC_5);
+    tagAc(AC_4); // scope: read-only notice state remains correctly rendered
+    mockCanWrite = false;
+    const { container } = renderPage();
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.className).toContain('max-w-5xl');
+    expect(root.className).not.toContain('max-w-2xl');
+    // The non-member notice still shows and the key tool stays hidden.
+    expect(
+      screen.getByText(/need to be a member of this Memex to manage its emission keys/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId('emission-keys-section')).not.toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/pages/MemexKeys.tsx
+++ b/packages/ui/src/pages/MemexKeys.tsx
@@ -19,9 +19,13 @@ export function MemexKeys() {
   const location = useLocation();
   const { canWrite } = useMemexAccess(location.pathname);
 
+  // spec-308 dec-1: the page widens to max-w-5xl (the data-rich page convention,
+  // matching Insights/Backstage) so the 6-column emission-keys table has room to
+  // stop wrapping. The intro prose is kept at a readable measure inside
+  // EmissionKeysSection rather than stretching to the full width.
   if (!canWrite) {
     return (
-      <div className="max-w-2xl mx-auto px-6 py-6 space-y-6">
+      <div className="max-w-5xl mx-auto px-6 py-6 space-y-6">
         <PageHeader title="Memex keys" />
         <p className="text-sm text-secondary">
           You need to be a member of this Memex to manage its emission keys.
@@ -31,7 +35,7 @@ export function MemexKeys() {
   }
 
   return (
-    <div className="max-w-2xl mx-auto px-6 py-6 space-y-6">
+    <div className="max-w-5xl mx-auto px-6 py-6 space-y-6">
       <PageHeader title="Memex keys" />
       <EmissionKeysSection />
     </div>


### PR DESCRIPTION
## Summary

Two stacked specs against the **Memex keys** admin page (`/<ns>/<mx>/keys`), both touching `EmissionKeysSection.tsx`.

### spec-308 — page too narrow, table wrapped into unreadable cells
The page was locked to `max-w-2xl` (672px) while the viewport had room to spare, so the 6-column emission-keys table wrapped — agent metadata stacked word-by-word, headers broke across two lines.

- Widen the page to `max-w-5xl` (the data-rich convention, matching Insights/Backstage), on both the writing-member and read-only-notice paths.
- Keep the intro prose at a readable measure (`max-w-2xl`) so it doesn't stretch to the full width.
- `whitespace-nowrap` on the table + an `overflow-x-auto` wrapper, so cells **cannot** wrap at any width (scroll instead of crush) — the structural fix, not just "wider and hope".

### spec-309 — filter the table by key type
All keys (durable **CI** + ephemeral **Agent**) were listed together, burying the CI keys a human manages under machine-provisioned agent keys.

- A **CI/Agent segmented toggle** above the Active table (CI selected by default, each segment showing its live count), modelled on `pulse/ScopeToggle` (keyboard-accessible radiogroup).
- **Type-aware columns**: the Agent view promotes **Spec** + **Expires** to their own labelled columns and drops the now-redundant Type column; the CI view stays lean (Name · Key · Last used · Created · Revoke). This also fixes a prod-reported gap where an agent key's Spec/expiry were crammed unlabelled into the Type cell.
- Filtering is client-side over already-fetched keys (no API change); the Revoked section is unaffected; per-type empty states.

## Cross-spec impact
Dropping the per-row Type cell required updating **spec-234**'s unit test and **e2e journey-28** to verify ac-8/ac-20 against the new toggle + Agent-view columns (intent unchanged). The spec-129 revoke test's selector was also adjusted for the new header layout.

## Test plan
- [x] New unit tests for spec-308 + spec-309 — **all ACs verified on prod** (spec-308 6/6, spec-309 15/15).
- [x] spec-234 ac-8/ac-20 re-verified against the new presentation.
- [x] Full `packages/ui` suite green (1377 passed, 1 skipped); `tsc --noEmit` clean.
- [x] New **e2e journey-35** (filter, type-aware columns, empty state, widened layout) + updated journey-28 — ran green locally via `make e2e-cold` (8/8 incl. retained control journey-17). std-28 gate satisfied.
- [x] Visually confirmed (CI + Agent views, selected-toggle contrast) at desktop width.

## Notes
- Pure front-end / presentational: no API, schema, auth/tenancy, or migration changes.
- Side observation (not addressed here): the server logs a std-32 `ATTRIBUTION DEFECT` when emission keys are created via the test seed surface — a RequestCtx-threading gap on that write path, worth its own issue.