### PR TITLE
spec-372 issue-18: reduce Home side whitespace by 25%

### DIFF
--- a/packages/ui/src/pages/HomeCanvas.spec-372-issue18.test.tsx
+++ b/packages/ui/src/pages/HomeCanvas.spec-372-issue18.test.tsx
@@ -1,0 +1,96 @@
+// spec-372 issue-18 (dec-9) — Home reduces the left/right whitespace by 25%.
+//   Both Home content containers — the page header and the journey-layer wrapper — cap
+//   their width with `max-w-[calc(25%_+_48rem)]` (CSS `max-width: calc(25% + 48rem)`)
+//   instead of `max-w-5xl`, so each side gutter is 75% of its former value at every pane
+//   width. This mirrors the spec-308 max-width className assertion pattern.
+//
+//   ac-47 (impl) — both containers carry the calc cap and no longer carry max-w-5xl.
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { tagAc } from '@memex-ai-ac/vitest';
+
+const fetchJourneyStateApi = vi.hoisted(() => vi.fn());
+const postJourneyEventApi = vi.hoisted(() => vi.fn());
+const postPersonaSelectedApi = vi.hoisted(() => vi.fn());
+const fetchHomeApi = vi.hoisted(() => vi.fn());
+
+vi.mock('../api/journey', () => ({ fetchJourneyStateApi, postJourneyEventApi, postPersonaSelectedApi }));
+vi.mock('../api/home', () => ({ fetchHomeApi }));
+vi.mock('../components/AuthContext', () => ({
+  useAuth: () => ({
+    user: { id: 'u-1', name: 'John Doe', email: 'john@example.com' },
+    session: { memberships: [{ slug: 'john', memexSlug: 'personal', kind: 'personal' }] },
+    token: 'fake',
+  }),
+}));
+vi.mock('../hooks/useUserChangeStream', () => ({ useUserChangeStream: () => undefined }));
+
+import { HomeCanvas } from './HomeCanvas';
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-372/acs/ac-${n}`;
+const CAP = 'max-w-[calc(25%_+_48rem)]';
+
+type Step = { id: string; attained: boolean };
+
+function stateFor(currentStepId: string, steps: Step[]) {
+  return {
+    milestones: {
+      identityConfirmed: false,
+      mcpConnected: false,
+      hasSpec: false,
+      hasResolvedDecision: false,
+      hasAc: false,
+      planGrounded: false,
+    },
+    currentStepId,
+    steps,
+    preview: false,
+    canPreview: false,
+  };
+}
+
+const NOT_GRADUATED: Step[] = [
+  { id: 'create-spec', attained: true },
+  { id: 'resolve-decision', attained: false },
+];
+
+function renderCanvas() {
+  return render(
+    <MemoryRouter initialEntries={['/home']}>
+      <HomeCanvas />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  fetchJourneyStateApi.mockReset();
+  postJourneyEventApi.mockReset();
+  postJourneyEventApi.mockResolvedValue(undefined);
+  postPersonaSelectedApi.mockReset();
+  fetchHomeApi.mockReset();
+  fetchHomeApi.mockResolvedValue({ whereYoureNeeded: [], specs: [] });
+  window.localStorage.clear();
+});
+
+describe('spec-372 issue-18 (dec-9): Home side whitespace reduced 25% (ac-47)', () => {
+  it('ac-47: the page header container caps at calc(25% + 48rem), not max-w-5xl', async () => {
+    tagAc(AC(47));
+    fetchJourneyStateApi.mockResolvedValue(stateFor('resolve-decision', NOT_GRADUATED));
+    renderCanvas();
+    const title = await screen.findByTestId('home-page-title');
+    const headerContainer = title.parentElement as HTMLElement;
+    expect(headerContainer.className).toContain(CAP);
+    expect(headerContainer.className).not.toContain('max-w-5xl');
+  });
+
+  it('ac-47: the journey-layer container caps at calc(25% + 48rem), not max-w-5xl', async () => {
+    tagAc(AC(47));
+    fetchJourneyStateApi.mockResolvedValue(stateFor('resolve-decision', NOT_GRADUATED));
+    renderCanvas();
+    const layer = await screen.findByTestId('journey-layer');
+    const layerContainer = layer.firstElementChild as HTMLElement;
+    expect(layerContainer.className).toContain(CAP);
+    expect(layerContainer.className).not.toContain('max-w-5xl');
+  });
+});

--- a/packages/ui/src/pages/HomeCanvas.tsx
+++ b/packages/ui/src/pages/HomeCanvas.tsx
@@ -318,7 +318,11 @@ export function HomeCanvas() {
   return (
     <div className="font-onboarding min-h-full" data-testid="home-canvas">
       {/* spec-336 / prototype: the page-level Home header above the tracker. */}
-      <div className="mx-auto max-w-5xl px-4 pt-10 sm:px-6">
+      {/* spec-372 issue-18 (dec-9) — cap content at calc(25% + 48rem) instead of max-w-5xl
+          (64rem) so each left/right gutter is 75% of its former value at every pane width:
+          gutter = (W − cap)/2, and 0.25·W + 0.75·64rem leaves 75% of (W − 64rem) as gutter.
+          Narrow widths (cap > pane) just fill the pane — no negative margins. */}
+      <div className="mx-auto max-w-[calc(25%_+_48rem)] px-4 pt-10 sm:px-6">
         <h1 data-testid="home-page-title" className="onboarding-heading">
           Home
         </h1>
@@ -329,7 +333,9 @@ export function HomeCanvas() {
 
       {layerVisible ? (
         <section data-testid="journey-layer" className="relative">
-          <div className="mx-auto max-w-5xl px-4 pt-6 sm:px-6">
+          {/* spec-372 issue-18 (dec-9) — same calc(25% + 48rem) cap as the header so the
+              two surfaces stay aligned and the 25% gutter reduction is uniform. */}
+          <div className="mx-auto max-w-[calc(25%_+_48rem)] px-4 pt-6 sm:px-6">
             {/* Header — static (spec-372 issue-8 removed the collapse/expand toggle + chevron). */}
             <div className="flex flex-wrap items-center gap-3 rounded-xl border-b border-edge px-2 pb-4 pt-1">
               {/* spec-372 issue-7 — title uses the onboarding accent #0482DC (the global


### PR DESCRIPTION
## What

Reduces the left/right whitespace flanking the **Home** page (`HomeCanvas` — the "Getting started on Memex" onboarding view) by 25%, so the content column gets correspondingly wider on desktop. Closes **issue-18** on spec-372.

## How

The Home content sat in two containers capped at `max-w-5xl` (64rem / 1024px), centred with `mx-auto`. The empty whitespace the user pointed at is the gutter outside that cap: `gutter_each = (W − 1024px) / 2`, where `W` is the AppShell `<main>` pane width — so it scales with the viewport and **no single fixed `max-width` reduces it by 25% at every screen size**.

Instead, both containers now cap at `max-w-[calc(25%_+_48rem)]` → `max-width: calc(25% + 48rem)`:

```
C = W − 0.75·(W − 1024px) = 0.25·W + 768px = calc(25% + 48rem)
```

This makes each side gutter **exactly 75% of its former value at every pane width** (the literal, viewport-independent reading of "−25%"). At narrow/mobile widths where the cap already exceeds the pane, the element just fills the pane — no negative margins, no regression. The `%` resolves against the `<main>` pane, which is the gutter's reference width.

Decision recorded as spec-372 **dec-9**.

## Test
- New `HomeCanvas.spec-372-issue18.test.tsx` asserts both the header and journey-layer containers carry the `calc(25% + 48rem)` cap and no longer carry `max-w-5xl` (tagged to **ac-47**; mirrors the spec-308 max-width className pattern).
- `vitest` green: new suite (2) + existing HomeCanvas/App spec-372 suites (35). `tsc -b` clean.
- This is a CSS-only gutter change with no flow/logic delta, so no new e2e journey; the required cold-DB e2e gate runs on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)