### PR TITLE
spec-482: post-creation Spec landing — agent continuity + MCP handoff

### DIFF
--- a/packages/server/src/agent/system-prompt.spec-482.test.ts
+++ b/packages/server/src/agent/system-prompt.spec-482.test.ts
@@ -1,0 +1,219 @@
+// spec-482 (t-4 / t-5 / t-8) — the in-Spec agent's OPENING POSTURE overlay.
+//
+// buildSystemBlocks appends the composed opening posture (toOpeningPosture) to the
+// PRIMARY Spec agent's prompt, driven by the entry framing (landing recap vs
+// return-visit reorientation) and the tier the two per-user signals (mcpConnected,
+// phaseWatermark) select. Pure assertions on the assembled prompt text — no DB, no
+// LLM. The prose is single-sourced from @memex/shared (std-15).
+
+import { describe, it, expect } from "vitest";
+import { toOpeningPosture } from "@memex/shared";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { buildSystemBlocks, type OpeningPosture } from "./system-prompt.js";
+import type { PhaseWatermark } from "../services/phase-watermark.js";
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-482/acs/ac-${n}`;
+
+const CTX = "## Document Context\nSpec: Ship the widget. Open decisions: 2. Open tasks: 3.";
+
+// The primary Spec agent's opening posture rides positional arg 9 of buildSystemBlocks:
+// (documentContext, phase, readOnly, reviewer, driftMode, integrationState,
+//  scaffoldMode, scopedMode, openingPosture).
+function specPrompt(posture?: OpeningPosture): string {
+  const blocks = buildSystemBlocks(
+    CTX,
+    "specify",
+    false,
+    false,
+    false,
+    undefined,
+    false,
+    undefined,
+    posture,
+  );
+  return blocks[0]!.text;
+}
+
+function posture(
+  entry: "landing" | "return",
+  mcpConnected: boolean,
+  phaseWatermark: PhaseWatermark,
+): OpeningPosture {
+  return { entry, mcpConnected, phaseWatermark };
+}
+
+// Distinctive, stable phrases from each prose block (single-sourced in scaffold-data.ts).
+const WHY_FIRST = "Lead with WHY it matters, grounded in THIS specific Spec";
+const LANDING_RECAP = "SHALLOW, state-computed RECAP";
+const LANDING_SKIP = "If NOTHING is open, SKIP the recap entirely";
+const LANDING_SCOPE = "normal Spec-authoring scope";
+const RETURN_FIXED = "FIXED-SHAPE reorientation";
+const RETURN_NO_REPLAY = "Do NOT replay or reference any earlier conversation";
+const RETURN_NO_ELAPSED = "do NOT branch on how long it has been since the last visit";
+const WHATS_OPEN = "unresolved decisions"; // the shared "what's open" reading
+
+const TIER_MCP_ONE_LINE = "AT MOST ONE line";
+const TIER_MCP_NO_QUESTION = "ask NO clarifying question";
+const TIER_MCP_CONNECT_NOT_INSTALL = 'Always say "connect" — NEVER "install"';
+const TIER_BUILD = "Explain what BUILD means";
+const TIER_VERIFY = "Teach ONLY verify";
+const TIER_DONE = "Teach ONLY the step to done";
+const TIER_EXPERIENCED = "Emit NO workflow-teaching content";
+
+describe("spec-482 opening posture — presence / single-sourcing", () => {
+  it("the default primary agent (no posture) carries NONE of the opening-posture prose", () => {
+    const p = specPrompt(undefined);
+    expect(p).not.toContain(WHY_FIRST);
+    expect(p).not.toContain(LANDING_RECAP);
+    expect(p).not.toContain(RETURN_FIXED);
+    expect(p).not.toContain(TIER_BUILD);
+  });
+
+  it("appends the composed posture VERBATIM (single source, std-15) and keeps the Spec-agent base", () => {
+    const pst = posture("landing", true, "none");
+    const p = specPrompt(pst);
+    // Verbatim single-source: the whole composed block is present, not re-inlined.
+    expect(p).toContain(
+      toOpeningPosture({ entry: "landing", tier: "teach_build" }),
+    );
+    // The agent keeps its general Spec-agent posture — the skills-awareness block and
+    // phase guidance still lead; the posture is an overlay, not a replacement.
+    expect(p).toContain("## Skills");
+  });
+
+  it("only the PRIMARY Spec agent gets the posture — a scoped/drift agent never does", () => {
+    // driftMode=true → not the primary agent; even with a posture arg it is suppressed.
+    const blocks = buildSystemBlocks(
+      CTX,
+      "specify",
+      false,
+      false,
+      true, // driftMode
+      undefined,
+      false,
+      undefined,
+      posture("landing", false, "none"),
+    );
+    expect(blocks[0]!.text).not.toContain(WHY_FIRST);
+    expect(blocks[0]!.text).not.toContain(LANDING_RECAP);
+  });
+});
+
+describe("spec-482 t-4 — landing recap (ac-6 / ac-7 / ac-8)", () => {
+  it("landing entry → a shallow state-computed recap of what's open, with a skip clause", () => {
+    tagAc(AC(6));
+    tagAc(AC(7));
+    const p = specPrompt(posture("landing", true, "none"));
+    // ac-6: a shallow, state-computed recap of the open decisions/tasks — not a cold
+    // greeting, not a replay.
+    expect(p).toContain(LANDING_RECAP);
+    expect(p).toContain(WHATS_OPEN);
+    expect(p).toContain("not a replay of any earlier conversation");
+    // ac-7: skipped entirely when nothing is open.
+    expect(p).toContain(LANDING_SKIP);
+  });
+
+  it("landing recap preserves the normal Spec-agent authoring scope (ac-8)", () => {
+    tagAc(AC(8));
+    const p = specPrompt(posture("landing", true, "none"));
+    expect(p).toContain(LANDING_SCOPE);
+    // Still the Spec agent: the phase-composed base is intact (skills overlay present).
+    expect(p).toContain("## Skills");
+  });
+});
+
+describe("spec-482 t-5 — tiers gated by mcpConnected then phaseWatermark", () => {
+  it("ac-12: watermark 'specify_build' teaches VERIFY and does NOT re-teach specify→build", () => {
+    tagAc(AC(12));
+    const p = specPrompt(posture("landing", true, "specify_build"));
+    expect(p).toContain(TIER_VERIFY);
+    expect(p).toContain("confirming the built work actually satisfies");
+    // The exited phase is never re-taught.
+    expect(p).not.toContain(TIER_BUILD);
+  });
+
+  it("ac-12: watermark 'none' (connected) teaches BUILD", () => {
+    tagAc(AC(12));
+    const p = specPrompt(posture("landing", true, "none"));
+    expect(p).toContain(TIER_BUILD);
+    // Not yet teaching a later phase.
+    expect(p).not.toContain(TIER_VERIFY);
+    expect(p).not.toContain(TIER_DONE);
+  });
+
+  it("watermark 'build_verify' teaches only the final step to DONE, never earlier phases", () => {
+    const p = specPrompt(posture("landing", true, "build_verify"));
+    expect(p).toContain(TIER_DONE);
+    expect(p).not.toContain(TIER_BUILD);
+    expect(p).not.toContain(TIER_VERIFY);
+  });
+
+  it("ac-13: watermark 'verify_done' emits NO workflow-teaching content", () => {
+    tagAc(AC(13));
+    const p = specPrompt(posture("landing", true, "verify_done"));
+    expect(p).toContain(TIER_EXPERIENCED);
+    // No phase is taught — none of the teaching directives appear.
+    expect(p).not.toContain(TIER_BUILD);
+    expect(p).not.toContain(TIER_VERIFY);
+    expect(p).not.toContain(TIER_DONE);
+  });
+
+  it("ac-16: mcpConnected=false → ≤1-line recap, no clarifying question, and 'connect' not 'install'", () => {
+    tagAc(AC(16));
+    // mcpConnected=false wins REGARDLESS of the watermark ordinal.
+    const p = specPrompt(posture("landing", false, "verify_done"));
+    expect(p).toContain(TIER_MCP_ONE_LINE);
+    expect(p).toContain(TIER_MCP_NO_QUESTION);
+    expect(p).toContain(TIER_MCP_CONNECT_NOT_INSTALL);
+    // The connect tier pre-empts every teaching tier.
+    expect(p).not.toContain(TIER_BUILD);
+    expect(p).not.toContain(TIER_EXPERIENCED);
+  });
+
+  it("ac-19: why-before-how leads EVERY tier", () => {
+    tagAc(AC(19));
+    const watermarks: PhaseWatermark[] = [
+      "none",
+      "specify_build",
+      "build_verify",
+      "verify_done",
+    ];
+    // The connected tiers…
+    for (const wm of watermarks) {
+      expect(specPrompt(posture("landing", true, wm))).toContain(WHY_FIRST);
+      expect(specPrompt(posture("return", true, wm))).toContain(WHY_FIRST);
+    }
+    // …and the disconnected tier.
+    expect(specPrompt(posture("landing", false, "none"))).toContain(WHY_FIRST);
+  });
+});
+
+describe("spec-482 t-8 — return-visit reorientation (ac-17 / ac-18)", () => {
+  it("ac-17: return entry → a fixed-shape reorientation, no replay, no elapsed-time branching", () => {
+    tagAc(AC(17));
+    const p = specPrompt(posture("return", true, "none"));
+    expect(p).toContain(RETURN_FIXED);
+    expect(p).toContain(RETURN_NO_REPLAY);
+    expect(p).toContain(RETURN_NO_ELAPSED);
+  });
+
+  it("ac-18: return visit reuses the SAME signals — only the entry framing differs from landing", () => {
+    tagAc(AC(18));
+    // Same "what's open" reading as the landing recap.
+    const ret = specPrompt(posture("return", true, "specify_build"));
+    expect(ret).toContain(WHATS_OPEN);
+
+    // For identical signals, landing and return differ ONLY in the entry framing —
+    // the tier block (the next-action) is byte-for-byte the same.
+    const landingBlock = toOpeningPosture({ entry: "landing", tier: "teach_verify" });
+    const returnBlock = toOpeningPosture({ entry: "return", tier: "teach_verify" });
+    expect(landingBlock).toContain(LANDING_RECAP);
+    expect(returnBlock).toContain(RETURN_FIXED);
+    // Strip the framing lines: both must carry the identical tier text (TIER_VERIFY).
+    expect(landingBlock).toContain(TIER_VERIFY);
+    expect(returnBlock).toContain(TIER_VERIFY);
+    // Neither leaks the other's framing.
+    expect(returnBlock).not.toContain(LANDING_RECAP);
+    expect(landingBlock).not.toContain(RETURN_FIXED);
+  });
+});

--- a/packages/server/src/agent/system-prompt.ts
+++ b/packages/server/src/agent/system-prompt.ts
@@ -14,11 +14,15 @@ import {
   SKILLS_AGENT_MODE_GUIDANCE,
   toPromptBlocks,
   toPhaseGuidance,
+  toOpeningPosture,
+  type OpeningTier,
+  type OpeningEntry,
   type SpecPhase,
 } from "@memex/shared";
 import type { SystemBlock } from "./types.js";
 import type { IntegrationState } from "./integration-state.js";
 import type { VocabFacet } from "../services/facet-vocab.js";
+import type { PhaseWatermark } from "../services/phase-watermark.js";
 import { loadSkill } from "./skills.js";
 
 // ──────────────────────────────────────────────
@@ -182,6 +186,35 @@ const DOC_BOUND_REACT_BLOCK_IDS: ReadonlySet<string> = new Set([
   "create-from-doc",
 ]);
 
+// spec-482 (t-5) — the per-request opening-posture signals the ROUTE computes for
+// the primary Spec agent: the entry framing (the request's `creationLanding` flag —
+// t-4 landing recap vs t-8 return-visit reorientation) plus the two per-user tier
+// signals (mcpConnected, phaseWatermark — dec-5 / dec-6). buildSystemBlocks maps
+// these to one `OpeningTier` and appends the composed posture (toOpeningPosture).
+export interface OpeningPosture {
+  entry: OpeningEntry;
+  mcpConnected: boolean;
+  phaseWatermark: PhaseWatermark;
+}
+
+// spec-482 (t-5) — the signal→tier mapping (pure LOGIC; the tier PROSE lives in the
+// scaffold model, std-15). Gated by mcpConnected FIRST, then the phaseWatermark
+// ordinal. Each tier teaches at most ONE phase past the user's high-water mark, so a
+// phase already exited is never re-taught.
+function selectOpeningTier(mcpConnected: boolean, watermark: PhaseWatermark): OpeningTier {
+  if (!mcpConnected) return "mcp_disconnected";
+  switch (watermark) {
+    case "none":
+      return "teach_build";
+    case "specify_build":
+      return "teach_verify";
+    case "build_verify":
+      return "teach_done";
+    case "verify_done":
+      return "experienced";
+  }
+}
+
 export function buildSystemBlocks(
   documentContext: string,
   phase: SpecPhase,
@@ -196,6 +229,11 @@ export function buildSystemBlocks(
   // spec-300 t-15 (dec-23): 'skills' is the fifth scoped mode — the dedicated
   // skills authoring / curation agent on the Skills page.
   scopedMode?: "standards" | "issues" | "skills",
+  // spec-482 (t-4 / t-5 / t-8): the primary Spec agent's opening posture. The route
+  // supplies it ONLY for the doc-bound spec agent (no scoped/scaffold/drift mode);
+  // it is composed from the entry framing + the tier the two per-user signals select
+  // and appended after the skills block, so it is the freshest first-turn instruction.
+  openingPosture?: OpeningPosture,
 ): SystemBlock[] {
   const projectedPhase: SpecPhase = phase === "draft" ? "specify" : phase;
   // spec-360: scaffold mode leads with its OWN identity — the doc-bound base
@@ -262,6 +300,19 @@ export function buildSystemBlocks(
   const withSkills = isPrimaryAgent
     ? `${withScoped}\n\n${SKILLS_BLOCK}`
     : withScoped;
+  // spec-482 (t-4 / t-5 / t-8): the primary Spec agent's opening posture — the entry
+  // framing (landing recap vs return-visit reorientation) composed with the tier the
+  // two per-user signals select. Appended LAST so it is the freshest first-turn
+  // instruction over the phase-composed base. Only the primary Spec agent carries it
+  // (the route passes it only there); scoped / scaffold / drift agents never do. The
+  // prose is single-sourced from the scaffold model (std-15) via toOpeningPosture.
+  const withOpening =
+    isPrimaryAgent && openingPosture
+      ? `${withSkills}\n\n${toOpeningPosture({
+          entry: openingPosture.entry,
+          tier: selectOpeningTier(openingPosture.mcpConnected, openingPosture.phaseWatermark),
+        })}`
+      : withSkills;
   // spec-360 t-1 (dec-1/dec-6): the scaffold identity now LEADS the instruction
   // block (prepended into baseContent above) instead of trailing it — appending
   // it after the doc-bound "document assistant" role let that role dominate a
@@ -270,7 +321,7 @@ export function buildSystemBlocks(
   // factual grounding rides the cached context block (buildScaffoldContext).
   const instructions: SystemBlock = {
     type: "text",
-    text: readOnly ? `${withSkills}\n\n${READ_ONLY_BLOCK}` : withSkills,
+    text: readOnly ? `${withOpening}\n\n${READ_ONLY_BLOCK}` : withOpening,
   };
 
   const context: SystemBlock = {

--- a/packages/server/src/journeys/onboarding.ts
+++ b/packages/server/src/journeys/onboarding.ts
@@ -31,9 +31,13 @@
 
 export type JourneyMilestone =
   | "identityConfirmed" // captured: the user placed themselves on the role triangle (name + role)
-  | "mcpConnected" // derived: the user's agent connected over MCP (shown inside the create-spec card's Stage 1)
-  | "mcpToolCalled" // derived, NON-GATING: the user's first MCP tool call — drives the
-  //                  connect reward's auto-dismiss inside the create-spec card (no step gates on it)
+  | "mcpConnected" // derived: the user's agent completed the MCP handshake (mcp.connected).
+  //                  Kept for cohorting/greeting gates; the create-spec rail step no longer
+  //                  gates on it (spec-482 dec-5 — a handshake with no tool call isn't a
+  //                  meaningful connection).
+  | "mcpToolCalled" // derived: the user's first MCP tool call (observed MCP traffic). GATES
+  //                  the create-spec "Connect MCP" rail step (spec-482 dec-5/ac-15) and drives
+  //                  the connect reward's auto-dismiss.
   | "hasSpec" // derived: the user created a (non-demo) spec
   | "hasResolvedDecision" // derived: the user resolved a decision
   | "hasAc" // derived: the user added an acceptance criterion
@@ -67,11 +71,19 @@ export interface JourneyDef {
 // spec-421: the old two-stage create-spec card is split into two discrete steps.
 // create-spec completes on mcpConnected; create-first-spec completes on hasSpec.
 // Steps 3–6 are hidden from the rail (code kept for future reintroduction).
+//
+// spec-482 dec-5 (ac-15): the "Connect MCP" rail step is verified INDEPENDENTLY,
+// via observed MCP TRAFFIC — an `mcp.tool_called` usage_event ever recorded
+// (the `mcpToolCalled` milestone) — NOT the `mcp.connected` handshake. A handshake
+// with no tool call isn't a meaningful connection; the same observed-traffic
+// definition the mcp-connection signal (services/mcp-connection.ts, t-2) uses.
+// This is a stricter signal than the old mcpConnected gate and never keys off the
+// create-first-spec landing event (hasSpec), so the two steps stay independent.
 export const onboardingJourney: JourneyDef = {
   id: "onboarding",
   steps: [
     { id: "identity", completedBy: "identityConfirmed" },
-    { id: "create-spec", completedBy: "mcpConnected" },
+    { id: "create-spec", completedBy: "mcpToolCalled" },
     { id: "create-first-spec", completedBy: "hasSpec" },
     { id: "resolve-decision", completedBy: "hasResolvedDecision" },
     { id: "add-ac", completedBy: "hasAc" },

--- a/packages/server/src/routes/journey.api.test.ts
+++ b/packages/server/src/routes/journey.api.test.ts
@@ -97,6 +97,11 @@ async function confirmIdentity(userId: string) {
 async function connectMcp(userId: string) {
   await recordUsageEvent({ memexId: null, actorUserId: userId, name: "mcp.connected", source: "backend" });
 }
+// spec-482 dec-5: the create-spec "Connect MCP" step is gated on OBSERVED MCP TRAFFIC —
+// an mcp.tool_called usage_event — not the mcp.connected handshake.
+async function callMcpTool(userId: string) {
+  await recordUsageEvent({ memexId: null, actorUserId: userId, name: "mcp.tool_called", source: "backend" });
+}
 async function seedSpec(userId: string) {
   return createDocDraft(memexId, "Seed spec", "Purpose", "spec", undefined, undefined, userId, {
     actorUserId: userId,
@@ -191,13 +196,13 @@ describe("Home Canvas journey-state (ac-3 derived position)", () => {
 
 describe("Home Canvas journey-state (ac-5 self-advance through the v2 arc)", () => {
   it("advances one step at a time through the full arc", async () => {
-    // spec-421: arc is now identity → create-spec (mcpConnected) → create-first-spec (hasSpec)
-    // → resolve-decision → add-ac → specs-match-reality → agents-build (terminal).
+    // spec-482 dec-5: arc is identity → create-spec (mcpToolCalled) → create-first-spec
+    // (hasSpec) → resolve-decision → add-ac → specs-match-reality → agents-build (terminal).
     tagAc(AC336(5));
     tagAc(AC336(8));
     const AC421 = (n: number) =>
       `mindset-prod/memex-building-itself/specs/spec-421/acs/ac-${n}`;
-    tagAc(AC421(5)); // create-spec completes on mcpConnected
+    tagAc(AC421(5)); // create-spec completes on the MCP-connect milestone
     tagAc(AC421(10)); // create-first-spec completes on hasSpec
     const user = await newUser();
     expect((await state(user.id)).body.currentStepId).toBe("identity");
@@ -205,8 +210,12 @@ describe("Home Canvas journey-state (ac-5 self-advance through the v2 arc)", () 
     await confirmIdentity(user.id);
     expect((await state(user.id)).body.currentStepId).toBe("create-spec");
 
+    // spec-482 dec-5: the mcp.connected handshake ALONE no longer advances create-spec —
+    // it needs observed traffic (mcp.tool_called).
     await connectMcp(user.id);
-    // spec-421: create-spec now completes on mcpConnected → advances to create-first-spec.
+    expect((await state(user.id)).body.currentStepId).toBe("create-spec");
+    await callMcpTool(user.id);
+    // Observed MCP traffic completes create-spec → advances to create-first-spec.
     expect((await state(user.id)).body.currentStepId).toBe("create-first-spec");
 
     const doc = await seedSpec(user.id);
@@ -242,9 +251,9 @@ describe("Home Canvas journey-state (ac-5 self-advance through the v2 arc)", () 
     const me = await newUser();
     const colleague = await newUser();
     await confirmIdentity(me.id);
-    await connectMcp(me.id);
-    // spec-421: after mcpConnected, I'm now on create-first-spec (create-spec completed).
-    // Colleague's spec does NOT satisfy MY hasSpec → I stay on create-first-spec.
+    await callMcpTool(me.id);
+    // spec-482 dec-5: after observed MCP traffic, I'm now on create-first-spec (create-spec
+    // completed). Colleague's spec does NOT satisfy MY hasSpec → I stay on create-first-spec.
     await seedSpec(colleague.id); // the colleague's spec, not mine
     expect((await state(me.id)).body.currentStepId).toBe("create-first-spec");
   });

--- a/packages/server/src/routes/llm.test.ts
+++ b/packages/server/src/routes/llm.test.ts
@@ -290,7 +290,7 @@ describe("POST /llm/chat", () => {
     // { context: "Mock document context", phase: "specify" }.
     // spec-143 t-4 (dec-6) adds a 5th `driftMode` arg — false here (not drift).
     // spec-180 adds a 6th `integrationState` arg — the resolved integration status.
-    expect(buildSystemBlocks).toHaveBeenCalledWith("Mock document context", "specify", false, false, false, mockIntegrationState, false, undefined);
+    expect(buildSystemBlocks).toHaveBeenCalledWith("Mock document context", "specify", false, false, false, mockIntegrationState, false, undefined, expect.objectContaining({ entry: "return" }));
   });
 
   it("uses fallback context when no docId", async () => {
@@ -318,6 +318,8 @@ describe("POST /llm/chat", () => {
       false,
       // spec-389 t-5: the 8th scopedMode arg — undefined (not standards/issues).
       undefined,
+      // spec-482: 9th openingPosture arg — undefined (no docId → no opening posture).
+      undefined,
     );
   });
 
@@ -338,7 +340,7 @@ describe("POST /llm/chat", () => {
     await res.text();
 
     expect(canWriteMemex).toHaveBeenCalledWith("test-user-id", "test-account-id");
-    expect(buildSystemBlocks).toHaveBeenCalledWith("Mock document context", "specify", true, false, false, mockIntegrationState, false, undefined);
+    expect(buildSystemBlocks).toHaveBeenCalledWith("Mock document context", "specify", true, false, false, mockIntegrationState, false, undefined, expect.objectContaining({ entry: "return" }));
   });
 
   it("passes readOnly=false to buildSystemBlocks for a writing member (ac-13)", async () => {
@@ -353,7 +355,7 @@ describe("POST /llm/chat", () => {
     });
     await res.text();
 
-    expect(buildSystemBlocks).toHaveBeenCalledWith("Mock document context", "specify", false, false, false, mockIntegrationState, false, undefined);
+    expect(buildSystemBlocks).toHaveBeenCalledWith("Mock document context", "specify", false, false, false, mockIntegrationState, false, undefined, expect.objectContaining({ entry: "return" }));
   });
 
   // spec-143 t-4 (dec-6): drift mode — the in-UI drift agent runs against the
@@ -390,6 +392,8 @@ describe("POST /llm/chat", () => {
       // spec-360 t-1: the 7th scaffoldMode arg — false here (drift, not scaffold).
       false,
       // spec-389 t-5: the 8th scopedMode arg — undefined (drift, not standards/issues).
+      undefined,
+      // spec-482: 9th openingPosture arg — undefined (drift mode → no opening posture).
       undefined,
     );
     expect(getToolDefinitions).toHaveBeenCalledWith({ reviewer: false, mode: "drift" });
@@ -732,7 +736,7 @@ describe("spec-126 review overlay", () => {
     // ac-1: the overlay threads reviewer into the server-built prompt + tool list.
     // spec-143 t-4 (dec-6): the 5th driftMode arg is false here; getToolDefinitions
     // now also receives `mode` (undefined when not in drift mode).
-    expect(buildSystemBlocks).toHaveBeenCalledWith("Mock document context", "specify", false, true, false, mockIntegrationState, false, undefined);
+    expect(buildSystemBlocks).toHaveBeenCalledWith("Mock document context", "specify", false, true, false, mockIntegrationState, false, undefined, expect.objectContaining({ entry: "return" }));
     expect(getToolDefinitions).toHaveBeenCalledWith({ reviewer: true, mode: undefined });
   });
 

--- a/packages/server/src/routes/llm.ts
+++ b/packages/server/src/routes/llm.ts
@@ -18,6 +18,11 @@ import { canWriteMemex, READ_ONLY_PUBLIC_MESSAGE } from "../mcp/auth.js";
 import { resolveRole } from "../services/doc-members.js";
 import { vocabForMemex } from "../services/facet-vocab.js";
 import { resolveIntegrationState } from "../agent/integration-state.js";
+// spec-482 (t-4 / t-5 / t-8): the per-user opening-posture signals — both DERIVED,
+// monotonic facts (no client input, no sticky flag). hasEverUsedMcp gates the
+// connect-handoff tier; getPhaseHighWaterMark gates which single phase the agent teaches.
+import { hasEverUsedMcp } from "../services/mcp-connection.js";
+import { getPhaseHighWaterMark } from "../services/phase-watermark.js";
 
 // spec-473: the creation + in-Spec agent runs on Sonnet 5 (was Sonnet 4.5). For
 // agentic/tool-calling work it's both faster and more capable than 4.5, so the
@@ -74,6 +79,13 @@ const chatSchema = z.object({
    *  agent that lives on the Skills page — memex-scoped, grounded in the skill
    *  catalogue, tool set pinned to SKILLS_SERVER_TOOLS. The Skills surface sends it. */
   mode: z.enum(["drift", "scaffold", "standards", "issues", "skills"]).optional(),
+  /** spec-482 (t-4 / t-8): the entry framing for the in-Spec agent's opening turn.
+   *  `true` when the user has just landed here after creating the Spec — the agent
+   *  opens with a shallow, state-computed recap of what's still open (t-4). Absent /
+   *  `false` is a normal return visit — a fixed-shape reorientation from the same
+   *  signals (t-8). The tier signals (mcpConnected, phaseWatermark) are computed
+   *  SERVER-side from the authenticated user; the client sends only this flag. */
+  creationLanding: z.boolean().optional(),
 });
 
 llmRouter.post("/chat", async (c) => {
@@ -84,7 +96,7 @@ llmRouter.post("/chat", async (c) => {
     return c.json({ error: "Invalid request", details: parsed.error.issues }, 400);
   }
 
-  const { docId, messages, mode } = parsed.data;
+  const { docId, messages, mode, creationLanding } = parsed.data;
   const driftMode = mode === "drift";
   const scaffoldMode = mode === "scaffold";
   const standardsMode = mode === "standards";
@@ -147,7 +159,13 @@ llmRouter.post("/chat", async (c) => {
   // spec-180: all three pre-LLM lookups (write-access, role, integration state)
   // are independent — run them in parallel to eliminate sequential DB round trips.
   const currentUserId = c.get("currentUserId");
-  const [readOnly, reviewer, integrationState] = await Promise.all([
+  // spec-482 (t-4 / t-5 / t-8): the opening posture is ONLY for the primary Spec
+  // agent chatting on a bound doc — never a scoped/scaffold/drift mode, and never the
+  // doc-less creation fallback. When it applies we derive the two per-user tier
+  // signals server-side (the client sends only `creationLanding`); otherwise we skip
+  // the queries entirely. Both signals fail-open to their least-experienced default.
+  const wantOpeningPosture = !mode && !!docId && !!currentUserId;
+  const [readOnly, reviewer, integrationState, mcpConnected, phaseWatermark] = await Promise.all([
     // spec-111 t-9 (dec-2): a signed-in NON-member chatting on a public Memex
     // gets the read-only agent posture — it can answer/search but must explain it
     // cannot mutate. Members → false (default). Server-side enforcement still lives
@@ -171,7 +189,28 @@ llmRouter.post("/chat", async (c) => {
       discordAmbiguous: false,
       discordChannelName: null,
     })),
+    // spec-482 t-5 (dec-5): the MCP-connection tier gate. Fail-open to `false` (the
+    // loudest connect-handoff tier) so a lookup hiccup never suppresses the handoff.
+    wantOpeningPosture
+      ? hasEverUsedMcp(currentUserId as string).catch(() => false)
+      : Promise.resolve(false),
+    // spec-482 t-5 (dec-6): the phase high-water mark. Fail-open to `'none'` (teach
+    // build) — the safe least-experienced default if the derived query errors.
+    wantOpeningPosture
+      ? getPhaseHighWaterMark(currentUserId as string).catch(() => "none" as const)
+      : Promise.resolve("none" as const),
   ]);
+
+  // spec-482 (t-4 / t-8): assemble the opening posture only where it applies. The
+  // entry framing comes from the client's `creationLanding` flag (landing recap vs
+  // return-visit reorientation); the tier signals were derived above.
+  const openingPosture = wantOpeningPosture
+    ? {
+        entry: (creationLanding ? "landing" : "return") as "landing" | "return",
+        mcpConnected,
+        phaseWatermark,
+      }
+    : undefined;
 
   const systemBlocks = buildSystemBlocks(
     documentContext.context,
@@ -188,6 +227,9 @@ llmRouter.post("/chat", async (c) => {
       : skillsMode
       ? "skills"
       : undefined,
+    // spec-482 (t-4 / t-5 / t-8): the primary Spec agent's opening posture (undefined
+    // for scoped/scaffold/drift modes and the doc-less creation fallback).
+    openingPosture,
   );
   // dec-3 definition filter: a reviewer's model never sees the blocked mutations.
   // spec-143 t-4 (dec-6): in drift mode the model sees only the focused drift

--- a/packages/server/src/services/journey-state.spec-482.test.ts
+++ b/packages/server/src/services/journey-state.spec-482.test.ts
@@ -1,0 +1,104 @@
+// spec-482 t-11 — onboarding rail milestone semantics (dec-1, dec-5).
+//
+// Two independent completion signals on the rail:
+//   • ac-14 — "Create your first spec" (step `create-first-spec`) completes the moment
+//     the user lands on their newly created Spec: the `hasSpec` milestone ALONE, with no
+//     MCP-paste / MCP-traffic evidence required.
+//   • ac-15 — "Connect MCP" (step `create-spec`) is verified INDEPENDENTLY via observed
+//     MCP TRAFFIC — the `mcpToolCalled` milestone (an `mcp.tool_called` usage_event), per
+//     dec-5 — NOT by the landing (`hasSpec`) event and NOT by the `mcp.connected` handshake
+//     (`mcpConnected`).
+//
+// Proven against the REAL onboardingJourney step config (not a fixture), so the test binds
+// to the milestone that actually gates each rail step. Mirrors journey-state.spec-337.test.ts.
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { stepStatuses, type JourneyMilestones } from "./journey-state.js";
+import { onboardingJourney } from "../journeys/onboarding.js";
+
+const AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-482/acs/ac-${n}`;
+const here = dirname(fileURLToPath(import.meta.url));
+
+const ALL_FALSE: JourneyMilestones = {
+  identityConfirmed: false,
+  mcpConnected: false,
+  mcpToolCalled: false,
+  hasSpec: false,
+  hasResolvedDecision: false,
+  hasAc: false,
+  acVerified: false,
+  planGrounded: false,
+};
+
+const attained = (m: JourneyMilestones, stepId: string): boolean =>
+  stepStatuses(m, onboardingJourney).find((s) => s.id === stepId)!.attained;
+
+describe("spec-482 t-11 — rail milestone semantics", () => {
+  describe("ac-14 — 'Create your first spec' completes on landing (hasSpec alone)", () => {
+    it("ticks the moment a spec exists, with NO MCP evidence of any kind", () => {
+      tagAc(AC(14));
+      // create-first-spec is gated by hasSpec — nothing else.
+      const step = onboardingJourney.steps.find((s) => s.id === "create-first-spec")!;
+      expect(step.completedBy).toBe("hasSpec");
+
+      // Landed on the new Spec (hasSpec=true) with zero MCP signals → step attained.
+      const landed: JourneyMilestones = { ...ALL_FALSE, hasSpec: true };
+      expect(attained(landed, "create-first-spec")).toBe(true);
+    });
+
+    it("does NOT wait for any MCP-paste / MCP-traffic evidence", () => {
+      tagAc(AC(14));
+      // Both MCP milestones true but no spec yet → the step is NOT attained: MCP evidence
+      // is neither necessary nor sufficient for this step.
+      const mcpButNoSpec: JourneyMilestones = {
+        ...ALL_FALSE,
+        mcpConnected: true,
+        mcpToolCalled: true,
+        hasSpec: false,
+      };
+      expect(attained(mcpButNoSpec, "create-first-spec")).toBe(false);
+    });
+  });
+
+  describe("ac-15 — 'Connect MCP' verified independently via observed MCP traffic (dec-5)", () => {
+    it("is gated by mcpToolCalled (observed traffic), not the mcp.connected handshake", () => {
+      tagAc(AC(15));
+      const step = onboardingJourney.steps.find((s) => s.id === "create-spec")!;
+      expect(step.completedBy).toBe("mcpToolCalled");
+
+      // Observed MCP traffic (mcp.tool_called) completes the step.
+      const traffic: JourneyMilestones = { ...ALL_FALSE, mcpToolCalled: true };
+      expect(attained(traffic, "create-spec")).toBe(true);
+
+      // The handshake ALONE (mcp.connected, no tool call) does NOT complete it — dec-5's
+      // observed-traffic definition, not the handshake.
+      const handshakeOnly: JourneyMilestones = { ...ALL_FALSE, mcpConnected: true };
+      expect(attained(handshakeOnly, "create-spec")).toBe(false);
+    });
+
+    it("does NOT complete on the landing (hasSpec) event — the two steps are independent", () => {
+      tagAc(AC(15));
+      // Landing on a created Spec must not tick the Connect-MCP step.
+      const landedNoTraffic: JourneyMilestones = { ...ALL_FALSE, hasSpec: true };
+      expect(attained(landedNoTraffic, "create-spec")).toBe(false);
+    });
+
+    it("the create-spec rail step keys off mcpToolCalled in source (guards the UI alignment)", () => {
+      tagAc(AC(15));
+      // Journey def: the observed-traffic milestone gates the step.
+      const journeySrc = readFileSync(join(here, "..", "journeys", "onboarding.ts"), "utf8");
+      expect(journeySrc).toMatch(/id:\s*"create-spec",\s*completedBy:\s*"mcpToolCalled"/);
+
+      // UI component reads the same observed-traffic milestone (not mcpConnected).
+      const uiSrc = readFileSync(
+        join(here, "..", "..", "..", "ui", "src", "components", "home", "CreateSpecStep.tsx"),
+        "utf8",
+      );
+      expect(uiSrc).toMatch(/milestones\?\.mcpToolCalled/);
+    });
+  });
+});

--- a/packages/server/src/services/mcp-connection.test.ts
+++ b/packages/server/src/services/mcp-connection.test.ts
@@ -1,0 +1,140 @@
+// spec-482 t-2 — the MCP-connection signal against the real DB. Mirrors the
+// activation-cohort integration test's setup (unique users, seed usage_events,
+// clean up in afterEach). The signal is a HISTORICAL, MONOTONIC fact derived
+// from `mcp.tool_called` usage_events — never a self-reported flag:
+//   ac-9  — false with no events; true after an mcp.tool_called event is seeded.
+//   ac-10 — once true, stays true (monotonic; never reverts).
+// Plus: the org variant is scoped correctly — a different org's traffic does NOT
+// flip it true (usage_events is RLS-excluded, so the query filters explicitly on
+// the org's member user IDs).
+import { afterEach, describe, expect, it } from "vitest";
+import { eq, inArray } from "drizzle-orm";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { db } from "../db/connection.js";
+import { namespaces, orgMemberships, orgs, usageEvents, users } from "../db/schema.js";
+import { hasEverUsedMcp, orgHasEverUsedMcp } from "./mcp-connection.js";
+
+const AC9 = "mindset-prod/memex-building-itself/specs/spec-482/acs/ac-9";
+const AC10 = "mindset-prod/memex-building-itself/specs/spec-482/acs/ac-10";
+
+const rand = () => Math.random().toString(36).slice(2, 8);
+let slugSeq = 0;
+const uniqueSlug = (p: string) => `${p}-${Date.now().toString(36)}-${(slugSeq += 1)}-${rand()}`.toLowerCase().slice(0, 39);
+
+const createdUsers: string[] = [];
+const createdOrgs: string[] = [];
+const createdNamespaces: string[] = [];
+
+async function seedUser(prefix: string): Promise<string> {
+  const [u] = await db
+    .insert(users)
+    .values({ email: `spec482-t2-${prefix}-${rand()}@example.test` })
+    .returning({ id: users.id });
+  createdUsers.push(u!.id);
+  return u!.id;
+}
+
+async function seedOrg(prefix: string, memberIds: string[]): Promise<string> {
+  const slug = uniqueSlug(prefix);
+  const [ns] = await db.insert(namespaces).values({ slug, kind: "org" }).returning();
+  createdNamespaces.push(ns!.id);
+  const [org] = await db
+    .insert(orgs)
+    .values({ namespaceId: ns!.id, name: `Test ${prefix}` })
+    .returning({ id: orgs.id });
+  createdOrgs.push(org!.id);
+  await db.update(namespaces).set({ ownerOrgId: org!.id }).where(eq(namespaces.id, ns!.id));
+  if (memberIds.length) {
+    await db
+      .insert(orgMemberships)
+      .values(memberIds.map((userId) => ({ userId, orgId: org!.id, role: "member" })))
+      .onConflictDoNothing();
+  }
+  return org!.id;
+}
+
+async function seedToolCalled(userId: string): Promise<void> {
+  await db
+    .insert(usageEvents)
+    .values({ actorUserId: userId, name: "mcp.tool_called", source: "backend", env: "test" });
+}
+
+afterEach(async () => {
+  if (createdUsers.length) {
+    await db.delete(usageEvents).where(inArray(usageEvents.actorUserId, createdUsers)).catch(() => {});
+  }
+  if (createdOrgs.length) {
+    await db.delete(orgMemberships).where(inArray(orgMemberships.orgId, createdOrgs)).catch(() => {});
+    await db.delete(orgs).where(inArray(orgs.id, createdOrgs)).catch(() => {});
+  }
+  if (createdNamespaces.length) {
+    await db.delete(namespaces).where(inArray(namespaces.id, createdNamespaces)).catch(() => {});
+  }
+  if (createdUsers.length) {
+    await db.delete(users).where(inArray(users.id, createdUsers)).catch(() => {});
+  }
+  createdUsers.length = 0;
+  createdOrgs.length = 0;
+  createdNamespaces.length = 0;
+});
+
+describe("mcp-connection signal (spec-482 t-2)", () => {
+  it("hasEverUsedMcp is false with no events, true after an mcp.tool_called (ac-9)", async () => {
+    tagAc(AC9);
+    const userId = await seedUser("user");
+
+    expect(await hasEverUsedMcp(userId)).toBe(false);
+
+    await seedToolCalled(userId);
+    expect(await hasEverUsedMcp(userId)).toBe(true);
+  });
+
+  it("other usage events (e.g. mcp.connected) do NOT flip the signal — only mcp.tool_called counts (ac-9)", async () => {
+    tagAc(AC9);
+    const userId = await seedUser("connected-only");
+    await db
+      .insert(usageEvents)
+      .values({ actorUserId: userId, name: "mcp.connected", source: "backend", env: "test" });
+
+    expect(await hasEverUsedMcp(userId)).toBe(false);
+  });
+
+  it("once true, stays true — monotonic, never reverts (ac-10)", async () => {
+    tagAc(AC10);
+    const userId = await seedUser("monotonic");
+
+    await seedToolCalled(userId);
+    expect(await hasEverUsedMcp(userId)).toBe(true);
+
+    // More tool calls only reinforce it; there is no path that clears the signal.
+    await seedToolCalled(userId);
+    await seedToolCalled(userId);
+    expect(await hasEverUsedMcp(userId)).toBe(true);
+  });
+
+  it("org variant: true iff a member has produced MCP traffic (ac-9)", async () => {
+    tagAc(AC9);
+    const member = await seedUser("org-member");
+    const orgId = await seedOrg("org", [member]);
+
+    expect(await orgHasEverUsedMcp(orgId)).toBe(false);
+
+    await seedToolCalled(member);
+    expect(await orgHasEverUsedMcp(orgId)).toBe(true);
+  });
+
+  it("org variant is scoped: a DIFFERENT org's traffic does NOT flip it true (ac-9)", async () => {
+    tagAc(AC9);
+    const memberA = await seedUser("orgA-member");
+    const memberB = await seedUser("orgB-member");
+    const orgA = await seedOrg("orgA", [memberA]);
+    const orgB = await seedOrg("orgB", [memberB]);
+
+    // Only org B's member produces traffic.
+    await seedToolCalled(memberB);
+
+    expect(await orgHasEverUsedMcp(orgB)).toBe(true);
+    // org A must stay false — no cross-tenant leak from B's usage_events.
+    expect(await orgHasEverUsedMcp(orgA)).toBe(false);
+  });
+});

--- a/packages/server/src/services/mcp-connection.ts
+++ b/packages/server/src/services/mcp-connection.ts
@@ -1,0 +1,60 @@
+// spec-482 t-2 — the MCP-connection SIGNAL: "has this user (or their org) EVER
+// produced observed MCP traffic?"
+//
+// This is a HISTORICAL, MONOTONIC fact derived from real telemetry, NOT a
+// self-reported flag. The truth is the presence of an `mcp.tool_called`
+// usage_event — one is written per MCP invocation (recordMcpToolCalled in
+// services/funnel-events.ts). Because we only ever COUNT rows that already
+// exist and never store or clear a sticky flag, the answer can only ever go
+// false→true and never revert: monotonic by construction.
+//
+// usage_events is RLS-EXCLUDED by design (schema.ts) — there is no memex_id
+// scoping applied automatically. The user-level query is naturally user-scoped
+// (it filters on actor_user_id). The ORG-level query MUST filter explicitly by
+// the org's member user IDs, or it would leak cross-tenant traffic. We never
+// count without an explicit actor_user_id predicate.
+
+import { and, eq, inArray, sql } from "drizzle-orm";
+import { db, type Db } from "../db/connection.js";
+import { orgMemberships, usageEvents } from "../db/schema.js";
+
+const MCP_TOOL_CALLED = "mcp.tool_called";
+
+/**
+ * True iff ≥1 `mcp.tool_called` usage_event exists for this user — i.e. the user
+ * has EVER produced observed MCP traffic. Monotonic: no sticky flag, so once a
+ * tool call is recorded this can never revert to false.
+ */
+export async function hasEverUsedMcp(userId: string, conn: Db = db): Promise<boolean> {
+  const [row] = await conn
+    .select({ n: sql<number>`count(*)::int` })
+    .from(usageEvents)
+    .where(and(eq(usageEvents.actorUserId, userId), eq(usageEvents.name, MCP_TOOL_CALLED)));
+  return (row?.n ?? 0) > 0;
+}
+
+/**
+ * True iff ANY member of the org has ≥1 `mcp.tool_called` usage_event — i.e.
+ * someone in the org has EVER produced observed MCP traffic. Same monotonic
+ * guarantee as the user-level signal.
+ *
+ * usage_events is RLS-excluded, so the query is scoped EXPLICITLY to the org's
+ * member user IDs (via org_memberships); a different org's traffic can never
+ * flip this true. Disabled memberships are retained for attribution but never
+ * grant access (std-6), so only ACTIVE members count toward the org signal.
+ */
+export async function orgHasEverUsedMcp(orgId: string, conn: Db = db): Promise<boolean> {
+  const members = await conn
+    .select({ userId: orgMemberships.userId })
+    .from(orgMemberships)
+    .where(and(eq(orgMemberships.orgId, orgId), eq(orgMemberships.status, "active")));
+
+  const memberIds = members.map((m) => m.userId);
+  if (memberIds.length === 0) return false;
+
+  const [row] = await conn
+    .select({ n: sql<number>`count(*)::int` })
+    .from(usageEvents)
+    .where(and(inArray(usageEvents.actorUserId, memberIds), eq(usageEvents.name, MCP_TOOL_CALLED)));
+  return (row?.n ?? 0) > 0;
+}

--- a/packages/server/src/services/phase-watermark.test.ts
+++ b/packages/server/src/services/phase-watermark.test.ts
@@ -1,0 +1,132 @@
+// spec-482 t-3 (ac-11) — the per-user, MCP-driven, monotonic phase high-water
+// mark. A DERIVED read over activity_log status_changed rows (no dedicated table).
+//
+//   ac-11  getPhaseHighWaterMark(userId) returns the furthest phase transition a
+//          user has EVER personally completed VIA MCP (channel='mcp'), as one
+//          monotonic ordinal per user. Web-UI (rest_ui) moves never advance it;
+//          the mark never regresses.
+//
+// TAGGED → reports to the PROD memex. Run with MEMEX_EMIT_KEY set.
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { eq, inArray } from "drizzle-orm";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { db } from "../db/connection.js";
+import {
+  users,
+  namespaces,
+  orgs,
+  orgMemberships,
+  memexes,
+  documents,
+  activityLog,
+} from "../db/schema.js";
+import { createDocDraft } from "./documents.js";
+import { getPhaseHighWaterMark } from "./phase-watermark.js";
+
+const AC = "mindset-prod/memex-building-itself/specs/spec-482/acs";
+
+const created = { users: [] as string[], memexes: [] as string[], docs: [] as string[] };
+let userId: string; // the subject under test
+let otherUserId: string; // a second user, to prove per-user isolation
+let memexId: string;
+let docId: string;
+
+// Seed one status_changed activity_log row directly — the precise control the
+// derived query needs over {actorUserId, channel, payload.to}.
+async function seedTransition(
+  actorUserId: string,
+  channel: "mcp" | "rest_ui",
+  to: string,
+  from: string,
+): Promise<void> {
+  await db.insert(activityLog).values({
+    memexId,
+    briefId: docId,
+    actorUserId,
+    actorName: "Barrie",
+    actorKind: channel === "mcp" ? "mcp_agent" : "human",
+    channel,
+    entity: "document",
+    action: "status_changed",
+    narrative: `${from} → ${to}`,
+    payload: { from, to },
+  } as typeof activityLog.$inferInsert);
+}
+
+beforeAll(async () => {
+  const tag = `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+  const [u] = await db
+    .insert(users)
+    .values({ email: `pw-${tag}@memex.ai`, name: "Barrie" } as typeof users.$inferInsert)
+    .returning();
+  userId = u.id;
+  created.users.push(u.id);
+  const [u2] = await db
+    .insert(users)
+    .values({ email: `pw-other-${tag}@memex.ai`, name: "Other" } as typeof users.$inferInsert)
+    .returning();
+  otherUserId = u2.id;
+  created.users.push(u2.id);
+
+  const [ns] = await db.insert(namespaces).values({ slug: `pw-${tag}`, kind: "org" }).returning();
+  const [org] = await db.insert(orgs).values({ namespaceId: ns.id, name: `T ${tag}` }).returning();
+  await db.update(namespaces).set({ ownerOrgId: org.id }).where(eq(namespaces.id, ns.id));
+  const [m] = await db.insert(memexes).values({ namespaceId: ns.id, slug: "main", name: `T ${tag}` }).returning();
+  memexId = m.id;
+  created.memexes.push(m.id);
+  await db.insert(orgMemberships).values({ userId: u.id, orgId: org.id, role: "administrator" });
+
+  const doc = await createDocDraft(memexId, "PW", "x", "spec");
+  docId = doc.id;
+  created.docs.push(doc.id);
+});
+
+afterAll(async () => {
+  if (created.docs.length) {
+    await db.delete(activityLog).where(inArray(activityLog.briefId, created.docs)).catch(() => {});
+    await db.delete(documents).where(inArray(documents.id, created.docs)).catch(() => {});
+  }
+  if (created.memexes.length) await db.delete(memexes).where(inArray(memexes.id, created.memexes)).catch(() => {});
+  if (created.users.length) await db.delete(users).where(inArray(users.id, created.users)).catch(() => {});
+});
+
+describe("phase high-water mark: per-user, MCP-driven, monotonic [spec-482 t-3]", () => {
+  it("ac-11: 'none' when the user has no MCP-driven transitions", async () => {
+    tagAc(`${AC}/ac-11`);
+    expect(await getPhaseHighWaterMark(userId)).toBe("none");
+  });
+
+  it("ac-11: advances specify_build → build_verify → verify_done as MCP rows land", async () => {
+    tagAc(`${AC}/ac-11`);
+
+    await seedTransition(userId, "mcp", "build", "specify");
+    expect(await getPhaseHighWaterMark(userId)).toBe("specify_build");
+
+    await seedTransition(userId, "mcp", "verify", "build");
+    expect(await getPhaseHighWaterMark(userId)).toBe("build_verify");
+
+    await seedTransition(userId, "mcp", "done", "verify");
+    expect(await getPhaseHighWaterMark(userId)).toBe("verify_done");
+  });
+
+  it("ac-11: a web-UI (rest_ui) transition does NOT advance the mark", async () => {
+    tagAc(`${AC}/ac-11`);
+    // otherUser has ONLY a rest_ui build_verify move — the mark stays 'none'.
+    await seedTransition(otherUserId, "rest_ui", "verify", "build");
+    expect(await getPhaseHighWaterMark(otherUserId)).toBe("none");
+
+    // And an MCP build for the same user advances only to specify_build — the
+    // higher-ranked rest_ui move is ignored.
+    await seedTransition(otherUserId, "mcp", "build", "specify");
+    expect(await getPhaseHighWaterMark(otherUserId)).toBe("specify_build");
+  });
+
+  it("ac-11: never regresses — a later, lower-phase MCP row leaves the mark at its max", async () => {
+    tagAc(`${AC}/ac-11`);
+    // userId already sits at verify_done. A later bounce back to build must NOT
+    // pull the monotonic mark down.
+    await seedTransition(userId, "mcp", "build", "verify");
+    expect(await getPhaseHighWaterMark(userId)).toBe("verify_done");
+  });
+});

--- a/packages/server/src/services/phase-watermark.ts
+++ b/packages/server/src/services/phase-watermark.ts
@@ -1,0 +1,61 @@
+// spec-482 t-3 (ac-11) — the phase high-water mark: the furthest workflow phase
+// transition a user has EVER personally completed VIA MCP, as one monotonic
+// ordinal per user. A DERIVED query over activity_log status_changed rows scoped
+// to channel='mcp' — NO dedicated table (the same journal-is-the-source posture
+// as phase-history.ts, spec-122 ac-11). Transitions driven through the web UI
+// (channel='rest_ui') never advance the mark; it only ever moves forward.
+
+import { PHASE_ORDER } from "@memex/shared";
+import { and, eq } from "drizzle-orm";
+import { db, type Db } from "../db/connection.js";
+import { activityLog } from "../db/schema.js";
+
+/** One monotonic ordinal per user: the furthest MCP-driven phase transition ever completed. */
+export type PhaseWatermark = "none" | "specify_build" | "build_verify" | "verify_done";
+
+// The three forward workflow transitions, keyed by the phase ENTERED (`payload.to`):
+// specify→build lands on `build`, build→verify on `verify`, verify→done on `done`.
+// A row entering `draft`/`specify` carries no forward transition and never advances the mark.
+const TRANSITION_BY_TO: Record<string, Exclude<PhaseWatermark, "none">> = {
+  build: "specify_build",
+  verify: "build_verify",
+  done: "verify_done",
+};
+
+// spec-355 dry-2 / phase-history.ts — PHASE_ORDER from @memex/shared is the single
+// source of ordering. A transition ranks by the phase it ENTERS, so a monotonic max
+// over ranks can never regress even if a later row records an earlier phase.
+const rankOf = (phase: string): number => PHASE_ORDER.indexOf(phase as (typeof PHASE_ORDER)[number]);
+
+/**
+ * The furthest workflow phase transition this user has EVER personally completed
+ * VIA MCP. Only `channel='mcp'` status_changed rows attributed to `userId` count;
+ * web-UI (`rest_ui`) moves are ignored. Monotonic: returns the max-rank transition
+ * ever seen, so out-of-order or backward rows cannot pull the mark down.
+ */
+export async function getPhaseHighWaterMark(userId: string, conn: Db = db): Promise<PhaseWatermark> {
+  const rows = await conn
+    .select({ payload: activityLog.payload })
+    .from(activityLog)
+    .where(
+      and(
+        eq(activityLog.action, "status_changed"),
+        eq(activityLog.channel, "mcp"),
+        eq(activityLog.actorUserId, userId),
+      ),
+    );
+
+  let best: PhaseWatermark = "none";
+  let bestRank = -1;
+  for (const r of rows) {
+    const to = ((r.payload ?? {}) as { to?: string }).to ?? "";
+    const transition = TRANSITION_BY_TO[to];
+    if (!transition) continue;
+    const rank = rankOf(to);
+    if (rank > bestRank) {
+      bestRank = rank;
+      best = transition;
+    }
+  }
+  return best;
+}

--- a/packages/shared/EVENT-STANDARD.md
+++ b/packages/shared/EVENT-STANDARD.md
@@ -41,6 +41,7 @@ versa.
 - `auth.login_started` — A sign-in attempt was initiated. props.method is the auth method enum (google | password | magic_link). Pre-auth → trackAnonymous().
 - `spec.card_opened` — A spec card on the board was opened. props.specSeq (the spec's handle ordinal — the "spec#"), props.phase, props.assigned (bool), props.assignedUserId (opaque user UUID — never a name/email).
 - `spec.tab_viewed` — A content sub-tab in the spec detail view was selected (which parts people read). props.tab (narrative | comments | decisions | work | qa-report), props.phase (the phase view it was selected under).
+- `spec.landing_shown` — The post-creation Spec landing screen was shown — the user arrived on a newly-created Spec via the creation flow's land-on-your-Spec hop (spec-482). Fires at most once per Spec landing. props.phase (draft | specify | build | verify | done), props.mcpConnected (bool — whether the user reads as MCP-connected, milestones.mcpToolCalled, at landing). Counts / enums / bools only — never content.
 - `board.phase_drag` — A spec card was dragged to a different phase column (the interaction; the outcome stays document.status_changed). props.from / props.to are phase enums.
 - `board.tag_filter_applied` — The board tag filter changed. props.filterCount is the number of active tag filters (count only).
 - `search.opened` — The ⌘K command palette was opened. props.trigger (hotkey | button).

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -104,6 +104,13 @@ export { DRIFT_AGENT_GUIDANCE } from './scaffold-data.js';
 // (the React UI's Scaffold Inspect surface sets mode "scaffold"). Lives in the
 // scaffold model (one home, std-15/std-16). Portable per std-22.
 export { SCAFFOLD_AGENT_GUIDANCE, SCAFFOLD_OPENING_TURN_SEED, scaffoldReviewEditSeed } from './scaffold-data.js';
+// spec-482 (t-4 / t-5 / t-8) — the in-Spec agent's opening-posture composer. The
+// PROSE (entry framing + five experience tiers) lives in scaffold-data.ts (std-15);
+// buildSystemBlocks appends the composed block for the primary Spec agent, driven by
+// the per-request creationLanding flag + the per-user mcpConnected / phaseWatermark
+// signals. The signal→tier mapping is logic in system-prompt.ts.
+export { toOpeningPosture } from './scaffold-data.js';
+export type { OpeningTier, OpeningEntry } from './scaffold-data.js';
 // spec-389 t-4 (dec-3): the shared cross-agent handoff contract (canonical map),
 // injected into every scoped in-app agent so it hands off rather than overreach.
 export { SHARED_HANDOFF_GUIDANCE } from './scaffold-data.js';

--- a/packages/shared/src/scaffold-data.ts
+++ b/packages/shared/src/scaffold-data.ts
@@ -353,6 +353,125 @@ export function scaffoldReviewEditSeed(input: {
   ].join('\n');
 }
 
+// ──────────────────────────────────────────────
+// spec-482 (t-4 / t-5 / t-8) — the in-Spec agent's OPENING POSTURE.
+//
+// The primary Spec agent's first-turn stance is driven by three signals the
+// server computes per request: an ENTRY framing (landing after creation vs a
+// normal return visit — the request's `creationLanding` flag) and an experience
+// TIER (`mcpConnected` then `phaseWatermark`, both derived per-user from real
+// telemetry — spec-482 dec-5 / dec-6). `buildSystemBlocks` appends the composed
+// posture (via `toOpeningPosture`) to the Spec agent's prompt; the tier→text
+// mapping is pure LOGIC in system-prompt.ts, the PROSE lives here (std-15/std-16).
+//
+// Portable per std-22 — the prose names no language, framework, repo layout, file
+// paths, or tooling. It speaks only in terms of THIS Spec, the phases, the coding
+// agent over MCP, and the on-screen affordances. It centres the user's own
+// product, never "adopting Memex", and never presumes an existing codebase.
+// ──────────────────────────────────────────────
+
+/** The five experience tiers, gated by mcpConnected then phaseWatermark
+ *  (spec-482 t-5). `system-prompt.ts` maps the signals to one tier; each teaches
+ *  at most ONE phase past the user's high-water mark and never re-teaches an
+ *  exited phase. */
+export type OpeningTier =
+  | 'mcp_disconnected' // mcpConnected=false — loudest connect-handoff bias
+  | 'teach_build' // connected, watermark 'none' — teach build
+  | 'teach_verify' // watermark 'specify_build' — teach verify, never re-teach build
+  | 'teach_done' // watermark 'build_verify' — teach the final step to done
+  | 'experienced'; // watermark 'verify_done' — no workflow teaching at all
+
+/** The entry framing: the post-creation landing (t-4) or a normal return visit
+ *  (t-8). Both reuse the SAME "what's open" computation; only the framing differs. */
+export type OpeningEntry = 'landing' | 'return';
+
+// Cross-tier preamble (t-5 ac-19): always lead with WHY-this-matters grounded in
+// THIS Spec, before any how/what. Centre the user's own product; never presume an
+// existing codebase, never frame the work as "adopting Memex".
+const OPENING_WHY_FIRST =
+  '## Opening posture — this is your FIRST turn on this Spec\n' +
+  'Lead with WHY it matters, grounded in THIS specific Spec, BEFORE any how-to or next step. Name what this Spec actually sets out to do — its real purpose and subject — and tie everything to the user’s OWN product and goal. Never frame this as "adopting Memex" or a tour of the tool, and never presume the user already has an existing codebase (the Spec may be greenfield). Only after the why do you give the how and the what. This posture governs your OPENING turn; once the conversation is under way, converse normally.';
+
+// Landing entry framing (t-4 ac-6/7/8): a shallow, state-computed recap of what is
+// still open, NOT a cold greeting and NOT a transcript replay. Skip when nothing is
+// open. At most one clarifying question (zero when MCP is not connected — the tier
+// block below enforces that). Runs under normal Spec-authoring scope (std-38).
+const OPENING_LANDING =
+  '### Entry: the post-creation landing\n' +
+  'The user just created this Spec and landed here. Open with a SHALLOW, state-computed RECAP of what is still OPEN on this Spec right now — its unresolved decisions and its open tasks, read from the Document Context above. This is a recap of the CURRENT state, not a cold greeting and not a replay of any earlier conversation. If NOTHING is open, SKIP the recap entirely and go straight to the tier-appropriate next step. Ask AT MOST ONE clarifying question this turn (and none at all when your coding agent is not yet connected). Stay within your normal Spec-authoring scope — you are the same Spec agent, just opening.';
+
+// Return-visit entry framing (t-8 ac-17/18): a fresh, FIXED-SHAPE reorientation
+// computed from the SAME signals — no new persisted state, no chat replay, no
+// elapsed-time branching. Reuses the same "what's open" computation as the landing.
+const OPENING_RETURN =
+  '### Entry: returning to this Spec\n' +
+  'The user has returned to this Spec. Open with a fresh, FIXED-SHAPE reorientation computed from the current state — the same shape every time: (1) the PHASE this Spec is in, (2) what is still OPEN — its unresolved decisions and open tasks, read from the Document Context above, (3) the single tier-appropriate NEXT action below. Do NOT replay or reference any earlier conversation, and do NOT branch on how long it has been since the last visit — you have only the current signals, nothing time-based. Reuse the same "what’s open" reading as a post-creation recap; only this entry framing differs.';
+
+// Tier 1 — mcpConnected=false (t-5 ac-16): loudest connect-handoff bias. Lead with
+// WHY, then step-by-step CONNECT instructions (say "connect", never "install"),
+// offer a conversational walk-through, point at the on-screen affordance, never
+// claim to perform the connection. ≤1-line recap, ZERO clarifying questions.
+const OPENING_TIER_MCP_DISCONNECTED =
+  '### Next step: connect your coding agent (this comes FIRST)\n' +
+  'This user has NEVER connected a coding agent over MCP. Until they connect one, this Spec cannot be built — so a connected coding agent is the single most important thing, and it biases this whole turn: keep any recap to AT MOST ONE line, and ask NO clarifying question.\n' +
+  '- Lead with WHY connecting matters for THIS Spec specifically — tie it to what this Spec sets out to build.\n' +
+  '- Then give concrete, step-by-step instructions to CONNECT their coding agent (e.g. Claude Code, Cursor) to this Memex over MCP. Always say "connect" — NEVER "install".\n' +
+  '- Offer to walk them through it conversationally, and point them at the connect affordance / handoff card on screen.\n' +
+  '- You CANNOT perform the connection yourself — do not claim to; guide them to do it.\n' +
+  'Everything else stays secondary until they are connected.';
+
+// Tier 2 — connected, watermark 'none' (t-5 ac-12): teach BUILD and how to reach it.
+const OPENING_TIER_TEACH_BUILD =
+  '### Next step: take this Spec into build\n' +
+  'Their coding agent is connected, but they have not yet driven any Spec from specify through into build. Teach the build step:\n' +
+  '- Lead with WHY building THIS Spec matters — grounded in its purpose and the user’s own product. If the product is new, this is scaffolding a fresh build, not "adopting Memex"; if code already exists, it is grounded against that code. Do not presume either.\n' +
+  '- Explain what BUILD means: handing the settled Spec to their connected coding agent to implement end-to-end — grounded against existing code where there is some, or scaffolded where the product is new.\n' +
+  '- Show them concretely HOW to reach build (the build-handoff affordance / prompt), and offer to help get the Spec ready for it.';
+
+// Tier 3 — watermark 'specify_build' (t-5 ac-12): STOP explaining specify→build;
+// teach VERIFY and how to reach it. Never re-teach the phase they have exited.
+const OPENING_TIER_TEACH_VERIFY =
+  '### Next step: verify\n' +
+  'This user has ALREADY driven a Spec from specify into build via their coding agent — so do NOT re-explain what build is or how to reach it; they know. Teach only verify:\n' +
+  '- Lead with WHY verifying THIS Spec matters for the user’s product.\n' +
+  '- Explain what VERIFY means: confirming the built work actually satisfies the Spec’s acceptance criteria — tests, type checks, and exercising the real path, not vibes — and how to reach verify from here.\n' +
+  'Teach ONLY verify; never re-teach the specify→build step they have already lived.';
+
+// Tier 4 — watermark 'build_verify' (t-5 ac-12 pattern): teach only the final step
+// out to done. Never re-teach specify→build or build→verify.
+const OPENING_TIER_TEACH_DONE =
+  '### Next step: done\n' +
+  'This user has ALREADY taken a Spec through build into verify — so do NOT re-explain build or verify; they know both. Teach only the final step:\n' +
+  '- Lead with WHY closing THIS Spec out matters.\n' +
+  '- Explain the FINAL step: moving a verified Spec to done — the closing-out that records the work as complete — and how to reach it. Closing a Spec is the user’s call, never yours.\n' +
+  'Teach ONLY the step to done; never re-teach specify→build or build→verify.';
+
+// Tier 5 — watermark 'verify_done' (t-5 ac-13): fully experienced — emit NO
+// workflow-teaching content at all; Spec-specific discourse only.
+const OPENING_TIER_EXPERIENCED =
+  '### Experienced user — no workflow teaching\n' +
+  'This user has ALREADY taken a Spec all the way through to done. Emit NO workflow-teaching content: do not explain what specify, build, verify, or done mean, or how to reach any phase — they know the entire workflow. Speak ONLY to THIS specific Spec: its open decisions, its readiness for the next phase, and any concrete blockers. Everything you say is about this Spec’s substance, never about the mechanics of the workflow.';
+
+const OPENING_TIER_TEXT: Record<OpeningTier, string> = {
+  mcp_disconnected: OPENING_TIER_MCP_DISCONNECTED,
+  teach_build: OPENING_TIER_TEACH_BUILD,
+  teach_verify: OPENING_TIER_TEACH_VERIFY,
+  teach_done: OPENING_TIER_TEACH_DONE,
+  experienced: OPENING_TIER_EXPERIENCED,
+};
+
+/**
+ * Compose the in-Spec agent's opening-posture block from the entry framing and the
+ * experience tier (spec-482). Order: the cross-tier why-first preamble (ac-19), the
+ * entry framing (landing recap t-4 / return-visit reorientation t-8), then the one
+ * tier block (t-5). Pure prose selection — the signal→tier mapping is LOGIC in
+ * system-prompt.ts. Single home for the prose per std-15/std-16; portable per std-22.
+ */
+export function toOpeningPosture(input: { entry: OpeningEntry; tier: OpeningTier }): string {
+  const framing = input.entry === 'landing' ? OPENING_LANDING : OPENING_RETURN;
+  return [OPENING_WHY_FIRST, framing, OPENING_TIER_TEXT[input.tier]].join('\n\n');
+}
+
 const BASE_MDX_COMPONENTS: PromptBlockNode = {
   kind: 'prompt_block',
   id: 'mdx-components',

--- a/packages/shared/src/usage-events-registry.ts
+++ b/packages/shared/src/usage-events-registry.ts
@@ -139,6 +139,12 @@ export const USAGE_EVENT_REGISTRY = [
     source: "frontend",
   },
   {
+    name: "spec.landing_shown",
+    description:
+      "The post-creation Spec landing screen was shown — the user arrived on a newly-created Spec via the creation flow's land-on-your-Spec hop (spec-482). Fires at most once per Spec landing. props.phase is the Spec phase enum (draft | specify | build | verify | done); props.mcpConnected (bool) is whether the user reads as MCP-connected (the dec-5 observed-traffic milestone, milestones.mcpToolCalled) at landing. Counts / enums / bools only — never content.",
+    source: "frontend",
+  },
+  {
     name: "board.phase_drag",
     description:
       "A spec card was dragged to a different phase column on the board (the interaction). props.from / props.to are phase enums. The OUTCOME stays document.status_changed (back-end); this captures the drag intent (std-35 cl-1).",

--- a/packages/ui/e2e/journey-61-spec-482-post-creation-landing.spec.ts
+++ b/packages/ui/e2e/journey-61-spec-482-post-creation-landing.spec.ts
@@ -1,0 +1,140 @@
+import { test, expect, tenantPath, emitAcEvents } from "./helpers/index.js";
+import { seedOrgTenant } from "./helpers/retained.js";
+import {
+  clearAnthropicQueue,
+  queueAnthropicResponse,
+} from "./helpers/anthropic-fake.js";
+
+// Journey 61 (spec-482): the post-creation landing + handoff card (std-28 gate).
+//
+// After a user creates a Spec through the in-app creation flow they land DIRECTLY
+// on the newly-created Spec's document view — not the Kanban board, not a closed
+// dialogue — with the agent panel (ChatPanel) open, and the ChatPanel renders the
+// three-step "connect" PostCreationHandoffCard with its one-click Spec-URL copy.
+//
+// The seam under test (built this session):
+//   • The ONBOARDING entry — a `/specs?new=1` deep-link (spec-482 dec-4, ac-24) —
+//     auto-opens the NewSpecModal with `openOnCreate` set (SpecList strips the param).
+//     The board's own "+ New Spec" button deliberately does NOT auto-land: it keeps
+//     spec-230's manual "Open Spec" footer (journey-26). So this journey enters via
+//     `?new=1`, never the button.
+//   • With openOnCreate set, a confirmed create navigates to `/specs/<handle>` with
+//     React-Router `state:{creationLanding:true}` (NewSpecModal.openSpec) — no
+//     "Open Spec" click, no dead-end dialogue.
+//   • ChatPanel reads that nav state (isCreationLanding), fires the landing opening
+//     turn, and renders <PostCreationHandoffCard> inside the messages area. Because a
+//     fresh tenant has no observed MCP traffic, `mcpToolCalled` is false, so the FULL
+//     three-step card (testid `post-creation-handoff-card`) shows — its step-2
+//     CodeBlock is the one-click Spec-URL copy affordance.
+//
+// The Anthropic SDK is the ONLY faked seam (MEMEX_ANTHROPIC_FAKE=1): create_doc runs
+// for real against a freshly seeded, isolated memex, so the first Spec is
+// deterministically `spec-1` (nextSpecHandle is per-memex).
+//
+// Emits spec-482 ac-3 (land directly on the created Spec's doc view with the agent
+// panel present) and ac-5 (the post-creation handoff card + its copy-Spec-URL step).
+
+const SPEC482 = "mindset-prod/memex-building-itself/specs/spec-482";
+const AC_LAND = `${SPEC482}/acs/ac-3`; // land on the Spec doc view, agent panel open
+const AC_CARD = `${SPEC482}/acs/ac-5`; // the handoff card + copy-Spec-URL affordance
+
+const FILE = "packages/ui/e2e/journey-61-spec-482-post-creation-landing.spec.ts";
+
+const TITLE =
+  "creating a Spec lands the user directly on its doc view with the agent panel open and the 3-step handoff card (ac-3, ac-5)";
+
+test.afterEach(async ({}, testInfo) => {
+  if (testInfo.status === "skipped") return;
+  await emitAcEvents(
+    [AC_LAND, AC_CARD],
+    testInfo.status === "passed" ? "pass" : "fail",
+    `${FILE}::${testInfo.title}`,
+    testInfo.duration,
+  );
+});
+
+test(TITLE, async ({ page, resources }) => {
+  await page.context().grantPermissions(["clipboard-read", "clipboard-write"]);
+
+  // A fresh org memex — its first created Spec is deterministically spec-1.
+  const tenant = await seedOrgTenant({ slug: resources.slug("j61") });
+
+  // Enter creation the ONBOARDING way: the `?new=1` deep-link (spec-482 dec-4,
+  // ac-24). SpecList reads it, auto-opens the NewSpecModal with openOnCreate set,
+  // and strips the param. This is the ONLY entry that auto-lands on the Spec — the
+  // board's "+ New Spec" button keeps spec-230's manual footer, so we do NOT click it.
+  await page.goto(
+    tenantPath(tenant.namespaceSlug, tenant.memexSlug, "/specs?new=1"),
+    { waitUntil: "commit" },
+  );
+
+  // Queue the agent's authoring turn: turn 1 creates the Spec (create_doc), turn 2
+  // is the closing hand-off text. openOnCreate navigates the instant create_doc
+  // commits, so the landing recap turn that ChatPanel fires next consumes whatever
+  // is left / falls back to the fake's default — the handoff card's visibility is
+  // driven by nav state, not by that turn, so its exact content is immaterial.
+  await clearAnthropicQueue();
+  await queueAnthropicResponse({
+    textDeltas: [],
+    content: [
+      {
+        type: "tool_use",
+        id: "c482_create",
+        name: "create_doc",
+        input: {
+          title: "Realtime Presence",
+          purpose:
+            "Show who is viewing a document, in real time, over the existing SSE bus.",
+          docType: "spec",
+        },
+      },
+    ],
+    stopReason: "tool_use",
+  });
+  await queueAnthropicResponse({
+    textDeltas: ["Your Spec is ready."],
+    content: [{ type: "text", text: "Your Spec is ready." }],
+    stopReason: "end_turn",
+  });
+
+  // The ?new=1 deep-link already auto-opened the modal — describe the Spec.
+  const modalInput = page.getByPlaceholder(/Describe the spec/i);
+  await expect(modalInput).toBeVisible({ timeout: 15_000 });
+  await modalInput.fill("A live presence indicator showing who is viewing a doc.");
+  await modalInput.press("Enter");
+
+  // ── ac-3: the user lands DIRECTLY on the created Spec's doc view ──────────────
+  // openOnCreate auto-navigates to `/specs/spec-1` on the confirmed create — no
+  // "Open Spec" click, and the creation modal (a full-screen dialogue) is gone.
+  await expect(page).toHaveURL(/\/specs\/spec-1$/, { timeout: 20_000 });
+  await expect(page.getByRole("heading", { name: "New Spec" })).toHaveCount(0);
+
+  // …with the agent panel (ChatPanel) present and open — its "Spec assistant"
+  // heading is the reliable panel-mounted anchor (journey-31 pattern).
+  await expect(page.getByText("Spec assistant")).toBeVisible({ timeout: 15_000 });
+
+  // ── ac-5: the post-creation handoff card renders inside the agent panel ───────
+  // The creation→landing hop is the only place it shows. A fresh tenant has no
+  // observed MCP traffic, so the FULL three-step card renders (not the connected /
+  // collapsed variants), naming its beats: connect, copy, paste.
+  const landing = page.getByTestId("creation-landing");
+  await expect(landing).toBeVisible({ timeout: 15_000 });
+  const card = page.getByTestId("post-creation-handoff-card");
+  await expect(card).toBeVisible();
+  // Step 1's LABEL frames the handoff as "Connect the Memex MCP server", never
+  // "install it" (dec-7) — the reused CLI command underneath still legitimately
+  // uses `install`, so we assert the connect framing at the heading, not a blanket
+  // "no install anywhere" (that would fail on the command text, and rightly so).
+  await expect(card).toContainText("Connect the Memex MCP server");
+  await expect(card.getByText("Copy this Spec's URL")).toBeVisible();
+
+  // The one-click Spec-URL copy affordance (step 2 CodeBlock) writes THIS Spec's
+  // canonical URL to the real clipboard — proving the copy path, not just markup.
+  const copyStep = card.getByTestId("handoff-spec-url");
+  await expect(copyStep).toBeVisible();
+  await copyStep.getByRole("button", { name: "Copy" }).click();
+  await expect(copyStep.getByRole("button", { name: "Copied!" })).toBeVisible();
+
+  const clip = (await page.evaluate(() => navigator.clipboard.readText())).trim();
+  expect(clip).toContain(`/${tenant.namespaceSlug}/${tenant.memexSlug}/specs/spec-1`);
+});

--- a/packages/ui/src/agent/graph.ts
+++ b/packages/ui/src/agent/graph.ts
@@ -96,6 +96,13 @@ export interface AgentConfig {
    * targets. Undefined for in-tenant callers, who resolve from the URL as before.
    */
   tenantBasePath?: string;
+  /**
+   * spec-482 (t-7): the creation→landing hop flag. When `true`, the doc-phase
+   * agentNode forwards `creationLanding: true` in the POST /llm/chat body so the
+   * server produces a landing recap for the single auto-sent opening turn. Set
+   * only by ChatContext's landing opening turn; undefined for every normal turn.
+   */
+  creationLanding?: boolean;
 }
 
 // ──────────────────────────────────────────────
@@ -440,7 +447,7 @@ async function agentNode(
   config: RunnableConfig,
   phaseLabel: string
 ): Promise<Partial<AgentStateType>> {
-  const { callbacks, signal } = (config.configurable ?? {}) as AgentConfig;
+  const { callbacks, signal, creationLanding } = (config.configurable ?? {}) as AgentConfig;
 
   console.log(
     `[LANGGRAPH] ${phaseLabel} node invoked — messages:`,
@@ -461,6 +468,9 @@ async function agentNode(
       // server runs the right agent (drift: open-drift context + tools; scaffold:
       // scaffold grounding + propose-then-confirm tool subset).
       mode: wireMode(state.agentMode),
+      // spec-482 (t-7): flag the creation→landing opening turn so the server
+      // produces a landing recap. Only set on that single turn; undefined else.
+      creationLanding,
     },
     signal
   )) {

--- a/packages/ui/src/agent/llm-client.ts
+++ b/packages/ui/src/agent/llm-client.ts
@@ -135,6 +135,13 @@ export async function* callLlmProxy(
      *  spec-300 t-15 (dec-23): 'skills' runs the dedicated skills authoring /
      *  curation agent (skill-catalogue context + SKILLS_SERVER_TOOLS subset). */
     mode?: 'drift' | 'scaffold' | 'standards' | 'issues' | 'skills';
+    /**
+     * spec-482 (t-7): the creation→landing hop. `true` ONLY for the single
+     * auto-sent opening turn fired when the user lands on a freshly-created Spec,
+     * so the server produces a landing recap instead of a normal reply. Normal
+     * turns omit it. Rides the same POST /llm/chat body as `mode`.
+     */
+    creationLanding?: boolean;
   },
   signal?: AbortSignal
 ): AsyncGenerator<LlmProxyEvent> {

--- a/packages/ui/src/agent/useAgentGraph.ts
+++ b/packages/ui/src/agent/useAgentGraph.ts
@@ -31,6 +31,13 @@ export interface InvokeParams {
    * `currentMemexId` → std-7 404). Omitted by in-tenant callers.
    */
   tenantBasePath?: string;
+  /**
+   * spec-482 (t-7): flag the creation→landing opening turn. `true` ONLY for the
+   * single auto-sent turn fired when the user lands on a freshly-created Spec, so
+   * the server produces a landing recap. Forwarded to the doc-phase agentNode via
+   * config.configurable; undefined for every normal turn.
+   */
+  creationLanding?: boolean;
 }
 
 export interface ResumeParams {
@@ -96,6 +103,7 @@ export function useAgentGraph() {
       callbacks,
       signal,
       tenantBasePath,
+      creationLanding,
     }: InvokeParams): Promise<InvokeResult> => {
       const threadId = `thread-${++threadCounterRef.current}`;
 
@@ -129,6 +137,7 @@ export function useAgentGraph() {
             callbacks,
             signal,
             tenantBasePath,
+            creationLanding,
           },
           signal,
         }

--- a/packages/ui/src/components/ChatContext.tsx
+++ b/packages/ui/src/components/ChatContext.tsx
@@ -119,6 +119,15 @@ interface ChatState {
    * outside scaffold mode and after the first fire.
    */
   startScaffoldOpeningTurn: (seed: string) => void;
+  /**
+   * spec-482 (t-7): fire the post-creation LANDING opening turn ONCE per Spec —
+   * the single auto-sent turn when the user lands on a freshly-created Spec via
+   * the creation flow. Streams the agent's landing recap (no visible user bubble,
+   * like the scaffold opening turn) and flags the request with `creationLanding:
+   * true` so the server produces a recap. No-ops outside spec mode, without a
+   * bound docId, or after the first fire for that docId.
+   */
+  startCreationLandingTurn: (seed: string) => void;
   sendMessage: (text: string) => void;
   stopStreaming: () => void;
   respondToUiTool: (toolId: string, result: string) => void;
@@ -186,6 +195,11 @@ export function ChatProvider({ children }: { children: ReactNode }) {
   // greeting that also used this ref was removed — opening a Spec no longer
   // auto-activates the agent; only the Drift Inbox uses this now.)
   const openingTurnStartedForRef = useRef<string | null>(null);
+  // spec-482 (t-7): guards the post-creation landing opening turn so it fires at
+  // most ONCE per landed-on Spec. Keyed by the bound docId so navigating to a
+  // DIFFERENT freshly-created Spec re-arms it, but a re-render / re-mount on the
+  // same Spec never re-fires the recap. Reset alongside the thread on setDocId.
+  const creationLandingStartedForRef = useRef<string | null>(null);
 
   const setDocId = useCallback((id: string | null) => {
     if (id === docIdRef.current) return;
@@ -198,6 +212,7 @@ export function ChatProvider({ children }: { children: ReactNode }) {
     setRespondedToolIds(new Set());
     anthropicMessagesRef.current = [];
     openingTurnStartedForRef.current = null;
+    creationLandingStartedForRef.current = null;
   }, []);
 
   // spec-143 t-4 (dec-6): enter / leave drift mode. Entering wipes any prior
@@ -575,6 +590,57 @@ export function ChatProvider({ children }: { children: ReactNode }) {
   // no startScopedOpeningTurn. Their controllers only enter/leave the scoped mode;
   // the first LLM call happens when the user types.
 
+  // spec-482 (t-7): the post-creation LANDING opening turn. When the user lands on
+  // a freshly-created Spec via the creation flow, the in-Spec chat auto-sends ONE
+  // turn flagged `creationLanding: true` so the server produces a landing recap.
+  // Mirrors startScaffoldOpeningTurn: it streams the assistant recap WITHOUT a
+  // visible user bubble (the seed is agent-facing only). Fires at most once per
+  // bound docId (guarded by creationLandingStartedForRef); no-ops outside spec
+  // mode, without a docId, or while a turn is already streaming.
+  const startCreationLandingTurn = useCallback(
+    async (seed: string) => {
+      if (agentModeRef.current !== 'spec') return;
+      const currentDocId = docIdRef.current;
+      if (!currentDocId) return;
+      if (creationLandingStartedForRef.current === currentDocId) return;
+      if (isStreaming) return;
+      creationLandingStartedForRef.current = currentDocId;
+
+      setError(null);
+      setIsStreaming(true);
+      streamingAssistantIdRef.current = null;
+      const controller = new AbortController();
+      abortRef.current = controller;
+
+      try {
+        const result = await invoke({
+          userMessage: seed,
+          docId: currentDocId,
+          existingMessages: anthropicMessagesRef.current,
+          agentMode: 'spec',
+          creationLanding: true,
+          callbacks: makeCallbacks(),
+          signal: controller.signal,
+        });
+        anthropicMessagesRef.current = result.messages;
+        const saveDocId = result.docId ?? currentDocId;
+        if (saveDocId) {
+          saveConversation(saveDocId, result.messages).catch(console.error);
+        }
+      } catch (err) {
+        if ((err as Error).name !== 'AbortError') {
+          setError(err instanceof Error ? err.message : String(err));
+        }
+      } finally {
+        if (abortRef.current === controller) {
+          setIsStreaming(false);
+          abortRef.current = null;
+        }
+      }
+    },
+    [isStreaming, invoke, makeCallbacks],
+  );
+
   const respondToUiTool = useCallback(
     async (toolId: string, result: string) => {
       const currentDocId = docIdRef.current;
@@ -739,6 +805,7 @@ export function ChatProvider({ children }: { children: ReactNode }) {
         clearScaffoldProposal,
         scaffoldNav,
         startScaffoldOpeningTurn,
+        startCreationLandingTurn,
         sendMessage,
         stopStreaming,
         respondToUiTool,

--- a/packages/ui/src/components/ChatPanel.test.tsx
+++ b/packages/ui/src/components/ChatPanel.test.tsx
@@ -13,6 +13,11 @@ const mockSendMessage = vi.fn();
 const mockStopStreaming = vi.fn();
 const mockClearChat = vi.fn();
 const mockRespondToUiTool = vi.fn();
+// spec-482 (t-7): the landing opening-turn dispatcher + the telemetry track spy,
+// plus the observed-traffic MCP signal the grounding/handoff gate reads.
+const mockStartCreationLandingTurn = vi.fn();
+const mockTrack = vi.fn();
+let mockMcpToolCalled = false;
 
 let mockChatState: {
   messages: ChatMessage[];
@@ -39,7 +44,17 @@ vi.mock('./ChatContext', () => ({
     stopStreaming: mockStopStreaming,
     clearChat: mockClearChat,
     respondToUiTool: mockRespondToUiTool,
+    startCreationLandingTurn: mockStartCreationLandingTurn,
   }),
+}));
+
+// spec-482 (t-7): stub the journey read (the grounding/handoff MCP gate) and the
+// telemetry hook so the panel's tests stay offline + deterministic.
+vi.mock('../hooks/useMcpToolCalled', () => ({
+  useMcpToolCalled: () => mockMcpToolCalled,
+}));
+vi.mock('../hooks/useTelemetry', () => ({
+  useTelemetry: () => ({ track: mockTrack, optedOut: false, setOptOut: vi.fn() }),
 }));
 
 // spec-283: the idle review block composes its prompts through the real
@@ -502,5 +517,100 @@ describe('ChatPanel — static scaffold intro (spec-360 issue-12, ac-11)', () =>
       await user.click(btn);
       expect(onCollapse).toHaveBeenCalledTimes(1);
     });
+  });
+});
+
+// ── spec-482 (t-7 / t-9): post-creation landing — grounding gate, handoff card,
+// landing telemetry. The grounding line hides once observed MCP traffic reads
+// connected (ac-22); on the landing hop neither the card nor the line then
+// prompts to connect (ac-20); the landing telemetry fires on landing (ac-4).
+describe('ChatPanel — post-creation landing (spec-482)', () => {
+  const AC482 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-482/acs/ac-${n}`;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockMcpToolCalled = false;
+    mockChatState = {
+      messages: [],
+      isStreaming: false,
+      error: null,
+      docId: 'doc-1',
+      doc: { status: 'specify' },
+      openCommentCount: 0,
+      contextChips: [],
+      respondedToolIds: new Set(),
+      isDriftMode: false,
+    };
+  });
+
+  // Render with the creation→landing nav state NewSpecModal sets on the hop.
+  function renderLanding() {
+    return rtlRender(
+      <MemoryRouter
+        initialEntries={[{ pathname: '/ns/mx/specs/spec-1', state: { creationLanding: true } }]}
+      >
+        <ChatPanel />
+      </MemoryRouter>,
+    );
+  }
+
+  it('the grounding line shows when mcpToolCalled=false and hides when true (ac-22)', () => {
+    tagAc(AC482(22));
+    const { unmount } = render(<ChatPanel />);
+    expect(screen.getByTestId('chat-grounding-line')).toBeInTheDocument();
+    unmount();
+
+    mockMcpToolCalled = true;
+    render(<ChatPanel />);
+    expect(screen.queryByTestId('chat-grounding-line')).not.toBeInTheDocument();
+  });
+
+  it('on landing while connected, neither the handoff card nor the grounding line prompts to connect (ac-20)', () => {
+    tagAc(AC482(20));
+    mockMcpToolCalled = true;
+    renderLanding();
+
+    // The landing card is present, but morphed to its CONNECTED form — the
+    // "Connect the Memex MCP server" step is gone.
+    expect(screen.getByTestId('creation-landing')).toBeInTheDocument();
+    expect(screen.getByTestId('handoff-connected')).toBeInTheDocument();
+    expect(screen.queryByTestId('post-creation-handoff-card')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('handoff-step-connect')).not.toBeInTheDocument();
+    // And the header grounding line is gone too.
+    expect(screen.queryByTestId('chat-grounding-line')).not.toBeInTheDocument();
+  });
+
+  it('on landing while NOT connected, the full handoff card renders with its connect step (ac-5)', () => {
+    tagAc(AC482(5));
+    mockMcpToolCalled = false;
+    renderLanding();
+
+    expect(screen.getByTestId('creation-landing')).toBeInTheDocument();
+    expect(screen.getByTestId('post-creation-handoff-card')).toBeInTheDocument();
+    expect(screen.getByTestId('handoff-step-connect')).toBeInTheDocument();
+    // The grounding line also still shows (not connected).
+    expect(screen.getByTestId('chat-grounding-line')).toBeInTheDocument();
+  });
+
+  it('fires the landing recap opening turn and spec.landing_shown telemetry once, on landing (ac-4, ac-2)', () => {
+    tagAc(AC482(4));
+    // ac-2: the landing recap turn firing IS the agent continuing the conversation
+    // from creation (Option B seeded summary) rather than a cold restart.
+    tagAc(AC482(2));
+    renderLanding();
+
+    expect(mockStartCreationLandingTurn).toHaveBeenCalledTimes(1);
+    expect(mockTrack).toHaveBeenCalledTimes(1);
+    expect(mockTrack).toHaveBeenCalledWith(
+      'spec.landing_shown',
+      expect.objectContaining({ phase: 'specify', mcpConnected: false }),
+    );
+  });
+
+  it('a normal open (no creationLanding state) shows no landing card and fires no landing telemetry', () => {
+    render(<ChatPanel />);
+    expect(screen.queryByTestId('creation-landing')).not.toBeInTheDocument();
+    expect(mockStartCreationLandingTurn).not.toHaveBeenCalled();
+    expect(mockTrack).not.toHaveBeenCalled();
   });
 });

--- a/packages/ui/src/components/ChatPanel.tsx
+++ b/packages/ui/src/components/ChatPanel.tsx
@@ -1,9 +1,13 @@
 import { useState, useRef, useEffect, type KeyboardEvent } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import { Alert } from './ui/Alert';
 import { toButtonPrompt, BASE_SCAFFOLD } from '@memex/shared';
 import { useChat } from './ChatContext';
 import { useOrgScaffoldBlocks } from '../hooks/useOrgScaffoldBlocks';
+import { useMcpToolCalled } from '../hooks/useMcpToolCalled';
+import { useTelemetry } from '../hooks/useTelemetry';
+import { getCurrentTenant } from '../utils/tenantUrl';
+import { PostCreationHandoffCard } from './home/PostCreationHandoffCard';
 import { ChatMarkdown } from './chat/ChatMarkdown';
 import { ContextChipBar } from './chat/ContextChipBar';
 import { UiToolRenderer } from './chat/ui-tools';
@@ -19,6 +23,13 @@ import { PublicAuthButtons } from './PublicAccessControls';
 // scaffold-data.ts), so the agent fires them with `context: {}` and no doc
 // context beyond the Org appends, mirroring DocDocument's `sendReviewPrompt`
 // direct-injection path. Labels/ids match the page's old REVIEW_ACTIONS.
+// spec-482 (t-7): the agent-facing seed for the post-creation landing opening
+// turn. It never shows as a user bubble (startCreationLandingTurn streams only
+// the assistant recap); the server keys the landing recap off the request's
+// `creationLanding: true` flag, so this is just the trigger text.
+const CREATION_LANDING_SEED =
+  "I've just created this Spec. Give me a short recap of what we captured and what the best next step is.";
+
 const REVIEW_ACTIONS: { label: string; buttonId: string }[] = [
   { label: 'Summarise Spec', buttonId: 'opening-review-summarise' },
   { label: 'Security review', buttonId: 'opening-review-security' },
@@ -137,7 +148,7 @@ export function makesCodeShapedClaims(content: string): boolean {
 }
 
 export function ChatPanel({ isAuthenticated = true, readOnly = false }: ChatPanelProps = {}) {
-  const { messages, isStreaming, error, sendMessage, stopStreaming, clearChat, respondedToolIds, respondToUiTool, docId, doc, contextChips, isDriftMode, isScaffoldMode, isStandardsMode, isIssuesMode, isSkillsMode } = useChat();
+  const { messages, isStreaming, error, sendMessage, stopStreaming, clearChat, respondedToolIds, respondToUiTool, docId, doc, contextChips, isDriftMode, isScaffoldMode, isStandardsMode, isIssuesMode, isSkillsMode, startCreationLandingTurn } = useChat();
   // spec-389: the docking shell (ResizableChatRail / DocumentShell) injects a
   // collapse handler when the panel can close to its strip; absent → no control.
   const { onCollapse } = useChatCollapse();
@@ -189,6 +200,51 @@ export function ChatPanel({ isAuthenticated = true, readOnly = false }: ChatPane
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const shouldAutoScroll = useRef(true);
+
+  // spec-482 (t-7): the observed-traffic MCP-connected signal (dec-5,
+  // milestones.mcpToolCalled). Gates the grounding line (ac-22 / ac-20) and morphs
+  // the post-creation handoff card past its connect step. Defaults false until the
+  // journey read resolves — so the not-connected surface shows first, unchanged.
+  const mcpToolCalled = useMcpToolCalled(isAuthenticated);
+  const { track } = useTelemetry(true);
+
+  // spec-482 (t-7): the post-creation landing seam. NewSpecModal's create-and-open
+  // path tags the navigation with `state.creationLanding` (React Router). We latch
+  // it against the docId it arrives with — so a normal in-app open (no flag) never
+  // shows the landing, and navigating to a DIFFERENT freshly-created Spec re-latches
+  // — then fire the recap opening turn + the landing telemetry ONCE per landed Spec.
+  const location = useLocation();
+  const landingFlag =
+    (location.state as { creationLanding?: boolean } | null)?.creationLanding === true;
+  const [landingDocId, setLandingDocId] = useState<string | null>(null);
+  useEffect(() => {
+    if (landingFlag && docId && landingDocId !== docId) setLandingDocId(docId);
+  }, [landingFlag, docId, landingDocId]);
+  // The landing surface only makes sense on the doc/spec agent (never a scoped
+  // memex agent) and only while the bound doc is the one we landed on.
+  const isCreationLanding = !!docId && docId === landingDocId && !scopedMode;
+
+  const landingHandledRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!isCreationLanding || !docId) return;
+    if (landingHandledRef.current === docId) return;
+    landingHandledRef.current = docId;
+    // One flagged opening turn → the server's landing recap (no user bubble).
+    startCreationLandingTurn?.(CREATION_LANDING_SEED);
+    // ac-4: the landing telemetry — low-cardinality props only (phase enum + the
+    // connected bool at landing), never content.
+    track('spec.landing_shown', {
+      phase: doc?.status,
+      mcpConnected: mcpToolCalled,
+    });
+  }, [isCreationLanding, docId, startCreationLandingTurn, track, doc?.status, mcpToolCalled]);
+
+  // spec-482 (t-7): this Spec's canonical URL for the handoff card's copy step —
+  // same shape DocDocument builds for its handoff context.
+  const landingTenant = getCurrentTenant();
+  const landingSpecUrl = doc?.handle
+    ? `${window.location.origin}/${landingTenant?.namespace ?? ''}/${landingTenant?.memex ?? ''}/specs/${doc.handle}`
+    : '';
 
   useEffect(() => {
     if (shouldAutoScroll.current) {
@@ -242,7 +298,9 @@ export function ChatPanel({ isAuthenticated = true, readOnly = false }: ChatPane
         <div className="flex-none px-4 py-3 border-b border-edge flex items-center justify-between">
           <AssistantHeading />
         </div>
-        <GroundingLine />
+        {/* spec-482 (t-7 / ac-22): the grounding line disappears once the user
+            reads as MCP-connected (observed traffic). */}
+        {!mcpToolCalled && <GroundingLine />}
         <div className="flex-1 flex flex-col items-center justify-center px-6 text-center gap-3">
           <p className="text-sm font-medium text-primary">Sign in to chat</p>
           <p className="text-sm text-muted">
@@ -273,7 +331,9 @@ export function ChatPanel({ isAuthenticated = true, readOnly = false }: ChatPane
             <AssistantHeading />
             <HeaderControls showClear={messages.length > 0} onClear={clearChat} onCollapse={onCollapse} />
           </div>
-          <GroundingLine />
+          {/* spec-482 (t-7 / ac-22, ac-20): hide the "connect a coding agent"
+              grounding line once observed MCP traffic says the user is connected. */}
+          {!mcpToolCalled && <GroundingLine />}
         </>
       )}
 
@@ -290,6 +350,22 @@ export function ChatPanel({ isAuthenticated = true, readOnly = false }: ChatPane
           >
             Read-only — the agent can answer questions and search, but can't
             make changes.
+          </div>
+        )}
+
+        {/* spec-482 (t-7 / ac-5, ac-20, ac-21): the post-creation handoff card —
+            shown only on the creation→landing hop. It hands the user off to their
+            coding agent; once observed MCP traffic says they're connected
+            (mcpConnected) it morphs past the connect step, and neither it nor the
+            grounding line then prompts to connect (ac-20). `thisSpecConnected` has
+            no per-Spec traffic signal yet, so it's false — FOLLOW-UP for a later task. */}
+        {isCreationLanding && (
+          <div data-testid="creation-landing">
+            <PostCreationHandoffCard
+              specUrl={landingSpecUrl}
+              mcpConnected={mcpToolCalled}
+              thisSpecConnected={false}
+            />
           </div>
         )}
 

--- a/packages/ui/src/components/NewSpecModal.tsx
+++ b/packages/ui/src/components/NewSpecModal.tsx
@@ -304,7 +304,13 @@ export function NewSpecModal({ open, onClose, prefill, onCreated, seedMessage, a
       // tenantPath() would yield an unroutable /specs/{handle}. When the caller
       // supplies the created memex's Specs-board base, navigate under it; else fall
       // back to tenantPath() (tenant-route callers, e.g. Issue conversion).
-      navigate(specsBasePath ? `${specsBasePath}/${handle}` : tenantPath(`/specs/${handle}`));
+      // spec-482 (t-7): tag this navigation as the creation→landing hop via React
+      // Router `state`, so the destination Spec view auto-sends the landing recap
+      // opening turn and shows the post-creation handoff card. Only THIS create-and-
+      // open path carries the flag — a normal in-app open of an existing Spec omits it.
+      navigate(specsBasePath ? `${specsBasePath}/${handle}` : tenantPath(`/specs/${handle}`), {
+        state: { creationLanding: true },
+      });
     },
     [handleClose, navigate, specsBasePath]
   );

--- a/packages/ui/src/components/home/CreateSpecStep.test.tsx
+++ b/packages/ui/src/components/home/CreateSpecStep.test.tsx
@@ -1,6 +1,8 @@
 // spec-305 / spec-336 — step 1 "Connect to the Memex MCP".
-// spec-421: Stage 2 (create the spec) moved to CreateFirstSpecStep. This step now
-// completes on mcpConnected (was hasSpec). The tests below cover the MCP-connect flow only.
+// spec-421: Stage 2 (create the spec) moved to CreateFirstSpecStep. This step completes
+// on the MCP-connect milestone. spec-482 dec-5: that milestone is now observed MCP TRAFFIC
+// (mcpToolCalled — an mcp.tool_called usage_event), not the mcp.connected handshake; the
+// mocks below supply mcpToolCalled accordingly. The tests cover the MCP-connect flow only.
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { tagAc } from '@memex-ai-ac/vitest';
@@ -18,7 +20,7 @@ const AC430 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-430/
 
 beforeEach(() => {
   fetchJourneyStateApi.mockReset();
-  fetchJourneyStateApi.mockResolvedValue({ milestones: { mcpConnected: false } });
+  fetchJourneyStateApi.mockResolvedValue({ milestones: { mcpToolCalled: false } });
   resetCachedJourneyState();
 });
 afterEach(() => {
@@ -29,10 +31,10 @@ afterEach(() => {
 // already connected MCP must see the "Connected" card on first paint, not the connect card
 // flipping to connected after an after-mount fetch.
 describe('CreateSpecStep — assess connected before draw (spec-421 issue-2)', () => {
-  it('a revisiting user (mcpConnected, cached assessment) sees the Connected card on the FIRST render (ac-21, ac-22)', () => {
+  it('a revisiting user (mcpToolCalled, cached assessment) sees the Connected card on the FIRST render (ac-21, ac-22)', () => {
     tagAc(AC421(21));
     tagAc(AC421(22));
-    setCachedJourneyState({ milestones: { mcpConnected: true } } as never);
+    setCachedJourneyState({ milestones: { mcpToolCalled: true } } as never);
 
     render(<CreateSpecStep onComplete={vi.fn()} />);
 
@@ -43,7 +45,7 @@ describe('CreateSpecStep — assess connected before draw (spec-421 issue-2)', (
   });
 });
 
-describe('CreateSpecStep — spec-421: MCP connect only, completes on mcpConnected', () => {
+describe('CreateSpecStep — spec-421: MCP connect only, completes on mcpToolCalled', () => {
   it('renders the MCP connect card with no Stage-2 prompt or source selectors', () => {
     tagAc(AC421(4)); // step 2 shows MCP connect card only, no "Create Your First Spec" section
     tagAc(AC421(11)); // no method selector / starting-point selector
@@ -56,12 +58,12 @@ describe('CreateSpecStep — spec-421: MCP connect only, completes on mcpConnect
     expect(screen.queryByTestId('source-prd')).toBeNull();
   });
 
-  it('advances the moment MCP is connected while the step is open (mcpConnected transition)', async () => {
-    tagAc(AC421(5)); // step 2 completes on mcpConnected
+  it('advances the moment MCP is connected while the step is open (mcpToolCalled transition)', async () => {
+    tagAc(AC421(5)); // step 2 completes on mcpToolCalled
     vi.useFakeTimers();
     fetchJourneyStateApi
-      .mockResolvedValueOnce({ milestones: { mcpConnected: false } }) // on arrival: not yet connected
-      .mockResolvedValue({ milestones: { mcpConnected: true } }); // a later poll: MCP connected
+      .mockResolvedValueOnce({ milestones: { mcpToolCalled: false } }) // on arrival: not yet connected
+      .mockResolvedValue({ milestones: { mcpToolCalled: true } }); // a later poll: MCP connected
     const onComplete = vi.fn();
     render(<CreateSpecStep onComplete={onComplete} />);
     await vi.advanceTimersByTimeAsync(0); // first read — not met, no advance
@@ -76,7 +78,7 @@ describe('CreateSpecStep — spec-421: MCP connect only, completes on mcpConnect
     // never bump you forward. spec-421: connected badge replaces the old "Created" badge.
     tagAc(AC421(5));
     vi.useFakeTimers();
-    fetchJourneyStateApi.mockResolvedValue({ milestones: { mcpConnected: true } });
+    fetchJourneyStateApi.mockResolvedValue({ milestones: { mcpToolCalled: true } });
     const onComplete = vi.fn();
     render(<CreateSpecStep onComplete={onComplete} />);
     await vi.advanceTimersByTimeAsync(0); // first read — already met: show connected, suppress advance
@@ -140,7 +142,7 @@ describe('CreateSpecStep — spec-372 issue-19 connected-card state', () => {
   // connected=true. Wall-clock findBy* is flaky under CI's coverage-instrumented load.
   const renderConnected = async () => {
     vi.useFakeTimers();
-    fetchJourneyStateApi.mockResolvedValue({ milestones: { mcpConnected: true } });
+    fetchJourneyStateApi.mockResolvedValue({ milestones: { mcpToolCalled: true } });
     render(<CreateSpecStep />);
     await vi.advanceTimersByTimeAsync(0); // first read — init branch sets connected
     await vi.advanceTimersByTimeAsync(4000); // a later poll — settle the re-render
@@ -181,7 +183,7 @@ describe('CreateSpecStep — spec-421 issue-4: clarify when the step ticks', () 
   it('hides the tick hint once connected', async () => {
     tagAc(AC421(27));
     vi.useFakeTimers();
-    fetchJourneyStateApi.mockResolvedValue({ milestones: { mcpConnected: true } });
+    fetchJourneyStateApi.mockResolvedValue({ milestones: { mcpToolCalled: true } });
     render(<CreateSpecStep />);
     await vi.advanceTimersByTimeAsync(0); // first read — init branch sets connected
     await vi.advanceTimersByTimeAsync(4000); // settle the re-render

--- a/packages/ui/src/components/home/CreateSpecStep.tsx
+++ b/packages/ui/src/components/home/CreateSpecStep.tsx
@@ -1,6 +1,12 @@
 // spec-336 — step 1 "Connect to the Memex MCP" (v2 originally had two stages; spec-421
-// splits it: this component shows Stage 1 (MCP install) only, completing on mcpConnected.
+// splits it: this component shows Stage 1 (MCP install) only.
 // Stage 2 (create the spec) moved to CreateFirstSpecStep / step "create-first-spec".
+//
+// spec-482 dec-5 (ac-15): this step is verified via observed MCP TRAFFIC — the
+// `mcpToolCalled` milestone (an `mcp.tool_called` usage_event ever recorded), NOT the
+// `mcp.connected` handshake (`mcpConnected`). A handshake with no tool call isn't a
+// meaningful connection. This mirrors the journey def (journeys/onboarding.ts) so the
+// card's done-state and the rail orb tick on the same observed-traffic signal.
 import { useEffect, useRef, useState } from 'react';
 import { fetchJourneyStateApi } from '../../api/journey';
 import { getCachedJourneyState } from '../../journeys/journeyStateCache';
@@ -30,7 +36,7 @@ export function CreateSpecStep({
   // MCP sees the "Connected to the Memex MCP" card on the FIRST paint instead of the connect
   // card flipping to connected after an after-mount fetch (the in-Home flicker). Seeded refs
   // make the effect treat it as "already known, do not advance". Cold → false (today's path).
-  const seededConnected = !preview && !!getCachedJourneyState()?.milestones?.mcpConnected;
+  const seededConnected = !preview && !!getCachedJourneyState()?.milestones?.mcpToolCalled;
   const [connected, setConnected] = useState(seededConnected);
   const [exploreCopied, setExploreCopied] = useState(false);
   const connectedRef = useRef(seededConnected);
@@ -48,7 +54,9 @@ export function CreateSpecStep({
     setTimeout(() => setExploreCopied(false), 1600);
   };
 
-  // spec-421: step completes on mcpConnected (was hasSpec in spec-336).
+  // spec-421: step completes on the connect milestone (was hasSpec in spec-336).
+  // spec-482 dec-5: that milestone is observed MCP traffic (mcpToolCalled), not the
+  // mcp.connected handshake.
   useEffect(() => {
     if (preview) return;
     let alive = true;
@@ -56,7 +64,7 @@ export function CreateSpecStep({
       try {
         const s = await fetchJourneyStateApi();
         if (!alive) return;
-        const isConnected = !!s.milestones?.mcpConnected;
+        const isConnected = !!s.milestones?.mcpToolCalled;
         if (!initRef.current) {
           initRef.current = true;
           if (isConnected) {

--- a/packages/ui/src/components/home/PostCreationHandoffCard.test.tsx
+++ b/packages/ui/src/components/home/PostCreationHandoffCard.test.tsx
@@ -1,0 +1,99 @@
+// spec-482 — the post-creation handoff card (presentational; signals are props).
+// ac-5  — 3-step "connect" (NEVER "install") card, with a one-click copy of this Spec's URL.
+// ac-21 — lifecycle via props: full → ✓ Connected morph → collapse.
+// ac-23 — reuses ConnectAgentStep's exported TOOLS / Instructions (one setup matrix).
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { PostCreationHandoffCard } from './PostCreationHandoffCard';
+import { TOOLS } from './ConnectAgentStep';
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-482/acs/ac-${n}`;
+
+const SPEC_URL = 'https://memex.ai/mindset-prod/memex-building-itself/specs/spec-482';
+
+const writeText = vi.fn().mockResolvedValue(undefined);
+
+beforeEach(() => {
+  writeText.mockClear();
+  Object.assign(navigator, { clipboard: { writeText } });
+});
+
+describe('PostCreationHandoffCard', () => {
+  it('renders the 3-step card with "connect" wording (never "install" as the action verb) and copies the Spec URL', async () => {
+    tagAc(AC(5));
+    render(
+      <PostCreationHandoffCard specUrl={SPEC_URL} mcpConnected={false} thisSpecConnected={false} />,
+    );
+
+    // Full card with all three sequenced steps.
+    expect(screen.getByTestId('post-creation-handoff-card')).toBeInTheDocument();
+    expect(screen.getByTestId('handoff-step-connect')).toBeInTheDocument();
+    expect(screen.getByTestId('handoff-step-copy')).toBeInTheDocument();
+    expect(screen.getByTestId('handoff-step-paste')).toBeInTheDocument();
+
+    // Step 1 heading says "Connect the Memex MCP server".
+    expect(screen.getByText('Connect the Memex MCP server')).toBeInTheDocument();
+
+    // The action verb in the step HEADINGS is "connect", never "install".
+    const headings = screen.getAllByRole('heading').map((h) => h.textContent ?? '');
+    expect(headings.join(' ')).toMatch(/connect/i);
+    expect(headings.join(' ').toLowerCase()).not.toContain('install');
+
+    // One-click copy affordance writes the current Spec URL to the clipboard.
+    const copyBtn = within(screen.getByTestId('handoff-spec-url')).getByText('Copy');
+    fireEvent.click(copyBtn);
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith(SPEC_URL));
+  });
+
+  it('fires onCopySpecUrl after a successful Spec-URL copy', async () => {
+    tagAc(AC(5));
+    const onCopySpecUrl = vi.fn();
+    render(
+      <PostCreationHandoffCard
+        specUrl={SPEC_URL}
+        mcpConnected={false}
+        thisSpecConnected={false}
+        onCopySpecUrl={onCopySpecUrl}
+      />,
+    );
+    fireEvent.click(within(screen.getByTestId('handoff-spec-url')).getByText('Copy'));
+    await waitFor(() => expect(onCopySpecUrl).toHaveBeenCalled());
+  });
+
+  it('morphs to the ✓ Connected state when mcpConnected && !thisSpecConnected, and collapses when thisSpecConnected', () => {
+    tagAc(AC(21));
+
+    // Morph: MCP connected, Spec not yet handed off.
+    const { rerender } = render(
+      <PostCreationHandoffCard specUrl={SPEC_URL} mcpConnected thisSpecConnected={false} />,
+    );
+    expect(screen.getByTestId('handoff-connected')).toBeInTheDocument();
+    expect(screen.getByText(/Connected — now paste your Spec URL/i)).toBeInTheDocument();
+    // The full 3-step card is gone in the morph state (connect step dropped).
+    expect(screen.queryByTestId('post-creation-handoff-card')).not.toBeInTheDocument();
+
+    // Collapse: this Spec has been connected/handed off.
+    rerender(<PostCreationHandoffCard specUrl={SPEC_URL} mcpConnected thisSpecConnected />);
+    expect(screen.getByTestId('handoff-collapsed')).toBeInTheDocument();
+    expect(screen.queryByTestId('handoff-connected')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('post-creation-handoff-card')).not.toBeInTheDocument();
+  });
+
+  it('reuses ConnectAgentStep TOOLS + Instructions — renders every agent-picker option from TOOLS', () => {
+    tagAc(AC(23));
+    render(
+      <PostCreationHandoffCard specUrl={SPEC_URL} mcpConnected={false} thisSpecConnected={false} />,
+    );
+    // Every tool from the shared TOOLS array is offered as a picker option.
+    for (const t of TOOLS) {
+      const btn = screen.getByTestId(`handoff-tool-${t.id}`);
+      expect(btn).toBeInTheDocument();
+      expect(btn.textContent).toContain(t.label);
+    }
+    // The reused per-tool Instructions render (Claude Code default → unified installer).
+    expect(screen.getByTestId('claude-code-instructions')).toBeInTheDocument();
+    const instr = screen.getByTestId('handoff-connect-instructions').textContent ?? '';
+    expect(instr).toContain('npx -y memex-ai install');
+  });
+});

--- a/packages/ui/src/components/home/PostCreationHandoffCard.tsx
+++ b/packages/ui/src/components/home/PostCreationHandoffCard.tsx
@@ -1,0 +1,155 @@
+// spec-482 (dec-7, dec-8; ac-5, ac-21, ac-23) — the post-creation handoff card.
+//
+// After a Spec is created, this persistent, sequenced card hands the user off to their
+// coding agent in three beats: (1) CONNECT the Memex MCP server, (2) COPY this Spec's
+// URL, (3) PASTE it into the agent and tell it to use the Memex MCP on this Spec. The
+// copy in step 1 says "connect" and NEVER "install" (dec-7).
+//
+// This is a PURE / PRESENTATIONAL component: the connection signals arrive as props
+// (`mcpConnected`, `thisSpecConnected`) so a later task can wire the real backend signal
+// without touching this component. It reuses — never rebuilds — the connect primitives
+// exported from ConnectAgentStep (`detectOs`, `TOOLS`, `Instructions`) so there is a
+// single per-tool setup matrix (ac-23).
+import { useState } from 'react';
+import { CodeBlock } from '../CodeBlock';
+import { detectOs, TOOLS, Instructions, type Tool } from './ConnectAgentStep';
+
+export function PostCreationHandoffCard({
+  specUrl,
+  mcpConnected,
+  thisSpecConnected,
+  onCopySpecUrl,
+}: {
+  specUrl: string;
+  mcpConnected: boolean;
+  thisSpecConnected: boolean;
+  // Fires after the Spec URL is copied — lets the parent record the handoff intent.
+  onCopySpecUrl?: () => void;
+}) {
+  const [tool, setTool] = useState<Tool>('claude-code');
+  // `detectOs` is reused for parity with ConnectAgentStep; the unified installer is
+  // OS-agnostic today, so it's passed through but doesn't branch the command.
+  const os = detectOs();
+
+  // Lifecycle (ac-21): once this Spec is connected, the whole card collapses away.
+  if (thisSpecConnected) {
+    return (
+      <div
+        data-testid="handoff-collapsed"
+        className="flex items-center gap-2 rounded-xl border border-edge bg-surface/60 px-4 py-2.5 text-sm text-muted"
+      >
+        <span
+          aria-hidden
+          className="flex h-5 w-5 flex-none items-center justify-center rounded-full bg-status-success-text text-xs text-white"
+        >
+          ✓
+        </span>
+        Your agent is working on this Spec.
+      </div>
+    );
+  }
+
+  // Lifecycle (ac-21): MCP is connected but this Spec hasn't been handed off yet — morph
+  // to a compact confirmation that drops the connect step and points at paste.
+  if (mcpConnected) {
+    return (
+      <article
+        data-testid="handoff-connected"
+        className="relative w-full max-w-2xl overflow-hidden rounded-3xl border border-edge bg-surface/70 p-6 shadow-xl backdrop-blur-xl sm:p-8"
+      >
+        <div className="mb-4 flex items-center gap-3">
+          <span
+            aria-hidden
+            className="flex h-8 w-8 flex-none items-center justify-center rounded-full bg-status-success-text text-base text-white"
+          >
+            ✓
+          </span>
+          <span className="text-xs font-semibold uppercase tracking-[0.14em] text-status-success-text">
+            Connected — now paste your Spec URL
+          </span>
+        </div>
+        <p className="max-w-prose leading-relaxed text-secondary">
+          Your agent is connected to the Memex MCP. Copy this Spec&apos;s URL, paste it into your
+          coding agent, and tell it to use the Memex MCP on this Spec.
+        </p>
+        <div className="mt-5" data-testid="handoff-connected-url">
+          <CodeBlock code={specUrl} onCopy={onCopySpecUrl} />
+        </div>
+      </article>
+    );
+  }
+
+  // Full card (mcpConnected === false): all three sequenced steps.
+  return (
+    <article
+      data-testid="post-creation-handoff-card"
+      className="relative w-full max-w-2xl overflow-hidden rounded-3xl border border-edge bg-surface/70 p-6 shadow-xl backdrop-blur-xl sm:p-8"
+    >
+      <div className="mb-5 font-mono text-xs lowercase tracking-tight text-muted">
+        // hand off to your coding agent
+      </div>
+
+      {/* Step 1 — connect (NEVER "install"): agent picker + reused per-tool setup. */}
+      <section data-testid="handoff-step-connect">
+        <div className="flex items-baseline gap-3">
+          <span className="flex h-7 w-7 flex-none items-center justify-center rounded-full border border-edge text-sm font-bold text-secondary">
+            1
+          </span>
+          <h2 className="text-lg font-bold text-heading">Connect the Memex MCP server</h2>
+        </div>
+        <div className="mt-4 pl-10">
+          <span className="mb-2 block text-sm font-medium text-secondary">Your coding agent</span>
+          <div className="flex flex-wrap gap-2">
+            {TOOLS.map((t) => (
+              <button
+                key={t.id}
+                type="button"
+                data-testid={`handoff-tool-${t.id}`}
+                onClick={() => setTool(t.id)}
+                className={`rounded-lg border px-3 py-1.5 text-sm transition ${
+                  t.id === tool
+                    ? 'border-accent bg-accent/10 font-medium text-accent'
+                    : 'border-edge text-secondary hover:bg-card-hover'
+                }`}
+              >
+                {t.label}
+              </button>
+            ))}
+          </div>
+          <div className="mt-4" data-testid="handoff-connect-instructions">
+            <Instructions tool={tool} os={os} />
+          </div>
+        </div>
+      </section>
+
+      {/* Step 2 — copy this Spec's URL (one-click copy affordance). */}
+      <section data-testid="handoff-step-copy" className="mt-8">
+        <div className="flex items-baseline gap-3">
+          <span className="flex h-7 w-7 flex-none items-center justify-center rounded-full border border-edge text-sm font-bold text-secondary">
+            2
+          </span>
+          <h2 className="text-lg font-bold text-heading">Copy this Spec&apos;s URL</h2>
+        </div>
+        <div className="mt-4 pl-10" data-testid="handoff-spec-url">
+          <CodeBlock code={specUrl} onCopy={onCopySpecUrl} />
+        </div>
+      </section>
+
+      {/* Step 3 — paste + instruct. */}
+      <section data-testid="handoff-step-paste" className="mt-8">
+        <div className="flex items-baseline gap-3">
+          <span className="flex h-7 w-7 flex-none items-center justify-center rounded-full border border-edge text-sm font-bold text-secondary">
+            3
+          </span>
+          <h2 className="text-lg font-bold text-heading">
+            Paste it into your coding agent and tell it to use the Memex MCP on this Spec
+          </h2>
+        </div>
+        <p className="mt-3 pl-10 max-w-prose leading-relaxed text-secondary">
+          Drop the URL into your agent and ask it to use the Memex MCP on this Spec — it&apos;ll read
+          the plan, decisions and tasks, then get to work.
+        </p>
+      </section>
+    </article>
+  );
+}

--- a/packages/ui/src/hooks/useMcpToolCalled.ts
+++ b/packages/ui/src/hooks/useMcpToolCalled.ts
@@ -1,0 +1,40 @@
+// spec-482 (t-7) — a light, user-scoped read of whether the user reads as
+// MCP-connected via OBSERVED TRAFFIC: milestones.mcpToolCalled (dec-5, the
+// signal a sibling task repointed onboarding to). The post-creation Spec landing
+// uses it to (a) gate the grounding line — once the user has real MCP traffic the
+// "connect a coding agent" nudge is noise (ac-22 / ac-20) — and (b) morph the
+// post-creation handoff card past its connect step.
+//
+// Fetches the journey state once on mount (and on window focus, mirroring
+// useJourneyGraduated) and reduces it to the single boolean. Returns `false`
+// until the first read resolves, so the not-connected surface is what shows
+// before the answer is known (preserving the existing grounding-line default).
+// Advisory — a failed fetch leaves the last known value.
+import { useEffect, useState } from 'react';
+import { fetchJourneyStateApi } from '../api/journey';
+
+export function useMcpToolCalled(enabled = true): boolean {
+  const [mcpToolCalled, setMcpToolCalled] = useState(false);
+
+  useEffect(() => {
+    if (!enabled) return;
+    let alive = true;
+    const load = () =>
+      fetchJourneyStateApi()
+        .then((s) => {
+          if (alive) setMcpToolCalled(!!s.milestones?.mcpToolCalled);
+        })
+        .catch(() => {
+          /* advisory — the grounding/handoff gate is non-essential; keep last value */
+        });
+    load();
+    const onFocus = () => load();
+    window.addEventListener('focus', onFocus);
+    return () => {
+      alive = false;
+      window.removeEventListener('focus', onFocus);
+    };
+  }, [enabled]);
+
+  return mcpToolCalled;
+}

--- a/packages/ui/src/pages/SpecList.test.tsx
+++ b/packages/ui/src/pages/SpecList.test.tsx
@@ -29,9 +29,16 @@ vi.mock('../api/client', () => ({
 }));
 
 // NewSpecModal pulls in heavy chat plumbing — stub so the test stays focused
-// on the list rendering behavior.
+// on the list rendering behavior. The stub records the props SpecList passes so
+// spec-482 can assert the board opts into land-on-Spec (openOnCreate).
+const { newSpecModalProps } = vi.hoisted(() => ({
+  newSpecModalProps: { value: null as Record<string, unknown> | null },
+}));
 vi.mock('../components/NewSpecModal', () => ({
-  NewSpecModal: () => null,
+  NewSpecModal: (props: Record<string, unknown>) => {
+    newSpecModalProps.value = props;
+    return null;
+  },
 }));
 
 vi.mock('../components/ShareModal', () => ({
@@ -576,5 +583,51 @@ describe('SpecList — phase display names (spec-164)', () => {
     expect(await screen.findByText('Auth migration')).toBeInTheDocument();
     expect(screen.getByText('Specify')).toBeInTheDocument();
     expect(screen.queryByText('Plan')).not.toBeInTheDocument();
+  });
+});
+
+// spec-482 (dec-4, ac-24): the board modal — shared by the ?new=1 onboarding
+// deep-link and the "+ New Spec" button — must opt into land-on-Spec so a new
+// user lands directly on the created Spec instead of the manual "Open Spec /
+// Close" completion footer. The navigation itself lives in NewSpecModal (covered
+// by spec-470's hero-path tests); here we assert SpecList wires openOnCreate.
+describe('SpecList — land on created Spec (spec-482)', () => {
+  const AC_LANDING = 'mindset-prod/memex-building-itself/specs/spec-482/acs/ac-24';
+
+  it('the ?new=1 onboarding entry passes openOnCreate so creation lands on the Spec', async () => {
+    tagAc(AC_LANDING);
+    // ac-3 (scope): landing directly on the created Spec — openOnCreate is the
+    // mechanism; the e2e journey (t-10) is the end-to-end proof.
+    tagAc('mindset-prod/memex-building-itself/specs/spec-482/acs/ac-3');
+    newSpecModalProps.value = null;
+    fetchDocsMock.mockResolvedValue([]);
+
+    render(
+      <MemoryRouter initialEntries={['/ns/mx/specs?new=1']}>
+        <SpecList />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(newSpecModalProps.value?.openOnCreate).toBe(true);
+    });
+  });
+
+  it('the board "+ New Spec" entry does NOT auto-land (spec-230 flow preserved)', async () => {
+    tagAc(AC_LANDING);
+    newSpecModalProps.value = null;
+    fetchDocsMock.mockResolvedValue([]);
+
+    render(
+      <MemoryRouter initialEntries={['/ns/mx/specs']}>
+        <SpecList />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(newSpecModalProps.value).not.toBeNull();
+    });
+    // No ?new=1 → landOnCreate stays false → the manual "Open Spec" footer path.
+    expect(newSpecModalProps.value?.openOnCreate).toBeFalsy();
   });
 });

--- a/packages/ui/src/pages/SpecList.tsx
+++ b/packages/ui/src/pages/SpecList.tsx
@@ -205,6 +205,11 @@ export function SpecList() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [modalOpen, setModalOpen] = useState(false);
+  // spec-482 (dec-4, ac-24): only the ?new=1 ONBOARDING entry lands the user
+  // directly on the created Spec. The board's own "+ New Spec" button keeps
+  // spec-230's manual "Open Spec" completion footer — this flag scopes the
+  // land-on-create behaviour to onboarding and leaves spec-230's flow untouched.
+  const [landOnCreate, setLandOnCreate] = useState(false);
   const [shareDocId, setShareDocId] = useState<string | null>(null);
   const [renameDoc, setRenameDoc] = useState<DocSummary | null>(null);
   const [moveDoc_, setMoveDoc] = useState<DocSummary | null>(null);
@@ -215,6 +220,7 @@ export function SpecList() {
   useEffect(() => {
     if (searchParams.get('new') === '1') {
       setModalOpen(true);
+      setLandOnCreate(true); // spec-482: onboarding entry lands on the Spec
       const next = new URLSearchParams(searchParams);
       next.delete('new');
       setSearchParams(next, { replace: true });
@@ -567,7 +573,20 @@ export function SpecList() {
         )}
       </div>
 
-      <NewSpecModal open={modalOpen} onClose={() => setModalOpen(false)} />
+      {/* spec-482 (dec-4, ac-24): the board modal is shared by the ?new=1 onboarding
+          deep-link and the "+ New Spec" button. ONLY the onboarding entry sets
+          landOnCreate, so it auto-lands the user on the created Spec (matching the
+          hero path); the "+ New Spec" button keeps spec-230's manual "Open Spec"
+          footer. SpecList renders under a tenant route, so openSpec's
+          tenantPath('/specs/<handle>') fallback resolves. */}
+      <NewSpecModal
+        open={modalOpen}
+        onClose={() => {
+          setModalOpen(false);
+          setLandOnCreate(false);
+        }}
+        openOnCreate={landOnCreate}
+      />
       {shareDocId && <ShareModal docId={shareDocId} onClose={() => setShareDocId(null)} />}
       {renameDoc && (
         <RenameSpecDialog


### PR DESCRIPTION
Implements [spec-482](https://memex.ai/mindset-prod/memex-building-itself/specs/spec-482) — after onboarding creation, land the user directly on the new Spec with a continued agent conversation and a clear MCP handoff.

## What changed
- **Landing:** the onboarding `?new=1` entry now auto-lands on the created Spec (dec-4/ac-24). The generic board "+ New Spec" flow is deliberately unchanged (keeps spec-230's manual "Open Spec" footer).
- **Agent continuity (dec-3, Option B):** a state-computed handoff summary of what's open seeds the Spec chat on landing — no persisted creation thread needed. Return-visit reorientation (dec-9) reuses the same computation.
- **Tiered agent behaviour:** gated by two new per-user signals — `hasEverUsedMcp` (observed MCP traffic, dec-5) and `getPhaseHighWaterMark` (furthest MCP-driven phase transition, dec-6). Teaches exactly the phase one past the mark; goes silent once the loop is complete; always leads with why-it-matters. Prose lives in `scaffold-data.ts` (std-15).
- **Handoff card:** a 3-step "connect" card (reuses spec-305's `ConnectAgentStep` picker, dec-8), morphs to ✓ once MCP traffic is seen (dec-7). The "Hasn't read your code" grounding line now hides once MCP-connected.
- **Onboarding fix:** the "Connect MCP" rail step now keys off observed `mcp.tool_called` traffic (dec-5) instead of the handshake.
- **Telemetry:** new `spec.landing_shown` funnel event.

## Signals & schema
Both signals are **derived queries** over existing tables (`usage_events`, `activity_log`) — **no migration**.

## Testing
- Unit/service + fixture-driven prompt tests + parity; full workspace `tsc` clean; server unit suite green (1793 passed).
- **e2e (std-28):** new `journey-61` (onboarding land + handoff card) passes `make e2e-cold`; `journey-26` (spec-230) preserved and passing.
- 23/24 ACs verified on the board (ac-1 is a documentation outcome).

## Follow-ups (filed as Spec issues, non-blocking)
- issue-1: wire a per-Spec MCP-traffic signal so the handoff card *collapses* (not just morphs).
- issue-2: minor "connects"→"first uses" copy tweak on the Connect-MCP rail hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)