### PR TITLE
fix(spec-300): skill create fails legibly and atomically

### DIFF
--- a/packages/server/src/routes/skills.integration.test.ts
+++ b/packages/server/src/routes/skills.integration.test.ts
@@ -16,6 +16,9 @@ import { makeTestMemex, makeTestMemexWithDevAdmin } from "../services/test-helpe
 import { reconstructSkillMd } from "../services/skills/reconstruct-skill-md.js";
 
 const AC_37 = "mindset-prod/memex-building-itself/specs/spec-300/acs/ac-37";
+// spec-300 t-12 (issue-1): an invalid SKILL.md must return an actionable 400,
+// never the opaque 500 the unmapped SkillParse/SkillValidationError produced.
+const AC_43 = "mindset-prod/memex-building-itself/specs/spec-300/acs/ac-43";
 
 const SKILL_MD = reconstructSkillMd({
   name: "route-skill",
@@ -73,6 +76,28 @@ describe("POST /api/<ns>/<mx>/skills — write access (dec-15, std-7)", () => {
     expect(list.status).toBe(200);
     const skills = (await list.json()) as { handle: string }[];
     expect(skills.some((s) => s.handle === body.handle)).toBe(true);
+  });
+
+  it("rejects an invalid SKILL.md with an actionable 400, not a 500 (ac-43)", async () => {
+    tagAc(AC_43);
+
+    // Ordinary Markdown with no `---name/description---` frontmatter — exactly what
+    // a user pasted when this produced `{"error":"Internal server error"}` at 500.
+    const res = await app.request(
+      `${memberPath}/skills`,
+      withApexHost({
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ skillMd: "# Just a heading\n\nNo frontmatter here." }),
+      }),
+    );
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    // The message is actionable (surfaces the validation detail), not the generic
+    // "Internal server error" the unmapped error used to yield.
+    expect(body.error).toBeTruthy();
+    expect(body.error).not.toMatch(/internal server error/i);
   });
 
   it("a non-member is refused (404, not 403 — std-7)", async () => {

--- a/packages/server/src/services/skills/errors.ts
+++ b/packages/server/src/services/skills/errors.ts
@@ -2,15 +2,26 @@
 //
 // These carry enough structure for callers (upload, in-app editor, MCP
 // update_skill) to surface a field-specific, user-visible message [dec-11]
-// without re-inspecting free-text. They are transport-agnostic: the HTTP/MCP
-// layers map them to their own status codes.
+// without re-inspecting free-text.
+//
+// They extend ValidationError (a DomainError) so BOTH transports classify a bad
+// SKILL.md as a client error automatically: the REST error-handler maps
+// ValidationError → 400 and the MCP handleError maps it → "Validation error:
+// <message>". Before this, they extended bare Error, fell through every mapping,
+// and surfaced as an opaque 500 / "Unexpected server error" on every create path
+// (spec-300 issue-1) — a user pasting ordinary Markdown with no frontmatter got
+// a wall instead of "SKILL.md needs name + description". The subclass identity is
+// preserved, so `err instanceof SkillValidationError` (draft-skill's retry loop)
+// still works.
+
+import { ValidationError } from "../../types/errors.js";
 
 /** Raised when SKILL.md frontmatter cannot be parsed at all (e.g. no `---` block,
  *  malformed YAML). A malformed Markdown *body* with valid frontmatter is NOT a
  *  parse error — it is accepted as-is and never executed [dec-11]. */
-export class SkillParseError extends Error {
+export class SkillParseError extends ValidationError {
   constructor(message: string) {
-    super(message);
+    super(message, "SKILL_PARSE_ERROR");
     this.name = "SkillParseError";
   }
 }
@@ -19,12 +30,12 @@ export class SkillParseError extends Error {
  *  missing/blank `name` or `description` [dec-11]. `field` names the first
  *  offending required field when one can be identified, so the UI can attach the
  *  message inline; `errors` carries the full list from the reference validator. */
-export class SkillValidationError extends Error {
+export class SkillValidationError extends ValidationError {
   readonly errors: readonly string[];
   readonly field?: string;
 
   constructor(message: string, errors: readonly string[], field?: string) {
-    super(message);
+    super(message, "SKILL_VALIDATION_ERROR");
     this.name = "SkillValidationError";
     this.errors = errors;
     this.field = field;

--- a/packages/server/src/services/skills/skill-create-hardening.integration.test.ts
+++ b/packages/server/src/services/skills/skill-create-hardening.integration.test.ts
@@ -1,0 +1,102 @@
+// spec-300 t-12 (issue-1) + t-13 (issue-3) — createSkill hardening.
+//
+// Two guarantees the original create path lacked:
+//   ac-43 — an invalid SKILL.md rejects as a ValidationError (→ 400 / MCP
+//           "Validation error"), never a bare Error that fell through to a 500.
+//   ac-44 — a failure while persisting an auxiliary file rolls the whole create
+//           back atomically, leaving NO orphan skill document (the observed
+//           skill-2 bug: doc committed, files failed, 500 returned).
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+import { and, eq, inArray } from "drizzle-orm";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+// Force the blob write to fail so we exercise the create-time storage-failure
+// window WITHOUT a real bucket. importActual keeps the other exports
+// (skillBlobKey / checksumOf / deleteSkillBlob) real, so the rollback's
+// best-effort blob cleanup still runs against the local provider.
+vi.mock("./skill-storage.js", async () => {
+  const actual =
+    await vi.importActual<typeof import("./skill-storage.js")>("./skill-storage.js");
+  return {
+    ...actual,
+    putSkillBlob: vi.fn(async () => {
+      throw new Error("simulated blob store failure");
+    }),
+  };
+});
+
+import { db } from "../../db/connection.js";
+import { documents, memexes } from "../../db/schema.js";
+import { ValidationError } from "../../types/errors.js";
+import { makeTestMemex } from "../test-helpers.js";
+import { createSkill, listSkills } from "./skills-service.js";
+import { reconstructSkillMd } from "./reconstruct-skill-md.js";
+
+const ac = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-300/acs/ac-${n}`;
+
+let memexId: string;
+
+beforeAll(async () => {
+  memexId = await makeTestMemex("skl-harden");
+});
+
+afterAll(async () => {
+  await db.delete(memexes).where(inArray(memexes.id, [memexId])).catch(() => {});
+});
+
+describe("createSkill hardening (spec-300 issue-1 / issue-3)", () => {
+  it("rejects an invalid SKILL.md as a ValidationError, not a bare Error (ac-43)", async () => {
+    tagAc(ac(43));
+
+    // No frontmatter at all — a plain Markdown doc, exactly what a user pasted
+    // when this produced an opaque 500.
+    await expect(
+      createSkill(memexId, { skillMd: "# heading only\n\nno frontmatter" }),
+    ).rejects.toBeInstanceOf(ValidationError);
+
+    // Frontmatter present but a required field (name) missing/blank.
+    await expect(
+      createSkill(memexId, {
+        skillMd: "---\ndescription: only a description\n---\n# x\n",
+      }),
+    ).rejects.toBeInstanceOf(ValidationError);
+  });
+
+  it("rolls back atomically when a binary aux file fails to store — no orphan (ac-44)", async () => {
+    tagAc(ac(44));
+
+    const md = reconstructSkillMd({
+      name: "rollback-check",
+      description: "Use when: verifying create rolls back on a storage failure.",
+      body: "# Rollback check\n\nBody.",
+    });
+
+    // The doc commits (step 1) before the binary blob upload (step 3) throws — the
+    // exact window that used to orphan a skill.
+    await expect(
+      createSkill(memexId, {
+        skillMd: md,
+        files: [
+          {
+            path: "assets/x.bin",
+            contentType: "application/octet-stream",
+            bytes: new Uint8Array([1, 2, 3, 4]),
+          },
+        ],
+      }),
+    ).rejects.toThrow(/blob store failure/i);
+
+    // No orphan: neither the service listing nor the raw documents table shows it.
+    const skills = await listSkills(memexId);
+    expect(skills.find((s) => s.name === "rollback-check")).toBeUndefined();
+
+    const rows = await db
+      .select({ id: documents.id })
+      .from(documents)
+      .where(
+        and(eq(documents.memexId, memexId), eq(documents.title, "rollback-check")),
+      );
+    expect(rows).toHaveLength(0);
+  });
+});

--- a/packages/server/src/services/skills/skills-service.ts
+++ b/packages/server/src/services/skills/skills-service.ts
@@ -26,7 +26,7 @@ import { resolveActorColumns } from "../actor.js";
 import { recordSkillUse } from "./skill-metering.js";
 import { isUuid } from "../shared/identifiers.js";
 import { createDocDraft } from "../documents.js";
-import { getStorageProvider } from "../storage/index.js";
+import { getStorageProvider, type StorageProvider } from "../storage/index.js";
 import { parseSkillMd } from "./parse-skill-md.js";
 import { validateSkill } from "./validate-skill.js";
 import { reconstructSkillMd } from "./reconstruct-skill-md.js";
@@ -39,6 +39,7 @@ import {
   skillBlobKey,
   checksumOf,
   putSkillBlob,
+  deleteSkillBlob,
 } from "./skill-storage.js";
 
 const SKILL_DOC_TYPE = "skill";
@@ -348,53 +349,116 @@ export async function createSkill(
     ctx,
   );
 
-  // 2. Stamp the Skill-specific columns on the doc row (document/updated).
-  const updated = await mutate(
-    ctx,
-    { memexId, docId: doc.id, entity: "document", action: "updated" },
-    async () => {
-      const [row] = await db
-        .update(documents)
-        .set({ description, skillCapabilities: capabilities })
-        .where(and(eq(documents.id, doc.id), eq(documents.memexId, memexId)))
-        .returning();
-      return row;
-    },
-  );
-
-  // 3. Persist the auxiliary-file manifest (one skill_file/created event per row).
-  let fileRows: SkillFile[] = [];
-  const files = input.files ?? [];
-  if (files.length > 0) {
-    const values = await Promise.all(files.map((f) => buildFileRow(doc.id, f)));
-    fileRows = await mutate(
+  // Steps 2-3 run AFTER the doc is committed (step 1), and each mutate() is its
+  // own transaction — so a failure here (e.g. a binary blob upload to an
+  // unprovisioned store) would orphan a half-created skill: the doc persists
+  // while the caller sees a 500 (spec-300 issue-3, observed as skill-2). Wrap
+  // them so a failure rolls the create back atomically before rethrowing the
+  // real cause.
+  try {
+    // 2. Stamp the Skill-specific columns on the doc row (document/updated).
+    const updated = await mutate(
       ctx,
-      values.map((v) => ({
-        memexId,
-        docId: doc.id,
-        entity: "skill_file" as const,
-        action: "created" as const,
-      })),
-      async () => db.insert(skillFiles).values(values).returning(),
+      { memexId, docId: doc.id, entity: "document", action: "updated" },
+      async () => {
+        const [row] = await db
+          .update(documents)
+          .set({ description, skillCapabilities: capabilities })
+          .where(and(eq(documents.id, doc.id), eq(documents.memexId, memexId)))
+          .returning();
+        return row;
+      },
     );
-  }
 
-  // createDocDraft doesn't return ns/mx slugs; resolve them so the returned view
-  // carries the canonical ref exactly like getSkill does.
-  const ref = await resolveSkillRef(memexId, updated.handle);
-  const view: SkillView = {
-    ref,
-    handle: updated.handle,
-    name: updated.title,
-    description,
-    capabilities,
-    skillMd: reconstructSkillMd({ name: updated.title, description, body }),
-    files: fileRows.map(toTocEntry),
-    lastUpdatedAt: await lastEditAt(doc.id, updated.statusChangedAt),
-  };
-  // The doc-column update is a genuine mutate() witness; forward its brand to the
-  // composite view (the ONE sanctioned brand transfer, mutate.ts forwardBrand).
-  return forwardBrand(updated, view);
+    // 3. Persist the auxiliary-file manifest (one skill_file/created event per row).
+    let fileRows: SkillFile[] = [];
+    const files = input.files ?? [];
+    if (files.length > 0) {
+      const values = await Promise.all(files.map((f) => buildFileRow(doc.id, f)));
+      fileRows = await mutate(
+        ctx,
+        values.map(() => ({
+          memexId,
+          docId: doc.id,
+          entity: "skill_file" as const,
+          action: "created" as const,
+        })),
+        async () => db.insert(skillFiles).values(values).returning(),
+      );
+    }
+
+    // createDocDraft doesn't return ns/mx slugs; resolve them so the returned view
+    // carries the canonical ref exactly like getSkill does.
+    const ref = await resolveSkillRef(memexId, updated.handle);
+    const view: SkillView = {
+      ref,
+      handle: updated.handle,
+      name: updated.title,
+      description,
+      capabilities,
+      skillMd: reconstructSkillMd({ name: updated.title, description, body }),
+      files: fileRows.map(toTocEntry),
+      lastUpdatedAt: await lastEditAt(doc.id, updated.statusChangedAt),
+    };
+    // The doc-column update is a genuine mutate() witness; forward its brand to the
+    // composite view (the ONE sanctioned brand transfer, mutate.ts forwardBrand).
+    return forwardBrand(updated, view);
+  } catch (err) {
+    await rollbackPartialSkillCreate(memexId, doc.id, input.files ?? [], ctx);
+    throw err;
+  }
+}
+
+/** Compensating rollback for a createSkill that failed AFTER its doc was
+ *  committed (spec-300 issue-3, ac-44). Removes any auxiliary blobs written for
+ *  this doc, then hard-deletes the doc through mutate() so the unified bus stays
+ *  consistent — step 1's document/created is balanced by a document/deleted, and
+ *  FK ON DELETE CASCADE clears the skill_files manifest. Best-effort throughout:
+ *  a cleanup failure must never mask the original error the caller is about to
+ *  see rethrown. */
+async function rollbackPartialSkillCreate(
+  memexId: string,
+  docId: string,
+  files: readonly SkillFileInput[],
+  ctx: RequestCtx,
+): Promise<void> {
+  // Blobs first. getStorageProvider() itself throws when storage is unconfigured
+  // — a common cause of the very failure we're rolling back — in which case
+  // nothing was uploaded, so skip silently.
+  let provider: StorageProvider | null = null;
+  try {
+    provider = getStorageProvider();
+  } catch {
+    provider = null;
+  }
+  if (provider) {
+    for (const f of files) {
+      const path = f.path?.trim();
+      if (isBinaryFile(f) && path) {
+        try {
+          await deleteSkillBlob(provider, skillBlobKey(docId, path));
+        } catch {
+          // best-effort — a stranded blob is far less bad than masking the cause
+        }
+      }
+    }
+  }
+  try {
+    await mutate(
+      ctx,
+      { memexId, docId, entity: "document", action: "deleted" },
+      async () => {
+        const [row] = await db
+          .delete(documents)
+          .where(and(eq(documents.id, docId), eq(documents.memexId, memexId)))
+          .returning();
+        return row;
+      },
+    );
+  } catch {
+    // best-effort — if even the compensating delete fails, still rethrow the
+    // original cause; an orphan is a lesser evil than swallowing the real error.
+  }
 }
 
 /** Resolve `<namespace>/<memex>/skills/<handle>` from a memexId + handle. */

--- a/packages/ui/src/components/skills/CreateSkillModal.test.tsx
+++ b/packages/ui/src/components/skills/CreateSkillModal.test.tsx
@@ -7,6 +7,9 @@ import { CreateSkillModal } from './CreateSkillModal';
 // spec-300 t-6:
 //   ac-21 — an agent-assisted authoring entry point (describe-in-plain-language).
 const AC21 = 'mindset-prod/memex-building-itself/specs/spec-300/acs/ac-21';
+// spec-300 t-14 (issue-4b):
+//   ac-45 — switching tabs clears any stale create-error banner.
+const AC45 = 'mindset-prod/memex-building-itself/specs/spec-300/acs/ac-45';
 
 const createSkillMock = vi.fn();
 vi.mock('../../api/skills', async () => {
@@ -88,5 +91,28 @@ describe('CreateSkillModal', () => {
     expect(await screen.findByTestId('create-skill-error')).toHaveTextContent(
       /frontmatter is missing/i,
     );
+  });
+
+  it('clears a stale create-error banner when switching tabs (ac-45)', async () => {
+    tagAc(AC45);
+    createSkillMock.mockRejectedValueOnce(new Error('SKILL.md frontmatter is missing `name`'));
+    renderModal();
+
+    // Produce an error on the Write tab.
+    fireEvent.click(screen.getByTestId('skill-mode-write'));
+    fireEvent.change(screen.getByTestId('skill-md-editor'), {
+      target: { value: 'no frontmatter' },
+    });
+    fireEvent.click(screen.getByTestId('create-skill-submit'));
+    expect(await screen.findByTestId('create-skill-error')).toBeInTheDocument();
+
+    // Switching to another tab (including Describe, whose action is disabled)
+    // must clear the banner so it never reads as a fresh failure (issue-4b).
+    fireEvent.click(screen.getByTestId('skill-mode-describe'));
+    expect(screen.queryByTestId('create-skill-error')).not.toBeInTheDocument();
+
+    // And back to Upload stays clean.
+    fireEvent.click(screen.getByTestId('skill-mode-upload'));
+    expect(screen.queryByTestId('create-skill-error')).not.toBeInTheDocument();
   });
 });

--- a/packages/ui/src/components/skills/CreateSkillModal.tsx
+++ b/packages/ui/src/components/skills/CreateSkillModal.tsx
@@ -56,6 +56,14 @@ export function CreateSkillModal({ onClose }: { onClose: () => void }) {
     setCapabilities((prev) => ({ ...prev, [key]: !prev[key] }));
   }, []);
 
+  // Switching tabs clears any create-error banner (spec-300 issue-4b): an error
+  // from a prior Upload/Write attempt must not read as a fresh failure on another
+  // tab (including Describe, whose action is disabled).
+  const handleModeChange = useCallback((next: Mode) => {
+    setMode(next);
+    setError(null);
+  }, []);
+
   const handleUpload = useCallback((file: File | undefined) => {
     if (!file) return;
     setError(null);
@@ -146,7 +154,7 @@ export function CreateSkillModal({ onClose }: { onClose: () => void }) {
               <button
                 key={m.id}
                 type="button"
-                onClick={() => setMode(m.id)}
+                onClick={() => handleModeChange(m.id)}
                 aria-pressed={mode === m.id}
                 data-testid={`skill-mode-${m.id}`}
                 className={`text-xs px-3 py-1.5 transition-colors ${


### PR DESCRIPTION
## Summary

Three defects found while testing the shipped **Skills** feature (spec-300, currently in `verify`). Filed as spec-300 **issue-1 / issue-3 / issue-4b**, fixed here with verifying ACs **ac-43 / ac-44 / ac-45**.

### 1. Invalid SKILL.md → opaque 500 on every create path (issue-1 / ac-43)
`SkillParseError` and `SkillValidationError` extended bare `Error`, so an invalid SKILL.md (e.g. ordinary Markdown with no `name`/`description` frontmatter) fell through every error mapping and surfaced as `{"error":"Internal server error"}` at 500 — on the Upload tab, the Write tab, and over MCP. They now extend `ValidationError`, so the REST global handler maps them to **400** and MCP `handleError` to `"Validation error: <message>"`. `draft-skill`'s `instanceof SkillValidationError` retry loop is preserved by the subclass identity.

### 2. Non-atomic create orphans a partial skill (issue-3 / ac-44)
`createSkill` committed the document before persisting auxiliary files, and each `mutate()` is its own transaction — so a failure in file persistence (e.g. a binary blob upload to an unprovisioned store) left the doc committed while the API returned 500 (observed as `skill-2`). Create now rolls back atomically: best-effort remove any written blobs, then hard-delete the doc through `mutate()` (the `document/created` event is balanced by `document/deleted`; FK `ON DELETE CASCADE` clears `skill_files`), then rethrow the real cause.

### 3. Stale create-error banner across modal tabs (issue-4b / ac-45)
The New-skill modal now clears the create-error banner on tab switch, so an error from a prior attempt never reads as a fresh failure on another tab (including the disabled Describe-it tab).

## Test plan
- [x] Full server suite — **574 files / 5443 passed**, 0 failures (isolated run)
- [x] Full UI suite — **284 files / 1929 passed**
- [x] Typecheck — server + ui both clean
- [x] New tests: `skill-create-hardening.integration.test.ts` (ac-43 service, ac-44 atomicity via mocked storage failure), route 400 test in `skills.integration.test.ts` (ac-43), banner-clear test in `CreateSkillModal.test.tsx` (ac-45)
- [x] ac-43 / ac-44 / ac-45 verified on the board

## Not in this PR
- **issue-2** (binary aux storage 500 in deployed envs) is unprovisioned infra: the deploy never sets `STORAGE_PROVIDER` / `STORAGE_GCS_BUCKET`. This PR makes the failure roll back cleanly (ac-44); provisioning the bucket + wiring the deploy is a separate, owner-authorized step. Kept open.
- The **skills in-app agent** (genuinely satisfies ac-21, currently a "Coming soon" stub) is the next task on spec-300, modeled on the standards/drift agent — its own PR with its own e2e journey.

Spec: [spec-300](https://memex.ai/mindset-prod/memex-building-itself/specs/spec-300)