### PR TITLE
feat(spec-304): in-app MCP install — desktop install/status UI (t-55)

### DIFF
--- a/packages/ui/e2e/journey-45-spec-304-mcp-session-mint.spec.ts
+++ b/packages/ui/e2e/journey-45-spec-304-mcp-session-mint.spec.ts
@@ -102,6 +102,32 @@ test(INSTALL_TEST, async ({ page }) => {
     };
   });
 
+  // Intercept the session-mint POST so the UI flow is deterministic and isn't
+  // coupled to live in-page POST timing (test 1 above already covers the REAL
+  // /api/mcp/tokens endpoint end-to-end). GET/other methods hit the real server.
+  // This still proves the UI mints via the session endpoint (the route fires),
+  // then routes the raw token to the native bridge — never the DOM.
+  const MINTED = "mxt_e2e0token0123456789abcdef";
+  let mintPosted = false;
+  await page.route("**/api/mcp/tokens", async (route) => {
+    if (route.request().method() === "POST") {
+      mintPosted = true;
+      await route.fulfill({
+        status: 201,
+        contentType: "application/json",
+        body: JSON.stringify({
+          token: MINTED,
+          id: "tok_e2e",
+          label: "Memex Desktop",
+          prefix: MINTED.slice(0, 12),
+          createdAt: "2026-06-27T00:00:00.000Z",
+        }),
+      });
+    } else {
+      await route.continue();
+    }
+  });
+
   await page.goto(bareUrl("/settings/integrations"));
 
   // The in-app install surface is present (desktop-shell only).
@@ -121,8 +147,11 @@ test(INSTALL_TEST, async ({ page }) => {
     timeout: 15_000,
   });
 
-  // The flow minted from the session and handed the RAW token to installMcp —
-  // and the token never appeared in the DOM (ac-6).
+  // The token came from the session-mint endpoint (no terminal / device flow).
+  expect(mintPosted).toBe(true);
+
+  // The flow handed the RAW minted token to installMcp — and it never appeared
+  // in the DOM (ac-6).
   const calls = await page.evaluate(
     () => (window as unknown as { __bridgeCalls: Array<{ name: string; args: { token?: string } }> }).__bridgeCalls,
   );

--- a/packages/ui/e2e/journey-45-spec-304-mcp-session-mint.spec.ts
+++ b/packages/ui/e2e/journey-45-spec-304-mcp-session-mint.spec.ts
@@ -1,32 +1,41 @@
-import { test, expect, emitAcEvents } from "./helpers/index.js";
+import { test, expect, bareUrl, emitAcEvents } from "./helpers/index.js";
 
-// Journey 45 — spec-304 t-13 (std-28, ac-28): the desktop app's in-app "Install
-// MCP" flow is session-minted. The native installMcp bridge only exists inside
-// the Flutter webview (it cannot be driven from a browser), so the part this
-// PR-gate journey owns is the SESSION-MINT: a logged-in web session mints an MCP
-// token via POST /api/mcp/tokens — no terminal, no CLI device flow — and that
-// token is a real, persisted token exposing only its safe prefix. (The bridge
-// handoff itself is covered desktop-side by memex-clients' installMcp tests.)
+// Journey 45 — spec-304 t-13 + t-55 (std-28): the desktop app's in-app "Install
+// Memex MCP" flow.
 //
-// Unlike the server integration test (which hits Hono in-process), this drives
-// the request through the running app's real HTTP surface: the UI origin's /api
-// proxy → the live server, the same path the embedded webview uses in dev mode.
+//  • t-13 (ac-28): the SESSION-MINT — a logged-in web session mints an MCP token
+//    via POST /api/mcp/tokens with no terminal / CLI device flow, persisted as a
+//    real token exposing only its safe prefix.
+//  • t-55 (ac-6 / ac-4 / ac-45): the IN-APP INSTALL UI — inside the desktop shell
+//    the DesktopMcpSection renders, mints from the live session, and hands the
+//    raw token to the native installMcp bridge (never showing it). The Flutter
+//    bridge only exists in the embedded webview, so here we STUB
+//    window.flutter_inappwebview to record the handoff and drive the React flow
+//    end-to-end against the running app; the native write itself is covered
+//    desktop-side by memex-clients' installMcp tests.
 
 const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-304/acs/ac-${n}`;
 const API_URL = process.env.E2E_API_URL ?? "http://localhost:8090";
 
+const ACS_BY_TEST: Record<string, string[]> = {};
+
 test.afterEach(async ({}, testInfo) => {
+  if (testInfo.status === "skipped") return;
+  const acRefs = ACS_BY_TEST[testInfo.title] ?? [];
+  if (acRefs.length === 0) return;
   await emitAcEvents(
-    [AC(28)],
+    acRefs,
     testInfo.status === "passed" ? "pass" : "fail",
     `packages/ui/e2e/journey-45-spec-304-mcp-session-mint.spec.ts::${testInfo.title}`,
     testInfo.duration,
   );
 });
 
-test("a logged-in session mints an MCP token with no device flow, and it persists as a safe-prefixed token", async ({
-  page,
-}) => {
+const MINT_TEST =
+  "a logged-in session mints an MCP token with no device flow, and it persists as a safe-prefixed token";
+ACS_BY_TEST[MINT_TEST] = [AC(28)];
+
+test(MINT_TEST, async ({ page }) => {
   const label = `Desktop e2e ${Date.now()}`;
 
   // The session-mint under test, through the running app's HTTP surface (the
@@ -53,4 +62,77 @@ test("a logged-in session mints an MCP token with no device flow, and it persist
   expect(found?.prefix.startsWith("mxt_")).toBe(true);
   // The list never echoes the raw secret back.
   expect(JSON.stringify(found)).not.toContain(minted.token);
+});
+
+const INSTALL_TEST =
+  "inside the desktop shell, Install mints from the session and hands the token to the native bridge — never shown";
+ACS_BY_TEST[INSTALL_TEST] = [AC(6), AC(4), AC(45)];
+
+test(INSTALL_TEST, async ({ page }) => {
+  // Stub the Flutter bridge BEFORE any page script runs so isDesktopShell() is
+  // true and DesktopMcpSection renders. callHandler records every call and
+  // returns canned native results; the recorded calls let us assert the token
+  // handoff without a real Flutter runtime.
+  await page.addInitScript(() => {
+    const calls: Array<{ name: string; args: unknown }> = [];
+    (window as unknown as { __bridgeCalls: typeof calls }).__bridgeCalls = calls;
+    (window as unknown as { flutter_inappwebview: unknown }).flutter_inappwebview = {
+      callHandler: (name: string, args: unknown) => {
+        calls.push({ name, args });
+        switch (name) {
+          case "mcpStatus":
+            return {
+              ok: true,
+              targets: {
+                claudeCode: { installed: false, urlMatches: false, tokenPrefix: null },
+                claudeDesktop: { installed: false, urlMatches: false, tokenPrefix: null },
+              },
+            };
+          case "installMcp":
+            return {
+              ok: true,
+              name: "Claude Code",
+              path: "/home/dev/.claude.json",
+              backupPath: "/home/dev/.claude.json.bak",
+            };
+          default:
+            return { ok: true };
+        }
+      },
+    };
+  });
+
+  await page.goto(bareUrl("/settings/integrations"));
+
+  // The in-app install surface is present (desktop-shell only).
+  await expect(
+    page.getByRole("heading", { name: "Install Memex MCP" }),
+  ).toBeVisible({ timeout: 15_000 });
+
+  const codeRow = page.getByTestId("mcp-client-claudeCode");
+  await expect(codeRow).toBeVisible();
+
+  // A never-installed client reads "Not installed" with an Install action.
+  await expect(page.getByTestId("mcp-status-claudeCode")).toHaveText("Not installed");
+  await codeRow.getByRole("button", { name: "Install" }).click();
+
+  // Success surfaces a restart prompt (ac-7's user-facing instruction).
+  await expect(page.getByRole("status")).toContainText("Restart Claude Code", {
+    timeout: 15_000,
+  });
+
+  // The flow minted from the session and handed the RAW token to installMcp —
+  // and the token never appeared in the DOM (ac-6).
+  const calls = await page.evaluate(
+    () => (window as unknown as { __bridgeCalls: Array<{ name: string; args: { token?: string } }> }).__bridgeCalls,
+  );
+  const install = calls.find((c) => c.name === "installMcp");
+  expect(install).toBeTruthy();
+  expect(install?.args.token).toMatch(/^mxt_/);
+  expect(install?.args.token?.length).toBeGreaterThan(12);
+
+  const rawToken = install!.args.token!;
+  expect(await page.content()).not.toContain(rawToken);
+  // Success was announced natively (dec-22 / ac-51).
+  expect(calls.some((c) => c.name === "showNotification")).toBe(true);
 });

--- a/packages/ui/e2e/journey-45-spec-304-mcp-session-mint.spec.ts
+++ b/packages/ui/e2e/journey-45-spec-304-mcp-session-mint.spec.ts
@@ -106,7 +106,7 @@ test(INSTALL_TEST, async ({ page }) => {
 
   // The in-app install surface is present (desktop-shell only).
   await expect(
-    page.getByRole("heading", { name: "Install Memex MCP" }),
+    page.getByRole("heading", { name: "Install Memex MCP on this device" }),
   ).toBeVisible({ timeout: 15_000 });
 
   const codeRow = page.getByTestId("mcp-client-claudeCode");

--- a/packages/ui/src/components/DesktopMcpSection.test.tsx
+++ b/packages/ui/src/components/DesktopMcpSection.test.tsx
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, fireEvent, within } from '@testing-library/react';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { DesktopMcpSection } from './DesktopMcpSection';
+
+const AC_UMBRELLA = 'mindset-prod/memex-building-itself/specs/spec-304/acs/ac-45';
+const AC_INSTALL = 'mindset-prod/memex-building-itself/specs/spec-304/acs/ac-4';
+const AC_REACH = 'mindset-prod/memex-building-itself/specs/spec-304/acs/ac-50';
+
+// ── Mocks ────────────────────────────────────────────────────────────────
+vi.mock('./AuthContext', () => ({ useAuth: () => ({ token: 'test-token' }) }));
+vi.mock('../hooks/useUserChangeStream', () => ({ useUserChangeStream: () => {} }));
+
+const listMcpTokensApi = vi.fn();
+const mintMcpTokenApi = vi.fn();
+vi.mock('../api/mcp', () => ({
+  listMcpTokensApi: (...a: unknown[]) => listMcpTokensApi(...a),
+  mintMcpTokenApi: (...a: unknown[]) => mintMcpTokenApi(...a),
+}));
+
+const fetchJourneyStateApi = vi.fn();
+vi.mock('../api/journey', () => ({
+  fetchJourneyStateApi: (...a: unknown[]) => fetchJourneyStateApi(...a),
+}));
+
+// The Flutter bridge: present = desktop shell. We drive callHandler per name.
+function installShell(
+  handlers: Record<string, (args: unknown) => unknown> = {},
+) {
+  (window as unknown as { flutter_inappwebview?: unknown }).flutter_inappwebview = {
+    callHandler: (name: string, args: unknown) =>
+      (handlers[name] ?? (() => ({ ok: true })))(args),
+  };
+}
+function removeShell() {
+  delete (window as unknown as { flutter_inappwebview?: unknown }).flutter_inappwebview;
+}
+
+const STATUS_ABSENT = {
+  ok: true,
+  targets: {
+    claudeCode: { installed: false, urlMatches: false, tokenPrefix: null },
+    claudeDesktop: { installed: false, urlMatches: false, tokenPrefix: null },
+  },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  listMcpTokensApi.mockResolvedValue([]);
+  mintMcpTokenApi.mockResolvedValue({ token: 'mxt_minted_secret_999', prefix: 'mxt_minted9' });
+  fetchJourneyStateApi.mockResolvedValue({ milestones: { mcpConnected: false } });
+});
+afterEach(() => removeShell());
+
+describe('spec-304 ac-45 / ac-50: the in-app MCP surface in Settings → Integrations', () => {
+  it('renders nothing in a plain browser (no shell = cannot write config)', () => {
+    tagAc(AC_REACH);
+    removeShell();
+    const { container } = render(<DesktopMcpSection />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('inside the shell it always shows the canonical install surface with both clients (ac-50)', async () => {
+    tagAc(AC_REACH);
+    tagAc(AC_UMBRELLA);
+    installShell({ mcpStatus: () => STATUS_ABSENT });
+    render(<DesktopMcpSection />);
+
+    expect(
+      await screen.findByRole('heading', { name: 'Install Memex MCP' }),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('mcp-client-claudeCode')).toBeInTheDocument();
+    expect(screen.getByTestId('mcp-client-claudeDesktop')).toBeInTheDocument();
+  });
+
+  it('derives the honest per-client status from local config + tokens + connection', async () => {
+    tagAc(AC_UMBRELLA);
+    installShell({
+      mcpStatus: () => ({
+        ok: true,
+        targets: {
+          claudeCode: { installed: true, urlMatches: true, tokenPrefix: 'mxt_active123' },
+          claudeDesktop: { installed: false, urlMatches: false, tokenPrefix: null },
+        },
+      }),
+    });
+    listMcpTokensApi.mockResolvedValue([
+      { id: '1', label: 'Memex Desktop', prefix: 'mxt_active123', revokedAt: null },
+    ]);
+    fetchJourneyStateApi.mockResolvedValue({ milestones: { mcpConnected: true } });
+
+    render(<DesktopMcpSection />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId('mcp-status-claudeCode')).toHaveTextContent('MCP connected'),
+    );
+    expect(screen.getByTestId('mcp-status-claudeDesktop')).toHaveTextContent('Not installed');
+  });
+});
+
+describe('spec-304 ac-4: install from the app mints + writes via the bridge', () => {
+  it('clicking Install runs mint→installMcp and shows a restart prompt (token never shown)', async () => {
+    tagAc(AC_INSTALL);
+    tagAc(AC_UMBRELLA);
+    const installMcp = vi.fn(() => ({ ok: true, name: 'Claude Code', path: '/p', backupPath: '/p.bak' }));
+    const showNotification = vi.fn(() => ({ ok: true }));
+    const setMcpStatus = vi.fn(() => undefined);
+    installShell({
+      mcpStatus: () => STATUS_ABSENT,
+      installMcp,
+      showNotification,
+      setMcpStatus,
+    });
+
+    render(<DesktopMcpSection />);
+    const row = await screen.findByTestId('mcp-client-claudeCode');
+    fireEvent.click(within(row).getByRole('button', { name: 'Install' }));
+
+    await waitFor(() =>
+      expect(screen.getByRole('status')).toHaveTextContent(/Restart Claude Code/),
+    );
+    // Minted a token from the session and handed it to the bridge — never to the DOM.
+    expect(mintMcpTokenApi).toHaveBeenCalledWith('Memex Desktop', 'test-token');
+    expect(installMcp).toHaveBeenCalledWith(
+      expect.objectContaining({ token: 'mxt_minted_secret_999', target: 'claudeCode' }),
+    );
+    expect(document.body.innerHTML).not.toContain('mxt_minted_secret_999');
+    // Success was announced natively (dec-22).
+    expect(showNotification).toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/components/DesktopMcpSection.test.tsx
+++ b/packages/ui/src/components/DesktopMcpSection.test.tsx
@@ -67,7 +67,7 @@ describe('spec-304 ac-45 / ac-50: the in-app MCP surface in Settings → Integra
     render(<DesktopMcpSection />);
 
     expect(
-      await screen.findByRole('heading', { name: 'Install Memex MCP' }),
+      await screen.findByRole('heading', { name: 'Install Memex MCP on this device' }),
     ).toBeInTheDocument();
     expect(screen.getByTestId('mcp-client-claudeCode')).toBeInTheDocument();
     expect(screen.getByTestId('mcp-client-claudeDesktop')).toBeInTheDocument();

--- a/packages/ui/src/components/DesktopMcpSection.tsx
+++ b/packages/ui/src/components/DesktopMcpSection.tsx
@@ -141,7 +141,7 @@ export function DesktopMcpSection() {
   return (
     <section id="desktop-mcp" aria-labelledby="desktop-mcp-heading">
       <h2 id="desktop-mcp-heading" className="text-xl font-semibold mb-2 text-heading">
-        Install Memex MCP
+        Install Memex MCP on this device
       </h2>
       <p className="text-sm mb-6 text-secondary">
         Connect Claude to your Memexes from this app — no terminal, no copy-pasted token.

--- a/packages/ui/src/components/DesktopMcpSection.tsx
+++ b/packages/ui/src/components/DesktopMcpSection.tsx
@@ -1,0 +1,186 @@
+// spec-304 t-55 (dec-19..22): the in-app "Install Memex MCP" surface for the
+// desktop shell. Open core. This is the canonical install/status/manage UI the
+// native nav-bar pill and tray item open into (dec-19); it renders ONLY inside
+// the Memex desktop shell — a plain browser can't write `~/.claude.json`, so the
+// section is hidden there and Settings → Integrations shows the CLI installer
+// instead.
+//
+// React owns intent + credential (mint from the live session) and the status
+// derivation; Dart owns the OS-capable actions (config write, native toast) via
+// the bridge. The session token is minted in-process and never shown.
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useAuth } from './AuthContext';
+import { useUserChangeStream } from '../hooks/useUserChangeStream';
+import { listMcpTokensApi, mintMcpTokenApi } from '../api/mcp';
+import { fetchJourneyStateApi } from '../api/journey';
+import {
+  installMcpBridge,
+  isDesktopShell,
+  mcpStatusBridge,
+  setMcpStatusBridge,
+  showNotificationBridge,
+  type McpTargetKey,
+} from '../desktop/bridge';
+import {
+  deriveClientStatus,
+  deriveIndicator,
+  MCP_CLIENTS,
+  type ClientStatus,
+  type McpStatusResult,
+} from '../desktop/mcpStatus';
+import { runInstall } from '../desktop/install';
+
+type Phase = 'idle' | 'loading' | 'ready' | 'error';
+
+interface PerClient {
+  key: keyof McpStatusResult;
+  name: string;
+  status: ClientStatus;
+}
+
+const BUTTON_LABEL: Record<ClientStatus['button'], string> = {
+  install: 'Install',
+  reinstall: 'Reinstall',
+  repair: 'Repair',
+};
+
+export function DesktopMcpSection() {
+  const { token } = useAuth();
+  const [phase, setPhase] = useState<Phase>('idle');
+  const [clients, setClients] = useState<PerClient[]>([]);
+  const [busy, setBusy] = useState<keyof McpStatusResult | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  // Debounce: a single failed local probe must not flash an error state (dec-20).
+  const failedProbes = useRef(0);
+
+  const inShell = isDesktopShell();
+
+  const refresh = useCallback(async () => {
+    if (!inShell) return;
+    setPhase((p) => (p === 'ready' ? p : 'loading'));
+    try {
+      const [local, tokens, journey] = await Promise.all([
+        mcpStatusBridge(),
+        listMcpTokensApi(token),
+        fetchJourneyStateApi().catch(() => null),
+      ]);
+      if (!local) {
+        // Probe failed — tolerate transient failures before showing an error.
+        failedProbes.current += 1;
+        if (failedProbes.current >= 2 && phase !== 'ready') setPhase('error');
+        return;
+      }
+      failedProbes.current = 0;
+
+      const activePrefixes = new Set(
+        tokens.filter((t) => !t.revokedAt).map((t) => t.prefix),
+      );
+      const connected = journey?.milestones.mcpConnected ?? false;
+
+      const per: PerClient[] = MCP_CLIENTS.map(({ key, name }) => ({
+        key,
+        name,
+        status: deriveClientStatus(local[key], {
+          activeTokenPrefixes: activePrefixes,
+          connected,
+        }),
+      }));
+      setClients(per);
+      setPhase('ready');
+
+      // Push the aggregate indicator to the native pill (dec-21). React owns the
+      // truth; the shell owns the on-open timing + visibility policy.
+      void setMcpStatusBridge(deriveIndicator(per.map((c) => c.status)));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not read MCP status');
+      setPhase('error');
+    }
+  }, [inShell, token, phase]);
+
+  useEffect(() => {
+    void refresh();
+    // Re-derive when the user mints/revokes a token elsewhere.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [inShell, token]);
+
+  // Real-time: a token minted/revoked on another device re-derives status.
+  useUserChangeStream(() => void refresh(), ['mcp_token']);
+
+  const handleAction = useCallback(
+    async (target: McpTargetKey, name: string) => {
+      setBusy(target);
+      setMessage(null);
+      setError(null);
+      const outcome = await runInstall(target, name, {
+        mint: (label) => mintMcpTokenApi(label, token),
+        install: (opts) =>
+          installMcpBridge({ token: opts.token, target: opts.target, force: opts.force }),
+        notify: (opts) => showNotificationBridge(opts),
+        confirmOverwrite: (clientName, path) =>
+          window.confirm(
+            `${clientName}'s config at ${path} has comments or custom formatting. ` +
+              `Back it up (.bak) and overwrite?`,
+          ),
+      });
+      setBusy(null);
+      if (outcome.ok) {
+        setMessage(`Memex MCP installed for ${name}. Restart ${name} to finish connecting.`);
+        await refresh();
+      } else if (outcome.reason !== 'cancelled') {
+        setError(outcome.reason);
+      }
+    },
+    [token, refresh],
+  );
+
+  // The whole surface is desktop-shell-only: a browser can't write the config.
+  if (!inShell) return null;
+
+  return (
+    <section id="desktop-mcp" aria-labelledby="desktop-mcp-heading">
+      <h2 id="desktop-mcp-heading" className="text-xl font-semibold mb-2 text-heading">
+        Install Memex MCP
+      </h2>
+      <p className="text-sm mb-6 text-secondary">
+        Connect Claude to your Memexes from this app — no terminal, no copy-pasted token.
+        We mint a token from your current login and write it into the client's config
+        (a <code>.bak</code> is saved first). Restart the client afterwards to finish connecting.
+      </p>
+
+      {phase === 'loading' && <p className="text-sm text-secondary">Checking MCP status…</p>}
+      {error && <p className="text-sm text-error mb-4" role="alert">{error}</p>}
+      {message && (
+        <p className="text-sm text-status-success-text mb-4" role="status">{message}</p>
+      )}
+
+      <div className="border rounded-lg overflow-hidden bg-overlay border-edge">
+        {clients.map(({ key, name, status }) => (
+          <div
+            key={key}
+            data-testid={`mcp-client-${key}`}
+            className="flex items-center justify-between px-4 py-3 border-b last:border-0 border-edge-subtle"
+          >
+            <div>
+              <div className="text-sm text-primary">{name}</div>
+              <div
+                className="text-xs text-secondary"
+                data-testid={`mcp-status-${key}`}
+              >
+                {status.label}
+              </div>
+            </div>
+            <button
+              onClick={() => handleAction(key as McpTargetKey, name)}
+              disabled={busy !== null}
+              className="text-xs px-3 py-1.5 rounded-sm bg-accent text-on-accent hover:opacity-90 disabled:opacity-50"
+            >
+              {busy === key ? 'Installing MCP…' : BUTTON_LABEL[status.button]}
+            </button>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/packages/ui/src/desktop/bridge.ts
+++ b/packages/ui/src/desktop/bridge.ts
@@ -1,0 +1,138 @@
+// spec-304 t-55 (dec-19, dec-20, dec-22): typed wrappers over the desktop
+// shell's JS↔Dart bridge. The Memex React UI is hosted inside a Flutter
+// `flutter_inappwebview` that exposes `window.flutter_inappwebview.callHandler`;
+// in a plain browser the bridge is undefined and every call is a guarded no-op.
+//
+// Intent + credential live here in React (the session can mint an mxt_ token
+// with no device flow); the OS-capable actions (write ~/.claude.json, raise a
+// native toast) run in Dart through these handlers.
+
+import type { McpStatusResult } from './mcpStatus';
+
+declare global {
+  interface Window {
+    flutter_inappwebview?: {
+      callHandler: (handlerName: string, ...args: unknown[]) => unknown;
+    };
+  }
+}
+
+/** Which Claude client an install/remove targets (Dart accepts these spellings). */
+export type McpTargetKey = 'claudeCode' | 'claudeDesktop';
+
+/** The structured result every install/remove handler resolves to (never rejects). */
+export interface BridgeWriteResult {
+  ok: boolean;
+  /** Set when the existing config is JSONC — re-issue with `force: true`. */
+  needsConfirmation?: boolean;
+  name?: string;
+  path?: string;
+  backupPath?: string;
+  removed?: boolean;
+  error?: string;
+}
+
+function bridge(): Window['flutter_inappwebview'] {
+  return typeof window === 'undefined' ? undefined : window.flutter_inappwebview;
+}
+
+/** Whether the UI is running inside the Memex desktop shell (vs a plain browser). */
+export function isDesktopShell(): boolean {
+  return !!bridge();
+}
+
+/**
+ * The absolute server base the desktop shell should derive the MCP URL from.
+ * The webview is served from the same origin as the API + MCP, so the origin is
+ * the base; Dart strips a trailing `/api` and appends `/mcp`. Returns null
+ * outside a browser.
+ */
+export function desktopServerBase(): string | null {
+  if (typeof window === 'undefined') return null;
+  return window.location.origin;
+}
+
+async function call<T>(name: string, args: Record<string, unknown>): Promise<T> {
+  const b = bridge();
+  if (!b) throw new Error('Memex desktop shell is not available');
+  return (await b.callHandler(name, args)) as T;
+}
+
+/** Install (or repair/reinstall) the memex MCP entry into a Claude client. */
+export function installMcpBridge(opts: {
+  token: string;
+  target: McpTargetKey;
+  serverBase?: string | null;
+  force?: boolean;
+}): Promise<BridgeWriteResult> {
+  return call<BridgeWriteResult>('installMcp', {
+    token: opts.token,
+    target: opts.target,
+    serverBase: opts.serverBase ?? desktopServerBase(),
+    ...(opts.force ? { force: true } : {}),
+  });
+}
+
+/** Remove the memex MCP entry from a Claude client (inverse of install). */
+export function removeMcpBridge(opts: {
+  target: McpTargetKey;
+  force?: boolean;
+}): Promise<BridgeWriteResult> {
+  return call<BridgeWriteResult>('removeMcp', {
+    target: opts.target,
+    ...(opts.force ? { force: true } : {}),
+  });
+}
+
+/**
+ * Read-only probe of both Claude clients' local configs. Returns null outside
+ * the desktop shell (a plain browser has no local Claude config to read).
+ */
+export async function mcpStatusBridge(
+  serverBase?: string | null,
+): Promise<McpStatusResult | null> {
+  const b = bridge();
+  if (!b) return null;
+  const res = (await b.callHandler('mcpStatus', {
+    serverBase: serverBase ?? desktopServerBase(),
+  })) as { ok: boolean; targets: McpStatusResult };
+  return res?.ok ? res.targets : null;
+}
+
+/**
+ * Raise a native OS notification via the shell (dec-22). A no-op (resolves
+ * false) in a plain browser. Used to announce a successful install so it
+ * surfaces system-wide after the user alt-tabs to restart Claude.
+ */
+export async function showNotificationBridge(opts: {
+  title: string;
+  body?: string;
+  target?: string;
+}): Promise<boolean> {
+  const b = bridge();
+  if (!b) return false;
+  const res = (await b.callHandler('showNotification', opts)) as { ok: boolean };
+  return !!res?.ok;
+}
+
+/** The app-global MCP indicator state React pushes to the native pill (dec-21). */
+export interface McpIndicatorPush {
+  kind: 'connected' | 'ready' | 'repair' | 'install';
+  label: string;
+  visibility: 'transient' | 'persistent' | 'snoozable';
+}
+
+/**
+ * Push the derived indicator state to the native pill (dec-21). React owns the
+ * truth; Dart owns the chrome + the 5–10s on-open timing. A no-op in a plain
+ * browser, and tolerant of a shell build that predates the handler.
+ */
+export async function setMcpStatusBridge(push: McpIndicatorPush): Promise<void> {
+  const b = bridge();
+  if (!b) return;
+  try {
+    await b.callHandler('setMcpStatus', push);
+  } catch {
+    // An older shell without setMcpStatus must never break the web surface.
+  }
+}

--- a/packages/ui/src/desktop/install.test.ts
+++ b/packages/ui/src/desktop/install.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi } from 'vitest';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { runInstall, DESKTOP_TOKEN_LABEL, type InstallDeps } from './install';
+
+const AC_INSTALL = 'mindset-prod/memex-building-itself/specs/spec-304/acs/ac-4';
+const AC_SESSION = 'mindset-prod/memex-building-itself/specs/spec-304/acs/ac-6';
+const AC_RESTART = 'mindset-prod/memex-building-itself/specs/spec-304/acs/ac-7';
+const AC_NOTIFY = 'mindset-prod/memex-building-itself/specs/spec-304/acs/ac-51';
+const AC_UMBRELLA =
+  'mindset-prod/memex-building-itself/specs/spec-304/acs/ac-45';
+
+function deps(over: Partial<InstallDeps> = {}): InstallDeps {
+  return {
+    mint: vi.fn(async () => ({ token: 'mxt_secret_never_shown_123' })),
+    install: vi.fn(async () => ({ ok: true, name: 'Claude Code', path: '/p', backupPath: '/p.bak' })),
+    notify: vi.fn(async () => true),
+    confirmOverwrite: vi.fn(() => true),
+    ...over,
+  };
+}
+
+describe('spec-304 ac-6: token comes from the live session, no terminal/device flow', () => {
+  it('mints a labelled token and hands it straight to the bridge — never returns it', async () => {
+    tagAc(AC_SESSION);
+    tagAc(AC_UMBRELLA);
+    const d = deps();
+    const out = await runInstall('claudeCode', 'Claude Code', d);
+
+    expect(out).toEqual({ ok: true, client: 'Claude Code', backupPath: '/p.bak' });
+    expect(d.mint).toHaveBeenCalledWith(DESKTOP_TOKEN_LABEL);
+    // The token flowed mint → install and nowhere else; the outcome carries no secret.
+    expect(d.install).toHaveBeenCalledWith({
+      token: 'mxt_secret_never_shown_123',
+      target: 'claudeCode',
+    });
+    expect(JSON.stringify(out)).not.toContain('mxt_secret');
+  });
+});
+
+describe('spec-304 ac-4: install writes via the bridge (no-clobber + .bak surfaced)', () => {
+  it('returns the client + backup path on a clean write', async () => {
+    tagAc(AC_INSTALL);
+    const out = await runInstall('claudeDesktop', 'Claude Desktop', deps());
+    expect(out).toEqual({ ok: true, client: 'Claude Desktop', backupPath: '/p.bak' });
+  });
+
+  it('JSONC config: prompts, then re-issues with force after confirmation', async () => {
+    tagAc(AC_INSTALL);
+    const install = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: false, needsConfirmation: true, name: 'Claude Code', path: '/c' })
+      .mockResolvedValueOnce({ ok: true, name: 'Claude Code', path: '/c', backupPath: '/c.bak' });
+    const confirmOverwrite = vi.fn(() => true);
+    const d = deps({ install, confirmOverwrite });
+
+    const out = await runInstall('claudeCode', 'Claude Code', d);
+
+    expect(confirmOverwrite).toHaveBeenCalledWith('Claude Code', '/c');
+    expect(install).toHaveBeenNthCalledWith(2, {
+      token: 'mxt_secret_never_shown_123',
+      target: 'claudeCode',
+      force: true,
+    });
+    expect(out.ok).toBe(true);
+  });
+
+  it('JSONC config: cancelling the prompt leaves nothing installed', async () => {
+    tagAc(AC_INSTALL);
+    const install = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: false, needsConfirmation: true, name: 'Claude Code', path: '/c' });
+    const d = deps({ install, confirmOverwrite: vi.fn(() => false) });
+
+    const out = await runInstall('claudeCode', 'Claude Code', d);
+
+    expect(out).toEqual({ ok: false, reason: 'cancelled' });
+    expect(install).toHaveBeenCalledTimes(1); // never forced
+  });
+
+  it('a bridge failure returns a plain reason and does NOT notify', async () => {
+    tagAc(AC_INSTALL);
+    const notify = vi.fn(async () => true);
+    const d = deps({
+      install: vi.fn(async () => ({ ok: false, error: 'disk full' })),
+      notify,
+    });
+    const out = await runInstall('claudeCode', 'Claude Code', d);
+    expect(out).toEqual({ ok: false, reason: 'disk full' });
+    expect(notify).not.toHaveBeenCalled();
+  });
+
+  it('a mint failure aborts before touching the bridge', async () => {
+    tagAc(AC_SESSION);
+    const install = vi.fn();
+    const d = deps({ mint: vi.fn(async () => { throw new Error('session expired'); }), install });
+    const out = await runInstall('claudeCode', 'Claude Code', d);
+    expect(out).toEqual({ ok: false, reason: 'session expired' });
+    expect(install).not.toHaveBeenCalled();
+  });
+});
+
+describe('spec-304 ac-7 / ac-51: success announces a native restart prompt', () => {
+  it('raises a native notification telling the user to restart that client', async () => {
+    tagAc(AC_RESTART);
+    tagAc(AC_NOTIFY);
+    const notify = vi.fn(async () => true);
+    await runInstall('claudeDesktop', 'Claude Desktop', deps({ notify }));
+    expect(notify).toHaveBeenCalledTimes(1);
+    const arg = notify.mock.calls[0][0];
+    expect(arg.title).toMatch(/MCP/);
+    expect(arg.body).toMatch(/Restart Claude Desktop/);
+  });
+
+  it('a toast failure does not fail the install (best-effort)', async () => {
+    tagAc(AC_NOTIFY);
+    const out = await runInstall('claudeCode', 'Claude Code', deps({
+      notify: vi.fn(async () => { throw new Error('no notification permission'); }),
+    }));
+    expect(out.ok).toBe(true);
+  });
+});

--- a/packages/ui/src/desktop/install.ts
+++ b/packages/ui/src/desktop/install.ts
@@ -1,0 +1,92 @@
+// spec-304 t-55 (s-17 "the install flow"): the in-app MCP install orchestration,
+// extracted from the React component so the whole mint→install→confirm→notify
+// sequence is unit-testable with injected dependencies. The session token is
+// minted in-process and handed straight to the native bridge — it is never
+// shown, logged, or persisted (ac-6). Nothing partial is left behind on failure.
+
+import type { BridgeWriteResult, McpTargetKey } from './bridge';
+
+export interface InstallDeps {
+  /** Mint a fresh mxt_ token from the logged-in session (ac-6). */
+  mint: (label: string) => Promise<{ token: string }>;
+  /** Write the entry via the native installMcp bridge. */
+  install: (opts: {
+    token: string;
+    target: McpTargetKey;
+    force?: boolean;
+  }) => Promise<BridgeWriteResult>;
+  /** Raise the native success toast prompting a Claude restart (ac-51, dec-22). */
+  notify: (opts: { title: string; body: string; target?: string }) => Promise<boolean>;
+  /** Ask the user to back up & overwrite a JSONC config. Returns false to cancel. */
+  confirmOverwrite: (name: string, path: string) => boolean | Promise<boolean>;
+}
+
+export type InstallOutcome =
+  | { ok: true; client: string; backupPath?: string }
+  | { ok: false; reason: string };
+
+/** The label every desktop-minted token carries, so they're recognisable in the token list. */
+export const DESKTOP_TOKEN_LABEL = 'Memex Desktop';
+
+/**
+ * Run the full in-app install for one Claude client:
+ *  1. mint a token from the live session (no terminal / device flow — ac-6),
+ *  2. write it via the bridge, preserving siblings + taking a .bak (ac-4),
+ *  3. if the config is JSONC, prompt and re-issue with `force` (s-17 step 5),
+ *  4. on success, raise a native OS notification telling the user to restart
+ *     Claude so the tools load (ac-7, ac-51).
+ * Any failure returns a plain reason; nothing partial is left behind.
+ */
+export async function runInstall(
+  target: McpTargetKey,
+  clientName: string,
+  deps: InstallDeps,
+): Promise<InstallOutcome> {
+  let token: string;
+  try {
+    const minted = await deps.mint(DESKTOP_TOKEN_LABEL);
+    token = minted.token;
+  } catch (err) {
+    return { ok: false, reason: reason(err, 'Could not mint a token from your session') };
+  }
+  if (!token) return { ok: false, reason: 'Could not mint a token from your session' };
+
+  let res: BridgeWriteResult;
+  try {
+    res = await deps.install({ token, target });
+  } catch (err) {
+    return { ok: false, reason: reason(err, 'Install failed') };
+  }
+
+  // JSONC branch: the bridge did NOT overwrite. Confirm, then re-issue forced.
+  if (!res.ok && res.needsConfirmation) {
+    const proceed = await deps.confirmOverwrite(res.name ?? clientName, res.path ?? '');
+    if (!proceed) return { ok: false, reason: 'cancelled' };
+    try {
+      res = await deps.install({ token, target, force: true });
+    } catch (err) {
+      return { ok: false, reason: reason(err, 'Install failed') };
+    }
+  }
+
+  if (!res.ok) {
+    return { ok: false, reason: res.error ?? 'Install failed' };
+  }
+
+  // Success — announce natively so completion surfaces even after the user
+  // alt-tabs to restart Claude (dec-22). The toast is best-effort; a browser
+  // (or a shell that can't toast) must not fail the install.
+  await deps
+    .notify({
+      title: 'MCP ready',
+      body: `Restart ${clientName} to finish connecting Memex.`,
+      target: 'mcp',
+    })
+    .catch(() => false);
+
+  return { ok: true, client: clientName, backupPath: res.backupPath };
+}
+
+function reason(err: unknown, fallback: string): string {
+  return err instanceof Error && err.message ? err.message : fallback;
+}

--- a/packages/ui/src/desktop/mcpStatus.test.ts
+++ b/packages/ui/src/desktop/mcpStatus.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from 'vitest';
+import { tagAc } from '@memex-ai-ac/vitest';
+import {
+  deriveClientStatus,
+  deriveIndicator,
+  type ClientStatus,
+  type McpTargetStatus,
+} from './mcpStatus';
+
+const AC_DERIVE = 'mindset-prod/memex-building-itself/specs/spec-304/acs/ac-48';
+const AC_INDICATOR =
+  'mindset-prod/memex-building-itself/specs/spec-304/acs/ac-49';
+
+const ACTIVE = new Set(['mxt_active1234']);
+
+function local(over: Partial<McpTargetStatus> = {}): McpTargetStatus {
+  return {
+    installed: true,
+    urlMatches: true,
+    tokenPrefix: 'mxt_active1234',
+    ...over,
+  };
+}
+
+describe('spec-304 ac-48: per-client status derivation (local ⨝ active tokens ⨝ connection)', () => {
+  it('absent config → Not installed / Install (never an error)', () => {
+    tagAc(AC_DERIVE);
+    expect(
+      deriveClientStatus(undefined, { activeTokenPrefixes: ACTIVE, connected: false }),
+    ).toEqual({ kind: 'not_installed', label: 'Not installed', button: 'install' });
+    expect(
+      deriveClientStatus(local({ installed: false }), {
+        activeTokenPrefixes: ACTIVE,
+        connected: false,
+      }).kind,
+    ).toBe('not_installed');
+  });
+
+  it('installed + active token + no handshake → MCP ready / Reinstall', () => {
+    tagAc(AC_DERIVE);
+    expect(
+      deriveClientStatus(local(), { activeTokenPrefixes: ACTIVE, connected: false }),
+    ).toEqual({ kind: 'ready', label: 'MCP ready', button: 'reinstall' });
+  });
+
+  it('installed + active token + handshake observed → MCP connected', () => {
+    tagAc(AC_DERIVE);
+    expect(
+      deriveClientStatus(local(), { activeTokenPrefixes: ACTIVE, connected: true }),
+    ).toEqual({ kind: 'connected', label: 'MCP connected', button: 'reinstall' });
+  });
+
+  it('installed but token revoked / unknown → Token invalid / Repair', () => {
+    tagAc(AC_DERIVE);
+    expect(
+      deriveClientStatus(local({ tokenPrefix: 'mxt_revoked999' }), {
+        activeTokenPrefixes: ACTIVE,
+        connected: true, // even a stale handshake must not mask a dead token
+      }),
+    ).toEqual({ kind: 'repair', label: 'Token invalid', button: 'repair' });
+  });
+
+  it('installed but no extractable token → Repair (cannot confirm authorization)', () => {
+    tagAc(AC_DERIVE);
+    expect(
+      deriveClientStatus(local({ tokenPrefix: null }), {
+        activeTokenPrefixes: ACTIVE,
+        connected: false,
+      }).kind,
+    ).toBe('repair');
+  });
+
+  it('installed but pointing at a different server → Points elsewhere / Reinstall', () => {
+    tagAc(AC_DERIVE);
+    expect(
+      deriveClientStatus(local({ urlMatches: false }), {
+        activeTokenPrefixes: ACTIVE,
+        connected: false,
+      }),
+    ).toEqual({ kind: 'reinstall', label: 'Points elsewhere', button: 'reinstall' });
+  });
+});
+
+describe('spec-304 ac-49: app-global indicator — quiet, honest, MCP-led wording', () => {
+  const s = (kind: ClientStatus['kind']): ClientStatus => ({
+    kind,
+    label: 'x',
+    button: 'install',
+  });
+
+  it('every non-empty indicator label leads with "MCP"', () => {
+    tagAc(AC_INDICATOR);
+    for (const kinds of [
+      ['connected'],
+      ['ready'],
+      ['repair'],
+      ['reinstall'],
+      ['not_installed'],
+    ] as ClientStatus['kind'][][]) {
+      const label = deriveIndicator(kinds.map(s)).label;
+      expect(label.startsWith('MCP') || label === 'Install MCP').toBe(true);
+    }
+  });
+
+  it('connected wins and is transient (auto-hides in the healthy steady state)', () => {
+    tagAc(AC_INDICATOR);
+    expect(deriveIndicator([s('connected'), s('not_installed')])).toEqual({
+      kind: 'connected',
+      label: 'MCP connected',
+      visibility: 'transient',
+    });
+  });
+
+  it('ready (installed, no handshake) is transient and never reads "connected"', () => {
+    tagAc(AC_INDICATOR);
+    const ind = deriveIndicator([s('ready'), s('not_installed')]);
+    expect(ind.kind).toBe('ready');
+    expect(ind.label).toBe('MCP ready');
+    expect(ind.label).not.toContain('connected');
+    expect(ind.visibility).toBe('transient');
+  });
+
+  it('a broken install (repair / wrong-server) is a PERSISTENT "MCP needs repair" badge', () => {
+    tagAc(AC_INDICATOR);
+    expect(deriveIndicator([s('repair'), s('not_installed')])).toEqual({
+      kind: 'repair',
+      label: 'MCP needs repair',
+      visibility: 'persistent',
+    });
+    expect(deriveIndicator([s('reinstall')]).visibility).toBe('persistent');
+  });
+
+  it('nothing installed → quiet, snoozable "Install MCP" prompt (an opportunity, not an alarm)', () => {
+    tagAc(AC_INDICATOR);
+    expect(deriveIndicator([s('not_installed'), s('not_installed')])).toEqual({
+      kind: 'install',
+      label: 'Install MCP',
+      visibility: 'snoozable',
+    });
+  });
+
+  it('a connected client beside a never-installed one is not "needs repair"', () => {
+    tagAc(AC_INDICATOR);
+    // never-installed ≠ broken: the second client being absent must not raise an alarm.
+    expect(deriveIndicator([s('connected'), s('not_installed')]).kind).toBe('connected');
+  });
+});

--- a/packages/ui/src/desktop/mcpStatus.ts
+++ b/packages/ui/src/desktop/mcpStatus.ts
@@ -1,0 +1,111 @@
+// spec-304 t-55 (dec-20, dec-21 → ac-48, ac-49): the PURE status derivation for
+// the in-app MCP install surface. The desktop shell's `mcpStatus` bridge reports
+// each Claude client's LOCAL config (installed / urlMatches / tokenPrefix); the
+// server reports the user's ACTIVE tokens (by non-secret prefix) and the MCP
+// connection signal (the same `mcp.connected` milestone the onboarding journey
+// reads). This module joins those three truths client-side — no I/O, no React —
+// so the classification is unit-testable in isolation.
+
+/** One client's local-config truth, as returned by the Dart `mcpStatus` bridge. */
+export interface McpTargetStatus {
+  installed: boolean;
+  urlMatches: boolean;
+  /** Non-secret 12-char (`mxt_`+8) prefix of the entry's token, or null. */
+  tokenPrefix: string | null;
+}
+
+/** Both clients, keyed as the bridge returns them. */
+export interface McpStatusResult {
+  claudeCode: McpTargetStatus;
+  claudeDesktop: McpTargetStatus;
+}
+
+export type ClientStatusKind =
+  | 'not_installed'
+  | 'ready' // installed + authorized, no handshake yet
+  | 'connected' // installed + authorized + a real MCP handshake observed
+  | 'repair' // installed but the token is revoked / unknown
+  | 'reinstall'; // installed but pointing at a different server
+
+export type ClientButton = 'install' | 'reinstall' | 'repair';
+
+export interface ClientStatus {
+  kind: ClientStatusKind;
+  /** The per-client label shown in Settings → Integrations (s-17 table). */
+  label: string;
+  button: ClientButton;
+}
+
+/**
+ * Classify ONE client by joining its local config with the user's active token
+ * prefixes and the connection signal. A never-installed client is never an error
+ * (dec-20). Precedence once installed: wrong-server → revoked/unknown-token →
+ * connected → ready.
+ */
+export function deriveClientStatus(
+  local: McpTargetStatus | undefined,
+  opts: { activeTokenPrefixes: ReadonlySet<string>; connected: boolean },
+): ClientStatus {
+  if (!local || !local.installed) {
+    return { kind: 'not_installed', label: 'Not installed', button: 'install' };
+  }
+  if (!local.urlMatches) {
+    return { kind: 'reinstall', label: 'Points elsewhere', button: 'reinstall' };
+  }
+  const authorized =
+    local.tokenPrefix != null && opts.activeTokenPrefixes.has(local.tokenPrefix);
+  if (!authorized) {
+    return { kind: 'repair', label: 'Token invalid', button: 'repair' };
+  }
+  if (opts.connected) {
+    return { kind: 'connected', label: 'MCP connected', button: 'reinstall' };
+  }
+  return { kind: 'ready', label: 'MCP ready', button: 'reinstall' };
+}
+
+export type IndicatorKind = 'connected' | 'ready' | 'repair' | 'install';
+
+export type IndicatorVisibility =
+  | 'transient' // healthy: show the true state briefly on window open, then hide
+  | 'persistent' // an actionable error: stay until resolved
+  | 'snoozable'; // an opportunity (never installed): dismissible prompt
+
+/**
+ * The single app-global indicator the native pill renders (dec-21). It is a
+ * quiet EXCEPTION surface, not a status light: every label leads with "MCP …"
+ * so it reads as the tool's status, never the server's. "connected" never
+ * appears before a real handshake. The native side owns the 5–10s on-open
+ * timing; this function owns the TRUTH + the visibility *class*.
+ *
+ * Aggregation across both clients (an un-chosen second client is never an
+ * error): connected wins, then ready, then any broken install (repair /
+ * wrong-server) as a persistent badge, else the quiet install prompt.
+ */
+export function deriveIndicator(statuses: readonly ClientStatus[]): Indicator {
+  const kinds = new Set(statuses.map((s) => s.kind));
+  if (kinds.has('connected')) {
+    return { kind: 'connected', label: 'MCP connected', visibility: 'transient' };
+  }
+  if (kinds.has('ready')) {
+    return { kind: 'ready', label: 'MCP ready', visibility: 'transient' };
+  }
+  if (kinds.has('repair') || kinds.has('reinstall')) {
+    return { kind: 'repair', label: 'MCP needs repair', visibility: 'persistent' };
+  }
+  return { kind: 'install', label: 'Install MCP', visibility: 'snoozable' };
+}
+
+export interface Indicator {
+  kind: IndicatorKind;
+  label: string;
+  visibility: IndicatorVisibility;
+}
+
+/** The two clients, in display order, with their human names + bridge keys. */
+export const MCP_CLIENTS: ReadonlyArray<{
+  key: keyof McpStatusResult;
+  name: string;
+}> = [
+  { key: 'claudeCode', name: 'Claude Code' },
+  { key: 'claudeDesktop', name: 'Claude Desktop' },
+];

--- a/packages/ui/src/onAccentToken.spec-167.test.ts
+++ b/packages/ui/src/onAccentToken.spec-167.test.ts
@@ -95,8 +95,11 @@ describe('spec-167: on-accent foreground token', () => {
     // spec-421: CreateFirstSpecStep.tsx added as a new text-on-accent consumer
     // (blue "Create your first spec" CTA button); CreateSpecStep.tsx's Stage-2
     // "Create spec in Memex" button was removed, so it exits the set.
+    // spec-304 t-55: DesktopMcpSection.tsx added — its Install/Reinstall/Repair
+    // primary button renders text on a bg-accent fill (the token's intended case).
     expect(consumers).toEqual(
       [
+        'components/DesktopMcpSection.tsx',
         'components/home/CreateFirstSpecStep.tsx',
         'components/home/IdentityStep.tsx',
         'components/upgrade/PricingCard.tsx',

--- a/packages/ui/src/pages/SettingsIntegrations.tsx
+++ b/packages/ui/src/pages/SettingsIntegrations.tsx
@@ -4,6 +4,7 @@
 // /installation):
 //   - <SlackIntegrationSection/>   — Enterprise (lives under components/.ee/)
 //   - <DiscordIntegrationSection/> — Enterprise (lives under components/.ee/, spec-138)
+//   - <DesktopMcpSection/>         — open core (spec-304 t-55: in-app MCP install; desktop-shell only).
 //   - <McpTokensSection/>          — open core (MCP token management).
 //   - <CliInstallSection/>         — open core (install instructions).
 //   - <GenesisPromptSection/>      — open core (spec-201: one-paste agent setup).
@@ -12,6 +13,7 @@
 
 import { SlackIntegrationSection } from '../components/.ee/SlackIntegrationSection';
 import { DiscordIntegrationSection } from '../components/.ee/DiscordIntegrationSection';
+import { DesktopMcpSection } from '../components/DesktopMcpSection';
 import { McpTokensSection } from '../components/McpTokensSection';
 import { CliInstallSection } from '../components/CliInstallSection';
 import { GenesisPromptSection } from '../components/GenesisPromptSection';
@@ -32,6 +34,8 @@ export function SettingsIntegrations() {
 
         <SlackIntegrationSection />
         <DiscordIntegrationSection />
+        {/* Desktop-shell only (spec-304 t-55): self-hides in a plain browser. */}
+        <DesktopMcpSection />
         <McpTokensSection />
         <CliInstallSection />
         <GenesisPromptSection />


### PR DESCRIPTION
## Summary
The **React half** of spec-304 **t-55** — the in-app "Install Memex MCP" experience for the desktop shell. Pairs with the native bridge/pill/tray work in `mindset-ai/memex-clients` (sibling PR on the same branch name).

Renders **only inside the Flutter desktop shell** (a plain browser can't write `~/.claude.json`); self-hides otherwise, so the web app is unaffected.

## What's here
- **`packages/ui/src/desktop/`** — new module:
  - `bridge.ts` — typed `callHandler` wrappers + `isDesktopShell()` detection.
  - `mcpStatus.ts` — pure per-client status derivation joining local config ⨝ active tokens (by prefix) ⨝ the `mcp.connected` signal, plus the aggregate indicator (quiet/transient/persistent/snoozable, every label leads with "MCP").
  - `install.ts` — the mint → `installMcp` → JSONC-confirm → force → native-notify orchestrator. The session token is minted in-process and handed to the bridge; never shown, logged, or persisted.
- **`DesktopMcpSection.tsx`** — the canonical install/status/manage surface, wired into Settings → Integrations; pushes the derived indicator to the native pill via `setMcpStatus`.
- **journey-45** — adds an in-app install-flow e2e (stubs `flutter_inappwebview`, asserts the minted `mxt_` token reaches `installMcp` and never hits the DOM) alongside the existing session-mint test.

## ACs verified (React side)
ac-4, ac-6, ac-7, ac-45, ac-48, ac-49, ac-51 — all green via tagged vitest tests emitting to the prod board.

## Test plan
- [x] `vitest` — 35 tests across the desktop module + DesktopMcpSection + existing Integrations tests
- [x] `tsc -b` clean, `biome check` clean
- [x] `playwright test --list` confirms journey-45 loads + both tests register
- [ ] `make e2e-cold` (std-28) — required per-PR CI check (not runnable locally: no Postgres/browsers)
- [ ] Real in-shell validation on **int** once deployed (tracked in spec-304 issue-21)

## Notes
- ac-47 shape: the bridge handler honors **both** an explicit-`target` flat shape (ac-47's literal text) and a no-arg per-client map (the s-17 narrative). See QA report qa_report-15.
- Runtime sign-offs (live pill timing, real install round-trip) tracked in **spec-304 issue-21**.