### PR TITLE
spec-482 dec-10: connect handoff as one copyable-steps card (atomic per-step copy)

### DIFF
--- a/packages/server/src/agent/context-builder.ts
+++ b/packages/server/src/agent/context-builder.ts
@@ -20,6 +20,13 @@ import { NotFoundError } from "../types/errors.js";
 export type DocumentContext = {
   context: string;
   phase: SpecPhase;
+  // spec-482 dec-10: the doc's canonical ref (`namespace/memex/specs/spec-N`). The
+  // landing route turns it into the Spec's public URL (`${APP_BASE_URL}/${docRef}`)
+  // to inject as the copyable Spec URL in the disconnected connect-handoff card, so
+  // the agent copies a REAL URL, never one it invented. Optional: only the real
+  // per-doc context (buildDocumentContext) sets it; the doc-less contexts (drift,
+  // scaffold, standards, issues, skills) omit it.
+  docRef?: string;
 };
 
 /**
@@ -177,6 +184,7 @@ export async function buildDocumentContext(
   return {
     context: lines.join("\n"),
     phase: statusToPhase(doc.status),
+    docRef,
   };
 }
 

--- a/packages/server/src/agent/system-prompt.spec-482.test.ts
+++ b/packages/server/src/agent/system-prompt.spec-482.test.ts
@@ -38,16 +38,20 @@ function posture(
   entry: "landing" | "return",
   mcpConnected: boolean,
   phaseWatermark: PhaseWatermark,
-  connectMcp?: { installCommand: string; mcpUrl: string },
+  connectMcp?: { installCommand: string; mcpUrl: string; specUrl: string },
 ): OpeningPosture {
   return { entry, mcpConnected, phaseWatermark, connectMcp };
 }
 
-// The route-injected real connect command (deriveConnectMcp) for the disconnected tier.
+// The route-injected real connect values (deriveConnectMcp) for the disconnected tier:
+// the working install command, the MCP endpoint, and THIS Spec's canonical URL.
 const CONNECT = {
   installCommand: "npx -y memex-ai install --api-base https://int.memex.ai",
   mcpUrl: "https://int.memex.ai/mcp",
+  specUrl: "https://int.memex.ai/mindset-prod/memex-building-itself/specs/spec-2",
 };
+// The ready-to-paste step-3 prompt the tier composes from the injected Spec URL.
+const PASTE_PROMPT = `Use the Memex MCP on this Spec: ${CONNECT.specUrl}`;
 
 // Distinctive, stable phrases from each prose block (single-sourced in scaffold-data.ts).
 const WHY_FIRST = "Lead with WHY it matters, grounded in THIS specific Spec";
@@ -62,10 +66,13 @@ const WHATS_OPEN = "unresolved decisions"; // the shared "what's open" reading
 const TIER_MCP_ONE_LINE = "AT MOST ONE line";
 const TIER_MCP_NO_QUESTION = "ask NO clarifying question";
 const TIER_MCP_CONNECT_NOT_INSTALL = 'Always say "connect" — NEVER "install"';
-// t-12 (dec-7 revised): the handoff is delivered as prose + a render_handoff Copy
-// block — never a persistent card, never inline copyable text.
-const COPY_BUTTON_RULE = 'renders with a Copy button';
+// dec-10: copyable text is delivered through a Copy-button affordance, each copying
+// EXACTLY one value — never inline, never a persistent card. The connect handoff is
+// ONE render_steps card of three atomic copy steps (not a render_handoff blob).
+const COPY_ATOMIC_RULE = 'Each Copy button copies EXACTLY ONE value';
 const COPY_NO_INLINE = 'NEVER as inline copyable text';
+const CONNECT_ONE_CARD = 'ONE `render_steps` card of THREE copyable steps';
+const CONNECT_NO_HANDOFF = 'Do NOT also emit a `render_handoff`';
 const HANDOFF_PASTE_STEP = 'use the Memex MCP on this Spec';
 const TIER_BUILD = "Explain what BUILD means";
 const TIER_VERIFY = "Teach ONLY verify";
@@ -182,58 +189,69 @@ describe("spec-482 t-5 — tiers gated by mcpConnected then phaseWatermark", () 
     expect(p).not.toContain(TIER_EXPERIENCED);
   });
 
-  it("ac-5 / ac-25: the connect tier delivers the 3-step handoff, with copyable text via a render_handoff Copy button (never a card, never inline)", () => {
+  it("ac-5 / ac-27: the connect tier delivers the 3-step handoff as ONE copyable-steps card — no render_handoff blob, no duplicate list", () => {
     tagAc(AC(5));
-    // ac-25 (dec-8): the connect tier reuses the existing connect path via render_handoff,
-    // says "connect" not "install", and hand-rolls no per-tool instruction matrix.
-    tagAc(AC(25));
+    // ac-27 (dec-10): one render_steps card of three atomic copy steps; the tier
+    // explicitly forbids also emitting a render_handoff and forbids a second list.
+    tagAc(AC(27));
     const p = specPrompt(posture("landing", false, "none"));
-    // The three-step sequence: connect → copy URL → paste + tell it to use MCP.
-    expect(p).toContain("copy THIS Spec");
+    // The three-step sequence: connect → give it the Spec (URL) → tell it to build.
+    expect(p).toContain(CONNECT_ONE_CARD);
+    expect(p).toContain("this Spec’s URL");
     expect(p).toContain(HANDOFF_PASTE_STEP);
     expect(p).toContain(TIER_MCP_CONNECT_NOT_INSTALL);
-    // Every copyable piece rides a render_handoff Copy button — not inline prose,
-    // and (post-t-12) not a persistent on-screen card.
-    expect(p).toContain("render_handoff");
-    expect(p).toContain(COPY_BUTTON_RULE);
+    // Delivered via the copyable-steps card — not a render_handoff blob, not inline.
+    expect(p).toContain(CONNECT_NO_HANDOFF);
+    expect(p).toContain("do NOT emit a second numbered list");
     expect(p).toContain(COPY_NO_INLINE);
   });
 
-  it("ac-5: the copyable-text-via-render_handoff rule is cross-tier (present even once connected)", () => {
+  it("ac-5: the copyable-text-via-Copy-button rule is cross-tier (present even once connected)", () => {
     tagAc(AC(5));
     // The COPYABLE TEXT RULE lives in the shared why-first preamble, so it governs
-    // every tier — a connected user copying a build-handoff prompt gets a Copy button too.
+    // every tier — a connected user copying a build-handoff prompt gets an atomic Copy too.
     for (const wm of ["none", "specify_build", "verify_done"] as PhaseWatermark[]) {
       const p = specPrompt(posture("landing", true, wm));
+      expect(p).toContain(COPY_ATOMIC_RULE);
+      // Both copy affordances are named as the sanctioned homes for copyable bytes.
       expect(p).toContain("render_handoff");
-      expect(p).toContain(COPY_BUTTON_RULE);
+      expect(p).toContain("render_steps");
     }
   });
 
-  it("ac-5 / ac-25: the disconnected tier carries the route-injected REAL install command verbatim, for the render_handoff", () => {
-    tagAc(AC(5));
+  it("ac-25 / ac-27 / ac-28: the disconnected tier carries the route-injected REAL command + Spec URL verbatim, placed into the step copies", () => {
+    // ac-25 (dec-8): still reuses the existing connect path — the route derives the
+    // real host-aware command (no per-tool matrix); now placed into the card's steps.
     tagAc(AC(25));
+    tagAc(AC(27));
+    // ac-28 (dec-10): the route injects the real command, MCP URL, and Spec URL; the
+    // prose tells the agent to place each VERBATIM into a render_steps step `copy`.
+    tagAc(AC(28));
     const p = specPrompt(posture("landing", false, "none", CONNECT));
-    // The exact installer command + MCP URL appear verbatim (not paraphrased).
+    // The exact installer command, MCP endpoint, Spec URL, and ready-to-paste prompt
+    // all appear verbatim (not paraphrased, not invented).
     expect(p).toContain(CONNECT.installCommand);
     expect(p).toContain(CONNECT.mcpUrl);
-    // With the explicit instruction to place it in the render_handoff unaltered.
-    expect(p).toContain("put it in your render_handoff VERBATIM");
-    expect(p).toContain("render_handoff");
+    expect(p).toContain(CONNECT.specUrl);
+    expect(p).toContain(PASTE_PROMPT);
+    // With the explicit instruction to place each into a step copy, unaltered.
+    expect(p).toContain("place each into a step `copy` VERBATIM");
+    expect(p).toContain(CONNECT_ONE_CARD);
   });
 
-  it("ac-25: the injected connect command rides ONLY the disconnected tier — never a connected one", () => {
-    tagAc(AC(25));
-    // Connected tiers must not leak the install command even if one is (defensively) passed.
+  it("ac-28: the injected connect values ride ONLY the disconnected tier — never a connected one", () => {
+    tagAc(AC(28));
+    // Connected tiers must not leak the install command / Spec URL even if (defensively) passed.
     for (const wm of ["none", "specify_build", "verify_done"] as PhaseWatermark[]) {
       const p = specPrompt(posture("landing", true, wm, CONNECT));
       expect(p).not.toContain(CONNECT.installCommand);
-      expect(p).not.toContain("put it in your render_handoff VERBATIM");
+      expect(p).not.toContain(CONNECT.specUrl);
+      expect(p).not.toContain("place each into a step `copy` VERBATIM");
     }
-    // And the disconnected tier without an injected command still composes (no crash,
-    // no command block) — the route only injects it in real requests.
+    // And the disconnected tier without injected values still composes (no crash,
+    // no values block) — the route only injects them in real requests.
     const bare = specPrompt(posture("landing", false, "none"));
-    expect(bare).not.toContain("put it in your render_handoff VERBATIM");
+    expect(bare).not.toContain("place each into a step `copy` VERBATIM");
     expect(bare).toContain(TIER_MCP_CONNECT_NOT_INSTALL);
   });
 

--- a/packages/server/src/agent/system-prompt.ts
+++ b/packages/server/src/agent/system-prompt.ts
@@ -198,7 +198,7 @@ export interface OpeningPosture {
   // spec-482 follow-up: the REAL, env-specific connect command for the MCP-disconnected
   // tier's render_handoff. The route derives it (host-aware) and sets it only when
   // mcpConnected is false; toOpeningPosture appends it verbatim to that one tier.
-  connectMcp?: { installCommand: string; mcpUrl: string };
+  connectMcp?: { installCommand: string; mcpUrl: string; specUrl: string };
 }
 
 // spec-482 (t-5) — the signal→tier mapping (pure LOGIC; the tier PROSE lives in the

--- a/packages/server/src/agent/tools.ts
+++ b/packages/server/src/agent/tools.ts
@@ -235,7 +235,8 @@ const uiTools: Tool[] = [
   },
   {
     name: "render_steps",
-    description: "Display a clean numbered-steps visual for a short process or plan (3-6 steps). Display-only.",
+    description:
+      "Display a clean numbered-steps visual for a short process or plan (3-6 steps). A step may carry an ATOMIC copyable via `copy` — a single value (one command, one URL, one ready-to-paste prompt) that renders its own Copy button copying EXACTLY that value. Use copyable steps to sequence a handoff (e.g. connect command → Spec URL → paste-prompt) in ONE card, one copy per step — never bundle several things into a single copyable, and never put human-facing prose (a why/next explanation) behind a Copy. Display-only.",
     input_schema: {
       type: "object" as const,
       properties: {
@@ -247,6 +248,16 @@ const uiTools: Tool[] = [
             properties: {
               label: { type: "string", description: "Short step label." },
               detail: { type: "string", description: "Optional one-line detail." },
+              copy: {
+                type: "string",
+                description:
+                  "Optional: a SINGLE value the user copies from this step (a command, a URL, or a ready-to-paste prompt). Renders a Copy button that copies EXACTLY this value — nothing else. Keep it atomic: one thing per step, no bundled instructions, no reason/why prose.",
+              },
+              copyLabel: {
+                type: "string",
+                description:
+                  "Optional label for this step's Copy button (default 'Copy'), e.g. 'Copy command', 'Copy URL', 'Copy prompt'. Only meaningful when `copy` is set.",
+              },
             },
             required: ["label"],
           },

--- a/packages/server/src/routes/llm.ts
+++ b/packages/server/src/routes/llm.ts
@@ -41,18 +41,21 @@ import { getPhaseHighWaterMark } from "../services/phase-watermark.js";
 // we set none.)
 const MODEL = "claude-sonnet-5";
 
-// spec-482 follow-up — the REAL connect-MCP command for the disconnected opening tier,
-// derived host-aware (mirrors packages/ui/src/utils/mcpUrl.ts + ConnectAgentStep's
-// unified installer, spec-430). `APP_BASE_URL` is the public host Cloud Run injects per
-// env (same var app.ts uses for install.sh). The bare `npx -y memex-ai install` command
-// is prod; any other host passes `--api-base`. The agent copies this VERBATIM into its
-// render_handoff so the user copies a working installer, not an LLM paraphrase.
-function deriveConnectMcp(): { installCommand: string; mcpUrl: string } {
+// spec-482 (dec-10) — the REAL, env-specific values for the disconnected opening tier's
+// connect-handoff card, derived host-aware (mirrors packages/ui/src/utils/mcpUrl.ts +
+// ConnectAgentStep's unified installer, spec-430). `APP_BASE_URL` is the public host
+// Cloud Run injects per env (same var app.ts uses for install.sh). The bare
+// `npx -y memex-ai install` command is prod; any other host passes `--api-base`. The
+// Spec URL is `${base}/${docRef}` (docRef is the canonical `namespace/memex/specs/spec-N`,
+// which IS the URL path — std-2/std-10). The agent copies each VERBATIM into a step
+// `copy` so the user copies a working installer + a real URL, not an LLM paraphrase.
+function deriveConnectMcp(docRef: string): { installCommand: string; mcpUrl: string; specUrl: string } {
   const base = process.env.APP_BASE_URL ?? "https://int.memex.ai";
   const apiBaseFlag = base === "https://memex.ai" ? "" : ` --api-base ${base}`;
   return {
     installCommand: `npx -y memex-ai install${apiBaseFlag}`,
     mcpUrl: `${base}/mcp`,
+    specUrl: `${base}/${docRef}`,
   };
 }
 
@@ -224,10 +227,15 @@ llmRouter.post("/chat", async (c) => {
         entry: (creationLanding ? "landing" : "return") as "landing" | "return",
         mcpConnected,
         phaseWatermark,
-        // spec-482 follow-up: only the MCP-disconnected tier needs the real connect
-        // command; deriving it host-aware here (mirrors the client's mcpUrl.ts) means
-        // the agent's render_handoff copies a WORKING installer, not a paraphrase.
-        connectMcp: mcpConnected ? undefined : deriveConnectMcp(),
+        // spec-482 dec-10: only the MCP-disconnected tier needs the real connect
+        // command + Spec URL; deriving them host-aware here (mirrors the client's
+        // mcpUrl.ts) means the agent's copyable-steps card copies a WORKING installer
+        // and a REAL URL, not paraphrases. docRef is always set when docId is present
+        // (wantOpeningPosture requires docId); the guard keeps it type-safe.
+        connectMcp:
+          mcpConnected || !documentContext.docRef
+            ? undefined
+            : deriveConnectMcp(documentContext.docRef),
       }
     : undefined;
 

--- a/packages/shared/src/scaffold-data.ts
+++ b/packages/shared/src/scaffold-data.ts
@@ -391,7 +391,7 @@ export type OpeningEntry = 'landing' | 'return';
 const OPENING_WHY_FIRST =
   '## Opening posture — this is your FIRST turn on this Spec\n' +
   'Lead with WHY it matters, grounded in THIS specific Spec, BEFORE any how-to or next step. Name what this Spec actually sets out to do — its real purpose and subject — and tie everything to the user’s OWN product and goal. Never frame this as "adopting Memex" or a tour of the tool, and never presume the user already has an existing codebase (the Spec may be greenfield). Only after the why do you give the how and the what. This posture governs your OPENING turn; once the conversation is under way, converse normally.\n' +
-  'COPYABLE TEXT RULE: whenever you give the user something to COPY — a command, a URL, or a prompt to paste into their coding agent — deliver it through a `render_handoff` block (target the coding agent; it renders with a Copy button), NEVER as inline copyable text in your prose. Your prose says what and why; the `render_handoff` block carries the exact bytes they copy.';
+  'COPYABLE TEXT RULE: whenever you give the user something to COPY — a command, a URL, or a prompt to paste into their coding agent — deliver it through a Copy-button affordance, NEVER as inline copyable text in your prose. Each Copy button copies EXACTLY ONE value (one command, OR one URL, OR one prompt) — never bundle several things, and never put your reason/why or a human-facing instruction behind a Copy. Two affordances carry copyables: a `render_handoff` block (for a single ready-to-paste prompt when handing work to another agent on refusal), and a `render_steps` card whose steps each carry their own atomic `copy` (for a sequenced handoff — one copy per step). Your prose says what and why; the Copy button carries the exact bytes they copy.';
 
 // Landing entry framing (t-4 ac-6/7/8): a shallow, state-computed recap of what is
 // still open, NOT a cold greeting and NOT a transcript replay. Skip when nothing is
@@ -417,8 +417,8 @@ const OPENING_TIER_MCP_DISCONNECTED =
   '### Next step: connect your coding agent (this comes FIRST)\n' +
   'This user has NEVER connected a coding agent over MCP. Until they connect one, this Spec cannot be built — so a connected coding agent is the single most important thing, and it biases this whole turn: keep any recap to AT MOST ONE line, and ask NO clarifying question.\n' +
   '- Lead with WHY connecting matters for THIS Spec specifically — tie it to what this Spec sets out to build.\n' +
-  '- Then walk them through the handoff in THREE steps: (1) CONNECT their coding agent (e.g. Claude Code, Cursor) to this Memex over MCP, (2) copy THIS Spec’s URL, (3) paste it into their coding agent and tell it to use the Memex MCP on this Spec. Always say "connect" — NEVER "install".\n' +
-  '- The FIRST copyable piece is the REAL connect command — use the EXACT install command provided below (verbatim), NOT an invented paraphrase. Deliver that command, plus this Spec’s URL, through a `render_handoff` block so it renders with a Copy button; NEVER paste copyable commands, URLs, or prompts inline in your prose. A handoff that omits the real install command — or that only tells the coding agent to "use the Memex MCP on this Spec" — is NOT connect instructions and is wrong here.\n' +
+  '- Deliver the handoff as ONE `render_steps` card of THREE copyable steps — the whole connect flow in a single card, one atomic Copy per step. Do NOT also emit a `render_handoff` for this, and do NOT emit a second numbered list restating the steps — one card, no duplication. Always say "connect" — NEVER "install". The three steps are: (1) CONNECT their coding agent (e.g. Claude Code, Cursor) to this Memex over MCP — its `copy` is the REAL connect command; (2) give their coding agent THIS Spec — its `copy` is this Spec’s URL; (3) tell it to build from the Spec — its `copy` is the ready-to-paste prompt. The exact values to place come from the block below.\n' +
+  '- Each step’s `copy` holds EXACTLY one value (a command, a URL, or a prompt) — nothing bundled, and never your reason/why prose. NEVER paste copyable commands, URLs, or prompts inline in your prose. A card whose connect step omits the real install command — or that only tells the coding agent to "use the Memex MCP on this Spec" without the real command — is NOT connect instructions and is wrong here.\n' +
   '- Offer to walk them through it conversationally. You CANNOT perform the connection yourself — do not claim to; guide them to do it.\n' +
   'Everything else stays secondary until they are connected.';
 
@@ -472,11 +472,12 @@ const OPENING_TIER_TEXT: Record<OpeningTier, string> = {
 export function toOpeningPosture(input: {
   entry: OpeningEntry;
   tier: OpeningTier;
-  // spec-482 follow-up: the MCP-disconnected tier's render_handoff must carry the REAL,
-  // working connect command — which is env-specific (prod vs int host). The route
-  // derives it per-request and passes it here; it is appended VERBATIM so the portable
-  // prose (std-22) never hardcodes a host/command. Ignored for every connected tier.
-  connectMcp?: { installCommand: string; mcpUrl: string };
+  // spec-482 (dec-10): the MCP-disconnected tier's copyable-steps card must carry the
+  // REAL, working connect command + this Spec's canonical URL — both env-specific (prod
+  // vs int host). The route derives them per-request and passes them here; they are
+  // appended VERBATIM so the portable prose (std-22) never hardcodes a host/command/URL.
+  // Ignored for every connected tier.
+  connectMcp?: { installCommand: string; mcpUrl: string; specUrl: string };
 }): string {
   const framing = input.entry === 'landing' ? OPENING_LANDING : OPENING_RETURN;
   const parts = [OPENING_WHY_FIRST, framing, OPENING_TIER_TEXT[input.tier]];
@@ -486,17 +487,19 @@ export function toOpeningPosture(input: {
   return parts.join('\n\n');
 }
 
-// The exact, env-specific connect command the disconnected-tier agent must place —
-// verbatim — inside its render_handoff, so the copyable payload is the REAL installer
-// (not an LLM paraphrase that assumes MCP is already connected). Composed from
-// route-injected values, never hardcoded here (std-22 portability).
-function toConnectMcpBlock(connect: { installCommand: string; mcpUrl: string }): string {
+// The exact, env-specific values the disconnected-tier agent must place — verbatim —
+// into the THREE copy steps of its `render_steps` card, so each copyable payload is the
+// REAL thing (not an LLM paraphrase that assumes MCP is already connected, nor a made-up
+// URL). Composed from route-injected values, never hardcoded here (std-22 portability).
+function toConnectMcpBlock(connect: { installCommand: string; mcpUrl: string; specUrl: string }): string {
   return (
-    '### The exact connect command — put it in your render_handoff VERBATIM\n' +
-    'This is the real, working way for the user to connect the Memex MCP server. Claude Code / Claude Desktop users run this in a terminal (one browser sign-in plants the token — nothing to paste by hand):\n' +
-    '`' + connect.installCommand + '`\n' +
-    'For coding agents configured by URL/config instead (Cursor, VS Code, claude.ai), the Memex MCP endpoint is `' + connect.mcpUrl + '`.\n' +
-    'Put the install command above into your `render_handoff` EXACTLY — do NOT invent, paraphrase, shorten, or alter it. That copyable command IS the payload of the handoff; a prompt that only says "use the Memex MCP on this Spec" is NOT connect instructions and is wrong. After the command you may add this Spec’s URL and a one-line "once connected, point your coding agent at this Spec" note.'
+    '### The exact values for your render_steps card — place each into a step `copy` VERBATIM\n' +
+    'These are the real, working values. Emit ONE `render_steps` card of three steps, each carrying its own atomic `copy` (do NOT invent, paraphrase, shorten, or alter any of them):\n' +
+    '- Step 1 — connect (copyLabel "Copy command"): `copy` = `' + connect.installCommand + '`\n' +
+    '  This is how the user connects the Memex MCP server. Claude Code / Claude Desktop users run it in a terminal (one browser sign-in plants the token — nothing to paste by hand). For coding agents configured by URL/config instead (Cursor, VS Code, claude.ai), the MCP endpoint is `' + connect.mcpUrl + '` — mention it in the step `detail` if useful, but the `copy` is the command above.\n' +
+    '- Step 2 — give it this Spec (copyLabel "Copy URL"): `copy` = `' + connect.specUrl + '`\n' +
+    '- Step 3 — tell it to build (copyLabel "Copy prompt"): `copy` = `Use the Memex MCP on this Spec: ' + connect.specUrl + '`\n' +
+    'A card whose connect step omits the real command above — or that only says "use the Memex MCP on this Spec" without it — is NOT connect instructions and is wrong. Do NOT also emit a `render_handoff` for this connect flow.'
   );
 }
 

--- a/packages/ui/src/components/chat/ui-tools/Steps.test.tsx
+++ b/packages/ui/src/components/chat/ui-tools/Steps.test.tsx
@@ -1,0 +1,129 @@
+// spec-482 dec-10 (ac-26): render_steps gains an optional per-step ATOMIC copyable.
+// These tests pin that a step's Copy button copies EXACTLY that step's `copy` value —
+// never the label, the detail, or another step's value — and that steps without `copy`
+// render no button (backward-compatible). This is what lets the connect handoff live in
+// ONE card with a per-step copy each, instead of one blob-copying render_handoff.
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { Steps } from './Steps';
+import { UiToolRenderer } from './index';
+
+const AC_STEP_COPY =
+  'mindset-prod/memex-building-itself/specs/spec-482/acs/ac-26';
+
+// The three-step connect handoff shape (dec-10): connect command, Spec URL, paste-prompt.
+const CONNECT_STEPS = [
+  {
+    label: 'Connect your coding agent over MCP',
+    detail: 'A one-time step so your agent can read and build from this Spec.',
+    copy: 'npx -y memex-ai install --api-base https://int.memex.ai',
+    copyLabel: 'Copy command',
+  },
+  {
+    label: 'Give your agent this Spec',
+    detail: 'Its address on Memex.',
+    copy: 'https://int.memex.ai/acme/checkout/specs/spec-2',
+    copyLabel: 'Copy URL',
+  },
+  {
+    label: 'Tell it to build from the Spec',
+    copy: 'Use the Memex MCP on this Spec: https://int.memex.ai/acme/checkout/specs/spec-2',
+    copyLabel: 'Copy prompt',
+  },
+];
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('Steps — atomic per-step copy (ac-26)', () => {
+  it('renders each step with its own labelled Copy button', () => {
+    tagAc(AC_STEP_COPY);
+    render(<Steps input={{ title: 'Get spec-2 ready to build', steps: CONNECT_STEPS }} />);
+    expect(screen.getByText(/Connect your coding agent over MCP/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Copy command:/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Copy URL:/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Copy prompt:/ })).toBeInTheDocument();
+    // Three copyable steps → three buttons, each its own chip.
+    expect(screen.getAllByTestId('step-copy-button')).toHaveLength(3);
+  });
+
+  it("a step's Copy copies EXACTLY that step's value — not the label, detail, or another step", async () => {
+    tagAc(AC_STEP_COPY);
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    render(<Steps input={{ steps: CONNECT_STEPS }} />);
+
+    // Copy step 1 (the command) — clipboard gets ONLY the command, nothing bundled.
+    await userEvent.click(screen.getByRole('button', { name: /Copy command:/ }));
+    expect(writeText).toHaveBeenCalledTimes(1);
+    expect(writeText).toHaveBeenLastCalledWith(
+      'npx -y memex-ai install --api-base https://int.memex.ai',
+    );
+
+    // Copy step 2 (the URL) — clipboard gets ONLY the URL, not the command.
+    await userEvent.click(screen.getByRole('button', { name: /Copy URL:/ }));
+    expect(writeText).toHaveBeenLastCalledWith(
+      'https://int.memex.ai/acme/checkout/specs/spec-2',
+    );
+
+    // Copy step 3 (the paste-prompt) — the ready-to-paste sentence only.
+    await userEvent.click(screen.getByRole('button', { name: /Copy prompt:/ }));
+    expect(writeText).toHaveBeenLastCalledWith(
+      'Use the Memex MCP on this Spec: https://int.memex.ai/acme/checkout/specs/spec-2',
+    );
+
+    // No copy ever carried a step label or detail — every clipboard write is one of the
+    // three atomic values, never the surrounding prose.
+    for (const call of writeText.mock.calls) {
+      expect(call[0]).not.toContain('Connect your coding agent');
+      expect(call[0]).not.toContain('A one-time step');
+    }
+  });
+
+  it("clicking Copy shows 'Copied' on that step only", async () => {
+    tagAc(AC_STEP_COPY);
+    Object.assign(navigator, { clipboard: { writeText: vi.fn().mockResolvedValue(undefined) } });
+    render(<Steps input={{ steps: CONNECT_STEPS }} />);
+    const buttons = screen.getAllByTestId('step-copy-button');
+    await userEvent.click(buttons[1]!);
+    await waitFor(() => expect(buttons[1]!).toHaveTextContent('Copied'));
+    // The other steps keep their own labels — the confirmation is per-step.
+    expect(buttons[0]!).toHaveTextContent('Copy command');
+    expect(buttons[2]!).toHaveTextContent('Copy prompt');
+  });
+
+  it('steps without a `copy` render no Copy button (backward-compatible)', () => {
+    tagAc(AC_STEP_COPY);
+    render(
+      <Steps
+        input={{
+          steps: [
+            { label: 'Plain step one', detail: 'no copyable here' },
+            { label: 'Plain step two' },
+          ],
+        }}
+      />,
+    );
+    expect(screen.getByText('Plain step one')).toBeInTheDocument();
+    expect(screen.queryByTestId('step-copy-button')).not.toBeInTheDocument();
+  });
+
+  it('the dispatcher routes render_steps (with copy) to the Steps component', () => {
+    tagAc(AC_STEP_COPY);
+    render(
+      <UiToolRenderer
+        toolName="render_steps"
+        toolId="tu-1"
+        input={{ steps: CONNECT_STEPS }}
+        disabled={false}
+        onRespond={() => {}}
+      />,
+    );
+    expect(screen.getByRole('button', { name: /Copy command:/ })).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/chat/ui-tools/Steps.tsx
+++ b/packages/ui/src/components/chat/ui-tools/Steps.tsx
@@ -70,7 +70,7 @@ export function Steps({ input }: StepsProps) {
                     data-testid="step-copy-button"
                     aria-label={`${step.copyLabel ?? 'Copy'}: ${step.copy}`}
                     onClick={() => copyStep(i, step.copy as string)}
-                    className="flex-none rounded border border-edge bg-accent/10 px-2 py-0.5 text-[11px] font-medium text-accent transition-colors hover:bg-accent/20 hover:text-accent-hover focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+                    className="flex-none rounded-sm border border-edge bg-accent/10 px-2 py-0.5 text-[11px] font-medium text-accent transition-colors hover:bg-accent/20 hover:text-accent-hover focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
                   >
                     {copiedIndex === i ? 'Copied' : (step.copyLabel ?? 'Copy')}
                   </button>

--- a/packages/ui/src/components/chat/ui-tools/Steps.tsx
+++ b/packages/ui/src/components/chat/ui-tools/Steps.tsx
@@ -1,8 +1,17 @@
+import { useState } from 'react';
 import { MarkdownText } from '../MarkdownText';
 
 interface StepItem {
   label: string;
   detail?: string;
+  // spec-482 dec-10: an optional ATOMIC copyable for this step. When present the
+  // step renders a Copy button that writes EXACTLY this value to the clipboard —
+  // never the label, the detail, or another step's value. This is what lets a
+  // sequenced handoff (connect command → Spec URL → paste-prompt) live in ONE card
+  // with a per-step copy each, instead of one render_handoff whose single button
+  // scoops up the whole block.
+  copy?: string;
+  copyLabel?: string;
 }
 
 interface StepsProps {
@@ -13,6 +22,17 @@ interface StepsProps {
 }
 
 export function Steps({ input }: StepsProps) {
+  // Which step's Copy button is showing its "Copied" confirmation. Only one at a
+  // time — a fresh copy supersedes the previous step's confirmation.
+  const [copiedIndex, setCopiedIndex] = useState<number | null>(null);
+
+  const copyStep = (i: number, value: string) => {
+    void navigator.clipboard?.writeText(value).then(() => {
+      setCopiedIndex(i);
+      setTimeout(() => setCopiedIndex((cur) => (cur === i ? null : cur)), 1500);
+    });
+  };
+
   return (
     <div className="my-3 rounded-lg border border-edge-subtle bg-overlay px-4 py-3">
       {input.title && (
@@ -26,13 +46,34 @@ export function Steps({ input }: StepsProps) {
             <span className="flex-none flex items-center justify-center w-6 h-6 rounded-full bg-accent/15 text-accent text-xs font-semibold tabular-nums">
               {i + 1}
             </span>
-            <div className="min-w-0 pt-0.5">
+            <div className="min-w-0 flex-1 pt-0.5">
               <div className="text-sm text-primary leading-snug">
                 <MarkdownText>{step.label}</MarkdownText>
               </div>
               {step.detail && (
                 <div className="text-xs text-muted mt-0.5">
                   <MarkdownText>{step.detail}</MarkdownText>
+                </div>
+              )}
+              {step.copy && (
+                <div
+                  data-testid="step-copy"
+                  className="mt-2 flex items-center gap-2 rounded-md border border-edge bg-input px-2.5 py-1.5"
+                >
+                  {/* The exact bytes copied — displayed verbatim, monospace, its own
+                      scroll so a long command/URL never widens the card. */}
+                  <code className="min-w-0 flex-1 overflow-x-auto whitespace-nowrap font-mono text-xs text-primary/90">
+                    {step.copy}
+                  </code>
+                  <button
+                    type="button"
+                    data-testid="step-copy-button"
+                    aria-label={`${step.copyLabel ?? 'Copy'}: ${step.copy}`}
+                    onClick={() => copyStep(i, step.copy as string)}
+                    className="flex-none rounded border border-edge bg-accent/10 px-2 py-0.5 text-[11px] font-medium text-accent transition-colors hover:bg-accent/20 hover:text-accent-hover focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+                  >
+                    {copiedIndex === i ? 'Copied' : (step.copyLabel ?? 'Copy')}
+                  </button>
                 </div>
               )}
             </div>

--- a/packages/ui/src/components/chat/ui-tools/index.tsx
+++ b/packages/ui/src/components/chat/ui-tools/index.tsx
@@ -59,7 +59,7 @@ export function UiToolRenderer({ toolName, toolId, input, disabled, onRespond }:
     case 'render_steps':
       return (
         <Steps
-          input={input as { title?: string; steps: { label: string; detail?: string }[] }}
+          input={input as { title?: string; steps: { label: string; detail?: string; copy?: string; copyLabel?: string }[] }}
         />
       );
     case 'render_quote':


### PR DESCRIPTION
## Why

Owner feedback on the live int landing: the MCP-disconnected post-creation landing rendered the connect flow **twice** (a `render_handoff` block *and* a `render_steps` numbered card), and the handoff's single **"Copy prompt"** button copied the **whole block** — reason prose + install command + a *"open the Spec in your browser and copy its address-bar URL"* meta-line + the paste sentence. Pasting that into a coding agent handed it human-facing instructions as noise, and the Spec URL was never actually shown or made copyable.

Agreed on the redesign via an artifact mockup first (before/after).

## What changed (dec-10)

The connect handoff is now **one** `render_steps` card of three sequenced steps, each with its **own atomic Copy**:

1. **Connect your coding agent over MCP** — Copy command → `npx -y memex-ai install [--api-base <host>]` only
2. **Give your agent this Spec** — Copy URL → the real Spec URL only
3. **Tell it to build from the Spec** — Copy prompt → `Use the Memex MCP on this Spec: <url>` only

Each Copy button copies exactly one value; no reason/why prose ever rides a Copy; the duplicate list is gone.

- **`Steps.tsx`** — optional per-step `copy` + `copyLabel` renders a chip whose Copy button writes EXACTLY that value (focus-visible, aria-label, per-step Copied state). Backward-compatible for steps without `copy`.
- **`tools.ts`** — `render_steps` schema documents `copy`/`copyLabel` as atomic single-value copyables; `index.tsx` dispatch type widened.
- **`scaffold-data.ts`** — COPYABLE TEXT RULE broadened ("a Copy-button affordance, each copying exactly one value"); `OPENING_TIER_MCP_DISCONNECTED` + `toConnectMcpBlock` rewritten to instruct ONE `render_steps` card, forbidding the `render_handoff` blob and a duplicate list.
- **`context-builder.ts`** — `buildDocumentContext` returns `docRef`; **`llm.ts`** `deriveConnectMcp` injects `specUrl = ${base}/${docRef}` alongside the real host-aware command; `system-prompt` `OpeningPosture.connectMcp` carries `specUrl`. Values placed verbatim, never hardcoded in portable prose (std-22).

`render_handoff` stays the shared refusal-handoff affordance (std-38 cl-5).

## Spec

dec-10 · t-14 · ac-26/27/28 (verified) · ac-5/16/25 statements reconciled to the copyable-steps mechanism.

## Testing

- server `system-prompt.spec-482.test.ts` **17/17**; ui `Steps.test.tsx` **5/5** (new); ui `ui-tools`+`ChatPanel`+`SpecList` **63/63**
- `tsc` clean (shared/server/ui); `biome check` clean
- e2e journey-61 stays at the deterministic ac-3 nav assertion; the copyable-steps card is unit-tested (the connect card is LLM-composed over the shared fake-Anthropic queue, so its render is covered deterministically by `Steps.test.tsx` rather than e2e — same rationale documented in the journey header).

🤖 Generated with [Claude Code](https://claude.com/claude-code)