### PR TITLE
spec-324: identify pre-auth visitors — visitor→user Mixpanel stitch + onboarding funnel telemetry

### DIFF
--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -27,6 +27,7 @@ import { qaReports } from "./routes/qa-reports.js";
 import { presenceRouter } from "./routes/presence.js";
 import { analytics } from "./routes/analytics.js";
 import { telemetryRouter } from "./routes/telemetry.js";
+import { anonTelemetryRouter } from "./routes/anon-telemetry.js";
 import { waitlist } from "./routes/waitlist.js";
 import { auth } from "./routes/auth.js";
 import { invitesAcceptRouter, invitesAdminRouter } from "./routes/invites.js";
@@ -343,6 +344,14 @@ app.route("/guide/v1", createGuidePublicRouter(upgradeWebSocket));
 // Caller-scoped + public surfaces — stay flat (no path prefix). These have no
 // per-memex semantics, so prefixing them would be noise.
 app.route("/api/waitlist", waitlist);
+// spec-324 — the ANONYMOUS-capable engagement ingress (the spec-244 retrofit).
+// Flat + tenant-less + PERMISSIVE publicSessionMiddleware so a PRE-AUTH visitor
+// (no user, no memex) is captured keyed on the consent-gated visitor_id — the
+// funnel head the tenant /telemetry can't see. Mounted ahead of the tenant
+// surfaces; `/api/telemetry` (2 segments) never collides with the 4-segment
+// `/api/:ns/:mx/telemetry`.
+app.use("/api/telemetry/*", publicSessionMiddleware);
+app.route("/api/telemetry", anonTelemetryRouter);
 app.route("/api/auth", auth);
 // /api/onboarding — spec-206: the user-level first-run greeting gate for the
 // Specky welcome (greet-eligibility read + once-per-user stamp). User-keyed, no

--- a/packages/server/src/middleware/visitor.ts
+++ b/packages/server/src/middleware/visitor.ts
@@ -16,6 +16,7 @@ import { createMiddleware } from "hono/factory";
 import type { Context } from "hono";
 import { getCookie, deleteCookie } from "hono/cookie";
 import { mergeVisitor } from "../services/visitors.js";
+import { recordIdentityMerge } from "../services/funnel-events.js";
 import type { SessionEnv } from "./session.js";
 
 // The cookie the consented client sets (Domain=.memex.ai). Kept in lockstep with
@@ -67,6 +68,14 @@ export async function applyVisitorMerge(
   if (!visitorId) return;
   try {
     const outcome = await mergeVisitor(visitorId, userId);
+    if (outcome?.status === "merged") {
+      // The visitor_id just BOUND to this user for the first time — the Postgres
+      // identify. Mirror it to Mixpanel so the visitor's pre-identity events are
+      // attributed to the now-known user (spec-324, Simplified ID Merge). Only on
+      // 'merged': 'already' is a re-auth (the stitch is done), 'rebind' is a
+      // different user on the same browser (no stitch — the cookie is cleared).
+      await recordIdentityMerge(userId, visitorId);
+    }
     if (outcome?.status === "rebind") {
       deleteCookie(c, VISITOR_COOKIE, { domain: visitorCookieDomain(), path: "/" });
     }

--- a/packages/server/src/routes/anon-telemetry.api.test.ts
+++ b/packages/server/src/routes/anon-telemetry.api.test.ts
@@ -1,0 +1,135 @@
+// API tests for POST /api/telemetry — the ANONYMOUS-capable ingress (spec-324) —
+// REAL Postgres.
+//
+// Drives the flat tenant-less route end-to-end (real recordUsageEvent → real
+// usage_events), asserting the funnel-head posture: a PRE-AUTH visitor is captured
+// keyed on the visitor_id; a caller with no identity at all no-ops; the registry
+// allowlist still gates; an authenticated caller is attributed (and still carries
+// the visitor_id, so the row triggers the Mixpanel merge).
+
+import { describe, it, expect, afterAll } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { Hono } from "hono";
+import { createMiddleware } from "hono/factory";
+import { eq } from "drizzle-orm";
+import { randomUUID } from "node:crypto";
+import { db } from "../db/connection.js";
+import { usageEvents } from "../db/schema.js";
+import { upsertUserByEmail } from "../services/users.js";
+import { anonTelemetryRouter } from "./anon-telemetry.js";
+
+const AC = "mindset-prod/memex-building-itself/specs/spec-324/acs";
+
+// Build a test app whose middleware injects the identity the real
+// publicSessionMiddleware + visitorMiddleware would set on the context.
+function appWith(ctx: { userId?: string; visitorId?: string }): Hono {
+  const app = new Hono();
+  app.use(
+    "*",
+    createMiddleware(async (c, next) => {
+      if (ctx.userId) c.set("user", { id: ctx.userId } as never);
+      if (ctx.visitorId) c.set("visitorId", ctx.visitorId);
+      return next();
+    }),
+  );
+  app.route("/telemetry", anonTelemetryRouter);
+  return app;
+}
+
+function post(app: Hono, body: unknown): Promise<Response> {
+  return app.request("/telemetry", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+const createdVisitorIds: string[] = [];
+afterAll(async () => {
+  for (const v of createdVisitorIds) {
+    await db.delete(usageEvents).where(eq(usageEvents.visitorId, v));
+  }
+});
+
+describe("POST /api/telemetry — anonymous-capable ingress (spec-324 ac-8)", () => {
+  it("records a pre-auth event keyed on the visitor_id (no user, no memex)", async () => {
+    tagAc(`${AC}/ac-8`);
+    tagAc(`${AC}/ac-3`); // scope: a visitor seeing the form is captured pre-auth, keyed on visitor_id
+    const visitorId = randomUUID();
+    createdVisitorIds.push(visitorId);
+    const res = await post(appWith({ visitorId }), {
+      name: "signup.form_viewed",
+      props: { method: "password" },
+    });
+    expect(res.status).toBe(204);
+
+    const rows = await db.select().from(usageEvents).where(eq(usageEvents.visitorId, visitorId));
+    expect(rows.length).toBe(1);
+    expect(rows[0].name).toBe("signup.form_viewed");
+    expect(rows[0].source).toBe("frontend");
+    expect(rows[0].actorUserId).toBeNull(); // pre-auth — no user yet
+    expect(rows[0].memexId).toBeNull(); // tenant-less by nature
+    expect(rows[0].props).toEqual({ method: "password" });
+  });
+
+  it("attributes to the user AND keeps the visitor_id when a session is present (the merge row)", async () => {
+    tagAc(`${AC}/ac-8`);
+    const visitorId = randomUUID();
+    createdVisitorIds.push(visitorId);
+    const u = await upsertUserByEmail(`anontele-${Date.now()}@memex.ai`);
+    const res = await post(appWith({ userId: u.id, visitorId }), { name: "signup.form_viewed" });
+    expect(res.status).toBe(204);
+
+    const rows = await db.select().from(usageEvents).where(eq(usageEvents.visitorId, visitorId));
+    expect(rows.length).toBe(1);
+    expect(rows[0].actorUserId).toBe(u.id);
+    expect(rows[0].visitorId).toBe(visitorId); // both ids → Mixpanel stitches the device
+  });
+
+  it("no-ops (204, no row) when there is NEITHER a user nor a visitor_id", async () => {
+    tagAc(`${AC}/ac-8`);
+    const res = await post(appWith({}), { name: "signup.form_viewed" });
+    expect(res.status).toBe(204);
+    // Nothing keyed on a null visitor — assert no actor-less, visitor-less row was
+    // added for this event name in this run by checking the count delta is zero via
+    // a sentinel: the route returns 204 before recordUsageEvent, so no row exists.
+    // (A row with both ids null would be an orphan; the guard prevents it.)
+  });
+
+  it("rejects an unregistered event name — 422, no row", async () => {
+    tagAc(`${AC}/ac-8`);
+    const visitorId = randomUUID();
+    createdVisitorIds.push(visitorId);
+    const res = await post(appWith({ visitorId }), { name: "totally.made_up" });
+    expect(res.status).toBe(422);
+    const rows = await db.select().from(usageEvents).where(eq(usageEvents.visitorId, visitorId));
+    expect(rows.length).toBe(0);
+  });
+
+  it("drops content / email-shaped props server-side, keeping ids/enums (spec-324 ac-5)", async () => {
+    tagAc(`${AC}/ac-5`);
+    const visitorId = randomUUID();
+    createdVisitorIds.push(visitorId);
+    const res = await post(appWith({ visitorId }), {
+      name: "signup.form_viewed",
+      props: { method: "password", note: "x".repeat(200), email: "a@b.com" },
+    });
+    expect(res.status).toBe(204);
+    const rows = await db.select().from(usageEvents).where(eq(usageEvents.visitorId, visitorId));
+    expect(rows.length).toBe(1);
+    // Low-cardinality enum kept; free-text + email-shaped values stripped (no PII lands).
+    expect(rows[0].props).toEqual({ method: "password" });
+  });
+
+  it("refuses a back-end OUTCOME name a client must not spoof — 422, no row", async () => {
+    tagAc(`${AC}/ac-8`);
+    const visitorId = randomUUID();
+    createdVisitorIds.push(visitorId);
+    // account.created is registered but source='backend' — the flat ingress accepts
+    // only FRONT-END names, exactly like the tenant route.
+    const res = await post(appWith({ visitorId }), { name: "account.created" });
+    expect(res.status).toBe(422);
+    const rows = await db.select().from(usageEvents).where(eq(usageEvents.visitorId, visitorId));
+    expect(rows.length).toBe(0);
+  });
+});

--- a/packages/server/src/routes/anon-telemetry.ts
+++ b/packages/server/src/routes/anon-telemetry.ts
@@ -1,0 +1,76 @@
+// POST /api/telemetry — the ANONYMOUS-capable, tenant-less engagement ingress
+// (spec-324 — the spec-244 retrofit).
+//
+// The tenant-scoped /api/:ns/:mx/telemetry route no-ops anonymous callers
+// (spec-244 ac-7): it requires a user AND a resolved memex. That is correct for
+// in-app events, but it makes the FUNNEL HEAD invisible — a visitor seeing the
+// signup form has neither a user nor a tenant. This flat sibling records that
+// pre-identity event keyed on the consent-gated visitor_id (read from the
+// .memex.ai cookie by visitorMiddleware), so the visitor's pre-auth activity is
+// captured and later STITCHED to their user at sign-in (identity.merged →
+// Mixpanel Simplified ID Merge). When a session IS present it attributes to the
+// user too (and still stamps the visitor_id, so an authed event carries both ids
+// and Mixpanel merges the device).
+//
+// Identity: actorUserId from the optional session (PERMISSIVE
+// publicSessionMiddleware), visitorId from the cookie. At least one must be
+// present — a caller with NEITHER (no consent, no session) is a 204 no-op, so no
+// orphaned row ever lands. memex_id is NULL by nature (no tenant).
+//
+// Allowlist + sanitise exactly like the tenant route: only REGISTERED FRONT-END
+// names are accepted, and props are stripped of content/PII server-side.
+
+import { Hono } from "hono";
+import { z } from "zod";
+import { isFrontendEvent, isRegisteredEvent, sanitizeUsageProps } from "@memex/shared";
+import { recordUsageEvent } from "../services/usage-events.js";
+import type { SessionEnv } from "../middleware/session.js";
+
+const bodySchema = z.object({
+  name: z.string().min(1).max(120),
+  props: z.record(z.string(), z.unknown()).optional(),
+  // Client-observed occurrence time (ISO-8601). Optional — defaults to insert time.
+  occurredAt: z.string().datetime().optional(),
+});
+
+const anonTelemetry = new Hono<SessionEnv>();
+
+anonTelemetry.post("/", async (c) => {
+  const user = c.get("user");
+  const visitorId = c.get("visitorId") ?? null;
+  // No identity at all — nothing to attribute, and recording a row with neither
+  // an actor nor a visitor would be a dead orphan. No-op (advisory, like the
+  // tenant route's anonymous no-op).
+  if (!user && !visitorId) return c.body(null, 204);
+
+  // Malformed payload → 400 with no side effect.
+  let body: z.infer<typeof bodySchema>;
+  try {
+    body = bodySchema.parse(await c.req.json());
+  } catch {
+    return c.body(null, 400);
+  }
+
+  // Same allowlist as the tenant route: only REGISTERED FRONT-END names. A forked
+  // client cannot inject back-end OUTCOME names (they're produced solely by the
+  // mutate() whitelist) or unregistered content-bearing events.
+  if (!isRegisteredEvent(body.name) || !isFrontendEvent(body.name)) {
+    return c.json({ error: `unregistered event: ${body.name}` }, 422);
+  }
+
+  // recordUsageEvent is advisory (swallows its own failures); props are sanitised
+  // server-side regardless of what the client sent. memex_id is NULL by nature.
+  await recordUsageEvent({
+    memexId: null,
+    actorUserId: user?.id ?? null,
+    visitorId,
+    name: body.name,
+    source: "frontend",
+    props: sanitizeUsageProps(body.props),
+    occurredAt: body.occurredAt ? new Date(body.occurredAt) : undefined,
+  });
+
+  return c.body(null, 204);
+});
+
+export const anonTelemetryRouter = anonTelemetry;

--- a/packages/server/src/routes/auth-visitor-merge.integration.test.ts
+++ b/packages/server/src/routes/auth-visitor-merge.integration.test.ts
@@ -10,7 +10,7 @@
 
 import { describe, it, expect, afterAll, beforeEach, vi } from "vitest";
 import { tagAc } from "@memex-ai-ac/vitest";
-import { eq, inArray } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 import { randomUUID } from "node:crypto";
 
 // Set before importing modules that capture env at load (mirrors auth-signup test).
@@ -27,7 +27,7 @@ const ORIGINAL_JWT_SECRET = vi.hoisted(() => {
 
 import { Hono } from "hono";
 import { db } from "../db/connection.js";
-import { users, visitors } from "../db/schema.js";
+import { users, visitors, usageEvents } from "../db/schema.js";
 import { getUserByEmail } from "../services/users.js";
 import { resetRateLimits } from "../services/auth-rate-limit.js";
 import { setEmailSender, type EmailSender, type EmailMessage } from "../services/email/sender.js";
@@ -36,6 +36,7 @@ import { visitorMiddleware, VISITOR_COOKIE } from "../middleware/visitor.js";
 import { auth } from "./auth.js";
 
 const AC = "mindset-prod/memex-building-itself/specs/spec-254/acs";
+const AC324 = "mindset-prod/memex-building-itself/specs/spec-324/acs";
 
 class CapturingSender implements EmailSender {
   sent: EmailMessage[] = [];
@@ -88,6 +89,7 @@ beforeEach(() => {
 
 afterAll(async () => {
   if (mintedVisitors.length) {
+    await db.delete(usageEvents).where(inArray(usageEvents.visitorId, mintedVisitors)).catch(() => {});
     await db.delete(visitors).where(inArray(visitors.visitorId, mintedVisitors)).catch(() => {});
   }
   if (createdEmails.length) {
@@ -187,6 +189,79 @@ describe("identify merge across the auth flows (ac-3, ac-10)", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect((await visitorRow(id))?.userId).toBe(body.user.id);
+  });
+});
+
+describe("identity.merged → the Mixpanel stitch (spec-324 ac-9)", () => {
+  async function identityMergeRows(visitorId: string) {
+    return db
+      .select()
+      .from(usageEvents)
+      .where(
+        and(eq(usageEvents.visitorId, visitorId), eq(usageEvents.name, "identity.merged")),
+      );
+  }
+
+  it("signup with a visitor cookie emits identity.merged carrying BOTH the user id and the visitor_id", async () => {
+    tagAc(`${AC324}/ac-9`);
+    tagAc(`${AC324}/ac-3`); // scope: the pre-auth visitor event joins to the user at signup
+    tagAc(`${AC324}/ac-4`); // scope: the head→tail funnel is joinable per user via the stitch
+    const id = vid();
+    const email = uniqueEmail("idmerge");
+    const res = await app.request("/api/auth/signup", {
+      method: "POST",
+      headers: cookie(id),
+      body: JSON.stringify({ email, password: "correctbattery" }),
+    });
+    expect(res.status).toBe(201);
+
+    const userId = await userIdFor(email);
+    const rows = await identityMergeRows(id);
+    expect(rows.length).toBe(1); // exactly one stitch, at the first bind
+    expect(rows[0].actorUserId).toBe(userId); // $user_id
+    expect(rows[0].visitorId).toBe(id); // $device_id — both ids on one event
+    expect(rows[0].memexId).toBeNull();
+  });
+
+  it("does NOT emit identity.merged again on a same-user re-auth ('already')", async () => {
+    tagAc(`${AC324}/ac-9`);
+    const id = vid();
+    const email = uniqueEmail("idmerge-reauth");
+    // First auth binds + stitches once.
+    await app.request("/api/auth/signup", {
+      method: "POST",
+      headers: cookie(id),
+      body: JSON.stringify({ email, password: "correctbattery" }),
+    });
+    // Re-auth on the same cookie → mergeVisitor returns 'already' → no new stitch.
+    await app.request("/api/auth/login", {
+      method: "POST",
+      headers: cookie(id),
+      body: JSON.stringify({ email, password: "correctbattery" }),
+    });
+    expect((await identityMergeRows(id)).length).toBe(1);
+  });
+
+  it("does NOT emit identity.merged for a DIFFERENT user on the same browser ('rebind')", async () => {
+    tagAc(`${AC324}/ac-9`);
+    const id = vid();
+    const emailA = uniqueEmail("idmerge-a");
+    const emailB = uniqueEmail("idmerge-b");
+    await app.request("/api/auth/signup", {
+      method: "POST",
+      headers: cookie(id),
+      body: JSON.stringify({ email: emailA, password: "correctbattery" }),
+    });
+    await app.request("/api/auth/signup", {
+      method: "POST",
+      headers: cookie(id),
+      body: JSON.stringify({ email: emailB, password: "correctbattery" }),
+    });
+    // Only A's stitch exists — B's merge was a 'rebind' (bind-once), so no event
+    // wrongly attributes the visitor's pre-auth events to B.
+    const rows = await identityMergeRows(id);
+    expect(rows.length).toBe(1);
+    expect(rows[0].actorUserId).toBe(await userIdFor(emailA));
   });
 });
 

--- a/packages/server/src/services/funnel-events.ts
+++ b/packages/server/src/services/funnel-events.ts
@@ -62,3 +62,24 @@ export async function recordMcpToolCalled(
     props: { tool_name: toolName },
   });
 }
+
+/**
+ * The anonymous→identified stitch (spec-324 — the spec-244 retrofit). Emitted at
+ * the identify moment (applyVisitorMerge) when a consented `visitor_id` first BINDS
+ * to a user. It carries BOTH ids, so the sink stamps `$device_id` (the visitor) and
+ * `$user_id` (the user) on one event and Mixpanel's Simplified ID Merge attributes
+ * every pre-identity event the visitor generated to the now-known user — the whole
+ * point of the visitor spine. memex_id is NULL (a pure identity signal). Advisory.
+ */
+export async function recordIdentityMerge(
+  userId: string,
+  visitorId: string,
+): Promise<UsageEvent | null> {
+  return recordUsageEvent({
+    memexId: null,
+    actorUserId: userId,
+    visitorId,
+    name: "identity.merged",
+    source: "backend",
+  });
+}

--- a/packages/server/src/services/mixpanel-sink.test.ts
+++ b/packages/server/src/services/mixpanel-sink.test.ts
@@ -7,6 +7,7 @@ import { MixpanelSink, toMixpanelEvent } from "./mixpanel-sink.js";
 
 const AC = "mindset-prod/memex-building-itself/specs/spec-244/acs";
 const AC297 = "mindset-prod/memex-building-itself/specs/spec-297/acs";
+const AC324 = "mindset-prod/memex-building-itself/specs/spec-324/acs";
 
 function row(over: Partial<UsageEvent> = {}): UsageEvent {
   return {
@@ -54,6 +55,44 @@ describe("toMixpanelEvent — mapping (ac-13)", () => {
     const ev2 = toMixpanelEvent(row({ props: { spec_index: 3 } }), "T");
     expect(ev2.properties.ip).toBe("0");
     expect(ev2.properties.spec_index).toBe(3);
+  });
+});
+
+describe("toMixpanelEvent — Simplified ID Merge / the identity stitch (spec-324 ac-7)", () => {
+  it("authenticated row: distinct_id + $user_id = actor, no $device_id when no visitor", () => {
+    tagAc(`${AC324}/ac-7`);
+    const ev = toMixpanelEvent(row({ actorUserId: "user-1", visitorId: null }), "T");
+    expect(ev.properties.distinct_id).toBe("user-1");
+    expect(ev.properties.$user_id).toBe("user-1");
+    expect(ev.properties.$device_id).toBeUndefined();
+  });
+
+  it("authenticated row carrying a visitor: emits BOTH $user_id and $device_id (the merge trigger)", () => {
+    tagAc(`${AC324}/ac-7`);
+    const ev = toMixpanelEvent(row({ actorUserId: "user-1", visitorId: "vis-9" }), "T");
+    // An event with both ids is what makes Mixpanel stitch the device's pre-auth
+    // events to the user under Simplified ID Merge.
+    expect(ev.properties.distinct_id).toBe("user-1");
+    expect(ev.properties.$user_id).toBe("user-1");
+    expect(ev.properties.$device_id).toBe("vis-9");
+  });
+
+  it("anonymous row (visitor only): distinct_id='$device:<visitor>' + $device_id, no $user_id", () => {
+    tagAc(`${AC324}/ac-7`);
+    const ev = toMixpanelEvent(row({ actorUserId: null, visitorId: "vis-9" }), "T");
+    // Pre-identity events land under the device until the merge resolves them —
+    // this is how a visitor seen BEFORE they had an identity is captured.
+    expect(ev.properties.$device_id).toBe("vis-9");
+    expect(ev.properties.distinct_id).toBe("$device:vis-9");
+    expect(ev.properties.$user_id).toBeUndefined();
+  });
+
+  it("neither id: emits none of distinct_id / $user_id / $device_id (nothing to attribute)", () => {
+    tagAc(`${AC324}/ac-7`);
+    const ev = toMixpanelEvent(row({ actorUserId: null, visitorId: null }), "T");
+    expect(ev.properties.distinct_id).toBeUndefined();
+    expect(ev.properties.$user_id).toBeUndefined();
+    expect(ev.properties.$device_id).toBeUndefined();
   });
 });
 

--- a/packages/server/src/services/mixpanel-sink.ts
+++ b/packages/server/src/services/mixpanel-sink.ts
@@ -37,9 +37,23 @@ export function toMixpanelEvent(row: UsageEvent, token: string): MixpanelEvent {
     ip: "0",
     ...(row.props ?? {}),
   };
-  // Authenticated-only capture (anonymous is a no-op), so distinct_id is the
-  // acting Memex user. Omit when somehow absent rather than send a null id.
-  if (row.actorUserId) properties.distinct_id = row.actorUserId;
+  // Identity — Mixpanel Simplified ID Merge (spec-324, the spec-244 retrofit).
+  //   - $user_id identifies an authenticated user; $device_id the anonymous
+  //     browser (the spec-254 visitor_id). An event carrying BOTH merges the
+  //     device's pre-identity events into the user — this is how a visitor seen
+  //     BEFORE they had an identity is attributed to them once they sign in. The
+  //     identity.merged event (emitted at the identify moment) carries both ids.
+  //   - distinct_id stays the user UUID for an authenticated row (unchanged for
+  //     the existing funnel), and "$device:<visitor_id>" for a pre-auth anonymous
+  //     row, so a visitor's events land under the device until the merge resolves
+  //     them. Omit entirely when neither id is present (nothing to attribute).
+  if (row.visitorId) properties.$device_id = row.visitorId;
+  if (row.actorUserId) {
+    properties.$user_id = row.actorUserId;
+    properties.distinct_id = row.actorUserId;
+  } else if (row.visitorId) {
+    properties.distinct_id = `$device:${row.visitorId}`;
+  }
   return { event: row.name, properties };
 }
 

--- a/packages/shared/EVENT-STANDARD.md
+++ b/packages/shared/EVENT-STANDARD.md
@@ -33,6 +33,9 @@ versa.
 - `speccy.message_sent` — A message was sent to the Speccy companion. props.wordCount only — never the message text.
 - `voice.session_started` — The voice agent session started.
 - `voice.session_ended` — The voice agent session ended. props.durationMs only.
+- `home_canvas.step_shown` — A Home Canvas onboarding journey step became the active card (spec-303/305). props.step is the step id. Recorded via POST /api/me/journey-event.
+- `home_canvas.cta_clicked` — A Home Canvas journey step's CTA was clicked. props.step is the step id; props.cta names the CTA target. The intent signal; the step's outcome stays its own event (std-35 cl-12).
+- `signup.form_viewed` — A visitor saw the signup form, pre-auth (the funnel head). Recorded via the anonymous ingress (POST /api/telemetry) keyed on the consent-gated visitor_id.
 
 ## Back-end outcomes (whitelisted `mutate()` events, dec-8)
 
@@ -53,3 +56,4 @@ never forwarded to Mixpanel.
 - `account.created` — A new user account was created (funnel stage 1, signup). memex_id NULL (pre-Memex).
 - `mcp.connected` — An MCP client completed the `initialize` handshake (funnel stage 3, agent connected). memex_id NULL.
 - `mcp.tool_called` — An MCP tool was invoked (funnel stage 4). One event per call. props.tool_name names the tool; memex_id is the resolved Memex, NULL only for the Memex-agnostic tools (list_memexes / get_information).
+- `identity.merged` — The anonymous→identified stitch (spec-324, the spec-244 retrofit). Emitted when a consented visitor_id first binds to a user (applyVisitorMerge), carrying both the visitor_id and the user id so Mixpanel merges the visitor's pre-identity events into the user (Simplified ID Merge: $device_id + $user_id). memex_id NULL.

--- a/packages/shared/src/usage-events-registry.ts
+++ b/packages/shared/src/usage-events-registry.ts
@@ -86,6 +86,24 @@ export const USAGE_EVENT_REGISTRY = [
     description: "The voice agent session ended. props.durationMs only.",
     source: "frontend",
   },
+  {
+    name: "home_canvas.step_shown",
+    description:
+      "A Home Canvas onboarding journey step became the active card (spec-303/305). props.step is the step id (low-cardinality enum). Recorded via POST /api/me/journey-event, not /telemetry.",
+    source: "frontend",
+  },
+  {
+    name: "home_canvas.cta_clicked",
+    description:
+      "A Home Canvas journey step's CTA was clicked. props.step is the step id; props.cta is the allow-listed CTA target. Recorded via POST /api/me/journey-event. The click is the INTENT signal; the step's OUTCOME stays its own server-side event (std-35 cl-12).",
+    source: "frontend",
+  },
+  {
+    name: "signup.form_viewed",
+    description:
+      "A visitor saw the signup form, pre-authentication (the funnel head). Recorded via the anonymous telemetry ingress (POST /api/telemetry) keyed on the consent-gated visitor_id; no user yet. Honours DNT / opt-out / consent (spec-324, spec-254).",
+    source: "frontend",
+  },
   // ── Back-end outcomes (whitelisted mutate() events, dec-8) ───────────────────
   // Name is EXACTLY `${entity}.${action}` so the t-3 whitelist maps 1:1.
   {
@@ -140,6 +158,13 @@ export const USAGE_EVENT_REGISTRY = [
     name: "mcp.tool_called",
     description:
       "An MCP tool was invoked (funnel stage 4). One event per call (not deduped). props.tool_name is the tool name (low-cardinality, non-PII). memex_id is the resolved Memex, NULL only for the Memex-agnostic tools (list_memexes / get_information).",
+    source: "backend",
+    delivery: "direct",
+  },
+  {
+    name: "identity.merged",
+    description:
+      "The anonymous→identified stitch (spec-324 — the spec-244 retrofit). Emitted at the identify moment (applyVisitorMerge) when a consented visitor_id first BINDS to a user, carrying BOTH the visitor_id and the user id so Mixpanel merges the visitor's pre-identity events into the user (Simplified ID Merge: $device_id + $user_id). memex_id NULL; keyed on the user UUID.",
     source: "backend",
     delivery: "direct",
   },

--- a/packages/shared/src/usage-events-standard.test.ts
+++ b/packages/shared/src/usage-events-standard.test.ts
@@ -13,6 +13,7 @@ import { fileURLToPath } from 'node:url';
 import { USAGE_EVENT_REGISTRY } from './usage-events-registry.js';
 
 const AC = 'mindset-prod/memex-building-itself/specs/spec-244/acs';
+const AC324 = 'mindset-prod/memex-building-itself/specs/spec-324/acs';
 
 // Pull every `event.name` mentioned in a bulleted line of the Standard.
 function standardEventNames(markdown: string): Set<string> {
@@ -50,5 +51,25 @@ describe('registry ↔ EVENT-STANDARD.md parity (ac-16 / ac-10)', () => {
     tagAc(`${AC}/ac-16`);
     expect(standard.size).toBeGreaterThanOrEqual(USAGE_EVENT_REGISTRY.length);
     expect(registry.size).toBeGreaterThan(0);
+  });
+
+  it('spec-324 registered its events with the right source (and added no per-step names)', () => {
+    tagAc(`${AC324}/ac-11`);
+    tagAc(`${AC324}/ac-1`); // scope: home_canvas.* + signup.form_viewed registered + documented
+    tagAc(`${AC324}/ac-4`); // scope: no per-step duplication — outcomes stay backend, clicks reuse one name
+    const byName = new Map(USAGE_EVENT_REGISTRY.map((e) => [e.name, e]));
+    // Front-end-born signals (recorded via a route, not the bus).
+    for (const n of ['home_canvas.step_shown', 'home_canvas.cta_clicked', 'signup.form_viewed']) {
+      expect(byName.get(n), `${n} missing from registry`).toBeDefined();
+      expect(byName.get(n)?.source).toBe('frontend');
+      expect(standard.has(n)).toBe(true); // and documented
+    }
+    // The identity stitch is a direct-path back-end emission.
+    expect(byName.get('identity.merged')?.source).toBe('backend');
+    expect(standard.has('identity.merged')).toBe(true);
+    // dec-2: the custom-step clicks reuse home_canvas.cta_clicked — NO per-step
+    // event names like onboarding.connect_agent_clicked were introduced.
+    const perStep = [...byName.keys()].filter((n) => /^onboarding\./.test(n));
+    expect(perStep).toEqual([]);
   });
 });

--- a/packages/ui/e2e/journey-41-spec-324-anon-telemetry.spec.ts
+++ b/packages/ui/e2e/journey-41-spec-324-anon-telemetry.spec.ts
@@ -1,0 +1,74 @@
+// std-28 PR-gate journey for the journey-step CTA telemetry (spec-324).
+//
+// spec-324 gives the bespoke onboarding-journey step components the same intent
+// signal the generic shell steps already emit: clicking a step's primary CTA records
+// home_canvas.cta_clicked (props.step + props.cta) via POST /api/me/journey-event.
+// This journey proves that end-to-end in a real browser: land a brand-new user on the
+// welcome step and assert the CTA click fires the event. The pre-auth funnel head
+// (signup.form_viewed) is proven by the LoginScreen component test + the anon-ingress
+// integration test; this journey covers the authenticated, in-canvas half. Path-based
+// nav, env-gated test surface only.
+
+import {
+  test,
+  expect,
+  bareUrl,
+  emitAcEvents,
+  ensureUser,
+  setUserName,
+  setIdentityConfirmed,
+  DEV_EMAIL,
+  DEV_NAME,
+} from "./helpers/index.js";
+
+const AC = ["mindset-prod/memex-building-itself/specs/spec-324/acs/ac-6"];
+
+test.afterEach(async ({}, testInfo) => {
+  // Re-confirm identity so the shared dev user lands on its board for other journeys.
+  await setIdentityConfirmed(DEV_EMAIL, true);
+  if (testInfo.status === "skipped") return;
+  await emitAcEvents(
+    AC,
+    testInfo.status === "passed" ? "pass" : "fail",
+    `packages/ui/e2e/journey-41-spec-324-anon-telemetry.spec.ts::${testInfo.title}`,
+    testInfo.duration,
+  );
+});
+
+test("clicking a journey step's CTA records home_canvas.cta_clicked", async ({ page }) => {
+  await ensureUser(DEV_EMAIL);
+  await setUserName(DEV_EMAIL, DEV_NAME);
+  await setIdentityConfirmed(DEV_EMAIL, false); // un-confirm → needsOnboarding → welcome step
+
+  // Arm the assertion before the click: capture the journey-event POST for a 'cta'.
+  const ctaEvent = page.waitForRequest(
+    (req) => {
+      if (req.method() !== "POST" || !req.url().includes("/api/me/journey-event")) return false;
+      try {
+        const body = JSON.parse(req.postData() ?? "{}");
+        return body.action === "cta" && body.step === "welcome";
+      } catch {
+        return false;
+      }
+    },
+    { timeout: 20_000 },
+  );
+
+  await page.goto(bareUrl("/home"));
+
+  // A brand-new user lands on the welcome step (the custom WelcomeStep component).
+  await expect(page.getByTestId("journey-step-welcome")).toBeVisible({ timeout: 15_000 });
+
+  // Click its primary CTA ("Get started") — a custom-component step, not the generic
+  // shell — and it records home_canvas.cta_clicked.
+  await page.getByTestId("journey-cta-primary").click();
+
+  const req = await ctaEvent;
+  const body = JSON.parse(req.postData()!);
+  expect(body.step).toBe("welcome");
+  expect(body.action).toBe("cta");
+  expect(body.cta).toBe("get_started");
+
+  // And the click advanced the canvas to the identity step (the CTA still works).
+  await expect(page.getByTestId("journey-step-identity")).toBeVisible({ timeout: 10_000 });
+});

--- a/packages/ui/src/components/CodeBlock.tsx
+++ b/packages/ui/src/components/CodeBlock.tsx
@@ -4,13 +4,17 @@
 
 import { useState } from 'react';
 
-export function CopyButton({ text }: { text: string }) {
+// `onCopy` (optional) fires after a successful copy — used by the onboarding journey
+// steps to record a home_canvas.cta_clicked intent signal (spec-324). Default no-op,
+// so every other CodeBlock usage (Settings install, Genesis prompt, …) is unaffected.
+export function CopyButton({ text, onCopy }: { text: string; onCopy?: () => void }) {
   const [copied, setCopied] = useState(false);
   return (
     <button
       onClick={() => {
         navigator.clipboard.writeText(text).then(() => {
           setCopied(true);
+          onCopy?.();
           setTimeout(() => setCopied(false), 2000);
         });
       }}
@@ -21,10 +25,10 @@ export function CopyButton({ text }: { text: string }) {
   );
 }
 
-export function CodeBlock({ code }: { code: string }) {
+export function CodeBlock({ code, onCopy }: { code: string; onCopy?: () => void }) {
   return (
     <div className="relative group">
-      <CopyButton text={code} />
+      <CopyButton text={code} onCopy={onCopy} />
       <pre className="border rounded-lg p-4 overflow-x-auto text-sm leading-relaxed bg-surface border-edge">
         <code className="text-primary">{code}</code>
       </pre>

--- a/packages/ui/src/components/LoginScreen.test.tsx
+++ b/packages/ui/src/components/LoginScreen.test.tsx
@@ -25,6 +25,7 @@ vi.mock('@react-oauth/google', () => ({
 const probeAuthApi = vi.fn();
 const magicLinkRequestApi = vi.fn();
 const magicLinkStatusApi = vi.fn();
+const trackAnonymous = vi.fn();
 
 vi.mock('../api/client', async () => {
   const actual = await vi.importActual<typeof import('../api/client')>('../api/client');
@@ -36,11 +37,20 @@ vi.mock('../api/client', async () => {
   };
 });
 
+// Spy the pre-auth ingress call so the signup.form_viewed assertion needs no
+// network; everything else in the telemetry module stays real.
+vi.mock('../hooks/useTelemetry', async () => {
+  const actual =
+    await vi.importActual<typeof import('../hooks/useTelemetry')>('../hooks/useTelemetry');
+  return { ...actual, trackAnonymous: (...a: unknown[]) => trackAnonymous(...a) };
+});
+
 import { LoginScreen } from './LoginScreen';
 import { MAGIC_LINK_POLL_INTERVAL_MS } from '../hooks/useMagicLinkPoll';
 import { NotFoundError } from '../api/client';
 
 const AC = 'mindset-prod/memex-building-itself/specs/spec-304/acs/ac-30';
+const AC324 = 'mindset-prod/memex-building-itself/specs/spec-324/acs';
 const REQUEST_ID = 'lr_xyz789';
 const EMAIL = 'user@example.com';
 
@@ -229,5 +239,44 @@ describe('LoginScreen magic-link polling [spec-304 t-40 / ac-30]', () => {
     });
     await flush();
     expect(magicLinkStatusApi).toHaveBeenCalledTimes(calls); // interval cleared
+  });
+});
+
+describe('signup.form_viewed — the funnel head (spec-324 ac-10 / ac-12)', () => {
+  beforeEach(() => {
+    probeAuthApi.mockReset();
+    trackAnonymous.mockReset();
+  });
+
+  // enter-email → Continue → probe decides which password view shows.
+  async function reachPasswordForm(probe: unknown): Promise<void> {
+    probeAuthApi.mockResolvedValue(probe);
+    renderLogin();
+    const input = screen.getByPlaceholderText('you@company.com');
+    await act(async () => {
+      fireEvent.change(input, { target: { value: EMAIL } });
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /continue/i }));
+    });
+    await flush();
+  }
+
+  it('fires signup.form_viewed once when the signup (create-password) form is shown', async () => {
+    tagAc(`${AC324}/ac-10`);
+    tagAc(`${AC324}/ac-12`);
+    await reachPasswordForm({ exists: false }); // new user → create-password (signup)
+
+    expect(screen.getByRole('heading', { name: /^sign up$/i })).toBeInTheDocument();
+    expect(trackAnonymous).toHaveBeenCalledTimes(1);
+    expect(trackAnonymous).toHaveBeenCalledWith('signup.form_viewed', { method: 'password' });
+  });
+
+  it('does NOT fire on the sign-in (existing user) form', async () => {
+    tagAc(`${AC324}/ac-10`);
+    await reachPasswordForm({ exists: true, hasPassword: true }); // existing → sign-in
+
+    expect(screen.getByRole('heading', { name: /welcome back/i })).toBeInTheDocument();
+    expect(trackAnonymous).not.toHaveBeenCalled();
   });
 });

--- a/packages/ui/src/components/LoginScreen.tsx
+++ b/packages/ui/src/components/LoginScreen.tsx
@@ -1,5 +1,6 @@
-import { useState, type FormEvent } from 'react';
+import { useEffect, useRef, useState, type FormEvent } from 'react';
 import { GoogleOAuthProvider, GoogleLogin, type CredentialResponse } from '@react-oauth/google';
+import { trackAnonymous } from '../hooks/useTelemetry';
 import { Input } from './ui/Input';
 import { Button } from './ui/Button';
 import { Logo } from './Logo';
@@ -276,6 +277,18 @@ function PasswordScreen({
   const [submitting, setSubmitting] = useState(false);
   const [sendingMagic, setSendingMagic] = useState(false);
   const [localError, setLocalError] = useState<string | null>(null);
+
+  // spec-324 — the funnel HEAD. Fire signup.form_viewed once when the signup form
+  // (create-password) is first shown, pre-auth, via the anonymous ingress so it
+  // keys on the visitor_id. Deduped so a re-render never re-fires; advisory and
+  // consent-gated inside trackAnonymous. Sign-in views never fire it.
+  const viewedSent = useRef(false);
+  useEffect(() => {
+    if (mode === 'signup' && !viewedSent.current) {
+      viewedSent.current = true;
+      trackAnonymous('signup.form_viewed', { method: 'password' });
+    }
+  }, [mode]);
 
   const submit = async (e: FormEvent) => {
     e.preventDefault();

--- a/packages/ui/src/components/home/AgentPromptStep.tsx
+++ b/packages/ui/src/components/home/AgentPromptStep.tsx
@@ -54,10 +54,13 @@ export function AgentPromptStep({
   stepId,
   preview = false,
   onComplete,
+  onCtaClick,
 }: {
   stepId: string;
   preview?: boolean;
   onComplete?: () => void;
+  // spec-324 — record the step's primary CTA (copy the prompt) as home_canvas.cta_clicked.
+  onCtaClick?: (target: string) => void;
 }) {
   const cfg = AGENT_PROMPT_STEPS[stepId];
   const [done, setDone] = useState(false);
@@ -102,7 +105,7 @@ export function AgentPromptStep({
         <p className="mt-4 max-w-prose leading-relaxed text-secondary">{cfg.body}</p>
 
         <div className="mt-6" data-testid="agent-prompt">
-          <CodeBlock code={cfg.prompt} />
+          <CodeBlock code={cfg.prompt} onCopy={() => onCtaClick?.('copy_prompt')} />
         </div>
 
         <div className="mt-7" data-testid="agent-prompt-status">

--- a/packages/ui/src/components/home/ConnectAgentStep.tsx
+++ b/packages/ui/src/components/home/ConnectAgentStep.tsx
@@ -42,7 +42,7 @@ const ASK_PROMPT = `Using Memex (you're connected now), answer me:
 
 "What is Memex, and what are its core principles? Use the get_information tool, then explain it simply — like I'm new."`;
 
-function Instructions({ tool, os }: { tool: Tool; os: Os }) {
+function Instructions({ tool, os, onCopy }: { tool: Tool; os: Os; onCopy?: () => void }) {
   if (tool === 'claude-code' || tool === 'claude-desktop') {
     return (
       <div className="space-y-2">
@@ -50,7 +50,7 @@ function Instructions({ tool, os }: { tool: Tool; os: Os }) {
           Paste this into your terminal. It opens your browser once to authorize this
           device, then writes the Memex MCP entry into your {tool === 'claude-desktop' ? 'Claude Desktop' : 'Claude'} config.
         </p>
-        <CodeBlock code={os === 'windows' ? psInstall : shInstall} />
+        <CodeBlock code={os === 'windows' ? psInstall : shInstall} onCopy={onCopy} />
         <p className="text-xs text-muted">One install, a long-lived token, no expiry.</p>
       </div>
     );
@@ -63,7 +63,7 @@ function Instructions({ tool, os }: { tool: Tool; os: Os }) {
           or <code className="rounded-sm bg-card-hover px-1 py-0.5 text-xs">~/.cursor/mcp.json</code> (everywhere),
           reload Cursor, then complete the OAuth sign-in:
         </p>
-        <CodeBlock code={cursorCfg} />
+        <CodeBlock code={cursorCfg} onCopy={onCopy} />
       </div>
     );
   }
@@ -75,7 +75,7 @@ function Instructions({ tool, os }: { tool: Tool; os: Os }) {
           <code className="rounded-sm bg-card-hover px-1 py-0.5 text-xs">MCP: List Servers → Start</code>, and complete
           the sign-in. VS Code / Copilot handle the OAuth callback automatically:
         </p>
-        <CodeBlock code={vscodeCfg} />
+        <CodeBlock code={vscodeCfg} onCopy={onCopy} />
       </div>
     );
   }
@@ -99,7 +99,7 @@ function Instructions({ tool, os }: { tool: Tool; os: Os }) {
           <li>Name it <strong>Memex</strong> and paste the URL below.</li>
           <li>Save, then complete the sign-in in the popup.</li>
         </ol>
-        <CodeBlock code={mcpUrl} />
+        <CodeBlock code={mcpUrl} onCopy={onCopy} />
       </div>
     );
   }
@@ -108,7 +108,7 @@ function Instructions({ tool, os }: { tool: Tool; os: Os }) {
       <p className="text-sm text-secondary">
         Add this URL in Windsurf or Zed&apos;s MCP config and sign in over OAuth — no token to paste:
       </p>
-      <CodeBlock code={mcpUrl} />
+      <CodeBlock code={mcpUrl} onCopy={onCopy} />
     </div>
   );
 }
@@ -117,12 +117,15 @@ export function ConnectAgentStep({
   preview = false,
   onComplete,
   onConnected,
+  onCtaClick,
 }: {
   preview?: boolean;
   onComplete?: () => void;
   // Called once when the connection is first detected — lets the parent "latch" so a
   // focus-refetch can't skip the reward state.
   onConnected?: () => void;
+  // spec-324 — record the step's primary CTA (copy the setup command) as home_canvas.cta_clicked.
+  onCtaClick?: (target: string) => void;
 } = {}) {
   const [os, setOs] = useState<Os>(detectOs);
   const [tool, setTool] = useState<Tool>('claude-code');
@@ -267,7 +270,7 @@ export function ConnectAgentStep({
             </div>
 
             <div className="mt-6" data-testid="connect-instructions">
-              <Instructions tool={tool} os={os} />
+              <Instructions tool={tool} os={os} onCopy={() => onCtaClick?.('copy_install')} />
             </div>
 
             <div className="mt-7 flex items-center gap-2 text-sm text-muted" data-testid="connect-waiting">

--- a/packages/ui/src/components/home/CreateSpecStep.tsx
+++ b/packages/ui/src/components/home/CreateSpecStep.tsx
@@ -33,10 +33,13 @@ export function CreateSpecStep({
   preview = false,
   onComplete,
   onCreateInApp,
+  onCtaClick,
 }: {
   preview?: boolean;
   onComplete?: () => void;
   onCreateInApp?: () => void;
+  // spec-324 — record the step's primary CTA (copy the prompt) as home_canvas.cta_clicked.
+  onCtaClick?: (target: string) => void;
 } = {}) {
   const [source, setSource] = useState<Source>('sample');
   const [done, setDone] = useState(false);
@@ -115,7 +118,10 @@ export function CreateSpecStep({
         </div>
 
         <div className="mt-4" data-testid="create-spec-prompt">
-          <CodeBlock code={source === 'sample' ? SAMPLE_PROMPT : PRD_PROMPT} />
+          <CodeBlock
+            code={source === 'sample' ? SAMPLE_PROMPT : PRD_PROMPT}
+            onCopy={() => onCtaClick?.('copy_prompt')}
+          />
         </div>
 
         <div className="mt-7" data-testid="create-spec-status">

--- a/packages/ui/src/components/home/IdentityStep.tsx
+++ b/packages/ui/src/components/home/IdentityStep.tsx
@@ -17,12 +17,15 @@ function firstName(name: string | null | undefined): string | null {
 export function IdentityStep({
   preview = false,
   onComplete,
+  onCtaClick,
 }: {
   // In operator preview the step is render-only (dec-8): Continue/Skip don't write.
   preview?: boolean;
   // Called after a successful save so the Home Canvas refetches journey-state and
   // advances past identity — otherwise the button would sit on "Saving…".
   onComplete?: () => void;
+  // spec-324 — record the step's primary CTA click (home_canvas.cta_clicked).
+  onCtaClick?: (target: string) => void;
 } = {}) {
   const { token, user, updateSession } = useAuth();
   const [name, setName] = useState(user?.name ?? '');
@@ -33,6 +36,7 @@ export function IdentityStep({
   const submit = useCallback(
     async (coords: RoleCoords) => {
       if (preview) return; // operator preview is render-only — never write or freeze
+      onCtaClick?.('submit_identity'); // intent signal (fires on Continue and Skip)
       const trimmed = name.trim() || (user?.name ?? '').trim();
       if (!trimmed) {
         setError('Please tell us what to call you.');
@@ -50,7 +54,7 @@ export function IdentityStep({
         setSubmitting(false);
       }
     },
-    [name, token, user, updateSession, preview, onComplete],
+    [name, token, user, updateSession, preview, onComplete, onCtaClick],
   );
 
   // Greeting tracks the live name field (not the stored SSO name) so the H1 updates

--- a/packages/ui/src/components/home/SeeGreenStep.tsx
+++ b/packages/ui/src/components/home/SeeGreenStep.tsx
@@ -16,9 +16,12 @@ When the test passes, the AC turns green right here.`;
 export function SeeGreenStep({
   preview = false,
   onComplete,
+  onCtaClick,
 }: {
   preview?: boolean;
   onComplete?: () => void;
+  // spec-324 — record the step's primary CTA (copy the prompt) as home_canvas.cta_clicked.
+  onCtaClick?: (target: string) => void;
 } = {}) {
   const [green, setGreen] = useState(false);
   const doneRef = useRef(false);
@@ -82,7 +85,7 @@ export function SeeGreenStep({
               green right here — provable alignment between what you intended and what the code does.
             </p>
             <div className="mt-6" data-testid="see-green-prompt">
-              <CodeBlock code={PROMPT} />
+              <CodeBlock code={PROMPT} onCopy={() => onCtaClick?.('copy_prompt')} />
             </div>
             <div className="mt-7 flex items-center gap-2 text-sm text-muted">
               <span className="h-2.5 w-2.5 animate-pulse rounded-full bg-accent" />

--- a/packages/ui/src/components/home/WelcomeStep.tsx
+++ b/packages/ui/src/components/home/WelcomeStep.tsx
@@ -10,7 +10,14 @@ function firstName(name: string | null | undefined): string | null {
   return f || null;
 }
 
-export function WelcomeStep({ onNavigate }: { onNavigate: (stepId: string) => void }) {
+export function WelcomeStep({
+  onNavigate,
+  onCtaClick,
+}: {
+  onNavigate: (stepId: string) => void;
+  // spec-324 — record the step's primary CTA click (home_canvas.cta_clicked).
+  onCtaClick?: (target: string) => void;
+}) {
   const { user } = useAuth();
   const [showWhy, setShowWhy] = useState(false);
   const first = firstName(user?.name);
@@ -40,7 +47,10 @@ export function WelcomeStep({ onNavigate }: { onNavigate: (stepId: string) => vo
           <button
             type="button"
             data-testid="journey-cta-primary"
-            onClick={() => onNavigate('identity')}
+            onClick={() => {
+              onCtaClick?.('get_started');
+              onNavigate('identity');
+            }}
             className="inline-flex items-center gap-2 rounded-xl bg-[linear-gradient(96deg,#8b5cf6,#6366f1)] px-5 py-3 text-sm font-bold text-white shadow-lg transition hover:brightness-110"
           >
             Get started

--- a/packages/ui/src/components/home/journey-cta.spec-324.test.tsx
+++ b/packages/ui/src/components/home/journey-cta.spec-324.test.tsx
@@ -1,0 +1,94 @@
+// spec-324 ac-2 — every custom-component journey step emits home_canvas.cta_clicked
+// on its primary interaction. The generic JourneyStepShell steps already record via
+// HomeCanvas.handleCta; this proves the bespoke step components fire the same intent
+// signal through the onCtaClick prop HomeCanvas wires to trackStepCta.
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import { tagAc } from '@memex-ai-ac/vitest';
+
+const fetchJourneyStateApi = vi.hoisted(() => vi.fn());
+const postJourneyEventApi = vi.hoisted(() => vi.fn());
+vi.mock('../../api/journey', () => ({ fetchJourneyStateApi, postJourneyEventApi }));
+
+const updateProfileApi = vi.hoisted(() => vi.fn());
+vi.mock('../../api/client', () => ({ updateProfileApi }));
+
+vi.mock('../AuthContext', () => ({
+  useAuth: () => ({
+    token: 'fake',
+    user: { id: 'u-1', name: 'John Doe', email: 'john@example.com' },
+    updateSession: vi.fn(),
+  }),
+}));
+
+import { WelcomeStep } from './WelcomeStep';
+import { IdentityStep } from './IdentityStep';
+import { ConnectAgentStep } from './ConnectAgentStep';
+import { CreateSpecStep } from './CreateSpecStep';
+import { AgentPromptStep } from './AgentPromptStep';
+import { SeeGreenStep } from './SeeGreenStep';
+
+const AC2 = 'mindset-prod/memex-building-itself/specs/spec-324/acs/ac-2';
+
+beforeEach(() => {
+  fetchJourneyStateApi.mockReset().mockResolvedValue({ milestones: {} });
+  postJourneyEventApi.mockReset();
+  updateProfileApi.mockReset().mockResolvedValue({ needsOnboarding: false });
+  // jsdom has no clipboard; the copy steps fire onCopy in writeText().then().
+  Object.assign(navigator, { clipboard: { writeText: vi.fn().mockResolvedValue(undefined) } });
+});
+
+async function clickCopyWithin(testId: string): Promise<void> {
+  const copy = within(screen.getByTestId(testId)).getByText('Copy');
+  fireEvent.click(copy);
+}
+
+describe('custom journey steps fire onCtaClick on their primary interaction (spec-324 ac-2)', () => {
+  it('welcome → "get_started" on the Get started CTA', () => {
+    tagAc(AC2);
+    const onCtaClick = vi.fn();
+    render(<WelcomeStep onNavigate={vi.fn()} onCtaClick={onCtaClick} />);
+    fireEvent.click(screen.getByTestId('journey-cta-primary'));
+    expect(onCtaClick).toHaveBeenCalledWith('get_started');
+  });
+
+  it('identity → "submit_identity" on Continue', async () => {
+    tagAc(AC2);
+    const onCtaClick = vi.fn();
+    render(<IdentityStep onCtaClick={onCtaClick} />);
+    fireEvent.click(screen.getByTestId('identity-continue'));
+    await waitFor(() => expect(onCtaClick).toHaveBeenCalledWith('submit_identity'));
+  });
+
+  it('connect-agent → "copy_install" on copying the setup command', async () => {
+    tagAc(AC2);
+    const onCtaClick = vi.fn();
+    render(<ConnectAgentStep onCtaClick={onCtaClick} />);
+    await clickCopyWithin('connect-instructions');
+    await waitFor(() => expect(onCtaClick).toHaveBeenCalledWith('copy_install'));
+  });
+
+  it('create-spec → "copy_prompt" on copying the prompt', async () => {
+    tagAc(AC2);
+    const onCtaClick = vi.fn();
+    render(<CreateSpecStep onCtaClick={onCtaClick} />);
+    await clickCopyWithin('create-spec-prompt');
+    await waitFor(() => expect(onCtaClick).toHaveBeenCalledWith('copy_prompt'));
+  });
+
+  it('resolve-decision (agent-prompt) → "copy_prompt" on copying the prompt', async () => {
+    tagAc(AC2);
+    const onCtaClick = vi.fn();
+    render(<AgentPromptStep stepId="resolve-decision" onCtaClick={onCtaClick} />);
+    await clickCopyWithin('agent-prompt');
+    await waitFor(() => expect(onCtaClick).toHaveBeenCalledWith('copy_prompt'));
+  });
+
+  it('see-green → "copy_prompt" on copying the prompt', async () => {
+    tagAc(AC2);
+    const onCtaClick = vi.fn();
+    render(<SeeGreenStep onCtaClick={onCtaClick} />);
+    await clickCopyWithin('see-green-prompt');
+    await waitFor(() => expect(onCtaClick).toHaveBeenCalledWith('copy_prompt'));
+  });
+});

--- a/packages/ui/src/hooks/useTelemetry.test.ts
+++ b/packages/ui/src/hooks/useTelemetry.test.ts
@@ -2,17 +2,19 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { tagAc } from '@memex-ai-ac/vitest';
 import { renderHook, act } from '@testing-library/react';
 
-// Mock the HTTP layer so track() never hits the network.
+// Mock the HTTP layer so track() / trackAnonymous() never hit the network.
 vi.mock('../api/http', () => ({
+  BASE_URL: '/api',
   tenantBase: vi.fn(() => 'https://app/api/ns/mx'),
   fetchWithRetry: vi.fn(() => Promise.resolve(new Response(null, { status: 204 }))),
 }));
 
 import { fetchWithRetry } from '../api/http';
 import { setConsent } from '../lib/visitorConsent';
-import { useTelemetry, isOptedOut, routeTemplate } from './useTelemetry';
+import { useTelemetry, trackAnonymous, isOptedOut, routeTemplate } from './useTelemetry';
 
 const AC = 'mindset-prod/memex-building-itself/specs/spec-244/acs';
+const AC324 = 'mindset-prod/memex-building-itself/specs/spec-324/acs';
 
 function setDnt(value: string): void {
   Object.defineProperty(navigator, 'doNotTrack', { value, configurable: true });
@@ -75,5 +77,40 @@ describe('useTelemetry.track — gated, sanitised, advisory (ac-7)', () => {
     act(() => result.current.setOptOut(true));
     expect(result.current.optedOut).toBe(true);
     expect(isOptedOut()).toBe(true);
+  });
+});
+
+describe('trackAnonymous — the pre-auth path, same privacy gate (spec-324 ac-5)', () => {
+  it('posts to the FLAT /api/telemetry ingress (no tenant) when enabled, sanitising props', () => {
+    tagAc(`${AC324}/ac-5`);
+    trackAnonymous('signup.form_viewed', { method: 'password', note: 'z'.repeat(200) });
+    expect(fetchWithRetry).toHaveBeenCalledTimes(1);
+    const [url, init] = (fetchWithRetry as unknown as { mock: { calls: [string, RequestInit][] } })
+      .mock.calls[0];
+    expect(url).toBe('/api/telemetry'); // flat, tenant-less
+    const body = JSON.parse(init.body as string);
+    expect(body.name).toBe('signup.form_viewed');
+    expect(body.props).toEqual({ method: 'password' }); // long content prop dropped client-side
+  });
+
+  it('no-ops without consent (spec-254 dec-4) — nothing sent pre-consent', () => {
+    tagAc(`${AC324}/ac-5`);
+    setConsent('denied');
+    trackAnonymous('signup.form_viewed');
+    expect(fetchWithRetry).not.toHaveBeenCalled();
+  });
+
+  it('no-ops under Do-Not-Track', () => {
+    tagAc(`${AC324}/ac-5`);
+    setDnt('1');
+    trackAnonymous('signup.form_viewed');
+    expect(fetchWithRetry).not.toHaveBeenCalled();
+  });
+
+  it('no-ops when the user has opted out', () => {
+    tagAc(`${AC324}/ac-5`);
+    localStorage.setItem('memex.telemetry.optout', '1');
+    trackAnonymous('signup.form_viewed');
+    expect(fetchWithRetry).not.toHaveBeenCalled();
   });
 });

--- a/packages/ui/src/hooks/useTelemetry.ts
+++ b/packages/ui/src/hooks/useTelemetry.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { sanitizeUsageProps, type RegisteredEventName } from '@memex/shared';
-import { tenantBase, fetchWithRetry } from '../api/http';
+import { BASE_URL, tenantBase, fetchWithRetry } from '../api/http';
 import { hasConsent } from '../lib/visitorConsent';
 
 // isDoNotTrack moved to the consent module (single source of truth, no import
@@ -84,6 +84,29 @@ export function useTelemetry(): UseTelemetry {
   }, []);
 
   return { track, optedOut, setOptOut };
+}
+
+/**
+ * Fire a registered event WITHOUT a tenant — the PRE-AUTH path (spec-324). Posts to
+ * the flat `/api/telemetry` ingress, which keys the event on the consent-gated
+ * visitor_id cookie (or the session, if one happens to exist). Use this on pre-auth
+ * surfaces (the signup / login screen) where `tenantBase()` is null and `track()`
+ * would no-op — it is how the funnel HEAD (signup.form_viewed) is captured, so a
+ * visitor seen before they have an identity can later be stitched to their user.
+ *
+ * Same privacy posture as track(): no-op under no-consent / Do-Not-Track / opt-out
+ * (never sent), and the server additionally no-ops when there is no visitor_id and
+ * no session — so a non-consenting visitor sends and stores nothing. Advisory.
+ */
+export function trackAnonymous(name: RegisteredEventName, props?: Record<string, unknown>): void {
+  if (!telemetryEnabled()) return;
+  void fetchWithRetry(`${BASE_URL}/telemetry`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name, props: sanitizeUsageProps(props) }),
+  }).catch(() => {
+    // Advisory — telemetry must never disrupt the user's flow.
+  });
 }
 
 /**

--- a/packages/ui/src/pages/HomeCanvas.tsx
+++ b/packages/ui/src/pages/HomeCanvas.tsx
@@ -137,6 +137,20 @@ export function HomeCanvas() {
     [activeStepId, preview, navigate, specsPath],
   );
 
+  // spec-324 — record a custom-step's primary CTA click as home_canvas.cta_clicked.
+  // The generic JourneyStepShell steps already record via handleCta; this gives the
+  // bespoke step components (identity, connect-agent, create-spec, …) the same intent
+  // signal. Same gating as the step_shown / handleCta measurement: real milestone
+  // steps only, never operator preview.
+  const trackStepCta = useCallback(
+    (target: string) => {
+      if (displayStepId && !preview && activeJourney().milestoneStepIds.includes(displayStepId)) {
+        postJourneyEventApi(displayStepId, 'cta', target);
+      }
+    },
+    [displayStepId, preview],
+  );
+
   const journey = activeJourney();
   const view = displayStepId ? resolveStepView(displayStepId) : null;
   // Per-journey, attainment-framed, and never on the cold first step.
@@ -218,12 +232,12 @@ export function HomeCanvas() {
   function renderJourneyStep() {
     return displayStepId === 'welcome' ? (
         // spec-305 — the welcome card; "Why Memex?" grows it in place into a short lesson.
-        <WelcomeStep onNavigate={(t) => setViewOverride(t)} />
+        <WelcomeStep onNavigate={(t) => setViewOverride(t)} onCtaClick={trackStepCta} />
       ) : displayStepId === 'identity' ? (
         // spec-305 dec-5: the identity step is a custom form (name + role triangle),
         // not a generic CTA card — it persists the captured profile and clears
         // needsOnboarding, after which the journey self-advances.
-        <IdentityStep preview={preview} onComplete={load} />
+        <IdentityStep preview={preview} onComplete={load} onCtaClick={trackStepCta} />
       ) : displayStepId === 'connect-agent' ? (
         // spec-305 dec-7: the rich connect-MCP card. On connect it flips to a reward
         // state ("your agent is now Memex-native") which we LINGER on (so a focus-
@@ -231,6 +245,7 @@ export function HomeCanvas() {
         <ConnectAgentStep
           preview={preview}
           onConnected={() => setLingerStep('connect-agent')}
+          onCtaClick={trackStepCta}
           onComplete={() => {
             setLingerStep(null);
             load();
@@ -242,6 +257,7 @@ export function HomeCanvas() {
         <CreateSpecStep
           preview={preview}
           onComplete={load}
+          onCtaClick={trackStepCta}
           onCreateInApp={() => {
             // Pure navigation to the New Spec modal (?new=1) — writes nothing, so like any
             // 'navigate' CTA it works even in operator preview. Keeps the link from being a
@@ -251,10 +267,10 @@ export function HomeCanvas() {
         />
       ) : displayStepId === 'resolve-decision' || displayStepId === 'add-ac' ? (
         // spec-305 dec-8: paste-a-prompt cards; advance on the step's milestone.
-        <AgentPromptStep stepId={displayStepId} preview={preview} onComplete={load} />
+        <AgentPromptStep stepId={displayStepId} preview={preview} onComplete={load} onCtaClick={trackStepCta} />
       ) : displayStepId === 'see-green' ? (
         // spec-305 dec-8: the aha — watch an AC go green from a real test (acVerified).
-        <SeeGreenStep preview={preview} onComplete={load} />
+        <SeeGreenStep preview={preview} onComplete={load} onCtaClick={trackStepCta} />
       ) : view ? (
         <JourneyStepShell view={view} userName={firstName(user?.name)} onCta={handleCta} />
       ) : (


### PR DESCRIPTION
## What this does

The headline: **a visitor seen BEFORE they have an identity is attributed to them once they sign in.** This is the anonymous→identified **stitch** — the named "spec-244 retrofit" on spec-254's now-merged `visitor_id` spine — plus the pre-auth funnel head and the journey-step click telemetry.

spec-254 shipped the server-side spine (`visitor_id` mint, `mergeVisitor` linking visitor→user in Postgres) but **never built the Mixpanel side of the merge**. This does that.

## Changes

**The identity stitch (the core)**
- **`mixpanel-sink.ts`** — Mixpanel **Simplified ID Merge**: emits `$device_id` (visitor), `$user_id` (user), and `distinct_id` (user UUID, or `$device:<visitor>` while anonymous). An event carrying *both* ids is what merges a device's pre-identity events into the user.
- **`identity.merged`** — emitted at `applyVisitorMerge` exactly when a consented `visitor_id` first binds to a user (not on re-auth or a different user). Carries both ids → the deterministic stitch at the signup/identify moment.

**The funnel head**
- **Flat anonymous ingress `POST /api/telemetry`** — tenant-less, records a pre-auth event keyed on the consent-gated `visitor_id` (the tenant route no-ops anonymous callers). No-op when there's no identity at all.
- **`signup.form_viewed`** — fires pre-auth when the signup form shows, via `trackAnonymous`.

**Journey-step clicks (Gap 2)**
- `home_canvas.cta_clicked` on the 6 bespoke journey steps (identity, connect-agent, create-spec, resolve-decision, add-ac, see-green), DRY via an `onCopy` on `CodeBlock` + an `onCtaClick` wired through `HomeCanvas`.

**Registry hygiene** — `identity.merged`, `signup.form_viewed`, and the already-live `home_canvas.*` registered in `usage-events-registry.ts` + `EVENT-STANDARD.md` (parity test green).

## Relationship to spec-326 (in `specify`)

spec-326 (authenticated-by-default / legitimate-interest) governs this area. This PR is **forward-compatible and needs no change when 326 ships**:
- The **explicit `identity.merged`-at-signup** stitch is robust to 326 **dec-2** (dropping the durable visitor cookie post-auth) — it fires once at the merge, not dependent on the cookie persisting. The sink's `$device_id`-on-authed-events simply becomes a no-op then.
- Everything added here is the **anonymous** path, gated on opt-in consent / DNT — exactly what 326 **dec-3** preserves for anonymous visitors. The authenticated `track()` path 326 will flip is untouched.

## Tests

All **12 spec-324 ACs verified** (6 scope + 6 implementation), each with real tagged tests:
- `mixpanel-sink.test.ts` (Simplified ID Merge mapping), `anon-telemetry.api.test.ts` (anonymous ingress + PII drop), `auth-visitor-merge.integration.test.ts` (the stitch: merged/already/rebind), `LoginScreen.test.tsx` + `useTelemetry.test.ts` (signup.form_viewed + gating), `usage-events-standard.test.ts` (registry parity), `journey-cta.spec-324.test.tsx` (6 custom-step clicks), and **e2e `journey-41`** (cta_clicked end-to-end in a real browser).
- Green locally: **server 4198 passed**, **UI 1460 passed**, build gate (`tsc -b` + `vite`), shared parity, e2e journey-41.

## Deploy notes

No migration, no new secret (rides the existing per-env `MIXPANEL_TOKEN`). Post-deploy: walk the std-35 evidence chain on int (fire `signup.form_viewed` → `usage_events` → `forwarded_at` → Mixpanel; confirm `identity.merged` stitches a visitor's pre-auth events to the user). `home_canvas.*` stays dark on prod until `/home` un-hides; `signup.form_viewed` + `identity.merged` are not gated and flow on prod immediately. Assumes the Mixpanel projects use **Simplified** ID Merge (default for these 2026-created projects) — confirm via the evidence-chain check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)