### PR TITLE
spec-372 issue-7: tracker title black + medium weight

### DIFF
--- a/packages/ui/src/pages/HomeCanvas.test.tsx
+++ b/packages/ui/src/pages/HomeCanvas.test.tsx
@@ -299,13 +299,15 @@ describe('HomeCanvas v2 — tracker is always expanded (spec-372 issue-8)', () =
     expect(screen.getByTestId('journey-content')).toBeInTheDocument();
   });
 
-  it('spec-372 issue-7: the tracker title uses the onboarding accent #0482DC', async () => {
-    tagAc(AC372(35));
+  it('spec-372 issue-7: the tracker title is black and medium weight (not blue, not bold)', async () => {
+    tagAc(AC372(48));
     fetchJourneyStateApi.mockResolvedValue(stateFor('create-spec', { attained: ['identity'] }));
     renderCanvas();
     const title = await screen.findByTestId('getting-started-title');
-    expect(title.className).toContain('text-[#0482DC]');
-    expect(title.className).not.toContain('text-accent');
+    expect(title.className).toContain('text-black');
+    expect(title.className).toContain('font-medium');
+    expect(title.className).not.toContain('text-[#0482DC]');
+    expect(title.className).not.toContain('font-bold');
   });
 });
 

--- a/packages/ui/src/pages/HomeCanvas.tsx
+++ b/packages/ui/src/pages/HomeCanvas.tsx
@@ -338,9 +338,8 @@ export function HomeCanvas() {
           <div className="mx-auto max-w-[calc(25%_+_48rem)] px-4 pt-6 sm:px-6">
             {/* Header — static (spec-372 issue-8 removed the collapse/expand toggle + chevron). */}
             <div className="flex flex-wrap items-center gap-3 rounded-xl border-b border-edge px-2 pb-4 pt-1">
-              {/* spec-372 issue-7 — title uses the onboarding accent #0482DC (the global
-                  text-accent token resolves to a different blue outside .font-onboarding's scope). */}
-              <h2 data-testid="getting-started-title" className="whitespace-nowrap text-lg font-bold text-[#0482DC]">
+              {/* spec-372 issue-7 — title is black (not the global accent blue) and medium weight. */}
+              <h2 data-testid="getting-started-title" className="whitespace-nowrap text-lg font-medium text-black">
                 Getting started on Memex
               </h2>
               <div className="ml-auto flex items-center gap-3">


### PR DESCRIPTION
## Summary

- Corrects the issue-7 fix: "Getting started on Memex" title is now `text-black` + `font-medium` (was incorrectly set to `text-[#0482DC]` + `font-bold`)
- Updates the test to assert the correct classes and retags it from ac-35 to ac-48
- ac-48 is verified green; ac-35 statement updated in Memex to note supersession

## Test plan

- [ ] `HomeCanvas.test.tsx` — "spec-372 issue-7: the tracker title is black and medium weight (not blue, not bold)" passes
- [ ] Visual check: "Getting started on Memex" header renders in black, medium weight on Home

🤖 Generated with [Claude Code](https://claude.com/claude-code)