### PR TITLE
Release: develop → main (facet-ballot-optional fix #410 + accumulated develop)

### DIFF
--- a/packages/server/src/__smoke__/authed.smoke.test.ts
+++ b/packages/server/src/__smoke__/authed.smoke.test.ts
@@ -310,7 +310,9 @@ describe.skipIf(!SMOKE_MCP_TOKEN)(
       await callMcpTool("update_doc", { ref: docRef!, status: "specify" });
       await callMcpTool("update_doc", { ref: docRef!, status: "build" });
 
-      // CREATE the deletable entity — a task on the throwaway doc.
+      // CREATE the deletable entity — a task on the throwaway doc. Intentionally sends NO
+      // facetBallot: this verifies the relaxed, optional-ballot behaviour (a client that
+      // omits the ballot must still succeed, never error). Do not "fix" by adding a ballot.
       const taskRes = await callMcpTool("create_task", {
         ref: docRef!,
         title: "smoke throwaway task",

--- a/packages/server/src/agent/facet-consume-handlers.integration.test.ts
+++ b/packages/server/src/agent/facet-consume-handlers.integration.test.ts
@@ -85,13 +85,17 @@ afterAll(async () => {
 
 const fullBallot = { verdict: { "xc-security": true, "xc-perf": false }, none: false };
 
-describe("create_task forces a ballot and hands back the governing standards (spec-423 t-5, dec-5)", () => {
-  it("rejects a missing/incomplete ballot with the vocabulary re-handed (ac-13, ac-2)", async () => {
+describe("create_task accepts an OPTIONAL facet ballot and hands back the governing standards (spec-423 t-5, dec-5; ballot relaxed to optional)", () => {
+  it("tolerates a MISSING ballot (relaxed) but still rejects a present-but-incomplete one, re-handing the vocabulary (ac-13, ac-2)", async () => {
     tagAc(AC(13));
-    tagAc(AC(2)); // scope: both tools force a ballot; empty/contradictory rejected + re-handed
-    await expect(
-      executeServerTool(memexId, "create_task", { ref: specRef, title: "no ballot", description: "x" }, userId),
-    ).rejects.toThrow(/xc-security/);
+    // NOTE: the ballot was relaxed from FORCED to OPTIONAL so clients on an older tool
+    // signature (no facetBallot param) don't error. ac-2/ac-13 still describe the OLD
+    // "forced" behaviour and need their statements relaxed on spec-423 (facets-team follow-up).
+    tagAc(AC(2));
+    // MISSING ballot → no longer an error: the task is created without facet adjudication.
+    const created = await executeServerTool(memexId, "create_task", { ref: specRef, title: "no ballot", description: "x" }, userId);
+    expect(created).toMatch(/ref:\s/);
+    // A PRESENT but incomplete ballot is STILL rejected, re-handing the missing facet.
     await expect(
       executeServerTool(
         memexId,
@@ -125,15 +129,19 @@ describe("create_task forces a ballot and hands back the governing standards (sp
   });
 });
 
-describe("resolve_decision forces a ballot and stores it work-side (spec-423 t-5, dec-6)", () => {
-  it("rejects a missing ballot, then accepts a complete one and stores it in decision_facet_ballots (ac-14, ac-5)", async () => {
+describe("resolve_decision accepts an OPTIONAL facet ballot and stores it work-side (spec-423 t-5, dec-6; ballot relaxed to optional)", () => {
+  it("tolerates a missing ballot (relaxed), then accepts a complete one and stores it in decision_facet_ballots (ac-14, ac-5)", async () => {
     tagAc(AC(14));
-    tagAc(AC(5)); // scope: decisions route to standards (work-side), never as binding precedent
+    tagAc(AC(5)); // ballot relaxed to optional (see create_task note); ac-5/ac-14 statements need relaxing on spec-423 (facets-team follow-up)
     const decRef = `${nsSlug}/main/specs/spec-1/decisions/dec-1`;
-    await expect(
-      executeServerTool(memexId, "resolve_decision", { ref: decRef, resolution: "done" }, userId),
-    ).rejects.toThrow(/xc-security/);
+    // MISSING ballot → resolves WITHOUT error, recording no ballot (no facet adjudication).
+    const first = await executeServerTool(memexId, "resolve_decision", { ref: decRef, resolution: "done" }, userId);
+    expect(first).toContain("resolved");
+    expect(
+      await db.select().from(decisionFacetBallots).where(eq(decisionFacetBallots.decisionId, decisionId)),
+    ).toHaveLength(0);
 
+    // Re-resolving WITH a complete ballot validates + stores it and appends the readout.
     const out = await executeServerTool(
       memexId,
       "resolve_decision",

--- a/packages/server/src/agent/handlers/decisions.ts
+++ b/packages/server/src/agent/handlers/decisions.ts
@@ -341,7 +341,7 @@ export const decisionsTools: ToolSpec[] = [
         })
         .optional()
         .describe(
-          "The facets this decision's work touches (dec-5). A complete verdict over the Memex's facet vocabulary; the response hands back the governing standards to keep top-of-mind.",
+          "The facets this decision's work touches: a complete verdict over the Memex's facet vocabulary, which surfaces the standards governing that work so they stay top-of-mind. First call the `facets` tool (verb:'list') to read the vocabulary, then pass a true/false verdict for EVERY facet, or none:true for honest no-facet work.",
         ),
       verbose: VERBOSE_FIELD,
     },
@@ -357,25 +357,32 @@ export const decisionsTools: ToolSpec[] = [
         );
       }
       const { memexId, doc, slugs, entity } = resolved;
-      // Validate the ballot BEFORE resolving, so a rejected ballot re-hands the
-      // vocabulary without mutating the decision (dec-5).
+      // FACET BALLOT — OPTIONAL (relaxed from spec-423 dec-5's forced ballot). A client
+      // on an OLDER tool signature — e.g. an MCP client that hasn't reloaded since the
+      // facets release, so it has no `facetBallot` param to send — must NOT hit an error.
+      // So: ABSENT ballot → resolve WITHOUT facet adjudication; PROVIDED ballot → validate
+      // strictly BEFORE resolving (re-hand the vocabulary on an invalid one) and store it.
+      // Re-tightening to a forced ballot is a later, deliberate step.
+      const hasBallot = input.facetBallot !== undefined;
       const ballot = parseBallotArg(input.facetBallot);
-      const vocab = await validateBallotForMemex(memexId, ballot);
+      const vocab = hasBallot ? await validateBallotForMemex(memexId, ballot) : [];
       const decision = await resolveDecision(memexId, entity.row.id, resolution, chosenOptionIndex, reqCtx(ctx));
       const decRef = buildChildRef(slugs, doc, { type: "decisions", seq: decision.seq });
-      // Store the ballot (work-side, dec-6), route + rank, log, and build the payoff
-      // readout appended to the response.
-      const readout = await storeRouteAndReadout({
-        memexId,
-        specDocId: decision.docId,
-        noun: "decision",
-        rowId: entity.row.id,
-        ownerRef: decRef,
-        queryText: `${decision.title}\n${decision.resolution ?? resolution ?? ""}`,
-        ballot,
-        vocab,
-        ctx: reqCtx(ctx),
-      });
+      // Store + route the ballot only when one was provided (work-side, dec-6); an absent
+      // ballot contributes no facet routing, so the readout is empty.
+      const readout = hasBallot
+        ? await storeRouteAndReadout({
+            memexId,
+            specDocId: decision.docId,
+            noun: "decision",
+            rowId: entity.row.id,
+            ownerRef: decRef,
+            queryText: `${decision.title}\n${decision.resolution ?? resolution ?? ""}`,
+            ballot,
+            vocab,
+            ctx: reqCtx(ctx),
+          })
+        : "";
       if (ctx.verbose) {
         const state = await fullDocState(memexId, decision.docId);
         const url = await ctx.workspaceUrl(memexId);

--- a/packages/server/src/agent/handlers/tasks.ts
+++ b/packages/server/src/agent/handlers/tasks.ts
@@ -153,7 +153,7 @@ export const tasksTools: ToolSpec[] = [
         })
         .optional()
         .describe(
-          "The facets this work touches (dec-5). A complete verdict over the Memex's facet vocabulary; the response hands back the governing standards to keep top-of-mind.",
+          "The facets this work touches: a complete verdict over the Memex's facet vocabulary, which surfaces the standards governing that work so they stay top-of-mind. First call the `facets` tool (verb:'list') to read the vocabulary, then pass a true/false verdict for EVERY facet, or none:true for honest no-facet work.",
         ),
       verbose: VERBOSE_FIELD,
     },
@@ -173,10 +173,15 @@ export const tasksTools: ToolSpec[] = [
         );
       }
       const { memexId, doc, slugs } = resolved;
-      // Validate the ballot BEFORE creating the task, so a rejected ballot (re-handing
-      // the vocabulary) never leaves an orphan task behind (dec-5).
+      // FACET BALLOT — OPTIONAL (relaxed from spec-423 dec-5's forced ballot). A client
+      // on an OLDER tool signature — no facetBallot param (e.g. an MCP client that hasn't
+      // reloaded since the facets release) — must NOT hit an error. So: ABSENT ballot →
+      // create the task WITHOUT facet adjudication; PROVIDED ballot → validate strictly
+      // BEFORE creating (re-hand the vocabulary on an invalid one, so no orphan task is
+      // left behind) and store it. Re-tightening to a forced ballot is a later step.
+      const hasBallot = input.facetBallot !== undefined;
       const ballot = parseBallotArg(input.facetBallot);
-      const vocab = await validateBallotForMemex(memexId, ballot);
+      const vocab = hasBallot ? await validateBallotForMemex(memexId, ballot) : [];
       const task = await createTask(
         memexId,
         doc.id,
@@ -187,19 +192,21 @@ export const tasksTools: ToolSpec[] = [
         reqCtx(ctx),
       );
       const taskRef = buildChildRef(slugs, doc, { type: "tasks", seq: task.seq });
-      // Store the ballot, route + rank its facets, log the decision, and append the
-      // top-K governing-standards readout — the payoff (dec-1/dec-2/dec-4).
-      const readout = await storeRouteAndReadout({
-        memexId,
-        specDocId: doc.id,
-        noun: "task",
-        rowId: task.id,
-        ownerRef: taskRef,
-        queryText: `${title}\n${description}`,
-        ballot,
-        vocab,
-        ctx: reqCtx(ctx),
-      });
+      // Store + route the ballot only when one was provided (the top-K governing-standards
+      // readout is its payoff); an absent ballot contributes no facet routing.
+      const readout = hasBallot
+        ? await storeRouteAndReadout({
+            memexId,
+            specDocId: doc.id,
+            noun: "task",
+            rowId: task.id,
+            ownerRef: taskRef,
+            queryText: `${title}\n${description}`,
+            ballot,
+            vocab,
+            ctx: reqCtx(ctx),
+          })
+        : "";
       if (ctx.verbose) {
         const state = await fullDocState(memexId, doc.id);
         const url = await ctx.workspaceUrl(memexId);


### PR DESCRIPTION
Production release: merge `develop` into `main`.

## Headline
Carries **#410 — facet ballot made optional** on `resolve_decision` + `create_task`. This is the fix that:
- stops unreloaded MCP clients erroring on the now-required ballot (colleagues hitting `resolve_decision`), and
- **turns the currently-RED prod post-deploy smoke green** (the `create_task`-with-no-ballot smoke passes once the lenient server is on prod).

Plus the rest of `develop` accumulated since the last release.

## Merge note (same as the prior release)
`main` is "ahead" by **10 commits, all of which are historical `Merge pull request … from develop` merge-commits** — there are **zero non-merge commits** on main missing from develop, so **nothing regresses**. GitHub will flag the branch out-of-date. Two ways through, your call:
- **Admin-override merge** (what was done for the last release #408) — fastest; or
- I raise a **fresh backmerge (main→develop)** first so this becomes a clean up-to-date merge with no override. (The existing backmerge #409 is stuck — its checks inherit the red prod-deploy run — so it'd be a *new* branch.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)