### PR TITLE
fix(deploy): COPY tsconfig.base.json into the Docker build stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,10 @@ RUN pnpm install --frozen-lockfile --ignore-scripts
 
 # Build @memex/shared first, then @memex/server.
 FROM deps AS build
+# Root base tsconfig the package tsconfigs extend (spec-356) — must be present
+# at /app before any `tsc` runs, or builds fail with TS5083 (can't read
+# ../../tsconfig.base.json). The build context is the repo root (see header).
+COPY tsconfig.base.json ./
 COPY packages/shared ./packages/shared
 COPY packages/server/tsconfig.json packages/server/tsconfig.build.json ./packages/server/
 COPY packages/server/src ./packages/server/src


### PR DESCRIPTION
## Problem
The develop→int **deploy** broke after spec-356 (#298) merged:
```
error TS5083: Cannot read file '/app/tsconfig.base.json'.
@memex/shared build: tsc → Exit status 2
```
spec-356 made `packages/shared` and `packages/server` tsconfigs `extends "../../tsconfig.base.json"`, but the root `./Dockerfile`'s curated COPY list didn't include the new `tsconfig.base.json`, so the in-container `tsc` couldn't find it.

## Why CI didn't catch it
The per-PR `build` gate runs `pnpm build` in the **full checkout** (base config present). Only the **Docker build's minimal COPY context** (deploy) exposes the gap — exactly the std-17 §6 class of failure.

## Fix
`COPY tsconfig.base.json ./` in the `build` stage (WORKDIR `/app`), before the build `RUN`. Verified the extends chain resolves to `/app/tsconfig.base.json`: `shared/tsconfig.json` and `server/tsconfig.json` → `../../tsconfig.base.json`; `server/tsconfig.build.json` → `./tsconfig.json` → base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)