### PR TITLE
spec-421 issue-2: assess journey-state before draw (in-memory) — fix the Home tracker flicker for real

### DIFF
--- a/packages/ui/e2e/journey-34-spec-421-issue2-home-flicker.spec.ts
+++ b/packages/ui/e2e/journey-34-spec-421-issue2-home-flicker.spec.ts
@@ -6,73 +6,91 @@ import {
   ensureUser,
   setUserName,
   setIdentityConfirmed,
+  seedSpecInMemex,
+  getPersonalMemexByEmail,
+  deleteDoc,
   DEV_EMAIL,
   DEV_NAME,
 } from "./helpers/index.js";
 
 // Journey 34b — spec-421 issue-2: the Home "Getting started" tracker no longer flickers on
-// draw. Navigating to /home, the tracker used to render in a pre-data state (the whole
-// journey layer absent while journey-state was in flight) and then POP into existence once
-// GET /api/me/journey-state resolved. The fix holds first paint behind a stable-height
-// skeleton (Barrie's "assess read-only before draw"), so the real tracker swaps in at its
-// true progress with no empty→populated pop and no transient 0% frame.
+// draw. Barrie's prescription (Slack 2026-06-27): the state was "only assessed when the page
+// is drawn, so you get the old state first and then a redraw" → assess it BEFORE draw, as a
+// quick read-only that is NOT stored. The app assesses journey-state once at landing
+// (RootRedirect) and shares it in-memory; navigating to /home paints the tracker from that
+// already-assessed state instead of re-assessing from null after draw.
 //
-//   ac-25 (spec-421) — an e2e journey navigates to /home for a user with onboarding progress
-//          and asserts the tracker shows the correct progress with no transient empty/0% frame
-//          (the skeleton holds first paint until journey-state resolves).
+// This journey proves it deterministically: warm the assessment by landing once, then make
+// the journey-state read HANG, then navigate to /home client-side. The tracker must still
+// appear at its correct state well within the hung read — which is only possible if it
+// painted from the shared (before-draw) assessment, not a fresh after-draw fetch.
+//
+//   ac-25 (spec-421) — e2e: after the app has assessed journey-state, navigating to /home
+//          shows the correct tracker immediately, with no transient empty/0% frame.
 //   ac-21 (spec-421) — cross-surface confirmation the issue-2 flicker no longer reproduces.
 const AC25 = "mindset-prod/memex-building-itself/specs/spec-421/acs/ac-25";
 const AC21 = "mindset-prod/memex-building-itself/specs/spec-421/acs/ac-21";
+const FILE = "packages/ui/e2e/journey-34-spec-421-issue2-home-flicker.spec.ts";
+
+let seededSpecId: string | null = null;
 
 const TITLE =
-  "navigating to /home holds first paint behind a skeleton (no empty/0% flash), then shows the correct tracker";
+  "after assessing journey-state at landing, navigating to /home paints the tracker from the shared assessment (no flicker even if a fresh read hangs)";
 
 test.afterEach(async ({}, testInfo) => {
-  // Re-confirm identity so the shared dev user lands on its board for other journeys.
+  if (seededSpecId) {
+    await deleteDoc(seededSpecId);
+    seededSpecId = null;
+  }
   await setIdentityConfirmed(DEV_EMAIL, true);
   if (testInfo.status === "skipped") return;
   await emitAcEvents(
     [AC25, AC21],
     testInfo.status === "passed" ? "pass" : "fail",
-    `packages/ui/e2e/journey-34-spec-421-issue2-home-flicker.spec.ts::${testInfo.title}`,
+    `${FILE}::${testInfo.title}`,
     testInfo.duration,
   );
 });
 
 test(TITLE, async ({ page }) => {
-  await ensureUser(DEV_EMAIL);
+  const userId = await ensureUser(DEV_EMAIL);
   await setUserName(DEV_EMAIL, DEV_NAME);
-  // Identity confirmed → the user has onboarding progress (past step 0): the tracker shows a
-  // non-zero, multi-step rail (so a stale empty/0% frame would be plainly visible if it flashed).
   await setIdentityConfirmed(DEV_EMAIL, true);
 
-  // Hold the journey-state response until we've checked the loading frame. This makes the
-  // "no flicker" guarantee deterministic: while the read-only fetch is in flight, the page
-  // must show the skeleton — never the real layer or a 0% progress value.
-  let releaseJourneyState!: () => void;
-  const gate = new Promise<void>((resolve) => {
-    releaseJourneyState = resolve;
+  // A real (non-demo) spec → the user is engaged (hasSpec). RootRedirect will land them on
+  // the Specs board, and the journey-state it reads warms the shared in-memory assessment.
+  const memex = await getPersonalMemexByEmail(DEV_EMAIL);
+  if (!memex) throw new Error("dev personal memex not provisioned");
+  const spec = await seedSpecInMemex({
+    memexId: memex.memexId,
+    title: "First spec (issue-2 flicker journey)",
+    createdByUserId: userId,
   });
-  await page.route("**/api/me/journey-state*", async (route) => {
-    await gate;
-    await route.continue();
+  seededSpecId = spec.docId;
+
+  // 1) Land at `/`: RootRedirect performs the ONE read-only journey-state assessment and,
+  //    because the user is engaged, routes them to the Specs board. Waiting for /specs
+  //    guarantees that read completed and the shared assessment is now warm.
+  await page.goto(bareUrl("/"));
+  await expect(page).toHaveURL(/\/specs(\?|#|$)/, { timeout: 15_000 });
+
+  // 2) Now make any FRESH journey-state read hang. If the Home tracker depended on an
+  //    after-draw fetch, it could only show a blank/old frame until this resolved.
+  await page.route("**/api/me/journey-state*", async () => {
+    // Never fulfilled within the test — simulates a slow read.
   });
 
-  await page.goto(bareUrl("/home"));
+  // 3) Navigate to /home CLIENT-SIDE (no full reload, so the in-memory assessment survives).
+  await page.getByTestId("primary-nav").getByRole("link", { name: "Home" }).click();
+  await expect(page).toHaveURL(/\/home(\?|#|$)/, { timeout: 15_000 });
 
-  // FIRST PAINT (fetch still in flight): the skeleton holds the tracker's place. The real
-  // journey layer is NOT mounted, and there is no transient "0% complete" progress frame.
-  await expect(page.getByTestId("journey-layer-skeleton")).toBeVisible({ timeout: 15_000 });
-  await expect(page.getByTestId("journey-layer")).toHaveCount(0);
-  await expect(page.getByTestId("journey-progress")).toHaveCount(0);
-
-  // Release the read-only journey-state read → the real tracker swaps in at its true state.
-  releaseJourneyState();
-
-  // The real tracker is now shown: the 3-node rail, a non-zero progress, identity ✓ — and the
-  // skeleton is gone. No empty→populated pop was ever visible.
-  await expect(page.getByTestId("journey-rail")).toBeVisible({ timeout: 15_000 });
-  await expect(page.getByTestId("journey-layer-skeleton")).toHaveCount(0);
+  // 4) The tracker paints from the shared assessment — promptly, despite the hung read —
+  //    at the correct engaged state (the first-spec step ticked), never an empty/0% frame.
+  await expect(page.getByTestId("journey-layer")).toBeVisible({ timeout: 5_000 });
+  await expect(page.getByTestId("journey-progress")).toBeVisible();
   await expect(page.getByTestId("journey-progress")).not.toHaveText("0% complete");
-  await expect(page.getByTestId("journey-rail-node-identity")).toHaveAttribute("data-attained", "true");
+  await expect(page.getByTestId("journey-rail-node-create-first-spec")).toHaveAttribute(
+    "data-attained",
+    "true",
+  );
 });

--- a/packages/ui/src/journeys/journeyStateCache.ts
+++ b/packages/ui/src/journeys/journeyStateCache.ts
@@ -1,0 +1,34 @@
+// spec-421 issue-2 — the session-scoped, in-memory journey-state cache.
+//
+// Barrie's clunkiness fix (Slack 2026-06-27): the journey/onboarding state was "only
+// assessed when the page is drawn, so you get the old state first and then a redraw."
+// His prescription — assess it BEFORE draw, as a quick read-only that is NOT stored:
+// "it's milliseconds to assess from the database based on what the user has done … a
+// quick read-only of the state (not stored). … if you persist the state then you will
+// get this slow load again as the state has to be reassessed and re-persisted per render."
+//
+// So this is a plain module variable — in-memory only, gone on a full page reload. It is
+// NOT localStorage / sessionStorage / any client store (that is the persistence Barrie
+// warned against, and what ac-24 forbids). It simply lets the ONE read-only assessment the
+// app already does (the login-time read in useShouldLandOnHome / RootRedirect) be shared,
+// so an in-app navigation to /home can paint the tracker at its already-assessed value on
+// first render instead of re-assessing from null after draw (the flicker). Every successful
+// read refreshes it; the live read on /home still runs and is authoritative.
+import type { JourneyStateResponse } from '../api/journey';
+
+let cached: JourneyStateResponse | null = null;
+
+/** The last read-only journey-state assessment this session, or null if none yet. */
+export function getCachedJourneyState(): JourneyStateResponse | null {
+  return cached;
+}
+
+/** Record the latest read-only assessment so the next surface can paint from it. */
+export function setCachedJourneyState(state: JourneyStateResponse | null): void {
+  cached = state;
+}
+
+/** Test-only: clear the in-memory assessment between cases. */
+export function resetCachedJourneyState(): void {
+  cached = null;
+}

--- a/packages/ui/src/journeys/landing.ts
+++ b/packages/ui/src/journeys/landing.ts
@@ -15,6 +15,7 @@
 // a reassess-and-re-persist per render — the very clunk this replaces.
 import { useEffect, useState } from 'react';
 import { fetchJourneyStateApi, type JourneyStateResponse } from '../api/journey';
+import { setCachedJourneyState } from './journeyStateCache';
 
 /**
  * Pure predicate: should this user land on /home, or go straight to the Specs board?
@@ -58,6 +59,10 @@ export function useShouldLandOnHome(enabled = true): boolean | null {
     const read = (attempt: number): void => {
       fetchJourneyStateApi()
         .then((s) => {
+          // spec-421 issue-2 — share this read-only assessment in-memory so a later in-app
+          // navigation to /home paints the tracker from it (before draw) instead of
+          // re-assessing from null after mount (the flicker). Not persisted (Barrie).
+          setCachedJourneyState(s);
           if (alive) setLandOnHome(shouldLandOnHome(s));
         })
         .catch(() => {

--- a/packages/ui/src/pages/HomeCanvas.spec-421-issue2.test.tsx
+++ b/packages/ui/src/pages/HomeCanvas.spec-421-issue2.test.tsx
@@ -1,21 +1,21 @@
 // spec-421 issue-2 — the in-Home half of Barrie's clunkiness report.
 //
-// Navigating to /home, the "Getting started on Memex" tracker used to first render in a
-// pre-data state (the whole journey layer absent while `state === null`) and then POP into
-// existence once GET /api/me/journey-state resolved — the visible flicker Barrie reported
-// (sibling to issue-1, which fixed the routing half in RootRedirect).
+// Barrie (Slack 2026-06-27): the journey state was "only assessed when the page is drawn,
+// so you get the old state first and then a redraw." His fix — assess it BEFORE draw, as a
+// quick read-only that is NOT stored. issue-1 did this for the LANDING decision in
+// RootRedirect; this is the in-Home tracker.
 //
-// The fix applies Barrie's "assess read-only before draw" discipline to HomeCanvas: while
-// the journey-state fetch is in flight, a stable-height SKELETON holds the first paint
-// (no empty→populated layer pop); when state resolves the real tracker swaps in at its true
-// progress. Because the skeleton (not a 0% layer) occupies the loading frame, the progress
-// bar mounts fresh at its true width — no 0%→fill enter animation.
+// The first attempt (a skeleton over an after-draw fetch, PR #400) did NOT follow that — it
+// still assessed after draw and still redrew (skeleton→tracker). The correct fix: the app
+// assesses journey-state once, read-only, and shares it IN-MEMORY (journeyStateCache); when
+// the user navigates to /home, HomeCanvas seeds its first paint from that shared assessment,
+// so the tracker renders already-correct on the FIRST commit — no from-null redraw.
 //
-//   ac-21 (bug)  — the issue-2 flicker no longer reproduces (skeleton holds first paint).
-//   ac-22        — skeleton shown while loading; no real layer / no 0% frame; swaps cleanly.
-//   ac-23        — on resolve, true progress on first data frame (graduated 100% + ✓s;
-//                  in-progress correct partial %).
-//   ac-24        — journey state read fresh from the API, never persisted as source of truth.
+//   ac-21 — the issue-2 flicker no longer reproduces (first paint is the real tracker).
+//   ac-22 — on navigation, the tracker paints from the shared assessment on first render.
+//   ac-23 — completed user 100%+✓ / in-progress correct % on first paint; cold load shows
+//           nothing (never a wrong/0% frame) until the read resolves.
+//   ac-24 — assessed read-only from the API; never persisted to localStorage / a client store.
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
@@ -40,6 +40,7 @@ vi.mock('../components/AuthContext', () => ({
 vi.mock('../hooks/useUserChangeStream', () => ({ useUserChangeStream: () => undefined }));
 
 import { HomeCanvas } from './HomeCanvas';
+import { setCachedJourneyState, resetCachedJourneyState } from '../journeys/journeyStateCache';
 
 const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-421/acs/ac-${n}`;
 
@@ -55,7 +56,7 @@ const ALL_STEPS = [
 
 function stateFor(currentStepId: string, attained: readonly string[] = []) {
   return {
-    milestones: {},
+    milestones: { hasSpec: attained.includes('create-first-spec') },
     roleCoords: null,
     currentStepId,
     steps: ALL_STEPS.map((id) => ({ id, attained: attained.includes(id) })),
@@ -64,15 +65,15 @@ function stateFor(currentStepId: string, attained: readonly string[] = []) {
   };
 }
 
-// A promise we resolve by hand, so we can observe the render WHILE the fetch is in flight.
+const GRADUATED = stateFor('create-first-spec', ['identity', 'create-spec', 'create-first-spec']);
+const IN_PROGRESS = stateFor('create-spec', ['identity']);
+
 function deferred<T>() {
   let resolve!: (v: T) => void;
-  let reject!: (e?: unknown) => void;
-  const promise = new Promise<T>((res, rej) => {
+  const promise = new Promise<T>((res) => {
     resolve = res;
-    reject = rej;
   });
-  return { promise, resolve, reject };
+  return { promise, resolve };
 }
 
 function renderCanvas(entry = '/home') {
@@ -90,83 +91,81 @@ beforeEach(() => {
   fetchDocs.mockReset();
   fetchDocs.mockResolvedValue([]);
   window.localStorage.clear();
+  resetCachedJourneyState();
 });
 
-describe('spec-421 issue-2 — no flicker: assess journey-state before paint', () => {
-  it('holds first paint behind a skeleton while journey-state is loading — no layer pop, no 0% frame (ac-21, ac-22)', async () => {
+describe('spec-421 issue-2 — assess journey-state before draw (in-memory, shared)', () => {
+  it('navigating to /home paints the completed tracker on the FIRST render from the shared assessment — no redraw (ac-21, ac-22, ac-23)', () => {
     tagAc(AC(21));
     tagAc(AC(22));
-    const d = deferred<ReturnType<typeof stateFor>>();
-    fetchJourneyStateApi.mockReturnValue(d.promise);
+    tagAc(AC(23));
+    // The app already assessed journey-state at login (RootRedirect / useShouldLandOnHome)
+    // and shared it in-memory. A graduated user now navigates to Home.
+    setCachedJourneyState(GRADUATED);
+    fetchJourneyStateApi.mockResolvedValue(GRADUATED);
 
     renderCanvas();
 
-    // WHILE the fetch is in flight: a stable-height skeleton holds the tracker's place.
-    // The real journey layer must NOT be mounted, and there must be no transient progress
-    // frame (no "0% complete") that would later snap to the real value.
-    expect(screen.getByTestId('journey-layer-skeleton')).toBeInTheDocument();
-    expect(screen.queryByTestId('journey-layer')).toBeNull();
-    expect(screen.queryByTestId('journey-progress')).toBeNull();
-
-    // Resolve to an in-progress user → the real tracker swaps in, the skeleton is gone.
-    d.resolve(stateFor('create-spec', ['identity']));
-    expect(await screen.findByTestId('journey-layer')).toBeInTheDocument();
+    // FIRST COMMIT — asserted synchronously, with NO await: the tracker is already correct.
+    // (Pre-fix the component initialised state=null and only an empty/skeleton frame painted
+    // here; this is the line that fails until first paint is seeded from the assessment.)
+    expect(screen.getByTestId('journey-layer')).toBeInTheDocument();
+    expect(screen.getByTestId('journey-progress')).toHaveTextContent('100% complete');
+    expect(screen.getByTestId('journey-progress-bar').firstElementChild).toHaveStyle({ width: '100%' });
+    // No skeleton placeholder is rendered (the old approach is gone).
     expect(screen.queryByTestId('journey-layer-skeleton')).toBeNull();
   });
 
-  it('a completed (graduated) user sees the completed tracker on first data frame — 100% + ✓ steps (ac-23)', async () => {
-    tagAc(AC(23));
-    // All three visible steps attained → graduated; develop shows the completed rail (PR #382).
-    fetchJourneyStateApi.mockResolvedValue(
-      stateFor('create-first-spec', ['identity', 'create-spec', 'create-first-spec']),
-    );
-
-    renderCanvas();
-
-    await screen.findByTestId('journey-layer');
-    expect(screen.getByTestId('journey-progress')).toHaveTextContent('100% complete');
-    // The progress bar fill carries its true width (100%), not a 0% that animates up.
-    const fill = screen.getByTestId('journey-progress-bar').firstElementChild as HTMLElement;
-    expect(fill.style.width).toBe('100%');
-    // Every visible rail node shows its ✓ (attained) state.
-    for (const id of ['identity', 'create-spec', 'create-first-spec']) {
-      expect(screen.getByTestId(`journey-rail-node-${id}`).getAttribute('data-attained')).toBe('true');
-    }
-  });
-
-  it('an in-progress user sees their correct partial state on first data frame — no empty→populated pop (ac-22, ac-23)', async () => {
+  it('an in-progress user navigating to /home sees their correct partial state on first render (ac-22, ac-23)', () => {
     tagAc(AC(22));
     tagAc(AC(23));
-    fetchJourneyStateApi.mockResolvedValue(stateFor('create-spec', ['identity']));
+    setCachedJourneyState(IN_PROGRESS);
+    fetchJourneyStateApi.mockResolvedValue(IN_PROGRESS);
 
     renderCanvas();
 
-    await screen.findByTestId('journey-layer');
-    // 1 of 3 visible steps attained → 33%.
+    // 1 of 3 visible steps attained → 33%, painted on the first commit.
     expect(screen.getByTestId('journey-progress')).toHaveTextContent('33% complete');
     expect(screen.getByTestId('journey-rail-node-identity').getAttribute('data-attained')).toBe('true');
     expect(screen.getByTestId('journey-rail-node-create-spec').getAttribute('data-attained')).toBe('false');
   });
 
-  it('assesses journey-state read-only from the API and never persists it as source of truth (ac-24)', async () => {
+  it('cold load with no prior assessment shows no tracker (never a wrong/0% frame) until the read resolves (ac-23)', async () => {
+    tagAc(AC(23));
+    // No cache seeded → cold. Hold the read so we can observe the pre-resolve frame.
+    const d = deferred<ReturnType<typeof stateFor>>();
+    fetchJourneyStateApi.mockReturnValue(d.promise);
+
+    renderCanvas();
+
+    // Before the read resolves: the tracker region renders nothing — crucially NOT a stale
+    // 0%/empty tracker that would later snap to the real value.
+    expect(screen.queryByTestId('journey-layer')).toBeNull();
+    expect(screen.queryByTestId('journey-progress')).toBeNull();
+
+    d.resolve(GRADUATED);
+    expect(await screen.findByTestId('journey-layer')).toBeInTheDocument();
+    expect(screen.getByTestId('journey-progress')).toHaveTextContent('100% complete');
+  });
+
+  it('assesses journey-state read-only from the API and never persists it to a client store (ac-24)', async () => {
     tagAc(AC(24));
-    fetchJourneyStateApi.mockResolvedValue(stateFor('create-spec', ['identity']));
+    setCachedJourneyState(GRADUATED);
+    fetchJourneyStateApi.mockResolvedValue(GRADUATED);
 
     renderCanvas();
     await screen.findByTestId('journey-layer');
 
-    // Read-only: the tracker derives from a fresh API read on load.
+    // Read-only refresh on mount (authoritative live read).
     expect(fetchJourneyStateApi).toHaveBeenCalled();
-
-    // Not persisted: no journey/attainment state is written to localStorage as the source of
-    // truth. (The spec-336 per-user viewing cursor is a separate, allowed concern — it stores
-    // only a bare step id, never the journey-state shape.)
+    // Not persisted: the shared assessment lives in-memory (a module variable), never in
+    // localStorage / sessionStorage / any client store (Barrie: "not stored"; ac-24).
     for (let i = 0; i < window.localStorage.length; i += 1) {
       const key = window.localStorage.key(i)!;
       const value = window.localStorage.getItem(key) ?? '';
       expect(value).not.toContain('currentStepId');
       expect(value).not.toContain('"steps"');
-      expect(value).not.toContain('attained');
+      expect(value).not.toContain('hasSpec');
     }
   });
 });

--- a/packages/ui/src/pages/HomeCanvas.tsx
+++ b/packages/ui/src/pages/HomeCanvas.tsx
@@ -37,6 +37,7 @@ import { fetchDocs } from '../api/docs';
 import { resolveSpecToken, SPEC_TOKEN_PLACEHOLDER } from '../components/home/specToken';
 import { resolveStepView, activeJourney } from '../journeys/registry';
 import { BUILDER_ONLY_STEP_IDS, HIDDEN_STEP_IDS } from '../journeys/onboarding/steps';
+import { getCachedJourneyState, setCachedJourneyState } from '../journeys/journeyStateCache';
 import { YourJourneys, type PearlJourney } from '../components/home/YourJourneys';
 import { HomeValue } from '../components/home/HomeValue';
 import { SHOW_GRADUATED_HOME } from './homeCanvasFlags';
@@ -118,7 +119,16 @@ export function HomeCanvas() {
 
   useDocumentTitle({ kind: 'page', title: 'Home' });
 
-  const [state, setState] = useState<JourneyStateResponse | null>(null);
+  // spec-421 issue-2 — assess BEFORE draw (Barrie). Seed the first paint from the shared
+  // in-memory journey-state the app already assessed read-only at login (useShouldLandOnHome
+  // / RootRedirect), so an in-app navigation to /home paints the tracker at its real state
+  // immediately instead of re-assessing from null after draw (the flicker). Preview reads
+  // are operator-pinned and must not seed from (or write to) the shared cache. On a cold
+  // load with no prior assessment this is null → the tracker region renders nothing until
+  // the read below resolves (a momentary blank, never a wrong/stale state).
+  const [state, setState] = useState<JourneyStateResponse | null>(() =>
+    previewParam ? null : getCachedJourneyState(),
+  );
   const [cursor, setCursor] = useState<string | null>(null);
   const [pinned, setPinned] = useState(false);
   const [restored, setRestored] = useState(false);
@@ -128,21 +138,17 @@ export function HomeCanvas() {
   // spec-372 issue-8 — the in-place collapse/expand of the tracker content was removed; the
   // tracker is always expanded, so there is no `contentCollapsed` state any more.
   const [forceShow, setForceShow] = useState(false);
-  // spec-421 issue-2 — has the journey-state fetch settled at least once? Until it has, we
-  // hold the tracker's first paint behind a stable-height skeleton (no empty→populated pop,
-  // Barrie's "assess read-only before draw"). A hard failure flips this true with state still
-  // null, so we fall back to the old no-layer behaviour rather than a forever-skeleton.
-  const [loadSettled, setLoadSettled] = useState(false);
 
   const load = useCallback(() => {
     fetchJourneyStateApi(previewParam)
       .then((s) => {
         setState(s);
-        setLoadSettled(true);
+        // Refresh the shared assessment so the next surface paints from the latest read.
+        // Never cache a preview-pinned read (it isn't the user's real state).
+        if (!previewParam) setCachedJourneyState(s);
       })
       .catch(() => {
         /* keep last good state — the canvas never hard-crashes on a fetch blip */
-        setLoadSettled(true);
       });
   }, [previewParam]);
 
@@ -344,14 +350,7 @@ export function HomeCanvas() {
         </p>
       </div>
 
-      {/* spec-421 issue-2 — while the read-only journey-state fetch is in flight, a
-          stable-height skeleton holds the tracker's place so the real layer never pops in
-          from nothing (and the progress bar mounts fresh at its true width — no 0%→fill).
-          Once the fetch settles the real layer (or nothing, if the user has no steps / a
-          hard failure) swaps in with no layout shift. */}
-      {state === null && !loadSettled ? (
-        <JourneyLayerSkeleton />
-      ) : layerVisible ? (
+      {layerVisible ? (
         <section data-testid="journey-layer" className="relative">
           {/* spec-372 issue-18 (dec-9) — same calc(25% + 48rem) cap as the header so the
               two surfaces stay aligned and the 25% gutter reduction is uniform. */}
@@ -487,42 +486,6 @@ export function HomeCanvas() {
         );
     }
   }
-}
-
-// spec-421 issue-2 — the loading placeholder for the journey layer. It mirrors the real
-// layer's outer container, header row, and rail+panel split so that when journey-state
-// resolves the real tracker swaps in with no layout shift and no empty→populated pop. It
-// renders NO progress value — there is no transient "0% complete" frame to flash before the
-// true value. Purely presentational (aria-hidden); the real tracker carries the semantics.
-function JourneyLayerSkeleton() {
-  return (
-    <section data-testid="journey-layer-skeleton" aria-hidden className="relative animate-pulse">
-      <div className="mx-auto max-w-[calc(25%_+_48rem)] px-4 pt-6 sm:px-6">
-        {/* Header row — title placeholder + progress placeholder. */}
-        <div className="flex flex-wrap items-center gap-3 rounded-xl border-b border-edge px-2 pb-4 pt-1">
-          <div className="h-6 w-56 rounded-sm bg-edge" />
-          <div className="ml-auto flex items-center gap-3">
-            <div className="h-2 w-40 rounded-full bg-edge sm:w-64" />
-            <div className="h-4 w-20 rounded-sm bg-edge" />
-          </div>
-        </div>
-        {/* Rail + content split — same gutter as the real layer. */}
-        <div className="mt-6 flex flex-col gap-8 md:flex-row md:gap-16">
-          <div className="w-full flex-none md:w-64">
-            <div className="flex flex-col gap-3">
-              <div className="h-12 rounded-xl bg-edge" />
-              <div className="h-12 rounded-xl bg-edge" />
-              <div className="h-12 rounded-xl bg-edge" />
-            </div>
-          </div>
-          <div className="min-w-0 flex-1 pt-1">
-            <div className="h-8 w-2/3 rounded-sm bg-edge" />
-            <div className="mt-4 h-40 rounded-2xl bg-edge" />
-          </div>
-        </div>
-      </div>
-    </section>
-  );
 }
 
 // spec-336 — the persistent vertical rail. Every visible step is a node: orb state from


### PR DESCRIPTION
## Why a second PR

The skeleton fix ([#400](https://github.com/mindset-ai/memex-ai/pull/400), merged) shipped to INT and **the flicker persisted**. Re-reading Barrie's Slack guidance (2026-06-27) confirmed it didn't follow it: `HomeCanvas` still assessed journey-state **after** draw (a `useEffect` fetch) and still redrew (skeleton→tracker). Barrie's prescription — *"the state is only assessed when the page is drawn, so you get the old state first and then a redraw"* → **assess it before draw, read-only, not stored.**

## The fix (in-memory, before draw — Ryan's call, honors "don't persist")

- **New** `journeys/journeyStateCache.ts` — a session-scoped **in-memory** cache (a plain module variable; **not** localStorage/sessionStorage/any client store).
- `journeys/landing.ts` — the login-time read in `useShouldLandOnHome` (`RootRedirect`) writes its read-only assessment into the cache, warming it before the user navigates.
- `pages/HomeCanvas.tsx` — **seeds its first paint from the cache** (non-preview) and refreshes it on each read, so an in-app navigation to `/home` paints the tracker at its already-assessed state on the **first commit** — no from-null redraw. **Removed** the skeleton + `loadSettled`.

### Scope / limitation (accepted, no-persist)
In-app **navigation** to Home (the reported scenario) is now flicker-free. A **hard browser reload** of `/home` (fresh JS context) still briefly shows nothing — never a *wrong* state — until the read resolves. Closing that too would require persisting state, which Barrie warned against and which we deliberately didn't do.

## Tests
- **Unit** `HomeCanvas.spec-421-issue2.test.tsx` (rewritten) — drives **red→green**: without the first-paint seed the synchronous first-render assertion fails; with it the completed tracker (100%+✓) / in-progress (33%) paint on the first commit; cold-load + read-only/not-persisted guards. Tags **ac-21/22/23/24**.
- **e2e** `journey-34-spec-421-issue2-home-flicker.spec.ts` (rewritten) — deterministic before-draw proof: warm the assessment, **hang** `/api/me/journey-state`, navigate client-side to `/home`; the tracker still paints correct from the shared assessment. Tags **ac-25/ac-21**.
- All 25 spec-421 ACs verified. UI suite green; UI `tsc` clean; `make e2e-cold` **115 passed** (sole fail = the known, unrelated `journey-45` desktop-MCP flake).

🤖 Generated with [Claude Code](https://claude.com/claude-code)