### PR TITLE
spec-337: derive planGrounded milestone for the codebase-grounding step

### DIFF
--- a/packages/server/src/journeys/onboarding.ts
+++ b/packages/server/src/journeys/onboarding.ts
@@ -17,7 +17,10 @@ export type JourneyMilestone =
   | "hasSpec" // derived: the user created a (non-demo) spec
   | "hasResolvedDecision" // derived: the user resolved a decision
   | "hasAc" // derived: the user added an acceptance criterion
-  | "acVerified"; // derived: one of the user's ACs went GREEN from a real test event
+  | "acVerified" // derived: one of the user's ACs went GREEN from a real test event
+  | "planGrounded"; // derived (spec-337): the user broke the work into tasks AND has a
+//                  test behind one of their ACs — the codebase-grounding signal that
+//                  completes the 'Specs that match reality' step (builder-only, spec-336)
 
 export interface JourneyStepDef {
   id: string;

--- a/packages/server/src/routes/journey.api.test.ts
+++ b/packages/server/src/routes/journey.api.test.ts
@@ -27,6 +27,7 @@ import {
   users,
   decisions,
   acs,
+  tasks,
   testEventLatest,
   documents,
   memexes,
@@ -110,6 +111,17 @@ async function seedAc(userId: string, docId: string) {
     actorUserId: userId,
   });
 }
+async function seedTask(userId: string, docId: string) {
+  await db.insert(tasks).values({
+    memexId,
+    docId,
+    seq: 1,
+    title: "Break out the work",
+    description: "A task the user authored.",
+    status: "not_started",
+    actorUserId: userId,
+  });
+}
 async function seedGreen(docId: string) {
   const [slugs] = await db
     .select({ ns: namespaces.slug, mx: memexes.slug, handle: documents.handle })
@@ -143,6 +155,7 @@ describe("Home Canvas journey-state (ac-3 derived position)", () => {
       hasResolvedDecision: false,
       hasAc: false,
       acVerified: false,
+      planGrounded: false,
     });
   });
 
@@ -245,5 +258,62 @@ describe("Home Canvas journey-state (ac-7 measurement)", () => {
       body: JSON.stringify({ action: "bogus", step: "welcome" }),
     });
     expect(res.status).toBe(400);
+  });
+});
+
+// spec-337 — planGrounded: the codebase-grounding milestone for the builder-only
+// 'Specs that match reality' step. Derived the same way as the others: user-scoped
+// counts over the acting user's own rows, demo-excluded. Ticks only when the user
+// has BOTH broken the work into tasks AND has a test behind one of their ACs.
+const AC337 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-337/acs/ac-${n}`;
+
+describe("journey-state planGrounded (spec-337)", () => {
+  it("is false until BOTH a task and an AC-with-a-test exist (ac-1, ac-4)", async () => {
+    tagAc(AC337(1));
+    tagAc(AC337(4));
+    const user = await newUser();
+    const doc = await seedSpec(user.id);
+    expect((await state(user.id)).body.milestones.planGrounded).toBe(false);
+
+    await seedTask(user.id, doc.id); // tasks only → still false
+    expect((await state(user.id)).body.milestones.planGrounded).toBe(false);
+
+    await seedAc(user.id, doc.id);
+    await seedGreen(doc.id); // a test event now exists on the user's AC (any status)
+    expect((await state(user.id)).body.milestones.planGrounded).toBe(true);
+  });
+
+  it("an AC-with-a-test but no tasks does not set it (ac-4)", async () => {
+    tagAc(AC337(4));
+    const user = await newUser();
+    const doc = await seedSpec(user.id);
+    await seedAc(user.id, doc.id);
+    await seedGreen(doc.id);
+    expect((await state(user.id)).body.milestones.planGrounded).toBe(false);
+  });
+
+  it("is user-scoped: a colleague's task + AC-test does not set mine (ac-1, ac-3)", async () => {
+    tagAc(AC337(1));
+    tagAc(AC337(3));
+    const me = await newUser();
+    const colleague = await newUser();
+    const doc = await seedSpec(colleague.id);
+    await seedTask(colleague.id, doc.id);
+    await seedAc(colleague.id, doc.id);
+    await seedGreen(doc.id);
+    expect((await state(me.id)).body.milestones.planGrounded).toBe(false);
+    expect((await state(colleague.id)).body.milestones.planGrounded).toBe(true);
+  });
+
+  it("excludes demo content: a task + AC-test on a demo spec do not count (ac-3, ac-5)", async () => {
+    tagAc(AC337(3));
+    tagAc(AC337(5));
+    const user = await newUser();
+    const doc = await seedSpec(user.id);
+    await db.update(documents).set({ isDemo: true }).where(eq(documents.id, doc.id));
+    await seedTask(user.id, doc.id);
+    await seedAc(user.id, doc.id);
+    await seedGreen(doc.id);
+    expect((await state(user.id)).body.milestones.planGrounded).toBe(false);
   });
 });

--- a/packages/server/src/services/journey-state.spec-337.test.ts
+++ b/packages/server/src/services/journey-state.spec-337.test.ts
@@ -1,0 +1,54 @@
+// spec-337 — the "Go build" step is a TERMINAL handoff (completedBy: null), not a
+// gated step, and spec-337 adds exactly ONE new milestone (planGrounded), no
+// "building" count (dec-2). Verified two ways: the engine's terminal-attainment rule
+// (a completedBy:null node is attained only once every prior milestone is met), and a
+// source assertion that the milestone union gained planGrounded but no "building".
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { stepStatuses, type JourneyMilestones } from "./journey-state.js";
+import type { JourneyDef } from "../journeys/onboarding.js";
+
+const AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-337/acs/ac-${n}`;
+const here = dirname(fileURLToPath(import.meta.url));
+
+const ALL_FALSE: JourneyMilestones = {
+  identityConfirmed: false,
+  mcpConnected: false,
+  mcpToolCalled: false,
+  hasSpec: false,
+  hasResolvedDecision: false,
+  hasAc: false,
+  acVerified: false,
+  planGrounded: false,
+};
+
+describe("spec-337 — terminal 'Go build' + no 'building' milestone", () => {
+  it("a terminal (completedBy:null) step is attained only once every prior milestone is met (ac-2, ac-6)", () => {
+    tagAc(AC(2));
+    tagAc(AC(6));
+    const journey: JourneyDef = {
+      id: "t",
+      steps: [
+        { id: "specs-match-reality", completedBy: "planGrounded" },
+        { id: "go-build", completedBy: null },
+      ],
+    };
+    // prior milestone unmet → the terminal node is NOT attained
+    const notYet = stepStatuses(ALL_FALSE, journey);
+    expect(notYet.find((s) => s.id === "go-build")!.attained).toBe(false);
+    // prior milestone met → the terminal node IS attained (so builders reach 100%)
+    const done = stepStatuses({ ...ALL_FALSE, planGrounded: true }, journey);
+    expect(done.find((s) => s.id === "go-build")!.attained).toBe(true);
+  });
+
+  it("the milestone union gained planGrounded and no 'building' milestone (ac-6)", () => {
+    tagAc(AC(6));
+    const src = readFileSync(join(here, "..", "journeys", "onboarding.ts"), "utf8");
+    expect(src).toMatch(/"planGrounded"/);
+    expect(src).not.toMatch(/"building"/);
+  });
+});

--- a/packages/server/src/services/journey-state.ts
+++ b/packages/server/src/services/journey-state.ts
@@ -21,6 +21,7 @@ import {
   usageEvents,
   users,
   acs,
+  tasks,
   memexes,
   namespaces,
   testEventLatest,
@@ -153,6 +154,33 @@ async function collectUserMilestones(
     )
     .where(and(eq(acs.actorUserId, userId), eq(testEventLatest.latestStatus, "pass")));
 
+  // planGrounded (spec-337 dec-1): the codebase-grounding signal — the user has both
+  // broken the work into TASKS and has a TEST behind at least one of their ACs. Two
+  // user-scoped, demo-excluded counts, ANDed. Mirrors the existing milestones (counts
+  // over the acting user's own rows; demo content excluded, spec-178).
+  //   (1) a task the user authored on a non-demo spec
+  const [taskRow] = await conn
+    .select({ n: sql<number>`count(*)::int` })
+    .from(tasks)
+    .innerJoin(documents, eq(tasks.docId, documents.id))
+    .where(and(eq(tasks.actorUserId, userId), eq(documents.isDemo, false)));
+  //   (2) a test event exists for one of the user's ACs — ANY latest status (a test
+  //       was WRITTEN, not necessarily green). Same ac_uid join acVerified uses.
+  const [acTestRow] = await conn
+    .select({ n: sql<number>`count(*)::int` })
+    .from(acs)
+    .innerJoin(documents, eq(acs.briefId, documents.id))
+    .innerJoin(memexes, eq(documents.memexId, memexes.id))
+    .innerJoin(namespaces, eq(memexes.namespaceId, namespaces.id))
+    .innerJoin(
+      testEventLatest,
+      eq(
+        testEventLatest.acUid,
+        sql`${namespaces.slug} || '/' || ${memexes.slug} || '/specs/' || ${documents.handle} || '/acs/ac-' || ${acs.seq}`,
+      ),
+    )
+    .where(and(eq(acs.actorUserId, userId), eq(documents.isDemo, false)));
+
   return {
     identityConfirmed: userRow?.roleCoords != null,
     mcpConnected: (connectedRow?.n ?? 0) > 0,
@@ -161,6 +189,7 @@ async function collectUserMilestones(
     hasResolvedDecision: (resolvedDecisionRow?.n ?? 0) > 0,
     hasAc: (acRow?.n ?? 0) > 0,
     acVerified: (verifiedRow?.n ?? 0) > 0,
+    planGrounded: (taskRow?.n ?? 0) > 0 && (acTestRow?.n ?? 0) > 0,
   };
 }
 

--- a/packages/ui/src/api/journey.spec-337.test.ts
+++ b/packages/ui/src/api/journey.spec-337.test.ts
@@ -1,0 +1,29 @@
+// spec-337 — the UI journey-state client's JourneyMilestones shape exposes
+// planGrounded, so the rail orbs + the progress % can read the codebase-grounding
+// signal for the 'Specs that match reality' step. The typed literal below only
+// compiles if the interface carries planGrounded (and exactly the milestone keys).
+import { describe, it, expect } from 'vitest';
+import { tagAc } from '@memex-ai-ac/vitest';
+import type { JourneyMilestones } from './journey';
+
+const AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-337/acs/ac-${n}`;
+
+describe('spec-337 — UI JourneyMilestones exposes planGrounded', () => {
+  it('planGrounded is part of the UI milestones shape (ac-5, ac-3)', () => {
+    tagAc(AC(5));
+    tagAc(AC(3));
+    const m: JourneyMilestones = {
+      identityConfirmed: false,
+      mcpConnected: false,
+      mcpToolCalled: false,
+      hasSpec: false,
+      hasResolvedDecision: false,
+      hasAc: false,
+      acVerified: false,
+      planGrounded: false,
+    };
+    expect('planGrounded' in m).toBe(true);
+    expect(typeof m.planGrounded).toBe('boolean');
+  });
+});

--- a/packages/ui/src/api/journey.ts
+++ b/packages/ui/src/api/journey.ts
@@ -13,6 +13,9 @@ export interface JourneyMilestones {
   hasResolvedDecision: boolean;
   hasAc: boolean;
   acVerified: boolean;
+  // Derived (spec-337): tasks broken out AND a test behind one of the user's ACs —
+  // the signal that ticks the 'Specs that match reality' step (builder-only, spec-336).
+  planGrounded: boolean;
 }
 
 export interface JourneyStepStatus {


### PR DESCRIPTION
## What

Adds the `planGrounded` journey milestone (spec-337) — the completion signal for the builder-only **"Specs that match reality"** step in the Home onboarding (spec-336).

`planGrounded` = the user has **broken the work into tasks** AND **has a test behind one of their acceptance criteria**. Two user-scoped, demo-excluded counts ANDed, computed exactly like the existing milestones (inside `runWithUserId`, owner-visibility RLS, same `ac_uid` join `acVerified` uses). Exposed on the UI `JourneyMilestones` interface. "Go build" stays a **terminal** step (no `building` milestone). **No new tables, no migration.**

## Files
- `packages/server/src/journeys/onboarding.ts` — `planGrounded` enum member
- `packages/server/src/services/journey-state.ts` — derivation query
- `packages/ui/src/api/journey.ts` — UI interface field
- tests: `journey.api.test.ts` (+4 integration cases + `seedTask`), `journey-state.spec-337.test.ts`, `journey.spec-337.test.ts`

## Verification
- All 6 spec-337 ACs verified (ac-1..6).
- Full server suite green, full UI suite green, server + UI typechecks clean.
- No new e2e journey (std-28): this ships no user-facing flow on its own; the journey coverage lives in spec-336.

Spec: https://memex.ai/mindset-prod/memex-building-itself/specs/spec-337

🤖 Generated with [Claude Code](https://claude.com/claude-code)
