### PR TITLE
feat(spec-304): per-client MCP pill notification toggle + connector stops asserting "connected" (t-60)

### DIFF
--- a/packages/ui/src/components/DesktopMcpSection.test.tsx
+++ b/packages/ui/src/components/DesktopMcpSection.test.tsx
@@ -6,14 +6,12 @@ import { DesktopMcpSection } from './DesktopMcpSection';
 const AC_UMBRELLA = 'mindset-prod/memex-building-itself/specs/spec-304/acs/ac-45';
 const AC_INSTALL = 'mindset-prod/memex-building-itself/specs/spec-304/acs/ac-4';
 const AC_REACH = 'mindset-prod/memex-building-itself/specs/spec-304/acs/ac-50';
-// t-56: Claude Desktop is connector-based — single "Install for my org" button
-// opening the instructions dialog (no npx install), and connected-via-signal.
-const AC_CONNECTOR_DIALOG =
-  'mindset-prod/memex-building-itself/specs/spec-304/acs/ac-55';
-const AC_CONNECTOR_STATUS =
-  'mindset-prod/memex-building-itself/specs/spec-304/acs/ac-56';
+// dec-24: connector is a neutral setup row (never "connected"); per-client pill
+// notification toggle.
+const AC_CONNECTOR = 'mindset-prod/memex-building-itself/specs/spec-304/acs/ac-56';
+const AC_DIALOG = 'mindset-prod/memex-building-itself/specs/spec-304/acs/ac-55';
+const AC_TOGGLE = 'mindset-prod/memex-building-itself/specs/spec-304/acs/ac-57';
 
-// ── Mocks ────────────────────────────────────────────────────────────────
 vi.mock('./AuthContext', () => ({ useAuth: () => ({ token: 'test-token' }) }));
 vi.mock('../hooks/useUserChangeStream', () => ({ useUserChangeStream: () => {} }));
 
@@ -24,18 +22,14 @@ vi.mock('../api/mcp', () => ({
   mintMcpTokenApi: (...a: unknown[]) => mintMcpTokenApi(...a),
 }));
 
-const fetchJourneyStateApi = vi.fn();
-vi.mock('../api/journey', () => ({
-  fetchJourneyStateApi: (...a: unknown[]) => fetchJourneyStateApi(...a),
-}));
-
-// The Flutter bridge: present = desktop shell. We drive callHandler per name.
-function installShell(
-  handlers: Record<string, (args: unknown) => unknown> = {},
-) {
+// Record every setMcpStatus push (both real states and the {kind:'none'} hide).
+let mcpPushes: Array<{ kind?: string }> = [];
+function installShell(handlers: Record<string, (args: unknown) => unknown> = {}) {
   (window as unknown as { flutter_inappwebview?: unknown }).flutter_inappwebview = {
-    callHandler: (name: string, args: unknown) =>
-      (handlers[name] ?? (() => ({ ok: true })))(args),
+    callHandler: (name: string, args: unknown) => {
+      if (name === 'setMcpStatus') mcpPushes.push(args as { kind?: string });
+      return (handlers[name] ?? (() => ({ ok: true })))(args);
+    },
   };
 }
 function removeShell() {
@@ -49,16 +43,25 @@ const STATUS_ABSENT = {
     claudeDesktop: { installed: false, urlMatches: false, tokenPrefix: null },
   },
 };
+// Claude Code installed + active token, no handshake → "MCP ready" (drives pill).
+const STATUS_CC_READY = {
+  ok: true,
+  targets: {
+    claudeCode: { installed: true, urlMatches: true, tokenPrefix: 'mxt_active123' },
+    claudeDesktop: { installed: false, urlMatches: false, tokenPrefix: null },
+  },
+};
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mcpPushes = [];
+  localStorage.clear(); // pill-notification prefs persist per-device — reset between tests
   listMcpTokensApi.mockResolvedValue([]);
   mintMcpTokenApi.mockResolvedValue({ token: 'mxt_minted_secret_999', prefix: 'mxt_minted9' });
-  fetchJourneyStateApi.mockResolvedValue({ milestones: { mcpConnected: false } });
 });
 afterEach(() => removeShell());
 
-describe('spec-304 ac-45 / ac-50: the in-app MCP surface in Settings → Integrations', () => {
+describe('spec-304 ac-45 / ac-50: the in-app MCP surface', () => {
   it('renders nothing in a plain browser (no shell = cannot write config)', () => {
     tagAc(AC_REACH);
     removeShell();
@@ -66,7 +69,7 @@ describe('spec-304 ac-45 / ac-50: the in-app MCP surface in Settings → Integra
     expect(container).toBeEmptyDOMElement();
   });
 
-  it('inside the shell it always shows the canonical install surface with both clients (ac-50)', async () => {
+  it('inside the shell it shows both client rows (ac-50)', async () => {
     tagAc(AC_REACH);
     tagAc(AC_UMBRELLA);
     installShell({ mcpStatus: () => STATUS_ABSENT });
@@ -79,44 +82,26 @@ describe('spec-304 ac-45 / ac-50: the in-app MCP surface in Settings → Integra
     expect(screen.getByTestId('mcp-client-claudeDesktop')).toBeInTheDocument();
   });
 
-  it('Claude Code connected reads from the per-token handshake (lastUsedAt), not the user signal', async () => {
+  it('Claude Code connected reads from the per-token handshake (lastUsedAt)', async () => {
     tagAc(AC_UMBRELLA);
-    installShell({
-      mcpStatus: () => ({
-        ok: true,
-        targets: {
-          claudeCode: { installed: true, urlMatches: true, tokenPrefix: 'mxt_active123' },
-          claudeDesktop: { installed: false, urlMatches: false, tokenPrefix: null },
-        },
-      }),
-    });
+    installShell({ mcpStatus: () => STATUS_CC_READY });
     listMcpTokensApi.mockResolvedValue([
       { id: '1', label: 'Memex Desktop', prefix: 'mxt_active123', lastUsedAt: '2026-06-28T10:00:00Z', revokedAt: null },
     ]);
-    // user-scoped signal is false — CC connected must come from the token only.
-    fetchJourneyStateApi.mockResolvedValue({ milestones: { mcpConnected: false } });
-
     render(<DesktopMcpSection />);
-
     await waitFor(() =>
       expect(screen.getByTestId('mcp-status-claudeCode')).toHaveTextContent('MCP connected'),
     );
   });
 });
 
-describe('spec-304 ac-4: Claude Code install from the app mints + writes via the bridge', () => {
+describe('spec-304 ac-4: Claude Code install mints + writes via the bridge', () => {
   it('clicking Install runs mint→installMcp and shows a restart prompt (token never shown)', async () => {
     tagAc(AC_INSTALL);
     tagAc(AC_UMBRELLA);
     const installMcp = vi.fn(() => ({ ok: true, name: 'Claude Code', path: '/p', backupPath: '/p.bak' }));
     const showNotification = vi.fn(() => ({ ok: true }));
-    const setMcpStatus = vi.fn(() => undefined);
-    installShell({
-      mcpStatus: () => STATUS_ABSENT,
-      installMcp,
-      showNotification,
-      setMcpStatus,
-    });
+    installShell({ mcpStatus: () => STATUS_ABSENT, installMcp, showNotification });
 
     render(<DesktopMcpSection />);
     const row = await screen.findByTestId('mcp-client-claudeCode');
@@ -125,46 +110,80 @@ describe('spec-304 ac-4: Claude Code install from the app mints + writes via the
     await waitFor(() =>
       expect(screen.getByRole('status')).toHaveTextContent(/Restart Claude Code/),
     );
-    // Minted a token from the session and handed it to the bridge — never to the DOM.
     expect(mintMcpTokenApi).toHaveBeenCalledWith('Memex Desktop', 'test-token');
     expect(installMcp).toHaveBeenCalledWith(
       expect.objectContaining({ token: 'mxt_minted_secret_999', target: 'claudeCode' }),
     );
     expect(document.body.innerHTML).not.toContain('mxt_minted_secret_999');
-    // Success was announced natively (dec-22).
     expect(showNotification).toHaveBeenCalled();
   });
 });
 
-describe('spec-304 ac-55 / ac-56 (t-56): Claude Desktop is connector-based, not npx', () => {
-  it('Claude Desktop shows a single "Install for my org" button that opens the connector dialog — no installMcp', async () => {
-    tagAc(AC_CONNECTOR_DIALOG);
+describe('spec-304 ac-55 / ac-56 (dec-24): Claude Desktop is a connector setup row, never "connected"', () => {
+  it('the Org Connector row shows a neutral "Set up in Claude" status — never "MCP connected"', async () => {
+    tagAc(AC_CONNECTOR);
+    installShell({ mcpStatus: () => STATUS_ABSENT });
+    render(<DesktopMcpSection />);
+
+    const cdRow = await screen.findByTestId('mcp-client-claudeDesktop');
+    await waitFor(() =>
+      expect(screen.getByTestId('mcp-status-claudeDesktop')).toHaveTextContent('Set up in Claude'),
+    );
+    expect(cdRow).not.toHaveTextContent(/MCP connected/i);
+    // It's labelled as the Org Connector and carries no notification toggle.
+    expect(cdRow).toHaveTextContent('Org Connector');
+    expect(within(cdRow).queryByRole('checkbox')).toBeNull();
+  });
+
+  it('"Install for my org" opens the connector dialog — no installMcp / mint', async () => {
+    tagAc(AC_DIALOG);
     const installMcp = vi.fn(() => ({ ok: true }));
     installShell({ mcpStatus: () => STATUS_ABSENT, installMcp });
 
     render(<DesktopMcpSection />);
     const cdRow = await screen.findByTestId('mcp-client-claudeDesktop');
-    // The npx-era Install/Reinstall/Repair button is gone for Claude Desktop.
-    const button = within(cdRow).getByRole('button', { name: 'Install for my org' });
-    fireEvent.click(button);
+    fireEvent.click(within(cdRow).getByRole('button', { name: 'Install for my org' }));
 
-    // The connector-instructions dialog opens…
     expect(await screen.findByRole('dialog')).toBeInTheDocument();
     expect(screen.getByTestId('connector-url')).toHaveTextContent('/mcp');
-    // …and NO npx/file-write install was attempted for Claude Desktop.
     expect(installMcp).not.toHaveBeenCalled();
     expect(mintMcpTokenApi).not.toHaveBeenCalled();
   });
+});
 
-  it('Claude Desktop reads "MCP connected" from the mcp.connected signal with no local entry (ac-56)', async () => {
-    tagAc(AC_CONNECTOR_STATUS);
-    installShell({ mcpStatus: () => STATUS_ABSENT }); // no local CD entry at all
-    fetchJourneyStateApi.mockResolvedValue({ milestones: { mcpConnected: true } });
-
+describe('spec-304 ac-57 (dec-24): per-client "MCP status notification" toggle drives / hides the pill', () => {
+  it('default ENABLED: Claude Code drives the pill (a real state is pushed, not a hide)', async () => {
+    tagAc(AC_TOGGLE);
+    installShell({ mcpStatus: () => STATUS_CC_READY });
+    listMcpTokensApi.mockResolvedValue([
+      { id: '1', label: 'Memex Desktop', prefix: 'mxt_active123', lastUsedAt: null, revokedAt: null },
+    ]);
     render(<DesktopMcpSection />);
 
-    await waitFor(() =>
-      expect(screen.getByTestId('mcp-status-claudeDesktop')).toHaveTextContent('MCP connected'),
-    );
+    // The toggle is on by default…
+    const toggle = await screen.findByRole('checkbox');
+    expect(toggle).toBeChecked();
+    // …and the pill is driven with the real "ready" state (never a hide).
+    await waitFor(() => expect(mcpPushes.length).toBeGreaterThan(0));
+    expect(mcpPushes.at(-1)?.kind).toBe('ready');
+  });
+
+  it('DISABLING it hides the pill ({kind:"none"}) while the inline status stays', async () => {
+    tagAc(AC_TOGGLE);
+    installShell({ mcpStatus: () => STATUS_CC_READY });
+    listMcpTokensApi.mockResolvedValue([
+      { id: '1', label: 'Memex Desktop', prefix: 'mxt_active123', lastUsedAt: null, revokedAt: null },
+    ]);
+    render(<DesktopMcpSection />);
+
+    const toggle = await screen.findByRole('checkbox');
+    await waitFor(() => expect(mcpPushes.length).toBeGreaterThan(0));
+    fireEvent.click(toggle); // turn OFF
+
+    // Claude Code no longer drives the pill → the explicit hide is pushed.
+    await waitFor(() => expect(mcpPushes.at(-1)?.kind).toBe('none'));
+    expect(toggle).not.toBeChecked();
+    // The inline row status is unaffected — only the pill is silenced.
+    expect(screen.getByTestId('mcp-status-claudeCode')).toHaveTextContent('MCP ready');
   });
 });

--- a/packages/ui/src/components/DesktopMcpSection.tsx
+++ b/packages/ui/src/components/DesktopMcpSection.tsx
@@ -28,6 +28,10 @@ import {
   type McpTargetKey,
 } from '../desktop/bridge';
 import type { ClientStatus, McpStatusResult } from '../desktop/mcpStatus';
+import {
+  isPillNotificationEnabled,
+  setPillNotificationEnabled,
+} from '../desktop/mcpPillPrefs';
 import { runInstall } from '../desktop/install';
 import { ClaudeConnectorDialog } from './ClaudeConnectorDialog';
 
@@ -118,8 +122,9 @@ export function DesktopMcpSection() {
               </div>
             </div>
             {transport === 'connector' ? (
-              // Claude Desktop: open the connector-instructions dialog. No token
-              // logic, no in-app file write — the app can't add a connector (dec-23).
+              // Claude Desktop – Org Connector: open the connector-instructions
+              // dialog. No token logic, no in-app file write, and no pill — the
+              // app can't add or detect an account-level connector (dec-23/dec-24).
               <button
                 onClick={() => setConnectorOpen(true)}
                 className="text-xs px-3 py-1.5 rounded-sm bg-accent text-on-accent hover:opacity-90"
@@ -127,13 +132,31 @@ export function DesktopMcpSection() {
                 {BUTTON_LABEL.connector}
               </button>
             ) : (
-              <button
-                onClick={() => handleInstall(key as McpTargetKey, name)}
-                disabled={busy !== null}
-                className="text-xs px-3 py-1.5 rounded-sm bg-accent text-on-accent hover:opacity-90 disabled:opacity-50"
-              >
-                {busy === key ? 'Installing MCP…' : BUTTON_LABEL[status.button]}
-              </button>
+              // Token clients (Claude Code): the install action PLUS a per-client
+              // "MCP status notification" toggle (dec-24, ac-57). Off → this
+              // client no longer drives the native pill; the inline status above
+              // stays. Lets a user who'll never use this client silence the pill.
+              <div className="flex items-center gap-3">
+                <label
+                  className="flex items-center gap-1.5 text-xs text-secondary cursor-pointer select-none"
+                  title="Show this client's MCP status in the desktop app's pill"
+                  data-testid={`mcp-notify-${key}`}
+                >
+                  <input
+                    type="checkbox"
+                    checked={isPillNotificationEnabled(key)}
+                    onChange={(e) => setPillNotificationEnabled(key, e.target.checked)}
+                  />
+                  MCP status notification
+                </label>
+                <button
+                  onClick={() => handleInstall(key as McpTargetKey, name)}
+                  disabled={busy !== null}
+                  className="text-xs px-3 py-1.5 rounded-sm bg-accent text-on-accent hover:opacity-90 disabled:opacity-50"
+                >
+                  {busy === key ? 'Installing MCP…' : BUTTON_LABEL[status.button]}
+                </button>
+              </div>
             )}
           </div>
         ))}

--- a/packages/ui/src/components/DesktopMcpStatusSync.test.tsx
+++ b/packages/ui/src/components/DesktopMcpStatusSync.test.tsx
@@ -44,6 +44,7 @@ const STATUS = {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  localStorage.clear(); // pill-notification prefs persist per-device — reset between tests
   listMcpTokensApi.mockResolvedValue([
     { id: '1', label: 'Memex Desktop', prefix: 'mxt_active123', lastUsedAt: null, revokedAt: null },
   ]);

--- a/packages/ui/src/desktop/bridge.ts
+++ b/packages/ui/src/desktop/bridge.ts
@@ -136,3 +136,21 @@ export async function setMcpStatusBridge(push: McpIndicatorPush): Promise<void> 
     // An older shell without setMcpStatus must never break the web surface.
   }
 }
+
+/**
+ * Hide the native pill (spec-304 t-60, dec-24): the explicit "nothing to show"
+ * signal, pushed when no enabled, pill-driving client has a state (e.g. the
+ * user switched off the only client's notification, or uses only the connector,
+ * which never drives the pill). Sent as `setMcpStatus { kind: 'none' }` so it
+ * needs no new handler; a shell that predates it treats the unknown kind as a
+ * malformed no-op, leaving the pill as-is — acceptable for an older build.
+ */
+export async function clearMcpStatusBridge(): Promise<void> {
+  const b = bridge();
+  if (!b) return;
+  try {
+    await b.callHandler('setMcpStatus', { kind: 'none' });
+  } catch {
+    // Older shell / no handler — never break the web surface.
+  }
+}

--- a/packages/ui/src/desktop/mcpPillPrefs.ts
+++ b/packages/ui/src/desktop/mcpPillPrefs.ts
@@ -1,0 +1,48 @@
+// spec-304 t-60 (dec-24): per-client "MCP status notification" preference — does
+// a given pill-driving (local/token) client drive the native chrome pill?
+//
+// Default ON. Switching it OFF for a client means that client never drives the
+// pill (its inline row status still shows). The classic case: a user who never
+// uses Claude Code switches it off and is no longer nagged to install it.
+//
+// A tiny module-level store (localStorage-backed, with subscribe) rather than
+// React state, on purpose: the pill is driven from TWO hook instances — the
+// app-global <DesktopMcpStatusSync/> and the Settings <DesktopMcpSection/> — and
+// they must agree on what drives the pill, or they'd fight (one pushing "hide",
+// the other re-pushing "install"). A single shared source of truth keeps every
+// reader consistent, and persists per-device (the pill is a per-machine concern).
+
+const STORAGE_PREFIX = 'memex.mcpPillNotify.';
+const listeners = new Set<() => void>();
+
+function key(client: string): string {
+  return `${STORAGE_PREFIX}${client}`;
+}
+
+/** Whether [client] drives the native pill. Default true (absent / unreadable). */
+export function isPillNotificationEnabled(client: string): boolean {
+  try {
+    return localStorage.getItem(key(client)) !== 'false';
+  } catch {
+    return true;
+  }
+}
+
+/** Set [client]'s pill preference and notify every subscriber (both hooks). */
+export function setPillNotificationEnabled(client: string, enabled: boolean): void {
+  try {
+    localStorage.setItem(key(client), enabled ? 'true' : 'false');
+  } catch {
+    // A storage failure must not break the toggle interaction; the in-memory
+    // notify below still refreshes the current session.
+  }
+  for (const l of listeners) l();
+}
+
+/** Subscribe to preference changes (returns an unsubscribe). */
+export function subscribePillPrefs(cb: () => void): () => void {
+  listeners.add(cb);
+  return () => {
+    listeners.delete(cb);
+  };
+}

--- a/packages/ui/src/desktop/mcpStatus.test.ts
+++ b/packages/ui/src/desktop/mcpStatus.test.ts
@@ -132,35 +132,21 @@ describe('spec-304 ac-52 (issue-23): "connected" is PER-TOKEN, never the user-sc
   });
 });
 
-describe('spec-304 ac-56 (t-56): Claude Desktop connector status from the mcp.connected signal', () => {
-  it('connected signal present → "MCP connected" (independent of any local config)', () => {
+describe('spec-304 ac-56 (dec-24): Claude Desktop connector never asserts "connected"', () => {
+  it('is a neutral, signal-free setup state — there is no per-connector signal to prove a connection', () => {
     tagAc(AC_CONNECTOR);
-    expect(deriveConnectorStatus({ connected: true })).toEqual({
-      kind: 'connected',
-      label: 'MCP connected',
+    // deriveConnectorStatus takes NO connection input — it cannot, and must not,
+    // claim "connected" off the user-scoped (monotonic, un-attributable) signal.
+    expect(deriveConnectorStatus()).toEqual({
+      kind: 'not_installed',
+      label: 'Set up in Claude',
       button: 'connector',
     });
   });
 
-  it('no connection yet → "Not connected", connector instructions still offered', () => {
+  it('the connector label never reads "connected"', () => {
     tagAc(AC_CONNECTOR);
-    expect(deriveConnectorStatus({ connected: false })).toEqual({
-      kind: 'not_installed',
-      label: 'Not connected',
-      button: 'connector',
-    });
-  });
-
-  it('a connected connector contributes "connected" to the aggregate indicator', () => {
-    tagAc(AC_CONNECTOR);
-    // CD connected + CC not installed → the pill reads connected (CD counts).
-    const cd = deriveConnectorStatus({ connected: true });
-    const cc: ClientStatus = {
-      kind: 'not_installed',
-      label: 'Not installed',
-      button: 'install',
-    };
-    expect(deriveIndicator([cc, cd]).kind).toBe('connected');
+    expect(deriveConnectorStatus().label.toLowerCase()).not.toContain('connect');
   });
 });
 

--- a/packages/ui/src/desktop/mcpStatus.ts
+++ b/packages/ui/src/desktop/mcpStatus.ts
@@ -97,20 +97,24 @@ export function deriveClientStatus(
 }
 
 /**
- * Classify a CONNECTOR-based client (Claude Desktop, dec-23 / t-56). The
- * account-level Custom Connector is NOT in claude_desktop_config.json, so there
- * is no local entry and no per-token signal to read — its only honest truth is
- * the user-scoped `mcp.connected` usage signal. When a handshake has been seen
- * the client reads "MCP connected"; otherwise it is "Not connected" and the
- * "Install for my org" connector instructions stay available (never an alarm).
- * The button always opens the instructions dialog (the app cannot write a
- * connector), so it is offered in both states.
+ * Classify a CONNECTOR-based client (Claude Desktop "Org Connector", dec-24,
+ * revises dec-23/t-56). The account-level Custom Connector is NOT in
+ * claude_desktop_config.json and is NOT an `mxt_` token in the user's token
+ * list, so there is NO signal that can attribute a connection to THIS client.
+ * The only thing available — the user-scoped `mcp.connected` milestone — is a
+ * monotonic "have you ever connected by anything" flag (it stayed true even
+ * after every memex entry was wiped, falsely painting the row "connected").
+ *
+ * So the connector NEVER asserts "connected" and NEVER drives the native pill
+ * (the caller excludes connector clients from the pill aggregate). It is a
+ * setup-only row: a neutral "Set up in Claude" inline status plus the
+ * "Install for my org" instructions dialog. A false "not set up" prompt is
+ * benign; a false "connected" is not. The precise "Last connected: <date>" /
+ * "Never used" status — and the per-credential signal that powers it — are
+ * deferred to issue-26.
  */
-export function deriveConnectorStatus(opts: { connected: boolean }): ClientStatus {
-  if (opts.connected) {
-    return { kind: 'connected', label: 'MCP connected', button: 'connector' };
-  }
-  return { kind: 'not_installed', label: 'Not connected', button: 'connector' };
+export function deriveConnectorStatus(): ClientStatus {
+  return { kind: 'not_installed', label: 'Set up in Claude', button: 'connector' };
 }
 
 export type IndicatorKind = 'connected' | 'ready' | 'repair' | 'install';
@@ -162,5 +166,9 @@ export const MCP_CLIENTS: ReadonlyArray<{
   transport: ClientTransport;
 }> = [
   { key: 'claudeCode', name: 'Claude Code', transport: 'token' },
-  { key: 'claudeDesktop', name: 'Claude Desktop', transport: 'connector' },
+  {
+    key: 'claudeDesktop',
+    name: 'Claude Desktop – Org Connector',
+    transport: 'connector',
+  },
 ];

--- a/packages/ui/src/hooks/useDesktopMcpStatus.ts
+++ b/packages/ui/src/hooks/useDesktopMcpStatus.ts
@@ -18,8 +18,8 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { useAuth } from '../components/AuthContext';
 import { useUserChangeStream } from './useUserChangeStream';
 import { listMcpTokensApi } from '../api/mcp';
-import { fetchJourneyStateApi } from '../api/journey';
 import {
+  clearMcpStatusBridge,
   isDesktopShell,
   mcpStatusBridge,
   setMcpStatusBridge,
@@ -34,6 +34,7 @@ import {
   type ClientTransport,
   type McpStatusResult,
 } from '../desktop/mcpStatus';
+import { isPillNotificationEnabled, subscribePillPrefs } from '../desktop/mcpPillPrefs';
 
 export type McpPhase = 'idle' | 'loading' | 'ready' | 'error';
 
@@ -71,15 +72,17 @@ export function useDesktopMcpStatus(): DesktopMcpStatus {
   // `phase` dep caused re-subscription on every status change).
   const phaseRef = useRef<McpPhase>('idle');
   phaseRef.current = phase;
+  // Bumped whenever the per-client pill preferences change, so the push effect
+  // below re-runs and re-derives what the pill should show (dec-24).
+  const [prefsVersion, setPrefsVersion] = useState(0);
 
   const refresh = useCallback(async () => {
     if (!inShell) return;
     setPhase((p) => (p === 'ready' ? p : 'loading'));
     try {
-      const [local, tokens, journey] = await Promise.all([
+      const [local, tokens] = await Promise.all([
         mcpStatusBridge(),
         listMcpTokensApi(token),
-        fetchJourneyStateApi().catch(() => null),
       ]);
       if (!local) {
         // Probe failed — tolerate transient failures before showing an error.
@@ -94,27 +97,22 @@ export function useDesktopMcpStatus(): DesktopMcpStatus {
       const activeTokens: ActiveToken[] = tokens
         .filter((t) => !t.revokedAt)
         .map((t) => ({ prefix: t.prefix, lastUsedAt: t.lastUsedAt }));
-      // User-scoped MCP connection signal — the Claude Desktop CONNECTOR has no
-      // local entry to read, so its "connected" derives from this (dec-23).
-      const userConnected = journey?.milestones.mcpConnected ?? false;
 
       const per: DesktopMcpClient[] = MCP_CLIENTS.map(({ key, name, transport }) => ({
         key,
         name,
         transport,
+        // Connector clients (Claude Desktop – Org Connector) have no detectable
+        // per-client signal, so they get a neutral setup status and never drive
+        // the pill (dec-24). Token clients derive from local config ⨝ tokens.
         status:
           transport === 'connector'
-            ? deriveConnectorStatus({ connected: userConnected })
+            ? deriveConnectorStatus()
             : deriveClientStatus(local[key], { activeTokens }),
       }));
       setClients(per);
       setError(null);
       setPhase('ready');
-
-      // Push the aggregate indicator to the native pill (dec-21). React owns the
-      // truth; the shell owns the on-open timing + visibility policy. This is the
-      // push that makes the pill app-global (issue-24 #1).
-      void setMcpStatusBridge(deriveIndicator(per.map((c) => c.status)));
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Could not read MCP status');
       setPhase('error');
@@ -124,6 +122,28 @@ export function useDesktopMcpStatus(): DesktopMcpStatus {
   useEffect(() => {
     void refresh();
   }, [refresh]);
+
+  // Push the aggregate indicator to the native pill (dec-21, dec-24) — in its
+  // own effect (not inside refresh) so a pill-preference TOGGLE re-pushes
+  // without re-probing. Only ENABLED, token-transport clients drive the pill;
+  // connector clients never do. When none drive a state, push the explicit HIDE
+  // so the pill clears (no "Install MCP" nag for a client the user opted out of).
+  useEffect(() => {
+    if (!inShell || clients.length === 0) return;
+    const pillClients = clients.filter(
+      (c) => c.transport === 'token' && isPillNotificationEnabled(c.key),
+    );
+    if (pillClients.length === 0) {
+      void clearMcpStatusBridge();
+      return;
+    }
+    void setMcpStatusBridge(deriveIndicator(pillClients.map((c) => c.status)));
+  }, [inShell, clients, prefsVersion]);
+
+  // Re-derive the pill when the per-client notification preference changes
+  // (toggled in DesktopMcpSection). The store is shared across hook instances so
+  // the app-global sync and the Settings section never disagree.
+  useEffect(() => subscribePillPrefs(() => setPrefsVersion((v) => v + 1)), []);
 
   // Real-time: a token minted/revoked anywhere re-derives status (and the mint
   // that an in-app install performs flows back through here to update the pill).


### PR DESCRIPTION
## What & why

Fixes the runtime finding from spec-304 verify testing (per **dec-24**, which revises dec-21/dec-23; full design in spec-304 comment **c-35**): after wiping every memex config, the Claude Desktop row still showed **"MCP connected"** — because the connector status read the user-scoped `mcp.connected` milestone, a monotonic *"ever connected"* flag that can't be attributed to the connector and never resets.

### Changes (memex-ai / React — the bulk)
- **`deriveConnectorStatus()`** no longer takes or uses any connection signal. The Claude Desktop row — relabelled **"Claude Desktop – Org Connector"** — shows a neutral **"Set up in Claude"** status, never "MCP connected", and never drives the pill. (Precise *"Last connected: <date>"* / *"Never used"* needs a per-credential signal → deferred to **issue-26**.)
- **Per-client "MCP status notification" toggle** on each pill-driving (token) row — Claude Code today. Default **ON**. When **OFF**, that client is excluded from the aggregate pushed to the native pill (inline row status still shows); when **no** enabled client drives a state, React pushes an explicit **hide** so the pill clears — no "Install MCP" nag for a client the user will never use. This is the fix for the rejected "pill = local installs only" idea that would have nagged Claude-Code-never users.
- Toggle state lives in a shared **`mcpPillPrefs`** store (localStorage + subscribe), so the app-global sync hook and the Settings section hook always agree on what drives the pill — otherwise they'd fight (one hiding, one re-pushing). Per-device.
- `useDesktopMcpStatus` pushes the pill from a dedicated effect (so a toggle re-pushes without re-probing) and drops the now-unused journey fetch. `bridge.ts` gains `clearMcpStatusBridge()` (`setMcpStatus { kind: 'none' }`).

Pairs with **memex-clients** (the native pill clear/hide).

## Testing
- vitest **red→green** for **ac-57** (toggle gates the pill / hides when none enabled) + revised **ac-56** (connector neutral, never "connected"). All touched files green (37); `tsc -b` + `biome` clean.
- Full `@memex/ui` suite: my changes are clean. The only two failures in a local full run are **unrelated and pre-existing on develop**: `UpgradeConfirmation.spec-171` (a locale-dependent assertion — hardcodes the en-US date string, so it's red only on a non-US-locale dev box; green in CI's en-US) and `e2e-ac-emission.spec-391` (only fails under `MEMEX_EMIT=false`; passes with emission on). Confirmed both via stashing my changes on clean develop.

## Scope
spec-304 / dec-24. Out of scope (issue-26): the per-credential connector `lastUsedAt` signal + date status, and the "Claude Desktop – Local Developer install" bridge row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
