### PR TITLE
fix(spec-433): reveal rail once create-spec is attained

### DIFF
--- a/packages/ui/src/pages/HomeCanvas.tsx
+++ b/packages/ui/src/pages/HomeCanvas.tsx
@@ -336,8 +336,11 @@ export function HomeCanvas() {
   // SHOW_GRADUATED_HOME flips and the YourJourneys pearls are live (spec-312/315).
   const layerVisible = !!state?.steps?.length || forceShow;
 
-  // The rail reveals once the user is past the first step (prototype: full-width step 0).
-  const showRail = !!displayStepId && displayStepId !== FIRST_STEP_ID && visibleSteps.length > 0;
+  // The first step renders full-width with no rail until it is attained — once the user
+  // has connected MCP (create-spec done), the rail appears even if the cursor hasn't
+  // advanced yet (spec-433 regression fix: returning users were stuck full-width at 100%).
+  const firstStepAttained = visibleSteps[0]?.attained ?? false;
+  const showRail = !!displayStepId && (displayStepId !== FIRST_STEP_ID || firstStepAttained) && visibleSteps.length > 0;
 
   return (
     <div className="font-onboarding min-h-full" data-testid="home-canvas">


### PR DESCRIPTION
## Summary

- spec-433 (merged today, PR #432) changed `FIRST_STEP_ID` from `'identity'` to `'create-spec'`, making `showRail = false` whenever the cursor is at `create-spec`
- Returning users who had already connected MCP (create-spec attained, 100% progress) were stuck in the full-width no-rail layout because their server cursor was parked at `create-spec`
- Fix: `showRail` now also enables when `visibleSteps[0].attained` is true — rail appears as soon as MCP is connected, even if the cursor hasn't advanced to `create-first-spec`

## Test plan

- [ ] New user (MCP not connected): lands on `create-spec` full-width with no rail ✓
- [ ] Returning user (MCP connected, cursor at `create-spec`): rail appears with both steps visible ✓
- [ ] 271 UI unit tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)