### PR TITLE
spec-361: comments as children in the segment outline + outline scroll-spy

### DIFF
--- a/packages/ui/src/components/DocOutline.spec-361.test.tsx
+++ b/packages/ui/src/components/DocOutline.spec-361.test.tsx
@@ -1,0 +1,200 @@
+// spec-361 — comments render as always-expanded child rows under each segment in
+// the SEGMENTS outline, marked with a comment icon, resolved ones struck through;
+// the badge stays the UNRESOLVED count; clicking a child navigates in situ.
+//
+//   ac-1 : each section comment renders as a child row with the comment icon.
+//   ac-2 : resolved comments render dimmed/struck-through, unresolved normally.
+//   ac-3 : clicking a comment child triggers in-situ navigation (here: the
+//          component contract — onCommentClick(seq, sectionId) fires).
+//   ac-4 : comment children update live (re-render) without a remount.
+//   ac-5 : comments only — no children for an empty segment, no decisions/tasks.
+//   ac-6 : the segment badge = UNRESOLVED count, hidden when all resolved.
+//   ac-7 : each child shows icon + snippet + author + a human-vs-agent indicator.
+//   ac-8 : a resolved child's snippet is struck through; an open one is not.
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { DocOutline } from './DocOutline';
+import type { Comment, Doc, DocSection } from '../api/types';
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-361/acs/ac-${n}`;
+
+const doc = { id: 'doc-1' } as unknown as Doc;
+
+function section(id: string, seq: number, title: string): DocSection {
+  return { id, sectionType: 'overview', title, content: '', seq } as DocSection;
+}
+
+function comment(over: Partial<Comment>): Comment {
+  return {
+    id: over.id ?? `cid-${over.seq ?? 1}`,
+    seq: over.seq,
+    sectionId: over.sectionId ?? 's-2',
+    decisionId: null,
+    taskId: null,
+    authorName: over.authorName ?? 'Barrie',
+    content: over.content ?? 'a comment',
+    resolution: null,
+    resolvedAt: over.resolvedAt ?? null,
+    createdAt: '2026-06-23T00:00:00Z',
+    ...over,
+  } as Comment;
+}
+
+const sections = [
+  section('s-1', 1, 'Overview'),
+  section('s-2', 2, 'Design & UX'),
+  section('s-3', 3, 'Architecture'),
+];
+
+describe('spec-361 — comments as child nodes in the segment outline', () => {
+  it('renders each section comment as a child row with the comment icon (ac-1)', () => {
+    tagAc(AC(1));
+    render(
+      <DocOutline
+        doc={doc}
+        sections={sections}
+        commentsBySection={{ 's-2': [comment({ seq: 1, content: 'tighten this' })] }}
+      />,
+    );
+    const row = screen.getByRole('button', { name: /tighten this/ });
+    expect(row).toBeInTheDocument();
+    expect(row).toHaveTextContent('💬');
+    expect(row).toHaveTextContent('tighten this');
+  });
+
+  it('renders no child rows for an empty segment, and only comments (ac-5)', () => {
+    tagAc(AC(5));
+    render(
+      <DocOutline
+        doc={doc}
+        sections={sections}
+        // s-2 has one comment; s-1 and s-3 have none.
+        commentsBySection={{ 's-2': [comment({ seq: 1, content: 'only child' })] }}
+      />,
+    );
+    // Exactly one comment child across the whole outline — no empty containers,
+    // and decisions/tasks are never projected as children.
+    const buttons = screen.getAllByRole('button');
+    expect(buttons).toHaveLength(1);
+    expect(screen.getByRole('button', { name: /only child/ })).toBeInTheDocument();
+  });
+
+  it('resolved comments render struck-through, unresolved do not (ac-2, ac-8)', () => {
+    tagAc(AC(2));
+    tagAc(AC(8));
+    render(
+      <DocOutline
+        doc={doc}
+        sections={sections}
+        commentsBySection={{
+          's-2': [
+            comment({ seq: 1, content: 'open one' }),
+            comment({ seq: 2, content: 'done one', resolvedAt: '2026-06-23T01:00:00Z' }),
+          ],
+        }}
+      />,
+    );
+    const openRow = screen.getByRole('button', { name: /open one/ });
+    const doneRow = screen.getByRole('button', { name: /done one/ });
+    expect(openRow).toHaveAttribute('data-resolved', 'false');
+    expect(doneRow).toHaveAttribute('data-resolved', 'true');
+    expect(within(doneRow).getByText('done one')).toHaveClass('line-through');
+    expect(within(openRow).getByText('open one')).not.toHaveClass('line-through');
+  });
+
+  it('badge = UNRESOLVED count and is hidden when all are resolved, while resolved children still render (ac-6)', () => {
+    tagAc(AC(6));
+    render(
+      <DocOutline
+        doc={doc}
+        sections={sections}
+        // s-2 has 1 unresolved (badge 1) even though it has 2 total children;
+        // s-1 has only a resolved comment → no badge but the child still shows.
+        commentCounts={{ 's-2': 1 }}
+        commentsBySection={{
+          's-2': [
+            comment({ seq: 1, content: 'open' }),
+            comment({ seq: 2, content: 'closed', resolvedAt: '2026-06-23T01:00:00Z' }),
+          ],
+          's-1': [comment({ seq: 3, content: 'all done', resolvedAt: '2026-06-23T01:00:00Z' })],
+        }}
+      />,
+    );
+    // Badge for s-2 reads the unresolved count (1), NOT the child count (2).
+    const s2 = screen.getByText('Design & UX').closest('a') as HTMLElement;
+    expect(within(s2).getByText('1')).toBeInTheDocument();
+    // s-1 has no unresolved comments → its row is just "1Overview", no badge,
+    // yet its resolved comment renders as a child.
+    const s1 = screen.getByText('Overview').closest('a') as HTMLElement;
+    expect(s1.textContent).toBe('1Overview');
+    expect(screen.getByRole('button', { name: /all done/ })).toHaveAttribute('data-resolved', 'true');
+  });
+
+  it('each child shows icon, snippet, author and a source indicator for human and agent (ac-7)', () => {
+    tagAc(AC(7));
+    render(
+      <DocOutline
+        doc={doc}
+        sections={sections}
+        commentsBySection={{
+          's-2': [
+            comment({ seq: 1, content: 'human note', authorName: 'Barrie', source: 'human' }),
+            comment({ seq: 2, content: 'agent note', authorName: 'Memex', source: 'agent' }),
+          ],
+        }}
+      />,
+    );
+    const humanRow = screen.getByRole('button', { name: /human note/ });
+    const agentRow = screen.getByRole('button', { name: /agent note/ });
+    // source indicator (data attribute, present for both branches)
+    expect(humanRow).toHaveAttribute('data-source', 'human');
+    expect(agentRow).toHaveAttribute('data-source', 'agent');
+    // author shown on both; agent also gets a visible "AI" badge
+    expect(humanRow).toHaveTextContent('Barrie');
+    expect(agentRow).toHaveTextContent('Memex');
+    expect(agentRow).toHaveTextContent('AI');
+    expect(humanRow).not.toHaveTextContent('AI');
+    // comment icon present
+    expect(humanRow).toHaveTextContent('💬');
+  });
+
+  it('clicking a comment child invokes in-situ navigation with its seq + section (ac-3)', () => {
+    tagAc(AC(3));
+    const onCommentClick = vi.fn();
+    render(
+      <DocOutline
+        doc={doc}
+        sections={sections}
+        onCommentClick={onCommentClick}
+        commentsBySection={{ 's-2': [comment({ seq: 7, content: 'jump me' })] }}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /jump me/ }));
+    expect(onCommentClick).toHaveBeenCalledWith(7, 's-2');
+  });
+
+  it('new comments appear as children on re-render, no remount (ac-4)', () => {
+    tagAc(AC(4));
+    const { rerender } = render(
+      <DocOutline
+        doc={doc}
+        sections={sections}
+        commentsBySection={{ 's-2': [comment({ seq: 1, content: 'first' })] }}
+      />,
+    );
+    expect(screen.getAllByRole('button')).toHaveLength(1);
+    rerender(
+      <DocOutline
+        doc={doc}
+        sections={sections}
+        commentsBySection={{
+          's-2': [comment({ seq: 1, content: 'first' }), comment({ seq: 2, content: 'second' })],
+        }}
+      />,
+    );
+    expect(screen.getByRole('button', { name: /second/ })).toBeInTheDocument();
+    expect(screen.getAllByRole('button')).toHaveLength(2);
+  });
+});

--- a/packages/ui/src/components/DocOutline.tsx
+++ b/packages/ui/src/components/DocOutline.tsx
@@ -1,11 +1,19 @@
-import type { Doc, DocSection } from '../api/types';
+import type { Comment, Doc, DocSection } from '../api/types';
 
 interface DocOutlineProps {
   doc: Doc;
   sections: DocSection[];
   activeSectionId?: string | null;
+  /** Per-section UNRESOLVED comment count — the badge stays a "needs attention"
+   *  signal (spec-361 dec-1), independent of how many children render. */
   commentCounts?: Record<string, number>;
+  /** Full comment thread per section. Rendered as always-expanded child rows
+   *  beneath each segment (spec-361). Comments only — decisions/tasks are not
+   *  projected into the outline. */
+  commentsBySection?: Record<string, Comment[]>;
   onSectionClick?: (sectionId: string) => void;
+  /** Click a comment child → navigate to it in situ (spec-325 deep-link path). */
+  onCommentClick?: (seq: number, sectionId: string) => void;
 }
 
 export function DocOutline({
@@ -13,7 +21,9 @@ export function DocOutline({
   sections,
   activeSectionId,
   commentCounts = {},
+  commentsBySection = {},
   onSectionClick,
+  onCommentClick,
 }: DocOutlineProps) {
   if (sections.length === 0) return null;
 
@@ -26,32 +36,93 @@ export function DocOutline({
           const title = section.title || capitalize(section.sectionType);
           const isActive = section.id === activeSectionId;
           const comments = commentCounts[section.id] ?? 0;
+          // spec-361: the section's comments, oldest first, rendered as children.
+          const childComments = [...(commentsBySection[section.id] ?? [])].sort(
+            (a, b) => (a.seq ?? 0) - (b.seq ?? 0),
+          );
 
           return (
-            <a
-              key={section.id}
-              href={`#section-${num}`}
-              onClick={(e) => {
-                if (onSectionClick) {
-                  e.preventDefault();
-                  onSectionClick(section.id);
-                  document.getElementById(`section-${num}`)?.scrollIntoView({ behavior: 'smooth' });
-                }
-              }}
-              className={`
-                flex items-center gap-2 pl-3 pr-2 py-1 -ml-px border-l transition-colors no-underline
-                ${isActive
-                  ? 'text-primary! font-medium border-primary'
-                  : 'text-muted! hover:text-secondary! border-transparent'
-                }
-              `}
-            >
-              <span className="flex-none w-3 text-right font-mono opacity-50">{num}</span>
-              <span className="truncate flex-1">{title}</span>
-              {comments > 0 && (
-                <span className="flex-none text-muted">{comments}</span>
+            <div key={section.id}>
+              <a
+                href={`#section-${num}`}
+                // spec-361 (issue-2): scroll-spy marks the in-view segment active.
+                aria-current={isActive ? 'true' : undefined}
+                onClick={(e) => {
+                  if (onSectionClick) {
+                    e.preventDefault();
+                    onSectionClick(section.id);
+                    document
+                      .getElementById(`section-${num}`)
+                      ?.scrollIntoView({ behavior: 'smooth' });
+                  }
+                }}
+                className={`
+                  flex items-center gap-2 pl-3 pr-2 py-1 -ml-px border-l transition-colors no-underline
+                  ${isActive
+                    ? 'text-primary! font-medium border-primary'
+                    : 'text-muted! hover:text-secondary! border-transparent'
+                  }
+                `}
+              >
+                <span className="flex-none w-3 text-right font-mono opacity-50">{num}</span>
+                <span className="truncate flex-1">{title}</span>
+                {/* spec-361 dec-1: badge = UNRESOLVED count, hidden at zero. */}
+                {comments > 0 && (
+                  <span className="flex-none text-muted">{comments}</span>
+                )}
+              </a>
+
+              {/* spec-361: always-expanded comment children. No empty container
+                  when a segment has no comments. */}
+              {childComments.length > 0 && (
+                <div className="border-l border-edge-subtle">
+                  {childComments.map((c) => {
+                    const resolved = c.resolvedAt != null;
+                    const isAgent = c.source === 'agent';
+                    const canNavigate = c.seq != null && onCommentClick != null;
+                    return (
+                      <button
+                        key={c.id}
+                        type="button"
+                        disabled={!canNavigate}
+                        data-comment-seq={c.seq ?? ''}
+                        data-source={c.source ?? 'human'}
+                        data-resolved={resolved ? 'true' : 'false'}
+                        aria-label={`Comment by ${c.authorName}: ${c.content}`}
+                        title={`${c.authorName}: ${c.content}`}
+                        onClick={() => {
+                          if (c.seq != null) onCommentClick?.(c.seq, section.id);
+                        }}
+                        className={`
+                          group flex w-full items-start gap-1.5 pl-6 pr-2 py-1 -ml-px border-l border-transparent
+                          text-left transition-colors no-underline text-muted! hover:text-secondary!
+                          ${canNavigate ? 'cursor-pointer' : 'cursor-default'}
+                        `}
+                      >
+                        <span aria-hidden className="flex-none leading-tight">💬</span>
+                        <span className="min-w-0 flex-1">
+                          {/* spec-361 dec-2 / ac-8: resolved → strikethrough. */}
+                          <span
+                            className={`block truncate ${resolved ? 'line-through opacity-60' : ''}`}
+                          >
+                            {c.content}
+                          </span>
+                          {/* author + human-vs-agent indicator (dec-2 / ac-7). */}
+                          <span className="block truncate text-[10px] text-muted/70">
+                            {c.authorName}
+                            {isAgent && (
+                              <span className="ml-1 rounded-sm bg-edge-subtle px-1 font-mono uppercase">
+                                AI
+                              </span>
+                            )}
+                          </span>
+                        </span>
+                      </button>
+                    );
+                  })}
+                </div>
               )}
-            </a>
+            </div>
           );
         })}
       </nav>

--- a/packages/ui/src/pages/DocDocument.spec-361-scrollspy.test.tsx
+++ b/packages/ui/src/pages/DocDocument.spec-361-scrollspy.test.tsx
@@ -1,0 +1,168 @@
+// spec-361 issue-2 (ac-9) — scroll-spy: scrolling the narrative updates which
+// segment is highlighted in the SEGMENTS outline. Driven by an IntersectionObserver
+// in DocDocument that watches the `section-${n}` card elements; the topmost one in
+// the viewport band becomes active (exposed as aria-current on the outline row).
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, act, waitFor } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { tagAc } from '@memex-ai-ac/vitest';
+import type { DocWithGraph } from '../api/types';
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-361/acs/ac-${n}`;
+
+// Capture IntersectionObserver instances so the test can drive intersections.
+type Entry = { target: Element; isIntersecting: boolean; intersectionRatio: number };
+const ioInstances: FakeIO[] = [];
+class FakeIO {
+  cb: (entries: Entry[]) => void;
+  elements: Element[] = [];
+  // Mirror the real IntersectionObserver signature (callback, options?) so the
+  // production `new IntersectionObserver(cb, { rootMargin, threshold })` call
+  // type-checks against the stub. Options are irrelevant to the test.
+  constructor(cb: (entries: Entry[]) => void, _options?: IntersectionObserverInit) {
+    this.cb = cb;
+    ioInstances.push(this);
+  }
+  observe(el: Element) {
+    this.elements.push(el);
+  }
+  unobserve(el: Element) {
+    this.elements = this.elements.filter((e) => e !== el);
+  }
+  disconnect() {
+    this.elements = [];
+  }
+  fire(entries: Entry[]) {
+    this.cb(entries);
+  }
+}
+
+// SectionCard mocked to render the stable `section-${n}` id the scroll-spy keys on.
+vi.mock('../components/SectionCard', () => ({
+  SectionCard: (props: { sectionNumber: number }) => (
+    <div data-testid="section-card" id={`section-${props.sectionNumber}`} />
+  ),
+}));
+vi.mock('../components/AllComments', () => ({ AllComments: () => <div data-testid="all-comments" /> }));
+vi.mock('../components/DecisionPanel', () => ({ DecisionPanel: () => <div data-testid="decision-panel" /> }));
+vi.mock('../components/AcPanel', () => ({ AcPanel: () => <div data-testid="ac-panel" /> }));
+vi.mock('../components/TaskPanel', () => ({ TaskPanel: () => <div data-testid="task-panel" /> }));
+vi.mock('../components/IssuePanel', () => ({ IssuePanel: () => <div data-testid="issue-panel" /> }));
+// DocOutline is the surface under test — NOT mocked.
+vi.mock('../components/TagPicker', () => ({ TagPicker: () => null }));
+vi.mock('../components/BylineAssignees', () => ({ BylineAssignees: () => <div data-testid="byline-assignees" /> }));
+vi.mock('../components/DoneSummary', () => ({ DoneSummary: () => <div data-testid="done-summary" /> }));
+
+vi.mock('../hooks/useMemexAccess', () => ({ useMemexAccess: () => ({ canWrite: true, isReadOnly: false }) }));
+vi.mock('../hooks/useDocRole', () => ({
+  useDocRole: () => ({ myRole: 'editor', editors: [], loading: false, refetch: vi.fn() }),
+}));
+vi.mock('../hooks/useDocChangeStream', () => ({ useDocChangeStream: () => {} }));
+vi.mock('../hooks/useOrgScaffoldBlocks', () => ({ useOrgScaffoldBlocks: () => [] }));
+
+const chat = { setDocId: vi.fn(), setDoc: vi.fn(), setOpenCommentCount: vi.fn(), sendMessage: vi.fn() };
+vi.mock('../components/ChatContext', () => ({ useChat: () => chat }));
+
+function makeDoc(): DocWithGraph {
+  return {
+    id: 'doc-uuid',
+    handle: 'spec-361',
+    title: 'Scroll-spy',
+    docType: 'spec',
+    status: 'specify',
+    creator: { name: 'Barrie', email: 'barrie@mindset.ai' },
+    createdAt: '2026-06-01T00:00:00Z',
+    statusChangedAt: '2026-06-04T00:00:00Z',
+    narrativeLastConsolidatedAt: null,
+    sections: [
+      { id: 's-1', seq: 1, title: 'Overview', body: 'x' },
+      { id: 's-2', seq: 2, title: 'User Interface', body: 'y' },
+    ],
+    decisions: [],
+    tasks: [],
+    tags: [],
+  } as unknown as DocWithGraph;
+}
+
+vi.mock('../api/client', () => ({
+  NotFoundError: class NotFoundError extends Error {},
+  fetchDoc: () => Promise.resolve(makeDoc()),
+  fetchDocComments: () => Promise.resolve({ sections: [], decisions: [], tasks: [] }),
+  fetchAcsForBrief: () => Promise.resolve([]),
+  fetchIssues: () => Promise.resolve([]),
+  fetchDocAssignees: () => Promise.resolve([]),
+  archiveDoc: vi.fn(),
+  pauseDoc: vi.fn(),
+  unpauseDoc: vi.fn(),
+  updateDocStatus: vi.fn(),
+  promoteToEditor: vi.fn(),
+  demoteToReviewer: vi.fn(),
+}));
+
+import { DocDocument } from './DocDocument';
+import { HeaderSlotProvider, useHeaderSlotContent } from '../components/HeaderSlot';
+
+function HeaderSink() {
+  return <div data-testid="header-slot">{useHeaderSlotContent()}</div>;
+}
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <HeaderSlotProvider>
+        <HeaderSink />
+        <Routes>
+          <Route path="/:ns/:mx/specs/:id" element={<DocDocument />} />
+        </Routes>
+      </HeaderSlotProvider>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  ioInstances.length = 0;
+  (globalThis as unknown as { IntersectionObserver: unknown }).IntersectionObserver =
+    FakeIO as unknown;
+});
+
+describe('spec-361 issue-2 — outline scroll-spy', () => {
+  it('scrolling a section into view marks its segment active; topmost wins (ac-9)', async () => {
+    tagAc(AC(9));
+    renderAt('/n/m/specs/spec-361');
+
+    // Outline rendered both segments; nothing is active before any scroll.
+    await screen.findByText('User Interface');
+    const seg1 = () => screen.getByText('Overview').closest('a') as HTMLElement;
+    const seg2 = () => screen.getByText('User Interface').closest('a') as HTMLElement;
+    expect(seg1()).not.toHaveAttribute('aria-current');
+    expect(seg2()).not.toHaveAttribute('aria-current');
+
+    // The scroll-spy effect wires an IntersectionObserver to the section cards.
+    // It runs after commit, so wait for it rather than assuming it's synchronous
+    // with the outline render (the assumption flaked under CI's slower run).
+    await waitFor(() => expect(ioInstances.length).toBeGreaterThan(0));
+
+    // Scroll so section 2 is the one in the viewport band → segment 2 active.
+    // Fire on the CURRENT observer each time: a selection re-render re-arms the
+    // effect, creating a fresh observer with an empty `visible` set.
+    act(() =>
+      ioInstances.at(-1)!.fire([
+        { target: document.getElementById('section-2')!, isIntersecting: true, intersectionRatio: 1 },
+      ]),
+    );
+    await waitFor(() => expect(seg2()).toHaveAttribute('aria-current', 'true'));
+    expect(seg1()).not.toHaveAttribute('aria-current');
+
+    // Both sections in view at once → the topmost (section 1) wins.
+    act(() =>
+      ioInstances.at(-1)!.fire([
+        { target: document.getElementById('section-1')!, isIntersecting: true, intersectionRatio: 1 },
+        { target: document.getElementById('section-2')!, isIntersecting: true, intersectionRatio: 1 },
+      ]),
+    );
+    await waitFor(() => expect(seg1()).toHaveAttribute('aria-current', 'true'));
+    expect(seg2()).not.toHaveAttribute('aria-current');
+  });
+});

--- a/packages/ui/src/pages/DocDocument.spec-361.test.tsx
+++ b/packages/ui/src/pages/DocDocument.spec-361.test.tsx
@@ -1,0 +1,160 @@
+// spec-361 — page-level wiring: comments fetched for a Spec render as child rows
+// in the real DocOutline, and clicking one navigates IN SITU (spec-325 path) —
+// threading the seq to the owning SectionCard and never the flat AllComments tab.
+//
+//   ac-3 : clicking a comment child sets the in-situ deep-link (seq reaches the
+//          section card) and does NOT land on the flat Comments tab.
+//   ac-4 : a comment present on load shows as a child under its segment, no
+//          manual refresh.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { tagAc } from '@memex-ai-ac/vitest';
+import type { DocWithGraph } from '../api/types';
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-361/acs/ac-${n}`;
+
+// SectionCard records the deepLinkCommentSeq it receives so we can assert the
+// click reached the in-situ narrative surface (not the flat tab).
+let sectionDeepLinkSeq: number | null | undefined = 'UNSET' as never;
+vi.mock('../components/SectionCard', () => ({
+  SectionCard: (props: { deepLinkCommentSeq?: number | null }) => {
+    sectionDeepLinkSeq = props.deepLinkCommentSeq;
+    return <div data-testid="section-card" data-deeplink={props.deepLinkCommentSeq ?? ''} />;
+  },
+}));
+// If AllComments renders, the click wrongly landed on the flat tab.
+vi.mock('../components/AllComments', () => ({
+  AllComments: () => <div data-testid="all-comments" />,
+}));
+vi.mock('../components/DecisionPanel', () => ({ DecisionPanel: () => <div data-testid="decision-panel" /> }));
+vi.mock('../components/AcPanel', () => ({ AcPanel: () => <div data-testid="ac-panel" /> }));
+vi.mock('../components/TaskPanel', () => ({ TaskPanel: () => <div data-testid="task-panel" /> }));
+vi.mock('../components/IssuePanel', () => ({ IssuePanel: () => <div data-testid="issue-panel" /> }));
+// NOTE: DocOutline is intentionally NOT mocked — it's the surface under test.
+vi.mock('../components/TagPicker', () => ({ TagPicker: () => null }));
+vi.mock('../components/BylineAssignees', () => ({ BylineAssignees: () => <div data-testid="byline-assignees" /> }));
+vi.mock('../components/DoneSummary', () => ({ DoneSummary: () => <div data-testid="done-summary" /> }));
+
+vi.mock('../hooks/useMemexAccess', () => ({
+  useMemexAccess: () => ({ canWrite: true, isReadOnly: false }),
+}));
+vi.mock('../hooks/useDocRole', () => ({
+  useDocRole: () => ({ myRole: 'editor', editors: [], loading: false, refetch: vi.fn() }),
+}));
+vi.mock('../hooks/useDocChangeStream', () => ({ useDocChangeStream: () => {} }));
+vi.mock('../hooks/useOrgScaffoldBlocks', () => ({ useOrgScaffoldBlocks: () => [] }));
+
+const chat = {
+  setDocId: vi.fn(),
+  setDoc: vi.fn(),
+  setOpenCommentCount: vi.fn(),
+  sendMessage: vi.fn(),
+};
+vi.mock('../components/ChatContext', () => ({ useChat: () => chat }));
+
+function makeDoc(): DocWithGraph {
+  return {
+    id: 'doc-uuid',
+    handle: 'spec-361',
+    title: 'Comments in the outline',
+    docType: 'spec',
+    status: 'specify',
+    creator: { name: 'Barrie', email: 'barrie@mindset.ai' },
+    createdAt: '2026-06-01T00:00:00Z',
+    statusChangedAt: '2026-06-04T00:00:00Z',
+    narrativeLastConsolidatedAt: null,
+    sections: [{ id: 's-1', seq: 1, title: 'Overview', body: 'x' }],
+    decisions: [],
+    tasks: [],
+    tags: [],
+  } as unknown as DocWithGraph;
+}
+
+const commentOnS1 = {
+  id: 'cid-3',
+  seq: 3,
+  sectionId: 's-1',
+  decisionId: null,
+  taskId: null,
+  authorName: 'Barrie',
+  content: 'tighten the overview',
+  resolution: null,
+  resolvedAt: null,
+  createdAt: '2026-06-10T00:00:00Z',
+  source: 'human',
+};
+
+vi.mock('../api/client', () => ({
+  NotFoundError: class NotFoundError extends Error {},
+  fetchDoc: () => Promise.resolve(makeDoc()),
+  fetchDocComments: () =>
+    Promise.resolve({
+      sections: [{ section: { id: 's-1', seq: 1, title: 'Overview' }, comments: [commentOnS1] }],
+      decisions: [],
+      tasks: [],
+    }),
+  fetchAcsForBrief: () => Promise.resolve([]),
+  fetchIssues: () => Promise.resolve([]),
+  fetchDocAssignees: () => Promise.resolve([]),
+  archiveDoc: vi.fn(),
+  pauseDoc: vi.fn(),
+  unpauseDoc: vi.fn(),
+  updateDocStatus: vi.fn(),
+  promoteToEditor: vi.fn(),
+  demoteToReviewer: vi.fn(),
+}));
+
+import { DocDocument } from './DocDocument';
+import { HeaderSlotProvider, useHeaderSlotContent } from '../components/HeaderSlot';
+
+function HeaderSink() {
+  return <div data-testid="header-slot">{useHeaderSlotContent()}</div>;
+}
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <HeaderSlotProvider>
+        <HeaderSink />
+        <Routes>
+          <Route path="/:ns/:mx/specs/:id" element={<DocDocument />} />
+        </Routes>
+      </HeaderSlotProvider>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  sectionDeepLinkSeq = 'UNSET' as never;
+});
+
+describe('spec-361 — outline comment children drive in-situ navigation', () => {
+  it('a comment present on load renders as a child row under its segment (ac-4)', async () => {
+    tagAc(AC(4));
+    renderAt('/n/m/specs/spec-361');
+    // The fetched comment shows as a clickable child in the outline.
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /tighten the overview/ })).toBeInTheDocument(),
+    );
+  });
+
+  it('clicking a comment child threads the seq to the section card, never the flat tab (ac-3)', async () => {
+    tagAc(AC(3));
+    renderAt('/n/m/specs/spec-361');
+
+    const child = await screen.findByRole('button', { name: /tighten the overview/ });
+    // No deep-link before the click.
+    expect(screen.getByTestId('section-card')).toHaveAttribute('data-deeplink', '');
+
+    fireEvent.click(child);
+
+    // After the click the owning SectionCard receives the seq (in situ)...
+    await waitFor(() => expect(sectionDeepLinkSeq).toBe(3));
+    expect(screen.getByTestId('section-card')).toHaveAttribute('data-deeplink', '3');
+    // ...and the flat AllComments tab is never the destination.
+    expect(screen.queryByTestId('all-comments')).not.toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/pages/DocDocument.tsx
+++ b/packages/ui/src/pages/DocDocument.tsx
@@ -42,7 +42,7 @@ import {
 } from '@memex/shared';
 import { QaReportCard, selectQaReports } from '../components/QaReportCard';
 import { useDocChangeStream } from '../hooks/useDocChangeStream';
-import { COMMENT_PARAM, parseCommentParam } from '../utils/commentDeepLink';
+import { COMMENT_PARAM, commentHandle, parseCommentParam } from '../utils/commentDeepLink';
 import { phaseDisplayName } from '../utils/phaseDisplay';
 import { ShareModal } from '../components/ShareModal';
 import { ShareSpecDialog } from '../components/ShareSpecDialog';
@@ -102,7 +102,7 @@ export function DocDocument() {
   // section cards below; the chat panel's read-only posture is handled in
   // DocumentShell.
   const { canWrite } = useMemexAccess(location.pathname);
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   // t-18: standard `[per dec-N]` references navigate here with `?decision=dec-N`
   // so the decisions tab is opened by default. The handle itself is used by the
   // decisions panel as a (best-effort) scroll/highlight hint. spec-64 i-3: the
@@ -330,6 +330,25 @@ export function DocDocument() {
     chat.setOpenCommentCount(totalCommentCount);
   }, [totalCommentCount]);
 
+
+  // spec-361: clicking a comment child in the outline opens it IN SITU — set the
+  // spec-325 (dec-1) `?comment=c-N` param, then reuse handleSelectSection (which
+  // shows the narrative, selects the owning section, and scrolls to it). The
+  // owning SectionCard pins its gutter card; never the flat Comments tab.
+  const handleSelectComment = useCallback(
+    (seq: number, sectionId: string) => {
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          next.set(COMMENT_PARAM, commentHandle(seq));
+          return next;
+        },
+        { replace: true },
+      );
+      handleSelectSection(sectionId);
+    },
+    [setSearchParams, handleSelectSection],
+  );
 
   const handleSectionCommentsChange = useCallback(
     (sectionId: string, comments: Comment[]) => {
@@ -876,6 +895,7 @@ export function DocDocument() {
       onSelectSection={setSelectedSectionId}
       deepLinkCommentSeq={initialCommentSeq}
       onOutlineSectionClick={handleSelectSection}
+      onOutlineCommentClick={handleSelectComment}
     />
   );
 

--- a/packages/ui/src/pages/doc-document/NarrativeView.tsx
+++ b/packages/ui/src/pages/doc-document/NarrativeView.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import type { Comment, DocSection, DocWithGraph } from '../../api/types';
 import { SectionCard } from '../../components/SectionCard';
 import { DocOutline } from '../../components/DocOutline';
@@ -40,6 +41,8 @@ interface NarrativeViewProps {
   deepLinkCommentSeq: number | null;
   /** Outline aside click → DocDocument's handleSelectSection. */
   onOutlineSectionClick: (sectionId: string) => void;
+  /** spec-361: outline comment-child click → in-situ comment navigation. */
+  onOutlineCommentClick: (seq: number, sectionId: string) => void;
 }
 
 export function NarrativeView({
@@ -58,7 +61,43 @@ export function NarrativeView({
   onSelectSection,
   deepLinkCommentSeq,
   onOutlineSectionClick,
+  onOutlineCommentClick,
 }: NarrativeViewProps) {
+  // spec-361 (issue-2): scroll-spy. Each section card carries a stable DOM id
+  // `section-${n}`. Without this the outline's active segment only tracks clicks,
+  // so scrolling the narrative leaves the highlight stale. An IntersectionObserver
+  // marks the topmost in-view section active via onSelectSection — a pure highlight
+  // update (SectionCard only styles on isSelected, no scroll side effect).
+  useEffect(() => {
+    if (narrativeSections.length === 0) return;
+    const els = narrativeSections
+      .map((s, i) => {
+        const el = document.getElementById(`section-${i + 1}`);
+        return el ? { el, id: s.id } : null;
+      })
+      .filter((x): x is { el: HTMLElement; id: string } => x != null);
+    if (els.length === 0) return;
+
+    const visible = new Set<string>();
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const e of entries) {
+          const elId = (e.target as HTMLElement).id;
+          if (e.isIntersecting) visible.add(elId);
+          else visible.delete(elId);
+        }
+        // The active section is the topmost one currently in the band.
+        const active = els.find(({ el }) => visible.has(el.id));
+        if (active) onSelectSection(active.id);
+      },
+      // Shrink the band to the top ~45% of the viewport so the highlight flips
+      // as a section reaches the top, the way a reader expects.
+      { rootMargin: '0px 0px -55% 0px', threshold: 0 },
+    );
+    els.forEach(({ el }) => observer.observe(el));
+    return () => observer.disconnect();
+  }, [narrativeSections, onSelectSection]);
+
   return (
     <div className="flex gap-8 items-start">
       <div className="flex-1 space-y-3 min-w-0">
@@ -103,7 +142,9 @@ export function NarrativeView({
           sections={narrativeSections}
           activeSectionId={selectedSectionId}
           commentCounts={commentCounts}
+          commentsBySection={commentsBySection}
           onSectionClick={onOutlineSectionClick}
+          onCommentClick={onOutlineCommentClick}
         />
       </aside>
     </div>


### PR DESCRIPTION
## What

Implements **spec-361** — surfacing comments in the **SEGMENTS** outline (`DocOutline`), plus a scroll-spy fix for the same surface.

### Comments as children (the ask)
Each segment now renders its comments as **always-expanded child rows**:
- 💬 comment icon + single-line truncated snippet + author
- an **AI** badge for agent-authored comments (`source`)
- **resolved comments shown struck-through**; the per-segment numeric badge keeps counting **unresolved only** (dec-1)
- clicking a child navigates **in situ** via the existing spec-325 `?comment=c-N` path (section gutter) — never the flat Comments tab
- **comments only** — decisions/tasks are not projected into the tree; a segment with no comments renders exactly as before

### Scroll-spy fix (issue-2, pre-existing bug)
The outline's active segment only tracked clicks, so scrolling the narrative left the highlight stale. An `IntersectionObserver` in `NarrativeView` now marks the in-view section active (exposed as `aria-current` for a11y/testing).

## Where
UI-only, `packages/ui` — no server/schema/API/MCP change. The comment data already reaches `DocDocument`; this threads it (and the click + scroll-spy) through `NarrativeView` → `DocOutline`. Rebased onto develop's `NarrativeView`/`useDocTabs` refactor (PR #300/#301).

## Decisions
- **dec-1** — badge stays unresolved-count; children show the full thread (badge ≠ visible-child count by design).
- **dec-2** — child row shows icon + snippet + author + human/agent indicator; resolved = strikethrough.

## Testing
- New AC-tagged tests: `DocOutline.spec-361.test.tsx`, `DocDocument.spec-361.test.tsx`, `DocDocument.spec-361-scrollspy.test.tsx`.
- **All 9 spec-361 ACs verified** (ac-1…ac-9).
- Full `packages/ui` vitest suite: **1518 pass / 1 skip / 0 fail**; `tsc` + eslint clean.

## Follow-up
- issue-1 (todo): clicking a *resolved* comment child scrolls to its section but pins no gutter card (the spec-325 gutter only renders open comments).

Spec: https://memex.ai/mindset-prod/memex-building-itself/specs/spec-361

🤖 Generated with [Claude Code](https://claude.com/claude-code)