### PR TITLE
fix(facets): make the facet ballot optional on resolve_decision + create_task

### DIFF
--- a/packages/server/src/__smoke__/authed.smoke.test.ts
+++ b/packages/server/src/__smoke__/authed.smoke.test.ts
@@ -310,7 +310,9 @@ describe.skipIf(!SMOKE_MCP_TOKEN)(
       await callMcpTool("update_doc", { ref: docRef!, status: "specify" });
       await callMcpTool("update_doc", { ref: docRef!, status: "build" });
 
-      // CREATE the deletable entity — a task on the throwaway doc.
+      // CREATE the deletable entity — a task on the throwaway doc. Intentionally sends NO
+      // facetBallot: this verifies the relaxed, optional-ballot behaviour (a client that
+      // omits the ballot must still succeed, never error). Do not "fix" by adding a ballot.
       const taskRes = await callMcpTool("create_task", {
         ref: docRef!,
         title: "smoke throwaway task",

--- a/packages/server/src/agent/facet-consume-handlers.integration.test.ts
+++ b/packages/server/src/agent/facet-consume-handlers.integration.test.ts
@@ -85,13 +85,17 @@ afterAll(async () => {
 
 const fullBallot = { verdict: { "xc-security": true, "xc-perf": false }, none: false };
 
-describe("create_task forces a ballot and hands back the governing standards (spec-423 t-5, dec-5)", () => {
-  it("rejects a missing/incomplete ballot with the vocabulary re-handed (ac-13, ac-2)", async () => {
+describe("create_task accepts an OPTIONAL facet ballot and hands back the governing standards (spec-423 t-5, dec-5; ballot relaxed to optional)", () => {
+  it("tolerates a MISSING ballot (relaxed) but still rejects a present-but-incomplete one, re-handing the vocabulary (ac-13, ac-2)", async () => {
     tagAc(AC(13));
-    tagAc(AC(2)); // scope: both tools force a ballot; empty/contradictory rejected + re-handed
-    await expect(
-      executeServerTool(memexId, "create_task", { ref: specRef, title: "no ballot", description: "x" }, userId),
-    ).rejects.toThrow(/xc-security/);
+    // NOTE: the ballot was relaxed from FORCED to OPTIONAL so clients on an older tool
+    // signature (no facetBallot param) don't error. ac-2/ac-13 still describe the OLD
+    // "forced" behaviour and need their statements relaxed on spec-423 (facets-team follow-up).
+    tagAc(AC(2));
+    // MISSING ballot → no longer an error: the task is created without facet adjudication.
+    const created = await executeServerTool(memexId, "create_task", { ref: specRef, title: "no ballot", description: "x" }, userId);
+    expect(created).toMatch(/ref:\s/);
+    // A PRESENT but incomplete ballot is STILL rejected, re-handing the missing facet.
     await expect(
       executeServerTool(
         memexId,
@@ -125,15 +129,19 @@ describe("create_task forces a ballot and hands back the governing standards (sp
   });
 });
 
-describe("resolve_decision forces a ballot and stores it work-side (spec-423 t-5, dec-6)", () => {
-  it("rejects a missing ballot, then accepts a complete one and stores it in decision_facet_ballots (ac-14, ac-5)", async () => {
+describe("resolve_decision accepts an OPTIONAL facet ballot and stores it work-side (spec-423 t-5, dec-6; ballot relaxed to optional)", () => {
+  it("tolerates a missing ballot (relaxed), then accepts a complete one and stores it in decision_facet_ballots (ac-14, ac-5)", async () => {
     tagAc(AC(14));
-    tagAc(AC(5)); // scope: decisions route to standards (work-side), never as binding precedent
+    tagAc(AC(5)); // ballot relaxed to optional (see create_task note); ac-5/ac-14 statements need relaxing on spec-423 (facets-team follow-up)
     const decRef = `${nsSlug}/main/specs/spec-1/decisions/dec-1`;
-    await expect(
-      executeServerTool(memexId, "resolve_decision", { ref: decRef, resolution: "done" }, userId),
-    ).rejects.toThrow(/xc-security/);
+    // MISSING ballot → resolves WITHOUT error, recording no ballot (no facet adjudication).
+    const first = await executeServerTool(memexId, "resolve_decision", { ref: decRef, resolution: "done" }, userId);
+    expect(first).toContain("resolved");
+    expect(
+      await db.select().from(decisionFacetBallots).where(eq(decisionFacetBallots.decisionId, decisionId)),
+    ).toHaveLength(0);
 
+    // Re-resolving WITH a complete ballot validates + stores it and appends the readout.
     const out = await executeServerTool(
       memexId,
       "resolve_decision",

--- a/packages/server/src/agent/handlers/decisions.ts
+++ b/packages/server/src/agent/handlers/decisions.ts
@@ -341,7 +341,7 @@ export const decisionsTools: ToolSpec[] = [
         })
         .optional()
         .describe(
-          "The facets this decision's work touches (dec-5). A complete verdict over the Memex's facet vocabulary; the response hands back the governing standards to keep top-of-mind.",
+          "The facets this decision's work touches: a complete verdict over the Memex's facet vocabulary, which surfaces the standards governing that work so they stay top-of-mind. First call the `facets` tool (verb:'list') to read the vocabulary, then pass a true/false verdict for EVERY facet, or none:true for honest no-facet work.",
         ),
       verbose: VERBOSE_FIELD,
     },
@@ -357,25 +357,32 @@ export const decisionsTools: ToolSpec[] = [
         );
       }
       const { memexId, doc, slugs, entity } = resolved;
-      // Validate the ballot BEFORE resolving, so a rejected ballot re-hands the
-      // vocabulary without mutating the decision (dec-5).
+      // FACET BALLOT — OPTIONAL (relaxed from spec-423 dec-5's forced ballot). A client
+      // on an OLDER tool signature — e.g. an MCP client that hasn't reloaded since the
+      // facets release, so it has no `facetBallot` param to send — must NOT hit an error.
+      // So: ABSENT ballot → resolve WITHOUT facet adjudication; PROVIDED ballot → validate
+      // strictly BEFORE resolving (re-hand the vocabulary on an invalid one) and store it.
+      // Re-tightening to a forced ballot is a later, deliberate step.
+      const hasBallot = input.facetBallot !== undefined;
       const ballot = parseBallotArg(input.facetBallot);
-      const vocab = await validateBallotForMemex(memexId, ballot);
+      const vocab = hasBallot ? await validateBallotForMemex(memexId, ballot) : [];
       const decision = await resolveDecision(memexId, entity.row.id, resolution, chosenOptionIndex, reqCtx(ctx));
       const decRef = buildChildRef(slugs, doc, { type: "decisions", seq: decision.seq });
-      // Store the ballot (work-side, dec-6), route + rank, log, and build the payoff
-      // readout appended to the response.
-      const readout = await storeRouteAndReadout({
-        memexId,
-        specDocId: decision.docId,
-        noun: "decision",
-        rowId: entity.row.id,
-        ownerRef: decRef,
-        queryText: `${decision.title}\n${decision.resolution ?? resolution ?? ""}`,
-        ballot,
-        vocab,
-        ctx: reqCtx(ctx),
-      });
+      // Store + route the ballot only when one was provided (work-side, dec-6); an absent
+      // ballot contributes no facet routing, so the readout is empty.
+      const readout = hasBallot
+        ? await storeRouteAndReadout({
+            memexId,
+            specDocId: decision.docId,
+            noun: "decision",
+            rowId: entity.row.id,
+            ownerRef: decRef,
+            queryText: `${decision.title}\n${decision.resolution ?? resolution ?? ""}`,
+            ballot,
+            vocab,
+            ctx: reqCtx(ctx),
+          })
+        : "";
       if (ctx.verbose) {
         const state = await fullDocState(memexId, decision.docId);
         const url = await ctx.workspaceUrl(memexId);

--- a/packages/server/src/agent/handlers/tasks.ts
+++ b/packages/server/src/agent/handlers/tasks.ts
@@ -153,7 +153,7 @@ export const tasksTools: ToolSpec[] = [
         })
         .optional()
         .describe(
-          "The facets this work touches (dec-5). A complete verdict over the Memex's facet vocabulary; the response hands back the governing standards to keep top-of-mind.",
+          "The facets this work touches: a complete verdict over the Memex's facet vocabulary, which surfaces the standards governing that work so they stay top-of-mind. First call the `facets` tool (verb:'list') to read the vocabulary, then pass a true/false verdict for EVERY facet, or none:true for honest no-facet work.",
         ),
       verbose: VERBOSE_FIELD,
     },
@@ -173,10 +173,15 @@ export const tasksTools: ToolSpec[] = [
         );
       }
       const { memexId, doc, slugs } = resolved;
-      // Validate the ballot BEFORE creating the task, so a rejected ballot (re-handing
-      // the vocabulary) never leaves an orphan task behind (dec-5).
+      // FACET BALLOT — OPTIONAL (relaxed from spec-423 dec-5's forced ballot). A client
+      // on an OLDER tool signature — no facetBallot param (e.g. an MCP client that hasn't
+      // reloaded since the facets release) — must NOT hit an error. So: ABSENT ballot →
+      // create the task WITHOUT facet adjudication; PROVIDED ballot → validate strictly
+      // BEFORE creating (re-hand the vocabulary on an invalid one, so no orphan task is
+      // left behind) and store it. Re-tightening to a forced ballot is a later step.
+      const hasBallot = input.facetBallot !== undefined;
       const ballot = parseBallotArg(input.facetBallot);
-      const vocab = await validateBallotForMemex(memexId, ballot);
+      const vocab = hasBallot ? await validateBallotForMemex(memexId, ballot) : [];
       const task = await createTask(
         memexId,
         doc.id,
@@ -187,19 +192,21 @@ export const tasksTools: ToolSpec[] = [
         reqCtx(ctx),
       );
       const taskRef = buildChildRef(slugs, doc, { type: "tasks", seq: task.seq });
-      // Store the ballot, route + rank its facets, log the decision, and append the
-      // top-K governing-standards readout — the payoff (dec-1/dec-2/dec-4).
-      const readout = await storeRouteAndReadout({
-        memexId,
-        specDocId: doc.id,
-        noun: "task",
-        rowId: task.id,
-        ownerRef: taskRef,
-        queryText: `${title}\n${description}`,
-        ballot,
-        vocab,
-        ctx: reqCtx(ctx),
-      });
+      // Store + route the ballot only when one was provided (the top-K governing-standards
+      // readout is its payoff); an absent ballot contributes no facet routing.
+      const readout = hasBallot
+        ? await storeRouteAndReadout({
+            memexId,
+            specDocId: doc.id,
+            noun: "task",
+            rowId: task.id,
+            ownerRef: taskRef,
+            queryText: `${title}\n${description}`,
+            ballot,
+            vocab,
+            ctx: reqCtx(ctx),
+          })
+        : "";
       if (ctx.verbose) {
         const state = await fullDocState(memexId, doc.id);
         const url = await ctx.workspaceUrl(memexId);


### PR DESCRIPTION
## Why (prod-impacting)

The facets feature (spec-423) made `facetBallot` a **required, server-enforced** input on `resolve_decision` and `create_task`. MCP clients **cache the tool schema at connect time**, and we can't force every user to reload — so any client connected **before** the facets release sends no ballot and hits a **hard error**. Colleagues are hitting this on `resolve_decision`; it also reddened the post-deploy smoke (`create_task` with no ballot).

Priority for now: **users must not encounter errors.** Strict adjudication can be re-tightened later, deliberately.

## Changes

**Server (the fix)** — in both handlers, an **absent** `facetBallot` now **skips** validation + storage and proceeds (no error, no facet adjudication); a **provided** ballot is still **validated strictly** (re-hands the vocabulary on an invalid/incomplete one) and stored. The validator (`facet-ballot.ts`) is unchanged. The Zod `facetBallot` stays `.optional()` so an absent ballot reaches the lenient handler rather than failing schema validation.

**Descriptions** — rewrote the `facetBallot` param description on both tools as a clear **directive that still elicits a ballot** from capable/reloaded clients: it names the `facets` tool (`verb:'list'`) to source the vocabulary and asks for a complete verdict or `none:true`. Dropped the internal `(dec-5)` ref (meaningless to a client). Leniency is a **silent safety net, not advertised** as optional.

**Smoke** — the ballot-less `create_task` journey now passes via the leniency (no edit); added a comment so it isn't "fixed" by re-adding a ballot — it now intentionally verifies the leniency.

**Tests** — flipped the two `facet-consume-handlers` assertions from missing-ballot→rejects to **missing-ballot→succeeds** (present-but-incomplete still rejects).

## Verification
- Full server suite: green (the run with these changes had only the 2 facet assertions to flip; both fixed + re-confirmed green). Deploy gate (`pnpm build`) green. Lint clean.

## ⚠ Follow-up (facets team, separate)
spec-423's ballot ACs (`ac-2`/`ac-5`/`ac-13`/`ac-14`) still describe the **old "forced ballot"** behaviour. Their statements should be relaxed in Memex, and the test tags reconciled. Left out of this PR to keep it tight. The broader internal-ref noise in these tool descriptions (`(spec-247 dec-5)`, etc.) was also deliberately left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)