### PR TITLE
feat(spec-468): recolour email accent coral #FC4F64 → brand blue #0482DC

### DIFF
--- a/packages/server/src/services/email/activation.test.ts
+++ b/packages/server/src/services/email/activation.test.ts
@@ -44,7 +44,7 @@ describe("buildConnectedInactiveEmail (Email 1 — connected-but-inactive)", () 
     // shared-renderer brand mark + solid coral CTA button (never a gradient).
     // Wordmark is single-colour dark-ink "Memex AI" live text (spec-465: no dot, uniform weight).
     expect(html).toContain('color:#0E1128;">Memex AI</div>');
-    expect(html).toContain("background:#FC4F64;color:#FFFFFF");
+    expect(html).toContain("background:#0482DC;color:#FFFFFF");
     expect(html).not.toContain("linear-gradient");
     expect(html).not.toContain("<img");
     // resources render as a presentation table (a table construct, not image buttons)
@@ -104,7 +104,7 @@ describe("buildSignedInDormantEmail (Email 2 — signed-in-but-dormant)", () => 
   it("renders solely through the shared renderer with the step + resources primitives, no imagery (ac-10)", () => {
     tagAc(AC(10));
     expect(html).toContain("<!doctype html>");
-    expect(html).toContain("background:#FC4F64;color:#FFFFFF");
+    expect(html).toContain("background:#0482DC;color:#FFFFFF");
     expect(html).not.toContain("linear-gradient");
     expect(html).not.toContain("<img");
     // spec-226 step primitive

--- a/packages/server/src/services/email/email-ui-polish.test.ts
+++ b/packages/server/src/services/email/email-ui-polish.test.ts
@@ -22,7 +22,7 @@ import {
 const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-451/acs/ac-${n}`;
 
 // Brand colours (mirror templates.ts).
-const CORAL = "#FC4F64";
+const CORAL = "#0482DC";
 const INK = "#0E1128";
 const SKY = "#0C9FE3";
 const MONO_MARKER = "'SF Mono'"; // MONO_STACK signature
@@ -96,12 +96,12 @@ describe("spec-451 — spacing between wordmark and headline (ac-3, ac-8)", () =
 
 describe("spec-451 — step labels restyled, '// Step N' kept (ac-4, ac-7, ac-8)", () => {
   const stepsHtml = renderSteps([{ label: "// Step 1", title: "Connect", body: "Body." }]);
-  it("label is body-font, bold, coral — not blue mono — and keeps the '// ' prefix", () => {
+  it("label is body-font, bold, accent #0482DC — not the old blue mono — and keeps the '// ' prefix", () => {
     tagAc(AC(4));
     tagAc(AC(7));
     // The "// Step 1" text is retained.
     expect(stepsHtml).toContain("// Step 1");
-    // Restyled: coral + bold, no longer blue mono / eyebrow letter-spacing.
+    // Restyled: accent #0482DC + bold, no longer blue mono / eyebrow letter-spacing.
     expect(stepsHtml).toContain(`color:${CORAL}`);
     expect(stepsHtml).toContain("font-weight:700");
     expect(stepsHtml).not.toContain(SKY);

--- a/packages/server/src/services/email/templates.ts
+++ b/packages/server/src/services/email/templates.ts
@@ -8,7 +8,7 @@ import type { EmailMessage } from "./sender.js";
 // renders consistently across Gmail, Apple Mail, Outlook, etc.
 
 const BRAND_INK = "#0E1128";
-const BRAND_CORAL = "#FC4F64";
+const BRAND_ACCENT = "#0482DC";
 const BRAND_SKY = "#0C9FE3";
 const BRAND_MUTED = "#6B7280";
 const BRAND_BORDER = "#E5E7EB";
@@ -78,7 +78,7 @@ export function renderSteps(steps?: EmailStep[]): string {
     .map(
       (s) =>
         `<div style="margin:20px 0;">` +
-        `<div style="font-family:${FONT_STACK};font-size:15px;font-weight:700;color:${BRAND_CORAL};">${escapeHtml(s.label)}</div>` +
+        `<div style="font-family:${FONT_STACK};font-size:15px;font-weight:700;color:${BRAND_ACCENT};">${escapeHtml(s.label)}</div>` +
         `<div style="margin:6px 0 2px;font-size:16px;font-weight:600;color:${BRAND_INK};">${escapeHtml(s.title)}</div>` +
         `<div style="color:${BRAND_INK};font-size:15px;line-height:1.6;">${escapeHtml(s.body)}</div>` +
         `</div>`,
@@ -95,7 +95,7 @@ export function renderResources(resources?: EmailResource[]): string {
     .map(
       (r) =>
         `<tr><td style="padding:12px 0;border-top:1px solid ${BRAND_BORDER};">` +
-        `<a href="${escapeHtml(r.url)}" style="color:${BRAND_CORAL};font-size:15px;font-weight:600;text-decoration:none;">${escapeHtml(r.title)}</a>` +
+        `<a href="${escapeHtml(r.url)}" style="color:${BRAND_ACCENT};font-size:15px;font-weight:600;text-decoration:none;">${escapeHtml(r.title)}</a>` +
         `<div style="margin-top:2px;color:${BRAND_MUTED};font-size:13px;line-height:1.5;">${escapeHtml(r.description)}</div>` +
         `</td></tr>`,
     )
@@ -145,7 +145,7 @@ function renderEmailHtml(input: RenderInput): string {
                 ${paragraphs}
                 ${stepsHtml}
                 <div style="margin:24px 0 8px;">
-                  <a href="${safeUrl}" style="display:inline-block;padding:12px 24px;background:${BRAND_CORAL};color:#FFFFFF;font-size:15px;font-weight:600;text-decoration:none;border-radius:8px;">${escapeHtml(input.ctaLabel)}</a>
+                  <a href="${safeUrl}" style="display:inline-block;padding:12px 24px;background:${BRAND_ACCENT};color:#FFFFFF;font-size:15px;font-weight:600;text-decoration:none;border-radius:8px;">${escapeHtml(input.ctaLabel)}</a>
                 </div>
                 ${pasteLink}
                 ${afterCta}
@@ -444,7 +444,7 @@ export function buildConnectedInactiveEmail(
     afterCtaParagraphs: [
       escapeHtml(afterCta1),
       escapeHtml(afterCta2),
-      `Watch your Spec come to life in <a href="${escapeHtml(input.memexUrl)}" style="color:${BRAND_CORAL};">your Memex</a>.`,
+      `Watch your Spec come to life in <a href="${escapeHtml(input.memexUrl)}" style="color:${BRAND_ACCENT};">your Memex</a>.`,
       escapeHtml(stuck),
       ACTIVATION_SIGNOFF_HTML,
     ],
@@ -486,7 +486,7 @@ export function buildSignedInDormantEmail(
   // escaped string is safe; the plain-text body keeps "#help" as prose.
   const afterCtaHtml = escapeHtml(afterCtaText).replace(
     "#help",
-    `<a href="${DISCORD_INVITE_URL}" style="color:${BRAND_CORAL};text-decoration:none;">#help</a>`,
+    `<a href="${DISCORD_INVITE_URL}" style="color:${BRAND_ACCENT};text-decoration:none;">#help</a>`,
   );
 
   const steps: EmailStep[] = [

--- a/packages/server/src/services/email/templates.visual.spec-465.test.ts
+++ b/packages/server/src/services/email/templates.visual.spec-465.test.ts
@@ -1,101 +1,24 @@
-// spec-465 — email design polish. Asserts the new shared + per-template treatment:
-// coral CTA button (white label), coral resource links everywhere, the "Memex AI"
-// wordmark (no dot, uniform weight), the connected-inactive "your Memex" coral link,
-// the signed-in-dormant "#help" coral Discord link, and the greeting fallback.
+// spec-465 — email design polish. The accent-COLOUR assertions moved to spec-468
+// (coral #FC4F64 → brand blue #0482DC); this file retains spec-465's still-valid,
+// colour-independent claims: the "Memex AI" wordmark (ac-3) and the greeting
+// fallback (ac-6). spec-465's coral colour ACs (ac-1/ac-2/ac-4/ac-5) are superseded
+// by spec-468 and intentionally no longer tagged here.
 import { describe, it, expect } from "vitest";
 import { tagAc } from "@memex-ai-ac/vitest";
-import {
-  buildVerificationEmail,
-  buildWelcomeEmail,
-  buildConnectedInactiveEmail,
-  buildSignedInDormantEmail,
-  buildVerifiedMilestoneEmail,
-  buildConnectPeopleEmail,
-} from "./templates.js";
+import { buildWelcomeEmail } from "./templates.js";
 
 const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-465/acs/ac-${n}`;
-
-const CORAL = "#FC4F64";
 const INK = "#0E1128";
-const DISCORD = "https://discord.com/invite/WJfBYG9eV";
 
-// A representative spread: a transactional email + the welcome + all activation emails,
-// to prove the SHARED changes cascade and the per-template ones land.
-const verification = buildVerificationEmail({ to: "a@b.test", verifyUrl: "https://int.memex.ai/verify-email?token=T" });
 const welcome = buildWelcomeEmail({ to: "a@b.test", appUrl: "https://int.memex.ai", firstName: "Ada" });
-const connected = buildConnectedInactiveEmail({ to: "a@b.test", firstName: "Ada", createSpecUrl: "https://int.memex.ai/n/m/specs/new", memexUrl: "https://int.memex.ai/n/m" });
-const signedIn = buildSignedInDormantEmail({ to: "a@b.test", firstName: "Ada", appUrl: "https://int.memex.ai" });
-const verified = buildVerifiedMilestoneEmail({ to: "a@b.test", firstName: "Ada", appUrl: "https://int.memex.ai" });
-const connect = buildConnectPeopleEmail({ to: "a@b.test", firstName: "Ada" });
-
-const all: Array<[string, { html?: string }]> = [
-  ["verification", verification],
-  ["welcome", welcome],
-  ["connected-inactive", connected],
-  ["signed-in-dormant", signedIn],
-  ["verified-milestone", verified],
-  ["connect-people", connect],
-];
-
-// Emails that render the resources block.
-const withResources: Array<[string, { html?: string }]> = [
-  ["welcome", welcome],
-  ["connected-inactive", connected],
-  ["signed-in-dormant", signedIn],
-];
-
-describe("spec-465 — coral CTA button, white label, on every email (ac-1)", () => {
-  for (const [name, msg] of all) {
-    it(`${name}: button is coral #FC4F64 with white text, no gradient`, () => {
-      tagAc(AC(1));
-      const html = msg.html ?? "";
-      expect(html).toContain(`background:${CORAL};color:#FFFFFF`);
-      expect(html).not.toContain(`background:${INK};color:#FFFFFF`);
-      expect(html).not.toContain("linear-gradient");
-    });
-  }
-});
-
-describe("spec-465 — resource-block links are coral everywhere (ac-2)", () => {
-  for (const [name, msg] of withResources) {
-    it(`${name}: the resources block links render in coral`, () => {
-      tagAc(AC(2));
-      const html = msg.html ?? "";
-      expect(html).toContain(`color:${CORAL};font-size:15px;font-weight:600;text-decoration:none;">Understanding Memex AI</a>`);
-    });
-  }
-});
 
 describe("spec-465 — the wordmark reads \"Memex AI\", uniform weight (ac-3)", () => {
   it("renders a single-colour dark-ink \"Memex AI\" wordmark — no dot, no lighter span", () => {
     tagAc(AC(3));
     const html = welcome.html ?? "";
-    // one uniform-weight dark-ink wordmark, live text
     expect(html).toContain(`color:${INK};">Memex AI</div>`);
-    // the old dotted / lighter-weight ".AI" span is gone
     expect(html).not.toContain(">.AI</span>");
     expect(html).not.toContain("font-weight:500");
-  });
-});
-
-describe("spec-465 — connected-inactive \"your Memex\" link is coral (ac-4)", () => {
-  it("renders the \"your Memex\" link in coral, not sky blue", () => {
-    tagAc(AC(4));
-    const html = connected.html ?? "";
-    expect(html).toContain(`style="color:${CORAL};">your Memex</a>`);
-    expect(html).not.toContain(`style="color:#0C9FE3;">your Memex</a>`);
-  });
-});
-
-describe("spec-465 — signed-in-dormant \"#help\" is a coral Discord link (ac-5)", () => {
-  it("links #help to the Discord invite in coral (HTML), plain text stays prose", () => {
-    tagAc(AC(5));
-    const html = signedIn.html ?? "";
-    const text = signedIn.text ?? "";
-    expect(html).toContain(`<a href="${DISCORD}" style="color:${CORAL};text-decoration:none;">#help</a>`);
-    // the plain-text body keeps "#help" as prose (no raw anchor leaking in)
-    expect(text).toContain("#help on Discord");
-    expect(text).not.toContain("<a ");
   });
 });
 

--- a/packages/server/src/services/email/templates.visual.spec-468.test.ts
+++ b/packages/server/src/services/email/templates.visual.spec-468.test.ts
@@ -1,0 +1,99 @@
+// spec-468 — email accent recolour: coral #FC4F64 → brand blue #0482DC.
+// Owns every accent-colour assertion: CTA button, "// Step N" labels, resource
+// links, connected-inactive "your Memex", signed-in-dormant "#help" — plus a
+// no-coral-anywhere guard. (Supersedes spec-465's coral colour ACs + spec-451's
+// coral step-label.)
+import { describe, it, expect } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import {
+  buildVerificationEmail,
+  buildWelcomeEmail,
+  buildConnectedInactiveEmail,
+  buildSignedInDormantEmail,
+  buildVerifiedMilestoneEmail,
+  buildConnectPeopleEmail,
+} from "./templates.js";
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-468/acs/ac-${n}`;
+const ACCENT = "#0482DC";
+const CORAL = "#FC4F64";
+const DISCORD = "https://discord.com/invite/WJfBYG9eV";
+
+const verification = buildVerificationEmail({ to: "a@b.test", verifyUrl: "https://int.memex.ai/verify-email?token=T" });
+const welcome = buildWelcomeEmail({ to: "a@b.test", appUrl: "https://int.memex.ai", firstName: "Ada" });
+const connected = buildConnectedInactiveEmail({ to: "a@b.test", firstName: "Ada", createSpecUrl: "https://int.memex.ai/n/m/specs/new", memexUrl: "https://int.memex.ai/n/m" });
+const signedIn = buildSignedInDormantEmail({ to: "a@b.test", firstName: "Ada", appUrl: "https://int.memex.ai" });
+const verified = buildVerifiedMilestoneEmail({ to: "a@b.test", firstName: "Ada", appUrl: "https://int.memex.ai" });
+const connect = buildConnectPeopleEmail({ to: "a@b.test", firstName: "Ada" });
+
+const all: Array<[string, { html?: string }]> = [
+  ["verification", verification],
+  ["welcome", welcome],
+  ["connected-inactive", connected],
+  ["signed-in-dormant", signedIn],
+  ["verified-milestone", verified],
+  ["connect-people", connect],
+];
+const withResources: Array<[string, { html?: string }]> = [
+  ["welcome", welcome],
+  ["connected-inactive", connected],
+  ["signed-in-dormant", signedIn],
+];
+
+describe("spec-468 — CTA button is #0482DC with white text (ac-1, ac-3)", () => {
+  for (const [name, msg] of all) {
+    it(`${name}: button background #0482DC, white label, no gradient`, () => {
+      tagAc(AC(1));
+      tagAc(AC(3));
+      const html = msg.html ?? "";
+      expect(html).toContain(`background:${ACCENT};color:#FFFFFF`);
+      expect(html).not.toContain(`background:${CORAL}`);
+      expect(html).not.toContain("linear-gradient");
+    });
+  }
+});
+
+describe("spec-468 — step labels + resource links are #0482DC (ac-1)", () => {
+  it("the \"// Step N\" labels render in #0482DC (welcome + signed-in-dormant)", () => {
+    tagAc(AC(1));
+    expect(welcome.html ?? "").toContain(`color:${ACCENT};">// Step 1`);
+    expect(signedIn.html ?? "").toContain(`color:${ACCENT};">// Step 1`);
+  });
+  for (const [name, msg] of withResources) {
+    it(`${name}: resource-block links render in #0482DC`, () => {
+      tagAc(AC(1));
+      expect(msg.html ?? "").toContain(`color:${ACCENT};font-size:15px;font-weight:600;text-decoration:none;">Understanding Memex AI</a>`);
+    });
+  }
+});
+
+describe("spec-468 — per-template accent links are #0482DC (ac-1)", () => {
+  it("connected-inactive \"your Memex\" link is #0482DC", () => {
+    tagAc(AC(1));
+    expect(connected.html ?? "").toContain(`style="color:${ACCENT};">your Memex</a>`);
+  });
+  it("signed-in-dormant \"#help\" is a #0482DC Discord link", () => {
+    tagAc(AC(1));
+    expect(signedIn.html ?? "").toContain(`<a href="${DISCORD}" style="color:${ACCENT};text-decoration:none;">#help</a>`);
+  });
+});
+
+describe("spec-468 — no coral remains anywhere (ac-2)", () => {
+  for (const [name, msg] of all) {
+    it(`${name}: rendered HTML contains no #FC4F64`, () => {
+      tagAc(AC(2));
+      expect((msg.html ?? "").toUpperCase()).not.toContain(CORAL);
+    });
+  }
+});
+
+describe("spec-468 — presentation-only, accent aside (ac-4)", () => {
+  it("the verification email keeps its structure (doctype, solid button, no imagery) with the new accent", () => {
+    tagAc(AC(4));
+    const html = verification.html ?? "";
+    expect(html).toContain("<!doctype html>");
+    expect(html).toContain(`background:${ACCENT};color:#FFFFFF`);
+    expect(html).not.toContain("linear-gradient");
+    expect(html).not.toContain("<img");
+  });
+});

--- a/packages/server/src/services/email/templates.visual.test.ts
+++ b/packages/server/src/services/email/templates.visual.test.ts
@@ -35,7 +35,7 @@ describe.each(samples.map((m) => [m.subject, m.html ?? ""] as const))(
     it("uses a solid coral CTA button, never a gradient", () => {
       tagAc(AC(1)); // scope: all six emails carry the corrected treatment (cascades)
       // Button colour is now coral — owned by spec-465 (reverses spec-226 dec-1/ac-4).
-      expect(html).toContain("background:#FC4F64;color:#FFFFFF");
+      expect(html).toContain("background:#0482DC;color:#FFFFFF");
       expect(html).not.toContain("linear-gradient");
     });
 


### PR DESCRIPTION
Follow-on to spec-465. Recolours every email accent from coral to the brand blue **`#0482DC`** (spec-372 onboarding accent). Spec: `mindset-prod/memex-building-itself/spec-468`.

## What
Repoint one token — `BRAND_CORAL` → `BRAND_ACCENT = "#0482DC"` in `templates.ts` — so all 5 accent sites follow: CTA button, `// Step N` labels, resource links, connected-inactive "your Memex", signed-in-dormant "#help". White button text kept. Presentation only; no schema/route/flag/behaviour change.

## Why
Brand alignment (`#0482DC` = spec-372 accent) **and** it retires spec-465's sub-WCAG-AA white-on-coral contrast (white on `#0482DC` is materially better).

## Tests
- New `templates.visual.spec-468.test.ts` owns the blue-accent + **no-`#FC4F64`-anywhere** assertions (spec-468 ac-1..ac-4).
- `#FC4F64`→`#0482DC` in colour-agnostic tests (activation/visual/email-ui-polish — tags kept).
- Trimmed `templates.visual.spec-465.test.ts` to its surviving claims (wordmark ac-3, greeting ac-6); **spec-465 ac-1/2/4/5 (coral) and spec-451's coral step-label are superseded here** — expect them untested on those specs (accurate signal).
- `tsc` clean; full server suite **5679 pass** (only red = known `MEMEX_EMIT_KEY` local-env guard, green in CI).

## ⚠️ Timing
Must reach **prod before the activation flag flips** so the ~124-email backlog renders blue, not coral.