### PR TITLE
feat(spec-326): authenticated users tracked by default (legitimate interest, opt-out)

### DIFF
--- a/packages/server/src/routes/telemetry.api.test.ts
+++ b/packages/server/src/routes/telemetry.api.test.ts
@@ -18,6 +18,7 @@ import { makeTestAppWithTenant } from "./route-test-helpers.js";
 import { telemetryRouter } from "./telemetry.js";
 
 const AC = "mindset-prod/memex-building-itself/specs/spec-244/acs";
+const AC326 = "mindset-prod/memex-building-itself/specs/spec-326/acs";
 
 let memexId: string;
 let userId: string;
@@ -117,5 +118,22 @@ describe("POST /telemetry — front-end capture (ac-3 / ac-7 / ac-8)", () => {
       body: "{ not json",
     });
     expect(res.status).toBe(400);
+  });
+});
+
+// spec-326 dec-2/ac-5: once authenticated, user_id is the identifier — capture does
+// NOT depend on the durable visitor_id cookie. authedApp() carries NO memex_vid (the
+// middleware never sets c.get("visitorId")), so this is the post-auth, cookie-absent
+// path: the event must still land, actor = user.id, visitor_id NULL.
+describe("POST /telemetry — authenticated capture does not depend on visitor_id (spec-326 ac-5)", () => {
+  it("records actor = user.id with visitor_id NULL when no memex_vid is present", async () => {
+    tagAc(`${AC326}/ac-5`);
+    const res = await post(authedApp(), { name: "nav.route_changed", props: { route: "/ns/mx" } });
+    expect(res.status).toBe(204);
+
+    const rows = await rowsFor("nav.route_changed");
+    expect(rows.length).toBe(1);
+    expect(rows[0].actorUserId).toBe(userId); // user_id IS the identifier
+    expect(rows[0].visitorId).toBeNull(); // no reliance on the durable cookie post-auth
   });
 });

--- a/packages/ui/e2e/journey-42-authenticated-default-tracking.spec.ts
+++ b/packages/ui/e2e/journey-42-authenticated-default-tracking.spec.ts
@@ -1,0 +1,110 @@
+// spec-326 (std-28) — authenticated users are tracked BY DEFAULT (legitimate
+// interest, opt-out), extending spec-254's anonymous opt-in.
+//
+// This journey drives the real UI to prove the regime change end-to-end:
+//   - The anonymous opt-in consent banner is NOT shown to an authenticated user,
+//     and no consent choice is ever recorded (ac-1).
+//   - With NO consent granted, navigating the app fires a /telemetry POST — capture
+//     is on by default for the authenticated user (ac-1).
+//   - The settings opt-out remains the right-to-object valve: toggling it off stops
+//     capture and persists across a reload (ac-3).
+//
+// `seedConsent: false` is deliberate — we must start from a CLEAN slate (no recorded
+// consent) to prove default-tracking, not a pre-seeded 'denied'. Path-based nav
+// [per std-2]; seeded via the env-gated test surface (no raw SQL).
+
+import {
+  test,
+  expect,
+  tenantPath,
+  DEV_EMAIL,
+  setUserName,
+  seedOrg,
+  emitAcEvents,
+} from "./helpers/index.js";
+
+// Clean slate: do not pre-record a 'denied' choice. We are proving that an
+// authenticated user is tracked WITHOUT ever consenting.
+test.use({ seedConsent: false });
+
+const AC = [
+  "mindset-prod/memex-building-itself/specs/spec-326/acs/ac-1",
+  "mindset-prod/memex-building-itself/specs/spec-326/acs/ac-3",
+];
+
+test.afterEach(async ({}, testInfo) => {
+  await emitAcEvents(
+    AC,
+    testInfo.status === "passed" ? "pass" : "fail",
+    `packages/ui/e2e/journey-42-authenticated-default-tracking.spec.ts::${testInfo.title}`,
+    testInfo.duration,
+  );
+});
+
+const isTelemetryPost = (req: { url(): string; method(): string }): boolean =>
+  req.url().includes("/telemetry") && req.method() === "POST";
+
+test("an authenticated user is tracked by default with no consent, and can still opt out", async ({
+  page,
+  resources,
+}) => {
+  await setUserName(DEV_EMAIL, "Dev User");
+  const slug = resources.slug("auth-track");
+  const org = await seedOrg({ ownerEmail: DEV_EMAIL, slug, name: "Tracking Org" });
+
+  // Land on the org's Specs board. The dev bootstrap authenticates dev@memex.ai and
+  // persists the session token to localStorage.
+  await page.goto(tenantPath(org.namespaceSlug, org.memexSlug, "/specs"), {
+    waitUntil: "commit",
+  });
+  await expect(page.getByRole("heading", { name: "Specs" })).toBeVisible({ timeout: 15_000 });
+
+  // Reload so the persisted token is present at mount — the consent banner reads it
+  // synchronously and suppresses itself for the authenticated visitor (deterministic,
+  // no first-login flash to race).
+  await page.reload({ waitUntil: "commit" });
+  await expect(page.getByRole("heading", { name: "Specs" })).toBeVisible({ timeout: 15_000 });
+
+  // ac-1: the anonymous opt-in banner is NOT shown to an authenticated user, and no
+  // consent choice was ever recorded (we never asked).
+  await expect(page.getByTestId("visitor-consent")).toHaveCount(0);
+  const consent = await page.evaluate(() =>
+    window.localStorage.getItem("memex.telemetry.consent"),
+  );
+  expect(consent).toBeNull();
+
+  // ac-1: navigating to a different route TEMPLATE fires a /telemetry POST — tracked
+  // by default, despite no consent having been granted.
+  const telemetryPost = page.waitForRequest(isTelemetryPost, { timeout: 15_000 });
+  await page.goto(tenantPath(org.namespaceSlug, org.memexSlug, "/standards"), {
+    waitUntil: "commit",
+  });
+  await telemetryPost;
+
+  // ac-3: the settings opt-out is still the right-to-object valve. Turn it off…
+  await page.goto(tenantPath(org.namespaceSlug, org.memexSlug, "/org?tab=settings"), {
+    waitUntil: "commit",
+  });
+  const toggle = page.getByTestId("telemetry-toggle");
+  await expect(toggle).toBeChecked({ timeout: 15_000 });
+  await toggle.uncheck();
+  await expect(page.getByText("Usage analytics off")).toBeVisible();
+
+  // …and the choice persists across a reload (it gates capture for this browser).
+  await page.reload({ waitUntil: "commit" });
+  await expect(page.getByTestId("telemetry-toggle")).not.toBeChecked({ timeout: 15_000 });
+
+  // ac-3: once opted out, navigation no longer fires /telemetry — capture is off.
+  let firedAfterOptOut = false;
+  page.on("request", (req) => {
+    if (isTelemetryPost(req)) firedAfterOptOut = true;
+  });
+  await page.goto(tenantPath(org.namespaceSlug, org.memexSlug, "/specs"), {
+    waitUntil: "commit",
+  });
+  await expect(page.getByRole("heading", { name: "Specs" })).toBeVisible({ timeout: 15_000 });
+  // Allow the deferred (requestIdleCallback / setTimeout) route-change fire window to
+  // elapse, then assert nothing was sent.
+  await page.waitForTimeout(2_500);
+  expect(firedAfterOptOut).toBe(false);
+});

--- a/packages/ui/e2e/visitor-1-consent.spec.ts
+++ b/packages/ui/e2e/visitor-1-consent.spec.ts
@@ -11,6 +11,23 @@ import { test, expect, bareUrl } from "./helpers/index.js";
 // shared fixture applies (see helpers/fixtures.ts) — show it from a clean slate.
 test.use({ seedConsent: false });
 
+// Run this journey as a GENUINELY ANONYMOUS visitor. The dev harness auto-logs-in
+// dev@memex.ai (the no-Google-client bootstrap persists memex-auth-token), and since
+// spec-326 the consent banner is an ANONYMOUS-only surface — suppressed once a token
+// is present. So to exercise the pre-auth banner we must stay logged out: set the
+// dev-logout sentinel (AuthContext's consumeDevLogoutSentinel) before every load —
+// addInitScript re-runs on each navigation, so it survives the reload in test 2.
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    try {
+      window.sessionStorage.setItem("memex-dev-logout", "1");
+    } catch {
+      // sessionStorage unavailable — the bootstrap would auth and the banner would
+      // be suppressed; the assertions below would then surface it as a failure.
+    }
+  });
+});
+
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 async function visitorCookie(page: import("@playwright/test").Page): Promise<string | undefined> {

--- a/packages/ui/src/components/LoginScreen.test.tsx
+++ b/packages/ui/src/components/LoginScreen.test.tsx
@@ -51,6 +51,7 @@ import { NotFoundError } from '../api/client';
 
 const AC = 'mindset-prod/memex-building-itself/specs/spec-304/acs/ac-30';
 const AC324 = 'mindset-prod/memex-building-itself/specs/spec-324/acs';
+const AC326 = 'mindset-prod/memex-building-itself/specs/spec-326/acs';
 const REQUEST_ID = 'lr_xyz789';
 const EMAIL = 'user@example.com';
 
@@ -244,6 +245,7 @@ describe('LoginScreen magic-link polling [spec-304 t-40 / ac-30]', () => {
 
 describe('signup.form_viewed — the funnel head (spec-324 ac-10 / ac-12)', () => {
   beforeEach(() => {
+    vi.useRealTimers();
     probeAuthApi.mockReset();
     trackAnonymous.mockReset();
   });
@@ -278,5 +280,47 @@ describe('signup.form_viewed — the funnel head (spec-324 ac-10 / ac-12)', () =
 
     expect(screen.getByRole('heading', { name: /welcome back/i })).toBeInTheDocument();
     expect(trackAnonymous).not.toHaveBeenCalled();
+  });
+});
+
+// spec-326 dec-1/ac-2 — the signup surface discloses legitimate-interest capture
+// (the LOUD supersede of a prior anonymous decline). Shown on signup, absent on signin.
+describe('LoginScreen — signup privacy notice [spec-326 ac-2]', () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+    probeAuthApi.mockReset();
+    magicLinkRequestApi.mockReset();
+  });
+
+  // Drive enter-email → the view the probe selects (create-password = signup,
+  // password = signin).
+  async function reachView(probe: { exists: boolean; hasPassword?: boolean }): Promise<void> {
+    probeAuthApi.mockResolvedValue(probe);
+    renderLogin();
+    const input = screen.getByPlaceholderText('you@company.com');
+    await act(async () => {
+      fireEvent.change(input, { target: { value: EMAIL } });
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /continue/i }));
+    });
+    await flush();
+  }
+
+  it('the signup view shows the legitimate-interest notice + the right-to-object pointer', async () => {
+    tagAc(`${AC326}/ac-2`);
+    await reachView({ exists: false }); // unknown email → create-password (signup)
+    expect(screen.getByRole('heading', { name: 'Sign up' })).toBeInTheDocument();
+    const notice = screen.getByTestId('signup-privacy-notice');
+    expect(notice).toBeInTheDocument();
+    expect(notice).toHaveTextContent(/legitimate-interest/i);
+    expect(notice).toHaveTextContent(/object/i);
+  });
+
+  it('the signin view does NOT show the signup privacy notice', async () => {
+    tagAc(`${AC326}/ac-2`);
+    await reachView({ exists: true, hasPassword: true }); // known + password → signin
+    expect(screen.getByRole('heading', { name: 'Welcome back' })).toBeInTheDocument();
+    expect(screen.queryByTestId('signup-privacy-notice')).toBeNull();
   });
 });

--- a/packages/ui/src/components/LoginScreen.tsx
+++ b/packages/ui/src/components/LoginScreen.tsx
@@ -390,6 +390,19 @@ function PasswordScreen({
           {sendingMagic ? 'Sending…' : 'Email me a sign-in link instead'}
         </button>
       </div>
+
+      {/* spec-326 dec-1/ac-2: the LOUD supersede. Signing up discloses that product
+          usage is captured by default under legitimate interest — visible here, so a
+          prior anonymous decline is superseded in the open, never silently flipped.
+          Placeholder copy; legal owns the final wording (spec-326 out-of-scope). */}
+      {mode === 'signup' && (
+        <p className="text-xs text-muted border-t border-edge pt-3" data-testid="signup-privacy-notice">
+          Memex records anonymous product-usage events (IDs and counts only — no
+          document content, message text, or keystrokes) to improve the product, on a
+          legitimate-interest basis. You can object at any time under Settings →
+          Product-usage analytics.
+        </p>
+      )}
     </div>
   );
 }

--- a/packages/ui/src/components/VisitorConsent.test.tsx
+++ b/packages/ui/src/components/VisitorConsent.test.tsx
@@ -11,6 +11,7 @@ import { getConsent } from '../lib/visitorConsent';
 import { VISITOR_COOKIE, VISITOR_LS_KEY } from '../lib/visitorId';
 
 const AC = 'mindset-prod/memex-building-itself/specs/spec-254/acs';
+const AC326 = 'mindset-prod/memex-building-itself/specs/spec-326/acs';
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 function cookieValue(): string | undefined {
@@ -49,6 +50,9 @@ describe('VisitorConsent banner', () => {
 
   it('Decline records the decline and writes no id (ac-12)', () => {
     tagAc(`${AC}/ac-12`);
+    // spec-326 ac-4: an anonymous decline stores NO durable visitor_id — spec-254
+    // dec-4 is preserved for the anonymous regime.
+    tagAc(`${AC326}/ac-4`);
     render(<VisitorConsent />);
     fireEvent.click(screen.getByTestId('visitor-consent-decline'));
     expect(getConsent()).toBe('denied');
@@ -62,5 +66,16 @@ describe('VisitorConsent banner', () => {
     setDnt(true);
     render(<VisitorConsent />);
     expect(screen.queryByTestId('visitor-consent')).toBeNull();
+  });
+
+  // spec-326 dec-1: the opt-in banner is an ANONYMOUS-only surface. An authenticated
+  // visitor is tracked by default under legitimate interest and must not be pestered
+  // by (or gated behind) the consent banner.
+  it('does not render for an AUTHENTICATED visitor, even with no prior choice (spec-326 ac-1)', () => {
+    tagAc(`${AC326}/ac-1`);
+    localStorage.setItem('memex-auth-token', 'tok_abc'); // a persisted session
+    render(<VisitorConsent />);
+    expect(screen.queryByTestId('visitor-consent')).toBeNull();
+    expect(getConsent()).toBeNull(); // and nothing was forced either way
   });
 });

--- a/packages/ui/src/hooks/useTelemetry.test.ts
+++ b/packages/ui/src/hooks/useTelemetry.test.ts
@@ -11,10 +11,11 @@ vi.mock('../api/http', () => ({
 
 import { fetchWithRetry } from '../api/http';
 import { setConsent } from '../lib/visitorConsent';
-import { useTelemetry, trackAnonymous, isOptedOut, routeTemplate } from './useTelemetry';
+import { useTelemetry, trackAnonymous, isOptedOut, routeTemplate, telemetryEnabled } from './useTelemetry';
 
 const AC = 'mindset-prod/memex-building-itself/specs/spec-244/acs';
 const AC324 = 'mindset-prod/memex-building-itself/specs/spec-324/acs';
+const AC326 = 'mindset-prod/memex-building-itself/specs/spec-326/acs';
 
 function setDnt(value: string): void {
   Object.defineProperty(navigator, 'doNotTrack', { value, configurable: true });
@@ -111,6 +112,72 @@ describe('trackAnonymous — the pre-auth path, same privacy gate (spec-324 ac-5
     tagAc(`${AC324}/ac-5`);
     localStorage.setItem('memex.telemetry.optout', '1');
     trackAnonymous('signup.form_viewed');
+    expect(fetchWithRetry).not.toHaveBeenCalled();
+  });
+});
+
+// spec-326 — authenticated users are tracked BY DEFAULT (legitimate interest,
+// opt-out), while the ANONYMOUS regime keeps spec-254's opt-in. These cases prove
+// the split inside the SAME gate, so a regression in either direction is caught.
+describe('telemetryEnabled — the authenticated/anonymous split (spec-326 ac-6)', () => {
+  it('AUTHENTICATED: tracked with no consent choice, and under Do-Not-Track', () => {
+    tagAc(`${AC326}/ac-6`);
+    tagAc(`${AC326}/ac-8`); // dec-3: DNT has no legal force once authenticated
+    // No setConsent() in this test — the visitor never chose. Anonymous would be
+    // gated off; authenticated is tracked by default.
+    localStorage.removeItem('memex.telemetry.consent');
+    expect(telemetryEnabled(true)).toBe(true);
+    setDnt('1'); // DNT is NOT honored once authenticated (dec-3)
+    expect(telemetryEnabled(true)).toBe(true);
+  });
+
+  it('AUTHENTICATED: a prior anonymous DECLINE does not suppress capture', () => {
+    tagAc(`${AC326}/ac-6`);
+    setConsent('denied'); // declined while anonymous
+    expect(telemetryEnabled(false)).toBe(false); // honored WHILE anonymous (ac-4)
+    expect(telemetryEnabled(true)).toBe(true); // superseded once authenticated (ac-2/dec-1)
+  });
+
+  it('AUTHENTICATED: the per-user opt-out still wins (right to object, ac-3/ac-7)', () => {
+    tagAc(`${AC326}/ac-3`); // the settings opt-out remains available + effective
+    tagAc(`${AC326}/ac-7`);
+    localStorage.setItem('memex.telemetry.optout', '1');
+    expect(telemetryEnabled(true)).toBe(false);
+  });
+
+  it('ANONYMOUS: a declined visitor is NOT tracked while anonymous (ac-4, spec-254 dec-4 preserved)', () => {
+    tagAc(`${AC326}/ac-4`);
+    setConsent('denied'); // declined as an anonymous visitor
+    expect(telemetryEnabled(false)).toBe(false); // not tracked while anonymous
+    localStorage.removeItem('memex.telemetry.consent');
+    expect(telemetryEnabled(false)).toBe(false); // undecided anonymous → also not tracked
+  });
+
+  it('ANONYMOUS: spec-254 opt-in is unchanged (granted on, DNT off, undecided off)', () => {
+    tagAc(`${AC326}/ac-6`);
+    localStorage.removeItem('memex.telemetry.consent');
+    expect(telemetryEnabled(false)).toBe(false); // undecided → no capture
+    setConsent('granted');
+    expect(telemetryEnabled(false)).toBe(true); // granted → capture
+    setDnt('1');
+    expect(telemetryEnabled(false)).toBe(false); // DNT overrides granted while anonymous
+  });
+});
+
+describe('useTelemetry(authenticated) — track() fires by default once authenticated (spec-326 ac-1)', () => {
+  it('an authenticated user who never granted consent still has track() fire', () => {
+    tagAc(`${AC326}/ac-1`);
+    localStorage.removeItem('memex.telemetry.consent'); // no consent choice at all
+    const { result } = renderHook(() => useTelemetry(true));
+    act(() => result.current.track('nav.route_changed', { route: '/ns/mx' }));
+    expect(fetchWithRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it('the same user, anonymous (no auth, no consent), does NOT fire', () => {
+    tagAc(`${AC326}/ac-1`);
+    localStorage.removeItem('memex.telemetry.consent');
+    const { result } = renderHook(() => useTelemetry(false));
+    act(() => result.current.track('nav.route_changed', { route: '/ns/mx' }));
     expect(fetchWithRetry).not.toHaveBeenCalled();
   });
 });

--- a/packages/ui/src/hooks/useTelemetry.ts
+++ b/packages/ui/src/hooks/useTelemetry.ts
@@ -32,10 +32,25 @@ export function isOptedOut(): boolean {
   }
 }
 
-/** Capture is allowed only on opt-IN consent (dec-4 = B; hasConsent already
- *  excludes Do-Not-Track) AND when the per-user opt-out isn't set. */
-export function telemetryEnabled(): boolean {
-  return hasConsent() && !isOptedOut();
+/**
+ * The capture gate. It splits by who is asking (spec-326 dec-1):
+ *
+ *   - AUTHENTICATED → tracked BY DEFAULT under legitimate interest. The only gate
+ *     is the per-user opt-out (the Art-21 right to object). Consent is NOT required
+ *     and Do-Not-Track is NOT honored (dec-3: DNT has no UK/EU legal force; the
+ *     settings opt-out is the meaningful, deliberate control).
+ *   - ANONYMOUS → spec-254's opt-in is unchanged: capture only on an explicit
+ *     'granted' consent (hasConsent already excludes Do-Not-Track) AND not opted out.
+ *
+ * The opt-out short-circuits both regimes — it is a withdraw that always wins.
+ *
+ * `authenticated` defaults to false (the anonymous opt-in gate), so callers on the
+ * pre-auth path — `trackAnonymous` (spec-324) and any other anonymous caller — get
+ * the correct opt-in semantics by calling `telemetryEnabled()` with no argument.
+ */
+export function telemetryEnabled(authenticated = false): boolean {
+  if (isOptedOut()) return false;
+  return authenticated || hasConsent();
 }
 
 // Replace id-shaped segments (handles like spec-7, bare numbers, uuids) with ':id'
@@ -57,11 +72,14 @@ export interface UseTelemetry {
   setOptOut: (value: boolean) => void;
 }
 
-export function useTelemetry(): UseTelemetry {
+export function useTelemetry(authenticated = false): UseTelemetry {
   const [optedOut, setOptedOut] = useState<boolean>(isOptedOut);
 
   const track = useCallback((name: RegisteredEventName, props?: Record<string, unknown>): void => {
-    if (!telemetryEnabled()) return;
+    // spec-326 dec-1: authenticated users are tracked by default (opt-out only);
+    // anonymous keep spec-254's opt-in. Default `authenticated=false` keeps every
+    // existing caller on the anonymous (opt-in) gate until it opts in explicitly.
+    if (!telemetryEnabled(authenticated)) return;
     const base = tenantBase();
     if (!base) return;
     void fetchWithRetry(`${base}/telemetry`, {
@@ -71,7 +89,7 @@ export function useTelemetry(): UseTelemetry {
     }).catch(() => {
       // Advisory — telemetry must never disrupt the user's flow.
     });
-  }, []);
+  }, [authenticated]);
 
   const setOptOut = useCallback((value: boolean): void => {
     try {
@@ -116,7 +134,11 @@ export function trackAnonymous(name: RegisteredEventName, props?: Record<string,
  * but there's no point sending).
  */
 export function useTrackRouteChange(pathname: string | null): void {
-  const { track } = useTelemetry();
+  // A non-null pathname is the App's signal that this is an authenticated,
+  // trackable context (App.tsx passes null for anonymous visitors). That same
+  // signal IS the authenticated flag for the gate (spec-326 dec-1): a route we
+  // actually track belongs to an authenticated user, captured by default.
+  const { track } = useTelemetry(pathname !== null);
   const last = useRef<string | null>(null);
   useEffect(() => {
     if (pathname === null) return;

--- a/packages/ui/src/lib/visitorConsent.ts
+++ b/packages/ui/src/lib/visitorConsent.ts
@@ -46,8 +46,28 @@ export function hasConsent(): boolean {
   return !isDoNotTrack() && getConsent() === 'granted';
 }
 
-/** Show the banner only when the visitor hasn't chosen and DNT isn't set (DNT is
- *  an automatic decline, so there's nothing to ask). */
+// The key AuthContext persists the session token under. Read directly (this module
+// sits OUTSIDE AuthProvider — VisitorConsent is mounted app-wide in main.tsx) so the
+// banner can tell an authenticated user from an anonymous one without the provider.
+// Kept in lockstep with AuthContext's restoreFromStorage().
+const AUTH_TOKEN_KEY = 'memex-auth-token';
+
+/** True when a session token is persisted — i.e. the visitor is authenticated. */
+export function isAuthenticatedVisitor(): boolean {
+  try {
+    return typeof localStorage !== 'undefined' && !!localStorage.getItem(AUTH_TOKEN_KEY);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Show the anonymous opt-in banner only to an ANONYMOUS visitor who hasn't chosen
+ * and isn't under DNT (DNT is an automatic decline, so there's nothing to ask).
+ * Authenticated users are tracked by default under legitimate interest (spec-326
+ * dec-1) — the opt-in banner is an anonymous-only surface and must never gate or
+ * pester them; their control is the settings opt-out (TelemetryOptOut).
+ */
 export function shouldShowConsentBanner(): boolean {
-  return !isDoNotTrack() && getConsent() === null;
+  return !isAuthenticatedVisitor() && !isDoNotTrack() && getConsent() === null;
 }


### PR DESCRIPTION
## What & why

Extends spec-254's anonymous opt-in: **authenticated users are captured BY DEFAULT** under **legitimate interest** (UK GDPR Art 6(1)(f)), escapable via the existing settings opt-out — no opt-in popup gating product use. The anonymous pre-signup banner stays; an anonymous decline is honored *while anonymous* and superseded **loudly at signup** via a visible privacy notice.

Implements [spec-326](https://memex.ai/mindset-prod/memex-building-itself/specs/spec-326). All 3 decisions resolved; **8/8 ACs verified**.

## Changes

- **`useTelemetry.ts`** — `telemetryEnabled(authenticated = false)`: authenticated → gated only on the per-user opt-out (consent not required, DNT not honored per dec-3); anonymous → unchanged spec-254 opt-in. Threaded via `useTrackRouteChange` (a non-null pathname is App's authenticated signal). The default keeps spec-324's `trackAnonymous()` on correct anonymous semantics.
- **`visitorConsent.ts`** — `shouldShowConsentBanner()` suppressed for authenticated visitors (reads `memex-auth-token`); the opt-in banner is an anonymous-only surface.
- **`LoginScreen.tsx`** — legitimate-interest privacy notice on the signup view only (`data-testid="signup-privacy-notice"`), the loud supersede.
- **No server change** — `/telemetry` already records authenticated-only with `user.id`; `visitor_id` stays a nullable join key (dec-2/ac-5, asserted by test).
- **Compliance artifacts** drafted as Memex **doc-9** (LIA + DPIA-screening note + privacy-notice draft).

## ⚠ Ship gate (do not release without this)

dec-3 requires a **human privacy stakeholder to initial the LIA** in doc-9 before release. Engineering may merge behind the gate; it must **not be released** until the LIA is signed. The agent drafted the artifacts; it cannot sign them off. Final privacy-notice/Terms wording is legal's (doc-9 Artifact 3 is the draft).

## Testing

- **Full UI suite**: 1470 passed, 1 skipped.
- **Full server suite**: 4198 passed, 29 skipped.
- **UI + server build typecheck**: clean.
- **Full e2e-cold (std-28 gate)**: 95 passed, 0 failed.
- **8/8 ACs verified** on the spec (emitted to memex.ai). New tagged tests in `useTelemetry.test.ts`, `VisitorConsent.test.tsx`, `LoginScreen.test.tsx`, `telemetry.api.test.ts`, and e2e **journey-42**.

## Notes for the reviewer

- **Rebased onto current develop**, resolving overlap with **spec-324** (which landed first): kept its `trackAnonymous` pre-auth path alongside the new gate; both specs' tests coexist; renamed my journey **41 → 42** (spec-324 took 41).
- Fixed a regression my banner-suppression surfaced: spec-254's `visitor-1` consent journey now runs **genuinely anonymous** (dev-logout sentinel) so it honestly tests the pre-auth banner — the dev harness otherwise auto-authenticates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)