### PR TITLE
spec-474: defer first-load readiness gate until email is verified

### DIFF
--- a/packages/ui/src/components/AuthContext.tsx
+++ b/packages/ui/src/components/AuthContext.tsx
@@ -332,7 +332,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 // magic-link, reset-password) can render under the provider without being blocked. App.tsx
 // composes RequireAuth around authenticated routes.
 export function RequireAuth({ children }: { children: ReactNode }) {
-  const { isAuthenticated, acceptSession } = useAuth();
+  const { isAuthenticated, session, acceptSession } = useAuth();
   const [error, setError] = useState<string | null>(null);
 
   const wrap = useCallback(
@@ -396,8 +396,13 @@ export function RequireAuth({ children }: { children: ReactNode }) {
 
   // spec-474 dec-6: gate authenticated content on first-load Memex readiness. The gate
   // is invisible for provisioned users; a brand-new user briefly sees "Getting your
-  // Memex ready…" while the onboarding content seed runs (off the signup path).
-  if (isAuthenticated) return <MemexReadyGate>{children}</MemexReadyGate>;
+  // Memex ready…" while the onboarding content seed runs (off the signup path). It
+  // defers to email verification: an unverified just-signed-up user sees VerifyEmailGate
+  // (rendered by the routes in `children`), and provisioning only runs once verified.
+  if (isAuthenticated)
+    return (
+      <MemexReadyGate emailVerified={!!session?.user.emailVerified}>{children}</MemexReadyGate>
+    );
 
   return (
     <LoginScreen

--- a/packages/ui/src/components/MemexReadyGate.spec-474-defer.test.tsx
+++ b/packages/ui/src/components/MemexReadyGate.spec-474-defer.test.tsx
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+// spec-474 dec-6 regression — the first-load readiness gate ("Getting your Memex ready…")
+// must DEFER to email verification. A just-signed-up user is admitted with
+// emailVerified=false; the readiness gate must not provision or show its blocker for that
+// user, or the blocker pre-empts the "Confirm your email" screen (VerifyEmailGate) that the
+// routes render inside `children`. Provisioning may only run once the session flips to
+// verified.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, act, waitFor } from '@testing-library/react';
+
+// Hoisted so the (hoisted) vi.mock factory can close over the same spies we assert on.
+const { fetchProvisionedMock, provisionMock } = vi.hoisted(() => ({
+  fetchProvisionedMock: vi.fn(),
+  provisionMock: vi.fn(),
+}));
+
+vi.mock('../api/provision', () => ({
+  fetchPersonalMemexProvisioned: fetchProvisionedMock,
+  provisionPersonalMemex: provisionMock,
+}));
+
+const BLOCKER = 'Getting your Memex ready…';
+
+// The gate keeps a module-level `knownReady` latch that survives across renders. Re-import
+// it fresh per test (after resetModules) so each case starts from a clean, un-latched state.
+async function loadGate() {
+  vi.resetModules();
+  const mod = await import('./MemexReadyGate');
+  return mod.MemexReadyGate;
+}
+
+describe('MemexReadyGate — defers readiness until email verified (spec-474 dec-6)', () => {
+  beforeEach(() => {
+    fetchProvisionedMock.mockReset();
+    provisionMock.mockReset();
+    // Default: a brand-new, unprovisioned personal Memex.
+    fetchProvisionedMock.mockResolvedValue(false);
+    provisionMock.mockResolvedValue(undefined);
+  });
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders children and never provisions while the email is unverified', async () => {
+    const MemexReadyGate = await loadGate();
+    await act(async () => {
+      render(
+        <MemexReadyGate emailVerified={false}>
+          <div>app content</div>
+        </MemexReadyGate>,
+      );
+    });
+
+    // The "Confirm your email" screen (part of children) shows — not the readiness blocker.
+    expect(screen.getByText('app content')).toBeTruthy();
+    expect(screen.queryByText(BLOCKER)).toBeNull();
+    // And no readiness work fired: no GET /me, no POST /me/provision.
+    expect(fetchProvisionedMock).not.toHaveBeenCalled();
+    expect(provisionMock).not.toHaveBeenCalled();
+  });
+
+  it('provisions behind the blocker once the email is verified', async () => {
+    const MemexReadyGate = await loadGate();
+    await act(async () => {
+      render(
+        <MemexReadyGate emailVerified={true}>
+          <div>app content</div>
+        </MemexReadyGate>,
+      );
+    });
+
+    await waitFor(() => expect(provisionMock).toHaveBeenCalledTimes(1));
+    expect(fetchProvisionedMock).toHaveBeenCalledTimes(1);
+    // After the seed completes the app renders.
+    await waitFor(() => expect(screen.getByText('app content')).toBeTruthy());
+  });
+
+  it('kicks off provisioning when the session flips unverified → verified', async () => {
+    const MemexReadyGate = await loadGate();
+    const { rerender } = render(
+      <MemexReadyGate emailVerified={false}>
+        <div>app content</div>
+      </MemexReadyGate>,
+    );
+    // Nothing provisions while unverified.
+    expect(fetchProvisionedMock).not.toHaveBeenCalled();
+    expect(provisionMock).not.toHaveBeenCalled();
+
+    // The user clicks the verification link; VerifyEmailGate's poll refreshes the session
+    // and it comes back verified, re-rendering this gate with emailVerified=true.
+    await act(async () => {
+      rerender(
+        <MemexReadyGate emailVerified={true}>
+          <div>app content</div>
+        </MemexReadyGate>,
+      );
+    });
+
+    await waitFor(() => expect(provisionMock).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(screen.getByText('app content')).toBeTruthy());
+  });
+});

--- a/packages/ui/src/components/MemexReadyGate.tsx
+++ b/packages/ui/src/components/MemexReadyGate.tsx
@@ -6,6 +6,14 @@
 // renders. Provisioned users (the overwhelming majority) never see the blocker — the
 // check is a single fast GET, and once known-ready we short-circuit for the rest of
 // the session so navigation never re-checks.
+//
+// Readiness is gated on email verification. A just-signed-up user is admitted with
+// emailVerified=false and must confirm their email first (VerifyEmailGate, rendered by
+// the routes inside `children`). Provisioning — and the "Getting your Memex ready…"
+// blocker — must NOT run for that user: otherwise the blocker pre-empts the "Confirm
+// your email" screen the moment the readiness GET reports "not provisioned". So while
+// unverified we render children untouched (letting VerifyEmailGate show) and only kick
+// off the readiness check once the session flips to verified.
 
 import { useEffect, useState, type ReactNode } from 'react';
 import { fetchPersonalMemexProvisioned, provisionPersonalMemex } from '../api/provision';
@@ -32,7 +40,13 @@ function GettingReadyBlocker() {
   );
 }
 
-export function MemexReadyGate({ children }: { children: ReactNode }) {
+export function MemexReadyGate({
+  children,
+  emailVerified,
+}: {
+  children: ReactNode;
+  emailVerified: boolean;
+}) {
   const [state, setState] = useState<State>(knownReady ? 'ready' : 'checking');
 
   useEffect(() => {
@@ -40,6 +54,12 @@ export function MemexReadyGate({ children }: { children: ReactNode }) {
       setState('ready');
       return;
     }
+    // Defer readiness until the email is verified. An unverified user stays in
+    // 'checking' (which renders children), so the routes' VerifyEmailGate — "Confirm
+    // your email" — shows instead of the blocker. When the session later flips to
+    // verified (VerifyEmailGate polls refreshSession), this effect re-runs via its
+    // `emailVerified` dep and provisioning kicks off then.
+    if (!emailVerified) return;
     // Guards STATE writes only — never the network calls. Under React StrictMode the
     // mount→cleanup→mount cycle would otherwise cancel the in-flight request before the
     // POST fired (and a `started` ref would make the second mount skip it), so a brand-new
@@ -72,7 +92,7 @@ export function MemexReadyGate({ children }: { children: ReactNode }) {
     return () => {
       active = false;
     };
-  }, []);
+  }, [emailVerified]);
 
   // Only a genuinely-unprovisioned new user (state==='provisioning') sees the blocker.
   // During the quick 'checking' GET we render the app, so provisioned users never flash


### PR DESCRIPTION
## The bug

spec-474 dec-6 moved the onboarding content-seed off the signup request onto a first-load gate, `MemexReadyGate`, which wraps **all** authenticated content in `RequireAuth` — *above* the per-route `VerifyEmailGate`.

Signup admits a new user immediately with `emailVerified=false` (by design, so a "Confirm your email" screen can gate them). But `MemexReadyGate` ran first: its readiness GET reported "not provisioned" for the brand-new account, so it flipped to **"Getting your Memex ready…"** and covered the screen — pre-empting the "Confirm your email" gate entirely. The email-verification step was silently skipped.

The verification email itself was already being sent by the signup route; the problem was purely that the readiness blocker jumped the queue in the UI.

## The fix

`MemexReadyGate` now defers to email verification:

- Takes an `emailVerified` prop (passed from the session in `RequireAuth`).
- While unverified it stays in `checking` and renders `children` untouched — so `VerifyEmailGate` shows — and runs **no** provisioning.
- The readiness effect now depends on `emailVerified`, so when the user clicks the link and `VerifyEmailGate`'s `refreshSession` poll flips the session to verified, provisioning kicks off *then* — the correct order.

## Tests

Adds `MemexReadyGate.spec-474-defer.test.tsx` locking in the behaviour that was missing (exactly the gap that let this regression through):
- no provisioning / no blocker while unverified (children render, so VerifyEmailGate shows);
- provisioning behind the blocker once verified;
- the unverified → verified flip kicking off the seed.

Full UI suite (2147 tests) + server suite green locally and in pre-push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)