### PR TITLE
spec-415: shared agent-panel min width — drift panel honours the rail px floor

### DIFF
--- a/packages/ui/src/components/DocumentShell.spec-415.test.tsx
+++ b/packages/ui/src/components/DocumentShell.spec-415.test.tsx
@@ -1,0 +1,70 @@
+// spec-415 (dec-1, ac-5): the drift chat Panel in DocumentShell must set `minSize`
+// to the shared PIXEL floor (CHAT_MIN_W → "300px"), not a viewport percentage, so
+// the drift agent can no longer shrink below the rail floor on small viewports.
+// We render DocumentShell with react-resizable-panels' Panel mocked to surface its
+// minSize prop, then assert the chat panel carries the px floor (not "16%").
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { CHAT_MIN_W } from './chat/chatPanelWidth';
+
+const AC5 = 'mindset-prod/memex-building-itself/specs/spec-415/acs/ac-5';
+
+vi.mock('./ChatContext', () => ({ useChat: () => ({ isDriftMode: true }) }));
+vi.mock('./AuthContext', () => ({ useAuth: () => ({ isAuthenticated: true }) }));
+vi.mock('../hooks/useMemexAccess', () => ({
+  useMemexAccess: () => ({ canWrite: true }),
+}));
+vi.mock('./ChatPanel', () => ({
+  ChatPanel: () => <div data-testid="chat-panel" />,
+}));
+// Surface each Panel's id + minSize so the test can read the rendered props.
+vi.mock('react-resizable-panels', () => ({
+  Group: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  Panel: ({
+    id,
+    minSize,
+    children,
+  }: {
+    id?: string;
+    minSize?: string;
+    children: React.ReactNode;
+  }) => (
+    <div data-testid={`panel-${id}`} data-min-size={String(minSize)}>
+      {children}
+    </div>
+  ),
+  Separator: () => <div data-testid="resize-handle" />,
+}));
+
+import { DocumentShell } from './DocumentShell';
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+function renderShell() {
+  return render(
+    <MemoryRouter>
+      <DocumentShell>
+        <div data-testid="content">page</div>
+      </DocumentShell>
+    </MemoryRouter>,
+  );
+}
+
+describe('DocumentShell — drift panel shares the rail px floor (spec-415)', () => {
+  it('ac-5: the drift chat Panel minSize is the shared px floor, not a percentage', () => {
+    tagAc(AC5);
+    renderShell();
+    const chatPanel = screen.getByTestId('panel-chat');
+    const minSize = chatPanel.getAttribute('data-min-size');
+    // The px floor (e.g. "300px") — a true pixel minimum independent of viewport.
+    expect(minSize).toBe(`${CHAT_MIN_W}px`);
+    expect(minSize).toMatch(/px$/);
+    // Specifically NOT the old viewport-percentage floor.
+    expect(minSize).not.toMatch(/%$/);
+  });
+});

--- a/packages/ui/src/components/DocumentShell.tsx
+++ b/packages/ui/src/components/DocumentShell.tsx
@@ -4,6 +4,11 @@ import { Group, Panel, Separator } from 'react-resizable-panels';
 import { ChatPanel } from './ChatPanel';
 import { ChatCollapseProvider } from './chat/ChatCollapseContext';
 import { CollapsedChatStrip } from './chat/CollapsedChatStrip';
+// spec-415 (dec-1): the drift panel honours the SAME pixel floor as the rails
+// (standards/issues/scaffold) instead of a viewport percentage, so it can't shrink
+// below the shared minimum on laptop/tablet widths. react-resizable-panels v4
+// accepts a "<n>px" minSize. defaultSize/maxSize stay percentages — shared MINIMUM only.
+import { CHAT_MIN_W } from './chat/chatPanelWidth';
 import { useChat } from './ChatContext';
 import { useAuth } from './AuthContext';
 import { useMemexAccess } from '../hooks/useMemexAccess';
@@ -79,7 +84,7 @@ export function DocumentShell({ children }: { children: ReactNode }) {
     // Group id, so default-size changes only reach users on a fresh id —
     // v10 ships the slimmer 24% chat default (was 32%).
     <Group id="memex-shell-v10" orientation="horizontal" className="h-full">
-      <Panel id="chat" defaultSize="24%" minSize="16%" maxSize="45%">
+      <Panel id="chat" defaultSize="24%" minSize={`${CHAT_MIN_W}px`} maxSize="45%">
         <aside className="h-full relative">
           <div className="absolute inset-0">
             <ChatCollapseProvider onCollapse={() => setCollapsedPersist(true)}>

--- a/packages/ui/src/components/chat/ResizableChatRail.tsx
+++ b/packages/ui/src/components/chat/ResizableChatRail.tsx
@@ -7,10 +7,9 @@
 import { useCallback, useEffect, useState, type ReactNode } from 'react';
 import { ChatCollapseProvider } from './ChatCollapseContext';
 import { CollapsedChatStrip } from './CollapsedChatStrip';
-
-const CHAT_MIN_W = 300;
-const CHAT_MAX_W = 720;
-const CHAT_DEFAULT_W = 384; // = the old fixed w-96
+// spec-415 (dec-2): the width bounds now live in one shared module so the rail floor
+// and the drift panel's floor (DocumentShell.tsx) can't diverge again.
+import { CHAT_MIN_W, CHAT_DEFAULT_W, CHAT_MAX_W } from './chatPanelWidth';
 
 export interface ResizableChatRailProps {
   /** Per-surface localStorage key, e.g. 'scaffold-chat-width', 'standards-chat-width'. */

--- a/packages/ui/src/components/chat/chatPanelWidth.spec-415.test.ts
+++ b/packages/ui/src/components/chat/chatPanelWidth.spec-415.test.ts
@@ -1,0 +1,52 @@
+// spec-415 (dec-2, ac-6): the width bounds have ONE source of truth. The shared
+// module exports the three constants, and both consumers (ResizableChatRail.tsx and
+// DocumentShell.tsx) import the floor from it — with ResizableChatRail no longer
+// defining its own min/default/max literals, so the floor can't diverge again.
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { CHAT_MIN_W, CHAT_DEFAULT_W, CHAT_MAX_W } from './chatPanelWidth';
+
+const AC6 = 'mindset-prod/memex-building-itself/specs/spec-415/acs/ac-6';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const rail = readFileSync(join(here, 'ResizableChatRail.tsx'), 'utf8');
+const shell = readFileSync(join(here, '..', 'DocumentShell.tsx'), 'utf8');
+
+describe('chatPanelWidth — single source of truth for the agent panel floor (spec-415)', () => {
+  it('ac-6: the shared module exports the three width constants with the canonical values', () => {
+    tagAc(AC6);
+    expect(CHAT_MIN_W).toBe(300);
+    expect(CHAT_DEFAULT_W).toBe(384);
+    expect(CHAT_MAX_W).toBe(720);
+  });
+
+  it('ac-6: both ResizableChatRail and DocumentShell import the floor from the shared module', () => {
+    tagAc(AC6);
+    // ResizableChatRail pulls all three from the shared module.
+    expect(rail).toMatch(
+      /import\s*\{[^}]*\bCHAT_MIN_W\b[^}]*\}\s*from\s*['"]\.\/chatPanelWidth['"]/,
+    );
+    // DocumentShell pulls the floor from the shared module.
+    expect(shell).toMatch(
+      /import\s*\{[^}]*\bCHAT_MIN_W\b[^}]*\}\s*from\s*['"]\.\/chat\/chatPanelWidth['"]/,
+    );
+  });
+
+  it('ac-6: ResizableChatRail no longer defines its own min/default/max literals', () => {
+    tagAc(AC6);
+    // No local `const CHAT_*_W = <number>` declarations remain in the rail — the
+    // numeric literals live only in the shared module now.
+    expect(rail).not.toMatch(/const\s+CHAT_MIN_W\s*=/);
+    expect(rail).not.toMatch(/const\s+CHAT_DEFAULT_W\s*=/);
+    expect(rail).not.toMatch(/const\s+CHAT_MAX_W\s*=/);
+  });
+
+  it('ac-6: DocumentShell wires the shared floor into the drift Panel minSize as a px value', () => {
+    tagAc(AC6);
+    expect(shell).toMatch(/minSize=\{`\$\{CHAT_MIN_W\}px`\}/);
+  });
+});

--- a/packages/ui/src/components/chat/chatPanelWidth.ts
+++ b/packages/ui/src/components/chat/chatPanelWidth.ts
@@ -1,0 +1,9 @@
+// spec-415 (dec-2): the single source of truth for the in-app agent panels' width
+// bounds. Extracted out of ResizableChatRail.tsx so the floor lives in ONE place
+// that every docked-agent mechanism imports — the percentage-sized drift panel in
+// DocumentShell.tsx and the pixel-sized rails (standards/issues/scaffold) can no
+// longer drift apart. The floor (CHAT_MIN_W) is the shared minimum; default/max
+// stay rail-only knobs.
+export const CHAT_MIN_W = 300;
+export const CHAT_DEFAULT_W = 384; // = the old fixed w-96
+export const CHAT_MAX_W = 720;


### PR DESCRIPTION
## What & why
The four in-app side-panel agents (drift, standards, scaffold, issues) sit alongside busy screens and need a conformant **minimum width**. Three already share a 300px floor via `ResizableChatRail`; the **drift** panel was the outlier. It renders via `DocumentShell` (`react-resizable-panels`) with a **percentage** `minSize="16%"`, so its real minimum varied with viewport — **~230px @1440** (laptop) and **~164px @1024** (tablet), well below the rail floor — cramping an already-busy surface.

## Root cause
Two sizing systems and **no single source of truth** for the floor: pixel constants lived inside `ResizableChatRail.tsx`; the drift panel's percentage bounds lived separately in `DocumentShell.tsx`. Nothing tied them together.

## The fix (width-only, client-side layout)
- **New module** `packages/ui/src/components/chat/chatPanelWidth.ts` — exports `CHAT_MIN_W=300` / `CHAT_DEFAULT_W=384` / `CHAT_MAX_W=720` (dec-2, the single source of truth).
- `ResizableChatRail.tsx` imports them and **deletes its local literals** — behaviour identical (drag-resize, collapse-to-strip, per-surface persistence all unchanged).
- `DocumentShell.tsx` drift `Panel` `minSize` `"16%"` → `` `${CHAT_MIN_W}px` `` ("300px") (dec-1). `defaultSize`/`maxSize` stay percentages — the agreed scope is a shared **minimum** only.

`react-resizable-panels` is v4.11.2 and accepts a `"<n>px"` `minSize`, so this is a one-prop change that keeps drift's two-pane resize UX — no CSS hack, no migration onto the rail. Net effect: all four agents share the same 300px floor; each stays independently resizable and persisted above it.

## Testing done
- **ac-5** (`DocumentShell.spec-415.test.tsx`): renders DocumentShell and asserts the drift Panel's `minSize` is the px floor (`"300px"`), not a percentage.
- **ac-6** (`chatPanelWidth.spec-415.test.ts`): asserts the shared module exports the three constants and both consumers import the floor (rail no longer defines its own literals).
- Red→green confirmed (tests fail with the source reverted, pass with the change).
- Full UI vitest suite: **254 files, 1752 passed, 1 skipped** — no regressions. `npx tsc -b` exit 0.

**std-28:** width-only change — no new e2e journey for a constant/prop change; std-28 governs user-facing **flow** changes, and no flow changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)