### PR TITLE
feat(spec-469): lead the facets tool with its outcome, not the word "facet"

### DIFF
--- a/packages/server/src/__regression__/facets-tool-copy.spec-469.regression.test.ts
+++ b/packages/server/src/__regression__/facets-tool-copy.spec-469.regression.test.ts
@@ -1,0 +1,111 @@
+// spec-469 — the `facets` tool leads with its OUTCOME, not the word "facet".
+//
+// This pins the agent-facing copy so it can't silently revert:
+//   - the description leads with the action ("Check which parts of your
+//     Standards apply..."), not "Read your Memex's FACET vocabulary";
+//   - it keeps an explicit `facets` + `facetBallot` anchor (dec-2), required
+//     because dec-1/B keeps the tool + param names (no rename, no migration);
+//   - the list-verb output drops the "Facet vocabulary for this Memex" header
+//     and carries an assistant breadcrumb steering USER-facing narration;
+//   - the change is confined: nothing is renamed and `formatRoutedStandards`
+//     (the payoff readout, already action-language) is untouched.
+//
+// Each test tags both its implementation AC (ac-7..ac-12) and the scope AC it
+// proves (ac-1..ac-6), so the board reflects the outcome and the mechanism.
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { toolManifest } from "@memex/shared";
+import { facetsTools, formatFacetList } from "../agent/handlers/facets.js";
+import { formatRoutedStandards, type RoutingResult } from "../services/facet-routing.js";
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-469/acs/ac-${n}`;
+const ACTION_LEAD = "Check which parts of your Standards apply";
+
+const facetsDesc = facetsTools[0].description;
+const facetsManifest = toolManifest.find((t) => t.name === "facets");
+const argsByName = new Map(toolManifest.map((t) => [t.name, t.args]));
+
+describe("spec-469: facets tool copy leads with the outcome, keeps the facet anchor", () => {
+  it("ac-9 / ac-1: handler description leads with the action, not 'facet vocabulary'", () => {
+    tagAc(AC(9));
+    tagAc(AC(1));
+    expect(facetsDesc.startsWith(ACTION_LEAD)).toBe(true);
+    expect(facetsDesc.toLowerCase()).not.toContain("facet vocabulary");
+    expect(facetsDesc).not.toContain("Verb-dispatched");
+  });
+
+  it("ac-10 / ac-6: handler description carries the facets + facetBallot anchor", () => {
+    tagAc(AC(10));
+    tagAc(AC(6));
+    expect(facetsDesc).toContain("facets");
+    expect(facetsDesc).toContain("facetBallot");
+  });
+
+  it("ac-7 / ac-2: handler description and manifest summary agree in intent (no drift)", () => {
+    tagAc(AC(7));
+    tagAc(AC(2));
+    expect(facetsManifest).toBeDefined();
+    const summary = facetsManifest!.summary;
+    // both lead with the same action and both carry the anchor
+    expect(summary.startsWith(ACTION_LEAD)).toBe(true);
+    expect(summary).toContain("facetBallot");
+    expect(summary.toLowerCase()).not.toContain("read your memex's facet vocabulary");
+    expect(facetsDesc.startsWith(ACTION_LEAD)).toBe(true);
+  });
+
+  it("ac-11 / ac-3: list output drops the old header and carries the narration breadcrumb", () => {
+    tagAc(AC(11));
+    tagAc(AC(3));
+    const out = formatFacetList([
+      { key: "security", name: "Security", description: "authz, tenancy, secrets" },
+      { key: "db-migrations", name: "Database & migrations", description: "schema changes" },
+    ]);
+    expect(out).not.toContain("Facet vocabulary for this Memex");
+    expect(out).toContain("Topics your Standards are tagged by (2)");
+    // breadcrumb steers user-facing narration and names the anti-pattern
+    expect(out).toContain("checking which parts of their Standards apply");
+    expect(out).toContain('not as "reading facets"');
+    // the vocabulary items still render
+    expect(out).toContain("- security (Security): authz, tenancy, secrets");
+  });
+
+  it("ac-8: nothing is renamed — tool name, facetBallot arg, and facet-bearing tools intact", () => {
+    tagAc(AC(8));
+    expect(facetsTools[0].name).toBe("facets");
+    expect(facetsManifest!.args).toBe("facets(verb, memex?)");
+    // the retained param / arg still present on the five other facet-bearing tools
+    expect(argsByName.get("create_task")).toContain("facetBallot");
+    expect(argsByName.get("create_decision")).toContain("facetBallot");
+    expect(argsByName.get("update_task")).toContain("facetBallot");
+    expect(argsByName.get("update_decision")).toContain("facetBallot");
+    expect(argsByName.get("add_clause")).toContain("facets");
+    expect(argsByName.get("edit_clause")).toContain("facets");
+  });
+
+  it("ac-12: formatRoutedStandards is untouched — empty routing yields no readout, no breadcrumb", () => {
+    tagAc(AC(12));
+    expect(formatRoutedStandards({ surfaced: [] } as unknown as RoutingResult)).toBe("");
+    // guard: the payoff readout source was NOT given the list breadcrumb and
+    // still speaks action-language.
+    const routingSrc = readFileSync(
+      resolve(dirname(fileURLToPath(import.meta.url)), "../services/facet-routing.ts"),
+      "utf8",
+    );
+    expect(routingSrc).toContain("govern this work");
+    expect(routingSrc).not.toContain("reading facets");
+  });
+
+  it("ac-4 / ac-5: the change is confined — the other tool descriptions were not swept", () => {
+    tagAc(AC(4));
+    tagAc(AC(5));
+    // the action lead is unique to `facets`: it did NOT leak into sibling tools
+    const leaked = toolManifest.filter(
+      (t) => t.name !== "facets" && t.summary.includes(ACTION_LEAD),
+    );
+    expect(leaked).toEqual([]);
+  });
+});

--- a/packages/server/src/agent/handlers/facets.integration.test.ts
+++ b/packages/server/src/agent/handlers/facets.integration.test.ts
@@ -63,7 +63,8 @@ describe("the verb-dispatched facets tool (spec-340 t-6)", () => {
 
     const ctx = { resolveMemex: async () => orgMemexId } as unknown as ToolCtx;
     const out = (await facetsTools[0].handler({ verb: "list" }, ctx)) as string;
-    expect(out).toContain("Facet vocabulary");
+    // spec-469: the list header now leads with the outcome, not "Facet vocabulary".
+    expect(out).toContain("Topics your Standards are tagged by");
     expect(out).toContain("security");
     expect(out).toContain("db-migrations");
 
@@ -72,6 +73,6 @@ describe("the verb-dispatched facets tool (spec-340 t-6)", () => {
     expect(personalVocab.length).toBe(16);
     const pctx = { resolveMemex: async () => personalMemexId } as unknown as ToolCtx;
     const pout = (await facetsTools[0].handler({ verb: "list" }, pctx)) as string;
-    expect(pout).toContain("Facet vocabulary");
+    expect(pout).toContain("Topics your Standards are tagged by");
   });
 });

--- a/packages/server/src/agent/handlers/facets.ts
+++ b/packages/server/src/agent/handlers/facets.ts
@@ -18,8 +18,12 @@ export const facetsTools: ToolSpec[] = [
   {
     name: "facets",
     annotations: { title: "Facets", readOnlyHint: true, destructiveHint: false },
+    // spec-469 (dec-2): lead with the OUTCOME ("which parts of your Standards
+    // apply"), not the internal noun. Keep an explicit `facets` + `facetBallot`
+    // anchor so the copy stays connected to the retained param and tables
+    // (dec-1 keeps both) — without it the agent meets an undefined `facetBallot`.
     description:
-      "Read your Memex's FACET vocabulary — the closed, per-owner set of cross-cutting practice areas (security, db-migrations, e2e-testing, api-design, …) that a standard's clauses are tagged with. Verb-dispatched so the whole facet surface stays one tool as it grows; v0 supports the verb 'list'.",
+      "Check which parts of your Standards apply to a piece of work. Lists the topics your Standards are tagged by (security, db-migrations, e2e-testing, and so on). Internally these are your Memex's facets: you cast them as the facetBallot argument on create_task / create_decision, and Memex surfaces the governing standard sections.",
     schema: {
       verb: z
         .enum(["list"])
@@ -33,16 +37,32 @@ export const facetsTools: ToolSpec[] = [
 
       if (verb === "list") {
         const vocab = await listFacetsForMemex(memexId);
-        if (vocab.length === 0) {
-          return "No facets defined for this Memex yet.";
-        }
-        const lines = vocab.map(
-          (f) => `- ${f.key}${f.name ? ` (${f.name})` : ""}: ${f.description}`,
-        );
-        return `Facet vocabulary for this Memex (${vocab.length}):\n${lines.join("\n")}`;
+        return formatFacetList(vocab);
       }
 
       throw new ValidationError(`Unknown facets verb '${verb as string}'.`);
     },
   },
 ];
+
+/**
+ * spec-469 (dec-3): format the `list` verb's output. Leads with the outcome and
+ * carries an assistant breadcrumb so the agent narrates the ACTION to the user
+ * ("which parts of your Standards apply"), never the internal noun. Pure and
+ * exported so it is unit-testable without a database.
+ */
+export function formatFacetList(
+  vocab: { key: string; name?: string | null; description: string }[],
+): string {
+  if (vocab.length === 0) {
+    return "No topics defined for this Memex yet (its Standards carry no facet tags).";
+  }
+  const lines = vocab.map(
+    (f) => `- ${f.key}${f.name ? ` (${f.name})` : ""}: ${f.description}`,
+  );
+  return (
+    `Topics your Standards are tagged by (${vocab.length}). Mark the ones a piece of work touches and Memex surfaces the applicable parts of your Standards:\n` +
+    lines.join("\n") +
+    `\n\n(Note to the assistant: when you tell the user what you're doing here, describe it as checking which parts of their Standards apply to the work, not as "reading facets".)`
+  );
+}

--- a/packages/shared/src/tool-manifest.ts
+++ b/packages/shared/src/tool-manifest.ts
@@ -421,7 +421,7 @@ export const toolManifest: ToolManifestEntry[] = [
   {
     name: 'facets',
     summary:
-      "Read your Memex's facet vocabulary — the closed, per-owner set of cross-cutting practice areas a standard's clauses are tagged with. Verb-dispatched so the surface stays one tool as it grows; v0 supports verb:'list'.",
+      "Check which parts of your Standards apply to a piece of work. Lists the topics your Standards are tagged by (security, db-migrations, e2e-testing, and so on). Internally these are your Memex's facets: you cast them as the facetBallot argument on create_task / create_decision, and Memex surfaces the governing standard sections.",
     args: 'facets(verb, memex?)',
     group: 'read',
     readOnlyHint: true,


### PR DESCRIPTION
## What & why

The `facets` MCP tool routes a team's governing Standards to a piece of work, but its agent-facing copy fronted the internal noun "facet", which means nothing to a developer who hasn't lived inside Memex. The trigger: an agent narrated *"Let me read the facet vocabulary before creating the new decisions"*, lifted almost verbatim from the tool's own description.

This makes the `facets` tool lead with the **outcome** instead of the mechanism, so neither the agent's narration nor the user meets the bare word "facet" as the headline.

Spec: [spec-469](https://memex.ai/mindset-prod/memex-building-itself/specs/spec-469)

## The change (agent-facing copy only)

- **Description** (`facets.ts` handler + `@memex/shared` manifest): now leads with *"Check which parts of your Standards apply to a piece of work…"* and keeps an explicit `facets` / `facetBallot` anchor so the copy stays tied to the retained param. Per std-16 the manifest string renders into the coding-agent Init Prompt.
- **List-verb output**: header reworded from *"Facet vocabulary for this Memex"* to *"Topics your Standards are tagged by"*, plus an assistant breadcrumb steering user-facing narration. Extracted into a pure, exported `formatFacetList()`.

## Deliberately NOT changed (dec-1)

No rename, no migration, no schema change. The `facets` tool name, the `facetBallot` param, every facet table, the five other facet-bearing tool descriptions, and `formatRoutedStandards` are untouched. The residual (tool still named `facets`) is the accepted price of a cheap, non-cascading fix; the description anchor keeps it discoverable.

## Decisions
- **dec-1** scope ladder → option B (rewrite the one description + breadcrumb; no rename / migration / cascade).
- **dec-2** no coined noun; lead with the outcome; keep a facet / `facetBallot` anchor.
- **dec-3** breadcrumb in the list output only; `formatRoutedStandards` untouched.

## Testing
- New `facets-tool-copy.spec-469.regression.test.ts` (7 tests) tagging all 12 ACs → **12/12 verified**.
- Updated the spec-340 `facets.integration.test.ts` header assertions for the new output.
- Full **server** suite green (5679 passed, isolated), full **UI** suite green (2093 passed), production build + `tsc` typecheck green.
- No new e2e journey: no web flow changed (std-28 n/a; facet pills unchanged).

## Test plan
- [ ] CI: server + UI suites green
- [ ] CI: e2e journeys green (no new journey; existing pill surface unchanged)
- [ ] CI: build / typecheck green

## Open micro-choices (non-blocking)
- Descriptor for the 16 list items defaulted to "topics" (vs areas / categories).
- `facetBallot` is backtick-free in the copy to satisfy the tool-spec audit (Probe 9); the alternative is to restore the backtick and allowlist it (like `test_identifier`).
