### PR TITLE
spec-290 (dec-4/ac-12): fix index.html <body> leaking a hardcoded near-white text colour

### DIFF
--- a/packages/ui/index.html
+++ b/packages/ui/index.html
@@ -6,7 +6,12 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>Memex.AI</title>
   </head>
-  <body class="bg-slate-900 text-slate-100">
+  <!-- Token utilities (NOT hardcoded slate-*): html starts `.dark`, so this is a
+       dark pre-hydration splash, but `bg-page`/`text-primary` follow the theme once
+       React swaps html to `.light`. Hardcoded `bg-slate-900 text-slate-100` here used
+       to win over the theme rules (utilities layer beats base) and leaked a near-white
+       default text colour app-wide — invisible on light surfaces (spec-290). -->
+  <body class="bg-page text-primary">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/packages/ui/src/index-html-body.spec-290.test.ts
+++ b/packages/ui/src/index-html-body.spec-290.test.ts
@@ -1,0 +1,46 @@
+// spec-290 dec-4 (ac-12) — the index.html <body> must use theme-token utilities,
+// never hardcoded slate-* colours.
+//
+// The v4 migration left `<body class="bg-slate-900 text-slate-100">` as a dark
+// pre-hydration splash. Because Tailwind v4 puts utilities in `@layer utilities`
+// (which beats `@layer base` regardless of specificity), that hardcoded text colour
+// overrode the theme's body rule and leaked a near-white default text colour app-wide
+// — invisible on light surfaces (the scaffold "white-on-white", confirmed via a live
+// browser inspection: body color stuck at slate-100 while every `--ch-*` var was the
+// correct light value). The fix is `bg-page text-primary`: html starts `.dark`, so the
+// splash is still dark, but the body now follows the theme after React swaps to `.light`.
+//
+// Static scan: the built bundle is what ships, but the <body> class is authored here.
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { tagAc } from '@memex-ai-ac/vitest';
+
+const AC = 'mindset-prod/memex-building-itself/specs/spec-290/acs/ac-12';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const indexHtml = readFileSync(join(HERE, '../index.html'), 'utf8');
+
+function bodyClass(): string {
+  const m = indexHtml.match(/<body[^>]*\bclass="([^"]*)"/);
+  if (!m) throw new Error('could not find <body class="…"> in index.html');
+  return m[1];
+}
+
+describe('spec-290 dec-4: index.html body uses theme tokens, not hardcoded slate-*', () => {
+  it('the <body> class carries the theme-token utilities', () => {
+    tagAc(AC);
+    const cls = bodyClass();
+    expect(cls).toContain('bg-page');
+    expect(cls).toContain('text-primary');
+  });
+
+  it('the <body> class has NO hardcoded slate-* colour (the leak we are guarding against)', () => {
+    tagAc(AC);
+    const cls = bodyClass();
+    // e.g. text-slate-100 / bg-slate-900 — a fixed colour that beats the theme base rule.
+    expect(cls).not.toMatch(/\b(text|bg)-slate-\d/);
+  });
+});


### PR DESCRIPTION
**The actual root cause** of the app-wide "white-on-white" / faint-text issue in light mode — found by driving a real headless browser against the scaffold page and walking the live DOM.

## What was happening
`packages/ui/index.html` hardcoded:
```html
<body class="bg-slate-900 text-slate-100">
```
That was meant as a dark pre-hydration splash. But Tailwind v4 places utilities in `@layer utilities`, which **beats `@layer base` regardless of specificity** — so `text-slate-100` overrode the theme's `.light body` rule and **silently defeated the default-to-primary fix in #368**. The body's text colour stayed slate-100 in *every* theme, and every element without its own colour class inherited it → invisible on light surfaces.

The live inspection made it unambiguous: in light mode, `<html>` had the correct `.light` class and every `--ch-text-*` variable was the correct light value (slate-800/900), yet `getComputedStyle(body).color` was stuck at `rgb(241 245 249)` (slate-100), inherited straight down to the button.

## The fix
```html
<body class="bg-page text-primary">
```
Token utilities instead of hardcoded slate-*. `<html>` starts `.dark`, so the splash is still dark, but the body now follows the theme after React swaps html to `.light`.

**Verified in a real browser** (both themes):
| theme | body/button text | body bg |
|---|---|---|
| light | `rgb(30,41,59)` slate-800 (dark, readable) | white |
| dark | `rgb(226,232,240)` slate-200 (light, readable) | `rgb(33,37,43)` |

## Testing
- New static-scan guard `index-html-body.spec-290.test.ts` (tags **spec-290 ac-12**): the `<body>` carries `bg-page text-primary` and **no** `*-slate-*` hardcode. Locks the regression out.
- Full UI suite **1749/1750** green (1 skipped).

## Relationship to the earlier PRs
- #368 (default base rule → primary) was correct but **masked** by this `index.html` line; together they now compose. 
- #363 (per-component `text-primary` on the Stats tab) stays valid but is now belt-and-suspenders.

This is the real systemic fix — it covers the whole app, not just the Stats tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)