### PR TITLE
spec-349: back auth rate-limiting with a cross-instance Postgres store [P1]

### DIFF
--- a/packages/server/drizzle/0105_add_rate_limit_counters.sql
+++ b/packages/server/drizzle/0105_add_rate_limit_counters.sql
@@ -1,0 +1,39 @@
+-- spec-349: cross-instance auth rate-limit store.
+--
+-- Auth rate-limiting (std-13 native auth) was enforced with PROCESS-LOCAL state
+-- (an in-memory Map in services/auth-rate-limit.ts). Prod runs on Cloud Run with
+-- up to 3 instances and no session affinity, so a "5 per 15min" cap effectively
+-- became up to 15 and reset on every cold start — the brute-force / enumeration
+-- guarantee was defeated across instances (parent audit spec-345, finding perf-3).
+--
+-- Fix: back the counter with Postgres so the window is shared across every
+-- instance. Redis was deliberately rejected for the bus (spec-156) to keep the
+-- zero-managed-dependency posture; we reuse the same lever here — a tiny counter
+-- table, incremented with a single atomic INSERT ... ON CONFLICT DO UPDATE so
+-- concurrent instances serialise on the row lock (no lost increments, no races).
+--
+-- The table is intentionally NOT tenant-scoped: rate-limit keys are IP / email /
+-- user-id, not memex-id, so RLS is left DISABLED (the runtime role reads/writes
+-- it directly). Stale rows are reaped lazily by the limiter and can be swept by
+-- housekeeping; `reset_at` carries the window boundary so the count is only ever
+-- read as live while now() < reset_at.
+CREATE TABLE IF NOT EXISTS rate_limit_counters (
+  scope text NOT NULL,
+  key text NOT NULL,
+  count integer NOT NULL,
+  reset_at timestamptz NOT NULL,
+  PRIMARY KEY (scope, key)
+);
+--> statement-breakpoint
+
+-- Lets the lazy / scheduled reaper drop expired windows by `reset_at` without a
+-- full scan.
+CREATE INDEX IF NOT EXISTS rate_limit_counters_reset_at_idx ON rate_limit_counters (reset_at);
+--> statement-breakpoint
+
+-- The restricted runtime role (memex_app, created in 0081) is the one that serves
+-- requests on Cloud Run. ALTER DEFAULT PRIVILEGES in 0081 already grants on tables
+-- created afterwards, but — mirroring migration 0100 — we GRANT explicitly so the
+-- privilege does not depend on the creating role matching the default-privileges
+-- grantor. No RLS is enabled on this table, so memex_app operates on it directly.
+GRANT SELECT, INSERT, UPDATE, DELETE ON rate_limit_counters TO memex_app;

--- a/packages/server/src/__regression__/schema-state.regression.test.ts
+++ b/packages/server/src/__regression__/schema-state.regression.test.ts
@@ -47,6 +47,7 @@ const EXPECTED_TABLES = [
   "cli_auth_requests",
   "tags",
   "document_tags",
+  "rate_limit_counters",
 ] as const;
 
 describe("regression: schema state", () => {

--- a/packages/server/src/__security__/oauth-register-rate-limit.security.test.ts
+++ b/packages/server/src/__security__/oauth-register-rate-limit.security.test.ts
@@ -23,10 +23,10 @@ const AC_5 = "mindset-prod/memex-building-itself/specs/spec-253/acs/ac-5";
 
 const originalFlag = process.env.OAUTH_ENABLED;
 
-beforeAll(() => {
+beforeAll(async () => {
   process.env.OAUTH_ENABLED = "1";
-  // Clear the in-memory bucket store so prior tests don't pollute this one.
-  resetRateLimits();
+  // Clear the shared rate-limit table so prior tests don't pollute this one.
+  await resetRateLimits();
 });
 
 afterAll(() => {

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -3056,3 +3056,27 @@ export const stripeEvents = pgTable(
 
 export type StripeEvent = InferSelectModel<typeof stripeEvents>;
 export type StripeEventInsert = InferInsertModel<typeof stripeEvents>;
+
+// ── spec-349: cross-instance auth rate-limit store ───────────────────────────
+// Backs services/auth-rate-limit.ts. The in-memory Map it replaced multiplied
+// every limit by the Cloud Run instance count (3) and reset on cold start
+// (spec-345 perf-3). One row per (scope, key); the limiter increments it with a
+// single atomic INSERT ... ON CONFLICT DO UPDATE so concurrent instances
+// serialise on the row lock. NOT tenant-scoped (keys are IP / email / user-id),
+// so no RLS — see migration 0105.
+export const rateLimitCounters = pgTable(
+  "rate_limit_counters",
+  {
+    scope: text("scope").notNull(),
+    key: text("key").notNull(),
+    count: integer("count").notNull(),
+    resetAt: timestamp("reset_at", { withTimezone: true }).notNull(),
+  },
+  (table) => [
+    primaryKey({ columns: [table.scope, table.key] }),
+    index("rate_limit_counters_reset_at_idx").on(table.resetAt),
+  ]
+);
+
+export type RateLimitCounter = InferSelectModel<typeof rateLimitCounters>;
+export type RateLimitCounterInsert = InferInsertModel<typeof rateLimitCounters>;

--- a/packages/server/src/routes/auth-signup.integration.test.ts
+++ b/packages/server/src/routes/auth-signup.integration.test.ts
@@ -61,10 +61,10 @@ beforeAll(async () => {
   // Clean slate for the dev user so rate limiters and previous tokens don't interfere.
 });
 
-beforeEach(() => {
+beforeEach(async () => {
   sender = new CapturingSender();
   setEmailSender(sender);
-  resetRateLimits();
+  await resetRateLimits();
 });
 
 afterAll(async () => {

--- a/packages/server/src/routes/auth-visitor-merge.integration.test.ts
+++ b/packages/server/src/routes/auth-visitor-merge.integration.test.ts
@@ -81,10 +81,10 @@ async function visitorRow(id: string) {
   return row;
 }
 
-beforeEach(() => {
+beforeEach(async () => {
   sender = new CapturingSender();
   setEmailSender(sender);
-  resetRateLimits();
+  await resetRateLimits();
 });
 
 afterAll(async () => {

--- a/packages/server/src/routes/auth/magic-link.ts
+++ b/packages/server/src/routes/auth/magic-link.ts
@@ -54,7 +54,7 @@ magicLink.post("/", async (c) => {
   const body = await readJsonBody<{ email?: unknown }>(c);
   const email = requireString(body?.email, "email");
 
-  const rl = rateLimit("magicLink", email.toLowerCase(), AUTH_LIMITS.magicLink);
+  const rl = await rateLimit("magicLink", email.toLowerCase(), AUTH_LIMITS.magicLink);
   if (!rl.ok) {
     return c.json(
       { error: "Too many magic link requests", retryAfterSec: rl.retryAfterSec },

--- a/packages/server/src/routes/auth/password.ts
+++ b/packages/server/src/routes/auth/password.ts
@@ -28,7 +28,7 @@ export const password = new Hono<MemexResolverEnv & SessionEnv>();
 // blocks sensitive actions until verification.
 password.post("/signup", async (c) => {
   const ip = clientIp(c);
-  const rl = rateLimit("signup", ip, AUTH_LIMITS.signup);
+  const rl = await rateLimit("signup", ip, AUTH_LIMITS.signup);
   if (!rl.ok) {
     return c.json(
       { error: "Too many signup attempts", retryAfterSec: rl.retryAfterSec },
@@ -107,7 +107,7 @@ password.post("/signup", async (c) => {
 // so it can't be ground through.
 password.post("/probe", async (c) => {
   const ip = clientIp(c);
-  const rl = rateLimit("probe", ip, AUTH_LIMITS.probe);
+  const rl = await rateLimit("probe", ip, AUTH_LIMITS.probe);
   if (!rl.ok) {
     return c.json(
       { error: "Too many probe attempts", retryAfterSec: rl.retryAfterSec },
@@ -131,7 +131,7 @@ password.post("/login", async (c) => {
   const email = requireString(body?.email, "email");
   const passwordStr = requireString(body?.password, "password");
 
-  const rl = rateLimit("login", `${ip}|${email.toLowerCase()}`, AUTH_LIMITS.login);
+  const rl = await rateLimit("login", `${ip}|${email.toLowerCase()}`, AUTH_LIMITS.login);
   if (!rl.ok) {
     return c.json(
       { error: "Too many login attempts", retryAfterSec: rl.retryAfterSec },
@@ -210,7 +210,7 @@ password.post("/resend-verification", sessionMiddleware, async (c) => {
     return c.json({ ok: true, alreadyVerified: true });
   }
 
-  const rl = rateLimit("resendVerification", user.id, AUTH_LIMITS.resendVerification);
+  const rl = await rateLimit("resendVerification", user.id, AUTH_LIMITS.resendVerification);
   if (!rl.ok) {
     return c.json(
       { error: "Too many resend attempts", retryAfterSec: rl.retryAfterSec },

--- a/packages/server/src/routes/auth/reset.ts
+++ b/packages/server/src/routes/auth/reset.ts
@@ -22,7 +22,7 @@ reset.post("/", async (c) => {
   const body = await readJsonBody<{ email?: unknown }>(c);
   const email = requireString(body?.email, "email");
 
-  const rl = rateLimit("passwordReset", email.toLowerCase(), AUTH_LIMITS.passwordReset);
+  const rl = await rateLimit("passwordReset", email.toLowerCase(), AUTH_LIMITS.passwordReset);
   if (!rl.ok) {
     return c.json(
       { error: "Too many reset requests", retryAfterSec: rl.retryAfterSec },

--- a/packages/server/src/routes/guide-public-mindset-website.test.ts
+++ b/packages/server/src/routes/guide-public-mindset-website.test.ts
@@ -81,9 +81,9 @@ async function mintSession(
   });
 }
 
-beforeEach(() => {
+beforeEach(async () => {
   vi.stubEnv("AUTH_JWT_SECRET", "x".repeat(48));
-  resetRateLimits();
+  await resetRateLimits();
 });
 afterEach(() => {
   vi.unstubAllEnvs();

--- a/packages/server/src/routes/guide-public.test.ts
+++ b/packages/server/src/routes/guide-public.test.ts
@@ -92,9 +92,9 @@ function makeApp(): Hono {
 
 const ALLOWED_ORIGIN = "https://www.memex.ai";
 
-beforeEach(() => {
+beforeEach(async () => {
   vi.stubEnv("AUTH_JWT_SECRET", "x".repeat(48));
-  resetRateLimits();
+  await resetRateLimits();
   streamArgs.last = null;
 });
 afterEach(() => {

--- a/packages/server/src/routes/guide-public.ts
+++ b/packages/server/src/routes/guide-public.ts
@@ -230,7 +230,7 @@ export function createGuidePublicRouter(upgradeWebSocket: UpgradeWebSocket): Hon
 
     // IP rate-limit (t-11 → ac-15). Over-limit → 429.
     const ip = clientIp(c);
-    const rl = rateLimit("guideSession", ip, AUTH_LIMITS.guideSession);
+    const rl = await rateLimit("guideSession", ip, AUTH_LIMITS.guideSession);
     if (!rl.ok) {
       c.header("Retry-After", String(rl.retryAfterSec ?? 1));
       return c.json(

--- a/packages/server/src/routes/oauth/register.ts
+++ b/packages/server/src/routes/oauth/register.ts
@@ -19,7 +19,7 @@ register.post("/", async (c) => {
   // generous for legitimate clients (which register once and reuse the
   // client_id) but cuts off bulk-registration probes.
   const ip = clientIp(c);
-  const rl = rateLimit("oauthRegister", ip, AUTH_LIMITS.oauthRegister);
+  const rl = await rateLimit("oauthRegister", ip, AUTH_LIMITS.oauthRegister);
   if (!rl.ok) {
     c.header("Retry-After", String(rl.retryAfterSec ?? 1));
     return c.json(

--- a/packages/server/src/services/auth-rate-limit.test.ts
+++ b/packages/server/src/services/auth-rate-limit.test.ts
@@ -1,32 +1,48 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import {
   rateLimit,
   resetRateLimits,
   AUTH_LIMITS,
 } from "./auth-rate-limit.js";
 
-// Unit coverage for the sliding-window rate limiter. Pure in-memory — no DB, no network.
-// Each test resets global buckets so ordering doesn't matter.
+// Coverage for the cross-instance (Postgres-backed) rate limiter (spec-349).
+// The counter lives in the `rate_limit_counters` table, NOT in process memory,
+// so these tests run against the real test DB. Each test truncates the table
+// first so ordering doesn't matter. Keys are randomised per test so parallel
+// workers (which share neither table — each owns a private DB clone — but run
+// the same file) never collide on a key within a clone.
 
-beforeEach(() => resetRateLimits());
+let n = 0;
+function uniqueKey(label = "key"): string {
+  // Worker-unique-ish: include the worker id and a monotonic counter so two
+  // tests in the same file never reuse a (scope,key) row (std-37).
+  const worker = process.env.VITEST_POOL_ID ?? "0";
+  return `${label}-w${worker}-${n++}-${Math.random().toString(36).slice(2)}`;
+}
+
+beforeEach(async () => {
+  await resetRateLimits();
+});
 
 describe("rateLimit", () => {
-  it("allows attempts up to max and returns ok=true with decreasing remaining", () => {
+  it("allows attempts up to max and returns ok=true with decreasing remaining", async () => {
     const config = { max: 3, windowMs: 60_000 };
-    const r1 = rateLimit("scope", "key", config);
-    const r2 = rateLimit("scope", "key", config);
-    const r3 = rateLimit("scope", "key", config);
+    const key = uniqueKey();
+    const r1 = await rateLimit("scope", key, config);
+    const r2 = await rateLimit("scope", key, config);
+    const r3 = await rateLimit("scope", key, config);
 
     expect(r1).toEqual({ ok: true, remaining: 2 });
     expect(r2).toEqual({ ok: true, remaining: 1 });
     expect(r3).toEqual({ ok: true, remaining: 0 });
   });
 
-  it("blocks once the counter reaches max and returns retryAfterSec", () => {
+  it("blocks once the counter reaches max and returns retryAfterSec", async () => {
     const config = { max: 2, windowMs: 60_000 };
-    rateLimit("scope", "key", config);
-    rateLimit("scope", "key", config);
-    const blocked = rateLimit("scope", "key", config);
+    const key = uniqueKey();
+    await rateLimit("scope", key, config);
+    await rateLimit("scope", key, config);
+    const blocked = await rateLimit("scope", key, config);
 
     expect(blocked.ok).toBe(false);
     expect(blocked.remaining).toBe(0);
@@ -35,55 +51,126 @@ describe("rateLimit", () => {
   });
 
   it("resets when the window expires (new bucket, counter=1)", async () => {
-    const config = { max: 1, windowMs: 20 };
-    const first = rateLimit("scope", "key", config);
+    const config = { max: 1, windowMs: 50 };
+    const key = uniqueKey();
+    const first = await rateLimit("scope", key, config);
     expect(first.ok).toBe(true);
-    const blocked = rateLimit("scope", "key", config);
+    const blocked = await rateLimit("scope", key, config);
     expect(blocked.ok).toBe(false);
 
-    // Wait out the window — the 20ms bound keeps this fast but deterministic.
-    await new Promise((r) => setTimeout(r, 30));
+    // Wait out the window — the DB stamps reset_at = now()+50ms, so a short
+    // wait lets the next call start a fresh window.
+    await new Promise((r) => setTimeout(r, 80));
 
-    const afterWindow = rateLimit("scope", "key", config);
+    const afterWindow = await rateLimit("scope", key, config);
     expect(afterWindow.ok).toBe(true);
     expect(afterWindow.remaining).toBe(0);
   });
 
-  it("keeps different scopes independent", () => {
+  it("keeps different scopes independent", async () => {
     const config = { max: 1, windowMs: 60_000 };
-    expect(rateLimit("login", "same-key", config).ok).toBe(true);
-    expect(rateLimit("signup", "same-key", config).ok).toBe(true);
-    // Both scopes are at max; third call in either blocks.
-    expect(rateLimit("login", "same-key", config).ok).toBe(false);
-    expect(rateLimit("signup", "same-key", config).ok).toBe(false);
+    const key = uniqueKey("shared");
+    expect((await rateLimit("login", key, config)).ok).toBe(true);
+    expect((await rateLimit("signup", key, config)).ok).toBe(true);
+    // Both scopes are at max; second call in either blocks.
+    expect((await rateLimit("login", key, config)).ok).toBe(false);
+    expect((await rateLimit("signup", key, config)).ok).toBe(false);
   });
 
-  it("keeps different keys within a scope independent", () => {
+  it("keeps different keys within a scope independent", async () => {
     const config = { max: 1, windowMs: 60_000 };
-    expect(rateLimit("scope", "key-a", config).ok).toBe(true);
-    expect(rateLimit("scope", "key-b", config).ok).toBe(true);
-    expect(rateLimit("scope", "key-a", config).ok).toBe(false);
-    expect(rateLimit("scope", "key-b", config).ok).toBe(false);
+    const keyA = uniqueKey("a");
+    const keyB = uniqueKey("b");
+    expect((await rateLimit("scope", keyA, config)).ok).toBe(true);
+    expect((await rateLimit("scope", keyB, config)).ok).toBe(true);
+    expect((await rateLimit("scope", keyA, config)).ok).toBe(false);
+    expect((await rateLimit("scope", keyB, config)).ok).toBe(false);
   });
 
-  it("floors retryAfterSec at 1 even when the window has just milliseconds left", () => {
-    // Hit the limiter, then manipulate nothing — the first block should have retryAfterSec
-    // rounded up via Math.ceil; assert it's never <1 so the client's 'Retry-After: 0' bug
-    // class is impossible.
+  it("floors retryAfterSec at 1 even when the window has just milliseconds left", async () => {
     const config = { max: 1, windowMs: 100 };
-    rateLimit("scope", "key", config);
-    const blocked = rateLimit("scope", "key", config);
+    const key = uniqueKey();
+    await rateLimit("scope", key, config);
+    const blocked = await rateLimit("scope", key, config);
     expect(blocked.retryAfterSec).toBeGreaterThanOrEqual(1);
+  });
+
+  it("does not let the counter grow unbounded once blocked (clamps at max+1)", async () => {
+    // A hammered key must keep reporting blocked, but the stored count is clamped
+    // so the row can't overflow / drift. We can't read `count` from the public
+    // API, but we CAN assert that many over-limit calls all stay blocked and the
+    // window doesn't keep getting pushed out by the increments.
+    const config = { max: 1, windowMs: 60_000 };
+    const key = uniqueKey();
+    expect((await rateLimit("scope", key, config)).ok).toBe(true);
+    for (let i = 0; i < 20; i++) {
+      const r = await rateLimit("scope", key, config);
+      expect(r.ok).toBe(false);
+      expect(r.retryAfterSec).toBeLessThanOrEqual(60);
+    }
+  });
+});
+
+// The headline guarantee: the limit must hold across SEPARATE process instances
+// (Cloud Run runs up to 3 with no session affinity). The old in-memory Map
+// multiplied the limit by the instance count and reset on cold start
+// (spec-345 perf-3 / spec-349). Here we simulate a second instance by resetting
+// the module registry and re-importing — that yields a FRESH module with FRESH
+// in-memory state — then prove the counter still blocks because it lives in the
+// shared Postgres table, not in the module.
+describe("cross-instance (survives a fresh process / module reload)", () => {
+  it("a key blocked on 'instance A' is still blocked on a freshly-loaded 'instance B'", async () => {
+    const config = { max: 3, windowMs: 60_000 };
+    const key = uniqueKey("xinst");
+
+    // ── Instance A: exhaust the limit. ──
+    const a = await import("./auth-rate-limit.js");
+    await a.resetRateLimits();
+    expect((await a.rateLimit("login", key, config)).ok).toBe(true);
+    expect((await a.rateLimit("login", key, config)).ok).toBe(true);
+    expect((await a.rateLimit("login", key, config)).ok).toBe(true);
+    const aBlocked = await a.rateLimit("login", key, config);
+    expect(aBlocked.ok).toBe(false); // 4th over a max of 3
+
+    // ── Instance B: a brand-new module load (no shared in-memory state). ──
+    vi.resetModules();
+    const b = await import("./auth-rate-limit.js");
+    // Sanity: it really is a different module object (fresh closure state).
+    expect(b).not.toBe(a);
+    // Do NOT reset — a real new instance starts cold but the DB row persists.
+    const bResult = await b.rateLimit("login", key, config);
+
+    // If the store were process-local, instance B would see count=1 and ALLOW.
+    // Backed by Postgres, instance B sees the exhausted window and BLOCKS.
+    expect(bResult.ok).toBe(false);
+    expect(bResult.retryAfterSec).toBeGreaterThan(0);
+  });
+
+  it("two concurrent instances cannot both slip an attempt past max (atomic increment)", async () => {
+    // Fire max+5 calls CONCURRENTLY for the same key. A read-modify-write store
+    // would lose increments under contention and allow more than `max` through;
+    // the single atomic upsert must allow exactly `max`.
+    const max = 5;
+    const config = { max, windowMs: 60_000 };
+    const key = uniqueKey("concurrent");
+
+    const results = await Promise.all(
+      Array.from({ length: max + 5 }, () => rateLimit("login", key, config)),
+    );
+    const allowed = results.filter((r) => r.ok).length;
+
+    expect(allowed).toBe(max);
   });
 });
 
 describe("resetRateLimits", () => {
-  it("wipes all counters so a previously-blocked key is allowed again", () => {
+  it("wipes all counters so a previously-blocked key is allowed again", async () => {
     const config = { max: 1, windowMs: 60_000 };
-    rateLimit("scope", "key", config);
-    expect(rateLimit("scope", "key", config).ok).toBe(false);
-    resetRateLimits();
-    expect(rateLimit("scope", "key", config).ok).toBe(true);
+    const key = uniqueKey();
+    await rateLimit("scope", key, config);
+    expect((await rateLimit("scope", key, config)).ok).toBe(false);
+    await resetRateLimits();
+    expect((await rateLimit("scope", key, config)).ok).toBe(true);
   });
 });
 

--- a/packages/server/src/services/auth-rate-limit.ts
+++ b/packages/server/src/services/auth-rate-limit.ts
@@ -1,9 +1,25 @@
-// In-memory sliding-window rate limiter for auth endpoints. Not distributed — OK for a
-// single-instance deployment; multi-replica prod needs a shared store (Redis) later.
+// Cross-instance sliding-window rate limiter for auth endpoints (spec-349).
+//
+// Counters live in the `rate_limit_counters` Postgres table, NOT in process
+// memory. Prod runs on Cloud Run with up to 3 instances and no session affinity,
+// so the old in-memory Map multiplied every limit by the instance count and reset
+// on cold start — the brute-force / enumeration guarantee was defeated across
+// instances (spec-345 perf-3). Redis was deliberately rejected for the bus
+// (spec-156) to keep the zero-managed-dependency posture; we reuse Postgres here
+// for the same reason.
+//
+// Each call is a SINGLE atomic `INSERT ... ON CONFLICT DO UPDATE ... RETURNING`,
+// so concurrent requests across instances serialise on the row lock — no lost
+// increments, no read-modify-write race. The window boundary (`reset_at`) and
+// the "is this window still live?" comparison are both computed in-DB via now(),
+// so instances agree regardless of clock skew.
 //
 // Usage:
-//   const result = rateLimit("login", `${ip}|${email}`, { max: 5, windowMs: 15 * 60 * 1000 });
+//   const result = await rateLimit("login", `${ip}|${email}`, { max: 5, windowMs: 15 * 60 * 1000 });
 //   if (!result.ok) return c.json({ error, retryAfterSec: result.retryAfterSec }, 429);
+
+import { sql } from "drizzle-orm";
+import { db } from "../db/connection.js";
 
 export interface RateLimitConfig {
   /** Max attempts per window before blocking. */
@@ -20,53 +36,67 @@ export interface RateLimitResult {
   retryAfterSec?: number;
 }
 
-interface Bucket {
-  count: number;
-  resetAt: number; // epoch ms when the window ends
-}
-
-// `buckets[scope][key]` maps a scope (e.g. "login") + a key (e.g. "1.2.3.4|alice@x.com")
-// to its current counter. Stale buckets are evicted lazily on access.
-const buckets = new Map<string, Map<string, Bucket>>();
-
-function getScopeMap(scope: string): Map<string, Bucket> {
-  let m = buckets.get(scope);
-  if (!m) {
-    m = new Map();
-    buckets.set(scope, m);
-  }
-  return m;
-}
-
-export function rateLimit(
+/**
+ * Atomically record one attempt against (scope, key) and report whether it is
+ * within the limit. Cross-instance correct: the counter is a Postgres row, and
+ * the increment is a single upsert so concurrent callers can't lose increments.
+ *
+ * The upsert:
+ *   - inserts {count: 1, reset_at: now()+window} on first hit;
+ *   - on conflict, if the existing window has expired (reset_at <= now()) it
+ *     STARTS A FRESH window (count=1, new reset_at) — the sliding reset;
+ *   - otherwise it increments, clamped at max+1 so a hammered key's count can't
+ *     grow without bound (it only ever needs to read as "> max" once blocked).
+ * RETURNING gives the post-increment count and the live retry-after, so the
+ * ok/blocked decision is derived purely from DB state.
+ */
+export async function rateLimit(
   scope: string,
   key: string,
   config: RateLimitConfig
-): RateLimitResult {
-  const now = Date.now();
-  const scopeMap = getScopeMap(scope);
+): Promise<RateLimitResult> {
+  // Window length as a Postgres interval (milliseconds → supports sub-second
+  // windows, which the unit tests exercise). make_interval has no ms arg, so we
+  // multiply the 1-millisecond unit interval.
+  const windowMs = config.windowMs;
+  const maxPlusOne = config.max + 1;
 
-  const existing = scopeMap.get(key);
-  if (!existing || existing.resetAt <= now) {
-    scopeMap.set(key, { count: 1, resetAt: now + config.windowMs });
-    return { ok: true, remaining: config.max - 1 };
+  const rows = (await db.execute(sql`
+    INSERT INTO rate_limit_counters (scope, key, count, reset_at)
+    VALUES (${scope}, ${key}, 1, now() + (${windowMs} * INTERVAL '1 millisecond'))
+    ON CONFLICT (scope, key) DO UPDATE SET
+      count = CASE
+        WHEN rate_limit_counters.reset_at <= now() THEN 1
+        ELSE LEAST(rate_limit_counters.count + 1, ${maxPlusOne})
+      END,
+      reset_at = CASE
+        WHEN rate_limit_counters.reset_at <= now()
+          THEN now() + (${windowMs} * INTERVAL '1 millisecond')
+        ELSE rate_limit_counters.reset_at
+      END
+    RETURNING
+      count AS count,
+      GREATEST(1, CEIL(EXTRACT(EPOCH FROM (reset_at - now()))))::int AS retry_after_sec
+  `)) as unknown as Array<{ count: number; retry_after_sec: number }>;
+
+  const row = rows[0];
+  // Defensive: a RETURNING upsert always yields exactly one row. If the driver
+  // ever hands back nothing, fail OPEN is the wrong call for a security control —
+  // but a missing row here means the write didn't happen, so treat as allowed-
+  // first-attempt to avoid locking every user out on an infra blip.
+  const count = row?.count ?? 1;
+  const retryAfterSec = row?.retry_after_sec ?? 1;
+
+  if (count > config.max) {
+    return { ok: false, remaining: 0, retryAfterSec };
   }
-
-  if (existing.count >= config.max) {
-    return {
-      ok: false,
-      remaining: 0,
-      retryAfterSec: Math.max(1, Math.ceil((existing.resetAt - now) / 1000)),
-    };
-  }
-
-  existing.count += 1;
-  return { ok: true, remaining: config.max - existing.count };
+  return { ok: true, remaining: config.max - count };
 }
 
-// Test hook: wipe all counters so tests don't interfere with each other.
-export function resetRateLimits(): void {
-  buckets.clear();
+// Test hook: wipe all counters so tests don't interfere with each other. Now a
+// TRUNCATE of the shared table rather than clearing an in-memory Map.
+export async function resetRateLimits(): Promise<void> {
+  await db.execute(sql`TRUNCATE rate_limit_counters`);
 }
 
 // Pre-configured limits for the auth surface area. Tune per-endpoint.


### PR DESCRIPTION
**Spec:** [spec-349](https://memex.ai/mindset-prod/memex-building-itself/specs/spec-349) — REFACTOR (parent audit spec-345). Lens: correctness / multi-instance safety.

## What
Auth rate-limiting moved from a process-local `Map` (limit multiplied by instance count, reset on cold start) to a new Postgres `rate_limit_counters` table — so limits hold across all Cloud Run instances.

- Each `rateLimit()` is a single atomic `INSERT ... ON CONFLICT DO UPDATE ... RETURNING`; concurrent requests serialize on the row lock (no lost increments). Window math via in-DB `now()` (no clock-skew disagreement). Count clamped at `max+1`.
- **Redis deliberately avoided** to preserve the zero-managed-dependency posture (same lever as spec-156's bus decision).
- Migration `0105_add_rate_limit_counters.sql` (table + index + `memex_app` grant; non-tenant-scoped, RLS off — keys are IP/email/user-id).
- Client-facing contract byte-for-byte preserved (same 429s, `Retry-After`, messages, `AUTH_LIMITS`) across all 8 endpoints; `rateLimit()`/`resetRateLimits()` now async.

## Verification
- `auth-rate-limit.test` → 11 passed incl. cross-instance (survives fresh process) + concurrency (exactly `max` allowed).
- Full server suite green except one pre-existing env-gated emission-key regression.

## Follow-up
No active reaper for expired rows (index on `reset_at` in place for a future housekeeping sweep) — worth a scheduled `DELETE ... WHERE reset_at < now()` if IP cardinality is high in prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)