### PR TITLE
feat(spec-445): facets on tasks & decisions — editable via update tools, visible on retrieval

### DIFF
--- a/packages/server/src/agent/facet-edit-handlers.spec-445.integration.test.ts
+++ b/packages/server/src/agent/facet-edit-handlers.spec-445.integration.test.ts
@@ -1,0 +1,222 @@
+// spec-445 — editing a task's or decision's facet classification through the EXISTING update_task
+// and update_decision tools (dec-1). End-to-end through executeServerTool against a seeded
+// facet vocabulary + a facet-tagged standard, mirroring the spec-423 consume-handler tests.
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { and, eq } from "drizzle-orm";
+import { toolManifest } from "@memex/shared";
+import { db } from "../db/connection.js";
+import {
+  users,
+  namespaces,
+  orgs,
+  orgMemberships,
+  memexes,
+  documents,
+  docSections,
+  standardClauses,
+  standardClauseFacets,
+  facets,
+  tasks,
+  decisions,
+  taskFacetBallots,
+  decisionFacetBallots,
+} from "../db/schema.js";
+import { executeServerTool } from "./tools.js";
+// get_doc (verbose) renders exactly formatState(url, await fullDocState(...)); test that
+// path directly since executeServerTool forces ctx.verbose=false.
+import { fullDocState, formatState } from "./handlers/shared.js";
+
+const SPEC = "mindset-prod/memex-building-itself/specs/spec-445";
+const AC = (n: number) => `${SPEC}/acs/ac-${n}`;
+
+let userId: string;
+let memexId: string;
+let specRef: string;
+let specDocId: string;
+// A second, VOCAB-LESS memex for the no-op case (ac-7).
+let bareMemexId: string;
+let bareSpecRef: string;
+let bareSpecDocId: string;
+
+const refOf = (out: string) => out.match(/ref:\s+(\S+)/)![1];
+const seqOf = (ref: string, kind: "t" | "dec") => Number(ref.match(new RegExp(`${kind}-(\\d+)`))![1]);
+type Verdict = Record<string, boolean>;
+
+// The stored verdict for a specific task/decision (by its seq within the main spec doc).
+async function taskVerdict(ref: string): Promise<Verdict | undefined> {
+  const [row] = await db
+    .select({ verdict: taskFacetBallots.verdict })
+    .from(taskFacetBallots)
+    .innerJoin(tasks, eq(tasks.id, taskFacetBallots.taskId))
+    .where(and(eq(tasks.docId, specDocId), eq(tasks.seq, seqOf(ref, "t"))));
+  return row?.verdict as Verdict | undefined;
+}
+async function decisionVerdict(ref: string): Promise<Verdict | undefined> {
+  const [row] = await db
+    .select({ verdict: decisionFacetBallots.verdict })
+    .from(decisionFacetBallots)
+    .innerJoin(decisions, eq(decisions.id, decisionFacetBallots.decisionId))
+    .where(and(eq(decisions.docId, specDocId), eq(decisions.seq, seqOf(ref, "dec"))));
+  return row?.verdict as Verdict | undefined;
+}
+
+async function seedOrgMemex(sub: string, withVocab: boolean): Promise<{ memexId: string; specRef: string; specDocId: string }> {
+  const [ns] = await db.insert(namespaces).values({ slug: sub, kind: "org" }).returning();
+  const [org] = await db.insert(orgs).values({ namespaceId: ns.id, name: `Test ${sub}` }).returning();
+  await db.update(namespaces).set({ ownerOrgId: org.id }).where(eq(namespaces.id, ns.id));
+  const [mx] = await db.insert(memexes).values({ namespaceId: ns.id, slug: "main", name: "Main" }).returning();
+  await db.insert(orgMemberships).values({ userId, orgId: org.id, role: "administrator" });
+  if (withVocab) {
+    const fid = new Map<string, string>();
+    for (const key of ["xc-security", "xc-perf"]) {
+      const [f] = await db.insert(facets).values({ ownerType: "org", ownerId: org.id, key, description: key }).returning();
+      fid.set(key, f.id);
+    }
+    const [std] = await db.insert(documents).values({ memexId: mx.id, handle: "std-1", title: "Auth guard standard", docType: "standard", status: "approved" }).returning();
+    const [sec] = await db.insert(docSections).values({ docId: std.id, sectionType: "rule", content: "Unauthorized access returns 404.", seq: 1, position: 1 }).returning();
+    const [cl] = await db.insert(standardClauses).values({ memexId: mx.id, docId: std.id, sectionId: sec.id, seq: 1, position: 1, body: "404 not 403" }).returning();
+    await db.insert(standardClauseFacets).values({ memexId: mx.id, clauseId: cl.id, facetId: fid.get("xc-security")! });
+  }
+  const [spec] = await db.insert(documents).values({ memexId: mx.id, handle: "spec-1", title: "Consumer spec", docType: "spec", status: "build" }).returning();
+  return { memexId: mx.id, specRef: `${ns.slug}/main/specs/spec-1`, specDocId: spec.id };
+}
+
+beforeAll(async () => {
+  const stamp = () => `s445-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`.toLowerCase();
+  const [u] = await db.insert(users).values({ email: `${stamp()}@example.com` } as never).returning();
+  userId = u.id;
+  const main = await seedOrgMemex(stamp(), true);
+  memexId = main.memexId;
+  specRef = main.specRef;
+  specDocId = main.specDocId;
+  const bare = await seedOrgMemex(stamp(), false);
+  bareMemexId = bare.memexId;
+  bareSpecRef = bare.specRef;
+  bareSpecDocId = bare.specDocId;
+});
+
+afterAll(async () => {
+  for (const mid of [memexId, bareMemexId]) {
+    await db.delete(documents).where(eq(documents.memexId, mid)).catch(() => {});
+    await db.delete(memexes).where(eq(memexes.id, mid)).catch(() => {});
+  }
+  await db.delete(users).where(eq(users.id, userId)).catch(() => {});
+});
+
+// A COMPLETE verdict over the two-facet vocab.
+const ballot = (security: boolean, perf: boolean) => ({ verdict: { "xc-security": security, "xc-perf": perf }, none: false });
+
+describe("update_task edits a task's facets in place (spec-445 dec-1, ac-5/ac-7)", () => {
+  it("replaces the stored ballot, re-routes, and re-surfaces the governing standard (ac-5, ac-7)", async () => {
+    tagAc(AC(5));
+    tagAc(AC(7)); // reuses the create-path validate+store+route machinery
+    tagAc(AC(1)); // scope: edit via the EXISTING update tool
+    tagAc(AC(2)); // scope: editing replaces the whole verdict and re-surfaces the standards
+    const ref = refOf(await executeServerTool(memexId, "create_task", { ref: specRef, title: "Wire the guard", description: "harden authz", facetBallot: ballot(false, true) }, userId));
+    expect(await taskVerdict(ref)).toEqual({ "xc-security": false, "xc-perf": true });
+
+    const out = await executeServerTool(memexId, "update_task", { ref, facetBallot: ballot(true, false) }, userId);
+    expect(out).toContain("std-1"); // re-routed on the new (security-true) ballot
+    expect(await taskVerdict(ref)).toEqual({ "xc-security": true, "xc-perf": false }); // replaced in place
+  });
+
+  it("rejects a provided-but-incomplete ballot (re-handing the vocab); a title-only edit leaves facets unchanged (ac-5)", async () => {
+    tagAc(AC(5));
+    const ref = refOf(await executeServerTool(memexId, "create_task", { ref: specRef, title: "Another task", description: "x", facetBallot: ballot(true, false) }, userId));
+    await expect(
+      executeServerTool(memexId, "update_task", { ref, facetBallot: { verdict: { "xc-security": true }, none: false } }, userId),
+    ).rejects.toThrow(/xc-perf/);
+    await executeServerTool(memexId, "update_task", { ref, title: "Renamed" }, userId);
+    expect(await taskVerdict(ref)).toEqual({ "xc-security": true, "xc-perf": false }); // untouched
+  });
+});
+
+describe("update_decision edits a decision's facets in place, on any status (spec-445 dec-1, ac-6/ac-7)", () => {
+  it("replaces the stored ballot and re-routes, and works on a RESOLVED decision (ac-6, ac-7)", async () => {
+    tagAc(AC(6));
+    tagAc(AC(7)); // status-independent — edits a resolved decision
+    tagAc(AC(2)); // scope: replace whole verdict + re-surface standards (decision side)
+    const ref = refOf(await executeServerTool(memexId, "create_decision", { ref: specRef, title: "Guard approach", context: "how", facetBallot: ballot(false, true) }, userId));
+    await executeServerTool(memexId, "resolve_decision", { ref, resolution: "go" }, userId); // reuses the creation ballot
+    expect(await decisionVerdict(ref)).toEqual({ "xc-security": false, "xc-perf": true });
+
+    const out = await executeServerTool(memexId, "update_decision", { ref, facetBallot: ballot(true, false) }, userId);
+    expect(out).toContain("std-1"); // re-routed on the new ballot, on a resolved decision
+    expect(await decisionVerdict(ref)).toEqual({ "xc-security": true, "xc-perf": false }); // replaced in place
+  });
+
+  it("rejects combining a facet edit with a status transition (ac-6)", async () => {
+    tagAc(AC(6));
+    const ref = refOf(await executeServerTool(memexId, "create_decision", { ref: specRef, title: "Combine guard", context: "x", facetBallot: ballot(true, false) }, userId));
+    await expect(
+      executeServerTool(memexId, "update_decision", { ref, status: "open", facetBallot: ballot(false, true) }, userId),
+    ).rejects.toThrow(/cannot combine/i);
+  });
+});
+
+describe("no bespoke facet tool; a vocab-less Memex is a no-op (spec-445 dec-1, ac-7)", () => {
+  it("adds NO facet-mutation tool to the manifest — the edit rides update_task / update_decision (ac-7)", () => {
+    tagAc(AC(7));
+    tagAc(AC(1)); // scope: no new facet-specific tool
+    const names = toolManifest.map((t) => t.name);
+    for (const banned of ["set_facets", "edit_facets", "change_facets", "assign_facets", "update_facets", "tag_facets"]) {
+      expect(names).not.toContain(banned);
+    }
+    expect(toolManifest.find((t) => t.name === "update_task")!.args).toContain("facetBallot");
+    expect(toolManifest.find((t) => t.name === "update_decision")!.args).toContain("facetBallot");
+  });
+
+  it("is a no-op on a Memex with no facet vocabulary — no ballot is stored, no error (ac-7)", async () => {
+    tagAc(AC(7));
+    const ref = refOf(await executeServerTool(bareMemexId, "create_task", { ref: bareSpecRef, title: "No-vocab task", description: "x" }, userId));
+    await executeServerTool(bareMemexId, "update_task", { ref, facetBallot: { verdict: { "anything": true }, none: false } }, userId);
+    const rows = await db.select().from(taskFacetBallots).where(eq(taskFacetBallots.memexId, bareMemexId));
+    expect(rows).toHaveLength(0);
+  });
+});
+
+describe("facets travel with a task/decision on retrieval, as read-only context (spec-445 dec-2, ac-8/ac-9)", () => {
+  it("get_doc surfaces each task's and decision's facets; list_tasks includes the task's inline (ac-8)", async () => {
+    tagAc(AC(8));
+    tagAc(AC(3)); // scope: facets travel with the item on retrieval
+    tagAc(AC(4)); // scope: a decision's facets are visible as context
+    const tRef = refOf(await executeServerTool(memexId, "create_task", { ref: specRef, title: "Retrieval task", description: "x", facetBallot: ballot(true, false) }, userId));
+    await executeServerTool(memexId, "create_decision", { ref: specRef, title: "Retrieval decision", context: "x", facetBallot: ballot(false, true) }, userId);
+
+    // get_doc (verbose) renders a "Facets:" line for the task (security) and decision (perf).
+    const docOut = await formatState("http://test", await fullDocState(memexId, specDocId));
+    expect(docOut).toContain("Facets: xc-security");
+    expect(docOut).toContain("Facets: xc-perf");
+
+    // list_tasks surfaces the task's facets inline on its own ref line.
+    const listOut = await executeServerTool(memexId, "list_tasks", { ref: specRef }, userId);
+    const tLine = listOut.split("\n").find((l) => l.includes(tRef))!;
+    expect(tLine).toContain("{facets: xc-security}");
+  });
+
+  it("a task with no ballot shows no facets (ac-8)", async () => {
+    tagAc(AC(8));
+    await executeServerTool(bareMemexId, "create_task", { ref: bareSpecRef, title: "Facetless task", description: "x" }, userId);
+    const docOut = await formatState("http://test", await fullDocState(bareMemexId, bareSpecDocId));
+    expect(docOut).not.toContain("Facets:");
+    const listOut = await executeServerTool(bareMemexId, "list_tasks", { ref: bareSpecRef }, userId);
+    expect(listOut).not.toContain("{facets:");
+  });
+
+  it("retrieval is read-only and never pre-fills; create_task still FORCES a fresh ballot (ac-9)", async () => {
+    tagAc(AC(9));
+    tagAc(AC(4)); // scope: visible context never biases the task's own forced ballot
+    // get_doc creates/alters no ballot.
+    const before = await db.select().from(taskFacetBallots).where(eq(taskFacetBallots.memexId, memexId));
+    await executeServerTool(memexId, "get_doc", { ref: specRef, verbose: true }, userId);
+    const after = await db.select().from(taskFacetBallots).where(eq(taskFacetBallots.memexId, memexId));
+    expect(after.length).toBe(before.length);
+    // No regression: create_task in a vocab Memex still hard-requires its own ballot —
+    // a parent decision's visible facets never auto-fill it.
+    await expect(
+      executeServerTool(memexId, "create_task", { ref: specRef, title: "No ballot", description: "x" }, userId),
+    ).rejects.toThrow(/facet ballot is REQUIRED/i);
+  });
+});

--- a/packages/server/src/agent/handlers/decisions.ts
+++ b/packages/server/src/agent/handlers/decisions.ts
@@ -355,7 +355,7 @@ export const decisionsTools: ToolSpec[] = [
       if (ctx.verbose) {
         const state = await fullDocState(memexId, updated.docId);
         const url = await ctx.workspaceUrl(memexId);
-        return formatState(url, state) + facetEditReadout;
+        return (await formatState(url, state)) + facetEditReadout;
       }
       const decRef = buildChildRef(slugs, doc, { type: "decisions", seq: updated.seq });
       // Response shape mirrors what callers parse (`^Decision <verb>: ref: ...`).

--- a/packages/server/src/agent/handlers/decisions.ts
+++ b/packages/server/src/agent/handlers/decisions.ts
@@ -11,6 +11,7 @@ import {
 } from "../../mcp/refs.js";
 import {
   createDecision,
+  getDecision,
   listDecisions,
   resolveDecision,
   reopenDecision,
@@ -240,6 +241,18 @@ export const decisionsTools: ToolSpec[] = [
         .nonnegative()
         .optional()
         .describe("Zero-based index into the decision's options (edit-in-place mode)."),
+      // spec-445 dec-1 — edit a decision's facet classification through this existing tool
+      // (no bespoke facet tool). An edit-in-place field: cannot combine with a status
+      // transition; omit to leave facets unchanged.
+      facetBallot: z
+        .object({
+          verdict: z.record(z.string(), z.boolean()).describe("Complete map: facet slug → true/false."),
+          none: z.boolean().describe("true = this work governs no facet (every verdict false)."),
+        })
+        .optional()
+        .describe(
+          "OPTIONAL (edit-in-place). Re-cast this decision's facet classification: a COMPLETE verdict over the Memex's facet vocabulary (a true/false for EVERY facet, or none:true) that REPLACES the stored ballot and re-surfaces the governing standards. Cannot combine with a status transition. Call the `facets` tool (verb:'list') first.",
+        ),
       verbose: VERBOSE_FIELD,
     },
     async handler(input, ctx) {
@@ -258,15 +271,18 @@ export const decisionsTools: ToolSpec[] = [
         fields.chosenOptionIndex = input.chosenOptionIndex;
       }
       const hasEditFields = Object.keys(fields).length > 0;
+      // spec-445 dec-1 — a facet re-cast is an edit-in-place operation, orthogonal to the
+      // content fields but subject to the same "not with a status transition" rule.
+      const hasFacetEdit = input.facetBallot !== undefined;
 
-      if (target && hasEditFields) {
+      if (target && (hasEditFields || hasFacetEdit)) {
         throw new ValidationError(
-          "update_decision: cannot combine a status transition with field edits in one call; pick one mode.",
+          "update_decision: cannot combine a status transition with field/facet edits in one call; pick one mode.",
         );
       }
-      if (!target && !hasEditFields) {
+      if (!target && !hasEditFields && !hasFacetEdit) {
         throw new ValidationError(
-          "update_decision requires either status (open/resolved/candidate/rejected to transition) or one of: title, context, resolution, chosenOptionIndex.",
+          "update_decision requires either status (open/resolved/candidate/rejected to transition) or one of: title, context, resolution, chosenOptionIndex, facetBallot.",
         );
       }
 
@@ -300,15 +316,46 @@ export const decisionsTools: ToolSpec[] = [
           );
         }
       } else {
-        // Edit-in-place mode.
-        updated = await updateDecisionFields(memexId, entity.row.id, fields);
+        // Edit-in-place mode (content fields and/or a facet re-cast, spec-445). A
+        // facet-only edit changes no content field, so read the row back for the response.
+        updated = hasEditFields
+          ? await updateDecisionFields(memexId, entity.row.id, fields)
+          : await getDecision(memexId, entity.row.id, doc.id);
         mode = "updated";
+      }
+
+      // spec-445 dec-1 — edit the decision's facet classification: a COMPLETE verdict
+      // REPLACES the stored ballot (decision_facet_ballots upserts one per decision) and
+      // re-surfaces the governing standards — the same validate+store+route path
+      // create_decision / resolve_decision take. A vocab-less Memex is a no-op.
+      let facetEditReadout = "";
+      if (hasFacetEdit) {
+        const ballot = parseBallotArg(input.facetBallot);
+        const vocab = await requireBallotForMemex(
+          memexId,
+          { provided: true, ballot },
+          { noun: "decision", channel: ctx.channel },
+        );
+        if (vocab.length > 0) {
+          const routeRef = buildChildRef(slugs, doc, { type: "decisions", seq: updated.seq });
+          facetEditReadout = await storeRouteAndReadout({
+            memexId,
+            specDocId: updated.docId,
+            noun: "decision",
+            rowId: entity.row.id,
+            ownerRef: routeRef,
+            queryText: `${updated.title}\n${updated.resolution ?? ""}`,
+            ballot,
+            vocab,
+            ctx: reqCtx(ctx),
+          });
+        }
       }
 
       if (ctx.verbose) {
         const state = await fullDocState(memexId, updated.docId);
         const url = await ctx.workspaceUrl(memexId);
-        return formatState(url, state);
+        return formatState(url, state) + facetEditReadout;
       }
       const decRef = buildChildRef(slugs, doc, { type: "decisions", seq: updated.seq });
       // Response shape mirrors what callers parse (`^Decision <verb>: ref: ...`).
@@ -321,7 +368,7 @@ export const decisionsTools: ToolSpec[] = [
       if (mode === "restored") {
         return `Decision restored: ref: ${decRef} "${updated.title}" [${updated.status}]`;
       }
-      return `Decision updated: ref: ${decRef} "${updated.title}" [${updated.status}]`;
+      return `Decision updated: ref: ${decRef} "${updated.title}" [${updated.status}]${facetEditReadout}`;
     },
   },
   {

--- a/packages/server/src/agent/handlers/shared.ts
+++ b/packages/server/src/agent/handlers/shared.ts
@@ -58,6 +58,7 @@ import {
 } from "../../services/tasks.js";
 import type { RequestCtx } from "../../services/mutate.js";
 import { listActivityView } from "../../services/activity-view.js";
+import { facetKeysByTask, facetKeysByDecision } from "../../services/facet-ballot.js";
 import { resolveTestEventActors } from "../../services/who-resolver.js";
 import { stripUuids, containsUuid } from "../../services/shared/identifiers.js";
 import { listPresent } from "../../services/presence.js";
@@ -402,8 +403,10 @@ export const COMPLETION_NUDGE =
 
 export interface FullDocState {
   doc: Awaited<ReturnType<typeof getDoc>>;
-  decs: Awaited<ReturnType<typeof listDecisions>>;
-  tasks: Awaited<ReturnType<typeof listTasks>>;
+  // spec-445 dec-2 — each decision/task carries its stored true facet keys, surfaced on
+  // the read (get_doc) as context.
+  decs: (Awaited<ReturnType<typeof listDecisions>>[number] & { facets?: string[] })[];
+  tasks: (Awaited<ReturnType<typeof listTasks>>[number] & { facets?: string[] })[];
   comments: Awaited<ReturnType<typeof listCommentsForDoc>>;
   // spec-136 t-4: the Spec's tags, rendered inline by formatFullDocState so any
   // doc-state response (get_doc, every mutation) carries them.
@@ -497,7 +500,15 @@ export async function fullDocState(memexId: string, docIdOrHandle: string): Prom
     listCommentsForDoc(memexId, doc.id),
     listDocTags(memexId, doc.id),
   ]);
-  return { doc, decs, tasks: tasksList, comments, tags: docTags };
+  // spec-445 dec-2 — attach each decision's/task's stored true facet keys so get_doc
+  // surfaces the classification as context (batched; a task/decision with no ballot gets []).
+  const [decFacets, taskFacets] = await Promise.all([
+    facetKeysByDecision(memexId, decs.map((d) => d.id)),
+    facetKeysByTask(memexId, tasksList.map((t) => t.id)),
+  ]);
+  const decsWithFacets = decs.map((d) => ({ ...d, facets: decFacets.get(d.id) ?? [] }));
+  const tasksWithFacets = tasksList.map((t) => ({ ...t, facets: taskFacets.get(t.id) ?? [] }));
+  return { doc, decs: decsWithFacets, tasks: tasksWithFacets, comments, tags: docTags };
 }
 
 /**

--- a/packages/server/src/agent/handlers/tasks.ts
+++ b/packages/server/src/agent/handlers/tasks.ts
@@ -25,7 +25,7 @@ import {
 // spec-423 dec-5 — the forced facet ballot + payoff readout. Vocab is read via
 // facet-ballot.ts → facet-vocab.ts (NO-LLM); the classifier engine is never imported
 // on this request path (the facet-classifier-no-request-path regression guard).
-import { requireBallotForMemex, taskBallotTrueFacets } from "../../services/facet-ballot.js";
+import { requireBallotForMemex, taskBallotTrueFacets, facetKeysByTask } from "../../services/facet-ballot.js";
 import { parseBallotArg, storeRouteAndReadout, routeAndReadout } from "../../services/facet-consume.js";
 import {
   ValidationError,
@@ -88,7 +88,12 @@ export const tasksTools: ToolSpec[] = [
         if (all.length === 0) {
           return `${formatDocStatusHeader(doc)}\n\nNo tasks on this doc.`;
         }
-        const lines = all.map((t) => `- t-${t.seq} [${t.status}] "${t.title}"`);
+        // spec-445 dec-2 — surface each task's stored facets as context.
+        const vFacets = await facetKeysByTask(memexId, all.map((t) => t.id));
+        const lines = all.map((t) => {
+          const f = vFacets.get(t.id) ?? [];
+          return `- t-${t.seq} [${t.status}] "${t.title}"${f.length > 0 ? ` {facets: ${f.join(", ")}}` : ""}`;
+        });
         return `${formatDocStatusHeader(doc)}\n\n${lines.join("\n")}`;
       }
 
@@ -107,6 +112,8 @@ export const tasksTools: ToolSpec[] = [
       }
       const all = await listTasks(memexId, doc.id);
       if (all.length === 0) return "No tasks on this doc.";
+      // spec-445 dec-2 — surface each task's stored facets as context.
+      const listFacets = await facetKeysByTask(memexId, all.map((t) => t.id));
       return all
         .map((t) => {
           const blockerHandles = [
@@ -118,7 +125,8 @@ export const tasksTools: ToolSpec[] = [
               ? `BLOCKED-by-${blockerHandles.join(",")}`
               : "READY";
           const taskRef = buildChildRef(slugs, doc, { type: "tasks", seq: t.seq });
-          return `- ref: ${taskRef} [${t.status}, ${marker}] "${t.title}"`;
+          const f = listFacets.get(t.id) ?? [];
+          return `- ref: ${taskRef} [${t.status}, ${marker}] "${t.title}"${f.length > 0 ? ` {facets: ${f.join(", ")}}` : ""}`;
         })
         .join("\n");
     },
@@ -256,6 +264,18 @@ export const tasksTools: ToolSpec[] = [
         .describe(
           "Canonical ref to a decision or task in the same parent doc, e.g. `mindset/main/specs/spec-3/decisions/dec-2`.",
         ),
+      // spec-445 dec-1 — edit a task's facet classification through this existing tool
+      // (no bespoke facet tool). A COMPLETE verdict REPLACES the stored ballot and
+      // re-surfaces the governing standards; omit to leave facets unchanged.
+      facetBallot: z
+        .object({
+          verdict: z.record(z.string(), z.boolean()).describe("Complete map: facet slug → true/false."),
+          none: z.boolean().describe("true = this work governs no facet (every verdict false)."),
+        })
+        .optional()
+        .describe(
+          "OPTIONAL. Re-cast this task's facet classification: a COMPLETE verdict over the Memex's facet vocabulary (a true/false for EVERY facet, or none:true) that REPLACES the stored ballot and re-surfaces the governing standards. Omit to leave facets unchanged. Call the `facets` tool (verb:'list') first to read the vocabulary.",
+        ),
       verbose: VERBOSE_FIELD,
     },
     async handler(input, ctx) {
@@ -310,6 +330,8 @@ export const tasksTools: ToolSpec[] = [
       // `status` is a single value — so at most one is non-empty per call.
       let inProgressReadout = "";
       let completedReadout = "";
+      // spec-445 dec-1 — the facet-edit readout, re-surfaced when the ballot is re-cast.
+      let facetEditReadout = "";
       if (
         title !== undefined ||
         description !== undefined ||
@@ -324,6 +346,34 @@ export const tasksTools: ToolSpec[] = [
         }, reqCtx(ctx));
         const taskRef = buildChildRef(slugs, doc, { type: "tasks", seq: updated.seq });
         messages.push(`Task ref: ${taskRef} fields updated.`);
+      }
+      // spec-445 dec-1 — edit the task's facet classification through this existing tool:
+      // a COMPLETE verdict REPLACES the stored ballot (task_facet_ballots upserts one per
+      // task) and re-surfaces the governing standards — the same validate+store+route path
+      // create_task takes. Omitted → facets unchanged; a vocab-less Memex is a no-op.
+      if (input.facetBallot !== undefined) {
+        const ballot = parseBallotArg(input.facetBallot);
+        const vocab = await requireBallotForMemex(
+          memexId,
+          { provided: true, ballot },
+          { noun: "task", channel: ctx.channel },
+        );
+        if (vocab.length > 0) {
+          const fresh = await getTask(memexId, taskUuid);
+          const taskRef = buildChildRef(slugs, doc, { type: "tasks", seq: fresh.seq });
+          facetEditReadout = await storeRouteAndReadout({
+            memexId,
+            specDocId: doc.id,
+            noun: "task",
+            rowId: taskUuid,
+            ownerRef: taskRef,
+            queryText: `${fresh.title}\n${fresh.description}`,
+            ballot,
+            vocab,
+            ctx: reqCtx(ctx),
+          });
+          messages.push(`Task ref: ${taskRef} facets updated.`);
+        }
       }
       if (status !== undefined) {
         const updated = await updateTaskStatus(memexId, taskUuid, status, reqCtx(ctx));
@@ -435,13 +485,13 @@ export const tasksTools: ToolSpec[] = [
         // spec-219 Phase 2 (sole-author): the completion steer is already
         // signalled above (kind:'task_completed'); composeGuidanceEnvelope owns
         // the prose for terse AND verbose. Nothing to park here.
-        return (await formatState(url, state, ctx)) + inProgressReadout + completedReadout;
+        return (await formatState(url, state, ctx)) + inProgressReadout + completedReadout + facetEditReadout;
       }
 
       if (messages.length === 0) {
-        return "No-op: pass at least one of status, title, description, acceptanceCriteria, sectionRef, addBlockerRef, removeBlockerRef.";
+        return "No-op: pass at least one of status, title, description, acceptanceCriteria, sectionRef, facetBallot, addBlockerRef, removeBlockerRef.";
       }
-      return messages.join(" ") + inProgressReadout + completedReadout;
+      return messages.join(" ") + inProgressReadout + completedReadout + facetEditReadout;
     },
   },
   {

--- a/packages/server/src/formatting/formatters.ts
+++ b/packages/server/src/formatting/formatters.ts
@@ -157,8 +157,10 @@ export function formatFullDocState(
     sections: DocSection[];
     checkoutHolder?: { name: string | null; email: string | null } | null;
   },
-  decisions: Decision[],
-  tasks: TaskWithBlockers[],
+  // spec-445 dec-2 — each decision/task may carry its stored true facet keys, surfaced
+  // on retrieval as context (attached by fullDocState; absent for facet-less callers).
+  decisions: (Decision & { facets?: string[] })[],
+  tasks: (TaskWithBlockers & { facets?: string[] })[],
   appBaseUrl?: string,
   comments?: DocCommentsResult,
   slugs?: FormatterRefContext,
@@ -754,7 +756,7 @@ function decisionOptionsBlock(decision: Decision): string | null {
 }
 
 function formatDecision(
-  decision: Decision,
+  decision: Decision & { facets?: string[] },
   parentDoc?: Doc,
   slugs?: FormatterRefContext,
 ): string {
@@ -772,6 +774,11 @@ function formatDecision(
   if (decision.context) {
     lines.push(`  Context: ${decision.context}`);
   }
+  // spec-445 dec-2 — the decision's facet classification, surfaced on retrieval as
+  // context (it informs the ballots of the tasks that implement it; it never pre-fills them).
+  if (decision.facets && decision.facets.length > 0) {
+    lines.push(`  Facets: ${decision.facets.join(", ")}`);
+  }
   if (parentDoc) {
     const canonical = maybeChildRef(slugs, parentDoc, "decisions", decision.seq);
     lines.push(`  ref: ${canonical}`);
@@ -780,7 +787,7 @@ function formatDecision(
 }
 
 function formatDecisionList(
-  decs: Decision[],
+  decs: (Decision & { facets?: string[] })[],
   parentDoc?: Doc,
   slugs?: FormatterRefContext,
 ): string {
@@ -816,7 +823,7 @@ function formatCommentBadge(counts?: { open: number; resolved: number }): string
 }
 
 function formatTask(
-  t: TaskWithBlockers,
+  t: TaskWithBlockers & { facets?: string[] },
   commentCounts?: { open: number; resolved: number },
   slugs?: FormatterRefContext,
   parentDoc?: Pick<Doc, "docType" | "handle">,
@@ -841,6 +848,10 @@ function formatTask(
   if (t.sectionRef) {
     lines.push(`  Section: ${t.sectionRef}`);
   }
+  // spec-445 dec-2 — the task's facet classification, surfaced on retrieval.
+  if (t.facets && t.facets.length > 0) {
+    lines.push(`  Facets: ${t.facets.join(", ")}`);
+  }
   const criteria = (t.acceptanceCriteria ?? []) as AcceptanceCriterion[];
   if (criteria.length > 0) {
     lines.push(`  Acceptance criteria:`);
@@ -856,7 +867,7 @@ function formatTask(
 }
 
 function formatTaskList(
-  items: TaskWithBlockers[],
+  items: (TaskWithBlockers & { facets?: string[] })[],
   commentCounts?: Map<string, { open: number; resolved: number }>,
   slugs?: FormatterRefContext,
   parentDoc?: Pick<Doc, "docType" | "handle">,

--- a/packages/shared/src/tool-manifest.ts
+++ b/packages/shared/src/tool-manifest.ts
@@ -251,8 +251,8 @@ export const toolManifest: ToolManifestEntry[] = [
   {
     name: 'update_decision',
     summary:
-      "Two modes: edit-in-place (title/context/resolution/chosenOptionIndex on any status) OR reopen (status='open' on a resolved decision). One per call. resolve_decision is the named verb for new resolutions.",
-    args: 'update_decision(ref, status?, title?, context?, resolution?, chosenOptionIndex?)',
+      "Two modes: edit-in-place (title/context/resolution/chosenOptionIndex/facetBallot on any status) OR reopen (status='open' on a resolved decision). One per call. resolve_decision is the named verb for new resolutions; facetBallot re-casts the decision's facets.",
+    args: 'update_decision(ref, status?, title?, context?, resolution?, chosenOptionIndex?, facetBallot?)',
     group: 'planning',
     readOnlyHint: false,
     trafficClass: 'specify',
@@ -340,8 +340,8 @@ export const toolManifest: ToolManifestEntry[] = [
   {
     name: 'update_task',
     summary:
-      'Update a task: status, title, description, acceptanceCriteria, sectionRef, add/removeBlockerRef.',
-    args: 'update_task(ref, status?, title?, description?, acceptanceCriteria?, sectionRef?, addBlockerRef?, removeBlockerRef?)',
+      'Update a task: status, title, description, acceptanceCriteria, sectionRef, facetBallot (re-cast facets), add/removeBlockerRef.',
+    args: 'update_task(ref, status?, title?, description?, acceptanceCriteria?, sectionRef?, addBlockerRef?, removeBlockerRef?, facetBallot?)',
     group: 'build',
     readOnlyHint: false,
     trafficClass: 'build',


### PR DESCRIPTION
## Summary

Phase 3 of facets (a small follow-on to [spec-423](https://memex.ai/mindset-prod/memex-building-itself/specs/spec-423)). Facets were declared once at creation and thereafter **invisible** (get_doc / list_tasks didn't surface them) and **uneditable** except by re-resolving a decision. This closes both gaps using **existing tools only** — no new MCP tool.

Spec: [spec-445](https://memex.ai/mindset-prod/memex-building-itself/specs/spec-445) (verify, 9/9 ACs verified).

## What changed

**Editable via the update tools (dec-1):** `update_task` and `update_decision` gain an optional `facetBallot`. When provided it validates against the live vocabulary, **replaces** the stored ballot (per-noun upsert), and re-routes + re-surfaces the governing-standards readout — the identical `requireBallotForMemex` + `storeRouteAndReadout` path create_task/create_decision take. Omitted = facets unchanged; vocab-less Memex = no-op; permitted on any status. On `update_decision` it's an edit-in-place field (composes with title/context/resolution; not with a status transition). Manifest arg-signatures updated (std-16). No bespoke facet-mutation tool.

**Visible on retrieval (dec-2):** `get_doc` (via `formatTask`/`formatDecision` + `fullDocState`) and `list_tasks` surface each item's stored true facet keys, batched through the existing `facetKeysByTask`/`facetKeysByDecision` readers. Read-only, no bus emission, empty for a ballot-less item. This is **context only** — `create_task` still forces a fresh, independent ballot, so a parent decision's facets *inform* a downstream task's classification without pre-filling it (answering the bias question directly).

No schema change, no migration. Files: `agent/handlers/{tasks,decisions,shared}.ts`, `formatting/formatters.ts`, `@memex/shared` tool-manifest, + a new integration test.

## Test plan
- New `facet-edit-handlers.spec-445` integration suite (9 tests, green), tagged to all 9 ACs (5 implementation + 4 scope) — **all verified on the board**.
- Full server suite green (549/550 files); the single red is the known `migration-smoke` global-user-scan parallel-fixture flake (passes 13/13 isolated; this Spec's fixtures use the excluded `@example.com` domain, so they are not the contaminator).
- UI suite green (277 files / 1901). `pnpm build` (server + UI) + typechecks green.
- Merged against current `develop` (fresh worktree) before running the gate.

## e2e (std-28)
No new Playwright journey: the facet-pill web surface is unchanged (covered by journey-50, spec-423), and the REST routes already return facets, so an agent-driven edit reflects on the existing pills with no UI change. The edit + MCP-retrieval capabilities are agent-facing and covered by the integration tests above.

## Licensing
Fair-code (open core) — no `.ee` files touched.
