### PR TITLE
feat(spec-441): restore /onboarding name-capture gate for email/password signups

### DIFF
--- a/packages/ui/e2e/journey-19-lifecycle-spine.spec.ts
+++ b/packages/ui/e2e/journey-19-lifecycle-spine.spec.ts
@@ -256,18 +256,19 @@ test(
     ).toBeVisible({ timeout: 15_000 });
     await expect(page.getByText(email)).toBeVisible();
 
-    // Continue → spec-305 dec-2: needsOnboarding routes the identity-unconfirmed new user
-    // to /home. spec-433: the identity step is removed; the user lands directly on
-    // create-spec (server returns 'identity' but clampToVisible maps it forward to
-    // 'create-spec' as FIRST_STEP_ID).
+    // Continue — spec-441: the user has no name, so the name-capture gate fires before
+    // /home. The user is intercepted at /onboarding, fills in a name, then lands on
+    // /home where spec-433's create-spec step (FIRST_STEP_ID) renders.
     await page.getByRole("button", { name: /Continue to your Memex/ }).click();
 
-    // spec-433: no identity form — the user lands directly on create-spec.
-    await expect(page.getByTestId("journey-step-create-spec")).toBeVisible({ timeout: 15_000 });
+    await expect(page).toHaveURL(/\/onboarding/, { timeout: 15_000 });
+    await page.getByPlaceholder("Your display name").fill("Spine User");
+    await page.getByRole("button", { name: /^Continue$/ }).click();
 
-    // The new user can now reach their personal-memex Specs board (the onboarding wall
-    // is gone, spec-312) — as the NEW user (sidebar identity shows `email`), never
-    // dev@memex.ai. `/` lands on /home now, so navigate to the Specs board explicitly.
+    // After naming, the user lands on /home with the standard Home Canvas.
+    await expect(page.getByTestId("getting-started-title")).toBeVisible({ timeout: 15_000 });
+
+    // Navigate to the personal-memex Specs board as the NEW user (not dev@memex.ai).
     await gotoSpecsBoard(page, email);
     // Use .first() — the email appears in both the sidebar user button and demo-spec metadata rows.
     // The sidebar user button is first in DOM order and is the identity proof we care about.

--- a/packages/ui/e2e/journey-51-spec-426-variant-a-handhold.spec.ts
+++ b/packages/ui/e2e/journey-51-spec-426-variant-a-handhold.spec.ts
@@ -80,9 +80,16 @@ test(TITLE, async ({ page, resources }) => {
   ).toBeVisible({ timeout: 15_000 });
 
   // Confirm identity so needsOnboarding clears (spec-305) and the first-load
-  // landing decision is reached for real — the alternative is walking the
-  // onboarding identity step in the UI (journey-19), unnecessary detail here.
+  // landing decision is reached for real.
   await setIdentityConfirmed(email, true);
+  // spec-441: email/password signups have no name in their session JWT at this point.
+  // Navigate through /onboarding to set the display name AND refresh the cached session,
+  // otherwise TenantLayout redirects every subsequent page.goto to /onboarding.
+  await page.getByRole("button", { name: /Continue to your Memex/ }).click();
+  await expect(page).toHaveURL(/\/onboarding/, { timeout: 15_000 });
+  await page.getByPlaceholder("Your display name").fill("Variant A User");
+  await page.getByRole("button", { name: /^Continue$/ }).click();
+  await expect(page).toHaveURL(/\/home/, { timeout: 15_000 });
 
   // ── Pin the CONTROL arm + seed the handhold demo deterministically ───────────
   // The experiment-arm test hook (POST /api/__test__/seed-experiment-arm) is now

--- a/packages/ui/e2e/journey-51-spec-426-variant-b-starter-spec.spec.ts
+++ b/packages/ui/e2e/journey-51-spec-426-variant-b-starter-spec.spec.ts
@@ -77,6 +77,14 @@ test(TITLE, async ({ page, resources }) => {
 
   // Confirm identity so needsOnboarding clears and the landing predicate is reached.
   await setIdentityConfirmed(email, true);
+  // spec-441: email/password signups have no name in their session JWT at this point.
+  // Navigate through /onboarding to set the display name AND refresh the cached session,
+  // otherwise TenantLayout redirects every subsequent page.goto to /onboarding.
+  await page.getByRole("button", { name: /Continue to your Memex/ }).click();
+  await expect(page).toHaveURL(/\/onboarding/, { timeout: 15_000 });
+  await page.getByPlaceholder("Your display name").fill("Variant B User");
+  await page.getByRole("button", { name: /^Continue$/ }).click();
+  await expect(page).toHaveURL(/\/home/, { timeout: 15_000 });
 
   // ── Pin the TREATMENT arm + seed the starter spec deterministically ──────────
   // The experiment-arm test hook (POST /api/__test__/seed-experiment-arm) is now

--- a/packages/ui/e2e/journey-51-whats-new-new-user.spec.ts
+++ b/packages/ui/e2e/journey-51-whats-new-new-user.spec.ts
@@ -1,4 +1,11 @@
-import { test, expect, emitAcEvents, bareUrl } from "./helpers/index.js";
+import {
+  test,
+  expect,
+  emitAcEvents,
+  bareUrl,
+  gotoSpecsBoard,
+  setIdentityConfirmed,
+} from "./helpers/index.js";
 import {
   signupWithToken,
   seedWhatsNewEntry,
@@ -74,14 +81,23 @@ test(
       page.getByRole("heading", { name: /You're all set!/ }),
     ).toBeVisible({ timeout: 15_000 });
 
-    // Navigate to the app. A fresh user lands on /home (onboarding canvas),
-    // not /specs — so we wait for the /api/whats-new response directly rather
-    // than a heading that only appears post-onboarding.
+    // spec-441: fresh signups have no name in their session JWT. Navigate
+    // through /onboarding to set a display name and refresh the cached session
+    // so TenantLayout routes don't redirect back to /onboarding.
+    await setIdentityConfirmed(email, true);
+    await page.getByRole("button", { name: /Continue to your Memex/ }).click();
+    await expect(page).toHaveURL(/\/onboarding/, { timeout: 15_000 });
+    await page.getByPlaceholder("Your display name").fill("WhatsNew Test User");
+    await page.getByRole("button", { name: /^Continue$/ }).click();
+    await expect(page).toHaveURL(/\/home/, { timeout: 15_000 });
+
+    // WhatsNewProvider only mounts inside TenantLayout (/:namespace/:memex/* routes).
+    // Navigate to the Specs board to trigger /api/whats-new.
     const whatsNewDone = page.waitForResponse(
       (r) => r.url().includes("/api/whats-new") && r.status() === 200,
       { timeout: 15_000 },
     );
-    await page.goto(bareUrl("/"), { waitUntil: "commit" });
+    await gotoSpecsBoard(page, email);
     await whatsNewDone;
 
     // Give React a tick to process the response and (if the fix were broken)

--- a/packages/ui/e2e/journey-52-spec-441-onboarding-gate.spec.ts
+++ b/packages/ui/e2e/journey-52-spec-441-onboarding-gate.spec.ts
@@ -1,0 +1,90 @@
+// Journey 52 — spec-441: /onboarding name-capture gate for email/password signups.
+//
+// A fresh email/password user arrives with no display name. spec-441 restores the
+// routing wall that sends them to /onboarding (name capture) before they can reach
+// any authenticated surface. This journey walks the full arc: signup → email
+// verification → intercepted at /onboarding → fills name → /home with the standard
+// Home Canvas.
+//
+// Covers:
+//   ac-1 — nameless authenticated user is redirected to /onboarding, not /home.
+//   ac-2 — after submitting a name on /onboarding, the user lands on /home.
+//   ac-6 — /home shows the Home Canvas (two visible onboarding steps; identity step
+//           absent per spec-433).
+//
+// Runs as a fresh per-test email — NOT dev@memex.ai — so the new session JWT proves
+// the browser is authenticated as the signup user (spec-172 issue-1 fix applies here
+// too: the dev bypass only fires on token-less requests).
+
+import {
+  test,
+  expect,
+  bareUrl,
+  emitAcEvents,
+  signupWithToken,
+} from "./helpers/index.js";
+
+const ACS = [
+  "mindset-prod/memex-building-itself/specs/spec-441/acs/ac-1",
+  "mindset-prod/memex-building-itself/specs/spec-441/acs/ac-2",
+  "mindset-prod/memex-building-itself/specs/spec-441/acs/ac-6",
+];
+
+test.afterEach(async ({}, testInfo) => {
+  if (testInfo.status === "skipped") return;
+  await emitAcEvents(
+    ACS,
+    testInfo.status === "passed" ? "pass" : "fail",
+    `packages/ui/e2e/journey-52-spec-441-onboarding-gate.spec.ts::${testInfo.title}`,
+    testInfo.duration,
+  );
+});
+
+test(
+  "email/password signup → intercepted at /onboarding (ac-1) → fills name → lands on /home with Home Canvas (ac-2, ac-6)",
+  async ({ page, resources }) => {
+    const email = resources.email("gate-newuser");
+    const { verificationToken } = await signupWithToken({
+      email,
+      password: "correct-horse-battery-staple-9",
+    });
+
+    // Real verification — stamps email_verified_at and stores the session JWT
+    // client-side (acceptSession). Postmark is never contacted.
+    await page.goto(
+      bareUrl(`/verify-email?token=${encodeURIComponent(verificationToken)}`),
+      { waitUntil: "commit" },
+    );
+    await expect(
+      page.getByRole("heading", { name: /You're all set!/ }),
+    ).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByText(email)).toBeVisible();
+
+    // Continue — the user has no display name, so spec-441's RootRedirect gate
+    // intercepts and redirects to /onboarding before /home renders.
+    await page.getByRole("button", { name: /Continue to your Memex/ }).click();
+
+    // ac-1: nameless authenticated user is sent to /onboarding, not /home.
+    await expect(page).toHaveURL(/\/onboarding/, { timeout: 15_000 });
+    await expect(page.getByText("What's your name?")).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // Fill in a display name and submit.
+    await page.getByPlaceholder("Your display name").fill("Gate User");
+    await page.getByRole("button", { name: /^Continue$/ }).click();
+
+    // ac-2: after submitting the name, the user lands on /home.
+    await expect(page).toHaveURL(/\/home/, { timeout: 15_000 });
+
+    // ac-6: /home shows the Home Canvas — getting-started-title + create-spec step
+    // visible; identity step absent (spec-433: hidden step removed from the UI).
+    await expect(page.getByTestId("getting-started-title")).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(page.getByTestId("journey-step-create-spec")).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(page.getByTestId("journey-step-identity")).not.toBeVisible();
+  },
+);

--- a/packages/ui/src/App.spec-441.test.tsx
+++ b/packages/ui/src/App.spec-441.test.tsx
@@ -1,0 +1,233 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { tagAc } from '@memex-ai-ac/vitest';
+import type { ReactNode } from 'react';
+import type { SessionPayload } from './api/client';
+
+// spec-441 — Restore /onboarding name-capture gate for email/password signups
+//
+// Tests the nameless-user guard in RootRedirect, FlatShell, and TenantLayout
+// (dec-1). ac-9 (Onboarding named-user redirect, dec-2) is in Onboarding.spec-441.test.tsx.
+//
+//   ac-1  (scope) — nameless user redirected to /onboarding regardless of which route they load
+//   ac-3  (scope) — named user (Google SSO) never sent to /onboarding
+//   ac-4  (scope) — returning named user's landing unchanged
+//   ac-5  (scope) — after name is set, / does not redirect back to /onboarding
+//   ac-7  (impl)  — FlatShell redirects nameless user to /onboarding
+//   ac-8  (impl)  — TenantLayout redirects nameless user to /onboarding
+//   impl  —        fetchJourneyStateApi never called for a nameless user
+//   impl  —        email gate takes priority over name gate
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-441/acs/ac-${n}`;
+
+let mockSession: SessionPayload;
+
+function makeSession(opts: {
+  name?: string;
+  emailVerified?: boolean;
+}): SessionPayload {
+  return {
+    user: {
+      id: 'u-1',
+      email: 'alice@example.com',
+      name: opts.name ?? 'Alice',
+      status: 'active',
+      emailVerified: opts.emailVerified ?? true,
+    },
+    memberships: [
+      {
+        memexId: 'mx-alice',
+        slug: 'alice',
+        memexSlug: 'personal',
+        name: 'Personal Memex',
+        kind: 'personal' as const,
+        role: 'administrator' as const,
+      },
+    ],
+    currentMemexId: 'mx-alice',
+    currentRole: 'administrator' as const,
+    needsOnboarding: false,
+    hiddenFeatures: [],
+  };
+}
+
+vi.mock('./components/AuthContext', async () => {
+  const real = await vi.importActual<typeof import('./components/AuthContext')>(
+    './components/AuthContext',
+  );
+  return {
+    ...real,
+    useAuth: () => ({
+      session: mockSession,
+      user: mockSession?.user
+        ? { name: mockSession.user.name, email: mockSession.user.email, picture: '' }
+        : null,
+      token: 'fake-token',
+      isAuthenticated: true,
+      authError: null,
+      logout: vi.fn(),
+      updateSession: vi.fn(),
+      acceptSession: vi.fn(),
+    }),
+  };
+});
+
+vi.mock('./components/AppShell', () => ({
+  AppShell: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+vi.mock('./components/ChatContext', () => ({
+  ChatProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+vi.mock('./components/OrgConsentDialog', () => ({ OrgConsentDialog: () => null }));
+
+vi.mock('./pages/HomeCanvas', () => ({
+  HomeCanvas: () => <div data-testid="home-canvas-page">home</div>,
+}));
+vi.mock('./pages/SpecList', () => ({
+  SpecList: () => <div data-testid="specs-page">specs</div>,
+}));
+vi.mock('./pages/SettingsIntegrations', () => ({
+  SettingsIntegrations: () => <div data-testid="integrations-page">integrations</div>,
+}));
+vi.mock('./pages/VerifyEmailGate', () => ({
+  VerifyEmailGate: () => <div data-testid="verify-email-gate">verify your email</div>,
+}));
+vi.mock('./pages/Onboarding', () => ({
+  Onboarding: () => <div data-testid="onboarding-page">onboarding</div>,
+}));
+
+const fetchJourneyStateSpy = vi.fn().mockResolvedValue({
+  milestones: {
+    identityConfirmed: false,
+    mcpConnected: false,
+    mcpToolCalled: false,
+    hasSpec: false,
+    hasResolvedDecision: false,
+    hasAc: false,
+    acVerified: false,
+    planGrounded: false,
+  },
+  roleCoords: null,
+  currentStepId: 'create-spec',
+  steps: [],
+  preview: false,
+  canPreview: false,
+});
+
+vi.mock('./api/journey', async () => {
+  const real = await vi.importActual<typeof import('./api/journey')>('./api/journey');
+  return { ...real, fetchJourneyStateApi: (...args: unknown[]) => fetchJourneyStateSpy(...args) };
+});
+
+import { PostLoginRouter } from './App';
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/*" element={<PostLoginRouter />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.stubEnv('VITE_GOOGLE_CLIENT_ID', 'test-client-id');
+  fetchJourneyStateSpy.mockClear();
+});
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('spec-441: RootRedirect name gate', () => {
+  it('ac-1: nameless user at / is redirected to /onboarding', async () => {
+    tagAc(AC(1));
+    mockSession = makeSession({ name: '' });
+    renderAt('/');
+    expect(await screen.findByTestId('onboarding-page')).toBeInTheDocument();
+    expect(screen.queryByTestId('home-canvas-page')).not.toBeInTheDocument();
+  });
+
+  it('ac-1: nameless user — fetchJourneyStateApi is never called (needDecision skipped)', async () => {
+    tagAc(AC(1));
+    mockSession = makeSession({ name: '' });
+    renderAt('/');
+    await screen.findByTestId('onboarding-page');
+    expect(fetchJourneyStateSpy).not.toHaveBeenCalled();
+  });
+
+  it('ac-3: named user (e.g. Google SSO) at / is NOT redirected to /onboarding', async () => {
+    tagAc(AC(3));
+    mockSession = makeSession({ name: 'Alice' });
+    renderAt('/');
+    expect(await screen.findByTestId('home-canvas-page')).toBeInTheDocument();
+    expect(screen.queryByTestId('onboarding-page')).not.toBeInTheDocument();
+  });
+
+  it('ac-4: returning named user landing (/ → /home) is unchanged', async () => {
+    tagAc(AC(4));
+    mockSession = makeSession({ name: 'Alice' });
+    renderAt('/');
+    expect(await screen.findByTestId('home-canvas-page')).toBeInTheDocument();
+    expect(screen.queryByTestId('onboarding-page')).not.toBeInTheDocument();
+  });
+
+  it('ac-5: named session at / does not redirect to /onboarding ("not asked again")', async () => {
+    tagAc(AC(5));
+    mockSession = makeSession({ name: 'Alice' });
+    renderAt('/');
+    expect(await screen.findByTestId('home-canvas-page')).toBeInTheDocument();
+    expect(screen.queryByTestId('onboarding-page')).not.toBeInTheDocument();
+  });
+
+  it('email gate fires before name gate — unverified nameless user sees VerifyEmailGate', async () => {
+    mockSession = makeSession({ name: '', emailVerified: false });
+    renderAt('/');
+    expect(await screen.findByTestId('verify-email-gate')).toBeInTheDocument();
+    expect(screen.queryByTestId('onboarding-page')).not.toBeInTheDocument();
+  });
+
+  it('email gate fires before name gate — unverified named user sees VerifyEmailGate', async () => {
+    mockSession = makeSession({ name: 'Alice', emailVerified: false });
+    renderAt('/');
+    expect(await screen.findByTestId('verify-email-gate')).toBeInTheDocument();
+    expect(screen.queryByTestId('onboarding-page')).not.toBeInTheDocument();
+  });
+});
+
+describe('spec-441: FlatShell name gate (dec-1 / ac-7)', () => {
+  it('ac-7: nameless user deep-linking to /settings/integrations is redirected to /onboarding', async () => {
+    tagAc(AC(7));
+    mockSession = makeSession({ name: '' });
+    renderAt('/settings/integrations');
+    expect(await screen.findByTestId('onboarding-page')).toBeInTheDocument();
+    expect(screen.queryByTestId('integrations-page')).not.toBeInTheDocument();
+  });
+
+  it('ac-7: named user deep-linking to a FlatShell route is NOT redirected to /onboarding', async () => {
+    tagAc(AC(7));
+    mockSession = makeSession({ name: 'Alice' });
+    renderAt('/settings/integrations');
+    expect(await screen.findByTestId('integrations-page')).toBeInTheDocument();
+    expect(screen.queryByTestId('onboarding-page')).not.toBeInTheDocument();
+  });
+});
+
+describe('spec-441: TenantLayout name gate (dec-1 / ac-8)', () => {
+  it('ac-8: nameless user deep-linking to a tenant route is redirected to /onboarding', async () => {
+    tagAc(AC(8));
+    mockSession = makeSession({ name: '' });
+    renderAt('/alice/personal/specs');
+    expect(await screen.findByTestId('onboarding-page')).toBeInTheDocument();
+    expect(screen.queryByTestId('specs-page')).not.toBeInTheDocument();
+  });
+
+  it('ac-8: named user deep-linking to a tenant route is NOT redirected to /onboarding', async () => {
+    tagAc(AC(8));
+    mockSession = makeSession({ name: 'Alice' });
+    renderAt('/alice/personal/specs');
+    expect(await screen.findByTestId('specs-page')).toBeInTheDocument();
+    expect(screen.queryByTestId('onboarding-page')).not.toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -235,6 +235,7 @@ function TenantLayout() {
   if (!session.user.emailVerified) {
     return <VerifyEmailGate />;
   }
+  if (!session.user.name) return <Navigate to="/onboarding" replace />; // spec-441
 
   // Membership check: redirect to the user's default tenant when they aren't
   // a member of the URL's namespace/memex. This replaces the host-based
@@ -405,7 +406,7 @@ function RootRedirect() {
   const homeHidden = !!session && isFeatureHidden(session, 'home');
   // Only consult journey-state when we genuinely face the Home-vs-Specs choice
   // (authenticated, verified, and 'home' visible). Otherwise skip the read.
-  const needDecision = !!session && emailVerified && !homeHidden;
+  const needDecision = !!session && emailVerified && !!session.user.name && !homeHidden;
   const landOnHome = useShouldLandOnHome(needDecision);
 
   // Engagement telemetry (advisory, fires once): record which way the router sent the
@@ -426,6 +427,7 @@ function RootRedirect() {
 
   if (!session) return null; // session bootstrap still pending
   if (!emailVerified) return <VerifyEmailGate />;
+  if (!session.user.name) return <Navigate to="/onboarding" replace />; // spec-441
   if (homeHidden) {
     // Loop-avoidance: 'home' hidden ⇒ land on the default tenant, no journey read.
     const fallback = computeDefaultLanding(session);
@@ -635,9 +637,7 @@ export function PostLoginRouter() {
 function FlatShell({ children }: { children: React.ReactNode }) {
   const { session } = useAuth();
   if (session && !session.user.emailVerified) return <VerifyEmailGate />;
-  // spec-312 dec-3: the needsOnboarding bounce-back that used to live here is gone —
-  // flat routes render for everyone past the email gate. Onboarding is a layer on
-  // /home, never a wall that ejects you from other surfaces.
+  if (session && !session.user.name) return <Navigate to="/onboarding" replace />; // spec-441
   return (
     <ChatProvider>
       <OrgConsentDialog />

--- a/packages/ui/src/pages/Onboarding.spec-441.test.tsx
+++ b/packages/ui/src/pages/Onboarding.spec-441.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { tagAc } from '@memex-ai-ac/vitest';
+
+// spec-441 dec-2 / ac-9 — Onboarding.tsx redirects already-named users to /
+// so they don't see "Welcome! Let's set up your profile." after a name is set.
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-441/acs/ac-${n}`;
+
+vi.mock('../components/AuthContext', async () => {
+  const real = await vi.importActual<typeof import('../components/AuthContext')>(
+    '../components/AuthContext',
+  );
+  return {
+    ...real,
+    useAuth: () => mockUseAuth(),
+  };
+});
+
+let mockUseAuth: () => ReturnType<typeof import('../components/AuthContext').useAuth>;
+
+import { Onboarding } from './Onboarding';
+
+function renderOnboarding() {
+  return render(
+    <MemoryRouter initialEntries={['/onboarding']}>
+      <Routes>
+        <Route path="/onboarding" element={<Onboarding />} />
+        <Route path="/" element={<div data-testid="root-page">root</div>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('spec-441 dec-2: Onboarding named-user redirect (ac-9)', () => {
+  it('ac-9: already-named user is immediately redirected to / — does not see the form', async () => {
+    tagAc(AC(9));
+    mockUseAuth = () => ({
+      session: null,
+      user: { name: 'Alice', email: 'alice@example.com', picture: '' },
+      token: 'fake-token',
+      isAuthenticated: true,
+      authError: null,
+      logout: vi.fn(),
+      updateSession: vi.fn(),
+      acceptSession: vi.fn(),
+    });
+    renderOnboarding();
+    expect(await screen.findByTestId('root-page')).toBeInTheDocument();
+    expect(screen.queryByText("What's your name?")).not.toBeInTheDocument();
+  });
+
+  it('ac-9: nameless user sees the name form — not redirected', async () => {
+    tagAc(AC(9));
+    mockUseAuth = () => ({
+      session: null,
+      user: { name: '', email: 'alice@example.com', picture: '' },
+      token: 'fake-token',
+      isAuthenticated: true,
+      authError: null,
+      logout: vi.fn(),
+      updateSession: vi.fn(),
+      acceptSession: vi.fn(),
+    });
+    renderOnboarding();
+    expect(await screen.findByText("What's your name?")).toBeInTheDocument();
+    expect(screen.queryByTestId('root-page')).not.toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/pages/Onboarding.tsx
+++ b/packages/ui/src/pages/Onboarding.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useState } from 'react';
+import { Navigate, useNavigate } from 'react-router-dom';
 import { Button } from '../components/ui/Button';
 import { Input } from '../components/ui/Input';
 import { Alert } from '../components/ui/Alert';
@@ -8,6 +9,7 @@ import { updateProfileApi } from '../api/client';
 
 export function Onboarding() {
   const { token, user, updateSession } = useAuth();
+  const navigate = useNavigate();
   const [name, setName] = useState(user?.name ?? '');
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -22,13 +24,16 @@ export function Onboarding() {
       try {
         const session = await updateProfileApi(token, trimmed);
         updateSession(session);
+        navigate('/');
       } catch (err) {
         setSubmitting(false);
         setError(err instanceof Error ? err.message : 'Something went wrong. Please try again.');
       }
     },
-    [name, token, updateSession]
+    [name, token, updateSession, navigate]
   );
+
+  if (user?.name) return <Navigate to="/" replace />;
 
   return (
     <div className="min-h-screen bg-page flex items-center justify-center p-6">


### PR DESCRIPTION
## Summary

- Adds a `/onboarding` name-capture gate for email/password signups: nameless, email-verified users are redirected to `/onboarding` from `RootRedirect`, `FlatShell`, and `TenantLayout` before reaching any authenticated surface
- After submitting a name, the user is navigated into the app normally (`/`)
- Named users and Google SSO users (who arrive pre-named) are never redirected

## Test plan

- [x] 10 unit tests (`App.spec-441.test.tsx`, `Onboarding.spec-441.test.tsx`) — all pass, covering ac-1, ac-3–ac-5, ac-7–ac-9
- [x] Journey-52 Playwright e2e (`journey-52-spec-441-onboarding-gate.spec.ts`) — 1/1 pass, covering ac-1, ac-2, ac-6
- [x] Journey-19 lifecycle spine updated to navigate through `/onboarding` — still passes
- [x] All 9/9 ACs verified in Memex (spec-441)

Spec: https://memex.ai/mindset-prod/memex-building-itself/specs/spec-441

🤖 Generated with [Claude Code](https://claude.com/claude-code)