### PR TITLE
fix(spec-447): persist the Specs-board assignee filter across the "← All specs" round-trip

### DIFF
--- a/packages/ui/e2e/journey-54-spec-447-assignee-filter-persistence.spec.ts
+++ b/packages/ui/e2e/journey-54-spec-447-assignee-filter-persistence.spec.ts
@@ -26,6 +26,8 @@ const SPEC = "mindset-prod/memex-building-itself/specs/spec-447";
 const ACS_BY_TEST: Record<string, string[]> = {
   'assignee filter survives opening a spec and returning via "← All specs" (ac-1)':
     [`${SPEC}/acs/ac-1`],
+  'an active filter is visible on the board and "Clear filters" resets it (ac-7, ac-8)':
+    [`${SPEC}/acs/ac-7`, `${SPEC}/acs/ac-8`],
 };
 test.afterEach(async ({}, testInfo) => {
   const acRefs = ACS_BY_TEST[testInfo.title] ?? [];
@@ -81,4 +83,51 @@ test('assignee filter survives opening a spec and returning via "← All specs" 
   await expect(page.getByText("Alpha assigned to me")).toBeVisible({ timeout: 15_000 });
   await expect(page.getByText("Beta not mine")).not.toBeVisible();
   await expect(page).toHaveURL(/assignee=me/);
+});
+
+// spec-447 dec-2: a persisted filter must never make a filtered board read as
+// unfiltered — the active state has to be visible in the UI (not just the URL),
+// and a single "Clear filters" control returns the board to its full view.
+test('an active filter is visible on the board and "Clear filters" resets it (ac-7, ac-8)', async ({
+  page,
+  resources,
+}) => {
+  const slug = resources.slug("j54c");
+  const tenant = await seedOrgTenant({ slug });
+  const devUserId = await ensureUser("dev@memex.ai");
+
+  const mine = await seedSpec({
+    memexId: tenant.memexId,
+    title: "Alpha assigned to me",
+    purpose: "This one is mine.",
+  });
+  await seedAssignee({ memexId: tenant.memexId, docId: mine.docId, userId: devUserId });
+  await seedSpec({
+    memexId: tenant.memexId,
+    title: "Beta not mine",
+    purpose: "This one is not mine.",
+  });
+
+  await page.goto(tenantPath(tenant.namespaceSlug, tenant.memexSlug, "/specs"));
+  await expect(page.getByText("Alpha assigned to me")).toBeVisible({ timeout: 15_000 });
+
+  // Unfiltered: no "Clear filters" affordance and the control is not active.
+  const assignee = page.getByLabel("Filter by assignee");
+  await expect(assignee).toHaveAttribute("data-active", "false");
+  await expect(page.getByTestId("clear-all-filters")).toHaveCount(0);
+
+  // Apply a filter — the board narrows, the control flips to its active state,
+  // and the "Clear filters" control appears (the board now reads as filtered).
+  await assignee.selectOption("me");
+  await expect(page.getByText("Beta not mine")).not.toBeVisible();
+  await expect(assignee).toHaveAttribute("data-active", "true");
+  await expect(page.getByTestId("clear-all-filters")).toBeVisible();
+
+  // One click clears the filter: the full board is restored, the URL drops
+  // ?assignee, and the clear control disappears again.
+  await page.getByTestId("clear-all-filters").click();
+  await expect(page.getByText("Beta not mine")).toBeVisible({ timeout: 15_000 });
+  await expect(page.getByText("Alpha assigned to me")).toBeVisible();
+  await expect(page).not.toHaveURL(/assignee=/);
+  await expect(page.getByTestId("clear-all-filters")).toHaveCount(0);
 });

--- a/packages/ui/e2e/journey-54-spec-447-assignee-filter-persistence.spec.ts
+++ b/packages/ui/e2e/journey-54-spec-447-assignee-filter-persistence.spec.ts
@@ -1,0 +1,84 @@
+import {
+  test,
+  expect,
+  tenantPath,
+  ensureUser,
+  seedAssignee,
+  emitAcEvents,
+} from "./helpers/index.js";
+import { seedOrgTenant, seedSpec } from "./helpers/retained.js";
+
+// Journey 54 (spec-447): the assignee filter on the Specs board must survive the
+// round-trip into a spec and back via the "← All specs" header link. The filter
+// lives in the URL (spec-118 ac-19), but that header link navigates to a BARE
+// /specs (resolveNavTo drops the query string), so returning that way used to
+// reset the board to "All". The fix remembers the filter per-tenant and restores
+// it on mount. This journey proves the user-visible outcome (ac-1): apply the
+// filter, open a spec, click "← All specs", and the board is still filtered.
+//
+// Path-based nav [per std-2]; HTTP-only seeding via the env-gated test surface
+// (no raw SQL) [per std-28].
+
+const SPEC = "mindset-prod/memex-building-itself/specs/spec-447";
+
+// AC emission per the ac-emission discipline (mirrors journey-24): emit on
+// pass AND fail. First hook arg destructured ({}) as Playwright requires.
+const ACS_BY_TEST: Record<string, string[]> = {
+  'assignee filter survives opening a spec and returning via "← All specs" (ac-1)':
+    [`${SPEC}/acs/ac-1`],
+};
+test.afterEach(async ({}, testInfo) => {
+  const acRefs = ACS_BY_TEST[testInfo.title] ?? [];
+  if (acRefs.length === 0) return;
+  await emitAcEvents(
+    acRefs,
+    testInfo.status === "passed" ? "pass" : "fail",
+    `packages/ui/e2e/journey-54-spec-447-assignee-filter-persistence.spec.ts::${testInfo.title}`,
+    testInfo.duration,
+  );
+});
+
+test('assignee filter survives opening a spec and returning via "← All specs" (ac-1)', async ({
+  page,
+  resources,
+}) => {
+  const slug = resources.slug("j54");
+  const tenant = await seedOrgTenant({ slug });
+  const devUserId = await ensureUser("dev@memex.ai");
+
+  // One spec assigned to me, one not — so "Assigned to me" narrows the board.
+  const mine = await seedSpec({
+    memexId: tenant.memexId,
+    title: "Alpha assigned to me",
+    purpose: "This one is mine.",
+  });
+  await seedAssignee({ memexId: tenant.memexId, docId: mine.docId, userId: devUserId });
+  await seedSpec({
+    memexId: tenant.memexId,
+    title: "Beta not mine",
+    purpose: "This one is not mine.",
+  });
+
+  // Board opens unfiltered — both specs visible.
+  await page.goto(tenantPath(tenant.namespaceSlug, tenant.memexSlug, "/specs"));
+  await expect(page.getByText("Alpha assigned to me")).toBeVisible({ timeout: 15_000 });
+  await expect(page.getByText("Beta not mine")).toBeVisible();
+
+  // Apply "Assigned to me": only my spec remains, and the filter is in the URL.
+  await page.getByLabel("Filter by assignee").selectOption("me");
+  await expect(page.getByText("Beta not mine")).not.toBeVisible();
+  await expect(page.getByText("Alpha assigned to me")).toBeVisible();
+  await expect(page).toHaveURL(/assignee=me/);
+
+  // Open my spec, then return to the board via the "← All specs" header link
+  // (the bare-/specs path that used to drop the filter).
+  await page.getByText("Alpha assigned to me").click();
+  await expect(page).toHaveURL(new RegExp(`/specs/${mine.handle}`));
+  await page.getByRole("link", { name: /All specs/ }).click();
+
+  // The filter SURVIVES the round-trip: the board is still narrowed to me,
+  // Beta stays hidden, and the filter is still reflected in the URL (shareable).
+  await expect(page.getByText("Alpha assigned to me")).toBeVisible({ timeout: 15_000 });
+  await expect(page.getByText("Beta not mine")).not.toBeVisible();
+  await expect(page).toHaveURL(/assignee=me/);
+});

--- a/packages/ui/src/pages/SpecList.test.tsx
+++ b/packages/ui/src/pages/SpecList.test.tsx
@@ -464,10 +464,10 @@ describe('SpecList assignee filter persistence (spec-447)', () => {
     expect(screen.getByTestId('location-search').textContent).not.toContain('assignee=');
   });
 
-  it('the URL is the source of truth — an explicit ?assignee wins over a stale remembered value and syncs storage (ac-6)', async () => {
+  it('the URL is the source of truth — an explicit ?assignee wins for the view without poisoning the remembered default (ac-6)', async () => {
     tagAc(AC447(6));
     // Storage remembers u1, but the URL explicitly asks for u2 (a shared link
-    // or the browser-back path). The URL must win.
+    // or the browser-back path). The URL must win for THIS view...
     sessionStorage.setItem(KEY, 'u1');
     fetchDocsMock.mockResolvedValue(twoSpecs());
 
@@ -480,10 +480,15 @@ describe('SpecList assignee filter persistence (spec-447)', () => {
 
     await screen.findByText('Bob work');
     expect(screen.queryByText('Alice work')).not.toBeInTheDocument();
-    // Storage is synced to the URL value, not the other way round.
+    // ...but a URL-supplied value is NOT promoted to the remembered default:
+    // opening someone else's shared ?assignee=u2 link must not overwrite the
+    // user's own remembered u1, or that stranger's filter would silently become
+    // the sticky default on every later bare /specs visit. Only a filter the
+    // user actively selects (setAssigneeFilter) updates storage.
     await waitFor(() => {
-      expect(sessionStorage.getItem(KEY)).toBe('u2');
+      expect(screen.getByTestId('location-search').textContent).toContain('assignee=u2');
     });
+    expect(sessionStorage.getItem(KEY)).toBe('u1');
   });
 });
 

--- a/packages/ui/src/pages/SpecList.test.tsx
+++ b/packages/ui/src/pages/SpecList.test.tsx
@@ -342,6 +342,151 @@ describe('SpecList assignees + filter (spec-118)', () => {
   });
 });
 
+// spec-447 — the assignee filter must survive the round-trip into a spec and
+// back. The filter lives in the URL (spec-118 ac-19), but the "← All specs"
+// header link navigates to a BARE /specs (resolveNavTo drops the query string),
+// so returning that way lost the filter. The fix mirrors the active value into
+// a per-tenant sessionStorage key and restores it on mount when the URL carries
+// no ?assignee. These tests render at a real tenant path so the router-aware
+// tenant key resolves (parseTenantFromPathname needs /<ns>/<mx>/…).
+describe('SpecList assignee filter persistence (spec-447)', () => {
+  const AC447 = (n: number) =>
+    `mindset-prod/memex-building-itself/specs/spec-447/acs/ac-${n}`;
+  const alice = { userId: 'u1', name: 'Alice', email: 'alice@x.com' };
+  const bob = { userId: 'u2', name: 'Bob', email: 'bob@x.com' };
+  const TENANT = '/myorg/mymemex/specs';
+  const KEY = 'specboard:assignee:myorg/mymemex';
+
+  const twoSpecs = () => [
+    spec({ id: 's-1', title: 'Alice work', handle: 'doc-1', assignees: [alice] }),
+    spec({ id: 's-2', title: 'Bob work', handle: 'doc-2', assignees: [bob] }),
+  ];
+
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it('mirrors the selected assignee into per-tenant sessionStorage, and clears it on "All" (ac-5)', async () => {
+    tagAc(AC447(5));
+    const user = userEvent.setup();
+    fetchDocsMock.mockResolvedValue(twoSpecs());
+
+    render(
+      <MemoryRouter initialEntries={[TENANT]}>
+        <SpecList />
+      </MemoryRouter>,
+    );
+
+    await screen.findByText('Alice work');
+    const select = screen.getByLabelText('Filter by assignee') as HTMLSelectElement;
+
+    // Selecting a person persists that value under the per-tenant key.
+    await user.selectOptions(select, 'u2');
+    expect(sessionStorage.getItem(KEY)).toBe('u2');
+
+    // A deliberate "All" clears the remembered value (so it is not re-applied).
+    await user.selectOptions(select, 'all');
+    expect(sessionStorage.getItem(KEY)).toBeNull();
+  });
+
+  it('restores a remembered filter on mount when the URL has no ?assignee, writing it back into the URL (ac-6, ac-2)', async () => {
+    tagAc(AC447(6));
+    tagAc(AC447(2));
+    // Simulate "I filtered earlier this session" — the round-trip that the
+    // "← All specs" bare-/specs link produces.
+    sessionStorage.setItem(KEY, 'u2');
+    fetchDocsMock.mockResolvedValue(twoSpecs());
+
+    render(
+      <MemoryRouter initialEntries={[TENANT]}>
+        <SpecList />
+        <LocationDisplay />
+      </MemoryRouter>,
+    );
+
+    // The remembered filter is restored: board narrows to Bob and the filter is
+    // reflected back into the URL (spec-118 ac-19 preserved — still shareable).
+    await waitFor(() => {
+      expect(screen.getByTestId('location-search').textContent).toContain('assignee=u2');
+    });
+    expect(screen.getByText('Bob work')).toBeInTheDocument();
+    expect(screen.queryByText('Alice work')).not.toBeInTheDocument();
+  });
+
+  it('respects a deliberate clear — after selecting "All" the filter is not re-applied (ac-3)', async () => {
+    tagAc(AC447(3));
+    const user = userEvent.setup();
+    sessionStorage.setItem(KEY, 'u2');
+    fetchDocsMock.mockResolvedValue(twoSpecs());
+
+    render(
+      <MemoryRouter initialEntries={[TENANT]}>
+        <SpecList />
+        <LocationDisplay />
+      </MemoryRouter>,
+    );
+
+    // Mount restores the remembered u2 filter.
+    await waitFor(() => {
+      expect(screen.getByTestId('location-search').textContent).toContain('assignee=u2');
+    });
+
+    // The user deliberately clears it.
+    const select = screen.getByLabelText('Filter by assignee') as HTMLSelectElement;
+    await user.selectOptions(select, 'all');
+
+    // Storage is cleared and the board shows everything again — the cleared
+    // state is honoured, not overridden by the previously-remembered value.
+    expect(sessionStorage.getItem(KEY)).toBeNull();
+    await waitFor(() => {
+      expect(screen.getByText('Alice work')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Bob work')).toBeInTheDocument();
+    expect(screen.getByTestId('location-search').textContent).not.toContain('assignee=');
+  });
+
+  it('does not leak a remembered filter across Memexes — a value stored under one tenant never applies to another (ac-4)', async () => {
+    tagAc(AC447(4));
+    // A filter remembered on a DIFFERENT Memex's board.
+    sessionStorage.setItem('specboard:assignee:otherorg/othermemex', 'u2');
+    fetchDocsMock.mockResolvedValue(twoSpecs());
+
+    render(
+      <MemoryRouter initialEntries={[TENANT]}>
+        <SpecList />
+        <LocationDisplay />
+      </MemoryRouter>,
+    );
+
+    // This Memex's board opens unfiltered — the other tenant's key is never read.
+    await screen.findByText('Alice work');
+    expect(screen.getByText('Bob work')).toBeInTheDocument();
+    expect(screen.getByTestId('location-search').textContent).not.toContain('assignee=');
+  });
+
+  it('the URL is the source of truth — an explicit ?assignee wins over a stale remembered value and syncs storage (ac-6)', async () => {
+    tagAc(AC447(6));
+    // Storage remembers u1, but the URL explicitly asks for u2 (a shared link
+    // or the browser-back path). The URL must win.
+    sessionStorage.setItem(KEY, 'u1');
+    fetchDocsMock.mockResolvedValue(twoSpecs());
+
+    render(
+      <MemoryRouter initialEntries={[`${TENANT}?assignee=u2`]}>
+        <SpecList />
+        <LocationDisplay />
+      </MemoryRouter>,
+    );
+
+    await screen.findByText('Bob work');
+    expect(screen.queryByText('Alice work')).not.toBeInTheDocument();
+    // Storage is synced to the URL value, not the other way round.
+    await waitFor(() => {
+      expect(sessionStorage.getItem(KEY)).toBe('u2');
+    });
+  });
+});
+
 // Placate the unused-import linter if `act` ends up unused in some refactors.
 void act;
 

--- a/packages/ui/src/pages/SpecList.test.tsx
+++ b/packages/ui/src/pages/SpecList.test.tsx
@@ -490,6 +490,67 @@ describe('SpecList assignee filter persistence (spec-447)', () => {
     });
     expect(sessionStorage.getItem(KEY)).toBe('u1');
   });
+
+  it('surfaces an active assignee filter in the UI and shows the "Clear filters" control only when a filter is set (ac-8)', async () => {
+    tagAc(AC447(8));
+    const user = userEvent.setup();
+    fetchDocsMock.mockResolvedValue(twoSpecs());
+
+    render(
+      <MemoryRouter initialEntries={[TENANT]}>
+        <SpecList />
+      </MemoryRouter>,
+    );
+
+    await screen.findByText('Alice work');
+    const select = screen.getByLabelText('Filter by assignee') as HTMLSelectElement;
+
+    // Unfiltered: the control reads as inactive and there is no clear affordance
+    // (its absence is itself the "nothing is filtered" signal).
+    expect(select.getAttribute('data-active')).toBe('false');
+    expect(screen.queryByTestId('clear-all-filters')).not.toBeInTheDocument();
+
+    // Applying a filter flips the control to its active (accented) state and
+    // reveals the "Clear filters" button — the board can no longer look
+    // unfiltered while a persisted filter is in force.
+    await user.selectOptions(select, 'u2');
+    expect(select.getAttribute('data-active')).toBe('true');
+    expect(screen.getByTestId('clear-all-filters')).toBeInTheDocument();
+  });
+
+  it('"Clear filters" resets every board filter (assignee + tags + grounded) in one action (ac-7)', async () => {
+    tagAc(AC447(7));
+    const user = userEvent.setup();
+    // Neither spec is code-grounded, so ?grounded=1 hides both — the board
+    // starts fully narrowed by three simultaneously-active filters.
+    fetchDocsMock.mockResolvedValue(twoSpecs());
+
+    render(
+      <MemoryRouter initialEntries={[`${TENANT}?assignee=u2&grounded=1&tags=priority::high`]}>
+        <SpecList />
+        <LocationDisplay />
+      </MemoryRouter>,
+    );
+
+    // Wait for the load to settle: with grounded=1 hiding both specs, assert the
+    // clear control is present (proves filters are recognised as active).
+    await waitFor(() => {
+      expect(screen.getByTestId('clear-all-filters')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId('clear-all-filters'));
+
+    // All three URL-reflected filters are gone and the full board is restored.
+    await waitFor(() => {
+      expect(screen.getByText('Alice work')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Bob work')).toBeInTheDocument();
+    const search = screen.getByTestId('location-search').textContent ?? '';
+    expect(search).not.toContain('assignee=');
+    expect(search).not.toContain('grounded=');
+    expect(search).not.toContain('tags=');
+    expect(screen.queryByTestId('clear-all-filters')).not.toBeInTheDocument();
+  });
 });
 
 // Placate the unused-import linter if `act` ends up unused in some refactors.

--- a/packages/ui/src/pages/SpecList.tsx
+++ b/packages/ui/src/pages/SpecList.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useCallback, useMemo } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams, useLocation } from 'react-router-dom';
 import { fetchDocs, archiveDoc, resetHandholdDemo } from '../api/client';
 import { type DocSummary } from '../api/types';
 import { statusTextClass } from '../utils/statusStyles';
@@ -12,7 +12,7 @@ import { TagFilter } from '../components/TagFilter';
 import { ShareModal } from '../components/ShareModal';
 import { RenameSpecDialog } from '../components/RenameSpecDialog';
 import { MoveSpecDialog } from '../components/MoveSpecDialog';
-import { getCurrentTenant } from '../utils/tenantUrl';
+import { getCurrentTenant, parseTenantFromPathname } from '../utils/tenantUrl';
 import { useAuth } from '../components/AuthContext';
 import { nextRevealPhase } from '../hooks/useHandholdReveal';
 import { useHandholdRevealValue } from '../hooks/HandholdRevealContext';
@@ -50,8 +50,31 @@ export function SpecList() {
   // so a filtered board is shareable, matching the board's existing URL conventions.
   const [searchParams, setSearchParams] = useSearchParams();
   const assigneeFilter = searchParams.get('assignee') ?? 'all';
+  // spec-447: remember the assignee filter per-tenant so it survives the
+  // round-trip into a spec and back. The filter lives in the URL (spec-118
+  // ac-19), but the "← All specs" header link (AppShell) navigates to a BARE
+  // /specs — resolveNavTo drops the query string — so returning that way lost
+  // the filter. We mirror the active value into a per-tenant sessionStorage key
+  // and restore it on mount when the URL carries no ?assignee. Router-aware
+  // tenant (useLocation, not window.location) so the key resolves in tests too.
+  const location = useLocation();
+  const filterTenant = parseTenantFromPathname(location.pathname);
+  const assigneeStorageKey = filterTenant
+    ? `specboard:assignee:${filterTenant.namespace}/${filterTenant.memex}`
+    : null;
   const setAssigneeFilter = useCallback(
     (value: string) => {
+      // Persist the selection (including a deliberate "all", which clears the
+      // remembered value so a clear is honoured, never re-applied — ac-3).
+      if (assigneeStorageKey) {
+        try {
+          if (value === 'all') sessionStorage.removeItem(assigneeStorageKey);
+          else sessionStorage.setItem(assigneeStorageKey, value);
+        } catch {
+          // sessionStorage unavailable (private mode / disabled) — persistence
+          // is best-effort; the URL still reflects the filter this session.
+        }
+      }
       setSearchParams(
         (prev) => {
           const next = new URLSearchParams(prev);
@@ -62,8 +85,42 @@ export function SpecList() {
         { replace: true },
       );
     },
-    [setSearchParams],
+    [setSearchParams, assigneeStorageKey],
   );
+  // spec-447: restore the remembered assignee filter when the board is opened
+  // with no ?assignee in the URL (the "← All specs" round-trip, the logo link,
+  // a fresh visit). The URL is the source of truth: if it already carries
+  // ?assignee (a shared link or the browser-back path) we keep it and sync
+  // storage to match; otherwise we write the remembered value back into the URL
+  // so the restored filter stays shareable (spec-118 ac-19). Keyed per-tenant,
+  // so a filter set on one Memex's board never leaks onto another (ac-4).
+  useEffect(() => {
+    if (!assigneeStorageKey) return;
+    let remembered: string | null = null;
+    try {
+      const inUrl = searchParams.get('assignee');
+      if (inUrl) {
+        sessionStorage.setItem(assigneeStorageKey, inUrl);
+        return;
+      }
+      remembered = sessionStorage.getItem(assigneeStorageKey);
+    } catch {
+      return;
+    }
+    if (remembered && remembered !== 'all') {
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          next.set('assignee', remembered as string);
+          return next;
+        },
+        { replace: true },
+      );
+    }
+    // Runs on mount and when the tenant key changes; intentionally not on every
+    // searchParams change so a user's clear is not immediately re-applied.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [assigneeStorageKey]);
   // spec-136 t-7 (ac-3): the board tag filter lives in the URL (?tags=scope::value
   // &tags=bug) so a filtered board is shareable, matching the assignee filter's
   // URL convention. Multi-valued: each selected tag is its own repeated param,

--- a/packages/ui/src/pages/SpecList.tsx
+++ b/packages/ui/src/pages/SpecList.tsx
@@ -165,6 +165,37 @@ export function SpecList() {
     },
     [setSearchParams],
   );
+  // spec-447: with the assignee filter now persisting across the round-trip, a
+  // filtered board must never look unfiltered — the active state has to be
+  // visible in the UI, not just in the URL, and clearable in one action. This
+  // covers all three URL-reflected board filters (assignee / tags / grounded) so
+  // "Clear filters" always returns the board to its full, unfiltered view.
+  const hasActiveFilters = assigneeFilter !== 'all' || tagFilter.length > 0 || groundedOnly;
+  const clearAllFilters = useCallback(() => {
+    // Clearing the assignee also drops its remembered value, so a deliberate
+    // clear is honoured and never re-applied on the next mount (ac-3 semantics).
+    if (assigneeStorageKey) {
+      try {
+        sessionStorage.removeItem(assigneeStorageKey);
+      } catch {
+        // best-effort — see setAssigneeFilter.
+      }
+    }
+    // ONE setSearchParams that drops all three params. Three separate setters
+    // would NOT compose: react-router's functional updater reads the same params
+    // snapshot within a batch and the last navigate wins, so only one filter
+    // would actually clear. Delete them together in a single navigate.
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        next.delete('assignee');
+        next.delete('tags');
+        next.delete('grounded');
+        return next;
+      },
+      { replace: true },
+    );
+  }, [setSearchParams, assigneeStorageKey]);
   // doc-19 dec-8: surface the Create-an-Org banner only when the user is
   // looking at their personal Memex's Specs page. The CreateOrgBanner
   // component handles the dismissal + has-org-membership suppression itself.
@@ -449,11 +480,20 @@ export function SpecList() {
                 each person currently assigned across the board. URL-reflected. */}
             <label className="flex items-center gap-1.5 text-xs text-secondary select-none">
               <span className="text-muted">Assignee</span>
+              {/* spec-447: when a non-"all" assignee is active the control is
+                  accented (and flagged aria-invalid=false→data attr) so a
+                  filtered board reads as filtered at a glance, not just in the
+                  URL — the persisted filter must never masquerade as unfiltered. */}
               <select
                 value={assigneeFilter}
                 onChange={(e) => setAssigneeFilter(e.target.value)}
                 aria-label="Filter by assignee"
-                className="bg-surface border border-edge-subtle rounded-sm px-1.5 py-1 text-xs text-primary cursor-pointer"
+                data-active={assigneeFilter !== 'all'}
+                className={`rounded-sm px-1.5 py-1 text-xs cursor-pointer ${
+                  assigneeFilter !== 'all'
+                    ? 'bg-accent/10 border border-accent text-accent'
+                    : 'bg-surface border border-edge-subtle text-primary'
+                }`}
               >
                 <option value="all">All</option>
                 <option value="me">Assigned to me</option>
@@ -509,9 +549,33 @@ export function SpecList() {
 
       {/* spec-136 t-7 (ac-3): board-level tag filter. Narrows the kanban to
           Specs carrying the selected tags; clearable. The selection lives in the
-          URL (?tags=) so a filtered board is shareable. */}
-      <div className="flex-none mb-4">
+          URL (?tags=) so a filtered board is shareable.
+          spec-447: a single "Clear filters" resets ALL three board filters
+          (assignee / tags / grounded) in one action. It appears only when at
+          least one filter is active — so its mere presence is itself a signal
+          the board is filtered, not just the accented controls. */}
+      <div className="flex-none mb-4 flex items-start gap-3">
         <TagFilter selected={tagFilter} onChange={setTagFilter} />
+        {hasActiveFilters && (
+          <button
+            type="button"
+            onClick={clearAllFilters}
+            data-testid="clear-all-filters"
+            className="inline-flex items-center gap-1 rounded-md border border-accent/40 px-2 py-1 text-xs text-accent hover:bg-accent/10 hover:border-accent transition-colors"
+          >
+            <svg
+              className="w-3.5 h-3.5"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+              aria-hidden="true"
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+            <span>Clear filters</span>
+          </button>
+        )}
       </div>
 
       {/* Board row. overflow-x-auto + a per-column min width: flex children

--- a/packages/ui/src/pages/SpecList.tsx
+++ b/packages/ui/src/pages/SpecList.tsx
@@ -90,19 +90,22 @@ export function SpecList() {
   // spec-447: restore the remembered assignee filter when the board is opened
   // with no ?assignee in the URL (the "← All specs" round-trip, the logo link,
   // a fresh visit). The URL is the source of truth: if it already carries
-  // ?assignee (a shared link or the browser-back path) we keep it and sync
-  // storage to match; otherwise we write the remembered value back into the URL
-  // so the restored filter stays shareable (spec-118 ac-19). Keyed per-tenant,
-  // so a filter set on one Memex's board never leaks onto another (ac-4).
+  // ?assignee (a shared link or the browser-back path) we honour it as-is and
+  // do NOT touch storage — only a filter the user actively selects
+  // (setAssigneeFilter) becomes the remembered default. Mirroring a URL-supplied
+  // value here would let someone else's shared ?assignee=<uuid> link silently
+  // become your sticky default for the rest of the session (and, if that user
+  // has no assignments, strand you on a blank-dropdown empty board). Otherwise
+  // we write the remembered value back into the URL so the restored filter stays
+  // shareable (spec-118 ac-19). Keyed per-tenant, so a filter set on one Memex's
+  // board never leaks onto another (ac-4).
   useEffect(() => {
     if (!assigneeStorageKey) return;
+    // URL wins: an explicit ?assignee (shared link / browser-back) is honoured
+    // for this view without being promoted to the remembered default.
+    if (searchParams.get('assignee')) return;
     let remembered: string | null = null;
     try {
-      const inUrl = searchParams.get('assignee');
-      if (inUrl) {
-        sessionStorage.setItem(assigneeStorageKey, inUrl);
-        return;
-      }
       remembered = sessionStorage.getItem(assigneeStorageKey);
     } catch {
       return;


### PR DESCRIPTION
## What & why
The Specs-board **assignee filter** was silently lost when you opened a spec and returned via the **"← All specs"** header link — the board reset to "All", forcing a re-apply every round-trip. Fixes **spec-118 issue-1** (promoted to **spec-447**, auto-resolves on merge).

## Root cause
The filter lives in the URL (`?assignee=`, spec-118 ac-19) and browser-back restores it, but the "← All specs" link (`AppShell` → `resolveNavTo`) navigates to a bare `/specs` with no query string, dropping the filter.

## Fix (spec-447)
`SpecList` mirrors the active assignee filter into a **per-tenant `sessionStorage` key** and **restores it to the URL on mount** when no `?assignee` is present. URL wins over storage; a deliberate "All" clears the remembered value; per-tenant key so a filter never leaks across Memexes. `AppShell` / `KanbanColumn` untouched — smallest blast radius.

> **Persistence is browser-only and per-user.** The remembered value lives in `sessionStorage` — per-origin, per-browser-tab, namespaced per-tenant (`specboard:assignee:<ns>/<mx>`). It is **never** sent to the server and **never** shared with other users, devices, or tabs. Nothing one user does can change what another user sees.

## Review follow-ups (this branch, on top of the original commit)

**1. Guard — a shared link must not poison your remembered default (`0f3d558`).**
The restore effect used to mirror *any* URL-supplied `?assignee` into storage. So opening someone else's shared `?assignee=<uuid>` link silently made their filter *your* sticky default for the session — and if that person had no assigned specs, you could land on a blank-dropdown empty board. Now the URL wins **for that view only**; only a filter you actively select is remembered. (ac-6's statement only covers the no-`?assignee` restore case, so the AC contract is unchanged.)

**2. Make the filter visible + one-click clear (spec-447 dec-2, `9573178`).**
Because the filter now persists, a filtered board could look unfiltered — the only signal was in the URL.
- The **Assignee control renders in an accented active state** (`data-active`) whenever a real filter is set.
- A single **"Clear filters"** button appears **only when a filter is active** and resets **all three** board filters (assignee + tags + grounded) in one action, dropping the remembered value.
- Implementation note: the reset is a **single** `setSearchParams` deleting all three params — three separate setters don't compose (react-router reads one snapshot per batch, last `navigate` wins). A component test caught this.

## Testing
- **SpecList.test.tsx** — 8 component tests (ac-1..ac-8), all pass.
- **journey-54** (std-28) — two Playwright journeys: the "← All specs" round-trip, and the visible-active-state → clear-all flow. Runs against a cold DB as the PR-gate check.
- **8/8 acceptance criteria verified.** UI `tsc` clean; `biome` clean; full UI suite green on push (1650 passed).
- Spec-447 is in **verify**; QA report attached.

Spec: https://memex.ai/mindset-prod/memex-building-itself/specs/spec-447
