### PR TITLE
spec-318: per-page document.title + setTheme emit for the desktop shell

### DIFF
--- a/packages/ui/src/components/PageHeader.tsx
+++ b/packages/ui/src/components/PageHeader.tsx
@@ -4,6 +4,7 @@ import { useAuth } from './AuthContext';
 import { MemexPublicBadge } from './MemexPublicBadge';
 import { useAnonymousPublicMemex } from './PublicMemexContext';
 import { getCurrentTenant, namespaceHomePath, tenantPathFor } from '../utils/tenantUrl';
+import { useDocumentTitle } from '../hooks/useDocumentTitle';
 
 // Breadcrumb-style page header used on every tenancy-scoped page. The pattern
 // is:
@@ -25,6 +26,10 @@ export interface PageHeaderProps {
 }
 
 export function PageHeader({ title, actions }: PageHeaderProps) {
+  // spec-318 t-11 (ac-17): every breadcrumb page routes its title through the
+  // single document.title writer. The Spec page is the one page that does NOT
+  // use PageHeader — it sets its own handle-first title (see DocDocument).
+  useDocumentTitle({ kind: 'page', title });
   const { session } = useAuth();
   const tenant = getCurrentTenant();
   const memberships = session?.memberships ?? [];

--- a/packages/ui/src/components/ThemeContext.test.tsx
+++ b/packages/ui/src/components/ThemeContext.test.tsx
@@ -1,0 +1,79 @@
+// spec-318 t-12 (ac-23): ThemeProvider emits setTheme(mode, background) to the
+// desktop Flutter shell on mount and on every light/dark switch — and is a safe
+// no-op in a plain browser where window.flutter_inappwebview is undefined.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { act } from 'react';
+import userEvent from '@testing-library/user-event';
+import { ThemeProvider, useTheme } from './ThemeContext';
+
+function Toggle() {
+  const { theme, toggleTheme } = useTheme();
+  return (
+    <button onClick={toggleTheme} data-testid="toggle">
+      {theme}
+    </button>
+  );
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  // Give --color-surface a resolvable value so the emitted background is concrete.
+  document.documentElement.style.setProperty('--color-surface', 'rgb(10, 20, 30)');
+  delete (window as Record<string, unknown>).flutter_inappwebview;
+});
+
+afterEach(() => {
+  cleanup();
+  document.documentElement.style.removeProperty('--color-surface');
+  delete (window as Record<string, unknown>).flutter_inappwebview;
+});
+
+describe('ThemeProvider → setTheme emit', () => {
+  it('emits setTheme on initial mount with the current mode + resolved background', () => {
+    const callHandler = vi.fn();
+    (window as Record<string, unknown>).flutter_inappwebview = { callHandler };
+
+    render(
+      <ThemeProvider>
+        <Toggle />
+      </ThemeProvider>,
+    );
+
+    expect(callHandler).toHaveBeenCalledWith('setTheme', {
+      mode: 'dark', // app default
+      background: 'rgb(10, 20, 30)',
+    });
+  });
+
+  it('re-emits setTheme with the new mode when the theme is toggled', async () => {
+    const callHandler = vi.fn();
+    (window as Record<string, unknown>).flutter_inappwebview = { callHandler };
+    const user = userEvent.setup();
+
+    render(
+      <ThemeProvider>
+        <Toggle />
+      </ThemeProvider>,
+    );
+    callHandler.mockClear();
+
+    await user.click(screen.getByTestId('toggle'));
+
+    expect(callHandler).toHaveBeenCalledWith('setTheme', {
+      mode: 'light',
+      background: 'rgb(10, 20, 30)',
+    });
+  });
+
+  it('is a safe no-op (never throws) when flutter_inappwebview is undefined', () => {
+    expect(() =>
+      render(
+        <ThemeProvider>
+          <Toggle />
+        </ThemeProvider>,
+      ),
+    ).not.toThrow();
+  });
+});

--- a/packages/ui/src/components/ThemeContext.test.tsx
+++ b/packages/ui/src/components/ThemeContext.test.tsx
@@ -4,7 +4,6 @@
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { render, screen, cleanup } from '@testing-library/react';
-import { act } from 'react';
 import userEvent from '@testing-library/user-event';
 import { ThemeProvider, useTheme } from './ThemeContext';
 

--- a/packages/ui/src/components/ThemeContext.tsx
+++ b/packages/ui/src/components/ThemeContext.tsx
@@ -9,6 +9,30 @@ interface ThemeState {
 
 const ThemeContext = createContext<ThemeState | null>(null);
 
+// spec-318 t-12 (ac-23): the desktop Flutter shell hosts this web app in an
+// `flutter_inappwebview` and exposes a JS bridge — `callHandler(name, ...args)`.
+// In a plain browser the bridge is undefined, so every emit is guarded.
+declare global {
+  interface Window {
+    flutter_inappwebview?: {
+      callHandler: (handlerName: string, ...args: unknown[]) => unknown;
+    };
+  }
+}
+
+// spec-318 t-12 (ac-23): tell the desktop shell the current theme + the RESOLVED
+// surface colour so it can paint the native title bar / tab strip to match. The
+// shell reads `--color-surface` (the page's background) via this push rather than
+// peeking into the webview's CSS. Guarded: a no-op outside the desktop shell.
+function emitTheme(mode: Theme): void {
+  const bridge = window.flutter_inappwebview;
+  if (!bridge) return;
+  const background = getComputedStyle(document.documentElement)
+    .getPropertyValue('--color-surface')
+    .trim();
+  bridge.callHandler('setTheme', { mode, background });
+}
+
 export function ThemeProvider({ children }: { children: ReactNode }) {
   const [theme, setTheme] = useState<Theme>(() => {
     const stored = localStorage.getItem('memex-theme');
@@ -19,6 +43,10 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     localStorage.setItem('memex-theme', theme);
     document.documentElement.classList.toggle('dark', theme === 'dark');
     document.documentElement.classList.toggle('light', theme === 'light');
+    // spec-318 t-12 (ac-23): push the resolved theme to the desktop shell AFTER
+    // the .dark/.light class flips, so getComputedStyle reads the NEW surface
+    // colour. Runs on mount and on every switch; a no-op in a plain browser.
+    emitTheme(theme);
   }, [theme]);
 
   const toggleTheme = useCallback(() => {

--- a/packages/ui/src/hooks/useDocumentTitle.test.tsx
+++ b/packages/ui/src/hooks/useDocumentTitle.test.tsx
@@ -1,0 +1,38 @@
+// spec-318 t-11 (ac-17): the hook applies the derived title to document.title.
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { useDocumentTitle } from './useDocumentTitle';
+import type { DocumentTitleInput } from '../utils/documentTitle';
+
+function Probe({ input }: { input: DocumentTitleInput }) {
+  useDocumentTitle(input);
+  return null;
+}
+
+afterEach(cleanup);
+
+describe('useDocumentTitle', () => {
+  it('sets a handle-first title for a Spec page', () => {
+    render(<Probe input={{ kind: 'spec', handle: 'spec-318', name: 'Desktop tabs' }} />);
+    expect(document.title).toBe('spec-318 · Desktop tabs');
+  });
+
+  it('sets the PageHeader title for a normal page', () => {
+    render(<Probe input={{ kind: 'page', title: 'Settings' }} />);
+    expect(document.title).toBe('Settings');
+  });
+
+  it('re-applies the title when the input changes', () => {
+    const { rerender } = render(<Probe input={{ kind: 'page', title: 'Issues' }} />);
+    expect(document.title).toBe('Issues');
+    rerender(<Probe input={{ kind: 'page', title: 'Decisions' }} />);
+    expect(document.title).toBe('Decisions');
+  });
+
+  it('leaves the current title untouched when there is nothing to set', () => {
+    document.title = 'Preserved';
+    render(<Probe input={{ kind: 'page', title: '   ' }} />);
+    expect(document.title).toBe('Preserved');
+  });
+});

--- a/packages/ui/src/hooks/useDocumentTitle.ts
+++ b/packages/ui/src/hooks/useDocumentTitle.ts
@@ -1,0 +1,17 @@
+import { useEffect } from 'react';
+import {
+  deriveDocumentTitle,
+  type DocumentTitleInput,
+} from '../utils/documentTitle';
+
+// spec-318 t-11 (ac-17): the single place that writes `document.title`. Pages
+// don't poke `document.title` directly — they call this hook (PageHeader does it
+// for every breadcrumb page; the Spec page does it with the handle-first form).
+// Keeping it in one effect-bearing hook means there's exactly one writer and the
+// derivation stays a pure, tested function.
+export function useDocumentTitle(input: DocumentTitleInput): void {
+  const next = deriveDocumentTitle(input);
+  useEffect(() => {
+    if (next) document.title = next;
+  }, [next]);
+}

--- a/packages/ui/src/pages/DocDocument.tsx
+++ b/packages/ui/src/pages/DocDocument.tsx
@@ -61,6 +61,7 @@ import { nextRevealPhase } from '../hooks/useHandholdReveal';
 import { useHandholdRevealValue } from '../hooks/HandholdRevealContext';
 import { BylineAssignees } from '../components/BylineAssignees';
 import { useDocRole } from '../hooks/useDocRole';
+import { useDocumentTitle } from '../hooks/useDocumentTitle';
 import { useOrgScaffoldBlocks } from '../hooks/useOrgScaffoldBlocks';
 import { usePresenceHeartbeat } from '../hooks/usePresenceHeartbeat';
 import { usePresence } from '../hooks/usePresence';
@@ -445,6 +446,18 @@ export function DocDocument() {
   const specRef = doc?.docType === 'spec' ? doc.handle : null;
   usePresenceHeartbeat(specRef);
   const { rows: presentRows } = usePresence(specRef);
+
+  // spec-318 t-11 (ac-17): the Spec page is the ONE page that doesn't use
+  // PageHeader, so it sets document.title itself — handle FIRST (`spec-N · name`)
+  // so the unique id survives truncation in a narrow desktop tab chip. Other
+  // doc types loaded here fall back to the plain doc title. Called before any
+  // early return so the hook order stays stable; a null doc yields no title and
+  // leaves the current one untouched.
+  useDocumentTitle(
+    doc?.docType === 'spec'
+      ? { kind: 'spec', handle: doc.handle, name: doc.title }
+      : { kind: 'page', title: doc?.title ?? '' },
+  );
 
   const headerActions = useMemo(() => {
     if (!doc) return null;

--- a/packages/ui/src/utils/documentTitle.test.ts
+++ b/packages/ui/src/utils/documentTitle.test.ts
@@ -1,0 +1,44 @@
+// Unit tests for the central document.title derivation (spec-318 t-11, ac-17).
+// UNTAGGED — pure-function checks. The desktop tab-chip consumer reads
+// document.title; the hook that applies these strings is exercised in
+// useDocumentTitle.test.tsx.
+
+import { describe, it, expect } from 'vitest';
+import { deriveDocumentTitle } from './documentTitle';
+
+describe('deriveDocumentTitle', () => {
+  it('puts the Spec handle FIRST so the unique id survives truncation', () => {
+    expect(
+      deriveDocumentTitle({ kind: 'spec', handle: 'spec-318', name: 'Desktop tabs' }),
+    ).toBe('spec-318 · Desktop tabs');
+  });
+
+  it('keeps the full spec name un-truncated (truncation is the consumer concern)', () => {
+    const name = 'A very long spec name that a narrow tab chip would have to clip';
+    expect(deriveDocumentTitle({ kind: 'spec', handle: 'spec-7', name })).toBe(
+      `spec-7 · ${name}`,
+    );
+  });
+
+  it('falls back to just the handle when a Spec has no name yet', () => {
+    expect(deriveDocumentTitle({ kind: 'spec', handle: 'spec-9', name: '' })).toBe(
+      'spec-9',
+    );
+    expect(
+      deriveDocumentTitle({ kind: 'spec', handle: 'spec-9', name: '   ' }),
+    ).toBe('spec-9');
+  });
+
+  it('derives a normal page title from the PageHeader title', () => {
+    expect(deriveDocumentTitle({ kind: 'page', title: 'Settings' })).toBe('Settings');
+    expect(deriveDocumentTitle({ kind: 'page', title: 'Decisions' })).toBe(
+      'Decisions',
+    );
+  });
+
+  it('trims a page title and ignores empty ones (keeps the existing title)', () => {
+    expect(deriveDocumentTitle({ kind: 'page', title: '  Issues  ' })).toBe('Issues');
+    expect(deriveDocumentTitle({ kind: 'page', title: '' })).toBeNull();
+    expect(deriveDocumentTitle({ kind: 'page', title: '   ' })).toBeNull();
+  });
+});

--- a/packages/ui/src/utils/documentTitle.ts
+++ b/packages/ui/src/utils/documentTitle.ts
@@ -1,0 +1,33 @@
+// spec-318 t-11 (ac-17): central derivation of `document.title`. The desktop
+// Flutter shell (spec-318) reads `document.title` to label each tab chip; a
+// narrow chip truncates from the RIGHT, so the Spec page leads with its handle
+// (`spec-N`) — the unique id has to survive the clip. Every other page derives
+// from the title it already hands to PageHeader.
+//
+// The string is produced FULL and un-truncated here; clipping is the consumer's
+// render concern (the tab chip), never ours.
+
+export type DocumentTitleInput =
+  | { kind: 'spec'; handle: string; name: string }
+  | { kind: 'page'; title: string };
+
+/**
+ * Resolve the `document.title` for the active page.
+ *
+ * - Spec page → `spec-N · <name>` (handle FIRST). When the Spec has no name
+ *   yet, falls back to the bare handle.
+ * - Any other page → its trimmed PageHeader title.
+ *
+ * Returns `null` when there's nothing meaningful to set (e.g. an empty page
+ * title) so the caller can leave the current title untouched rather than
+ * blanking it.
+ */
+export function deriveDocumentTitle(input: DocumentTitleInput): string | null {
+  if (input.kind === 'spec') {
+    const handle = input.handle.trim();
+    const name = input.name.trim();
+    return name ? `${handle} · ${name}` : handle || null;
+  }
+  const title = input.title.trim();
+  return title || null;
+}


### PR DESCRIPTION
## What
The **web half** of Memex **spec-318** (desktop multi-tab). Two additions the desktop shell consumes.

## Changes
- **t-11 — per-page `document.title`**: a central `useDocumentTitle` hook (wired once in `PageHeader`, covering every breadcrumb page) plus `DocDocument` setting the handle-first `spec-N · <name>` title for Spec pages. Labels both the desktop tab chip and the browser tab. (Previously only the static `index.html` title existed.)
- **t-12 — `setTheme` emit**: `ThemeContext` calls `window.flutter_inappwebview.callHandler('setTheme', { mode, background })` on load and on every light/dark switch (resolved `--color-surface`), guarded to a safe no-op in a normal browser.

## Testing
- vitest unit tests for the title derivation and the emit-on-change + guarded-no-op; `tsc -b` clean; full `ui` suite green.

## Cross-repo
Consumed by the desktop shell — companion PR mindset-ai/memex-clients#12. Verified together against localhost.

Spec: https://memex.ai/mindset-prod/memex-building-itself/specs/spec-318

🤖 Generated with [Claude Code](https://claude.com/claude-code)
