### PR TITLE
Release: develop → main (spec-430 issue-2 personal-memex authz + issue-3 env-switch re-mint)

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -99,6 +99,18 @@ server-side token. To revoke:
 
 Or run `uninstall` followed by a server-side revoke.
 
+## Releasing
+
+`memex-ai` is published to the public npm registry. A change under `packages/cli`
+reaches users ONLY when the package is published; merging to `develop` or `main` does
+NOT ship it. There is no CI auto-publish, so every release is manual:
+
+1. Bump `version` in `packages/cli/package.json`.
+2. From `packages/cli`, run `npm publish`.
+
+Publishing requires npm publish rights on the `memex-ai` package; ask a maintainer if
+you don't have them.
+
 ## Source
 
 Built and maintained at

--- a/packages/cli/bin/cli.mjs
+++ b/packages/cli/bin/cli.mjs
@@ -1,5 +1,9 @@
 #!/usr/bin/env node
 
+// ⚠ RELEASE: this is the published `memex-ai` npm package. A change here reaches users
+// ONLY after `npm publish`; merging does NOT ship it. Bump `version` in package.json
+// and publish (see README.md#releasing). No CI auto-publish.
+
 // Memex MCP installer (v2). Device-flow auth: claim a code from the server, open the
 // user's browser to authorize, long-poll for a long-lived mxt_ token, then merge it
 // into the Claude Code + Claude Desktop config files.

--- a/packages/cli/lib/checkout-bootstrap.js
+++ b/packages/cli/lib/checkout-bootstrap.js
@@ -48,6 +48,18 @@ export function keyFromStore(store) {
   return null;
 }
 
+// Whether the stored key is usable for THIS env, i.e. the install/mint can short-circuit
+// (issue-3). A key is reusable when one is present AND it was not minted for a DIFFERENT
+// api_base. A stored api_base that DIFFERS from the requested one means an env switch
+// (e.g. int -> prod): the key must be re-minted, or the MCP/claims go to the new env
+// while edits still phone home to the old one with the wrong key (silent 401s). A
+// MISSING api_base (legacy store) is treated as same-env so we don't force a needless
+// re-mint (and sign-in) on existing installs.
+export function hasKeyForEnv(store, apiBase) {
+  if (keyFromStore(store) == null) return false;
+  return store?.api_base == null || store.api_base === apiBase;
+}
+
 // The browser URL the user signs in + confirms the device code on. Mirrors the MCP
 // installer (bin/cli.mjs): the admin UI base is the api base minus `/api`.
 export function authUrlFor(apiBase, code) {
@@ -80,25 +92,27 @@ function persist(path, store, apiBase, key, fs) {
   fs.write(path, JSON.stringify(next, null, 2) + "\n");
 }
 
-// Mint + store from an EXISTING signed-in token — NO sign-in. Idempotent: a stored
-// hook_key short-circuits. Returns { provisioned, key }.
+// Mint + store from an EXISTING signed-in token — NO sign-in. Short-circuits when a key
+// is already stored FOR THIS env; an env switch (stored api_base differs) re-mints and
+// overwrites (issue-3). Returns { provisioned, key }.
 export async function provisionHookKey({ apiBase, token, fs = DEFAULT_FS, deps = {} }) {
   const path = deps.storePath ?? storePath();
   const store = loadStore(path, fs);
-  const existing = keyFromStore(store);
-  if (existing) return { provisioned: false, key: existing };
+  if (hasKeyForEnv(store, apiBase)) return { provisioned: false, key: keyFromStore(store) };
   const key = await mintHookKey(apiBase, token, deps);
   persist(path, store, apiBase, key, fs);
   return { provisioned: true, key };
 }
 
-// Standalone: ensure a key exists, doing ONE device-flow sign-in if absent. Idempotent.
-// Returns { provisioned, signedIn, key }.
+// Standalone: ensure a key exists for THIS env, doing ONE device-flow sign-in if
+// absent — or if the stored key was minted for a different env (issue-3). A same-env
+// key short-circuits with no sign-in. Returns { provisioned, signedIn, key }.
 export async function ensureHookKey({ apiBase, fs = DEFAULT_FS, deps = {} }) {
   const path = deps.storePath ?? storePath();
   const store = loadStore(path, fs);
-  const existing = keyFromStore(store);
-  if (existing) return { provisioned: false, signedIn: false, key: existing };
+  if (hasKeyForEnv(store, apiBase)) {
+    return { provisioned: false, signedIn: false, key: keyFromStore(store) };
+  }
 
   const { reqId, code } = await startCliAuth(apiBase, deps);
   if (deps.openBrowser) deps.openBrowser(authUrlFor(apiBase, code));

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,7 @@
 {
   "name": "memex-ai",
-  "version": "3.1.0",
+  "version": "3.1.1",
+  "//publish": "Published to public npm as `memex-ai`. A change to packages/cli reaches users ONLY via `npm publish`; merging does NOT ship it. Bump this `version` and publish (see README.md#releasing). No CI auto-publish.",
   "description": "Install the Memex AI MCP server for Claude Code and Claude Desktop",
   "type": "module",
   "bin": {

--- a/packages/cli/test/checkout-bootstrap.test.js
+++ b/packages/cli/test/checkout-bootstrap.test.js
@@ -203,3 +203,71 @@ describe("checkout credential bootstrap (spec-430 dec-1/dec-3)", () => {
     expect(parsed.command).toBe("checkout-setup");
   });
 });
+
+// spec-430 issue-3: installing/minting against a NEW env must not keep a stale-env key.
+// Stored api_base != requested apiBase (e.g. int -> prod) means MCP/claims would go to
+// the new env while edits still phone home to the old one with the wrong key (silent
+// 401). The env compare is purely local — no extra sign-in unless the env changed.
+describe("spec-430 issue-3: an env switch re-mints the checkout key", () => {
+  it("provisionHookKey: stored int + requested prod → re-mints + overwrites, no sign-in (uses the token)", async () => {
+    const fs = memFs(JSON.stringify({ api_base: "https://int.memex.ai", hook_key: "mxh_int" }));
+    const calls = [];
+    const fetch = async (url, init) => {
+      calls.push(url);
+      if (url.endsWith("/api/hook-keys")) {
+        expect(init.headers.Authorization).toBe("Bearer mxt_prod");
+        return { ok: true, json: async () => ({ key: "mxh_prod" }) };
+      }
+      throw new Error("unexpected fetch " + url);
+    };
+    const res = await provisionHookKey({
+      apiBase: "https://memex.ai",
+      token: "mxt_prod",
+      fs,
+      deps: { storePath: "/fake", fetch },
+    });
+    expect(res).toMatchObject({ provisioned: true, key: "mxh_prod" });
+    // checkout.json now points at prod with the fresh key…
+    expect(fs.current().api_base).toBe("https://memex.ai");
+    expect(fs.current().hook_key).toBe("mxh_prod");
+    // …and no device-flow sign-in happened (provision uses the install's token).
+    expect(calls.some((u) => u.includes("/api/cli/auth/"))).toBe(false);
+  });
+
+  it("provisionHookKey: stored prod + requested prod → skips (no mint)", async () => {
+    const fs = memFs(JSON.stringify({ api_base: "https://memex.ai", hook_key: "mxh_prod" }));
+    const fetch = vi.fn();
+    const res = await provisionHookKey({
+      apiBase: "https://memex.ai",
+      token: "mxt_x",
+      fs,
+      deps: { storePath: "/fake", fetch },
+    });
+    expect(res).toMatchObject({ provisioned: false, key: "mxh_prod" });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("ensureHookKey: stored int + requested prod → ONE sign-in and re-mints for prod", async () => {
+    const fs = memFs(JSON.stringify({ api_base: "https://int.memex.ai", hook_key: "mxh_int" }));
+    const calls = [];
+    const fetch = async (url) => {
+      calls.push(url);
+      if (url.endsWith("/api/cli/auth/start"))
+        return { ok: true, json: async () => ({ reqId: "r1", code: "ABCD" }) };
+      if (url.includes("/api/cli/auth/poll/"))
+        return { ok: true, json: async () => ({ status: "completed", token: "mxt_prod" }) };
+      if (url.endsWith("/api/hook-keys"))
+        return { ok: true, json: async () => ({ key: "mxh_prod" }) };
+      throw new Error("unexpected fetch " + url);
+    };
+    const res = await ensureHookKey({
+      apiBase: "https://memex.ai",
+      fs,
+      deps: { storePath: "/fake", fetch, openBrowser: () => {}, now: () => 0 },
+    });
+    expect(res).toMatchObject({ provisioned: true, signedIn: true, key: "mxh_prod" });
+    expect(calls.filter((u) => u.endsWith("/api/cli/auth/start"))).toHaveLength(1);
+    expect(fs.current().api_base).toBe("https://memex.ai");
+    expect(fs.current().hook_key).toBe("mxh_prod");
+  });
+});

--- a/packages/server/src/routes/spec-checkout.ts
+++ b/packages/server/src/routes/spec-checkout.ts
@@ -20,11 +20,9 @@
 import { Hono } from "hono";
 import { and, eq } from "drizzle-orm";
 import { db, runWithMemexId } from "../db/connection.js";
-import { documents } from "../db/schema.js";
+import { documents, namespaces, memexes } from "../db/schema.js";
 import { verifyHookKey, bumpHookKeyLastUsed } from "../services/hook-keys.js";
-import { resolveMemexId } from "../services/emission-keys.js";
-import { getOrgIdForMemex } from "../services/memexes.js";
-import { isActiveOrgMember } from "../services/org-memberships.js";
+import { isMemberOfMemex } from "../middleware/memex-resolver.js";
 import { recordCheckoutEdit } from "../services/spec-checkout.js";
 import { setCheckoutThread } from "../services/checkout.js";
 
@@ -100,18 +98,31 @@ specCheckoutRouter.post("/", async (c) => {
   if (!parsed) return c.json({ recorded: false, reason: "not_a_spec_ref" }, 200);
 
   // Authorize by MEMBERSHIP (spec-430 dec-1): a user-scoped key (memexId NULL) writes
-  // for ANY memex its creator is an active member of, so a personal->org graduation
-  // needs no new key (ac-5). A legacy per-memex key (memexId set) is additionally
-  // pinned to its own memex. Tenant isolation is membership + RLS, not key
-  // granularity. These lookups read the CONTROL PLANE (memexes/orgs/org_memberships),
-  // not RLS-tenant tables, so they run correctly before the runWithMemexId wrap below.
-  const memexId = await resolveMemexId(parsed.namespace, parsed.memexSlug);
+  // for ANY memex its creator can access, so a personal->org graduation needs no new
+  // key (ac-5). A legacy per-memex key (memexId set) is additionally pinned to its own
+  // memex. We reuse the SAME predicate the MCP layer gates on — `isMemberOfMemex` —
+  // which grants a user their OWN personal (kind='user') memex via
+  // `namespace.owner_user_id`, not just org membership (issue-2: an org-only check
+  // 401'd a user's own personal memex, breaking day-one checkout). These lookups read
+  // the CONTROL PLANE (namespaces/memexes/org_memberships), not RLS-tenant tables, so
+  // they run correctly before the runWithMemexId wrap below.
+  const ns = await db.query.namespaces.findFirst({
+    where: eq(namespaces.slug, parsed.namespace),
+  });
+  const mx = ns
+    ? await db.query.memexes.findFirst({
+        where: and(eq(memexes.namespaceId, ns.id), eq(memexes.slug, parsed.memexSlug)),
+      })
+    : null;
   const actorUserId = hookKey.createdByUserId ?? null;
-  const scopeOk = hookKey.memexId === null || hookKey.memexId === memexId;
-  const orgId = memexId ? await getOrgIdForMemex(memexId) : null;
-  const authorized =
-    !!memexId && scopeOk && !!actorUserId && !!orgId && (await isActiveOrgMember(actorUserId, orgId));
-  if (!authorized) {
+  const scopeOk = !!mx && (hookKey.memexId === null || hookKey.memexId === mx.id);
+  if (
+    !ns ||
+    !mx ||
+    !actorUserId ||
+    !scopeOk ||
+    !(await isMemberOfMemex(actorUserId, mx, ns))
+  ) {
     return c.json(
       {
         error: "unauthorized",
@@ -120,6 +131,7 @@ specCheckoutRouter.post("/", async (c) => {
       401,
     );
   }
+  const memexId = mx.id;
 
   // body.thread_uid was validated as a string above, but TypeScript does not preserve
   // that narrowing across the runWithMemexId callback boundary below — hoist it (the
@@ -129,8 +141,9 @@ specCheckoutRouter.post("/", async (c) => {
   // Everything below reads/writes TENANT tables (documents, then spec_checkout_edits)
   // under row-level security (std-36): the policy filters every row unless `app.memex_id`
   // is set, and the Cloud Run runtime role `memex_app` is a NON-OWNER, so the policy
-  // applies to it in full. The hook-key auth + resolveMemexId above run on RLS-EXCLUDED
-  // tables, so they need no context — but the spec lookup does. runWithMemexId stamps
+  // applies to it in full. The hook-key auth + the namespace/memex/membership
+  // resolution above run on RLS-EXCLUDED control-plane tables, so they need no context
+  // — but the spec lookup does. runWithMemexId stamps
   // app.memex_id for the duration. WITHOUT this wrap the read returns zero rows on int
   // (every phone-home silently records nothing), while local tests pass because the
   // postgres superuser bypasses RLS — the exact 2026-06-10 emission-outage trap

--- a/packages/server/src/routes/spec-checkout.user-scoped.spec-430.integration.test.ts
+++ b/packages/server/src/routes/spec-checkout.user-scoped.spec-430.integration.test.ts
@@ -7,6 +7,8 @@ import { createDocDraft } from "../services/documents.js";
 import { mintHookKey } from "../services/hook-keys.js";
 import { listCheckoutEditsForSpec } from "../services/spec-checkout.js";
 import { specCheckoutRouter } from "./spec-checkout.js";
+import { db } from "../db/connection.js";
+import { namespaces, memexes } from "../db/schema.js";
 
 // spec-430 ac-5 — the graduation guarantee: ONE user-scoped mxh_ key, minted once,
 // records checkout edits against EVERY memex its creator belongs to (personal + any
@@ -90,5 +92,71 @@ describe("spec-430 ac-5: one user-scoped key records across every memex its owne
     expect(res.status).toBe(201);
     const rows = await listCheckoutEditsForSpec(b.memexId, b.docId);
     expect(rows.some((r) => r.threadUid === "grad-thread-b")).toBe(true);
+  });
+});
+
+// A PERSONAL memex: a kind='user' namespace OWNED by `ownerId` (owner_user_id set, as
+// in production). makePersonalTestMemex leaves the owner null, which would not exercise
+// the personal-access path, so we create it directly here.
+async function makePersonalMemexWithSpec(ownerId: string): Promise<MemexCtx> {
+  const slug = ("p" + crypto.randomUUID().replace(/-/g, "")).slice(0, 39).toLowerCase();
+  const [ns] = await db
+    .insert(namespaces)
+    .values({ slug, kind: "user", ownerUserId: ownerId })
+    .returning();
+  const [mx] = await db
+    .insert(memexes)
+    .values({ namespaceId: ns.id, slug: "main", name: "Personal" })
+    .returning();
+  const doc = await createDocDraft(
+    mx.id,
+    "Personal spec",
+    "purpose",
+    "spec",
+    undefined,
+    undefined,
+    ownerId,
+  );
+  return {
+    memexId: mx.id,
+    slug: ns.slug,
+    docId: doc.id,
+    ref: `${ns.slug}/main/specs/${doc.handle}`,
+  };
+}
+
+// spec-430 issue-2: a user-scoped key 401'd against the key owner's OWN personal memex
+// — the authz checked org membership only and never consulted personal-namespace
+// ownership (`namespaces.owner_user_id` for kind='user'). Personal is everyone's
+// day-one memex, so this broke checkout for essentially everyone. The fix reuses
+// isMemberOfMemex (the predicate the MCP layer already gates on).
+describe("spec-430 issue-2: user-scoped key records against the owner's PERSONAL memex", () => {
+  it("the owner's key records against their own personal memex (recorded:true)", async () => {
+    tagAc(AC_5);
+    const owner = await upsertUserByEmail(`personal-owner-${crypto.randomUUID()}@example.com`);
+    const personal = await makePersonalMemexWithSpec(owner.id);
+    const ownerKey = (await mintHookKey("personal checkout hook", owner.id)).raw;
+    const res = await post(ownerKey, {
+      ref: personal.ref,
+      thread_uid: "issue2-personal",
+      changed_paths: ["packages/server/src/p.ts"],
+    });
+    expect(res.status).toBe(201);
+    const rows = await listCheckoutEditsForSpec(personal.memexId, personal.docId);
+    expect(rows.some((r) => r.threadUid === "issue2-personal")).toBe(true);
+  });
+
+  it("a NON-owner's key cannot record against someone else's personal memex (→ 401)", async () => {
+    tagAc(AC_5);
+    const owner = await upsertUserByEmail(`personal-owner-${crypto.randomUUID()}@example.com`);
+    const personal = await makePersonalMemexWithSpec(owner.id);
+    const stranger = await upsertUserByEmail(`stranger-${crypto.randomUUID()}@example.com`);
+    const strangerKey = (await mintHookKey("stranger hook", stranger.id)).raw;
+    const res = await post(strangerKey, {
+      ref: personal.ref,
+      thread_uid: "issue2-stranger",
+      changed_paths: ["x.ts"],
+    });
+    expect(res.status).toBe(401);
   });
 });


### PR DESCRIPTION
## Summary

Promotes `develop` to `main` (production). Carries the two prod bug fixes filed on spec-430:

- **issue-2 (server) — personal-memex checkout authz.** `POST /api/spec-checkout` now authorizes by **membership** via `isMemberOfMemex`, which grants a user their own personal (`kind='user'`) memex through `namespace.owner_user_id`, not just org membership. The previous org-only check 401'd a user against their *own* personal memex, breaking day-one checkout. **This fix reaches production only on this deploy** (the CLI half shipped separately).
- **issue-3 (CLI) — env-switch re-mint.** The checkout key is now re-minted when `api_base` changes (e.g. int → prod) instead of silently reusing a key minted for the other environment (which produced silent 401s). Already live as `memex-ai@3.1.1` on npm; included here for parity in the tree.

Also: `packages/cli` version bump to 3.1.1 and publish-safety notes (release banner in `cli.mjs`, `//publish` note in `package.json`, README "Releasing" section).

## Changes (develop ahead of main by 2 commits)

- `9a2f81f8` Merge PR #427 from `fix/spec-430-issue-2-3`
- `debcb223` fix(spec-430): personal-memex checkout authz (issue-2) + env-switch re-mint (issue-3)

Files: server route + integration test; CLI bootstrap + tests; CLI README / cli.mjs / package.json.

## Blind-spot coverage

Both fixes were proven to go **RED** without the production change (the issues existed because the suite had a blind spot):

- issue-2: new integration test exercises a **personal** memex (owner_user_id set) — owner records (201), non-owner 401. Previously only org memexes were tested.
- issue-3: new CLI tests cover the int → prod switch (`provisionHookKey` / `ensureHookKey` re-mint on env change; same-env short-circuits). Env mismatch was never tested before.

## Test plan

- [x] Full server suite green (local)
- [x] Full UI suite green (local)
- [x] CLI suite green (local)
- [ ] CI green on this PR (build, cli, server, ui, e2e, semgrep, migration)
- [ ] After merge + prod deploy: verify personal-memex checkout works on prod (issue-2), and int → prod env switch re-mints (issue-3)
