### PR TITLE
spec-378: hoist duplicated channel/actor_kind CHECK vocab to named constants [P3]

### DIFF
--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -1,4 +1,4 @@
-import { pgTable, text, uuid, timestamp, integer, unique, uniqueIndex, check, primaryKey, jsonb, boolean, index, customType, doublePrecision } from "drizzle-orm/pg-core";
+import { pgTable, text, uuid, timestamp, integer, unique, uniqueIndex, check, primaryKey, jsonb, boolean, index, customType, doublePrecision, type AnyPgColumn } from "drizzle-orm/pg-core";
 import { relations, type InferSelectModel, type InferInsertModel, sql } from "drizzle-orm";
 import type { CommentAction, CommentAudience } from "../types/roles.js";
 
@@ -44,6 +44,21 @@ const inet = customType<{ data: string; driverData: string }>({
     return "inet";
   },
 });
+
+// std-32 (spec-122 dec-2) — the activity contract's load-bearing vocabularies.
+// HOW (`channel`) = the surface a write arrived through; WHO-kind (`actor_kind`) =
+// the class of actor behind it. These value lists are duplicated across every
+// activity-bearing table's CHECK; hoisting them to one source keeps the allowed
+// set authoritative and drift-proof. The fragment interpolates the table's own
+// column so the emitted SQL stays byte-identical to the per-site originals.
+//
+// NOTE: comms_log.channel is a *notification* channel ('email','in_app',…) — a
+// different vocabulary that intentionally does NOT use this helper.
+const activityChannelCheck = (column: AnyPgColumn) =>
+  sql`${column} IN ('rest_ui', 'mcp', 'in_app_agent', 'server')`;
+
+const activityActorKindCheck = (column: AnyPgColumn) =>
+  sql`${column} IN ('human', 'mcp_agent', 'in_app_agent', 'system')`;
 
 // Forward-declared so child tables can reference memexes.id. The actual memexes table
 // definition lives later in this file (multi-tenancy section). All resource tables carry
@@ -172,7 +187,7 @@ export const docSections = pgTable(
   (table) => [
     check(
       "doc_sections_channel_valid",
-      sql`${table.channel} IN ('rest_ui', 'mcp', 'in_app_agent', 'server')`,
+      activityChannelCheck(table.channel),
     ),
     // `seq` is the allocate-once identity (spec-150 dec-2): minted as MAX(seq)+1 and
     // never reused, so a deleted section's frozen seq can't collide with a live one.
@@ -373,7 +388,7 @@ export const docComments = pgTable(
     ),
     check(
       "doc_comments_channel_valid",
-      sql`${table.channel} IN ('rest_ui', 'mcp', 'in_app_agent', 'server')`
+      activityChannelCheck(table.channel)
     ),
     // doc-26 t-4: cross_reference comments must point at exactly one target
     // kind (or zero, for legacy rows whose backfill couldn't resolve a
@@ -469,7 +484,7 @@ export const decisions = pgTable(
     ),
     check(
       "decisions_channel_valid",
-      sql`${table.channel} IN ('rest_ui', 'mcp', 'in_app_agent', 'server')`,
+      activityChannelCheck(table.channel),
     ),
     check(
       "decisions_status_valid",
@@ -529,7 +544,7 @@ export const tasks = pgTable(
       .where(sql`${table.actorUserId} IS NOT NULL`),
     check(
       "tasks_channel_valid",
-      sql`${table.channel} IN ('rest_ui', 'mcp', 'in_app_agent', 'server')`,
+      activityChannelCheck(table.channel),
     ),
   ]
 );
@@ -641,7 +656,7 @@ export const acs = pgTable(
     // allowed while a stamped value is constrained to the contract's vocabulary.
     check(
       "acs_channel_valid",
-      sql`${table.channel} IN ('rest_ui', 'mcp', 'in_app_agent', 'server')`,
+      activityChannelCheck(table.channel),
     ),
   ]
 );
@@ -2571,11 +2586,11 @@ export const activityLog = pgTable(
     ),
     check(
       "activity_log_actor_kind_valid",
-      sql`${table.actorKind} IN ('human', 'mcp_agent', 'in_app_agent', 'system')`
+      activityActorKindCheck(table.actorKind)
     ),
     check(
       "activity_log_channel_valid",
-      sql`${table.channel} IN ('rest_ui', 'mcp', 'in_app_agent', 'server')`
+      activityChannelCheck(table.channel)
     ),
   ]
 );
@@ -2834,11 +2849,11 @@ export const presence = pgTable(
     index("presence_memex_id_last_seen_at_idx").on(table.memexId, table.lastSeenAt),
     check(
       "presence_actor_kind_valid",
-      sql`${table.actorKind} IN ('human', 'mcp_agent', 'in_app_agent', 'system')`,
+      activityActorKindCheck(table.actorKind),
     ),
     check(
       "presence_channel_valid",
-      sql`${table.channel} IN ('rest_ui', 'mcp', 'in_app_agent', 'server')`,
+      activityChannelCheck(table.channel),
     ),
   ]
 );

--- a/packages/server/src/db/spec-378-activity-check-vocab.test.ts
+++ b/packages/server/src/db/spec-378-activity-check-vocab.test.ts
@@ -1,0 +1,128 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, it, expect } from "vitest";
+import { getTableConfig, PgDialect } from "drizzle-orm/pg-core";
+import { tagAc } from "@memex-ai-ac/vitest";
+import {
+  docSections,
+  docComments,
+  decisions,
+  tasks,
+  acs,
+  activityLog,
+  presence,
+  commsLog,
+} from "./schema.js";
+
+// spec-378 (parent spec-355 dry-3, audit spec-345) — the activity contract's
+// `channel` / `actor_kind` CHECK vocabularies (std-32) were hand-written across
+// 9 sites in schema.ts. They were hoisted to two named SQL-fragment helpers
+// (activityChannelCheck / activityActorKindCheck) that interpolate each table's
+// own column. This guard pins the EMITTED CHECK SQL byte-for-byte, so a future
+// edit to a helper (or an accidental drift of an allowed value) is caught: the
+// allowed values are load-bearing (std-32), and the refactor must be SQL-identical.
+
+const AC = "mindset-prod/memex-building-itself/specs/spec-378/acs/ac-5";
+// Scope ACs this guard empirically verifies (outcome commitments):
+const AC_CHANNEL_SINGLE_SOURCE = "mindset-prod/memex-building-itself/specs/spec-378/acs/ac-1";
+const AC_ACTOR_KIND_SINGLE_SOURCE = "mindset-prod/memex-building-itself/specs/spec-378/acs/ac-2";
+const AC_BYTE_IDENTICAL = "mindset-prod/memex-building-itself/specs/spec-378/acs/ac-3";
+const AC_COMMS_LOG_UNTOUCHED = "mindset-prod/memex-building-itself/specs/spec-378/acs/ac-4";
+
+const dialect = new PgDialect();
+
+// The pre-refactor literal SQL for each CHECK — proven byte-identical to HEAD by
+// emitting both via getTableConfig + sqlToQuery and diffing (dec-1 resolution).
+const CHANNEL_LIST = "IN ('rest_ui', 'mcp', 'in_app_agent', 'server')";
+const ACTOR_KIND_LIST = "IN ('human', 'mcp_agent', 'in_app_agent', 'system')";
+
+// table object → fully-qualified column reference drizzle emits in the CHECK.
+const CHANNEL_TABLES: Array<[string, ReturnType<typeof getTableConfig>, string]> = [
+  ["doc_sections", getTableConfig(docSections), `"doc_sections"."channel" ${CHANNEL_LIST}`],
+  ["doc_comments", getTableConfig(docComments), `"doc_comments"."channel" ${CHANNEL_LIST}`],
+  ["decisions", getTableConfig(decisions), `"decisions"."channel" ${CHANNEL_LIST}`],
+  ["tasks", getTableConfig(tasks), `"tasks"."channel" ${CHANNEL_LIST}`],
+  ["acs", getTableConfig(acs), `"acs"."channel" ${CHANNEL_LIST}`],
+  ["activity_log", getTableConfig(activityLog), `"activity_log"."channel" ${CHANNEL_LIST}`],
+  ["presence", getTableConfig(presence), `"presence"."channel" ${CHANNEL_LIST}`],
+];
+
+const ACTOR_KIND_TABLES: Array<[string, ReturnType<typeof getTableConfig>, string]> = [
+  ["activity_log", getTableConfig(activityLog), `"activity_log"."actor_kind" ${ACTOR_KIND_LIST}`],
+  ["presence", getTableConfig(presence), `"presence"."actor_kind" ${ACTOR_KIND_LIST}`],
+];
+
+function checkSqlByName(cfg: ReturnType<typeof getTableConfig>, name: string): string {
+  const check = cfg.checks.find((c) => c.name === name);
+  if (!check) throw new Error(`CHECK '${name}' not found on table`);
+  return dialect.sqlToQuery(check.value).sql;
+}
+
+describe("spec-378: activity-contract CHECK vocab is hoisted, SQL byte-identical (ac-5)", () => {
+  it("ac-5: all 7 channel CHECKs emit the canonical activity-channel vocabulary verbatim", () => {
+    tagAc(AC);
+    for (const [table, cfg, expected] of CHANNEL_TABLES) {
+      const constraintName = `${table}_channel_valid`;
+      const got = checkSqlByName(cfg, constraintName);
+      expect(got, `${constraintName} CHECK SQL drifted`).toBe(expected);
+    }
+  });
+
+  it("ac-5: both actor_kind CHECKs emit the canonical actor-kind vocabulary verbatim", () => {
+    tagAc(AC);
+    for (const [table, cfg, expected] of ACTOR_KIND_TABLES) {
+      const constraintName = `${table}_actor_kind_valid`;
+      const got = checkSqlByName(cfg, constraintName);
+      expect(got, `${constraintName} CHECK SQL drifted`).toBe(expected);
+    }
+  });
+
+  it("ac-4 / ac-5: comms_log.channel keeps its DISTINCT notification vocabulary (not collapsed onto the activity helper)", () => {
+    tagAc(AC);
+    tagAc(AC_COMMS_LOG_UNTOUCHED);
+    const got = checkSqlByName(getTableConfig(commsLog), "comms_log_channel_valid");
+    expect(got).toBe(`"comms_log"."channel" IN ('email', 'in_app', 'badge', 'os')`);
+    // And it must NOT have been rewritten to the activity-channel list.
+    expect(got).not.toContain("rest_ui");
+  });
+});
+
+// Source-level single-source guard: the load-bearing value-list literal for each
+// activity vocabulary must appear EXACTLY ONCE in schema.ts — inside its helper.
+// That is what "defined in exactly one place" (ac-1 / ac-2) means concretely.
+const SCHEMA_SRC = readFileSync(
+  fileURLToPath(new URL("./schema.ts", import.meta.url)),
+  "utf8",
+);
+
+function countOccurrences(haystack: string, needle: string): number {
+  return haystack.split(needle).length - 1;
+}
+
+describe("spec-378: each activity vocabulary literal is defined in exactly one place (ac-1, ac-2)", () => {
+  it("ac-1: the channel value-list literal appears exactly once in schema.ts (the helper)", () => {
+    tagAc(AC_CHANNEL_SINGLE_SOURCE);
+    expect(
+      countOccurrences(SCHEMA_SRC, "IN ('rest_ui', 'mcp', 'in_app_agent', 'server')"),
+      "activity-channel vocabulary should be hoisted to a single helper",
+    ).toBe(1);
+  });
+
+  it("ac-2: the actor_kind value-list literal appears exactly once in schema.ts (the helper)", () => {
+    tagAc(AC_ACTOR_KIND_SINGLE_SOURCE);
+    expect(
+      countOccurrences(SCHEMA_SRC, "IN ('human', 'mcp_agent', 'in_app_agent', 'system')"),
+      "actor_kind vocabulary should be hoisted to a single helper",
+    ).toBe(1);
+  });
+
+  it("ac-3: byte-identity is asserted (cross-tags the dedicated emitted-SQL checks above)", () => {
+    tagAc(AC_BYTE_IDENTICAL);
+    // The emitted-SQL assertions in the first describe block prove byte-identity;
+    // this case ties that empirical proof to the byte-identity scope AC explicitly.
+    for (const [, cfg, expected] of [...CHANNEL_TABLES, ...ACTOR_KIND_TABLES]) {
+      const name = cfg.checks.find((c) => dialect.sqlToQuery(c.value).sql === expected)?.name;
+      expect(name, `expected a CHECK emitting exactly: ${expected}`).toBeTruthy();
+    }
+  });
+});


### PR DESCRIPTION
## What

Behaviour-preserving DRY refactor (parent **spec-355** finding **dry-3**, HIGH; audit **spec-345**; sibling precedent spec-374/spec-368). Child Spec: **spec-378**.

In `packages/server/src/db/schema.ts` the activity contract's two load-bearing CHECK vocabularies (**std-32**) were hand-written across many tables:

- `channel IN ('rest_ui', 'mcp', 'in_app_agent', 'server')` — duplicated **7×** (`doc_sections`, `doc_comments`, `decisions`, `tasks`, `acs`, `activity_log`, `presence`).
- `actor_kind IN ('human', 'mcp_agent', 'in_app_agent', 'system')` — duplicated **2×** (`activity_log`, `presence`).

Both are now hoisted to a single named SQL-fragment helper each:

```ts
const activityChannelCheck   = (column: AnyPgColumn) => sql`${column} IN ('rest_ui', 'mcp', 'in_app_agent', 'server')`;
const activityActorKindCheck = (column: AnyPgColumn) => sql`${column} IN ('human', 'mcp_agent', 'in_app_agent', 'system')`;
```

Each CHECK site calls the helper with its own column, so drizzle's per-table column interpolation is preserved.

## std-32 grounding

Per **std-32** (the activity contract, spec-122 dec-2) the allowed `channel` (HOW) and `actor_kind` (WHO-kind) values are load-bearing — a missed copy on a future vocabulary change is silent contract drift. One source per vocabulary makes the allowed set authoritative.

## SQL is byte-identical

This is a `schema.ts` SOURCE refactor only — **no drizzle migration is generated or added**; the emitted SQL must not change. Proven by emitting every CHECK's SQL via `getTableConfig` + `new PgDialect().sqlToQuery()` on `HEAD`'s schema vs the refactor and diffing — **IDENTICAL** (e.g. `"acs"."channel" IN ('rest_ui', 'mcp', 'in_app_agent', 'server')`). A new vitest guard (`spec-378-activity-check-vocab.test.ts`) pins the emitted CHECK SQL byte-for-byte and asserts each vocabulary literal appears exactly once.

`comms_log.channel` (`'email','in_app','badge','os'`) is a **distinct notification vocabulary** — deliberately left inline and NOT collapsed onto the activity helper.

## Lean verification

Per the agent-watchdog constraint (no long silent full-suite runs), verification was lean; full sharded suites are deferred to CI (the merge authority):

- `pnpm --filter @memex/server exec tsc --noEmit` — 0 errors in the touched files (only pre-existing unrelated test-file errors remain).
- `pnpm exec biome check` over `schema.ts` + the new test — clean.
- Targeted vitest `spec-378-activity-check-vocab.test.ts` — 6 tests green; flips all 5 spec-378 ACs to verified (1 implementation + 4 scope).
- Programmatic HEAD-vs-refactor SQL-emission diff — byte-identical.

## Scope

- Files changed: `packages/server/src/db/schema.ts` (helpers + 9 call sites), new `packages/server/src/db/spec-378-activity-check-vocab.test.ts`.
- No Dockerfile / tsconfig / package.json / .github / migration changes.
- Licence: fair-code (open core) — no `.ee` files touched (std-25).

🤖 Generated with [Claude Code](https://claude.com/claude-code)