### PR TITLE
spec-482 follow-up: real MCP install command in the handoff + no board flash on ?new=1

### DIFF
--- a/packages/server/src/agent/system-prompt.spec-482.test.ts
+++ b/packages/server/src/agent/system-prompt.spec-482.test.ts
@@ -38,9 +38,16 @@ function posture(
   entry: "landing" | "return",
   mcpConnected: boolean,
   phaseWatermark: PhaseWatermark,
+  connectMcp?: { installCommand: string; mcpUrl: string },
 ): OpeningPosture {
-  return { entry, mcpConnected, phaseWatermark };
+  return { entry, mcpConnected, phaseWatermark, connectMcp };
 }
+
+// The route-injected real connect command (deriveConnectMcp) for the disconnected tier.
+const CONNECT = {
+  installCommand: "npx -y memex-ai install --api-base https://int.memex.ai",
+  mcpUrl: "https://int.memex.ai/mcp",
+};
 
 // Distinctive, stable phrases from each prose block (single-sourced in scaffold-data.ts).
 const WHY_FIRST = "Lead with WHY it matters, grounded in THIS specific Spec";
@@ -201,6 +208,33 @@ describe("spec-482 t-5 — tiers gated by mcpConnected then phaseWatermark", () 
       expect(p).toContain("render_handoff");
       expect(p).toContain(COPY_BUTTON_RULE);
     }
+  });
+
+  it("ac-5 / ac-25: the disconnected tier carries the route-injected REAL install command verbatim, for the render_handoff", () => {
+    tagAc(AC(5));
+    tagAc(AC(25));
+    const p = specPrompt(posture("landing", false, "none", CONNECT));
+    // The exact installer command + MCP URL appear verbatim (not paraphrased).
+    expect(p).toContain(CONNECT.installCommand);
+    expect(p).toContain(CONNECT.mcpUrl);
+    // With the explicit instruction to place it in the render_handoff unaltered.
+    expect(p).toContain("put it in your render_handoff VERBATIM");
+    expect(p).toContain("render_handoff");
+  });
+
+  it("ac-25: the injected connect command rides ONLY the disconnected tier — never a connected one", () => {
+    tagAc(AC(25));
+    // Connected tiers must not leak the install command even if one is (defensively) passed.
+    for (const wm of ["none", "specify_build", "verify_done"] as PhaseWatermark[]) {
+      const p = specPrompt(posture("landing", true, wm, CONNECT));
+      expect(p).not.toContain(CONNECT.installCommand);
+      expect(p).not.toContain("put it in your render_handoff VERBATIM");
+    }
+    // And the disconnected tier without an injected command still composes (no crash,
+    // no command block) — the route only injects it in real requests.
+    const bare = specPrompt(posture("landing", false, "none"));
+    expect(bare).not.toContain("put it in your render_handoff VERBATIM");
+    expect(bare).toContain(TIER_MCP_CONNECT_NOT_INSTALL);
   });
 
   it("ac-19: why-before-how leads EVERY tier", () => {

--- a/packages/server/src/agent/system-prompt.ts
+++ b/packages/server/src/agent/system-prompt.ts
@@ -195,6 +195,10 @@ export interface OpeningPosture {
   entry: OpeningEntry;
   mcpConnected: boolean;
   phaseWatermark: PhaseWatermark;
+  // spec-482 follow-up: the REAL, env-specific connect command for the MCP-disconnected
+  // tier's render_handoff. The route derives it (host-aware) and sets it only when
+  // mcpConnected is false; toOpeningPosture appends it verbatim to that one tier.
+  connectMcp?: { installCommand: string; mcpUrl: string };
 }
 
 // spec-482 (t-5) — the signal→tier mapping (pure LOGIC; the tier PROSE lives in the
@@ -311,6 +315,7 @@ export function buildSystemBlocks(
       ? `${withSkills}\n\n${toOpeningPosture({
           entry: openingPosture.entry,
           tier: selectOpeningTier(openingPosture.mcpConnected, openingPosture.phaseWatermark),
+          connectMcp: openingPosture.connectMcp,
         })}`
       : withSkills;
   // spec-360 t-1 (dec-1/dec-6): the scaffold identity now LEADS the instruction

--- a/packages/server/src/routes/llm.ts
+++ b/packages/server/src/routes/llm.ts
@@ -41,6 +41,21 @@ import { getPhaseHighWaterMark } from "../services/phase-watermark.js";
 // we set none.)
 const MODEL = "claude-sonnet-5";
 
+// spec-482 follow-up — the REAL connect-MCP command for the disconnected opening tier,
+// derived host-aware (mirrors packages/ui/src/utils/mcpUrl.ts + ConnectAgentStep's
+// unified installer, spec-430). `APP_BASE_URL` is the public host Cloud Run injects per
+// env (same var app.ts uses for install.sh). The bare `npx -y memex-ai install` command
+// is prod; any other host passes `--api-base`. The agent copies this VERBATIM into its
+// render_handoff so the user copies a working installer, not an LLM paraphrase.
+function deriveConnectMcp(): { installCommand: string; mcpUrl: string } {
+  const base = process.env.APP_BASE_URL ?? "https://int.memex.ai";
+  const apiBaseFlag = base === "https://memex.ai" ? "" : ` --api-base ${base}`;
+  return {
+    installCommand: `npx -y memex-ai install${apiBaseFlag}`,
+    mcpUrl: `${base}/mcp`,
+  };
+}
+
 type Env = MemexResolverEnv & SessionEnv;
 
 // std-5 exemption: this router mounts under both /api/<ns>/<mx>/llm (path-prefixed,
@@ -209,6 +224,10 @@ llmRouter.post("/chat", async (c) => {
         entry: (creationLanding ? "landing" : "return") as "landing" | "return",
         mcpConnected,
         phaseWatermark,
+        // spec-482 follow-up: only the MCP-disconnected tier needs the real connect
+        // command; deriving it host-aware here (mirrors the client's mcpUrl.ts) means
+        // the agent's render_handoff copies a WORKING installer, not a paraphrase.
+        connectMcp: mcpConnected ? undefined : deriveConnectMcp(),
       }
     : undefined;
 

--- a/packages/shared/src/scaffold-data.ts
+++ b/packages/shared/src/scaffold-data.ts
@@ -418,7 +418,7 @@ const OPENING_TIER_MCP_DISCONNECTED =
   'This user has NEVER connected a coding agent over MCP. Until they connect one, this Spec cannot be built — so a connected coding agent is the single most important thing, and it biases this whole turn: keep any recap to AT MOST ONE line, and ask NO clarifying question.\n' +
   '- Lead with WHY connecting matters for THIS Spec specifically — tie it to what this Spec sets out to build.\n' +
   '- Then walk them through the handoff in THREE steps: (1) CONNECT their coding agent (e.g. Claude Code, Cursor) to this Memex over MCP, (2) copy THIS Spec’s URL, (3) paste it into their coding agent and tell it to use the Memex MCP on this Spec. Always say "connect" — NEVER "install".\n' +
-  '- Deliver every COPYABLE piece — any connect command, this Spec’s URL, and the ready-to-paste coding-agent prompt — through a `render_handoff` block so it renders with a Copy button; NEVER paste copyable commands, URLs, or prompts inline in your prose.\n' +
+  '- The FIRST copyable piece is the REAL connect command — use the EXACT install command provided below (verbatim), NOT an invented paraphrase. Deliver that command, plus this Spec’s URL, through a `render_handoff` block so it renders with a Copy button; NEVER paste copyable commands, URLs, or prompts inline in your prose. A handoff that omits the real install command — or that only tells the coding agent to "use the Memex MCP on this Spec" — is NOT connect instructions and is wrong here.\n' +
   '- Offer to walk them through it conversationally. You CANNOT perform the connection yourself — do not claim to; guide them to do it.\n' +
   'Everything else stays secondary until they are connected.';
 
@@ -469,9 +469,35 @@ const OPENING_TIER_TEXT: Record<OpeningTier, string> = {
  * tier block (t-5). Pure prose selection — the signal→tier mapping is LOGIC in
  * system-prompt.ts. Single home for the prose per std-15/std-16; portable per std-22.
  */
-export function toOpeningPosture(input: { entry: OpeningEntry; tier: OpeningTier }): string {
+export function toOpeningPosture(input: {
+  entry: OpeningEntry;
+  tier: OpeningTier;
+  // spec-482 follow-up: the MCP-disconnected tier's render_handoff must carry the REAL,
+  // working connect command — which is env-specific (prod vs int host). The route
+  // derives it per-request and passes it here; it is appended VERBATIM so the portable
+  // prose (std-22) never hardcodes a host/command. Ignored for every connected tier.
+  connectMcp?: { installCommand: string; mcpUrl: string };
+}): string {
   const framing = input.entry === 'landing' ? OPENING_LANDING : OPENING_RETURN;
-  return [OPENING_WHY_FIRST, framing, OPENING_TIER_TEXT[input.tier]].join('\n\n');
+  const parts = [OPENING_WHY_FIRST, framing, OPENING_TIER_TEXT[input.tier]];
+  if (input.tier === 'mcp_disconnected' && input.connectMcp) {
+    parts.push(toConnectMcpBlock(input.connectMcp));
+  }
+  return parts.join('\n\n');
+}
+
+// The exact, env-specific connect command the disconnected-tier agent must place —
+// verbatim — inside its render_handoff, so the copyable payload is the REAL installer
+// (not an LLM paraphrase that assumes MCP is already connected). Composed from
+// route-injected values, never hardcoded here (std-22 portability).
+function toConnectMcpBlock(connect: { installCommand: string; mcpUrl: string }): string {
+  return (
+    '### The exact connect command — put it in your render_handoff VERBATIM\n' +
+    'This is the real, working way for the user to connect the Memex MCP server. Claude Code / Claude Desktop users run this in a terminal (one browser sign-in plants the token — nothing to paste by hand):\n' +
+    '`' + connect.installCommand + '`\n' +
+    'For coding agents configured by URL/config instead (Cursor, VS Code, claude.ai), the Memex MCP endpoint is `' + connect.mcpUrl + '`.\n' +
+    'Put the install command above into your `render_handoff` EXACTLY — do NOT invent, paraphrase, shorten, or alter it. That copyable command IS the payload of the handoff; a prompt that only says "use the Memex MCP on this Spec" is NOT connect instructions and is wrong. After the command you may add this Spec’s URL and a one-line "once connected, point your coding agent at this Spec" note.'
+  );
 }
 
 const BASE_MDX_COMPONENTS: PromptBlockNode = {

--- a/packages/ui/e2e/journey-61-spec-482-post-creation-landing.spec.ts
+++ b/packages/ui/e2e/journey-61-spec-482-post-creation-landing.spec.ts
@@ -109,6 +109,13 @@ test(TITLE, async ({ page, resources }) => {
   // The ?new=1 deep-link already auto-opened the modal — describe the Spec.
   const modalInput = page.getByPlaceholder(/Describe the spec/i);
   await expect(modalInput).toBeVisible({ timeout: 15_000 });
+
+  // spec-482 follow-up: the ?new=1 onboarding entry must NOT flash the specs board
+  // behind the create modal — SpecList renders the modal over a plain page (no
+  // spinner + Kanban) so the create→land hop goes straight to the Spec, matching the
+  // hero path. Assert the Kanban board is not rendered while the auto-opened modal is up.
+  await expect(page.getByTestId("kanban-board")).toHaveCount(0);
+
   await modalInput.fill("A live presence indicator showing who is viewing a doc.");
   await modalInput.press("Enter");
 

--- a/packages/ui/src/pages/SpecList.tsx
+++ b/packages/ui/src/pages/SpecList.tsx
@@ -344,6 +344,32 @@ export function SpecList() {
     [handleArchive],
   );
 
+  // spec-482 (dec-4, ac-24): the create modal — shared by the ?new=1 onboarding
+  // deep-link and the board's "+ New Spec" button. Only the onboarding entry sets
+  // landOnCreate, so it auto-lands the user on the created Spec (matching the hero
+  // path); the "+ New Spec" button keeps spec-230's manual "Open Spec" footer.
+  const newSpecModal = (
+    <NewSpecModal
+      open={modalOpen}
+      onClose={() => {
+        setModalOpen(false);
+        setLandOnCreate(false);
+      }}
+      openOnCreate={landOnCreate}
+    />
+  );
+
+  // spec-482 follow-up: the ?new=1 onboarding entry auto-opens the create modal to LAND
+  // the user directly on the new Spec. Render it over a PLAIN page — never the board
+  // (spinner + Kanban) behind it — so the create→land hop doesn't flash the specs board
+  // on the way to the Spec. The board's own "+ New Spec" button never sets landOnCreate,
+  // so it's unaffected (its modal still opens over the already-rendered board). On create,
+  // the modal navigates straight to /specs/<handle>; on cancel, landOnCreate clears and the
+  // board renders below as usual.
+  if (landOnCreate && modalOpen) {
+    return <div className="min-h-screen bg-page">{newSpecModal}</div>;
+  }
+
   if (loading) {
     return (
       <div className="flex justify-center items-center min-h-[50vh]">
@@ -573,20 +599,11 @@ export function SpecList() {
         )}
       </div>
 
-      {/* spec-482 (dec-4, ac-24): the board modal is shared by the ?new=1 onboarding
-          deep-link and the "+ New Spec" button. ONLY the onboarding entry sets
-          landOnCreate, so it auto-lands the user on the created Spec (matching the
-          hero path); the "+ New Spec" button keeps spec-230's manual "Open Spec"
-          footer. SpecList renders under a tenant route, so openSpec's
-          tenantPath('/specs/<handle>') fallback resolves. */}
-      <NewSpecModal
-        open={modalOpen}
-        onClose={() => {
-          setModalOpen(false);
-          setLandOnCreate(false);
-        }}
-        openOnCreate={landOnCreate}
-      />
+      {/* The create modal (defined above). Rendered here over the board for the
+          "+ New Spec" flow; the ?new=1 onboarding entry short-circuits above and
+          renders it over a plain page instead (no board flash). SpecList renders under
+          a tenant route, so openSpec's tenantPath('/specs/<handle>') fallback resolves. */}
+      {newSpecModal}
       {shareDocId && <ShareModal docId={shareDocId} onClose={() => setShareDocId(null)} />}
       {renameDoc && (
         <RenameSpecDialog


### PR DESCRIPTION
Two post-landing fixes from user feedback on the shipped spec-482 experience.

## 1. The handoff now carries the REAL connect command
The disconnected-tier agent was generating a vague *"use the Memex MCP on this Spec"* prompt that **assumes MCP is already connected** — not install instructions. The route now derives the actual host-aware installer and injects it into the agent's grounding:
- `deriveConnectMcp()` (llm.ts) → `npx -y memex-ai install [--api-base <host>]` + `<host>/mcp`, mirroring `mcpUrl.ts` / spec-430's unified installer.
- `toOpeningPosture` (scaffold-data.ts) appends it **verbatim** to the disconnected tier with an explicit *"put it in your render_handoff VERBATIM — a prompt that only says 'use the Memex MCP on this Spec' is NOT connect instructions"* directive.
- Env-specific value stays out of the portable scaffold prose (std-22) — passed in at request time; rides **only** the disconnected tier.

## 2. `?new=1` onboarding create no longer flashes the specs board
SpecList routed the deep-link through the full board (spinner → Kanban → modal-over-board) before landing. Now, when the onboarding auto-open is active (`landOnCreate && modalOpen`), SpecList renders **only** the modal over a plain `bg-page` — no board behind it — so create → land goes straight to `/specs/<handle>`, matching the hero path. The board's own "+ New Spec" button (no `landOnCreate`) is unchanged.

## Tests
- `system-prompt.spec-482.test.ts` (+2): the injected command appears verbatim on the disconnected tier only, with the render_handoff directive.
- `journey-61`: asserts the Kanban board is **not** rendered behind the `?new=1` modal, then lands on `/specs/spec-1`. Passes cold (2/2).
- `journey-26` (spec-230 "+ New Spec"): unchanged and green.
- `tsc` clean; SpecList + ChatPanel unit suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)