### PR TITLE
spec-318: Home Canvas sets document.title to 'Home' (ac-17)

### DIFF
--- a/packages/ui/src/pages/HomeCanvas.test.tsx
+++ b/packages/ui/src/pages/HomeCanvas.test.tsx
@@ -185,6 +185,20 @@ describe('HomeCanvas — attainment progress map', () => {
   });
 });
 
+describe('HomeCanvas — document.title (spec-318 ac-17)', () => {
+  it("sets document.title to 'Home' so the desktop shell labels the /home tab", async () => {
+    tagAc('mindset-prod/memex-building-itself/specs/spec-318/acs/ac-17');
+    // Simulate a stale title left by a previously-visited page (the bug: the
+    // /home tab kept reading "Specs"). The Home Canvas is the one top-level page
+    // without a PageHeader, so it must set its own title.
+    document.title = 'Specs';
+    fetchJourneyStateApi.mockResolvedValue(stateFor('welcome'));
+    renderCanvas();
+    await screen.findByTestId('journey-step-welcome');
+    expect(document.title).toBe('Home');
+  });
+});
+
 describe('HomeCanvas — CTA allow-list (ac-5 / impl ac-12)', () => {
   it("an 'action' CTA routes into the real flow (invite → integrations)", async () => {
     tagAc(AC(5));

--- a/packages/ui/src/pages/HomeCanvas.tsx
+++ b/packages/ui/src/pages/HomeCanvas.tsx
@@ -6,6 +6,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useAuth } from '../components/AuthContext';
 import { useUserChangeStream } from '../hooks/useUserChangeStream';
+import { useDocumentTitle } from '../hooks/useDocumentTitle';
 import {
   fetchJourneyStateApi,
   postJourneyEventApi,
@@ -47,6 +48,13 @@ export function HomeCanvas() {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const previewParam = searchParams.get('preview');
+
+  // spec-318 (ac-17): the Home Canvas is the one top-level page that does NOT use
+  // PageHeader, so it sets its own document.title. The desktop shell reads
+  // document.title to label the tab — without this the /home tab keeps whatever
+  // the previous page set (e.g. "Specs"). Set unconditionally at the top so it
+  // applies across all of this component's conditional render branches.
+  useDocumentTitle({ kind: 'page', title: 'Home' });
 
   const [state, setState] = useState<JourneyStateResponse | null>(null);
   // An in-canvas navigate (e.g. "Why Memex?") that wins until the real step changes.


### PR DESCRIPTION
## Problem
The per-page `document.title` work (#264, merged + live on int) routes titles through `PageHeader` and the Spec page. But the **`/home` Home Canvas** uses neither `PageHeader` nor `useDocumentTitle`, so the desktop shell's tab kept whatever title the previously-visited page set — e.g. navigating Specs → Home left the tab reading **"Specs"**.

## Fix
Wire `HomeCanvas` to `useDocumentTitle({ kind: 'page', title: 'Home' })` at the top of the component, so it sets the title across all of its conditional render branches (welcome / identity / connect-agent / … / all-set).

## Pairs with
- memex-clients shell now lands new tabs on `/home` (so the Home tab is what users see first on prod).
- The `HIDDEN_FEATURES` gate: where `home` is hidden (int), `/home` redirects to the specs board, so this title surfaces on **prod** (Home on) and gracefully degrades to "Specs" on **int** (Home off).

## Testing
- New test (tagged spec-318 **ac-17**): HomeCanvas overrides a stale `"Specs"` `document.title` to `"Home"`.
- `HomeCanvas.test.tsx` suite green (**18**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)