### PR TITLE
spec-387: architecture-enforcement guards — db-schema @memex/shared boundary + std-30 direct-Anthropic static scans

### DIFF
--- a/packages/server/src/__regression__/db-schema-shared-boundary.regression.test.ts
+++ b/packages/server/src/__regression__/db-schema-shared-boundary.regression.test.ts
@@ -1,0 +1,284 @@
+// Static-scan guard for the db-schema standalone boundary (spec-279 / std-24).
+//
+// `@mindset-ai/db-schema` (packages/db-schema, spec-279 dec-1) is published to
+// GitHub Packages so an out-of-workspace repo (Backstage — spec-280) can consume
+// the production DB schema with full types WITHOUT forking schema.ts or depending
+// on the monorepo. Its entry (packages/db-schema/src/index.ts) does
+// `export * from "../../server/src/db/schema.js"`, and the build (tsup/esbuild)
+// bundles the schema source plus the few type-only cross-file imports it makes
+// into a self-contained dist whose ONLY surviving runtime dep is `drizzle-orm`.
+//
+// The hard constraint: NO file reachable from db-schema's bundle may import
+// `@memex/shared`. pnpm's isolated node_modules does not resolve `@memex/shared`
+// from within the db-schema package, so any such import breaks the dts/tsup build
+// at install time. This is not hypothetical — it bit during spec-374, when
+// `types/roles.ts` gained a `@memex/shared` import (PHASE_ORDER) and PR #312's
+// `server (2)` shard failed on `packages/db-schema prepare:
+// ../server/src/types/roles.ts: error TS2307: Cannot find module '@memex/shared'`.
+// roles.ts now carries a NOTE *comment* warning future authors off — that comment
+// must NOT trip this scan; only a real import statement does.
+//
+// dec-1: we WALK the relative import graph from the entry (index.ts) transitively
+// into packages/server/src — following only `./`/`../` specifiers, treating bare
+// specifiers (drizzle-orm, @memex/shared) as leaves — and build the set of files
+// tsup actually bundles. A flat hardcoded file list would cover today's three
+// files (index.ts → db/schema.ts → types/roles.ts) but silently miss any new
+// relative import schema.ts/roles.ts gain later — exactly the regression class
+// this guard exists to catch.
+//
+// The scan is comment/string-aware (it reuses the stripComments approach proven
+// by mutate-coverage.static-scan.test.ts) so a `@memex/shared` mention inside a
+// comment or string literal never trips it — only a real `from "@memex/shared"`
+// import/export-from clause does.
+
+import { describe, it, expect } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, relative, resolve } from "node:path";
+
+const AC = "mindset-prod/memex-building-itself/specs/spec-387/acs";
+
+// The published package's entry point — the root of the bundle graph.
+// __dirname = packages/server/src/__regression__ → repo packages/ is two up.
+const PACKAGES_DIR = resolve(__dirname, "..", "..", "..");
+const DB_SCHEMA_ENTRY = resolve(PACKAGES_DIR, "db-schema", "src", "index.ts");
+// The walk only follows relative imports INTO this tree (where the bundled
+// server sources live); imports that escape it are not part of db-schema's
+// bundle and are not our concern.
+const SERVER_SRC = resolve(PACKAGES_DIR, "server", "src");
+
+// ── lexing: strip comments + strings so a mention in prose never trips the scan
+// (mirrors mutate-coverage.static-scan.test.ts) ──────────────────────────────
+
+function skipString(src: string, i: number, quote: string): number {
+  i++; // past opening quote
+  while (i < src.length) {
+    if (src[i] === "\\") {
+      i += 2;
+      continue;
+    }
+    if (src[i] === quote) return i + 1;
+    i++;
+  }
+  return i;
+}
+
+// NOTE: unlike the std-30 scanner's stripper, this one COPIES string interiors
+// through verbatim rather than blanking them — the import SPECIFIER we extract
+// (`from "@memex/shared"`) lives inside the string, so blanking it would erase
+// what we need to read. A bare string mention (`const x = "@memex/shared"`) is
+// not flagged because the import regexes require a `from`/`import` keyword
+// immediately before the quote; a comment mention is removed by the comment
+// passes below. Only string-embedded COMMENT MARKERS need neutralising, which
+// the copy-through achieves.
+function stripComments(src: string): string {
+  let out = "";
+  let i = 0;
+  while (i < src.length) {
+    const ch = src[i];
+    if (ch === '"' || ch === "'" || ch === "`") {
+      const end = skipString(src, i, ch);
+      out += src.slice(i, end);
+      i = end;
+    } else if (ch === "/" && src[i + 1] === "/") {
+      while (i < src.length && src[i] !== "\n") i++;
+    } else if (ch === "/" && src[i + 1] === "*") {
+      i += 2;
+      while (i < src.length && !(src[i] === "*" && src[i + 1] === "/")) {
+        if (src[i] === "\n") out += "\n";
+        i++;
+      }
+      i += 2;
+    } else {
+      out += ch;
+      i++;
+    }
+  }
+  return out;
+}
+
+// ── import extraction ────────────────────────────────────────────────────────
+
+// Every module specifier in an `import ... from "X"`, `export ... from "X"`,
+// `import "X"` (side-effect), or dynamic `import("X")` form. We strip comments
+// first so a specifier sitting inside a comment is never extracted.
+const FROM_RE = /\bfrom\s*["']([^"']+)["']/g;
+const SIDE_EFFECT_RE = /\bimport\s*["']([^"']+)["']/g;
+const DYNAMIC_RE = /\bimport\s*\(\s*["']([^"']+)["']\s*\)/g;
+
+function extractSpecifiers(strippedSrc: string): string[] {
+  const out = new Set<string>();
+  for (const re of [FROM_RE, SIDE_EFFECT_RE, DYNAMIC_RE]) {
+    re.lastIndex = 0;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(strippedSrc)) !== null) out.add(m[1]);
+  }
+  return [...out];
+}
+
+function isRelative(spec: string): boolean {
+  return spec.startsWith("./") || spec.startsWith("../");
+}
+
+// Resolve a relative specifier (which carries a `.js` extension under
+// NodeNext/ESM) to the on-disk `.ts` source file it actually denotes.
+function resolveRelativeToTs(fromFile: string, spec: string): string | null {
+  const base = resolve(dirname(fromFile), spec);
+  const candidates = [
+    base.replace(/\.js$/, ".ts"), // `./foo.js` → `./foo.ts`
+    base, // already a real path (e.g. `.ts` written directly)
+    `${base}.ts`, // extensionless `./foo` → `./foo.ts`
+    resolve(base, "index.ts"), // `./dir` → `./dir/index.ts`
+  ];
+  for (const c of candidates) {
+    if (existsSync(c) && c.endsWith(".ts")) return c;
+  }
+  return null;
+}
+
+// ── the bundle graph walk ────────────────────────────────────────────────────
+
+interface SharedImport {
+  file: string; // relative-to-packages/ for readable failure messages
+  line: number;
+  context: string;
+}
+
+// Build the set of source files tsup bundles into db-schema, by following only
+// relative imports transitively from the entry. Returns the absolute file set.
+export function collectBundleFiles(entry: string): string[] {
+  const seen = new Set<string>();
+  const stack = [entry];
+  while (stack.length) {
+    const file = stack.pop()!;
+    if (seen.has(file)) continue;
+    seen.add(file);
+    const stripped = stripComments(readFileSync(file, "utf8"));
+    for (const spec of extractSpecifiers(stripped)) {
+      if (!isRelative(spec)) continue; // bare specifiers are leaves
+      const resolved = resolveRelativeToTs(file, spec);
+      // Only follow imports that stay within the server src tree (or the
+      // db-schema src itself) — those are the files that get bundled.
+      if (
+        resolved &&
+        (resolved.startsWith(SERVER_SRC) ||
+          resolved.startsWith(resolve(PACKAGES_DIR, "db-schema", "src")))
+      ) {
+        stack.push(resolved);
+      }
+    }
+  }
+  return [...seen];
+}
+
+// Find every real `@memex/shared` (or `@memex/shared/...`) import/export-from in
+// one file's source (comments/strings stripped).
+const SHARED_IMPORT_RE =
+  /\b(?:from|import)\s*\(?\s*["']@memex\/shared(?:\/[^"']*)?["']/g;
+
+export function findSharedImports(absFile: string): SharedImport[] {
+  const stripped = stripComments(readFileSync(absFile, "utf8"));
+  const out: SharedImport[] = [];
+  let m: RegExpExecArray | null;
+  SHARED_IMPORT_RE.lastIndex = 0;
+  while ((m = SHARED_IMPORT_RE.exec(stripped)) !== null) {
+    const line = stripped.slice(0, m.index).split("\n").length;
+    const lineEnd = stripped.indexOf("\n", m.index);
+    const context = stripped
+      .slice(m.index, lineEnd === -1 ? stripped.length : lineEnd)
+      .trim();
+    out.push({ file: relative(PACKAGES_DIR, absFile), line, context });
+  }
+  return out;
+}
+
+describe("db-schema standalone boundary (spec-279 / std-24)", () => {
+  it("the db-schema entry point exists", () => {
+    tagAc(`${AC}/ac-1`);
+    expect(existsSync(DB_SCHEMA_ENTRY)).toBe(true);
+  });
+
+  const bundleFiles = collectBundleFiles(DB_SCHEMA_ENTRY);
+
+  it("the bundle graph walk reaches schema.ts and roles.ts (and nothing escapes the walk)", () => {
+    tagAc(`${AC}/ac-1`);
+    const rel = bundleFiles.map((f) => relative(PACKAGES_DIR, f));
+    // index.ts → db/schema.ts → types/roles.ts is the known chain today; the
+    // walk MUST cover at least these, proving it followed the relative imports
+    // rather than stopping at the entry.
+    expect(rel).toContain("db-schema/src/index.ts");
+    expect(rel.some((r) => r.endsWith("server/src/db/schema.ts"))).toBe(true);
+    expect(rel.some((r) => r.endsWith("server/src/types/roles.ts"))).toBe(true);
+  });
+
+  it("no file in the db-schema bundle imports @memex/shared", () => {
+    tagAc(`${AC}/ac-1`); // scope ac-1
+    tagAc(`${AC}/ac-6`); // implementation ac-6: the graph-walk bundle scan asserts no @memex/shared import
+    const violations = bundleFiles.flatMap(findSharedImports);
+    expect(
+      violations,
+      violations.length
+        ? `db-schema boundary violation (spec-279 / std-24): a file bundled into ` +
+            `the standalone @mindset-ai/db-schema package imports @memex/shared, ` +
+            `which pnpm's isolated node_modules cannot resolve there — it breaks the ` +
+            `dts/tsup build at install (this exact failure bit roles.ts during ` +
+            `spec-374). Offending import(s):\n` +
+            violations
+              .map((v) => `  • ${v.file}:${v.line}  ${v.context}`)
+              .join("\n") +
+            `\nThe db-schema bundle (everything reachable from ` +
+            `packages/db-schema/src/index.ts via relative imports) may depend ONLY ` +
+            `on drizzle-orm. Move the needed value out of @memex/shared into a ` +
+            `bundle-local module, or inline it — do not pull @memex/shared into a ` +
+            `schema-reachable file. roles.ts's NOTE comment exists to warn you off.`
+        : "",
+    ).toEqual([]);
+  });
+});
+
+describe("db-schema boundary scanner meta-tests (catch-a-violation)", () => {
+  // Synthesize a tiny graph in memory-equivalent terms by exercising the pure
+  // extractors against crafted source, so we prove the scan distinguishes real
+  // imports from prose without touching the real tree.
+
+  it("findSharedImports-style detection flags a real import but not a comment/string (ac-3)", () => {
+    tagAc(`${AC}/ac-1`);
+    tagAc(`${AC}/ac-3`); // scope ac-3: comments/strings must not trip the scan
+    tagAc(`${AC}/ac-4`); // scope ac-4: the guard goes red on a real violation
+    tagAc(`${AC}/ac-5`); // scope ac-5: findSharedImports records file:line + context for the message
+    const run = (src: string) => {
+      const stripped = stripComments(src);
+      const out: number[] = [];
+      let m: RegExpExecArray | null;
+      SHARED_IMPORT_RE.lastIndex = 0;
+      while ((m = SHARED_IMPORT_RE.exec(stripped)) !== null) out.push(m.index);
+      return out;
+    };
+
+    // A real import — flagged.
+    expect(
+      run(`import { PHASE_ORDER } from "@memex/shared";`).length,
+    ).toBe(1);
+    // A subpath import — flagged.
+    expect(
+      run(`import { x } from "@memex/shared/phases";`).length,
+    ).toBe(1);
+    // A re-export — flagged.
+    expect(run(`export { x } from "@memex/shared";`).length).toBe(1);
+    // The legitimate roles.ts NOTE comment — NOT flagged.
+    expect(
+      run(`// NOTE: do NOT import @memex/shared here. roles.ts is re-exported`)
+        .length,
+    ).toBe(0);
+    // A string mention — NOT flagged.
+    expect(run(`const pkg = "@memex/shared";`).length).toBe(0);
+  });
+
+  it("the relative-import walk follows ./ and ../ but treats bare specifiers as leaves", () => {
+    tagAc(`${AC}/ac-1`);
+    expect(isRelative("./roles.js")).toBe(true);
+    expect(isRelative("../types/roles.js")).toBe(true);
+    expect(isRelative("drizzle-orm")).toBe(false);
+    expect(isRelative("@memex/shared")).toBe(false);
+  });
+});

--- a/packages/server/src/__regression__/no-direct-anthropic.regression.test.ts
+++ b/packages/server/src/__regression__/no-direct-anthropic.regression.test.ts
@@ -1,0 +1,258 @@
+// Static-scan guard for std-30: the metering wrapper is the only sanctioned
+// path to an LLM, so direct `new Anthropic(...)` construction is forbidden
+// anywhere but inside the wrapper module.
+//
+// std-30 §s-1 cl-2: "No code outside the wrapper may instantiate a provider SDK
+// client: no `new Anthropic(...)` [...] anywhere but inside the wrapper module."
+// cl-5: "This rule is enforced by lint, not convention [...] so a bypass fails
+// CI rather than relying on a reviewer to catch it." This test IS that
+// enforcement: it scans every `packages/server/src/**/*.ts` source file (tests,
+// `.d.ts`, and build output excluded) for a `new Anthropic(` construction and
+// asserts the ONLY site is the one allowlisted metering wrapper — the file where
+// `getAnthropicClient()` lives (agent/anthropic-client.ts). A chokepoint that
+// can be bypassed is not a chokepoint (cl-7): one escaped call site silently
+// corrupts every per-tenant cost figure.
+//
+// The scan is comment/string-aware (it reuses the same stripComments approach
+// proven by mutate-coverage.static-scan.test.ts): a `new Anthropic(` mentioned
+// inside a // comment, a /* block */, or a string/template literal does NOT
+// trip it — only a real construction in code does.
+//
+// Allowlist: a single path-keyed entry (relative to src/, posix separators),
+// matching how the sibling scanners allowlist. Each entry carries its reason.
+
+import { describe, it, expect } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join, relative, sep } from "node:path";
+
+const AC = "mindset-prod/memex-building-itself/specs/spec-387/acs";
+
+// packages/server/src — the std-30 §s-3 cl-11 scope for the server package.
+const SRC_DIR = join(__dirname, "..");
+
+// The ONE file allowed to construct the Anthropic SDK client: the metering
+// wrapper itself (std-30 §s-3 cl-13 — "the one exempt module [...] where the SDK
+// clients live"). Keyed by path RELATIVE TO src/ (posix separators) so a future
+// file that merely shares the basename is NOT exempt.
+const ALLOWLIST: Record<string, string> = {
+  "agent/anthropic-client.ts":
+    "The metering wrapper itself — getAnthropicClient() lives here; std-30 §s-3 cl-13 names it the one exempt module where the SDK client is instantiated.",
+};
+
+// Directory basenames we never descend into.
+const EXCLUDE_DIR_NAMES = new Set(["node_modules", "dist", "build", "coverage"]);
+
+function isScannableFile(path: string): boolean {
+  if (!path.endsWith(".ts")) return false;
+  if (path.endsWith(".test.ts")) return false;
+  if (path.endsWith(".d.ts")) return false;
+  return true;
+}
+
+function listScannableFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    if (EXCLUDE_DIR_NAMES.has(entry)) continue;
+    const full = join(dir, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      out.push(...listScannableFiles(full));
+    } else if (isScannableFile(full)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+// Path relative to src/, normalised to posix separators so the allowlist keys
+// read the same on every platform (e.g. "agent/anthropic-client.ts").
+function relKey(absPath: string): string {
+  return relative(SRC_DIR, absPath).split(sep).join("/");
+}
+
+// Skip a string / char / template literal, returning the index just past its
+// closing quote. Handles backslash escapes. (Mirrors the helper in
+// mutate-coverage.static-scan.test.ts.)
+function skipString(src: string, i: number, quote: string): number {
+  i++; // past opening quote
+  while (i < src.length) {
+    if (src[i] === "\\") {
+      i += 2;
+      continue;
+    }
+    if (src[i] === quote) return i + 1;
+    i++;
+  }
+  return i;
+}
+
+// Strip line comments, block comments, AND string/template-literal interiors so
+// a `new Anthropic(` inside a comment OR a string does not trip the scanner.
+// Keeps line numbers (and offsets) intact by preserving newlines and replacing
+// stripped content with spaces. String-literal-aware in the same spirit as
+// mutate-coverage.static-scan.test.ts (a quote-embedded `/*` or `//` is NOT a
+// comment), but here we go one step further and blank the literal's interior
+// too: unlike a DB write, the substring `new Anthropic(` plausibly appears
+// inside a doc string or error message, so the interior must not be scanned.
+function stripComments(src: string): string {
+  let out = "";
+  let i = 0;
+  while (i < src.length) {
+    const ch = src[i];
+    if (ch === '"' || ch === "'" || ch === "`") {
+      // String / char / template literal — blank the interior (keep the quotes
+      // and any newlines so line/offset accuracy survives) so neither a comment
+      // marker NOR a `new Anthropic(` inside it is ever matched.
+      const end = skipString(src, i, ch);
+      const literal = src.slice(i, end);
+      out += literal.replace(/[^\n]/g, " ");
+      i = end;
+    } else if (ch === "/" && src[i + 1] === "/") {
+      while (i < src.length && src[i] !== "\n") i++;
+    } else if (ch === "/" && src[i + 1] === "*") {
+      i += 2;
+      while (i < src.length && !(src[i] === "*" && src[i + 1] === "/")) {
+        if (src[i] === "\n") out += "\n";
+        i++;
+      }
+      i += 2;
+    } else {
+      out += ch;
+      i++;
+    }
+  }
+  return out;
+}
+
+interface Construction {
+  line: number;
+  context: string;
+}
+
+// Match a direct construction of the Anthropic SDK client. `new` followed by
+// `Anthropic` and an opening paren — tolerant of arbitrary whitespace and a
+// generic type-argument list between the name and the `(` (e.g.
+// `new Anthropic <Foo>(`). The `\b` after `Anthropic` ensures we don't match a
+// longer identifier like `AnthropicLike` or `AnthropicBedrock`.
+const NEW_ANTHROPIC_RE = /\bnew\s+Anthropic\b\s*(?:<[^>]*>\s*)?\(/g;
+
+// Pure, testable core: given a file's raw source, return every direct Anthropic
+// construction (comments/strings stripped first).
+export function findDirectAnthropicConstructions(src: string): Construction[] {
+  const stripped = stripComments(src);
+  const out: Construction[] = [];
+  let m: RegExpExecArray | null;
+  NEW_ANTHROPIC_RE.lastIndex = 0;
+  while ((m = NEW_ANTHROPIC_RE.exec(stripped)) !== null) {
+    const line = stripped.slice(0, m.index).split("\n").length;
+    const lineEnd = stripped.indexOf("\n", m.index);
+    const context = stripped
+      .slice(m.index, lineEnd === -1 ? stripped.length : lineEnd)
+      .trim();
+    out.push({ line, context });
+  }
+  return out;
+}
+
+describe("std-30: no direct `new Anthropic(` outside the metering wrapper", () => {
+  const files = listScannableFiles(SRC_DIR);
+
+  it("finds server source files to scan", () => {
+    tagAc(`${AC}/ac-2`);
+    expect(files.length).toBeGreaterThan(20);
+  });
+
+  it("the allowlisted metering wrapper exists and is scanned", () => {
+    tagAc(`${AC}/ac-2`);
+    const keys = files.map(relKey);
+    for (const allowed of Object.keys(ALLOWLIST)) {
+      expect(keys, `allowlisted file missing from scan: ${allowed}`).toContain(
+        allowed,
+      );
+    }
+  });
+
+  // One assertion per file so a single violation names the exact file + line.
+  for (const file of files) {
+    const key = relKey(file);
+    const allowReason = ALLOWLIST[key];
+    it(`${key}: no direct \`new Anthropic(\`${allowReason ? " — allowlisted (wrapper)" : ""}`, () => {
+      tagAc(`${AC}/ac-2`); // scope ac-2
+      tagAc(`${AC}/ac-7`); // implementation ac-7: the per-file scan + single allowlist
+      const src = readFileSync(file, "utf8");
+      const hits = findDirectAnthropicConstructions(src);
+
+      if (allowReason) {
+        // The wrapper is the one place this is legitimate — assert nothing more.
+        return;
+      }
+
+      expect(
+        hits,
+        hits.length
+          ? `std-30 violation: ${key} constructs the Anthropic SDK client directly ` +
+              `(line ${hits[0].line}: \`${hits[0].context}\`).\n` +
+              `std-30 (the metering wrapper is the only sanctioned path) forbids ` +
+              `\`new Anthropic(...)\` anywhere but the wrapper module — all LLM ` +
+              `access goes through getAnthropicClient() so metering stays complete. ` +
+              `Call getAnthropicClient() (packages/server/src/agent/anthropic-client.ts) ` +
+              `instead; if the wrapper lacks a capability you need, extend the ` +
+              `wrapper (std-30 cl-6) — never reach around it to the SDK. If this ` +
+              `file legitimately IS a wrapper module, add it to ALLOWLIST with a reason.`
+          : "",
+      ).toEqual([]);
+    });
+  }
+});
+
+describe("std-30 scanner meta-tests (catch-a-violation)", () => {
+  it("flags a real direct construction in code", () => {
+    tagAc(`${AC}/ac-2`);
+    tagAc(`${AC}/ac-4`); // scope ac-4: the guard goes red on a real violation
+    tagAc(`${AC}/ac-5`); // scope ac-5: the hit carries the line + context to name in the failure
+    const offending = `
+      import Anthropic from "@anthropic-ai/sdk";
+      function make() {
+        return new Anthropic({ apiKey: "x" });
+      }
+    `;
+    const hits = findDirectAnthropicConstructions(offending);
+    expect(hits.length).toBe(1);
+    expect(hits[0].context).toContain("new Anthropic(");
+    // ac-5: the match records the offending line number + a readable context
+    // snippet — the two facts the per-file failure message names.
+    expect(hits[0].line).toBeGreaterThan(0);
+  });
+
+  it("flags the whitespace / generic-arg variants", () => {
+    tagAc(`${AC}/ac-2`);
+    expect(findDirectAnthropicConstructions("new   Anthropic ({})").length).toBe(
+      1,
+    );
+    expect(findDirectAnthropicConstructions("new Anthropic<Foo>({})").length).toBe(
+      1,
+    );
+  });
+
+  it("does NOT flag a construction inside a comment or string (ac-3)", () => {
+    tagAc(`${AC}/ac-2`);
+    tagAc(`${AC}/ac-3`); // scope ac-3: comments/strings must not trip the scan
+    const lineComment = "// historically this did `new Anthropic({apiKey})`\n";
+    const blockComment = "/* never do new Anthropic({}) here */\n";
+    const stringMention = 'const msg = "do not call new Anthropic( directly";\n';
+    expect(findDirectAnthropicConstructions(lineComment)).toEqual([]);
+    expect(findDirectAnthropicConstructions(blockComment)).toEqual([]);
+    expect(findDirectAnthropicConstructions(stringMention)).toEqual([]);
+  });
+
+  it("does NOT flag longer identifiers (AnthropicLike / AnthropicBedrock)", () => {
+    tagAc(`${AC}/ac-2`);
+    expect(findDirectAnthropicConstructions("new AnthropicLike({})")).toEqual(
+      [],
+    );
+    expect(
+      findDirectAnthropicConstructions("new AnthropicBedrock({})"),
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What

Two **TEST-ONLY** static-scan guards in the established `packages/server/src/__regression__/` pattern (gated by the now-required `server-result` CI check). **No production code changes** — only two new test files. Spec: `mindset-prod/memex-building-itself/specs/spec-387` (left at **verify**). Follows the spec-345 architecture-audit work and the code-quality enforcement review; hardens the spec-279/std-24 boundary that broke during spec-374 and the std-30 metering rule.

## Guard 1 — db-schema standalone boundary (spec-279 / std-24)

`db-schema-shared-boundary.regression.test.ts`

**Invariant locked:** the published `@mindset-ai/db-schema` package may depend only on `drizzle-orm`. Its entry `packages/db-schema/src/index.ts` re-exports `../../server/src/db/schema.js`, which re-exports `types/roles.ts`. pnpm's isolated `node_modules` cannot resolve `@memex/shared` from that bundle, so **any file reachable from db-schema's bundle that imports `@memex/shared` breaks the dts/tsup build at install** — exactly the failure that broke `roles.ts` during spec-374 (PR #312 `server (2)` shard: `Cannot find module '@memex/shared'`).

**How it scans:** walks the **relative** import graph transitively from `index.ts` into `packages/server/src` (follows `./`/`../` specifiers, resolving the ESM `.js` suffix to the on-disk `.ts`; treats bare specifiers like `drizzle-orm`/`@memex/shared` as leaves), building the file set tsup actually bundles. Asserts none contain a real `from "@memex/shared"` import/export-from/dynamic-import. Comment/string-aware — the legitimate `@memex/shared` NOTE *comment* in `roles.ts` passes; only a real import trips it.

## Guard 2 — std-30: no direct `new Anthropic(` outside the metering wrapper

`no-direct-anthropic.regression.test.ts`

**Invariant locked (std-30):** all LLM access goes through the `getAnthropicClient()` singleton; direct `new Anthropic(...)` construction is forbidden anywhere but the metering wrapper.

**How it scans:** scans `packages/server/src/**/*.ts` (excludes `*.test.ts`/`.d.ts`/`dist`) for `new Anthropic(` (whitespace + generic-arg tolerant; `\b` so `AnthropicLike`/`AnthropicBedrock` don't match). Single path-keyed allowlist entry — `agent/anthropic-client.ts`, where `getAnthropicClient()` lives (std-30 §s-3 cl-13). Comment/string-aware. Failure cites std-30.

## Both pass on current develop

Targeted run: **285 passed (2 files)** — confirming the boundary is clean and the codebase is std-30 compliant. `tsc --noEmit -p tsconfig.json` clean on both files; Biome clean.

## Catch-a-violation sanity check

Beyond the in-file meta-tests, each guard was exercised against a **real injected violation in the actual tree**, then reverted:
- Guard 1: added `import { PHASE_ORDER } from "@memex/shared";` to `types/roles.ts` (the exact spec-374 break) → red, naming `server/src/types/roles.ts:1` with the spec-279/std-24 message.
- Guard 2: added `new Anthropic({...})` to `routes/llm.ts` → red, naming `routes/llm.ts:68` with the std-30 message.

Both reverted; re-run after revert: 285 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)