### PR TITLE
feat(spec-300): skills in-app agent — describe-to-draft + dedicated chat mode (t-15)

### DIFF
--- a/packages/server/src/agent/context-builder.skills.test.ts
+++ b/packages/server/src/agent/context-builder.skills.test.ts
@@ -1,0 +1,82 @@
+// spec-300 t-15 (dec-23, ac-51): unit tests for buildSkillsContext — the skills
+// agent's grounding. It lists the Memex's active Skills (handle, name, capability
+// flags, ref, description) so the agent grounds drafting / curation in what
+// actually exists. We mock listSkills so the summary shape is asserted without
+// touching the DB (mirrors context-builder.drift.test.ts).
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+vi.mock("../services/skills/skills-service.js", () => ({
+  listSkills: vi.fn(),
+}));
+
+import { buildSkillsContext } from "./context-builder.js";
+import { listSkills } from "../services/skills/skills-service.js";
+
+// spec-300 t-15: the skills-agent mode is grounded per-request in the Memex's
+// skill catalogue by buildSkillsContext.
+const AC_SKILLS_GROUNDING =
+  "mindset-prod/memex-building-itself/specs/spec-300/acs/ac-51";
+
+type Skill = Awaited<ReturnType<typeof listSkills>>[number];
+
+function skill(overrides: Partial<Skill> = {}): Skill {
+  return {
+    ref: "mindset-prod/memex-building-itself/skills/skill-1",
+    handle: "skill-1",
+    name: "pdf-extractor",
+    description: "Use when: extracting text from a PDF.",
+    capabilities: { codebaseAccess: false, codeEditing: false, externalTools: false },
+    ...overrides,
+  } as Skill;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("buildSkillsContext", () => {
+  it("lists each active skill with handle, name, ref, description, and capability flags", async () => {
+    tagAc(AC_SKILLS_GROUNDING);
+    vi.mocked(listSkills).mockResolvedValueOnce([
+      skill(),
+      skill({
+        ref: "mindset-prod/memex-building-itself/skills/skill-2",
+        handle: "skill-2",
+        name: "repo-auditor",
+        description: "Use when: auditing a codebase.",
+        capabilities: { codebaseAccess: true, codeEditing: false, externalTools: true },
+      }),
+    ]);
+
+    const result = await buildSkillsContext("mx-uuid");
+
+    expect(result.phase).toBe("specify");
+    expect(result.context).toContain("Skills in this Memex: 2.");
+    // Each skill leads with its handle + name and carries its ref + description.
+    expect(result.context).toContain('- skill-1 "pdf-extractor"');
+    expect(result.context).toContain(
+      "ref: mindset-prod/memex-building-itself/skills/skill-1",
+    );
+    expect(result.context).toContain("Use when: extracting text from a PDF.");
+    // Capability flags surface for a skill that declares them.
+    expect(result.context).toContain(
+      '- skill-2 "repo-auditor" [codebase-access, external-tools]',
+    );
+    // The authoring guidance names the one verbed write path the UI + MCP share.
+    expect(result.context).toContain("update_skill");
+    expect(listSkills).toHaveBeenCalledWith("mx-uuid");
+  });
+
+  it("returns an explicit 'no skills yet' context when the Memex has none", async () => {
+    tagAc(AC_SKILLS_GROUNDING);
+    vi.mocked(listSkills).mockResolvedValueOnce([]);
+
+    const result = await buildSkillsContext("mx-uuid");
+    expect(result.phase).toBe("specify");
+    expect(result.context).toContain("Skills: none yet.");
+    // Must not claim a phantom catalogue count.
+    expect(result.context).not.toContain("Skills in this Memex:");
+  });
+});

--- a/packages/server/src/agent/context-builder.ts
+++ b/packages/server/src/agent/context-builder.ts
@@ -6,6 +6,7 @@ import { listTasks } from "../services/tasks.js";
 import { reviewDocComments } from "../services/comments.js";
 import { listDriftInbox, type DriftInboxRow } from "../services/drift-inbox.js";
 import { listStandards } from "../services/standards.js";
+import { listSkills } from "../services/skills/skills-service.js";
 import { listMemexIssues } from "../services/issues-list.js";
 import { buildChildRef, buildDocRef, memexSlugsById } from "../mcp/refs.js";
 import { phaseFromStatus } from "../formatting/formatters.js";
@@ -483,6 +484,54 @@ export async function buildIssuesContext(
   }
   lines.push(
     "To act: triage with `update_issue`, close with `resolve_issue`, or promote a todo straight to a Task with `convert_issue_to_task` — use `get_issue` / `search_issues` for an issue's exact ref first, and gate every change with `render_confirmation`. When a request actually needs a Spec, do NOT create one — hand off to the New Spec flow with `render_handoff`.",
+  );
+
+  return { context: lines.join("\n"), phase: "specify" };
+}
+
+/**
+ * spec-300 t-15 (dec-23, ac-51): build the SKILLS agent's grounding context.
+ *
+ * The skills agent's world is this Memex's Skills catalogue. The context lists
+ * every active Skill — handle, name, capability flags, a canonical ref the agent
+ * can pass straight to `get_skill`, and the one-line description it dispatches on —
+ * so it grounds answers in what actually exists before curating or drafting. It
+ * authors / curates Skills only; the surface restriction is the server-side
+ * MODE_TOOLS gate (SKILLS_SERVER_TOOLS), the behaviour is SKILLS_AGENT_MODE_GUIDANCE.
+ * Returns `phase: 'specify'` — like drift / standards / issues, the skills mode is
+ * not a Spec phase but buildSystemBlocks needs a base phase to project the general
+ * orientation. Mirrors buildStandardsContext.
+ */
+export async function buildSkillsContext(
+  memexId: string,
+): Promise<DocumentContext> {
+  const skills = await listSkills(memexId);
+
+  if (skills.length === 0) {
+    return {
+      context:
+        "Skills: none yet. This Memex has no Skills. You author Skills, so offer to help the user create their first one — ask them to describe it in plain language, then draft a spec-compliant SKILL.md for their review and create it with `update_skill` once they confirm.",
+      phase: "specify",
+    };
+  }
+
+  const lines: string[] = [];
+  lines.push(
+    `Skills in this Memex: ${skills.length}. Each is listed with its handle, name, capability flags, ref, and the description it dispatches on. Call \`get_skill\` on a Skill's ref to read its full SKILL.md + auxiliary-file table, and \`list_skills\` to re-enumerate.`,
+  );
+  lines.push("");
+  for (const s of skills) {
+    const flags: string[] = [];
+    if (s.capabilities.codebaseAccess) flags.push("codebase-access");
+    if (s.capabilities.codeEditing) flags.push("code-editing");
+    if (s.capabilities.externalTools) flags.push("external-tools");
+    const caps = flags.length > 0 ? ` [${flags.join(", ")}]` : "";
+    // Keep this a SINGLE-line template literal (std-15 prose-location drift-guard).
+    lines.push(`- ${s.handle} "${s.name}"${caps} · ref: ${s.ref} — ${s.description}`);
+  }
+  lines.push("");
+  lines.push(
+    "To author: draft a new Skill from the user's plain-language description and create it with `update_skill` (create); curate an existing one with `update_skill` (edit / delete / restore) — the one verbed write path the manual UI and MCP share. Gate every mutation with `render_confirmation` first. Navigate the reader to a Skill with `render_navigate`; quote exact SKILL.md text with `render_quote`, never inline quotation marks. You never execute a Skill or touch code — hand off with `render_handoff` for anything outside skill authoring.",
   );
 
   return { context: lines.join("\n"), phase: "specify" };

--- a/packages/server/src/agent/system-prompt.scoped.test.ts
+++ b/packages/server/src/agent/system-prompt.scoped.test.ts
@@ -11,8 +11,12 @@ import { buildSystemBlocks } from "./system-prompt.js";
 // to its own function.
 const AC_NEW_AGENTS =
   "mindset-prod/memex-building-itself/specs/spec-389/acs/ac-4";
+// spec-300 t-15 (dec-23): ac-51 — the skills-agent mode prompt block is injected
+// only when mode === 'skills', and appends the shared handoff map (std-38).
+const AC_SKILLS_BLOCK =
+  "mindset-prod/memex-building-itself/specs/spec-300/acs/ac-51";
 
-function instructionText(scopedMode?: "standards" | "issues"): string {
+function instructionText(scopedMode?: "standards" | "issues" | "skills"): string {
   const blocks = buildSystemBlocks(
     "ctx",
     "specify",
@@ -53,5 +57,20 @@ describe("buildSystemBlocks — scoped standards/issues modes (ac-4)", () => {
     const text = instructionText(undefined);
     expect(text).not.toContain("## Standards agent");
     expect(text).not.toContain("## Issues agent");
+  });
+
+  it("spec-300 ac-51: skills mode injects the skills-agent block + the shared handoff map, only when mode is skills", () => {
+    tagAc(AC_SKILLS_BLOCK);
+    const text = instructionText("skills");
+    // The dedicated skills-agent MODE block (distinct from the awareness block
+    // "## Skills — reusable procedures you can follow" every agent carries).
+    expect(text).toContain("## Skills agent");
+    expect(text).toContain("update_skill"); // its one verbed authoring/curation path
+    expect(text).toContain("hand off"); // the shared cross-agent handoff map rides along
+    // Not the sibling scoped blocks.
+    expect(text).not.toContain("## Standards agent");
+    expect(text).not.toContain("## Issues agent");
+    // And an unscoped (spec) build does NOT carry the dedicated skills-agent block.
+    expect(instructionText(undefined)).not.toContain("## Skills agent");
   });
 });

--- a/packages/server/src/agent/system-prompt.ts
+++ b/packages/server/src/agent/system-prompt.ts
@@ -11,6 +11,7 @@ import {
   ISSUES_AGENT_GUIDANCE,
   SHARED_HANDOFF_GUIDANCE,
   SKILLS_AGENT_GUIDANCE,
+  SKILLS_AGENT_MODE_GUIDANCE,
   toPromptBlocks,
   toPhaseGuidance,
   type SpecPhase,
@@ -114,9 +115,14 @@ if (!SCAFFOLD_BLOCK) {
 const STANDARDS_BLOCK = STANDARDS_AGENT_GUIDANCE.text;
 const ISSUES_BLOCK = ISSUES_AGENT_GUIDANCE.text;
 const HANDOFF_BLOCK = SHARED_HANDOFF_GUIDANCE.text;
-if (!STANDARDS_BLOCK || !ISSUES_BLOCK || !HANDOFF_BLOCK) {
+// spec-300 t-15 (dec-23) — the dedicated SKILLS-agent mode block (distinct from the
+// SKILLS_BLOCK awareness overlay below). Injected by buildSystemBlocks when the
+// per-request mode is 'skills', like the standards / issues overlays, followed by
+// the shared handoff map so the agent hands off anything outside skill authoring.
+const SKILLS_MODE_BLOCK = SKILLS_AGENT_MODE_GUIDANCE.text;
+if (!STANDARDS_BLOCK || !ISSUES_BLOCK || !HANDOFF_BLOCK || !SKILLS_MODE_BLOCK) {
   throw new Error(
-    "STANDARDS_/ISSUES_AGENT_GUIDANCE or SHARED_HANDOFF_GUIDANCE text is empty — the scoped agent blocks cannot be assembled",
+    "STANDARDS_/ISSUES_/SKILLS_AGENT mode guidance or SHARED_HANDOFF_GUIDANCE text is empty — the scoped agent blocks cannot be assembled",
   );
 }
 
@@ -186,7 +192,9 @@ export function buildSystemBlocks(
   // spec-389 t-5 (dec-2): the new scoped agent modes. Each appends its behaviour
   // block + the shared handoff map over the same phase-composed base, like the
   // drift overlay; their factual grounding rides the cached context block.
-  scopedMode?: "standards" | "issues",
+  // spec-300 t-15 (dec-23): 'skills' is the fifth scoped mode — the dedicated
+  // skills authoring / curation agent on the Skills page.
+  scopedMode?: "standards" | "issues" | "skills",
 ): SystemBlock[] {
   const projectedPhase: SpecPhase = phase === "draft" ? "specify" : phase;
   // spec-360: scaffold mode leads with its OWN identity — the doc-bound base
@@ -233,11 +241,16 @@ export function buildSystemBlocks(
   // spec-389 t-5 (dec-2): the standards / issues posture overlays — each appends
   // its behaviour block plus the shared cross-agent handoff map (spec-389 t-4) so
   // the agent stays in its lane and hands off (render_handoff) for anything else.
+  // spec-300 t-15 (dec-23): the skills posture overlays like standards / issues —
+  // its authoring/curation behaviour block + the shared handoff map, so the skills
+  // agent stays in its lane and hands off anything outside skill authoring.
   const withScoped =
     scopedMode === "standards"
       ? `${withDrift}\n\n${STANDARDS_BLOCK}\n\n${HANDOFF_BLOCK}`
       : scopedMode === "issues"
       ? `${withDrift}\n\n${ISSUES_BLOCK}\n\n${HANDOFF_BLOCK}`
+      : scopedMode === "skills"
+      ? `${withDrift}\n\n${SKILLS_MODE_BLOCK}\n\n${HANDOFF_BLOCK}`
       : withDrift;
   // spec-300 t-7 (dec-7 / dec-20 / dec-2): the PRIMARY in-app agent — the doc/spec
   // agent, no scoped mode — is the one that dispatches skills; append the

--- a/packages/server/src/agent/tools.handoff.test.ts
+++ b/packages/server/src/agent/tools.handoff.test.ts
@@ -13,6 +13,13 @@ import type { AgentMode } from "./tools.js";
 // target agent.
 const AC_HANDOFF =
   "mindset-prod/memex-building-itself/specs/spec-389/acs/ac-11";
+// spec-300 t-15 (dec-23): ac-48 — for a request outside skill authoring the skills
+// agent declines honestly and hands off with a copyable render_handoff, rather than
+// reaching for a tool it should not have. render_handoff riding into skills mode
+// (and update_skill being its ONLY write verb, asserted in tools.mode-map) IS that
+// mechanism.
+const AC_SKILLS_HANDOFF =
+  "mindset-prod/memex-building-itself/specs/spec-300/acs/ac-48";
 
 const ALL_MODES: AgentMode[] = [
   "spec",
@@ -20,6 +27,7 @@ const ALL_MODES: AgentMode[] = [
   "scaffold",
   "standards",
   "issues",
+  "skills",
 ];
 
 describe("render_handoff — the shared cross-agent handoff (ac-11)", () => {
@@ -32,6 +40,9 @@ describe("render_handoff — the shared cross-agent handoff (ac-11)", () => {
 
   it("rides into EVERY mode so any agent can hand off out-of-scope work", () => {
     tagAc(AC_HANDOFF);
+    // spec-300 ac-48: the skills agent inherits the same honest-refusal handoff —
+    // render_handoff is present in skills mode too.
+    tagAc(AC_SKILLS_HANDOFF);
     for (const mode of ALL_MODES) {
       const names = getToolDefinitions({ mode }).map((t) => t.name);
       expect(names).toContain("render_handoff");

--- a/packages/server/src/agent/tools.mode-map.test.ts
+++ b/packages/server/src/agent/tools.mode-map.test.ts
@@ -39,6 +39,16 @@ const AC_CREATE_STANDARD =
 // tasks. The mode-map inclusion/exclusion assertion IS that outcome.
 const AC_SCOPE_BOUNDARY =
   "mindset-prod/memex-building-itself/specs/spec-416/acs/ac-3";
+// spec-300 t-15 (dec-23): ac-50 — the skills agent is registered with a scoped
+// allowlist of EXACTLY {list_skills, get_skill, update_skill, search_memex,
+// get_doc}; a skills-mode call cannot reach any tool outside that set (std-38).
+const AC_SKILLS_MODE =
+  "mindset-prod/memex-building-itself/specs/spec-300/acs/ac-50";
+// spec-300 t-15 (dec-23): ac-47 — the skills agent performs create/edit/archive/
+// restore through the ONE validated write path (update_skill) and its authority is
+// limited to skills, nothing else. The mode-map inclusion/exclusion IS that boundary.
+const AC_SKILLS_AUTHORITY =
+  "mindset-prod/memex-building-itself/specs/spec-300/acs/ac-47";
 
 // The read/grounding base every scoped mode shares.
 const READ_BASE = ["search_memex", "get_doc"];
@@ -87,6 +97,11 @@ const EXPECTED: Record<Exclude<AgentMode, "spec">, string[]> = {
     "convert_issue_to_task",
     "search_issues",
   ],
+  // spec-300 t-15 (dec-23, ac-50): the SKILLS agent's subset — the read/grounding
+  // base plus the three skill verbs (the ONE verbed update_skill covers create /
+  // edit / delete / restore). This map is EXHAUSTIVE over AgentMode, so a missing
+  // 'skills' entry fails the typecheck — the registration is forced, not optional.
+  skills: ["list_skills", "get_skill", "update_skill", "search_memex", "get_doc"],
 };
 
 const SCOPED_MODES = Object.keys(EXPECTED) as Exclude<AgentMode, "spec">[];
@@ -146,6 +161,28 @@ describe("getToolDefinitions — each scoped mode exposes exactly its subset (ac
     // The /tools/execute gate agrees: create_standard permitted, create_doc not.
     expect(isToolAllowedInMode("standards", "create_standard")).toBe(true);
     expect(isToolAllowedInMode("standards", "create_doc")).toBe(false);
+  });
+
+  it("spec-300 ac-50: skills mode → exactly {list_skills,get_skill,update_skill,search_memex,get_doc}, nothing else", () => {
+    tagAc(AC_SKILLS_MODE);
+    // The same inclusion/exclusion IS the ac-47 authority boundary: the agent's
+    // one write verb is the validated update_skill; it can reach nothing else.
+    tagAc(AC_SKILLS_AUTHORITY);
+    const names = getToolDefinitions({ mode: "skills" }).map((t) => t.name);
+    // Exactly the five-tool skills subset — no broader mutation surface leaks in.
+    const serverNames = names.filter((n) => !isUiTool(n)).sort();
+    expect(serverNames).toEqual(
+      ["get_doc", "get_skill", "list_skills", "search_memex", "update_skill"].sort(),
+    );
+    // The one verbed write path is permitted; the broad doc / task / standard /
+    // issue verbs are refused at the gate (std-38 narrow authority).
+    expect(isToolAllowedInMode("skills", "update_skill")).toBe(true);
+    expect(isToolAllowedInMode("skills", "create_doc")).toBe(false);
+    expect(isToolAllowedInMode("skills", "create_task")).toBe(false);
+    expect(isToolAllowedInMode("skills", "propose_standard_change")).toBe(false);
+    expect(isToolAllowedInMode("skills", "register_issue")).toBe(false);
+    // And a sibling scoped mode cannot reach the skill write path.
+    expect(isToolAllowedInMode("standards", "update_skill")).toBe(false);
   });
 
   it("the issues agent can manage Issues but cannot author Standards or Spec body", () => {

--- a/packages/server/src/agent/tools.ts
+++ b/packages/server/src/agent/tools.ts
@@ -510,10 +510,35 @@ const ISSUES_SERVER_TOOLS = new Set<string>([
   "search_issues",
 ]);
 
+// spec-300 t-15 (dec-23): the SKILLS agent's focused server surface. Its world is
+// this Memex's Skills — it drafts new ones from a description AND curates existing
+// ones (create / edit / archive / restore, all through the ONE verbed update_skill
+// write path the manual UI + MCP share). list_skills / get_skill ground it in the
+// catalogue; search_memex / get_doc give it the broad Memex-wide awareness every
+// in-app agent has (std-38). It never reaches the doc / decision / task / standard
+// mutation surface — for anything outside skill authoring it hands off
+// (render_handoff, a UI tool always included). No new tool is introduced: all five
+// already exist on the in-app surface.
+const SKILLS_SERVER_TOOLS = new Set<string>([
+  "list_skills",
+  "get_skill",
+  "update_skill",
+  "search_memex",
+  "get_doc",
+]);
+
 // spec-389 t-3 (dec-2): the in-app agent modes. `spec` is the doc/Spec agent —
 // the UNRESTRICTED surface, governed by phase + reviewer gates rather than a mode
 // subset. Every other mode is scoped to a narrow server-tool subset below.
-export type AgentMode = "spec" | "drift" | "scaffold" | "standards" | "issues";
+// spec-300 t-15 (dec-23): `skills` is the fifth scoped mode — the dedicated skills
+// authoring / curation agent that lives on the Skills page.
+export type AgentMode =
+  | "spec"
+  | "drift"
+  | "scaffold"
+  | "standards"
+  | "issues"
+  | "skills";
 
 // spec-389 t-3 (dec-2): ONE server-owned mode → allow-list map, generalising the
 // per-mode booleans (DRIFT_/SCAFFOLD_SERVER_TOOLS) into a single auditable place.
@@ -526,6 +551,7 @@ const MODE_TOOLS: Record<Exclude<AgentMode, "spec">, ReadonlySet<string>> = {
   scaffold: SCAFFOLD_SERVER_TOOLS,
   standards: STANDARDS_SERVER_TOOLS,
   issues: ISSUES_SERVER_TOOLS,
+  skills: SKILLS_SERVER_TOOLS,
 };
 
 /** All tool definitions for the Anthropic API. Last tool has cache_control.

--- a/packages/server/src/routes/llm.ts
+++ b/packages/server/src/routes/llm.ts
@@ -5,7 +5,7 @@ import "dotenv/config";
 import type Anthropic from "@anthropic-ai/sdk";
 import type { MessageParam, ContentBlockParam } from "@anthropic-ai/sdk/resources/messages.js";
 import { getAnthropicClient, LlmNotConfiguredError } from "../agent/anthropic-client.js";
-import { buildDocumentContext, buildDriftContext, buildScaffoldContext, buildStandardsContext, buildIssuesContext } from "../agent/context-builder.js";
+import { buildDocumentContext, buildDriftContext, buildScaffoldContext, buildStandardsContext, buildIssuesContext, buildSkillsContext } from "../agent/context-builder.js";
 import { buildSystemBlocks, buildCreationSystemBlocks } from "../agent/system-prompt.js";
 import { getToolDefinitions, getCreationToolDefinitions, executeServerTool, isToolAllowedForReviewer, isReadOnlyTool, isToolAllowedInMode } from "../agent/tools.js";
 import { logRequest, logResponse, logError, logToolExecution, logExtractionOutcome } from "../agent/logger.js";
@@ -53,8 +53,11 @@ const chatSchema = z.object({
    *  focused scaffold subset. The React UI's Scaffold Inspect surface sends this.
    *  spec-389 t-5 (dec-2): `'standards'` / `'issues'` are the new scoped agents —
    *  memex-scoped (no bound doc), each with its grounding context, mode block, and
-   *  MODE_TOOLS subset. The Standards / Issues surfaces send these. */
-  mode: z.enum(["drift", "scaffold", "standards", "issues"]).optional(),
+   *  MODE_TOOLS subset. The Standards / Issues surfaces send these.
+   *  spec-300 t-15 (dec-23): `'skills'` is the dedicated skills authoring / curation
+   *  agent that lives on the Skills page — memex-scoped, grounded in the skill
+   *  catalogue, tool set pinned to SKILLS_SERVER_TOOLS. The Skills surface sends it. */
+  mode: z.enum(["drift", "scaffold", "standards", "issues", "skills"]).optional(),
 });
 
 llmRouter.post("/chat", async (c) => {
@@ -70,6 +73,7 @@ llmRouter.post("/chat", async (c) => {
   const scaffoldMode = mode === "scaffold";
   const standardsMode = mode === "standards";
   const issuesMode = mode === "issues";
+  const skillsMode = mode === "skills";
   console.log(
     `[LLM PROXY] docId=${docId ?? "none"}, messages=${messages.length}, mode=${mode ?? "spec"}`,
   );
@@ -97,10 +101,14 @@ llmRouter.post("/chat", async (c) => {
   // is no bound doc. The context is the composed scaffold grounding (cached).
   // spec-389 t-5 (dec-2): standards / issues modes are memex-scoped like drift /
   // scaffold — their grounding is the Standards corpus / open-Issues parking lot.
+  // spec-300 t-15 (dec-23): skills mode is memex-scoped like the other scoped
+  // agents — its grounding is the Memex's skill catalogue (buildSkillsContext).
   const documentContext = standardsMode
     ? await buildStandardsContext(memexId)
     : issuesMode
     ? await buildIssuesContext(memexId)
+    : skillsMode
+    ? await buildSkillsContext(memexId)
     : scaffoldMode
     ? await buildScaffoldContext(memexId)
     : driftMode
@@ -157,7 +165,13 @@ llmRouter.post("/chat", async (c) => {
     driftMode,
     integrationState,
     scaffoldMode,
-    standardsMode ? "standards" : issuesMode ? "issues" : undefined,
+    standardsMode
+      ? "standards"
+      : issuesMode
+      ? "issues"
+      : skillsMode
+      ? "skills"
+      : undefined,
   );
   // dec-3 definition filter: a reviewer's model never sees the blocked mutations.
   // spec-143 t-4 (dec-6): in drift mode the model sees only the focused drift
@@ -337,8 +351,10 @@ const toolExecSchema = z.object({
    *  spec-360 t-1 (dec-1): when `'scaffold'`, the call is from the scaffold
    *  assistant — memex-scoped, no bound doc, restricted to the scaffold subset.
    *  spec-389 t-3 (dec-2): `'standards'` / `'issues'` are the new scoped agents,
-   *  each memex-scoped and pinned to its own MODE_TOOLS subset by the gate. */
-  mode: z.enum(["drift", "scaffold", "standards", "issues"]).optional(),
+   *  each memex-scoped and pinned to its own MODE_TOOLS subset by the gate.
+   *  spec-300 t-15 (dec-23): `'skills'` is pinned to SKILLS_SERVER_TOOLS the same
+   *  way — this enum MUST accept it too, else /tools/execute 400s while /chat works. */
+  mode: z.enum(["drift", "scaffold", "standards", "issues", "skills"]).optional(),
 });
 
 llmRouter.post("/tools/execute", async (c) => {

--- a/packages/server/src/routes/skills-draft.integration.test.ts
+++ b/packages/server/src/routes/skills-draft.integration.test.ts
@@ -1,0 +1,122 @@
+// spec-300 t-15 Increment 1 (ac-49, closes ac-21) — the POST /skills/draft route
+// the "Describe it" tab calls. The route delegates to draftSkillFromDescription
+// (LLM-backed via getAnthropicClient, std-30), so we stub THAT here and assert the
+// route's own contract: write-access gate (dec-15 / std-7), input validation, and
+// the JSON shape it hands back for the create flow to persist. The draft service's
+// own describe→draft→validate behaviour is unit-tested in draft-skill.test.ts.
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+import { eq, inArray } from "drizzle-orm";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+// Dev-mode auth (no minted JWT) — same shape as skills.integration.test.ts.
+vi.hoisted(() => {
+  process.env.GOOGLE_CLIENT_ID = "";
+  return undefined;
+});
+
+const draftMock = vi.fn();
+vi.mock("../services/skills/draft-skill.js", () => ({
+  draftSkillFromDescription: (...a: unknown[]) => draftMock(...a),
+}));
+
+import { db } from "../db/connection.js";
+import { memexes, namespaces } from "../db/schema.js";
+import { app } from "../app.js";
+import { makeTestMemex, makeTestMemexWithDevAdmin } from "../services/test-helpers.js";
+
+const AC_49 = "mindset-prod/memex-building-itself/specs/spec-300/acs/ac-49";
+
+const DRAFT = {
+  skillMd:
+    "---\nname: drafted-skill\ndescription: Drafted from a plain-language description.\n---\n# Drafted skill\n\nSteps.\n",
+  name: "drafted-skill",
+  description: "Drafted from a plain-language description.",
+  body: "# Drafted skill\n\nSteps.\n",
+};
+
+let memberPath: string; // dev is administrator (write) here
+let nonMemberPath: string; // dev is NOT a member here
+const memexIds: string[] = [];
+
+function withApexHost(init: RequestInit = {}): RequestInit {
+  return { ...init, headers: { ...(init.headers ?? {}), Host: "memex.ai" } };
+}
+
+beforeAll(async () => {
+  const member = await makeTestMemexWithDevAdmin("skl-draft-m");
+  memberPath = `/api/${member.slug}/main`;
+  memexIds.push(member.memexId);
+
+  const outsiderId = await makeTestMemex("skl-draft-x");
+  memexIds.push(outsiderId);
+  const [ns] = await db
+    .select({ slug: namespaces.slug })
+    .from(namespaces)
+    .innerJoin(memexes, eq(memexes.namespaceId, namespaces.id))
+    .where(eq(memexes.id, outsiderId))
+    .limit(1);
+  nonMemberPath = `/api/${ns!.slug}/main`;
+});
+
+afterAll(async () => {
+  await db.delete(memexes).where(inArray(memexes.id, memexIds)).catch(() => {});
+});
+
+describe("POST /api/<ns>/<mx>/skills/draft (spec-300 t-15 Increment 1)", () => {
+  it("drafts a validated SKILL.md from a description for a write member (ac-49)", async () => {
+    tagAc(AC_49);
+    draftMock.mockResolvedValueOnce(DRAFT);
+
+    const res = await app.request(
+      `${memberPath}/skills/draft`,
+      withApexHost({
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ description: "A skill that reviews a PR for missing tests." }),
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as typeof DRAFT;
+    expect(body.skillMd).toBe(DRAFT.skillMd);
+    expect(body.name).toBe("drafted-skill");
+    // The description reached the draft service verbatim.
+    expect(draftMock).toHaveBeenCalledTimes(1);
+    expect(draftMock.mock.calls[0][0]).toContain("reviews a PR");
+  });
+
+  it("rejects a blank description with a 400 (ac-49)", async () => {
+    tagAc(AC_49);
+    draftMock.mockClear();
+
+    const res = await app.request(
+      `${memberPath}/skills/draft`,
+      withApexHost({
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ description: "   " }),
+      }),
+    );
+
+    expect(res.status).toBe(400);
+    // Validation fails before the LLM is ever consulted.
+    expect(draftMock).not.toHaveBeenCalled();
+  });
+
+  it("refuses a non-member as not-found (404, std-7) — no draft attempted (ac-49)", async () => {
+    tagAc(AC_49);
+    draftMock.mockClear();
+
+    const res = await app.request(
+      `${nonMemberPath}/skills/draft`,
+      withApexHost({
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ description: "anything" }),
+      }),
+    );
+
+    expect(res.status).toBe(404);
+    expect(draftMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/server/src/routes/skills.ts
+++ b/packages/server/src/routes/skills.ts
@@ -27,6 +27,7 @@ import {
   listSkills,
   type SkillFileInput,
 } from "../services/skills/skills-service.js";
+import { draftSkillFromDescription } from "../services/skills/draft-skill.js";
 import {
   getSkillUsageReport,
   getSkillsUsedForSpec,
@@ -208,6 +209,23 @@ skillsRouter.get("/:handle/files/*", async (c) => {
   if (!filePath) throw new ValidationError("A file path is required");
   const access = await getSkillFile(memexId, handle, filePath);
   return c.json(access);
+});
+
+// spec-300 t-15 Increment 1 (ac-49, closes ac-21) — agent-assisted authoring.
+// Draft a spec-compliant SKILL.md from a plain-language description: the same
+// describe→draft→validate turn the "Describe it" tab wires up. Persists NOTHING —
+// draftSkillFromDescription runs the SAME validateSkill the create path runs, then
+// hands the validated SKILL.md back; the UI persists it via POST /skills on confirm.
+// Registered before `/:handle` verbs; `/draft` is a static segment (no handle
+// collision). Write access required (dec-15) — it is an authoring precursor.
+skillsRouter.post("/draft", async (c) => {
+  requireWriteMemexId(c);
+  const body = await c.req.json<{ description?: string }>();
+  if (typeof body.description !== "string" || body.description.trim().length === 0) {
+    throw new ValidationError("A plain-language `description` is required");
+  }
+  const draft = await draftSkillFromDescription(body.description);
+  return c.json(draft);
 });
 
 // Create accepts TWO body shapes (spec-300 issue-6a):

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -111,6 +111,10 @@ export { SHARED_HANDOFF_GUIDANCE } from './scaffold-data.js';
 // (injected by buildSystemBlocks) + the agent-assisted SKILL.md authoring system
 // prompt (dec-9). Prose has one home here (std-15).
 export { SKILLS_AGENT_GUIDANCE, SKILL_AUTHOR_INSTRUCTION } from './scaffold-data.js';
+// spec-300 t-15 (dec-23, std-38): the dedicated skills-agent MODE block, injected
+// by buildSystemBlocks when the per-request mode is 'skills' (the Skills surface
+// sets it). Distinct from SKILLS_AGENT_GUIDANCE (the cross-agent awareness block).
+export { SKILLS_AGENT_MODE_GUIDANCE } from './scaffold-data.js';
 // spec-389 t-5 (dec-2): the standards + issues agent mode blocks, injected by
 // buildSystemBlocks when the per-request mode is standards / issues. (Per dec-1
 // the scoped agents open with a static intro, not an LLM turn — no opening seed.)

--- a/packages/shared/src/scaffold-data.ts
+++ b/packages/shared/src/scaffold-data.ts
@@ -302,6 +302,34 @@ export const ISSUES_AGENT_GUIDANCE: PromptBlockNode = {
     'spec-389 t-5 (dec-2): the issues-agent mode block, injected by buildSystemBlocks when the per-request mode is "issues". Behaviour only — the factual Issues grounding is composed per-request by buildIssuesContext. The real enforcement is the render_confirmation gate + the /tools/execute MODE_TOOLS gate (spec-389 t-3). Portable per std-22.',
 };
 
+// spec-300 t-15 (dec-23, std-38) — the SKILLS-agent MODE block. Distinct from the
+// SKILLS_AGENT_GUIDANCE awareness block above (which teaches EVERY in-app agent to
+// dispatch / follow / hand off a skill): this is the DEDICATED skills authoring +
+// curation agent that lives on the Skills page. It drafts a new Skill from a plain-
+// language description AND curates existing ones (edit / archive / restore), all
+// through the ONE verbed update_skill write path. Prose lives here (std-15/std-16),
+// injected by buildSystemBlocks only when the per-request mode is 'skills' (the
+// React UI's Skills surface sets it); SHARED_HANDOFF_GUIDANCE is appended after it
+// (std-38). The factual GROUNDING (this Memex's skill catalogue) is composed
+// per-request by buildSkillsContext. Portable per std-22 — no language/framework/
+// repo/path assumptions.
+export const SKILLS_AGENT_MODE_GUIDANCE: PromptBlockNode = {
+  kind: 'prompt_block',
+  id: 'skills-agent',
+  surface: 'react_only',
+  text:
+    '## Skills agent\n' +
+    "You are this Memex's skills agent. Your world is its **Skills** — reusable, self-contained procedures, each a SKILL.md (YAML frontmatter with `name` + `description`, then a Markdown body of steps). You have two jobs: help the user AUTHOR a new Skill, and CURATE the existing ones — edit, archive, or restore — behind a confirmation gate. You can SEE the catalogue in your context (name, description, capability flags, ref); use `list_skills` to enumerate, `get_skill({ ref })` to read one in full, and `search_memex` / `get_doc` to ground answers in the wider Memex before you claim a fact.\n\n" +
+    '### Authoring a new Skill (from a description)\n' +
+    'When the user describes a Skill in plain language, draft a single, spec-compliant SKILL.md for them: `name` — a short lowercase hyphen-separated identifier (letters, digits, hyphens; no spaces; ≤ 64 chars); `description` — one or two sentences (≤ 1024 chars) saying what it does AND when to use it, opening the trigger with "Use when:"; `body` — clear, numbered Markdown steps a follower can carry out. Do not invent capabilities the author did not mention, and never add an `allowed-tools` field. Show the drafted SKILL.md for review, then create it with `update_skill` (create) only after the user confirms.\n\n' +
+    '### Curating existing Skills (behind confirmation)\n' +
+    'On an existing Skill you can edit its SKILL.md or capability flags, add or remove auxiliary files, archive it (non-destructive — its content is preserved), or restore an archived one — all through the ONE verbed `update_skill` tool (create / edit / delete / restore) that the manual UI and MCP share, so every write runs the same validation. Propose EVERY mutation through `render_confirmation` first, showing exactly what you will write; never create, edit, archive, or restore until the user confirms. Navigate the reader to a Skill with `render_navigate`, and quote exact SKILL.md text with `render_quote`, never inline quotation marks.\n\n' +
+    '### Stay in your lane\n' +
+    'You author and curate Skills ONLY — nothing else. You never EXECUTE a Skill or run code; a Skill that needs the codebase, code edits, or external tools is authored here but RUN by the coding agent. When asked for anything outside skill authoring — edit a Standard, resolve drift, touch code, create a Spec — do not reach for a tool you should not have (the server refuses it anyway); hand off with `render_handoff` per the handoff map. Honest handoff over faked action (std-34).',
+  rationale:
+    'spec-300 t-15 (dec-23, std-38): the dedicated skills-agent mode block — the fifth scoped agentMode. Distinct from SKILLS_AGENT_GUIDANCE (the cross-agent awareness/dispatch block); this is the authoring/curation posture for the agent on the Skills page. Injected by buildSystemBlocks when mode === "skills"; the SHARED_HANDOFF_GUIDANCE map is appended after it. Behaviour only — the factual skill-catalogue grounding is composed per-request by buildSkillsContext. The real authoring enforcement is the render_confirmation gate + the /tools/execute MODE_TOOLS gate (SKILLS_SERVER_TOOLS), not this prose. Portable per std-22.',
+};
+
 // spec-360: when an admin makes a MANUAL org-guidance edit/addition inline (not
 // through the assistant's propose flow), the surface fires this seed so the
 // assistant actually ASSESSES the change — feasibility + effectiveness — rather

--- a/packages/ui/e2e/journey-55-spec-300-skills.spec.ts
+++ b/packages/ui/e2e/journey-55-spec-300-skills.spec.ts
@@ -1,6 +1,10 @@
-import { test, expect, tenantPath, bareUrl } from "./helpers/index.js";
+import { test, expect, tenantPath, bareUrl, sendChat } from "./helpers/index.js";
 import { seedOrgTenant } from "./helpers/retained.js";
 import { installAcEmission } from "./helpers/emit-ac.js";
+import {
+  clearAnthropicQueue,
+  queueAnthropicResponse,
+} from "./helpers/anthropic-fake.js";
 
 // spec-300 t-9 — the PR-gate e2e journey for Skills (std-28). Drives the real UI
 // end-to-end: a user UPLOADS a SKILL.md file into a Memex and attaches one
@@ -25,11 +29,20 @@ import { installAcEmission } from "./helpers/emit-ac.js";
 const SPEC300 = "mindset-prod/memex-building-itself/specs/spec-300";
 const AC_UPLOAD = `${SPEC300}/acs/ac-1`;
 const AC_AUTHOR = `${SPEC300}/acs/ac-2`;
+// spec-300 t-15 Increment 2 — the dedicated skills chat agent on the Skills page.
+const AC_AGENT_SURFACE = `${SPEC300}/acs/ac-46`; // a chat agent in the shared shell
+const AC_AGENT_AUTHORITY = `${SPEC300}/acs/ac-47`; // create/edit/archive via the validated write path
+const AC_AGENT_JOURNEY = `${SPEC300}/acs/ac-53`; // the PR-gate e2e journey (std-28)
 
 const TITLE =
   "a user uploads a SKILL.md with an auxiliary file, sees it in the Skills list, and opens its detail view";
+const AGENT_TITLE =
+  "a user asks the Skills-page agent to create a skill from a description, then to archive it — both go through the validated write path";
 
-installAcEmission(test, import.meta.url, { [TITLE]: [AC_UPLOAD, AC_AUTHOR] });
+installAcEmission(test, import.meta.url, {
+  [TITLE]: [AC_UPLOAD, AC_AUTHOR],
+  [AGENT_TITLE]: [AC_AGENT_SURFACE, AC_AGENT_AUTHORITY, AC_AGENT_JOURNEY],
+});
 
 // A spec-valid SKILL.md: required frontmatter (name lowercase-alnum-hyphens,
 // description) + a Markdown body. The [per std-28] cite exercises the in-app
@@ -161,5 +174,140 @@ test.describe("spec-300 — Skills author → list → view", () => {
     await card.click();
     await page.waitForURL(/\/skills\/skill-1$/, { timeout: 15_000 });
     await expect(page.getByText(BODY_MARKER)).toBeVisible({ timeout: 15_000 });
+  });
+
+  // spec-300 t-15 Increment 2 (ac-46/ac-47/ac-53) — the dedicated skills chat agent
+  // docked on the Skills page. Drives it end to end against a cold DB via the
+  // deterministic Anthropic fake (MEMEX_ANTHROPIC_FAKE=1): the user describes a
+  // skill and the agent CREATES it through the one validated update_skill write
+  // path, then the user asks to archive it and the agent ARCHIVES it — both
+  // verified against the real Skills service (GET /skills), not the fake. The agent's
+  // authority is skills-only: update_skill is its sole write verb (asserted in the
+  // server MODE_TOOLS unit tests). Mirrors the tool-use drive of journey-9.
+  test(AGENT_TITLE, async ({ page, resources }) => {
+    const tenant = await seedOrgTenant({
+      slug: resources.slug("spec300-skills-agent"),
+      ownerEmail: "dev@memex.ai",
+      memexSlug: "skills",
+    });
+
+    const memexRef = `${tenant.namespaceSlug}/${tenant.memexSlug}`;
+    const skillRef = `${memexRef}/skills/skill-1`;
+    const apiBase =
+      process.env.E2E_API_URL ??
+      `http://localhost:${process.env.E2E_SERVER_PORT ?? 8090}`;
+    const skillsApi = `${apiBase}/api/${tenant.namespaceSlug}/${tenant.memexSlug}/skills`;
+
+    const AGENT_SKILL_MD = `---
+name: commit-message-linter
+description: Reviews a commit message for format and suggests fixes when it drifts from the convention.
+---
+
+# Commit message linter
+
+1. Read the commit subject line and body.
+2. Flag a subject over 50 characters or not in the imperative mood.
+3. Suggest a corrected subject and body.
+`;
+
+    // Turn 1: the agent responds to the description by calling update_skill(create).
+    // Turn 2: after the tool_result round-trips, it confirms in prose.
+    await clearAnthropicQueue();
+    await queueAnthropicResponse({
+      textDeltas: [],
+      content: [
+        {
+          type: "tool_use",
+          id: "toolu_j55_create",
+          name: "update_skill",
+          input: { verb: "create", memex: memexRef, skill_md: AGENT_SKILL_MD },
+        },
+      ],
+      stopReason: "tool_use",
+    });
+    await queueAnthropicResponse({
+      // The UI renders the streamed deltas, so they must spell the full sentence.
+      textDeltas: ["Created ", "the ", "commit-message-linter ", "skill."],
+      content: [{ type: "text", text: "Created the commit-message-linter skill." }],
+      stopReason: "end_turn",
+    });
+
+    // Land on the Skills page — the skills agent docks in the left rail (ac-46),
+    // opens with the shared STATIC intro card (no opening LLM turn), and its input
+    // is LIVE on arrival (skills mode binds no doc).
+    await page.goto(bareUrl("/"), { waitUntil: "commit" });
+    await page.goto(tenantPath(tenant.namespaceSlug, tenant.memexSlug, "/skills"));
+    const panel = page.getByTestId("skills-assistant-panel");
+    await expect(panel).toBeVisible({ timeout: 15_000 });
+    await expect(panel.getByText("Skills agent")).toBeVisible();
+    await expect(page.getByTestId("agent-intro-skills")).toBeVisible();
+    await expect(page.getByTestId("chat-markdown")).toHaveCount(0);
+
+    // ── CREATE BY DESCRIBING ────────────────────────────────────────────────────
+    await sendChat(
+      page,
+      "Create a skill that lints commit messages and suggests fixes.",
+    );
+    await expect(page.getByTestId("chat-markdown")).toHaveText(
+      /Created the commit-message-linter skill\./,
+      { timeout: 15_000 },
+    );
+
+    // The skill really landed via the validated write path (ac-47) — GET /skills
+    // from the real service now returns it. Poll: createSkill persists in-band, but
+    // the SSE + fetch settle asynchronously.
+    await expect
+      .poll(
+        async () => {
+          const res = await page.request.get(skillsApi);
+          if (!res.ok()) return [] as string[];
+          const body = (await res.json()) as Array<{ name: string }>;
+          return body.map((s) => s.name);
+        },
+        { timeout: 10_000 },
+      )
+      .toContain("commit-message-linter");
+
+    // ── ARCHIVE THROUGH THE AGENT ───────────────────────────────────────────────
+    // Turn 3: the agent archives the skill (update_skill delete = soft-archive).
+    // Turn 4: it confirms. Archiving is non-destructive but hides the skill from list.
+    await queueAnthropicResponse({
+      textDeltas: [],
+      content: [
+        {
+          type: "tool_use",
+          id: "toolu_j55_archive",
+          name: "update_skill",
+          input: { verb: "delete", ref: skillRef },
+        },
+      ],
+      stopReason: "tool_use",
+    });
+    await queueAnthropicResponse({
+      textDeltas: ["Archived ", "the ", "commit-message-linter ", "skill."],
+      content: [{ type: "text", text: "Archived the commit-message-linter skill." }],
+      stopReason: "end_turn",
+    });
+
+    await sendChat(page, "Archive that skill.");
+    await expect(page.getByTestId("chat-markdown").last()).toHaveText(
+      /Archived the commit-message-linter skill\./,
+      { timeout: 15_000 },
+    );
+
+    // The archive really applied via the validated write path — the skill drops out
+    // of the active list (archiving hides it from list/get, ac-8), proving the
+    // agent's edit reached the real service, not just the chat transcript.
+    await expect
+      .poll(
+        async () => {
+          const res = await page.request.get(skillsApi);
+          if (!res.ok()) return ["<error>"];
+          const body = (await res.json()) as Array<{ name: string }>;
+          return body.map((s) => s.name);
+        },
+        { timeout: 10_000 },
+      )
+      .not.toContain("commit-message-linter");
   });
 });

--- a/packages/ui/src/agent/graph.test.ts
+++ b/packages/ui/src/agent/graph.test.ts
@@ -657,6 +657,19 @@ describe('LangGraph agent graph', () => {
       ).toBe('planAgent');
     });
 
+    // spec-300 t-15 (dec-23, ac-52): skills mode behaves like the other scoped
+    // modes — memex-scoped, doc-less, routed to the generic agentNode (planAgent).
+    // No new graph node is added; the posture comes from the server-side prompt +
+    // SKILLS_SERVER_TOOLS subset selected by mode 'skills'.
+    it('routes to the generic agent node in skills mode even with no docId (no new node)', () => {
+      const AC_SKILLS_ROUTE =
+        'mindset-prod/memex-building-itself/specs/spec-300/acs/ac-52';
+      tagAc(AC_SKILLS_ROUTE);
+      expect(
+        routeByPhase({ ...baseState, docId: null, specPhase: null, agentMode: 'skills' })
+      ).toBe('planAgent');
+    });
+
     it('routes to the matching per-phase agent for each SpecPhase', () => {
       // `draft` is a Spec attribute / Kanban column, not a graph node —
       // it routes to planAgent (collapsed in b-33). The dedicated test

--- a/packages/ui/src/agent/graph.ts
+++ b/packages/ui/src/agent/graph.ts
@@ -40,7 +40,7 @@ export const AgentState = Annotation.Root({
    * drift mode the entry router goes straight to an agent node (not createDoc)
    * even with no docId, and the mode is forwarded to the server (chat + tools).
    */
-  agentMode: Annotation<'spec' | 'drift' | 'scaffold' | 'standards' | 'issues'>({
+  agentMode: Annotation<'spec' | 'drift' | 'scaffold' | 'standards' | 'issues' | 'skills'>({
     reducer: (_, update) => update,
     default: () => 'spec',
   }),
@@ -51,8 +51,8 @@ export const AgentState = Annotation.Root({
  *  agent node (not createDoc). `'spec'` becomes `undefined` on the wire (the
  *  default surface); every scoped mode forwards as-is. */
 function wireMode(
-  agentMode: 'spec' | 'drift' | 'scaffold' | 'standards' | 'issues',
-): 'drift' | 'scaffold' | 'standards' | 'issues' | undefined {
+  agentMode: 'spec' | 'drift' | 'scaffold' | 'standards' | 'issues' | 'skills',
+): 'drift' | 'scaffold' | 'standards' | 'issues' | 'skills' | undefined {
   return agentMode === 'spec' ? undefined : agentMode;
 }
 

--- a/packages/ui/src/agent/llm-client.ts
+++ b/packages/ui/src/agent/llm-client.ts
@@ -118,8 +118,10 @@ export async function* callLlmProxy(
      *  spec-360 t-1 (dec-1): when 'scaffold', the server runs the scaffold
      *  assistant — scaffold grounding, propose-then-confirm tool subset.
      *  spec-389 t-5 (dec-2): 'standards' / 'issues' run the memex-scoped
-     *  standards / issues agents (their context + MODE_TOOLS subset). */
-    mode?: 'drift' | 'scaffold' | 'standards' | 'issues';
+     *  standards / issues agents (their context + MODE_TOOLS subset).
+     *  spec-300 t-15 (dec-23): 'skills' runs the dedicated skills authoring /
+     *  curation agent (skill-catalogue context + SKILLS_SERVER_TOOLS subset). */
+    mode?: 'drift' | 'scaffold' | 'standards' | 'issues' | 'skills';
   },
   signal?: AbortSignal
 ): AsyncGenerator<LlmProxyEvent> {

--- a/packages/ui/src/agent/tool-client.ts
+++ b/packages/ui/src/agent/tool-client.ts
@@ -27,7 +27,7 @@ export async function executeToolRemote(
   input: Record<string, unknown>,
   signal?: AbortSignal,
   docId?: string,
-  mode?: 'drift' | 'scaffold' | 'standards' | 'issues'
+  mode?: 'drift' | 'scaffold' | 'standards' | 'issues' | 'skills'
 ): Promise<string> {
   const headers: Record<string, string> = { 'Content-Type': 'application/json' };
   if (authToken) {

--- a/packages/ui/src/agent/useAgentGraph.ts
+++ b/packages/ui/src/agent/useAgentGraph.ts
@@ -21,7 +21,7 @@ export interface InvokeParams {
    * spec-143 t-4 (dec-6): the agent mode. `'drift'` routes to the memex-scoped
    * drift agent (no bound doc); default `'spec'` is the doc/creation agent.
    */
-  agentMode?: 'spec' | 'drift' | 'scaffold' | 'standards' | 'issues';
+  agentMode?: 'spec' | 'drift' | 'scaffold' | 'standards' | 'issues' | 'skills';
   callbacks: AgentCallbacks;
   signal?: AbortSignal;
 }
@@ -31,7 +31,7 @@ export interface ResumeParams {
   /** Current Spec phase, if known — see `InvokeParams`. */
   specPhase?: SpecPhase | null;
   /** spec-143 t-4 (dec-6): the agent mode — see `InvokeParams`. */
-  agentMode?: 'spec' | 'drift' | 'scaffold' | 'standards' | 'issues';
+  agentMode?: 'spec' | 'drift' | 'scaffold' | 'standards' | 'issues' | 'skills';
   /** Full conversation messages including the UI tool result */
   messages: MessageParam[];
   callbacks: AgentCallbacks;

--- a/packages/ui/src/api/skills.ts
+++ b/packages/ui/src/api/skills.ts
@@ -87,6 +87,16 @@ export interface EditSkillInput {
   readonly capabilities?: Partial<SkillCapabilities>;
 }
 
+/** A validated, spec-compliant SKILL.md drafted from a plain-language description
+ *  (spec-300 t-15 Increment 1, ac-49/ac-21). The server has already run the same
+ *  validateSkill the create path runs; the UI persists `skillMd` on confirm. */
+export interface DraftedSkill {
+  readonly skillMd: string;
+  readonly name: string;
+  readonly description: string;
+  readonly body: string;
+}
+
 // ── Endpoints ─────────────────────────────────────────────────────────────────
 
 /** List the current Memex's active skills, alphabetical by name (server-sorted). */
@@ -134,6 +144,19 @@ export async function editSkill(
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(input),
+  });
+}
+
+/**
+ * Draft a spec-compliant SKILL.md from a plain-language description (ac-49/ac-21).
+ * The server drafts + validates and returns the SKILL.md for review; the create
+ * flow persists it via createSkill on confirm. A 4xx surfaces its message verbatim.
+ */
+export async function draftSkill(description: string): Promise<DraftedSkill> {
+  return fetchJson<DraftedSkill>(fetchWithRetry, `${tBase()}/skills/draft`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ description }),
   });
 }
 

--- a/packages/ui/src/components/AppShell.tsx
+++ b/packages/ui/src/components/AppShell.tsx
@@ -545,12 +545,15 @@ export function AppShell({ children }: { children: ReactNode }) {
   // two-column surface whose chat panel scrolls independently. Unlike content-flow
   // pages (which scroll at the <main> level), they need a BOUNDED-height wrapper so
   // the rail's `h-full` resolves; without it the streaming chat expands the wrapper
-  // and scrolls the whole page. The scaffold, standards-list, and issues surfaces
-  // all dock the rail (standards/:id is a doc page, handled above — not here).
+  // and scrolls the whole page. The scaffold, standards-list, issues, and skills-list
+  // surfaces all dock the rail (standards/:id and skills/:id are doc pages, handled
+  // above — not here).
   const onScaffoldPage = !!useMatch('/:namespace/:memex/scaffold');
   const onStandardsListPage = !!useMatch('/:namespace/:memex/standards');
   const onIssuesPage = !!useMatch('/:namespace/:memex/issues');
-  const onAgentRailPage = onScaffoldPage || onStandardsListPage || onIssuesPage;
+  // spec-300 t-15 (dec-23): the Skills list docks the skills authoring agent rail.
+  const onSkillsListPage = !!useMatch('/:namespace/:memex/skills');
+  const onAgentRailPage = onScaffoldPage || onStandardsListPage || onIssuesPage || onSkillsListPage;
   // spec-410: the Drift Inbox is the odd one out — it's not a doc page (it keeps
   // the sidebar + drift badge), but it docks the agent via DocumentShell's
   // two-pane shell rather than a ResizableChatRail. Either way the bounding need

--- a/packages/ui/src/components/ChatContext.scoped.test.tsx
+++ b/packages/ui/src/components/ChatContext.scoped.test.tsx
@@ -50,6 +50,10 @@ function renderProvider() {
 
 const AC_NEW_AGENTS =
   'mindset-prod/memex-building-itself/specs/spec-389/acs/ac-4';
+// spec-300 t-15 (dec-23): ac-52 — ChatContext gains enter/exitSkillsMode; entering
+// flips isSkillsMode and unbinds any doc, exitScopedMode resets to 'spec'.
+const AC_SKILLS_MODE =
+  'mindset-prod/memex-building-itself/specs/spec-300/acs/ac-52';
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -76,11 +80,26 @@ describe('ChatContext — standards / issues mode entry (ac-4)', () => {
     expect(ctx.isStandardsMode).toBe(false);
   });
 
+  it('enterSkillsMode flips into skills mode; exitScopedMode resets to spec (spec-300 ac-52)', async () => {
+    tagAc(AC_SKILLS_MODE);
+    renderProvider();
+    expect(ctx.isSkillsMode).toBe(false);
+    await act(async () => { ctx.enterSkillsMode(); });
+    expect(ctx.isSkillsMode).toBe(true);
+    // Skills is exclusive of the sibling scoped modes.
+    expect(ctx.isStandardsMode).toBe(false);
+    expect(ctx.isIssuesMode).toBe(false);
+    await act(async () => { ctx.exitScopedMode(); });
+    expect(ctx.isSkillsMode).toBe(false);
+  });
+
   it('the scoped agents do NOT fire an opening LLM turn on entry (dec-1: static intro)', async () => {
     tagAc(AC_NEW_AGENTS);
+    tagAc(AC_SKILLS_MODE);
     renderProvider();
     await act(async () => { ctx.enterStandardsMode(); });
     await act(async () => { ctx.enterIssuesMode(); });
+    await act(async () => { ctx.enterSkillsMode(); });
     expect(mockInvoke).not.toHaveBeenCalled();
   });
 });

--- a/packages/ui/src/components/ChatContext.tsx
+++ b/packages/ui/src/components/ChatContext.tsx
@@ -88,6 +88,13 @@ interface ChatState {
   isIssuesMode: boolean;
   enterStandardsMode: () => void;
   enterIssuesMode: () => void;
+  /**
+   * spec-300 t-15 (dec-23): the dedicated skills authoring / curation agent mode.
+   * The Skills page enters it on mount (enterSkillsMode) and leaves on unmount
+   * (exitScopedMode resets to 'spec'). Mirrors the standards / issues controls.
+   */
+  isSkillsMode: boolean;
+  enterSkillsMode: () => void;
   exitScopedMode: () => void;
   /**
    * spec-360 t-4 (dec-4): the pending propose-then-confirm change the assistant
@@ -154,8 +161,8 @@ export function ChatProvider({ children }: { children: ReactNode }) {
   // input-enable check via isDriftMode); the ref mirrors it so the async
   // sendMessage / opening-turn closures read the current mode without
   // re-subscribing to it (same pattern as docIdRef). Default 'spec'.
-  const [agentMode, setAgentModeState] = useState<'spec' | 'drift' | 'scaffold' | 'standards' | 'issues'>('spec');
-  const agentModeRef = useRef<'spec' | 'drift' | 'scaffold' | 'standards' | 'issues'>('spec');
+  const [agentMode, setAgentModeState] = useState<'spec' | 'drift' | 'scaffold' | 'standards' | 'issues' | 'skills'>('spec');
+  const agentModeRef = useRef<'spec' | 'drift' | 'scaffold' | 'standards' | 'issues' | 'skills'>('spec');
   // spec-360 t-4 (dec-4): the pending propose-then-confirm change, parsed from a
   // `propose_scaffold_change` tool result. Drives the live preview on the
   // Scaffold Inspect surface.
@@ -275,7 +282,7 @@ export function ChatProvider({ children }: { children: ReactNode }) {
   // agent. Both update the ref synchronously so the async send / opening-turn
   // closures read the current mode immediately. Idempotent on re-entry.
   const enterScopedMode = useCallback(
-    (mode: 'standards' | 'issues') => {
+    (mode: 'standards' | 'issues' | 'skills') => {
       if (agentModeRef.current === mode) return;
       agentModeRef.current = mode;
       setAgentModeState(mode);
@@ -309,6 +316,11 @@ export function ChatProvider({ children }: { children: ReactNode }) {
   );
   const enterIssuesMode = useCallback(
     () => enterScopedMode('issues'),
+    [enterScopedMode],
+  );
+  // spec-300 t-15 (dec-23): enter the dedicated skills authoring / curation agent.
+  const enterSkillsMode = useCallback(
+    () => enterScopedMode('skills'),
     [enterScopedMode],
   );
 
@@ -720,6 +732,8 @@ export function ChatProvider({ children }: { children: ReactNode }) {
         isIssuesMode: agentMode === 'issues',
         enterStandardsMode,
         enterIssuesMode,
+        isSkillsMode: agentMode === 'skills',
+        enterSkillsMode,
         exitScopedMode,
         scaffoldProposal,
         clearScaffoldProposal,

--- a/packages/ui/src/components/ChatPanel.tsx
+++ b/packages/ui/src/components/ChatPanel.tsx
@@ -137,7 +137,7 @@ export function makesCodeShapedClaims(content: string): boolean {
 }
 
 export function ChatPanel({ isAuthenticated = true, readOnly = false }: ChatPanelProps = {}) {
-  const { messages, isStreaming, error, sendMessage, stopStreaming, clearChat, respondedToolIds, respondToUiTool, docId, doc, contextChips, isDriftMode, isScaffoldMode, isStandardsMode, isIssuesMode } = useChat();
+  const { messages, isStreaming, error, sendMessage, stopStreaming, clearChat, respondedToolIds, respondToUiTool, docId, doc, contextChips, isDriftMode, isScaffoldMode, isStandardsMode, isIssuesMode, isSkillsMode } = useChat();
   // spec-389: the docking shell (ResizableChatRail / DocumentShell) injects a
   // collapse handler when the panel can close to its strip; absent → no control.
   const { onCollapse } = useChatCollapse();
@@ -152,12 +152,15 @@ export function ChatPanel({ isAuthenticated = true, readOnly = false }: ChatPane
     ? 'standards'
     : isIssuesMode
     ? 'issues'
+    : isSkillsMode
+    ? 'skills'
     : null;
   const SCOPED_HEADINGS: Record<string, string> = {
     drift: 'Drift agent',
     scaffold: 'Scaffold assistant',
     standards: 'Standards agent',
     issues: 'Issues agent',
+    skills: 'Skills agent',
   };
   // spec-283 dec-1: the review buttons are POSTURE-INDEPENDENT — gated solely on
   // the Spec's phase (`doc.status==='specify'`, already exposed by useChat) and
@@ -181,7 +184,7 @@ export function ChatPanel({ isAuthenticated = true, readOnly = false }: ChatPane
   };
   // spec-143 t-4 (dec-6) / spec-360 t-1: in drift / scaffold mode the agent is
   // LIVE on arrival (no bound doc), so the input is enabled before any context chip.
-  const canChat = !!docId || contextChips.length > 0 || isDriftMode || isScaffoldMode || isStandardsMode || isIssuesMode;
+  const canChat = !!docId || contextChips.length > 0 || isDriftMode || isScaffoldMode || isStandardsMode || isIssuesMode || isSkillsMode;
   const [input, setInput] = useState('');
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);

--- a/packages/ui/src/components/chat/AgentIntro.test.tsx
+++ b/packages/ui/src/components/chat/AgentIntro.test.tsx
@@ -15,6 +15,10 @@ const AC_VISUAL = 'mindset-prod/memex-building-itself/specs/spec-389/acs/ac-1';
 // duplicated per mode.
 const AC_SINGLE_SOURCED =
   'mindset-prod/memex-building-itself/specs/spec-389/acs/ac-5';
+// spec-300 t-15 (dec-23): ac-52 — the Skills page mounts the shared ChatPanel with
+// an AGENT_INTROS.skills intro card (one registry, no per-mode copy).
+const AC_SKILLS_INTRO =
+  'mindset-prod/memex-building-itself/specs/spec-300/acs/ac-52';
 
 const MODES = Object.keys(AGENT_INTROS) as AgentChatMode[];
 
@@ -26,9 +30,10 @@ describe('AgentIntro — shared static intro card (ac-1, ac-5)', () => {
       expect(AGENT_INTROS[mode].lead.length).toBeGreaterThan(0);
       expect(AGENT_INTROS[mode].bullets.length).toBeGreaterThan(0);
     }
-    // The five surfaces the Spec unifies are all covered.
+    // All the unified surfaces are covered — spec-300 t-15 adds 'skills' as the
+    // sixth scoped agent card.
     expect(MODES.sort()).toEqual(
-      ['drift', 'issues', 'scaffold', 'spec', 'standards'].sort(),
+      ['drift', 'issues', 'scaffold', 'skills', 'spec', 'standards'].sort(),
     );
   });
 
@@ -44,4 +49,14 @@ describe('AgentIntro — shared static intro card (ac-1, ac-5)', () => {
       }
     });
   }
+
+  it('renders the skills intro from the registry (no LLM call) (spec-300 ac-52)', () => {
+    tagAc(AC_SKILLS_INTRO);
+    render(<AgentIntro mode="skills" />);
+    expect(screen.getByTestId('agent-intro-skills')).toBeInTheDocument();
+    expect(screen.getByText(AGENT_INTROS.skills.lead)).toBeInTheDocument();
+    for (const bullet of AGENT_INTROS.skills.bullets) {
+      expect(screen.getByText(bullet)).toBeInTheDocument();
+    }
+  });
 });

--- a/packages/ui/src/components/chat/OpeningSkillsController.test.tsx
+++ b/packages/ui/src/components/chat/OpeningSkillsController.test.tsx
@@ -1,0 +1,56 @@
+// spec-300 t-15 (dec-23) — the skills agent's on-mount controller.
+//
+//   - the controller enters 'skills' mode on mount and leaves it (exitScopedMode)
+//     on unmount;
+//   - like the standards / issues agents (spec-389 dec-1) it opens with the shared
+//     STATIC AgentIntro card, NOT an opening LLM turn — so it fires no opening turn;
+//     the first LLM call waits for the user.
+
+import { render } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { tagAc } from '@memex-ai-ac/vitest';
+
+// ac-46 (scope): a user can open an in-app agent on the Skills page in the shared
+// shell and converse with it to author / curate skills.
+const AC_SKILLS_SURFACE =
+  'mindset-prod/memex-building-itself/specs/spec-300/acs/ac-46';
+// ac-52 (implementation): the Skills page mounts the shared ChatPanel via an
+// OpeningSkillsController; ChatContext gains enter/exitSkillsMode.
+const AC_SKILLS_MOUNT =
+  'mindset-prod/memex-building-itself/specs/spec-300/acs/ac-52';
+
+const mockEnterSkillsMode = vi.fn();
+const mockExitScopedMode = vi.fn();
+
+vi.mock('../ChatContext', () => ({
+  useChat: () => ({
+    enterSkillsMode: mockEnterSkillsMode,
+    exitScopedMode: mockExitScopedMode,
+  }),
+}));
+
+import { OpeningSkillsController } from './OpeningSkillsController';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('OpeningSkillsController', () => {
+  it('enters skills mode on mount and leaves it on unmount', () => {
+    tagAc(AC_SKILLS_SURFACE);
+    tagAc(AC_SKILLS_MOUNT);
+    const { unmount } = render(<OpeningSkillsController />);
+    expect(mockEnterSkillsMode).toHaveBeenCalledTimes(1);
+    expect(mockExitScopedMode).not.toHaveBeenCalled();
+    unmount();
+    expect(mockExitScopedMode).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT fire an opening LLM turn on entry (static intro)', () => {
+    tagAc(AC_SKILLS_MOUNT);
+    // The controller only enters/leaves the scoped mode — no opening-turn hook is
+    // consumed, guarding against a money-costing icebreaker being reintroduced.
+    render(<OpeningSkillsController />);
+    expect(mockEnterSkillsMode).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/ui/src/components/chat/OpeningSkillsController.tsx
+++ b/packages/ui/src/components/chat/OpeningSkillsController.tsx
@@ -1,0 +1,23 @@
+// spec-300 t-15 (dec-23) — the on-mount controller for the SKILLS agent. Renders
+// NOTHING. It flips ChatContext into 'skills' mode on mount (so the ChatPanel input
+// is live on arrival and the shared static AgentIntro shows) and leaves the scoped
+// mode on unmount, restoring the default doc/creation agent.
+//
+// Like the standards / issues surfaces (spec-389 dec-1), the skills agent opens with
+// a STATIC intro card (AGENT_INTROS.skills), NOT a money-costing opening LLM turn —
+// so this controller fires no opening turn. The first real LLM call happens when the
+// user types. Mirrors OpeningStandardsController.
+
+import { useEffect } from 'react';
+import { useChat } from '../ChatContext';
+
+export function OpeningSkillsController() {
+  const { enterSkillsMode, exitScopedMode } = useChat();
+
+  useEffect(() => {
+    enterSkillsMode();
+    return () => exitScopedMode();
+  }, [enterSkillsMode, exitScopedMode]);
+
+  return null;
+}

--- a/packages/ui/src/components/chat/agentIntros.ts
+++ b/packages/ui/src/components/chat/agentIntros.ts
@@ -6,7 +6,7 @@
 // the UI rather than the scaffold model.
 
 /** The in-app agent modes that render in the shared ChatPanel shell. */
-export type AgentChatMode = 'spec' | 'drift' | 'scaffold' | 'standards' | 'issues';
+export type AgentChatMode = 'spec' | 'drift' | 'scaffold' | 'standards' | 'issues' | 'skills';
 
 export interface AgentIntroContent {
   /** One-line statement of what this agent is for. */
@@ -65,6 +65,16 @@ export const AGENT_INTROS: Record<AgentChatMode, AgentIntroContent> = {
       'Ask me to summarise open Issues, or filter them by Spec or type.',
       'I can update, resolve, or promote a todo Issue straight to a Task.',
       'I manage Issues only; when something needs a Spec I’ll hand you a prompt for the New Spec flow.',
+    ],
+    footer: START,
+  },
+  // spec-300 t-15 (dec-23): the dedicated skills authoring / curation agent card.
+  skills: {
+    lead: 'I help you author and curate this Memex’s Skills — the reusable procedures your agents follow.',
+    bullets: [
+      'Describe a skill in plain language and I’ll draft a spec-compliant SKILL.md for your review.',
+      'Ask me to edit, archive, or restore an existing skill — I propose every change before it’s written.',
+      'I author Skills only; I never run one or touch code — for that I’ll hand you a prompt for the coding agent.',
     ],
     footer: START,
   },

--- a/packages/ui/src/components/skills/CreateSkillModal.test.tsx
+++ b/packages/ui/src/components/skills/CreateSkillModal.test.tsx
@@ -10,11 +10,20 @@ const AC21 = 'mindset-prod/memex-building-itself/specs/spec-300/acs/ac-21';
 // spec-300 t-14 (issue-4b):
 //   ac-45 — switching tabs clears any stale create-error banner.
 const AC45 = 'mindset-prod/memex-building-itself/specs/spec-300/acs/ac-45';
+// spec-300 t-15 Increment 1:
+//   ac-49 — the Describe-it tab wires the full describe→draft→validate→create
+//           round-trip; the disabled "Coming soon" stub is removed.
+const AC49 = 'mindset-prod/memex-building-itself/specs/spec-300/acs/ac-49';
 
 const createSkillMock = vi.fn();
+const draftSkillMock = vi.fn();
 vi.mock('../../api/skills', async () => {
   const actual = await vi.importActual<typeof import('../../api/skills')>('../../api/skills');
-  return { ...actual, createSkill: (...a: unknown[]) => createSkillMock(...a) };
+  return {
+    ...actual,
+    createSkill: (...a: unknown[]) => createSkillMock(...a),
+    draftSkill: (...a: unknown[]) => draftSkillMock(...a),
+  };
 });
 
 const navigateMock = vi.fn();
@@ -45,7 +54,7 @@ describe('CreateSkillModal', () => {
     expect(describeTab).toBeInTheDocument();
     fireEvent.click(describeTab);
 
-    expect(screen.getByTestId('skill-describe-stub')).toBeInTheDocument();
+    expect(screen.getByTestId('skill-describe-panel')).toBeInTheDocument();
     expect(screen.getByTestId('skill-describe-input')).toBeInTheDocument();
   });
 
@@ -90,6 +99,75 @@ describe('CreateSkillModal', () => {
 
     expect(await screen.findByTestId('create-skill-error')).toHaveTextContent(
       /frontmatter is missing/i,
+    );
+  });
+
+  it('drafts a SKILL.md from a description, then creates it on confirm (ac-49, closes ac-21)', async () => {
+    tagAc(AC49);
+    const draftMd =
+      '---\nname: pr-test-review\ndescription: Reviews a PR for missing tests.\n---\n# PR test review\n\nSteps.\n';
+    draftSkillMock.mockResolvedValueOnce({
+      skillMd: draftMd,
+      name: 'pr-test-review',
+      description: 'Reviews a PR for missing tests.',
+      body: '# PR test review\n\nSteps.\n',
+    });
+    createSkillMock.mockResolvedValueOnce({ handle: 'skill-9' });
+    const onClose = vi.fn();
+    renderModal(onClose);
+
+    fireEvent.click(screen.getByTestId('skill-mode-describe'));
+    fireEvent.change(screen.getByTestId('skill-describe-input'), {
+      target: { value: 'A skill that reviews a PR for missing tests.' },
+    });
+    fireEvent.click(screen.getByTestId('skill-draft-submit'));
+
+    // The plain-language description is sent to the server draft turn.
+    await waitFor(() => expect(draftSkillMock).toHaveBeenCalledTimes(1));
+    expect(draftSkillMock.mock.calls[0][0]).toContain('reviews a PR');
+
+    // The validated draft is shown for review in the editor.
+    expect(await screen.findByTestId('skill-draft-review')).toBeInTheDocument();
+    expect(screen.getByTestId('skill-md-editor')).toHaveValue(draftMd);
+
+    // Confirm → the ordinary create path persists the drafted SKILL.md verbatim.
+    fireEvent.click(screen.getByTestId('create-skill-submit'));
+    await waitFor(() => expect(createSkillMock).toHaveBeenCalledTimes(1));
+    expect(createSkillMock.mock.calls[0][0].skillMd).toBe(draftMd);
+    expect(navigateMock).toHaveBeenCalled();
+  });
+
+  it('replaced the disabled "Coming soon" stub with a real draft action (ac-49)', () => {
+    tagAc(AC49);
+    renderModal();
+    fireEvent.click(screen.getByTestId('skill-mode-describe'));
+
+    // The old permanently-disabled stub is gone.
+    expect(screen.queryByTestId('skill-describe-stub')).not.toBeInTheDocument();
+
+    // The draft button is disabled only while the description is empty — it enables
+    // once there is text to draft from (not a coming-soon dead affordance).
+    const draftBtn = screen.getByTestId('skill-draft-submit');
+    expect(draftBtn).toBeDisabled();
+    fireEvent.change(screen.getByTestId('skill-describe-input'), {
+      target: { value: 'A skill that formats commit messages.' },
+    });
+    expect(draftBtn).toBeEnabled();
+  });
+
+  it('surfaces a draft failure inline (ac-49)', async () => {
+    tagAc(AC49);
+    draftSkillMock.mockRejectedValueOnce(new Error('Could not draft a spec-valid SKILL.md'));
+    renderModal();
+
+    fireEvent.click(screen.getByTestId('skill-mode-describe'));
+    fireEvent.change(screen.getByTestId('skill-describe-input'), {
+      target: { value: 'too vague' },
+    });
+    fireEvent.click(screen.getByTestId('skill-draft-submit'));
+
+    expect(await screen.findByTestId('create-skill-error')).toHaveTextContent(
+      /could not draft/i,
     );
   });
 

--- a/packages/ui/src/components/skills/CreateSkillModal.tsx
+++ b/packages/ui/src/components/skills/CreateSkillModal.tsx
@@ -4,10 +4,11 @@
 //                 errors from the server surface inline on submit.
 //   • Write     — the in-app Markdown editor (the shared design-system TextArea,
 //                 the same primitive Spec authoring uses) for the SKILL.md text.
-//   • Describe  — agent-assisted authoring (ac-21): describe the skill in plain
-//                 language and the agent drafts the SKILL.md. Thin stub for now
-//                 (the drafting round-trip is a follow-up); the entry point is
-//                 real so the flow is discoverable.
+//   • Describe  — agent-assisted authoring (ac-21 / ac-49): describe the skill in
+//                 plain language and the agent drafts a spec-compliant SKILL.md
+//                 (POST /skills/draft → describe→draft→validate, t-15 Increment 1).
+//                 The validated draft loads into the editor for review, then the
+//                 ordinary create path persists it on confirm.
 //
 // Capability flags (dec-20) are three checkboxes; auxiliary files (text + binary)
 // are staged by <AuxiliaryFilesPanel>. On submit everything POSTs via createSkill.
@@ -15,7 +16,7 @@
 import { useCallback, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useNavigate } from 'react-router-dom';
-import { createSkill, EMPTY_CAPABILITIES, type SkillCapabilities } from '../../api/skills';
+import { createSkill, draftSkill, EMPTY_CAPABILITIES, type SkillCapabilities } from '../../api/skills';
 import { tenantPath } from '../../utils/tenantUrl';
 import { Alert } from '../ui/Alert';
 import { Button, TextArea } from '../ui';
@@ -50,6 +51,10 @@ export function CreateSkillModal({ onClose }: { onClose: () => void }) {
   const [files, setFiles] = useState<ReadonlyArray<StagedFile>>([]);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Describe-it (ac-49): the plain-language description and whether the draft turn
+  // is in flight. The returned SKILL.md lands in `skillMd`, reviewed in the editor.
+  const [description, setDescription] = useState('');
+  const [drafting, setDrafting] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const toggleCapability = useCallback((key: keyof SkillCapabilities) => {
@@ -63,6 +68,24 @@ export function CreateSkillModal({ onClose }: { onClose: () => void }) {
     setMode(next);
     setError(null);
   }, []);
+
+  // Describe → draft (ac-49, closes ac-21): send the plain-language description to
+  // the server describe→draft→validate turn; the validated SKILL.md lands in the
+  // editor for review, then the ordinary create path persists it on confirm.
+  const handleDraft = useCallback(async () => {
+    const trimmed = description.trim();
+    if (trimmed.length === 0 || drafting) return;
+    setDrafting(true);
+    setError(null);
+    try {
+      const draft = await draftSkill(trimmed);
+      setSkillMd(draft.skillMd);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to draft skill.');
+    } finally {
+      setDrafting(false);
+    }
+  }, [description, drafting]);
 
   const handleUpload = useCallback((file: File | undefined) => {
     if (!file) return;
@@ -197,25 +220,41 @@ export function CreateSkillModal({ onClose }: { onClose: () => void }) {
           {mode === 'write' && <div className="space-y-2">{editor}</div>}
 
           {mode === 'describe' && (
-            <div
-              className="rounded-lg border border-dashed border-edge bg-panel p-4 space-y-2"
-              data-testid="skill-describe-stub"
-            >
-              <p className="text-sm text-heading font-medium">Draft it with the agent</p>
-              <p className="text-xs text-muted">
-                Describe the skill in plain language and the agent will draft a
-                SKILL.md you can refine. This hand-off is coming soon; for now, switch
-                to <span className="font-medium">Write it</span> to author directly.
-              </p>
-              <TextArea
-                placeholder="e.g. A skill that reviews a PR for missing tests and suggests the cases to add."
-                aria-label="Describe the skill"
-                data-testid="skill-describe-input"
-                className="min-h-[6rem] text-sm"
-              />
-              <Button type="button" variant="agent" size="sm" disabled title="Coming soon">
-                Draft with agent
-              </Button>
+            <div className="space-y-3" data-testid="skill-describe-panel">
+              <div className="rounded-lg border border-dashed border-edge bg-panel p-4 space-y-2">
+                <p className="text-sm text-heading font-medium">Draft it with the agent</p>
+                <p className="text-xs text-muted">
+                  Describe the skill in plain language and the agent drafts a
+                  spec-compliant SKILL.md you can refine before creating.
+                </p>
+                <TextArea
+                  value={description}
+                  onChange={(e) => setDescription(e.target.value)}
+                  placeholder="e.g. A skill that reviews a PR for missing tests and suggests the cases to add."
+                  aria-label="Describe the skill"
+                  data-testid="skill-describe-input"
+                  className="min-h-[6rem] text-sm"
+                  disabled={drafting}
+                />
+                <Button
+                  type="button"
+                  variant="agent"
+                  size="sm"
+                  onClick={handleDraft}
+                  disabled={description.trim().length === 0 || drafting}
+                  data-testid="skill-draft-submit"
+                >
+                  {drafting ? 'Drafting…' : 'Draft with agent'}
+                </Button>
+              </div>
+              {skillMd.trim().length > 0 && (
+                <div className="space-y-2" data-testid="skill-draft-review">
+                  <p className="text-xs text-muted">
+                    Review the draft and edit as needed, then create the skill.
+                  </p>
+                  {editor}
+                </div>
+              )}
             </div>
           )}
 

--- a/packages/ui/src/pages/SkillList.test.tsx
+++ b/packages/ui/src/pages/SkillList.test.tsx
@@ -19,6 +19,16 @@ vi.mock('../api/skills', async () => {
   return { ...actual, fetchSkills: (...a: unknown[]) => fetchSkillsMock(...a) };
 });
 
+// spec-300 t-15: the Skills page now docks the skills agent rail. These tests
+// don't exercise the chat, so stub the rail's ChatProvider-dependent pieces (they'd
+// otherwise throw "useChat must be used within ChatProvider") — mirrors the
+// Standards list test. The rail wiring is covered by OpeningSkillsController /
+// ChatContext.scoped / AgentIntro tests.
+vi.mock('../components/ChatPanel', () => ({ ChatPanel: () => null }));
+vi.mock('../components/chat/OpeningSkillsController', () => ({
+  OpeningSkillsController: () => null,
+}));
+
 // PageHeader pulls AuthContext for the breadcrumb — stub like the Standards test.
 vi.mock('../components/PageHeader', () => ({
   PageHeader: ({ title, actions }: { title: string; actions?: React.ReactNode }) => (

--- a/packages/ui/src/pages/SkillList.tsx
+++ b/packages/ui/src/pages/SkillList.tsx
@@ -13,6 +13,9 @@ import { Button } from '../components/ui';
 import { tenantPath } from '../utils/tenantUrl';
 import { CapabilityChips } from '../components/skills/CapabilityChips';
 import { CreateSkillModal } from '../components/skills/CreateSkillModal';
+import { ChatPanel } from '../components/ChatPanel';
+import { ResizableChatRail } from '../components/chat/ResizableChatRail';
+import { OpeningSkillsController } from '../components/chat/OpeningSkillsController';
 
 function matchesQuery(query: string, skill: SkillListItem): boolean {
   const q = query.trim().toLowerCase();
@@ -55,7 +58,20 @@ export function SkillList() {
   );
 
   return (
-    <div className="px-6 py-6">
+    // spec-300 t-15 (dec-23): the Skills surface docks the skills authoring /
+    // curation agent in the shared resizable rail on the left, mirroring the
+    // Standards surface — one shared ChatPanel shell (std-38), no bespoke agent UI.
+    <div className="flex h-full min-h-0">
+      <OpeningSkillsController />
+      <ResizableChatRail
+        storageKey="skills-chat-width"
+        testId="skills-assistant-panel"
+        handleTestId="skills-chat-resize"
+        label="Skills"
+      >
+        <ChatPanel />
+      </ResizableChatRail>
+      <div className="flex-1 min-w-0 h-full flex flex-col px-6 py-6">
       <PageHeader
         title="Skills"
         actions={
@@ -85,7 +101,7 @@ export function SkillList() {
         </div>
       )}
 
-      <div>
+      <div className="flex-1 min-h-0 overflow-y-auto">
         {loading ? (
           <div className="flex justify-center items-center min-h-[40vh]">
             <Spinner />
@@ -154,6 +170,7 @@ export function SkillList() {
           }}
         />
       )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Implements **spec-300 t-15** — the dedicated Skills in-app agent — closing the last open task on spec-300. Both increments land in one branch. All 53 spec-300 ACs are now verified (100%).

## Increment 1 — "Describe it" tab (ac-49, closes ac-21)
The New-skill modal's "Describe it" tab was a disabled "Coming soon" stub. It now wires the full round-trip: the plain-language description goes to a new **`POST /skills/draft`** route (`draftSkillFromDescription` → `SKILL_AUTHOR_INSTRUCTION` + `emit_skill` + `validateSkill`, all pre-existing from t-7), the validated SKILL.md loads into the editor for review, and the ordinary create path persists it on confirm.

## Increment 2 — dedicated chat-rail agent (ac-46/47/48/50/51/52/53)
A fifth scoped `agentMode` — `skills` — on the shared LangGraph graph (std-38). **Registration + UI wiring only: no new graph node, no new tools, no new prompt `.md`.**

- **server**: `SKILLS_SERVER_TOOLS = {list_skills, get_skill, update_skill, search_memex, get_doc}` in the `MODE_TOOLS` map (type-forced exhaustive); `"skills"` in both `llm.ts` zod enums (chat + `/tools/execute`); `buildSkillsContext`; `system-prompt` `scopedMode` widened.
- **shared**: `SKILLS_AGENT_MODE_GUIDANCE` prompt block in `scaffold-data.ts` (std-15), re-exported.
- **ui**: mode unions across `graph`/`useAgentGraph`/`llm-client`/`tool-client`; `ChatContext` `enter/exitSkillsMode`; `OpeningSkillsController`; `AGENT_INTROS.skills`; Skills page mounts the shared `ChatPanel` in a `ResizableChatRail`; `AppShell` docks the rail.

The agent drafts new skills from a description and curates existing ones (create/edit/archive/restore via the one validated `update_skill` path); its authority is skills-only (server `MODE_TOOLS` gate); for out-of-scope requests it refuses and hands off with `render_handoff`.

## Standards
std-38 (four invariants: shared shell, Memex-wide grounding, narrow authority, copyable handoff; new mode not new class), std-15 (prose home), std-30 (metered LLM), std-11, std-28 (e2e journey), std-16 intact (no new tools → no manifest change).

## Test plan
- [x] Full server suite green (5461 passed / 28 skipped)
- [x] Full UI suite green (1941 passed / 1 skipped)
- [x] Server + UI typecheck clean
- [x] `make e2e-cold` — 127/128 journeys pass (extended **journey-55**: create-by-describe → archive, driven through the agent against a cold DB via the Anthropic fake; verified against the real Skills service)
- [x] All 53 spec-300 ACs verified via emission (ac-46…53 new this PR)

### Known non-blocker
`journey-45-spec-304-mcp-session-mint` (INSTALL) is a **pre-existing load-induced flake** — under full-suite resource pressure it stalls on the desktop-shell `mcpStatusBridge()` + token-list round-trip; **passes cleanly in isolation (2/2)**. Zero overlap with this PR's diff (no MCP/settings/install file touched). CI on a clean runner is the authoritative gate.

QA report: `qa_report-2` on spec-300.