### PR TITLE
fix(server): await onboarding seed so it survives Cloud Run (empty new-user Memexes)

### DIFF
--- a/packages/server/src/services/user-namespaces.default-standards-seed-resilience.test.ts
+++ b/packages/server/src/services/user-namespaces.default-standards-seed-resilience.test.ts
@@ -1,10 +1,11 @@
 // spec-184 t-3 / ac-9 — a default-Standards seed FAILURE never blocks signup: the
 // user account + personal memex are still created and the seed error is logged, not
-// surfaced. seedDefaultStandards is fired as a detached best-effort step inside
-// ensureUserNamespace (`void seedDefaultStandards(memexId).catch(...)`), so mocking it
-// to reject exercises the exact catch branch ac-9 protects. This ALSO guards the
-// wiring: if the hook were dropped the mock would never be called, the seed error would
-// never be logged, and this test would fail.
+// surfaced. seedDefaultStandards is AWAITED inside ensureUserNamespace, wrapped in a
+// try/catch (`await seedDefaultStandards(memexId)` → caught + logged) — it used to be
+// detached, but the detached post-response promise was starved on Cloud Run, so it was
+// moved onto the request path. Mocking it to reject exercises the exact catch branch ac-9
+// protects. This ALSO guards the wiring: if the hook were dropped the mock would never be
+// called, the seed error would never be logged, and this test would fail.
 //
 // Runs against REAL Postgres (the namespace + memex are really created); only the
 // seeders are mocked. The handhold seed shares the same best-effort hook, so it's
@@ -82,10 +83,9 @@ describe("ensureUserNamespace — a default-Standards seed failure never blocks 
       .limit(1);
     expect(mx).toBeDefined();
 
-    // The detached best-effort seed rejects on a microtask after the call returns; give
-    // it a tick, then assert the error was logged (swallowed, not surfaced) — which also
-    // proves the hook actually fired.
-    await new Promise((r) => setTimeout(r, 50));
+    // The seed is awaited inside ensureUserNamespace, so by the time it resolves the
+    // rejection has already been caught + logged (no tick needed) — which also proves the
+    // hook actually fired.
     expect(errSpy).toHaveBeenCalled();
     const loggedTheSeedError = errSpy.mock.calls.some((args) =>
       args.some((arg) => arg === seedError),

--- a/packages/server/src/services/user-namespaces.handhold-seed-resilience.test.ts
+++ b/packages/server/src/services/user-namespaces.handhold-seed-resilience.test.ts
@@ -3,13 +3,16 @@
 // logged rather than surfaced to the user." The pre-existing ac-7 tests only exercised
 // the SUCCESS path (seed lands 5 / org seeds 0), so the resilience the AC exists to
 // guarantee was unverified: a regression that let a seed error propagate out of
-// ensureUserNamespace (dropping the `.catch`, or awaiting the seed) would have passed
-// every tagged test. This drives the FAILURE path directly.
+// ensureUserNamespace would have passed every tagged test. This drives the FAILURE path
+// directly.
 //
-// seedHandholdDemo is fired as a detached best-effort step inside ensureUserNamespace
-// (`void seedHandholdDemo(memexId).catch(...)`), so mocking it to reject exercises the
-// exact catch branch ac-7 protects. Runs against REAL Postgres (the namespace + memex
-// are really created); only the demo seeder is mocked.
+// seedHandholdDemo is now AWAITED inside ensureUserNamespace (it used to be detached, but
+// the detached post-response promise was starved on Cloud Run, leaving new users with an
+// empty Memex — so it was moved onto the request path). The await is wrapped in a try/catch
+// (`await seedHandholdDemo(memexId)` → caught + logged), so mocking it to reject exercises
+// the exact catch branch ac-7 protects: the error is swallowed and ensureUserNamespace still
+// resolves. Runs against REAL Postgres (the namespace + memex are really created); only the
+// demo seeder is mocked.
 
 import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
 import { and, eq, inArray } from "drizzle-orm";
@@ -90,9 +93,9 @@ describe("ensureUserNamespace — a demo-seed failure never blocks signup (ac-7 
       .limit(1);
     expect(mx).toBeDefined();
 
-    // The detached best-effort seed rejects on a microtask after the call returns;
-    // give it a tick, then assert the error was logged (swallowed, not surfaced).
-    await new Promise((r) => setTimeout(r, 50));
+    // The seed is awaited inside ensureUserNamespace, so by the time it resolves the
+    // rejection has already been caught + logged (no tick needed). Assert it was logged
+    // (swallowed, not surfaced).
     expect(errSpy).toHaveBeenCalled();
     const loggedTheSeedError = errSpy.mock.calls.some((args) =>
       args.some((arg) => arg === seedError),

--- a/packages/server/src/services/user-namespaces.signup-seed-completion.test.ts
+++ b/packages/server/src/services/user-namespaces.signup-seed-completion.test.ts
@@ -1,0 +1,83 @@
+// Regression: the signup onboarding seed must COMPLETE before ensureUserNamespace
+// resolves — i.e. it is awaited, not fire-and-forget.
+//
+// The bug this guards: the handhold demo (spec-178) + default Standards (spec-184) seeds
+// were originally detached (`void seed…()`) and run AFTER the HTTP response flushed. On
+// Cloud Run, CPU is throttled to ~0 once the response is sent, so those post-response
+// multi-insert promises were starved/killed before committing — new users (seen on PROD
+// with HealthStream sign-ups, 2026-06) landed in an EMPTY personal Memex: no demo spec,
+// no Standards. The fix awaits both seeds inside ensureUserNamespace, on the request path,
+// where CPU is allocated.
+//
+// This test asserts the seeded rows exist the INSTANT ensureUserNamespace resolves, with
+// NO tick / setTimeout to let a detached promise settle. Under the old fire-and-forget code
+// the rows would not be present yet and this fails; under the awaited fix it is deterministic.
+// Runs against REAL Postgres (the rows are really inserted).
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { and, eq, inArray } from "drizzle-orm";
+import { db } from "../db/connection.js";
+import { namespaces, memexes, users, documents } from "../db/schema.js";
+import { ensureUserNamespace } from "./user-namespaces.js";
+import { upsertUserByEmail } from "./users.js";
+import { DEFAULT_STANDARDS_COUNT } from "../db/default-standards.fixture.js";
+
+const createdNamespaceIds: string[] = [];
+const createdUserIds: string[] = [];
+
+// spec-186: the vitest config disables both signup-seed hooks suite-wide; this suite is
+// specifically verifying that they fire + complete, so opt back in (read at CALL time).
+beforeAll(() => {
+  process.env.MEMEX_HANDHOLD_SIGNUP_SEED = "on";
+  process.env.MEMEX_DEFAULT_STANDARDS_SIGNUP_SEED = "on";
+});
+afterAll(() => {
+  process.env.MEMEX_HANDHOLD_SIGNUP_SEED = "off";
+  process.env.MEMEX_DEFAULT_STANDARDS_SIGNUP_SEED = "off";
+});
+
+afterAll(async () => {
+  // Namespaces cascade to their memex + docs; users last.
+  if (createdNamespaceIds.length) {
+    await db
+      .delete(namespaces)
+      .where(inArray(namespaces.id, createdNamespaceIds))
+      .catch(() => {});
+  }
+  if (createdUserIds.length) {
+    await db.delete(users).where(inArray(users.id, createdUserIds)).catch(() => {});
+  }
+});
+
+describe("ensureUserNamespace — onboarding seed completes before it resolves (not fire-and-forget)", () => {
+  it("a brand-new personal Memex already holds the demo spec + all default Standards the instant ensureUserNamespace resolves — no tick", async () => {
+    const user = await upsertUserByEmail(
+      `seed-completion-${Date.now()}-${Math.random().toString(36).slice(2, 8)}@example.com`,
+    );
+    createdUserIds.push(user.id);
+
+    const created = await ensureUserNamespace(user.id);
+    const memexId = created.memex.id;
+
+    // Track for cleanup.
+    const [ns] = await db
+      .select({ id: namespaces.id })
+      .from(namespaces)
+      .where(and(eq(namespaces.ownerUserId, user.id), eq(namespaces.kind, "user")))
+      .limit(1);
+    if (ns) createdNamespaceIds.push(ns.id);
+
+    // NO setTimeout / tick here — the assertion is the point: the rows are committed by the
+    // time ensureUserNamespace resolves, proving the seeds were awaited.
+    const docs = await db
+      .select({ id: documents.id, docType: documents.docType, isDemo: documents.isDemo })
+      .from(documents)
+      .where(eq(documents.memexId, memexId));
+
+    const demoDocs = docs.filter((d) => d.isDemo);
+    const standards = docs.filter((d) => d.docType === "standard");
+
+    expect(demoDocs.length).toBeGreaterThan(0);
+    expect(standards.length).toBe(DEFAULT_STANDARDS_COUNT);
+  });
+});

--- a/packages/server/src/services/user-namespaces.signup-seed-completion.test.ts
+++ b/packages/server/src/services/user-namespaces.signup-seed-completion.test.ts
@@ -17,7 +17,7 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { and, eq, inArray } from "drizzle-orm";
 import { db } from "../db/connection.js";
-import { namespaces, memexes, users, documents } from "../db/schema.js";
+import { namespaces, users, documents } from "../db/schema.js";
 import { ensureUserNamespace } from "./user-namespaces.js";
 import { upsertUserByEmail } from "./users.js";
 import { DEFAULT_STANDARDS_COUNT } from "../db/default-standards.fixture.js";

--- a/packages/server/src/services/user-namespaces.ts
+++ b/packages/server/src/services/user-namespaces.ts
@@ -151,8 +151,7 @@ export async function ensureUserNamespace(
     // is harmless). The needsLink-only repair path has a pre-existing memex and
     // does NOT seed.
     if (!existingMemex) {
-      seedHandholdDemoBestEffort(created.memex.id);
-      seedDefaultStandardsBestEffort(created.memex.id);
+      await seedNewPersonalMemex(created.memex.id);
     }
     return created;
   }
@@ -216,51 +215,71 @@ export async function ensureUserNamespace(
   // Memex. AFTER the mutate() commits, on the create path only (the fast-path
   // returns earlier and never reaches here). This funnels every signup flow
   // (password / magic-link / SSO) — they all create the namespace through here.
-  seedHandholdDemoBestEffort(created.memex.id);
-  seedDefaultStandardsBestEffort(created.memex.id);
+  await seedNewPersonalMemex(created.memex.id);
   return created;
 }
 
-// Fire-and-forget the handhold demo seed for a newly-created personal Memex
-// (spec-178 t-4). Best-effort by contract: a seed failure must NEVER roll back
-// or block signup, so the promise is detached (`void`) and any rejection is
-// swallowed to a log line. The seed itself is idempotent (NO-OP if the Memex
-// already has a demo doc — ac-8), so even a duplicate fire is harmless.
+// Seed a freshly-created personal Memex with the onboarding content (spec-178
+// handhold demo + spec-184 default Standards) and AWAIT it before ensureUserNamespace
+// returns. The two seeds run concurrently; allSettled guarantees this never rejects.
 //
-// spec-186: MEMEX_HANDHOLD_SIGNUP_SEED=off disables the hook. The vitest config
-// sets it suite-wide — under vitest every test that creates a user spawned a
-// detached multi-insert seed that outlived the test, racing its cleanup (FK
-// violations, rotating deadlocks: share-tokens / org-access / path-routing) and
-// logging after worker teardown (the EnvironmentTeardownError rpc race). The
-// hook's OWN suites (handhold.api.test.ts, the seed-resilience test) stub the
-// var back on — the env is read at CALL time, never cached, precisely so they
-// can. Prod/dev/e2e behaviour is unchanged (var unset ⇒ hook fires).
-function seedHandholdDemoBestEffort(memexId: string): void {
-  if (process.env.MEMEX_HANDHOLD_SIGNUP_SEED === "off") return;
-  void seedHandholdDemo(memexId).catch((err) =>
-    console.error("[handhold seed]", err),
-  );
+// Why AWAIT and not fire-and-forget: these seeds were originally detached (`void seed…()`)
+// so a slow/failed seed couldn't block or roll back signup. But on Cloud Run, CPU is
+// throttled to ~0 the instant the HTTP response flushes, so the detached post-response
+// multi-insert was getting starved/killed before its rows committed — new users landed in
+// an EMPTY Memex (no demo spec, no Standards), intermittently (it only completed when the
+// instance happened to stay warm). Awaiting keeps the inserts on the request path, where
+// CPU is allocated for the lifetime of the request, so they actually finish. The seeds are
+// bounded local-DB writes (the section embeddings they trigger are themselves fire-and-forget
+// inside the doc/section/clause primitives, so they do NOT lengthen this await). Cost is a
+// one-time latency bump on the single request that first creates a user's namespace.
+//
+// Best-effort is preserved by the per-seed try/catch below: a seed failure is logged and
+// swallowed, so signup still succeeds (the namespace + memex are already committed by the
+// time we get here). The seeds are individually idempotent (handhold: NO-OP if a demo doc
+// exists — ac-8; standards: NO-OP once the Memex holds any standard), so a duplicate fire
+// (e.g. a signup race twin) is harmless.
+async function seedNewPersonalMemex(memexId: string): Promise<void> {
+  await Promise.allSettled([
+    seedHandholdDemoBestEffort(memexId),
+    seedDefaultStandardsBestEffort(memexId),
+  ]);
 }
 
-// Fire-and-forget the default-Standards seed for a newly-created personal Memex
-// (spec-184 t-3 / dec-2). Best-effort by contract: a seed failure must NEVER roll
-// back or block signup, so the promise is detached (`void`) and any rejection is
-// swallowed to a log line. The seed is idempotent (NO-OP once the Memex holds any
-// standard — the zero-Standards guard), so even a duplicate fire is harmless. Only
-// reached on the personal-namespace create path (kind='user'), so seeding is
-// inherently personal-only (dec-6).
+// Seed the handhold onboarding demo (spec-178 t-4), awaited + isolated — see
+// seedNewPersonalMemex. A rejection is caught and logged so it never propagates out of
+// ensureUserNamespace (ac-7 / ac-41: a seed failure must never block signup).
 //
-// spec-186 gate (mirrors seedHandholdDemoBestEffort): this detached multi-insert seed
-// otherwise outlives a test and races its cleanup — FK noise + a console log after
-// worker teardown (the EnvironmentTeardownError rpc race) — so vitest disables it
-// suite-wide via MEMEX_DEFAULT_STANDARDS_SIGNUP_SEED=off. The seed's OWN suites stub it
-// back on (read at CALL time, never cached). Prod/dev/e2e are unchanged (var unset ⇒
-// hook fires).
-function seedDefaultStandardsBestEffort(memexId: string): void {
+// spec-186: MEMEX_HANDHOLD_SIGNUP_SEED=off disables the hook. The vitest config sets it
+// suite-wide — under vitest every test that creates a user would otherwise run a multi-insert
+// seed it then has to clean up (FK violations, rotating deadlocks). The hook's OWN suites
+// (handhold.api.test.ts, the seed-resilience test) stub the var back on — the env is read at
+// CALL time, never cached, precisely so they can. Prod/dev/e2e behaviour is unchanged
+// (var unset ⇒ hook fires).
+async function seedHandholdDemoBestEffort(memexId: string): Promise<void> {
+  if (process.env.MEMEX_HANDHOLD_SIGNUP_SEED === "off") return;
+  try {
+    await seedHandholdDemo(memexId);
+  } catch (err) {
+    console.error("[handhold seed]", err);
+  }
+}
+
+// Seed the six default Standards (spec-184 t-3 / dec-2), awaited + isolated — see
+// seedNewPersonalMemex. A rejection is caught and logged so it never propagates out of
+// ensureUserNamespace. Only reached on the personal-namespace create path (kind='user'),
+// so seeding is inherently personal-only (dec-6).
+//
+// spec-186 gate (mirrors seedHandholdDemoBestEffort): vitest disables it suite-wide via
+// MEMEX_DEFAULT_STANDARDS_SIGNUP_SEED=off; the seed's OWN suites stub it back on (read at
+// CALL time, never cached). Prod/dev/e2e are unchanged (var unset ⇒ hook fires).
+async function seedDefaultStandardsBestEffort(memexId: string): Promise<void> {
   if (process.env.MEMEX_DEFAULT_STANDARDS_SIGNUP_SEED === "off") return;
-  void seedDefaultStandards(memexId).catch((err) =>
-    console.error("[default-standards seed]", err),
-  );
+  try {
+    await seedDefaultStandards(memexId);
+  } catch (err) {
+    console.error("[default-standards seed]", err);
+  }
 }
 
 // Returns the user's default Memex (creates one if needed). The signup paths


### PR DESCRIPTION
## Problem

New users were intermittently landing in an **empty personal Memex** — no handhold demo spec (spec-178), no default Standards (spec-184). Surfaced via new sign-ups (incl. a HealthStream user); a PROD audit found **37 of 101 personal Memexes completely un-seeded**.

**Root cause:** both signup seeds ran *detached* (`void seedHandholdDemo()` / `void seedDefaultStandards()`) **after** the HTTP response flushed, inside `ensureUserNamespace`. On Cloud Run, CPU is throttled to ~0 once the response is sent, so the detached multi-insert promise was starved/killed before its rows committed. The personal Memex (created in-request) survived; its seeded content did not. Intermittent because it only completed when the instance happened to stay warm.

## Fix

Await both seeds on the request path (where CPU is allocated), via a new `seedNewPersonalMemex()` (`Promise.allSettled` of the two). Each seed is wrapped in try/catch so a failure is **still logged and swallowed** — signup is never blocked or rolled back (preserves ac-7 / ac-9 / ac-41). Section embeddings remain fire-and-forget inside the doc/section/clause primitives, so the await stays bounded (no heavy synchronous work).

## Tests

- **New:** `user-namespaces.signup-seed-completion.test.ts` — asserts the demo spec + all 6 default Standards exist *the instant* `ensureUserNamespace` resolves, with **no tick**. Under the old fire-and-forget code this query hit an empty Memex; now it's deterministic. This is the direct regression guard.
- Updated the two seed-resilience tests' comments to reflect the awaited contract (they still verify a seed failure never blocks signup).
- Full seed/signup suites green locally (38 tests); typecheck clean for changed files.

## PROD rescue (already done, separately)

The 37 empty Memexes have been backfilled via the existing idempotent backfill scripts (`missing_standards=0`, `missing_demo=0`); 2 Memexes left with partial Standard sets were repaired to 6/6. Caveat: rescued content isn't vector-indexed yet (backfill ran without an embed provider) — a separate embed backfill can index it.

## Follow-up (not in this PR)

The deploy-time backfill safety net (`deploy.sh` 1c/1d) evidently isn't catching these Memexes on each prod deploy — worth investigating whether it's hitting its 600s cap or silently erroring (it's non-gating).

🤖 Generated with [Claude Code](https://claude.com/claude-code)