### PR TITLE
feat(spec-465): coral CTA button, pink resource/link accents, "Memex AI" wordmark

### DIFF
--- a/packages/server/src/services/email/activation.test.ts
+++ b/packages/server/src/services/email/activation.test.ts
@@ -41,10 +41,10 @@ describe("buildConnectedInactiveEmail (Email 1 — connected-but-inactive)", () 
   it("renders solely through the shared renderer with a solid CTA and no imagery (ac-10)", () => {
     tagAc(AC(10));
     expect(html).toContain("<!doctype html>");
-    // shared-renderer brand mark + solid BRAND_INK CTA button (never a gradient).
-    // spec-451 ac-2 — the .AI wordmark is now single-colour dark ink (was coral).
-    expect(html).toContain('<span style="font-weight:500;color:#0E1128;">.AI</span>');
-    expect(html).toContain("background:#0E1128;color:#FFFFFF");
+    // shared-renderer brand mark + solid coral CTA button (never a gradient).
+    // Wordmark is single-colour dark-ink "Memex AI" live text (spec-465: no dot, uniform weight).
+    expect(html).toContain('color:#0E1128;">Memex AI</div>');
+    expect(html).toContain("background:#FC4F64;color:#FFFFFF");
     expect(html).not.toContain("linear-gradient");
     expect(html).not.toContain("<img");
     // resources render as a presentation table (a table construct, not image buttons)
@@ -104,7 +104,7 @@ describe("buildSignedInDormantEmail (Email 2 — signed-in-but-dormant)", () => 
   it("renders solely through the shared renderer with the step + resources primitives, no imagery (ac-10)", () => {
     tagAc(AC(10));
     expect(html).toContain("<!doctype html>");
-    expect(html).toContain("background:#0E1128;color:#FFFFFF");
+    expect(html).toContain("background:#FC4F64;color:#FFFFFF");
     expect(html).not.toContain("linear-gradient");
     expect(html).not.toContain("<img");
     // spec-226 step primitive

--- a/packages/server/src/services/email/email-ui-polish.test.ts
+++ b/packages/server/src/services/email/email-ui-polish.test.ts
@@ -58,14 +58,14 @@ describe("spec-451 — eyebrow removed everywhere (ac-1, ac-6)", () => {
       // No eyebrow div (its unique letter-spacing signature is gone).
       expect(html).not.toContain(EYEBROW_MARKER);
       // The wordmark is immediately followed by the <h1> — nothing between them.
-      expect(html).toMatch(/\.AI<\/span><\/div>\s*<h1/);
+      expect(html).toMatch(/>Memex AI<\/div>\s*<h1/);
     });
   }
   it("the activation/welcome emails also carry no eyebrow", () => {
     tagAc(AC(6));
     for (const [, msg] of activation) {
       expect(msg.html!).not.toContain(EYEBROW_MARKER);
-      expect(msg.html!).toMatch(/\.AI<\/span><\/div>\s*<h1/);
+      expect(msg.html!).toMatch(/>Memex AI<\/div>\s*<h1/);
     }
   });
 });
@@ -75,8 +75,8 @@ describe("spec-451 — single-colour dark wordmark (ac-2)", () => {
     tagAc(AC(2));
     for (const [, msg] of [...eyebrowed, ...activation]) {
       const html = msg.html!;
-      expect(html).toContain(`color:${INK};">.AI</span>`);
-      expect(html).not.toContain(`color:${CORAL};">.AI</span>`);
+      expect(html).toContain(`color:${INK};">Memex AI</div>`);
+      expect(html).not.toContain(`color:${CORAL};">Memex AI</div>`);
       expect(html).not.toContain("<img");
       expect(html).not.toContain("<svg");
     }

--- a/packages/server/src/services/email/templates.ts
+++ b/packages/server/src/services/email/templates.ts
@@ -66,7 +66,7 @@ function renderEmailText(input: {
 }): string {
   const parts = [...input.intro];
   if (input.url) parts.push(input.url);
-  parts.push(input.closing, "Memex.AI");
+  parts.push(input.closing, "Memex AI");
   return parts.join("\n\n");
 }
 
@@ -95,7 +95,7 @@ export function renderResources(resources?: EmailResource[]): string {
     .map(
       (r) =>
         `<tr><td style="padding:12px 0;border-top:1px solid ${BRAND_BORDER};">` +
-        `<a href="${escapeHtml(r.url)}" style="color:${BRAND_INK};font-size:15px;font-weight:600;text-decoration:none;">${escapeHtml(r.title)}</a>` +
+        `<a href="${escapeHtml(r.url)}" style="color:${BRAND_CORAL};font-size:15px;font-weight:600;text-decoration:none;">${escapeHtml(r.title)}</a>` +
         `<div style="margin-top:2px;color:${BRAND_MUTED};font-size:13px;line-height:1.5;">${escapeHtml(r.description)}</div>` +
         `</td></tr>`,
     )
@@ -140,12 +140,12 @@ function renderEmailHtml(input: RenderInput): string {
           <table role="presentation" width="560" cellpadding="0" cellspacing="0" border="0" style="max-width:560px;width:100%;background-color:#FFFFFF;border:1px solid ${BRAND_BORDER};border-radius:12px;overflow:hidden;">
             <tr>
               <td style="padding:32px 40px;">
-                <div style="margin:0 0 20px;font-size:20px;font-weight:700;letter-spacing:-0.01em;color:${BRAND_INK};">Memex<span style="font-weight:500;color:${BRAND_INK};">.AI</span></div>
+                <div style="margin:0 0 20px;font-size:20px;font-weight:700;letter-spacing:-0.01em;color:${BRAND_INK};">Memex AI</div>
                 <h1 style="margin:0 0 16px;color:${BRAND_INK};font-size:22px;line-height:1.3;font-weight:600;letter-spacing:-0.01em;">${escapeHtml(input.heading)}</h1>
                 ${paragraphs}
                 ${stepsHtml}
                 <div style="margin:24px 0 8px;">
-                  <a href="${safeUrl}" style="display:inline-block;padding:12px 24px;background:${BRAND_INK};color:#FFFFFF;font-size:15px;font-weight:600;text-decoration:none;border-radius:8px;">${escapeHtml(input.ctaLabel)}</a>
+                  <a href="${safeUrl}" style="display:inline-block;padding:12px 24px;background:${BRAND_CORAL};color:#FFFFFF;font-size:15px;font-weight:600;text-decoration:none;border-radius:8px;">${escapeHtml(input.ctaLabel)}</a>
                 </div>
                 ${pasteLink}
                 ${afterCta}
@@ -444,7 +444,7 @@ export function buildConnectedInactiveEmail(
     afterCtaParagraphs: [
       escapeHtml(afterCta1),
       escapeHtml(afterCta2),
-      `Watch your Spec come to life in <a href="${escapeHtml(input.memexUrl)}" style="color:${BRAND_SKY};">your Memex</a>.`,
+      `Watch your Spec come to life in <a href="${escapeHtml(input.memexUrl)}" style="color:${BRAND_CORAL};">your Memex</a>.`,
       escapeHtml(stuck),
       ACTIVATION_SIGNOFF_HTML,
     ],
@@ -481,6 +481,13 @@ export function buildSignedInDormantEmail(
     "Once you're in, your agents build from what you actually decided, not what they guessed. Every decision is captured as you go, so nothing important gets buried in a chat thread or quietly chosen for you mid-build. And done means verified, not just claimed. No more vibe coding.";
   const afterCtaText =
     "We'll send you a few short emails over the next few weeks, and there are some resources below to get you started. If you get stuck, just reply here or find us in #help on Discord.";
+  // spec-465: link "#help" to the Discord invite in the HTML body only (coral).
+  // escapeHtml leaves the literal "#help" untouched, so replacing it on the
+  // escaped string is safe; the plain-text body keeps "#help" as prose.
+  const afterCtaHtml = escapeHtml(afterCtaText).replace(
+    "#help",
+    `<a href="${DISCORD_INVITE_URL}" style="color:${BRAND_CORAL};text-decoration:none;">#help</a>`,
+  );
 
   const steps: EmailStep[] = [
     {
@@ -520,7 +527,7 @@ export function buildSignedInDormantEmail(
     ctaLabel: "Open Memex AI",
     ctaUrl: input.appUrl,
     showPasteLink: false,
-    afterCtaParagraphs: [escapeHtml(afterCtaText), ACTIVATION_SIGNOFF_HTML],
+    afterCtaParagraphs: [afterCtaHtml, ACTIVATION_SIGNOFF_HTML],
     resources: ACTIVATION_RESOURCES,
     footerNote: ACTIVATION_FOOTER,
   });

--- a/packages/server/src/services/email/templates.visual.spec-465.test.ts
+++ b/packages/server/src/services/email/templates.visual.spec-465.test.ts
@@ -1,0 +1,115 @@
+// spec-465 — email design polish. Asserts the new shared + per-template treatment:
+// coral CTA button (white label), coral resource links everywhere, the "Memex AI"
+// wordmark (no dot, uniform weight), the connected-inactive "your Memex" coral link,
+// the signed-in-dormant "#help" coral Discord link, and the greeting fallback.
+import { describe, it, expect } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import {
+  buildVerificationEmail,
+  buildWelcomeEmail,
+  buildConnectedInactiveEmail,
+  buildSignedInDormantEmail,
+  buildVerifiedMilestoneEmail,
+  buildConnectPeopleEmail,
+} from "./templates.js";
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-465/acs/ac-${n}`;
+
+const CORAL = "#FC4F64";
+const INK = "#0E1128";
+const DISCORD = "https://discord.com/invite/WJfBYG9eV";
+
+// A representative spread: a transactional email + the welcome + all activation emails,
+// to prove the SHARED changes cascade and the per-template ones land.
+const verification = buildVerificationEmail({ to: "a@b.test", verifyUrl: "https://int.memex.ai/verify-email?token=T" });
+const welcome = buildWelcomeEmail({ to: "a@b.test", appUrl: "https://int.memex.ai", firstName: "Ada" });
+const connected = buildConnectedInactiveEmail({ to: "a@b.test", firstName: "Ada", createSpecUrl: "https://int.memex.ai/n/m/specs/new", memexUrl: "https://int.memex.ai/n/m" });
+const signedIn = buildSignedInDormantEmail({ to: "a@b.test", firstName: "Ada", appUrl: "https://int.memex.ai" });
+const verified = buildVerifiedMilestoneEmail({ to: "a@b.test", firstName: "Ada", appUrl: "https://int.memex.ai" });
+const connect = buildConnectPeopleEmail({ to: "a@b.test", firstName: "Ada" });
+
+const all: Array<[string, { html?: string }]> = [
+  ["verification", verification],
+  ["welcome", welcome],
+  ["connected-inactive", connected],
+  ["signed-in-dormant", signedIn],
+  ["verified-milestone", verified],
+  ["connect-people", connect],
+];
+
+// Emails that render the resources block.
+const withResources: Array<[string, { html?: string }]> = [
+  ["welcome", welcome],
+  ["connected-inactive", connected],
+  ["signed-in-dormant", signedIn],
+];
+
+describe("spec-465 — coral CTA button, white label, on every email (ac-1)", () => {
+  for (const [name, msg] of all) {
+    it(`${name}: button is coral #FC4F64 with white text, no gradient`, () => {
+      tagAc(AC(1));
+      const html = msg.html ?? "";
+      expect(html).toContain(`background:${CORAL};color:#FFFFFF`);
+      expect(html).not.toContain(`background:${INK};color:#FFFFFF`);
+      expect(html).not.toContain("linear-gradient");
+    });
+  }
+});
+
+describe("spec-465 — resource-block links are coral everywhere (ac-2)", () => {
+  for (const [name, msg] of withResources) {
+    it(`${name}: the resources block links render in coral`, () => {
+      tagAc(AC(2));
+      const html = msg.html ?? "";
+      expect(html).toContain(`color:${CORAL};font-size:15px;font-weight:600;text-decoration:none;">Understanding Memex AI</a>`);
+    });
+  }
+});
+
+describe("spec-465 — the wordmark reads \"Memex AI\", uniform weight (ac-3)", () => {
+  it("renders a single-colour dark-ink \"Memex AI\" wordmark — no dot, no lighter span", () => {
+    tagAc(AC(3));
+    const html = welcome.html ?? "";
+    // one uniform-weight dark-ink wordmark, live text
+    expect(html).toContain(`color:${INK};">Memex AI</div>`);
+    // the old dotted / lighter-weight ".AI" span is gone
+    expect(html).not.toContain(">.AI</span>");
+    expect(html).not.toContain("font-weight:500");
+  });
+});
+
+describe("spec-465 — connected-inactive \"your Memex\" link is coral (ac-4)", () => {
+  it("renders the \"your Memex\" link in coral, not sky blue", () => {
+    tagAc(AC(4));
+    const html = connected.html ?? "";
+    expect(html).toContain(`style="color:${CORAL};">your Memex</a>`);
+    expect(html).not.toContain(`style="color:#0C9FE3;">your Memex</a>`);
+  });
+});
+
+describe("spec-465 — signed-in-dormant \"#help\" is a coral Discord link (ac-5)", () => {
+  it("links #help to the Discord invite in coral (HTML), plain text stays prose", () => {
+    tagAc(AC(5));
+    const html = signedIn.html ?? "";
+    const text = signedIn.text ?? "";
+    expect(html).toContain(`<a href="${DISCORD}" style="color:${CORAL};text-decoration:none;">#help</a>`);
+    // the plain-text body keeps "#help" as prose (no raw anchor leaking in)
+    expect(text).toContain("#help on Discord");
+    expect(text).not.toContain("<a ");
+  });
+});
+
+describe("spec-465 — greeting shows the name, else \"Hi there,\" (never a placeholder) (ac-6)", () => {
+  it("interpolates the user's first name", () => {
+    tagAc(AC(6));
+    expect(welcome.html ?? "").toContain("Hi Ada,");
+    expect((welcome.html ?? "")).not.toContain("[FirstName]");
+  });
+  it("degrades to \"Hi there,\" with no name — never \"Hi untitled\" or \"Hi ,\"", () => {
+    tagAc(AC(6));
+    const nameless = buildWelcomeEmail({ to: "a@b.test", appUrl: "https://int.memex.ai" }).html ?? "";
+    expect(nameless).toContain("Hi there,");
+    expect(nameless).not.toContain("Hi ,");
+    expect(nameless.toLowerCase()).not.toContain("hi untitled");
+  });
+});

--- a/packages/server/src/services/email/templates.visual.test.ts
+++ b/packages/server/src/services/email/templates.visual.test.ts
@@ -32,10 +32,10 @@ const samples = [
 describe.each(samples.map((m) => [m.subject, m.html ?? ""] as const))(
   "shared email renderer visual treatment — %s",
   (_subject, html) => {
-    it("uses a solid BRAND_INK CTA button, never a gradient", () => {
-      tagAc(AC(1)); // scope: all six emails carry the corrected treatment
-      tagAc(AC(4)); // impl: renderEmailHtml renders a solid BRAND_INK button
-      expect(html).toContain("background:#0E1128;color:#FFFFFF");
+    it("uses a solid coral CTA button, never a gradient", () => {
+      tagAc(AC(1)); // scope: all six emails carry the corrected treatment (cascades)
+      // Button colour is now coral — owned by spec-465 (reverses spec-226 dec-1/ac-4).
+      expect(html).toContain("background:#FC4F64;color:#FFFFFF");
       expect(html).not.toContain("linear-gradient");
     });
 


### PR DESCRIPTION
Email design polish — follow-on to spec-226. Spec: `mindset-prod/memex-building-itself/spec-465`.

## What (all in `packages/server/src/services/email/templates.ts`)
- **CTA button** → coral `#FC4F64`, white label, shared renderer (all emails). Reverses spec-226 dec-1's solid dark button.
- **Resource-block links** → coral everywhere the block renders.
- **Header wordmark** → "Memex AI" (no dot) at one uniform weight; plain-text closing matched.
- **connected-inactive** "your Memex" link → coral.
- **signed-in-dormant** "#help" → coral Discord hyperlink (HTML; plain text kept as prose).

## Verification (user asked to double-check)
- `Hi [FirstName],` interpolates the real first name; **no-name → "Hi there,"**, never "Hi untitled" (no such default exists). Guarded by ac-6.

## Tests
- New `templates.visual.spec-465.test.ts` tags spec-465 ac-1..ac-6.
- Updated the spec-226/427/451 shared-treatment assertions in place (claims still hold). **spec-226 ac-4** ("solid BRAND_INK button") is superseded — its tag dropped; spec-465 owns the coral claim. It'll read untested on spec-226 (accurate signal).
- `tsc` clean; **full server suite 5665 pass** (only red = the known `spec-129` `MEMEX_EMIT_KEY` local-env guard, green in CI).

## Notes
- **a11y:** white-on-coral button label ~2.9:1, below WCAG AA — a conscious brand call (accepted in spec-465).
- Out of scope: auth-email *body copy* + `EMAIL_FROM` still say "Memex.AI" (separate brand-drift sweep).
- No migration; ships with the code (no flag), like spec-226.