### PR TITLE
spec-342: test emission events must not auto-advance a Spec's phase

### DIFF
--- a/packages/server/src/__regression__/test-events-namespace-guard.regression.test.ts
+++ b/packages/server/src/__regression__/test-events-namespace-guard.regression.test.ts
@@ -45,9 +45,8 @@ vi.mock("../services/mutate.js", () => ({
   ),
 }));
 
-vi.mock("../services/spec-traffic.js", () => ({
-  observeTestEventTraffic: vi.fn(),
-}));
+// spec-342: the route no longer calls into spec-traffic.js (the test-event
+// phase auto-advance was removed), so there is nothing to stub here.
 
 vi.mock("../services/issues.js", () => ({
   maybeAutoResolveIssuesForAcUid: vi.fn().mockResolvedValue(undefined),

--- a/packages/server/src/mcp/spec-traffic.integration.test.ts
+++ b/packages/server/src/mcp/spec-traffic.integration.test.ts
@@ -45,7 +45,6 @@ import { listAssignees } from "../services/doc-assignees.js";
 import { resolveRole } from "../services/doc-members.js";
 import {
   observeSpecTraffic,
-  observeTestEventTraffic,
   type SpecTrafficEvent,
 } from "../services/spec-traffic.js";
 import { bus, type ChangeEvent } from "../services/bus.js";
@@ -260,26 +259,12 @@ describe("spec-189: traffic-driven phase advancement through real MCP tool calls
     expect(await assigneeIds(spec.id)).toContain(actor.member.id);
   });
 
-  it("draft + verify-class traffic (test_event arriving) → verify; done reopens to verify (ac-2, ac-7)", async () => {
-    tagAc(AC(2));
-    tagAc(AC(7));
-    // Verify-class has no MCP tool (dec-1): it arrives as CI test_events.
-    // observeTestEventTraffic is exactly what POST /api/test-events invokes
-    // after an accepted, non-hidden emission.
-    const fromDraft = await makeSpec("Draft to Verify");
-    await observeTestEventTraffic(
-      actor.memexId,
-      `${actor.slug}/main/specs/${fromDraft.handle}/acs/ac-1`,
-    );
-    expect(await specStatus(fromDraft.id)).toBe("verify");
-
-    const fromDone = await makeSpec("Done reopens to Verify", "done");
-    await observeTestEventTraffic(
-      actor.memexId,
-      `${actor.slug}/main/specs/${fromDone.handle}/acs/ac-1`,
-    );
-    expect(await specStatus(fromDone.id)).toBe("verify");
-  });
+  // spec-342 SUPERSEDES the former "test_event arriving → verify" behaviour:
+  // CI test events no longer drive phase at all (observeTestEventTraffic was
+  // removed). The new no-advance contract — a test event leaves a Spec's phase
+  // untouched from any source phase, including the old done→verify reopen — is
+  // owned by spec-342-test-event-no-advance.integration.test.ts. spec-189 ac-2
+  // / ac-7 remain covered here by the build-class / specify-class cases below.
 
   it("specify + build-class traffic (update_task) → build, even with open decisions (ac-7, ac-8)", async () => {
     tagAc(AC(7));

--- a/packages/server/src/routes/spec-342-test-event-no-advance.integration.test.ts
+++ b/packages/server/src/routes/spec-342-test-event-no-advance.integration.test.ts
@@ -1,0 +1,175 @@
+// spec-342: test emission events must NOT auto-advance a Spec's phase.
+//
+// Before spec-342, POST /api/test-events called observeTestEventTraffic, which
+// advanced the AC's Spec build→verify (and reopened a `done` Spec to verify),
+// channel='server', no actor — a surprise move the Spec owner never heard about.
+// This Spec removed that path entirely: a test event now updates the AC verdict
+// + audit trail only; phase is a deliberate human / handoff placement.
+//
+// These tests drive the REAL route handler against a real Postgres, with only
+// the emission-key auth mocked (the auth/memex-match itself is covered by
+// emission-auth.api.test.ts). Real specs are created with real handles under a
+// real memex, so a reintroduced observeTestEventTraffic WOULD find the doc by
+// (memexId, handle) and flip it — making this a genuine regression guard, not a
+// tautology.
+
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+import { Hono } from "hono";
+import { eq, inArray } from "drizzle-orm";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+// Holder is set in beforeAll once the real memex exists; the mocked auth reads
+// it at request time so verifyEmissionKey/resolveMemexId agree on the same
+// memexId (auth passes: targetMemexId === emissionKey.memexId).
+const h = vi.hoisted(() => ({ memexId: "" }));
+
+vi.mock("../services/emission-keys.js", () => ({
+  verifyEmissionKey: vi.fn(async () => ({
+    id: "test-key",
+    memexId: h.memexId,
+    scopedSpecHandle: null,
+  })),
+  resolveMemexId: vi.fn(async () => h.memexId),
+  bumpLastUsed: vi.fn(),
+}));
+
+import { db } from "../db/connection.js";
+import {
+  documents,
+  testEvents,
+  testEventLatest,
+  namespaces,
+} from "../db/schema.js";
+import { createDocDraft, updateDocStatus } from "../services/documents.js";
+import { makeTestMemexWithDevAdmin } from "../services/test-helpers.js";
+import { upsertUserByEmail } from "../services/users.js";
+import { testEventsRouter } from "./test-events.js";
+
+const AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-342/acs/ac-${n}`;
+
+const app = new Hono();
+app.route("/api/test-events", testEventsRouter);
+
+let slug: string;
+let ownerId: string;
+const createdDocIds: string[] = [];
+const createdAcUids: string[] = [];
+
+beforeAll(async () => {
+  const made = await makeTestMemexWithDevAdmin("s342");
+  h.memexId = made.memexId;
+  slug = made.slug;
+  ownerId = (await upsertUserByEmail("dev@memex.ai")).id;
+});
+
+afterAll(async () => {
+  if (createdAcUids.length) {
+    await db.delete(testEvents).where(inArray(testEvents.acUid, createdAcUids)).catch(() => {});
+    await db.delete(testEventLatest).where(inArray(testEventLatest.acUid, createdAcUids)).catch(() => {});
+  }
+  if (createdDocIds.length) {
+    await db.delete(documents).where(inArray(documents.id, createdDocIds)).catch(() => {});
+  }
+  if (slug) {
+    await db.delete(namespaces).where(eq(namespaces.slug, slug)).catch(() => {});
+  }
+});
+
+/** Create a real spec under the test memex, in the given phase. */
+async function makeSpec(title: string, status: string): Promise<{ id: string; acUid: string }> {
+  const doc = await createDocDraft(h.memexId, title, "purpose", "spec", undefined, undefined, ownerId);
+  createdDocIds.push(doc.id);
+  if (status !== "draft") {
+    await updateDocStatus(h.memexId, doc.id, status);
+  }
+  const acUid = `${slug}/main/specs/${doc.handle}/acs/ac-1`;
+  createdAcUids.push(acUid);
+  return { id: doc.id, acUid };
+}
+
+async function specStatus(id: string): Promise<string> {
+  const row = await db.query.documents.findFirst({ where: eq(documents.id, id) });
+  return row!.status;
+}
+
+async function emit(acUid: string, opts: { hidden?: boolean } = {}) {
+  return app.request("/api/test-events", {
+    method: "POST",
+    headers: { Authorization: "Bearer test-key", "Content-Type": "application/json" },
+    body: JSON.stringify({
+      ac_uid: acUid,
+      status: "pass",
+      test_identifier: "spec-342.test.ts::no-advance",
+      hidden: opts.hidden ?? false,
+    }),
+  });
+}
+
+describe("spec-342: a test event never advances a Spec's phase", () => {
+  it("a non-hidden test event leaves the phase untouched from EVERY source phase, including the former done→verify reopen [ac-1][ac-5][ac-7]", async () => {
+    tagAc(AC(1));
+    tagAc(AC(5));
+    tagAc(AC(7));
+    for (const phase of ["draft", "specify", "build", "done"]) {
+      const spec = await makeSpec(`No-advance from ${phase}`, phase);
+      expect(await specStatus(spec.id)).toBe(phase); // sanity: seeded as expected
+      const res = await emit(spec.acUid);
+      expect(res.status).toBe(201);
+      // The whole point: the emission did not move the lifecycle.
+      expect(await specStatus(spec.id)).toBe(phase);
+    }
+  });
+
+  it("a non-hidden pass still updates the AC verdict while the phase stays put [ac-2][ac-6]", async () => {
+    tagAc(AC(2));
+    tagAc(AC(6));
+    const spec = await makeSpec("Verdict still lands", "build");
+    const res = await emit(spec.acUid);
+    expect(res.status).toBe(201);
+    // Phase unchanged…
+    expect(await specStatus(spec.id)).toBe("build");
+    // …but the verdict summary was materialised by the non-hidden pass.
+    const [summary] = await db
+      .select({ latestStatus: testEventLatest.latestStatus })
+      .from(testEventLatest)
+      .where(eq(testEventLatest.acUid, spec.acUid));
+    expect(summary?.latestStatus).toBe("pass");
+  });
+
+  it("the hidden flag is decoupled from phase: a hidden emission changes neither the phase nor the visible verdict [ac-3][ac-8]", async () => {
+    tagAc(AC(3));
+    tagAc(AC(8));
+    const spec = await makeSpec("Hidden is audit-only", "build");
+    const res = await emit(spec.acUid, { hidden: true });
+    expect(res.status).toBe(201);
+    // No phase effect (the only behaviour the old code gated on `hidden`).
+    expect(await specStatus(spec.id)).toBe("build");
+    // Audit row exists, flagged hidden; the visible verdict is NOT a hidden pass
+    // (the summary upsert skips hidden emissions — verdict/audit only).
+    const events = await db
+      .select({ hidden: testEvents.hidden })
+      .from(testEvents)
+      .where(eq(testEvents.acUid, spec.acUid));
+    expect(events.some((e) => e.hidden === true)).toBe(true);
+    // The hidden emission is excluded from the verdict summary entirely (the
+    // upsert skips hidden rows) — so it creates no visible verdict at all.
+    const summaryRows = await db
+      .select({ latestStatus: testEventLatest.latestStatus })
+      .from(testEventLatest)
+      .where(eq(testEventLatest.acUid, spec.acUid));
+    expect(summaryRows.length).toBe(0);
+  });
+
+  it("regression pin: POST /api/test-events is accepted but drives no transition — the contract spec-327/spec-189 relied on is retired [ac-4]", async () => {
+    tagAc(AC(4));
+    // A build Spec receiving repeated CI passes (the spec-36/spec-39 scenario)
+    // stays in build no matter how many land.
+    const spec = await makeSpec("Repeated CI passes, no churn", "build");
+    for (let i = 0; i < 3; i++) {
+      const res = await emit(spec.acUid);
+      expect(res.status).toBe(201);
+    }
+    expect(await specStatus(spec.id)).toBe("build");
+  });
+});

--- a/packages/server/src/routes/test-events.ts
+++ b/packages/server/src/routes/test-events.ts
@@ -55,7 +55,6 @@ import {
   resolveMemexId,
 } from "../services/emission-keys.js";
 import { mutate } from "../services/mutate.js";
-import { observeTestEventTraffic } from "../services/spec-traffic.js";
 import type { ChangeEntity } from "../services/bus.js";
 
 const testEventsRouter = new Hono();
@@ -356,15 +355,10 @@ testEventsRouter.post("/", async (c) => {
   // bump never blocks or fails the emission — it only leaves a slightly stale timestamp.
   bumpLastUsed(emissionKey.id);
 
-  // spec-189: a test_event arriving is verify-class traffic on the AC's Spec
-  // (dec-1) — a done Spec reopens to verify; a draft Spec advances to verify.
-  // Hidden emissions are excluded by design (`hidden: true` exists to keep an
-  // emission out of the visible signals — e.g. iterating on a done-phase
-  // regression fix must not reopen the Spec). Best-effort and non-throwing;
-  // no assignment (an emission key carries no acting user).
-  if (!insertValues.hidden) {
-    await observeTestEventTraffic(targetMemexId, insertValues.acUid);
-  }
+  // spec-342: a test_event NEVER changes a Spec's phase. It updates the AC
+  // verdict (applyEmissionToSummary, above) and the audit trail only; phase is
+  // a deliberate human / handoff placement. The former build→verify (and
+  // done→verify reopen) auto-promote was removed — see spec-traffic.ts.
 
   // Stdout log so observers can tail the dev server output during deploys
   // and behavioural probes. Cheap and useful.

--- a/packages/server/src/services/spec-traffic.ts
+++ b/packages/server/src/services/spec-traffic.ts
@@ -20,10 +20,11 @@
 //      manifest precisely so auto-assignment can't fight them —
 //      unassign_spec(self) must not instantly undo itself).
 //
-// Verify-class traffic has no MCP tool today: it arrives as CI test_events
-// via POST /api/test-events, which calls `observeTestEventTraffic` below
-// (transition only — an emission key carries no acting user, so there is
-// nothing to assign).
+// spec-342: test emission events NO LONGER drive phase. A Spec's phase is a
+// deliberate human / handoff placement; CI test_events (POST /api/test-events)
+// update AC verdicts and the audit trail only. The former build→verify (and
+// done→verify reopen) auto-promote — `observeTestEventTraffic` — was removed
+// here, completing the arc spec-327 began: traffic is not a phase intent.
 //
 // Failure posture: observation is best-effort and MUST NEVER fail or delay
 // the user's tool call semantics — every entry point catches everything and
@@ -241,42 +242,9 @@ export async function runToolWithSpecTraffic(
   return text;
 }
 
-/**
- * Verify-class traffic from CI: a test_event arriving for an AC is evidence
- * of verification activity on the AC's Spec (dec-1). Transition only — the
- * emission key authenticates a Memex, not a user, so there is no caller to
- * assign. Hidden emissions are excluded: `hidden: true` exists precisely to
- * keep an emission out of the visible signals (e.g. iterating on a
- * done-phase regression fix must not reopen the Spec). Never throws.
- */
-export async function observeTestEventTraffic(
-  memexId: string,
-  acUid: string,
-): Promise<void> {
-  try {
-    // ac_uid grammar: <namespace>/<memex>/specs/<spec-handle>/acs/<ac-handle>
-    const match = /\/specs\/([^/]+)\/acs\//.exec(acUid);
-    const specHandle = match?.[1];
-    if (!specHandle) return;
-
-    const doc = await db.query.documents.findFirst({
-      where: and(
-        eq(documents.memexId, memexId),
-        eq(documents.handle, specHandle),
-      ),
-    });
-    if (!doc || doc.docType !== "spec" || doc.isDemo) return;
-    if (doc.pausedAt !== null || doc.archivedAt !== null) return;
-    if (!isSpecStatus(doc.status)) return;
-
-    const next = nextPhaseForTraffic(doc.status, "verify");
-    if (next === doc.status) return;
-
-    await updateDocStatus(memexId, doc.id, next, {
-      ctx: { channel: "server" },
-      narrative: `auto-advanced ${doc.handle} ${doc.status} → ${next} (test event for ${acUid.split("/").pop()})`,
-    });
-  } catch (err) {
-    console.warn("[spec-traffic] test-event observation failed:", err);
-  }
-}
+// spec-342: `observeTestEventTraffic` was removed here. A CI test_event used to
+// auto-advance its AC's Spec build→verify (and reopen a done Spec to verify);
+// it no longer does — test events update the AC verdict + audit trail only, and
+// phase is a deliberate human placement. POST /api/test-events therefore makes
+// no phase change. The verdict path (applyEmissionToSummary, analytics) is
+// untouched and is the sole remaining reader of the `hidden` flag.


### PR DESCRIPTION
## What & why

A Spec in `build` silently jumped to `verify` the moment a non-hidden CI test event landed for any of its ACs — no human acted, the move was attributed to nobody (`channel: 'server'`), and the owner's MCP coding session got no signal. On `mindset-platform`, spec-36/spec-39 churned this way and QA saw the board move before the owner did. Prod Cloud Run logs confirmed non-hidden test events for spec-39 (Jun 22 ~12:58 UTC) as the trigger.

This removes the test-event phase auto-advance entirely. A CI test event now updates the **AC verdict + audit trail only**; a Spec's phase is a deliberate human/handoff placement. It completes the arc **spec-327** began (traffic ≠ phase intent): with `create_task`'s build-class advance already retired, this removes the last traffic-driven path to `verify` — the build→verify auto-promote, including the `done`→`verify` reopen. The `hidden` flag is now read only by verdict/audit code, fully decoupled from phase.

Spec: `mindset-prod/memex-building-itself/specs/spec-342` (dec-1, dec-2).

## Changes (removal-only — no schema, migration, route, UI, or manifest change)

- **`services/spec-traffic.ts`** — delete `observeTestEventTraffic`. `observeSpecTraffic` / tool-call traffic untouched.
- **`routes/test-events.ts`** — drop the import and the `if (!hidden) observeTestEventTraffic(...)` post-emit block. The `mutate()` SSE emit, `applyEmissionToSummary` verdict upsert, and `[test-events]` log stay.
- **new `routes/spec-342-test-event-no-advance.integration.test.ts`** — real route + real Postgres (only emission-key auth mocked); creates real specs so a reintroduced advance *would* flip them. Asserts no phase change from draft/specify/build/done (incl. done→verify reopen), verdict still lands for a non-hidden pass, hidden stays audit-only, repeated CI passes don't churn.
- **`mcp/spec-traffic.integration.test.ts`** — remove the obsolete "test_event → verify" case + dead import (spec-189 ac-2/ac-7 still covered by surviving cases).
- **`__regression__/test-events-namespace-guard.regression.test.ts`** — remove the now-pointless `spec-traffic.js` mock.

## Testing

- All **8 spec-342 ACs verified** (`list_acs`: 8 verified, 0 failing).
- Full server suite: **4229 passed, 28 skipped**. The 5 failures are pre-existing telemetry-ingress tests (`anon-telemetry.api.test.ts` / spec-324, 422-vs-204) — verified pre-existing by re-running with this diff stashed; none touch files in this PR.

## Cross-spec

- **spec-189** — its test-event (verify-class) advancement is what's removed; its traffic tests were edited and **spec-189/issue-3** filed for its verifier. Its tool-call advancement (specify→build via `update_task`) is unchanged.
- **spec-327** — thesis completed; no spec-327 code changed.

## Out of scope (tracked separately)

- **MCP-session notification gap** — a coding session still gets no async notice of a phase change elsewhere (stateless MCP transport, no push). This PR fixes only the unwanted *move*; the notification channel is flagged for spec-274.
- **mindset-platform emitter `hidden` inconsistency** (352/48 on spec-36/39) — lives in that repo's CI emitter, not this codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)