### PR TITLE
fix(spec-304): current CD connector steps + stop MCP pill re-revealing on nav (t-61, t-63)

### DIFF
--- a/packages/ui/src/components/ClaudeConnectorDialog.test.tsx
+++ b/packages/ui/src/components/ClaudeConnectorDialog.test.tsx
@@ -8,6 +8,12 @@ import { ClaudeConnectorDialog } from './ClaudeConnectorDialog';
 const AC_DIALOG =
   'mindset-prod/memex-building-itself/specs/spec-304/acs/ac-55';
 
+// t-63 → issue-29 / ac-60: Claude Desktop moved the connector UI. The steps
+// must reflect the current flow (Customize → Connectors → "+") rather than the
+// stale "Settings → Connectors → Add custom connector".
+const AC_STEPS_CURRENT =
+  'mindset-prod/memex-building-itself/specs/spec-304/acs/ac-60';
+
 beforeEach(() => {
   vi.restoreAllMocks();
 });
@@ -49,6 +55,27 @@ describe('spec-304 ac-55 (t-56): Claude Desktop connector-instructions dialog', 
 
     await waitFor(() => expect(writeText).toHaveBeenCalledWith('https://memex.ai/mcp'));
     expect(await screen.findByRole('button', { name: 'Copied!' })).toBeInTheDocument();
+  });
+
+  it('uses the current Claude Desktop flow: Customize → Connectors → "+" (ac-60)', () => {
+    tagAc(AC_STEPS_CURRENT);
+    render(
+      <ClaudeConnectorDialog connectorUrl="https://memex.ai/mcp" onClose={() => {}} />,
+    );
+
+    // Step 1 now routes through Customize → Connectors (Claude moved it out of
+    // Settings). The stale "Settings → Connectors" wording must be gone.
+    expect(screen.getByText(/Customize/)).toBeInTheDocument();
+    expect(screen.queryByText(/Settings → Connectors/)).not.toBeInTheDocument();
+
+    // The new intermediate step: click the "+" next to Connectors before
+    // "Add custom connector".
+    const steps = screen.getByRole('list');
+    expect(steps.textContent ?? '').toMatch(/\+\s*next to Connectors/i);
+    expect(screen.getByText(/Add custom connector/i)).toBeInTheDocument();
+
+    // std-1: no user-visible "account"/"team" in the steps copy.
+    expect(steps.textContent ?? '').not.toMatch(/\baccount\b|\bteam\b/i);
   });
 
   it('Escape and the Done button both close the dialog', () => {

--- a/packages/ui/src/components/ClaudeConnectorDialog.tsx
+++ b/packages/ui/src/components/ClaudeConnectorDialog.tsx
@@ -109,7 +109,8 @@ export function ClaudeConnectorDialog({ connectorUrl, onClose }: ClaudeConnector
           </div>
 
           <ol className="list-decimal pl-5 space-y-1.5 text-sm text-secondary">
-            <li>Open <span className="text-primary">Claude → Settings → Connectors</span>.</li>
+            <li>Open <span className="text-primary">Claude → Customize → Connectors</span>.</li>
+            <li>Click the <span className="text-primary">+</span> next to Connectors.</li>
             <li>Click <span className="text-primary">Add custom connector</span>.</li>
             <li>Paste the connector URL above.</li>
             <li>Keep <span className="text-primary">Individual sign-in</span> selected (each person signs in with their own Memex login).</li>

--- a/packages/ui/src/hooks/useDesktopMcpStatus.dedupe.test.tsx
+++ b/packages/ui/src/hooks/useDesktopMcpStatus.dedupe.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, waitFor, act } from '@testing-library/react';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { DesktopMcpStatusSync } from '../components/DesktopMcpStatusSync';
+
+// t-61 → issue-27 / ac-58: the native pill re-revealed on (nearly) every
+// navigation because a background re-derive re-pushed the SAME indicator. React
+// must de-dupe — only push when the derived indicator actually changed — so a
+// redundant re-derive does not make the pill pop back open.
+const AC_NO_REREVEAL =
+  'mindset-prod/memex-building-itself/specs/spec-304/acs/ac-58';
+
+vi.mock('../components/AuthContext', () => ({ useAuth: () => ({ token: 'test-token' }) }));
+
+// Capture the user-change-stream callback so the test can fire a re-derive
+// exactly like a background SSE event would (the source of the spurious pushes).
+let changeCb: (() => void) | null = null;
+vi.mock('../hooks/useUserChangeStream', () => ({
+  useUserChangeStream: (cb: () => void) => {
+    changeCb = cb;
+  },
+}));
+
+const listMcpTokensApi = vi.fn();
+vi.mock('../api/mcp', () => ({
+  listMcpTokensApi: (...a: unknown[]) => listMcpTokensApi(...a),
+  mintMcpTokenApi: vi.fn(),
+}));
+
+const STATUS = {
+  ok: true,
+  targets: {
+    claudeCode: { installed: true, urlMatches: true, tokenPrefix: 'mxt_active123' },
+    claudeDesktop: { installed: false, urlMatches: false, tokenPrefix: null },
+  },
+};
+
+function installShell(handlers: Record<string, (args: unknown) => unknown>) {
+  (window as unknown as { flutter_inappwebview?: unknown }).flutter_inappwebview = {
+    callHandler: (name: string, args: unknown) =>
+      (handlers[name] ?? (() => ({ ok: true })))(args),
+  };
+}
+function removeShell() {
+  delete (window as unknown as { flutter_inappwebview?: unknown }).flutter_inappwebview;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+  changeCb = null;
+  listMcpTokensApi.mockResolvedValue([
+    { id: '1', label: 'Memex Desktop', prefix: 'mxt_active123', lastUsedAt: null, revokedAt: null },
+  ]);
+});
+afterEach(() => removeShell());
+
+describe('spec-304 ac-58 (t-61, issue-27): the pill is not re-pushed on a redundant re-derive', () => {
+  it('pushes the indicator once and does NOT re-push when an SSE re-derive yields the same status (ac-58)', async () => {
+    tagAc(AC_NO_REREVEAL);
+    const setMcpStatus = vi.fn(() => ({ ok: true }));
+    installShell({ mcpStatus: () => STATUS, setMcpStatus });
+
+    render(<DesktopMcpStatusSync />);
+
+    // First derive → one push of the honest "MCP ready" state.
+    await waitFor(() => expect(setMcpStatus).toHaveBeenCalledTimes(1));
+
+    // A background user-change event fires a re-derive. The local config and
+    // tokens are unchanged, so the derived indicator is identical — it must NOT
+    // be pushed again (issue-27: a redundant push made the pill re-reveal).
+    await act(async () => {
+      changeCb?.();
+    });
+    // Give the async refresh time to complete and (wrongly) re-push if it would.
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(setMcpStatus).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/ui/src/hooks/useDesktopMcpStatus.ts
+++ b/packages/ui/src/hooks/useDesktopMcpStatus.ts
@@ -75,6 +75,12 @@ export function useDesktopMcpStatus(): DesktopMcpStatus {
   // Bumped whenever the per-client pill preferences change, so the push effect
   // below re-runs and re-derives what the pill should show (dec-24).
   const [prefsVersion, setPrefsVersion] = useState(0);
+  // The last indicator pushed to the native pill, so a redundant re-derive (a
+  // background SSE event fires `refresh`, minting a NEW `clients` array on
+  // nearly every navigation) doesn't re-push an identical state — re-pushing
+  // makes the pill re-reveal/pop by itself (issue-27, ac-58). '__none__' marks
+  // the explicit hide so it, too, is pushed only once.
+  const lastPushRef = useRef<string | null>(null);
 
   const refresh = useCallback(async () => {
     if (!inShell) return;
@@ -134,10 +140,20 @@ export function useDesktopMcpStatus(): DesktopMcpStatus {
       (c) => c.transport === 'token' && isPillNotificationEnabled(c.key),
     );
     if (pillClients.length === 0) {
-      void clearMcpStatusBridge();
+      if (lastPushRef.current !== '__none__') {
+        lastPushRef.current = '__none__';
+        void clearMcpStatusBridge();
+      }
       return;
     }
-    void setMcpStatusBridge(deriveIndicator(pillClients.map((c) => c.status)));
+    const indicator = deriveIndicator(pillClients.map((c) => c.status));
+    // De-dupe (issue-27, ac-58): only push when the derived indicator actually
+    // changed. A re-derive that lands on the same state must NOT re-push, or the
+    // native pill re-reveals on every navigation.
+    const key = `${indicator.kind}|${indicator.label}|${indicator.visibility}`;
+    if (lastPushRef.current === key) return;
+    lastPushRef.current = key;
+    void setMcpStatusBridge(indicator);
   }, [inShell, clients, prefsVersion]);
 
   // Re-derive the pill when the per-client notification preference changes


### PR DESCRIPTION
Fixes two of the four staging-verify polish issues (web side) on spec-304.

## issue-29 → t-63 (ac-60) — Claude Desktop connector steps were stale
`ClaudeConnectorDialog` told users to go to *Settings → Connectors*. Claude moved it. Steps now follow the current flow: **Customize → Connectors → "+" → Add custom connector → paste URL → keep Individual sign-in → Add & sign in → restart Claude**. Connector URL, honest-CTA framing, and the managed-plan owner note unchanged. No user-visible "account"/"team" (std-1).

## issue-27 → t-61 (ac-58) — native MCP pill re-revealed on every navigation
The app-global status hook re-pushed the *same* indicator on every background re-derive (a new `clients` array on nearly every navigation), so the native pill kept popping back open in the healthy steady state. `useDesktopMcpStatus` now de-dupes: it only pushes when the derived indicator actually changed (and pushes the hide only once).

> t-61 is the **web half**; the load-bearing native half (reveal only on a genuine state change) ships in the memex-clients PR. The `setMcpStatus` bridge contract is unchanged, so a mixed-version shell/UI degrades gracefully.

## Tests
- `ClaudeConnectorDialog.test.tsx`: new case tagged **ac-60** (current flow present, stale wording gone, std-1 clean) — red→green.
- `useDesktopMcpStatus.dedupe.test.tsx` (new): tagged **ac-58** — a background re-derive with unchanged status pushes once, not twice — red→green.
- Full `ui` suite green except a pre-existing, unrelated date-sensitive test (`UpgradeConfirmation.spec-171`).

QA report: spec-304 `qa_report-17`.