### PR TITLE
fix(spec-304): MCP pill — Ready stays + auto-flips to Connected (t-65, t-66)

### DIFF
--- a/packages/ui/src/desktop/mcpStatus.test.ts
+++ b/packages/ui/src/desktop/mcpStatus.test.ts
@@ -20,6 +20,10 @@ const AC_PER_TOKEN =
 // signal, independent of local config.
 const AC_CONNECTOR =
   'mindset-prod/memex-building-itself/specs/spec-304/acs/ac-56';
+// issue-31 → t-65: "MCP Ready" must STAY like the Install prompt (snoozable),
+// not auto-hide like Connected (transient).
+const AC_READY_STAYS =
+  'mindset-prod/memex-building-itself/specs/spec-304/acs/ac-62';
 
 // An active token whose matching local entry HAS handshaked (lastUsedAt set).
 const CONNECTED_TOKEN: ActiveToken = {
@@ -180,13 +184,28 @@ describe('spec-304 ac-49: app-global indicator — quiet, honest, MCP-led wordin
     });
   });
 
-  it('ready (installed, no handshake) is transient and never reads "connected"', () => {
+  it('ready (installed, no handshake) stays (snoozable) and never reads "connected"', () => {
     tagAc(AC_INDICATOR);
     const ind = deriveIndicator([s('ready'), s('not_installed')]);
     expect(ind.kind).toBe('ready');
     expect(ind.label).toBe('MCP ready');
     expect(ind.label).not.toContain('connected');
-    expect(ind.visibility).toBe('transient');
+    // Ready stays up like Install, not auto-hidden like Connected (issue-31).
+    expect(ind.visibility).toBe('snoozable');
+  });
+
+  it('ready STAYS visible like the Install prompt — snoozable, not transient (ac-62)', () => {
+    tagAc(AC_READY_STAYS);
+    // Ready = installed + authorized, no handshake yet: an actionable "go make
+    // Claude connect" state, not the quiet healthy steady state. It must stay
+    // up (dismissible) like Install, not auto-hide like Connected (issue-31).
+    const ready = deriveIndicator([s('ready'), s('not_installed')]);
+    expect(ready.kind).toBe('ready');
+    expect(ready.visibility).toBe('snoozable');
+    // It now matches the Install prompt's staying behaviour…
+    expect(deriveIndicator([s('not_installed')]).visibility).toBe('snoozable');
+    // …while Connected stays transient (quiet when genuinely healthy).
+    expect(deriveIndicator([s('connected')]).visibility).toBe('transient');
   });
 
   it('a broken install (repair / wrong-server) is a PERSISTENT "MCP needs repair" badge', () => {

--- a/packages/ui/src/desktop/mcpStatus.ts
+++ b/packages/ui/src/desktop/mcpStatus.ts
@@ -141,7 +141,12 @@ export function deriveIndicator(statuses: readonly ClientStatus[]): Indicator {
     return { kind: 'connected', label: 'MCP connected', visibility: 'transient' };
   }
   if (kinds.has('ready')) {
-    return { kind: 'ready', label: 'MCP ready', visibility: 'transient' };
+    // Ready = installed + authorized, no handshake yet. It STAYS visible like
+    // the Install prompt (snoozable), not auto-hidden like Connected — it's an
+    // actionable "go make Claude connect" state, not the quiet healthy steady
+    // state (issue-31). It flips to the transient "connected" once a handshake
+    // is observed.
+    return { kind: 'ready', label: 'MCP ready', visibility: 'snoozable' };
   }
   if (kinds.has('repair') || kinds.has('reinstall')) {
     return { kind: 'repair', label: 'MCP needs repair', visibility: 'persistent' };

--- a/packages/ui/src/hooks/useDesktopMcpStatus.poll.test.tsx
+++ b/packages/ui/src/hooks/useDesktopMcpStatus.poll.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, act } from '@testing-library/react';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { DesktopMcpStatusSync } from '../components/DesktopMcpStatusSync';
+
+// t-66 → issue-32 / ac-63: the handshake that flips Ready→Connected is a SILENT,
+// user-less server write (mcp-tokens.bumpLastUsed), so no SSE event ever fires.
+// While the pill shows "Ready", the hook must re-probe on a backoff until it
+// observes the handshake (token.lastUsedAt) and pushes "Connected" — without the
+// user having to visit the Integrations page.
+const AC_POLL = 'mindset-prod/memex-building-itself/specs/spec-304/acs/ac-63';
+
+vi.mock('../components/AuthContext', () => ({ useAuth: () => ({ token: 'test-token' }) }));
+// No SSE: the whole point is that the handshake does NOT emit one.
+vi.mock('../hooks/useUserChangeStream', () => ({ useUserChangeStream: () => {} }));
+
+const listMcpTokensApi = vi.fn();
+vi.mock('../api/mcp', () => ({
+  listMcpTokensApi: (...a: unknown[]) => listMcpTokensApi(...a),
+  mintMcpTokenApi: vi.fn(),
+}));
+
+const STATUS = {
+  ok: true,
+  targets: {
+    claudeCode: { installed: true, urlMatches: true, tokenPrefix: 'mxt_active123' },
+    claudeDesktop: { installed: false, urlMatches: false, tokenPrefix: null },
+  },
+};
+
+function installShell(setMcpStatus: (args: unknown) => unknown) {
+  (window as unknown as { flutter_inappwebview?: unknown }).flutter_inappwebview = {
+    callHandler: (name: string, args: unknown) => {
+      if (name === 'mcpStatus') return STATUS;
+      if (name === 'setMcpStatus') return setMcpStatus(args);
+      return { ok: true };
+    },
+  };
+}
+function removeShell() {
+  delete (window as unknown as { flutter_inappwebview?: unknown }).flutter_inappwebview;
+}
+
+const token = (lastUsedAt: string | null) => [
+  { id: '1', label: 'Memex Desktop', prefix: 'mxt_active123', lastUsedAt, revokedAt: null },
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+});
+afterEach(() => {
+  removeShell();
+  vi.useRealTimers();
+});
+
+describe('spec-304 ac-63 (t-66, issue-32): pill auto-flips Ready→Connected via backoff re-probe', () => {
+  it('re-probes while Ready and pushes Connected once the token handshakes — no Integrations visit, no SSE (ac-63)', async () => {
+    tagAc(AC_POLL);
+    const pushes: Array<{ kind: string }> = [];
+    const setMcpStatus = vi.fn((args: unknown) => {
+      pushes.push(args as { kind: string });
+      return { ok: true };
+    });
+
+    // Start: token minted but never used → Ready.
+    listMcpTokensApi.mockResolvedValue(token(null));
+    installShell(setMcpStatus);
+
+    vi.useFakeTimers();
+    render(<DesktopMcpStatusSync />);
+
+    // Flush the on-mount probe → Ready pushed, Connected not yet.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(pushes.some((p) => p.kind === 'ready')).toBe(true);
+    expect(pushes.some((p) => p.kind === 'connected')).toBe(false);
+
+    // The handshake happens server-side (lastUsedAt set). NO SSE event fires.
+    listMcpTokensApi.mockResolvedValue(token('2026-06-29T19:00:00Z'));
+
+    // Advance past the first backoff step (10s): the re-probe must run and flip.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_000);
+    });
+
+    expect(pushes.some((p) => p.kind === 'connected')).toBe(true);
+  });
+});

--- a/packages/ui/src/hooks/useDesktopMcpStatus.ts
+++ b/packages/ui/src/hooks/useDesktopMcpStatus.ts
@@ -14,7 +14,7 @@
 // per-token lastUsedAt — ac-52), and the user-scoped mcp.connected signal (used
 // for the Claude Desktop connector, dec-23). No-op outside the desktop shell.
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useAuth } from '../components/AuthContext';
 import { useUserChangeStream } from './useUserChangeStream';
 import { listMcpTokensApi } from '../api/mcp';
@@ -37,6 +37,12 @@ import {
 import { isPillNotificationEnabled, subscribePillPrefs } from '../desktop/mcpPillPrefs';
 
 export type McpPhase = 'idle' | 'loading' | 'ready' | 'error';
+
+// issue-32 (ac-63): the Ready→Connected handshake is a SILENT, user-less server
+// write (mcp-tokens.bumpLastUsed), so no SSE event flips the pill. While the
+// pill shows "MCP Ready", re-probe on this backoff (ms) — then STOP (never poll
+// forever). A return-to-foreground restarts the schedule from the top.
+const REPROBE_BACKOFF_MS = [10_000, 15_000, 30_000, 60_000, 120_000, 240_000, 360_000];
 
 export interface DesktopMcpClient {
   key: keyof McpStatusResult;
@@ -160,6 +166,52 @@ export function useDesktopMcpStatus(): DesktopMcpStatus {
   // (toggled in DesktopMcpSection). The store is shared across hook instances so
   // the app-global sync and the Settings section never disagree.
   useEffect(() => subscribePillPrefs(() => setPrefsVersion((v) => v + 1)), []);
+
+  // Whether the pill is currently in the "ready" (installed, awaiting first
+  // handshake) state — the only state the re-probe below needs to chase.
+  const awaitingHandshake = useMemo(() => {
+    if (!inShell || clients.length === 0) return false;
+    const pillClients = clients.filter(
+      (c) => c.transport === 'token' && isPillNotificationEnabled(c.key),
+    );
+    if (pillClients.length === 0) return false;
+    return deriveIndicator(pillClients.map((c) => c.status)).kind === 'ready';
+  }, [inShell, clients, prefsVersion]);
+
+  // Backoff re-probe while Ready (issue-32, ac-63). Each step re-runs refresh();
+  // once the handshake lands the state leaves 'ready', this effect tears down,
+  // and polling stops. After the final step we stop entirely — no infinite
+  // poll. Returning to the foreground (visibilitychange → visible) restarts the
+  // schedule from the top and probes immediately, so it self-heals after the
+  // hard stop and catches a handshake that happened while we were away.
+  // `visibilitychange` (not focus) is deliberate: focus churns on every webview
+  // navigation, but visibilityState only flips on a genuine hide/show.
+  useEffect(() => {
+    if (!awaitingHandshake || typeof document === 'undefined') return;
+    let step = 0;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const scheduleNext = () => {
+      if (step >= REPROBE_BACKOFF_MS.length) return; // hard stop
+      timer = setTimeout(() => {
+        void refresh();
+        step += 1;
+        scheduleNext();
+      }, REPROBE_BACKOFF_MS[step]);
+    };
+    const onVisibility = () => {
+      if (document.visibilityState !== 'visible') return;
+      clearTimeout(timer);
+      step = 0;
+      void refresh();
+      scheduleNext();
+    };
+    scheduleNext();
+    document.addEventListener('visibilitychange', onVisibility);
+    return () => {
+      clearTimeout(timer);
+      document.removeEventListener('visibilitychange', onVisibility);
+    };
+  }, [awaitingHandshake, refresh]);
 
   // Real-time: a token minted/revoked anywhere re-derives status (and the mint
   // that an in-app install performs flows back through here to update the pill).


### PR DESCRIPTION
Two of the three pill visibility/state bugs from the 2026-06-29 staging-verify round (web side). Found by Will testing the desktop staging build.

## issue-31 → t-65 (ac-62) — "MCP Ready" auto-hid; it should stay
`deriveIndicator` mapped `ready` → `transient` (same class as `connected`), so "MCP Ready" hid after the reveal window. Ready = installed-but-never-handshaked = an actionable "go make Claude connect" state, not the quiet healthy steady state. Now maps `ready` → **`snoozable`**: it stays visible with a dismiss "×", exactly like the Install prompt. `connected` stays `transient` (correct — quiet when genuinely healthy). The Dart pill already renders snoozable persistently, so no native change.

## issue-32 → t-66 (ac-63) — pill never flipped Ready→Connected on its own
The handshake that flips Ready→Connected (`token.lastUsedAt`) is written by `mcp-tokens.bumpLastUsed`, which is `{ silent: true }` **and carries no `userId`** — so it emits nothing on the `/api/me/events` bus the pill listens on. The app-global hook therefore never re-probed after a handshake; the pill showed stale "Ready" until you visited Integrations (which mounts a second hook instance that re-probes).

Fix (client-only, no server change): while the derived state is `ready`, `useDesktopMcpStatus` re-probes on a **`[10,15,30,60,120,240,360]s` backoff, then stops** (no infinite poll). A return-to-foreground (`visibilitychange → visible`, *not* focus — focus churns on every navigation) restarts the schedule from the top and probes immediately, so it self-heals after the hard stop. The existing push-dedupe (ac-58) means unchanged re-probes push nothing.

## Tests
- `mcpStatus.test.ts`: new case tagged **ac-62** (ready ⇒ snoozable; connected stays transient) — red→green; stale ac-49 assertion updated to match.
- `useDesktopMcpStatus.poll.test.tsx` (new): tagged **ac-63** — Ready, then a *silent* handshake (lastUsedAt set, no SSE), advance 10s → auto-pushes Connected — red→green.
- Full `ui` suite green except the pre-existing, unrelated `UpgradeConfirmation.spec-171` date-format test (untouched by this PR). `tsc --noEmit` clean.

QA report: spec-304 (this build session). Native counterpart (issue-33/t-67, the reveal-on-navigation fix) is a separate memex-clients PR.