### PR TITLE
spec-456: group the account menu into sections with icons + What's New micro-interaction

### DIFF
--- a/packages/ui/src/components/AppShell.spec-456.test.tsx
+++ b/packages/ui/src/components/AppShell.spec-456.test.tsx
@@ -14,9 +14,11 @@ const AC_HOOKS = 'mindset-prod/memex-building-itself/specs/spec-456/acs/ac-5';
 const AC_MICRO = 'mindset-prod/memex-building-itself/specs/spec-456/acs/ac-6';
 
 // Hoisted spies so the test can assert the callbacks the menu items are wired to.
-const { logoutSpy, openWhatsNewSpy } = vi.hoisted(() => ({
+const { logoutSpy, openWhatsNewSpy, whatsNewState } = vi.hoisted(() => ({
   logoutSpy: vi.fn(),
   openWhatsNewSpy: vi.fn(),
+  // Mutable so a test can flip What's New availability / unread state.
+  whatsNewState: { available: true, hasUnseen: true },
 }));
 
 const TEAM_ADMIN = {
@@ -47,7 +49,8 @@ vi.mock('./AuthContext', () => ({
 // surface it so the notification row + its micro-interaction are exercised.
 vi.mock('./whats-new/WhatsNewContext', () => ({
   useWhatsNew: () => ({
-    available: true,
+    available: whatsNewState.available,
+    hasUnseen: whatsNewState.hasUnseen,
     openPopup: openWhatsNewSpy,
     registerMenuAnchor: vi.fn(),
   }),
@@ -101,6 +104,9 @@ function menuRoot(): HTMLElement {
 
 afterEach(() => {
   vi.clearAllMocks();
+  vi.restoreAllMocks();
+  whatsNewState.available = true;
+  whatsNewState.hasUnseen = true;
 });
 
 describe('spec-456: account menu grouping + icons + micro-interaction', () => {
@@ -219,6 +225,7 @@ describe('spec-456: account menu grouping + icons + micro-interaction', () => {
 
   it('ac-6: What’s New carries the unwrap+confetti structure and stays safe under reduced motion', () => {
     tagAc(AC_MICRO);
+    const getCtx = vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(null);
     openMenu();
 
     const whatsNew = screen.getByTestId('user-menu-whats-new');
@@ -235,15 +242,39 @@ describe('spec-456: account menu grouping + icons + micro-interaction', () => {
     fireEvent.click(whatsNew);
     expect(openWhatsNewSpy).toHaveBeenCalledTimes(1);
 
-    // Under prefers-reduced-motion the click path is still safe and functional.
+    // Under prefers-reduced-motion the click path is still safe + functional, and
+    // no confetti is attempted (the burst bails before touching the canvas).
+    getCtx.mockClear();
     const originalMatchMedia = window.matchMedia;
     window.matchMedia = vi.fn().mockReturnValue({ matches: true }) as unknown as typeof window.matchMedia;
     try {
       openUserMenu();
       fireEvent.click(screen.getByTestId('user-menu-whats-new'));
       expect(openWhatsNewSpy).toHaveBeenCalledTimes(2);
+      expect(getCtx).not.toHaveBeenCalled();
     } finally {
       window.matchMedia = originalMatchMedia;
     }
+  });
+
+  it('ac-6: confetti fires only for unread entries, never when re-opening seen notes', () => {
+    tagAc(AC_MICRO);
+    // getContext being called is our proxy for "the confetti burst was attempted".
+    const getCtx = vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(null);
+
+    // Unread entry → clicking attempts the burst and opens the popup.
+    whatsNewState.hasUnseen = true;
+    openMenu();
+    fireEvent.click(screen.getByTestId('user-menu-whats-new'));
+    expect(openWhatsNewSpy).toHaveBeenCalledTimes(1);
+    expect(getCtx).toHaveBeenCalled();
+
+    // Already-seen → clicking still re-opens the popup but fires no confetti.
+    getCtx.mockClear();
+    whatsNewState.hasUnseen = false;
+    openUserMenu();
+    fireEvent.click(screen.getByTestId('user-menu-whats-new'));
+    expect(openWhatsNewSpy).toHaveBeenCalledTimes(2);
+    expect(getCtx).not.toHaveBeenCalled();
   });
 });

--- a/packages/ui/src/components/AppShell.spec-456.test.tsx
+++ b/packages/ui/src/components/AppShell.spec-456.test.tsx
@@ -1,0 +1,249 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { ThemeProvider } from './ThemeContext';
+
+// spec-456 — account menu grouped into sections + icons + danger sign-out +
+// What's New micro-interaction. One AC per observable outcome.
+const AC_GROUPS = 'mindset-prod/memex-building-itself/specs/spec-456/acs/ac-1';
+const AC_ICONS = 'mindset-prod/memex-building-itself/specs/spec-456/acs/ac-2';
+const AC_SIGNOUT = 'mindset-prod/memex-building-itself/specs/spec-456/acs/ac-3';
+const AC_PRESERVED = 'mindset-prod/memex-building-itself/specs/spec-456/acs/ac-4';
+const AC_HOOKS = 'mindset-prod/memex-building-itself/specs/spec-456/acs/ac-5';
+const AC_MICRO = 'mindset-prod/memex-building-itself/specs/spec-456/acs/ac-6';
+
+// Hoisted spies so the test can assert the callbacks the menu items are wired to.
+const { logoutSpy, openWhatsNewSpy } = vi.hoisted(() => ({
+  logoutSpy: vi.fn(),
+  openWhatsNewSpy: vi.fn(),
+}));
+
+const TEAM_ADMIN = {
+  memexId: 'm1',
+  slug: 'acme',
+  memexSlug: 'team',
+  name: 'Acme Inc',
+  memexName: 'Team',
+  kind: 'team' as const,
+  role: 'administrator' as const,
+};
+
+const session = {
+  user: { name: 'Tester', email: 't@acme.test' },
+  memberships: [TEAM_ADMIN],
+  currentMemexId: 'm1',
+};
+
+vi.mock('./AuthContext', () => ({
+  useAuth: () => ({
+    user: { name: 'Tester', email: 't@acme.test' },
+    session,
+    logout: logoutSpy,
+  }),
+}));
+
+// What's New is hidden by default (WhatsNewContext defaults to available:false);
+// surface it so the notification row + its micro-interaction are exercised.
+vi.mock('./whats-new/WhatsNewContext', () => ({
+  useWhatsNew: () => ({
+    available: true,
+    openPopup: openWhatsNewSpy,
+    registerMenuAnchor: vi.fn(),
+  }),
+}));
+
+vi.mock('./MemexSwitcher', () => ({
+  MemexSwitcher: () => <div data-testid="memex-switcher" />,
+}));
+
+vi.mock('./InviteMembersDialog', () => ({
+  InviteMembersDialog: () => <div data-testid="invite-dialog" />,
+}));
+
+vi.mock('../hooks/useMemexAccess', () => ({
+  useMemexAccess: () => ({ isAuthenticated: true, isVisitedReadOnly: false }),
+}));
+
+vi.mock('../hooks/useDriftInboxCount', () => ({
+  useDriftInboxCount: () => 0,
+}));
+
+import { AppShell } from './AppShell';
+
+function renderShell() {
+  render(
+    <ThemeProvider>
+      <MemoryRouter initialEntries={['/acme/team/specs']}>
+        <AppShell>
+          <div data-testid="page-content">page</div>
+        </AppShell>
+      </MemoryRouter>
+    </ThemeProvider>
+  );
+}
+
+// Click the user card to (re-)open the dropdown. Safe to call more than once in
+// a test — the shell stays mounted, so there's only ever one "Tester" to click.
+function openUserMenu() {
+  fireEvent.click(screen.getByText('Tester'));
+}
+
+function openMenu() {
+  renderShell();
+  openUserMenu();
+}
+
+/** The popup element that holds the menu rows. */
+function menuRoot(): HTMLElement {
+  return screen.getByTestId('user-menu-whats-new').parentElement as HTMLElement;
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('spec-456: account menu grouping + icons + micro-interaction', () => {
+  it('ac-1: groups the 7 items into four sections with three dividers, none re-routed', () => {
+    tagAc(AC_GROUPS);
+    openMenu();
+    const menu = menuRoot();
+
+    // Three dividers → four groups.
+    expect(within(menu).getAllByRole('separator')).toHaveLength(3);
+
+    // Every item still present (team-admin on localhost → all gates open).
+    expect(screen.getByTestId('user-menu-whats-new')).toBeInTheDocument();
+    for (const label of [
+      'Memex settings',
+      'Memex keys',
+      'Org configuration',
+      'Integrations',
+      'Email preview',
+      'Watch intro video',
+    ]) {
+      expect(screen.getByRole('link', { name: label })).toBeInTheDocument();
+    }
+    expect(screen.getByRole('button', { name: 'Sign out' })).toBeInTheDocument();
+
+    // Order preserved: What's New first, Sign out last.
+    const rows = Array.from(menu.querySelectorAll('a, button')).map((el) =>
+      el.textContent?.trim()
+    );
+    expect(rows[0]).toBe("What's New");
+    expect(rows[rows.length - 1]).toBe('Sign out');
+    const idx = (t: string) => rows.indexOf(t);
+    expect(idx('Memex settings')).toBeLessThan(idx('Integrations'));
+    expect(idx('Integrations')).toBeLessThan(idx('Watch intro video'));
+
+    // Destinations unchanged (nothing re-routed).
+    expect(screen.getByRole('link', { name: 'Memex settings' })).toHaveAttribute(
+      'href',
+      '/acme/team/settings'
+    );
+    expect(screen.getByRole('link', { name: 'Org configuration' })).toHaveAttribute(
+      'href',
+      '/acme/team/org'
+    );
+    expect(screen.getByRole('link', { name: 'Integrations' })).toHaveAttribute(
+      'href',
+      '/settings/integrations'
+    );
+    expect(screen.getByRole('link', { name: 'Watch intro video' })).toHaveAttribute(
+      'href',
+      '/welcome?rewatch=1'
+    );
+  });
+
+  it('ac-2: every row shows a leading svg icon, and What’s New drops the emoji', () => {
+    tagAc(AC_ICONS);
+    openMenu();
+    const menu = menuRoot();
+
+    for (const row of Array.from(menu.querySelectorAll('a, button'))) {
+      expect(row.querySelector('svg')).not.toBeNull();
+    }
+    // The 🎁 emoji is gone — replaced by the gift svg.
+    const whatsNew = screen.getByTestId('user-menu-whats-new');
+    expect(whatsNew.textContent).not.toContain('🎁');
+    expect(whatsNew.querySelector('svg')).not.toBeNull();
+  });
+
+  it('ac-3: Sign out sits after its own divider and reddens on hover', () => {
+    tagAc(AC_SIGNOUT);
+    openMenu();
+
+    const signOut = screen.getByRole('button', { name: 'Sign out' });
+    expect(signOut.className).toContain('hover:text-status-danger-text');
+    // Its immediately-preceding sibling is a divider.
+    expect(signOut.previousElementSibling).toHaveAttribute('role', 'separator');
+  });
+
+  it('ac-4: visibility gates and click behaviours are preserved', () => {
+    tagAc(AC_PRESERVED);
+    openMenu();
+
+    // Gate-open items render for a team admin.
+    expect(screen.getByRole('link', { name: 'Memex settings' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Memex keys' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Org configuration' })).toBeInTheDocument();
+
+    // Sign out still calls logout.
+    fireEvent.click(screen.getByRole('button', { name: 'Sign out' }));
+    expect(logoutSpy).toHaveBeenCalledTimes(1);
+
+    // Clicking a link closes the menu (setOpen(false) preserved).
+    openUserMenu();
+    fireEvent.click(screen.getByRole('link', { name: 'Integrations' }));
+    expect(screen.queryByRole('button', { name: 'Sign out' })).not.toBeInTheDocument();
+  });
+
+  it('ac-5: existing testids and role selectors still resolve', () => {
+    tagAc(AC_HOOKS);
+    openMenu();
+
+    // The testids other code/tests rely on are unchanged.
+    expect(screen.getByTestId('user-menu-whats-new')).toBeInTheDocument();
+    expect(screen.getByTestId('user-menu-email-preview')).toBeInTheDocument();
+
+    // The exact queries spec-141 uses against this menu still pass.
+    expect(screen.getByRole('link', { name: 'Memex settings' })).toHaveAttribute(
+      'href',
+      '/acme/team/settings'
+    );
+    expect(screen.getByRole('link', { name: 'Integrations' })).toHaveAttribute(
+      'href',
+      '/settings/integrations'
+    );
+  });
+
+  it('ac-6: What’s New carries the unwrap+confetti structure and stays safe under reduced motion', () => {
+    tagAc(AC_MICRO);
+    openMenu();
+
+    const whatsNew = screen.getByTestId('user-menu-whats-new');
+    // Hover unwrap: the row is a group and the gift has a lid + sparkle to animate.
+    expect(whatsNew.className).toContain('group');
+    expect(whatsNew.querySelector('.wn-lid')).not.toBeNull();
+    expect(whatsNew.querySelector('.wn-sparkle')).not.toBeNull();
+    // Click confetti: a canvas is present to draw into.
+    expect(
+      screen.getByTestId('user-menu-whats-new-confetti').tagName.toLowerCase()
+    ).toBe('canvas');
+
+    // Clicking still opens the popup (confetti is a no-op in jsdom, never throws).
+    fireEvent.click(whatsNew);
+    expect(openWhatsNewSpy).toHaveBeenCalledTimes(1);
+
+    // Under prefers-reduced-motion the click path is still safe and functional.
+    const originalMatchMedia = window.matchMedia;
+    window.matchMedia = vi.fn().mockReturnValue({ matches: true }) as unknown as typeof window.matchMedia;
+    try {
+      openUserMenu();
+      fireEvent.click(screen.getByTestId('user-menu-whats-new'));
+      expect(openWhatsNewSpy).toHaveBeenCalledTimes(2);
+    } finally {
+      window.matchMedia = originalMatchMedia;
+    }
+  });
+});

--- a/packages/ui/src/components/AppShell.tsx
+++ b/packages/ui/src/components/AppShell.tsx
@@ -199,6 +199,195 @@ interface UserMenuUser {
   picture?: string | null;
 }
 
+// spec-456 — icons for the account menu rows, in the heroicons-outline
+// convention already used in this file (the theme toggle, InvitePersonIcon):
+// w-4 h-4, fill:none, stroke:currentColor so each icon follows its row's
+// text-secondary→text-primary hover colour. Module-level so they're defined
+// once, not re-created per render.
+const MENU_ICON_CLASS = 'w-4 h-4 flex-none';
+
+// The "What's New" gift, split into an unwrappable lid + a hidden sparkle
+// (both animated by the .wn-* rules in index.css on group hover/focus).
+function WhatsNewGiftIcon() {
+  return (
+    <svg
+      className={MENU_ICON_CLASS}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.75}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <rect x="4" y="11" width="16" height="9" rx="1.6" />
+      <line x1="12" y1="11" x2="12" y2="20" />
+      <path
+        className="wn-sparkle"
+        d="M12 12.4l0.7 1.6 1.6 0.7-1.6 0.7-0.7 1.6-0.7-1.6-1.6-0.7 1.6-0.7z"
+        stroke="#ffb020"
+        fill="#ffb020"
+      />
+      <g className="wn-lid">
+        <rect x="3" y="7.2" width="18" height="4.6" rx="1.4" />
+        <line x1="12" y1="7.2" x2="12" y2="11.8" />
+        <path d="M9.3 7.2c-1.6 0-2.6-1-2.6-2.2S7.6 2.8 9 2.8c1.7 0 2.6 2.2 3 4.4" />
+        <path d="M14.7 7.2c1.6 0 2.6-1 2.6-2.2S16.4 2.8 15 2.8c-1.7 0-2.6 2.2-3 4.4" />
+      </g>
+    </svg>
+  );
+}
+
+function SettingsGearIcon() {
+  return (
+    <svg className={MENU_ICON_CLASS} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.75} aria-hidden="true">
+      <path strokeLinecap="round" strokeLinejoin="round" d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.324.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 011.37.49l1.296 2.247a1.125 1.125 0 01-.26 1.431l-1.003.827c-.293.24-.438.613-.431.992a6.759 6.759 0 010 .255c-.007.378.138.752.43.992l1.005.827c.424.35.534.955.26 1.43l-1.298 2.247a1.125 1.125 0 01-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.57 6.57 0 01-.22.128c-.331.183-.581.495-.644.869l-.213 1.28c-.09.543-.56.941-1.11.941h-2.594c-.55 0-1.019-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 01-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 01-1.369-.49l-1.297-2.247a1.125 1.125 0 01.26-1.431l1.004-.827c.292-.24.437-.613.43-.992a6.932 6.932 0 010-.255c.007-.378-.138-.752-.43-.992l-1.004-.827a1.125 1.125 0 01-.26-1.43l1.297-2.247a1.125 1.125 0 011.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.087.22-.128.332-.183.582-.495.644-.869l.214-1.28z" />
+      <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+    </svg>
+  );
+}
+
+function KeyIcon() {
+  return (
+    <svg className={MENU_ICON_CLASS} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.75} aria-hidden="true">
+      <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 5.25a3 3 0 013 3m3 0a6 6 0 01-7.029 5.912c-.563-.097-1.159.026-1.563.43L10.5 17.25H8.25v2.25H6v2.25H2.25v-2.818c0-.597.237-1.17.659-1.591l6.499-6.499c.404-.404.527-1 .43-1.563A6 6 0 1121.75 8.25z" />
+    </svg>
+  );
+}
+
+function OrgBuildingIcon() {
+  return (
+    <svg className={MENU_ICON_CLASS} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.75} aria-hidden="true">
+      <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 21h16.5M4.5 3h15M5.25 3v18m13.5-18v18M9 6.75h1.5m-1.5 3h1.5m-1.5 3h1.5m3-6H15m-1.5 3H15m-1.5 3H15M9 21v-3.375c0-.621.504-1.125 1.125-1.125h3.75c.621 0 1.125.504 1.125 1.125V21" />
+    </svg>
+  );
+}
+
+function IntegrationsLinkIcon() {
+  return (
+    <svg className={MENU_ICON_CLASS} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.75} aria-hidden="true">
+      <path strokeLinecap="round" strokeLinejoin="round" d="M13.19 8.688a4.5 4.5 0 011.242 7.244l-4.5 4.5a4.5 4.5 0 01-6.364-6.364l1.757-1.757m13.35-.622l1.757-1.757a4.5 4.5 0 00-6.364-6.364l-4.5 4.5a4.5 4.5 0 001.242 7.244" />
+    </svg>
+  );
+}
+
+function PlayCircleIcon() {
+  return (
+    <svg className={MENU_ICON_CLASS} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.75} aria-hidden="true">
+      <path strokeLinecap="round" strokeLinejoin="round" d="M15.91 11.672a.375.375 0 010 .656l-5.603 3.113a.375.375 0 01-.557-.328V8.887c0-.286.307-.466.557-.327l5.603 3.112z" />
+      <path strokeLinecap="round" strokeLinejoin="round" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+    </svg>
+  );
+}
+
+function LogoutIcon() {
+  return (
+    <svg className={MENU_ICON_CLASS} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.75} aria-hidden="true">
+      <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 9V5.25A2.25 2.25 0 0013.5 3h-6a2.25 2.25 0 00-2.25 2.25v13.5A2.25 2.25 0 007.5 21h6a2.25 2.25 0 002.25-2.25V15M12 9l-3 3m0 0l3 3m-3-3h12.75" />
+    </svg>
+  );
+}
+
+// One shared row style so every account-menu item matches (was duplicated on
+// each Link/button). Danger variant reddens Sign out on hover so a destructive
+// action reads differently from the settings links above it.
+const USER_MENU_ITEM_CLASS =
+  'flex w-full items-center gap-2.5 px-3 py-2 text-left text-sm rounded-md transition-colors text-secondary hover:text-primary hover:bg-overlay';
+const USER_MENU_DANGER_CLASS =
+  'flex w-full items-center gap-2.5 px-3 py-2 text-left text-sm rounded-md transition-colors text-secondary hover:text-status-danger-text hover:bg-overlay';
+
+function UserMenuDivider() {
+  return <div role="separator" className="my-1 border-t border-edge" />;
+}
+
+function UserMenuLink({
+  to,
+  icon,
+  onClick,
+  testId,
+  children,
+}: {
+  to: string;
+  icon: ReactNode;
+  onClick: () => void;
+  testId?: string;
+  children: ReactNode;
+}) {
+  return (
+    <Link to={to} onClick={onClick} data-testid={testId} className={USER_MENU_ITEM_CLASS}>
+      {icon}
+      {children}
+    </Link>
+  );
+}
+
+// spec-456 — the What's New row's click flourish: a short confetti burst drawn
+// from the gift icon before the What's New popup opens. Purely decorative, so
+// it fails safe: a no-op under prefers-reduced-motion, and wherever the canvas
+// 2D context is unavailable (e.g. jsdom in unit tests, canvas.getContext → null).
+function burstWhatsNewConfetti(canvas: HTMLCanvasElement | null): void {
+  if (!canvas) return;
+  const prefersReduced =
+    typeof window !== 'undefined' &&
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  if (prefersReduced) return;
+  let ctx: CanvasRenderingContext2D | null = null;
+  try {
+    ctx = canvas.getContext('2d');
+  } catch {
+    // jsdom (no canvas pkg) throws "Not implemented" here; treat as no-op.
+    return;
+  }
+  if (!ctx) return;
+
+  const colors = ['#ff6b3d', '#ffc94d', '#2fbfa8', '#5b7cfa'];
+  const cx = canvas.width / 2;
+  const cy = canvas.height / 2;
+  const count = 16;
+  const particles = Array.from({ length: count }, (_, i) => {
+    const angle = (Math.PI * 2 * i) / count + Math.random() * 0.4;
+    const speed = 1.6 + Math.random() * 1.8;
+    return {
+      x: cx,
+      y: cy,
+      vx: Math.cos(angle) * speed,
+      vy: Math.sin(angle) * speed - 1.2,
+      size: 2.5 + Math.random() * 2,
+      color: colors[i % colors.length],
+      rot: Math.random() * Math.PI,
+      vr: (Math.random() - 0.5) * 0.4,
+    };
+  });
+
+  const DURATION = 650;
+  const start = performance.now();
+  function frame(now: number) {
+    const elapsed = now - start;
+    const life = Math.max(0, 1 - elapsed / DURATION);
+    ctx!.clearRect(0, 0, canvas!.width, canvas!.height);
+    for (const p of particles) {
+      p.vy += 0.09;
+      p.x += p.vx;
+      p.y += p.vy;
+      p.rot += p.vr;
+      ctx!.save();
+      ctx!.globalAlpha = life;
+      ctx!.translate(p.x, p.y);
+      ctx!.rotate(p.rot);
+      ctx!.fillStyle = p.color;
+      ctx!.fillRect(-p.size / 2, -p.size / 2, p.size, p.size * 0.6);
+      ctx!.restore();
+    }
+    if (elapsed < DURATION) {
+      requestAnimationFrame(frame);
+    } else {
+      ctx!.clearRect(0, 0, canvas!.width, canvas!.height);
+    }
+  }
+  requestAnimationFrame(frame);
+}
+
 // Bottom-of-sidebar identity card. Click avatar/name to open the menu (account
 // configuration + sign out). Theme toggle is a sibling button — visually next
 // to the avatar but a separate action.
@@ -300,80 +489,82 @@ function SidebarUserCard({
         )}
       </button>
       {open && (
-        <div className="absolute left-0 right-0 bottom-full mb-2 z-40 rounded-lg shadow-xl py-1 border bg-card-hover border-edge">
+        // spec-456 — grouped into four sections divided by rules: notification,
+        // then the settings/config cluster, then help, then the account exit.
+        // Every row carries a leading icon; Sign out is set apart with a danger
+        // hover. No item is added, removed, or re-routed vs. the flat list.
+        <div className="absolute left-0 right-0 bottom-full mb-2 z-40 rounded-lg shadow-xl py-1 px-1 border bg-card-hover border-edge">
           {whatsNewAvailable && (
-            <button
-              data-testid="user-menu-whats-new"
-              onClick={() => {
-                setOpen(false);
-                openWhatsNew();
-              }}
-              className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm transition-colors text-secondary hover:text-primary hover:bg-overlay"
-            >
-              <span aria-hidden="true">🎁</span>
-              What's New
-            </button>
+            <>
+              <button
+                data-testid="user-menu-whats-new"
+                onClick={(e) => {
+                  // The gift's confetti fires from its own icon canvas, then the
+                  // What's New popup opens (behaviour unchanged from the flat menu).
+                  burstWhatsNewConfetti(e.currentTarget.querySelector('canvas'));
+                  setOpen(false);
+                  openWhatsNew();
+                }}
+                className={`group ${USER_MENU_ITEM_CLASS}`}
+              >
+                <span className="relative flex-none">
+                  <WhatsNewGiftIcon />
+                  <canvas
+                    data-testid="user-menu-whats-new-confetti"
+                    aria-hidden="true"
+                    width={72}
+                    height={72}
+                    className="pointer-events-none absolute left-1/2 top-1/2 z-10 -translate-x-1/2 -translate-y-1/2"
+                  />
+                </span>
+                What's New
+              </button>
+              <UserMenuDivider />
+            </>
           )}
           {showMemexSettings && (
-            <Link
-              to={memexSettingsHref}
-              onClick={() => setOpen(false)}
-              className="block w-full text-left px-3 py-2 text-sm transition-colors text-secondary hover:text-primary hover:bg-overlay"
-            >
+            <UserMenuLink to={memexSettingsHref} icon={<SettingsGearIcon />} onClick={() => setOpen(false)}>
               Memex settings
-            </Link>
+            </UserMenuLink>
           )}
           {showMemexKeys && (
-            <Link
-              to={memexKeysHref}
-              onClick={() => setOpen(false)}
-              className="block w-full text-left px-3 py-2 text-sm transition-colors text-secondary hover:text-primary hover:bg-overlay"
-            >
+            <UserMenuLink to={memexKeysHref} icon={<KeyIcon />} onClick={() => setOpen(false)}>
               Memex keys
-            </Link>
+            </UserMenuLink>
           )}
           {showOrgConfig && (
-            <Link
-              to={orgConfigHref}
-              onClick={() => setOpen(false)}
-              className="block w-full text-left px-3 py-2 text-sm transition-colors text-secondary hover:text-primary hover:bg-overlay"
-            >
+            <UserMenuLink to={orgConfigHref} icon={<OrgBuildingIcon />} onClick={() => setOpen(false)}>
               Org configuration
-            </Link>
+            </UserMenuLink>
           )}
-          <Link
-            to="/settings/integrations"
-            onClick={() => setOpen(false)}
-            className="block w-full text-left px-3 py-2 text-sm transition-colors text-secondary hover:text-primary hover:bg-overlay"
-          >
+          <UserMenuLink to="/settings/integrations" icon={<IntegrationsLinkIcon />} onClick={() => setOpen(false)}>
             Integrations
-          </Link>
+          </UserMenuLink>
+          <UserMenuDivider />
           {/* spec-226 t-6: internal email-preview gallery, gated off prod. */}
           {emailPreviewEnabled() && (
-            <Link
+            <UserMenuLink
               to="/email-preview"
-              data-testid="user-menu-email-preview"
+              icon={<PlayCircleIcon />}
+              testId="user-menu-email-preview"
               onClick={() => setOpen(false)}
-              className="block w-full text-left px-3 py-2 text-sm transition-colors text-secondary hover:text-primary hover:bg-overlay"
             >
               Email preview
-            </Link>
+            </UserMenuLink>
           )}
           {/* spec-444: always-visible rewatch entry — present regardless of dismissal state. */}
-          <Link
-            to="/welcome?rewatch=1"
-            onClick={() => setOpen(false)}
-            className="block w-full text-left px-3 py-2 text-sm transition-colors text-secondary hover:text-primary hover:bg-overlay"
-          >
+          <UserMenuLink to="/welcome?rewatch=1" icon={<PlayCircleIcon />} onClick={() => setOpen(false)}>
             Watch intro video
-          </Link>
+          </UserMenuLink>
+          <UserMenuDivider />
           <button
             onClick={() => {
               setOpen(false);
               onLogout();
             }}
-            className="w-full text-left px-3 py-2 text-sm transition-colors text-secondary hover:text-primary hover:bg-overlay"
+            className={USER_MENU_DANGER_CLASS}
           >
+            <LogoutIcon />
             Sign out
           </button>
         </div>

--- a/packages/ui/src/components/AppShell.tsx
+++ b/packages/ui/src/components/AppShell.tsx
@@ -425,7 +425,12 @@ function SidebarUserCard({
   const wrapperRef = useRef<HTMLDivElement>(null);
   // spec-200: this card is the fly-home target for the What's New ribbon, and
   // hosts the "What's New" menu item that re-opens the popup.
-  const { available: whatsNewAvailable, openPopup: openWhatsNew, registerMenuAnchor } = useWhatsNew();
+  const {
+    available: whatsNewAvailable,
+    hasUnseen: whatsNewHasUnseen,
+    openPopup: openWhatsNew,
+    registerMenuAnchor,
+  } = useWhatsNew();
 
   useEffect(() => {
     registerMenuAnchor(wrapperRef.current);
@@ -499,9 +504,13 @@ function SidebarUserCard({
               <button
                 data-testid="user-menu-whats-new"
                 onClick={(e) => {
-                  // The gift's confetti fires from its own icon canvas, then the
-                  // What's New popup opens (behaviour unchanged from the flat menu).
-                  burstWhatsNewConfetti(e.currentTarget.querySelector('canvas'));
+                  // The gift's confetti fires from its own icon canvas — but only
+                  // when there's an unread entry (spec-456), so re-opening the popup
+                  // for already-seen notes stays quiet. Then the What's New popup
+                  // opens (behaviour unchanged from the flat menu).
+                  if (whatsNewHasUnseen) {
+                    burstWhatsNewConfetti(e.currentTarget.querySelector('canvas'));
+                  }
                   setOpen(false);
                   openWhatsNew();
                 }}

--- a/packages/ui/src/components/whats-new/WhatsNewContext.tsx
+++ b/packages/ui/src/components/whats-new/WhatsNewContext.tsx
@@ -27,6 +27,12 @@ interface WhatsNewContextValue {
   available: boolean;
   /** The ribbon reports feed availability here. */
   setAvailable: (v: boolean) => void;
+  /** True when the newest entry is newer than the user's dismiss marker — i.e.
+   *  there's unread content. spec-456: gates the menu item's confetti so the
+   *  flourish only fires for genuinely-new entries, not on every popup re-open. */
+  hasUnseen: boolean;
+  /** The ribbon reports unread state here. */
+  setHasUnseen: (v: boolean) => void;
   /** Open the What's New popup (used by the sidebar menu item). */
   openPopup: () => void;
   /** The ribbon registers the handler that openPopup() invokes. */
@@ -42,6 +48,8 @@ const noop = () => {};
 const WhatsNewContext = createContext<WhatsNewContextValue>({
   available: false,
   setAvailable: noop,
+  hasUnseen: false,
+  setHasUnseen: noop,
   openPopup: noop,
   registerOpener: noop,
   registerMenuAnchor: noop,
@@ -50,6 +58,7 @@ const WhatsNewContext = createContext<WhatsNewContextValue>({
 
 export function WhatsNewProvider({ children }: { children: ReactNode }) {
   const [available, setAvailable] = useState(false);
+  const [hasUnseen, setHasUnseen] = useState(false);
   const openerRef = useRef<(() => void) | null>(null);
   const anchorRef = useRef<HTMLElement | null>(null);
 
@@ -63,8 +72,17 @@ export function WhatsNewProvider({ children }: { children: ReactNode }) {
   const getMenuAnchor = useCallback(() => anchorRef.current, []);
 
   const value = useMemo<WhatsNewContextValue>(
-    () => ({ available, setAvailable, openPopup, registerOpener, registerMenuAnchor, getMenuAnchor }),
-    [available, openPopup, registerOpener, registerMenuAnchor, getMenuAnchor],
+    () => ({
+      available,
+      setAvailable,
+      hasUnseen,
+      setHasUnseen,
+      openPopup,
+      registerOpener,
+      registerMenuAnchor,
+      getMenuAnchor,
+    }),
+    [available, hasUnseen, openPopup, registerOpener, registerMenuAnchor, getMenuAnchor],
   );
 
   return <WhatsNewContext.Provider value={value}>{children}</WhatsNewContext.Provider>;

--- a/packages/ui/src/components/whats-new/WhatsNewRibbon.tsx
+++ b/packages/ui/src/components/whats-new/WhatsNewRibbon.tsx
@@ -73,7 +73,7 @@ export function WhatsNewRibbon({
   fetcher = fetchWhatsNew,
   autoDismissMs = AUTO_DISMISS_MS,
 }: WhatsNewRibbonProps) {
-  const { setAvailable, registerOpener, getMenuAnchor } = useWhatsNew();
+  const { setAvailable, setHasUnseen, registerOpener, getMenuAnchor } = useWhatsNew();
   const { track } = useTelemetry(true);
 
   const [entries, setEntries] = useState<WhatsNewEntry[]>([]);
@@ -135,6 +135,15 @@ export function WhatsNewRibbon({
   useEffect(() => {
     setAvailable(entries.length > 0);
   }, [entries.length, setAvailable]);
+
+  // spec-456: report unread state so the menu item only confetti's for a
+  // genuinely-new entry. Same "unread" basis as fireOpened's unreadCount — the
+  // newest entry newer than the dismiss marker. Re-runs on dismiss (which
+  // advances the marker), flipping this back to false. Reduced-motion is handled
+  // downstream in the burst fn, not here.
+  useEffect(() => {
+    setHasUnseen(!!newest && Date.parse(newest.publishedAt) > readMarker(DISMISS_KEY));
+  }, [newest, dismissed, setHasUnseen]);
 
   // Engagement with release notes (spec-200). Count only — entries still newer
   // than the user's dismiss marker at the moment the popup opens.

--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -640,6 +640,51 @@
   }
 }
 
+/* spec-456 — the "What's New" account-menu row is the menu's one deliberately
+   playful moment. On hover/focus the gift lid tilts open ("unwrap") and a small
+   sparkle peeks out; the click-time confetti burst is drawn in a <canvas> by
+   burstWhatsNewConfetti() in AppShell.tsx. transform-box:fill-box makes each
+   SVG part rotate/scale about its own box rather than the whole SVG viewport.
+   Reduced-motion users get an instant, motionless state: no lid tilt, no scale. */
+.wn-lid {
+  transform-box: fill-box;
+  transform-origin: 28% 92%;
+  transition: transform 0.22s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+.wn-sparkle {
+  transform-box: fill-box;
+  transform-origin: center;
+  opacity: 0;
+  transform: scale(0.4);
+  transition:
+    opacity 0.2s ease,
+    transform 0.2s ease;
+}
+.group:hover .wn-lid,
+.group:focus-visible .wn-lid {
+  transform: rotate(-20deg) translateY(-0.5px);
+}
+.group:hover .wn-sparkle,
+.group:focus-visible .wn-sparkle {
+  opacity: 1;
+  transform: scale(1);
+}
+@media (prefers-reduced-motion: reduce) {
+  .wn-lid,
+  .wn-sparkle {
+    transition: none;
+  }
+  .group:hover .wn-lid,
+  .group:focus-visible .wn-lid {
+    transform: none;
+  }
+  .group:hover .wn-sparkle,
+  .group:focus-visible .wn-sparkle {
+    opacity: 0;
+    transform: scale(0.4);
+  }
+}
+
 /* spec-372 — Home Onboarding v3 fonts + accent, SELF-HOSTED and SCOPED to the onboarding
    surface. The v3 design re-cut the onboarding type to Inter (spec-336 used Hanken Grotesk)
    and the accent to #0482DC. Inter is SELF-HOSTED because the app base stack is system-first


### PR DESCRIPTION
## What & why

Restructures the sidebar account dropdown (`SidebarUserCard` in `packages/ui/src/components/AppShell.tsx`). Today it's a flat, unstyled list whose only visual anchor is a lone 🎁 emoji. Same **7 destinations, same order — nothing added, removed, or re-routed** — just structure.

Spec: [spec-456](https://memex.ai/mindset-prod/memex-building-itself/specs/spec-456) · design reviewed with Ryan across two mocks (grouped before/after, then the What's New micro-interaction options).

## Changes

- **Four groups, divided by thin rules:** (1) What's New, (2) Memex settings · Memex keys · Org configuration · Integrations, (3) Watch intro video (+ dev-only Email preview), (4) Sign out.
- **A leading line icon on every row** (gift, gear, key, building, link, play-circle, logout) in the heroicons-outline convention already used by the theme toggle. The standalone 🎁 emoji becomes a matching gift icon so it stops reading like a promo badge.
- **Sign out** set apart by its own divider + a danger hover (`hover:text-status-danger-text`) so a destructive action reads differently from the settings links.
- **What's New micro-interaction** (the menu's one playful moment): hover unwraps the gift lid with a sparkle peek; click fires a short confetti burst from the icon before the existing popup opens. Both gated by `prefers-reduced-motion` → instant, motionless fallback.
- Extracted `UserMenuLink` / `UserMenuDivider` + shared row classes to kill the duplicated Tailwind strings.

**Why nothing collapses:** the existing separations are deliberate — Memex settings (admin-only) vs Memex keys (any writing member) are split by permission tier (spec-129 dec-8); Org configuration is org-scoped, hidden on personal Memexes, and carries its own tab bar; Integrations is the page spec-141 consolidated from three routes.

## Testing

- **New:** `AppShell.spec-456.test.tsx` — 6 vitest+RTL tests, one tagged to each of ac-1..ac-6. All green; **all 6 ACs verified on the board (100%)**.
- **Regression:** existing `AppShell.test.tsx` / `spec-141` / `spec-129` suites unchanged (26 pass, 1 skip). Full UI unit suite green apart from 4 failures that are **pre-existing on develop** (verified by stashing this change — identical failures), unrelated to this diff.
- **e2e (`make e2e-cold`):** journey-53 (opens this dropdown → "Watch intro video") passes. 128 passed; the 1 failure (journey-45, MCP session-mint, unrelated) passes in isolation — the known different-journey-each-run flake.
- Typecheck + Biome clean on the changed files. Ran locally via `start-memex.sh` to eyeball the grouping + micro-interaction.

## Notes

- UI-only; no back-end, schema, routes, or auth touched.
- CSS (`.wn-*` + reduced-motion block) added to `index.css` following its existing keyframe convention.
- Out of scope (raised, deliberately deferred): collapsing "What's New" + "Watch intro video" into one "Help" entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)