### PR TITLE
fix: show completed rail for graduated users (no blank Home page)

### DIFF
--- a/packages/ui/src/pages/HomeCanvas.spec-312.test.tsx
+++ b/packages/ui/src/pages/HomeCanvas.spec-312.test.tsx
@@ -16,7 +16,7 @@
 //   ac-18 (impl)  — pearls derive from activity (state.steps); stable across remount.
 //   ac-19 (impl)  — collapse + re-open from the pearls; collapse never erases the row.
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { tagAc } from '@memex-ai-ac/vitest';
 
@@ -120,12 +120,12 @@ describe('spec-312 t-2: layered Home (dec-2)', () => {
     expect(await screen.findByTestId('journey-layer')).toBeInTheDocument();
     expect(screen.getByTestId('home-of-value')).toBeInTheDocument();
     unmount();
-    // graduated → the journey layer recedes (collapsed to pearls); home content prominent
+    // graduated → the journey layer remains visible (all ticks green); home content also present
     fetchJourneyStateApi.mockResolvedValue(stateFor('all-set', ALL_ATTAINED));
     renderCanvas();
     expect(await screen.findByTestId('home-of-value')).toBeInTheDocument();
     expect(screen.getByTestId('your-journeys')).toBeInTheDocument();
-    expect(screen.queryByTestId('journey-layer')).not.toBeInTheDocument();
+    expect(await screen.findByTestId('journey-layer')).toBeInTheDocument();
   });
 });
 
@@ -170,18 +170,11 @@ describe('spec-312 t-3: "Your Journeys" pearls (dec-4)', () => {
     expect(read()).toEqual(first);
   });
 
-  it('ac-19: graduation recedes the layer to the pearls; re-open from the pearls; the row is never erased', async () => {
+  it('ac-19: graduated → journey layer stays visible (all ticks green) alongside pearls; row never erased', async () => {
     tagAc(AC(19));
-    // spec-336 (2026-06-23) moved the CHEVRON to an in-place toggle; the recede-to-pearls
-    // is now triggered by graduation (the real signal), not the chevron — but the AC's
-    // intent (recede → pearls → re-open, never erased) is preserved and verified here.
     fetchJourneyStateApi.mockResolvedValue(stateFor('all-set', ALL_ATTAINED));
     renderCanvas();
-    // Graduated → the layer recedes; the pearls remain (escapable, never erasable).
-    expect(await screen.findByTestId('your-journeys')).toBeInTheDocument();
-    await waitFor(() => expect(screen.queryByTestId('journey-layer')).not.toBeInTheDocument());
-    // Re-open from the pearls.
-    fireEvent.click(screen.getByTestId('journey-pearls-onboarding'));
+    // Graduated → the layer remains (completed rail, no blank page); pearls are also present.
     expect(await screen.findByTestId('journey-layer')).toBeInTheDocument();
     expect(screen.getByTestId('your-journeys')).toBeInTheDocument();
   });

--- a/packages/ui/src/pages/HomeCanvas.spec-315.test.tsx
+++ b/packages/ui/src/pages/HomeCanvas.spec-315.test.tsx
@@ -64,8 +64,8 @@ describe('HomeCanvas — graduated layout (spec-315)', () => {
     // ac-3: journeys still render as the spec-312 pearls (consumed, not rebuilt).
     const pearls = await screen.findByTestId('your-journeys');
     const homeOfValue = screen.getByTestId('home-of-value');
-    // graduated ⇒ the expanded journey layer is gone.
-    expect(screen.queryByTestId('journey-layer')).toBeNull();
+    // graduated ⇒ the journey layer remains visible (all ticks green, no blank page).
+    expect(screen.queryByTestId('journey-layer')).toBeInTheDocument();
     // ac-9: the home-of-value surface precedes the pearls in the DOM.
     expect(
       homeOfValue.compareDocumentPosition(pearls) & Node.DOCUMENT_POSITION_FOLLOWING,

--- a/packages/ui/src/pages/HomeCanvas.tsx
+++ b/packages/ui/src/pages/HomeCanvas.tsx
@@ -37,7 +37,6 @@ import { fetchDocs } from '../api/docs';
 import { resolveSpecToken, SPEC_TOKEN_PLACEHOLDER } from '../components/home/specToken';
 import { resolveStepView, activeJourney } from '../journeys/registry';
 import { BUILDER_ONLY_STEP_IDS, HIDDEN_STEP_IDS } from '../journeys/onboarding/steps';
-import { isJourneyGraduated } from '../journeys/graduation';
 import { YourJourneys, type PearlJourney } from '../components/home/YourJourneys';
 import { HomeValue } from '../components/home/HomeValue';
 import { SHOW_GRADUATED_HOME } from './homeCanvasFlags';
@@ -312,9 +311,10 @@ export function HomeCanvas() {
   // for all persona types. nonBuilderTerminal is no longer applicable.
   const nonBuilderTerminal = false;
 
-  // The journey layer recedes to the pearls once graduated (spec-312), unless re-opened.
-  const graduated = isJourneyGraduated(state ? { ...state, steps: visibleSteps } : null);
-  const layerVisible = !!state?.steps?.length && (!graduated || forceShow);
+  // spec-421 patch: remove the graduation gate — graduated users see the completed rail
+  // (all ticks green) rather than a blank page. forceShow re-opens the layer when
+  // SHOW_GRADUATED_HOME flips and the YourJourneys pearls are live (spec-312/315).
+  const layerVisible = !!state?.steps?.length || forceShow;
 
   // The rail reveals once the user is past the first step (prototype: full-width step 0).
   const showRail = !!displayStepId && displayStepId !== FIRST_STEP_ID && visibleSteps.length > 0;


### PR DESCRIPTION
## Summary

- Graduated users (all 3 onboarding steps attained) were seeing a completely blank Home page because `layerVisible` gated on `!graduated`
- Remove the graduation gate — `layerVisible = !!state?.steps?.length || forceShow` — so graduated users see the completed 3-step rail with all ticks green
- `SHOW_GRADUATED_HOME` and the spec-312/315 pearl surfaces are untouched; the `forceShow` path is preserved for when Wic's graduated-home redesign ships
- 3 spec-312/315 test assertions updated to reflect new behavior (layer present when graduated, not absent)

## Root cause

`homeCanvasFlags.ts` has `SHOW_GRADUATED_HOME = false` (Wic-gated, spec-372 dec-3). When a user is graduated *and* that flag is off, both the journey layer and the post-graduation content (HomeValue, YourJourneys) are hidden — leaving nothing on the page.

## Test plan

- [ ] `pnpm test` — 1760 UI tests green
- [ ] `make e2e-cold` — 111/112 passed (1 skipped, same as baseline)
- [ ] Visit Home on INT as ryan.soosayraj@mindset.ai — confirm completed rail renders instead of blank canvas

🤖 Generated with [Claude Code](https://claude.com/claude-code)