### PR TITLE
docs(spec-326): house LIA + DPIA-screening + privacy notice in-repo

### DIFF
--- a/compliance/README.md
+++ b/compliance/README.md
@@ -1,0 +1,9 @@
+# Compliance
+
+Privacy and data-protection reasoning, kept in the repo and public — the same transparency posture as the source code and the public event registry. There is no separate sign-off ceremony: these documents live in `main` via normal PR review, and git history is the accountability record.
+
+- [legitimate-interests-assessment.md](./legitimate-interests-assessment.md) — why authenticated product-usage analytics is lawful under legitimate interest (UK GDPR Art 6(1)(f)).
+- [dpia-screening.md](./dpia-screening.md) — why a full DPIA is not required.
+- [privacy-notice.md](./privacy-notice.md) — the product-usage-analytics clause (the canonical customer-facing version lives in the site's privacy policy).
+
+Decisions of record live in Memex: [spec-326](https://memex.ai/mindset-prod/memex-building-itself/specs/spec-326).

--- a/compliance/dpia-screening.md
+++ b/compliance/dpia-screening.md
@@ -1,0 +1,17 @@
+# DPIA screening — authenticated product-usage analytics
+
+**Owner:** Mindset AI (privacy). **Approved via:** git history / PR review. **Decision of record:** [spec-326](https://memex.ai/mindset-prod/memex-building-itself/specs/spec-326) dec-3.
+
+**Screening question: does this processing require a full Data Protection Impact Assessment (DPIA)?**
+
+**No.** Authenticated first-party product-usage analytics, as scoped in spec-326 and in the [Legitimate Interests Assessment](./legitimate-interests-assessment.md), is **not high-risk** processing under UK GDPR Art 35 / ICO criteria:
+
+- **No special-category data** (Art 9): events carry only IDs, enums, and counts — no content, no health/biometric/political/etc. data.
+- **No systematic monitoring of a publicly accessible area.**
+- **No large-scale processing of special-category or criminal-offence data.**
+- **No profiling or automated decision-making with legal or similarly significant effect** (Art 22): the data informs aggregate product decisions, not decisions about individuals.
+- **No matching/combining datasets, no targeting of vulnerable subjects, no innovative-tech risk, no denial of service/contract** based on the processing.
+
+It triggers none of the ICO's high-risk indicators (two or more would warrant a DPIA). The processing is transparent (public registry, public source, public LIA), minimised, and escapable (Art-21 opt-out).
+
+**Conclusion:** a full DPIA is **not required**. This screening note, together with the LIA, is the proportionate documentation.

--- a/compliance/legitimate-interests-assessment.md
+++ b/compliance/legitimate-interests-assessment.md
@@ -1,0 +1,36 @@
+# Legitimate Interests Assessment — authenticated product-usage analytics
+
+**Owner:** Mindset AI (privacy). **Approved via:** git history / PR review — whoever merges this to `main` owns it. There is no separate sign-off step; this file being in `main` is the record.
+
+**Scope:** first-party, in-product usage analytics for **authenticated** users of Memex — registered event names carrying only IDs, enums, and counts (no document content, message text, or keystrokes; the full event registry is public in the codebase). The identifier is `user_id`; the durable `visitor_id` cookie is not used post-authentication. Anonymous pre-signup capture stays opt-in (spec-254) and is out of scope here.
+
+**Decision of record:** [spec-326](https://memex.ai/mindset-prod/memex-building-itself/specs/spec-326) dec-1 / dec-3 — authenticated users are tracked by default under **legitimate interest** (UK GDPR Art 6(1)(f)), with privacy-notice disclosure and a settings opt-out as the Art-21 right to object. Deliberately **not** bundled "consent in the Terms" (invalid consent under GDPR).
+
+## 1. Purpose test — is there a legitimate interest?
+
+Yes. Mindset has a legitimate interest in understanding how authenticated users use Memex (which value paths they walk, where flows stall) to improve product quality, reliability, and roadmap decisions. First-party product analytics for a service the user has chosen to use is a well-established legitimate interest.
+
+## 2. Necessity test — is the processing necessary, and minimised?
+
+Yes, and it is minimised. Only registered event names carrying IDs, enums, and counts are captured — no document content, message text, or keystrokes (sanitised both client- and server-side; the registry is public). The identifier is the authenticated `user_id`; the durable cross-property `visitor_id` cookie is not used post-authentication, removing the ePrivacy surface. An opt-in popup yields a self-selected, unrepresentative minority and effectively blinds the team — there is no less-intrusive way to obtain reliable in-product usage signal.
+
+## 3. Balancing test — do the individual's interests override the interest?
+
+No, on balance. Factors keeping impact low:
+
+- data is minimal and non-content;
+- the event registry is public (the processing is transparent — and so is this assessment);
+- the user is an authenticated user in an ongoing service relationship and would reasonably expect product-usage measurement;
+- a clear privacy notice is shown at signup;
+- a one-click right to object is always available in Settings → Product-usage analytics;
+- no special-category data, no automated decision-making with legal/similarly-significant effect, no profiling, no third-party sale or sharing.
+
+The processing is not a surprise and is easily escapable, so it does not override the individual's rights and freedoms.
+
+## Safeguards relied on
+
+Data minimisation (IDs/enums/counts only), public event registry, public source code and this public assessment, the signup privacy notice, the persistent settings opt-out (Art-21), and dropping the durable `visitor_id` cookie post-authentication.
+
+## Conclusion
+
+Legitimate interest is an appropriate lawful basis for authenticated first-party product analytics as scoped. Anonymous pre-signup capture remains opt-in (spec-254) and is outside this assessment.

--- a/compliance/privacy-notice.md
+++ b/compliance/privacy-notice.md
@@ -1,0 +1,18 @@
+# Privacy notice — product-usage analytics
+
+**Owner:** Mindset AI (privacy / legal own the final public wording). **Approved via:** git history / PR review. **Decision of record:** [spec-326](https://memex.ai/mindset-prod/memex-building-itself/specs/spec-326) dec-1 / dec-3.
+
+This is the substance of the product-usage-analytics clause. The canonical, customer-facing version lives in the public privacy policy on the site; this in-repo copy keeps the source code and the privacy posture consistent. The short form is also shown at signup (`data-testid="signup-privacy-notice"`).
+
+## Clause
+
+> **Product-usage analytics.** When you are signed in, Memex records anonymous product-usage events — which features and value paths you use — to understand how the product is used and to improve it. These events carry only identifiers, category labels, and counts: **no document content, no message text, and no keystrokes**. The full list of events we record is public in our event registry.
+>
+> **Lawful basis: legitimate interest** (UK GDPR Article 6(1)(f)) — improving a product you have chosen to use. We have assessed that this processing is proportionate and does not override your rights; our [Legitimate Interests Assessment](./legitimate-interests-assessment.md) is public.
+>
+> **Your right to object.** You can turn product-usage analytics off at any time in **Settings → Product-usage analytics**. We treat UK and EU users the same way.
+
+## Notes
+
+- Lawful basis is **legitimate interest, not bundled consent in the Terms** — bundled consent is invalid under GDPR (must be freely given, specific, unbundled, not a condition of service).
+- Anonymous pre-signup visitors remain **opt-in** (spec-254); the banner there is unchanged.


### PR DESCRIPTION
Follow-up to #269 (spec-326). Houses the dec-3 compliance artifacts **in the repo, public**, under `compliance/` — same transparency posture as the source and the public event registry. (These were authored after #269 had already merged, so they need their own PR.)

- `compliance/legitimate-interests-assessment.md` — why authenticated product-usage analytics is lawful under legitimate interest (UK GDPR Art 6(1)(f))
- `compliance/dpia-screening.md` — why a full DPIA is not required
- `compliance/privacy-notice.md` — the product-usage-analytics clause
- `compliance/README.md` — index

**No sign-off ceremony:** these live in `main` via normal PR review; git history is the accountability record. Decision of record stays in Memex (spec-326 dec-1/dec-3).

Docs-only — no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)