### PR TITLE
spec-371: surface the checkout holder in get_doc ("Checked out by: X (N minutes ago)")

### DIFF
--- a/packages/server/src/formatting/formatters.ts
+++ b/packages/server/src/formatting/formatters.ts
@@ -151,7 +151,12 @@ function formatTagStrip(tags: Tag[] | undefined): string | null {
 }
 
 export function formatFullDocState(
-  doc: Doc & { sections: DocSection[] },
+  // spec-371: checkoutHolder is the resolved holder name (getDoc attaches it);
+  // checked_out_by/at ride along on Doc. Optional so plain-Doc callers still compile.
+  doc: Doc & {
+    sections: DocSection[];
+    checkoutHolder?: { name: string | null; email: string | null } | null;
+  },
   decisions: Decision[],
   tasks: TaskWithBlockers[],
   appBaseUrl?: string,
@@ -187,6 +192,19 @@ export function formatFullDocState(
   lines.push(`ref: ${maybeDocRef(slugs, doc)}`);
   lines.push(`Type: ${doc.docType} | Handle: ${doc.handle}`);
   lines.push(`Status: ${doc.status} (changed ${formatDate(doc.statusChangedAt)})`);
+  // spec-371: surface who currently holds the checkout + how long ago, so a reader
+  // (or an agent about to edit) sees it before stepping on a colleague. Only when a
+  // spec is actually held.
+  if (doc.docType === "spec" && doc.checkedOutBy && doc.checkedOutAt) {
+    const who =
+      doc.checkoutHolder?.name?.trim() || doc.checkoutHolder?.email || "someone";
+    const mins = Math.max(
+      0,
+      Math.round((Date.now() - new Date(doc.checkedOutAt).getTime()) / 60_000),
+    );
+    const ago = mins < 1 ? "less than a minute ago" : `${mins} minute${mins === 1 ? "" : "s"} ago`;
+    lines.push(`Checked out by: ${who} (${ago})`);
+  }
   if (appBaseUrl) {
     lines.push(`URL: ${docUrl(appBaseUrl, doc.docType, doc.handle)}`);
   }

--- a/packages/server/src/services/checkout-surface.integration.test.ts
+++ b/packages/server/src/services/checkout-surface.integration.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { db } from "../db/connection.js";
+import { documents } from "../db/schema.js";
+import { makeTestMemex } from "./test-helpers.js";
+import { upsertUserByEmail } from "./users.js";
+import { stampCheckout } from "./checkout.js";
+import { getDoc } from "./documents.js";
+import { formatFullDocState } from "../formatting/formatters.js";
+
+// spec-371: who currently holds a spec's checkout (+ how long ago) is SURFACED in
+// the get_doc output (ac-6) — the read affordance that makes the checkout visible.
+const AC_6 = "mindset-prod/memex-building-itself/specs/spec-371/acs/ac-6";
+
+async function makeSpec(memexId: string): Promise<string> {
+  const [doc] = await db
+    .insert(documents)
+    .values({ memexId, handle: "spec-1", title: "Surface Spec", docType: "spec" })
+    .returning({ id: documents.id });
+  return doc.id;
+}
+
+const render = async (memexId: string, docId: string) =>
+  formatFullDocState(await getDoc(memexId, docId), [], []);
+
+describe("get_doc surfaces the checkout holder (spec-371 ac-6)", () => {
+  it("a free spec shows NO 'Checked out by' line", async () => {
+    tagAc(AC_6);
+    const memexId = await makeTestMemex("cs");
+    const docId = await makeSpec(memexId);
+    expect(await render(memexId, docId)).not.toMatch(/Checked out by/);
+  });
+
+  it("a held spec shows 'Checked out by: <holder> (N minutes ago)'", async () => {
+    tagAc(AC_6);
+    const memexId = await makeTestMemex("cs");
+    const holder = await upsertUserByEmail("holder@example.com");
+    const docId = await makeSpec(memexId);
+
+    // just now → "less than a minute ago"
+    await stampCheckout({ docId, userId: holder.id, thread: "conv-1" });
+    expect(await render(memexId, docId)).toMatch(
+      /Checked out by: holder@example\.com \(less than a minute ago\)/,
+    );
+
+    // 8 minutes ago → the minutes count is surfaced
+    await stampCheckout({
+      docId,
+      userId: holder.id,
+      thread: "conv-1",
+      now: new Date(Date.now() - 8 * 60_000),
+    });
+    expect(await render(memexId, docId)).toMatch(
+      /Checked out by: holder@example\.com \(8 minutes ago\)/,
+    );
+  });
+});

--- a/packages/server/src/services/documents.ts
+++ b/packages/server/src/services/documents.ts
@@ -715,6 +715,11 @@ export async function getDoc(
   Doc & {
     sections: DocSection[];
     creator: { name: string | null; email: string | null } | null;
+    // spec-371: the current checkout holder's display fields, resolved from
+    // checked_out_by (the durable checkout record rides along on `...doc`). null
+    // when the spec is free or the holder was wiped (FK ON DELETE SET NULL). The
+    // formatter renders "Checked out by X (N minutes ago)" from this + checked_out_at.
+    checkoutHolder: { name: string | null; email: string | null } | null;
     // spec-178 dec-8 / ac-28: for is_demo docs, the per-phase value-banner copy
     // (a fixture CONSTANT keyed by the doc's phase) the UI renders atop the demo
     // spec. Unset for non-demo docs and for any demo phase with no callout.
@@ -766,6 +771,17 @@ export async function getDoc(
     if (u) creator = u;
   }
 
+  // spec-371: resolve the current checkout holder (mirrors creator). Skipped when
+  // the spec is free or the holder was wiped.
+  let checkoutHolder: { name: string | null; email: string | null } | null = null;
+  if (doc.checkedOutBy) {
+    const [u] = await db
+      .select({ name: users.name, email: users.email })
+      .from(users)
+      .where(eq(users.id, doc.checkedOutBy));
+    if (u) checkoutHolder = u;
+  }
+
   // spec-409 (dec-4): derive the grounded-but-drifted state at read time.
   const groundedStale = await isGroundingStale(
     doc.id,
@@ -779,11 +795,11 @@ export async function getDoc(
   if (doc.isDemo) {
     const callout = HANDHOLD_PHASES.find((p) => p.phase === doc.status)?.valueCallout;
     if (callout !== undefined) {
-      return { ...doc, sections, creator, demoValueCallout: callout, groundedStale };
+      return { ...doc, sections, creator, checkoutHolder, demoValueCallout: callout, groundedStale };
     }
   }
 
-  return { ...doc, sections, creator, groundedStale };
+  return { ...doc, sections, creator, checkoutHolder, groundedStale };
 }
 
 export async function updateDocTitle(memexId: string, id: string, title: string): Promise<Mutated<Doc>> {


### PR DESCRIPTION
Follow-up to the checkout rework (#397). The checkout state lived only in the `documents` columns + the gate — nothing exposed it on a **read**. This surfaces it.

## What it does
`get_doc` now resolves the current holder's name (mirroring how it already resolves `creator`), and the doc-header formatter renders one line:

```
Checked out by: pete@example.com (8 minutes ago)
```

…but **only for a spec that is actually held**. Free specs render exactly as before.

## Why
- Makes the checkout visible to a reader, and to an **agent about to edit** (it sees who holds it before stepping on a colleague). Delivers the surfaceable half of ac-6.
- Makes verifying the rework on int a clean one-token check: read a spec → no line; advance/edit it → the line appears.

## Changes
- `services/documents.ts` — `getDoc` resolves `checkoutHolder` from `checked_out_by`.
- `formatting/formatters.ts` — render the line in `formatFullDocState`.
- `checkout-surface.integration.test.ts` — ac-6: held spec shows the line + minutes; free spec shows none.

## Test plan
- [x] Surface test (2/2), server typecheck clean
- [x] Rebased on latest develop (merged the spec-423 facet work, no conflicts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)