### PR TITLE
spec-444: swap welcome video to v5

### DIFF
--- a/packages/ui/e2e/journey-54-spec-460-welcome-ctas.spec.ts
+++ b/packages/ui/e2e/journey-54-spec-460-welcome-ctas.spec.ts
@@ -2,7 +2,7 @@
 //
 // Extends the spec-444 welcome arc (journey-53) with the spec-460 additions,
 // exercised against the running app:
-//   - the /welcome video src is the v4 asset (ac-1)
+//   - the /welcome video src is the v5 asset (ac-1)
 //   - the "book a call" line is hidden during playback and revealed once the
 //     viewer crosses ~85%, linking to the booking alias in a new tab (ac-2)
 //   - the Getting Started sidebar card shows its rows and dismissal persists
@@ -42,15 +42,15 @@ test.afterEach(async ({}, testInfo) => {
 });
 
 test(
-  "/welcome plays the v4 video (ac-1) and reveals the book-a-call line near the end (ac-2)",
+  "/welcome plays the v5 video (ac-1) and reveals the book-a-call line near the end (ac-2)",
   async ({ page }) => {
     await setVideoWelcomed(DEV_EMAIL, false);
     await page.goto(bareUrl("/"), { waitUntil: "commit" });
     await expect(page).toHaveURL(/\/welcome/, { timeout: 15_000 });
 
-    // ac-1: the video src is the v4 asset on the public CDN.
+    // ac-1: the video src is the v5 asset on the public CDN.
     const videoSrc = await page.getByTestId("welcome-video-player").getAttribute("src");
-    expect(videoSrc).toContain("welcome-to-memex-v4.mp4");
+    expect(videoSrc).toContain("welcome-to-memex-v5.mp4");
 
     // ac-2: the call line is hidden during playback.
     const callCta = page.getByTestId("welcome-video-call-cta");

--- a/packages/ui/src/pages/WelcomePage.telemetry.test.tsx
+++ b/packages/ui/src/pages/WelcomePage.telemetry.test.tsx
@@ -63,7 +63,7 @@ describe('WelcomePage — onboarding.video_* telemetry', () => {
     const started = track.mock.calls.filter((c) => c[0] === 'onboarding.video_started');
     expect(started).toHaveLength(1);
     expect(started[0][1]).toEqual({
-      video_id: 'welcome-to-memex-v4',
+      video_id: 'welcome-to-memex-v5',
       position_seconds: 3,
       duration_seconds: 120,
       percent_watched: 3, // 3/120 = 2.5 → rounded
@@ -80,7 +80,7 @@ describe('WelcomePage — onboarding.video_* telemetry', () => {
 
     const completed = track.mock.calls.filter((c) => c[0] === 'onboarding.video_completed');
     expect(completed).toHaveLength(1);
-    expect(completed[0][1]).toMatchObject({ video_id: 'welcome-to-memex-v4', percent_watched: 100 });
+    expect(completed[0][1]).toMatchObject({ video_id: 'welcome-to-memex-v5', percent_watched: 100 });
   });
 
   // spec-462: before completion the primary button is "▶ Play now" / "Playing…",
@@ -97,7 +97,7 @@ describe('WelcomePage — onboarding.video_* telemetry', () => {
 
     const skipped = track.mock.calls.filter((c) => c[0] === 'onboarding.video_skipped');
     expect(skipped).toHaveLength(1);
-    expect(skipped[0][1]).toMatchObject({ video_id: 'welcome-to-memex-v4', position_seconds: 10 });
+    expect(skipped[0][1]).toMatchObject({ video_id: 'welcome-to-memex-v5', position_seconds: 10 });
     await waitFor(() => expect(dismissWelcomeVideoApi).toHaveBeenCalled());
   });
 
@@ -227,7 +227,7 @@ describe('WelcomePage — spec-460 book-a-call reveal', () => {
     renderPage();
     const src = screen.getByTestId('welcome-video-player').getAttribute('src');
     expect(src).toBe(
-      'https://storage.googleapis.com/memex-ai-prod-app-static/media/welcome-to-memex-v4.mp4',
+      'https://storage.googleapis.com/memex-ai-prod-app-static/media/welcome-to-memex-v5.mp4',
     );
   });
 

--- a/packages/ui/src/pages/WelcomePage.tsx
+++ b/packages/ui/src/pages/WelcomePage.tsx
@@ -15,12 +15,12 @@ import { dismissWelcomeVideoApi } from '../api/auth';
 import { useTelemetry } from '../hooks/useTelemetry';
 
 const VIDEO_URL =
-  'https://storage.googleapis.com/memex-ai-prod-app-static/media/welcome-to-memex-v4.mp4';
+  'https://storage.googleapis.com/memex-ai-prod-app-static/media/welcome-to-memex-v5.mp4';
 
 // Stable, low-cardinality identifier for this video — the filename stem of
 // VIDEO_URL. Kept as its own const so a src bump is a one-line, deliberate change
 // (props carry ids/counts only — std-35 cl-5).
-const VIDEO_ID = 'welcome-to-memex-v4';
+const VIDEO_ID = 'welcome-to-memex-v5';
 
 // spec-460: the "book a call" CTA revealed near the end of the video points at the
 // neutral booking alias on the marketing site (never the raw HubSpot URL — std-31,


### PR DESCRIPTION
## What

Replaces the `/welcome` intro video (spec-444) with the new **v5** cut. Nothing else changes — no layout, copy, gating, routing, or telemetry-shape changes.

- `WelcomePage.tsx` — `VIDEO_URL` + `VIDEO_ID` → `welcome-to-memex-v5.mp4`
- `WelcomePage.telemetry.test.tsx` — telemetry assertions → v5
- `journey-54-spec-460-welcome-ctas.spec.ts` — e2e src assertion + comments → v5

## Asset

The v5 file was re-encoded to match the v4 treatment (720p H.264 High, ~1.4 Mbps, `+faststart`) and uploaded to the same public GCS bucket:

`https://storage.googleapis.com/memex-ai-prod-app-static/media/welcome-to-memex-v5.mp4`

- Same 176s cut, same 720p — only bitrate changed (raw export was 12 Mbps / 267 MB)
- Final asset **32.8 MB**, `moov` before `mdat` (progressive streaming), `Cache-Control: public, max-age=31536000, immutable`
- Versioned filename → no stale-cache concern

## Testing

- `WelcomePage.telemetry.test.tsx` — 14/14 pass
- `make e2e-cold` — **145 passed, 0 failed**; journey-54 confirms `/welcome plays the v5 video (ac-1)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)