### PR TITLE
fix(deploy): guard spec-21 conversion secrets on version, not just existence

### DIFF
--- a/packages/server/deploy.sh
+++ b/packages/server/deploy.sh
@@ -148,29 +148,37 @@ fi
 #   printf %s "<id>"     | gcloud secrets create openai-pixel-id              --data-file=- --project "${GCP_PROJECT}" --replication-policy=user-managed --locations=us-east4
 #   printf %s "<key>"    | gcloud secrets create openai-pixel-api-key         --data-file=- --project "${GCP_PROJECT}" --replication-policy=user-managed --locations=us-east4
 #   # then for each: gcloud secrets add-iam-policy-binding <secret> --project "${GCP_PROJECT}" --member="serviceAccount:<runtime-SA>" --role="roles/secretmanager.secretAccessor"
-if gcloud secrets describe google-ads-client-id --project "${GCP_PROJECT}" >/dev/null 2>&1 \
-   && gcloud secrets describe google-ads-client-secret --project "${GCP_PROJECT}" >/dev/null 2>&1 \
-   && gcloud secrets describe google-ads-refresh-token --project "${GCP_PROJECT}" >/dev/null 2>&1 \
-   && gcloud secrets describe google-ads-developer-token --project "${GCP_PROJECT}" >/dev/null 2>&1 \
-   && gcloud secrets describe google-ads-customer-id --project "${GCP_PROJECT}" >/dev/null 2>&1 \
-   && gcloud secrets describe google-ads-conversion-action-id --project "${GCP_PROJECT}" >/dev/null 2>&1; then
+# spec-21: a conversion secret is only USABLE if it has an accessible `latest` VERSION.
+# `gcloud secrets describe` passes on an empty (versionless) container, which would flip a
+# guard ON and then fail the Cloud Run deploy resolving `:latest` (the linkedin-ad-account-id
+# half-provisioned incident). Check the version instead so a half-provisioned secret cleanly
+# DISABLES its conversion group rather than breaking the deploy.
+secret_has_version() {
+  gcloud secrets versions access latest --secret="$1" --project "${GCP_PROJECT}" >/dev/null 2>&1
+}
+if secret_has_version google-ads-client-id \
+   && secret_has_version google-ads-client-secret \
+   && secret_has_version google-ads-refresh-token \
+   && secret_has_version google-ads-developer-token \
+   && secret_has_version google-ads-customer-id \
+   && secret_has_version google-ads-conversion-action-id; then
   echo "  ✓ Google Ads conversion secrets present — Enhanced Conversions enabled (spec-21)"
   HAS_GOOGLE_ADS_CONVERSIONS=1
 else
   echo "  ⚠ Google Ads conversion secrets not found — Enhanced Conversions disabled (spec-21 issue-3)"
   HAS_GOOGLE_ADS_CONVERSIONS=0
 fi
-if gcloud secrets describe linkedin-access-token --project "${GCP_PROJECT}" >/dev/null 2>&1 \
-   && gcloud secrets describe linkedin-ad-account-id --project "${GCP_PROJECT}" >/dev/null 2>&1 \
-   && gcloud secrets describe linkedin-conversion-id --project "${GCP_PROJECT}" >/dev/null 2>&1; then
+if secret_has_version linkedin-access-token \
+   && secret_has_version linkedin-ad-account-id \
+   && secret_has_version linkedin-conversion-id; then
   echo "  ✓ LinkedIn Conversions API secrets present — server-side conversions enabled (spec-21)"
   HAS_LINKEDIN_CONVERSIONS=1
 else
   echo "  ⚠ LinkedIn Conversions API secrets not found — LinkedIn server-side conversions disabled (spec-21 issue-3)"
   HAS_LINKEDIN_CONVERSIONS=0
 fi
-if gcloud secrets describe openai-pixel-id --project "${GCP_PROJECT}" >/dev/null 2>&1 \
-   && gcloud secrets describe openai-pixel-api-key --project "${GCP_PROJECT}" >/dev/null 2>&1; then
+if secret_has_version openai-pixel-id \
+   && secret_has_version openai-pixel-api-key; then
   echo "  ✓ OpenAI pixel secrets present — server-side conversions enabled (spec-21)"
   HAS_OPENAI_PIXEL_CONVERSIONS=1
 else


### PR DESCRIPTION
## Why

Last night's **prod deploy failed** (develop→main PR #516): the Cloud Run revision couldn't be created —

```
ERROR: (gcloud.run.deploy) ...secret_key_ref.name:
Secret .../linkedin-ad-account-id/versions/latest was not found
```

`deploy.sh` guards spec-21's conversion secrets so a group is only wired when its secrets are present. But the guard used `gcloud secrets describe`, which **passes on an empty (versionless) secret container**. In prod, `linkedin-ad-account-id` existed with no value → the guard flipped `HAS_LINKEDIN_CONVERSIONS=on` → the deploy then failed resolving `:latest`. A half-provisioned secret **broke the deploy** instead of cleanly disabling its feature.

## Fix

Check for an accessible `latest` **version** (`secret_has_version` helper) rather than mere container existence, across all three conversion guards (Google Ads / LinkedIn / OpenAI pixel).

- **Fully provisioned** secret → still enabled (unchanged).
- **Fully absent** secret → still disabled (unchanged).
- **Half-provisioned** (container, no version) → now **cleanly disabled** instead of breaking the deploy.

The app already no-ops when the env is absent (`fireLinkedInConversion` returns early; fire-and-forget), so disabling a group is safe — the conversion just doesn't fire until real values are wired.

## Unblocks the prod release without prod GCP access
On merge, this validates on **int first** (secrets fully provisioned there → no behaviour change), then the develop→main promotion lets prod deploy cleanly with LinkedIn conversions disabled. No code is under test for `deploy.sh`; validated with `bash -n` + `shellcheck -S error` (both clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)