### PR TITLE
spec-421 issue-3: fix duplicated subtitle on "Create your first spec" step

### DIFF
--- a/packages/ui/src/components/home/CreateFirstSpecStep.test.tsx
+++ b/packages/ui/src/components/home/CreateFirstSpecStep.test.tsx
@@ -122,6 +122,17 @@ describe('CreateFirstSpecStep — spec-421 step 3', () => {
     expect(badge.className).toContain('rounded-full');
   });
 
+  it('ac-26: the content-area subtitle is the create-spec copy, not the MCP-step subtitle (issue-3)', () => {
+    // issue-3 — the content panel duplicated the "Connect to the Memex MCP" subtitle.
+    // The create-spec step must show its own subtitle and NOT the MCP one.
+    tagAc(AC421(26));
+    const { container } = render(<CreateFirstSpecStep preview />);
+    expect(container.textContent).toContain(
+      'Draft your first spec with your coding agent, or create it here in the app.',
+    );
+    expect(container.textContent).not.toContain('Get the full magic of Memex by connecting to the MCP');
+  });
+
   it('ac-11: no method selector or starting-point selector', () => {
     tagAc(AC421(11));
     render(<CreateFirstSpecStep preview />);

--- a/packages/ui/src/components/home/CreateFirstSpecStep.tsx
+++ b/packages/ui/src/components/home/CreateFirstSpecStep.tsx
@@ -85,7 +85,7 @@ export function CreateFirstSpecStep({
       ) : (
         <>
           <p className="mb-8 text-xl font-medium leading-snug text-primary">
-            Get the full magic of Memex by connecting to the MCP and using it in your Agent
+            Draft your first spec with your coding agent, or create it here in the app.
           </p>
 
           {/* Primary CTA — opens New Spec dialog on the Specs page via ?new=1 (dec-4). */}


### PR DESCRIPTION
## What

Fixes **[spec-421](https://memex.ai/mindset-prod/memex-building-itself/specs/spec-421) / issue-3**: the **content-panel** subtitle on the "Create your first spec" onboarding step was a duplicate of the "Connect to the Memex MCP" step's subtitle.

- **Before:** _"Get the full magic of Memex by connecting to the MCP and using it in your Agent"_ (the MCP step's copy)
- **After:** _"Draft your first spec with your coding agent, or create it here in the app."_

The **rail** subtitle for this step was already correct and is **untouched**. Only the content-area `<p>` in `CreateFirstSpecStep.tsx` changed.

The new copy offers both the coding-agent path and the in-app path — honest-CTA compliant ([per std-34], no MCP-only instruction).

## Test

Adds a unit test tagged to **ac-26** in `CreateFirstSpecStep.test.tsx` asserting the create-spec step shows its own subtitle and **not** the MCP one. Verified red→green locally (fails on the old duplicated copy, passes with the fix).

## Verification

- ✅ Unit: `CreateFirstSpecStep` / `CreateSpecStep` / `onboarding-copy.spec-372` suites green (26 tests); ac-26 proven red→green
- ✅ `tsc --noEmit` clean (packages/ui)
- ✅ Biome clean on changed files
- ✅ No b-105 banned vocab in the diff
- ✅ `make e2e-cold`: 115 passed; the one failure (`journey-45-spec-304-mcp-session-mint`, unrelated desktop-shell MCP row) is the known flaky journey — passes 2/2 on isolated re-run

> Note: ac-26 flips green on the board once the tagged UI suite is run with an emission key (left to the spec owner per our AC-emission policy). The issue then auto-resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)