### PR TITLE
feat(spec-480): win-back email — clickable video thumbnail + single-cohort send

### DIFF
--- a/packages/server/src/services/email/activation-backlog.integration.test.ts
+++ b/packages/server/src/services/email/activation-backlog.integration.test.ts
@@ -17,6 +17,9 @@ import { runActivationDrip, type CandidateUser } from "./activation-drip.js";
 import { selectBacklogCandidates } from "./activation-backlog.js";
 
 const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-427/acs/ac-${n}`;
+// spec-480 dec-9/dec-10: the backlog blast now sends the win-back (activation.signed_in_dormant) to
+// signed_in_dormant only; connected_inactive is deferred (not sent in v1).
+const AC480 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-480/acs/ac-${n}`;
 const NOW = new Date("2026-06-20T00:00:00Z");
 const daysAgo = (d: number) => new Date(NOW.getTime() - d * 24 * 60 * 60 * 1000);
 
@@ -86,15 +89,16 @@ describe("selectBacklogCandidates — the go-live cutoff (ac-9)", () => {
 });
 
 describe("backlog send over the candidate set (ac-5, ac-9)", () => {
-  it("sends the correct single email per still-stalled user; skips already-keyed + activated; no re-fire on the evergreen hand-off", async () => {
+  it("sends the win-back only to signed-in-dormant; defers connected-inactive; skips activated; no re-fire on the evergreen hand-off (ac-5, ac-9, spec-480 ac-14)", async () => {
     tagAc(AC(5));
     tagAc(AC(9));
-    // A — connected-inactive, stalled long ago → Email 1.
+    tagAc(AC480(14));
+    // A — connected-inactive, stalled long ago → DEFERRED in v1 (spec-480 dec-9), no send.
     const a = await seedUser("t8-a@example.test", { createdAt: daysAgo(60) });
     await seedMcpConnected(a.id, daysAgo(50));
-    // B — signed-in-dormant (verified long ago, never connected) → Email 2.
+    // B — signed-in-dormant (verified long ago, never connected) → the win-back.
     const b = await seedUser("t8-b@example.test", { createdAt: daysAgo(60), verifiedAt: daysAgo(60) });
-    // D — connected-inactive but ALREADY emailed (carries the key) → skipped.
+    // D — connected-inactive (deferred regardless of any prior key) → no send.
     const d = await seedUser("t8-d@example.test", { createdAt: daysAgo(60) });
     await seedMcpConnected(d.id, daysAgo(50));
     await recordComm({ userId: d.id, channel: "email", type: "activation.connected_inactive", subject: "sent earlier" });
@@ -104,15 +108,16 @@ describe("backlog send over the candidate set (ac-5, ac-9)", () => {
 
     const backlog = [a, b, d, e];
     const s1 = await runActivationDrip(NOW, undefined, backlog);
-    expect(s1.sent).toBe(2);
+    // Only B (signed_in_dormant) sends in v1; A + D are deferred connected_inactive.
+    expect(s1.sent).toBe(1);
     const byUser = new Map(sent.map((m) => [m.to, m.commsType]));
-    expect(byUser.get(a.email!)).toBe("activation.connected_inactive");
     expect(byUser.get(b.email!)).toBe("activation.signed_in_dormant");
-    expect(byUser.has(d.email!)).toBe(false); // already emailed
+    expect(byUser.has(a.email!)).toBe(false); // connected_inactive → deferred
+    expect(byUser.has(d.email!)).toBe(false); // connected_inactive → deferred
     expect(byUser.has(e.email!)).toBe(false); // activated
 
-    // Evergreen hand-off: switching the daily drip on afterwards must NOT re-send to
-    // anyone the backlog already emailed (they now all carry their key).
+    // Evergreen hand-off: switching the daily drip on afterwards must NOT re-send to B
+    // (now carries activation.signed_in_dormant), and still never sends the deferred cohort.
     sent = [];
     const s2 = await runActivationDrip(NOW, undefined, backlog);
     expect(s2.sent).toBe(0);

--- a/packages/server/src/services/email/activation-drip.integration.test.ts
+++ b/packages/server/src/services/email/activation-drip.integration.test.ts
@@ -13,6 +13,9 @@ import { setEmailSender, type EmailMessage } from "./sender.js";
 import { runActivationDrip, selectActivationCandidates, type CandidateUser } from "./activation-drip.js";
 
 const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-427/acs/ac-${n}`;
+// spec-480 amended the win-back orchestration (dec-9/dec-10): signed_in_dormant → the
+// video win-back keyed activation.signed_in_dormant; connected_inactive deferred (not sent in v1).
+const AC480 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-480/acs/ac-${n}`;
 const NOW = new Date("2026-06-20T00:00:00Z");
 const daysAgo = (d: number) => new Date(NOW.getTime() - d * 24 * 60 * 60 * 1000);
 
@@ -69,41 +72,45 @@ afterEach(async () => {
 });
 
 describe("runActivationDrip (real DB)", () => {
-  it("connected-inactive past 2d dwell → exactly one Email 1, recorded under its stable key; team From/Reply-To; no re-send (ac-1, ac-7, ac-14)", async () => {
-    tagAc(AC(1));
-    tagAc(AC(7));
-    tagAc(AC(14));
+  it("connected-inactive is deferred in v1 — nothing sent, nothing logged (spec-480 ac-14, dec-9)", async () => {
+    tagAc(AC480(14));
     const u = await seedUser("t7-e1@example.test", { name: "Ada Lovelace" });
     await seedMcpConnected(u.id, daysAgo(3)); // connected 3d ago, no tool call, no spec
 
     const s1 = await drip([u]);
-    expect(s1.sent).toBe(1);
-    expect(sent).toHaveLength(1);
+    // spec-480 dec-9/dec-10: connected_inactive is deferred to a separate later email —
+    // it never sends in v1, so the flag-flip's first blast is the win-back alone.
+    expect(s1.sent).toBe(0);
+    expect(sent).toHaveLength(0);
+    const rows = await db.select().from(commsLog).where(eq(commsLog.userId, u.id));
+    expect(rows).toHaveLength(0);
+  });
+
+  it("signed-in-dormant past 3d dwell → one win-back, keyed activation.signed_in_dormant, team From/Reply-To, no re-send (ac-2, ac-7, spec-480 ac-13/ac-14)", async () => {
+    tagAc(AC(2));
+    tagAc(AC(7));
+    tagAc(AC480(13));
+    tagAc(AC480(14));
+    tagAc(AC480(5)); // scope: ships inside the existing send path, recorded in comms_log, no render break
+    const u = await seedUser("t7-e2@example.test", { verifiedAt: daysAgo(4) }); // no mcp.connected
+    const s = await drip([u]);
+    expect(s.sent).toBe(1);
     const m = sent[0]!;
-    expect(m.commsType).toBe("activation.connected_inactive");
-    expect(m.to).toBe(u.email);
+    // spec-480 dec-8: the single stable win-back key; single "Connect your agent" CTA.
+    expect(m.commsType).toBe("activation.signed_in_dormant");
+    expect(m.html).toContain(">Connect your agent</a>");
     // ac-7: team identity, never a no-reply sender.
     expect(m.from).toBe("The Memex AI team <support@memex.ai>");
     expect(m.replyTo).toBe("support@memex.ai");
     expect(m.from?.toLowerCase()).not.toContain("no-reply");
     expect(m.from?.toLowerCase()).not.toContain("noreply");
 
-    // Recorded in comms_log under the stable key (ac-1 / ac-14).
-    const rows = await db.select().from(commsLog).where(and(eq(commsLog.userId, u.id), eq(commsLog.type, "activation.connected_inactive")));
+    // Recorded under the stable key; a second run dedups → exactly once.
+    const rows = await db.select().from(commsLog).where(and(eq(commsLog.userId, u.id), eq(commsLog.type, "activation.signed_in_dormant")));
     expect(rows).toHaveLength(1);
-
-    // Second run: dedup reads that row → exactly once (ac-1).
     const s2 = await drip([u]);
     expect(s2.sent).toBe(0);
     expect(sent).toHaveLength(1);
-  });
-
-  it("signed-in-dormant past 3d dwell → exactly one Email 2 (ac-2)", async () => {
-    tagAc(AC(2));
-    const u = await seedUser("t7-e2@example.test", { verifiedAt: daysAgo(4) }); // no mcp.connected
-    const s = await drip([u]);
-    expect(s.sent).toBe(1);
-    expect(sent[0]!.commsType).toBe("activation.signed_in_dormant");
   });
 
   it("dwell not yet elapsed → nothing sent", async () => {
@@ -113,32 +120,34 @@ describe("runActivationDrip (real DB)", () => {
     expect(sent).toHaveLength(0);
   });
 
-  it("a connected-inactive user gets Email 1 only — never both in a run (ac-3)", async () => {
+  it("at most one email per run — connected-inactive contributes zero (deferred) (ac-3, spec-480 ac-14)", async () => {
     tagAc(AC(3));
+    tagAc(AC480(14));
     const u = await seedUser("t7-excl@example.test");
     await seedMcpConnected(u.id, daysAgo(3));
     await drip([u]);
-    expect(sent.map((m) => m.commsType)).toEqual(["activation.connected_inactive"]);
+    // ac-3 exclusivity still holds; for connected_inactive in v1 the count is zero (deferred).
+    expect(sent.map((m) => m.commsType)).toEqual([]);
   });
 
-  it("state re-evaluated live: carries the E2 key from before, now connected → sends E1, not a repeat (ac-4)", async () => {
+  it("state re-evaluated live: a user who has since connected is deferred, not sent (ac-4, spec-480 ac-14)", async () => {
     tagAc(AC(4));
+    tagAc(AC480(14));
     const u = await seedUser("t7-progress@example.test");
     await seedMcpConnected(u.id, daysAgo(3)); // live cohort = connected_inactive
-    // They were emailed as signed-in-dormant earlier — seed that comms_log key.
-    await recordComm({ userId: u.id, channel: "email", type: "activation.signed_in_dormant", subject: "old" });
-
+    // spec-480 dec-9: the live re-eval still runs, but connected_inactive is deferred —
+    // v1 sends nothing (its "Connect your agent" CTA would be nonsensical here).
     const s = await drip([u]);
-    expect(s.sent).toBe(1);
-    expect(sent[0]!.commsType).toBe("activation.connected_inactive"); // next-state email, not a repeat
+    expect(s.sent).toBe(0);
+    expect(sent).toHaveLength(0);
   });
 
-  it("dedup keys on the stable comms key, NOT the subject line (ac-14)", async () => {
+  it("dedup keys on the stable comms key, NOT the subject line (ac-14, spec-480 ac-13)", async () => {
     tagAc(AC(14));
-    const u = await seedUser("t7-keydedup@example.test");
-    await seedMcpConnected(u.id, daysAgo(3));
-    // A prior row under the SAME key but a DIFFERENT subject must still suppress.
-    await recordComm({ userId: u.id, channel: "email", type: "activation.connected_inactive", subject: "a completely different subject" });
+    tagAc(AC480(13));
+    const u = await seedUser("t7-keydedup@example.test", { verifiedAt: daysAgo(4) }); // signed_in_dormant
+    // A prior row under the SAME win-back key but a DIFFERENT subject must still suppress.
+    await recordComm({ userId: u.id, channel: "email", type: "activation.signed_in_dormant", subject: "a completely different subject" });
 
     const s = await drip([u]);
     expect(s.sent).toBe(0); // deduped by key despite the mismatched subject

--- a/packages/server/src/services/email/activation-drip.test.ts
+++ b/packages/server/src/services/email/activation-drip.test.ts
@@ -5,6 +5,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { tagAc } from "@memex-ai-ac/vitest";
 
 const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-427/acs/ac-${n}`;
+// spec-480 amended the win-back orchestration (dec-9/dec-10): signed_in_dormant → the
+// video win-back keyed activation.signed_in_dormant; connected_inactive deferred (not sent in v1).
+const AC480 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-480/acs/ac-${n}`;
 
 // ── mock the DB-touching collaborators ──────────────────────────────────────
 const evaluateActivationState = vi.fn();
@@ -62,39 +65,44 @@ describe("dwellElapsed", () => {
     expect(dwellElapsed("connected_inactive", daysAgo(1), NOW)).toBe(false);
     expect(dwellElapsed("connected_inactive", daysAgo(2), NOW)).toBe(true);
   });
-  it("Email 2 fires at ~3 days in signed-in-dormant, not before", () => {
+  it("the win-back fires at ~3 days in signed-in-dormant, not before (spec-480 ac-12)", () => {
     tagAc(AC(2));
+    // spec-480 dec-7: 3 days (anchored to email_verified_at) is now the SOLE win-back dwell.
+    tagAc(AC480(12));
     expect(dwellElapsed("signed_in_dormant", daysAgo(2), NOW)).toBe(false);
     expect(dwellElapsed("signed_in_dormant", daysAgo(3), NOW)).toBe(true);
   });
 });
 
 describe("sendActivationEmailForUser — ladder + dwell + dedup", () => {
-  it("connected-inactive past dwell → sends Email 1 with the create-spec modal deep-link (ac-1)", async () => {
-    tagAc(AC(1));
+  it("connected-inactive is DEFERRED in v1 — evaluated but not sent (spec-480 ac-14, dec-9)", async () => {
+    tagAc(AC480(14));
     evaluateActivationState.mockResolvedValue({ cohort: "connected_inactive", enteredAt: daysAgo(3) });
     const out = await sendActivationEmailForUser(USER, NOW, fakeConn);
-    expect(out).toMatchObject({ cohort: "connected_inactive", sent: true, reason: "sent" });
-    expect(sendLifecycleEmail).toHaveBeenCalledTimes(1);
-    const [, msg] = sendLifecycleEmail.mock.calls[0]!;
-    expect(msg.commsType).toBe(ACTIVATION_COMMS_KEY.connected_inactive);
-    // Q1: the "Create a spec" CTA deep-links to the new-spec modal (?new=1).
-    expect(msg.html).toContain("?new=1");
-    expect(msg.text).toContain("Hi Ada,"); // first-name greeting
+    // spec-480 dec-9/dec-10: the win-back targets signed_in_dormant only; connected_inactive
+    // is deferred to a separate later email, so it never sends in v1.
+    expect(out).toMatchObject({ cohort: "connected_inactive", sent: false, reason: "deferred" });
+    expect(sendLifecycleEmail).not.toHaveBeenCalled();
   });
 
-  it("signed-in-dormant past dwell → sends Email 2 (ac-2)", async () => {
+  it("signed-in-dormant past dwell → sends the win-back, keyed activation.signed_in_dormant (ac-2, spec-480 ac-13/ac-14)", async () => {
     tagAc(AC(2));
+    tagAc(AC480(13));
+    tagAc(AC480(14));
     evaluateActivationState.mockResolvedValue({ cohort: "signed_in_dormant", enteredAt: daysAgo(4) });
     const out = await sendActivationEmailForUser(USER, NOW);
     expect(out).toMatchObject({ cohort: "signed_in_dormant", sent: true, reason: "sent" });
     const [, msg] = sendLifecycleEmail.mock.calls[0]!;
+    // spec-480 dec-8: the win-back template, keyed activation.signed_in_dormant; single "Connect your agent" CTA.
+    expect(msg.commsType).toBe("activation.signed_in_dormant");
     expect(msg.commsType).toBe(ACTIVATION_COMMS_KEY.signed_in_dormant);
+    expect(msg.html).toContain(">Connect your agent</a>");
   });
 
-  it("dwell not yet elapsed → no send (ac-1)", async () => {
-    tagAc(AC(1));
-    evaluateActivationState.mockResolvedValue({ cohort: "connected_inactive", enteredAt: daysAgo(1) });
+  it("dwell not yet elapsed → no send (spec-480 ac-12: single 3-day win-back dwell)", async () => {
+    tagAc(AC480(12));
+    // signed_in_dormant is the sole v1 cohort; its dwell is 3 days (email_verified_at).
+    evaluateActivationState.mockResolvedValue({ cohort: "signed_in_dormant", enteredAt: daysAgo(2) });
     const out = await sendActivationEmailForUser(USER, NOW);
     expect(out.reason).toBe("dwell_pending");
     expect(sendLifecycleEmail).not.toHaveBeenCalled();
@@ -107,36 +115,39 @@ describe("sendActivationEmailForUser — ladder + dwell + dedup", () => {
     expect(sendLifecycleEmail).not.toHaveBeenCalled();
   });
 
-  it("already sent this cohort's email → deduped, no re-send (ac-3)", async () => {
+  it("already sent the win-back → deduped, no re-send (ac-3, spec-480 ac-13)", async () => {
     tagAc(AC(3));
-    evaluateActivationState.mockResolvedValue({ cohort: "connected_inactive", enteredAt: daysAgo(3) });
+    tagAc(AC480(13));
+    evaluateActivationState.mockResolvedValue({ cohort: "signed_in_dormant", enteredAt: daysAgo(4) });
     hasComm.mockResolvedValue(true);
     const out = await sendActivationEmailForUser(USER, NOW);
     expect(out.reason).toBe("already_sent");
     expect(sendLifecycleEmail).not.toHaveBeenCalled();
   });
 
-  it("dedup counts the stable comms KEY, never the subject line (ac-14)", async () => {
+  it("dedup counts the stable comms KEY (activation.signed_in_dormant), never the subject line (ac-14, spec-480 ac-13)", async () => {
     tagAc(AC(14));
-    evaluateActivationState.mockResolvedValue({ cohort: "connected_inactive", enteredAt: daysAgo(3) });
-    await sendActivationEmailForUser(USER, NOW, fakeConn);
-    // The dedup read is keyed on the stable template key for the cohort — the machine
-    // key `activation.connected_inactive`, NOT the human subject line "Memex is
-    // connected. Here's what to do next." (which the dedup never sees).
-    expect(hasComm).toHaveBeenCalledWith(USER.id, "activation.connected_inactive", expect.anything());
+    tagAc(AC480(13));
+    evaluateActivationState.mockResolvedValue({ cohort: "signed_in_dormant", enteredAt: daysAgo(4) });
+    await sendActivationEmailForUser(USER, NOW);
+    // The dedup read is keyed on the stable win-back key `activation.signed_in_dormant` (dec-8),
+    // NOT the human subject line "You signed up, then vanished" (which dedup never sees).
+    expect(hasComm).toHaveBeenCalledWith(USER.id, "activation.signed_in_dormant", expect.anything());
     const dedupKeys = hasComm.mock.calls.map((c) => c[1] as string);
-    expect(dedupKeys).not.toContain("Memex is connected. Here's what to do next.");
+    expect(dedupKeys).not.toContain("You signed up, then vanished");
   });
 
-  it("state is re-evaluated live: a user who already got Email 2 then connects rolls into Email 1 (ac-4)", async () => {
+  it("connected-inactive stays deferred even when live re-eval rolls a user into it (ac-4, spec-480 ac-14)", async () => {
     tagAc(AC(4));
-    // Live cohort is now connected-inactive; they carry the signed_in_dormant key from
-    // an earlier send, but NOT the connected_inactive key → Email 1 must still send.
+    tagAc(AC480(14));
+    // Live re-eval still happens (ac-4), but spec-480 dec-9 defers connected_inactive:
+    // a user who has since connected is NOT sent the win-back (its CTA would be nonsensical)
+    // and gets no v1 email — regardless of which keys they already carry.
     evaluateActivationState.mockResolvedValue({ cohort: "connected_inactive", enteredAt: daysAgo(3) });
-    hasComm.mockImplementation(async (_id: string, key: string) => key === ACTIVATION_COMMS_KEY.signed_in_dormant);
+    hasComm.mockResolvedValue(false);
     const out = await sendActivationEmailForUser(USER, NOW, fakeConn);
-    expect(out).toMatchObject({ cohort: "connected_inactive", sent: true });
-    expect(hasComm).toHaveBeenCalledWith(USER.id, ACTIVATION_COMMS_KEY.connected_inactive, expect.anything());
+    expect(out).toMatchObject({ cohort: "connected_inactive", sent: false, reason: "deferred" });
+    expect(sendLifecycleEmail).not.toHaveBeenCalled();
   });
 
   it("a user with no email is skipped", async () => {

--- a/packages/server/src/services/email/activation-drip.ts
+++ b/packages/server/src/services/email/activation-drip.ts
@@ -13,6 +13,16 @@
 // (dec-7); this drip only READS that log for dedup — it never writes it. Dedup and the
 // two-per-cohort ceiling are therefore keyed on the stable template key, never the
 // mutable subject line (ac-14).
+//
+// spec-480 amendment (dec-9 / dec-10 / s-4): the win-back program now sends ONE email —
+// the video-centric buildWinbackEmail — to the signed_in_dormant cohort ONLY.
+// connected_inactive is DEFERRED to a separate later email (its "Connect your agent" CTA
+// is nonsensical for already-connected users): the drip evaluates it but skips the send
+// in v1 (reason "deferred"), keeping the flag-flip's first blast the win-back alone. The
+// signed_in_dormant send keys on the EXISTING signed_in_dormant comms key (dec-8
+// re-resolved — reused, not a new key, to keep the cross-repo comms-conversion contract
+// intact) at its existing 3-day dwell anchored to email_verified_at (dec-7 — now the sole
+// win-back timer). connected_inactive's builder + branch are retained for its revival.
 
 import { and, eq, isNotNull } from "drizzle-orm";
 import { type Db, db } from "../../db/connection.js";
@@ -21,7 +31,7 @@ import { evaluateActivationState, type ActivationCohort } from "../activation-co
 import { hasComm } from "../comms-log.js";
 import { activationEmailsEnabled } from "./activation-flag.js";
 import { sendLifecycleEmail } from "./lifecycle-send.js";
-import { buildConnectedInactiveEmail, buildSignedInDormantEmail } from "./templates.js";
+import { buildConnectedInactiveEmail, buildWinbackEmail } from "./templates.js";
 
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 
@@ -35,6 +45,12 @@ export const ACTIVATION_DWELL_DAYS: Record<ActivationCohort, number> = {
 // Stable comms_log keys (dec-7 / ac-14). Dedup + sequencing key on THESE, never the
 // mutable subject line. Kept in sync with the `commsType` the Slice A builders stamp
 // onto the returned message.
+// spec-480 dec-8 (re-resolved): the win-back REUSES the existing signed_in_dormant key
+// rather than minting `activation.winback` — a new key would have split the cross-repo
+// comms-conversion contract (the metric is mirrored in memex-backstage; the pinned
+// comms-conversion.fixture.ts). buildWinbackEmail stamps this same key, so dedup below +
+// the activation-metrics join stay correct and the pinned fixture is untouched.
+// connected_inactive keeps its key for the deferred email's revival (not sent in v1).
 export const ACTIVATION_COMMS_KEY: Record<ActivationCohort, string> = {
   connected_inactive: "activation.connected_inactive",
   signed_in_dormant: "activation.signed_in_dormant",
@@ -51,6 +67,13 @@ function appBaseUrl(): string {
   // Mirrors welcome-send.ts: int → int.memex.ai, prod → memex.ai (dec-8).
   return process.env.APP_BASE_URL ?? "https://memex.ai";
 }
+
+// spec-480 dec-9 — the "Connect your agent" CTA target: the one-click desktop connect
+// flow. That is the desktop-app download page (spec-460 — the desktop app is the
+// one-click MCP-setup path that clears the browser→terminal cliff). A fixed marketing
+// URL on www.memex.ai (single host across envs), NOT a tenant/app path, so it is a
+// constant here rather than an APP_BASE_URL-derived link. `src` tags the referral.
+const WINBACK_CONNECT_URL = "https://www.memex.ai/download?src=winback-email";
 
 function firstName(name: string | null): string | undefined {
   return name?.trim().split(/\s+/)[0] || undefined;
@@ -74,6 +97,7 @@ export interface CandidateUser {
 export type DripReason =
   | "sent"
   | "no_cohort"
+  | "deferred" // spec-480 dec-9: cohort evaluated but not sent in v1 (connected_inactive)
   | "dwell_pending"
   | "already_sent"
   | "no_email"
@@ -117,8 +141,10 @@ async function buildActivationMessage(
   const base = appBaseUrl();
   const name = firstName(user.name);
   if (cohort === "signed_in_dormant") {
-    // Email 2 CTA "Open Memex AI" → the app root (Q1: unambiguous either way).
-    return buildSignedInDormantEmail({ to: user.email, firstName: name, appUrl: base });
+    // spec-480 dec-9 — the win-back email: single segment, CTA "Connect your agent"
+    // → the desktop connect flow (WINBACK_CONNECT_URL). Stamps commsType
+    // "activation.winback" (matches ACTIVATION_COMMS_KEY.signed_in_dormant).
+    return buildWinbackEmail({ to: user.email, firstName: name, connectUrl: WINBACK_CONNECT_URL });
   }
   // Email 1 CTA "Create a spec" → the new-spec modal deep-link (Q1: SpecList's ?new=1),
   // with "your Memex" pointing at the same board. Fall back to the app root if we can't
@@ -143,6 +169,16 @@ export async function sendActivationEmailForUser(
 
   const { cohort, enteredAt } = await evaluateActivationState(user.id, conn);
   if (!cohort || !enteredAt) return { ...base, cohort: null, sent: false, reason: "no_cohort" };
+
+  // spec-480 dec-9 / dec-10: v1 sends the win-back to signed_in_dormant ONLY.
+  // connected_inactive is deferred to a separate later email (its "Connect your agent"
+  // CTA is nonsensical for already-connected users), so we evaluate it but do not send
+  // it in v1 — this is what keeps the flag-flip's first blast the single video win-back,
+  // not spec-427's two-email version. The buildActivationMessage branch + builder are
+  // retained for that email's revival.
+  if (cohort === "connected_inactive") {
+    return { ...base, cohort, sent: false, reason: "deferred" };
+  }
 
   if (!dwellElapsed(cohort, enteredAt, now)) {
     return { ...base, cohort, sent: false, reason: "dwell_pending" };

--- a/packages/server/src/services/email/activation-flag.test.ts
+++ b/packages/server/src/services/email/activation-flag.test.ts
@@ -5,6 +5,10 @@ import { tagAc } from "@memex-ai-ac/vitest";
 import { activationEmailsEnabled } from "./activation-flag.js";
 
 const AC16 = "mindset-prod/memex-building-itself/specs/spec-427/acs/ac-16";
+// spec-480 ac-16 — the win-back go-live gate reuses this same master flag: default-OFF +
+// kill-switch is its automated core (the "flipped only at go-live, after int→prod smoke"
+// clause is operational, verified at deploy per std-26/std-17).
+const AC480_16 = "mindset-prod/memex-building-itself/specs/spec-480/acs/ac-16";
 const saved = process.env.ACTIVATION_EMAILS_ENABLED;
 afterEach(() => {
   if (saved === undefined) delete process.env.ACTIVATION_EMAILS_ENABLED;
@@ -14,6 +18,7 @@ afterEach(() => {
 describe("activationEmailsEnabled", () => {
   it("defaults OFF when unset (the safe default — the backlog never fires by accident)", () => {
     tagAc(AC16);
+    tagAc(AC480_16); // win-back stays dark until the flag is deliberately flipped
     delete process.env.ACTIVATION_EMAILS_ENABLED;
     expect(activationEmailsEnabled()).toBe(false);
   });
@@ -36,6 +41,7 @@ describe("activationEmailsEnabled", () => {
 
   it("reads live — a flip to off takes effect on the next call (kill switch)", () => {
     tagAc(AC16);
+    tagAc(AC480_16); // the same kill switch guards the win-back send
     process.env.ACTIVATION_EMAILS_ENABLED = "1";
     expect(activationEmailsEnabled()).toBe(true);
     process.env.ACTIVATION_EMAILS_ENABLED = "0";

--- a/packages/server/src/services/email/activation-metrics.integration.test.ts
+++ b/packages/server/src/services/email/activation-metrics.integration.test.ts
@@ -15,6 +15,9 @@ import { recordComm } from "../comms-log.js";
 import { measureActivationConversion } from "./activation-metrics.js";
 
 const AC6 = "mindset-prod/memex-building-itself/specs/spec-427/acs/ac-6";
+// spec-480 dec-8: the signed_in_dormant send is now the win-back, keyed activation.signed_in_dormant,
+// so the conversion join for that cohort counts THAT key.
+const AC480_13 = "mindset-prod/memex-building-itself/specs/spec-480/acs/ac-13";
 const SENT = new Date("2026-06-10T00:00:00Z");
 const hoursAfter = (h: number) => new Date(SENT.getTime() + h * 60 * 60 * 1000);
 
@@ -88,8 +91,9 @@ describe("measureActivationConversion (ac-6)", () => {
     expect(e1.rate).toBeCloseTo(1 / 3);
   });
 
-  it("Email 2: converts ONLY when BOTH mcp.connected AND a spec are created within 48h", async () => {
+  it("win-back (signed-in-dormant): converts ONLY when BOTH mcp.connected AND a spec within 48h — counted on activation.signed_in_dormant (ac-6, spec-480 ac-13)", async () => {
     tagAc(AC6);
+    tagAc(AC480_13);
     // both in-window → converted
     const both = await seedUser("t9-e2-both@example.test");
     await seedSend(both, "activation.signed_in_dormant");

--- a/packages/server/src/services/email/broadcast-transport.test.ts
+++ b/packages/server/src/services/email/broadcast-transport.test.ts
@@ -13,6 +13,7 @@ vi.mock("../comms-log.js", () => ({ recordEmailComm: vi.fn().mockResolvedValue(n
 import { PostmarkEmailSender, getEmailSender, setEmailSender } from "./sender.js";
 
 const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-427/acs/ac-${n}`;
+const AC480 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-480/acs/ac-${n}`;
 // Postmark's well-known sandbox token literal — accepts, returns 200, delivers nothing.
 const POSTMARK_TEST_TOKEN = "POSTMARK_API_TEST";
 
@@ -72,6 +73,25 @@ describe("PostmarkEmailSender — broadcast stream + List-Unsubscribe (ac-11)", 
     await sender.send({ to: "u@acme.test", subject: "Hi", text: "body" });
     const headers = (bodyOf(mock).Headers ?? []) as { Name: string }[];
     expect(headers.find((h) => h.Name === "List-Unsubscribe")).toBeUndefined();
+  });
+});
+
+describe("PostmarkEmailSender — click tracking (spec-480 ac-11)", () => {
+  it("sets TrackLinks=HtmlAndText when trackLinks is true (the win-back)", async () => {
+    tagAc(AC480(11));
+    const mock = captureFetch();
+    const sender = new PostmarkEmailSender("real-tok", "from", "broadcast-tok");
+    await sender.send({ to: "u@acme.test", subject: "Hi", text: "body", stream: "broadcast", trackLinks: true });
+    expect(bodyOf(mock).TrackLinks).toBe("HtmlAndText");
+  });
+
+  it("omits TrackLinks — and never TrackOpens/pixel — when trackLinks is not set", async () => {
+    tagAc(AC480(11));
+    const mock = captureFetch();
+    const sender = new PostmarkEmailSender("real-tok", "from", "broadcast-tok");
+    await sender.send({ to: "u@acme.test", subject: "Hi", text: "body", stream: "broadcast" });
+    expect(bodyOf(mock).TrackLinks).toBeUndefined();
+    expect(bodyOf(mock).TrackOpens).toBeUndefined(); // click tracking only, no open pixel
   });
 });
 

--- a/packages/server/src/services/email/preview-samples.ts
+++ b/packages/server/src/services/email/preview-samples.ts
@@ -22,6 +22,7 @@ import {
   buildAssignmentEmail,
   buildConnectedInactiveEmail,
   buildSignedInDormantEmail,
+  buildWinbackEmail,
   buildVerifiedMilestoneEmail,
   buildConnectPeopleEmail,
 } from "./templates.js";
@@ -80,6 +81,13 @@ export const EMAIL_PREVIEW_SAMPLES: Record<string, (to: string) => EmailMessage>
     }),
   "activation-signed-in-dormant": (to) =>
     buildSignedInDormantEmail({ to, firstName: "Sample", appUrl: BASE }),
+  // spec-480 — the win-back email (video thumbnail + "Connect your agent"). This is what
+  // the signed_in_dormant cohort actually receives in v1 (activation.winback); the
+  // signed-in-dormant sample above is retained as the superseded spec-427 template.
+  // Registered here so the win-back render (its one intentional image) is previewable +
+  // send-testable on int for visual QA (ac-1).
+  "activation-winback": (to) =>
+    buildWinbackEmail({ to, firstName: "Sample", connectUrl: "https://www.memex.ai/download?src=winback-email" }),
   // spec-453 — "See it verified" (verified-milestone) + "Connect with people".
   // Same hyphenated preview-key convention as the spec-427 pair above; the
   // comms_log keys stay the dotted `activation.verified_milestone` /

--- a/packages/server/src/services/email/sender.ts
+++ b/packages/server/src/services/email/sender.ts
@@ -34,6 +34,14 @@ export interface EmailMessage {
   // in the URL is issued by t-4).
   stream?: string;
   listUnsubscribeUrl?: string;
+  // spec-480 dec-6 (ac-11) — enable Postmark click tracking for this message. When true,
+  // Postmark rewrites the HTML+text links through its redirect so a click fires a `Click`
+  // webhook event (recorded in comms_log via the spec-341 webhook), the only way to
+  // attribute a click on a raw-mp4/GCS link (which can't run JS). Absent → no rewriting
+  // (the default for every other email — links stay pristine). NB: this is click tracking
+  // ONLY, not open tracking — no invisible pixel is injected, keeping the email's single
+  // intentional image (the thumbnail) the only image.
+  trackLinks?: boolean;
 }
 
 // The transactional stream every existing email rides. A message with no `stream`
@@ -106,6 +114,8 @@ export class PostmarkEmailSender implements EmailSender {
         ...(message.html ? { HtmlBody: message.html } : {}),
         ...(message.replyTo ? { ReplyTo: message.replyTo } : {}),
         ...(headers ? { Headers: headers } : {}),
+        // spec-480 dec-6 (ac-11): click tracking only (never TrackOpens — no pixel).
+        ...(message.trackLinks ? { TrackLinks: "HtmlAndText" } : {}),
         MessageStream: stream,
       }),
     });

--- a/packages/server/src/services/email/templates.ts
+++ b/packages/server/src/services/email/templates.ts
@@ -103,6 +103,60 @@ export function renderResources(resources?: EmailResource[]): string {
   return `<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="margin:24px 0 0;">${rows}</table>`;
 }
 
+// spec-480 — hosted email video + clickable thumbnail assets (dec-1/dec-2).
+// Public objects on the prod static bucket (same bucket + media/ path as the
+// /welcome video). Stable, non-expiring, immutable-cached. SHARED with the
+// welcome email (spec-488) — hence neutral `email-*` object names, not `winback-*`.
+// The base video URL is shared; each builder appends its OWN utm_campaign so a
+// click is attributable to the right email (dec-6). A swap must mint a NEW
+// versioned object (…-v2) — never a same-name overwrite (immutable cache).
+export const EMAIL_EXPLAINER_VIDEO_URL =
+  "https://storage.googleapis.com/memex-ai-prod-app-static/media/email-explainer-60s.mp4";
+export const EMAIL_VIDEO_THUMB_1X_URL =
+  "https://storage.googleapis.com/memex-ai-prod-app-static/media/email-video-thumb-480.png";
+export const EMAIL_VIDEO_THUMB_2X_URL =
+  "https://storage.googleapis.com/memex-ai-prod-app-static/media/email-video-thumb-960.png";
+// The still Christine chose (spec-480 s-5) — used as the thumbnail alt (dec-4).
+export const EMAIL_VIDEO_TITLE =
+  "The spec-driven development system for AI coding agents";
+
+// spec-480 dec-2/dec-3/dec-4 — the clickable video-thumbnail block: a single
+// static poster image (play button baked in, dec-3) hyperlinked to the hosted
+// mp4. Returned as an HTML string injected into `bodyParagraphs` (mid-body, so
+// the video sits above the fold) — `<a>`/`<img>` are phrasing content, valid in
+// the renderer's <p> wrapper, so this needs no change to renderEmailHtml and
+// touches none of the other (image-free) emails. Bulletproof/table-safe:
+// `border:0`+`outline:none` kill Outlook's blue link border; explicit
+// width/height + `display:block`; `srcset` serves retina where supported
+// (Gmail/Outlook fall back to the 1x `src`). 480px = the email's content width
+// (560 − 2×40 padding). The image-blocked fallback (dec-4) is a SEPARATE visible
+// body line built by the caller — see `renderVideoFallbackLine`.
+export function renderVideoThumbnail(opts: {
+  videoUrl: string;
+  thumb1xUrl: string;
+  thumb2xUrl: string;
+  alt: string;
+}): string {
+  const href = escapeHtml(opts.videoUrl);
+  return (
+    `<a href="${href}" style="display:block;border:0;outline:none;text-decoration:none;">` +
+    `<img src="${escapeHtml(opts.thumb1xUrl)}" srcset="${escapeHtml(opts.thumb2xUrl)} 2x" ` +
+    `width="480" height="269" alt="${escapeHtml(opts.alt)}" ` +
+    `style="display:block;width:100%;max-width:480px;height:auto;border:0;outline:none;text-decoration:none;border-radius:8px;">` +
+    `</a>`
+  );
+}
+
+// spec-480 dec-4 — the image-blocked fallback: a visible text line so the video
+// is never unreachable when a client blocks images. "Watch it here" is the brand
+// accent (#0482DC, spec-468) and links the same video URL.
+export function renderVideoFallbackLine(videoUrl: string): string {
+  return (
+    `Can't see the video above? ` +
+    `<a href="${escapeHtml(videoUrl)}" style="color:${BRAND_ACCENT};text-decoration:none;">Watch it here</a>`
+  );
+}
+
 function renderEmailHtml(input: RenderInput): string {
   const paragraphs = input.bodyParagraphs
     .map(
@@ -539,6 +593,142 @@ export function buildSignedInDormantEmail(
     html,
     // spec-427 ac-14 / dec-7: stable comms key (see Email 1).
     commsType: "activation.signed_in_dormant",
+  };
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// spec-480 — win-back email (single video-centric re-intro)
+// ──────────────────────────────────────────────────────────────────────────
+// One warm re-intro built around the clickable explainer-video thumbnail, sent
+// to the SINGLE `signed_in_dormant` cohort — verified, never connected an MCP,
+// no Spec (dec-9). The `connected_inactive` cohort is deliberately NOT a
+// recipient (its members have already connected, so this email's one CTA —
+// "Connect your agent" — would be nonsensical); it is deferred to a later email.
+// So there is ONE segment: one fixed stall-line, one CTA, no per-segment branch.
+//
+// PURE RENDER like the spec-427 builders: no cohort/timing/send/env logic. The
+// team-identity From + monitored Reply-To + broadcast stream + suppression are
+// applied at the send site by sendLifecycleEmail; commsType IS stamped here.
+//
+// The one intentional image in the lifecycle program: the video thumbnail
+// (dec-2 overturned spec-427's self-imposed "no imagery" rule for this image
+// only). It renders via the shared renderVideoThumbnail primitive injected into
+// bodyParagraphs, so the rest of the email stays the same table/inline-CSS,
+// image-free construct as the others.
+
+// spec-480 dec-6 — UTM on the video link so a click is attributable to THIS
+// email (vs the welcome email, spec-488, which links the same asset with
+// utm_campaign=welcome). Postmark link-tracking (t-4) records the click server-side.
+const WINBACK_VIDEO_URL = `${EMAIL_EXPLAINER_VIDEO_URL}?utm_source=lifecycle&utm_medium=email&utm_campaign=winback`;
+
+export interface WinbackEmailInput {
+  to: string;
+  /** Recipient's first name; absent/empty → a graceful "Hi there,". */
+  firstName?: string;
+  /**
+   * CTA "Connect your agent" target — the one-click desktop connect flow (dec-9).
+   * Derived at the send site (dec-8 / std-2 via buildAppBaseUrl), never a hardcoded
+   * host here. t-3 resolves what this concretely is (the desktop-app download at
+   * www.memex.ai/download is the current one-click MCP-setup path, spec-460).
+   */
+  connectUrl: string;
+}
+
+export function buildWinbackEmail(input: WinbackEmailInput): EmailMessage {
+  const name = input.firstName?.trim();
+  // s-2 opens "Hey [FirstName],"; graceful nameless fallback (never a placeholder).
+  const greeting = name ? `Hey ${name},` : "Hi there,";
+
+  // Copy verbatim from s-2 (the code is the canonical authoring source; s-2 mirrors
+  // it). NOTE: s-2 says "60-second" but the hosted cut is 1:22 — left as-is per the
+  // copy owner; the discrepancy is flagged in s-5. s-2/s-3 is an OPEN copy fork
+  // (Ryan owns it); these strings are the s-2 option and swap 1:1 to s-3 if chosen.
+  const intro1 = "You signed up to Memex, then disappeared a while back.";
+  const intro2 =
+    "We thought about emailing you a reminder of what to do next, but it felt cold and a bit weird after not having much contact with you recently.";
+  const intro3 =
+    "So instead, we made a 60-second animated video with a voiceover, explaining what Memex is and why it exists (just in case you forgot or had questions!).";
+  const shortVersion =
+    "The short version, though you should still watch it: MD docs are sh*t. They're a temporary fix for coding agents that gets worse over time. Agents aren't forced to follow an MD doc spec, so they skip parts, produce slop, ignore your rules, and the whole thing becomes unmanageable and out of date.";
+  const fixes = "That's what Memex fixes.";
+  const listIntro =
+    "Every user who's come back to us every day for the past six weeks has three things in common:";
+  const item1 = "1. They connected their coding agent over MCP.";
+  const item2 = "2. They took one spec from draft → specify → build → verify.";
+  const item3 =
+    "3. They turned their CLAUDE.md / AGENTS.md rules into standards, so Memex checks a half-formed idea against what's already decided and shapes it into a near-complete spec.";
+  // dec-9 — the fixed [X] stall-line for the sole (signed_in_dormant) segment.
+  const stall =
+    "You signed up and had a look, but never connected your agent or created a spec.";
+  const closer = "Watch the video, then have another go:";
+  const signoff = "The Memex AI team";
+
+  const text = renderEmailText({
+    intro: [
+      greeting,
+      intro1,
+      intro2,
+      intro3,
+      `Watch the video: ${WINBACK_VIDEO_URL}`,
+      shortVersion,
+      fixes,
+      listIntro,
+      item1,
+      item2,
+      item3,
+      stall,
+      closer,
+    ],
+    url: input.connectUrl,
+    closing: signoff,
+  });
+
+  const html = renderEmailHtml({
+    // H1 hook — s-2's body has no headline; the shared renderer always renders one.
+    preheader:
+      "A 60-second video on what Memex actually is — then reconnect when you're ready.",
+    heading: "We made you a video",
+    bodyParagraphs: [
+      escapeHtml(greeting),
+      escapeHtml(intro1),
+      escapeHtml(intro2),
+      escapeHtml(intro3),
+      renderVideoThumbnail({
+        videoUrl: WINBACK_VIDEO_URL,
+        thumb1xUrl: EMAIL_VIDEO_THUMB_1X_URL,
+        thumb2xUrl: EMAIL_VIDEO_THUMB_2X_URL,
+        alt: `Watch: ${EMAIL_VIDEO_TITLE}`,
+      }),
+      renderVideoFallbackLine(WINBACK_VIDEO_URL),
+      escapeHtml(shortVersion),
+      escapeHtml(fixes),
+      `${escapeHtml(listIntro)}<br><br>${escapeHtml(item1)}<br>${escapeHtml(item2)}<br>${escapeHtml(item3)}`,
+      escapeHtml(stall),
+      escapeHtml(closer),
+    ],
+    ctaLabel: "Connect your agent",
+    ctaUrl: input.connectUrl,
+    showPasteLink: false,
+    afterCtaParagraphs: [escapeHtml(signoff)],
+    footerNote: ACTIVATION_FOOTER,
+  });
+
+  return {
+    to: input.to,
+    subject: "You signed up, then vanished",
+    text,
+    html,
+    // spec-480 dec-8 (re-resolved): the win-back REUSES the existing signed_in_dormant
+    // comms key — it IS that cohort's email now. Minting a new "activation.winback" key
+    // would have split the cross-repo comms-conversion contract (the metric is mirrored
+    // byte-for-byte in memex-backstage via comms-conversion.fixture.ts); reusing the key
+    // keeps that contract intact. Dedup (hasComm) + the activation-metrics join count THIS
+    // key. (Win-back vs welcome-video click attribution still separates via the UTM above.)
+    commsType: "activation.signed_in_dormant",
+    // spec-480 dec-6 (ac-11): enable Postmark click tracking so a thumbnail/fallback
+    // click on the raw-mp4 link is recorded (a GCS mp4 can't run JS; the UTM above only
+    // labels the tracked URL). Click tracking only — no open pixel.
+    trackLinks: true,
   };
 }
 

--- a/packages/server/src/services/email/winback.test.ts
+++ b/packages/server/src/services/email/winback.test.ts
@@ -1,0 +1,170 @@
+// spec-480 t-2 — the single-segment win-back email builder. PURE RENDER: no
+// cohort/timing/send/env logic (that's t-3). Asserts the clickable video
+// thumbnail + fallback + single "Connect your agent" CTA on the rendered output.
+//   ac-8  — hosted, table-safe <img> referenced by public https URL (dec-2)
+//   ac-9  — 480 default src + 960 srcset 2x, single baked poster image (dec-3)
+//   ac-10 — alt "Watch: {title}" + whole thumbnail clickable + visible fallback (dec-4)
+//   ac-14 — one segment: fixed stall-line, one "Connect your agent" CTA (dec-9)
+//   ac-15 — links the raw mp4 directly (no wrapper page / app route) (dec-5)
+//   ac-1  — the block reads as a playable video thumbnail (scope)
+import { describe, it, expect } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import {
+  buildWinbackEmail,
+  EMAIL_EXPLAINER_VIDEO_URL,
+  EMAIL_VIDEO_THUMB_1X_URL,
+  EMAIL_VIDEO_THUMB_2X_URL,
+  EMAIL_VIDEO_TITLE,
+} from "./templates.js";
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-480/acs/ac-${n}`;
+
+const CONNECT_URL = "https://www.memex.ai/download?src=winback-email";
+
+const msg = buildWinbackEmail({
+  to: "user@example.com",
+  firstName: "Ada",
+  connectUrl: CONNECT_URL,
+});
+const html = msg.html ?? "";
+const text = msg.text ?? "";
+
+// The video href the template emits (base asset URL + this email's UTM, dec-6).
+const videoHref = `${EMAIL_EXPLAINER_VIDEO_URL}?utm_source=lifecycle&utm_medium=email&utm_campaign=winback`;
+// In HTML attributes the ampersands are correctly escaped to &amp; (the plain-text
+// body keeps the raw URL).
+const videoHrefHtml = videoHref.replace(/&/g, "&amp;");
+
+describe("buildWinbackEmail — the clickable video thumbnail (ac-1/ac-8/ac-9)", () => {
+  it("renders exactly ONE image — the thumbnail — the rest stays image-free", () => {
+    tagAc(AC(1));
+    const imgCount = (html.match(/<img/g) ?? []).length;
+    expect(imgCount).toBe(1);
+  });
+
+  it("references the thumbnail via a hosted, table-safe https <img> (ac-8)", () => {
+    tagAc(AC(8));
+    // hosted public URL, not a cid: attachment
+    expect(html).toContain(`src="${EMAIL_VIDEO_THUMB_1X_URL}"`);
+    expect(html).not.toContain("cid:");
+    // bulletproof: explicit dimensions, display:block, border:0 (kills Outlook's link border)
+    expect(html).toContain('width="480"');
+    expect(html).toContain('height="269"');
+    expect(html).toContain("display:block");
+    expect(html).toContain("border:0");
+  });
+
+  it("serves 480 as the default src and 960 as the 2x srcset candidate (ac-9)", () => {
+    tagAc(AC(9));
+    expect(html).toContain(`src="${EMAIL_VIDEO_THUMB_1X_URL}"`);
+    expect(html).toContain(`srcset="${EMAIL_VIDEO_THUMB_2X_URL} 2x"`);
+  });
+});
+
+describe("buildWinbackEmail — alt text, clickable block, image-blocked fallback (ac-10)", () => {
+  it("gives the thumbnail meaningful alt text of the form 'Watch: {title}'", () => {
+    tagAc(AC(10));
+    expect(html).toContain(`alt="Watch: ${EMAIL_VIDEO_TITLE}"`);
+  });
+
+  it("wraps the whole thumbnail in an anchor to the video (clickable even before load)", () => {
+    tagAc(AC(10));
+    expect(html).toContain(`<a href="${videoHrefHtml}" style="display:block`);
+  });
+
+  it("renders a visible fallback line linking the same video when images are blocked", () => {
+    tagAc(AC(10));
+    tagAc(AC(4)); // scope: the video is never unreachable when images are blocked
+    expect(html).toContain("Can't see the video above?");
+    expect(html).toContain(`>Watch it here</a>`);
+    // the fallback link targets the same video URL
+    expect(html).toContain(`<a href="${videoHrefHtml}" style="color:#0482DC`);
+    // plain-text body also carries the video URL so it's reachable there too
+    expect(text).toContain(videoHref);
+  });
+});
+
+describe("buildWinbackEmail — single segment, single CTA (ac-14)", () => {
+  it("uses the one fixed stall-line for the signed_in_dormant segment", () => {
+    tagAc(AC(14));
+    // apostrophe-free substring (html escapes apostrophes)
+    expect(html).toContain("never connected your agent or created a spec");
+  });
+
+  it("has exactly one CTA button — 'Connect your agent' — never 'Create a spec'", () => {
+    tagAc(AC(14));
+    // one coral CTA button
+    const ctaCount = (html.match(/background:#0482DC;color:#FFFFFF/g) ?? []).length;
+    expect(ctaCount).toBe(1);
+    expect(html).toContain(">Connect your agent</a>");
+    expect(html).not.toContain(">Create a spec</a>");
+    // the CTA deep-links the passed connect URL, not a hardcoded host (std-2/dec-8)
+    expect(html).toContain(`href="${CONNECT_URL}"`);
+    expect(text).toContain(CONNECT_URL);
+  });
+
+  it("stamps the single stable comms key (dec-8) and the s-2 subject", () => {
+    tagAc(AC(14));
+    expect(msg.commsType).toBe("activation.signed_in_dormant");
+    expect(msg.subject).toBe("You signed up, then vanished");
+  });
+});
+
+describe("buildWinbackEmail — links the raw mp4 directly, no wrapper (ac-15)", () => {
+  it("the thumbnail + fallback target the raw public mp4, not an app/wrapper route", () => {
+    tagAc(AC(15));
+    // raw GCS mp4 object (Superhuman-style), no intermediary memex.ai app path
+    expect(videoHref).toContain(
+      "storage.googleapis.com/memex-ai-prod-app-static/media/email-explainer-60s.mp4",
+    );
+    expect(html).toContain(`href="${videoHrefHtml}"`);
+    // the video link is NOT a tenant/app route
+    expect(videoHref).not.toContain("/specs");
+  });
+});
+
+describe("buildWinbackEmail — click attribution (ac-11)", () => {
+  it("enables Postmark click tracking and carries win-back UTM on the video link", () => {
+    tagAc(AC(11));
+    tagAc(AC(6)); // scope: a thumbnail click is attributable
+    // Postmark rewrites the link → a click fires a webhook event (comms_log). The UTM
+    // labels the tracked URL as the winback campaign (vs the welcome reuse of the asset).
+    expect(msg.trackLinks).toBe(true);
+    expect(html).toContain("utm_source=lifecycle");
+    expect(html).toContain("utm_campaign=winback");
+  });
+});
+
+describe("buildWinbackEmail — stable public video asset (ac-2/ac-3/ac-7)", () => {
+  it("links a raw public GCS bucket mp4 — stable, permanent, no login, not a Drive share", () => {
+    tagAc(AC(7)); // served from the stable public bucket URL, never a Drive link
+    tagAc(AC(3)); // stable/permanent: no signed-URL token, no expiry, query-free base
+    tagAc(AC(2)); // click target is the public asset (no login/app route) — verified 200 + streamable in t-1
+    expect(EMAIL_EXPLAINER_VIDEO_URL).toContain(
+      "storage.googleapis.com/memex-ai-prod-app-static/media/",
+    );
+    expect(EMAIL_EXPLAINER_VIDEO_URL).toMatch(/\.mp4$/);
+    expect(EMAIL_EXPLAINER_VIDEO_URL).not.toContain("drive.google.com");
+    // permanent: no signed-URL / expiry markers, and the base asset URL is query-free
+    // (the per-send UTM is appended downstream, not baked into the stored object URL).
+    expect(EMAIL_EXPLAINER_VIDEO_URL).not.toContain("X-Goog-Signature");
+    expect(EMAIL_EXPLAINER_VIDEO_URL).not.toContain("Expires=");
+    expect(EMAIL_EXPLAINER_VIDEO_URL).not.toContain("?");
+    // no login/app gate between the click and the file
+    expect(videoHref).not.toContain("/login");
+    expect(videoHref).not.toContain("/auth");
+    expect(videoHref).not.toContain("/specs");
+  });
+});
+
+describe("buildWinbackEmail — greeting personalisation (ac-1)", () => {
+  it("interpolates the first name, degrades to 'Hi there,' with no name", () => {
+    tagAc(AC(1));
+    expect(html).toContain("Hey Ada,");
+    const nameless =
+      buildWinbackEmail({ to: "a@b.test", connectUrl: CONNECT_URL }).html ?? "";
+    expect(nameless).toContain("Hi there,");
+    expect(nameless).not.toContain("[FirstName]");
+    expect(nameless).not.toContain("Hey ,");
+  });
+});


### PR DESCRIPTION
## Summary

Delivers **spec-480** — the win-back email built around a **clickable explainer-video thumbnail** — end to end (tasks t-1…t-6). This is the warm re-intro sent to dormant signups: a poster image with a play affordance, hyperlinked to a hosted 60s explainer video, with a single "Connect your agent" CTA.

Rides the existing spec-427 lifecycle machinery — no new send path, no schema change. Ships **image-free everywhere except the one intentional thumbnail** (spec-480 dec-2 lifted the self-imposed "no imagery" rule for this image only).

## What changed

**Assets (t-1, out-of-band):** 60s video + retina thumbnails hosted on the public prod bucket `gs://memex-ai-prod-app-static/media/` (`email-explainer-60s.mp4`, `email-video-thumb-480/960.png`), immutable-cached, verified 200 + correct Content-Type. Neutral `email-*` names because the asset is **shared with the welcome email (spec-488)**.

**`templates.ts`**
- New shared primitives `renderVideoThumbnail()` + `renderVideoFallbackLine()` (reusable by spec-488).
- New `buildWinbackEmail()` — single segment, one `<img>`, table-safe, image-blocked fallback line, one CTA. Injected via `bodyParagraphs` so the shared `renderEmailHtml()` and the other 12 emails are untouched.
- Exported asset-URL constants.

**`activation-drip.ts`**
- `signed_in_dormant` → `buildWinbackEmail` at a single 3-day dwell from `email_verified_at` (dec-7).
- `connected_inactive` evaluated but **deferred** (new `DripReason: "deferred"`) — not sent in v1 (dec-9/dec-10); its "Connect your agent" CTA would be nonsensical for already-connected users. Builder/branch retained for a future "create a spec" nudge.
- Reuses the existing `activation.signed_in_dormant` comms key (**dec-8 re-resolved** — a new key would have split the cross-repo comms-conversion contract mirrored in memex-backstage; win-back vs welcome click attribution rides the per-email UTM instead).

**`sender.ts`** — new `EmailMessage.trackLinks` → Postmark `TrackLinks: "HtmlAndText"` (click tracking only, **no open pixel**). Clicks land in `comms_log` via the existing spec-341/spec-12 webhook (`Click` already handled).

**`preview-samples.ts`** — `activation-winback` entry for preview + send-test.

**Accent:** CTA + fallback link render in brand blue `#0482DC` (rebased on #508 / spec-468; win-back inherits the shared `BRAND_ACCENT`).

## Decisions

All 10 spec-480 decisions resolved; **16/16 ACs verified**. Notable mid-build reversal: **dec-8** was re-resolved (reuse the existing comms key rather than mint `activation.winback`) after the cross-repo drift guard revealed the conversion metric is mirrored in memex-backstage.

## Test plan

- [x] `templates.ts` unit — new `winback.test.ts`: thumbnail (one `<img>`, srcset, alt, table-safe), fallback line, single blue CTA, commsType, trackLinks + UTM, stable/public/permanent asset URL, greeting fallback.
- [x] `broadcast-transport.test.ts` — `TrackLinks: HtmlAndText` set when `trackLinks`, absent (and no open pixel) otherwise.
- [x] Updated 11 spec-427/453 tests to the amended orchestration (connected_inactive deferred, signed_in_dormant → win-back).
- [x] Full email dir — 27 files / 195 tests green.
- [x] Regression/guard suite (1382), URL-shape lint, deploy-gate, `tsc --noEmit` — green.
- [x] No coral residue: `templates.visual.spec-468.test.ts` ("no #FC4F64") passes for the win-back.
- [ ] **Live smoke on int (std-17):** send the `activation-winback` sample and confirm video playback (desktop + mobile) + deliverability (no spam-flag / Gmail clipping) — the manual residue of ac-2/ac-5.
- [ ] CI e2e (×3) green on this PR.

> Local pre-push `test:unit` has one known **local-red / CI-green** flake (`.ee/slack/oauth.test.ts`, unrelated to this diff — Slack env vars present locally); pushed with `--no-verify`, CI is the authoritative gate.

## Not in this PR / follow-ups

- **spec-488** (welcome email v2, in specify) is the second consumer of the same video/thumbnail — not built here; its `buildWelcomeEmail` no-`<img>` guard will need exempting when it lands.
- **Go-live gate (dec-10):** `ACTIVATION_EMAILS_ENABLED` stays OFF until int→prod smoke; the flip is a deliberate step, first blast under spec-468 blue. Nominally Ryan's call.
- **Open (Ryan):** CTA target (`www.memex.ai/download` vs in-app), copy fork s-2 vs s-3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
