### PR TITLE
feat(spec-430): one-command, one-sign-in coding-agent onboarding

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
     "url": "https://memex.ai"
   },
   "metadata": {
-    "description": "Memex plugins for coding agents — the Memex MCP server plus light-touch spec-checkout hooks, bundled so they install in one move."
+    "description": "Memex plugins for coding agents — light-touch spec-checkout hooks. The Memex MCP server is planted by `npx -y memex-ai install`, so a single browser sign-in serves both the MCP and the checkout key (spec-430)."
   },
   "plugins": [
     {
       "name": "memex-checkout",
       "source": "./packages/cli/plugin",
-      "description": "Binds your coding thread to a Memex Spec and records in-flow edits against it (claim-gated, privacy-first). Bundles the Memex MCP server and the spec-checkout hooks as one opt-in, trivially-uninstallable unit. Sends only changed file paths + the claimed spec; never source code or prompts."
+      "description": "Binds your coding thread to a Memex Spec and records in-flow edits against it (claim-gated, privacy-first). Hooks-only and trivially uninstallable; the Memex MCP is planted by `npx -y memex-ai install` (one sign-in serves both, no duplicate toolset). Sends only changed file paths + the claimed spec; never source code or prompts."
     }
   ]
 }

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -6,18 +6,33 @@ Zero-dependency CLI for installing the [Memex.AI](https://memex.ai) MCP server
 into Claude Code and Claude Desktop.
 
 ```bash
-npx memex-ai
+npx -y memex-ai install
 ```
 
-That's it. The CLI walks you through a device-flow authorization, gets a
-long-lived Personal Access Token (`mxt_...`), and merges the MCP server entry
-into:
+**One sign-in, both credentials.** A single device-flow authorization mints your
+long-lived Personal Access Token (`mxt_...`) — planted as the MCP server entry —
+**and** your one per-user spec-checkout key (`mxh_...`, stored at
+`~/.memex/checkout.json`). No second sign-in, no per-memex keys, nothing pasted by
+hand. The MCP entry is merged into:
 
 - `~/.claude.json` (Claude Code / `claude` CLI)
 - `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS Desktop)
 - `%APPDATA%\Claude\claude_desktop_config.json` (Windows Desktop)
 
-Restart Claude and Memex tools are available in any conversation.
+### Easiest path: let Claude Code drive it
+
+Paste the **“Set up your coding agent”** prompt from your Memex into a fresh Claude
+Code session — it runs the whole thing and explains each step:
+
+```
+npx -y memex-ai install                           # this CLI — MCP token + checkout key
+claude plugin marketplace add mindset-ai/memex-ai
+claude plugin install memex-checkout@memex         # the hooks-only checkout plugin
+# …then reload the window (hooks load at session start)
+```
+
+The checkout plugin is **hooks-only** — it carries the spec-checkout hooks, not an
+MCP server, so it never duplicates the MCP this CLI plants.
 
 ## Prefer OAuth?
 
@@ -40,19 +55,19 @@ next call. **Use this `memex-ai` CLI when**:
 
 ```bash
 # Default: install (writes Claude configs)
-npx memex-ai
+npx -y memex-ai install
 
-# Custom device label (default: hostname)
-npx memex-ai --label "Linux laptop"
+# Mint JUST the checkout key (when you already have the MCP) — one sign-in, no --memex
+npx -y memex-ai checkout-setup
 
 # Skip auto-opening the browser; print the URL instead
-npx memex-ai --no-browser
+npx -y memex-ai install --no-browser
 
 # Point at a custom Memex server (default: https://memex.ai)
-npx memex-ai --api-base https://int.memex.ai/api
+npx -y memex-ai install --api-base https://int.memex.ai/api
 
 # Remove Memex from all Claude configs
-npx memex-ai uninstall
+npx -y memex-ai uninstall
 ```
 
 Run `npx memex-ai --help` for the full list.

--- a/packages/cli/bin/cli.mjs
+++ b/packages/cli/bin/cli.mjs
@@ -7,14 +7,13 @@
 // Zero dependencies — Node 18+ built-ins only. The pure logic lives in ../lib/ so the
 // behaviour is unit-testable; this file just wires stdout + browser side-effects.
 
-import { hostname, platform } from "node:os";
+import { platform } from "node:os";
 import { spawn } from "node:child_process";
 
 import { parseArgs, DEFAULT_API_BASE } from "../lib/argv.js";
 import { getConfigTargets } from "../lib/config-paths.js";
 import { writeMemexEntry, removeMemexEntry } from "../lib/config-merge.js";
-import { startCliAuth, pollForToken } from "../lib/auth-flow.js";
-import { ensureHookKey } from "../lib/checkout-bootstrap.js";
+import { ensureHookKey, unifiedInstall } from "../lib/checkout-bootstrap.js";
 
 const BOLD = "\x1b[1m";
 const GREEN = "\x1b[32m";
@@ -26,13 +25,14 @@ const RESET = "\x1b[0m";
 
 function printHelp() {
   console.log(`  ${BOLD}Usage:${RESET}`);
-  console.log(`    memex-ai install         Authorize this device + write Claude configs (default)`);
+  console.log(`    memex-ai install         One sign-in → MCP token + checkout key (default)`);
   console.log(`    memex-ai uninstall       Remove memex from Claude configs`);
-  console.log(`    memex-ai checkout-setup  Mint the spec-checkout plugin's scoped key (one sign-in)`);
+  console.log(`    memex-ai checkout-setup  Mint JUST the checkout key (one sign-in; no --memex)`);
+  console.log();
+  console.log(`  ${DIM}Tip: run \`install\` through Claude Code (paste the “Set up your coding agent”`);
+  console.log(`       prompt) and it also adds the plugin + reloads for you.${RESET}`);
   console.log();
   console.log(`  ${BOLD}Options:${RESET}`);
-  console.log(`    --label <name>           Device label (default: hostname)`);
-  console.log(`    --memex <ns>/<memex>     Target memex for checkout-setup (e.g. mindset-prod/memex-building-itself)`);
   console.log(`    --api-base <url>         Memex server (default: ${DEFAULT_API_BASE})`);
   console.log(`    --admin-base <url>       Memex UI base URL for the auth confirm page (default: derived from --api-base)`);
   console.log(`    --no-browser             Skip auto-opening the browser; print URL only`);
@@ -70,74 +70,69 @@ async function uninstall() {
   console.log();
 }
 
-async function install({ apiBase, adminBase: adminBaseArg, label, skipBrowser }) {
-  const deviceLabel = label || hostname() || "Unknown device";
-
-  console.log(`  ${BOLD}Step 1/3${RESET} — claiming device code...`);
-  const { reqId, code } = await startCliAuth(apiBase);
-
-  // The device-flow confirm page lives on the same host as the API now (single-host
-  // path-routed). Explicit --admin-base wins; otherwise strip /api from apiBase.
+// Unified install (spec-430 dec-2/dec-3): ONE device-flow sign-in mints BOTH the MCP
+// token (planted into the Claude configs) AND the single user-scoped checkout key —
+// no second sign-in, no per-memex anything. This command owns CREDENTIALS only; the
+// plugin (hooks) is installed by `claude plugin …`, which Claude Code runs for you
+// when you paste the "Set up your coding agent" prompt (dec-4).
+async function install({ apiBase, adminBase: adminBaseArg, skipBrowser }) {
   const adminBase = adminBaseArg ?? apiBase.replace("/api", "");
-  const authUrl = `${adminBase}/install/mcp/auth?code=${code}`;
-
-  console.log();
-  console.log(`  ${BOLD}Step 2/3${RESET} — open this URL in your browser:`);
-  console.log();
-  console.log(`    ${CYAN}${authUrl}${RESET}`);
-  console.log();
-  console.log(`    ${DIM}Code: ${BOLD}${code}${RESET}${DIM} (valid for 5 minutes)${RESET}`);
-  console.log();
-
-  if (!skipBrowser) {
-    if (openInBrowser(authUrl)) {
-      console.log(`  ${DIM}(opened in your default browser)${RESET}`);
-    } else {
-      console.log(`  ${YELLOW}Could not auto-open browser; copy the URL above.${RESET}`);
-    }
-    console.log();
-  }
-
-  console.log(`  ${BOLD}Step 3/3${RESET} — waiting for authorization...`);
-  const token = await pollForToken(apiBase, reqId);
-
-  console.log();
-  console.log(`  ${GREEN}✓${RESET} Token issued (mxt_…). Writing Claude configs:`);
-  console.log();
-
   const mcpUrl = `${apiBase}/mcp`;
   const targets = getConfigTargets();
-  for (const target of Object.values(targets)) {
-    const result = await writeMemexEntry(target, mcpUrl, token);
-    console.log(`  ${GREEN}✓${RESET} Configured ${BOLD}${result.name}${RESET}`);
-    console.log(`    ${DIM}${result.path}${RESET}`);
-  }
+
+  console.log(`  ${BOLD}Step 1${RESET} — one sign-in mints your MCP token + checkout key...`);
+
+  const result = await unifiedInstall({
+    apiBase,
+    deps: {
+      openBrowser: (url) => {
+        console.log();
+        console.log(`  ${BOLD}Open this URL to authorize:${RESET}`);
+        console.log(`    ${CYAN}${url}${RESET}`);
+        console.log();
+        if (!skipBrowser && openInBrowser(url)) {
+          console.log(`  ${DIM}(opened in your default browser)${RESET}`);
+        } else if (!skipBrowser) {
+          console.log(`  ${YELLOW}Could not auto-open browser; copy the URL above.${RESET}`);
+        }
+        console.log(`  ${DIM}waiting for authorization...${RESET}`);
+      },
+      plantMcp: async (token) => {
+        console.log();
+        for (const target of Object.values(targets)) {
+          const r = await writeMemexEntry(target, mcpUrl, token);
+          console.log(`  ${GREEN}✓${RESET} MCP configured for ${BOLD}${r.name}${RESET} ${DIM}${r.path}${RESET}`);
+        }
+      },
+    },
+  });
 
   console.log();
-  console.log(`  ${GREEN}${BOLD}Done!${RESET} Restart Claude to pick up the new MCP server.`);
-  console.log(`  ${DIM}Device label: ${deviceLabel}. Manage tokens at ${adminBase}/settings/tokens${RESET}`);
+  console.log(
+    result.hook.provisioned
+      ? `  ${GREEN}✓${RESET} Checkout key minted + stored ${DIM}(~/.memex/checkout.json)${RESET}`
+      : `  ${GREEN}✓${RESET} Checkout key already present ${DIM}(no re-mint, no sign-in)${RESET}`,
+  );
   console.log();
-  console.log(`  ${DIM}Tip: for Claude.ai web or Claude Code, you can also use OAuth via the${RESET}`);
-  console.log(`  ${DIM}     in-product connector picker. This CLI is best for CI / scripted setups.${RESET}`);
+  console.log(`  ${BOLD}Step 2${RESET} — install the checkout plugin (the hooks):`);
+  console.log(`    ${CYAN}claude plugin marketplace add mindset-ai/memex-ai${RESET}`);
+  console.log(`    ${CYAN}claude plugin install memex-checkout@memex${RESET}`);
+  console.log();
+  console.log(`  ${BOLD}Step 3${RESET} — reload the window ${DIM}(hooks load at session start).${RESET}`);
+  console.log();
+  console.log(`  ${DIM}Easiest path: run this through Claude Code — paste the “Set up your coding`);
+  console.log(`       agent” prompt from ${adminBase} and it runs these steps for you.${RESET}`);
   console.log();
 }
 
-// checkout-setup: provision the scoped hook key the spec-checkout plugin uses, off the
-// SAME single Memex device-flow sign-in (spec-371 dec-10). No key is ever pasted; an
-// existing key short-circuits with no sign-in. Stores ~/.memex/checkout.json; never
-// touches settings.json (the plugin owns hooks + MCP declaratively, dec-9).
-async function checkoutSetup({ apiBase, memex, skipBrowser }) {
-  if (!memex || !memex.includes("/")) {
-    throw new Error(
-      "checkout-setup needs --memex <namespace>/<memex> (e.g. mindset-prod/memex-building-itself)",
-    );
-  }
-  console.log(
-    `  ${BOLD}Step 1/2${RESET} — sign in to mint a scoped checkout key for ${BOLD}${memex}${RESET}...`,
-  );
+// checkout-setup: provision JUST the checkout key (when you already have the MCP and
+// only need the hook credential). One sign-in mints the single USER key (spec-430
+// dec-1/dec-3) — no --memex, never pasted, no per-memex map. An existing key
+// short-circuits with no sign-in. Most users don't need this: `install` does it.
+async function checkoutSetup({ apiBase, skipBrowser }) {
+  console.log(`  ${BOLD}Step 1/2${RESET} — sign in once to mint your checkout key...`);
   const res = await ensureHookKey({
     apiBase,
-    memexRef: memex,
     deps: {
       // Always surface the URL; auto-open unless --no-browser.
       openBrowser: (url) => {
@@ -158,16 +153,15 @@ async function checkoutSetup({ apiBase, memex, skipBrowser }) {
   });
 
   console.log();
-  if (res.provisioned) {
-    console.log(`  ${GREEN}✓${RESET} Checkout key minted + stored for ${BOLD}${memex}${RESET}.`);
-  } else {
-    console.log(
-      `  ${GREEN}✓${RESET} Already set up — a checkout key for ${BOLD}${memex}${RESET} is present (no sign-in needed).`,
-    );
-  }
   console.log(
-    `  ${DIM}While you're checked out (claim_spec), the plugin's edit hook reports edits to this memex.${RESET}`,
+    res.provisioned
+      ? `  ${GREEN}✓${RESET} Checkout key minted + stored ${DIM}(~/.memex/checkout.json)${RESET}`
+      : `  ${GREEN}✓${RESET} Already set up — a checkout key is present ${DIM}(no sign-in needed)${RESET}`,
   );
+  console.log(
+    `  ${DIM}One user key works for EVERY memex you belong to. While checked out (claim_spec),`,
+  );
+  console.log(`  ${DIM}the edit hook reports edits to the claimed spec's memex.${RESET}`);
   console.log();
 }
 

--- a/packages/cli/lib/checkout-bootstrap.js
+++ b/packages/cli/lib/checkout-bootstrap.js
@@ -1,20 +1,22 @@
-// lib/checkout-bootstrap.js — spec-371 first-run credential bootstrap (dec-10).
+// lib/checkout-bootstrap.js — the per-USER checkout credential (spec-430 dec-1/dec-3).
 //
-// ONE Memex device-flow sign-in mints the scoped mxh_ hook key and stores it where
-// the edit hook reads it — the user never copies a key off the web UI. Idempotent:
-// a valid stored key for the memex short-circuits with NO sign-in. All IO (fetch,
-// browser, clock, store) is injected so the orchestration unit-tests with no
-// network, no browser, and no real HOME. The same device-flow the MCP installer
-// uses (auth-flow.js) backs it, so it is the one proper sign-in that binds the
-// install to a signed-in Memex user; the mint route is membership-gated.
+// ONE key per user, minted at the user-level POST /api/hook-keys (no memex in the
+// path), stored as a single `hook_key` in ~/.memex/checkout.json — never a per-memex
+// map. The edit hook uses that one key for every memex. Entry points:
+//   - unifiedInstall(): ONE device-flow sign-in, then both credentials off the same
+//     mxt_ token — the caller plants the MCP entry (plantMcp), and we mint the mxh_
+//     hook key. No second sign-in (spec-430 dec-2).
+//   - provisionHookKey(): mint + store from an EXISTING signed-in token (no sign-in).
+//   - ensureHookKey(): standalone — device-flow ONCE then provision.
+// Idempotent: a stored hook_key short-circuits with no mint and no sign-in. All IO
+// (fetch, browser, clock, fs) is injected so the orchestration unit-tests offline.
 
 import { startCliAuth, pollForToken } from "./auth-flow.js";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
 
-// The store the edit hook reads: ~/.memex/checkout.json. Per-memex keys live under
-// `keys["<ns>/<memex>"]`; a legacy single `hook_key` is still honoured on read.
+// The store the edit hook reads: ~/.memex/checkout.json — one user key under `hook_key`.
 export function storePath(home = homedir()) {
   return join(home, ".memex", "checkout.json");
 }
@@ -34,25 +36,29 @@ export function loadStore(path, fs = DEFAULT_FS) {
   }
 }
 
-// The hook key for a memex: the per-memex map (current format) with a legacy
-// single-key fallback (so an older ~/.memex/checkout.json still works).
-export function keyForMemex(store, memexRef) {
-  if (store?.keys && typeof store.keys[memexRef] === "string") return store.keys[memexRef];
+// The single user key. Prefer the canonical `hook_key`; fall back to ANY value in a
+// legacy per-memex `keys` map (migration back-compat — an older checkout.json keeps
+// working until the next install rewrites it to a single key).
+export function keyFromStore(store) {
   if (typeof store?.hook_key === "string") return store.hook_key;
+  if (store?.keys && typeof store.keys === "object") {
+    const legacy = Object.values(store.keys).find((v) => typeof v === "string");
+    if (legacy) return legacy;
+  }
   return null;
 }
 
-// The browser URL the user opens to sign in + confirm the device code. Mirrors the
-// MCP installer (bin/cli.mjs): the admin UI base is the api base minus `/api`.
+// The browser URL the user signs in + confirms the device code on. Mirrors the MCP
+// installer (bin/cli.mjs): the admin UI base is the api base minus `/api`.
 export function authUrlFor(apiBase, code) {
   return `${apiBase.replace("/api", "")}/install/mcp/auth?code=${code}`;
 }
 
-// Mint a scoped hook key off a signed-in user token, via the membership-gated route
-// (so the key is inherently bound to the signed-in user's memex). Raw key once.
-export async function mintHookKey(apiBase, namespace, memex, token, deps = {}) {
+// Mint a user-scoped hook key off a signed-in user token, at the USER-level route
+// (no memex in the path, spec-430 dec-3). Raw key returned once.
+export async function mintHookKey(apiBase, token, deps = {}) {
   const fetchImpl = deps.fetch ?? fetch;
-  const res = await fetchImpl(`${apiBase}/api/${namespace}/${memex}/hook-keys`, {
+  const res = await fetchImpl(`${apiBase}/api/hook-keys`, {
     method: "POST",
     headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
     body: JSON.stringify({ name: "memex checkout hook" }),
@@ -66,37 +72,54 @@ export async function mintHookKey(apiBase, namespace, memex, token, deps = {}) {
   return json.key;
 }
 
-// Ensure a scoped hook key exists for `memexRef` ("<ns>/<memex>"), minting one off a
-// SINGLE device-flow sign-in if absent (dec-10). Returns { provisioned, signedIn,
-// memex, key }:
-//   stored key present → { provisioned:false, signedIn:false }  — NO sign-in (idempotent)
-//   absent → device-flow ONCE → mint → store → { provisioned:true, signedIn:true }
-export async function ensureHookKey({ apiBase, memexRef, fs = DEFAULT_FS, deps = {} }) {
+// Persist the single user key, dropping any legacy per-memex map (per-memex dies).
+function persist(path, store, apiBase, key, fs) {
+  const next = { ...store, api_base: apiBase, hook_key: key };
+  delete next.keys; // spec-430 dec-3: never a per-memex map
+  fs.mkdirp(join(path, "..")); // ensure ~/.memex
+  fs.write(path, JSON.stringify(next, null, 2) + "\n");
+}
+
+// Mint + store from an EXISTING signed-in token — NO sign-in. Idempotent: a stored
+// hook_key short-circuits. Returns { provisioned, key }.
+export async function provisionHookKey({ apiBase, token, fs = DEFAULT_FS, deps = {} }) {
   const path = deps.storePath ?? storePath();
   const store = loadStore(path, fs);
+  const existing = keyFromStore(store);
+  if (existing) return { provisioned: false, key: existing };
+  const key = await mintHookKey(apiBase, token, deps);
+  persist(path, store, apiBase, key, fs);
+  return { provisioned: true, key };
+}
 
-  const existing = keyForMemex(store, memexRef);
-  if (existing) {
-    return { provisioned: false, signedIn: false, memex: memexRef, key: existing };
-  }
+// Standalone: ensure a key exists, doing ONE device-flow sign-in if absent. Idempotent.
+// Returns { provisioned, signedIn, key }.
+export async function ensureHookKey({ apiBase, fs = DEFAULT_FS, deps = {} }) {
+  const path = deps.storePath ?? storePath();
+  const store = loadStore(path, fs);
+  const existing = keyFromStore(store);
+  if (existing) return { provisioned: false, signedIn: false, key: existing };
 
-  // No stored key → exactly one sign-in: claim a device code, open the browser to
-  // the Memex confirm page, long-poll for the user token.
+  const { reqId, code } = await startCliAuth(apiBase, deps);
+  if (deps.openBrowser) deps.openBrowser(authUrlFor(apiBase, code));
+  const token = await pollForToken(apiBase, reqId, deps);
+  const key = await mintHookKey(apiBase, token, deps);
+  persist(path, store, apiBase, key, fs);
+  return { provisioned: true, signedIn: true, key };
+}
+
+// The unified install (spec-430 dec-2): ONE device-flow sign-in yields BOTH
+// credentials. The caller supplies `plantMcp(token)` to write the MCP entry off the
+// SAME mxt_ token; we mint the user-scoped mxh_ hook key off it too. No second
+// sign-in. Returns { token, hook }.
+export async function unifiedInstall({ apiBase, fs = DEFAULT_FS, deps = {} }) {
   const { reqId, code } = await startCliAuth(apiBase, deps);
   if (deps.openBrowser) deps.openBrowser(authUrlFor(apiBase, code));
   const token = await pollForToken(apiBase, reqId, deps);
 
-  const slash = memexRef.indexOf("/");
-  const namespace = memexRef.slice(0, slash);
-  const memex = memexRef.slice(slash + 1);
-  const key = await mintHookKey(apiBase, namespace, memex, token, deps);
-
-  const next = {
-    ...store,
-    api_base: apiBase,
-    keys: { ...(store.keys ?? {}), [memexRef]: key },
-  };
-  fs.mkdirp(join(path, "..")); // ensure ~/.memex
-  fs.write(path, JSON.stringify(next, null, 2) + "\n");
-  return { provisioned: true, signedIn: true, memex: memexRef, key };
+  // Both credentials from the SAME token. MCP first (the caller plants it), then the
+  // hook key — neither triggers another sign-in.
+  if (deps.plantMcp) await deps.plantMcp(token);
+  const hook = await provisionHookKey({ apiBase, token, fs, deps });
+  return { token, hook };
 }

--- a/packages/cli/plugin/.claude-plugin/plugin.json
+++ b/packages/cli/plugin/.claude-plugin/plugin.json
@@ -1,12 +1,6 @@
 {
   "name": "memex-checkout",
-  "version": "0.1.1",
-  "description": "Memex spec-checkout — binds your coding thread to a Spec and records in-flow edits against it (claim-gated, privacy-first). Non-blocking, opt-in, uninstallable any time. Sends only changed file paths + the claimed spec; never source code or prompts.",
-  "author": { "name": "Mindset AI", "url": "https://memex.ai" },
-  "mcpServers": {
-    "memex": {
-      "type": "http",
-      "url": "https://memex.ai/mcp"
-    }
-  }
+  "version": "0.2.0",
+  "description": "Memex spec-checkout — binds your coding thread to a Spec and records in-flow edits against it (claim-gated, privacy-first). Non-blocking, opt-in, uninstallable any time. Sends only changed file paths + the claimed spec; never source code or prompts. Hooks-only: the Memex MCP is planted by `npx memex-ai install` (spec-430 dec-2) so a single sign-in serves both, with no duplicate MCP toolset.",
+  "author": { "name": "Mindset AI", "url": "https://memex.ai" }
 }

--- a/packages/cli/plugin/hooks/edit-phonehome.mjs
+++ b/packages/cli/plugin/hooks/edit-phonehome.mjs
@@ -24,20 +24,21 @@ function readStdin() {
   });
 }
 
-// Where the bootstrap stored { api_base, keys: { "<ns>/<memex>": "mxh_…" } } — keyed
-// per memex (dec-10). Env vars override (CI); a legacy single `hook_key` still works.
-// Resolves the key for the CLAIMED memex so a multi-memex user phones each home with
-// the right scoped credential.
-function loadConfig(memexRef) {
+// Where the bootstrap stored { api_base, hook_key: "mxh_…" } — ONE user key (spec-430
+// dec-1/dec-3), used for EVERY memex. Env vars override (CI). A legacy per-memex
+// `keys` map is still honoured on read (migration back-compat) — any key in it works,
+// since the key is user-scoped regardless of which memex it was once filed under.
+function loadConfig() {
   const envBase = process.env.MEMEX_CHECKOUT_API_BASE;
   const envKey = process.env.MEMEX_CHECKOUT_HOOK_KEY;
   if (envBase && envKey) return { apiBase: envBase, hookKey: envKey };
   try {
     const cfg = JSON.parse(readFileSync(join(homedir(), ".memex", "checkout.json"), "utf8"));
     const apiBase = typeof cfg.api_base === "string" ? cfg.api_base : envBase;
-    const perMemex =
-      cfg.keys && memexRef && typeof cfg.keys[memexRef] === "string" ? cfg.keys[memexRef] : null;
-    const hookKey = perMemex ?? (typeof cfg.hook_key === "string" ? cfg.hook_key : null);
+    let hookKey = typeof cfg.hook_key === "string" ? cfg.hook_key : null;
+    if (!hookKey && cfg.keys && typeof cfg.keys === "object") {
+      hookKey = Object.values(cfg.keys).find((v) => typeof v === "string") ?? null;
+    }
     if (apiBase && hookKey) return { apiBase, hookKey };
   } catch {
     /* not installed / unreadable → fail quiet */
@@ -100,7 +101,7 @@ async function main() {
   if (paths.length === 0) return; // no file actually changed → nothing to report or steer
 
   // (1) RECORD the edit (network). Best-effort; skipped silently if no key is planted.
-  const cfg = loadConfig(decision.claim.memex);
+  const cfg = loadConfig();
   if (cfg) {
     const cwd = p.cwd || process.cwd();
     await phoneHome(cfg, {

--- a/packages/cli/plugin/hooks/hooks.json
+++ b/packages/cli/plugin/hooks/hooks.json
@@ -1,5 +1,15 @@
 {
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/session-start-guide.mjs\""
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "mcp__.*memex__.*",

--- a/packages/cli/plugin/hooks/session-start-guide.mjs
+++ b/packages/cli/plugin/hooks/session-start-guide.mjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+// spec-430 dec-4 — the SessionStart self-heal guide. When the checkout key isn't set
+// up on this machine (no `hook_key` in ~/.memex/checkout.json and no env override),
+// emit a short additionalContext steer so Claude Code can OFFER to finish setup. Once
+// set up, it is fully silent. Non-blocking; never errors the session; exits 0.
+//
+// This is the pre-MCP priming layer: the MCP's own instructions can't guide a user
+// before the MCP is connected, so the bundled hook closes that gap.
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+function readStdin() {
+  return new Promise((resolve) => {
+    let data = "";
+    process.stdin.setEncoding("utf8");
+    process.stdin.on("data", (c) => (data += c));
+    process.stdin.on("end", () => resolve(data));
+    process.stdin.on("error", () => resolve(data));
+  });
+}
+
+// Is a usable checkout key present? Env override (CI) or a stored single key, or any
+// value in a legacy per-memex map (back-compat) — the key is user-scoped either way.
+function isSetUp() {
+  if (process.env.MEMEX_CHECKOUT_HOOK_KEY) return true;
+  try {
+    const cfg = JSON.parse(readFileSync(join(homedir(), ".memex", "checkout.json"), "utf8"));
+    if (typeof cfg.hook_key === "string" && cfg.hook_key) return true;
+    if (cfg.keys && typeof cfg.keys === "object") {
+      return Object.values(cfg.keys).some((v) => typeof v === "string" && v);
+    }
+  } catch {
+    /* absent / unreadable → not set up */
+  }
+  return false;
+}
+
+const STEER = [
+  "Memex spec-checkout is installed but not fully set up on this machine: no checkout",
+  "key is present, so in-flow edits to a claimed Spec won't be recorded yet. If the",
+  "user wants Memex spec-checkout working, OFFER (don't nag) to finish setup by running",
+  "`npx -y memex-ai install` — one browser sign-in that plants the MCP token and mints",
+  "the user checkout key. If they decline, stay silent for the rest of the session.",
+].join(" ");
+
+async function main() {
+  await readStdin(); // drain the SessionStart payload; we only need local state
+  if (isSetUp()) return; // set up → silent
+  process.stdout.write(
+    JSON.stringify({
+      hookSpecificOutput: { hookEventName: "SessionStart", additionalContext: STEER },
+    }),
+  );
+}
+
+main().catch(() => {});

--- a/packages/cli/test/checkout-bootstrap.test.js
+++ b/packages/cli/test/checkout-bootstrap.test.js
@@ -2,16 +2,19 @@ import { describe, it, expect, vi } from "vitest";
 import { tagAc } from "@memex-ai-ac/vitest";
 import {
   ensureHookKey,
-  keyForMemex,
+  provisionHookKey,
+  unifiedInstall,
+  keyFromStore,
   authUrlFor,
 } from "../lib/checkout-bootstrap.js";
 import { parseArgs } from "../lib/argv.js";
 
-// spec-371 t-5 — the first-run credential bootstrap (dec-10). One device-flow
-// sign-in mints the scoped mxh_ key and stores it where the edit hook reads it;
-// never pasted; idempotent (a stored key triggers no sign-in).
-const AC_18 = "mindset-prod/memex-building-itself/specs/spec-371/acs/ac-18";
-const MEMEX = "mindset-prod/memex-building-itself";
+// spec-430 — the per-USER checkout credential + the unified one-sign-in install.
+const AC_18 = "mindset-prod/memex-building-itself/specs/spec-371/acs/ac-18"; // bootstrap: 1 sign-in, never pasted, idempotent
+const AC_1 = "mindset-prod/memex-building-itself/specs/spec-430/acs/ac-1"; // two actions: one command + one reload
+const AC_2 = "mindset-prod/memex-building-itself/specs/spec-430/acs/ac-2"; // exactly one sign-in
+const AC_7 = "mindset-prod/memex-building-itself/specs/spec-430/acs/ac-7"; // both creds from one mxt_, no 2nd sign-in
+const AC_8 = "mindset-prod/memex-building-itself/specs/spec-430/acs/ac-8"; // user-level mint (no memex in the path)
 
 // In-memory ~/.memex/checkout.json double.
 function memFs(initial = null) {
@@ -33,16 +36,112 @@ function memFs(initial = null) {
   };
 }
 
-describe("first-run credential bootstrap (spec-371 ac-18)", () => {
-  it("with a stored key for the memex, does NOT sign in (idempotent)", async () => {
+describe("checkout credential bootstrap (spec-430 dec-1/dec-3)", () => {
+  it("keyFromStore prefers the single hook_key, falls back to a legacy per-memex map", () => {
+    tagAc(AC_8);
+    expect(keyFromStore({ hook_key: "mxh_a" })).toBe("mxh_a");
+    expect(keyFromStore({ keys: { "ns/m": "mxh_legacy" } })).toBe("mxh_legacy"); // back-compat read
+    expect(keyFromStore({})).toBe(null);
+  });
+
+  it("authUrlFor builds the confirm-page URL the user signs in on", () => {
     tagAc(AC_18);
-    const fs = memFs(
-      JSON.stringify({ api_base: "https://memex.ai", keys: { [MEMEX]: "mxh_existing" } }),
+    expect(authUrlFor("https://memex.ai", "WXYZ")).toBe(
+      "https://memex.ai/install/mcp/auth?code=WXYZ",
     );
+  });
+
+  it("provisionHookKey: mints from an EXISTING token at the user-level route — NO sign-in (ac-7, ac-8)", async () => {
+    tagAc(AC_7);
+    tagAc(AC_8);
+    const fs = memFs(null);
+    const calls = [];
+    const fetch = async (url, init) => {
+      calls.push(url);
+      if (url.endsWith("/api/hook-keys")) {
+        expect(init.headers.Authorization).toBe("Bearer mxt_abc"); // minted off the install token
+        return { ok: true, json: async () => ({ key: "mxh_x" }) };
+      }
+      throw new Error("unexpected fetch " + url);
+    };
+    const res = await provisionHookKey({
+      apiBase: "https://memex.ai",
+      token: "mxt_abc",
+      fs,
+      deps: { storePath: "/f", fetch },
+    });
+    expect(res).toMatchObject({ provisioned: true, key: "mxh_x" });
+    // NEVER touched the device flow — no second sign-in
+    expect(calls.some((u) => u.includes("/api/cli/auth/"))).toBe(false);
+    // stored as a single user key, no per-memex map
+    expect(fs.current().hook_key).toBe("mxh_x");
+    expect(fs.current().keys).toBeUndefined();
+  });
+
+  it("provisionHookKey: idempotent — an existing key short-circuits with no mint", async () => {
+    tagAc(AC_18);
+    const fs = memFs(JSON.stringify({ hook_key: "mxh_existing" }));
+    const fetch = vi.fn();
+    const res = await provisionHookKey({
+      apiBase: "https://memex.ai",
+      token: "mxt_abc",
+      fs,
+      deps: { storePath: "/f", fetch },
+    });
+    expect(res).toMatchObject({ provisioned: false, key: "mxh_existing" });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("unifiedInstall: ONE sign-in yields BOTH credentials from the same token (ac-1, ac-2, ac-7)", async () => {
+    tagAc(AC_1);
+    tagAc(AC_2);
+    tagAc(AC_7);
+    const fs = memFs(null);
+    const calls = [];
+    let plantedToken = null;
+    const fetch = async (url, init) => {
+      calls.push(url);
+      if (url.endsWith("/api/cli/auth/start"))
+        return { ok: true, json: async () => ({ reqId: "r1", code: "ABCD" }) };
+      if (url.includes("/api/cli/auth/poll/"))
+        return { ok: true, json: async () => ({ status: "completed", token: "mxt_user" }) };
+      if (url.endsWith("/api/hook-keys")) {
+        expect(init.headers.Authorization).toBe("Bearer mxt_user");
+        return { ok: true, json: async () => ({ key: "mxh_minted" }) };
+      }
+      throw new Error("unexpected fetch " + url);
+    };
+    const opened = [];
+    const res = await unifiedInstall({
+      apiBase: "https://memex.ai",
+      fs,
+      deps: {
+        storePath: "/fake",
+        fetch,
+        now: () => 0,
+        openBrowser: (u) => opened.push(u),
+        plantMcp: async (token) => {
+          plantedToken = token;
+        },
+      },
+    });
+    // exactly ONE device-flow sign-in (ac-2)
+    expect(calls.filter((u) => u.endsWith("/api/cli/auth/start"))).toHaveLength(1);
+    expect(opened).toEqual(["https://memex.ai/install/mcp/auth?code=ABCD"]);
+    // the MCP was planted with the SAME token the hook key was minted from (ac-7)
+    expect(plantedToken).toBe("mxt_user");
+    expect(res.hook).toMatchObject({ provisioned: true, key: "mxh_minted" });
+    // stored as a single user key — never a per-memex map (dec-3)
+    expect(fs.current().hook_key).toBe("mxh_minted");
+    expect(fs.current().keys).toBeUndefined();
+  });
+
+  it("ensureHookKey: a stored key → NO sign-in (idempotent)", async () => {
+    tagAc(AC_18);
+    const fs = memFs(JSON.stringify({ api_base: "https://memex.ai", hook_key: "mxh_existing" }));
     const fetch = vi.fn(async () => ({ ok: true, json: async () => ({}) }));
     const res = await ensureHookKey({
       apiBase: "https://memex.ai",
-      memexRef: MEMEX,
       fs,
       deps: { storePath: "/fake", fetch },
     });
@@ -50,8 +149,9 @@ describe("first-run credential bootstrap (spec-371 ac-18)", () => {
     expect(fetch).not.toHaveBeenCalled(); // zero network — no sign-in, no mint
   });
 
-  it("with no stored key: ONE device-flow sign-in, mint, store per-memex; never pasted", async () => {
-    tagAc(AC_18);
+  it("ensureHookKey: no key → ONE sign-in, mint at the user-level route, store ONE key (ac-2, ac-8)", async () => {
+    tagAc(AC_2);
+    tagAc(AC_8);
     const fs = memFs(null);
     const calls = [];
     const fetch = async (url, init) => {
@@ -60,8 +160,7 @@ describe("first-run credential bootstrap (spec-371 ac-18)", () => {
         return { ok: true, json: async () => ({ reqId: "r1", code: "ABCD" }) };
       if (url.includes("/api/cli/auth/poll/"))
         return { ok: true, json: async () => ({ status: "completed", token: "mxt_user" }) };
-      if (url.endsWith(`/api/${MEMEX}/hook-keys`)) {
-        // minted off the signed-in user token, membership-gated route
+      if (url.endsWith("/api/hook-keys")) {
         expect(init.headers.Authorization).toBe("Bearer mxt_user");
         return { ok: true, json: async () => ({ key: "mxh_minted" }) };
       }
@@ -70,16 +169,13 @@ describe("first-run credential bootstrap (spec-371 ac-18)", () => {
     const opened = [];
     const res = await ensureHookKey({
       apiBase: "https://memex.ai",
-      memexRef: MEMEX,
       fs,
       deps: { storePath: "/fake", fetch, openBrowser: (u) => opened.push(u), now: () => 0 },
     });
     expect(res).toMatchObject({ provisioned: true, signedIn: true, key: "mxh_minted" });
-    // exactly ONE sign-in handshake
     expect(calls.filter((u) => u.endsWith("/api/cli/auth/start"))).toHaveLength(1);
     expect(opened[0]).toBe("https://memex.ai/install/mcp/auth?code=ABCD");
-    // stored where the edit hook reads it, keyed by memex — no key ever entered by hand
-    expect(fs.current().keys[MEMEX]).toBe("mxh_minted");
+    expect(fs.current().hook_key).toBe("mxh_minted");
   });
 
   it("a mint failure propagates — fail loud, not silently keyless", async () => {
@@ -95,31 +191,15 @@ describe("first-run credential bootstrap (spec-371 ac-18)", () => {
     await expect(
       ensureHookKey({
         apiBase: "https://memex.ai",
-        memexRef: MEMEX,
         fs,
         deps: { storePath: "/f", fetch, now: () => 0 },
       }),
     ).rejects.toThrow(/403/);
   });
 
-  it("keyForMemex prefers the per-memex key, falls back to a legacy single key", () => {
-    tagAc(AC_18);
-    expect(keyForMemex({ keys: { [MEMEX]: "mxh_a" } }, MEMEX)).toBe("mxh_a");
-    expect(keyForMemex({ hook_key: "mxh_legacy" }, MEMEX)).toBe("mxh_legacy");
-    expect(keyForMemex({}, MEMEX)).toBe(null);
-  });
-
-  it("authUrlFor builds the confirm-page URL the user signs in on", () => {
-    tagAc(AC_18);
-    expect(authUrlFor("https://memex.ai", "WXYZ")).toBe(
-      "https://memex.ai/install/mcp/auth?code=WXYZ",
-    );
-  });
-
-  it("the CLI exposes a `checkout-setup --memex` trigger for the one-time mint", () => {
-    tagAc(AC_18);
-    const parsed = parseArgs(["node", "cli", "checkout-setup", "--memex", MEMEX]);
+  it("the CLI exposes a `checkout-setup` trigger — no --memex needed (dec-3)", () => {
+    tagAc(AC_8);
+    const parsed = parseArgs(["node", "cli", "checkout-setup"]);
     expect(parsed.command).toBe("checkout-setup");
-    expect(parsed.memex).toBe(MEMEX);
   });
 });

--- a/packages/cli/test/config-merge.test.js
+++ b/packages/cli/test/config-merge.test.js
@@ -1,9 +1,15 @@
 import { describe, it, expect } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
 import {
   readJsonFile,
   writeMemexEntry,
   removeMemexEntry,
 } from "../lib/config-merge.js";
+
+// spec-430 ac-3 — a migrator with a hand-configured mcp__memex__ follows the IDENTICAL
+// path: install overwrites the same `mcpServers.memex` key in place, so no separate
+// "remove the old MCP" step is ever required of them.
+const AC_3_430 = "mindset-prod/memex-building-itself/specs/spec-430/acs/ac-3";
 
 // In-memory fs double. Matches the exact surface writeMemexEntry / readJsonFile touch
 // (readFile, writeFile, mkdir, existsSync) so tests need no tmpdir for unit coverage.
@@ -79,11 +85,14 @@ describe("writeMemexEntry", () => {
     });
   });
 
-  it("preserves other mcpServers entries on re-install", async () => {
+  it("preserves other mcpServers entries on re-install; OVERWRITES a hand-configured memex in place (migrator path, spec-430 ac-3)", async () => {
+    tagAc(AC_3_430);
     const existing = {
       mcpServers: {
         unrelated: { command: "other", args: ["x"] },
-        memex: { type: "http", url: "https://old", headers: {} },
+        // the migrator's hand-configured Memex MCP — same `memex` key, so install
+        // subsumes it; no separate "remove the old MCP" step is needed.
+        memex: { type: "http", url: "https://old", headers: { Authorization: "Bearer mxt_hand" } },
       },
       anotherTopLevelKey: true,
     };

--- a/packages/cli/test/hooks-e2e.test.js
+++ b/packages/cli/test/hooks-e2e.test.js
@@ -1,7 +1,15 @@
 import { describe, it, expect } from "vitest";
 import { tagAc } from "@memex-ai-ac/vitest";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, rmSync, readFileSync, existsSync, readdirSync } from "node:fs";
+import {
+  mkdtempSync,
+  rmSync,
+  readFileSync,
+  existsSync,
+  readdirSync,
+  writeFileSync,
+  mkdirSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -161,5 +169,48 @@ describe("spec-371 hooks e2e (ac-7, ac-9, ac-10, ac-12, ac-15)", () => {
     // No per-vendor adapter files for other agents in v1.
     const names = readdirSync(PLUGIN).join(" ").toLowerCase();
     expect(names).not.toMatch(/cursor|windsurf|copilot/);
+  });
+});
+
+// spec-430 dec-4 — the SessionStart self-heal guide.
+const AC_9_430 = "mindset-prod/memex-building-itself/specs/spec-430/acs/ac-9";
+
+function runSessionStart(home) {
+  // Controlled env: clear the CI override so the file-state path is what's exercised.
+  const env = { ...process.env, HOME: home };
+  delete env.MEMEX_CHECKOUT_HOOK_KEY;
+  delete env.MEMEX_CHECKOUT_API_BASE;
+  return execFileSync("node", [join(HOOKS, "session-start-guide.mjs")], {
+    input: JSON.stringify({ session_id: "s", hook_event_name: "SessionStart" }),
+    env,
+    encoding: "utf8",
+  });
+}
+
+describe("spec-430 SessionStart self-heal guide (ac-9)", () => {
+  it("no checkout key → emits an additionalContext steer offering to finish setup", () => {
+    tagAc(AC_9_430);
+    withHome((home) => {
+      const out = runSessionStart(home); // empty HOME, no ~/.memex/checkout.json
+      const parsed = JSON.parse(out);
+      expect(parsed.hookSpecificOutput.hookEventName).toBe("SessionStart");
+      expect(parsed.hookSpecificOutput.additionalContext).toMatch(/memex-ai install/);
+      // non-blocking: never denies/blocks.
+      expect(out).not.toMatch(/"decision"\s*:\s*"block"/);
+      expect(out).not.toMatch(/"permissionDecision"\s*:\s*"deny"/);
+    });
+  });
+
+  it("a stored hook_key → SILENT (no steer, nothing emitted)", () => {
+    tagAc(AC_9_430);
+    withHome((home) => {
+      mkdirSync(join(home, ".memex"), { recursive: true });
+      writeFileSync(
+        join(home, ".memex", "checkout.json"),
+        JSON.stringify({ api_base: "https://memex.ai", hook_key: "mxh_present" }),
+      );
+      const out = runSessionStart(home);
+      expect(out.trim()).toBe("");
+    });
   });
 });

--- a/packages/cli/test/plugin-bundle.test.js
+++ b/packages/cli/test/plugin-bundle.test.js
@@ -7,24 +7,25 @@ import { dirname, resolve } from "node:path";
 // spec-371 t-5 / t-6 — the plugin IS the installer: one Claude Code plugin that
 // bundles the Memex MCP server + the checkout hooks, distributed from a committed
 // marketplace (dec-9), NOT by hand-planting into ~/.claude/settings.json.
-const AC_15 = "mindset-prod/memex-building-itself/specs/spec-371/acs/ac-15"; // single plugin bundles hooks + MCP + tools
+const AC_15 = "mindset-prod/memex-building-itself/specs/spec-371/acs/ac-15"; // single Claude Code plugin; no per-vendor adapter
 const AC_17 = "mindset-prod/memex-building-itself/specs/spec-371/acs/ac-17"; // marketplace install; settings-planting retired
 const AC_8 = "mindset-prod/memex-building-itself/specs/spec-371/acs/ac-8"; // install transparency / no residue
+const AC_6_430 = "mindset-prod/memex-building-itself/specs/spec-430/acs/ac-6"; // exactly one Memex MCP toolset (plugin is hooks-only)
 
 const here = dirname(fileURLToPath(import.meta.url));
 const pluginRoot = resolve(here, "../plugin");
 const repoRoot = resolve(here, "../../..");
 const readJson = (p) => JSON.parse(readFileSync(p, "utf8"));
 
-describe("plugin bundle: MCP + hooks as one unit (spec-371 ac-15)", () => {
-  it("the plugin manifest bundles the Memex remote MCP server", () => {
-    tagAc(AC_15);
+describe("plugin bundle: hooks-only — the CLI plants the MCP (spec-430 dec-2/dec-4)", () => {
+  it("the plugin manifest declares NO MCP server — it is hooks-only (spec-430 ac-6)", () => {
+    tagAc(AC_6_430);
+    // spec-430 dec-2/dec-4 supersedes spec-371's MCP-bundling plugin: a single
+    // device-flow sign-in plants the mxt_ MCP via `npx memex-ai install`, so the
+    // plugin must NOT also declare an MCP — otherwise the two coexist as duplicate
+    // toolsets AND the plugin's OAuth MCP re-introduces a second sign-in.
     const manifest = readJson(resolve(pluginRoot, ".claude-plugin/plugin.json"));
-    expect(manifest.mcpServers?.memex).toBeTruthy();
-    // Remote Streamable-HTTP server — the same transport the CLI installer plants
-    // for Claude Code (lib/config-paths.js: { type:'http', url, headers }).
-    expect(manifest.mcpServers.memex.type).toBe("http");
-    expect(manifest.mcpServers.memex.url).toBe("https://memex.ai/mcp");
+    expect(manifest.mcpServers).toBeUndefined();
   });
 
   it("the plugin still declares both checkout hooks (marker-write + edit-phonehome)", () => {
@@ -55,12 +56,12 @@ describe("plugin bundle: MCP + hooks as one unit (spec-371 ac-15)", () => {
     expect(re.test("mcp__plugin_memex-checkout_memex__claim_spec")).toBe(true);
   });
 
-  it("the bundled MCP entry bakes NO per-user token (OAuth runs on enable)", () => {
-    tagAc(AC_15);
-    // A committed file must never carry a per-user bearer token; the server's
-    // OAuth flow (app.ts WWW-Authenticate discovery) authenticates on enable.
+  it("no committed token risk — the manifest carries no mcpServers block at all", () => {
+    tagAc(AC_6_430);
+    // With the MCP planted by the CLI (not bundled), there is no committed MCP entry
+    // that could ever carry a per-user bearer token.
     const manifest = readJson(resolve(pluginRoot, ".claude-plugin/plugin.json"));
-    expect(manifest.mcpServers.memex.headers).toBeUndefined();
+    expect("mcpServers" in manifest).toBe(false);
   });
 });
 

--- a/packages/server/drizzle/0116_spec_430_user_scoped_hook_keys.sql
+++ b/packages/server/drizzle/0116_spec_430_user_scoped_hook_keys.sql
@@ -1,0 +1,11 @@
+-- spec-430 dec-1: the mxh_ hook key becomes USER-scoped, not per-memex. A checkout
+-- phone-home write is now authorized when the key's creator is an ACTIVE member of
+-- the org owning the spec named in the request (membership + RLS, std-36), so a
+-- personal -> org graduation needs no new key and no new sign-in (ac-5).
+--
+-- New keys are minted with memex_id NULL (user-scoped). Existing per-memex rows keep
+-- their memex_id and continue to work — their creator is a member of that memex's
+-- org, so they still authorize there; the route additionally pins a non-null
+-- memex_id to its own memex (back-compat). Hand-written additive ALTER (idempotent),
+-- same mechanism as 0115_spec_371_checkout_columns.
+ALTER TABLE "memex_hook_keys" ALTER COLUMN "memex_id" DROP NOT NULL;

--- a/packages/server/src/__e2e__/hook-keys-mcp-token-auth.api.test.ts
+++ b/packages/server/src/__e2e__/hook-keys-mcp-token-auth.api.test.ts
@@ -22,6 +22,8 @@ import { createOrgWithMemexAndOwner } from "../services/__test__/seed-org.js";
 
 // ac-14 — the hook key is a least-privilege mxh_, never the user's mxt_/OAuth.
 const AC_14 = "mindset-prod/memex-building-itself/specs/spec-371/acs/ac-14";
+// spec-430 ac-8 — minting is USER-level (POST /api/hook-keys, no memex in the path).
+const AC_8 = "mindset-prod/memex-building-itself/specs/spec-430/acs/ac-8";
 
 const createdUserIds: string[] = [];
 const createdMemexIds: string[] = [];
@@ -99,12 +101,13 @@ describe("hook-key mint accepts the device-flow mxt_ token (spec-371 ac-14)", ()
     });
     memexId = seeded.memex.id;
     createdMemexIds.push(memexId);
-    hookKeysBase = `/api/${seeded.namespace.slug}/${seeded.memex.slug}/hook-keys`;
+    hookKeysBase = `/api/hook-keys`; // spec-430 dec-3: user-level, no memex in the path
     emissionKeysBase = `/api/${seeded.namespace.slug}/${seeded.memex.slug}/emission-keys`;
   });
 
-  it("THE FIX — a valid mxt_ PAT mints a key; the PLANTED credential is a least-privilege mxh_ (ac-14)", async () => {
+  it("THE FIX — a valid mxt_ PAT mints a key at the user-level endpoint; the PLANTED credential is a least-privilege mxh_ (ac-14, spec-430 ac-8)", async () => {
     tagAc(AC_14);
+    tagAc(AC_8);
     const { res, body } = await mint(hookKeysBase, ownerMxt);
     expect(res.status).toBe(201);
     // dec-6: the mxt_ only AUTHENTICATES; what we hand back is the scoped mxh_.
@@ -113,11 +116,13 @@ describe("hook-key mint accepts the device-flow mxt_ token (spec-371 ac-14)", ()
     expect(body.key as string).not.toMatch(/^mxt_/);
     expect(body.createdByUserId).toBe(ownerUserId);
 
-    // The mint persisted a real row for this memex, owned by the PAT's user.
+    // The mint persisted a real row owned by the PAT's user. spec-430 dec-1: the key
+    // is USER-scoped, so the row has NO home memex (memexId null) — authz is by
+    // membership, not key granularity.
     const row = await db.query.memexHookKeys.findFirst({
       where: eq(memexHookKeys.id, body.id as string),
     });
-    expect(row?.memexId).toBe(memexId);
+    expect(row?.memexId).toBeNull();
     expect(row?.createdByUserId).toBe(ownerUserId);
   });
 
@@ -140,13 +145,17 @@ describe("hook-key mint accepts the device-flow mxt_ token (spec-371 ac-14)", ()
     expect(res.status).toBe(401);
   });
 
-  it("a valid mxt_ for a NON-MEMBER cannot mint — membership is still enforced → 404 (std-7)", async () => {
-    tagAc(AC_14);
+  it("any authenticated user mints their OWN user-scoped key — no membership required (spec-430 dec-3, ac-8)", async () => {
+    tagAc(AC_8);
+    // A hook key is per USER. A user who belongs to no org still mints their own key —
+    // the credential is user-level, not gated on memex membership.
     const strangerId = await seedUser();
     const { raw: strangerMxt } = await mintMcpToken(strangerId, "stranger device");
-    const { res } = await mint(hookKeysBase, strangerMxt);
-    expect(res.status).toBe(404);
-    // Belt-and-braces: no membership was created as a side effect.
+    const { res, body } = await mint(hookKeysBase, strangerMxt);
+    expect(res.status).toBe(201);
+    expect(body.key as string).toMatch(/^mxh_/);
+    expect(body.createdByUserId).toBe(strangerId);
+    // The mint created NO org membership as a side effect — purely a user credential.
     const membership = await db.query.orgMemberships.findFirst({
       where: eq(orgMemberships.userId, strangerId),
     });

--- a/packages/server/src/__e2e__/migration-smoke.api.test.ts
+++ b/packages/server/src/__e2e__/migration-smoke.api.test.ts
@@ -114,7 +114,11 @@ describe("migration-smoke [t-9]", () => {
     // reserved for testing per RFC 6761 / 2606. Any email under those is a test
     // fixture from a concurrent run and can be safely excluded from this
     // production-invariant check. Same for doc-move-*@memex.ai which is a
-    // legacy test pattern.
+    // legacy test pattern. The throwaway domains below (acme.com, a.com, …) are
+    // raw-insert fixtures other suites create without going through signup
+    // (ensureUserNamespace) — excluded so a concurrent file sharing this worker's DB
+    // clone can't trip the scan (std-37, parallel-fixture isolation). A test DB has no
+    // real users, so excluding these can never mask a production bug.
     const result = await db.execute(sql`
       SELECT count(*)::int AS missing FROM users
       WHERE status = 'active'
@@ -127,6 +131,14 @@ describe("migration-smoke [t-9]", () => {
         AND email NOT LIKE '%.invalid'
         AND email NOT LIKE '%.local'
         AND email NOT LIKE 'doc-move-%@memex.ai'
+        AND email NOT LIKE '%@acme.com'
+        AND email NOT LIKE '%@anydomain.io'
+        AND email NOT LIKE '%@a.com'
+        AND email NOT LIKE '%@a.co'
+        AND email NOT LIKE '%@b.com'
+        AND email NOT LIKE '%@b.co'
+        AND email NOT LIKE '%@x.com'
+        AND email NOT LIKE '%@x'
     `);
     expect((result as unknown as { missing: number }[])[0].missing).toBe(0);
   });

--- a/packages/server/src/__regression__/spec-checkout-phonehome-rls.regression.test.ts
+++ b/packages/server/src/__regression__/spec-checkout-phonehome-rls.regression.test.ts
@@ -2,7 +2,7 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { eq, inArray, sql } from "drizzle-orm";
 import postgres from "postgres";
 import { db } from "../db/connection.js";
-import { namespaces, memexes, documents } from "../db/schema.js";
+import { namespaces, orgs, memexes, documents } from "../db/schema.js";
 
 // Regression guard for the spec-checkout phone-home RLS trap (spec-371).
 //
@@ -29,6 +29,8 @@ const NS_SLUG = "phonehome-rls-regress-ns";
 const SPEC_HANDLE = "spec-rls-1";
 
 describe("regression: spec-checkout phone-home read needs app.memex_id under RLS", () => {
+  let nsId: string;
+  let orgId: string;
   let memexId: string;
   let docId: string;
 
@@ -38,9 +40,19 @@ describe("regression: spec-checkout phone-home read needs app.memex_id under RLS
       .insert(namespaces)
       .values({ slug: NS_SLUG, kind: "org" })
       .returning({ id: namespaces.id });
+    nsId = ns!.id;
+    // Own the namespace by an org so it satisfies the owner-XOR invariant — otherwise a
+    // kind='org' namespace with a NULL owner_org_id trips migration-smoke's global scan
+    // when these tests share a worker DB clone (std-37, parallel-fixture isolation).
+    const [org] = await db
+      .insert(orgs)
+      .values({ namespaceId: nsId, name: "Phonehome RLS Regress Org" })
+      .returning({ id: orgs.id });
+    orgId = org!.id;
+    await db.update(namespaces).set({ ownerOrgId: orgId }).where(eq(namespaces.id, nsId));
     const [mx] = await db
       .insert(memexes)
-      .values({ namespaceId: ns!.id, slug: "phonehome-rls-regress-mx", name: "Phonehome RLS Regress" })
+      .values({ namespaceId: nsId, slug: "phonehome-rls-regress-mx", name: "Phonehome RLS Regress" })
       .returning({ id: memexes.id });
     memexId = mx!.id;
     const [doc] = await db
@@ -51,11 +63,17 @@ describe("regression: spec-checkout phone-home read needs app.memex_id under RLS
   });
 
   afterAll(async () => {
-    // FK order; the test namespace is kind='org' without owner_org_id (test-only),
-    // which would otherwise trip the owner-XOR invariant in migration-smoke.
+    // FK order: documents → memexes → break the namespace↔org cycle (null the
+    // namespace's owner_org_id) → org → namespace.
     if (memexId) {
       await db.delete(documents).where(eq(documents.memexId, memexId)).catch(() => {});
       await db.delete(memexes).where(inArray(memexes.id, [memexId])).catch(() => {});
+    }
+    if (nsId) {
+      await db.update(namespaces).set({ ownerOrgId: null }).where(eq(namespaces.id, nsId)).catch(() => {});
+    }
+    if (orgId) {
+      await db.delete(orgs).where(eq(orgs.id, orgId)).catch(() => {});
     }
     await db.delete(namespaces).where(eq(namespaces.slug, NS_SLUG)).catch(() => {});
   });

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -242,8 +242,6 @@ app.route("/api/:namespace/:memex/tasks", tasksRouter);
 app.route("/api/:namespace/:memex/issues", issuesRouter);
 app.route("/api/:namespace/:memex/acs", acsRouter);
 app.route("/api/:namespace/:memex/emission-keys", emissionKeysRouter);
-// spec-371: scoped hook-key minting for the plugin installer (membership-gated).
-app.route("/api/:namespace/:memex/hook-keys", hookKeysRouter);
 app.route("/api/:namespace/:memex/discord-webhook", discordWebhookRouter);
 // spec-118 — per-Spec roles (editor/reviewer) + ticket-style assignment.
 app.route("/api/:namespace/:memex/doc-members", docMembersRouter);
@@ -424,6 +422,9 @@ app.route("/api/backstage", backstageRouter);
 // Device-flow installer + token settings (t-14).
 app.route("/api/cli/auth", cliAuth);
 app.route("/api/mcp/tokens", mcpTokensRouter);
+// spec-430 dec-3: hook keys are per USER, never per memex — user-level mint, no
+// :namespace/:memex in the path (modelled on /api/mcp/tokens above).
+app.route("/api/hook-keys", hookKeysRouter);
 
 // OAuth 2.1 + DCR + PKCE (b-31 W1). Gated by OAUTH_ENABLED=1 so the entire
 // surface (routes + well-known discovery) is dead until explicitly turned on.

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -1823,9 +1823,10 @@ export const memexHookKeys = pgTable(
   "memex_hook_keys",
   {
     id: uuid("id").primaryKey().defaultRandom(),
-    memexId: uuid("memex_id")
-      .notNull()
-      .references(() => memexes.id, { onDelete: "cascade" }),
+    // spec-430 dec-1: NULL = USER-scoped (the key authorizes any memex its creator is
+    // an active member of). A non-null value is a legacy per-memex key, additionally
+    // pinned to that memex by the /api/spec-checkout authz. New keys mint NULL.
+    memexId: uuid("memex_id").references(() => memexes.id, { onDelete: "cascade" }),
     name: text("name").notNull(),
     hashedKey: text("hashed_key").notNull().unique(),
     prefix: text("prefix").notNull(),

--- a/packages/server/src/routes/hook-keys.ts
+++ b/packages/server/src/routes/hook-keys.ts
@@ -1,35 +1,30 @@
-// HTTP routes for the scoped HOOK KEY surface (spec-371). Tenant-scoped, mounted
-// under /api/:namespace/:memex/hook-keys. Mirrors routes/emission-keys.ts: every
-// verb is a membership-gated operation (the key is a secret).
+// HTTP routes for the scoped HOOK KEY surface (spec-371, spec-430). USER-level:
+// mounted at /api/hook-keys with NO memex in the path (spec-430 dec-3 — a hook key is
+// per user, never per memex). Modelled on the user-level mcpTokensRouter
+// (/api/mcp/tokens): every verb operates on the AUTHENTICATED caller's own keys.
 //
-// The plugin installer (packages/cli) calls POST / after its device-flow auth to
-// plant a least-privilege key the checkout hook authenticates with — never the
-// user's MCP PAT or OAuth token (dec-6). The raw key is returned exactly once.
+// The plugin installer (packages/cli) calls POST / after its single device-flow auth
+// to plant the least-privilege key the checkout hook authenticates with — never the
+// user's MCP PAT or OAuth token (spec-371 dec-6). The raw key is returned exactly once.
 //
-// Auth note (spec-371): the device flow yields an mxt_ MCP token, not a web-session
-// JWT, so this surface uses sessionWithMcpTokenMiddleware — the one session route
-// that also accepts a valid mxt_ PAT. dec-6 is preserved: the PAT only AUTHENTICATES
-// the mint; the credential we PLANT is still the least-privilege mxh_ this route
-// returns. Membership is still enforced (the PAT resolves a user, the std-5 tail
-// 404s a non-member), so a PAT can only mint a key for a memex its owner belongs to.
+// Auth note: the installer holds an mxt_ MCP token (not a web-session JWT), so this
+// surface uses sessionWithMcpTokenMiddleware — the one session middleware that also
+// accepts a valid mxt_ PAT. dec-6 is preserved: the PAT only AUTHENTICATES the mint;
+// the credential we PLANT is still the least-privilege mxh_ this route returns.
 
 import { Hono } from "hono";
 import {
   mintHookKey,
-  listHookKeysForMemex,
+  listHookKeysForUser,
   revokeHookKey,
 } from "../services/hook-keys.js";
 import {
   sessionWithMcpTokenMiddleware,
   type SessionEnv,
 } from "../middleware/session.js";
-import type { MemexResolverEnv } from "../middleware/memex-resolver.js";
-import { requireMemexId } from "./shared.js";
 import type { MemexHookKey } from "../db/schema.js";
 
-type Env = MemexResolverEnv & SessionEnv;
-
-const hookKeysRouter = new Hono<Env>();
+const hookKeysRouter = new Hono<SessionEnv>();
 hookKeysRouter.use("/*", sessionWithMcpTokenMiddleware);
 
 // Display-safe projection: the hashed_key and the raw key are NEVER serialised.
@@ -47,28 +42,28 @@ function toSafe(row: MemexHookKey) {
 }
 
 hookKeysRouter.post("/", async (c) => {
-  const memexId = requireMemexId(c);
-  const createdByUserId = c.get("currentUserId") as string;
+  const userId = c.get("currentUserId") as string;
   const { name } = await c.req.json<{ name?: unknown }>().catch(() => ({ name: undefined }));
   const label =
     typeof name === "string" && name.trim().length > 0
       ? name.trim()
       : "memex checkout hook";
-  const result = await mintHookKey(memexId, label, createdByUserId);
+  const result = await mintHookKey(label, userId);
   // The ONLY time the raw key is ever returned — unrecoverable afterwards.
   return c.json({ key: result.raw, ...toSafe(result.row) }, 201);
 });
 
 hookKeysRouter.get("/", async (c) => {
-  const memexId = requireMemexId(c);
-  const rows = await listHookKeysForMemex(memexId);
+  const userId = c.get("currentUserId") as string;
+  const rows = await listHookKeysForUser(userId);
   return c.json(rows.map(toSafe));
 });
 
 hookKeysRouter.post("/:id/revoke", async (c) => {
-  const memexId = requireMemexId(c);
+  // Owner-scoped (spec-430 dec-1): the caller revokes their OWN key by id.
+  const userId = c.get("currentUserId") as string;
   const id = c.req.param("id");
-  const result = await revokeHookKey(id, memexId);
+  const result = await revokeHookKey(id, userId);
   if (!result) return c.json({ error: "Hook key not found" }, 404);
   return c.json(toSafe(result));
 });

--- a/packages/server/src/routes/spec-checkout.integration.test.ts
+++ b/packages/server/src/routes/spec-checkout.integration.test.ts
@@ -20,6 +20,9 @@ const AC_3 = "mindset-prod/memex-building-itself/specs/spec-371/acs/ac-3";
 const AC_11 = "mindset-prod/memex-building-itself/specs/spec-371/acs/ac-11";
 const AC_16 = "mindset-prod/memex-building-itself/specs/spec-371/acs/ac-16";
 const AC_23 = "mindset-prod/memex-building-itself/specs/spec-371/acs/ac-23"; // checked_out_thread = conversation UID
+// spec-430 ac-4 — after the single sign-in, a claimed spec's in-flow edits are recorded
+// server-side, with no separate checkout-setup invocation.
+const AC_4_430 = "mindset-prod/memex-building-itself/specs/spec-430/acs/ac-4";
 
 const app = new Hono();
 app.route("/api/spec-checkout", specCheckoutRouter);
@@ -36,7 +39,7 @@ interface Ctx {
 async function setup(prefix: string): Promise<Ctx> {
   const made = await makeTestMemexWithDevAdmin(prefix);
   const owner = await upsertUserByEmail("dev@memex.ai");
-  const minted = await mintHookKey(made.memexId, "test hook", owner.id);
+  const minted = await mintHookKey("test hook", owner.id);
   const doc = await createDocDraft(
     made.memexId,
     "Phone-home spec",
@@ -76,6 +79,7 @@ describe("spec-371: record-only phone-home (ac-3, ac-11, ac-16)", () => {
     tagAc(AC_3);
     tagAc(AC_11);
     tagAc(AC_16);
+    tagAc(AC_4_430); // spec-430: in-flow edits recorded server-side, no separate checkout-setup
     const res = await post(ctx.rawKey, {
       ref: ctx.ref,
       thread_uid: "thread-phc-1",
@@ -111,11 +115,14 @@ describe("spec-371: record-only phone-home (ac-3, ac-11, ac-16)", () => {
     ).toBe(401);
   });
 
-  it("a key for a DIFFERENT memex cannot record against this spec (cross-tenant → 401)", async () => {
+  it("a key whose creator is NOT a member of the spec's memex cannot record (→ 401, spec-430 dec-1)", async () => {
     tagAc(AC_11);
-    const other = await setup("phc2");
-    const res = await post(other.rawKey, {
-      ref: ctx.ref, // the FIRST memex's spec
+    // A user-scoped key authorises by MEMBERSHIP. Mint one for a stranger who is a
+    // member of NO org that owns ctx's memex, then post against ctx's spec.
+    const stranger = await upsertUserByEmail("stranger@example.com");
+    const strangerKey = (await mintHookKey("stranger hook", stranger.id)).raw;
+    const res = await post(strangerKey, {
+      ref: ctx.ref, // the FIRST memex's spec — stranger is not a member there
       thread_uid: "thread-x",
       changed_paths: ["x.ts"],
     });

--- a/packages/server/src/routes/spec-checkout.ts
+++ b/packages/server/src/routes/spec-checkout.ts
@@ -23,6 +23,8 @@ import { db, runWithMemexId } from "../db/connection.js";
 import { documents } from "../db/schema.js";
 import { verifyHookKey, bumpHookKeyLastUsed } from "../services/hook-keys.js";
 import { resolveMemexId } from "../services/emission-keys.js";
+import { getOrgIdForMemex } from "../services/memexes.js";
+import { isActiveOrgMember } from "../services/org-memberships.js";
 import { recordCheckoutEdit } from "../services/spec-checkout.js";
 import { setCheckoutThread } from "../services/checkout.js";
 
@@ -97,9 +99,19 @@ specCheckoutRouter.post("/", async (c) => {
   // Not a spec ref → fail quiet, record nothing (std-7). Never an error.
   if (!parsed) return c.json({ recorded: false, reason: "not_a_spec_ref" }, 200);
 
-  // The key only authorises its OWN Memex — mirror the test-events cross-tenant guard.
+  // Authorize by MEMBERSHIP (spec-430 dec-1): a user-scoped key (memexId NULL) writes
+  // for ANY memex its creator is an active member of, so a personal->org graduation
+  // needs no new key (ac-5). A legacy per-memex key (memexId set) is additionally
+  // pinned to its own memex. Tenant isolation is membership + RLS, not key
+  // granularity. These lookups read the CONTROL PLANE (memexes/orgs/org_memberships),
+  // not RLS-tenant tables, so they run correctly before the runWithMemexId wrap below.
   const memexId = await resolveMemexId(parsed.namespace, parsed.memexSlug);
-  if (!memexId || memexId !== hookKey.memexId) {
+  const actorUserId = hookKey.createdByUserId ?? null;
+  const scopeOk = hookKey.memexId === null || hookKey.memexId === memexId;
+  const orgId = memexId ? await getOrgIdForMemex(memexId) : null;
+  const authorized =
+    !!memexId && scopeOk && !!actorUserId && !!orgId && (await isActiveOrgMember(actorUserId, orgId));
+  if (!authorized) {
     return c.json(
       {
         error: "unauthorized",
@@ -138,7 +150,6 @@ specCheckoutRouter.post("/", async (c) => {
       .limit(1);
     if (!doc) return c.json({ recorded: false, reason: "spec_not_found" }, 200);
 
-    const actorUserId = hookKey.createdByUserId ?? null;
     await recordCheckoutEdit({
       memexId,
       docId: doc.id,

--- a/packages/server/src/routes/spec-checkout.user-scoped.spec-430.integration.test.ts
+++ b/packages/server/src/routes/spec-checkout.user-scoped.spec-430.integration.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { Hono } from "hono";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { makeTestMemexWithDevAdmin } from "../services/test-helpers.js";
+import { upsertUserByEmail } from "../services/users.js";
+import { createDocDraft } from "../services/documents.js";
+import { mintHookKey } from "../services/hook-keys.js";
+import { listCheckoutEditsForSpec } from "../services/spec-checkout.js";
+import { specCheckoutRouter } from "./spec-checkout.js";
+
+// spec-430 ac-5 — the graduation guarantee: ONE user-scoped mxh_ key, minted once,
+// records checkout edits against EVERY memex its creator belongs to (personal + any
+// org, present or future), with ZERO new authentication. This is the whole payoff of
+// dec-1's user-scoping: no per-memex re-mint, no second sign-in on graduation.
+const AC_5 = "mindset-prod/memex-building-itself/specs/spec-430/acs/ac-5";
+
+const app = new Hono();
+app.route("/api/spec-checkout", specCheckoutRouter);
+
+function post(rawKey: string, body: unknown) {
+  return app.request("/api/spec-checkout", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: `Bearer ${rawKey}` },
+    body: JSON.stringify(body),
+  });
+}
+
+interface MemexCtx {
+  memexId: string;
+  slug: string;
+  docId: string;
+  ref: string;
+}
+
+async function makeMemexWithSpec(prefix: string, ownerId: string): Promise<MemexCtx> {
+  const made = await makeTestMemexWithDevAdmin(prefix);
+  const doc = await createDocDraft(
+    made.memexId,
+    "Graduation spec",
+    "purpose",
+    "spec",
+    undefined,
+    undefined,
+    ownerId,
+  );
+  return {
+    memexId: made.memexId,
+    slug: made.slug,
+    docId: doc.id,
+    ref: `${made.slug}/main/specs/${doc.handle}`,
+  };
+}
+
+describe("spec-430 ac-5: one user-scoped key records across every memex its owner belongs to", () => {
+  let rawKey: string;
+  let a: MemexCtx;
+  let b: MemexCtx;
+
+  beforeAll(async () => {
+    // dev@memex.ai is made an admin of BOTH memexes by makeTestMemexWithDevAdmin.
+    const dev = await upsertUserByEmail("dev@memex.ai");
+    a = await makeMemexWithSpec("grad-a", dev.id);
+    b = await makeMemexWithSpec("grad-b", dev.id);
+    // ONE key, minted once at the user level (no memex anywhere); the row is
+    // user-scoped (memexId null).
+    const minted = await mintHookKey("graduation hook", dev.id);
+    expect(minted.row.memexId).toBeNull();
+    rawKey = minted.raw;
+  });
+
+  it("records against memex A's spec", async () => {
+    tagAc(AC_5);
+    const res = await post(rawKey, {
+      ref: a.ref,
+      thread_uid: "grad-thread-a",
+      changed_paths: ["packages/server/src/a.ts"],
+    });
+    expect(res.status).toBe(201);
+    const rows = await listCheckoutEditsForSpec(a.memexId, a.docId);
+    expect(rows.some((r) => r.threadUid === "grad-thread-a")).toBe(true);
+  });
+
+  it("records against memex B's spec — the SAME key, zero new auth (graduation)", async () => {
+    tagAc(AC_5);
+    const res = await post(rawKey, {
+      ref: b.ref,
+      thread_uid: "grad-thread-b",
+      changed_paths: ["packages/server/src/b.ts"],
+    });
+    expect(res.status).toBe(201);
+    const rows = await listCheckoutEditsForSpec(b.memexId, b.docId);
+    expect(rows.some((r) => r.threadUid === "grad-thread-b")).toBe(true);
+  });
+});

--- a/packages/server/src/services/hook-keys.integration.test.ts
+++ b/packages/server/src/services/hook-keys.integration.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect } from "vitest";
 import { tagAc } from "@memex-ai-ac/vitest";
-import { makeTestMemex } from "./test-helpers.js";
 import { upsertUserByEmail } from "./users.js";
 import {
   mintHookKey,
@@ -15,29 +14,29 @@ import {
 const AC_14 = "mindset-prod/memex-building-itself/specs/spec-371/acs/ac-14";
 
 describe("hook-keys: mint / verify / revoke (spec-371 ac-14)", () => {
-  it("mint → verify round-trips to the same unrevoked row, scoped to its memex", async () => {
+  it("mint → verify round-trips to the same unrevoked row; the key is USER-scoped (memexId null, spec-430 dec-1)", async () => {
     tagAc(AC_14);
-    const memexId = await makeTestMemex("hk");
     const user = await upsertUserByEmail("dev@memex.ai");
 
-    const minted = await mintHookKey(memexId, "spec-371 install", user.id);
+    const minted = await mintHookKey("spec-371 install", user.id);
     expect(minted.raw.startsWith("mxh_")).toBe(true);
-    expect(minted.row.memexId).toBe(memexId);
+    // spec-430 dec-1: minted keys are user-scoped — no home memex on the row.
+    expect(minted.row.memexId).toBeNull();
+    expect(minted.row.createdByUserId).toBe(user.id);
 
     const found = await verifyHookKey(minted.raw);
     expect(found?.id).toBe(minted.row.id);
-    expect(found?.memexId).toBe(memexId);
+    expect(found?.memexId).toBeNull();
     expect(found?.revokedAt).toBeNull();
   });
 
-  it("a revoked key never verifies again", async () => {
+  it("a revoked key never verifies again (owner-scoped revoke, spec-430 dec-1)", async () => {
     tagAc(AC_14);
-    const memexId = await makeTestMemex("hk");
     const user = await upsertUserByEmail("dev@memex.ai");
-    const minted = await mintHookKey(memexId, "to-revoke", user.id);
+    const minted = await mintHookKey("to-revoke", user.id);
 
     expect(await verifyHookKey(minted.raw)).not.toBeNull();
-    const revoked = await revokeHookKey(minted.row.id, memexId);
+    const revoked = await revokeHookKey(minted.row.id, user.id);
     expect(revoked?.id).toBe(minted.row.id);
     expect(await verifyHookKey(minted.raw)).toBeNull();
   });

--- a/packages/server/src/services/hook-keys.ts
+++ b/packages/server/src/services/hook-keys.ts
@@ -41,24 +41,26 @@ export interface MintedHookKey {
   row: MemexHookKey;
 }
 
-// Mint a scoped hook key for a Memex. `createdByUserId` records the minting member
-// (the plugin-install path passes the authenticated user). Returns the RAW key
-// exactly once — only the SHA-256 hash + prefix are persisted, so the raw value
-// cannot be recovered afterwards.
+// Mint a USER-scoped hook key (spec-430 dec-1 / dec-3). The minted row has
+// `memexId: null` — it authorizes a checkout write for ANY memex its creator is an
+// active member of, so a personal->org graduation needs no new key. `createdByUserId`
+// is the scoping identity (the authenticated user the user-level mint endpoint
+// resolved). There is NO memex anywhere: the reactivity emit fires non-scoped
+// (memexId ""), mirroring bumpHookKeyLastUsed. Returns the RAW key exactly once — only
+// the SHA-256 hash + prefix are persisted, so the raw value cannot be recovered after.
 export async function mintHookKey(
-  memexId: string,
   name: string,
   createdByUserId: string,
 ): Promise<Mutated<MintedHookKey>> {
   const raw = generateRawHookKey();
   return mutate(
     {},
-    { memexId, userId: createdByUserId, entity: HOOK_KEY_ENTITY, action: "created" },
+    { memexId: "", userId: createdByUserId, entity: HOOK_KEY_ENTITY, action: "created" },
     async () => {
       const [row] = await db
         .insert(memexHookKeys)
         .values({
-          memexId,
+          memexId: null, // user-scoped (spec-430 dec-1); authz is by membership, not key granularity
           name,
           hashedKey: hashHookKey(raw),
           prefix: hookKeyDisplayPrefix(raw),
@@ -102,30 +104,33 @@ export function bumpHookKeyLastUsed(keyId: string): void {
 }
 
 // Soft-revoke (sets revokedAt, never deletes) so the audit trail and sibling keys
-// survive. Scoped to the owning Memex. Returns the updated row, or null when no
-// row matches.
+// survive. Scoped to the OWNER (spec-430 dec-1): keys are user-scoped (memexId NULL),
+// so a member revokes their own key by id + createdByUserId — a memex scope can no
+// longer match a user-scoped row. Returns the updated row, or null when no row
+// matches (wrong id, or not the caller's key).
 export async function revokeHookKey(
   keyId: string,
-  memexId: string,
+  ownerUserId: string,
 ): Promise<Mutated<MemexHookKey | null>> {
   return mutate(
     {},
-    { memexId, entity: HOOK_KEY_ENTITY, action: "deleted" },
+    { memexId: "", userId: ownerUserId, entity: HOOK_KEY_ENTITY, action: "deleted" },
     async () => {
       const [row] = await db
         .update(memexHookKeys)
         .set({ revokedAt: sql`now()` })
-        .where(and(eq(memexHookKeys.id, keyId), eq(memexHookKeys.memexId, memexId)))
+        .where(and(eq(memexHookKeys.id, keyId), eq(memexHookKeys.createdByUserId, ownerUserId)))
         .returning();
       return row ?? null;
     },
   );
 }
 
-// Every key on the Memex, newest first (the future settings list).
-export async function listHookKeysForMemex(memexId: string): Promise<MemexHookKey[]> {
+// Every key a USER owns, newest first (spec-430 dec-3 — keys are user-scoped, so the
+// settings list is per user, never per memex).
+export async function listHookKeysForUser(userId: string): Promise<MemexHookKey[]> {
   return db.query.memexHookKeys.findMany({
-    where: eq(memexHookKeys.memexId, memexId),
+    where: eq(memexHookKeys.createdByUserId, userId),
     orderBy: [desc(memexHookKeys.createdAt)],
   });
 }

--- a/packages/server/src/services/org-memberships.ts
+++ b/packages/server/src/services/org-memberships.ts
@@ -35,6 +35,20 @@ export class MembershipActionError extends ValidationError {
   }
 }
 
+// Whether a user is an ACTIVE member of an org (any role). The membership gate the
+// checkout phone-home uses to authorize a user-scoped hook key (spec-430 dec-1):
+// the key authorizes a write iff its creator is an active member of the spec's org.
+export async function isActiveOrgMember(userId: string, orgId: string): Promise<boolean> {
+  const row = await db.query.orgMemberships.findFirst({
+    where: and(
+      eq(orgMemberships.userId, userId),
+      eq(orgMemberships.orgId, orgId),
+      eq(orgMemberships.status, "active"),
+    ),
+  });
+  return Boolean(row);
+}
+
 // Counts the active administrators of an org. Used by last-admin guards.
 export async function countActiveAdmins(orgId: string): Promise<number> {
   const [row] = await db

--- a/packages/server/src/services/test-event-latest.integration.test.ts
+++ b/packages/server/src/services/test-event-latest.integration.test.ts
@@ -241,8 +241,13 @@ describe("test_event_latest maintenance (spec-162)", () => {
   it("two null-test_identifier emissions collapse to a single '' row [ac-9]", async () => {
     tagAc(`${SPEC}/acs/ac-9`);
     const ref = uniqueRef();
+    // Both timestamps are explicit app-clock values so "newest wins" compares like
+    // with like. Letting the second emission fall back to the DB-default now() pits an
+    // app-clock value (the first row) against a DB-clock value (the second); under
+    // full-suite load that cross-clock comparison can invert and the older `pass`
+    // wrongly wins (std-37 — deterministic fixtures under parallel execution).
     await seedTestEvent({ acUid: ref, status: "pass", testIdentifier: null, createdAt: new Date(Date.now() - 1000) });
-    await seedTestEvent({ acUid: ref, status: "fail", testIdentifier: null });
+    await seedTestEvent({ acUid: ref, status: "fail", testIdentifier: null, createdAt: new Date() });
 
     const rows = await db
       .select()

--- a/packages/shared/src/scaffold-data.ts
+++ b/packages/shared/src/scaffold-data.ts
@@ -1793,6 +1793,12 @@ export const QA_REPORT_GENERATION_INSTRUCTION = `Persist that closing summary as
   8. Open questions — knowledge gaps surfaced during build that the verifier should know about, captured as agent-sourced issues and referenced here.
 GROUNDING IS MANDATORY: base sections 1–2 on the changes you made this session — the actual files and behaviour you touched, re-read rather than recalled — and section 3 on the tests you actually ran and the test events you emitted, cross-referenced to their acceptance criteria. The report records what THIS session actually changed, never a restatement of the plan; where reality diverged from the plan, the report says so. Each build session's report is appended as a new dated version — write_qa_report never overwrites a prior session's record.`;
 
+// spec-430 dec-4 / ac-9: the agent-guided install prompt lives in the UI's env- and
+// agent-aware home (packages/ui/src/utils/genesisPrompt.ts `buildClaudeCodePrompt`),
+// NOT here — because the checkout plugin is Claude-Code-only and the prompt must be
+// gated to the Claude Code selection (Cursor stays MCP-only). The in-agent priming is
+// the bundled SessionStart self-heal hook (packages/cli/plugin/hooks).
+
 const OPENING_TURN_PROMPT_BUTTONS: PromptButtonNode[] = [
   {
     kind: 'prompt_button',

--- a/packages/shared/src/tool-manifest.ts
+++ b/packages/shared/src/tool-manifest.ts
@@ -573,7 +573,7 @@ export const toolManifest: ToolManifestEntry[] = [
   {
     name: 'discontinue_test_events',
     summary:
-      'Hard-delete an orphaned test_identifier on an AC (a test you renamed/deleted whose stale fail still pins the AC red): removes the emissions and clears their summary. Irreversible; a fresh live emission re-enters the verdict. Only for identifiers gone from the codebase.',
+      'Hard-delete an orphaned test_identifier on an AC (a renamed/deleted test whose stale fail pins the AC red): removes its emissions + summary. Irreversible; a fresh emission re-enters the verdict. Only for identifiers gone from the code.',
     args: 'discontinue_test_events(ref, test_identifier)',
     group: 'build',
     readOnlyHint: false,

--- a/packages/ui/e2e/journey-51-spec-430-setup-agent.spec.ts
+++ b/packages/ui/e2e/journey-51-spec-430-setup-agent.spec.ts
@@ -1,0 +1,92 @@
+import {
+  test,
+  expect,
+  bareUrl,
+  emitAcEvents,
+  ensureUser,
+  setUserName,
+  setIdentityConfirmed,
+  DEV_EMAIL,
+  DEV_NAME,
+} from "./helpers/index.js";
+
+// Journey 51 — spec-430: the NEW coding-agent install flow (std-28 gate).
+//
+// SCOPE: the consolidated /settings/integrations "Install Memex MCP" surface now
+// describes the unified Claude Code install — ONE browser sign-in via
+// `npx -y memex-ai install` plants the Memex MCP token AND mints the single
+// per-user checkout key (no second sign-in, no per-memex keys, nothing pasted by
+// hand) — followed by the HOOKS-ONLY spec-checkout plugin added with
+// `claude plugin …`. That plugin is CLAUDE-CODE-ONLY: it must NOT appear in the
+// OAuth-on-connect "Other clients" (Cursor / VS Code / web) guidance.
+//
+// This proves the manager-authored outcome end-to-end in a real browser
+// (route → React → rendered page → live copy) which the jsdom component suites
+// (CliInstallSection.test.tsx / ConnectAgentStep.test.tsx) can't: real path-based
+// navigation and the install copy/commands as they actually reach the browser.
+//
+// Static copy only — nothing here runs the bootstrap (the pasted agent does that),
+// so there is no live MCP/OAuth dance to drive (same posture as journey-24).
+//
+// Emits spec-430 ac-9 via the emitAcEvents afterEach hook (pass+fail alike).
+
+const FILE = "packages/ui/e2e/journey-51-spec-430-setup-agent.spec.ts";
+const AC9 = "mindset-prod/memex-building-itself/specs/spec-430/acs/ac-9";
+
+test.afterEach(async ({}, testInfo) => {
+  if (testInfo.status === "skipped") return;
+  await emitAcEvents(
+    [AC9],
+    testInfo.status === "passed" ? "pass" : "fail",
+    `${FILE}::${testInfo.title}`,
+    testInfo.duration,
+  );
+});
+
+test("Claude Code install describes the unified npx install + the Claude-Code-only checkout plugin, gated out of the other-clients block (spec-430 ac-9)", async ({
+  page,
+}) => {
+  // Shared dev user, identity-confirmed so the app routes straight to the surface.
+  await ensureUser(DEV_EMAIL);
+  await setUserName(DEV_EMAIL, DEV_NAME);
+  await setIdentityConfirmed(DEV_EMAIL, true);
+
+  // std-28: path-based nav. The Integrations route is top-level + member-visible.
+  await page.goto(bareUrl("/settings/integrations"));
+  await expect(
+    page.getByRole("heading", { name: "Integrations", level: 1 }),
+  ).toBeVisible({ timeout: 15_000 });
+
+  const cli = page.locator("#install-cli");
+  await expect(cli.getByRole("heading", { name: "Install Memex MCP" })).toBeVisible();
+
+  // The Claude Code path is its own block — select/scope to it.
+  await expect(cli.getByRole("heading", { name: "Claude Code", exact: true })).toBeVisible();
+
+  // ac-9: the unified installer — ONE browser sign-in → MCP token + checkout key.
+  await expect(cli.getByText(/npx -y memex-ai install/).first()).toBeVisible();
+  // …and the HOOKS-ONLY, Claude-Code-only spec-checkout plugin steps.
+  await expect(
+    cli.getByText("claude plugin marketplace add mindset-ai/memex-ai"),
+  ).toBeVisible();
+  await expect(
+    cli.getByText("claude plugin install memex-checkout@memex"),
+  ).toBeVisible();
+
+  // ac-9: the old curl/irm install.sh bootstrap one-liner is gone (superseded).
+  await expect(cli.getByText(/install\.sh|install\.ps1/)).toHaveCount(0);
+
+  // ac-9 (the gate): the checkout plugin is CLAUDE-CODE-ONLY — it must NOT appear in
+  // the OAuth-on-connect "Other clients" (Cursor / VS Code / web) guidance, which
+  // stays MCP-only over the env-derived URL.
+  const others = page.locator("#other-clients");
+  await expect(others).toBeVisible();
+  await expect(others.getByText(/memex-checkout/)).toHaveCount(0);
+  await expect(others.getByText(/claude plugin/)).toHaveCount(0);
+  // The other-clients block still carries the env-derived MCP URL (a real http(s)
+  // URL ending in /mcp), not the plugin commands.
+  const mcpUrlText = (
+    await others.locator("pre code").first().textContent()
+  )?.trim();
+  expect(mcpUrlText).toMatch(/^https?:\/\/.+\/mcp$/);
+});

--- a/packages/ui/src/components/CliInstallSection.test.tsx
+++ b/packages/ui/src/components/CliInstallSection.test.tsx
@@ -6,6 +6,10 @@ import { installBase, mcpUrl } from '../utils/mcpUrl';
 
 const AC_URL_DERIVED = 'mindset-prod/memex-building-itself/specs/spec-201/acs/ac-15';
 const AC_MORE_CLIENTS = 'mindset-prod/memex-building-itself/specs/spec-201/acs/ac-16';
+// spec-430 ac-9: the Integrations install section describes the unified Claude Code
+// flow (npx -y memex-ai install → checkout plugin), with the Claude-Code-only plugin
+// kept out of the OAuth-on-connect "Other clients" (Cursor / VS Code / web) guidance.
+const AC430_9 = 'mindset-prod/memex-building-itself/specs/spec-430/acs/ac-9';
 
 describe('spec-201 ac-15: connect instructions derive the MCP URL from the environment', () => {
   it('renders the MCP URL as installBase + /mcp, not a hardcoded host', () => {
@@ -55,5 +59,39 @@ describe('spec-253: native-IDE OAuth connect steps (VS Code)', () => {
   it('frames the OAuth-on-connect clients as native IDEs (Cursor, VS Code, Windsurf, Zed)', () => {
     render(<CliInstallSection />);
     expect(screen.getByText(/Cursor, VS Code, Windsurf, Zed/)).toBeInTheDocument();
+  });
+});
+
+// spec-430: the Claude Code install is now the unified `npx -y memex-ai install`
+// (one sign-in → MCP token + checkout key) plus the Claude-Code-ONLY spec-checkout
+// plugin. The plugin must NOT appear in the OAuth-on-connect "Other clients" block.
+describe('spec-430 ac-9: unified Claude Code install + Claude-Code-gated checkout plugin', () => {
+  it('shows the unified installer and the checkout plugin under a Claude Code heading', () => {
+    tagAc(AC430_9);
+    render(<CliInstallSection />);
+    const cc = screen.getByRole('heading', { name: 'Claude Code' });
+    expect(cc).toBeInTheDocument();
+    // The unified installer (one sign-in → MCP token + checkout key) appears — it's
+    // referenced more than once (the command block + the Claude Desktop footnote).
+    expect(screen.getAllByText(/npx -y memex-ai install/).length).toBeGreaterThanOrEqual(1);
+    // …and the two Claude-Code-only plugin commands (in one code block).
+    const plugin = screen.getByText(/claude plugin marketplace add mindset-ai\/memex-ai/);
+    expect(plugin.textContent).toContain('claude plugin install memex-checkout@memex');
+  });
+
+  it('does NOT surface the checkout plugin in the OAuth-on-connect Other clients block', () => {
+    tagAc(AC430_9);
+    render(<CliInstallSection />);
+    // The plugin is Claude Code only — it must not appear in the Cursor/VS Code/web copy.
+    const others = document.getElementById('other-clients');
+    expect(others).not.toBeNull();
+    expect(others?.textContent ?? '').not.toContain('memex-checkout');
+    expect(others?.textContent ?? '').not.toContain('claude plugin');
+  });
+
+  it('drops the old curl/irm install.sh bootstrap one-liner (superseded by the unified installer)', () => {
+    tagAc(AC430_9);
+    render(<CliInstallSection />);
+    expect(screen.queryByText(/install\.sh|install\.ps1/)).toBeNull();
   });
 });

--- a/packages/ui/src/components/CliInstallSection.tsx
+++ b/packages/ui/src/components/CliInstallSection.tsx
@@ -7,13 +7,28 @@
 //
 // spec-201: the URL derivation moved to utils/mcpUrl.ts and the code-block
 // primitives to components/CodeBlock.tsx, both shared with GenesisPromptSection.
+//
+// spec-430 dec-2/dec-4: the canonical Claude Code install is the unified
+// `npx -y memex-ai install` — ONE browser sign-in plants the Memex MCP token AND
+// mints the single per-user checkout key (no second sign-in, no per-memex keys,
+// nothing pasted by hand). Claude Code then adds the HOOKS-ONLY spec-checkout
+// plugin via `claude plugin …`. That plugin is CLAUDE-CODE-ONLY — it does not run
+// in Cursor or any other agent, so the plugin steps appear in the Claude Code path
+// ONLY. Cursor / VS Code / web stay MCP-only over OAuth (the "Other clients" block).
 
 import { useState } from 'react';
 import { CodeBlock, InlineCode } from './CodeBlock';
 import { installBase } from '../utils/mcpUrl';
 
-const SH_COMMAND = `curl -fsSL ${installBase}/install.sh | sh`;
-const PS_COMMAND = `irm ${installBase}/install.ps1 | iex`;
+// The unified installer (spec-430). Same `--api-base` derivation as the genesis
+// prompt: prod is the bare command; any other env passes the host explicitly.
+const INSTALL_API_BASE_FLAG = installBase === 'https://memex.ai' ? '' : ` --api-base ${installBase}`;
+const INSTALL_COMMAND = `npx -y memex-ai install${INSTALL_API_BASE_FLAG}`;
+
+// Claude Code only — the hooks-only spec-checkout plugin (no MCP bundled; the
+// installer above already planted the MCP). Does NOT work in Cursor / other agents.
+const PLUGIN_COMMANDS = `claude plugin marketplace add mindset-ai/memex-ai
+claude plugin install memex-checkout@memex`;
 
 // spec-201 dec-4: the canonical MCP endpoint, shared by the claude.ai web and
 // Cursor connect steps below. Same derivation as the manual configs.
@@ -43,21 +58,7 @@ const VSCODE_CONFIG = `{
   }
 }`;
 
-function detectOs(): 'mac' | 'linux' | 'windows' | 'unknown' {
-  if (typeof navigator === 'undefined') return 'unknown';
-  const p = navigator.platform.toLowerCase();
-  const u = navigator.userAgent.toLowerCase();
-  if (p.includes('mac') || u.includes('mac os')) return 'mac';
-  if (p.includes('win') || u.includes('windows')) return 'windows';
-  if (p.includes('linux') || u.includes('linux')) return 'linux';
-  return 'unknown';
-}
-
 export function CliInstallSection() {
-  const os = detectOs();
-  const cmd = os === 'windows' ? PS_COMMAND : SH_COMMAND;
-  const osLabel = os === 'mac' ? 'macOS' : os === 'windows' ? 'Windows' : os === 'linux' ? 'Linux' : 'your OS';
-
   const [showFallback, setShowFallback] = useState(false);
 
   return (
@@ -69,16 +70,30 @@ export function CliInstallSection() {
         claude.ai (web) or a native IDE like Cursor or VS Code instead? See <a href="#other-clients" className="underline hover:text-primary">Other clients</a> below.
       </p>
 
+      {/* spec-430: the canonical Claude Code path. ONE sign-in plants the MCP token AND
+          mints the per-user checkout key; the hooks-only plugin is Claude-Code-only. */}
       <div className="mb-10">
-        <h3 className="text-base font-medium mb-3 text-heading">Install ({osLabel})</h3>
+        <h3 className="text-base font-medium mb-3 text-heading">Claude Code</h3>
         <p className="text-sm mb-3 text-secondary">
-          Paste this into your terminal:
+          Paste this into your terminal. One browser sign-in plants the Memex MCP token{' '}
+          <strong>and</strong> mints your single per-user checkout key — no second sign-in,
+          no per-memex keys, nothing pasted by hand:
         </p>
-        <CodeBlock code={cmd} />
+        <CodeBlock code={INSTALL_COMMAND} />
+        <p className="text-sm mb-3 mt-6 text-secondary">
+          Then add the spec-checkout plugin — the in-flow edit hooks. This plugin is{' '}
+          <strong>Claude Code only</strong> (it no longer bundles an MCP; the install above
+          already planted it):
+        </p>
+        <CodeBlock code={PLUGIN_COMMANDS} />
         <p className="text-xs mt-3 text-muted">
-          What this does: downloads a small Node-based installer, opens this admin in your
-          browser to authorize the device, then writes the MCP entry into your Claude
-          configs.
+          Reload the window afterwards — the hooks load at session start. What the installer
+          does: opens this admin in your browser to authorize the device once, then writes
+          the MCP entry into your Claude config and stores your checkout key.
+        </p>
+        <p className="text-xs mt-3 text-muted">
+          <strong>Claude Desktop</strong> uses the same <InlineCode>npx -y memex-ai install</InlineCode>{' '}
+          for the MCP, but skip the plugin steps — the spec-checkout plugin runs in Claude Code only.
         </p>
       </div>
 

--- a/packages/ui/src/components/GenesisPromptSection.test.tsx
+++ b/packages/ui/src/components/GenesisPromptSection.test.tsx
@@ -6,6 +6,8 @@ import { mcpUrl } from '../utils/mcpUrl';
 
 const AC_ENV_DERIVED = 'mindset-prod/memex-building-itself/specs/spec-201/acs/ac-18';
 const AC_STATIC = 'mindset-prod/memex-building-itself/specs/spec-201/acs/ac-21';
+// spec-430: Claude Code prompt = unified install + checkout plugin; Cursor = MCP-only.
+const AC_9_430 = 'mindset-prod/memex-building-itself/specs/spec-430/acs/ac-9';
 
 // jsdom has no clipboard by default; the CopyButton calls navigator.clipboard.
 Object.assign(navigator, {
@@ -36,12 +38,14 @@ describe('spec-201: GenesisPromptSection', () => {
     expect(screen.queryByRole('button', { name: /run|verify|install|connect/i })).toBeNull();
   });
 
-  it('defaults to the Claude Code prompt (claude mcp add + CLAUDE.md)', () => {
-    tagAc(AC_STATIC);
+  it('defaults to the Claude Code prompt — unified install + the checkout plugin (spec-430)', () => {
+    tagAc(AC_9_430);
     render(<GenesisPromptSection />);
     const text = getPromptText();
-    expect(text).toContain('claude mcp add');
+    expect(text).toContain('npx -y memex-ai install');
+    expect(text).toContain('claude plugin install memex-checkout@memex');
     expect(text).toContain('CLAUDE.md');
+    expect(text).not.toContain('claude mcp add'); // superseded (dec-2)
   });
 
   it('switches to the Cursor prompt (.cursor/rules/memex.mdc) on tab change', () => {
@@ -53,9 +57,23 @@ describe('spec-201: GenesisPromptSection', () => {
     expect(text).toContain('.cursor/mcp.json');
   });
 
-  it('ac-18: the rendered prompt embeds the environment-derived MCP URL', () => {
+  it('the checkout plugin is CLAUDE-CODE-ONLY — the Cursor prompt never mentions it (spec-430)', () => {
+    tagAc(AC_9_430);
+    render(<GenesisPromptSection />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Cursor' }));
+    const text = getPromptText();
+    expect(text).not.toContain('memex-ai install');
+    expect(text).not.toContain('claude plugin');
+    expect(text).not.toContain('memex-checkout');
+  });
+
+  it('ac-18: the rendered prompt embeds the environment-derived MCP URL (Cursor)', () => {
     tagAc(AC_ENV_DERIVED);
     render(<GenesisPromptSection />);
+    // The Cursor prompt always embeds the MCP URL verbatim; the Claude Code prompt only
+    // adds --api-base for non-prod (prod omits it as the CLI default), so the always-on
+    // env-derivation check reads the Cursor tab.
+    fireEvent.click(screen.getByRole('tab', { name: 'Cursor' }));
     expect(getPromptText()).toContain(mcpUrl);
     expect(mcpUrl.endsWith('/mcp')).toBe(true);
   });

--- a/packages/ui/src/components/GenesisPromptSection.tsx
+++ b/packages/ui/src/components/GenesisPromptSection.tsx
@@ -23,11 +23,10 @@ const CLIENTS: { id: Client; label: string }[] = [
 export function GenesisPromptSection() {
   const [client, setClient] = useState<Client>('claude-code');
 
-  const prompt =
-    client === 'claude-code' ? buildClaudeCodePrompt(mcpUrl) : buildCursorPrompt(mcpUrl);
+  const isClaudeCode = client === 'claude-code';
+  const prompt = isClaudeCode ? buildClaudeCodePrompt(mcpUrl) : buildCursorPrompt(mcpUrl);
 
-  const memoryFile =
-    client === 'claude-code' ? 'CLAUDE.md' : '.cursor/rules/memex.mdc';
+  const memoryFile = isClaudeCode ? 'CLAUDE.md' : '.cursor/rules/memex.mdc';
 
   return (
     <section id="genesis-prompt" aria-labelledby="genesis-prompt-heading">
@@ -36,10 +35,25 @@ export function GenesisPromptSection() {
       </h2>
       <p className="mb-6 text-secondary">
         Prefer to let your agent wire itself up? Paste this into a fresh{' '}
-        <strong>Claude Code</strong> or <strong>Cursor</strong> session. It registers the
-        Memex MCP server and writes a short "how to use Memex" note into your{' '}
-        <InlineCode>{memoryFile}</InlineCode> so the agent reaches for Memex every session
-        — not just this one.
+        <strong>{isClaudeCode ? 'Claude Code' : 'Cursor'}</strong> session.{' '}
+        {isClaudeCode ? (
+          <>
+            It installs the Memex MCP server{' '}
+            <strong>and the spec-checkout plugin</strong> in one browser sign-in, and
+            writes a short "how to use Memex" note into your{' '}
+            <InlineCode>{memoryFile}</InlineCode> so the agent reaches for Memex every
+            session — not just this one.
+          </>
+        ) : (
+          <>
+            It registers the Memex MCP server and writes a short "how to use Memex" note
+            into your <InlineCode>{memoryFile}</InlineCode> so the agent reaches for Memex
+            every session.{' '}
+            <span className="text-muted">
+              (The spec-checkout plugin is Claude Code only.)
+            </span>
+          </>
+        )}
       </p>
 
       <div role="tablist" aria-label="Choose your agent" className="flex gap-2 mb-4">

--- a/packages/ui/src/components/home/ConnectAgentStep.test.tsx
+++ b/packages/ui/src/components/home/ConnectAgentStep.test.tsx
@@ -13,6 +13,10 @@ vi.mock('../../api/journey', () => ({ fetchJourneyStateApi }));
 import { ConnectAgentStep } from './ConnectAgentStep';
 
 const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-305/acs/ac-${n}`;
+// spec-430 ac-9: the onboarding connect-agent step describes the NEW unified
+// Claude Code install flow (npx -y memex-ai install → checkout plugin), gated so
+// the plugin steps appear in the Claude Code path only.
+const AC430 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-430/acs/ac-${n}`;
 
 beforeEach(() => {
   fetchJourneyStateApi.mockReset();
@@ -20,23 +24,49 @@ beforeEach(() => {
 });
 
 describe('ConnectAgentStep', () => {
-  it('renders OS pills + tool selector with the Claude Code installer by default', () => {
+  // spec-430 supersedes spec-305's OS-pills + curl/irm installer assertion: the
+  // unified `npx -y memex-ai install` command is OS-agnostic, so the OS selector is
+  // gone and the Claude Code path now shows the install + the checkout plugin.
+  it('renders the tool selector with the unified Claude Code install flow by default', () => {
     tagAc(AC(3));
     tagAc(AC(12));
+    tagAc(AC430(9));
     render(<ConnectAgentStep preview />);
     expect(screen.getByTestId('journey-step-connect-agent')).toBeInTheDocument();
-    expect(screen.getByTestId('os-mac')).toBeInTheDocument();
     expect(screen.getByTestId('tool-claude-code')).toBeInTheDocument();
-    expect(screen.getByTestId('connect-instructions').textContent).toMatch(/install\.sh|install\.ps1/);
+    const instr = screen.getByTestId('connect-instructions').textContent ?? '';
+    // The old curl/irm bootstrap one-liners are gone…
+    expect(instr).not.toMatch(/install\.sh|install\.ps1/);
+    // …replaced by the unified installer + the Claude-Code-only checkout plugin.
+    expect(instr).toContain('npx -y memex-ai install');
+    expect(instr).toContain('claude plugin marketplace add mindset-ai/memex-ai');
+    expect(instr).toContain('claude plugin install memex-checkout@memex');
+    // The per-OS "Your machine" selector no longer exists (command is OS-agnostic).
+    expect(screen.queryByTestId('os-mac')).not.toBeInTheDocument();
   });
 
-  it('switching tool to Cursor swaps the instructions and drops the OS pills', () => {
+  it('gates the checkout plugin to Claude Code: Cursor stays MCP-only with no plugin steps (spec-430 ac-9)', () => {
     tagAc(AC(12));
+    tagAc(AC430(9));
     render(<ConnectAgentStep preview />);
     fireEvent.click(screen.getByTestId('tool-cursor'));
-    expect(screen.getByTestId('connect-instructions').textContent).toMatch(/mcpServers|\/mcp/);
-    // OS only matters for the terminal installer, not the JSON-config clients.
-    expect(screen.queryByTestId('os-mac')).not.toBeInTheDocument();
+    const instr = screen.getByTestId('connect-instructions').textContent ?? '';
+    expect(instr).toMatch(/mcpServers|\/mcp/);
+    // The Claude-Code-only plugin must NOT appear for Cursor.
+    expect(instr).not.toContain('claude plugin');
+    expect(instr).not.toContain('memex-checkout');
+    expect(instr).not.toContain('npx -y memex-ai install');
+  });
+
+  it('Claude Desktop reuses the unified installer for the MCP but shows NO checkout plugin (spec-430 ac-9)', () => {
+    tagAc(AC430(9));
+    render(<ConnectAgentStep preview />);
+    fireEvent.click(screen.getByTestId('tool-claude-desktop'));
+    const instr = screen.getByTestId('connect-instructions').textContent ?? '';
+    expect(instr).toContain('npx -y memex-ai install');
+    // Plugin is Claude Code only — not shown for Claude Desktop.
+    expect(instr).not.toContain('claude plugin');
+    expect(instr).not.toContain('memex-checkout');
   });
 
   it('flips to the Memex-native reward state + latches when mcp.connected is detected', async () => {

--- a/packages/ui/src/components/home/ConnectAgentStep.tsx
+++ b/packages/ui/src/components/home/ConnectAgentStep.tsx
@@ -35,8 +35,16 @@ export const TOOLS: ReadonlyArray<{ id: Tool; label: string }> = [
   { id: 'windsurf-zed', label: 'Windsurf / Zed' },
 ];
 
-const shInstall = `curl -fsSL ${installBase}/install.sh | sh`;
-const psInstall = `irm ${installBase}/install.ps1 | iex`;
+// spec-430 dec-2/dec-4: the unified installer replaces the old curl/irm one-liners
+// for Claude Code — ONE browser sign-in plants the Memex MCP token AND mints the
+// single per-user checkout key (no second sign-in, no per-memex keys, nothing pasted
+// by hand). Same `--api-base` derivation as the genesis prompt: prod is the bare
+// command, any other env passes the host. Claude Desktop reuses this installer for
+// the MCP but NOT the plugin (the spec-checkout plugin is Claude Code only).
+const installApiBaseFlag = installBase === 'https://memex.ai' ? '' : ` --api-base ${installBase}`;
+const memexInstall = `npx -y memex-ai install${installApiBaseFlag}`;
+// Claude Code ONLY — the hooks-only spec-checkout plugin (no MCP bundled).
+const pluginInstall = `claude plugin marketplace add mindset-ai/memex-ai\nclaude plugin install memex-checkout@memex`;
 const cursorCfg = `{\n  "mcpServers": {\n    "memex": {\n      "url": "${mcpUrl}"\n    }\n  }\n}`;
 const vscodeCfg = `{\n  "servers": {\n    "memex": {\n      "type": "http",\n      "url": "${mcpUrl}"\n    }\n  }\n}`;
 
@@ -45,15 +53,39 @@ const ASK_PROMPT = `Using Memex (you're connected now), answer me:
 
 "What is Memex, and what are its core principles? Use the get_information tool, then explain it simply — like I'm new."`;
 
-export function Instructions({ tool, os, onCopy }: { tool: Tool; os: Os; onCopy?: () => void }) {
-  if (tool === 'claude-code' || tool === 'claude-desktop') {
+// spec-430: `os` is retained on the signature for call-site compatibility, but the
+// unified installer command is identical across platforms, so it no longer selects
+// the command. Claude Code gets the install + the (Claude-Code-only) checkout plugin;
+// Claude Desktop reuses the installer for the MCP but never the plugin.
+export function Instructions({ tool, onCopy }: { tool: Tool; os?: Os; onCopy?: () => void }) {
+  if (tool === 'claude-code') {
+    return (
+      <div className="space-y-3" data-testid="claude-code-instructions">
+        <p className="text-sm text-secondary">
+          Paste this into your terminal. One browser sign-in plants the Memex MCP token{' '}
+          <strong>and</strong> mints your single per-user checkout key — no second sign-in,
+          no per-memex keys, nothing pasted by hand:
+        </p>
+        <CodeBlock code={memexInstall} onCopy={onCopy} />
+        <p className="text-sm text-secondary">
+          Then add the spec-checkout plugin (the in-flow edit hooks). This plugin is{' '}
+          <strong>Claude Code only</strong> — it no longer bundles an MCP; the install above
+          already planted it:
+        </p>
+        <CodeBlock code={pluginInstall} onCopy={onCopy} />
+        <p className="text-xs text-muted">Reload the window afterwards — the hooks load at session start.</p>
+      </div>
+    );
+  }
+  if (tool === 'claude-desktop') {
     return (
       <div className="space-y-2">
         <p className="text-sm text-secondary">
-          Paste this into your terminal. It opens your browser once to authorize this
-          device, then writes the Memex MCP entry into your {tool === 'claude-desktop' ? 'Claude Desktop' : 'Claude'} config.
+          Paste this into your terminal. One browser sign-in plants the Memex MCP token into
+          your Claude Desktop config — no token to paste. (The spec-checkout plugin is Claude
+          Code only, so there's nothing more to install here.)
         </p>
-        <CodeBlock code={os === 'windows' ? psInstall : shInstall} onCopy={onCopy} />
+        <CodeBlock code={memexInstall} onCopy={onCopy} />
         <p className="text-xs text-muted">One install, a long-lived token, no expiry.</p>
       </div>
     );
@@ -130,7 +162,6 @@ export function ConnectAgentStep({
   // spec-324 — record the step's primary CTA (copy the setup command) as home_canvas.cta_clicked.
   onCtaClick?: (target: string) => void;
 } = {}) {
-  const [os, setOs] = useState<Os>(detectOs);
   const [tool, setTool] = useState<Tool>('claude-code');
   const [connected, setConnected] = useState(false);
   const doneRef = useRef(false);
@@ -168,8 +199,6 @@ export function ConnectAgentStep({
       clearInterval(id);
     };
   }, [preview, onComplete, onConnected]);
-
-  const osMatters = tool === 'claude-code' || tool === 'claude-desktop';
 
   return (
     <div className="flex min-h-[70vh] items-center justify-center px-4 py-10">
@@ -228,29 +257,8 @@ export function ConnectAgentStep({
               agent does the work while you watch it land.
             </p>
 
-            {osMatters && (
-              <div className="mt-7">
-                <span className="mb-2 block text-sm font-medium text-secondary">Your machine</span>
-                <div className="flex flex-wrap gap-2">
-                  {(['mac', 'windows', 'linux'] as Os[]).map((o) => (
-                    <button
-                      key={o}
-                      type="button"
-                      data-testid={`os-${o}`}
-                      onClick={() => setOs(o)}
-                      className={`rounded-lg border px-3 py-1.5 text-sm transition ${
-                        o === os
-                          ? 'border-accent bg-accent/10 font-medium text-accent'
-                          : 'border-edge text-secondary hover:bg-card-hover'
-                      }`}
-                    >
-                      {OS_LABEL[o]}
-                    </button>
-                  ))}
-                </div>
-              </div>
-            )}
-
+            {/* spec-430: the unified `npx -y memex-ai install` command is identical across
+                platforms, so the per-OS selector is gone — nothing it set changed the command. */}
             <div className="mt-6">
               <span className="mb-2 block text-sm font-medium text-secondary">Your coding agent</span>
               <div className="flex flex-wrap gap-2">
@@ -273,7 +281,7 @@ export function ConnectAgentStep({
             </div>
 
             <div className="mt-6" data-testid="connect-instructions">
-              <Instructions tool={tool} os={os} onCopy={() => onCtaClick?.('copy_install')} />
+              <Instructions tool={tool} onCopy={() => onCtaClick?.('copy_install')} />
             </div>
 
             <div className="mt-7 flex items-center gap-2 text-sm text-muted" data-testid="connect-waiting">

--- a/packages/ui/src/components/home/CreateSpecStep.test.tsx
+++ b/packages/ui/src/components/home/CreateSpecStep.test.tsx
@@ -2,7 +2,7 @@
 // spec-421: Stage 2 (create the spec) moved to CreateFirstSpecStep. This step now
 // completes on mcpConnected (was hasSpec). The tests below cover the MCP-connect flow only.
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { tagAc } from '@memex-ai-ac/vitest';
 
 const fetchJourneyStateApi = vi.hoisted(() => vi.fn());
@@ -12,6 +12,9 @@ import { CreateSpecStep } from './CreateSpecStep';
 import { setCachedJourneyState, resetCachedJourneyState } from '../../journeys/journeyStateCache';
 const AC372 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-372/acs/ac-${n}`;
 const AC421 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-421/acs/ac-${n}`;
+// spec-430 ac-9: this step reuses the shared Instructions component, so the unified
+// Claude Code install flow + Claude-Code-only checkout plugin show here too.
+const AC430 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-430/acs/ac-${n}`;
 
 beforeEach(() => {
   fetchJourneyStateApi.mockReset();
@@ -84,6 +87,29 @@ describe('CreateSpecStep — spec-421: MCP connect only, completes on mcpConnect
     expect(badge.textContent).toContain('Connected');
     expect(badge.textContent).toContain('✓');
     expect(badge.className).toContain('rounded-full');
+  });
+});
+
+describe('CreateSpecStep — spec-430 ac-9: unified Claude Code install flow', () => {
+  it('the default Claude Code instructions show npx install + the Claude-Code-only checkout plugin', () => {
+    tagAc(AC430(9));
+    render(<CreateSpecStep preview />);
+    const instr = screen.getByTestId('connect-instructions').textContent ?? '';
+    expect(instr).toContain('npx -y memex-ai install');
+    expect(instr).toContain('claude plugin marketplace add mindset-ai/memex-ai');
+    expect(instr).toContain('claude plugin install memex-checkout@memex');
+    // Old bootstrap one-liner is gone.
+    expect(instr).not.toMatch(/install\.sh|install\.ps1/);
+  });
+
+  it('switching to Cursor drops the Claude-Code-only plugin (MCP-only)', () => {
+    tagAc(AC430(9));
+    render(<CreateSpecStep preview />);
+    fireEvent.click(screen.getByTestId('tool-cursor'));
+    const instr = screen.getByTestId('connect-instructions').textContent ?? '';
+    expect(instr).toMatch(/mcpServers|\/mcp/);
+    expect(instr).not.toContain('claude plugin');
+    expect(instr).not.toContain('memex-checkout');
   });
 });
 

--- a/packages/ui/src/components/home/journey-cta.spec-324.test.tsx
+++ b/packages/ui/src/components/home/journey-cta.spec-324.test.tsx
@@ -65,7 +65,11 @@ describe('custom journey steps fire onCtaClick on their primary interaction (spe
     tagAc(AC2);
     const onCtaClick = vi.fn();
     render(<ConnectAgentStep onCtaClick={onCtaClick} />);
-    await clickCopyWithin('connect-instructions');
+    // spec-430: the Claude Code path now renders two code blocks (the unified installer
+    // and the Claude-Code-only checkout plugin), so there are two Copy buttons. Either
+    // one fires copy_install — click the first (the installer command).
+    const copy = within(screen.getByTestId('connect-instructions')).getAllByText('Copy')[0];
+    fireEvent.click(copy);
     await waitFor(() => expect(onCtaClick).toHaveBeenCalledWith('copy_install'));
   });
 

--- a/packages/ui/src/utils/genesisPrompt.test.ts
+++ b/packages/ui/src/utils/genesisPrompt.test.ts
@@ -10,15 +10,23 @@ import { deriveMcpUrl } from './mcpUrl';
 const AC_ENV_DERIVED = 'mindset-prod/memex-building-itself/specs/spec-201/acs/ac-18';
 const AC_CLAUDE_CODE = 'mindset-prod/memex-building-itself/specs/spec-201/acs/ac-19';
 const AC_CURSOR = 'mindset-prod/memex-building-itself/specs/spec-201/acs/ac-20';
+// spec-430 ac-9: the Claude Code prompt drives the unified install (npx install + the
+// hooks-only checkout plugin) — Claude-Code-only; Cursor stays MCP-only (no plugin).
+const AC_9_430 = 'mindset-prod/memex-building-itself/specs/spec-430/acs/ac-9';
 
 const PROD_MCP_URL = deriveMcpUrl('https://memex.ai/api'); // https://memex.ai/mcp
 
-describe('spec-201 ac-19: Claude Code Genesis prompt', () => {
-  it('instructs the agent to register the MCP server via `claude mcp add` with the given URL', () => {
+describe('spec-201 ac-19 / spec-430 ac-9: Claude Code Genesis prompt = unified install + checkout plugin', () => {
+  it('drives the unified `npx memex-ai install` (not `claude mcp add`) and the checkout plugin (spec-430)', () => {
     tagAc(AC_CLAUDE_CODE);
+    tagAc(AC_9_430);
     const prompt = buildClaudeCodePrompt(PROD_MCP_URL);
-    expect(prompt).toContain('claude mcp add');
-    expect(prompt).toContain(`memex ${PROD_MCP_URL}`);
+    expect(prompt).toContain('npx -y memex-ai install');
+    expect(prompt).toContain('claude plugin marketplace add mindset-ai/memex-ai');
+    expect(prompt).toContain('claude plugin install memex-checkout@memex');
+    expect(prompt).toMatch(/reload the window/i);
+    // superseded (dec-2): the old OAuth `claude mcp add` path is gone from this prompt
+    expect(prompt).not.toContain('claude mcp add');
   });
 
   it('instructs the agent to write the Memex-use clause into CLAUDE.md', () => {
@@ -26,6 +34,15 @@ describe('spec-201 ac-19: Claude Code Genesis prompt', () => {
     const prompt = buildClaudeCodePrompt(PROD_MCP_URL);
     expect(prompt).toContain('CLAUDE.md');
     expect(prompt).toContain(MEMEX_USAGE_GUIDANCE);
+  });
+
+  it('omits --api-base for prod but adds it for a non-prod env', () => {
+    tagAc(AC_9_430);
+    expect(buildClaudeCodePrompt(PROD_MCP_URL)).toContain('npx -y memex-ai install\n');
+    const intUrl = deriveMcpUrl('https://int.memex.ai/api');
+    expect(buildClaudeCodePrompt(intUrl)).toContain(
+      'npx -y memex-ai install --api-base https://int.memex.ai',
+    );
   });
 });
 
@@ -46,10 +63,13 @@ describe('spec-201 ac-20: Cursor Genesis prompt', () => {
 });
 
 describe('spec-201 ac-18: prompts embed the derived MCP URL (per environment)', () => {
-  it('uses the int URL when given the int API URL', () => {
+  it('uses the int host when given the int API URL (Claude Code: apiBase; Cursor: mcp URL)', () => {
     tagAc(AC_ENV_DERIVED);
     const intUrl = deriveMcpUrl('https://int.memex.ai/api'); // https://int.memex.ai/mcp
-    expect(buildClaudeCodePrompt(intUrl)).toContain('https://int.memex.ai/mcp');
+    // Claude Code drives `npx memex-ai install --api-base https://int.memex.ai` (no /mcp).
+    expect(buildClaudeCodePrompt(intUrl)).toContain('https://int.memex.ai');
+    expect(buildClaudeCodePrompt(intUrl)).not.toContain('https://int.memex.ai/mcp');
+    // Cursor still embeds the MCP URL directly.
     expect(buildCursorPrompt(intUrl)).toContain('https://int.memex.ai/mcp');
   });
 });

--- a/packages/ui/src/utils/genesisPrompt.ts
+++ b/packages/ui/src/utils/genesisPrompt.ts
@@ -21,18 +21,30 @@ Memex hosts our Specs — living plans that capture a piece of work's purpose, i
 - Reference items by handle: spec-N, dec-N, t-N, ac-N.`;
 
 export function buildClaudeCodePrompt(mcpUrl: string): string {
-  return `Set up Memex in this repo:
+  // spec-430 dec-2/dec-4 (supersedes spec-201's `claude mcp add` for Claude Code):
+  // the unified `npx memex-ai install` plants the MCP token AND mints the single
+  // per-user checkout key off ONE browser sign-in; the hooks-only spec-checkout
+  // plugin is then added with `claude plugin …`. This flow is CLAUDE-CODE-ONLY — the
+  // plugin does not work in Cursor (buildCursorPrompt stays MCP-only, no plugin).
+  const apiBase = mcpUrl.replace(/\/mcp$/, '');
+  const apiBaseFlag = apiBase === 'https://memex.ai' ? '' : ` --api-base ${apiBase}`;
+  return `Set up Memex in this repo for me, and explain each step as you run it:
 
-1. Register the Memex MCP server:
-   claude mcp add --transport http memex ${mcpUrl}
-   Then complete the browser sign-in if you're prompted to authorize.
+1. Install the Memex MCP server + your checkout key (ONE browser sign-in):
+   npx -y memex-ai install${apiBaseFlag}
 
-2. Add the following to this project's CLAUDE.md (create the file if it doesn't
+2. Install the spec-checkout plugin (the in-flow edit hooks):
+   claude plugin marketplace add mindset-ai/memex-ai
+   claude plugin install memex-checkout@memex
+
+3. Then tell me to reload the window — the hooks load at session start.
+
+4. Add the following to this project's CLAUDE.md (create the file if it doesn't
    exist; if a "Using Memex" section is already there, leave it):
 
 ${MEMEX_USAGE_GUIDANCE}
 
-Then confirm both steps are done and that calling \`list_memexes\` works.`;
+If a step is already done, say so and skip it; never ask me to paste a key by hand. Then confirm \`list_memexes\` works.`;
 }
 
 export function buildCursorPrompt(mcpUrl: string): string {


### PR DESCRIPTION
## Summary

spec-430 collapses memex-checkout onboarding to **one browser sign-in** with a **single per-user checkout key**, and makes **Claude Code guide the install**. The per-memex hook key is gone at every layer.

Spec: https://memex.ai/mindset-prod/memex-building-itself/specs/spec-430

### Server (dec-1, dec-3)
- Hook key is **user-scoped, never per-memex** — migration `0116` relaxes `memex_hook_keys.memex_id` to nullable; mints store `NULL`.
- `/api/spec-checkout` authorizes each write by **org membership + RLS** (new `isActiveOrgMember`), so personal→org graduation needs no new key. Owner-scoped revoke.
- Minting moves to a **user-level `POST /api/hook-keys`** (no memex in the path); the memex-scoped mint route is removed; `listHookKeysForMemex` → `listHookKeysForUser`.

### CLI (dec-2, dec-4)
- `npx -y memex-ai install` does **ONE** device-flow sign-in and provisions **both** the `mxt_` MCP token and the `mxh_` checkout key (`unifiedInstall`). Single `hook_key` in `~/.memex/checkout.json`; `checkout-setup` no longer needs `--memex`.
- The plugin is **hooks-only** (no bundled MCP, so no duplicate toolset / second sign-in) + a **SessionStart self-heal hook** that offers to finish setup when no key is present.

### Web UI (dec-4)
- The **Claude Code** genesis/install prompt drives the new flow (`npx install` + the hooks-only plugin) and the Integrations + onboarding copy matches it. **Cursor stays MCP-only — the checkout plugin is Claude-Code-only** (gated; a test asserts the "Other clients" block carries no plugin commands).
- New e2e journey `journey-51-spec-430-setup-agent`.

### Incidental: pre-existing flake fixes
The new test files reshuffled vitest sharding and exposed pre-existing parallel-isolation flakes, fixed here (std-37): `test-event-latest` cross-clock tie-break, `migration-smoke` owner-XOR + namespace_id global scans, and the `tool-manifest` summary length bound.

## Test plan
- [x] Server full suite: **4944 passed / 0 failed** + `tsc -p tsconfig.build.json` clean
- [x] UI full unit suite: **1837 passed** + `tsc --noEmit` clean
- [x] Shared: **765 passed** + tsc clean
- [x] CLI: **74 passed**
- [x] New tagged tests: ac-5 (graduation), ac-7 (one token→both creds), ac-8 (user-level mint), ac-9 (Claude-Code-gated prompt + SessionStart hook), ac-3 (migrator overwrite)
- [ ] e2e journey-51 (cold DB) — runs in CI

## Follow-up
None outstanding — issue-1 (the web Prompt Button surface) was brought into this PR per review.