### PR TITLE
release: signup no longer blocks on verification-email send (#467)

### DIFF
--- a/packages/server/src/routes/auth/password.ts
+++ b/packages/server/src/routes/auth/password.ts
@@ -91,7 +91,12 @@ password.post("/signup", async (c) => {
       userId: user.id,
     });
     const verifyUrl = `${APP_BASE_URL}/verify-email?token=${encodeURIComponent(issued.raw)}`;
-    await getEmailSender()
+    // Fire-and-forget: the verification-email send is a slow provider round-trip, and the
+    // user is admitted immediately (emailVerified=false, gated by a banner — see the
+    // handler docstring). Awaiting it here blocked the 201, so the client sat on
+    // "Signing up…" until the mail provider replied — a sluggish, double-Enter feel.
+    // Detach it so signup returns as soon as the session is ready (matches waitlist.ts).
+    void getEmailSender()
       .send(buildVerificationEmail({ to: user.email, verifyUrl }))
       .catch((err) => console.error("Failed to send verification email:", err));
   }


### PR DESCRIPTION
Release to prod. Ships a single change:

- **fix(auth): don't block signup response on verification-email send** (#467)

  `POST /auth/signup` awaited the verification-email send before returning `201`, so the client sat on "Signing up…" for the full mail-provider round-trip — a sluggish, double-Enter feel. Detached to fire-and-forget; the user was already admitted immediately (`emailVerified=false`, banner-gated), so the email was never a blocker for entry.

## Pre-flight
- Content invariant (std-21): `git log develop..main --no-merges` is exactly this one commit.
- int deploy + smoke green for the merge SHA `0a370d4` (std-17/std-26).
- CI on #467: full `test` + `e2e` matrix passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)