### PR TITLE
feat: rename a Memex (display name + URL slug) — spec-479

### DIFF
--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -35,6 +35,7 @@ import { telemetryRouter } from "./routes/telemetry.js";
 import { anonTelemetryRouter } from "./routes/anon-telemetry.js";
 import { waitlist } from "./routes/waitlist.js";
 import { live } from "./routes/live.js";
+import { redirectsRouter } from "./routes/redirects.js";
 import { auth } from "./routes/auth.js";
 import { invitesAcceptRouter, invitesAdminRouter } from "./routes/invites.js";
 import { teamRouter } from "./routes/team.js";
@@ -376,6 +377,9 @@ app.route("/guide/v1", createGuidePublicRouter(upgradeWebSocket));
 
 // Caller-scoped + public surfaces — stay flat (no path prefix). These have no
 // per-memex semantics, so prefixing them would be noise.
+// spec-479 dec-5 — public page-path redirect resolution for the CDN-served SPA.
+app.route("/api/redirects", redirectsRouter);
+
 app.route("/api/waitlist", waitlist);
 // spec-458 (PROTOTYPE) — PUBLIC global live-stats aggregate behind memex.ai/live.
 // Flat + tenant-less + NO session middleware (the /api/health pattern): the

--- a/packages/server/src/middleware/memex-resolver.ts
+++ b/packages/server/src/middleware/memex-resolver.ts
@@ -47,6 +47,8 @@ const NON_TENANT_API_PREFIXES = [
   "/api/auth/",
   "/api/auth", // exact
   "/api/waitlist",
+  "/api/redirects/",
+  "/api/redirects", // spec-479 dec-5 — public page-path redirect resolution
   "/api/cli/auth/",
   "/api/cli/auth",
   "/api/mcp/tokens",
@@ -99,6 +101,7 @@ const RESERVED_API_ROOTS = new Set([
   "onboarding",
   "orgs",
   "namespaces",
+  "redirects",
   "consent",
   "invites",
   "team",

--- a/packages/server/src/routes/memexes.integration.test.ts
+++ b/packages/server/src/routes/memexes.integration.test.ts
@@ -13,7 +13,7 @@
 // → canReadMemex end-to-end.
 
 import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
-import { inArray } from "drizzle-orm";
+import { inArray, sql } from "drizzle-orm";
 
 vi.hoisted(() => {
   // Force auth-mode session middleware so per-user Bearer tokens are honored.
@@ -39,6 +39,8 @@ const AC_6 = "mindset-prod/memex-building-itself/specs/spec-111/acs/ac-6";
 // spec-111 t-6 wiring (ac-9): the GET read path pins a public Memex onto a
 // signed-in non-member's account via recordPublicMemexVisit.
 const AC_9 = "mindset-prod/memex-building-itself/specs/spec-111/acs/ac-9";
+// spec-479 t-3: the PATCH route accepts name + slug rename, not just visibility.
+const AC_479_ROUTE = "mindset-prod/memex-building-itself/specs/spec-479/acs/ac-10";
 
 async function pinRowCount(userId: string, memexId: string): Promise<number> {
   const rows = await db
@@ -207,6 +209,108 @@ describe("PATCH /api/:ns/:mx/memexes/:id — visibility flip (ac-4)", () => {
       where: (m, { eq }) => eq(m.id, memexId),
     });
     expect(row?.visibility).toBe("private");
+  });
+});
+
+describe("PATCH /api/:ns/:mx/memexes/:id — name + slug rename (spec-479 t-3)", () => {
+  // Redirect rows created by slug renames aren't FK'd to namespaces, so the
+  // afterAll cascade won't remove them — sweep them by namespace slug here.
+  const renameNsSlugs: string[] = [];
+  afterAll(async () => {
+    for (const s of renameNsSlugs) {
+      await db
+        .execute(
+          sql`DELETE FROM redirects WHERE old_path LIKE ${s + "/%"} OR new_path LIKE ${s + "/%"}`,
+        )
+        .catch(() => {});
+    }
+  });
+
+  it("owner renames the display name (slug unchanged)", async () => {
+    tagAc(AC_479_ROUTE);
+    const { ownerBearer, nsSlug, memexSlug, memexId } = await seedOrgWithMemex();
+    renameNsSlugs.push(nsSlug);
+    const res = await req(`/api/${nsSlug}/${memexSlug}/memexes/${memexId}`, {
+      method: "PATCH",
+      bearer: ownerBearer,
+      body: JSON.stringify({ name: "Renamed Display" }),
+    });
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.memex.name).toBe("Renamed Display");
+    expect(json.memex.slug).toBe(memexSlug); // slug untouched
+  });
+
+  it("owner renames the slug", async () => {
+    tagAc(AC_479_ROUTE);
+    const { ownerBearer, nsSlug, memexSlug, memexId } = await seedOrgWithMemex();
+    renameNsSlugs.push(nsSlug);
+    const res = await req(`/api/${nsSlug}/${memexSlug}/memexes/${memexId}`, {
+      method: "PATCH",
+      bearer: ownerBearer,
+      body: JSON.stringify({ slug: "renamed-slug" }),
+    });
+    expect(res.status).toBe(200);
+    expect((await res.json()).memex.slug).toBe("renamed-slug");
+    const row = await db.query.memexes.findFirst({
+      where: (m, { eq }) => eq(m.id, memexId),
+    });
+    expect(row?.slug).toBe("renamed-slug");
+  });
+
+  it("returns 409 when renaming to a slug reserved by a prior rename", async () => {
+    tagAc(AC_479_ROUTE);
+    const { ownerBearer, nsSlug, memexSlug, memexId } = await seedOrgWithMemex();
+    renameNsSlugs.push(nsSlug);
+    // First rename moves the slug away; the old slug becomes a redirect source.
+    const first = await req(`/api/${nsSlug}/${memexSlug}/memexes/${memexId}`, {
+      method: "PATCH",
+      bearer: ownerBearer,
+      body: JSON.stringify({ slug: "moved-away" }),
+    });
+    expect(first.status).toBe(200);
+    // Renaming back onto the original slug is blocked (D-4 reuse-guard → 409).
+    // The path must use the NEW slug now that the memex lives there.
+    const back = await req(`/api/${nsSlug}/moved-away/memexes/${memexId}`, {
+      method: "PATCH",
+      bearer: ownerBearer,
+      body: JSON.stringify({ slug: memexSlug }),
+    });
+    expect(back.status).toBe(409);
+  });
+
+  it("returns 400 for an empty name", async () => {
+    tagAc(AC_479_ROUTE);
+    const { ownerBearer, nsSlug, memexSlug, memexId } = await seedOrgWithMemex();
+    const res = await req(`/api/${nsSlug}/${memexSlug}/memexes/${memexId}`, {
+      method: "PATCH",
+      bearer: ownerBearer,
+      body: JSON.stringify({ name: "   " }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when more than one field is supplied", async () => {
+    tagAc(AC_479_ROUTE);
+    const { ownerBearer, nsSlug, memexSlug, memexId } = await seedOrgWithMemex();
+    const res = await req(`/api/${nsSlug}/${memexSlug}/memexes/${memexId}`, {
+      method: "PATCH",
+      bearer: ownerBearer,
+      body: JSON.stringify({ name: "X", slug: "y" }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("does not let a non-admin rename", async () => {
+    tagAc(AC_479_ROUTE);
+    const { nsSlug, memexSlug, memexId } = await seedOrgWithMemex();
+    const stranger = await seedUser();
+    const res = await req(`/api/${nsSlug}/${memexSlug}/memexes/${memexId}`, {
+      method: "PATCH",
+      bearer: stranger.bearer,
+      body: JSON.stringify({ name: "Hijack" }),
+    });
+    expect(res.status).not.toBe(200);
   });
 });
 

--- a/packages/server/src/routes/memexes.ts
+++ b/packages/server/src/routes/memexes.ts
@@ -37,9 +37,11 @@ import {
   getMemexById,
   isMemexVisibility,
   updateMemexVisibility,
+  updateMemexName,
+  renameMemexSlug,
 } from "../services/memexes.js";
 import { recordPublicMemexVisit } from "../services/users.js";
-import { ValidationError } from "../types/errors.js";
+import { ConflictError, NotFoundError, ValidationError } from "../types/errors.js";
 
 type Env = MemexResolverEnv & SessionEnv;
 
@@ -151,7 +153,10 @@ memexesRouter.get("/:id", async (c, next) => {
   });
 });
 
-// PATCH /:id { visibility: 'public' | 'private' } — flip Memex visibility.
+// PATCH /:id — mutate exactly one Memex setting per request: { visibility } |
+// { name } | { slug } (spec-479 D-2). visibility flips public/private, name is
+// a cosmetic display rename, slug is the URL rename (writes a memex_rename
+// redirect so old links forward, std-10 §7).
 //
 // The `:id` MUST be the memex resolved from the URL path (the one adminGate
 // authorized via currentMemexId). Editing a DIFFERENT memex through this route
@@ -172,17 +177,49 @@ memexesRouter.patch("/:id", async (c, next) => {
   }
 
   const body = await c.req.json().catch(() => null);
-  if (!body || !isMemexVisibility(body.visibility)) {
+  if (!body || typeof body !== "object") {
+    return c.json({ error: "invalid body", code: "validation_error" }, 400);
+  }
+
+  // Exactly one field per request. The settings UI (spec-479 D-2) saves
+  // visibility, display name, and URL slug as independent actions, so the route
+  // does one thing per call — none or several is a 400.
+  const fields = (["visibility", "name", "slug"] as const).filter(
+    (k) => body[k] !== undefined,
+  );
+  if (fields.length !== 1) {
     return c.json(
-      { error: "visibility must be 'public' or 'private'", code: "validation_error" },
+      {
+        error: "provide exactly one of visibility, name, slug",
+        code: "validation_error",
+      },
       400,
     );
   }
+  const field = fields[0];
 
   try {
-    const updated = await updateMemexVisibility(id, body.visibility, {
-      channel: "rest_ui",
-    });
+    const ctx = { channel: "rest_ui" as const };
+    let updated: Awaited<ReturnType<typeof updateMemexVisibility>>;
+    if (field === "visibility") {
+      if (!isMemexVisibility(body.visibility)) {
+        return c.json(
+          { error: "visibility must be 'public' or 'private'", code: "validation_error" },
+          400,
+        );
+      }
+      updated = await updateMemexVisibility(id, body.visibility, ctx);
+    } else if (field === "name") {
+      if (typeof body.name !== "string") {
+        return c.json({ error: "name must be a string", code: "validation_error" }, 400);
+      }
+      updated = await updateMemexName(id, body.name, ctx);
+    } else {
+      if (typeof body.slug !== "string") {
+        return c.json({ error: "slug must be a string", code: "validation_error" }, 400);
+      }
+      updated = await renameMemexSlug(id, body.slug, ctx);
+    }
     return c.json({
       memex: {
         id: updated.id,
@@ -193,9 +230,20 @@ memexesRouter.patch("/:id", async (c, next) => {
       },
     });
   } catch (err) {
-    if (err instanceof ValidationError) {
-      // Memex disappeared between gate and write — surface as 404 (std-7).
+    // Slug already taken, or reserved by a prior rename's redirect (D-4).
+    if (err instanceof ConflictError) {
+      return c.json({ error: err.message, code: "conflict" }, 409);
+    }
+    // Memex/namespace vanished between the admin gate and the write (std-7).
+    if (err instanceof NotFoundError) {
       return c.json({ error: "Not found" }, 404);
+    }
+    if (err instanceof ValidationError) {
+      // Bad input reaching the service (empty name, invalid slug format, same
+      // slug). updateMemexVisibility only ever throws ValidationError for a
+      // vanished memex, so keep that branch's prior 404 behaviour.
+      if (field === "visibility") return c.json({ error: "Not found" }, 404);
+      return c.json({ error: err.message, code: "validation_error" }, 400);
     }
     throw err;
   }

--- a/packages/server/src/routes/redirects-resolve.spec-479.integration.test.ts
+++ b/packages/server/src/routes/redirects-resolve.spec-479.integration.test.ts
@@ -1,0 +1,70 @@
+// spec-479 t-6 (dec-5) — GET /api/redirects/resolve lets the statically-served
+// SPA forward a stale tenant PAGE url after a rename (the browser never reaches
+// the server's redirect handler). Public, unauth: it resolves a path string via
+// lookupRedirect; the destination's own access control still applies when the
+// browser navigates there (std-10 cl-100/101).
+
+import { describe, it, expect, afterEach } from "vitest";
+import { eq, sql } from "drizzle-orm";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { app } from "../app.js";
+import { db } from "../db/connection.js";
+import { namespaces } from "../db/schema.js";
+import { makeTestMemex } from "../services/test-helpers.js";
+import { getMemexById, renameMemexSlug } from "../services/memexes.js";
+
+const AC_479_RESOLVE =
+  "mindset-prod/memex-building-itself/specs/spec-479/acs/ac-11";
+
+const nsSlugsToClean: string[] = [];
+afterEach(async () => {
+  while (nsSlugsToClean.length) {
+    const s = nsSlugsToClean.pop()!;
+    await db
+      .execute(
+        sql`DELETE FROM redirects WHERE old_path LIKE ${s + "/%"} OR new_path LIKE ${s + "/%"}`,
+      )
+      .catch(() => {});
+  }
+});
+
+function resolve(path: string) {
+  return app.request(
+    `/api/redirects/resolve?path=${encodeURIComponent(path)}`,
+    { headers: { Host: "memex.ai", Accept: "application/json" } },
+  );
+}
+
+describe("GET /api/redirects/resolve (spec-479 t-6)", () => {
+  it("resolves a stale tenant path to its post-rename path", async () => {
+    tagAc(AC_479_RESOLVE);
+    const memexId = await makeTestMemex("resolve");
+    const memex = await getMemexById(memexId);
+    const ns = await db.query.namespaces.findFirst({
+      where: eq(namespaces.id, memex!.namespaceId),
+      columns: { slug: true },
+    });
+    nsSlugsToClean.push(ns!.slug);
+    await renameMemexSlug(memexId, "renamed", { channel: "rest_ui" });
+
+    const res = await resolve(`/${ns!.slug}/main/specs/spec-1`);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      redirected: `/${ns!.slug}/renamed/specs/spec-1`,
+    });
+  });
+
+  it("returns notFound for a path with no redirect", async () => {
+    tagAc(AC_479_RESOLVE);
+    const res = await resolve(`/no-such-ns-479/no-mx/specs/spec-1`);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ notFound: true });
+  });
+
+  it("returns notFound for an empty path", async () => {
+    tagAc(AC_479_RESOLVE);
+    const res = await resolve("");
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ notFound: true });
+  });
+});

--- a/packages/server/src/routes/redirects.ts
+++ b/packages/server/src/routes/redirects.ts
@@ -1,0 +1,36 @@
+// /api/redirects/* — page-path redirect resolution for the statically-served
+// SPA (spec-479 dec-5).
+//
+// Browser page loads are served from the CDN bucket, so they never reach the
+// server's `app.use("*")` redirect handler. After a rename the SPA can hit a
+// stale tenant path (`/<ns>/<old-mx>/...`); this endpoint lets it ask the server
+// "where does this path resolve now?" and forward the user client-side.
+//
+// PUBLIC / unauth by design: it resolves a path string only. Per std-10
+// cl-100/101 path-existence may leak; the destination's own access control
+// still applies when the browser actually navigates there.
+
+import { Hono } from "hono";
+import { lookupRedirect } from "../services/redirects.js";
+
+export const redirectsRouter = new Hono();
+
+// GET /api/redirects/resolve?path=<ns>/<mx>/... →
+//   { redirected: "/<ns>/<new-mx>/..." }  when a rename/move redirect matches
+//   { notFound: true }                    otherwise (and for empty/malformed input)
+// The stored `old_path` carries no leading slash; we strip the caller's and
+// re-add one to the result so the SPA gets a router-ready absolute path.
+redirectsRouter.get("/resolve", async (c) => {
+  const path = (c.req.query("path") ?? "").replace(/^\/+/, "").trim();
+  if (!path) return c.json({ notFound: true } as const);
+
+  // lookupRedirect throws on a corrupt chain (cycle / runaway depth) — treat
+  // that as "no usable redirect" rather than surfacing a 500 to the browser.
+  const result = await lookupRedirect(path).catch(
+    () => ({ notFound: true }) as const,
+  );
+  if ("redirected" in result) {
+    return c.json({ redirected: `/${result.redirected}` });
+  }
+  return c.json({ notFound: true } as const);
+});

--- a/packages/server/src/services/memexes.rename.spec-479.integration.test.ts
+++ b/packages/server/src/services/memexes.rename.spec-479.integration.test.ts
@@ -1,0 +1,134 @@
+// spec-479 (t-2) — renameMemexSlug / updateMemexName services + the D-4
+// reuse-guard.
+//
+//   • renameMemexSlug changes memexes.slug AND writes a memex_rename redirect
+//     (`<ns>/<old>` → `<ns>/<new>`) atomically, so old URLs forward instead of
+//     404ing (std-10 §7 / ac-8).
+//   • The D-4 reuse-guard (ac-9): once a slug is the source of a live redirect,
+//     isMemexSlugAvailable reports it unavailable and a rename back onto it is
+//     rejected — a fresh Memex can never shadow the outstanding redirect.
+//   • updateMemexName changes only the display name — no slug/URL change.
+//
+// Per-worker-unique fixtures via makeTestMemex (std-37); redirect rows created
+// by these tests are cleaned up afterEach (std-39 hygiene).
+
+import { describe, it, expect, afterEach } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { eq, sql } from "drizzle-orm";
+import { db } from "../db/connection.js";
+import { namespaces } from "../db/schema.js";
+import { makeTestMemex } from "./test-helpers.js";
+import {
+  getMemexById,
+  renameMemexSlug,
+  updateMemexName,
+  isMemexSlugAvailable,
+} from "./memexes.js";
+import { lookupRedirect } from "./redirects.js";
+
+const AC_479_RENAME_SERVICE =
+  "mindset-prod/memex-building-itself/specs/spec-479/acs/ac-8";
+const AC_479_REUSE_GUARD =
+  "mindset-prod/memex-building-itself/specs/spec-479/acs/ac-9";
+
+// Namespace slugs whose redirect rows we must sweep after each test.
+const nsSlugsToClean: string[] = [];
+
+afterEach(async () => {
+  while (nsSlugsToClean.length) {
+    const nsSlug = nsSlugsToClean.pop()!;
+    await db.execute(sql`
+      DELETE FROM redirects
+       WHERE old_path LIKE ${nsSlug + "/%"}
+          OR old_path = ${nsSlug}
+          OR new_path LIKE ${nsSlug + "/%"}
+    `);
+  }
+});
+
+// Build a fresh org memex and return its id + namespace slug + current slug.
+async function freshMemex(prefix: string) {
+  const memexId = await makeTestMemex(prefix);
+  const memex = await getMemexById(memexId);
+  if (!memex) throw new Error("fixture memex not found");
+  const ns = await db.query.namespaces.findFirst({
+    where: eq(namespaces.id, memex.namespaceId),
+    columns: { slug: true },
+  });
+  if (!ns) throw new Error("fixture namespace not found");
+  nsSlugsToClean.push(ns.slug);
+  return { memexId, nsSlug: ns.slug, slug: memex.slug };
+}
+
+describe("renameMemexSlug (spec-479 t-2)", () => {
+  it("renames the slug and forwards every old URL via a memex_rename redirect", async () => {
+    tagAc(AC_479_RENAME_SERVICE);
+    const { memexId, nsSlug, slug: oldSlug } = await freshMemex("mxr");
+
+    await renameMemexSlug(memexId, "renamed", { channel: "rest_ui" });
+
+    const after = await getMemexById(memexId);
+    expect(after?.slug).toBe("renamed");
+
+    // A deep old path forwards to the new slug, suffix preserved.
+    const result = await lookupRedirect(`${nsSlug}/${oldSlug}/specs/spec-1/tasks/t-1`);
+    expect(result).toEqual({
+      redirected: `${nsSlug}/renamed/specs/spec-1/tasks/t-1`,
+    });
+  });
+
+  it("rejects renaming to the current slug (no self-redirect)", async () => {
+    tagAc(AC_479_RENAME_SERVICE);
+    const { memexId, slug } = await freshMemex("mxs");
+    await expect(renameMemexSlug(memexId, slug, {})).rejects.toThrow(
+      /same as the current slug|nothing to rename/i,
+    );
+  });
+
+  it("D-4 reuse-guard: a redirected slug is unavailable and can't be re-registered", async () => {
+    tagAc(AC_479_REUSE_GUARD);
+    const { memexId, nsSlug, slug: oldSlug } = await freshMemex("mxg");
+
+    await renameMemexSlug(memexId, "moved", { channel: "rest_ui" });
+
+    // The old slug is now the source of a live redirect → unavailable.
+    const avail = await isMemexSlugAvailable(
+      (await getMemexById(memexId))!.namespaceId,
+      oldSlug,
+    );
+    expect(avail).toEqual({ available: false, reason: "redirected" });
+
+    // And renaming back onto it is blocked (would shadow the redirect).
+    await expect(renameMemexSlug(memexId, oldSlug, {})).rejects.toThrow(
+      /reserved by a redirect/i,
+    );
+
+    // Sanity: nsSlug used above to satisfy the cleanup sweep.
+    expect(nsSlug).toBeTruthy();
+  });
+});
+
+describe("updateMemexName (spec-479 t-2)", () => {
+  it("changes the display name only — slug and URLs are untouched", async () => {
+    tagAc(AC_479_RENAME_SERVICE);
+    const { memexId, nsSlug, slug } = await freshMemex("mxn");
+
+    await updateMemexName(memexId, "Renamed Display", { channel: "rest_ui" });
+
+    const after = await getMemexById(memexId);
+    expect(after?.name).toBe("Renamed Display");
+    expect(after?.slug).toBe(slug); // slug unchanged
+
+    // No redirect was written for a name-only change.
+    const result = await lookupRedirect(`${nsSlug}/${slug}/specs/spec-1`);
+    expect(result).toEqual({ notFound: true });
+  });
+
+  it("rejects an empty name", async () => {
+    tagAc(AC_479_RENAME_SERVICE);
+    const { memexId } = await freshMemex("mxe");
+    await expect(updateMemexName(memexId, "   ", {})).rejects.toThrow(
+      /cannot be empty/i,
+    );
+  });
+});

--- a/packages/server/src/services/memexes.ts
+++ b/packages/server/src/services/memexes.ts
@@ -10,7 +10,7 @@ import { memexes, namespaces } from "../db/schema.js";
 import type { Memex } from "../db/schema.js";
 import { validateSlugFormat, type SlugFormatError } from "./shared/slug.js";
 import { pgError } from "./shared/pg-error.js";
-import { ConflictError, ValidationError } from "../types/errors.js";
+import { ConflictError, NotFoundError, ValidationError } from "../types/errors.js";
 import { mutate, type Mutated, type RequestCtx } from "./mutate.js";
 import { insertRedirect, isRedirectSource } from "./redirects.js";
 
@@ -138,7 +138,7 @@ export async function updateMemexName(
         .where(eq(memexes.id, memexId))
         .returning();
       if (!updated) {
-        throw new ValidationError(`Memex ${memexId} not found`);
+        throw new NotFoundError(`Memex ${memexId} not found`);
       }
       return updated;
     },
@@ -165,7 +165,7 @@ export async function renameMemexSlug(
   const normalized = newSlug.trim().toLowerCase();
 
   const memex = await getMemexById(memexId);
-  if (!memex) throw new ValidationError(`Memex ${memexId} not found`);
+  if (!memex) throw new NotFoundError(`Memex ${memexId} not found`);
   if (normalized === memex.slug) {
     throw new ValidationError(
       "New slug matches the current slug — nothing to rename",
@@ -176,7 +176,7 @@ export async function renameMemexSlug(
     where: eq(namespaces.id, memex.namespaceId),
     columns: { slug: true },
   });
-  if (!ns) throw new ValidationError("Namespace not found");
+  if (!ns) throw new NotFoundError("Namespace not found");
 
   const avail = await isMemexSlugAvailable(memex.namespaceId, normalized);
   if (!avail.available) {
@@ -207,7 +207,7 @@ export async function renameMemexSlug(
           .where(eq(memexes.id, memexId))
           .returning();
         if (!updated) {
-          throw new ValidationError(`Memex ${memexId} not found`);
+          throw new NotFoundError(`Memex ${memexId} not found`);
         }
         // Same transaction as the slug write → the rename and its redirect
         // commit atomically; a failure here rolls back the slug change too.

--- a/packages/server/src/services/memexes.ts
+++ b/packages/server/src/services/memexes.ts
@@ -12,6 +12,7 @@ import { validateSlugFormat, type SlugFormatError } from "./shared/slug.js";
 import { pgError } from "./shared/pg-error.js";
 import { ConflictError, ValidationError } from "../types/errors.js";
 import { mutate, type Mutated, type RequestCtx } from "./mutate.js";
+import { insertRedirect, isRedirectSource } from "./redirects.js";
 
 export async function getMemexById(id: string): Promise<Memex | undefined> {
   return db.query.memexes.findFirst({ where: eq(memexes.id, id) });
@@ -36,7 +37,9 @@ export async function getOrgIdForMemex(memexId: string): Promise<string | null> 
 // memex slugs are unique per namespace, not globally.
 export interface MemexSlugCheckResult {
   available: boolean;
-  reason?: SlugFormatError | "taken";
+  // "redirected" (spec-479 D-4): the slug is the source of a live rename
+  // redirect and must not be re-registered — see the guard below.
+  reason?: SlugFormatError | "taken" | "redirected";
 }
 
 export async function isMemexSlugAvailable(
@@ -53,6 +56,19 @@ export async function isMemexSlugAvailable(
       and(eq(m.namespaceId, namespaceId), eq(m.slug, normalized)),
   });
   if (existing) return { available: false, reason: "taken" };
+
+  // spec-479 D-4 reuse-guard: a slug that a prior rename points AWAY from (the
+  // old_path of a live memex_rename redirect, `<ns-slug>/<slug>`) must stay
+  // unavailable, or a fresh/renamed Memex here would shadow that redirect
+  // (direct-first resolution, std-10 cl-91) and mis-route old links.
+  const ns = await db.query.namespaces.findFirst({
+    where: eq(namespaces.id, namespaceId),
+    columns: { slug: true },
+  });
+  if (ns && (await isRedirectSource(`${ns.slug}/${normalized}`))) {
+    return { available: false, reason: "redirected" };
+  }
+
   return { available: true };
 }
 
@@ -96,6 +112,108 @@ export async function updateMemexVisibility(
       }
       return updated;
     },
+  );
+}
+
+/**
+ * Rename a Memex's display name (`memexes.name`). Cosmetic — no URL/slug
+ * impact, so no redirect and no cooldown. Caller authorization (owner/admin)
+ * is enforced UPSTREAM by the route's adminGate. Per std-8 the write goes
+ * through `mutate()` and emits `memex`/`updated` on the unified bus.
+ */
+export async function updateMemexName(
+  memexId: string,
+  name: string,
+  ctx: RequestCtx = {},
+): Promise<Mutated<Memex>> {
+  const trimmed = name.trim();
+  if (!trimmed) throw new ValidationError("Memex name cannot be empty");
+  return mutate(
+    ctx,
+    { memexId, entity: "memex", action: "updated" },
+    async () => {
+      const [updated] = await db
+        .update(memexes)
+        .set({ name: trimmed, updatedAt: new Date() })
+        .where(eq(memexes.id, memexId))
+        .returning();
+      if (!updated) {
+        throw new ValidationError(`Memex ${memexId} not found`);
+      }
+      return updated;
+    },
+  );
+}
+
+/**
+ * Rename a Memex's URL slug (`memexes.slug`), preserving its namespace. The
+ * slug update and the `memex_rename` redirect (`<ns>/<old>` → `<ns>/<new>`,
+ * std-10 §7) commit in ONE transaction so a half-applied rename can never
+ * leave old links 404ing. Availability (format + per-namespace uniqueness +
+ * the D-4 reuse-guard) is checked first. No cooldown / reservation — memex
+ * slugs are per-namespace, not the global pool std-3 governs (spec-479 D-4).
+ *
+ * Caller authorization (owner/admin) is enforced UPSTREAM by the route's
+ * adminGate. Per std-8 the write goes through `mutate()` and emits
+ * `memex`/`updated` on the unified bus.
+ */
+export async function renameMemexSlug(
+  memexId: string,
+  newSlug: string,
+  ctx: RequestCtx = {},
+): Promise<Mutated<Memex>> {
+  const normalized = newSlug.trim().toLowerCase();
+
+  const memex = await getMemexById(memexId);
+  if (!memex) throw new ValidationError(`Memex ${memexId} not found`);
+  if (normalized === memex.slug) {
+    throw new ValidationError(
+      "New slug matches the current slug — nothing to rename",
+    );
+  }
+
+  const ns = await db.query.namespaces.findFirst({
+    where: eq(namespaces.id, memex.namespaceId),
+    columns: { slug: true },
+  });
+  if (!ns) throw new ValidationError("Namespace not found");
+
+  const avail = await isMemexSlugAvailable(memex.namespaceId, normalized);
+  if (!avail.available) {
+    if (avail.reason === "taken") {
+      throw new ConflictError(
+        `Slug '${normalized}' is already taken in this namespace`,
+      );
+    }
+    if (avail.reason === "redirected") {
+      throw new ConflictError(
+        `Slug '${normalized}' is reserved by a redirect from a prior rename`,
+      );
+    }
+    throw new ValidationError(`Invalid slug: ${avail.reason}`);
+  }
+
+  const oldPath = `${ns.slug}/${memex.slug}`;
+  const newPath = `${ns.slug}/${normalized}`;
+
+  return mutate(
+    ctx,
+    { memexId, entity: "memex", action: "updated" },
+    async () =>
+      db.transaction(async (tx) => {
+        const [updated] = await tx
+          .update(memexes)
+          .set({ slug: normalized, updatedAt: new Date() })
+          .where(eq(memexes.id, memexId))
+          .returning();
+        if (!updated) {
+          throw new ValidationError(`Memex ${memexId} not found`);
+        }
+        // Same transaction as the slug write → the rename and its redirect
+        // commit atomically; a failure here rolls back the slug change too.
+        await insertRedirect(oldPath, newPath, "memex_rename", tx);
+        return updated;
+      }),
   );
 }
 

--- a/packages/server/src/services/redirects.integration.test.ts
+++ b/packages/server/src/services/redirects.integration.test.ts
@@ -16,6 +16,7 @@
 // deletes their own rows.
 
 import { describe, it, expect, afterEach } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
 import { sql } from "drizzle-orm";
 import { db } from "../db/connection.js";
 import { lookupRedirect, insertRedirect, rewriteBriefPathToSpec } from "./redirects.js";
@@ -143,8 +144,11 @@ describe("redirects service (b-36 T-4)", () => {
     const target2 = pathFor(prefix, "other");
 
     await insertRedirect(oldPath, target1, "brief_move");
-    // Second call uses a different reason + new target — should UPSERT.
-    await insertRedirect(oldPath, target2, "memex_rename");
+    // Second call: same old_path, new target — should UPSERT (one row, latest
+    // wins). Both are per-entity moves so they use full canonical refs
+    // (brief_move); UPSERT of a rename-reason PREFIX row is covered in the
+    // spec-479 D-1 block below.
+    await insertRedirect(oldPath, target2, "brief_move");
 
     const result = await lookupRedirect(oldPath);
     expect(result).toEqual({ redirected: target2 });
@@ -155,7 +159,108 @@ describe("redirects service (b-36 T-4)", () => {
     `)) as unknown as Array<{ old_path: string; new_path: string; reason: string }>;
     expect(rows).toHaveLength(1);
     expect(rows[0].new_path).toBe(target2);
-    expect(rows[0].reason).toBe("memex_rename");
+    expect(rows[0].reason).toBe("brief_move");
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// spec-479 D-1 — insertRedirect accepts namespace/memex-level PREFIX rows so a
+// single row per rename event forwards every descendant path (std-10 §7,
+// cl-84/85). Before this, insertRedirect validated BOTH paths as full 4/6-
+// segment canonical refs (parseRef), making namespace_rename / memex_rename
+// un-insertable — the drift flagged as std-10 c-3.
+// ──────────────────────────────────────────────────────────────────────────
+const AC_479_PREFIX_ACCEPT =
+  "mindset-prod/memex-building-itself/specs/spec-479/acs/ac-5";
+const AC_479_PREFIX_REWRITE =
+  "mindset-prod/memex-building-itself/specs/spec-479/acs/ac-6";
+
+// Short, per-worker-unique, lowercase slug stem (std-37). Kept well under the
+// 39-char slug cap so it round-trips through validateSlugFormat.
+function renameStem(): string {
+  return `s479${Math.random().toString(36).slice(2, 8)}`;
+}
+
+describe("insertRedirect rename-prefix rows (spec-479 D-1)", () => {
+  it("namespace_rename: a 1-segment prefix row rewrites every descendant path", async () => {
+    tagAc(AC_479_PREFIX_ACCEPT);
+    tagAc(AC_479_PREFIX_REWRITE);
+    const s = renameStem();
+    cleanupPrefixes.push(s);
+    const oldNs = `${s}o`;
+    const newNs = `${s}n`;
+
+    await insertRedirect(oldNs, newNs, "namespace_rename");
+
+    // A deep descendant under a memex inside the renamed namespace inherits
+    // the rewrite via the resolver's prefix-match — suffix preserved.
+    const result = await lookupRedirect(`${oldNs}/team/specs/spec-1/tasks/t-1`);
+    expect(result).toEqual({
+      redirected: `${newNs}/team/specs/spec-1/tasks/t-1`,
+    });
+  });
+
+  it("memex_rename: a 2-segment ns/mx prefix row rewrites descendants (namespace preserved)", async () => {
+    tagAc(AC_479_PREFIX_ACCEPT);
+    tagAc(AC_479_PREFIX_REWRITE);
+    const s = renameStem();
+    cleanupPrefixes.push(s);
+    const ns = `${s}x`;
+
+    await insertRedirect(`${ns}/oldmx`, `${ns}/newmx`, "memex_rename");
+
+    const result = await lookupRedirect(`${ns}/oldmx/specs/spec-1`);
+    expect(result).toEqual({ redirected: `${ns}/newmx/specs/spec-1` });
+  });
+
+  it("prefix rows UPSERT idempotently on the old_path PK", async () => {
+    tagAc(AC_479_PREFIX_ACCEPT);
+    const s = renameStem();
+    cleanupPrefixes.push(s);
+    const oldNs = `${s}o`;
+
+    await insertRedirect(oldNs, `${s}n1`, "namespace_rename");
+    // Re-record the same rename to a new target — one row, latest wins.
+    await insertRedirect(oldNs, `${s}n2`, "namespace_rename");
+
+    const rows = (await db.execute(sql`
+      SELECT old_path, new_path, reason FROM redirects WHERE old_path = ${oldNs}
+    `)) as unknown as Array<{ old_path: string; new_path: string; reason: string }>;
+    expect(rows).toHaveLength(1);
+    expect(rows[0].new_path).toBe(`${s}n2`);
+    expect(rows[0].reason).toBe("namespace_rename");
+  });
+
+  it("accepts digit-leading slugs (slug authority, not refs.ts letter-first regex)", async () => {
+    tagAc(AC_479_PREFIX_ACCEPT);
+    // A legitimate digit-leading slug (e.g. `2024-recap`) must NOT be rejected.
+    const s = `9${Math.random().toString(36).slice(2, 7)}`;
+    cleanupPrefixes.push(s);
+    await expect(
+      insertRedirect(`${s}o`, `${s}n`, "namespace_rename"),
+    ).resolves.toBeUndefined();
+  });
+
+  it("rejects a rename row whose prefix has the wrong segment count", async () => {
+    tagAc(AC_479_PREFIX_ACCEPT);
+    const s = renameStem();
+    // namespace_rename must be exactly 1 segment.
+    await expect(
+      insertRedirect(`${s}o/mx`, `${s}n/mx`, "namespace_rename"),
+    ).rejects.toThrow();
+    // memex_rename must be exactly 2 segments.
+    await expect(
+      insertRedirect(`${s}o`, `${s}n`, "memex_rename"),
+    ).rejects.toThrow();
+  });
+
+  it("non-rename reasons still require a full 4/6-segment canonical ref", async () => {
+    tagAc(AC_479_PREFIX_REWRITE);
+    const s = renameStem();
+    // A bare namespace prefix is not a valid brief_move ref — parseRef rejects.
+    await expect(
+      insertRedirect(`${s}o`, `${s}n`, "brief_move"),
+    ).rejects.toThrow();
   });
 });
 

--- a/packages/server/src/services/redirects.ts
+++ b/packages/server/src/services/redirects.ts
@@ -25,6 +25,7 @@
 import { sql } from "drizzle-orm";
 import { db } from "../db/connection.js";
 import { parseRef } from "./refs.js";
+import { validateSlugFormat } from "./shared/slug.js";
 
 export type RedirectReason =
   | "brief_move"
@@ -197,22 +198,61 @@ export function rewriteBriefPathToSpec(path: string): BriefToSpecRedirect | null
   return null;
 }
 
-// Record a redirect. Both paths must parse as canonical refs — see
-// services/refs.ts for the grammar. UPSERT on the primary key so re-running
-// the same move (e.g. retried migration step) is a no-op rather than an
-// error; `reason` + `created_at` are refreshed to reflect the latest event.
+// spec-479 D-1 — a namespace/memex rename records ONE redirect row keyed on a
+// PATH PREFIX, not a full entity ref: `namespace_rename` on the 1-segment
+// namespace slug (`old-ns`), `memex_rename` on the 2-segment `<ns>/<mx>`
+// (`old-ns/old-mx`). The resolver's prefix-match (`lookupOneStep`) rewrites
+// every descendant path from it (std-10 §7, cl-84/85). Such a prefix is
+// deliberately NOT a valid canonical ref (parseRef demands 4 or 6 segments),
+// so it gets its own validator. Segments are checked against the slug-creation
+// authority (`validateSlugFormat`) — NOT refs.ts's letter-first SLUG_RE —
+// so a legitimate digit-leading slug (e.g. `2024-recap`) is accepted; and
+// case-strictly, since old_path is stored lowercase and matched literally by
+// the resolver's `LIKE old_path || '/%'`.
+function assertRenamePrefix(
+  path: string,
+  segments: 1 | 2,
+  argName: string,
+  reason: RedirectReason
+): void {
+  const parts = path.split("/");
+  if (parts.length !== segments) {
+    throw new Error(
+      `insertRedirect: ${reason} ${argName} "${path}" must have exactly ${segments} slug segment(s), got ${parts.length}`
+    );
+  }
+  for (const seg of parts) {
+    if (seg !== seg.toLowerCase() || !validateSlugFormat(seg).valid) {
+      throw new Error(
+        `insertRedirect: ${reason} ${argName} "${path}" has an invalid slug segment "${seg}"`
+      );
+    }
+  }
+}
+
+// Record a redirect. UPSERT on the primary key so re-running the same move
+// (e.g. a retried migration step) is a no-op rather than an error; `reason` +
+// `created_at` are refreshed to reflect the latest event. Path validation is
+// reason-gated: rename reasons store a prefix (see `assertRenamePrefix`);
+// every other reason (a per-entity move) must be a full canonical ref.
 export async function insertRedirect(
   oldPath: string,
   newPath: string,
   reason: RedirectReason
 ): Promise<void> {
-  const oldParse = parseRef(oldPath);
-  if (!oldParse.ok) {
-    throw new Error(`insertRedirect: invalid oldPath "${oldPath}": ${oldParse.reason}`);
-  }
-  const newParse = parseRef(newPath);
-  if (!newParse.ok) {
-    throw new Error(`insertRedirect: invalid newPath "${newPath}": ${newParse.reason}`);
+  if (reason === "namespace_rename" || reason === "memex_rename") {
+    const segments = reason === "namespace_rename" ? 1 : 2;
+    assertRenamePrefix(oldPath, segments, "oldPath", reason);
+    assertRenamePrefix(newPath, segments, "newPath", reason);
+  } else {
+    const oldParse = parseRef(oldPath);
+    if (!oldParse.ok) {
+      throw new Error(`insertRedirect: invalid oldPath "${oldPath}": ${oldParse.reason}`);
+    }
+    const newParse = parseRef(newPath);
+    if (!newParse.ok) {
+      throw new Error(`insertRedirect: invalid newPath "${newPath}": ${newParse.reason}`);
+    }
   }
 
   await db.execute(sql`

--- a/packages/server/src/services/redirects.ts
+++ b/packages/server/src/services/redirects.ts
@@ -22,10 +22,16 @@
 // the DB lookup — every old Brief URL becomes a permanent 301 to its Spec
 // equivalent without inserting one redirect row per Brief.
 
-import { sql } from "drizzle-orm";
+import { sql, type SQL } from "drizzle-orm";
 import { db } from "../db/connection.js";
 import { parseRef } from "./refs.js";
 import { validateSlugFormat } from "./shared/slug.js";
+
+// db and a transaction handle both satisfy this. It lets a caller record a
+// redirect inside its own transaction (e.g. renameMemexSlug) so the rename and
+// its redirect row commit atomically — a half-applied rename would recreate the
+// std-10 §7 "old links 404" bug this layer exists to prevent.
+type SqlExecutor = { execute: (query: SQL) => Promise<unknown> };
 
 export type RedirectReason =
   | "brief_move"
@@ -238,7 +244,8 @@ function assertRenamePrefix(
 export async function insertRedirect(
   oldPath: string,
   newPath: string,
-  reason: RedirectReason
+  reason: RedirectReason,
+  executor: SqlExecutor = db
 ): Promise<void> {
   if (reason === "namespace_rename" || reason === "memex_rename") {
     const segments = reason === "namespace_rename" ? 1 : 2;
@@ -255,7 +262,7 @@ export async function insertRedirect(
     }
   }
 
-  await db.execute(sql`
+  await executor.execute(sql`
     INSERT INTO redirects (old_path, new_path, reason)
     VALUES (${oldPath}, ${newPath}, ${reason})
     ON CONFLICT (old_path) DO UPDATE
@@ -263,4 +270,17 @@ export async function insertRedirect(
            reason     = excluded.reason,
            created_at = now()
   `);
+}
+
+// spec-479 D-4 reuse-guard — is `path` the SOURCE (old_path) of a live
+// redirect? Because redirects never expire (std-10 cl-97), a slug a rename
+// points away from must not be handed to a new/renamed entity: direct-first
+// resolution (std-10 cl-91) would let the new entity shadow the redirect and
+// silently mis-route every old link to the wrong place. Callers consult this
+// before (re)registering a slug. old_path is the PK, so this is an index hit.
+export async function isRedirectSource(path: string): Promise<boolean> {
+  const rows = (await db.execute(sql`
+    SELECT 1 FROM redirects WHERE old_path = ${path} LIMIT 1
+  `)) as unknown as unknown[];
+  return rows.length > 0;
 }

--- a/packages/ui/e2e/journey-61-spec-479-memex-rename.spec.ts
+++ b/packages/ui/e2e/journey-61-spec-479-memex-rename.spec.ts
@@ -1,0 +1,88 @@
+import {
+  test,
+  expect,
+  tenantPath,
+  DEV_EMAIL,
+  setUserName,
+  seedOrg,
+  emitAcEvents,
+} from "./helpers/index.js";
+
+// Journey 61 — spec-479: rename a Memex (display name + URL slug) from the
+// per-Memex settings page (std-28 gate).
+//
+// Emits:
+//   ac-1 — an admin renames the display name AND the URL slug from the settings page
+//   ac-4 — the slug rename states its consequences before commit; the name change does not
+//   ac-7 — the settings page renders the rename section; a slug change navigates to the new URL
+//
+// OUT of scope here (deliberately): browser-level forwarding of a STALE tenant
+// PAGE url (part of ac-2). The memex_rename redirect resolves at the
+// canonical-ref / API layer — proven by the server service + redirect
+// integration tests (renameMemexSlug → lookupRedirect forwards the old path).
+// Page-route forwarding for a renamed tenant path is NOT wired in app.ts (only
+// the b-N→spec-N regex is), so asserting a browser redirect here would be
+// false. Tracked as a follow-up issue.
+
+const AC = [
+  "mindset-prod/memex-building-itself/specs/spec-479/acs/ac-1",
+  "mindset-prod/memex-building-itself/specs/spec-479/acs/ac-4",
+  "mindset-prod/memex-building-itself/specs/spec-479/acs/ac-7",
+];
+
+test.afterEach(async ({}, testInfo) => {
+  if (testInfo.status === "skipped") return;
+  await emitAcEvents(
+    AC,
+    testInfo.status === "passed" ? "pass" : "fail",
+    `packages/ui/e2e/journey-61-spec-479-memex-rename.spec.ts::${testInfo.title}`,
+    testInfo.duration,
+  );
+});
+
+test("admin renames the Memex display name and URL slug from Settings (ac-1, ac-4, ac-7)", async ({
+  page,
+  resources,
+}) => {
+  await setUserName(DEV_EMAIL, "Dev User");
+  const org = await seedOrg({
+    ownerEmail: DEV_EMAIL,
+    slug: resources.slug("rename-org"),
+    memexSlug: "workspace",
+    memexName: "Workspace",
+  });
+
+  await page.goto(tenantPath(org.namespaceSlug, org.memexSlug, "/settings"));
+
+  const section = page.getByTestId("memex-rename");
+  await expect(section).toBeVisible();
+
+  // ── Display name: saves immediately, no confirm (ac-1 name half; ac-4 — a
+  //    name change shows no consequence warnings). ──
+  await page.getByTestId("memex-name-input").fill("Renamed Workspace");
+  await page.getByTestId("memex-name-save").click();
+  await expect(page.getByText("Name saved.")).toBeVisible();
+  // No slug confirm appeared for a name-only change.
+  await expect(page.getByTestId("memex-slug-confirm")).toHaveCount(0);
+
+  // ── URL slug: change → live availability clears → confirm consequences →
+  //    navigate to the new URL. ──
+  await page.getByTestId("memex-slug-input").fill("workspace-renamed");
+  const renameBtn = page.getByTestId("memex-slug-rename");
+  // Enables only once the debounced availability check reports the slug free.
+  await expect(renameBtn).toBeEnabled();
+  await renameBtn.click();
+
+  // ac-4: the confirm names the consequence (old links forward) BEFORE commit.
+  const confirm = page.getByTestId("memex-slug-confirm");
+  await expect(confirm).toBeVisible();
+  await expect(confirm).toContainText("forward");
+  await page.getByTestId("memex-slug-confirm-btn").click();
+
+  // ac-7 / ac-1 slug half: the page navigates to the new /<ns>/<new-slug>/settings
+  // URL and the settings surface renders there.
+  await expect(page).toHaveURL(
+    tenantPath(org.namespaceSlug, "workspace-renamed", "/settings"),
+  );
+  await expect(page.getByTestId("memex-rename")).toBeVisible();
+});

--- a/packages/ui/e2e/journey-61-spec-479-memex-rename.spec.ts
+++ b/packages/ui/e2e/journey-61-spec-479-memex-rename.spec.ts
@@ -15,19 +15,15 @@ import {
 //   ac-1 — an admin renames the display name AND the URL slug from the settings page
 //   ac-4 — the slug rename states its consequences before commit; the name change does not
 //   ac-7 — the settings page renders the rename section; a slug change navigates to the new URL
-//
-// OUT of scope here (deliberately): browser-level forwarding of a STALE tenant
-// PAGE url (part of ac-2). The memex_rename redirect resolves at the
-// canonical-ref / API layer — proven by the server service + redirect
-// integration tests (renameMemexSlug → lookupRedirect forwards the old path).
-// Page-route forwarding for a renamed tenant path is NOT wired in app.ts (only
-// the b-N→spec-N regex is), so asserting a browser redirect here would be
-// false. Tracked as a follow-up issue.
+//   ac-11 — a bookmarked OLD tenant page URL forwards to the new one in the browser
+//           (dec-5: TenantLayout consults GET /api/redirects/resolve on a miss)
 
 const AC = [
   "mindset-prod/memex-building-itself/specs/spec-479/acs/ac-1",
   "mindset-prod/memex-building-itself/specs/spec-479/acs/ac-4",
   "mindset-prod/memex-building-itself/specs/spec-479/acs/ac-7",
+  // ac-11 (dec-5): the stale-tenant page URL forwards in the browser.
+  "mindset-prod/memex-building-itself/specs/spec-479/acs/ac-11",
 ];
 
 test.afterEach(async ({}, testInfo) => {
@@ -85,4 +81,10 @@ test("admin renames the Memex display name and URL slug from Settings (ac-1, ac-
     tenantPath(org.namespaceSlug, "workspace-renamed", "/settings"),
   );
   await expect(page.getByTestId("memex-rename")).toBeVisible();
+
+  // ac-11 (dec-5): a bookmarked OLD url forwards to the new one in the browser.
+  await page.goto(tenantPath(org.namespaceSlug, org.memexSlug, "/settings"));
+  await expect(page).toHaveURL(
+    tenantPath(org.namespaceSlug, "workspace-renamed", "/settings"),
+  );
 });

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -131,6 +131,7 @@ import { VoiceLayer } from './voice/session/VoiceLayer';
 import { createReactRouterNavigationAdapter } from './voice/reactRouterNavigationAdapter';
 import { HandholdRevealProvider, useHandholdRevealValue } from './hooks/HandholdRevealContext';
 import { useTrackRouteChange, useTelemetry, trackAnonymous } from './hooks/useTelemetry';
+import { useStaleTenantForward } from './hooks/useStaleTenantForward';
 import { useShouldLandOnHome } from './journeys/landing';
 import { getCachedJourneyState } from './journeys/journeyStateCache';
 import { tenantBase, BASE_URL, fetchWithRetry } from './api/http';
@@ -219,9 +220,31 @@ function TenantLayout() {
   //   - private/unknown → bounce to /login (returnTo brings them back)
   // The probe stays inert for authenticated users (enabled === false).
   const probe = usePublicMemexProbe(namespace, memex, anonymous);
+
+  // spec-479 dec-5: membership match for the URL's tenant (pure — safe while
+  // session is still null). Reused below for the authed bounce.
+  const isMember =
+    !!session &&
+    session.memberships.some(
+      (m) => m.slug === namespace && (m.memexSlug === memex || (!m.memexSlug && memex === 'main')),
+    );
+  // A stale tenant URL (a memex whose slug was renamed) would otherwise bounce
+  // to /login (anonymous) or the default landing (authed non-member). Before
+  // bouncing, ask the server whether the path forwards. Fires ONLY on the miss.
+  const staleForward =
+    (anonymous && probe.state === 'no') ||
+    (!anonymous &&
+      !!session &&
+      session.user.emailVerified &&
+      !!session.user.name &&
+      !isMember);
+  const forward = useStaleTenantForward(location.pathname, staleForward);
+
   if (anonymous) {
     if (probe.state === 'loading') return null; // transient — avoid flashing the wrong UI
     if (probe.state === 'no') {
+      if (forward.state === 'loading') return null;
+      if (forward.to) return <Navigate to={`${forward.to}${location.search}`} replace />;
       const returnTo = encodeURIComponent(location.pathname + location.search);
       return <Navigate to={`/login?returnTo=${returnTo}`} replace />;
     }
@@ -278,11 +301,10 @@ function TenantLayout() {
   // a member of the URL's namespace/memex. This replaces the host-based
   // PostLoginRouter redirect (which used to bounce non-members back to the
   // bare base domain).
-  const ok = session.memberships.some(
-    (m) => m.slug === namespace && (m.memexSlug === memex || (!m.memexSlug && memex === 'main')),
-  );
-
-  if (!ok) {
+  if (!isMember) {
+    // spec-479 dec-5: a renamed memex's old URL forwards here before bouncing.
+    if (forward.state === 'loading') return null;
+    if (forward.to) return <Navigate to={`${forward.to}${location.search}`} replace />;
     const fallback = computeDefaultLanding(session);
     if (fallback) return <Navigate to={fallback} replace />;
     return <Navigate to="/" replace />;

--- a/packages/ui/src/api/memex.ts
+++ b/packages/ui/src/api/memex.ts
@@ -100,6 +100,28 @@ export async function renameMemexSlugApi(
   return (body as { memex: MemexVisibilityDto }).memex;
 }
 
+/**
+ * spec-479 dec-5 — resolve a stale tenant PAGE path to its current path after a
+ * rename. The SPA is served statically, so a bookmarked `/<ns>/<old-mx>/…` never
+ * hits the server redirect layer; TenantLayout calls this on a resolution miss
+ * and forwards on a hit. Returns the new absolute path, or null (no redirect /
+ * error) so the caller falls through to its normal bounce. Sends no auth header
+ * — it only resolves a path; the destination gates access on navigation.
+ */
+export async function resolveTenantRedirectApi(pathname: string): Promise<string | null> {
+  try {
+    const res = await fetch(
+      `${BASE_URL}/redirects/resolve?path=${encodeURIComponent(pathname)}`,
+      { headers: { Accept: 'application/json' } },
+    );
+    if (!res.ok) return null;
+    const body = (await res.json()) as { redirected?: string };
+    return body.redirected ?? null;
+  } catch {
+    return null;
+  }
+}
+
 /** The public-facing Memex shape returned by the slug-based readability probe. */
 export interface PublicMemexProbe {
   id: string;

--- a/packages/ui/src/api/memex.ts
+++ b/packages/ui/src/api/memex.ts
@@ -56,6 +56,50 @@ export async function updateMemexVisibilityApi(
   return (body as { memex: MemexVisibilityDto }).memex;
 }
 
+/**
+ * Rename a Memex's display name (spec-479). Owner/admin-gated server-side; the
+ * URL/slug is untouched. Returns the updated row.
+ */
+export async function updateMemexNameApi(
+  memexId: string,
+  name: string,
+  token: string | null,
+): Promise<MemexVisibilityDto> {
+  const res = await fetchWithRetry(`${tBase()}/memexes/${memexId}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json', ...authHeaders(token) },
+    body: JSON.stringify({ name }),
+  });
+  const body = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    throw new Error(body.error ?? body.message ?? `Rename failed: ${res.status}`);
+  }
+  return (body as { memex: MemexVisibilityDto }).memex;
+}
+
+/**
+ * Rename a Memex's URL slug (spec-479). Owner/admin-gated. The server writes a
+ * memex_rename redirect so old links keep working; a slug that is taken or
+ * reserved by a prior rename returns 409 (surfaced as the thrown message). The
+ * returned row carries the new slug — the caller navigates to the new URL.
+ */
+export async function renameMemexSlugApi(
+  memexId: string,
+  slug: string,
+  token: string | null,
+): Promise<MemexVisibilityDto> {
+  const res = await fetchWithRetry(`${tBase()}/memexes/${memexId}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json', ...authHeaders(token) },
+    body: JSON.stringify({ slug }),
+  });
+  const body = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    throw new Error(body.error ?? body.message ?? `Rename failed: ${res.status}`);
+  }
+  return (body as { memex: MemexVisibilityDto }).memex;
+}
+
 /** The public-facing Memex shape returned by the slug-based readability probe. */
 export interface PublicMemexProbe {
   id: string;

--- a/packages/ui/src/components/RenameMemexSection.test.tsx
+++ b/packages/ui/src/components/RenameMemexSection.test.tsx
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { tagAc } from '@memex-ai-ac/vitest';
+
+// spec-479 t-4 — component-level verification of the rename controls. Proves the
+// UI behaviour (name saves via the API; slug rename is gated on live
+// availability, states consequences before commit, then renames + navigates to
+// the new URL) with the API + router mocked. The full-page journey (journey-61)
+// covers ac-1 end-to-end in CI's cold-DB gate.
+const AC_UI = 'mindset-prod/memex-building-itself/specs/spec-479/acs/ac-7';
+const AC_UX = 'mindset-prod/memex-building-itself/specs/spec-479/acs/ac-4';
+
+const navigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual =
+    await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return { ...actual, useNavigate: () => navigate };
+});
+
+vi.mock('./AuthContext', () => ({
+  useAuth: () => ({ token: 'test-token' }),
+}));
+
+const fetchMemexApi = vi.fn();
+const updateMemexNameApi = vi.fn();
+const renameMemexSlugApi = vi.fn();
+const checkMemexSlugApi = vi.fn();
+vi.mock('../api/client', () => ({
+  fetchMemexApi: (...a: unknown[]) => fetchMemexApi(...a),
+  updateMemexNameApi: (...a: unknown[]) => updateMemexNameApi(...a),
+  renameMemexSlugApi: (...a: unknown[]) => renameMemexSlugApi(...a),
+  checkMemexSlugApi: (...a: unknown[]) => checkMemexSlugApi(...a),
+}));
+
+import { RenameMemexSection } from './RenameMemexSection';
+
+const MEMEX = {
+  id: 'm1',
+  namespaceId: 'ns-uuid',
+  slug: 'workspace',
+  name: 'Workspace',
+  visibility: 'private' as const,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  fetchMemexApi.mockResolvedValue({ ...MEMEX });
+});
+
+function renderSection() {
+  return render(
+    <MemoryRouter>
+      <RenameMemexSection memexId="m1" namespaceSlug="ns" />
+    </MemoryRouter>,
+  );
+}
+
+describe('RenameMemexSection (spec-479 t-4)', () => {
+  it('saves the display name via updateMemexNameApi and shows no slug confirm', async () => {
+    tagAc(AC_UI);
+    updateMemexNameApi.mockResolvedValue({ ...MEMEX, name: 'Renamed' });
+    const user = userEvent.setup();
+    renderSection();
+
+    const nameInput = await screen.findByTestId('memex-name-input');
+    await user.clear(nameInput);
+    await user.type(nameInput, 'Renamed');
+    await user.click(screen.getByTestId('memex-name-save'));
+
+    await waitFor(() =>
+      expect(updateMemexNameApi).toHaveBeenCalledWith('m1', 'Renamed', 'test-token'),
+    );
+    expect(await screen.findByText('Name saved.')).toBeInTheDocument();
+    // ac-4: a name change never surfaces the slug consequence confirm.
+    expect(screen.queryByTestId('memex-slug-confirm')).toBeNull();
+  });
+
+  it('gates the slug rename on availability, confirms consequences, then renames + navigates', async () => {
+    tagAc(AC_UI);
+    tagAc(AC_UX);
+    checkMemexSlugApi.mockResolvedValue({ available: true });
+    renameMemexSlugApi.mockResolvedValue({ ...MEMEX, slug: 'renamed' });
+    const user = userEvent.setup();
+    renderSection();
+
+    const slugInput = await screen.findByTestId('memex-slug-input');
+    await user.clear(slugInput);
+    await user.type(slugInput, 'renamed');
+
+    const renameBtn = screen.getByTestId('memex-slug-rename');
+    await waitFor(() => expect(renameBtn).toBeEnabled());
+    await user.click(renameBtn);
+
+    // ac-4: consequences stated BEFORE commit.
+    const confirm = await screen.findByTestId('memex-slug-confirm');
+    expect(confirm).toHaveTextContent(/forward/i);
+
+    await user.click(screen.getByTestId('memex-slug-confirm-btn'));
+    await waitFor(() =>
+      expect(renameMemexSlugApi).toHaveBeenCalledWith('m1', 'renamed', 'test-token'),
+    );
+    // ac-7: navigates to the new /<ns>/<new-slug>/settings URL.
+    expect(navigate).toHaveBeenCalledWith('/ns/renamed/settings', { replace: true });
+  });
+
+  it('blocks the rename and explains when the slug is reserved by a prior rename', async () => {
+    tagAc(AC_UX);
+    checkMemexSlugApi.mockResolvedValue({ available: false, reason: 'redirected' });
+    const user = userEvent.setup();
+    renderSection();
+
+    const slugInput = await screen.findByTestId('memex-slug-input');
+    await user.clear(slugInput);
+    await user.type(slugInput, 'oldname');
+
+    await waitFor(() =>
+      expect(screen.getByTestId('memex-slug-unavailable')).toBeInTheDocument(),
+    );
+    expect(screen.getByTestId('memex-slug-unavailable')).toHaveTextContent(/reserved/i);
+    expect(screen.getByTestId('memex-slug-rename')).toBeDisabled();
+  });
+});

--- a/packages/ui/src/components/RenameMemexSection.test.tsx
+++ b/packages/ui/src/components/RenameMemexSection.test.tsx
@@ -19,8 +19,9 @@ vi.mock('react-router-dom', async () => {
   return { ...actual, useNavigate: () => navigate };
 });
 
+const refreshSession = vi.fn();
 vi.mock('./AuthContext', () => ({
-  useAuth: () => ({ token: 'test-token' }),
+  useAuth: () => ({ token: 'test-token', refreshSession }),
 }));
 
 const fetchMemexApi = vi.fn();
@@ -47,6 +48,7 @@ const MEMEX = {
 beforeEach(() => {
   vi.clearAllMocks();
   fetchMemexApi.mockResolvedValue({ ...MEMEX });
+  refreshSession.mockResolvedValue(undefined);
 });
 
 function renderSection() {
@@ -100,6 +102,14 @@ describe('RenameMemexSection (spec-479 t-4)', () => {
     await user.click(screen.getByTestId('memex-slug-confirm-btn'));
     await waitFor(() =>
       expect(renameMemexSlugApi).toHaveBeenCalledWith('m1', 'renamed', 'test-token'),
+    );
+    await waitFor(() => expect(navigate).toHaveBeenCalled());
+    // The session MUST refresh before navigating — otherwise TenantLayout gates
+    // the new URL on stale membership (old slug) and bounces to the default
+    // landing. This is the exact regression CI's journey-61 caught.
+    expect(refreshSession).toHaveBeenCalled();
+    expect(refreshSession.mock.invocationCallOrder[0]).toBeLessThan(
+      navigate.mock.invocationCallOrder[0],
     );
     // ac-7: navigates to the new /<ns>/<new-slug>/settings URL.
     expect(navigate).toHaveBeenCalledWith('/ns/renamed/settings', { replace: true });

--- a/packages/ui/src/components/RenameMemexSection.tsx
+++ b/packages/ui/src/components/RenameMemexSection.tsx
@@ -28,7 +28,7 @@ export function RenameMemexSection({
   memexId: string;
   namespaceSlug: string;
 }) {
-  const { token } = useAuth();
+  const { token, refreshSession } = useAuth();
   const navigate = useNavigate();
   const [memex, setMemex] = useState<MemexVisibilityDto | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -101,12 +101,14 @@ export function RenameMemexSection({
       setMemex(updated);
       setName(updated.name);
       setNameSaved(true);
+      // Keep the session's membership label (sidebar switcher) in sync.
+      await refreshSession();
     } catch (err) {
       setError((err as Error).message);
     } finally {
       setSavingName(false);
     }
-  }, [memex, name, memexId, token]);
+  }, [memex, name, memexId, token, refreshSession]);
 
   const onConfirmRename = useCallback(async () => {
     if (!memex) return;
@@ -115,15 +117,18 @@ export function RenameMemexSection({
     setError(null);
     try {
       const updated = await renameMemexSlugApi(memexId, trimmed, token);
-      // The page's own URL is now stale — navigate to the new address. The slug
-      // is server-validated ([a-z0-9-]) so the path is safe/same-origin.
+      // Refresh the session FIRST: its membership rows still carry the old slug,
+      // and TenantLayout gates the new URL on membership — navigating before the
+      // refresh bounces the user to their default landing. Only then navigate to
+      // the new address (server-validated slug → safe/same-origin path).
+      await refreshSession();
       navigate(`/${namespaceSlug}/${updated.slug}/settings`, { replace: true });
     } catch (err) {
       setError((err as Error).message);
       setRenaming(false);
       setConfirming(false);
     }
-  }, [memex, slug, memexId, token, namespaceSlug, navigate]);
+  }, [memex, slug, memexId, token, namespaceSlug, navigate, refreshSession]);
 
   if (!memex) {
     return error ? (

--- a/packages/ui/src/components/RenameMemexSection.tsx
+++ b/packages/ui/src/components/RenameMemexSection.tsx
@@ -1,0 +1,244 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Button } from './ui/Button';
+import { Input } from './ui/Input';
+import { Alert } from './ui/Alert';
+import { useAuth } from './AuthContext';
+import {
+  fetchMemexApi,
+  updateMemexNameApi,
+  renameMemexSlugApi,
+  checkMemexSlugApi,
+  type MemexVisibilityDto,
+} from '../api/client';
+
+// spec-479 t-4 — rename controls on the per-Memex settings page, beside the
+// visibility editor. Two independent actions (D-2):
+//   • Display name saves immediately — no URL impact, no confirm.
+//   • URL slug is the address segment; renaming it changes every link, so it
+//     goes through a confirm and, on success, navigates to the new
+//     /<ns>/<new-slug>/settings URL. Old links keep working via the server's
+//     memex_rename redirect (std-10 §7), and the freed slug can't be reused
+//     while that redirect is live (D-4) — surfaced by the live availability
+//     check as "reserved".
+export function RenameMemexSection({
+  memexId,
+  namespaceSlug,
+}: {
+  memexId: string;
+  namespaceSlug: string;
+}) {
+  const { token } = useAuth();
+  const navigate = useNavigate();
+  const [memex, setMemex] = useState<MemexVisibilityDto | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const [name, setName] = useState('');
+  const [savingName, setSavingName] = useState(false);
+  const [nameSaved, setNameSaved] = useState(false);
+
+  const [slug, setSlug] = useState('');
+  const [check, setCheck] = useState<{ available: boolean; reason?: string } | null>(null);
+  const [checking, setChecking] = useState(false);
+  const [confirming, setConfirming] = useState(false);
+  const [renaming, setRenaming] = useState(false);
+  const checkSeq = useRef(0);
+
+  const refresh = useCallback(async () => {
+    try {
+      setError(null);
+      const data = await fetchMemexApi(memexId, token);
+      setMemex(data);
+      setName(data.name);
+      setSlug(data.slug);
+    } catch (err) {
+      setError((err as Error).message);
+    }
+  }, [memexId, token]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  // Live slug availability — 400ms debounce, seq-guarded (mirrors CreateOrgForm),
+  // only while the slug differs from the persisted value.
+  useEffect(() => {
+    if (!memex) return;
+    const trimmed = slug.trim().toLowerCase();
+    if (!trimmed || trimmed === memex.slug) {
+      setCheck(null);
+      setChecking(false);
+      return;
+    }
+    setChecking(true);
+    const seq = ++checkSeq.current;
+    const handle = window.setTimeout(async () => {
+      try {
+        const result = await checkMemexSlugApi(memex.namespaceId, trimmed, token);
+        if (checkSeq.current === seq) {
+          setCheck(result);
+          setChecking(false);
+        }
+      } catch {
+        if (checkSeq.current === seq) {
+          setCheck(null);
+          setChecking(false);
+        }
+      }
+    }, 400);
+    return () => window.clearTimeout(handle);
+  }, [slug, memex, token]);
+
+  const onSaveName = useCallback(async () => {
+    if (!memex) return;
+    const trimmed = name.trim();
+    if (!trimmed || trimmed === memex.name) return;
+    setSavingName(true);
+    setError(null);
+    setNameSaved(false);
+    try {
+      const updated = await updateMemexNameApi(memexId, trimmed, token);
+      setMemex(updated);
+      setName(updated.name);
+      setNameSaved(true);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setSavingName(false);
+    }
+  }, [memex, name, memexId, token]);
+
+  const onConfirmRename = useCallback(async () => {
+    if (!memex) return;
+    const trimmed = slug.trim().toLowerCase();
+    setRenaming(true);
+    setError(null);
+    try {
+      const updated = await renameMemexSlugApi(memexId, trimmed, token);
+      // The page's own URL is now stale — navigate to the new address. The slug
+      // is server-validated ([a-z0-9-]) so the path is safe/same-origin.
+      navigate(`/${namespaceSlug}/${updated.slug}/settings`, { replace: true });
+    } catch (err) {
+      setError((err as Error).message);
+      setRenaming(false);
+      setConfirming(false);
+    }
+  }, [memex, slug, memexId, token, namespaceSlug, navigate]);
+
+  if (!memex) {
+    return error ? (
+      <div className="text-sm text-status-danger-text">{error}</div>
+    ) : (
+      <div className="text-sm text-muted">Loading…</div>
+    );
+  }
+
+  const trimmedSlug = slug.trim().toLowerCase();
+  const slugChanged = trimmedSlug !== '' && trimmedSlug !== memex.slug;
+  const slugAvailable = check?.available === true;
+
+  return (
+    <section className="space-y-6" data-testid="memex-rename">
+      <div>
+        <h3 className="text-sm font-semibold text-heading">Rename</h3>
+        <p className="text-sm text-secondary mt-1">
+          Change this Memex's display name or its URL address.
+        </p>
+      </div>
+
+      {error && (
+        <Alert variant="danger" size="md">
+          {error}
+        </Alert>
+      )}
+
+      <div className="space-y-2">
+        <label className="block text-sm text-secondary">
+          Display name
+          <div className="flex gap-2 mt-1">
+            <Input
+              value={name}
+              onChange={(e) => {
+                setName(e.target.value);
+                setNameSaved(false);
+              }}
+              data-testid="memex-name-input"
+            />
+            <Button
+              onClick={onSaveName}
+              disabled={savingName || !name.trim() || name.trim() === memex.name}
+              data-testid="memex-name-save"
+            >
+              Save
+            </Button>
+          </div>
+        </label>
+        {nameSaved && <div className="text-xs text-status-success-text">Name saved.</div>}
+      </div>
+
+      <div className="space-y-2">
+        <label className="block text-sm text-secondary">
+          URL address
+          <div className="flex gap-2 mt-1">
+            <Input
+              value={slug}
+              onChange={(e) => {
+                setSlug(e.target.value);
+                setConfirming(false);
+              }}
+              data-testid="memex-slug-input"
+            />
+            <Button
+              variant="secondary"
+              onClick={() => setConfirming(true)}
+              disabled={!slugChanged || !slugAvailable || checking}
+              data-testid="memex-slug-rename"
+            >
+              Rename URL
+            </Button>
+          </div>
+        </label>
+        <p className="text-xs text-muted">
+          memex.ai/{namespaceSlug}/
+          <span className="text-primary">{trimmedSlug || memex.slug}</span>
+        </p>
+        {slugChanged && !checking && check && !check.available && (
+          <div className="text-xs text-status-danger-text" data-testid="memex-slug-unavailable">
+            {check.reason === 'redirected'
+              ? 'That address was used before and is reserved by a redirect.'
+              : check.reason === 'taken'
+                ? 'That address is already taken in this namespace.'
+                : "That address isn't valid."}
+          </div>
+        )}
+      </div>
+
+      {confirming && (
+        <div
+          className="space-y-3 p-3 rounded-lg border border-edge bg-card"
+          data-testid="memex-slug-confirm"
+        >
+          <p className="text-sm text-primary">
+            Rename the URL to <code>{trimmedSlug}</code>?
+          </p>
+          <ul className="text-xs text-secondary list-disc pl-5 space-y-1">
+            <li>Old links keep working — they forward to the new address.</li>
+            <li>The old address can't be reused while that forward is live.</li>
+          </ul>
+          <div className="flex gap-2">
+            <Button
+              onClick={onConfirmRename}
+              disabled={renaming}
+              data-testid="memex-slug-confirm-btn"
+            >
+              {renaming ? 'Renaming…' : 'Confirm rename'}
+            </Button>
+            <Button variant="ghost" onClick={() => setConfirming(false)} disabled={renaming}>
+              Cancel
+            </Button>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/packages/ui/src/hooks/useStaleTenantForward.test.ts
+++ b/packages/ui/src/hooks/useStaleTenantForward.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { tagAc } from '@memex-ai-ac/vitest';
+
+// spec-479 t-6 — the fetch-and-decide logic behind the stale-tenant forward.
+// The end-to-end forward (TenantLayout navigating a renamed memex's old URL to
+// the new one) is exercised by journey-61 in CI; this proves the hook's
+// contract locally.
+const AC = 'mindset-prod/memex-building-itself/specs/spec-479/acs/ac-11';
+
+const resolveTenantRedirectApi = vi.fn();
+vi.mock('../api/client', () => ({
+  resolveTenantRedirectApi: (...a: unknown[]) => resolveTenantRedirectApi(...a),
+}));
+
+import { useStaleTenantForward } from './useStaleTenantForward';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useStaleTenantForward (spec-479 t-6)', () => {
+  it('stays idle and never fetches when disabled', () => {
+    tagAc(AC);
+    const { result } = renderHook(() =>
+      useStaleTenantForward('/ns/old/specs/spec-1', false),
+    );
+    expect(result.current.state).toBe('idle');
+    expect(resolveTenantRedirectApi).not.toHaveBeenCalled();
+  });
+
+  it('resolves to the forwarded path on a hit', async () => {
+    tagAc(AC);
+    resolveTenantRedirectApi.mockResolvedValue('/ns/new/specs/spec-1');
+    const { result } = renderHook(() =>
+      useStaleTenantForward('/ns/old/specs/spec-1', true),
+    );
+    expect(result.current.state).toBe('loading');
+    await waitFor(() => expect(result.current.state).toBe('done'));
+    expect(result.current.to).toBe('/ns/new/specs/spec-1');
+    expect(resolveTenantRedirectApi).toHaveBeenCalledWith('/ns/old/specs/spec-1');
+  });
+
+  it('resolves to null (caller falls through) on a miss', async () => {
+    tagAc(AC);
+    resolveTenantRedirectApi.mockResolvedValue(null);
+    const { result } = renderHook(() =>
+      useStaleTenantForward('/ns/old/specs/spec-1', true),
+    );
+    await waitFor(() => expect(result.current.state).toBe('done'));
+    expect(result.current.to).toBeNull();
+  });
+});

--- a/packages/ui/src/hooks/useStaleTenantForward.ts
+++ b/packages/ui/src/hooks/useStaleTenantForward.ts
@@ -1,0 +1,44 @@
+import { useEffect, useState } from 'react';
+import { resolveTenantRedirectApi } from '../api/client';
+
+// spec-479 dec-5 — when TenantLayout can't resolve the URL's tenant (a memex
+// whose slug was renamed), ask the server whether the path forwards, so the SPA
+// can navigate there instead of bouncing to /login (anonymous) or the default
+// landing (authed non-member).
+//
+// Fires ONLY when `enabled` (i.e. we're already on a resolution miss and about
+// to bounce) — never on a normal successful load. While the lookup is in
+// flight the caller should render nothing (avoid flashing the bounce); on a hit
+// it navigates to `to`; on a miss/error it falls through to the normal bounce.
+export type StaleForward =
+  | { state: 'idle'; to: null }
+  | { state: 'loading'; to: null }
+  | { state: 'done'; to: string | null };
+
+export function useStaleTenantForward(pathname: string, enabled: boolean): StaleForward {
+  // undefined = not yet resolved this cycle; null = miss; string = hit.
+  const [to, setTo] = useState<string | null | undefined>(undefined);
+
+  useEffect(() => {
+    if (!enabled) {
+      setTo(undefined);
+      return;
+    }
+    let cancelled = false;
+    setTo(undefined);
+    resolveTenantRedirectApi(pathname)
+      .then((result) => {
+        if (!cancelled) setTo(result);
+      })
+      .catch(() => {
+        if (!cancelled) setTo(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [pathname, enabled]);
+
+  if (!enabled) return { state: 'idle', to: null };
+  if (to === undefined) return { state: 'loading', to: null };
+  return { state: 'done', to: typeof to === 'string' ? to : null };
+}

--- a/packages/ui/src/pages/MemexSettings.tsx
+++ b/packages/ui/src/pages/MemexSettings.tsx
@@ -14,6 +14,7 @@ import { useLocation } from 'react-router-dom';
 import { useAuth } from '../components/AuthContext';
 import { parseTenantFromPathname } from '../utils/tenantUrl';
 import { MemexVisibilitySettings } from '../components/MemexVisibilitySettings';
+import { RenameMemexSection } from '../components/RenameMemexSection';
 import { PageHeader } from '../components/PageHeader';
 
 export function MemexSettings() {
@@ -48,8 +49,14 @@ export function MemexSettings() {
       <PageHeader title="Settings" />
       {memexId ? (
         // Emission keys moved to their own member-visible page (spec-129 dec-8,
-        // Option B): /<ns>/<mx>/keys. This admin-only page keeps Memex visibility.
-        <MemexVisibilitySettings memexId={memexId} />
+        // Option B): /<ns>/<mx>/keys. This admin-only page keeps Memex visibility
+        // and (spec-479) the rename controls.
+        <>
+          {tenant?.namespace && (
+            <RenameMemexSection memexId={memexId} namespaceSlug={tenant.namespace} />
+          )}
+          <MemexVisibilitySettings memexId={memexId} />
+        </>
       ) : (
         <div className="text-sm text-muted">No Memex selected.</div>
       )}


### PR DESCRIPTION
## Why
A question — "can I rename a Memex space?" — surfaced that **nothing renames a Memex today** (only visibility is mutable; the historical rename was direct SQL). This builds it end-to-end and fixes a std-10 §7 redirect drift found along the way. Full record: **[spec-479](https://memex.ai/mindset-prod/memex-building-itself/specs/spec-479)**.

## What (6 tasks, dependency order)
1. **Redirect validator (t-1)** — `insertRedirect` reason-gated: `namespace_rename` = 1-segment slug prefix, `memex_rename` = 2-segment `ns/mx` prefix; other reasons keep the strict 4/6-segment `parseRef`. Segments validated via the slug authority (`validateSlugFormat`), so digit-leading slugs work. **Closes the std-10 §7 drift** — those reasons were previously un-insertable. No migration (the DB CHECK already allowed them).
2. **Services (t-2)** — `renameMemexSlug` (slug + `memex_rename` redirect atomically in one tx via `mutate()`, std-8) and `updateMemexName`. **D-4 reuse-guard**: `isMemexSlugAvailable` rejects a slug that is the source of a live redirect (reason `redirected`) so a fresh Memex can't shadow an outstanding rename. No cooldown/reservation — memex slugs are per-namespace, not std-3's global pool.
3. **Route (t-3)** — `PATCH /api/:ns/:memex/memexes/:id` accepts exactly one of `{ visibility | name | slug }`; admin-gated (std-7 404), `ConflictError`→409 / `NotFoundError`→404 / `ValidationError`→400.
4. **UI (t-4)** — a Rename section on the Memex Settings page: display-name (saves immediately) + URL-slug (live availability, consequences confirm, navigates to the new URL on success).
5. **std-3 amendment (t-5)** — proposed clause documenting the memex-slug lifecycle (`propose_standard_change` → std-3 c-3).
6. **Page-forward (t-6 / issue-1)** — new public `GET /api/redirects/resolve` + `TenantLayout` client-side forward, so a bookmarked old tenant URL forwards in the browser after a rename (the SPA is CDN-served and never hit the server redirect layer).

## Test plan
- **Server:** 5730 tests green (full suite). New: `redirects` prefix rows + rewrite, `renameMemexSlug`/reuse-guard, route name/slug/409, `redirects/resolve`. Verified ac-5/6/8/9/10/11.
- **UI:** 2135 tests green (full suite). New: `RenameMemexSection` (ac-7/4) + `useStaleTenantForward` (ac-11) component/hook tests.
- **e2e:** `journey-61` added (rename flow + browser forward), covers scope ac-1/ac-2 — **runs here in CI's cold-DB gate** (local cold-DB harness is broken, unrelated).
- `tsc` clean (server + ui). Two local failures are non-regressions: `.ee/slack/oauth` (documented local-red/CI-green flake) and `e2e-ac-emission.spec-391` (only fails under the `MEMEX_EMIT=false` dry-run flag; passes normally).

## Notes for review
- **Drift filed:** std-10 c-3 (redirect drift, now fixed), std-3 c-3 (memex-slug amendment), std-3 c-4 (reserved-list vs code drift — pre-existing, unrelated).
- **Follow-up:** spec-481 (namespace rename) — backend already works; it now reuses the `redirects/resolve` endpoint verbatim, so it's just UI wiring.
- No DB migration; deploy is code-only (server before SPA so the new endpoint exists before the SPA calls it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)