### PR TITLE
fix(ui): reorder Memex settings sections (identity + visibility first, rename last)

### DIFF
--- a/packages/ui/src/pages/MemexSettings.tsx
+++ b/packages/ui/src/pages/MemexSettings.tsx
@@ -50,12 +50,13 @@ export function MemexSettings() {
       {memexId ? (
         // Emission keys moved to their own member-visible page (spec-129 dec-8,
         // Option B): /<ns>/<mx>/keys. This admin-only page keeps Memex visibility
-        // and (spec-479) the rename controls.
+        // and (spec-479) the rename controls. Order: identity + visibility first
+        // (the Memex name heading + Private/Public), rename controls last.
         <>
+          <MemexVisibilitySettings memexId={memexId} />
           {tenant?.namespace && (
             <RenameMemexSection memexId={memexId} namespaceSlug={tenant.namespace} />
           )}
-          <MemexVisibilitySettings memexId={memexId} />
         </>
       ) : (
         <div className="text-sm text-muted">No Memex selected.</div>


### PR DESCRIPTION
## Summary

Small design tweak to the per-Memex settings page (`/<ns>/<mx>/settings`): show the Memex identity + visibility block first, and the rename controls last.

Before: **Rename** → (Memex name + **Visibility**)
After: (Memex name + **Visibility**) → **Rename**

One-line swap of the two child components in `MemexSettings.tsx`; no logic, no API, no schema change.

## Test plan
- [x] Production build (tsc + vite) green.
- [x] Playwright journey-61 (spec-479 memex-rename, which drives this page) green — order-independent, still finds + exercises the rename controls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)