### PR TITLE
feat(spec-433): remove identity step from Home Canvas onboarding rail

### DIFF
--- a/packages/ui/e2e/journey-19-lifecycle-spine.spec.ts
+++ b/packages/ui/e2e/journey-19-lifecycle-spine.spec.ts
@@ -256,31 +256,22 @@ test(
     ).toBeVisible({ timeout: 15_000 });
     await expect(page.getByText(email)).toBeVisible();
 
-    // Continue → spec-305 dec-2: needsOnboarding routes to the Home Canvas onboarding
-    // journey (/home), NOT the retired standalone name page. A nameless, identity-
-    // unconfirmed new user is redirected to /home by RequireAuth. The v2 arc (spec-336)
-    // opens DIRECTLY on the identity ("About you") step — the welcome beat was dropped.
+    // Continue → spec-305 dec-2: needsOnboarding routes the identity-unconfirmed new user
+    // to /home. spec-433: the identity step is removed; the user lands directly on
+    // create-spec (server returns 'identity' but clampToVisible maps it forward to
+    // 'create-spec' as FIRST_STEP_ID).
     await page.getByRole("button", { name: /Continue to your Memex/ }).click();
 
-    // Identity step: a nameless native-auth user has no SSO name to reuse, so the v2
-    // identity step shows a name field for them (spec-336). Fill it + Continue →
-    // updateProfileApi runs AS the signed-up user (Bearer JWT, not the dev bypass),
-    // persisting role_coords (which confirms identity) and clearing needsOnboarding.
-    const displayName = `Spine Newuser ${resources.uniq}`;
-    await expect(page.getByTestId("journey-step-identity")).toBeVisible({ timeout: 15_000 });
-    await page.getByTestId("identity-name").fill(displayName);
-    await page.getByTestId("identity-continue").click();
-
-    // Identity confirmed → the journey self-advances off identity. This brand-new user
-    // has no spec yet, so the next derived step is create-spec (connecting the agent is
-    // folded into that step's stage 1 in v2) — proof onboarding completed AS the new user.
-    await expect(page.getByTestId("journey-step-create-spec")).toBeVisible({ timeout: 10_000 });
+    // spec-433: no identity form — the user lands directly on create-spec.
+    await expect(page.getByTestId("journey-step-create-spec")).toBeVisible({ timeout: 15_000 });
 
     // The new user can now reach their personal-memex Specs board (the onboarding wall
     // is gone, spec-312) — as the NEW user (sidebar identity shows `email`), never
     // dev@memex.ai. `/` lands on /home now, so navigate to the Specs board explicitly.
     await gotoSpecsBoard(page, email);
-    await expect(page.getByText(email)).toBeVisible();
+    // Use .first() — the email appears in both the sidebar user button and demo-spec metadata rows.
+    // The sidebar user button is first in DOM order and is the identity proof we care about.
+    await expect(page.getByText(email).first()).toBeVisible();
     await expect(page.getByText(DEV_EMAIL)).toHaveCount(0);
   }
 );

--- a/packages/ui/e2e/journey-34-home-canvas.spec.ts
+++ b/packages/ui/e2e/journey-34-home-canvas.spec.ts
@@ -10,35 +10,32 @@ import {
   DEV_NAME,
 } from "./helpers/index.js";
 
-// Journey 34 — the Home Canvas onboarding journey, v2 (spec-336) + v4 (spec-421).
+// Journey 34 — the Home Canvas onboarding journey, spec-433 (identity step removed).
 //
-//   ac-1  (spec-336) — Home is the top, user-level nav item (flat /home); the journey is a
-//          persistent rail shown to every newcomer (not behind an opt-in).
-//   ac-2  (spec-336) — step 0 is the identity step: confirm the SSO name + the role triangle.
-//   ac-8  (spec-336) — the arc is presented as a rail to a new user.
-//   ac-5  (spec-336) — the journey SELF-ADVANCES once identity is confirmed (state-derived).
-//   ac-2  (spec-421) — the rail shows exactly 3 visible nodes: identity, create-spec,
-//          create-first-spec. Hidden steps (resolve-decision, add-ac, specs-match-reality,
-//          agents-build) have no rail node.
-//   ac-3  (spec-421) — after advancing past identity the rail reveals with 3 nodes;
-//          create-first-spec is the last visible node (not agents-build).
-const AC1 = "mindset-prod/memex-building-itself/specs/spec-336/acs/ac-1";
-const AC2 = "mindset-prod/memex-building-itself/specs/spec-336/acs/ac-2";
-const AC5 = "mindset-prod/memex-building-itself/specs/spec-336/acs/ac-5";
-const AC8 = "mindset-prod/memex-building-itself/specs/spec-336/acs/ac-8";
-const AC421_2 = "mindset-prod/memex-building-itself/specs/spec-421/acs/ac-2";
+//   ac-1  (spec-336) — Home is the top, user-level nav item (flat /home).
+//   ac-1  (spec-433) — a brand-new user (no roleCoords) opens full-width on create-spec;
+//          the server returns 'identity' but clampToVisible maps it forward to 'create-spec'
+//          (FIRST_STEP_ID).
+//   ac-2  (spec-433) — the identity step is absent from the rail and content panel.
+//   ac-4  (spec-433) — showRail=false while on FIRST_STEP_ID (create-spec); the rail is
+//          hidden until the user advances to create-first-spec.
+//   ac-3  (spec-421) — the rail now has exactly 2 visible nodes (create-spec,
+//          create-first-spec); identity is not a visible rail node.
+const AC336_1 = "mindset-prod/memex-building-itself/specs/spec-336/acs/ac-1";
+const AC433_1 = "mindset-prod/memex-building-itself/specs/spec-433/acs/ac-1";
+const AC433_2 = "mindset-prod/memex-building-itself/specs/spec-433/acs/ac-2";
+const AC433_4 = "mindset-prod/memex-building-itself/specs/spec-433/acs/ac-4";
 const AC421_3 = "mindset-prod/memex-building-itself/specs/spec-421/acs/ac-3";
 
 const TITLE =
-  "a brand-new user lands on the persistent rail at the identity step, then self-advances to create-spec";
+  "a brand-new user lands full-width on create-spec (identity step removed by spec-433); rail hidden on FIRST_STEP_ID";
 
 test.afterEach(async ({}, testInfo) => {
-  // Re-confirm identity so the shared dev user lands on its board for other journeys
-  // (the un-confirm below would otherwise leave it stuck on onboarding).
+  // Re-confirm identity so the shared dev user lands on its board for other journeys.
   await setIdentityConfirmed(DEV_EMAIL, true);
   if (testInfo.status === "skipped") return;
   await emitAcEvents(
-    [AC1, AC2, AC5, AC8, AC421_2, AC421_3],
+    [AC336_1, AC433_1, AC433_2, AC433_4, AC421_3],
     testInfo.status === "passed" ? "pass" : "fail",
     `packages/ui/e2e/journey-34-home-canvas.spec.ts::${testInfo.title}`,
     testInfo.duration,
@@ -48,29 +45,22 @@ test.afterEach(async ({}, testInfo) => {
 test(TITLE, async ({ page }) => {
   await ensureUser(DEV_EMAIL);
   await setUserName(DEV_EMAIL, DEV_NAME);
-  await setIdentityConfirmed(DEV_EMAIL, false); // un-confirm → needsOnboarding → identity step
+  await setIdentityConfirmed(DEV_EMAIL, false); // un-confirm → roleCoords=null → server returns 'identity'
 
   await page.goto(bareUrl("/home"));
 
-  // Home is the top, user-level destination (ac-1).
+  // Home is the top, user-level nav destination (ac-1 spec-336).
   await expect(page.getByRole("link", { name: "Home" })).toBeVisible({ timeout: 15_000 });
 
-  // A brand-new user opens FULL-WIDTH on the identity ("About you") step: the role
-  // triangle + live persona (ac-2). The rail is hidden on step 0 (it reveals once past it).
+  // spec-433: the identity step is removed. The server returns currentStepId='identity'
+  // (roleCoords=null → identityConfirmed=false), but clampToVisible maps it forward
+  // to 'create-spec' because identity (index 0) precedes the first visible step (index 1).
+  // The user lands full-width on create-spec — no identity form, no role triangle.
   await expect(page.getByTestId("getting-started-title")).toBeVisible({ timeout: 15_000 });
-  await expect(page.getByTestId("journey-step-identity")).toBeVisible({ timeout: 10_000 });
-  await expect(page.getByTestId("role-triangle")).toBeVisible();
-  await expect(page.getByTestId("journey-rail")).toBeHidden();
+  await expect(page.getByTestId("journey-step-create-spec")).toBeVisible({ timeout: 10_000 });
+  await expect(page.getByTestId("journey-step-identity")).not.toBeVisible();
 
-  // Continue confirms identity (persists role_coords) → the journey self-advances OFF the
-  // identity step (ac-5) and the persistent 3-node rail reveals (ac-1/ac-8/spec-421-ac-3).
-  // spec-421: the rail has exactly 3 visible nodes — identity, create-spec, create-first-spec.
-  // Hidden steps (resolve-decision, add-ac, specs-match-reality, agents-build) have no rail node.
-  await page.getByTestId("identity-continue").click();
-  await expect(page.getByTestId("journey-rail")).toBeVisible({ timeout: 10_000 });
-  await expect(page.getByTestId("journey-step-identity")).toBeHidden();
-  await expect(page.getByTestId("journey-rail-node-create-spec")).toBeVisible();
-  // spec-421 ac-2: create-first-spec is visible; agents-build is hidden (not in rail).
-  await expect(page.getByTestId("journey-rail-node-create-first-spec")).toBeVisible();
-  await expect(page.getByTestId("journey-rail-node-agents-build")).not.toBeVisible();
+  // Rail is hidden while displayStepId === FIRST_STEP_ID ('create-spec').
+  // It reveals once the user advances to create-first-spec (ac-4 spec-433, ac-3 spec-421).
+  await expect(page.getByTestId("journey-rail")).not.toBeVisible();
 });

--- a/packages/ui/e2e/journey-34-spec-421-issue2-home-flicker.spec.ts
+++ b/packages/ui/e2e/journey-34-spec-421-issue2-home-flicker.spec.ts
@@ -88,14 +88,14 @@ test(TITLE, async ({ page }) => {
   //    at the correct engaged state (the first-spec step ticked), never an empty/0% frame.
   await expect(page.getByTestId("journey-layer")).toBeVisible({ timeout: 5_000 });
   await expect(page.getByTestId("journey-progress")).toBeVisible();
-  await expect(page.getByTestId("journey-progress")).not.toHaveText("0% complete");
-  await expect(page.getByTestId("journey-rail-node-create-first-spec")).toHaveAttribute(
-    "data-attained",
-    "true",
-  );
+  // spec-433: create-spec is FIRST_STEP_ID → rail is hidden when the user is on it
+  // (mcpConnected=false means server returns create-spec as the current step).
+  // The anti-flicker proof pivots to the progress bar: with identityConfirmed=true and
+  // hasSpec=true, create-first-spec is attained → 1/2 visible steps = 50%, painted on
+  // the first commit from the shared assessment, never a 0% frame.
+  await expect(page.getByTestId("journey-progress")).toHaveText("50% complete");
   // NB: the content panel's step component (its own Create→Created / Connect→Connected
   // done-flip — the real flicker site) is proven seeded-before-draw at the unit level
-  // (CreateFirstSpecStep / CreateSpecStep tests). Which step shows here depends on the
-  // user's milestone profile (this fixture has a spec but no MCP, so the displayed step is
-  // the genuinely-not-connected create-spec), so the content-done assertion lives in units.
+  // (CreateFirstSpecStep / CreateSpecStep tests). This fixture has a spec but no MCP, so
+  // the displayed step is the genuinely-not-connected create-spec; content-done assertion lives in units.
 });

--- a/packages/ui/e2e/journey-41-spec-324-anon-telemetry.spec.ts
+++ b/packages/ui/e2e/journey-41-spec-324-anon-telemetry.spec.ts
@@ -38,17 +38,18 @@ test.afterEach(async ({}, testInfo) => {
 test("clicking a journey step's CTA records home_canvas.cta_clicked", async ({ page }) => {
   await ensureUser(DEV_EMAIL);
   await setUserName(DEV_EMAIL, DEV_NAME);
-  await setIdentityConfirmed(DEV_EMAIL, false); // un-confirm → needsOnboarding → identity step
+  await setIdentityConfirmed(DEV_EMAIL, false); // un-confirm → roleCoords=null → server returns 'identity' → clamped to create-spec
 
   // Arm the assertion before the click: capture the journey-event POST for a 'cta'.
-  // spec-336: the v2 arc opens on the bespoke identity step; its Continue button records
-  // home_canvas.cta_clicked (step 'identity', cta 'submit_identity').
+  // spec-433: the identity step is hidden; the first visible step is create-spec.
+  // Its primary CTA ("copy-explore-prompt") records home_canvas.cta_clicked
+  // (step 'create-spec', cta 'copy_explore_prompt').
   const ctaEvent = page.waitForRequest(
     (req) => {
       if (req.method() !== "POST" || !req.url().includes("/api/me/journey-event")) return false;
       try {
         const body = JSON.parse(req.postData() ?? "{}");
-        return body.action === "cta" && body.step === "identity";
+        return body.action === "cta" && body.step === "create-spec";
       } catch {
         return false;
       }
@@ -58,27 +59,15 @@ test("clicking a journey step's CTA records home_canvas.cta_clicked", async ({ p
 
   await page.goto(bareUrl("/home"));
 
-  // A brand-new user lands on the bespoke identity step (a custom-component step, not the
-  // generic shell).
-  await expect(page.getByTestId("journey-step-identity")).toBeVisible({ timeout: 15_000 });
+  // spec-433: a brand-new user lands on create-spec (not identity).
+  await expect(page.getByTestId("journey-step-create-spec")).toBeVisible({ timeout: 15_000 });
 
-  // Click its primary CTA ("Continue") — it records home_canvas.cta_clicked.
-  await page.getByTestId("identity-continue").click();
+  // Click the primary CTA — it records home_canvas.cta_clicked.
+  await page.getByTestId("copy-explore-prompt").click();
 
   const req = await ctaEvent;
   const body = JSON.parse(req.postData()!);
-  expect(body.step).toBe("identity");
+  expect(body.step).toBe("create-spec");
   expect(body.action).toBe("cta");
-  expect(body.cta).toBe("submit_identity");
-
-  // And the click functionally advanced the canvas — the CTA still works, not just emits.
-  // We assert the identity step is left behind rather than that a SPECIFIC next step
-  // (create-spec) appears: which step is current is milestone-DERIVED (HomeCanvas /
-  // spec-336 follows getUserJourneyState), and create-spec is current only while
-  // `hasSpec` is false. `hasSpec` counts ANY non-demo spec the shared dev@memex.ai user
-  // has authored across ALL memexes (journey-state.ts), so a parallel journey holding a
-  // spec legitimately attains create-spec and the canvas skips it — a cross-journey race
-  // on shared state, not a CTA regression. Asserting "advanced off identity" proves the
-  // CTA's effect without coupling to the dev user's spec count.
-  await expect(page.getByTestId("journey-step-identity")).toBeHidden({ timeout: 10_000 });
+  expect(body.cta).toBe("copy_explore_prompt");
 });

--- a/packages/ui/src/journeys/onboarding/steps.tsx
+++ b/packages/ui/src/journeys/onboarding/steps.tsx
@@ -23,7 +23,8 @@ export const BUILDER_ONLY_STEP_IDS = ['specs-match-reality', 'agents-build'] as 
 
 // spec-421 — steps hidden from the rail. Their components are never mounted while hidden
 // so no telemetry, done-state badges, or completion machinery fires.
-export const HIDDEN_STEP_IDS = ['resolve-decision', 'add-ac', 'specs-match-reality', 'agents-build'] as const;
+// spec-433 — 'identity' (About You) added: new users land directly on 'create-spec'.
+export const HIDDEN_STEP_IDS = ['identity', 'resolve-decision', 'add-ac', 'specs-match-reality', 'agents-build'] as const;
 
 export const ONBOARDING_STEP_VIEWS: Record<string, JourneyStepView> = {
   // Step 0 — About you. Rendered by IdentityStep (the role triangle) in HomeCanvas.

--- a/packages/ui/src/pages/HomeCanvas.spec-421-issue2.test.tsx
+++ b/packages/ui/src/pages/HomeCanvas.spec-421-issue2.test.tsx
@@ -66,7 +66,9 @@ function stateFor(currentStepId: string, attained: readonly string[] = []) {
 }
 
 const GRADUATED = stateFor('create-first-spec', ['identity', 'create-spec', 'create-first-spec']);
-const IN_PROGRESS = stateFor('create-spec', ['identity']);
+// spec-433: identity is now hidden; 2 visible steps (create-spec, create-first-spec).
+// In-progress = create-spec attained (1/2 visible = 50%); server on create-first-spec so rail shows.
+const IN_PROGRESS = stateFor('create-first-spec', ['create-spec']);
 
 function deferred<T>() {
   let resolve!: (v: T) => void;
@@ -124,10 +126,10 @@ describe('spec-421 issue-2 — assess journey-state before draw (in-memory, shar
 
     renderCanvas();
 
-    // 1 of 3 visible steps attained → 33%, painted on the first commit.
-    expect(screen.getByTestId('journey-progress')).toHaveTextContent('33% complete');
-    expect(screen.getByTestId('journey-rail-node-identity').getAttribute('data-attained')).toBe('true');
-    expect(screen.getByTestId('journey-rail-node-create-spec').getAttribute('data-attained')).toBe('false');
+    // spec-433: 1 of 2 visible steps attained → 50%, painted on the first commit.
+    expect(screen.getByTestId('journey-progress')).toHaveTextContent('50% complete');
+    expect(screen.getByTestId('journey-rail-node-create-spec').getAttribute('data-attained')).toBe('true');
+    expect(screen.getByTestId('journey-rail-node-create-first-spec').getAttribute('data-attained')).toBe('false');
   });
 
   it('cold load with no prior assessment shows no tracker (never a wrong/0% frame) until the read resolves (ac-23)', async () => {

--- a/packages/ui/src/pages/HomeCanvas.test.tsx
+++ b/packages/ui/src/pages/HomeCanvas.test.tsx
@@ -50,10 +50,11 @@ import { HomeCanvas } from './HomeCanvas';
 const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-336/acs/ac-${n}`;
 const AC344 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-344/acs/ac-${n}`;
 const AC372 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-372/acs/ac-${n}`;
+const AC433 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-433/acs/ac-${n}`;
 
-// spec-421: create-first-spec added between create-spec and resolve-decision.
-// Steps 3-6 (resolve-decision, add-ac, specs-match-reality, agents-build) are hidden from
-// the rail by HIDDEN_STEP_IDS; the 3 visible steps are identity, create-spec, create-first-spec.
+// spec-433: identity hidden. spec-421: create-first-spec added.
+// HIDDEN_STEP_IDS = [identity, resolve-decision, add-ac, specs-match-reality, agents-build].
+// 2 visible steps: create-spec (FIRST_STEP_ID, full-width no-rail) and create-first-spec.
 const ALL_STEPS = [
   'identity',
   'create-spec',
@@ -64,8 +65,8 @@ const ALL_STEPS = [
   'agents-build',
 ] as const;
 
-const VISIBLE_STEPS = ['identity', 'create-spec', 'create-first-spec'] as const;
-const HIDDEN_STEPS = ['resolve-decision', 'add-ac', 'specs-match-reality', 'agents-build'] as const;
+const VISIBLE_STEPS = ['create-spec', 'create-first-spec'] as const;
+const HIDDEN_STEPS = ['identity', 'resolve-decision', 'add-ac', 'specs-match-reality', 'agents-build'] as const;
 
 const DEV_HEAVY = { dev: 0.9, design: 0.05, pm: 0.05 }; // → "All-in builder"
 const DESIGN_HEAVY = { dev: 0.05, design: 0.9, pm: 0.05 }; // → "Pure designer" (non-builder)
@@ -122,44 +123,68 @@ beforeEach(() => {
 });
 
 describe('HomeCanvas v2 — persistent rail + content panel (ac-1, ac-2, ac-8, ac-9)', () => {
-  it('opens a new user full-width on step 0 (the identity triangle); the rail is hidden until they advance', async () => {
-    tagAc(AC(2));
-    tagAc(AC(8));
-    tagAc(AC344(3)); // a normal (non-staff) user's journey renders unchanged by spec-344
+  it('server returning hidden identity step for brand-new user clamps forward to create-spec (ac-1, ac-7, spec-433)', async () => {
+    tagAc(AC433(1));
+    tagAc(AC433(7)); // clampToVisible maps hidden identity → first visible step (create-spec)
+    // Brand-new user: identityConfirmed=false → server returns currentStepId='identity'.
+    // clampToVisible detects identity precedes the first visible step (create-spec) and
+    // returns create-spec instead of the default last-visible fallback.
     fetchJourneyStateApi.mockResolvedValue(stateFor('identity'));
     renderCanvas();
 
+    expect(await screen.findByTestId('journey-step-create-spec')).toBeInTheDocument();
+    expect(screen.queryByTestId('journey-step-identity')).toBeNull();
+    expect(screen.queryByTestId('journey-rail')).toBeNull();
+  });
+
+  it('opens a new user full-width on step 0 (create-spec, Connect MCP); the rail is hidden until they advance', async () => {
+    tagAc(AC(2));
+    tagAc(AC(8));
+    tagAc(AC344(3)); // a normal (non-staff) user's journey renders unchanged by spec-344
+    tagAc(AC433(3)); // display name drawn from SSO identity — no prompt to confirm/edit
+    tagAc(AC433(6)); // FIRST_STEP_ID = 'create-spec' → full-width no-rail layout
+    // spec-433: identity is hidden; create-spec is FIRST_STEP_ID (full-width, no rail).
+    fetchJourneyStateApi.mockResolvedValue(stateFor('create-spec'));
+    renderCanvas();
+
     expect(await screen.findByTestId('getting-started-title')).toBeInTheDocument();
-    // Step 0 ("About you") is full-width — the rail only reveals once past it (ac-2/ac-8).
-    expect(screen.getByTestId('journey-step-identity')).toBeInTheDocument();
-    expect(screen.getByTestId('role-triangle')).toBeInTheDocument();
-    expect(screen.getByTestId('persona-label')).toBeInTheDocument();
+    // create-spec is full-width on step 0 — the rail only reveals on create-first-spec (ac-2/ac-8).
+    expect(screen.getByTestId('journey-step-create-spec')).toBeInTheDocument();
+    expect(screen.getByTestId('connect-stage')).toBeInTheDocument();
+    // No role triangle, no name input (identity step is hidden — ac-1 / ac-3).
+    expect(screen.queryByTestId('journey-step-identity')).toBeNull();
+    expect(screen.queryByTestId('role-triangle')).toBeNull();
     expect(screen.queryByTestId('journey-rail')).toBeNull();
     // A progress indicator at 0% for a brand-new user (derived, dec-6).
     expect(screen.getByTestId('journey-progress')).toHaveTextContent('0% complete');
   });
 
-  it('past step 0, shows 3 visible nodes in the rail; hidden steps have no rail nodes (spec-421)', async () => {
+  it('past step 0, shows 2 visible nodes in the rail; hidden steps have no rail nodes (spec-421, spec-433)', async () => {
     const AC421 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-421/acs/ac-${n}`;
     tagAc(AC(1));
     tagAc(AC(9));
-    tagAc(AC421(2)); // rail shows 3 nodes
+    tagAc(AC421(2)); // rail shows visible nodes (2 after spec-433)
     tagAc(AC421(3)); // hidden steps have no rail nodes
-    fetchJourneyStateApi.mockResolvedValue(stateFor('create-spec', { attained: ['identity'] }));
+    tagAc(AC433(2)); // rail shows exactly 2 steps (Connect MCP + Create First Spec)
+    tagAc(AC433(5)); // identity is in HIDDEN_STEP_IDS → absent from rail
+    // spec-433: create-spec is FIRST_STEP_ID (no rail). Rail reveals on create-first-spec.
+    // Use attained:[] so the create-spec subtitle is not collapsed (subtitle hides when
+    // attained+not-selected; with no attainment both nodes show their subtitles).
+    fetchJourneyStateApi.mockResolvedValue(stateFor('create-first-spec', { attained: [] }));
     renderCanvas();
 
     expect(await screen.findByTestId('journey-rail')).toBeInTheDocument();
-    // spec-421: 3 visible nodes in the rail.
+    // spec-433: 2 visible nodes in the rail (identity is now hidden).
     for (const id of VISIBLE_STEPS) {
       expect(screen.getByTestId(`journey-rail-node-${id}`)).toBeInTheDocument();
     }
-    // Hidden steps are absent from the rail.
+    // Hidden steps (including identity) are absent from the rail.
     for (const id of HIDDEN_STEPS) {
       expect(screen.queryByTestId(`journey-rail-node-${id}`)).toBeNull();
     }
     expect(screen.getByTestId('journey-content')).toBeInTheDocument();
-    expect(screen.getByTestId('journey-step-create-spec')).toBeInTheDocument();
-    // ac-13: step 2 rail subtitle reads "Connect to MCP to get the full magic of Memex".
+    expect(screen.getByTestId('journey-step-create-first-spec')).toBeInTheDocument();
+    // ac-13: create-spec rail node label and subtitle.
     tagAc(AC421(13));
     const createSpecNode = screen.getByTestId('journey-rail-node-create-spec');
     expect(createSpecNode.textContent).toContain('Connect to the Memex MCP');
@@ -168,28 +193,27 @@ describe('HomeCanvas v2 — persistent rail + content panel (ac-1, ac-2, ac-8, a
 });
 
 describe('HomeCanvas v2 — viewing is free and decoupled from attainment (ac-13, ac-14)', () => {
-  it('clicking a later step views it without changing any orb or the %', async () => {
+  it('clicking a step views it without changing any orb or the %', async () => {
     tagAc(AC(6));
     tagAc(AC(13));
     tagAc(AC(14));
-    // spec-421: identity attained → 1/3 visible ≈ 33% (3 visible steps total).
-    fetchJourneyStateApi.mockResolvedValue(stateFor('create-spec', { attained: ['identity'] }));
+    // spec-433: 2 visible steps. Rail shows on create-first-spec; 0/2 attained → 0%.
+    fetchJourneyStateApi.mockResolvedValue(stateFor('create-first-spec', { attained: [] }));
     renderCanvas();
 
     await screen.findByTestId('journey-rail');
     const pctBefore = screen.getByTestId('journey-progress').textContent;
-    expect(pctBefore).toBe('33% complete');
-    // create-first-spec is visible and not attained.
-    expect(screen.getByTestId('journey-rail-node-create-first-spec').getAttribute('data-attained')).toBe('false');
+    expect(pctBefore).toBe('0% complete');
+    // create-spec is visible and not attained.
+    expect(screen.getByTestId('journey-rail-node-create-spec').getAttribute('data-attained')).toBe('false');
 
-    // View a step the user is nowhere near — free navigation, no gating.
-    fireEvent.click(screen.getByTestId('journey-rail-node-create-first-spec'));
-    expect(await screen.findByTestId('journey-step-create-first-spec')).toBeInTheDocument();
+    // View create-spec via free navigation (rail node click) — no gating.
+    // create-spec is FIRST_STEP_ID, so the rail hides after selection; content still renders.
+    fireEvent.click(screen.getByTestId('journey-rail-node-create-spec'));
+    expect(await screen.findByTestId('journey-step-create-spec')).toBeInTheDocument();
 
-    // Neither the % nor that step's orb changed from merely viewing it.
+    // % did NOT change from merely clicking (no attainment event fired).
     expect(screen.getByTestId('journey-progress').textContent).toBe(pctBefore);
-    expect(screen.getByTestId('journey-rail-node-create-first-spec').getAttribute('data-attained')).toBe('false');
-    expect(screen.getByTestId('journey-rail-node-identity').getAttribute('data-attained')).toBe('true');
   });
 });
 
@@ -197,23 +221,23 @@ describe('HomeCanvas v2 — remembered cursor + no restart (ac-15)', () => {
   it('remembers the last-viewed step across a remount and exposes no restart control', async () => {
     tagAc(AC(6));
     tagAc(AC(15));
-    // Start past step 0 so the rail is shown and navigable.
-    fetchJourneyStateApi.mockResolvedValue(stateFor('create-spec', { attained: ['identity'] }));
+    // spec-433: rail shows on create-first-spec. Navigate back to create-spec (FIRST_STEP_ID).
+    fetchJourneyStateApi.mockResolvedValue(stateFor('create-first-spec', { attained: [] }));
     const { unmount } = renderCanvas();
 
     await screen.findByTestId('journey-rail');
-    // spec-421: navigate to create-first-spec (visible; add-ac is now hidden).
-    fireEvent.click(screen.getByTestId('journey-rail-node-create-first-spec'));
-    expect(await screen.findByTestId('journey-step-create-first-spec')).toBeInTheDocument();
+    // Navigate to create-spec from the rail; create-spec is FIRST_STEP_ID so rail hides.
+    fireEvent.click(screen.getByTestId('journey-rail-node-create-spec'));
+    expect(await screen.findByTestId('journey-step-create-spec')).toBeInTheDocument();
     // No restart control anywhere.
     expect(screen.queryByText(/restart/i)).toBeNull();
     expect(screen.queryByTestId('journey-restart')).toBeNull();
 
     unmount();
 
-    // Next visit lands back on the remembered step.
+    // Next visit lands back on the remembered step (create-spec, not yet attained).
     renderCanvas();
-    expect(await screen.findByTestId('journey-step-create-first-spec')).toBeInTheDocument();
+    expect(await screen.findByTestId('journey-step-create-spec')).toBeInTheDocument();
   });
 
   it('does NOT strand a returning user on a remembered step they have already completed', async () => {
@@ -229,37 +253,39 @@ describe('HomeCanvas v2 — remembered cursor + no restart (ac-15)', () => {
 });
 
 describe('HomeCanvas v2 — role branching (ac-7, ac-10, ac-11) — spec-421 updates', () => {
-  it('spec-421: both builder and non-builder see the same 3 visible nodes; no divider (hidden steps override builder-only)', async () => {
-    // spec-336 dec-3 builder branching is superseded by spec-421 HIDDEN_STEP_IDS for steps 3-6.
-    // Both personas now see [identity, create-spec, create-first-spec]; no build-from-codebase divider.
+  it('spec-421: both builder and non-builder see the same 2 visible nodes; no divider (hidden steps override builder-only)', async () => {
+    // spec-336 dec-3 builder branching superseded by HIDDEN_STEP_IDS; spec-433 also hides identity.
+    // Both personas now see [create-spec, create-first-spec]; no build-from-codebase divider.
     tagAc(AC(7));
     tagAc(AC(10));
     tagAc(AC(11));
     const AC421 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-421/acs/ac-${n}`;
     tagAc(AC421(2));
     tagAc(AC421(3));
-    fetchJourneyStateApi.mockResolvedValue(stateFor('create-spec', { roleCoords: DEV_HEAVY, attained: ['identity'] }));
+    // spec-433: rail shows on create-first-spec (create-spec is FIRST_STEP_ID).
+    fetchJourneyStateApi.mockResolvedValue(stateFor('create-first-spec', { roleCoords: DEV_HEAVY, attained: ['create-spec'] }));
     renderCanvas();
 
     await screen.findByTestId('journey-rail');
-    // All 3 visible steps present for a builder.
+    // Both 2 visible steps present for a builder.
     for (const id of VISIBLE_STEPS) {
       expect(screen.getByTestId(`journey-rail-node-${id}`)).toBeInTheDocument();
     }
-    // Builder-only steps are hidden (they're in HIDDEN_STEP_IDS).
-    expect(screen.queryByTestId('journey-rail-node-specs-match-reality')).toBeNull();
-    expect(screen.queryByTestId('journey-rail-node-agents-build')).toBeNull();
+    // All hidden steps are absent from the rail (including identity).
+    for (const id of HIDDEN_STEPS) {
+      expect(screen.queryByTestId(`journey-rail-node-${id}`)).toBeNull();
+    }
     // No divider since specs-match-reality is hidden.
     expect(screen.queryByTestId('rail-divider-build')).toBeNull();
   });
 
-  it('spec-421: a non-builder persona also sees 3 steps; hidden steps absent; % over 3', async () => {
+  it('spec-421: a non-builder persona also sees 2 steps; hidden steps absent; % over 2', async () => {
     tagAc(AC(7));
     tagAc(AC(10));
     tagAc(AC(11));
-    // identity + create-spec attained (2 of 3 visible) → 67%.
+    // spec-433: create-spec attained (1 of 2 visible) → 50%.
     fetchJourneyStateApi.mockResolvedValue(
-      stateFor('create-first-spec', { roleCoords: DESIGN_HEAVY, attained: ['identity', 'create-spec'] }),
+      stateFor('create-first-spec', { roleCoords: DESIGN_HEAVY, attained: ['create-spec'] }),
     );
     renderCanvas();
 
@@ -267,11 +293,12 @@ describe('HomeCanvas v2 — role branching (ac-7, ac-10, ac-11) — spec-421 upd
     for (const id of VISIBLE_STEPS) {
       expect(screen.getByTestId(`journey-rail-node-${id}`)).toBeInTheDocument();
     }
+    expect(screen.queryByTestId('journey-rail-node-identity')).toBeNull();
     expect(screen.queryByTestId('journey-rail-node-add-ac')).toBeNull();
     expect(screen.queryByTestId('journey-rail-node-specs-match-reality')).toBeNull();
     expect(screen.queryByTestId('journey-rail-node-agents-build')).toBeNull();
     expect(screen.queryByTestId('rail-divider-build')).toBeNull();
-    expect(screen.getByTestId('journey-progress')).toHaveTextContent('67% complete');
+    expect(screen.getByTestId('journey-progress')).toHaveTextContent('50% complete');
   });
 });
 
@@ -302,17 +329,17 @@ describe('HomeCanvas v2 — non-builder handoff (ac-12) — spec-421: always abs
 describe('HomeCanvas rail — done steps collapse + dim (spec-372 issue-10)', () => {
   it('a done step you have moved past dims its title; the selected step stays prominent', async () => {
     tagAc(AC372(38));
-    // Viewing create-spec with identity attained: identity is done + NOT selected → dimmed;
-    // create-spec is the selected step → heading colour (not dimmed).
-    fetchJourneyStateApi.mockResolvedValue(stateFor('create-spec', { attained: ['identity'] }));
+    // spec-433: Viewing create-first-spec with create-spec attained.
+    // create-spec is done + NOT selected → dimmed; create-first-spec is selected → prominent.
+    fetchJourneyStateApi.mockResolvedValue(stateFor('create-first-spec', { attained: ['create-spec'] }));
     renderCanvas();
     await screen.findByTestId('journey-rail');
 
     // The title is the first font-semibold span in the node (label text varies via views).
-    const doneTitle = screen.getByTestId('journey-rail-node-identity').querySelector('span.font-semibold');
+    const doneTitle = screen.getByTestId('journey-rail-node-create-spec').querySelector('span.font-semibold');
     expect(doneTitle?.className).toContain('text-muted');
 
-    const selectedTitle = screen.getByTestId('journey-rail-node-create-spec').querySelector('span.font-semibold');
+    const selectedTitle = screen.getByTestId('journey-rail-node-create-first-spec').querySelector('span.font-semibold');
     expect(selectedTitle?.className).toContain('text-heading');
     expect(selectedTitle?.className).not.toContain('text-muted');
   });
@@ -323,7 +350,8 @@ describe('HomeCanvas v2 — tracker is always expanded (spec-372 issue-8)', () =
     tagAc(AC(6));
     tagAc(AC(16));
     tagAc(AC372(36));
-    fetchJourneyStateApi.mockResolvedValue(stateFor('create-spec', { roleCoords: DEV_HEAVY, attained: ['identity'] }));
+    // spec-433: rail shows on create-first-spec.
+    fetchJourneyStateApi.mockResolvedValue(stateFor('create-first-spec', { roleCoords: DEV_HEAVY, attained: ['create-spec'] }));
     renderCanvas();
 
     await screen.findByTestId('journey-rail');
@@ -425,5 +453,29 @@ describe('HomeCanvas v2 — operator preview removed (spec-344) + document.title
     renderCanvas();
     await screen.findByTestId('getting-started-title');
     expect(document.title).toBe('Home');
+  });
+});
+
+describe('HomeCanvas — spec-433 dormant code (ac-4)', () => {
+  it('IdentityStep and RoleTriangle remain importable (dormant, not deleted)', async () => {
+    tagAc(AC433(4));
+    // Import the components dynamically to assert they are still present in the bundle.
+    // This is a static existence check — the components are dormant but not removed.
+    const { IdentityStep } = await import('../components/home/IdentityStep');
+    const { personaLabel } = await import('../components/home/RoleTriangle');
+    expect(IdentityStep).toBeDefined();
+    expect(personaLabel).toBeDefined();
+  });
+});
+
+describe('HomeCanvas — spec-434 intact voice infrastructure (ac-4)', () => {
+  it('Specky component and voice session pipeline remain importable — no voice code removed', async () => {
+    const AC434 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-434/acs/ac-${n}`;
+    tagAc(AC434(4));
+    const { Specky } = await import('@memex/guide-sdk');
+    const { VoiceSessionPill, VoiceIcon } = await import('@memex/guide-sdk');
+    expect(Specky).toBeDefined();
+    expect(VoiceSessionPill).toBeDefined();
+    expect(VoiceIcon).toBeDefined();
   });
 });

--- a/packages/ui/src/pages/HomeCanvas.tsx
+++ b/packages/ui/src/pages/HomeCanvas.tsx
@@ -54,8 +54,8 @@ import type { JourneyCta, JourneyStepView } from '../journeys/types';
 type NavMembership = { slug: string; memexSlug?: string | null; kind: string };
 
 // The first step is rendered full-width with no rail (spec-336 / prototype: the rail
-// reveals once the user is past "About you").
-const FIRST_STEP_ID = 'identity';
+// reveals once the user is past step 0). spec-433: identity hidden, first visible step is create-spec.
+const FIRST_STEP_ID = 'create-spec';
 
 function firstName(name: string | null | undefined): string | null {
   if (!name) return null;
@@ -189,9 +189,14 @@ export function HomeCanvas() {
   const clampToVisible = useCallback(
     (id: string | null): string | null => {
       if (id && visibleIds.includes(id)) return id;
-      return visibleIds.length ? visibleIds[visibleIds.length - 1] : id;
+      if (!visibleIds.length) return id;
+      const allIds = state?.steps?.map((s) => s.id) ?? [];
+      const hiddenIdx = id != null ? allIds.indexOf(id) : Infinity;
+      const firstVisibleIdx = allIds.indexOf(visibleIds[0]);
+      if (hiddenIdx < firstVisibleIdx) return visibleIds[0];
+      return visibleIds[visibleIds.length - 1];
     },
-    [visibleIds],
+    [visibleIds, state],
   );
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

- Adds `'identity'` to `HIDDEN_STEP_IDS` in `steps.tsx` — the "About you" step never renders in the rail or content panel
- Changes `FIRST_STEP_ID` from `'identity'` to `'create-spec'` in `HomeCanvas.tsx` — new users land full-width on `create-spec` with no rail
- Fixes `clampToVisible` in `HomeCanvas.tsx` — when the server returns a hidden step whose position precedes the first visible step (e.g. `identity` before `create-spec`), maps forward to the first visible step
- Updates 4 e2e journeys (34, 34b, 41, 19) to assert `create-spec` as the new user landing step

## Test plan

- [x] `make e2e-cold` — 115 pass, 1 known flaky (journey-45, passes on retry)
- [x] Unit tests: `HomeCanvas.test.tsx` — new clamp regression + ac-7 test green
- [x] Unit tests: `HomeCanvas.spec-421-issue2.test.tsx` — updated for 2-visible-step model

🤖 Generated with [Claude Code](https://claude.com/claude-code)