### PR TITLE
release: spec-440 tenant-context safety (+ spec-442) → prod

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -154,6 +154,48 @@ jobs:
           include-hidden-files: true
           retention-days: 14
 
+  # spec-440: the RESTRICTED-ROLE RLS suite. Runs the tenancy/seed integration
+  # tests with the Drizzle singleton connected AS the non-owner `memex_app` role
+  # (RLS-subject), so a context-less write to an RLS-gated table FAILS here —
+  # making the spec-436 empty-workspace class visible in CI instead of only in
+  # prod. A SEPARATE vitest project (vitest.rls.config.ts); the sharded suite
+  # above runs as the owner and never exercises this path. Its global-setup
+  # enables LOGIN on memex_app in the ephemeral CI cluster only.
+  server-rls:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    services:
+      postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: memex
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/memex
+      MEMEX_EMIT_KEY: ${{ secrets.MEMEX_EMIT_KEY }}
+      MEMEX_EMIT: ${{ github.actor == 'dependabot[bot]' && 'false' || '' }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Seed test DB (cached template clone)
+        uses: ./.github/actions/migrate-db
+      - name: Restricted-role RLS suite (connects as memex_app)
+        run: pnpm --filter @memex/server test:rls
+
   # Merge the 3 shard coverage blobs and enforce the t-17 thresholds on the MERGED
   # full-suite coverage (spec-276 dec-2). This job's name is the STABLE required
   # check for branch protection — the matrix leg names ("server (1)" …) shift with

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@
 #   make typecheck           TypeScript type checking
 # ──────────────────────────────────────────────────────────────
 
-.PHONY: test test-unit test-integration test-api test-security test-perf test-regression \
+.PHONY: test test-unit test-integration test-api test-security test-perf test-regression test-rls \
         test-server test-ui e2e e2e-cold smoke smoke-int smoke-prod smoke-int-with-db smoke-prod-with-db \
         dev build db-migrate db-seed typecheck lint \
         check-url-shape help
@@ -61,6 +61,12 @@ test-perf:
 ## Server: regression guards (e.g. URL shape, instructions cap, mutate coverage)
 test-regression:
 	pnpm --filter @memex/server test:regression
+
+## Server: restricted-role RLS suite (spec-440) — connects the singleton AS the
+## non-owner `memex_app` role so tenancy/seed writes are SUBJECT to RLS, making a
+## missing app.memex_id fail in CI instead of only in prod. Requires local Postgres.
+test-rls:
+	pnpm --filter @memex/server test:rls
 
 ## Server: all test types
 test-server:

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -48,6 +48,7 @@
     "test:security": "vitest run src/__security__",
     "test:perf": "vitest run src/__perf__",
     "test:regression": "vitest run src/__regression__",
+    "test:rls": "vitest run --config vitest.rls.config.ts",
     "test:coverage": "vitest run --coverage",
     "notify:mcp-refs": "tsx scripts/notify-mcp-canonical-refs.ts",
     "email:send-test": "tsx scripts/send-test-email.ts",

--- a/packages/server/src/db/connection.ts
+++ b/packages/server/src/db/connection.ts
@@ -7,6 +7,7 @@ import type { ExtractTablesWithRelations } from "drizzle-orm";
 import postgres from "postgres";
 import * as schema from "./schema.js";
 import { instrumentSqlClientIfEnabled } from "../observability/otel/index.js";
+import { guardContextlessWrite, setRlsSubjectRuntime } from "./rls-context-guard.js";
 
 const connectionString = process.env.DATABASE_URL;
 
@@ -41,6 +42,26 @@ const poolOptions = {
 const client = socketPath
   ? postgres(connectionString, { host: socketPath, ...poolOptions })
   : postgres(connectionString, poolOptions);
+
+// Resolve ONCE whether this runtime's connection is subject to RLS — a non-owner
+// role with neither SUPERUSER nor BYPASSRLS (prod's `memex_app`). The
+// tenant-context guard (rls-context-guard.ts, spec-440) fires only when RLS is
+// actually enforced, so owner-connection paths (dev, the default test suite,
+// migrations, admin scripts) that bypass RLS (std-36: ENABLE, NO FORCE) stay
+// silent — no false positives. Fire-and-forget: the guard defaults inactive
+// until this resolves, and a probe failure simply leaves it inactive.
+void (async () => {
+  try {
+    const rows = (await client`
+      SELECT NOT (rolsuper OR rolbypassrls) AS subject
+      FROM pg_roles
+      WHERE rolname = current_user
+    `) as unknown as Array<{ subject: boolean }>;
+    setRlsSubjectRuntime(rows[0]?.subject === true);
+  } catch {
+    // Leave the guard inactive if the runtime role can't be determined.
+  }
+})();
 
 // ── Per-query RLS tenant injection (spec-199 ac-13–ac-17) ────────────────────
 //
@@ -209,6 +230,10 @@ function createRlsClient(baseClient: SqlClient): SqlClient {
       if (prop === "unsafe") {
         return (query: string, params: QueryParams = []) => {
           const ctx = memexContext.getStore();
+          // spec-440: make a context-less write to an RLS-gated table LOUD
+          // (warn + metric) before it silently fails RLS under memex_app. No-op
+          // unless the runtime is RLS-subject; cheap for reads / context-present.
+          guardContextlessWrite(query, ctx);
           if (!ctx?.memexId && !ctx?.userId) return target.unsafe(query, params);
           return makeRlsQuery(target, ctx, query, params);
         };

--- a/packages/server/src/db/rls-context-guard.test.ts
+++ b/packages/server/src/db/rls-context-guard.test.ts
@@ -1,0 +1,134 @@
+// spec-440 ac-9: the tenant-context guard makes a context-less write to an
+// RLS-gated table LOUD (warn + metric), phase 1 (no throw), catching raw
+// db.insert/update/delete — not just mutate(). Pure unit test: exercises the
+// guard's decision + emission directly, forcing the RLS-subject flag rather than
+// relying on the async boot probe, so it is deterministic and DB-free.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import {
+  __resetRlsGuardForTests,
+  __setRlsSubjectRuntimeForTests,
+  guardContextlessWrite,
+  isContextlessGatedWrite,
+  writeTargetTable,
+} from "./rls-context-guard.js";
+
+const AC_9 = "mindset-prod/memex-building-itself/specs/spec-440/acs/ac-9";
+
+let warnSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  __resetRlsGuardForTests();
+  // Silence the std-14 domain logger's console.log fan-out; assert on warn only.
+  vi.spyOn(console, "log").mockImplementation(() => {});
+  warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  __resetRlsGuardForTests();
+});
+
+describe("spec-440 ac-9: writeTargetTable extracts the write target", () => {
+  it("parses INSERT / UPDATE / DELETE, quoted + schema-qualified; reads → null", () => {
+    tagAc(AC_9);
+
+    expect(writeTargetTable('insert into "documents" ("id") values ($1)')).toBe("documents");
+    expect(writeTargetTable("INSERT INTO documents DEFAULT VALUES")).toBe("documents");
+    expect(writeTargetTable('update "presence" set "last_seen_at" = now()')).toBe("presence");
+    expect(writeTargetTable('update only "tasks" set x = 1')).toBe("tasks");
+    expect(writeTargetTable('delete from "acs" where "id" = $1')).toBe("acs");
+    expect(writeTargetTable('insert into "public"."decisions" (a) values (1)')).toBe("decisions");
+    expect(writeTargetTable('  \n  insert into "issues" (a) values (1)')).toBe("issues");
+
+    // Reads and non-writes carry no write target.
+    expect(writeTargetTable('select * from "documents"')).toBeNull();
+    expect(writeTargetTable("SELECT 1")).toBeNull();
+    expect(writeTargetTable("begin")).toBeNull();
+  });
+});
+
+describe("spec-440 ac-9: isContextlessGatedWrite decision", () => {
+  it("true only for a write to a gated table with no memexId in context", () => {
+    tagAc(AC_9);
+
+    // Gated write, no context → a violation.
+    expect(isContextlessGatedWrite('insert into "documents" (a) values (1)', undefined)).toBe(true);
+    expect(isContextlessGatedWrite('insert into "documents" (a) values (1)', {})).toBe(true);
+    // userId-only context still lacks app.memex_id → a write still violates.
+    expect(
+      isContextlessGatedWrite('insert into "documents" (a) values (1)', {} as { memexId?: string }),
+    ).toBe(true);
+
+    // Tenant context present → RLS will pass, not a violation.
+    expect(
+      isContextlessGatedWrite('insert into "documents" (a) values (1)', { memexId: "m-1" }),
+    ).toBe(false);
+
+    // Non-gated table → never a violation (e.g. activity_log, usage_events).
+    expect(isContextlessGatedWrite('insert into "activity_log" (a) values (1)', undefined)).toBe(
+      false,
+    );
+    expect(isContextlessGatedWrite('insert into "usage_events" (a) values (1)', undefined)).toBe(
+      false,
+    );
+
+    // Reads are never violations, even on a gated table with no context.
+    expect(isContextlessGatedWrite('select * from "documents"', undefined)).toBe(false);
+  });
+});
+
+describe("spec-440 ac-9: guardContextlessWrite emits LOUD, only when RLS-subject", () => {
+  it("warns (once per table) on a context-less gated write when the runtime is RLS-subject", () => {
+    tagAc(AC_9);
+    __setRlsSubjectRuntimeForTests(true);
+
+    guardContextlessWrite('insert into "documents" (a) values (1)', undefined);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(String(warnSpy.mock.calls[0]?.[0])).toContain("[rls]");
+    expect(String(warnSpy.mock.calls[0]?.[0])).toContain("documents");
+
+    // Dedup: a second write to the same table warns no more (metric still counts).
+    guardContextlessWrite('insert into "documents" (b) values (2)', undefined);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+
+    // A different gated table warns once more.
+    guardContextlessWrite('update "presence" set x = 1', undefined);
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("does NOT warn when tenant context is present", () => {
+    tagAc(AC_9);
+    __setRlsSubjectRuntimeForTests(true);
+
+    guardContextlessWrite('insert into "documents" (a) values (1)', { memexId: "m-1" });
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("does NOT warn on a context-less write to a NON-gated table", () => {
+    tagAc(AC_9);
+    __setRlsSubjectRuntimeForTests(true);
+
+    guardContextlessWrite('insert into "activity_log" (a) values (1)', undefined);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("does NOT warn on a read, even of a gated table", () => {
+    tagAc(AC_9);
+    __setRlsSubjectRuntimeForTests(true);
+
+    guardContextlessWrite('select * from "documents"', undefined);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("stays SILENT when the runtime is NOT RLS-subject (owner connection)", () => {
+    tagAc(AC_9);
+    __setRlsSubjectRuntimeForTests(false);
+
+    // The exact write that would warn under memex_app is a no-op under the owner
+    // role (RLS bypassed), so the guard must not cry wolf in dev/test/migrations.
+    guardContextlessWrite('insert into "documents" (a) values (1)', undefined);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/server/src/db/rls-context-guard.ts
+++ b/packages/server/src/db/rls-context-guard.ts
@@ -1,0 +1,127 @@
+// The tenant-context guard (spec-440 dec-2, phase 1: LOUD, not fatal).
+//
+// A write to an RLS-gated tenant table only satisfies the `*_memex_isolation`
+// policy when `app.memex_id` is set in the session — supplied by the rlsClient
+// proxy from the `memexContext` ALS store. A code path that writes such a table
+// with NO active `runWithMemexId(memexId, …)` on its async stack is rejected by
+// Postgres under the non-owner `memex_app` runtime role (prod) — and that
+// rejection is often swallowed by best-effort `try/catch`, so the only symptom
+// is missing data days later (the spec-436 empty-workspace class).
+//
+// This guard makes that class LOUD at the moment it happens: when a context-less
+// write targets a gated table AND the runtime is actually subject to RLS, it
+// emits a WARN (Cloud Run + the std-14 `rls` domain log) and bumps a metric. It
+// does NOT throw — phase 1 observes so we can audit callers from the signal
+// before phase 2 (mutate() throwing, dec-2). Catching raw `db.insert`/`db.update`
+// as well as mutate() is exactly why it lives at the proxy boundary, not in
+// mutate() (which never sees the raw SQL).
+//
+// ROLE-AWARE by design: the guard fires ONLY when the runtime connection is
+// RLS-subject (a non-owner, NOBYPASSRLS role — prod's `memex_app`, and the
+// restricted-role test harness of dec-1). Under the owner role (dev, the default
+// vitest suite, migrations, admin scripts) RLS is bypassed (std-36: ENABLE, NO
+// FORCE), so a context-less gated write is harmless there and the guard stays
+// silent — no false-positive firehose. connection.ts resolves the role once at
+// boot and calls setRlsSubjectRuntime().
+
+import { createDomainLogger } from "../observability/domain-logger.js";
+import { recordRlsContextViolation } from "../observability/otel/index.js";
+import { isRlsGatedTable } from "./rls-tables.js";
+
+const log = createDomainLogger("rls");
+
+// Whether THIS runtime's DB connection is subject to RLS (non-owner /
+// NOBYPASSRLS). Defaults false so nothing fires until the role is positively
+// confirmed RLS-subject — dev/test/migration owner connections stay silent.
+let rlsSubjectRuntime = false;
+// A test override (via __setRlsSubjectRuntimeForTests) latches this so the
+// async boot probe in connection.ts can't clobber it mid-test (the probe runs
+// at module load and may resolve at any point during a test run).
+let explicitlySet = false;
+
+/** Called once by connection.ts after it resolves the runtime role. A test
+ * override wins — the boot probe never overwrites an explicitly-set value. */
+export function setRlsSubjectRuntime(isSubject: boolean): void {
+  if (explicitlySet) return;
+  rlsSubjectRuntime = isSubject;
+}
+
+// Warn once per table per process so a hot write loop can't flood the logs; the
+// metric still counts every occurrence. Reset between tests via the test hook.
+const warnedTables = new Set<string>();
+
+/**
+ * The leading write target of a SQL statement, lower-cased, or null when the
+ * statement is not an INSERT/UPDATE/DELETE (reads never violate a write policy).
+ * Tolerates an optional `public.` schema qualifier and double-quoting, matching
+ * the shape Drizzle's postgres-js driver emits (`insert into "documents" …`).
+ */
+export function writeTargetTable(sql: string): string | null {
+  const m =
+    /^\s*(?:insert\s+into|update(?:\s+only)?|delete\s+from)\s+(?:"?public"?\.)?"?([a-z_][a-z0-9_$]*)"?/i.exec(
+      sql,
+    );
+  return m ? m[1]!.toLowerCase() : null;
+}
+
+/** True iff `sql` is a write to an RLS-gated table with no tenant in `ctx`. */
+export function isContextlessGatedWrite(
+  sql: string,
+  ctx: { memexId?: string } | undefined,
+): boolean {
+  if (ctx?.memexId) return false; // tenant context present → RLS will pass
+  const table = writeTargetTable(sql);
+  return table !== null && isRlsGatedTable(table);
+}
+
+/** Emit the WARN + metric for one violation. Exported for direct testing. */
+export function reportRlsContextViolation(table: string): void {
+  // Metric on EVERY occurrence (no-op unless OTLP telemetry is configured).
+  recordRlsContextViolation(table);
+  // WARN once per table to keep logs readable. console.warn is the real severity
+  // signal in Cloud Run (production observability, cl-30); the domain log is the
+  // greppable std-14 trail.
+  if (warnedTables.has(table)) return;
+  warnedTables.add(table);
+  const msg =
+    `context-less write to RLS-gated table "${table}" — no app.memex_id in context. ` +
+    `Under the memex_app runtime role this write is REJECTED by RLS and, if best-effort, ` +
+    `silently drops data. Wrap the call in runWithMemexId(memexId, …). [spec-440]`;
+  console.warn(`[rls] ${msg}`);
+  log.block("guard", `context-less gated-table write: ${table}`, msg);
+}
+
+/**
+ * The proxy hook. Cheap no-op unless the runtime is RLS-subject; only then does
+ * it inspect the statement. Called from the rlsClient `unsafe` intercept for
+ * every query, so the fast path (guard inactive, or a read, or context present)
+ * must stay allocation-light.
+ */
+export function guardContextlessWrite(
+  sql: string,
+  ctx: { memexId?: string } | undefined,
+): void {
+  if (!rlsSubjectRuntime) return;
+  if (!isContextlessGatedWrite(sql, ctx)) return;
+  reportRlsContextViolation(writeTargetTable(sql)!);
+}
+
+/** Test-only: reset the module's activation + dedup state. */
+export function __resetRlsGuardForTests(): void {
+  rlsSubjectRuntime = false;
+  explicitlySet = false;
+  warnedTables.clear();
+}
+
+/** Test-only: force (and latch) the RLS-subject activation flag. */
+export function __setRlsSubjectRuntimeForTests(isSubject: boolean): void {
+  rlsSubjectRuntime = isSubject;
+  explicitlySet = true;
+}
+
+/** Test-only: clear only the warn-dedup set, leaving activation untouched — so an
+ * integration test under the real memex_app role can re-assert the WARN without
+ * deactivating the guard the boot probe legitimately turned on. */
+export function __clearRlsGuardWarnedTablesForTests(): void {
+  warnedTables.clear();
+}

--- a/packages/server/src/db/rls-harness-isolation.test.ts
+++ b/packages/server/src/db/rls-harness-isolation.test.ts
@@ -1,0 +1,47 @@
+// spec-440 ac-8: the restricted-role RLS project is CONFINED — the default suite
+// (this test runs in it) still connects as the DB OWNER, which bypasses RLS
+// (std-36: ENABLE, NO FORCE), so the 200+ owner-visibility suites are unaffected.
+// Two independent guarantees:
+//   1. the default project connects as an RLS-BYPASSING owner (not memex_app);
+//   2. the default config EXCLUDES the *.rls-restricted.test.ts glob, so those
+//      suites can only ever run under vitest.rls.config.ts (as memex_app).
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { sql } from "drizzle-orm";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { db } from "./connection.js";
+
+const AC_8 = "mindset-prod/memex-building-itself/specs/spec-440/acs/ac-8";
+
+describe("spec-440 ac-8: the restricted-role harness is confined to its own project", () => {
+  it("the default suite connects as an RLS-bypassing owner (not memex_app)", async () => {
+    tagAc(AC_8);
+
+    const rows = (await db.execute(
+      sql`SELECT current_user AS role, (rolsuper OR rolbypassrls) AS bypasses
+          FROM pg_roles WHERE rolname = current_user`,
+    )) as unknown as Array<{ role: string; bypasses: boolean }>;
+
+    // Owner bypass is exactly why owner suites are unaffected: they see every
+    // row regardless of app.memex_id. If this ever read `memex_app`, the default
+    // suite would have flipped RLS-subject and could break unrelated suites.
+    expect(rows[0]?.role).not.toBe("memex_app");
+    expect(rows[0]?.bypasses).toBe(true);
+  });
+
+  it("the default vitest config excludes the *.rls-restricted.test.ts glob", () => {
+    tagAc(AC_8);
+
+    const configPath = resolve(
+      dirname(fileURLToPath(import.meta.url)),
+      "../../vitest.config.ts",
+    );
+    const config = readFileSync(configPath, "utf8");
+    // The restricted suites must be excluded here so they never run under the
+    // owner connection (where the RLS assertion would be vacuous).
+    expect(config).toContain("src/**/*.rls-restricted.test.ts");
+  });
+});

--- a/packages/server/src/db/rls-tables.pg-policy-parity.test.ts
+++ b/packages/server/src/db/rls-tables.pg-policy-parity.test.ts
@@ -1,0 +1,50 @@
+// spec-440 ac-11: the gated-table set is a SINGLE SOURCE OF TRUTH that cannot
+// silently drift from the migrations. RLS_TENANT_TABLES is hand-maintained, so
+// this test pins it to the live schema: it must EXACTLY equal the set of tables
+// carrying a `*_memex_isolation` policy in pg_policies. Add a gated table (or
+// drop a policy) in a migration without updating the constant → this fails CI.
+//
+// Runs against the local test DB as the owner role (a catalog read); it asserts
+// what the schema actually enforces, independent of which role the app connects
+// as at runtime.
+
+import { describe, expect, it } from "vitest";
+import { sql } from "drizzle-orm";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { db } from "./connection.js";
+import { RLS_TENANT_TABLES } from "./rls-tables.js";
+
+const AC_11 = "mindset-prod/memex-building-itself/specs/spec-440/acs/ac-11";
+
+describe("spec-440 ac-11: RLS_TENANT_TABLES matches the live *_memex_isolation policy set", () => {
+  it("the constant equals pg_policies' _memex_isolation tables, exactly (no drift)", async () => {
+    tagAc(AC_11);
+
+    const rows = (await db.execute(sql`
+      SELECT tablename
+      FROM pg_policies
+      WHERE policyname LIKE '%\\_memex\\_isolation'
+      ORDER BY tablename
+    `)) as unknown as Array<{ tablename: string }>;
+
+    const live = new Set(rows.map((r) => r.tablename));
+    const declared = new Set(RLS_TENANT_TABLES);
+
+    // Symmetric difference, reported both ways so a failure names the exact gap.
+    const missingFromConstant = [...live].filter((t) => !declared.has(t)).sort();
+    const staleInConstant = [...declared].filter((t) => !live.has(t)).sort();
+
+    expect(
+      missingFromConstant,
+      `gated tables in the schema but NOT in RLS_TENANT_TABLES (add them): ${missingFromConstant.join(", ")}`,
+    ).toEqual([]);
+    expect(
+      staleInConstant,
+      `tables in RLS_TENANT_TABLES with NO live _memex_isolation policy (remove them): ${staleInConstant.join(", ")}`,
+    ).toEqual([]);
+
+    // Sanity: the set is non-empty (a broken query returning 0 rows would make
+    // the two "empty diff" assertions vacuously pass).
+    expect(live.size).toBeGreaterThan(0);
+  });
+});

--- a/packages/server/src/db/rls-tables.ts
+++ b/packages/server/src/db/rls-tables.ts
@@ -1,0 +1,48 @@
+// The RLS-gated tenant tables — the single source of truth for "which tables
+// enforce per-tenant isolation" (spec-440 dec-2 / ac-11).
+//
+// Each table here carries a `<table>_memex_isolation` policy (FOR ALL, USING +
+// WITH CHECK on `app.memex_id = memex_id`) created by the migrations (0081,
+// 0087, 0092, 0100, 0114, 0115). A write to any of these tables only satisfies
+// RLS when `app.memex_id` is set in the session — supplied by the rlsClient
+// proxy from the `memexContext` ALS store (connection.ts). Under the non-owner
+// runtime role `memex_app` (prod), a context-less write is REJECTED; under the
+// owner role (dev/test/migrations) it is bypassed (std-36: ENABLE, NO FORCE).
+//
+// This list is HAND-MAINTAINED but drift-proofed: `rls-tables.pg-policy-parity`
+// asserts it exactly equals `SELECT tablename FROM pg_policies WHERE policyname
+// LIKE '%_memex_isolation'` against the live schema, so a new gated table (or a
+// removed policy) that isn't reflected here fails CI. When you add/remove a
+// `*_memex_isolation` policy in a migration, update this set in the same change.
+//
+// NOTE the deliberate EXCLUSION of `memex_emission_keys`: it was given the
+// policy in 0081 but had it DROPPED in 0087_emission_keys_rls_exclusion.sql — it
+// is an identity-establishment table read BEFORE any tenant context exists, so
+// it must stay RLS-free (pinned by __regression__/emission-key-contextless-verify).
+export const RLS_TENANT_TABLES: ReadonlySet<string> = new Set([
+  "acs",
+  "clause_refs",
+  "comment_mentions",
+  "decision_facet_ballots",
+  "decisions",
+  "doc_assignees",
+  "doc_comments",
+  "doc_members",
+  "document_tags",
+  "documents",
+  "facet_routing_log",
+  "issues",
+  "presence",
+  "qa_report_views",
+  "repos",
+  "standard_clause_facets",
+  "standard_clauses",
+  "tags",
+  "task_facet_ballots",
+  "tasks",
+]);
+
+/** True iff `table` is one of the RLS-gated tenant tables (case-insensitive). */
+export function isRlsGatedTable(table: string): boolean {
+  return RLS_TENANT_TABLES.has(table.toLowerCase());
+}

--- a/packages/server/src/db/test-db-url.ts
+++ b/packages/server/src/db/test-db-url.ts
@@ -65,6 +65,29 @@ export function deriveWorkerDatabaseUrl(
   return url.toString();
 }
 
+// ── Restricted-role RLS test harness (spec-440 dec-1) ────────────────────────
+//
+// The default suite connects as the DB owner (`postgres`), which BYPASSES RLS
+// (std-36: ENABLE, NO FORCE), so a missing `app.memex_id` is invisible in test.
+// The RLS project (vitest.rls.config.ts) connects the singleton AS the real
+// prod runtime role `memex_app` — a non-owner, NOBYPASSRLS role that is SUBJECT
+// to every `*_memex_isolation` policy — so a context-less write to a gated table
+// FAILS in test exactly as it does in prod. `memex_app` is NOLOGIN by default
+// (prod grants login via a deploy secret); the RLS global-setup enables LOGIN on
+// it with this fixed password, in the TEST cluster only. Its table grants are
+// already in the migrated template (migration 0081), inherited by every clone.
+export const RLS_TEST_ROLE = "memex_app";
+export const RLS_TEST_ROLE_PASSWORD = "memex_app_test_only";
+
+/** Rewrite a connection URL to authenticate as the restricted RLS runtime role
+ * (`memex_app`). Preserves host/port/database/query — only credentials change. */
+export function deriveRestrictedRoleUrl(url: string): string {
+  const u = new URL(url);
+  u.username = RLS_TEST_ROLE;
+  u.password = RLS_TEST_ROLE_PASSWORD;
+  return u.toString();
+}
+
 // Env-aware resolution used by both vitest.config.ts (worker env override)
 // and vitest.global-setup.ts (create/migrate) so they always agree on the
 // same database.

--- a/packages/server/src/observability/otel/index.ts
+++ b/packages/server/src/observability/otel/index.ts
@@ -13,6 +13,7 @@
  *
  * The singleton ties both to one MeterProvider / exporter built from config.
  */
+import type { Counter } from "@opentelemetry/api";
 import type { MeterProvider } from "@opentelemetry/sdk-metrics";
 import { type OtelConfig, readOtelConfig } from "./config.js";
 import {
@@ -73,7 +74,38 @@ export function startDbTelemetry(
   return provider;
 }
 
+// ── RLS tenant-context guard metric (spec-440 dec-2) ─────────────────────────
+// A correctness counter, not a DB-health signal, so it rides the shared
+// MeterProvider on its OWN meter ("memex.rls") rather than db-telemetry's
+// instruments. Lazily created on first violation; a no-op when telemetry is
+// disabled (local dev + tests), so the guard's console.warn is the only signal
+// there — which is exactly what makes the class visible without an OTLP backend.
+let rlsViolationCounter: Counter | null = null;
+
+/**
+ * Record one RLS tenant-context violation (a write to an RLS-gated table with no
+ * `app.memex_id` in context). No-op unless OTLP telemetry is configured. The
+ * `table` label is drawn from the fixed RLS_TENANT_TABLES set, so it is bounded /
+ * low-cardinality and safe as a metric label (never a tenant or user id).
+ */
+export function recordRlsContextViolation(
+  table: string,
+  config: OtelConfig = readOtelConfig(),
+): void {
+  if (!config.enabled) return;
+  if (!rlsViolationCounter) {
+    rlsViolationCounter = getDbTelemetry(config).provider
+      .getMeter("memex.rls")
+      .createCounter("memex.db.rls.context_violations", {
+        description:
+          "Writes to an RLS-gated table attempted with no app.memex_id in context.",
+      });
+  }
+  rlsViolationCounter.add(1, { table });
+}
+
 /** Test-only: drop the singleton so a fresh config can be applied. */
 export function __resetDbTelemetryForTests(): void {
   singleton = null;
+  rlsViolationCounter = null;
 }

--- a/packages/server/src/services/default-standards.ts
+++ b/packages/server/src/services/default-standards.ts
@@ -19,7 +19,7 @@
 // self-heal machinery that an is_demo flag would afford — see dec-3.
 
 import { and, eq } from "drizzle-orm";
-import { db } from "../db/connection.js";
+import { db, runWithMemexId } from "../db/connection.js";
 import { documents, namespaces, memexes } from "../db/schema.js";
 import { createDocDraft } from "./documents.js";
 import { addSection } from "./sections.js";
@@ -112,10 +112,16 @@ export async function backfillDefaultStandards(): Promise<{ memexesSeeded: numbe
 
   let memexesSeeded = 0;
   for (const { memexId } of personalMemexes) {
-    const before = await countStandards(memexId);
-    await seedDefaultStandards(memexId);
-    // Count only Memexes that had ZERO Standards and therefore got the fresh seed.
-    if (before === 0) memexesSeeded += 1;
+    // spec-440: run the per-memex read (countStandards) + seed (seedDefaultStandards →
+    // documents/standard_clauses/clause_refs) inside the tenant context so they carry
+    // app.memex_id and satisfy RLS under the runtime memex_app role. Deploy-wired
+    // (deploy.sh); correct regardless of the connecting role with this wrapper.
+    await runWithMemexId(memexId, async () => {
+      const before = await countStandards(memexId);
+      await seedDefaultStandards(memexId);
+      // Count only Memexes that had ZERO Standards and therefore got the fresh seed.
+      if (before === 0) memexesSeeded += 1;
+    });
   }
   return { memexesSeeded };
 }

--- a/packages/server/src/services/handhold-demo.ts
+++ b/packages/server/src/services/handhold-demo.ts
@@ -18,7 +18,7 @@
 // and the per-phase value banner (attached by getDoc).
 
 import { and, eq, inArray } from "drizzle-orm";
-import { db } from "../db/connection.js";
+import { db, runWithMemexId } from "../db/connection.js";
 import {
   documents,
   namespaces,
@@ -422,13 +422,20 @@ export async function backfillHandholdDemo(): Promise<{ memexesSeeded: number }>
 
   let memexesSeeded = 0;
   for (const { memexId } of personalMemexes) {
-    const before = await listDemoDocIds(memexId);
-    // Call seedHandholdDemo UNCONDITIONALLY (issue-2): it no-ops on a canonical full
-    // set and self-heals a partial/doubled set, so the per-deploy backfill doubles as
-    // the periodic self-heal trigger. Count only memexes that had ZERO demo docs and
-    // got a fresh seed — a heal of a partial set is not a new seed.
-    await seedHandholdDemo(memexId);
-    if (before.length === 0) memexesSeeded += 1;
+    // spec-440: establish the per-memex tenant context so the gated-table reads
+    // (listDemoDocIds) and writes (seedHandholdDemo → documents/decisions/tasks/acs)
+    // carry app.memex_id and satisfy RLS under the runtime memex_app role. This
+    // backfill is deploy-wired (deploy.sh) and today runs as the owner (bypassing
+    // RLS), but the wrapper makes it correct regardless of the connecting role.
+    await runWithMemexId(memexId, async () => {
+      const before = await listDemoDocIds(memexId);
+      // Call seedHandholdDemo UNCONDITIONALLY (issue-2): it no-ops on a canonical full
+      // set and self-heals a partial/doubled set, so the per-deploy backfill doubles as
+      // the periodic self-heal trigger. Count only memexes that had ZERO demo docs and
+      // got a fresh seed — a heal of a partial set is not a new seed.
+      await seedHandholdDemo(memexId);
+      if (before.length === 0) memexesSeeded += 1;
+    });
   }
   return { memexesSeeded };
 }

--- a/packages/server/src/services/mutate.ambient-tenancy.test.ts
+++ b/packages/server/src/services/mutate.ambient-tenancy.test.ts
@@ -1,0 +1,40 @@
+// spec-440 ac-12 (dec-3): this Spec keeps tenant identity AMBIENT
+// (AsyncLocalStorage via runWithMemexId) and deliberately does NOT thread an
+// explicit memexId/RequestCtx through mutate(). The durable type-level fix —
+// making tenancy carried by the write rather than ambient — is recorded as a
+// follow-on (spec-440 issue-1), not built here (its marginal value drops once
+// the loud guard + restricted-role CI harness land). This test guards that
+// decision: if someone later adds a memexId to mutate()'s RequestCtx, they must
+// revisit dec-3 rather than drift into a half-done refactor.
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+const AC_12 = "mindset-prod/memex-building-itself/specs/spec-440/acs/ac-12";
+
+describe("spec-440 ac-12: mutate() tenancy stays ambient (dec-3)", () => {
+  it("mutate()'s RequestCtx does NOT carry a memexId — tenancy is not threaded through mutate", () => {
+    tagAc(AC_12);
+
+    const src = readFileSync(
+      resolve(dirname(fileURLToPath(import.meta.url)), "./mutate.ts"),
+      "utf8",
+    );
+
+    // Isolate the RequestCtx interface body so an unrelated `memexId` elsewhere
+    // in the file (e.g. ChangeKey.memexId, which is the bus key — not the write's
+    // ambient tenant) can't mask a real change to the write context.
+    const match = /export interface RequestCtx\s*\{([\s\S]*?)\n\}/.exec(src);
+    expect(match, "RequestCtx interface not found in mutate.ts").not.toBeNull();
+    const body = match![1]!;
+
+    expect(
+      /\bmemexId\b/.test(body),
+      "RequestCtx gained a memexId — dec-3 chose ambient ALS + guard over threading " +
+        "an explicit tenant id through mutate(). Revisit spec-440 dec-3 / issue-1 before adding this.",
+    ).toBe(false);
+  });
+});

--- a/packages/server/src/services/user-namespaces.seed.rls-restricted.test.ts
+++ b/packages/server/src/services/user-namespaces.seed.rls-restricted.test.ts
@@ -1,0 +1,195 @@
+// spec-440 — the RESTRICTED-ROLE regression (runs ONLY under vitest.rls.config.ts,
+// i.e. connected AS the non-owner `memex_app` role, RLS-subject). This is the test
+// the spec-436 fix could not have here in the owner-connection suite: because the
+// default suite connects as the DB owner (RLS bypassed), a "did the docs seed?"
+// assertion passes with OR without the runWithMemexId wrapper. Under memex_app it
+// does not — a context-less write to a gated table is REJECTED by Postgres, so the
+// spec-436 empty-workspace class is finally catchable by OUTCOME, in CI, on a laptop.
+//
+// This file is excluded from the default project (vitest.config.ts) and included
+// only by vitest.rls.config.ts. `make test-rls` runs it. It exercises real service
+// code (ensureUserNamespace → seedNewPersonalMemex) through the singleton, so the
+// connecting role — not a hand-rolled second connection — is what enforces RLS.
+
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { and, eq, inArray, sql } from "drizzle-orm";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { db, runWithMemexId } from "../db/connection.js";
+import { documents, namespaces, standardClauses, users } from "../db/schema.js";
+import { ensureUserNamespace } from "./user-namespaces.js";
+import { upsertUserByEmail } from "./users.js";
+import { backfillDefaultStandards } from "./default-standards.js";
+
+const AC = "mindset-prod/memex-building-itself/specs/spec-440/acs";
+
+const createdNamespaceIds: string[] = [];
+const createdUserIds: string[] = [];
+const createdMemexIds: string[] = [];
+
+async function makeUserWithMemex(tag: string): Promise<{ userId: string; memexId: string }> {
+  const user = await upsertUserByEmail(
+    `spec440-${tag}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}@example.com`,
+  );
+  createdUserIds.push(user.id);
+  const created = await ensureUserNamespace(user.id);
+  createdMemexIds.push(created.memex.id);
+  const [ns] = await db
+    .select({ id: namespaces.id })
+    .from(namespaces)
+    .where(and(eq(namespaces.ownerUserId, user.id), eq(namespaces.kind, "user")))
+    .limit(1);
+  if (ns) createdNamespaceIds.push(ns.id);
+  return { userId: user.id, memexId: created.memex.id };
+}
+
+let fixtureMemexId: string;
+
+beforeAll(async () => {
+  // A memex to hang the deliberate-rejection test on. Seeds are off suite-wide,
+  // so this creates only non-gated rows (namespace + memex) — writable by
+  // memex_app without a tenant GUC.
+  const fixture = await makeUserWithMemex("fixture");
+  fixtureMemexId = fixture.memexId;
+});
+
+afterAll(async () => {
+  // Clean up as memex_app WITH the tenant GUC set, so gated deletes satisfy RLS.
+  // Best-effort — the per-worker clone is dropped/recreated every run anyway.
+  for (const memexId of createdMemexIds) {
+    await runWithMemexId(memexId, async () => {
+      await db.delete(documents).where(eq(documents.memexId, memexId)).catch(() => {});
+    });
+  }
+  if (createdNamespaceIds.length) {
+    await db.delete(namespaces).where(inArray(namespaces.id, createdNamespaceIds)).catch(() => {});
+  }
+  if (createdUserIds.length) {
+    await db.delete(users).where(inArray(users.id, createdUserIds)).catch(() => {});
+  }
+});
+
+describe("spec-440 — provisioning seed under the restricted memex_app role", () => {
+  it("ac-6: the singleton is connected AS the non-owner memex_app role", async () => {
+    tagAc(`${AC}/ac-6`);
+
+    const rows = (await db.execute(
+      sql`SELECT current_user AS role, (rolbypassrls OR rolsuper) AS bypasses
+          FROM pg_roles WHERE rolname = current_user`,
+    )) as unknown as Array<{ role: string; bypasses: boolean }>;
+
+    // The whole point of the harness: real service code runs as an RLS-subject
+    // role, not the owner. If this ever reads `postgres`, the project mis-wired
+    // and every RLS assertion below would be vacuous.
+    expect(rows[0]?.role).toBe("memex_app");
+    expect(rows[0]?.bypasses).toBe(false);
+  });
+
+  it("ac-1/ac-2: a context-less write to a gated table is REJECTED by RLS and made LOUD", async () => {
+    tagAc(`${AC}/ac-1`);
+    tagAc(`${AC}/ac-2`);
+
+    const { __clearRlsGuardWarnedTablesForTests } = await import("../db/rls-context-guard.js");
+    __clearRlsGuardWarnedTablesForTests();
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(console, "log").mockImplementation(() => {}); // silence the domain log fan-out
+
+    try {
+      // No runWithMemexId → no app.memex_id. Under memex_app the documents
+      // WITH CHECK policy rejects this INSERT — the exact spec-436 failure.
+      let caught: unknown;
+      try {
+        await db.insert(documents).values({
+          memexId: fixtureMemexId,
+          handle: "spec440-rls-reject",
+          title: "should be rejected",
+          docType: "document",
+        });
+      } catch (err) {
+        caught = err;
+      }
+
+      // Drizzle wraps the driver error ("Failed query: …"); the Postgres RLS
+      // message rides on `.cause`. Check both so we assert the REAL cause, not
+      // merely that some error was thrown.
+      expect(caught, "the context-less gated write must be rejected").toBeDefined();
+      const errText = `${(caught as Error)?.message ?? ""} ${
+        ((caught as Error)?.cause as Error | undefined)?.message ?? ""
+      }`;
+      expect(errText).toMatch(/row-level security/i);
+
+      // …and the guard made it LOUD before Postgres rejected it (dec-2 phase 1).
+      expect(warnSpy).toHaveBeenCalled();
+      expect(String(warnSpy.mock.calls[0]?.[0])).toContain("[rls]");
+      expect(String(warnSpy.mock.calls[0]?.[0])).toContain("documents");
+    } finally {
+      vi.restoreAllMocks();
+    }
+  });
+
+  it("ac-7: seedNewPersonalMemex seeds gated rows under memex_app (removing the wrapper would fail this)", async () => {
+    tagAc(`${AC}/ac-7`);
+
+    // Turn the default-Standards seeder ON just for this creation (it writes
+    // `documents` + `standard_clauses` — both RLS-gated). The gate reads env at
+    // call time, so scope it tightly and restore after.
+    const prev = process.env.MEMEX_DEFAULT_STANDARDS_SIGNUP_SEED;
+    process.env.MEMEX_DEFAULT_STANDARDS_SIGNUP_SEED = "on";
+    let memexId: string;
+    try {
+      ({ memexId } = await makeUserWithMemex("seed"));
+    } finally {
+      process.env.MEMEX_DEFAULT_STANDARDS_SIGNUP_SEED = prev;
+    }
+
+    // Read WITH the tenant GUC (memex_app sees a gated table's rows only under
+    // the matching app.memex_id). Non-zero ⇒ the seed INSERTs satisfied RLS,
+    // which they can ONLY do because seedNewPersonalMemex wraps them in
+    // runWithMemexId(memexId). Remove that wrapper and this drops to 0 → red.
+    const { docCount, clauseCount } = await runWithMemexId(memexId, async () => {
+      const docs = await db
+        .select({ id: documents.id })
+        .from(documents)
+        .where(eq(documents.memexId, memexId));
+      const clauses = await db
+        .select({ id: standardClauses.id })
+        .from(standardClauses)
+        .where(eq(standardClauses.memexId, memexId));
+      return { docCount: docs.length, clauseCount: clauses.length };
+    });
+
+    expect(docCount, "default Standards documents should be seeded").toBeGreaterThan(0);
+    expect(clauseCount, "default Standards clauses should be seeded").toBeGreaterThan(0);
+  });
+
+  it("ac-3: the deploy-wired backfill establishes tenant context under memex_app", async () => {
+    tagAc(`${AC}/ac-3`);
+
+    // A fresh personal memex with NO Standards (signup seeds are off suite-wide).
+    const { memexId } = await makeUserWithMemex("backfill");
+    const before = await runWithMemexId(memexId, async () =>
+      (
+        await db
+          .select({ id: standardClauses.id })
+          .from(standardClauses)
+          .where(eq(standardClauses.memexId, memexId))
+      ).length,
+    );
+    expect(before, "the fresh memex starts with no Standard clauses").toBe(0);
+
+    // backfillDefaultStandards() loops personal memexes and seeds those with none.
+    // Under memex_app its gated INSERTs (documents/standard_clauses/clause_refs)
+    // satisfy RLS ONLY because it now wraps each memex in runWithMemexId(memexId)
+    // (spec-440). Remove that wrapper and the fresh memex stays empty → red.
+    await backfillDefaultStandards();
+
+    const after = await runWithMemexId(memexId, async () =>
+      (
+        await db
+          .select({ id: standardClauses.id })
+          .from(standardClauses)
+          .where(eq(standardClauses.memexId, memexId))
+      ).length,
+    );
+    expect(after, "backfill should have seeded Standard clauses into the memex").toBeGreaterThan(0);
+  });
+});

--- a/packages/server/vitest.config.ts
+++ b/packages/server/vitest.config.ts
@@ -113,6 +113,10 @@ export default defineConfig({
       "**/.{idea,git,cache,output,temp}/**",
       "**/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc,cypress,tsup,build,eslint,prettier}.config.*",
       "src/__smoke__/**",
+      // spec-440: the restricted-role RLS project (vitest.rls.config.ts) owns
+      // these — they must run AS memex_app (RLS-subject), never under the owner
+      // connection here, where RLS is bypassed and the assertion would be vacuous.
+      "src/**/*.rls-restricted.test.ts",
     ],
     // Test files run in parallel workers; each worker owns a private clone of
     // the migrated test database (see vitest.worker-db.setup.ts), so DB-backed

--- a/packages/server/vitest.rls.config.ts
+++ b/packages/server/vitest.rls.config.ts
@@ -1,0 +1,73 @@
+// RESTRICTED-ROLE RLS test project (spec-440 dec-1).
+//
+// A SEPARATE vitest project — run on its own via `make test-rls` — that connects
+// the Drizzle singleton AS the non-owner `memex_app` role (RLS-subject), so the
+// tenancy/seed integration suites exercise real service code under the exact RLS
+// enforcement production sees. The default `vitest.config.ts` still runs as the
+// owner (`postgres`), so the 200+ owner-visibility suites are unaffected (ac-8):
+// this project runs ONLY `*.rls-restricted.test.ts` files, which the default
+// config excludes.
+//
+// Why a separate project (not a flag on the main one): db/connection.ts reads
+// DATABASE_URL at import and builds one singleton per process, so the connecting
+// role is fixed at process start. Running the restricted role therefore needs a
+// distinct process with its own env + setup — this config.
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import dotenv from "dotenv";
+import { defineConfig } from "vitest/config";
+import { resolveTestDatabaseUrl, TEST_MAX_WORKERS } from "./src/db/test-db-url.js";
+
+// Surface the repo-root .env's AC-emission key + the local .env's DATABASE_URL,
+// parsed WITHOUT mutating process.env (identical rationale to vitest.config.ts).
+function readEnvFile(relPath: string): Record<string, string> {
+  try {
+    return dotenv.parse(
+      readFileSync(resolve(dirname(fileURLToPath(import.meta.url)), relPath), "utf8"),
+    );
+  } catch {
+    return {};
+  }
+}
+const rootEnv = readEnvFile("../../.env");
+const localEnv = readEnvFile(".env");
+const TEST_DATABASE_URL = resolveTestDatabaseUrl({ ...process.env, ...localEnv });
+
+export default defineConfig({
+  test: {
+    globals: true,
+    // ONLY the restricted suites. The default config excludes this glob, so a
+    // file authored here runs under memex_app and nowhere else.
+    include: ["src/**/*.rls-restricted.test.ts"],
+    testTimeout: 20_000,
+    hookTimeout: 30_000,
+    // Provision DB + clones (reusing the main setup) AND enable memex_app LOGIN.
+    globalSetup: ["./vitest.rls.global-setup.ts"],
+    // 1. rewrite DATABASE_URL to this worker's clone AND to the memex_app role;
+    // 2. the AC-emission helper. Order matters — the rewrite must precede any
+    //    test module importing db/connection.ts (which reads DATABASE_URL once).
+    setupFiles: ["./vitest.rls.worker-db.setup.ts", "@memex-ai-ac/vitest/setup"],
+    fileParallelism: true,
+    maxWorkers: TEST_MAX_WORKERS,
+    sequence: { concurrent: false },
+    env: {
+      SLACK_TOKEN_ENCRYPTION: "plaintext",
+      GOOGLE_CLIENT_ID: "test-google-client-id",
+      DEV_USER_EMAIL: "dev@memex.ai",
+      // Owner URL; vitest.rls.worker-db.setup.ts rewrites it per-worker to the
+      // clone AND to the memex_app role before connection.ts imports.
+      DATABASE_URL: TEST_DATABASE_URL,
+      ...(rootEnv.MEMEX_EMIT_KEY ? { MEMEX_EMIT_KEY: rootEnv.MEMEX_EMIT_KEY } : {}),
+      ...(rootEnv.MEMEX_EMIT ? { MEMEX_EMIT: rootEnv.MEMEX_EMIT } : {}),
+      // Signup seed hooks stay OFF suite-wide (as in the main config); the seed
+      // regression turns the specific seeder it needs back ON per-test.
+      MEMEX_HANDHOLD_SIGNUP_SEED: "off",
+      MEMEX_DEFAULT_STANDARDS_SIGNUP_SEED: "off",
+      MEMEX_DEFAULT_FACETS_SEED: "off",
+    },
+    typecheck: { enabled: false },
+    // No coverage gate on this project — it's a targeted fidelity harness, and
+    // the merged coverage tiers live on the main config (spec-390).
+  },
+});

--- a/packages/server/vitest.rls.global-setup.ts
+++ b/packages/server/vitest.rls.global-setup.ts
@@ -1,0 +1,50 @@
+// Global setup for the RESTRICTED-ROLE RLS test project (spec-440 dec-1).
+//
+// Runs once, in the main process, before any RLS worker starts. It:
+//   1. reuses the default global-setup — create the per-worktree test DB, run
+//      migrations, and clone one DB per worker slot (identical provisioning, so
+//      the RLS project sees the same freshly-migrated schema as the main suite);
+//   2. enables LOGIN on the `memex_app` role with a fixed test password, in the
+//      TEST cluster only. `memex_app` is created NOLOGIN by migration 0081 (prod
+//      grants login via a deploy secret); the RLS worker setup then connects the
+//      singleton AS `memex_app` so every gated-table write is subject to RLS.
+//
+// This role change is cluster-global but confined to the local/CI test cluster,
+// and it does NOT alter the attributes the memex_app role tests assert
+// (NOSUPERUSER / NOBYPASSRLS / NOCREATEROLE / NOCREATEDB) — only LOGIN + password.
+import "dotenv/config";
+import postgres from "postgres";
+import defaultGlobalSetup from "./vitest.global-setup.js";
+import {
+  RLS_TEST_ROLE,
+  RLS_TEST_ROLE_PASSWORD,
+  resolveTestDatabaseUrl,
+} from "./src/db/test-db-url.js";
+
+export default async function rlsGlobalSetup(): Promise<void> {
+  // 1. Provision DB + per-worker clones exactly as the main suite does.
+  await defaultGlobalSetup();
+
+  // 2. Make memex_app loginable in the test cluster so the singleton can connect
+  //    AS it. Connect as the owner (the resolved test URL's default credentials).
+  const ownerUrl = resolveTestDatabaseUrl();
+  const admin = postgres(ownerUrl, { max: 1, connect_timeout: 5, onnotice: () => {} });
+  try {
+    // Identifier is a fixed literal; the password is a fixed test constant. ALTER
+    // ROLE can't be parameterised, so both are inlined — neither is user input.
+    await admin.unsafe(
+      `ALTER ROLE ${RLS_TEST_ROLE} WITH LOGIN PASSWORD '${RLS_TEST_ROLE_PASSWORD}'`,
+    );
+    console.log(
+      `[rls-test] enabled LOGIN on "${RLS_TEST_ROLE}" (test cluster only) — ` +
+        `the RLS suite connects the singleton as this RLS-subject role`,
+    );
+  } catch (err) {
+    console.warn(
+      `[rls-test] could not enable LOGIN on ${RLS_TEST_ROLE} (${(err as Error).message}). ` +
+        `The RLS suite will fail to connect; the main suite is unaffected.`,
+    );
+  } finally {
+    await admin.end({ timeout: 1 });
+  }
+}

--- a/packages/server/vitest.rls.worker-db.setup.ts
+++ b/packages/server/vitest.rls.worker-db.setup.ts
@@ -1,0 +1,23 @@
+// Per-worker DATABASE_URL rewrite for the RESTRICTED-ROLE RLS project
+// (spec-440 dec-1). Runs inside each RLS worker, before any test module imports
+// db/connection.ts (which reads DATABASE_URL at import).
+//
+// Two hops, in order:
+//   1. same as the main suite — point at this worker's private clone
+//      (`<testDb>_w<VITEST_POOL_ID>`) so parallel files don't trample each other;
+//   2. swap the credentials to the restricted runtime role `memex_app`, so the
+//      singleton connection is SUBJECT to RLS. This is the whole point of the
+//      project: real service code (seedNewPersonalMemex, mutate(), …) executes
+//      as the non-owner role, so a context-less write to a gated table fails
+//      here exactly as it does in prod — instead of being invisibly bypassed by
+//      the owner role in the default suite.
+import {
+  deriveRestrictedRoleUrl,
+  deriveWorkerDatabaseUrl,
+} from "./src/db/test-db-url.js";
+
+const poolId = process.env.VITEST_POOL_ID;
+if (poolId && process.env.DATABASE_URL) {
+  const workerUrl = deriveWorkerDatabaseUrl(process.env.DATABASE_URL, poolId);
+  process.env.DATABASE_URL = deriveRestrictedRoleUrl(workerUrl);
+}


### PR DESCRIPTION
## Release: develop → main (prod)

Promotes the int-verified `develop` tip (25d1e7e, deployed + smoked on int) to prod.

**Includes:**
- **spec-440 — tenant-context safety** (#446): loud RLS-context guard (dec-2 phase 1), restricted-role CI harness (`server-rls`), seed regression under `memex_app`, deploy-wired backfill wraps, std-36 amendment. 9/12 ACs verified; full suite + e2e + `server-rls` green on int.
- **spec-442 — auth-email comms fix** (#445): already int-verified in its own prior deploy (migration 0120).

**Deploy risk:** low. spec-440 guard is warn-only (never throws), harness is test-only, backfill wraps are defensive (run as owner in deploy). One new migration on this release: `0120_spec_442_fix_comms_log_email_tracking` (spec-442, already applied on int).

Int smoke: `✓ Smoke passed (ENV=int)`; `int.memex.ai/api/health` = ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
