### PR TITLE
fix(spec-436): wrap provisioning seeds in runWithMemexId so documents RLS passes (empty-workspace on signup)

### DIFF
--- a/packages/server/src/services/user-namespaces.seed-rls-context.test.ts
+++ b/packages/server/src/services/user-namespaces.seed-rls-context.test.ts
@@ -1,0 +1,92 @@
+// spec-436 regression: the provisioning seed path must run inside runWithMemexId(memexId)
+// so the rlsClient proxy emits `set_config('app.memex_id', …)` and the `documents` RLS
+// WITH CHECK policy passes. The runtime connects as the non-owner `memex_app` role, which is
+// SUBJECT to RLS (std-36: ENABLE, never FORCE), so a seed INSERT without the tenant GUC is
+// rejected ("new row violates row-level security policy for table \"documents\"") and the new
+// personal Memex comes up EMPTY — the exact prod failure on revs 00083→00091.
+//
+// We assert the MECHANISM (the tenant context is active for the new memex while a seeder runs)
+// rather than the DB outcome, because the test database may connect as the OWNER role that
+// bypasses RLS (ENABLE-not-FORCE), which would mask the bug entirely — a real-DB "did the docs
+// get seeded" assertion passes with OR without the fix. Asserting the GUC is host-independent:
+// remove the runWithMemexId wrapper and the captured store is undefined → this fails.
+
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { and, eq, inArray } from "drizzle-orm";
+
+const AC = "mindset-prod/memex-building-itself/specs/spec-436/acs";
+
+// Capture holder, hoisted so the vi.mock factory below can close over it.
+const cap = vi.hoisted(() => ({
+  store: undefined as { memexId?: string; userId?: string } | undefined,
+  calls: 0,
+}));
+
+// Mock the LAST seeder in seedNewPersonalMemex's allSettled. It always runs (the handhold +
+// default-Standards seeders are gated OFF suite-wide by the vitest config), so it is a clean
+// probe: whatever ALS context it observes is exactly the context the real seeders' INSERTs run
+// under. The mock does no DB work, so the test stays isolated to the namespace/memex rows.
+vi.mock("./default-facets.js", () => ({
+  seedDefaultFacetsForMemexBestEffort: vi.fn(async () => {
+    const { memexContext } = await import("../db/connection.js");
+    cap.calls += 1;
+    cap.store = memexContext.getStore();
+  }),
+}));
+
+import { db } from "../db/connection.js";
+import { namespaces, users } from "../db/schema.js";
+import { ensureUserNamespace } from "./user-namespaces.js";
+import { upsertUserByEmail } from "./users.js";
+
+const createdNamespaceIds: string[] = [];
+const createdUserIds: string[] = [];
+
+beforeAll(() => {
+  // Keep the heavy seeders off (the default vitest posture) — only the mocked facets probe
+  // runs, so this test neither writes demo/standards rows nor depends on RLS being enforced.
+  process.env.MEMEX_HANDHOLD_SIGNUP_SEED = "off";
+  process.env.MEMEX_DEFAULT_STANDARDS_SIGNUP_SEED = "off";
+});
+
+afterAll(async () => {
+  // Namespaces cascade to their memex; users last.
+  if (createdNamespaceIds.length) {
+    await db
+      .delete(namespaces)
+      .where(inArray(namespaces.id, createdNamespaceIds))
+      .catch(() => {});
+  }
+  if (createdUserIds.length) {
+    await db.delete(users).where(inArray(users.id, createdUserIds)).catch(() => {});
+  }
+});
+
+describe("spec-436 — provisioning seeds run under the new memex's tenant GUC", () => {
+  it("seedNewPersonalMemex runs its seeders inside runWithMemexId(memexId) so app.memex_id is set", async () => {
+    tagAc(`${AC}/ac-5`); // implementation: seeders run inside runWithMemexId(memexId)
+    tagAc(`${AC}/ac-3`); // scope: tenant context via runWithMemexId, not a bypass role
+    tagAc(`${AC}/ac-4`); // scope: regression guard — removing the wrapper fails CI
+
+    const user = await upsertUserByEmail(
+      `seed-rls-${Date.now()}-${Math.random().toString(36).slice(2, 8)}@example.com`,
+    );
+    createdUserIds.push(user.id);
+
+    const created = await ensureUserNamespace(user.id);
+    const memexId = created.memex.id;
+
+    const [ns] = await db
+      .select({ id: namespaces.id })
+      .from(namespaces)
+      .where(and(eq(namespaces.ownerUserId, user.id), eq(namespaces.kind, "user")))
+      .limit(1);
+    if (ns) createdNamespaceIds.push(ns.id);
+
+    // The probe seeder ran, and it ran with the freshly-created memex's tenant context active —
+    // i.e. every seed INSERT issued under this scope carries app.memex_id and satisfies RLS.
+    expect(cap.calls).toBeGreaterThan(0);
+    expect(cap.store?.memexId).toBe(memexId);
+  });
+});

--- a/packages/server/src/services/user-namespaces.ts
+++ b/packages/server/src/services/user-namespaces.ts
@@ -1,5 +1,5 @@
 import { eq, and } from "drizzle-orm";
-import { db } from "../db/connection.js";
+import { db, runWithMemexId } from "../db/connection.js";
 import { namespaces, memexes, users, experiments, experimentVariants } from "../db/schema.js";
 import type { Memex, Namespace } from "../db/schema.js";
 import { ValidationError } from "../types/errors.js";
@@ -260,17 +260,30 @@ export async function ensureUserNamespace(
 // time we get here). The seeds are individually idempotent (handhold: NO-OP if a demo doc
 // exists — ac-8; standards: NO-OP once the Memex holds any standard), so a duplicate fire
 // (e.g. a signup race twin) is harmless.
+//
+// spec-436: run the seeders inside runWithMemexId(memexId) so the rlsClient proxy emits
+// `set_config('app.memex_id', …)` for every INSERT they issue. The runtime connects as the
+// non-owner `memex_app` role, which is SUBJECT to RLS (std-36: ENABLE, never FORCE), and the
+// `documents` WITH CHECK policy keys on app.memex_id. Unlike a normal API request — which the
+// session middleware already wraps in runWithMemexId(currentMemexId) — provisioning runs
+// OUTSIDE any tenant context for the just-created memex (the signup request isn't scoped to
+// it), so without this wrapper every seed INSERT was rejected ("new row violates row-level
+// security policy for table \"documents\"") and the new workspace came up empty. One wrapper
+// over the shared allSettled covers all current and future seeders; the experiment lookup the
+// provisioning seed performs reads RLS-EXCLUDED tables, so the GUC is a harmless no-op there.
 async function seedNewPersonalMemex(memexId: string, ownerUserId: string): Promise<void> {
-  await Promise.allSettled([
-    seedProvisioningBehaviourBestEffort(memexId, ownerUserId),
-    seedDefaultStandardsBestEffort(memexId),
-    // spec-340 t-3 (dec-7): seed the personal memex's own facet vocabulary
-    // (owner_type='memex' — a personal memex is not modelled as its own org, so it
-    // owns its facets directly). Best-effort + idempotent, isolated by allSettled so
-    // a seed failure never blocks signup. Reached only on the personal-namespace
-    // create path, so seeding is inherently personal-only.
-    seedDefaultFacetsForMemexBestEffort(memexId),
-  ]);
+  await runWithMemexId(memexId, async () => {
+    await Promise.allSettled([
+      seedProvisioningBehaviourBestEffort(memexId, ownerUserId),
+      seedDefaultStandardsBestEffort(memexId),
+      // spec-340 t-3 (dec-7): seed the personal memex's own facet vocabulary
+      // (owner_type='memex' — a personal memex is not modelled as its own org, so it
+      // owns its facets directly). Best-effort + idempotent, isolated by allSettled so
+      // a seed failure never blocks signup. Reached only on the personal-namespace
+      // create path, so seeding is inherently personal-only.
+      seedDefaultFacetsForMemexBestEffort(memexId),
+    ]);
+  });
 }
 
 // spec-426: seed the new personal Memex with the EXPERIMENT-ASSIGNED onboarding


### PR DESCRIPTION
## What & why (spec-436)

Every new personal-Memex signup on prod was landing in an **empty workspace** — no handhold demo Specs (spec-178), no default Standards (spec-184), no default facets (spec-340). Root cause confirmed against prod Cloud Run + CloudSQL logs:

The provisioning seeds insert into `documents` as the non-owner `memex_app` role, which is **subject to RLS** (std-36: ENABLE, never FORCE). They ran **outside** any `runWithMemexId` for the just-created memex — unlike a normal API request, which session middleware already wraps in `runWithMemexId(currentMemexId)` — so no `set_config('app.memex_id')` was emitted and every seed INSERT was rejected:

```
ERROR: new row violates row-level security policy for table "documents"
```

The best-effort `try/catch` swallowed it (`[provisioning seed]` / `[default-standards seed]` in logs), so signup succeeded but the workspace was empty.

**Pre-existing, not a recent deploy.** The failures span Cloud Run revs **00083→00091 (June 28 onward)**, before the 2026-06-30 develop→main release. That release's only RLS-seam touch (`connection.ts` OTel wrapper, spec-412) is inert in prod (`OTEL_EXPORTER_OTLP_ENDPOINT` unset → `instrumentSqlClientIfEnabled` returns the client unchanged), and migrations 0116/0117 add no `documents` RLS DDL. A rollback would not have fixed it.

## The fix

Wrap `seedNewPersonalMemex`'s `Promise.allSettled` body in a single `runWithMemexId(memexId, …)` (spec-436 dec-1). One wrapper covers all current and future seeders; the experiment lookup it performs reads RLS-EXCLUDED tables, so the GUC is a harmless no-op there. Keeps the seeds inside the std-36 RLS model — preferred over a BYPASSRLS/owner-role escape.

## Test

`user-namespaces.seed-rls-context.test.ts` asserts the **mechanism** — the tenant GUC (`app.memex_id`) is active for the new memex while a seeder runs — rather than the DB outcome, because the test DB may connect as the owner role that bypasses RLS (ENABLE-not-FORCE) and would mask the bug. Verified red→green: with the wrapper removed the captured store is `undefined` and the test fails.

Local gates: `make typecheck` ✓ · `pnpm lint` ✓ · server unit suite (1472 passed) ✓ · seed-path integration tests (this + signup-seed-completion + handhold-seed-resilience) ✓.

Spec: `mindset-prod/memex-building-itself/specs/spec-436`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
