### PR TITLE
spec-344: hide the operator 'manual step switcher' preview bar from Home

### DIFF
--- a/packages/ui/src/pages/HomeCanvas.test.tsx
+++ b/packages/ui/src/pages/HomeCanvas.test.tsx
@@ -107,6 +107,7 @@ describe('HomeCanvas v2 — persistent rail + content panel (ac-1, ac-2, ac-8, a
   it('opens a new user full-width on step 0 (the identity triangle); the rail is hidden until they advance', async () => {
     tagAc(AC(2));
     tagAc(AC(8));
+    tagAc(AC344(3)); // a normal (non-staff) user's journey renders unchanged by spec-344
     fetchJourneyStateApi.mockResolvedValue(stateFor('identity'));
     renderCanvas();
 
@@ -320,6 +321,9 @@ describe('HomeCanvas v2 — step 1 connect + create, per-stage prompts (ac-3, ac
 describe('HomeCanvas v2 — operator preview removed (spec-344) + document.title (regression)', () => {
   it('renders no operator preview bar, even for a canPreview staff user (spec-344 ac-5)', async () => {
     tagAc(AC344(5));
+    tagAc(AC344(1)); // staff no longer sees the yellow banner
+    tagAc(AC344(2)); // Home content sits at the top — same as a normal user's
+    tagAc(AC344(4)); // the preview is not exposed as a persistent banner
     // The yellow "manual step switcher" banner is gone for everyone now — staff Home
     // looks like a normal user's.
     fetchJourneyStateApi.mockResolvedValue(stateFor('identity', { canPreview: true }));
@@ -331,6 +335,7 @@ describe('HomeCanvas v2 — operator preview removed (spec-344) + document.title
 
   it('still forwards the ?preview=<step> debug param to the journey-state fetch (spec-344 ac-6)', async () => {
     tagAc(AC344(6));
+    tagAc(AC344(4)); // preview survives only as an opt-in URL, not a banner
     // The banner is gone but the URL capability survives: visiting /home?preview=<step>
     // reads the param and requests that previewed state (server still gates it via canPreview).
     fetchJourneyStateApi.mockResolvedValue(stateFor('create-spec', { canPreview: true, preview: true }));

--- a/packages/ui/src/pages/HomeCanvas.test.tsx
+++ b/packages/ui/src/pages/HomeCanvas.test.tsx
@@ -40,6 +40,7 @@ vi.mock('../hooks/useUserChangeStream', () => ({
 import { HomeCanvas } from './HomeCanvas';
 
 const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-336/acs/ac-${n}`;
+const AC344 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-344/acs/ac-${n}`;
 
 const SIX = [
   'identity',
@@ -86,9 +87,9 @@ function LocationDisplay() {
   );
 }
 
-function renderCanvas() {
+function renderCanvas(entry = '/home') {
   return render(
-    <MemoryRouter initialEntries={['/home']}>
+    <MemoryRouter initialEntries={[entry]}>
       <HomeCanvas />
       <LocationDisplay />
     </MemoryRouter>,
@@ -316,19 +317,26 @@ describe('HomeCanvas v2 — step 1 connect + create, per-stage prompts (ac-3, ac
   });
 });
 
-describe('HomeCanvas v2 — operator preview + document.title (regression)', () => {
-  it('shows the operator preview bar when canPreview is true; hides it otherwise', async () => {
+describe('HomeCanvas v2 — operator preview removed (spec-344) + document.title (regression)', () => {
+  it('renders no operator preview bar, even for a canPreview staff user (spec-344 ac-5)', async () => {
+    tagAc(AC344(5));
+    // The yellow "manual step switcher" banner is gone for everyone now — staff Home
+    // looks like a normal user's.
     fetchJourneyStateApi.mockResolvedValue(stateFor('identity', { canPreview: true }));
-    const { unmount } = renderCanvas();
-    expect(await screen.findByTestId('journey-preview-bar')).toBeInTheDocument();
-    expect(screen.getByTestId('journey-preview-create-spec')).toBeInTheDocument();
-    unmount();
-    window.localStorage.clear();
-
-    fetchJourneyStateApi.mockResolvedValue(stateFor('identity', { canPreview: false }));
     renderCanvas();
     await screen.findByTestId('getting-started-title');
     expect(screen.queryByTestId('journey-preview-bar')).toBeNull();
+    expect(screen.queryByTestId('journey-info')).toBeNull();
+  });
+
+  it('still forwards the ?preview=<step> debug param to the journey-state fetch (spec-344 ac-6)', async () => {
+    tagAc(AC344(6));
+    // The banner is gone but the URL capability survives: visiting /home?preview=<step>
+    // reads the param and requests that previewed state (server still gates it via canPreview).
+    fetchJourneyStateApi.mockResolvedValue(stateFor('create-spec', { canPreview: true, preview: true }));
+    renderCanvas('/home?preview=create-spec');
+    await screen.findByTestId('getting-started-title');
+    expect(fetchJourneyStateApi).toHaveBeenCalledWith('create-spec');
   });
 
   it("sets document.title to 'Home' so the desktop shell labels the /home tab (spec-318 ac-17)", async () => {

--- a/packages/ui/src/pages/HomeCanvas.tsx
+++ b/packages/ui/src/pages/HomeCanvas.tsx
@@ -105,7 +105,11 @@ const HANDOFF_MESSAGE =
 export function HomeCanvas() {
   const { user, session } = useAuth();
   const navigate = useNavigate();
-  const [searchParams, setSearchParams] = useSearchParams();
+  // The operator step-switcher UI (PreviewBar) was removed in spec-344, but the
+  // `?preview=<step>` debug capability is retained: staff can still preview any step by
+  // visiting /home?preview=<step> (server-gated by canPreview). So we still READ the param,
+  // we just no longer write it from any in-page control.
+  const [searchParams] = useSearchParams();
   const previewParam = searchParams.get('preview');
 
   useDocumentTitle({ kind: 'page', title: 'Home' });
@@ -294,13 +298,6 @@ export function HomeCanvas() {
 
   return (
     <div className="font-onboarding min-h-full" data-testid="home-canvas">
-      {state?.canPreview && (
-        <PreviewBar
-          activeStepId={serverStepId}
-          onPick={(id) => setSearchParams(id ? { preview: id } : {})}
-        />
-      )}
-
       {/* spec-336 / prototype: the page-level Home header above the tracker. */}
       <div className="mx-auto max-w-5xl px-4 pt-10 sm:px-6">
         <h1 data-testid="home-page-title" className="text-4xl font-black tracking-tight text-heading">
@@ -525,82 +522,6 @@ function JourneyRail({
   );
 }
 
-// Internal explainer of the journey concept, shown in the staff-only bar.
-function JourneyInfo() {
-  return (
-    <span className="group relative inline-flex items-center">
-      <button
-        type="button"
-        aria-label="What is a journey?"
-        data-testid="journey-info"
-        className="inline-flex h-4 w-4 items-center justify-center rounded-full border border-status-warning-border text-[10px] font-bold leading-none text-status-warning-text"
-      >
-        i
-      </button>
-      <span
-        role="tooltip"
-        className="pointer-events-none absolute left-0 top-6 z-50 hidden w-[23rem] rounded-lg border border-edge bg-panel p-3 text-[11px] font-normal normal-case leading-relaxed tracking-normal text-secondary shadow-xl group-hover:block group-focus-within:block"
-      >
-        <b className="text-heading">This is the onboarding journey.</b> The rail shows the
-        whole arc at once. Each step&apos;s orb ticks from your real activity — creating a spec,
-        resolving a decision, raising an AC — never from clicking. You can view any step freely;
-        viewing never changes your progress.
-      </span>
-    </span>
-  );
-}
-
-// Operator-only (spec-303 dec-9): pin any milestone step on your own account to review it
-// without minting a new user. Render-only — the underlying state is intact. Renders only
-// for entitled operators (server-enforced canPreview).
-function PreviewBar({
-  activeStepId,
-  onPick,
-}: {
-  activeStepId: string | null;
-  onPick: (id: string | null) => void;
-}) {
-  const steps = activeJourney().milestoneStepIds;
-  return (
-    <div
-      data-testid="journey-preview-bar"
-      title="Mindset staff only: a manual step-switcher for previewing the journey. The Home Canvas and the journey itself are live for every user — only this row of step buttons is staff-only, and using it changes nothing about your real progress."
-      className="flex flex-wrap items-center gap-2 border-b border-dashed border-status-warning-border bg-status-warning-bg px-4 py-1.5 text-xs"
-    >
-      <span className="inline-flex items-center gap-1.5 font-semibold uppercase tracking-wider text-status-warning-text">
-        <svg className="h-3.5 w-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
-          <path strokeLinecap="round" strokeLinejoin="round" d="M12 3l7 3v5c0 4.5-3 7.5-7 9-4-1.5-7-4.5-7-9V6l7-3z" />
-        </svg>
-        Mindset only · manual step switcher
-      </span>
-      <JourneyInfo />
-      <span className="mx-1 hidden text-status-warning-text/70 sm:inline">|</span>
-      {steps.map((id) => (
-        <button
-          key={id}
-          type="button"
-          data-testid={`journey-preview-${id}`}
-          onClick={() => onPick(id)}
-          className={`rounded-md border px-2 py-0.5 ${
-            id === activeStepId
-              ? 'border-status-warning-border bg-status-warning-bg font-medium text-status-warning-text'
-              : 'border-status-warning-border/50 text-status-warning-text/80 hover:bg-status-warning-bg'
-          }`}
-        >
-          {id}
-        </button>
-      ))}
-      <button
-        type="button"
-        data-testid="journey-preview-live"
-        onClick={() => onPick(null)}
-        className="rounded-md border border-status-warning-border/50 px-2 py-0.5 text-status-warning-text/80 hover:bg-status-warning-bg"
-      >
-        Live
-      </button>
-      <span className="ml-auto hidden text-[10px] normal-case tracking-normal text-status-warning-text/70 md:inline">
-        the journey below is live for everyone
-      </span>
-    </div>
-  );
-}
+// spec-344: the operator-only PreviewBar (a yellow "manual step switcher" banner, spec-303
+// dec-9) and its JourneyInfo tooltip were removed — staff Home now looks like everyone's.
+// The `?preview=<step>` debug capability is retained via the URL (see previewParam above).


### PR DESCRIPTION
## What

Removes the full-width yellow **"MINDSET ONLY · MANUAL STEP SWITCHER"** banner from `/home`. It's the spec-303 (dec-9) operator preview (`PreviewBar`), gated by `canPreview`, which rendered above the real Home content for every Mindset-staff session — spec-303's own QA already flagged it as "internal, temporary." Implements **spec-344**.

## How (dec-1, option b — remove banner, keep the debug URL)

In `packages/ui/src/pages/HomeCanvas.tsx`:
- Deleted the `{state?.canPreview && <PreviewBar/>}` render and the `PreviewBar` + `JourneyInfo` components.
- **Retained** the `?preview=<step>` capability: `previewParam` is still read from the URL and forwarded to `fetchJourneyStateApi` (server still gates it via `canPreview`), so QA can preview any journey step via `/home?preview=<step>` without minting a user. Only `setSearchParams` (the bar's writer) was dropped.
- No change to the `canPreview` entitlement or any server route — UI-only.

## Tests / gates
- `HomeCanvas` unit tests updated: no preview bar even for a `canPreview` staff user (**ac-5**); `?preview=` still forwarded to the fetch (**ac-6**).
- UI typecheck clean · full UI suite **1506 pass / 1 skip**.
- No e2e change: the bar was operator-only (no journey covered it); journey-34 already guards the live Home.

## Notes
- Spec: spec-344 (build). Scope ACs ac-1..4, implementation ac-5/ac-6.
- Held at the merge gate for Ryan; not merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)