### PR TITLE
fix(spec-371): hook-key mint accepts the device-flow mxt_ token

### DIFF
--- a/packages/server/src/__e2e__/hook-keys-mcp-token-auth.api.test.ts
+++ b/packages/server/src/__e2e__/hook-keys-mcp-token-auth.api.test.ts
@@ -1,0 +1,162 @@
+// spec-371 — the hook-key mint must accept the credential the CLI installer
+// actually holds. The plugin's device flow authenticates the user and yields an
+// mxt_ MCP token (mintMcpToken), NOT a web-session JWT. The mint route originally
+// ran the JWT-only sessionMiddleware, so checkout-setup's mxt_ bounced with a 401
+// ("Invalid or expired token") and a key could never be planted. The unit test
+// mocked fetch, so the auth mismatch only surfaced against the live int deploy.
+//
+// This exercises the REAL assembled app + DB through /api/:ns/:memex/hook-keys and
+// pins the dec-6 boundary it sits on (ac-14): the mxt_ PAT only AUTHENTICATES the
+// mint; the credential we PLANT is still a least-privilege mxh_. It also proves the
+// opt-in is CONTAINED — a PAT still can't drive a sibling JWT-only session route.
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { eq, inArray } from "drizzle-orm";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { db } from "../db/connection.js";
+import { app } from "../app.js";
+import { users, memexHookKeys, orgMemberships } from "../db/schema.js";
+import { signSessionToken } from "../services/auth-jwt.js";
+import { mintMcpToken } from "../services/mcp-tokens.js";
+import { createOrgWithMemexAndOwner } from "../services/__test__/seed-org.js";
+
+// ac-14 — the hook key is a least-privilege mxh_, never the user's mxt_/OAuth.
+const AC_14 = "mindset-prod/memex-building-itself/specs/spec-371/acs/ac-14";
+
+const createdUserIds: string[] = [];
+const createdMemexIds: string[] = [];
+
+afterAll(async () => {
+  if (createdMemexIds.length) {
+    await db
+      .delete(memexHookKeys)
+      .where(inArray(memexHookKeys.memexId, createdMemexIds))
+      .catch(() => {});
+  }
+  for (const id of createdUserIds) {
+    await db.delete(users).where(eq(users.id, id)).catch(() => {});
+  }
+});
+
+async function seedUser(): Promise<string> {
+  const [u] = await db
+    .insert(users)
+    .values({
+      email: `hookkey-auth-${crypto.randomUUID()}@example.com`,
+      emailVerifiedAt: new Date(),
+    } as typeof users.$inferInsert)
+    .returning();
+  createdUserIds.push(u.id);
+  return u.id;
+}
+
+async function authed(
+  path: string,
+  bearer: string | null,
+  init: RequestInit = {},
+): Promise<Response> {
+  const headers = new Headers(init.headers ?? {});
+  if (bearer) headers.set("Authorization", `Bearer ${bearer}`);
+  headers.set("Host", "memex.ai");
+  if (init.body && !headers.has("Content-Type")) {
+    headers.set("Content-Type", "application/json");
+  }
+  return app.request(path, { ...init, headers });
+}
+
+describe("hook-key mint accepts the device-flow mxt_ token (spec-371 ac-14)", () => {
+  beforeEach(() => {
+    if (!process.env.GOOGLE_CLIENT_ID) {
+      process.env.GOOGLE_CLIENT_ID = "test-client.apps.googleusercontent.com";
+    }
+  });
+
+  let ownerUserId: string;
+  let ownerMxt: string; // a real mxt_ PAT for the owner (what the device flow yields)
+  let ownerJwt: string; // a real web-session JWT for the owner (the control)
+  let memexId: string;
+  let hookKeysBase: string;
+  let emissionKeysBase: string;
+
+  const mint = async (base: string, bearer: string | null, name = "checkout hook") => {
+    const res = await authed(base, bearer, {
+      method: "POST",
+      body: JSON.stringify({ name }),
+    });
+    const body = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+    return { res, body };
+  };
+
+  beforeAll(async () => {
+    ownerUserId = await seedUser();
+    ownerJwt = signSessionToken(ownerUserId);
+    const { raw } = await mintMcpToken(ownerUserId, "test device");
+    ownerMxt = raw;
+
+    const seeded = await createOrgWithMemexAndOwner({
+      slug: `hk-auth-${Date.now().toString(36)}`,
+      ownerUserId,
+    });
+    memexId = seeded.memex.id;
+    createdMemexIds.push(memexId);
+    hookKeysBase = `/api/${seeded.namespace.slug}/${seeded.memex.slug}/hook-keys`;
+    emissionKeysBase = `/api/${seeded.namespace.slug}/${seeded.memex.slug}/emission-keys`;
+  });
+
+  it("THE FIX — a valid mxt_ PAT mints a key; the PLANTED credential is a least-privilege mxh_ (ac-14)", async () => {
+    tagAc(AC_14);
+    const { res, body } = await mint(hookKeysBase, ownerMxt);
+    expect(res.status).toBe(201);
+    // dec-6: the mxt_ only AUTHENTICATES; what we hand back is the scoped mxh_.
+    expect(typeof body.key).toBe("string");
+    expect(body.key as string).toMatch(/^mxh_/);
+    expect(body.key as string).not.toMatch(/^mxt_/);
+    expect(body.createdByUserId).toBe(ownerUserId);
+
+    // The mint persisted a real row for this memex, owned by the PAT's user.
+    const row = await db.query.memexHookKeys.findFirst({
+      where: eq(memexHookKeys.id, body.id as string),
+    });
+    expect(row?.memexId).toBe(memexId);
+    expect(row?.createdByUserId).toBe(ownerUserId);
+  });
+
+  it("REGRESSION GUARD — a web-session JWT still mints (the original path is unchanged)", async () => {
+    tagAc(AC_14);
+    const { res, body } = await mint(hookKeysBase, ownerJwt);
+    expect(res.status).toBe(201);
+    expect(body.key as string).toMatch(/^mxh_/);
+  });
+
+  it("no Authorization header → 401 (strict session unchanged)", async () => {
+    tagAc(AC_14);
+    const { res } = await mint(hookKeysBase, null);
+    expect(res.status).toBe(401);
+  });
+
+  it("an invalid mxt_-shaped bearer is NOT silently accepted → 401", async () => {
+    tagAc(AC_14);
+    const { res } = await mint(hookKeysBase, "mxt_not-a-real-token-deadbeef");
+    expect(res.status).toBe(401);
+  });
+
+  it("a valid mxt_ for a NON-MEMBER cannot mint — membership is still enforced → 404 (std-7)", async () => {
+    tagAc(AC_14);
+    const strangerId = await seedUser();
+    const { raw: strangerMxt } = await mintMcpToken(strangerId, "stranger device");
+    const { res } = await mint(hookKeysBase, strangerMxt);
+    expect(res.status).toBe(404);
+    // Belt-and-braces: no membership was created as a side effect.
+    const membership = await db.query.orgMemberships.findFirst({
+      where: eq(orgMemberships.userId, strangerId),
+    });
+    expect(membership).toBeUndefined();
+  });
+
+  it("CONTAINMENT — the same mxt_ PAT still does NOT authorise a sibling JWT-only route (emission-keys) → 401", async () => {
+    tagAc(AC_14);
+    // emission-keys uses plain sessionMiddleware; the opt-in must not leak there.
+    const { res } = await mint(emissionKeysBase, ownerMxt);
+    expect(res.status).toBe(401);
+  });
+});

--- a/packages/server/src/middleware/session.ts
+++ b/packages/server/src/middleware/session.ts
@@ -5,6 +5,7 @@ import { memexes, namespaces, orgs, orgMemberships } from "../db/schema.js";
 import { getUserByEmail, getUserById, listMemberships, upsertUserByEmail } from "../services/users.js";
 import { ensureUserNamespace } from "../services/user-namespaces.js";
 import { verifySessionToken, InvalidTokenError } from "../services/auth-jwt.js";
+import { verifyMcpToken, bumpLastUsed } from "../services/mcp-tokens.js";
 import type { User, Memex, Namespace } from "../db/schema.js";
 
 export type SessionEnv = {
@@ -153,6 +154,7 @@ type BearerResolution =
  */
 async function resolveBearerUser(
   c: Parameters<Parameters<typeof createMiddleware<SessionEnv>>[0]>[0],
+  opts: { allowMcpToken?: boolean } = {},
 ): Promise<BearerResolution> {
   // Evaluate the dev flag BEFORE any token work so the b-38 F-1 prod guard
   // (isDevMode() throws when GOOGLE_CLIENT_ID is missing in production) still
@@ -191,6 +193,30 @@ async function resolveBearerUser(
     return { kind: "user", user };
   } catch (err) {
     if (err instanceof InvalidTokenError) {
+      // Not a session JWT. On routes that OPT IN (allowMcpToken — today only the
+      // hook-key mint, hit by the CLI installer whose device-flow auth yields an
+      // mxt_ MCP token, NOT a web-session JWT — spec-371), accept a valid mxt_
+      // PAT as proof of identity. It resolves to the same user; minting a
+      // strictly-less-privileged scoped hook key off a full PAT is no escalation,
+      // and dec-6 keeps the PLANTED credential a least-privilege mxh_ — the PAT
+      // only authenticates the mint. Every other session route stays JWT-only.
+      if (opts.allowMcpToken && token.startsWith("mxt_")) {
+        const mcpToken = await verifyMcpToken(token);
+        if (mcpToken) {
+          const user = await getUserById(mcpToken.userId);
+          if (user) {
+            bumpLastUsed(mcpToken.id);
+            return { kind: "user", user };
+          }
+          // Valid PAT whose subject was deleted: same userGone semantics as a JWT.
+          if (devMode) {
+            return { kind: "user", user: await resolveDevUser() };
+          }
+          return { kind: "userGone" };
+        }
+        // An mxt_-shaped bearer that doesn't verify falls through to the normal
+        // invalid-token handling below (→ anonymous → strict 401).
+      }
       // Malformed/expired token: dev mode keeps the no-token convenience
       // (fall back to the dev user); real mode reports anonymous.
       if (devMode) {
@@ -280,8 +306,9 @@ async function establishUserSession(
   return null;
 }
 
-export const sessionMiddleware = createMiddleware<SessionEnv>(async (c, next) => {
-  const resolution = await resolveBearerUser(c);
+function makeSessionMiddleware(opts: { allowMcpToken?: boolean } = {}) {
+  return createMiddleware<SessionEnv>(async (c, next) => {
+  const resolution = await resolveBearerUser(c, opts);
 
   if (resolution.kind === "reject") {
     return resolution.response;
@@ -304,6 +331,21 @@ export const sessionMiddleware = createMiddleware<SessionEnv>(async (c, next) =>
   const short = await establishUserSession(c, resolution.user);
   if (short) return short;
   return runWithMemexId(c.get("currentMemexId"), next);
+  });
+}
+
+// Strict session: a valid web-session JWT (or, in dev, the token-less fallback).
+// This is the default for every gated route.
+export const sessionMiddleware = makeSessionMiddleware();
+
+// spec-371 — the hook-key mint (routes/hook-keys.ts) is the ONE session route that
+// ALSO accepts a valid mxt_ MCP token. The CLI installer authenticates via the
+// device flow, which yields an MCP PAT rather than a web-session JWT; without this
+// it could never mint the scoped hook key it plants. Strictly opt-in: every other
+// route keeps `sessionMiddleware` and stays JWT-only, so a PAT can't drive the web
+// API at large.
+export const sessionWithMcpTokenMiddleware = makeSessionMiddleware({
+  allowMcpToken: true,
 });
 
 /**

--- a/packages/server/src/routes/hook-keys.ts
+++ b/packages/server/src/routes/hook-keys.ts
@@ -1,10 +1,17 @@
 // HTTP routes for the scoped HOOK KEY surface (spec-371). Tenant-scoped, mounted
 // under /api/:namespace/:memex/hook-keys. Mirrors routes/emission-keys.ts: every
-// verb is a strict-session, membership-gated operation (the key is a secret).
+// verb is a membership-gated operation (the key is a secret).
 //
 // The plugin installer (packages/cli) calls POST / after its device-flow auth to
 // plant a least-privilege key the checkout hook authenticates with — never the
 // user's MCP PAT or OAuth token (dec-6). The raw key is returned exactly once.
+//
+// Auth note (spec-371): the device flow yields an mxt_ MCP token, not a web-session
+// JWT, so this surface uses sessionWithMcpTokenMiddleware — the one session route
+// that also accepts a valid mxt_ PAT. dec-6 is preserved: the PAT only AUTHENTICATES
+// the mint; the credential we PLANT is still the least-privilege mxh_ this route
+// returns. Membership is still enforced (the PAT resolves a user, the std-5 tail
+// 404s a non-member), so a PAT can only mint a key for a memex its owner belongs to.
 
 import { Hono } from "hono";
 import {
@@ -12,7 +19,10 @@ import {
   listHookKeysForMemex,
   revokeHookKey,
 } from "../services/hook-keys.js";
-import { sessionMiddleware, type SessionEnv } from "../middleware/session.js";
+import {
+  sessionWithMcpTokenMiddleware,
+  type SessionEnv,
+} from "../middleware/session.js";
 import type { MemexResolverEnv } from "../middleware/memex-resolver.js";
 import { requireMemexId } from "./shared.js";
 import type { MemexHookKey } from "../db/schema.js";
@@ -20,7 +30,7 @@ import type { MemexHookKey } from "../db/schema.js";
 type Env = MemexResolverEnv & SessionEnv;
 
 const hookKeysRouter = new Hono<Env>();
-hookKeysRouter.use("/*", sessionMiddleware);
+hookKeysRouter.use("/*", sessionWithMcpTokenMiddleware);
 
 // Display-safe projection: the hashed_key and the raw key are NEVER serialised.
 // The raw key appears only in the POST / response, exactly once.


### PR DESCRIPTION
## The bug (caught by the live int run, spec-371 ac-19)

`checkout-setup` (the plugin installer) authenticates via the **device flow**, which yields an **`mxt_` MCP token**, not a web-session JWT. The hook-keys mint route (`POST /api/:ns/:memex/hook-keys`) ran **JWT-only `sessionMiddleware`**, so the installer's token bounced with:

```
Failed to mint hook key (401): {"error":"Invalid or expired token"}
```

…and the scoped hook key could **never be planted**. The unit test mocked `fetch`, so the auth mismatch was invisible until `checkout-setup` ran against the live int deploy.

## Root cause

`completeCliAuthRequest` → `mintMcpToken(...)` → the CLI polls and receives an `mxt_` PAT. The mint route's `sessionMiddleware` → `resolveBearerUser` only ran `verifySessionToken` (a JWT). An `mxt_` is not a JWT, so it resolved as anonymous → strict 401.

## The fix (surgical, opt-in)

- `resolveBearerUser` gains an opt-in `{ allowMcpToken }`. When set and the bearer is a valid `mxt_`, it resolves the user via `verifyMcpToken` (the same resolver the `/mcp` endpoint uses).
- `sessionMiddleware` is now produced by a `makeSessionMiddleware()` factory; behaviour for every existing route is **byte-identical** (`allowMcpToken` defaults false).
- A new `sessionWithMcpTokenMiddleware` (opt-in) is wired to **only** the hook-keys surface.

### Why this is safe
- **dec-6 preserved** — the `mxt_` PAT only *authenticates* the mint; the credential we *plant* is still a least-privilege `mxh_`.
- **No escalation** — minting a strictly-weaker scoped key off a full PAT grants nothing the PAT didn't already have.
- **Membership still enforced** — the std-5 tail 404s a non-member even with a valid PAT.
- **Contained** — every other session route stays JWT-only; a PAT still cannot drive the web API at large.

## Test plan

New `__e2e__/hook-keys-mcp-token-auth.api.test.ts` hits the **real assembled app** with a **real `mxt_`** (the gap the mocked unit test missed):
- [x] valid `mxt_` → 201, plants an `mxh_` (never an `mxt_`), owned by the PAT's user, row persisted
- [x] web-session JWT still mints (original path unchanged)
- [x] no Authorization header → 401
- [x] invalid `mxt_`-shaped bearer → 401 (not silently accepted)
- [x] valid `mxt_` for a **non-member** → 404 (std-7; membership enforced)
- [x] **containment**: same `mxt_` still 401s on the sibling JWT-only emission-keys route

Locally: full server suite green (4936 pass; the lone red is the known `OPENAI_API_KEY`-in-shell `standards-graph` flake, green with the key unset = CI conditions). Deploy gate (`pnpm build`) green. Biome lint clean.

## Follow-ups (not in this PR)
- The bundled plugin hardcodes the **prod** MCP URL (`https://memex.ai/mcp`); an int install needs that made configurable.
- `make typecheck` (tests-included `tsc`) has pre-existing, codebase-wide fixture drift (~21 files, incl. some `checkedOutBy/At/Thread` from #397) — **not gated by CI** (`pnpm build` excludes tests) — worth a dedicated cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)