### PR TITLE
spec-350: serialize per-doc comment-actions via a Postgres advisory lock [P1]

### DIFF
--- a/packages/server/src/services/comment-actions.integration.test.ts
+++ b/packages/server/src/services/comment-actions.integration.test.ts
@@ -172,3 +172,77 @@ describe("applyCommentAction — Address (agent edit, apply-with-undo)", () => {
     expect(sawOverlap).toBe(false);
   });
 });
+
+// spec-350 (REFACTOR, parent audit spec-345 perf-4): per-doc serialisation moved
+// from a process-local Map to a Postgres advisory lock so it holds ACROSS Cloud
+// Run instances. These tests prove the two properties that matter: same-doc
+// actions serialise (no two run concurrently), and DIFFERENT-doc actions are not
+// blocked by each other (the lock is per-doc, so parallelism is preserved). Both
+// run through the real DB-backed lock — the only path a single test process can
+// observe; the cross-instance guarantee is the same lock object in shared Postgres.
+describe("spec-350: per-doc advisory lock serialises comment-actions", () => {
+  // Build N anchored agent comments on one section and fire Address on all of
+  // them concurrently. The runEdit stub records the max concurrency seen.
+  async function seedDoc(title: string) {
+    const doc = await createDocDraft(memexId, title, "Purpose");
+    createdDocIds.push(doc.id);
+    const section = doc.sections[0];
+    await updateSection(memexId, section.id, "Alpha point. Beta point. Gamma point.");
+    const c1 = await seedWeaknessComment(section.id, "Alpha point.".length);
+    const c2 = await seedWeaknessComment(section.id, "Alpha point. Beta point.".length);
+    return { docId: doc.id, sectionId: section.id, comments: [c1, c2] };
+  }
+
+  it("two concurrent SAME-doc actions never run their edits at the same time", async () => {
+    tagAc(AC_DEC2_ACTION);
+    const { comments } = await seedDoc("Spec350SameDoc");
+
+    let active = 0;
+    let maxConcurrent = 0;
+    const runEdit = async (input: { sectionContent: string }) => {
+      active++;
+      maxConcurrent = Math.max(maxConcurrent, active);
+      await new Promise((r) => setTimeout(r, 30));
+      active--;
+      return input.sectionContent; // no-op edit (markers preserved)
+    };
+
+    await Promise.all(
+      comments.map((c) => applyCommentAction(memexId, c.id, "Address", { runEdit })),
+    );
+
+    // Serialised: at no point did two same-doc edits overlap.
+    expect(maxConcurrent).toBe(1);
+    // Both actions still completed and resolved.
+    for (const c of comments) {
+      const reread = await db.query.docComments.findFirst({ where: eq(docComments.id, c.id) });
+      expect(reread!.resolvedAt).not.toBeNull();
+    }
+  });
+
+  it("actions on DIFFERENT docs are NOT blocked by each other (they overlap)", async () => {
+    tagAc(AC_DEC2_ACTION);
+    const a = await seedDoc("Spec350DiffDocA");
+    const b = await seedDoc("Spec350DiffDocB");
+
+    let active = 0;
+    let maxConcurrent = 0;
+    const runEdit = async (input: { sectionContent: string }) => {
+      active++;
+      maxConcurrent = Math.max(maxConcurrent, active);
+      await new Promise((r) => setTimeout(r, 40));
+      active--;
+      return input.sectionContent;
+    };
+
+    // One action per doc, fired together — different doc ids → different lock
+    // keys → they must be allowed to run concurrently.
+    await Promise.all([
+      applyCommentAction(memexId, a.comments[0].id, "Address", { runEdit }),
+      applyCommentAction(memexId, b.comments[0].id, "Address", { runEdit }),
+    ]);
+
+    // Parallelism preserved: the two different-doc edits overlapped.
+    expect(maxConcurrent).toBe(2);
+  });
+});

--- a/packages/server/src/services/comment-actions.ts
+++ b/packages/server/src/services/comment-actions.ts
@@ -23,7 +23,7 @@
 // scope. The export form remains the read / external-paste path.
 
 import { and, desc, eq, sql } from "drizzle-orm";
-import { db } from "../db/connection.js";
+import { db, sqlClient } from "../db/connection.js";
 import { docComments, docSections, activityLog } from "../db/schema.js";
 import type { DocComment } from "../db/schema.js";
 import type { CommentAction } from "../types/roles.js";
@@ -59,23 +59,62 @@ export interface ApplyActionResult {
 }
 
 // ── Per-doc serialization (spec §3: one agent action at a time per spec) ──
-// In-memory promise chain keyed by docId. Subsequent actions on the same doc
-// queue behind the in-flight one rather than interleaving edits to the source.
-const docLocks = new Map<string, Promise<unknown>>();
-
+// spec-350 (REFACTOR, parent audit spec-345 perf-4): the original guard was a
+// process-local `Map<docId, Promise>` promise-chain. That serialises within ONE
+// Node process only — and prod runs up to 3 Cloud Run instances behind the LB,
+// so two instances handling concurrent comment-actions on the SAME source doc
+// could interleave their edits and corrupt marker/ordering state. The fix moves
+// serialisation into Postgres (shared by every instance) via an advisory lock
+// keyed by the doc id, so same-doc actions serialise across the whole fleet
+// while different-doc actions stay fully parallel.
+//
+// ── Why a SESSION-scoped lock on a reserved connection (not pg_advisory_xact_lock) ──
+// The spec sketched `pg_advisory_xact_lock(<bigint>)` inside the mutating
+// transaction. A transaction-scoped lock auto-releases on COMMIT/ROLLBACK, which
+// is the safer primitive — BUT it only protects writes that live in the SAME
+// transaction as the lock. Here the critical section is NOT one transaction: it
+// runs the agent edit (`runEdit`) and then calls updateSection() + resolveComment()
+// + the audit insert — each of which opens its OWN mutate()-wrapped pool
+// transaction (std-8). Folding all of those onto a single shared `tx` would mean
+// duplicating updateSection's ownership/attribution/re-embed logic and
+// resolveComment's attribution inline — drift-prone, and re-licensing well-tested
+// seams. Worse, holding ONE pool connection open across those inner writes while
+// THEY each need a pool connection is exactly the connection-starvation deadlock
+// default-standards.ts documents from spec-184 ("Do NOT 'fix' that with a held
+// advisory lock … starves the small connection pool … deadlocks the test suite").
+//
+// So we take a SESSION-scoped `pg_advisory_lock` on a DEDICATED reserved
+// connection (sqlClient.reserve()). That connection holds ONLY the lock; the
+// inner writes draw from the rest of the pool (max 5; ≥4 free), so there is no
+// starvation — the precise distinction from the spec-184 case, where the held
+// connection was also needed by the inner writes. The lock is released in
+// `finally` (pg_advisory_unlock) and the connection released back to the pool;
+// even on a crash the session lock auto-releases when the backend connection
+// drops, so it cannot leak indefinitely. Cross-instance serialisation holds
+// because the lock lives in shared Postgres, not in any one Node process.
+//
+// Key derivation: pg_advisory_lock takes a single signed bigint. We derive it
+// from the doc UUID with Postgres' own `hashtextextended(text, 0)` (a stable
+// 64-bit hash), computed server-side so it is identical on every instance. Doc
+// ids are UUIDs (high entropy), so advisory-key collisions across distinct docs
+// are vanishingly unlikely and harmless even if they occurred (two unrelated
+// docs would merely serialise against each other — never corrupt data).
 async function withDocLock<T>(docId: string, fn: () => Promise<T>): Promise<T> {
-  const prior = docLocks.get(docId) ?? Promise.resolve();
-  const run = prior.then(fn, fn);
-  // Keep the chain alive but swallow this run's result/throw for the *next*
-  // waiter — each caller still gets its own result/throw from `run`.
-  docLocks.set(
-    docId,
-    run.then(
-      () => undefined,
-      () => undefined,
-    ),
-  );
-  return run;
+  // Reserve a dedicated connection so the lock is held on a session that is NOT
+  // contended by the inner writes (which use the rest of the pool).
+  const conn = await sqlClient.reserve();
+  try {
+    await conn`SELECT pg_advisory_lock(hashtextextended(${docId}, 0))`;
+    return await fn();
+  } finally {
+    // Best-effort explicit release; the lock would also drop when the reserved
+    // connection is released/closed, but unlocking keeps the session reusable.
+    try {
+      await conn`SELECT pg_advisory_unlock(hashtextextended(${docId}, 0))`;
+    } finally {
+      conn.release();
+    }
+  }
 }
 
 function findAction(comment: DocComment, label: string): CommentAction {


### PR DESCRIPTION
**Spec:** [spec-350](https://memex.ai/mindset-prod/memex-building-itself/specs/spec-350) — REFACTOR (parent audit spec-345). Lens: correctness / multi-instance safety.

## What
Per-doc comment-action serialization moved from a process-local `Map<docId, Promise>` (single-instance only) to a **Postgres advisory lock keyed by the doc id**, so same-doc actions serialize across all Cloud Run instances while different docs stay parallel.

- Session-scoped `pg_advisory_lock` on a **dedicated reserved connection** (released in `finally`, auto-released on drop), keyed by `hashtextextended(docId, 0)`.
- Chosen over transaction-scoped `pg_advisory_xact_lock`: the critical section spans multiple `mutate()`-wrapped transactions (updateSection + resolveComment + audit), and holding one pool connection across them would reintroduce the spec-184 connection-starvation deadlock. The reserved connection holds only the lock; inner writes draw from the rest of the pool.
- std-8 write seams unchanged.

## Verification
- `comment-actions.integration` → 7 passed, incl. two new tests: same-doc actions never overlap (both resolve); different-doc actions do overlap.
- Full server suite green except one pre-existing env-gated emission-key regression (`MEMEX_EMIT_KEY` unset locally).

Files: `packages/server/src/services/comment-actions.ts` (+ integration test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)