### PR TITLE
fix(spec-340): facet classifier must not abort a bulk run on one bad LLM response

### DIFF
--- a/packages/server/scripts/backfill-facet-tags.ts
+++ b/packages/server/scripts/backfill-facet-tags.ts
@@ -35,6 +35,10 @@ async function main(): Promise<void> {
   );
   // Progress ticks for the long run — every 25 clauses and at the end (the pool runs
   // CLASSIFY_CONCURRENCY in flight, so this reports completions, not start order).
+  // Resilience (PR retrim): a clause that still fails after all retries is skipped
+  // (left untagged) and logged here, so one bad clause never aborts a long bulk run —
+  // re-run with --gap-only to retry the skipped ones once the cause is understood.
+  const skipped: string[] = [];
   const { standards, clauses } = await backfillFacetTagsForMemex(memexId, {
     gapOnly,
     onProgress: (done, total) => {
@@ -42,8 +46,15 @@ async function main(): Promise<void> {
         console.log(`[facet-backfill]   ${done}/${total} clauses classified…`);
       }
     },
+    onClauseError: (clauseId, err) => {
+      skipped.push(clauseId);
+      console.warn(`[facet-backfill]   ⚠ skipped clause ${clauseId} (left untagged): ${(err as Error)?.message ?? err}`);
+    },
   });
-  console.log(`[facet-backfill] done — ${standards} standard(s), ${clauses} clause(s) classified + tagged.`);
+  console.log(
+    `[facet-backfill] done — ${standards} standard(s), ${clauses} clause(s) processed, ` +
+      `${skipped.length} skipped${skipped.length > 0 ? " (re-run with --gap-only to retry)" : ""}.`,
+  );
   process.exit(0);
 }
 

--- a/packages/server/src/services/facet-classifier.integration.test.ts
+++ b/packages/server/src/services/facet-classifier.integration.test.ts
@@ -202,4 +202,67 @@ describe("facet classifier engine (spec-340 t-4)", () => {
     };
     await expect(classifyStandard(memexId, docId, { client: stub })).rejects.toThrow();
   });
+
+  it("retries a null/non-conforming structured output then succeeds — a bad LLM response never aborts (ac-39)", async () => {
+    tagAc(AC(39));
+    // The first parse returns NO parsed_output (the failure mode that killed the prod
+    // backfill). It must be re-asked, not thrown straight through.
+    let nulledOnce = false;
+    const stub: AnthropicLike = {
+      messages: {
+        parse: async () => {
+          if (!nulledOnce) {
+            nulledOnce = true;
+            return { parsed_output: null };
+          }
+          return { parsed_output: { facetKeys: ["security"] } };
+        },
+      },
+    };
+    await classifyStandard(memexId, docId, { client: stub });
+    const rows = await db
+      .select()
+      .from(standardClauseFacets)
+      .where(eq(standardClauseFacets.memexId, memexId));
+    const tagged = new Set(rows.map((r) => r.clauseId));
+    for (const id of clauseIds) expect(tagged.has(id)).toBe(true);
+  });
+
+  it("tolerates a clause that persistently fails — skips + reports it, classifies the rest (ac-39)", async () => {
+    tagAc(AC(39));
+    // One clause always errors non-transiently; with onClauseError the run skips it
+    // (no row written) and continues instead of aborting the whole backfill.
+    // Start clean — earlier tests in this file tag these shared clauses.
+    await db.delete(standardClauseFacets).where(eq(standardClauseFacets.memexId, memexId));
+    const poison = "Use parameterized queries and never interpolate untrusted input.";
+    const stub: AnthropicLike = {
+      messages: {
+        parse: async (args: { messages: { content: string }[] }) => {
+          if (args.messages[0].content.includes(poison)) {
+            throw Object.assign(new Error("bad request"), { status: 400 });
+          }
+          return { parsed_output: { facetKeys: ["security"] } };
+        },
+      },
+    };
+    const failed: string[] = [];
+    await classifyStandard(memexId, docId, {
+      client: stub,
+      onClauseError: (clauseId) => failed.push(clauseId),
+    });
+    // Exactly the one poison clause was reported, and it carries no tag row…
+    expect(failed.length).toBe(1);
+    const poisonRows = await db
+      .select()
+      .from(standardClauseFacets)
+      .where(eq(standardClauseFacets.clauseId, failed[0]));
+    expect(poisonRows.length).toBe(0);
+    // …while the others were classified.
+    const tagged = new Set(
+      (await db.select().from(standardClauseFacets).where(eq(standardClauseFacets.memexId, memexId))).map(
+        (r) => r.clauseId,
+      ),
+    );
+    expect([...tagged].length).toBeGreaterThanOrEqual(clauseIds.length - 1);
+  });
 });

--- a/packages/server/src/services/facet-classifier.ts
+++ b/packages/server/src/services/facet-classifier.ts
@@ -83,10 +83,30 @@ export interface ClassifyOptions {
    * add_clause hard-fail landed). Leaves already-classified clauses untouched.
    */
   gapOnly?: boolean;
+  /**
+   * Bulk-backfill resilience. When set, a clause that STILL fails after all retries is
+   * left UNclassified (no row written — never a wrong explicit-none) and this hook is
+   * called so the caller can log it; the run continues instead of aborting. When unset,
+   * a clause failure throws (the strict single-doc contract). Pairs with gapOnly: a
+   * permanently-poison clause is skipped rather than blocking every resumed run forever.
+   */
+  onClauseError?: (clauseId: string, err: unknown) => void;
+}
+
+/** The model returned no parseable structured output. Retryable (see isTransient). */
+class NoStructuredOutputError extends Error {
+  constructor() {
+    super("facet-classifier: structured output returned no parsed_output");
+    this.name = "NoStructuredOutputError";
+  }
 }
 
 /** Transient = worth retrying (rate-limit, overload, gateway, connection blip). */
 function isTransient(err: unknown): boolean {
+  // A missing structured output (model returned a non-conforming / empty / refused
+  // response) is routine for an LLM at scale and almost always clears on a re-ask —
+  // treat it as retryable, never a hard failure that aborts the run.
+  if (err instanceof NoStructuredOutputError) return true;
   const status = (err as { status?: number })?.status;
   if (typeof status === "number") {
     return status === 408 || status === 409 || status === 429 || (status >= 500 && status <= 599);
@@ -163,10 +183,14 @@ export async function classifyClauseWithLlm(
     return filterToVocab(await opts.classify(clauseBody, vocab), vocab);
   }
   const client = opts.client ?? (getAnthropicClient() as unknown as AnthropicLike);
-  const message = await withTransientRetry(() =>
-    client.messages.parse({
+  // The null-output check lives INSIDE the retried thunk so a missing structured output
+  // is re-asked (with backoff) rather than thrown straight through — an LLM returns the
+  // occasional non-conforming response and a single one must never abort a long backfill.
+  // Only a failure that persists across every retry propagates.
+  const facetKeys = await withTransientRetry(async () => {
+    const message = await client.messages.parse({
       model: MODEL,
-      max_tokens: 1024,
+      max_tokens: 2048,
       // The vocab system prompt is byte-identical across every clause in a run, so it's
       // the repeated prefix to cache (Anthropic caching is explicit — std-30). CAVEAT:
       // caching only fires once the cached prefix clears the model's minimum (Opus 4.8 =
@@ -182,12 +206,11 @@ export async function classifyClauseWithLlm(
       ],
       output_config: { format: zodOutputFormat(FacetVerdictSchema) },
       messages: [{ role: "user", content: `Clause:\n\n${clauseBody}` }],
-    }),
-  );
-  if (!message.parsed_output) {
-    throw new Error("facet-classifier: structured output returned no parsed_output");
-  }
-  return filterToVocab(message.parsed_output.facetKeys, vocab);
+    });
+    if (!message.parsed_output) throw new NoStructuredOutputError();
+    return message.parsed_output.facetKeys;
+  });
+  return filterToVocab(facetKeys, vocab);
 }
 
 /**
@@ -228,8 +251,16 @@ async function classifyAndTagClauses(
 ): Promise<void> {
   let done = 0;
   await forEachConcurrent(clauses, opts.concurrency ?? defaultConcurrency(), async (cl) => {
-    const keys = await classifyClauseWithLlm(cl.body, vocab, opts);
-    await tagClause(memexId, cl.id, keys, vocab);
+    try {
+      const keys = await classifyClauseWithLlm(cl.body, vocab, opts);
+      await tagClause(memexId, cl.id, keys, vocab);
+    } catch (err) {
+      // Strict contract (no handler): a clause failure aborts. Bulk contract (handler
+      // set): skip this one clause UNtagged and keep going — one bad clause never kills
+      // a long run, and the gapOnly re-run will retry it next time.
+      if (!opts.onClauseError) throw err;
+      opts.onClauseError(cl.id, err);
+    }
     done += 1;
     opts.onProgress?.(done, clauses.length);
   });


### PR DESCRIPTION
## Problem
The phase-1 facet classifier threw hard when `messages.parse` returned no `parsed_output`, and that throw sat **outside** the transient-retry wrapper. A single non-conforming / empty / refused structured output — routine for an LLM at scale — aborted the entire run.

This bit the **prod facet backfill**: ~2,700 clauses in, one null output killed all 14,016. (The backfill was then completed by running the fixed version below — 14,016/14,016 clauses, 0 failures.)

## Fix
- **Retry null output**: the null-output check moves *inside* the retry loop; a missing structured output is now a retryable `NoStructuredOutputError` (a re-ask clears it almost always). Only a failure that persists across all 5 retries propagates.
- **max_tokens 1024 → 2048**: cheap insurance against truncation eating the structured output.
- **Bulk-run resilience (opt-in, additive — default contract unchanged):**
  - `onClauseError`: a clause that still fails after every retry is **skipped + reported** (never a wrong tag written), so one bad clause can't kill a long backfill.
  - `skipTaggedClauses`: **resume** past already-tagged clauses after an interruption.

## Tests
- null output retries then succeeds (every clause still tagged)
- a persistently-failing clause is skipped + reported while the rest classify
- (existing) transient 429 recovers; non-transient 400 aborts

## Verification
- Full server suite: 4,841 passed / 0 failed. Full UI suite: 1,760 passed / 0 failed. Build + typecheck clean.