### PR TITLE
fix(spec-421 issue-5): "Getting started" title invisible in dark mode

### DIFF
--- a/packages/ui/src/pages/HomeCanvas.test.tsx
+++ b/packages/ui/src/pages/HomeCanvas.test.tsx
@@ -334,12 +334,12 @@ describe('HomeCanvas v2 — tracker is always expanded (spec-372 issue-8)', () =
     expect(screen.getByTestId('journey-content')).toBeInTheDocument();
   });
 
-  it('spec-372 issue-7: the tracker title is black and medium weight (not blue, not bold)', async () => {
+  it('spec-372 issue-7: the tracker title is theme-aware and medium weight (not blue, not bold)', async () => {
     tagAc(AC372(48));
     fetchJourneyStateApi.mockResolvedValue(stateFor('create-spec', { attained: ['identity'] }));
     renderCanvas();
     const title = await screen.findByTestId('getting-started-title');
-    expect(title.className).toContain('text-black');
+    expect(title.className).toContain('text-foreground');
     expect(title.className).toContain('font-medium');
     expect(title.className).not.toContain('text-[#0482DC]');
     expect(title.className).not.toContain('font-bold');

--- a/packages/ui/src/pages/HomeCanvas.tsx
+++ b/packages/ui/src/pages/HomeCanvas.tsx
@@ -358,7 +358,7 @@ export function HomeCanvas() {
             {/* Header — static (spec-372 issue-8 removed the collapse/expand toggle + chevron). */}
             <div className="flex flex-wrap items-center gap-3 rounded-xl border-b border-edge px-2 pb-4 pt-1">
               {/* spec-372 issue-7 — title is black (not the global accent blue) and medium weight. */}
-              <h2 data-testid="getting-started-title" className="whitespace-nowrap text-lg font-medium text-black">
+              <h2 data-testid="getting-started-title" className="whitespace-nowrap text-lg font-medium text-foreground">
                 Getting started on Memex
               </h2>
               <div className="ml-auto flex items-center gap-3">


### PR DESCRIPTION
## Summary

- `text-black` was hardcoded on the "Getting started on Memex" `<h2>` in `HomeCanvas.tsx` (spec-372 i-7 set it intentionally to avoid the accent blue)
- In dark mode the text is invisible (black on dark background)
- Fix: swap `text-black` → `text-foreground` so the title respects the active theme

Closes spec-421 issue-5.

## Test plan

- [ ] Open app in dark mode as an onboarding user → Home → "Getting started on Memex" title is legible
- [ ] Open app in light mode → title still renders dark (not accent blue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)