### PR TITLE
feat: namespace-slug rename UI + D-2 mutation guard (spec-481)

### DIFF
--- a/packages/server/src/routes/namespaces.integration.test.ts
+++ b/packages/server/src/routes/namespaces.integration.test.ts
@@ -3,7 +3,7 @@
 // per-namespace slug-availability check.
 
 import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
-import { eq, inArray } from "drizzle-orm";
+import { eq, inArray, sql } from "drizzle-orm";
 
 vi.hoisted(() => {
   // Force auth-mode session middleware so per-user Bearer tokens are honored.
@@ -25,6 +25,7 @@ import {
 import { signSessionToken } from "../services/auth-jwt.js";
 import { ensureUserNamespace } from "../services/user-namespaces.js";
 import { createOrgForUser } from "../services/orgs.js";
+import { insertRedirect } from "../services/redirects.js";
 
 const createdUserIds: string[] = [];
 const createdNamespaceIds: string[] = [];
@@ -334,6 +335,54 @@ describe("GET /api/namespaces/:namespaceId/memexes/check", () => {
     expect(res.status).toBe(404);
     const body = await res.json();
     expect(body.error).toBe("Namespace not found");
+  });
+});
+
+// spec-481 t-2 — the namespace slug-availability check distinguishes a slug
+// freed by a rename (held by a live redirect) from one actively taken, so the
+// rename UI can explain WHY the freed slug is blocked (parity with the memex
+// check). Availability itself already came from the shared isSlugAvailable.
+describe("GET /api/namespaces/check", () => {
+  const redirectSources: string[] = [];
+  afterAll(async () => {
+    for (const s of redirectSources) {
+      await db.execute(sql`DELETE FROM redirects WHERE old_path = ${s}`).catch(() => {});
+    }
+  });
+
+  it("returns { available: false, reason: 'redirected' } for a live redirect source", async () => {
+    const caller = await seedUser();
+    const source = `ns481r${caller.userId.slice(0, 6)}`;
+    redirectSources.push(source);
+    // A namespace_rename redirect whose old_path is this bare 1-segment slug.
+    await insertRedirect(source, `${source}new`, "namespace_rename");
+    redirectSources.push(`${source}new`);
+
+    const res = await authedRequest(
+      `/api/namespaces/check?slug=${source}`,
+      { method: "GET" },
+      caller.bearer,
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ available: false, reason: "redirected" });
+  });
+
+  it("returns { available: false, reason: 'taken' } for an active namespace slug", async () => {
+    const owner = await seedUser();
+    const created = await createOrgForUser({
+      slug: `ns481t${owner.userId.slice(0, 6)}`,
+      name: "Taken Co",
+      userId: owner.userId,
+    });
+    createdNamespaceIds.push(created.namespace.id);
+
+    const res = await authedRequest(
+      `/api/namespaces/check?slug=${created.namespace.slug}`,
+      { method: "GET" },
+      owner.bearer,
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ available: false, reason: "taken" });
   });
 });
 

--- a/packages/server/src/routes/namespaces.ts
+++ b/packages/server/src/routes/namespaces.ts
@@ -24,6 +24,7 @@ import {
   MemexCreationError,
 } from "../services/memexes.js";
 import { isSlugAvailable, validateSlugFormat } from "../services/shared/slug.js";
+import { isRedirectSource } from "../services/redirects.js";
 import { ConflictError, ValidationError } from "../types/errors.js";
 
 export const namespacesRouter = new Hono<SessionEnv>();
@@ -41,7 +42,13 @@ namespacesRouter.get("/check", async (c) => {
   }
   const available = await isSlugAvailable(slug);
   if (!available) {
-    return c.json({ available: false, reason: "taken" });
+    // Distinguish a slug freed by a rename (still held by a live, permanent
+    // redirect — spec-481 D-2) from one that's actively taken/reserved, so the
+    // rename UI can explain WHY the freed slug is blocked. Parity with the
+    // memex slug check (spec-479). Extra query only on the unavailable branch;
+    // old_path is the redirects PK, so it's an index hit.
+    const redirected = await isRedirectSource(slug);
+    return c.json({ available: false, reason: redirected ? "redirected" : "taken" });
   }
   return c.json({ available: true });
 });
@@ -57,11 +64,12 @@ namespacesRouter.patch("/:id/slug", async (c) => {
     return c.json({ error: "slug is required" }, 400);
   }
   try {
-    const updated = await renameNamespaceSlug({
-      namespaceId,
-      newSlug: body.slug,
-      userId: user.id,
-    });
+    const updated = await renameNamespaceSlug(
+      { namespaceId, newSlug: body.slug, userId: user.id },
+      // std-32: stamp WHO + HOW so the mutation isn't a channel-less attribution
+      // defect on the activity bus. Mirrors the memex-rename route (spec-479).
+      { channel: "rest_ui", actorUserId: user.id },
+    );
     return c.json({ namespace: updated });
   } catch (err) {
     if (err instanceof ValidationError) {

--- a/packages/server/src/services/namespaces.rename-redirect.spec-481.integration.test.ts
+++ b/packages/server/src/services/namespaces.rename-redirect.spec-481.integration.test.ts
@@ -1,0 +1,96 @@
+// spec-481 t-1 — renameNamespaceSlug writes a namespace_rename redirect so old
+// namespace URLs forward (ac-3), and isSlugAvailable rejects a slug that is the
+// source of a live redirect (D-2 reuse-guard, ac-5).
+//
+// Per-worker-unique slugs (std-37); redirect + reservation rows created here are
+// swept afterEach (std-39 hygiene).
+
+import { describe, it, expect, afterEach } from "vitest";
+import { sql } from "drizzle-orm";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { db } from "../db/connection.js";
+import { namespaces, memexes, users } from "../db/schema.js";
+import { renameNamespaceSlug } from "./namespaces.js";
+import { isSlugAvailable } from "./shared/slug.js";
+import { insertRedirect, lookupRedirect } from "./redirects.js";
+
+const AC_481_REDIRECT =
+  "mindset-prod/memex-building-itself/specs/spec-481/acs/ac-3";
+const AC_481_GUARD =
+  "mindset-prod/memex-building-itself/specs/spec-481/acs/ac-5";
+
+function stem(): string {
+  return `s481${Math.random().toString(36).slice(2, 8)}`;
+}
+
+const slugsToClean: string[] = [];
+afterEach(async () => {
+  while (slugsToClean.length) {
+    const s = slugsToClean.pop()!;
+    await db
+      .execute(
+        sql`DELETE FROM redirects WHERE old_path LIKE ${s + "%"} OR new_path LIKE ${s + "%"}`,
+      )
+      .catch(() => {});
+    await db
+      .execute(sql`DELETE FROM namespace_slug_reservations WHERE slug LIKE ${s + "%"}`)
+      .catch(() => {});
+  }
+});
+
+// Seed a personal (user-kind) namespace + one memex; returns the ids + slug.
+async function seedUserNamespace(oldSlug: string) {
+  const [user] = await db
+    .insert(users)
+    .values({ email: `${oldSlug}@example.com` } as typeof users.$inferInsert)
+    .returning();
+  const [ns] = await db
+    .insert(namespaces)
+    .values({ slug: oldSlug, kind: "user", ownerUserId: user.id })
+    .returning();
+  await db
+    .insert(memexes)
+    .values({ namespaceId: ns.id, slug: "main", name: "Main" })
+    .returning();
+  return { userId: user.id, namespaceId: ns.id };
+}
+
+describe("renameNamespaceSlug redirect + reuse-guard (spec-481 t-1)", () => {
+  it("writes a namespace_rename redirect so a stale namespace path forwards", async () => {
+    tagAc(AC_481_REDIRECT);
+    const base = stem();
+    const oldSlug = `${base}o`;
+    const newSlug = `${base}n`;
+    slugsToClean.push(base);
+    const { userId, namespaceId } = await seedUserNamespace(oldSlug);
+
+    await renameNamespaceSlug({ namespaceId, newSlug, userId });
+
+    const ns = await db.query.namespaces.findFirst({
+      where: (n, { eq }) => eq(n.id, namespaceId),
+      columns: { slug: true },
+    });
+    expect(ns?.slug).toBe(newSlug);
+
+    // A deep path under the old namespace forwards to the new one.
+    const result = await lookupRedirect(`${oldSlug}/main/specs/spec-1/tasks/t-1`);
+    expect(result).toEqual({
+      redirected: `${newSlug}/main/specs/spec-1/tasks/t-1`,
+    });
+  });
+
+  it("isSlugAvailable rejects a slug that is the source of a live redirect", async () => {
+    tagAc(AC_481_GUARD);
+    const base = stem();
+    const orphan = `${base}src`; // never reserved — only a redirect source
+    slugsToClean.push(base);
+
+    // Available before any redirect exists.
+    expect(await isSlugAvailable(orphan)).toBe(true);
+
+    await insertRedirect(orphan, `${base}dst`, "namespace_rename");
+
+    // Now unavailable purely because it is a redirect source (no reservation).
+    expect(await isSlugAvailable(orphan)).toBe(false);
+  });
+});

--- a/packages/server/src/services/namespaces.rename-redirect.spec-481.integration.test.ts
+++ b/packages/server/src/services/namespaces.rename-redirect.spec-481.integration.test.ts
@@ -93,4 +93,33 @@ describe("renameNamespaceSlug redirect + reuse-guard (spec-481 t-1)", () => {
     // Now unavailable purely because it is a redirect source (no reservation).
     expect(await isSlugAvailable(orphan)).toBe(false);
   });
+
+  // issue-1 — the guard above must ALSO fire on the mutation path, not just the
+  // isolated helper. A raw PATCH /api/namespaces/:id/slug that targets a live
+  // redirect source (once its 30-day reservation lapses) would let a reborn
+  // namespace shadow the permanent redirect (std-10 cl-91/97) and mis-route
+  // every old link. `orphan` is a redirect source that was NEVER a namespace
+  // and holds NO reservation, so it isolates the redirect-source guard from the
+  // reservation/taken checks — exactly the D-2 hole.
+  it("renameNamespaceSlug refuses to rename TO a live redirect source", async () => {
+    tagAc(AC_481_GUARD);
+    const base = stem();
+    const cSlug = `${base}c`;
+    const orphan = `${base}src`; // redirect source, never a namespace or reservation
+    slugsToClean.push(base);
+    const { userId, namespaceId } = await seedUserNamespace(cSlug);
+
+    await insertRedirect(orphan, `${base}dst`, "namespace_rename");
+
+    await expect(
+      renameNamespaceSlug({ namespaceId, newSlug: orphan, userId }),
+    ).rejects.toThrow(/redirect/i);
+
+    // And the namespace slug is unchanged — the tx rolled back.
+    const ns = await db.query.namespaces.findFirst({
+      where: (n, { eq }) => eq(n.id, namespaceId),
+      columns: { slug: true },
+    });
+    expect(ns?.slug).toBe(cSlug);
+  });
 });

--- a/packages/server/src/services/namespaces.ts
+++ b/packages/server/src/services/namespaces.ts
@@ -17,7 +17,7 @@ import {
 } from "../db/schema.js";
 import type { Namespace } from "../db/schema.js";
 import { validateSlugFormat } from "./shared/slug.js";
-import { insertRedirect } from "./redirects.js";
+import { insertRedirect, isRedirectSource } from "./redirects.js";
 import { ConflictError, ValidationError } from "../types/errors.js";
 import { mutate, type Mutated } from "./mutate.js";
 
@@ -216,6 +216,19 @@ export async function renameNamespaceSlug(input: RenameSlugRequest): Promise<Mut
       const taken = await tx.query.namespaces.findFirst({ where: eq(namespaces.slug, newSlug) });
       if (taken) {
         throw new ConflictError(`Slug '${newSlug}' is already taken`);
+      }
+
+      // spec-481 D-2 / issue-1: reject a slug that is the SOURCE of a live
+      // redirect, even once its 30-day reservation has lapsed. Redirects never
+      // expire (std-10 cl-97), so a reborn namespace on this slug would shadow
+      // the permanent redirect under direct-first resolution (std-10 cl-91) and
+      // silently mis-route every old link. The isolated isSlugAvailable guard
+      // isn't on this mutation path (raw PATCH bypasses it), so enforce it here
+      // inside the tx alongside the reservation/taken checks.
+      if (await isRedirectSource(newSlug, tx)) {
+        throw new ConflictError(
+          `Slug '${newSlug}' was used before and is reserved by a redirect`,
+        );
       }
 
       // Reserve the OLD slug for 30 days post-rename.

--- a/packages/server/src/services/namespaces.ts
+++ b/packages/server/src/services/namespaces.ts
@@ -19,7 +19,7 @@ import type { Namespace } from "../db/schema.js";
 import { validateSlugFormat } from "./shared/slug.js";
 import { insertRedirect, isRedirectSource } from "./redirects.js";
 import { ConflictError, ValidationError } from "../types/errors.js";
-import { mutate, type Mutated } from "./mutate.js";
+import { mutate, type Mutated, type RequestCtx } from "./mutate.js";
 
 export async function getNamespaceBySlug(slug: string): Promise<Namespace | undefined> {
   return db.query.namespaces.findFirst({
@@ -144,7 +144,10 @@ export interface RenameSlugRequest {
 const SLUG_COOLDOWN_DAYS = 30;
 const SLUG_RESERVATION_DAYS = 30;
 
-export async function renameNamespaceSlug(input: RenameSlugRequest): Promise<Mutated<Namespace>> {
+export async function renameNamespaceSlug(
+  input: RenameSlugRequest,
+  ctx: RequestCtx = {},
+): Promise<Mutated<Namespace>> {
   const newSlug = input.newSlug.trim().toLowerCase();
 
   const format = validateSlugFormat(newSlug);
@@ -165,7 +168,10 @@ export async function renameNamespaceSlug(input: RenameSlugRequest): Promise<Mut
   const memexId = memexRow?.id ?? "";
 
   return mutate(
-    {},
+    // Thread the caller's channel/identity so the mutation isn't a channel-less
+    // "attribution defect" on the activity bus (std-32). The route passes
+    // channel:'rest_ui', mirroring the memex-rename sibling (spec-479).
+    ctx,
     { memexId, entity: "user_namespace", action: "updated" },
     () => db.transaction(async (tx) => {
       const ns = await tx.query.namespaces.findFirst({

--- a/packages/server/src/services/namespaces.ts
+++ b/packages/server/src/services/namespaces.ts
@@ -17,6 +17,7 @@ import {
 } from "../db/schema.js";
 import type { Namespace } from "../db/schema.js";
 import { validateSlugFormat } from "./shared/slug.js";
+import { insertRedirect } from "./redirects.js";
 import { ConflictError, ValidationError } from "../types/errors.js";
 import { mutate, type Mutated } from "./mutate.js";
 
@@ -237,6 +238,13 @@ export async function renameNamespaceSlug(input: RenameSlugRequest): Promise<Mut
         .set({ slug: newSlug, slugChangedAt: new Date() })
         .where(eq(namespaces.id, ns.id))
         .returning();
+
+      // spec-481 — record the namespace_rename redirect in the SAME transaction
+      // so old `/<old-ns>/...` URLs + MCP refs forward instead of 404ing
+      // (std-10 §7). insertRedirect accepts the 1-segment prefix + a tx executor
+      // (spec-479 D-1); the resolver prefix-matches so every descendant path is
+      // covered by this one row.
+      await insertRedirect(ns.slug, newSlug, "namespace_rename", tx);
 
       return updated;
     }),

--- a/packages/server/src/services/redirects.ts
+++ b/packages/server/src/services/redirects.ts
@@ -278,8 +278,14 @@ export async function insertRedirect(
 // resolution (std-10 cl-91) would let the new entity shadow the redirect and
 // silently mis-route every old link to the wrong place. Callers consult this
 // before (re)registering a slug. old_path is the PK, so this is an index hit.
-export async function isRedirectSource(path: string): Promise<boolean> {
-  const rows = (await db.execute(sql`
+// Accepts an optional `executor` (mirrors insertRedirect) so a rename can run
+// the guard inside its own transaction, consistent with the reservation/taken
+// checks it sits beside.
+export async function isRedirectSource(
+  path: string,
+  executor: SqlExecutor = db
+): Promise<boolean> {
+  const rows = (await executor.execute(sql`
     SELECT 1 FROM redirects WHERE old_path = ${path} LIMIT 1
   `)) as unknown as unknown[];
   return rows.length > 0;

--- a/packages/server/src/services/shared/slug.ts
+++ b/packages/server/src/services/shared/slug.ts
@@ -4,7 +4,7 @@
 // and the rename cooldown are all centralised here so the route layer, the DB
 // CHECK constraint, and the t-1 e2e spec stay in sync.
 
-import { eq, lt } from "drizzle-orm";
+import { eq, lt, sql } from "drizzle-orm";
 import { db } from "../../db/connection.js";
 import { namespaces, namespaceSlugReservations } from "../../db/schema.js";
 
@@ -90,6 +90,18 @@ export async function isSlugAvailable(slug: string): Promise<boolean> {
     where: eq(namespaceSlugReservations.slug, normalized),
   });
   if (reserved && reserved.reservedUntil > now) return false;
+
+  // spec-481 D-2 reuse-guard: a slug that a rename points AWAY from (the
+  // old_path of a live redirect) must stay unavailable even after its 30-day
+  // reservation lapses — otherwise a reborn namespace would shadow the permanent
+  // redirect under direct-first resolution (std-10 cl-91) and silently
+  // mis-route old links. Mirrors spec-479 D-4's isRedirectSource; inlined here
+  // to avoid a shared/ → services/redirects import cycle.
+  const redirected = (await db.execute(
+    sql`SELECT 1 FROM redirects WHERE old_path = ${normalized} LIMIT 1`,
+  )) as unknown as unknown[];
+  if (redirected.length > 0) return false;
+
   return true;
 }
 

--- a/packages/ui/e2e/journey-62-spec-481-namespace-rename.spec.ts
+++ b/packages/ui/e2e/journey-62-spec-481-namespace-rename.spec.ts
@@ -73,4 +73,11 @@ test("admin renames the namespace slug from Settings; old deep links forward (ac
   // resolver rewrites every descendant path from it.
   await page.goto(tenantPath(oldNs, "workspace", "/specs"));
   await expect(page).toHaveURL(tenantPath(newNs, "workspace", "/specs"));
+
+  // ac-2 (bare home): the OLD bare namespace home forwards too. NamespaceHome
+  // consults the redirect layer on a miss rather than dead-ending on
+  // "Namespace not found" — so EVERY previously-valid URL under the old slug
+  // forwards, not just deep tenant paths.
+  await page.goto(bareUrl(`/${oldNs}`));
+  await expect(page).toHaveURL(bareUrl(`/${newNs}`));
 });

--- a/packages/ui/e2e/journey-62-spec-481-namespace-rename.spec.ts
+++ b/packages/ui/e2e/journey-62-spec-481-namespace-rename.spec.ts
@@ -1,0 +1,76 @@
+import {
+  test,
+  expect,
+  tenantPath,
+  bareUrl,
+  DEV_EMAIL,
+  seedOrg,
+  emitAcEvents,
+} from "./helpers/index.js";
+
+// Journey 62 — spec-481: rename a NAMESPACE slug from /:namespace/settings, and
+// prove old links under the namespace forward to the new slug (std-28 gate).
+//
+// Emits:
+//   ac-1 — an admin renames the namespace slug from a web UI surface (org namespace)
+//   ac-4 — the /:namespace/settings page gates on live availability, states its
+//          consequences before commit, then navigates to the new /<new-ns>/ home
+//   ac-2 — a previously-valid DEEP tenant URL under the OLD namespace slug forwards
+//          to its new-slug equivalent in the browser (TenantLayout stale-forward)
+
+const AC = [
+  "mindset-prod/memex-building-itself/specs/spec-481/acs/ac-1",
+  "mindset-prod/memex-building-itself/specs/spec-481/acs/ac-2",
+  "mindset-prod/memex-building-itself/specs/spec-481/acs/ac-4",
+];
+
+test.afterEach(async ({}, testInfo) => {
+  if (testInfo.status === "skipped") return;
+  await emitAcEvents(
+    AC,
+    testInfo.status === "passed" ? "pass" : "fail",
+    `packages/ui/e2e/journey-62-spec-481-namespace-rename.spec.ts::${testInfo.title}`,
+    testInfo.duration,
+  );
+});
+
+test("admin renames the namespace slug from Settings; old deep links forward (ac-1, ac-2, ac-4)", async ({
+  page,
+  resources,
+}) => {
+  const oldNs = resources.slug("rename-ns");
+  const newNs = resources.slug("rename-ns-new");
+  await seedOrg({
+    ownerEmail: DEV_EMAIL,
+    slug: oldNs,
+    memexSlug: "workspace",
+    memexName: "Workspace",
+  });
+
+  // ── The settings surface renders for the admin. ──
+  await page.goto(bareUrl(`/${oldNs}/settings`));
+  const section = page.getByTestId("namespace-rename");
+  await expect(section).toBeVisible();
+
+  // ── Slug: change → live availability clears → confirm consequences →
+  //    navigate to the new /<new-ns>/ home. ──
+  await page.getByTestId("namespace-slug-input").fill(newNs);
+  const renameBtn = page.getByTestId("namespace-slug-rename");
+  await expect(renameBtn).toBeEnabled(); // enables once the debounced check reports free
+  await renameBtn.click();
+
+  // ac-4: the confirm names the consequence (old links forward) BEFORE commit.
+  const confirm = page.getByTestId("namespace-slug-confirm");
+  await expect(confirm).toBeVisible();
+  await expect(confirm).toContainText("forward");
+  await page.getByTestId("namespace-slug-confirm-btn").click();
+
+  // ac-1 slug half: navigates to the new /<new-ns>/ home.
+  await expect(page).toHaveURL(bareUrl(`/${newNs}`));
+
+  // ac-2: a bookmarked OLD deep tenant URL forwards to the new-slug equivalent
+  // in the browser. The namespace_rename redirect is a 1-segment prefix, so the
+  // resolver rewrites every descendant path from it.
+  await page.goto(tenantPath(oldNs, "workspace", "/specs"));
+  await expect(page).toHaveURL(tenantPath(newNs, "workspace", "/specs"));
+});

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -32,6 +32,9 @@ const IssuesList = lazy(() => import('./pages/IssuesList').then((m) => ({ defaul
 const NamespaceHome = lazy(() =>
   import('./pages/NamespaceHome').then((m) => ({ default: m.NamespaceHome })),
 );
+const NamespaceSettings = lazy(() =>
+  import('./pages/NamespaceSettings').then((m) => ({ default: m.NamespaceSettings })),
+);
 const HomeCanvas = lazy(() => import('./pages/HomeCanvas').then((m) => ({ default: m.HomeCanvas })));
 const StandardList = lazy(() =>
   import('./pages/StandardList').then((m) => ({ default: m.StandardList })),
@@ -593,6 +596,13 @@ export function PostLoginRouter() {
           OrgHome / Personal Home. More specific /:namespace/:memex routes below
           take precedence (React Router 7 specificity). */}
       <Route path="/:namespace" element={<FlatShell><NamespaceHome /></FlatShell>} />
+
+      {/* spec-481 t-2 (ac-4): per-namespace settings — the namespace-slug rename
+          surface. `settings` is a reserved slug (no Memex can be named it), so
+          this static segment safely wins over the `/:namespace/:memex` dynamic
+          route below (RRv7 ranks static above dynamic). Declared before it to
+          keep the precedence obvious to a reader too. */}
+      <Route path="/:namespace/settings" element={<FlatShell><NamespaceSettings /></FlatShell>} />
 
       {/* Tenancy-scoped routes — every path segment lives under /:ns/:mx. */}
       <Route path="/:namespace/:memex" element={<TenantLayout />}>

--- a/packages/ui/src/api/auth.ts
+++ b/packages/ui/src/api/auth.ts
@@ -333,7 +333,13 @@ export interface OrgCreateResponse {
   namespace: { id: string; slug: string; kind: 'user' | 'org' };
 }
 
-export type OrgSlugCheckReason = 'too_short' | 'too_long' | 'invalid_chars' | 'reserved' | 'taken';
+export type OrgSlugCheckReason =
+  | 'too_short'
+  | 'too_long'
+  | 'invalid_chars'
+  | 'reserved'
+  | 'taken'
+  | 'redirected';
 
 export interface OrgSlugCheckResult {
   available: boolean;

--- a/packages/ui/src/components/AddMemexForm.tsx
+++ b/packages/ui/src/components/AddMemexForm.tsx
@@ -22,6 +22,7 @@ const SLUG_REASON_MESSAGES: Record<OrgSlugCheckReason, string> = {
   invalid_chars: 'Use only letters, numbers, and hyphens (no leading or trailing hyphen)',
   reserved: 'That slug is reserved — pick another',
   taken: 'That slug is already taken in this Org',
+  redirected: 'That slug was used before and is reserved by a redirect',
 };
 
 const ERROR_CODE_MESSAGES: Record<string, string> = {

--- a/packages/ui/src/components/CreateOrgForm.tsx
+++ b/packages/ui/src/components/CreateOrgForm.tsx
@@ -22,6 +22,7 @@ const SLUG_REASON_MESSAGES: Record<OrgSlugCheckReason, string> = {
   invalid_chars: 'Use only letters, numbers, and hyphens (no leading or trailing hyphen)',
   reserved: 'That namespace is reserved — pick another',
   taken: 'That namespace is already taken',
+  redirected: 'That namespace was used before and is reserved by a redirect',
 };
 
 // Server-side error codes we render targeted copy for. Anything else falls through

--- a/packages/ui/src/components/RenameNamespaceSection.test.tsx
+++ b/packages/ui/src/components/RenameNamespaceSection.test.tsx
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { tagAc } from '@memex-ai-ac/vitest';
+
+// spec-481 t-2 — component-level verification of the namespace-slug rename.
+// Proves the UI behaviour (gated on live availability, states consequences
+// before commit, then renames + refreshes the session BEFORE navigating to the
+// new /<new-ns>/ home) with the API + router mocked. The full-page journey
+// (journey-62) covers ac-2's old-link forward end-to-end in CI's cold-DB gate.
+const AC_UI = 'mindset-prod/memex-building-itself/specs/spec-481/acs/ac-4';
+
+const navigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual =
+    await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return { ...actual, useNavigate: () => navigate };
+});
+
+const refreshSession = vi.fn();
+vi.mock('./AuthContext', () => ({
+  useAuth: () => ({ token: 'test-token', refreshSession }),
+}));
+
+const checkNamespaceSlugApi = vi.fn();
+const renameNamespaceSlugApi = vi.fn();
+vi.mock('../api/client', () => ({
+  checkNamespaceSlugApi: (...a: unknown[]) => checkNamespaceSlugApi(...a),
+  renameNamespaceSlugApi: (...a: unknown[]) => renameNamespaceSlugApi(...a),
+}));
+
+import { RenameNamespaceSection } from './RenameNamespaceSection';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  refreshSession.mockResolvedValue(undefined);
+});
+
+function renderSection() {
+  return render(
+    <MemoryRouter>
+      <RenameNamespaceSection namespaceId="ns-uuid" currentSlug="acme" />
+    </MemoryRouter>,
+  );
+}
+
+describe('RenameNamespaceSection (spec-481 t-2)', () => {
+  it('gates on availability, confirms consequences, then renames + refreshes before navigating', async () => {
+    tagAc(AC_UI);
+    checkNamespaceSlugApi.mockResolvedValue({ available: true });
+    renameNamespaceSlugApi.mockResolvedValue({ namespace: { id: 'ns-uuid', slug: 'globex' } });
+    const user = userEvent.setup();
+    renderSection();
+
+    const slugInput = await screen.findByTestId('namespace-slug-input');
+    await user.clear(slugInput);
+    await user.type(slugInput, 'globex');
+
+    const renameBtn = screen.getByTestId('namespace-slug-rename');
+    await waitFor(() => expect(renameBtn).toBeEnabled());
+    await user.click(renameBtn);
+
+    // Consequences stated BEFORE commit (30-day cooldown + old links forward).
+    const confirm = await screen.findByTestId('namespace-slug-confirm');
+    expect(confirm).toHaveTextContent(/forward/i);
+    expect(confirm).toHaveTextContent(/30 days/i);
+
+    await user.click(screen.getByTestId('namespace-slug-confirm-btn'));
+    await waitFor(() =>
+      expect(renameNamespaceSlugApi).toHaveBeenCalledWith('ns-uuid', 'globex', 'test-token'),
+    );
+    await waitFor(() => expect(navigate).toHaveBeenCalled());
+    // The session MUST refresh before navigating — otherwise TenantLayout gates
+    // tenant URLs on stale membership (old slug) and bounces the user. This is
+    // the spec-479 journey-61 regression, carried forward.
+    expect(refreshSession).toHaveBeenCalled();
+    expect(refreshSession.mock.invocationCallOrder[0]).toBeLessThan(
+      navigate.mock.invocationCallOrder[0],
+    );
+    // ac-4: navigates to the new /<new-ns>/ home.
+    expect(navigate).toHaveBeenCalledWith('/globex', { replace: true });
+  });
+
+  it('blocks the rename and explains when the slug is reserved by a prior rename', async () => {
+    tagAc(AC_UI);
+    checkNamespaceSlugApi.mockResolvedValue({ available: false, reason: 'redirected' });
+    const user = userEvent.setup();
+    renderSection();
+
+    const slugInput = await screen.findByTestId('namespace-slug-input');
+    await user.clear(slugInput);
+    await user.type(slugInput, 'oldname');
+
+    await waitFor(() =>
+      expect(screen.getByTestId('namespace-slug-unavailable')).toBeInTheDocument(),
+    );
+    expect(screen.getByTestId('namespace-slug-unavailable')).toHaveTextContent(/reserved/i);
+    expect(screen.getByTestId('namespace-slug-rename')).toBeDisabled();
+  });
+});

--- a/packages/ui/src/components/RenameNamespaceSection.tsx
+++ b/packages/ui/src/components/RenameNamespaceSection.tsx
@@ -1,0 +1,177 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Button } from './ui/Button';
+import { Input } from './ui/Input';
+import { Alert } from './ui/Alert';
+import { useAuth } from './AuthContext';
+import {
+  checkNamespaceSlugApi,
+  renameNamespaceSlugApi,
+  type OrgSlugCheckResult,
+} from '../api/client';
+
+// spec-481 t-2 — the namespace-slug rename control on /:namespace/settings.
+//
+// A namespace has no display name (only orgs do — edited elsewhere), so unlike
+// RenameMemexSection this is slug-only. The slug is the first URL segment;
+// renaming it changes every link under the namespace, so it goes through a
+// confirm and, on success, navigates to the new /<new-ns>/ home (ac-4). Old
+// links keep working via the server's namespace_rename redirect (std-10 §7),
+// and the freed slug can't be reused while that redirect is live (D-2) —
+// surfaced live by the availability check as "reserved by a redirect".
+export function RenameNamespaceSection({
+  namespaceId,
+  currentSlug,
+}: {
+  namespaceId: string;
+  currentSlug: string;
+}) {
+  const { token, refreshSession } = useAuth();
+  const navigate = useNavigate();
+
+  const [slug, setSlug] = useState(currentSlug);
+  const [check, setCheck] = useState<OrgSlugCheckResult | null>(null);
+  const [checking, setChecking] = useState(false);
+  const [confirming, setConfirming] = useState(false);
+  const [renaming, setRenaming] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const checkSeq = useRef(0);
+
+  // Live slug availability — 400ms debounce, seq-guarded (mirrors
+  // RenameMemexSection / CreateOrgForm), only while the slug differs from the
+  // persisted value. The namespace pool is global, so the check takes no
+  // namespaceId.
+  useEffect(() => {
+    const trimmed = slug.trim().toLowerCase();
+    if (!trimmed || trimmed === currentSlug) {
+      setCheck(null);
+      setChecking(false);
+      return;
+    }
+    setChecking(true);
+    const seq = ++checkSeq.current;
+    const handle = window.setTimeout(async () => {
+      try {
+        const result = await checkNamespaceSlugApi(trimmed, token);
+        if (checkSeq.current === seq) {
+          setCheck(result);
+          setChecking(false);
+        }
+      } catch {
+        if (checkSeq.current === seq) {
+          setCheck(null);
+          setChecking(false);
+        }
+      }
+    }, 400);
+    return () => window.clearTimeout(handle);
+  }, [slug, currentSlug, token]);
+
+  const onConfirmRename = useCallback(async () => {
+    const trimmed = slug.trim().toLowerCase();
+    setRenaming(true);
+    setError(null);
+    try {
+      const { namespace } = await renameNamespaceSlugApi(namespaceId, trimmed, token);
+      // Refresh the session FIRST: its membership rows still carry the old
+      // namespace slug, and TenantLayout gates tenant URLs on membership —
+      // navigating before the refresh can bounce the user to their default
+      // landing (the spec-479 lesson). Only then navigate to the new namespace
+      // home (server-validated slug → safe/same-origin path).
+      await refreshSession();
+      navigate(`/${namespace.slug}`, { replace: true });
+    } catch (err) {
+      setError((err as Error).message);
+      setRenaming(false);
+      setConfirming(false);
+    }
+  }, [slug, namespaceId, token, navigate, refreshSession]);
+
+  const trimmedSlug = slug.trim().toLowerCase();
+  const slugChanged = trimmedSlug !== '' && trimmedSlug !== currentSlug;
+  const slugAvailable = check?.available === true;
+
+  return (
+    <section className="space-y-6" data-testid="namespace-rename">
+      <div>
+        <h3 className="text-sm font-semibold text-heading">Namespace URL</h3>
+        <p className="text-sm text-secondary mt-1">
+          Change the address that every Memex in this namespace lives under.
+        </p>
+      </div>
+
+      {error && (
+        <Alert variant="danger" size="md">
+          {error}
+        </Alert>
+      )}
+
+      <div className="space-y-2">
+        <label className="block text-sm text-secondary">
+          URL address
+          <div className="flex gap-2 mt-1">
+            <Input
+              value={slug}
+              onChange={(e) => {
+                setSlug(e.target.value);
+                setConfirming(false);
+              }}
+              data-testid="namespace-slug-input"
+            />
+            <Button
+              variant="secondary"
+              onClick={() => setConfirming(true)}
+              disabled={!slugChanged || !slugAvailable || checking}
+              data-testid="namespace-slug-rename"
+            >
+              Rename URL
+            </Button>
+          </div>
+        </label>
+        <p className="text-xs text-muted">
+          memex.ai/<span className="text-primary">{trimmedSlug || currentSlug}</span>
+        </p>
+        {slugChanged && !checking && check && !check.available && (
+          <div
+            className="text-xs text-status-danger-text"
+            data-testid="namespace-slug-unavailable"
+          >
+            {check.reason === 'redirected'
+              ? 'That address was used before and is reserved by a redirect.'
+              : check.reason === 'taken' || check.reason === 'reserved'
+                ? 'That address is already taken.'
+                : "That address isn't valid."}
+          </div>
+        )}
+      </div>
+
+      {confirming && (
+        <div
+          className="space-y-3 p-3 rounded-lg border border-edge bg-card"
+          data-testid="namespace-slug-confirm"
+        >
+          <p className="text-sm text-primary">
+            Rename the namespace URL to <code>{trimmedSlug}</code>?
+          </p>
+          <ul className="text-xs text-secondary list-disc pl-5 space-y-1">
+            <li>Every Memex in this namespace moves to the new address.</li>
+            <li>Old links keep working — they forward to the new address.</li>
+            <li>You can't rename again for 30 days, and the old address stays reserved.</li>
+          </ul>
+          <div className="flex gap-2">
+            <Button
+              onClick={onConfirmRename}
+              disabled={renaming}
+              data-testid="namespace-slug-confirm-btn"
+            >
+              {renaming ? 'Renaming…' : 'Confirm rename'}
+            </Button>
+            <Button variant="ghost" onClick={() => setConfirming(false)} disabled={renaming}>
+              Cancel
+            </Button>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/packages/ui/src/pages/NamespaceHome.test.tsx
+++ b/packages/ui/src/pages/NamespaceHome.test.tsx
@@ -4,11 +4,20 @@ import { MemoryRouter, Routes, Route } from 'react-router-dom';
 
 const listMyNamespacesApi = vi.hoisted(() => vi.fn());
 const getNamespaceHomeApi = vi.hoisted(() => vi.fn());
+const resolveTenantRedirectApi = vi.hoisted(() => vi.fn());
 
 vi.mock('../api/client', () => ({
   listMyNamespacesApi,
   getNamespaceHomeApi,
+  resolveTenantRedirectApi,
 }));
+
+const navigate = vi.hoisted(() => vi.fn());
+vi.mock('react-router-dom', async () => {
+  const actual =
+    await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return { ...actual, useNavigate: () => navigate };
+});
 
 vi.mock('../components/AuthContext', () => ({
   useAuth: () => ({ token: 'fake', session: { user: { id: 'u-1' } } }),
@@ -38,6 +47,9 @@ describe('NamespaceHome', () => {
   beforeEach(() => {
     listMyNamespacesApi.mockReset();
     getNamespaceHomeApi.mockReset();
+    resolveTenantRedirectApi.mockReset();
+    resolveTenantRedirectApi.mockResolvedValue(null); // default: no redirect
+    navigate.mockReset();
   });
   afterEach(() => vi.restoreAllMocks());
 
@@ -96,11 +108,24 @@ describe('NamespaceHome', () => {
     expect(screen.getByRole('button', { name: /Create an Org/ })).toBeInTheDocument();
   });
 
-  it('shows an error when the namespace is not in the picker list', async () => {
+  it('shows not-found when the namespace is missing and has no redirect', async () => {
     listMyNamespacesApi.mockResolvedValue([]);
     renderAt('/missing');
     await waitFor(() =>
-      expect(screen.getByText(/Failed to load namespace/)).toBeInTheDocument(),
+      expect(screen.getByText('Namespace not found')).toBeInTheDocument(),
     );
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it('forwards a bare stale namespace home to the renamed slug (spec-481 ac-2)', async () => {
+    // The slug isn't in the caller's list (renamed away), but the redirect
+    // layer resolves it → the bare home forwards instead of dead-ending.
+    listMyNamespacesApi.mockResolvedValue([]);
+    resolveTenantRedirectApi.mockResolvedValue('/new-ns');
+    renderAt('/old-ns');
+    await waitFor(() =>
+      expect(navigate).toHaveBeenCalledWith('/new-ns', { replace: true }),
+    );
+    expect(screen.queryByText('Namespace not found')).toBeNull();
   });
 });

--- a/packages/ui/src/pages/NamespaceHome.tsx
+++ b/packages/ui/src/pages/NamespaceHome.tsx
@@ -131,7 +131,16 @@ export function NamespaceHome() {
   if (kind === 'personal' && personalHome && namespaceSlug) {
     return (
       <div className="max-w-2xl mx-auto px-6 py-10">
-        <h1 className="text-2xl font-semibold text-heading mb-2">Your personal Memex</h1>
+        <div className="flex items-start justify-between gap-4 mb-2">
+          <h1 className="text-2xl font-semibold text-heading">Your personal Memex</h1>
+          {/* spec-481 t-2 — entry point to the namespace-slug rename surface. */}
+          <Link
+            to={`/${namespaceSlug}/settings`}
+            className="text-sm text-secondary hover:text-link whitespace-nowrap mt-1"
+          >
+            Namespace settings →
+          </Link>
+        </div>
         <p className="text-secondary mb-6">
           Yours forever. Use it for personal notes, drafts, and your own Specs.
         </p>
@@ -274,6 +283,15 @@ function OrgCard({
             <Button variant="secondary" onClick={onInviteMembers}>
               Invite members
             </Button>
+          )}
+          {isAdmin && (
+            // spec-481 t-2 — entry point to the namespace-slug rename surface.
+            <Link
+              to={`/${namespaceSlug}/settings`}
+              className="text-sm px-3 py-1.5 rounded-md border border-edge text-secondary hover:bg-card-hover transition-colors"
+            >
+              Settings
+            </Link>
           )}
           <Button variant="secondary" onClick={onAddMemex}>+ Add Memex</Button>
         </div>

--- a/packages/ui/src/pages/NamespaceHome.tsx
+++ b/packages/ui/src/pages/NamespaceHome.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useState } from 'react';
-import { useParams, Link } from 'react-router-dom';
+import { useParams, useNavigate, useLocation, Link } from 'react-router-dom';
 import { useAuth } from '../components/AuthContext';
 import {
   getNamespaceHomeApi,
   listMyNamespacesApi,
   type NamespaceHomeResponse,
 } from '../api/client';
+import { useStaleTenantForward } from '../hooks/useStaleTenantForward';
 import { tenantPathFor } from '../utils/tenantUrl';
 import { AddMemexDialog } from '../components/AddMemexDialog';
 import { CreateOrgDialog } from '../components/CreateOrgDialog';
@@ -31,6 +32,8 @@ interface OrgEntry {
 export function NamespaceHome() {
   const { namespace: namespaceSlug } = useParams<{ namespace: string }>();
   const { token, refreshSession } = useAuth();
+  const navigate = useNavigate();
+  const location = useLocation();
   const [kind, setKind] = useState<'personal' | 'org' | null>(null);
   const [personalHome, setPersonalHome] = useState<
     Extract<NamespaceHomeResponse, { kind: 'personal' }> | null
@@ -38,6 +41,12 @@ export function NamespaceHome() {
   const [orgs, setOrgs] = useState<OrgEntry[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  // spec-481 ac-2 — a bare `/<old-ns>` home is a resolution miss after a
+  // namespace rename. Unlike deep tenant paths (TenantLayout forwards those),
+  // this page has to consult the redirect layer itself so the bare home URL
+  // forwards to `/<new-ns>` too, instead of dead-ending on "Namespace not
+  // found". `notFound` gates the same stale-forward hook TenantLayout uses.
+  const [notFound, setNotFound] = useState(false);
   const [addMemexForOrg, setAddMemexForOrg] = useState<OrgEntry | null>(null);
   const [inviteForOrg, setInviteForOrg] = useState<OrgEntry | null>(null);
   const [createOrgOpen, setCreateOrgOpen] = useState(false);
@@ -50,6 +59,7 @@ export function NamespaceHome() {
     if (!namespaceSlug) return;
     setLoading(true);
     setError(null);
+    setNotFound(false);
     let cancelled = false;
     (async () => {
       try {
@@ -57,7 +67,9 @@ export function NamespaceHome() {
         const match = groups.find((g) => g.namespaceSlug === namespaceSlug);
         if (!match?.namespaceId) {
           if (!cancelled) {
-            setError('Namespace not found');
+            // Don't dead-end: flag a miss and let the stale-forward hook below
+            // consult the redirect layer (a renamed namespace forwards).
+            setNotFound(true);
             setLoading(false);
           }
           return;
@@ -110,10 +122,41 @@ export function NamespaceHome() {
     };
   }, [namespaceSlug, token, reloadTick]);
 
+  // On a resolution miss, ask the server whether this bare namespace path
+  // forwards (a renamed slug). Fires only while `notFound` (mirrors
+  // TenantLayout's use of the same hook for deep tenant paths).
+  const staleForward = useStaleTenantForward(location.pathname, notFound);
+  useEffect(() => {
+    if (staleForward.state === 'done' && staleForward.to) {
+      navigate(staleForward.to, { replace: true });
+    }
+  }, [staleForward, navigate]);
+
   if (loading) {
     return (
       <div className="flex justify-center items-center min-h-[50vh]">
         <Spinner />
+      </div>
+    );
+  }
+
+  // A miss: keep rendering the spinner while the redirect lookup is in flight or
+  // a forward is about to navigate; only show "not found" once the lookup
+  // resolves to no redirect.
+  if (notFound) {
+    const settled = staleForward.state === 'done' && !staleForward.to;
+    if (!settled) {
+      return (
+        <div className="flex justify-center items-center min-h-[50vh]">
+          <Spinner />
+        </div>
+      );
+    }
+    return (
+      <div className="px-6 py-8">
+        <div className="bg-status-danger-bg border border-status-danger-border rounded-lg p-4 text-status-danger-text">
+          Namespace not found
+        </div>
       </div>
     );
   }

--- a/packages/ui/src/pages/NamespaceSettings.test.tsx
+++ b/packages/ui/src/pages/NamespaceSettings.test.tsx
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { tagAc } from '@memex-ai-ac/vitest';
+
+// spec-481 t-2 (ac-1) — the settings page shows the rename control only to an
+// administrator, and hides it (std-7 posture) from a non-admin member. Resolves
+// the namespace + role from the caller's own namespace list.
+const AC_SCOPE = 'mindset-prod/memex-building-itself/specs/spec-481/acs/ac-1';
+
+vi.mock('../components/AuthContext', () => ({
+  useAuth: () => ({ token: 'test-token', refreshSession: vi.fn() }),
+}));
+
+const listMyNamespacesApi = vi.fn();
+vi.mock('../api/client', () => ({
+  listMyNamespacesApi: (...a: unknown[]) => listMyNamespacesApi(...a),
+}));
+
+// The rename section is exercised in its own test; stub it so this test targets
+// the page's resolve + authorize logic in isolation.
+vi.mock('../components/RenameNamespaceSection', () => ({
+  RenameNamespaceSection: ({ currentSlug }: { currentSlug: string }) => (
+    <div data-testid="rename-section">rename {currentSlug}</div>
+  ),
+}));
+
+import { NamespaceSettings } from './NamespaceSettings';
+
+function renderAt(slug: string) {
+  return render(
+    <MemoryRouter initialEntries={[`/${slug}/settings`]}>
+      <Routes>
+        <Route path="/:namespace/settings" element={<NamespaceSettings />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('NamespaceSettings (spec-481 t-2)', () => {
+  it('renders the rename control for an administrator', async () => {
+    tagAc(AC_SCOPE);
+    listMyNamespacesApi.mockResolvedValue([
+      { namespaceId: 'ns-1', namespaceSlug: 'acme', kind: 'team', role: 'administrator', memexes: [] },
+    ]);
+    renderAt('acme');
+    expect(await screen.findByTestId('rename-section')).toHaveTextContent('rename acme');
+  });
+
+  it('hides the control from a non-admin member', async () => {
+    tagAc(AC_SCOPE);
+    listMyNamespacesApi.mockResolvedValue([
+      { namespaceId: 'ns-1', namespaceSlug: 'acme', kind: 'team', role: 'member', memexes: [] },
+    ]);
+    renderAt('acme');
+    await waitFor(() =>
+      expect(screen.getByText(/only administrators/i)).toBeInTheDocument(),
+    );
+    expect(screen.queryByTestId('rename-section')).toBeNull();
+  });
+});

--- a/packages/ui/src/pages/NamespaceSettings.tsx
+++ b/packages/ui/src/pages/NamespaceSettings.tsx
@@ -1,0 +1,72 @@
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { useAuth } from '../components/AuthContext';
+import { listMyNamespacesApi, type NamespaceGroup } from '../api/client';
+import { RenameNamespaceSection } from '../components/RenameNamespaceSection';
+import { PageHeader } from '../components/PageHeader';
+import { Spinner } from '../components/Spinner';
+
+// spec-481 t-2 (ac-4/ac-1) — the per-namespace settings page, mounted at
+// /:namespace/settings (safe above /:namespace/:memex because `settings` is a
+// reserved slug, so no Memex can be named it). Serves both org and personal
+// namespaces: it resolves the namespaceId + caller role from the caller's own
+// namespace list (same source as NamespaceHome), and only an administrator sees
+// the rename control (personal-namespace owners come back as `administrator`).
+// Authorization is enforced server-side too (renameNamespaceSlug) per std-7;
+// this gate just avoids showing a control that would 4xx.
+export function NamespaceSettings() {
+  const { namespace: namespaceSlug } = useParams<{ namespace: string }>();
+  const { token } = useAuth();
+  const [group, setGroup] = useState<NamespaceGroup | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!namespaceSlug) return;
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    listMyNamespacesApi(token)
+      .then((groups) => {
+        if (cancelled) return;
+        setGroup(groups.find((g) => g.namespaceSlug === namespaceSlug) ?? null);
+        setLoading(false);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : 'Failed to load');
+        setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [namespaceSlug, token]);
+
+  if (loading) {
+    return (
+      <div className="flex justify-center items-center min-h-[50vh]">
+        <Spinner />
+      </div>
+    );
+  }
+
+  const isAdmin = group?.role === 'administrator' && !!group.namespaceId;
+
+  return (
+    <div className="max-w-2xl mx-auto px-6 py-6 space-y-6">
+      <PageHeader title="Namespace settings" />
+      {error && <p className="text-sm text-status-danger-text">{error}</p>}
+      {!error && !isAdmin && (
+        <p className="text-sm text-secondary">
+          Only administrators can configure this namespace.
+        </p>
+      )}
+      {isAdmin && group && (
+        <RenameNamespaceSection
+          namespaceId={group.namespaceId!}
+          currentSlug={group.namespaceSlug}
+        />
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Namespace-slug rename becomes a first-class **web UI** feature (spec-481). The backend rename existed since doc-19; this ships the missing UI surface, closes a real D-2 correctness hole in the backend, and makes old links forward under either reading of ac-2.

### Front-end
- **New page `/<namespace>/settings`** (`NamespaceSettings` + `RenameNamespaceSection`): admin-gated (org admin or personal-namespace owner), live slug availability, consequences confirm (Memexes move · old links forward · 30-day cooldown), `refreshSession()` **before** navigating to the new `/<new-ns>/` home (the spec-479 lesson — stale membership otherwise bounces the user).
- Route ordered above `/:namespace/:memex` (static beats dynamic in RRv7; safe because `settings` is a reserved slug).
- Entry points: a "Settings" link on each org card + "Namespace settings →" on the personal home.
- **Old links forward** — deep tenant paths *and* the bare `/<old-ns>` home now forward to the new slug (reused `useStaleTenantForward` in `NamespaceHome`'s miss branch).

### Back-end
- **issue-1 fix (D-2):** `renameNamespaceSlug` now rejects renaming *to* a slug that is the source of a live redirect — previously enforced only in the isolated `isSlugAvailable` helper, so a raw `PATCH` could shadow a permanent redirect once the 30-day reservation lapsed and silently mis-route old links. `isRedirectSource` gained an optional tx-executor param.
- **std-32:** the rename mutation now threads `RequestCtx` (`channel:'rest_ui'` + actor) — was a channel-less attribution defect surfaced by journey-62.
- `GET /api/namespaces/check` returns `reason:'redirected'` for a redirect-source slug (parity with the memex check).

## Test plan
- [x] Full server suite: 5747 passed (only failure = documented `.ee/slack/oauth` local-red/CI-green flake).
- [x] Full UI suite: 2159 passed (`e2e-ac-emission.spec-391` fails only under `MEMEX_EMIT=false`; passed with emission on).
- [x] Mutation-level D-2 guard test (RED→GREEN); namespace check `'redirected'` test; RenameNamespaceSection + NamespaceSettings component tests; NamespaceHome bare-home forward regression test.
- [x] Playwright **journey-62** (deep-path + bare-home forward) — green locally; runs per-PR against a cold DB (std-28).
- [x] All 5 spec-481 ACs verified on the Memex board.
- [x] `tsc` clean (server + ui).

No schema migration — pure code. Licence: fair-code (open core); no `.ee` files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
