### PR TITLE
fix(spec-171): /api/stripe/webhook 404'd by memex-resolver — Stripe deliveries never reached the handler

### DIFF
--- a/packages/server/src/__e2e__/path-routing.api.test.ts
+++ b/packages/server/src/__e2e__/path-routing.api.test.ts
@@ -189,6 +189,28 @@ describe("path-routing [std-2] [t-2]", () => {
       // NOT 404 from the resolver claiming "namespace not found".
       expect([200, 500]).toContain(res.status);
     });
+
+    it("routes /api/stripe/webhook to the webhook handler, not the tenant resolver (spec-171)", async () => {
+      // Regression (issue-13 sibling, caught in manual int testing): the Stripe
+      // webhook mounts at /api/stripe/webhook — TWO segments that match the
+      // /api/<namespace>/<memex> shape. Without "stripe" in the resolver's
+      // reserved-API-roots, parseMemexPath read namespace=stripe/memex=webhook
+      // and 404'd BEFORE the webhook router ran, so every Stripe delivery got a
+      // 404 and orgs never received their purchased tier. Posting with no
+      // Stripe-Signature reaches the handler, which rejects it (400 "Missing
+      // Stripe-Signature header"). Critically NOT 404 (resolver shadowing).
+      const res = await request(
+        "/api/stripe/webhook",
+        "memex.ai",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ id: "evt_test", type: "ping" }),
+        },
+      );
+      expect(res.status).not.toBe(404);
+      expect(res.status).toBe(400);
+    });
   });
 
   // ── t-18: path-prefixed mounts for tenancy-scoped surfaces ───────────────

--- a/packages/server/src/middleware/memex-resolver.ts
+++ b/packages/server/src/middleware/memex-resolver.ts
@@ -113,6 +113,11 @@ const RESERVED_API_ROOTS = new Set([
   // tenant-less). Without this, parseMemexPath would read "/guide/v1/…" as
   // namespace=guide / memex=v1 and 404 before the public router ever runs.
   "guide",
+  // spec-171: the Stripe webhook receiver mounts at /api/stripe/webhook (public —
+  // the Stripe-Signature HMAC is the auth). Without this, parseMemexPath reads
+  // "/api/stripe/webhook" as namespace=stripe / memex=webhook and 404s before the
+  // webhook router runs, so Stripe deliveries fail and orgs never get their tier.
+  "stripe",
 ]);
 
 // Parses `/<namespace>/<memex>/...` or `/api/<namespace>/<memex>/...` from a


### PR DESCRIPTION
## Problem (caught in manual int testing)
A real Stripe **test purchase succeeded** (subscription `active` for org1, correct `org_id` metadata) — but org1 stayed **Cloud Free** in the app. The `checkout.session.completed` webhook never applied the tier.

## Root cause
`POST /api/stripe/webhook` returned **404** on int. The webhook mounts at `/api/stripe/webhook` — two segments matching the `/api/<namespace>/<memex>` shape. `stripe` was **missing from `RESERVED_API_ROOTS`** in `memex-resolver.ts`, so the resolver read `namespace=stripe / memex=webhook`, failed to resolve, and 404'd **before** the webhook router ran. Stripe got 404 on every delivery → orgs never received their purchased tier.

The webhook integration tests passed because they invoke `stripeWebhookRouter.request('/')` **directly**, bypassing the resolver middleware — so the live 404 was invisible to CI.

## Fix
- Add `stripe` to `RESERVED_API_ROOTS` (memex-resolver.ts) → `/api/stripe/*` is treated as an app mount, not a tenant → routes to the webhook handler.
- **Guard:** a `path-routing.api.test.ts` case that POSTs to `/api/stripe/webhook` **through the full app** and asserts **400** (missing signature), not 404 (resolver shadowing). This is the test that was missing.

## Test
`path-routing.api.test.ts` 25/25 green (incl. the new guard). Server `tsc -p tsconfig.build.json --noEmit` clean.

## Post-merge
After int deploy: `/api/stripe/webhook` returns 400 (not 404). Stripe auto-retries the failed `checkout.session.completed` (or resend manually from the Dashboard) → org1 gets Premium. Same fix needed in prod (covered by the spec-330 go-live checklist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)