### PR TITLE
feat(spec-12): core comms_event enrichment for the Backstage Comms page

### DIFF
--- a/packages/server/drizzle/0117_add_comms_event.sql
+++ b/packages/server/drizzle/0117_add_comms_event.sql
@@ -1,0 +1,58 @@
+-- spec-12 (memex-backstage) t-1 — comms_event: one row per Postmark delivery /
+-- engagement event for an already-logged email (Delivery / Open / Click / Bounce /
+-- SpamComplaint), the fidelity layer comms_log's thin sent|delivered|failed shadow
+-- lacks. Core (memex-ai) OWNS + WRITES this public table from the Postmark webhook
+-- (routes/postmark-webhook.ts, spec-12 t-2); Backstage READS it cross-tenant via the
+-- memex_admin BYPASSRLS role and never writes it (spec-280 admin↔public boundary).
+-- It powers the Comms page's per-message OUTCOME, the single-message event trail
+-- fallback, and repeat-send / high-retry detection (spec-12 dec-2).
+--
+-- LINK: comms_log_id is a real FK to comms_log(id) ON DELETE cascade, so the
+-- core-side 90-day retention prune (pruneCommsLog) cascades these rows away with
+-- their parent — no orphan accumulation. source_ref (the Postmark MessageID) is
+-- denormalized alongside it: it is the join key the webhook matches on (it only has
+-- the MessageID, not our row id) AND the dedup discriminator. Events for a MessageID
+-- with no matching comms_log row (e.g. a send we never logged) are simply not
+-- recorded — same graceful no-op as updateCommDeliveryStatus on an unknown id.
+--
+-- METADATA ONLY (spec-6 dec-4, carried forward): event type + bounce type/reason +
+-- timestamps + the link — NEVER a message body. Full content stays in Postmark,
+-- reached via source_ref. No html/text/body column exists.
+--
+-- IDEMPOTENT enrichment (spec-12 dec-6): UNIQUE (source_ref, event_type, occurred_at)
+-- lets the webhook write ON CONFLICT DO NOTHING, so a redelivered/duplicate Postmark
+-- event is a no-op. That unique index leads with source_ref, so it ALSO serves the
+-- source_ref join lookups — no separate source_ref index is needed. occurred_at is
+-- the Postmark event timestamp (NOT now()): the displayed per-message outcome is
+-- resolved by event recency/priority at read time so a late Delivery never clobbers
+-- an earlier Bounce/SpamComplaint.
+--
+-- RLS — deliberately EXCLUDED, mirroring comms_log (0104) and usage_events (0090).
+-- comms_event is a CROSS-TENANT, user-scoped telemetry dimension written ADVISORILY
+-- from the contextless Postmark webhook (no request ALS / tenant GUC) — a FORCE-RLS
+-- WITH CHECK would silently reject those inserts, and a memex_id USING clause is
+-- meaningless on a row keyed via comms_log → user_id, not memex_id. The row holds
+-- only ids/enums/a bounce reason line (no body, no credentials); isolation is at the
+-- service layer and, in Backstage, the requireOperator gate. OMITTING all RLS DDL IS
+-- the exclusion (same justification comms_log / usage_events / visitors carry).
+--
+-- Idempotent (IF NOT EXISTS): the hand-migration runner wraps each file in a
+-- transaction and tracks it in manual_migrations; the guards let a retry re-apply
+-- cleanly if a prior run committed the DDL but not the tracking row.
+
+CREATE TABLE IF NOT EXISTS "comms_event" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "comms_log_id" uuid NOT NULL REFERENCES "comms_log"("id") ON DELETE cascade,
+  "source_ref" text NOT NULL,
+  "event_type" text NOT NULL,
+  "bounce_type" text,
+  "bounce_reason" text,
+  "occurred_at" timestamp with time zone NOT NULL,
+  "received_at" timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "comms_event_dedup" UNIQUE ("source_ref", "event_type", "occurred_at")
+);
+
+-- FK lookups + ON DELETE cascade performance (the source_ref join is served by the
+-- comms_event_dedup unique index, which leads with source_ref).
+CREATE INDEX IF NOT EXISTS "comms_event_comms_log_id_idx"
+  ON "comms_event" ("comms_log_id");

--- a/packages/server/drizzle/reverts/0117_add_comms_event.revert.sql
+++ b/packages/server/drizzle/reverts/0117_add_comms_event.revert.sql
@@ -1,0 +1,2 @@
+-- Revert spec-12 t-1 (0117_add_comms_event.sql).
+DROP TABLE IF EXISTS "comms_event";

--- a/packages/server/src/db/comms-event-schema.integration.test.ts
+++ b/packages/server/src/db/comms-event-schema.integration.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from "vitest";
+import { getTableColumns, sql } from "drizzle-orm";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { db } from "./connection.js";
+import { commsEvent } from "./schema.js";
+
+// spec-12 (memex-backstage) t-1 — comms_event schema guard.
+//
+// comms_event is a public.* table OWNED + WRITTEN by core (memex-ai) from the
+// Postmark webhook and READ by Backstage cross-tenant via the memex_admin
+// BYPASSRLS role. These tests pin its shape against migration 0117: the modelled
+// columns match the DB (so the @mindset-ai/db-schema re-export is what Backstage
+// consumes typed — ac-13), it links to comms_log via a real FK + carries source_ref,
+// it dedups on (source_ref, event_type, occurred_at), it is RLS-EXCLUDED like
+// comms_log/usage_events, and it stores only metadata — never a message body.
+
+const AC_COMMS_EVENT = "mindset-prod/memex-backstage/specs/spec-12/acs/ac-13";
+
+const EXPECTED_COLUMNS = [
+  "id",
+  "comms_log_id",
+  "source_ref",
+  "event_type",
+  "bounce_type",
+  "bounce_reason",
+  "occurred_at",
+  "received_at",
+] as const;
+
+describe("spec-12 t-1: comms_event table + shape (ac-13)", () => {
+  it("ac-13: comms_event exists in public with exactly the modelled columns", async () => {
+    tagAc(AC_COMMS_EVENT);
+
+    const rows = (await db.execute(sql`
+      SELECT column_name
+      FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = 'comms_event'
+      ORDER BY column_name
+    `)) as unknown as Array<{ column_name: string }>;
+
+    const got = rows.map((r) => r.column_name).sort();
+    expect(got, "comms_event column set drifted from migration 0117").toEqual(
+      [...EXPECTED_COLUMNS].sort(),
+    );
+  });
+
+  it("ac-13: the modelled schema (re-exported by @mindset-ai/db-schema) matches the DB columns", async () => {
+    tagAc(AC_COMMS_EVENT);
+
+    // commsEvent is re-exported verbatim by @mindset-ai/db-schema (packages/db-schema
+    // does `export * from server/src/db/schema`), so asserting the modelled shape
+    // here IS asserting what Backstage consumes typed.
+    const modelled = Object.values(getTableColumns(commsEvent))
+      .map((c) => c.name)
+      .sort();
+    expect(modelled).toEqual([...EXPECTED_COLUMNS].sort());
+  });
+
+  it("ac-13: links to comms_log via a FK on comms_log_id and carries source_ref as the join key", async () => {
+    tagAc(AC_COMMS_EVENT);
+
+    const fks = (await db.execute(sql`
+      SELECT
+        att.attname AS column_name,
+        confrel.relname AS referenced_table
+      FROM pg_constraint con
+      JOIN pg_class rel ON rel.oid = con.conrelid
+      JOIN pg_class confrel ON confrel.oid = con.confrelid
+      JOIN pg_attribute att ON att.attrelid = con.conrelid AND att.attnum = ANY (con.conkey)
+      WHERE con.contype = 'f' AND rel.relname = 'comms_event'
+    `)) as unknown as Array<{ column_name: string; referenced_table: string }>;
+
+    expect(
+      fks.some((f) => f.column_name === "comms_log_id" && f.referenced_table === "comms_log"),
+      "comms_event.comms_log_id must FK to comms_log (dec-2)",
+    ).toBe(true);
+
+    // source_ref is present (the Postmark MessageID join key Backstage matches on).
+    const cols = Object.values(getTableColumns(commsEvent)).map((c) => c.name);
+    expect(cols).toContain("source_ref");
+  });
+
+  it("ac-13: dedups on (source_ref, event_type, occurred_at) so the webhook is idempotent (dec-6)", async () => {
+    tagAc(AC_COMMS_EVENT);
+
+    const rows = (await db.execute(sql`
+      SELECT con.conname,
+             array_agg(att.attname ORDER BY att.attnum) AS cols
+      FROM pg_constraint con
+      JOIN pg_class rel ON rel.oid = con.conrelid
+      JOIN pg_attribute att ON att.attrelid = con.conrelid AND att.attnum = ANY (con.conkey)
+      WHERE con.contype = 'u' AND rel.relname = 'comms_event'
+      GROUP BY con.conname
+    `)) as unknown as Array<{ conname: string; cols: string[] }>;
+
+    const dedup = rows.find((r) => r.conname === "comms_event_dedup");
+    expect(dedup, "comms_event_dedup unique constraint missing").toBeTruthy();
+    expect([...dedup!.cols].sort()).toEqual(
+      ["source_ref", "event_type", "occurred_at"].sort(),
+    );
+  });
+
+  it("ac-13: comms_event is RLS-EXCLUDED (relrowsecurity = false), like comms_log", async () => {
+    tagAc(AC_COMMS_EVENT);
+
+    const rows = (await db.execute(sql`
+      SELECT c.relrowsecurity AS rowsecurity, c.relforcerowsecurity AS forcerowsecurity
+      FROM pg_class c
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+      WHERE n.nspname = 'public' AND c.relname = 'comms_event'
+    `)) as unknown as Array<{ rowsecurity: boolean; forcerowsecurity: boolean }>;
+
+    expect(rows, "comms_event not found in pg_class").toHaveLength(1);
+    expect(rows[0]!.rowsecurity, "comms_event must be RLS-excluded (mirrors comms_log)").toBe(false);
+    expect(rows[0]!.forcerowsecurity, "comms_event must not be FORCE'd").toBe(false);
+  });
+
+  it("ac-13: stores metadata only — no message-body column (dec-4)", async () => {
+    tagAc(AC_COMMS_EVENT);
+
+    const modelled = Object.values(getTableColumns(commsEvent)).map((c) => c.name);
+    for (const forbidden of ["body", "content", "html", "text_body", "message"]) {
+      expect(modelled, `comms_event must not carry a '${forbidden}' column (dec-4: summary only)`).not.toContain(
+        forbidden,
+      );
+    }
+  });
+});

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -2941,6 +2941,65 @@ export const commsLog = pgTable(
   ],
 );
 export type CommsLogRow = InferSelectModel<typeof commsLog>;
+
+// spec-12 (memex-backstage) t-1 — comms_event: one row per Postmark delivery /
+// engagement event (Delivery / Open / Click / Bounce / SpamComplaint) for an
+// already-logged email. The fidelity layer comms_log's thin sent|delivered|failed
+// shadow lacks — it captures repeat opens/clicks, bounce type & reason, and powers
+// the Comms page's per-message OUTCOME, drill-down fallback, and repeat/high-retry
+// detection (dec-2). Core OWNS + WRITES it from the Postmark webhook (t-2); Backstage
+// READS it cross-tenant via memex_admin and never writes it.
+//
+// LINK: commsLogId is a real FK (cascade) so the 90-day retention prune cascades
+// these away with the parent; sourceRef (the Postmark MessageID) is denormalized as
+// the webhook's join key (it only has the MessageID) AND the dedup discriminator.
+//
+// METADATA ONLY (dec-4): event type + bounce type/reason + timestamps — NEVER a body.
+//
+// IDEMPOTENT (dec-6): the (sourceRef, eventType, occurredAt) unique key lets the
+// webhook write ON CONFLICT DO NOTHING; occurredAt is the Postmark event timestamp
+// (not now()) so read-time recency/priority resolution is stable. RLS-EXCLUDED,
+// mirroring comms_log (no RLS DDL) — written from the contextless webhook, read
+// cross-tenant; see drizzle/0117 for the full justification.
+export const commsEvent = pgTable(
+  "comms_event",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    // The logged email this event belongs to. Cascade: pruning the comms_log row
+    // (retention) takes its events with it — no orphans.
+    commsLogId: uuid("comms_log_id")
+      .notNull()
+      .references(() => commsLog.id, { onDelete: "cascade" }),
+    // The Postmark MessageID (= comms_log.source_ref). Denormalized: the webhook
+    // matches on it (it has no row id), and it is the dedup discriminator.
+    sourceRef: text("source_ref").notNull(),
+    // Postmark RecordType — 'Delivery' | 'Open' | 'Click' | 'Bounce' |
+    // 'SpamComplaint'. Free text (no CHECK) so a new Postmark event type needs no
+    // migration; the webhook only writes the types it recognises.
+    eventType: text("event_type").notNull(),
+    // Postmark bounce Type (e.g. 'HardBounce' | 'SoftBounce' | 'SpamNotification');
+    // null unless this is a Bounce/SpamComplaint event.
+    bounceType: text("bounce_type"),
+    // Postmark bounce Description / Details — the SMTP reason line; null otherwise.
+    // A short reason string, never the message body.
+    bounceReason: text("bounce_reason"),
+    // The Postmark EVENT timestamp (DeliveredAt / BouncedAt / ReceivedAt …), NOT our
+    // insert time — recency/priority outcome resolution and dedup both depend on it.
+    occurredAt: timestamp("occurred_at", { withTimezone: true }).notNull(),
+    // When we recorded the event.
+    receivedAt: timestamp("received_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    // FK lookups + ON DELETE cascade. The source_ref join is served by the dedup
+    // unique index below (it leads with source_ref), so no separate index for it.
+    index("comms_event_comms_log_id_idx").on(table.commsLogId),
+    // Idempotency (dec-6): a redelivered/duplicate Postmark event is ON CONFLICT
+    // DO NOTHING. Leads with source_ref, so it doubles as the join index.
+    unique("comms_event_dedup").on(table.sourceRef, table.eventType, table.occurredAt),
+  ],
+);
+export type CommsEventRow = InferSelectModel<typeof commsEvent>;
+
 export type VisitorInsert = InferInsertModel<typeof visitors>;
 
 // ══════════════════════════════════════

--- a/packages/server/src/routes/postmark-webhook-events.integration.test.ts
+++ b/packages/server/src/routes/postmark-webhook-events.integration.test.ts
@@ -1,0 +1,162 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { and, eq } from "drizzle-orm";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { db } from "../db/connection.js";
+import { commsEvent, commsLog, users } from "../db/schema.js";
+import { recordComm } from "../services/comms-log.js";
+import { postmarkWebhookRouter } from "./postmark-webhook.js";
+
+// spec-12 t-2 — the webhook's comms_event enrichment.
+//   ac-14: Open / Click / Bounce / SpamComplaint each persist a comms_event row;
+//          bounce type & reason are captured.
+//   ac-17: idempotent (dedup on source_ref+type+occurred_at); a late/duplicate
+//          Delivery doesn't override a later Bounce (recency-resolvable); unknown
+//          types are no-ops; the write is fire-and-forget (the response never waits).
+
+const AC_EVENTS = "mindset-prod/memex-backstage/specs/spec-12/acs/ac-14";
+const AC_IDEMPOTENT = "mindset-prod/memex-backstage/specs/spec-12/acs/ac-17";
+
+const TOKEN = "test-pm-token-spec12";
+const authHeader = { Authorization: `Basic ${Buffer.from(`postmark:${TOKEN}`).toString("base64")}` };
+
+let userId: string;
+
+beforeAll(async () => {
+  process.env.POSTMARK_WEBHOOK_TOKEN = TOKEN;
+  const [u] = await db
+    .insert(users)
+    .values({ email: "spec12-webhook-events@example.com" })
+    .returning({ id: users.id });
+  userId = u!.id;
+});
+
+afterAll(async () => {
+  if (userId) await db.delete(users).where(eq(users.id, userId)).catch(() => {});
+  delete process.env.POSTMARK_WEBHOOK_TOKEN;
+});
+
+async function post(body: unknown, headers: Record<string, string> = authHeader) {
+  return postmarkWebhookRouter.request("/", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  });
+}
+
+/** Seed a comms_log row for `sourceRef` so the event has a parent to attach to. */
+async function seedSend(sourceRef: string) {
+  await recordComm({ userId, channel: "email", type: "transactional", status: "sent", sourceRef });
+}
+
+/** The webhook records comms_event fire-and-forget; poll until rows appear. */
+async function eventsFor(sourceRef: string, expectAtLeast = 1, tries = 40): Promise<Array<typeof commsEvent.$inferSelect>> {
+  for (let i = 0; i < tries; i++) {
+    const rows = await db.select().from(commsEvent).where(eq(commsEvent.sourceRef, sourceRef));
+    if (rows.length >= expectAtLeast) return rows;
+    await new Promise((r) => setTimeout(r, 25));
+  }
+  return db.select().from(commsEvent).where(eq(commsEvent.sourceRef, sourceRef));
+}
+
+describe("spec-12 t-2: webhook persists comms_event rows (ac-14)", () => {
+  it("ac-14: an Open event is persisted as a comms_event row", async () => {
+    tagAc(AC_EVENTS);
+    const ref = "pm12-open-1";
+    await seedSend(ref);
+    const res = await post({ RecordType: "Open", MessageID: ref, ReceivedAt: "2026-06-30T10:00:00Z" });
+    expect(res.status).toBe(200);
+    const rows = await eventsFor(ref);
+    expect(rows.map((r) => r.eventType)).toContain("Open");
+  });
+
+  it("ac-14: a Click event is persisted", async () => {
+    tagAc(AC_EVENTS);
+    const ref = "pm12-click-1";
+    await seedSend(ref);
+    await post({ RecordType: "Click", MessageID: ref, ReceivedAt: "2026-06-30T10:05:00Z" });
+    const rows = await eventsFor(ref);
+    expect(rows.map((r) => r.eventType)).toContain("Click");
+  });
+
+  it("ac-14: a Bounce captures bounce type + reason", async () => {
+    tagAc(AC_EVENTS);
+    const ref = "pm12-bounce-1";
+    await seedSend(ref);
+    await post({
+      RecordType: "Bounce",
+      MessageID: ref,
+      Type: "HardBounce",
+      Description: "The server was unable to deliver your message (ex: unknown user)",
+      BouncedAt: "2026-06-30T10:10:00Z",
+    });
+    const rows = await eventsFor(ref);
+    const bounce = rows.find((r) => r.eventType === "Bounce");
+    expect(bounce, "a Bounce comms_event row should exist").toBeTruthy();
+    expect(bounce!.bounceType).toBe("HardBounce");
+    expect(bounce!.bounceReason).toContain("unable to deliver");
+  });
+
+  it("ac-14: a SpamComplaint captures its type", async () => {
+    tagAc(AC_EVENTS);
+    const ref = "pm12-spam-1";
+    await seedSend(ref);
+    await post({ RecordType: "SpamComplaint", MessageID: ref, Type: "SpamComplaint", BouncedAt: "2026-06-30T10:12:00Z" });
+    const rows = await eventsFor(ref);
+    expect(rows.map((r) => r.eventType)).toContain("SpamComplaint");
+  });
+});
+
+describe("spec-12 t-2: webhook enrichment is idempotent + recency-resolvable (ac-17)", () => {
+  it("ac-17: a duplicate event (same source_ref+type+timestamp) inserts exactly once", async () => {
+    tagAc(AC_IDEMPOTENT);
+    const ref = "pm12-dup-1";
+    await seedSend(ref);
+    const evt = { RecordType: "Delivery", MessageID: ref, DeliveredAt: "2026-06-30T11:00:00Z" };
+    await post(evt);
+    await eventsFor(ref); // wait for the first
+    await post(evt); // redelivery — must dedup
+    // give the second a chance to (not) insert
+    await new Promise((r) => setTimeout(r, 200));
+    const rows = await db
+      .select()
+      .from(commsEvent)
+      .where(and(eq(commsEvent.sourceRef, ref), eq(commsEvent.eventType, "Delivery")));
+    expect(rows).toHaveLength(1);
+  });
+
+  it("ac-17: a late/duplicate Delivery does not override a later Bounce — both stored, recency picks Bounce", async () => {
+    tagAc(AC_IDEMPOTENT);
+    const ref = "pm12-reorder-1";
+    await seedSend(ref);
+    // Delivery happened EARLIER (T1) but its webhook arrives out of order, after the
+    // Bounce (T2). Both must persist; the latest-by-occurred_at event is the Bounce.
+    await post({ RecordType: "Bounce", MessageID: ref, Type: "HardBounce", Description: "blocked", BouncedAt: "2026-06-30T12:05:00Z" });
+    await eventsFor(ref);
+    await post({ RecordType: "Delivery", MessageID: ref, DeliveredAt: "2026-06-30T12:00:00Z" });
+    const rows = await eventsFor(ref, 2);
+    expect(rows.length, "both Delivery and Bounce should be stored").toBeGreaterThanOrEqual(2);
+    const latest = [...rows].sort((a, b) => b.occurredAt.getTime() - a.occurredAt.getTime())[0];
+    expect(latest!.eventType, "recency resolution: the later Bounce wins over the late Delivery").toBe("Bounce");
+  });
+
+  it("ac-17: an unknown record type writes no comms_event row and is a 200 no-op", async () => {
+    tagAc(AC_IDEMPOTENT);
+    const ref = "pm12-unknown-1";
+    await seedSend(ref);
+    const res = await post({ RecordType: "SubscriptionChange", MessageID: ref, ChangedAt: "2026-06-30T13:00:00Z" });
+    expect(res.status).toBe(200);
+    await new Promise((r) => setTimeout(r, 150));
+    const rows = await db.select().from(commsEvent).where(eq(commsEvent.sourceRef, ref));
+    expect(rows).toHaveLength(0);
+  });
+
+  it("ac-17: an event for an unlogged MessageID is a graceful no-op (no row, no error, 200)", async () => {
+    tagAc(AC_IDEMPOTENT);
+    const ref = "pm12-orphan-never-logged";
+    const res = await post({ RecordType: "Delivery", MessageID: ref, DeliveredAt: "2026-06-30T14:00:00Z" });
+    expect(res.status).toBe(200);
+    await new Promise((r) => setTimeout(r, 150));
+    const rows = await db.select().from(commsEvent).where(eq(commsEvent.sourceRef, ref));
+    expect(rows).toHaveLength(0);
+  });
+});

--- a/packages/server/src/routes/postmark-webhook-events.integration.test.ts
+++ b/packages/server/src/routes/postmark-webhook-events.integration.test.ts
@@ -2,7 +2,7 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { and, eq } from "drizzle-orm";
 import { tagAc } from "@memex-ai-ac/vitest";
 import { db } from "../db/connection.js";
-import { commsEvent, commsLog, users } from "../db/schema.js";
+import { commsEvent, users } from "../db/schema.js";
 import { recordComm } from "../services/comms-log.js";
 import { postmarkWebhookRouter } from "./postmark-webhook.js";
 

--- a/packages/server/src/routes/postmark-webhook.ts
+++ b/packages/server/src/routes/postmark-webhook.ts
@@ -1,4 +1,4 @@
-// spec-341 t-2: Postmark delivery webhook.
+// spec-341 t-2 / spec-12 t-2: Postmark delivery + engagement webhook.
 //
 // Mounted at /api/postmark/webhook (flat, no tenancy prefix — Postmark calls this
 // directly). NO sessionMiddleware — like the Stripe webhook (routes/stripe-webhook.ts),
@@ -6,12 +6,21 @@
 // webhook URL (you configure user:token in the Postmark server's webhook settings),
 // so we verify the Basic credential against POSTMARK_WEBHOOK_TOKEN before processing.
 //
-// Postmark posts one JSON object per event with a RecordType + MessageID. We map the
-// delivery-outcome types to a comms_log status and update the row by MessageID
-// (source_ref). Open/Click/etc. are 200 no-ops. Matching is source-agnostic — any
-// Postmark-sent email is updated regardless of which code path sent it (spec-341 ac-9).
+// Postmark posts one JSON object per event with a RecordType + MessageID. Two things
+// happen per event, both keyed on MessageID (= comms_log.source_ref), both advisory:
+//   1. STATUS FLIP (spec-341): delivery-outcome types flip the comms_log row's status
+//      (Delivery→delivered, Bounce/SpamComplaint→failed). Engagement types (Open,
+//      Click) and unknown types do NOT change status — they stay a 200 no-op here.
+//   2. EVENT ENRICHMENT (spec-12 dec-2): Delivery / Open / Click / Bounce /
+//      SpamComplaint are each written as a comms_event row (one row per event) so the
+//      Comms page can resolve a true per-message OUTCOME, show the engagement trail,
+//      and detect repeats — fidelity the thin status shadow can't carry. The write is
+//      fire-and-forget + idempotent (dedup on source_ref+type+timestamp), so a
+//      redelivered event or a webhook fault never blocks or corrupts core's send path.
+// Matching is source-agnostic — any Postmark-sent email is updated regardless of
+// which code path sent it (spec-341 ac-9).
 import { Hono } from "hono";
-import { updateCommDeliveryStatus } from "../services/comms-log.js";
+import { recordCommEvent, updateCommDeliveryStatus } from "../services/comms-log.js";
 
 const postmarkWebhookRouter = new Hono();
 
@@ -28,12 +37,36 @@ function basicAuthPassword(header: string | undefined): string | null {
 }
 
 // Postmark RecordType → comms_log status. Only delivery outcomes update a row;
-// engagement types (Open, Click, SubscriptionChange) are ignored.
+// engagement types (Open, Click, SubscriptionChange) leave status as-is.
 const STATUS_BY_RECORD_TYPE: Record<string, "delivered" | "failed"> = {
   Delivery: "delivered",
   Bounce: "failed",
   SpamComplaint: "failed",
 };
+
+// RecordTypes we persist as comms_event rows (spec-12). A superset of the status
+// types — it adds the engagement types Open + Click. Anything else stays a no-op.
+const EVENT_RECORD_TYPES = new Set(["Delivery", "Open", "Click", "Bounce", "SpamComplaint"]);
+
+function asString(v: unknown): string | undefined {
+  return typeof v === "string" && v.length > 0 ? v : undefined;
+}
+
+/**
+ * Extract the Postmark EVENT timestamp for dedup/recency. The field name varies by
+ * RecordType: Delivery→DeliveredAt, Bounce/SpamComplaint→BouncedAt, Open/Click→
+ * ReceivedAt. Returns a valid Date or null (a missing/unparseable timestamp means we
+ * can't dedup, so the event is skipped rather than recorded with a wrong time).
+ */
+function eventTimestamp(payload: Record<string, unknown>): Date | null {
+  const raw =
+    asString(payload.DeliveredAt) ??
+    asString(payload.BouncedAt) ??
+    asString(payload.ReceivedAt);
+  if (!raw) return null;
+  const d = new Date(raw);
+  return Number.isNaN(d.getTime()) ? null : d;
+}
 
 postmarkWebhookRouter.post("/", async (c) => {
   const expected = process.env.POSTMARK_WEBHOOK_TOKEN;
@@ -43,24 +76,48 @@ postmarkWebhookRouter.post("/", async (c) => {
     return c.json({ error: "unauthorized" }, 401);
   }
 
-  let payload: { RecordType?: unknown; MessageID?: unknown };
+  let payload: Record<string, unknown>;
   try {
-    payload = await c.req.json();
+    payload = (await c.req.json()) as Record<string, unknown>;
   } catch {
     return c.json({ error: "Expected a JSON body" }, 400);
   }
 
-  const recordType = typeof payload.RecordType === "string" ? payload.RecordType : "";
-  const messageId = typeof payload.MessageID === "string" ? payload.MessageID : "";
-  const status = STATUS_BY_RECORD_TYPE[recordType];
+  const recordType = asString(payload.RecordType) ?? "";
+  const messageId = asString(payload.MessageID) ?? "";
 
-  // Not a delivery-outcome event (Open/Click/etc.), or no MessageID → accept + no-op.
-  if (!status || !messageId) {
+  // No MessageID → nothing to match on. Accept + no-op (Postmark stops retrying).
+  if (!messageId) {
     return c.json({ received: true, applied: false });
   }
 
-  // Advisory: updateCommDeliveryStatus is a no-op for an unknown MessageID and
-  // swallows its own errors. Always answer 200 so Postmark stops retrying.
+  // 2) Enrichment: write a comms_event row for the types we track. Fire-and-forget
+  //    + advisory (recordCommEvent resolves the parent by source_ref, dedups, and
+  //    swallows its own errors), so it never blocks or fails the response. Bounce
+  //    type/reason are captured for Bounce/SpamComplaint; Open/Click carry neither.
+  if (EVENT_RECORD_TYPES.has(recordType)) {
+    const occurredAt = eventTimestamp(payload);
+    if (occurredAt) {
+      const isBounce = recordType === "Bounce" || recordType === "SpamComplaint";
+      void recordCommEvent({
+        sourceRef: messageId,
+        eventType: recordType,
+        occurredAt,
+        bounceType: isBounce ? asString(payload.Type) ?? null : null,
+        bounceReason: isBounce
+          ? asString(payload.Description) ?? asString(payload.Details) ?? null
+          : null,
+      });
+    }
+  }
+
+  // 1) Status flip: only delivery-outcome types touch comms_log.status. Advisory:
+  //    updateCommDeliveryStatus is a no-op for an unknown MessageID and swallows its
+  //    own errors. `applied` reflects this status flip (unchanged spec-341 contract).
+  const status = STATUS_BY_RECORD_TYPE[recordType];
+  if (!status) {
+    return c.json({ received: true, applied: false });
+  }
   const updated = await updateCommDeliveryStatus(messageId, status);
   return c.json({ received: true, applied: updated > 0 });
 });

--- a/packages/server/src/services/comms-log.ts
+++ b/packages/server/src/services/comms-log.ts
@@ -17,10 +17,10 @@
 // METADATA ONLY (spec-6 dec-4): callers pass a one-line subject/summary — NEVER a
 // message body. Full content stays in the system-of-record, reached via sourceRef.
 
-import { and, eq, isNull, lt, sql } from "drizzle-orm";
+import { and, desc, eq, isNull, lt, sql } from "drizzle-orm";
 import { db, type Db } from "../db/connection.js";
-import { commsLog, users, orgs } from "../db/schema.js";
-import type { CommsLogRow } from "../db/schema.js";
+import { commsLog, commsEvent, users, orgs } from "../db/schema.js";
+import type { CommsLogRow, CommsEventRow } from "../db/schema.js";
 
 /**
  * Retention window (spec-6 dec-4): comms_log keeps a bounded history; the source
@@ -131,6 +131,74 @@ export async function updateCommDeliveryStatus(
   } catch (err) {
     log("status update failed (advisory — swallowed):", err instanceof Error ? err.message : err);
     return 0;
+  }
+}
+
+// ── Postmark event enrichment (spec-12 t-2 / ac-14, ac-17) ───────────────────
+
+/** One Postmark event to enrich an already-logged email with (spec-12 dec-2). */
+export interface RecordCommEventInput {
+  /** The Postmark MessageID — matches comms_log.source_ref. Required. */
+  sourceRef: string;
+  /** Postmark RecordType: 'Delivery' | 'Open' | 'Click' | 'Bounce' | 'SpamComplaint'. */
+  eventType: string;
+  /** The Postmark EVENT timestamp (DeliveredAt / BouncedAt / ReceivedAt). Required —
+   *  it is part of the dedup key, so it must come from the payload, never now(). */
+  occurredAt: Date;
+  /** Postmark bounce Type (HardBounce / SoftBounce / SpamNotification …); null otherwise. */
+  bounceType?: string | null;
+  /** Postmark bounce Description / Details — the SMTP reason; null otherwise. */
+  bounceReason?: string | null;
+}
+
+/**
+ * Record one Postmark delivery/engagement event as a comms_event row (spec-12 t-2).
+ * Resolves the parent comms_log row by `sourceRef` (the webhook has only the
+ * MessageID, not our row id); an UNMATCHED sourceRef is a graceful no-op (returns
+ * null) — an event for an email we never logged (a non-user send, a pre-comms_log
+ * message). Idempotent (dec-6): writes ON CONFLICT DO NOTHING against the
+ * (source_ref, event_type, occurred_at) unique key, so a redelivered/duplicate
+ * Postmark event inserts nothing and returns null (success, not failure). Advisory:
+ * any failure is logged and swallowed so the webhook is never broken by it — the
+ * displayed per-message outcome is resolved by event recency/priority at read time,
+ * so a late Delivery never clobbers an earlier Bounce. Returns the inserted row, or
+ * null when skipped / deduped / failed.
+ */
+export async function recordCommEvent(
+  input: RecordCommEventInput,
+  conn: Db = db,
+): Promise<CommsEventRow | null> {
+  if (!input.sourceRef || !input.eventType || !(input.occurredAt instanceof Date) || Number.isNaN(input.occurredAt.getTime())) {
+    return null;
+  }
+  try {
+    // Match the parent comms_log row by source_ref (most recent if somehow >1).
+    const [parent] = await conn
+      .select({ id: commsLog.id })
+      .from(commsLog)
+      .where(eq(commsLog.sourceRef, input.sourceRef))
+      .orderBy(desc(commsLog.createdAt))
+      .limit(1);
+    if (!parent) return null; // event for an email we never logged → skip
+
+    const [row] = await conn
+      .insert(commsEvent)
+      .values({
+        commsLogId: parent.id,
+        sourceRef: input.sourceRef,
+        eventType: input.eventType,
+        bounceType: input.bounceType ?? null,
+        bounceReason: input.bounceReason ?? null,
+        occurredAt: input.occurredAt,
+      })
+      .onConflictDoNothing({
+        target: [commsEvent.sourceRef, commsEvent.eventType, commsEvent.occurredAt],
+      })
+      .returning();
+    return row ?? null; // null ⇒ deduped (idempotent no-op), not an error
+  } catch (err) {
+    log("recordCommEvent failed (advisory — swallowed):", err instanceof Error ? err.message : err);
+    return null;
   }
 }
 

--- a/packages/server/src/services/email/templates.ts
+++ b/packages/server/src/services/email/templates.ts
@@ -175,6 +175,13 @@ export function buildVerificationEmail(input: VerificationEmailInput): EmailMess
     subject: `Confirm your Memex.AI email`,
     text,
     html,
+    // spec-12 t-9 / dec-7: stamp a distinct, stable comms type so the signup
+    // confirmation email is identifiable in comms_log — Backstage's stuck-signup
+    // worklist joins on type='email_verification' instead of brittle subject
+    // matching. Both call sites (routes/auth/password.ts signup + resend) send this
+    // EmailMessage, so the type travels with the template; recordEmailComm stores it
+    // (else it would default to 'transactional', the password-reset/magic-link bucket).
+    commsType: "email_verification",
   };
 }
 

--- a/packages/server/src/services/email/verification-email-comms-type.integration.test.ts
+++ b/packages/server/src/services/email/verification-email-comms-type.integration.test.ts
@@ -1,0 +1,84 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { eq } from "drizzle-orm";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { db } from "../../db/connection.js";
+import { commsLog, users } from "../../db/schema.js";
+import { recordEmailComm } from "../comms-log.js";
+import { buildVerificationEmail } from "./templates.js";
+
+// spec-12 t-9 / dec-7 (ac-19): the signup confirmation email must be identifiable in
+// comms_log by a distinct, stable comms type — 'email_verification' — so Backstage's
+// stuck-signup worklist (t-6) joins on type instead of matching the literal subject.
+// Without this it lands as type='transactional' (the default at comms-log.ts), the
+// same bucket as password-reset and magic-link, and is indistinguishable.
+
+const AC_VERIFY_TYPE = "mindset-prod/memex-backstage/specs/spec-12/acs/ac-19";
+
+let userId: string;
+const EMAIL = "spec12-verify-type@example.com";
+
+beforeAll(async () => {
+  const [u] = await db.insert(users).values({ email: EMAIL }).returning({ id: users.id });
+  userId = u!.id;
+});
+
+afterAll(async () => {
+  if (userId) await db.delete(users).where(eq(users.id, userId)).catch(() => {});
+});
+
+describe("spec-12 t-9: verification email carries a distinct comms type (ac-19)", () => {
+  it("ac-19: buildVerificationEmail stamps commsType 'email_verification' (not the transactional default)", () => {
+    tagAc(AC_VERIFY_TYPE);
+    const msg = buildVerificationEmail({ to: EMAIL, verifyUrl: "https://memex.ai/verify?t=abc" });
+    expect(msg.commsType).toBe("email_verification");
+    expect(msg.commsType).not.toBe("transactional");
+  });
+
+  it("ac-19: a recorded verification email lands in comms_log with type='email_verification'", async () => {
+    tagAc(AC_VERIFY_TYPE);
+    const msg = buildVerificationEmail({ to: EMAIL, verifyUrl: "https://memex.ai/verify?t=abc" });
+
+    const row = await recordEmailComm({
+      to: msg.to,
+      commsType: msg.commsType,
+      subject: msg.subject,
+      messageId: "pm-verify-1",
+    });
+
+    expect(row, "verification email should record a per-user comm").toBeTruthy();
+    expect(row!.type).toBe("email_verification");
+    expect(row!.userId).toBe(userId);
+
+    // And it really is in the table with that type (not the transactional default).
+    const [stored] = await db
+      .select({ type: commsLog.type })
+      .from(commsLog)
+      .where(eq(commsLog.id, row!.id));
+    expect(stored!.type).toBe("email_verification");
+  });
+
+  it("ac-19: PostmarkEmailSender threads the template's commsType through to recordEmailComm", async () => {
+    tagAc(AC_VERIFY_TYPE);
+    // Prove the send path carries the type end-to-end (template → sender → recorder)
+    // without a network call: mock recordEmailComm + fetch, send the built message.
+    vi.resetModules();
+    const recordSpy = vi.fn().mockResolvedValue(null);
+    vi.doMock("../comms-log.js", () => ({ recordEmailComm: recordSpy }));
+    const { PostmarkEmailSender } = await import("./sender.js");
+    const { buildVerificationEmail: build } = await import("./templates.js");
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: true, json: async () => ({ MessageID: "pm-verify-2" }) }),
+    );
+    const sender = new PostmarkEmailSender("tok", "Memex <x@memex.ai>");
+    await sender.send(build({ to: EMAIL, verifyUrl: "https://memex.ai/verify?t=xyz" }));
+
+    expect(recordSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ to: EMAIL, commsType: "email_verification", messageId: "pm-verify-2" }),
+    );
+    vi.unstubAllGlobals();
+    vi.doUnmock("../comms-log.js");
+    vi.resetModules();
+  });
+});


### PR DESCRIPTION
Core (memex-ai) half of **spec-12** — the data the new Backstage Comms page reads. Paired with the memex-backstage PR (the page itself).

## What this adds
- **`public.comms_event` child table** (migration `0117`, hand-runner, RLS-excluded with a matching revert): one row per Postmark event — `event_type` (Delivery/Open/Click/Bounce/SpamComplaint), `bounce_type`, `bounce_reason`, `occurred_at` — linked to `comms_log` by a real FK (`comms_log_id`, ON DELETE cascade, so the retention prune cascades) plus a denormalized `source_ref` (Postmark MessageID) as the join key + dedup discriminator. Modelled in `schema.ts` (`commsEvent`/`CommsEventRow`) and re-exported via `@mindset-ai/db-schema`.
- **Webhook enrichment** (`routes/postmark-webhook.ts` + `recordCommEvent` in `services/comms-log.ts`): the Postmark webhook now writes a `comms_event` row per event (parsing the type-specific timestamp + bounce Type/Description), **idempotent** (`ON CONFLICT (source_ref,event_type,occurred_at) DO NOTHING`) and **fire-and-forget/advisory** so it never blocks the send path. The existing `sent → delivered/failed` status flip is unchanged; unknown types and unlogged MessageIDs are graceful no-ops.
- **Verification-email type** (`services/email/templates.ts`): `buildVerificationEmail` now stamps `commsType: 'email_verification'` so the signup confirmation's `comms_log` row is distinctly typed (was the default `'transactional'`, indistinguishable from password-reset/magic-link). Forward-looking: only emails sent after deploy carry it.

## Testing
New tagged integration tests (verify spec-12 ac-13/14/17/19), all green; existing spec-341 webhook + comms-log + email suites unchanged. Core comms suite: **40/40** post-rebase onto `develop`.

## Deploy notes
- Apply migration `0117` via the hand-runner (`node scripts/apply-hand-migrations.mjs`), **not** drizzle-kit. Revert: `drizzle/reverts/0117_add_comms_event.revert.sql`.
- Republish `@mindset-ai/db-schema` for the `CommsEventRow` type (optional for Backstage runtime, which reads via raw SQL).
- No secrets, no data backfill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)