### PR TITLE
spec-377: extract mountStandardSessionPolicy across route files

### DIFF
--- a/packages/server/src/routes/acs.ts
+++ b/packages/server/src/routes/acs.ts
@@ -39,21 +39,18 @@ import {
   setAcAcceptance,
   clearAcAcceptance,
 } from "../services/acs.js";
-import {
-  sessionMiddleware,
-  publicSessionMiddleware,
-  type SessionEnv,
-} from "../middleware/session.js";
+import { type SessionEnv } from "../middleware/session.js";
 import type { MemexResolverEnv } from "../middleware/memex-resolver.js";
 import { requireMemexId, resolveReadableMemexId } from "./shared.js";
+import { mountStandardSessionPolicy } from "./session-policy.js";
 
 type Env = MemexResolverEnv & SessionEnv;
 
 const acsRouter = new Hono<Env>();
-// spec-111 t-10 — per-verb session policy. GET reads permissive (public read /
-// private 404 via resolveReadableMemexId); the DELETE write stays strict.
-acsRouter.on("GET", "/*", publicSessionMiddleware);
-acsRouter.on(["POST", "PUT", "PATCH", "DELETE"], "/*", sessionMiddleware);
+// spec-377 (was spec-111 t-10) — the standard per-verb session policy: GET reads
+// permissive (public read / private 404 via resolveReadableMemexId); the DELETE
+// write stays strict.
+mountStandardSessionPolicy(acsRouter);
 
 acsRouter.get("/doc/:docId", async (c) => {
   const memexId = await resolveReadableMemexId(c);

--- a/packages/server/src/routes/activity.ts
+++ b/packages/server/src/routes/activity.ts
@@ -2,13 +2,10 @@ import { Hono } from "hono";
 import { listActivity } from "../services/activity-log.js";
 import { getDoc } from "../services/documents.js";
 import { ValidationError } from "../types/errors.js";
-import {
-  sessionMiddleware,
-  publicSessionMiddleware,
-  type SessionEnv,
-} from "../middleware/session.js";
+import { type SessionEnv } from "../middleware/session.js";
 import type { MemexResolverEnv } from "../middleware/memex-resolver.js";
 import { resolveReadableMemexId } from "./shared.js";
+import { mountStandardSessionPolicy } from "./session-policy.js";
 
 // ── Pulse history (b-60, t-12) ────────────────────────────────────────────────
 //
@@ -27,12 +24,11 @@ import { resolveReadableMemexId } from "./shared.js";
 type Env = MemexResolverEnv & SessionEnv;
 const activity = new Hono<Env>();
 
-// spec-111 t-10 — the Pulse timeline is part of the public-Memex view, so the
-// GET read goes behind the permissive session (public read / private 404 via
-// resolveReadableMemexId). Mutating verbs (there are none today) stay strict so
-// any future write can never be reached anonymously.
-activity.on("GET", "/*", publicSessionMiddleware);
-activity.on(["POST", "PUT", "PATCH", "DELETE"], "/*", sessionMiddleware);
+// spec-377 (was spec-111 t-10) — the Pulse timeline is part of the public-Memex
+// view, so the GET read goes behind the permissive session (public read / private
+// 404 via resolveReadableMemexId). Mutating verbs (there are none today) stay
+// strict so any future write can never be reached anonymously.
+mountStandardSessionPolicy(activity);
 
 // Parse a positive-integer query param. Returns undefined when absent; throws a
 // 400 on a present-but-unparseable value so callers learn about a typo instead

--- a/packages/server/src/routes/analytics.ts
+++ b/packages/server/src/routes/analytics.ts
@@ -1,11 +1,8 @@
 import { Hono } from "hono";
-import {
-  sessionMiddleware,
-  publicSessionMiddleware,
-  type SessionEnv,
-} from "../middleware/session.js";
+import { type SessionEnv } from "../middleware/session.js";
 import type { MemexResolverEnv } from "../middleware/memex-resolver.js";
 import { resolveReadableMemexId } from "./shared.js";
+import { mountStandardSessionPolicy } from "./session-policy.js";
 import {
   specsOverTime,
   specsByPhase,
@@ -34,8 +31,8 @@ import { ValidationError } from "../types/errors.js";
 type Env = MemexResolverEnv & SessionEnv;
 const analytics = new Hono<Env>();
 
-analytics.on("GET", "/*", publicSessionMiddleware);
-analytics.on(["POST", "PUT", "PATCH", "DELETE"], "/*", sessionMiddleware);
+// spec-377 — the standard per-verb session policy (see session-policy.ts).
+mountStandardSessionPolicy(analytics);
 
 // GET /analytics/specs-over-time — per-day created + cumulative (ac-1).
 analytics.get("/specs-over-time", async (c) => {

--- a/packages/server/src/routes/comments.ts
+++ b/packages/server/src/routes/comments.ts
@@ -20,13 +20,10 @@ import {
   type CommentType,
 } from "../types/roles.js";
 import { ValidationError } from "../types/errors.js";
-import {
-  sessionMiddleware,
-  publicSessionMiddleware,
-  type SessionEnv,
-} from "../middleware/session.js";
+import { type SessionEnv } from "../middleware/session.js";
 import type { MemexResolverEnv } from "../middleware/memex-resolver.js";
 import { requireMemexId, resolveReadableMemexId } from "./shared.js";
+import { mountStandardSessionPolicy } from "./session-policy.js";
 import { restCtx } from "./_actor-ctx.js";
 import { getOrgIdForMemex } from "../services/memexes.js";
 import { searchMentionableMembers } from "../services/users.js";
@@ -39,10 +36,10 @@ import {
 
 type Env = MemexResolverEnv & SessionEnv;
 const comments = new Hono<Env>();
-// spec-111 t-10 — per-verb session policy. GET reads permissive (public read /
-// private 404 via resolveReadableMemexId); every mutating verb stays strict.
-comments.on("GET", "/*", publicSessionMiddleware);
-comments.on(["POST", "PUT", "PATCH", "DELETE"], "/*", sessionMiddleware);
+// spec-377 (was spec-111 t-10) — the standard per-verb session policy: GET reads
+// permissive (public read / private 404 via resolveReadableMemexId); every
+// mutating verb stays strict.
+mountStandardSessionPolicy(comments);
 
 // Build a CommentExtras from the raw JSON body, returning undefined when nothing
 // typed-comment-related was supplied. Returning undefined preserves the existing

--- a/packages/server/src/routes/decisions.ts
+++ b/packages/server/src/routes/decisions.ts
@@ -11,22 +11,18 @@ import {
   AmbiguousDecisionHandleError,
   SpecParentMismatchError,
 } from "../services/decisions.js";
-import {
-  sessionMiddleware,
-  publicSessionMiddleware,
-  type SessionEnv,
-} from "../middleware/session.js";
+import { type SessionEnv } from "../middleware/session.js";
 import type { MemexResolverEnv } from "../middleware/memex-resolver.js";
 import { requireMemexId, resolveReadableMemexId } from "./shared.js";
+import { mountStandardSessionPolicy } from "./session-policy.js";
 
 type Env = MemexResolverEnv & SessionEnv;
 const decisionsRouter = new Hono<Env>();
-// spec-111 t-10 — per-verb session policy. GET reads go behind the permissive
-// public session (anonymous-friendly; each handler gates the memex via
-// resolveReadableMemexId → public read / private 404). Every mutating verb stays
-// strict so a non-member can never reach a write.
-decisionsRouter.on("GET", "/*", publicSessionMiddleware);
-decisionsRouter.on(["POST", "PUT", "PATCH", "DELETE"], "/*", sessionMiddleware);
+// spec-377 (was spec-111 t-10) — the standard per-verb session policy: GET reads
+// go behind the permissive public session (anonymous-friendly; each handler gates
+// the memex via resolveReadableMemexId → public read / private 404). Every
+// mutating verb stays strict so a non-member can never reach a write.
+mountStandardSessionPolicy(decisionsRouter);
 
 
 

--- a/packages/server/src/routes/doc-assignees.ts
+++ b/packages/server/src/routes/doc-assignees.ts
@@ -1,8 +1,9 @@
 import { Hono } from "hono";
 import { assign, unassign, listAssignees } from "../services/doc-assignees.js";
-import { sessionMiddleware, publicSessionMiddleware, type SessionEnv } from "../middleware/session.js";
+import { type SessionEnv } from "../middleware/session.js";
 import type { MemexResolverEnv } from "../middleware/memex-resolver.js";
 import { requireMemexId, resolveReadableMemexId } from "./shared.js";
+import { mountStandardSessionPolicy } from "./session-policy.js";
 import { restCtx } from "./_actor-ctx.js";
 
 // Thin REST mirror of the assignment service (spec-118 t-4). Assignment is the
@@ -11,8 +12,8 @@ import { restCtx } from "./_actor-ctx.js";
 // emit on the unified bus (ac-20) so the board updates live via spec-16.
 type Env = MemexResolverEnv & SessionEnv;
 const docAssigneesRouter = new Hono<Env>();
-docAssigneesRouter.on("GET", "/*", publicSessionMiddleware);
-docAssigneesRouter.on(["POST", "PUT", "PATCH", "DELETE"], "/*", sessionMiddleware);
+// spec-377 — the standard per-verb session policy (see session-policy.ts).
+mountStandardSessionPolicy(docAssigneesRouter);
 
 docAssigneesRouter.get("/doc/:docId", async (c) => {
   const memexId = await resolveReadableMemexId(c);

--- a/packages/server/src/routes/doc-members.ts
+++ b/packages/server/src/routes/doc-members.ts
@@ -5,9 +5,10 @@ import {
   promoteToEditor,
   demoteToReviewer,
 } from "../services/doc-members.js";
-import { sessionMiddleware, publicSessionMiddleware, type SessionEnv } from "../middleware/session.js";
+import { type SessionEnv } from "../middleware/session.js";
 import type { MemexResolverEnv } from "../middleware/memex-resolver.js";
 import { requireMemexId, resolveReadableMemexId } from "./shared.js";
+import { mountStandardSessionPolicy } from "./session-policy.js";
 import { restCtx } from "./_actor-ctx.js";
 
 // Thin REST mirror of the per-Spec role service (spec-118 t-3). Roles gate
@@ -18,8 +19,8 @@ import { restCtx } from "./_actor-ctx.js";
 // any active org member, on self or another (dec-5), so there is no finer check.
 type Env = MemexResolverEnv & SessionEnv;
 const docMembersRouter = new Hono<Env>();
-docMembersRouter.on("GET", "/*", publicSessionMiddleware);
-docMembersRouter.on(["POST", "PUT", "PATCH", "DELETE"], "/*", sessionMiddleware);
+// spec-377 — the standard per-verb session policy (see session-policy.ts).
+mountStandardSessionPolicy(docMembersRouter);
 
 // The editors of a Spec + the caller's own resolved posture. The React UI reads
 // `myRole` to choose reviewer vs editor mode and `editors` for the member list.

--- a/packages/server/src/routes/issues.ts
+++ b/packages/server/src/routes/issues.ts
@@ -13,13 +13,10 @@ import {
   type IssueType,
   type IssueStatus,
 } from "../services/issues.js";
-import {
-  sessionMiddleware,
-  publicSessionMiddleware,
-  type SessionEnv,
-} from "../middleware/session.js";
+import { type SessionEnv } from "../middleware/session.js";
 import type { MemexResolverEnv } from "../middleware/memex-resolver.js";
 import { requireMemexId, resolveReadableMemexId } from "./shared.js";
+import { mountStandardSessionPolicy } from "./session-policy.js";
 
 // Thin REST mirror of the Issues service (spec-112 t-10). The React UI's
 // IssuePanel talks to this surface exactly as TaskPanel talks to /api/tasks;
@@ -29,11 +26,10 @@ import { requireMemexId, resolveReadableMemexId } from "./shared.js";
 //
 // Per-verb session policy mirrors tasks.ts: GET reads are permissive (public
 // read / private 404 via resolveReadableMemexId, std-7); every mutating verb
-// stays strict.
+// stays strict. spec-377 — the standard policy (see session-policy.ts).
 type Env = MemexResolverEnv & SessionEnv;
 const issuesRouter = new Hono<Env>();
-issuesRouter.on("GET", "/*", publicSessionMiddleware);
-issuesRouter.on(["POST", "PUT", "PATCH", "DELETE"], "/*", sessionMiddleware);
+mountStandardSessionPolicy(issuesRouter);
 
 // List Issues for a Spec, optionally filtered. `?type=bug|todo` and
 // `?status=open|converted|resolved|wont_fix` are the REST mirror of the

--- a/packages/server/src/routes/presence.ts
+++ b/packages/server/src/routes/presence.ts
@@ -18,22 +18,18 @@ import { markPresent, listPresent } from "../services/presence.js";
 import { parseRef } from "./../services/refs.js";
 import { ValidationError } from "../types/errors.js";
 import { actorName } from "../services/actor.js";
-import {
-  sessionMiddleware,
-  publicSessionMiddleware,
-  type SessionEnv,
-} from "../middleware/session.js";
+import { type SessionEnv } from "../middleware/session.js";
 import type { MemexResolverEnv } from "../middleware/memex-resolver.js";
 import { requireMemexId, resolveReadableMemexId } from "./shared.js";
+import { mountStandardSessionPolicy } from "./session-policy.js";
 
 type Env = MemexResolverEnv & SessionEnv;
 const presenceRouter = new Hono<Env>();
 
 // GET (read who's here) is public-read like the rest of the spec surface; the
 // POST heartbeat is a write and stays strict (only an authenticated member can
-// declare presence).
-presenceRouter.on("GET", "/*", publicSessionMiddleware);
-presenceRouter.on(["POST", "PUT", "PATCH", "DELETE"], "/*", sessionMiddleware);
+// declare presence). spec-377 — the standard policy (see session-policy.ts).
+mountStandardSessionPolicy(presenceRouter);
 
 // Accept either a full canonical ref ("<ns>/<mx>/specs/spec-N") or a bare
 // "spec-N" handle. getDoc resolves either form scoped to the memex.

--- a/packages/server/src/routes/qa-reports.ts
+++ b/packages/server/src/routes/qa-reports.ts
@@ -6,13 +6,10 @@ import {
   recordQaReportsView,
 } from "../services/qa-reports.js";
 import { NotFoundError, ValidationError } from "../types/errors.js";
-import {
-  sessionMiddleware,
-  publicSessionMiddleware,
-  type SessionEnv,
-} from "../middleware/session.js";
+import { type SessionEnv } from "../middleware/session.js";
 import type { MemexResolverEnv } from "../middleware/memex-resolver.js";
 import { resolveReadableMemexId } from "./shared.js";
+import { mountStandardSessionPolicy } from "./session-policy.js";
 
 // ── QA Reports feed + unread counter (spec-260 dec-5 / dec-6) ─────────────────
 //
@@ -31,8 +28,8 @@ import { resolveReadableMemexId } from "./shared.js";
 type Env = MemexResolverEnv & SessionEnv;
 const qaReports = new Hono<Env>();
 
-qaReports.on("GET", "/*", publicSessionMiddleware);
-qaReports.on(["POST", "PUT", "PATCH", "DELETE"], "/*", sessionMiddleware);
+// spec-377 — the standard per-verb session policy (see session-policy.ts).
+mountStandardSessionPolicy(qaReports);
 
 // Same shape-validators as routes/activity.ts — present-but-invalid params 400
 // rather than silently defaulting.

--- a/packages/server/src/routes/session-policy.ts
+++ b/packages/server/src/routes/session-policy.ts
@@ -1,0 +1,30 @@
+// spec-377 (spec-355 dry-10) — the standard per-verb session policy, extracted.
+//
+// Almost every tenant-scoped resource router wires the SAME two lines: GET reads
+// run behind the PERMISSIVE publicSessionMiddleware (public read / private 404 via
+// the read gate, e.g. resolveReadableMemexId), and every mutating verb stays STRICT
+// behind sessionMiddleware so a non-member can never reach a write. That ordering is
+// exactly what produces std-7's 404-not-403 unauthorized posture, so it must be
+// applied identically everywhere.
+//
+// This helper is the single source of that wiring. It is generic over any Env that
+// includes SessionEnv, so each router keeps its own precise Hono<Env> type.
+//
+// NOT for every router: routers that genuinely deviate (e.g. a GET-only read router
+// with no mutating verbs, like search.ts) keep their own bespoke wiring — never
+// flatten a real difference into this helper.
+
+import type { Hono } from "hono";
+import {
+  sessionMiddleware,
+  publicSessionMiddleware,
+  type SessionEnv,
+} from "../middleware/session.js";
+
+export function mountStandardSessionPolicy<E extends SessionEnv>(
+  router: Hono<E>,
+): Hono<E> {
+  router.on("GET", "/*", publicSessionMiddleware);
+  router.on(["POST", "PUT", "PATCH", "DELETE"], "/*", sessionMiddleware);
+  return router;
+}

--- a/packages/server/src/routes/tasks.ts
+++ b/packages/server/src/routes/tasks.ts
@@ -13,23 +13,20 @@ import {
 } from "../services/tasks.js";
 import type { AcceptanceCriterion } from "../services/tasks.js";
 import { addBlocker, removeBlocker } from "../services/shared/blockers.js";
-import {
-  sessionMiddleware,
-  publicSessionMiddleware,
-  type SessionEnv,
-} from "../middleware/session.js";
+import { type SessionEnv } from "../middleware/session.js";
 import type { MemexResolverEnv } from "../middleware/memex-resolver.js";
 import { requireMemexId, resolveReadableMemexId } from "./shared.js";
+import { mountStandardSessionPolicy } from "./session-policy.js";
 
 // Public route surface stays at /api/tasks/* — only the underlying service module was
 // renamed to tasks per dec-1. New v2 endpoints introduced in later slices use
 // the task terminology directly.
 type Env = MemexResolverEnv & SessionEnv;
 const tasksRouter = new Hono<Env>();
-// spec-111 t-10 — per-verb session policy. GET reads permissive (public read /
-// private 404 via resolveReadableMemexId); every mutating verb stays strict.
-tasksRouter.on("GET", "/*", publicSessionMiddleware);
-tasksRouter.on(["POST", "PUT", "PATCH", "DELETE"], "/*", sessionMiddleware);
+// spec-377 (was spec-111 t-10) — the standard per-verb session policy: GET reads
+// permissive (public read / private 404 via resolveReadableMemexId); every
+// mutating verb stays strict.
+mountStandardSessionPolicy(tasksRouter);
 
 
 


### PR DESCRIPTION
## What

DRY refactor (spec-355 dry-10). The identical two-line per-verb session policy was repeated verbatim across 11 tenant-scoped route files. Extracted into a single generic helper `mountStandardSessionPolicy<E extends SessionEnv>(router)` in a new `packages/server/src/routes/session-policy.ts`, called once per router.

The helper applies the exact two lines each site applied today, in order:
```ts
router.on("GET", "/*", publicSessionMiddleware);
router.on(["POST", "PUT", "PATCH", "DELETE"], "/*", sessionMiddleware);
```

## Route files converted (11)

- acs.ts
- activity.ts
- analytics.ts
- comments.ts
- decisions.ts
- doc-assignees.ts
- doc-members.ts
- issues.ts
- presence.ts
- qa-reports.ts
- tasks.ts

Each dropped its now-unused runtime `sessionMiddleware`/`publicSessionMiddleware` imports (keeping `type SessionEnv`) and gained the single helper call.

## std-7 grounding — 404-not-403 posture preserved

This per-verb wiring is what produces std-7's unauthorized posture: GET reads run behind the **permissive** `publicSessionMiddleware` (public read / private 404 via the read gate, e.g. `resolveReadableMemexId`); every mutating verb stays **strict** behind `sessionMiddleware` so a non-member can never reach a write. The extracted helper applies the **exact same** middleware, in the same order, with the same options, for the same verbs — behaviour is byte-for-byte preserved. The cross-tenant 404-not-403 posture suite (`public-content-read.integration.test.ts`) stays green.

## Deliberately not converted

- **`routes/documents.ts` — EXCLUDED.** It carries the same identical wiring but a concurrent sibling PR is editing it; left untouched to avoid conflict. Noted as the obvious follow-up once that PR lands.
- **`routes/search.ts` — left as-is.** It has only the GET line (no mutating verbs) — a genuine deviation, not the standard pattern; not flattened into the helper.

## Verification (lean — full sharded suites left to CI)

- `tsc --noEmit`: zero errors in all touched source files (remaining repo-wide errors are pre-existing test-file module-resolution noise).
- vitest (local DB): 127 targeted auth/session/404-posture + converted-router tests green — `comments`/`decisions`/`tasks` unit (37), `public-content-read` + `activity` (x2) + `analytics` + `qa-reports` integration (59), router-coverage + aggregates + issues-list (31).
- Biome lint over all 12 touched files: clean, no unused imports.

Memex: spec-377 (child of spec-355), left at `verify`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)