### PR TITLE
ci(deploy): wire EMAIL_ACTIVATION_* env vars into the server deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -154,6 +154,13 @@ jobs:
           SMOKE_MCP_TOKEN: ${{ secrets.SMOKE_MCP_TOKEN }}
           SMOKE_SESSION_TOKEN: ${{ secrets.SMOKE_SESSION_TOKEN }}
           MEMEX_EMIT_KEY: ${{ secrets.MEMEX_EMIT_KEY }}
+          # spec-428 dec-1/dec-3 — team-identity sender for the welcome + spec-427 drip.
+          # Non-sensitive brand copy, so kept as per-environment VARIABLES (not in the
+          # DEPLOY_ENV_FILE secret blob). deploy.sh pushes them to Cloud Run via its
+          # optional ${VAR+...} wiring, so an unset variable is simply omitted.
+          EMAIL_ACTIVATION_FROM: ${{ vars.EMAIL_ACTIVATION_FROM }}
+          EMAIL_ACTIVATION_REPLY_TO: ${{ vars.EMAIL_ACTIVATION_REPLY_TO }}
+          EMAIL_SENDER_NAME: ${{ vars.EMAIL_SENDER_NAME }}
         run: bash deploy.sh
 
       # spec-243 dec-2 / ac-6: every deploy posts a friendly note to the matching


### PR DESCRIPTION
## What
Pass the three per-environment GitHub **variables** `EMAIL_ACTIVATION_FROM` / `EMAIL_ACTIVATION_REPLY_TO` / `EMAIL_SENDER_NAME` into the deploy step's `env` so `deploy.sh` pushes them to Cloud Run.

## Why
The welcome (spec-428) + drip (spec-427) sender identity ("The Memex AI team") is non-sensitive brand copy, set as per-env GitHub **Environment variables**. But `deploy.yml` only injected the `DEPLOY_ENV_FILE` **secret** blob into `scripts/deploy.<env>.env`, so the individual variables were never consumed — the welcome kept falling back to the generic transactional `From`. `deploy.sh` already reads these via the optional `${VAR+...}` pattern (an unset variable is omitted), so this just makes them reachable.

## Effect
On the next int/prod deploy, Cloud Run gets `EMAIL_ACTIVATION_*` → the welcome sends `From: The Memex AI team <support@memex.ai>`, Reply-To `support@memex.ai`. Resolves the deploy-config gap in spec-428/issue-2.

## Test plan
- [x] deploy.yml YAML validates
- [ ] After merge: int auto-deploy → `gcloud run services describe memex-api --project=memex-ai-int --region=us-east4` shows the 3 vars → send-test shows the team From