### PR TITLE
feat(spec-340): facets foundation (phase 1) — schema, per-owner seeding, classifier, facets tool

### DIFF
--- a/packages/server/drizzle/0114_add_facets.sql
+++ b/packages/server/drizzle/0114_add_facets.sql
@@ -1,0 +1,89 @@
+-- spec-340 t-1 (phase 1, the inert foundation): the facet substrate.
+--
+-- Two tables only — the PRODUCE side:
+--   1. facets                 — the per-owner vocabulary (dec-7). Polymorphic owner.
+--   2. standard_clause_facets — clause→facet tags (dec-2/dec-8). Memex-scoped.
+--
+-- The consume-side ballot tables (task/decision facet ballots) belong to phase 2
+-- (spec-423) and are deliberately NOT created here.
+--
+-- Named UNIQUE / CHECK / index names match the Drizzle schema's
+-- unique()/index()/uniqueIndex()/check() names so introspection-by-conname stays in
+-- lockstep. Idempotent (IF NOT EXISTS) so the hand-migration runner re-applies cleanly.
+
+-- 1. facets — the per-owner vocabulary (dec-7) ---------------------------------------
+--
+-- POLYMORPHIC owner: owner_type ∈ {org, memex} + owner_id. An org-owned memex shares
+-- its org's vocabulary (owner_type='org', owner_id=org.id, per std-4); a personal
+-- memex with no owning org carries its own (owner_type='memex', owner_id=memex.id).
+-- owner_id is intentionally NOT a foreign key — it points at one of two tables; the
+-- seeding paths enforce referential integrity for the org case. Owner-config posture
+-- like org_scaffold_additions: NO memex_id, so NO memex_isolation RLS (a row could
+-- never satisfy a memex_id=GUC predicate); access is gated at the service layer.
+-- Uniqueness is per-owner (owner_type, owner_id, key), so two owners diverge freely.
+-- `key` is the stable slug tags anchor on (never rewritten by a display rename, dec-5);
+-- `name` is the renameable display override; `description` is the REQUIRED classifier rubric.
+CREATE TABLE IF NOT EXISTS facets (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  owner_type  TEXT NOT NULL,
+  owner_id    UUID NOT NULL,
+  key         TEXT NOT NULL,
+  name        TEXT,
+  description TEXT NOT NULL,
+  ord         INTEGER NOT NULL DEFAULT 0,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT facets_owner_key_unique UNIQUE (owner_type, owner_id, key),
+  CONSTRAINT facets_owner_type_valid CHECK (owner_type IN ('org', 'memex'))
+);
+
+CREATE INDEX IF NOT EXISTS facets_owner_idx ON facets (owner_type, owner_id);
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON facets TO memex_app;
+
+-- 2. standard_clause_facets — clause→facet tags (dec-2/dec-8) ------------------------
+--
+-- Assigned by the agent-driven classifier (local backfill in phase 1; NOT a
+-- hand-maintained join — the distinction the spec-193 guard reconciliation rides, t-7).
+-- Memex-scoped: rides the standards corpus. The tri-state the design requires (explicit
+-- "governs nothing" distinguishable from "not yet classified") is encoded by the
+-- nullable facet_id:
+--   • NO rows for a clause            → not-yet-classified
+--   • exactly one row, facet_id NULL  → explicit "governs nothing"
+--   • one row per member facet         → governs those facets
+-- Standard-level pills are the union over member rows only.
+CREATE TABLE IF NOT EXISTS standard_clause_facets (
+  id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  memex_id   UUID NOT NULL,
+  clause_id  UUID NOT NULL REFERENCES standard_clauses(id) ON DELETE CASCADE,
+  facet_id   UUID REFERENCES facets(id) ON DELETE CASCADE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- At most one membership row per (clause, facet); at most one explicit-none marker per clause.
+CREATE UNIQUE INDEX IF NOT EXISTS standard_clause_facets_clause_facet_unique
+  ON standard_clause_facets (clause_id, facet_id) WHERE facet_id IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS standard_clause_facets_clause_none_unique
+  ON standard_clause_facets (clause_id) WHERE facet_id IS NULL;
+CREATE INDEX IF NOT EXISTS standard_clause_facets_clause_id_idx ON standard_clause_facets (clause_id);
+CREATE INDEX IF NOT EXISTS standard_clause_facets_facet_id_idx  ON standard_clause_facets (facet_id);
+CREATE INDEX IF NOT EXISTS standard_clause_facets_memex_id_idx  ON standard_clause_facets (memex_id);
+
+-- Tenancy (std-36): direct memex_id, so the memex_isolation policy applies. ENABLED but
+-- NOT FORCED (spec-257 dec-1, migration 0093) — FORCE bites the owner role `postgres`
+-- used by migrations/deploys; NO FORCE lets the owner bypass while the runtime role
+-- memex_app stays subject to RLS. The spec-199 RLS guard fails CI on any FORCE'd table.
+ALTER TABLE standard_clause_facets ENABLE ROW LEVEL SECURITY;
+ALTER TABLE standard_clause_facets NO FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS standard_clause_facets_memex_isolation ON standard_clause_facets;
+CREATE POLICY standard_clause_facets_memex_isolation ON standard_clause_facets
+  USING (
+    nullif(current_setting('app.memex_id', true), '') IS NOT NULL
+    AND memex_id = current_setting('app.memex_id', true)::uuid
+  )
+  WITH CHECK (
+    nullif(current_setting('app.memex_id', true), '') IS NOT NULL
+    AND memex_id = current_setting('app.memex_id', true)::uuid
+  );
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON standard_clause_facets TO memex_app;

--- a/packages/server/scripts/backfill-default-facets.ts
+++ b/packages/server/scripts/backfill-default-facets.ts
@@ -1,0 +1,27 @@
+// Backfill the 16 default facets onto EVERY existing owner — every org AND every
+// personal memex (spec-340 t-2, dec-7). Idempotent: an owner that already carries
+// any facet is skipped (the zero-row guard).
+//
+// This seeds the VOCABULARY only — it makes NO LLM calls. (The separate, optional
+// clause→facet classification backfill is scripts/backfill-facet-tags.ts.)
+//
+// Local, operator-run, one-time. Needs DATABASE_URL in the environment.
+//
+// Usage:
+//   pnpm --filter @memex/server tsx scripts/backfill-default-facets.ts
+
+import { backfillDefaultFacetsAllOwners } from "../src/services/default-facets.js";
+
+async function main(): Promise<void> {
+  console.log("[default-facets backfill] seeding the 16 defaults into every org and personal memex…");
+  const { orgs, personalMemexes } = await backfillDefaultFacetsAllOwners();
+  console.log(
+    `[default-facets backfill] done — ${orgs} org(s) and ${personalMemexes} personal memex(es) ensured seeded.`,
+  );
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error("[default-facets backfill] failed:", err);
+  process.exit(1);
+});

--- a/packages/server/scripts/backfill-facet-tags.ts
+++ b/packages/server/scripts/backfill-facet-tags.ts
@@ -25,7 +25,15 @@ async function main(): Promise<void> {
     process.exit(1);
   }
   console.log(`[facet-backfill] classifying standards' clauses for memex ${memexId}…`);
-  const { standards, clauses } = await backfillFacetTagsForMemex(memexId);
+  // Progress ticks for the long run — every 25 clauses and at the end (the pool runs
+  // CLASSIFY_CONCURRENCY in flight, so this reports completions, not start order).
+  const { standards, clauses } = await backfillFacetTagsForMemex(memexId, {
+    onProgress: (done, total) => {
+      if (done % 25 === 0 || done === total) {
+        console.log(`[facet-backfill]   ${done}/${total} clauses classified…`);
+      }
+    },
+  });
   console.log(`[facet-backfill] done — ${standards} standard(s), ${clauses} clause(s) classified + tagged.`);
   process.exit(0);
 }

--- a/packages/server/scripts/backfill-facet-tags.ts
+++ b/packages/server/scripts/backfill-facet-tags.ts
@@ -1,0 +1,36 @@
+// Backfill facet tags onto EXISTING standards' clauses (spec-340 t-4 / dec-8).
+//
+// THIS script is the one-time catch-up for standards authored before facets existed:
+// it classifies every clause of every standard in a memex with a REAL Anthropic call
+// (Claude Opus 4.8) and writes the tags. Idempotent (tagClause replaces a clause's
+// tags), so re-running is safe.
+//
+// dec-8: this is a LOCAL, operator/agent-run script — NOT a server request/write path,
+// and NOT run by this Spec's deploy. It is the ONLY invoker of the server-side LLM
+// classifier engine; a regression guard pins that no MCP handler/route imports it.
+// Needs ANTHROPIC_API_KEY + DATABASE_URL in the environment.
+//
+// (The separate scripts/backfill-default-facets.ts seeds the VOCABULARY and makes no
+// LLM calls — run that first so there is a vocabulary to classify against.)
+//
+// Usage:
+//   pnpm --filter @memex/server tsx scripts/backfill-facet-tags.ts <memexId>
+
+import { backfillFacetTagsForMemex } from "../src/services/facet-classifier.js";
+
+async function main(): Promise<void> {
+  const memexId = process.argv[2];
+  if (!memexId) {
+    console.error("usage: tsx scripts/backfill-facet-tags.ts <memexId>");
+    process.exit(1);
+  }
+  console.log(`[facet-backfill] classifying standards' clauses for memex ${memexId}…`);
+  const { standards, clauses } = await backfillFacetTagsForMemex(memexId);
+  console.log(`[facet-backfill] done — ${standards} standard(s), ${clauses} clause(s) classified + tagged.`);
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error("[facet-backfill] failed:", err);
+  process.exit(1);
+});

--- a/packages/server/src/__regression__/facet-classifier-no-request-path.regression.test.ts
+++ b/packages/server/src/__regression__/facet-classifier-no-request-path.regression.test.ts
@@ -1,0 +1,69 @@
+// spec-340 t-4 / dec-8 — guard: the LLM facet classifier engine
+// (services/facet-classifier.ts) must NEVER be imported by a server request/write
+// path. Memex has no server-side LLM-on-write architecture; the intelligence lives in
+// the user's coding agent. The classifier engine is reachable ONLY from the local,
+// operator-run backfill script (scripts/backfill-facet-tags.ts) and tests.
+//
+// The request path reads the facet VOCABULARY through services/facet-vocab.ts (no LLM),
+// not through this engine — so banning the whole engine module from request-path dirs
+// is airtight. Tags ac-39.
+
+import { describe, it, expect } from "vitest";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { resolve, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+const SPEC = "mindset-prod/memex-building-itself/specs/spec-340";
+const AC = (n: number) => `${SPEC}/acs/ac-${n}`;
+
+const __dirname = resolve(fileURLToPath(import.meta.url), "..");
+const SRC = resolve(__dirname, "..");
+
+// The request/write surfaces — anything reachable from an inbound HTTP/MCP call.
+const REQUEST_PATH_DIRS = ["routes", "agent", "mcp", "middleware"] as const;
+
+// Module specifiers that resolve to the classifier engine.
+const BANNED = ["facet-classifier"];
+
+function walk(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      out.push(...walk(full));
+    } else if (/\.(ts|tsx)$/.test(entry)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+describe("facet classifier is never on a request path (spec-340 t-4, dec-8)", () => {
+  it("no file under routes/agent/mcp/middleware imports services/facet-classifier (ac-39)", () => {
+    tagAc(AC(39));
+    const offenders: string[] = [];
+    for (const d of REQUEST_PATH_DIRS) {
+      const dir = join(SRC, d);
+      let files: string[];
+      try {
+        files = walk(dir);
+      } catch {
+        continue; // dir may not exist
+      }
+      for (const f of files) {
+        // Skip the guard's own test files / anything under __regression__ within these
+        // dirs (none today, but keep it honest).
+        if (f.includes("__regression__")) continue;
+        const src = readFileSync(f, "utf8");
+        // Only inspect import/require statements that name the banned module.
+        const importsBanned = BANNED.some((m) => {
+          const re = new RegExp(`(import[^;]*from\\s*['\"][^'\"]*${m}[^'\"]*['\"])|(require\\(['\"][^'\"]*${m}[^'\"]*['\"]\\))`);
+          return re.test(src);
+        });
+        if (importsBanned) offenders.push(relative(SRC, f));
+      }
+    }
+    expect(offenders, `request-path files importing the LLM facet classifier:\n${offenders.join("\n")}`).toEqual([]);
+  });
+});

--- a/packages/server/src/__regression__/mutate-coverage.static-scan.regression.test.ts
+++ b/packages/server/src/__regression__/mutate-coverage.static-scan.regression.test.ts
@@ -97,6 +97,16 @@ const ALLOWLIST: Record<string, string> = {
   // now verifies them like any other service.
   "services/mcp-telemetry.ts":
     "MCP tool-call telemetry (mcp_sessions, mcp_tool_calls). Cross-tenant observability rows — no memex_id, no bus entity, no SSE fan-out. The bus is keyed on memexId for tenant fan-out; telemetry rows have no tenancy by design (they record cross-Memex MCP traffic).",
+  // spec-340 phase 1 (the inert foundation). facets is an owner-config vocabulary
+  // table (like org_scaffold_additions) seeded per owner; standard_clause_facets are
+  // auto-assigned clause→facet tags. Neither has a bus entity or an SSE subscriber in
+  // phase 1 — nothing reads the tags until phase 2 (spec-423) — so the seed/tag writes
+  // do not route through mutate(). Route them through mutate() in phase 2 when a live
+  // editing/pill surface lands. Silent-allowed per std-8 §6.
+  "services/default-facets.ts":
+    "spec-340 phase 1 — seeds the per-owner default facet vocabulary (facets, owner-config like org_scaffold_additions). No bus entity, no SSE subscriber in phase 1 (the inert foundation); mutate() wrap deferred to phase 2 when a live editing/pill surface lands.",
+  "services/facet-classifier.ts":
+    "spec-340 phase 1 — tagClause writes auto-assigned clause→facet tags (standard_clause_facets) from the agent-driven/local-backfill classifier only (dec-8). No bus entity, no SSE subscriber in phase 1 (nothing reads the tags until phase 2); mutate() wrap deferred to phase 2.",
   "routes/backstage.ts":
     "Dev-mode-only org_membership grant (DEV_USER_EMAIL admin self-grant). org_membership is an access-control bootstrap row — no memex_id, no bus entity, not Memex-scoped tenant content; nothing subscribes to it over SSE.",
   "middleware/session.ts":

--- a/packages/server/src/__regression__/ref-emission.regression.test.ts
+++ b/packages/server/src/__regression__/ref-emission.regression.test.ts
@@ -142,6 +142,9 @@ const SKIPS = new Map<string, string>([
   // before/after), not an entity confirmation — it writes nothing and emits no
   // `ref:` line. The actual write happens on approval through the scaffold route.
   ["propose_scaffold_change", "agent-only scaffold proposal — returns a proposal, not entity-acting"],
+  // spec-340: the facets list verb returns the vocabulary listing (key/name/description),
+  // a discovery output like list_docs — not an entity confirmation, so no `ref:` line.
+  ["facets", "facet vocabulary listing — read tool, not entity-acting"],
   // search_memex is the T-8 sister deliverable. It's a discovery tool whose
   // output mirrors list_memexes / list_docs; not an entity-acting tool, so
   // ref emission isn't required. Skip until T-8 confirms the shape.

--- a/packages/server/src/__regression__/spec-193-tripwire.regression.test.ts
+++ b/packages/server/src/__regression__/spec-193-tripwire.regression.test.ts
@@ -110,6 +110,16 @@ describe("ac-8 — L0 functions with no tripwire-tag store", () => {
     // no per-standard tag lookup.
     expect(specifyNudge).toMatch(/search_memex\(\{ query, kind: 'standard' \}\)/);
     // No tag-store / bridge-table machinery anywhere in the scaffold data.
+    //
+    // spec-340 RECONCILIATION (narrowing, dec-1 reversal): this prohibition is
+    // SCOPED TO THE SCAFFOLD LAYER (`scaffoldData` = shared/scaffold-data.ts). It
+    // forbids a HAND-MAINTAINED standard↔tripwire/facet MAP living in the product
+    // prompting layer — the thing spec-193 dec-1 ruled out. It deliberately does
+    // NOT touch the DB: spec-340 introduces AUTO-ASSIGNED clause→facet tags
+    // (db/schema.ts `standardClauseFacets`), which are DERIVED data written by the
+    // agent-driven classifier, not a hand-maintained product map — and are
+    // explicitly PERMITTED. The reconciliation is pinned executably by
+    // spec-340-spec-193-reconciliation.regression.test.ts (spec-340 ac-34).
     expect(scaffoldData).not.toMatch(/tripwireTag|standardTripwireMap|TRIPWIRE_TO_STANDARD|bridge[- ]?table/i);
   });
 });

--- a/packages/server/src/__regression__/spec-340-spec-193-reconciliation.regression.test.ts
+++ b/packages/server/src/__regression__/spec-340-spec-193-reconciliation.regression.test.ts
@@ -1,0 +1,51 @@
+// spec-340 t-7 — reconcile the spec-193 guard with spec-340's auto-assigned tags.
+//
+// spec-193 dec-1 set a "no stored tags" default: the agent classifies its work and
+// reaches standards by semantic search, with NO hand-maintained standard↔tripwire
+// MAP in the product prompting layer. spec-340 introduces AUTO-ASSIGNED clause→facet
+// tags in the DB (standard_clause_facets), written by the agent-driven classifier.
+// These are NOT the thing spec-193 forbade — they are derived data, not a
+// hand-maintained product map — so the two coexist.
+//
+// This guard pins the narrowing executably (ac-34): the spec-193 bridge-table
+// prohibition stays SCOPED TO THE SCAFFOLD LAYER, and the auto-assigned clause→facet
+// DB tags are permitted.
+
+import { describe, it, expect } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-340/acs/ac-${n}`;
+
+const SERVER_ROOT = join(__dirname, "..", "..");
+const SHARED_SRC = join(SERVER_ROOT, "..", "shared", "src");
+const read = (p: string) => readFileSync(p, "utf-8");
+
+const guard = read(join(SERVER_ROOT, "src", "__regression__", "spec-193-tripwire.regression.test.ts"));
+const scaffoldData = read(join(SHARED_SRC, "scaffold-data.ts"));
+const schema = read(join(SERVER_ROOT, "src", "db", "schema.ts"));
+
+describe("spec-340 ↔ spec-193 reconciliation (spec-340 t-7)", () => {
+  it("the spec-193 guard still FORBIDS a hand-maintained map, scoped to the scaffold layer (ac-34)", () => {
+    tagAc(AC(34));
+    // The prohibition exists and targets scaffoldData (the product prompting layer),
+    // not the DB schema — so it bans a hand-maintained product-side map, nothing more.
+    expect(guard).toMatch(/scaffoldData\)\.not\.toMatch\(\/tripwireTag\|standardTripwireMap\|TRIPWIRE_TO_STANDARD\|bridge\[- \]\?table\/i\)/);
+    // And the scaffold layer genuinely carries no such hand-maintained map today.
+    expect(scaffoldData).not.toMatch(/tripwireTag|standardTripwireMap|TRIPWIRE_TO_STANDARD|bridge[- ]?table/i);
+    // The narrowing is documented in the guard for a future reader (ac-34: legible intent).
+    expect(guard).toMatch(/spec-340 RECONCILIATION/);
+  });
+
+  it("PERMITS spec-340's auto-assigned clause→facet DB tags (ac-34)", () => {
+    tagAc(AC(34));
+    // The auto-assigned tags live in the DB schema (derived data), NOT the scaffold
+    // layer — this is what the narrowed guard explicitly allows.
+    expect(schema).toMatch(/export const standardClauseFacets = pgTable\(/);
+    // They are clause→facet membership rows (a tag store), exactly the kind of stored
+    // tag spec-193's default ruled out for the PRODUCT layer but spec-340 reverses for
+    // the DB. Confirm the prohibition does not reach the schema file.
+    expect(schema).toMatch(/facetId: uuid\("facet_id"\)/);
+  });
+});

--- a/packages/server/src/__regression__/tool-annotations.regression.test.ts
+++ b/packages/server/src/__regression__/tool-annotations.regression.test.ts
@@ -62,6 +62,9 @@ const READ_ONLY = new Set<string>([
   // nothing — the write happens only on the admin's approval through the
   // existing scaffold route — so readOnlyHint: true.
   "propose_scaffold_change",
+  // spec-340: the facets tool's v0 `list` verb only READS the vocabulary — no
+  // mutation, so readOnlyHint: true.
+  "facets",
 ]);
 
 // spec-358: discontinue_test_events now hard-deletes the orphan's emissions

--- a/packages/server/src/agent/handlers/facets.integration.test.ts
+++ b/packages/server/src/agent/handlers/facets.integration.test.ts
@@ -1,0 +1,77 @@
+// spec-340 t-6 (dec-9) — the verb-dispatched `facets` tool (v0: list), resolved via
+// the polymorphic owner. Tags ac-40.
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { and, eq } from "drizzle-orm";
+import { db } from "../../db/connection.js";
+import { namespaces, memexes, facets } from "../../db/schema.js";
+import { makeTestMemex, makePersonalTestMemex } from "../../services/test-helpers.js";
+import { seedDefaultFacetsForOwner } from "../../services/default-facets.js";
+import { listFacetsForMemex } from "../../services/facet-vocab.js";
+import { facetsTools } from "./facets.js";
+import { toolSpecs } from "../tool-specs.js";
+import type { ToolCtx } from "./shared.js";
+
+const SPEC = "mindset-prod/memex-building-itself/specs/spec-340";
+const AC = (n: number) => `${SPEC}/acs/ac-${n}`;
+
+let orgMemexId: string;
+let orgId: string;
+let personalMemexId: string;
+
+beforeAll(async () => {
+  orgMemexId = await makeTestMemex("ffac");
+  const [row] = await db
+    .select({ orgId: namespaces.ownerOrgId })
+    .from(memexes)
+    .innerJoin(namespaces, eq(memexes.namespaceId, namespaces.id))
+    .where(eq(memexes.id, orgMemexId))
+    .limit(1);
+  orgId = row!.orgId!;
+  await seedDefaultFacetsForOwner({ ownerType: "org", ownerId: orgId });
+
+  personalMemexId = await makePersonalTestMemex("ffacp");
+  await seedDefaultFacetsForOwner({ ownerType: "memex", ownerId: personalMemexId });
+});
+
+afterAll(async () => {
+  await db.delete(facets).where(and(eq(facets.ownerType, "org"), eq(facets.ownerId, orgId))).catch(() => {});
+  await db.delete(facets).where(and(eq(facets.ownerType, "memex"), eq(facets.ownerId, personalMemexId))).catch(() => {});
+});
+
+describe("the verb-dispatched facets tool (spec-340 t-6)", () => {
+  it("is exactly ONE verb-dispatched tool; no per-operation facet tools exist (ac-40)", () => {
+    tagAc(AC(40));
+    const names = toolSpecs.map((t) => t.name);
+    expect(names.filter((n) => /facet/i.test(n))).toEqual(["facets"]);
+    for (const banned of ["list_facets", "add_facet", "edit_facet", "delete_facet"]) {
+      expect(names).not.toContain(banned);
+    }
+    expect(Object.keys(facetsTools[0].schema)).toContain("verb");
+    expect(facetsTools[0].annotations.readOnlyHint).toBe(true);
+  });
+
+  it("verb 'list' returns the owner's vocabulary, resolved via owner_type/owner_id (ac-40)", async () => {
+    tagAc(AC(40));
+    // org-owned memex → resolves to the org owner
+    const orgVocab = await listFacetsForMemex(orgMemexId);
+    expect(orgVocab.length).toBe(16);
+    expect(orgVocab.every((f) => f.key && f.description)).toBe(true);
+    const ords = orgVocab.map((f) => f.ord);
+    expect(ords).toEqual([...ords].sort((a, b) => a - b));
+
+    const ctx = { resolveMemex: async () => orgMemexId } as unknown as ToolCtx;
+    const out = (await facetsTools[0].handler({ verb: "list" }, ctx)) as string;
+    expect(out).toContain("Facet vocabulary");
+    expect(out).toContain("security");
+    expect(out).toContain("db-migrations");
+
+    // personal memex → resolves to the memex owner (dec-7), returns ITS own vocabulary
+    const personalVocab = await listFacetsForMemex(personalMemexId);
+    expect(personalVocab.length).toBe(16);
+    const pctx = { resolveMemex: async () => personalMemexId } as unknown as ToolCtx;
+    const pout = (await facetsTools[0].handler({ verb: "list" }, pctx)) as string;
+    expect(pout).toContain("Facet vocabulary");
+  });
+});

--- a/packages/server/src/agent/handlers/facets.ts
+++ b/packages/server/src/agent/handlers/facets.ts
@@ -1,0 +1,48 @@
+// spec-340 t-6 (dec-9) — the verb-dispatched `facets` MCP tool.
+//
+// One tool for the whole facet-operations surface, dispatched on a `verb` so the
+// low-frequency facet operations never proliferate into separate top-level tools. v0
+// implements exactly the `list` verb; the deferred CRUD (add/edit/delete, dec-7) slots
+// in here as new verbs, never as new tools.
+//
+// Read-only (Phase 1 is inert): it reads the vocabulary via services/facet-vocab.ts,
+// resolved through the memex's polymorphic owner (dec-7). It does NOT import the LLM
+// classifier engine (dec-8).
+
+import { z } from "zod";
+import { ValidationError } from "../../types/errors.js";
+import { listFacetsForMemex } from "../../services/facet-vocab.js";
+import { MEMEX_DESC, VERBOSE_FIELD, type ToolSpec } from "./shared.js";
+
+export const facetsTools: ToolSpec[] = [
+  {
+    name: "facets",
+    annotations: { title: "Facets", readOnlyHint: true, destructiveHint: false },
+    description:
+      "Read your Memex's FACET vocabulary — the closed, per-owner set of cross-cutting practice areas (security, db-migrations, e2e-testing, api-design, …) that a standard's clauses are tagged with. Verb-dispatched so the whole facet surface stays one tool as it grows; v0 supports the verb 'list'.",
+    schema: {
+      verb: z
+        .enum(["list"])
+        .describe("The facet operation. v0: 'list' returns this Memex's facet vocabulary (key, name, description)."),
+      memex: z.string().optional().describe(MEMEX_DESC),
+      verbose: VERBOSE_FIELD,
+    },
+    async handler(input, ctx) {
+      const verb = input.verb as "list";
+      const memexId = await ctx.resolveMemex(input.memex as string | undefined);
+
+      if (verb === "list") {
+        const vocab = await listFacetsForMemex(memexId);
+        if (vocab.length === 0) {
+          return "No facets defined for this Memex yet.";
+        }
+        const lines = vocab.map(
+          (f) => `- ${f.key}${f.name ? ` (${f.name})` : ""}: ${f.description}`,
+        );
+        return `Facet vocabulary for this Memex (${vocab.length}):\n${lines.join("\n")}`;
+      }
+
+      throw new ValidationError(`Unknown facets verb '${verb as string}'.`);
+    },
+  },
+];

--- a/packages/server/src/agent/handlers/index.ts
+++ b/packages/server/src/agent/handlers/index.ts
@@ -12,4 +12,5 @@ export { lifecycleTools } from "./lifecycle.js";
 export { issuesTools } from "./issues.js";
 export { rolesTools } from "./roles.js";
 export { standardsTools } from "./standards.js";
+export { facetsTools } from "./facets.js";
 export { integrationsTools } from "./integrations.js";

--- a/packages/server/src/agent/tool-specs.audit.integration.test.ts
+++ b/packages/server/src/agent/tool-specs.audit.integration.test.ts
@@ -740,6 +740,9 @@ const REF_PROBE_SKIP = new Map<string, string>([
   // dec-1 sense. Tested separately via the verbose path and by the
   // per-mode pins.
   ["assess_spec", "returns analysis text keyed on handle, not a per-entity UUID confirmation"],
+  // spec-340: the facets list verb is a discovery/read tool — output is the facet
+  // vocabulary listing (key/name/description), not a per-entity `ref:` confirmation.
+  ["facets", "discovery tool — facet vocabulary listing, no per-entity confirmation"],
   // search_memex (b-34) is a discovery tool, not entity-acting — its output is a
   // ranked hit list with canonical URL paths as headings (no `ref:` lines per
   // hit and no per-call entity confirmation). Audited in ref-emission.regression

--- a/packages/server/src/agent/tool-specs.ts
+++ b/packages/server/src/agent/tool-specs.ts
@@ -58,6 +58,7 @@ import {
   issuesTools,
   rolesTools,
   standardsTools,
+  facetsTools,
   integrationsTools,
 } from "./handlers/index.js";
 // spec-360: the scaffold-assistant authoring tool (propose_scaffold_change).
@@ -96,6 +97,7 @@ export const toolSpecs: ToolSpec[] = [
   ...issuesTools,
   ...rolesTools,
   ...standardsTools,
+  ...facetsTools,
 
   // ── Codebase intelligence ─────────────────────────────────
   // TEMPORARILY DISABLED — codebase tools are commented out (both MCP + React UI agent).

--- a/packages/server/src/db/default-facets.fixture.ts
+++ b/packages/server/src/db/default-facets.fixture.ts
@@ -1,0 +1,122 @@
+// Default facet vocabulary (spec-340 t-2 / dec-7).
+//
+// The closed v1 set of 16 cross-cutting practice areas, seeded per organization
+// at provisioning. Each org gets its own editable copy; these are the product
+// DEFAULTS, not a global shared set. The `description` is the load-bearing field:
+// it is the rubric the classifier reads to decide whether a clause GOVERNS the
+// facet (sets a rule about it) versus merely MENTIONS it, and to disambiguate the
+// confusable pairs (security vs api-design, architecture vs code-style, …).
+// Precision is improved at the SOURCE here (dec-3), so each description draws the
+// boundary against its nearest neighbour.
+//
+// PORTABILITY (std-22): the vocabulary + descriptions are product-generic — no
+// language, framework, file path, tool, or tenant specifics. They apply to any
+// codebase a Memex sits on.
+
+export interface DefaultFacet {
+  /** Stable slug — the code/prompt/LLM anchor and the pill label by default. */
+  readonly key: string;
+  /** Renameable display label. */
+  readonly name: string;
+  /** The disambiguating classifier rubric (governs-vs-mentions + nearest-neighbour boundary). */
+  readonly description: string;
+}
+
+export const DEFAULT_FACETS: readonly DefaultFacet[] = [
+  {
+    key: "test-coverage",
+    name: "Test coverage",
+    description:
+      "Unit and service/integration tests that assert a unit of code behaves as specified. Governs a clause only when it sets a rule about writing, structuring, or requiring such tests (coverage thresholds, test-first, what must be tested) — not when it merely notes that something was tested. Distinct from e2e-testing, which exercises whole assembled flows rather than isolated units.",
+  },
+  {
+    key: "e2e-testing",
+    name: "End-to-end testing",
+    description:
+      "End-to-end / user-facing-flow testing that drives the assembled product the way a user would (e.g. browser journeys). Governs a clause that requires or shapes such journeys for user-facing changes. Distinct from test-coverage (isolated unit/service tests) and from post-deploy-smoke (which runs against a deployed environment, not the pre-merge build).",
+  },
+  {
+    key: "post-deploy-smoke",
+    name: "Post-deploy smoke",
+    description:
+      "Verification that runs against a live, deployed environment to confirm a release is healthy. Governs a clause mandating smoke checks or live verification after a deploy. Distinct from e2e-testing, which runs pre-merge against the build rather than against the deployed environment.",
+  },
+  {
+    key: "deploy-release",
+    name: "Deploy & release",
+    description:
+      "How software is promoted and released to an environment: branch-to-environment mapping, release gates, rollout, and rollback. Governs a clause about the deploy/release procedure itself. Distinct from ci-pr-process (the pre-merge pipeline) and post-deploy-smoke (verification after the release lands).",
+  },
+  {
+    key: "security",
+    name: "Security",
+    description:
+      "Authorization, tenancy isolation, authentication, secret handling, and input validation. Governs a clause that sets a rule protecting data or access (who may see a resource, how tenants are isolated, how secrets are stored, how input is validated). When an interface-shape rule exists for a security reason (e.g. return 404 not 403 to avoid leaking existence), prefer security over api-design.",
+  },
+  {
+    key: "architecture",
+    name: "Architecture",
+    description:
+      "System and module structure, boundaries, and design patterns — how components are separated and how they communicate. Governs a clause about where logic belongs or how pieces fit together. Distinct from code-style, which is about local conventions (naming, formatting, typing) rather than structural decomposition.",
+  },
+  {
+    key: "code-style",
+    name: "Code style",
+    description:
+      "Local code conventions: naming, formatting, lint rules, typing idioms, and file organization. Governs a clause prescribing how code is written at the line or file level. On a typing rule, prefer code-style unless the rule is really about module boundaries — then it is architecture.",
+  },
+  {
+    key: "db-migrations",
+    name: "Database & migrations",
+    description:
+      "Database schema and the migrations that change it: tables, columns, indexes, constraints, row-level security, and backfills. Governs a clause about schema shape or how a schema change is authored and applied. Distinct from api-design, which is about external contracts rather than persistence.",
+  },
+  {
+    key: "api-design",
+    name: "API design",
+    description:
+      "The shape and contract of an interface other code or clients call: endpoints, request/response shapes, status codes, versioning, and backward compatibility. Governs a clause about that contract. When a status-code or shape rule is chosen for a security reason, prefer security.",
+  },
+  {
+    key: "observability",
+    name: "Observability",
+    description:
+      "Error handling, logging, metrics, tracing, and the structured signals an operator reads to understand a running system. Governs a clause about how failures are surfaced or how activity is recorded for diagnosis. Distinct from post-deploy-smoke (a one-time verification step) — this is ongoing instrumentation.",
+  },
+  {
+    key: "performance",
+    name: "Performance",
+    description:
+      "Latency, throughput, resource use, and the budgets or limits that bound them. Governs a clause that sets a performance constraint or requires a hot path stay cheap. Not every mention of speed — only rules that bound or require performance characteristics.",
+  },
+  {
+    key: "accessibility",
+    name: "Accessibility & design system",
+    description:
+      "Conformance to accessibility and design-system standards so the product is usable by everyone: semantic markup, contrast, keyboard navigation, and component reuse. Governs a clause prescribing such conformance. Distinct from code-style, which is about code conventions rather than the rendered experience.",
+  },
+  {
+    key: "ci-pr-process",
+    name: "CI & PR process",
+    description:
+      "The pre-merge pipeline and contribution process: required checks, branch and commit conventions, and review/merge rules. Governs a clause about how a change gets reviewed and merged. Distinct from deploy-release, which promotes an already-merged change to an environment.",
+  },
+  {
+    key: "documentation",
+    name: "Documentation",
+    description:
+      "Human-readable docs that accompany the code: READMEs, changelogs, runbooks, and reference guides. Governs a clause requiring or shaping such documentation. A clause that merely IS documentation does not count — it must set a rule about producing or maintaining docs.",
+  },
+  {
+    key: "dependencies",
+    name: "Dependencies",
+    description:
+      "Third-party packages and their lifecycle: adding, pinning, upgrading, and single-version discipline across a workspace. Governs a clause about how external dependencies are chosen or managed. Distinct from architecture, which is about internal structure.",
+  },
+  {
+    key: "feature-flags",
+    name: "Feature flags & rollout",
+    description:
+      "Gated rollout and user migration: flags, staged enablement, and moving users from old to new behavior. Governs a clause about controlling the exposure of a change or migrating users. Distinct from deploy-release, which ships the code rather than gating who sees it.",
+  },
+];

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -2937,6 +2937,86 @@ export const presence = pgTable(
   ]
 );
 
+// ══════════════════════════════════════
+// Facets (spec-340 — the inert foundation, phase 1)
+// ══════════════════════════════════════
+
+// The facet vocabulary (spec-340 dec-7). A closed per-owner set of cross-cutting
+// practice areas (security, db-migrations, e2e-testing, …); each owner gets its own
+// editable copy of the default 16, seeded at provisioning (t-2/t-3).
+//
+// Owner is POLYMORPHIC (dec-7): `ownerType` ∈ {org, memex} + `ownerId`. An
+// org-owned memex shares its org's vocabulary (ownerType='org', ownerId=org.id, per
+// std-4); a personal memex with no owning org carries its own (ownerType='memex',
+// ownerId=memex.id). This supersedes the original org_id-only model so personal
+// memexes — which are NOT modelled as their own org — still get a vocabulary.
+// `ownerId` is intentionally NOT a foreign key (it points at one of two tables);
+// referential integrity for the org case is enforced by the seeding paths, not the
+// schema. Owner-config posture like org_scaffold_additions — NO memex_id, so NO
+// memex_isolation RLS (a row could never satisfy a memex_id=GUC predicate); access
+// is gated at the service layer by owner resolution + membership.
+export const facets = pgTable(
+  "facets",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    ownerType: text("owner_type").notNull(),
+    ownerId: uuid("owner_id").notNull(),
+    // Stable slug — the code/prompt/LLM anchor AND the pill label by default.
+    // Clause tags (and, in phase 2, ballots) anchor on this; a display rename never
+    // rewrites it (dec-5).
+    key: text("key").notNull(),
+    // Renameable display override; the pill shows name ?? key.
+    name: text("name"),
+    // REQUIRED disambiguating rubric the classifier reads (dec-7) — never null.
+    description: text("description").notNull(),
+    // Advisory display order.
+    ord: integer("ord").notNull().default(0),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    // Per-owner uniqueness — two owners may diverge under the same key (dec-7).
+    unique("facets_owner_key_unique").on(table.ownerType, table.ownerId, table.key),
+    index("facets_owner_idx").on(table.ownerType, table.ownerId),
+    check("facets_owner_type_valid", sql`${table.ownerType} IN ('org', 'memex')`),
+  ],
+);
+
+// Clause→facet tags (spec-340 dec-2/dec-8) — assigned by the agent-driven classifier
+// (local backfill in phase 1; NOT a hand-maintained join — the distinction the
+// spec-193 guard reconciliation rides, t-7). Memex-scoped (rides the standards
+// corpus). The tri-state the design requires is encoded by the nullable facet_id:
+//   • NO rows for a clause            → not-yet-classified
+//   • exactly one row, facet_id NULL  → explicit "governs nothing"
+//   • one row per member facet         → governs those facets
+// Standard-level pills are the union over member rows only.
+export const standardClauseFacets = pgTable(
+  "standard_clause_facets",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    memexId: uuid("memex_id").notNull(),
+    clauseId: uuid("clause_id")
+      .notNull()
+      .references(() => standardClauses.id, { onDelete: "cascade" }),
+    // NULL = the explicit "governs nothing" marker, distinguishable from no rows.
+    facetId: uuid("facet_id").references(() => facets.id, { onDelete: "cascade" }),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    // At most one membership row per (clause, facet).
+    uniqueIndex("standard_clause_facets_clause_facet_unique")
+      .on(table.clauseId, table.facetId)
+      .where(sql`${table.facetId} IS NOT NULL`),
+    // At most one explicit-none marker per clause.
+    uniqueIndex("standard_clause_facets_clause_none_unique")
+      .on(table.clauseId)
+      .where(sql`${table.facetId} IS NULL`),
+    index("standard_clause_facets_clause_id_idx").on(table.clauseId),
+    index("standard_clause_facets_facet_id_idx").on(table.facetId),
+    index("standard_clause_facets_memex_id_idx").on(table.memexId),
+  ],
+);
+
 // ── Relations (codebase intelligence) ────────────
 // Minimum set the services are likely to need. Extend as needed.
 
@@ -2975,6 +3055,10 @@ export const symbolsRelations = relations(symbols, ({ one }) => ({
 export type Doc = InferSelectModel<typeof documents>;
 export type DocSection = InferSelectModel<typeof docSections>;
 export type StandardClause = InferSelectModel<typeof standardClauses>;
+export type Facet = InferSelectModel<typeof facets>;
+export type FacetInsert = InferInsertModel<typeof facets>;
+export type StandardClauseFacet = InferSelectModel<typeof standardClauseFacets>;
+export type StandardClauseFacetInsert = InferInsertModel<typeof standardClauseFacets>;
 export type ClauseRef = InferSelectModel<typeof clauseRefs>;
 export type ClauseRefInsert = InferInsertModel<typeof clauseRefs>;
 export type DocComment = InferSelectModel<typeof docComments>;

--- a/packages/server/src/services/default-facets-autoseed.integration.test.ts
+++ b/packages/server/src/services/default-facets-autoseed.integration.test.ts
@@ -1,0 +1,87 @@
+// spec-340 t-3 — the two make-or-break auto-seed paths: a freshly-created org and a
+// freshly-created personal Memex each land with the 16 default facets, no manual step
+// (ac-31). The suite-wide MEMEX_DEFAULT_FACETS_SEED=off gate (vitest.config.ts) is
+// stubbed back ON here per the spec-178/184 sibling pattern (read at call time).
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { and, eq } from "drizzle-orm";
+import { db } from "../db/connection.js";
+import { facets, users, namespaces, memexes } from "../db/schema.js";
+import { DEFAULT_FACETS } from "../db/default-facets.fixture.js";
+import { createOrgForUser } from "./orgs.js";
+import { ensureUserNamespace } from "./user-namespaces.js";
+
+const SPEC = "mindset-prod/memex-building-itself/specs/spec-340";
+const AC = (n: number) => `${SPEC}/acs/ac-${n}`;
+
+const KEYS = new Set(DEFAULT_FACETS.map((f) => f.key));
+const uniq = (p: string) => `${p}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 7)}`;
+
+async function facetKeysFor(ownerType: "org" | "memex", ownerId: string): Promise<Set<string>> {
+  const rows = await db
+    .select({ key: facets.key })
+    .from(facets)
+    .where(and(eq(facets.ownerType, ownerType), eq(facets.ownerId, ownerId)));
+  return new Set(rows.map((r) => r.key));
+}
+
+let savedGate: string | undefined;
+const createdOrgIds: string[] = [];
+const createdMemexIds: string[] = [];
+
+beforeAll(() => {
+  // Turn the auto-seed back ON for this suite (it is off suite-wide).
+  savedGate = process.env.MEMEX_DEFAULT_FACETS_SEED;
+  delete process.env.MEMEX_DEFAULT_FACETS_SEED;
+});
+
+afterAll(async () => {
+  if (savedGate === undefined) delete process.env.MEMEX_DEFAULT_FACETS_SEED;
+  else process.env.MEMEX_DEFAULT_FACETS_SEED = savedGate;
+  for (const id of createdOrgIds) {
+    await db.delete(facets).where(and(eq(facets.ownerType, "org"), eq(facets.ownerId, id))).catch(() => {});
+  }
+  for (const id of createdMemexIds) {
+    await db.delete(facets).where(and(eq(facets.ownerType, "memex"), eq(facets.ownerId, id))).catch(() => {});
+  }
+});
+
+describe("auto-seed the 16 facets on creation (spec-340 t-3, dec-7)", () => {
+  it("creating a new org auto-seeds the 16 facets (owner_type='org') (ac-31)", async () => {
+    tagAc(AC(31));
+    const [user] = await db
+      .insert(users)
+      .values({ email: `${uniq("facorg")}@example.com`, emailVerifiedAt: new Date() } as typeof users.$inferInsert)
+      .returning();
+    // The user needs a personal namespace first (mirrors the real signup→create-org flow).
+    await ensureUserNamespace(user.id);
+
+    const created = await createOrgForUser({ slug: uniq("facorg"), name: "Facet Org", userId: user.id });
+    createdOrgIds.push(created.org.id);
+
+    expect(await facetKeysFor("org", created.org.id)).toEqual(KEYS);
+  });
+
+  it("creating a new personal Memex auto-seeds the 16 facets (owner_type='memex') (ac-31)", async () => {
+    tagAc(AC(31));
+    const [user] = await db
+      .insert(users)
+      .values({ email: `${uniq("facmem")}@example.com`, emailVerifiedAt: new Date() } as typeof users.$inferInsert)
+      .returning();
+
+    const { memex } = await ensureUserNamespace(user.id);
+    createdMemexIds.push(memex.id);
+
+    // The namespace is personal (kind='user'), so the owner is the memex itself.
+    const [ns] = await db
+      .select({ kind: namespaces.kind })
+      .from(memexes)
+      .innerJoin(namespaces, eq(namespaces.id, memexes.namespaceId))
+      .where(eq(memexes.id, memex.id))
+      .limit(1);
+    expect(ns.kind).toBe("user");
+
+    expect(await facetKeysFor("memex", memex.id)).toEqual(KEYS);
+  });
+});

--- a/packages/server/src/services/default-facets.integration.test.ts
+++ b/packages/server/src/services/default-facets.integration.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { tagAc } from "@memex-ai-ac/vitest";
-import { and, eq, inArray } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { db } from "../db/connection.js";
 import { facets, namespaces, memexes } from "../db/schema.js";
 import { DEFAULT_FACETS } from "../db/default-facets.fixture.js";

--- a/packages/server/src/services/default-facets.integration.test.ts
+++ b/packages/server/src/services/default-facets.integration.test.ts
@@ -1,0 +1,121 @@
+// spec-340 t-2 — per-owner default-facet seeding + the backfill that seeds every
+// existing org AND personal memex. DB-backed: the zero-row idempotency guard and the
+// (owner_type, owner_id, key) uniqueness are enforced by Postgres.
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { and, eq, inArray } from "drizzle-orm";
+import { db } from "../db/connection.js";
+import { facets, namespaces, memexes } from "../db/schema.js";
+import { DEFAULT_FACETS } from "../db/default-facets.fixture.js";
+import {
+  seedDefaultFacetsForOwner,
+  backfillDefaultFacetsAllOwners,
+} from "./default-facets.js";
+import { makeTestMemex, makePersonalTestMemex } from "./test-helpers.js";
+import { ownerForMemex } from "./shared/memex-ownership.js";
+
+const SPEC = "mindset-prod/memex-building-itself/specs/spec-340";
+const AC = (n: number) => `${SPEC}/acs/ac-${n}`;
+
+async function orgIdFor(memexId: string): Promise<string> {
+  const [row] = await db
+    .select({ orgId: namespaces.ownerOrgId })
+    .from(memexes)
+    .innerJoin(namespaces, eq(memexes.namespaceId, namespaces.id))
+    .where(eq(memexes.id, memexId))
+    .limit(1);
+  if (!row?.orgId) throw new Error("could not resolve org for test memex");
+  return row.orgId;
+}
+
+async function facetKeysFor(ownerType: "org" | "memex", ownerId: string): Promise<string[]> {
+  const rows = await db
+    .select({ key: facets.key, name: facets.name, ord: facets.ord })
+    .from(facets)
+    .where(and(eq(facets.ownerType, ownerType), eq(facets.ownerId, ownerId)));
+  return rows.map((r) => r.key);
+}
+
+let orgMemexId: string;
+let orgId: string;
+let personalMemexId: string;
+
+beforeAll(async () => {
+  orgMemexId = await makeTestMemex("facseed");
+  orgId = await orgIdFor(orgMemexId);
+  personalMemexId = await makePersonalTestMemex("facseedp");
+});
+
+afterAll(async () => {
+  await db.delete(facets).where(and(eq(facets.ownerType, "org"), eq(facets.ownerId, orgId))).catch(() => {});
+  await db.delete(facets).where(and(eq(facets.ownerType, "memex"), eq(facets.ownerId, personalMemexId))).catch(() => {});
+});
+
+describe("default-facet seeding per owner (spec-340 t-2)", () => {
+  it("seeds exactly the 16 defaults with stable key, label, and fixture order (ac-32)", async () => {
+    tagAc(AC(32));
+    await seedDefaultFacetsForOwner({ ownerType: "org", ownerId: orgId });
+
+    const rows = await db
+      .select({ key: facets.key, name: facets.name, ord: facets.ord })
+      .from(facets)
+      .where(and(eq(facets.ownerType, "org"), eq(facets.ownerId, orgId)))
+      .orderBy(facets.ord);
+
+    expect(rows.length).toBe(DEFAULT_FACETS.length); // 16
+    expect(rows.map((r) => r.key)).toEqual(DEFAULT_FACETS.map((f) => f.key));
+    expect(rows.map((r) => r.name)).toEqual(DEFAULT_FACETS.map((f) => f.name));
+    expect(rows.map((r) => r.ord)).toEqual(DEFAULT_FACETS.map((_, i) => i));
+    // Every facet carries a non-empty description (the classifier rubric is REQUIRED).
+    const descs = await db
+      .select({ description: facets.description })
+      .from(facets)
+      .where(and(eq(facets.ownerType, "org"), eq(facets.ownerId, orgId)));
+    expect(descs.every((d) => d.description.length > 0)).toBe(true);
+  });
+
+  it("is idempotent — re-running seeds no duplicates, keys/ids unchanged (ac-36)", async () => {
+    tagAc(AC(36));
+    const before = await db
+      .select({ id: facets.id, key: facets.key })
+      .from(facets)
+      .where(and(eq(facets.ownerType, "org"), eq(facets.ownerId, orgId)));
+    // Re-seed twice — the zero-row guard short-circuits, no new rows, ids preserved.
+    await seedDefaultFacetsForOwner({ ownerType: "org", ownerId: orgId });
+    await seedDefaultFacetsForOwner({ ownerType: "org", ownerId: orgId });
+    const after = await db
+      .select({ id: facets.id, key: facets.key })
+      .from(facets)
+      .where(and(eq(facets.ownerType, "org"), eq(facets.ownerId, orgId)));
+
+    expect(after.length).toBe(before.length);
+    expect(new Set(after.map((r) => r.id))).toEqual(new Set(before.map((r) => r.id)));
+  });
+});
+
+describe("backfill seeds every org AND personal memex (spec-340 t-2, ac-31)", () => {
+  it("after backfill, both an org owner and a personal memex carry the 16 defaults (ac-31, ac-36)", async () => {
+    tagAc(AC(31));
+    tagAc(AC(36));
+
+    // Personal memex starts with no vocabulary (makePersonalTestMemex doesn't seed).
+    expect(await ownerForMemex(personalMemexId)).toEqual({ ownerType: "memex", ownerId: personalMemexId });
+    expect((await facetKeysFor("memex", personalMemexId)).length).toBe(0);
+
+    await backfillDefaultFacetsAllOwners();
+
+    // The org owner carries the 16 (idempotent over the t-2 describe's seed).
+    expect(new Set(await facetKeysFor("org", orgId))).toEqual(new Set(DEFAULT_FACETS.map((f) => f.key)));
+    // The personal memex now carries its own copy of the 16 — the make-or-break path
+    // a naive org-only seed would have missed (dec-7).
+    expect(new Set(await facetKeysFor("memex", personalMemexId))).toEqual(
+      new Set(DEFAULT_FACETS.map((f) => f.key)),
+    );
+
+    // Idempotent: a second backfill leaves counts unchanged.
+    await backfillDefaultFacetsAllOwners();
+    expect((await facetKeysFor("memex", personalMemexId)).length).toBe(DEFAULT_FACETS.length);
+    expect((await facetKeysFor("org", orgId)).length).toBe(DEFAULT_FACETS.length);
+  });
+});

--- a/packages/server/src/services/default-facets.ts
+++ b/packages/server/src/services/default-facets.ts
@@ -1,0 +1,105 @@
+// Default facet vocabulary seeding (spec-340 t-2 / t-3, dec-7).
+//
+// Seeds an owner (an org, or a personal memex with no owning org) with its own copy
+// of the default 16 facets so it lands with a working vocabulary. The canonical
+// content lives ONCE in db/default-facets.fixture.ts; this module is the idempotent
+// write path. Mirrors services/default-standards.ts (the spec-184 sibling): defaults
+// are ORDINARY editable rows with NO marker, so idempotency keys off "the owner
+// already has ≥1 facet" (the zero-row guard) — which also means a backfill touches
+// only owners with an empty vocabulary.
+//
+// std-8: the facets table is owner-config (like org_scaffold_additions) with no
+// bus entity and no SSE subscriber in phase 1 (the inert foundation), so these
+// writes do not route through mutate(). Allowlisted in
+// mutate-coverage.static-scan.regression.test.ts; route through mutate() in phase 2
+// when a live editing/pill surface lands.
+
+import { and, eq } from "drizzle-orm";
+import { db } from "../db/connection.js";
+import { facets, memexes, namespaces, orgs } from "../db/schema.js";
+import { DEFAULT_FACETS } from "../db/default-facets.fixture.js";
+import { ownerForMemex, type FacetOwner } from "./shared/memex-ownership.js";
+
+// Count an owner's facet rows. The seed/backfill guard: an owner with ANY facet is
+// left untouched (no marker → we can't distinguish ours from the owner's own edits).
+async function countFacets(owner: FacetOwner): Promise<number> {
+  const rows = await db
+    .select({ id: facets.id })
+    .from(facets)
+    .where(and(eq(facets.ownerType, owner.ownerType), eq(facets.ownerId, owner.ownerId)));
+  return rows.length;
+}
+
+// Seed an owner with the default 16 facets. Idempotent via the zero-row guard plus
+// onConflictDoNothing on (owner_type, owner_id, key), so a concurrent double-seed
+// (e.g. an email-resend race) is absorbed rather than 23505-ing. `ord` follows
+// fixture order. The stable key + immutable id are never rewritten.
+export async function seedDefaultFacetsForOwner(owner: FacetOwner): Promise<void> {
+  if ((await countFacets(owner)) > 0) return;
+  await db
+    .insert(facets)
+    .values(
+      DEFAULT_FACETS.map((f, i) => ({
+        ownerType: owner.ownerType,
+        ownerId: owner.ownerId,
+        key: f.key,
+        name: f.name,
+        description: f.description,
+        ord: i,
+      })),
+    )
+    .onConflictDoNothing();
+}
+
+// Best-effort wrapper fired from a provisioning funnel (org creation, t-3). A
+// rejection is caught and logged so it never propagates out of creation (the owner
+// must still be created even if the seed fails). Gated off by
+// MEMEX_DEFAULT_FACETS_SEED=off (read at call time); mirrors
+// seedDefaultStandardsBestEffort.
+export async function seedDefaultFacetsForOwnerBestEffort(owner: FacetOwner): Promise<void> {
+  if (process.env.MEMEX_DEFAULT_FACETS_SEED === "off") return;
+  try {
+    await seedDefaultFacetsForOwner(owner);
+  } catch (err) {
+    console.error("[default-facets seed]", err);
+  }
+}
+
+// Best-effort seed for a memex by resolving its owner first (the personal-memex
+// auto-seed hook, t-3). For an org-owned memex this resolves to the org owner; for a
+// personal memex (no owning org) it resolves to the memex itself (dec-7).
+export async function seedDefaultFacetsForMemexBestEffort(memexId: string): Promise<void> {
+  if (process.env.MEMEX_DEFAULT_FACETS_SEED === "off") return;
+  try {
+    const owner = await ownerForMemex(memexId);
+    if (owner) await seedDefaultFacetsForOwner(owner);
+  } catch (err) {
+    console.error("[default-facets seed]", err);
+  }
+}
+
+// t-2 backfill: seed every existing org AND every existing personal memex with the
+// default 16 (idempotent per owner via the zero-row guard). An owner with zero facets
+// is a defect, not a valid state (ac-31). Returns counts for the operator's log.
+export async function backfillDefaultFacetsAllOwners(): Promise<{
+  orgs: number;
+  personalMemexes: number;
+}> {
+  const orgRows = await db.select({ id: orgs.id }).from(orgs);
+  for (const o of orgRows) {
+    await seedDefaultFacetsForOwner({ ownerType: "org", ownerId: o.id });
+  }
+
+  // Personal memexes: those under a user-kind namespace (no owning org). Each owns
+  // its vocabulary directly (owner_type='memex').
+  const personal = await db
+    .select({ id: memexes.id })
+    .from(memexes)
+    .innerJoin(namespaces, eq(namespaces.id, memexes.namespaceId))
+    .where(eq(namespaces.kind, "user"));
+  for (const m of personal) {
+    await seedDefaultFacetsForOwner({ ownerType: "memex", ownerId: m.id });
+  }
+
+  return { orgs: orgRows.length, personalMemexes: personal.length };
+}

--- a/packages/server/src/services/facet-classifier.integration.test.ts
+++ b/packages/server/src/services/facet-classifier.integration.test.ts
@@ -1,0 +1,162 @@
+// spec-340 t-4 — the clause→facet classifier engine. DB-backed for the persistence +
+// rollup; the LLM call is exercised through an injected stub (key-free) that captures
+// the model + structured-output config and measures concurrency. Tags ac-39.
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { and, eq, isNull } from "drizzle-orm";
+import { db } from "../db/connection.js";
+import { facets, standardClauseFacets, namespaces, memexes, documents, docSections, standardClauses } from "../db/schema.js";
+import {
+  classifyStandard,
+  backfillFacetTagsForMemex,
+  standardPillSet,
+  type AnthropicLike,
+} from "./facet-classifier.js";
+import { seedDefaultFacetsForOwner } from "./default-facets.js";
+import { makeTestMemex } from "./test-helpers.js";
+
+const SPEC = "mindset-prod/memex-building-itself/specs/spec-340";
+const AC = (n: number) => `${SPEC}/acs/ac-${n}`;
+
+async function orgIdFor(memexId: string): Promise<string> {
+  const [row] = await db
+    .select({ orgId: namespaces.ownerOrgId })
+    .from(memexes)
+    .innerJoin(namespaces, eq(memexes.namespaceId, namespaces.id))
+    .where(eq(memexes.id, memexId))
+    .limit(1);
+  if (!row?.orgId) throw new Error("could not resolve org for test memex");
+  return row.orgId;
+}
+
+let memexId: string;
+let orgId: string;
+let docId: string;
+let sectionId: string;
+const clauseIds: string[] = [];
+
+async function addClause(body: string): Promise<string> {
+  const [cl] = await db
+    .insert(standardClauses)
+    .values({ memexId, docId, sectionId, seq: clauseIds.length + 1, position: clauseIds.length + 1, body })
+    .returning();
+  clauseIds.push(cl.id);
+  return cl.id;
+}
+
+beforeAll(async () => {
+  memexId = await makeTestMemex("faccls");
+  orgId = await orgIdFor(memexId);
+  await seedDefaultFacetsForOwner({ ownerType: "org", ownerId: orgId });
+
+  const [doc] = await db
+    .insert(documents)
+    .values({ memexId, handle: "std-faccls", title: "Classifier test standard", docType: "standard", status: "approved" })
+    .returning();
+  docId = doc.id;
+  const [section] = await db
+    .insert(docSections)
+    .values({ docId, sectionType: "rule", content: "x", seq: 1, position: 1 })
+    .returning();
+  sectionId = section.id;
+  await addClause("All database access must enforce row-level security per tenant.");
+  await addClause("This is a rationale clause that merely explains why; it governs nothing.");
+  await addClause("Every endpoint must validate its input and return 404 (not 403) on unauthorized access.");
+  await addClause("Use parameterized queries and never interpolate untrusted input.");
+  await addClause("Prefer small focused files over large ones.");
+});
+
+afterAll(async () => {
+  await db.delete(standardClauseFacets).where(eq(standardClauseFacets.memexId, memexId)).catch(() => {});
+  await db.delete(facets).where(and(eq(facets.ownerType, "org"), eq(facets.ownerId, orgId))).catch(() => {});
+  if (docId) await db.delete(documents).where(eq(documents.id, docId)).catch(() => {});
+});
+
+describe("facet classifier engine (spec-340 t-4)", () => {
+  it("uses claude-opus-4-8 + Anthropic structured output, and classifies clauses in bounded-parallel (ac-39)", async () => {
+    tagAc(AC(39));
+    const seenModels: string[] = [];
+    let sawStructuredFormat = false;
+    let inFlight = 0;
+    let maxInFlight = 0;
+
+    const stub: AnthropicLike = {
+      messages: {
+        parse: async (args: { model: string; output_config?: { format?: unknown } }) => {
+          seenModels.push(args.model);
+          if (args.output_config?.format) sawStructuredFormat = true;
+          inFlight++;
+          maxInFlight = Math.max(maxInFlight, inFlight);
+          await new Promise((r) => setTimeout(r, 15));
+          inFlight--;
+          // structured output: the SDK returns the validated object on parsed_output —
+          // no raw JSON parsing by the caller.
+          return { parsed_output: { facetKeys: ["security"] } };
+        },
+      },
+    };
+
+    await classifyStandard(memexId, docId, { client: stub });
+
+    // One call per clause, every call on the coding-agent model.
+    expect(seenModels.length).toBe(clauseIds.length);
+    expect(new Set(seenModels)).toEqual(new Set(["claude-opus-4-8"]));
+    // Structured output, not raw JSON parsing.
+    expect(sawStructuredFormat).toBe(true);
+    // Parallel (more than one in flight at once) but bounded (never all five — the
+    // pool caps concurrency; with 5 clauses and a cap of 8 it would be 5, so assert
+    // it actually ran concurrently rather than serially).
+    expect(maxInFlight).toBeGreaterThan(1);
+  });
+
+  it("persists the tri-state via the deterministic classify seam (governs / explicit-none) (ac-39)", async () => {
+    tagAc(AC(39));
+    // A deterministic classifier: clause body decides its facets — no LLM.
+    const classify = (body: string): string[] => {
+      if (body.includes("row-level security")) return ["security", "db-migrations"];
+      if (body.includes("rationale")) return []; // governs nothing → explicit-none
+      if (body.includes("404")) return ["security", "api-design"];
+      if (body.includes("parameterized")) return ["security"];
+      return []; // "small focused files" → code-style in reality, but [] exercises explicit-none too
+    };
+    await classifyStandard(memexId, docId, { classify });
+
+    // clause[0] → two member rows (security, db-migrations).
+    const c0 = await db.select().from(standardClauseFacets).where(eq(standardClauseFacets.clauseId, clauseIds[0]));
+    expect(c0.length).toBe(2);
+    expect(c0.every((r) => r.facetId !== null)).toBe(true);
+
+    // clause[1] (rationale) → exactly one explicit-none marker (facet_id NULL).
+    const c1 = await db
+      .select()
+      .from(standardClauseFacets)
+      .where(and(eq(standardClauseFacets.clauseId, clauseIds[1]), isNull(standardClauseFacets.facetId)));
+    expect(c1.length).toBe(1);
+
+    // The standard's pill set is the UNION of member keys (explicit-none excluded).
+    const pills = await standardPillSet(memexId, docId);
+    expect(pills).toEqual(["api-design", "db-migrations", "security"]);
+  });
+
+  it("backfill tags every standard's clauses and is idempotent (ac-39)", async () => {
+    tagAc(AC(39));
+    const classify = (body: string): string[] => (body.includes("rationale") ? [] : ["security"]);
+
+    const first = await backfillFacetTagsForMemex(memexId, { classify });
+    expect(first.standards).toBeGreaterThanOrEqual(1);
+    expect(first.clauses).toBe(clauseIds.length);
+
+    // Every clause now carries exactly one row (member or none-marker) — none left
+    // not-yet-classified.
+    const after = await db.select().from(standardClauseFacets).where(eq(standardClauseFacets.memexId, memexId));
+    const byClause = new Map<string, number>();
+    for (const r of after) byClause.set(r.clauseId, (byClause.get(r.clauseId) ?? 0) + 1);
+    for (const id of clauseIds) expect(byClause.get(id)).toBeGreaterThanOrEqual(1);
+
+    // Idempotent: a second run replaces, doesn't duplicate — clause[0] still has 1 row.
+    await backfillFacetTagsForMemex(memexId, { classify });
+    const c0 = await db.select().from(standardClauseFacets).where(eq(standardClauseFacets.clauseId, clauseIds[0]));
+    expect(c0.length).toBe(1);
+  });
+});

--- a/packages/server/src/services/facet-classifier.integration.test.ts
+++ b/packages/server/src/services/facet-classifier.integration.test.ts
@@ -159,4 +159,47 @@ describe("facet classifier engine (spec-340 t-4)", () => {
     const c0 = await db.select().from(standardClauseFacets).where(eq(standardClauseFacets.clauseId, clauseIds[0]));
     expect(c0.length).toBe(1);
   });
+
+  it("retries a transient blip and still tags every clause — one 429 never aborts the run (ac-39)", async () => {
+    tagAc(AC(39));
+    // The first parse call across the whole run throws a 429; the pool must retry it
+    // (backoff) and complete rather than abort — the robustness a long backfill needs.
+    let calls = 0;
+    let threwOnce = false;
+    const stub: AnthropicLike = {
+      messages: {
+        parse: async () => {
+          calls++;
+          if (!threwOnce) {
+            threwOnce = true;
+            throw Object.assign(new Error("overloaded"), { status: 429 });
+          }
+          return { parsed_output: { facetKeys: ["security"] } };
+        },
+      },
+    };
+
+    await classifyStandard(memexId, docId, { client: stub });
+
+    // One retry = exactly one extra call beyond the clause count, and every clause tagged.
+    expect(calls).toBe(clauseIds.length + 1);
+    const rows = await db
+      .select()
+      .from(standardClauseFacets)
+      .where(eq(standardClauseFacets.memexId, memexId));
+    const tagged = new Set(rows.map((r) => r.clauseId));
+    for (const id of clauseIds) expect(tagged.has(id)).toBe(true);
+  });
+
+  it("does NOT retry a non-transient error — it surfaces and aborts (ac-39)", async () => {
+    tagAc(AC(39));
+    const stub: AnthropicLike = {
+      messages: {
+        parse: async () => {
+          throw Object.assign(new Error("bad request"), { status: 400 });
+        },
+      },
+    };
+    await expect(classifyStandard(memexId, docId, { client: stub })).rejects.toThrow();
+  });
 });

--- a/packages/server/src/services/facet-classifier.ts
+++ b/packages/server/src/services/facet-classifier.ts
@@ -27,9 +27,22 @@ import { vocabForMemex, type VocabFacet } from "./facet-vocab.js";
 // classifier is a one-off local backfill, so it runs on the most capable tier.
 const MODEL = "claude-opus-4-8";
 
-// How many clauses to classify concurrently. Bounded so a large standards corpus
-// doesn't open hundreds of simultaneous Anthropic requests (ac-39: bounded concurrency).
-const CONCURRENCY = 8;
+// Per-clause LLM calls are independent, so the backfill runs them through a bounded
+// pool rather than one-at-a-time — the difference between a ~hour and a few minutes
+// over the full corpus. The cap keeps us inside Anthropic's rate limits. 16 keeps the
+// full ~2k-clause corpus under ~4 min while staying inside the per-tier limit; push it
+// higher via CLASSIFY_CONCURRENCY when the key's tier allows.
+function defaultConcurrency(): number {
+  const fromEnv = Number(process.env.CLASSIFY_CONCURRENCY);
+  return Number.isFinite(fromEnv) && fromEnv > 0 ? Math.floor(fromEnv) : 16;
+}
+
+// A long backfill against a rate-limited endpoint WILL see transient blips
+// (429/overload/5xx/network). Without a retry, a single blip rejects the whole pool
+// and aborts the run partway. Retry transients with exponential backoff + jitter so
+// one blip never aborts a long run.
+const MAX_RETRIES = 5;
+const RETRY_BASE_MS = 500;
 
 // Structured-output contract: the facet slugs the clause GOVERNS. Empty = the clause
 // governs nothing (explicit none). Kept to a plain string array so the JSON Schema
@@ -57,26 +70,62 @@ export interface ClassifyOptions {
    * LLM is never called — used to test the orchestration + persistence key-free.
    */
   classify?: (clauseBody: string, vocab: VocabFacet[]) => Promise<string[]> | string[];
+  /**
+   * Max in-flight clause classifications. Defaults to CLASSIFY_CONCURRENCY env or 16.
+   * A pool, not a batch — each clause is still its own LLM call + DB write.
+   */
+  concurrency?: number;
+  /** Progress hook for long runs (called after each clause is tagged). */
+  onProgress?: (done: number, total: number) => void;
 }
 
-// Run `fn` over `items` with at most `limit` in flight at once — bounded-concurrency
-// parallelism (ac-39). Order of results matches input order.
-async function mapWithConcurrency<T, R>(
+/** Transient = worth retrying (rate-limit, overload, gateway, connection blip). */
+function isTransient(err: unknown): boolean {
+  const status = (err as { status?: number })?.status;
+  if (typeof status === "number") {
+    return status === 408 || status === 409 || status === 429 || (status >= 500 && status <= 599);
+  }
+  // Network-layer errors (no HTTP status) — connection reset/timeout/etc.
+  const name = (err as { name?: string })?.name ?? "";
+  return /connection|timeout|socket|network|fetch/i.test(name);
+}
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+/** Retry a thunk on transient failures with exponential backoff + jitter. */
+async function withTransientRetry<T>(fn: () => Promise<T>): Promise<T> {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      if (attempt >= MAX_RETRIES || !isTransient(err)) throw err;
+      const backoff = RETRY_BASE_MS * 2 ** attempt;
+      const jitter = Math.floor(backoff * 0.25 * Math.random());
+      await sleep(backoff + jitter);
+    }
+  }
+}
+
+/**
+ * Run `fn` over `items` with at most `limit` concurrent in-flight — bounded-concurrency
+ * parallelism (ac-39). Side-effecting (each unit classifies + persists one clause). A
+ * worker that throws rejects the whole run — callers want a hard failure, not silent gaps.
+ */
+async function forEachConcurrent<T>(
   items: readonly T[],
   limit: number,
-  fn: (item: T, index: number) => Promise<R>,
-): Promise<R[]> {
-  const results = new Array<R>(items.length);
+  fn: (item: T, index: number) => Promise<void>,
+): Promise<void> {
   let next = 0;
-  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
+  const worker = async (): Promise<void> => {
     while (true) {
       const i = next++;
       if (i >= items.length) return;
-      results[i] = await fn(items[i], i);
+      await fn(items[i], i);
     }
-  });
-  await Promise.all(workers);
-  return results;
+  };
+  const lanes = Math.max(1, Math.min(limit, items.length));
+  await Promise.all(Array.from({ length: lanes }, () => worker()));
 }
 
 function classifierSystemPrompt(vocab: VocabFacet[]): string {
@@ -108,13 +157,27 @@ export async function classifyClauseWithLlm(
     return filterToVocab(await opts.classify(clauseBody, vocab), vocab);
   }
   const client = opts.client ?? (getAnthropicClient() as unknown as AnthropicLike);
-  const message = await client.messages.parse({
-    model: MODEL,
-    max_tokens: 1024,
-    system: classifierSystemPrompt(vocab),
-    output_config: { format: zodOutputFormat(FacetVerdictSchema) },
-    messages: [{ role: "user", content: `Clause:\n\n${clauseBody}` }],
-  });
+  const message = await withTransientRetry(() =>
+    client.messages.parse({
+      model: MODEL,
+      max_tokens: 1024,
+      // The vocab system prompt is byte-identical across every clause in a run, so it's
+      // the repeated prefix to cache (Anthropic caching is explicit — std-30). CAVEAT:
+      // caching only fires once the cached prefix clears the model's minimum (Opus 4.8 =
+      // 4096 tokens). Today's 16-facet prompt is ~1.8k tokens, so on Opus this marker is
+      // an inert no-op; it starts paying off if the vocab grows past the floor or the
+      // model moves to a lower one.
+      system: [
+        {
+          type: "text",
+          text: classifierSystemPrompt(vocab),
+          cache_control: { type: "ephemeral" },
+        },
+      ],
+      output_config: { format: zodOutputFormat(FacetVerdictSchema) },
+      messages: [{ role: "user", content: `Clause:\n\n${clauseBody}` }],
+    }),
+  );
   if (!message.parsed_output) {
     throw new Error("facet-classifier: structured output returned no parsed_output");
   }
@@ -148,16 +211,21 @@ export async function tagClause(
   });
 }
 
-// Classify + tag a set of clauses with bounded-concurrency parallelism (ac-39).
+// Classify + tag a set of clauses through a bounded-concurrency pool (ac-39). Each unit
+// is its own LLM call (with transient retry) + DB write; the pool just runs
+// `concurrency` of them at once and reports progress for long runs.
 async function classifyAndTagClauses(
   memexId: string,
   clauses: { id: string; body: string }[],
   vocab: VocabFacet[],
   opts: ClassifyOptions,
 ): Promise<void> {
-  await mapWithConcurrency(clauses, CONCURRENCY, async (cl) => {
+  let done = 0;
+  await forEachConcurrent(clauses, opts.concurrency ?? defaultConcurrency(), async (cl) => {
     const keys = await classifyClauseWithLlm(cl.body, vocab, opts);
     await tagClause(memexId, cl.id, keys, vocab);
+    done += 1;
+    opts.onProgress?.(done, clauses.length);
   });
 }
 

--- a/packages/server/src/services/facet-classifier.ts
+++ b/packages/server/src/services/facet-classifier.ts
@@ -1,0 +1,225 @@
+// spec-340 t-4 — the clause→facet classifier (the LLM ENGINE) + standard-level pill
+// rollup.
+//
+// dec-8: classification is AGENT-DRIVEN. The ONLY caller of this engine is the local,
+// operator-run backfill script (scripts/backfill-facet-tags.ts) and tests — NO server
+// request/write path imports it (enforced by
+// facet-classifier-no-request-path.regression.test.ts). This Spec's deploy does NOT
+// run the backfill; it is a local one-off. Authoring-time classification (the
+// add_clause hard-fail) is deferred to phase 2 (spec-423).
+//
+// Parallel with BOUNDED CONCURRENCY + Claude Opus 4.8 (the model the coding agent
+// itself runs) — ac-39. The LLM call (classifyClauseWithLlm) is separated from the
+// deterministic persistence (tagClause) and rollup (standardPillSet) so the DB logic
+// is tested without the model. Structured output via Anthropic `messages.parse` +
+// zodOutputFormat — same path as the clause-translator sibling (spec-150 dec-6) — and
+// the client is injectable so tests run key-free.
+
+import { z } from "zod";
+import { zodOutputFormat } from "@anthropic-ai/sdk/helpers/zod";
+import { and, eq, ne } from "drizzle-orm";
+import { db } from "../db/connection.js";
+import { documents, facets, standardClauses, standardClauseFacets } from "../db/schema.js";
+import { getAnthropicClient } from "../agent/anthropic-client.js";
+import { vocabForMemex, type VocabFacet } from "./facet-vocab.js";
+
+// Claude Opus 4.8 — the model the coding agent itself runs (dec-8 / ac-39). The
+// classifier is a one-off local backfill, so it runs on the most capable tier.
+const MODEL = "claude-opus-4-8";
+
+// How many clauses to classify concurrently. Bounded so a large standards corpus
+// doesn't open hundreds of simultaneous Anthropic requests (ac-39: bounded concurrency).
+const CONCURRENCY = 8;
+
+// Structured-output contract: the facet slugs the clause GOVERNS. Empty = the clause
+// governs nothing (explicit none). Kept to a plain string array so the JSON Schema
+// constrains cleanly; unknown slugs are filtered after decode.
+export const FacetVerdictSchema = z.object({
+  facetKeys: z.array(z.string()),
+});
+export type FacetVerdict = z.infer<typeof FacetVerdictSchema>;
+
+// Minimal Anthropic surface (messages.parse with structured outputs) so tests can
+// inject a stub client.
+export interface AnthropicLike {
+  messages: {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    parse: (args: any) => Promise<{ parsed_output: FacetVerdict | null }>;
+  };
+}
+
+export interface ClassifyOptions {
+  /** Injected client for tests; defaults to the shared Anthropic client. */
+  client?: AnthropicLike;
+  /**
+   * Test seam: bypass the model entirely with a deterministic classifier over
+   * (clauseBody, vocab). Returns the governing facet keys ([] = none). When set, the
+   * LLM is never called — used to test the orchestration + persistence key-free.
+   */
+  classify?: (clauseBody: string, vocab: VocabFacet[]) => Promise<string[]> | string[];
+}
+
+// Run `fn` over `items` with at most `limit` in flight at once — bounded-concurrency
+// parallelism (ac-39). Order of results matches input order.
+async function mapWithConcurrency<T, R>(
+  items: readonly T[],
+  limit: number,
+  fn: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let next = 0;
+  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
+    while (true) {
+      const i = next++;
+      if (i >= items.length) return;
+      results[i] = await fn(items[i], i);
+    }
+  });
+  await Promise.all(workers);
+  return results;
+}
+
+function classifierSystemPrompt(vocab: VocabFacet[]): string {
+  const lines = vocab.map((f) => `- ${f.key}: ${f.description}`).join("\n");
+  return `You classify a single clause from a standards document against a fixed vocabulary of cross-cutting practice areas ("facets").
+
+Return ONLY the facet slugs this clause GOVERNS — i.e. the clause sets a RULE about that area — judged against each facet's description. A clause that merely MENTIONS, motivates, or illustrates an area does NOT govern it. Many clauses (rationale, examples, background) govern NOTHING: return an empty list for those. Use only slugs from the vocabulary below; never invent one.
+
+Vocabulary:
+${lines}`;
+}
+
+function filterToVocab(keys: string[], vocab: VocabFacet[]): string[] {
+  const known = new Set(vocab.map((f) => f.key));
+  return [...new Set(keys.filter((k) => known.has(k)))];
+}
+
+/**
+ * Classify ONE clause → the member facet keys it governs ([] = governs nothing).
+ * Returned keys are always a subset of the supplied vocabulary (a hallucinated slug
+ * is dropped, never persisted).
+ */
+export async function classifyClauseWithLlm(
+  clauseBody: string,
+  vocab: VocabFacet[],
+  opts: ClassifyOptions = {},
+): Promise<string[]> {
+  if (opts.classify) {
+    return filterToVocab(await opts.classify(clauseBody, vocab), vocab);
+  }
+  const client = opts.client ?? (getAnthropicClient() as unknown as AnthropicLike);
+  const message = await client.messages.parse({
+    model: MODEL,
+    max_tokens: 1024,
+    system: classifierSystemPrompt(vocab),
+    output_config: { format: zodOutputFormat(FacetVerdictSchema) },
+    messages: [{ role: "user", content: `Clause:\n\n${clauseBody}` }],
+  });
+  if (!message.parsed_output) {
+    throw new Error("facet-classifier: structured output returned no parsed_output");
+  }
+  return filterToVocab(message.parsed_output.facetKeys, vocab);
+}
+
+/**
+ * Persist a clause's facet membership (deterministic, no LLM). Replaces any prior tags
+ * for the clause, then writes EITHER one member row per facet key OR a single
+ * explicit-none marker (facet_id NULL) when keys is empty — so the tri-state
+ * (governs / explicit-none / not-yet-classified) holds. Idempotent: re-tagging a
+ * clause overwrites its prior verdict.
+ */
+export async function tagClause(
+  memexId: string,
+  clauseId: string,
+  facetKeys: string[],
+  vocab: VocabFacet[],
+): Promise<void> {
+  const idByKey = new Map(vocab.map((f) => [f.key, f.id]));
+  const keys = [...new Set(facetKeys.filter((k) => idByKey.has(k)))];
+  await db.transaction(async (tx) => {
+    await tx.delete(standardClauseFacets).where(eq(standardClauseFacets.clauseId, clauseId));
+    if (keys.length === 0) {
+      await tx.insert(standardClauseFacets).values({ memexId, clauseId, facetId: null });
+    } else {
+      await tx
+        .insert(standardClauseFacets)
+        .values(keys.map((k) => ({ memexId, clauseId, facetId: idByKey.get(k)! })));
+    }
+  });
+}
+
+// Classify + tag a set of clauses with bounded-concurrency parallelism (ac-39).
+async function classifyAndTagClauses(
+  memexId: string,
+  clauses: { id: string; body: string }[],
+  vocab: VocabFacet[],
+  opts: ClassifyOptions,
+): Promise<void> {
+  await mapWithConcurrency(clauses, CONCURRENCY, async (cl) => {
+    const keys = await classifyClauseWithLlm(cl.body, vocab, opts);
+    await tagClause(memexId, cl.id, keys, vocab);
+  });
+}
+
+/**
+ * Classify every (non-deleted) clause of a standard and store its tags. The per-clause
+ * verdict is the classifier's; the persistence is deterministic. Clauses are classified
+ * in parallel (bounded).
+ */
+export async function classifyStandard(
+  memexId: string,
+  docId: string,
+  opts: ClassifyOptions = {},
+): Promise<void> {
+  const vocab = await vocabForMemex(memexId);
+  const clauses = await db
+    .select({ id: standardClauses.id, body: standardClauses.body })
+    .from(standardClauses)
+    .where(and(eq(standardClauses.docId, docId), ne(standardClauses.status, "deleted")));
+  await classifyAndTagClauses(memexId, clauses, vocab, opts);
+}
+
+/**
+ * spec-340 t-4 — backfill: classify every clause of every standard in a memex (dec-8).
+ * The one-off `tsx` script calls this with the REAL Anthropic client; tests inject
+ * `opts.classify`. All clauses across all standards are classified in ONE
+ * bounded-concurrency pool. Idempotent (tagClause replaces a clause's tags). Returns
+ * counts for the operator's log.
+ */
+export async function backfillFacetTagsForMemex(
+  memexId: string,
+  opts: ClassifyOptions = {},
+): Promise<{ standards: number; clauses: number }> {
+  const vocab = await vocabForMemex(memexId);
+  const standardDocs = await db
+    .select({ id: documents.id })
+    .from(documents)
+    .where(and(eq(documents.memexId, memexId), eq(documents.docType, "standard")));
+
+  const allClauses: { id: string; body: string }[] = [];
+  for (const doc of standardDocs) {
+    const cls = await db
+      .select({ id: standardClauses.id, body: standardClauses.body })
+      .from(standardClauses)
+      .where(and(eq(standardClauses.docId, doc.id), ne(standardClauses.status, "deleted")));
+    allClauses.push(...cls);
+  }
+
+  await classifyAndTagClauses(memexId, allClauses, vocab, opts);
+  return { standards: standardDocs.length, clauses: allClauses.length };
+}
+
+/**
+ * The standard-level pill set: the UNION of member facet keys over the doc's clauses.
+ * The inner join on facet_id excludes explicit-none markers, so rationale/example
+ * clauses never dilute the pill (dec-2 / s-2).
+ */
+export async function standardPillSet(memexId: string, docId: string): Promise<string[]> {
+  const rows = await db
+    .select({ key: facets.key })
+    .from(standardClauseFacets)
+    .innerJoin(standardClauses, eq(standardClauseFacets.clauseId, standardClauses.id))
+    .innerJoin(facets, eq(standardClauseFacets.facetId, facets.id))
+    .where(and(eq(standardClauses.docId, docId), eq(standardClauseFacets.memexId, memexId)));
+  return [...new Set(rows.map((r) => r.key))].sort();
+}

--- a/packages/server/src/services/facet-vocab.ts
+++ b/packages/server/src/services/facet-vocab.ts
@@ -1,0 +1,50 @@
+// spec-340 — facet vocabulary READ helpers (no LLM).
+//
+// Deliberately separated from facet-classifier.ts (the LLM engine) so the request
+// path — the `facets` list tool (t-6) — can read the vocabulary WITHOUT importing the
+// classifier. dec-8: no server request/write path may import the LLM classifier; the
+// no-import guard (facet-classifier-no-request-path.regression.test.ts) bans the whole
+// facet-classifier module from request-path dirs, so the vocabulary reads live here.
+
+import { and, asc, eq } from "drizzle-orm";
+import { db } from "../db/connection.js";
+import { facets } from "../db/schema.js";
+import { ownerForMemex } from "./shared/memex-ownership.js";
+
+// The classifier's input shape: id + key + the disambiguating description.
+export interface VocabFacet {
+  id: string;
+  key: string;
+  description: string;
+}
+
+// The display shape for the `facets` list verb (t-6).
+export interface OwnerFacet {
+  key: string;
+  name: string | null;
+  description: string;
+  ord: number;
+}
+
+// Load a memex's facet vocabulary (id/key/description) for the classifier — resolved
+// via the polymorphic owner (dec-7). Empty when the owner can't be resolved.
+export async function vocabForMemex(memexId: string): Promise<VocabFacet[]> {
+  const owner = await ownerForMemex(memexId);
+  if (!owner) return [];
+  return db
+    .select({ id: facets.id, key: facets.key, description: facets.description })
+    .from(facets)
+    .where(and(eq(facets.ownerType, owner.ownerType), eq(facets.ownerId, owner.ownerId)));
+}
+
+// The owner's full facet vocabulary for display (the `facets` list verb), ordered by
+// ord. Resolved via the same polymorphic owner rule as seeding (dec-7).
+export async function listFacetsForMemex(memexId: string): Promise<OwnerFacet[]> {
+  const owner = await ownerForMemex(memexId);
+  if (!owner) return [];
+  return db
+    .select({ key: facets.key, name: facets.name, description: facets.description, ord: facets.ord })
+    .from(facets)
+    .where(and(eq(facets.ownerType, owner.ownerType), eq(facets.ownerId, owner.ownerId)))
+    .orderBy(asc(facets.ord));
+}

--- a/packages/server/src/services/facets-schema.integration.test.ts
+++ b/packages/server/src/services/facets-schema.integration.test.ts
@@ -13,7 +13,6 @@ import {
   standardClauseFacets,
   namespaces,
   memexes,
-  orgs,
   documents,
   docSections,
   standardClauses,

--- a/packages/server/src/services/facets-schema.integration.test.ts
+++ b/packages/server/src/services/facets-schema.integration.test.ts
@@ -1,0 +1,202 @@
+// spec-340 t-1 — schema shape for the facet substrate (facets with a polymorphic
+// owner, clause→facet tags with the tri-state). DB-backed: the constraints
+// (per-owner uniqueness, the owner_type CHECK, the clause-tag tri-state) are
+// enforced by Postgres, so a pure unit test on the Drizzle objects could pass while
+// the migration is wrong. Each `it` tags the implementation/scope AC it proves.
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { and, eq, inArray, isNull, sql } from "drizzle-orm";
+import { db } from "../db/connection.js";
+import {
+  facets,
+  standardClauseFacets,
+  namespaces,
+  memexes,
+  orgs,
+  documents,
+  docSections,
+  standardClauses,
+} from "../db/schema.js";
+import { makeTestMemex } from "./test-helpers.js";
+import { ownerForMemex } from "./shared/memex-ownership.js";
+
+const SPEC = "mindset-prod/memex-building-itself/specs/spec-340";
+const AC = (n: number) => `${SPEC}/acs/ac-${n}`;
+
+async function orgIdFor(memexId: string): Promise<string> {
+  const [row] = await db
+    .select({ orgId: namespaces.ownerOrgId })
+    .from(memexes)
+    .innerJoin(namespaces, eq(memexes.namespaceId, namespaces.id))
+    .where(eq(memexes.id, memexId))
+    .limit(1);
+  if (!row?.orgId) throw new Error("could not resolve org for test memex");
+  return row.orgId;
+}
+
+// Create a PERSONAL memex (namespace kind='user', no owning org) so the
+// owner_type='memex' branch of dec-7 can be exercised directly.
+async function makePersonalMemex(prefix: string): Promise<string> {
+  const slug = `${prefix}-${Math.abs(hashCode(prefix + Date.now().toString()))}`;
+  return db.transaction(async (tx) => {
+    const [ns] = await tx
+      .insert(namespaces)
+      .values({ slug, kind: "user" })
+      .returning();
+    const [memex] = await tx
+      .insert(memexes)
+      .values({ namespaceId: ns.id, slug: "main", name: "Personal" })
+      .returning();
+    return memex.id;
+  });
+}
+
+function hashCode(s: string): number {
+  let h = 0;
+  for (let i = 0; i < s.length; i++) h = (Math.imul(31, h) + s.charCodeAt(i)) | 0;
+  return h;
+}
+
+let orgMemexId: string;
+let orgId: string;
+let orgId2: string;
+let personalMemexId: string;
+let docId: string;
+const clauseIds: string[] = [];
+
+beforeAll(async () => {
+  orgMemexId = await makeTestMemex("facsch");
+  orgId = await orgIdFor(orgMemexId);
+  // A second org to prove facet keys are unique PER OWNER, not globally.
+  orgId2 = await orgIdFor(await makeTestMemex("facsch2"));
+  personalMemexId = await makePersonalMemex("facschp");
+
+  // A standard doc + section + three clauses to hang clause→facet tags on.
+  const [doc] = await db
+    .insert(documents)
+    .values({ memexId: orgMemexId, handle: "std-facsch", title: "Facet schema test standard", docType: "standard", status: "approved" })
+    .returning();
+  docId = doc.id;
+  const [section] = await db
+    .insert(docSections)
+    .values({ docId, sectionType: "rule", content: "x", seq: 1, position: 1 })
+    .returning();
+  for (let i = 0; i < 3; i++) {
+    const [cl] = await db
+      .insert(standardClauses)
+      .values({ memexId: orgMemexId, docId, sectionId: section.id, seq: i + 1, position: i + 1, body: `clause ${i}` })
+      .returning();
+    clauseIds.push(cl.id);
+  }
+});
+
+afterAll(async () => {
+  await db.delete(standardClauseFacets).where(eq(standardClauseFacets.memexId, orgMemexId)).catch(() => {});
+  await db.delete(facets).where(and(eq(facets.ownerType, "org"), inArray(facets.ownerId, [orgId, orgId2]))).catch(() => {});
+  await db.delete(facets).where(and(eq(facets.ownerType, "memex"), eq(facets.ownerId, personalMemexId))).catch(() => {});
+  if (docId) await db.delete(documents).where(eq(documents.id, docId)).catch(() => {});
+});
+
+describe("facets vocabulary table — polymorphic owner (spec-340 t-1, dec-7)", () => {
+  it("has owner_type/owner_id and NO org_id column — no query assumes a non-null org_id (ac-35)", async () => {
+    tagAc(AC(35));
+    const cols = await db.execute<{ column_name: string }>(
+      sql`SELECT column_name FROM information_schema.columns WHERE table_name = 'facets'`,
+    );
+    const names = new Set((cols as unknown as { column_name: string }[]).map((r) => r.column_name));
+    expect(names.has("owner_type")).toBe(true);
+    expect(names.has("owner_id")).toBe(true);
+    expect(names.has("org_id")).toBe(false);
+  });
+
+  it("is owner-scoped with per-owner (not global) key uniqueness on (owner_type, owner_id, key) (ac-35, ac-32)", async () => {
+    tagAc(AC(35));
+    tagAc(AC(32));
+    // A key that is NOT one of the seeded defaults, so it can't collide with another
+    // file's seedDefaultFacets rows in a shared worker DB clone.
+    const KEY = "xowner-shared-key";
+    // Same key under two different org owners — both must succeed (no global unique).
+    await db.insert(facets).values({ ownerType: "org", ownerId: orgId, key: KEY, description: "authz/tenancy/secrets" });
+    await db.insert(facets).values({ ownerType: "org", ownerId: orgId2, key: KEY, description: "authz/tenancy/secrets" });
+    // …and a personal-memex owner may ALSO hold the same key (dec-7: personal memex owns directly).
+    await db.insert(facets).values({ ownerType: "memex", ownerId: personalMemexId, key: KEY, description: "authz" });
+
+    const rows = await db
+      .select()
+      .from(facets)
+      .where(and(eq(facets.key, KEY), inArray(facets.ownerId, [orgId, orgId2, personalMemexId])));
+    expect(rows.length).toBe(3);
+    expect(new Set(rows.map((r) => `${r.ownerType}:${r.ownerId}`))).toEqual(
+      new Set([`org:${orgId}`, `org:${orgId2}`, `memex:${personalMemexId}`]),
+    );
+
+    // Duplicate (owner_type, owner_id, key) — must violate facets_owner_key_unique.
+    await expect(
+      db.insert(facets).values({ ownerType: "org", ownerId: orgId, key: KEY, description: "dup" }),
+    ).rejects.toThrow();
+  });
+
+  it("rejects an owner_type outside {org, memex} (facets_owner_type_valid CHECK) (ac-35)", async () => {
+    tagAc(AC(35));
+    await expect(
+      db.insert(facets).values({ ownerType: "wat", ownerId: orgId, key: "bad-owner-type", description: "x" }),
+    ).rejects.toThrow();
+  });
+
+  it("resolves a personal memex to owner_type='memex'/owner_id=memexId (dec-7 owner rule) (ac-35)", async () => {
+    tagAc(AC(35));
+    const owner = await ownerForMemex(personalMemexId);
+    expect(owner).toEqual({ ownerType: "memex", ownerId: personalMemexId });
+    const orgOwner = await ownerForMemex(orgMemexId);
+    expect(orgOwner).toEqual({ ownerType: "org", ownerId: orgId });
+  });
+});
+
+describe("clause→facet tags — the tri-state (spec-340 t-1, dec-2/dec-8)", () => {
+  it("distinguishes governs-facet, explicit-none, and not-yet-classified (ac-33)", async () => {
+    tagAc(AC(33));
+    const [secFacet] = await db
+      .insert(facets)
+      .values({ ownerType: "org", ownerId: orgId, key: "sec-tag", description: "x" })
+      .returning();
+
+    // clause[0] governs a facet (member row).
+    await db.insert(standardClauseFacets).values({ memexId: orgMemexId, clauseId: clauseIds[0], facetId: secFacet.id });
+    // clause[1] is explicitly classified as governing nothing (facet_id NULL).
+    await db.insert(standardClauseFacets).values({ memexId: orgMemexId, clauseId: clauseIds[1], facetId: null });
+    // clause[2] has NO rows → not-yet-classified.
+
+    const member = await db
+      .select()
+      .from(standardClauseFacets)
+      .where(and(eq(standardClauseFacets.clauseId, clauseIds[0]), eq(standardClauseFacets.facetId, secFacet.id)));
+    expect(member.length).toBe(1);
+
+    const noneMarker = await db
+      .select()
+      .from(standardClauseFacets)
+      .where(and(eq(standardClauseFacets.clauseId, clauseIds[1]), isNull(standardClauseFacets.facetId)));
+    expect(noneMarker.length).toBe(1); // explicit "governs nothing"
+
+    const unclassified = await db
+      .select()
+      .from(standardClauseFacets)
+      .where(eq(standardClauseFacets.clauseId, clauseIds[2]));
+    expect(unclassified.length).toBe(0); // not-yet-classified — absence of any row
+  });
+
+  it("enforces at-most-one none-marker and at-most-one membership per (clause,facet) (ac-33)", async () => {
+    tagAc(AC(33));
+    const [f] = await db.insert(facets).values({ ownerType: "org", ownerId: orgId, key: "dup-tag", description: "x" }).returning();
+    await db.insert(standardClauseFacets).values({ memexId: orgMemexId, clauseId: clauseIds[0], facetId: f.id });
+    // duplicate membership → partial unique violation
+    await expect(
+      db.insert(standardClauseFacets).values({ memexId: orgMemexId, clauseId: clauseIds[0], facetId: f.id }),
+    ).rejects.toThrow();
+    // second none-marker on clause[1] (already has one) → partial unique violation
+    await expect(
+      db.insert(standardClauseFacets).values({ memexId: orgMemexId, clauseId: clauseIds[1], facetId: null }),
+    ).rejects.toThrow();
+  });
+});

--- a/packages/server/src/services/orgs.ts
+++ b/packages/server/src/services/orgs.ts
@@ -31,6 +31,7 @@ import { pgError } from "./shared/pg-error.js";
 import { isFreeEmailDomain } from "./free-email-domains.js";
 import { mutate, type Mutated, type RequestCtx } from "./mutate.js";
 import { primaryMemexIdForOrg } from "./shared/memex-ownership.js";
+import { seedDefaultFacetsForOwnerBestEffort } from "./default-facets.js";
 
 export async function getOrgById(id: string): Promise<Org | undefined> {
   return db.query.orgs.findFirst({ where: eq(orgs.id, id) });
@@ -411,6 +412,12 @@ export async function createOrgForUser(input: CreateOrgRequest): Promise<Created
     ownerUserId: input.userId,
     createdByUserId: input.userId,
   });
+
+  // spec-340 t-3 (dec-7): auto-seed the org's own copy of the default facet
+  // vocabulary (owner_type='org'). Post-commit, best-effort, idempotent — mirrors
+  // the spec-178/184 seed-on-creation pattern (the org must still be created if the
+  // seed fails). A freshly-created owner always lands with a vocabulary (ac-31).
+  await seedDefaultFacetsForOwnerBestEffort({ ownerType: "org", ownerId: result.org.id });
 
   return {
     org: result.org,

--- a/packages/server/src/services/shared/memex-ownership.ts
+++ b/packages/server/src/services/shared/memex-ownership.ts
@@ -41,6 +41,33 @@ export async function orgIdForMemex(memexId: string): Promise<string | null> {
   return row?.ownerOrgId ?? null;
 }
 
+// The polymorphic facet owner (spec-340 dec-7): either an org (its vocabulary is
+// shared across all the org's memexes, per std-4) or a personal memex with no owning
+// org (it owns its vocabulary directly).
+export type FacetOwner = { ownerType: "org" | "memex"; ownerId: string };
+
+// Resolve the facet-vocabulary owner for a memex (spec-340 dec-7 — the owner-resolution
+// rule, load-bearing for seeding AND the read tool). Org-owned namespace → the org owns
+// the vocabulary (ownerType='org', ownerId=org.id). Personal namespace (kind='user',
+// no ownerOrgId) → the memex owns it directly (ownerType='memex', ownerId=memexId).
+// orgIdForMemex returns null for a personal memex — that null is exactly the case the
+// 'memex' branch must catch; a naive port that only seeds where an org resolves would
+// leave every personal memex with zero facets, the bug this Spec exists to prevent.
+// Returns null only in the pathological no-namespace state.
+export async function ownerForMemex(memexId: string): Promise<FacetOwner | null> {
+  const [row] = await db
+    .select({ kind: namespaces.kind, ownerOrgId: namespaces.ownerOrgId })
+    .from(memexes)
+    .innerJoin(namespaces, eq(namespaces.id, memexes.namespaceId))
+    .where(eq(memexes.id, memexId))
+    .limit(1);
+  if (!row) return null;
+  if (row.kind === "org" && row.ownerOrgId) {
+    return { ownerType: "org", ownerId: row.ownerOrgId };
+  }
+  return { ownerType: "memex", ownerId: memexId };
+}
+
 // Returns the document if it belongs to memexId, otherwise throws NotFoundError.
 // We return NotFoundError (not ForbiddenError) intentionally — leaking "this doc exists
 // but isn't yours" via a 403 enables enumeration attacks.

--- a/packages/server/src/services/test-helpers.ts
+++ b/packages/server/src/services/test-helpers.ts
@@ -95,6 +95,25 @@ export async function makeTestMemex(prefix = "ta"): Promise<string> {
   return result.id;
 }
 
+// Create a PERSONAL memex: a user-kind namespace with no owning org (spec-340 dec-7).
+// Its facet-vocabulary owner resolves to the memex itself (owner_type='memex'). Used
+// by the facet seeding tests to exercise the personal-memex branch.
+export async function makePersonalTestMemex(prefix = "pers"): Promise<string> {
+  const slug = uniqueSlug(prefix);
+  const result = await db.transaction(async (tx) => {
+    const [ns] = await tx
+      .insert(namespaces)
+      .values({ slug, kind: "user" })
+      .returning();
+    const [memex] = await tx
+      .insert(memexes)
+      .values({ namespaceId: ns.id, slug: "main", name: "Personal" })
+      .returning();
+    return memex;
+  });
+  return result.id;
+}
+
 // Returns the memex id and the namespace slug, plus enrolls the dev user as
 // administrator of the org so route-level integration tests can hit the API
 // through tenant + session middleware.

--- a/packages/server/src/services/user-namespaces.ts
+++ b/packages/server/src/services/user-namespaces.ts
@@ -6,6 +6,7 @@ import { ValidationError } from "../types/errors.js";
 import { mutate, type Mutated } from "./mutate.js";
 import { seedHandholdDemo } from "./handhold-demo.js";
 import { seedDefaultStandards } from "./default-standards.js";
+import { seedDefaultFacetsForMemexBestEffort } from "./default-facets.js";
 
 // Canonical display name for personal memexes. Per product decision, personal memexes
 // cannot be renamed — the switcher always shows "Personal Memex" so there's no ambiguity
@@ -243,6 +244,12 @@ async function seedNewPersonalMemex(memexId: string, ownerUserId: string): Promi
   await Promise.allSettled([
     seedHandholdDemoBestEffort(memexId, ownerUserId),
     seedDefaultStandardsBestEffort(memexId),
+    // spec-340 t-3 (dec-7): seed the personal memex's own facet vocabulary
+    // (owner_type='memex' — a personal memex is not modelled as its own org, so it
+    // owns its facets directly). Best-effort + idempotent, isolated by allSettled so
+    // a seed failure never blocks signup. Reached only on the personal-namespace
+    // create path, so seeding is inherently personal-only.
+    seedDefaultFacetsForMemexBestEffort(memexId),
   ]);
 }
 

--- a/packages/server/vitest.config.ts
+++ b/packages/server/vitest.config.ts
@@ -159,6 +159,11 @@ export default defineConfig({
       // detached seed on the same ensureUserNamespace path. Off suite-wide; the seed's
       // own suites stub it back on per-test.
       MEMEX_DEFAULT_STANDARDS_SIGNUP_SEED: "off",
+      // spec-340: same treatment for the default-facets auto-seed (on org creation AND
+      // personal-memex creation). Off suite-wide so org/user-creation tests don't each
+      // seed + clean up 16 facet rows; the seed's own suite stubs it back on per-test
+      // (the gate reads env at call time).
+      MEMEX_DEFAULT_FACETS_SEED: "off",
     },
     typecheck: { enabled: false },
     coverage: {

--- a/packages/shared/src/scaffold-data.ts
+++ b/packages/shared/src/scaffold-data.ts
@@ -909,6 +909,8 @@ const TOOL_RATIONALES: Record<string, string> = {
     "Flag drift on a standard section: post a typed `drift` comment (sourced 'agent') when the rule is right but the codebase has diverged from it. Surfaces in the Drift Inbox; use propose_standard_change instead when the rule itself is wrong.",
   propose_standard_change:
     "Propose a corrected version of a standard section: lands a typed `plan_revision` comment (sourced 'agent') with the full replacement markdown and a rationale, for the standard owner to accept or reject in the Drift Inbox.",
+  facets:
+    "Read (and later manage) your Memex's facet vocabulary — the closed, per-owner set of cross-cutting practice areas a standard's clauses are tagged with. Verb-dispatched so the surface stays one tool; v0 supports verb:'list'.",
   create_ac:
     'Create an Acceptance Criterion under a Spec. Scope ACs are manager-authored outcomes; implementation ACs are agent-spawned from resolved Decisions.',
   list_acs:

--- a/packages/shared/src/tool-manifest.ts
+++ b/packages/shared/src/tool-manifest.ts
@@ -386,6 +386,15 @@ export const toolManifest: ToolManifestEntry[] = [
     readOnlyHint: false,
     trafficClass: null,
   },
+  {
+    name: 'facets',
+    summary:
+      "Read your Memex's facet vocabulary — the closed, per-owner set of cross-cutting practice areas a standard's clauses are tagged with. Verb-dispatched so the surface stays one tool as it grows; v0 supports verb:'list'.",
+    args: 'facets(verb, memex?)',
+    group: 'read',
+    readOnlyHint: true,
+    trafficClass: null,
+  },
 
   // ── Issues (any phase) ────────────────────────────────────
   {


### PR DESCRIPTION
## Spec
[spec-340 — Facets foundation — schema, per-owner seeding, and clause classification (phase 1)](https://memex.ai/mindset-prod/memex-building-itself/specs/spec-340)

Phase 1 is the **inert produce-side foundation** for facets (a closed, per-owner vocabulary of cross-cutting practice areas that ties a unit of work to its governing standards). It *produces and maintains* the tag-data and consumes none of it yet — nothing reads the tags, and no existing tool contract changes. The consume side (routing, ballots, the verify gate, the `add_clause` facet requirement) is Phase 2 ([spec-423](https://memex.ai/mindset-prod/memex-building-itself/specs/spec-423)).

## What ships
- **Schema + migration** (`drizzle/0114_add_facets.sql`): `facets` (polymorphic owner — `owner_type` ∈ {org, memex} + `owner_id`, unique `(owner_type, owner_id, key)`; dec-7) and `standard_clause_facets` (clause→facet tags with a nullable-`facet_id` tri-state). std-36 RLS on the tag rows; no ballot tables (Phase 2).
- **Seeding** (make-or-break): the 16 default facets seeded per owner; a backfill for **every existing org AND personal memex**; auto-seed on **new org creation AND new personal-Memex creation**. An owner with zero facets is a defect, not a valid state.
- **Classifier**: an Opus 4.8, bounded-concurrency-parallel clause→facet classifier (structured output, injectable client) + a **local, operator-run** backfill script. The LLM engine is never imported by a request/write path (dec-8) — a regression guard pins this; a no-LLM `facet-vocab.ts` carries the request-path reads.
- **Read surface**: one verb-dispatched, read-only `facets` MCP tool (v0 `list` verb), resolved via the polymorphic owner.
- **spec-193 reconciliation**: the guard's bridge-table prohibition is narrowed to the scaffold layer, permitting the auto-assigned clause→facet DB tags; documented in the guard + spec-193's trail.

## Tests
- All **8 acceptance criteria verified** (ac-31…ac-36, ac-39, ac-40), each via a tagged test.
- **Full server suite: 4837 passed, 0 failed** (28 skipped). **Full UI suite: 1760 passed, 0 failed** (1 skipped).
- Server build typecheck + UI `tsc -b` + biome: clean.

## Deploy notes
- Apply `0114_add_facets.sql` (idempotent, via `db:migrate`); rebuild `@memex/shared`.
- Post-deploy: run `tsx scripts/backfill-default-facets.ts` to seed existing owners (no LLM). The clause-tagging backfill (`scripts/backfill-facet-tags.ts`, needs `ANTHROPIC_API_KEY`) is **local/manual and not run by this deploy** — Phase 1 ships the engine + script only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)