### PR TITLE
spec-290 (dec-4): default app-wide text colour to primary, not secondary

### DIFF
--- a/packages/ui/src/default-text-colour.spec-290.test.ts
+++ b/packages/ui/src/default-text-colour.spec-290.test.ts
@@ -1,0 +1,48 @@
+// spec-290 dec-4 (ac-11) — the app-wide DEFAULT text colour is PRIMARY, not
+// secondary. The v4 migration left body defaulting to --ch-text-secondary, so any
+// element written without an explicit text-* utility rendered de-emphasised
+// (invisible at large sizes — the Stats-tab "white-on-white", spec-406). This
+// static-scan guard locks the default to primary in BOTH theme roots so a
+// regression to a secondary (or absent) default fails CI.
+//
+// Static scan rather than a computed-style assertion: jsdom does not apply the
+// real index.css cascade, so getComputedStyle would not see the base rule.
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { tagAc } from '@memex-ai-ac/vitest';
+
+const AC = 'mindset-prod/memex-building-itself/specs/spec-290/acs/ac-11';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const indexCss = readFileSync(join(HERE, './index.css'), 'utf8');
+
+// Pull the declaration block for a base theme-root rule, e.g. `.light body, .light`.
+function blockFor(selector: string): string {
+  const re = new RegExp(`${selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*\\{([^}]*)\\}`);
+  const m = indexCss.match(re);
+  if (!m) throw new Error(`could not find the \`${selector}\` rule in index.css`);
+  return m[1];
+}
+
+// The `color:` declaration inside a block (last one wins, mirroring the cascade).
+function colourDecl(block: string): string {
+  const matches = [...block.matchAll(/(?:^|[;{])\s*color\s*:\s*([^;]+);/g)];
+  if (matches.length === 0) throw new Error('no `color:` declaration in the block');
+  return matches[matches.length - 1][1].trim();
+}
+
+describe('spec-290 dec-4: the default text colour is primary, not secondary', () => {
+  for (const selector of ['.dark body, .dark', '.light body, .light']) {
+    it(`\`${selector}\` defaults text colour to --ch-text-primary`, () => {
+      tagAc(AC);
+      const colour = colourDecl(blockFor(selector));
+      expect(colour).toContain('--ch-text-primary');
+      // The trap we are guarding against: a secondary (or muted) default.
+      expect(colour).not.toContain('--ch-text-secondary');
+      expect(colour).not.toContain('--ch-text-muted');
+    });
+  }
+});

--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -321,13 +321,21 @@
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   }
 
+  /* spec-290 dec — the app-wide DEFAULT text colour is PRIMARY, not secondary.
+     The v4 migration left body defaulting to --ch-text-secondary (an anomaly: v3
+     defaulted body to a primary-weight gray, and the same migration also broke
+     text-body/border defaults, patched piecemeal). A secondary default is the
+     inverse of every framework's convention — it makes any element written
+     WITHOUT an explicit text-* utility render de-emphasised (invisible at large
+     sizes), the trap that bit the Stats tab (spec-406). De-emphasised copy opts
+     IN via text-secondary / text-muted; primary is the floor. */
   .dark body, .dark {
     background-color: rgb(var(--ch-page));
-    color: rgb(var(--ch-text-secondary));
+    color: rgb(var(--ch-text-primary));
   }
   .light body, .light {
     background-color: rgb(var(--ch-page));
-    color: rgb(var(--ch-text-secondary));
+    color: rgb(var(--ch-text-primary));
   }
 
   /* Thin, subtle scrollbars */


### PR DESCRIPTION
Formalises the systemic fix behind the Stats-tab "white-on-white" (#363) under spec-290 (the v4 migration). **dec-4 / ac-11.**

## Root cause
The v4 migration left the global default text colour set to `--ch-text-secondary` on `.dark body, .dark` / `.light body, .light` in `index.css`. Any element written **without** an explicit `text-*` utility inherits the de-emphasised colour — invisible at large/semibold sizes on a light card (what bit the Stats tab), under-emphasised everywhere else. This is the inverse of every framework's convention (body text = primary/foreground; you opt **into** de-emphasis).

It's a migration artifact, not a deliberate choice: v3 defaulted body to a primary-weight gray, and the same migration also broke `text-body` ("rendering colorless", `index.css` line 71) and the border default (line 9) — both already patched piecemeal. The recurrence is real: the latest develop commit (`#367`) was *another* body-text-legibility fix.

## The change
One base rule, both theme roots:
```css
.dark body, .dark   { color: rgb(var(--ch-text-primary)); }  /* was --ch-text-secondary */
.light body, .light { color: rgb(var(--ch-text-primary)); }
```

## Why low-risk
The codebase already specifies colour explicitly almost everywhere — `text-secondary` (141 files), `text-muted` (142), `text-heading` (91), `text-primary` (130). Intentional de-emphasis is explicit and **unaffected**. The only text that changes is content relying on the *implicit* default: slate-500 → slate-800, i.e. it becomes more readable. After this, an agent who forgets the colour class gets readable text, not an invisible one — closing the trap for good.

## Testing
- New static-scan guard `default-text-colour.spec-290.test.ts` (tags **spec-290 ac-11**) asserts both theme roots default to `--ch-text-primary` and fail on any regression to secondary/muted. Static scan because jsdom doesn't apply the real `index.css` cascade.
- Full UI suite **1746/1747** green (1 skipped) — the flip broke no rendering/snapshot test.

## Visual pass before merge (please eyeball)
Best confirmed by eye on a few dense, text-heavy screens in **light mode**, looking for any *intentional* body copy that leaned on the implicit-secondary default and now reads too dark:
- [ ] Spec detail page (narrative + panels)
- [ ] List pages (specs/standards/issues)
- [ ] Settings / Setup
- [ ] Pulse / insights

## Relationship to #363
#363 (per-component `text-primary` on the Stats tab) becomes **redundant but harmless** once this lands — explicit primary on a now-primary default is a no-op. Recommend merging #363 first (immediate Stats fix), then this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)