### PR TITLE
feat(spec-427): activation email templates + preview registry (Slice A)

### DIFF
--- a/packages/server/src/services/email/activation.test.ts
+++ b/packages/server/src/services/email/activation.test.ts
@@ -1,0 +1,132 @@
+// spec-427 t-1 (Slice A) — the two activation/win-back email templates, tagged to
+// their render ACs. These are PURE RENDER builders: no cohort/timing/send logic and
+// no env reads (From/Reply-To are applied at the send site, identical to the landed
+// spec-428 welcome — welcome-send.ts:45-46; see spec-427 t-1 drift note).
+//   ac-10 — renders solely through the shared renderEmailHtml() + spec-226
+//           step/resources primitives; no parallel/raw-HTML path; CTA + resources
+//           are table / inline-CSS constructs with no <img>.
+//   ac-13 — the copy is sourced from the templates.ts builder fns (the canonical
+//           authoring source); nothing reads copy from an external/runtime source.
+import { describe, it, expect } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import {
+  buildConnectedInactiveEmail,
+  buildSignedInDormantEmail,
+} from "./templates.js";
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-427/acs/ac-${n}`;
+
+describe("buildConnectedInactiveEmail (Email 1 — connected-but-inactive)", () => {
+  const msg = buildConnectedInactiveEmail({
+    to: "user@example.com",
+    firstName: "Sample",
+    createSpecUrl: "https://int.memex.ai/mindset-prod/sample/specs/new",
+    memexUrl: "https://int.memex.ai/mindset-prod/sample",
+  });
+  const html = msg.html ?? "";
+  const text = msg.text ?? "";
+
+  it("uses the verbatim subject + headline + Create-a-spec CTA, rendered from code", () => {
+    tagAc(AC(13)); // copy sourced from the code builder, not an external doc
+    expect(msg.subject).toBe("Memex is connected. Here's what to do next.");
+    // headline (apostrophe-free substring — html escapes it)
+    expect(html).toContain("Your Memex MCP is connected. The hard part is done.");
+    expect(text).toContain("Your Memex MCP is connected. The hard part is done.");
+    expect(html).toContain("Create a spec");
+    // the "moment it clicks" prose (apostrophe-free)
+    expect(html).toContain("the decisions it needs you to resolve");
+    expect(html).toContain("Memex does not touch your code.");
+  });
+
+  it("renders solely through the shared renderer with a solid CTA and no imagery (ac-10)", () => {
+    tagAc(AC(10));
+    expect(html).toContain("<!doctype html>");
+    // shared-renderer brand mark + solid BRAND_INK CTA button (never a gradient)
+    expect(html).toContain('<span style="font-weight:500;color:#FC4F64;">.AI</span>');
+    expect(html).toContain("background:#0E1128;color:#FFFFFF");
+    expect(html).not.toContain("linear-gradient");
+    expect(html).not.toContain("<img");
+    // resources render as a presentation table (a table construct, not image buttons)
+    expect(html).toContain('<table role="presentation" width="100%"');
+    expect(html).toContain("Understanding Memex AI");
+    expect(html).toContain("Documentation");
+    expect(html).toContain("Community");
+  });
+
+  it("deep-links the CTA + 'your Memex' from the passed URLs, not a hardcoded host (dec-8)", () => {
+    tagAc(AC(10));
+    expect(html).toContain('href="https://int.memex.ai/mindset-prod/sample/specs/new"');
+    expect(html).toContain('href="https://int.memex.ai/mindset-prod/sample"');
+    // no prod host baked in when an int URL was supplied
+    expect(html).not.toContain('href="https://memex.ai/');
+  });
+
+  it("stamps the stable activation.connected_inactive comms key (ac-14/dec-7)", () => {
+    tagAc(AC(13));
+    expect(msg.commsType).toBe("activation.connected_inactive");
+  });
+
+  it("personalises the greeting and degrades to a nameless greeting", () => {
+    tagAc(AC(13));
+    expect(html).toContain("Hi Sample,");
+    const nameless =
+      buildConnectedInactiveEmail({
+        to: "x@y.com",
+        createSpecUrl: "https://int.memex.ai/n/m/specs/new",
+        memexUrl: "https://int.memex.ai/n/m",
+      }).html ?? "";
+    expect(nameless).toContain("Hi there,");
+    expect(nameless).not.toContain("Hi ,");
+  });
+});
+
+describe("buildSignedInDormantEmail (Email 2 — signed-in-but-dormant)", () => {
+  const msg = buildSignedInDormantEmail({
+    to: "user@example.com",
+    firstName: "Sample",
+    appUrl: "https://int.memex.ai",
+  });
+  const html = msg.html ?? "";
+  const text = msg.text ?? "";
+
+  it("uses the verbatim subject + Open-Memex-AI CTA + two-step copy, rendered from code", () => {
+    tagAc(AC(13)); // copy sourced from the code builder, not an external doc
+    expect(msg.subject).toBe("You're two steps from your first Spec");
+    expect(html).toContain("Open Memex AI");
+    expect(html).toContain('href="https://int.memex.ai"');
+    // the "no more vibe coding" value prop (apostrophe-free substrings)
+    expect(html).toContain("done means verified, not just claimed");
+    expect(html).toContain("No more vibe coding.");
+    expect(text).toContain("No more vibe coding.");
+  });
+
+  it("renders solely through the shared renderer with the step + resources primitives, no imagery (ac-10)", () => {
+    tagAc(AC(10));
+    expect(html).toContain("<!doctype html>");
+    expect(html).toContain("background:#0E1128;color:#FFFFFF");
+    expect(html).not.toContain("linear-gradient");
+    expect(html).not.toContain("<img");
+    // spec-226 step primitive
+    expect(html).toContain("// Step 1");
+    expect(html).toContain("Connect to the Memex MCP");
+    expect(html).toContain("// Step 2");
+    expect(html).toContain("Create your first Spec");
+    // resources table
+    expect(html).toContain('<table role="presentation" width="100%"');
+    expect(html).toContain("Understanding Memex AI");
+  });
+
+  it("stamps the stable activation.signed_in_dormant comms key (ac-14/dec-7)", () => {
+    tagAc(AC(13));
+    expect(msg.commsType).toBe("activation.signed_in_dormant");
+  });
+
+  it("personalises the greeting and degrades to a nameless greeting", () => {
+    tagAc(AC(13));
+    expect(html).toContain("Hi Sample,");
+    const nameless =
+      buildSignedInDormantEmail({ to: "x@y.com", appUrl: "https://int.memex.ai" }).html ?? "";
+    expect(nameless).toContain("Hi there,");
+    expect(nameless).not.toContain("Hi ,");
+  });
+});

--- a/packages/server/src/services/email/preview-samples.ts
+++ b/packages/server/src/services/email/preview-samples.ts
@@ -20,6 +20,8 @@ import {
   buildMcpCanonicalRefsSwitchEmail,
   buildMentionEmail,
   buildAssignmentEmail,
+  buildConnectedInactiveEmail,
+  buildSignedInDormantEmail,
 } from "./templates.js";
 
 const BASE = process.env.APP_BASE_URL ?? "https://memex.ai";
@@ -64,6 +66,18 @@ export const EMAIL_PREVIEW_SAMPLES: Record<string, (to: string) => EmailMessage>
       specLabel: "spec-1 — Sample Spec",
       commentUrl: sampleUrl("/mindset-prod/sample/specs/spec-1?comment=c-1"),
     }),
+  // spec-427 t-2 — the two activation/win-back emails. Preview keys are hyphenated
+  // (like `magic-link`); the comms_log keys are the dotted `activation.*` — keep
+  // the two namespaces distinct. App deep-links derive from APP_BASE_URL (dec-8).
+  "activation-connected-inactive": (to) =>
+    buildConnectedInactiveEmail({
+      to,
+      firstName: "Sample",
+      createSpecUrl: sampleUrl("/mindset-prod/sample/specs/new"),
+      memexUrl: sampleUrl("/mindset-prod/sample"),
+    }),
+  "activation-signed-in-dormant": (to) =>
+    buildSignedInDormantEmail({ to, firstName: "Sample", appUrl: BASE }),
 };
 
 export const EMAIL_TEMPLATE_NAMES: string[] = Object.keys(EMAIL_PREVIEW_SAMPLES);

--- a/packages/server/src/services/email/templates.ts
+++ b/packages/server/src/services/email/templates.ts
@@ -354,6 +354,193 @@ export function buildWelcomeEmail(input: WelcomeEmailInput): EmailMessage {
   };
 }
 
+// ──────────────────────────────────────────────────────────────────────────
+// spec-427 — activation & win-back emails (Slice A: pure render)
+// ──────────────────────────────────────────────────────────────────────────
+// Two lifecycle emails that recover stalled signups (dec-6: the code is the
+// canonical authoring source; s-2 mirrors this copy). Both render through the
+// SAME shared renderEmailHtml() using the spec-226 step/resources primitives —
+// no parallel/raw-HTML path, CTA + resources are table / inline-CSS constructs,
+// no imagery (ac-10). App deep-link CTAs come in as inputs derived from
+// APP_BASE_URL at the send site (dec-8), never a hardcoded host.
+//
+// These builders are PURE RENDER: no cohort/timing/send logic, no env reads. The
+// team-identity From + monitored Reply-To (dec-1) are applied at the send site
+// from EMAIL_ACTIVATION_FROM / EMAIL_ACTIVATION_REPLY_TO — identical to the
+// welcome (welcome-send.ts), NOT set in the builder (see spec-427 t-1 drift note).
+// commsType IS stamped here (static, send-independent): Slice B's dedup/cap counts
+// these stable keys in comms_log (ac-14 / dec-7) and never reaches back for copy.
+
+// Shared "Resources to get started" block — identical across both activation
+// emails (s-2). Rendered as a table, not image buttons (Postmark constraints).
+const ACTIVATION_RESOURCES: EmailResource[] = [
+  {
+    title: "Understanding Memex AI",
+    description: "The 10-minute read on why it exists and how it works.",
+    url: "https://www.memex.ai/understanding-memex.pdf",
+  },
+  {
+    title: "Documentation",
+    description: "The complete reference, from getting started to the deep technical detail.",
+    url: "https://www.memex.ai/docs",
+  },
+  {
+    title: "Community",
+    description: "Say hello on Discord, whether you're weighing Memex up or already building.",
+    url: "https://www.memex.ai/discord",
+  },
+];
+
+function activationGreeting(firstName?: string): string {
+  const name = firstName?.trim();
+  return name ? `Hi ${name},` : "Hi there,";
+}
+
+const ACTIVATION_SIGNOFF = "Best, The Memex AI team";
+const ACTIVATION_FOOTER =
+  "You're getting this because you signed up for Memex AI, built by Mindset AI.";
+
+export interface ConnectedInactiveEmailInput {
+  to: string;
+  /** Recipient's first name; absent/empty → a graceful "Hi there,". */
+  firstName?: string;
+  /** CTA "Create a spec" deep-link — derived from APP_BASE_URL at the send site (dec-8). */
+  createSpecUrl: string;
+  /** Link to the user's own Memex ("your Memex") — derived from APP_BASE_URL (dec-8). */
+  memexUrl: string;
+}
+
+// Email 1 — connected-but-inactive (MCP connected, no tool call, no Spec).
+// Subject "Memex is connected. Here's what to do next." · CTA "Create a spec".
+export function buildConnectedInactiveEmail(
+  input: ConnectedInactiveEmailInput,
+): EmailMessage {
+  const greeting = activationGreeting(input.firstName);
+  const afterCta1 =
+    "Memex will work with your agent to structure the work, and comes back with a Spec and the decisions it needs you to resolve. That's the moment it clicks.";
+  const afterCta2 = "Memex does not touch your code.";
+  const stuck = "If you get stuck, just reply here or find us in #help on Discord.";
+
+  const text = renderEmailText({
+    intro: [
+      greeting,
+      "Your Memex MCP is connected. The hard part is done.",
+      "The next step is to create your first Spec. Bring an idea and we'll help you shape it, start to finish. Not sure where to start? Click the button below and we'll guide you through step by step.",
+      afterCta1,
+      afterCta2,
+      `Watch your Spec come to life in your Memex: ${input.memexUrl}`,
+      stuck,
+    ],
+    url: input.createSpecUrl,
+    closing: ACTIVATION_SIGNOFF,
+  });
+
+  const html = renderEmailHtml({
+    preheader: "Your Memex MCP is connected — create your first Spec.",
+    eyebrow: "",
+    heading: "Your Memex MCP is connected. The hard part is done.",
+    bodyParagraphs: [
+      escapeHtml(greeting),
+      "The next step is to create your first Spec. Bring an idea and we'll help you shape it, start to finish. Not sure where to start? Click the button below and we'll guide you through step by step.",
+    ],
+    ctaLabel: "Create a spec",
+    ctaUrl: input.createSpecUrl,
+    showPasteLink: false,
+    afterCtaParagraphs: [
+      escapeHtml(afterCta1),
+      escapeHtml(afterCta2),
+      `Watch your Spec come to life in <a href="${escapeHtml(input.memexUrl)}" style="color:${BRAND_SKY};">your Memex</a>.`,
+      escapeHtml(stuck),
+      escapeHtml(ACTIVATION_SIGNOFF),
+    ],
+    resources: ACTIVATION_RESOURCES,
+    footerNote: ACTIVATION_FOOTER,
+  });
+
+  return {
+    to: input.to,
+    subject: "Memex is connected. Here's what to do next.",
+    text,
+    html,
+    // spec-427 ac-14 / dec-7: stable comms key — Slice B's dedup + two-per-cohort
+    // cap count this key in comms_log, never the subject line.
+    commsType: "activation.connected_inactive",
+  };
+}
+
+export interface SignedInDormantEmailInput {
+  to: string;
+  /** Recipient's first name; absent/empty → a graceful "Hi there,". */
+  firstName?: string;
+  /** CTA "Open Memex AI" target — derived from APP_BASE_URL at the send site (dec-8). */
+  appUrl: string;
+}
+
+// Email 2 — signed-in-but-dormant (signed in, identity complete, MCP never
+// connected). Subject "You're two steps from your first Spec" · CTA "Open Memex AI".
+export function buildSignedInDormantEmail(
+  input: SignedInDormantEmailInput,
+): EmailMessage {
+  const greeting = activationGreeting(input.firstName);
+  const value =
+    "Once you're in, your agents build from what you actually decided, not what they guessed. Every decision is captured as you go, so nothing important gets buried in a chat thread or quietly chosen for you mid-build. And done means verified, not just claimed. No more vibe coding.";
+  const afterCtaText =
+    "We'll send you a few short emails over the next few weeks, and there are some resources below to get you started. If you get stuck, just reply here or find us in #help on Discord.";
+
+  const steps: EmailStep[] = [
+    {
+      label: "// Step 1",
+      title: "Connect to the Memex MCP",
+      body: "The app shows you exactly how to connect, whatever coding agent you're using.",
+    },
+    {
+      label: "// Step 2",
+      title: "Create your first Spec",
+      body: "Bring an idea and we'll help you shape it, start to finish.",
+    },
+  ];
+
+  const text = renderEmailText({
+    intro: [
+      greeting,
+      "Getting Memex set up takes two simple steps.",
+      value,
+      "// Step 1 — Connect to the Memex MCP: The app shows you exactly how to connect, whatever coding agent you're using.",
+      "// Step 2 — Create your first Spec: Bring an idea and we'll help you shape it, start to finish.",
+      afterCtaText,
+    ],
+    url: input.appUrl,
+    closing: ACTIVATION_SIGNOFF,
+  });
+
+  const html = renderEmailHtml({
+    preheader: "You're two steps from your first Spec.",
+    eyebrow: "",
+    heading: "You're two steps from your first Spec",
+    bodyParagraphs: [
+      escapeHtml(greeting),
+      "Getting Memex set up takes two simple steps.",
+      escapeHtml(value),
+    ],
+    steps,
+    ctaLabel: "Open Memex AI",
+    ctaUrl: input.appUrl,
+    showPasteLink: false,
+    afterCtaParagraphs: [escapeHtml(afterCtaText), escapeHtml(ACTIVATION_SIGNOFF)],
+    resources: ACTIVATION_RESOURCES,
+    footerNote: ACTIVATION_FOOTER,
+  });
+
+  return {
+    to: input.to,
+    subject: "You're two steps from your first Spec",
+    text,
+    html,
+    // spec-427 ac-14 / dec-7: stable comms key (see Email 1).
+    commsType: "activation.signed_in_dormant",
+  };
+}
+
 export interface MagicLinkEmailInput {
   to: string;
   loginUrl: string;


### PR DESCRIPTION
## Summary

**Slice A of spec-427** (activation & win-back email orchestration) — the two lifecycle email templates and their preview-registry entries. **Pure render, no orchestration** — Slices B/C (send transport, cohorts, drip, backlog, suppression) are untouched.

- **Email 1 — connected-but-inactive.** Subject "Memex is connected. Here's what to do next." · CTA **Create a spec**.
- **Email 2 — signed-in-but-dormant.** Subject "You're two steps from your first Spec" · CTA **Open Memex AI**, using the spec-226 step primitive.

Both render **solely** through the shared `renderEmailHtml()` + spec-226 step/resources primitives — no parallel/raw-HTML path, CTA + resources are table / inline-CSS constructs, no imagery (**ac-10**). Copy is sourced from the builders (**ac-13** / dec-6). App deep-link CTAs come in as inputs derived from `APP_BASE_URL` at the send site (dec-8). Stable comms keys (`activation.connected_inactive` / `activation.signed_in_dormant`) are stamped in the builder for Slice B's dedup/cap (ac-14 / dec-7).

Registered both in `EMAIL_PREVIEW_SAMPLES` under hyphenated keys `activation-connected-inactive` / `activation-signed-in-dormant` (distinct from the dotted comms keys) — instantly reachable from the dev preview route, send-test script, and the int designer gallery (spec-226/t-5,t-6).

## Design note — builders are pure render (drift flagged on t-1)

t-1's narrative said the builders set From/Reply-To from `EMAIL_ACTIVATION_FROM/REPLY_TO`. That contradicts the task's own "pure render, zero send dependency" and does **not** match the landed spec-428 welcome it cites as identical: `buildWelcomeEmail` reads no env; From/Reply-To are applied at the **send site** (`welcome-send.ts:45-46`). This PR follows the welcome pattern — builders read no env, set no `from`/`replyTo`; that wiring is **Slice B's** (t-3/t-7). Consequently **ac-7 (team-identity From/Reply-To) verifies in Slice B, not here.** Flagged on the Spec (comment c-1) for re-wording.

## Test plan

- [x] New `activation.test.ts` — 9 TDD tests (RED→GREEN), tagged **ac-10** + **ac-13**, asserting both `text` and `html`; emissions landed (Spec board 16→14 untested ACs).
- [x] Preview registration exercised by existing `__dev__.test.ts` (renders every registered template).
- [x] Full **server** suite: 5160 passed (1 known local flake `.ee/slack/oauth`, CI-green, unrelated).
- [x] Full **UI** suite: green (std-1 copy sweep + repo-wide guards).
- [x] `tsc --noEmit` clean.
- [x] Rendered both emails at `APP_BASE_URL=https://int.memex.ai` and verified structure vs s-2.

## Follow-ups (Slice B)
- Confirm real Discord invite URL (resources block; same TODO the welcome carries).
- Confirm the create-spec deep-link path Slice B passes as `createSpecUrl`.
- Slice B send path wires From/Reply-To + broadcast stream + List-Unsubscribe.