### PR TITLE
hotfix(spec-396): close cross-org activity bleed in activity_view (→ develop / int)

### DIFF
--- a/packages/server/drizzle/0109_activity_view_tenant_scope.sql
+++ b/packages/server/drizzle/0109_activity_view_tenant_scope.sql
@@ -1,0 +1,198 @@
+-- spec-396 — SECURITY: close the cross-org activity bleed in activity_view.
+--
+-- THE LEAK (fixed here): the test_events arm of activity_view (migration 0089)
+-- joined test_events → documents on the SPEC HANDLE alone:
+--
+--     ON spec_doc.handle = substring(te.ac_uid from 'specs/([^/]+)/')
+--    AND spec_doc.doc_type = 'spec'
+--
+-- `test_events` carries NO memex_id and NO RLS — every memex's events are
+-- globally visible; tenancy lives only inside the `ac_uid` STRING
+-- (<namespace>/<memex>/specs/spec-N/acs/ac-M). Spec handles ("spec-1", "spec-99")
+-- are per-memex and collide across every memex, so one memex's test event matched
+-- EVERY other memex's same-numbered spec and inherited that doc's memex_id — a
+-- live cross-org bleed (markhadfield@agent-craft surfaced inside
+-- mindset-prod/memex-building-itself; ~1.5M rows affected). RLS on `documents`
+-- did NOT backstop it: it scopes which documents are visible, but the unprotected
+-- test_events row is the bridge and has no tenancy to filter on. The 0089 header's
+-- claim that security_invoker "closes the handle-join across memexes", and the
+-- arm's claim of a "(handle, memex_id)" join, were both false.
+--
+-- THE FIX: resolve the owning memex from the FULL ac_uid prefix
+-- (<namespace>/<memex>) via namespaces+memexes, and REQUIRE the spec doc to live
+-- in that memex (spec_doc.memex_id = te_mx.id). Handle-only matching is gone, so a
+-- test event can only ever attach to a spec in its OWN memex. Rows whose ac_uid
+-- prefix doesn't resolve to a real namespace/memex (legacy/partial ac_uids) are
+-- dropped rather than mis-attributed.
+--
+-- Every OTHER arm is reproduced verbatim from 0089 (CREATE OR REPLACE VIEW must
+-- restate the whole view). security_invoker is retained. Idempotent.
+--
+-- SHIP PATH: this is the break-glass hotfix (std-21 hotfix lane). It is cut from
+-- main and numbered 0109 so the SAME filename is collision-free on BOTH main (a
+-- gap after 0104) and the develop back-merge (0105/0106/0107 plus 0108 are taken
+-- on develop — 0108 went to spec-391's 0108_ac_reviewed_reason while this hotfix
+-- was in flight). Identical filename on both lines means the later develop→main
+-- release re-applies nothing. Supersedes the develop-based PR #331 (migration 0107).
+
+CREATE OR REPLACE VIEW activity_view WITH (security_invoker = true) AS
+
+-- ── Arm 1: source tables ─────────────────────────────────────────────────────
+
+-- documents (the spec/doc itself). No updated_at → created_at.
+SELECT
+  d.created_at                          AS at,
+  NULL::uuid                            AS actor_user_id,
+  NULL::text                            AS actor_name,
+  NULL::text                            AS actor_raw,
+  NULL::text                            AS channel,
+  d.id                                  AS spec_ref,
+  'document'::text                      AS kind,
+  d.id                                  AS entity_id,
+  'created'::text                       AS action,
+  NULL::text                            AS narrative,
+  d.memex_id                            AS memex_id
+FROM documents d
+
+UNION ALL
+
+-- acs
+SELECT
+  COALESCE(a.updated_at, a.created_at)  AS at,
+  a.actor_user_id                       AS actor_user_id,
+  a.actor_name                          AS actor_name,
+  NULL::text                            AS actor_raw,
+  a.channel                             AS channel,
+  a.brief_id                            AS spec_ref,
+  'ac'::text                            AS kind,
+  a.id                                  AS entity_id,
+  'created'::text                       AS action,
+  a.statement                           AS narrative,
+  a.memex_id                            AS memex_id
+FROM acs a
+
+UNION ALL
+
+-- tasks (no updated_at column → created_at)
+SELECT
+  t.created_at                          AS at,
+  t.actor_user_id                       AS actor_user_id,
+  t.actor_name                          AS actor_name,
+  NULL::text                            AS actor_raw,
+  t.channel                             AS channel,
+  t.doc_id                              AS spec_ref,
+  'task'::text                          AS kind,
+  t.id                                  AS entity_id,
+  'created'::text                       AS action,
+  t.title                               AS narrative,
+  t.memex_id                            AS memex_id
+FROM tasks t
+
+UNION ALL
+
+-- decisions (no updated_at column → created_at)
+SELECT
+  dec.created_at                        AS at,
+  dec.actor_user_id                     AS actor_user_id,
+  dec.actor_name                        AS actor_name,
+  NULL::text                            AS actor_raw,
+  dec.channel                           AS channel,
+  dec.doc_id                            AS spec_ref,
+  'decision'::text                      AS kind,
+  dec.id                                AS entity_id,
+  'created'::text                       AS action,
+  dec.title                             AS narrative,
+  dec.memex_id                          AS memex_id
+FROM decisions dec
+
+UNION ALL
+
+-- doc_sections
+SELECT
+  COALESCE(s.updated_at, s.created_at)  AS at,
+  s.actor_user_id                       AS actor_user_id,
+  s.actor_name                          AS actor_name,
+  NULL::text                            AS actor_raw,
+  s.channel                             AS channel,
+  s.doc_id                              AS spec_ref,
+  'section'::text                       AS kind,
+  s.id                                  AS entity_id,
+  'created'::text                       AS action,
+  s.title                               AS narrative,
+  -- doc_sections has no memex_id; derive it from the owning document.
+  (SELECT pd.memex_id FROM documents pd WHERE pd.id = s.doc_id) AS memex_id
+FROM doc_sections s
+
+UNION ALL
+
+-- doc_comments — WHO is author_user_id / author_name (no actor_* columns here).
+SELECT
+  c.created_at                          AS at,
+  c.author_user_id                      AS actor_user_id,
+  c.author_name                         AS actor_name,
+  NULL::text                            AS actor_raw,
+  c.channel                             AS channel,
+  c.doc_id                              AS spec_ref,
+  'comment'::text                       AS kind,
+  c.id                                  AS entity_id,
+  'created'::text                       AS action,
+  c.content                             AS narrative,
+  c.memex_id                            AS memex_id
+FROM doc_comments c
+
+UNION ALL
+
+-- ── Arm 2: test_events — verification flips, TENANT-SCOPED (spec-396) ─────────
+-- The free-form actor rides the TOP-LEVEL test_events.actor column → actor_raw
+-- (resolved at the read path by services/who-resolver.ts). actor_user_id /
+-- actor_name are NULL.
+--
+-- spec_ref / memex_id are recovered by resolving the FULL ac_uid prefix
+-- (<namespace>/<memex>) to a memex and requiring the spec doc to live in it — NOT
+-- by the spec handle alone (that was the cross-org leak this migration fixes). A
+-- test event can therefore only attach to a spec in its OWN memex.
+SELECT
+  te.created_at                         AS at,
+  NULL::uuid                            AS actor_user_id,
+  NULL::text                            AS actor_name,
+  te.actor                              AS actor_raw,
+  NULL::text                            AS channel,
+  spec_doc.id                           AS spec_ref,
+  'test_event'::text                    AS kind,
+  te.id                                 AS entity_id,
+  CASE
+    WHEN te.status = 'pass' THEN 'verified'
+    WHEN te.status IN ('fail', 'error') THEN 'regressed'
+    ELSE te.status
+  END                                   AS action,
+  NULL::text                            AS narrative,
+  spec_doc.memex_id                     AS memex_id
+FROM test_events te
+JOIN namespaces te_ns
+  ON te_ns.slug = split_part(te.ac_uid, '/', 1)
+JOIN memexes te_mx
+  ON te_mx.namespace_id = te_ns.id
+ AND te_mx.slug = split_part(te.ac_uid, '/', 2)
+JOIN documents spec_doc
+  ON spec_doc.memex_id = te_mx.id
+ AND spec_doc.handle = substring(te.ac_uid from 'specs/([^/]+)/')
+ AND spec_doc.doc_type = 'spec'
+
+UNION ALL
+
+-- ── Arm 3: activity_log — the SOURCELESS events ──────────────────────────────
+-- Checkpoint beats + spec-179 status_changed phase moves. These have NO
+-- source-table row, so the view UNIONs them straight from activity_log.
+SELECT
+  al.created_at                         AS at,
+  al.actor_user_id                      AS actor_user_id,
+  al.actor_name                         AS actor_name,
+  NULL::text                            AS actor_raw,
+  al.channel                            AS channel,
+  al.brief_id                           AS spec_ref,
+  'activity_log'::text                  AS kind,
+  al.id                                 AS entity_id,
+  al.action                             AS action,
+  al.narrative                          AS narrative,
+  al.memex_id                           AS memex_id
+FROM activity_log al;

--- a/packages/server/src/agent/spec-396-activity-view-tenant-isolation.integration.test.ts
+++ b/packages/server/src/agent/spec-396-activity-view-tenant-isolation.integration.test.ts
@@ -1,0 +1,165 @@
+// spec-396 — SECURITY regression: the activity_view test_events arm must NOT
+// leak one memex's test activity into another memex that shares a spec handle.
+//
+// THE BUG (migration 0089): the test_events arm joined test_events → documents on
+// the spec HANDLE alone. test_events has no memex_id and no RLS, and spec handles
+// ("spec-1", "spec-99", …) collide across every memex, so one memex's test event
+// matched every other memex's same-numbered spec and surfaced — actor name, status,
+// timing — in the foreign memex's get_doc agent footer / Pulse / Home feeds. On
+// prod, markhadfield@agent-craft bled into mindset-prod/memex-building-itself
+// (~1.5M rows). FIX (migration 0109): scope the arm by the FULL ac_uid prefix
+// (<namespace>/<memex>) so a test event can only attach to a spec in its OWN memex.
+//
+// This test reproduces the colliding-handle scenario and FAILS if the bleed
+// returns (ac-1, ac-2). It also proves legitimate same-memex events still surface
+// (ac-3). Tagged so verification lands on spec-396.
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { eq, inArray } from "drizzle-orm";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { db } from "../db/connection.js";
+import {
+  users,
+  namespaces,
+  orgs,
+  orgMemberships,
+  memexes,
+  documents,
+  testEvents,
+} from "../db/schema.js";
+import { createDocDraft } from "../services/documents.js";
+import { listActivityView } from "../services/activity-view.js";
+import { craftActivityBlock } from "./tool-specs.js";
+
+const AC = "mindset-prod/memex-building-itself/specs/spec-396/acs";
+
+const created = {
+  users: [] as string[],
+  namespaces: [] as string[],
+  orgs: [] as string[],
+  memexes: [] as string[],
+  docs: [] as string[],
+  testEvents: [] as string[],
+};
+
+// Two SEPARATE tenants (namespace + org + memex each). Both memexes are slugged
+// "main"; the leak is on the SPEC handle, which collides across memexes.
+let nsAslug: string;
+let memexAId: string;
+let docAId: string;
+let handleA: string;
+
+let memexBId: string;
+let docBId: string;
+let handleB: string;
+
+let callerId: string; // a member of tenant B, the one reading B's footer
+let foreignActor: string; // the free-form CI actor on tenant A's event
+
+async function makeTenant(tag: string): Promise<{ nsSlug: string; memexId: string }> {
+  const [ns] = await db
+    .insert(namespaces)
+    .values({ slug: `s396-${tag}`, kind: "org" })
+    .returning();
+  created.namespaces.push(ns.id);
+  const [org] = await db.insert(orgs).values({ namespaceId: ns.id, name: `T ${tag}` }).returning();
+  created.orgs.push(org.id);
+  await db.update(namespaces).set({ ownerOrgId: org.id }).where(eq(namespaces.id, ns.id));
+  const [m] = await db
+    .insert(memexes)
+    .values({ namespaceId: ns.id, slug: "main", name: `T ${tag}` })
+    .returning();
+  created.memexes.push(m.id);
+  return { nsSlug: ns.slug, memexId: m.id };
+}
+
+async function makeSpec(memexId: string, title: string): Promise<{ id: string; handle: string }> {
+  const doc = await createDocDraft(memexId, title, "x", "spec");
+  created.docs.push(doc.id);
+  const [row] = await db.select().from(documents).where(eq(documents.id, doc.id));
+  return { id: doc.id, handle: row.handle };
+}
+
+beforeAll(async () => {
+  const tag = `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`.toLowerCase();
+  foreignActor = `craftspy-${tag}`;
+
+  const [caller] = await db
+    .insert(users)
+    .values({ email: `caller-${tag}@memex.ai`, name: `Caller ${tag}` } as typeof users.$inferInsert)
+    .returning();
+  callerId = caller.id;
+  created.users.push(caller.id);
+
+  // Tenant A — owns the test event that must NOT leak.
+  const a = await makeTenant(`${tag}a`);
+  nsAslug = a.nsSlug;
+  memexAId = a.memexId;
+  const sa = await makeSpec(memexAId, "Tenant A spec");
+  docAId = sa.id;
+  handleA = sa.handle;
+
+  // Tenant B — the victim memex doing the reading.
+  const b = await makeTenant(`${tag}b`);
+  memexBId = b.memexId;
+  // Make B's org include the caller so craftActivityBlock renders for them.
+  const [orgB] = await db
+    .select()
+    .from(orgs)
+    .where(eq(orgs.id, created.orgs[created.orgs.length - 1]));
+  await db.insert(orgMemberships).values({ userId: caller.id, orgId: orgB.id, role: "administrator" });
+  const sb = await makeSpec(memexBId, "Tenant B spec");
+  docBId = sb.id;
+  handleB = sb.handle;
+
+  // Tenant A emits a CI flip on ITS spec, addressed by A's full canonical ac_uid.
+  const acUid = `${nsAslug}/main/specs/${handleA}/acs/ac-1`;
+  const [te] = await db
+    .insert(testEvents)
+    .values({ acUid, status: "pass", actor: foreignActor } as typeof testEvents.$inferInsert)
+    .returning();
+  created.testEvents.push(te.id);
+});
+
+afterAll(async () => {
+  if (created.testEvents.length)
+    await db.delete(testEvents).where(inArray(testEvents.id, created.testEvents)).catch(() => {});
+  if (created.docs.length)
+    await db.delete(documents).where(inArray(documents.id, created.docs)).catch(() => {});
+  if (created.memexes.length)
+    await db.delete(memexes).where(inArray(memexes.id, created.memexes)).catch(() => {});
+  if (created.orgs.length)
+    await db.delete(orgs).where(inArray(orgs.id, created.orgs)).catch(() => {});
+  if (created.namespaces.length)
+    await db.delete(namespaces).where(inArray(namespaces.id, created.namespaces)).catch(() => {});
+  if (created.users.length)
+    await db.delete(users).where(inArray(users.id, created.users)).catch(() => {});
+});
+
+describe("activity_view is tenant-isolated across colliding spec handles [spec-396]", () => {
+  it("precondition: both tenants' first spec share the same handle (the collision)", () => {
+    // If this ever fails, handles stopped colliding and the test no longer
+    // exercises the bug — fix the fixture, don't delete the guard.
+    expect(handleA).toBe(handleB);
+  });
+
+  it("ac-1: tenant B's activity view never returns tenant A's test event", async () => {
+    tagAc(`${AC}/ac-1`);
+    const rows = await listActivityView(memexBId, { specRef: docBId });
+    const leaked = rows.filter((r) => r.actorRaw === foreignActor);
+    expect(leaked, "no foreign test_event may appear in another memex's activity").toEqual([]);
+  });
+
+  it("ac-2: tenant B's get_doc footer never names tenant A's CI actor", async () => {
+    tagAc(`${AC}/ac-2`);
+    const block = await craftActivityBlock(memexBId, docBId, callerId);
+    expect(block ?? "").not.toContain(foreignActor);
+  });
+
+  it("ac-3: the event STILL appears in its own memex's activity (no over-scoping)", async () => {
+    tagAc(`${AC}/ac-3`);
+    const rows = await listActivityView(memexAId, { specRef: docAId });
+    const own = rows.filter((r) => r.actorRaw === foreignActor);
+    expect(own.length, "the legitimate same-memex event must be preserved").toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Develop/int companion of the prod hotfix → \`develop\`

The integration-line half of the std-21 break-glass hotfix. Pairs with the \`→ main\` prod PR **#334** (same fix, branch cut from \`main\`). Cut from \`develop\` so it can satisfy develop's up-to-date (\`strict\`) merge requirement without ever touching the \`→ main\` branch.

### What it does
Rewrites \`activity_view\`'s \`test_events\` arm to resolve the owning memex from the **full \`ac_uid\` prefix** (\`<namespace>/<memex>\`) and require the spec doc to live in that memex, instead of matching the spec handle alone. The handle-only join collided across memexes and leaked foreign test activity (\`markhadfield@agent-craft\` → \`memex-building-itself\`, ~1.5M rows). \`CREATE OR REPLACE VIEW\`, every other arm verbatim from 0089, \`security_invoker\` retained.

### Files
- \`drizzle/0108_activity_view_tenant_scope.sql\` — clears develop's existing \`0107_scaffold_additions_personal_namespace.sql\`.
- \`spec-396-activity-view-tenant-isolation.integration.test.ts\` — tenant-isolation regression (imports \`craftActivityBlock\` via \`tool-specs.ts\`'s re-export of \`handlers/shared.ts\`).

### Relationship to other PRs
- **#334** → \`main\`: the prod ship (branch off main). Once both this and #334 merge, \`git log develop..main --no-merges\` is empty.
- **Supersedes PR #331** (same fix, migration \`0107\`) — close #331 once this lands.

### ⚠️ Merge condition
**Merge only on green CI.** A local-only \`memex-embeddings.integration.test.ts\` failure (shared-fixture pollution) is green in CI on #331's identical suite and is untouched here.

🔒 spec-396 · break-glass (int half) · raised for review — do not auto-merge.