### PR TITLE
spec-431: surface empty orgs in MemexSwitcher

### DIFF
--- a/packages/server/src/services/auth.ts
+++ b/packages/server/src/services/auth.ts
@@ -3,6 +3,7 @@ import {
   getUserById,
   listMemberships,
   listMembershipsMatchingDomain,
+  listEmptyOrgs,
   type MembershipSummary,
 } from "./users.js";
 import { upsertVerifiedDomain } from "./verified-domains.js";
@@ -42,6 +43,18 @@ export interface SessionPayload {
   /** Server-issued JWT the client stores as `memex-auth-token`. Omitted when the
    * session is refreshed via /api/auth/me (the caller already has the token). */
   token?: string;
+  /**
+   * Orgs the user is an active member of that have no Memexes yet (doc-19 dec-1:
+   * new orgs start empty). These are invisible in `memberships` (which is
+   * memex-keyed) but must appear in the switcher so the user can navigate to them
+   * and create their first Memex. Optional for back-compat with cached sessions.
+   */
+  emptyOrgs?: Array<{
+    orgId: string;
+    slug: string;
+    name: string;
+    role: "member" | "administrator";
+  }>;
 }
 
 // Parses the HIDDEN_FEATURES env var (comma-separated feature slugs) into a list.
@@ -230,7 +243,10 @@ export async function resolveSession(
     throw new DisabledUserError(user.email);
   }
 
-  const memberships = await listMemberships(user.id);
+  const [memberships, emptyOrgs] = await Promise.all([
+    listMemberships(user.id),
+    listEmptyOrgs(user.id),
+  ]);
   const current = pickCurrentMemex(memberships, requestedMemexId);
 
   return {
@@ -242,6 +258,7 @@ export async function resolveSession(
       emailVerified: !!user.emailVerifiedAt,
     },
     memberships,
+    emptyOrgs,
     currentMemexId: current?.memexId ?? null,
     currentRole: current?.role ?? null,
     needsOnboarding: !user.identityConfirmedAt, // spec-305 dec-2/dec-4: gate on the identity step, not just a name (SSO users arrive named)

--- a/packages/server/src/services/users.integration.test.ts
+++ b/packages/server/src/services/users.integration.test.ts
@@ -20,6 +20,7 @@ import {
   getUserById,
   listMemberships,
   listMembershipsMatchingDomain,
+  listEmptyOrgs,
 } from "./users.js";
 
 const createdUserIds: string[] = [];
@@ -189,5 +190,57 @@ describe("listMemberships / listMembershipsMatchingDomain", () => {
 
     const matches = await listMembershipsMatchingDomain(user.id, "IVY.COM");
     expect(matches).toHaveLength(1);
+  });
+});
+
+// spec-431: orgs with no Memex were invisible in the switcher because
+// listMemberships uses an INNER JOIN on memexes. listEmptyOrgs surfaces them.
+describe("listEmptyOrgs", () => {
+  // Seed an org namespace WITHOUT a memex (unlike seedMemexTuple which always
+  // creates one). Returns { org, namespace }.
+  async function seedEmptyOrg(opts: { name: string; slug: string }) {
+    const [ns] = await db.insert(namespaces).values({ slug: opts.slug, kind: "org" }).returning();
+    const [org] = await db
+      .insert(orgs)
+      .values({ namespaceId: ns.id, name: opts.name, emailDomains: [] })
+      .returning();
+    await db.update(namespaces).set({ ownerOrgId: org.id }).where(eq(namespaces.id, ns.id));
+    return { org, namespace: ns };
+  }
+
+  it("returns the org when the user is a member and it has no Memexes", async () => {
+    const user = await upsertUserByEmail(uniqueEmail("empty-org-a"));
+    createdUserIds.push(user.id);
+
+    const { org } = await seedEmptyOrg({ name: "Empty Co", slug: uniqueSubdomain("emptyco") });
+
+    await db.insert(orgMemberships).values({ userId: user.id, orgId: org.id, role: "administrator" });
+
+    const result = await listEmptyOrgs(user.id);
+    const match = result.find((r) => r.orgId === org.id);
+    expect(match).toBeDefined();
+    expect(match!.name).toBe("Empty Co");
+    expect(match!.role).toBe("administrator");
+  });
+
+  it("does NOT return an org that already has a Memex", async () => {
+    const user = await upsertUserByEmail(uniqueEmail("empty-org-b"));
+    createdUserIds.push(user.id);
+
+    const { memex, org } = await seedMemexTuple({ name: "Full Co", slug: uniqueSubdomain("fullco") });
+    createdAccountIds.push(memex.id);
+
+    await db.insert(orgMemberships).values({ userId: user.id, orgId: org.id, role: "member" });
+
+    const result = await listEmptyOrgs(user.id);
+    expect(result.find((r) => r.orgId === org.id)).toBeUndefined();
+  });
+
+  it("returns empty array when user has no org memberships", async () => {
+    const user = await upsertUserByEmail(uniqueEmail("empty-org-c"));
+    createdUserIds.push(user.id);
+
+    const result = await listEmptyOrgs(user.id);
+    expect(result).toHaveLength(0);
   });
 });

--- a/packages/server/src/services/users.ts
+++ b/packages/server/src/services/users.ts
@@ -327,13 +327,47 @@ export async function listAccessibleNamespaces(userId: string): Promise<Namespac
   return [...personal, ...orgList];
 }
 
+// Returns orgs the user has an active membership in but that have no Memexes yet.
+// Used by resolveSession to include them in the session payload so the switcher
+// can surface them (doc-19 dec-1: new orgs are created empty by design).
+export async function listEmptyOrgs(userId: string): Promise<
+  Array<{ orgId: string; slug: string; name: string; role: "member" | "administrator" }>
+> {
+  const rows = await db
+    .select({
+      orgId: orgs.id,
+      slug: namespaces.slug,
+      name: orgs.name,
+      role: orgMemberships.role,
+      memexId: memexes.id,
+    })
+    .from(orgMemberships)
+    .innerJoin(orgs, eq(orgMemberships.orgId, orgs.id))
+    .innerJoin(namespaces, eq(orgs.namespaceId, namespaces.id))
+    .leftJoin(memexes, eq(memexes.namespaceId, namespaces.id))
+    .where(
+      and(
+        eq(orgMemberships.userId, userId),
+        eq(orgMemberships.status, "active"),
+      ),
+    );
+
+  return rows
+    .filter((r) => r.memexId === null)
+    .map((r) => ({
+      orgId: r.orgId,
+      slug: r.slug,
+      name: r.name ?? r.slug,
+      role: r.role as "member" | "administrator",
+    }));
+}
+
 // Returns ACTIVE memberships only — disabled members can't access the org, so they
 // shouldn't see it in their session/switcher. Re-enabling is admin-driven.
 //
 // Each row is keyed on a memex the user can reach (memexes joined via
 // org → namespace → memexes). Plus the user's personal Memex (their own namespace).
-// Orgs with zero memexes produce zero rows — use listAccessibleNamespaces if
-// the caller needs to surface empty orgs.
+// Orgs with zero memexes produce zero rows — see listEmptyOrgs for those.
 export async function listMemberships(userId: string): Promise<MembershipSummary[]> {
   const orgRows = await db
     .select({

--- a/packages/ui/src/api/auth.ts
+++ b/packages/ui/src/api/auth.ts
@@ -82,6 +82,18 @@ export interface SessionPayload {
   /** Fresh session token (present on signup/login/SSO/magic-link responses). Client stores
    *  as `memex-auth-token`. Absent on session refresh responses (client already has it). */
   token?: string;
+  /**
+   * Orgs the user is an active member of that have no Memexes yet (doc-19 dec-1).
+   * These are invisible in `memberships` (memex-keyed) but must appear in the
+   * switcher so the user can navigate to them. Optional for back-compat with
+   * sessions cached before this field shipped.
+   */
+  emptyOrgs?: Array<{
+    orgId: string;
+    slug: string;
+    name: string;
+    role: 'member' | 'administrator';
+  }>;
 }
 
 async function authEndpoint(

--- a/packages/ui/src/components/MemexSwitcher.tsx
+++ b/packages/ui/src/components/MemexSwitcher.tsx
@@ -139,6 +139,13 @@ export function MemexSwitcher({ variant = 'topbar' }: { variant?: 'topbar' | 'si
       });
     }
   }
+  // Orgs with no Memexes yet (doc-19 dec-1) don't appear in `memberships` at all.
+  // Seed them with an empty memexes array so they still show up in the switcher.
+  for (const org of session?.emptyOrgs ?? []) {
+    if (!orgsByNamespace.has(org.slug)) {
+      orgsByNamespace.set(org.slug, { name: org.name, role: org.role, memexes: [] });
+    }
+  }
 
   const isSidebar = variant === 'sidebar';
   const triggerClass = isSidebar
@@ -199,20 +206,32 @@ export function MemexSwitcher({ variant = 'topbar' }: { variant?: 'topbar' | 'si
                           {group.role}
                         </div>
                       </div>
-                      {group.memexes.map((mx) => {
-                        const mxSlug = mx.memexSlug ?? 'main';
-                        const active =
-                          isCurrentOrg && current?.memex === mxSlug;
-                        return (
-                          <SwitcherRow
-                            key={mx.memexId}
-                            title={mx.memexName ?? mx.name}
-                            active={active}
-                            onClick={() => goToOrgMemex(mx)}
-                            indent
-                          />
-                        );
-                      })}
+                      {group.memexes.length === 0 ? (
+                        <button
+                          onClick={() => {
+                            setOpen(false);
+                            navigate(namespaceHomePath(nsSlug));
+                          }}
+                          className="w-full text-left pl-6 pr-3 py-1.5 text-xs text-muted hover:text-primary hover:bg-overlay transition-colors"
+                        >
+                          No Memex yet — go to org
+                        </button>
+                      ) : (
+                        group.memexes.map((mx) => {
+                          const mxSlug = mx.memexSlug ?? 'main';
+                          const active =
+                            isCurrentOrg && current?.memex === mxSlug;
+                          return (
+                            <SwitcherRow
+                              key={mx.memexId}
+                              title={mx.memexName ?? mx.name}
+                              active={active}
+                              onClick={() => goToOrgMemex(mx)}
+                              indent
+                            />
+                          );
+                        })
+                      )}
                     </div>
                   );
                 })}


### PR DESCRIPTION
## Summary

- Orgs with no Memexes were silently absent from the session and MemexSwitcher because `listMemberships` uses an INNER JOIN on `memexes` — orgs with zero Memexes produce zero rows
- Discovered during Francesco's onboarding (2026-06-29): creating an Org immediately made it invisible in the UI
- Fixes: [spec-431](https://memex.ai/mindset-prod/memex-building-itself/specs/spec-431)

## Changes

**Backend** (`packages/server/src/services/users.ts` + `auth.ts`)
- New `listEmptyOrgs(userId)`: LEFT JOIN on `memexes`, filter WHERE `memexes.id IS NULL`
- `resolveSession` calls `listMemberships` + `listEmptyOrgs` in parallel, attaches `emptyOrgs` to `SessionPayload`
- `emptyOrgs` is optional — backward-compatible with cached sessions

**Frontend** (`packages/ui/src/api/auth.ts` + `MemexSwitcher.tsx`)
- Mirror `emptyOrgs` on the client-side `SessionPayload` type
- `MemexSwitcher` seeds empty orgs into `orgsByNamespace`; renders a "No Memex yet — go to org" row that navigates to `/<slug>/`

## Test plan

- [ ] 3 new integration tests in `users.integration.test.ts` — all 13 pass locally (`vitest run`)
- [ ] Create an Org without adding a Memex → Org appears in the switcher
- [ ] "No Memex yet — go to org" navigates to `/<slug>/`
- [ ] After adding a Memex to the Org, normal `SwitcherRow` renders instead of the placeholder

🤖 Generated with [Claude Code](https://claude.com/claude-code)