### PR TITLE
spec-420: fix tag scope display — remove uppercase CSS and add case-insensitive scope collision detection

### DIFF
--- a/packages/server/src/services/tags.integration.test.ts
+++ b/packages/server/src/services/tags.integration.test.ts
@@ -21,6 +21,7 @@ import {
   setTagOnDoc,
   removeTagFromDoc,
   listDocTags,
+  listMemexTags,
   applyTagString,
 } from "./tags.js";
 import type { RequestCtx } from "./mutate.js";
@@ -184,6 +185,30 @@ describe("tags service [spec-136 t-2]", () => {
       .where(and(eq(documentTags.docId, docId), eq(documentTags.tagId, tag.id)));
     expect(link.length).toBe(1);
     expect(link[0].addedBy).toBe(author.id);
+  });
+
+  // ── spec-420: case-insensitive scope collision detection ──────────────────
+  it("ac-2 (spec-420): getOrCreateTag reuses existing tag when scope matches case-insensitively", async () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-420/acs/ac-2");
+    const existing = await getOrCreateTag(ctx, memexId, "DEPLOY", "26-July-A");
+    const reused = await getOrCreateTag(ctx, memexId, "Deploy", "26-July-A");
+    expect(reused.id).toBe(existing.id);
+    expect(reused.scope).toBe("DEPLOY"); // original casing preserved
+  });
+
+  it("ac-3 (spec-420): pre-existing tags with different scope casing are both returned by listMemexTags", async () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-420/acs/ac-3");
+    // Simulate legacy data: insert two rows with different scope casing directly,
+    // bypassing getOrCreateTag to represent data that existed before the fix.
+    const [tag1] = await db.insert(tags).values({ memexId, scope: "LEGACY", value: "ci-test" }).returning();
+    const [tag2] = await db.insert(tags).values({ memexId, scope: "legacy", value: "ci-test" }).returning();
+
+    const all = await listMemexTags(memexId);
+    const legacyTags = all.filter((t) => t.value === "ci-test");
+    expect(legacyTags.length).toBe(2);
+
+    await db.delete(tags).where(eq(tags.id, tag1.id));
+    await db.delete(tags).where(eq(tags.id, tag2.id));
   });
 
   it("applyTagString rejects a Spec that isn't in this Memex (same-tenant invariant)", async () => {

--- a/packages/server/src/services/tags.ts
+++ b/packages/server/src/services/tags.ts
@@ -18,7 +18,7 @@
 // single `added_by` FK to users (db/schema.ts) — passed here as `addedBy` (string|null),
 // NOT the author_name/author_namespace_id stub the pre-develop reference carried.
 
-import { and, eq, isNull, inArray, ne } from "drizzle-orm";
+import { and, eq, isNull, inArray, ne, sql } from "drizzle-orm";
 import { db } from "../db/connection.js";
 import { documents, tags, documentTags } from "../db/schema.js";
 import type { Tag, DocumentTag } from "../db/schema.js";
@@ -75,6 +75,24 @@ export async function getOrCreateTag(
 
   const [existing] = await db.select().from(tags).where(matchTag).limit(1);
   if (existing) return existing;
+
+  // Case-insensitive scope fallback: if a tag with the same value and a
+  // case-insensitively matching scope already exists, reuse it rather than
+  // minting a near-duplicate (e.g. "Deploy::foo" when "DEPLOY::foo" is present).
+  if (scope !== null) {
+    const [ciMatch] = await db
+      .select()
+      .from(tags)
+      .where(
+        and(
+          eq(tags.memexId, memexId),
+          sql`lower(${tags.scope}) = lower(${scope})`,
+          eq(tags.value, value),
+        ),
+      )
+      .limit(1);
+    if (ciMatch) return ciMatch;
+  }
 
   const created = await mutate(
     ctx,

--- a/packages/ui/src/components/TagChip.test.tsx
+++ b/packages/ui/src/components/TagChip.test.tsx
@@ -51,6 +51,27 @@ describe('TagChip', () => {
     expect(chip.textContent).toBe('bug');
   });
 
+  // spec-420 ac-1: scope renders in stored casing, no forced uppercase
+  it('renders scope in stored casing — no uppercase CSS transform (ac-1)', () => {
+    tagAc('mindset-prod/memex-building-itself/specs/spec-420/acs/ac-1');
+
+    render(<TagChip tag={{ scope: 'Deploy', value: '26-July-A' }} />);
+
+    const scope = screen.getByTestId('tag-chip-scope');
+    expect(scope.textContent).toBe('Deploy');
+    expect(scope.className).not.toContain('uppercase');
+  });
+
+  // spec-420 ac-4: uppercase scope still renders uppercase — no regression
+  it('renders uppercase scope as-is when stored in uppercase (ac-4)', () => {
+    tagAc('mindset-prod/memex-building-itself/specs/spec-420/acs/ac-4');
+
+    render(<TagChip tag={{ scope: 'DEPLOY', value: '26-July-A' }} />);
+
+    const scope = screen.getByTestId('tag-chip-scope');
+    expect(scope.textContent).toBe('DEPLOY');
+  });
+
   it('renders tag text escaped (user input is not interpreted as HTML)', () => {
     tagAc('mindset-prod/memex-building-itself/specs/spec-136/acs/ac-4');
 

--- a/packages/ui/src/components/TagChip.tsx
+++ b/packages/ui/src/components/TagChip.tsx
@@ -47,7 +47,7 @@ export function TagChip({ tag, onRemove, removeLabel, className = '' }: TagChipP
         <>
           <span
             data-testid="tag-chip-scope"
-            className="font-semibold uppercase tracking-wide text-accent"
+            className="font-semibold tracking-wide text-accent"
           >
             {tag.scope}
           </span>


### PR DESCRIPTION
## Summary

- **`TagChip.tsx`**: Remove `uppercase` from the scope span's CSS className. The scope now renders in the exact casing it was stored with — `Deploy` shows as `Deploy`, not `DEPLOY`. What you type is what you see.
- **`tags.ts`**: In `getOrCreateTag`, add a case-insensitive scope fallback lookup after the exact-match miss. If a tag with `lower(scope) = lower(incoming)` and the same value already exists, reuse it (preserving original casing) rather than minting a near-duplicate catalogue row.
- **Tests**: Tagged vitest tests added for ac-1..ac-4 in `TagChip.test.tsx` and `tags.integration.test.ts`.

Closes: spec-420 (promoted from issue-1 on spec-136)

## Context

The bug: `TagChip` applied a CSS `uppercase` transform to the scope segment, so `Deploy::26-July-A` and `DEPLOY::26-July-A` looked identical in the filter dropdown. The system stored and treated them as two different tags, creating a phantom duplicate visible to users (reported by Roxann against the 26-July-A deploy labels). Fix is a one-class removal + a fallback SELECT in the write path.

## Test plan

- [ ] Run `packages/ui/src/components/TagChip.test.tsx` — ac-1 and ac-4 tests pass
- [ ] Run `packages/server/src/services/tags.integration.test.ts` with a local DB — ac-2 and ac-3 tests pass (requires Postgres up: `brew services start postgresql@16`)
- [ ] `pnpm --filter @memex/ui exec tsc --noEmit` — clean
- [ ] Visually confirm: apply a title-case tag (e.g. `Deploy::test`) in the UI and verify the chip shows `Deploy`, not `DEPLOY`
- [ ] Visually confirm: applying `deploy::test` when `DEPLOY::test` exists returns the existing tag (no duplicate in filter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)