### PR TITLE
feat(spec-430): copy-the-install-prompt CTA on the Claude Code install section

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memex-ai",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Install the Memex AI MCP server for Claude Code and Claude Desktop",
   "type": "module",
   "bin": {

--- a/packages/ui/e2e/journey-24-integrations-setup.spec.ts
+++ b/packages/ui/e2e/journey-24-integrations-setup.spec.ts
@@ -74,7 +74,10 @@ test(TEST_1, async ({ page }) => {
 
   // ac-2: copy controls are live — clicking Copy writes to the clipboard and the
   // control confirms ("Copied!"). Proves the real clipboard path, not just markup.
-  const copyBtn = cli.getByRole("button", { name: "Copy" }).first();
+  // `exact` targets the CodeBlock "Copy" buttons specifically — the Claude Code
+  // section also has a "Copy install prompt for Claude Code" CTA (spec-430 dec-4)
+  // that would otherwise be the first substring match.
+  const copyBtn = cli.getByRole("button", { name: "Copy", exact: true }).first();
   await copyBtn.click();
   await expect(cli.getByRole("button", { name: "Copied!" }).first()).toBeVisible();
 

--- a/packages/ui/src/components/CliInstallSection.test.tsx
+++ b/packages/ui/src/components/CliInstallSection.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { tagAc } from '@memex-ai-ac/vitest';
 import { CliInstallSection } from './CliInstallSection';
 import { installBase, mcpUrl } from '../utils/mcpUrl';
@@ -93,5 +93,30 @@ describe('spec-430 ac-9: unified Claude Code install + Claude-Code-gated checkou
     tagAc(AC430_9);
     render(<CliInstallSection />);
     expect(screen.queryByText(/install\.sh|install\.ps1/)).toBeNull();
+  });
+});
+
+// spec-430 dec-4: the agent-guided install is the principal Claude Code path — a CTA
+// copies a single prompt the user pastes into Claude Code, which then runs the whole
+// install itself. The manual commands stay below as the run-it-yourself fallback.
+describe('spec-430 dec-4: copy-the-install-prompt CTA', () => {
+  it('copies the install prompt (unified install + the checkout plugin) to the clipboard', async () => {
+    tagAc(AC430_9);
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+    render(<CliInstallSection />);
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /copy install prompt for claude code/i }),
+    );
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
+    const prompt = writeText.mock.calls[0][0] as string;
+    expect(prompt).toContain('npx -y memex-ai install');
+    expect(prompt).toContain('claude plugin marketplace add mindset-ai/memex-ai');
+    expect(prompt).toContain('claude plugin install memex-checkout@memex');
+    expect(prompt).toMatch(/reload the window/i);
+    // The button confirms the copy back to the user.
+    expect(await screen.findByText(/Copied/)).toBeInTheDocument();
   });
 });

--- a/packages/ui/src/components/CliInstallSection.tsx
+++ b/packages/ui/src/components/CliInstallSection.tsx
@@ -30,6 +30,19 @@ const INSTALL_COMMAND = `npx -y memex-ai install${INSTALL_API_BASE_FLAG}`;
 const PLUGIN_COMMANDS = `claude plugin marketplace add mindset-ai/memex-ai
 claude plugin install memex-checkout@memex`;
 
+// spec-430 dec-4: the agent-guided install is the PRINCIPAL Claude Code path. The
+// user pastes THIS one prompt into a Claude Code session and the agent runs every
+// step itself — pausing only for the single browser sign-in. Step 1 reuses
+// INSTALL_COMMAND so its `--api-base` stays correct per environment. The manual
+// commands remain below as the run-it-yourself fallback.
+const INSTALL_PROMPT = `Set up Memex in this session. Run each step yourself, explain it in one line, and pause for me when a browser sign-in opens:
+
+1. \`${INSTALL_COMMAND}\`. One sign-in that writes the Memex MCP server into my Claude config and mints my checkout key.
+2. \`claude plugin marketplace add mindset-ai/memex-ai\`
+3. \`claude plugin install memex-checkout@memex\`
+
+Then tell me to reload the window so the hooks load. If a step errors, show me the error and what to do, and never ask me to paste a key by hand.`;
+
 // spec-201 dec-4: the canonical MCP endpoint, shared by the claude.ai web and
 // Cursor connect steps below. Same derivation as the manual configs.
 const MCP_URL = `${installBase}/mcp`;
@@ -60,6 +73,17 @@ const VSCODE_CONFIG = `{
 
 export function CliInstallSection() {
   const [showFallback, setShowFallback] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  const copyInstallPrompt = async () => {
+    try {
+      await navigator.clipboard.writeText(INSTALL_PROMPT);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2500);
+    } catch {
+      /* clipboard unavailable — no-op */
+    }
+  };
 
   return (
     <section id="install-cli" aria-labelledby="install-cli-heading">
@@ -74,9 +98,26 @@ export function CliInstallSection() {
           mints the per-user checkout key; the hooks-only plugin is Claude-Code-only. */}
       <div className="mb-10">
         <h3 className="text-base font-medium mb-3 text-heading">Claude Code</h3>
+
+        {/* spec-430 dec-4: the PRINCIPAL path — let Claude Code drive the install. */}
         <p className="text-sm mb-3 text-secondary">
-          Paste this into your terminal. One browser sign-in plants the Memex MCP token{' '}
-          <strong>and</strong> mints your single per-user checkout key — no second sign-in,
+          The easiest way is to let Claude Code install everything for you. Copy this prompt,
+          paste it into a Claude Code session, and the agent runs the whole setup (the MCP
+          server, your checkout key, and the spec-checkout plugin), pausing only for the one
+          browser sign-in.
+        </p>
+        <button
+          type="button"
+          onClick={copyInstallPrompt}
+          className="inline-flex items-center gap-2 px-4 py-2 rounded-sm text-sm font-medium bg-btn-primary text-white hover:opacity-90 transition-opacity"
+        >
+          {copied ? '✓ Copied, now paste it into Claude Code' : 'Copy install prompt for Claude Code'}
+        </button>
+
+        {/* Fallback: run the commands yourself. */}
+        <p className="text-sm mb-3 mt-8 text-secondary">
+          Prefer to run the commands yourself? One browser sign-in plants the Memex MCP token{' '}
+          <strong>and</strong> mints your single per-user checkout key. No second sign-in,
           no per-memex keys, nothing pasted by hand:
         </p>
         <CodeBlock code={INSTALL_COMMAND} />


### PR DESCRIPTION
## Summary
Makes the **agent-guided install the principal Claude Code path** on the Integrations page (the dec-4 vision in practice). The Claude Code section now leads with a **"Copy install prompt for Claude Code"** button: it copies a single prompt the user pastes into a Claude Code session, and the agent then runs the whole install itself (`npx -y memex-ai install` + the `claude plugin …` steps), pausing only for the one browser sign-in. The manual commands stay directly below as the run-it-yourself fallback.

- **Env-aware:** the copied prompt reuses `INSTALL_COMMAND`, so its `--api-base` is correct per environment (bare for prod, explicit host for int) — same derivation as the displayed command.
- Scope is one file + its test. No server/CLI/shared changes. Pre-existing copy left untouched.

## Test plan
- [x] `CliInstallSection.test.tsx`: new test clicks the CTA and asserts the clipboard receives the prompt (npx install + both plugin commands + reload), and the button confirms "Copied".
- [x] Full UI suite green: **1840 passed**, `tsc --noEmit` clean.