### PR TITLE
fix(outline): readable comment text in light mode + last-segment scroll-spy

### DIFF
--- a/packages/ui/src/components/DocOutline.tsx
+++ b/packages/ui/src/components/DocOutline.tsx
@@ -95,7 +95,7 @@ export function DocOutline({
                         }}
                         className={`
                           group flex w-full items-start gap-1.5 pl-6 pr-2 py-1 -ml-px border-l border-transparent
-                          text-left transition-colors no-underline text-muted! hover:text-secondary!
+                          text-left transition-colors no-underline text-primary! hover:text-primary!
                           ${canNavigate ? 'cursor-pointer' : 'cursor-default'}
                         `}
                       >
@@ -108,7 +108,7 @@ export function DocOutline({
                             {c.content}
                           </span>
                           {/* author + human-vs-agent indicator (dec-2 / ac-7). */}
-                          <span className="block truncate text-[10px] text-muted/70">
+                          <span className="block truncate text-[10px] text-secondary">
                             {c.authorName}
                             {isAgent && (
                               <span className="ml-1 rounded-sm bg-edge-subtle px-1 font-mono uppercase">

--- a/packages/ui/src/pages/doc-document/NarrativeView.tsx
+++ b/packages/ui/src/pages/doc-document/NarrativeView.tsx
@@ -78,6 +78,18 @@ export function NarrativeView({
       .filter((x): x is { el: HTMLElement; id: string } => x != null);
     if (els.length === 0) return;
 
+    // The element that actually scrolls the narrative (AppShell's <main>). Walked
+    // up from a section so we don't hard-code it. A short FINAL section can never
+    // scroll high enough to enter the band below — so once this scroller bottoms
+    // out, the last segment is the active one. Without this guard, clicking the
+    // final segment highlights it for a frame, then the observer snaps the
+    // highlight back to whatever's still topmost (the reported bug).
+    const scroller = findScrollParent(els[0].el);
+    const atBottom = () => {
+      if (!scroller || scroller.scrollHeight <= scroller.clientHeight + 2) return false;
+      return scroller.scrollTop + scroller.clientHeight >= scroller.scrollHeight - 2;
+    };
+
     const visible = new Set<string>();
     const observer = new IntersectionObserver(
       (entries) => {
@@ -86,7 +98,12 @@ export function NarrativeView({
           if (e.isIntersecting) visible.add(elId);
           else visible.delete(elId);
         }
-        // The active section is the topmost one currently in the band.
+        // The active section is the topmost one currently in the band — unless
+        // we've bottomed out, in which case the last segment wins.
+        if (atBottom()) {
+          onSelectSection(els[els.length - 1].id);
+          return;
+        }
         const active = els.find(({ el }) => visible.has(el.id));
         if (active) onSelectSection(active.id);
       },
@@ -95,7 +112,25 @@ export function NarrativeView({
       { rootMargin: '0px 0px -55% 0px', threshold: 0 },
     );
     els.forEach(({ el }) => observer.observe(el));
-    return () => observer.disconnect();
+
+    // The observer only fires when a section crosses the band edge; a small scroll
+    // at the very bottom won't, so watch the scroller directly to land the
+    // bottom guard (rAF-coalesced; agrees with the observer, so no fight).
+    let raf = 0;
+    const onScroll = () => {
+      if (raf) return;
+      raf = requestAnimationFrame(() => {
+        raf = 0;
+        if (atBottom()) onSelectSection(els[els.length - 1].id);
+      });
+    };
+    scroller?.addEventListener('scroll', onScroll, { passive: true });
+
+    return () => {
+      observer.disconnect();
+      scroller?.removeEventListener('scroll', onScroll);
+      if (raf) cancelAnimationFrame(raf);
+    };
   }, [narrativeSections, onSelectSection]);
 
   return (
@@ -149,4 +184,20 @@ export function NarrativeView({
       </aside>
     </div>
   );
+}
+
+// Nearest scrollable ancestor — the element whose own overflow actually scrolls
+// the content (AppShell's <main> in the app; null under jsdom, where Tailwind's
+// `overflow-y-auto` isn't resolved, so the scroll-spy keeps its observer-only
+// behaviour in tests).
+function findScrollParent(el: HTMLElement): HTMLElement | null {
+  let node: HTMLElement | null = el.parentElement;
+  while (node) {
+    const overflowY = getComputedStyle(node).overflowY;
+    if ((overflowY === 'auto' || overflowY === 'scroll') && node.scrollHeight > node.clientHeight) {
+      return node;
+    }
+    node = node.parentElement;
+  }
+  return null;
 }


### PR DESCRIPTION
## What

Two fixes to the document **outline / SEGMENTS** sidebar (`DocOutline`, spec-361), found while testing the unified agents in light mode.

### 1. Comment-preview text was unreadable in light mode
The outline's comment-preview rows rendered the comment **content** at `text-muted` — **slate-400** on a slate-50 surface (~2.6:1 contrast), the same washed-out class of bug as the agent panels. Now:
- **Content** → `text-primary` (slate-800 — matches the active section title, fully readable)
- **Byline** → `text-secondary` (slate-500), so the content > author hierarchy is preserved.

Also improves dark mode (content goes slate-400 → slate-200-ish via the brighter token).

### 2. Clicking the last segment didn't highlight it
The scroll-spy's active band is the top ~45% of the viewport. A short **final** section can never scroll high enough to enter it, so clicking the last segment highlighted it for one frame, then the `IntersectionObserver` snapped the highlight back to whatever was still topmost.

Added a **bottom guard**: once the scroll container (AppShell's `<main>`) bottoms out, the last segment is the active one. The guard is **inert under jsdom** (Tailwind's `overflow-y-auto` isn't resolved, so the scroll parent resolves to `null`), so the existing spec-361 observer contract — and its test — are untouched.

## Verification
- `pnpm build` (tsc -b && vite build) ✅
- `biome check` ✅
- `DocDocument.spec-361-scrollspy.test.tsx` + `DocOutline.spec-361.test.tsx` → **8/8 pass**
- Manually verified live: comment text renders dark; clicking the final segment keeps it highlighted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)