### PR TITLE
test: verify spec-304 ac-29 (magic-link) + add ac-24/ac-14 workspace-boundary guard

### DIFF
--- a/packages/server/src/routes/auth/magic-link-login-request.test.ts
+++ b/packages/server/src/routes/auth/magic-link-login-request.test.ts
@@ -5,6 +5,14 @@
 // a live DB.
 
 import { describe, it, expect, vi, beforeEach, afterAll } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+// ac-29: the magic-link originating-session surrogate — loginRequestId + the
+// login_requests TTL'd row, the unauthenticated status endpoint
+// (not-verified / expired / unknown-404), the post-consume verified payload
+// with single-shot pickup, and /consume still requiring the raw token. Every
+// `it` below asserts one clause of that AC.
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-304/acs/ac-${n}`;
 
 const ORIGINAL_JWT_SECRET = vi.hoisted(() => {
   const v = process.env.AUTH_JWT_SECRET;
@@ -123,6 +131,7 @@ const JSON_HEADERS = { "Content-Type": "application/json" };
 
 describe("POST /api/auth/magic-link (issue)", () => {
   it("returns a loginRequestId and never leaks the raw token", async () => {
+    tagAc(AC(29));
     getUserByEmail.mockResolvedValue({ id: "user-1", email: EMAIL });
     issueAuthToken.mockResolvedValue({
       raw: "RAW-SECRET-TOKEN",
@@ -151,6 +160,7 @@ describe("POST /api/auth/magic-link (issue)", () => {
 
 describe("POST /api/auth/magic-link/consume", () => {
   it("flips the surrogate verified after consuming the token", async () => {
+    tagAc(AC(29));
     consumeAuthToken.mockResolvedValue({ id: TOKEN_ID, email: EMAIL, userId: "user-1" });
     upsertUserByEmail.mockResolvedValue({ id: "user-1", email: EMAIL });
     resolveSession.mockResolvedValue(sampleSession);
@@ -170,6 +180,7 @@ describe("POST /api/auth/magic-link/consume", () => {
   });
 
   it("still requires the raw token (invalid token → 400, no verify)", async () => {
+    tagAc(AC(29));
     consumeAuthToken.mockRejectedValue(new AuthTokenErrorMock("unknown", "Invalid"));
 
     const res = await app.request("/api/auth/magic-link/consume", {
@@ -185,12 +196,14 @@ describe("POST /api/auth/magic-link/consume", () => {
 
 describe("GET /api/auth/magic-link/login-requests/:id/status", () => {
   it("404s for an unknown id", async () => {
+    tagAc(AC(29));
     getLoginRequestStatus.mockResolvedValue(null);
     const res = await app.request(`/api/auth/magic-link/login-requests/${LR_ID}/status`);
     expect(res.status).toBe(404);
   });
 
   it("returns not-verified before the link is consumed", async () => {
+    tagAc(AC(29));
     getLoginRequestStatus.mockResolvedValue({
       id: LR_ID,
       email: EMAIL,
@@ -203,6 +216,7 @@ describe("GET /api/auth/magic-link/login-requests/:id/status", () => {
   });
 
   it("returns expired for an unverified, lapsed request", async () => {
+    tagAc(AC(29));
     getLoginRequestStatus.mockResolvedValue({
       id: LR_ID,
       email: EMAIL,
@@ -215,6 +229,7 @@ describe("GET /api/auth/magic-link/login-requests/:id/status", () => {
   });
 
   it("returns a verified session payload after consume, and single-shots the row", async () => {
+    tagAc(AC(29));
     getLoginRequestStatus.mockResolvedValue({
       id: LR_ID,
       email: EMAIL,
@@ -237,6 +252,7 @@ describe("GET /api/auth/magic-link/login-requests/:id/status", () => {
   });
 
   it("hands out exactly one session under a concurrent-poll race (delete is the gate)", async () => {
+    tagAc(AC(29));
     // Both polls read the same verified, unexpired row...
     getLoginRequestStatus.mockResolvedValue({
       id: LR_ID,
@@ -257,6 +273,7 @@ describe("GET /api/auth/magic-link/login-requests/:id/status", () => {
   });
 
   it("refuses to mint a session for a verified-but-expired request", async () => {
+    tagAc(AC(29));
     getLoginRequestStatus.mockResolvedValue({
       id: LR_ID,
       email: EMAIL,

--- a/packages/server/src/workspace-boundary.spec-304.test.ts
+++ b/packages/server/src/workspace-boundary.spec-304.test.ts
@@ -1,0 +1,83 @@
+// spec-304: the desktop client ships from its own repo, NOT the memex-ai pnpm
+// workspace. This guards the in-repo, falsifiable half of that boundary:
+//   - ac-24: "...absent from the memex-ai pnpm-workspace.yaml packages glob."
+//   - ac-14: "...independent of the memex-ai pnpm workspace..." (the
+//            workspace-independence clause; the "ships from
+//            github.com/mindset-ai/memex-clients with its own build/CI/release
+//            pipeline" clause is confirmed live via the git remote + branch
+//            protection, recorded in the Spec's QA report).
+//
+// The regression this catches: someone vendoring the Flutter desktop client in
+// as a workspace package (a `packages/*` dir carrying a pubspec.yaml), which
+// would re-couple the client to this workspace.
+
+import { describe, it, expect } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { readFileSync, existsSync, readdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-304/acs/ac-${n}`;
+
+/** Walk up from this file until the repo root (the dir with pnpm-workspace.yaml). */
+function findRepoRoot(): string {
+  let dir = dirname(fileURLToPath(import.meta.url));
+  for (let i = 0; i < 10; i++) {
+    if (existsSync(join(dir, "pnpm-workspace.yaml"))) return dir;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  throw new Error("pnpm-workspace.yaml not found walking up from the test file");
+}
+
+/** Extract the `- "<glob>"` entries under the top-level `packages:` key. */
+function workspacePackageGlobs(yaml: string): string[] {
+  const globs: string[] = [];
+  let inPackages = false;
+  for (const raw of yaml.split(/\r?\n/)) {
+    if (/^packages:\s*$/.test(raw)) {
+      inPackages = true;
+      continue;
+    }
+    if (inPackages) {
+      // A non-indented, non-empty line ends the packages block.
+      if (raw.trim() !== "" && !/^\s/.test(raw)) break;
+      const m = raw.match(/^\s*-\s*["']?(.+?)["']?\s*$/);
+      if (m) globs.push(m[1]);
+    }
+  }
+  return globs;
+}
+
+describe("workspace boundary — desktop client is not a memex-ai package (spec-304)", () => {
+  const root = findRepoRoot();
+
+  it("pnpm-workspace.yaml only globs packages/* — nothing outside packages/", () => {
+    tagAc(AC(24));
+    tagAc(AC(14));
+    const yaml = readFileSync(join(root, "pnpm-workspace.yaml"), "utf8");
+    const globs = workspacePackageGlobs(yaml);
+
+    expect(globs.length).toBeGreaterThan(0);
+    // Every workspace glob must be confined under packages/ — so a sibling repo
+    // checked out alongside (e.g. memex-clients) can never be a workspace member.
+    for (const glob of globs) {
+      expect(glob.startsWith("packages/")).toBe(true);
+    }
+  });
+
+  it("no packages/* dir carries a pubspec.yaml (the Flutter desktop client is not vendored)", () => {
+    tagAc(AC(24));
+    const packagesDir = join(root, "packages");
+    const entries = readdirSync(packagesDir, { withFileTypes: true });
+    const flutterPkgs = entries
+      .filter((e) => e.isDirectory())
+      .filter((e) => existsSync(join(packagesDir, e.name, "pubspec.yaml")))
+      .map((e) => e.name);
+
+    expect(flutterPkgs).toEqual([]);
+    // And specifically no desktop-client package by name.
+    expect(entries.some((e) => e.name === "memex-clients")).toBe(false);
+  });
+});


### PR DESCRIPTION
Part of closing out **spec-304** (desktop app). Two ACs were untested only for lack of emission/coverage, not behaviour.

## What changed
- `packages/server/src/routes/auth/magic-link-login-request.test.ts`: add `tagAc(ac-29)` to all 9 `it()`s. The file already covered the originating-session magic-link flow (loginRequestId, consume stamping, status not-verified/expired/unknown-404, verified single-shot pickup, concurrent-poll race, verified-but-expired refusal, /consume still requires the raw token) — it just wasn't emitting. **No assertion logic changed.**
- `packages/server/src/workspace-boundary.spec-304.test.ts` (new): a standing guard that the Flutter desktop client can never be vendored into the memex-ai pnpm workspace (globs confined to `packages/*`; no `packages/*` dir carries a `pubspec.yaml`; no `memex-clients` package). Emits **ac-24** and the workspace-independence clause of **ac-14**.

## Verification
`pnpm --filter @memex/server test <both files>`: **11/11 pass**, emitting to the spec-304 board. ac-29 and ac-24 now show verified.

No production code touched.