### PR TITLE
fix(spec-171): billing-display gaps (issue-15 + issue-16)

### DIFF
--- a/packages/server/src/routes/orgs.subscription-billing.integration.test.ts
+++ b/packages/server/src/routes/orgs.subscription-billing.integration.test.ts
@@ -1,0 +1,221 @@
+// spec-171 issue-15 — GET /current/subscription surfaces billing cycle + next
+// billing date.
+//
+// The webhook persists planTier/seatsPurchased/stripeSubscriptionId but NOT the
+// billing interval or current_period_end, so the /org billing page rendered "—"
+// for "Billing cycle" and "Next billing date". The GET endpoint now retrieves
+// the live Stripe subscription (when there is one) and derives:
+//   - billingCycle  ← the price id, via resolvePlanFromPriceId (same source of
+//                     truth the webhook uses for the tier)
+//   - currentPeriodEnd ← current_period_end (unix → ISO)
+//
+// This suite proves:
+//   (1) an org WITH a subscription → cycle + next-date are present (Stripe mocked).
+//   (2) a free org (no subscription) → both null, Stripe never called.
+//   (3) resilience: a Stripe failure does NOT 500 — we return the persisted data
+//       with cycle/date null.
+//
+// Mirrors orgs.subscription-guard.integration.test.ts: real Postgres org rows,
+// the Stripe network surface mocked via vi.mock + importOriginal, dev-mode
+// session auto-resolves the single admin membership so adminGate passes.
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from "vitest";
+import { eq, inArray } from "drizzle-orm";
+import { db } from "../db/connection.js";
+import { memexes, namespaces, orgs, orgMemberships, users } from "../db/schema.js";
+import { upsertUserByEmail } from "../services/users.js";
+
+// NOTE: issue-15 (surface billing cycle + next-date on the GET) has no dedicated
+// spec-171 AC — the closest, ac-39, is about which org the checkout targets
+// (issue-16), not the GET enrichment. Rather than mis-tag an unrelated AC, this
+// suite is left untagged; it still runs in CI as a plain integration test.
+
+// Force dev mode so sessionMiddleware logs in as dev@memex.ai without a real JWT.
+const originalClientId = process.env.GOOGLE_CLIENT_ID;
+beforeAll(() => {
+  delete process.env.GOOGLE_CLIENT_ID;
+  vi.resetModules();
+});
+
+// Mock only getSubscription; everything else in stripe.js stays real so the
+// real resolvePlanFromPriceId runs against the env price ids set below.
+const { getSubscriptionMock } = vi.hoisted(() => ({
+  getSubscriptionMock: vi.fn(),
+}));
+vi.mock("../services/stripe.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../services/stripe.js")>();
+  return {
+    ...actual,
+    getSubscription: getSubscriptionMock,
+  };
+});
+
+import { Hono } from "hono";
+import { orgsCurrentRouter } from "./orgs.js";
+import { errorHandler } from "../middleware/error-handler.js";
+
+const app = new Hono();
+app.onError(errorHandler);
+app.route("/api/orgs", orgsCurrentRouter);
+
+// resolvePlanFromPriceId reads these env vars; pin them so the real mapping runs.
+const ANNUAL_PRICE = "price_premium_annual_test";
+const originalAnnualPrice = process.env.STRIPE_PREMIUM_ANNUAL_PRICE_ID;
+beforeAll(() => {
+  process.env.STRIPE_PREMIUM_ANNUAL_PRICE_ID = ANNUAL_PRICE;
+});
+
+const createdMemexIds: string[] = [];
+const createdUserIds: string[] = [];
+
+afterAll(async () => {
+  if (originalClientId !== undefined) process.env.GOOGLE_CLIENT_ID = originalClientId;
+  if (originalAnnualPrice !== undefined) {
+    process.env.STRIPE_PREMIUM_ANNUAL_PRICE_ID = originalAnnualPrice;
+  } else {
+    delete process.env.STRIPE_PREMIUM_ANNUAL_PRICE_ID;
+  }
+  if (createdUserIds.length) {
+    await db.delete(users).where(inArray(users.id, createdUserIds)).catch(() => {});
+  }
+  if (createdMemexIds.length) {
+    await db.delete(memexes).where(inArray(memexes.id, createdMemexIds)).catch(() => {});
+  }
+});
+
+beforeEach(() => {
+  getSubscriptionMock.mockReset();
+});
+
+function uniqueSlug(prefix: string): string {
+  return `${prefix}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`.toLowerCase();
+}
+
+async function seedOrgWithAdmin(orgPatch: Partial<typeof orgs.$inferInsert>): Promise<{ orgId: string }> {
+  const slug = uniqueSlug("billing");
+  const dev = await upsertUserByEmail("dev@memex.ai");
+  if (!createdUserIds.includes(dev.id)) createdUserIds.push(dev.id);
+
+  const [ns] = await db.insert(namespaces).values({ slug, kind: "org" }).returning();
+  const [org] = await db
+    .insert(orgs)
+    .values({ namespaceId: ns.id, name: "Billing Test Org", stripeCustomerId: `cus_${slug}`, ...orgPatch })
+    .returning();
+  await db.update(namespaces).set({ ownerOrgId: org.id }).where(eq(namespaces.id, ns.id));
+  const [mx] = await db.insert(memexes).values({ namespaceId: ns.id, slug: "main", name: "Billing Test" }).returning();
+  createdMemexIds.push(mx.id);
+
+  await db.delete(orgMemberships).where(eq(orgMemberships.userId, dev.id));
+  await db.update(users).set({ namespaceId: null }).where(eq(users.id, dev.id));
+  await db.delete(namespaces).where(eq(namespaces.ownerUserId, dev.id));
+  await db.update(users).set({ namespaceId: ns.id }).where(eq(users.id, dev.id));
+  await db.insert(orgMemberships).values({ userId: dev.id, orgId: org.id, role: "administrator" });
+
+  return { orgId: org.id };
+}
+
+async function getSubscriptionEndpoint(): Promise<Response> {
+  return app.request("/api/orgs/current/subscription", {
+    headers: { "content-type": "application/json" },
+  });
+}
+
+interface SubBody {
+  tier: string;
+  seatsPurchased: number | null;
+  billingCycle: "monthly" | "annual" | null;
+  currentPeriodEnd: string | null;
+}
+
+describe("spec-171 issue-15: GET subscription surfaces cycle + next billing date", () => {
+  it("returns billingCycle + currentPeriodEnd when the org has a live subscription", async () => {
+
+    await seedOrgWithAdmin({
+      stripeSubscriptionId: "sub_live_123",
+      planTier: "premium",
+      seatsPurchased: 5,
+    });
+
+    const periodEndUnix = 1_750_000_000; // arbitrary fixed unix ts
+    getSubscriptionMock.mockResolvedValue({
+      id: "sub_live_123",
+      object: "subscription",
+      status: "active",
+      current_period_end: periodEndUnix,
+      items: { data: [{ id: "si_1", price: { id: ANNUAL_PRICE }, quantity: 5 }] },
+    });
+
+    const res = await getSubscriptionEndpoint();
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as SubBody;
+
+    expect(getSubscriptionMock).toHaveBeenCalledWith("sub_live_123");
+    expect(body.tier).toBe("premium");
+    expect(body.billingCycle).toBe("annual");
+    expect(body.currentPeriodEnd).toBe(new Date(periodEndUnix * 1000).toISOString());
+  });
+
+  it("reads current_period_end off the first item when the top-level field is absent", async () => {
+
+    await seedOrgWithAdmin({
+      stripeSubscriptionId: "sub_item_period",
+      planTier: "premium",
+      seatsPurchased: 2,
+    });
+
+    const periodEndUnix = 1_760_000_000;
+    getSubscriptionMock.mockResolvedValue({
+      id: "sub_item_period",
+      object: "subscription",
+      status: "active",
+      // no top-level current_period_end (newer API versions)
+      items: {
+        data: [{ id: "si_1", price: { id: ANNUAL_PRICE }, quantity: 2, current_period_end: periodEndUnix }],
+      },
+    });
+
+    const res = await getSubscriptionEndpoint();
+    const body = (await res.json()) as SubBody;
+    expect(body.currentPeriodEnd).toBe(new Date(periodEndUnix * 1000).toISOString());
+    expect(body.billingCycle).toBe("annual");
+  });
+
+  it("returns nulls and never calls Stripe for a free org with no subscription", async () => {
+
+    await seedOrgWithAdmin({
+      stripeSubscriptionId: null,
+      planTier: null,
+      seatsPurchased: null,
+    });
+
+    const res = await getSubscriptionEndpoint();
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as SubBody;
+
+    expect(getSubscriptionMock).not.toHaveBeenCalled();
+    expect(body.tier).toBe("free");
+    expect(body.billingCycle).toBeNull();
+    expect(body.currentPeriodEnd).toBeNull();
+  });
+
+  it("does not 500 the billing page when the Stripe fetch fails", async () => {
+
+    await seedOrgWithAdmin({
+      stripeSubscriptionId: "sub_stripe_down",
+      planTier: "premium",
+      seatsPurchased: 4,
+    });
+
+    getSubscriptionMock.mockRejectedValue(new Error("Stripe is down"));
+
+    const res = await getSubscriptionEndpoint();
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as SubBody;
+
+    // Persisted data still comes back; only the live-derived fields fall to null.
+    expect(body.tier).toBe("premium");
+    expect(body.seatsPurchased).toBe(4);
+    expect(body.billingCycle).toBeNull();
+    expect(body.currentPeriodEnd).toBeNull();
+  });
+});

--- a/packages/server/src/routes/orgs.ts
+++ b/packages/server/src/routes/orgs.ts
@@ -32,6 +32,9 @@ import {
   createCheckoutSession,
   updateSubscriptionSeats,
   previewUpcomingInvoice,
+  getSubscription,
+  resolvePlanFromPriceId,
+  type BillingCycle,
 } from "../services/stripe.js";
 import { ConflictError, ValidationError } from "../types/errors.js";
 import { readJsonBody, requireString } from "./validation.js";
@@ -323,6 +326,18 @@ orgsCurrentRouter.post("/current/subscription", adminGate, async (c) => {
   }
 
   const baseUrl = buildAppBaseUrl();
+  // issue-16: carry the purchased org's tenant (namespace/memexSlug) through the
+  // success_url. After the full browser redirect back from stripe.com, React
+  // Router state is gone and the confirmation page can't tell WHICH org was
+  // purchased (the session's current memex is the non-billable personal one).
+  // These params come straight off the request path the client targeted
+  // (/api/<ns>/<mx>/orgs/current/subscription), so they are the purchased org.
+  const namespaceSlug = c.req.param("namespace");
+  const memexSlug = c.req.param("memex");
+  const orgParam =
+    namespaceSlug && memexSlug
+      ? `&org=${encodeURIComponent(`${namespaceSlug}/${memexSlug}`)}`
+      : "";
   const session = await createCheckoutSession({
     customerId,
     orgId,
@@ -331,8 +346,9 @@ orgsCurrentRouter.post("/current/subscription", adminGate, async (c) => {
     billingCycle,
     // Confirmation page falls back to fetching the live subscription using the
     // session id when React Router state is absent (full browser redirect back
-    // from stripe.com discards in-app state).
-    successUrl: `${baseUrl}/upgrade/confirmation?session_id={CHECKOUT_SESSION_ID}`,
+    // from stripe.com discards in-app state). The `org` param tells it WHICH
+    // org's subscription to poll (issue-16).
+    successUrl: `${baseUrl}/upgrade/confirmation?session_id={CHECKOUT_SESSION_ID}${orgParam}`,
     cancelUrl: `${baseUrl}/upgrade/${plan}`,
   });
 
@@ -435,6 +451,7 @@ orgsCurrentRouter.get("/current/subscription", adminGate, async (c) => {
   const [org] = await db
     .select({
       stripeCustomerId: orgs.stripeCustomerId,
+      stripeSubscriptionId: orgs.stripeSubscriptionId,
       planTier: orgs.planTier,
       seatsPurchased: orgs.seatsPurchased,
     })
@@ -458,12 +475,37 @@ orgsCurrentRouter.get("/current/subscription", adminGate, async (c) => {
       ? { purchased: seatsPurchased, active: activeMemberCount }
       : null;
 
+  // issue-15: surface the billing interval + next billing date the webhook
+  // doesn't persist. When the org has a live subscription, retrieve it from
+  // Stripe and derive the cycle (from the price id — the same source of truth
+  // the webhook uses for the tier, via resolvePlanFromPriceId) and the next
+  // billing date (current_period_end, top-level on older API versions, on the
+  // first item on newer ones). Resilient: a Stripe failure must NOT 500 the
+  // billing page — we fall back to nulls and still return the persisted data.
+  let billingCycle: BillingCycle | null = null;
+  let currentPeriodEnd: string | null = null;
+  if (org.stripeSubscriptionId) {
+    try {
+      const subscription = await getSubscription(org.stripeSubscriptionId);
+      const priceId = subscription.items.data[0]?.price.id;
+      billingCycle = priceId ? (resolvePlanFromPriceId(priceId)?.billingCycle ?? null) : null;
+      const periodEndUnix =
+        subscription.current_period_end ?? subscription.items.data[0]?.current_period_end;
+      currentPeriodEnd =
+        typeof periodEndUnix === "number"
+          ? new Date(periodEndUnix * 1000).toISOString()
+          : null;
+    } catch (err) {
+      console.error("Failed to enrich subscription from Stripe:", err);
+    }
+  }
+
   return c.json({
     tier,
     seatsPurchased,
     activeMemberCount,
-    billingCycle: null,      // TODO t-8: read from Stripe subscription once subscription create is wired
-    currentPeriodEnd: null,  // TODO t-8: read from Stripe subscription once subscription create is wired
+    billingCycle,
+    currentPeriodEnd,
     seatsWarning,
   });
 });

--- a/packages/ui/src/pages/upgrade/UpgradeConfirmation.spec-171.test.tsx
+++ b/packages/ui/src/pages/upgrade/UpgradeConfirmation.spec-171.test.tsx
@@ -1,0 +1,99 @@
+// spec-171 issue-16 — the confirmation page polls the org that was purchased.
+//
+// After the full browser redirect back from stripe.com, React Router state is
+// gone and the page can't tell WHICH org was purchased — so it rendered all
+// fields as "—" (it was polling the session's current, non-billable personal
+// memex, which is always 'free'). The success_url now carries `org=<ns>/<mx>`;
+// the page reads it, polls fetchCurrentSubscription for THAT tenant, and fills
+// Plan / Seats / Billing / Next billing date.
+//
+// NOTE: not tagged to an AC. The nearest, ac-39, is verified specifically by an
+// e2e that "asserts the real POST URL carries that org's namespace" — i.e. the
+// OUTBOUND checkout POST. This suite exercises the INBOUND confirmation-page
+// poll (a different mechanism), so tagging ac-39 here would flip it to verified
+// without exercising its stated claim. Left untagged; runs as a plain unit test.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { UpgradeConfirmation } from './UpgradeConfirmation';
+import type { SubscriptionDto, OrgTenant } from '../../api/client';
+
+const { fetchCurrentSubscriptionMock } = vi.hoisted(() => ({
+  fetchCurrentSubscriptionMock: vi.fn(),
+}));
+
+vi.mock('../../api/client', () => ({
+  fetchCurrentSubscription: fetchCurrentSubscriptionMock,
+}));
+
+// A session with TWO admin orgs → the single-admin heuristic can't disambiguate,
+// so without the `org` param the page would fall back to the session current.
+// The param must override that and pin the poll to the purchased org.
+vi.mock('../../components/AuthContext', () => ({
+  useAuth: () => ({ token: 'test-token', session: { sub: 'u1' } }),
+  computeDefaultLanding: () => '/acme/main',
+}));
+
+vi.mock('./adminOrgs', () => ({
+  deriveAdminOrgs: () => [
+    { orgId: 'o1', namespace: 'acme', memexSlug: 'main' },
+    { orgId: 'o2', namespace: 'beta', memexSlug: 'main' },
+  ],
+}));
+
+function renderConfirmation(search: string) {
+  return render(
+    <MemoryRouter initialEntries={[`/upgrade/confirmation${search}`]}>
+      <Routes>
+        <Route path="/upgrade/confirmation" element={<UpgradeConfirmation />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+const PREMIUM_ANNUAL: SubscriptionDto = {
+  tier: 'premium',
+  seatsPurchased: 7,
+  activeMemberCount: 3,
+  billingCycle: 'annual',
+  currentPeriodEnd: '2027-06-21T00:00:00.000Z',
+  seatsWarning: null,
+};
+
+beforeEach(() => {
+  fetchCurrentSubscriptionMock.mockReset();
+});
+
+describe('spec-171 issue-16: UpgradeConfirmation reads the org param + fills fields', () => {
+  it('polls the org named in the `org` param and renders plan/seats/billing/date', async () => {
+    fetchCurrentSubscriptionMock.mockResolvedValue(PREMIUM_ANNUAL);
+
+    renderConfirmation('?session_id=cs_test_123&org=beta%2Fmain');
+
+    await waitFor(() => expect(fetchCurrentSubscriptionMock).toHaveBeenCalled());
+
+    // The poll targets the org from the PARAM (beta/main), not the first admin org.
+    const tenantArg = fetchCurrentSubscriptionMock.mock.calls[0][1] as OrgTenant;
+    expect(tenantArg).toEqual({ namespace: 'beta', memexSlug: 'main' });
+
+    // Fields fill once the (non-free) tier resolves.
+    await screen.findByText('Premium');
+    expect(screen.getByText('7')).toBeInTheDocument();
+    expect(screen.getByText('Annual')).toBeInTheDocument();
+    expect(screen.getByText(/June 21, 2027/)).toBeInTheDocument();
+  });
+
+  it('falls back gracefully when the org param is absent (legacy link)', async () => {
+    fetchCurrentSubscriptionMock.mockResolvedValue(PREMIUM_ANNUAL);
+
+    renderConfirmation('?session_id=cs_test_123');
+
+    await waitFor(() => expect(fetchCurrentSubscriptionMock).toHaveBeenCalled());
+
+    // Two admin orgs + no param → can't disambiguate → orgTenant is undefined
+    // (the poll falls back to the session current; current behaviour preserved).
+    const tenantArg = fetchCurrentSubscriptionMock.mock.calls[0][1];
+    expect(tenantArg).toBeUndefined();
+  });
+});

--- a/packages/ui/src/pages/upgrade/UpgradeConfirmation.tsx
+++ b/packages/ui/src/pages/upgrade/UpgradeConfirmation.tsx
@@ -47,20 +47,35 @@ export function UpgradeConfirmation() {
 
   const routerState = location.state as ConfirmationState | null;
   const sessionId = searchParams.get('session_id');
+  const orgParam = searchParams.get('org');
 
-  // spec-171 t-25 / dec-40: billing is per-org. After a Stripe redirect the
-  // router state is gone, so we poll the live subscription — but it MUST target
-  // the org that was upgraded, not the session's current (personal) Memex (which
-  // is always 'free' → the poll would never resolve and the paying user would
-  // see "Finalizing…" forever). When the caller administers exactly one org we
-  // can resolve it unambiguously; with several we can't tell from the
-  // confirmation page alone, so the poll falls back to the session current and
-  // simply times out into the "active" view (the webhook still applied the tier).
+  // spec-171 t-25 / dec-40 / issue-16: billing is per-org. After a Stripe
+  // redirect the router state is gone, so we poll the live subscription — but it
+  // MUST target the org that was upgraded, not the session's current (personal)
+  // Memex (which is always 'free' → the poll would never resolve and the paying
+  // user would see "Finalizing…" forever).
+  //   - Preferred: the `org=<ns>/<mx>` param the success_url carries (issue-16)
+  //     names the purchased org unambiguously.
+  //   - Fallback: when the param is absent (legacy link) and the caller
+  //     administers exactly one org, resolve it from the session. With several
+  //     orgs and no param we can't tell, so the poll falls back to the session
+  //     current and times out into the "active" view (the webhook still applied
+  //     the tier).
   const adminOrgs = useMemo(() => deriveAdminOrgs(session), [session]);
+  const paramTenant = useMemo(() => {
+    if (!orgParam) return undefined;
+    const slash = orgParam.indexOf('/');
+    if (slash <= 0 || slash === orgParam.length - 1) return undefined;
+    return {
+      namespace: orgParam.slice(0, slash),
+      memexSlug: orgParam.slice(slash + 1),
+    };
+  }, [orgParam]);
   const orgTenant =
-    adminOrgs.length === 1
+    paramTenant ??
+    (adminOrgs.length === 1
       ? { namespace: adminOrgs[0].namespace, memexSlug: adminOrgs[0].memexSlug }
-      : undefined;
+      : undefined);
 
   const [sub, setSub] = useState<SubscriptionDto | null>(null);
   const [finalizing, setFinalizing] = useState(!routerState && !!sessionId);
@@ -95,10 +110,17 @@ export function UpgradeConfirmation() {
     return () => {
       cancelled = true;
     };
-    // orgTenant is derived from the single admin org; key the effect on its id
-    // (a stable primitive) rather than the fresh object to avoid a re-poll loop.
+    // orgTenant is derived from the `org` param (preferred) or the single admin
+    // org; key the effect on stable primitives (the raw param + the resolved
+    // single-org id) rather than the fresh object to avoid a re-poll loop.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [routerState, sessionId, token, adminOrgs.length === 1 ? adminOrgs[0].orgId : null]);
+  }, [
+    routerState,
+    sessionId,
+    token,
+    orgParam,
+    adminOrgs.length === 1 ? adminOrgs[0].orgId : null,
+  ]);
 
   // Neither in-app state nor a Stripe session id → nothing to confirm.
   if (!routerState && !sessionId) return <Navigate to="/upgrade" replace />;


### PR DESCRIPTION
## What

Two display-only gaps from manual int validation of the spec-171 hosted purchase flow. The data was already correct; the UI just didn't surface it.

### issue-15 — /org billing showed "—" for Billing cycle + Next billing date
`GET /api/<ns>/<mx>/orgs/current/subscription` returned `billingCycle: null` / `currentPeriodEnd: null` (left as a TODO). The handler now, when the org has a `stripeSubscriptionId`, retrieves the live Stripe subscription and derives:
- **billingCycle** — from `items[0].price.id` via `resolvePlanFromPriceId` (the same source of truth the webhook uses for the tier; no new Stripe type needed).
- **currentPeriodEnd** — `current_period_end` read top-level OR off the first item (newer Stripe API versions moved it), unix → ISO.

Resilient: a Stripe fetch failure is logged (`console.error`, matching `stripe-webhook.ts`) and falls back to `null` for both fields — the billing page never 500s. `BillingTab.tsx` already consumed `sub.billingCycle` / `sub.currentPeriodEnd`; it was simply receiving `null`.

### issue-16 — UpgradeConfirmation page empty after a successful purchase
After the full browser redirect back from stripe.com, React Router state is gone and the page couldn't tell WHICH org was purchased (it polled the session's current, non-billable personal memex → always `free` → fields stayed "—").

- **success_url now carries `org=<ns>/<mx>`**, built server-side from the request path params (`c.req.param("namespace")`/`"memex"`) — the client already targets `/api/<org-ns>/<org-mx>/orgs/current/subscription`, so those params ARE the purchased org. `encodeURIComponent`'d.
- **UpgradeConfirmation** reads the `org` param, splits it into `{namespace, memexSlug}`, and polls `fetchCurrentSubscription` for THAT tenant. Falls back to the existing single-admin-org heuristic when the param is absent (legacy links). The poll effect dep array now keys on the raw `org` param.

The two fixes compose: the confirmation page polls the right org AND the GET returns cycle+date, so the page fills completely.

## Tests
- `packages/server/src/routes/orgs.subscription-billing.integration.test.ts` (new, 4 cases): enriched fields present with a live subscription; `current_period_end` read off the first item; free org → nulls + Stripe never called; Stripe-failure resilience (200 with persisted data, derived fields null). Stripe `getSubscription` mocked, real Postgres org rows (mirrors the existing subscription-guard harness).
- `packages/ui/src/pages/upgrade/UpgradeConfirmation.spec-171.test.tsx` (new, 2 cases): param-targeted poll fills Plan/Seats/Billing/Next-date; graceful fallback (undefined tenant) when the param is absent.

Neither new test is AC-tagged: issue-15 has no spec-171 AC, and the nearest (ac-39) is verified by an e2e asserting the OUTBOUND checkout POST URL — a different mechanism from these INBOUND-poll tests. Tagging would flip ac-39 to verified without exercising its claim.

## Verification run locally (as CI runs)
- **Server** `vitest run` (SLACK_CLIENT_* cleared, pg16 on :5433): **4272 passed, 26 skipped, 1 failed**. The single failure is `src/services/.ee/slack/oauth.test.ts` — the documented local-only env case, unrelated to this diff.
- **UI** `pnpm test:coverage`: **1507 passed, 1 skipped, 1 failed**. The single failure is `src/usage-events-catalog.spec-338.test.ts` — **pre-existing on clean origin/develop** (confirmed by stashing this diff: it still fails). Same analytics-event-registry drift produces the 21 `tsc -b` errors below.
- **Typecheck** server `tsc -p tsconfig.build.json --noEmit`: **clean (0)**. UI `tsc -b`: 21 errors, all `TS2345` analytics-event-enum mismatches in files this PR does not touch — **pre-existing on develop**, none in the changed files.
- New tests: 4 server + 2 UI all green.

## Pre-existing develop reds (NOT introduced here)
develop is currently red on `tsc -b` (21 analytics-enum errors) and `test:coverage` (spec-338). Flagging so the red checks aren't read as this PR's. The slack/oauth server failure is the documented local-env case.