### PR TITLE
spec-460: welcome video v4 + post-video CTAs (in-app) — DO NOT MERGE until website PR #45 is live

### DIFF
--- a/packages/shared/src/usage-events-registry.ts
+++ b/packages/shared/src/usage-events-registry.ts
@@ -229,6 +229,54 @@ export const USAGE_EVENT_REGISTRY = [
       "The user dismissed/skipped the first-run welcome video BEFORE completion (WelcomePage Get-started / Skip / × close, spec-444). Fires at most once per view and only when the video has not already completed. props.video_id, props.position_seconds, props.duration_seconds, props.percent_watched (0–100, NaN-guarded) — counts only.",
     source: "frontend",
   },
+  {
+    name: "onboarding.video_call_cta_shown",
+    description:
+      "The 'book a call' line on the welcome video revealed once the viewer crossed ~85% of the v4 video, or it ended (WelcomePage, spec-460). Fires at most once per view. props.video_id, props.position_seconds, props.duration_seconds, props.percent_watched — counts only.",
+    source: "frontend",
+  },
+  {
+    name: "onboarding.video_call_cta_clicked",
+    description:
+      "The viewer clicked the revealed 'book a 30-minute call' link on the welcome video (WelcomePage, spec-460), opening the /book-a-call alias in a new tab. props.video_id + playback counts only.",
+    source: "frontend",
+  },
+  {
+    name: "getting_started.card_shown",
+    description:
+      "The Getting Started sidebar card became visible for the first time this session (AppShell, spec-460). Fires at most once per session. No content props — counts only.",
+    source: "frontend",
+  },
+  {
+    name: "getting_started.app_row_clicked",
+    description:
+      "The user clicked the 'Get the desktop app' row in the Getting Started card (spec-460), opening the /download page. Counts only.",
+    source: "frontend",
+  },
+  {
+    name: "getting_started.call_row_clicked",
+    description:
+      "The user clicked the 'Book a 30-min call' row in the Getting Started card (spec-460), opening the /book-a-call alias. Counts only.",
+    source: "frontend",
+  },
+  {
+    name: "getting_started.call_row_dismissed",
+    description:
+      "The user dismissed the 'Book a 30-min call' row (× ) in the Getting Started card (spec-460). Counts only.",
+    source: "frontend",
+  },
+  {
+    name: "getting_started.card_dismissed",
+    description:
+      "The user dismissed the whole Getting Started card (card-level ×) (spec-460). Counts only.",
+    source: "frontend",
+  },
+  {
+    name: "getting_started.app_row_retired",
+    description:
+      "The desktop-app row retired itself because the user's MCP is connected (spec-434 milestone observed, spec-460). Fires at most once per session. Counts only.",
+    source: "frontend",
+  },
   // ── Back-end outcomes (whitelisted mutate() events, dec-8) ───────────────────
   // Name is EXACTLY `${entity}.${action}` so the t-3 whitelist maps 1:1.
   {

--- a/packages/ui/e2e/journey-54-spec-460-welcome-ctas.spec.ts
+++ b/packages/ui/e2e/journey-54-spec-460-welcome-ctas.spec.ts
@@ -1,0 +1,119 @@
+// Journey 54 — spec-460: welcome video v4 + post-video CTAs.
+//
+// Extends the spec-444 welcome arc (journey-53) with the spec-460 additions,
+// exercised against the running app:
+//   - the /welcome video src is the v4 asset (ac-1)
+//   - the "book a call" line is hidden during playback and revealed once the
+//     viewer crosses ~85%, linking to the booking alias in a new tab (ac-2)
+//   - the Getting Started sidebar card shows its rows and dismissal persists
+//     across a reload; dismissing every row unmounts the card (ac-3, ac-4)
+//   - the avatar dropdown carries the Download desktop app + Book a call
+//     fallbacks (ac-6)
+//
+// The download page + booking redirect themselves live on the marketing site
+// (memex-website) and are verified there; ac-5 is not exercised here.
+
+import {
+  test,
+  expect,
+  bareUrl,
+  gotoSpecsBoard,
+  setVideoWelcomed,
+  emitAcEvents,
+  DEV_EMAIL,
+} from "./helpers/index.js";
+
+const ACS = [
+  "mindset-prod/memex-building-itself/specs/spec-460/acs/ac-1",
+  "mindset-prod/memex-building-itself/specs/spec-460/acs/ac-2",
+  "mindset-prod/memex-building-itself/specs/spec-460/acs/ac-3",
+  "mindset-prod/memex-building-itself/specs/spec-460/acs/ac-4",
+  "mindset-prod/memex-building-itself/specs/spec-460/acs/ac-6",
+];
+
+test.afterEach(async ({}, testInfo) => {
+  if (testInfo.status === "skipped") return;
+  await emitAcEvents(
+    ACS,
+    testInfo.status === "passed" ? "pass" : "fail",
+    `packages/ui/e2e/journey-54-spec-460-welcome-ctas.spec.ts::${testInfo.title}`,
+    testInfo.duration,
+  );
+});
+
+test(
+  "/welcome plays the v4 video (ac-1) and reveals the book-a-call line near the end (ac-2)",
+  async ({ page }) => {
+    await setVideoWelcomed(DEV_EMAIL, false);
+    await page.goto(bareUrl("/"), { waitUntil: "commit" });
+    await expect(page).toHaveURL(/\/welcome/, { timeout: 15_000 });
+
+    // ac-1: the video src is the v4 asset on the public CDN.
+    const videoSrc = await page.getByTestId("welcome-video-player").getAttribute("src");
+    expect(videoSrc).toContain("welcome-to-memex-v4.mp4");
+
+    // ac-2: the call line is hidden during playback.
+    const callCta = page.getByTestId("welcome-video-call-cta");
+    await expect(callCta).toHaveAttribute("aria-hidden", "true");
+
+    // Drive the <video> past the 85% reveal threshold and fire timeupdate. jsdom
+    // can't decode the media, so we set the numbers directly and dispatch the event
+    // the component listens on (matches how the unit test stubs playback).
+    await page.getByTestId("welcome-video-player").evaluate((el) => {
+      const v = el as HTMLVideoElement;
+      Object.defineProperty(v, "duration", { value: 100, configurable: true });
+      Object.defineProperty(v, "currentTime", { value: 90, configurable: true });
+      v.dispatchEvent(new Event("timeupdate"));
+    });
+
+    await expect(callCta).toHaveAttribute("aria-hidden", "false", { timeout: 5_000 });
+    const link = callCta.getByRole("link", { name: /book a 30-minute call/i });
+    await expect(link).toHaveAttribute("href", "https://www.memex.ai/book-a-call?src=welcome-video");
+    await expect(link).toHaveAttribute("target", "_blank");
+
+    // The primary path to /specs is unchanged (no interstitial).
+    await page.getByTestId("welcome-video-cta").click();
+    await expect(page).toHaveURL(/\/specs/, { timeout: 15_000 });
+  },
+);
+
+test(
+  "Getting Started card shows its rows and dismissal persists across reload; card unmounts when empty (ac-3, ac-4)",
+  async ({ page }) => {
+    await gotoSpecsBoard(page);
+
+    // ac-3: the card is present with the book-a-call row (the dev user is not
+    // MCP-connected in the cold DB, so the desktop-app row shows too).
+    const card = page.getByTestId("getting-started-card");
+    await expect(card).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByTestId("getting-started-call-row")).toBeVisible();
+
+    // ac-4: dismiss the call row; it goes and stays gone across a reload (localStorage).
+    await page.getByTestId("getting-started-dismiss-call").click();
+    await expect(page.getByTestId("getting-started-call-row")).toHaveCount(0);
+    await page.reload({ waitUntil: "commit" });
+    await expect(page.getByTestId("getting-started-call-row")).toHaveCount(0, { timeout: 10_000 });
+
+    // Dismiss the whole card; it unmounts and stays gone across a reload.
+    await page.getByTestId("getting-started-dismiss-card").click();
+    await expect(page.getByTestId("getting-started-card")).toHaveCount(0);
+    await page.reload({ waitUntil: "commit" });
+    await expect(page.getByTestId("getting-started-card")).toHaveCount(0, { timeout: 10_000 });
+  },
+);
+
+test(
+  "avatar dropdown carries the Download desktop app + Book a call fallbacks (ac-6)",
+  async ({ page }) => {
+    await gotoSpecsBoard(page);
+
+    await page.getByRole("button", { name: /Dev User/i }).click();
+
+    const download = page.getByTestId("user-menu-download-app");
+    const book = page.getByTestId("user-menu-book-a-call");
+    await expect(download).toBeVisible({ timeout: 5_000 });
+    await expect(download).toHaveAttribute("href", "https://www.memex.ai/download?src=account-menu");
+    await expect(book).toBeVisible();
+    await expect(book).toHaveAttribute("href", "https://www.memex.ai/book-a-call?src=account-menu");
+  },
+);

--- a/packages/ui/src/components/AppShell.spec-460.test.tsx
+++ b/packages/ui/src/components/AppShell.spec-460.test.tsx
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { ThemeProvider } from './ThemeContext';
+
+// spec-460 ac-18: the account menu carries always-present "Download desktop app"
+// and "Book a call" fallbacks so dismissing the Getting Started card never loses
+// either action.
+const AC_MENU_FALLBACKS = 'mindset-prod/memex-building-itself/specs/spec-460/acs/ac-18';
+
+const { logoutSpy } = vi.hoisted(() => ({ logoutSpy: vi.fn() }));
+
+const TEAM_ADMIN = {
+  memexId: 'm1',
+  slug: 'acme',
+  memexSlug: 'team',
+  name: 'Acme Inc',
+  memexName: 'Team',
+  kind: 'team' as const,
+  role: 'administrator' as const,
+};
+
+const session = {
+  user: { id: 'u1', name: 'Tester', email: 't@acme.test' },
+  memberships: [TEAM_ADMIN],
+  currentMemexId: 'm1',
+};
+
+vi.mock('./AuthContext', () => ({
+  useAuth: () => ({
+    user: { id: 'u1', name: 'Tester', email: 't@acme.test' },
+    session,
+    logout: logoutSpy,
+  }),
+}));
+
+vi.mock('./whats-new/WhatsNewContext', () => ({
+  useWhatsNew: () => ({
+    available: true,
+    hasUnseen: false,
+    openPopup: vi.fn(),
+    registerMenuAnchor: vi.fn(),
+  }),
+}));
+
+vi.mock('./MemexSwitcher', () => ({ MemexSwitcher: () => <div data-testid="memex-switcher" /> }));
+vi.mock('./InviteMembersDialog', () => ({ InviteMembersDialog: () => <div data-testid="invite-dialog" /> }));
+vi.mock('../hooks/useMemexAccess', () => ({
+  useMemexAccess: () => ({ isAuthenticated: true, isVisitedReadOnly: false }),
+}));
+vi.mock('../hooks/useDriftInboxCount', () => ({ useDriftInboxCount: () => 0 }));
+
+// Keep the Getting Started card out of the way for this menu test: seed it as
+// connected (app row retired) so it doesn't fire a real journey fetch.
+vi.mock('../journeys/journeyStateCache', () => ({
+  getCachedJourneyState: () => ({ milestones: { mcpConnected: true } }),
+}));
+vi.mock('../api/journey', () => ({
+  fetchJourneyStateApi: () => Promise.resolve({ milestones: { mcpConnected: true } }),
+}));
+vi.mock('../hooks/useTelemetry', () => ({
+  useTelemetry: () => ({ track: vi.fn(), optedOut: false, setOptOut: vi.fn() }),
+}));
+
+import { AppShell } from './AppShell';
+
+function openMenu() {
+  render(
+    <ThemeProvider>
+      <MemoryRouter initialEntries={['/acme/team/specs']}>
+        <AppShell>
+          <div data-testid="page-content">page</div>
+        </AppShell>
+      </MemoryRouter>
+    </ThemeProvider>,
+  );
+  fireEvent.click(screen.getByText('Tester'));
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('spec-460: account-menu fallback rows (ac-18)', () => {
+  it('shows Download desktop app + Book a call, pointing at the marketing pages with ?src=account-menu', () => {
+    tagAc(AC_MENU_FALLBACKS);
+    openMenu();
+
+    const download = screen.getByTestId('user-menu-download-app');
+    const book = screen.getByTestId('user-menu-book-a-call');
+
+    expect(download).toHaveTextContent('Download desktop app');
+    expect(download).toHaveAttribute('href', 'https://www.memex.ai/download?src=account-menu');
+    expect(download).toHaveAttribute('target', '_blank');
+    expect(download).toHaveAttribute('rel', 'noopener noreferrer');
+
+    expect(book).toHaveTextContent('Book a call');
+    expect(book).toHaveAttribute('href', 'https://www.memex.ai/book-a-call?src=account-menu');
+    expect(book).toHaveAttribute('target', '_blank');
+    expect(book).toHaveAttribute('rel', 'noopener noreferrer');
+
+    // Each row carries an icon, matching the spec-456 menu convention.
+    expect(download.querySelector('svg')).not.toBeNull();
+    expect(book.querySelector('svg')).not.toBeNull();
+  });
+
+  it('keeps the rows present regardless of Getting Started card state (always-on fallback)', () => {
+    tagAc(AC_MENU_FALLBACKS);
+    // Card is retired (mcpConnected) in this harness; the menu rows must still exist.
+    openMenu();
+    expect(screen.getByTestId('user-menu-download-app')).toBeInTheDocument();
+    expect(screen.getByTestId('user-menu-book-a-call')).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/AppShell.spec-460.test.tsx
+++ b/packages/ui/src/components/AppShell.spec-460.test.tsx
@@ -85,6 +85,7 @@ afterEach(() => {
 describe('spec-460: account-menu fallback rows (ac-18)', () => {
   it('shows Download desktop app + Book a call, pointing at the marketing pages with ?src=account-menu', () => {
     tagAc(AC_MENU_FALLBACKS);
+    tagAc('mindset-prod/memex-building-itself/specs/spec-460/acs/ac-20'); // account-menu booking alias + src
     openMenu();
 
     const download = screen.getByTestId('user-menu-download-app');

--- a/packages/ui/src/components/AppShell.tsx
+++ b/packages/ui/src/components/AppShell.tsx
@@ -12,6 +12,7 @@ import { useHiddenFeatures } from '../hooks/useIsFeatureHidden';
 import { MemexSwitcher } from './MemexSwitcher';
 import { InviteMembersDialog } from './InviteMembersDialog';
 import { PublicAuthButtons, ReadOnlyBadge } from './PublicAccessControls';
+import { GettingStartedCard } from './GettingStartedCard';
 import { useMemexAccess } from '../hooks/useMemexAccess';
 import { emailPreviewEnabled } from '../utils/devTools';
 import { HeaderSlotProvider, useHeaderSlotContent } from './HeaderSlot';
@@ -284,6 +285,25 @@ function LogoutIcon() {
   return (
     <svg className={MENU_ICON_CLASS} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.75} aria-hidden="true">
       <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 9V5.25A2.25 2.25 0 0013.5 3h-6a2.25 2.25 0 00-2.25 2.25v13.5A2.25 2.25 0 007.5 21h6a2.25 2.25 0 002.25-2.25V15M12 9l-3 3m0 0l3 3m-3-3h12.75" />
+    </svg>
+  );
+}
+
+// spec-460: desktop-download + book-a-call icons for the account-menu fallback rows.
+function DesktopDownloadIcon() {
+  return (
+    <svg className={MENU_ICON_CLASS} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.75} aria-hidden="true">
+      <rect x="2.75" y="4" width="18.5" height="12.5" rx="2" />
+      <path strokeLinecap="round" strokeLinejoin="round" d="M8 20.5h8M12 16.5v4" />
+    </svg>
+  );
+}
+
+function BookCallIcon() {
+  return (
+    <svg className={MENU_ICON_CLASS} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.75} aria-hidden="true">
+      <rect x="3" y="4.5" width="18" height="16" rx="2" />
+      <path strokeLinecap="round" strokeLinejoin="round" d="M3 9.5h18M8 2.5v4M16 2.5v4" />
     </svg>
   );
 }
@@ -565,6 +585,31 @@ function SidebarUserCard({
           <UserMenuLink to="/welcome?rewatch=1" icon={<PlayCircleIcon />} onClick={() => setOpen(false)}>
             Watch intro video
           </UserMenuLink>
+          {/* spec-460: long-tail fallbacks for the two CTAs — always present so
+              dismissing the Getting Started card never loses either action. External
+              marketing-site links (download page + booking alias), new tab. */}
+          <a
+            href="https://www.memex.ai/download?src=account-menu"
+            target="_blank"
+            rel="noopener noreferrer"
+            data-testid="user-menu-download-app"
+            onClick={() => setOpen(false)}
+            className={USER_MENU_ITEM_CLASS}
+          >
+            <DesktopDownloadIcon />
+            Download desktop app
+          </a>
+          <a
+            href="https://www.memex.ai/book-a-call?src=account-menu"
+            target="_blank"
+            rel="noopener noreferrer"
+            data-testid="user-menu-book-a-call"
+            onClick={() => setOpen(false)}
+            className={USER_MENU_ITEM_CLASS}
+          >
+            <BookCallIcon />
+            Book a call
+          </a>
           <UserMenuDivider />
           <button
             onClick={() => {
@@ -936,6 +981,9 @@ export function AppShell({ children }: { children: ReactNode }) {
           <div className="border-t border-edge p-3 space-y-2">
             {/* Read-only badge for a signed-in non-member on a public Memex. */}
             {access.isAuthenticated && access.isVisitedReadOnly && <ReadOnlyBadge />}
+            {/* spec-460: Getting Started card — desktop-app + book-a-call, above the
+                user card. Self-retiring; renders null once its rows are done/dismissed. */}
+            {user && <GettingStartedCard userId={user.id} />}
             {user && (
               <SidebarUserCard
                 user={user}

--- a/packages/ui/src/components/GettingStartedCard.test.tsx
+++ b/packages/ui/src/components/GettingStartedCard.test.tsx
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, act, within } from '@testing-library/react';
+import { tagAc } from '@memex-ai-ac/vitest';
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-460/acs/ac-${n}`;
+
+// Mutable journey state the mocked cache/fetch return, flipped per test.
+const { journey, track, fetchSpy } = vi.hoisted(() => ({
+  journey: {
+    value: null as null | { milestones: Record<string, boolean> },
+    // When set, the mount fetch returns this promise instead of resolving
+    // immediately — lets a test hold the card in its pre-resolve (no-flash) state.
+    pending: null as null | Promise<{ milestones: Record<string, boolean> }>,
+  },
+  track: vi.fn(),
+  fetchSpy: vi.fn(),
+}));
+
+vi.mock('../journeys/journeyStateCache', () => ({
+  getCachedJourneyState: () => journey.value,
+}));
+
+vi.mock('../api/journey', () => ({
+  fetchJourneyStateApi: (...args: unknown[]) => {
+    fetchSpy(...args);
+    return journey.pending ?? Promise.resolve(journey.value ?? { milestones: { mcpConnected: false } });
+  },
+}));
+
+vi.mock('../hooks/useTelemetry', () => ({
+  useTelemetry: () => ({ track, optedOut: false, setOptOut: vi.fn() }),
+}));
+
+import { GettingStartedCard } from './GettingStartedCard';
+
+const USER = 'user-1';
+
+function seedCache(milestones: Record<string, boolean>) {
+  journey.value = { milestones };
+}
+
+beforeEach(() => {
+  track.mockClear();
+  fetchSpy.mockClear();
+  journey.value = null;
+  localStorage.clear();
+  sessionStorage.clear();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('spec-460: GettingStartedCard', () => {
+  it('renders both rows for a non-connected, non-dismissed user (ac-10)', () => {
+    tagAc(AC(10));
+    seedCache({ mcpConnected: false });
+    render(<GettingStartedCard userId={USER} />);
+
+    expect(screen.getByTestId('getting-started-card')).toBeInTheDocument();
+    expect(screen.getByTestId('getting-started-app-row')).toBeInTheDocument();
+    expect(screen.getByTestId('getting-started-call-row')).toBeInTheDocument();
+    // Links point at the marketing pages with the sidebar-card source.
+    expect(screen.getByTestId('getting-started-app-row')).toHaveAttribute(
+      'href',
+      'https://www.memex.ai/download?src=sidebar-card',
+    );
+  });
+
+  it('hides the desktop-app row when MCP is connected, regardless of dismissal (ac-11)', () => {
+    tagAc(AC(11));
+    seedCache({ mcpConnected: true });
+    render(<GettingStartedCard userId={USER} />);
+
+    expect(screen.queryByTestId('getting-started-app-row')).not.toBeInTheDocument();
+    // Call row still there (not dismissed) → card still visible.
+    expect(screen.getByTestId('getting-started-call-row')).toBeInTheDocument();
+    // The retirement signal fired.
+    expect(track.mock.calls.filter((c) => c[0] === 'getting_started.app_row_retired')).toHaveLength(1);
+  });
+
+  it('unmounts the whole card once every row is retired or dismissed (ac-12)', () => {
+    tagAc(AC(12));
+    // Connected (app row retired) AND call previously dismissed → nothing to show.
+    seedCache({ mcpConnected: true });
+    localStorage.setItem(`memex.gettingStarted.callDismissed:${USER}`, '1');
+    render(<GettingStartedCard userId={USER} />);
+
+    expect(screen.queryByTestId('getting-started-card')).not.toBeInTheDocument();
+  });
+
+  it('dismisses the call row on × with no network, and hasSpec has no effect (ac-13)', () => {
+    tagAc(AC(13));
+    // hasSpec true must NOT retire the call row (dec-8 dismiss-only).
+    seedCache({ mcpConnected: false, hasSpec: true });
+    render(<GettingStartedCard userId={USER} />);
+
+    expect(screen.getByTestId('getting-started-call-row')).toBeInTheDocument(); // hasSpec ignored
+    fetchSpy.mockClear();
+
+    fireEvent.click(screen.getByTestId('getting-started-dismiss-call'));
+
+    expect(screen.queryByTestId('getting-started-call-row')).not.toBeInTheDocument();
+    expect(track.mock.calls.filter((c) => c[0] === 'getting_started.call_row_dismissed')).toHaveLength(1);
+    // No network write on dismiss (cache was seeded, so no mount fetch either).
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('persists dismissal across a remount via user-scoped localStorage, and syncs cross-tab (ac-14)', () => {
+    tagAc(AC(14));
+    seedCache({ mcpConnected: false });
+
+    // Dismiss the call row, then remount (simulates a reload): it stays gone.
+    const r1 = render(<GettingStartedCard userId={USER} />);
+    fireEvent.click(within(r1.container).getByTestId('getting-started-dismiss-call'));
+    expect(localStorage.getItem(`memex.gettingStarted.callDismissed:${USER}`)).toBe('1');
+    r1.unmount();
+
+    const r2 = render(<GettingStartedCard userId={USER} />);
+    expect(within(r2.container).queryByTestId('getting-started-call-row')).not.toBeInTheDocument();
+    r2.unmount();
+
+    // A DIFFERENT user on the same device is unaffected (scoped key).
+    const r3 = render(<GettingStartedCard userId="other-user" />);
+    expect(within(r3.container).getByTestId('getting-started-call-row')).toBeInTheDocument();
+    r3.unmount();
+
+    // Cross-tab: another tab dismisses the whole card → storage event unmounts it here.
+    // (USER still shows the app row, so the card is visible until the card-level dismiss.)
+    const r4 = render(<GettingStartedCard userId={USER} />);
+    expect(within(r4.container).getByTestId('getting-started-card')).toBeInTheDocument();
+    act(() => {
+      localStorage.setItem(`memex.gettingStarted.cardDismissed:${USER}`, '1');
+      window.dispatchEvent(
+        new StorageEvent('storage', { key: `memex.gettingStarted.cardDismissed:${USER}` }),
+      );
+    });
+    expect(within(r4.container).queryByTestId('getting-started-card')).not.toBeInTheDocument();
+  });
+
+  it('renders nothing until the journey signal resolves (no-flash guard)', async () => {
+    // Cold: no cache, and the mount fetch is held pending. The card must not paint
+    // until the signal resolves (never flash a card that might then vanish).
+    journey.value = null;
+    let resolveFetch: (v: { milestones: Record<string, boolean> }) => void = () => {};
+    journey.pending = new Promise((r) => {
+      resolveFetch = r;
+    });
+
+    render(<GettingStartedCard userId={USER} />);
+    expect(screen.queryByTestId('getting-started-card')).not.toBeInTheDocument();
+
+    await act(async () => {
+      resolveFetch({ milestones: { mcpConnected: false } });
+      await journey.pending;
+    });
+    expect(screen.getByTestId('getting-started-card')).toBeInTheDocument();
+    journey.pending = null;
+  });
+});

--- a/packages/ui/src/components/GettingStartedCard.test.tsx
+++ b/packages/ui/src/components/GettingStartedCard.test.tsx
@@ -60,11 +60,17 @@ describe('spec-460: GettingStartedCard', () => {
     expect(screen.getByTestId('getting-started-card')).toBeInTheDocument();
     expect(screen.getByTestId('getting-started-app-row')).toBeInTheDocument();
     expect(screen.getByTestId('getting-started-call-row')).toBeInTheDocument();
-    // Links point at the marketing pages with the sidebar-card source.
+    // Links point at the marketing pages with the sidebar-card source (ac-20:
+    // the booking row uses the neutral alias + src=sidebar-card, new tab, noopener).
+    tagAc(AC(20));
     expect(screen.getByTestId('getting-started-app-row')).toHaveAttribute(
       'href',
       'https://www.memex.ai/download?src=sidebar-card',
     );
+    const callLink = screen.getByTestId('getting-started-call-row').querySelector('a')!;
+    expect(callLink).toHaveAttribute('href', 'https://www.memex.ai/book-a-call?src=sidebar-card');
+    expect(callLink).toHaveAttribute('target', '_blank');
+    expect(callLink).toHaveAttribute('rel', 'noopener noreferrer');
   });
 
   it('hides the desktop-app row when MCP is connected, regardless of dismissal (ac-11)', () => {
@@ -75,7 +81,9 @@ describe('spec-460: GettingStartedCard', () => {
     expect(screen.queryByTestId('getting-started-app-row')).not.toBeInTheDocument();
     // Call row still there (not dismissed) → card still visible.
     expect(screen.getByTestId('getting-started-call-row')).toBeInTheDocument();
-    // The retirement signal fired.
+    // The retirement signal fired (ac-21: getting_started.app_row_retired).
+    tagAc(AC(21));
+    tagAc(AC(7));
     expect(track.mock.calls.filter((c) => c[0] === 'getting_started.app_row_retired')).toHaveLength(1);
   });
 

--- a/packages/ui/src/components/GettingStartedCard.tsx
+++ b/packages/ui/src/components/GettingStartedCard.tsx
@@ -157,7 +157,7 @@ export function GettingStartedCard({ userId }: { userId: string }) {
   return (
     <div
       data-testid="getting-started-card"
-      className="rounded-lg border border-edge bg-overlay/40 p-2"
+      className="rounded-lg border border-edge bg-overlay p-2"
     >
       <div className="flex items-center justify-between px-1 pb-1.5">
         <span className="text-[10px] font-semibold uppercase tracking-wider text-muted">

--- a/packages/ui/src/components/GettingStartedCard.tsx
+++ b/packages/ui/src/components/GettingStartedCard.tsx
@@ -1,0 +1,231 @@
+// spec-460 dec-2: a compact "Getting Started" card at the bottom of the sidebar,
+// above the user card. Two state-aware rows:
+//   1. Get the desktop app — the one-click MCP-setup path. Auto-retires when the
+//      user's MCP is connected by ANY means (the spec-434 journey milestone).
+//   2. Book a 30-min call — dismiss-only (dec-8); no hasSpec auto-retire.
+// When no rows remain (or the card is dismissed) the card unmounts entirely, so the
+// sidebar returns to exactly its pre-feature chrome. Persistent until the job is
+// done, never persistent forever.
+//
+// No-flash guard (review finding 3): the card renders nothing until the journey
+// state has resolved. It seeds mcpConnected from the in-memory journey-state cache
+// (warmed by RootRedirect at landing, spec-421) so a connected user never sees the
+// card flash on first paint; only a cold reload with no cache does a mount fetch.
+//
+// Dismissal is per-device localStorage (dec-9), user-scoped so two accounts on one
+// machine don't share it, with a storage-event listener for cross-tab sync. No
+// network write on dismiss.
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { getCachedJourneyState } from '../journeys/journeyStateCache';
+import { fetchJourneyStateApi } from '../api/journey';
+import { useTelemetry } from '../hooks/useTelemetry';
+
+// The download + booking pages live on the marketing site (spec-460 dec-10/dec-6).
+// ?src attributes the surface; the booking alias keeps the raw HubSpot URL out of
+// the app (std-31).
+const DOWNLOAD_URL = 'https://www.memex.ai/download?src=sidebar-card';
+const BOOK_A_CALL_URL = 'https://www.memex.ai/book-a-call?src=sidebar-card';
+
+const callDismissedKey = (userId: string) => `memex.gettingStarted.callDismissed:${userId}`;
+const cardDismissedKey = (userId: string) => `memex.gettingStarted.cardDismissed:${userId}`;
+// Once-per-session guards for the display/retire signals (not persisted per-device).
+const SHOWN_SESSION_KEY = 'memex.gettingStarted.shown';
+const RETIRED_SESSION_KEY = 'memex.gettingStarted.appRowRetired';
+
+function readFlag(key: string): boolean {
+  try {
+    return localStorage.getItem(key) === '1';
+  } catch {
+    return false;
+  }
+}
+
+function writeFlag(key: string): void {
+  try {
+    localStorage.setItem(key, '1');
+  } catch {
+    /* storage unavailable — non-fatal, the row just re-shows next load */
+  }
+}
+
+function MonitorIcon() {
+  return (
+    <svg className="w-4 h-4 flex-none" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.8} aria-hidden="true">
+      <rect x="2.5" y="4" width="19" height="13" rx="2" />
+      <path strokeLinecap="round" d="M8 20.5h8M12 17v3.5" />
+    </svg>
+  );
+}
+
+function CalendarIcon() {
+  return (
+    <svg className="w-4 h-4 flex-none" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.8} aria-hidden="true">
+      <rect x="3" y="4.5" width="18" height="16" rx="2" />
+      <path strokeLinecap="round" d="M3 9.5h18M8 2.5v4M16 2.5v4" />
+    </svg>
+  );
+}
+
+export function GettingStartedCard({ userId }: { userId: string }) {
+  const { track } = useTelemetry(true);
+
+  // Seed from the in-memory cache so a warmed session paints correctly on the first
+  // render. `resolved` is false only on a cold reload with no cache yet.
+  const seeded = getCachedJourneyState();
+  const [resolved, setResolved] = useState(seeded !== null);
+  const [mcpConnected, setMcpConnected] = useState(!!seeded?.milestones?.mcpConnected);
+  const [callDismissed, setCallDismissed] = useState(() => readFlag(callDismissedKey(userId)));
+  const [cardDismissed, setCardDismissed] = useState(() => readFlag(cardDismissedKey(userId)));
+
+  const shownFiredRef = useRef(false);
+
+  // Cold reload with no cache: fetch once so we can decide whether to show the app
+  // row. Render nothing until this resolves (no flash of a card that then vanishes).
+  useEffect(() => {
+    if (resolved) return;
+    let alive = true;
+    void fetchJourneyStateApi()
+      .then((s) => {
+        if (!alive) return;
+        setMcpConnected(!!s.milestones?.mcpConnected);
+        setResolved(true);
+      })
+      .catch(() => {
+        // On failure, resolve as not-connected: better to offer the setup path than
+        // to hide the card forever behind a transient error.
+        if (alive) setResolved(true);
+      });
+    return () => {
+      alive = false;
+    };
+  }, [resolved]);
+
+  // Cross-tab dismissal sync (dec-9): re-read the flags when another tab writes them.
+  useEffect(() => {
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === callDismissedKey(userId)) setCallDismissed(readFlag(callDismissedKey(userId)));
+      if (e.key === cardDismissedKey(userId)) setCardDismissed(readFlag(cardDismissedKey(userId)));
+    };
+    window.addEventListener('storage', onStorage);
+    return () => window.removeEventListener('storage', onStorage);
+  }, [userId]);
+
+  const showAppRow = resolved && !mcpConnected;
+  const showCallRow = resolved && !callDismissed;
+  const visible = resolved && !cardDismissed && (showAppRow || showCallRow);
+
+  // app_row_retired: once per session, when the user's MCP is connected (the row's
+  // job is done). Fired regardless of card visibility so the retirement is measurable.
+  useEffect(() => {
+    if (!resolved || !mcpConnected) return;
+    try {
+      if (sessionStorage.getItem(RETIRED_SESSION_KEY)) return;
+      sessionStorage.setItem(RETIRED_SESSION_KEY, '1');
+    } catch {
+      /* ignore */
+    }
+    track('getting_started.app_row_retired', {});
+  }, [resolved, mcpConnected, track]);
+
+  // card_shown: once per session, the first time the card is actually visible.
+  useEffect(() => {
+    if (!visible || shownFiredRef.current) return;
+    shownFiredRef.current = true;
+    try {
+      if (sessionStorage.getItem(SHOWN_SESSION_KEY)) return;
+      sessionStorage.setItem(SHOWN_SESSION_KEY, '1');
+    } catch {
+      /* ignore */
+    }
+    track('getting_started.card_shown', {});
+  }, [visible, track]);
+
+  const dismissCall = useCallback(() => {
+    writeFlag(callDismissedKey(userId));
+    setCallDismissed(true);
+    track('getting_started.call_row_dismissed', {});
+  }, [userId, track]);
+
+  const dismissCard = useCallback(() => {
+    writeFlag(cardDismissedKey(userId));
+    setCardDismissed(true);
+    track('getting_started.card_dismissed', {});
+  }, [userId, track]);
+
+  if (!visible) return null;
+
+  return (
+    <div
+      data-testid="getting-started-card"
+      className="rounded-lg border border-edge bg-overlay/40 p-2"
+    >
+      <div className="flex items-center justify-between px-1 pb-1.5">
+        <span className="text-[10px] font-semibold uppercase tracking-wider text-muted">
+          Getting started
+        </span>
+        <button
+          data-testid="getting-started-dismiss-card"
+          onClick={dismissCard}
+          aria-label="Dismiss getting started"
+          className="text-muted hover:text-secondary transition-colors text-xs leading-none p-0.5"
+        >
+          ✕
+        </button>
+      </div>
+
+      {showAppRow && (
+        <a
+          data-testid="getting-started-app-row"
+          href={DOWNLOAD_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={() => track('getting_started.app_row_clicked', {})}
+          className="flex items-start gap-2.5 rounded-md p-2 hover:bg-overlay transition-colors"
+        >
+          <span className="mt-0.5 text-secondary">
+            <MonitorIcon />
+          </span>
+          <span className="min-w-0">
+            <span className="block text-sm font-medium text-primary">Get the desktop app</span>
+            <span className="block text-xs text-muted leading-snug">
+              One-click MCP setup, connect your coding agent
+            </span>
+          </span>
+        </a>
+      )}
+
+      {showCallRow && (
+        <div
+          data-testid="getting-started-call-row"
+          className="group flex items-start gap-2.5 rounded-md p-2 hover:bg-overlay transition-colors"
+        >
+          <a
+            href={BOOK_A_CALL_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={() => track('getting_started.call_row_clicked', {})}
+            className="flex min-w-0 flex-1 items-start gap-2.5"
+          >
+            <span className="mt-0.5 text-secondary">
+              <CalendarIcon />
+            </span>
+            <span className="min-w-0">
+              <span className="block text-sm font-medium text-primary">Book a 30-min call</span>
+              <span className="block text-xs text-muted leading-snug">
+                We&apos;ll show you Memex on your own workflow. 30 minutes, or we can wrap up in 15.
+              </span>
+            </span>
+          </a>
+          <button
+            data-testid="getting-started-dismiss-call"
+            onClick={dismissCall}
+            aria-label="Dismiss book a call"
+            className="flex-none text-muted hover:text-secondary transition-colors text-xs leading-none p-0.5"
+          >
+            ✕
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/ui/src/pages/WelcomePage.telemetry.test.tsx
+++ b/packages/ui/src/pages/WelcomePage.telemetry.test.tsx
@@ -2,6 +2,10 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
+import { tagAc } from '@memex-ai-ac/vitest';
+
+// spec-460 acceptance criteria (mindset-prod/memex-building-itself).
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-460/acs/ac-${n}`;
 
 // spec-444 welcome-video instrumentation. The onboarding.video_* events ride the
 // SAME analytics client as every other front-end signal — useTelemetry().track()
@@ -59,7 +63,7 @@ describe('WelcomePage — onboarding.video_* telemetry', () => {
     const started = track.mock.calls.filter((c) => c[0] === 'onboarding.video_started');
     expect(started).toHaveLength(1);
     expect(started[0][1]).toEqual({
-      video_id: 'welcome-to-memex-v2',
+      video_id: 'welcome-to-memex-v4',
       position_seconds: 3,
       duration_seconds: 120,
       percent_watched: 3, // 3/120 = 2.5 → rounded
@@ -76,7 +80,7 @@ describe('WelcomePage — onboarding.video_* telemetry', () => {
 
     const completed = track.mock.calls.filter((c) => c[0] === 'onboarding.video_completed');
     expect(completed).toHaveLength(1);
-    expect(completed[0][1]).toMatchObject({ video_id: 'welcome-to-memex-v2', percent_watched: 100 });
+    expect(completed[0][1]).toMatchObject({ video_id: 'welcome-to-memex-v4', percent_watched: 100 });
   });
 
   it('fires onboarding.video_skipped ONCE when the CTA dismisses before completion', async () => {
@@ -89,7 +93,7 @@ describe('WelcomePage — onboarding.video_* telemetry', () => {
 
     const skipped = track.mock.calls.filter((c) => c[0] === 'onboarding.video_skipped');
     expect(skipped).toHaveLength(1);
-    expect(skipped[0][1]).toMatchObject({ video_id: 'welcome-to-memex-v2', position_seconds: 10 });
+    expect(skipped[0][1]).toMatchObject({ video_id: 'welcome-to-memex-v4', position_seconds: 10 });
     await waitFor(() => expect(dismissWelcomeVideoApi).toHaveBeenCalled());
   });
 
@@ -124,5 +128,100 @@ describe('WelcomePage — onboarding.video_* telemetry', () => {
 
     const started = track.mock.calls.find((c) => c[0] === 'onboarding.video_started');
     expect(started?.[1]).toMatchObject({ percent_watched: 0, duration_seconds: 0 });
+  });
+});
+
+// spec-460 dec-1/dec-7: the "book a call" line is hidden during playback, revealed
+// once the viewer is ≥85% through (or the video ends), links to the neutral booking
+// alias in a new tab, and never gates the path to /specs.
+describe('WelcomePage — spec-460 book-a-call reveal', () => {
+  beforeEach(() => {
+    track.mockClear();
+    updateSession.mockClear();
+    dismissWelcomeVideoApi.mockClear();
+    sessionStorage.clear();
+  });
+
+  it('hides the call CTA before the reveal threshold and shows it after, linking to the alias in a new tab (ac-8)', () => {
+    tagAc(AC(8));
+    renderPage();
+    const cta = screen.getByTestId('welcome-video-call-cta');
+    const link = cta.querySelector('a')!;
+
+    // Hidden pre-reveal: aria-hidden, not focusable, no shown event.
+    expect(cta).toHaveAttribute('aria-hidden', 'true');
+    expect(link).toHaveAttribute('tabindex', '-1');
+    expect(track.mock.calls.filter((c) => c[0] === 'onboarding.video_call_cta_shown')).toHaveLength(0);
+
+    const video = screen.getByTestId('welcome-video-player') as HTMLVideoElement;
+    stubPlayback(video, 90, 100); // 90% > 85% threshold
+    fireEvent.timeUpdate(video);
+
+    expect(cta).toHaveAttribute('aria-hidden', 'false');
+    expect(link).toHaveAttribute('tabindex', '0');
+    expect(link).toHaveAttribute('href', 'https://www.memex.ai/book-a-call?src=welcome-video');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+    // Primary CTA (dec-1: no interstitial, path to /specs unchanged) still present.
+    expect(screen.getByTestId('welcome-video-cta')).toBeInTheDocument();
+  });
+
+  it('reveals at ≥85% via playback/seek, and via ended, and stays shown once revealed (fires once) (ac-9)', () => {
+    tagAc(AC(9));
+    renderPage();
+    const cta = screen.getByTestId('welcome-video-call-cta');
+    const video = screen.getByTestId('welcome-video-player') as HTMLVideoElement;
+
+    // Below threshold: still hidden.
+    stubPlayback(video, 50, 100);
+    fireEvent.timeUpdate(video);
+    expect(cta).toHaveAttribute('aria-hidden', 'true');
+
+    // Cross threshold: revealed.
+    stubPlayback(video, 86, 100);
+    fireEvent.timeUpdate(video);
+    expect(cta).toHaveAttribute('aria-hidden', 'false');
+
+    // Seek back below threshold: stays revealed (no re-hide).
+    stubPlayback(video, 10, 100);
+    fireEvent.timeUpdate(video);
+    expect(cta).toHaveAttribute('aria-hidden', 'false');
+
+    // The shown event fired exactly once across all those updates.
+    expect(track.mock.calls.filter((c) => c[0] === 'onboarding.video_call_cta_shown')).toHaveLength(1);
+  });
+
+  it('reveals on ended even if timeupdate never crossed the threshold (ac-9)', () => {
+    tagAc(AC(9));
+    renderPage();
+    const cta = screen.getByTestId('welcome-video-call-cta');
+    const video = screen.getByTestId('welcome-video-player') as HTMLVideoElement;
+
+    stubPlayback(video, 100, 100);
+    fireEvent.ended(video);
+    expect(cta).toHaveAttribute('aria-hidden', 'false');
+  });
+
+  it('fires onboarding.video_call_cta_clicked when the revealed link is clicked', async () => {
+    tagAc(AC(8));
+    renderPage();
+    const video = screen.getByTestId('welcome-video-player') as HTMLVideoElement;
+    stubPlayback(video, 90, 100);
+    fireEvent.timeUpdate(video);
+
+    const link = screen.getByTestId('welcome-video-call-cta').querySelector('a')!;
+    await userEvent.click(link);
+
+    expect(track.mock.calls.filter((c) => c[0] === 'onboarding.video_call_cta_clicked')).toHaveLength(1);
+  });
+
+  it('keeps the spec-444 headline and subtitle copy unchanged (ac-22)', () => {
+    tagAc(AC(22));
+    renderPage();
+    expect(screen.getByText("Let's dive in.")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Here's a quick look to get you started with Memex\./),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Hit play to start.')).toBeInTheDocument();
   });
 });

--- a/packages/ui/src/pages/WelcomePage.telemetry.test.tsx
+++ b/packages/ui/src/pages/WelcomePage.telemetry.test.tsx
@@ -142,8 +142,10 @@ describe('WelcomePage — spec-460 book-a-call reveal', () => {
     sessionStorage.clear();
   });
 
-  it('hides the call CTA before the reveal threshold and shows it after, linking to the alias in a new tab (ac-8)', () => {
+  it('hides the call CTA before the reveal threshold and shows it after, linking to the alias in a new tab (ac-8, ac-20, ac-7)', () => {
     tagAc(AC(8));
+    tagAc(AC(20)); // welcome-video surface: alias + src=welcome-video + noopener
+    tagAc(AC(7)); // reveal is instrumented + links to the neutral alias
     renderPage();
     const cta = screen.getByTestId('welcome-video-call-cta');
     const link = cta.querySelector('a')!;
@@ -202,17 +204,27 @@ describe('WelcomePage — spec-460 book-a-call reveal', () => {
     expect(cta).toHaveAttribute('aria-hidden', 'false');
   });
 
-  it('fires onboarding.video_call_cta_clicked when the revealed link is clicked', async () => {
-    tagAc(AC(8));
+  it('fires onboarding.video_call_cta_shown on reveal and _clicked on click (ac-21, ac-7)', async () => {
+    tagAc(AC(21)); // welcome_video.call_cta_shown / _clicked events fire
+    tagAc(AC(7));
     renderPage();
     const video = screen.getByTestId('welcome-video-player') as HTMLVideoElement;
     stubPlayback(video, 90, 100);
     fireEvent.timeUpdate(video);
+    expect(track.mock.calls.filter((c) => c[0] === 'onboarding.video_call_cta_shown')).toHaveLength(1);
 
     const link = screen.getByTestId('welcome-video-call-cta').querySelector('a')!;
     await userEvent.click(link);
-
     expect(track.mock.calls.filter((c) => c[0] === 'onboarding.video_call_cta_clicked')).toHaveLength(1);
+  });
+
+  it('points the video at the v4 CDN asset (ac-19)', () => {
+    tagAc(AC(19));
+    renderPage();
+    const src = screen.getByTestId('welcome-video-player').getAttribute('src');
+    expect(src).toBe(
+      'https://storage.googleapis.com/memex-ai-prod-app-static/media/welcome-to-memex-v4.mp4',
+    );
   });
 
   it('keeps the spec-444 headline and subtitle copy unchanged (ac-22)', () => {

--- a/packages/ui/src/pages/WelcomePage.tsx
+++ b/packages/ui/src/pages/WelcomePage.tsx
@@ -15,12 +15,22 @@ import { dismissWelcomeVideoApi } from '../api/auth';
 import { useTelemetry } from '../hooks/useTelemetry';
 
 const VIDEO_URL =
-  'https://storage.googleapis.com/memex-ai-prod-app-static/media/welcome-to-memex-v2.mp4';
+  'https://storage.googleapis.com/memex-ai-prod-app-static/media/welcome-to-memex-v4.mp4';
 
 // Stable, low-cardinality identifier for this video — the filename stem of
 // VIDEO_URL. Kept as its own const so a src bump is a one-line, deliberate change
 // (props carry ids/counts only — std-35 cl-5).
-const VIDEO_ID = 'welcome-to-memex-v2';
+const VIDEO_ID = 'welcome-to-memex-v4';
+
+// spec-460: the "book a call" CTA revealed near the end of the video points at the
+// neutral booking alias on the marketing site (never the raw HubSpot URL — std-31,
+// dec-6). ?src attributes the booking to this surface.
+const BOOK_A_CALL_URL = 'https://www.memex.ai/book-a-call?src=welcome-video';
+
+// spec-460 dec-7: reveal the call CTA once the viewer is ≥85% through the video.
+// The v4 cut is ~3 min, so a strict "on ended" reveal would reach far fewer
+// viewers; 85% catches near-finishers while staying roughly synced to the outro.
+const CALL_CTA_REVEAL_FRACTION = 0.85;
 
 // Build the numeric playback props shared by every onboarding.video_* event.
 // duration is NaN until metadata loads, so percent_watched is guarded against
@@ -58,16 +68,43 @@ export function WelcomePage() {
   const completedRef = useRef(false);
   const skippedRef = useRef(false);
 
+  // spec-460 dec-7: the "book a call" CTA is hidden during playback and revealed
+  // once the viewer crosses CALL_CTA_REVEAL_FRACTION (via natural playback, a seek
+  // past the threshold, or the ended event). Once shown it stays shown — a
+  // seek-back must not re-hide it. The ref guards the reveal event to once-per-view.
+  const [callCtaShown, setCallCtaShown] = useState(false);
+  const callCtaShownRef = useRef(false);
+
+  const revealCallCta = useCallback(() => {
+    if (callCtaShownRef.current) return; // reveal + fire once per view
+    callCtaShownRef.current = true;
+    setCallCtaShown(true);
+    track('onboarding.video_call_cta_shown', videoProps(videoRef.current));
+  }, [track]);
+
   const onVideoPlay = useCallback(() => {
     if (startedRef.current) return; // fire once per view
     startedRef.current = true;
     track('onboarding.video_started', videoProps(videoRef.current));
   }, [track]);
 
+  // Reveal decisions never run before metadata loads (duration is NaN until then,
+  // so the fraction guard below is false and nothing reveals prematurely).
+  const onVideoTimeUpdate = useCallback(() => {
+    const v = videoRef.current;
+    if (!v || !Number.isFinite(v.duration) || v.duration <= 0) return;
+    if (v.currentTime / v.duration >= CALL_CTA_REVEAL_FRACTION) revealCallCta();
+  }, [revealCallCta]);
+
   const onVideoEnded = useCallback(() => {
+    revealCallCta(); // a short video the viewer finishes should always show the CTA
     if (completedRef.current) return; // fire once per view
     completedRef.current = true;
     track('onboarding.video_completed', videoProps(videoRef.current));
+  }, [track, revealCallCta]);
+
+  const onCallCtaClick = useCallback(() => {
+    track('onboarding.video_call_cta_clicked', videoProps(videoRef.current));
   }, [track]);
 
   // Skip = a dismiss BEFORE completion. At most once, and never if the video
@@ -136,6 +173,7 @@ export function WelcomePage() {
           preload="metadata"
           onPlay={onVideoPlay}
           onPlaying={onVideoPlay}
+          onTimeUpdate={onVideoTimeUpdate}
           onEnded={onVideoEnded}
           className="w-full rounded-lg"
           style={{ aspectRatio: '16/9' }}
@@ -169,6 +207,30 @@ export function WelcomePage() {
             Back to Memex
           </button>
         )}
+
+        {/* spec-460 dec-1/dec-7: quiet "book a call" line, hidden until the viewer
+            reaches ~85% of the video (or finishes it), then faded in. It never gates
+            the path to /specs — the primary CTA above stays dominant. Kept in the DOM
+            so the fade can run, but non-focusable and hidden from AT until revealed. */}
+        <p
+          data-testid="welcome-video-call-cta"
+          className={`text-center text-sm text-gray-500 transition-opacity duration-500 motion-reduce:transition-none ${
+            callCtaShown ? 'opacity-100' : 'opacity-0 pointer-events-none'
+          }`}
+          aria-hidden={!callCtaShown}
+        >
+          Prefer a guided tour?{' '}
+          <a
+            href={BOOK_A_CALL_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={onCallCtaClick}
+            tabIndex={callCtaShown ? 0 : -1}
+            className="text-blue-600 hover:text-blue-700 underline underline-offset-2 font-medium"
+          >
+            Book a 30-minute call with us
+          </a>
+        </p>
       </div>
     </div>
   );


### PR DESCRIPTION
The memex-ai (in-app) half of **spec-460**. Pairs with **memex-website PR #45** (`/download` + `/book-a-call`).

> ⚠️ **Merge ordering:** the CTAs here link to `www.memex.ai/download` and `www.memex.ai/book-a-call`. Those must be **live** (PR #45 merged + deployed) before this merges, or the links 404. This is the review-finding-1 blocker.

## What's here

- **WelcomePage**: video `src`/`id` → **v4** (already uploaded to `gs://memex-ai-prod-app-static/media/welcome-to-memex-v4.mp4`, 41 MB, faststart). A quiet **"book a call" line** is hidden during playback and revealed at **≥85% watched** (dec-7: via `timeupdate`, a seek past the threshold, or `ended`; stays shown), opening `…/book-a-call?src=welcome-video` in a new tab. Explicitly **not** an interstitial — the path to `/specs` is unchanged (dec-1). Headline/subtitle copy unchanged (dec-11). Events `onboarding.video_call_cta_shown` / `_clicked` (matches the file's existing `onboarding.video_*` namespace; watch-depth events already existed from spec-444, so review finding 7 is covered).
- **GettingStartedCard** (new), mounted above the sidebar user card: **desktop-app row** auto-retires on `mcpConnected` (spec-434 journey milestone, any connect method); **book-a-call row** is dismiss-only (dec-8, `hasSpec` not consumed). **No-flash guard** — renders nothing until the journey signal resolves, seeded from the spec-421 in-memory cache. Dismissals persist in **user-scoped localStorage** (dec-9) with a `storage`-event cross-tab sync, no network write. Card unmounts when empty. Full telemetry set.
- **Account menu**: always-present **Download desktop app** + **Book a call** fallbacks (`?src=account-menu`) beside spec-444's *Watch intro video* (dec-4).

## Testing

Unit (vitest + jsdom), all green: `WelcomePage.telemetry` 11/11 (reveal/click/copy tagged ac-8/9/22), `GettingStartedCard` 6/6 (ac-10–14 + no-flash), `AppShell.spec-460` 2/2 (ac-18). `spec-456` account-menu test unregressed (7/7). `tsc --noEmit` clean. E2e **journey-54** authored (ac-1/2/3/4/6).

**Not yet run in this session (do before merge):** `make e2e-cold` (environment-heavy) and the AC-board emission (needs `MEMEX_EMIT_KEY`; unit/e2e tests are tagged and will emit once a key is present).

🤖 Generated with [Claude Code](https://claude.com/claude-code)