### PR TITLE
docs: feature-hiding is the source of truth on where HIDDEN_FEATURES lives

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -409,7 +409,7 @@ make deploy-admin      # SPA only (object storage + CDN)
 
 > The official `memex.ai` / `int.memex.ai` instances are operated by Mindset on GCP, and the deploy scripts assume that environment (Cloud SQL, Secret Manager, and JIT credentials). The Mindset-internal runbook — project names, PAM entitlements, prerequisite CLIs — is not part of the public repo. Self-hosters should treat the `make deploy*` targets and `deploy.sh` / `packages/server/deploy.sh` as a reference and adapt them to their own infrastructure.
 
-**Feature hiding (soft-launch control).** The server reads the per-environment `HIDDEN_FEATURES` env var (comma-separated feature slugs) at runtime to suppress UI elements — per-environment, all-or-nothing, fail-open (empty = nothing hidden). To hide/unhide a feature, edit `HIDDEN_FEATURES` in the target env's `scripts/deploy.<env>.env` and run `make deploy-server` (no admin-bundle rebuild needed). Full hide/unhide runbook: [`docs/feature-hiding.md`](docs/feature-hiding.md).
+**Feature hiding (soft-launch control).** The server reads the per-environment `HIDDEN_FEATURES` env var (comma-separated feature slugs) at runtime to suppress UI elements — per-environment, all-or-nothing, fail-open (empty = nothing hidden). The value that **survives a deploy** lives in the `DEPLOY_ENV_FILE` GitHub Actions environment secret (CI writes it to `scripts/deploy.<env>.env` at deploy time); editing the live Cloud Run env var or the GCP `memex-<env>-deploy-env` secret is reverted by the next deploy. Full hide/unhide runbook — slugs, the three stores, and the durable change procedure: [`docs/feature-hiding.md`](docs/feature-hiding.md).
 
 ### Production URLs
 

--- a/docs/feature-hiding.md
+++ b/docs/feature-hiding.md
@@ -1,88 +1,146 @@
 # Feature Hiding Runbook (`HIDDEN_FEATURES`)
 
-Operational runbook for hiding/unhiding soft-launched features per environment.
+How to hide/unhide soft-launched features per environment — and, more importantly,
+**where the value actually lives** so a change sticks instead of being reverted by
+the next deploy.
 
-The server reads the `HIDDEN_FEATURES` env var at runtime via
-`getHiddenFeatures()` (`packages/server/src/services/auth.ts`) and suppresses
-the matching UI elements server-wide. No admin-bundle (SPA) rebuild is needed —
-this is a server-side env var, picked up on the next `make deploy-server`.
+> **TL;DR — to durably change what's hidden on an environment, edit the
+> `HIDDEN_FEATURES` line inside the GitHub Actions environment secret
+> `DEPLOY_ENV_FILE` (scoped to the `prod` / `int` environment).** That secret is
+> what CI reads on every deploy. Editing the live Cloud Run env var, the local
+> `scripts/deploy.<env>.env`, or the GCP `memex-<env>-deploy-env` secret will
+> *not* survive the next merge-to-`main`/`develop` deploy. See
+> [Where the value actually lives](#where-the-value-actually-lives).
+
+## What `HIDDEN_FEATURES` does
+
+The server reads `HIDDEN_FEATURES` at runtime via `getHiddenFeatures()`
+([`packages/server/src/services/auth.ts`](../packages/server/src/services/auth.ts)),
+puts the parsed slug list on the session payload (`/api/auth/me`), and the React
+UI drops the matching nav links + routes via
+[`packages/ui/src/utils/featureFlags.ts`](../packages/ui/src/utils/featureFlags.ts).
+It's a server-side env var — no SPA/admin-bundle rebuild is needed, it's picked up
+on the next server deploy.
 
 ## Slugs in play
 
-| Slug         | Feature  |
-|--------------|----------|
-| `scaffold`   | spec-146 |
-| `spec-pause` | spec-147 |
-| `pulse`      | spec-148 |
+| Slug         | Hides                           |
+|--------------|---------------------------------|
+| `scaffold`   | Scaffold inspector              |
+| `spec-pause` | Spec pause/resume controls      |
+| `pulse`      | Pulse activity board            |
+| `home`       | Home tab (nav link + `/` route) |
 
-## Semantics
+The value is a comma-separated slug list, e.g. `HIDDEN_FEATURES="spec-pause,home"`.
 
-- **Per-environment.** `HIDDEN_FEATURES` lives in each env's deploy config
-  (`scripts/deploy.int.env`, `scripts/deploy.prod.env`), so int and prod are
-  controlled independently.
-- **All-or-nothing.** The value is a comma-separated slug list; a slug is either
-  in the list (hidden) or not (shown). There is no partial/percentage rollout.
-- **Fail-open (runtime).** On the running server, unset or empty
-  `HIDDEN_FEATURES` => `getHiddenFeatures()` returns `[]` => nothing is hidden.
-- **Deploy-time: unset ≠ empty (spec-168 dec-4).** A deploy only writes
-  `HIDDEN_FEATURES` onto the service when the deployer's config **explicitly
-  sets** it. If the value is **unset** (line absent/commented), the deploy
-  **omits** it and leaves whatever is already live untouched — it will NOT blank
-  an existing hidden state. An **explicit empty** value (`HIDDEN_FEATURES=""`) is
-  a deliberate instruction to un-hide. This stops a deploy from a checkout that
-  never set the value from silently un-hiding features (the failure mode that
-  shipped prod rev `memex-api-00035` un-hidden).
+## Where the value actually lives
 
-## HIDE a feature
+This is the part that causes confusion. There are **three** places the value can
+appear, but for a normal (CI) deploy **only one governs**:
 
-1. Edit the target env's deploy config and add the slug(s) to `HIDDEN_FEATURES`
-   (comma-separated, no spaces required):
-   - int  → `scripts/deploy.int.env`
-   - prod → `scripts/deploy.prod.env`
+| # | Store | Read by | Authoritative for |
+|---|-------|---------|-------------------|
+| 1 | **GitHub Actions environment secret `DEPLOY_ENV_FILE`** (one per env: `prod`, `int`) — holds the entire `deploy.<env>.env` body | The `deploy` CI job ([`.github/workflows/deploy.yml`](../.github/workflows/deploy.yml)) writes it to `scripts/deploy.<env>.env`, then `deploy-config.sh` sources it | **Every CI deploy** (merge to `main` → prod, `develop` → int). **This is the one that matters.** |
+| 2 | Live Cloud Run env var on `memex-api` | The running container | The current revision *only*. Overwritten by the next CI deploy. |
+| 3 | GCP Secret Manager secret `memex-<env>-deploy-env` | `deploy-config.sh` **only when no local `scripts/deploy.<env>.env` exists** | Laptop deploys with no local file. **Not read in CI** — CI always writes the local file from `DEPLOY_ENV_FILE`, which wins. Effectively a red herring for the deploy pipeline. |
 
-   ```bash
-   HIDDEN_FEATURES="scaffold,spec-pause,pulse"
-   ```
-2. Redeploy the server:
-   ```bash
-   make deploy-server            # int (ENV defaults to int)
-   ENV=prod make deploy-server   # prod
-   ```
+### Why (1) wins in CI
 
-No admin-bundle rebuild is required.
+`deploy-config.sh` resolves its config source like this:
 
-## UNHIDE a feature
+- `DEPLOY_CONFIG_SOURCE=local` → use `scripts/deploy.<env>.env`
+- `DEPLOY_CONFIG_SOURCE=secret` → fetch GCP Secret Manager `memex-<env>-deploy-env`
+- **unset (the default)** → if `scripts/deploy.<env>.env` is present, use it; otherwise fetch the GCP secret.
 
-1. In the target env's deploy config, **explicitly set** `HIDDEN_FEATURES` to the
-   reduced slug list, or to `""` to unhide everything. ⚠️ **Deleting or
-   commenting out the line does NOT unhide** (spec-168 dec-4) — an unset value is
-   left untouched on the running service, so an explicit assignment is required
-   to clear it:
-   ```bash
-   HIDDEN_FEATURES=""         # un-hide everything
-   # HIDDEN_FEATURES="pulse"  # …or keep some hidden
-   ```
-2. Redeploy the server (`make deploy-server`, or `ENV=prod make deploy-server`
-   for prod).
+The CI deploy job writes `scripts/deploy.<env>.env` from the `DEPLOY_ENV_FILE`
+secret *before* running the deploy, so the local-file branch always wins and the
+GCP secret is never consulted. Then
+[`packages/server/deploy.sh`](../packages/server/deploy.sh) injects the value with
+`gcloud run deploy --update-env-vars HIDDEN_FEATURES=<value>`.
 
-   Or clear it directly on the running service without a redeploy:
-   ```bash
-   gcloud run services update memex-api --region=us-east4 \
-     --project=memex-ai-<env> --remove-env-vars HIDDEN_FEATURES
-   ```
+### Why editing (2) or (3) doesn't stick
 
-## Launch-env cutover
+- **(2) Live Cloud Run env var** — a manual
+  `gcloud run services update ... --update-env-vars=HIDDEN_FEATURES=...` changes
+  the serving revision immediately, but the next CI deploy reads `DEPLOY_ENV_FILE`
+  and overwrites it. (This is the "I bumped it and it reverted" loop.)
+- **(3) GCP `memex-<env>-deploy-env`** — only the canonical-on-paper copy. CI
+  doesn't read it. Changing it alone does nothing to CI deploys.
 
-`HIDDEN_FEATURES="spec-pause"` on **both int and prod today** — Pulse (spec-148)
-and Scaffold (spec-146) have shipped and are un-hidden; only the pause feature
-(spec-147) remains hidden pending its own launch. Both the canonical
-`memex-<env>-deploy-env` secrets and the running `memex-api` services carry this
-value.
+## Deploy-time semantics: unset ≠ empty
 
-To un-hide the pause feature once it ships, set `HIDDEN_FEATURES=""` (explicit
-empty — see UNHIDE above; deleting the line does NOT un-hide) and redeploy, or
-clear it on the running service directly.
+`--update-env-vars` is a **merge**, and `deploy.sh` only includes
+`HIDDEN_FEATURES` in that merge when the sourced config **explicitly set** it
+(`${HIDDEN_FEATURES+...}`):
 
-History: the soft-launch shipped with `HIDDEN_FEATURES="scaffold,spec-pause,pulse"`
-hiding all three on both envs. Pulse + Scaffold were un-hidden together once
-spec-122 (the Pulse activity board) landed.
+- **Set to a value** (`HIDDEN_FEATURES="spec-pause,home"`) → that value is written.
+- **Set to empty** (`HIDDEN_FEATURES=""`) → a deliberate "un-hide everything"; written as empty.
+- **Unset** (line absent/commented) → **omitted** from the merge; whatever is
+  already live is left untouched. Deleting the line does **not** un-hide — it
+  freezes the current state. (This guard stops a deploy from a checkout that
+  never set the value from silently un-hiding features.)
+
+Runtime is **fail-open**: an unset/empty `HIDDEN_FEATURES` on the running server
+makes `getHiddenFeatures()` return `[]` → nothing hidden.
+
+## Durably change what's hidden (the procedure that sticks)
+
+GitHub Actions secrets are **write-only opaque blobs** — there is no way to patch
+one line in place; you re-upload the whole `DEPLOY_ENV_FILE` body. Because the
+local `scripts/deploy.<env>.env` and the GCP `memex-<env>-deploy-env` secret are
+meant to mirror it, the safe flow is: rebuild the full body from the canonical GCP
+copy, edit the one line, push it back to GitHub, and re-sync the GCP copy.
+
+```bash
+ENV=prod                              # or int
+PROJECT=memex-ai-${ENV}
+SRC=scripts/deploy.${ENV}.env
+NEW_VALUE="spec-pause"                # the desired full slug list
+
+# 1. Rebuild the full config body from the canonical GCP copy, flipping ONE line.
+gcloud secrets versions access latest --secret="memex-${ENV}-deploy-env" --project="$PROJECT" \
+  | sed -E "s/^(export[[:space:]]+)?HIDDEN_FEATURES=.*/HIDDEN_FEATURES=\"${NEW_VALUE}\"/" \
+  > "$SRC"
+
+# 2. Sanity-check just the line you changed.
+grep HIDDEN_FEATURES "$SRC"
+
+# 3. Push the whole body to the GitHub env secret CI actually reads (the durable fix).
+gh secret set DEPLOY_ENV_FILE --env "$ENV" --repo mindset-ai/memex-ai < "$SRC"
+
+# 4. Keep the canonical GCP copy in sync so the two stores don't drift.
+gcloud secrets versions add "memex-${ENV}-deploy-env" --project="$PROJECT" --data-file="$SRC"
+
+# 5. The local file holds DB coordinates — remove it once done (CI regenerates it).
+rm "$SRC"
+```
+
+The change takes effect on the **next deploy** of that env (merge to `main`/`develop`,
+or a manual "Deploy" workflow_dispatch). To also flip the *currently live* revision
+without waiting for a deploy, additionally run the manual update below — but the
+durable fix above is what makes it last.
+
+## Flip the live revision immediately (does NOT persist on its own)
+
+```bash
+gcloud run services update memex-api --region=us-east4 --project=memex-ai-<env> \
+  --update-env-vars=HIDDEN_FEATURES=spec-pause
+```
+
+Use this only for an instant change; pair it with the durable procedure above or
+the next CI deploy will revert it.
+
+## Check the current state
+
+```bash
+# What the live prod service is serving right now:
+gcloud run services describe memex-api --project=memex-ai-prod --region=us-east4 \
+  --format="value(spec.template.spec.containers[0].env)" | tr ';' '\n' | grep HIDDEN_FEATURES
+
+# Which GitHub env secrets exist (values are write-only, can't be read back):
+gh secret list --env prod --repo mindset-ai/memex-ai
+```
+
+(`DEPLOY_ENV_FILE` is what governs the next deploy, but its value can't be read
+back — confirm intended changes by inspecting the live service after a deploy, or
+the GCP `memex-<env>-deploy-env` copy if it's been kept in sync.)

--- a/packages/server/src/services/auth.ts
+++ b/packages/server/src/services/auth.ts
@@ -47,6 +47,9 @@ export interface SessionPayload {
 // Parses the HIDDEN_FEATURES env var (comma-separated feature slugs) into a list.
 // Fail-open: an unset or empty var yields [] — never throws, never hides by default.
 // Kept here as the single reusable parse site for sibling specs (spec-147/spec-148).
+// To CHANGE what's hidden per environment, see docs/feature-hiding.md (the runbook):
+// the value that survives a deploy lives in the DEPLOY_ENV_FILE GitHub Actions secret,
+// NOT the live Cloud Run env var or the GCP memex-<env>-deploy-env secret.
 export function getHiddenFeatures(): string[] {
   return (process.env.HIDDEN_FEATURES ?? "")
     .split(",")


### PR DESCRIPTION
## Why

A question as small as \"unhide the Home tab on prod\" took ~30 minutes to resolve because the docs pointed at the wrong store. \`docs/feature-hiding.md\` and the \`DEVELOPMENT.md\` blurb both said: edit \`HIDDEN_FEATURES\` in \`scripts/deploy.<env>.env\` and run \`make deploy-server\`.

CI deploys read **neither** that local file **nor** the GCP \`memex-<env>-deploy-env\` secret. They read the **\`DEPLOY_ENV_FILE\` GitHub Actions environment secret** (written to \`scripts/deploy.<env>.env\` on the runner at deploy time). So the documented procedure — and a manual \`gcloud run ... --update-env-vars\` bump of the live revision — is silently reverted by the next deploy. That's the loop this PR kills.

## What changed

- **\`docs/feature-hiding.md\`** — rewritten around *where the value actually lives*: the three stores, which one CI reads, and why the other two don't persist. Adds the \`home\` slug, the durable change procedure (re-upload the whole \`DEPLOY_ENV_FILE\` body — GitHub secrets are write-only), and replaces the stale hardcoded \"current state\" section with commands to check live state.
- **\`DEVELOPMENT.md\`** — names \`DEPLOY_ENV_FILE\` as the store that survives a deploy.
- **\`packages/server/src/services/auth.ts\`** — a runbook pointer comment at \`getHiddenFeatures()\`.

These shipped surfaces are kept self-contained: no internal Memex handles (\`std-\`/\`spec-\`/\`dec-N\`) are referenced, since self-hosters get the codebase but not our Standards.

## Companion (Memex-side)

The governing rule (std-26 §9, \"deploy.sh is the only injection point\") is being strengthened separately to name the *change-an-existing-value* case and link this runbook (Standard→code, the allowed direction).

## Test plan

- [x] Docs + one non-functional comment; no behavior change.
- [ ] Required CI gate (full server/UI suite + e2e) green on this PR.