### PR TITLE
feat(spec-427): lifecycle/broadcast email transport (Slice B, t-3)

### DIFF
--- a/packages/server/deploy.sh
+++ b/packages/server/deploy.sh
@@ -285,6 +285,15 @@ SECRETS_WIRING+=",AUTH_JWT_SECRET=auth-jwt-secret:latest"
 if gcloud secrets describe postmark-webhook-token --project "${GCP_PROJECT}" >/dev/null 2>&1; then
   SECRETS_WIRING+=",POSTMARK_WEBHOOK_TOKEN=postmark-webhook-token:latest"
 fi
+# spec-427 t-3 / dec-8 (ac-15): the lifecycle/broadcast path uses the REAL Postmark
+# token ONLY in prod (the same server-token secret, on the real broadcast stream —
+# no second Postmark server). int deliberately leaves POSTMARK_BROADCAST_TOKEN unset
+# so the server defaults to Postmark's sandbox token and delivers no real broadcast
+# mail (fail-safe — see getEmailSender). The transactional POSTMARK_SERVER_TOKEN
+# wiring above is unchanged in both envs.
+if [ "$ENV" = "prod" ]; then
+  SECRETS_WIRING+=",POSTMARK_BROADCAST_TOKEN=postmark-server-token:latest"
+fi
 SECRETS_WIRING+=",OPENAI_API_KEY=openai-api-key:latest"
 if [ "$HAS_SLACK" = "1" ]; then
   SECRETS_WIRING+=",SLACK_CLIENT_SECRET=slack-client-secret:latest"

--- a/packages/server/src/services/email/broadcast-transport.test.ts
+++ b/packages/server/src/services/email/broadcast-transport.test.ts
@@ -1,0 +1,131 @@
+// spec-427 t-3 (Slice B) — the lifecycle/broadcast transport: a per-message
+// MessageStream, env token isolation, and the RFC 8058 List-Unsubscribe header.
+//   ac-11 — 427 emails go on the Postmark broadcast stream (not `outbound`),
+//           selected via a per-message stream field, and carry a List-Unsubscribe
+//           header. (Suppression is t-4.)
+//   ac-15 — int broadcast uses the Postmark TEST token (no delivery); prod uses
+//           the real token + real stream; transactional stream/token unchanged;
+//           no second Postmark server.
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+vi.mock("../comms-log.js", () => ({ recordEmailComm: vi.fn().mockResolvedValue(null) }));
+import { PostmarkEmailSender, getEmailSender, setEmailSender } from "./sender.js";
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-427/acs/ac-${n}`;
+// Postmark's well-known sandbox token literal — accepts, returns 200, delivers nothing.
+const POSTMARK_TEST_TOKEN = "POSTMARK_API_TEST";
+
+function captureFetch(): ReturnType<typeof vi.fn> {
+  const mock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ MessageID: "pm-1" }) });
+  vi.stubGlobal("fetch", mock);
+  return mock;
+}
+const bodyOf = (mock: ReturnType<typeof vi.fn>) =>
+  JSON.parse((mock.mock.calls[0]![1] as { body: string }).body);
+const tokenOf = (mock: ReturnType<typeof vi.fn>) =>
+  (mock.mock.calls[0]![1] as { headers: Record<string, string> }).headers["X-Postmark-Server-Token"];
+
+beforeEach(() => vi.unstubAllGlobals());
+
+describe("PostmarkEmailSender — broadcast stream + List-Unsubscribe (ac-11)", () => {
+  it("defaults MessageStream to `outbound` and uses the transactional token", async () => {
+    tagAc(AC(15)); // transactional path unchanged
+    const mock = captureFetch();
+    const sender = new PostmarkEmailSender("real-tok", "Memex.AI <support@memex.ai>", "broadcast-tok");
+    await sender.send({ to: "u@acme.test", subject: "Hi", text: "body" });
+    expect(bodyOf(mock).MessageStream).toBe("outbound");
+    expect(tokenOf(mock)).toBe("real-tok");
+  });
+
+  it("sends a broadcast-stream message on that stream and honours it verbatim", async () => {
+    tagAc(AC(11));
+    const mock = captureFetch();
+    const sender = new PostmarkEmailSender("real-tok", "from", "broadcast-tok");
+    await sender.send({ to: "u@acme.test", subject: "Hi", text: "body", stream: "broadcast" });
+    expect(bodyOf(mock).MessageStream).toBe("broadcast");
+  });
+
+  it("attaches an angle-bracketed one-click List-Unsubscribe header pair when a URL is given", async () => {
+    tagAc(AC(11));
+    const mock = captureFetch();
+    const sender = new PostmarkEmailSender("real-tok", "from", "broadcast-tok");
+    await sender.send({
+      to: "u@acme.test",
+      subject: "Hi",
+      text: "body",
+      stream: "broadcast",
+      listUnsubscribeUrl: "https://int.memex.ai/email/unsubscribe?token=TKN",
+    });
+    const headers = bodyOf(mock).Headers as { Name: string; Value: string }[];
+    const unsub = headers.find((h) => h.Name === "List-Unsubscribe");
+    const post = headers.find((h) => h.Name === "List-Unsubscribe-Post");
+    // RFC 8058/2369 — bracket-wrapped URL or clients won't honour one-click
+    expect(unsub?.Value).toBe("<https://int.memex.ai/email/unsubscribe?token=TKN>");
+    expect(post?.Value).toBe("List-Unsubscribe=One-Click");
+  });
+
+  it("adds no List-Unsubscribe header to a transactional message", async () => {
+    tagAc(AC(11));
+    const mock = captureFetch();
+    const sender = new PostmarkEmailSender("real-tok", "from", "broadcast-tok");
+    await sender.send({ to: "u@acme.test", subject: "Hi", text: "body" });
+    const headers = (bodyOf(mock).Headers ?? []) as { Name: string }[];
+    expect(headers.find((h) => h.Name === "List-Unsubscribe")).toBeUndefined();
+  });
+});
+
+describe("PostmarkEmailSender — env token isolation (ac-15)", () => {
+  it("uses the broadcast token for a broadcast-stream send, the shared token for transactional", async () => {
+    tagAc(AC(15));
+    const sender = new PostmarkEmailSender("real-tok", "from", POSTMARK_TEST_TOKEN);
+
+    const broadcast = captureFetch();
+    await sender.send({ to: "u@acme.test", subject: "Hi", text: "body", stream: "broadcast" });
+    expect(tokenOf(broadcast)).toBe(POSTMARK_TEST_TOKEN);
+
+    vi.unstubAllGlobals();
+    const transactional = captureFetch();
+    await sender.send({ to: "u@acme.test", subject: "Hi", text: "body" });
+    expect(tokenOf(transactional)).toBe("real-tok");
+  });
+
+  it("falls back to the shared token for broadcast when no broadcast token is configured", async () => {
+    tagAc(AC(15));
+    const mock = captureFetch();
+    const sender = new PostmarkEmailSender("real-tok", "from"); // no broadcast token
+    await sender.send({ to: "u@acme.test", subject: "Hi", text: "body", stream: "broadcast" });
+    expect(tokenOf(mock)).toBe("real-tok");
+  });
+});
+
+describe("getEmailSender — fail-safe broadcast token wiring (ac-15)", () => {
+  const saved = { ...process.env };
+  afterEach(() => {
+    setEmailSender(null);
+    process.env = { ...saved };
+  });
+
+  it("defaults the broadcast token to the Postmark TEST sandbox literal when unset (int-safe)", async () => {
+    tagAc(AC(15));
+    setEmailSender(null);
+    process.env.POSTMARK_SERVER_TOKEN = "real-tok";
+    process.env.EMAIL_FROM = "Memex.AI <support@memex.ai>";
+    delete process.env.POSTMARK_BROADCAST_TOKEN;
+    const mock = captureFetch();
+    await getEmailSender().send({ to: "u@acme.test", subject: "Hi", text: "body", stream: "broadcast" });
+    // no explicit broadcast token → sandbox, so a forgotten int deploy never sends real broadcast mail
+    expect(tokenOf(mock)).toBe(POSTMARK_TEST_TOKEN);
+  });
+
+  it("uses the configured broadcast token when set (prod opts into real delivery)", async () => {
+    tagAc(AC(15));
+    setEmailSender(null);
+    process.env.POSTMARK_SERVER_TOKEN = "real-tok";
+    process.env.EMAIL_FROM = "Memex.AI <support@memex.ai>";
+    process.env.POSTMARK_BROADCAST_TOKEN = "real-tok";
+    const mock = captureFetch();
+    await getEmailSender().send({ to: "u@acme.test", subject: "Hi", text: "body", stream: "broadcast" });
+    expect(tokenOf(mock)).toBe("real-tok");
+  });
+});

--- a/packages/server/src/services/email/sender.ts
+++ b/packages/server/src/services/email/sender.ts
@@ -25,7 +25,25 @@ export interface EmailMessage {
   // → the configured default From and no Reply-To (the existing 6 emails unchanged).
   from?: string;
   replyTo?: string;
+  // spec-427 t-3 (dec-5/dec-8) — the lifecycle/broadcast transport. `stream` is the
+  // Postmark MessageStream id; absent → "outbound" (the transactional stream all
+  // existing emails use, unchanged). Any non-"outbound" stream is a broadcast/
+  // lifecycle send: it selects the broadcast token (int-safe sandbox by default,
+  // real in prod) rather than the transactional token. `listUnsubscribeUrl`, when
+  // present, emits the RFC 8058 one-click List-Unsubscribe header pair (the token
+  // in the URL is issued by t-4).
+  stream?: string;
+  listUnsubscribeUrl?: string;
 }
+
+// The transactional stream every existing email rides. A message with no `stream`
+// (or this exact value) takes the transactional token; anything else is broadcast.
+const TRANSACTIONAL_STREAM = "outbound";
+// Postmark's well-known sandbox token literal — accepts, returns 200, delivers
+// nothing, no reputation impact. The fail-safe default for the broadcast path so a
+// deploy that forgets POSTMARK_BROADCAST_TOKEN (e.g. int) can never send real
+// broadcast mail (spec-427 dec-8 / ac-15).
+const POSTMARK_TEST_TOKEN = "POSTMARK_API_TEST";
 
 export interface EmailSender {
   send(message: EmailMessage): Promise<void>;
@@ -51,15 +69,34 @@ export class PostmarkEmailSender implements EmailSender {
   constructor(
     private readonly token: string,
     private readonly from: string,
+    // spec-427 t-3 — the token used for broadcast/lifecycle sends. Distinct from the
+    // transactional `token` so int can deliver nothing (sandbox) while prod uses the
+    // real token; the transactional path always uses `token`. Absent → the broadcast
+    // path falls back to the shared `token`.
+    private readonly broadcastToken?: string,
   ) {}
 
   async send(message: EmailMessage): Promise<void> {
+    const stream = message.stream ?? TRANSACTIONAL_STREAM;
+    // Non-transactional streams are lifecycle/broadcast: select the broadcast token
+    // (int-safe sandbox / prod real). Transactional sends always use the shared token.
+    const token =
+      stream === TRANSACTIONAL_STREAM ? this.token : this.broadcastToken ?? this.token;
+    // spec-427 t-3 (ac-11) — RFC 8058 one-click unsubscribe. The URL MUST be
+    // angle-bracket wrapped (RFC 2369) or clients won't honour one-click.
+    const headers = message.listUnsubscribeUrl
+      ? [
+          { Name: "List-Unsubscribe", Value: `<${message.listUnsubscribeUrl}>` },
+          { Name: "List-Unsubscribe-Post", Value: "List-Unsubscribe=One-Click" },
+        ]
+      : undefined;
+
     const res = await fetch("https://api.postmarkapp.com/email", {
       method: "POST",
       headers: {
         "Accept": "application/json",
         "Content-Type": "application/json",
-        "X-Postmark-Server-Token": this.token,
+        "X-Postmark-Server-Token": token,
       },
       body: JSON.stringify({
         From: message.from ?? this.from,
@@ -68,7 +105,8 @@ export class PostmarkEmailSender implements EmailSender {
         TextBody: message.text,
         ...(message.html ? { HtmlBody: message.html } : {}),
         ...(message.replyTo ? { ReplyTo: message.replyTo } : {}),
-        MessageStream: "outbound",
+        ...(headers ? { Headers: headers } : {}),
+        MessageStream: stream,
       }),
     });
 
@@ -130,7 +168,11 @@ export function getEmailSender(): EmailSender {
   const postmarkToken = process.env.POSTMARK_SERVER_TOKEN;
   const from = process.env.EMAIL_FROM;
   if (postmarkToken && from) {
-    cached = new PostmarkEmailSender(postmarkToken, from);
+    // spec-427 dec-8 / ac-15 — fail-safe: the broadcast token defaults to Postmark's
+    // sandbox literal, so an env that never sets POSTMARK_BROADCAST_TOKEN (int)
+    // delivers no real broadcast mail. Prod sets it to the real token to opt in.
+    const broadcastToken = process.env.POSTMARK_BROADCAST_TOKEN || POSTMARK_TEST_TOKEN;
+    cached = new PostmarkEmailSender(postmarkToken, from, broadcastToken);
     return cached;
   }
 


### PR DESCRIPTION
## Summary

**t-3 of spec-427 Slice B** — the transport layer the activation drip rides on (dec-5 / dec-8). Transactional email is untouched; this adds an opt-in broadcast path. **Inert until a caller sets `stream`** (t-7 wires the sends).

- `EmailMessage` gains optional `stream` (Postmark MessageStream, default `"outbound"`) and `listUnsubscribeUrl`. Any non-`"outbound"` stream is a lifecycle/broadcast send.
- `PostmarkEmailSender` takes an optional `broadcastToken`: broadcast sends use it (falling back to the shared token), transactional sends **always** use the shared token — **ac-15**. When `listUnsubscribeUrl` is set, it emits the RFC 8058 one-click `List-Unsubscribe` + `List-Unsubscribe-Post` header pair, URL angle-bracket-wrapped per RFC 2369 — **ac-11**.
- `getEmailSender` **fail-safe**: `POSTMARK_BROADCAST_TOKEN` defaults to Postmark's sandbox literal (`POSTMARK_API_TEST`), so an env that never sets it (int) delivers no real broadcast mail. Prod opts into real delivery.
- `packages/server/deploy.sh` wires `POSTMARK_BROADCAST_TOKEN=postmark-server-token:latest` **only in prod** (same secret, real broadcast stream — no second Postmark server); int stays on the sandbox default.

## Blast radius
None at runtime yet. All existing emails default to the `outbound` transactional stream + shared token — byte-for-byte unchanged. The broadcast path only activates when a caller passes `stream` (Slice B t-7). The token in `listUnsubscribeUrl` and the suppression gate are t-4.

## Test plan
- [x] `broadcast-transport.test.ts` — 8 tests, TDD (RED→GREEN), tagged **ac-11** + **ac-15**: default outbound stream + transactional token; broadcast stream honoured; token selection (broadcast vs transactional); fail-safe `getEmailSender` wiring (sandbox default when unset, real token when set); angle-bracketed List-Unsubscribe pair; no header on transactional.
- [x] Full server suite: 5168 passed (1 known local flake `.ee/slack/oauth`, CI-green, unrelated). `tsc --noEmit` clean. `bash -n deploy.sh` clean.

## Deploy note
Prod needs no manual secret work — `postmark-server-token` already exists and is reused. The drip does **not** send yet: gated behind `ACTIVATION_EMAILS_ENABLED` (t-6, default OFF).