### PR TITLE
ci(security): run Semgrep on develop→main release PRs too

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,4 +1,4 @@
-# Security — Semgrep OSS static-analysis gate on develop.
+# Security — Semgrep OSS static-analysis gate on develop + the develop→main release PR.
 #
 # Complements CodeQL (codeql.yml): CodeQL is the deep dataflow engine, Semgrep
 # adds fast pattern-based rules (incl. a broad secrets pack) from the public
@@ -13,7 +13,14 @@ name: Security
 
 on:
   pull_request:
-    branches: [develop]
+    # `develop` gates every feature PR. `main` ALSO gates the develop→main release
+    # PR — without it the REQUIRED `semgrep` status never attaches to the release
+    # head (a develop merge commit the develop-only trigger never scans), so the
+    # release blocks forever "waiting for semgrep". On a release PR the baseline is
+    # the PR base (main), so it stays a diff-scan of what the release introduces —
+    # never the full-repo scan that workflow_dispatch does (which fails on the
+    # repo's pre-existing findings).
+    branches: [develop, main]
   workflow_dispatch:
 
 # Least-privilege default for GITHUB_TOKEN.


### PR DESCRIPTION
Fixes the release-blocking gap surfaced on #346: the required `semgrep` check only ran on `pull_request` into develop, so it never attached a status to a `develop → main` release PR head (a develop merge commit). Adds `main` to the trigger; on a release PR the baseline is the PR base (main), so it stays a diff-scan (not the full-repo scan `workflow_dispatch` does, which fails on pre-existing findings). Unblocks #346 and every future release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)