### PR TITLE
fix(spec-171): reserve /upgrade route so checkout POST hits the tenant-scoped endpoint (404)

### DIFF
--- a/packages/ui/e2e/journey-42-spec-171-upgrade.spec.ts
+++ b/packages/ui/e2e/journey-42-spec-171-upgrade.spec.ts
@@ -130,10 +130,12 @@ test("hosted upgrade: pick Enterprise, set seats + annual, redirect to Stripe Ch
   // ── 4. intercept checkout — branch on method so the plan-select GET to the
   //       same path (fetchCurrentSubscription) is not clobbered ───────────────
   let capturedBody: unknown = null;
+  let capturedUrl: string | null = null;
   await page.route("**/orgs/current/subscription", async (route) => {
     const req = route.request();
     if (req.method() === "POST") {
       capturedBody = req.postDataJSON();
+      capturedUrl = req.url();
       // Fulfill 200 { url } — NO real Stripe API is hit.
       await route.fulfill({
         status: 200,
@@ -171,4 +173,13 @@ test("hosted upgrade: pick Enterprise, set seats + annual, redirect to Stripe Ch
     seats: 5,
     billingCycle: "annual",
   });
+
+  // REGRESSION (the 404 manual testing caught): the checkout endpoint is mounted
+  // ONLY under the tenant prefix (/api/<ns>/<mx>/orgs/current/subscription,
+  // resolved from session). The /upgrade/:plan path must NOT be mis-parsed as a
+  // tenant — a too-loose "**/orgs/current/subscription" glob previously matched
+  // the buggy /api/upgrade/enterprise/orgs/current/subscription and hid this.
+  expect(capturedUrl).not.toBeNull();
+  expect(capturedUrl!).toContain("/orgs/current/subscription");
+  expect(capturedUrl!).not.toContain("/upgrade/");
 });

--- a/packages/ui/src/utils/tenantUrl.ts
+++ b/packages/ui/src/utils/tenantUrl.ts
@@ -28,6 +28,12 @@ const CALLER_SCOPED_PREFIXES = [
   "account",
   "backstage",
   "invites",
+  // spec-171: the hosted upgrade flow is a FLAT route (/upgrade, /upgrade/:plan,
+  // /upgrade/confirmation) — never a tenant. Without this, /upgrade/premium parses
+  // as namespace=upgrade/memex=premium and the checkout POST 404s at
+  // /api/upgrade/premium/orgs/current/subscription instead of the tenant-scoped
+  // /api/<ns>/<mx>/orgs/current/subscription (resolved from session).
+  "upgrade",
 ];
 
 export interface CurrentTenant {


### PR DESCRIPTION
## Problem (caught in manual testing on int)
Clicking **Continue to payment** on `/upgrade/premium` POSTed to `/api/upgrade/premium/orgs/current/subscription` → **404**.

## Cause
The checkout endpoint is mounted **only** under the tenant prefix (`app.route('/api/:namespace/:memex/orgs', orgsCurrentRouter)`). The UI derives that prefix via `tenantBase()` → `parseTenantFromPathname()`. `/upgrade/:plan` is a **flat** route, but `upgrade` was missing from `CALLER_SCOPED_PREFIXES`, so `/upgrade/premium` parsed as `namespace=upgrade / memex=premium` → wrong base. The correct path is the tenant-scoped one resolved from the **session** (`tenantBaseFromSession`).

## Fix
- Add `upgrade` to `CALLER_SCOPED_PREFIXES` (packages/ui/src/utils/tenantUrl.ts) → `/upgrade/*` parses as flat → falls through to the session tenant base.
- **e2e regression guard:** journey-42 missed this because its `**/orgs/current/subscription` intercept glob matched the buggy URL too. Now asserts the captured POST URL contains `/orgs/current/subscription` and **no** `/upgrade/` segment.

## Test
journey-42 green locally (free ports, pg16:5433). UI `tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)