### PR TITLE
fix(spec-442): correct auth-email comms type and stamp sent_at (write path + backfill)

### DIFF
--- a/packages/server/drizzle/0120_spec_442_fix_comms_log_email_tracking.sql
+++ b/packages/server/drizzle/0120_spec_442_fix_comms_log_email_tracking.sql
@@ -1,0 +1,57 @@
+-- spec-442 — Fix email-send tracking in comms_log. Two data-correctness backfills
+-- plus a forward-guard constraint. All changes target the public schema.
+--
+-- The hand-migration runner wraps this whole file in ONE transaction and splits it
+-- into statements on the breakpoint marker, so the two backfills, the constraint
+-- add, and its validation are atomic: either the guard lands over clean data or
+-- nothing changes. Order matters — both backfills MUST precede VALIDATE so no
+-- existing row trips the new CHECK.
+--
+-- 1) TYPE — auth emails were mis-classified as 'transactional' (recordEmailComm's
+--    default) because the magic-link / password-reset templates carried no commsType.
+--    Re-type the three auth subjects to their precise taxonomy; leave every other
+--    subject untouched. Idempotent — re-running maps the same subjects to the same
+--    types (email_verification rows already correct since spec-12 stay put).
+UPDATE "comms_log"
+SET "type" = CASE "subject"
+    WHEN 'Confirm your Memex.AI email' THEN 'email_verification'
+    WHEN 'Your Memex.AI sign-in link' THEN 'magic_link'
+    WHEN 'Reset your Memex.AI password' THEN 'password_reset'
+    ELSE "type"
+  END
+WHERE "channel" = 'email'
+  AND "subject" IN (
+    'Confirm your Memex.AI email',
+    'Your Memex.AI sign-in link',
+    'Reset your Memex.AI password'
+  );
+--> statement-breakpoint
+
+-- 2) SENT_AT — the send path stamped status='sent' but never sent_at, so every
+--    historical row is sent/NULL. The true Postmark send time is unknown for these
+--    (comms_event holds no Delivery event for them), so approximate with created_at
+--    — a DOCUMENTED approximation: created_at is the log-write time, within moments
+--    of the actual send for an immediate-fire email. Future rows carry the real
+--    send time (Postmark SubmittedAt, else now()) at write time.
+UPDATE "comms_log"
+SET "sent_at" = "created_at"
+WHERE "status" = 'sent' AND "sent_at" IS NULL;
+--> statement-breakpoint
+
+-- 3) GUARD (spec-442 dec-1, ac-7) — enforce status='sent' ⇒ sent_at IS NOT NULL going
+--    forward. Added NOT VALID so the add itself takes only a brief lock; the two
+--    backfills above already cleaned existing rows, so VALIDATE (next statement)
+--    passes. Guarded by pg_constraint so a retry after a partial apply is a no-op.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'comms_log_sent_requires_sent_at'
+  ) THEN
+    ALTER TABLE "comms_log"
+      ADD CONSTRAINT "comms_log_sent_requires_sent_at"
+      CHECK ("status" <> 'sent' OR "sent_at" IS NOT NULL) NOT VALID;
+  END IF;
+END $$;
+--> statement-breakpoint
+
+ALTER TABLE "comms_log" VALIDATE CONSTRAINT "comms_log_sent_requires_sent_at";

--- a/packages/server/drizzle/reverts/0120_spec_442_fix_comms_log_email_tracking.revert.sql
+++ b/packages/server/drizzle/reverts/0120_spec_442_fix_comms_log_email_tracking.revert.sql
@@ -1,0 +1,7 @@
+-- Revert spec-442 (0120_spec_442_fix_comms_log_email_tracking.sql).
+-- Drops only the forward-guard constraint. The two data backfills (type re-mapping
+-- and sent_at = created_at) are DATA CORRECTIONS and are NOT reversed: the prior
+-- state (auth rows mis-typed 'transactional', sent_at NULL) was the defect, and the
+-- original per-row values are not recoverable. Dropping the constraint is enough to
+-- restore the pre-0120 schema shape.
+ALTER TABLE "comms_log" DROP CONSTRAINT IF EXISTS "comms_log_sent_requires_sent_at";

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -2958,6 +2958,13 @@ export const commsLog = pgTable(
       "comms_log_status_valid",
       sql`${table.status} IN ('scheduled', 'sent', 'delivered', 'failed')`,
     ),
+    // spec-442 dec-1 (ac-7): a 'sent' row must always carry a send time. Enforced at
+    // the DB as a backstop; recordComm() also stamps sent_at at the write path so this
+    // is never actually hit in practice (added via 0120 as NOT VALID → VALIDATE).
+    check(
+      "comms_log_sent_requires_sent_at",
+      sql`${table.status} <> 'sent' OR ${table.sentAt} IS NOT NULL`,
+    ),
   ],
 );
 export type CommsLogRow = InferSelectModel<typeof commsLog>;

--- a/packages/server/src/services/comms-log-backfill.integration.test.ts
+++ b/packages/server/src/services/comms-log-backfill.integration.test.ts
@@ -1,0 +1,93 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { eq, inArray, sql } from "drizzle-orm";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { db } from "../db/connection.js";
+import { commsLog, users } from "../db/schema.js";
+
+// spec-442 (ac-3 / ac-5): the 0120 backfill corrects EXISTING rows. This exercises the
+// migration's type-remap UPDATE verbatim against seeded mis-typed rows — auth emails
+// that landed as 'transactional' (the old default) must be re-typed by subject, while
+// non-auth mail and non-email channels are left untouched. (The sent_at=created_at half
+// of the backfill produces the state the ac-7 CHECK then guarantees — that a 'sent' row
+// always carries a send time — so its end-state is verified there.)
+
+const AC_BACKFILL_SCOPE = "mindset-prod/memex-building-itself/specs/spec-442/acs/ac-3";
+const AC_TESTS_SCOPE = "mindset-prod/memex-building-itself/specs/spec-442/acs/ac-5";
+
+const EMAIL = "spec442-backfill@example.com";
+let userId: string;
+const ids: string[] = [];
+
+// The exact type-remap statement from 0120_spec_442_fix_comms_log_email_tracking.sql.
+async function runTypeBackfill(): Promise<void> {
+  await db.execute(sql`
+    UPDATE "comms_log"
+    SET "type" = CASE "subject"
+        WHEN 'Confirm your Memex.AI email' THEN 'email_verification'
+        WHEN 'Your Memex.AI sign-in link' THEN 'magic_link'
+        WHEN 'Reset your Memex.AI password' THEN 'password_reset'
+        ELSE "type"
+      END
+    WHERE "channel" = 'email'
+      AND "subject" IN (
+        'Confirm your Memex.AI email',
+        'Your Memex.AI sign-in link',
+        'Reset your Memex.AI password'
+      )
+  `);
+}
+
+beforeAll(async () => {
+  const [u] = await db.insert(users).values({ email: EMAIL }).returning({ id: users.id });
+  userId = u!.id;
+  const now = new Date();
+  const rows = await db
+    .insert(commsLog)
+    .values([
+      // three auth emails that were mis-typed 'transactional' (sent_at set to satisfy the CHECK)
+      { userId, channel: "email", type: "transactional", status: "sent", sentAt: now, subject: "Your Memex.AI sign-in link" },
+      { userId, channel: "email", type: "transactional", status: "sent", sentAt: now, subject: "Reset your Memex.AI password" },
+      { userId, channel: "email", type: "transactional", status: "sent", sentAt: now, subject: "Confirm your Memex.AI email" },
+      // genuine transactional mail — must stay 'transactional'
+      { userId, channel: "email", type: "transactional", status: "sent", sentAt: now, subject: "Your Memex.AI receipt" },
+      // a non-email channel with a colliding subject — must be left untouched
+      { userId, channel: "in_app", type: "work_notification", status: "sent", sentAt: now, subject: "Your Memex.AI sign-in link" },
+    ])
+    .returning({ id: commsLog.id });
+  ids.push(...rows.map((r) => r.id));
+});
+
+afterAll(async () => {
+  if (ids.length) await db.delete(commsLog).where(inArray(commsLog.id, ids)).catch(() => {});
+  if (userId) await db.delete(users).where(eq(users.id, userId)).catch(() => {});
+});
+
+async function typeOf(subject: string, channel: string): Promise<string | undefined> {
+  const rows = await db
+    .select({ type: commsLog.type, subject: commsLog.subject, channel: commsLog.channel })
+    .from(commsLog)
+    .where(inArray(commsLog.id, ids));
+  return rows.find((r) => r.subject === subject && r.channel === channel)?.type;
+}
+
+describe("spec-442: 0120 backfill re-types existing mis-typed auth emails", () => {
+  it("ac-3/ac-5: the subject taxonomy is applied to email rows; non-auth and non-email are untouched", async () => {
+    tagAc(AC_BACKFILL_SCOPE);
+    tagAc(AC_TESTS_SCOPE);
+
+    // Precondition: all three auth emails currently sit in the 'transactional' bucket.
+    expect(await typeOf("Your Memex.AI sign-in link", "email")).toBe("transactional");
+    expect(await typeOf("Reset your Memex.AI password", "email")).toBe("transactional");
+    expect(await typeOf("Confirm your Memex.AI email", "email")).toBe("transactional");
+
+    await runTypeBackfill();
+
+    // Auth emails re-typed by subject…
+    expect(await typeOf("Your Memex.AI sign-in link", "email")).toBe("magic_link");
+    expect(await typeOf("Reset your Memex.AI password", "email")).toBe("password_reset");
+    expect(await typeOf("Confirm your Memex.AI email", "email")).toBe("email_verification");
+    // …while genuine transactional mail and the non-email channel are left alone.
+    expect(await typeOf("Your Memex.AI receipt", "email")).toBe("transactional");
+    expect(await typeOf("Your Memex.AI sign-in link", "in_app")).toBe("work_notification");
+  });
+});

--- a/packages/server/src/services/comms-log-lifecycle.integration.test.ts
+++ b/packages/server/src/services/comms-log-lifecycle.integration.test.ts
@@ -110,6 +110,8 @@ describe("spec-6 t-8: retention prune (ac-15)", () => {
         type: "transactional",
         status: "sent",
         subject: "Recent receipt",
+        // spec-442: a 'sent' row must carry a send time (comms_log_sent_requires_sent_at).
+        sentAt: new Date(Date.now() - 5 * DAY),
         createdAt: new Date(Date.now() - 5 * DAY),
       })
       .returning({ id: commsLog.id });
@@ -136,6 +138,8 @@ describe("spec-6 t-8: retention prune (ac-15)", () => {
         type: "work_notification",
         status: "sent",
         subject: "Ten days old",
+        // spec-442: a 'sent' row must carry a send time (comms_log_sent_requires_sent_at).
+        sentAt: new Date(Date.now() - 10 * DAY),
         createdAt: new Date(Date.now() - 10 * DAY),
       })
       .returning({ id: commsLog.id });

--- a/packages/server/src/services/comms-log-prune-schedule.integration.test.ts
+++ b/packages/server/src/services/comms-log-prune-schedule.integration.test.ts
@@ -36,6 +36,8 @@ describe("spec-341 t-3: startCommsLogPrune (ac-8)", () => {
         channel: "email",
         type: "transactional",
         status: "sent",
+        // spec-442: a 'sent' row must carry a send time (comms_log_sent_requires_sent_at).
+        sentAt: new Date(Date.now() - 101 * DAY),
         createdAt: new Date(Date.now() - 101 * DAY),
       })
       .returning({ id: commsLog.id });

--- a/packages/server/src/services/comms-log-sent-at.integration.test.ts
+++ b/packages/server/src/services/comms-log-sent-at.integration.test.ts
@@ -1,0 +1,147 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { eq } from "drizzle-orm";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { db } from "../db/connection.js";
+import { commsLog, users } from "../db/schema.js";
+import { recordComm, recordEmailComm } from "./comms-log.js";
+
+// spec-442 (ac-2 / ac-4 / ac-6 / ac-7 / ac-9): the invariant status='sent' ⇒ sent_at
+// IS NOT NULL. Before this fix the send path inserted status='sent' with sent_at NULL
+// on every email. recordComm now stamps sent_at (real Postmark SubmittedAt when
+// threaded, else now()) for any 'sent' row, and a DB CHECK backstops it.
+
+const AC_SENT_SCOPE = "mindset-prod/memex-building-itself/specs/spec-442/acs/ac-2";
+const AC_GUARD_SCOPE = "mindset-prod/memex-building-itself/specs/spec-442/acs/ac-4";
+const AC_STAMP_IMPL = "mindset-prod/memex-building-itself/specs/spec-442/acs/ac-6";
+const AC_CHECK_IMPL = "mindset-prod/memex-building-itself/specs/spec-442/acs/ac-7";
+const AC_DEFAULT_IMPL = "mindset-prod/memex-building-itself/specs/spec-442/acs/ac-9";
+
+const EMAIL = "spec442-sentat@example.com";
+let userId: string;
+
+beforeAll(async () => {
+  const [u] = await db.insert(users).values({ email: EMAIL }).returning({ id: users.id });
+  userId = u!.id;
+});
+
+afterAll(async () => {
+  if (userId) await db.delete(users).where(eq(users.id, userId)).catch(() => {});
+});
+
+describe("spec-442: sent_at is stamped whenever status='sent'", () => {
+  it("ac-9/ac-2: a 'sent' insert with no explicit sentAt gets sent_at ≈ now()", async () => {
+    tagAc(AC_DEFAULT_IMPL);
+    tagAc(AC_SENT_SCOPE);
+    const before = Date.now();
+    const row = await recordComm({
+      userId,
+      channel: "email",
+      type: "transactional",
+      status: "sent",
+      subject: "no sentAt supplied",
+    });
+    expect(row?.sentAt).toBeInstanceOf(Date);
+    const stamped = row!.sentAt!.getTime();
+    expect(stamped).toBeGreaterThanOrEqual(before - 1000);
+    expect(stamped).toBeLessThanOrEqual(Date.now() + 1000);
+  });
+
+  it("ac-6: an explicitly threaded sentAt (Postmark SubmittedAt) is used verbatim", async () => {
+    tagAc(AC_STAMP_IMPL);
+    const submitted = new Date("2026-06-01T12:34:56.000Z");
+    const row = await recordComm({
+      userId,
+      channel: "email",
+      type: "transactional",
+      status: "sent",
+      sentAt: submitted,
+      subject: "explicit sentAt",
+    });
+    expect(row?.sentAt?.toISOString()).toBe(submitted.toISOString());
+  });
+
+  it("ac-6: recordEmailComm threads sentAt through to the stored row", async () => {
+    tagAc(AC_STAMP_IMPL);
+    const submitted = new Date("2026-05-15T09:00:00.000Z");
+    const row = await recordEmailComm({
+      to: EMAIL,
+      commsType: "magic_link",
+      subject: "Your Memex.AI sign-in link",
+      messageId: "pm-sentat-1",
+      sentAt: submitted,
+    });
+    expect(row?.sentAt?.toISOString()).toBe(submitted.toISOString());
+  });
+
+  it("ac-4: a 'scheduled' row keeps sent_at NULL (the invariant only binds 'sent')", async () => {
+    tagAc(AC_GUARD_SCOPE);
+    const row = await recordComm({
+      userId,
+      channel: "email",
+      type: "transactional",
+      status: "scheduled",
+      scheduledFor: new Date("2027-01-01T00:00:00.000Z"),
+      subject: "scheduled, not yet sent",
+    });
+    expect(row?.status).toBe("scheduled");
+    expect(row?.sentAt).toBeNull();
+  });
+
+  it("ac-6: PostmarkEmailSender parses SubmittedAt from the response and threads it as sentAt", async () => {
+    tagAc(AC_STAMP_IMPL);
+    vi.resetModules();
+    const recordSpy = vi.fn().mockResolvedValue(null);
+    // sender.ts (src/services/email/) imports recordEmailComm from "../comms-log.js",
+    // which resolves to src/services/comms-log.js — the same module this test reaches
+    // via "./comms-log.js". Mocking that path swaps the recorder the sender calls.
+    vi.doMock("./comms-log.js", () => ({ recordEmailComm: recordSpy }));
+    const { PostmarkEmailSender } = await import("./email/sender.js");
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ MessageID: "pm-sentat-2", SubmittedAt: "2026-06-23T10:11:12.000Z" }),
+      }),
+    );
+    const sender = new PostmarkEmailSender("tok", "Memex <x@memex.ai>");
+    await sender.send({ to: EMAIL, subject: "Your Memex.AI sign-in link", text: "hi", commsType: "magic_link" });
+
+    expect(recordSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messageId: "pm-sentat-2",
+        sentAt: new Date("2026-06-23T10:11:12.000Z"),
+      }),
+    );
+    vi.unstubAllGlobals();
+    vi.doUnmock("./comms-log.js");
+    vi.doUnmock("../services/comms-log.js");
+    vi.resetModules();
+  });
+
+  it("ac-7/ac-4: the DB CHECK rejects a raw status='sent' / sent_at=NULL insert", async () => {
+    tagAc(AC_CHECK_IMPL);
+    tagAc(AC_GUARD_SCOPE);
+    // Bypass recordComm's stamping and insert straight to the table — the DB CHECK
+    // is the backstop that must fire. Drizzle wraps the driver error, so the
+    // constraint name rides on the underlying PostgresError (err.cause).
+    let caught: unknown;
+    await db
+      .insert(commsLog)
+      .values({
+        userId,
+        channel: "email",
+        type: "transactional",
+        status: "sent",
+        sentAt: null,
+        subject: "raw insert bypassing recordComm's stamping",
+      })
+      .catch((e: unknown) => {
+        caught = e;
+      });
+    expect(caught, "a raw status='sent'/sent_at=NULL insert must be rejected").toBeDefined();
+    const cause = (caught as { cause?: { message?: string; constraint_name?: string; code?: string } })?.cause;
+    expect(cause?.code).toBe("23514"); // check_violation
+    expect(`${cause?.constraint_name} ${cause?.message}`).toContain("comms_log_sent_requires_sent_at");
+  });
+});

--- a/packages/server/src/services/comms-log.ts
+++ b/packages/server/src/services/comms-log.ts
@@ -81,6 +81,14 @@ export async function recordComm(
   conn: Db = db,
 ): Promise<CommsLogRow | null> {
   if (!input.userId) return null;
+  const status = input.status ?? "sent";
+  // spec-442 (ac-2/ac-6, dec-1/dec-2): enforce status='sent' ⇒ sent_at IS NOT NULL at
+  // the write path. When the row resolves to 'sent' but the caller threads no explicit
+  // send time, stamp now(); the real Postmark SubmittedAt is passed through when the
+  // response carries it. Scheduled/other statuses keep sent_at null until markCommSent()
+  // flips them. Holds for every caller (Postmark send, Stripe, tests), so no code path
+  // produces a 'sent' row with a null sent_at.
+  const sentAt = input.sentAt ?? (status === "sent" ? new Date() : null);
   try {
     const [row] = await conn
       .insert(commsLog)
@@ -88,9 +96,9 @@ export async function recordComm(
         userId: input.userId,
         channel: input.channel,
         type: input.type,
-        status: input.status ?? "sent",
+        status,
         scheduledFor: input.scheduledFor ?? null,
-        sentAt: input.sentAt ?? null,
+        sentAt,
         subject: input.subject ?? null,
         sourceRef: input.sourceRef ?? null,
       })
@@ -312,7 +320,7 @@ export function startCommsLogPrune(intervalMs: number = ONE_DAY_MS): NodeJS.Time
  * Advisory: any failure is logged and swallowed — never affects the send.
  */
 export async function recordEmailComm(
-  input: { to: string; userId?: string; commsType?: string; subject?: string; messageId?: string },
+  input: { to: string; userId?: string; commsType?: string; subject?: string; messageId?: string; sentAt?: Date | null },
   conn: Db = db,
 ): Promise<CommsLogRow | null> {
   try {
@@ -333,6 +341,9 @@ export async function recordEmailComm(
         type: input.commsType ?? "transactional",
         subject: input.subject ?? null,
         sourceRef: input.messageId ?? null,
+        // spec-442 (ac-6): thread the real Postmark send time (SubmittedAt) when the
+        // sender captured it. Omitted/null ⇒ recordComm stamps now() for the 'sent' row.
+        sentAt: input.sentAt ?? null,
       },
       conn,
     );

--- a/packages/server/src/services/email/auth-email-comms-type.integration.test.ts
+++ b/packages/server/src/services/email/auth-email-comms-type.integration.test.ts
@@ -1,0 +1,94 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { eq } from "drizzle-orm";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { db } from "../../db/connection.js";
+import { commsLog, users } from "../../db/schema.js";
+import { recordEmailComm } from "../comms-log.js";
+import { buildMagicLinkEmail, buildPasswordResetEmail } from "./templates.js";
+
+// spec-442 (ac-1 / ac-8): auth emails must carry a precise comms type, set at the
+// template write-site so the type travels with the message (mirroring how
+// buildVerificationEmail already stamps 'email_verification'). Before this fix the
+// magic-link and password-reset builders set no commsType, so recordEmailComm
+// defaulted them to 'transactional' — the bucket reserved for genuine non-auth mail.
+
+const AC_TYPE_SCOPE = "mindset-prod/memex-building-itself/specs/spec-442/acs/ac-1";
+const AC_TYPE_TEMPLATE = "mindset-prod/memex-building-itself/specs/spec-442/acs/ac-8";
+
+const MAGIC_EMAIL = "spec442-magic@example.com";
+const RESET_EMAIL = "spec442-reset@example.com";
+const PLAIN_EMAIL = "spec442-plain@example.com";
+
+let magicUser: string;
+let resetUser: string;
+let plainUser: string;
+
+beforeAll(async () => {
+  const rows = await db
+    .insert(users)
+    .values([{ email: MAGIC_EMAIL }, { email: RESET_EMAIL }, { email: PLAIN_EMAIL }])
+    .returning({ id: users.id, email: users.email });
+  magicUser = rows.find((r) => r.email === MAGIC_EMAIL)!.id;
+  resetUser = rows.find((r) => r.email === RESET_EMAIL)!.id;
+  plainUser = rows.find((r) => r.email === PLAIN_EMAIL)!.id;
+});
+
+afterAll(async () => {
+  const ids = [magicUser, resetUser, plainUser].filter(Boolean);
+  for (const id of ids) await db.delete(users).where(eq(users.id, id)).catch(() => {});
+});
+
+describe("spec-442: auth emails carry a precise comms type", () => {
+  it("ac-8: buildMagicLinkEmail stamps commsType 'magic_link' (not the transactional default)", () => {
+    tagAc(AC_TYPE_TEMPLATE);
+    const msg = buildMagicLinkEmail({ to: MAGIC_EMAIL, loginUrl: "https://memex.ai/login?t=abc" });
+    expect(msg.commsType).toBe("magic_link");
+    expect(msg.commsType).not.toBe("transactional");
+  });
+
+  it("ac-8: buildPasswordResetEmail stamps commsType 'password_reset' (not the transactional default)", () => {
+    tagAc(AC_TYPE_TEMPLATE);
+    const msg = buildPasswordResetEmail({ to: RESET_EMAIL, resetUrl: "https://memex.ai/reset?t=abc" });
+    expect(msg.commsType).toBe("password_reset");
+    expect(msg.commsType).not.toBe("transactional");
+  });
+
+  it("ac-1: a recorded magic-link email lands in comms_log with type='magic_link'", async () => {
+    tagAc(AC_TYPE_SCOPE);
+    const msg = buildMagicLinkEmail({ to: MAGIC_EMAIL, loginUrl: "https://memex.ai/login?t=xyz" });
+    const row = await recordEmailComm({
+      to: msg.to,
+      commsType: msg.commsType,
+      subject: msg.subject,
+      messageId: "pm-magic-1",
+    });
+    expect(row?.type).toBe("magic_link");
+    const [stored] = await db
+      .select({ type: commsLog.type })
+      .from(commsLog)
+      .where(eq(commsLog.id, row!.id));
+    expect(stored!.type).toBe("magic_link");
+  });
+
+  it("ac-1: a recorded password-reset email lands in comms_log with type='password_reset'", async () => {
+    tagAc(AC_TYPE_SCOPE);
+    const msg = buildPasswordResetEmail({ to: RESET_EMAIL, resetUrl: "https://memex.ai/reset?t=xyz" });
+    const row = await recordEmailComm({
+      to: msg.to,
+      commsType: msg.commsType,
+      subject: msg.subject,
+      messageId: "pm-reset-1",
+    });
+    expect(row?.type).toBe("password_reset");
+  });
+
+  it("ac-1: 'transactional' stays reserved — an email with no commsType is NOT re-typed as auth", async () => {
+    tagAc(AC_TYPE_SCOPE);
+    const row = await recordEmailComm({
+      to: PLAIN_EMAIL,
+      subject: "Your Memex.AI receipt",
+      messageId: "pm-plain-1",
+    });
+    expect(row?.type).toBe("transactional");
+  });
+});

--- a/packages/server/src/services/email/sender.ts
+++ b/packages/server/src/services/email/sender.ts
@@ -85,11 +85,18 @@ export class PostmarkEmailSender implements EmailSender {
     // never affect the send, so we also guard the response parse and never await
     // into the caller's failure path.
     let messageId: string | undefined;
+    let sentAt: Date | undefined;
     try {
-      const body = (await res.json()) as { MessageID?: string };
+      const body = (await res.json()) as { MessageID?: string; SubmittedAt?: string };
       messageId = body.MessageID;
+      // spec-442 (ac-6): use Postmark's SubmittedAt as the true send time when present
+      // and parseable; otherwise leave it undefined and let recordComm fall back to now().
+      if (body.SubmittedAt) {
+        const parsed = new Date(body.SubmittedAt);
+        if (!Number.isNaN(parsed.getTime())) sentAt = parsed;
+      }
     } catch {
-      // response parse is best-effort — proceed to record without a MessageID
+      // response parse is best-effort — proceed to record without a MessageID / send time
     }
     void recordEmailComm({
       to: message.to,
@@ -97,6 +104,7 @@ export class PostmarkEmailSender implements EmailSender {
       commsType: message.commsType,
       subject: message.subject,
       messageId,
+      sentAt,
     });
   }
 }

--- a/packages/server/src/services/email/templates.ts
+++ b/packages/server/src/services/email/templates.ts
@@ -383,6 +383,11 @@ export function buildMagicLinkEmail(input: MagicLinkEmailInput): EmailMessage {
     subject: `Your Memex.AI sign-in link`,
     text,
     html,
+    // spec-442 ac-1/ac-8: stamp the precise auth comms type so the sign-in link is
+    // classified as 'magic_link' in comms_log — the type travels with the template
+    // (mirroring email_verification above), else recordEmailComm defaults it to
+    // 'transactional', which is reserved for genuine non-auth mail.
+    commsType: "magic_link",
   };
 }
 
@@ -510,6 +515,11 @@ export function buildPasswordResetEmail(input: PasswordResetEmailInput): EmailMe
     subject: `Reset your Memex.AI password`,
     text,
     html,
+    // spec-442 ac-1/ac-8: stamp the precise auth comms type so the reset email is
+    // classified as 'password_reset' in comms_log — the type travels with the
+    // template (mirroring email_verification above), else recordEmailComm defaults
+    // it to 'transactional', which is reserved for genuine non-auth mail.
+    commsType: "password_reset",
   };
 }
 


### PR DESCRIPTION
Fixes two data-correctness defects in the email→`comms_log` write path that spec-341 shipped. No mail is sent or re-sent — data change only. Spec: `mindset-prod/memex-building-itself/specs/spec-442`.

## Defects
1. **Auth emails mis-typed `transactional`.** The magic-link and password-reset templates carried no `commsType`, so `recordEmailComm` defaulted them. (Verification email already set `email_verification` per spec-12.)
2. **`sent_at` never populated.** `recordComm` inserted `status='sent'` with `sent_at` NULL on every email.

## Fix
- **Templates** (`templates.ts`): stamp `commsType` `'magic_link'` / `'password_reset'` at the two auth builders so the type travels with the message.
- **Write path** (`comms-log.ts`): `recordComm` stamps `sent_at` (defaults to `now()`) for any resolved `status='sent'` row lacking one — holds for **every** caller. `recordEmailComm` forwards an optional `sentAt`.
- **Send time** (`sender.ts`): `PostmarkEmailSender` reads `SubmittedAt` from the Postmark response and threads it as the real send time (fallback `now()`).
- **Migration `0120`** (+ revert): re-types existing auth emails by subject; backfills `sent_at = created_at` for historical `sent`/NULL rows (documented approximation — no `comms_event` delivery time exists for them); adds CHECK `comms_log_sent_requires_sent_at` (`status <> 'sent' OR sent_at IS NOT NULL`) as **NOT VALID → VALIDATE** after the backfill. Mirrored in `schema.ts`.

`comms_log` stays user-keyed, RLS-excluded, and outside `mutate()` (spec-6 — unchanged; no `memex_id`, per dec-5).

## Testing
- 3 new tagged test files (type mapping, `sent_at` stamping + `SubmittedAt` threading, CHECK rejection, `0120` type-remap over seeded rows) — **ac-1…ac-9 all verified**.
- Updated 3 pre-existing fixtures that seeded invalid `sent`/NULL rows.
- **Full server suite green** (5137 passed; a first run's 7 failures were confirmed flaky parallel-DB teardown races — pass in isolation, clean on re-run). `tsc --noEmit` clean.

## Notes for reviewers
- The task's "wire up Postmark delivery-webhook ingestion into `comms_event`" follow-up is **already built** (spec-12 t-2, `routes/postmark-webhook.ts`); the empty table reflects no delivery webhooks received in-env, not missing code. Once those flow, real delivery data replaces the `created_at` approximation.
- The `sent_at=created_at` backfill's positive path can't be unit-tested after the fact (the new CHECK forbids creating the precondition); its end-state is guaranteed by the CHECK (ac-7). The type-remap half is tested directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)