### PR TITLE
feat(spec-427): lifecycle-email unsubscribe + suppression + pre-send gate (Slice B, t-4)

### DIFF
--- a/packages/server/drizzle/0121_spec427_lifecycle_email_unsubscribe.sql
+++ b/packages/server/drizzle/0121_spec427_lifecycle_email_unsubscribe.sql
@@ -1,0 +1,8 @@
+-- spec-427 t-4 (dec-5): lifecycle-email suppression store. One nullable timestamp on
+-- users — null = subscribed, a timestamp = the user unsubscribed from activation/
+-- win-back (lifecycle/broadcast) email via the one-click List-Unsubscribe link. Scope
+-- is LIFECYCLE ONLY: transactional/auth email and the spec-428 welcome ignore it and
+-- always send (ac-11 scope / ac-12). users is global (not RLS/memex-scoped), so no
+-- policy change is needed. Idempotent — re-running is a no-op.
+ALTER TABLE "users"
+  ADD COLUMN IF NOT EXISTS "lifecycle_email_unsubscribed_at" timestamp with time zone;

--- a/packages/server/drizzle/reverts/0121_spec427_lifecycle_email_unsubscribe.revert.sql
+++ b/packages/server/drizzle/reverts/0121_spec427_lifecycle_email_unsubscribe.revert.sql
@@ -1,0 +1,4 @@
+-- Revert spec-427 t-4 (0121_spec427_lifecycle_email_unsubscribe.sql).
+-- Drops the lifecycle-email suppression column. Any recorded unsubscribes are lost
+-- on revert (the column IS the store) — acceptable for a schema rollback.
+ALTER TABLE "users" DROP COLUMN IF EXISTS "lifecycle_email_unsubscribed_at";

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -35,6 +35,7 @@ import { auth } from "./routes/auth.js";
 import { invitesAcceptRouter, invitesAdminRouter } from "./routes/invites.js";
 import { teamRouter } from "./routes/team.js";
 import { shareRouter } from "./routes/share.js";
+import { unsubscribeRouter } from "./routes/unsubscribe.js";
 import { backstageRouter } from "./routes/backstage.js";
 import { cliAuth, mcpTokensRouter } from "./routes/cli-auth.js";
 import { oauth, isOAuthEnabled } from "./routes/oauth/index.js";
@@ -408,6 +409,10 @@ app.route("/api/me", homeRouter);
 app.route("/api/whats-new", whatsNewRouter);
 // PUBLIC: share routes skip session middleware — guests access shared docs by token alone (t-10).
 app.route("/api/share", shareRouter);
+
+// spec-427 t-4 — PUBLIC lifecycle-email unsubscribe (GET one-click + POST RFC 8058).
+// No session/tenant middleware: the HMAC token in the URL is the capability.
+app.route("/api/email", unsubscribeRouter);
 
 // spec-171 t-3: Stripe webhook receiver. No session middleware — the
 // Stripe-Signature HMAC header IS the auth (verified inside the router).

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -1359,6 +1359,11 @@ export const users = pgTable("users", {
   // the identity step.
   roleCoords: jsonb("role_coords").$type<{ dev: number; design: number; pm: number }>(),
   identityConfirmedAt: timestamp("identity_confirmed_at", { withTimezone: true }),
+  // spec-427 t-4 (dec-5): lifecycle-email suppression. Null = subscribed; a timestamp =
+  // the user unsubscribed from activation/win-back (lifecycle/broadcast) email via the
+  // one-click List-Unsubscribe link. Scope is LIFECYCLE ONLY — transactional/auth email
+  // and the spec-428 welcome ignore this flag and always send (ac-11 scope / ac-12).
+  lifecycleEmailUnsubscribedAt: timestamp("lifecycle_email_unsubscribed_at", { withTimezone: true }),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
 }, (table) => [

--- a/packages/server/src/middleware/permissions.test.ts
+++ b/packages/server/src/middleware/permissions.test.ts
@@ -38,6 +38,7 @@ function buildApp(routePath: string) {
       onboardingGreetedAt: null,
       roleCoords: null,
       identityConfirmedAt: null,
+      lifecycleEmailUnsubscribedAt: null,
       createdAt: new Date(),
       updatedAt: new Date(),
     });

--- a/packages/server/src/routes/unsubscribe.integration.test.ts
+++ b/packages/server/src/routes/unsubscribe.integration.test.ts
@@ -1,0 +1,90 @@
+// spec-427 t-4 (ac-12) — the public unsubscribe endpoint, end-to-end against the DB:
+// following the link/token suppresses the user; a tampered token suppresses no one;
+// the write is idempotent. Suppression governs LIFECYCLE only — transactional/auth
+// email is unaffected (asserted structurally: the flag is a dedicated lifecycle column,
+// and isLifecycleEmailUnsubscribed is the only gate sendLifecycleEmail consults).
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { eq } from "drizzle-orm";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { db } from "../db/connection.js";
+import { users } from "../db/schema.js";
+import { isLifecycleEmailUnsubscribed } from "../services/users.js";
+import { mintUnsubscribeToken } from "../services/email/unsubscribe-token.js";
+import { unsubscribeRouter } from "./unsubscribe.js";
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-427/acs/ac-${n}`;
+
+let userId: string;
+const EMAIL = "spec427-t4-unsub@example.test";
+
+beforeAll(async () => {
+  const [u] = await db.insert(users).values({ email: EMAIL }).returning({ id: users.id });
+  userId = u!.id;
+});
+afterAll(async () => {
+  if (userId) await db.delete(users).where(eq(users.id, userId)).catch(() => {});
+});
+
+// Hono routers expose .request() — hit the real handler with no session/tenant context,
+// exactly as an unauthenticated mail-client one-click would.
+const post = (token: string) =>
+  unsubscribeRouter.request(`/unsubscribe?token=${encodeURIComponent(token)}`, { method: "POST" });
+const get = (token: string) =>
+  unsubscribeRouter.request(`/unsubscribe?token=${encodeURIComponent(token)}`, { method: "GET" });
+
+describe("POST /api/email/unsubscribe (RFC 8058 one-click)", () => {
+  it("suppresses the user on a valid token and returns 200", async () => {
+    tagAc(AC(12));
+    expect(await isLifecycleEmailUnsubscribed(userId)).toBe(false);
+    const res = await post(mintUnsubscribeToken(userId));
+    expect(res.status).toBe(200);
+    expect(await isLifecycleEmailUnsubscribed(userId)).toBe(true);
+  });
+
+  it("is idempotent — a second unsubscribe still 200s and preserves the first timestamp", async () => {
+    tagAc(AC(12));
+    const [before] = await db
+      .select({ at: users.lifecycleEmailUnsubscribedAt })
+      .from(users)
+      .where(eq(users.id, userId));
+    const res = await post(mintUnsubscribeToken(userId));
+    expect(res.status).toBe(200);
+    const [after] = await db
+      .select({ at: users.lifecycleEmailUnsubscribedAt })
+      .from(users)
+      .where(eq(users.id, userId));
+    expect(after!.at?.getTime()).toBe(before!.at?.getTime());
+  });
+});
+
+describe("unsubscribe endpoint — a forged token suppresses no one", () => {
+  let victimId: string;
+  const VICTIM = "spec427-t4-victim@example.test";
+  beforeAll(async () => {
+    const [u] = await db.insert(users).values({ email: VICTIM }).returning({ id: users.id });
+    victimId = u!.id;
+  });
+  afterAll(async () => {
+    if (victimId) await db.delete(users).where(eq(users.id, victimId)).catch(() => {});
+  });
+
+  it("400s on a tampered token and leaves the victim subscribed (POST)", async () => {
+    tagAc(AC(12));
+    const [user, mac] = mintUnsubscribeToken(victimId).split(".");
+    const forged = `${user}.${Buffer.from("forged").toString("base64url")}`;
+    expect(mac).not.toBe(Buffer.from("forged").toString("base64url"));
+    const res = await post(forged);
+    expect(res.status).toBe(400);
+    expect(await isLifecycleEmailUnsubscribed(victimId)).toBe(false);
+  });
+
+  it("GET renders a confirmation page for a valid token and a 400 page for a bad one", async () => {
+    tagAc(AC(12));
+    const bad = await get("garbage");
+    expect(bad.status).toBe(400);
+    const ok = await get(mintUnsubscribeToken(victimId));
+    expect(ok.status).toBe(200);
+    expect(await ok.text()).toContain("unsubscribed");
+    expect(await isLifecycleEmailUnsubscribed(victimId)).toBe(true);
+  });
+});

--- a/packages/server/src/routes/unsubscribe.ts
+++ b/packages/server/src/routes/unsubscribe.ts
@@ -1,0 +1,51 @@
+import { Hono } from "hono";
+import { verifyUnsubscribeToken } from "../services/email/unsubscribe-token.js";
+import { markLifecycleEmailUnsubscribed } from "../services/users.js";
+
+// spec-427 t-4 (dec-5) — the PUBLIC lifecycle-email unsubscribe endpoint. No session
+// or tenant middleware (mounted flat, like /api/share and /api/stripe/webhook): the
+// HMAC token IS the capability. Mail clients POST one-click cross-origin with no
+// session and no CSRF token, so this route deliberately sits outside any auth/CSRF
+// guard — the token proves the request.
+//
+// RFC 8058: the token lives in the query string for BOTH verbs. A GET is the human
+// clicking the in-body link (a mail-client link scanner may prefetch it — that
+// auto-unsubscribes, which is acceptable and spec-mandated: there is no resubscribe
+// path in scope). A POST with `List-Unsubscribe=One-Click` in the body is the
+// one-click header path (Gmail/Apple Mail); we still read the token from ?token=.
+const unsubscribeRouter = new Hono();
+
+// Minimal inline confirmation pages — no imagery, no external assets.
+const OK_PAGE =
+  "<!doctype html><meta charset=utf-8><title>Unsubscribed</title>" +
+  "<body style=\"font-family:system-ui,sans-serif;max-width:32rem;margin:4rem auto;padding:0 1rem;color:#0E1128\">" +
+  "<h1>You're unsubscribed</h1><p>You won't receive any more activation or product-update " +
+  "emails from Memex AI. Account and security emails (sign-in links, password resets) still send. " +
+  "Changed your mind? Just reply to any Memex email.</p></body>";
+const BAD_PAGE =
+  "<!doctype html><meta charset=utf-8><title>Invalid link</title>" +
+  "<body style=\"font-family:system-ui,sans-serif;max-width:32rem;margin:4rem auto;padding:0 1rem;color:#0E1128\">" +
+  "<h1>This link isn't valid</h1><p>The unsubscribe link is malformed or incomplete. " +
+  "If you keep getting emails you don't want, reply to any Memex email and we'll sort it.</p></body>";
+
+// Resolve the token and record the suppression. Idempotent (markLifecycleEmailUnsubscribed
+// only stamps a still-null row). Returns true when a valid token was applied.
+async function applyUnsubscribe(token: string | undefined): Promise<boolean> {
+  const userId = verifyUnsubscribeToken(token);
+  if (!userId) return false;
+  await markLifecycleEmailUnsubscribed(userId);
+  return true;
+}
+
+unsubscribeRouter.get("/unsubscribe", async (c) => {
+  const ok = await applyUnsubscribe(c.req.query("token"));
+  return c.html(ok ? OK_PAGE : BAD_PAGE, ok ? 200 : 400);
+});
+
+unsubscribeRouter.post("/unsubscribe", async (c) => {
+  // RFC 8058: token is on the URL, not in the form body (which is List-Unsubscribe=One-Click).
+  const ok = await applyUnsubscribe(c.req.query("token"));
+  return c.body(null, ok ? 200 : 400);
+});
+
+export { unsubscribeRouter };

--- a/packages/server/src/services/email/lifecycle-send.test.ts
+++ b/packages/server/src/services/email/lifecycle-send.test.ts
@@ -1,0 +1,78 @@
+// spec-427 t-4 — the lifecycle send chokepoint: gates on suppression (ac-12), rides
+// the broadcast stream + carries the one-click List-Unsubscribe URL (ac-11), and uses
+// the team-identity From/Reply-To (dec-1). The suppression read is mocked so this is a
+// pure unit test of the chokepoint's behaviour.
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-427/acs/ac-${n}`;
+
+// Control the suppression gate without a DB.
+const isSuppressed = vi.fn<(id: string) => Promise<boolean>>();
+vi.mock("../users.js", () => ({ isLifecycleEmailUnsubscribed: (id: string) => isSuppressed(id) }));
+
+import { sendLifecycleEmail } from "./lifecycle-send.js";
+import { setEmailSender, type EmailMessage } from "./sender.js";
+
+const USER = { id: "11111111-1111-1111-1111-111111111111", email: "u@example.test" };
+const MSG: EmailMessage = { to: "", subject: "Create your first Spec", text: "body", commsType: "activation.connected_inactive" };
+
+let sent: EmailMessage[];
+const savedEnv = { ...process.env };
+
+beforeEach(() => {
+  sent = [];
+  setEmailSender({ send: async (m) => { sent.push(m); } });
+  process.env.APP_BASE_URL = "https://int.memex.ai";
+  process.env.EMAIL_ACTIVATION_FROM = "The Memex AI team <support@memex.ai>";
+  process.env.EMAIL_ACTIVATION_REPLY_TO = "support@memex.ai";
+});
+afterEach(() => {
+  setEmailSender(null);
+  process.env = { ...savedEnv };
+  vi.clearAllMocks();
+});
+
+describe("sendLifecycleEmail", () => {
+  it("sends a subscribed user on the broadcast stream with a List-Unsubscribe URL + team identity", async () => {
+    tagAc(AC(11));
+    isSuppressed.mockResolvedValue(false);
+    const ok = await sendLifecycleEmail(USER, MSG);
+    expect(ok).toBe(true);
+    expect(sent).toHaveLength(1);
+    const m = sent[0]!;
+    expect(m.to).toBe(USER.email);
+    expect(m.userId).toBe(USER.id);
+    expect(m.stream).toBe("broadcast");
+    expect(m.stream).not.toBe("outbound");
+    expect(m.listUnsubscribeUrl).toContain("https://int.memex.ai/api/email/unsubscribe?token=");
+    expect(m.from).toBe("The Memex AI team <support@memex.ai>");
+    expect(m.replyTo).toBe("support@memex.ai");
+    // template payload preserved
+    expect(m.commsType).toBe("activation.connected_inactive");
+  });
+
+  it("skips a suppressed user — no send (ac-12)", async () => {
+    tagAc(AC(12));
+    isSuppressed.mockResolvedValue(true);
+    const ok = await sendLifecycleEmail(USER, MSG);
+    expect(ok).toBe(false);
+    expect(sent).toHaveLength(0);
+  });
+
+  it("fails CLOSED — a suppression-read error skips the send, never emails on error", async () => {
+    tagAc(AC(12));
+    isSuppressed.mockRejectedValue(new Error("db down"));
+    const ok = await sendLifecycleEmail(USER, MSG);
+    expect(ok).toBe(false);
+    expect(sent).toHaveLength(0);
+  });
+
+  it("skips a user with no email address", async () => {
+    tagAc(AC(11));
+    isSuppressed.mockResolvedValue(false);
+    const ok = await sendLifecycleEmail({ id: USER.id, email: "" }, MSG);
+    expect(ok).toBe(false);
+    expect(sent).toHaveLength(0);
+  });
+});

--- a/packages/server/src/services/email/lifecycle-send.ts
+++ b/packages/server/src/services/email/lifecycle-send.ts
@@ -1,0 +1,46 @@
+// spec-427 t-4 — the single chokepoint every lifecycle/activation (427) email goes
+// through. The drip (t-7) and the one-time backlog (t-8) build the EmailMessage and
+// decide WHO gets WHICH email WHEN; this function owns HOW a lifecycle email is sent
+// safely: it gates on suppression, rides the broadcast stream (t-3), carries the RFC
+// 8058 one-click unsubscribe URL (t-4), and uses the team-identity From/Reply-To
+// (dec-1) — identical config to the welcome. Keeping this the SOLE lifecycle send path
+// is what makes "every 427 send honours suppression + carries List-Unsubscribe" true.
+
+import type { User } from "../../db/schema.js";
+import { getEmailSender, type EmailMessage } from "./sender.js";
+import { isLifecycleEmailUnsubscribed } from "../users.js";
+import { unsubscribeUrl } from "./unsubscribe-token.js";
+
+// The Postmark broadcast stream id for lifecycle mail. Configurable per env; the
+// non-"outbound" value is what routes the send to the broadcast token (t-3).
+const BROADCAST_STREAM = process.env.POSTMARK_BROADCAST_STREAM || "broadcast";
+
+/**
+ * Send one lifecycle email to a user. Returns true if it was handed to the transport,
+ * false if skipped (no email address, or the user has unsubscribed).
+ *
+ * Suppression is fail-CLOSED: if the suppression read throws, we skip the send rather
+ * than risk emailing someone who unsubscribed (respecting an unsubscribe is a legal
+ * obligation; missing one drip send is harmless — it retries next run). The caller
+ * threads `to`/`userId` from the user, so the message builders don't need them.
+ */
+export async function sendLifecycleEmail(
+  user: Pick<User, "id" | "email">,
+  message: EmailMessage,
+): Promise<boolean> {
+  if (!user.email) return false;
+
+  const suppressed = await isLifecycleEmailUnsubscribed(user.id).catch(() => true);
+  if (suppressed) return false;
+
+  await getEmailSender().send({
+    ...message,
+    to: user.email,
+    userId: user.id,
+    stream: BROADCAST_STREAM,
+    listUnsubscribeUrl: unsubscribeUrl(user.id),
+    from: process.env.EMAIL_ACTIVATION_FROM,
+    replyTo: process.env.EMAIL_ACTIVATION_REPLY_TO,
+  });
+  return true;
+}

--- a/packages/server/src/services/email/unsubscribe-token.test.ts
+++ b/packages/server/src/services/email/unsubscribe-token.test.ts
@@ -1,0 +1,72 @@
+// spec-427 t-4 (ac-12) — the stateless unsubscribe token: stable, verifiable, no-PII,
+// and (the load-bearing property) UNFORGEABLE — a tampered userId or MAC must never
+// resolve to a valid user, or anyone could unsubscribe anyone.
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import {
+  mintUnsubscribeToken,
+  verifyUnsubscribeToken,
+  unsubscribeUrl,
+} from "./unsubscribe-token.js";
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-427/acs/ac-${n}`;
+const USER = "11111111-1111-1111-1111-111111111111";
+
+describe("unsubscribe token — mint / verify round-trip", () => {
+  it("verifies a freshly minted token back to its userId", () => {
+    tagAc(AC(12));
+    expect(verifyUnsubscribeToken(mintUnsubscribeToken(USER))).toBe(USER);
+  });
+
+  it("is stable — the same user always mints the same token (embeddable in every send)", () => {
+    tagAc(AC(12));
+    expect(mintUnsubscribeToken(USER)).toBe(mintUnsubscribeToken(USER));
+  });
+
+  it("carries no email / PII — only the (UUID) userId segment and a MAC", () => {
+    tagAc(AC(12));
+    const token = mintUnsubscribeToken(USER);
+    expect(token).not.toContain("@");
+    // exactly two base64url segments joined by a dot
+    expect(token.split(".")).toHaveLength(2);
+  });
+});
+
+describe("unsubscribe token — unforgeable (the negative that matters)", () => {
+  it("rejects a tampered userId segment", () => {
+    tagAc(AC(12));
+    const [user, mac] = mintUnsubscribeToken(USER).split(".");
+    const otherUser = Buffer.from("22222222-2222-2222-2222-222222222222", "utf8").toString("base64url");
+    expect(user).not.toBe(otherUser);
+    // swap in a different user but keep the original MAC → must not verify
+    expect(verifyUnsubscribeToken(`${otherUser}.${mac}`)).toBeNull();
+  });
+
+  it("rejects a tampered MAC", () => {
+    tagAc(AC(12));
+    const [user] = mintUnsubscribeToken(USER).split(".");
+    const forgedMac = Buffer.from("not-the-real-mac").toString("base64url");
+    expect(verifyUnsubscribeToken(`${user}.${forgedMac}`)).toBeNull();
+  });
+
+  it("rejects malformed / empty tokens without throwing", () => {
+    tagAc(AC(12));
+    for (const bad of [undefined, null, "", "no-dot", "a.b.c", ".", "x."] as const) {
+      expect(verifyUnsubscribeToken(bad as string | undefined | null)).toBeNull();
+    }
+  });
+});
+
+describe("unsubscribe URL — host from APP_BASE_URL (dec-8)", () => {
+  const saved = process.env.APP_BASE_URL;
+  beforeEach(() => { process.env.APP_BASE_URL = "https://int.memex.ai"; });
+  afterEach(() => { process.env.APP_BASE_URL = saved; });
+
+  it("builds an env-derived absolute URL carrying the verifiable token", () => {
+    tagAc(AC(12));
+    const url = unsubscribeUrl(USER);
+    expect(url.startsWith("https://int.memex.ai/api/email/unsubscribe?token=")).toBe(true);
+    const token = decodeURIComponent(new URL(url).searchParams.get("token")!);
+    expect(verifyUnsubscribeToken(token)).toBe(USER);
+  });
+});

--- a/packages/server/src/services/email/unsubscribe-token.ts
+++ b/packages/server/src/services/email/unsubscribe-token.ts
@@ -1,0 +1,66 @@
+// spec-427 t-4 (dec-5) — the lifecycle-email unsubscribe token.
+//
+// A STABLE, verifiable, no-PII token embedded in every activation/win-back email's
+// one-click List-Unsubscribe link. Deliberately stateless — an HMAC over the userId,
+// NOT a stored/consumable token (auth_tokens style is for single-use links; this one
+// is the same for every send to a user and never expires, so a stored token would be
+// pure overhead). The userId is a UUID, not PII, and the URL carries no email address.
+//
+// The MAC reuses AUTH_JWT_SECRET via getSecret(), domain-separated with an "unsub:"
+// prefix so an unsubscribe token can never be cross-used as (or forged from) a session
+// JWT or any other AUTH_JWT_SECRET-signed artifact.
+
+import { createHmac, timingSafeEqual } from "node:crypto";
+import { getSecret } from "../auth-jwt.js";
+
+// Domain separation — the MAC is over this prefix + the userId, so the signing input
+// space never overlaps the session-JWT signing input (`header.payload`).
+const DOMAIN = "unsub:";
+
+function mac(userId: string): Buffer {
+  return createHmac("sha256", getSecret()).update(DOMAIN + userId).digest();
+}
+
+/** Mint the stable unsubscribe token for a user: `b64url(userId).b64url(mac)`. */
+export function mintUnsubscribeToken(userId: string): string {
+  const user = Buffer.from(userId, "utf8").toString("base64url");
+  return `${user}.${mac(userId).toString("base64url")}`;
+}
+
+/**
+ * Verify a token and return the userId it authorises, or null if it is missing,
+ * malformed, or the MAC doesn't match. NEVER throws — a bad token is a null, not an
+ * error (the endpoint turns null into a 400). Length is guarded before timingSafeEqual,
+ * which throws RangeError on unequal-length buffers.
+ */
+export function verifyUnsubscribeToken(token: string | undefined | null): string | null {
+  if (!token || typeof token !== "string") return null;
+  const parts = token.split(".");
+  if (parts.length !== 2) return null;
+  const [encUser, encMac] = parts;
+
+  let userId: string;
+  let providedMac: Buffer;
+  try {
+    userId = Buffer.from(encUser, "base64url").toString("utf8");
+    providedMac = Buffer.from(encMac, "base64url");
+  } catch {
+    return null;
+  }
+  if (!userId) return null;
+
+  const expected = mac(userId);
+  // timingSafeEqual throws on length mismatch — guard it (a truncated MAC is invalid).
+  if (providedMac.length !== expected.length) return null;
+  return timingSafeEqual(providedMac, expected) ? userId : null;
+}
+
+/**
+ * The absolute one-click unsubscribe URL for a user, host derived from APP_BASE_URL
+ * (dec-8: int → int.memex.ai, prod → memex.ai), never hardcoded. This is the value
+ * that rides the RFC 8058 List-Unsubscribe header (t-3) on every lifecycle send.
+ */
+export function unsubscribeUrl(userId: string): string {
+  const base = process.env.APP_BASE_URL ?? "https://memex.ai";
+  return `${base}/api/email/unsubscribe?token=${encodeURIComponent(mintUnsubscribeToken(userId))}`;
+}

--- a/packages/server/src/services/users.ts
+++ b/packages/server/src/services/users.ts
@@ -1,4 +1,4 @@
-import { eq, and, sql, asc } from "drizzle-orm";
+import { eq, and, sql, asc, isNull } from "drizzle-orm";
 import { db } from "../db/connection.js";
 import { users, orgMemberships, namespaces, orgs, memexes, userMemexAccess } from "../db/schema.js";
 import type { User } from "../db/schema.js";
@@ -201,6 +201,32 @@ export async function markEmailVerified(userId: string): Promise<User> {
   // errors); idempotent via the `welcome` comms_log key (dec-7).
   void sendWelcomeEmail(updated);
   return updated;
+}
+
+// spec-427 t-4 (dec-5) — lifecycle-email suppression. Stamp the user as unsubscribed
+// from activation/win-back (lifecycle/broadcast) email. Direct users update, no
+// mutate() (users is global/non-RLS; mirrors markEmailVerified). Idempotent: the
+// guarded WHERE only stamps a still-null row, so a double-unsubscribe preserves the
+// first timestamp. Scope is LIFECYCLE ONLY — transactional/auth mail ignores it.
+export async function markLifecycleEmailUnsubscribed(userId: string): Promise<void> {
+  if (!userId) return;
+  await db
+    .update(users)
+    .set({ lifecycleEmailUnsubscribedAt: new Date(), updatedAt: new Date() })
+    .where(and(eq(users.id, userId), isNull(users.lifecycleEmailUnsubscribedAt)));
+}
+
+// spec-427 t-4 — the pre-send gate read: has this user unsubscribed from lifecycle
+// email? Consumed by sendLifecycleEmail (services/email/lifecycle-send.ts) before any
+// 427 send. A missing user reads as not-unsubscribed (no row → false).
+export async function isLifecycleEmailUnsubscribed(userId: string): Promise<boolean> {
+  if (!userId) return false;
+  const [row] = await db
+    .select({ at: users.lifecycleEmailUnsubscribedAt })
+    .from(users)
+    .where(eq(users.id, userId))
+    .limit(1);
+  return !!row?.at;
 }
 
 // spec-206 t-1 (dec-3 / dec-4 / ac-14): stamp the first-run greeting flag.


### PR DESCRIPTION
## Summary

**t-4 of spec-427 Slice B** — the unsubscribe path for the activation drip (dec-5). Suppression governs **lifecycle email only**; transactional/auth mail and the spec-428 welcome always send (**ac-11** scope / **ac-12**).

- **Token** (`services/email/unsubscribe-token.ts`) — a **stable, verifiable, no-PII HMAC** over the userId (domain-separated `unsub:` prefix, reusing `AUTH_JWT_SECRET`), *not* a stored/consumable token: the same link rides every send and never expires, so a token table would be pure overhead. `verify` never throws (length-guards `timingSafeEqual`); a tampered userId or MAC → `null`. `unsubscribeUrl` derives the host from `APP_BASE_URL` (dec-8).
- **Suppression store** — one nullable `users.lifecycle_email_unsubscribed_at` column (hand-authored migration **0121** + revert, mirroring the recent 0119/0120 convention). Written by `markLifecycleEmailUnsubscribed` (raw idempotent update, no `mutate()` — `users` is global/non-RLS, mirrors `markEmailVerified`). `isLifecycleEmailUnsubscribed` is the pre-send gate read.
- **Endpoint** (`routes/unsubscribe.ts`, mounted flat at `/api/email`) — `GET /unsubscribe` (one-click; renders a confirmation page) + `POST` (RFC 8058 `List-Unsubscribe=One-Click`). **No session/tenant middleware** — the HMAC token is the capability, like `/api/share`. Token read from the query string for both verbs.
- **Chokepoint** (`services/email/lifecycle-send.ts`) — `sendLifecycleEmail` gates on suppression (**fail-CLOSED**: a read error skips rather than risk emailing an unsubscribed user), rides the broadcast stream (t-3), attaches the List-Unsubscribe URL, and sets the team From/Reply-To (dec-1).

## Forward note for t-7
`sendLifecycleEmail` is the **sole** lifecycle send path — "every 427 send honours suppression + carries List-Unsubscribe" holds only if the drip (t-7) and backlog (t-8) route *all* sends through it. Do not add a second send path around it.

## Blast radius
- New public endpoint, unauthenticated by design (token is the capability). A mail-client link-scanner prefetch of the GET can auto-unsubscribe — spec-mandated ("GET one-click adds to suppression"), lifecycle-only, no resubscribe path in scope.
- Additive migration (nullable column, `ADD COLUMN IF NOT EXISTS`), backward-compatible. No drip sends yet (gated behind `ACTIVATION_EMAILS_ENABLED`, t-6, default OFF).

## Test plan
- [x] `unsubscribe-token.test.ts` — round-trip, stability, no-PII, **tampered userId/MAC rejected** (the load-bearing negative), malformed tokens don't throw, `unsubscribeUrl` env-derived. Tagged ac-12.
- [x] `lifecycle-send.test.ts` — subscribed→sent on broadcast stream w/ List-Unsubscribe + team identity; suppressed→skip; **fail-closed on read error**; no-email→skip. Tagged ac-11/ac-12.
- [x] `unsubscribe.integration.test.ts` (real DB + migration 0121) — POST suppresses + 200; idempotent (timestamp preserved); **forged token → 400, victim stays subscribed**; GET renders confirmation. Tagged ac-12.
- [x] Full server suite: 5189 passed (1 known local flake `.ee/slack/oauth`, unrelated). `tsc --noEmit` clean.