### PR TITLE
feat(spec-434): gate Specky greeting on mcpConnected AND hasSpec

### DIFF
--- a/packages/server/src/routes/onboarding-backfill.api.test.ts
+++ b/packages/server/src/routes/onboarding-backfill.api.test.ts
@@ -35,9 +35,11 @@ vi.hoisted(() => {
 
 import { db } from "../db/connection.js";
 import { app } from "../app.js";
-import { users } from "../db/schema.js";
+import { users, documents } from "../db/schema.js";
 import { upsertUserByEmail, getUserById } from "../services/users.js";
 import { signSessionToken } from "../services/auth-jwt.js";
+import { recordMcpConnected } from "../services/funnel-events.js";
+import { makeTestMemex } from "../services/test-helpers.js";
 import { tagAc } from "@memex-ai-ac/vitest";
 
 const AC = (n: number) =>
@@ -111,7 +113,20 @@ describe("onboarding_greeted_at backfill (spec-213 t-1)", () => {
   it("a pre-existing (null) user is stamped by the backfill → greet=false", async () => {
     tagAc(AC(6));
     const u = await makeUser("sp213-existing");
-    // Pre-existing user: null flag, so the gate would greet them.
+    // Pre-existing user: null flag. spec-434: gate also requires mcpConnected+hasSpec,
+    // so seed both to make this a faithful "would greet → backfill prevents it" probe.
+    await recordMcpConnected(u.id);
+    const memexId = await makeTestMemex("sp213bt");
+    await db.insert(documents).values({
+      memexId,
+      title: "Backfill test spec",
+      status: "draft",
+      handle: "spec-1",
+      docType: "spec",
+      isDemo: false,
+      createdByUserId: u.id,
+      statusChangedAt: new Date(),
+    });
     expect((await getUserById(u.id))!.onboardingGreetedAt).toBeNull();
     expect(await greet(u.bearer)).toBe(true);
 
@@ -130,8 +145,22 @@ describe("onboarding_greeted_at backfill (spec-213 t-1)", () => {
     expect((await getUserById(existing.id))!.onboardingGreetedAt).toBeInstanceOf(Date);
 
     // ...then a brand-new signup arrives. It was NOT in the backfill set, so its
-    // flag is null and the spec-206 first-run greeting still fires for it.
+    // flag is null and the spec-206 first-run greeting fires when they are ready.
+    // spec-434: gate requires mcpConnected+hasSpec — seed both to prove null flag
+    // preserves greet eligibility for new signups once they reach that milestone.
     const newcomer = await makeUser("sp213-newcomer");
+    await recordMcpConnected(newcomer.id);
+    const ncMemexId = await makeTestMemex("sp213nc");
+    await db.insert(documents).values({
+      memexId: ncMemexId,
+      title: "Newcomer test spec",
+      status: "draft",
+      handle: "spec-1",
+      docType: "spec",
+      isDemo: false,
+      createdByUserId: newcomer.id,
+      statusChangedAt: new Date(),
+    });
     expect((await getUserById(newcomer.id))!.onboardingGreetedAt).toBeNull();
     expect(await greet(newcomer.bearer)).toBe(true);
   });

--- a/packages/server/src/routes/onboarding.api.test.ts
+++ b/packages/server/src/routes/onboarding.api.test.ts
@@ -25,7 +25,7 @@ vi.hoisted(() => {
 
 import { db } from "../db/connection.js";
 import { app } from "../app.js";
-import { users } from "../db/schema.js";
+import { users, documents } from "../db/schema.js";
 import { eq } from "drizzle-orm";
 import {
   upsertUserByEmail,
@@ -33,6 +33,8 @@ import {
   getUserById,
 } from "../services/users.js";
 import { signSessionToken } from "../services/auth-jwt.js";
+import { recordMcpConnected } from "../services/funnel-events.js";
+import { makeTestMemex } from "../services/test-helpers.js";
 import { tagAc } from "@memex-ai-ac/vitest";
 
 const AC = (n: number) =>
@@ -80,9 +82,25 @@ describe("first-run greeting gate (spec-206 t-1)", () => {
     expect(row!.onboardingGreetedAt).toBeNull();
   });
 
-  it("GET returns greet=true while ungreeted, greet=false once stamped", async () => {
+  it("GET returns greet=true while ungreeted (with MCP+spec), greet=false once stamped", async () => {
     tagAc(AC(13));
     const { id, bearer } = await makeUser("sp206-gate", "Ryan Soosayraj");
+
+    // spec-434: gate also requires mcpConnected AND hasSpec. Seed both so this
+    // test remains a faithful probe of the "ungreeted → greet=true" path.
+    await recordMcpConnected(id);
+    const memexId = await makeTestMemex("sp206gate");
+    createdUserIds.push(); // memex cleanup handled by user cascade
+    await db.insert(documents).values({
+      memexId,
+      title: "Gate test spec",
+      status: "draft",
+      handle: "spec-1",
+      docType: "spec",
+      isDemo: false,
+      createdByUserId: id,
+      statusChangedAt: new Date(),
+    });
 
     const before = await getGreeting(bearer);
     expect(before.status).toBe(200);
@@ -122,8 +140,9 @@ describe("first-run greeting gate (spec-206 t-1)", () => {
 
     // B was never stamped by A's calls — cross-user isolation.
     expect((await getUserById(b.id))!.onboardingGreetedAt).toBeNull();
+    // spec-434: a fresh user without MCP+spec gets greet=false (not greet=true).
     const bGate = await getGreeting(b.bearer);
-    expect((await bGate.json()).greet).toBe(true);
+    expect((await bGate.json()).greet).toBe(false);
 
     // Anonymous (no Bearer) is 401'd before the handler — cannot read or stamp.
     expect((await getGreeting()).status).toBe(401);

--- a/packages/server/src/routes/onboarding.ts
+++ b/packages/server/src/routes/onboarding.ts
@@ -21,6 +21,7 @@
 import { Hono } from "hono";
 import { sessionMiddleware, type SessionEnv } from "../middleware/session.js";
 import { markOnboardingGreeted } from "../services/users.js";
+import { getUserMilestones } from "../services/journey-state.js";
 
 const onboarding = new Hono<SessionEnv>();
 
@@ -34,10 +35,16 @@ export function deriveFirstName(name: string | null | undefined): string | null 
   return first ? first : null;
 }
 
-onboarding.get("/greeting", (c) => {
+// spec-434: gate greeting on mcpConnected AND hasSpec — Specky only appears once the
+// user has connected MCP and created their first Spec (both conditions must be met).
+onboarding.get("/greeting", async (c) => {
   const user = c.get("user");
+  if (user.onboardingGreetedAt != null) {
+    return c.json({ greet: false, firstName: deriveFirstName(user.name) });
+  }
+  const milestones = await getUserMilestones(user.id);
   return c.json({
-    greet: user.onboardingGreetedAt == null,
+    greet: milestones.mcpConnected && milestones.hasSpec,
     firstName: deriveFirstName(user.name),
   });
 });

--- a/packages/server/src/routes/spec-433-434.api.test.ts
+++ b/packages/server/src/routes/spec-433-434.api.test.ts
@@ -11,7 +11,7 @@
 // Runs against a REAL Postgres through the full Hono app + strict sessionMiddleware.
 
 import { describe, it, expect, afterAll, vi } from "vitest";
-import { inArray, eq } from "drizzle-orm";
+import { inArray } from "drizzle-orm";
 
 vi.hoisted(() => {
   process.env.GOOGLE_CLIENT_ID = "test-client.apps.googleusercontent.com";

--- a/packages/server/src/routes/spec-433-434.api.test.ts
+++ b/packages/server/src/routes/spec-433-434.api.test.ts
@@ -1,0 +1,136 @@
+// Integration tests for spec-434 (hide Specky for new users until MCP connected + first spec).
+//
+// spec-434:
+//   ac-1  — new user: no auto-greeting, no voice session initiated
+//   ac-2  — Specky activates normally for graduated users (mcpConnected AND hasSpec)
+//   ac-3  — pre-existing greeted users see no change in Specky's behaviour
+//   ac-5  — GET /api/onboarding/greeting returns greet=false for an ungreeted user who
+//           has NOT yet connected MCP.
+//   ac-6  — GET returns greet=true for an ungreeted user who HAS connected MCP AND hasSpec.
+//
+// Runs against a REAL Postgres through the full Hono app + strict sessionMiddleware.
+
+import { describe, it, expect, afterAll, vi } from "vitest";
+import { inArray, eq } from "drizzle-orm";
+
+vi.hoisted(() => {
+  process.env.GOOGLE_CLIENT_ID = "test-client.apps.googleusercontent.com";
+  process.env.AUTH_JWT_SECRET = process.env.AUTH_JWT_SECRET ?? "x".repeat(48);
+  return undefined;
+});
+
+import { db } from "../db/connection.js";
+import { app } from "../app.js";
+import { users, documents } from "../db/schema.js";
+import { upsertUserByEmail } from "../services/users.js";
+import { signSessionToken } from "../services/auth-jwt.js";
+import { recordMcpConnected } from "../services/funnel-events.js";
+import { makeTestMemex } from "../services/test-helpers.js";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+const AC434 = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-434/acs/ac-${n}`;
+
+const createdUserIds: string[] = [];
+const createdMemexIds: string[] = [];
+
+function uniqueEmail(prefix: string): string {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}@spec433434.test`;
+}
+
+async function makeUser(prefix: string) {
+  const user = await upsertUserByEmail(uniqueEmail(prefix));
+  createdUserIds.push(user.id);
+  return { id: user.id, bearer: signSessionToken(user.id) };
+}
+
+function getGreeting(bearer?: string) {
+  const headers = new Headers();
+  if (bearer) headers.set("Authorization", `Bearer ${bearer}`);
+  return app.request("/api/onboarding/greeting", { headers });
+}
+
+afterAll(async () => {
+  if (createdUserIds.length) {
+    await db.delete(users).where(inArray(users.id, createdUserIds));
+  }
+});
+
+// ── spec-434 ─────────────────────────────────────────────────────────────────
+
+describe("spec-434: greeting gate requires mcpConnected AND hasSpec", () => {
+  it("returns greet=false for an ungreeted user with no MCP connection and no spec", async () => {
+    tagAc(AC434(5));
+    tagAc(AC434(1)); // new user: no auto-greeting, no voice session initiated
+    const { bearer } = await makeUser("sp434-fresh");
+    const res = await getGreeting(bearer);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.greet).toBe(false);
+  });
+
+  it("returns greet=false for an ungreeted user with MCP connected but no spec", async () => {
+    tagAc(AC434(5));
+    tagAc(AC434(1));
+    const { id, bearer } = await makeUser("sp434-mcp-only");
+    await recordMcpConnected(id);
+    const res = await getGreeting(bearer);
+    expect((await res.json()).greet).toBe(false);
+  });
+
+  it("returns greet=true for an ungreeted user with MCP connected AND a spec created", async () => {
+    tagAc(AC434(6));
+    tagAc(AC434(2)); // Specky activates normally for graduated users
+    const { id, bearer } = await makeUser("sp434-graduated");
+    await recordMcpConnected(id);
+
+    // Seed a real spec document in a test memex owned by this user.
+    const memexId = await makeTestMemex("sp434");
+    createdMemexIds.push(memexId);
+    await db.insert(documents).values({
+      memexId,
+      title: "Test spec for greeting gate",
+      status: "draft",
+      handle: "spec-1",
+      docType: "spec",
+      isDemo: false,
+      createdByUserId: id,
+      statusChangedAt: new Date(),
+    });
+
+    const res = await getGreeting(bearer);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.greet).toBe(true);
+  });
+
+  it("returns greet=false once already stamped, even if mcpConnected and hasSpec", async () => {
+    tagAc(AC434(6));
+    tagAc(AC434(3)); // pre-existing greeted users see no change in Specky's behaviour
+    const { id, bearer } = await makeUser("sp434-already-greeted");
+    await recordMcpConnected(id);
+
+    const memexId = await makeTestMemex("sp434b");
+    createdMemexIds.push(memexId);
+    await db.insert(documents).values({
+      memexId,
+      title: "Test spec",
+      status: "draft",
+      handle: "spec-1",
+      docType: "spec",
+      isDemo: false,
+      createdByUserId: id,
+      statusChangedAt: new Date(),
+    });
+
+    // First call: greet=true; stamp it.
+    expect((await (await getGreeting(bearer)).json()).greet).toBe(true);
+    await app.request("/api/onboarding/greeting", {
+      method: "POST",
+      headers: new Headers({ Authorization: `Bearer ${bearer}` }),
+    });
+
+    // After stamp: greet=false.
+    expect((await (await getGreeting(bearer)).json()).greet).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- `GET /api/onboarding/greeting` now returns `greet: true` only when **both** `mcpConnected` and `hasSpec` are true — Specky stays silent for users who haven't yet connected MCP or created their first spec
- Previously a fresh ungreeted user always got `greet: true`, triggering the voice guide immediately on first visit
- `onboarding.api.test.ts` updated: existing "greet=true" test now seeds MCP + spec prerequisites; cross-user isolation test updated to assert `greet=false` for fresh users
- `spec-433-434.api.test.ts` (new): 4 integration tests covering greet=false (no MCP), greet=false (MCP only), greet=true (MCP + spec), idempotent stamp

## Test plan

- [x] Server integration tests: `pnpm --filter @memex/server test -- spec-433-434` — 4/4 pass
- [x] `onboarding.api.test.ts` — all existing tests still pass with updated prerequisites
- [x] ac-4 (voice infra intact): `HomeCanvas.test.tsx` `spec-434 intact voice infrastructure` test — green (covered in spec-433 PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)