### PR TITLE
spec-421 issue-4: clarify the Connect-MCP step ticks on connect, not on paste

### DIFF
--- a/packages/ui/src/components/home/CreateSpecStep.test.tsx
+++ b/packages/ui/src/components/home/CreateSpecStep.test.tsx
@@ -138,3 +138,27 @@ describe('CreateSpecStep — spec-372 issue-19 connected-card state', () => {
     expect(stage.className).toContain('transition-all'); // animated change
   });
 });
+
+// spec-421 issue-4 (Frederic Zingg, via Slack) — users paste the install command and
+// expect the box to tick immediately; it only ticks once the agent first connects. The
+// not-connected card must spell out when the step completes.
+describe('CreateSpecStep — spec-421 issue-4: clarify when the step ticks', () => {
+  it('shows a hint that the card ticks when the agent first connects, not on paste', () => {
+    tagAc(AC421(27));
+    render(<CreateSpecStep preview />);
+    const hint = screen.getByTestId('connect-tick-hint');
+    const text = hint.textContent?.toLowerCase() ?? '';
+    expect(text).toContain('connects'); // tells the user the tick is gated on the agent connecting
+    expect(text).toContain('agent'); // names what they must launch
+  });
+
+  it('hides the tick hint once connected', async () => {
+    tagAc(AC421(27));
+    vi.useFakeTimers();
+    fetchJourneyStateApi.mockResolvedValue({ milestones: { mcpConnected: true } });
+    render(<CreateSpecStep />);
+    await vi.advanceTimersByTimeAsync(0); // first read — init branch sets connected
+    await vi.advanceTimersByTimeAsync(4000); // settle the re-render
+    expect(screen.queryByTestId('connect-tick-hint')).toBeNull();
+  });
+});

--- a/packages/ui/src/components/home/CreateSpecStep.tsx
+++ b/packages/ui/src/components/home/CreateSpecStep.tsx
@@ -172,6 +172,15 @@ export function CreateSpecStep({
             <div data-testid="connect-instructions">
               <Instructions tool={tool} os={os} onCopy={() => onCtaClick?.('copy_install')} />
             </div>
+            {/* spec-421 issue-4 — make it clear the step doesn't tick on paste: it ticks the
+                first time the agent actually connects (Frederic Zingg, via Slack). */}
+            <div className="mt-4 flex items-start gap-2 text-sm text-muted" data-testid="connect-tick-hint">
+              <span className="mt-0.5 h-2 w-2 flex-none animate-pulse rounded-full bg-accent" aria-hidden />
+              <span>
+                Run the command, then start your coding agent — this step ticks the first time your agent
+                connects, not when you copy the command.
+              </span>
+            </div>
           </>
         )}
       </section>


### PR DESCRIPTION
## What

The Home onboarding **"Connect to the Memex MCP"** card (`CreateSpecStep`) told users *how* to install the MCP but never said *when* the step completes. Users pasted the install command and expected the checkbox to tick immediately — but it only ticks the first time their agent actually connects.

This adds a clarifying hint under the install instructions, shown only in the not-connected state:

> Run the command, then start your coding agent — this step ticks the first time your agent connects, not when you copy the command.

Raised by **Frederic Zingg via Slack** → [spec-421 issue-4](https://memex.ai/mindset-prod/memex-building-itself/specs/spec-421).

## Changes
- `CreateSpecStep.tsx` — new `connect-tick-hint` line (pulse dot + copy) after the install `Instructions`, inside the `!connected` branch so it disappears once connected.
- `CreateSpecStep.test.tsx` — two tests tagged to `ac-27`: the hint is present (and names "agent"/"connects") when not connected, and hidden once connected. Driven red→green.

## Testing
- `CreateSpecStep` suite: 10/10 pass (new issue-4 tests confirmed red before the fix, green after).
- Related onboarding suites (`onboarding-copy.spec-372`, `journey-cta.spec-324`): 15/15 pass.
- `tsc --noEmit`: clean. b-105 vocab guard: clean.
- `make e2e-cold`: 115 passed; the lone failure (`journey-45-spec-304-mcp-session-mint`, desktop-shell native bridge — unrelated to this change) is the known flaky journey and passes in isolation.

> Note: `ac-27` lands green once the tagged vitest suite runs with a valid `MEMEX_EMIT_KEY`; issue-4 auto-resolves at that point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)