### PR TITLE
spec-421 issue-2: hold Home tracker first paint behind a skeleton (no flicker)

### DIFF
--- a/packages/ui/e2e/journey-34-spec-421-issue2-home-flicker.spec.ts
+++ b/packages/ui/e2e/journey-34-spec-421-issue2-home-flicker.spec.ts
@@ -1,0 +1,78 @@
+import {
+  test,
+  expect,
+  bareUrl,
+  emitAcEvents,
+  ensureUser,
+  setUserName,
+  setIdentityConfirmed,
+  DEV_EMAIL,
+  DEV_NAME,
+} from "./helpers/index.js";
+
+// Journey 34b — spec-421 issue-2: the Home "Getting started" tracker no longer flickers on
+// draw. Navigating to /home, the tracker used to render in a pre-data state (the whole
+// journey layer absent while journey-state was in flight) and then POP into existence once
+// GET /api/me/journey-state resolved. The fix holds first paint behind a stable-height
+// skeleton (Barrie's "assess read-only before draw"), so the real tracker swaps in at its
+// true progress with no empty→populated pop and no transient 0% frame.
+//
+//   ac-25 (spec-421) — an e2e journey navigates to /home for a user with onboarding progress
+//          and asserts the tracker shows the correct progress with no transient empty/0% frame
+//          (the skeleton holds first paint until journey-state resolves).
+//   ac-21 (spec-421) — cross-surface confirmation the issue-2 flicker no longer reproduces.
+const AC25 = "mindset-prod/memex-building-itself/specs/spec-421/acs/ac-25";
+const AC21 = "mindset-prod/memex-building-itself/specs/spec-421/acs/ac-21";
+
+const TITLE =
+  "navigating to /home holds first paint behind a skeleton (no empty/0% flash), then shows the correct tracker";
+
+test.afterEach(async ({}, testInfo) => {
+  // Re-confirm identity so the shared dev user lands on its board for other journeys.
+  await setIdentityConfirmed(DEV_EMAIL, true);
+  if (testInfo.status === "skipped") return;
+  await emitAcEvents(
+    [AC25, AC21],
+    testInfo.status === "passed" ? "pass" : "fail",
+    `packages/ui/e2e/journey-34-spec-421-issue2-home-flicker.spec.ts::${testInfo.title}`,
+    testInfo.duration,
+  );
+});
+
+test(TITLE, async ({ page }) => {
+  await ensureUser(DEV_EMAIL);
+  await setUserName(DEV_EMAIL, DEV_NAME);
+  // Identity confirmed → the user has onboarding progress (past step 0): the tracker shows a
+  // non-zero, multi-step rail (so a stale empty/0% frame would be plainly visible if it flashed).
+  await setIdentityConfirmed(DEV_EMAIL, true);
+
+  // Hold the journey-state response until we've checked the loading frame. This makes the
+  // "no flicker" guarantee deterministic: while the read-only fetch is in flight, the page
+  // must show the skeleton — never the real layer or a 0% progress value.
+  let releaseJourneyState!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    releaseJourneyState = resolve;
+  });
+  await page.route("**/api/me/journey-state*", async (route) => {
+    await gate;
+    await route.continue();
+  });
+
+  await page.goto(bareUrl("/home"));
+
+  // FIRST PAINT (fetch still in flight): the skeleton holds the tracker's place. The real
+  // journey layer is NOT mounted, and there is no transient "0% complete" progress frame.
+  await expect(page.getByTestId("journey-layer-skeleton")).toBeVisible({ timeout: 15_000 });
+  await expect(page.getByTestId("journey-layer")).toHaveCount(0);
+  await expect(page.getByTestId("journey-progress")).toHaveCount(0);
+
+  // Release the read-only journey-state read → the real tracker swaps in at its true state.
+  releaseJourneyState();
+
+  // The real tracker is now shown: the 3-node rail, a non-zero progress, identity ✓ — and the
+  // skeleton is gone. No empty→populated pop was ever visible.
+  await expect(page.getByTestId("journey-rail")).toBeVisible({ timeout: 15_000 });
+  await expect(page.getByTestId("journey-layer-skeleton")).toHaveCount(0);
+  await expect(page.getByTestId("journey-progress")).not.toHaveText("0% complete");
+  await expect(page.getByTestId("journey-rail-node-identity")).toHaveAttribute("data-attained", "true");
+});

--- a/packages/ui/src/pages/HomeCanvas.spec-421-issue2.test.tsx
+++ b/packages/ui/src/pages/HomeCanvas.spec-421-issue2.test.tsx
@@ -1,0 +1,172 @@
+// spec-421 issue-2 — the in-Home half of Barrie's clunkiness report.
+//
+// Navigating to /home, the "Getting started on Memex" tracker used to first render in a
+// pre-data state (the whole journey layer absent while `state === null`) and then POP into
+// existence once GET /api/me/journey-state resolved — the visible flicker Barrie reported
+// (sibling to issue-1, which fixed the routing half in RootRedirect).
+//
+// The fix applies Barrie's "assess read-only before draw" discipline to HomeCanvas: while
+// the journey-state fetch is in flight, a stable-height SKELETON holds the first paint
+// (no empty→populated layer pop); when state resolves the real tracker swaps in at its true
+// progress. Because the skeleton (not a 0% layer) occupies the loading frame, the progress
+// bar mounts fresh at its true width — no 0%→fill enter animation.
+//
+//   ac-21 (bug)  — the issue-2 flicker no longer reproduces (skeleton holds first paint).
+//   ac-22        — skeleton shown while loading; no real layer / no 0% frame; swaps cleanly.
+//   ac-23        — on resolve, true progress on first data frame (graduated 100% + ✓s;
+//                  in-progress correct partial %).
+//   ac-24        — journey state read fresh from the API, never persisted as source of truth.
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { tagAc } from '@memex-ai-ac/vitest';
+
+const fetchJourneyStateApi = vi.hoisted(() => vi.fn());
+const postJourneyEventApi = vi.hoisted(() => vi.fn());
+const fetchDocs = vi.hoisted(() => vi.fn());
+
+vi.mock('../api/journey', () => ({ fetchJourneyStateApi, postJourneyEventApi }));
+vi.mock('../api/docs', async (orig) => ({
+  ...(await orig<typeof import('../api/docs')>()),
+  fetchDocs,
+}));
+vi.mock('../components/AuthContext', () => ({
+  useAuth: () => ({
+    user: { id: 'u-1', name: 'John Doe', email: 'john@example.com' },
+    session: { memberships: [{ slug: 'john', memexSlug: 'personal', kind: 'personal' }] },
+    token: 'fake',
+  }),
+}));
+vi.mock('../hooks/useUserChangeStream', () => ({ useUserChangeStream: () => undefined }));
+
+import { HomeCanvas } from './HomeCanvas';
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-421/acs/ac-${n}`;
+
+const ALL_STEPS = [
+  'identity',
+  'create-spec',
+  'create-first-spec',
+  'resolve-decision',
+  'add-ac',
+  'specs-match-reality',
+  'agents-build',
+] as const;
+
+function stateFor(currentStepId: string, attained: readonly string[] = []) {
+  return {
+    milestones: {},
+    roleCoords: null,
+    currentStepId,
+    steps: ALL_STEPS.map((id) => ({ id, attained: attained.includes(id) })),
+    preview: false,
+    canPreview: false,
+  };
+}
+
+// A promise we resolve by hand, so we can observe the render WHILE the fetch is in flight.
+function deferred<T>() {
+  let resolve!: (v: T) => void;
+  let reject!: (e?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function renderCanvas(entry = '/home') {
+  return render(
+    <MemoryRouter initialEntries={[entry]}>
+      <HomeCanvas />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  fetchJourneyStateApi.mockReset();
+  postJourneyEventApi.mockReset();
+  postJourneyEventApi.mockResolvedValue(undefined);
+  fetchDocs.mockReset();
+  fetchDocs.mockResolvedValue([]);
+  window.localStorage.clear();
+});
+
+describe('spec-421 issue-2 — no flicker: assess journey-state before paint', () => {
+  it('holds first paint behind a skeleton while journey-state is loading — no layer pop, no 0% frame (ac-21, ac-22)', async () => {
+    tagAc(AC(21));
+    tagAc(AC(22));
+    const d = deferred<ReturnType<typeof stateFor>>();
+    fetchJourneyStateApi.mockReturnValue(d.promise);
+
+    renderCanvas();
+
+    // WHILE the fetch is in flight: a stable-height skeleton holds the tracker's place.
+    // The real journey layer must NOT be mounted, and there must be no transient progress
+    // frame (no "0% complete") that would later snap to the real value.
+    expect(screen.getByTestId('journey-layer-skeleton')).toBeInTheDocument();
+    expect(screen.queryByTestId('journey-layer')).toBeNull();
+    expect(screen.queryByTestId('journey-progress')).toBeNull();
+
+    // Resolve to an in-progress user → the real tracker swaps in, the skeleton is gone.
+    d.resolve(stateFor('create-spec', ['identity']));
+    expect(await screen.findByTestId('journey-layer')).toBeInTheDocument();
+    expect(screen.queryByTestId('journey-layer-skeleton')).toBeNull();
+  });
+
+  it('a completed (graduated) user sees the completed tracker on first data frame — 100% + ✓ steps (ac-23)', async () => {
+    tagAc(AC(23));
+    // All three visible steps attained → graduated; develop shows the completed rail (PR #382).
+    fetchJourneyStateApi.mockResolvedValue(
+      stateFor('create-first-spec', ['identity', 'create-spec', 'create-first-spec']),
+    );
+
+    renderCanvas();
+
+    await screen.findByTestId('journey-layer');
+    expect(screen.getByTestId('journey-progress')).toHaveTextContent('100% complete');
+    // The progress bar fill carries its true width (100%), not a 0% that animates up.
+    const fill = screen.getByTestId('journey-progress-bar').firstElementChild as HTMLElement;
+    expect(fill.style.width).toBe('100%');
+    // Every visible rail node shows its ✓ (attained) state.
+    for (const id of ['identity', 'create-spec', 'create-first-spec']) {
+      expect(screen.getByTestId(`journey-rail-node-${id}`).getAttribute('data-attained')).toBe('true');
+    }
+  });
+
+  it('an in-progress user sees their correct partial state on first data frame — no empty→populated pop (ac-22, ac-23)', async () => {
+    tagAc(AC(22));
+    tagAc(AC(23));
+    fetchJourneyStateApi.mockResolvedValue(stateFor('create-spec', ['identity']));
+
+    renderCanvas();
+
+    await screen.findByTestId('journey-layer');
+    // 1 of 3 visible steps attained → 33%.
+    expect(screen.getByTestId('journey-progress')).toHaveTextContent('33% complete');
+    expect(screen.getByTestId('journey-rail-node-identity').getAttribute('data-attained')).toBe('true');
+    expect(screen.getByTestId('journey-rail-node-create-spec').getAttribute('data-attained')).toBe('false');
+  });
+
+  it('assesses journey-state read-only from the API and never persists it as source of truth (ac-24)', async () => {
+    tagAc(AC(24));
+    fetchJourneyStateApi.mockResolvedValue(stateFor('create-spec', ['identity']));
+
+    renderCanvas();
+    await screen.findByTestId('journey-layer');
+
+    // Read-only: the tracker derives from a fresh API read on load.
+    expect(fetchJourneyStateApi).toHaveBeenCalled();
+
+    // Not persisted: no journey/attainment state is written to localStorage as the source of
+    // truth. (The spec-336 per-user viewing cursor is a separate, allowed concern — it stores
+    // only a bare step id, never the journey-state shape.)
+    for (let i = 0; i < window.localStorage.length; i += 1) {
+      const key = window.localStorage.key(i)!;
+      const value = window.localStorage.getItem(key) ?? '';
+      expect(value).not.toContain('currentStepId');
+      expect(value).not.toContain('"steps"');
+      expect(value).not.toContain('attained');
+    }
+  });
+});

--- a/packages/ui/src/pages/HomeCanvas.tsx
+++ b/packages/ui/src/pages/HomeCanvas.tsx
@@ -128,12 +128,21 @@ export function HomeCanvas() {
   // spec-372 issue-8 — the in-place collapse/expand of the tracker content was removed; the
   // tracker is always expanded, so there is no `contentCollapsed` state any more.
   const [forceShow, setForceShow] = useState(false);
+  // spec-421 issue-2 — has the journey-state fetch settled at least once? Until it has, we
+  // hold the tracker's first paint behind a stable-height skeleton (no empty→populated pop,
+  // Barrie's "assess read-only before draw"). A hard failure flips this true with state still
+  // null, so we fall back to the old no-layer behaviour rather than a forever-skeleton.
+  const [loadSettled, setLoadSettled] = useState(false);
 
   const load = useCallback(() => {
     fetchJourneyStateApi(previewParam)
-      .then(setState)
+      .then((s) => {
+        setState(s);
+        setLoadSettled(true);
+      })
       .catch(() => {
         /* keep last good state — the canvas never hard-crashes on a fetch blip */
+        setLoadSettled(true);
       });
   }, [previewParam]);
 
@@ -335,7 +344,14 @@ export function HomeCanvas() {
         </p>
       </div>
 
-      {layerVisible ? (
+      {/* spec-421 issue-2 — while the read-only journey-state fetch is in flight, a
+          stable-height skeleton holds the tracker's place so the real layer never pops in
+          from nothing (and the progress bar mounts fresh at its true width — no 0%→fill).
+          Once the fetch settles the real layer (or nothing, if the user has no steps / a
+          hard failure) swaps in with no layout shift. */}
+      {state === null && !loadSettled ? (
+        <JourneyLayerSkeleton />
+      ) : layerVisible ? (
         <section data-testid="journey-layer" className="relative">
           {/* spec-372 issue-18 (dec-9) — same calc(25% + 48rem) cap as the header so the
               two surfaces stay aligned and the 25% gutter reduction is uniform. */}
@@ -471,6 +487,42 @@ export function HomeCanvas() {
         );
     }
   }
+}
+
+// spec-421 issue-2 — the loading placeholder for the journey layer. It mirrors the real
+// layer's outer container, header row, and rail+panel split so that when journey-state
+// resolves the real tracker swaps in with no layout shift and no empty→populated pop. It
+// renders NO progress value — there is no transient "0% complete" frame to flash before the
+// true value. Purely presentational (aria-hidden); the real tracker carries the semantics.
+function JourneyLayerSkeleton() {
+  return (
+    <section data-testid="journey-layer-skeleton" aria-hidden className="relative animate-pulse">
+      <div className="mx-auto max-w-[calc(25%_+_48rem)] px-4 pt-6 sm:px-6">
+        {/* Header row — title placeholder + progress placeholder. */}
+        <div className="flex flex-wrap items-center gap-3 rounded-xl border-b border-edge px-2 pb-4 pt-1">
+          <div className="h-6 w-56 rounded-sm bg-edge" />
+          <div className="ml-auto flex items-center gap-3">
+            <div className="h-2 w-40 rounded-full bg-edge sm:w-64" />
+            <div className="h-4 w-20 rounded-sm bg-edge" />
+          </div>
+        </div>
+        {/* Rail + content split — same gutter as the real layer. */}
+        <div className="mt-6 flex flex-col gap-8 md:flex-row md:gap-16">
+          <div className="w-full flex-none md:w-64">
+            <div className="flex flex-col gap-3">
+              <div className="h-12 rounded-xl bg-edge" />
+              <div className="h-12 rounded-xl bg-edge" />
+              <div className="h-12 rounded-xl bg-edge" />
+            </div>
+          </div>
+          <div className="min-w-0 flex-1 pt-1">
+            <div className="h-8 w-2/3 rounded-sm bg-edge" />
+            <div className="mt-4 h-40 rounded-2xl bg-edge" />
+          </div>
+        </div>
+      </div>
+    </section>
+  );
 }
 
 // spec-336 — the persistent vertical rail. Every visible step is a node: orb state from


### PR DESCRIPTION
## What & why

Fixes the **in-Home half** of Barrie's clunkiness report (Slack 2026-06-27) — spec-421 **issue-2**, sibling to issue-1 (which fixed the routing half in `RootRedirect`, [#399](https://github.com/mindset-ai/memex-ai/pull/399)).

Navigating to `/home`, the "Getting started on Memex" tracker rendered in a pre-data state — the whole journey layer absent while `GET /api/me/journey-state` was in flight — then **popped into existence** once the read resolved ("looks like I haven't completed, then snaps to completed").

## The fix

Apply Barrie's read-only *assess-before-draw* discipline (dec-5) to `HomeCanvas`:

- While the journey-state fetch is in flight, a stable-height **`JourneyLayerSkeleton`** holds the tracker's place — no empty→populated pop, no layout shift.
- The real tracker swaps in at its **true progress** on the first data frame. Because the skeleton (not a 0% layer) occupies the loading frame, the progress bar **mounts fresh at its true width** — no 0%→fill — while the existing `transition-[width]` still animates *in-session* progress changes.
- A `loadSettled` flag falls back to the prior header-only behaviour on a hard fetch failure (no forever-skeleton).

UI-only. No routes/schema/migrations. Nothing persisted — the journey state stays a read-only assessment per dec-5.

## Tests (red→green)

- **Unit** `HomeCanvas.spec-421-issue2.test.tsx` — reproduction confirmed RED (skeleton absent → the pop) then GREEN; tags **ac-21/22/23/24**.
- **e2e** `journey-34-spec-421-issue2-home-flicker.spec.ts` — a gated `journey-state` route deterministically proves the skeleton-only loading frame; tags **ac-25/ac-21**.
- **All 25 spec-421 ACs verified (100%)**; issue-2 → resolved.
- Full UI suite green (1817 passed / 1 skipped), UI `tsc` clean; `make e2e-cold`: **116 passed, 1 skipped, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)