### PR TITLE
feat(telemetry): front-end engagement usage events (spec-338)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -262,6 +262,16 @@ jobs:
   ui:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    env:
+      # UI unit tests tag ACs too (std-35 Recipe A — "representative unit tests at
+      # the track() sites"); emit them like the server / e2e / ac-emit jobs do.
+      # Without this the ui job ran tagged tests but emitted nothing, so any
+      # UI-unit-verified AC stayed untested. Value lives in the MEMEX_EMIT_KEY repo
+      # secret, never here.
+      MEMEX_EMIT_KEY: ${{ secrets.MEMEX_EMIT_KEY }}
+      # Dependabot PRs receive no repo secrets — turn emission OFF for them so no
+      # bogus unauthenticated emission is attempted (mirrors the server job).
+      MEMEX_EMIT: ${{ github.actor == 'dependabot[bot]' && 'false' || '' }}
     steps:
       - uses: actions/checkout@v6
       # No `version:` here — pnpm/action-setup@v6 reads the pinned version from

--- a/packages/server/src/services/documents.ts
+++ b/packages/server/src/services/documents.ts
@@ -160,6 +160,11 @@ export async function createDocDraft(
       payload: {
         ...docAttribution(created.id, created.docType),
         ...(specIndex !== undefined ? { spec_index: specIndex } : {}),
+        // spec-338 dec-1: the coarse creation SOURCE = the std-32 channel
+        // (rest_ui | mcp | in_app_agent | server), so funnels can split
+        // "where specs/docs are created" off the one outcome event — without
+        // a front-end creation event, and covering agent/MCP creates too.
+        ...(ctx.channel ? { source: ctx.channel } : {}),
       },
     }),
     async () => {

--- a/packages/server/src/services/event-doc-attribution.integration.test.ts
+++ b/packages/server/src/services/event-doc-attribution.integration.test.ts
@@ -26,6 +26,8 @@ import { startUsageBackendSink, _stopUsageBackendSink } from "./usage-backend-si
 import { startActivityLogSink, _stopActivityLogSink } from "./activity-log.js";
 
 const AC = "mindset-prod/memex-building-itself/specs/spec-306/acs";
+// spec-338 dec-1: the coarse creation `source` prop on document.created.
+const AC338 = "mindset-prod/memex-building-itself/specs/spec-338/acs";
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 let memexId: string;
@@ -142,11 +144,37 @@ describe("document.created attributes the new document itself (spec-306 ac-10)",
     // scope ACs this also evidences:
     tagAc(`${AC}/ac-3`); // additive — the event still fires, only gains props (no new event name)
     tagAc(`${AC}/ac-4`); // attribution applied to document.created too (consistency across all in-scope events)
+    // spec-338 dec-1: creation is captured by document.created with doc_type
+    // (the spec-vs-doc distinction) — no front-end creation event.
+    tagAc(`${AC338}/ac-7`);
     const doc = await createDocDraft(memexId, "Self doc", "p", "standard", undefined, undefined, userId, { actorUserId: userId, channel: "rest_ui" });
     const props = await waitForRow("document.created", doc.id);
     expect(props, "document.created usage row with its own doc_id should land").toBeDefined();
     expect(props!.doc_id).toBe(doc.id);
     expect(props!.doc_type).toBe("standard");
+    expectNoLeak(props!);
+  });
+});
+
+// spec-338 dec-1 (ac-8): document.created carries a coarse `source` = the std-32
+// channel, so funnels can split "where specs/docs are created" off the one outcome
+// event — and crucially that includes agent/MCP creates a front-end event can't see.
+describe("document.created carries the coarse creation source (spec-338 ac-8)", () => {
+  it("stamps source = 'rest_ui' for a UI-initiated create", async () => {
+    tagAc(`${AC338}/ac-8`);
+    const doc = await createDocDraft(memexId, "UI source doc", "p", "spec", undefined, undefined, userId, { actorUserId: userId, channel: "rest_ui" });
+    const props = await waitForRow("document.created", doc.id);
+    expect(props, "document.created usage row should land").toBeDefined();
+    expect(props!.source).toBe("rest_ui");
+    expectNoLeak(props!);
+  });
+
+  it("stamps source = 'mcp' for an agent/MCP create (a path no front-end event sees)", async () => {
+    tagAc(`${AC338}/ac-8`);
+    const doc = await createDocDraft(memexId, "MCP source doc", "p", "spec", undefined, undefined, userId, { actorUserId: userId, channel: "mcp" });
+    const props = await waitForRow("document.created", doc.id);
+    expect(props, "document.created usage row should land").toBeDefined();
+    expect(props!.source).toBe("mcp");
     expectNoLeak(props!);
   });
 });

--- a/packages/shared/EVENT-STANDARD.md
+++ b/packages/shared/EVENT-STANDARD.md
@@ -36,6 +36,19 @@ versa.
 - `home_canvas.step_shown` — A Home Canvas onboarding journey step became the active card (spec-303/305). props.step is the step id. Recorded via POST /api/me/journey-event.
 - `home_canvas.cta_clicked` — A Home Canvas journey step's CTA was clicked. props.step is the step id; props.cta names the CTA target. The intent signal; the step's outcome stays its own event (std-35 cl-12).
 - `signup.form_viewed` — A visitor saw the signup form, pre-auth (the funnel head). Recorded via the anonymous ingress (POST /api/telemetry) keyed on the consent-gated visitor_id.
+- `auth.login_started` — A sign-in attempt was initiated. props.method is the auth method enum (google | password | magic_link). Pre-auth → trackAnonymous().
+- `spec.card_opened` — A spec card on the board was opened. props.specSeq (the spec's handle ordinal — the "spec#"), props.phase, props.assigned (bool), props.assignedUserId (opaque user UUID — never a name/email).
+- `spec.tab_viewed` — A content sub-tab in the spec detail view was selected (which parts people read). props.tab (narrative | comments | decisions | work | qa-report), props.phase (the phase view it was selected under).
+- `board.phase_drag` — A spec card was dragged to a different phase column (the interaction; the outcome stays document.status_changed). props.from / props.to are phase enums.
+- `board.tag_filter_applied` — The board tag filter changed. props.filterCount is the number of active tag filters (count only).
+- `search.opened` — The ⌘K command palette was opened. props.trigger (hotkey | button).
+- `search.query_submitted` — A query produced results in the palette. props.queryLength (char count only — never the text), props.hasResults (bool).
+- `search.result_selected` — A result was chosen in the palette. props.lane (jumpTo | assigned | content), props.resultKind, props.resultIndex.
+- `comments.filter_changed` — A comments filter changed. props.authorFilter / props.statusFilter are the selected filter enums.
+- `whatsnew.opened` — The What's New feed was opened. props.unreadCount (count only).
+- `workspace.switched` — The active Memex was switched via the workspace switcher. props.memexId (target Memex UUID).
+- `voice.mic_permission_result` — The mic permission prompt resolved during a voice attempt. props.result (granted | denied | dismissed).
+- `voice.icon_shown` — The voice entry point was presented (adoption denominator). Fired once per mount. props.surface (icon | pill).
 
 ## Back-end outcomes (whitelisted `mutate()` events, dec-8)
 

--- a/packages/shared/src/usage-events-registry.frontend-engagement.test.ts
+++ b/packages/shared/src/usage-events-registry.frontend-engagement.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
 import {
   USAGE_EVENT_REGISTRY,
   isRegisteredEvent,
@@ -6,6 +7,8 @@ import {
   BACKEND_EVENT_NAMES,
   type RegisteredEventName,
 } from "./usage-events-registry";
+
+const AC = "mindset-prod/memex-building-itself/specs/spec-338/acs";
 
 // The front-end engagement events seeded for the spec-336 Home revamp follow-on
 // (board / search / voice / filters / workspace). std-35 Recipe A: each must be a
@@ -28,19 +31,33 @@ const NEW_FRONTEND_EVENTS: RegisteredEventName[] = [
 
 describe("front-end engagement events (spec-336 follow-on)", () => {
   it.each(NEW_FRONTEND_EVENTS)("%s is a registered front-end event", (name) => {
+    tagAc(`${AC}/ac-5`); // machine contract: registered + RegisteredEventName-typed
+    tagAc(`${AC}/ac-1`); // each is a registered Recipe-A (front-end) event
     expect(isRegisteredEvent(name)).toBe(true);
     expect(isFrontendEvent(name)).toBe(true);
   });
 
   it("are NOT in the back-end bus whitelist (front-end events never ride the bus)", () => {
+    tagAc(`${AC}/ac-1`); // server outcomes stay Recipe B — no double-counting
     for (const name of NEW_FRONTEND_EVENTS) {
       expect(BACKEND_EVENT_NAMES).not.toContain(name);
     }
   });
 
   it("every registry entry has a non-empty description (std-35 props discipline lives there)", () => {
+    tagAc(`${AC}/ac-5`);
     for (const e of USAGE_EVENT_REGISTRY) {
       expect(e.description.trim().length).toBeGreaterThan(0);
     }
+  });
+
+  it("adds no onboarding.* events and leaves the home_canvas.* events intact (Home untouched — spec-336 owns it)", () => {
+    tagAc(`${AC}/ac-3`);
+    const names = USAGE_EVENT_REGISTRY.map((e) => e.name);
+    // No new onboarding surface was introduced by this batch.
+    expect(names.filter((n) => n.startsWith("onboarding."))).toHaveLength(0);
+    // The existing Home Canvas events are still present, unchanged.
+    expect(names).toContain("home_canvas.step_shown");
+    expect(names).toContain("home_canvas.cta_clicked");
   });
 });

--- a/packages/shared/src/usage-events-registry.frontend-engagement.test.ts
+++ b/packages/shared/src/usage-events-registry.frontend-engagement.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import {
+  USAGE_EVENT_REGISTRY,
+  isRegisteredEvent,
+  isFrontendEvent,
+  BACKEND_EVENT_NAMES,
+  type RegisteredEventName,
+} from "./usage-events-registry";
+
+// The front-end engagement events seeded for the spec-336 Home revamp follow-on
+// (board / search / voice / filters / workspace). std-35 Recipe A: each must be a
+// registered FRONT-END name so POST /telemetry accepts it and track() type-checks.
+const NEW_FRONTEND_EVENTS: RegisteredEventName[] = [
+  "auth.login_started",
+  "spec.card_opened",
+  "spec.tab_viewed",
+  "board.phase_drag",
+  "board.tag_filter_applied",
+  "search.opened",
+  "search.query_submitted",
+  "search.result_selected",
+  "comments.filter_changed",
+  "whatsnew.opened",
+  "workspace.switched",
+  "voice.mic_permission_result",
+  "voice.icon_shown",
+];
+
+describe("front-end engagement events (spec-336 follow-on)", () => {
+  it.each(NEW_FRONTEND_EVENTS)("%s is a registered front-end event", (name) => {
+    expect(isRegisteredEvent(name)).toBe(true);
+    expect(isFrontendEvent(name)).toBe(true);
+  });
+
+  it("are NOT in the back-end bus whitelist (front-end events never ride the bus)", () => {
+    for (const name of NEW_FRONTEND_EVENTS) {
+      expect(BACKEND_EVENT_NAMES).not.toContain(name);
+    }
+  });
+
+  it("every registry entry has a non-empty description (std-35 props discipline lives there)", () => {
+    for (const e of USAGE_EVENT_REGISTRY) {
+      expect(e.description.trim().length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/packages/shared/src/usage-events-registry.ts
+++ b/packages/shared/src/usage-events-registry.ts
@@ -104,6 +104,88 @@ export const USAGE_EVENT_REGISTRY = [
       "A visitor saw the signup form, pre-authentication (the funnel head). Recorded via the anonymous telemetry ingress (POST /api/telemetry) keyed on the consent-gated visitor_id; no user yet. Honours DNT / opt-out / consent (spec-324, spec-254).",
     source: "frontend",
   },
+  // ── Front-end engagement interactions (track(), spec-336 follow-on) ──────────
+  // Pure UI taps the server never sees — board navigation, search, voice, filters.
+  // Server OUTCOMES (spec/decision/task created, phase advanced) stay back-end
+  // (Recipe B above); these capture only the interaction/intent (std-35 cl-1).
+  {
+    name: "auth.login_started",
+    description:
+      "A sign-in attempt was initiated from the login screen. props.method is the auth method enum (google | password | magic_link). Pre-auth, so fired via trackAnonymous() on the visitor_id; completion stays the server-side account/session outcome.",
+    source: "frontend",
+  },
+  {
+    name: "spec.card_opened",
+    description:
+      "A spec card on the board was opened. props.specSeq (the spec's handle ordinal — the 'spec#'), props.phase (phase enum), props.assigned (bool), props.assignedUserId (opaque user UUID — never a name/email).",
+    source: "frontend",
+  },
+  {
+    name: "spec.tab_viewed",
+    description:
+      "A content sub-tab in the spec detail view was selected (which parts of a spec people read). props.tab is the sub-tab enum (narrative | comments | decisions | work | qa-report); props.phase is the phase view it was selected under (specify | build | verify | done).",
+    source: "frontend",
+  },
+  {
+    name: "board.phase_drag",
+    description:
+      "A spec card was dragged to a different phase column on the board (the interaction). props.from / props.to are phase enums. The OUTCOME stays document.status_changed (back-end); this captures the drag intent (std-35 cl-1).",
+    source: "frontend",
+  },
+  {
+    name: "board.tag_filter_applied",
+    description:
+      "The board tag filter selection changed. props.filterCount is the number of active tag filters (count only — never the tag values).",
+    source: "frontend",
+  },
+  {
+    name: "search.opened",
+    description:
+      "The ⌘K command palette was opened. props.trigger is how it was opened (hotkey | button).",
+    source: "frontend",
+  },
+  {
+    name: "search.query_submitted",
+    description:
+      "A query produced results in the command palette. props.queryLength (character count only — never the query text), props.hasResults (bool).",
+    source: "frontend",
+  },
+  {
+    name: "search.result_selected",
+    description:
+      "A result was chosen in the command palette. props.lane (jumpTo | assigned | content), props.resultKind (entity kind enum), props.resultIndex (position).",
+    source: "frontend",
+  },
+  {
+    name: "comments.filter_changed",
+    description:
+      "A comments filter was changed. props.authorFilter / props.statusFilter are the selected filter enums.",
+    source: "frontend",
+  },
+  {
+    name: "whatsnew.opened",
+    description:
+      "The What's New feed was opened. props.unreadCount is the number of unread items at open (count only).",
+    source: "frontend",
+  },
+  {
+    name: "workspace.switched",
+    description:
+      "The user switched the active Memex via the workspace switcher. props.memexId is the target Memex UUID (id only).",
+    source: "frontend",
+  },
+  {
+    name: "voice.mic_permission_result",
+    description:
+      "The browser microphone permission prompt resolved during a voice session attempt. props.result is the outcome enum (granted | denied | dismissed).",
+    source: "frontend",
+  },
+  {
+    name: "voice.icon_shown",
+    description:
+      "The voice entry point was presented to the user (the adoption denominator). Fired once per mount, not per render. props.surface is where it appeared (icon | pill).",
+    source: "frontend",
+  },
   // ── Back-end outcomes (whitelisted mutate() events, dec-8) ───────────────────
   // Name is EXACTLY `${entity}.${action}` so the t-3 whitelist maps 1:1.
   {

--- a/packages/ui/e2e/journey-43-fe-engagement-telemetry.spec.ts
+++ b/packages/ui/e2e/journey-43-fe-engagement-telemetry.spec.ts
@@ -1,0 +1,148 @@
+import { test, expect, bareUrl, gotoSpecsBoard } from "./helpers/index.js";
+import {
+  getPersonalMemexByEmail,
+  ensureUser,
+  setUserName,
+  seedSpecInMemex,
+  deleteDoc,
+} from "./helpers/index.js";
+import type { Page, Request } from "@playwright/test";
+
+// std-28 PR-gate journey for the front-end engagement events seeded per std-35
+// Recipe A (the spec-336 Home-revamp follow-on). Component tests cover each
+// track() site under jsdom; this journey proves the rail end-to-end in a real
+// browser — a click reaches the typed track() and lands a POST /api/<ns>/<mx>/
+// telemetry with the registered name + IDs/enums/counts only (no content).
+//
+// Auth/tenant: drive the dev session like journey-18 — the dev fixture's personal
+// memex (namespace `dev` / memex `personal`). Authenticated users are tracked by
+// default (spec-326), so track() fires without a consent dance. Path-based nav.
+
+const SPEC_TITLE = "Vorpal Narwhal Telemetry Beacon";
+
+// Resolve the tenant /telemetry POST for a given registered event name, with an
+// optional predicate over its sanitised props. Returns the parsed body.
+function waitForTelemetry(
+  page: Page,
+  name: string,
+  propsPredicate?: (props: Record<string, unknown>) => boolean,
+): Promise<{ name: string; props: Record<string, unknown> }> {
+  return page
+    .waitForRequest(
+      (req: Request) => {
+        if (req.method() !== "POST" || !req.url().includes("/telemetry")) return false;
+        try {
+          const body = JSON.parse(req.postData() ?? "{}");
+          if (body.name !== name) return false;
+          return propsPredicate ? propsPredicate(body.props ?? {}) : true;
+        } catch {
+          return false;
+        }
+      },
+      { timeout: 20_000 },
+    )
+    .then((req) => JSON.parse(req.postData()!));
+}
+
+test.describe("Journey 43 — front-end engagement telemetry (std-35)", () => {
+  let docId: string;
+  let nsSlug: string;
+  let mxSlug: string;
+  let specHandle: string;
+
+  test.beforeEach(async () => {
+    const memex = await getPersonalMemexByEmail("dev@memex.ai");
+    if (!memex) throw new Error("dev@memex.ai has no personal memex — fixture setup drifted");
+    nsSlug = memex.namespaceSlug;
+    mxSlug = memex.memexSlug;
+    await setUserName("dev@memex.ai", "Dev User");
+    const devUserId = await ensureUser("dev@memex.ai");
+    ({ docId, handle: specHandle } = await seedSpecInMemex({
+      memexId: memex.memexId,
+      title: SPEC_TITLE,
+      purpose: "Vorpal Narwhal Telemetry Beacon — purpose body for the telemetry journey.",
+      createdByUserId: devUserId,
+    }));
+  });
+
+  test.afterEach(async () => {
+    if (docId) await deleteDoc(docId);
+  });
+
+  const HOTKEY = process.platform === "darwin" ? "Meta+k" : "Control+k";
+
+  test("the ⌘K search funnel emits opened → query_submitted → result_selected", async ({
+    page,
+  }) => {
+    await gotoSpecsBoard(page);
+    await expect(page.getByRole("heading", { name: "Specs" })).toBeVisible({ timeout: 15_000 });
+
+    // search.opened (hotkey): arm before the keypress.
+    const opened = waitForTelemetry(
+      page,
+      "search.opened",
+      (p) => p.trigger === "hotkey",
+    );
+    await page.keyboard.press(HOTKEY);
+    const dialog = page.getByRole("dialog", { name: "Search this memex" });
+    await expect(dialog).toBeVisible();
+    expect((await opened).props.trigger).toBe("hotkey");
+
+    // search.query_submitted: fires after the debounced fetch settles. Props are
+    // counts/bools only — the query text must NEVER appear.
+    const submitted = waitForTelemetry(page, "search.query_submitted");
+    await page.getByPlaceholder(/Search specs/i).fill(SPEC_TITLE);
+    const submittedBody = await submitted;
+    expect(typeof submittedBody.props.queryLength).toBe("number");
+    expect(submittedBody.props.hasResults).toBe(true);
+    // Defence-in-depth: no prop value carries the query string.
+    expect(JSON.stringify(submittedBody.props)).not.toContain(SPEC_TITLE);
+
+    // search.result_selected: arm, then click the seeded Spec's row.
+    const selected = waitForTelemetry(page, "search.result_selected");
+    const specRow = dialog
+      .locator('[data-testid="search-result"][data-kind="spec"]')
+      .filter({ hasText: SPEC_TITLE })
+      .first();
+    await expect(specRow).toBeVisible({ timeout: 10_000 });
+    await specRow.click();
+    const selectedBody = await selected;
+    expect(["jumpTo", "assigned", "content"]).toContain(selectedBody.props.lane);
+    expect(selectedBody.props.resultKind).toBe("spec");
+    expect(typeof selectedBody.props.resultIndex).toBe("number");
+
+    // The selection actually navigated to the Spec (the track() didn't block it).
+    await expect(page).toHaveURL(new RegExp(`/specs/${specHandle}(\\b|/|$)`), {
+      timeout: 10_000,
+    });
+  });
+
+  test("opening a spec card on the board emits spec.card_opened (the 'spec#' + phase)", async ({
+    page,
+  }) => {
+    await gotoSpecsBoard(page);
+    await expect(page.getByRole("heading", { name: "Specs" })).toBeVisible({ timeout: 15_000 });
+
+    const cardOpened = waitForTelemetry(page, "spec.card_opened");
+    // The board card is a link to /specs/<handle>; click the seeded one.
+    await page.getByRole("link", { name: new RegExp(SPEC_TITLE, "i") }).first().click();
+
+    const body = await cardOpened;
+    // specSeq is the spec's handle ordinal (the "spec#") — an id, never a title.
+    expect(body.props.specSeq).toBeDefined();
+    expect(["draft", "specify", "build", "verify", "done"]).toContain(body.props.phase);
+    expect(typeof body.props.assigned).toBe("boolean");
+    expect(JSON.stringify(body.props)).not.toContain(SPEC_TITLE);
+  });
+
+  test("the board search trigger button emits search.opened with trigger=button", async ({
+    page,
+  }) => {
+    await gotoSpecsBoard(page);
+    await expect(page.getByRole("heading", { name: "Specs" })).toBeVisible({ timeout: 15_000 });
+
+    const opened = waitForTelemetry(page, "search.opened", (p) => p.trigger === "button");
+    await page.getByTestId("search-palette-trigger-board").click();
+    expect((await opened).props.trigger).toBe("button");
+  });
+});

--- a/packages/ui/e2e/journey-43-fe-engagement-telemetry.spec.ts
+++ b/packages/ui/e2e/journey-43-fe-engagement-telemetry.spec.ts
@@ -1,10 +1,11 @@
-import { test, expect, bareUrl, gotoSpecsBoard } from "./helpers/index.js";
+import { test, expect, gotoSpecsBoard } from "./helpers/index.js";
 import {
   getPersonalMemexByEmail,
   ensureUser,
   setUserName,
   seedSpecInMemex,
   deleteDoc,
+  emitAcEvents,
 } from "./helpers/index.js";
 import type { Page, Request } from "@playwright/test";
 
@@ -67,6 +68,42 @@ test.describe("Journey 43 — front-end engagement telemetry (std-35)", () => {
 
   test.afterEach(async () => {
     if (docId) await deleteDoc(docId);
+  });
+
+  // std-28 / std-35 step 6: emit pass/fail for the ACs this journey evidences,
+  // keyed by test title (routing is namespace-derived → memex.ai). The search
+  // funnel proves query_submitted (ac-12); the card test proves card_opened
+  // (ac-10); all three prove the FE events fire (ac-1), carry no content (ac-2),
+  // and that the std-28 journey exists (ac-6).
+  const SPEC = "mindset-prod/memex-building-itself/specs/spec-338";
+  const ACS_BY_TEST: Record<string, string[]> = {
+    "the ⌘K search funnel emits opened → query_submitted → result_selected": [
+      `${SPEC}/acs/ac-12`,
+      `${SPEC}/acs/ac-1`,
+      `${SPEC}/acs/ac-2`,
+      `${SPEC}/acs/ac-6`,
+    ],
+    "opening a spec card on the board emits spec.card_opened (the 'spec#' + phase)": [
+      `${SPEC}/acs/ac-10`,
+      `${SPEC}/acs/ac-1`,
+      `${SPEC}/acs/ac-2`,
+      `${SPEC}/acs/ac-6`,
+    ],
+    "the board search trigger button emits search.opened with trigger=button": [
+      `${SPEC}/acs/ac-1`,
+      `${SPEC}/acs/ac-6`,
+    ],
+  };
+  test.afterEach(async ({}, testInfo) => {
+    if (testInfo.status === "skipped") return;
+    const refs = ACS_BY_TEST[testInfo.title];
+    if (!refs) return;
+    await emitAcEvents(
+      refs,
+      testInfo.status === "passed" ? "pass" : "fail",
+      `packages/ui/e2e/journey-43-fe-engagement-telemetry.spec.ts::${testInfo.title}`,
+      testInfo.duration ?? 0,
+    );
   });
 
   const HOTKEY = process.platform === "darwin" ? "Meta+k" : "Control+k";

--- a/packages/ui/src/components/AllComments.tsx
+++ b/packages/ui/src/components/AllComments.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import type { Comment, DocSection, Decision, Task } from '../api/types';
+import { useTelemetry } from '../hooks/useTelemetry';
 import { CommentBubble } from './CommentTray';
 import { filterComments, type AuthorKindFilter, type StatusFilter } from '../utils/filterComments';
 import { commentAnchorId, buildCommentLink } from '../utils/commentDeepLink';
@@ -125,6 +126,17 @@ export function AllComments({
   // history, shown on demand. authorKind defaults to 'all' (Everyone).
   const [authorKind, setAuthorKind] = useState<AuthorKindFilter>('all');
   const [status, setStatus] = useState<StatusFilter>('open');
+  const { track } = useTelemetry(true);
+
+  // Adoption of the comment filters (spec-194). Enums only.
+  const handleAuthorKind = (next: AuthorKindFilter) => {
+    track('comments.filter_changed', { authorFilter: next, statusFilter: status });
+    setAuthorKind(next);
+  };
+  const handleStatus = (next: StatusFilter) => {
+    track('comments.filter_changed', { authorFilter: authorKind, statusFilter: next });
+    setStatus(next);
+  };
   const applyLocal = (list: Comment[]) =>
     filterComments(list, { authorKind, status, type: null });
 
@@ -218,7 +230,7 @@ export function AllComments({
             group="author"
             options={AUTHOR_KIND_OPTIONS}
             active={authorKind}
-            onChange={setAuthorKind}
+            onChange={handleAuthorKind}
             tone="agent"
           />
           <span aria-hidden className="h-4 w-px bg-edge-subtle" />
@@ -226,7 +238,7 @@ export function AllComments({
             group="status"
             options={STATUS_OPTIONS}
             active={status}
-            onChange={setStatus}
+            onChange={handleStatus}
           />
         </div>
       )}

--- a/packages/ui/src/components/LoginScreen.tsx
+++ b/packages/ui/src/components/LoginScreen.tsx
@@ -78,12 +78,17 @@ function LoginCard(props: LoginScreenProps) {
         <EnterEmailScreen
           authError={props.authError}
           googleClientId={props.googleClientId}
-          onGoogleCredential={props.onGoogleCredential}
+          onGoogleCredential={(credential) => {
+            // Pre-auth → trackAnonymous (no tenant yet); method enum only.
+            trackAnonymous('auth.login_started', { method: 'google' });
+            return props.onGoogleCredential(credential);
+          }}
           onContinue={async (email) => {
             const probe = await probeAuthApi(email);
             if (!probe.exists) setView({ kind: 'create-password', email });
             else if (probe.hasPassword) setView({ kind: 'password', email });
             else {
+              trackAnonymous('auth.login_started', { method: 'magic_link' });
               const { loginRequestId } = await props.onMagicLink(email);
               setView({ kind: 'magic-sent', email, loginRequestId });
             }
@@ -97,9 +102,13 @@ function LoginCard(props: LoginScreenProps) {
           email={view.email}
           mode="signin"
           authError={props.authError}
-          onSubmit={(password) => props.onLogin(view.email, password)}
+          onSubmit={(password) => {
+            trackAnonymous('auth.login_started', { method: 'password' });
+            return props.onLogin(view.email, password);
+          }}
           onForgot={() => setView({ kind: 'forgot' })}
           onMagicLink={async () => {
+            trackAnonymous('auth.login_started', { method: 'magic_link' });
             const { loginRequestId } = await props.onMagicLink(view.email);
             setView({ kind: 'magic-sent', email: view.email, loginRequestId });
           }}

--- a/packages/ui/src/components/MemexSwitcher.tsx
+++ b/packages/ui/src/components/MemexSwitcher.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from './AuthContext';
 import { getCurrentTenant, namespaceHomePath, tenantPathFor } from '../utils/tenantUrl';
+import { useTelemetry } from '../hooks/useTelemetry';
 
 // Top-right Memex switcher. Always rendered for authenticated users — the primary
 // indicator of which Memex the user is currently in (GitHub-style). Dropdown
@@ -22,6 +23,7 @@ import { getCurrentTenant, namespaceHomePath, tenantPathFor } from '../utils/ten
 export function MemexSwitcher({ variant = 'topbar' }: { variant?: 'topbar' | 'sidebar' } = {}) {
   const { session } = useAuth();
   const navigate = useNavigate();
+  const { track } = useTelemetry(true);
   const [open, setOpen] = useState(false);
   const wrapperRef = useRef<HTMLDivElement>(null);
 
@@ -94,22 +96,28 @@ export function MemexSwitcher({ variant = 'topbar' }: { variant?: 'topbar' | 'si
     if (!personalMembership) return;
     const ns = personalMembership.slug;
     const mx = personalMembership.memexSlug ?? 'personal';
+    // Only a real switch (not re-selecting the current Memex). id only.
+    if (!currentIsPersonal) {
+      track('workspace.switched', { memexId: personalMembership.memexId });
+    }
     navigate(tenantPathFor(ns, mx, '/specs'));
   }
 
-  function goToOrgMemex(m: { slug: string; memexSlug?: string }) {
+  function goToOrgMemex(m: { slug: string; memexSlug?: string; memexId: string }) {
     setOpen(false);
     const mx = m.memexSlug ?? 'main';
     if (m.slug === currentSlug && current?.memex === mx) return;
+    track('workspace.switched', { memexId: m.memexId });
     navigate(tenantPathFor(m.slug, mx, '/specs'));
   }
 
   // Visited rows always carry a memexSlug (the server's join selects it), so no
   // 'main' fallback dance is needed — but keep one for parity/safety.
-  function goToVisitedMemex(m: { slug: string; memexSlug?: string }) {
+  function goToVisitedMemex(m: { slug: string; memexSlug?: string; memexId: string }) {
     setOpen(false);
     const mx = m.memexSlug ?? 'main';
     if (m.slug === currentSlug && current?.memex === mx) return;
+    track('workspace.switched', { memexId: m.memexId });
     navigate(tenantPathFor(m.slug, mx, '/specs'));
   }
 

--- a/packages/ui/src/components/SearchContext.tsx
+++ b/packages/ui/src/components/SearchContext.tsx
@@ -8,6 +8,7 @@ import {
   type ReactNode,
 } from 'react';
 import { SearchPalette } from './SearchPalette';
+import { useTelemetry } from '../hooks/useTelemetry';
 
 // spec-192 t-1 (ac-2 / ac-8 / ac-10): the global ⌘K search open-state lives here
 // so the app chrome — the Specs board header (SpecList) and the doc-page header
@@ -40,6 +41,7 @@ export function useSearch(): SearchContextValue | null {
 }
 
 export function SearchProvider({ children }: { children: ReactNode }) {
+  const { track } = useTelemetry(true);
   const [open, setOpen] = useState(false);
   const openRef = useRef(false);
   const restoreFocusRef = useRef<HTMLElement | null>(null);
@@ -73,14 +75,22 @@ export function SearchProvider({ children }: { children: ReactNode }) {
     function onKeyDown(e: KeyboardEvent) {
       if ((e.metaKey || e.ctrlKey) && (e.key === 'k' || e.key === 'K')) {
         e.preventDefault();
+        // Fire only on the open transition (the hotkey toggles), so a close
+        // press isn't counted as an open. Measures ⌘K discoverability.
+        if (!openRef.current) track('search.opened', { trigger: 'hotkey' });
         setOpenSafe(!openRef.current);
       }
     }
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
-  }, [setOpenSafe]);
+  }, [setOpenSafe, track]);
 
-  const openSearch = useCallback(() => setOpenSafe(true), [setOpenSafe]);
+  // The chrome triggers (board header + doc header) all call openSearch — count
+  // those as button-opened, only when not already open.
+  const openSearch = useCallback(() => {
+    if (!openRef.current) track('search.opened', { trigger: 'button' });
+    setOpenSafe(true);
+  }, [setOpenSafe, track]);
   const closeSearch = useCallback(() => setOpenSafe(false), [setOpenSafe]);
 
   return (

--- a/packages/ui/src/components/SearchPalette.tsx
+++ b/packages/ui/src/components/SearchPalette.tsx
@@ -9,6 +9,7 @@ import {
 } from '../api/client';
 import { snippetText } from '../utils/format';
 import { Badge } from './ui';
+import { useTelemetry } from '../hooks/useTelemetry';
 
 // spec-64 t-3/t-4: the global command-palette omnibox.
 //
@@ -120,11 +121,13 @@ function HitBadges({ hit }: { hit: SearchHit }) {
 function ResultRow({
   hit,
   lane,
+  index,
   onPick,
 }: {
   hit: SearchHit;
   lane: 'jumpTo' | 'assigned' | 'content';
-  onPick: (hit: SearchHit) => void;
+  index: number;
+  onPick: (hit: SearchHit, lane: 'jumpTo' | 'assigned' | 'content', index: number) => void;
 }) {
   const snippet =
     lane === 'content' && hit.matchingSections.length > 0
@@ -147,7 +150,7 @@ function ResultRow({
       // Disable cmdk's text-scoring against this value (it's a synthetic key,
       // not user-facing text) — selection still works, ordering stays ours.
       keywords={[]}
-      onSelect={() => onPick(hit)}
+      onSelect={() => onPick(hit, lane, index)}
       className="flex cursor-pointer flex-col gap-1 rounded-md px-3 py-2 text-sm aria-selected:bg-selected"
       data-testid="search-result"
       data-kind={hit.kind}
@@ -183,6 +186,7 @@ function ResultRow({
 
 export function SearchPalette({ open, onOpenChange }: SearchPaletteProps) {
   const navigate = useNavigate();
+  const { track } = useTelemetry(true);
   const [query, setQuery] = useState('');
   const [results, setResults] = useState<SearchEnvelope>(EMPTY_ENVELOPE);
   const [loading, setLoading] = useState(false);
@@ -217,6 +221,16 @@ export function SearchPalette({ open, onOpenChange }: SearchPaletteProps) {
           if (!controller.signal.aborted) {
             setResults(envelope);
             setLoading(false);
+            // A settled search (debounce coalesces fast typing into one fetch).
+            // Counts/booleans only — never the query text (std-35 cl-5).
+            track('search.query_submitted', {
+              queryLength: trimmed.length,
+              hasResults:
+                envelope.jumpTo.length +
+                  envelope.assigned.length +
+                  envelope.content.length >
+                0,
+            });
           }
         })
         .catch((err) => {
@@ -233,18 +247,24 @@ export function SearchPalette({ open, onOpenChange }: SearchPaletteProps) {
       clearTimeout(timer);
       controller.abort();
     };
-  }, [query, open]);
+  }, [query, open, track]);
 
   // spec-64 t-4 (ac-10): Enter (or click) navigates to the focused hit's
   // canonical path via react-router. `path` has no leading slash, so prefix one
   // — the admin routes mount specs at /:namespace/:memex/specs/... (App.tsx), and
   // `path` is already `<ns>/<mx>/specs/spec-N`, so `/` + path lands on-route.
   const handlePick = useCallback(
-    (hit: SearchHit) => {
+    (hit: SearchHit, lane: 'jumpTo' | 'assigned' | 'content', index: number) => {
+      // Which lane delivers value + jump-by-number adoption. IDs/enums/counts only.
+      track('search.result_selected', {
+        lane,
+        resultKind: hit.kind,
+        resultIndex: index,
+      });
       onOpenChange(false);
       navigate('/' + hit.path);
     },
-    [navigate, onOpenChange],
+    [navigate, onOpenChange, track],
   );
 
   const { jumpTo, assigned, content } = results;
@@ -300,11 +320,12 @@ export function SearchPalette({ open, onOpenChange }: SearchPaletteProps) {
             heading="Jump to"
             className={GROUP_CLASS}
           >
-            {jumpTo.map((hit) => (
+            {jumpTo.map((hit, i) => (
               <ResultRow
                 key={`jumpTo:${hit.path}`}
                 hit={hit}
                 lane="jumpTo"
+                index={i}
                 onPick={handlePick}
               />
             ))}
@@ -317,11 +338,12 @@ export function SearchPalette({ open, onOpenChange }: SearchPaletteProps) {
             heading="Assigned"
             className={GROUP_CLASS}
           >
-            {assigned.map((hit) => (
+            {assigned.map((hit, i) => (
               <ResultRow
                 key={`assigned:${hit.path}`}
                 hit={hit}
                 lane="assigned"
+                index={i}
                 onPick={handlePick}
               />
             ))}
@@ -339,11 +361,12 @@ export function SearchPalette({ open, onOpenChange }: SearchPaletteProps) {
                 heading={KIND_GROUP_HEADING[kind]}
                 className={GROUP_CLASS}
               >
-                {hits.map((hit) => (
+                {hits.map((hit, i) => (
                   <ResultRow
                     key={`content:${hit.path}`}
                     hit={hit}
                     lane="content"
+                    index={i}
                     onPick={handlePick}
                   />
                 ))}

--- a/packages/ui/src/components/TagFilter.telemetry.test.tsx
+++ b/packages/ui/src/components/TagFilter.telemetry.test.tsx
@@ -1,7 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { tagAc } from '@memex-ai-ac/vitest';
 import type { Tag } from '../api/types';
+
+const AC = 'mindset-prod/memex-building-itself/specs/spec-338/acs';
 
 // Capture track() calls without a live tenant (useTelemetry no-ops without one in
 // jsdom, so we stub the hook to observe the call the component makes).
@@ -24,6 +27,8 @@ describe('TagFilter — board.tag_filter_applied telemetry', () => {
   beforeEach(() => track.mockClear());
 
   it('fires board.tag_filter_applied with the new count (count only, no tag values)', async () => {
+    tagAc(`${AC}/ac-2`); // props are counts only — never the tag values (no PII/content)
+    tagAc(`${AC}/ac-1`); // an in-scope FE interaction emits a registered track() event
     const onChange = vi.fn();
     render(<TagFilter selected={[]} onChange={onChange} />);
 
@@ -39,6 +44,7 @@ describe('TagFilter — board.tag_filter_applied telemetry', () => {
   });
 
   it('fires filterCount: 0 when the selection is cleared', async () => {
+    tagAc(`${AC}/ac-1`);
     const onChange = vi.fn();
     render(<TagFilter selected={['priority::high']} onChange={onChange} />);
 

--- a/packages/ui/src/components/TagFilter.telemetry.test.tsx
+++ b/packages/ui/src/components/TagFilter.telemetry.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { Tag } from '../api/types';
+
+// Capture track() calls without a live tenant (useTelemetry no-ops without one in
+// jsdom, so we stub the hook to observe the call the component makes).
+const track = vi.fn();
+vi.mock('../hooks/useTelemetry', () => ({
+  useTelemetry: () => ({ track, optedOut: false, setOptOut: vi.fn() }),
+}));
+
+const CATALOGUE: Tag[] = [
+  { id: 't1', memexId: 'm1', scope: 'priority', value: 'high', createdAt: '2025-01-01T00:00:00Z' },
+  { id: 't2', memexId: 'm1', scope: 'priority', value: 'low', createdAt: '2025-01-01T00:00:00Z' },
+];
+vi.mock('../api/client', () => ({
+  fetchMemexTags: vi.fn(async () => CATALOGUE),
+}));
+
+import { TagFilter } from './TagFilter';
+
+describe('TagFilter — board.tag_filter_applied telemetry', () => {
+  beforeEach(() => track.mockClear());
+
+  it('fires board.tag_filter_applied with the new count (count only, no tag values)', async () => {
+    const onChange = vi.fn();
+    render(<TagFilter selected={[]} onChange={onChange} />);
+
+    await userEvent.click(screen.getByTestId('tag-filter-toggle'));
+    const options = await screen.findAllByTestId('tag-filter-option');
+    await userEvent.click(options[0]);
+
+    expect(track).toHaveBeenCalledWith('board.tag_filter_applied', { filterCount: 1 });
+    // The props carry only the count — never the tag scope/value (std-35 cl-5).
+    const [, props] = track.mock.calls.at(-1)!;
+    expect(Object.keys(props as object)).toEqual(['filterCount']);
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires filterCount: 0 when the selection is cleared', async () => {
+    const onChange = vi.fn();
+    render(<TagFilter selected={['priority::high']} onChange={onChange} />);
+
+    await userEvent.click(screen.getByTestId('tag-filter-clear'));
+
+    await waitFor(() =>
+      expect(track).toHaveBeenCalledWith('board.tag_filter_applied', { filterCount: 0 }),
+    );
+  });
+});

--- a/packages/ui/src/components/TagFilter.tsx
+++ b/packages/ui/src/components/TagFilter.tsx
@@ -3,6 +3,7 @@ import type { Tag } from '../api/types';
 import { fetchMemexTags } from '../api/client';
 import { TagChip } from './TagChip';
 import { formatTagInput, tagMatchesQuery, parseTagInput } from '../utils/tagInput';
+import { useTelemetry } from '../hooks/useTelemetry';
 
 interface TagFilterProps {
   /**
@@ -27,6 +28,7 @@ interface TagFilterProps {
  * applies the same AND/OR semantics on the indexed (scope, value) join.
  */
 export function TagFilter({ selected, onChange, className = '' }: TagFilterProps) {
+  const { track } = useTelemetry(true);
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState('');
   const [catalogue, setCatalogue] = useState<Tag[]>([]);
@@ -78,15 +80,25 @@ export function TagFilter({ selected, onChange, className = '' }: TagFilterProps
 
   const selectedSet = useMemo(() => new Set(selected), [selected]);
 
+  // Every selection change goes through here so the telemetry fires once per
+  // change (count only — never the tag values, std-35 cl-5).
+  const applyChange = useCallback(
+    (next: string[]) => {
+      track('board.tag_filter_applied', { filterCount: next.length });
+      onChange(next);
+    },
+    [onChange, track],
+  );
+
   const toggle = useCallback(
     (raw: string) => {
       if (selectedSet.has(raw)) {
-        onChange(selected.filter((s) => s !== raw));
+        applyChange(selected.filter((s) => s !== raw));
       } else {
-        onChange([...selected, raw]);
+        applyChange([...selected, raw]);
       }
     },
-    [selected, selectedSet, onChange],
+    [selected, selectedSet, applyChange],
   );
 
   const visible = useMemo(
@@ -132,7 +144,7 @@ export function TagFilter({ selected, onChange, className = '' }: TagFilterProps
           <button
             type="button"
             data-testid="tag-filter-clear"
-            onClick={() => onChange([])}
+            onClick={() => applyChange([])}
             className="text-xs text-muted hover:text-secondary underline-offset-2 hover:underline"
           >
             Clear

--- a/packages/ui/src/components/whats-new/WhatsNewRibbon.tsx
+++ b/packages/ui/src/components/whats-new/WhatsNewRibbon.tsx
@@ -25,6 +25,7 @@ import { Specky } from '@memex/guide-sdk';
 import { Confetti } from './Confetti';
 import { useWhatsNew } from './WhatsNewContext';
 import { fetchWhatsNew, type WhatsNewEntry } from '../../api/whatsNew';
+import { useTelemetry } from '../../hooks/useTelemetry';
 
 const DISMISS_KEY = 'whats-new:dismissed-at';
 const CONFETTI_KEY = 'whats-new:confetti-shown-at';
@@ -73,6 +74,7 @@ export function WhatsNewRibbon({
   autoDismissMs = AUTO_DISMISS_MS,
 }: WhatsNewRibbonProps) {
   const { setAvailable, registerOpener, getMenuAnchor } = useWhatsNew();
+  const { track } = useTelemetry(true);
 
   const [entries, setEntries] = useState<WhatsNewEntry[]>([]);
   const [dismissed, setDismissed] = useState(false);
@@ -121,11 +123,24 @@ export function WhatsNewRibbon({
     setAvailable(entries.length > 0);
   }, [entries.length, setAvailable]);
 
+  // Engagement with release notes (spec-200). Count only — entries still newer
+  // than the user's dismiss marker at the moment the popup opens.
+  const fireOpened = useCallback(() => {
+    const dismissedAt = readMarker(DISMISS_KEY);
+    const unreadCount = entries.filter(
+      (e) => Date.parse(e.publishedAt) > dismissedAt,
+    ).length;
+    track('whatsnew.opened', { unreadCount });
+  }, [entries, track]);
+
   // Register the menu opener so the sidebar "What's New" item can open the popup.
   useEffect(() => {
-    registerOpener(() => setOpen(true));
+    registerOpener(() => {
+      fireOpened();
+      setOpen(true);
+    });
     return () => registerOpener(null);
-  }, [registerOpener]);
+  }, [registerOpener, fireOpened]);
 
   // Slide the ribbon in, and fire confetti only the first time THIS entry is seen
   // (req 1/2): a marker distinct from dismissal, so a repeat visit gets no confetti.
@@ -184,8 +199,9 @@ export function WhatsNewRibbon({
   const openFromRibbon = useCallback(() => {
     clearTimeout(dismissTimer.current);
     setCountingDown(false);
+    fireOpened();
     setOpen(true);
-  }, []);
+  }, [fireOpened]);
 
   // Manually closing the popup dismisses the ribbon — the popup disappears, then
   // the ribbon flies home (req 5/6). If the ribbon is already gone (opened from

--- a/packages/ui/src/pages/DocDocument.tsx
+++ b/packages/ui/src/pages/DocDocument.tsx
@@ -27,6 +27,7 @@ import { AllComments } from '../components/AllComments';
 import { AcPanel } from '../components/AcPanel';
 import { PhaseTabBar, type PhaseTab } from '../components/PhaseTabBar';
 import { phaseColors } from '../components/phaseColors';
+import { useTelemetry } from '../hooks/useTelemetry';
 import { TransitionSentence } from '../components/TransitionSentence';
 import { DoneSummary } from '../components/DoneSummary';
 import { Badge, Tabs } from '../components/ui';
@@ -165,6 +166,7 @@ export function DocDocument() {
   const [commentsByDecision, setCommentsByDecision] = useState<Record<string, Comment[]>>({});
   const [commentsByTask, setCommentsByTask] = useState<Record<string, Comment[]>>({});
   const [selectedSectionId, setSelectedSectionId] = useState<string | null>(null);
+  const { track } = useTelemetry(true);
   // spec-159 t-6: the page is organised around the Spec's three working phases
   // (Specify / Build / Verify) instead of the six flat content tabs. `selectedTab`
   // is the phase view the user is browsing — it never drives the Spec's phase
@@ -1115,7 +1117,14 @@ export function DocDocument() {
       <Tabs
         tabs={subTabs}
         activeTab={effectiveSubTab}
-        onChange={(t) => setSubTab(t as SubTab)}
+        onChange={(t) => {
+          // Which parts of a spec people read. Fire only on a real change
+          // (the explicit user selection), enum-only props.
+          if (t !== effectiveSubTab) {
+            track('spec.tab_viewed', { tab: t, phase: viewedTab });
+          }
+          setSubTab(t as SubTab);
+        }}
         variant="underline"
       />
       {effectiveSubTab === 'narrative' && narrativeView}

--- a/packages/ui/src/pages/SpecList.tsx
+++ b/packages/ui/src/pages/SpecList.tsx
@@ -17,6 +17,7 @@ import { RenameSpecDialog } from '../components/RenameSpecDialog';
 import { MoveSpecDialog } from '../components/MoveSpecDialog';
 import { tenantPath, getCurrentTenant } from '../utils/tenantUrl';
 import { useAuth } from '../components/AuthContext';
+import { useTelemetry } from '../hooks/useTelemetry';
 import { nextRevealPhase, type RevealPhase } from '../hooks/useHandholdReveal';
 import { useHandholdRevealValue } from '../hooks/HandholdRevealContext';
 import { useIsFeatureHidden } from '../hooks/useIsFeatureHidden';
@@ -140,6 +141,7 @@ interface KanbanColumnProps {
 }
 
 function KanbanColumn(props: KanbanColumnProps) {
+  const { track } = useTelemetry(true);
   const {
     id,
     label,
@@ -210,6 +212,16 @@ function KanbanColumn(props: KanbanColumnProps) {
               <Link
                 to={tenantPath(`/specs/${d.handle}`)}
                 draggable={canWrite}
+                onClick={() =>
+                  track('spec.card_opened', {
+                    specSeq: docSeq(d.handle) ?? d.handle,
+                    phase: id,
+                    assigned: (d.assignees?.length ?? 0) > 0,
+                    ...(d.assignees?.[0]?.userId
+                      ? { assignedUserId: d.assignees[0].userId }
+                      : {}),
+                  })
+                }
                 onDragStart={canWrite ? (e) => onDragStart(e, d.id) : undefined}
                 onDragEnd={canWrite ? onDragEnd : undefined}
                 className={`block border rounded-md p-3 pr-9 transition-all bg-panel border-edge-subtle hover:border-edge hover:bg-card-hover ${
@@ -352,6 +364,7 @@ function KanbanColumn(props: KanbanColumnProps) {
  */
 export function SpecList() {
   const { session, user } = useAuth();
+  const { track } = useTelemetry(true);
   // spec-118 ac-19: the assignee filter lives in the URL (?assignee=all|me|<userId>)
   // so a filtered board is shareable, matching the board's existing URL conventions.
   const [searchParams, setSearchParams] = useSearchParams();
@@ -585,6 +598,10 @@ export function SpecList() {
 
     const current = docs.find((d) => d.id === docId);
     if (!current || current.status === column) return;
+
+    // The drag interaction (intent). The OUTCOME is document.status_changed
+    // (back-end); this captures whether drag-to-move is used vs the detail view.
+    track('board.phase_drag', { from: current.status, to: column });
 
     // Promote the drag-time auto-expand to a sticky open state once a card
     // actually lands in Done, so the user can see what they just dropped.

--- a/packages/ui/src/usage-events-catalog.spec-338.test.ts
+++ b/packages/ui/src/usage-events-catalog.spec-338.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { USAGE_EVENT_REGISTRY, isFrontendEvent } from '@memex/shared';
+
+// UI-side mirror of the shared registry-contract assertions, for AC EMISSION.
+// The shared package's unit tests carry the same assertions but run in a CI job
+// without MEMEX_EMIT_KEY, so their tagAc() calls no-op — the events never land.
+// This file re-asserts the registry facts from the UI job (which DOES emit), so
+// ac-5 (machine contract) and ac-3 (Home untouched) actually verify. Importing
+// @memex/shared gives the real, built registry (with the spec-338 events).
+
+const AC = 'mindset-prod/memex-building-itself/specs/spec-338/acs';
+
+const NEW_FRONTEND_EVENTS = [
+  'auth.login_started',
+  'spec.card_opened',
+  'spec.tab_viewed',
+  'board.phase_drag',
+  'board.tag_filter_applied',
+  'search.opened',
+  'search.query_submitted',
+  'search.result_selected',
+  'comments.filter_changed',
+  'whatsnew.opened',
+  'workspace.switched',
+  'voice.mic_permission_result',
+  'voice.icon_shown',
+] as const;
+
+describe('spec-338 registry contract (UI-side, emits ACs)', () => {
+  it('the 13 engagement events are registered front-end events (machine contract)', () => {
+    tagAc(`${AC}/ac-5`);
+    tagAc(`${AC}/ac-1`);
+    for (const name of NEW_FRONTEND_EVENTS) {
+      expect(isFrontendEvent(name)).toBe(true);
+    }
+  });
+
+  it('adds no onboarding.* events and leaves home_canvas.* intact (Home untouched — spec-336 owns it)', () => {
+    tagAc(`${AC}/ac-3`);
+    const names = USAGE_EVENT_REGISTRY.map((e) => e.name);
+    expect(names.filter((n) => n.startsWith('onboarding.'))).toHaveLength(0);
+    expect(names).toContain('home_canvas.step_shown');
+    expect(names).toContain('home_canvas.cta_clicked');
+  });
+});

--- a/packages/ui/src/voice/session/VoiceLayer.telemetry.test.tsx
+++ b/packages/ui/src/voice/session/VoiceLayer.telemetry.test.tsx
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+
+// A mutable fake voice session the test drives through the state machine; the
+// VoiceLayer effect observes status transitions at the shell and fires telemetry.
+let sessionStatus = 'inactive';
+vi.mock('@memex/guide-sdk', () => ({
+  useVoiceSession: () => ({ status: sessionStatus, error: null }),
+  VoiceIcon: () => null,
+  VoiceSessionPill: () => null,
+  Specky: () => null,
+}));
+vi.mock('react-router-dom', () => ({ useLocation: () => ({ pathname: '/ns/mx/specs' }) }));
+vi.mock('@memex/shared', () => ({ resolveScreenKey: () => 'specs' }));
+
+const track = vi.fn();
+vi.mock('../../hooks/useTelemetry', () => ({
+  useTelemetry: () => ({ track, optedOut: false, setOptOut: vi.fn() }),
+}));
+
+import { VoiceLayer } from './VoiceLayer';
+
+describe('VoiceLayer — voice telemetry transitions', () => {
+  beforeEach(() => {
+    track.mockClear();
+    sessionStatus = 'inactive';
+  });
+
+  it('fires icon_shown once on mount when the entry icon is visible', () => {
+    render(<VoiceLayer />);
+    const iconShown = track.mock.calls.filter((c) => c[0] === 'voice.icon_shown');
+    expect(iconShown).toHaveLength(1);
+    expect(iconShown[0][1]).toEqual({ surface: 'icon' });
+  });
+
+  it('grant path: requesting → active fires session_started + mic granted', () => {
+    sessionStatus = 'inactive';
+    const { rerender } = render(<VoiceLayer />);
+    track.mockClear();
+
+    sessionStatus = 'requesting_permission';
+    rerender(<VoiceLayer />);
+    sessionStatus = 'active';
+    rerender(<VoiceLayer />);
+
+    expect(track).toHaveBeenCalledWith('voice.session_started');
+    expect(track).toHaveBeenCalledWith('voice.mic_permission_result', { result: 'granted' });
+  });
+
+  it('denied path: requesting → permission_denied fires mic denied (no session_started)', () => {
+    sessionStatus = 'requesting_permission';
+    const { rerender } = render(<VoiceLayer />);
+    track.mockClear();
+
+    sessionStatus = 'permission_denied';
+    rerender(<VoiceLayer />);
+
+    expect(track).toHaveBeenCalledWith('voice.mic_permission_result', { result: 'denied' });
+    expect(track).not.toHaveBeenCalledWith('voice.session_started');
+  });
+
+  it('active → inactive fires session_ended with a numeric durationMs', () => {
+    sessionStatus = 'active';
+    const { rerender } = render(<VoiceLayer />);
+    track.mockClear();
+
+    sessionStatus = 'inactive';
+    rerender(<VoiceLayer />);
+
+    const ended = track.mock.calls.find((c) => c[0] === 'voice.session_ended');
+    expect(ended).toBeTruthy();
+    expect(typeof (ended![1] as { durationMs: number }).durationMs).toBe('number');
+  });
+});

--- a/packages/ui/src/voice/session/VoiceLayer.telemetry.test.tsx
+++ b/packages/ui/src/voice/session/VoiceLayer.telemetry.test.tsx
@@ -14,7 +14,13 @@ vi.mock('@memex/guide-sdk', () => ({
   Specky: () => null,
 }));
 vi.mock('react-router-dom', () => ({ useLocation: () => ({ pathname: '/ns/mx/specs' }) }));
-vi.mock('@memex/shared', () => ({ resolveScreenKey: () => 'specs' }));
+// Spread the REAL @memex/shared and override only resolveScreenKey — a full-module
+// replacement would strip whatever the AC-emit setup imports from it and silently
+// kill this file's tagAc emissions (the reason ac-9/ac-11/ac-4 didn't land first time).
+vi.mock('@memex/shared', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return { ...actual, resolveScreenKey: () => 'specs' };
+});
 
 const track = vi.fn();
 vi.mock('../../hooks/useTelemetry', () => ({

--- a/packages/ui/src/voice/session/VoiceLayer.telemetry.test.tsx
+++ b/packages/ui/src/voice/session/VoiceLayer.telemetry.test.tsx
@@ -1,5 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render } from '@testing-library/react';
+import { tagAc } from '@memex-ai-ac/vitest';
+
+const AC = 'mindset-prod/memex-building-itself/specs/spec-338/acs';
 
 // A mutable fake voice session the test drives through the state machine; the
 // VoiceLayer effect observes status transitions at the shell and fires telemetry.
@@ -27,6 +30,8 @@ describe('VoiceLayer — voice telemetry transitions', () => {
   });
 
   it('fires icon_shown once on mount when the entry icon is visible', () => {
+    tagAc(`${AC}/ac-9`); // voice.icon_shown once per mount
+    tagAc(`${AC}/ac-4`); // scope: voice funnel — the entry icon is presented
     render(<VoiceLayer />);
     const iconShown = track.mock.calls.filter((c) => c[0] === 'voice.icon_shown');
     expect(iconShown).toHaveLength(1);
@@ -34,6 +39,8 @@ describe('VoiceLayer — voice telemetry transitions', () => {
   });
 
   it('grant path: requesting → active fires session_started + mic granted', () => {
+    tagAc(`${AC}/ac-11`); // session_started/ended + mic_permission from transitions
+    tagAc(`${AC}/ac-4`);
     sessionStatus = 'inactive';
     const { rerender } = render(<VoiceLayer />);
     track.mockClear();
@@ -48,6 +55,8 @@ describe('VoiceLayer — voice telemetry transitions', () => {
   });
 
   it('denied path: requesting → permission_denied fires mic denied (no session_started)', () => {
+    tagAc(`${AC}/ac-11`);
+    tagAc(`${AC}/ac-4`);
     sessionStatus = 'requesting_permission';
     const { rerender } = render(<VoiceLayer />);
     track.mockClear();
@@ -60,6 +69,8 @@ describe('VoiceLayer — voice telemetry transitions', () => {
   });
 
   it('active → inactive fires session_ended with a numeric durationMs', () => {
+    tagAc(`${AC}/ac-11`);
+    tagAc(`${AC}/ac-4`);
     sessionStatus = 'active';
     const { rerender } = render(<VoiceLayer />);
     track.mockClear();

--- a/packages/ui/src/voice/session/VoiceLayer.tsx
+++ b/packages/ui/src/voice/session/VoiceLayer.tsx
@@ -21,12 +21,58 @@ import {
   VoiceSessionPill,
   Specky,
 } from '@memex/guide-sdk';
+import { useEffect, useRef } from 'react';
+import { useTelemetry } from '../../hooks/useTelemetry';
 
 const ANCHOR = 'fixed bottom-6 right-6 z-50';
 
 export function VoiceLayer(): React.JSX.Element | null {
   const session = useVoiceSession();
   const { pathname } = useLocation();
+  const { track } = useTelemetry(true);
+  const status = session.status;
+
+  // Telemetry stays app-side (the SDK stays pure): observe the session state
+  // machine at the shell, where every transition is visible. Maps to the voice
+  // funnel — adoption (started), the mic-permission drop-off, and dwell.
+  const prevStatus = useRef<string | null>(null);
+  const startedAt = useRef<number | null>(null);
+  useEffect(() => {
+    const prev = prevStatus.current;
+    if (prev === status) return;
+    if (status === 'active' && prev !== 'active') {
+      startedAt.current = Date.now();
+      track('voice.session_started');
+      // A real prompt resolved to granted only when we came through the request.
+      if (prev === 'requesting_permission') {
+        track('voice.mic_permission_result', { result: 'granted' });
+      }
+    } else if (status === 'permission_denied' && prev !== 'permission_denied') {
+      track('voice.mic_permission_result', { result: 'denied' });
+    }
+    if (prev === 'active' && status !== 'active') {
+      const ms = startedAt.current != null ? Date.now() - startedAt.current : undefined;
+      track('voice.session_ended', ms != null ? { durationMs: ms } : undefined);
+      startedAt.current = null;
+    }
+    prevStatus.current = status;
+  }, [status, track]);
+
+  // The voice entry point (the Specky icon) is presented in the inactive/
+  // requesting/mic-unavailable branch on registered screens — the adoption
+  // denominator. Fire once per mount (not per render), surface = 'icon'.
+  const iconVisible =
+    status !== 'active' &&
+    status !== 'permission_denied' &&
+    status !== 'error' &&
+    resolveScreenKey(pathname) !== null;
+  const iconShownFired = useRef(false);
+  useEffect(() => {
+    if (iconVisible && !iconShownFired.current) {
+      iconShownFired.current = true;
+      track('voice.icon_shown', { surface: 'icon' });
+    }
+  }, [iconVisible, track]);
 
   if (session.status === 'active') {
     return (


### PR DESCRIPTION
## What

The next batch of **front-end engagement events** (spec-338) — the user-initiated UI interactions the server never sees — wired through the spec-244 rail per **std-35 Recipe A**. spec-244 called its event list "a floor, not a ceiling"; this grows it.

**13 new front-end events** (`track()`): `spec.card_opened` (specSeq/phase/assigned/assignedUserId), `board.phase_drag`, `board.tag_filter_applied`, `search.opened` (hotkey/button), `search.query_submitted`, `search.result_selected`, `spec.tab_viewed`, `comments.filter_changed`, `whatsnew.opened`, `workspace.switched`, `voice.icon_shown` (once/mount), `voice.mic_permission_result`, `auth.login_started`. Plus **wiring** the already-registered `voice.session_started` / `voice.session_ended`.

**One server change (dec-1):** `document.created` now carries a coarse `source` = the std-32 channel (`rest_ui`/`mcp`/`in_app_agent`/`server`), so *what triggered* a spec/doc creation is captured across **every** path — including agent/MCP creates a front-end event can't see. No new FE creation event (no double-count).

Props are **IDs/enums/counts only, no PII** — `assignedUserId`/`memexId` opaque, query *length* not text (`sanitizeUsageProps` enforces, client + server).

**Out of scope:** the Home/onboarding surface (already instrumented; owned by the spec-336 revamp).

## Tests
- Unit: registry-contract, `TagFilter`, `VoiceLayer` transition tests. Full UI suite **1488/0** + shared parity **693** green; UI typecheck clean.
- Server integration: `document.created` `source` (incl. an MCP-channel create) — **8/8** green.
- std-28: `journey-43-fe-engagement-telemetry.spec.ts` (⌘K funnel + board card + button trigger).

## Notes for review
- AC verification (spec-338 ac-1…ac-12) flips green on this PR's CI `server` emission run.
- Local cold-e2e can't surface `/telemetry` POSTs (the baseline `journey-42` fails there too) — an env limitation of the bare harness, not this change; CI e2e is authoritative.
- Catalog of all events lives in Memex **doc-10**; **spec-339** tracks auto-keeping it current.

🤖 Generated with [Claude Code](https://claude.com/claude-code)