### PR TITLE
spec-406: per-Spec Stats tab + std-32 attribution-gap fix

### DIFF
--- a/packages/server/src/agent/handlers/decisions.ts
+++ b/packages/server/src/agent/handlers/decisions.ts
@@ -231,7 +231,7 @@ export const decisionsTools: ToolSpec[] = [
         // be using `resolve_decision`, `approve_candidate`,
         // `reject_candidate`, or `delete_decision` instead.
         if (current === "resolved" && target === "open") {
-          updated = await reopenDecision(memexId, entity.row.id);
+          updated = await reopenDecision(memexId, entity.row.id, reqCtx(ctx));
           mode = "reopened";
         } else if (current === "deleted") {
           updated = await restoreDecision(memexId, entity.row.id, target);
@@ -431,7 +431,7 @@ export const decisionsTools: ToolSpec[] = [
         );
       }
       const { memexId, doc, slugs, entity } = resolved;
-      const decision = await approveDecision(memexId, entity.row.id);
+      const decision = await approveDecision(memexId, entity.row.id, reqCtx(ctx));
       if (ctx.verbose) {
         const state = await fullDocState(memexId, decision.docId);
         const url = await ctx.workspaceUrl(memexId);
@@ -466,7 +466,7 @@ export const decisionsTools: ToolSpec[] = [
         );
       }
       const { memexId, doc, slugs, entity } = resolved;
-      const decision = await rejectDecision(memexId, entity.row.id, reason);
+      const decision = await rejectDecision(memexId, entity.row.id, reason, reqCtx(ctx));
       if (ctx.verbose) {
         const state = await fullDocState(memexId, decision.docId);
         const url = await ctx.workspaceUrl(memexId);

--- a/packages/server/src/agent/handlers/issues.ts
+++ b/packages/server/src/agent/handlers/issues.ts
@@ -344,7 +344,7 @@ export const issuesTools: ToolSpec[] = [
         );
       }
       const { memexId, doc, slugs, entity } = resolved;
-      const result = await convertIssueToTask(memexId, entity.row.id);
+      const result = await convertIssueToTask(memexId, entity.row.id, reqCtx(ctx));
       const taskRef = buildChildRef(slugs, doc, { type: "tasks", seq: result.task.seq });
       const issueRef = buildChildRef(slugs, doc, { type: "issues", seq: result.issue.seq });
       if (ctx.verbose) {

--- a/packages/server/src/routes/acs.ts
+++ b/packages/server/src/routes/acs.ts
@@ -42,6 +42,7 @@ import {
 import { type SessionEnv } from "../middleware/session.js";
 import type { MemexResolverEnv } from "../middleware/memex-resolver.js";
 import { requireMemexId, resolveReadableMemexId } from "./shared.js";
+import { restCtx } from "./_actor-ctx.js";
 import { mountStandardSessionPolicy } from "./session-policy.js";
 
 type Env = MemexResolverEnv & SessionEnv;
@@ -88,14 +89,14 @@ acsRouter.post("/:acId/acceptance", async (c) => {
   const acId = c.req.param("acId");
   const user = c.get("user");
   const actor = user?.name?.trim() || user?.email || "";
-  const result = await setAcAcceptance(memexId, acId, actor);
+  const result = await setAcAcceptance(memexId, acId, actor, restCtx(c));
   return c.json(result);
 });
 
 acsRouter.delete("/:acId/acceptance", async (c) => {
   const memexId = requireMemexId(c);
   const acId = c.req.param("acId");
-  const result = await clearAcAcceptance(memexId, acId);
+  const result = await clearAcAcceptance(memexId, acId, restCtx(c));
   return c.json(result);
 });
 

--- a/packages/server/src/routes/analytics.ts
+++ b/packages/server/src/routes/analytics.ts
@@ -1,4 +1,4 @@
-import { Hono } from "hono";
+import { Hono, type Context } from "hono";
 import { type SessionEnv } from "../middleware/session.js";
 import type { MemexResolverEnv } from "../middleware/memex-resolver.js";
 import { resolveReadableMemexId } from "./shared.js";
@@ -13,8 +13,14 @@ import {
   acsOverTime,
   testRunVolume,
   testSignalPulse,
+  specPhaseDurations,
+  specLifecycleSummary,
+  specTaskVelocity,
+  specAcVerification,
+  specActivityAudit,
 } from "../services/analytics.js";
 import { standardsGraph, DEFAULT_SEMANTIC_THRESHOLD } from "../services/standards-graph.js";
+import { getDoc } from "../services/documents.js";
 import { ValidationError } from "../types/errors.js";
 
 // ── Spec analytics (spec-179) ────────────────────────────────────────────────
@@ -33,6 +39,25 @@ const analytics = new Hono<Env>();
 
 // spec-377 — the standard per-verb session policy (see session-policy.ts).
 mountStandardSessionPolicy(analytics);
+
+// Parse a present-but-optional integer query param; throw 400 on a bad value so a
+// typo surfaces instead of silently defaulting. Absent → undefined.
+function parsePositiveInt(raw: string | undefined, field: string): number | undefined {
+  if (raw === undefined) return undefined;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || !Number.isInteger(n) || n <= 0) {
+    throw new ValidationError(`Query param '${field}' must be a positive integer`);
+  }
+  return n;
+}
+function parseNonNegativeInt(raw: string | undefined, field: string): number | undefined {
+  if (raw === undefined) return undefined;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || !Number.isInteger(n) || n < 0) {
+    throw new ValidationError(`Query param '${field}' must be a non-negative integer`);
+  }
+  return n;
+}
 
 // GET /analytics/specs-over-time — per-day created + cumulative (ac-1).
 analytics.get("/specs-over-time", async (c) => {
@@ -115,6 +140,55 @@ analytics.get("/standards-graph", async (c) => {
     semanticThreshold = n;
   }
   return c.json(await standardsGraph(memexId, { semanticThreshold }));
+});
+
+// ── Per-spec stats (spec-406) ────────────────────────────────────────────────
+//
+// GET /api/<ns>/<mx>/analytics/spec/<id>/* — the spec-scoped siblings powering
+// the Stats tab. `id` is a spec handle (spec-N) or UUID; getDoc resolves it
+// scoped to this memex and 404s an unknown/cross-tenant id (std-7 — dec-6).
+// Ungated: no hiddenFeatures check, read-only, public-readable wherever the
+// memex is (resolveReadableMemexId).
+
+/** Resolve the readable memexId + the spec's canonical id from the `:id` ref. */
+async function resolveSpec(c: Context<Env>): Promise<{ memexId: string; docId: string }> {
+  const memexId = await resolveReadableMemexId(c);
+  const spec = await getDoc(memexId, c.req.param("id")!);
+  return { memexId, docId: spec.id };
+}
+
+// GET /analytics/spec/:id/phase-durations — event-series time-in-phase (dec-1, dec-4).
+analytics.get("/spec/:id/phase-durations", async (c) => {
+  const { memexId, docId } = await resolveSpec(c);
+  return c.json(await specPhaseDurations(memexId, docId));
+});
+
+// GET /analytics/spec/:id/summary — the lifecycle summary strip (dec-5).
+analytics.get("/spec/:id/summary", async (c) => {
+  const { memexId, docId } = await resolveSpec(c);
+  return c.json(await specLifecycleSummary(memexId, docId));
+});
+
+// GET /analytics/spec/:id/task-velocity — created/started/completed + status split.
+analytics.get("/spec/:id/task-velocity", async (c) => {
+  const { memexId, docId } = await resolveSpec(c);
+  return c.json(await specTaskVelocity(memexId, docId));
+});
+
+// GET /analytics/spec/:id/ac-verification — spec-scoped donut.
+analytics.get("/spec/:id/ac-verification", async (c) => {
+  const { memexId, docId } = await resolveSpec(c);
+  return c.json(await specAcVerification(memexId, docId));
+});
+
+// GET /analytics/spec/:id/activity?showAll&limit&offset — the who/what/when audit (dec-3).
+analytics.get("/spec/:id/activity", async (c) => {
+  const { memexId, docId } = await resolveSpec(c);
+  const rawShow = c.req.query("showAll");
+  const showAll = rawShow === "1" || rawShow === "true";
+  const limit = parsePositiveInt(c.req.query("limit"), "limit");
+  const offset = parseNonNegativeInt(c.req.query("offset"), "offset");
+  return c.json(await specActivityAudit(memexId, docId, { showAll, limit, offset }));
 });
 
 export { analytics };

--- a/packages/server/src/routes/decisions.test.ts
+++ b/packages/server/src/routes/decisions.test.ts
@@ -203,7 +203,7 @@ describe("POST /api/decisions/:id/reopen", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.status).toBe("open");
-    expect(reopenDecision).toHaveBeenCalledWith(TEST_MEMEX_ID, "dec-uuid-1");
+    expect(reopenDecision).toHaveBeenCalledWith(TEST_MEMEX_ID, "dec-uuid-1", expect.anything());
   });
 });
 
@@ -220,7 +220,7 @@ describe("POST /api/decisions/:id/approve", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.status).toBe("open");
-    expect(approveDecision).toHaveBeenCalledWith(TEST_MEMEX_ID, "dec-uuid-1");
+    expect(approveDecision).toHaveBeenCalledWith(TEST_MEMEX_ID, "dec-uuid-1", expect.anything());
   });
 
   it("returns 400 when the decision is not a candidate", async () => {
@@ -256,6 +256,7 @@ describe("POST /api/decisions/:id/reject", () => {
       TEST_MEMEX_ID,
       "dec-uuid-1",
       "Out of scope",
+      expect.anything(),
     );
   });
 

--- a/packages/server/src/routes/decisions.ts
+++ b/packages/server/src/routes/decisions.ts
@@ -136,7 +136,7 @@ decisionsRouter.post("/:id/resolve", async (c) => {
 decisionsRouter.post("/:id/reopen", async (c) => {
   const memexId = requireMemexId(c);
   const id = c.req.param("id");
-  const result = await reopenDecision(memexId, id);
+  const result = await reopenDecision(memexId, id, restCtx(c));
   return c.json(result);
 });
 
@@ -148,7 +148,7 @@ decisionsRouter.post("/:id/reopen", async (c) => {
 decisionsRouter.post("/:id/approve", async (c) => {
   const memexId = requireMemexId(c);
   const id = c.req.param("id");
-  const result = await approveDecision(memexId, id);
+  const result = await approveDecision(memexId, id, restCtx(c));
   return c.json(result);
 });
 
@@ -156,7 +156,7 @@ decisionsRouter.post("/:id/reject", async (c) => {
   const memexId = requireMemexId(c);
   const id = c.req.param("id");
   const { reason } = await c.req.json<{ reason: string }>();
-  const result = await rejectDecision(memexId, id, reason);
+  const result = await rejectDecision(memexId, id, reason, restCtx(c));
   return c.json(result);
 });
 

--- a/packages/server/src/routes/handhold.ts
+++ b/packages/server/src/routes/handhold.ts
@@ -19,6 +19,7 @@ import { sessionMiddleware, type SessionEnv } from "../middleware/session.js";
 import type { MemexResolverEnv } from "../middleware/memex-resolver.js";
 import type { Namespace } from "../db/schema.js";
 import { requireMemexId } from "./shared.js";
+import { restCtx } from "./_actor-ctx.js";
 import { resetHandholdDemo } from "../services/handhold-demo.js";
 
 type Env = MemexResolverEnv & SessionEnv;
@@ -46,7 +47,7 @@ handhold.post("/reset", async (c) => {
     return c.json({ error: "Not found" }, 404);
   }
 
-  const result = await resetHandholdDemo(memexId);
+  const result = await resetHandholdDemo(memexId, restCtx(c));
   return c.json({ status: "ok", seeded: result.seeded });
 });
 

--- a/packages/server/src/routes/issues.ts
+++ b/packages/server/src/routes/issues.ts
@@ -17,6 +17,7 @@ import { type SessionEnv } from "../middleware/session.js";
 import type { MemexResolverEnv } from "../middleware/memex-resolver.js";
 import { requireMemexId, resolveReadableMemexId } from "./shared.js";
 import { mountStandardSessionPolicy } from "./session-policy.js";
+import { restCtx } from "./_actor-ctx.js";
 
 // Thin REST mirror of the Issues service (spec-112 t-10). The React UI's
 // IssuePanel talks to this surface exactly as TaskPanel talks to /api/tasks;
@@ -104,7 +105,7 @@ issuesRouter.delete("/:id", async (c) => {
 issuesRouter.post("/:id/convert-to-task", async (c) => {
   const memexId = requireMemexId(c);
   const id = c.req.param("id");
-  const result = await convertIssueToTask(memexId, id);
+  const result = await convertIssueToTask(memexId, id, restCtx(c));
   return c.json(result, 201);
 });
 

--- a/packages/server/src/routes/spec-stats.integration.test.ts
+++ b/packages/server/src/routes/spec-stats.integration.test.ts
@@ -1,0 +1,260 @@
+// Integration tests for the per-spec Stats endpoints (spec-406).
+//
+// Real Postgres + real app routing, same shape as analytics.integration.test.ts:
+// memexResolver parses `/api/<ns-slug>/main/...`, dev-mode auth lets
+// app.request() through, and rows are seeded directly with controlled
+// timestamps so every aggregate is exactly predictable.
+
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { inArray } from "drizzle-orm";
+
+vi.hoisted(() => {
+  process.env.GOOGLE_CLIENT_ID = "";
+  return undefined;
+});
+
+import { db } from "../db/connection.js";
+import { acs, activityLog, documents, memexes, namespaces, tasks, testEvents, testEventLatest } from "../db/schema.js";
+import { app } from "../app.js";
+import { makeTestMemexWithDevAdmin } from "../services/test-helpers.js";
+
+const A = (n: number) => `mindset-prod/memex-building-itself/specs/spec-406/acs/ac-${n}`;
+
+function withApexHost(init: RequestInit = {}): RequestInit {
+  return { ...init, headers: { ...(init.headers ?? {}), Host: "memex.ai" } };
+}
+
+let memexId: string;
+let path: string;
+let slug: string;
+let phaseSpec: string; // has a full transition series + tasks + acs
+let preSpec: string; // no transitions (pre-emission)
+let auditSpec: string; // activity-audit fixture
+const memexIds: string[] = [];
+
+async function seedSpec(handle: string, over: { status?: string; createdAt?: string; statusChangedAt?: string }): Promise<string> {
+  const [row] = await db
+    .insert(documents)
+    .values({
+      memexId,
+      handle,
+      title: `stats fixture ${handle}`,
+      docType: "spec",
+      status: over.status ?? "build",
+      createdAt: new Date(over.createdAt ?? "2026-06-01T00:00:00Z"),
+      statusChangedAt: new Date(over.statusChangedAt ?? over.createdAt ?? "2026-06-01T00:00:00Z"),
+    })
+    .returning();
+  return row.id;
+}
+
+async function seedTransition(docId: string, from: string, to: string, at: string) {
+  await db.insert(activityLog).values({
+    memexId,
+    briefId: docId,
+    actorKind: "human",
+    actorName: "Alice",
+    channel: "rest_ui",
+    entity: "document",
+    action: "status_changed",
+    narrative: `moved ${from} → ${to}`,
+    payload: { from, to, doc_id: docId, doc_type: "spec" },
+    createdAt: new Date(at),
+  });
+}
+
+beforeAll(async () => {
+  const m = await makeTestMemexWithDevAdmin("spec-stats");
+  memexId = m.memexId;
+  slug = m.slug;
+  path = `/api/${m.slug}/main`;
+  memexIds.push(memexId);
+
+  // ── phaseSpec: created Jun 1 (draft), walks draft→specify→build→verify, then
+  // RE-ENTERS build (verify→build) where it now sits. Current status: build.
+  phaseSpec = await seedSpec("spec-phase", {
+    status: "build",
+    createdAt: "2026-06-01T00:00:00Z",
+    statusChangedAt: "2026-06-06T00:00:00Z",
+  });
+  await seedTransition(phaseSpec, "draft", "specify", "2026-06-02T00:00:00Z");
+  await seedTransition(phaseSpec, "specify", "build", "2026-06-03T00:00:00Z");
+  await seedTransition(phaseSpec, "build", "verify", "2026-06-05T00:00:00Z");
+  await seedTransition(phaseSpec, "verify", "build", "2026-06-06T00:00:00Z"); // re-entry
+
+  // Tasks for velocity + summary: 3 tasks, 1 complete, 1 in_progress, 1 not_started.
+  await db.insert(tasks).values([
+    { memexId, docId: phaseSpec, seq: 1, title: "t1", description: "d", status: "complete", createdAt: new Date("2026-06-03T00:00:00Z"), startedAt: new Date("2026-06-03T06:00:00Z"), completedAt: new Date("2026-06-04T00:00:00Z") },
+    { memexId, docId: phaseSpec, seq: 2, title: "t2", description: "d", status: "in_progress", createdAt: new Date("2026-06-03T00:00:00Z"), startedAt: new Date("2026-06-05T00:00:00Z") },
+    { memexId, docId: phaseSpec, seq: 3, title: "t3", description: "d", status: "not_started", createdAt: new Date("2026-06-03T00:00:00Z") },
+  ]);
+
+  // 3 active ACs; ac-1 verified, ac-2 failing, ac-3 untested (+1 superseded, ignored).
+  await db.insert(acs).values([
+    { memexId, briefId: phaseSpec, seq: 1, kind: "implementation", statement: "ac one", status: "active" },
+    { memexId, briefId: phaseSpec, seq: 2, kind: "implementation", statement: "ac two", status: "active" },
+    { memexId, briefId: phaseSpec, seq: 3, kind: "implementation", statement: "ac three", status: "active" },
+    { memexId, briefId: phaseSpec, seq: 4, kind: "implementation", statement: "ac four", status: "superseded" },
+  ]);
+  const acPrefix = `${slug}/main/specs/spec-phase/acs`;
+  await db.insert(testEventLatest).values([
+    { memexId, acUid: `${acPrefix}/ac-1`, testIdentifier: "t1", latestStatus: "pass", latestRunAt: new Date(), runCount: 1 },
+    { memexId, acUid: `${acPrefix}/ac-2`, testIdentifier: "t1", latestStatus: "pass", latestRunAt: new Date(), runCount: 1 },
+    { memexId, acUid: `${acPrefix}/ac-2`, testIdentifier: "t2", latestStatus: "fail", latestRunAt: new Date(), runCount: 1 },
+  ]);
+
+  // ── preSpec: no transition events at all (pre-emission), sits in build.
+  preSpec = await seedSpec("spec-pre", {
+    status: "build",
+    createdAt: "2026-06-01T00:00:00Z",
+    statusChangedAt: "2026-06-10T00:00:00Z",
+  });
+
+  // ── auditSpec: a normal attributed edit (kept), a read (excluded), a system
+  // sweep (excluded), and a test-event (excluded by default, shown with showAll).
+  auditSpec = await seedSpec("spec-audit", { status: "build" });
+  await db.insert(activityLog).values([
+    { memexId, briefId: auditSpec, actorKind: "human", actorName: "Alice", channel: "rest_ui", entity: "document", action: "updated", narrative: "edited the spec", createdAt: new Date("2026-06-08T00:00:00Z") },
+    { memexId, briefId: auditSpec, actorKind: "human", actorName: "Bob", channel: "rest_ui", entity: "document", action: "viewed", narrative: "viewed", createdAt: new Date("2026-06-08T01:00:00Z") },
+    { memexId, briefId: auditSpec, actorKind: "system", actorUserId: null, actorName: null, channel: "server", entity: "document", action: "checkpoint", narrative: "sweep", createdAt: new Date("2026-06-08T02:00:00Z") },
+  ]);
+  await db.insert(testEvents).values({
+    memexId,
+    acUid: `${slug}/main/specs/spec-audit/acs/ac-1`,
+    status: "pass",
+    testIdentifier: "t-audit",
+    hidden: false,
+    createdAt: new Date("2026-06-08T03:00:00Z"),
+  });
+});
+
+afterAll(async () => {
+  const rows = await db.select().from(memexes).where(inArray(memexes.id, memexIds));
+  await db.delete(namespaces).where(inArray(namespaces.id, rows.map((m) => m.namespaceId)));
+});
+
+describe("GET /analytics/spec/:id/phase-durations", () => {
+  it("derives the segment series from status_changed events, seeded from created_at (ac-7)", async () => {
+    tagAc(A(7));
+    const res = await app.request(`${path}/analytics/spec/spec-phase/phase-durations`, withApexHost());
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { segments: Array<{ phase: string; start: string; end: string | null }>; hasTransitionHistory: boolean };
+    expect(body.hasTransitionHistory).toBe(true);
+    // First segment is draft, seeded from the doc's created_at → first transition.
+    expect(body.segments[0]).toMatchObject({ phase: "draft", start: "2026-06-01T00:00:00.000Z", end: "2026-06-02T00:00:00.000Z" });
+    // Five segments: draft, specify, build, verify, build(re-entry).
+    expect(body.segments.map((s) => s.phase)).toEqual(["draft", "specify", "build", "verify", "build"]);
+  });
+
+  it("sums re-entries into one per-phase total and runs the open phase to now (ac-8, ac-9)", async () => {
+    tagAc(A(8));
+    tagAc(A(9));
+    tagAc(A(2)); // scope: the tab shows time spent in each phase, re-entry aware, open phase to now
+    const res = await app.request(`${path}/analytics/spec/spec-phase/phase-durations`, withApexHost());
+    const body = (await res.json()) as { totals: Array<{ phase: string; days: number }>; segments: Array<{ phase: string; end: string | null }> };
+    const byPhase = Object.fromEntries(body.totals.map((t) => [t.phase, t.days]));
+    expect(byPhase.draft).toBe(1);
+    expect(byPhase.specify).toBe(1);
+    expect(byPhase.verify).toBe(1);
+    // build appears ONCE in totals (re-entries merged): the closed 2-day visit
+    // PLUS the open visit (Jun 6 → now), so well over 2.
+    expect(body.totals.filter((t) => t.phase === "build")).toHaveLength(1);
+    expect(byPhase.build).toBeGreaterThan(2);
+    // Exactly one open segment (end === null) — the current phase running to now.
+    expect(body.segments.filter((s) => s.end === null)).toHaveLength(1);
+  });
+
+  it("falls back to a single caveated current-phase band for a pre-emission spec, no fabricated boundaries (ac-10)", async () => {
+    tagAc(A(10));
+    const res = await app.request(`${path}/analytics/spec/spec-pre/phase-durations`, withApexHost());
+    const body = (await res.json()) as { segments: Array<{ phase: string; start: string; end: string | null }>; totals: unknown[]; hasTransitionHistory: boolean; caveat: string | null };
+    expect(body.hasTransitionHistory).toBe(false);
+    expect(body.caveat).toBeTruthy();
+    expect(body.segments).toHaveLength(1);
+    expect(body.segments[0]).toMatchObject({ phase: "build", start: "2026-06-10T00:00:00.000Z", end: null });
+    expect(body.totals).toHaveLength(1);
+  });
+});
+
+describe("GET /analytics/spec/:id/* — endpoint shape & read access", () => {
+  it("resolves a spec by handle and returns shaped summary data, not raw rows (ac-11, ac-12)", async () => {
+    tagAc(A(11));
+    tagAc(A(12));
+    tagAc(A(3)); // scope: every number is server-side SQL-derived, not raw rows
+    const res = await app.request(`${path}/analytics/spec/spec-phase/summary`, withApexHost());
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { currentPhase: string; ageDays: number; tasks: { total: number; complete: number }; acs: { total: number; verified: number } };
+    // A chart-shaped summary object — not a dump of document/task rows.
+    expect(body.currentPhase).toBe("build");
+    expect(typeof body.ageDays).toBe("number");
+    expect(body.tasks).toMatchObject({ total: 3, complete: 1 });
+    expect(body.acs).toMatchObject({ total: 3, verified: 1 });
+  });
+
+  it("is ungated — reachable with no feature flag set (ac-22)", async () => {
+    tagAc(A(22));
+    const res = await app.request(`${path}/analytics/spec/spec-phase/ac-verification`, withApexHost());
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ total: 3, verified: 1, failing: 1, untested: 1 });
+  });
+
+  it("404s an unknown namespace and a cross-tenant / unknown spec id (ac-23)", async () => {
+    tagAc(A(23));
+    const unknownNs = await app.request("/api/no-such-ns/main/analytics/spec/spec-phase/summary", withApexHost());
+    expect(unknownNs.status).toBe(404);
+    const unknownSpec = await app.request(`${path}/analytics/spec/spec-does-not-exist/summary`, withApexHost());
+    expect(unknownSpec.status).toBe(404);
+    tagAc(A(6)); // scope: endpoints are read-only and respect memex read access (404 on unknown/cross-tenant)
+  });
+});
+
+describe("GET /analytics/spec/:id/task-velocity", () => {
+  it("returns the daily created/started/completed series + status breakdown (ac-21 data)", async () => {
+    tagAc(A(21));
+    const res = await app.request(`${path}/analytics/spec/spec-phase/task-velocity`, withApexHost());
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { points: Array<{ day: string; created: number; started: number; completed: number }>; statusBreakdown: Record<string, number> };
+    expect(body.statusBreakdown).toMatchObject({ not_started: 1, in_progress: 1, complete: 1 });
+    const jun3 = body.points.find((p) => p.day === "2026-06-03")!;
+    expect(jun3).toMatchObject({ created: 3, started: 1 }); // all 3 created, t1 started Jun 3
+    const jun4 = body.points.find((p) => p.day === "2026-06-04")!;
+    expect(jun4.completed).toBe(1);
+  });
+});
+
+describe("GET /analytics/spec/:id/activity — the who/what/when audit", () => {
+  it("curates out reads, test-events and system sweeps by default (ac-13)", async () => {
+    tagAc(A(13));
+    const res = await app.request(`${path}/analytics/spec/spec-audit/activity`, withApexHost());
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { rows: Array<{ action: string | null; kind: string; narrative: string | null }> };
+    const actions = body.rows.map((r) => r.action);
+    const kinds = body.rows.map((r) => r.kind);
+    expect(body.rows.some((r) => r.narrative === "edited the spec")).toBe(true); // kept
+    expect(actions).not.toContain("viewed"); // read excluded
+    expect(actions).not.toContain("checkpoint"); // system sweep excluded
+    expect(kinds).not.toContain("test_event"); // test-event excluded
+  });
+
+  it("re-admits the full slice with showAll (ac-14)", async () => {
+    tagAc(A(14));
+    const res = await app.request(`${path}/analytics/spec/spec-audit/activity?showAll=1`, withApexHost());
+    const body = (await res.json()) as { rows: Array<{ action: string | null; kind: string }> };
+    expect(body.rows.some((r) => r.action === "viewed")).toBe(true);
+    expect(body.rows.some((r) => r.kind === "test_event")).toBe(true);
+  });
+
+  it("attributes each row with WHO, WHEN, HOW and WHAT (ac-15)", async () => {
+    tagAc(A(15));
+    tagAc(A(4)); // scope: the tab includes a who/what/when activity audit, per-row attributed
+    const res = await app.request(`${path}/analytics/spec/spec-audit/activity`, withApexHost());
+    const body = (await res.json()) as { rows: Array<{ at: string; actorName: string | null; channel: string | null; kind: string; action: string | null; narrative: string | null }> };
+    const edit = body.rows.find((r) => r.narrative === "edited the spec")!;
+    expect(edit.actorName).toBe("Alice"); // WHO
+    expect(typeof edit.at).toBe("string"); // WHEN
+    expect(edit.channel).toBe("rest_ui"); // HOW
+    expect(edit.action).toBe("updated"); // WHAT
+    expect(edit.kind).toBe("activity_log");
+  });
+});

--- a/packages/server/src/services/acs.ts
+++ b/packages/server/src/services/acs.ts
@@ -539,18 +539,24 @@ export async function setAcAcceptance(
   memexId: string,
   acId: string,
   actor: string,
+  ctx: RequestCtx = {},
 ): Promise<Mutated<Ac>> {
   if (!actor.trim()) {
     throw new ValidationError("actor is required to accept an AC");
   }
   const ac = await getAc(memexId, acId); // tenancy check
   return mutate(
-    {},
+    ctx,
     { memexId, docId: ac.briefId, entity: "ac", action: "updated" },
     async () => {
       const [row] = await db
         .update(acs)
-        .set({ acceptedBy: actor.trim(), acceptedAt: new Date(), updatedAt: new Date() })
+        .set({
+          acceptedBy: actor.trim(),
+          acceptedAt: new Date(),
+          updatedAt: new Date(),
+          ...(await resolveActorColumns(ctx)),
+        })
         .where(and(eq(acs.id, acId), eq(acs.memexId, memexId)))
         .returning();
       return row;
@@ -566,20 +572,27 @@ export async function setAcAcceptance(
 export async function clearAcAcceptance(
   memexId: string,
   acId: string,
+  ctx: RequestCtx = {},
 ): Promise<Mutated<Ac>> {
   const ac = await getAc(memexId, acId); // tenancy check
   if (ac.acceptedAt === null) {
     throw new ConflictError(`AC ${acId} has no acceptance to revoke`);
   }
   return mutate(
-    {},
+    ctx,
     { memexId, docId: ac.briefId, entity: "ac", action: "updated" },
     async () => {
       const [row] = await db
         .update(acs)
         // spec-391: clearing the acceptance also clears the reviewed-verification
         // rationale — the reason is meaningless without the sign-off it explains.
-        .set({ acceptedBy: null, acceptedAt: null, reviewedReason: null, updatedAt: new Date() })
+        .set({
+          acceptedBy: null,
+          acceptedAt: null,
+          reviewedReason: null,
+          updatedAt: new Date(),
+          ...(await resolveActorColumns(ctx)),
+        })
         .where(and(eq(acs.id, acId), eq(acs.memexId, memexId)))
         .returning();
       return row;

--- a/packages/server/src/services/analytics.ts
+++ b/packages/server/src/services/analytics.ts
@@ -548,3 +548,318 @@ export async function testSignalPulse(
 
   return { windowMinutes, buckets, totals };
 }
+
+// ── Per-spec stats (spec-406) ────────────────────────────────────────────────
+//
+// The spec-scoped siblings of the memex-wide aggregates above. Each takes
+// (memexId, docId) and powers one surface of the per-Spec Stats tab. Same
+// discipline: aggregate in SQL, return chart-shaped data, never raw rows.
+// dec-2: these live alongside the memex-scoped functions and reuse SPEC_PHASES.
+
+/** Normalise a raw documents.status onto the lifecycle enum (JS sibling of PHASE_CASE). */
+const PHASE_NORMALIZE: Record<string, SpecPhase> = {
+  review: "specify",
+  implementation: "build",
+  approved: "done",
+};
+function normalizePhase(status: string): SpecPhase {
+  return (PHASE_NORMALIZE[status] ?? status) as SpecPhase;
+}
+
+/** Look up `<namespace>/<memex>/specs/<handle>/acs/` — the ac_uid prefix for ONE spec. */
+async function specAcUidPrefix(memexId: string, docId: string): Promise<string | null> {
+  const [row] = (await db.execute(sql`
+    SELECT n.slug AS ns, m.slug AS mx, d.handle AS handle
+    FROM documents d
+    JOIN memexes m ON m.id = d.memex_id
+    JOIN namespaces n ON n.id = m.namespace_id
+    WHERE d.id = ${docId} AND d.memex_id = ${memexId}
+  `)) as unknown as Array<{ ns: string; mx: string; handle: string }>;
+  if (!row) return null;
+  return `${row.ns}/${row.mx}/specs/${row.handle}/acs/`;
+}
+
+export interface PhaseSegment {
+  phase: SpecPhase;
+  /** ISO start of this visit to the phase. */
+  start: string;
+  /** ISO end, or null when this is the open current phase (runs to now). */
+  end: string | null;
+}
+
+export interface SpecPhaseDurations {
+  /** Each visit to a phase, in chronological order — re-entries are separate segments (dec-4). */
+  segments: PhaseSegment[];
+  /** Total days per phase, re-entries summed, in lifecycle order (dec-1). */
+  totals: Array<{ phase: SpecPhase; days: number }>;
+  /** False when no status_changed events exist (pre-emission spec) — the UI shows a caveat band. */
+  hasTransitionHistory: boolean;
+  /** True only when the recorded history reaches back to draft; else early phases are compressed. */
+  fullHistory: boolean;
+  /** Human caveat when history is partial/absent, else null. */
+  caveat: string | null;
+}
+
+const DAY_MS = 86_400_000;
+const toDays = (ms: number) => Math.round((ms / DAY_MS) * 100) / 100;
+
+/**
+ * Per-spec time-in-phase from the `activity_log` status_changed event series
+ * (dec-1). Orders transitions, seeds the first interval from the doc's
+ * created_at, pairs consecutive transitions into segments, and SUMS per phase so
+ * a re-entered phase (verify→build→verify) counts every visit. The open current
+ * phase runs to now(). A spec with no recorded transitions falls back to
+ * status_changed_at with a caveat — never a fabricated boundary.
+ */
+export async function specPhaseDurations(memexId: string, docId: string): Promise<SpecPhaseDurations> {
+  const [doc] = (await db.execute(sql`
+    SELECT created_at AS "createdAt", status, status_changed_at AS "statusChangedAt"
+    FROM documents WHERE id = ${docId} AND memex_id = ${memexId}
+  `)) as unknown as Array<{ createdAt: string; status: string; statusChangedAt: string }>;
+  if (!doc) {
+    return { segments: [], totals: [], hasTransitionHistory: false, fullHistory: false, caveat: null };
+  }
+
+  const events = (await db.execute(sql`
+    SELECT created_at AS at, payload->>'from' AS "from", payload->>'to' AS "to"
+    FROM activity_log
+    WHERE action = 'status_changed'
+      AND memex_id = ${memexId}
+      AND (payload->>'doc_id') = ${docId}
+    ORDER BY created_at ASC
+  `)) as unknown as Array<{ at: string; from: string | null; to: string | null }>;
+
+  const now = Date.now();
+  const createdAt = new Date(doc.createdAt);
+  const currentPhase = normalizePhase(doc.status);
+  const segments: PhaseSegment[] = [];
+
+  if (events.length === 0) {
+    // Pre-emission spec: no recorded transitions. Honest fallback — show only the
+    // current phase from its last-known entry (status_changed_at) to now, caveated.
+    const start = new Date(doc.statusChangedAt ?? doc.createdAt);
+    segments.push({ phase: currentPhase, start: start.toISOString(), end: null });
+    const totals = [{ phase: currentPhase, days: toDays(now - start.getTime()) }];
+    return {
+      segments,
+      totals,
+      hasTransitionHistory: false,
+      fullHistory: false,
+      caveat: "No recorded phase transitions for this spec — only the current phase is shown.",
+    };
+  }
+
+  // Seed the first interval from creation → first transition, attributed to the
+  // phase the first transition moved OUT of (dec-1).
+  const firstFrom = normalizePhase(events[0].from ?? currentPhase);
+  segments.push({ phase: firstFrom, start: createdAt.toISOString(), end: new Date(events[0].at).toISOString() });
+  for (let i = 0; i < events.length; i++) {
+    const to = normalizePhase(events[i].to ?? currentPhase);
+    const start = new Date(events[i].at);
+    const end = i + 1 < events.length ? new Date(events[i + 1].at) : null;
+    segments.push({ phase: to, start: start.toISOString(), end: end ? end.toISOString() : null });
+  }
+
+  // Sum per phase (re-entry aware), then order by the lifecycle.
+  const sums = new Map<SpecPhase, number>();
+  for (const s of segments) {
+    const endMs = s.end ? new Date(s.end).getTime() : now;
+    sums.set(s.phase, (sums.get(s.phase) ?? 0) + (endMs - new Date(s.start).getTime()));
+  }
+  const order = new Map(SPEC_PHASES.map((p, i) => [p, i]));
+  const totals = [...sums.entries()]
+    .map(([phase, ms]) => ({ phase, days: toDays(ms) }))
+    .sort((a, b) => (order.get(a.phase) ?? 99) - (order.get(b.phase) ?? 99));
+
+  const fullHistory = firstFrom === "draft";
+  return {
+    segments,
+    totals,
+    hasTransitionHistory: true,
+    fullHistory,
+    caveat: fullHistory
+      ? null
+      : "Transition history begins mid-lifecycle; time before the first recorded move is attributed to the earliest known phase.",
+  };
+}
+
+export interface SpecLifecycleSummary {
+  createdAt: string;
+  currentPhase: SpecPhase;
+  ageDays: number;
+  timeInCurrentPhaseDays: number;
+  tasks: { total: number; complete: number };
+  acs: { total: number; verified: number; failing: number; covered: number };
+}
+
+/** The lifecycle summary strip: created/phase/age/time-in-phase, task progress, AC health (dec-5). */
+export async function specLifecycleSummary(memexId: string, docId: string): Promise<SpecLifecycleSummary | null> {
+  const [doc] = (await db.execute(sql`
+    SELECT created_at AS "createdAt", status, status_changed_at AS "statusChangedAt"
+    FROM documents WHERE id = ${docId} AND memex_id = ${memexId}
+  `)) as unknown as Array<{ createdAt: string; status: string; statusChangedAt: string }>;
+  if (!doc) return null;
+
+  const [taskRow] = (await db.execute(sql`
+    SELECT count(*)::int AS total,
+           count(*) FILTER (WHERE status = 'complete')::int AS complete
+    FROM tasks WHERE doc_id = ${docId}
+  `)) as unknown as Array<{ total: number; complete: number }>;
+
+  const verification = await specAcVerification(memexId, docId);
+
+  const now = Date.now();
+  return {
+    createdAt: new Date(doc.createdAt).toISOString(),
+    currentPhase: normalizePhase(doc.status),
+    ageDays: toDays(now - new Date(doc.createdAt).getTime()),
+    timeInCurrentPhaseDays: toDays(now - new Date(doc.statusChangedAt ?? doc.createdAt).getTime()),
+    tasks: { total: taskRow?.total ?? 0, complete: taskRow?.complete ?? 0 },
+    acs: {
+      total: verification.total,
+      verified: verification.verified,
+      failing: verification.failing,
+      covered: verification.verified + verification.failing,
+    },
+  };
+}
+
+export interface SpecTaskVelocityPoint {
+  day: string;
+  created: number;
+  started: number;
+  completed: number;
+}
+
+export interface SpecTaskVelocity {
+  /** Gapless daily counts of task lifecycle events; empty when the spec has no tasks. */
+  points: SpecTaskVelocityPoint[];
+  statusBreakdown: { not_started: number; in_progress: number; complete: number };
+}
+
+/** Task velocity: per-day created/started/completed + the current status split (dec-5). */
+export async function specTaskVelocity(memexId: string, docId: string): Promise<SpecTaskVelocity> {
+  const points = (await db.execute(sql`
+    WITH ev AS (
+      SELECT created_at::date AS day, 'created' AS kind FROM tasks WHERE doc_id = ${docId}
+      UNION ALL SELECT started_at::date, 'started' FROM tasks WHERE doc_id = ${docId} AND started_at IS NOT NULL
+      UNION ALL SELECT completed_at::date, 'completed' FROM tasks WHERE doc_id = ${docId} AND completed_at IS NOT NULL
+    ),
+    per_day AS (SELECT day, kind, count(*)::int AS n FROM ev GROUP BY 1, 2),
+    days AS (
+      SELECT generate_series((SELECT min(day) FROM per_day), CURRENT_DATE, interval '1 day')::date AS day
+    )
+    SELECT
+      to_char(days.day, 'YYYY-MM-DD') AS day,
+      COALESCE(sum(per_day.n) FILTER (WHERE per_day.kind = 'created'), 0)::int AS created,
+      COALESCE(sum(per_day.n) FILTER (WHERE per_day.kind = 'started'), 0)::int AS started,
+      COALESCE(sum(per_day.n) FILTER (WHERE per_day.kind = 'completed'), 0)::int AS completed
+    FROM days LEFT JOIN per_day ON per_day.day = days.day
+    GROUP BY days.day ORDER BY days.day
+  `)) as unknown as SpecTaskVelocityPoint[];
+
+  const statusRows = (await db.execute(sql`
+    SELECT status, count(*)::int AS n FROM tasks WHERE doc_id = ${docId} GROUP BY status
+  `)) as unknown as Array<{ status: string; n: number }>;
+  const byStatus = new Map(statusRows.map((r) => [r.status, r.n]));
+
+  return {
+    points,
+    statusBreakdown: {
+      not_started: byStatus.get("not_started") ?? 0,
+      in_progress: byStatus.get("in_progress") ?? 0,
+      complete: byStatus.get("complete") ?? 0,
+    },
+  };
+}
+
+/** Spec-scoped AC verification donut — the spec's own active ACs, rolled up like acVerification (dec-5). */
+export async function specAcVerification(memexId: string, docId: string): Promise<AcVerificationSummary> {
+  const [{ total }] = (await db.execute(sql`
+    SELECT count(*)::int AS total
+    FROM acs WHERE memex_id = ${memexId} AND brief_id = ${docId} AND status = 'active'
+  `)) as unknown as Array<{ total: number }>;
+
+  const prefix = await specAcUidPrefix(memexId, docId);
+  if (!prefix) return { total, verified: 0, failing: 0, untested: total };
+
+  const [rollup] = (await db.execute(sql`
+    SELECT
+      count(*) FILTER (WHERE has_fail)::int AS failing,
+      count(*) FILTER (WHERE NOT has_fail AND has_pass)::int AS verified
+    FROM (
+      SELECT
+        ac_uid,
+        bool_or(latest_status IN ('fail', 'error')) AS has_fail,
+        bool_or(latest_status = 'pass') AS has_pass
+      FROM test_event_latest
+      WHERE ac_uid LIKE ${prefix + "%"}
+      GROUP BY ac_uid
+    ) per_ac
+  `)) as unknown as Array<{ failing: number; verified: number }>;
+
+  const { failing, verified } = rollup ?? { failing: 0, verified: 0 };
+  return { total, verified, failing, untested: Math.max(0, total - verified - failing) };
+}
+
+export interface SpecActivityRow {
+  at: string;
+  actorName: string | null;
+  channel: string | null;
+  kind: string;
+  action: string | null;
+  narrative: string | null;
+  entityId: string | null;
+}
+
+export interface SpecActivityAudit {
+  rows: SpecActivityRow[];
+  hasMore: boolean;
+}
+
+/**
+ * The who/what/when audit for ONE spec, off `activity_view` sliced by spec_ref
+ * (dec-3). Curated by default — drops reads (`viewed`), test-event rows, and the
+ * unattributed system sweeps (the activity_view has no actor_kind column, so a
+ * `system` actor surfaces as an activity_log-arm row with a server channel and no
+ * resolved user). `showAll` re-admits the full slice. Newest-first, paginated.
+ * actor_user_id is never projected — the denormalised display name is the WHO.
+ */
+export async function specActivityAudit(
+  memexId: string,
+  docId: string,
+  opts: { showAll?: boolean; limit?: number; offset?: number } = {},
+): Promise<SpecActivityAudit> {
+  const limit = Math.max(1, Math.min(200, opts.limit ?? 50));
+  const offset = Math.max(0, opts.offset ?? 0);
+  const curated = opts.showAll
+    ? sql``
+    : sql`AND action IS DISTINCT FROM 'viewed'
+          AND kind <> 'test_event'
+          AND NOT (kind = 'activity_log' AND actor_user_id IS NULL AND channel = 'server')`;
+
+  const rows = (await db.execute(sql`
+    SELECT
+      at,
+      COALESCE(actor_name, actor_raw) AS "actorName",
+      channel,
+      kind,
+      action,
+      narrative,
+      entity_id AS "entityId"
+    FROM activity_view
+    WHERE memex_id = ${memexId} AND spec_ref = ${docId}
+    ${curated}
+    ORDER BY at DESC
+    LIMIT ${limit + 1} OFFSET ${offset}
+  `)) as unknown as SpecActivityRow[];
+
+  const hasMore = rows.length > limit;
+  return {
+    rows: (hasMore ? rows.slice(0, limit) : rows).map((r) => {
+      const at = r.at as unknown as string | Date;
+      return { ...r, at: at instanceof Date ? at.toISOString() : new Date(at).toISOString() };
+    }),
+    hasMore,
+  };
+}

--- a/packages/server/src/services/attribution-repair.spec-406.integration.test.ts
+++ b/packages/server/src/services/attribution-repair.spec-406.integration.test.ts
@@ -1,0 +1,274 @@
+// spec-406 t-8 (dec-7) — closing the std-32 attribution gap on the state-transition
+// write paths the Stats-tab audit reads from.
+//
+//   ac-24  convertIssueToTask threads a RequestCtx and stamps actor + channel on
+//          BOTH the task and the AC it mints.
+//   ac-25  the transition helpers approveDecision / rejectDecision / reopenDecision
+//          (decisions.ts) and setAcAcceptance / clearAcAcceptance (acs.ts) thread a
+//          RequestCtx, stamping actor + channel on the updated row.
+//   ac-26  seedHandholdDemo threads a server ctx (channel='server' + the seeded
+//          user as actor) so its seeded specs/ACs/tasks/decisions carry attribution
+//          rather than landing fully unattributed.
+//   ac-27  REGRESSION: every repaired path lands a non-null channel on its row — a
+//          revert to mutate({}) (silent 'server', NULL source-row channel) fails this.
+//
+// TAGGED with tagAc → reports to the PROD memex. A human runs it with
+// MEMEX_EMIT_KEY set; auto mode skips tagged suites.
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { eq, inArray } from "drizzle-orm";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { db } from "../db/connection.js";
+import {
+  users,
+  namespaces,
+  orgs,
+  orgMemberships,
+  memexes,
+  documents,
+  acs,
+  tasks,
+  decisions,
+  testEvents,
+  testEventLatest,
+  activityLog,
+} from "../db/schema.js";
+import { createDocDraft } from "./documents.js";
+import { createAc } from "./acs.js";
+import { setAcAcceptance, clearAcAcceptance } from "./acs.js";
+import { createDecision, approveDecision, rejectDecision, reopenDecision } from "./decisions.js";
+import { createIssue, convertIssueToTask } from "./issues.js";
+import { seedHandholdDemo } from "./handhold-demo.js";
+import type { RequestCtx } from "./mutate.js";
+
+const AC = "mindset-prod/memex-building-itself/specs/spec-406/acs";
+
+const created = { users: [] as string[], memexes: [] as string[], docs: [] as string[] };
+
+async function setupActor(prefix: string) {
+  const sub = `${prefix}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`.toLowerCase();
+  const [u] = await db
+    .insert(users)
+    .values({ email: `s406-${sub}@memex.ai`, name: "Dakota" } as typeof users.$inferInsert)
+    .returning();
+  created.users.push(u.id);
+  const [ns] = await db.insert(namespaces).values({ slug: sub, kind: "org" }).returning();
+  const [org] = await db.insert(orgs).values({ namespaceId: ns.id, name: `Test ${sub}` }).returning();
+  await db.update(namespaces).set({ ownerOrgId: org.id }).where(eq(namespaces.id, ns.id));
+  const [a] = await db.insert(memexes).values({ namespaceId: ns.id, slug: "main", name: `Test ${sub}` }).returning();
+  created.memexes.push(a.id);
+  await db.insert(orgMemberships).values({ userId: u.id, orgId: org.id, role: "administrator" });
+  return { user: u, memexId: a.id, nsSlug: ns.slug };
+}
+
+let actor: Awaited<ReturnType<typeof setupActor>>;
+let docId: string;
+
+beforeAll(async () => {
+  actor = await setupActor("attr");
+  const doc = await createDocDraft(actor.memexId, "Attribution repair", "T", "spec");
+  docId = doc.id;
+  // convertIssueToTask is a build-phase down-bridge; put the Spec in build so the
+  // minted task isn't rejected by the spec-327 planning-phase guard.
+  await db.update(documents).set({ status: "build" }).where(eq(documents.id, docId));
+  created.docs.push(docId);
+});
+
+afterAll(async () => {
+  if (created.memexes.length) {
+    // test_events / test_event_latest carry no docId cascade (the handhold seed
+    // writes synthetic emissions) — clear them by memex first, then the memexes
+    // themselves (acs / tasks / decisions / issues / documents cascade off memex).
+    await db.delete(testEvents).where(inArray(testEvents.memexId, created.memexes)).catch(() => {});
+    await db.delete(testEventLatest).where(inArray(testEventLatest.memexId, created.memexes)).catch(() => {});
+    await db.delete(activityLog).where(inArray(activityLog.memexId, created.memexes)).catch(() => {});
+    await db.delete(memexes).where(inArray(memexes.id, created.memexes)).catch(() => {});
+  }
+  if (created.users.length) await db.delete(users).where(inArray(users.id, created.users)).catch(() => {});
+});
+
+describe("spec-406 t-8: attribution threaded through the repaired transition paths", () => {
+  // ── ac-24 ─────────────────────────────────────────────────────────────────
+  it("ac-24: convertIssueToTask stamps actor + channel on the task AND the minted AC", async () => {
+    tagAc(`${AC}/ac-24`);
+    const ctx: RequestCtx = { actorUserId: actor.user.id, channel: "rest_ui" };
+    const issue = await createIssue({
+      memexId: actor.memexId,
+      docId,
+      title: "Convert me",
+      body: "behaviour to deliver",
+      type: "bug",
+    });
+    const result = await convertIssueToTask(actor.memexId, issue.id, ctx);
+
+    const [taskRow] = await db.select().from(tasks).where(eq(tasks.id, result.task.id));
+    expect(taskRow.actorUserId).toBe(actor.user.id);
+    expect(taskRow.actorName).toBe("Dakota");
+    expect(taskRow.channel).toBe("rest_ui");
+
+    const [acRow] = await db.select().from(acs).where(eq(acs.id, result.acId));
+    expect(acRow.actorUserId).toBe(actor.user.id);
+    expect(acRow.actorName).toBe("Dakota");
+    expect(acRow.channel).toBe("rest_ui");
+  });
+
+  // ── ac-25 ─────────────────────────────────────────────────────────────────
+  it("ac-25: approveDecision stamps actor + channel on the candidate→open update", async () => {
+    tagAc(`${AC}/ac-25`);
+    const dec = await createDecision(actor.memexId, docId, "approve me", "ctx", "agent");
+    await db.update(decisions).set({ status: "candidate" }).where(eq(decisions.id, dec.id));
+    const updated = await approveDecision(actor.memexId, dec.id, {
+      actorUserId: actor.user.id,
+      channel: "mcp",
+    });
+    const [row] = await db.select().from(decisions).where(eq(decisions.id, updated.id));
+    expect(row.status).toBe("open");
+    expect(row.actorUserId).toBe(actor.user.id);
+    expect(row.actorName).toBe("Dakota");
+    expect(row.channel).toBe("mcp");
+  });
+
+  it("ac-25: rejectDecision stamps actor + channel on the candidate→rejected update", async () => {
+    tagAc(`${AC}/ac-25`);
+    const dec = await createDecision(actor.memexId, docId, "reject me", "ctx", "agent");
+    await db.update(decisions).set({ status: "candidate" }).where(eq(decisions.id, dec.id));
+    const updated = await rejectDecision(actor.memexId, dec.id, "not load-bearing", {
+      actorUserId: actor.user.id,
+      channel: "in_app_agent",
+    });
+    const [row] = await db.select().from(decisions).where(eq(decisions.id, updated.id));
+    expect(row.status).toBe("rejected");
+    expect(row.actorUserId).toBe(actor.user.id);
+    expect(row.actorName).toBe("Dakota");
+    expect(row.channel).toBe("in_app_agent");
+  });
+
+  it("ac-25: reopenDecision stamps actor + channel on the resolved→open update", async () => {
+    tagAc(`${AC}/ac-25`);
+    const dec = await createDecision(actor.memexId, docId, "reopen me", "ctx", "human");
+    await db.update(decisions).set({ status: "resolved" }).where(eq(decisions.id, dec.id));
+    const updated = await reopenDecision(actor.memexId, dec.id, {
+      actorUserId: actor.user.id,
+      channel: "rest_ui",
+    });
+    const [row] = await db.select().from(decisions).where(eq(decisions.id, updated.id));
+    expect(row.status).toBe("open");
+    expect(row.actorUserId).toBe(actor.user.id);
+    expect(row.actorName).toBe("Dakota");
+    expect(row.channel).toBe("rest_ui");
+  });
+
+  it("ac-25: setAcAcceptance and clearAcAcceptance stamp actor + channel on the AC", async () => {
+    tagAc(`${AC}/ac-25`);
+    const ac = await createAc(
+      { memexId: actor.memexId, briefId: docId, kind: "implementation", statement: "accept me" },
+      { actorUserId: actor.user.id, channel: "rest_ui" },
+    );
+    await setAcAcceptance(actor.memexId, ac.id, "Dakota", {
+      actorUserId: actor.user.id,
+      channel: "mcp",
+    });
+    const [setRow] = await db.select().from(acs).where(eq(acs.id, ac.id));
+    expect(setRow.acceptedBy).toBe("Dakota");
+    expect(setRow.actorUserId).toBe(actor.user.id);
+    expect(setRow.actorName).toBe("Dakota");
+    expect(setRow.channel).toBe("mcp");
+
+    await clearAcAcceptance(actor.memexId, ac.id, {
+      actorUserId: actor.user.id,
+      channel: "in_app_agent",
+    });
+    const [clearRow] = await db.select().from(acs).where(eq(acs.id, ac.id));
+    expect(clearRow.acceptedAt).toBeNull();
+    expect(clearRow.actorUserId).toBe(actor.user.id);
+    expect(clearRow.actorName).toBe("Dakota");
+    expect(clearRow.channel).toBe("in_app_agent");
+  });
+
+  // ── ac-26 ─────────────────────────────────────────────────────────────────
+  it("ac-26: seedHandholdDemo stamps the seeded user + channel='server' on its rows", async () => {
+    tagAc(`${AC}/ac-26`);
+    // A pristine personal-style memex to seed into (the seed no-ops if any demo
+    // doc already exists).
+    const demo = await setupActor("seed");
+    await seedHandholdDemo(demo.memexId, { channel: "server", actorUserId: demo.user.id });
+
+    const demoDocs = await db
+      .select({ id: documents.id })
+      .from(documents)
+      .where(eq(documents.memexId, demo.memexId));
+    const demoDocIds = demoDocs.map((d) => d.id);
+    expect(demoDocIds.length).toBeGreaterThan(0);
+
+    // Every seeded AC / task / decision carries the server channel + the seeded user.
+    const seededAcs = await db.select().from(acs).where(inArray(acs.briefId, demoDocIds));
+    expect(seededAcs.length).toBeGreaterThan(0);
+    for (const row of seededAcs) {
+      expect(row.channel).toBe("server");
+      expect(row.actorUserId).toBe(demo.user.id);
+      expect(row.actorName).toBe("Dakota");
+    }
+    const seededTasks = await db.select().from(tasks).where(inArray(tasks.docId, demoDocIds));
+    expect(seededTasks.length).toBeGreaterThan(0);
+    for (const row of seededTasks) {
+      expect(row.channel).toBe("server");
+      expect(row.actorUserId).toBe(demo.user.id);
+    }
+    const seededDecs = await db.select().from(decisions).where(inArray(decisions.docId, demoDocIds));
+    expect(seededDecs.length).toBeGreaterThan(0);
+    for (const row of seededDecs) {
+      expect(row.channel).toBe("server");
+      expect(row.actorUserId).toBe(demo.user.id);
+    }
+  });
+
+  // ── ac-27 (regression) ──────────────────────────────────────────────────────
+  it("ac-27: NO repaired-path row reaches the activity sink with a null channel", async () => {
+    tagAc(`${AC}/ac-27`);
+    // Re-run every repaired write under this Spec's memex, then assert that none of
+    // the touched source rows nor their activity_log entries carry a null channel.
+    // A revert to mutate({}) would null the source-row channel (silent 'server'),
+    // which this guard catches.
+    const ctx: RequestCtx = { actorUserId: actor.user.id, channel: "rest_ui" };
+
+    const issue = await createIssue({
+      memexId: actor.memexId,
+      docId,
+      title: "Guard convert",
+      body: "b",
+      type: "todo",
+    });
+    const conv = await convertIssueToTask(actor.memexId, issue.id, ctx);
+
+    const dec = await createDecision(actor.memexId, docId, "guard reopen", "c", "human");
+    await db.update(decisions).set({ status: "resolved" }).where(eq(decisions.id, dec.id));
+    const reopened = await reopenDecision(actor.memexId, dec.id, ctx);
+
+    const ac = await createAc(
+      { memexId: actor.memexId, briefId: docId, kind: "implementation", statement: "guard accept" },
+      ctx,
+    );
+    await setAcAcceptance(actor.memexId, ac.id, "Dakota", ctx);
+
+    // Source rows: none may carry a null channel.
+    const [taskRow] = await db.select().from(tasks).where(eq(tasks.id, conv.task.id));
+    const [convAcRow] = await db.select().from(acs).where(eq(acs.id, conv.acId));
+    const [decRow] = await db.select().from(decisions).where(eq(decisions.id, reopened.id));
+    const [acRow] = await db.select().from(acs).where(eq(acs.id, ac.id));
+    for (const row of [taskRow, convAcRow, decRow, acRow]) {
+      expect(row.channel).not.toBeNull();
+    }
+
+    // The activity sink itself: every activity_log row for this memex carries a
+    // channel (the column is NOT NULL, but a missing ctx would silently stamp
+    // 'server' — std-32 calls that a defect; here every repaired write is given a
+    // real channel, so none should be the silent fallback for these entities).
+    const logRows = await db
+      .select({ channel: activityLog.channel, entity: activityLog.entity })
+      .from(activityLog)
+      .where(eq(activityLog.memexId, actor.memexId));
+    for (const row of logRows) {
+      expect(row.channel).toBeTruthy();
+    }
+  });
+});

--- a/packages/server/src/services/decisions.ts
+++ b/packages/server/src/services/decisions.ts
@@ -515,7 +515,11 @@ async function loadOwnedDecision(memexId: string, id: string): Promise<Decision>
   return decision;
 }
 
-export async function approveDecision(memexId: string, id: string): Promise<Mutated<Decision>> {
+export async function approveDecision(
+  memexId: string,
+  id: string,
+  ctx: RequestCtx = {},
+): Promise<Mutated<Decision>> {
   const decision = await loadOwnedDecision(memexId, id);
   if (decision.status !== "candidate") {
     throw new ValidationError(
@@ -524,12 +528,12 @@ export async function approveDecision(memexId: string, id: string): Promise<Muta
   }
 
   return mutate(
-    {},
+    ctx,
     { memexId, docId: decision.docId, entity: "decision", action: "updated" },
     async () => {
       const [updated] = await db
         .update(decisions)
-        .set({ status: "open" })
+        .set({ status: "open", ...(await resolveActorColumns(ctx)) })
         .where(and(eq(decisions.id, id), eq(decisions.memexId, memexId)))
         .returning();
       return updated;
@@ -541,6 +545,7 @@ export async function rejectDecision(
   memexId: string,
   id: string,
   reason: string,
+  ctx: RequestCtx = {},
 ): Promise<Mutated<Decision>> {
   if (typeof reason !== "string" || reason.trim().length === 0) {
     throw new ValidationError("reason must be a non-empty string");
@@ -553,12 +558,17 @@ export async function rejectDecision(
   }
 
   const result = await mutate(
-    {},
+    ctx,
     { memexId, docId: decision.docId, entity: "decision", action: "updated" },
     async () => {
       const [updated] = await db
         .update(decisions)
-        .set({ status: "rejected", resolution: reason.trim(), resolvedAt: new Date() })
+        .set({
+          status: "rejected",
+          resolution: reason.trim(),
+          resolvedAt: new Date(),
+          ...(await resolveActorColumns(ctx)),
+        })
         .where(and(eq(decisions.id, id), eq(decisions.memexId, memexId)))
         .returning();
       return updated;
@@ -822,7 +832,11 @@ export async function resolveDecision(
   return updated;
 }
 
-export async function reopenDecision(memexId: string, id: string): Promise<Mutated<Decision>> {
+export async function reopenDecision(
+  memexId: string,
+  id: string,
+  ctx: RequestCtx = {},
+): Promise<Mutated<Decision>> {
   const decision = await loadOwnedDecision(memexId, id);
   // Strict transition: only `resolved` decisions can be reopened. Open decisions are
   // already in the target state; candidate / rejected decisions follow approve/reject
@@ -834,7 +848,7 @@ export async function reopenDecision(memexId: string, id: string): Promise<Mutat
   }
 
   const result = await mutate(
-    {},
+    ctx,
     { memexId, docId: decision.docId, entity: "decision", action: "updated" },
     async () => {
       const [updated] = await db
@@ -845,6 +859,7 @@ export async function reopenDecision(memexId: string, id: string): Promise<Mutat
           resolvedAt: null,
           // Clear chosen option on reopen — the choice is up for re-evaluation.
           chosenOptionIndex: null,
+          ...(await resolveActorColumns(ctx)),
         })
         .where(and(eq(decisions.id, id), eq(decisions.memexId, memexId)))
         .returning();

--- a/packages/server/src/services/handhold-demo.ts
+++ b/packages/server/src/services/handhold-demo.ts
@@ -27,7 +27,7 @@ import {
   testEventLatest,
   activityLog,
 } from "../db/schema.js";
-import { mutate } from "./mutate.js";
+import { mutate, type RequestCtx } from "./mutate.js";
 import { createDocDraft } from "./documents.js";
 import { addSection } from "./sections.js";
 import { createDecision, resolveDecision } from "./decisions.js";
@@ -138,6 +138,10 @@ async function seedOnePhase(
   memexId: string,
   slice: HandholdPhaseSlice,
   slugs: { namespace: string; memex: string } | null,
+  // spec-406 (dec-7 / ac-26): the seed runs server-side on behalf of the new
+  // user, so every row it writes carries channel='server' + the seeded user as
+  // actor rather than landing fully unattributed in the activity contract (std-32).
+  ctx: RequestCtx = { channel: "server" },
 ): Promise<string> {
   const created = await createDocDraft(
     memexId,
@@ -150,6 +154,9 @@ async function seedOnePhase(
     // the terminal phase-flip below, the leftover is a proper demo doc (excluded from
     // search/agents, badged, removable by Reset), never a search-visible fake real spec.
     { isDemo: true },
+    // createdByUserId — seed the legacy attribution id from the same actor.
+    ctx.actorUserId,
+    ctx,
   );
   const docId = created.id;
 
@@ -158,13 +165,13 @@ async function seedOnePhase(
   for (const key of slice.includeSections) {
     if (key === "overview") continue;
     const meta = SECTION_META[key];
-    await addSection(memexId, docId, meta.sectionType, HANDHOLD_SECTIONS[key], meta.title);
+    await addSection(memexId, docId, meta.sectionType, HANDHOLD_SECTIONS[key], meta.title, undefined, ctx);
   }
 
   if (slice.includeDecisions) {
     for (const dec of HANDHOLD_DECISIONS) {
-      const createdDec = await createDecision(memexId, docId, dec.title, dec.context);
-      await resolveDecision(memexId, createdDec.id, dec.chosen);
+      const createdDec = await createDecision(memexId, docId, dec.title, dec.context, "human", ctx);
+      await resolveDecision(memexId, createdDec.id, dec.chosen, undefined, ctx);
     }
   }
 
@@ -180,11 +187,13 @@ async function seedOnePhase(
         task.title,
         task.body,
         acceptanceCriteria,
+        undefined,
+        ctx,
       );
       if (slice.tasksComplete) {
         // Safe to complete here: the doc is still 'draft', so updateTaskStatus's
         // build→verify auto-promote (which only fires on a 'build' Spec) is inert.
-        await updateTaskStatus(memexId, createdTask.id, "complete");
+        await updateTaskStatus(memexId, createdTask.id, "complete", ctx);
       }
     }
   }
@@ -192,12 +201,15 @@ async function seedOnePhase(
   const createdAcSeqs: number[] = [];
   if (slice.includeAcs) {
     for (const ac of HANDHOLD_ACS) {
-      const createdAc = await createAc({
-        memexId,
-        briefId: docId,
-        kind: ac.kind,
-        statement: ac.statement,
-      });
+      const createdAc = await createAc(
+        {
+          memexId,
+          briefId: docId,
+          kind: ac.kind,
+          statement: ac.statement,
+        },
+        ctx,
+      );
       createdAcSeqs.push(createdAc.seq);
     }
   }
@@ -207,7 +219,7 @@ async function seedOnePhase(
   // the load-bearing change is the status flip. Goes through mutate() (std-8) so the
   // document.updated event fires for live UIs.
   await mutate(
-    {},
+    ctx,
     { memexId, docId, entity: "document", action: "updated" },
     async () => {
       const [row] = await db
@@ -257,7 +269,13 @@ async function listDemoDocIds(memexId: string): Promise<string[]> {
  * + reset + repeated calls safe). Builds one frozen copy per HANDHOLD_PHASES
  * entry; sets documents.is_demo=true + the phase status on each.
  */
-export async function seedHandholdDemo(memexId: string): Promise<void> {
+export async function seedHandholdDemo(
+  memexId: string,
+  // spec-406 (ac-26): channel='server' + the seeded user as actor, threaded onto
+  // every row this seed writes. Defaults to a bare server ctx for callers (Reset)
+  // that have no user in scope.
+  ctx: RequestCtx = { channel: "server" },
+): Promise<void> {
   const existing = await listDemoDocIds(memexId);
   // Idempotency + self-healing (issue-2): a memex holding the EXACT full set is
   // already seeded → no-op. Any OTHER non-zero count is a NON-canonical leftover —
@@ -276,7 +294,7 @@ export async function seedHandholdDemo(memexId: string): Promise<void> {
   const slugs = anyAcs ? await resolveMemexSlugs(memexId) : null;
 
   for (const slice of HANDHOLD_PHASES) {
-    await seedOnePhase(memexId, slice, slugs);
+    await seedOnePhase(memexId, slice, slugs, ctx);
   }
 }
 
@@ -363,11 +381,14 @@ async function clearDemoDocs(memexId: string, demoDocIds: string[]): Promise<voi
  *
  * Returns { seeded } — the count of demo Specs after the re-seed (5).
  */
-export async function resetHandholdDemo(memexId: string): Promise<{ seeded: number }> {
+export async function resetHandholdDemo(
+  memexId: string,
+  ctx: RequestCtx = { channel: "server" },
+): Promise<{ seeded: number }> {
   const demoDocIds = await listDemoDocIds(memexId);
   await clearDemoDocs(memexId, demoDocIds);
   // Re-seed from the fixture. seedHandholdDemo now sees zero demo docs.
-  await seedHandholdDemo(memexId);
+  await seedHandholdDemo(memexId, ctx);
   return { seeded: HANDHOLD_PHASES.length };
 }
 

--- a/packages/server/src/services/issues.ts
+++ b/packages/server/src/services/issues.ts
@@ -40,7 +40,8 @@ import {
 } from "../db/schema.js";
 import type { Issue, Task } from "../db/schema.js";
 import { NotFoundError, ValidationError } from "../types/errors.js";
-import { mutate, type Mutated } from "./mutate.js";
+import { mutate, type Mutated, type RequestCtx } from "./mutate.js";
+import { resolveActorColumns } from "./actor.js";
 import { nextSeq, withSeqRetry } from "./shared/sequence.js";
 import { embedAndStoreIssue } from "./memex-embeddings.js";
 import { buildAcRef } from "./acs.js";
@@ -347,6 +348,7 @@ export interface ConvertIssueToTaskResult {
 export async function convertIssueToTask(
   memexId: string,
   issueId: string,
+  ctx: RequestCtx = {},
 ): Promise<Mutated<ConvertIssueToTaskResult>> {
   const issue = await getIssue(memexId, issueId); // tenancy check (std-7)
 
@@ -369,8 +371,11 @@ export async function convertIssueToTask(
       ? `The bug from Issue issue-${issue.seq} ("${issue.title}") no longer reproduces.`
       : `The behaviour described by Issue issue-${issue.seq} ("${issue.title}") is delivered.`;
 
+  // Resolve WHO/HOW once (std-32) — stamped onto every row this conversion writes.
+  const actorCols = await resolveActorColumns(ctx);
+
   return mutate(
-    {},
+    ctx,
     [
       { memexId, docId: issue.docId, entity: "task", action: "created" },
       { memexId, docId: issue.docId, entity: "ac", action: "created" },
@@ -392,6 +397,7 @@ export async function convertIssueToTask(
             acceptanceCriteria: [],
             sectionRef: null,
             status: "not_started",
+            ...actorCols,
           })
           .returning();
 
@@ -406,6 +412,7 @@ export async function convertIssueToTask(
             kind: "implementation",
             statement: acStatement,
             status: "active",
+            ...actorCols,
           })
           .returning();
 
@@ -422,7 +429,7 @@ export async function convertIssueToTask(
         // 5. Issue → converted, recording the satisfying Task (ac-21).
         const [updatedIssue] = await tx
           .update(issues)
-          .set({ status: "converted", satisfyingTaskId: task.id, updatedAt: new Date() })
+          .set({ status: "converted", satisfyingTaskId: task.id, updatedAt: new Date(), ...actorCols })
           .where(and(eq(issues.id, issue.id), eq(issues.memexId, memexId)))
           .returning();
 

--- a/packages/server/src/services/user-namespaces.ts
+++ b/packages/server/src/services/user-namespaces.ts
@@ -151,7 +151,7 @@ export async function ensureUserNamespace(
     // is harmless). The needsLink-only repair path has a pre-existing memex and
     // does NOT seed.
     if (!existingMemex) {
-      await seedNewPersonalMemex(created.memex.id);
+      await seedNewPersonalMemex(created.memex.id, userId);
     }
     return created;
   }
@@ -215,7 +215,7 @@ export async function ensureUserNamespace(
   // Memex. AFTER the mutate() commits, on the create path only (the fast-path
   // returns earlier and never reaches here). This funnels every signup flow
   // (password / magic-link / SSO) — they all create the namespace through here.
-  await seedNewPersonalMemex(created.memex.id);
+  await seedNewPersonalMemex(created.memex.id, userId);
   return created;
 }
 
@@ -239,9 +239,9 @@ export async function ensureUserNamespace(
 // time we get here). The seeds are individually idempotent (handhold: NO-OP if a demo doc
 // exists — ac-8; standards: NO-OP once the Memex holds any standard), so a duplicate fire
 // (e.g. a signup race twin) is harmless.
-async function seedNewPersonalMemex(memexId: string): Promise<void> {
+async function seedNewPersonalMemex(memexId: string, ownerUserId: string): Promise<void> {
   await Promise.allSettled([
-    seedHandholdDemoBestEffort(memexId),
+    seedHandholdDemoBestEffort(memexId, ownerUserId),
     seedDefaultStandardsBestEffort(memexId),
   ]);
 }
@@ -256,10 +256,12 @@ async function seedNewPersonalMemex(memexId: string): Promise<void> {
 // (handhold.api.test.ts, the seed-resilience test) stub the var back on — the env is read at
 // CALL time, never cached, precisely so they can. Prod/dev/e2e behaviour is unchanged
 // (var unset ⇒ hook fires).
-async function seedHandholdDemoBestEffort(memexId: string): Promise<void> {
+async function seedHandholdDemoBestEffort(memexId: string, ownerUserId: string): Promise<void> {
   if (process.env.MEMEX_HANDHOLD_SIGNUP_SEED === "off") return;
   try {
-    await seedHandholdDemo(memexId);
+    // spec-406 (ac-26): attribute the seed to the new user over the server channel
+    // (std-32) so its demo Specs/ACs/tasks/decisions carry a WHO + HOW.
+    await seedHandholdDemo(memexId, { channel: "server", actorUserId: ownerUserId });
   } catch (err) {
     console.error("[handhold seed]", err);
   }

--- a/packages/ui/e2e/journey-41-spec-406-stats-tab.spec.ts
+++ b/packages/ui/e2e/journey-41-spec-406-stats-tab.spec.ts
@@ -1,0 +1,74 @@
+// Journey 41 — the per-spec Stats tab (spec-406, std-28 PR-gate journey).
+//
+// Covers the user-facing flow: a Stats sub-tab is present in the persistent
+// sub-tab control, and opening it renders the lifecycle surfaces — the summary
+// strip, the phase-duration timeline, and the who/what/when activity audit with
+// its "Show everything" toggle. A freshly-seeded spec has no transition history,
+// so the timeline shows its honest caveated current-phase band rather than bare
+// axes (ac-1/ac-4/ac-5).
+//
+// Seeding is HTTP-only over the __test__ surface (spec-172 dec-2); navigation is
+// path-based [per std-2].
+
+import { test, expect, tenantPath, emitAcEvents } from "./helpers/index.js";
+import { seedOrgTenant, seedSpec, setDocStatus } from "./helpers/retained.js";
+
+const SPEC406 = "mindset-prod/memex-building-itself/specs/spec-406";
+
+const ACS_BY_TEST: Record<string, string[]> = {
+  "the Stats tab is present and renders the summary, phase timeline and activity audit": [
+    `${SPEC406}/acs/ac-1`,
+    `${SPEC406}/acs/ac-4`,
+    `${SPEC406}/acs/ac-5`,
+  ],
+};
+
+test.afterEach(async ({}, testInfo) => {
+  if (testInfo.status === "skipped") return;
+  const refs = ACS_BY_TEST[testInfo.title];
+  if (!refs) return;
+  await emitAcEvents(
+    refs,
+    testInfo.status === "passed" ? "pass" : "fail",
+    `packages/ui/e2e/journey-41-spec-406-stats-tab.spec.ts::${testInfo.title}`,
+    testInfo.duration
+  );
+});
+
+test("the Stats tab is present and renders the summary, phase timeline and activity audit", async ({
+  page,
+  resources,
+}) => {
+  const tenant = await seedOrgTenant({ slug: resources.slug("j41") });
+  const spec = await seedSpec({
+    memexId: tenant.memexId,
+    title: "Stats tab journey",
+    purpose: "The per-spec Stats tab renders its lifecycle surfaces.",
+  });
+  await setDocStatus({ memexId: tenant.memexId, docId: spec.docId, status: "build" });
+
+  await page.goto(
+    tenantPath(tenant.namespaceSlug, tenant.memexSlug, `/specs/${spec.handle}`),
+    { waitUntil: "commit" }
+  );
+  await expect(
+    page.getByRole("heading", { level: 1, name: /Stats tab journey/ })
+  ).toBeVisible({ timeout: 15_000 });
+
+  // ── ac-1: the Stats sub-tab is present; opening it renders the tab body. ──
+  await page.getByRole("button", { name: /^Stats\b/ }).click();
+  await expect(page.getByTestId("spec-stats-view")).toBeVisible({ timeout: 15_000 });
+
+  // ── ac-1: the lifecycle summary strip + phase-duration timeline render. ──
+  await expect(page.getByTestId("spec-summary-strip")).toBeVisible();
+  await expect(page.getByTestId("spec-phase-timeline")).toBeVisible();
+
+  // ── ac-4: the who/what/when activity audit renders, with its curated default
+  //    and the "Show everything" toggle (dec-3). ──
+  await expect(page.getByTestId("spec-activity-audit")).toBeVisible();
+  const showAll = page.getByTestId("audit-show-all");
+  await expect(showAll).toBeVisible();
+  await showAll.check();
+  // Re-admitting the full slice keeps the audit mounted (no crash on refetch).
+  await expect(page.getByTestId("spec-activity-audit")).toBeVisible();
+});

--- a/packages/ui/src/api/insights.ts
+++ b/packages/ui/src/api/insights.ts
@@ -165,3 +165,102 @@ export async function fetchTestRunVolume(): Promise<TestRunVolumePoint[]> {
   );
   return points;
 }
+
+// ── Per-spec stats (spec-406 — the Stats tab) ─────────────────────────────────
+// Spec-scoped siblings of the aggregates above. Shapes mirror the new functions
+// in packages/server/src/services/analytics.ts exactly. `specRef` is the spec
+// handle (spec-N) or UUID — it becomes the `/analytics/spec/<ref>/…` path segment.
+
+export interface PhaseSegment {
+  phase: SpecPhase;
+  start: string;
+  /** null = the open current phase, running to now. */
+  end: string | null;
+}
+
+export interface SpecPhaseDurations {
+  segments: PhaseSegment[];
+  totals: Array<{ phase: SpecPhase; days: number }>;
+  hasTransitionHistory: boolean;
+  fullHistory: boolean;
+  caveat: string | null;
+}
+
+export async function fetchSpecPhaseDurations(specRef: string): Promise<SpecPhaseDurations> {
+  return fetchJsonRaw<SpecPhaseDurations>(
+    fetchWithRetry,
+    `${tBase()}/analytics/spec/${encodeURIComponent(specRef)}/phase-durations`,
+  );
+}
+
+export interface SpecLifecycleSummary {
+  createdAt: string;
+  currentPhase: SpecPhase;
+  ageDays: number;
+  timeInCurrentPhaseDays: number;
+  tasks: { total: number; complete: number };
+  acs: { total: number; verified: number; failing: number; covered: number };
+}
+
+export async function fetchSpecSummary(specRef: string): Promise<SpecLifecycleSummary> {
+  return fetchJsonRaw<SpecLifecycleSummary>(
+    fetchWithRetry,
+    `${tBase()}/analytics/spec/${encodeURIComponent(specRef)}/summary`,
+  );
+}
+
+export interface SpecTaskVelocityPoint {
+  day: string;
+  created: number;
+  started: number;
+  completed: number;
+}
+
+export interface SpecTaskVelocity {
+  points: SpecTaskVelocityPoint[];
+  statusBreakdown: { not_started: number; in_progress: number; complete: number };
+}
+
+export async function fetchSpecTaskVelocity(specRef: string): Promise<SpecTaskVelocity> {
+  return fetchJsonRaw<SpecTaskVelocity>(
+    fetchWithRetry,
+    `${tBase()}/analytics/spec/${encodeURIComponent(specRef)}/task-velocity`,
+  );
+}
+
+export async function fetchSpecAcVerification(specRef: string): Promise<AcVerificationSummary> {
+  return fetchJsonRaw<AcVerificationSummary>(
+    fetchWithRetry,
+    `${tBase()}/analytics/spec/${encodeURIComponent(specRef)}/ac-verification`,
+  );
+}
+
+export interface SpecActivityRow {
+  at: string;
+  actorName: string | null;
+  channel: string | null;
+  kind: string;
+  action: string | null;
+  narrative: string | null;
+  entityId: string | null;
+}
+
+export interface SpecActivityAudit {
+  rows: SpecActivityRow[];
+  hasMore: boolean;
+}
+
+export async function fetchSpecActivity(
+  specRef: string,
+  opts: { showAll?: boolean; limit?: number; offset?: number } = {},
+): Promise<SpecActivityAudit> {
+  const q = new URLSearchParams();
+  if (opts.showAll) q.set('showAll', '1');
+  if (opts.limit != null) q.set('limit', String(opts.limit));
+  if (opts.offset != null) q.set('offset', String(opts.offset));
+  const qs = q.toString();
+  return fetchJsonRaw<SpecActivityAudit>(
+    fetchWithRetry,
+    `${tBase()}/analytics/spec/${encodeURIComponent(specRef)}/activity${qs ? `?${qs}` : ''}`,
+  );
+}

--- a/packages/ui/src/components/insights/SpecActivityAudit.tsx
+++ b/packages/ui/src/components/insights/SpecActivityAudit.tsx
@@ -1,0 +1,135 @@
+// spec-406 (dec-3): the who/what/when audit for one spec. A chronological table
+// off activity_view, curated by default (reads, test-events and system sweeps
+// excluded server-side) with a "Show everything" toggle that re-admits the full
+// slice. Each row carries WHO · WHEN · HOW · WHAT per the std-32 activity contract.
+
+import { useEffect, useState } from 'react';
+import { fetchSpecActivity, type SpecActivityRow } from '../../api/insights';
+import { useChartPalette } from './theme';
+
+interface Props {
+  specRef: string;
+}
+
+const PAGE = 50;
+
+// Actor-hue families (std-27 cl-4): humans = blue, MCP agent = violet, memex
+// agent = cyan. Channel is the cheapest signal of which.
+function channelTone(channel: string | null, palette: ReturnType<typeof useChartPalette>): string {
+  if (channel === 'mcp') return palette.actor.mcp_agent;
+  if (channel === 'in_app_agent') return palette.actor.in_app_agent;
+  return palette.actor.human;
+}
+
+// Friendly labels for the std-32 `channel` enum (the surface a write came from) —
+// never show the raw enum to a reader.
+const CHANNEL_LABEL: Record<string, string> = {
+  rest_ui: 'Web',
+  mcp: 'MCP',
+  in_app_agent: 'In-app agent',
+  server: 'Server',
+};
+function channelLabel(channel: string | null): string {
+  return channel ? CHANNEL_LABEL[channel] ?? channel : '—';
+}
+
+// std-32 attribution is forward-only, so many (older / source-table) rows carry
+// no stamped `actor_name`. When that happens, name the actor by the agent the
+// channel implies rather than leaving the WHO blank.
+const CHANNEL_ACTOR: Record<string, string> = {
+  in_app_agent: 'Memex agent',
+  mcp: 'Coding agent',
+  server: 'System',
+};
+function whoLabel(row: { actorName: string | null; channel: string | null }): string {
+  if (row.actorName) return row.actorName;
+  if (row.channel && CHANNEL_ACTOR[row.channel]) return CHANNEL_ACTOR[row.channel];
+  return '—';
+}
+
+function fmtWhen(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleString('en-US', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' });
+}
+
+export function SpecActivityAudit({ specRef }: Props) {
+  const palette = useChartPalette();
+  const [showAll, setShowAll] = useState(false);
+  const [rows, setRows] = useState<SpecActivityRow[]>([]);
+  const [hasMore, setHasMore] = useState(false);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    fetchSpecActivity(specRef, { showAll, limit: PAGE })
+      .then((res) => {
+        if (cancelled) return;
+        setRows(res.rows);
+        setHasMore(res.hasMore);
+      })
+      .finally(() => !cancelled && setLoading(false));
+    return () => {
+      cancelled = true;
+    };
+  }, [specRef, showAll]);
+
+  return (
+    <div data-testid="spec-activity-audit">
+      <div className="flex items-center justify-between mb-2">
+        <div className="text-xs text-secondary">
+          {showAll ? 'every event, including reads and system writes' : 'meaningful work — reads, test-events and system noise excluded'}
+        </div>
+        <label className="text-xs inline-flex items-center gap-1.5 cursor-pointer select-none">
+          <input
+            type="checkbox"
+            data-testid="audit-show-all"
+            checked={showAll}
+            onChange={(e) => setShowAll(e.target.checked)}
+          />
+          Show everything
+        </label>
+      </div>
+
+      {loading && rows.length === 0 ? (
+        <div className="text-sm text-secondary py-6 text-center">Loading activity…</div>
+      ) : rows.length === 0 ? (
+        <div className="text-sm text-secondary py-6 text-center">No activity recorded yet.</div>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm border-collapse">
+            <thead>
+              <tr className="text-xs text-secondary text-left border-b border-[rgb(var(--ch-edge,148_163_184)/0.3)]">
+                <th className="py-1.5 pr-3 font-medium">When</th>
+                <th className="py-1.5 pr-3 font-medium">Who</th>
+                <th className="py-1.5 pr-3 font-medium">How</th>
+                <th className="py-1.5 font-medium">What</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((r, i) => (
+                <tr key={r.entityId ?? i} className="border-b border-[rgb(var(--ch-edge,148_163_184)/0.12)] align-top">
+                  <td className="py-1.5 pr-3 whitespace-nowrap text-secondary text-xs">{fmtWhen(r.at)}</td>
+                  <td className="py-1.5 pr-3 whitespace-nowrap">
+                    <span style={{ color: channelTone(r.channel, palette) }}>{whoLabel(r)}</span>
+                  </td>
+                  <td className="py-1.5 pr-3 whitespace-nowrap text-xs text-secondary">{channelLabel(r.channel)}</td>
+                  <td className="py-1.5">
+                    <span className="text-xs uppercase tracking-wide text-secondary mr-1.5">{r.kind}</span>
+                    {r.action}
+                    {r.narrative && <span className="text-secondary"> — {r.narrative.slice(0, 120)}</span>}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          {hasMore && (
+            <div className="text-xs text-secondary py-2 text-center">
+              Showing the {PAGE} most recent events.
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/ui/src/components/insights/SpecPhaseTimelineChart.tsx
+++ b/packages/ui/src/components/insights/SpecPhaseTimelineChart.tsx
@@ -1,0 +1,113 @@
+// spec-406 (dec-4): the per-spec phase timeline — a Gantt-style strip on a real
+// date axis. Each visit to a phase is drawn where it actually happened, so
+// re-entries (verify→build→verify) appear as separate segments and idle gaps
+// between phases are visible literally. Nivo has no Gantt primitive and its bar
+// charts can't position bars at arbitrary time offsets, so this is a custom SVG —
+// but it still draws from the ONE shared palette (useChartPalette, std-27) so the
+// reserved phase hues match every other chart.
+
+import { useState } from 'react';
+import type { SpecPhaseDurations } from '../../api/insights';
+import { phaseLabel, shortDate, useChartPalette } from './theme';
+
+interface Props {
+  data: SpecPhaseDurations;
+}
+
+const fmtDays = (d: number) => (d >= 1 ? `${d.toFixed(d >= 10 ? 0 : 1)}d` : `${Math.round(d * 24)}h`);
+
+export function SpecPhaseTimelineChart({ data }: Props) {
+  const { phase: phaseColors } = useChartPalette();
+  const [hover, setHover] = useState<number | null>(null);
+
+  if (data.segments.length === 0) {
+    return (
+      <div
+        data-testid="spec-phase-timeline"
+        className="h-24 flex items-center justify-center text-sm text-secondary"
+      >
+        This spec hasn&apos;t entered a phase yet — the timeline unlocks on its first transition.
+      </div>
+    );
+  }
+
+  const now = Date.now();
+  const starts = data.segments.map((s) => new Date(s.start).getTime());
+  const ends = data.segments.map((s) => (s.end ? new Date(s.end).getTime() : now));
+  const t0 = Math.min(...starts);
+  const t1 = Math.max(...ends, now);
+  const span = Math.max(1, t1 - t0);
+  const pct = (ms: number) => `${((ms - t0) / span) * 100}%`;
+  const width = (a: number, b: number) => `${((b - a) / span) * 100}%`;
+
+  // The phases present, in first-appearance order, for the legend.
+  const legendPhases = [...new Set(data.segments.map((s) => s.phase))];
+
+  return (
+    <div data-testid="spec-phase-timeline" className="relative">
+      {/* The timeline band. */}
+      <div className="relative h-9 w-full rounded-md bg-[rgb(var(--ch-edge,148_163_184)/0.12)] overflow-hidden">
+        {data.segments.map((seg, i) => {
+          const a = new Date(seg.start).getTime();
+          const b = seg.end ? new Date(seg.end).getTime() : now;
+          const days = (b - a) / 86_400_000;
+          return (
+            <div
+              key={i}
+              data-testid="phase-segment"
+              data-phase={seg.phase}
+              className="absolute top-0 h-full transition-[opacity] duration-300"
+              style={{
+                left: pct(a),
+                width: width(a, b),
+                background: `${phaseColors[seg.phase]}${hover === null || hover === i ? 'cc' : '66'}`,
+                borderRight: seg.end ? '1px solid rgb(var(--ch-surface,255 255 255))' : undefined,
+              }}
+              onMouseEnter={() => setHover(i)}
+              onMouseLeave={() => setHover(null)}
+            >
+              {hover === i && (
+                <div
+                  className="absolute z-10 bottom-full mb-1 left-0 whitespace-nowrap text-xs rounded-lg px-3 py-2"
+                  style={{ background: 'rgb(var(--ch-surface, 255 255 255))', color: 'rgb(var(--ch-text-primary, 15 23 42))', boxShadow: '0 4px 16px rgba(0,0,0,0.12)' }}
+                >
+                  <span className="font-medium">{phaseLabel(seg.phase)}</span> · {fmtDays(days)}
+                  {!seg.end && ' (ongoing)'}
+                  <div className="text-secondary">
+                    {shortDate(seg.start.slice(0, 10))} → {seg.end ? shortDate(seg.end.slice(0, 10)) : 'now'}
+                  </div>
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Date axis endpoints. */}
+      <div className="flex justify-between text-[10px] text-secondary mt-1">
+        <span>{shortDate(new Date(t0).toISOString().slice(0, 10))}</span>
+        <span>now</span>
+      </div>
+
+      {/* Legend with reserved hues + per-phase totals. */}
+      <div className="flex flex-wrap gap-x-4 gap-y-1 mt-2 text-xs">
+        {legendPhases.map((p) => {
+          const total = data.totals.find((t) => t.phase === p);
+          return (
+            <span key={p} className="inline-flex items-center gap-1.5">
+              <span className="inline-block w-2.5 h-2.5 rounded-sm" style={{ background: phaseColors[p] }} />
+              {phaseLabel(p)}
+              {total && <span className="text-secondary">· {fmtDays(total.days)}</span>}
+            </span>
+          );
+        })}
+      </div>
+
+      {data.caveat && (
+        <div data-testid="phase-timeline-caveat" className="text-xs text-secondary mt-2 italic">
+          {data.caveat}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/ui/src/components/insights/SpecSummaryStrip.tsx
+++ b/packages/ui/src/components/insights/SpecSummaryStrip.tsx
@@ -1,0 +1,62 @@
+// spec-406 (dec-5): the lifecycle summary strip — the at-a-glance header of the
+// Stats tab. Created date · current phase · age · time-in-current-phase · task
+// progress · AC verification. All values are server-computed (SQL); this just
+// formats them.
+
+import type { SpecLifecycleSummary } from '../../api/insights';
+import { phaseLabel, shortDate, useChartPalette } from './theme';
+
+interface Props {
+  summary: SpecLifecycleSummary;
+}
+
+const fmtDays = (d: number) => (d >= 1 ? `${d.toFixed(d >= 10 ? 0 : 1)}d` : `${Math.round(d * 24)}h`);
+
+function Stat({ label, value, sub }: { label: string; value: string; sub?: string }) {
+  return (
+    <div className="flex flex-col">
+      <span className="text-xs text-secondary">{label}</span>
+      <span className="text-lg font-semibold leading-tight">{value}</span>
+      {sub && <span className="text-xs text-secondary">{sub}</span>}
+    </div>
+  );
+}
+
+export function SpecSummaryStrip({ summary }: Props) {
+  const { phase: phaseColors } = useChartPalette();
+  const taskPct = summary.tasks.total > 0 ? Math.round((summary.tasks.complete / summary.tasks.total) * 100) : 0;
+  const acPct = summary.acs.total > 0 ? Math.round((summary.acs.verified / summary.acs.total) * 100) : 0;
+
+  return (
+    <div
+      data-testid="spec-summary-strip"
+      className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-4"
+    >
+      <Stat label="Created" value={shortDate(summary.createdAt.slice(0, 10))} />
+      <div className="flex flex-col">
+        <span className="text-xs text-secondary">Phase</span>
+        <span className="text-lg font-semibold leading-tight inline-flex items-center gap-1.5">
+          <span className="inline-block w-2.5 h-2.5 rounded-sm" style={{ background: phaseColors[summary.currentPhase] }} />
+          {phaseLabel(summary.currentPhase)}
+        </span>
+        <span className="text-xs text-secondary">{fmtDays(summary.timeInCurrentPhaseDays)} in phase</span>
+      </div>
+      <Stat label="Age" value={fmtDays(summary.ageDays)} />
+      <Stat
+        label="Tasks"
+        value={`${taskPct}%`}
+        sub={`${summary.tasks.complete}/${summary.tasks.total} complete`}
+      />
+      <Stat
+        label="ACs verified"
+        value={`${acPct}%`}
+        sub={`${summary.acs.verified}/${summary.acs.total} verified`}
+      />
+      <Stat
+        label="AC coverage"
+        value={summary.acs.total > 0 ? `${Math.round((summary.acs.covered / summary.acs.total) * 100)}%` : '—'}
+        sub={`${summary.acs.covered}/${summary.acs.total} tested`}
+      />
+    </div>
+  );
+}

--- a/packages/ui/src/components/insights/SpecTaskVelocityChart.tsx
+++ b/packages/ui/src/components/insights/SpecTaskVelocityChart.tsx
@@ -1,0 +1,66 @@
+// spec-406 (dec-5): per-spec task velocity — grouped daily bars of tasks
+// created / started / completed. A Nivo chart, so it consumes the shared theme
+// + palette and is registered in CHART_FILES (std-27 cl-14).
+
+import { ResponsiveBar } from '@nivo/bar';
+import type { SpecTaskVelocityPoint } from '../../api/insights';
+import { TOOLTIP_STYLE, insightsTheme, integerTicks, shortDate, useChartPalette } from './theme';
+
+interface Props {
+  points: SpecTaskVelocityPoint[];
+}
+
+const SERIES = ['created', 'started', 'completed'] as const;
+
+export function SpecTaskVelocityChart({ points }: Props) {
+  const palette = useChartPalette();
+  // Reserved hues: created = the accent (intent), started = build (in flight),
+  // completed = done (verified green).
+  const colorFor: Record<(typeof SERIES)[number], string> = {
+    created: palette.accent,
+    started: palette.phase.build,
+    completed: palette.phase.done,
+  };
+
+  if (points.length === 0 || points.every((p) => p.created + p.started + p.completed === 0)) {
+    return (
+      <div
+        data-testid="spec-task-velocity-chart"
+        className="h-64 flex items-center justify-center text-sm text-secondary"
+      >
+        No tasks yet — velocity unlocks once this spec has build tasks.
+      </div>
+    );
+  }
+
+  const max = Math.max(1, ...points.map((p) => Math.max(p.created, p.started, p.completed)));
+
+  return (
+    <div data-testid="spec-task-velocity-chart" className="h-64">
+      <ResponsiveBar
+        data={points as unknown as Array<Record<string, string | number>>}
+        keys={[...SERIES]}
+        indexBy="day"
+        groupMode="grouped"
+        margin={{ top: 16, right: 16, bottom: 36, left: 32 }}
+        padding={0.2}
+        innerPadding={1}
+        colors={(d) => colorFor[d.id as (typeof SERIES)[number]]}
+        theme={insightsTheme}
+        enableLabel={false}
+        axisLeft={{ tickValues: integerTicks(max) }}
+        gridYValues={integerTicks(max)}
+        axisBottom={{
+          format: (v) => shortDate(String(v)),
+          tickRotation: points.length > 8 ? -40 : 0,
+        }}
+        tooltip={({ id, value, indexValue }) => (
+          <div className="text-xs rounded-lg px-3 py-2" style={TOOLTIP_STYLE}>
+            <span className="font-medium">{value}</span> {String(id)} · {shortDate(String(indexValue))}
+          </div>
+        )}
+        animate
+      />
+    </div>
+  );
+}

--- a/packages/ui/src/components/insights/StatsView.tsx
+++ b/packages/ui/src/components/insights/StatsView.tsx
@@ -1,0 +1,112 @@
+// spec-406: the Stats tab body. One scrollable column of cards, in the dec-5
+// order: lifecycle summary strip → phase-duration timeline → (task velocity + AC
+// donut, half-width pair) → who/what/when activity audit. Owns fetching the four
+// snapshot aggregates in parallel; the audit owns its own paging/toggle fetch.
+// Every number is server-computed (SQL) — this view only formats and arranges.
+
+import { useEffect, useState } from 'react';
+import {
+  fetchSpecPhaseDurations,
+  fetchSpecSummary,
+  fetchSpecTaskVelocity,
+  fetchSpecAcVerification,
+  type SpecPhaseDurations,
+  type SpecLifecycleSummary,
+  type SpecTaskVelocity,
+} from '../../api/insights';
+import type { AcVerificationSummary } from '../../api/client';
+import { Card } from '../ui';
+import { SpecSummaryStrip } from './SpecSummaryStrip';
+import { SpecPhaseTimelineChart } from './SpecPhaseTimelineChart';
+import { SpecTaskVelocityChart } from './SpecTaskVelocityChart';
+import { AcVerificationChart } from './AcVerificationChart';
+import { SpecActivityAudit } from './SpecActivityAudit';
+
+interface Props {
+  /** The spec handle (spec-N) or UUID — becomes the /analytics/spec/<ref>/… segment. */
+  specRef: string;
+}
+
+interface StatsData {
+  summary: SpecLifecycleSummary;
+  durations: SpecPhaseDurations;
+  velocity: SpecTaskVelocity;
+  verification: AcVerificationSummary;
+}
+
+type LoadState =
+  | { kind: 'loading' }
+  | { kind: 'error'; message: string }
+  | { kind: 'ready'; data: StatsData };
+
+export function StatsView({ specRef }: Props) {
+  const [state, setState] = useState<LoadState>({ kind: 'loading' });
+
+  useEffect(() => {
+    let cancelled = false;
+    setState({ kind: 'loading' });
+    Promise.all([
+      fetchSpecSummary(specRef),
+      fetchSpecPhaseDurations(specRef),
+      fetchSpecTaskVelocity(specRef),
+      fetchSpecAcVerification(specRef),
+    ])
+      .then(([summary, durations, velocity, verification]) => {
+        if (cancelled) return;
+        setState({ kind: 'ready', data: { summary, durations, velocity, verification } });
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setState({ kind: 'error', message: err instanceof Error ? err.message : 'Failed to load' });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [specRef]);
+
+  if (state.kind === 'loading') {
+    return (
+      <div data-testid="spec-stats-loading" className="text-sm text-secondary py-12 text-center">
+        Loading stats…
+      </div>
+    );
+  }
+  if (state.kind === 'error') {
+    return (
+      <div data-testid="spec-stats-error" className="text-sm text-secondary py-12 text-center">
+        Couldn&apos;t load stats: {state.message}
+      </div>
+    );
+  }
+
+  const { summary, durations, velocity, verification } = state.data;
+
+  return (
+    <div data-testid="spec-stats-view" className="flex flex-col gap-4">
+      <Card>
+        <SpecSummaryStrip summary={summary} />
+      </Card>
+
+      <Card>
+        <h2 className="text-sm font-semibold mb-3">Phase timeline</h2>
+        <SpecPhaseTimelineChart data={durations} />
+      </Card>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        <Card>
+          <h2 className="text-sm font-semibold mb-2">Task velocity</h2>
+          <SpecTaskVelocityChart points={velocity.points} />
+        </Card>
+        <Card>
+          <h2 className="text-sm font-semibold mb-2">AC verification</h2>
+          <AcVerificationChart summary={verification} />
+        </Card>
+      </div>
+
+      <Card>
+        <h2 className="text-sm font-semibold mb-2">Activity</h2>
+        <SpecActivityAudit specRef={specRef} />
+      </Card>
+    </div>
+  );
+}

--- a/packages/ui/src/components/insights/quality.spec-179.test.ts
+++ b/packages/ui/src/components/insights/quality.spec-179.test.ts
@@ -32,6 +32,9 @@ const CHART_FILES = [
   'AcVerificationChart.tsx',
   'AcsOverTimeChart.tsx',
   'TestRunVolumeChart.tsx',
+  // spec-406: the per-spec Stats tab's Nivo chart. (The phase-timeline Gantt is a
+  // custom SVG — no @nivo import — so it is intentionally NOT in this list.)
+  'SpecTaskVelocityChart.tsx',
 ];
 
 function chartSource(file: string): string {

--- a/packages/ui/src/components/insights/spec-406-stats.test.tsx
+++ b/packages/ui/src/components/insights/spec-406-stats.test.tsx
@@ -1,0 +1,162 @@
+// spec-406 — UI gates for the per-spec Stats tab. Renders the components against
+// fixed data + asserts the structural wiring (tab registration, CHART_FILES).
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { tagAc } from '@memex-ai-ac/vitest';
+
+const A = (n: number) => `mindset-prod/memex-building-itself/specs/spec-406/acs/ac-${n}`;
+const HERE = dirname(fileURLToPath(import.meta.url));
+const read = (rel: string) => readFileSync(join(HERE, rel), 'utf8');
+
+// ── Mock the spec-stats API so StatsView resolves to fixed data ──────────────
+const SUMMARY = {
+  createdAt: '2026-06-01T00:00:00.000Z',
+  currentPhase: 'build',
+  ageDays: 24,
+  timeInCurrentPhaseDays: 19,
+  tasks: { total: 3, complete: 1 },
+  acs: { total: 3, verified: 1, failing: 1, covered: 2 },
+};
+const DURATIONS = {
+  segments: [
+    { phase: 'draft', start: '2026-06-01T00:00:00.000Z', end: '2026-06-02T00:00:00.000Z' },
+    { phase: 'specify', start: '2026-06-02T00:00:00.000Z', end: '2026-06-03T00:00:00.000Z' },
+    { phase: 'build', start: '2026-06-03T00:00:00.000Z', end: '2026-06-05T00:00:00.000Z' },
+    { phase: 'verify', start: '2026-06-05T00:00:00.000Z', end: '2026-06-06T00:00:00.000Z' },
+    { phase: 'build', start: '2026-06-06T00:00:00.000Z', end: null },
+  ],
+  totals: [
+    { phase: 'draft', days: 1 },
+    { phase: 'specify', days: 1 },
+    { phase: 'build', days: 21 },
+    { phase: 'verify', days: 1 },
+  ],
+  hasTransitionHistory: true,
+  fullHistory: true,
+  caveat: null,
+};
+const VELOCITY = {
+  points: [
+    { day: '2026-06-03', created: 3, started: 1, completed: 0 },
+    { day: '2026-06-04', created: 0, started: 0, completed: 1 },
+  ],
+  statusBreakdown: { not_started: 1, in_progress: 1, complete: 1 },
+};
+const VERIFICATION = { total: 3, verified: 1, failing: 1, untested: 1 };
+
+vi.mock('../../api/insights', () => ({
+  fetchSpecSummary: () => Promise.resolve(SUMMARY),
+  fetchSpecPhaseDurations: () => Promise.resolve(DURATIONS),
+  fetchSpecTaskVelocity: () => Promise.resolve(VELOCITY),
+  fetchSpecAcVerification: () => Promise.resolve(VERIFICATION),
+  fetchSpecActivity: () => Promise.resolve({ rows: [], hasMore: false }),
+}));
+
+// Import AFTER the mock is declared.
+import { SpecPhaseTimelineChart } from './SpecPhaseTimelineChart';
+import { SpecTaskVelocityChart } from './SpecTaskVelocityChart';
+import { StatsView } from './StatsView';
+
+describe('ac-16: phase timeline draws a date-axis segment per visit, re-entries separate', () => {
+  it('renders one segment per phase visit, with the re-entered phase appearing twice', () => {
+    tagAc(A(16));
+    render(<SpecPhaseTimelineChart data={DURATIONS as never} />);
+    const segs = screen.getAllByTestId('phase-segment');
+    expect(segs).toHaveLength(5); // draft, specify, build, verify, build(re-entry)
+    expect(segs.filter((s) => s.getAttribute('data-phase') === 'build')).toHaveLength(2);
+    // Positioned on a date axis: each segment carries an absolute left + width.
+    for (const s of segs) {
+      expect(s.style.left).not.toBe('');
+      expect(s.style.width).not.toBe('');
+    }
+  });
+});
+
+describe('ac-17: reserved hues via useChartPalette + new Nivo chart registered in CHART_FILES', () => {
+  it('the timeline sources phase hues from the shared palette', () => {
+    tagAc(A(17));
+    const src = read('SpecPhaseTimelineChart.tsx');
+    expect(src).toContain('useChartPalette');
+    expect(src).toContain('phaseColors[seg.phase]');
+  });
+
+  it('the new Nivo velocity chart is registered in the chart-quality gate list', () => {
+    tagAc(A(17));
+    const gate = read('quality.spec-179.test.ts');
+    expect(gate).toContain("'SpecTaskVelocityChart.tsx'");
+  });
+});
+
+describe('ac-18: a stats SubTab is wired into the Spec page', () => {
+  it('the SubTab union and DocDocument both carry the stats tab', () => {
+    tagAc(A(18));
+    const hook = read('../../hooks/useDocTabs.ts');
+    expect(hook).toMatch(/SubTab =[^;]*'stats'/s);
+    const page = read('../../pages/DocDocument.tsx');
+    expect(page).toContain("id: 'stats'");
+    expect(page).toContain("effectiveSubTab === 'stats'");
+    expect(page).toContain('<StatsView');
+  });
+});
+
+describe('ac-19/20/21: StatsView renders all five surfaces in order with their data', () => {
+  it('renders summary → phase timeline → velocity + AC donut → audit (ac-19)', async () => {
+    tagAc(A(19));
+    tagAc(A(1)); // scope: the Stats tab body renders without error
+    const { container } = render(<StatsView specRef="spec-1" />);
+    await screen.findByTestId('spec-stats-view');
+    const ids = [
+      'spec-summary-strip',
+      'spec-phase-timeline',
+      'spec-task-velocity-chart',
+      'ac-verification-chart',
+      'spec-activity-audit',
+    ];
+    for (const id of ids) expect(screen.getByTestId(id)).toBeInTheDocument();
+    // Order: each appears before the next in the DOM.
+    const html = container.innerHTML;
+    for (let i = 1; i < ids.length; i++) {
+      expect(html.indexOf(ids[i - 1])).toBeLessThan(html.indexOf(ids[i]));
+    }
+  });
+
+  it('the summary strip shows created, phase, age, task progress and AC verification (ac-20)', async () => {
+    tagAc(A(20));
+    render(<StatsView specRef="spec-1" />);
+    await screen.findByTestId('spec-summary-strip');
+    expect(screen.getByText('Created')).toBeInTheDocument();
+    expect(screen.getByText('Phase')).toBeInTheDocument();
+    expect(screen.getByText('Age')).toBeInTheDocument();
+    expect(screen.getByText('Tasks')).toBeInTheDocument();
+    expect(screen.getByText('ACs verified')).toBeInTheDocument();
+  });
+
+  it('renders the task-velocity chart and the AC verification donut (ac-21)', async () => {
+    tagAc(A(21));
+    render(<StatsView specRef="spec-1" />);
+    await screen.findByTestId('spec-stats-view');
+    expect(screen.getByTestId('spec-task-velocity-chart')).toBeInTheDocument();
+    expect(screen.getByTestId('ac-verification-chart')).toBeInTheDocument();
+  });
+});
+
+describe('ac-5: shared palette + explanatory empty states when a metric has no data', () => {
+  it('the phase timeline and velocity chart show an empty state instead of bare axes', () => {
+    tagAc(A(5));
+    const { rerender } = render(
+      <SpecPhaseTimelineChart
+        data={{ segments: [], totals: [], hasTransitionHistory: false, fullHistory: false, caveat: null } as never}
+      />,
+    );
+    expect(screen.getByTestId('spec-phase-timeline')).toHaveTextContent(/unlocks on its first transition/i);
+    rerender(<SpecTaskVelocityChart points={[]} />);
+    expect(screen.getByTestId('spec-task-velocity-chart')).toHaveTextContent(/No tasks yet/i);
+    // The charts draw from the shared palette, not per-chart constants.
+    expect(read('SpecPhaseTimelineChart.tsx')).toContain('useChartPalette');
+    expect(read('SpecTaskVelocityChart.tsx')).toContain('useChartPalette');
+  });
+});

--- a/packages/ui/src/hooks/useDocTabs.ts
+++ b/packages/ui/src/hooks/useDocTabs.ts
@@ -14,7 +14,7 @@ import type { DocWithGraph, SpecStatus } from '../api/types';
 // spec-282 (dec-1/dec-2): the SINGLE, ordered inventory of sub-tabs the unified
 // control carries in EVERY phase (Narrative · Comments · Decisions & ACs · Agent
 // Tasks & Issues · QA Report).
-export type SubTab = 'narrative' | 'comments' | 'decisions' | 'work' | 'qa-report';
+export type SubTab = 'narrative' | 'comments' | 'decisions' | 'work' | 'qa-report' | 'stats';
 
 // spec-282 (dec-3): each phase's preferred LANDING sub-tab. Selecting any other
 // tab is always free — this is only the default applied when the user navigates

--- a/packages/ui/src/pages/DocDocument.spec-282.test.tsx
+++ b/packages/ui/src/pages/DocDocument.spec-282.test.tsx
@@ -6,7 +6,7 @@
 //
 //   ac-8 / ac-9 : one <Tabs> carrying the exact ordered inventory —
 //                 Narrative · Comments · Decisions & ACs · Agent Tasks & Issues ·
-//                 QA Report — in every phase.
+//                 QA Report · Stats — in every phase. (Stats appended by spec-406.)
 //   ac-1 / ac-2 : the same control persists across Specify/Build/Verify and the
 //                 set never shrinks (Narrative & Comments reachable in Build and
 //                 Verify).
@@ -141,7 +141,9 @@ function renderAt(status: DocWithGraph['status']) {
   );
 }
 
-const SUB_TABS = ['Narrative', 'Comments', 'Decisions & ACs', 'Agent Tasks & Issues', 'QA Report'];
+// spec-406 appended a 'Stats' sub-tab to the unified inventory (the per-spec
+// lifecycle/audit surface) — it accretes onto the end, after QA Report.
+const SUB_TABS = ['Narrative', 'Comments', 'Decisions & ACs', 'Agent Tasks & Issues', 'QA Report', 'Stats'];
 
 // The sub-tab bar is the Tabs underline row; anchor on the Narrative button and
 // read its sibling buttons in DOM order.
@@ -160,7 +162,7 @@ beforeEach(() => {
 });
 
 describe('spec-282 — unified sub-tab inventory & ordering (ac-8, ac-9)', () => {
-  it('renders exactly Narrative · Comments · Decisions & ACs · Agent Tasks & Issues · QA Report, in order', async () => {
+  it('renders exactly Narrative · Comments · Decisions & ACs · Agent Tasks & Issues · QA Report · Stats, in order', async () => {
     tagAc(AC(8));
     tagAc(AC(9));
     renderAt('specify');

--- a/packages/ui/src/pages/DocDocument.tsx
+++ b/packages/ui/src/pages/DocDocument.tsx
@@ -18,6 +18,7 @@ import {
 import type { Comment, DocWithGraph, Issue, SpecStatus, Tag } from '../api/types';
 import { TagPicker } from '../components/TagPicker';
 import { Spinner } from '../components/Spinner';
+import { StatsView } from '../components/insights/StatsView';
 import { DecisionPanel } from '../components/DecisionPanel';
 import { TaskPanel } from '../components/TaskPanel';
 import { IssuePanel } from '../components/IssuePanel';
@@ -871,6 +872,9 @@ export function DocDocument() {
     /* spec-282 dec-1: QA Report is present in every phase; before a report
        exists it renders an honest empty-state placeholder (ac-3). */
     { id: 'qa-report', label: 'QA Report', count: qaReports.length || undefined },
+    /* spec-406: per-spec Stats — phase-duration timeline, lifecycle charts, and a
+       who/what/when activity audit. Persistent across phases like the others. */
+    { id: 'stats', label: 'Stats' },
   ];
 
   // ── Reusable content fragments — each phase layout below composes these ─────
@@ -1085,6 +1089,8 @@ export function DocDocument() {
           emptyState="No QA report yet — generated when build hands off to verify"
         />
       )}
+      {/* spec-406: the per-spec Stats tab, keyed by the spec handle. */}
+      {effectiveSubTab === 'stats' && <StatsView specRef={doc.handle} />}
     </>
   );
 


### PR DESCRIPTION
## Summary

Adds a **Stats** sub-tab to the Spec page — the per-spec lifecycle detail derivable purely from SQL — and fixes a std-32 attribution gap surfaced while building it. Spec: `mindset-prod/memex-building-itself/specs/spec-406`.

### The Stats tab (t-1..t-7)
- **Phase-duration timeline** — each phase visit positioned on a date axis (re-entries appear as separate segments, idle gaps visible), reserved std-27 phase hues.
- **Lifecycle summary strip** — created, current phase, age, time-in-phase, % tasks complete, AC coverage & verified %.
- **Task velocity + AC-verification donut** — created/started/completed over time + status breakdown; verified/failing/untested scoped to the spec.
- **Who/what/when activity audit** — off `activity_view`, curated by default (reads/test-events/system noise excluded) with a "Show everything" toggle. Labels the `in_app_agent`/`mcp`/`server` channels and names the implied actor for legacy rows with no `actor_name`.
- Server aggregates live in `services/analytics.ts` (SQL-only, `(memexId, docId)`); routes under `GET /analytics/spec/:id/*`, gated by `resolveReadableMemexId`, 404 (not 403) for private memexes per std-7, RLS-isolated per std-36.

### std-32 attribution fix (dec-7 / ac-24..ac-27, t-8)
While testing the audit, ~65% of ACs showed unattributed — ~99.6% of that volume is the onboarding demo seed, with a tail from transition write paths calling `mutate({})` (silent `'server'`, NULL source-row channel — a std-32 visible defect). Threaded `RequestCtx` through every leaking path and stamped actor/channel via `resolveActorColumns`:
- `convertIssueToTask` (task + minted AC), `approve`/`reject`/`reopenDecision`, `set`/`clearAcAcceptance`
- the handhold-demo signup seed (`channel: 'server'` + the seeded user as actor)
- all REST/MCP callers now pass `restCtx(c)` / `reqCtx(ctx)`
- a regression test fails if any repaired path lands a null channel

The fix is **forward-only** by design (std-32 stamps at write); existing historical rows (overwhelmingly demo seed) are not backfilled.

## Testing
- **Server** `src/services`: **1884/1884** pass. Touched route/handler suites + new `attribution-repair.spec-406.integration.test.ts` (ac-24..ac-27) green.
- **UI**: **1714/1715** (1 skipped) pass, incl. `spec-406-stats.test.tsx` and the chart-quality gate. `DocDocument.spec-282.test.tsx` updated for the new Stats inventory member.
- `tsc -p tsconfig.build.json` clean (server + post-rebase).
- spec-406 **ac-1..ac-27 all verified** in the Memex.
- **e2e:** journey-41 (the Stats tab) passed in isolation during build. The full `make e2e-cold` did **not** produce a clean local signal — a leftover `make dev` was reused by Playwright (`reuseExistingServer`) against the dev DB instead of the cold `memex_e2e` DB, timing out every journey (incl. unrelated ones). Environment artifact, not a regression; e2e is currently off the required PR gate (nightly/manual per `e50b34e`).

## Follow-ups
- Other unattributed write paths remain (namespace/memex provisioning, default-standards seed, the `__test__` e2e seed surface) — out of dec-7's scope; can be tracked as a std-32 cleanup issue.
- Optional historical attribution backfill / demo re-seed for a clean prod audit surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)