### PR TITLE
chore(spec-371): bump memex-checkout plugin to 0.1.1

### DIFF
--- a/packages/cli/plugin/.claude-plugin/plugin.json
+++ b/packages/cli/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memex-checkout",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Memex spec-checkout — binds your coding thread to a Spec and records in-flow edits against it (claim-gated, privacy-first). Non-blocking, opt-in, uninstallable any time. Sends only changed file paths + the claimed spec; never source code or prompts.",
   "author": { "name": "Mindset AI", "url": "https://memex.ai" },
   "mcpServers": {


### PR DESCRIPTION
Bumps `memex-checkout` **0.1.0 → 0.1.1** so the plugin-namespace hook fix (#414) actually reaches installed users.

`claude plugin update` only pulls a new build when `plugin.json` advertises a higher version. #414 fixed the code on `develop` but left the version at `0.1.0`, so existing installs (pinned to `0.1.0`) would not pick it up. This bumps the version only — no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
