### PR TITLE
fix(auth): don't block signup response on verification-email send

### DIFF
--- a/packages/server/src/routes/auth/password.ts
+++ b/packages/server/src/routes/auth/password.ts
@@ -91,7 +91,12 @@ password.post("/signup", async (c) => {
       userId: user.id,
     });
     const verifyUrl = `${APP_BASE_URL}/verify-email?token=${encodeURIComponent(issued.raw)}`;
-    await getEmailSender()
+    // Fire-and-forget: the verification-email send is a slow provider round-trip, and the
+    // user is admitted immediately (emailVerified=false, gated by a banner — see the
+    // handler docstring). Awaiting it here blocked the 201, so the client sat on
+    // "Signing up…" until the mail provider replied — a sluggish, double-Enter feel.
+    // Detach it so signup returns as soon as the session is ready (matches waitlist.ts).
+    void getEmailSender()
       .send(buildVerificationEmail({ to: user.email, verifyUrl }))
       .catch((err) => console.error("Failed to send verification email:", err));
   }


### PR DESCRIPTION
## Problem

The signup password dialog feels sluggish — pressing Enter (or clicking the button) appears to require a second Enter. The button sits on **"Signing up…"** for what feels like a beat too long before advancing.

## Root cause

Not a UI bug. The `POST /auth/signup` handler **awaited the verification-email send** before resolving the session and returning `201`:

```ts
await getEmailSender()
  .send(buildVerificationEmail({ to: user.email, verifyUrl }))
  .catch(...)                         // ← full mail-provider round-trip, on the request path
const session = await resolveSession(...)
return c.json(withToken(session), 201) // ← only now does the client un-stick
```

The client (`LoginScreen.tsx`) correctly awaits the single signup call and only navigates on resolve — so the entire Postmark round-trip was charged to perceived signup latency.

## Fix

Detach the send to fire-and-forget so signup returns as soon as the session is ready:

```ts
void getEmailSender()
  .send(buildVerificationEmail({ to: user.email, verifyUrl }))
  .catch((err) => console.error("Failed to send verification email:", err));
```

Safe because the user is **already admitted immediately** with `emailVerified=false` (gated behind a banner per the handler's own contract) — the email was never a blocker for entry, only an accidental latency tax. Mirrors the existing fire-and-forget precedent in `waitlist.ts` and the `void syncUserProfile(...)` call a few lines above in the same handler.

## Verification

- `auth-signup.integration.test.ts` — **24/24 pass** (the capturing sender pushes synchronously, so the "verification email was sent" assertion still holds).
- `tsc --noEmit` on `@memex/server` — clean.

No flow surface changes (same steps, same screens), so no new e2e journey — the existing signup journey covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)