### PR TITLE
fix(spec-371): fire checkout hooks on plugin-namespaced MCP tools

### DIFF
--- a/packages/cli/plugin/hooks/hooks.json
+++ b/packages/cli/plugin/hooks/hooks.json
@@ -2,7 +2,7 @@
   "hooks": {
     "PostToolUse": [
       {
-        "matcher": "mcp__memex__.*",
+        "matcher": "mcp__.*memex__.*",
         "hooks": [
           {
             "type": "command",

--- a/packages/cli/plugin/lib/checkout-marker.js
+++ b/packages/cli/plugin/lib/checkout-marker.js
@@ -224,7 +224,12 @@ function toolCallFailed(payload) {
 // The caller keys the marker on payload.session_id (the conversation UID).
 export function decideMarkerAction(payload) {
   const toolName = typeof payload?.tool_name === "string" ? payload.tool_name : "";
-  const bare = toolName.replace(/^mcp__memex__/, "");
+  // Strip the MCP server prefix down to the bare tool name. The Memex server is
+  // exposed as `mcp__memex__<tool>` when configured directly, but as
+  // `mcp__plugin_<plugin>_memex__<tool>` when the SAME server ships inside this
+  // plugin (Claude Code namespaces a plugin's MCP servers). Accept both, or the
+  // gate silently no-ops on every real plugin install.
+  const bare = toolName.replace(/^mcp__(?:plugin_[a-z0-9-]+_)?memex__/, "");
   if (bare === "unclaim_spec") return { action: "clear" };
   if (!ARMING_TOOLS.has(bare)) return { action: "skip" };
   if (toolCallFailed(payload)) return { action: "skip" };

--- a/packages/cli/test/checkout-marker.test.js
+++ b/packages/cli/test/checkout-marker.test.js
@@ -137,6 +137,27 @@ describe("decideMarkerAction: arm on any successful spec mutation, not on a fail
       "skip",
     );
   });
+
+  it("arms/clears identically when the MCP is plugin-namespaced (mcp__plugin_<plugin>_memex__...) (ac-9)", () => {
+    tagAc(AC_9);
+    // The SAME Memex server, bundled as a Claude Code plugin, exposes its tools as
+    // `mcp__plugin_memex-checkout_memex__<tool>`. The bare-name strip must still
+    // resolve the tool, or no marker is ever written on a real plugin install.
+    expect(
+      decideMarkerAction(ev("mcp__plugin_memex-checkout_memex__claim_spec", "ns/m/specs/spec-1")),
+    ).toEqual({ action: "write", memex: "ns/m", spec: "spec-1" });
+    expect(
+      decideMarkerAction(
+        ev("mcp__plugin_memex-checkout_memex__update_section", "ns/m/specs/spec-1/sections/s-2"),
+      ),
+    ).toEqual({ action: "write", memex: "ns/m", spec: "spec-1" });
+    expect(
+      decideMarkerAction(ev("mcp__plugin_memex-checkout_memex__unclaim_spec", "ns/m/specs/spec-1")),
+    ).toEqual({ action: "clear" });
+    expect(
+      decideMarkerAction(ev("mcp__plugin_memex-checkout_memex__get_doc", "ns/m/specs/spec-1")).action,
+    ).toBe("skip");
+  });
 });
 
 // The task-sync STEER: a short, CONDITIONAL nag emitted after a file edit in a

--- a/packages/cli/test/hooks-e2e.test.js
+++ b/packages/cli/test/hooks-e2e.test.js
@@ -90,6 +90,21 @@ describe("spec-371 hooks e2e (ac-7, ac-9, ac-10, ac-12, ac-15)", () => {
     });
   });
 
+  it("marker-write: arms the thread when the MCP tool is plugin-namespaced — the real install shape (ac-9)", () => {
+    tagAc(AC_9);
+    withHome((home) => {
+      // When the Memex server ships inside the plugin, Claude Code names the tool
+      // `mcp__plugin_memex-checkout_memex__claim_spec` — the exact name a real
+      // install fires the hook with. The marker must still be written.
+      run("marker-write.mjs", {
+        session_id: "plug",
+        tool_name: "mcp__plugin_memex-checkout_memex__claim_spec",
+        tool_input: { ref: "ns/m/specs/spec-371" },
+      }, home);
+      expect(markerOf(home, "plug")).toMatchObject({ memex: "ns/m", spec: "spec-371" });
+    });
+  });
+
   it("edit hook: no checkout → SILENT — no steer, no network, nothing leaves (ac-10, ac-16)", () => {
     tagAc(AC_10);
     tagAc(AC_16);

--- a/packages/cli/test/plugin-bundle.test.js
+++ b/packages/cli/test/plugin-bundle.test.js
@@ -37,6 +37,24 @@ describe("plugin bundle: MCP + hooks as one unit (spec-371 ac-15)", () => {
     expect(cmds.some((c) => c.includes("edit-phonehome.mjs"))).toBe(true);
   });
 
+  it("the marker-write matcher fires on the plugin-namespaced MCP tool, not just the bare name (regression: v0.1.0 plugin install)", () => {
+    tagAc(AC_15);
+    const hooks = readJson(resolve(pluginRoot, "hooks/hooks.json"));
+    // The PostToolUse entry that runs marker-write.mjs is the one guarding Memex MCP calls.
+    const entry = (hooks.hooks?.PostToolUse ?? []).find((e) =>
+      e.hooks.some((h) => h.command.includes("marker-write.mjs")),
+    );
+    expect(entry).toBeTruthy();
+    // Anchored is the strict reading (the original `.*` suffix implies start-anchoring);
+    // if it passes anchored it passes a looser substring match too.
+    const re = new RegExp(`^${entry.matcher}$`);
+    // Direct install exposes `mcp__memex__<tool>`; bundled-as-plugin exposes
+    // `mcp__plugin_<plugin>_memex__<tool>`. The matcher MUST catch BOTH, or the hook
+    // never fires on the plugin's own bundled MCP (the shipped v0.1.0 bug).
+    expect(re.test("mcp__memex__claim_spec")).toBe(true);
+    expect(re.test("mcp__plugin_memex-checkout_memex__claim_spec")).toBe(true);
+  });
+
   it("the bundled MCP entry bakes NO per-user token (OAuth runs on enable)", () => {
     tagAc(AC_15);
     // A committed file must never carry a per-user bearer token; the server's


### PR DESCRIPTION
## What & why

The `memex-checkout` plugin's PostToolUse hooks never fire on the plugin's **own bundled MCP**. Two spots hardcoded the directly-configured tool name `mcp__memex__<tool>`:

- `plugin/hooks/hooks.json` matcher: `mcp__memex__.*`
- `plugin/lib/checkout-marker.js` strip: `/^mcp__memex__/`

When the Memex MCP ships **inside** the plugin, Claude Code namespaces its tools as `mcp__plugin_memex-checkout_memex__<tool>`, which neither matched. On every real plugin install the result is: checkout marker never written → `edit-phonehome` stays silent → no `spec_checkout_edits` rows, no steer. v0.1.0 is effectively a no-op as a plugin.

## Fix (namespace-agnostic, both spots)

- matcher → `mcp__.*memex__.*` — matches the direct **and** plugin namespaces; verified under both anchored and substring matching.
- strip → `/^mcp__(?:plugin_[a-z0-9-]+_)?memex__/` — resolves the bare tool name in both forms.

The direct-install path is preserved, so a hand-configured MCP does not regress.

## Tests

The existing suite only ever used the bare `mcp__memex__*` name — which is exactly why this shipped. Added coverage at all three layers, each **red on the prior code, green with the fix**:

- `plugin-bundle.test.js` — the `hooks.json` matcher regex matches the plugin-namespaced tool name
- `checkout-marker.test.js` — `decideMarkerAction` arms/clears on plugin-namespaced tools
- `hooks-e2e.test.js` — `marker-write.mjs` writes the marker for the real plugin tool name

`pnpm --filter memex-ai test` → 69/69 green.

## Validated end-to-end on PROD

`claim_spec` → marker written → file edit → real row in `spec_checkout_edits` (correct `thread_uid`, `changed_paths`, `commit_sha`, `branch`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
