### PR TITLE
ci(e2e): retry playwright apt install on transient mirror-sync flake

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -561,12 +561,37 @@ jobs:
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
+      # Both install steps shell out to `apt`, which periodically red-flags a shard
+      # on a transient Google CDN mirror-sync race (apt fetches the Chrome repo index
+      # mid-sync → "File has unexpected size … Mirror sync in progress?" → exit 100,
+      # before any test runs). The window is short, so a bounded retry with backoff
+      # clears it; a real, persistent failure still fails the step after all attempts.
       - name: Install Playwright Chromium
         if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: pnpm --filter @memex/ui exec playwright install --with-deps chromium
+        run: |
+          attempts=4
+          for attempt in $(seq 1 "$attempts"); do
+            if pnpm --filter @memex/ui exec playwright install --with-deps chromium; then exit 0; fi
+            if [ "$attempt" -lt "$attempts" ]; then
+              echo "::warning::playwright install --with-deps failed (attempt $attempt/$attempts) — likely a transient apt mirror sync; retrying after backoff"
+              sleep $((attempt * 15))
+            fi
+          done
+          echo "::error::playwright install --with-deps failed after $attempts attempts"
+          exit 1
       - name: Install Playwright OS deps (cached browser)
         if: steps.playwright-cache.outputs.cache-hit == 'true'
-        run: pnpm --filter @memex/ui exec playwright install-deps chromium
+        run: |
+          attempts=4
+          for attempt in $(seq 1 "$attempts"); do
+            if pnpm --filter @memex/ui exec playwright install-deps chromium; then exit 0; fi
+            if [ "$attempt" -lt "$attempts" ]; then
+              echo "::warning::playwright install-deps failed (attempt $attempt/$attempts) — likely a transient apt mirror sync; retrying after backoff"
+              sleep $((attempt * 15))
+            fi
+          done
+          echo "::error::playwright install-deps failed after $attempts attempts"
+          exit 1
       - name: E2E journeys (shard ${{ matrix.shard }}/3)
         run: pnpm --filter @memex/ui test:e2e --shard=${{ matrix.shard }}/3
       - name: Upload Playwright trace on failure


### PR DESCRIPTION
## The flake

The e2e job's two Playwright install steps shell out to `apt`, and `apt` periodically fails a whole shard on a **transient Google CDN mirror-sync race** — it fetches the Chrome repo index mid-sync, the file size doesn't match the index, and the install aborts with exit 100, **before any journey runs**:

```
E: Failed to fetch https://dl.google.com/linux/chrome-stable/deb/.../Packages.gz
   File has unexpected size (1214 != 1213). Mirror sync in progress?
Failed to install browser dependencies — exit code 100
```

It's pure infra noise (nothing is actually broken), but it red-flags the PR and forces a manual re-run. Observed on PR #355's `e2e (3)` shard; the re-run was green.

## The fix

Wrap **both** install paths in a bounded retry:
- `playwright install --with-deps chromium` (cache **miss**)
- `playwright install-deps chromium` (cache **hit** — the one that failed on #355)

Up to **4 attempts** with escalating backoff (15/30/45s), a `::warning::` on each transient failure. A genuinely persistent failure still fails the step after all attempts — this masks flakes, not real breakage. No third-party action added; plain bash.

## Verification
- `actionlint` clean on the change (the one finding it reports is a pre-existing `SC2012` in an unrelated blob-counting step).
- YAML parses.
- Behavioural validation is inherently CI-side (the retry path only triggers on a real apt failure, which can't be forced locally).

CI-infra change — flagging for Barrie.