### PR TITLE
spec-485: task completion must not auto-advance a Spec's phase

### DIFF
--- a/packages/server/src/mcp/workflows.integration.test.ts
+++ b/packages/server/src/mcp/workflows.integration.test.ts
@@ -31,6 +31,7 @@ import {
   users,
 } from "../db/schema.js";
 import { createMcpServer } from "./tools.js";
+import { tagAc } from "@memex-ai-ac/vitest";
 import { COMPLETION_NUDGE } from "../agent/tool-specs.js";
 import { setAcReviewedVerification } from "../services/acs.js";
 
@@ -557,13 +558,17 @@ describe("update_task completion nudge", () => {
   });
 
   beforeEach(async () => {
-    // spec-327: completing the last task auto-promotes the Spec build→verify
-    // (maybeAutoPromoteToVerify), and create_task is now gated to build — so
-    // reset to build before each case creates its tasks.
+    // create_task is gated to build (spec-327), so keep the Spec in build before
+    // each case creates its tasks. (spec-485: completing the last task no longer
+    // auto-promotes build→verify — the former maybeAutoPromoteToVerify is removed —
+    // so this reset is now defensive rather than load-bearing.)
     await db.update(documents).set({ status: "build" }).where(eq(documents.id, spec.id));
   });
 
   it("emits the canonical nudge on status=complete with no dependents", async () => {
+    // spec-485 ac-9: this file no longer asserts the removed build→verify
+    // auto-promote; the completion nudge (separate path) is the sole signal.
+    tagAc("mindset-prod/memex-building-itself/specs/spec-485/acs/ac-9");
     await callTool(actor.user.id, "create_task", {
       ref: specRef,
       title: "Standalone nudge task",

--- a/packages/server/src/services/tasks.integration.test.ts
+++ b/packages/server/src/services/tasks.integration.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterAll, beforeAll } from "vitest";
+import { describe, it, expect, afterAll, beforeAll, vi } from "vitest";
 import { eq } from "drizzle-orm";
 import { db } from "../db/connection.js";
 import { documents, decisions, tasks, decisionDeps, taskDeps } from "../db/schema.js";
@@ -15,6 +15,10 @@ import {
 import { addDecisionDep, addTaskDep } from "./dependencies.js";
 import { NotFoundError, ValidationError } from "../types/errors.js";
 import { makeTestMemex } from "./test-helpers.js";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+const AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-485/acs/ac-${n}`;
 
 const createdDocIds: string[] = [];
 
@@ -143,11 +147,21 @@ describe("updateTaskStatus", () => {
     ).rejects.toThrow(NotFoundError);
   });
 
-  // Per dec-4 of doc-10: when the last open task on a Spec flips to complete,
-  // the Spec auto-promotes from `build` to `verify`. Service-layer placement
-  // means this fires regardless of which client wrote the task status.
-  it("auto-promotes a Spec from build → verify when the last task completes", async () => {
-    const spec = await createDocDraft(memexId, "AutoPromote Spec", "Purpose", "spec");
+  // spec-485 (ac-5, ac-8): completing a task NEVER advances a Spec's phase.
+  // This is the regression guard for the removed `maybeAutoPromoteToVerify` — the
+  // last surviving limb of the "phase is a deliberate placement" arc
+  // (spec-189→295/327/342→464). Real specs under a real memex, so a reintroduced
+  // auto-promote WOULD flip the doc here — a genuine guard, not a tautology.
+  it("does NOT advance a Spec build → verify when the last task completes", async () => {
+    tagAc(AC(8));
+    tagAc(AC(5));
+    tagAc(AC(7));
+    tagAc(AC(9));
+    // Scope ACs proven by the same behaviour:
+    tagAc(AC(1)); // last-task completion no longer changes phase
+    tagAc(AC(2)); // no task-state change advances phase (service layer → any caller)
+    tagAc(AC(4)); // this IS the regression guard against reintroduction
+    const spec = await createDocDraft(memexId, "No-AutoPromote Spec", "Purpose", "spec");
     createdDocIds.push(spec.id);
     const { updateDocStatus } = await import("./documents.js");
     await updateDocStatus(memexId, spec.id, "build");
@@ -157,15 +171,44 @@ describe("updateTaskStatus", () => {
 
     await updateTaskStatus(memexId, t1.id, "complete");
     let row = await db.query.documents.findFirst({ where: eq(documents.id, spec.id) });
-    expect(row?.status).toBe("build"); // still build — t2 is open
+    expect(row?.status).toBe("build"); // one task still open
 
+    // Completing the LAST open task must still leave the Spec in build —
+    // the phase move is the human's deliberate call, never an auto side-effect.
     await updateTaskStatus(memexId, t2.id, "complete");
     row = await db.query.documents.findFirst({ where: eq(documents.id, spec.id) });
-    expect(row?.status).toBe("verify");
+    expect(row?.status).toBe("build");
   });
 
-  it("does not auto-promote non-Spec docs", async () => {
-    const doc = await createDocDraft(memexId, "AutoPromote Doc", "Purpose", "document");
+  // spec-485 (ac-6): the removal is surgical — the sibling issue auto-resolution
+  // call (spec-112 ac-22) on task completion is preserved. Spy the module binding
+  // and assert `updateTaskStatus(..., 'complete')` still invokes it.
+  it("still runs issue auto-resolution when a task completes (ac-6 — sibling preserved)", async () => {
+    tagAc(AC(6));
+    tagAc(AC(3)); // task completion still succeeds + issue auto-resolution unaffected
+    const issues = await import("./issues.js");
+    const spy = vi
+      .spyOn(issues, "maybeAutoResolveIssuesForTask")
+      .mockResolvedValue([]);
+    try {
+      const spec = await createDocDraft(memexId, "IssueResolve Spec", "Purpose", "spec");
+      createdDocIds.push(spec.id);
+      const { updateDocStatus } = await import("./documents.js");
+      await updateDocStatus(memexId, spec.id, "build");
+
+      const t1 = await createTask(memexId, spec.id, "Task", "Desc");
+      await updateTaskStatus(memexId, t1.id, "complete");
+
+      expect(spy).toHaveBeenCalledWith(memexId, t1.id);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("does not move non-Spec docs on task completion", async () => {
+    tagAc(AC(5));
+    tagAc(AC(2));
+    const doc = await createDocDraft(memexId, "No-AutoPromote Doc", "Purpose", "document");
     createdDocIds.push(doc.id);
     const { updateDocStatus } = await import("./documents.js");
     await updateDocStatus(memexId, doc.id, "build");
@@ -177,7 +220,9 @@ describe("updateTaskStatus", () => {
     expect(row?.status).toBe("build"); // unchanged
   });
 
-  it("does not auto-promote if Spec is not currently in build", async () => {
+  it("does not move a Spec that is not in build on task completion", async () => {
+    tagAc(AC(5));
+    tagAc(AC(2));
     const spec = await createDocDraft(memexId, "Specify Spec", "Purpose", "spec");
     createdDocIds.push(spec.id);
     const { updateDocStatus } = await import("./documents.js");

--- a/packages/server/src/services/tasks.ts
+++ b/packages/server/src/services/tasks.ts
@@ -1,4 +1,4 @@
-import { and, eq, asc, ne, sql, isNull } from "drizzle-orm";
+import { and, eq, asc, isNull } from "drizzle-orm";
 import { db } from "../db/connection.js";
 import { tasks, documents } from "../db/schema.js";
 import type { Task, Decision } from "../db/schema.js";
@@ -11,7 +11,6 @@ import type { Blockers } from "./dependencies.js";
 import { nextSeq, withSeqRetry } from "./shared/sequence.js";
 import { isUuid, parseHandle } from "./shared/identifiers.js";
 import { docAttribution } from "./shared/doc-attribution.js";
-import { updateDocStatus } from "./documents.js";
 import { maybeAutoResolveIssuesForTask } from "./issues.js";
 
 // Per doc-37: bare `T-N` handles can collide within a memex because `tasks.seq` is
@@ -310,13 +309,14 @@ export async function updateTaskStatus(
     },
   );
 
-  // Per dec-4 of doc-10: when the last open task on a Spec flips to `complete`,
-  // auto-promote the Spec's status from `build`→`verify`. Service-layer
-  // placement so it fires for any caller (kanban DnD, MCP, agent). Other transitions
-  // (draft→specify, specify→build, verify→done) stay manual. updateDocStatus emits its
-  // own document.updated event — independent invariant per dec-2 of doc-16.
+  // spec-485 (dec-1): completing a task NEVER moves a Spec's phase. Phase is a
+  // deliberate human/handoff placement, not inferred from code-work. Completing the
+  // last open task used to auto-promote build→verify (the former
+  // `maybeAutoPromoteToVerify`) — the last surviving limb of the arc
+  // spec-189→295/327/342→464, now removed. The explicit "that was the last task →
+  // move to verify" prompt lives in a SEPARATE path (the `task_completed` footer
+  // signal in agent/handlers/tasks.ts) and remains the deliberate signal.
   if (status === "complete") {
-    await maybeAutoPromoteToVerify(memexId, item.docId, ctx);
     // spec-112 ac-22: a `converted` Issue whose satisfying Task just completed
     // transitions → `resolved` IFF the verifying AC's latest test_event is a pass.
     // Best-effort: a failure here must not fail the task-status write (the Issue
@@ -324,49 +324,6 @@ export async function updateTaskStatus(
     await maybeAutoResolveIssuesForTask(memexId, item.id).catch(() => {});
   }
   return updated;
-}
-
-async function maybeAutoPromoteToVerify(
-  memexId: string,
-  docId: string,
-  ctx: RequestCtx = {},
-): Promise<void> {
-  const doc = await db.query.documents.findFirst({
-    where: and(eq(documents.id, docId), eq(documents.memexId, memexId)),
-  });
-  if (
-    !doc ||
-    doc.docType !== "spec" ||
-    doc.status !== "build"
-  )
-    return;
-
-  const [{ openCount }] = await db
-    .select({ openCount: sql<number>`count(*)::int` })
-    .from(tasks)
-    .where(and(eq(tasks.docId, docId), ne(tasks.status, "complete")));
-
-  if (Number(openCount) === 0) {
-    // spec-122 dec-3 — carry the actor/channel onto the auto-promotion's
-    // status_changed journal row (t-4).
-    //
-    // spec-391: the build→verify naked-decision gate (and any future
-    // advancement gate) now lives in updateDocStatus and can THROW. This is an
-    // AUTOMATIC side-effect of completing the last task — i.e. developer
-    // code-work — and spec-388 dec-2 is explicit that the gate blocks the
-    // spec ADVANCEMENT only, NEVER the developer's code-work. So a blocked
-    // auto-promote must not fail the task-completion: swallow the gate's
-    // ValidationError (best-effort, mirroring the maybeAutoResolveIssuesForTask
-    // sibling above). The task still completes; the Spec simply stays in `build`
-    // and the human gets the gate's guidance when they advance explicitly via
-    // update_doc({status:'verify'}).
-    await updateDocStatus(memexId, docId, "verify", { ctx }).catch((err) => {
-      console.warn(
-        `[tasks] auto-promote build→verify blocked for ${docId} (Spec stays in build):`,
-        err instanceof Error ? err.message : err,
-      );
-    });
-  }
 }
 
 export async function updateTask(


### PR DESCRIPTION
Removes the **last surviving code-work-driven phase auto-advance**: completing the last incomplete task on a `build` Spec silently promoted it to `verify` via `maybeAutoPromoteToVerify` in `services/tasks.ts`. No human acted — a live agent session tripped it and had to move the Spec back by hand.

This path predates and escaped the whole "phase is a deliberate placement, not inferred" arc (spec-189 → 295/327/342 → 464); neither spec-342 nor spec-464 touched `tasks.ts`. Its own comment even called the trigger "developer code-work" — exactly the category that arc ruled must not move a phase.

Full context, decisions, and ACs: **spec-485** (`mindset-prod/memex-building-itself/specs/spec-485`).

## Change (removal-only, mirrors spec-342)
- Delete `maybeAutoPromoteToVerify` + its call site in `updateTaskStatus`.
- Keep the `maybeAutoResolveIssuesForTask` sibling (spec-112 ac-22).
- Drop three now-orphaned imports (`updateDocStatus`, `ne`, `sql`).
- Refresh the stale block comment (cited the superseded doc-10 dec-4).

The deliberate signal is **unchanged**: the `task_completed` footer ("That was the last task… move the spec to verify") lives in a separate handler path and now becomes the single, consistent prompt — it previously *contradicted* the silent auto-move.

## Tests
- New no-advance regression guard (inverts the former auto-promote test): completing the last task on a `build` Spec leaves it in `build`.
- `vi.spyOn` test proving the issue-resolution sibling still fires on completion.
- Corrected stale auto-promote references in `tasks.integration` + `workflows.integration`.
- Full server suite green (**5683 passed, 0 failed**); typecheck clean; **9/9 ACs verified**.

No schema / migration / route / UI / manifest change. No new e2e journey (no user-facing flow change — the only difference is the *absence* of an unexpected kanban move).

🤖 Generated with [Claude Code](https://claude.com/claude-code)