### PR TITLE
Release: spec-407 bulk presence read (kills the Pulse per-Spec fan-out)

### DIFF
--- a/packages/server/src/routes/presence.bulk.integration.test.ts
+++ b/packages/server/src/routes/presence.bulk.integration.test.ts
@@ -1,0 +1,174 @@
+// spec-407 t-1/t-3 — the BULK (whole-workspace) presence read.
+//
+//   ac-7  GET /presence with no `ref` returns whole-workspace presence (every
+//         present spec in the Memex) in one request via listPresentForMemex;
+//         the `?ref=<spec>` path is unchanged; a decayed row is excluded.
+//   ac-8  the bulk read sits behind the standard session policy and is
+//   ac-4  tenant-scoped — a second Memex's presence never appears in this one's
+//         read (the path → memexId → memexId-filtered-rows chain; std-36).
+//   ac-1  the "Working now" answer for many specs comes back in ONE request and
+//   ac-2  is O(1) in the number of specs (no per-spec fan-out on the server).
+//
+// Mirrors activity.integration.test.ts's two-Memex harness. TAGGED with tagAc →
+// reports to the PROD memex. Runs with MEMEX_EMIT_KEY set.
+
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+import { inArray } from "drizzle-orm";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+// Force dev-mode auth so app.request() can resolve the tenant without a JWT
+// (same shape as activity.integration.test.ts).
+vi.hoisted(() => {
+  process.env.GOOGLE_CLIENT_ID = "";
+  return undefined;
+});
+
+import { db } from "../db/connection.js";
+import { users, documents, memexes, presence } from "../db/schema.js";
+import { app } from "../app.js";
+import { createDocDraft } from "../services/documents.js";
+import { makeTestMemexWithDevAdmin } from "../services/test-helpers.js";
+import { PRESENCE_TTL_MS } from "../services/presence.js";
+
+const AC = "mindset-prod/memex-building-itself/specs/spec-407/acs";
+
+// Path-based routing per std-2: memexResolver parses `/api/<slug>/main/...` from
+// the URL with the apex Host.
+function withApexHost(init: RequestInit = {}): RequestInit {
+  return { ...init, headers: { ...(init.headers ?? {}), Host: "memex.ai" } };
+}
+
+const createdUsers: string[] = [];
+const createdDocs: string[] = [];
+const memexIds: string[] = [];
+
+let userId: string;
+let pathA: string;
+let memexA: string;
+let pathB: string;
+let memexB: string;
+let specA1: { id: string; handle: string };
+let specA2: { id: string; handle: string };
+let specB1: { id: string; handle: string };
+
+async function seedPresence(
+  memexId: string,
+  docId: string,
+  clientId: string,
+  lastSeenAt: Date,
+): Promise<void> {
+  await db.insert(presence).values({
+    memexId,
+    docId,
+    actorUserId: userId,
+    actorName: "Tester",
+    actorKind: "human",
+    channel: "rest_ui",
+    clientId,
+    lastSeenAt,
+  } as typeof presence.$inferInsert);
+}
+
+beforeAll(async () => {
+  // Per-worker-unique identifiers (std-37).
+  const uniq = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
+  const [u] = await db
+    .insert(users)
+    .values({ email: `s407-${uniq}@memex.ai`, name: "Tester" } as typeof users.$inferInsert)
+    .returning();
+  userId = u.id;
+  createdUsers.push(u.id);
+
+  const a = await makeTestMemexWithDevAdmin("s407-a");
+  memexA = a.memexId;
+  pathA = `/api/${a.slug}/main`;
+  memexIds.push(memexA);
+
+  const b = await makeTestMemexWithDevAdmin("s407-b");
+  memexB = b.memexId;
+  pathB = `/api/${b.slug}/main`;
+  memexIds.push(memexB);
+
+  specA1 = await createDocDraft(memexA, "Spec A1", "A1", "spec");
+  specA2 = await createDocDraft(memexA, "Spec A2", "A2", "spec");
+  specB1 = await createDocDraft(memexB, "Spec B1", "B1", "spec");
+  createdDocs.push(specA1.id, specA2.id, specB1.id);
+});
+
+afterAll(async () => {
+  await db.delete(presence).where(inArray(presence.docId, createdDocs)).catch(() => {});
+  if (createdDocs.length)
+    await db.delete(documents).where(inArray(documents.id, createdDocs)).catch(() => {});
+  if (memexIds.length) await db.delete(memexes).where(inArray(memexes.id, memexIds)).catch(() => {});
+  if (createdUsers.length)
+    await db.delete(users).where(inArray(users.id, createdUsers)).catch(() => {});
+});
+
+interface ApiRow {
+  docId: string;
+  clientId: string;
+}
+
+describe("bulk presence read [spec-407 t-1]", () => {
+  it("ac-7/ac-1/ac-2: GET /presence with no ref returns whole-workspace presence across multiple specs in one request", async () => {
+    tagAc(`${AC}/ac-7`);
+    tagAc(`${AC}/ac-1`);
+    tagAc(`${AC}/ac-2`);
+
+    // Present on two DIFFERENT specs in Memex A.
+    await seedPresence(memexA, specA1.id, "tab-a1", new Date());
+    await seedPresence(memexA, specA2.id, "tab-a2", new Date());
+
+    const res = await app.request(`${pathA}/presence`, withApexHost());
+    expect(res.status).toBe(200);
+    const rows = (await res.json()) as ApiRow[];
+
+    const docIds = new Set(rows.map((r) => r.docId));
+    // BOTH specs answered by a SINGLE request — the per-spec fan-out is gone.
+    expect(docIds.has(specA1.id)).toBe(true);
+    expect(docIds.has(specA2.id)).toBe(true);
+  });
+
+  it("ac-7: a row past the TTL decays out of the bulk read", async () => {
+    tagAc(`${AC}/ac-7`);
+    await seedPresence(
+      memexA,
+      specA1.id,
+      "tab-decayed",
+      new Date(Date.now() - PRESENCE_TTL_MS - 5_000),
+    );
+    const res = await app.request(`${pathA}/presence`, withApexHost());
+    const rows = (await res.json()) as ApiRow[];
+    expect(rows.some((r) => r.clientId === "tab-decayed")).toBe(false);
+  });
+
+  it("ac-7: GET /presence?ref=<spec> still returns only that spec's presence", async () => {
+    tagAc(`${AC}/ac-7`);
+    await seedPresence(memexA, specA1.id, "ref-a1", new Date());
+    await seedPresence(memexA, specA2.id, "ref-a2", new Date());
+
+    const res = await app.request(`${pathA}/presence?ref=${specA1.handle}`, withApexHost());
+    expect(res.status).toBe(200);
+    const rows = (await res.json()) as ApiRow[];
+    expect(rows.length).toBeGreaterThan(0);
+    expect(rows.every((r) => r.docId === specA1.id)).toBe(true);
+  });
+
+  it("ac-8/ac-4: the bulk read is tenant-scoped — Memex B's presence never appears in Memex A's read", async () => {
+    tagAc(`${AC}/ac-8`);
+    tagAc(`${AC}/ac-4`);
+
+    await seedPresence(memexB, specB1.id, "tab-b1", new Date());
+
+    // A's read must not leak B.
+    const resA = await app.request(`${pathA}/presence`, withApexHost());
+    const rowsA = (await resA.json()) as ApiRow[];
+    expect(rowsA.some((r) => r.docId === specB1.id)).toBe(false);
+    expect(rowsA.some((r) => r.clientId === "tab-b1")).toBe(false);
+
+    // B's own read DOES see B (proves the row exists and is scoped, not missing).
+    const resB = await app.request(`${pathB}/presence`, withApexHost());
+    const rowsB = (await resB.json()) as ApiRow[];
+    expect(rowsB.some((r) => r.docId === specB1.id)).toBe(true);
+  });
+});

--- a/packages/server/src/routes/presence.ts
+++ b/packages/server/src/routes/presence.ts
@@ -14,7 +14,7 @@
 
 import { Hono } from "hono";
 import { getDoc } from "../services/documents.js";
-import { markPresent, listPresent } from "../services/presence.js";
+import { markPresent, listPresent, listPresentForMemex } from "../services/presence.js";
 import { parseRef } from "./../services/refs.js";
 import { ValidationError } from "../types/errors.js";
 import { actorName } from "../services/actor.js";
@@ -73,11 +73,25 @@ presenceRouter.post("/", async (c) => {
   return c.json({ ok: true });
 });
 
-// GET /api/<ns>/<mx>/presence?ref=<spec> — who's "here" in a spec, for the UI.
+// GET /api/<ns>/<mx>/presence — who's "here", for the UI.
+//   • no `ref`        → whole-workspace presence in ONE indexed read (spec-407
+//     dec-1, option A). The Pulse "Working now" zone calls this once per poll
+//     instead of fanning out one request per spec — listPresentForMemex returns
+//     the table rows (within TTL) UNIONed with the passive floor, merged.
+//   • `?ref=<spec>`   → presence for a single spec (the ambient indicator).
+// Both forms stay behind mountStandardSessionPolicy, so tenant resolution + RLS
+// scoping (std-36) are identical: the whole-workspace read returns ONLY the
+// caller's Memex (tableRowsForMemex filters by memexId, RLS enforces it). No
+// multi-ref `?refs=a,b,c` shape — the only fan-out caller wants the whole
+// workspace, so it would be API surface with no consumer (spec-407 dec-1).
 presenceRouter.get("/", async (c) => {
   const memexId = await resolveReadableMemexId(c);
   const ref = c.req.query("ref")?.trim();
-  if (!ref) throw new ValidationError("presence read requires a 'ref' query param");
+
+  if (!ref) {
+    const rows = await listPresentForMemex(memexId);
+    return c.json(rows);
+  }
 
   const spec = await getDoc(memexId, specHandleFromRef(ref));
   const rows = await listPresent(memexId, spec.id);

--- a/packages/ui/e2e/journey-49-spec-407-bulk-presence.spec.ts
+++ b/packages/ui/e2e/journey-49-spec-407-bulk-presence.spec.ts
@@ -1,0 +1,105 @@
+import { test, expect, tenantPath } from "./helpers/index.js";
+import {
+  getPersonalMemexByEmail,
+  ensureUser,
+  seedSpecInMemex,
+  deleteDoc,
+  emitAcEvents,
+} from "./helpers/index.js";
+import type { Request } from "@playwright/test";
+
+// std-28 PR-gate journey for spec-407 — the bulk presence read.
+//
+// The Pulse "Working now" zone used to ask "who's here?" once PER SPEC, fanning
+// out one GET /presence?ref=<spec> per spec on every poll (~366 on the largest
+// workspace, the production CPU incident). spec-407 collapses that to ONE
+// whole-workspace GET /presence (no ref) per poll. This journey proves it in a
+// real browser at the network layer: with multiple specs in the workspace,
+// opening Pulse must issue the bulk (no-ref) read and NEVER the per-spec
+// ?ref= fan-out.
+//
+// Auth/tenant: the dev fixture's personal memex (namespace `dev` / memex
+// `personal`). Path-based nav. The /pulse route is reachable because
+// HIDDEN_FEATURES is unset in e2e (isFeatureHidden → false).
+
+const SPEC = "mindset-prod/memex-building-itself/specs/spec-407";
+
+test.describe("Journey 49 — spec-407 bulk presence read (std-28)", () => {
+  let nsSlug: string;
+  let mxSlug: string;
+  const docIds: string[] = [];
+
+  test.beforeEach(async () => {
+    const memex = await getPersonalMemexByEmail("dev@memex.ai");
+    if (!memex) throw new Error("dev@memex.ai has no personal memex — fixture setup drifted");
+    nsSlug = memex.namespaceSlug;
+    mxSlug = memex.memexSlug;
+    const devUserId = await ensureUser("dev@memex.ai");
+
+    // Seed TWO specs so usePresence receives >1 ref and exercises the
+    // whole-workspace bulk path (a single ref would use the targeted ?ref=
+    // read — that's the ambient indicator, not the pathological fan-out).
+    for (const title of ["Jabberwock Presence A", "Jabberwock Presence B"]) {
+      const { docId } = await seedSpecInMemex({
+        memexId: memex.memexId,
+        title,
+        purpose: `${title} — seeded for the spec-407 bulk-presence journey.`,
+        createdByUserId: devUserId,
+      });
+      docIds.push(docId);
+    }
+  });
+
+  test.afterEach(async () => {
+    while (docIds.length) {
+      const id = docIds.pop();
+      if (id) await deleteDoc(id);
+    }
+  });
+
+  test.afterEach(async ({}, testInfo) => {
+    if (testInfo.status === "skipped") return;
+    await emitAcEvents(
+      [`${SPEC}/acs/ac-3`, `${SPEC}/acs/ac-1`],
+      testInfo.status === "passed" ? "pass" : "fail",
+      `packages/ui/e2e/journey-49-spec-407-bulk-presence.spec.ts::${testInfo.title}`,
+      testInfo.duration ?? 0,
+    );
+  });
+
+  test("ac-1/ac-3: opening Pulse 'Working now' issues the bulk presence read, never the per-spec fan-out", async ({
+    page,
+  }) => {
+    // Collect every presence READ (GET) the page makes. The heartbeat is a POST
+    // and is filtered out; we only care about the read fan-out.
+    const presenceReads: string[] = [];
+    page.on("request", (req: Request) => {
+      if (req.method() !== "GET") return;
+      if (req.url().includes("/presence")) presenceReads.push(req.url());
+    });
+
+    await page.goto(tenantPath(nsSlug, mxSlug, "/pulse"));
+
+    // The "Working now" zone polls presence once the spec list loads.
+    await page.waitForRequest(
+      (req) => req.method() === "GET" && req.url().includes("/presence"),
+      { timeout: 20_000 },
+    );
+    // Give any (erroneous) per-spec fan-out requests a chance to also fire.
+    await page.waitForTimeout(1_500);
+
+    expect(presenceReads.length).toBeGreaterThan(0);
+
+    // The fan-out signature is a per-spec ?ref= query. After spec-407 there must
+    // be NONE — the page asks once for the whole workspace.
+    const fannedOut = presenceReads.filter((u) => u.includes("ref="));
+    expect(fannedOut, `expected no per-spec presence fan-out, saw: ${fannedOut.join(", ")}`).toEqual(
+      [],
+    );
+
+    // And at least one request IS the bulk whole-workspace read (path ends at
+    // /presence with no query).
+    const bulk = presenceReads.filter((u) => new URL(u).pathname.endsWith("/presence") && !u.includes("?"));
+    expect(bulk.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/ui/src/hooks/usePresence.test.ts
+++ b/packages/ui/src/hooks/usePresence.test.ts
@@ -1,0 +1,137 @@
+// spec-407 t-2/t-3 — the READ hook's request shape.
+//
+//   ac-9  given many refs (the Pulse "Working now" caller), usePresence issues
+//         EXACTLY ONE request per poll to the bulk endpoint (`/presence`, no
+//         ref) — never one-per-ref. The single-ref ambient path keeps its
+//         targeted `/presence?ref=<spec>` request.
+//   ac-1  one request per poll regardless of spec count, and
+//   ac-2  O(1) in the number of specs — the direct guard against the per-spec
+//   ac-6  fan-out performance cliff ever silently returning.
+//   ac-5  the single-Spec ambient indicator path is unchanged.
+//
+// We mock the http layer + global fetch so the assertions are about WHAT the
+// hook requests, not transport. TAGGED with tagAc → reports to the PROD memex.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { tagAc } from '@memex-ai-ac/vitest';
+import type { PresentRow } from '../components/pulse/types';
+
+const tenantBaseMock = vi.fn(() => '/api/ns/mx');
+vi.mock('../api/http', () => ({
+  tenantBase: () => tenantBaseMock(),
+}));
+
+import { usePresence } from './usePresence';
+
+const AC = 'mindset-prod/memex-building-itself/specs/spec-407/acs';
+
+function row(over: Partial<PresentRow> = {}): PresentRow {
+  return {
+    memexId: 'm-1',
+    docId: 'd-1',
+    actorUserId: 'u-1',
+    actorName: 'Tester',
+    actorKind: 'human',
+    channel: 'rest_ui',
+    clientId: 'c-1',
+    lastSeenAt: new Date().toISOString() as unknown as PresentRow['lastSeenAt'],
+    source: 'heartbeat',
+    ...over,
+  };
+}
+
+function okResponse(rows: PresentRow[]): Response {
+  return new Response(JSON.stringify(rows), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+const fetchMock = vi.fn(() => Promise.resolve(okResponse([])));
+
+beforeEach(() => {
+  fetchMock.mockClear();
+  fetchMock.mockResolvedValue(okResponse([]));
+  tenantBaseMock.mockClear();
+  vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+// A large ref set — proves the request count does not scale with spec count.
+const MANY_REFS = Array.from({ length: 200 }, (_, i) => `spec-${i + 1}`);
+
+describe('usePresence — request shape [spec-407 t-2]', () => {
+  it('ac-9/ac-1/ac-2/ac-6: many refs → exactly ONE bulk request per poll (no per-spec fan-out)', async () => {
+    tagAc(`${AC}/ac-9`);
+    tagAc(`${AC}/ac-1`);
+    tagAc(`${AC}/ac-2`);
+    tagAc(`${AC}/ac-6`);
+
+    renderHook(() => usePresence(MANY_REFS));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    // 200 specs, ONE request — not 200.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toBe('/api/ns/mx/presence');
+    // Crucially: NO per-spec ref query param.
+    expect(url).not.toContain('ref=');
+  });
+
+  it('ac-5/ac-9: a single ref → one targeted /presence?ref=<spec> request (ambient path unchanged)', async () => {
+    tagAc(`${AC}/ac-5`);
+    tagAc(`${AC}/ac-9`);
+
+    const ref = 'mindset-prod/memex-building-itself/specs/spec-122';
+    renderHook(() => usePresence(ref));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toBe(`/api/ns/mx/presence?ref=${encodeURIComponent(ref)}`);
+  });
+
+  it('ac-9: merges/de-dupes returned rows by (actorUserId, clientId, docId)', async () => {
+    tagAc(`${AC}/ac-9`);
+
+    const dup = row({ actorUserId: 'u-1', clientId: 'c-1', docId: 'd-1' });
+    const other = row({ actorUserId: 'u-2', clientId: 'c-2', docId: 'd-2' });
+    fetchMock.mockResolvedValue(okResponse([dup, dup, other]));
+
+    const { result } = renderHook(() => usePresence(MANY_REFS));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.rows).toHaveLength(2);
+  });
+
+  it('best-effort: a failed poll keeps the last-known rows rather than flickering empty', async () => {
+    tagAc(`${AC}/ac-9`);
+    vi.useFakeTimers();
+
+    const present = row({ clientId: 'still-here' });
+    fetchMock.mockResolvedValueOnce(okResponse([present]));
+
+    const { result } = renderHook(() => usePresence(MANY_REFS, { intervalMs: 1_000 }));
+
+    // First poll resolves with one present row.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(result.current.rows).toHaveLength(1);
+
+    // Next poll fails — last-known rows must remain.
+    fetchMock.mockRejectedValueOnce(new Error('network'));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_000);
+    });
+    expect(result.current.rows).toHaveLength(1);
+    expect(result.current.rows[0].clientId).toBe('still-here');
+  });
+});

--- a/packages/ui/src/hooks/usePresence.ts
+++ b/packages/ui/src/hooks/usePresence.ts
@@ -5,18 +5,24 @@ import type { PresentRow } from '../components/pulse/types';
 /**
  * usePresence — the READ half of spec-122's presence plane (dec-4, ac-1/ac-5).
  *
- * Polls `GET /api/<ns>/<mx>/presence?ref=<spec>` for who's "here NOW" on one or
- * more specs and returns the merged set of present rows. Presence decays ~30s
- * server-side, so we re-poll on a short cadence to keep the live picture honest
- * (and to age workers out as their beats stop).
+ * Polls `GET /api/<ns>/<mx>/presence` for who's "here NOW" and returns the
+ * merged set of present rows. Presence decays ~30s server-side, so we re-poll on
+ * a short cadence to keep the live picture honest (and to age workers out as
+ * their beats stop).
  *
- *   - The Pulse "Working now" zone passes EVERY active spec ref so it can show
- *     one line per active worker across the whole Memex (the presence endpoint
- *     is per-spec, so we fan out and merge).
- *   - The spec/AC ambient indicator passes a single ref.
+ *   - The Pulse "Working now" zone passes EVERY active spec ref. It wants
+ *     whole-workspace presence, so we make ONE request to the bulk endpoint
+ *     (`/presence`, no ref) per poll — NOT one request per spec. This is the
+ *     spec-407 fix: the old per-spec fan-out fired O(number of Specs) requests
+ *     every poll (~366 on the largest workspace) and was the dominant source of
+ *     production DB load. Presence rows only ever exist for spec docs, so the
+ *     whole-workspace set equals the old fan-out's merged result.
+ *   - The spec/AC ambient indicator passes a single ref → one targeted
+ *     `/presence?ref=<spec>` request, unchanged.
  *
- * Best-effort: a failed poll leaves the last-known rows in place rather than
- * flickering the indicator empty.
+ * Best-effort: a FAILED poll (network error or non-ok response) leaves the
+ * last-known rows in place rather than flickering the indicator empty; a
+ * successful empty response clears them (so decayed workers disappear).
  */
 
 const POLL_INTERVAL_MS = 10_000;
@@ -52,23 +58,24 @@ export function usePresence(
       setLoading(false);
       return;
     }
+    // One request per poll: the whole-workspace bulk read for the many-refs
+    // caller (Pulse "Working now"), or the single-spec read for the ambient
+    // indicator. The per-spec fan-out is gone (spec-407).
+    const url =
+      list.length === 1
+        ? `${base}/presence?ref=${encodeURIComponent(list[0])}`
+        : `${base}/presence`;
     try {
-      const results = await Promise.all(
-        list.map((ref) =>
-          fetch(`${base}/presence?ref=${encodeURIComponent(ref)}`, {
-            headers: authHeader(),
-          })
-            .then((res) => (res.ok ? (res.json() as Promise<PresentRow[]>) : []))
-            .catch(() => [] as PresentRow[]),
-        ),
-      );
-      // Merge + de-dupe across specs by (actorUserId, clientId, docId) — a worker
-      // is one line per spec they're on.
+      const res = await fetch(url, { headers: authHeader() });
+      // A failed request keeps the last-known rows (don't flicker to empty); a
+      // successful response — even an empty one — is authoritative and replaces.
+      if (!res.ok) return;
+      const fetched = (await res.json()) as PresentRow[];
+      // De-dupe by (actorUserId, clientId, docId) — a worker is one line per
+      // spec they're on.
       const byKey = new Map<string, PresentRow>();
-      for (const set of results) {
-        for (const r of set) {
-          byKey.set(`${r.actorUserId}|${r.clientId}|${r.docId}`, r);
-        }
+      for (const r of fetched) {
+        byKey.set(`${r.actorUserId}|${r.clientId}|${r.docId}`, r);
       }
       const merged = [...byKey.values()].sort(
         (a, b) => new Date(b.lastSeenAt).getTime() - new Date(a.lastSeenAt).getTime(),

--- a/packages/ui/src/pages/Pulse.tsx
+++ b/packages/ui/src/pages/Pulse.tsx
@@ -282,10 +282,9 @@ export function Pulse() {
     setLiveRows([]);
   }, [scope, specId, clientId]);
 
-  // ── Working-now zone (ac-1): presence across every spec. The presence GET
-  // endpoint is per-spec, so we poll it for each spec handle and the hook merges
-  // the results into one "who's here now" set. We pass bare `spec-N` handles —
-  // the endpoint accepts either a full ref or a bare handle. ───────────────────
+  // ── Working-now zone (ac-1): presence across every spec. We pass every spec
+  // handle; usePresence makes ONE whole-workspace bulk request per poll (not one
+  // per spec) and returns the merged "who's here now" set (spec-407). ──────────
   const specRefs = useMemo(
     () => specDocs.map((d) => d.handle),
     [specDocs],


### PR DESCRIPTION
## Release: develop → main (prod)

Ships **one** change: **spec-407 — bulk presence read** (PR #360, already merged to develop, green on **int**).

Spec: [spec-407](https://memex.ai/mindset-prod/memex-building-itself/specs/spec-407)

### Why this goes to prod now
The Pulse "Working now" panel asked the server *"who's here?"* once per Spec — ~366 `GET /presence?ref=<spec>` requests every 10s poll from a single open tab. On 2026-06-25 this was traced as the dominant source of **production** DB load: one open Pulse tab generated ≈87% of the entire DB's query volume on its single-vCPU instance. This fix is the actual remedy (the incident was only mitigated by closing the tab); it takes effect once it reaches prod.

### What's in the release (6 files)
- `packages/server/src/routes/presence.ts` — `GET /presence` with no `ref` returns whole-workspace presence via the pre-existing `listPresentForMemex` (table ∪ floor, merged); `?ref=` unchanged; no `?refs=` variant. Same `mountStandardSessionPolicy`, RLS tenant-scoped (std-36). Computes the passive floor once per poll instead of ~366×.
- `packages/ui/src/hooks/usePresence.ts` — many-refs caller (Pulse) → one bulk request per poll; single-ref ambient indicator unchanged.
- `packages/ui/src/pages/Pulse.tsx` — stale comment update.
- Tests: `presence.bulk.integration.test.ts`, `usePresence.test.ts`, `journey-49-spec-407-bulk-presence.spec.ts`.

Net effect: ~366 presence requests/poll → **1**, and the cost no longer grows with the workspace.

### Verification
- All 9 ACs verified on the board (100%).
- On develop / int: `test` ✅, `deploy` → int + int smoke ✅ (commit `3f6def56`).
- Pre-merge local: full server (4776) + UI (1710) suites, both typechecks, `make e2e-cold` (110 journeys) — all green.

### Risk / rollback
No schema, migration, config, or feature flag. Backward-compatible (`?ref=` endpoint unchanged), safe mid-deploy. Rollback = revert PR #360.

### Follow-up
Option B (presence over the SSE bus, no poll) is captured as [spec-408](https://memex.ai/mindset-prod/memex-building-itself/specs/spec-408).

🤖 Generated with [Claude Code](https://claude.com/claude-code)