### PR TITLE
feat(spec-371): task-sync steer — nudge the agent to keep Memex tasks honest after edits

### DIFF
--- a/packages/cli/plugin/hooks/edit-phonehome.mjs
+++ b/packages/cli/plugin/hooks/edit-phonehome.mjs
@@ -1,12 +1,14 @@
 #!/usr/bin/env node
-// spec-371 Hook B — the EDIT PHONE-HOME. A Claude Code PostToolUse hook matched to
-// file edits. It consults the local marker (the privacy gate, dec-2): only when
-// this thread is checked out does anything leave the machine. NOT checked out →
-// silence, no nudge (dec-8 rework). Non-blocking; never throws.
+// spec-371 Hook B: the EDIT hook. A Claude Code PostToolUse hook matched to file
+// edits. It consults the local marker (the privacy gate, dec-2): only when this
+// thread is CHECKED OUT does it (1) phone home to RECORD the edit and (2) STEER,
+// surfacing a short task-sync reminder to the model via additionalContext. NOT
+// checked out means fully silent: no network, no steer. Non-blocking; exits 0.
 //
-// What it ever sends: changed file paths + the checked-out spec ref + the git
-// commit/branch + the conversation UID. Never source code, never your prompts.
-import { decideEditAction } from "../lib/checkout-marker.js";
+// What it ever sends over the network: changed file paths + the checked-out spec
+// ref + git commit/branch + the conversation UID. Never source code, never prompts.
+// The steer is emitted LOCALLY on stdout, independent of the network call.
+import { decideEditAction, decideEditSteer } from "../lib/checkout-marker.js";
 import { readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
@@ -93,20 +95,35 @@ async function main() {
   if (!sessionId) return;
 
   const decision = decideEditAction(sessionId);
-  if (decision.action !== "phone-home") return; // not checked out → silent, no nudge
-  // 'phone-home': this thread is checked out → report the edit.
-  const cfg = loadConfig(decision.claim.memex);
-  if (!cfg) return; // no key planted → fail quiet, nothing leaves
+  if (decision.action !== "phone-home") return; // not checked out → silent: no network, no steer
   const paths = changedPaths(p);
-  if (paths.length === 0) return;
-  const cwd = p.cwd || process.cwd();
-  await phoneHome(cfg, {
-    ref: decision.claim.ref,
-    thread_uid: sessionId,
-    changed_paths: paths,
-    commit_sha: gitOut(cwd, ["rev-parse", "HEAD"]),
-    branch: gitOut(cwd, ["rev-parse", "--abbrev-ref", "HEAD"]),
-  });
+  if (paths.length === 0) return; // no file actually changed → nothing to report or steer
+
+  // (1) RECORD the edit (network). Best-effort; skipped silently if no key is planted.
+  const cfg = loadConfig(decision.claim.memex);
+  if (cfg) {
+    const cwd = p.cwd || process.cwd();
+    await phoneHome(cfg, {
+      ref: decision.claim.ref,
+      thread_uid: sessionId,
+      changed_paths: paths,
+      commit_sha: gitOut(cwd, ["rev-parse", "HEAD"]),
+      branch: gitOut(cwd, ["rev-parse", "--abbrev-ref", "HEAD"]),
+    });
+  }
+
+  // (2) STEER (spec-371): nudge the agent to keep task STATE in sync in Memex. Gated on
+  // the SAME checkout marker, rate-limited by NAG_MIN_INTERVAL_MS. Surfaced to the model
+  // as a PostToolUse system reminder (additionalContext) on its next turn — non-blocking,
+  // not a user-facing chat message. Last stdout write; the process then exits 0.
+  const steer = decideEditSteer(sessionId);
+  if (steer.nag) {
+    process.stdout.write(
+      JSON.stringify({
+        hookSpecificOutput: { hookEventName: "PostToolUse", additionalContext: steer.text },
+      }),
+    );
+  }
 }
 
 main().catch(() => {});

--- a/packages/cli/plugin/lib/checkout-marker.js
+++ b/packages/cli/plugin/lib/checkout-marker.js
@@ -24,6 +24,12 @@ import {
 // edit that phones home.
 export const DEFAULT_TTL_MS = 8 * 60 * 60 * 1000; // 8h of inactivity
 
+// The task-sync STEER cadence (spec-371). 0 = nag after EVERY edit (the v1 "simple
+// stick"). This is the single knob: raise it (e.g. 5 * 60 * 1000 for once-per-5min)
+// to throttle the nag with NO other code change — decideEditSteer reads it and the
+// per-session `lastNagAt` clock stamped in the marker enforces it.
+export const NAG_MIN_INTERVAL_MS = 0;
+
 // Default checkout dir: ~/.memex/checkouts. A claim's marker is <session_id>.json;
 // the once-per-session "you haven't claimed" nudge leaves a <session_id>.nudged
 // sentinel beside it. `opts.dir` / `opts.home` override for tests.
@@ -90,11 +96,29 @@ export function isExpired(marker, ttlMs = DEFAULT_TTL_MS, now = Date.now()) {
 }
 
 // Refresh a live marker's timestamp (called on each phoned-home edit) so an
-// actively-built spec never expires mid-session (dec-4).
+// actively-built spec never expires mid-session (dec-4). PRESERVES the lastNagAt
+// clock — activity refreshes the TTL but must not reset the steer's rate limiter.
 export function touchMarker(sessionId, opts = {}) {
   const m = readMarker(sessionId, opts);
   if (!m) return null;
-  return writeMarker(sessionId, { memex: m.memex, spec: m.spec }, opts);
+  const ts = opts.now ?? Date.now();
+  const next = { memex: m.memex, spec: m.spec, ts };
+  if (typeof m.lastNagAt === "number") next.lastNagAt = m.lastNagAt;
+  mkdirSync(checkoutDir(opts), { recursive: true });
+  writeFileSync(markerPathFor(sessionId, opts), JSON.stringify(next), "utf8");
+  return next;
+}
+
+// Stamp the task-sync steer clock (lastNagAt) for this session, preserving the
+// claim + activity ts. Called when decideEditSteer decides to nag, so the
+// NAG_MIN_INTERVAL_MS throttle has a per-session "last fired" to measure against.
+export function stampNag(sessionId, opts = {}) {
+  const m = readMarker(sessionId, opts);
+  if (!m) return null;
+  const next = { memex: m.memex, spec: m.spec, ts: m.ts, lastNagAt: opts.now ?? Date.now() };
+  mkdirSync(checkoutDir(opts), { recursive: true });
+  writeFileSync(markerPathFor(sessionId, opts), JSON.stringify(next), "utf8");
+  return next;
 }
 
 // The active claim for a session, or null when there is none OR it has expired.
@@ -105,21 +129,53 @@ export function resolveActiveClaim(sessionId, opts = {}) {
   return { memex: m.memex, spec: m.spec, ref: `${m.memex}/specs/${m.spec}` };
 }
 
-// Decide what the EDIT hook should do, given the session's marker state. PURE
-// logic — the privacy gate (dec-2), and NO nudge (dec-8 rework: the first-edit
-// nudge is removed; the only interruption anywhere is the server's collision
-// takeover, dec-11):
-//   - 'phone-home' : checked out (fresh marker) → report the edit, refresh the TTL.
-//   - 'silent'     : NOT checked out → do nothing, NO network call, no nudge.
+// Decide what the EDIT hook should do for PHONE-HOME, given the session's marker
+// state. The privacy gate (dec-2): only a fresh checkout marker lets anything leave
+// the machine.
+//   - 'phone-home' : checked out (fresh marker) -> report the edit, refresh the TTL.
+//   - 'silent'     : NOT checked out -> do nothing, NO network call.
 // The crucial invariant (ac-2 / ac-16): only 'phone-home' ever leaves the machine,
-// and a thread that isn't a Memex thread is simply silent.
+// and a thread that isn't a Memex thread is simply silent. The task-sync STEER is a
+// SEPARATE, additive layer (decideEditSteer) the hook applies on top, gated on the
+// SAME checkout marker, so it too is silent on a non-Memex thread.
 export function decideEditAction(sessionId, opts = {}) {
   const claim = resolveActiveClaim(sessionId, opts);
   if (claim) {
-    touchMarker(sessionId, opts); // refresh TTL on activity
+    touchMarker(sessionId, opts); // refresh TTL on activity (preserves lastNagAt)
     return { action: "phone-home", claim };
   }
   return { action: "silent" };
+}
+
+// The task-sync STEER text (spec-371). A short, CONDITIONAL nudge: it asks for a task
+// state change ONLY when the edit is a state transition, and explicitly licenses doing
+// nothing on a mid-task edit, so a task that legitimately spans many edits is never
+// updated prematurely. Kept plain (no em dashes / arrows) for the model's reminder.
+export function nagText(spec) {
+  return (
+    `${spec} is checked out in this session. Keep Memex in sync with what this edit means: ` +
+    `if it COMPLETED a task, mark that task done with update_task; ` +
+    `if it STARTED a task you have picked up, mark that task in progress; ` +
+    `if it began work that no task covers yet, create the task with create_task. ` +
+    `If it is just a mid-task edit, no update is needed: keep going.`
+  );
+}
+
+// The task-sync STEER decision (spec-371): on an edit in a CHECKED-OUT session, decide
+// whether to nudge the agent to reflect task STATE in Memex. Gated on the checkout
+// marker (nothing is surfaced on a non-Memex thread, dec-2) and rate-limited by
+// NAG_MIN_INTERVAL_MS via the per-session lastNagAt clock. Stamps the clock when it
+// fires. Returns { nag: false } or { nag: true, text }.
+export function decideEditSteer(sessionId, opts = {}) {
+  const claim = resolveActiveClaim(sessionId, opts);
+  if (!claim) return { nag: false }; // not checked out -> no steer (privacy gate, dec-2)
+  const now = opts.now ?? Date.now();
+  const interval = opts.nagIntervalMs ?? NAG_MIN_INTERVAL_MS;
+  const m = readMarker(sessionId, opts);
+  const last = typeof m?.lastNagAt === "number" ? m.lastNagAt : 0;
+  if (last && now - last < interval) return { nag: false }; // throttled by the cadence knob
+  stampNag(sessionId, opts);
+  return { nag: true, text: nagText(claim.spec) };
 }
 
 // Parse a Memex MCP tool_input `ref` into { memex: "ns/slug", spec: "spec-N", ref }

--- a/packages/cli/test/checkout-marker.test.js
+++ b/packages/cli/test/checkout-marker.test.js
@@ -10,9 +10,11 @@ import {
   isExpired,
   resolveActiveClaim,
   decideEditAction,
+  decideEditSteer,
   decideMarkerAction,
   parseSpecRef,
   DEFAULT_TTL_MS,
+  NAG_MIN_INTERVAL_MS,
 } from "../plugin/lib/checkout-marker.js";
 
 // spec-371 t-11 — the client-side marker logic (the privacy gate; no nudge), pure.
@@ -134,5 +136,44 @@ describe("decideMarkerAction: arm on any successful spec mutation, not on a fail
     expect(decideMarkerAction(ev("mcp__memex__create_decision", "ns/m/specs/spec-1", collision)).action).toBe(
       "skip",
     );
+  });
+});
+
+// The task-sync STEER: a short, CONDITIONAL nag emitted after a file edit in a
+// CHECKED-OUT session, nudging the agent to keep task STATE honest in Memex.
+// NOTE: this is new behavior that reverses the rework's "no nudge" stance for the
+// checked-out case. It needs a dedicated decision + AC on spec-371; tagging is
+// deferred until that AC exists (so this suite doesn't emit a phantom AC to prod).
+describe("task-sync steer: conditional nag on a checked-out edit (spec-371, AC pending)", () => {
+  it("no checkout → no steer (the privacy gate gates the nag too)", () => {
+    expect(decideEditSteer("none", o()).nag).toBe(false);
+  });
+
+  it("a checked-out edit → a conditional nag naming the spec + all three task-state moves, plus the no-op license", () => {
+    writeMarker("s", { memex: "ns/m", spec: "spec-371" }, o({ now: 1000 }));
+    const r = decideEditSteer("s", o({ now: 1001 }));
+    expect(r.nag).toBe(true);
+    expect(r.text).toContain("spec-371");
+    expect(r.text).toContain("update_task"); // completed a task → done
+    expect(r.text).toContain("in progress"); // started a picked-up task → in progress
+    expect(r.text).toContain("create_task"); // untracked work → create the task
+    expect(r.text).toMatch(/no update is needed/i); // mid-task edit → explicitly no premature update
+  });
+
+  it("ships as the simple stick (every edit) but is throttle-ready: NAG_MIN_INTERVAL_MS + lastNagAt", () => {
+    expect(NAG_MIN_INTERVAL_MS).toBe(0); // v1 default: nag after every edit
+    writeMarker("t", { memex: "ns/m", spec: "spec-9" }, o({ now: 0 }));
+    // simulate a throttle window via opts.nagIntervalMs (the constant in prod)
+    expect(decideEditSteer("t", o({ now: 100, nagIntervalMs: 1000 })).nag).toBe(true); // first → nag + stamp
+    expect(decideEditSteer("t", o({ now: 200, nagIntervalMs: 1000 })).nag).toBe(false); // within window → throttled
+    expect(decideEditSteer("t", o({ now: 1200, nagIntervalMs: 1000 })).nag).toBe(true); // past window → nag again
+  });
+
+  it("edit activity preserves the nag clock — the throttle survives intervening edits", () => {
+    writeMarker("p", { memex: "ns/m", spec: "spec-9" }, o({ now: 0 }));
+    decideEditSteer("p", o({ now: 100, nagIntervalMs: 10000 })); // stamps lastNagAt=100
+    decideEditAction("p", o({ now: 500 })); // a later edit refreshes TTL (touch) but must NOT reset the nag clock
+    expect(readMarker("p", o()).lastNagAt).toBe(100); // preserved across touch
+    expect(decideEditSteer("p", o({ now: 600, nagIntervalMs: 10000 })).nag).toBe(false); // still throttled
   });
 });

--- a/packages/cli/test/hooks-e2e.test.js
+++ b/packages/cli/test/hooks-e2e.test.js
@@ -90,11 +90,12 @@ describe("spec-371 hooks e2e (ac-7, ac-9, ac-10, ac-12, ac-15)", () => {
     });
   });
 
-  it("edit hook: no checkout → SILENT, no nudge, nothing leaves (ac-10, ac-16)", () => {
+  it("edit hook: no checkout → SILENT — no steer, no network, nothing leaves (ac-10, ac-16)", () => {
     tagAc(AC_10);
     tagAc(AC_16);
     withHome((home) => {
-      // An unchecked-out thread editing files emits NOTHING — no nudge, no network.
+      // An unchecked-out thread editing files emits NOTHING — the steer is gated off
+      // by the same checkout marker, so there's no nudge and no network.
       const out = run("edit-phonehome.mjs", {
         session_id: "u",
         tool_name: "Edit",
@@ -107,7 +108,7 @@ describe("spec-371 hooks e2e (ac-7, ac-9, ac-10, ac-12, ac-15)", () => {
     });
   });
 
-  it("edit hook: a claim with no key planted fails quiet — nothing leaves (ac-10)", () => {
+  it("edit hook: a CHECKED-OUT edit emits the task-sync STEER (additionalContext), non-blocking, even with no key (the steer is local, key-independent) (ac-10)", () => {
     tagAc(AC_10);
     withHome((home) => {
       run("marker-write.mjs", {
@@ -115,14 +116,24 @@ describe("spec-371 hooks e2e (ac-7, ac-9, ac-10, ac-12, ac-15)", () => {
         tool_name: "mcp__memex__claim_spec",
         tool_input: { ref: "ns/m/specs/spec-371" },
       }, home);
-      // claimed, but no ~/.memex/checkout.json and no env key → no phone-home, no output.
+      // No ~/.memex/checkout.json + no env key → the phone-home (network) is skipped,
+      // but the STEER is emitted locally on stdout — it does not depend on the key.
       const out = run("edit-phonehome.mjs", {
         session_id: "c",
         tool_name: "Edit",
         tool_input: { file_path: "/x/y.ts" },
         cwd: home,
       }, home);
-      expect(out.trim()).toBe("");
+      const parsed = JSON.parse(out);
+      expect(parsed.hookSpecificOutput.hookEventName).toBe("PostToolUse");
+      const ctx = parsed.hookSpecificOutput.additionalContext;
+      expect(ctx).toContain("spec-371");
+      expect(ctx).toContain("update_task");
+      expect(ctx).toContain("create_task");
+      expect(ctx).toMatch(/no update is needed/i); // never forces a premature update
+      // non-blocking: it never denies/blocks the edit.
+      expect(out).not.toMatch(/"decision"\s*:\s*"block"/);
+      expect(out).not.toMatch(/"permissionDecision"\s*:\s*"deny"/);
     });
   });
 


### PR DESCRIPTION
## Why

The checkout hook became telemetry-only in the rework (it records edits, emits no steer). Its **actual purpose is steering**: after a file edit in a checked-out session, nudge the agent to keep **task state** honest in Memex — the task-sync-while-you-work failure point everything hinges on.

## What

`edit-phonehome.mjs`, when (and only when) the session is **checked out**, emits a PostToolUse `additionalContext` reminder. The model sees it as a system reminder on its next turn; it's **non-blocking** and **not** a user chat message.

The nag is **conditional by design** — it asks for a task-state change *only* when the edit is a transition, and explicitly licenses doing nothing otherwise:
> `<spec> is checked out in this session. Keep Memex in sync with what this edit means: if it COMPLETED a task, mark that task done with update_task; if it STARTED a task you have picked up, mark that task in progress; if it began work that no task covers yet, create the task with create_task. If it is just a mid-task edit, no update is needed: keep going.`

This avoids the premature-update trap: a task that legitimately spans many edits is never flagged done early.

## Guarantees
- **Privacy gate preserved (dec-2):** gated on the *same* checkout marker as the phone-home. Unchecked-out / non-Memex thread → fully silent (no steer, no network). Proven by test.
- **Client-side + key-independent:** the steer fires from the local marker even with no phone-home key; it does **not** reverse `dec-8` (the phone-home response stays record-only).
- **Throttle-ready, one knob:** `NAG_MIN_INTERVAL_MS` (default `0` = every edit, the v1 "simple stick") + a per-session `lastNagAt` clock preserved across edit activity. Raising the constant throttles with no other change.
- **Mechanism verified** against the Claude Code hooks docs: `hookSpecificOutput.additionalContext`, exit 0, model-visible.

## Tests
- `decideEditSteer`: not-checked-out → no steer; checked-out → conditional nag naming the spec + all three moves + the no-op license; throttle via `NAG_MIN_INTERVAL_MS`/`lastNagAt`; clock preserved across `touchMarker`.
- hooks e2e: a real `node` run of the hook emits the steer JSON when checked out (even with no key), silent when not, never blocks. Full CLI suite green (66), lint clean.

## ⚠️ Spec follow-up (SDD)
This **reverses the rework's "no nudge" stance for the checked-out case** and needs a dedicated **decision + AC on spec-371**. The new tests are written but **tagging is deferred** until that AC exists (so this suite doesn't emit a phantom AC to prod). I'm currently on the int MCP and can't author the prod-spec AC from here — flagging for formalization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)