### PR TITLE
spec-376: route documents.ts body-parse through shared validation helpers

### DIFF
--- a/packages/server/src/routes/documents.ts
+++ b/packages/server/src/routes/documents.ts
@@ -14,7 +14,12 @@ import {
   parseTagInput,
   type ParsedTag,
 } from "../services/tags.js";
-import { ValidationError } from "../types/errors.js";
+import {
+  parseJsonBodyOrNull,
+  requireString,
+  requireStringType,
+  requireStringArray,
+} from "./validation.js";
 import {
   createShareToken,
   listShareTokensForDoc,
@@ -228,11 +233,10 @@ docs.get("/:id", async (c) => {
 docs.post("/:id/status", async (c) => {
   const memexId = requireMemexId(c);
   const id = c.req.param("id");
-  const body = (await c.req.json().catch(() => null)) as { status?: unknown } | null;
-  const status = body?.status;
-  if (typeof status !== "string") {
-    throw new ValidationError("Body must include a 'status' string");
-  }
+  const body = await parseJsonBodyOrNull<{ status?: unknown }>(c);
+  const status = requireStringType(body?.status, "status", {
+    message: "Body must include a 'status' string",
+  });
   // spec-122 dec-3 — carry the actor/channel onto the status_changed journal row.
   const updated = await updateDocStatus(memexId, id, status, { source: "rest", ctx: restCtx(c) });
   return c.json(updated);
@@ -262,14 +266,10 @@ docs.post("/:id/unpause", async (c) => {
 docs.post("/:id/move", async (c) => {
   const memexId = requireMemexId(c);
   const id = c.req.param("id");
-  const body = (await c.req.json().catch(() => null)) as {
-    targetMemexId?: unknown;
-  } | null;
-
-  const targetMemexId = body?.targetMemexId;
-  if (typeof targetMemexId !== "string" || targetMemexId.length === 0) {
-    throw new ValidationError("Body must include a 'targetMemexId' string");
-  }
+  const body = await parseJsonBodyOrNull<{ targetMemexId?: unknown }>(c);
+  const targetMemexId = requireString(body?.targetMemexId, "targetMemexId", {
+    message: "Body must include a 'targetMemexId' string",
+  });
 
   // spec-293 dec-2/dec-3: a move is always whole — no per-artifact opt-out. The
   // RequestCtx carries the actor + rest_ui channel onto both emitted events
@@ -282,11 +282,10 @@ docs.post("/:id/move", async (c) => {
 docs.post("/:id/title", async (c) => {
   const memexId = requireMemexId(c);
   const id = c.req.param("id");
-  const body = (await c.req.json().catch(() => null)) as { title?: unknown } | null;
-  const title = body?.title;
-  if (typeof title !== "string") {
-    throw new ValidationError("Body must include a 'title' string");
-  }
+  const body = await parseJsonBodyOrNull<{ title?: unknown }>(c);
+  const title = requireStringType(body?.title, "title", {
+    message: "Body must include a 'title' string",
+  });
   const updated = await updateDocTitle(memexId, id, title);
   return c.json(updated);
 });
@@ -305,17 +304,16 @@ docs.post("/:id/title", async (c) => {
 docs.post("/:id/tags", async (c) => {
   const memexId = requireMemexId(c);
   const id = c.req.param("id");
-  const body = (await c.req.json().catch(() => null)) as { tags?: unknown } | null;
-  const rawTags = body?.tags;
-  if (!Array.isArray(rawTags) || rawTags.some((t) => typeof t !== "string")) {
-    throw new ValidationError("Body must include a 'tags' array of strings");
-  }
+  const body = await parseJsonBodyOrNull<{ tags?: unknown }>(c);
+  const rawTags = requireStringArray(body?.tags, "tags", {
+    message: "Body must include a 'tags' array of strings",
+  });
   const addedBy = (c.get("currentUserId") as string | null) ?? null;
   const applied = await applyTagStrings(
     { channel: "rest_ui" },
     memexId,
     id,
-    rawTags as string[],
+    rawTags,
     addedBy,
   );
   const docTags = await listDocTags(memexId, id);
@@ -327,11 +325,10 @@ docs.post("/:id/tags", async (c) => {
 docs.post("/:id/tags/remove", async (c) => {
   const memexId = requireMemexId(c);
   const id = c.req.param("id");
-  const body = (await c.req.json().catch(() => null)) as { tagId?: unknown } | null;
-  const tagId = body?.tagId;
-  if (typeof tagId !== "string" || tagId.length === 0) {
-    throw new ValidationError("Body must include a 'tagId' string");
-  }
+  const body = await parseJsonBodyOrNull<{ tagId?: unknown }>(c);
+  const tagId = requireString(body?.tagId, "tagId", {
+    message: "Body must include a 'tagId' string",
+  });
   await removeTagFromDoc({ channel: "rest_ui" }, memexId, id, tagId);
   const docTags = await listDocTags(memexId, id);
   return c.json({ tags: docTags });
@@ -353,11 +350,10 @@ docs.post("/sections/:sectionId/split", async (c) => {
 docs.post("/sections/:sectionId", async (c) => {
   const memexId = requireMemexId(c);
   const sectionId = c.req.param("sectionId");
-  const body = await c.req.json().catch(() => ({}));
-  const content = body?.content;
-  if (typeof content !== "string") {
-    throw new ValidationError("Body must include a 'content' string");
-  }
+  const body = await parseJsonBodyOrNull<{ content?: unknown }>(c);
+  const content = requireStringType(body?.content, "content", {
+    message: "Body must include a 'content' string",
+  });
   const updated = await updateSection(memexId, sectionId, content, {}, restCtx(c));
   return c.json(updated);
 });

--- a/packages/server/src/routes/validation.test.ts
+++ b/packages/server/src/routes/validation.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect } from "vitest";
-import { requireString, requireUuid, requireEmail, readJsonBody } from "./validation.js";
+import {
+  requireString,
+  requireStringType,
+  requireStringArray,
+  requireUuid,
+  requireEmail,
+  readJsonBody,
+  parseJsonBodyOrNull,
+} from "./validation.js";
 import { ValidationError } from "../types/errors.js";
 
 describe("requireString", () => {
@@ -40,6 +48,91 @@ describe("requireString", () => {
     expect(requireString("a".repeat(100), "name", { trim: true, maxLength: 100 })).toHaveLength(
       100,
     );
+  });
+
+  it("uses a custom message when { message } is supplied (default path unchanged otherwise)", () => {
+    try {
+      requireString(undefined, "targetMemexId", {
+        message: "Body must include a 'targetMemexId' string",
+      });
+      expect.fail("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ValidationError);
+      expect((err as Error).message).toBe("Body must include a 'targetMemexId' string");
+    }
+    // No-message callers keep the default wording.
+    expect(() => requireString(undefined, "domain")).toThrow("domain is required");
+  });
+});
+
+describe("requireStringType", () => {
+  it("ACCEPTS the empty string (unlike requireString)", () => {
+    expect(requireStringType("", "title")).toBe("");
+    expect(requireStringType("hello", "title")).toBe("hello");
+  });
+
+  it("throws on non-string with the default message", () => {
+    expect(() => requireStringType(undefined, "content")).toThrow("content must be a string");
+    expect(() => requireStringType(123, "content")).toThrow(ValidationError);
+    expect(() => requireStringType(null, "content")).toThrow(ValidationError);
+  });
+
+  it("uses a custom message when supplied", () => {
+    expect(() =>
+      requireStringType(undefined, "status", {
+        message: "Body must include a 'status' string",
+      }),
+    ).toThrow("Body must include a 'status' string");
+  });
+});
+
+describe("requireStringArray", () => {
+  it("returns the array when every element is a string", () => {
+    expect(requireStringArray(["a", "b"], "tags")).toEqual(["a", "b"]);
+    expect(requireStringArray([], "tags")).toEqual([]);
+  });
+
+  it("throws on non-array or arrays with a non-string element", () => {
+    expect(() => requireStringArray(undefined, "tags")).toThrow("tags must be an array of strings");
+    expect(() => requireStringArray("nope", "tags")).toThrow(ValidationError);
+    expect(() => requireStringArray(["a", 1], "tags")).toThrow(ValidationError);
+  });
+
+  it("uses a custom message when supplied", () => {
+    expect(() =>
+      requireStringArray(null, "tags", {
+        message: "Body must include a 'tags' array of strings",
+      }),
+    ).toThrow("Body must include a 'tags' array of strings");
+  });
+});
+
+describe("parseJsonBodyOrNull", () => {
+  it("returns parsed JSON when valid", async () => {
+    const c = { req: { json: async () => ({ a: 1 }) } };
+    expect(await parseJsonBodyOrNull(c)).toEqual({ a: 1 });
+  });
+
+  it("returns null on malformed JSON (does NOT throw, unlike readJsonBody)", async () => {
+    const c = {
+      req: {
+        json: async () => {
+          throw new SyntaxError("bad");
+        },
+      },
+    };
+    expect(await parseJsonBodyOrNull(c)).toBeNull();
+  });
+
+  it("honours a custom fallback", async () => {
+    const c = {
+      req: {
+        json: async () => {
+          throw new SyntaxError("bad");
+        },
+      },
+    };
+    expect(await parseJsonBodyOrNull(c, {})).toEqual({});
   });
 });
 

--- a/packages/server/src/routes/validation.ts
+++ b/packages/server/src/routes/validation.ts
@@ -20,16 +20,46 @@ const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 export function requireString(
   value: unknown,
   fieldName: string,
-  opts: { trim?: boolean; maxLength?: number } = {}
+  opts: { trim?: boolean; maxLength?: number; message?: string } = {}
 ): string {
   if (typeof value !== "string" || !value || (opts.trim && !value.trim())) {
-    throw new ValidationError(`${fieldName} is required`);
+    throw new ValidationError(opts.message ?? `${fieldName} is required`);
   }
   const out = opts.trim ? value.trim() : value;
   if (opts.maxLength && out.length > opts.maxLength) {
     throw new ValidationError(`${fieldName} must be ${opts.maxLength} characters or fewer`);
   }
   return out;
+}
+
+// Like requireString but ACCEPTS the empty string — the value must merely be of
+// type `string`. Some endpoints legitimately allow an empty body field (e.g. a
+// doc title or section content can be cleared to ""), where requireString's
+// reject-empty rule would be wrong. The `message` overrides the default error
+// text so callers can preserve a bespoke wording verbatim.
+export function requireStringType(
+  value: unknown,
+  fieldName: string,
+  opts: { message?: string } = {}
+): string {
+  if (typeof value !== "string") {
+    throw new ValidationError(opts.message ?? `${fieldName} must be a string`);
+  }
+  return value;
+}
+
+// Requires an array whose every element is a string. Throws ValidationError on
+// any other shape (non-array, or an array containing a non-string). The
+// `message` overrides the default error text to preserve a caller's wording.
+export function requireStringArray(
+  value: unknown,
+  fieldName: string,
+  opts: { message?: string } = {}
+): string[] {
+  if (!Array.isArray(value) || value.some((v) => typeof v !== "string")) {
+    throw new ValidationError(opts.message ?? `${fieldName} must be an array of strings`);
+  }
+  return value as string[];
 }
 
 export function requireUuid(value: unknown, fieldName: string): string {
@@ -58,5 +88,21 @@ export async function readJsonBody<T = Record<string, unknown>>(c: {
     return (await c.req.json()) as T;
   } catch {
     throw new ValidationError("Request body must be valid JSON");
+  }
+}
+
+// Parses JSON body, returning `fallback` (default null) on malformed JSON
+// INSTEAD of throwing — the opposite policy to readJsonBody. This is for
+// endpoints that intentionally let a bad/empty body fall through to a
+// field-specific validation message (`c.req.json().catch(() => null)`), so the
+// caller's own field check, not a generic JSON error, decides the response.
+export async function parseJsonBodyOrNull<T = Record<string, unknown>>(
+  c: { req: { json: () => Promise<unknown> } },
+  fallback: T | null = null
+): Promise<T | null> {
+  try {
+    return (await c.req.json()) as T;
+  } catch {
+    return fallback;
   }
 }


### PR DESCRIPTION
## What

dry-9 of the spec-355 DRY audit. `routes/documents.ts` open-coded the
**body-parse + typecheck + `ValidationError`** dance **6 times**. This routes all six sites through the shared helpers in `routes/validation.ts`:

- `POST /:id/status`
- `POST /:id/move`
- `POST /:id/title`
- `POST /:id/tags`
- `POST /:id/tags/remove`
- `POST /sections/:sectionId`

## How — extend the shared helpers backward-compatibly

A verbatim swap onto the existing `readJsonBody` / `requireString` would have *changed* behaviour (different message text, throw-on-bad-JSON instead of fall-through, no array case). So the helpers are extended additively, defaults untouched:

- **`requireString`** gains an optional `{ message }` to override the default `"<field> is required"` wording. **Default path is unchanged** — `share.ts`, `orgs.ts`, all `auth/*` callers stay byte-identical.
- **`requireStringType`** (new) — like `requireString` but **accepts `""`**. `status` / `title` / `content` legitimately allow an empty value, which `requireString` rejects; this preserves that.
- **`requireStringArray`** (new) — array-of-strings validation for the `/:id/tags` case.
- **`parseJsonBodyOrNull`** (new) — parses the body, returning `null` on malformed JSON (the `c.req.json().catch(() => null)` policy), so the field check still produces the field-specific message. `readJsonBody`'s throw-on-bad-JSON default is **left untouched** for its existing callers.

## Error responses are unchanged

Every one of the 6 sites keeps its **exact message text** (`Body must include a '<field>' string` / `... array of strings`), **HTTP 400**, **empty-string semantics**, **array handling**, and **malformed-JSON fall-through**. No request/response contract changes. The per-verb session-policy middleware wiring is untouched (a sibling refactor owns it).

## Lean verification

- `pnpm --filter @memex/server exec tsc --noEmit` — **0 errors in touched files** (documents.ts, validation.ts, validation.test.ts).
- vitest: `validation.test.ts` (**+10 new helper tests, 52 pass**), `documents.test.ts`, `documents.tags.test.ts`, `share.integration.test.ts` — **all green**.
- biome check on touched files — clean, no unused imports.
- Full sharded suites left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)