### PR TITLE
Release: retry playwright apt install on transient mirror-sync flake (#358)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -561,12 +561,37 @@ jobs:
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
+      # Both install steps shell out to `apt`, which periodically red-flags a shard
+      # on a transient Google CDN mirror-sync race (apt fetches the Chrome repo index
+      # mid-sync → "File has unexpected size … Mirror sync in progress?" → exit 100,
+      # before any test runs). The window is short, so a bounded retry with backoff
+      # clears it; a real, persistent failure still fails the step after all attempts.
       - name: Install Playwright Chromium
         if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: pnpm --filter @memex/ui exec playwright install --with-deps chromium
+        run: |
+          attempts=4
+          for attempt in $(seq 1 "$attempts"); do
+            if pnpm --filter @memex/ui exec playwright install --with-deps chromium; then exit 0; fi
+            if [ "$attempt" -lt "$attempts" ]; then
+              echo "::warning::playwright install --with-deps failed (attempt $attempt/$attempts) — likely a transient apt mirror sync; retrying after backoff"
+              sleep $((attempt * 15))
+            fi
+          done
+          echo "::error::playwright install --with-deps failed after $attempts attempts"
+          exit 1
       - name: Install Playwright OS deps (cached browser)
         if: steps.playwright-cache.outputs.cache-hit == 'true'
-        run: pnpm --filter @memex/ui exec playwright install-deps chromium
+        run: |
+          attempts=4
+          for attempt in $(seq 1 "$attempts"); do
+            if pnpm --filter @memex/ui exec playwright install-deps chromium; then exit 0; fi
+            if [ "$attempt" -lt "$attempts" ]; then
+              echo "::warning::playwright install-deps failed (attempt $attempt/$attempts) — likely a transient apt mirror sync; retrying after backoff"
+              sleep $((attempt * 15))
+            fi
+          done
+          echo "::error::playwright install-deps failed after $attempts attempts"
+          exit 1
       - name: E2E journeys (shard ${{ matrix.shard }}/3)
         run: pnpm --filter @memex/ui test:e2e --shard=${{ matrix.shard }}/3
       - name: Upload Playwright trace on failure


### PR DESCRIPTION
## Release contents

One change promotes from develop:

- **#358 — `ci(e2e)`: retry playwright apt install on transient mirror-sync flake.** The e2e job's two Playwright install steps shell out to `apt`, which periodically fails a whole shard on a transient Google CDN mirror-sync race (fetches the Chrome repo index mid-sync → size mismatch → exit 100, before any journey runs). Both `playwright install --with-deps` (cache miss) and `playwright install-deps` (cache hit) are now wrapped in a bounded retry: 4 attempts, escalating backoff (15/30/45s), warning on each transient failure. A genuinely persistent failure still fails after all attempts — masks flakes, not bugs. Workflow-only change (`.github/workflows/test.yml`); no app code touched.

## Verification already done
- PR #358: actionlint clean on the change; YAML parses.
- develop→**int** deploy (run 28169621408): gate ✅ → deploy ✅ → **✓ Smoke passed (ENV=int)**.

## Content invariant
`git log develop..main --no-merges` is empty. Release via merge commit per std-21 cl-50.