### PR TITLE
spec-421 issue-2: seed step-component done-state before draw (the real flicker site)

### DIFF
--- a/packages/ui/e2e/journey-34-spec-421-issue2-home-flicker.spec.ts
+++ b/packages/ui/e2e/journey-34-spec-421-issue2-home-flicker.spec.ts
@@ -93,4 +93,9 @@ test(TITLE, async ({ page }) => {
     "data-attained",
     "true",
   );
+  // NB: the content panel's step component (its own Create→Created / Connect→Connected
+  // done-flip — the real flicker site) is proven seeded-before-draw at the unit level
+  // (CreateFirstSpecStep / CreateSpecStep tests). Which step shows here depends on the
+  // user's milestone profile (this fixture has a spec but no MCP, so the displayed step is
+  // the genuinely-not-connected create-spec), so the content-done assertion lives in units.
 });

--- a/packages/ui/src/components/home/CreateFirstSpecStep.test.tsx
+++ b/packages/ui/src/components/home/CreateFirstSpecStep.test.tsx
@@ -13,15 +13,43 @@ const fetchJourneyStateApi = vi.hoisted(() => vi.fn());
 vi.mock('../../api/journey', () => ({ fetchJourneyStateApi }));
 
 import { CreateFirstSpecStep } from './CreateFirstSpecStep';
+import { setCachedJourneyState, resetCachedJourneyState } from '../../journeys/journeyStateCache';
 
 const AC421 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-421/acs/ac-${n}`;
 
 beforeEach(() => {
   fetchJourneyStateApi.mockReset();
   fetchJourneyStateApi.mockResolvedValue({ milestones: { hasSpec: false } });
+  resetCachedJourneyState();
 });
 afterEach(() => {
   vi.useRealTimers();
+});
+
+// spec-421 issue-2 — the in-Home flicker was the content panel, not the rail: `done` started
+// false and flipped true after an after-mount journey-state fetch ("Create" → "Created").
+// With the shared assessment warm, a revisiting user must see the DONE state on first paint.
+describe('CreateFirstSpecStep — assess done before draw (spec-421 issue-2)', () => {
+  it('a revisiting user (hasSpec, cached assessment) sees "Created" on the FIRST render — no Create→Created flip (ac-21, ac-22)', () => {
+    tagAc(AC421(21));
+    tagAc(AC421(22));
+    setCachedJourneyState({ milestones: { hasSpec: true } } as never);
+
+    render(<CreateFirstSpecStep onComplete={vi.fn()} />);
+
+    // Synchronous first render — no await: already the done state, never the "Create" card.
+    expect(screen.getByRole('heading', { level: 2 }).textContent).toMatch(/Created your first spec/);
+    expect(screen.getByTestId('create-first-spec-done')).toBeInTheDocument();
+    expect(screen.queryByTestId('create-first-spec-btn')).toBeNull();
+    expect(screen.queryByTestId('create-first-spec-status')).toBeNull();
+  });
+
+  it('with no cached assessment the first paint is unchanged (not-done) — cold path preserved (ac-23)', () => {
+    tagAc(AC421(23));
+    render(<CreateFirstSpecStep onComplete={vi.fn()} />);
+    expect(screen.getByRole('heading', { level: 2 }).textContent).toMatch(/^Create your first spec/);
+    expect(screen.queryByTestId('create-first-spec-done')).toBeNull();
+  });
 });
 
 describe('CreateFirstSpecStep — spec-421 step 3', () => {

--- a/packages/ui/src/components/home/CreateFirstSpecStep.tsx
+++ b/packages/ui/src/components/home/CreateFirstSpecStep.tsx
@@ -6,6 +6,7 @@ import { useEffect, useRef, useState } from 'react';
 import { CopyButton } from '../CodeBlock';
 import { StepDoneBadge } from './StepDoneBadge';
 import { fetchJourneyStateApi } from '../../api/journey';
+import { getCachedJourneyState } from '../../journeys/journeyStateCache';
 import { SAMPLE_PROMPT } from '../../utils/createSpecPrompts';
 
 export function CreateFirstSpecStep({
@@ -19,10 +20,17 @@ export function CreateFirstSpecStep({
   onCreateInApp?: () => void;
   onCtaClick?: (target: string) => void;
 } = {}) {
-  const [done, setDone] = useState(false);
+  // spec-421 issue-2 — assess "done" BEFORE draw from the shared in-memory journey-state
+  // (same read RootRedirect warmed at landing). A revisiting user who already has a spec
+  // sees "Created your first spec" on the FIRST paint instead of the not-done card flipping
+  // to done after an after-mount fetch (the in-Home flicker). doneRef/initRef start seeded
+  // so the effect treats this as "already known, do not advance" (mirrors its first-read
+  // revisiting branch). Cold (no cached assessment) → false, i.e. today's behaviour.
+  const seededDone = !preview && !!getCachedJourneyState()?.milestones?.hasSpec;
+  const [done, setDone] = useState(seededDone);
   const [expanded, setExpanded] = useState(false);
-  const doneRef = useRef(false);
-  const initRef = useRef(false);
+  const doneRef = useRef(seededDone);
+  const initRef = useRef(seededDone);
 
   useEffect(() => {
     if (preview) return;

--- a/packages/ui/src/components/home/CreateSpecStep.test.tsx
+++ b/packages/ui/src/components/home/CreateSpecStep.test.tsx
@@ -9,15 +9,35 @@ const fetchJourneyStateApi = vi.hoisted(() => vi.fn());
 vi.mock('../../api/journey', () => ({ fetchJourneyStateApi }));
 
 import { CreateSpecStep } from './CreateSpecStep';
+import { setCachedJourneyState, resetCachedJourneyState } from '../../journeys/journeyStateCache';
 const AC372 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-372/acs/ac-${n}`;
 const AC421 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-421/acs/ac-${n}`;
 
 beforeEach(() => {
   fetchJourneyStateApi.mockReset();
   fetchJourneyStateApi.mockResolvedValue({ milestones: { mcpConnected: false } });
+  resetCachedJourneyState();
 });
 afterEach(() => {
   vi.useRealTimers();
+});
+
+// spec-421 issue-2 — same before-draw fix as CreateFirstSpecStep: a revisiting user who has
+// already connected MCP must see the "Connected" card on first paint, not the connect card
+// flipping to connected after an after-mount fetch.
+describe('CreateSpecStep — assess connected before draw (spec-421 issue-2)', () => {
+  it('a revisiting user (mcpConnected, cached assessment) sees the Connected card on the FIRST render (ac-21, ac-22)', () => {
+    tagAc(AC421(21));
+    tagAc(AC421(22));
+    setCachedJourneyState({ milestones: { mcpConnected: true } } as never);
+
+    render(<CreateSpecStep onComplete={vi.fn()} />);
+
+    // Synchronous first render — no await: the connected done-badge (rendered only when
+    // `connected` is true) is present immediately, never the not-connected→connected flip.
+    expect(screen.getByTestId('create-spec-connected')).toBeInTheDocument();
+    expect(screen.getByText('Connected to the Memex MCP')).toBeInTheDocument();
+  });
 });
 
 describe('CreateSpecStep — spec-421: MCP connect only, completes on mcpConnected', () => {

--- a/packages/ui/src/components/home/CreateSpecStep.tsx
+++ b/packages/ui/src/components/home/CreateSpecStep.tsx
@@ -3,6 +3,7 @@
 // Stage 2 (create the spec) moved to CreateFirstSpecStep / step "create-first-spec".
 import { useEffect, useRef, useState } from 'react';
 import { fetchJourneyStateApi } from '../../api/journey';
+import { getCachedJourneyState } from '../../journeys/journeyStateCache';
 import { Instructions, TOOLS, detectOs, type Os, type Tool } from './ConnectAgentStep';
 import { EXPLORE_PROMPT, DOCS_HREF } from '../../utils/createSpecPrompts';
 
@@ -24,10 +25,16 @@ export function CreateSpecStep({
   // spec-372 issue-6 — OS is auto-detected; the manual "Your machine" selector is removed.
   const [os] = useState<Os>(detectOs);
   const [tool, setTool] = useState<Tool>('claude-code');
-  const [connected, setConnected] = useState(false);
+  // spec-421 issue-2 — assess "connected" BEFORE draw from the shared in-memory journey-state
+  // (the read RootRedirect warmed at landing), so a revisiting user who has already connected
+  // MCP sees the "Connected to the Memex MCP" card on the FIRST paint instead of the connect
+  // card flipping to connected after an after-mount fetch (the in-Home flicker). Seeded refs
+  // make the effect treat it as "already known, do not advance". Cold → false (today's path).
+  const seededConnected = !preview && !!getCachedJourneyState()?.milestones?.mcpConnected;
+  const [connected, setConnected] = useState(seededConnected);
   const [exploreCopied, setExploreCopied] = useState(false);
-  const connectedRef = useRef(false);
-  const initRef = useRef(false);
+  const connectedRef = useRef(seededConnected);
+  const initRef = useRef(seededConnected);
 
   // spec-372 change #13 — copy the doc-grounded evaluation prompt to the clipboard.
   const copyExplorePrompt = () => {


### PR DESCRIPTION
## The flicker that survived #400 and #402

Ryan on INT after #402: *"there's a moment when you see the state where the step isn't complete, and then it completes… the progress bar is always 100%… happens every time"* (in-app nav, no refresh).

That 100%-bar detail was the tell: #402's before-draw cache **did** fix the progress bar/rail (they read the seeded journey-state). But the flicker is in the **content panel** — the step component keeps its *own* completion state:

- `CreateFirstSpecStep.done` and `CreateSpecStep.connected` both start `false` and flip `true` only after the component's **own** after-mount `fetchJourneyStateApi()`.
- So the panel renders "**Create** your first spec" → "**Created** your first spec" (and "**Connect**" → "**Connected**") on every visit for an already-engaged user — independent of the bar.

## Fix

Both visible step components seed their initial `done`/`connected` (and `doneRef`/`connectedRef`/`initRef`) from the shared in-memory `journeyStateCache` that the landing read already warmed — so a revisiting user sees the done/connected card on the **first paint**, no after-mount flip. Seeded refs make the effect treat it as "already known, do not advance" (mirrors each component's existing first-read revisiting branch). Cold (no cached assessment) is unchanged.

These are the **only two visible steps** with this pattern — the other flip-components (`AgentPromptStep`, `SpecsMatchRealityStep`) are in `HIDDEN_STEP_IDS` and never render.

## Tests
- `CreateFirstSpecStep` / `CreateSpecStep` units — **red→green**: forcing the seed off renders the not-done card on first paint (fail); seeded renders done/connected on the first synchronous render (pass). Tags **ac-21/22/23**.
- `journey-34-spec-421-issue2` e2e — integration paint-from-warm-cache (rail/progress correct despite a hung read) still proven. Tags **ac-25/ac-21**.
- All 25 spec-421 ACs verified. UI suite **1823 pass**; UI `tsc` clean; `make e2e-cold` **116 pass, 0 fail**.

Builds on #402 (the shared in-memory assessment). No persistence (Barrie's constraint). Hard-reload of `/home` still cold-paints (the accepted in-memory tradeoff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)