### PR TITLE
spec-356: lint + type-safety foundation — Biome (green baseline), shared tsconfig, RLS typing, std-14 logger [P2]

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -238,6 +238,28 @@ jobs:
               && echo "ac-3 emitted: $STATUS" || echo "ac-3 emission failed (non-blocking)"
           fi
 
+  # Lint gate (spec-356, cq-1/cq-2). Before this, the repo had NO lint/format
+  # tooling at all — only `tsc` — while 110 `eslint-disable` directives suppressed
+  # a linter that did not exist. `pnpm lint` runs `biome ci` against the curated
+  # baseline in `biome.json`. The baseline is deliberately a SMALL set of
+  # high-signal correctness/suspicious rules that the CURRENT tree already passes
+  # (formatter + style rules are deferred — see biome.json for the ramp plan), so
+  # this job is green on the existing code without a repo-wide reformat. As rules
+  # are promoted into the baseline over time, this job tightens with them.
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Biome lint (curated baseline — no reformat)
+        run: pnpm lint
+
   # Production build gate (std-17 §6 / cl-55): `make build` is what the deploy
   # actually runs, and vitest does NOT typecheck — a green test matrix can hide
   # a TS2741 that splits the deploy (exactly how PR #44's AcPill gap shipped:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -249,6 +249,9 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # Least-privilege: this job only checks out and runs Biome locally.
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@
 
 .PHONY: test test-unit test-integration test-api test-security test-perf test-regression \
         test-server test-ui e2e e2e-cold smoke smoke-int smoke-prod smoke-int-with-db smoke-prod-with-db \
-        dev build db-migrate db-seed typecheck \
+        dev build db-migrate db-seed typecheck lint \
         check-url-shape help
 
 # ── Tests ────────────────────────────────────────────────────
@@ -149,6 +149,10 @@ build:
 typecheck:
 	pnpm --filter @memex/server exec tsc --noEmit
 	pnpm --filter @memex/ui exec tsc --noEmit
+
+## Lint (Biome — curated baseline per spec-356; no reformat)
+lint:
+	pnpm lint
 
 # ── Database ─────────────────────────────────────────────────
 

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.5.1/schema.json",
+  "files": {
+    "includes": ["packages/*/src/**/*.{ts,tsx,js,jsx,mjs,cjs}"]
+  },
+  "formatter": { "enabled": false },
+  "assist": { "enabled": false },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": false,
+      "correctness": {
+        "noUnusedLabels": "error",
+        "noUnreachableSuper": "error",
+        "noInvalidConstructorSuper": "error",
+        "noConstantCondition": "error",
+        "noSelfAssign": "error",
+        "noSwitchDeclarations": "error"
+      },
+      "suspicious": {
+        "noDoubleEquals": "error",
+        "noDuplicateCase": "error",
+        "noDuplicateObjectKeys": "error",
+        "noDuplicateParameters": "error",
+        "noFunctionAssign": "error",
+        "noCompareNegZero": "error",
+        "noDebugger": "error",
+        "noSparseArray": "error",
+        "useGetterReturn": "error"
+      },
+      "complexity": {
+        "noUselessLoneBlockStatements": "error",
+        "noUselessEmptyExport": "error"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -9,10 +9,17 @@
     "build": "pnpm --filter @memex/server build && pnpm --filter @memex/ui build",
     "build:server": "pnpm --filter @memex/server build",
     "build:ui": "pnpm --filter @memex/ui build",
-    "release:sdk": "node scripts/release-sdk.mjs"
+    "release:sdk": "node scripts/release-sdk.mjs",
+    "lint": "biome ci",
+    "lint:fix": "biome check --write",
+    "format": "biome format",
+    "format:fix": "biome format --write"
   },
   "pnpm": {
-    "onlyBuiltDependencies": ["esbuild", "protobufjs"],
+    "onlyBuiltDependencies": [
+      "esbuild",
+      "protobufjs"
+    ],
     "overrides": {
       "vitest": "4.1.8",
       "@vitest/coverage-v8": "4.1.8",
@@ -24,5 +31,8 @@
       "form-data": ">=4.0.6",
       "protobufjs": ">=7.6.3 <8"
     }
+  },
+  "devDependencies": {
+    "@biomejs/biome": "2.5.1"
   }
 }

--- a/packages/ac-emit-vitest/tsconfig.json
+++ b/packages/ac-emit-vitest/tsconfig.json
@@ -1,13 +1,8 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
     "outDir": "dist",
     "rootDir": "src",
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,

--- a/packages/db-schema/tsconfig.json
+++ b/packages/db-schema/tsconfig.json
@@ -1,11 +1,6 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
     "declaration": true,
     "declarationMap": true,
     "forceConsistentCasingInFileNames": true,

--- a/packages/extractor/tsconfig.json
+++ b/packages/extractor/tsconfig.json
@@ -1,13 +1,8 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
     "noEmit": true,
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
     "types": ["node"]

--- a/packages/guide-sdk/tsconfig.json
+++ b/packages/guide-sdk/tsconfig.json
@@ -1,15 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "jsx": "react-jsx",
     "outDir": "dist",
     "rootDir": "src",
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,

--- a/packages/server/src/db/connection.ts
+++ b/packages/server/src/db/connection.ts
@@ -68,11 +68,22 @@ interface RlsRequestContext {
 
 export const memexContext = new AsyncLocalStorage<RlsRequestContext>();
 
+// ── RLS-seam query types (spec-356 cq-4) ─────────────────────────────────────
+// The seam below proxies the postgres-js driver. Before spec-356 it carried 15
+// `any`s + eslint-disables for a linter that did not exist (see std-36: this
+// seam is security-load-bearing — it injects the tenant GUC on every query, so
+// loose typing here is the worst place for it). These aliases pin the seam to
+// the driver's own published types: a tagged-template-or-`unsafe` SQL handle
+// (`Sql`), its transaction-scoped form (`TransactionSql`), and the parameter
+// array `unsafe()` accepts.
+type SqlClient = postgres.Sql;
+type TxClient = postgres.TransactionSql;
+type QueryParams = postgres.ParameterOrJSON<never>[];
+
 /** Emit `set_config(...)` for whichever RLS GUCs the context carries. Absent
  * GUCs are simply not set, so the matching policy sees NULL for that GUC and
  * contributes nothing — each policy is additive per GUC. */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-async function applyRlsGucs(txSql: any, ctx: RlsRequestContext): Promise<void> {
+async function applyRlsGucs(txSql: TxClient, ctx: RlsRequestContext): Promise<void> {
   if (ctx.memexId) {
     await txSql.unsafe("SELECT set_config('app.memex_id', $1, true)", [ctx.memexId]);
   }
@@ -139,31 +150,39 @@ export function runWithUserId<T>(
  * (returns row objects) and .values() chaining (returns row arrays — the form
  * Drizzle uses internally for SELECT field mapping).
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function makeRlsQuery(pool: any, ctx: RlsRequestContext, query: string, params: any[]) {
-  const run = (useValues: boolean) =>
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    pool.begin(async (txSql: any) => {
+function makeRlsQuery(
+  pool: SqlClient,
+  ctx: RlsRequestContext,
+  query: string,
+  params: QueryParams,
+) {
+  // The executed query resolves to driver rows; row objects vs row arrays
+  // (`.values()`) are the same data in two shapes, so `unknown` is the honest
+  // payload type here — Drizzle re-types the result at its own call site.
+  const run = (useValues: boolean): Promise<unknown> =>
+    pool.begin(async (txSql: TxClient) => {
       await applyRlsGucs(txSql, ctx);
       const q = txSql.unsafe(query, params);
       return useValues ? q.values() : q;
     });
 
   return {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    then(onfulfilled: any, onrejected: any) { return run(false).then(onfulfilled, onrejected); },
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    catch(onrejected: any) { return run(false).catch(onrejected); },
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    finally(onfinally: any) { return run(false).finally(onfinally); },
+    then: <R1 = unknown, R2 = never>(
+      onfulfilled?: ((value: unknown) => R1 | PromiseLike<R1>) | null,
+      onrejected?: ((reason: unknown) => R2 | PromiseLike<R2>) | null,
+    ) => run(false).then(onfulfilled, onrejected),
+    catch: <R = never>(onrejected?: ((reason: unknown) => R | PromiseLike<R>) | null) =>
+      run(false).catch(onrejected),
+    finally: (onfinally?: (() => void) | null) => run(false).finally(onfinally),
     values() {
       return {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        then(onfulfilled: any, onrejected: any) { return run(true).then(onfulfilled, onrejected); },
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        catch(onrejected: any) { return run(true).catch(onrejected); },
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        finally(onfinally: any) { return run(true).finally(onfinally); },
+        then: <R1 = unknown, R2 = never>(
+          onfulfilled?: ((value: unknown) => R1 | PromiseLike<R1>) | null,
+          onrejected?: ((reason: unknown) => R2 | PromiseLike<R2>) | null,
+        ) => run(true).then(onfulfilled, onrejected),
+        catch: <R = never>(onrejected?: ((reason: unknown) => R | PromiseLike<R>) | null) =>
+          run(true).catch(onrejected),
+        finally: (onfinally?: (() => void) | null) => run(true).finally(onfinally),
       };
     },
   };
@@ -183,33 +202,28 @@ function makeRlsQuery(pool: any, ctx: RlsRequestContext, query: string, params: 
  * Savepoints (nested tx.transaction()) use the transaction-scoped txSql which
  * already has the GUC set — they are never proxied.
  */
-function createRlsClient(baseClient: postgres.Sql): postgres.Sql {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return new Proxy(baseClient as any, {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    get(target: any, prop: string | symbol) {
+function createRlsClient(baseClient: SqlClient): SqlClient {
+  return new Proxy(baseClient, {
+    get(target: SqlClient, prop: string | symbol, receiver: unknown) {
       if (prop === "unsafe") {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        return function (query: string, params: any[] = []) {
+        return (query: string, params: QueryParams = []) => {
           const ctx = memexContext.getStore();
           if (!ctx?.memexId && !ctx?.userId) return target.unsafe(query, params);
           return makeRlsQuery(target, ctx, query, params);
         };
       }
       if (prop === "begin") {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        return function (callback: (txSql: any) => Promise<any>) {
+        return (callback: (txSql: TxClient) => Promise<unknown>) => {
           const ctx = memexContext.getStore();
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          return target.begin(async (txSql: any) => {
+          return target.begin(async (txSql: TxClient) => {
             if (ctx) await applyRlsGucs(txSql, ctx);
             return callback(txSql);
           });
         };
       }
-      return Reflect.get(target, prop, target);
+      return Reflect.get(target, prop, receiver);
     },
-  }) as postgres.Sql;
+  }) as SqlClient;
 }
 
 const rlsClient = createRlsClient(client);

--- a/packages/server/src/observability/domain-logger.test.ts
+++ b/packages/server/src/observability/domain-logger.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDomainLogger } from "./domain-logger.js";
+
+describe("createDomainLogger (std-14)", () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+    delete process.env.DEBUG_TESTDOMAIN;
+  });
+
+  it("is enabled by default (no DEBUG_<DOMAIN> set) and writes a std-14 block to console", () => {
+    delete process.env.DEBUG_TESTDOMAIN;
+    const log = createDomainLogger("testdomain");
+    expect(log.enabled).toBe(true);
+
+    log.block("mint", "minted token", "userId=u_123\nscope=read");
+
+    expect(consoleSpy).toHaveBeenCalledTimes(1);
+    const out = consoleSpy.mock.calls[0]?.[0] as string;
+    // Block framing per std-14 cl-7.
+    expect(out).toContain("┌─ [TESTDOMAIN mint]");
+    expect(out).toContain("— minted token");
+    expect(out).toContain("│ userId=u_123");
+    expect(out).toContain("│ scope=read");
+    expect(out).toContain("└─ (end mint)");
+  });
+
+  it("is silenced by DEBUG_<DOMAIN>=0 (cl-10/cl-11) — no console write, enabled=false", () => {
+    process.env.DEBUG_TESTDOMAIN = "0";
+    const log = createDomainLogger("testdomain");
+    expect(log.enabled).toBe(false);
+
+    log.block("mint", "should not appear");
+    expect(consoleSpy).not.toHaveBeenCalled();
+  });
+
+  it("derives the env var from the domain slug (DEBUG_<UPPER>)", () => {
+    process.env.DEBUG_TESTDOMAIN = "0";
+    // A different domain is unaffected by another domain's flag.
+    const other = createDomainLogger("otherdomain");
+    expect(other.enabled).toBe(true);
+  });
+});

--- a/packages/server/src/observability/domain-logger.ts
+++ b/packages/server/src/observability/domain-logger.ts
@@ -1,0 +1,109 @@
+/**
+ * Per-domain debug logger factory [per std-14].
+ *
+ * std-14 says every cross-cutting server subsystem (auth, MCP, future Slack
+ * ingestion, …) should write structured multi-line blocks to console AND to its
+ * own append-only `packages/server/.logs/<domain>.log`, gated by a
+ * `DEBUG_<DOMAIN>` env var, rotating the prior session to `.log.prev` on the
+ * first call after process start. Before spec-356 that mechanism lived ONLY
+ * inside `agent/logger.ts`, so every new subsystem had to copy-paste it (and 120
+ * ad-hoc `console.*` calls across resolver/mcp/services/routes never adopted it
+ * at all — cq-5). This factory extracts the mechanism once, typed, so a new
+ * domain logger is one call instead of a re-implementation.
+ *
+ * What this factory gives you (the std-14 mechanics, cl-5..cl-10):
+ *   - co-located, one-call construction: `const log = createDomainLogger("auth")`
+ *   - console + file fan-out to `packages/server/.logs/<domain>.log`
+ *   - `.log.prev` rotation on first write after process start (one generation)
+ *   - `DEBUG_<DOMAIN>` gating, default ON in dev, OFF unless any non-`0` value
+ *   - the `┌─ │ └─` block format, so every domain log greps the same way
+ *
+ * What it does NOT do — the caller's responsibility (cl-12/cl-13): NEVER pass
+ * secrets (JWTs, passwords, scrypt output, raw Anthropic/Postmark keys, `mxt_…`
+ * token values — only the `prefix` is safe). Redact `Authorization` headers and
+ * the like in the BODY you hand to `.block(...)`, exactly as `agent/logger.ts`
+ * does.
+ *
+ * `packages/server/.logs/` is git-ignored (cl-14); CI never reads it (cl-15);
+ * production observability is Cloud Run logs, not these files (cl-30).
+ *
+ * Existing loggers (`agent/logger.ts`) predate this factory and keep their own
+ * domain-shaped helpers; migrating them onto this base is opportunistic
+ * follow-up, not required (their public API must not change).
+ */
+import { appendFileSync, existsSync, mkdirSync, renameSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/** A typed per-domain logger. `enabled` lets a caller cheaply guard expensive
+ * body construction; `block` writes one std-14 block to console + file. */
+export interface DomainLogger {
+  /** True when `DEBUG_<DOMAIN>` is not `0` — gate expensive formatting on this. */
+  readonly enabled: boolean;
+  /**
+   * Write one std-14 block:
+   *   ┌─ [DOMAIN <label>] <ISO timestamp> — <summary>
+   *   │ <body>
+   *   └─ (end <label>)
+   * `body` may be multi-line. No-op when the logger is disabled.
+   */
+  block(label: string, summary: string, body?: string): void;
+}
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Build a std-14 per-domain logger.
+ *
+ * @param domain lower-case domain slug, e.g. `"auth"` → `DEBUG_AUTH`,
+ *   `packages/server/.logs/auth.log`. The console label is upper-cased.
+ */
+export function createDomainLogger(domain: string): DomainLogger {
+  const envKey = `DEBUG_${domain.toUpperCase().replace(/[^A-Z0-9]/g, "_")}`;
+  const enabled = process.env[envKey] !== "0";
+  const consoleLabel = domain.toUpperCase();
+
+  const logFile = resolve(__dirname, `../../.logs/${domain}.log`);
+  const prevLogFile = `${logFile}.prev`;
+  let fileReady = false;
+
+  function ensureFileForSession(): void {
+    if (fileReady) return;
+    try {
+      mkdirSync(dirname(logFile), { recursive: true });
+      if (existsSync(logFile)) {
+        // Keep exactly one prior generation (cl-8/cl-28).
+        renameSync(logFile, prevLogFile);
+      }
+    } catch {
+      // best-effort — console logging still works
+    }
+    fileReady = true;
+  }
+
+  function writeToFile(line: string): void {
+    ensureFileForSession();
+    try {
+      appendFileSync(logFile, `${line}\n`);
+    } catch {
+      // ignore file-system errors — console logging continues regardless
+    }
+  }
+
+  return {
+    enabled,
+    block(label: string, summary: string, body = ""): void {
+      if (!enabled) return;
+      const ts = new Date().toISOString();
+      const bodyLines = body
+        .split("\n")
+        .map((l) => `│ ${l}`)
+        .join("\n");
+      const out = `\n┌─ [${consoleLabel} ${label}] ${ts} — ${summary}${
+        body ? `\n${bodyLines}` : ""
+      }\n└─ (end ${label})`;
+      console.log(out);
+      writeToFile(out);
+    },
+  };
+}

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -1,13 +1,8 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
     "outDir": "dist",
     "rootDir": "src",
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,13 +1,8 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
     "outDir": "dist",
     "rootDir": "src",
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,7 +17,11 @@ overrides:
 
 importers:
 
-  .: {}
+  .:
+    devDependencies:
+      '@biomejs/biome':
+        specifier: 2.5.1
+        version: 2.5.1
 
   packages/ac-emit-vitest:
     devDependencies:
@@ -513,6 +517,63 @@ packages:
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
+
+  '@biomejs/biome@2.5.1':
+    resolution: {integrity: sha512-IXWLCxKmae+rI7LOHS1B3EbVisQ6GRAWbhN9msa6KjNCyFWrvKZWR4oUdinaNssrV852OrSHuSPa95h1GPJc7Q==}
+    engines: {node: '>=14.21.3'}
+    hasBin: true
+
+  '@biomejs/cli-darwin-arm64@2.5.1':
+    resolution: {integrity: sha512-npqDzvqv7vFaWRiNN1Te71siRgPaqS9MpqgYCdP/CrUbkJ7ApezaeaKjueKHRN/JH/6lRjJQAHi8acQDCAz22w==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@biomejs/cli-darwin-x64@2.5.1':
+    resolution: {integrity: sha512-RgwTqPAM8g2tn1j+b5oRjF/DbSBX8a4gwojtuG9XuhfK7GgomvZ9+T+tqjXiVbjLEeGJOoL6VEk8mvRTVeSybw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@biomejs/cli-linux-arm64-musl@2.5.1':
+    resolution: {integrity: sha512-WMcvMLgByyTqVxGlq918NBBYliq9FRR9GAQVETHb+VjGVqXCZFfHlZHC1FX4ibuYY/Hg6TJE3rHU0xVrdJXNRw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@biomejs/cli-linux-arm64@2.5.1':
+    resolution: {integrity: sha512-yhV35CzZh38VyMvTEXi3JTjxZBs++oCKK9KG8vB6VI5+uvQvZNR3BFWEKKzuOmx9DJJj7sQpZ4LQJcmbGTs3+Q==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@biomejs/cli-linux-x64-musl@2.5.1':
+    resolution: {integrity: sha512-ANTowtlLmPYm5yeMckWY8Xzb9Ix+JJP3tgHR/n6xRj1VWyIzzWtfRfih9hv9VmClwadpBvZduISZIbBsIlYG3A==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@biomejs/cli-linux-x64@2.5.1':
+    resolution: {integrity: sha512-J/7uHSX7NfoYDI7HijAkd8lnQIOrRb2W7j3X+tw4R+N5ExvXGsyXFiGdQcfcxfOmNQmZVSQOCDk757fwpzqQcg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@biomejs/cli-win32-arm64@2.5.1':
+    resolution: {integrity: sha512-zgXnKNgWPC4iPF7Y1lR3STUeCUuZRpD6IiOrC7TZTlh0Lx6FiVUT05myuMQHQ9D+1cc7uyMldi4forE6lp0ivQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@biomejs/cli-win32-x64@2.5.1':
+    resolution: {integrity: sha512-6uxpR9hvaglANkZemeSiN/FhYgkGasrEGn267eXIWvjrjJ2LhDlk251IhjVJq6MXzkV2/bcXwLwSroLyPtqRZg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [win32]
 
   '@bramus/specificity@2.4.2':
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
@@ -4349,6 +4410,41 @@ snapshots:
       '@babel/helper-validator-identifier': 7.29.7
 
   '@bcoe/v8-coverage@1.0.2': {}
+
+  '@biomejs/biome@2.5.1':
+    optionalDependencies:
+      '@biomejs/cli-darwin-arm64': 2.5.1
+      '@biomejs/cli-darwin-x64': 2.5.1
+      '@biomejs/cli-linux-arm64': 2.5.1
+      '@biomejs/cli-linux-arm64-musl': 2.5.1
+      '@biomejs/cli-linux-x64': 2.5.1
+      '@biomejs/cli-linux-x64-musl': 2.5.1
+      '@biomejs/cli-win32-arm64': 2.5.1
+      '@biomejs/cli-win32-x64': 2.5.1
+
+  '@biomejs/cli-darwin-arm64@2.5.1':
+    optional: true
+
+  '@biomejs/cli-darwin-x64@2.5.1':
+    optional: true
+
+  '@biomejs/cli-linux-arm64-musl@2.5.1':
+    optional: true
+
+  '@biomejs/cli-linux-arm64@2.5.1':
+    optional: true
+
+  '@biomejs/cli-linux-x64-musl@2.5.1':
+    optional: true
+
+  '@biomejs/cli-linux-x64@2.5.1':
+    optional: true
+
+  '@biomejs/cli-win32-arm64@2.5.1':
+    optional: true
+
+  '@biomejs/cli-win32-x64@2.5.1':
+    optional: true
 
   '@bramus/specificity@2.4.2':
     dependencies:

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,20 @@
+{
+  // Shared compiler options every package extends (spec-356, cq-6). Holds ONLY
+  // the options that were byte-for-byte identical across all package tsconfigs
+  // before this file existed — so `extends`-ing it changes effective compilation
+  // for no package. Per-package tsconfigs still set everything package-specific
+  // (outDir/rootDir/lib/jsx/noEmit/declaration/types/include/exclude) and may
+  // override any value here (e.g. the browser UI pins target ES2020).
+  //
+  // Ramp: as packages converge, more options can migrate up here. Do NOT add an
+  // option that any extending package would need to override back — that defeats
+  // the de-duplication.
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  }
+}


### PR DESCRIPTION
**Spec:** [spec-356](https://memex.ai/mindset-prod/memex-building-itself/specs/spec-356) — REFACTOR (parent audit spec-345, findings cq-1..cq-7 + bnd-1). Lens: quality / sustainability.

Establishes the previously-absent lint + type-safety foundation **additively — no repo-wide reformat** (deliberately, so it doesn't conflict with the other in-flight refactor PRs).

## What landed
- **Biome 2.5.1** (root devDep, exact pin per std-24). `biome.json` scopes to `packages/*/src`, **formatter + assist disabled**, with a curated minimal lint baseline of high-signal correctness/suspicious rules the current tree already passes. `pnpm lint` / `make lint` / a required CI `lint` job are all **exit-0 on the current tree with zero source rewrite**.
- **Shared `tsconfig.base.json`** holding the 6 byte-identical compiler options; 6 packages now `extends` it (UI excluded — it pins ES2020). Effective compilation unchanged.
- **RLS-seam typing (std-36):** `connection.ts` tenant-GUC proxy — 15 `any` + their eslint-disables replaced with the postgres-js driver's real `Sql`/`TransactionSql`/`ParameterOrJSON` types.
- **std-14 logging:** a typed `createDomainLogger` factory (`src/observability/`) + tests, demonstrating the per-domain rotation/`DEBUG_<DOMAIN>` gating pattern.

## Verification
- `make typecheck` → same 14 pre-existing errors, **0 new** · `pnpm lint` → exit 0 (1336 files) · UI suite 1505 green · server suite 4268 green (1 pre-existing env-gated failure).

## Documented follow-ups (future specs)
Enable the formatter + scoped reformat once the PR backlog clears; promote more lint rules + strip the 110 legacy `eslint-disable`s; resolve the std-14 scope decision + migrate ~120 ad-hoc `console.*`; **bnd-1 (wire-bound Date-vs-string types) not addressed here — remains open.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)