### PR TITLE
release: fix /home import→Spec flow (LLM 404 + facet ballot)

### DIFF
--- a/packages/server/src/agent/phases/creation/system.md
+++ b/packages/server/src/agent/phases/creation/system.md
@@ -49,6 +49,8 @@ Steps 1–3 are a dependency chain — do them **one tool call at a time** (the 
 
 For add_section calls, use a short slug for sectionType — "design", "architecture", "testing", "issues", "acceptance", or "body-<n>" for initiative-specific sections. sectionType must be unique within the document.
 
+**Facet ballot on decisions.** If a "Facet ballot" section appears below (this Memex has a facet vocabulary), every `create_decision` you emit MUST carry a complete `facetBallot` — a true/false verdict for each listed facet, or `none: true` for legitimate no-facet work. Cast it inline in the same batched step-4 turn; a decision with an absent or incomplete ballot is rejected and not created. `add_section` and `create_ac` need no ballot. If no such section is present, omit `facetBallot`.
+
 ## Handling Responses to Interactive UI Tools (IMPORTANT — never leave the user hanging)
 
 After an interactive UI tool (render_confirmation / render_choices / render_action_buttons) returns, you MUST produce a follow-up assistant turn. Never return an empty response. The user always sees SOME assistant output after clicking a button.

--- a/packages/server/src/agent/system-prompt.test.ts
+++ b/packages/server/src/agent/system-prompt.test.ts
@@ -507,4 +507,41 @@ describe("buildCreationSystemBlocks (spec-230 — input-driven parity, supersede
     // text should be different from the role text.
     expect(blocks[1].text).not.toBe(blocks[0].text);
   });
+
+  // spec-473: the creation surface omits the `facets` tool (to keep step-4 authoring
+  // one batched turn), so where the Memex has a facet vocabulary we inject it into the
+  // prompt with a ballot instruction — otherwise create_decision (which hard-requires a
+  // complete ballot, spec-423 dec-5) is rejected and no decision is created.
+  describe("facet-ballot injection", () => {
+    const VOCAB = [
+      { id: "f1", key: "security", description: "auth, secrets, data exposure" },
+      { id: "f2", key: "api-design", description: "public surface shape" },
+    ];
+
+    it("appends a facet-ballot block listing the vocabulary when the Memex has facets", () => {
+      const blocks = buildCreationSystemBlocks(VOCAB);
+      expect(blocks).toHaveLength(3);
+      const facet = blocks[2].text;
+      expect(facet).toMatch(/facet ballot/i);
+      expect(facet).toMatch(/REQUIRED on every create_decision/i);
+      expect(facet).toContain("facetBallot");
+      // Every vocabulary key + description is rendered so the agent can cast a
+      // COMPLETE verdict without a separate `facets` round-trip.
+      expect(facet).toContain("security");
+      expect(facet).toContain("auth, secrets, data exposure");
+      expect(facet).toContain("api-design");
+      expect(facet).toMatch(/"none"/);
+    });
+
+    it("does NOT append a facet block for an empty vocabulary (unchanged 2 blocks)", () => {
+      expect(buildCreationSystemBlocks([])).toHaveLength(2);
+      expect(buildCreationSystemBlocks()).toHaveLength(2);
+    });
+
+    it("keeps the facet block AFTER the cached role+skill prefix (per-Memex, not cached)", () => {
+      const blocks = buildCreationSystemBlocks(VOCAB);
+      expect(blocks[1].cache_control).toEqual({ type: "ephemeral" });
+      expect(blocks[2].cache_control).toBeUndefined();
+    });
+  });
 });

--- a/packages/server/src/agent/system-prompt.ts
+++ b/packages/server/src/agent/system-prompt.ts
@@ -18,6 +18,7 @@ import {
 } from "@memex/shared";
 import type { SystemBlock } from "./types.js";
 import type { IntegrationState } from "./integration-state.js";
+import type { VocabFacet } from "../services/facet-vocab.js";
 import { loadSkill } from "./skills.js";
 
 // ──────────────────────────────────────────────
@@ -322,7 +323,7 @@ export function buildSystemBlocks(
  * Creation is out of scope for b-68: it keeps reading from disk via the
  * existing `phases/creation/system.md` + skill-loader path.
  */
-export function buildCreationSystemBlocks(): SystemBlock[] {
+export function buildCreationSystemBlocks(vocab: VocabFacet[] = []): SystemBlock[] {
   const role: SystemBlock = {
     type: "text",
     text: CREATION_SYSTEM,
@@ -334,5 +335,51 @@ export function buildCreationSystemBlocks(): SystemBlock[] {
     cache_control: { type: "ephemeral" },
   };
 
-  return [role, skill];
+  const blocks = [role, skill];
+
+  // spec-473: when this Memex has a facet vocabulary, `create_decision` HARD-REQUIRES
+  // a complete facet ballot (spec-423 dec-5, enforced in handlers/decisions.ts via
+  // requireBallotForMemex) — an absent/incomplete ballot is rejected and the decision
+  // is NOT created. The creation surface deliberately omits the `facets` tool to keep
+  // step-4 authoring a single batched turn, so we inject the live vocabulary here and
+  // instruct the agent to cast the ballot inline. Appended AFTER the cached prefix
+  // (role + skill) since the vocabulary is per-Memex. Empty vocab → no block, unchanged.
+  if (vocab.length > 0) {
+    blocks.push({ type: "text", text: renderFacetBallotBlock(vocab) });
+  }
+
+  return blocks;
+}
+
+// Render the per-Memex facet-ballot instruction injected into the creation prompt.
+// Mirrors the create_decision schema's `facetBallot` contract + the `facets` list
+// verb's vocabulary readout, so the agent can cast a COMPLETE ballot without a
+// separate round-trip.
+function renderFacetBallotBlock(vocab: VocabFacet[]): string {
+  const keys = vocab.map((f) => f.key);
+  const lines = vocab.map((f) => `- \`${f.key}\` — ${f.description}`).join("\n");
+  return [
+    "## Facet ballot — REQUIRED on every create_decision (this Memex has a facet vocabulary)",
+    "",
+    "Each decision you create MUST carry a complete `facetBallot` naming which governance",
+    "facets the decision touches. A create_decision with an absent, incomplete, or",
+    "contradictory ballot is REJECTED and the decision is NOT created — so cast the ballot",
+    "inline, in the SAME batched step-4 turn, on every `create_decision` block.",
+    "",
+    "Ballot shape (pass as the `facetBallot` argument):",
+    "```json",
+    '{ "verdict": { ' + keys.map((k) => `"${k}": <true|false>`).join(", ") + ' }, "none": false }',
+    "```",
+    "",
+    "Rules:",
+    "- `verdict` must include an explicit true/false for EVERY facet key below — no omissions.",
+    "- Set a facet `true` only when the decision genuinely governs that concern; otherwise `false`.",
+    "- For a decision that legitimately touches NO facet, set every verdict `false` AND `none: true`.",
+    "- `none` must be `false` whenever any facet is `true` (never both).",
+    "- These facets are a work-side routing hook (they surface the governing Standards), not",
+    "  binding precedent (spec-423 dec-6) — classify the decision's own scope, honestly.",
+    "",
+    "Facet vocabulary for this Memex:",
+    lines,
+  ].join("\n");
 }

--- a/packages/server/src/routes/llm.ts
+++ b/packages/server/src/routes/llm.ts
@@ -16,6 +16,7 @@ import type { MemexResolverEnv } from "../middleware/memex-resolver.js";
 import { requireMemexId } from "./shared.js";
 import { canWriteMemex, READ_ONLY_PUBLIC_MESSAGE } from "../mcp/auth.js";
 import { resolveRole } from "../services/doc-members.js";
+import { vocabForMemex } from "../services/facet-vocab.js";
 import { resolveIntegrationState } from "../agent/integration-state.js";
 
 // spec-473: the creation + in-Spec agent runs on Sonnet 5 (was Sonnet 4.5). For
@@ -319,7 +320,20 @@ llmRouter.post("/chat/create", async (c) => {
     throw err;
   }
 
-  const systemBlocks = buildCreationSystemBlocks();
+  // spec-473: inject this Memex's facet vocabulary so the creation agent can cast the
+  // complete facet ballot that `create_decision` hard-requires (spec-423 dec-5). The
+  // creation surface omits the `facets` tool (to keep step-4 authoring one batched
+  // turn), so without this the agent can't comply and every decision is rejected.
+  // Best-effort: on any resolution/load hiccup, fall back to no facet block (the prior
+  // behaviour) rather than blocking creation — the empty-vocab path is a no-op anyway.
+  let facetVocab: Awaited<ReturnType<typeof vocabForMemex>> = [];
+  try {
+    facetVocab = await vocabForMemex(requireMemexId(c));
+  } catch (err) {
+    logError("chat/create", err);
+  }
+
+  const systemBlocks = buildCreationSystemBlocks(facetVocab);
   const tools = getCreationToolDefinitions();
 
   // The creation flow has no LangGraph resume path — if the prior assistant

--- a/packages/ui/src/agent/graph.test.ts
+++ b/packages/ui/src/agent/graph.test.ts
@@ -457,8 +457,17 @@ describe('LangGraph agent graph', () => {
       { configurable: { thread_id: 'create-2', callbacks } }
     );
 
-    // create_doc was executed
-    expect(executeToolRemote).toHaveBeenCalledWith('create_doc', { title: 'My Spec', purpose: 'Define API', docType: 'spec' }, undefined);
+    // create_doc was executed. Trailing args: signal, docId, mode, tenantBasePath —
+    // all undefined here (no AbortSignal, and this in-tenant invoke passes no
+    // tenantBasePath override, so the client resolves the tenant from the URL).
+    expect(executeToolRemote).toHaveBeenCalledWith(
+      'create_doc',
+      { title: 'My Spec', purpose: 'Define API', docType: 'spec' },
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+    );
 
     // onDocCreated callback fired with the extracted doc info. In the ref-only
     // shape there's no UUID to surface, so docId carries the canonical ref and

--- a/packages/ui/src/agent/graph.ts
+++ b/packages/ui/src/agent/graph.ts
@@ -87,6 +87,15 @@ export interface AgentCallbacks {
 export interface AgentConfig {
   callbacks?: AgentCallbacks;
   signal?: AbortSignal;
+  /**
+   * spec-473 hotfix: explicit tenant API base (`/api/<ns>/<mx>`) for the /home
+   * import-hero creation flow. That flow runs off a flat `/home` URL, so the
+   * clients' tenantBase() would fall back to the ambient `currentMemexId` (from
+   * localStorage) — possibly a stale/foreign memex the server rejects with a 404
+   * (std-7). Pins the creation LLM + tool calls to the personal memex the hero
+   * targets. Undefined for in-tenant callers, who resolve from the URL as before.
+   */
+  tenantBasePath?: string;
 }
 
 // ──────────────────────────────────────────────
@@ -268,7 +277,7 @@ async function createDocNode(
   state: AgentStateType,
   config: RunnableConfig
 ): Promise<Partial<AgentStateType>> {
-  const { callbacks, signal } = (config.configurable ?? {}) as AgentConfig;
+  const { callbacks, signal, tenantBasePath } = (config.configurable ?? {}) as AgentConfig;
 
   console.log('[LANGGRAPH] createDoc node invoked — messages:', state.messages.length);
 
@@ -276,7 +285,8 @@ async function createDocNode(
 
   for await (const event of callLlmCreateProxy(
     { messages: state.messages },
-    signal
+    signal,
+    tenantBasePath
   )) {
     switch (event.type) {
       case 'text_delta':
@@ -334,11 +344,19 @@ function shouldContinueCreate(state: AgentStateType): 'createDocTools' | '__end_
 async function runServerToolBlock(
   block: ToolUseBlock,
   callbacks: AgentCallbacks | undefined,
-  signal: AbortSignal | undefined
+  signal: AbortSignal | undefined,
+  tenantBasePath?: string
 ): Promise<ContentBlock> {
   callbacks?.onToolStart?.(block.name, block.id);
   try {
-    const result = await executeToolRemote(block.name, block.input, signal);
+    const result = await executeToolRemote(
+      block.name,
+      block.input,
+      signal,
+      undefined,
+      undefined,
+      tenantBasePath
+    );
     callbacks?.onToolResult?.(block.id, result);
     // Announce created doc (with handle + title) so the modal can surface a link.
     if (block.name === 'create_doc') {
@@ -362,7 +380,7 @@ async function createDocToolsNode(
   state: AgentStateType,
   config: RunnableConfig
 ): Promise<Partial<AgentStateType>> {
-  const { callbacks, signal } = (config.configurable ?? {}) as AgentConfig;
+  const { callbacks, signal, tenantBasePath } = (config.configurable ?? {}) as AgentConfig;
   const lastMsg = state.messages[state.messages.length - 1];
   const toolBlocks = getToolUseBlocks(lastMsg);
   const serverBlocks = getServerToolBlocks(toolBlocks);
@@ -383,12 +401,12 @@ async function createDocToolsNode(
   const byId = new Map<string, ContentBlock>();
   // Order-sensitive: sections, one at a time, in the order the model emitted them.
   for (const block of sectionBlocks) {
-    byId.set(block.id, await runServerToolBlock(block, callbacks, signal));
+    byId.set(block.id, await runServerToolBlock(block, callbacks, signal, tenantBasePath));
   }
   // Order-insensitive: fan out the rest concurrently.
   await Promise.all(
     parallelBlocks.map(async (block) => {
-      byId.set(block.id, await runServerToolBlock(block, callbacks, signal));
+      byId.set(block.id, await runServerToolBlock(block, callbacks, signal, tenantBasePath));
     })
   );
 

--- a/packages/ui/src/agent/llm-client.test.ts
+++ b/packages/ui/src/agent/llm-client.test.ts
@@ -154,6 +154,20 @@ describe('LLM SSE client', () => {
     expect(calledUrl).toContain('/llm/chat/create');
   });
 
+  it('callLlmCreateProxy pins the tenant when tenantBasePath is passed (spec-473 hotfix)', async () => {
+    // The /home import hero passes an explicit personal-memex API base so creation
+    // targets that memex instead of the ambient (possibly stale) currentMemexId.
+    const stream = sseChunk([{ event: 'text_delta', data: { text: 'hi' } }]);
+    vi.mocked(fetchWithRetry).mockResolvedValueOnce(fakeResponse(stream));
+
+    await collectEvents(
+      callLlmCreateProxy({ messages: [] }, undefined, '/api/alice/personal'),
+    );
+
+    const calledUrl = vi.mocked(fetchWithRetry).mock.calls[0][0] as string;
+    expect(calledUrl).toBe('/api/alice/personal/llm/chat/create');
+  });
+
   it('includes Authorization header when token is set', async () => {
     const stream = sseChunk([
       { event: 'text_delta', data: { text: 'ok' } },

--- a/packages/ui/src/agent/llm-client.ts
+++ b/packages/ui/src/agent/llm-client.ts
@@ -7,8 +7,14 @@ import type { MessageParam, LlmProxyEvent } from './types';
 // the rest of the tenancy-scoped routers carry for the std-5 single-
 // membership case). Use tenantBase() to build the URL from the current
 // browsing context.
-function llmBase(): string {
-  return tenantBase() ?? BASE_URL;
+// spec-473 hotfix: `override` pins the tenant API base (`/api/<ns>/<mx>`) for
+// the /home import-hero creation flow. That flow runs off a FLAT `/home` URL, so
+// tenantBase() would fall back to the ambient `currentMemexId` from localStorage —
+// possibly a stale/foreign memex the server rejects with a 404 (std-7). The hero
+// passes the personal-memex base so creation targets the same memex it navigates
+// to. In-tenant callers omit it and resolve from the URL exactly as before.
+function llmBase(override?: string): string {
+  return override ?? tenantBase() ?? BASE_URL;
 }
 
 let authToken: string | null = null;
@@ -142,8 +148,9 @@ export async function* callLlmProxy(
  */
 export async function* callLlmCreateProxy(
   params: { messages: MessageParam[] },
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  tenantBasePath?: string
 ): AsyncGenerator<LlmProxyEvent> {
-  const res = await postLlm(`${llmBase()}/llm/chat/create`, params, signal);
+  const res = await postLlm(`${llmBase(tenantBasePath)}/llm/chat/create`, params, signal);
   yield* parseLlmSSE(res);
 }

--- a/packages/ui/src/agent/tool-client.ts
+++ b/packages/ui/src/agent/tool-client.ts
@@ -4,8 +4,13 @@ import { tenantBase, BASE_URL } from '../api/http';
 // t-18 of doc-15 (F.3): /api/llm/* is tenancy-scoped. Use tenantBase() so the
 // browser's current Memex context maps to /api/<ns>/<mx>/llm/tools/execute;
 // fall back to the flat surface for std-5 single-membership inference.
-function llmBase(): string {
-  return tenantBase() ?? BASE_URL;
+// spec-473 hotfix: `override` pins the tenant API base (`/api/<ns>/<mx>`) so the
+// /home import-hero creation flow executes its tools (create_doc, add_section…)
+// against the SAME personal memex its /chat/create call targets — not the ambient
+// `currentMemexId`, which off a flat `/home` URL can be a stale/foreign memex the
+// server 404s (std-7). In-tenant callers omit it and resolve from the URL.
+function llmBase(override?: string): string {
+  return override ?? tenantBase() ?? BASE_URL;
 }
 
 let authToken: string | null = null;
@@ -27,7 +32,8 @@ export async function executeToolRemote(
   input: Record<string, unknown>,
   signal?: AbortSignal,
   docId?: string,
-  mode?: 'drift' | 'scaffold' | 'standards' | 'issues' | 'skills'
+  mode?: 'drift' | 'scaffold' | 'standards' | 'issues' | 'skills',
+  tenantBasePath?: string
 ): Promise<string> {
   const headers: Record<string, string> = { 'Content-Type': 'application/json' };
   if (authToken) {
@@ -42,7 +48,7 @@ export async function executeToolRemote(
   if (docId) reqBody.docId = docId;
   if (mode) reqBody.mode = mode;
 
-  const res = await fetchWithRetry(`${llmBase()}/llm/tools/execute`, {
+  const res = await fetchWithRetry(`${llmBase(tenantBasePath)}/llm/tools/execute`, {
     method: 'POST',
     headers,
     body: JSON.stringify(reqBody),

--- a/packages/ui/src/agent/useAgentGraph.ts
+++ b/packages/ui/src/agent/useAgentGraph.ts
@@ -24,6 +24,13 @@ export interface InvokeParams {
   agentMode?: 'spec' | 'drift' | 'scaffold' | 'standards' | 'issues' | 'skills';
   callbacks: AgentCallbacks;
   signal?: AbortSignal;
+  /**
+   * spec-473 hotfix: explicit tenant API base (`/api/<ns>/<mx>`) to pin the
+   * creation LLM + tool calls to a specific memex. Set by the /home import-hero
+   * (which runs off a flat URL where the ambient tenant would resolve to a stale
+   * `currentMemexId` → std-7 404). Omitted by in-tenant callers.
+   */
+  tenantBasePath?: string;
 }
 
 export interface ResumeParams {
@@ -36,6 +43,8 @@ export interface ResumeParams {
   messages: MessageParam[];
   callbacks: AgentCallbacks;
   signal?: AbortSignal;
+  /** spec-473 hotfix: pin creation to a specific memex — see `InvokeParams`. */
+  tenantBasePath?: string;
 }
 
 export interface InvokeResult {
@@ -86,6 +95,7 @@ export function useAgentGraph() {
       agentMode = 'spec',
       callbacks,
       signal,
+      tenantBasePath,
     }: InvokeParams): Promise<InvokeResult> => {
       const threadId = `thread-${++threadCounterRef.current}`;
 
@@ -118,6 +128,7 @@ export function useAgentGraph() {
             thread_id: threadId,
             callbacks,
             signal,
+            tenantBasePath,
           },
           signal,
         }
@@ -136,6 +147,7 @@ export function useAgentGraph() {
       messages,
       callbacks,
       signal,
+      tenantBasePath,
     }: ResumeParams): Promise<InvokeResult> => {
       const threadId = `thread-${++threadCounterRef.current}`;
 
@@ -147,6 +159,7 @@ export function useAgentGraph() {
             thread_id: threadId,
             callbacks,
             signal,
+            tenantBasePath,
           },
           signal,
         }

--- a/packages/ui/src/components/NewSpecModal.tsx
+++ b/packages/ui/src/components/NewSpecModal.tsx
@@ -86,6 +86,16 @@ interface NewSpecModalProps {
    */
   specsBasePath?: string;
   /**
+   * spec-473 hotfix: the tenant API base (`/api/<ns>/<mx>`) of the memex the agent
+   * should create in. The /home hero opens this modal from a FLAT `/home` URL, so
+   * the agent clients' ambient tenantBase() would resolve to `currentMemexId` from
+   * localStorage — possibly a stale/foreign memex the server 404s (std-7). Passing
+   * the personal-memex base pins creation (the /chat/create call AND its create_doc /
+   * add_section tool executions) to the same memex `specsBasePath` navigates to.
+   * Omitted → the agent resolves the tenant from the URL, unchanged for board callers.
+   */
+  creationTenantBasePath?: string;
+  /**
    * spec-470: navigate straight to the Spec the instant it's created — no "Open Spec"
    * click. This delivers the hero's Lovable-style "describe it → land on your Spec"
    * flow (ac-2), AND it is load-bearing: the hero renders on /home only while
@@ -201,7 +211,7 @@ type DisplayMessage =
       timestamp: Date;
     };
 
-export function NewSpecModal({ open, onClose, prefill, onCreated, seedMessage, autoSend, seedKind = 'idea', specsBasePath, openOnCreate }: NewSpecModalProps) {
+export function NewSpecModal({ open, onClose, prefill, onCreated, seedMessage, autoSend, seedKind = 'idea', specsBasePath, creationTenantBasePath, openOnCreate }: NewSpecModalProps) {
   const { invoke, resume } = useAgentGraph();
 
   const [messages, setMessages] = useState<DisplayMessage[]>([]);
@@ -527,6 +537,7 @@ export function NewSpecModal({ open, onClose, prefill, onCreated, seedMessage, a
           existingMessages: anthropicMessagesRef.current,
           callbacks: makeCallbacks(),
           signal: controller.signal,
+          tenantBasePath: creationTenantBasePath,
         });
         anthropicMessagesRef.current = result.messages;
       } catch (err) {
@@ -538,7 +549,7 @@ export function NewSpecModal({ open, onClose, prefill, onCreated, seedMessage, a
         abortRef.current = null;
       }
     },
-    [invoke, makeCallbacks]
+    [invoke, makeCallbacks, creationTenantBasePath]
   );
 
   // spec-470 dec-4: auto-send the hero's seeded sentence on open. Runs AFTER the
@@ -687,6 +698,7 @@ export function NewSpecModal({ open, onClose, prefill, onCreated, seedMessage, a
           messages: messagesWithResult,
           callbacks: makeCallbacks(),
           signal: controller.signal,
+          tenantBasePath: creationTenantBasePath,
         });
         anthropicMessagesRef.current = result.messages;
       } catch (err) {
@@ -698,7 +710,7 @@ export function NewSpecModal({ open, onClose, prefill, onCreated, seedMessage, a
         abortRef.current = null;
       }
     },
-    [respondedToolIds, resume, makeCallbacks]
+    [respondedToolIds, resume, makeCallbacks, creationTenantBasePath]
   );
 
   const handlePaste = (e: ClipboardEvent<HTMLTextAreaElement>) => {

--- a/packages/ui/src/components/home/BuildPromptHero.tsx
+++ b/packages/ui/src/components/home/BuildPromptHero.tsx
@@ -50,10 +50,17 @@ function hasAcceptedExtension(name: string): boolean {
 export function BuildPromptHero({
   firstName,
   specsPath,
+  creationTenantBasePath,
 }: {
   firstName: string | null;
   /** The user's Specs board path for the escape link; falls back to /specs. */
   specsPath: string | null;
+  /**
+   * spec-473 hotfix: the tenant API base (`/api/<ns>/<mx>`) of the user's personal
+   * memex — pins the creation agent to it so authoring off the flat /home URL
+   * doesn't resolve a stale ambient tenant the server 404s (std-7).
+   */
+  creationTenantBasePath?: string | null;
 }) {
   const navigate = useNavigate();
   const { track } = useTelemetry(true);
@@ -301,6 +308,10 @@ export function BuildPromptHero({
         // The hero opens from the flat /home route, so hand the modal the user's
         // Specs-board path so post-create navigation resolves the tenant.
         specsBasePath={specsPath ?? undefined}
+        // spec-473 hotfix: pin the CREATION agent (LLM + tool calls) to the same
+        // personal memex — off /home the ambient tenant would resolve to a stale
+        // localStorage currentMemexId the server 404s (std-7).
+        creationTenantBasePath={creationTenantBasePath ?? undefined}
         // Land on the new Spec the instant it's created (beats the graduation unmount).
         openOnCreate
       />

--- a/packages/ui/src/pages/HomeCanvas.tsx
+++ b/packages/ui/src/pages/HomeCanvas.tsx
@@ -34,6 +34,7 @@ import {
   type RoleCoords,
 } from '../api/journey';
 import { fetchDocs } from '../api/docs';
+import { BASE_URL } from '../api/http';
 import { resolveSpecToken, SPEC_TOKEN_PLACEHOLDER } from '../components/home/specToken';
 import { resolveStepView, activeJourney } from '../journeys/registry';
 import { BUILDER_ONLY_STEP_IDS, HIDDEN_STEP_IDS } from '../journeys/onboarding/steps';
@@ -64,12 +65,34 @@ function firstName(name: string | null | undefined): string | null {
   return f || null;
 }
 
-function personalSpecsPath(memberships?: ReadonlyArray<NavMembership>): string | null {
+// Resolve the user's personal (or first) memex to its ns/mx slug pair. Both the
+// Specs-board path and the creation tenant API base derive from this ONE resolver
+// so they can never disagree — the spec-473 404 came from two call sites resolving
+// the tenant differently (personal membership here vs. ambient currentMemexId in
+// the agent clients).
+function personalTenant(
+  memberships?: ReadonlyArray<NavMembership>,
+): { ns: string; mx: string } | null {
   if (!memberships || memberships.length === 0) return null;
   const personal = memberships.find((m) => m.kind === 'personal') ?? memberships[0];
   const ns = personal.slug;
   const mx = personal.memexSlug ?? (personal.kind === 'personal' ? 'personal' : 'main');
-  return `/${ns}/${mx}/specs`;
+  return { ns, mx };
+}
+
+function personalSpecsPath(memberships?: ReadonlyArray<NavMembership>): string | null {
+  const t = personalTenant(memberships);
+  return t ? `/${t.ns}/${t.mx}/specs` : null;
+}
+
+// spec-473 hotfix: the tenant API base (`/api/<ns>/<mx>`) of the personal memex,
+// handed to the /home import hero so the creation agent pins its LLM + tool calls
+// to it instead of the ambient (possibly stale) currentMemexId (std-7 404).
+function personalTenantApiBase(
+  memberships?: ReadonlyArray<NavMembership>,
+): string | null {
+  const t = personalTenant(memberships);
+  return t ? `${BASE_URL}/${t.ns}/${t.mx}` : null;
 }
 
 // spec-336 dec-3: builder-ness derived from the captured role placement via the SHARED
@@ -273,6 +296,12 @@ export function HomeCanvas() {
     () => personalSpecsPath(session?.memberships as ReadonlyArray<NavMembership> | undefined),
     [session],
   );
+  // spec-473 hotfix: the personal-memex API base, pinned onto the import hero's
+  // creation agent so authoring off /home targets the same memex specsPath does.
+  const creationTenantBasePath = useMemo(
+    () => personalTenantApiBase(session?.memberships as ReadonlyArray<NavMembership> | undefined),
+    [session],
+  );
 
   const selectStep = useCallback(
     (id: string) => {
@@ -380,7 +409,13 @@ export function HomeCanvas() {
       ? heroDecisionRef.current === true
       : !!state && !state.milestones.hasSpec);
   if (showHero) {
-    return <BuildPromptHero firstName={firstName(user?.name)} specsPath={specsPath} />;
+    return (
+      <BuildPromptHero
+        firstName={firstName(user?.name)}
+        specsPath={specsPath}
+        creationTenantBasePath={creationTenantBasePath}
+      />
+    );
   }
 
   return (


### PR DESCRIPTION
Promotes the two spec-473 import-hero fixes to production (validated on int deploy + smoke, run 29010199211):

- `70b442a` — pin the /home import-hero creation to the personal memex (fixes `LLM proxy request failed: 404`, std-7 tenant resolution off the flat /home URL).
- `ed63215` — let the creation agent cast facet ballots on `create_decision` (inject the memex facet vocab + instruct the ballot inline; fixes the "facet ballot is REQUIRED" rejection).

Together these make the "Turn this document into a Spec" flow work end-to-end. Full detail in #522.

🤖 Generated with [Claude Code](https://claude.com/claude-code)