### PR TITLE
spec-410: Drift Inbox agent panel stays fixed (stop it scrolling with the list)

### DIFF
--- a/packages/ui/src/components/AppShell.spec-360.test.tsx
+++ b/packages/ui/src/components/AppShell.spec-360.test.tsx
@@ -97,3 +97,24 @@ describe('AppShell — bounded content wrapper on agent-rail routes (spec-389)',
     expect(contentWrapper().className).not.toContain('min-h-0');
   });
 });
+
+// spec-410: the Drift Inbox docks its agent via DocumentShell's two-pane shell
+// (not a ResizableChatRail), but the bounding need is identical — without a
+// `min-h-0` wrapper DocumentShell's `h-full` can't resolve and the whole <main>
+// scrolls as one unit, dragging the drift agent panel along with the rows. The
+// `/drift` route must get the same bounded wrapper as the agent-rail routes.
+const AC_410 = 'mindset-prod/memex-building-itself/specs/spec-410/acs/ac-5';
+
+describe('AppShell — bounded content wrapper on the drift route (spec-410, ac-5)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('gives the drift tenant route a bounded (min-h-0) wrapper so the agent stays fixed', () => {
+    tagAc(AC_410);
+    renderShell(['/acme/main/drift']);
+    const wrapper = contentWrapper();
+    expect(wrapper.className).toContain('min-h-0');
+    expect(wrapper.className).toContain('flex-1');
+  });
+});

--- a/packages/ui/src/components/AppShell.tsx
+++ b/packages/ui/src/components/AppShell.tsx
@@ -520,6 +520,13 @@ export function AppShell({ children }: { children: ReactNode }) {
   const onStandardsListPage = !!useMatch('/:namespace/:memex/standards');
   const onIssuesPage = !!useMatch('/:namespace/:memex/issues');
   const onAgentRailPage = onScaffoldPage || onStandardsListPage || onIssuesPage;
+  // spec-410: the Drift Inbox is the odd one out — it's not a doc page (it keeps
+  // the sidebar + drift badge), but it docks the agent via DocumentShell's
+  // two-pane shell rather than a ResizableChatRail. Either way the bounding need
+  // is identical: without a `min-h-0` wrapper DocumentShell's `h-full` can't
+  // resolve, the shell grows to content height, and the whole <main> scrolls as
+  // one unit — dragging the agent panel along with the drift rows. Bound it too.
+  const onDriftPage = !!useMatch('/:namespace/:memex/drift');
 
   // Open standards drift count for the nav badge (b-63). Skipped on doc pages,
   // where the sidebar is hidden.
@@ -719,8 +726,11 @@ export function AppShell({ children }: { children: ReactNode }) {
         {/* spec-360 / spec-389: an agent-rail page (scaffold, standards, issues)
             gets a bounded wrapper so its `h-full` resolves and the rail scrolls
             internally; content-flow pages keep the natural `flex-1` and scroll at
-            the <main> level. */}
-        <div className={onAgentRailPage ? 'flex-1 min-h-0' : 'flex-1'}>{children}</div>
+            the <main> level. spec-410: the Drift Inbox needs the same bounding —
+            it docks the agent via DocumentShell's two-pane shell. */}
+        <div className={onAgentRailPage || onDriftPage ? 'flex-1 min-h-0' : 'flex-1'}>
+          {children}
+        </div>
       </main>
 
       {/* spec-141 dec-2: invite dialog (portal-rendered to body). Opened from


### PR DESCRIPTION
## What & why

Fixes the bug in **spec-410**: on the Drift Inbox (`/<ns>/<mx>/drift`) the agent panel was **not** fixed — it scrolled together with the drift rows instead of staying pinned while only the list scrolls. Every other in-app agent surface (Spec, Standards, Issues, Scaffold) keeps the agent fixed.

## Root cause

The `/drift` route docks its agent via `DocumentShell`'s two-pane shell (left = `ChatPanel` `h-full`, right = canvas `h-full overflow-y-auto`). For those `h-full`s to resolve, the wrapping `<div>` in `AppShell` must be height-bounded. The Spec page gets that from the `onDocPage` branch; scaffold/standards/issues get it from `onAgentRailPage`. **Drift was in neither bucket**, so its wrapper was plain `flex-1` (no `min-h-0`) — DocumentShell's `h-full` then measured against an unbounded parent, the shell grew to content height, and the whole `<main>` scrolled as one unit, dragging the agent panel along with the rows.

## The fix (dec-1, Approach A — layout-only)

```ts
const onDriftPage = !!useMatch('/:namespace/:memex/drift');
...
<div className={onAgentRailPage || onDriftPage ? 'flex-1 min-h-0' : 'flex-1'}>
```

No change to `DocumentShell`, the drift agent's mode/wiring, the focus chip, or the list rendering. Rejected alternatives: routing `/drift` as a doc page (hides the sidebar + drift badge the in-box needs) and bounding inside `DocumentShell` (shared with the already-correct Spec page).

## Testing

- Extended `AppShell.spec-360.test.tsx` with a `/drift` case asserting the wrapper carries `flex-1 min-h-0` (tagged spec-410 `ac-5`, **verified** on the board). Red→green confirmed — fails with the fix reverted.
- Full UI unit suite green: 245 files, 1711 passed, 1 skipped. `tsc -b` clean. Re-verified after rebasing onto current `develop`.

**Note:** verification is a className assertion (jsdom can't measure real-layout scroll fixity). No new Playwright journey added for a one-class toggle — `e2e/journey-12-cross-tab-drift` already exercises the surface. Flagging the choice; happy to add a visual assertion if wanted.

Spec: `mindset-prod/memex-building-itself/specs/spec-410`

🤖 Generated with [Claude Code](https://claude.com/claude-code)