### PR TITLE
test: known-flaky triage comments on two shared-clone tests

### DIFF
--- a/packages/server/src/__e2e__/migration-smoke.api.test.ts
+++ b/packages/server/src/__e2e__/migration-smoke.api.test.ts
@@ -1,3 +1,20 @@
+// ⚠ KNOWN-FLAKY UNDER FULL LOCAL PARALLEL RUNS (not a code defect).
+// The "every active user has namespace_id" check below is a GLOBAL scan of the
+// users table on a per-worker DB clone that other test files share. Another
+// file's fixture can leave an `active`, null-namespace user on the same clone →
+// false failure. It is green in CI (the server suite runs 3-way sharded, each
+// shard on its own fresh DB) and green when this file is run alone.
+// TRIAGE before assuming you broke it:
+//   1. Re-run THIS FILE in isolation:
+//        pnpm --filter @memex/server exec vitest run src/__e2e__/migration-smoke.api.test.ts
+//      If it passes alone, it's the known shared-clone flake — your change is
+//      almost certainly innocent. Do NOT pull develop and re-run the world.
+//   2. A failure here is only genuinely suspicious if your diff touched user
+//      creation / ensureUserNamespace / users.namespace_id population / signup,
+//      or the test-DB harness (vitest.global-setup / worker-db.setup).
+// The durable fix (deferred) is to scope this assertion to users the test
+// itself created, instead of scanning the whole clone.
+//
 // t-9 of doc-15 — one-shot migration smoke test, run against the post-migration
 // database at cutover. Verifies the §7 data-integrity contract from the spec.
 //

--- a/packages/server/src/services/memex-embeddings.integration.test.ts
+++ b/packages/server/src/services/memex-embeddings.integration.test.ts
@@ -1,3 +1,15 @@
+// ⚠ KNOWN-FLAKY UNDER FULL LOCAL PARALLEL RUNS (not a code defect).
+// The backfill idempotency assertion ("second pass embeds 0") counts over every
+// section this file created in a memex it shares across its own tests; under
+// full parallel local load it intermittently sees one extra. Green in isolation
+// and under CI's 3-way sharding.
+// TRIAGE before assuming you broke it:
+//   1. Re-run THIS FILE in isolation:
+//        pnpm --filter @memex/server exec vitest run src/services/memex-embeddings.integration.test.ts
+//      Passes alone ⇒ known flake; don't pull develop and re-run everything.
+//   2. Only suspect a real break if your diff touched backfillSectionEmbeddings /
+//      embedding-model resolution / writeEmbedding / the doc_sections schema.
+//
 // Integration tests for the Memex embedding pipeline (b-34 T-2 — generalised
 // from the standards-only pipeline shipped in doc-8 t-5). Uses a deterministic
 // FakeEmbeddingProvider so we don't burn API tokens and so the test asserts


### PR DESCRIPTION
## What
Adds a top-of-file **triage comment** to the two server tests that flake only under full **local** parallel runs:
- `packages/server/src/__e2e__/migration-smoke.api.test.ts` (global `users.namespace_id` scan)
- `packages/server/src/services/memex-embeddings.integration.test.ts` (backfill idempotency count)

**Comment-only — no behaviour change** (29 insertions, 0 deletions).

## Why
Both tests are green in CI (the server suite runs 3-way sharded, each shard on its own fresh DB) and green when run in isolation, but flake intermittently in a full local single-pass run because they assert over state broader than the rows they create on a **per-worker DB clone shared with other test files**.

The cost today is wasted time: a failure here sends a contributor (often an AI coding agent) into "did I break this?" — pulling develop, re-running the whole suite to prove the flake — when the answer is almost always no. Each comment gives a **deterministic triage**: re-run the file in isolation (passes alone ⇒ known flake), and only suspect a real regression if the diff touched the named load-bearing areas (user creation / `ensureUserNamespace` / `namespace_id` population for the first; `backfillSectionEmbeddings` / embedding-model resolution / `writeEmbedding` / `doc_sections` schema for the second).

## Not a fix
This is a time-saving signpost, not a repair — the tests are still fragile. The durable fix (scoping each assertion to self-created rows so it's correct under any sharding/worker count) is deferred to a follow-up.

## Verification
Both files pass in isolation (41 tests). No source/logic touched.