### PR TITLE
fix(spec-398): make 0111 retention migration deadlock-proof

### DIFF
--- a/packages/server/drizzle/0111_test_events_retention_and_memex_id.sql
+++ b/packages/server/drizzle/0111_test_events_retention_and_memex_id.sql
@@ -26,6 +26,36 @@
 -- runner is transactional). first_verified_at was snapshotted in 0110, BEFORE this
 -- prune deletes the oldest passing rows.
 
+-- ── 0. Deadlock guard — take both table locks up front, in the APP's lock order ─
+-- This migration mutates test_event_latest (§1 ALTER) before test_events (§2
+-- swap). Live /api/test-events emissions take the SAME two locks in the OPPOSITE
+-- order (INSERT test_events → UPSERT test_event_latest, routes/test-events.ts), so
+-- the first prod release deadlocked (40P01) against traffic and rolled the whole
+-- file back. Acquiring both locks here, up front, in the emission order (test_events
+-- first), removes the lock-order cycle: the migration now either wins a clean
+-- exclusive window or fails fast on lock_timeout and retries on the next deploy — it
+-- can never deadlock. It does hold test_events ACCESS EXCLUSIVE for the ~80s the §2
+-- row-copy takes, so emissions/feed reads pause for that deploy window — acceptable,
+-- and far better than a failed deploy.
+--
+-- Why the LOCK is wrapped in a DO block rather than a bare `LOCK TABLE`: this file
+-- is applied two ways. (1) Prod / the dev hand-runner (apply-hand-migrations.mjs)
+-- wraps the whole file in ONE transaction — a bare LOCK would work there. (2) The
+-- e2e-cold template build pipes each file through `psql -f` in AUTOCOMMIT, where a
+-- bare `LOCK TABLE` errors ("can only be used in transaction blocks", Postgres 16).
+-- A DO block runs its body inside an implicit transaction in BOTH paths, so the LOCK
+-- is valid either way. The lock has transaction scope, so under the transactional
+-- prod runner it is HELD for the rest of the migration (verified via pg_locks);
+-- under autocommit it is released when the DO block returns — harmless, since the
+-- cold template build has no concurrent traffic to deadlock against. lock_timeout is
+-- set at session level first so it bounds the LOCK's wait inside the block.
+SET lock_timeout = '15s';
+--> statement-breakpoint
+DO $$ BEGIN
+  LOCK TABLE test_events, test_event_latest IN ACCESS EXCLUSIVE MODE;
+END $$;
+--> statement-breakpoint
+
 -- ── 1. test_event_latest.memex_id ────────────────────────────────────────────
 ALTER TABLE test_event_latest ADD COLUMN IF NOT EXISTS memex_id uuid;
 --> statement-breakpoint

--- a/packages/server/src/__regression__/spec-398-migration-deadlock-guard.regression.test.ts
+++ b/packages/server/src/__regression__/spec-398-migration-deadlock-guard.regression.test.ts
@@ -1,0 +1,119 @@
+// spec-398 — the bounded-retention migration (0111) must be deadlock-proof.
+//
+// The first prod release of 0111 deadlocked (Postgres 40P01) against live traffic
+// and rolled the whole file back. Cause: a two-table lock-order cycle.
+//   • 0111 mutates test_event_latest (§1 ALTER … ADD memex_id) BEFORE test_events
+//     (§2 rewrite-and-swap) — lock order test_event_latest → test_events.
+//   • Live /api/test-events emissions, in one transaction, INSERT test_events then
+//     upsert test_event_latest (routes/test-events.ts) — lock order test_events →
+//     test_event_latest, the OPPOSITE.
+// Two transactions taking the same two locks in opposite orders is the textbook
+// deadlock, and test_events is written continuously, so it was near-certain.
+//
+// The fix: 0111 takes BOTH locks up front, in the EMISSION order (test_events
+// first), under a bounded lock_timeout — before any DDL/DML. The cycle is gone
+// (everyone now requests test_events first); the migration either wins a clean
+// exclusive window or fails fast on lock_timeout and retries next deploy. It can
+// never deadlock again.
+//
+// The LOCK is wrapped in a DO $$ … $$ block, NOT a bare `LOCK TABLE`, because the
+// file is applied two ways: the prod/dev hand-runner wraps each file in ONE
+// transaction (a bare LOCK would work), but the e2e-cold template build pipes each
+// file through `psql -f` in AUTOCOMMIT, where a bare LOCK errors ("can only be used
+// in transaction blocks", PG16). A DO block runs its body in an implicit transaction
+// in BOTH paths. The bare-LOCK regression is silent (e2e-cold goes red only at
+// template-build), so the DO-block wrapper is guarded explicitly below.
+//
+// This is a STATIC GUARD on the migration file: it fails if the up-front lock guard
+// is ever removed, reordered out of emission order, made unbounded, pushed below the
+// first schema statement, or un-wrapped from its DO block. It tags ac-4 (the
+// rewrite-and-swap) — the lock guard is what makes that swap safely applicable
+// against a live, continuously-written table.
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+const SPEC = "mindset-prod/memex-building-itself/specs/spec-398";
+const MIGRATION = join(
+  __dirname,
+  "..",
+  "..",
+  "drizzle",
+  "0111_test_events_retention_and_memex_id.sql",
+);
+
+const raw = readFileSync(MIGRATION, "utf-8");
+
+// Strip SQL line comments so prose mentioning ALTER/LOCK can't skew the positions.
+function stripComments(sql: string): string {
+  return sql
+    .split("\n")
+    .filter((line) => !line.trimStart().startsWith("--"))
+    .join("\n");
+}
+
+const body = stripComments(raw);
+const lower = body.toLowerCase();
+
+describe("spec-398 ac-4: the 0111 retention migration is deadlock-proof (static guard)", () => {
+  it("takes both table locks up front in ACCESS EXCLUSIVE MODE", () => {
+    tagAc(`${SPEC}/acs/ac-4`);
+    // One LOCK statement naming BOTH tables in ACCESS EXCLUSIVE MODE.
+    expect(lower).toMatch(
+      /lock\s+table\s+test_events\s*,\s*test_event_latest\s+in\s+access\s+exclusive\s+mode/,
+    );
+  });
+
+  it("wraps the LOCK in a DO block so it survives BOTH the transactional runner and autocommit psql -f", () => {
+    tagAc(`${SPEC}/acs/ac-4`);
+    // A bare `LOCK TABLE` errors under the e2e-cold template build (psql -f,
+    // autocommit). The DO block makes it valid there too. Guard the wrapper so a
+    // future "simplification" back to a bare LOCK can't silently break e2e-cold.
+    expect(lower).toMatch(
+      /do\s+\$\$\s*begin[\s\S]*lock\s+table\s+test_events\s*,\s*test_event_latest\s+in\s+access\s+exclusive\s+mode[\s\S]*end\s*\$\$/,
+    );
+  });
+
+  it("locks in the APP's emission order — test_events BEFORE test_event_latest", () => {
+    tagAc(`${SPEC}/acs/ac-4`);
+    // Live emissions lock test_events first; the migration must agree, or the
+    // cycle re-forms. Assert the order within the LOCK statement explicitly.
+    const lockStmt = lower.match(/lock\s+table\s+([^;]+?)\s+in\s+access\s+exclusive/);
+    expect(lockStmt, "LOCK TABLE … IN ACCESS EXCLUSIVE statement must exist").not.toBeNull();
+    const tablesText = lockStmt![1];
+    expect(tablesText.indexOf("test_events")).toBeLessThan(
+      tablesText.indexOf("test_event_latest"),
+    );
+  });
+
+  it("bounds the wait with a lock_timeout so it fails fast instead of hanging", () => {
+    tagAc(`${SPEC}/acs/ac-4`);
+    // A bounded timeout is what turns "deadlock against traffic" into "fail fast,
+    // retry next deploy". An unbounded LOCK could block indefinitely behind a long
+    // reader. Require lock_timeout to be SET, and SET before the LOCK is requested.
+    expect(lower).toMatch(/set\s+lock_timeout\s*=\s*'[^']+'/);
+    const setIdx = lower.search(/set\s+lock_timeout/);
+    const lockIdx = lower.search(/lock\s+table\s+test_events/);
+    expect(setIdx).toBeGreaterThanOrEqual(0);
+    expect(lockIdx).toBeGreaterThan(setIdx);
+  });
+
+  it("acquires the locks BEFORE any schema/data statement (no DDL runs unlocked)", () => {
+    tagAc(`${SPEC}/acs/ac-4`);
+    const lockIdx = lower.search(/lock\s+table\s+test_events/);
+    expect(lockIdx).toBeGreaterThanOrEqual(0);
+    // The first real mutating statement in the file: §1's ALTER … ADD memex_id, or
+    // any CREATE/UPDATE/DELETE/DROP/INSERT. Whichever comes first MUST come after
+    // the lock — otherwise that statement runs in the old (deadlock-prone) order.
+    const firstDdlIdx = lower.search(
+      /\b(alter\s+table|create\s+table|create\s+or\s+replace\s+view|update\s+|delete\s+from|drop\s+(table|view)|insert\s+into)\b/,
+    );
+    expect(firstDdlIdx).toBeGreaterThanOrEqual(0);
+    expect(
+      lockIdx,
+      "LOCK TABLE must precede the first schema/data statement",
+    ).toBeLessThan(firstDdlIdx);
+  });
+});


### PR DESCRIPTION
## Why

spec-398's first prod release (develop→main, merge `ecf8c74c`, 2026-06-24) **failed**: migration `0111_test_events_retention_and_memex_id.sql` hit a Postgres **deadlock (40P01)** against live traffic and rolled back. The hand-runner wraps each file in its own transaction, so 0111 rolled back cleanly while 0110 committed, and the deploy aborted before the Cloud Run push — prod is unchanged (old code, untrimmed ~2.37M-row `test_events`) with only the unused, backfilled `ac_first_verified` table from 0110.

**Verified against prod** before touching anything: `manual_migrations` has `0110` present / `0111` absent, `test_events` has no `memex_id` column and ~2.37M rows, `ac_first_verified` exists. State is exactly as expected.

### Root cause — two-table lock-order cycle

| Actor | Lock order |
|---|---|
| Migration 0111 | `test_event_latest` (§1 ALTER) → `test_events` (§2 rewrite-and-swap) |
| Live `/api/test-events` emission | `test_events` (INSERT) → `test_event_latest` (upsert) |

Opposite orders on a continuously-written table → near-certain deadlock under traffic.

## Fix

Take **both** locks up front, in **one place**, in the app's **emission order** (`test_events` first), under a bounded `lock_timeout`, **before any DDL**. The migration now either wins a clean exclusive window or fails fast on `lock_timeout` and retries next deploy — it **can never deadlock again**. It holds `test_events` ACCESS EXCLUSIVE for the ~80s the §2 row-copy takes (emissions/feed pause for that deploy window) — acceptable, and far better than a failed deploy.

**Why a `DO` block, not a bare `LOCK TABLE`:** the file is applied two ways — the prod/dev hand-runner (`apply-hand-migrations.mjs`) wraps each file in one transaction (a bare LOCK would work), but the `e2e-cold` template build pipes each file through `psql -f` in **autocommit**, where a bare `LOCK TABLE` **errors** ("can only be used in transaction blocks", PG16). A `DO` block runs its body in an implicit transaction in **both** paths. The lock has transaction scope, so under the transactional prod runner it is **held for the whole migration** (verified via `pg_locks`); under autocommit it releases when the block returns — harmless, the cold build has no concurrent traffic.

No schema/data change vs the INT-validated migration — **only the lock guard**. The keep-last-10 + `memex_id` backfill + `activity_view` rewrite are untouched.

## Tests

- New static regression guard `spec-398-migration-deadlock-guard.regression.test.ts` (tags ac-4): asserts the up-front lock is present, `DO`-wrapped (survives both runner paths), bounded by `lock_timeout`, in emission order (`test_events` before `test_event_latest`), and precedes all DDL.

## Local gate (all green)

- Server suite: **4766 passed**, 28 skipped
- UI suite: **1706 passed**, 1 skipped
- `pnpm build` (the prod tsc+vite type gate): ✓
- db-schema **drift gate** + db-schema package tests (18): ✓
- Cold migrate via **both** runner paths (transactional `.mjs` + autocommit `psql -f`): ✓ — `test_events.memex_id` NOT NULL
- UI typecheck + server build-config typecheck: ✓
- `make e2e-cold`: **109 passed**, 1 skipped (template rebuilt via `psql -f` — the path that would have broken with a bare LOCK)

## After merge

Promote develop → main. Real confirmation is on the prod DB, not a CI badge: `0111` in `manual_migrations`, `test_events.memex_id` NOT NULL, no `(ac_uid, test_identifier)` group > 10 rows, `activity_view` free of `split_part`, Cloud SQL CPU at baseline.