### PR TITLE
spec-406: fix light-mode contrast + task-velocity axis on the Stats tab

### DIFF
--- a/packages/ui/src/components/insights/SpecActivityAudit.tsx
+++ b/packages/ui/src/components/insights/SpecActivityAudit.tsx
@@ -114,7 +114,7 @@ export function SpecActivityAudit({ specRef }: Props) {
                     <span style={{ color: channelTone(r.channel, palette) }}>{whoLabel(r)}</span>
                   </td>
                   <td className="py-1.5 pr-3 whitespace-nowrap text-xs text-secondary">{channelLabel(r.channel)}</td>
-                  <td className="py-1.5">
+                  <td className="py-1.5 text-primary">
                     <span className="text-xs uppercase tracking-wide text-secondary mr-1.5">{r.kind}</span>
                     {r.action}
                     {r.narrative && <span className="text-secondary"> — {r.narrative.slice(0, 120)}</span>}

--- a/packages/ui/src/components/insights/SpecPhaseTimelineChart.tsx
+++ b/packages/ui/src/components/insights/SpecPhaseTimelineChart.tsx
@@ -94,7 +94,7 @@ export function SpecPhaseTimelineChart({ data }: Props) {
         {legendPhases.map((p) => {
           const total = data.totals.find((t) => t.phase === p);
           return (
-            <span key={p} className="inline-flex items-center gap-1.5">
+            <span key={p} className="inline-flex items-center gap-1.5 text-primary">
               <span className="inline-block w-2.5 h-2.5 rounded-sm" style={{ background: phaseColors[p] }} />
               {phaseLabel(p)}
               {total && <span className="text-secondary">· {fmtDays(total.days)}</span>}

--- a/packages/ui/src/components/insights/SpecSummaryStrip.tsx
+++ b/packages/ui/src/components/insights/SpecSummaryStrip.tsx
@@ -16,7 +16,7 @@ function Stat({ label, value, sub }: { label: string; value: string; sub?: strin
   return (
     <div className="flex flex-col">
       <span className="text-xs text-secondary">{label}</span>
-      <span className="text-lg font-semibold leading-tight">{value}</span>
+      <span className="text-lg font-semibold leading-tight text-primary">{value}</span>
       {sub && <span className="text-xs text-secondary">{sub}</span>}
     </div>
   );
@@ -35,7 +35,7 @@ export function SpecSummaryStrip({ summary }: Props) {
       <Stat label="Created" value={shortDate(summary.createdAt.slice(0, 10))} />
       <div className="flex flex-col">
         <span className="text-xs text-secondary">Phase</span>
-        <span className="text-lg font-semibold leading-tight inline-flex items-center gap-1.5">
+        <span className="text-lg font-semibold leading-tight text-primary inline-flex items-center gap-1.5">
           <span className="inline-block w-2.5 h-2.5 rounded-sm" style={{ background: phaseColors[summary.currentPhase] }} />
           {phaseLabel(summary.currentPhase)}
         </span>

--- a/packages/ui/src/components/insights/SpecTaskVelocityChart.tsx
+++ b/packages/ui/src/components/insights/SpecTaskVelocityChart.tsx
@@ -35,6 +35,12 @@ export function SpecTaskVelocityChart({ points }: Props) {
 
   const max = Math.max(1, ...points.map((p) => Math.max(p.created, p.started, p.completed)));
 
+  // A band scale draws one tick per day by default — illegible across a multi-week
+  // spec. Thin to ~8 evenly-spaced day labels so the axis stays readable regardless
+  // of span (the bars themselves still render one per day).
+  const stride = Math.max(1, Math.ceil(points.length / 8));
+  const bottomTickValues = points.filter((_, i) => i % stride === 0).map((p) => p.day);
+
   return (
     <div data-testid="spec-task-velocity-chart" className="h-64">
       <ResponsiveBar
@@ -42,7 +48,7 @@ export function SpecTaskVelocityChart({ points }: Props) {
         keys={[...SERIES]}
         indexBy="day"
         groupMode="grouped"
-        margin={{ top: 16, right: 16, bottom: 36, left: 32 }}
+        margin={{ top: 16, right: 16, bottom: 44, left: 32 }}
         padding={0.2}
         innerPadding={1}
         colors={(d) => colorFor[d.id as (typeof SERIES)[number]]}
@@ -52,7 +58,8 @@ export function SpecTaskVelocityChart({ points }: Props) {
         gridYValues={integerTicks(max)}
         axisBottom={{
           format: (v) => shortDate(String(v)),
-          tickRotation: points.length > 8 ? -40 : 0,
+          tickValues: bottomTickValues,
+          tickRotation: bottomTickValues.length > 6 ? -40 : 0,
         }}
         tooltip={({ id, value, indexValue }) => (
           <div className="text-xs rounded-lg px-3 py-2" style={TOOLTIP_STYLE}>


### PR DESCRIPTION
Follow-up to #361 — two rendering fixes spotted once the Stats tab was live on int.

## 1. Light-mode white-on-white text
After the Tailwind v4 migration, primary text inside a `<span>` renders **colorless** unless it carries an explicit colour utility (documented in `index.css`). Three spots relied on inherited body colour and were invisible in light mode:
- summary-strip values (Created / Age / Tasks / ACs verified / AC coverage)
- phase-timeline legend labels (`build`, etc.)
- the activity-audit action word (`created`, …)

Each now carries `text-primary`. Headings were unaffected (base `h2` styles apply), which is why they stayed readable.

## 2. Task-velocity x-axis was illegible
A band scale draws one tick per day, so a multi-week spec crammed 40+ overlapping rotated date labels onto the axis. Thinned to ~8 evenly-spaced ticks (the bars still render one per day), rotating only when more than 6 remain.

## Testing
- UI `tsc -b` clean.
- `spec-406-stats.test.tsx` passes (8/8). Changes are class/axis-config only — no structural or behavioural change.

Best verified visually: light mode, Stats tab on a multi-week spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)