### PR TITLE
spec-460 follow-up: welcome rewatch exit → /specs (INT fix)

### DIFF
--- a/packages/ui/src/pages/WelcomePage.telemetry.test.tsx
+++ b/packages/ui/src/pages/WelcomePage.telemetry.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import { tagAc } from '@memex-ai-ac/vitest';
 
 // spec-460 acceptance criteria (mindset-prod/memex-building-itself).
@@ -235,5 +235,32 @@ describe('WelcomePage — spec-460 book-a-call reveal', () => {
       screen.getByText(/Here's a quick look to get you started with Memex\./),
     ).toBeInTheDocument();
     expect(screen.getByText('Hit play to start.')).toBeInTheDocument();
+  });
+});
+
+// Rewatch-mode exit ("Back to Memex" / ×) lands on the specs board, not wherever
+// the user opened rewatch from (INT feedback: it dropped users on Home).
+describe('WelcomePage — rewatch exit destination', () => {
+  function renderRewatch() {
+    return render(
+      <MemoryRouter initialEntries={['/welcome?rewatch=1']}>
+        <Routes>
+          <Route path="/welcome" element={<WelcomePage />} />
+          <Route path="/specs" element={<div data-testid="specs-board">specs</div>} />
+        </Routes>
+      </MemoryRouter>,
+    );
+  }
+
+  it('"Back to Memex" navigates to /specs', async () => {
+    renderRewatch();
+    await userEvent.click(screen.getByTestId('welcome-video-back'));
+    expect(screen.getByTestId('specs-board')).toBeInTheDocument();
+  });
+
+  it('× close in rewatch mode also navigates to /specs', async () => {
+    renderRewatch();
+    await userEvent.click(screen.getByTestId('welcome-video-close'));
+    expect(screen.getByTestId('specs-board')).toBeInTheDocument();
   });
 });

--- a/packages/ui/src/pages/WelcomePage.tsx
+++ b/packages/ui/src/pages/WelcomePage.tsx
@@ -138,8 +138,12 @@ export function WelcomePage() {
     navigate('/specs', { replace: true });
   }, [trackSkip, navigate]);
 
+  // Rewatch exit (Back to Memex / × in rewatch mode) lands on the specs board,
+  // consistent with the two first-run exits above. navigate(-1) used to send the
+  // user back to wherever they opened rewatch from (e.g. Home), which is not where
+  // they expect to land after the video.
   const rewatchExit = useCallback(() => {
-    navigate(-1);
+    navigate('/specs', { replace: true });
   }, [navigate]);
 
   return (


### PR DESCRIPTION
INT testing of spec-460 surfaced one bug: clicking **"Back to Memex"** on the welcome page (rewatch mode, reached via the avatar menu's *Watch intro video*) dropped the user on whatever page they came from (e.g. **Home**) instead of the specs board.

**Cause:** `rewatchExit` used `navigate(-1)`, while the two first-run exits use `navigate('/specs', { replace: true })`.

**Fix:** `rewatchExit` now navigates to `/specs` (replace), consistent with the other exits. The × close in rewatch mode shares `rewatchExit`, so it lands on `/specs` too. Two unit tests added (real-router navigation → specs board).

tsc clean; WelcomePage suite 14/14.

(Separately, the "book a call" URL showing the calendar owner's name is working as designed — the app links to the neutral `www.memex.ai/book-a-call` alias per std-31 and it redirects to the real HubSpot calendar; hiding the name in the final URL is a HubSpot-side slug change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)