### PR TITLE
feat(spec-320): empty-state when there's no one to mention

### DIFF
--- a/packages/ui/e2e/journey-37-spec-320-comment-mentions.spec.ts
+++ b/packages/ui/e2e/journey-37-spec-320-comment-mentions.spec.ts
@@ -198,6 +198,11 @@ test("the INLINE section comment composer offers the @-mention typeahead (ac-12,
     // member typeahead (it previously did nothing here — only the discussion tray).
     const textarea = composer.getByTestId("comment-composer-text");
     await textarea.click();
+    // Empty-state (ac-13): a query that matches no one still OPENS the box with an
+    // explicit notice — never silence (the single-player-Memex complaint).
+    await textarea.fill("Note @zzzznobody");
+    await expect(composer.getByTestId("mention-empty")).toBeVisible({ timeout: 10_000 });
+
     await textarea.fill("Take a look @Harr");
     const option = composer.getByTestId("mention-option").filter({ hasText: COLLEAGUE_NAME }).first();
     await expect(option).toBeVisible({ timeout: 10_000 });
@@ -212,7 +217,7 @@ test("the INLINE section comment composer offers the @-mention typeahead (ac-12,
     passed = true;
   } finally {
     await emitAcEvents(
-      [AC(12), AC(5)],
+      [AC(12), AC(5), AC(13)],
       passed ? "pass" : "fail",
       `packages/ui/e2e/journey-37-spec-320-comment-mentions.spec.ts::inline-composer`,
       0,

--- a/packages/ui/src/components/CommentComposerPopover.tsx
+++ b/packages/ui/src/components/CommentComposerPopover.tsx
@@ -51,8 +51,14 @@ export function CommentComposerPopover({
 
   const token = activeMentionToken(value, caret);
   const chosen = new Set(mentions.map((m) => m.userId));
-  const results = useMentionSearch(token ? token.query : null).filter((m) => !chosen.has(m.userId));
-  const open = token !== null && results.length > 0 && !dismissed;
+  const search = useMentionSearch(token ? token.query : null);
+  const results = search.results.filter((m) => !chosen.has(m.userId));
+  // The dropdown opens as soon as you're in an @-token (unless dismissed). It shows
+  // members when there are any, or a clear "no one to mention" line when the search
+  // settled empty — so a single-player Memex never gets silence (spec-320 ac-13).
+  const dropdownOpen = token !== null && !dismissed && search.status !== 'idle';
+  const hasOptions = results.length > 0;
+  const showEmpty = dropdownOpen && !hasOptions && search.status === 'done';
 
   // Focus on open and grow the textarea to fit (so long comments wrap, design #3).
   useEffect(() => {
@@ -88,7 +94,9 @@ export function CommentComposerPopover({
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if (open) {
+    // Only the OPTIONS capture arrows/Enter — the empty-state never traps keys, so
+    // Enter still sends when there's no one to pick.
+    if (dropdownOpen && hasOptions) {
       if (e.key === 'ArrowDown') {
         e.preventDefault();
         setActiveIdx((i) => (i + 1) % results.length);
@@ -100,18 +108,18 @@ export function CommentComposerPopover({
         return;
       }
       if (e.key === 'Enter') {
-        // While the typeahead is open, Enter picks the active member — it does NOT
-        // send (so an @-mention can't accidentally submit a half-typed comment).
+        // While options are shown, Enter picks the active member — it does NOT send
+        // (so an @-mention can't accidentally submit a half-typed comment).
         e.preventDefault();
         selectMember(results[activeIdx]!);
         return;
       }
-      if (e.key === 'Escape') {
-        // Close the dropdown but keep the composer open + the draft intact.
-        e.preventDefault();
-        setDismissed(true);
-        return;
-      }
+    }
+    if (e.key === 'Escape' && dropdownOpen) {
+      // Close the dropdown but keep the composer open + the draft intact.
+      e.preventDefault();
+      setDismissed(true);
+      return;
     }
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
@@ -162,33 +170,44 @@ export function CommentComposerPopover({
           </button>
         </div>
 
-        {open && (
+        {dropdownOpen && (
           <div
             role="listbox"
             data-testid="mention-typeahead"
             className="absolute left-0 right-0 top-full z-20 mt-1 max-h-56 overflow-y-auto rounded-md border border-edge bg-panel py-1 shadow-lg"
           >
-            {results.map((m, i) => (
-              <button
-                key={m.userId}
-                type="button"
-                role="option"
-                aria-selected={i === activeIdx}
-                data-testid="mention-option"
-                data-user-id={m.userId}
-                onMouseDown={(e) => {
-                  // mousedown (not click) so the textarea doesn't blur first.
-                  e.preventDefault();
-                  selectMember(m);
-                }}
-                className={`flex w-full flex-col items-start px-3 py-1.5 text-left text-xs ${
-                  i === activeIdx ? 'bg-overlay' : ''
-                } hover:bg-overlay`}
-              >
-                <span className="text-heading">{personLabel(m)}</span>
-                {m.name && <span className="text-[10px] text-muted">{m.email}</span>}
-              </button>
-            ))}
+            {hasOptions &&
+              results.map((m, i) => (
+                <button
+                  key={m.userId}
+                  type="button"
+                  role="option"
+                  aria-selected={i === activeIdx}
+                  data-testid="mention-option"
+                  data-user-id={m.userId}
+                  onMouseDown={(e) => {
+                    // mousedown (not click) so the textarea doesn't blur first.
+                    e.preventDefault();
+                    selectMember(m);
+                  }}
+                  className={`flex w-full flex-col items-start px-3 py-1.5 text-left text-xs ${
+                    i === activeIdx ? 'bg-overlay' : ''
+                  } hover:bg-overlay`}
+                >
+                  <span className="text-heading">{personLabel(m)}</span>
+                  {m.name && <span className="text-[10px] text-muted">{m.email}</span>}
+                </button>
+              ))}
+            {/* Empty-state: no one to mention (e.g. a single-player Memex). A future
+                spec adds an "Invite teammates" link here (out of scope today). */}
+            {showEmpty && (
+              <p data-testid="mention-empty" className="px-3 py-1.5 text-xs text-muted">
+                No one to mention.
+              </p>
+            )}
+            {!hasOptions && search.status === 'loading' && (
+              <p className="px-3 py-1.5 text-xs text-muted">Searching…</p>
+            )}
           </div>
         )}
       </div>

--- a/packages/ui/src/components/MentionComposer.tsx
+++ b/packages/ui/src/components/MentionComposer.tsx
@@ -38,20 +38,25 @@ export function MentionComposer({ placeholder = 'Add a comment...', submitting, 
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState<string | null>(null);
   const [results, setResults] = useState<MentionableMember[]>([]);
+  const [searching, setSearching] = useState(false);
   const [activeIdx, setActiveIdx] = useState(0);
 
   const textRef = useRef<HTMLTextAreaElement | null>(null);
   const seqRef = useRef(0);
 
-  // Recompute the active @-token whenever the text or caret moves.
+  // Recompute the active @-token whenever the text or caret moves. `searching` is
+  // set true synchronously with the token so an empty result never flashes "no one"
+  // before the search resolves.
   function syncToken(value: string, caretPos: number) {
     const token = activeMentionToken(value, caretPos);
     if (token) {
       setQuery(token.query);
       setOpen(true);
+      setSearching(true);
     } else {
       setQuery(null);
       setOpen(false);
+      setSearching(false);
     }
   }
 
@@ -66,6 +71,7 @@ export function MentionComposer({ placeholder = 'Add a comment...', submitting, 
         const chosen = new Set(mentions.map((m) => m.userId));
         setResults(members.filter((m) => !chosen.has(m.userId)));
         setActiveIdx(0);
+        setSearching(false);
       }
     }, DEBOUNCE_MS);
     return () => window.clearTimeout(handle);
@@ -163,33 +169,44 @@ export function MentionComposer({ placeholder = 'Add a comment...', submitting, 
           rows={2}
           textAreaSize="compact"
         />
-        {open && results.length > 0 && (
+        {open && (
           <div
             role="listbox"
             data-testid="mention-typeahead"
             className="absolute z-20 mt-1 max-h-56 w-64 overflow-y-auto rounded-md border border-edge bg-panel py-1 shadow-lg"
           >
-            {results.map((m, i) => (
-              <button
-                key={m.userId}
-                type="button"
-                role="option"
-                aria-selected={i === activeIdx}
-                data-testid="mention-option"
-                data-user-id={m.userId}
-                onMouseDown={(e) => {
-                  // mousedown (not click) so the textarea doesn't blur first.
-                  e.preventDefault();
-                  selectMember(m);
-                }}
-                className={`flex w-full flex-col items-start px-3 py-1.5 text-left text-xs ${
-                  i === activeIdx ? 'bg-overlay' : ''
-                } hover:bg-overlay`}
-              >
-                <span className="text-heading">{personLabel(m)}</span>
-                {m.name && <span className="text-[10px] text-muted">{m.email}</span>}
-              </button>
-            ))}
+            {results.length > 0 &&
+              results.map((m, i) => (
+                <button
+                  key={m.userId}
+                  type="button"
+                  role="option"
+                  aria-selected={i === activeIdx}
+                  data-testid="mention-option"
+                  data-user-id={m.userId}
+                  onMouseDown={(e) => {
+                    // mousedown (not click) so the textarea doesn't blur first.
+                    e.preventDefault();
+                    selectMember(m);
+                  }}
+                  className={`flex w-full flex-col items-start px-3 py-1.5 text-left text-xs ${
+                    i === activeIdx ? 'bg-overlay' : ''
+                  } hover:bg-overlay`}
+                >
+                  <span className="text-heading">{personLabel(m)}</span>
+                  {m.name && <span className="text-[10px] text-muted">{m.email}</span>}
+                </button>
+              ))}
+            {/* Empty-state: no one to mention (e.g. a single-player Memex). A future
+                spec adds an "Invite teammates" link here (out of scope today). */}
+            {results.length === 0 && !searching && (
+              <p data-testid="mention-empty" className="px-3 py-1.5 text-xs text-muted">
+                No one to mention.
+              </p>
+            )}
+            {results.length === 0 && searching && (
+              <p className="px-3 py-1.5 text-xs text-muted">Searching…</p>
+            )}
           </div>
         )}
       </div>

--- a/packages/ui/src/hooks/useMentionSearch.ts
+++ b/packages/ui/src/hooks/useMentionSearch.ts
@@ -3,28 +3,42 @@ import { searchMentionableMembers, type MentionableMember } from '../api/client'
 
 const DEBOUNCE_MS = 150;
 
+export type MentionSearchStatus = 'idle' | 'loading' | 'done';
+
+export interface MentionSearchState {
+  results: MentionableMember[];
+  /** 'idle' = no active token; 'loading' = a search is in flight; 'done' = the
+   *  latest query has resolved (so an empty `results` here means "genuinely no one
+   *  to mention", which the composer surfaces as an empty-state rather than silence). */
+  status: MentionSearchStatus;
+}
+
 // spec-320 (dec-4): the shared, debounced data source for the @-mention typeahead.
 // Given the active `@`-token's query (or null when the caret isn't in a token),
-// returns the matching ACTIVE org members (substring on name / email). A null query
-// clears the results; stale responses are dropped via a sequence guard. Used by
-// both the inline section comment composer (CommentComposerPopover) and the
-// discussion-tray composer (MentionComposer) so there is ONE search implementation.
-export function useMentionSearch(query: string | null): MentionableMember[] {
-  const [results, setResults] = useState<MentionableMember[]>([]);
+// returns the matching ACTIVE org members (substring on name / email) plus a status
+// so the composer can tell "still searching" from "searched, found no one". A null
+// query resets to idle; stale responses are dropped via a sequence guard. Used by
+// both the inline section composer (CommentComposerPopover) and the discussion-tray
+// composer (MentionComposer) so there is ONE search implementation.
+export function useMentionSearch(query: string | null): MentionSearchState {
+  const [state, setState] = useState<MentionSearchState>({ results: [], status: 'idle' });
   const seqRef = useRef(0);
 
   useEffect(() => {
     if (query === null) {
-      setResults([]);
+      setState({ results: [], status: 'idle' });
       return;
     }
     const seq = ++seqRef.current;
+    // Keep the previous results on screen while the next query resolves (no flicker),
+    // but mark the box as loading so an empty result doesn't flash "no one" early.
+    setState((s) => ({ results: s.results, status: 'loading' }));
     const handle = window.setTimeout(async () => {
       const members = await searchMentionableMembers(query);
-      if (seqRef.current === seq) setResults(members);
+      if (seqRef.current === seq) setState({ results: members, status: 'done' });
     }, DEBOUNCE_MS);
     return () => window.clearTimeout(handle);
   }, [query]);
 
-  return results;
+  return state;
 }


### PR DESCRIPTION
## spec-320 follow-up — empty-state when there's no one to mention

Follow-up to #260 (which merged the inline-composer typeahead). On a **single-player Memex** (no org / no other members), the member search returns an empty list and the typeahead dropdown simply didn't render — so typing `@` gave **silence** instead of feedback (found while dogfooding on int). This adds an explicit empty-state.

### Changes
- **`useMentionSearch`** now returns `{ results, status }` so a composer can tell "still searching" from "searched, found no one" (no early flash).
- **`CommentComposerPopover`** (inline) and **`MentionComposer`** (discussion tray) render a clear **"No one to mention."** line (`data-testid="mention-empty"`) when the search settles empty. The empty-state never traps keys — Enter still sends.
- **`ac-13`** on spec-320 tracks it; `journey-37`'s inline test now asserts the empty-state on a no-match query.
- A future spec will drop an "invite teammates" link into this empty-state (explicitly out of scope here).

### Test plan
- [x] `journey-37` (3 tests incl. the empty-state) green on a cold DB; full `make e2e-cold` **85 passed** (run on an isolated DB/ports to avoid colliding with a concurrent e2e run in another worktree).
- [x] UI vitest 1409 passed; UI typecheck clean.
- [x] UI-only — no server/schema impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
