### PR TITLE
spec-348: route orgs.ts billing writes through a mutate()-wrapped updater [P1] (std-8 drift)

### DIFF
--- a/packages/server/src/routes/orgs.ts
+++ b/packages/server/src/routes/orgs.ts
@@ -5,8 +5,10 @@ import {
   createOrgForUser,
   getOrgSummary,
   updateOrgSettings,
+  updateOrgBilling,
   refreshOrgDomainVerifiedFlag,
 } from "../services/orgs.js";
+import { restCtx } from "./_actor-ctx.js";
 import { getMemexById } from "../services/memexes.js";
 import {
   createDomainVerificationToken,
@@ -197,7 +199,7 @@ orgsCurrentRouter.patch("/current", adminGate, async (c) => {
   }
 
   try {
-    const summary = await updateOrgSettings(orgId, input);
+    const summary = await updateOrgSettings(orgId, input, restCtx(c));
     return c.json(summary);
   } catch (err) {
     if (err instanceof ValidationError) {
@@ -319,7 +321,7 @@ orgsCurrentRouter.post("/current/subscription", adminGate, async (c) => {
   let customerId = org.stripeCustomerId;
   if (!customerId) {
     customerId = await createStripeCustomer(user.email, org.name, orgId);
-    await db.update(orgs).set({ stripeCustomerId: customerId }).where(eq(orgs.id, orgId));
+    await updateOrgBilling(orgId, { stripeCustomerId: customerId }, restCtx(c));
   }
 
   const baseUrl = buildAppBaseUrl();
@@ -389,7 +391,7 @@ orgsCurrentRouter.patch("/current/subscription", adminGate, async (c) => {
   if (!org.stripeSubscriptionId) return c.json({ error: "No active subscription" }, 402);
 
   await updateSubscriptionSeats(org.stripeSubscriptionId, seats);
-  await db.update(orgs).set({ seatsPurchased: seats }).where(eq(orgs.id, orgId));
+  await updateOrgBilling(orgId, { seatsPurchased: seats }, restCtx(c));
 
   return c.json({ ok: true, seatsPurchased: seats });
 });

--- a/packages/server/src/services/orgs.ts
+++ b/packages/server/src/services/orgs.ts
@@ -29,7 +29,7 @@ import {
 import { ConflictError, ValidationError } from "../types/errors.js";
 import { pgError } from "./shared/pg-error.js";
 import { isFreeEmailDomain } from "./free-email-domains.js";
-import { mutate, type Mutated } from "./mutate.js";
+import { mutate, type Mutated, type RequestCtx } from "./mutate.js";
 import { primaryMemexIdForOrg } from "./shared/memex-ownership.js";
 
 export async function getOrgById(id: string): Promise<Org | undefined> {
@@ -208,6 +208,10 @@ export interface UpdateOrgInput {
 export async function updateOrgSettings(
   orgId: string,
   input: UpdateOrgInput,
+  // spec-122 dec-5 / std-32 — carries the activity contract (WHO/HOW) onto the
+  // emitted org.updated event. Optional so existing/system callers still type-check;
+  // an empty ctx emits an unattributed event (a visible defect per t-3, not a default).
+  ctx: RequestCtx = {},
 ): Promise<Mutated<OrgSummary>> {
   const current = await getOrgById(orgId);
   if (!current) throw new ValidationError(`Org ${orgId} not found`);
@@ -248,7 +252,7 @@ export async function updateOrgSettings(
   const memexId = (await primaryMemexIdForOrg(orgId)) ?? "";
 
   return mutate(
-    {},
+    ctx,
     { memexId, entity: "org", action: "updated" },
     async () => {
       await db.update(orgs).set(patch).where(eq(orgs.id, orgId));
@@ -259,10 +263,45 @@ export async function updateOrgSettings(
   );
 }
 
-export async function refreshOrgDomainVerifiedFlag(orgId: string): Promise<Mutated<void>> {
+// Billing-side org writes (Stripe customer id, purchased seat count). The
+// settings-page UpdateOrgInput deliberately excludes these columns — they are set
+// from the billing/checkout route + Stripe webhook, not the settings form — so
+// they get their own input shape and their own wrapped writer. Like
+// updateOrgSettings, every write goes through mutate({entity:"org"}) so the React
+// UI billing surface gets the SSE refresh (std-8) and the change is attributed (std-32).
+export interface UpdateOrgBillingInput {
+  stripeCustomerId?: string;
+  seatsPurchased?: number;
+}
+
+export async function updateOrgBilling(
+  orgId: string,
+  input: UpdateOrgBillingInput,
+  ctx: RequestCtx = {},
+): Promise<Mutated<void>> {
+  const patch: Partial<typeof orgs.$inferInsert> & { updatedAt: Date } = {
+    updatedAt: new Date(),
+  };
+  if (input.stripeCustomerId !== undefined) patch.stripeCustomerId = input.stripeCustomerId;
+  if (input.seatsPurchased !== undefined) patch.seatsPurchased = input.seatsPurchased;
+
   const memexId = (await primaryMemexIdForOrg(orgId)) ?? "";
   return mutate(
-    {},
+    ctx,
+    { memexId, entity: "org", action: "updated" },
+    async () => {
+      await db.update(orgs).set(patch).where(eq(orgs.id, orgId));
+    },
+  );
+}
+
+export async function refreshOrgDomainVerifiedFlag(
+  orgId: string,
+  ctx: RequestCtx = {},
+): Promise<Mutated<void>> {
+  const memexId = (await primaryMemexIdForOrg(orgId)) ?? "";
+  return mutate(
+    ctx,
     { memexId, entity: "org", action: "updated" },
     async () => {
       const verified = await db.query.verifiedDomains.findFirst({


### PR DESCRIPTION
**Spec:** [spec-348](https://memex.ai/mindset-prod/memex-building-itself/specs/spec-348) — REFACTOR (parent audit spec-345, finding svc-1). **Closes std-8 drift.**

## What
Two Stripe billing writes in `routes/orgs.ts` (`:322` stripeCustomerId, `:392` seatsPurchased) wrote the `orgs` table directly, bypassing the `mutate()` bus — so the billing UI never got the SSE refresh and the writes were unattributed.

Both now flow through a new `mutate({entity:"org",action:"updated"})`-wrapped `updateOrgBilling()` in `services/orgs.ts`, with the request actor threaded through (std-32). Kept separate from `updateOrgSettings` because billing columns come from checkout/webhook, not the settings form — but every org write now goes through one wrapped path.

## Verification
- std-8 static scanner passes for `routes/orgs.ts` with **no allowlist entry**.
- subscription-guard + stripe-webhook integration suites + org mutate-coverage tests green; full server suite green except 4 pre-existing telemetry-ingress failures (reproduce on clean develop).

## ⚠ Merge coordination
The companion scanner fix (spec-347, branch `spec-347-std8-scanner-fix`) adds an allowlist entry for `routes/orgs.ts`. Once **both** land, that entry is redundant and must be dropped (this PR removes the actual bypass, so the scanner passes without it).

Files: `packages/server/src/routes/orgs.ts`, `packages/server/src/services/orgs.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)