### PR TITLE
fix(spec-304): CD connector dialog + app-global MCP pill + per-token connected + hash-scroll (t-56, issues 23/24/25)

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -95,6 +95,7 @@ import { ChatProvider } from './components/ChatContext';
 import { AppShell } from './components/AppShell';
 import { DocumentShell } from './components/DocumentShell';
 import { OrgConsentDialog } from './components/OrgConsentDialog';
+import { DesktopMcpStatusSync } from './components/DesktopMcpStatusSync';
 import { parseTenantFromPathname } from './utils/tenantUrl';
 import { isFeatureHidden } from './utils/featureFlags';
 import { probePublicMemex, type PublicMemexProbe } from './api/client';
@@ -417,6 +418,10 @@ export function PostLoginRouter() {
   const { session } = useAuth();
   return (
     <Suspense fallback={RouteFallback}>
+    {/* spec-304 t-58 (issue-24 #1): app-global MCP status sync — mounted once,
+        outside <Routes>, so the native pill is driven on EVERY route, not only
+        on Settings → Integrations. Renders nothing; no-op in a plain browser. */}
+    <DesktopMcpStatusSync />
     <Routes>
       {/* Flat (caller-scoped) routes — no tenant prefix. */}
       <Route path="/" element={<RootRedirect />} />

--- a/packages/ui/src/components/ClaudeConnectorDialog.test.tsx
+++ b/packages/ui/src/components/ClaudeConnectorDialog.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { ClaudeConnectorDialog } from './ClaudeConnectorDialog';
+
+// t-56 → dec-23 / ac-55: the Claude Desktop "Install for my org" connector
+// dialog — env-derived URL + copy + steps + admin note + honest-CTA copy.
+const AC_DIALOG =
+  'mindset-prod/memex-building-itself/specs/spec-304/acs/ac-55';
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('spec-304 ac-55 (t-56): Claude Desktop connector-instructions dialog', () => {
+  it('shows the env-derived connector URL, the add-connector steps, and the Team/Enterprise admin note', () => {
+    tagAc(AC_DIALOG);
+    render(
+      <ClaudeConnectorDialog connectorUrl="https://int.memex.ai/mcp" onClose={() => {}} />,
+    );
+
+    // The env-derived URL (int here; prod would be https://memex.ai/mcp).
+    expect(screen.getByTestId('connector-url')).toHaveTextContent('https://int.memex.ai/mcp');
+    // Step-by-step add-a-connector instructions.
+    expect(screen.getByText(/Add custom connector/i)).toBeInTheDocument();
+    expect(screen.getByText(/Individual sign-in/i)).toBeInTheDocument();
+    // The Team/Enterprise admin-only note (Owner adds; members sign in).
+    expect(screen.getByText(/only a workspace\s*Owner can add/i)).toBeInTheDocument();
+  });
+
+  it('reads as honest guidance to set up INSIDE Claude (std-34), not an in-app install', () => {
+    tagAc(AC_DIALOG);
+    render(
+      <ClaudeConnectorDialog connectorUrl="https://memex.ai/mcp" onClose={() => {}} />,
+    );
+    // The honest-CTA signal: Memex can't add it for you; you add it in Claude.
+    expect(screen.getByText(/Memex can’t add it for you/i)).toBeInTheDocument();
+  });
+
+  it('copies the connector URL to the clipboard', async () => {
+    tagAc(AC_DIALOG);
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    render(
+      <ClaudeConnectorDialog connectorUrl="https://memex.ai/mcp" onClose={() => {}} />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Copy URL' }));
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith('https://memex.ai/mcp'));
+    expect(await screen.findByRole('button', { name: 'Copied!' })).toBeInTheDocument();
+  });
+
+  it('Escape and the Done button both close the dialog', () => {
+    tagAc(AC_DIALOG);
+    const onClose = vi.fn();
+    render(
+      <ClaudeConnectorDialog connectorUrl="https://memex.ai/mcp" onClose={onClose} />,
+    );
+    fireEvent.keyDown(document, { key: 'Escape' });
+    fireEvent.click(screen.getByRole('button', { name: 'Done' }));
+    expect(onClose).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/ui/src/components/ClaudeConnectorDialog.tsx
+++ b/packages/ui/src/components/ClaudeConnectorDialog.tsx
@@ -1,0 +1,137 @@
+// spec-304 t-56 (dec-23 → ac-55): the Claude Desktop "Install for my org"
+// connector-instructions dialog. Open core.
+//
+// dec-23 dropped the npx mcp-remote Claude Desktop path (it re-introduced the
+// Node dependency the spec set out to remove, and broke on Windows — issue-22).
+// Claude Desktop's Node-free remote-MCP route is an account-level Custom
+// Connector added in Claude's own Connectors UI (OAuth 2.1 + PKCE + DCR, which
+// the Memex server already implements). The app CANNOT write a connector — it is
+// account-level and, on Team/Enterprise, only an Owner can add it — so this is
+// GUIDANCE, not an in-app file write.
+//
+// std-34 (the honest-CTA rule): the copy says plainly that the connector is set
+// up INSIDE Claude, signalling the web↔MCP capability boundary rather than
+// implying the app does it.
+//
+// Deep-link / prefill investigation (ac-55): Claude Desktop exposes no public,
+// documented URL scheme to open "Add custom connector" prefilled with a URL
+// (the claude:// scheme is undocumented and not contractual). So the dialog's
+// primary action is the graceful fallback — copy the connector URL + open
+// Claude's settings manually + follow the steps. If a documented deep link ever
+// ships, the primary action becomes that link with this as the fallback.
+
+import { useCallback, useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { Button } from './ui';
+
+interface ClaudeConnectorDialogProps {
+  /** The env-derived MCP connector URL (e.g. https://memex.ai/mcp). */
+  connectorUrl: string;
+  onClose: () => void;
+}
+
+export function ClaudeConnectorDialog({ connectorUrl, onClose }: ClaudeConnectorDialogProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    },
+    [onClose],
+  );
+
+  useEffect(() => {
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [handleKeyDown]);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(connectorUrl);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1600);
+    } catch {
+      // Clipboard can be denied (permissions / insecure context); the URL is
+      // still shown on screen for manual copy, so a copy failure is non-fatal.
+    }
+  };
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-xs"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div
+        role="dialog"
+        aria-labelledby="cd-connector-heading"
+        className="w-[520px] max-w-[92vw] rounded-xl border border-edge bg-panel shadow-2xl"
+      >
+        <div className="flex items-center justify-between px-5 py-3 border-b border-edge">
+          <h2 id="cd-connector-heading" className="text-sm font-semibold text-heading">
+            Connect Claude Desktop for your org
+          </h2>
+          <button
+            onClick={onClose}
+            aria-label="Close"
+            className="p-1 rounded-md text-muted hover:text-primary hover:bg-overlay transition-colors"
+          >
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        <div className="px-5 py-4 space-y-4">
+          {/* Honest CTA (std-34): name the boundary — this is set up inside
+              Claude, the app can't add the connector for you. */}
+          <p className="text-sm text-muted">
+            Claude Desktop connects to Memex through a{' '}
+            <span className="font-medium text-primary">Custom Connector</span> you add inside
+            Claude — Memex can’t add it for you. Copy the connector URL below, then follow these
+            steps in Claude:
+          </p>
+
+          <div>
+            <div className="mb-1 text-xs font-medium text-secondary">Connector URL</div>
+            <div className="flex items-center gap-2">
+              <code
+                data-testid="connector-url"
+                className="flex-1 truncate rounded-md bg-overlay px-3 py-2 text-xs text-primary border border-edge-subtle"
+              >
+                {connectorUrl}
+              </code>
+              <Button size="sm" onClick={handleCopy}>
+                {copied ? 'Copied!' : 'Copy URL'}
+              </Button>
+            </div>
+          </div>
+
+          <ol className="list-decimal pl-5 space-y-1.5 text-sm text-secondary">
+            <li>Open <span className="text-primary">Claude → Settings → Connectors</span>.</li>
+            <li>Click <span className="text-primary">Add custom connector</span>.</li>
+            <li>Paste the connector URL above.</li>
+            <li>Keep <span className="text-primary">Individual sign-in</span> selected (each person signs in with their own Memex account).</li>
+            <li>Click <span className="text-primary">Add</span>, then sign in to Memex when prompted.</li>
+            <li>Restart Claude Desktop to finish connecting.</li>
+          </ol>
+
+          {/* The admin reality on Team/Enterprise (dec-23). */}
+          <p className="rounded-md bg-overlay px-3 py-2 text-xs text-muted border border-edge-subtle">
+            <span className="font-medium text-secondary">Team or Enterprise?</span> Only a workspace
+            Owner can add a custom connector. Once an Owner has added it, every member signs in
+            individually with their own Memex account.
+          </p>
+        </div>
+
+        <div className="flex justify-end gap-2 px-5 py-3 border-t border-edge">
+          <Button variant="ghost" size="sm" onClick={onClose}>
+            Done
+          </Button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/packages/ui/src/components/ClaudeConnectorDialog.tsx
+++ b/packages/ui/src/components/ClaudeConnectorDialog.tsx
@@ -112,16 +112,16 @@ export function ClaudeConnectorDialog({ connectorUrl, onClose }: ClaudeConnector
             <li>Open <span className="text-primary">Claude → Settings → Connectors</span>.</li>
             <li>Click <span className="text-primary">Add custom connector</span>.</li>
             <li>Paste the connector URL above.</li>
-            <li>Keep <span className="text-primary">Individual sign-in</span> selected (each person signs in with their own Memex account).</li>
+            <li>Keep <span className="text-primary">Individual sign-in</span> selected (each person signs in with their own Memex login).</li>
             <li>Click <span className="text-primary">Add</span>, then sign in to Memex when prompted.</li>
             <li>Restart Claude Desktop to finish connecting.</li>
           </ol>
 
           {/* The admin reality on Team/Enterprise (dec-23). */}
           <p className="rounded-md bg-overlay px-3 py-2 text-xs text-muted border border-edge-subtle">
-            <span className="font-medium text-secondary">Team or Enterprise?</span> Only a workspace
+            <span className="font-medium text-secondary">Managed Claude plan?</span> Only a workspace
             Owner can add a custom connector. Once an Owner has added it, every member signs in
-            individually with their own Memex account.
+            individually with their own Memex login.
           </p>
         </div>
 

--- a/packages/ui/src/components/DesktopMcpSection.test.tsx
+++ b/packages/ui/src/components/DesktopMcpSection.test.tsx
@@ -6,6 +6,12 @@ import { DesktopMcpSection } from './DesktopMcpSection';
 const AC_UMBRELLA = 'mindset-prod/memex-building-itself/specs/spec-304/acs/ac-45';
 const AC_INSTALL = 'mindset-prod/memex-building-itself/specs/spec-304/acs/ac-4';
 const AC_REACH = 'mindset-prod/memex-building-itself/specs/spec-304/acs/ac-50';
+// t-56: Claude Desktop is connector-based — single "Install for my org" button
+// opening the instructions dialog (no npx install), and connected-via-signal.
+const AC_CONNECTOR_DIALOG =
+  'mindset-prod/memex-building-itself/specs/spec-304/acs/ac-55';
+const AC_CONNECTOR_STATUS =
+  'mindset-prod/memex-building-itself/specs/spec-304/acs/ac-56';
 
 // ── Mocks ────────────────────────────────────────────────────────────────
 vi.mock('./AuthContext', () => ({ useAuth: () => ({ token: 'test-token' }) }));
@@ -73,7 +79,7 @@ describe('spec-304 ac-45 / ac-50: the in-app MCP surface in Settings → Integra
     expect(screen.getByTestId('mcp-client-claudeDesktop')).toBeInTheDocument();
   });
 
-  it('derives the honest per-client status from local config + tokens + connection', async () => {
+  it('Claude Code connected reads from the per-token handshake (lastUsedAt), not the user signal', async () => {
     tagAc(AC_UMBRELLA);
     installShell({
       mcpStatus: () => ({
@@ -85,20 +91,20 @@ describe('spec-304 ac-45 / ac-50: the in-app MCP surface in Settings → Integra
       }),
     });
     listMcpTokensApi.mockResolvedValue([
-      { id: '1', label: 'Memex Desktop', prefix: 'mxt_active123', revokedAt: null },
+      { id: '1', label: 'Memex Desktop', prefix: 'mxt_active123', lastUsedAt: '2026-06-28T10:00:00Z', revokedAt: null },
     ]);
-    fetchJourneyStateApi.mockResolvedValue({ milestones: { mcpConnected: true } });
+    // user-scoped signal is false — CC connected must come from the token only.
+    fetchJourneyStateApi.mockResolvedValue({ milestones: { mcpConnected: false } });
 
     render(<DesktopMcpSection />);
 
     await waitFor(() =>
       expect(screen.getByTestId('mcp-status-claudeCode')).toHaveTextContent('MCP connected'),
     );
-    expect(screen.getByTestId('mcp-status-claudeDesktop')).toHaveTextContent('Not installed');
   });
 });
 
-describe('spec-304 ac-4: install from the app mints + writes via the bridge', () => {
+describe('spec-304 ac-4: Claude Code install from the app mints + writes via the bridge', () => {
   it('clicking Install runs mint→installMcp and shows a restart prompt (token never shown)', async () => {
     tagAc(AC_INSTALL);
     tagAc(AC_UMBRELLA);
@@ -127,5 +133,38 @@ describe('spec-304 ac-4: install from the app mints + writes via the bridge', ()
     expect(document.body.innerHTML).not.toContain('mxt_minted_secret_999');
     // Success was announced natively (dec-22).
     expect(showNotification).toHaveBeenCalled();
+  });
+});
+
+describe('spec-304 ac-55 / ac-56 (t-56): Claude Desktop is connector-based, not npx', () => {
+  it('Claude Desktop shows a single "Install for my org" button that opens the connector dialog — no installMcp', async () => {
+    tagAc(AC_CONNECTOR_DIALOG);
+    const installMcp = vi.fn(() => ({ ok: true }));
+    installShell({ mcpStatus: () => STATUS_ABSENT, installMcp });
+
+    render(<DesktopMcpSection />);
+    const cdRow = await screen.findByTestId('mcp-client-claudeDesktop');
+    // The npx-era Install/Reinstall/Repair button is gone for Claude Desktop.
+    const button = within(cdRow).getByRole('button', { name: 'Install for my org' });
+    fireEvent.click(button);
+
+    // The connector-instructions dialog opens…
+    expect(await screen.findByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByTestId('connector-url')).toHaveTextContent('/mcp');
+    // …and NO npx/file-write install was attempted for Claude Desktop.
+    expect(installMcp).not.toHaveBeenCalled();
+    expect(mintMcpTokenApi).not.toHaveBeenCalled();
+  });
+
+  it('Claude Desktop reads "MCP connected" from the mcp.connected signal with no local entry (ac-56)', async () => {
+    tagAc(AC_CONNECTOR_STATUS);
+    installShell({ mcpStatus: () => STATUS_ABSENT }); // no local CD entry at all
+    fetchJourneyStateApi.mockResolvedValue({ milestones: { mcpConnected: true } });
+
+    render(<DesktopMcpSection />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId('mcp-status-claudeDesktop')).toHaveTextContent('MCP connected'),
+    );
   });
 });

--- a/packages/ui/src/components/DesktopMcpSection.tsx
+++ b/packages/ui/src/components/DesktopMcpSection.tsx
@@ -92,8 +92,8 @@ export function DesktopMcpSection() {
       <p className="text-sm mb-6 text-secondary">
         Connect Claude to your Memexes from this app. For Claude Code we mint a token from your
         current login and write it into the client's config (a <code>.bak</code> is saved first) —
-        no terminal, no copy-pasted token. Claude Desktop connects through an account-level
-        connector you add inside Claude. Restart the client afterwards to finish connecting.
+        no terminal, no copy-pasted token. Claude Desktop connects through a connector you add
+        inside Claude. Restart the client afterwards to finish connecting.
       </p>
 
       {phase === 'loading' && <p className="text-sm text-secondary">Checking MCP status…</p>}

--- a/packages/ui/src/components/DesktopMcpSection.tsx
+++ b/packages/ui/src/components/DesktopMcpSection.tsx
@@ -1,114 +1,59 @@
-// spec-304 t-55 (dec-19..22): the in-app "Install Memex MCP" surface for the
-// desktop shell. Open core. This is the canonical install/status/manage UI the
-// native nav-bar pill and tray item open into (dec-19); it renders ONLY inside
-// the Memex desktop shell — a plain browser can't write `~/.claude.json`, so the
-// section is hidden there and Settings → Integrations shows the CLI installer
-// instead.
+// spec-304 t-55/t-56/t-58 (dec-19..23): the in-app "Install Memex MCP" surface
+// for the desktop shell. Open core. This is the canonical install/status/manage
+// UI the native nav-bar pill and tray item open into (dec-19); it renders ONLY
+// inside the Memex desktop shell — a plain browser can't write `~/.claude.json`,
+// so the section is hidden there and Settings → Integrations shows the CLI
+// installer instead.
 //
-// React owns intent + credential (mint from the live session) and the status
-// derivation; Dart owns the OS-capable actions (config write, native toast) via
-// the bridge. The session token is minted in-process and never shown.
+// Two transports per dec-23:
+//  - Claude Code (token): mint from the live session → installMcp bridge writes
+//    the HTTP entry. The session token never leaves the webview.
+//  - Claude Desktop (connector): a single "Install for my org" button opens a
+//    connector-instructions dialog (the app cannot write an account-level
+//    connector — it's guidance, not a file write). The npx mcp-remote path is
+//    GONE from the UI (t-56).
+//
+// The status derivation + native pill push are app-global (useDesktopMcpStatus,
+// issue-24 #1); this section reuses the same hook for its per-client rows and to
+// refresh after an install.
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { useAuth } from './AuthContext';
-import { useUserChangeStream } from '../hooks/useUserChangeStream';
-import { listMcpTokensApi, mintMcpTokenApi } from '../api/mcp';
-import { fetchJourneyStateApi } from '../api/journey';
+import { mintMcpTokenApi } from '../api/mcp';
+import { useDesktopMcpStatus } from '../hooks/useDesktopMcpStatus';
 import {
+  desktopServerBase,
   installMcpBridge,
-  isDesktopShell,
-  mcpStatusBridge,
-  setMcpStatusBridge,
   showNotificationBridge,
   type McpTargetKey,
 } from '../desktop/bridge';
-import {
-  deriveClientStatus,
-  deriveIndicator,
-  MCP_CLIENTS,
-  type ClientStatus,
-  type McpStatusResult,
-} from '../desktop/mcpStatus';
+import type { ClientStatus, McpStatusResult } from '../desktop/mcpStatus';
 import { runInstall } from '../desktop/install';
-
-type Phase = 'idle' | 'loading' | 'ready' | 'error';
-
-interface PerClient {
-  key: keyof McpStatusResult;
-  name: string;
-  status: ClientStatus;
-}
+import { ClaudeConnectorDialog } from './ClaudeConnectorDialog';
 
 const BUTTON_LABEL: Record<ClientStatus['button'], string> = {
   install: 'Install',
   reinstall: 'Reinstall',
   repair: 'Repair',
+  connector: 'Install for my org',
 };
+
+/** The env-derived MCP connector URL the Claude Desktop dialog hands the user. */
+function connectorUrl(): string {
+  const base = desktopServerBase();
+  return base ? `${base}/mcp` : '/mcp';
+}
 
 export function DesktopMcpSection() {
   const { token } = useAuth();
-  const [phase, setPhase] = useState<Phase>('idle');
-  const [clients, setClients] = useState<PerClient[]>([]);
+  const { inShell, phase, clients, error: statusError, refresh } = useDesktopMcpStatus();
   const [busy, setBusy] = useState<keyof McpStatusResult | null>(null);
   const [message, setMessage] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
-  // Debounce: a single failed local probe must not flash an error state (dec-20).
-  const failedProbes = useRef(0);
+  // The Claude Desktop connector-instructions dialog (t-56).
+  const [connectorOpen, setConnectorOpen] = useState(false);
 
-  const inShell = isDesktopShell();
-
-  const refresh = useCallback(async () => {
-    if (!inShell) return;
-    setPhase((p) => (p === 'ready' ? p : 'loading'));
-    try {
-      const [local, tokens, journey] = await Promise.all([
-        mcpStatusBridge(),
-        listMcpTokensApi(token),
-        fetchJourneyStateApi().catch(() => null),
-      ]);
-      if (!local) {
-        // Probe failed — tolerate transient failures before showing an error.
-        failedProbes.current += 1;
-        if (failedProbes.current >= 2 && phase !== 'ready') setPhase('error');
-        return;
-      }
-      failedProbes.current = 0;
-
-      const activePrefixes = new Set(
-        tokens.filter((t) => !t.revokedAt).map((t) => t.prefix),
-      );
-      const connected = journey?.milestones.mcpConnected ?? false;
-
-      const per: PerClient[] = MCP_CLIENTS.map(({ key, name }) => ({
-        key,
-        name,
-        status: deriveClientStatus(local[key], {
-          activeTokenPrefixes: activePrefixes,
-          connected,
-        }),
-      }));
-      setClients(per);
-      setPhase('ready');
-
-      // Push the aggregate indicator to the native pill (dec-21). React owns the
-      // truth; the shell owns the on-open timing + visibility policy.
-      void setMcpStatusBridge(deriveIndicator(per.map((c) => c.status)));
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Could not read MCP status');
-      setPhase('error');
-    }
-  }, [inShell, token, phase]);
-
-  useEffect(() => {
-    void refresh();
-    // Re-derive when the user mints/revokes a token elsewhere.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [inShell, token]);
-
-  // Real-time: a token minted/revoked on another device re-derives status.
-  useUserChangeStream(() => void refresh(), ['mcp_token']);
-
-  const handleAction = useCallback(
+  const handleInstall = useCallback(
     async (target: McpTargetKey, name: string) => {
       setBusy(target);
       setMessage(null);
@@ -139,24 +84,28 @@ export function DesktopMcpSection() {
   if (!inShell) return null;
 
   return (
-    <section id="desktop-mcp" aria-labelledby="desktop-mcp-heading">
+    // scroll-mt keeps the heading off the very top edge when deep-linked (issue-25).
+    <section id="desktop-mcp" aria-labelledby="desktop-mcp-heading" className="scroll-mt-6">
       <h2 id="desktop-mcp-heading" className="text-xl font-semibold mb-2 text-heading">
         Install Memex MCP on this device
       </h2>
       <p className="text-sm mb-6 text-secondary">
-        Connect Claude to your Memexes from this app — no terminal, no copy-pasted token.
-        We mint a token from your current login and write it into the client's config
-        (a <code>.bak</code> is saved first). Restart the client afterwards to finish connecting.
+        Connect Claude to your Memexes from this app. For Claude Code we mint a token from your
+        current login and write it into the client's config (a <code>.bak</code> is saved first) —
+        no terminal, no copy-pasted token. Claude Desktop connects through an account-level
+        connector you add inside Claude. Restart the client afterwards to finish connecting.
       </p>
 
       {phase === 'loading' && <p className="text-sm text-secondary">Checking MCP status…</p>}
-      {error && <p className="text-sm text-error mb-4" role="alert">{error}</p>}
+      {(error ?? statusError) && (
+        <p className="text-sm text-error mb-4" role="alert">{error ?? statusError}</p>
+      )}
       {message && (
         <p className="text-sm text-status-success-text mb-4" role="status">{message}</p>
       )}
 
       <div className="border rounded-lg overflow-hidden bg-overlay border-edge">
-        {clients.map(({ key, name, status }) => (
+        {clients.map(({ key, name, transport, status }) => (
           <div
             key={key}
             data-testid={`mcp-client-${key}`}
@@ -164,23 +113,38 @@ export function DesktopMcpSection() {
           >
             <div>
               <div className="text-sm text-primary">{name}</div>
-              <div
-                className="text-xs text-secondary"
-                data-testid={`mcp-status-${key}`}
-              >
+              <div className="text-xs text-secondary" data-testid={`mcp-status-${key}`}>
                 {status.label}
               </div>
             </div>
-            <button
-              onClick={() => handleAction(key as McpTargetKey, name)}
-              disabled={busy !== null}
-              className="text-xs px-3 py-1.5 rounded-sm bg-accent text-on-accent hover:opacity-90 disabled:opacity-50"
-            >
-              {busy === key ? 'Installing MCP…' : BUTTON_LABEL[status.button]}
-            </button>
+            {transport === 'connector' ? (
+              // Claude Desktop: open the connector-instructions dialog. No token
+              // logic, no in-app file write — the app can't add a connector (dec-23).
+              <button
+                onClick={() => setConnectorOpen(true)}
+                className="text-xs px-3 py-1.5 rounded-sm bg-accent text-on-accent hover:opacity-90"
+              >
+                {BUTTON_LABEL.connector}
+              </button>
+            ) : (
+              <button
+                onClick={() => handleInstall(key as McpTargetKey, name)}
+                disabled={busy !== null}
+                className="text-xs px-3 py-1.5 rounded-sm bg-accent text-on-accent hover:opacity-90 disabled:opacity-50"
+              >
+                {busy === key ? 'Installing MCP…' : BUTTON_LABEL[status.button]}
+              </button>
+            )}
           </div>
         ))}
       </div>
+
+      {connectorOpen && (
+        <ClaudeConnectorDialog
+          connectorUrl={connectorUrl()}
+          onClose={() => setConnectorOpen(false)}
+        />
+      )}
     </section>
   );
 }

--- a/packages/ui/src/components/DesktopMcpStatusSync.test.tsx
+++ b/packages/ui/src/components/DesktopMcpStatusSync.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { DesktopMcpStatusSync } from './DesktopMcpStatusSync';
+
+// issue-24 #1 → t-58: the native MCP pill must be APP-GLOBAL. The status
+// derivation + setMcpStatus push must run without DesktopMcpSection (the
+// Settings page) being mounted at all.
+const AC_GLOBAL =
+  'mindset-prod/memex-building-itself/specs/spec-304/acs/ac-53';
+
+vi.mock('./AuthContext', () => ({ useAuth: () => ({ token: 'test-token' }) }));
+vi.mock('../hooks/useUserChangeStream', () => ({ useUserChangeStream: () => {} }));
+
+const listMcpTokensApi = vi.fn();
+vi.mock('../api/mcp', () => ({
+  listMcpTokensApi: (...a: unknown[]) => listMcpTokensApi(...a),
+  // mintMcpTokenApi unused here but exported so the module shape matches.
+  mintMcpTokenApi: vi.fn(),
+}));
+
+const fetchJourneyStateApi = vi.fn();
+vi.mock('../api/journey', () => ({
+  fetchJourneyStateApi: (...a: unknown[]) => fetchJourneyStateApi(...a),
+}));
+
+function installShell(handlers: Record<string, (args: unknown) => unknown> = {}) {
+  (window as unknown as { flutter_inappwebview?: unknown }).flutter_inappwebview = {
+    callHandler: (name: string, args: unknown) =>
+      (handlers[name] ?? (() => ({ ok: true })))(args),
+  };
+}
+function removeShell() {
+  delete (window as unknown as { flutter_inappwebview?: unknown }).flutter_inappwebview;
+}
+
+const STATUS = {
+  ok: true,
+  targets: {
+    claudeCode: { installed: true, urlMatches: true, tokenPrefix: 'mxt_active123' },
+    claudeDesktop: { installed: false, urlMatches: false, tokenPrefix: null },
+  },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  listMcpTokensApi.mockResolvedValue([
+    { id: '1', label: 'Memex Desktop', prefix: 'mxt_active123', lastUsedAt: null, revokedAt: null },
+  ]);
+  fetchJourneyStateApi.mockResolvedValue({ milestones: { mcpConnected: false } });
+});
+afterEach(() => removeShell());
+
+describe('spec-304 ac-53 (issue-24 #1): the native MCP pill is app-global, not page-scoped', () => {
+  it('derives status and PUSHES it to the native pill without the Settings section mounted', async () => {
+    tagAc(AC_GLOBAL);
+    const setMcpStatus = vi.fn(() => ({ ok: true }));
+    installShell({ mcpStatus: () => STATUS, setMcpStatus });
+
+    // Only the app-global sync is mounted — NOT DesktopMcpSection.
+    render(<DesktopMcpStatusSync />);
+
+    await waitFor(() => expect(setMcpStatus).toHaveBeenCalled());
+    // Claude Code is installed + active token, no handshake → the pill reads the
+    // honest "MCP ready" (transient), proving the real derivation ran here.
+    const pushed = setMcpStatus.mock.calls.at(-1)?.[0] as {
+      kind: string;
+      label: string;
+    };
+    expect(pushed.label).toMatch(/^MCP/);
+    expect(pushed.kind).toBe('ready');
+  });
+
+  it('pushes nothing in a plain browser (no shell to drive a pill)', async () => {
+    tagAc(AC_GLOBAL);
+    removeShell();
+    // No bridge present → isDesktopShell() false → the hook is a no-op. Rendering
+    // must not throw and must not attempt any native call.
+    const { container } = render(<DesktopMcpStatusSync />);
+    expect(container).toBeEmptyDOMElement();
+    expect(listMcpTokensApi).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/components/DesktopMcpStatusSync.tsx
+++ b/packages/ui/src/components/DesktopMcpStatusSync.tsx
@@ -1,0 +1,27 @@
+// spec-304 t-58 (issue-24 #1): the app-global mount point for the desktop MCP
+// status derivation. Renders nothing — it exists so the probe → derive → push
+// (useDesktopMcpStatus) runs on EVERY route, keeping the native nav-bar pill
+// populated regardless of which page is open (the page-scoped DesktopMcpSection
+// only ran it on Settings → Integrations). Mounted once near the router root
+// (App.tsx PostLoginRouter).
+//
+// Gated on isDesktopShell() BEFORE any hook runs: in a plain browser (the 99%
+// case, and every web test) this returns null without subscribing to the
+// user-change SSE stream or touching auth context — the desktop status machinery
+// has no reason to run there. isDesktopShell() is stable for the app's lifetime
+// (the bridge is present or it isn't), so the conditional mount is hook-safe.
+
+import { isDesktopShell } from '../desktop/bridge';
+import { useDesktopMcpStatus } from '../hooks/useDesktopMcpStatus';
+
+export function DesktopMcpStatusSync() {
+  if (!isDesktopShell()) return null;
+  return <DesktopMcpStatusActive />;
+}
+
+function DesktopMcpStatusActive() {
+  // The hook probes, derives, and pushes the indicator to the native pill; we
+  // only need it mounted, not its return value.
+  useDesktopMcpStatus();
+  return null;
+}

--- a/packages/ui/src/desktop/mcpStatus.test.ts
+++ b/packages/ui/src/desktop/mcpStatus.test.ts
@@ -2,7 +2,9 @@ import { describe, it, expect } from 'vitest';
 import { tagAc } from '@memex-ai-ac/vitest';
 import {
   deriveClientStatus,
+  deriveConnectorStatus,
   deriveIndicator,
+  type ActiveToken,
   type ClientStatus,
   type McpTargetStatus,
 } from './mcpStatus';
@@ -10,8 +12,22 @@ import {
 const AC_DERIVE = 'mindset-prod/memex-building-itself/specs/spec-304/acs/ac-48';
 const AC_INDICATOR =
   'mindset-prod/memex-building-itself/specs/spec-304/acs/ac-49';
+// issue-23 → t-57: "connected" must be PER-TOKEN (lastUsedAt), not the
+// user-scoped journey milestone.
+const AC_PER_TOKEN =
+  'mindset-prod/memex-building-itself/specs/spec-304/acs/ac-52';
+// t-56 → dec-23: Claude Desktop connector status derives from the mcp.connected
+// signal, independent of local config.
+const AC_CONNECTOR =
+  'mindset-prod/memex-building-itself/specs/spec-304/acs/ac-56';
 
-const ACTIVE = new Set(['mxt_active1234']);
+// An active token whose matching local entry HAS handshaked (lastUsedAt set).
+const CONNECTED_TOKEN: ActiveToken = {
+  prefix: 'mxt_active1234',
+  lastUsedAt: '2026-06-28T10:00:00.000Z',
+};
+// An active token freshly minted — authorized but never used against /mcp yet.
+const FRESH_TOKEN: ActiveToken = { prefix: 'mxt_active1234', lastUsedAt: null };
 
 function local(over: Partial<McpTargetStatus> = {}): McpTargetStatus {
   return {
@@ -22,16 +38,15 @@ function local(over: Partial<McpTargetStatus> = {}): McpTargetStatus {
   };
 }
 
-describe('spec-304 ac-48: per-client status derivation (local ⨝ active tokens ⨝ connection)', () => {
+describe('spec-304 ac-48: per-client status derivation (local ⨝ active tokens ⨝ handshake)', () => {
   it('absent config → Not installed / Install (never an error)', () => {
     tagAc(AC_DERIVE);
     expect(
-      deriveClientStatus(undefined, { activeTokenPrefixes: ACTIVE, connected: false }),
+      deriveClientStatus(undefined, { activeTokens: [CONNECTED_TOKEN] }),
     ).toEqual({ kind: 'not_installed', label: 'Not installed', button: 'install' });
     expect(
       deriveClientStatus(local({ installed: false }), {
-        activeTokenPrefixes: ACTIVE,
-        connected: false,
+        activeTokens: [CONNECTED_TOKEN],
       }).kind,
     ).toBe('not_installed');
   });
@@ -39,14 +54,14 @@ describe('spec-304 ac-48: per-client status derivation (local ⨝ active tokens 
   it('installed + active token + no handshake → MCP ready / Reinstall', () => {
     tagAc(AC_DERIVE);
     expect(
-      deriveClientStatus(local(), { activeTokenPrefixes: ACTIVE, connected: false }),
+      deriveClientStatus(local(), { activeTokens: [FRESH_TOKEN] }),
     ).toEqual({ kind: 'ready', label: 'MCP ready', button: 'reinstall' });
   });
 
   it('installed + active token + handshake observed → MCP connected', () => {
     tagAc(AC_DERIVE);
     expect(
-      deriveClientStatus(local(), { activeTokenPrefixes: ACTIVE, connected: true }),
+      deriveClientStatus(local(), { activeTokens: [CONNECTED_TOKEN] }),
     ).toEqual({ kind: 'connected', label: 'MCP connected', button: 'reinstall' });
   });
 
@@ -54,8 +69,8 @@ describe('spec-304 ac-48: per-client status derivation (local ⨝ active tokens 
     tagAc(AC_DERIVE);
     expect(
       deriveClientStatus(local({ tokenPrefix: 'mxt_revoked999' }), {
-        activeTokenPrefixes: ACTIVE,
-        connected: true, // even a stale handshake must not mask a dead token
+        // even a used token elsewhere must not mask THIS entry's dead token
+        activeTokens: [CONNECTED_TOKEN],
       }),
     ).toEqual({ kind: 'repair', label: 'Token invalid', button: 'repair' });
   });
@@ -64,8 +79,7 @@ describe('spec-304 ac-48: per-client status derivation (local ⨝ active tokens 
     tagAc(AC_DERIVE);
     expect(
       deriveClientStatus(local({ tokenPrefix: null }), {
-        activeTokenPrefixes: ACTIVE,
-        connected: false,
+        activeTokens: [CONNECTED_TOKEN],
       }).kind,
     ).toBe('repair');
   });
@@ -74,10 +88,79 @@ describe('spec-304 ac-48: per-client status derivation (local ⨝ active tokens 
     tagAc(AC_DERIVE);
     expect(
       deriveClientStatus(local({ urlMatches: false }), {
-        activeTokenPrefixes: ACTIVE,
-        connected: false,
+        activeTokens: [CONNECTED_TOKEN],
       }),
     ).toEqual({ kind: 'reinstall', label: 'Points elsewhere', button: 'reinstall' });
+  });
+});
+
+describe('spec-304 ac-52 (issue-23): "connected" is PER-TOKEN, never the user-scoped milestone', () => {
+  it('a freshly-installed token (lastUsedAt null) reads "MCP ready" — NOT connected — even when the user has connected elsewhere', () => {
+    tagAc(AC_PER_TOKEN);
+    // The bug: a prior MCP connection set the user-scoped mcp.connected milestone
+    // true, so the just-reinstalled client falsely showed "MCP connected" before
+    // its OWN token handshaked. The fix joins on the token's lastUsedAt: a fresh
+    // mint is null until THAT token hits /mcp.
+    const status = deriveClientStatus(local(), { activeTokens: [FRESH_TOKEN] });
+    expect(status.kind).toBe('ready');
+    expect(status.label).toBe('MCP ready');
+    expect(status.label).not.toContain('connected');
+  });
+
+  it('the SAME token flips to "MCP connected" only once its lastUsedAt is non-null', () => {
+    tagAc(AC_PER_TOKEN);
+    expect(deriveClientStatus(local(), { activeTokens: [FRESH_TOKEN] }).kind).toBe(
+      'ready',
+    );
+    expect(
+      deriveClientStatus(local(), { activeTokens: [CONNECTED_TOKEN] }).kind,
+    ).toBe('connected');
+  });
+
+  it('a handshake on a DIFFERENT token does not mark this install connected', () => {
+    tagAc(AC_PER_TOKEN);
+    // This install's entry carries mxt_active1234 (fresh); another active token
+    // has been used. The other token must not paint this entry "connected".
+    const otherUsed: ActiveToken = {
+      prefix: 'mxt_other99999',
+      lastUsedAt: '2026-06-28T09:00:00.000Z',
+    };
+    const status = deriveClientStatus(local(), {
+      activeTokens: [FRESH_TOKEN, otherUsed],
+    });
+    expect(status.kind).toBe('ready');
+  });
+});
+
+describe('spec-304 ac-56 (t-56): Claude Desktop connector status from the mcp.connected signal', () => {
+  it('connected signal present → "MCP connected" (independent of any local config)', () => {
+    tagAc(AC_CONNECTOR);
+    expect(deriveConnectorStatus({ connected: true })).toEqual({
+      kind: 'connected',
+      label: 'MCP connected',
+      button: 'connector',
+    });
+  });
+
+  it('no connection yet → "Not connected", connector instructions still offered', () => {
+    tagAc(AC_CONNECTOR);
+    expect(deriveConnectorStatus({ connected: false })).toEqual({
+      kind: 'not_installed',
+      label: 'Not connected',
+      button: 'connector',
+    });
+  });
+
+  it('a connected connector contributes "connected" to the aggregate indicator', () => {
+    tagAc(AC_CONNECTOR);
+    // CD connected + CC not installed → the pill reads connected (CD counts).
+    const cd = deriveConnectorStatus({ connected: true });
+    const cc: ClientStatus = {
+      kind: 'not_installed',
+      label: 'Not installed',
+      button: 'install',
+    };
+    expect(deriveIndicator([cc, cd]).kind).toBe('connected');
   });
 });
 

--- a/packages/ui/src/desktop/mcpStatus.ts
+++ b/packages/ui/src/desktop/mcpStatus.ts
@@ -1,10 +1,21 @@
 // spec-304 t-55 (dec-20, dec-21 → ac-48, ac-49): the PURE status derivation for
 // the in-app MCP install surface. The desktop shell's `mcpStatus` bridge reports
 // each Claude client's LOCAL config (installed / urlMatches / tokenPrefix); the
-// server reports the user's ACTIVE tokens (by non-secret prefix) and the MCP
-// connection signal (the same `mcp.connected` milestone the onboarding journey
-// reads). This module joins those three truths client-side — no I/O, no React —
-// so the classification is unit-testable in isolation.
+// server reports the user's ACTIVE tokens (by non-secret prefix, each carrying a
+// `lastUsedAt`) and the MCP connection signal (the same `mcp.connected` milestone
+// the onboarding journey reads). This module joins those truths client-side — no
+// I/O, no React — so the classification is unit-testable in isolation.
+//
+// Two transports, two derivations (dec-23):
+//  - Claude Code is TOKEN-based (an mxt_ HTTP entry in the local config). Its
+//    "connected" is PER-TOKEN: the active token matching the local entry's prefix
+//    has a non-null `lastUsedAt`, i.e. THAT token has actually hit /mcp. A fresh
+//    mint is null until the client reconnects, so "connected" never appears before
+//    a real handshake for this install (issue-23 / ac-52).
+//  - Claude Desktop is CONNECTOR-based (an account-level Custom Connector added in
+//    Claude, NOT in claude_desktop_config.json). It has no local entry to read, so
+//    its status derives purely from the user-scoped `mcp.connected` signal
+//    (issue-22 superseded; t-56 / ac-56).
 
 /** One client's local-config truth, as returned by the Dart `mcpStatus` bridge. */
 export interface McpTargetStatus {
@@ -20,6 +31,17 @@ export interface McpStatusResult {
   claudeDesktop: McpTargetStatus;
 }
 
+/**
+ * One of the user's active MCP tokens, as surfaced by `listMcpTokensApi` — the
+ * non-secret `prefix` joins to a local config entry, and `lastUsedAt` is the
+ * PER-TOKEN handshake signal: null until that token first hits /mcp, non-null
+ * thereafter (issue-23 / ac-52).
+ */
+export interface ActiveToken {
+  prefix: string;
+  lastUsedAt: string | null;
+}
+
 export type ClientStatusKind =
   | 'not_installed'
   | 'ready' // installed + authorized, no handshake yet
@@ -27,7 +49,9 @@ export type ClientStatusKind =
   | 'repair' // installed but the token is revoked / unknown
   | 'reinstall'; // installed but pointing at a different server
 
-export type ClientButton = 'install' | 'reinstall' | 'repair';
+export type ClientButton = 'install' | 'reinstall' | 'repair' | 'connector';
+
+export type ClientTransport = 'token' | 'connector';
 
 export interface ClientStatus {
   kind: ClientStatusKind;
@@ -37,14 +61,21 @@ export interface ClientStatus {
 }
 
 /**
- * Classify ONE client by joining its local config with the user's active token
- * prefixes and the connection signal. A never-installed client is never an error
- * (dec-20). Precedence once installed: wrong-server → revoked/unknown-token →
- * connected → ready.
+ * Classify a TOKEN-based client (Claude Code) by joining its local config with
+ * the user's active tokens. A never-installed client is never an error (dec-20).
+ * Precedence once installed: wrong-server → revoked/unknown-token → connected →
+ * ready.
+ *
+ * "connected" is PER-TOKEN (issue-23 / ac-52): the active token matching the
+ * local entry's prefix must carry a non-null `lastUsedAt` — proof that THIS
+ * install's token has actually handshaked against /mcp. A freshly-minted token
+ * is `lastUsedAt: null`, so a fresh (re)install reads "MCP ready" until Claude
+ * reconnects — the user-scoped milestone can no longer paint it "connected"
+ * prematurely.
  */
 export function deriveClientStatus(
   local: McpTargetStatus | undefined,
-  opts: { activeTokenPrefixes: ReadonlySet<string>; connected: boolean },
+  opts: { activeTokens: ReadonlyArray<ActiveToken> },
 ): ClientStatus {
   if (!local || !local.installed) {
     return { kind: 'not_installed', label: 'Not installed', button: 'install' };
@@ -52,15 +83,34 @@ export function deriveClientStatus(
   if (!local.urlMatches) {
     return { kind: 'reinstall', label: 'Points elsewhere', button: 'reinstall' };
   }
-  const authorized =
-    local.tokenPrefix != null && opts.activeTokenPrefixes.has(local.tokenPrefix);
-  if (!authorized) {
+  const match =
+    local.tokenPrefix != null
+      ? opts.activeTokens.find((t) => t.prefix === local.tokenPrefix)
+      : undefined;
+  if (!match) {
     return { kind: 'repair', label: 'Token invalid', button: 'repair' };
   }
-  if (opts.connected) {
+  if (match.lastUsedAt != null) {
     return { kind: 'connected', label: 'MCP connected', button: 'reinstall' };
   }
   return { kind: 'ready', label: 'MCP ready', button: 'reinstall' };
+}
+
+/**
+ * Classify a CONNECTOR-based client (Claude Desktop, dec-23 / t-56). The
+ * account-level Custom Connector is NOT in claude_desktop_config.json, so there
+ * is no local entry and no per-token signal to read — its only honest truth is
+ * the user-scoped `mcp.connected` usage signal. When a handshake has been seen
+ * the client reads "MCP connected"; otherwise it is "Not connected" and the
+ * "Install for my org" connector instructions stay available (never an alarm).
+ * The button always opens the instructions dialog (the app cannot write a
+ * connector), so it is offered in both states.
+ */
+export function deriveConnectorStatus(opts: { connected: boolean }): ClientStatus {
+  if (opts.connected) {
+    return { kind: 'connected', label: 'MCP connected', button: 'connector' };
+  }
+  return { kind: 'not_installed', label: 'Not connected', button: 'connector' };
 }
 
 export type IndicatorKind = 'connected' | 'ready' | 'repair' | 'install';
@@ -101,11 +151,16 @@ export interface Indicator {
   visibility: IndicatorVisibility;
 }
 
-/** The two clients, in display order, with their human names + bridge keys. */
+/**
+ * The two clients, in display order, with their human names, bridge keys, and
+ * transport (dec-23): Claude Code installs a local HTTP token; Claude Desktop
+ * connects via an account-level Custom Connector (instructions only).
+ */
 export const MCP_CLIENTS: ReadonlyArray<{
   key: keyof McpStatusResult;
   name: string;
+  transport: ClientTransport;
 }> = [
-  { key: 'claudeCode', name: 'Claude Code' },
-  { key: 'claudeDesktop', name: 'Claude Desktop' },
+  { key: 'claudeCode', name: 'Claude Code', transport: 'token' },
+  { key: 'claudeDesktop', name: 'Claude Desktop', transport: 'connector' },
 ];

--- a/packages/ui/src/hooks/useDesktopMcpStatus.ts
+++ b/packages/ui/src/hooks/useDesktopMcpStatus.ts
@@ -1,0 +1,133 @@
+// spec-304 t-58 (issue-24, dec-19/dec-20/dec-21): the APP-GLOBAL MCP status
+// derivation for the desktop shell.
+//
+// The native nav-bar pill is meant to be ubiquitous (dec-19's whole rationale).
+// Originally the derive + `setMcpStatus` push lived inside DesktopMcpSection,
+// which only mounts on Settings → Integrations — so the pill stayed empty on
+// every other page (issue-24 #1). This hook lifts the probe → derive → push out
+// of the page so it runs on EVERY route: mount it once app-globally (see
+// <DesktopMcpStatusSync/>) and the pill reflects status regardless of which page
+// is open. DesktopMcpSection reuses the SAME hook for its per-client rows.
+//
+// It joins three truths client-side (dec-20): the local Claude config (the
+// read-only mcpStatus bridge), the user's active tokens (listMcpTokensApi, with
+// per-token lastUsedAt — ac-52), and the user-scoped mcp.connected signal (used
+// for the Claude Desktop connector, dec-23). No-op outside the desktop shell.
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useAuth } from '../components/AuthContext';
+import { useUserChangeStream } from './useUserChangeStream';
+import { listMcpTokensApi } from '../api/mcp';
+import { fetchJourneyStateApi } from '../api/journey';
+import {
+  isDesktopShell,
+  mcpStatusBridge,
+  setMcpStatusBridge,
+} from '../desktop/bridge';
+import {
+  deriveClientStatus,
+  deriveConnectorStatus,
+  deriveIndicator,
+  MCP_CLIENTS,
+  type ActiveToken,
+  type ClientStatus,
+  type ClientTransport,
+  type McpStatusResult,
+} from '../desktop/mcpStatus';
+
+export type McpPhase = 'idle' | 'loading' | 'ready' | 'error';
+
+export interface DesktopMcpClient {
+  key: keyof McpStatusResult;
+  name: string;
+  transport: ClientTransport;
+  status: ClientStatus;
+}
+
+export interface DesktopMcpStatus {
+  /** Whether we're running inside the Memex desktop shell (vs a plain browser). */
+  inShell: boolean;
+  phase: McpPhase;
+  clients: DesktopMcpClient[];
+  error: string | null;
+  refresh: () => Promise<void>;
+}
+
+/**
+ * Probe + derive + push the desktop MCP status. Safe to mount more than once
+ * (the app-global sync AND the Settings section both call it); each call pushes
+ * the same derived indicator, and the push is idempotent.
+ */
+export function useDesktopMcpStatus(): DesktopMcpStatus {
+  const { token } = useAuth();
+  const inShell = isDesktopShell();
+  const [phase, setPhase] = useState<McpPhase>('idle');
+  const [clients, setClients] = useState<DesktopMcpClient[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  // Debounce: a single failed local probe must not flash an error state (dec-20).
+  const failedProbes = useRef(0);
+  // Read phase in refresh without making it a dependency — keeps refresh stable
+  // so the effect + SSE subscription don't churn (the page-scoped version's
+  // `phase` dep caused re-subscription on every status change).
+  const phaseRef = useRef<McpPhase>('idle');
+  phaseRef.current = phase;
+
+  const refresh = useCallback(async () => {
+    if (!inShell) return;
+    setPhase((p) => (p === 'ready' ? p : 'loading'));
+    try {
+      const [local, tokens, journey] = await Promise.all([
+        mcpStatusBridge(),
+        listMcpTokensApi(token),
+        fetchJourneyStateApi().catch(() => null),
+      ]);
+      if (!local) {
+        // Probe failed — tolerate transient failures before showing an error.
+        failedProbes.current += 1;
+        if (failedProbes.current >= 2 && phaseRef.current !== 'ready') {
+          setPhase('error');
+        }
+        return;
+      }
+      failedProbes.current = 0;
+
+      const activeTokens: ActiveToken[] = tokens
+        .filter((t) => !t.revokedAt)
+        .map((t) => ({ prefix: t.prefix, lastUsedAt: t.lastUsedAt }));
+      // User-scoped MCP connection signal — the Claude Desktop CONNECTOR has no
+      // local entry to read, so its "connected" derives from this (dec-23).
+      const userConnected = journey?.milestones.mcpConnected ?? false;
+
+      const per: DesktopMcpClient[] = MCP_CLIENTS.map(({ key, name, transport }) => ({
+        key,
+        name,
+        transport,
+        status:
+          transport === 'connector'
+            ? deriveConnectorStatus({ connected: userConnected })
+            : deriveClientStatus(local[key], { activeTokens }),
+      }));
+      setClients(per);
+      setError(null);
+      setPhase('ready');
+
+      // Push the aggregate indicator to the native pill (dec-21). React owns the
+      // truth; the shell owns the on-open timing + visibility policy. This is the
+      // push that makes the pill app-global (issue-24 #1).
+      void setMcpStatusBridge(deriveIndicator(per.map((c) => c.status)));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not read MCP status');
+      setPhase('error');
+    }
+  }, [inShell, token]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  // Real-time: a token minted/revoked anywhere re-derives status (and the mint
+  // that an in-app install performs flows back through here to update the pill).
+  useUserChangeStream(() => void refresh(), ['mcp_token']);
+
+  return { inShell, phase, clients, error, refresh };
+}

--- a/packages/ui/src/hooks/useScrollToHash.test.tsx
+++ b/packages/ui/src/hooks/useScrollToHash.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { useScrollToHash } from './useScrollToHash';
+
+// issue-25 → t-59: deep-linking to #desktop-mcp (from the pill / tray) must
+// scroll the section into view on FIRST navigation, not require a second click.
+const AC_SCROLL =
+  'mindset-prod/memex-building-itself/specs/spec-304/acs/ac-54';
+
+function Harness({ withTarget }: { withTarget: boolean }) {
+  useScrollToHash();
+  return withTarget ? <section id="desktop-mcp">MCP</section> : null;
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('spec-304 ac-54 (issue-25): deep-linked hash scrolls into view on first nav', () => {
+  it('scrolls the #hash target into view when the route carries a hash', async () => {
+    tagAc(AC_SCROLL);
+    const scrollIntoView = vi.fn();
+    // jsdom does not implement scrollIntoView — install a spy on the prototype.
+    Element.prototype.scrollIntoView = scrollIntoView;
+
+    render(
+      <MemoryRouter initialEntries={['/settings/integrations#desktop-mcp']}>
+        <Harness withTarget />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(scrollIntoView).toHaveBeenCalled());
+  });
+
+  it('does nothing when there is no hash (no spurious scroll)', async () => {
+    tagAc(AC_SCROLL);
+    const scrollIntoView = vi.fn();
+    Element.prototype.scrollIntoView = scrollIntoView;
+
+    render(
+      <MemoryRouter initialEntries={['/settings/integrations']}>
+        <Harness withTarget />
+      </MemoryRouter>,
+    );
+
+    // Give any retry frames a chance to fire, then assert nothing scrolled.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(scrollIntoView).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/hooks/useScrollToHash.ts
+++ b/packages/ui/src/hooks/useScrollToHash.ts
@@ -1,0 +1,43 @@
+// spec-304 t-59 (issue-25): scroll a deep-linked `#section` into view on first
+// navigation. A single-page app does NOT honour a URL hash the way a full page
+// load does — navigating to `/settings/integrations#desktop-mcp` (e.g. from the
+// native MCP pill or tray item) lands on the page but never scrolls, so the user
+// had to click a second time. This hook scrolls the hash target into view once
+// it exists, retrying across a few frames because the target often mounts AFTER
+// the route change. No-op when there is no hash.
+
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+/** Max animation frames to wait for the hash target to mount before giving up. */
+const MAX_FRAMES = 30;
+
+export function useScrollToHash(): void {
+  const { hash } = useLocation();
+
+  useEffect(() => {
+    if (!hash) return;
+    const id = decodeURIComponent(hash.slice(1));
+    if (!id) return;
+
+    let frame = 0;
+    let tries = 0;
+    const tryScroll = () => {
+      const el = document.getElementById(id);
+      if (el) {
+        // `scroll-margin-top` on the target (set by the section) keeps the
+        // heading off the very top edge.
+        el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        return;
+      }
+      // The target usually mounts just after the route change — retry a few
+      // frames before giving up rather than missing it on first render.
+      if (tries++ < MAX_FRAMES) frame = requestAnimationFrame(tryScroll);
+    };
+    tryScroll();
+
+    return () => {
+      if (frame) cancelAnimationFrame(frame);
+    };
+  }, [hash]);
+}

--- a/packages/ui/src/pages/SettingsIntegrations.tsx
+++ b/packages/ui/src/pages/SettingsIntegrations.tsx
@@ -18,8 +18,13 @@ import { McpTokensSection } from '../components/McpTokensSection';
 import { CliInstallSection } from '../components/CliInstallSection';
 import { GenesisPromptSection } from '../components/GenesisPromptSection';
 import { AcEmitterSection } from '../components/AcEmitterSection';
+import { useScrollToHash } from '../hooks/useScrollToHash';
 
 export function SettingsIntegrations() {
+  // Deep-link from the native MCP pill / tray item lands on
+  // …/settings/integrations#desktop-mcp — scroll that section into view on first
+  // navigation (issue-25), not only after a second click.
+  useScrollToHash();
   // AppShell's <main> is `overflow-hidden`, so each page owns its own scroll
   // container (same pattern as Standard.tsx).
   return (


### PR DESCRIPTION
## What & why

Closes the remaining **spec-304** (Memex desktop app) build work per **dec-23** — the React/web half. Pairs with **memex-clients** PR (the Dart pill-placement half).

### t-56 — Claude Desktop "Install for my org" connector dialog (ac-55, ac-56)
- New `ClaudeConnectorDialog`: env-derived connector URL (`memex.ai/mcp` / `int.memex.ai/mcp`), copy-to-clipboard, step-by-step *Add custom connector* instructions, Team/Enterprise Owner-only admin note, and honest-CTA copy [per std-34] — it says plainly the connector is set up **inside Claude** (the app can't write one).
- **Removed the npx `mcp-remote` Claude Desktop path from the UI** (dec-23 / issue-22 superseded). The Dart stdio branch stays in the bridge per dec-23; the UI no longer drives an npx install. **Claude Code's HTTP-token install is unchanged.**
- CD status now derives from the `mcp.connected` signal **independent of `claude_desktop_config.json`** (a connector isn't in local config).
- **Deep-link/prefill investigation:** Claude Desktop exposes no documented URL scheme to open *Add custom connector* prefilled, so the dialog uses the graceful copy-URL + manual-steps fallback.

### issue-23 — "MCP connected" is now per-token (ac-52)
`deriveClientStatus` joins on the active token's `lastUsedAt` (a fresh mint is `null` until it handshakes), so a reinstall no longer shows "connected" off the user-scoped milestone before its own handshake.

### issue-24 — the native pill is app-global (ac-53, React half)
Lifted the derive+push into `useDesktopMcpStatus`, mounted once via `<DesktopMcpStatusSync/>` in `PostLoginRouter` so the pill is driven on **every route** (was Settings-only). Gated on `isDesktopShell()` so the desktop machinery never runs for browser users. (Dart chrome-placement half is in the memex-clients PR.)

### issue-25 — deep-link scroll (ac-54)
`useScrollToHash` scrolls `#desktop-mcp` into view on first navigation (SPA hash); `scroll-mt` anchor padding on the section.

## Testing
- vitest **red→green** for ac-52 / ac-53 / ac-54 (reproduced the bug, then fixed); green for ac-55 / ac-56. All tagged → **ac-52..56 verified on the prod board**.
- Full `@memex/ui` unit suite, `tsc -b`, `biome check` — clean.
- e2e: the in-app install journey (journey-45) covers the unchanged Claude Code flow; the CD connector dialog is covered by component tests. `make e2e-cold` runs in CI [per std-28].

## Out of scope (deferred)
- issue-26 (bundled "Install for myself" stdio↔HTTP bridge) — its own child spec.
- t-29 / t-30 / issue-21 — signed-build runtime sign-offs (ac-1/ac-2/ac-3/ac-11), manual at verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
