### PR TITLE
Release: welcome-video fixes + onboarding analytics + SEO slug reservations

### DIFF
--- a/packages/server/src/__e2e__/slug-allocation.api.test.ts
+++ b/packages/server/src/__e2e__/slug-allocation.api.test.ts
@@ -82,7 +82,9 @@ describe("slug-allocation [std-3] [t-1]", () => {
     it("rejects reserved slugs (login, api, mcp, install, settings, ...)", async () => {
       const { userId, bearer } = await seedUser({ verified: true });
       try {
-        for (const reserved of ["login", "api", "mcp", "install", "settings", "memex"]) {
+        // Includes marketing section slugs (writing, pricing, …) — reserved
+        // because the apex 301-redirects them to www.memex.ai (see slug.ts).
+        for (const reserved of ["login", "api", "mcp", "install", "settings", "memex", "writing", "pricing", "coding-agents"]) {
           const res = await authedRequest(
             "/api/orgs",
             { method: "POST", body: JSON.stringify({ slug: reserved }) },

--- a/packages/server/src/services/shared/slug.ts
+++ b/packages/server/src/services/shared/slug.ts
@@ -8,10 +8,19 @@ import { eq, lt } from "drizzle-orm";
 import { db } from "../../db/connection.js";
 import { namespaces, namespaceSlugReservations } from "../../db/schema.js";
 
-// std-3 / dec-11 — small, stable list of app-utility paths only. Marketing
-// terms (pricing, about, blog, …) deliberately NOT reserved because marketing
-// lives on www.memex.ai.
+// std-3 — reserved slugs fall in two groups:
+//   1. App-utility paths (login, api, mcp, …) that collide with the app's own
+//      routes on the apex.
+//   2. Marketing section slugs. These REVERSE dec-11's original "marketing terms
+//      are not reserved" stance: the marketing site (www.memex.ai) owns these
+//      top-level paths, and the apex load balancer 301-redirects memex.ai/<seg>
+//      (and every sub-path) to www for SEO — see memex-website infra/url-map.yaml.
+//      A tenant could therefore never actually reach a namespace home at one of
+//      these slugs on the apex, so we reserve them to prevent the conflict up
+//      front. Keep this group in sync with the top-level routes in
+//      memex-website/src/lib/routes.ts.
 export const RESERVED_SLUGS = new Set([
+  // group 1 — app-utility paths
   "login",
   "signup",
   "install",
@@ -27,10 +36,20 @@ export const RESERVED_SLUGS = new Set([
   "admin",
   "account",
   "app",
-  "docs",
   "support",
   "help",
   "memex",
+  // group 2 — marketing section slugs (redirected apex → www; mirror routes.ts)
+  "docs",
+  "pricing",
+  "story",
+  "community",
+  "writing",
+  "legal",
+  "research",
+  "coding-agents",
+  "get-started",
+  "branding",
 ]);
 
 const SLUG_RE = /^[a-z0-9][a-z0-9-]{0,38}$/;

--- a/packages/shared/EVENT-STANDARD.md
+++ b/packages/shared/EVENT-STANDARD.md
@@ -52,6 +52,9 @@ versa.
 - `voice.mic_permission_result` — The mic permission prompt resolved during a voice attempt. props.result (granted | denied | dismissed).
 - `voice.icon_shown` — The voice entry point was presented (adoption denominator). Fired once per mount. props.surface (icon | pill).
 - `home.landing_routed` — The app router decided a user's first-load landing from a read-only onboarding-state check (spec-421 dec-5). props.destination (home | specs), props.graduated (bool). Measures whether routing graduated users straight to Specs lifts engagement. Advisory.
+- `onboarding.video_started` — The first-run welcome video began playing (WelcomePage, spec-444). Fires at most once per view on the first play/playing event. props.video_id, props.position_seconds, props.duration_seconds, props.percent_watched (0–100, NaN-guarded) — counts only.
+- `onboarding.video_completed` — The first-run welcome video reached its end (WelcomePage, spec-444). Fires at most once per view. props.video_id, props.position_seconds, props.duration_seconds, props.percent_watched — counts only. The activation-funnel success signal for the video step.
+- `onboarding.video_skipped` — The user dismissed/skipped the first-run welcome video BEFORE completion (WelcomePage Get-started / Skip / × close, spec-444). Fires at most once per view and only when the video has not already completed. props.video_id, props.position_seconds, props.duration_seconds, props.percent_watched — counts only.
 
 ## Back-end outcomes (whitelisted `mutate()` events, dec-8)
 

--- a/packages/shared/src/usage-events-registry.frontend-engagement.test.ts
+++ b/packages/shared/src/usage-events-registry.frontend-engagement.test.ts
@@ -53,10 +53,13 @@ describe("front-end engagement events (spec-336 follow-on)", () => {
 
   it("adds no onboarding.* events and leaves the home_canvas.* events intact (Home untouched — spec-336 owns it)", () => {
     tagAc(`${AC}/ac-3`);
-    const names = USAGE_EVENT_REGISTRY.map((e) => e.name);
-    // No new onboarding surface was introduced by this batch.
-    expect(names.filter((n) => n.startsWith("onboarding."))).toHaveLength(0);
+    // No new onboarding surface was introduced by THIS (spec-336 follow-on) batch —
+    // asserted against the batch's own event list, not the whole registry, so a
+    // later spec that legitimately adds onboarding.* events (spec-444's welcome
+    // video) doesn't retroactively falsify this batch's claim.
+    expect(NEW_FRONTEND_EVENTS.filter((n) => n.startsWith("onboarding."))).toHaveLength(0);
     // The existing Home Canvas events are still present, unchanged.
+    const names = USAGE_EVENT_REGISTRY.map((e) => e.name);
     expect(names).toContain("home_canvas.step_shown");
     expect(names).toContain("home_canvas.cta_clicked");
   });

--- a/packages/shared/src/usage-events-registry.ts
+++ b/packages/shared/src/usage-events-registry.ts
@@ -204,6 +204,31 @@ export const USAGE_EVENT_REGISTRY = [
       "The app router (RootRedirect) decided a user's first-load landing from a read-only onboarding-state check (spec-421 dec-5). props.destination is where they were sent (home | specs); props.graduated (bool) is whether the onboarding journey was graduated. Lets us measure whether routing graduated users straight to their Specs board lifts engagement. Advisory (never throws into routing).",
     source: "frontend",
   },
+  // ── Onboarding welcome video (spec-444) ─────────────────────────────────────
+  // The first-run welcome video (WelcomePage). Front-end lifecycle signals fired
+  // via useTelemetry().track() from the tenant-scoped /telemetry ingress, so they
+  // carry the real actor_user_id and join the activation funnel. Each fires AT
+  // MOST ONCE per view (ref-guarded — replay/seek/pause never re-fire). Props are
+  // IDs + counts only (std-35 cl-5): a stable video_id plus playback position /
+  // duration / percent (all NaN-guarded numbers, never content).
+  {
+    name: "onboarding.video_started",
+    description:
+      "The first-run welcome video began playing (WelcomePage, spec-444). Fires at most once per view on the first play/playing event. props.video_id (stable video slug), props.position_seconds, props.duration_seconds, props.percent_watched (0–100, NaN-guarded) — counts only.",
+    source: "frontend",
+  },
+  {
+    name: "onboarding.video_completed",
+    description:
+      "The first-run welcome video reached its end (WelcomePage 'ended', spec-444). Fires at most once per view. props.video_id, props.position_seconds, props.duration_seconds, props.percent_watched (0–100, NaN-guarded) — counts only. The activation-funnel success signal for the video step.",
+    source: "frontend",
+  },
+  {
+    name: "onboarding.video_skipped",
+    description:
+      "The user dismissed/skipped the first-run welcome video BEFORE completion (WelcomePage Get-started / Skip / × close, spec-444). Fires at most once per view and only when the video has not already completed. props.video_id, props.position_seconds, props.duration_seconds, props.percent_watched (0–100, NaN-guarded) — counts only.",
+    source: "frontend",
+  },
   // ── Back-end outcomes (whitelisted mutate() events, dec-8) ───────────────────
   // Name is EXACTLY `${entity}.${action}` so the t-3 whitelist maps 1:1.
   {

--- a/packages/shared/src/usage-events-standard.test.ts
+++ b/packages/shared/src/usage-events-standard.test.ts
@@ -68,8 +68,12 @@ describe('registry ↔ EVENT-STANDARD.md parity (ac-16 / ac-10)', () => {
     expect(byName.get('identity.merged')?.source).toBe('backend');
     expect(standard.has('identity.merged')).toBe(true);
     // dec-2: the custom-step clicks reuse home_canvas.cta_clicked — NO per-step
-    // event names like onboarding.connect_agent_clicked were introduced.
-    const perStep = [...byName.keys()].filter((n) => /^onboarding\./.test(n));
+    // event names like onboarding.connect_agent_clicked were introduced. (The
+    // spec-444 welcome-video lifecycle events, onboarding.video_*, are a separate
+    // surface — not per-step Home-journey click names — so they're excluded here.)
+    const perStep = [...byName.keys()].filter(
+      (n) => /^onboarding\./.test(n) && !/^onboarding\.video_/.test(n),
+    );
     expect(perStep).toEqual([]);
   });
 });

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -559,6 +559,13 @@ export function PostLoginRouter() {
       />
 
 
+      {/* Bare /specs is a flat, single-segment path with no tenant prefix, so it
+          would otherwise be claimed by /:namespace below and resolved as a bogus
+          "specs" namespace. The specs board is tenant-scoped (/<ns>/<mx>/specs);
+          send the user to their default landing (personal memex, or /home if they
+          have no spec yet). Same RootRedirect pattern as /login and hidden /home. */}
+      <Route path="/specs" element={<RootRedirect />} />
+
       {/* doc-19 t-10: namespace home — /<namespace>/ renders the kind-aware
           OrgHome / Personal Home. More specific /:namespace/:memex routes below
           take precedence (React Router 7 specificity). */}

--- a/packages/ui/src/pages/WelcomePage.telemetry.test.tsx
+++ b/packages/ui/src/pages/WelcomePage.telemetry.test.tsx
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+
+// spec-444 welcome-video instrumentation. The onboarding.video_* events ride the
+// SAME analytics client as every other front-end signal — useTelemetry().track()
+// (std-35 Recipe A). useTelemetry no-ops without a live tenant in jsdom, so we stub
+// the hook to observe the exact call the component makes (mirrors the pattern in
+// TagFilter.telemetry.test.tsx).
+const track = vi.fn();
+vi.mock('../hooks/useTelemetry', () => ({
+  useTelemetry: () => ({ track, optedOut: false, setOptOut: vi.fn() }),
+}));
+
+const updateSession = vi.fn();
+vi.mock('../components/AuthContext', () => ({
+  useAuth: () => ({ token: 'tok', updateSession }),
+}));
+
+const dismissWelcomeVideoApi = vi.fn(async () => ({}) as never);
+vi.mock('../api/auth', () => ({
+  dismissWelcomeVideoApi: () => dismissWelcomeVideoApi(),
+}));
+
+import { WelcomePage } from './WelcomePage';
+
+function renderPage(route = '/welcome') {
+  return render(
+    <MemoryRouter initialEntries={[route]}>
+      <WelcomePage />
+    </MemoryRouter>,
+  );
+}
+
+/** Give the jsdom <video> concrete playback numbers (jsdom leaves them 0 / NaN). */
+function stubPlayback(video: HTMLVideoElement, currentTime: number, duration: number) {
+  Object.defineProperty(video, 'currentTime', { value: currentTime, configurable: true });
+  Object.defineProperty(video, 'duration', { value: duration, configurable: true });
+}
+
+describe('WelcomePage — onboarding.video_* telemetry', () => {
+  beforeEach(() => {
+    track.mockClear();
+    updateSession.mockClear();
+    dismissWelcomeVideoApi.mockClear();
+    sessionStorage.clear();
+  });
+
+  it('fires onboarding.video_started ONCE with the guarded props on first play', () => {
+    renderPage();
+    const video = screen.getByTestId('welcome-video-player') as HTMLVideoElement;
+    stubPlayback(video, 3, 120);
+
+    fireEvent.play(video);
+    fireEvent.playing(video); // resume / multiple play events must not re-fire
+    fireEvent.play(video);
+
+    const started = track.mock.calls.filter((c) => c[0] === 'onboarding.video_started');
+    expect(started).toHaveLength(1);
+    expect(started[0][1]).toEqual({
+      video_id: 'welcome-to-memex-v2',
+      position_seconds: 3,
+      duration_seconds: 120,
+      percent_watched: 3, // 3/120 = 2.5 → rounded
+    });
+  });
+
+  it('fires onboarding.video_completed ONCE on ended', () => {
+    renderPage();
+    const video = screen.getByTestId('welcome-video-player') as HTMLVideoElement;
+    stubPlayback(video, 120, 120);
+
+    fireEvent.ended(video);
+    fireEvent.ended(video);
+
+    const completed = track.mock.calls.filter((c) => c[0] === 'onboarding.video_completed');
+    expect(completed).toHaveLength(1);
+    expect(completed[0][1]).toMatchObject({ video_id: 'welcome-to-memex-v2', percent_watched: 100 });
+  });
+
+  it('fires onboarding.video_skipped ONCE when the CTA dismisses before completion', async () => {
+    renderPage();
+    const video = screen.getByTestId('welcome-video-player') as HTMLVideoElement;
+    stubPlayback(video, 10, 120);
+    fireEvent.play(video);
+
+    await userEvent.click(screen.getByTestId('welcome-video-cta'));
+
+    const skipped = track.mock.calls.filter((c) => c[0] === 'onboarding.video_skipped');
+    expect(skipped).toHaveLength(1);
+    expect(skipped[0][1]).toMatchObject({ video_id: 'welcome-to-memex-v2', position_seconds: 10 });
+    await waitFor(() => expect(dismissWelcomeVideoApi).toHaveBeenCalled());
+  });
+
+  it('fires onboarding.video_skipped when the × close (session dismiss) fires before completion', async () => {
+    renderPage();
+    const video = screen.getByTestId('welcome-video-player') as HTMLVideoElement;
+    stubPlayback(video, 5, 120);
+    fireEvent.play(video);
+
+    await userEvent.click(screen.getByTestId('welcome-video-close'));
+
+    expect(track.mock.calls.filter((c) => c[0] === 'onboarding.video_skipped')).toHaveLength(1);
+  });
+
+  it('does NOT fire onboarding.video_skipped once the video has completed', async () => {
+    renderPage();
+    const video = screen.getByTestId('welcome-video-player') as HTMLVideoElement;
+    stubPlayback(video, 120, 120);
+    fireEvent.ended(video);
+
+    await userEvent.click(screen.getByTestId('welcome-video-cta'));
+
+    expect(track.mock.calls.filter((c) => c[0] === 'onboarding.video_skipped')).toHaveLength(0);
+    expect(track.mock.calls.filter((c) => c[0] === 'onboarding.video_completed')).toHaveLength(1);
+  });
+
+  it('guards percent_watched against NaN/zero duration (metadata not yet loaded)', () => {
+    renderPage();
+    const video = screen.getByTestId('welcome-video-player') as HTMLVideoElement;
+    // duration NaN (default in jsdom before metadata) → percent must be 0, not NaN.
+    fireEvent.play(video);
+
+    const started = track.mock.calls.find((c) => c[0] === 'onboarding.video_started');
+    expect(started?.[1]).toMatchObject({ percent_watched: 0, duration_seconds: 0 });
+  });
+});

--- a/packages/ui/src/pages/WelcomePage.tsx
+++ b/packages/ui/src/pages/WelcomePage.tsx
@@ -8,23 +8,79 @@
 // tab so clicking "Get started" still navigates away cleanly within the session.
 // The × button writes sessionStorage only — the video re-appears on next login.
 
-import { useCallback, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useAuth } from '../components/AuthContext';
 import { dismissWelcomeVideoApi } from '../api/auth';
+import { useTelemetry } from '../hooks/useTelemetry';
 
 const VIDEO_URL =
   'https://storage.googleapis.com/memex-ai-prod-app-static/media/welcome-to-memex-v2.mp4';
 
+// Stable, low-cardinality identifier for this video — the filename stem of
+// VIDEO_URL. Kept as its own const so a src bump is a one-line, deliberate change
+// (props carry ids/counts only — std-35 cl-5).
+const VIDEO_ID = 'welcome-to-memex-v2';
+
+// Build the numeric playback props shared by every onboarding.video_* event.
+// duration is NaN until metadata loads, so percent_watched is guarded against
+// NaN / divide-by-zero and every value is rounded (ids + counts only — no content).
+function videoProps(video: HTMLVideoElement | null): {
+  video_id: string;
+  position_seconds: number;
+  duration_seconds: number;
+  percent_watched: number;
+} {
+  const position = video && Number.isFinite(video.currentTime) ? video.currentTime : 0;
+  const duration = video && Number.isFinite(video.duration) ? video.duration : 0;
+  const percent = duration > 0 ? Math.min(100, Math.max(0, (position / duration) * 100)) : 0;
+  return {
+    video_id: VIDEO_ID,
+    position_seconds: Math.round(position),
+    duration_seconds: Math.round(duration),
+    percent_watched: Math.round(percent),
+  };
+}
+
 export function WelcomePage() {
   const { token, updateSession } = useAuth();
   const navigate = useNavigate();
+  const { track } = useTelemetry(true);
   const [searchParams] = useSearchParams();
   const isRewatch = searchParams.get('rewatch') === '1';
   const [dismissing, setDismissing] = useState(false);
 
+  // spec-444 instrumentation. Refs (not state) so the once-per-view guards can be
+  // read/written inside stable useCallbacks without re-creating them, and so
+  // replay / seek / pause-resume / multiple play events never re-fire an event.
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+  const startedRef = useRef(false);
+  const completedRef = useRef(false);
+  const skippedRef = useRef(false);
+
+  const onVideoPlay = useCallback(() => {
+    if (startedRef.current) return; // fire once per view
+    startedRef.current = true;
+    track('onboarding.video_started', videoProps(videoRef.current));
+  }, [track]);
+
+  const onVideoEnded = useCallback(() => {
+    if (completedRef.current) return; // fire once per view
+    completedRef.current = true;
+    track('onboarding.video_completed', videoProps(videoRef.current));
+  }, [track]);
+
+  // Skip = a dismiss BEFORE completion. At most once, and never if the video
+  // already completed (a completed watch that then dismisses is not a skip).
+  const trackSkip = useCallback(() => {
+    if (completedRef.current || skippedRef.current) return;
+    skippedRef.current = true;
+    track('onboarding.video_skipped', videoProps(videoRef.current));
+  }, [track]);
+
   const permanentDismiss = useCallback(async () => {
     if (dismissing) return;
+    trackSkip();
     setDismissing(true);
     try {
       const session = await dismissWelcomeVideoApi(token);
@@ -37,12 +93,13 @@ export function WelcomePage() {
     // back to /welcome after they click "Get started" or "Skip".
     sessionStorage.setItem('welcomeVideoDismissed', '1');
     navigate('/specs', { replace: true });
-  }, [dismissing, token, updateSession, navigate]);
+  }, [dismissing, trackSkip, token, updateSession, navigate]);
 
   const sessionDismiss = useCallback(() => {
+    trackSkip();
     sessionStorage.setItem('welcomeVideoDismissed', '1');
     navigate('/specs', { replace: true });
-  }, [navigate]);
+  }, [trackSkip, navigate]);
 
   const rewatchExit = useCallback(() => {
     navigate(-1);
@@ -72,10 +129,14 @@ export function WelcomePage() {
         </div>
 
         <video
+          ref={videoRef}
           data-testid="welcome-video-player"
           src={VIDEO_URL}
           controls
           preload="metadata"
+          onPlay={onVideoPlay}
+          onPlaying={onVideoPlay}
+          onEnded={onVideoEnded}
           className="w-full rounded-lg"
           style={{ aspectRatio: '16/9' }}
         />

--- a/packages/ui/src/usage-events-catalog.spec-338.test.ts
+++ b/packages/ui/src/usage-events-catalog.spec-338.test.ts
@@ -38,8 +38,11 @@ describe('spec-338 registry contract (UI-side, emits ACs)', () => {
 
   it('adds no onboarding.* events and leaves home_canvas.* intact (Home untouched — spec-336 owns it)', () => {
     tagAc(`${AC}/ac-3`);
+    // Scoped to THIS batch's own events (not the whole registry), so a later spec
+    // that legitimately adds onboarding.* events (spec-444's welcome video) doesn't
+    // retroactively break this batch's "added none" claim.
+    expect(NEW_FRONTEND_EVENTS.filter((n) => n.startsWith('onboarding.'))).toHaveLength(0);
     const names = USAGE_EVENT_REGISTRY.map((e) => e.name);
-    expect(names.filter((n) => n.startsWith('onboarding.'))).toHaveLength(0);
     expect(names).toContain('home_canvas.step_shown');
     expect(names).toContain('home_canvas.cta_clicked');
   });


### PR DESCRIPTION
Promotes the current `develop` (validated on int) to production `main` per std-21. Single release: the three commits from #465.

## Contents
- **fix(ui): route bare `/specs` through RootRedirect** — welcome-video "Get started"/"Skip" no longer bounce off a bogus `specs` namespace; they land on the caller's tenant board (or `/home`).
- **feat(analytics): onboarding welcome-video events** — `onboarding.video_started/_completed/_skipped` via the existing telemetry pipeline (std-35), once-per-view.
- **feat(slug): reserve marketing section slugs (std-3)** — reserves `pricing, story, community, writing, legal, research, coding-agents, get-started, branding`.

## Pre-merge gate (std-17 / std-26)
- [ ] int smoke suite green on the current `develop` deploy before merging to `main`.
- This PR **cannot fast-forward** (std-21 cl-50) — it lands as a merge commit. Content invariant after merge: `git log develop..main --no-merges` empty.

## Coupling caveats (read before merging)
- The **slug reservations ship safely on their own** — reserving those slugs is harmless without the redirect (it just blocks new namespaces at those names). No prod behaviour change beyond that.
- The companion **marketing apex→www redirect + canonical flip lives in `memex-website`** (branch `feat/marketing-apex-to-www-seo`, not yet pushed/merged) and only goes live via `gcloud compute url-maps import memex-app-lb`. Deploying this release does **not** activate those redirects.
- Known gap: `int.memex.ai/<marketing-path>` has no redirect (int is a separate GCP project / LB) — tracked separately.
- std-3 / dec-11 reversal recorded via `propose_standard_change` on std-3 (pending owner acceptance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)