### PR TITLE
spec-421: Home Onboarding v4 — condense rail to 3 steps

### DIFF
--- a/packages/server/src/journeys/onboarding.ts
+++ b/packages/server/src/journeys/onboarding.ts
@@ -63,11 +63,16 @@ export interface JourneyDef {
 // server still emits them; the Home Canvas hides them for non-builder personas
 // (spec-336 dec-3). `agents-build` is terminal (completedBy: null): it ticks once every
 // prior step's milestone is met (stepStatuses' all-milestones-met rule).
+//
+// spec-421: the old two-stage create-spec card is split into two discrete steps.
+// create-spec completes on mcpConnected; create-first-spec completes on hasSpec.
+// Steps 3–6 are hidden from the rail (code kept for future reintroduction).
 export const onboardingJourney: JourneyDef = {
   id: "onboarding",
   steps: [
     { id: "identity", completedBy: "identityConfirmed" },
-    { id: "create-spec", completedBy: "hasSpec" },
+    { id: "create-spec", completedBy: "mcpConnected" },
+    { id: "create-first-spec", completedBy: "hasSpec" },
     { id: "resolve-decision", completedBy: "hasResolvedDecision" },
     { id: "add-ac", completedBy: "hasAc" },
     { id: "specs-match-reality", completedBy: "planGrounded" },

--- a/packages/server/src/routes/journey.api.test.ts
+++ b/packages/server/src/routes/journey.api.test.ts
@@ -190,22 +190,27 @@ describe("Home Canvas journey-state (ac-3 derived position)", () => {
 });
 
 describe("Home Canvas journey-state (ac-5 self-advance through the v2 arc)", () => {
-  it("advances one step at a time through the whole six-step arc", async () => {
+  it("advances one step at a time through the full arc", async () => {
+    // spec-421: arc is now identity → create-spec (mcpConnected) → create-first-spec (hasSpec)
+    // → resolve-decision → add-ac → specs-match-reality → agents-build (terminal).
     tagAc(AC336(5));
     tagAc(AC336(8));
+    const AC421 = (n: number) =>
+      `mindset-prod/memex-building-itself/specs/spec-421/acs/ac-${n}`;
+    tagAc(AC421(5)); // create-spec completes on mcpConnected
+    tagAc(AC421(10)); // create-first-spec completes on hasSpec
     const user = await newUser();
     expect((await state(user.id)).body.currentStepId).toBe("identity");
 
     await confirmIdentity(user.id);
-    // spec-336: connect is folded into the create-spec card (Stage 1) — connecting is
-    // shown inline, but the STEP advances on hasSpec, so identity → create-spec directly.
     expect((await state(user.id)).body.currentStepId).toBe("create-spec");
 
     await connectMcp(user.id);
-    // mcpConnected no longer gates a dedicated step — still on create-spec until a spec exists.
-    expect((await state(user.id)).body.currentStepId).toBe("create-spec");
+    // spec-421: create-spec now completes on mcpConnected → advances to create-first-spec.
+    expect((await state(user.id)).body.currentStepId).toBe("create-first-spec");
 
     const doc = await seedSpec(user.id);
+    // spec-421: create-first-spec completes on hasSpec → advances to resolve-decision.
     expect((await state(user.id)).body.currentStepId).toBe("resolve-decision");
 
     await seedResolvedDecision(user.id, doc.id);
@@ -238,8 +243,10 @@ describe("Home Canvas journey-state (ac-5 self-advance through the v2 arc)", () 
     const colleague = await newUser();
     await confirmIdentity(me.id);
     await connectMcp(me.id);
+    // spec-421: after mcpConnected, I'm now on create-first-spec (create-spec completed).
+    // Colleague's spec does NOT satisfy MY hasSpec → I stay on create-first-spec.
     await seedSpec(colleague.id); // the colleague's spec, not mine
-    expect((await state(me.id)).body.currentStepId).toBe("create-spec");
+    expect((await state(me.id)).body.currentStepId).toBe("create-first-spec");
   });
 });
 

--- a/packages/ui/e2e/journey-34-home-canvas.spec.ts
+++ b/packages/ui/e2e/journey-34-home-canvas.spec.ts
@@ -10,19 +10,24 @@ import {
   DEV_NAME,
 } from "./helpers/index.js";
 
-// Journey 34 — the Home Canvas onboarding journey, v2 (spec-336).
+// Journey 34 — the Home Canvas onboarding journey, v2 (spec-336) + v4 (spec-421).
 //
-//   ac-1 — Home is the top, user-level nav item (flat /home); the journey is a persistent
-//          rail with a six-node nav, shown to every newcomer (not behind an opt-in).
-//   ac-2 — step 0 is the identity step: confirm the SSO name + the developer/designer/PM
-//          triangle.
-//   ac-8 — the full arc is presented as a rail to a new user.
-//   ac-5 — the journey SELF-ADVANCES once identity is confirmed (state-derived): with the
-//          spec not yet created, the next step is create-spec.
+//   ac-1  (spec-336) — Home is the top, user-level nav item (flat /home); the journey is a
+//          persistent rail shown to every newcomer (not behind an opt-in).
+//   ac-2  (spec-336) — step 0 is the identity step: confirm the SSO name + the role triangle.
+//   ac-8  (spec-336) — the arc is presented as a rail to a new user.
+//   ac-5  (spec-336) — the journey SELF-ADVANCES once identity is confirmed (state-derived).
+//   ac-2  (spec-421) — the rail shows exactly 3 visible nodes: identity, create-spec,
+//          create-first-spec. Hidden steps (resolve-decision, add-ac, specs-match-reality,
+//          agents-build) have no rail node.
+//   ac-3  (spec-421) — after advancing past identity the rail reveals with 3 nodes;
+//          create-first-spec is the last visible node (not agents-build).
 const AC1 = "mindset-prod/memex-building-itself/specs/spec-336/acs/ac-1";
 const AC2 = "mindset-prod/memex-building-itself/specs/spec-336/acs/ac-2";
 const AC5 = "mindset-prod/memex-building-itself/specs/spec-336/acs/ac-5";
 const AC8 = "mindset-prod/memex-building-itself/specs/spec-336/acs/ac-8";
+const AC421_2 = "mindset-prod/memex-building-itself/specs/spec-421/acs/ac-2";
+const AC421_3 = "mindset-prod/memex-building-itself/specs/spec-421/acs/ac-3";
 
 const TITLE =
   "a brand-new user lands on the persistent rail at the identity step, then self-advances to create-spec";
@@ -33,7 +38,7 @@ test.afterEach(async ({}, testInfo) => {
   await setIdentityConfirmed(DEV_EMAIL, true);
   if (testInfo.status === "skipped") return;
   await emitAcEvents(
-    [AC1, AC2, AC5, AC8],
+    [AC1, AC2, AC5, AC8, AC421_2, AC421_3],
     testInfo.status === "passed" ? "pass" : "fail",
     `packages/ui/e2e/journey-34-home-canvas.spec.ts::${testInfo.title}`,
     testInfo.duration,
@@ -58,14 +63,14 @@ test(TITLE, async ({ page }) => {
   await expect(page.getByTestId("journey-rail")).toBeHidden();
 
   // Continue confirms identity (persists role_coords) → the journey self-advances OFF the
-  // identity step (ac-5) and the persistent full-arc rail reveals (ac-1/ac-8). We assert
-  // the advance + the rail rather than a specific next step: this shared dev user may
-  // already have a spec/decision from other journeys, so the first unmet step varies —
-  // what's invariant is that confirming identity moves you forward onto the rail, where
-  // create-spec (universal) and the builder-only agents-build node are both present.
+  // identity step (ac-5) and the persistent 3-node rail reveals (ac-1/ac-8/spec-421-ac-3).
+  // spec-421: the rail has exactly 3 visible nodes — identity, create-spec, create-first-spec.
+  // Hidden steps (resolve-decision, add-ac, specs-match-reality, agents-build) have no rail node.
   await page.getByTestId("identity-continue").click();
   await expect(page.getByTestId("journey-rail")).toBeVisible({ timeout: 10_000 });
   await expect(page.getByTestId("journey-step-identity")).toBeHidden();
   await expect(page.getByTestId("journey-rail-node-create-spec")).toBeVisible();
-  await expect(page.getByTestId("journey-rail-node-agents-build")).toBeVisible();
+  // spec-421 ac-2: create-first-spec is visible; agents-build is hidden (not in rail).
+  await expect(page.getByTestId("journey-rail-node-create-first-spec")).toBeVisible();
+  await expect(page.getByTestId("journey-rail-node-agents-build")).not.toBeVisible();
 });

--- a/packages/ui/src/components/home/CreateFirstSpecStep.test.tsx
+++ b/packages/ui/src/components/home/CreateFirstSpecStep.test.tsx
@@ -1,0 +1,106 @@
+// spec-421 — step 2 "Create your first spec".
+//   ac-6  — step 3 renders the "Create your first spec" H2, blue CTA, sample prompt helper.
+//   ac-7  — blue CTA navigates to the Specs page with ?new=1 (onCreateInApp).
+//   ac-8  — sample prompt helper is collapsible (truncated by default, expand/collapse).
+//   ac-9  — copying the sample prompt fires the copy_create_prompt CTA (via journey-cta.spec-324).
+//   ac-10 — step 3 completes on hasSpec (not mcpConnected).
+//   ac-11 — no method selector / starting-point selector.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { tagAc } from '@memex-ai-ac/vitest';
+
+const fetchJourneyStateApi = vi.hoisted(() => vi.fn());
+vi.mock('../../api/journey', () => ({ fetchJourneyStateApi }));
+
+import { CreateFirstSpecStep } from './CreateFirstSpecStep';
+
+const AC421 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-421/acs/ac-${n}`;
+
+beforeEach(() => {
+  fetchJourneyStateApi.mockReset();
+  fetchJourneyStateApi.mockResolvedValue({ milestones: { hasSpec: false } });
+});
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('CreateFirstSpecStep — spec-421 step 3', () => {
+  it('ac-6: renders the "Create your first spec" H2, blue CTA, and sample prompt helper', () => {
+    tagAc(AC421(6));
+    render(<CreateFirstSpecStep preview />);
+    expect(screen.getByTestId('journey-step-create-first-spec')).toBeInTheDocument();
+    const h2 = screen.getByRole('heading', { level: 2 });
+    expect(h2.textContent).toMatch(/Create your first spec/);
+    expect(screen.getByTestId('create-first-spec-btn')).toBeInTheDocument();
+    expect(screen.getByTestId('sample-prompt-helper')).toBeInTheDocument();
+  });
+
+  it('ac-7: the blue CTA fires onCreateInApp (navigates to Specs page with ?new=1)', () => {
+    tagAc(AC421(7));
+    const onCreateInApp = vi.fn();
+    render(<CreateFirstSpecStep preview onCreateInApp={onCreateInApp} />);
+    fireEvent.click(screen.getByTestId('create-first-spec-btn'));
+    expect(onCreateInApp).toHaveBeenCalledTimes(1);
+  });
+
+  it('ac-8: the sample prompt helper is collapsed by default and expands/collapses', () => {
+    tagAc(AC421(8));
+    render(<CreateFirstSpecStep preview />);
+    const container = screen.getByTestId('sample-prompt-container');
+    // Collapsed by default — the container has a max-height cap.
+    expect(container.className).toContain('max-h-[13rem]');
+    // Expand button visible; collapse button hidden.
+    expect(screen.getByTestId('sample-prompt-expand')).toBeInTheDocument();
+    expect(screen.queryByTestId('sample-prompt-collapse')).toBeNull();
+    // Click expand.
+    fireEvent.click(screen.getByTestId('sample-prompt-expand'));
+    // Now expanded — no max-h cap; expand button gone; collapse visible.
+    expect(screen.getByTestId('sample-prompt-container').className).not.toContain('max-h-[13rem]');
+    expect(screen.queryByTestId('sample-prompt-expand')).toBeNull();
+    expect(screen.getByTestId('sample-prompt-collapse')).toBeInTheDocument();
+    // Click collapse.
+    fireEvent.click(screen.getByTestId('sample-prompt-collapse'));
+    expect(screen.getByTestId('sample-prompt-container').className).toContain('max-h-[13rem]');
+  });
+
+  it('ac-10: advances the moment hasSpec transitions to true (spec completes on hasSpec)', async () => {
+    tagAc(AC421(10));
+    vi.useFakeTimers();
+    fetchJourneyStateApi
+      .mockResolvedValueOnce({ milestones: { hasSpec: false } })
+      .mockResolvedValue({ milestones: { hasSpec: true } });
+    const onComplete = vi.fn();
+    render(<CreateFirstSpecStep onComplete={onComplete} />);
+    await vi.advanceTimersByTimeAsync(0); // first read — not yet, no advance
+    expect(onComplete).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(4000); // next poll sees the transition
+    await vi.advanceTimersByTimeAsync(1400);
+    expect(onComplete).toHaveBeenCalled();
+  });
+
+  it('ac-10: does NOT advance when hasSpec is already true on arrival (revisiting a done step)', async () => {
+    tagAc(AC421(10));
+    vi.useFakeTimers();
+    fetchJourneyStateApi.mockResolvedValue({ milestones: { hasSpec: true } });
+    const onComplete = vi.fn();
+    render(<CreateFirstSpecStep onComplete={onComplete} />);
+    await vi.advanceTimersByTimeAsync(0); // first read — already met: show done, no advance
+    await vi.advanceTimersByTimeAsync(4000);
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(onComplete).not.toHaveBeenCalled();
+    const badge = screen.getByTestId('create-first-spec-done');
+    expect(badge.textContent).toContain('Created');
+    expect(badge.textContent).toContain('✓');
+    expect(badge.className).toContain('rounded-full');
+  });
+
+  it('ac-11: no method selector or starting-point selector', () => {
+    tagAc(AC421(11));
+    render(<CreateFirstSpecStep preview />);
+    // No method (agent/in-app) or source (sample/prd) chips.
+    expect(screen.queryByTestId('source-sample')).toBeNull();
+    expect(screen.queryByTestId('source-prd')).toBeNull();
+    expect(screen.queryByTestId('method-agent')).toBeNull();
+    expect(screen.queryByTestId('method-app')).toBeNull();
+  });
+});

--- a/packages/ui/src/components/home/CreateFirstSpecStep.tsx
+++ b/packages/ui/src/components/home/CreateFirstSpecStep.tsx
@@ -1,0 +1,150 @@
+// spec-421 — step 2 "Create your first spec". Split out from CreateSpecStep's Stage 2
+// (spec-336/372). Completes on hasSpec. Simplified: no method/starting-point toggles;
+// a blue CTA navigates to the Specs page with ?new=1 to open the New Spec dialog, plus
+// a collapsible sample-prompt helper for users who want to use their coding agent.
+import { useEffect, useRef, useState } from 'react';
+import { CopyButton } from '../CodeBlock';
+import { StepDoneBadge } from './StepDoneBadge';
+import { fetchJourneyStateApi } from '../../api/journey';
+import { SAMPLE_PROMPT } from '../../utils/createSpecPrompts';
+
+export function CreateFirstSpecStep({
+  preview = false,
+  onComplete,
+  onCreateInApp,
+  onCtaClick,
+}: {
+  preview?: boolean;
+  onComplete?: () => void;
+  onCreateInApp?: () => void;
+  onCtaClick?: (target: string) => void;
+} = {}) {
+  const [done, setDone] = useState(false);
+  const [expanded, setExpanded] = useState(false);
+  const doneRef = useRef(false);
+  const initRef = useRef(false);
+
+  useEffect(() => {
+    if (preview) return;
+    let alive = true;
+    const tick = async () => {
+      try {
+        const s = await fetchJourneyStateApi();
+        if (!alive) return;
+        const hasSpec = !!s.milestones?.hasSpec;
+        // First read: if spec already exists the user is revisiting — show done but
+        // do NOT advance (spec-336 dec-6: viewing never bumps you forward).
+        if (!initRef.current) {
+          initRef.current = true;
+          if (hasSpec) {
+            doneRef.current = true;
+            setDone(true);
+          }
+          return;
+        }
+        if (hasSpec && !doneRef.current) {
+          doneRef.current = true;
+          setDone(true);
+          setTimeout(() => onComplete?.(), 1400);
+        }
+      } catch {
+        /* best-effort */
+      }
+    };
+    void tick();
+    const id = setInterval(() => void tick(), 4000);
+    return () => {
+      alive = false;
+      clearInterval(id);
+    };
+  }, [preview, onComplete]);
+
+  return (
+    <div data-testid="journey-step-create-first-spec" className="animate-[panelIn_0.35s_ease] max-w-3xl">
+      <div className="flex items-start justify-between gap-3 mb-4">
+        <div>
+          <h2 className="onboarding-heading">
+            {done ? 'Created your first spec' : 'Create your first spec'}
+          </h2>
+        </div>
+        {done && <StepDoneBadge label="Created" testId="create-first-spec-done" />}
+      </div>
+
+      {done ? (
+        <p className="mb-6 text-xl font-medium leading-snug text-primary">
+          Nice work — your first spec is in Memex. You&apos;re all set.
+        </p>
+      ) : (
+        <>
+          <p className="mb-8 text-xl font-medium leading-snug text-primary">
+            Get the full magic of Memex by connecting to the MCP and using it in your Agent
+          </p>
+
+          {/* Primary CTA — opens New Spec dialog on the Specs page via ?new=1 (dec-4). */}
+          <button
+            type="button"
+            data-testid="create-first-spec-btn"
+            onClick={() => {
+              onCtaClick?.('create_spec');
+              onCreateInApp?.();
+            }}
+            className="mb-8 inline-flex items-center gap-2 rounded-xl bg-accent px-6 py-3.5 text-base font-bold text-on-accent shadow-lg transition hover:bg-accent-hover"
+          >
+            Create your first spec
+            <span aria-hidden>→</span>
+          </button>
+
+          {/* Sample prompt helper — collapsible, ~10 lines visible, copy button. */}
+          <div data-testid="sample-prompt-helper" className="rounded-2xl border border-edge bg-surface p-5">
+            <p className="mb-3 text-sm text-secondary">
+              Need some help getting started? Use our sample prompt to create a spec in your Agent.
+            </p>
+            <div className="relative">
+              {/* Truncated to ~10 lines (line-height ~1.5 × 14px font ≈ 21px × 10 = 210px). */}
+              <div
+                data-testid="sample-prompt-container"
+                className={`overflow-hidden transition-all duration-300 ${expanded ? '' : 'max-h-[13rem]'}`}
+              >
+                <pre className="whitespace-pre-wrap break-words rounded-lg border border-edge bg-surface p-4 pr-20 text-sm leading-relaxed text-primary">
+                  <code>{SAMPLE_PROMPT}</code>
+                </pre>
+              </div>
+              <div className="absolute right-2 top-2">
+                <CopyButton text={SAMPLE_PROMPT} onCopy={() => onCtaClick?.('copy_create_prompt')} />
+              </div>
+              {!expanded && (
+                <div className="absolute bottom-0 left-0 right-0 flex justify-center bg-gradient-to-t from-surface pb-2 pt-8">
+                  <button
+                    type="button"
+                    data-testid="sample-prompt-expand"
+                    onClick={() => setExpanded(true)}
+                    className="rounded-md bg-card-hover px-3 py-1 text-xs font-semibold text-secondary transition hover:text-primary"
+                  >
+                    Show more
+                  </button>
+                </div>
+              )}
+            </div>
+            {expanded && (
+              <button
+                type="button"
+                data-testid="sample-prompt-collapse"
+                onClick={() => setExpanded(false)}
+                className="mt-2 text-xs font-semibold text-secondary transition hover:text-primary"
+              >
+                Show less
+              </button>
+            )}
+          </div>
+
+          <div className="mt-5" data-testid="create-first-spec-status">
+            <div className="flex items-center gap-2.5 text-sm text-muted">
+              <span className="h-2.5 w-2.5 flex-none animate-pulse rounded-full bg-accent" />
+              Waiting for your agent to create the spec — this advances the moment it does.
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/packages/ui/src/components/home/CreateSpecStep.test.tsx
+++ b/packages/ui/src/components/home/CreateSpecStep.test.tsx
@@ -1,43 +1,44 @@
-// spec-305 — the create-spec step (copy-paste prompt + BYO PRD / sample, dec-9).
-// ac-14 — the card presents a prompt + a built-in sample, and uploads nothing.
-// ac-4  — the canvas self-advances the moment the spec exists (hasSpec).
+// spec-305 / spec-336 — step 1 "Connect to the Memex MCP".
+// spec-421: Stage 2 (create the spec) moved to CreateFirstSpecStep. This step now
+// completes on mcpConnected (was hasSpec). The tests below cover the MCP-connect flow only.
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { tagAc } from '@memex-ai-ac/vitest';
 
 const fetchJourneyStateApi = vi.hoisted(() => vi.fn());
 vi.mock('../../api/journey', () => ({ fetchJourneyStateApi }));
 
 import { CreateSpecStep } from './CreateSpecStep';
-const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-305/acs/ac-${n}`;
 const AC372 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-372/acs/ac-${n}`;
+const AC421 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-421/acs/ac-${n}`;
 
 beforeEach(() => {
   fetchJourneyStateApi.mockReset();
-  fetchJourneyStateApi.mockResolvedValue({ milestones: { hasSpec: false } });
+  fetchJourneyStateApi.mockResolvedValue({ milestones: { mcpConnected: false } });
 });
 afterEach(() => {
   vi.useRealTimers();
 });
 
-describe('CreateSpecStep', () => {
-  it('defaults to the sample prompt and can switch to a BYO-PRD prompt', () => {
-    tagAc(AC(14));
+describe('CreateSpecStep — spec-421: MCP connect only, completes on mcpConnected', () => {
+  it('renders the MCP connect card with no Stage-2 prompt or source selectors', () => {
+    tagAc(AC421(4)); // step 2 shows MCP connect card only, no "Create Your First Spec" section
+    tagAc(AC421(11)); // no method selector / starting-point selector
     render(<CreateSpecStep preview />);
     expect(screen.getByTestId('journey-step-create-spec')).toBeInTheDocument();
-    expect(screen.getByTestId('create-spec-prompt').textContent).toMatch(/Orders Dashboard/);
-    fireEvent.click(screen.getByTestId('source-prd'));
-    expect(screen.getByTestId('create-spec-prompt').textContent).toMatch(/PRD/);
-    // no file input — the agent reads the source locally (no Memex-side upload).
-    expect(document.querySelector('input[type="file"]')).toBeNull();
+    expect(screen.getByTestId('connect-stage')).toBeInTheDocument();
+    // Stage 2 elements are gone (moved to CreateFirstSpecStep).
+    expect(screen.queryByTestId('create-spec-prompt')).toBeNull();
+    expect(screen.queryByTestId('source-sample')).toBeNull();
+    expect(screen.queryByTestId('source-prd')).toBeNull();
   });
 
-  it('advances the moment the spec is created while the step is open (hasSpec transition)', async () => {
-    tagAc(AC(4));
+  it('advances the moment MCP is connected while the step is open (mcpConnected transition)', async () => {
+    tagAc(AC421(5)); // step 2 completes on mcpConnected
     vi.useFakeTimers();
     fetchJourneyStateApi
-      .mockResolvedValueOnce({ milestones: { hasSpec: false } }) // on arrival: not yet created
-      .mockResolvedValue({ milestones: { hasSpec: true } }); // a later poll: the agent created it
+      .mockResolvedValueOnce({ milestones: { mcpConnected: false } }) // on arrival: not yet connected
+      .mockResolvedValue({ milestones: { mcpConnected: true } }); // a later poll: MCP connected
     const onComplete = vi.fn();
     render(<CreateSpecStep onComplete={onComplete} />);
     await vi.advanceTimersByTimeAsync(0); // first read — not met, no advance
@@ -47,28 +48,27 @@ describe('CreateSpecStep', () => {
     expect(onComplete).toHaveBeenCalled();
   });
 
-  it('does NOT advance when the spec already exists on arrival (revisiting a completed step)', async () => {
-    // spec-336 dec-6: viewing a step you already finished shows it as done but must never
-    // bump you forward to the next step.
-    tagAc(AC(4));
-    tagAc(AC372(46)); // spec-372 issue-17 — done shows the "✓ Created" badge
+  it('does NOT advance when MCP is already connected on arrival (revisiting a completed step)', async () => {
+    // spec-336 dec-6: viewing a step you already finished shows it as connected but must
+    // never bump you forward. spec-421: connected badge replaces the old "Created" badge.
+    tagAc(AC421(5));
     vi.useFakeTimers();
-    fetchJourneyStateApi.mockResolvedValue({ milestones: { hasSpec: true } });
+    fetchJourneyStateApi.mockResolvedValue({ milestones: { mcpConnected: true } });
     const onComplete = vi.fn();
     render(<CreateSpecStep onComplete={onComplete} />);
-    await vi.advanceTimersByTimeAsync(0); // first read — already met: show done, suppress advance
-    await vi.advanceTimersByTimeAsync(4000); // a later poll still met, but the arrival was consumed
-    await vi.advanceTimersByTimeAsync(2000); // well past any advance window
+    await vi.advanceTimersByTimeAsync(0); // first read — already met: show connected, suppress advance
+    await vi.advanceTimersByTimeAsync(4000); // later poll still met, arrival already consumed
+    await vi.advanceTimersByTimeAsync(2000);
     expect(onComplete).not.toHaveBeenCalled();
-    const badge = screen.getByTestId('create-spec-done');
-    expect(badge.textContent).toContain('Created');
+    const badge = screen.getByTestId('create-spec-connected');
+    expect(badge.textContent).toContain('Connected');
     expect(badge.textContent).toContain('✓');
-    expect(badge.className).toContain('rounded-full'); // pill, not the old dot+sentence
+    expect(badge.className).toContain('rounded-full');
   });
 });
 
-describe('CreateSpecStep — spec-372 step-1 polish (issues 5/6/9/12)', () => {
-  it('issue-5: the subtitle "Memex" has no glossary tooltip', () => {
+describe('CreateSpecStep — spec-372 step-1 polish (issues 5/6)', () => {
+  it('issue-5: the subtitle has no glossary tooltip', () => {
     tagAc(AC372(33));
     render(<CreateSpecStep preview />);
     expect(screen.getByText(/Get the full magic of Memex/)).toBeInTheDocument();
@@ -78,28 +78,7 @@ describe('CreateSpecStep — spec-372 step-1 polish (issues 5/6/9/12)', () => {
   it('issue-6: the Connect-MCP card shows no manual OS selector', () => {
     tagAc(AC372(34));
     render(<CreateSpecStep preview />);
-    // claude-code is the default tool (OS-dependent) — the OS toggle is still absent.
     expect(screen.queryByTestId('os-mac')).toBeNull();
     expect(screen.queryByText('Your machine')).toBeNull();
-  });
-
-  it('issue-9: the selected starting-point chip is white-filled with an accent border + text', () => {
-    tagAc(AC372(37));
-    render(<CreateSpecStep preview />);
-    const selected = screen.getByTestId('source-sample'); // default selection
-    expect(selected.className).toContain('bg-surface');
-    expect(selected.className).toContain('border-accent');
-    expect(selected.className).toContain('text-accent');
-    expect(selected.className).not.toContain('bg-accent/10');
-  });
-
-  it('issue-12: the "Point at my PRD" prompt is the short version with the fill-in path placeholder', () => {
-    tagAc(AC372(40));
-    render(<CreateSpecStep preview />);
-    fireEvent.click(screen.getByTestId('source-prd'));
-    const text = screen.getByTestId('create-spec-prompt').textContent ?? '';
-    expect(text).toMatch(/<your path to our PRD>/);
-    expect(text).not.toMatch(/Surface the decisions/i);
-    expect(text).not.toMatch(/scope acceptance criteria/i);
   });
 });

--- a/packages/ui/src/components/home/CreateSpecStep.tsx
+++ b/packages/ui/src/components/home/CreateSpecStep.tsx
@@ -1,65 +1,32 @@
-// spec-336 — step 1 "Create your spec" (v2). Flat, full-width, two numbered stages:
-// Stage 1 connects the coding agent to Memex over MCP (reusing the built per-tool/OS
-// installer — dec-4, never the flat INT one-liner), Stage 2 creates the first spec with
-// that agent or in the app. The STEP advances on the hasSpec milestone; Stage 1's
-// connection shows inline (a green tick on mcpConnected) but is not itself a gate.
+// spec-336 — step 1 "Connect to the Memex MCP" (v2 originally had two stages; spec-421
+// splits it: this component shows Stage 1 (MCP install) only, completing on mcpConnected.
+// Stage 2 (create the spec) moved to CreateFirstSpecStep / step "create-first-spec".
 import { useEffect, useRef, useState } from 'react';
-import { CodeBlock } from '../CodeBlock';
-import { StepDoneBadge } from './StepDoneBadge';
 import { fetchJourneyStateApi } from '../../api/journey';
 import { Instructions, TOOLS, detectOs, type Os, type Tool } from './ConnectAgentStep';
-// spec-372 — clipboard prompt prose lives in a dedicated util module (std-23 / b-68
-// prose-location guard), not inline here. These are human-pasted prompts for the user's
-// own coding agent, not Mindset-agent prose, so they sit alongside genesisPrompt.ts.
-import {
-  SAMPLE_PROMPT,
-  PRD_PROMPT,
-  APP_SAMPLE_PROMPT,
-  APP_PRD_PROMPT,
-  EXPLORE_PROMPT,
-  DOCS_HREF,
-} from '../../utils/createSpecPrompts';
+import { EXPLORE_PROMPT, DOCS_HREF } from '../../utils/createSpecPrompts';
 
-type Source = 'prd' | 'sample';
-type Method = 'agent' | 'app';
-
-// spec-372 issue-9 — selected chips are WHITE-filled (bg-surface), keeping the accent
-// border + accent text as the selection cue (consistent with the white method toggle).
+// spec-372 issue-9 — selected chips are WHITE-filled (bg-surface).
 const chip = (selected: boolean) =>
   `rounded-lg border px-4 py-2 text-sm transition ${
     selected ? 'border-accent bg-surface font-semibold text-accent' : 'border-edge text-secondary hover:bg-card-hover'
   }`;
 
-// spec-372 t-13 — v3 stage heading: 28px / 600, no number prefix (the v2 mono "1/2" is gone).
-function StageHeading({ title, sub, compact = false }: { title: string; sub: string; compact?: boolean }) {
-  return (
-    <div className={compact ? '' : 'mb-4'}>
-      <div className="text-[28px] font-semibold leading-tight tracking-[-0.015em] text-heading">{title}</div>
-      <div className="mt-1 text-base text-secondary">{sub}</div>
-    </div>
-  );
-}
-
 export function CreateSpecStep({
   preview = false,
   onComplete,
-  onCreateInApp,
   onCtaClick,
 }: {
   preview?: boolean;
   onComplete?: () => void;
-  onCreateInApp?: () => void;
   onCtaClick?: (target: string) => void;
 } = {}) {
   // spec-372 issue-6 — OS is auto-detected; the manual "Your machine" selector is removed.
   const [os] = useState<Os>(detectOs);
   const [tool, setTool] = useState<Tool>('claude-code');
-  const [method, setMethod] = useState<Method>('agent');
-  const [source, setSource] = useState<Source>('sample');
   const [connected, setConnected] = useState(false);
-  const [done, setDone] = useState(false);
   const [exploreCopied, setExploreCopied] = useState(false);
-  const doneRef = useRef(false);
+  const connectedRef = useRef(false);
   const initRef = useRef(false);
 
   // spec-372 change #13 — copy the doc-grounded evaluation prompt to the clipboard.
@@ -74,6 +41,7 @@ export function CreateSpecStep({
     setTimeout(() => setExploreCopied(false), 1600);
   };
 
+  // spec-421: step completes on mcpConnected (was hasSpec in spec-336).
   useEffect(() => {
     if (preview) return;
     let alive = true;
@@ -81,24 +49,19 @@ export function CreateSpecStep({
       try {
         const s = await fetchJourneyStateApi();
         if (!alive) return;
-        if (s.milestones?.mcpConnected) setConnected(true);
-        const hasSpec = !!s.milestones?.hasSpec;
-        // First read after this step opens. If the spec already exists the user is
-        // REVISITING a completed step — show it as done but do NOT advance them off it
-        // (spec-336 dec-6: viewing never bumps you forward). Only a hasSpec transition
-        // observed while the step is open advances the canvas.
+        const isConnected = !!s.milestones?.mcpConnected;
         if (!initRef.current) {
           initRef.current = true;
-          if (hasSpec) {
-            doneRef.current = true;
-            setDone(true);
+          if (isConnected) {
+            connectedRef.current = true;
+            setConnected(true);
           }
           return;
         }
-        if (hasSpec) {
-          setDone(true);
-          if (!doneRef.current) {
-            doneRef.current = true;
+        if (isConnected) {
+          setConnected(true);
+          if (!connectedRef.current) {
+            connectedRef.current = true;
             setTimeout(() => onComplete?.(), 1400);
           }
         }
@@ -114,16 +77,14 @@ export function CreateSpecStep({
     };
   }, [preview, onComplete]);
 
-
   return (
     <div data-testid="journey-step-create-spec" className="animate-[panelIn_0.35s_ease] max-w-3xl">
       <h2 className="onboarding-heading mb-4">
-        Build exactly what you decided
+        Connect to the Memex MCP
       </h2>
       {/* spec-372 t-13 — v3 subtitle weight is 500 (medium), not bold. */}
       <p className="mb-4 text-xl font-medium leading-snug text-primary">
-        Get the full magic of Memex by connecting to the MCP and using it in
-        your coding agent
+        Get the full magic of Memex by connecting to the MCP and using it in your Agent
       </p>
       {/* spec-372 change #13 — "New to the MCP?" helper: docs link + Copy-a-prompt-for-your-agent. */}
       <p className="mb-7 flex flex-wrap items-center gap-x-2 gap-y-1 text-base text-secondary">
@@ -149,27 +110,26 @@ export function CreateSpecStep({
         </button>
       </p>
 
-      {/* Stage 1 — Connect to Memex MCP (reuses the real per-tool/OS installer).
-          spec-372 t-13 — v3 highlights this card: 1.5px accent border + a soft accent glow ring.
-          spec-372 issue-19 — once connected the card transitions to a muted completed style. */}
+      {/* Connect to Memex MCP card — spec-372 t-13 / issue-19 done-state styling. */}
       <section
         data-testid="connect-stage"
-        className={`mb-5 rounded-2xl p-6 transition-all duration-300 ${
+        className={`rounded-2xl p-6 transition-all duration-300 ${
           connected
             ? 'border border-edge bg-surface'
             : 'border-[1.5px] border-accent bg-surface ring-[5px] ring-accent/10'
         }`}
       >
         <div className="flex items-start justify-between gap-3">
-          <StageHeading
-            title={connected ? 'Connected to the Memex MCP' : 'Connect to the Memex MCP'}
-            sub={
-              connected
+          <div className={connected ? '' : 'mb-4'}>
+            <div className="text-[28px] font-semibold leading-tight tracking-[-0.015em] text-heading">
+              {connected ? 'Connected to the Memex MCP' : 'Connect to the Memex MCP'}
+            </div>
+            <div className="mt-1 text-base text-secondary">
+              {connected
                 ? "You're connected to the Memex MCP. Need to make changes? Manage it any time from the Integrations page under your profile menu."
-                : 'Use the command below to install the MCP for your coding agent.'
-            }
-            compact={connected}
-          />
+                : 'Use the command below to install the MCP for your coding agent.'}
+            </div>
+          </div>
           {connected && (
             <span
               data-testid="create-spec-connected"
@@ -182,8 +142,7 @@ export function CreateSpecStep({
 
         {!connected && (
           <>
-            {/* spec-372 issue-6 — OS selector removed; `os` is auto-detected and the
-                install command below reflects it without a manual toggle. */}
+            {/* spec-372 issue-6 — OS selector removed; `os` is auto-detected. */}
             <div className="mb-3">
               <span className="mb-2 block text-sm font-medium text-secondary">Your coding agent</span>
               <div className="flex flex-wrap gap-2">
@@ -205,118 +164,6 @@ export function CreateSpecStep({
             </div>
             <div data-testid="connect-instructions">
               <Instructions tool={tool} os={os} onCopy={() => onCtaClick?.('copy_install')} />
-            </div>
-          </>
-        )}
-      </section>
-
-      {/* Stage 2 — Create your first spec.
-          spec-372 issue-19 — blue focus ring moves here once MCP connected; muted when done. */}
-      <section
-        data-testid="create-stage"
-        className={`rounded-2xl p-6 transition-all duration-300 ${
-          done
-            ? 'border border-edge bg-surface'
-            : connected
-              ? 'border-[1.5px] border-accent bg-surface ring-[5px] ring-accent/10'
-              : 'border border-edge bg-surface'
-        }`}
-      >
-        {/* spec-372 issue-17 — the created state is a "✓ Created" badge by the heading,
-            mirroring Stage-1's "✓ Connected" badge (not a sentence at the bottom). */}
-        <div className="flex items-start justify-between gap-3">
-          <StageHeading
-            title={done ? 'Created your first spec' : 'Create your first spec'}
-            sub={
-              done
-                ? 'Nice work, your first spec is in Memex. Next up, your agent surfaces the key decisions and locks in acceptance criteria, so your build starts on solid ground.'
-                : 'Draft your first spec with your coding agent, or create it here in the app.'
-            }
-            compact={done}
-          />
-          {done && <StepDoneBadge label="Created" testId="create-spec-done" />}
-        </div>
-
-        {!done && (
-          <>
-            <div className="mb-5 inline-flex gap-1 rounded-xl bg-card-hover p-1">
-              {(['agent', 'app'] as Method[]).map((m) => (
-                <button
-                  key={m}
-                  type="button"
-                  data-testid={`method-${m}`}
-                  onClick={() => {
-                    setMethod(m);
-                    onCtaClick?.('create_method');
-                  }}
-                  className={`rounded-lg px-4 py-2 text-sm font-semibold transition ${
-                    method === m ? 'bg-surface text-accent shadow-sm' : 'text-muted hover:text-secondary'
-                  }`}
-                >
-                  {m === 'agent' ? 'With your coding agent' : 'In the app'}
-                </button>
-              ))}
-            </div>
-
-            <span className="mb-2.5 block text-sm font-semibold text-primary">Starting point</span>
-            <div className="mb-4 flex flex-wrap gap-2.5">
-              <button
-                type="button"
-                data-testid="source-sample"
-                onClick={() => {
-                  setSource('sample');
-                  onCtaClick?.('starting_point');
-                }}
-                className={chip(source === 'sample')}
-              >
-                Use our sample
-              </button>
-              <button
-                type="button"
-                data-testid="source-prd"
-                onClick={() => {
-                  setSource('prd');
-                  onCtaClick?.('starting_point');
-                }}
-                className={chip(source === 'prd')}
-              >
-                Point at my PRD
-              </button>
-            </div>
-
-            {method === 'agent' ? (
-              <div data-testid="create-spec-prompt">
-                <CodeBlock code={source === 'sample' ? SAMPLE_PROMPT : PRD_PROMPT} onCopy={() => onCtaClick?.('copy_create_prompt')} />
-              </div>
-            ) : (
-              <>
-                {/* spec-372 — the in-app method also shows the (fleshed-out) prompt, matching v3. */}
-                <div className="mb-4" data-testid="create-spec-app-prompt">
-                  <CodeBlock
-                    code={source === 'sample' ? APP_SAMPLE_PROMPT : APP_PRD_PROMPT}
-                    onCopy={() => onCtaClick?.('copy_create_prompt')}
-                  />
-                </div>
-                <button
-                  type="button"
-                  data-testid="create-spec-in-app"
-                  onClick={() => {
-                    onCtaClick?.('create_spec');
-                    onCreateInApp?.();
-                  }}
-                  className="inline-flex items-center gap-2 rounded-xl bg-accent px-6 py-3.5 text-base font-bold text-on-accent shadow-lg transition hover:bg-accent-hover"
-                >
-                  Create spec in Memex
-                  <span aria-hidden>→</span>
-                </button>
-              </>
-            )}
-
-            <div className="mt-5" data-testid="create-spec-status">
-              <div className="flex items-center gap-2.5 text-sm text-muted">
-                <span className="h-2.5 w-2.5 flex-none animate-pulse rounded-full bg-accent" />
-                Waiting for your agent to create the spec — this advances the moment it does.
-              </div>
             </div>
           </>
         )}

--- a/packages/ui/src/components/home/IdentityStep.test.tsx
+++ b/packages/ui/src/components/home/IdentityStep.test.tsx
@@ -101,8 +101,12 @@ describe('IdentityStep (v2)', () => {
     expect(name).toBe('Jane Roe');
   });
 
-  it('spec-372 issue-4: the name field shows a confirm tick only after typing, and the tick submits', async () => {
+  it('spec-372 issue-4: the name field shows a confirm tick only after typing; spec-421 t-1: the tick blurs (does not submit)', async () => {
+    // spec-372 issue-4 / ac-32: tick appears after typing. spec-421 t-1 fixes the Enter-submits
+    // bug by making the tick blur the field only — Continue is the sole step-advance path.
     tagAc(AC372(32));
+    const AC421 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-421/acs/ac-${n}`;
+    tagAc(AC421(1));
     authUser.value = { id: 'u-2', name: '', email: 'jane@example.com' };
     render(<IdentityStep />);
     // Hidden while the field is empty.
@@ -111,8 +115,11 @@ describe('IdentityStep (v2)', () => {
     fireEvent.change(screen.getByTestId('identity-name'), { target: { value: 'Jane' } });
     const confirm = screen.getByTestId('identity-name-confirm');
     expect(confirm).toBeInTheDocument();
-    // Clicking it submits like Continue (persists the typed name).
+    // Clicking the tick blurs the field — it does NOT submit (spec-421 t-1: Continue is the sole submit path).
     fireEvent.click(confirm);
+    expect(updateProfileApi).not.toHaveBeenCalled();
+    // Continue still submits normally.
+    fireEvent.click(screen.getByTestId('identity-continue'));
     await waitFor(() => expect(updateProfileApi).toHaveBeenCalledTimes(1));
     expect(updateProfileApi.mock.calls[0][1]).toBe('Jane');
   });

--- a/packages/ui/src/components/home/IdentityStep.tsx
+++ b/packages/ui/src/components/home/IdentityStep.tsx
@@ -73,9 +73,10 @@ export function IdentityStep({
         Built around how you work
       </h2>
 
-      {/* spec-372 issue-4 — for nameless (native-auth) users the name field sits directly
-          below the heading, above the intro copy. The ✓ confirm button appears only once a
-          name has been typed (hidden while empty) and submits the step like Continue. */}
+      {/* spec-421 t-1 — for nameless (native-auth) users the name field sits directly
+          below the heading, above the intro copy. The ✓ confirm button appears once a name
+          has been typed and blurs the field (name-commit only — it does NOT advance the step).
+          Enter key is intentionally inert: Continue is the sole step-advance action. */}
       {needsName && (
         <div className="mb-6 max-w-sm">
           <label htmlFor="identity-name" className="mb-1.5 block text-sm font-semibold text-secondary">
@@ -88,9 +89,6 @@ export function IdentityStep({
               type="text"
               value={name}
               onChange={(e) => setName(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter' && name.trim()) submit(role);
-              }}
               placeholder="How should we address you?"
               className="w-full rounded-xl border border-edge bg-surface py-3 pl-4 pr-14 text-base text-primary outline-hidden transition focus:border-accent"
             />
@@ -99,7 +97,7 @@ export function IdentityStep({
                 type="button"
                 data-testid="identity-name-confirm"
                 aria-label="Confirm your name"
-                onClick={() => submit(role)}
+                onClick={() => document.getElementById('identity-name')?.blur()}
                 className="absolute right-2 top-1/2 inline-flex h-9 w-9 -translate-y-1/2 items-center justify-center rounded-lg bg-accent text-on-accent transition hover:bg-accent-hover"
               >
                 <span aria-hidden>✓</span>

--- a/packages/ui/src/components/home/journey-cta.spec-324.test.tsx
+++ b/packages/ui/src/components/home/journey-cta.spec-324.test.tsx
@@ -25,6 +25,7 @@ import { WelcomeStep } from './WelcomeStep';
 import { IdentityStep } from './IdentityStep';
 import { ConnectAgentStep } from './ConnectAgentStep';
 import { CreateSpecStep } from './CreateSpecStep';
+import { CreateFirstSpecStep } from './CreateFirstSpecStep';
 import { AgentPromptStep } from './AgentPromptStep';
 import { SeeGreenStep } from './SeeGreenStep';
 
@@ -68,13 +69,15 @@ describe('custom journey steps fire onCtaClick on their primary interaction (spe
     await waitFor(() => expect(onCtaClick).toHaveBeenCalledWith('copy_install'));
   });
 
-  it('create-spec → "copy_create_prompt" on copying the prompt', async () => {
-    // spec-372 t-10 (dec-6 Layer C) — the create-spec prompt copy now emits the specific
-    // cta discriminator `copy_create_prompt` (was the generic `copy_prompt`).
+  it('create-first-spec → "copy_create_prompt" on copying the sample prompt', async () => {
+    // spec-421 t-3b: the copy_create_prompt CTA moved from CreateSpecStep's Stage-2 prompt
+    // to CreateFirstSpecStep's collapsible sample-prompt helper (spec-372 t-10 dec-6 intent preserved).
+    const AC421 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-421/acs/ac-${n}`;
     tagAc(AC2);
+    tagAc(AC421(9)); // copying the sample prompt emits copy_create_prompt
     const onCtaClick = vi.fn();
-    render(<CreateSpecStep onCtaClick={onCtaClick} />);
-    await clickCopyWithin('create-spec-prompt');
+    render(<CreateFirstSpecStep preview onCtaClick={onCtaClick} />);
+    await clickCopyWithin('sample-prompt-helper');
     await waitFor(() => expect(onCtaClick).toHaveBeenCalledWith('copy_create_prompt'));
   });
 

--- a/packages/ui/src/components/home/onboarding-copy.spec-372.test.tsx
+++ b/packages/ui/src/components/home/onboarding-copy.spec-372.test.tsx
@@ -16,6 +16,7 @@ vi.mock('../../api/journey', async () => {
 });
 
 import { CreateSpecStep } from './CreateSpecStep';
+import { CreateFirstSpecStep } from './CreateFirstSpecStep';
 import { SpecsMatchRealityStep } from './SpecsMatchRealityStep';
 import { RoleTriangle, CENTERED_ROLE, personaLabel, personaPromise } from './RoleTriangle';
 
@@ -67,32 +68,30 @@ describe('spec-372 — v3 role triangle (ac-29, ac-2)', () => {
 });
 
 describe('spec-372 — step-1 reframe + prompts (ac-17, ac-18, ac-19)', () => {
-  it('ac-19: step-1 presents the reframed copy with no trailing period on the header', () => {
+  it('ac-19: step-1 presents the renamed "Connect to the Memex MCP" copy with no trailing period', () => {
+    // spec-421 t-2: step 2 renamed from "Build exactly what you decided" →
+    // "Connect to the Memex MCP". Stage-2 prose removed from this step.
     tagAc(AC(19));
     const { container } = render(<CreateSpecStep preview />);
-    const h2 = screen.getByText('Build exactly what you decided');
-    expect(h2.tagName).toBe('H2');
-    expect(h2.textContent?.trim().endsWith('.')).toBe(false);
-    // spec-372 issue-5 — the "Memex" glossary tooltip was removed, so the subtitle is now
-    // plain text; assert on the rendered text content.
-    expect(container.textContent).toContain(
-      'Get the full magic of Memex by connecting to the MCP and using it in your coding agent',
-    );
-    expect(screen.getByText('Connect to the Memex MCP')).toBeInTheDocument();
-    expect(
-      screen.getByText('Draft your first spec with your coding agent, or create it here in the app.'),
-    ).toBeInTheDocument();
+    const h2 = container.querySelector('h2');
+    expect(h2).not.toBeNull();
+    expect(h2!.textContent?.trim()).toBe('Connect to the Memex MCP');
+    expect(h2!.textContent?.trim().endsWith('.')).toBe(false);
+    // Subtitle still references the MCP magic.
+    expect(container.textContent).toContain('Get the full magic of Memex by connecting to the MCP');
+    // Stage-2 prose no longer in CreateSpecStep (moved to CreateFirstSpecStep).
+    expect(screen.queryByText(/Draft your first spec/)).toBeNull();
   });
 
-  it('ac-17: the agent-method sample prompt instructs create AND fully flesh out a rich spec (not bare create_doc)', () => {
+  it('ac-17: the sample prompt in step-3 (CreateFirstSpecStep) instructs create AND fully flesh out a rich spec', () => {
+    // spec-421: the rich sample prompt moved from CreateSpecStep (Stage 2) to
+    // CreateFirstSpecStep's collapsible helper. The richness requirement still holds.
     tagAc(AC(17));
     tagAc(AC(39)); // spec-372 issue-11
-    render(<CreateSpecStep preview />);
-    const prompt = within(screen.getByTestId('create-spec-prompt')).getByText(/Using the Memex MCP/);
-    const text = prompt.textContent ?? '';
-    // spec-372 issue-11 — the sample prompt is a rich PRD-style starting point: create + fully
-    // flesh out, a rich purpose narrative ("not just a feature list"), and dedicated spec
-    // sections — i.e. far more than a bare create_doc call.
+    render(<CreateFirstSpecStep preview />);
+    const container = screen.getByTestId('sample-prompt-container');
+    const text = container.textContent ?? '';
+    // The sample prompt is a rich PRD-style starting point.
     expect(text).toMatch(/create and fully flesh out/i);
     expect(text).toMatch(/not just a feature list/i);
     expect(text).toMatch(/Problem section/i);

--- a/packages/ui/src/journeys/onboarding/steps.tsx
+++ b/packages/ui/src/journeys/onboarding/steps.tsx
@@ -1,32 +1,32 @@
 // spec-336 — Home Onboarding v2: the onboarding journey's step metadata.
-// (Supersedes spec-305's MCP-first arc.) The six steps mirror the v2 design's six-node
-// rail one-for-one; the Home Canvas renders the rail from these mapLabel/mapSubLabel
-// pairs and shows the selected step's content in a side panel. Every step's content is
-// a bespoke component (triangle, connect+create card, paste-a-prompt cards, product
-// shots, go-build handoff), so these view entries are primarily the rail's labels — the
-// headline/body fields are a presentational fallback, never the primary surface.
+// spec-421 — v4: condenses to 3 visible steps (About you / Connect to the Memex MCP /
+// Create your first spec). Steps 2–5 are hidden from the rail (code kept for later).
+// The rail reads mapLabel/mapSubLabel; headline/primary are fallbacks only.
 import type { JourneyStepView } from '../types';
 
 // The server-derived steps a user can land on, in order (mirrors the server's
-// journeys/onboarding.ts). The last two are builder-only — the Home Canvas hides them
-// for non-builder personas (spec-336 dec-3) — but the engine still emits all six.
+// journeys/onboarding.ts). Steps 2–5 are hidden from the rail by spec-421 but kept
+// here so the server milestone engine still tracks them.
 export const ONBOARDING_MILESTONE_STEP_IDS = [
   'identity',
   'create-spec',
+  'create-first-spec',
   'resolve-decision',
   'add-ac',
   'specs-match-reality',
   'agents-build',
 ] as const;
 
-// spec-336 dec-3: the two trailing "Build from your codebase" steps a non-builder never
-// sees. The Home Canvas filters the visible step set + the progress-% denominator by
-// removing these for non-builder personas.
+// spec-336 dec-3: builder-only steps. spec-421: steps hidden from the rail entirely
+// (kept in code for future reintroduction).
 export const BUILDER_ONLY_STEP_IDS = ['specs-match-reality', 'agents-build'] as const;
 
+// spec-421 — steps hidden from the rail. Their components are never mounted while hidden
+// so no telemetry, done-state badges, or completion machinery fires.
+export const HIDDEN_STEP_IDS = ['resolve-decision', 'add-ac', 'specs-match-reality', 'agents-build'] as const;
+
 export const ONBOARDING_STEP_VIEWS: Record<string, JourneyStepView> = {
-  // Step 0 — About you. Rendered by IdentityStep (the role triangle) in HomeCanvas, so
-  // the headline/primary here are a fallback only; the rail uses the labels.
+  // Step 0 — About you. Rendered by IdentityStep (the role triangle) in HomeCanvas.
   identity: {
     id: 'identity',
     mapLabel: 'About you',
@@ -35,17 +35,29 @@ export const ONBOARDING_STEP_VIEWS: Record<string, JourneyStepView> = {
     primary: { label: 'Continue', kind: 'navigate', target: 'create-spec' },
   },
 
-  // Step 1 — Create your spec. Rendered by CreateSpecStep (Stage 1 connect MCP + Stage 2
-  // create the spec) in HomeCanvas; ticks on hasSpec.
+  // Step 1 — Connect to the Memex MCP. Rendered by CreateSpecStep (MCP install only).
+  // spec-421: renamed from "Build exactly what you decided"; Stage 2 moved to step 2.
   'create-spec': {
     id: 'create-spec',
-    mapLabel: 'Build exactly what you decided',
-    mapSubLabel: 'Connect to MCP and create your first spec',
-    headline: 'Build exactly what you decided.',
+    mapLabel: 'Connect to the Memex MCP',
+    mapSubLabel: 'Connect to MCP to get the full magic of Memex',
+    headline: 'Connect to the Memex MCP.',
+    primary: { label: 'Continue', kind: 'navigate', target: 'create-first-spec' },
+  },
+
+  // Step 2 — Create your first spec. Rendered by CreateFirstSpecStep; ticks on hasSpec.
+  // spec-421: split out from the old Stage 2 of CreateSpecStep.
+  'create-first-spec': {
+    id: 'create-first-spec',
+    mapLabel: 'Create your first spec',
+    mapSubLabel: 'Draft your first spec',
+    headline: 'Create your first spec.',
     primary: { label: 'Create your first spec', kind: 'action', target: 'create_spec' },
   },
 
-  // Step 2 — Decisions raised. Rendered by AgentPromptStep; ticks on hasResolvedDecision.
+  // Steps below are hidden from the rail (spec-421) — code kept for future reintroduction.
+
+  // Step 3 — Decisions raised. Rendered by AgentPromptStep; ticks on hasResolvedDecision.
   'resolve-decision': {
     id: 'resolve-decision',
     mapLabel: 'No agent decides for you',
@@ -54,8 +66,7 @@ export const ONBOARDING_STEP_VIEWS: Record<string, JourneyStepView> = {
     primary: { label: 'Open your spec', kind: 'action', target: 'open_specs' },
   },
 
-  // Step 3 — Acceptance criteria raised. Rendered by AgentPromptStep; ticks on hasAc.
-  // For non-builders this is the TERMINAL step — HomeCanvas shows the handoff message.
+  // Step 4 — Acceptance criteria raised. Rendered by AgentPromptStep; ticks on hasAc.
   'add-ac': {
     id: 'add-ac',
     mapLabel: 'Done becomes a fact',
@@ -64,8 +75,7 @@ export const ONBOARDING_STEP_VIEWS: Record<string, JourneyStepView> = {
     primary: { label: 'Open your spec', kind: 'action', target: 'open_specs' },
   },
 
-  // Step 4 — Improved from your code (BUILDER-ONLY). Rendered by SpecsMatchRealityStep
-  // (4 product shots + the improve-from-code prompt); ticks on planGrounded (spec-337).
+  // Step 5 — Improved from your code (BUILDER-ONLY). Rendered by SpecsMatchRealityStep.
   'specs-match-reality': {
     id: 'specs-match-reality',
     mapLabel: 'Specs that match reality',
@@ -74,13 +84,12 @@ export const ONBOARDING_STEP_VIEWS: Record<string, JourneyStepView> = {
     primary: { label: 'Open your spec', kind: 'action', target: 'open_specs' },
   },
 
-  // Step 5 — Go build (BUILDER-ONLY, terminal). Rendered by AgentsBuildStep (the go-build
-  // handoff prompt). Terminal: no further waiting/advance.
+  // Step 6 — Go build (BUILDER-ONLY, terminal). Rendered by AgentsBuildStep.
   'agents-build': {
     id: 'agents-build',
     mapLabel: 'Agents build in lockstep',
-    // Reworded from the design's "One coordinated team on your tasks" — std-1 forbids the
-    // reserved noun "team" in user-visible copy (see AgentsBuildStep).
+    // Reworded from the design's "One coordinated team on your tasks" — std-1 forbids
+    // the reserved noun "team" in user-visible copy (see AgentsBuildStep).
     mapSubLabel: 'One coordinated effort across your tasks',
     headline: 'Agents build in lockstep.',
     primary: { label: 'Open your Specs', kind: 'action', target: 'open_specs' },

--- a/packages/ui/src/onAccentToken.spec-167.test.ts
+++ b/packages/ui/src/onAccentToken.spec-167.test.ts
@@ -92,9 +92,12 @@ describe('spec-167: on-accent foreground token', () => {
       .filter((f) => readFileSync(join(SRC_DIR, f), 'utf8').includes('text-on-accent'))
       .map((f) => f.split(sep).join('/'))
       .sort();
+    // spec-421: CreateFirstSpecStep.tsx added as a new text-on-accent consumer
+    // (blue "Create your first spec" CTA button); CreateSpecStep.tsx's Stage-2
+    // "Create spec in Memex" button was removed, so it exits the set.
     expect(consumers).toEqual(
       [
-        'components/home/CreateSpecStep.tsx',
+        'components/home/CreateFirstSpecStep.tsx',
         'components/home/IdentityStep.tsx',
         'components/upgrade/PricingCard.tsx',
         'pages/OauthAuthorize.tsx',

--- a/packages/ui/src/pages/HomeCanvas.spec-372-issue18.test.tsx
+++ b/packages/ui/src/pages/HomeCanvas.spec-372-issue18.test.tsx
@@ -50,8 +50,12 @@ function stateFor(currentStepId: string, steps: Step[]) {
   };
 }
 
+// spec-421: resolve-decision is hidden; must include create-first-spec (not attained) so
+// the journey layer remains visible (otherwise all visible steps are attained → graduated).
 const NOT_GRADUATED: Step[] = [
+  { id: 'identity', attained: true },
   { id: 'create-spec', attained: true },
+  { id: 'create-first-spec', attained: false },
   { id: 'resolve-decision', attained: false },
 ];
 

--- a/packages/ui/src/pages/HomeCanvas.spec-372.test.tsx
+++ b/packages/ui/src/pages/HomeCanvas.spec-372.test.tsx
@@ -54,12 +54,19 @@ function stateFor(currentStepId: string, steps: Step[]) {
   };
 }
 
+// spec-421: resolve-decision is now in HIDDEN_STEP_IDS, so visible steps are filtered to
+// [identity, create-spec, create-first-spec]. NOT_GRADUATED must include at least one
+// non-attained visible step so the journey layer stays open (not graduated).
 const NOT_GRADUATED: Step[] = [
+  { id: 'identity', attained: true },
   { id: 'create-spec', attained: true },
+  { id: 'create-first-spec', attained: false },
   { id: 'resolve-decision', attained: false },
 ];
 const GRADUATED: Step[] = [
+  { id: 'identity', attained: true },
   { id: 'create-spec', attained: true },
+  { id: 'create-first-spec', attained: true },
   { id: 'resolve-decision', attained: true },
 ];
 
@@ -121,16 +128,19 @@ describe('spec-372 t-2: Home layout (ac-5)', () => {
   });
 });
 
-describe('spec-372 t-10: funnel-spine step_shown (ac-21)', () => {
-  it('ac-21: the active step emits home_canvas.step_shown, and all six steps are milestone steps', async () => {
+describe('spec-372 t-10 / spec-421: funnel-spine step_shown (ac-21)', () => {
+  it('ac-21: the active step emits home_canvas.step_shown; spec-421 adds create-first-spec as a milestone step', async () => {
     tagAc(AC(21));
-    fetchJourneyStateApi.mockResolvedValue(stateFor('resolve-decision', NOT_GRADUATED));
+    // spec-421: resolve-decision is hidden; visible steps are identity, create-spec, create-first-spec.
+    // The canvas clamps the server step to the last visible, which is create-first-spec.
+    fetchJourneyStateApi.mockResolvedValue(stateFor('create-first-spec', NOT_GRADUATED));
     renderCanvas();
-    await waitFor(() => expect(postJourneyEventApi).toHaveBeenCalledWith('resolve-decision', 'shown'));
-    // The funnel spine covers all six v3 steps (each fires step_shown when active).
+    await waitFor(() => expect(postJourneyEventApi).toHaveBeenCalledWith('create-first-spec', 'shown'));
+    // spec-421: create-first-spec added between create-spec and resolve-decision.
     expect([...ONBOARDING_MILESTONE_STEP_IDS]).toEqual([
       'identity',
       'create-spec',
+      'create-first-spec',
       'resolve-decision',
       'add-ac',
       'specs-match-reality',

--- a/packages/ui/src/pages/HomeCanvas.test.tsx
+++ b/packages/ui/src/pages/HomeCanvas.test.tsx
@@ -51,20 +51,27 @@ const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-336/acs
 const AC344 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-344/acs/ac-${n}`;
 const AC372 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-372/acs/ac-${n}`;
 
-const SIX = [
+// spec-421: create-first-spec added between create-spec and resolve-decision.
+// Steps 3-6 (resolve-decision, add-ac, specs-match-reality, agents-build) are hidden from
+// the rail by HIDDEN_STEP_IDS; the 3 visible steps are identity, create-spec, create-first-spec.
+const ALL_STEPS = [
   'identity',
   'create-spec',
+  'create-first-spec',
   'resolve-decision',
   'add-ac',
   'specs-match-reality',
   'agents-build',
 ] as const;
 
+const VISIBLE_STEPS = ['identity', 'create-spec', 'create-first-spec'] as const;
+const HIDDEN_STEPS = ['resolve-decision', 'add-ac', 'specs-match-reality', 'agents-build'] as const;
+
 const DEV_HEAVY = { dev: 0.9, design: 0.05, pm: 0.05 }; // → "All-in builder"
 const DESIGN_HEAVY = { dev: 0.05, design: 0.9, pm: 0.05 }; // → "Pure designer" (non-builder)
 
 function stepsOf(attained: readonly string[]) {
-  return SIX.map((id) => ({ id, attained: attained.includes(id) }));
+  return ALL_STEPS.map((id) => ({ id, attained: attained.includes(id) }));
 }
 
 function stateFor(
@@ -132,19 +139,31 @@ describe('HomeCanvas v2 — persistent rail + content panel (ac-1, ac-2, ac-8, a
     expect(screen.getByTestId('journey-progress')).toHaveTextContent('0% complete');
   });
 
-  it('past step 0, shows the full six-step arc as a vertical rail beside the content panel', async () => {
+  it('past step 0, shows 3 visible nodes in the rail; hidden steps have no rail nodes (spec-421)', async () => {
+    const AC421 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-421/acs/ac-${n}`;
     tagAc(AC(1));
     tagAc(AC(9));
+    tagAc(AC421(2)); // rail shows 3 nodes
+    tagAc(AC421(3)); // hidden steps have no rail nodes
     fetchJourneyStateApi.mockResolvedValue(stateFor('create-spec', { attained: ['identity'] }));
     renderCanvas();
 
-    // The rail is present with all six nodes (not a single derived card).
     expect(await screen.findByTestId('journey-rail')).toBeInTheDocument();
-    for (const id of SIX) {
+    // spec-421: 3 visible nodes in the rail.
+    for (const id of VISIBLE_STEPS) {
       expect(screen.getByTestId(`journey-rail-node-${id}`)).toBeInTheDocument();
+    }
+    // Hidden steps are absent from the rail.
+    for (const id of HIDDEN_STEPS) {
+      expect(screen.queryByTestId(`journey-rail-node-${id}`)).toBeNull();
     }
     expect(screen.getByTestId('journey-content')).toBeInTheDocument();
     expect(screen.getByTestId('journey-step-create-spec')).toBeInTheDocument();
+    // ac-13: step 2 rail subtitle reads "Connect to MCP to get the full magic of Memex".
+    tagAc(AC421(13));
+    const createSpecNode = screen.getByTestId('journey-rail-node-create-spec');
+    expect(createSpecNode.textContent).toContain('Connect to the Memex MCP');
+    expect(createSpecNode.textContent).toContain('Connect to MCP to get the full magic of Memex');
   });
 });
 
@@ -153,23 +172,23 @@ describe('HomeCanvas v2 — viewing is free and decoupled from attainment (ac-13
     tagAc(AC(6));
     tagAc(AC(13));
     tagAc(AC(14));
-    // identity attained → 1/6 ≈ 17%.
+    // spec-421: identity attained → 1/3 visible ≈ 33% (3 visible steps total).
     fetchJourneyStateApi.mockResolvedValue(stateFor('create-spec', { attained: ['identity'] }));
     renderCanvas();
 
     await screen.findByTestId('journey-rail');
     const pctBefore = screen.getByTestId('journey-progress').textContent;
-    expect(pctBefore).toBe('17% complete');
-    // The far step is not attained.
-    expect(screen.getByTestId('journey-rail-node-add-ac').getAttribute('data-attained')).toBe('false');
+    expect(pctBefore).toBe('33% complete');
+    // create-first-spec is visible and not attained.
+    expect(screen.getByTestId('journey-rail-node-create-first-spec').getAttribute('data-attained')).toBe('false');
 
     // View a step the user is nowhere near — free navigation, no gating.
-    fireEvent.click(screen.getByTestId('journey-rail-node-add-ac'));
-    expect(await screen.findByTestId('journey-step-add-ac')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('journey-rail-node-create-first-spec'));
+    expect(await screen.findByTestId('journey-step-create-first-spec')).toBeInTheDocument();
 
     // Neither the % nor that step's orb changed from merely viewing it.
     expect(screen.getByTestId('journey-progress').textContent).toBe(pctBefore);
-    expect(screen.getByTestId('journey-rail-node-add-ac').getAttribute('data-attained')).toBe('false');
+    expect(screen.getByTestId('journey-rail-node-create-first-spec').getAttribute('data-attained')).toBe('false');
     expect(screen.getByTestId('journey-rail-node-identity').getAttribute('data-attained')).toBe('true');
   });
 });
@@ -183,8 +202,9 @@ describe('HomeCanvas v2 — remembered cursor + no restart (ac-15)', () => {
     const { unmount } = renderCanvas();
 
     await screen.findByTestId('journey-rail');
-    fireEvent.click(screen.getByTestId('journey-rail-node-add-ac'));
-    expect(await screen.findByTestId('journey-step-add-ac')).toBeInTheDocument();
+    // spec-421: navigate to create-first-spec (visible; add-ac is now hidden).
+    fireEvent.click(screen.getByTestId('journey-rail-node-create-first-spec'));
+    expect(await screen.findByTestId('journey-step-create-first-spec')).toBeInTheDocument();
     // No restart control anywhere.
     expect(screen.queryByText(/restart/i)).toBeNull();
     expect(screen.queryByTestId('journey-restart')).toBeNull();
@@ -193,7 +213,7 @@ describe('HomeCanvas v2 — remembered cursor + no restart (ac-15)', () => {
 
     // Next visit lands back on the remembered step.
     renderCanvas();
-    expect(await screen.findByTestId('journey-step-add-ac')).toBeInTheDocument();
+    expect(await screen.findByTestId('journey-step-create-first-spec')).toBeInTheDocument();
   });
 
   it('does NOT strand a returning user on a remembered step they have already completed', async () => {
@@ -208,55 +228,70 @@ describe('HomeCanvas v2 — remembered cursor + no restart (ac-15)', () => {
   });
 });
 
-describe('HomeCanvas v2 — role branching (ac-7, ac-10, ac-11)', () => {
-  it('a builder persona sees all six steps and the build-from-codebase divider', async () => {
+describe('HomeCanvas v2 — role branching (ac-7, ac-10, ac-11) — spec-421 updates', () => {
+  it('spec-421: both builder and non-builder see the same 3 visible nodes; no divider (hidden steps override builder-only)', async () => {
+    // spec-336 dec-3 builder branching is superseded by spec-421 HIDDEN_STEP_IDS for steps 3-6.
+    // Both personas now see [identity, create-spec, create-first-spec]; no build-from-codebase divider.
     tagAc(AC(7));
     tagAc(AC(10));
     tagAc(AC(11));
+    const AC421 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-421/acs/ac-${n}`;
+    tagAc(AC421(2));
+    tagAc(AC421(3));
     fetchJourneyStateApi.mockResolvedValue(stateFor('create-spec', { roleCoords: DEV_HEAVY, attained: ['identity'] }));
     renderCanvas();
 
     await screen.findByTestId('journey-rail');
-    expect(screen.getByTestId('journey-rail-node-specs-match-reality')).toBeInTheDocument();
-    expect(screen.getByTestId('journey-rail-node-agents-build')).toBeInTheDocument();
-    expect(screen.getByTestId('rail-divider-build')).toBeInTheDocument();
+    // All 3 visible steps present for a builder.
+    for (const id of VISIBLE_STEPS) {
+      expect(screen.getByTestId(`journey-rail-node-${id}`)).toBeInTheDocument();
+    }
+    // Builder-only steps are hidden (they're in HIDDEN_STEP_IDS).
+    expect(screen.queryByTestId('journey-rail-node-specs-match-reality')).toBeNull();
+    expect(screen.queryByTestId('journey-rail-node-agents-build')).toBeNull();
+    // No divider since specs-match-reality is hidden.
+    expect(screen.queryByTestId('rail-divider-build')).toBeNull();
   });
 
-  it('a non-builder persona sees only the first four steps; the % is over those four', async () => {
+  it('spec-421: a non-builder persona also sees 3 steps; hidden steps absent; % over 3', async () => {
     tagAc(AC(7));
     tagAc(AC(10));
     tagAc(AC(11));
-    // 3 of 4 visible attained → 75% (the denominator excludes the two builder steps).
+    // identity + create-spec attained (2 of 3 visible) → 67%.
     fetchJourneyStateApi.mockResolvedValue(
-      stateFor('add-ac', { roleCoords: DESIGN_HEAVY, attained: ['identity', 'create-spec', 'resolve-decision'] }),
+      stateFor('create-first-spec', { roleCoords: DESIGN_HEAVY, attained: ['identity', 'create-spec'] }),
     );
     renderCanvas();
 
     await screen.findByTestId('journey-rail');
-    expect(screen.getByTestId('journey-rail-node-add-ac')).toBeInTheDocument();
+    for (const id of VISIBLE_STEPS) {
+      expect(screen.getByTestId(`journey-rail-node-${id}`)).toBeInTheDocument();
+    }
+    expect(screen.queryByTestId('journey-rail-node-add-ac')).toBeNull();
     expect(screen.queryByTestId('journey-rail-node-specs-match-reality')).toBeNull();
     expect(screen.queryByTestId('journey-rail-node-agents-build')).toBeNull();
     expect(screen.queryByTestId('rail-divider-build')).toBeNull();
-    expect(screen.getByTestId('journey-progress')).toHaveTextContent('75% complete');
+    expect(screen.getByTestId('journey-progress')).toHaveTextContent('67% complete');
   });
 });
 
-describe('HomeCanvas v2 — non-builder handoff (ac-12)', () => {
-  it('shows the handoff message on the terminal "Done becomes a fact" step for a non-builder', async () => {
+describe('HomeCanvas v2 — non-builder handoff (ac-12) — spec-421: always absent', () => {
+  it('spec-421: the nonbuilder-handoff is never shown (add-ac is hidden; create-first-spec is the terminal visible step for all)', async () => {
+    // spec-421: nonBuilderTerminal = false because add-ac is hidden from the rail.
+    // Neither builder nor non-builder ever sees the handoff message.
     tagAc(AC(12));
     fetchJourneyStateApi.mockResolvedValue(
-      stateFor('add-ac', { roleCoords: DESIGN_HEAVY, attained: ['identity', 'create-spec', 'resolve-decision'] }),
+      stateFor('create-first-spec', { roleCoords: DESIGN_HEAVY, attained: ['identity', 'create-spec'] }),
     );
     renderCanvas();
-
-    expect(await screen.findByTestId('nonbuilder-handoff')).toBeInTheDocument();
-    expect(screen.getByTestId('nonbuilder-handoff')).toHaveTextContent(/hand it off to a human or a coding agent/i);
+    await screen.findByTestId('journey-rail');
+    expect(screen.queryByTestId('nonbuilder-handoff')).toBeNull();
   });
 
-  it('does NOT show the handoff for a builder', async () => {
+  it('spec-421: no handoff for a builder either (all personas end at create-first-spec)', async () => {
     tagAc(AC(12));
     fetchJourneyStateApi.mockResolvedValue(
-      stateFor('add-ac', { roleCoords: DEV_HEAVY, attained: ['identity', 'create-spec', 'resolve-decision'] }),
+      stateFor('create-first-spec', { roleCoords: DEV_HEAVY, attained: ['identity', 'create-spec'] }),
     );
     renderCanvas();
     await screen.findByTestId('journey-rail');
@@ -325,33 +360,35 @@ describe('HomeCanvas v2 — no invite modal (ac-17)', () => {
   });
 });
 
-describe('HomeCanvas v2 — step 1 connect + create, per-stage prompts (ac-3, ac-4)', () => {
-  it('step 1 offers the MCP connect stage and the create-spec prompt', async () => {
+describe('HomeCanvas v2 — step 1 connect + create, per-stage prompts (ac-3, ac-4) — spec-421 updates', () => {
+  it('step 1 offers the MCP connect stage (Stage 2 prompt moved to CreateFirstSpecStep)', async () => {
+    const AC421 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-421/acs/ac-${n}`;
     tagAc(AC(3));
+    tagAc(AC421(4)); // step 2 renders MCP connect only, no "Create Your First Spec" section
     fetchJourneyStateApi.mockResolvedValue(stateFor('create-spec', { roleCoords: DEV_HEAVY, attained: ['identity'] }));
     renderCanvas();
     expect(await screen.findByTestId('journey-step-create-spec')).toBeInTheDocument();
     expect(screen.getByTestId('connect-stage')).toBeInTheDocument();
-    expect(screen.getByTestId('create-spec-prompt')).toBeInTheDocument();
+    // Stage-2 prompt moved to step 3 (CreateFirstSpecStep).
+    expect(screen.queryByTestId('create-spec-prompt')).toBeNull();
   });
 
-  it('the builder-only "specs-match-reality" and "agents-build" steps carry their copyable prompts', async () => {
+  it('spec-421: the hidden "specs-match-reality" and "agents-build" steps are not accessible via rail or clamping', async () => {
+    const AC421 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-421/acs/ac-${n}`;
     tagAc(AC(4));
+    tagAc(AC421(12)); // hidden steps produce no telemetry (not mounted, not in rail)
+    // With specs-match-reality as currentStepId (hidden) and create-first-spec not yet
+    // attained, the canvas clamps to create-first-spec (last visible). We keep
+    // create-first-spec unattained so the journey layer stays visible (not graduated).
     fetchJourneyStateApi.mockResolvedValue(
-      stateFor('specs-match-reality', { roleCoords: DEV_HEAVY, attained: ['identity', 'create-spec', 'resolve-decision', 'add-ac'] }),
-    );
-    const { unmount } = renderCanvas();
-    expect(await screen.findByTestId('specs-match-reality-prompt')).toBeInTheDocument();
-    expect(screen.getByTestId('specs-match-reality-outcomes')).toBeInTheDocument();
-    unmount();
-    // Fresh visit (clear the remembered viewing cursor the first render persisted).
-    window.localStorage.clear();
-
-    fetchJourneyStateApi.mockResolvedValue(
-      stateFor('agents-build', { roleCoords: DEV_HEAVY, attained: ['identity', 'create-spec', 'resolve-decision', 'add-ac', 'specs-match-reality'] }),
+      stateFor('specs-match-reality', { roleCoords: DEV_HEAVY, attained: ['identity', 'create-spec'] }),
     );
     renderCanvas();
-    expect(await screen.findByTestId('agents-build-prompt')).toBeInTheDocument();
+    // The clamped step (create-first-spec) renders; the hidden step does not.
+    expect(await screen.findByTestId('journey-step-create-first-spec')).toBeInTheDocument();
+    expect(screen.queryByTestId('specs-match-reality-prompt')).toBeNull();
+    expect(screen.queryByTestId('journey-rail-node-specs-match-reality')).toBeNull();
+    expect(screen.queryByTestId('journey-rail-node-agents-build')).toBeNull();
   });
 });
 

--- a/packages/ui/src/pages/HomeCanvas.tsx
+++ b/packages/ui/src/pages/HomeCanvas.tsx
@@ -36,7 +36,7 @@ import {
 import { fetchDocs } from '../api/docs';
 import { resolveSpecToken, SPEC_TOKEN_PLACEHOLDER } from '../components/home/specToken';
 import { resolveStepView, activeJourney } from '../journeys/registry';
-import { BUILDER_ONLY_STEP_IDS } from '../journeys/onboarding/steps';
+import { BUILDER_ONLY_STEP_IDS, HIDDEN_STEP_IDS } from '../journeys/onboarding/steps';
 import { isJourneyGraduated } from '../journeys/graduation';
 import { YourJourneys, type PearlJourney } from '../components/home/YourJourneys';
 import { HomeValue } from '../components/home/HomeValue';
@@ -44,6 +44,7 @@ import { SHOW_GRADUATED_HOME } from './homeCanvasFlags';
 import { JourneyStepShell } from '../components/home/JourneyStepShell';
 import { IdentityStep } from '../components/home/IdentityStep';
 import { CreateSpecStep } from '../components/home/CreateSpecStep';
+import { CreateFirstSpecStep } from '../components/home/CreateFirstSpecStep';
 import { AgentPromptStep } from '../components/home/AgentPromptStep';
 import { SpecsMatchRealityStep } from '../components/home/SpecsMatchRealityStep';
 import { AgentsBuildStep } from '../components/home/AgentsBuildStep';
@@ -165,7 +166,9 @@ export function HomeCanvas() {
   const builder = isBuilderPersona(state?.roleCoords ?? null);
   const visibleSteps = useMemo(() => {
     const all = state?.steps ?? [];
-    return builder ? all : all.filter((s) => !(BUILDER_ONLY_STEP_IDS as readonly string[]).includes(s.id));
+    // spec-421: hidden steps are fully inert — not in the rail, no telemetry, no badges.
+    const withoutHidden = all.filter((s) => !(HIDDEN_STEP_IDS as readonly string[]).includes(s.id));
+    return builder ? withoutHidden : withoutHidden.filter((s) => !(BUILDER_ONLY_STEP_IDS as readonly string[]).includes(s.id));
   }, [state, builder]);
   const visibleIds = useMemo(() => visibleSteps.map((s) => s.id), [visibleSteps]);
 
@@ -305,8 +308,9 @@ export function HomeCanvas() {
     ];
   }, [visibleSteps, journey]);
 
-  const nonBuilderTerminal =
-    !builder && displayStepId === visibleIds[visibleIds.length - 1] && displayStepId === 'add-ac';
+  // spec-421: add-ac is hidden from the rail; the terminal visible step is create-first-spec
+  // for all persona types. nonBuilderTerminal is no longer applicable.
+  const nonBuilderTerminal = false;
 
   // The journey layer recedes to the pearls once graduated (spec-312), unless re-opened.
   const graduated = isJourneyGraduated(state ? { ...state, steps: visibleSteps } : null);
@@ -424,6 +428,14 @@ export function HomeCanvas() {
             preview={preview}
             onComplete={handleStepComplete}
             onCtaClick={trackStepCta}
+          />
+        );
+      case 'create-first-spec':
+        return (
+          <CreateFirstSpecStep
+            preview={preview}
+            onComplete={handleStepComplete}
+            onCtaClick={trackStepCta}
             onCreateInApp={() => {
               if (specsPath) navigate(`${specsPath}?new=1`);
             }}
@@ -489,7 +501,8 @@ function JourneyRail({
           const view = views[s.id];
           const isSelected = s.id === selectedStepId;
           const isCurrent = s.id === serverStepId;
-          const showDivider = s.id === 'specs-match-reality';
+          // spec-421: specs-match-reality is hidden from the rail so the divider never fires.
+          const showDivider = false;
           // spec-372 issue-10 — a done (attained) step you've moved past collapses: its
           // subtitle is hidden and its title dims. The selected step (even a done one you
           // clicked back to) stays expanded.


### PR DESCRIPTION
## Summary

- **Enter-key bug fixed** — pressing Enter in the "What should we call you?" field now commits the name only; Continue is the sole step-advance action
- **Step 2 renamed** to "Connect to the Memex MCP" (was "Build exactly what you decided"); spec-creation UI removed from this step
- **New step 3** — "Create your first spec" — blue CTA navigates to `/specs?new=1` and opens the New Spec dialog; collapsible sample prompt helper included
- **Steps 4–7 hidden** from the rail (resolve-decision, add-ac, specs-match-reality, agents-build); code kept intact for future reintroduction
- **Server arc updated** — `create-first-spec` step added to `onboardingJourney`; no schema changes, no migrations

## Test plan

- [x] UI suite: 1760 passed, 1 skipped
- [x] Server suite: 4804 passed (2 pre-existing failures unrelated to spec-421: spec-199 BYPASSRLS + spec-129 CI emission key)
- [x] e2e-cold: 112 passed, 0 failed
- [x] 13/13 spec-421 ACs verified via AC emission

Closes spec-421.

🤖 Generated with [Claude Code](https://claude.com/claude-code)