### PR TITLE
spec-484: fix HTML-entity titles + raw-markdown prose across the UI

### DIFF
--- a/packages/ui/src/api/docs.spec-484.test.ts
+++ b/packages/ui/src/api/docs.spec-484.test.ts
@@ -1,0 +1,106 @@
+// spec-484 t-1 (dec-1) — decode-on-read is applied by EVERY title-returning read in
+// docs.ts, not only fetchDoc.
+//
+//   ac-1  — fetchDocs returns decoded titles ("&amp;" -> "&").
+//   ac-3  — a single shared normalizer is applied across fetchDocs + splitSection.
+//   ac-4  — content/body fields are NOT decoded by the normalizer (only titles).
+//   ac-11 — the normalizer is applied by fetchDocs and splitSection (not only fetchDoc).
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { fetchDocs, splitSection } from './docs';
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-484/acs/ac-${n}`;
+
+// Stub global fetch with a JSON payload. The api layer resolves tBase() to the flat
+// `/api` base in jsdom (no tenant path, no cached session), which is irrelevant here —
+// we answer every request with the same body regardless of URL.
+function mockFetchJson(body: unknown) {
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: async () => body,
+  } as Response);
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('spec-484: docs.ts decode-on-read', () => {
+  it('ac-1 / ac-11: fetchDocs decodes each summary title', async () => {
+    tagAc(AC(1));
+    tagAc(AC(11));
+    mockFetchJson([
+      {
+        id: 'd1',
+        handle: 'spec-1',
+        title: 'Architecture &amp; Security',
+        docType: 'spec',
+        status: 'draft',
+        parentDocId: null,
+        createdAt: '2026-01-01',
+        statusChangedAt: '2026-01-01',
+        sectionCount: 0,
+        archivedAt: null,
+      },
+    ]);
+    const docs = await fetchDocs('spec');
+    expect(docs[0].title).toBe('Architecture & Security');
+  });
+
+  it('ac-2 / ac-1: fetchDocs decodes the promoted-from parent title too', async () => {
+    tagAc(AC(2));
+    tagAc(AC(1));
+    mockFetchJson([
+      {
+        id: 'd2',
+        handle: 'spec-2',
+        title: 'Child &amp; Heir',
+        docType: 'spec',
+        status: 'draft',
+        parentDocId: 'p1',
+        parent: { id: 'p1', handle: 'doc-9', title: 'Parent &amp;amp; Root', docType: 'brief' },
+        createdAt: '2026-01-01',
+        statusChangedAt: '2026-01-01',
+        sectionCount: 0,
+        archivedAt: null,
+      },
+    ]);
+    const docs = await fetchDocs('spec');
+    expect(docs[0].title).toBe('Child & Heir');
+    // Double-encoded parent label fully resolves via the fixpoint decoder.
+    expect(docs[0].parent?.title).toBe('Parent & Root');
+  });
+
+  it('ac-3 / ac-11: splitSection decodes returned section titles', async () => {
+    tagAc(AC(3));
+    tagAc(AC(11));
+    mockFetchJson([
+      { id: 's1', docId: 'd1', sectionType: 'lens', title: 'Design &amp; UX', content: '', seq: 0 },
+      { id: 's2', docId: 'd1', sectionType: 'lens', title: null, content: '', seq: 1 },
+    ]);
+    const sections = await splitSection('s1');
+    expect(sections[0].title).toBe('Design & UX');
+    expect(sections[1].title).toBeNull();
+  });
+
+  it('ac-4: the normalizer decodes titles but NOT body content', async () => {
+    tagAc(AC(4));
+    mockFetchJson([
+      {
+        id: 's1',
+        docId: 'd1',
+        sectionType: 'lens',
+        title: 'Design &amp; UX',
+        // Content carries entity-like text (e.g. a code span) that must survive verbatim.
+        content: 'use `a &amp; b` and &lt;tag&gt; here',
+        seq: 0,
+      },
+    ]);
+    const sections = await splitSection('s1');
+    expect(sections[0].title).toBe('Design & UX'); // title decoded
+    expect(sections[0].content).toBe('use `a &amp; b` and &lt;tag&gt; here'); // content untouched
+  });
+});

--- a/packages/ui/src/api/docs.spec-484.test.ts
+++ b/packages/ui/src/api/docs.spec-484.test.ts
@@ -61,7 +61,7 @@ describe('spec-484: docs.ts decode-on-read', () => {
         docType: 'spec',
         status: 'draft',
         parentDocId: 'p1',
-        parent: { id: 'p1', handle: 'doc-9', title: 'Parent &amp;amp; Root', docType: 'brief' },
+        parent: { id: 'p1', handle: 'doc-9', title: 'Parent &amp;amp; Root', docType: 'document' },
         createdAt: '2026-01-01',
         statusChangedAt: '2026-01-01',
         sectionCount: 0,

--- a/packages/ui/src/api/docs.ts
+++ b/packages/ui/src/api/docs.ts
@@ -65,7 +65,10 @@ export async function fetchDocs(
   }
   const qs = params.toString();
   const url = qs ? `${tBase()}/docs?${qs}` : `${tBase()}/docs`;
-  return fetchJsonRaw<DocSummary[]>(fetchWithRetry, url);
+  const docs = await fetchJsonRaw<DocSummary[]>(fetchWithRetry, url);
+  // spec-484 t-1: decode-on-read for every title-bearing field a summary carries —
+  // its own title plus the promoted-from `parent` projection ("Promoted from <title>").
+  return docs.map(decodeDocSummary);
 }
 
 // ── Tags (spec-136 t-4 REST surface) ─────────────────────────────────────────
@@ -321,6 +324,15 @@ function decodeTitle<T extends { title?: string | null }>(x: T): T {
   return x.title ? { ...x, title: decodeHtmlEntities(x.title) } : x;
 }
 
+// spec-484 t-1: the shared decode-on-read normalizer for a board summary. Decodes the
+// summary's own title AND its promoted-from `parent` projection (both title-bearing),
+// reusing the same `decodeTitle` primitive as fetchDoc/splitSection so there is one
+// decode path, not per-call-site copies. Content/body fields are never touched.
+function decodeDocSummary(doc: DocSummary): DocSummary {
+  const decoded = decodeTitle(doc);
+  return doc.parent ? { ...decoded, parent: decodeTitle(doc.parent) } : decoded;
+}
+
 function normalizeDocTitles(doc: DocWithGraph): DocWithGraph {
   return {
     ...doc,
@@ -440,7 +452,9 @@ export async function splitSection(sectionId: string): Promise<DocSection[]> {
   if (!res.ok) {
     throw new Error(`Failed to split section: ${res.status}`);
   }
-  return res.json();
+  // spec-484 t-1: decode-on-read the returned section titles, same as fetchDoc's graph.
+  const sections = (await res.json()) as DocSection[];
+  return sections.map(decodeTitle);
 }
 
 // ── Document versioning (spec-448 t-6 REST surface) ─────────────────────────

--- a/packages/ui/src/api/memex.spec-484.test.ts
+++ b/packages/ui/src/api/memex.spec-484.test.ts
@@ -1,0 +1,82 @@
+// spec-484 t-1 (dec-1) — the public shared-document read decodes its titles too, so a
+// shared Spec renders "Architecture & Security", never the raw "&amp;".
+//
+//   ac-2  — shared-doc titles (doc + section) are decoded on read.
+//   ac-3  — the same shared decoder is applied here as in fetchDocs/splitSection.
+//   ac-4  — section CONTENT is not decoded (only titles).
+//   ac-11 — getSharedDocumentApi applies the normalizer (not only fetchDoc).
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { getSharedDocumentApi } from './memex';
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-484/acs/ac-${n}`;
+
+function mockFetchJson(body: unknown) {
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: async () => body,
+  } as Response);
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('spec-484: getSharedDocumentApi decode-on-read', () => {
+  it('ac-2 / ac-11: the doc title and section titles are decoded', async () => {
+    tagAc(AC(2));
+    tagAc(AC(11));
+    mockFetchJson({
+      doc: {
+        id: 'd1',
+        memexId: 'm1',
+        handle: 'spec-1',
+        title: 'Architecture &amp;amp; Security',
+        docType: 'spec',
+        status: 'draft',
+        createdAt: '2026-01-01',
+        statusChangedAt: '2026-01-01',
+      },
+      sections: [
+        { id: 's1', docId: 'd1', sectionType: 'lens', title: 'Design &amp; UX', content: 'body', seq: 0, createdAt: '', updatedAt: '' },
+        { id: 's2', docId: 'd1', sectionType: 'lens', title: null, content: 'body', seq: 1, createdAt: '', updatedAt: '' },
+      ],
+      namespaceSlug: 'ns',
+      memexName: 'MX',
+      comments: [],
+    });
+    const dto = await getSharedDocumentApi('tok');
+    // Double-encoded doc title fully resolves; single-encoded section title decodes.
+    expect(dto.doc.title).toBe('Architecture & Security');
+    expect(dto.sections[0].title).toBe('Design & UX');
+    expect(dto.sections[1].title).toBeNull();
+  });
+
+  it('ac-4: section content is left untouched (titles only)', async () => {
+    tagAc(AC(4));
+    mockFetchJson({
+      doc: {
+        id: 'd1',
+        memexId: 'm1',
+        handle: 'spec-1',
+        title: 'Clean Title',
+        docType: 'spec',
+        status: 'draft',
+        createdAt: '2026-01-01',
+        statusChangedAt: '2026-01-01',
+      },
+      sections: [
+        { id: 's1', docId: 'd1', sectionType: 'lens', title: 'A &amp; B', content: 'code `x &amp; y` and &lt;t&gt;', seq: 0, createdAt: '', updatedAt: '' },
+      ],
+      namespaceSlug: 'ns',
+      memexName: 'MX',
+      comments: [],
+    });
+    const dto = await getSharedDocumentApi('tok');
+    expect(dto.sections[0].title).toBe('A & B'); // title decoded
+    expect(dto.sections[0].content).toBe('code `x &amp; y` and &lt;t&gt;'); // content verbatim
+  });
+});

--- a/packages/ui/src/api/memex.ts
+++ b/packages/ui/src/api/memex.ts
@@ -4,6 +4,7 @@
 import { NotFoundError, ShareAccessError } from './errors';
 import { BASE_URL, fetchWithRetry, authHeaders } from './http';
 import { tBase } from './internal';
+import { decodeHtmlEntities } from '../utils/decodeHtmlEntities';
 
 export type MemexVisibility = 'public' | 'private';
 
@@ -184,6 +185,20 @@ export interface SharedDocumentDto {
   comments: SharedCommentDto[];
 }
 
+// spec-484 t-1: decode-on-read the title-bearing fields of a shared document — the
+// doc title and each section's title — mirroring how the authenticated fetchDoc path
+// normalizes its graph. Body `content` is markdown (ReactMarkdown decodes it) and is
+// deliberately left untouched, so only titles pass through the shared decoder.
+function normalizeSharedDocument(dto: SharedDocumentDto): SharedDocumentDto {
+  return {
+    ...dto,
+    doc: { ...dto.doc, title: decodeHtmlEntities(dto.doc.title) },
+    sections: dto.sections.map((s) =>
+      s.title ? { ...s, title: decodeHtmlEntities(s.title) } : s,
+    ),
+  };
+}
+
 // PUBLIC endpoint — no Authorization header sent.
 export async function getSharedDocumentApi(shareToken: string): Promise<SharedDocumentDto> {
   const res = await fetchWithRetry(`${BASE_URL}/share/${shareToken}`);
@@ -192,7 +207,7 @@ export async function getSharedDocumentApi(shareToken: string): Promise<SharedDo
     const reason: 'unknown' | 'revoked' = body.reason === 'revoked' ? 'revoked' : 'unknown';
     throw new ShareAccessError(reason, body.error ?? `Share access failed: ${res.status}`);
   }
-  return body;
+  return normalizeSharedDocument(body as SharedDocumentDto);
 }
 
 // External comment POST (t-11). Bearer token required — the commenter must be a Memex user

--- a/packages/ui/src/components/AcPanel.spec-484.test.tsx
+++ b/packages/ui/src/components/AcPanel.spec-484.test.tsx
@@ -1,0 +1,81 @@
+// spec-484 t-3 / dec-2 — AcPanel statement renders inline markdown.
+//
+// The unified AC list printed `r.ac.statement` as plain text, so authored
+// `code`/`**bold**` showed as literal syntax. This pins that the statement now
+// routes through the shared markdown renderer in INLINE mode: `code` → <code>,
+// `**bold**` → <strong>, with no <p>/list wrapper disturbing the row layout.
+
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AcPanel } from './AcPanel';
+import {
+  fetchAcsForBrief,
+  fetchAcAlignmentHistory,
+  type AcWithVerification,
+} from '../api/client';
+import { tagAc } from '@memex-ai-ac/vitest';
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-484/acs/ac-${n}`;
+
+vi.mock('../api/client', async () => {
+  const actual = await vi.importActual<typeof import('../api/client')>('../api/client');
+  return {
+    ...actual,
+    fetchAcsForBrief: vi.fn(),
+    fetchAcAlignmentHistory: vi.fn(),
+    fetchAcTestMatrix: vi.fn().mockResolvedValue([]),
+  };
+});
+
+vi.mock('./ChatContext', () => ({
+  useChat: () => ({ addContextChip: vi.fn() }),
+}));
+
+beforeEach(() => {
+  (globalThis as { ResizeObserver?: unknown }).ResizeObserver = class {
+    observe(): void {}
+    unobserve(): void {}
+    disconnect(): void {}
+  };
+  vi.clearAllMocks();
+});
+
+function makeAc(): AcWithVerification {
+  return {
+    ac: {
+      id: 'ac-1',
+      memexId: 'memex-1',
+      briefId: 'spec-1',
+      seq: 1,
+      kind: 'implementation',
+      statement: 'The `login` form rejects **bad** passwords',
+      status: 'active',
+      acceptedBy: null,
+      acceptedAt: null,
+      createdAt: '2026-05-01T00:00:00Z',
+      updatedAt: '2026-05-01T00:00:00Z',
+    },
+    canonicalRef: 'ns/m/specs/spec-484/acs/ac-1',
+    tests: [],
+    verificationState: 'untested',
+    daysSinceLastRun: 0,
+    parents: [],
+  } as AcWithVerification;
+}
+
+describe('spec-484: AcPanel statement renders inline markdown', () => {
+  it('ac-8 / ac-13: the AC statement routes through the markdown renderer (code + strong)', async () => {
+    tagAc(AC(8));
+    tagAc(AC(13));
+    vi.mocked(fetchAcsForBrief).mockResolvedValue([makeAc()]);
+    vi.mocked(fetchAcAlignmentHistory).mockResolvedValue([]);
+
+    render(<AcPanel docId="doc-1" />);
+
+    const list = await screen.findByTestId('ac-unified-list');
+    await waitFor(() => expect(list.querySelector('code')).not.toBeNull());
+    expect(list.querySelector('code')?.textContent).toBe('login');
+    expect(list.querySelector('strong')?.textContent).toBe('bad');
+    expect(list.textContent).not.toContain('`login`');
+  });
+});

--- a/packages/ui/src/components/AcPanel.tsx
+++ b/packages/ui/src/components/AcPanel.tsx
@@ -41,6 +41,7 @@ import { useChat } from './ChatContext';
 import { AcSparkline } from './AcSparkline';
 import { AcAboutDialog } from './AcAboutDialog';
 import { AcMatrixCollapsible } from './AcMatrixCollapsible';
+import { MarkdownText } from './chat/MarkdownText';
 import { PromptButton } from './PromptButton';
 import { phaseDisplayName } from '../utils/phaseDisplay';
 import { Metric, type BarSegment } from './MetricBar';
@@ -444,7 +445,7 @@ function UnifiedAcList({
                 <span className="text-sm font-mono text-muted">ac-{r.ac.seq}</span>
                 <KindBadge kind={r.ac.kind} />
               </div>
-              <div className="text-base text-body">{r.ac.statement}</div>
+              <MarkdownText inline className="text-base text-body">{r.ac.statement}</MarkdownText>
               <AcRowMeta row={r} onInvestigate={onInvestigate} />
               {/* spec-188 (ac-1): the accept action sits alongside the
                   test-history toggle. The collapsible keeps the full row

--- a/packages/ui/src/components/AcPill.spec-484.test.tsx
+++ b/packages/ui/src/components/AcPill.spec-484.test.tsx
@@ -1,0 +1,49 @@
+// spec-484 t-3 / dec-2 — AcPill tooltip statement renders inline markdown.
+//
+// The hover tooltip printed `row.ac.statement` as plain text. This pins that it
+// now routes through the shared markdown renderer (inline mode): `code` →
+// <code>, `**bold**` → <strong>.
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { AcPill } from './AcPill';
+import type { AcWithVerification, AcVerificationState } from '../api/client';
+import { tagAc } from '@memex-ai-ac/vitest';
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-484/acs/ac-${n}`;
+
+function row(statement: string): AcWithVerification {
+  return {
+    ac: {
+      id: 'ac-id',
+      memexId: 'mx',
+      briefId: 'doc-1',
+      seq: 3,
+      kind: 'scope',
+      statement,
+      status: 'active',
+      acceptedBy: null,
+      acceptedAt: null,
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-01T00:00:00Z',
+    },
+    canonicalRef: 'ns/mx/specs/spec-484/acs/ac-3',
+    tests: [],
+    verificationState: 'verified' as AcVerificationState,
+    daysSinceLastRun: null,
+    parents: [],
+  } as AcWithVerification;
+}
+
+describe('spec-484: AcPill tooltip renders inline markdown', () => {
+  it('ac-8 / ac-13: the statement routes through the markdown renderer (code + strong)', () => {
+    tagAc(AC(8));
+    tagAc(AC(13));
+    render(<AcPill row={row('The `login` form rejects **bad** passwords')} onClick={vi.fn()} />);
+    fireEvent.mouseEnter(screen.getByRole('button'));
+    const tip = screen.getByRole('tooltip');
+    expect(tip.querySelector('code')?.textContent).toBe('login');
+    expect(tip.querySelector('strong')?.textContent).toBe('bad');
+    expect(tip.textContent).not.toContain('`login`');
+  });
+});

--- a/packages/ui/src/components/AcPill.tsx
+++ b/packages/ui/src/components/AcPill.tsx
@@ -12,6 +12,7 @@
 // palette or hover affordance changes, change it once here.
 
 import { useRef, useState } from 'react';
+import { MarkdownText } from './chat/MarkdownText';
 import type {
   AcWithVerification,
   AcVerificationState,
@@ -109,9 +110,9 @@ export function AcPill({ row, onClick, clickHint }: AcPillProps) {
             <span className="opacity-60">·</span>
             <span>{STATE_LABEL[row.verificationState]}</span>
           </div>
-          <div className="font-medium leading-snug mb-2">
+          <MarkdownText inline className="font-medium leading-snug mb-2 block">
             {row.ac.statement}
-          </div>
+          </MarkdownText>
           {row.tests.length === 0 ? (
             <div className="opacity-70 italic">
               No test in the codebase asserts this yet.

--- a/packages/ui/src/components/CommentTray.spec-484.test.tsx
+++ b/packages/ui/src/components/CommentTray.spec-484.test.tsx
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { tagAc } from '@memex-ai-ac/vitest';
+import type { ReactNode } from 'react';
+import { CommentBubble, CommentMarkdown } from './CommentTray';
+import type { Comment } from '../api/types';
+
+// spec-484 t-2 / dec-2 — comment bodies render markdown (they are human- OR
+// LLM-authored and legitimately contain markdown) while BOTH ref syntaxes stay
+// linkified: full canonical paths (rehypeRefLinkifier) + the `[per dec-N]` /
+// `[per t-N]` shorthand (rehypePerRefLinkifier). CommentBubble (the tray) and
+// SectionCard's popover both render through the shared CommentMarkdown.
+
+const AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-484/acs/ac-${n}`;
+
+function makeComment(content: string, over: Partial<Comment> = {}): Comment {
+  return {
+    id: 'c-1',
+    content,
+    authorName: 'Alice',
+    createdAt: new Date('2026-07-01T10:00:00Z').toISOString(),
+    resolvedAt: null,
+    resolution: null,
+    docId: 'doc-1',
+    ...over,
+  } as Comment;
+}
+
+function renderBubble(content: string, over: Partial<Comment> = {}) {
+  return render(
+    <MemoryRouter>
+      <CommentBubble comment={makeComment(content, over)} />
+    </MemoryRouter>,
+  );
+}
+
+function wrap(children: ReactNode) {
+  return render(<MemoryRouter>{children}</MemoryRouter>);
+}
+
+describe('spec-484: CommentBubble renders markdown (ac-6)', () => {
+  it('ac-6: **bold** renders <strong>, - list renders <li>, [x](/y) renders <a>', () => {
+    tagAc(AC(6));
+    const { container } = renderBubble('This is **bold**\n\n- one\n- two\n\nsee [docs](/y)');
+    expect(container.querySelector('strong')?.textContent).toBe('bold');
+    expect(container.querySelectorAll('li')).toHaveLength(2);
+    const link = container.querySelector('a[href="/y"]');
+    expect(link?.textContent).toBe('docs');
+    // No literal markdown syntax leaks through as text.
+    expect(container.textContent).not.toContain('**bold**');
+  });
+
+  it('ac-6: SectionCard popover path (CommentMarkdown directly) renders markdown', () => {
+    tagAc(AC(6));
+    const { container } = wrap(
+      <CommentMarkdown content={'**strong** and `code`'} className="text-secondary" />,
+    );
+    expect(container.querySelector('strong')?.textContent).toBe('strong');
+    expect(container.querySelector('code')?.textContent).toBe('code');
+  });
+});
+
+describe('spec-484: comment linkification survives the markdown path (ac-9)', () => {
+  it('ac-9: [per dec-N] + a full canonical path + plain markdown all render, no mangling', () => {
+    tagAc(AC(9));
+    const { container } = renderBubble(
+      'Per [per dec-3] and mindset-int/memex-app/specs/spec-3 — this is **important**.',
+    );
+    // Shorthand → interactive DecisionLink.
+    expect(container.querySelector('[data-decision-handle="dec-3"]')).toBeInTheDocument();
+    // Full canonical path → linkified anchor with the same-origin href.
+    const canonical = container.querySelector('a[href="/mindset-int/memex-app/specs/spec-3"]');
+    expect(canonical).toBeInTheDocument();
+    expect(canonical?.textContent).toBe('mindset-int/memex-app/specs/spec-3');
+    // Surrounding markdown still renders.
+    expect(container.querySelector('strong')?.textContent).toBe('important');
+    // Text is not double-processed / mangled — the prose words survive verbatim.
+    expect(container.textContent).toContain('Per ');
+    expect(container.textContent).toContain(' and ');
+  });
+});
+
+describe('spec-484: parseEntityRefs loop is gone; refs route through markdown (ac-14)', () => {
+  it('ac-14: [per dec-N] renders a DecisionLink through the markdown render path', () => {
+    tagAc(AC(14));
+    const { container } = renderBubble('Blocked per [per dec-7].');
+    const link = container.querySelector('[data-testid="decision-link"]');
+    expect(link).toBeInTheDocument();
+    expect(link?.getAttribute('data-decision-handle')).toBe('dec-7');
+  });
+
+  it('ac-14: [per t-N] renders a TaskLink through the markdown render path', () => {
+    tagAc(AC(14));
+    const { container } = renderBubble('Waiting on [per t-4].');
+    const link = container.querySelector('[data-testid="task-link"]');
+    expect(link).toBeInTheDocument();
+    expect(link?.getAttribute('data-task-handle')).toBe('t-4');
+  });
+
+  it('ac-14: shorthand inside inline code is NOT turned into a link', () => {
+    tagAc(AC(14));
+    const { container } = renderBubble('Type `[per dec-3]` verbatim.');
+    expect(container.querySelector('[data-decision-handle]')).not.toBeInTheDocument();
+    expect(container.querySelector('code')?.textContent).toBe('[per dec-3]');
+  });
+});

--- a/packages/ui/src/components/CommentTray.tsx
+++ b/packages/ui/src/components/CommentTray.tsx
@@ -1,4 +1,8 @@
 import { useState, useEffect } from 'react';
+import ReactMarkdown, { type Components } from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import { rehypeRefLinkifier } from './chat/refLinkifier';
+import { rehypePerRefLinkifier } from './chat/perRefLinkifier';
 import type { Comment, CommentTargetType } from '../api/types';
 import { useAuth } from './AuthContext';
 import {
@@ -16,7 +20,7 @@ import {
 import { MentionComposer, type MentionSubmit } from './MentionComposer';
 import { CommentTypePill } from './CommentTypePill';
 import { CommentSourceAvatar } from './CommentSourceAvatar';
-import { DecisionLink, TaskLink, parseEntityRefs } from './DecisionLink';
+import { DecisionLink, TaskLink } from './DecisionLink';
 import { commentTypeAccentBorder } from '../utils/commentStyles';
 // spec-259 ac-5: render WHEN as the SAME relative phrase the MCP/agent surface
 // uses ("3d ago") so the web Specify readiness picture matches the agent's.
@@ -209,6 +213,75 @@ function mentionLabel(m: CommentMentionView): string {
   return m.name?.trim() || m.email?.trim() || 'Unknown';
 }
 
+/**
+ * spec-484 dec-2 (ac-6 / ac-9): comment bodies are human- OR LLM-authored and
+ * legitimately contain markdown, so they render as real markdown instead of
+ * literal `**bold**` / `- list` / `[link](url)` text.
+ *
+ * Both ref syntaxes stay linkified in one render pass by running BOTH rehype
+ * plugins: `rehypeRefLinkifier` (full canonical paths) + `rehypePerRefLinkifier`
+ * (the `[per dec-N]` / `[per t-N]` shorthand). The shorthand plugin stamps
+ * `data-per-ref` / `data-per-handle` on its anchors; the `a` component mapping
+ * below upgrades those into interactive `<DecisionLink>` / `<TaskLink>` so the
+ * exact resolve-on-click + navigate affordance survives the move onto the
+ * markdown path (the crux of spec-484 t-2). Plain markdown links render as
+ * external anchors, matching MarkdownText's block mode.
+ *
+ * Exported so SectionCard's comment popover renders comment bodies identically.
+ */
+export function CommentMarkdown({
+  content,
+  parentDocId,
+  className = 'text-primary',
+}: {
+  content: string;
+  /** b-42 t-2: scope bare-handle resolution to the comment's parent doc. */
+  parentDocId?: string;
+  className?: string;
+}) {
+  const components: Components = {
+    a: ({ children, href, node }) => {
+      const props = (node?.properties ?? {}) as Record<string, unknown>;
+      const perRef = (props['data-per-ref'] ?? props['dataPerRef']) as
+        | string
+        | undefined;
+      if (perRef) {
+        const handle = String(
+          props['data-per-handle'] ?? props['dataPerHandle'] ?? '',
+        );
+        return perRef === 'task' ? (
+          <TaskLink handle={handle} parentDocId={parentDocId} />
+        ) : (
+          <DecisionLink handle={handle} parentDocId={parentDocId} />
+        );
+      }
+      return (
+        <a
+          href={href}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline text-accent hover:text-accent/80"
+        >
+          {children}
+        </a>
+      );
+    },
+  };
+  return (
+    <div
+      className={`text-sm ${className} [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 [&_p]:my-2 [&_ul]:my-2 [&_ol]:my-2 [&_li]:my-0.5 [&_code]:px-1 [&_code]:py-0.5 [&_code]:rounded-sm [&_code]:bg-overlay [&_code]:text-xs`}
+    >
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        rehypePlugins={[rehypeRefLinkifier, rehypePerRefLinkifier]}
+        components={components}
+      >
+        {content}
+      </ReactMarkdown>
+    </div>
+  );
+}
+
 export function CommentBubble({
   comment,
   sectionTitle,
@@ -280,19 +353,11 @@ export function CommentBubble({
           {relative}
         </span>
       </div>
-      <p className="text-sm text-primary whitespace-pre-wrap">
-        {parseEntityRefs(comment.content).map((seg, i) =>
-          seg.kind === 'text' ? (
-            <span key={i}>{seg.value}</span>
-          ) : seg.kind === 'dec' ? (
-            // b-42 t-2: scope bare-handle resolution to the comment's parent
-            // doc so memexes with dec-1 / t-1 in multiple Specs don't 409.
-            <DecisionLink key={i} handle={seg.value} parentDocId={comment.docId} />
-          ) : (
-            <TaskLink key={i} handle={seg.value} parentDocId={comment.docId} />
-          ),
-        )}
-      </p>
+      {/* spec-484 dec-2 (ac-6 / ac-9): the body renders as markdown; both ref
+          syntaxes stay linkified via CommentMarkdown's dual rehype plugins.
+          b-42 t-2: bare-handle resolution is scoped to the comment's parent doc
+          so memexes with dec-1 / t-1 in multiple Specs don't 409. */}
+      <CommentMarkdown content={comment.content} parentDocId={comment.docId} />
       {(mentions.length > 0 || assignee) && (
         <div className="mt-1 flex flex-wrap items-center gap-1" data-testid="comment-mentions">
           {assignee && (

--- a/packages/ui/src/components/DecisionPanel.spec-484.test.tsx
+++ b/packages/ui/src/components/DecisionPanel.spec-484.test.tsx
@@ -1,0 +1,68 @@
+// spec-484 t-3 / dec-2 — decision option trade_offs render markdown.
+//
+// The candidate/open/resolved option rows used to print `opt.trade_offs` as
+// plain text (whitespace-pre-wrap), so authored markdown showed as literal
+// syntax. This pins that the trade_offs now route through the shared markdown
+// renderer (block mode): `- bullet` → <li>, `**bold**` → <strong>.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { DecisionPanel } from './DecisionPanel';
+import type { Decision } from '../api/types';
+import { tagAc } from '@memex-ai-ac/vitest';
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-484/acs/ac-${n}`;
+
+vi.mock('./ChatContext', () => ({
+  useChat: () => ({ addContextChip: vi.fn(), sendMessage: vi.fn() }),
+}));
+vi.mock('./AuthContext', () => ({
+  useAuth: () => ({ user: { name: 'Tester', email: 'tester@memex.ai' } }),
+}));
+vi.mock('../api/client', () => ({
+  createDecision: vi.fn(),
+  resolveDecisionApi: vi.fn(),
+  createDecisionComment: vi.fn(),
+  fetchAcsForBrief: vi.fn().mockResolvedValue([]),
+}));
+vi.mock('./CommentTray', () => ({
+  CommentTray: () => <div data-testid="comment-tray-stub" />,
+}));
+
+const TRADE_OFFS = 'Trade-offs:\n\n- **Fast** to build\n- Cheap to run';
+
+function makeDecision(overrides: Partial<Decision> = {}): Decision {
+  return {
+    id: `dec-${Math.random().toString(36).slice(2, 6)}`,
+    docId: 'doc-1',
+    seq: 1,
+    title: 'Which database?',
+    context: '',
+    status: 'candidate',
+    resolution: null,
+    resolvedAt: null,
+    createdAt: new Date().toISOString(),
+    options: [{ label: 'Postgres', trade_offs: TRADE_OFFS }],
+    chosenOptionIndex: null,
+    ...overrides,
+  } as Decision;
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('spec-484: DecisionPanel trade_offs render markdown', () => {
+  it('ac-7 / ac-13: candidate option trade_offs route through the markdown renderer (li + strong)', () => {
+    tagAc(AC(7));
+    tagAc(AC(13));
+    const { container, getByTestId } = render(
+      <DecisionPanel docId="doc-1" decisions={[makeDecision()]} onUpdate={vi.fn()} />,
+    );
+    const opts = getByTestId('candidate-options');
+    // Rendered markdown, not literal syntax.
+    expect(opts.querySelector('li')).not.toBeNull();
+    expect(opts.querySelector('strong')).not.toBeNull();
+    expect(opts.querySelector('strong')?.textContent).toBe('Fast');
+    // The raw markdown bullet/asterisks must NOT survive as visible literal text.
+    expect(container.textContent).not.toContain('- **Fast**');
+  });
+});

--- a/packages/ui/src/components/DecisionPanel.tsx
+++ b/packages/ui/src/components/DecisionPanel.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { rehypeRefLinkifier } from './chat/refLinkifier';
+import { MarkdownText } from './chat/MarkdownText';
 import { phaseDisplayName } from '../utils/phaseDisplay';
 import type { Decision, Comment } from '../api/types';
 import {
@@ -437,7 +438,7 @@ export function DecisionPanel({ docId, decisions, commentsByDecision = {}, force
                       >
                         <div className="text-sm font-medium text-primary">{opt.label}</div>
                         {opt.trade_offs && (
-                          <div className="text-xs text-muted mt-0.5 whitespace-pre-wrap">{opt.trade_offs}</div>
+                          <MarkdownText inline={false} className="text-xs text-muted mt-0.5">{opt.trade_offs}</MarkdownText>
                         )}
                       </div>
                     ))}
@@ -593,7 +594,7 @@ export function DecisionPanel({ docId, decisions, commentsByDecision = {}, force
                             <div className="flex-1 min-w-0">
                               <div className="text-sm font-medium text-primary">{opt.label}</div>
                               {opt.trade_offs && (
-                                <div className="text-xs text-muted mt-0.5 whitespace-pre-wrap">{opt.trade_offs}</div>
+                                <MarkdownText inline={false} className="text-xs text-muted mt-0.5">{opt.trade_offs}</MarkdownText>
                               )}
                             </div>
                           </label>
@@ -764,7 +765,7 @@ export function DecisionPanel({ docId, decisions, commentsByDecision = {}, force
                               <div className="flex-1 min-w-0">
                                 <div className="text-sm font-medium text-primary">{opt.label}</div>
                                 {opt.trade_offs && (
-                                  <div className="text-xs text-muted mt-0.5 whitespace-pre-wrap">{opt.trade_offs}</div>
+                                  <MarkdownText inline={false} className="text-xs text-muted mt-0.5">{opt.trade_offs}</MarkdownText>
                                 )}
                               </div>
                             </label>

--- a/packages/ui/src/components/DocOutline.spec-484.test.tsx
+++ b/packages/ui/src/components/DocOutline.spec-484.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { DocOutline } from './DocOutline';
+import type { Comment, Doc, DocSection } from '../api/types';
+
+// spec-484 t-2 / dec-2 — the DocOutline comment child is a single-line,
+// truncated PREVIEW. Unlike CommentTray/SectionCard bodies, it must STAY plain
+// text (no markdown), so a `**bold**` preview reads as literal characters on one
+// clamped line. This guards against the markdown treatment leaking here (ac-10).
+
+const AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-484/acs/ac-${n}`;
+
+const MARKDOWNY = '**bold** and `code` and - a list item';
+
+function makeDoc(): Doc {
+  return { id: 'd-1' } as Doc;
+}
+function makeSection(): DocSection {
+  return { id: 's-1', sectionType: 'body', title: 'Intro' } as DocSection;
+}
+function makeComment(content: string): Comment {
+  return {
+    id: 'c-1',
+    content,
+    authorName: 'Alice',
+    seq: 1,
+    createdAt: new Date('2026-07-01T10:00:00Z').toISOString(),
+    resolvedAt: null,
+    resolution: null,
+  } as Comment;
+}
+
+describe('spec-484: DocOutline comment preview stays plain (ac-10)', () => {
+  it('ac-10: markdown-y comment content renders as literal text on a clamped line', () => {
+    tagAc(AC(10));
+    const { container } = render(
+      <DocOutline
+        doc={makeDoc()}
+        sections={[makeSection()]}
+        commentsBySection={{ 's-1': [makeComment(MARKDOWNY)] }}
+      />,
+    );
+    // No markdown was rendered — the preview shows the raw characters.
+    expect(container.querySelector('strong')).toBeNull();
+    expect(container.querySelector('li')).toBeNull();
+    // The content lives inside a single-line, truncated span verbatim.
+    const clamped = container.querySelector('span.block.truncate');
+    expect(clamped?.textContent).toBe(MARKDOWNY);
+  });
+});

--- a/packages/ui/src/components/DoneSummary.spec-484.test.tsx
+++ b/packages/ui/src/components/DoneSummary.spec-484.test.tsx
@@ -1,0 +1,126 @@
+// spec-484 t-3 / dec-2 — DoneSummary "Read the spec" prose renders markdown.
+//
+// The read-the-spec record printed decision resolutions (whitespace-pre-wrap)
+// and AC statements as plain text. This pins that:
+//   • ac-7  — a decision resolution renders as block markdown (li + strong)
+//   • ac-8  — an AC statement renders inline markdown (`code` → <code>)
+//   • ac-13 — both route through the shared markdown renderer, not literal text
+//
+// DoneSummary takes plain props and makes no network call, so no providers are
+// needed.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, fireEvent, within } from '@testing-library/react';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { DoneSummary } from './DoneSummary';
+import type { Decision, DocWithGraph } from '../api/types';
+import type { AcWithVerification } from '../api/client';
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-484/acs/ac-${n}`;
+
+const CREATED_AT = '2026-06-02T12:00:00Z';
+const COMPLETED_AT = '2026-06-09T12:00:00Z';
+
+function makeDoc(overrides: Partial<DocWithGraph> = {}): DocWithGraph {
+  return {
+    id: 'doc-uuid',
+    handle: 'spec-484',
+    title: 'Render correctness',
+    docType: 'spec',
+    status: 'done',
+    creator: { name: 'Tester', email: 'tester@memex.ai' },
+    createdAt: CREATED_AT,
+    statusChangedAt: COMPLETED_AT,
+    sections: [],
+    decisions: [],
+    tasks: [],
+    ...overrides,
+  } as DocWithGraph;
+}
+
+function makeDecision(): Decision {
+  return {
+    id: 'dec-1',
+    docId: 'doc-uuid',
+    seq: 1,
+    title: 'Which database?',
+    context: null,
+    status: 'resolved',
+    resolution: 'Chose Postgres:\n\n- **Mature** ecosystem\n- Strong SQL',
+    resolvedAt: COMPLETED_AT,
+    createdAt: CREATED_AT,
+    options: null,
+    chosenOptionIndex: null,
+  } as Decision;
+}
+
+function makeAc(): AcWithVerification {
+  return {
+    ac: {
+      id: 'ac-1',
+      memexId: 'memex',
+      briefId: 'doc-uuid',
+      seq: 1,
+      kind: 'implementation',
+      statement: 'The `login` form rejects **bad** passwords',
+      status: 'active',
+      acceptedBy: null,
+      acceptedAt: null,
+      createdAt: CREATED_AT,
+      updatedAt: CREATED_AT,
+    },
+    canonicalRef: 'ns/m/specs/spec-484/acs/ac-1',
+    tests: [],
+    verificationState: 'verified',
+    daysSinceLastRun: null,
+    parents: [],
+  } as AcWithVerification;
+}
+
+let fetchSpy: ReturnType<typeof vi.spyOn>;
+beforeEach(() => {
+  fetchSpy = vi.spyOn(globalThis, 'fetch' as never).mockImplementation((() => {
+    throw new Error('DoneSummary must not fetch');
+  }) as never);
+});
+afterEach(() => fetchSpy.mockRestore());
+
+describe('spec-484: DoneSummary read-the-spec prose renders markdown', () => {
+  it('ac-7 / ac-13: a decision resolution renders as block markdown (li + strong)', () => {
+    tagAc(AC(7));
+    tagAc(AC(13));
+    const { getByTestId } = render(
+      <DoneSummary
+        doc={makeDoc()}
+        decisions={[makeDecision()]}
+        tasks={[]}
+        acs={[]}
+        issues={[]}
+      />,
+    );
+    fireEvent.click(getByTestId('done-read-spec'));
+    const decision = getByTestId('done-read-decision');
+    expect(decision.querySelector('li')).not.toBeNull();
+    expect(decision.querySelector('strong')?.textContent).toBe('Mature');
+    expect(decision.textContent).not.toContain('- **Mature**');
+  });
+
+  it('ac-8 / ac-13: an AC statement renders inline markdown (`code` → <code>)', () => {
+    tagAc(AC(8));
+    tagAc(AC(13));
+    const { getByTestId } = render(
+      <DoneSummary
+        doc={makeDoc()}
+        decisions={[]}
+        tasks={[]}
+        acs={[makeAc()]}
+        issues={[]}
+      />,
+    );
+    fireEvent.click(getByTestId('done-read-spec'));
+    const acRow = getByTestId('done-read-ac');
+    expect(within(acRow).getByText('login').tagName).toBe('CODE');
+    expect(acRow.querySelector('strong')?.textContent).toBe('bad');
+    expect(acRow.textContent).not.toContain('`login`');
+  });
+});

--- a/packages/ui/src/components/DoneSummary.tsx
+++ b/packages/ui/src/components/DoneSummary.tsx
@@ -30,6 +30,7 @@ import { useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeHighlight from 'rehype-highlight';
+import { MarkdownText } from './chat/MarkdownText';
 import { isQaReportSectionType } from '@memex/shared';
 import type { Decision, Task, Issue, DocWithGraph } from '../api/types';
 import type { AcWithVerification, DocAssigneeView } from '../api/client';
@@ -355,7 +356,7 @@ export function DoneSummary({
                       <span className="font-medium text-primary">{d.title}</span>{' '}
                       <span className="text-muted">({d.status})</span>
                       {d.resolution && (
-                        <div className="text-secondary mt-1 whitespace-pre-wrap">{d.resolution}</div>
+                        <MarkdownText inline={false} className="text-secondary mt-1">{d.resolution}</MarkdownText>
                       )}
                     </li>
                   ))}
@@ -382,7 +383,7 @@ export function DoneSummary({
                 <ul className="space-y-1.5">
                   {acs.map((a) => (
                     <li key={a.ac.id} className="text-sm text-primary" data-testid="done-read-ac">
-                      {a.ac.statement}{' '}
+                      <MarkdownText inline>{a.ac.statement}</MarkdownText>{' '}
                       <span className="text-muted">
                         ({a.ac.kind}
                         {a.verificationState === 'verified' ? ' · verified' : ''})

--- a/packages/ui/src/components/ExecutionPlanModal.spec-484.test.tsx
+++ b/packages/ui/src/components/ExecutionPlanModal.spec-484.test.tsx
@@ -1,0 +1,62 @@
+// spec-484 t-3 / dec-2 — ExecutionPlanModal readiness assessment renders markdown.
+//
+// The agent-authored readiness banner printed its content with
+// whitespace-pre-wrap, so markdown showed as literal syntax. This pins that the
+// readiness body now routes through the same ReactMarkdown wiring the plan
+// sections use: `- bullet` → <li>, `**bold**` → <strong>, `code` → <code>.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { ExecutionPlanModal } from './ExecutionPlanModal';
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-484/acs/ac-${n}`;
+
+const mockFetchDoc = vi.fn();
+const mockFetchTaskComments = vi.fn();
+
+vi.mock('../api/client', () => ({
+  fetchDoc: (...a: unknown[]) => mockFetchDoc(...a),
+  fetchTaskComments: (...a: unknown[]) => mockFetchTaskComments(...a),
+  updateDocStatus: vi.fn(),
+  createComment: vi.fn(),
+}));
+
+vi.mock('./AuthContext', () => ({
+  useAuth: () => ({ user: { name: 'Reviewer', email: 'r@memex.ai' } }),
+}));
+
+const READINESS = 'READY — the plan is complete:\n\n- **all** sections filled\n- `pnpm test` green';
+
+function makePlanDoc() {
+  return {
+    id: 'plan-1',
+    status: 'draft',
+    sections: [
+      { id: 'sec-1', sectionType: 'approach', title: 'Approach', content: 'Do the thing.' },
+    ],
+  };
+}
+
+const task = { id: 't-1', seq: 3, title: 'Wire it up' } as never;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockFetchDoc.mockResolvedValue(makePlanDoc());
+  mockFetchTaskComments.mockResolvedValue([
+    { id: 'c-1', content: READINESS, type: 'readiness_check', createdAt: '2026-06-01T00:00:00Z' },
+  ]);
+});
+
+describe('spec-484: ExecutionPlanModal readiness renders markdown', () => {
+  it('ac-8 / ac-13: readiness content routes through the markdown renderer (li + strong + code)', async () => {
+    tagAc(AC(8));
+    tagAc(AC(13));
+    render(<ExecutionPlanModal task={task} planDocId="plan-1" onClose={() => {}} />);
+    const banner = await screen.findByTestId('plan-readiness');
+    await waitFor(() => expect(banner.querySelector('li')).not.toBeNull());
+    expect(banner.querySelector('strong')?.textContent).toBe('all');
+    expect(banner.querySelector('code')?.textContent).toBe('pnpm test');
+    expect(banner.textContent).not.toContain('- **all**');
+  });
+});

--- a/packages/ui/src/components/ExecutionPlanModal.tsx
+++ b/packages/ui/src/components/ExecutionPlanModal.tsx
@@ -241,8 +241,8 @@ export function ExecutionPlanModal({
                   </div>
                   {/* spec-389: theme-aware prose (see ChatMarkdown) — `prose-invert`
                       was a dead no-op that washed out in light mode. */}
-                  <div className="prose-dark max-w-none whitespace-pre-wrap wrap-break-word text-sm">
-                    {readiness.content}
+                  <div className="prose-dark max-w-none wrap-break-word text-sm [&>*:first-child]:mt-0 [&>*:last-child]:mb-0">
+                    <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeRefLinkifier]}>{readiness.content}</ReactMarkdown>
                   </div>
                 </div>
               )}

--- a/packages/ui/src/components/IssuePanel.spec-484.test.tsx
+++ b/packages/ui/src/components/IssuePanel.spec-484.test.tsx
@@ -1,0 +1,84 @@
+// spec-484 t-3 / dec-2 — IssuePanel expanded body renders markdown; the
+// collapsed preview stays plain.
+//
+//   • ac-8 / ac-13 — the EXPANDED issue body routes through the markdown
+//     renderer (block mode): `- bullet` → <li>, `**bold**` → <strong>.
+//   • ac-10        — the COLLAPSED line-clamp-2 preview stays PLAIN: no <li>,
+//     no <strong>; the literal markdown syntax is what's shown (a single
+//     clamped line, unchanged layout).
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { IssuePanel } from './IssuePanel';
+import type { Issue } from '../api/types';
+import { tagAc } from '@memex-ai-ac/vitest';
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-484/acs/ac-${n}`;
+
+const mockFetchIssues = vi.fn();
+
+vi.mock('./ChatContext', () => ({
+  useChat: () => ({ addContextChip: vi.fn() }),
+}));
+vi.mock('../hooks/useDocChangeStream', () => ({
+  useDocChangeStream: () => {},
+}));
+vi.mock('../api/client', () => ({
+  fetchIssues: (...a: unknown[]) => mockFetchIssues(...a),
+  createIssueApi: vi.fn(),
+  updateIssueStatusApi: vi.fn(),
+  convertIssueToTaskApi: vi.fn(),
+}));
+
+const BODY = 'Repro steps:\n\n- open **Safari**\n- click login';
+
+function makeIssue(overrides: Partial<Issue> = {}): Issue {
+  return {
+    id: 'iss-1',
+    docId: 'doc-1',
+    seq: 1,
+    title: 'Login is a no-op',
+    body: BODY,
+    type: 'bug',
+    severity: null,
+    status: 'open',
+    source: 'human',
+    satisfyingTaskId: null,
+    promotedDocId: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  } as Issue;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockFetchIssues.mockResolvedValue([makeIssue()]);
+});
+
+describe('spec-484: IssuePanel body markdown', () => {
+  it('ac-10: the collapsed preview stays PLAIN (no li / no strong, literal syntax)', async () => {
+    tagAc(AC(10));
+    render(<IssuePanel docId="doc-1" />);
+    const card = await screen.findByTestId('issue-card');
+    // Collapsed by default — the clamped preview is a plain <p>.
+    const preview = card.querySelector('.line-clamp-2');
+    expect(preview).not.toBeNull();
+    expect(preview!.querySelector('li')).toBeNull();
+    expect(preview!.querySelector('strong')).toBeNull();
+    // The literal markdown is shown, un-rendered.
+    expect(preview!.textContent).toContain('**Safari**');
+  });
+
+  it('ac-8 / ac-13: the expanded body routes through the markdown renderer (li + strong)', async () => {
+    tagAc(AC(8));
+    tagAc(AC(13));
+    render(<IssuePanel docId="doc-1" />);
+    const card = await screen.findByTestId('issue-card');
+    fireEvent.click(card);
+    const expanded = within(card).getByTestId('issue-expanded');
+    expect(expanded.querySelector('li')).not.toBeNull();
+    expect(expanded.querySelector('strong')?.textContent).toBe('Safari');
+    expect(expanded.textContent).not.toContain('- open **Safari**');
+  });
+});

--- a/packages/ui/src/components/IssuePanel.tsx
+++ b/packages/ui/src/components/IssuePanel.tsx
@@ -33,6 +33,7 @@ import { Badge, Button } from './ui';
 import { Input } from './ui/Input';
 import { TextArea } from './ui/TextArea';
 import { Metric } from './MetricBar';
+import { MarkdownText } from './chat/MarkdownText';
 
 interface IssuePanelProps {
   docId: string;
@@ -400,7 +401,7 @@ export function IssuePanel({
                   // card again to collapse.
                   <div data-testid="issue-expanded" className="mt-2 space-y-2">
                     {issue.body && (
-                      <p className="text-xs text-body whitespace-pre-wrap">{issue.body}</p>
+                      <MarkdownText inline={false} className="text-xs text-body">{issue.body}</MarkdownText>
                     )}
                     <p className="text-[11px] text-muted">
                       issue-{issue.seq} · {TYPE_LABEL[issue.type]} ·{' '}

--- a/packages/ui/src/components/SectionCard.tsx
+++ b/packages/ui/src/components/SectionCard.tsx
@@ -6,6 +6,7 @@ import type { DocSection, Comment } from '../api/types';
 import { useChat } from './ChatContext';
 import { useAuth } from './AuthContext';
 import { CommentSourceAvatar } from './CommentSourceAvatar';
+import { CommentMarkdown } from './CommentTray';
 import { rehypeRefLinkifier } from './chat/refLinkifier';
 import { createComment, resolveComment, deleteComment, addCommentMentions } from '../api/client';
 import { buildCommentLink } from '../utils/commentDeepLink';
@@ -566,7 +567,10 @@ export const SectionCard = memo(function SectionCard({
                   {c.createdAt && <div className="text-[10px] text-muted">{formatCommentTime(c.createdAt)}</div>}
                 </div>
               </div>
-              <p className="text-sm text-secondary whitespace-pre-wrap wrap-break-word">{bodyText}</p>
+              {/* spec-484 dec-2 (ac-6): the popover body renders as markdown
+                  (both ref syntaxes stay linkified), matching CommentTray. The
+                  truncation-aware `bodyText` is fed straight through. */}
+              <CommentMarkdown content={bodyText} parentDocId={c.docId} className="text-secondary wrap-break-word" />
               {long && (
                 <button type="button" data-testid={`card-showmore-${c.seq}`} onClick={(e) => { e.stopPropagation(); toggleExpand(c.id); }} className="text-[11px] text-accent hover:underline">
                   {expanded ? 'Show less' : 'Show more'}

--- a/packages/ui/src/components/TaskPanel.spec-484.test.tsx
+++ b/packages/ui/src/components/TaskPanel.spec-484.test.tsx
@@ -1,0 +1,74 @@
+// spec-484 t-3 / dec-2 — TaskPanel clamped previews render inline markdown
+// without breaking the clamp.
+//
+//   • ac-8 / ac-13 — the task description and each acceptance-criterion line
+//     route through the markdown renderer (inline mode): `code` → <code>,
+//     `**bold**` → <strong>.
+//   • ac-15        — the previews stay CLAMPED: the description keeps its
+//     line-clamp-2 wrapper and no block list (<li>) leaks into the single line.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { TaskPanel } from './TaskPanel';
+import type { Task } from '../api/types';
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-484/acs/ac-${n}`;
+
+vi.mock('./ChatContext', () => ({
+  useChat: () => ({ addContextChip: vi.fn() }),
+}));
+vi.mock('../api/client', () => ({
+  fetchPlanReadiness: vi.fn().mockResolvedValue([]),
+}));
+vi.mock('./ExecutionPlanModal', () => ({
+  ExecutionPlanModal: () => <div data-testid="execution-plan-modal-stub" />,
+  derivePlanBadgeState: () => 'submitted',
+  planStateLabel: () => 'Submitted',
+  PLAN_STATE_CLASSES: { none: '', submitted: '', ready: '', not_ready: '', approved: '' },
+}));
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: 't-1',
+    docId: 'doc-1',
+    seq: 1,
+    title: 'Write tests',
+    description: 'Cover the `happy` **path**',
+    status: 'not_started',
+    blocked: false,
+    blockedByDecisions: [],
+    blockedByTasks: [],
+    sectionRef: null,
+    acceptanceCriteria: [{ description: 'The `login` button is **disabled**', done: false }],
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  } as Task;
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('spec-484: TaskPanel clamped previews render inline markdown', () => {
+  it('ac-8 / ac-13 / ac-15: description + AC lines render inline markdown, clamp preserved, no block leak', () => {
+    tagAc(AC(8));
+    tagAc(AC(13));
+    tagAc(AC(15));
+    render(<TaskPanel docId="doc-1" tasks={[makeTask()]} onUpdate={vi.fn()} />);
+
+    const card = screen.getByTestId('task-card');
+
+    // The description preview keeps its clamp wrapper and renders inline markdown.
+    const preview = card.querySelector('.line-clamp-2');
+    expect(preview).not.toBeNull();
+    expect(preview!.querySelector('code')?.textContent).toBe('happy');
+    expect(preview!.querySelector('strong')?.textContent).toBe('path');
+    // No block list leaks into the clamped single line.
+    expect(preview!.querySelector('li')).toBeNull();
+    expect(preview!.textContent).not.toContain('`happy`');
+
+    // The acceptance-criterion line renders inline markdown too.
+    expect(within(card).getByText('login').tagName).toBe('CODE');
+    expect(card.querySelector('li')).toBeNull();
+  });
+});

--- a/packages/ui/src/components/TaskPanel.tsx
+++ b/packages/ui/src/components/TaskPanel.tsx
@@ -11,6 +11,7 @@ import {
 import { Badge } from './ui';
 import { FacetPills } from './FacetPills';
 import { Metric } from './MetricBar';
+import { MarkdownText } from './chat/MarkdownText';
 
 interface TaskPanelProps {
   /** Retained for call-site compatibility — was only consumed by the removed
@@ -173,7 +174,7 @@ export function TaskPanel({ docId: _docId, doc: _doc, tasks, onUpdate, canWrite:
                     <Badge status={display} label={display === 'blocked' ? 'blocked' : statusLabel[t.status]} />
                     <span className="text-sm truncate text-primary">{t.title}</span>
                   </div>
-                  <p className="text-xs text-muted mt-1 line-clamp-2">{t.description}</p>
+                  <p className="text-xs text-muted mt-1 line-clamp-2"><MarkdownText inline>{t.description}</MarkdownText></p>
                   {t.sectionRef && (
                     <Badge status="archived" label={t.sectionRef} className="mt-1" />
                   )}
@@ -183,7 +184,7 @@ export function TaskPanel({ docId: _docId, doc: _doc, tasks, onUpdate, canWrite:
                       {t.acceptanceCriteria.map((ac, i) => (
                         <div key={i} className="flex items-center gap-1.5 text-[11px]">
                           <span className={ac.done ? 'text-status-success-text' : 'text-muted'}>{ac.done ? '[x]' : '[ ]'}</span>
-                          <span className={ac.done ? 'text-muted line-through' : 'text-secondary'}>{ac.description}</span>
+                          <MarkdownText inline className={ac.done ? 'text-muted line-through' : 'text-secondary'}>{ac.description}</MarkdownText>
                         </div>
                       ))}
                     </div>

--- a/packages/ui/src/components/chat/ChatDecisionCard.spec-484.test.tsx
+++ b/packages/ui/src/components/chat/ChatDecisionCard.spec-484.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { tagAc } from '@memex-ai-ac/vitest';
+
+// spec-484 t-2 / dec-2 — the ChatDecisionCard resolution line is a single-line
+// truncated PREVIEW. Like DocOutline, it must STAY plain text: markdown-y
+// resolution content reads as literal characters on one clamped line, never
+// rendered (ac-15).
+
+const AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-484/acs/ac-${n}`;
+
+const MARKDOWNY = '**bold** resolution with `code`';
+
+vi.mock('../ChatContext', () => ({
+  useChat: () => ({
+    doc: {
+      decisions: [
+        {
+          id: 'x',
+          seq: 1,
+          title: 'A decision',
+          status: 'resolved',
+          resolution: MARKDOWNY,
+        },
+      ],
+    },
+  }),
+}));
+
+import { ChatDecisionCard } from './ChatDecisionCard';
+
+describe('spec-484: ChatDecisionCard preview stays plain (ac-15)', () => {
+  it('ac-15: markdown-y resolution renders as literal text, clamped, not as markdown', () => {
+    tagAc(AC(15));
+    const { container } = render(<ChatDecisionCard id="dec-1" />);
+    // No markdown rendered.
+    expect(container.querySelector('strong')).toBeNull();
+    expect(container.querySelector('code')).toBeNull();
+    // Verbatim characters live inside the single-line truncated preview.
+    const clamped = container.querySelector('.truncate');
+    expect(clamped?.textContent).toBe(MARKDOWNY);
+  });
+});

--- a/packages/ui/src/components/chat/perRefLinkifier.spec-484.test.tsx
+++ b/packages/ui/src/components/chat/perRefLinkifier.spec-484.test.tsx
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import ReactMarkdown from 'react-markdown';
+import rehypeRaw from 'rehype-raw';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { rehypePerRefLinkifier, PER_REF_PATTERN } from './perRefLinkifier';
+
+// spec-484 t-2 / dec-2 — perRefLinkifier is the companion rehype plugin that
+// keeps the `[per dec-N]` / `[per t-N]` shorthand linkified once comment bodies
+// render through markdown. This file unit-tests the plugin directly (ac-14),
+// mirroring refLinkifier.test.tsx's render-the-full-hast-pipeline approach.
+
+const AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-484/acs/ac-${n}`;
+
+function renderMd(content: string) {
+  return render(
+    <ReactMarkdown rehypePlugins={[rehypeRaw, rehypePerRefLinkifier]}>
+      {content}
+    </ReactMarkdown>,
+  );
+}
+
+function getPerLinks(container: HTMLElement): HTMLAnchorElement[] {
+  return Array.from(
+    container.querySelectorAll<HTMLAnchorElement>('a.per-ref-link'),
+  );
+}
+
+describe('rehypePerRefLinkifier (spec-484 ac-14)', () => {
+  it('ac-14: turns [per dec-N] into a dec-routed anchor', () => {
+    tagAc(AC(14));
+    const { container } = renderMd('See [per dec-3] for the rationale.');
+    const links = getPerLinks(container);
+    expect(links).toHaveLength(1);
+    expect(links[0].getAttribute('data-per-ref')).toBe('dec');
+    expect(links[0].getAttribute('data-per-handle')).toBe('dec-3');
+    expect(links[0].textContent).toBe('dec-3');
+  });
+
+  it('ac-14: turns [per t-N] into a task-routed anchor', () => {
+    tagAc(AC(14));
+    const { container } = renderMd('Blocked by [per t-5].');
+    const links = getPerLinks(container);
+    expect(links).toHaveLength(1);
+    expect(links[0].getAttribute('data-per-ref')).toBe('task');
+    expect(links[0].getAttribute('data-per-handle')).toBe('t-5');
+  });
+
+  it('ac-14: handles the qualified [per doc-N:dec-M] cite form', () => {
+    tagAc(AC(14));
+    const { container } = renderMd('Per [per doc-12:dec-4] we chose X.');
+    const links = getPerLinks(container);
+    expect(links).toHaveLength(1);
+    expect(links[0].getAttribute('data-per-ref')).toBe('dec');
+    expect(links[0].getAttribute('data-per-handle')).toBe('doc-12:dec-4');
+  });
+
+  it('ac-14: does NOT linkify shorthand inside inline code', () => {
+    tagAc(AC(14));
+    const { container } = renderMd('Write `[per dec-3]` literally in code.');
+    expect(getPerLinks(container)).toHaveLength(0);
+    const code = container.querySelector('code');
+    expect(code?.textContent).toBe('[per dec-3]');
+  });
+
+  it('ac-14: does NOT linkify shorthand inside fenced code blocks', () => {
+    tagAc(AC(14));
+    const md = ['```', '[per dec-3]', '[per t-1]', '```'].join('\n');
+    const { container } = renderMd(md);
+    expect(getPerLinks(container)).toHaveLength(0);
+    const pre = container.querySelector('pre');
+    expect(pre?.textContent).toContain('[per dec-3]');
+  });
+
+  it('ac-14: does NOT double-link inside an existing anchor', () => {
+    tagAc(AC(14));
+    const { container } = renderMd('Link: <a href="/x">[per dec-3]</a>.');
+    const all = container.querySelectorAll('a');
+    expect(all).toHaveLength(1);
+    expect(all[0].getAttribute('href')).toBe('/x');
+    expect(getPerLinks(container)).toHaveLength(0);
+  });
+
+  it('ac-14: preserves surrounding text and handles multiple refs', () => {
+    tagAc(AC(14));
+    const { container } = renderMd('Before [per dec-1] and [per t-9] after.');
+    const links = getPerLinks(container);
+    expect(links).toHaveLength(2);
+    expect(links[0].getAttribute('data-per-handle')).toBe('dec-1');
+    expect(links[1].getAttribute('data-per-handle')).toBe('t-9');
+    // The paragraph still carries the surrounding prose intact.
+    expect(container.querySelector('p')?.textContent).toBe(
+      'Before dec-1 and t-9 after.',
+    );
+  });
+
+  it('ac-14: leaves non-matching bracketed text alone', () => {
+    tagAc(AC(14));
+    const { container } = renderMd('This [per whatever] is not a ref.');
+    expect(getPerLinks(container)).toHaveLength(0);
+  });
+
+  it('PER_REF_PATTERN matches the three cite forms + task handles', () => {
+    // Structural guard: keep the pattern in lock-step with DecisionLink's
+    // PER_REF_REGEX so the two ref surfaces never drift.
+    for (const s of ['[per dec-3]', '[per mis-2:dec-4]', '[per doc-1:dec-9]', '[per t-7]']) {
+      PER_REF_PATTERN.lastIndex = 0;
+      expect(PER_REF_PATTERN.test(s), `${s} should match`).toBe(true);
+    }
+  });
+});

--- a/packages/ui/src/components/chat/perRefLinkifier.ts
+++ b/packages/ui/src/components/chat/perRefLinkifier.ts
@@ -1,0 +1,181 @@
+/**
+ * rehypePerRefLinkifier — a rehype plugin that auto-links the `[per dec-N]` /
+ * `[per t-N]` cross-entity SHORTHAND inside markdown text nodes.
+ *
+ * This is the companion to `rehypeRefLinkifier` (spec-484 dec-2). The two are
+ * ORTHOGONAL: `rehypeRefLinkifier` matches FULL canonical paths
+ * (`ns/mx/specs/spec-N/...`); this plugin matches the `[per dec-N]` /
+ * `[per t-N]` shorthand that `parseEntityRefs` (DecisionLink.tsx) used to
+ * handle before comment bodies moved onto the markdown render path. Running
+ * both plugins keeps every ref syntax linkified while comment bodies compose
+ * as real markdown.
+ *
+ * The anchor this plugin emits carries `data-per-ref` (`dec` | `task`) +
+ * `data-per-handle` (the bare handle) so a react-markdown `a` component mapping
+ * can upgrade it into an interactive `<DecisionLink>` / `<TaskLink>` — those
+ * components resolve the handle server-side on click and navigate to the parent
+ * Spec (the route a plain static anchor cannot know at render time). A plain
+ * anchor is emitted when no component mapping intercepts it, so the plugin is
+ * still meaningful on its own (and directly unit-testable).
+ *
+ * Rules (mirrors refLinkifier):
+ *   - Text inside `<code>` (inline) or `<pre>` (fenced) is skipped — shorthand
+ *     embedded in code samples renders verbatim.
+ *   - Text inside an existing `<a>` is skipped to avoid double-linking.
+ *   - Surrounding text is preserved exactly; only the matched `[per …]`
+ *     substring is wrapped in an anchor.
+ *   - Pure / render-time only: no Date.now / Math.random. Storage stays plain.
+ */
+
+// Local hast type shims — narrow versions of the @types/hast definitions,
+// matching what `react-markdown` hands to rehype plugins (see refLinkifier.ts
+// for the rationale on keeping these local).
+
+type HastText = { type: 'text'; value: string };
+
+type HastProperties = Record<
+  string,
+  string | number | boolean | null | undefined | (string | number)[]
+>;
+
+interface HastElement {
+  type: 'element';
+  tagName: string;
+  properties?: HastProperties;
+  children: HastChild[];
+}
+
+type HastChild = HastText | HastElement | { type: string; [key: string]: unknown };
+
+interface HastRoot {
+  type: 'root';
+  children: HastChild[];
+}
+
+// `[per <handle>]` where <handle> is one of the three cite forms parseEntityRefs
+// accepts — Spec-qualified (`mis-N:dec-M`, t-7), doc-qualified (`doc-N:dec-M`,
+// legacy), or bare (`dec-M`) — plus bare task handles (`t-N`). Kept structurally
+// identical to `PER_REF_REGEX` in DecisionLink.tsx so the two never drift. `g`
+// because we scan each text node for every shorthand it contains.
+export const PER_REF_PATTERN =
+  /\[per ((?:(?:mis|doc)-\d+:)?dec-\d+|t-\d+)\]/g;
+
+const SKIP_TAGS = new Set(['code', 'pre', 'a']);
+
+/**
+ * The entity channel a handle routes to — `t-N` → task, everything else → dec.
+ * Mirrors the `kind` derivation in `parseEntityRefs`.
+ */
+function perRefKind(handle: string): 'dec' | 'task' {
+  return handle.startsWith('t-') ? 'task' : 'dec';
+}
+
+/**
+ * Builds a hast anchor carrying the shorthand handle + kind. A react-markdown
+ * `a` component mapping reads `data-per-ref` / `data-per-handle` to render the
+ * interactive DecisionLink / TaskLink; unmapped it renders as a plain anchor.
+ * The visible label is the bare handle (matching DecisionLink's own label),
+ * not the `[per …]` wrapper.
+ */
+function makePerAnchor(handle: string): HastElement {
+  return {
+    type: 'element',
+    tagName: 'a',
+    properties: {
+      // No static route is knowable at render time (DecisionLink/TaskLink
+      // resolve the handle on click); the component mapping intercepts this.
+      href: '#',
+      className: ['per-ref-link'],
+      'data-per-ref': perRefKind(handle),
+      'data-per-handle': handle,
+    },
+    children: [{ type: 'text', value: handle }],
+  };
+}
+
+/**
+ * Splits a single text node into text + anchor nodes by scanning for `[per …]`
+ * shorthand. Returns the original node (wrapped) when nothing matches so callers
+ * can leave the reference unchanged.
+ */
+function linkifyTextNode(node: HastText): HastChild[] {
+  const value = node.value;
+  PER_REF_PATTERN.lastIndex = 0;
+
+  const out: HastChild[] = [];
+  let cursor = 0;
+  let match: RegExpExecArray | null;
+  while ((match = PER_REF_PATTERN.exec(value)) !== null) {
+    const [full, handle] = match;
+    const start = match.index;
+    const end = start + full.length;
+
+    if (start > cursor) {
+      out.push({ type: 'text', value: value.slice(cursor, start) });
+    }
+    out.push(makePerAnchor(handle));
+    cursor = end;
+
+    if (match.index === PER_REF_PATTERN.lastIndex) {
+      PER_REF_PATTERN.lastIndex++;
+    }
+  }
+
+  if (out.length === 0) return [node];
+  if (cursor < value.length) {
+    out.push({ type: 'text', value: value.slice(cursor) });
+  }
+  return out;
+}
+
+/**
+ * Recursively walks the hast tree, transforming text children of any element
+ * that isn't itself `code` / `pre` / `a` (those subtrees are skipped wholesale).
+ */
+function walk(node: HastRoot | HastElement): void {
+  if (!Array.isArray(node.children)) return;
+
+  const nextChildren: HastChild[] = [];
+  let mutated = false;
+
+  for (const child of node.children) {
+    if (child.type === 'text') {
+      const textChild = child as HastText;
+      const replacement = linkifyTextNode(textChild);
+      if (replacement.length !== 1 || replacement[0] !== textChild) {
+        mutated = true;
+      }
+      nextChildren.push(...replacement);
+      continue;
+    }
+
+    if (child.type === 'element') {
+      const elementChild = child as HastElement;
+      if (SKIP_TAGS.has(elementChild.tagName)) {
+        nextChildren.push(elementChild);
+        continue;
+      }
+      walk(elementChild);
+      nextChildren.push(elementChild);
+      continue;
+    }
+
+    nextChildren.push(child);
+  }
+
+  if (mutated) {
+    node.children = nextChildren;
+  }
+}
+
+/**
+ * rehype plugin factory. Pass to `rehypePlugins` on `<ReactMarkdown>` alongside
+ * `rehypeRefLinkifier`.
+ */
+export function rehypePerRefLinkifier() {
+  return (tree: HastRoot) => {
+    walk(tree);
+  };
+}
+
+export default rehypePerRefLinkifier;

--- a/packages/ui/src/pages/SharedDocument.spec-484.test.tsx
+++ b/packages/ui/src/pages/SharedDocument.spec-484.test.tsx
@@ -1,0 +1,42 @@
+// spec-484 t-1 (dec-1) — the shared-document comment body renders markdown.
+//
+//   ac-6 (partial) — a comment written with **bold** renders a <strong>, not literal
+//                    asterisks (the body was previously plain whitespace-pre-wrap text).
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { CommentRow } from './SharedDocument';
+import type { SharedCommentDto } from '../api/client';
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-484/acs/ac-${n}`;
+
+function makeComment(content: string): SharedCommentDto {
+  return {
+    id: 'c1',
+    memexId: 'm1',
+    sectionId: 's1',
+    decisionId: null,
+    taskId: null,
+    authorName: 'Alex',
+    authorUserId: 'u1',
+    authorNamespaceId: 'm1',
+    content,
+    resolution: null,
+    resolvedAt: null,
+    createdAt: '2026-01-01T00:00:00.000Z',
+  };
+}
+
+describe('spec-484: SharedDocument comment body markdown', () => {
+  it('ac-6: **bold** in a comment renders a <strong>, not literal asterisks', () => {
+    tagAc(AC(6));
+    const { container, queryByText } = render(
+      <CommentRow comment={makeComment('this is **bold** text')} hostMemexId="m1" />,
+    );
+    const strong = container.querySelector('strong');
+    expect(strong).not.toBeNull();
+    expect(strong?.textContent).toBe('bold');
+    // The raw markdown source must NOT survive as literal text.
+    expect(queryByText(/\*\*bold\*\*/)).toBeNull();
+  });
+});

--- a/packages/ui/src/pages/SharedDocument.tsx
+++ b/packages/ui/src/pages/SharedDocument.tsx
@@ -13,6 +13,7 @@ import {
   type SharedCommentDto,
 } from '../api/client';
 import { buildBareDomainUrl } from '../utils/tenantUrl';
+import { decodeHtmlEntities } from '../utils/decodeHtmlEntities';
 // t-23 of doc-15: buildBareDomainUrl now returns ${origin}/ — no subdomain
 // stripping. Used here to build the "sign in to comment" return-to link.
 
@@ -100,7 +101,9 @@ export function SharedDocument() {
       <main className="flex-1">
         <article className="max-w-3xl mx-auto px-6 py-10 space-y-8">
           <header>
-            <h1 className="text-3xl font-semibold text-heading">{data.doc.title}</h1>
+            <h1 className="text-3xl font-semibold text-heading">
+              {decodeHtmlEntities(data.doc.title)}
+            </h1>
             <div className="text-xs text-muted mt-2">
               {data.doc.handle} · {data.doc.docType}
             </div>
@@ -195,7 +198,9 @@ function SectionBlock({
 
   return (
     <section className="space-y-3">
-      {section.title && <h2 className="text-xl font-semibold text-heading">{section.title}</h2>}
+      {section.title && (
+        <h2 className="text-xl font-semibold text-heading">{decodeHtmlEntities(section.title)}</h2>
+      )}
       <div className="prose prose-sm max-w-none text-primary">
         <ReactMarkdown rehypePlugins={[rehypeRefLinkifier]}>{section.content}</ReactMarkdown>
       </div>
@@ -244,7 +249,9 @@ function SectionBlock({
   );
 }
 
-function CommentRow({
+// Exported for spec-484 ac-6 — the comment body renders markdown (**bold** / lists /
+// links), not literal source. Kept a named export so the unit test can mount it directly.
+export function CommentRow({
   comment,
   hostMemexId,
 }: {
@@ -267,7 +274,13 @@ function CommentRow({
           {new Date(comment.createdAt).toLocaleDateString()}
         </span>
       </div>
-      <div className="text-primary whitespace-pre-wrap">{comment.content}</div>
+      {/* spec-484 t-1 (ac-6): render the comment body as markdown so **bold** / lists /
+          links render, mirroring the section-body wiring above (same ReactMarkdown +
+          rehypeRefLinkifier). Comment CONTENT is markdown and is NOT entity-decoded —
+          ReactMarkdown handles entities, and re-decoding could corrupt code spans. */}
+      <div className="prose prose-sm max-w-none text-primary">
+        <ReactMarkdown rehypePlugins={[rehypeRefLinkifier]}>{comment.content}</ReactMarkdown>
+      </div>
     </div>
   );
 }

--- a/packages/ui/src/utils/decodeHtmlEntities.spec-484.test.ts
+++ b/packages/ui/src/utils/decodeHtmlEntities.spec-484.test.ts
@@ -1,0 +1,41 @@
+// spec-484 t-1 (dec-1) — the decode-on-read primitive.
+//
+//   ac-5  — double-encoded "&amp;amp;" decodes fully to "&" (fixpoint), while a
+//           bare "&" and an entity-free string are left untouched.
+//   ac-12 — an already-clean / entity-free title is returned unchanged (the
+//           decoder is a no-op on data that carries no entity).
+import { describe, it, expect } from 'vitest';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { decodeHtmlEntities } from './decodeHtmlEntities';
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-484/acs/ac-${n}`;
+
+describe('spec-484: decodeHtmlEntities fixpoint decode', () => {
+  it('ac-5: double-encoded "&amp;amp;" decodes fully to "&"', () => {
+    tagAc(AC(5));
+    // The core legacy bug: some rows were double-encoded. One pass would leave a
+    // literal "&amp;" on screen; the fixpoint loop resolves every layer.
+    expect(decodeHtmlEntities('Architecture &amp;amp; Security')).toBe('Architecture & Security');
+    expect(decodeHtmlEntities('&amp;amp;')).toBe('&');
+    // Single-encoded still works (the common case).
+    expect(decodeHtmlEntities('Design &amp; UX')).toBe('Design & UX');
+  });
+
+  it('ac-5: a bare "&" with no trailing entity is preserved', () => {
+    tagAc(AC(5));
+    expect(decodeHtmlEntities('Tom & Jerry')).toBe('Tom & Jerry');
+    expect(decodeHtmlEntities('R&D budget')).toBe('R&D budget');
+  });
+
+  it('ac-5: unknown entities pass through verbatim', () => {
+    tagAc(AC(5));
+    expect(decodeHtmlEntities('&notARealEntity; stays')).toBe('&notARealEntity; stays');
+  });
+
+  it('ac-12: an entity-free / already-clean title is returned unchanged', () => {
+    tagAc(AC(12));
+    expect(decodeHtmlEntities('Plain title')).toBe('Plain title');
+    expect(decodeHtmlEntities('Architecture & Security')).toBe('Architecture & Security');
+    expect(decodeHtmlEntities('')).toBe('');
+  });
+});

--- a/packages/ui/src/utils/decodeHtmlEntities.test.ts
+++ b/packages/ui/src/utils/decodeHtmlEntities.test.ts
@@ -38,8 +38,9 @@ describe('decodeHtmlEntities', () => {
     expect(decodeHtmlEntities('no entities here')).toBe('no entities here');
   });
 
-  it('only decodes a single layer (titles were never double-encoded)', () => {
-    // &amp;amp; -> &amp; (one pass); proves we are not aggressively re-decoding.
-    expect(decodeHtmlEntities('A &amp;amp; B')).toBe('A &amp; B');
+  it('fully decodes multi-encoded values to a fixpoint (spec-484 t-1)', () => {
+    // Some legacy rows were double-encoded. A single pass left a literal "&amp;" on
+    // screen; the fixpoint loop resolves every layer: &amp;amp; -> &amp; -> &.
+    expect(decodeHtmlEntities('A &amp;amp; B')).toBe('A & B');
   });
 });

--- a/packages/ui/src/utils/decodeHtmlEntities.ts
+++ b/packages/ui/src/utils/decodeHtmlEntities.ts
@@ -11,7 +11,9 @@
 //
 // Pure + dependency-free (no DOM), so it runs the same in the browser, jsdom tests,
 // and any SSR path. Decodes the named entities a title realistically carries plus
-// decimal/hex numeric refs. Single-pass (we never produced double-encoded titles).
+// decimal/hex numeric refs. Loops to a fixpoint so MULTI-encoded legacy values are
+// fully decoded ("&amp;amp;" -> "&amp;" -> "&"): some legacy rows were double-encoded,
+// and a single pass would only half-decode them, leaving a literal "&amp;" on screen.
 
 const NAMED: Record<string, string> = {
   amp: '&',
@@ -25,9 +27,9 @@ const NAMED: Record<string, string> = {
 // Matches a well-formed entity: &name; | &#123; | &#x1F600;
 const ENTITY = /&(#x[0-9a-fA-F]+|#[0-9]+|[a-zA-Z][a-zA-Z0-9]*);/g;
 
-export function decodeHtmlEntities(input: string): string {
-  // Fast path: nothing that could be an entity.
-  if (!input || input.indexOf('&') === -1) return input;
+// A single decode pass: resolves every well-formed entity once. A bare "&" with no
+// trailing entity, and any unknown entity, are left verbatim.
+function decodeOnce(input: string): string {
   return input.replace(ENTITY, (match, body: string) => {
     if (body[0] === '#') {
       const code =
@@ -42,6 +44,21 @@ export function decodeHtmlEntities(input: string): string {
       }
     }
     const decoded = NAMED[body.toLowerCase()];
-    return decoded ?? match; // unknown entity → leave verbatim
+    return decoded ?? match; // unknown entity -> leave verbatim
   });
+}
+
+export function decodeHtmlEntities(input: string): string {
+  // Fast path: nothing that could be an entity.
+  if (!input || input.indexOf('&') === -1) return input;
+  // Decode repeatedly until the string stops changing (fixpoint). A pass that changes
+  // anything strictly shortens the string (an entity -> a single char), so this
+  // terminates; the cap is a defensive guard against pathological input.
+  let current = input;
+  for (let i = 0; i < 16; i++) {
+    const next = decodeOnce(current);
+    if (next === current) break;
+    current = next;
+  }
+  return current;
 }


### PR DESCRIPTION
Fixes two UI render-correctness defect classes — **UI-only, no server/schema/migration**. Full write-up: [spec-484](https://memex.ai/mindset-prod/memex-building-itself/specs/spec-484).

## What was broken
1. **Titles showed raw `&amp;`.** Legacy titles stored HTML-entity-encoded (sometimes double-encoded `&amp;amp;`) render as plain React text, so the literal entity showed on the spec board, the public shared viewer, and split-section results. A decoder existed but was wired into only the single-doc fetch.
2. **Prose showed literal markdown.** Comment bodies, decision trade-offs, agent "Readiness assessment", issue bodies, and AC statements were rendered as plain text, so users saw literal `**bold**`, `- bullets`, `[links](url)`.

## What changed
- **Titles (dec-1, decode-on-read):** one shared title-normalizer applied by `fetchDocs`, `splitSection`, and `getSharedDocumentApi` (not just `fetchDoc`); `decodeHtmlEntities` now loops to a fixpoint so `&amp;amp;` fully decodes to `&`. Titles/labels only — `content` is never decoded (react-markdown already handles it). No data migration (encoded rows are bounded legacy data; backfill deferred per dec-1).
- **Prose (dec-2, shared markdown router):** ~11 full-display sites routed through the shared `MarkdownText`. New `perRefLinkifier` rehype plugin linkifies the `[per dec-N]`/`[per t-N]` comment shorthand at the hast level so markdown + both ref syntaxes compose in one render; the manual `parseEntityRefs` loop in `CommentBubble` is retired. Single-line truncated previews stay plain.

## Testing
- 15 acceptance criteria, each covered by colocated `*.spec-484` tests asserting real rendered DOM.
- Full `@memex/ui` suite green: **321 files, 2133 passed, 0 failed**; `tsc --noEmit` clean.
- All 15 ACs verified on the Memex board (`0 untested, 0 failing`).
- No new Playwright journey — rendering-correctness change, not a new user flow (std-28); existing journeys unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)