### PR TITLE
fix(home): pluralise Memexes in Home subtitle copy

### DIFF
--- a/packages/ui/src/pages/HomeCanvas.tsx
+++ b/packages/ui/src/pages/HomeCanvas.tsx
@@ -354,7 +354,7 @@ export function HomeCanvas() {
           Home
         </h1>
         <p className="mt-2 text-lg text-secondary">
-          Keep updated with the things that need your attention across all your Personal and Organisational Memex&apos;s
+          Keep updated with the things that need your attention across all your Personal and Organisational Memexes
         </p>
       </div>
 


### PR DESCRIPTION
## What

One-line copy fix on the Home page subtitle:

> Keep updated with the things that need your attention across all your Personal and Organisational ~~Memex's~~ **Memexes**

The apostrophe-s was a possessive on what should be a plural.

## Testing

- `make e2e-cold`: 128 passed; the single failure (`journey-45-spec-304-mcp-session-mint`) is the known intermittent flake — re-run in isolation with `--retries=2`, 2/2 passed.
- No tests assert the old copy string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)