### PR TITLE
feat(spec-325): comments open in situ — a comment link pins the comment in its section, never the flat tab

### DIFF
--- a/packages/ui/e2e/journey-41-spec-325-comment-in-situ.spec.ts
+++ b/packages/ui/e2e/journey-41-spec-325-comment-in-situ.spec.ts
@@ -1,0 +1,122 @@
+import { test, expect, tenantPath, emitAcEvents } from "./helpers/index.js";
+import { seedOrgTenant, seedSpec, seedComment } from "./helpers/retained.js";
+
+// Journey 41 — spec-325: a comment link opens the comment IN SITU, in its
+// section's spec-319 gutter, never on the flat Comments tab.
+//
+//   ac-1 : clicking a comment link opens it in situ — scrolled to + surfaced in
+//          its section — and never lands on the flat Comments tab.
+//   ac-3 : the content the comment refers to (its section body / anchored passage)
+//          is visible alongside it; never stranded next to a bare heading.
+//   ac-9 : the flat Comments tab (AllComments) is not the deep-link's destination.
+//
+// Real-browser tier (std-28): the deep-link → scroll → programmatic-pin path is a
+// real load-time + layout effect jsdom can't reproduce; SectionCard.spec-325 /
+// DocDocument.spec-325 pin the unit behaviour, this proves the whole flow in the
+// browser and is the emitting tier for ac-1/ac-3/ac-9.
+const AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-325/acs/ac-${n}`;
+
+const PASSAGE =
+  "Provisioning the agent emission key is the first move; everything downstream depends on it.";
+const SPAN_COMMENT = "This anchored note hangs off the first word.";
+const SECTION_COMMENT = "A whole-section comment, no span anchor at all.";
+
+test.afterEach(async ({}, testInfo) => {
+  await emitAcEvents(
+    [AC(1), AC(3), AC(9)],
+    testInfo.status === "passed" ? "pass" : "fail",
+    `packages/ui/e2e/journey-41-spec-325-comment-in-situ.spec.ts::${testInfo.title}`,
+    testInfo.duration,
+  );
+});
+
+// Seed one spec carrying BOTH a span-anchored comment and a section-level comment
+// on the same section, and return both seqs so each deep-link can be exercised.
+async function seedSpecWithComments(resources) {
+  const tenant = await seedOrgTenant({ slug: resources.slug("j41") });
+  const spec = await seedSpec({
+    memexId: tenant.memexId,
+    title: "In-Situ Comment Spec",
+    purpose: PASSAGE,
+  });
+  // Span comment: anchored to "Provisioning" (offsets 0..12) → renders its gutter
+  // indicator at the anchored line, with the amber passage highlight.
+  const span = await seedComment({
+    memexId: tenant.memexId,
+    target: "section",
+    targetId: spec.sectionId,
+    authorName: "Casey Reviewer",
+    content: SPAN_COMMENT,
+    anchorStartOffset: 0,
+    anchorEndOffset: 12,
+  });
+  // Section-level comment: NO anchor offsets. Before spec-325 this rendered no
+  // gutter indicator at all (it only showed on the flat tab); now it sits at the
+  // top of the section body.
+  const section = await seedComment({
+    memexId: tenant.memexId,
+    target: "section",
+    targetId: spec.sectionId,
+    authorName: "Dana Lead",
+    content: SECTION_COMMENT,
+  });
+  return { tenant, spec, spanSeq: span.seq, sectionSeq: section.seq };
+}
+
+async function gotoComment(page, tenant, spec, seq: number) {
+  await page.goto(
+    tenantPath(
+      tenant.namespaceSlug,
+      tenant.memexSlug,
+      `/specs/${spec.handle}?comment=c-${seq}`,
+    ),
+    { waitUntil: "commit" },
+  );
+  await expect(
+    page.getByRole("heading", { level: 1, name: /In-Situ Comment Spec/ }),
+  ).toBeVisible({ timeout: 15_000 });
+}
+
+test("a span-comment link opens the comment pinned in its section, not the flat tab (ac-1, ac-3, ac-9)", async ({
+  page,
+  resources,
+}) => {
+  const { tenant, spec, spanSeq } = await seedSpecWithComments(resources);
+  await gotoComment(page, tenant, spec, spanSeq);
+
+  // The comment is pinned IN SITU on load (the deep-link emulates a card click) —
+  // its content is visible beside the section body, not on a divorced tab.
+  const popover = page.getByTestId("comment-popover");
+  await expect(popover).toBeVisible({ timeout: 15_000 });
+  await expect(popover).toHaveAttribute("data-pinned", "true");
+  await expect(popover).toContainText(SPAN_COMMENT);
+
+  // The section it lives on is rendered (the content "this" refers to is visible).
+  await expect(page.getByTestId("section-card").first()).toBeVisible();
+
+  // It did NOT land on the flat AllComments tab — that view's summary is absent.
+  await expect(page.getByTestId("open-comments-summary")).toHaveCount(0);
+});
+
+test("a section-level comment link opens it pinned at the section top, not the flat tab (ac-1, ac-3, ac-9)", async ({
+  page,
+  resources,
+}) => {
+  const { tenant, spec, sectionSeq } = await seedSpecWithComments(resources);
+  await gotoComment(page, tenant, spec, sectionSeq);
+
+  // A section-level comment (no span anchor) now renders in the gutter and is
+  // pinned in situ by the deep-link — the spec-325 case that previously only
+  // existed on the flat tab.
+  const popover = page.getByTestId("comment-popover");
+  await expect(popover).toBeVisible({ timeout: 15_000 });
+  await expect(popover).toHaveAttribute("data-pinned", "true");
+  await expect(popover).toContainText(SECTION_COMMENT);
+
+  // Its gutter indicator exists (proof it renders in-context at all).
+  await expect(page.locator(`#indicator-c-${sectionSeq}`)).toBeVisible();
+
+  // Still never the flat Comments tab.
+  await expect(page.getByTestId("open-comments-summary")).toHaveCount(0);
+});

--- a/packages/ui/src/components/SectionCard.spec-325.test.tsx
+++ b/packages/ui/src/components/SectionCard.spec-325.test.tsx
@@ -1,0 +1,201 @@
+// spec-325 — comments are read in situ. A SECTION-LEVEL comment (no span anchor)
+// must render through the SAME spec-319 gutter surface span comments use, pinned
+// to the TOP of the section body (dec-2, dec-4 / option c). And a comment
+// deep-link emulates a click on that gutter card — pinning it on load (dec-1,
+// dec-4 click-emulation).
+//
+//   ac-6 : a section-level comment renders a gutter indicator + peek/pin popover.
+//   ac-7 : it sits at the section top; on collision with a top-of-body span
+//          indicator the two stack with an offset.
+//   ac-8 : a deep-link emulates the click — the target comment is pinned on load
+//          (section-level: card at top, no passage highlight).
+//   ac-4 : span-anchored indicators are unchanged (no regression).
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, within, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { SectionCard } from './SectionCard';
+import type { DocSection, Comment } from '../api/types';
+import { tagAc } from '@memex-ai-ac/vitest';
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-325/acs/ac-${n}`;
+
+vi.mock('./ChatContext', () => ({ useChat: () => ({ addContextChip: vi.fn() }) }));
+vi.mock('./AuthContext', () => ({ useAuth: () => ({ user: { id: 'u1', name: 'Tester' } }) }));
+vi.mock('../api/client', () => ({
+  resolveComment: vi.fn().mockResolvedValue({}),
+  deleteComment: vi.fn().mockResolvedValue(undefined),
+  createComment: vi.fn().mockResolvedValue({}),
+}));
+
+// A span-anchored comment carries its end sentinel in the source; withRenderedMarkers
+// turns it into the #marker-c-N anchor the indicator layer measures.
+function endMarker(seq: number): string {
+  return `anchor${seq}[^c-${seq}e]`;
+}
+function makeSection(over: Partial<DocSection> = {}): DocSection {
+  return {
+    id: 'sec-1',
+    docId: 'doc-1',
+    sectionType: 'overview',
+    title: 'Overview',
+    content: '# Heading\n\nMarkdown **body** here.',
+    seq: 1,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...over,
+  } as DocSection;
+}
+function comment(over: Partial<Comment> & Pick<Comment, 'id' | 'seq'>): Comment {
+  return {
+    authorName: 'A',
+    content: 'a comment',
+    resolvedAt: null,
+    anchorSnippet: null, // section-level by default
+    createdAt: new Date().toISOString(),
+    ...over,
+  } as Comment;
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('spec-325 — section-level comments render in the gutter (dec-2, dec-4)', () => {
+  it('a section-level comment (no anchorSnippet, no body marker) renders a gutter indicator (ac-6)', () => {
+    tagAc(AC(6));
+    render(
+      <SectionCard
+        section={makeSection()}
+        sectionNumber={1}
+        commentCount={1}
+        comments={[comment({ id: 'c1', seq: 1, content: 'on the whole section' })]}
+      />,
+    );
+    // The section body has NO `[^c-1e]` marker, yet the indicator must still appear.
+    expect(document.getElementById('indicator-c-1')).toBeInTheDocument();
+  });
+
+  it('clicking a section-level indicator pins a popover that shows the comment (ac-2, ac-6)', async () => {
+    tagAc(AC(2)); // scope: a section-level comment is readable in the context of its section
+    tagAc(AC(6));
+    const user = userEvent.setup();
+    render(
+      <SectionCard
+        section={makeSection()}
+        sectionNumber={1}
+        commentCount={1}
+        comments={[comment({ id: 'c1', seq: 1, authorName: 'Wic', content: 'whole-section note' })]}
+      />,
+    );
+    await user.click(document.getElementById('indicator-c-1')!);
+    const pop = screen.getByTestId('comment-popover');
+    expect(pop).toHaveAttribute('data-pinned', 'true');
+    expect(within(pop).getByText('whole-section note')).toBeInTheDocument();
+    expect(within(pop).getByText('Wic')).toBeInTheDocument();
+  });
+
+  it('positions a lone section-level indicator at the section top (ac-7)', () => {
+    tagAc(AC(7));
+    render(
+      <SectionCard
+        section={makeSection()}
+        sectionNumber={1}
+        commentCount={1}
+        comments={[comment({ id: 'c1', seq: 1 })]}
+      />,
+    );
+    const ind = document.getElementById('indicator-c-1') as HTMLElement;
+    expect(ind.style.top).toBe('0px');
+  });
+
+  it('stacks a section-level indicator below a top-of-body span indicator on collision (ac-7)', () => {
+    tagAc(AC(7));
+    render(
+      <SectionCard
+        // span comment c-1 carries a marker (measured to top 0 in jsdom); c-2 is section-level.
+        section={makeSection({ content: `Intro ${endMarker(1)} body.` })}
+        sectionNumber={1}
+        commentCount={2}
+        comments={[
+          comment({ id: 'c1', seq: 1, anchorSnippet: 'Intro', content: 'span one' }),
+          comment({ id: 'c2', seq: 2, content: 'section-level two' }),
+        ]}
+      />,
+    );
+    const span = document.getElementById('indicator-c-1') as HTMLElement;
+    const sectionLevel = document.getElementById('indicator-c-2') as HTMLElement;
+    expect(span.style.top).toBe('0px');
+    // The section-level indicator must NOT overlap the span indicator at top 0.
+    expect(parseInt(sectionLevel.style.top, 10)).toBeGreaterThan(0);
+  });
+
+  it('does not regress span-only rendering: a span comment still renders its indicator (ac-4)', () => {
+    tagAc(AC(4));
+    render(
+      <SectionCard
+        section={makeSection({ content: `Intro ${endMarker(1)} body.` })}
+        sectionNumber={1}
+        commentCount={1}
+        comments={[comment({ id: 'c1', seq: 1, anchorSnippet: 'Intro', content: 'span note' })]}
+      />,
+    );
+    expect(document.getElementById('indicator-c-1')).toBeInTheDocument();
+  });
+});
+
+describe('spec-325 — a deep-link emulates a click on the gutter card (dec-1, dec-4)', () => {
+  it('pins the target section-level comment on load via deepLinkCommentSeq (ac-1, ac-3, ac-8)', async () => {
+    tagAc(AC(1)); // scope: opened from a link, the comment is surfaced in situ on load
+    tagAc(AC(3)); // scope: the comment's content is visible alongside its section, not stranded
+    tagAc(AC(8));
+    render(
+      <SectionCard
+        section={makeSection()}
+        sectionNumber={1}
+        commentCount={1}
+        comments={[comment({ id: 'c1', seq: 1, content: 'deep-linked section note' })]}
+        deepLinkCommentSeq={1}
+      />,
+    );
+    // No click — the deep-link emulates one, so the card is pinned on load.
+    await waitFor(() => {
+      const pop = screen.getByTestId('comment-popover');
+      expect(pop).toHaveAttribute('data-pinned', 'true');
+      expect(within(pop).getByText('deep-linked section note')).toBeInTheDocument();
+    });
+  });
+
+  it('pins the target span comment on load (ac-1, ac-3, ac-8)', async () => {
+    tagAc(AC(1)); // scope: a span comment link also opens in situ on load
+    tagAc(AC(3)); // scope: the anchored passage's comment content is visible alongside it
+    tagAc(AC(8));
+    render(
+      <SectionCard
+        section={makeSection({ content: `Intro ${endMarker(2)} body.` })}
+        sectionNumber={1}
+        commentCount={1}
+        comments={[comment({ id: 'c2', seq: 2, anchorSnippet: 'Intro', content: 'deep-linked span note' })]}
+        deepLinkCommentSeq={2}
+      />,
+    );
+    await waitFor(() => {
+      const pop = screen.getByTestId('comment-popover');
+      expect(pop).toHaveAttribute('data-pinned', 'true');
+      expect(within(pop).getByText('deep-linked span note')).toBeInTheDocument();
+    });
+  });
+
+  it('does nothing when this section does not own the deep-linked comment', async () => {
+    render(
+      <SectionCard
+        section={makeSection()}
+        sectionNumber={1}
+        commentCount={1}
+        comments={[comment({ id: 'c1', seq: 1, content: 'not the target' })]}
+        deepLinkCommentSeq={99}
+      />,
+    );
+    // Give the pin effect a chance to (not) fire.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(screen.queryByTestId('comment-popover')).not.toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/SectionCard.tsx
+++ b/packages/ui/src/components/SectionCard.tsx
@@ -70,6 +70,15 @@ interface SectionCardProps {
    * Defaults to false (real specs keep auto-linking).
    */
   isDemo?: boolean;
+  /**
+   * spec-325 (dec-1): a comment deep-link (`?comment=c-N`) emulates a click on
+   * that comment's gutter card. When this section OWNS the target comment, it
+   * pins it on load — reproducing exactly what a manual click produces (span →
+   * passage highlight + card; section-level → card at the section top). `null`/
+   * `undefined` means no deep-link is active. The same seq is passed to every
+   * section; only the owning one acts on it.
+   */
+  deepLinkCommentSeq?: number | null;
 }
 
 export const SectionCard = memo(function SectionCard({
@@ -84,6 +93,7 @@ export const SectionCard = memo(function SectionCard({
   canWrite = true,
   commentsCollapsed = false,
   isDemo = false,
+  deepLinkCommentSeq,
 }: SectionCardProps) {
   const [revealed, setRevealed] = useState(!isNew);
 
@@ -327,6 +337,50 @@ export const SectionCard = memo(function SectionCard({
     openComments.map((c) => c.seq).filter((s): s is number => s != null),
   );
 
+  // spec-325 (dec-4 / option c): a section-level comment (no `anchorSnippet`) has
+  // no body `marker-c-N`, so it isn't measured into `markerTops`. It renders in
+  // the SAME right-edge gutter, pinned to the TOP of the section body. Multiple
+  // section-level comments stack; and where a span indicator already sits at/near
+  // the top, the section-level ones stack BELOW it so the two never overlap.
+  const SECTION_INDICATOR_STACK = 32; // px between stacked top-of-body indicators
+  const spanIndicatorsAtTop = Object.values(markerTops).filter(
+    (t) => t < SECTION_INDICATOR_STACK,
+  ).length;
+  const sectionLevelTops: Record<number, number> = {};
+  openComments
+    .filter((c) => c.anchorSnippet == null && c.seq != null)
+    .forEach((c, i) => {
+      sectionLevelTops[c.seq as number] = (spanIndicatorsAtTop + i) * SECTION_INDICATOR_STACK;
+    });
+
+  // The vertical position of an open comment's gutter indicator: the measured line
+  // for a span comment, the stacked body-top for a section-level one. `undefined`
+  // means "not placeable yet" (a span whose marker hasn't been measured) → it
+  // simply doesn't render this frame.
+  const indicatorTop = (c: Comment): number | undefined => {
+    if (c.seq == null) return undefined;
+    return c.anchorSnippet != null ? markerTops[c.seq] : sectionLevelTops[c.seq];
+  };
+
+  // spec-325 (dec-1): a comment deep-link emulates a click on this comment's
+  // gutter card. If THIS section owns the target, pin it on load and scroll the
+  // section into view — reproducing exactly what a manual click produces. A span
+  // comment additionally gets the amber passage highlight (via the `shown`→
+  // highlight effect); a section-level comment has no passage, so no highlight
+  // (correct and inherent). Runs once; re-armed only if the target seq changes.
+  const deepLinkPinnedSeq = useRef<number | null>(null);
+  useEffect(() => {
+    if (deepLinkCommentSeq == null || commentsCollapsed) return;
+    if (deepLinkPinnedSeq.current === deepLinkCommentSeq) return;
+    if (!openComments.some((c) => c.seq === deepLinkCommentSeq)) return;
+    const el = document.getElementById(`indicator-c-${deepLinkCommentSeq}`);
+    if (!el) return; // indicator not placed yet (span awaiting measure) — re-run on next deps change
+    deepLinkPinnedSeq.current = deepLinkCommentSeq;
+    pinComment(deepLinkCommentSeq, el);
+    cardRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [deepLinkCommentSeq, openSeqKey, markerTops, commentsCollapsed]);
+
   // spec-100 card actions: mark done (resolve) and delete-your-own. Both drop
   // the card from the open list on success.
   const dropCard = (id: string) => onCommentsChange?.(section.id, comments.filter((x) => x.id !== id));
@@ -465,17 +519,19 @@ export const SectionCard = memo(function SectionCard({
             <MemoizedMarkdown content={withRenderedMarkers(section.content, visibleSeqs)} isDemo={isDemo} />
           </div>
 
-          {/* right-edge comment indicators, one per open comment, vertically
-              aligned to its anchored line (measured). Generic comment icon for
-              now; per-author avatars later. */}
-          {!commentsCollapsed && openComments.map((c) =>
-            c.seq != null && markerTops[c.seq] != null ? (
+          {/* right-edge comment indicators, one per open comment: a span comment
+              aligns to its measured anchored line; a section-level comment (spec-325)
+              sits at the top of the body (stacked on collision). Generic comment
+              icon for now; per-author avatars later. */}
+          {!commentsCollapsed && openComments.map((c) => {
+            const top = indicatorTop(c);
+            return c.seq != null && top != null ? (
               <button
                 key={c.id}
                 id={`indicator-c-${c.seq}`}
                 data-indicator-seq={c.seq}
                 type="button"
-                style={{ top: markerTops[c.seq] }}
+                style={{ top }}
                 onMouseEnter={(e) => peekComment(c.seq!, e.currentTarget)}
                 onMouseLeave={schedulePeekClose}
                 onClick={(e) => { e.stopPropagation(); pinComment(c.seq!, e.currentTarget); }}
@@ -491,8 +547,8 @@ export const SectionCard = memo(function SectionCard({
                   <path strokeLinecap="round" strokeLinejoin="round" d="M7.5 8.25h9m-9 3H12m-9.75 1.51c0 1.6 1.123 2.994 2.707 3.227 1.129.166 2.27.293 3.423.379.35.026.67.21.865.501L12 21l2.755-4.133a1.14 1.14 0 01.865-.501 48.172 48.172 0 003.423-.379c1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0012 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018z" />
                 </svg>
               </button>
-            ) : null,
-          )}
+            ) : null;
+          })}
         </div>
 
         {/* peek (hover) / pinned (click) comment popover. Actions only show

--- a/packages/ui/src/pages/DocDocument.spec-325.test.tsx
+++ b/packages/ui/src/pages/DocDocument.spec-325.test.tsx
@@ -1,0 +1,146 @@
+// spec-325 — a comment deep-link (`?comment=c-N`) must open the comment IN SITU
+// in the narrative (its section's spec-319 gutter), never on the flat AllComments
+// tab. DocDocument's job: do NOT select the comments sub-tab; show the narrative
+// and thread the target seq down to the section cards so the owning one pins it.
+//
+//   ac-5 : the deep-link lands in-context (narrative), never the flat Comments tab,
+//          and the target seq reaches the section cards.
+//   ac-9 : the flat Comments tab is not the deep-link's destination.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { tagAc } from '@memex-ai-ac/vitest';
+import type { DocWithGraph } from '../api/types';
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-325/acs/ac-${n}`;
+
+// SectionCard records the deepLinkCommentSeq it receives so we can assert the
+// deep-link reached the narrative surface (not the flat tab).
+let sectionDeepLinkSeq: number | null | undefined = 'UNSET' as never;
+vi.mock('../components/SectionCard', () => ({
+  SectionCard: (props: { deepLinkCommentSeq?: number | null }) => {
+    sectionDeepLinkSeq = props.deepLinkCommentSeq;
+    return <div data-testid="section-card" data-deeplink={props.deepLinkCommentSeq ?? ''} />;
+  },
+}));
+// If AllComments renders, the deep-link wrongly landed on the flat tab.
+vi.mock('../components/AllComments', () => ({
+  AllComments: () => <div data-testid="all-comments" />,
+}));
+vi.mock('../components/DecisionPanel', () => ({ DecisionPanel: () => <div data-testid="decision-panel" /> }));
+vi.mock('../components/AcPanel', () => ({ AcPanel: () => <div data-testid="ac-panel" /> }));
+vi.mock('../components/TaskPanel', () => ({ TaskPanel: () => <div data-testid="task-panel" /> }));
+vi.mock('../components/IssuePanel', () => ({ IssuePanel: () => <div data-testid="issue-panel" /> }));
+vi.mock('../components/DocOutline', () => ({ DocOutline: () => <div data-testid="doc-outline" /> }));
+vi.mock('../components/TagPicker', () => ({ TagPicker: () => null }));
+vi.mock('../components/BylineAssignees', () => ({ BylineAssignees: () => <div data-testid="byline-assignees" /> }));
+vi.mock('../components/DoneSummary', () => ({ DoneSummary: () => <div data-testid="done-summary" /> }));
+
+vi.mock('../hooks/useMemexAccess', () => ({
+  useMemexAccess: () => ({ canWrite: true, isReadOnly: false }),
+}));
+vi.mock('../hooks/useDocRole', () => ({
+  useDocRole: () => ({ myRole: 'editor', editors: [], loading: false, refetch: vi.fn() }),
+}));
+vi.mock('../hooks/useDocChangeStream', () => ({ useDocChangeStream: () => {} }));
+vi.mock('../hooks/useOrgScaffoldBlocks', () => ({ useOrgScaffoldBlocks: () => [] }));
+
+const chat = {
+  setDocId: vi.fn(),
+  setDoc: vi.fn(),
+  setOpenCommentCount: vi.fn(),
+  sendMessage: vi.fn(),
+};
+vi.mock('../components/ChatContext', () => ({ useChat: () => chat }));
+
+function makeDoc(): DocWithGraph {
+  return {
+    id: 'doc-uuid',
+    handle: 'spec-325',
+    title: 'Comments in situ',
+    docType: 'spec',
+    // 'specify' defaults to the narrative sub-tab, so the no-deep-link case still
+    // renders the section cards. The deep-link behaviour under test is phase-
+    // independent — a `?comment` param forces 'narrative' in any phase.
+    status: 'specify',
+    creator: { name: 'Wic', email: 'wic@mindset.ai' },
+    createdAt: '2026-06-01T00:00:00Z',
+    statusChangedAt: '2026-06-04T00:00:00Z',
+    narrativeLastConsolidatedAt: null,
+    sections: [{ id: 's-1', seq: 1, title: 'Overview', body: 'x' }],
+    decisions: [],
+    tasks: [],
+    tags: [],
+  } as unknown as DocWithGraph;
+}
+
+vi.mock('../api/client', () => ({
+  NotFoundError: class NotFoundError extends Error {},
+  fetchDoc: () => Promise.resolve(makeDoc()),
+  fetchDocComments: () => Promise.resolve({ sections: [], decisions: [], tasks: [] }),
+  fetchAcsForBrief: () => Promise.resolve([]),
+  fetchIssues: () => Promise.resolve([]),
+  fetchDocAssignees: () => Promise.resolve([]),
+  archiveDoc: vi.fn(),
+  pauseDoc: vi.fn(),
+  unpauseDoc: vi.fn(),
+  updateDocStatus: vi.fn(),
+  promoteToEditor: vi.fn(),
+  demoteToReviewer: vi.fn(),
+}));
+
+import { DocDocument } from './DocDocument';
+import { HeaderSlotProvider, useHeaderSlotContent } from '../components/HeaderSlot';
+
+function HeaderSink() {
+  return <div data-testid="header-slot">{useHeaderSlotContent()}</div>;
+}
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <HeaderSlotProvider>
+        <HeaderSink />
+        <Routes>
+          <Route path="/:ns/:mx/specs/:id" element={<DocDocument />} />
+        </Routes>
+      </HeaderSlotProvider>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  sectionDeepLinkSeq = 'UNSET' as never;
+});
+
+describe('spec-325 — comment deep-link lands in situ, never the flat Comments tab', () => {
+  it('a `?comment=c-3` link shows the narrative section cards and threads the seq down (ac-1, ac-5)', async () => {
+    tagAc(AC(1)); // scope: clicking a comment link opens it in situ (in the section view)
+    tagAc(AC(5));
+    renderAt('/n/m/specs/spec-325?comment=c-3');
+
+    // The narrative (section cards) is shown...
+    await waitFor(() => expect(screen.getByTestId('section-card')).toBeInTheDocument());
+    // ...and the target seq reached the section card.
+    expect(screen.getByTestId('section-card')).toHaveAttribute('data-deeplink', '3');
+    expect(sectionDeepLinkSeq).toBe(3);
+  });
+
+  it('a `?comment=c-3` link does NOT land on the flat AllComments tab (ac-1, ac-5, ac-9)', async () => {
+    tagAc(AC(1)); // scope: never lands on the flat Comments tab
+    tagAc(AC(5));
+    tagAc(AC(9));
+    renderAt('/n/m/specs/spec-325?comment=c-3');
+
+    await waitFor(() => expect(screen.getByTestId('section-card')).toBeInTheDocument());
+    expect(screen.queryByTestId('all-comments')).not.toBeInTheDocument();
+  });
+
+  it('with no comment param the section cards do not receive a deep-link seq', async () => {
+    renderAt('/n/m/specs/spec-325');
+    await waitFor(() => expect(screen.getByTestId('section-card')).toBeInTheDocument());
+    expect(screen.getByTestId('section-card')).toHaveAttribute('data-deeplink', '');
+  });
+});

--- a/packages/ui/src/pages/DocDocument.tsx
+++ b/packages/ui/src/pages/DocDocument.tsx
@@ -43,7 +43,7 @@ import {
 } from '@memex/shared';
 import { QaReportCard, selectQaReports } from '../components/QaReportCard';
 import { useDocChangeStream } from '../hooks/useDocChangeStream';
-import { COMMENT_PARAM, parseCommentParam, commentAnchorId } from '../utils/commentDeepLink';
+import { COMMENT_PARAM, parseCommentParam } from '../utils/commentDeepLink';
 import { phaseDisplayName } from '../utils/phaseDisplay';
 import { ShareModal } from '../components/ShareModal';
 import { ShareSpecDialog } from '../components/ShareSpecDialog';
@@ -134,8 +134,10 @@ export function DocDocument() {
   // scroll/highlights the target issue (mirrors the decision hint). Also honours a
   // `?issue=issue-N` query param for parity with `?decision=`.
   const initialIssueHandle = issueId ?? searchParams.get('issue');
-  // spec-100 ac-6: `?comment=c-N` deep-links straight to a comment — open the
-  // comments tab and (once loaded) scroll/highlight the target.
+  // spec-100 ac-6 / spec-325 (dec-1): `?comment=c-N` deep-links straight to a
+  // comment — but IN SITU, in the narrative, never the flat Comments tab. We land
+  // on the narrative sub-tab and hand the seq to the section cards; the owning
+  // SectionCard pins the comment on load (emulating a click on its gutter card).
   const initialCommentSeq = parseCommentParam(searchParams.get(COMMENT_PARAM));
   const chat = useChat();
   const [doc, setDoc] = useState<DocWithGraph | null>(null);
@@ -177,8 +179,10 @@ export function DocDocument() {
   // phase navigation resets it to null. A deep-link to a decision/issue/comment
   // sets the relevant landing tab up front.
   const [subTab, setSubTab] = useState<SubTab | null>(
+    // spec-325 (dec-1): a comment deep-link lands on the NARRATIVE (where the
+    // section's in-context gutter lives), NOT the flat 'comments' tab.
     initialCommentSeq != null
-      ? 'comments'
+      ? 'narrative'
       : initialDecisionHandle
         ? 'decisions'
         : initialIssueHandle
@@ -225,21 +229,11 @@ export function DocDocument() {
     setCommentsByTask(tMap);
   }, []);
 
-  // spec-100 ac-6: once the comments have rendered, scroll the deep-linked
-  // comment into view and briefly highlight it. Runs when the target seq or the
-  // loaded comment sets change; the element only exists while the Plan view's
-  // Comments sub-tab is active (the initial planSubTab handles that). Best-effort
-  // — if the target is filtered out (e.g. resolved under the default open
-  // filter) it simply won't be found.
-  useEffect(() => {
-    if (initialCommentSeq == null || subTab !== 'comments') return;
-    const el = document.getElementById(commentAnchorId(initialCommentSeq));
-    if (!el) return;
-    el.scrollIntoView({ behavior: 'smooth', block: 'center' });
-    el.classList.add('ring-2', 'ring-accent', 'rounded-md');
-    const t = setTimeout(() => el.classList.remove('ring-2', 'ring-accent', 'rounded-md'), 2000);
-    return () => clearTimeout(t);
-  }, [initialCommentSeq, subTab, commentsBySection, commentsByDecision, commentsByTask]);
+  // spec-325 (dec-1): the deep-linked comment is scrolled-to + pinned IN SITU by
+  // the owning SectionCard (it receives `deepLinkCommentSeq` and emulates a click
+  // on its gutter card). DocDocument no longer scrolls to a flat-tab anchor or
+  // selects the Comments tab — that divorced-tab routing is exactly what spec-325
+  // removes. (Replaces the old spec-100 scroll-to-`comment-c-{seq}` effect.)
 
   useEffect(() => {
     if (!id) return;
@@ -963,6 +957,9 @@ export function DocDocument() {
             onExpandComments={() => setCommentsCollapsed(false)}
             /* spec-178 ac-24: a frozen demo spec suppresses handle auto-linking. */
             isDemo={doc?.isDemo ?? false}
+            /* spec-325 (dec-1): hand the comment deep-link's seq to every section;
+               the owning one pins it in situ on load (emulating a card click). */
+            deepLinkCommentSeq={initialCommentSeq}
           />
         ))}
       </div>


### PR DESCRIPTION
## What & why

Spec: [spec-325](https://memex.ai/mindset-prod/memex-building-itself/specs/spec-325) — *Comments are read in situ — a comment opens in its section, never on the divorced tab.*

Clicking a comment link (e.g. Home's "where you're needed" item) used to dump you on the flat **Comments tab**, where a comment like "@wic, see this" is meaningless — severed from the prose it refers to. Now the link opens the comment **where it lives**: the document scrolls to its section and the comment card is pinned open in the spec-319 gutter — reproducing exactly what a manual click on that card does.

- **Span comment** → anchored passage highlighted + card pinned (identical to clicking today).
- **Section-level comment** (no anchored phrase) → card pinned at the section top. These previously had *no* in-document affordance (flat-tab only); they now render a gutter indicator like span comments, stacked below a top-of-section span indicator so the two never overlap.

The flat Comments tab is otherwise untouched (dec-3) — it's simply no longer where a comment link lands.

## Changes (all in `packages/ui`)

- **`SectionCard.tsx`** — section-level comments render a gutter indicator at the body-top (no longer filtered out for lacking a measured span-marker top); collision stacking; new `deepLinkCommentSeq` prop pins the target comment on load via the existing `pinComment` path (no new highlight/popover code).
- **`DocDocument.tsx`** — `?comment=c-N` routes to the **narrative** sub-tab (not `comments`) and threads the seq to the section cards; drops the old flat-tab `comment-c-{seq}` scroll effect.
- No server / schema / migration change.

## Decision

dec-4 resolved to **option (c)** — gutter-reuse at the section top, deep-link emulates a click. Resolved with Wic before build.

## Testing

- `SectionCard.spec-325.test.tsx`, `DocDocument.spec-325.test.tsx` — unit (TDD: RED→GREEN).
- `e2e/journey-41-spec-325-comment-in-situ.spec.ts` (std-28) — real-browser: span + section-level links land in situ, flat tab absent.
- **AC coverage: 9/9 verified, 0 failing** (4 scope + 5 implementation).

Run green locally before opening:
- Full UI suite — 204 files, 1459 passed
- `pnpm build` (production tsc + vite) — clean
- Full server suite — 420 files, 4183 passed
- `make e2e-cold` (std-28 cold-DB) — 95 passed

## Notes

- journey-41's e2e AC emissions are keyless in the Playwright process (no `MEMEX_EMIT_KEY` surfaced to that runner), so the scope ACs are emitted by the unit tier; the journey remains the real-browser proof. Wiring the emit key into the e2e runner is broader test-infra (affects every journey).