### PR TITLE
fix(spec-371): scope phone-home spec lookup with runWithMemexId (RLS)

### DIFF
--- a/packages/server/src/__regression__/spec-checkout-phonehome-rls.regression.test.ts
+++ b/packages/server/src/__regression__/spec-checkout-phonehome-rls.regression.test.ts
@@ -1,0 +1,121 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { eq, inArray, sql } from "drizzle-orm";
+import postgres from "postgres";
+import { db } from "../db/connection.js";
+import { namespaces, memexes, documents } from "../db/schema.js";
+
+// Regression guard for the spec-checkout phone-home RLS trap (spec-371).
+//
+// POST /api/spec-checkout authenticates a HOOK KEY (an RLS-excluded table, like
+// emission keys) and resolves the tenant from the body ref — both run with NO
+// app.memex_id context. It then must READ the `documents` table to resolve the
+// claimed spec's doc id. `documents` has ROW LEVEL SECURITY enabled (std-36:
+// ENABLE, never FORCE): the policy filters every row unless app.memex_id is set.
+// ENABLE (not FORCE) means the table OWNER bypasses — but the Cloud Run runtime
+// role `memex_app` is NOT the owner, so the policy applies to it in full.
+//
+// The trap (identical to the 2026-06-10 emission outage, see
+// emission-key-contextless-verify.regression.test.ts): a contextless read passes
+// locally because the dev `postgres` role is a SUPERUSER that bypasses RLS, then
+// returns ZERO rows the moment Cloud Run connects as the non-super `memex_app`
+// role — so on int every phone-home resolved `spec_not_found` and recorded nothing.
+//
+// The fix wraps the read (and the record write) in runWithMemexId(memexId), which
+// sets app.memex_id for the policy. These tests pin the invariant the way the
+// emission test does: SET LOCAL ROLE memex_app inside a transaction drops the
+// superuser bypass, so the connection sees exactly what the runtime role sees.
+
+const NS_SLUG = "phonehome-rls-regress-ns";
+const SPEC_HANDLE = "spec-rls-1";
+
+describe("regression: spec-checkout phone-home read needs app.memex_id under RLS", () => {
+  let memexId: string;
+  let docId: string;
+
+  beforeAll(async () => {
+    // Setup runs as the superuser (global `db`) — bypasses RLS to seed the rows.
+    const [ns] = await db
+      .insert(namespaces)
+      .values({ slug: NS_SLUG, kind: "org" })
+      .returning({ id: namespaces.id });
+    const [mx] = await db
+      .insert(memexes)
+      .values({ namespaceId: ns!.id, slug: "phonehome-rls-regress-mx", name: "Phonehome RLS Regress" })
+      .returning({ id: memexes.id });
+    memexId = mx!.id;
+    const [doc] = await db
+      .insert(documents)
+      .values({ memexId, handle: SPEC_HANDLE, title: "RLS Regress Spec", docType: "spec" })
+      .returning({ id: documents.id });
+    docId = doc!.id;
+  });
+
+  afterAll(async () => {
+    // FK order; the test namespace is kind='org' without owner_org_id (test-only),
+    // which would otherwise trip the owner-XOR invariant in migration-smoke.
+    if (memexId) {
+      await db.delete(documents).where(eq(documents.memexId, memexId)).catch(() => {});
+      await db.delete(memexes).where(inArray(memexes.id, [memexId])).catch(() => {});
+    }
+    await db.delete(namespaces).where(eq(namespaces.slug, NS_SLUG)).catch(() => {});
+  });
+
+  it("documents has RLS ENABLED — the trap that filters the non-owner runtime role", async () => {
+    const rows = (await db.execute(sql`
+      SELECT c.relrowsecurity AS rowsecurity,
+             c.relforcerowsecurity AS forcerowsecurity
+      FROM pg_class c
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+      WHERE n.nspname = 'public' AND c.relname = 'documents'
+    `)) as unknown as Array<{ rowsecurity: boolean; forcerowsecurity: boolean }>;
+    expect(rows).toHaveLength(1);
+    // ENABLE is what subjects the non-owner memex_app role to the policy.
+    expect(rows[0]!.rowsecurity).toBe(true);
+    // NOT forced — std-36 (ENABLE, never FORCE). FORCE isn't needed for the trap:
+    // memex_app is a non-owner role, so plain ENABLE already filters it. The owner /
+    // superuser bypass that ENABLE permits is exactly what masks the bug locally.
+    expect(rows[0]!.forcerowsecurity).toBe(false);
+  });
+
+  it("as memex_app with NO app.memex_id, the spec lookup returns ZERO rows (the bug)", async () => {
+    const dbUrl =
+      process.env.DATABASE_URL ?? "postgresql://postgres:postgres@localhost:5432/memex";
+    const roleSql = postgres(dbUrl, { max: 1 });
+    try {
+      // The exact lookup POST /api/spec-checkout issues, as the Cloud Run runtime
+      // role with no context. Pre-fix this returned 0 rows → spec_not_found → the
+      // phone-home recorded nothing on int.
+      const rows = await roleSql.begin(async (tx) => {
+        await tx.unsafe("SET LOCAL ROLE memex_app");
+        return tx.unsafe(
+          "SELECT id FROM documents WHERE memex_id = $1 AND handle = $2 AND doc_type = 'spec'",
+          [memexId, SPEC_HANDLE],
+        );
+      });
+      expect(rows).toHaveLength(0);
+    } finally {
+      await roleSql.end({ timeout: 5 });
+    }
+  });
+
+  it("as memex_app WITH app.memex_id set (what runWithMemexId does), the spec is found (the fix)", async () => {
+    const dbUrl =
+      process.env.DATABASE_URL ?? "postgresql://postgres:postgres@localhost:5432/memex";
+    const roleSql = postgres(dbUrl, { max: 1 });
+    try {
+      const rows = await roleSql.begin(async (tx) => {
+        await tx.unsafe("SET LOCAL ROLE memex_app");
+        // runWithMemexId(memexId) issues exactly this set_config before the read.
+        await tx.unsafe("SELECT set_config('app.memex_id', $1, true)", [memexId]);
+        return tx.unsafe(
+          "SELECT id FROM documents WHERE memex_id = $1 AND handle = $2 AND doc_type = 'spec'",
+          [memexId, SPEC_HANDLE],
+        );
+      });
+      expect(rows).toHaveLength(1);
+      expect((rows[0] as { id: string }).id).toBe(docId);
+    } finally {
+      await roleSql.end({ timeout: 5 });
+    }
+  });
+});

--- a/packages/server/src/routes/spec-checkout.ts
+++ b/packages/server/src/routes/spec-checkout.ts
@@ -19,7 +19,7 @@
 
 import { Hono } from "hono";
 import { and, eq } from "drizzle-orm";
-import { db } from "../db/connection.js";
+import { db, runWithMemexId } from "../db/connection.js";
 import { documents } from "../db/schema.js";
 import { verifyHookKey, bumpHookKeyLastUsed } from "../services/hook-keys.js";
 import { resolveMemexId } from "../services/emission-keys.js";
@@ -109,45 +109,61 @@ specCheckoutRouter.post("/", async (c) => {
     );
   }
 
-  // Resolve the spec doc. Unknown spec → fail quiet (std-7), record nothing.
-  const [doc] = await db
-    .select({ id: documents.id })
-    .from(documents)
-    .where(
-      and(
-        eq(documents.memexId, memexId),
-        eq(documents.handle, parsed.specHandle),
-        eq(documents.docType, "spec"),
-      ),
-    )
-    .limit(1);
-  if (!doc) return c.json({ recorded: false, reason: "spec_not_found" }, 200);
+  // body.thread_uid was validated as a string above, but TypeScript does not preserve
+  // that narrowing across the runWithMemexId callback boundary below — hoist it (the
+  // same reason test-events.ts captures its insert values before the mutate() callback).
+  const threadUid = body.thread_uid;
 
-  const actorUserId = hookKey.createdByUserId ?? null;
-  await recordCheckoutEdit({
-    memexId,
-    docId: doc.id,
-    threadUid: body.thread_uid,
-    changedPaths: body.changed_paths as string[],
-    commitSha: (body.commit_sha as string | undefined) ?? null,
-    branch: (body.branch as string | undefined) ?? null,
-    actorUserId,
+  // Everything below reads/writes TENANT tables (documents, then spec_checkout_edits)
+  // under row-level security (std-36): the policy filters every row unless `app.memex_id`
+  // is set, and the Cloud Run runtime role `memex_app` is a NON-OWNER, so the policy
+  // applies to it in full. The hook-key auth + resolveMemexId above run on RLS-EXCLUDED
+  // tables, so they need no context — but the spec lookup does. runWithMemexId stamps
+  // app.memex_id for the duration. WITHOUT this wrap the read returns zero rows on int
+  // (every phone-home silently records nothing), while local tests pass because the
+  // postgres superuser bypasses RLS — the exact 2026-06-10 emission-outage trap
+  // (see emission-key-contextless-verify.regression).
+  return runWithMemexId(memexId, async () => {
+    // Resolve the spec doc. Unknown spec → fail quiet (std-7), record nothing.
+    const [doc] = await db
+      .select({ id: documents.id })
+      .from(documents)
+      .where(
+        and(
+          eq(documents.memexId, memexId),
+          eq(documents.handle, parsed.specHandle),
+          eq(documents.docType, "spec"),
+        ),
+      )
+      .limit(1);
+    if (!doc) return c.json({ recorded: false, reason: "spec_not_found" }, 200);
+
+    const actorUserId = hookKey.createdByUserId ?? null;
+    await recordCheckoutEdit({
+      memexId,
+      docId: doc.id,
+      threadUid,
+      changedPaths: body.changed_paths as string[],
+      commitSha: (body.commit_sha as string | undefined) ?? null,
+      branch: (body.branch as string | undefined) ?? null,
+      actorUserId,
+    });
+
+    // Reconcile checked_out_thread to the CONVERSATION UID (dec-12, ac-23). The
+    // server never sees the conversation UID on a raw MCP call (dec-3), so the hook
+    // carries it here as thread_uid; this is the join key for "return me to the
+    // conversation that worked on this spec". Only updates when this user currently
+    // holds the spec, so a stray report can't relabel another holder. Does NOT write
+    // presence — checkout is decoupled from the presence plane (dec-5).
+    if (actorUserId) {
+      await setCheckoutThread({ docId: doc.id, userId: actorUserId, thread: threadUid });
+    }
+
+    bumpHookKeyLastUsed(hookKey.id);
+
+    // RECORD-ONLY: a minimal ack, NO steering payload (dec-8).
+    return c.json({ recorded: true }, 201);
   });
-
-  // Reconcile checked_out_thread to the CONVERSATION UID (dec-12, ac-23). The
-  // server never sees the conversation UID on a raw MCP call (dec-3), so the hook
-  // carries it here as thread_uid; this is the join key for "return me to the
-  // conversation that worked on this spec". Only updates when this user currently
-  // holds the spec, so a stray report can't relabel another holder. Does NOT write
-  // presence — checkout is decoupled from the presence plane (dec-5).
-  if (actorUserId) {
-    await setCheckoutThread({ docId: doc.id, userId: actorUserId, thread: body.thread_uid });
-  }
-
-  bumpHookKeyLastUsed(hookKey.id);
-
-  // RECORD-ONLY: a minimal ack, NO steering payload (dec-8).
-  return c.json({ recorded: true }, 201);
 });
 
 export { specCheckoutRouter };


### PR DESCRIPTION
## The bug (found by the live int run — the proper test)

`POST /api/spec-checkout` (the checkout hook's phone-home) authenticates a hook key and resolves the tenant from the body `ref` — both on RLS-excluded tables, no context needed. It then reads the **`documents`** table to resolve the claimed spec's doc id. That read ran with **no `app.memex_id`** set.

`documents` has row-level security enabled (std-36). The dev `postgres` role is a **superuser → bypasses RLS**, so local tests pass. The Cloud Run runtime role `memex_app` is a **non-owner → subject to the policy**, so on int the contextless read returned **zero rows** → every phone-home resolved `spec_not_found` and **recorded nothing**. Same mask as the 2026-06-10 emission outage (`emission-key-contextless-verify.regression.test.ts`).

Verified live on int: mint succeeds (`201`), but every phone-home → `{recorded:false, reason:"spec_not_found"}` for all specs.

## The fix — add context, don't relax RLS

**No policy / migration / `FORCE` / `BYPASSRLS` / exclusion change.** The tenant is already known *and validated* at read time (the route enforces `memexId === hookKey.memexId` first), so the read + record are wrapped in `runWithMemexId(memexId, …)`, which sets `app.memex_id`. The **existing** `documents_memex_isolation` policy then admits exactly that memex's rows. RLS still filters per-row (defense in depth); the `app.memex_id` set is always the hook key's own validated memex.

This is different from the emission-keys fix (which *excluded* its table): emission keys is an identity-*establishment* table read before any tenant is known; `documents` is read *after* the tenant is known, so the correct move is to **set** the context.

## Test plan
- [x] New `spec-checkout-phonehome-rls.regression.test.ts` via the `SET LOCAL ROLE memex_app` harness: documents RLS is `ENABLE` (not FORCE, std-36); without `app.memex_id` the spec lookup returns **0 rows**; with it set, **exactly 1**. (If RLS were relaxed, the 0-rows assertion would fail — it passes, proving RLS still filters.)
- [x] Existing spec-checkout suite green; full server suite green (lone red is the known parallel-pollution migration-smoke flake, 13/13 in isolation); deploy gate (`pnpm build`) green; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)