### PR TITLE
fix(spec-453): register See it verified + Connect with people in the email previewer

### DIFF
--- a/packages/server/src/services/email/preview-samples.ts
+++ b/packages/server/src/services/email/preview-samples.ts
@@ -22,6 +22,8 @@ import {
   buildAssignmentEmail,
   buildConnectedInactiveEmail,
   buildSignedInDormantEmail,
+  buildVerifiedMilestoneEmail,
+  buildConnectPeopleEmail,
 } from "./templates.js";
 
 const BASE = process.env.APP_BASE_URL ?? "https://memex.ai";
@@ -78,6 +80,15 @@ export const EMAIL_PREVIEW_SAMPLES: Record<string, (to: string) => EmailMessage>
     }),
   "activation-signed-in-dormant": (to) =>
     buildSignedInDormantEmail({ to, firstName: "Sample", appUrl: BASE }),
+  // spec-453 — "See it verified" (verified-milestone) + "Connect with people".
+  // Same hyphenated preview-key convention as the spec-427 pair above; the
+  // comms_log keys stay the dotted `activation.verified_milestone` /
+  // `activation.connect_people`. Registered here so both are previewable and
+  // send-testable on int (spec-453/issue-1).
+  "activation-verified-milestone": (to) =>
+    buildVerifiedMilestoneEmail({ to, firstName: "Sample", appUrl: BASE }),
+  "activation-connect-people": (to) =>
+    buildConnectPeopleEmail({ to, firstName: "Sample" }),
 };
 
 export const EMAIL_TEMPLATE_NAMES: string[] = Object.keys(EMAIL_PREVIEW_SAMPLES);


### PR DESCRIPTION
## What
Registers the two spec-453 lifecycle emails in the internal Email Previewer registry (`EMAIL_PREVIEW_SAMPLES`, `packages/server/src/services/email/preview-samples.ts`):

- `activation-verified-milestone` → `buildVerifiedMilestoneEmail` ("See it verified" / *"Green means it's actually done"*)
- `activation-connect-people` → `buildConnectPeopleEmail` ("Connect with people" / *"You've run the loop. Don't run it alone."*)

## Why
Both builders were already send-wired, but neither was in the preview registry — so they didn't appear in the Email Previewer on int. PMs/designers could preview every other onboarding email but not these two. Surfaced when mapping the onboarding-sequence explainer against the int previewer. Closes **spec-453/issue-1**.

Preview keys use the hyphenated convention of the spec-427 pair (`activation-connected-inactive` / `activation-signed-in-dormant`); the dotted `comms_log` keys (`activation.verified_milestone` / `activation.connect_people`) are unchanged.

## Scope / safety
- Dev-tooling only: no runtime send-path, DB schema, or prod surface change. Previewer is gated off prod (spec-226). Sample values only (no PII).
- **std-28 e2e:** N/A — no user-facing flow added or altered (internal, prod-gated dev tool).

## Test plan
- [x] `src/routes/__dev__.test.ts` — 9/9 green. Data-driven over `EMAIL_TEMPLATE_NAMES`, so it now renders + send-tests both new templates through the real preview route.
- [x] `tsc --noEmit` (server) — clean; builder inputs type-correct.
- [x] Full server suite — 5596 passed. The one red (`spec-129 ac-5`) is a local-only env guard (`MEMEX_EMIT_KEY` unset locally; green in CI) and disjoint from this diff.