### PR TITLE
Release: develop → main (spec-371 plugin hook fix + 0.1.1 bump + accumulated develop)

### DIFF
--- a/packages/cli/plugin/.claude-plugin/plugin.json
+++ b/packages/cli/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memex-checkout",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Memex spec-checkout — binds your coding thread to a Spec and records in-flow edits against it (claim-gated, privacy-first). Non-blocking, opt-in, uninstallable any time. Sends only changed file paths + the claimed spec; never source code or prompts.",
   "author": { "name": "Mindset AI", "url": "https://memex.ai" },
   "mcpServers": {

--- a/packages/cli/plugin/hooks/hooks.json
+++ b/packages/cli/plugin/hooks/hooks.json
@@ -2,7 +2,7 @@
   "hooks": {
     "PostToolUse": [
       {
-        "matcher": "mcp__memex__.*",
+        "matcher": "mcp__.*memex__.*",
         "hooks": [
           {
             "type": "command",

--- a/packages/cli/plugin/lib/checkout-marker.js
+++ b/packages/cli/plugin/lib/checkout-marker.js
@@ -224,7 +224,12 @@ function toolCallFailed(payload) {
 // The caller keys the marker on payload.session_id (the conversation UID).
 export function decideMarkerAction(payload) {
   const toolName = typeof payload?.tool_name === "string" ? payload.tool_name : "";
-  const bare = toolName.replace(/^mcp__memex__/, "");
+  // Strip the MCP server prefix down to the bare tool name. The Memex server is
+  // exposed as `mcp__memex__<tool>` when configured directly, but as
+  // `mcp__plugin_<plugin>_memex__<tool>` when the SAME server ships inside this
+  // plugin (Claude Code namespaces a plugin's MCP servers). Accept both, or the
+  // gate silently no-ops on every real plugin install.
+  const bare = toolName.replace(/^mcp__(?:plugin_[a-z0-9-]+_)?memex__/, "");
   if (bare === "unclaim_spec") return { action: "clear" };
   if (!ARMING_TOOLS.has(bare)) return { action: "skip" };
   if (toolCallFailed(payload)) return { action: "skip" };

--- a/packages/cli/test/checkout-marker.test.js
+++ b/packages/cli/test/checkout-marker.test.js
@@ -137,6 +137,27 @@ describe("decideMarkerAction: arm on any successful spec mutation, not on a fail
       "skip",
     );
   });
+
+  it("arms/clears identically when the MCP is plugin-namespaced (mcp__plugin_<plugin>_memex__...) (ac-9)", () => {
+    tagAc(AC_9);
+    // The SAME Memex server, bundled as a Claude Code plugin, exposes its tools as
+    // `mcp__plugin_memex-checkout_memex__<tool>`. The bare-name strip must still
+    // resolve the tool, or no marker is ever written on a real plugin install.
+    expect(
+      decideMarkerAction(ev("mcp__plugin_memex-checkout_memex__claim_spec", "ns/m/specs/spec-1")),
+    ).toEqual({ action: "write", memex: "ns/m", spec: "spec-1" });
+    expect(
+      decideMarkerAction(
+        ev("mcp__plugin_memex-checkout_memex__update_section", "ns/m/specs/spec-1/sections/s-2"),
+      ),
+    ).toEqual({ action: "write", memex: "ns/m", spec: "spec-1" });
+    expect(
+      decideMarkerAction(ev("mcp__plugin_memex-checkout_memex__unclaim_spec", "ns/m/specs/spec-1")),
+    ).toEqual({ action: "clear" });
+    expect(
+      decideMarkerAction(ev("mcp__plugin_memex-checkout_memex__get_doc", "ns/m/specs/spec-1")).action,
+    ).toBe("skip");
+  });
 });
 
 // The task-sync STEER: a short, CONDITIONAL nag emitted after a file edit in a

--- a/packages/cli/test/hooks-e2e.test.js
+++ b/packages/cli/test/hooks-e2e.test.js
@@ -90,6 +90,21 @@ describe("spec-371 hooks e2e (ac-7, ac-9, ac-10, ac-12, ac-15)", () => {
     });
   });
 
+  it("marker-write: arms the thread when the MCP tool is plugin-namespaced — the real install shape (ac-9)", () => {
+    tagAc(AC_9);
+    withHome((home) => {
+      // When the Memex server ships inside the plugin, Claude Code names the tool
+      // `mcp__plugin_memex-checkout_memex__claim_spec` — the exact name a real
+      // install fires the hook with. The marker must still be written.
+      run("marker-write.mjs", {
+        session_id: "plug",
+        tool_name: "mcp__plugin_memex-checkout_memex__claim_spec",
+        tool_input: { ref: "ns/m/specs/spec-371" },
+      }, home);
+      expect(markerOf(home, "plug")).toMatchObject({ memex: "ns/m", spec: "spec-371" });
+    });
+  });
+
   it("edit hook: no checkout → SILENT — no steer, no network, nothing leaves (ac-10, ac-16)", () => {
     tagAc(AC_10);
     tagAc(AC_16);

--- a/packages/cli/test/plugin-bundle.test.js
+++ b/packages/cli/test/plugin-bundle.test.js
@@ -37,6 +37,24 @@ describe("plugin bundle: MCP + hooks as one unit (spec-371 ac-15)", () => {
     expect(cmds.some((c) => c.includes("edit-phonehome.mjs"))).toBe(true);
   });
 
+  it("the marker-write matcher fires on the plugin-namespaced MCP tool, not just the bare name (regression: v0.1.0 plugin install)", () => {
+    tagAc(AC_15);
+    const hooks = readJson(resolve(pluginRoot, "hooks/hooks.json"));
+    // The PostToolUse entry that runs marker-write.mjs is the one guarding Memex MCP calls.
+    const entry = (hooks.hooks?.PostToolUse ?? []).find((e) =>
+      e.hooks.some((h) => h.command.includes("marker-write.mjs")),
+    );
+    expect(entry).toBeTruthy();
+    // Anchored is the strict reading (the original `.*` suffix implies start-anchoring);
+    // if it passes anchored it passes a looser substring match too.
+    const re = new RegExp(`^${entry.matcher}$`);
+    // Direct install exposes `mcp__memex__<tool>`; bundled-as-plugin exposes
+    // `mcp__plugin_<plugin>_memex__<tool>`. The matcher MUST catch BOTH, or the hook
+    // never fires on the plugin's own bundled MCP (the shipped v0.1.0 bug).
+    expect(re.test("mcp__memex__claim_spec")).toBe(true);
+    expect(re.test("mcp__plugin_memex-checkout_memex__claim_spec")).toBe(true);
+  });
+
   it("the bundled MCP entry bakes NO per-user token (OAuth runs on enable)", () => {
     tagAc(AC_15);
     // A committed file must never carry a per-user bearer token; the server's

--- a/packages/server/src/services/auth.ts
+++ b/packages/server/src/services/auth.ts
@@ -3,6 +3,7 @@ import {
   getUserById,
   listMemberships,
   listMembershipsMatchingDomain,
+  listEmptyOrgs,
   type MembershipSummary,
 } from "./users.js";
 import { upsertVerifiedDomain } from "./verified-domains.js";
@@ -42,6 +43,18 @@ export interface SessionPayload {
   /** Server-issued JWT the client stores as `memex-auth-token`. Omitted when the
    * session is refreshed via /api/auth/me (the caller already has the token). */
   token?: string;
+  /**
+   * Orgs the user is an active member of that have no Memexes yet (doc-19 dec-1:
+   * new orgs start empty). These are invisible in `memberships` (which is
+   * memex-keyed) but must appear in the switcher so the user can navigate to them
+   * and create their first Memex. Optional for back-compat with cached sessions.
+   */
+  emptyOrgs?: Array<{
+    orgId: string;
+    slug: string;
+    name: string;
+    role: "member" | "administrator";
+  }>;
 }
 
 // Parses the HIDDEN_FEATURES env var (comma-separated feature slugs) into a list.
@@ -230,7 +243,10 @@ export async function resolveSession(
     throw new DisabledUserError(user.email);
   }
 
-  const memberships = await listMemberships(user.id);
+  const [memberships, emptyOrgs] = await Promise.all([
+    listMemberships(user.id),
+    listEmptyOrgs(user.id),
+  ]);
   const current = pickCurrentMemex(memberships, requestedMemexId);
 
   return {
@@ -242,6 +258,7 @@ export async function resolveSession(
       emailVerified: !!user.emailVerifiedAt,
     },
     memberships,
+    emptyOrgs,
     currentMemexId: current?.memexId ?? null,
     currentRole: current?.role ?? null,
     needsOnboarding: !user.identityConfirmedAt, // spec-305 dec-2/dec-4: gate on the identity step, not just a name (SSO users arrive named)

--- a/packages/server/src/services/users.integration.test.ts
+++ b/packages/server/src/services/users.integration.test.ts
@@ -20,6 +20,7 @@ import {
   getUserById,
   listMemberships,
   listMembershipsMatchingDomain,
+  listEmptyOrgs,
 } from "./users.js";
 
 const createdUserIds: string[] = [];
@@ -189,5 +190,57 @@ describe("listMemberships / listMembershipsMatchingDomain", () => {
 
     const matches = await listMembershipsMatchingDomain(user.id, "IVY.COM");
     expect(matches).toHaveLength(1);
+  });
+});
+
+// spec-431: orgs with no Memex were invisible in the switcher because
+// listMemberships uses an INNER JOIN on memexes. listEmptyOrgs surfaces them.
+describe("listEmptyOrgs", () => {
+  // Seed an org namespace WITHOUT a memex (unlike seedMemexTuple which always
+  // creates one). Returns { org, namespace }.
+  async function seedEmptyOrg(opts: { name: string; slug: string }) {
+    const [ns] = await db.insert(namespaces).values({ slug: opts.slug, kind: "org" }).returning();
+    const [org] = await db
+      .insert(orgs)
+      .values({ namespaceId: ns.id, name: opts.name, emailDomains: [] })
+      .returning();
+    await db.update(namespaces).set({ ownerOrgId: org.id }).where(eq(namespaces.id, ns.id));
+    return { org, namespace: ns };
+  }
+
+  it("returns the org when the user is a member and it has no Memexes", async () => {
+    const user = await upsertUserByEmail(uniqueEmail("empty-org-a"));
+    createdUserIds.push(user.id);
+
+    const { org } = await seedEmptyOrg({ name: "Empty Co", slug: uniqueSubdomain("emptyco") });
+
+    await db.insert(orgMemberships).values({ userId: user.id, orgId: org.id, role: "administrator" });
+
+    const result = await listEmptyOrgs(user.id);
+    const match = result.find((r) => r.orgId === org.id);
+    expect(match).toBeDefined();
+    expect(match!.name).toBe("Empty Co");
+    expect(match!.role).toBe("administrator");
+  });
+
+  it("does NOT return an org that already has a Memex", async () => {
+    const user = await upsertUserByEmail(uniqueEmail("empty-org-b"));
+    createdUserIds.push(user.id);
+
+    const { memex, org } = await seedMemexTuple({ name: "Full Co", slug: uniqueSubdomain("fullco") });
+    createdAccountIds.push(memex.id);
+
+    await db.insert(orgMemberships).values({ userId: user.id, orgId: org.id, role: "member" });
+
+    const result = await listEmptyOrgs(user.id);
+    expect(result.find((r) => r.orgId === org.id)).toBeUndefined();
+  });
+
+  it("returns empty array when user has no org memberships", async () => {
+    const user = await upsertUserByEmail(uniqueEmail("empty-org-c"));
+    createdUserIds.push(user.id);
+
+    const result = await listEmptyOrgs(user.id);
+    expect(result).toHaveLength(0);
   });
 });

--- a/packages/server/src/services/users.ts
+++ b/packages/server/src/services/users.ts
@@ -327,13 +327,47 @@ export async function listAccessibleNamespaces(userId: string): Promise<Namespac
   return [...personal, ...orgList];
 }
 
+// Returns orgs the user has an active membership in but that have no Memexes yet.
+// Used by resolveSession to include them in the session payload so the switcher
+// can surface them (doc-19 dec-1: new orgs are created empty by design).
+export async function listEmptyOrgs(userId: string): Promise<
+  Array<{ orgId: string; slug: string; name: string; role: "member" | "administrator" }>
+> {
+  const rows = await db
+    .select({
+      orgId: orgs.id,
+      slug: namespaces.slug,
+      name: orgs.name,
+      role: orgMemberships.role,
+      memexId: memexes.id,
+    })
+    .from(orgMemberships)
+    .innerJoin(orgs, eq(orgMemberships.orgId, orgs.id))
+    .innerJoin(namespaces, eq(orgs.namespaceId, namespaces.id))
+    .leftJoin(memexes, eq(memexes.namespaceId, namespaces.id))
+    .where(
+      and(
+        eq(orgMemberships.userId, userId),
+        eq(orgMemberships.status, "active"),
+      ),
+    );
+
+  return rows
+    .filter((r) => r.memexId === null)
+    .map((r) => ({
+      orgId: r.orgId,
+      slug: r.slug,
+      name: r.name ?? r.slug,
+      role: r.role as "member" | "administrator",
+    }));
+}
+
 // Returns ACTIVE memberships only — disabled members can't access the org, so they
 // shouldn't see it in their session/switcher. Re-enabling is admin-driven.
 //
 // Each row is keyed on a memex the user can reach (memexes joined via
 // org → namespace → memexes). Plus the user's personal Memex (their own namespace).
-// Orgs with zero memexes produce zero rows — use listAccessibleNamespaces if
-// the caller needs to surface empty orgs.
+// Orgs with zero memexes produce zero rows — see listEmptyOrgs for those.
 export async function listMemberships(userId: string): Promise<MembershipSummary[]> {
   const orgRows = await db
     .select({

--- a/packages/ui/src/api/auth.ts
+++ b/packages/ui/src/api/auth.ts
@@ -82,6 +82,18 @@ export interface SessionPayload {
   /** Fresh session token (present on signup/login/SSO/magic-link responses). Client stores
    *  as `memex-auth-token`. Absent on session refresh responses (client already has it). */
   token?: string;
+  /**
+   * Orgs the user is an active member of that have no Memexes yet (doc-19 dec-1).
+   * These are invisible in `memberships` (memex-keyed) but must appear in the
+   * switcher so the user can navigate to them. Optional for back-compat with
+   * sessions cached before this field shipped.
+   */
+  emptyOrgs?: Array<{
+    orgId: string;
+    slug: string;
+    name: string;
+    role: 'member' | 'administrator';
+  }>;
 }
 
 async function authEndpoint(

--- a/packages/ui/src/components/ClaudeConnectorDialog.test.tsx
+++ b/packages/ui/src/components/ClaudeConnectorDialog.test.tsx
@@ -8,6 +8,12 @@ import { ClaudeConnectorDialog } from './ClaudeConnectorDialog';
 const AC_DIALOG =
   'mindset-prod/memex-building-itself/specs/spec-304/acs/ac-55';
 
+// t-63 → issue-29 / ac-60: Claude Desktop moved the connector UI. The steps
+// must reflect the current flow (Customize → Connectors → "+") rather than the
+// stale "Settings → Connectors → Add custom connector".
+const AC_STEPS_CURRENT =
+  'mindset-prod/memex-building-itself/specs/spec-304/acs/ac-60';
+
 beforeEach(() => {
   vi.restoreAllMocks();
 });
@@ -49,6 +55,27 @@ describe('spec-304 ac-55 (t-56): Claude Desktop connector-instructions dialog', 
 
     await waitFor(() => expect(writeText).toHaveBeenCalledWith('https://memex.ai/mcp'));
     expect(await screen.findByRole('button', { name: 'Copied!' })).toBeInTheDocument();
+  });
+
+  it('uses the current Claude Desktop flow: Customize → Connectors → "+" (ac-60)', () => {
+    tagAc(AC_STEPS_CURRENT);
+    render(
+      <ClaudeConnectorDialog connectorUrl="https://memex.ai/mcp" onClose={() => {}} />,
+    );
+
+    // Step 1 now routes through Customize → Connectors (Claude moved it out of
+    // Settings). The stale "Settings → Connectors" wording must be gone.
+    expect(screen.getByText(/Customize/)).toBeInTheDocument();
+    expect(screen.queryByText(/Settings → Connectors/)).not.toBeInTheDocument();
+
+    // The new intermediate step: click the "+" next to Connectors before
+    // "Add custom connector".
+    const steps = screen.getByRole('list');
+    expect(steps.textContent ?? '').toMatch(/\+\s*next to Connectors/i);
+    expect(screen.getByText(/Add custom connector/i)).toBeInTheDocument();
+
+    // std-1: no user-visible "account"/"team" in the steps copy.
+    expect(steps.textContent ?? '').not.toMatch(/\baccount\b|\bteam\b/i);
   });
 
   it('Escape and the Done button both close the dialog', () => {

--- a/packages/ui/src/components/ClaudeConnectorDialog.tsx
+++ b/packages/ui/src/components/ClaudeConnectorDialog.tsx
@@ -109,7 +109,8 @@ export function ClaudeConnectorDialog({ connectorUrl, onClose }: ClaudeConnector
           </div>
 
           <ol className="list-decimal pl-5 space-y-1.5 text-sm text-secondary">
-            <li>Open <span className="text-primary">Claude → Settings → Connectors</span>.</li>
+            <li>Open <span className="text-primary">Claude → Customize → Connectors</span>.</li>
+            <li>Click the <span className="text-primary">+</span> next to Connectors.</li>
             <li>Click <span className="text-primary">Add custom connector</span>.</li>
             <li>Paste the connector URL above.</li>
             <li>Keep <span className="text-primary">Individual sign-in</span> selected (each person signs in with their own Memex login).</li>

--- a/packages/ui/src/components/MemexSwitcher.tsx
+++ b/packages/ui/src/components/MemexSwitcher.tsx
@@ -139,6 +139,13 @@ export function MemexSwitcher({ variant = 'topbar' }: { variant?: 'topbar' | 'si
       });
     }
   }
+  // Orgs with no Memexes yet (doc-19 dec-1) don't appear in `memberships` at all.
+  // Seed them with an empty memexes array so they still show up in the switcher.
+  for (const org of session?.emptyOrgs ?? []) {
+    if (!orgsByNamespace.has(org.slug)) {
+      orgsByNamespace.set(org.slug, { name: org.name, role: org.role, memexes: [] });
+    }
+  }
 
   const isSidebar = variant === 'sidebar';
   const triggerClass = isSidebar
@@ -199,20 +206,32 @@ export function MemexSwitcher({ variant = 'topbar' }: { variant?: 'topbar' | 'si
                           {group.role}
                         </div>
                       </div>
-                      {group.memexes.map((mx) => {
-                        const mxSlug = mx.memexSlug ?? 'main';
-                        const active =
-                          isCurrentOrg && current?.memex === mxSlug;
-                        return (
-                          <SwitcherRow
-                            key={mx.memexId}
-                            title={mx.memexName ?? mx.name}
-                            active={active}
-                            onClick={() => goToOrgMemex(mx)}
-                            indent
-                          />
-                        );
-                      })}
+                      {group.memexes.length === 0 ? (
+                        <button
+                          onClick={() => {
+                            setOpen(false);
+                            navigate(namespaceHomePath(nsSlug));
+                          }}
+                          className="w-full text-left pl-6 pr-3 py-1.5 text-xs text-muted hover:text-primary hover:bg-overlay transition-colors"
+                        >
+                          No Memex yet — go to org
+                        </button>
+                      ) : (
+                        group.memexes.map((mx) => {
+                          const mxSlug = mx.memexSlug ?? 'main';
+                          const active =
+                            isCurrentOrg && current?.memex === mxSlug;
+                          return (
+                            <SwitcherRow
+                              key={mx.memexId}
+                              title={mx.memexName ?? mx.name}
+                              active={active}
+                              onClick={() => goToOrgMemex(mx)}
+                              indent
+                            />
+                          );
+                        })
+                      )}
                     </div>
                   );
                 })}

--- a/packages/ui/src/components/home/CreateSpecStep.test.tsx
+++ b/packages/ui/src/components/home/CreateSpecStep.test.tsx
@@ -138,3 +138,27 @@ describe('CreateSpecStep — spec-372 issue-19 connected-card state', () => {
     expect(stage.className).toContain('transition-all'); // animated change
   });
 });
+
+// spec-421 issue-4 (Frederic Zingg, via Slack) — users paste the install command and
+// expect the box to tick immediately; it only ticks once the agent first connects. The
+// not-connected card must spell out when the step completes.
+describe('CreateSpecStep — spec-421 issue-4: clarify when the step ticks', () => {
+  it('shows a hint that the card ticks when the agent first connects, not on paste', () => {
+    tagAc(AC421(27));
+    render(<CreateSpecStep preview />);
+    const hint = screen.getByTestId('connect-tick-hint');
+    const text = hint.textContent?.toLowerCase() ?? '';
+    expect(text).toContain('connects'); // tells the user the tick is gated on the agent connecting
+    expect(text).toContain('agent'); // names what they must launch
+  });
+
+  it('hides the tick hint once connected', async () => {
+    tagAc(AC421(27));
+    vi.useFakeTimers();
+    fetchJourneyStateApi.mockResolvedValue({ milestones: { mcpConnected: true } });
+    render(<CreateSpecStep />);
+    await vi.advanceTimersByTimeAsync(0); // first read — init branch sets connected
+    await vi.advanceTimersByTimeAsync(4000); // settle the re-render
+    expect(screen.queryByTestId('connect-tick-hint')).toBeNull();
+  });
+});

--- a/packages/ui/src/components/home/CreateSpecStep.tsx
+++ b/packages/ui/src/components/home/CreateSpecStep.tsx
@@ -172,6 +172,15 @@ export function CreateSpecStep({
             <div data-testid="connect-instructions">
               <Instructions tool={tool} os={os} onCopy={() => onCtaClick?.('copy_install')} />
             </div>
+            {/* spec-421 issue-4 — make it clear the step doesn't tick on paste: it ticks the
+                first time the agent actually connects (Frederic Zingg, via Slack). */}
+            <div className="mt-4 flex items-start gap-2 text-sm text-muted" data-testid="connect-tick-hint">
+              <span className="mt-0.5 h-2 w-2 flex-none animate-pulse rounded-full bg-accent" aria-hidden />
+              <span>
+                Run the command, then start your coding agent — this step ticks the first time your agent
+                connects, not when you copy the command.
+              </span>
+            </div>
           </>
         )}
       </section>

--- a/packages/ui/src/hooks/useDesktopMcpStatus.dedupe.test.tsx
+++ b/packages/ui/src/hooks/useDesktopMcpStatus.dedupe.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, waitFor, act } from '@testing-library/react';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { DesktopMcpStatusSync } from '../components/DesktopMcpStatusSync';
+
+// t-61 → issue-27 / ac-58: the native pill re-revealed on (nearly) every
+// navigation because a background re-derive re-pushed the SAME indicator. React
+// must de-dupe — only push when the derived indicator actually changed — so a
+// redundant re-derive does not make the pill pop back open.
+const AC_NO_REREVEAL =
+  'mindset-prod/memex-building-itself/specs/spec-304/acs/ac-58';
+
+vi.mock('../components/AuthContext', () => ({ useAuth: () => ({ token: 'test-token' }) }));
+
+// Capture the user-change-stream callback so the test can fire a re-derive
+// exactly like a background SSE event would (the source of the spurious pushes).
+let changeCb: (() => void) | null = null;
+vi.mock('../hooks/useUserChangeStream', () => ({
+  useUserChangeStream: (cb: () => void) => {
+    changeCb = cb;
+  },
+}));
+
+const listMcpTokensApi = vi.fn();
+vi.mock('../api/mcp', () => ({
+  listMcpTokensApi: (...a: unknown[]) => listMcpTokensApi(...a),
+  mintMcpTokenApi: vi.fn(),
+}));
+
+const STATUS = {
+  ok: true,
+  targets: {
+    claudeCode: { installed: true, urlMatches: true, tokenPrefix: 'mxt_active123' },
+    claudeDesktop: { installed: false, urlMatches: false, tokenPrefix: null },
+  },
+};
+
+function installShell(handlers: Record<string, (args: unknown) => unknown>) {
+  (window as unknown as { flutter_inappwebview?: unknown }).flutter_inappwebview = {
+    callHandler: (name: string, args: unknown) =>
+      (handlers[name] ?? (() => ({ ok: true })))(args),
+  };
+}
+function removeShell() {
+  delete (window as unknown as { flutter_inappwebview?: unknown }).flutter_inappwebview;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+  changeCb = null;
+  listMcpTokensApi.mockResolvedValue([
+    { id: '1', label: 'Memex Desktop', prefix: 'mxt_active123', lastUsedAt: null, revokedAt: null },
+  ]);
+});
+afterEach(() => removeShell());
+
+describe('spec-304 ac-58 (t-61, issue-27): the pill is not re-pushed on a redundant re-derive', () => {
+  it('pushes the indicator once and does NOT re-push when an SSE re-derive yields the same status (ac-58)', async () => {
+    tagAc(AC_NO_REREVEAL);
+    const setMcpStatus = vi.fn(() => ({ ok: true }));
+    installShell({ mcpStatus: () => STATUS, setMcpStatus });
+
+    render(<DesktopMcpStatusSync />);
+
+    // First derive → one push of the honest "MCP ready" state.
+    await waitFor(() => expect(setMcpStatus).toHaveBeenCalledTimes(1));
+
+    // A background user-change event fires a re-derive. The local config and
+    // tokens are unchanged, so the derived indicator is identical — it must NOT
+    // be pushed again (issue-27: a redundant push made the pill re-reveal).
+    await act(async () => {
+      changeCb?.();
+    });
+    // Give the async refresh time to complete and (wrongly) re-push if it would.
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(setMcpStatus).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/ui/src/hooks/useDesktopMcpStatus.ts
+++ b/packages/ui/src/hooks/useDesktopMcpStatus.ts
@@ -75,6 +75,12 @@ export function useDesktopMcpStatus(): DesktopMcpStatus {
   // Bumped whenever the per-client pill preferences change, so the push effect
   // below re-runs and re-derives what the pill should show (dec-24).
   const [prefsVersion, setPrefsVersion] = useState(0);
+  // The last indicator pushed to the native pill, so a redundant re-derive (a
+  // background SSE event fires `refresh`, minting a NEW `clients` array on
+  // nearly every navigation) doesn't re-push an identical state — re-pushing
+  // makes the pill re-reveal/pop by itself (issue-27, ac-58). '__none__' marks
+  // the explicit hide so it, too, is pushed only once.
+  const lastPushRef = useRef<string | null>(null);
 
   const refresh = useCallback(async () => {
     if (!inShell) return;
@@ -134,10 +140,20 @@ export function useDesktopMcpStatus(): DesktopMcpStatus {
       (c) => c.transport === 'token' && isPillNotificationEnabled(c.key),
     );
     if (pillClients.length === 0) {
-      void clearMcpStatusBridge();
+      if (lastPushRef.current !== '__none__') {
+        lastPushRef.current = '__none__';
+        void clearMcpStatusBridge();
+      }
       return;
     }
-    void setMcpStatusBridge(deriveIndicator(pillClients.map((c) => c.status)));
+    const indicator = deriveIndicator(pillClients.map((c) => c.status));
+    // De-dupe (issue-27, ac-58): only push when the derived indicator actually
+    // changed. A re-derive that lands on the same state must NOT re-push, or the
+    // native pill re-reveals on every navigation.
+    const key = `${indicator.kind}|${indicator.label}|${indicator.visibility}`;
+    if (lastPushRef.current === key) return;
+    lastPushRef.current = key;
+    void setMcpStatusBridge(indicator);
   }, [inShell, clients, prefsVersion]);
 
   // Re-derive the pill when the per-client notification preference changes


### PR DESCRIPTION
Promotes `develop` → `main` (prod). Headline: the spec-371 checkout-plugin hook fix + the version bump that delivers it to installed users.

## Shipped in this release
- **fix(spec-371) #414** — checkout hooks now fire on the plugin-namespaced MCP tools (`mcp__plugin_memex-checkout_memex__*`), not only the direct `mcp__memex__*`. Before this, the `memex-checkout` plugin's marker → phone-home chain was a silent no-op on **every real plugin install**. Namespace-agnostic matcher + strip, with regression tests at all three layers (red on the prior code). Validated end-to-end against PROD (real `spec_checkout_edits` row).
- **chore(spec-371) #415** — bump `memex-checkout` `0.1.0 → 0.1.1`, so `claude plugin update` actually pulls the fix (installs pinned to 0.1.0 wouldn't otherwise).
- **fix(spec-304) #413** — current Claude Desktop connector steps; stop the MCP pill re-revealing on nav.
- **spec-421** — clarify the Connect-MCP step ticks on connect, not on paste.

## Deploy note
Per std-21 / `deploy.yml`, **merging this PR triggers the unattended prod deploy** — merging *is* the decision to ship. Opened for that explicit call; intentionally not auto-merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
