### PR TITLE
chore(spec-14): GRANT UPDATE on public.experiments to memex_admin

### DIFF
--- a/packages/server/drizzle/0118_grant_experiments_update_memex_admin.sql
+++ b/packages/server/drizzle/0118_grant_experiments_update_memex_admin.sql
@@ -1,0 +1,26 @@
+-- spec-14 (memex-backstage) — GRANT UPDATE on public.experiments to memex_admin.
+-- The Backstage "Experiments" operator tab switches an experiment on/off by writing
+-- experiments.status. Backstage connects as the memex_admin BYPASSRLS role, which is
+-- read-oriented today (it SELECTs public.* cross-tenant but does not write it). The
+-- experiments cluster is platform-global, operator-owned and RLS-excluded (spec-426,
+-- 0116_add_experiments.sql), so a status flip is operator-plane state, not a tenant
+-- mutation — Backstage performs it as a direct, audited UPDATE under memex_admin
+-- (spec-14 dec-3), pairing it with an audit row in Backstage's own admin schema. That
+-- UPDATE needs this grant; without it the write fails with "permission denied for
+-- table experiments". Core owns public.experiments, so the grant ships here as a
+-- forward-only hand migration (std-9: DDL against int/prod Cloud SQL is CI/migration
+-- only, never hand-run). SELECT is already available to memex_admin; this adds only
+-- UPDATE, and only on experiments — NOT experiment_variants / experiment_assignments,
+-- which Backstage only reads. GRANT is idempotent, so a re-run is a no-op.
+--
+-- ROLE GUARD: `memex_admin` is a Backstage-infra role that exists in the shared prod
+-- database (where Backstage connects as it) but NOT in core's CI / local test
+-- containers — and core migrations otherwise never reference it. A bare GRANT there
+-- fails with "role memex_admin does not exist" and breaks the migration runner. So we
+-- grant only when the role is present: a no-op in CI/local, the real grant in prod.
+do $$
+begin
+  if exists (select 1 from pg_roles where rolname = 'memex_admin') then
+    grant update on public.experiments to memex_admin;
+  end if;
+end $$;


### PR DESCRIPTION
## What

A forward-only hand migration (`drizzle/0118_grant_experiments_update_memex_admin.sql`) that issues:

```sql
GRANT UPDATE ON public.experiments TO memex_admin;
```

## Why

This is the **core-side prerequisite** for the Backstage **Experiments operator tab** (`memex-backstage` spec-14). That tab switches an experiment on/off by writing `experiments.status`. Backstage connects as the `memex_admin` BYPASSRLS role, which is **read-oriented today** (it SELECTs `public.*` cross-tenant but does not write it).

The experiments cluster is platform-global, operator-owned and RLS-excluded (spec-426, `0116_add_experiments.sql`), so a status flip is **operator-plane state, not a tenant mutation** — Backstage performs it as a direct, audited `UPDATE` under `memex_admin` (spec-14 dec-3), pairing it with an audit row in Backstage's own `admin` schema. Without this grant the write fails with `permission denied for table experiments`.

## Scope / safety

- Only `UPDATE`, only on `experiments` — **not** `experiment_variants` / `experiment_assignments` (Backstage only reads those).
- `GRANT` is idempotent; a re-run is a no-op.
- std-9: ships as a CI/migration-applied grant, never hand-run DDL against int/prod Cloud SQL.

## Deploy ordering

**This must land + deploy before** Backstage's status-write path is exercised in an environment. Reads and the rest of the tab work without it; only the on/off control is gated. Paired Backstage PR: the `spec-14-experiments` feature branch in `memex-backstage`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)