### PR TITLE
fix(spec-453): /api/internal/lifecycle-tick 404s behind the tenant resolver

### DIFF
--- a/packages/server/src/middleware/memex-resolver.test.ts
+++ b/packages/server/src/middleware/memex-resolver.test.ts
@@ -18,6 +18,7 @@ vi.mock("../db/connection.js", () => ({
 }));
 
 import { Hono } from "hono";
+import { tagAc } from "@memex-ai-ac/vitest";
 import { memexResolver, parseMemexPath } from "./memex-resolver.js";
 
 const app = new Hono();
@@ -54,6 +55,14 @@ describe("parseMemexPath", () => {
   it("returns null for reserved API roots", () => {
     expect(parseMemexPath("/api/orgs/check")).toBeNull();
     expect(parseMemexPath("/api/health")).toBeNull();
+  });
+
+  it("treats /api/internal/* as non-tenant, not namespace=internal (spec-453 t-6)", () => {
+    // Regression: /api/internal/lifecycle-tick has two segments, so without the
+    // reserved-root entry it resolves as namespace=internal / memex=lifecycle-tick and
+    // 404s before the scheduler endpoint runs. Must parse to null (non-tenant).
+    tagAc("mindset-prod/memex-building-itself/specs/spec-453/acs/ac-20");
+    expect(parseMemexPath("/api/internal/lifecycle-tick")).toBeNull();
   });
 });
 

--- a/packages/server/src/middleware/memex-resolver.ts
+++ b/packages/server/src/middleware/memex-resolver.ts
@@ -56,6 +56,8 @@ const NON_TENANT_API_PREFIXES = [
   "/api/oauth",
   "/api/onboarding/",
   "/api/onboarding", // exact — spec-206 first-run greeting gate (user-level)
+  "/api/internal/",
+  "/api/internal", // exact — spec-453 t-6 machine lifecycle tick (non-tenant, scheduler-only)
   "/api/install",
   "/install.sh",
   "/install.ps1",
@@ -124,6 +126,12 @@ const RESERVED_API_ROOTS = new Set([
   // before the webhook router runs, so Postmark deliveries never update comms_log.
   // (Same class of bug as spec-171's "stripe" entry.)
   "postmark",
+  // spec-453 t-6: the machine lifecycle-tick mounts at /api/internal/lifecycle-tick
+  // (non-tenant; a shared bearer secret is the auth). Without this, parseMemexPath reads
+  // "/api/internal/lifecycle-tick" as namespace=internal / memex=lifecycle-tick and 404s
+  // before the router runs, so Cloud Scheduler could never trigger the drip / Day-12 pass.
+  // (Same class of bug as the stripe / postmark webhook entries above.)
+  "internal",
 ]);
 
 // Parses `/<namespace>/<memex>/...` or `/api/<namespace>/<memex>/...` from a


### PR DESCRIPTION
## Problem
The t-6 scheduler endpoint (`POST /api/internal/lifecycle-tick`, PR #493) **404s in the deployed app**. `/api/internal/lifecycle-tick` has two segments after `/api`, so `memexResolver` reads it as `namespace=internal` / `memex=lifecycle-tick`, fails to resolve, and returns 404 **before** the router runs.

Caught by a live int sanity check (POST → **404**, not the expected fail-closed **401**). The t-6 unit/integration tests mounted the router on a bare Hono app **without** `memexResolver`, so they gave a false green — the classic "test doesn't exercise the real middleware stack" gap.

## Fix
Reserve `internal` as a non-tenant API root — the exact same fix already applied for the `stripe` / `postmark` webhook receivers:
- add `internal` to `RESERVED_API_ROOTS` (so `parseMemexPath` returns null → non-tenant),
- add `/api/internal` + `/api/internal/` to `NON_TENANT_API_PREFIXES` (fast-skip).

## Test
Regression assertion in `memex-resolver.test.ts`: `parseMemexPath("/api/internal/lifecycle-tick")` is null (non-tenant), tagged **ac-20**. Resolver suite 12/12, `tsc` clean.

Unblocks the spec-453 int rollout (the endpoint must be reachable for the Cloud Scheduler provisioning).