### PR TITLE
ci(spec-427): wire ACTIVATION_EMAILS_ENABLED through the deploy step (dec-9)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -161,6 +161,12 @@ jobs:
           EMAIL_ACTIVATION_FROM: ${{ vars.EMAIL_ACTIVATION_FROM }}
           EMAIL_ACTIVATION_REPLY_TO: ${{ vars.EMAIL_ACTIVATION_REPLY_TO }}
           EMAIL_SENDER_NAME: ${{ vars.EMAIL_SENDER_NAME }}
+          # spec-427 dec-9 — the activation-drip master/kill switch. Non-sensitive
+          # (0/1), so a per-environment VARIABLE like the sender vars above (not in the
+          # DEPLOY_ENV_FILE blob), enabling a by-hand prod flip + kill from the GitHub
+          # environment UI. deploy.sh wires it to Cloud Run only when set (${VAR+...}),
+          # so an unset/absent variable is omitted and the drip stays OFF by default.
+          ACTIVATION_EMAILS_ENABLED: ${{ vars.ACTIVATION_EMAILS_ENABLED }}
         run: bash deploy.sh
 
       # spec-243 dec-2 / ac-6: every deploy posts a friendly note to the matching


### PR DESCRIPTION
## Why
spec-427 t-6 wired the activation-drip master/kill switch `ACTIVATION_EMAILS_ENABLED` into `deploy.sh` (`--update-env-vars … ${ACTIVATION_EMAILS_ENABLED+…}`) and `deploy-config.sh`, **but never added the CI passthrough to `deploy.yml`**. GitHub Actions only exposes `vars.*` to a step that references them, so the deploy step never set the variable — meaning there was **no way to flip the flag via the CI/CD path at all**. dec-9 requires "enabled only in prod, by hand"; without this line that hand-flip route didn't exist.

This is the standard std-26 §9 trap: editing config the deploy command doesn't reference does nothing.

## Change
One line in the deploy step's `env:` block, mirroring the sibling `EMAIL_ACTIVATION_*` per-environment variables directly above it:

```yaml
ACTIVATION_EMAILS_ENABLED: ${{ vars.ACTIVATION_EMAILS_ENABLED }}
```

`deploy.sh` already gates this with `${ACTIVATION_EMAILS_ENABLED+…}`, so an unset/absent GitHub Environment variable is **omitted** from the Cloud Run wiring and the drip stays **OFF by default** (fail-safe preserved).

## Go-live path this unblocks
1. (this PR) merge → the deploy step now honours the variable.
2. Set the **prod** GitHub Environment variable `ACTIVATION_EMAILS_ENABLED` = `1` (baseline `0`/unset = off).
3. Deploy prod → verify it reached the container:
   `gcloud run services describe memex-api --region us-east4 --project memex-ai-prod --format="value(spec.template.spec.containers[0].env[].name)" | tr ',' '\n' | grep ACTIVATION_EMAILS_ENABLED`
4. Kill switch: set it to `0`, redeploy.

## Test plan
- [x] `deploy.yml` parses as valid YAML
- [ ] CI green on this PR
- [ ] Post-deploy: the `gcloud run services describe … | grep` check above shows the var present when the prod Environment variable is set

No application code touched — CI workflow only.