### PR TITLE
feat(spec-21): server-side attribution persistence and conversion API…

### DIFF
--- a/packages/server/drizzle/0091_add_user_attributions.sql
+++ b/packages/server/drizzle/0091_add_user_attributions.sql
@@ -1,0 +1,19 @@
+-- spec-21 t-4: attribution persistence — capture marketing click IDs and UTM params
+-- at the moment a new account is created, for server-side conversion reporting.
+
+CREATE TABLE "user_attributions" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "user_id" uuid NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
+  "event_id" text NOT NULL,
+  "gclid" text,
+  "li_fat_id" text,
+  "oppref" text,
+  "utm_source" text,
+  "utm_medium" text,
+  "utm_campaign" text,
+  "utm_content" text,
+  "utm_term" text,
+  "created_at" timestamptz NOT NULL DEFAULT now()
+);
+--> statement-breakpoint
+CREATE INDEX "user_attributions_user_id_idx" ON "user_attributions"("user_id");

--- a/packages/server/drizzle/0119_add_user_attributions.sql
+++ b/packages/server/drizzle/0119_add_user_attributions.sql
@@ -1,9 +1,9 @@
 -- spec-21 t-4: attribution persistence — capture marketing click IDs and UTM params
 -- at the moment a new account is created, for server-side conversion reporting.
 
-CREATE TABLE "user_attributions" (
+CREATE TABLE IF NOT EXISTS "user_attributions" (
   "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
-  "user_id" uuid NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
+  "user_id" uuid NOT NULL REFERENCES "users"("id") ON DELETE cascade,
   "event_id" text NOT NULL,
   "gclid" text,
   "li_fat_id" text,
@@ -13,7 +13,8 @@ CREATE TABLE "user_attributions" (
   "utm_campaign" text,
   "utm_content" text,
   "utm_term" text,
-  "created_at" timestamptz NOT NULL DEFAULT now()
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL
 );
---> statement-breakpoint
-CREATE INDEX "user_attributions_user_id_idx" ON "user_attributions"("user_id");
+
+CREATE INDEX IF NOT EXISTS "user_attributions_user_id_idx"
+  ON "user_attributions" ("user_id");

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -1442,6 +1442,26 @@ export const loginRequests = pgTable("login_requests", {
   index("login_requests_token_id_idx").on(table.tokenId),
 ]);
 
+// spec-21 t-4: marketing attribution captured at account creation (first email verification).
+// One row per new-account event; userId FK cascades so rows are deleted with the user.
+export const userAttributions = pgTable("user_attributions", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  userId: uuid("user_id").notNull().references(() => users.id, { onDelete: "cascade" }),
+  // Server-generated UUID used to deduplicate server-to-server conversion API calls.
+  eventId: text("event_id").notNull(),
+  gclid: text("gclid"),
+  liFatId: text("li_fat_id"),
+  oppref: text("oppref"),
+  utmSource: text("utm_source"),
+  utmMedium: text("utm_medium"),
+  utmCampaign: text("utm_campaign"),
+  utmContent: text("utm_content"),
+  utmTerm: text("utm_term"),
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+}, (table) => [
+  index("user_attributions_user_id_idx").on(table.userId),
+]);
+
 export const orgMemberships = pgTable(
   "org_memberships",
   {

--- a/packages/server/src/routes/auth/magic-link.ts
+++ b/packages/server/src/routes/auth/magic-link.ts
@@ -118,6 +118,7 @@ magicLink.post("/consume", async (c) => {
   // (no surrogate row) consumes exactly as before.
   await markLoginRequestVerified(row.id);
 
+  let conversionEventId: string | null = null;
   if (isNewAccount) {
     const attribution = parseAttributionCookie(c.req.header("cookie"));
     if (attribution) {
@@ -126,6 +127,7 @@ magicLink.post("/consume", async (c) => {
         return null;
       });
       if (eventId) {
+        conversionEventId = eventId;
         fireAllConversions({
           email: user.email,
           hashedEmail: hashEmail(user.email),
@@ -142,7 +144,7 @@ magicLink.post("/consume", async (c) => {
   const session = await buildMagicLinkSession(c, user.id);
   setKnownCookie(c);
   await applyVisitorMerge(c, user.id); // spec-254 — identify merge (magic link / email-only signup)
-  return c.json({ ...withToken(session), isNewAccount });
+  return c.json({ ...withToken(session), isNewAccount, conversionEventId });
 });
 
 // GET /api/auth/magic-link/login-requests/:id/status

--- a/packages/server/src/routes/auth/magic-link.ts
+++ b/packages/server/src/routes/auth/magic-link.ts
@@ -2,6 +2,8 @@ import { Hono } from "hono";
 import type { Context } from "hono";
 import { resolveSession } from "../../services/auth.js";
 import { getUserByEmail, markEmailVerified, upsertUserByEmail } from "../../services/users.js";
+import { parseAttributionCookie, saveAttribution, hashEmail } from "../../services/attribution.js";
+import { fireAllConversions } from "../../services/conversion-apis.js";
 import { ensureUserMemex } from "../../services/user-namespaces.js";
 import { issueAuthToken, consumeAuthToken, AuthTokenError } from "../../services/auth-tokens.js";
 import {
@@ -106,6 +108,7 @@ magicLink.post("/consume", async (c) => {
 
   // Upsert the user (magic-link is also the signup path for new email-only users).
   const user = await upsertUserByEmail(row.email);
+  const isNewAccount = !user.emailVerifiedAt;
   await markEmailVerified(user.id);
   await ensureUserMemex(user.id);
 
@@ -115,10 +118,31 @@ magicLink.post("/consume", async (c) => {
   // (no surrogate row) consumes exactly as before.
   await markLoginRequestVerified(row.id);
 
+  if (isNewAccount) {
+    const attribution = parseAttributionCookie(c.req.header("cookie"));
+    if (attribution) {
+      const eventId = await saveAttribution(user.id, attribution).catch((err) => {
+        console.error("[spec-21] failed to save attribution:", err instanceof Error ? err.message : String(err));
+        return null;
+      });
+      if (eventId) {
+        fireAllConversions({
+          email: user.email,
+          hashedEmail: hashEmail(user.email),
+          eventId,
+          attribution,
+          conversionDateTime: new Date().toISOString(),
+        });
+      }
+    }
+  }
+
+  // buildMagicLinkSession handles the tenant override (surfaces the URL's team account
+  // as currentMemexId when the user is a member).
   const session = await buildMagicLinkSession(c, user.id);
   setKnownCookie(c);
   await applyVisitorMerge(c, user.id); // spec-254 — identify merge (magic link / email-only signup)
-  return c.json(withToken(session));
+  return c.json({ ...withToken(session), isNewAccount });
 });
 
 // GET /api/auth/magic-link/login-requests/:id/status

--- a/packages/server/src/routes/auth/password.ts
+++ b/packages/server/src/routes/auth/password.ts
@@ -203,6 +203,7 @@ password.post("/verify-email", async (c) => {
 
   await markEmailVerified(row.userId);
 
+  let conversionEventId: string | null = null;
   if (isNewAccount) {
     const attribution = parseAttributionCookie(c.req.header("cookie"));
     if (attribution) {
@@ -211,6 +212,7 @@ password.post("/verify-email", async (c) => {
         return null;
       });
       if (eventId && preVerifyUser) {
+        conversionEventId = eventId;
         fireAllConversions({
           email: preVerifyUser.email,
           hashedEmail: hashEmail(preVerifyUser.email),
@@ -225,7 +227,7 @@ password.post("/verify-email", async (c) => {
   const session = await resolveSession(row.userId, null);
   setKnownCookie(c);
   await applyVisitorMerge(c, row.userId); // spec-254 — identify merge (email verification)
-  return c.json({ ...withToken(session), isNewAccount });
+  return c.json({ ...withToken(session), isNewAccount, conversionEventId });
 });
 
 // POST /api/auth/resend-verification (authenticated)

--- a/packages/server/src/routes/auth/password.ts
+++ b/packages/server/src/routes/auth/password.ts
@@ -1,10 +1,13 @@
 import { Hono } from "hono";
 import { resolveSession } from "../../services/auth.js";
 import {
+  getUserById,
   getUserByEmail,
   createUserWithPassword,
   markEmailVerified,
 } from "../../services/users.js";
+import { parseAttributionCookie, saveAttribution, hashEmail } from "../../services/attribution.js";
+import { fireAllConversions } from "../../services/conversion-apis.js";
 import { ensureUserMemex } from "../../services/user-namespaces.js";
 import { syncUserProfile } from "../../services/mixpanel-profile.js";
 import { hashPassword, verifyPassword, validatePasswordStrength } from "../../services/passwords.js";
@@ -195,11 +198,34 @@ password.post("/verify-email", async (c) => {
     return c.json({ error: "Token has no associated user" }, 400);
   }
 
+  const preVerifyUser = await getUserById(row.userId);
+  const isNewAccount = !preVerifyUser?.emailVerifiedAt;
+
   await markEmailVerified(row.userId);
+
+  if (isNewAccount) {
+    const attribution = parseAttributionCookie(c.req.header("cookie"));
+    if (attribution) {
+      const eventId = await saveAttribution(row.userId, attribution).catch((err) => {
+        console.error("[spec-21] failed to save attribution:", err instanceof Error ? err.message : String(err));
+        return null;
+      });
+      if (eventId && preVerifyUser) {
+        fireAllConversions({
+          email: preVerifyUser.email,
+          hashedEmail: hashEmail(preVerifyUser.email),
+          eventId,
+          attribution,
+          conversionDateTime: new Date().toISOString(),
+        });
+      }
+    }
+  }
+
   const session = await resolveSession(row.userId, null);
   setKnownCookie(c);
   await applyVisitorMerge(c, row.userId); // spec-254 — identify merge (email verification)
-  return c.json(withToken(session));
+  return c.json({ ...withToken(session), isNewAccount });
 });
 
 // POST /api/auth/resend-verification (authenticated)

--- a/packages/server/src/routes/auth/sso.ts
+++ b/packages/server/src/routes/auth/sso.ts
@@ -6,6 +6,8 @@ import {
   type SsoTokenPayload,
 } from "../../services/auth.js";
 import { markEmailVerified } from "../../services/users.js";
+import { parseAttributionCookie, saveAttribution, hashEmail } from "../../services/attribution.js";
+import { fireAllConversions } from "../../services/conversion-apis.js";
 import type { MemexResolverEnv } from "../../middleware/memex-resolver.js";
 import type { SessionEnv } from "../../middleware/session.js";
 import { readJsonBody, requireString } from "../validation.js";
@@ -70,9 +72,31 @@ sso.post("/google", async (c) => {
 
     // If Google asserts the email is verified AND we haven't already stamped it, mirror
     // that into users.email_verified_at so the user skips our verification gate.
-    if (!session.user.emailVerified) {
+    const isNewAccount = !session.user.emailVerified;
+    if (isNewAccount) {
       await markEmailVerified(session.user.id);
       session = { ...session, user: { ...session.user, emailVerified: true } };
+    }
+
+    let conversionEventId: string | null = null;
+    if (isNewAccount) {
+      const attribution = parseAttributionCookie(c.req.header("cookie"));
+      if (attribution) {
+        const eventId = await saveAttribution(session.user.id, attribution).catch((err) => {
+          console.error("[spec-21] failed to save attribution:", err instanceof Error ? err.message : String(err));
+          return null;
+        });
+        if (eventId) {
+          conversionEventId = eventId;
+          fireAllConversions({
+            email: session.user.email,
+            hashedEmail: hashEmail(session.user.email),
+            eventId,
+            attribution,
+            conversionDateTime: new Date().toISOString(),
+          });
+        }
+      }
     }
 
     // Tenant override (t-7): if the request hostname resolves to an account the user is a
@@ -89,7 +113,7 @@ sso.post("/google", async (c) => {
     }
     setKnownCookie(c);
     await applyVisitorMerge(c, session.user.id); // spec-254 — identify merge (SSO)
-    return c.json(withToken(session));
+    return c.json({ ...withToken(session), isNewAccount, conversionEventId });
   } catch (err) {
     if (err instanceof DisabledUserError) {
       return c.json({ error: "User is disabled" }, 403);

--- a/packages/server/src/services/attribution.test.ts
+++ b/packages/server/src/services/attribution.test.ts
@@ -1,0 +1,75 @@
+// Unit tests for spec-21 t-4 attribution service utilities.
+// Does not require a database connection — only the pure parsing/hashing functions.
+import { describe, it, expect } from 'vitest';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { parseAttributionCookie, hashEmail } from './attribution.js';
+
+const AC8 = 'mindset-prod/memex-website/specs/spec-21/acs/ac-8';
+
+describe('parseAttributionCookie (spec-21 t-4)', () => {
+  it('extracts gclid and utm params from a Cookie header', () => {
+    tagAc(AC8);
+    const data = { gclid: 'abc123', utm_source: 'google', utm_medium: 'cpc', utm_campaign: 'brand' };
+    const cookie = `_memex_attribution=${encodeURIComponent(JSON.stringify(data))}`;
+    const result = parseAttributionCookie(cookie);
+    expect(result?.gclid).toBe('abc123');
+    expect(result?.utm_source).toBe('google');
+    expect(result?.utm_medium).toBe('cpc');
+    expect(result?.utm_campaign).toBe('brand');
+  });
+
+  it('extracts li_fat_id and oppref', () => {
+    tagAc(AC8);
+    const data = { li_fat_id: 'li456', oppref: 'oai789' };
+    const cookie = `_memex_attribution=${encodeURIComponent(JSON.stringify(data))}`;
+    const result = parseAttributionCookie(cookie);
+    expect(result?.li_fat_id).toBe('li456');
+    expect(result?.oppref).toBe('oai789');
+  });
+
+  it('returns null when Cookie header is null or empty', () => {
+    tagAc(AC8);
+    expect(parseAttributionCookie(null)).toBeNull();
+    expect(parseAttributionCookie(undefined)).toBeNull();
+    expect(parseAttributionCookie('')).toBeNull();
+  });
+
+  it('returns null when cookie is absent from a multi-cookie header', () => {
+    tagAc(AC8);
+    expect(parseAttributionCookie('session=abc; other=xyz')).toBeNull();
+  });
+
+  it('returns null on malformed JSON', () => {
+    tagAc(AC8);
+    const bad = `_memex_attribution=${encodeURIComponent('not-json')}`;
+    expect(parseAttributionCookie(bad)).toBeNull();
+  });
+
+  it('works when _memex_attribution is not the first cookie', () => {
+    tagAc(AC8);
+    const data = { gclid: 'x' };
+    const cookie = `session=s; _memex_attribution=${encodeURIComponent(JSON.stringify(data))}; other=o`;
+    const result = parseAttributionCookie(cookie);
+    expect(result?.gclid).toBe('x');
+  });
+});
+
+describe('hashEmail (spec-21 t-4)', () => {
+  it('produces a hex SHA-256 hash of the lowercased trimmed email', () => {
+    tagAc(AC8);
+    const h = hashEmail('test@example.com');
+    // SHA-256 is always 64 hex chars
+    expect(h).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('normalises case and whitespace before hashing', () => {
+    tagAc(AC8);
+    expect(hashEmail('Test@Example.com')).toBe(hashEmail('test@example.com'));
+    expect(hashEmail('  test@example.com  ')).toBe(hashEmail('test@example.com'));
+  });
+
+  it('produces different hashes for different emails', () => {
+    tagAc(AC8);
+    expect(hashEmail('a@a.com')).not.toBe(hashEmail('b@b.com'));
+  });
+});

--- a/packages/server/src/services/attribution.ts
+++ b/packages/server/src/services/attribution.ts
@@ -42,7 +42,7 @@ export async function saveAttribution(
   const eventId = randomUUID();
   await mutate(
     ctx,
-    { entity: "user_attribution", action: "created", userId },
+    { memexId: "", userId, entity: "user_attribution", action: "created" },
     async () => {
       await db.insert(userAttributions).values({
         userId,

--- a/packages/server/src/services/attribution.ts
+++ b/packages/server/src/services/attribution.ts
@@ -1,0 +1,54 @@
+import { createHash, randomUUID } from "node:crypto";
+import { db } from "../db/connection.js";
+import { userAttributions } from "../db/schema.js";
+
+export interface AttributionData {
+  gclid?: string;
+  li_fat_id?: string;
+  oppref?: string;
+  utm_source?: string;
+  utm_medium?: string;
+  utm_campaign?: string;
+  utm_content?: string;
+  utm_term?: string;
+}
+
+export function parseAttributionCookie(cookieHeader: string | null | undefined): AttributionData | null {
+  if (!cookieHeader) return null;
+  try {
+    const m = cookieHeader.match(/(?:^|; )_memex_attribution=([^;]*)/);
+    if (!m) return null;
+    const parsed = JSON.parse(decodeURIComponent(m[1]));
+    if (typeof parsed !== "object" || parsed === null) return null;
+    return parsed as AttributionData;
+  } catch {
+    return null;
+  }
+}
+
+export function hashEmail(email: string): string {
+  return createHash("sha256").update(email.trim().toLowerCase()).digest("hex");
+}
+
+// Persists attribution data for a new account. Generates a server-side event_id
+// used to deduplicate server-to-server conversion API calls.
+// Returns the event_id so callers can pass it to conversion-api fire calls.
+export async function saveAttribution(
+  userId: string,
+  data: AttributionData,
+): Promise<string> {
+  const eventId = randomUUID();
+  await db.insert(userAttributions).values({
+    userId,
+    eventId,
+    gclid: data.gclid ?? null,
+    liFatId: data.li_fat_id ?? null,
+    oppref: data.oppref ?? null,
+    utmSource: data.utm_source ?? null,
+    utmMedium: data.utm_medium ?? null,
+    utmCampaign: data.utm_campaign ?? null,
+    utmContent: data.utm_content ?? null,
+    utmTerm: data.utm_term ?? null,
+  });
+  return eventId;
+}

--- a/packages/server/src/services/attribution.ts
+++ b/packages/server/src/services/attribution.ts
@@ -1,6 +1,7 @@
 import { createHash, randomUUID } from "node:crypto";
 import { db } from "../db/connection.js";
 import { userAttributions } from "../db/schema.js";
+import { mutate, type RequestCtx } from "./mutate.js";
 
 export interface AttributionData {
   gclid?: string;
@@ -36,19 +37,27 @@ export function hashEmail(email: string): string {
 export async function saveAttribution(
   userId: string,
   data: AttributionData,
+  ctx: RequestCtx = {},
 ): Promise<string> {
   const eventId = randomUUID();
-  await db.insert(userAttributions).values({
-    userId,
-    eventId,
-    gclid: data.gclid ?? null,
-    liFatId: data.li_fat_id ?? null,
-    oppref: data.oppref ?? null,
-    utmSource: data.utm_source ?? null,
-    utmMedium: data.utm_medium ?? null,
-    utmCampaign: data.utm_campaign ?? null,
-    utmContent: data.utm_content ?? null,
-    utmTerm: data.utm_term ?? null,
-  });
+  await mutate(
+    ctx,
+    { entity: "user_attribution", action: "created", userId },
+    async () => {
+      await db.insert(userAttributions).values({
+        userId,
+        eventId,
+        gclid: data.gclid ?? null,
+        liFatId: data.li_fat_id ?? null,
+        oppref: data.oppref ?? null,
+        utmSource: data.utm_source ?? null,
+        utmMedium: data.utm_medium ?? null,
+        utmCampaign: data.utm_campaign ?? null,
+        utmContent: data.utm_content ?? null,
+        utmTerm: data.utm_term ?? null,
+      });
+    },
+    { silent: true },
+  );
   return eventId;
 }

--- a/packages/server/src/services/bus.ts
+++ b/packages/server/src/services/bus.ts
@@ -92,7 +92,9 @@ export type ChangeEntity =
   // coverage scanner hold even though no SSE consumer subscribes (spec-156 ac-18).
   | "oauth_client"
   | "oauth_code"
-  | "oauth_refresh_token";
+  | "oauth_refresh_token"
+  // spec-21: per-user attribution record (silent-allowed per std-8 §6 — no SSE subscriber).
+  | "user_attribution";
 
 export type ChangeAction =
   // Mutation actions — the original bus contract.

--- a/packages/server/src/services/conversion-apis.ts
+++ b/packages/server/src/services/conversion-apis.ts
@@ -1,0 +1,129 @@
+// Server-to-server conversion API calls for spec-21 t-5.
+// All calls are non-blocking — callers fire-and-forget. Silently skips when
+// required env vars are absent so dev/staging environments don't error.
+
+import type { AttributionData } from "./attribution.js";
+
+export interface ConversionParams {
+  email: string;
+  hashedEmail: string;
+  eventId: string;
+  attribution: AttributionData;
+  conversionDateTime: string; // ISO 8601, e.g. "2026-06-27T12:00:00+00:00"
+}
+
+// Google Ads Enhanced Conversions (offline click conversion upload).
+// Required env vars: GOOGLE_ADS_ACCESS_TOKEN, GOOGLE_ADS_DEVELOPER_TOKEN,
+//   GOOGLE_ADS_CUSTOMER_ID, GOOGLE_ADS_CONVERSION_ACTION_ID
+export async function fireGoogleAdsConversion(params: ConversionParams): Promise<void> {
+  const token = process.env.GOOGLE_ADS_ACCESS_TOKEN;
+  const devToken = process.env.GOOGLE_ADS_DEVELOPER_TOKEN;
+  const customerId = process.env.GOOGLE_ADS_CUSTOMER_ID;
+  const actionId = process.env.GOOGLE_ADS_CONVERSION_ACTION_ID;
+  if (!token || !devToken || !customerId || !actionId) return;
+  if (!params.attribution.gclid) return;
+
+  const url = `https://googleads.googleapis.com/v17/customers/${customerId}:uploadClickConversions`;
+  await fetch(url, {
+    method: "POST",
+    headers: {
+      "Authorization": `Bearer ${token}`,
+      "developer-token": devToken,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      conversions: [{
+        gclid: params.attribution.gclid,
+        conversionAction: `customers/${customerId}/conversionActions/${actionId}`,
+        conversionDateTime: params.conversionDateTime,
+        hashedEmailAddress: params.hashedEmail,
+      }],
+      partialFailure: true,
+    }),
+  }).then(async (res) => {
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      console.error(`[spec-21] Google Ads conversion upload failed (${res.status}):`, body.slice(0, 200));
+    }
+  }).catch((err) => {
+    console.error("[spec-21] Google Ads conversion upload error:", err instanceof Error ? err.message : String(err));
+  });
+}
+
+// LinkedIn Conversions API (server-side event).
+// Required env vars: LINKEDIN_ACCESS_TOKEN, LINKEDIN_AD_ACCOUNT_ID, LINKEDIN_CONVERSION_ID
+export async function fireLinkedInConversion(params: ConversionParams): Promise<void> {
+  const token = process.env.LINKEDIN_ACCESS_TOKEN;
+  const adAccountId = process.env.LINKEDIN_AD_ACCOUNT_ID;
+  const conversionId = process.env.LINKEDIN_CONVERSION_ID;
+  if (!token || !adAccountId || !conversionId) return;
+
+  const userIds: { idType: string; idValue: string }[] = [
+    { idType: "SHA256_EMAIL", idValue: params.hashedEmail },
+  ];
+  if (params.attribution.li_fat_id) {
+    userIds.push({ idType: "LINKEDIN_FIRST_PARTY_ADS_TRACKING_UUID", idValue: params.attribution.li_fat_id });
+  }
+
+  await fetch("https://api.linkedin.com/rest/conversionEvents", {
+    method: "POST",
+    headers: {
+      "Authorization": `Bearer ${token}`,
+      "Content-Type": "application/json",
+      "X-Restli-Protocol-Version": "2.0.0",
+      "LinkedIn-Version": "202409",
+    },
+    body: JSON.stringify({
+      conversion: `urn:lla:llaPartnerConversion:${conversionId}`,
+      conversionHappenedAt: Date.now(),
+      eventId: params.eventId,
+      user: { userIds },
+    }),
+  }).then(async (res) => {
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      console.error(`[spec-21] LinkedIn conversion upload failed (${res.status}):`, body.slice(0, 200));
+    }
+  }).catch((err) => {
+    console.error("[spec-21] LinkedIn conversion upload error:", err instanceof Error ? err.message : String(err));
+  });
+}
+
+// OpenAI advertising pixel — server-side conversion event.
+// Required env vars: OPENAI_PIXEL_ID, OPENAI_PIXEL_API_KEY
+export async function fireOpenAiConversion(params: ConversionParams): Promise<void> {
+  const pixelId = process.env.OPENAI_PIXEL_ID;
+  const apiKey = process.env.OPENAI_PIXEL_API_KEY;
+  if (!pixelId || !apiKey) return;
+  if (!params.attribution.oppref) return;
+
+  await fetch(`https://bzrapi.openai.com/v1/pixels/${pixelId}/events`, {
+    method: "POST",
+    headers: {
+      "Authorization": `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      event_name: "registration_completed",
+      event_id: params.eventId,
+      event_time: Math.floor(Date.now() / 1000),
+      user_data: { em: params.hashedEmail },
+      custom_data: { oppref: params.attribution.oppref },
+    }),
+  }).then(async (res) => {
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      console.error(`[spec-21] OpenAI conversion upload failed (${res.status}):`, body.slice(0, 200));
+    }
+  }).catch((err) => {
+    console.error("[spec-21] OpenAI conversion upload error:", err instanceof Error ? err.message : String(err));
+  });
+}
+
+// Fires all three conversion APIs for a new account. Non-blocking — does NOT
+// await individual calls; errors are logged but never surfaced to the caller.
+export function fireAllConversions(params: ConversionParams): void {
+  fireGoogleAdsConversion(params).catch(() => {});
+  fireLinkedInConversion(params).catch(() => {});
+  fireOpenAiConversion(params).catch(() => {});
+}

--- a/packages/ui/src/api/auth.ts
+++ b/packages/ui/src/api/auth.ts
@@ -85,6 +85,11 @@ export interface SessionPayload {
   /** Present on verify-email and magic-link/consume responses only. True when this was
    *  the first verification (a new account), false/absent for subsequent logins. */
   isNewAccount?: boolean;
+  /** The event_id used for server-side conversion API calls on new-account verification.
+   *  Client should use this (not a freshly-generated UUID) for the dataLayer push so
+   *  both legs share the same ID and ad platforms can deduplicate. Null when attribution
+   *  cookie was absent on verification. */
+  conversionEventId?: string | null;
   /**
    * Orgs the user is an active member of that have no Memexes yet (doc-19 dec-1).
    * These are invisible in `memberships` (memex-keyed) but must appear in the

--- a/packages/ui/src/api/auth.ts
+++ b/packages/ui/src/api/auth.ts
@@ -82,6 +82,9 @@ export interface SessionPayload {
   /** Fresh session token (present on signup/login/SSO/magic-link responses). Client stores
    *  as `memex-auth-token`. Absent on session refresh responses (client already has it). */
   token?: string;
+  /** Present on verify-email and magic-link/consume responses only. True when this was
+   *  the first verification (a new account), false/absent for subsequent logins. */
+  isNewAccount?: boolean;
   /**
    * Orgs the user is an active member of that have no Memexes yet (doc-19 dec-1).
    * These are invisible in `memberships` (memex-keyed) but must appear in the

--- a/packages/ui/src/components/AuthContext.tsx
+++ b/packages/ui/src/components/AuthContext.tsx
@@ -16,6 +16,7 @@ import {
   AuthApiError,
   type SessionPayload,
 } from '../api/client';
+import { readAttributionCookie, pushDataLayer } from '../lib/attribution';
 import { LoginScreen } from './LoginScreen';
 import { isFeatureHidden } from '../utils/featureFlags';
 import { buildBareDomainUrl } from '../utils/tenantUrl';
@@ -381,6 +382,13 @@ export function RequireAuth({ children }: { children: ReactNode }) {
       wrap(async () => {
         const s = await ssoLoginApi(credential);
         acceptSession(s);
+        if (s.isNewAccount) {
+          pushDataLayer({
+            event: 'sign_up_completed',
+            event_id: s.conversionEventId ?? crypto.randomUUID(),
+            ...readAttributionCookie(),
+          });
+        }
       }).then(() => undefined),
     [wrap, acceptSession],
   );

--- a/packages/ui/src/components/LoginScreen.tsx
+++ b/packages/ui/src/components/LoginScreen.tsx
@@ -7,6 +7,7 @@ import { Alert } from './ui/Alert';
 import { Logo } from './Logo';
 import { probeAuthApi, AuthApiError, type SessionPayload } from '../api/client';
 import { useMagicLinkPoll } from '../hooks/useMagicLinkPoll';
+import { readAttributionCookie, pushDataLayer } from '../lib/attribution';
 // t-23 of doc-15: Google SSO is on a single origin under the path-based
 // router. The previous cross-subdomain bounce (sign in on memex.ai then return
 // here with a JWT in the URL fragment) is no longer needed — everything is
@@ -86,8 +87,14 @@ function LoginCard(props: LoginScreenProps) {
           }}
           onContinue={async (email) => {
             const probe = await probeAuthApi(email);
-            if (!probe.exists) setView({ kind: 'create-password', email });
-            else if (probe.hasPassword) setView({ kind: 'password', email });
+            if (!probe.exists) {
+              pushDataLayer({
+                event: 'sign_up_started',
+                event_id: crypto.randomUUID(),
+                ...readAttributionCookie(),
+              });
+              setView({ kind: 'create-password', email });
+            } else if (probe.hasPassword) setView({ kind: 'password', email });
             else {
               trackAnonymous('auth.login_started', { method: 'magic_link' });
               const { loginRequestId } = await props.onMagicLink(email);

--- a/packages/ui/src/lib/attribution.ts
+++ b/packages/ui/src/lib/attribution.ts
@@ -1,0 +1,30 @@
+export interface AttributionData {
+  gclid?: string;
+  li_fat_id?: string;
+  oppref?: string;
+  utm_source?: string;
+  utm_medium?: string;
+  utm_campaign?: string;
+  utm_content?: string;
+  utm_term?: string;
+}
+
+export function readAttributionCookie(): AttributionData | null {
+  try {
+    const m = document.cookie.match(/(?:^|; )_memex_attribution=([^;]*)/);
+    if (!m) return null;
+    return JSON.parse(decodeURIComponent(m[1])) as AttributionData;
+  } catch {
+    return null;
+  }
+}
+
+export function pushDataLayer(event: Record<string, unknown>): void {
+  try {
+    (window as Record<string, unknown>).dataLayer =
+      (window as Record<string, unknown>).dataLayer ?? [];
+    ((window as Record<string, unknown>).dataLayer as unknown[]).push(event);
+  } catch {
+    // never throw from analytics
+  }
+}

--- a/packages/ui/src/lib/attribution.ts
+++ b/packages/ui/src/lib/attribution.ts
@@ -21,9 +21,9 @@ export function readAttributionCookie(): AttributionData | null {
 
 export function pushDataLayer(event: Record<string, unknown>): void {
   try {
-    (window as Record<string, unknown>).dataLayer =
-      (window as Record<string, unknown>).dataLayer ?? [];
-    ((window as Record<string, unknown>).dataLayer as unknown[]).push(event);
+    const w = window as unknown as Record<string, unknown>;
+    w.dataLayer = w.dataLayer ?? [];
+    (w.dataLayer as unknown[]).push(event);
   } catch {
     // never throw from analytics
   }

--- a/packages/ui/src/pages/MagicLinkConsume.tsx
+++ b/packages/ui/src/pages/MagicLinkConsume.tsx
@@ -3,6 +3,7 @@ import { Link, useSearchParams } from 'react-router-dom';
 import { useAuth, computeDefaultLanding } from '../components/AuthContext';
 import { isFeatureHidden } from '../utils/featureFlags';
 import { magicLinkConsumeApi, AuthApiError } from '../api/client';
+import { readAttributionCookie, pushDataLayer } from '../lib/attribution';
 import { Spinner } from '../components/Spinner';
 
 type Stage = 'consuming' | 'success' | 'failed';
@@ -32,6 +33,13 @@ export function MagicLinkConsume() {
     magicLinkConsumeApi(token)
       .then((session) => {
         acceptSession(session);
+        if (session.isNewAccount) {
+          pushDataLayer({
+            event: 'sign_up_completed',
+            event_id: crypto.randomUUID(),
+            ...readAttributionCookie(),
+          });
+        }
         setStage('success');
         // spec-421 dec-5: route through /login (whose element is RootRedirect) so the
         // onboarding-state landing decision applies — a returning engaged user lands on

--- a/packages/ui/src/pages/MagicLinkConsume.tsx
+++ b/packages/ui/src/pages/MagicLinkConsume.tsx
@@ -36,7 +36,7 @@ export function MagicLinkConsume() {
         if (session.isNewAccount) {
           pushDataLayer({
             event: 'sign_up_completed',
-            event_id: crypto.randomUUID(),
+            event_id: session.conversionEventId ?? crypto.randomUUID(),
             ...readAttributionCookie(),
           });
         }

--- a/packages/ui/src/pages/VerifyEmail.spec-21.test.tsx
+++ b/packages/ui/src/pages/VerifyEmail.spec-21.test.tsx
@@ -100,6 +100,33 @@ describe('VerifyEmail — sign_up_completed gating (spec-21 t-3)', () => {
     expect(dataLayerEvents()).not.toContain('sign_up_completed');
   });
 
+  it('uses the server-provided conversionEventId as the dataLayer event_id', async () => {
+    tagAc(AC7);
+    vi.mocked(verifyEmailApi).mockResolvedValueOnce({
+      user: { id: 'u4', email: 'new2@example.com', name: null, status: 'active', emailVerified: true },
+      memberships: [],
+      currentMemexId: null,
+      currentRole: null,
+      needsOnboarding: false,
+      hiddenFeatures: [],
+      isNewAccount: true,
+      conversionEventId: 'server-event-id-123',
+    });
+
+    await act(async () => {
+      render(
+        <MemoryRouter initialEntries={['/?token=tok4']}>
+          <VerifyEmail />
+        </MemoryRouter>,
+      );
+    });
+
+    const dl = ((window as Record<string, unknown>).dataLayer as Record<string, unknown>[] | undefined ?? []);
+    const completedEvent = dl.find((e) => e.event === 'sign_up_completed');
+    expect(completedEvent).toBeDefined();
+    expect(completedEvent!.event_id).toBe('server-event-id-123');
+  });
+
   it('does NOT push sign_up_completed when isNewAccount is absent', async () => {
     tagAc(AC7);
     vi.mocked(verifyEmailApi).mockResolvedValueOnce({

--- a/packages/ui/src/pages/VerifyEmail.spec-21.test.tsx
+++ b/packages/ui/src/pages/VerifyEmail.spec-21.test.tsx
@@ -1,0 +1,124 @@
+// @vitest-environment jsdom
+// Tests for spec-21 t-3: sign_up_completed dataLayer event gating.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, act } from '@testing-library/react';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { MemoryRouter } from 'react-router-dom';
+
+const AC7 = 'mindset-prod/memex-website/specs/spec-21/acs/ac-7';
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+vi.mock('../api/client', () => ({
+  verifyEmailApi: vi.fn(),
+  AuthApiError: class AuthApiError extends Error {
+    constructor(
+      public status: number,
+      public reason: string,
+      message: string,
+    ) { super(message); }
+  },
+}));
+
+vi.mock('../components/AuthContext', () => ({
+  useAuth: () => ({ acceptSession: vi.fn(), session: null }),
+  computeDefaultLanding: () => '/ns/memex/specs',
+}));
+
+vi.mock('../components/Confetti', () => ({ Confetti: () => null }));
+vi.mock('../components/Spinner', () => ({ Spinner: () => null }));
+
+function dataLayerEvents(): string[] {
+  return ((window as Record<string, unknown>).dataLayer as { event?: string }[] | undefined ?? [])
+    .map((e) => e.event ?? '')
+    .filter(Boolean);
+}
+
+function clearDataLayer(): void {
+  (window as Record<string, unknown>).dataLayer = [];
+}
+
+// Import after mocks are set up
+const { verifyEmailApi } = await import('../api/client');
+const { VerifyEmail } = await import('./VerifyEmail');
+
+// ── tests ────────────────────────────────────────────────────────────────────
+
+describe('VerifyEmail — sign_up_completed gating (spec-21 t-3)', () => {
+  beforeEach(() => {
+    clearDataLayer();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    clearDataLayer();
+  });
+
+  it('pushes sign_up_completed to dataLayer when isNewAccount is true', async () => {
+    tagAc(AC7);
+    vi.mocked(verifyEmailApi).mockResolvedValueOnce({
+      user: { id: 'u1', email: 'new@example.com', name: null, status: 'active', emailVerified: true },
+      memberships: [],
+      currentMemexId: null,
+      currentRole: null,
+      needsOnboarding: false,
+      hiddenFeatures: [],
+      isNewAccount: true,
+    });
+
+    await act(async () => {
+      render(
+        <MemoryRouter initialEntries={['/?token=tok1']}>
+          <VerifyEmail />
+        </MemoryRouter>,
+      );
+    });
+
+    expect(dataLayerEvents()).toContain('sign_up_completed');
+  });
+
+  it('does NOT push sign_up_completed when isNewAccount is false (returning user)', async () => {
+    tagAc(AC7);
+    vi.mocked(verifyEmailApi).mockResolvedValueOnce({
+      user: { id: 'u2', email: 'existing@example.com', name: null, status: 'active', emailVerified: true },
+      memberships: [],
+      currentMemexId: null,
+      currentRole: null,
+      needsOnboarding: false,
+      hiddenFeatures: [],
+      isNewAccount: false,
+    });
+
+    await act(async () => {
+      render(
+        <MemoryRouter initialEntries={['/?token=tok2']}>
+          <VerifyEmail />
+        </MemoryRouter>,
+      );
+    });
+
+    expect(dataLayerEvents()).not.toContain('sign_up_completed');
+  });
+
+  it('does NOT push sign_up_completed when isNewAccount is absent', async () => {
+    tagAc(AC7);
+    vi.mocked(verifyEmailApi).mockResolvedValueOnce({
+      user: { id: 'u3', email: 'login@example.com', name: null, status: 'active', emailVerified: true },
+      memberships: [],
+      currentMemexId: null,
+      currentRole: null,
+      needsOnboarding: false,
+      hiddenFeatures: [],
+    });
+
+    await act(async () => {
+      render(
+        <MemoryRouter initialEntries={['/?token=tok3']}>
+          <VerifyEmail />
+        </MemoryRouter>,
+      );
+    });
+
+    expect(dataLayerEvents()).not.toContain('sign_up_completed');
+  });
+});

--- a/packages/ui/src/pages/VerifyEmail.tsx
+++ b/packages/ui/src/pages/VerifyEmail.tsx
@@ -40,7 +40,7 @@ export function VerifyEmail() {
         if (s.isNewAccount) {
           pushDataLayer({
             event: 'sign_up_completed',
-            event_id: crypto.randomUUID(),
+            event_id: s.conversionEventId ?? crypto.randomUUID(),
             ...readAttributionCookie(),
           });
         }

--- a/packages/ui/src/pages/VerifyEmail.tsx
+++ b/packages/ui/src/pages/VerifyEmail.tsx
@@ -4,6 +4,7 @@ import { useAuth, computeDefaultLanding } from '../components/AuthContext';
 import { isFeatureHidden } from '../utils/featureFlags';
 import { Logo } from '../components/Logo';
 import { verifyEmailApi, AuthApiError } from '../api/client';
+import { readAttributionCookie, pushDataLayer } from '../lib/attribution';
 import { Spinner } from '../components/Spinner';
 import { Confetti } from '../components/Confetti';
 import { Button } from '../components/ui/Button';
@@ -36,6 +37,13 @@ export function VerifyEmail() {
     verifyEmailApi(token)
       .then((s) => {
         acceptSession(s);
+        if (s.isNewAccount) {
+          pushDataLayer({
+            event: 'sign_up_completed',
+            event_id: crypto.randomUUID(),
+            ...readAttributionCookie(),
+          });
+        }
         setStage('success');
       })
       .catch((err) => {


### PR DESCRIPTION
 feat(spec-21): server-side attribution persistence and conversion API firing

  ▎ - Migration 0091: user_attributions table stores click IDs + UTM params at account creation
  ▎ - /verify-email + /magic-link/consume now detect new accounts, save attribution, fire Google Ads / LinkedIn / OpenAI conversion APIs non-blocking
  ▎ - isNewAccount flag in session response gates sign_up_completed dataLayer event client-side
  ▎ - sign_up_started fires on login page when probe confirms new user
  ▎ - 12 new tests (ac-7, ac-8)
  
  Deploy note: run db:migrate. Set GOOGLE_ADS_*, LINKEDIN_*, OPENAI_PIXEL_* env vars to enable conversion API calls — safe without them (silently skipped).