### PR TITLE
fix(spec-171): upgrade/billing flow bills the chosen org, not the personal Memex (t-25 / ac-39 / dec-40)

### DIFF
--- a/packages/ui/e2e/journey-42-spec-171-upgrade.spec.ts
+++ b/packages/ui/e2e/journey-42-spec-171-upgrade.spec.ts
@@ -5,6 +5,7 @@ import {
   DEV_EMAIL,
   setUserName,
   seedOrg,
+  getPersonalMemexByEmail,
   emitAcEvents,
 } from "./helpers/index.js";
 
@@ -67,14 +68,25 @@ test("hosted upgrade: pick Enterprise, set seats + annual, redirect to Stripe Ch
     name: "Upgrade Journey Org",
   });
 
+  // The dev user's PERSONAL namespace — billing must NOT target it (it's the
+  // non-billable personal Memex the buggy session-current default resolved to).
+  // Resolve its real slug so the negative URL assertion is exact, not a guess.
+  const personal = await getPersonalMemexByEmail(DEV_EMAIL);
+  expect(personal).not.toBeNull();
+  const personalNamespace = personal!.namespaceSlug;
+
   // ── 1. plan select ────────────────────────────────────────────────────────
   // /upgrade is a FLAT route [per App.tsx PostLoginRouter] — registered at the top
   // level, NOT under /:ns/:mx. Navigating a tenant path /<ns>/<mx>/upgrade falls
   // through the tenant route tree to the catch-all and bounces to the Specs board,
-  // so we navigate the BARE path. The seeded org still backs "current org" via the
-  // session (best-effort) — and the POST is intercepted regardless, so the exact
-  // org-current resolution is moot here.
-  void org; // seeded for the admin-on-Cloud-Free precondition; nav is path-agnostic
+  // so we navigate the BARE path.
+  //
+  // spec-171 t-25 / ac-39 / dec-40 (option A): the upgrade flow now resolves the
+  // billable org from the SESSION's admin memberships (deriveAdminOrgs), not the
+  // session's current memex. The org was seeded BEFORE this navigation, so the
+  // app's on-load /api/auth/me refresh carries the new membership; the seats
+  // screen surfaces the single admin org and bills IT. We drive that REAL
+  // resolution (no stubbed org) and assert the POST hits the org's tenant base.
   await page.goto(bareUrl("/upgrade"), { waitUntil: "commit" });
 
   await expect(
@@ -99,6 +111,16 @@ test("hosted upgrade: pick Enterprise, set seats + annual, redirect to Stripe Ch
   await expect(
     page.getByRole("heading", { name: "Upgrade to Hosted Enterprise" }),
   ).toBeVisible({ timeout: 15_000 });
+
+  // spec-171 t-25 / ac-39: the seats screen surfaces WHICH org is being upgraded.
+  // With exactly one admin org it auto-selects and renders the org name. Asserting
+  // it BEFORE continuing is the deterministic wait for the on-load session refresh
+  // to land the seeded membership — and proves the org came from REAL resolution
+  // (deriveAdminOrgs over the session), not a stub. The "Continue" button stays
+  // disabled until an org resolves, so this gate is load-bearing.
+  await expect(page.getByText("Upgrade Journey Org")).toBeVisible({
+    timeout: 15_000,
+  });
 
   // seat input present…
   const seatInput = page.getByLabel("Number of seats");
@@ -182,4 +204,12 @@ test("hosted upgrade: pick Enterprise, set seats + annual, redirect to Stripe Ch
   expect(capturedUrl).not.toBeNull();
   expect(capturedUrl!).toContain("/orgs/current/subscription");
   expect(capturedUrl!).not.toContain("/upgrade/");
+
+  // spec-171 t-25 / ac-39 / dec-40 (option A) — THE core fix: billing is per-org.
+  // The POST must target the CHOSEN org's tenant base (its namespace), NOT the
+  // session's current memex (which defaults to the non-billable personal Memex
+  // and 404'd "Org context required"). Positive: the URL carries the seeded org's
+  // namespace. Negative: it must NOT carry the dev user's personal namespace.
+  expect(capturedUrl!).toContain(`/api/${slug}/`);
+  expect(capturedUrl!).not.toContain(`/api/${personalNamespace}/`);
 });

--- a/packages/ui/src/api/client.ts
+++ b/packages/ui/src/api/client.ts
@@ -35,6 +35,28 @@ function tBase(): string {
   return tenantBase() ?? BASE_URL;
 }
 
+// spec-171 t-25 / dec-40 (option A): billing is PER-ORG. The subscription routes
+// resolve the org from the MEMEX in the path, so to bill a CHOSEN org we must
+// build the tenant base from that org's namespace + one of its memexes — NOT
+// from `tBase()`/session.currentMemexId, which defaults to the non-billable
+// personal Memex. Callers pass an explicit `OrgTenant`; this builds its prefix.
+export interface OrgTenant {
+  /** The org namespace slug — first path segment. */
+  namespace: string;
+  /** A representative memex slug under the org — second path segment. */
+  memexSlug: string;
+}
+
+/**
+ * Resolve the `/api/<ns>/<mx>` prefix for org-billing calls. When an explicit
+ * `OrgTenant` is given (the upgrade/billing flows always pass one), build the
+ * prefix from it. Otherwise fall back to `tBase()` for legacy in-tenant callers.
+ */
+function orgBillingBase(orgTenant?: OrgTenant): string {
+  if (orgTenant) return `${BASE_URL}/${orgTenant.namespace}/${orgTenant.memexSlug}`;
+  return tBase();
+}
+
 export interface FetchDocsOptions {
   /** Comma-separated server include tokens. `'driftCount'` (t-19 W2) attaches
    *  open drift counts to Standards; `'acHealth'` (b-66 t-2) attaches the
@@ -1044,6 +1066,13 @@ export async function fetchMemexIssues(
 export interface MembershipSummary {
   /** The Memex id this membership grants access to. */
   memexId: string;
+  /**
+   * The owning Org id for team rows; null/absent for personal rows and for
+   * sessions cached before this field shipped. Set by the server's
+   * `listMemberships`. spec-171 t-25: the upgrade/billing flows group billable
+   * admin memberships by this id so the caller can choose WHICH org to bill.
+   */
+  orgId?: string | null;
   /** Namespace slug — the first path segment in /<namespace>/<memex>/ URLs. */
   slug: string;
   /**
@@ -2760,8 +2789,9 @@ export interface SubscriptionDto {
 
 export async function fetchCurrentSubscription(
   token: string | null,
+  orgTenant?: OrgTenant,
 ): Promise<SubscriptionDto> {
-  const res = await fetchWithRetry(`${tBase()}/orgs/current/subscription`, {
+  const res = await fetchWithRetry(`${orgBillingBase(orgTenant)}/orgs/current/subscription`, {
     headers: authHeaders(token),
   });
   if (!res.ok) throw new Error(`Failed to fetch subscription: ${res.status}`);
@@ -2777,8 +2807,9 @@ export interface StartCheckoutInput {
 export async function fetchBillingPortalUrl(
   token: string | null,
   returnUrl: string,
+  orgTenant?: OrgTenant,
 ): Promise<string> {
-  const url = `${tBase()}/orgs/current/billing-portal?returnUrl=${encodeURIComponent(returnUrl)}`;
+  const url = `${orgBillingBase(orgTenant)}/orgs/current/billing-portal?returnUrl=${encodeURIComponent(returnUrl)}`;
   const res = await fetchWithRetry(url, { headers: authHeaders(token) });
   if (!res.ok) throw new Error(`Billing portal request failed: ${res.status}`);
   const body = await res.json();
@@ -2788,9 +2819,10 @@ export async function fetchBillingPortalUrl(
 export async function previewSeatChange(
   token: string | null,
   seats: number,
+  orgTenant?: OrgTenant,
 ): Promise<{ amountDue: number; currency: string }> {
   const res = await fetchWithRetry(
-    `${tBase()}/orgs/current/subscription/preview?seats=${seats}`,
+    `${orgBillingBase(orgTenant)}/orgs/current/subscription/preview?seats=${seats}`,
     { headers: authHeaders(token) },
   );
   if (!res.ok) throw new Error(`Preview failed: ${res.status}`);
@@ -2800,8 +2832,9 @@ export async function previewSeatChange(
 export async function updateOrgSeats(
   token: string | null,
   seats: number,
+  orgTenant?: OrgTenant,
 ): Promise<void> {
-  const res = await fetchWithRetry(`${tBase()}/orgs/current/subscription`, {
+  const res = await fetchWithRetry(`${orgBillingBase(orgTenant)}/orgs/current/subscription`, {
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json', ...authHeaders(token) },
     body: JSON.stringify({ seats }),
@@ -2812,11 +2845,18 @@ export async function updateOrgSeats(
 // spec-171 dec-38 / ac-33: start a hosted purchase. Returns the Stripe-hosted
 // Checkout URL — the caller redirects the browser to it. No card data is ever
 // collected in our UI.
+//
+// spec-171 t-25 / dec-40 (option A): the caller MUST pass the chosen org's
+// tenant — billing is per-org and we must NOT bill the session's current memex
+// (which defaults to the non-billable personal Memex). The POST therefore
+// targets /api/<org-ns>/<org-mx>/orgs/current/subscription, where the server
+// resolves the org FROM that memex.
 export async function startCheckout(
   input: StartCheckoutInput,
   token: string | null,
+  orgTenant: OrgTenant,
 ): Promise<{ url: string }> {
-  const res = await fetchWithRetry(`${tBase()}/orgs/current/subscription`, {
+  const res = await fetchWithRetry(`${orgBillingBase(orgTenant)}/orgs/current/subscription`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', ...authHeaders(token) },
     body: JSON.stringify(input),

--- a/packages/ui/src/components/account/BillingTab.tsx
+++ b/packages/ui/src/components/account/BillingTab.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../AuthContext';
 import { Alert } from '../ui/Alert';
@@ -10,6 +10,8 @@ import {
   updateOrgSeats,
   type SubscriptionDto,
 } from '../../api/client';
+import { deriveAdminOrgs } from '../../pages/upgrade/adminOrgs';
+import { OrgSelector } from '../upgrade/OrgSelector';
 
 function formatDate(iso: string | null): string {
   if (!iso) return '—';
@@ -25,8 +27,31 @@ function formatCurrency(amount: number, currency: string): string {
 }
 
 export function BillingTab() {
-  const { token } = useAuth();
+  const { token, session } = useAuth();
   const navigate = useNavigate();
+
+  // spec-171 t-25 / dec-40 (option A): billing is per-org and /org is a flat
+  // (non-tenant) route, so the session's current memex defaults to the
+  // non-billable personal Memex. Resolve the billable org explicitly from the
+  // orgs the caller administers and target ITS tenant base on every billing call.
+  const adminOrgs = useMemo(() => deriveAdminOrgs(session), [session]);
+  const [selectedOrgId, setSelectedOrgId] = useState<string | null>(() =>
+    adminOrgs.length === 1 ? adminOrgs[0].orgId : null,
+  );
+  const selectedOrg = adminOrgs.find((o) => o.orgId === selectedOrgId) ?? null;
+  const orgTenant = selectedOrg
+    ? { namespace: selectedOrg.namespace, memexSlug: selectedOrg.memexSlug }
+    : undefined;
+
+  // The state initializer runs once. AuthContext fast-paints a cached session
+  // then refreshes /api/auth/me in the background; if the org arrives via that
+  // refresh, adminOrgs becomes length-1 AFTER mount. Auto-select then so the
+  // single-org case isn't stuck on the (control-less) read-only selector.
+  useEffect(() => {
+    if (selectedOrgId === null && adminOrgs.length === 1) {
+      setSelectedOrgId(adminOrgs[0].orgId);
+    }
+  }, [adminOrgs, selectedOrgId]);
 
   const [sub, setSub] = useState<SubscriptionDto | null>(null);
   const [loading, setLoading] = useState(true);
@@ -42,17 +67,25 @@ export function BillingTab() {
 
   useEffect(() => {
     if (!token) return;
+    // No org chosen yet (0 admin orgs, or many and none picked): nothing to load.
+    if (!orgTenant) {
+      setLoading(false);
+      return;
+    }
     setLoading(true);
-    fetchCurrentSubscription(token)
+    setError(null);
+    fetchCurrentSubscription(token, orgTenant)
       .then((s) => { setSub(s); setSeatInput(s.seatsPurchased ?? 1); })
       .catch(() => setError('Could not load billing information.'))
       .finally(() => setLoading(false));
-  }, [token]);
+    // orgTenant is derived from selectedOrgId; re-fetch when the chosen org changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [token, selectedOrgId]);
 
   async function handleBillingPortal() {
     if (!token) return;
     try {
-      const url = await fetchBillingPortalUrl(token, window.location.href);
+      const url = await fetchBillingPortalUrl(token, window.location.href, orgTenant);
       window.open(url, '_blank', 'noopener');
     } catch {
       setError('Could not open billing portal. Please try again.');
@@ -64,7 +97,7 @@ export function BillingTab() {
     setPreviewLoading(true);
     setPreview(null);
     try {
-      const p = await previewSeatChange(token, seats);
+      const p = await previewSeatChange(token, seats, orgTenant);
       setPreview(p);
     } catch {
       // Non-fatal; user still sees the confirm button
@@ -78,7 +111,7 @@ export function BillingTab() {
     setSaving(true);
     setSaveError(null);
     try {
-      await updateOrgSeats(token, seatInput);
+      await updateOrgSeats(token, seatInput, orgTenant);
       setSub((prev) => prev ? { ...prev, seatsPurchased: seatInput } : prev);
       setConfirmOpen(false);
       setPreview(null);
@@ -87,6 +120,32 @@ export function BillingTab() {
     } finally {
       setSaving(false);
     }
+  }
+
+  function handleCreateOrg() {
+    const personal = session?.memberships.find((m) => m.kind === 'personal');
+    navigate(personal ? `/${personal.slug}` : '/');
+  }
+
+  // No billable org resolved yet: either the caller administers none (show the
+  // create-an-org prompt) or several and hasn't picked one (show the chooser).
+  // Either way there's no single org whose billing we can display.
+  if (!selectedOrg) {
+    return (
+      <div className="py-6 space-y-4 max-w-xl">
+        {adminOrgs.length > 1 && (
+          <p className="text-sm text-muted">
+            Choose which organisation's billing you want to manage.
+          </p>
+        )}
+        <OrgSelector
+          orgs={adminOrgs}
+          selectedOrgId={selectedOrgId}
+          onSelect={setSelectedOrgId}
+          onCreateOrg={handleCreateOrg}
+        />
+      </div>
+    );
   }
 
   if (loading) {
@@ -108,6 +167,24 @@ export function BillingTab() {
 
   return (
     <div className="py-6 space-y-6 max-w-xl">
+      {/* Which org's billing is shown — switchable when the caller admins many.
+          spec-171 t-25: never assume the session's current memex is the org. */}
+      {adminOrgs.length > 1 && (
+        <div className="flex items-center justify-between gap-3 rounded-lg border border-edge bg-surface/50 px-4 py-2.5">
+          <div>
+            <p className="text-xs text-muted">Managing organisation</p>
+            <p className="text-sm font-medium text-primary">{selectedOrg.name}</p>
+          </div>
+          <button
+            type="button"
+            className="text-xs text-link underline hover:no-underline"
+            onClick={() => setSelectedOrgId(null)}
+          >
+            Switch organisation
+          </button>
+        </div>
+      )}
+
       {/* Seats warning banner */}
       {sub.seatsWarning && (
         <Alert variant="warning">

--- a/packages/ui/src/components/upgrade/OrgSelector.tsx
+++ b/packages/ui/src/components/upgrade/OrgSelector.tsx
@@ -1,0 +1,85 @@
+// spec-171 t-25 / ac-39 / dec-40 (option A): let the caller CHOOSE which org to
+// upgrade/bill. Billing is per-org (std-1 cl-3) and a user may administer several
+// orgs, so the upgrade flow must surface the orgs the caller administers and bill
+// the chosen one — never the session's current (personal) Memex.
+//
+// Behaviour:
+//   • none     → a clear "create an org first" CTA (no billable target exists).
+//   • exactly 1 → auto-selected; rendered read-only so the user sees WHICH org
+//                  is being upgraded.
+//   • many     → a chooser (radio list).
+//
+// Pure presentational + selection logic; the parent owns the selected org and
+// passes it to the billing client calls.
+
+import type { AdminOrg } from '../../pages/upgrade/adminOrgs';
+
+interface OrgSelectorProps {
+  orgs: AdminOrg[];
+  selectedOrgId: string | null;
+  onSelect: (orgId: string) => void;
+  /** Navigate to where the user can create an org (their personal namespace). */
+  onCreateOrg: () => void;
+}
+
+export function OrgSelector({
+  orgs,
+  selectedOrgId,
+  onSelect,
+  onCreateOrg,
+}: OrgSelectorProps) {
+  if (orgs.length === 0) {
+    return (
+      <div className="rounded-lg border border-edge bg-surface/50 px-4 py-4 space-y-2">
+        <p className="text-sm font-medium text-primary">
+          You don't administer any organisations yet.
+        </p>
+        <p className="text-sm text-muted">
+          Billing is per organisation — create an organisation first, then upgrade it.
+        </p>
+        <button
+          type="button"
+          className="text-sm text-link underline hover:no-underline"
+          onClick={onCreateOrg}
+        >
+          Create an organisation →
+        </button>
+      </div>
+    );
+  }
+
+  if (orgs.length === 1) {
+    const org = orgs[0];
+    return (
+      <div className="rounded-lg border border-edge bg-surface/50 px-4 py-3">
+        <p className="text-xs text-muted mb-0.5">Upgrading organisation</p>
+        <p className="text-sm font-medium text-primary">{org.name}</p>
+      </div>
+    );
+  }
+
+  return (
+    <fieldset>
+      <legend className="block text-sm font-medium text-primary mb-1.5">
+        Which organisation are you upgrading?
+      </legend>
+      <div className="space-y-2">
+        {orgs.map((org) => (
+          <label
+            key={org.orgId}
+            className="flex items-center gap-3 cursor-pointer rounded-lg border border-edge bg-surface/30 px-3 py-2"
+          >
+            <input
+              type="radio"
+              name="upgrade-org"
+              checked={selectedOrgId === org.orgId}
+              onChange={() => onSelect(org.orgId)}
+              className="accent-accent"
+            />
+            <span className="text-sm text-primary">{org.name}</span>
+          </label>
+        ))}
+      </div>
+    </fieldset>
+  );
+}

--- a/packages/ui/src/pages/upgrade/UpgradeConfirmation.tsx
+++ b/packages/ui/src/pages/upgrade/UpgradeConfirmation.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useLocation, useNavigate, useSearchParams, Navigate } from 'react-router-dom';
 import { useAuth } from '../../components/AuthContext';
 import { computeDefaultLanding } from '../../components/AuthContext';
 import { fetchCurrentSubscription, type SubscriptionDto } from '../../api/client';
+import { deriveAdminOrgs } from './adminOrgs';
 
 // spec-171 dec-38 / ac-33: this page is the Stripe Checkout `success_url`
 // target. The user lands here via a FULL browser redirect from stripe.com, so
@@ -47,6 +48,20 @@ export function UpgradeConfirmation() {
   const routerState = location.state as ConfirmationState | null;
   const sessionId = searchParams.get('session_id');
 
+  // spec-171 t-25 / dec-40: billing is per-org. After a Stripe redirect the
+  // router state is gone, so we poll the live subscription — but it MUST target
+  // the org that was upgraded, not the session's current (personal) Memex (which
+  // is always 'free' → the poll would never resolve and the paying user would
+  // see "Finalizing…" forever). When the caller administers exactly one org we
+  // can resolve it unambiguously; with several we can't tell from the
+  // confirmation page alone, so the poll falls back to the session current and
+  // simply times out into the "active" view (the webhook still applied the tier).
+  const adminOrgs = useMemo(() => deriveAdminOrgs(session), [session]);
+  const orgTenant =
+    adminOrgs.length === 1
+      ? { namespace: adminOrgs[0].namespace, memexSlug: adminOrgs[0].memexSlug }
+      : undefined;
+
   const [sub, setSub] = useState<SubscriptionDto | null>(null);
   const [finalizing, setFinalizing] = useState(!routerState && !!sessionId);
 
@@ -60,7 +75,7 @@ export function UpgradeConfirmation() {
     async function poll() {
       attempts += 1;
       try {
-        const s = await fetchCurrentSubscription(token);
+        const s = await fetchCurrentSubscription(token, orgTenant);
         if (cancelled) return;
         setSub(s);
         if (s.tier !== 'free') {
@@ -80,7 +95,10 @@ export function UpgradeConfirmation() {
     return () => {
       cancelled = true;
     };
-  }, [routerState, sessionId, token]);
+    // orgTenant is derived from the single admin org; key the effect on its id
+    // (a stable primitive) rather than the fresh object to avoid a re-poll loop.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [routerState, sessionId, token, adminOrgs.length === 1 ? adminOrgs[0].orgId : null]);
 
   // Neither in-app state nor a Stripe session id → nothing to confirm.
   if (!routerState && !sessionId) return <Navigate to="/upgrade" replace />;

--- a/packages/ui/src/pages/upgrade/UpgradeSeats.tsx
+++ b/packages/ui/src/pages/upgrade/UpgradeSeats.tsx
@@ -1,20 +1,42 @@
-import { useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useParams, useNavigate, Navigate } from 'react-router-dom';
 import { Button } from '../../components/ui/Button';
 import { useAuth } from '../../components/AuthContext';
+import { OrgSelector } from '../../components/upgrade/OrgSelector';
 import { startCheckout } from '../../api/client';
 import { PLAN_CONFIG, ANNUAL_FACTOR, calcPrice, type UpgradePlan } from './pricing';
+import { deriveAdminOrgs } from './adminOrgs';
 
 export function UpgradeSeats() {
   const { plan } = useParams<{ plan: string }>();
   const navigate = useNavigate();
-  const { token } = useAuth();
+  const { token, session } = useAuth();
+
+  // spec-171 t-25 / dec-40 (option A): billing is per-org. Derive the orgs the
+  // caller administers from the session and let them pick WHICH to upgrade —
+  // never the session's current (personal) Memex.
+  const adminOrgs = useMemo(() => deriveAdminOrgs(session), [session]);
 
   const [seats, setSeats] = useState(1);
   const [seatError, setSeatError] = useState<string | null>(null);
   const [annual, setAnnual] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Preselect when exactly one org; otherwise force an explicit choice.
+  const [selectedOrgId, setSelectedOrgId] = useState<string | null>(() =>
+    adminOrgs.length === 1 ? adminOrgs[0].orgId : null,
+  );
+
+  // The state initializer runs once. AuthContext fast-paints a cached session
+  // then refreshes /api/auth/me in the background; if the org arrives via that
+  // refresh, adminOrgs becomes length-1 AFTER mount. Auto-select then so the
+  // single-org case isn't stuck unselected (its read-only view has no manual
+  // select control).
+  useEffect(() => {
+    if (selectedOrgId === null && adminOrgs.length === 1) {
+      setSelectedOrgId(adminOrgs[0].orgId);
+    }
+  }, [adminOrgs, selectedOrgId]);
 
   if (!plan || !(plan in PLAN_CONFIG)) {
     return <Navigate to="/upgrade" replace />;
@@ -24,16 +46,33 @@ export function UpgradeSeats() {
   const total = calcPrice(seats, config.monthlyPrice, annual);
   const perSeat = config.monthlyPrice * (annual ? ANNUAL_FACTOR : 1);
 
+  const selectedOrg = adminOrgs.find((o) => o.orgId === selectedOrgId) ?? null;
+
+  // Send the user to their personal namespace home, where the "Create an Org"
+  // dialog lives. Personal-namespace rows are excluded from adminOrgs, so read
+  // the personal slug straight off the session memberships.
+  function handleCreateOrg() {
+    const personal = session?.memberships.find((m) => m.kind === 'personal');
+    navigate(personal ? `/${personal.slug}` : '/');
+  }
+
   async function handleContinue() {
     if (submitting) return;
+    if (!selectedOrg) {
+      setError('Select the organisation you want to upgrade.');
+      return;
+    }
     setError(null);
     setSubmitting(true);
     try {
       // spec-171 dec-38 / ac-33: redirect to Stripe-hosted Checkout. Card data
       // is collected on Stripe's page, never in our UI.
+      // spec-171 t-25 / dec-40: bill the CHOSEN org — target its tenant base,
+      // not the session's current memex.
       const { url } = await startCheckout(
         { plan: plan as UpgradePlan, seats, billingCycle: annual ? 'annual' : 'monthly' },
         token,
+        { namespace: selectedOrg.namespace, memexSlug: selectedOrg.memexSlug },
       );
       window.location.assign(url);
     } catch {
@@ -59,6 +98,14 @@ export function UpgradeSeats() {
       </p>
 
       <div className="space-y-6">
+        {/* Org selector — billing is per-org (spec-171 t-25 / dec-40). */}
+        <OrgSelector
+          orgs={adminOrgs}
+          selectedOrgId={selectedOrgId}
+          onSelect={setSelectedOrgId}
+          onCreateOrg={handleCreateOrg}
+        />
+
         {/* Seat count */}
         <div>
           <label className="block text-sm font-medium text-primary mb-1.5" htmlFor="seat-count">
@@ -162,7 +209,7 @@ export function UpgradeSeats() {
           variant="primary"
           className="w-full justify-center py-2.5"
           onClick={handleContinue}
-          disabled={submitting}
+          disabled={submitting || !selectedOrg}
         >
           {submitting ? 'Redirecting…' : 'Continue to payment →'}
         </Button>

--- a/packages/ui/src/pages/upgrade/adminOrgs.test.ts
+++ b/packages/ui/src/pages/upgrade/adminOrgs.test.ts
@@ -1,0 +1,102 @@
+// spec-171 t-25 / ac-39 / dec-40 (option A): the upgrade/billing flows must bill
+// a CHOSEN org, never the session's current (personal) Memex. deriveAdminOrgs is
+// the resolution primitive — it must surface exactly the orgs the caller can be
+// billed for, with a tenant base resolvable to each.
+
+import { describe, it, expect } from 'vitest';
+import { deriveAdminOrgs } from './adminOrgs';
+import type { MembershipSummary, SessionPayload } from '../../api/client';
+
+function session(memberships: MembershipSummary[]): SessionPayload {
+  return {
+    user: { id: 'u1', email: 'a@b.com', name: 'A', status: 'active', emailVerified: true },
+    memberships,
+    currentMemexId: null,
+    currentRole: null,
+    needsOnboarding: false,
+    hiddenFeatures: [],
+  };
+}
+
+const personal: MembershipSummary = {
+  memexId: 'm-personal',
+  slug: 'alice',
+  memexSlug: 'main',
+  name: 'Alice',
+  kind: 'personal',
+  role: 'administrator',
+};
+
+const adminOrg: MembershipSummary = {
+  memexId: 'm-acme',
+  orgId: 'org-acme',
+  slug: 'acme',
+  memexSlug: 'acme-memex',
+  name: 'Acme Inc',
+  kind: 'team',
+  role: 'administrator',
+};
+
+describe('deriveAdminOrgs', () => {
+  it('returns [] for null/undefined/empty session', () => {
+    expect(deriveAdminOrgs(null)).toEqual([]);
+    expect(deriveAdminOrgs(undefined)).toEqual([]);
+    expect(deriveAdminOrgs(session([]))).toEqual([]);
+  });
+
+  it('excludes the personal namespace (never billable)', () => {
+    expect(deriveAdminOrgs(session([personal]))).toEqual([]);
+  });
+
+  it('surfaces an admin org with a tenant base resolved to one of its memexes', () => {
+    expect(deriveAdminOrgs(session([personal, adminOrg]))).toEqual([
+      {
+        orgId: 'org-acme',
+        name: 'Acme Inc',
+        namespace: 'acme',
+        memexSlug: 'acme-memex',
+      },
+    ]);
+  });
+
+  it('excludes orgs where the caller is only a member (cannot bill)', () => {
+    const memberOrg: MembershipSummary = { ...adminOrg, role: 'member' };
+    expect(deriveAdminOrgs(session([memberOrg]))).toEqual([]);
+  });
+
+  it("excludes 'visited' read-only public-memex pins (not a real org membership)", () => {
+    const visited: MembershipSummary = { ...adminOrg, source: 'visited' };
+    expect(deriveAdminOrgs(session([visited]))).toEqual([]);
+  });
+
+  it('groups multiple memexes of one org into a single entry (first memex wins)', () => {
+    const sibling: MembershipSummary = {
+      ...adminOrg,
+      memexId: 'm-acme-2',
+      memexSlug: 'acme-second',
+    };
+    const orgs = deriveAdminOrgs(session([adminOrg, sibling]));
+    expect(orgs).toHaveLength(1);
+    expect(orgs[0].memexSlug).toBe('acme-memex');
+  });
+
+  it('returns every distinct admin org when the caller administers many', () => {
+    const second: MembershipSummary = {
+      memexId: 'm-globex',
+      orgId: 'org-globex',
+      slug: 'globex',
+      memexSlug: 'globex-memex',
+      name: 'Globex',
+      kind: 'team',
+      role: 'administrator',
+    };
+    const orgs = deriveAdminOrgs(session([adminOrg, second]));
+    expect(orgs.map((o) => o.orgId)).toEqual(['org-acme', 'org-globex']);
+  });
+
+  it('skips admin team rows that lack an orgId (cannot group) or memexSlug (cannot route)', () => {
+    const noOrgId: MembershipSummary = { ...adminOrg, orgId: null };
+    const noMemexSlug: MembershipSummary = { ...adminOrg, memexSlug: '' };
+    expect(deriveAdminOrgs(session([noOrgId, noMemexSlug]))).toEqual([]);
+  });
+});

--- a/packages/ui/src/pages/upgrade/adminOrgs.ts
+++ b/packages/ui/src/pages/upgrade/adminOrgs.ts
@@ -1,0 +1,73 @@
+// spec-171 t-25 / ac-39 / dec-40 (option A): billing is PER-ORG (std-1 cl-3).
+// A user has a personal Memex (NOT billable) and may administer MULTIPLE orgs
+// (std-4, spec-307). The hosted upgrade + billing flows must let the caller
+// CHOOSE which org to bill — they must NOT silently bill whatever the session
+// happens to be scoped to (which defaults to the non-billable personal Memex).
+//
+// The subscription routes are mounted ONLY under the tenant prefix
+// (/api/<ns>/<mx>/orgs/current/subscription) and resolve the org from the MEMEX
+// in the path (resolveOrgIdFromMemex). So to bill a chosen org we build the
+// tenant base from THAT org's namespace slug + one representative memex slug.
+//
+// Everything we need is already on the cached session's `memberships` — each row
+// carries `orgId`, `role`, `kind`, namespace `slug`, and `memexSlug`. No new
+// server endpoint required: we filter + group client-side. This module is pure
+// (no React) so it can be unit-tested in isolation.
+
+import type { MembershipSummary, SessionPayload } from '../../api/client';
+
+/**
+ * A billable org the caller administers, with a tenant base resolved to one of
+ * the org's memexes. `namespace`/`memexSlug` form the `/api/<ns>/<mx>` prefix the
+ * subscription routes are mounted under.
+ */
+export interface AdminOrg {
+  orgId: string;
+  /** Org display name (std-1: an "org", never a "team"/"account"). */
+  name: string;
+  /** Namespace slug — first path segment of the org's tenant URLs. */
+  namespace: string;
+  /** A representative memex slug under the org — second path segment. */
+  memexSlug: string;
+}
+
+/**
+ * Derive the orgs the caller can be billed for: org-namespace memberships
+ * (`kind: 'team'`) where the caller is an administrator and the row is a real
+ * membership (not a read-only `'visited'` pin on a public memex). Personal
+ * namespaces are excluded — they're never billable.
+ *
+ * Grouped by `orgId` (an org can expose several memexes; we only need one to
+ * address the org), preserving first-seen order. The representative memex is the
+ * first membership row seen for that org.
+ */
+export function deriveAdminOrgs(
+  session: SessionPayload | null | undefined,
+): AdminOrg[] {
+  const memberships = session?.memberships;
+  if (!memberships || memberships.length === 0) return [];
+
+  const byOrg = new Map<string, AdminOrg>();
+  for (const m of memberships) {
+    if (!isBillableAdminMembership(m)) continue;
+    const orgId = m.orgId;
+    // orgId is required for grouping; skip rows that somehow lack it.
+    if (!orgId) continue;
+    if (byOrg.has(orgId)) continue; // keep the first representative memex
+    byOrg.set(orgId, {
+      orgId,
+      name: m.name,
+      namespace: m.slug,
+      memexSlug: m.memexSlug,
+    });
+  }
+  return Array.from(byOrg.values());
+}
+
+function isBillableAdminMembership(m: MembershipSummary): boolean {
+  if (m.kind !== 'team') return false; // exclude personal namespaces
+  if (m.role !== 'administrator') return false; // only admins can bill
+  if (m.source === 'visited') return false; // read-only public pin, not a real org membership
+  if (!m.memexSlug) return false; // can't build a tenant base without it
+  return true;
+}


### PR DESCRIPTION
## The bug (t-25 / ac-39 / dec-40, option A)

Billing is **per-org** (std-1 cl-3) and a user may administer several orgs, but `/upgrade` and `/org` billing resolved the target org from `session.currentMemexId` via `tenantBase()` → which defaults to the **non-billable personal Memex**. So the checkout POST hit `/api/<personal-ns>/personal/orgs/current/subscription` and 404'd `"Org context required"` (`resolveOrgIdFromMemex` returns null for a personal namespace).

The subscription routes are mounted only under the tenant prefix and resolve the org **from the memex in the path**. To bill a chosen org we must build the tenant base from that org's namespace + a representative memex.

## Fix — choose the org, bill that org

Everything needed already rides the session's `memberships` (`orgId`, `role`, `kind`, namespace `slug`, `memexSlug`). **No new server endpoint** — admin orgs are derived client-side.

- **`adminOrgs.ts`** — `deriveAdminOrgs(session)`: billable admin orgs only (`kind: 'team'`, `role: 'administrator'`, excludes the personal namespace and read-only `'visited'` pins), grouped by `orgId` with a representative memex per org. Unit-tested (`adminOrgs.test.ts`, 8 cases).
- **`client.ts`** — adds `OrgTenant` + `orgBillingBase()`; threads an explicit org target through all five billing calls: `startCheckout` (now **required**), `fetchCurrentSubscription`, `previewSeatChange`, `updateOrgSeats`, `fetchBillingPortalUrl` — no longer `tBase()`/session-current. Adds `orgId` to the UI `MembershipSummary` (the server already sends it).
- **`OrgSelector.tsx`** — none → "create an organisation" CTA (navigates to the personal namespace home where the create-org dialog lives); exactly one → auto-selected, shown read-only ("Upgrading organisation"); many → radio chooser. std-1 vocabulary throughout ("organisation", never "team"/"account").
- **`UpgradeSeats.tsx`** — derives admin orgs, surfaces the selector, bills the chosen org's tenant; "Continue to payment" disabled until an org is selected.
- **`BillingTab.tsx`** — resolves the org the same explicit way: single admin org → correct automatically; multiple → chooser + a "Switch organisation" header. Targets the chosen org's tenant on every billing call.
- **`UpgradeConfirmation.tsx`** — after the Stripe redirect (router state gone) the poll now targets the upgraded org (single-admin-org case) instead of session-current, which is always `free` → the poll would otherwise never resolve and a paying user would see "Finalizing…" forever.

Both `UpgradeSeats` and `BillingTab` also carry a post-mount sync effect: if the org arrives via AuthContext's background `/api/auth/me` refresh *after* mount, the single-org case still auto-selects (the read-only single-org view has no manual control).

## Verify

`journey-42` now seeds a **FREE** admin org, drives the **real** session-based org resolution (waits for the org name to render before continuing — no stubbed org), and asserts the intercepted checkout POST URL **contains the org's namespace** and **does not contain the personal namespace** (alongside the existing not-`/upgrade/` regression assertion).

- **journey-42 + journey-43**: green (`E2E_UI_PORT=5273 E2E_SERVER_PORT=8380 E2E_DATABASE_URL=postgresql://fcooker:fcooker@localhost:5433/memex MEMEX_EMIT=false`).
- **Full UI suite**: `pnpm --filter @memex/ui test:coverage` → 208 files, 1498 passed, 1 skipped.
- **Full server suite**: `vitest run` → the only failures are `slack/oauth.test.ts` (pre-existing local-only env flake, confirmed failing on clean develop) and `migration-smoke` (full-run shared-DB ordering artifact; passes in isolation). Neither is touched by this PR.
- **Typecheck**: UI `tsc -b` clean; server `tsc -p tsconfig.build.json --noEmit` clean.
- **Full cold e2e**: 11 unrelated agent-streaming/SSE/reactivity journeys (journey-8/12/15/16/23) fail identically on clean develop with this branch's changes stashed → pre-existing environmental, not a regression. journey-42/43 (this PR's scope) pass.

## Scope notes / known gaps

- `SeatsWarningBanner` is left URL-gated (only renders inside a tenant context) — already correct; not in scope.
- `UpgradePlanSelect`'s current-plan highlight stays best-effort (session-current; cosmetic, errors swallowed).
- `UpgradeConfirmation` post-redirect poll is precise only for the single-admin-org case; with several admin orgs it can't tell which org was upgraded from the confirmation page alone, so it falls back and times out gracefully into the "active" view (the webhook still applied the tier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)