### PR TITLE
fix(spec-453): harden the lifecycle-scheduler provisioning script

### DIFF
--- a/scripts/deploy-lifecycle-scheduler.sh
+++ b/scripts/deploy-lifecycle-scheduler.sh
@@ -16,8 +16,9 @@
 # comms_log key), so the secret is defense-in-depth. NOTE: a Cloud Scheduler header value is
 # stored in the job config (readable with cloudscheduler.jobs.get — project-admin IAM). That
 # is the accepted trade-off of the shared-secret transport; the OIDC alternative (an
-# invoker SA + in-app token verification) avoids storing it but adds a dependency. Raw secret
-# VALUES never live in this repo — seed them into Secret Manager separately (see below).
+# invoker SA + in-app token verification) avoids storing it but adds a dependency. No raw
+# secret VALUE lives in this repo — the script generates one with openssl at runtime and
+# seeds it into Secret Manager on first provisioning (idempotent; never rotates thereafter).
 #
 # Idempotent — safe to re-run; creates what's missing, updates otherwise.
 #
@@ -32,7 +33,6 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 source "${REPO_ROOT}/scripts/deploy-config.sh" "$ENV"
 
 SCHED="memex-lifecycle-daily"
-SCHED_SA="lifecycle-scheduler@${GCP_PROJECT}.iam.gserviceaccount.com"
 SECRET_NAME="lifecycle-tick-secret"
 TICK_URL="${API_BASE_URL}/api/internal/lifecycle-tick"
 # Daily at 09:17 UTC — an off-round minute (dodges top-of-hour load), once a day (the
@@ -41,16 +41,38 @@ CRON="${LIFECYCLE_CRON:-17 9 * * *}"
 
 echo "▸ env=${ENV} project=${GCP_PROJECT} region=${REGION} url=${TICK_URL}"
 
-# ── Scheduler invoker service account ───────────────────────────────────────
-gcloud iam service-accounts describe "$SCHED_SA" --project "$GCP_PROJECT" >/dev/null 2>&1 || \
-  gcloud iam service-accounts create lifecycle-scheduler --project "$GCP_PROJECT" \
-    --display-name "spec-453 lifecycle Cloud Scheduler"
+# ── Required APIs (idempotent) ──────────────────────────────────────────────
+# Cloud Scheduler is often disabled on a fresh project (it was on int at first
+# provisioning). A header-based HTTP target needs NO invoker service account, so
+# none is created — the shared bearer secret is the auth.
+gcloud services enable cloudscheduler.googleapis.com secretmanager.googleapis.com \
+  --project "$GCP_PROJECT"
 
-# ── Secret container for LIFECYCLE_TICK_SECRET (VALUE seeded separately) ─────
+# ── Secret LIFECYCLE_TICK_SECRET (container + a value) ──────────────────────
 # Org policy forbids 'global' secrets → pin replication to the project region.
 gcloud secrets describe "$SECRET_NAME" --project "$GCP_PROJECT" >/dev/null 2>&1 || \
   gcloud secrets create "$SECRET_NAME" --project "$GCP_PROJECT" \
     --replication-policy user-managed --locations "$REGION"
+# Seed a strong random value on first provisioning so the service can mount the secret
+# and the scheduler has a token to send. IDEMPOTENT: only adds a version when none
+# exists, so re-runs never rotate the live secret. (openssl generates at runtime; no raw
+# secret ever lands in this repo.)
+if ! gcloud secrets versions list "$SECRET_NAME" --project "$GCP_PROJECT" --limit 1 \
+       --format='value(name)' 2>/dev/null | grep -q .; then
+  printf '%s' "$(openssl rand -base64 32)" | \
+    gcloud secrets versions add "$SECRET_NAME" --project "$GCP_PROJECT" --data-file=-
+fi
+# The Cloud Run runtime SA must be able to READ the secret. It usually already holds
+# project-level secretAccessor (it reads other secrets the same way), so this per-secret
+# grant is belt-and-suspenders — NON-FATAL so a project with the project-level grant (or a
+# gcloud build that dislikes this verb) never aborts provisioning.
+RUNTIME_SA="$(gcloud run services describe "$SERVICE" --project "$GCP_PROJECT" --region "$REGION" \
+  --format='value(spec.template.spec.serviceAccountName)' 2>/dev/null || true)"
+if [ -n "$RUNTIME_SA" ]; then
+  gcloud secrets add-iam-policy-binding "$SECRET_NAME" --project "$GCP_PROJECT" \
+    --member "serviceAccount:${RUNTIME_SA}" --role roles/secretmanager.secretAccessor >/dev/null 2>&1 \
+    || echo "▸ warn: could not grant secretAccessor to ${RUNTIME_SA} (likely already has project-level access — continuing)"
+fi
 
 # ── Wire the secret into the Cloud Run service (env var LIFECYCLE_TICK_SECRET) ─
 # --update-secrets is additive (leaves the service's other env/secrets intact). The service
@@ -74,22 +96,21 @@ if [ "${SKIP_SCHEDULER:-0}" != "1" ]; then
     --uri "$TICK_URL" --http-method POST \
     --headers "Authorization=Bearer ${SECRET_VAL}"
 else
-  echo "▸ SKIP_SCHEDULER=1 — scheduler not created (seed the secret + set ACTIVATION_CONNECT_GO_LIVE first)"
+  echo "▸ SKIP_SCHEDULER=1 — scheduler not created (set ACTIVATION_CONNECT_GO_LIVE, then re-run)"
 fi
 
 cat <<NOTE
 
-✅ Infra applied. Remaining operator steps (values never live in this repo):
-  1. Seed the tick secret (once):
-       printf '%s' "\$(openssl rand -base64 32)" | \\
-         gcloud secrets versions add ${SECRET_NAME} --project ${GCP_PROJECT} --data-file=-
-     Then re-run this script WITHOUT SKIP_SCHEDULER so the scheduler picks up the value.
-  2. Set the Connect go-live instant on the service — the SAME moment t-1's migration
+✅ Infra applied (APIs enabled, secret created + seeded, secret wired to the service,
+   scheduler ${SKIP_SCHEDULER:+NOT }created). Remaining operator steps:
+  1. Set the Connect go-live instant on the service — the SAME moment t-1's migration
      backfilled users.first_ac_verified_at (deploy time), so both emails agree on go-live:
        gcloud run services update ${SERVICE} --project ${GCP_PROJECT} --region ${REGION} \\
          --update-env-vars ACTIVATION_CONNECT_GO_LIVE=<deploy-timestamp-ISO8601>
      (or set ACTIVATION_CONNECT_GO_LIVE in the per-env deploy config so deploy.sh carries it).
-  3. Flip ACTIVATION_EMAILS_ENABLED=1 when ready to send (spec-427 master switch).
+     Unset → the tick SKIPS the Connect pass (drip still runs); never a back-catalog blast.
+  2. Flip ACTIVATION_EMAILS_ENABLED=1 when ready to send (spec-427 master switch).
 
-Nothing sends until ACTIVATION_EMAILS_ENABLED is on; the tick is a no-op before then.
+Smoke: an unauth POST to the tick URL returns 401; an authed POST (Bearer = the secret)
+returns 200 with zero sends while the flag is off. Nothing sends until the flag is on.
 NOTE


### PR DESCRIPTION
Follow-up to the spec-453 int rollout. Provisioning int by hand surfaced three gaps in `scripts/deploy-lifecycle-scheduler.sh` (the prod runbook) — it only succeeded because I filled them manually:

- **Enable the APIs up front** (`cloudscheduler.googleapis.com`, `secretmanager.googleapis.com`). Cloud Scheduler was **disabled** on int → `scheduler jobs create` failed `SERVICE_DISABLED`. Prod likely too.
- **Drop the unused invoker service account.** A header-based HTTP target needs no SA (the shared bearer secret is the auth); the script created one but never used it.
- **Auto-seed the secret** with a random `openssl` value on first run (idempotent — never rotates). Removes the "seed then re-run" dance and the empty-secret revision-mount failure.
- **Grant the runtime SA `secretAccessor`** on the secret, **non-fatal** (it usually already holds project-level access, as on int; a fresh project now gets covered without aborting on the grant).

## Verified on int (live)
Endpoint deployed, `unauth → 401`, `authed → 200` with both passes running (zero sends while `ACTIVATION_EMAILS_ENABLED` is off), Cloud Scheduler `memex-lifecycle-daily` created + fires successfully. This PR makes the **prod** run reproduce that without manual intervention.

No app code; script-only. `bash -n` clean.