### PR TITLE
spec-462: /welcome primary button — three-state Play-now machine (stop CTA being mistaken for skip)

### DIFF
--- a/packages/ui/e2e/journey-53-spec-444-welcome-video.spec.ts
+++ b/packages/ui/e2e/journey-53-spec-444-welcome-video.spec.ts
@@ -87,7 +87,16 @@ test(
     const videoSrc = await page.getByTestId('welcome-video-player').getAttribute('src');
     expect(videoSrc).toContain('storage.googleapis.com/memex-ai-prod-app-static');
 
+    // spec-462: before the video ends the primary button is "▶ Play now" — the
+    // permanent-dismiss "Get started →" only appears once the video ends. Drive the
+    // <video> to ended (headless Chromium can't decode the CDN asset) to surface it.
+    await expect(page.getByTestId('welcome-video-cta')).toHaveText(/Play now/);
+    await page.getByTestId('welcome-video-player').evaluate((el) => {
+      (el as HTMLVideoElement).dispatchEvent(new Event('ended'));
+    });
+
     // ac-4, ac-6, ac-8, ac-9: "Get started" permanently dismisses → /specs.
+    await expect(page.getByTestId('welcome-video-cta')).toHaveText(/Get started/);
     await page.getByTestId('welcome-video-cta').click();
     await expect(page).toHaveURL(/\/specs/, { timeout: 15_000 });
 

--- a/packages/ui/e2e/journey-54-spec-460-welcome-ctas.spec.ts
+++ b/packages/ui/e2e/journey-54-spec-460-welcome-ctas.spec.ts
@@ -71,7 +71,12 @@ test(
     await expect(link).toHaveAttribute("href", "https://www.memex.ai/book-a-call?src=welcome-video");
     await expect(link).toHaveAttribute("target", "_blank");
 
-    // The primary path to /specs is unchanged (no interstitial).
+    // The primary path to /specs is unchanged (no interstitial). spec-462: end the
+    // video so the primary button becomes "Get started →", then dismiss.
+    await page.getByTestId("welcome-video-player").evaluate((el) => {
+      (el as HTMLVideoElement).dispatchEvent(new Event("ended"));
+    });
+    await expect(page.getByTestId("welcome-video-cta")).toHaveText(/Get started/);
     await page.getByTestId("welcome-video-cta").click();
     await expect(page).toHaveURL(/\/specs/, { timeout: 15_000 });
   },

--- a/packages/ui/e2e/journey-55-spec-462-welcome-play-button.spec.ts
+++ b/packages/ui/e2e/journey-55-spec-462-welcome-play-button.spec.ts
@@ -1,0 +1,103 @@
+// Journey 55 — spec-462: the /welcome primary button is a three-state machine so
+// it can never be mistaken for a skip.
+//
+// Before spec-462 the loud blue button and the quiet "Skip" link both dismissed —
+// users read the loudest element as "play" and got silently skipped past the
+// explainer. Now, exercised against the running app:
+//   idle    → "▶ Play now"    (does NOT navigate)                         (ac-6)
+//   playing → "Playing…"      (inert status)                             (ac-7)
+//   ended   → "Get started →" (permanent dismiss → /specs)               (ac-8)
+//   the "Skip" link is present in every state and dismisses               (ac-9)
+//   rewatch=1 is unchanged ("Back to Memex")                              (ac-10)
+//
+// Headless Chromium can't decode the CDN video, so playback state is driven by
+// dispatching the media events the component listens on (same approach as
+// journey-54's book-a-call reveal). ac-11 (telemetry) is covered by the unit test.
+
+import {
+  test,
+  expect,
+  bareUrl,
+  gotoSpecsBoard,
+  setVideoWelcomed,
+  emitAcEvents,
+  DEV_EMAIL,
+} from "./helpers/index.js";
+
+const ACS = [
+  "mindset-prod/memex-building-itself/specs/spec-462/acs/ac-6",
+  "mindset-prod/memex-building-itself/specs/spec-462/acs/ac-7",
+  "mindset-prod/memex-building-itself/specs/spec-462/acs/ac-8",
+  "mindset-prod/memex-building-itself/specs/spec-462/acs/ac-9",
+  "mindset-prod/memex-building-itself/specs/spec-462/acs/ac-10",
+];
+
+test.afterEach(async ({}, testInfo) => {
+  if (testInfo.status === "skipped") return;
+  await emitAcEvents(
+    ACS,
+    testInfo.status === "passed" ? "pass" : "fail",
+    `packages/ui/e2e/journey-55-spec-462-welcome-play-button.spec.ts::${testInfo.title}`,
+    testInfo.duration,
+  );
+});
+
+test(
+  "primary button walks Play now → Playing… → Get started; idle does not navigate, ended dismisses (ac-6, ac-7, ac-8)",
+  async ({ page }) => {
+    await setVideoWelcomed(DEV_EMAIL, false);
+    await page.goto(bareUrl("/"), { waitUntil: "commit" });
+    await expect(page).toHaveURL(/\/welcome/, { timeout: 15_000 });
+
+    const cta = page.getByTestId("welcome-video-cta");
+    const player = page.getByTestId("welcome-video-player");
+
+    // ac-6: idle shows "▶ Play now" and no "Get started".
+    await expect(cta).toHaveText(/Play now/);
+    await expect(page.getByText("Get started →")).toHaveCount(0);
+
+    // ac-6: clicking "Play now" must NOT navigate away (it plays the video).
+    await cta.click();
+    await expect(page).toHaveURL(/\/welcome/); // still on /welcome
+
+    // ac-7: once playing, the button is an inert "Playing…" status (not a <button>).
+    await player.evaluate((el) => (el as HTMLVideoElement).dispatchEvent(new Event("play")));
+    await expect(cta).toHaveText(/Playing…/);
+    await expect(cta).toHaveJSProperty("tagName", "DIV");
+
+    // ac-8: only after the video ends does "Get started →" appear and dismiss → /specs.
+    await player.evaluate((el) => (el as HTMLVideoElement).dispatchEvent(new Event("ended")));
+    await expect(cta).toHaveText(/Get started/);
+    await cta.click();
+    await expect(page).toHaveURL(/\/specs/, { timeout: 15_000 });
+  },
+);
+
+test(
+  "the Skip link dismisses without watching, in the idle state (ac-9)",
+  async ({ page }) => {
+    await setVideoWelcomed(DEV_EMAIL, false);
+    await page.goto(bareUrl("/"), { waitUntil: "commit" });
+    await expect(page).toHaveURL(/\/welcome/, { timeout: 15_000 });
+
+    // ac-9: the Skip link is present even before playing, and dismisses → /specs.
+    await expect(page.getByTestId("welcome-video-cta")).toHaveText(/Play now/);
+    await page.getByTestId("welcome-video-skip").click();
+    await expect(page).toHaveURL(/\/specs/, { timeout: 15_000 });
+  },
+);
+
+test(
+  "rewatch mode is unchanged — Back to Memex, no Play-now machine (ac-10)",
+  async ({ page }) => {
+    // Pre-stamped (already welcomed); open the rewatch entry directly.
+    await gotoSpecsBoard(page);
+    await page.goto(bareUrl("/welcome?rewatch=1"), { waitUntil: "commit" });
+    await expect(page.getByText("Let's dive in.")).toBeVisible({ timeout: 10_000 });
+
+    // ac-10: rewatch keeps its "Back to Memex" button; the three-state cta is absent.
+    await expect(page.getByTestId("welcome-video-back")).toHaveText(/Back to Memex/);
+    await expect(page.getByTestId("welcome-video-cta")).toHaveCount(0);
+    await expect(page.getByText("Play now")).toHaveCount(0);
+  },
+);

--- a/packages/ui/src/pages/WelcomePage.spec-462.test.tsx
+++ b/packages/ui/src/pages/WelcomePage.spec-462.test.tsx
@@ -1,0 +1,183 @@
+// spec-462 — the /welcome primary button is a three-state machine so it can never
+// be mistaken for a skip (the pre-462 bug: the loud blue button and the quiet
+// "Skip" link both dismissed, so users read the loudest element as "play" and got
+// silently skipped past the explainer).
+//
+//   idle    → "▶ Play now"    starts playback, does NOT navigate/dismiss   (ac-6)
+//   playing → "Playing…"      inert status, not a skip target, survives pause (ac-7)
+//   ended   → "Get started →" the real forward move (permanentDismiss)     (ac-8)
+//
+//   ac-9  : the "Skip, I'm already familiar" link is present + dismisses in every state
+//   ac-10 : rewatch=1 is unchanged ("Back to Memex")
+//   ac-11 : telemetry preserved — play → end → Get started emits started+completed,
+//           NOT skipped
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { tagAc } from '@memex-ai-ac/vitest';
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-462/acs/ac-${n}`;
+
+const track = vi.fn();
+vi.mock('../hooks/useTelemetry', () => ({
+  useTelemetry: () => ({ track, optedOut: false, setOptOut: vi.fn() }),
+}));
+
+const updateSession = vi.fn();
+vi.mock('../components/AuthContext', () => ({
+  useAuth: () => ({ token: 'tok', updateSession }),
+}));
+
+const dismissWelcomeVideoApi = vi.fn(async () => ({}) as never);
+vi.mock('../api/auth', () => ({
+  dismissWelcomeVideoApi: () => dismissWelcomeVideoApi(),
+}));
+
+// Observe navigation without a real router move (keep MemoryRouter + useSearchParams real).
+const navigate = vi.fn();
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>();
+  return { ...actual, useNavigate: () => navigate };
+});
+
+import { WelcomePage } from './WelcomePage';
+
+function renderPage(route = '/welcome') {
+  return render(
+    <MemoryRouter initialEntries={[route]}>
+      <WelcomePage />
+    </MemoryRouter>,
+  );
+}
+
+/** Give the jsdom <video> concrete playback numbers (jsdom leaves them 0 / NaN). */
+function stubPlayback(video: HTMLVideoElement, currentTime: number, duration: number) {
+  Object.defineProperty(video, 'currentTime', { value: currentTime, configurable: true });
+  Object.defineProperty(video, 'duration', { value: duration, configurable: true });
+}
+
+// jsdom does not implement HTMLMediaElement.play(); stub it so "Play now" can call it.
+let playSpy: ReturnType<typeof vi.spyOn>;
+
+describe('spec-462 — /welcome three-state primary button', () => {
+  beforeEach(() => {
+    track.mockClear();
+    updateSession.mockClear();
+    dismissWelcomeVideoApi.mockClear();
+    navigate.mockClear();
+    sessionStorage.clear();
+    playSpy = vi
+      .spyOn(HTMLMediaElement.prototype, 'play')
+      .mockResolvedValue(undefined as unknown as void);
+  });
+
+  afterEach(() => {
+    playSpy.mockRestore();
+  });
+
+  it('idle renders "▶ Play now"; clicking it plays the video and does NOT navigate or dismiss (ac-6)', async () => {
+    tagAc(AC(6));
+    renderPage();
+
+    const cta = screen.getByTestId('welcome-video-cta');
+    expect(cta).toHaveTextContent('Play now');
+    expect(screen.queryByText(/Get started/)).not.toBeInTheDocument();
+
+    await userEvent.click(cta);
+
+    expect(playSpy).toHaveBeenCalledTimes(1);
+    expect(navigate).not.toHaveBeenCalled();
+    expect(dismissWelcomeVideoApi).not.toHaveBeenCalled();
+  });
+
+  it('once playing the button becomes an inert "Playing…" status that survives pause and is not a skip target (ac-7)', async () => {
+    tagAc(AC(7));
+    renderPage();
+    const video = screen.getByTestId('welcome-video-player') as HTMLVideoElement;
+
+    fireEvent.play(video);
+
+    const status = screen.getByTestId('welcome-video-cta');
+    expect(status).toHaveTextContent('Playing…');
+    expect(status.tagName).not.toBe('BUTTON'); // inert — no onClick, not clickable
+
+    // Clicking the status must not dismiss/navigate.
+    await userEvent.click(status);
+    expect(navigate).not.toHaveBeenCalled();
+    expect(dismissWelcomeVideoApi).not.toHaveBeenCalled();
+
+    // Pause must NOT flip the label back (native controls own resume).
+    fireEvent.pause(video);
+    expect(screen.getByTestId('welcome-video-cta')).toHaveTextContent('Playing…');
+  });
+
+  it('only after the video ends does the button become "Get started →" wired to permanentDismiss (ac-8)', async () => {
+    tagAc(AC(8));
+    renderPage();
+    const video = screen.getByTestId('welcome-video-player') as HTMLVideoElement;
+    stubPlayback(video, 120, 120);
+
+    // Before ended there is no "Get started".
+    fireEvent.play(video);
+    expect(screen.queryByText(/Get started/)).not.toBeInTheDocument();
+
+    fireEvent.ended(video);
+    const cta = screen.getByTestId('welcome-video-cta');
+    expect(cta).toHaveTextContent('Get started →');
+
+    await userEvent.click(cta);
+    await waitFor(() => expect(dismissWelcomeVideoApi).toHaveBeenCalled());
+    await waitFor(() => expect(navigate).toHaveBeenCalledWith('/specs', { replace: true }));
+    expect(sessionStorage.getItem('welcomeVideoDismissed')).toBe('1');
+  });
+
+  it('the "Skip, I\'m already familiar" link is present and dismisses in every state (ac-9)', async () => {
+    tagAc(AC(9));
+    const { unmount } = renderPage();
+    const video = screen.getByTestId('welcome-video-player') as HTMLVideoElement;
+
+    // idle
+    expect(screen.getByTestId('welcome-video-skip')).toBeInTheDocument();
+    // playing
+    fireEvent.play(video);
+    expect(screen.getByTestId('welcome-video-skip')).toBeInTheDocument();
+    // ended
+    fireEvent.ended(video);
+    expect(screen.getByTestId('welcome-video-skip')).toBeInTheDocument();
+
+    // and it actually dismisses
+    await userEvent.click(screen.getByTestId('welcome-video-skip'));
+    await waitFor(() => expect(navigate).toHaveBeenCalledWith('/specs', { replace: true }));
+    unmount();
+  });
+
+  it('rewatch mode (rewatch=1) is unchanged — "Back to Memex", no Play-now machine (ac-10)', async () => {
+    tagAc(AC(10));
+    renderPage('/welcome?rewatch=1');
+
+    expect(screen.getByTestId('welcome-video-back')).toHaveTextContent('Back to Memex');
+    expect(screen.queryByTestId('welcome-video-cta')).not.toBeInTheDocument();
+    expect(screen.queryByText('Play now')).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByTestId('welcome-video-back'));
+    expect(navigate).toHaveBeenCalledWith('/specs', { replace: true });
+  });
+
+  it('play → end → "Get started" emits video_started + video_completed and NOT video_skipped (ac-11)', async () => {
+    tagAc(AC(11));
+    renderPage();
+    const video = screen.getByTestId('welcome-video-player') as HTMLVideoElement;
+    stubPlayback(video, 120, 120);
+
+    fireEvent.play(video);
+    fireEvent.ended(video);
+    await userEvent.click(screen.getByTestId('welcome-video-cta')); // now "Get started →"
+
+    const kinds = (name: string) => track.mock.calls.filter((c) => c[0] === name);
+    expect(kinds('onboarding.video_started')).toHaveLength(1);
+    expect(kinds('onboarding.video_completed')).toHaveLength(1);
+    expect(kinds('onboarding.video_skipped')).toHaveLength(0);
+  });
+});

--- a/packages/ui/src/pages/WelcomePage.telemetry.test.tsx
+++ b/packages/ui/src/pages/WelcomePage.telemetry.test.tsx
@@ -83,13 +83,17 @@ describe('WelcomePage — onboarding.video_* telemetry', () => {
     expect(completed[0][1]).toMatchObject({ video_id: 'welcome-to-memex-v4', percent_watched: 100 });
   });
 
-  it('fires onboarding.video_skipped ONCE when the CTA dismisses before completion', async () => {
+  // spec-462: before completion the primary button is "▶ Play now" / "Playing…",
+  // never a dismiss — so the skip-before-completion path is the "Skip" link (and the
+  // × close, covered by the next test). The primary button only dismisses once it
+  // has become "Get started →" (post-ended), and that path is NOT a skip.
+  it('fires onboarding.video_skipped ONCE when the Skip link dismisses before completion', async () => {
     renderPage();
     const video = screen.getByTestId('welcome-video-player') as HTMLVideoElement;
     stubPlayback(video, 10, 120);
     fireEvent.play(video);
 
-    await userEvent.click(screen.getByTestId('welcome-video-cta'));
+    await userEvent.click(screen.getByTestId('welcome-video-skip'));
 
     const skipped = track.mock.calls.filter((c) => c[0] === 'onboarding.video_skipped');
     expect(skipped).toHaveLength(1);

--- a/packages/ui/src/pages/WelcomePage.tsx
+++ b/packages/ui/src/pages/WelcomePage.tsx
@@ -60,6 +60,18 @@ export function WelcomePage() {
   const isRewatch = searchParams.get('rewatch') === '1';
   const [dismissing, setDismissing] = useState(false);
 
+  // spec-462: the primary button is a three-state machine so it can never be
+  // mistaken for a skip. Before spec-462 the loud blue button and the quiet
+  // "Skip" link both called permanentDismiss — the loudest element on the page
+  // was a disguised skip, and users read it as "play". Now:
+  //   idle    → "▶ Play now"      (loud blue)  → starts playback
+  //   playing → "Playing…"        (quiet)      → inert status, not a skip target
+  //   ended   → "Get started →"   (loud blue)  → permanentDismiss (the real exit)
+  // The "leave without watching" job is already fully covered by the ever-present
+  // "Skip" link, which frees the blue button to become the play affordance. Only
+  // the first-run (non-rewatch) path uses this; rewatch keeps its "Back to Memex".
+  const [buttonPhase, setButtonPhase] = useState<'idle' | 'playing' | 'ended'>('idle');
+
   // spec-444 instrumentation. Refs (not state) so the once-per-view guards can be
   // read/written inside stable useCallbacks without re-creating them, and so
   // replay / seek / pause-resume / multiple play events never re-fire an event.
@@ -82,7 +94,24 @@ export function WelcomePage() {
     track('onboarding.video_call_cta_shown', videoProps(videoRef.current));
   }, [track]);
 
+  // spec-462: clicking "▶ Play now" starts playback. Guarded for jsdom/autoplay —
+  // play() is unimplemented in jsdom (throws) and can reject under autoplay policy;
+  // either way onPlay simply won't fire and the button stays in idle, which is fine.
+  const playVideo = useCallback(() => {
+    const v = videoRef.current;
+    if (!v) return;
+    try {
+      const p = v.play();
+      if (p && typeof p.catch === 'function') p.catch(() => {});
+    } catch {
+      /* jsdom / blocked autoplay — no-op */
+    }
+  }, []);
+
   const onVideoPlay = useCallback(() => {
+    // spec-462: idle → playing on first play; once ended, a replay keeps the
+    // "Get started →" state (the forward move stays available).
+    setButtonPhase((p) => (p === 'ended' ? 'ended' : 'playing'));
     if (startedRef.current) return; // fire once per view
     startedRef.current = true;
     track('onboarding.video_started', videoProps(videoRef.current));
@@ -97,6 +126,7 @@ export function WelcomePage() {
   }, [revealCallCta]);
 
   const onVideoEnded = useCallback(() => {
+    setButtonPhase('ended'); // spec-462: reveal the real "Get started →" forward move
     revealCallCta(); // a short video the viewer finishes should always show the CTA
     if (completedRef.current) return; // fire once per view
     completedRef.current = true;
@@ -185,14 +215,38 @@ export function WelcomePage() {
 
         {!isRewatch ? (
           <>
-            <button
-              data-testid="welcome-video-cta"
-              onClick={permanentDismiss}
-              disabled={dismissing}
-              className="w-full py-3 px-4 rounded-lg bg-blue-600 hover:bg-blue-700 text-white font-semibold text-base transition-colors disabled:opacity-60"
-            >
-              {dismissing ? 'One moment…' : 'Get started →'}
-            </button>
+            {/* spec-462: one primary button, three states. Same testid + reserved
+                height across states so the layout never jumps. idle/ended are the
+                loud blue CTA; playing is a quiet, inert status so it can't be
+                mistaken for a skip target. */}
+            {buttonPhase === 'idle' && (
+              <button
+                data-testid="welcome-video-cta"
+                onClick={playVideo}
+                className="w-full py-3 px-4 rounded-lg bg-blue-600 hover:bg-blue-700 text-white font-semibold text-base transition-colors"
+              >
+                ▶ Play now
+              </button>
+            )}
+            {buttonPhase === 'playing' && (
+              <div
+                data-testid="welcome-video-cta"
+                aria-live="polite"
+                className="w-full py-3 px-4 rounded-lg bg-gray-100 text-gray-400 font-semibold text-base text-center select-none"
+              >
+                Playing…
+              </div>
+            )}
+            {buttonPhase === 'ended' && (
+              <button
+                data-testid="welcome-video-cta"
+                onClick={permanentDismiss}
+                disabled={dismissing}
+                className="w-full py-3 px-4 rounded-lg bg-blue-600 hover:bg-blue-700 text-white font-semibold text-base transition-colors disabled:opacity-60"
+              >
+                {dismissing ? 'One moment…' : 'Get started →'}
+              </button>
+            )}
             <button
               data-testid="welcome-video-skip"
               onClick={permanentDismiss}


### PR DESCRIPTION
## What & why
On `/welcome`, the loud blue **"Get started →"** button and the quiet **"Skip"** link both called `permanentDismiss` — so the loudest element on the page was a *disguised skip*. Users read it as "play", clicked it, and were silently skipped past the explainer (inflating `onboarding.video_skipped`). spec-460 had just lengthened this to a ~3-min v4 explainer, so the accidental skip is costly.

The Skip link already covers "leave without watching", which frees the blue button to become the **play** affordance.

## The change
Primary button is now a three-state machine (non-rewatch mode only), in `packages/ui/src/pages/WelcomePage.tsx`:

| State | Button | Behaviour |
|---|---|---|
| **idle** | ▶ Play now | starts playback (`videoRef.play()`) — no longer navigates |
| **playing** | Playing… | quiet grey, inert `<div>`, survives pause |
| **ended** | Get started → | the real forward move (`permanentDismiss` → `/specs`), appears only on `onEnded` |

- "Skip, I'm already familiar" is unchanged and visible in **all** states (escape hatch).
- Rewatch mode (`?rewatch=1`) untouched ("Back to Memex").
- Button height reserved across states — no layout jump.
- No back-end / schema / gate changes; telemetry contract unchanged.

## Tests
- **New** `WelcomePage.spec-462.test.tsx` (6 unit tests → ac-6..ac-11) and `journey-55-spec-462-welcome-play-button.spec.ts` (3 e2e → ac-6..ac-10).
- **Updated**: the skip-before-completion telemetry case now drives the **Skip** link (the primary button is no longer a pre-completion dismiss); journeys 53 (spec-444) & 54 (spec-460) drive the `<video>` to `ended` before clicking the CTA.
- **Local runs:** unit 20/20 · `tsc --noEmit` clean · `make e2e-cold` (journeys 53/54/55) 10/10.

## Memex
Spec: `mindset-prod/memex-building-itself/specs/spec-462` — in **verify**, all 6 implementation ACs verified, QA report attached. Follow-up to spec-460 → spec-444.

🤖 Generated with [Claude Code](https://claude.com/claude-code)