### PR TITLE
fix(ui): MemexReadyGate uses the theme page background, not near-black

### DIFF
--- a/packages/ui/src/components/MemexReadyGate.tsx
+++ b/packages/ui/src/components/MemexReadyGate.tsx
@@ -29,10 +29,10 @@ function GettingReadyBlocker() {
     <div
       role="status"
       aria-live="polite"
-      className="fixed inset-0 z-50 flex flex-col items-center justify-center gap-4 bg-white text-neutral-800 dark:bg-neutral-950 dark:text-neutral-100"
+      className="fixed inset-0 z-50 flex flex-col items-center justify-center gap-4 bg-page text-primary"
     >
       <div
-        className="h-8 w-8 animate-spin rounded-full border-2 border-neutral-300 border-t-neutral-700 dark:border-neutral-700 dark:border-t-neutral-200"
+        className="h-8 w-8 animate-spin rounded-full border-2 border-edge border-t-primary"
         aria-hidden="true"
       />
       <p className="text-sm font-medium">Getting your Memex ready…</p>


### PR DESCRIPTION
The **"Getting your Memex ready…"** first-load blocker (`MemexReadyGate`, spec-474) rendered on a near-black background (`dark:bg-neutral-950` = `#0a0a0a`), noticeably darker than every other screen. The standard app canvas is `bg-page` (`#21252b`) — used by the onboarding profile screen, etc.

## Fix
Swap the hard-coded neutrals for theme tokens that adapt to light/dark on their own:
- container: `bg-white text-neutral-800 dark:bg-neutral-950 dark:text-neutral-100` → **`bg-page text-primary`**
- spinner: `border-neutral-300 border-t-neutral-700 dark:…` → **`border-edge border-t-primary`**

No `dark:` variants needed — the tokens are theme-driven.

## Verification
- `tsc --noEmit` clean; `MemexReadyGate` unit tests pass (3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)