### PR TITLE
spec-384: prune stale dependabot ignores + bound security-floor overrides

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,13 +22,8 @@ updates:
       # Deferred breaking migrations — each owned by a Spec, so dependabot must
       # not re-propose them (a plain bump fails CI and churns the merge gate).
       # Remove the matching ignore when its Spec lands, to resume normal bumps.
-      - dependency-name: "tailwindcss" # spec-290 owns the v3 → v4 migration
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "web-tree-sitter" # spec-292 owns the 0.25 → 0.26 ABI migration
-        # 0.x: dependabot classifies 0.25 → 0.26 as "minor" (which is why it slipped
-        # into npm-minor-and-patch), so ignore minor + major to keep it out until 292.
-        update-types:
-          ["version-update:semver-minor", "version-update:semver-major"]
+      # (spec-290 tailwindcss v4 + spec-292 web-tree-sitter 0.26 have landed —
+      #  their ignores were pruned in spec-384; v4 / 0.26 are now in the tree.)
       - dependency-name: "@hono/node-server" # 2.x unsupported by @hono/node-ws (voice WS adapter)
         # #221 over-bumped node-server to 2.0 ahead of its WS adapter (no @hono/node-ws
         # release peers node-server@2 yet). Reverted to 1.x; ignore major re-proposals

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
       "react": "19.2.7",
       "react-dom": "19.2.7",
       "typescript": "6.0.3",
-      "esbuild": ">=0.28.1",
-      "form-data": ">=4.0.6",
+      "esbuild": ">=0.28.1 <1",
+      "form-data": ">=4.0.6 <5",
       "protobufjs": ">=7.6.3 <8"
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,8 +11,8 @@ overrides:
   react: 19.2.7
   react-dom: 19.2.7
   typescript: 6.0.3
-  esbuild: '>=0.28.1'
-  form-data: '>=4.0.6'
+  esbuild: '>=0.28.1 <1'
+  form-data: '>=4.0.6 <5'
   protobufjs: '>=7.6.3 <8'
 
 importers:
@@ -1964,7 +1964,7 @@ packages:
     resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     peerDependencies:
-      esbuild: '>=0.28.1'
+      esbuild: '>=0.28.1 <1'
 
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
@@ -3940,7 +3940,7 @@ packages:
     peerDependencies:
       '@types/node': 26.0.0
       '@vitejs/devtools': ^0.1.18
-      esbuild: '>=0.28.1'
+      esbuild: '>=0.28.1 <1'
       jiti: '>=1.21.0'
       less: ^4.0.0
       sass: ^1.70.0


### PR DESCRIPTION
## What

Config-only dependency hygiene. Parent **spec-357**, audit **spec-345**; findings **sus-2** + **sus-3**. Sibling of #275-strand spec-382. Spec: `spec-384`.

Three files: `.github/dependabot.yml`, root `package.json`, `pnpm-lock.yaml`. No application source, schema, migration, route, auth, or tenancy touched.

## sus-2 — pruned stale dependabot ignores

Removed two `ignore` entries from `.github/dependabot.yml`; both were Spec-owned defers whose Specs have **landed**, verified two ways each:

| Ignore | Owning Spec | Status | In the tree? |
|---|---|---|---|
| `tailwindcss` (semver-major) | spec-290 (Tailwind v3→v4) | **verify** | yes — `packages/ui` declares `tailwindcss: "^4.3.1"` |
| `web-tree-sitter` (semver-minor+major) | spec-292 (web-tree-sitter 0.25→0.26) | **done** | yes — `packages/extractor` declares `web-tree-sitter: "^0.26.9"` |

Stale ignores only suppress legitimate future routine bumps, so they're gone (per the in-file guidance: "Remove the matching ignore when its Spec lands").

**Kept** the `@hono/node-server` semver-major ignore unchanged — it is a deliberate ongoing constraint (2.x unsupported by `@hono/node-ws`, the voice WS adapter; #221 / spec-292 issue-1), not a landed-Spec defer.

## sus-3 — bounded the security-floor overrides

Root `package.json` `pnpm.overrides`:

```diff
-      "esbuild": ">=0.28.1",
-      "form-data": ">=4.0.6",
+      "esbuild": ">=0.28.1 <1",
+      "form-data": ">=4.0.6 <5",
       "protobufjs": ">=7.6.3 <8"
```

Mirrors the existing `protobufjs` next-major cap so "security floor only, not an unbounded major jump" is explicit. Grounded in **std-24** (these three are the security-floor pins in `pnpm.overrides`) and the lockfile-resolved versions (`esbuild@0.28.1`, `form-data@4.0.6`) — both caps **include** the currently-resolved version, so no resolution changes. `form-data` is major 4 → cap `<5`; `esbuild` is 0.x (pre-1.0) → cap `<1`, keeping routine 0.28.x bumps open while blocking a silent 0.x→1.0 graduation. Recorded as spec-384 dec-1.

## Verification

- `pnpm install` — resolves clean in ~10s. Lockfile diff is trivial and expected: only the `overrides:` constraint strings echo (+ the same strings in two peerDependencies blocks). **No resolved version changed** — `esbuild@0.28.1`, `form-data@4.0.6` unchanged.
- dependabot.yml parses as valid YAML; ignore list is exactly `["@hono/node-server"]`.
- `tsc --noEmit` (server): the only errors are pre-existing `*.test.ts` strictness issues present byte-identical on `develop` — none introduced here (diff touches only the 3 config files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
