### PR TITLE
spec-381: adopt <Alert variant="danger"> across UI danger banners

### DIFF
--- a/packages/ui/src/components/AddMemexForm.tsx
+++ b/packages/ui/src/components/AddMemexForm.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { Button } from './ui/Button';
 import { Input } from './ui/Input';
+import { Alert } from './ui/Alert';
 import { useAuth } from './AuthContext';
 import {
   checkMemexSlugApi,
@@ -157,9 +158,9 @@ export function AddMemexForm({
       <SlugStatus slug={trimmed} checking={checking} check={check} />
 
       {submitError && (
-        <div className="px-3 py-2 rounded-lg bg-status-danger-bg border border-status-danger-border text-sm text-status-danger-text">
+        <Alert variant="danger" size="md">
           {submitError}
-        </div>
+        </Alert>
       )}
 
       <div className="flex justify-end gap-2">

--- a/packages/ui/src/components/ChatPanel.tsx
+++ b/packages/ui/src/components/ChatPanel.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect, type KeyboardEvent } from 'react';
 import { Link } from 'react-router-dom';
+import { Alert } from './ui/Alert';
 import { toButtonPrompt, BASE_SCAFFOLD } from '@memex/shared';
 import { useChat } from './ChatContext';
 import { useOrgScaffoldBlocks } from '../hooks/useOrgScaffoldBlocks';
@@ -326,9 +327,9 @@ export function ChatPanel({ isAuthenticated = true, readOnly = false }: ChatPane
         )}
 
         {error && (
-          <div className="px-3 py-2 rounded-lg bg-status-danger-bg border border-status-danger-border text-sm text-status-danger-text">
+          <Alert variant="danger" size="md">
             {error}
-          </div>
+          </Alert>
         )}
 
         <div ref={messagesEndRef} />

--- a/packages/ui/src/components/CreateOrgForm.tsx
+++ b/packages/ui/src/components/CreateOrgForm.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { Button } from './ui/Button';
 import { Input } from './ui/Input';
+import { Alert } from './ui/Alert';
 import { useAuth } from './AuthContext';
 import {
   checkNamespaceSlugApi,
@@ -177,7 +178,7 @@ export function CreateOrgForm({ onCancel, onCreated }: CreateOrgFormProps) {
       <SlugStatus slug={trimmed} checking={checking} check={check} />
 
       {submitError && (
-        <div className="px-3 py-2 rounded-lg bg-status-danger-bg border border-status-danger-border text-sm text-status-danger-text">
+        <Alert variant="danger" size="md">
           <div>{submitError.message}</div>
           {submitError.showVerifyLink && (
             <a
@@ -187,7 +188,7 @@ export function CreateOrgForm({ onCancel, onCreated }: CreateOrgFormProps) {
               Go to email verification →
             </a>
           )}
-        </div>
+        </Alert>
       )}
 
       <div className="flex justify-end gap-2">

--- a/packages/ui/src/components/InviteMembersDialog.tsx
+++ b/packages/ui/src/components/InviteMembersDialog.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
+import { Alert } from './ui/Alert';
 import { useAuth } from './AuthContext';
 import { Button } from './ui/Button';
 import {
@@ -128,9 +129,9 @@ export function InviteMembersDialog({
           </div>
 
           {error && (
-            <div className="px-3 py-2 rounded-lg bg-status-danger-bg border border-status-danger-border text-sm text-status-danger-text">
+            <Alert variant="danger" size="md">
               {error}
-            </div>
+            </Alert>
           )}
 
           {loading && <div className="text-sm text-muted">Loading…</div>}

--- a/packages/ui/src/components/LoginScreen.tsx
+++ b/packages/ui/src/components/LoginScreen.tsx
@@ -3,6 +3,7 @@ import { GoogleOAuthProvider, GoogleLogin, type CredentialResponse } from '@reac
 import { trackAnonymous } from '../hooks/useTelemetry';
 import { Input } from './ui/Input';
 import { Button } from './ui/Button';
+import { Alert } from './ui/Alert';
 import { Logo } from './Logo';
 import { probeAuthApi, AuthApiError, type SessionPayload } from '../api/client';
 import { useMagicLinkPoll } from '../hooks/useMagicLinkPoll';
@@ -219,9 +220,9 @@ function EnterEmailScreen({
         </label>
 
         {error && (
-          <div className="px-3 py-2 rounded-lg bg-status-danger-bg border border-status-danger-border text-xs text-status-danger-text">
+          <Alert variant="danger">
             {error}
-          </div>
+          </Alert>
         )}
 
         <Button type="submit" disabled={submitting || !email.trim()} className="w-full">
@@ -379,9 +380,9 @@ function PasswordScreen({
         </label>
 
         {error && (
-          <div className="px-3 py-2 rounded-lg bg-status-danger-bg border border-status-danger-border text-xs text-status-danger-text">
+          <Alert variant="danger">
             {error}
-          </div>
+          </Alert>
         )}
 
         <Button type="submit" disabled={!canSubmit} className="w-full">
@@ -470,9 +471,9 @@ function ForgotPasswordForm({
           />
         </label>
         {authError && (
-          <div className="px-3 py-2 rounded-lg bg-status-danger-bg border border-status-danger-border text-xs text-status-danger-text">
+          <Alert variant="danger">
             {authError}
-          </div>
+          </Alert>
         )}
         <Button type="submit" disabled={submitting || !email.trim()} className="w-full">
           {submitting ? 'Sending…' : 'Send reset link'}

--- a/packages/ui/src/components/MemexVisibilitySettings.tsx
+++ b/packages/ui/src/components/MemexVisibilitySettings.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useAuth } from './AuthContext';
 import { MemexPublicBadge } from './MemexPublicBadge';
+import { Alert } from './ui/Alert';
 import { MemexVisibilityConfirmDialog } from './MemexVisibilityConfirmDialog';
 import {
   fetchMemexApi,
@@ -99,9 +100,9 @@ export function MemexVisibilitySettings({ memexId }: { memexId: string }) {
       </div>
 
       {error && (
-        <div className="px-3 py-2 rounded-lg bg-status-danger-bg border border-status-danger-border text-sm text-status-danger-text">
+        <Alert variant="danger" size="md">
           {error}
-        </div>
+        </Alert>
       )}
 
       <div className="space-y-2">

--- a/packages/ui/src/components/NewSpecModal.tsx
+++ b/packages/ui/src/components/NewSpecModal.tsx
@@ -7,6 +7,7 @@ import {
   type KeyboardEvent,
 } from 'react';
 import { createPortal } from 'react-dom';
+import { Alert } from './ui/Alert';
 import { useNavigate } from 'react-router-dom';
 import { tenantPath } from '../utils/tenantUrl';
 import { useAgentGraph } from '../agent/useAgentGraph';
@@ -721,9 +722,9 @@ export function NewSpecModal({ open, onClose, prefill, onCreated }: NewSpecModal
           )}
 
           {error && (
-            <div className="px-3 py-2 rounded-lg bg-status-danger-bg border border-status-danger-border text-sm text-status-danger-text">
+            <Alert variant="danger" size="md">
               {error}
-            </div>
+            </Alert>
           )}
 
           <div ref={messagesEndRef} />

--- a/packages/ui/src/components/OrgConsentDialog.tsx
+++ b/packages/ui/src/components/OrgConsentDialog.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { createPortal } from 'react-dom';
+import { Alert } from './ui/Alert';
 import { useAuth } from './AuthContext';
 import { Button } from './ui/Button';
 import {
@@ -214,9 +215,9 @@ export function OrgConsentDialog({
                 </label>
               ))}
               {submitError && (
-                <div className="px-3 py-2 rounded-lg bg-status-danger-bg border border-status-danger-border text-sm text-status-danger-text">
+                <Alert variant="danger" size="md">
                   {submitError}
-                </div>
+                </Alert>
               )}
             </div>
           </>

--- a/packages/ui/src/components/ShareModal.tsx
+++ b/packages/ui/src/components/ShareModal.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { Button } from './ui/Button';
+import { Alert } from './ui/Alert';
 import { useAuth } from './AuthContext';
 import { useDocChangeStream } from '../hooks/useDocChangeStream';
 import {
@@ -96,9 +97,9 @@ export function ShareModal({
         </div>
 
         {error && (
-          <div className="px-3 py-2 rounded-lg bg-status-danger-bg border border-status-danger-border text-sm text-status-danger-text">
+          <Alert variant="danger" size="md">
             {error}
-          </div>
+          </Alert>
         )}
 
         {loading && <div className="text-sm text-muted">Loading…</div>}

--- a/packages/ui/src/components/account/InvitesTab.tsx
+++ b/packages/ui/src/components/account/InvitesTab.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { Button } from '../ui/Button';
+import { Alert } from '../ui/Alert';
 import { useAuth } from '../AuthContext';
 import {
   createInviteApi,
@@ -80,9 +81,9 @@ export function InvitesTab() {
       </div>
 
       {error && (
-        <div className="px-3 py-2 rounded-lg bg-status-danger-bg border border-status-danger-border text-sm text-status-danger-text">
+        <Alert variant="danger" size="md">
           {error}
-        </div>
+        </Alert>
       )}
 
       {loading && <div className="text-sm text-muted">Loading…</div>}

--- a/packages/ui/src/components/account/SettingsTab.tsx
+++ b/packages/ui/src/components/account/SettingsTab.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { Button } from '../ui/Button';
 import { Input } from '../ui/Input';
+import { Alert } from '../ui/Alert';
 import { useAuth } from '../AuthContext';
 import {
   getOrgApi,
@@ -51,9 +52,9 @@ export function SettingsTab() {
       </div>
 
       {error && (
-        <div className="px-3 py-2 rounded-lg bg-status-danger-bg border border-status-danger-border text-sm text-status-danger-text">
+        <Alert variant="danger" size="md">
           {error}
-        </div>
+        </Alert>
       )}
 
       <DomainsSection org={org} token={token} onRefresh={refresh} setError={setError} />

--- a/packages/ui/src/components/account/UsersTab.tsx
+++ b/packages/ui/src/components/account/UsersTab.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { Button } from '../ui/Button';
+import { Alert } from '../ui/Alert';
 import { useAuth } from '../AuthContext';
 import {
   listOrgMembersApi,
@@ -102,9 +103,9 @@ export function UsersTab({ onSwitchTab }: { onSwitchTab: (id: string) => void })
       </div>
 
       {error && (
-        <div className="px-3 py-2 rounded-lg bg-status-danger-bg border border-status-danger-border text-sm text-status-danger-text">
+        <Alert variant="danger" size="md">
           {error}
-        </div>
+        </Alert>
       )}
 
       {loading && <div className="text-sm text-muted">Loading…</div>}

--- a/packages/ui/src/pages/Backstage.tsx
+++ b/packages/ui/src/pages/Backstage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { Alert } from '../components/ui/Alert';
 
 // Platform-admin Memex picker. Opt-in dev-mode tool — the backend returns 403 when
 // GOOGLE_CLIENT_ID is set, so hitting this page in prod shows an empty/error state.
@@ -91,9 +92,9 @@ export function Backstage() {
         />
 
         {error && (
-          <div className="px-3 py-2 rounded-lg bg-status-danger-bg border border-status-danger-border text-sm text-status-danger-text">
+          <Alert variant="danger" size="md">
             {error}
-          </div>
+          </Alert>
         )}
 
         {!accounts && !error && (

--- a/packages/ui/src/pages/Onboarding.tsx
+++ b/packages/ui/src/pages/Onboarding.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useState } from 'react';
 import { Button } from '../components/ui/Button';
 import { Input } from '../components/ui/Input';
+import { Alert } from '../components/ui/Alert';
 import { useAuth } from '../components/AuthContext';
 import { Logo } from '../components/Logo';
 import { updateProfileApi } from '../api/client';
@@ -52,9 +53,9 @@ export function Onboarding() {
           </label>
 
           {error && (
-            <div className="px-3 py-2 rounded-lg bg-status-danger-bg border border-status-danger-border text-sm text-status-danger-text">
+            <Alert variant="danger" size="md">
               {error}
-            </div>
+            </Alert>
           )}
 
           <div className="flex justify-end">

--- a/packages/ui/src/pages/ResetPassword.tsx
+++ b/packages/ui/src/pages/ResetPassword.tsx
@@ -1,6 +1,7 @@
 import { useState, type FormEvent } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import { useAuth, computeDefaultLanding } from '../components/AuthContext';
+import { Alert } from '../components/ui/Alert';
 import { isFeatureHidden } from '../utils/featureFlags';
 import { passwordResetConfirmApi, AuthApiError } from '../api/client';
 import { Input } from '../components/ui/Input';
@@ -95,9 +96,9 @@ export function ResetPassword() {
                   />
                 </label>
                 {error && (
-                  <div className="px-3 py-2 rounded-lg bg-status-danger-bg border border-status-danger-border text-xs text-status-danger-text">
+                  <Alert variant="danger">
                     {error}
-                  </div>
+                  </Alert>
                 )}
                 <Button
                   type="submit"


### PR DESCRIPTION
Child Spec **spec-381** (parent spec-355, audit spec-345) — Wave A/B sibling of spec-374/spec-375/spec-377.

## What
Replaces the hardcoded danger-banner className (`px-3 py-2 rounded-lg border bg-status-danger-bg text-status-danger-text border-status-danger-border` + `text-xs`/`text-sm`) with the existing `<Alert variant="danger">` component (`packages/ui/src/components/ui/Alert.tsx`).

## Files converted (18 banners across 15 files)
- `components/OrgConsentDialog.tsx` (size=md)
- `components/NewSpecModal.tsx` (size=md)
- `components/InviteMembersDialog.tsx` (size=md)
- `components/CreateOrgForm.tsx` (size=md — nested children preserved)
- `components/AddMemexForm.tsx` (size=md)
- `components/ChatPanel.tsx` (size=md)
- `components/MemexVisibilitySettings.tsx` (size=md)
- `components/ShareModal.tsx` (size=md)
- `components/account/UsersTab.tsx` (size=md)
- `components/account/InvitesTab.tsx` (size=md)
- `components/account/SettingsTab.tsx` (size=md)
- `components/LoginScreen.tsx` (3 banners, default size)
- `pages/Backstage.tsx` (size=md)
- `pages/Onboarding.tsx` (size=md)
- `pages/ResetPassword.tsx` (default size)

## DOM / visual equivalence
Each converted site renders the **identical** Tailwind class set Alert's danger variant already emits. `text-sm` sites map to `size="md"`; `text-xs` sites use Alert's default `size="sm"`. The only DOM delta is the **addition** of `role="alert"` (Alert applies it to all danger banners) — a pure accessibility improvement, never a removal.

## Alert extension
**None.** Alert.tsx is unchanged, so existing callers (BillingTab, VerifyEmailGate, EmissionKeysSection) render byte-for-byte identically. (spec-381 dec-1)

## Banners intentionally left as-is (divergent shape, would regress or need an additive Alert API)
- `IssuePanel`, `IssuesList`, `NeedsAttentionTray`, `MoveSpecDialog` — `rounded-md` / `p-2`/`p-3`
- `SpecList`, `DocDocument`, `StandardList`, `Standard`, `NamespaceHome`, `DocumentList`, `DriftInbox` — `p-4` padding (page load-error blocks)
- `upgrade/UpgradeSeats` — `<p>` element, no border
- `home/IdentityStep` — load-bearing `data-testid="identity-error"` the current Alert API can't carry

## Verification (lean)
- `pnpm --filter @memex/ui exec tsc -b` → clean
- `pnpm --filter @memex/ui build` → clean
- `vitest run NewSpecModal MemexVisibilitySettings LoginScreen` → 22 tests pass
- Biome check on all 15 touched files → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)