### PR TITLE
fix(spec-327): repair the spec-189 smoke probe for the create_task gate

### DIFF
--- a/packages/server/src/__smoke__/authed.smoke.test.ts
+++ b/packages/server/src/__smoke__/authed.smoke.test.ts
@@ -411,7 +411,8 @@ describe.skipIf(!SMOKE_MCP_TOKEN)(
     //
     //    Specify-class traffic (create_decision) at a freshly-created draft
     //    Spec must auto-advance it draft → specify; build-class traffic
-    //    (create_task) must then advance it specify → build. This is the
+    //    (update_issue, post spec-327 — create_task no longer advances) must
+    //    then advance it specify → build. This is the
     //    deployed-contract probe for the runToolWithSpecTraffic seam — the
     //    exact class of /mcp wiring that std-17's first live run proved local
     //    suites can miss. The full matrix is locked by unit + integration
@@ -444,16 +445,35 @@ describe.skipIf(!SMOKE_MCP_TOKEN)(
       );
       expect(docText).toMatch(/\[spec,\s*specify\]|status:\s*specify|phase:\s*specify/i);
 
-      // Build-class traffic: task creation (also sweeps via createdTaskRefs).
-      const task = await callMcpTool("create_task", {
-        ref: specRef!,
-        title: "[smoke] spec-189 probe task",
-        description: "Throwaway — drives specify → build.",
+      // Build-class traffic: an Issue edit. spec-327 gated create_task to
+      // build/verify (it no longer advances), so the build-class advance
+      // exemplar is register_issue (the non-advancing parking lot, spec-295
+      // dec-2) followed by update_issue (still build-class) — the seam advances
+      // specify → build.
+      const issue = await callMcpTool("register_issue", {
+        spec_ref: specRef!,
+        title: "[smoke] spec-189 probe issue",
+        body: "Throwaway — seeded to drive specify → build via update_issue.",
+        type: "todo",
       });
-      expect(task.status).toBe(200);
-      expect(task.body.result?.isError).toBeFalsy();
-      const taskRef = parseRef(mcpTextPayload(task.body));
-      if (taskRef) createdTaskRefs.push(taskRef);
+      expect(issue.status).toBe(200);
+      expect(issue.body.result?.isError).toBeFalsy();
+      const issueRef = parseRef(mcpTextPayload(issue.body));
+      expect(issueRef, "register_issue should return a canonical ref").toBeTruthy();
+
+      // register_issue is non-advancing — still specify.
+      docText = mcpTextPayload(
+        (await callMcpTool("get_doc", { ref: specRef! })).body,
+      );
+      expect(docText).toMatch(/\[spec,\s*specify\]|status:\s*specify|phase:\s*specify/i);
+
+      // update_issue is build-class — advances specify → build.
+      const upd = await callMcpTool("update_issue", {
+        ref: issueRef!,
+        body: "Edited — build-class traffic drives specify → build.",
+      });
+      expect(upd.status).toBe(200);
+      expect(upd.body.result?.isError).toBeFalsy();
 
       docText = mcpTextPayload(
         (await callMcpTool("get_doc", { ref: specRef! })).body,


### PR DESCRIPTION
## Why

The merge of #267 (spec-327: gate create_task to build/verify) **failed the deploy** at the post-deploy smoke gate — `packages/server/src/__smoke__/authed.smoke.test.ts:454`. The spec-189 smoke probe drove `specify → build` via an MCP `create_task` call, which the new guard rejects.

This smoke tier runs against **live int post-deploy** and is gated on `SMOKE_MCP_TOKEN`, so it isn't part of `make test` — which is why it slipped past the server-suite and e2e fixes in #267.

## Fix

The probe's stated purpose is to prove the `runToolWithSpecTraffic` seam is **alive on the deployed image** (not to test `create_task` specifically). Drive the build-class advance with `register_issue` (the non-advancing parking lot, spec-295 dec-2) + `update_issue` (still build-class) — the seam advances `specify → build` exactly as before. Added an intermediate assertion that `register_issue` leaves the phase at `specify` (proving it's non-advancing).

Block 1 of the smoke suite (the create/delete probe at :309) already moves the spec to `build` before `create_task`, so it's unaffected.

## Verification

Could not run the authed smoke tier locally (needs the int `SMOKE_MCP_TOKEN` secret). Grounded instead: `register_issue` returns `ref: <issueRef> [todo, open]` (parseRef captures it) and `update_issue` is build-class (`tool-manifest.ts:412`), so `nextPhaseForTraffic(specify, build) = build` — the same advancement the matrix + integration tests lock. The re-deploy's smoke run is the live confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)