### PR TITLE
fix(spec-304): clear the desktop email-verification gate on return (issue-16, t-77)

### DIFF
--- a/packages/ui/src/pages/VerifyEmailGate.spec-304-issue16.test.tsx
+++ b/packages/ui/src/pages/VerifyEmailGate.spec-304-issue16.test.tsx
@@ -1,0 +1,108 @@
+// @vitest-environment jsdom
+// spec-304 issue-16 / ac-76: the desktop VerifyEmailGate must clear promptly once
+// the email is verified OUTSIDE the webview (the link opens in the system browser),
+// without a manual reload and without relying on an incidental SSE reconnect.
+// The fix is client-side: re-check the session (the existing refreshSession()) on
+// window focus / tab visibility, plus a gentle poll while the gate is mounted.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, act } from '@testing-library/react';
+import { tagAc } from '@memex-ai-ac/vitest';
+
+const AC = 'mindset-prod/memex-building-itself/specs/spec-304/acs/ac-76';
+
+// Hoisted so the (hoisted) vi.mock factory below can close over the same spy we
+// assert on.
+const { refreshSessionMock } = vi.hoisted(() => ({ refreshSessionMock: vi.fn() }));
+
+vi.mock('../components/AuthContext', () => ({
+  useAuth: () => ({
+    session: { user: { email: 'new@example.com' } },
+    token: 'tok',
+    logout: vi.fn(),
+    refreshSession: refreshSessionMock,
+  }),
+}));
+
+vi.mock('../api/client', () => ({
+  resendVerificationApi: vi.fn(),
+  AuthApiError: class AuthApiError extends Error {
+    constructor(public status: number, public reason: string, message: string) {
+      super(message);
+    }
+  },
+}));
+
+vi.mock('../components/Logo', () => ({ Logo: () => null }));
+
+const { VerifyEmailGate } = await import('./VerifyEmailGate');
+
+describe('VerifyEmailGate — clears on return, no manual reload (spec-304 issue-16, ac-76)', () => {
+  beforeEach(() => {
+    refreshSessionMock.mockReset();
+    refreshSessionMock.mockResolvedValue(undefined);
+  });
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('does not re-check on mount, but re-checks on window focus (ac-76)', async () => {
+    tagAc(AC);
+    await act(async () => {
+      render(<VerifyEmailGate />);
+    });
+    expect(refreshSessionMock).not.toHaveBeenCalled();
+
+    await act(async () => {
+      window.dispatchEvent(new Event('focus'));
+    });
+    expect(refreshSessionMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-checks when the tab becomes visible (ac-76)', async () => {
+    tagAc(AC);
+    await act(async () => {
+      render(<VerifyEmailGate />);
+    });
+    // jsdom's default document.visibilityState is 'visible'.
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+    expect(refreshSessionMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('polls the session while the gate is mounted (ac-76)', async () => {
+    tagAc(AC);
+    vi.useFakeTimers();
+    try {
+      render(<VerifyEmailGate />);
+      expect(refreshSessionMock).not.toHaveBeenCalled();
+      await act(async () => {
+        vi.advanceTimersByTime(8000);
+      });
+      expect(refreshSessionMock).toHaveBeenCalledTimes(1);
+      await act(async () => {
+        vi.advanceTimersByTime(8000);
+      });
+      expect(refreshSessionMock).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('tears the poll + listeners down on unmount (ac-76)', async () => {
+    tagAc(AC);
+    vi.useFakeTimers();
+    try {
+      const { unmount } = render(<VerifyEmailGate />);
+      unmount();
+      await act(async () => {
+        vi.advanceTimersByTime(24000);
+      });
+      window.dispatchEvent(new Event('focus'));
+      expect(refreshSessionMock).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/packages/ui/src/pages/VerifyEmailGate.tsx
+++ b/packages/ui/src/pages/VerifyEmailGate.tsx
@@ -11,7 +11,7 @@ const RESEND_COOLDOWN_SEC = 60;
 // Shown for authenticated users whose emailVerified=false. They can't proceed into their
 // Memex until they click the link in their inbox. Provides a resend button + sign out.
 export function VerifyEmailGate() {
-  const { session, token, logout } = useAuth();
+  const { session, token, logout, refreshSession } = useAuth();
   const [sending, setSending] = useState(false);
   const [sentAt, setSentAt] = useState<number | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -31,6 +31,36 @@ export function VerifyEmailGate() {
     const id = setInterval(() => setCooldown((s) => Math.max(0, s - 1)), 1000);
     return () => clearInterval(id);
   }, [coolingDown]);
+
+  // Clear the gate promptly once the email is verified. Verification happens OUTSIDE
+  // this webview/tab — the confirmation link opens in the system browser — and the
+  // server emits nothing on the unified bus when it stamps email_verified_at
+  // (user-identity writes carry no bus entity), so nothing here learns about it on
+  // its own; the gate historically only cleared on an incidental SSE reconnect,
+  // minutes later (spec-304 issue-16). Re-check the session whenever the user returns
+  // to the app (window focus / the tab becoming visible), and poll gently while this
+  // gate is mounted, so it clears with no manual reload. refreshSession() re-fetches
+  // /api/auth/me; once it comes back verified, AuthContext swaps the session and this
+  // gate unmounts (tearing the listeners + poll down via the cleanup below).
+  useEffect(() => {
+    const recheck = () => {
+      void refreshSession().catch(() => {
+        // Best-effort: a transient refresh failure just retries on the next
+        // focus/visibility/poll tick; never surface it on the gate.
+      });
+    };
+    const onVisibility = () => {
+      if (document.visibilityState === 'visible') recheck();
+    };
+    window.addEventListener('focus', recheck);
+    document.addEventListener('visibilitychange', onVisibility);
+    const poll = window.setInterval(recheck, 8000);
+    return () => {
+      window.removeEventListener('focus', recheck);
+      document.removeEventListener('visibilitychange', onVisibility);
+      window.clearInterval(poll);
+    };
+  }, [refreshSession]);
 
   const resend = async () => {
     if (sending || cooldown > 0) return;


### PR DESCRIPTION
## Problem (spec-304 issue-16)
On the signed desktop build, email+password signup shows `VerifyEmailGate`. The confirmation link opens in the **external system browser** and verifies there, but the desktop webview stayed on "Confirm your email" for ~2 minutes — it only cleared on an incidental SSE reconnect. Root cause: the server stamps `email_verified_at` with a bare write that emits nothing on the unified bus (user-identity writes carry no bus entity — `services/users.ts` is deliberately allowlisted in the mutate-coverage guard), and the gate had no polling/focus refresh.

## Fix (client-only — deliberately not a server bus change)
`packages/ui/src/pages/VerifyEmailGate.tsx`: re-check the session via the **existing** `refreshSession()` on `window` **focus** + `visibilitychange→visible`, plus a gentle **8s poll** while the gate is mounted. Returning to the app/tab (or the poll) re-fetches `/api/auth/me`; once it's verified, `AuthContext` swaps the session and the gate unmounts (cleaning up listeners + poll).

### Why client-only, not the server emit
The issue suggested emitting on the bus like mcp-tokens, but there is **no `user` `ChangeEntity`** and `services/users.ts` is an explicit mutate-coverage allowlist exemption. A server emit would require adding a new bus entity + activity-log handling **on the critical auth path** — too much blast radius for this fix. This change touches **no** server code: the verify endpoint, token consumption, session resolution, the bus, and the allowlist are all unchanged, so it structurally cannot regress account verification. (A real-time server emit remains a possible future hardening; not in scope here.)

## Tests
- `VerifyEmailGate.spec-304-issue16.test.tsx` (4 tests, tagged ac-76): re-checks on focus, on visibility, polls while mounted, and tears down on unmount. All green.
- `@memex/ui` type-check: 0 errors.
- Manual runtime confirmation (sign up → verify in a separate browser → return → gate clears) recommended before release but not required for the unit-level AC.

Resolves issue-16 / t-77 (spec-304).