### PR TITLE
refactor(ui): generic useBadgeCount + shared link class const (spec-379)

### DIFF
--- a/packages/ui/src/components/DecisionLink.tsx
+++ b/packages/ui/src/components/DecisionLink.tsx
@@ -28,6 +28,24 @@ import {
 const SPEC_DOC_TYPES = new Set(['spec']);
 const parentDocTypeCache = new Map<string, Promise<string | null>>();
 
+/**
+ * Shared inline-cite button className (spec-355 dry-12). DecisionLink and
+ * TaskLink render identical inline-link buttons; this single source keeps their
+ * styling — base layout + the error-vs-interactive state branch + the disabled
+ * dimming — byte-identical. `error` toggles the danger (non-interactive)
+ * treatment vs the accent (clickable) treatment.
+ */
+function linkButtonClassName(error: boolean): string {
+  return `
+        inline-flex items-center font-mono text-[0.95em]
+        rounded-sm px-1 py-px transition-colors
+        ${error
+          ? 'text-status-danger-text bg-status-danger-bg cursor-default'
+          : 'text-accent hover:text-accent-hover hover:bg-card-hover cursor-pointer'}
+        disabled:opacity-60
+      `;
+}
+
 async function resolveParentDocType(docHandle: string): Promise<string | null> {
   let pending = parentDocTypeCache.get(docHandle);
   if (!pending) {
@@ -186,14 +204,7 @@ export function DecisionLink({
           ? `Resolving ${displayLabel}…`
           : `Open source decision ${displayLabel}`
       }
-      className={`
-        inline-flex items-center font-mono text-[0.95em]
-        rounded-sm px-1 py-px transition-colors
-        ${error
-          ? 'text-status-danger-text bg-status-danger-bg cursor-default'
-          : 'text-accent hover:text-accent-hover hover:bg-card-hover cursor-pointer'}
-        disabled:opacity-60
-      `}
+      className={linkButtonClassName(!!error)}
     >
       {displayLabel}
     </button>
@@ -254,14 +265,7 @@ export function TaskLink({
           ? `Resolving ${handle}…`
           : `Open source task ${handle}`
       }
-      className={`
-        inline-flex items-center font-mono text-[0.95em]
-        rounded-sm px-1 py-px transition-colors
-        ${error
-          ? 'text-status-danger-text bg-status-danger-bg cursor-default'
-          : 'text-accent hover:text-accent-hover hover:bg-card-hover cursor-pointer'}
-        disabled:opacity-60
-      `}
+      className={linkButtonClassName(!!error)}
     >
       {handle}
     </button>

--- a/packages/ui/src/hooks/useBadgeCount.ts
+++ b/packages/ui/src/hooks/useBadgeCount.ts
@@ -1,0 +1,61 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useLocation } from 'react-router-dom';
+import { useDocChangeStream } from './useDocChangeStream';
+
+/**
+ * Shared nav-badge count hook (spec-355 dry-11). Backs the drift-inbox and
+ * my-issues badges, which were byte-identical except for the fetch they invoke.
+ *
+ * Behaviour (identical to the two former hooks):
+ * - Best-effort: any fetch error yields 0 so the badge hides rather than
+ *   surfacing an error in the chrome.
+ * - Re-fetches whenever the URL pathname changes. The host (AppShell) stays
+ *   mounted across a client-side Memex switch (the switcher uses `navigate()`,
+ *   not a full reload), and `fetchItems` resolves the tenant from the URL path,
+ *   so a path change MUST re-run the fetch against the newly-selected tenant —
+ *   otherwise the badge keeps the prior Memex's stale count.
+ * - Refreshes live on the SSE bus (drift/issues are mutated by the agent, often
+ *   via MCP), so the badge reacts without a manual reload.
+ * - Pass `enabled = false` (e.g. on doc pages where the sidebar is hidden) to
+ *   skip the fetch entirely.
+ *
+ * `fetchItems` is the single axis of variation (spec-379 dec-1). It is held in
+ * a ref refreshed each render so `reload` can keep its deps as
+ * `[enabled, pathname]` — `reload`'s identity stays stable across renders and
+ * the effect re-runs only on mount / enabled change / pathname change / SSE,
+ * exactly as the former hooks did. Callers pass a module-stable thunk.
+ */
+export function useBadgeCount(
+  fetchItems: () => Promise<{ length: number }>,
+  enabled = true,
+): number {
+  const [count, setCount] = useState(0);
+  // The active tenant lives in the URL path; re-fetch whenever it changes.
+  const { pathname } = useLocation();
+
+  // Hold the fetch in a ref so its identity never feeds the `reload` deps —
+  // keeping `reload` stable across renders (matches the former hooks exactly).
+  const fetchItemsRef = useRef(fetchItems);
+  fetchItemsRef.current = fetchItems;
+
+  const reload = useCallback(() => {
+    if (!enabled) return;
+    fetchItemsRef
+      .current()
+      .then((items) => setCount(items.length))
+      .catch(() => setCount(0));
+    // `pathname` is a dependency so a Memex switch (client-side navigation,
+    // host stays mounted) re-fetches against the newly-selected tenant.
+  }, [enabled, pathname]);
+
+  useEffect(() => {
+    reload();
+  }, [reload]);
+
+  // Same global channel the inbox / issues boards use — entries are flagged or
+  // resolved by the agent (often via MCP), so the badge must react without a
+  // manual refresh.
+  useDocChangeStream(null, reload);
+
+  return count;
+}

--- a/packages/ui/src/hooks/useDriftInboxCount.ts
+++ b/packages/ui/src/hooks/useDriftInboxCount.ts
@@ -1,47 +1,18 @@
-import { useCallback, useEffect, useState } from 'react';
-import { useLocation } from 'react-router-dom';
 import { fetchDriftInbox } from '../api/client';
-import { useDocChangeStream } from './useDocChangeStream';
+import { useBadgeCount } from './useBadgeCount';
 
 /**
  * Open standards drift + proposal count for the nav badge (b-63).
  *
- * Best-effort: any fetch error (e.g. no tenant resolvable on a flat route)
- * yields 0 so the badge simply hides rather than surfacing an error in the
- * chrome. Refreshes live on the SSE bus, so flagging or resolving drift updates
- * the badge without a reload. Pass `enabled = false` (e.g. on doc pages where
- * the sidebar is hidden) to skip the fetch entirely.
+ * Thin wrapper over the shared {@link useBadgeCount} (spec-355 dry-11): the
+ * count is the number of drift-inbox items for the current tenant. Best-effort
+ * (errors → 0), tenant-aware (re-fetches on a client-side Memex switch), and
+ * live on the SSE bus. Pass `enabled = false` (e.g. on doc pages where the
+ * sidebar is hidden) to skip the fetch entirely.
  *
- * `fetchDriftInbox` resolves the tenant from the URL path (`tBase()`), so the
- * count is implicitly scoped to the current Memex. But AppShell — where this
- * hook lives — stays mounted across a Memex switch (the switcher uses client-
- * side `navigate()`, not a full reload), so we MUST re-fetch when the active
- * tenant changes. We key the refetch on the location pathname: switching
- * `barrie/personal` → `Main` changes the path, which re-runs `reload()` against
- * the new tenant base and updates the badge (e.g. 3 → 0). Without this the badge
- * would keep the prior Memex's stale count even though the page body is empty.
+ * `fetchDriftInbox` is a module-level function, so the thunk passed here is
+ * stable across renders.
  */
 export function useDriftInboxCount(enabled = true): number {
-  const [count, setCount] = useState(0);
-  // The active tenant lives in the URL path; re-fetch whenever it changes.
-  const { pathname } = useLocation();
-
-  const reload = useCallback(() => {
-    if (!enabled) return;
-    fetchDriftInbox()
-      .then((items) => setCount(items.length))
-      .catch(() => setCount(0));
-    // `pathname` is a dependency so a Memex switch (client-side navigation,
-    // AppShell stays mounted) re-fetches against the newly-selected tenant.
-  }, [enabled, pathname]);
-
-  useEffect(() => {
-    reload();
-  }, [reload]);
-
-  // Same global channel the inbox + standards boards use — drift is flagged by
-  // the agent (often via MCP), so the badge must react without a manual refresh.
-  useDocChangeStream(null, reload);
-
-  return count;
+  return useBadgeCount(fetchDriftInbox, enabled);
 }

--- a/packages/ui/src/hooks/useMyIssuesCount.ts
+++ b/packages/ui/src/hooks/useMyIssuesCount.ts
@@ -1,7 +1,9 @@
-import { useCallback, useEffect, useState } from 'react';
-import { useLocation } from 'react-router-dom';
 import { fetchMemexIssues } from '../api/client';
-import { useDocChangeStream } from './useDocChangeStream';
+import { useBadgeCount } from './useBadgeCount';
+
+// Module-stable thunk so the reference handed to useBadgeCount never changes
+// across renders (mirrors useDriftInboxCount passing the bare fetch fn).
+const fetchMine = () => fetchMemexIssues({ scope: 'mine' });
 
 /**
  * Open-issue count for the Issues nav badge (spec-158) — scoped to MY issues
@@ -9,33 +11,11 @@ import { useDocChangeStream } from './useDocChangeStream';
  * `scope=mine` default), matching the Issues page's own Mine default so the
  * badge and the landing view agree.
  *
- * Mirrors useDriftInboxCount: best-effort (any fetch error yields 0 so the
- * badge hides rather than erroring in the chrome), refreshes live on the SSE
- * bus, and re-fetches on a pathname change because AppShell stays mounted
- * across a client-side Memex switch. Pass `enabled = false` (e.g. on doc pages
+ * Thin wrapper over the shared {@link useBadgeCount} (spec-355 dry-11):
+ * best-effort (errors → 0), tenant-aware (re-fetches on a client-side Memex
+ * switch), and live on the SSE bus. Pass `enabled = false` (e.g. on doc pages
  * where the sidebar is hidden) to skip the fetch entirely.
  */
 export function useMyIssuesCount(enabled = true): number {
-  const [count, setCount] = useState(0);
-  // The active tenant lives in the URL path; re-fetch whenever it changes.
-  const { pathname } = useLocation();
-
-  const reload = useCallback(() => {
-    if (!enabled) return;
-    fetchMemexIssues({ scope: 'mine' })
-      .then((items) => setCount(items.length))
-      .catch(() => setCount(0));
-    // `pathname` is a dependency so a Memex switch (client-side navigation,
-    // AppShell stays mounted) re-fetches against the newly-selected tenant.
-  }, [enabled, pathname]);
-
-  useEffect(() => {
-    reload();
-  }, [reload]);
-
-  // Same global channel the Issues page rides — issues are registered/resolved
-  // by agents (often via MCP), so the badge must react without a manual refresh.
-  useDocChangeStream(null, reload);
-
-  return count;
+  return useBadgeCount(fetchMine, enabled);
 }


### PR DESCRIPTION
Behaviour-preserving DRY refactor in `packages/ui` — spec-355 audit **dry-11** + **dry-12** (parent audit spec-345). Child Spec: **spec-379**.

## dry-11 — unify the twin nav-badge hooks
`useDriftInboxCount` and `useMyIssuesCount` were the same hook differing only in the fetch they invoke. Collapsed into one generic:

```ts
useBadgeCount(fetchItems: () => Promise<{ length: number }>, enabled = true): number
```

It captures the shared mechanics: best-effort count (catch → 0), `useLocation` pathname dependency (re-fetch on a client-side Memex switch while AppShell stays mounted), SSE refresh via `useDocChangeStream(null, reload)`, and the `enabled` gate.

**Behaviour identity:** `fetchItems` is held in a ref refreshed each render, so `reload`'s `useCallback` deps stay `[enabled, pathname]` — `reload` identity is stable across renders and the effect re-runs only on mount / enabled / pathname / SSE, the exact trigger set of both originals. The two named hooks become one-line wrappers passing **module-stable** thunks (`fetchDriftInbox`; a module-level `fetchMine = () => fetchMemexIssues({ scope: 'mine' })`). Public signatures and AppShell call sites are unchanged.

## dry-12 — shared inline-cite link className
`DecisionLink` and `TaskLink` carried a byte-identical Tailwind className template. Hoisted to one module-level `linkButtonClassName(error: boolean)`; both buttons use `className={linkButtonClassName(!!error)}`. `!!error` reproduces the original truthiness branch, so the class string is **byte-identical** for the error and default branches.

## Behaviour-identity confirmation
- Both named hooks: same fetch invoked, same return shape (`number`), same re-fetch triggers, same caching/SSE semantics. Existing `useDriftInboxCount.test.tsx` (which mocks `./useDriftInboxCount` directly) passes unchanged.
- Both links: byte-identical class output for every branch of the ternary; `DecisionLink.test.tsx` passes unchanged.

## Lean verification
- `pnpm --filter @memex/ui exec tsc -b` → clean
- `pnpm --filter @memex/ui exec vitest run` (useDriftInboxCount, DecisionLink, AppShell) → **43 passed, 1 skipped**
- `pnpm --filter @memex/ui exec biome check` (4 touched files) → clean

Full suites + e2e left to CI (the merge authority). No `.ee` markers; fair-code (open core).

🤖 Generated with [Claude Code](https://claude.com/claude-code)