### PR TITLE
spec-341: wire POSTMARK_WEBHOOK_TOKEN into Cloud Run (optional)

### DIFF
--- a/packages/server/deploy.sh
+++ b/packages/server/deploy.sh
@@ -322,6 +322,16 @@ echo "Deploying to Cloud Run..."
 SECRETS_WIRING="ANTHROPIC_API_KEY=anthropic-api-key:latest"
 SECRETS_WIRING+=",POSTMARK_SERVER_TOKEN=postmark-server-token:latest"
 SECRETS_WIRING+=",AUTH_JWT_SECRET=auth-jwt-secret:latest"
+# spec-341: Basic-auth credential for the Postmark delivery webhook
+# (/api/postmark/webhook). OPTIONAL — only wired if the secret exists (same
+# posture as COHERE below), so this deploy never breaks if it's not yet created.
+# Until the secret is present the webhook route returns 401 (deliveries rejected);
+# email send-logging + Stripe capture work regardless. Create with:
+#   gcloud secrets create postmark-webhook-token --replication-policy=user-managed \
+#     --locations=us-east4 --data-file=- --project "<project>"
+if gcloud secrets describe postmark-webhook-token --project "${GCP_PROJECT}" >/dev/null 2>&1; then
+  SECRETS_WIRING+=",POSTMARK_WEBHOOK_TOKEN=postmark-webhook-token:latest"
+fi
 SECRETS_WIRING+=",OPENAI_API_KEY=openai-api-key:latest"
 if [ "$HAS_SLACK" = "1" ]; then
   SECRETS_WIRING+=",SLACK_CLIENT_SECRET=slack-client-secret:latest"


### PR DESCRIPTION
Wires `POSTMARK_WEBHOOK_TOKEN` from Secret Manager into the Cloud Run service so the spec-341 Postmark delivery webhook (`/api/postmark/webhook`) can authenticate incoming deliveries.

**Optional by design** — wired only if the `postmark-webhook-token` secret exists in the project (mirrors the COHERE/SLACK pattern). So this is **safe to merge anytime**:
- the deploy never fails if the secret isn't created yet;
- the webhook begins authenticating as soon as the secret is present (on the next deploy/redeploy).

Until the secret exists, the webhook route returns **401** (deliveries rejected) — email send-logging and Stripe billing-event capture are unaffected.

### Prerequisite (separate, needs Secret Manager Admin / PAM)
Create the secret in each project and grant the Cloud Run runtime SA accessor:
- `memex-ai-int` → SA `1045591124578-compute@developer.gserviceaccount.com`
- `memex-ai-prod` → SA `memex-api-runtime@memex-ai-prod.iam.gserviceaccount.com`

Then register the webhook URL in Postmark (per env) with HTTP Basic auth, password = the token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
