### PR TITLE
release: develop → main — activation emails + namespace rename

### DIFF
--- a/packages/server/src/routes/__dev__.test.ts
+++ b/packages/server/src/routes/__dev__.test.ts
@@ -10,8 +10,10 @@ import {
   EMAIL_PREVIEW_SAMPLES,
   EMAIL_TEMPLATE_NAMES,
 } from "../services/email/preview-samples.js";
+import { ACTIVATION_DWELL_DAYS } from "../services/email/activation-drip.js";
 
 const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-226/acs/ac-${n}`;
+const AC493 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-493/acs/ac-${n}`;
 
 describe("email preview samples registry", () => {
   it("builds every registered template without throwing", () => {
@@ -50,6 +52,76 @@ describe("GET /email-preview", () => {
     expect(res.status).toBe(404);
     const json = (await res.json()) as { templates: string[] };
     expect(json.templates).toEqual(EMAIL_TEMPLATE_NAMES);
+  });
+});
+
+// spec-493 t-1 (dec-2) — /templates carries per-email send-condition metadata so the
+// React gallery can lay out the onboarding timeline; the payload is objects, not string[].
+describe("GET /email-preview/templates returns per-email metadata (spec-493)", () => {
+  const onboarding = [
+    "activation-connect-people",
+    "activation-connected-inactive",
+    "activation-verified-milestone",
+    "activation-winback",
+    "welcome",
+  ].sort();
+
+  it("returns metadata objects (name + sequence) for every template, not a flat string[] (ac-9)", async () => {
+    tagAc(AC493(9));
+    const res = await devToolsRouter.request("/email-preview/templates");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      templates: Array<{ name: string; sequence: boolean }>;
+      perCohortCap: number;
+    };
+    expect(Array.isArray(body.templates)).toBe(true);
+    for (const t of body.templates) {
+      expect(typeof t.name).toBe("string");
+      expect(typeof t.sequence).toBe("boolean");
+    }
+    // every registered template is present
+    expect(body.templates.map((t) => t.name).sort()).toEqual([...EMAIL_TEMPLATE_NAMES].sort());
+    // exactly the 5 onboarding emails are flagged sequence:true (ac-11)
+    expect(
+      body.templates.filter((t) => t.sequence).map((t) => t.name).sort(),
+    ).toEqual(onboarding);
+    expect(body.perCohortCap).toBeGreaterThan(0);
+  });
+
+  it("onboarding entries carry send-path-imported day/branch/flag facts (ac-9)", async () => {
+    tagAc(AC493(9));
+    const res = await devToolsRouter.request("/email-preview/templates");
+    const body = (await res.json()) as {
+      templates: Array<{ name: string; dayOffset: number | null; branch: string; flagGated: boolean }>;
+    };
+    const winback = body.templates.find((t) => t.name === "activation-winback");
+    expect(winback?.dayOffset).toBe(ACTIVATION_DWELL_DAYS.signed_in_dormant);
+    expect(winback?.branch).toBe("win-back");
+    expect(winback?.flagGated).toBe(true);
+  });
+});
+
+// spec-493 t-1 (dec-2) — the timeline lives ONLY in the React gallery; the server HTML
+// index is untouched (still a flat link list).
+describe("server HTML index is unchanged by the timeline work (spec-493)", () => {
+  it("no ?template still returns the flat link index, not a timeline (ac-10)", async () => {
+    tagAc(AC493(10));
+    const res = await devToolsRouter.request("/email-preview");
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    for (const name of EMAIL_TEMPLATE_NAMES) {
+      expect(body).toContain(`template=${name}`);
+    }
+    expect(body).toContain("<h1>Email templates</h1>"); // the plain index, not the gallery
+  });
+});
+
+// spec-493 t-1 (ac-6) — the timeline adds no new prod-reachable surface: the whole dev
+// tools router still never mounts on prod.
+describe("timeline adds no prod-reachable surface (spec-493)", () => {
+  it("dev tools still never mount on prod (ac-6)", () => {
+    tagAc(AC493(6));
+    expect(shouldMountDevTools("prod")).toBe(false);
   });
 });
 

--- a/packages/server/src/routes/__dev__.ts
+++ b/packages/server/src/routes/__dev__.ts
@@ -13,6 +13,10 @@ import {
   EMAIL_PREVIEW_SAMPLES,
   EMAIL_TEMPLATE_NAMES,
 } from "../services/email/preview-samples.js";
+import {
+  ONBOARDING_SEQUENCE,
+  PER_COHORT_CAP,
+} from "../services/email/send-conditions.js";
 import { getEmailSender } from "../services/email/sender.js";
 import type { UsageEnv } from "../services/usage-events.js";
 import type { SessionEnv } from "../middleware/session.js";
@@ -35,13 +39,35 @@ function escapeHtml(value: string): string {
     .replace(/>/g, "&gt;");
 }
 
-// GET /api/__dev__/email-preview/templates → JSON list of template names.
-// The React gallery (spec-226 t-6) consumes this to populate its picker, then
-// fetches each template's HTML below. JSON (not the HTML index) because the SPA
-// renders the picker itself; both are fetched via the token-carrying http client.
-devToolsRouter.get("/email-preview/templates", (c) =>
-  c.json({ templates: EMAIL_TEMPLATE_NAMES }),
-);
+// GET /api/__dev__/email-preview/templates → JSON metadata for every template.
+// The React gallery (spec-226 t-6) consumes this to populate its picker; spec-493
+// extends the payload from a flat string[] to one metadata object per template so the
+// gallery can lay out the onboarding emails as a timeline (dec-2). Each entry carries
+// `sequence`: the 5 onboarding emails are `true` (with their send-condition facts); every
+// other template is `false` and the gallery renders it in a flat grouped list. The
+// sequence facts come from send-conditions.ts, whose day/comms values are imported from
+// the send path (dec-1) so the timeline cannot silently disagree with what really sends.
+const ONBOARDING_BY_TEMPLATE = new Map(ONBOARDING_SEQUENCE.map((c) => [c.template, c]));
+
+devToolsRouter.get("/email-preview/templates", (c) => {
+  const templates = EMAIL_TEMPLATE_NAMES.map((name) => {
+    const cond = ONBOARDING_BY_TEMPLATE.get(name);
+    if (!cond) return { name, sequence: false as const };
+    return {
+      name,
+      sequence: true as const,
+      order: cond.order,
+      dayOffset: cond.dayOffset,
+      anchor: cond.anchor,
+      cohort: cond.cohort,
+      trigger: cond.trigger,
+      branch: cond.branch,
+      flagGated: cond.flagGated,
+      commsKey: cond.commsKey,
+    };
+  });
+  return c.json({ templates, perCohortCap: PER_COHORT_CAP });
+});
 
 // GET /api/__dev__/email-preview            → index of available templates
 // GET /api/__dev__/email-preview?template=X → rendered HTML for template X

--- a/packages/server/src/routes/namespaces.integration.test.ts
+++ b/packages/server/src/routes/namespaces.integration.test.ts
@@ -3,7 +3,7 @@
 // per-namespace slug-availability check.
 
 import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
-import { eq, inArray } from "drizzle-orm";
+import { eq, inArray, sql } from "drizzle-orm";
 
 vi.hoisted(() => {
   // Force auth-mode session middleware so per-user Bearer tokens are honored.
@@ -25,6 +25,7 @@ import {
 import { signSessionToken } from "../services/auth-jwt.js";
 import { ensureUserNamespace } from "../services/user-namespaces.js";
 import { createOrgForUser } from "../services/orgs.js";
+import { insertRedirect } from "../services/redirects.js";
 
 const createdUserIds: string[] = [];
 const createdNamespaceIds: string[] = [];
@@ -334,6 +335,54 @@ describe("GET /api/namespaces/:namespaceId/memexes/check", () => {
     expect(res.status).toBe(404);
     const body = await res.json();
     expect(body.error).toBe("Namespace not found");
+  });
+});
+
+// spec-481 t-2 — the namespace slug-availability check distinguishes a slug
+// freed by a rename (held by a live redirect) from one actively taken, so the
+// rename UI can explain WHY the freed slug is blocked (parity with the memex
+// check). Availability itself already came from the shared isSlugAvailable.
+describe("GET /api/namespaces/check", () => {
+  const redirectSources: string[] = [];
+  afterAll(async () => {
+    for (const s of redirectSources) {
+      await db.execute(sql`DELETE FROM redirects WHERE old_path = ${s}`).catch(() => {});
+    }
+  });
+
+  it("returns { available: false, reason: 'redirected' } for a live redirect source", async () => {
+    const caller = await seedUser();
+    const source = `ns481r${caller.userId.slice(0, 6)}`;
+    redirectSources.push(source);
+    // A namespace_rename redirect whose old_path is this bare 1-segment slug.
+    await insertRedirect(source, `${source}new`, "namespace_rename");
+    redirectSources.push(`${source}new`);
+
+    const res = await authedRequest(
+      `/api/namespaces/check?slug=${source}`,
+      { method: "GET" },
+      caller.bearer,
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ available: false, reason: "redirected" });
+  });
+
+  it("returns { available: false, reason: 'taken' } for an active namespace slug", async () => {
+    const owner = await seedUser();
+    const created = await createOrgForUser({
+      slug: `ns481t${owner.userId.slice(0, 6)}`,
+      name: "Taken Co",
+      userId: owner.userId,
+    });
+    createdNamespaceIds.push(created.namespace.id);
+
+    const res = await authedRequest(
+      `/api/namespaces/check?slug=${created.namespace.slug}`,
+      { method: "GET" },
+      owner.bearer,
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ available: false, reason: "taken" });
   });
 });
 

--- a/packages/server/src/routes/namespaces.ts
+++ b/packages/server/src/routes/namespaces.ts
@@ -24,6 +24,7 @@ import {
   MemexCreationError,
 } from "../services/memexes.js";
 import { isSlugAvailable, validateSlugFormat } from "../services/shared/slug.js";
+import { isRedirectSource } from "../services/redirects.js";
 import { ConflictError, ValidationError } from "../types/errors.js";
 
 export const namespacesRouter = new Hono<SessionEnv>();
@@ -41,7 +42,13 @@ namespacesRouter.get("/check", async (c) => {
   }
   const available = await isSlugAvailable(slug);
   if (!available) {
-    return c.json({ available: false, reason: "taken" });
+    // Distinguish a slug freed by a rename (still held by a live, permanent
+    // redirect — spec-481 D-2) from one that's actively taken/reserved, so the
+    // rename UI can explain WHY the freed slug is blocked. Parity with the
+    // memex slug check (spec-479). Extra query only on the unavailable branch;
+    // old_path is the redirects PK, so it's an index hit.
+    const redirected = await isRedirectSource(slug);
+    return c.json({ available: false, reason: redirected ? "redirected" : "taken" });
   }
   return c.json({ available: true });
 });
@@ -57,11 +64,12 @@ namespacesRouter.patch("/:id/slug", async (c) => {
     return c.json({ error: "slug is required" }, 400);
   }
   try {
-    const updated = await renameNamespaceSlug({
-      namespaceId,
-      newSlug: body.slug,
-      userId: user.id,
-    });
+    const updated = await renameNamespaceSlug(
+      { namespaceId, newSlug: body.slug, userId: user.id },
+      // std-32: stamp WHO + HOW so the mutation isn't a channel-less attribution
+      // defect on the activity bus. Mirrors the memex-rename route (spec-479).
+      { channel: "rest_ui", actorUserId: user.id },
+    );
     return c.json({ namespace: updated });
   } catch (err) {
     if (err instanceof ValidationError) {

--- a/packages/server/src/services/email/activation-backlog.integration.test.ts
+++ b/packages/server/src/services/email/activation-backlog.integration.test.ts
@@ -20,6 +20,9 @@ const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-427/acs
 // spec-480 dec-9/dec-10: the backlog blast now sends the win-back (activation.signed_in_dormant) to
 // signed_in_dormant only; connected_inactive is deferred (not sent in v1).
 const AC480 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-480/acs/ac-${n}`;
+// spec-487 revived connected_inactive (dec-1) — it now sends in the drip AND the one-time
+// backlog blast (Fred 2026-07-17, reversing spec-480 dec-10).
+const AC487 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-487/acs/ac-${n}`;
 const NOW = new Date("2026-06-20T00:00:00Z");
 const daysAgo = (d: number) => new Date(NOW.getTime() - d * 24 * 60 * 60 * 1000);
 
@@ -89,16 +92,16 @@ describe("selectBacklogCandidates — the go-live cutoff (ac-9)", () => {
 });
 
 describe("backlog send over the candidate set (ac-5, ac-9)", () => {
-  it("sends the win-back only to signed-in-dormant; defers connected-inactive; skips activated; no re-fire on the evergreen hand-off (ac-5, ac-9, spec-480 ac-14)", async () => {
+  it("blast sends the win-back to signed-in-dormant AND the Day-2 to connected-inactive; dedups the already-emailed; skips activated; no re-fire on the evergreen hand-off (ac-5, ac-9, spec-487 ac-5)", async () => {
     tagAc(AC(5));
     tagAc(AC(9));
-    tagAc(AC480(14));
-    // A — connected-inactive, stalled long ago → DEFERRED in v1 (spec-480 dec-9), no send.
+    tagAc(AC487(5));
+    // A — connected-inactive, stalled long ago → NOW SENDS its Day-2 (spec-487 revive).
     const a = await seedUser("t8-a@example.test", { createdAt: daysAgo(60) });
     await seedMcpConnected(a.id, daysAgo(50));
     // B — signed-in-dormant (verified long ago, never connected) → the win-back.
     const b = await seedUser("t8-b@example.test", { createdAt: daysAgo(60), verifiedAt: daysAgo(60) });
-    // D — connected-inactive (deferred regardless of any prior key) → no send.
+    // D — connected-inactive but ALREADY emailed the Day-2 → deduped on its key, no re-send.
     const d = await seedUser("t8-d@example.test", { createdAt: daysAgo(60) });
     await seedMcpConnected(d.id, daysAgo(50));
     await recordComm({ userId: d.id, channel: "email", type: "activation.connected_inactive", subject: "sent earlier" });
@@ -108,16 +111,16 @@ describe("backlog send over the candidate set (ac-5, ac-9)", () => {
 
     const backlog = [a, b, d, e];
     const s1 = await runActivationDrip(NOW, undefined, backlog);
-    // Only B (signed_in_dormant) sends in v1; A + D are deferred connected_inactive.
-    expect(s1.sent).toBe(1);
+    // A (connected_inactive) + B (signed_in_dormant) send; D deduped; E activated.
+    expect(s1.sent).toBe(2);
     const byUser = new Map(sent.map((m) => [m.to, m.commsType]));
+    expect(byUser.get(a.email!)).toBe("activation.connected_inactive"); // revived Day-2
     expect(byUser.get(b.email!)).toBe("activation.signed_in_dormant");
-    expect(byUser.has(a.email!)).toBe(false); // connected_inactive → deferred
-    expect(byUser.has(d.email!)).toBe(false); // connected_inactive → deferred
+    expect(byUser.has(d.email!)).toBe(false); // already emailed → deduped
     expect(byUser.has(e.email!)).toBe(false); // activated
 
-    // Evergreen hand-off: switching the daily drip on afterwards must NOT re-send to B
-    // (now carries activation.signed_in_dormant), and still never sends the deferred cohort.
+    // Evergreen hand-off: switching the daily drip on afterwards must NOT re-send to A or B
+    // (both now carry their stable keys), and still never re-sends the deduped cohort.
     sent = [];
     const s2 = await runActivationDrip(NOW, undefined, backlog);
     expect(s2.sent).toBe(0);

--- a/packages/server/src/services/email/activation-backlog.integration.test.ts
+++ b/packages/server/src/services/email/activation-backlog.integration.test.ts
@@ -17,6 +17,9 @@ import { runActivationDrip, type CandidateUser } from "./activation-drip.js";
 import { selectBacklogCandidates } from "./activation-backlog.js";
 
 const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-427/acs/ac-${n}`;
+// spec-480 dec-9/dec-10: the backlog blast now sends the win-back (activation.signed_in_dormant) to
+// signed_in_dormant only; connected_inactive is deferred (not sent in v1).
+const AC480 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-480/acs/ac-${n}`;
 const NOW = new Date("2026-06-20T00:00:00Z");
 const daysAgo = (d: number) => new Date(NOW.getTime() - d * 24 * 60 * 60 * 1000);
 
@@ -86,15 +89,16 @@ describe("selectBacklogCandidates — the go-live cutoff (ac-9)", () => {
 });
 
 describe("backlog send over the candidate set (ac-5, ac-9)", () => {
-  it("sends the correct single email per still-stalled user; skips already-keyed + activated; no re-fire on the evergreen hand-off", async () => {
+  it("sends the win-back only to signed-in-dormant; defers connected-inactive; skips activated; no re-fire on the evergreen hand-off (ac-5, ac-9, spec-480 ac-14)", async () => {
     tagAc(AC(5));
     tagAc(AC(9));
-    // A — connected-inactive, stalled long ago → Email 1.
+    tagAc(AC480(14));
+    // A — connected-inactive, stalled long ago → DEFERRED in v1 (spec-480 dec-9), no send.
     const a = await seedUser("t8-a@example.test", { createdAt: daysAgo(60) });
     await seedMcpConnected(a.id, daysAgo(50));
-    // B — signed-in-dormant (verified long ago, never connected) → Email 2.
+    // B — signed-in-dormant (verified long ago, never connected) → the win-back.
     const b = await seedUser("t8-b@example.test", { createdAt: daysAgo(60), verifiedAt: daysAgo(60) });
-    // D — connected-inactive but ALREADY emailed (carries the key) → skipped.
+    // D — connected-inactive (deferred regardless of any prior key) → no send.
     const d = await seedUser("t8-d@example.test", { createdAt: daysAgo(60) });
     await seedMcpConnected(d.id, daysAgo(50));
     await recordComm({ userId: d.id, channel: "email", type: "activation.connected_inactive", subject: "sent earlier" });
@@ -104,15 +108,16 @@ describe("backlog send over the candidate set (ac-5, ac-9)", () => {
 
     const backlog = [a, b, d, e];
     const s1 = await runActivationDrip(NOW, undefined, backlog);
-    expect(s1.sent).toBe(2);
+    // Only B (signed_in_dormant) sends in v1; A + D are deferred connected_inactive.
+    expect(s1.sent).toBe(1);
     const byUser = new Map(sent.map((m) => [m.to, m.commsType]));
-    expect(byUser.get(a.email!)).toBe("activation.connected_inactive");
     expect(byUser.get(b.email!)).toBe("activation.signed_in_dormant");
-    expect(byUser.has(d.email!)).toBe(false); // already emailed
+    expect(byUser.has(a.email!)).toBe(false); // connected_inactive → deferred
+    expect(byUser.has(d.email!)).toBe(false); // connected_inactive → deferred
     expect(byUser.has(e.email!)).toBe(false); // activated
 
-    // Evergreen hand-off: switching the daily drip on afterwards must NOT re-send to
-    // anyone the backlog already emailed (they now all carry their key).
+    // Evergreen hand-off: switching the daily drip on afterwards must NOT re-send to B
+    // (now carries activation.signed_in_dormant), and still never sends the deferred cohort.
     sent = [];
     const s2 = await runActivationDrip(NOW, undefined, backlog);
     expect(s2.sent).toBe(0);

--- a/packages/server/src/services/email/activation-drip.integration.test.ts
+++ b/packages/server/src/services/email/activation-drip.integration.test.ts
@@ -16,6 +16,8 @@ const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-427/acs
 // spec-480 amended the win-back orchestration (dec-9/dec-10): signed_in_dormant → the
 // video win-back keyed activation.signed_in_dormant; connected_inactive deferred (not sent in v1).
 const AC480 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-480/acs/ac-${n}`;
+// spec-487 revived connected_inactive (dec-1): it now sends its own Day-2 "create a spec" email.
+const AC487 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-487/acs/ac-${n}`;
 const NOW = new Date("2026-06-20T00:00:00Z");
 const daysAgo = (d: number) => new Date(NOW.getTime() - d * 24 * 60 * 60 * 1000);
 
@@ -72,18 +74,18 @@ afterEach(async () => {
 });
 
 describe("runActivationDrip (real DB)", () => {
-  it("connected-inactive is deferred in v1 — nothing sent, nothing logged (spec-480 ac-14, dec-9)", async () => {
-    tagAc(AC480(14));
+  it("connected-inactive past 2d dwell → one Day-2 email, keyed activation.connected_inactive (spec-487 ac-5)", async () => {
+    tagAc(AC487(5));
     const u = await seedUser("t7-e1@example.test", { name: "Ada Lovelace" });
-    await seedMcpConnected(u.id, daysAgo(3)); // connected 3d ago, no tool call, no spec
+    await seedMcpConnected(u.id, daysAgo(3)); // connected 3d ago (> 2d dwell), no tool call, no spec
 
     const s1 = await drip([u]);
-    // spec-480 dec-9/dec-10: connected_inactive is deferred to a separate later email —
-    // it never sends in v1, so the flag-flip's first blast is the win-back alone.
-    expect(s1.sent).toBe(0);
-    expect(sent).toHaveLength(0);
+    // spec-487 dec-1: connected_inactive is REVIVED — it sends its own "create a spec" email.
+    expect(s1.sent).toBe(1);
+    expect(sent).toHaveLength(1);
+    expect(sent[0]!.commsType).toBe("activation.connected_inactive");
     const rows = await db.select().from(commsLog).where(eq(commsLog.userId, u.id));
-    expect(rows).toHaveLength(0);
+    expect(rows).toHaveLength(1);
   });
 
   it("signed-in-dormant past 3d dwell → one win-back, keyed activation.signed_in_dormant, team From/Reply-To, no re-send (ac-2, ac-7, spec-480 ac-13/ac-14)", async () => {
@@ -120,26 +122,26 @@ describe("runActivationDrip (real DB)", () => {
     expect(sent).toHaveLength(0);
   });
 
-  it("at most one email per run — connected-inactive contributes zero (deferred) (ac-3, spec-480 ac-14)", async () => {
+  it("at most one email per run — connected-inactive now contributes exactly one (ac-3, spec-487 ac-5)", async () => {
     tagAc(AC(3));
-    tagAc(AC480(14));
+    tagAc(AC487(5));
     const u = await seedUser("t7-excl@example.test");
     await seedMcpConnected(u.id, daysAgo(3));
     await drip([u]);
-    // ac-3 exclusivity still holds; for connected_inactive in v1 the count is zero (deferred).
-    expect(sent.map((m) => m.commsType)).toEqual([]);
+    // ac-3 exclusivity: at most one email per user per run; connected_inactive sends its one.
+    expect(sent.map((m) => m.commsType)).toEqual(["activation.connected_inactive"]);
   });
 
-  it("state re-evaluated live: a user who has since connected is deferred, not sent (ac-4, spec-480 ac-14)", async () => {
+  it("state re-evaluated live: a user who has since connected gets the Day-2 email (ac-4, spec-487 ac-5)", async () => {
     tagAc(AC(4));
-    tagAc(AC480(14));
+    tagAc(AC487(5));
     const u = await seedUser("t7-progress@example.test");
     await seedMcpConnected(u.id, daysAgo(3)); // live cohort = connected_inactive
-    // spec-480 dec-9: the live re-eval still runs, but connected_inactive is deferred —
-    // v1 sends nothing (its "Connect your agent" CTA would be nonsensical here).
+    // spec-487: the live re-eval runs and connected_inactive now sends its "create a spec" email.
     const s = await drip([u]);
-    expect(s.sent).toBe(0);
-    expect(sent).toHaveLength(0);
+    expect(s.sent).toBe(1);
+    expect(sent).toHaveLength(1);
+    expect(sent[0]!.commsType).toBe("activation.connected_inactive");
   });
 
   it("dedup keys on the stable comms key, NOT the subject line (ac-14, spec-480 ac-13)", async () => {

--- a/packages/server/src/services/email/activation-drip.integration.test.ts
+++ b/packages/server/src/services/email/activation-drip.integration.test.ts
@@ -13,6 +13,9 @@ import { setEmailSender, type EmailMessage } from "./sender.js";
 import { runActivationDrip, selectActivationCandidates, type CandidateUser } from "./activation-drip.js";
 
 const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-427/acs/ac-${n}`;
+// spec-480 amended the win-back orchestration (dec-9/dec-10): signed_in_dormant → the
+// video win-back keyed activation.signed_in_dormant; connected_inactive deferred (not sent in v1).
+const AC480 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-480/acs/ac-${n}`;
 const NOW = new Date("2026-06-20T00:00:00Z");
 const daysAgo = (d: number) => new Date(NOW.getTime() - d * 24 * 60 * 60 * 1000);
 
@@ -69,41 +72,45 @@ afterEach(async () => {
 });
 
 describe("runActivationDrip (real DB)", () => {
-  it("connected-inactive past 2d dwell → exactly one Email 1, recorded under its stable key; team From/Reply-To; no re-send (ac-1, ac-7, ac-14)", async () => {
-    tagAc(AC(1));
-    tagAc(AC(7));
-    tagAc(AC(14));
+  it("connected-inactive is deferred in v1 — nothing sent, nothing logged (spec-480 ac-14, dec-9)", async () => {
+    tagAc(AC480(14));
     const u = await seedUser("t7-e1@example.test", { name: "Ada Lovelace" });
     await seedMcpConnected(u.id, daysAgo(3)); // connected 3d ago, no tool call, no spec
 
     const s1 = await drip([u]);
-    expect(s1.sent).toBe(1);
-    expect(sent).toHaveLength(1);
+    // spec-480 dec-9/dec-10: connected_inactive is deferred to a separate later email —
+    // it never sends in v1, so the flag-flip's first blast is the win-back alone.
+    expect(s1.sent).toBe(0);
+    expect(sent).toHaveLength(0);
+    const rows = await db.select().from(commsLog).where(eq(commsLog.userId, u.id));
+    expect(rows).toHaveLength(0);
+  });
+
+  it("signed-in-dormant past 3d dwell → one win-back, keyed activation.signed_in_dormant, team From/Reply-To, no re-send (ac-2, ac-7, spec-480 ac-13/ac-14)", async () => {
+    tagAc(AC(2));
+    tagAc(AC(7));
+    tagAc(AC480(13));
+    tagAc(AC480(14));
+    tagAc(AC480(5)); // scope: ships inside the existing send path, recorded in comms_log, no render break
+    const u = await seedUser("t7-e2@example.test", { verifiedAt: daysAgo(4) }); // no mcp.connected
+    const s = await drip([u]);
+    expect(s.sent).toBe(1);
     const m = sent[0]!;
-    expect(m.commsType).toBe("activation.connected_inactive");
-    expect(m.to).toBe(u.email);
+    // spec-480 dec-8: the single stable win-back key; single "Connect your agent" CTA.
+    expect(m.commsType).toBe("activation.signed_in_dormant");
+    expect(m.html).toContain(">Connect your agent</a>");
     // ac-7: team identity, never a no-reply sender.
     expect(m.from).toBe("The Memex AI team <support@memex.ai>");
     expect(m.replyTo).toBe("support@memex.ai");
     expect(m.from?.toLowerCase()).not.toContain("no-reply");
     expect(m.from?.toLowerCase()).not.toContain("noreply");
 
-    // Recorded in comms_log under the stable key (ac-1 / ac-14).
-    const rows = await db.select().from(commsLog).where(and(eq(commsLog.userId, u.id), eq(commsLog.type, "activation.connected_inactive")));
+    // Recorded under the stable key; a second run dedups → exactly once.
+    const rows = await db.select().from(commsLog).where(and(eq(commsLog.userId, u.id), eq(commsLog.type, "activation.signed_in_dormant")));
     expect(rows).toHaveLength(1);
-
-    // Second run: dedup reads that row → exactly once (ac-1).
     const s2 = await drip([u]);
     expect(s2.sent).toBe(0);
     expect(sent).toHaveLength(1);
-  });
-
-  it("signed-in-dormant past 3d dwell → exactly one Email 2 (ac-2)", async () => {
-    tagAc(AC(2));
-    const u = await seedUser("t7-e2@example.test", { verifiedAt: daysAgo(4) }); // no mcp.connected
-    const s = await drip([u]);
-    expect(s.sent).toBe(1);
-    expect(sent[0]!.commsType).toBe("activation.signed_in_dormant");
   });
 
   it("dwell not yet elapsed → nothing sent", async () => {
@@ -113,32 +120,34 @@ describe("runActivationDrip (real DB)", () => {
     expect(sent).toHaveLength(0);
   });
 
-  it("a connected-inactive user gets Email 1 only — never both in a run (ac-3)", async () => {
+  it("at most one email per run — connected-inactive contributes zero (deferred) (ac-3, spec-480 ac-14)", async () => {
     tagAc(AC(3));
+    tagAc(AC480(14));
     const u = await seedUser("t7-excl@example.test");
     await seedMcpConnected(u.id, daysAgo(3));
     await drip([u]);
-    expect(sent.map((m) => m.commsType)).toEqual(["activation.connected_inactive"]);
+    // ac-3 exclusivity still holds; for connected_inactive in v1 the count is zero (deferred).
+    expect(sent.map((m) => m.commsType)).toEqual([]);
   });
 
-  it("state re-evaluated live: carries the E2 key from before, now connected → sends E1, not a repeat (ac-4)", async () => {
+  it("state re-evaluated live: a user who has since connected is deferred, not sent (ac-4, spec-480 ac-14)", async () => {
     tagAc(AC(4));
+    tagAc(AC480(14));
     const u = await seedUser("t7-progress@example.test");
     await seedMcpConnected(u.id, daysAgo(3)); // live cohort = connected_inactive
-    // They were emailed as signed-in-dormant earlier — seed that comms_log key.
-    await recordComm({ userId: u.id, channel: "email", type: "activation.signed_in_dormant", subject: "old" });
-
+    // spec-480 dec-9: the live re-eval still runs, but connected_inactive is deferred —
+    // v1 sends nothing (its "Connect your agent" CTA would be nonsensical here).
     const s = await drip([u]);
-    expect(s.sent).toBe(1);
-    expect(sent[0]!.commsType).toBe("activation.connected_inactive"); // next-state email, not a repeat
+    expect(s.sent).toBe(0);
+    expect(sent).toHaveLength(0);
   });
 
-  it("dedup keys on the stable comms key, NOT the subject line (ac-14)", async () => {
+  it("dedup keys on the stable comms key, NOT the subject line (ac-14, spec-480 ac-13)", async () => {
     tagAc(AC(14));
-    const u = await seedUser("t7-keydedup@example.test");
-    await seedMcpConnected(u.id, daysAgo(3));
-    // A prior row under the SAME key but a DIFFERENT subject must still suppress.
-    await recordComm({ userId: u.id, channel: "email", type: "activation.connected_inactive", subject: "a completely different subject" });
+    tagAc(AC480(13));
+    const u = await seedUser("t7-keydedup@example.test", { verifiedAt: daysAgo(4) }); // signed_in_dormant
+    // A prior row under the SAME win-back key but a DIFFERENT subject must still suppress.
+    await recordComm({ userId: u.id, channel: "email", type: "activation.signed_in_dormant", subject: "a completely different subject" });
 
     const s = await drip([u]);
     expect(s.sent).toBe(0); // deduped by key despite the mismatched subject

--- a/packages/server/src/services/email/activation-drip.test.ts
+++ b/packages/server/src/services/email/activation-drip.test.ts
@@ -5,6 +5,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { tagAc } from "@memex-ai-ac/vitest";
 
 const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-427/acs/ac-${n}`;
+// spec-480 amended the win-back orchestration (dec-9/dec-10): signed_in_dormant → the
+// video win-back keyed activation.signed_in_dormant; connected_inactive deferred (not sent in v1).
+const AC480 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-480/acs/ac-${n}`;
 
 // ── mock the DB-touching collaborators ──────────────────────────────────────
 const evaluateActivationState = vi.fn();
@@ -62,39 +65,44 @@ describe("dwellElapsed", () => {
     expect(dwellElapsed("connected_inactive", daysAgo(1), NOW)).toBe(false);
     expect(dwellElapsed("connected_inactive", daysAgo(2), NOW)).toBe(true);
   });
-  it("Email 2 fires at ~3 days in signed-in-dormant, not before", () => {
+  it("the win-back fires at ~3 days in signed-in-dormant, not before (spec-480 ac-12)", () => {
     tagAc(AC(2));
+    // spec-480 dec-7: 3 days (anchored to email_verified_at) is now the SOLE win-back dwell.
+    tagAc(AC480(12));
     expect(dwellElapsed("signed_in_dormant", daysAgo(2), NOW)).toBe(false);
     expect(dwellElapsed("signed_in_dormant", daysAgo(3), NOW)).toBe(true);
   });
 });
 
 describe("sendActivationEmailForUser — ladder + dwell + dedup", () => {
-  it("connected-inactive past dwell → sends Email 1 with the create-spec modal deep-link (ac-1)", async () => {
-    tagAc(AC(1));
+  it("connected-inactive is DEFERRED in v1 — evaluated but not sent (spec-480 ac-14, dec-9)", async () => {
+    tagAc(AC480(14));
     evaluateActivationState.mockResolvedValue({ cohort: "connected_inactive", enteredAt: daysAgo(3) });
     const out = await sendActivationEmailForUser(USER, NOW, fakeConn);
-    expect(out).toMatchObject({ cohort: "connected_inactive", sent: true, reason: "sent" });
-    expect(sendLifecycleEmail).toHaveBeenCalledTimes(1);
-    const [, msg] = sendLifecycleEmail.mock.calls[0]!;
-    expect(msg.commsType).toBe(ACTIVATION_COMMS_KEY.connected_inactive);
-    // Q1: the "Create a spec" CTA deep-links to the new-spec modal (?new=1).
-    expect(msg.html).toContain("?new=1");
-    expect(msg.text).toContain("Hi Ada,"); // first-name greeting
+    // spec-480 dec-9/dec-10: the win-back targets signed_in_dormant only; connected_inactive
+    // is deferred to a separate later email, so it never sends in v1.
+    expect(out).toMatchObject({ cohort: "connected_inactive", sent: false, reason: "deferred" });
+    expect(sendLifecycleEmail).not.toHaveBeenCalled();
   });
 
-  it("signed-in-dormant past dwell → sends Email 2 (ac-2)", async () => {
+  it("signed-in-dormant past dwell → sends the win-back, keyed activation.signed_in_dormant (ac-2, spec-480 ac-13/ac-14)", async () => {
     tagAc(AC(2));
+    tagAc(AC480(13));
+    tagAc(AC480(14));
     evaluateActivationState.mockResolvedValue({ cohort: "signed_in_dormant", enteredAt: daysAgo(4) });
     const out = await sendActivationEmailForUser(USER, NOW);
     expect(out).toMatchObject({ cohort: "signed_in_dormant", sent: true, reason: "sent" });
     const [, msg] = sendLifecycleEmail.mock.calls[0]!;
+    // spec-480 dec-8: the win-back template, keyed activation.signed_in_dormant; single "Connect your agent" CTA.
+    expect(msg.commsType).toBe("activation.signed_in_dormant");
     expect(msg.commsType).toBe(ACTIVATION_COMMS_KEY.signed_in_dormant);
+    expect(msg.html).toContain(">Connect your agent</a>");
   });
 
-  it("dwell not yet elapsed → no send (ac-1)", async () => {
-    tagAc(AC(1));
-    evaluateActivationState.mockResolvedValue({ cohort: "connected_inactive", enteredAt: daysAgo(1) });
+  it("dwell not yet elapsed → no send (spec-480 ac-12: single 3-day win-back dwell)", async () => {
+    tagAc(AC480(12));
+    // signed_in_dormant is the sole v1 cohort; its dwell is 3 days (email_verified_at).
+    evaluateActivationState.mockResolvedValue({ cohort: "signed_in_dormant", enteredAt: daysAgo(2) });
     const out = await sendActivationEmailForUser(USER, NOW);
     expect(out.reason).toBe("dwell_pending");
     expect(sendLifecycleEmail).not.toHaveBeenCalled();
@@ -107,36 +115,39 @@ describe("sendActivationEmailForUser — ladder + dwell + dedup", () => {
     expect(sendLifecycleEmail).not.toHaveBeenCalled();
   });
 
-  it("already sent this cohort's email → deduped, no re-send (ac-3)", async () => {
+  it("already sent the win-back → deduped, no re-send (ac-3, spec-480 ac-13)", async () => {
     tagAc(AC(3));
-    evaluateActivationState.mockResolvedValue({ cohort: "connected_inactive", enteredAt: daysAgo(3) });
+    tagAc(AC480(13));
+    evaluateActivationState.mockResolvedValue({ cohort: "signed_in_dormant", enteredAt: daysAgo(4) });
     hasComm.mockResolvedValue(true);
     const out = await sendActivationEmailForUser(USER, NOW);
     expect(out.reason).toBe("already_sent");
     expect(sendLifecycleEmail).not.toHaveBeenCalled();
   });
 
-  it("dedup counts the stable comms KEY, never the subject line (ac-14)", async () => {
+  it("dedup counts the stable comms KEY (activation.signed_in_dormant), never the subject line (ac-14, spec-480 ac-13)", async () => {
     tagAc(AC(14));
-    evaluateActivationState.mockResolvedValue({ cohort: "connected_inactive", enteredAt: daysAgo(3) });
-    await sendActivationEmailForUser(USER, NOW, fakeConn);
-    // The dedup read is keyed on the stable template key for the cohort — the machine
-    // key `activation.connected_inactive`, NOT the human subject line "Memex is
-    // connected. Here's what to do next." (which the dedup never sees).
-    expect(hasComm).toHaveBeenCalledWith(USER.id, "activation.connected_inactive", expect.anything());
+    tagAc(AC480(13));
+    evaluateActivationState.mockResolvedValue({ cohort: "signed_in_dormant", enteredAt: daysAgo(4) });
+    await sendActivationEmailForUser(USER, NOW);
+    // The dedup read is keyed on the stable win-back key `activation.signed_in_dormant` (dec-8),
+    // NOT the human subject line "You signed up, then vanished" (which dedup never sees).
+    expect(hasComm).toHaveBeenCalledWith(USER.id, "activation.signed_in_dormant", expect.anything());
     const dedupKeys = hasComm.mock.calls.map((c) => c[1] as string);
-    expect(dedupKeys).not.toContain("Memex is connected. Here's what to do next.");
+    expect(dedupKeys).not.toContain("You signed up, then vanished");
   });
 
-  it("state is re-evaluated live: a user who already got Email 2 then connects rolls into Email 1 (ac-4)", async () => {
+  it("connected-inactive stays deferred even when live re-eval rolls a user into it (ac-4, spec-480 ac-14)", async () => {
     tagAc(AC(4));
-    // Live cohort is now connected-inactive; they carry the signed_in_dormant key from
-    // an earlier send, but NOT the connected_inactive key → Email 1 must still send.
+    tagAc(AC480(14));
+    // Live re-eval still happens (ac-4), but spec-480 dec-9 defers connected_inactive:
+    // a user who has since connected is NOT sent the win-back (its CTA would be nonsensical)
+    // and gets no v1 email — regardless of which keys they already carry.
     evaluateActivationState.mockResolvedValue({ cohort: "connected_inactive", enteredAt: daysAgo(3) });
-    hasComm.mockImplementation(async (_id: string, key: string) => key === ACTIVATION_COMMS_KEY.signed_in_dormant);
+    hasComm.mockResolvedValue(false);
     const out = await sendActivationEmailForUser(USER, NOW, fakeConn);
-    expect(out).toMatchObject({ cohort: "connected_inactive", sent: true });
-    expect(hasComm).toHaveBeenCalledWith(USER.id, ACTIVATION_COMMS_KEY.connected_inactive, expect.anything());
+    expect(out).toMatchObject({ cohort: "connected_inactive", sent: false, reason: "deferred" });
+    expect(sendLifecycleEmail).not.toHaveBeenCalled();
   });
 
   it("a user with no email is skipped", async () => {

--- a/packages/server/src/services/email/activation-drip.test.ts
+++ b/packages/server/src/services/email/activation-drip.test.ts
@@ -8,6 +8,8 @@ const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-427/acs
 // spec-480 amended the win-back orchestration (dec-9/dec-10): signed_in_dormant → the
 // video win-back keyed activation.signed_in_dormant; connected_inactive deferred (not sent in v1).
 const AC480 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-480/acs/ac-${n}`;
+// spec-487 revived connected_inactive (dec-1): it now sends its own Day-2 "create a spec" email.
+const AC487 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-487/acs/ac-${n}`;
 
 // ── mock the DB-touching collaborators ──────────────────────────────────────
 const evaluateActivationState = vi.fn();
@@ -75,14 +77,15 @@ describe("dwellElapsed", () => {
 });
 
 describe("sendActivationEmailForUser — ladder + dwell + dedup", () => {
-  it("connected-inactive is DEFERRED in v1 — evaluated but not sent (spec-480 ac-14, dec-9)", async () => {
-    tagAc(AC480(14));
+  it("connected-inactive past dwell → sends its Day-2 email, keyed activation.connected_inactive (spec-487 ac-5)", async () => {
+    tagAc(AC487(5));
     evaluateActivationState.mockResolvedValue({ cohort: "connected_inactive", enteredAt: daysAgo(3) });
     const out = await sendActivationEmailForUser(USER, NOW, fakeConn);
-    // spec-480 dec-9/dec-10: the win-back targets signed_in_dormant only; connected_inactive
-    // is deferred to a separate later email, so it never sends in v1.
-    expect(out).toMatchObject({ cohort: "connected_inactive", sent: false, reason: "deferred" });
-    expect(sendLifecycleEmail).not.toHaveBeenCalled();
+    // spec-487 dec-1: connected_inactive is REVIVED — it sends its own "create a spec" email.
+    expect(out).toMatchObject({ cohort: "connected_inactive", sent: true, reason: "sent" });
+    const [, msg] = sendLifecycleEmail.mock.calls[0]!;
+    expect(msg.commsType).toBe("activation.connected_inactive");
+    expect(msg.commsType).toBe(ACTIVATION_COMMS_KEY.connected_inactive);
   });
 
   it("signed-in-dormant past dwell → sends the win-back, keyed activation.signed_in_dormant (ac-2, spec-480 ac-13/ac-14)", async () => {
@@ -137,17 +140,16 @@ describe("sendActivationEmailForUser — ladder + dwell + dedup", () => {
     expect(dedupKeys).not.toContain("You signed up, then vanished");
   });
 
-  it("connected-inactive stays deferred even when live re-eval rolls a user into it (ac-4, spec-480 ac-14)", async () => {
+  it("live re-eval rolls a user into connected-inactive → sends its Day-2 email (ac-4, spec-487 ac-5)", async () => {
     tagAc(AC(4));
-    tagAc(AC480(14));
-    // Live re-eval still happens (ac-4), but spec-480 dec-9 defers connected_inactive:
-    // a user who has since connected is NOT sent the win-back (its CTA would be nonsensical)
-    // and gets no v1 email — regardless of which keys they already carry.
+    tagAc(AC487(5));
+    // Live re-eval (ac-4): a user who has since connected but made no spec is now
+    // connected_inactive — and since spec-487 revived it, gets its "create a spec" email.
     evaluateActivationState.mockResolvedValue({ cohort: "connected_inactive", enteredAt: daysAgo(3) });
     hasComm.mockResolvedValue(false);
     const out = await sendActivationEmailForUser(USER, NOW, fakeConn);
-    expect(out).toMatchObject({ cohort: "connected_inactive", sent: false, reason: "deferred" });
-    expect(sendLifecycleEmail).not.toHaveBeenCalled();
+    expect(out).toMatchObject({ cohort: "connected_inactive", sent: true, reason: "sent" });
+    expect(sendLifecycleEmail).toHaveBeenCalledTimes(1);
   });
 
   it("a user with no email is skipped", async () => {

--- a/packages/server/src/services/email/activation-drip.ts
+++ b/packages/server/src/services/email/activation-drip.ts
@@ -14,15 +14,15 @@
 // two-per-cohort ceiling are therefore keyed on the stable template key, never the
 // mutable subject line (ac-14).
 //
-// spec-480 amendment (dec-9 / dec-10 / s-4): the win-back program now sends ONE email —
-// the video-centric buildWinbackEmail — to the signed_in_dormant cohort ONLY.
-// connected_inactive is DEFERRED to a separate later email (its "Connect your agent" CTA
-// is nonsensical for already-connected users): the drip evaluates it but skips the send
-// in v1 (reason "deferred"), keeping the flag-flip's first blast the win-back alone. The
-// signed_in_dormant send keys on the EXISTING signed_in_dormant comms key (dec-8
-// re-resolved — reused, not a new key, to keep the cross-repo comms-conversion contract
-// intact) at its existing 3-day dwell anchored to email_verified_at (dec-7 — now the sole
-// win-back timer). connected_inactive's builder + branch are retained for its revival.
+// spec-480 amendment (dec-8 / s-4): the signed_in_dormant cohort sends the video-centric
+// buildWinbackEmail, keyed on the EXISTING signed_in_dormant comms key (dec-8 re-resolved
+// — reused, not a new key, to keep the cross-repo comms-conversion contract intact) at its
+// 3-day dwell anchored to email_verified_at (dec-7).
+//
+// spec-487 amendment (t-2 / dec-1): connected_inactive is REVIVED — it sends its own Day-2
+// "create a spec" email (buildConnectedInactiveEmail) again, at its 2-day dwell anchored to
+// first mcp.connected. This reverses spec-480 dec-9 (CTA-mismatch deferral) and dec-10 (the
+// launch blast now includes connected_inactive, since the backlog shares this send path).
 
 import { and, eq, isNotNull } from "drizzle-orm";
 import { type Db, db } from "../../db/connection.js";
@@ -50,7 +50,7 @@ export const ACTIVATION_DWELL_DAYS: Record<ActivationCohort, number> = {
 // comms-conversion contract (the metric is mirrored in memex-backstage; the pinned
 // comms-conversion.fixture.ts). buildWinbackEmail stamps this same key, so dedup below +
 // the activation-metrics join stay correct and the pinned fixture is untouched.
-// connected_inactive keeps its key for the deferred email's revival (not sent in v1).
+// connected_inactive uses its own stable key for the Day-2 "create a spec" email (spec-487).
 export const ACTIVATION_COMMS_KEY: Record<ActivationCohort, string> = {
   connected_inactive: "activation.connected_inactive",
   signed_in_dormant: "activation.signed_in_dormant",
@@ -97,7 +97,6 @@ export interface CandidateUser {
 export type DripReason =
   | "sent"
   | "no_cohort"
-  | "deferred" // spec-480 dec-9: cohort evaluated but not sent in v1 (connected_inactive)
   | "dwell_pending"
   | "already_sent"
   | "no_email"
@@ -170,15 +169,13 @@ export async function sendActivationEmailForUser(
   const { cohort, enteredAt } = await evaluateActivationState(user.id, conn);
   if (!cohort || !enteredAt) return { ...base, cohort: null, sent: false, reason: "no_cohort" };
 
-  // spec-480 dec-9 / dec-10: v1 sends the win-back to signed_in_dormant ONLY.
-  // connected_inactive is deferred to a separate later email (its "Connect your agent"
-  // CTA is nonsensical for already-connected users), so we evaluate it but do not send
-  // it in v1 — this is what keeps the flag-flip's first blast the single video win-back,
-  // not spec-427's two-email version. The buildActivationMessage branch + builder are
-  // retained for that email's revival.
-  if (cohort === "connected_inactive") {
-    return { ...base, cohort, sent: false, reason: "deferred" };
-  }
+  // spec-487 (t-2, dec-1) — connected_inactive is REVIVED: it now sends its own Day-2
+  // "create a spec" email (buildConnectedInactiveEmail), reversing spec-480 dec-9 (the
+  // CTA-mismatch deferral, moot now the email has its own "Create a spec" CTA) AND
+  // dec-10 (Fred 2026-07-17: the launch blast now includes connected_inactive — the
+  // backlog delegates to this same path, so the ~4 connected-inactive stalled users get
+  // the Day-2 in the first wave alongside the ~133 win-back). Both cohorts now route
+  // through dwell → dedup → send below.
 
   if (!dwellElapsed(cohort, enteredAt, now)) {
     return { ...base, cohort, sent: false, reason: "dwell_pending" };

--- a/packages/server/src/services/email/activation-drip.ts
+++ b/packages/server/src/services/email/activation-drip.ts
@@ -13,6 +13,16 @@
 // (dec-7); this drip only READS that log for dedup — it never writes it. Dedup and the
 // two-per-cohort ceiling are therefore keyed on the stable template key, never the
 // mutable subject line (ac-14).
+//
+// spec-480 amendment (dec-9 / dec-10 / s-4): the win-back program now sends ONE email —
+// the video-centric buildWinbackEmail — to the signed_in_dormant cohort ONLY.
+// connected_inactive is DEFERRED to a separate later email (its "Connect your agent" CTA
+// is nonsensical for already-connected users): the drip evaluates it but skips the send
+// in v1 (reason "deferred"), keeping the flag-flip's first blast the win-back alone. The
+// signed_in_dormant send keys on the EXISTING signed_in_dormant comms key (dec-8
+// re-resolved — reused, not a new key, to keep the cross-repo comms-conversion contract
+// intact) at its existing 3-day dwell anchored to email_verified_at (dec-7 — now the sole
+// win-back timer). connected_inactive's builder + branch are retained for its revival.
 
 import { and, eq, isNotNull } from "drizzle-orm";
 import { type Db, db } from "../../db/connection.js";
@@ -21,7 +31,7 @@ import { evaluateActivationState, type ActivationCohort } from "../activation-co
 import { hasComm } from "../comms-log.js";
 import { activationEmailsEnabled } from "./activation-flag.js";
 import { sendLifecycleEmail } from "./lifecycle-send.js";
-import { buildConnectedInactiveEmail, buildSignedInDormantEmail } from "./templates.js";
+import { buildConnectedInactiveEmail, buildWinbackEmail } from "./templates.js";
 
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 
@@ -35,6 +45,12 @@ export const ACTIVATION_DWELL_DAYS: Record<ActivationCohort, number> = {
 // Stable comms_log keys (dec-7 / ac-14). Dedup + sequencing key on THESE, never the
 // mutable subject line. Kept in sync with the `commsType` the Slice A builders stamp
 // onto the returned message.
+// spec-480 dec-8 (re-resolved): the win-back REUSES the existing signed_in_dormant key
+// rather than minting `activation.winback` — a new key would have split the cross-repo
+// comms-conversion contract (the metric is mirrored in memex-backstage; the pinned
+// comms-conversion.fixture.ts). buildWinbackEmail stamps this same key, so dedup below +
+// the activation-metrics join stay correct and the pinned fixture is untouched.
+// connected_inactive keeps its key for the deferred email's revival (not sent in v1).
 export const ACTIVATION_COMMS_KEY: Record<ActivationCohort, string> = {
   connected_inactive: "activation.connected_inactive",
   signed_in_dormant: "activation.signed_in_dormant",
@@ -51,6 +67,13 @@ function appBaseUrl(): string {
   // Mirrors welcome-send.ts: int → int.memex.ai, prod → memex.ai (dec-8).
   return process.env.APP_BASE_URL ?? "https://memex.ai";
 }
+
+// spec-480 dec-9 — the "Connect your agent" CTA target: the one-click desktop connect
+// flow. That is the desktop-app download page (spec-460 — the desktop app is the
+// one-click MCP-setup path that clears the browser→terminal cliff). A fixed marketing
+// URL on www.memex.ai (single host across envs), NOT a tenant/app path, so it is a
+// constant here rather than an APP_BASE_URL-derived link. `src` tags the referral.
+const WINBACK_CONNECT_URL = "https://www.memex.ai/download?src=winback-email";
 
 function firstName(name: string | null): string | undefined {
   return name?.trim().split(/\s+/)[0] || undefined;
@@ -74,6 +97,7 @@ export interface CandidateUser {
 export type DripReason =
   | "sent"
   | "no_cohort"
+  | "deferred" // spec-480 dec-9: cohort evaluated but not sent in v1 (connected_inactive)
   | "dwell_pending"
   | "already_sent"
   | "no_email"
@@ -117,8 +141,10 @@ async function buildActivationMessage(
   const base = appBaseUrl();
   const name = firstName(user.name);
   if (cohort === "signed_in_dormant") {
-    // Email 2 CTA "Open Memex AI" → the app root (Q1: unambiguous either way).
-    return buildSignedInDormantEmail({ to: user.email, firstName: name, appUrl: base });
+    // spec-480 dec-9 — the win-back email: single segment, CTA "Connect your agent"
+    // → the desktop connect flow (WINBACK_CONNECT_URL). Stamps commsType
+    // "activation.winback" (matches ACTIVATION_COMMS_KEY.signed_in_dormant).
+    return buildWinbackEmail({ to: user.email, firstName: name, connectUrl: WINBACK_CONNECT_URL });
   }
   // Email 1 CTA "Create a spec" → the new-spec modal deep-link (Q1: SpecList's ?new=1),
   // with "your Memex" pointing at the same board. Fall back to the app root if we can't
@@ -143,6 +169,16 @@ export async function sendActivationEmailForUser(
 
   const { cohort, enteredAt } = await evaluateActivationState(user.id, conn);
   if (!cohort || !enteredAt) return { ...base, cohort: null, sent: false, reason: "no_cohort" };
+
+  // spec-480 dec-9 / dec-10: v1 sends the win-back to signed_in_dormant ONLY.
+  // connected_inactive is deferred to a separate later email (its "Connect your agent"
+  // CTA is nonsensical for already-connected users), so we evaluate it but do not send
+  // it in v1 — this is what keeps the flag-flip's first blast the single video win-back,
+  // not spec-427's two-email version. The buildActivationMessage branch + builder are
+  // retained for that email's revival.
+  if (cohort === "connected_inactive") {
+    return { ...base, cohort, sent: false, reason: "deferred" };
+  }
 
   if (!dwellElapsed(cohort, enteredAt, now)) {
     return { ...base, cohort, sent: false, reason: "dwell_pending" };

--- a/packages/server/src/services/email/activation-flag.test.ts
+++ b/packages/server/src/services/email/activation-flag.test.ts
@@ -5,6 +5,10 @@ import { tagAc } from "@memex-ai-ac/vitest";
 import { activationEmailsEnabled } from "./activation-flag.js";
 
 const AC16 = "mindset-prod/memex-building-itself/specs/spec-427/acs/ac-16";
+// spec-480 ac-16 — the win-back go-live gate reuses this same master flag: default-OFF +
+// kill-switch is its automated core (the "flipped only at go-live, after int→prod smoke"
+// clause is operational, verified at deploy per std-26/std-17).
+const AC480_16 = "mindset-prod/memex-building-itself/specs/spec-480/acs/ac-16";
 const saved = process.env.ACTIVATION_EMAILS_ENABLED;
 afterEach(() => {
   if (saved === undefined) delete process.env.ACTIVATION_EMAILS_ENABLED;
@@ -14,6 +18,7 @@ afterEach(() => {
 describe("activationEmailsEnabled", () => {
   it("defaults OFF when unset (the safe default — the backlog never fires by accident)", () => {
     tagAc(AC16);
+    tagAc(AC480_16); // win-back stays dark until the flag is deliberately flipped
     delete process.env.ACTIVATION_EMAILS_ENABLED;
     expect(activationEmailsEnabled()).toBe(false);
   });
@@ -36,6 +41,7 @@ describe("activationEmailsEnabled", () => {
 
   it("reads live — a flip to off takes effect on the next call (kill switch)", () => {
     tagAc(AC16);
+    tagAc(AC480_16); // the same kill switch guards the win-back send
     process.env.ACTIVATION_EMAILS_ENABLED = "1";
     expect(activationEmailsEnabled()).toBe(true);
     process.env.ACTIVATION_EMAILS_ENABLED = "0";

--- a/packages/server/src/services/email/activation-metrics.integration.test.ts
+++ b/packages/server/src/services/email/activation-metrics.integration.test.ts
@@ -15,6 +15,9 @@ import { recordComm } from "../comms-log.js";
 import { measureActivationConversion } from "./activation-metrics.js";
 
 const AC6 = "mindset-prod/memex-building-itself/specs/spec-427/acs/ac-6";
+// spec-480 dec-8: the signed_in_dormant send is now the win-back, keyed activation.signed_in_dormant,
+// so the conversion join for that cohort counts THAT key.
+const AC480_13 = "mindset-prod/memex-building-itself/specs/spec-480/acs/ac-13";
 const SENT = new Date("2026-06-10T00:00:00Z");
 const hoursAfter = (h: number) => new Date(SENT.getTime() + h * 60 * 60 * 1000);
 
@@ -88,8 +91,9 @@ describe("measureActivationConversion (ac-6)", () => {
     expect(e1.rate).toBeCloseTo(1 / 3);
   });
 
-  it("Email 2: converts ONLY when BOTH mcp.connected AND a spec are created within 48h", async () => {
+  it("win-back (signed-in-dormant): converts ONLY when BOTH mcp.connected AND a spec within 48h — counted on activation.signed_in_dormant (ac-6, spec-480 ac-13)", async () => {
     tagAc(AC6);
+    tagAc(AC480_13);
     // both in-window → converted
     const both = await seedUser("t9-e2-both@example.test");
     await seedSend(both, "activation.signed_in_dormant");

--- a/packages/server/src/services/email/activation.test.ts
+++ b/packages/server/src/services/email/activation.test.ts
@@ -26,39 +26,49 @@ describe("buildConnectedInactiveEmail (Email 1 — connected-but-inactive)", () 
   const html = msg.html ?? "";
   const text = msg.text ?? "";
 
-  it("uses the verbatim subject + headline + Create-a-spec CTA, rendered from code", () => {
-    tagAc(AC(13)); // copy sourced from the code builder, not an external doc
-    expect(msg.subject).toBe("Memex is connected. Here's what to do next.");
-    // headline (apostrophe-free substring — html escapes it)
-    expect(html).toContain("Your Memex MCP is connected. The hard part is done.");
-    expect(text).toContain("Your Memex MCP is connected. The hard part is done.");
+  const AC487 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-487/acs/ac-${n}`;
+
+  it("uses the v2 subject + s-2 copy + Create-a-spec CTA, rendered from code (spec-487 ac-10)", () => {
+    tagAc(AC(13)); // spec-427: copy sourced from the code builder, not an external doc
+    tagAc(AC487(10)); // spec-487: the s-2 rewrite
+    expect(msg.subject).toBe("Connected, but the output has not changed yet");
+    // v2 leads with the greeting — no repeated headline
+    expect(html).not.toContain("<h1");
+    // key s-2 body lines (apostrophe-free substrings — html escapes apostrophes)
+    expect(html).toContain("the change you signed up for does not show until there is a Spec");
+    expect(html).toContain("A Memex spec fixes that");
+    expect(text).toContain("the change you signed up for does not show until there is a Spec");
     expect(html).toContain("Create a spec");
-    // the "moment it clicks" prose (apostrophe-free)
-    expect(html).toContain("the decisions it needs you to resolve");
-    expect(html).toContain("Memex does not touch your code.");
+    // old Option-3 copy gone
+    expect(html).not.toContain("The hard part is done");
   });
 
-  it("renders solely through the shared renderer with a solid CTA and no imagery (ac-10)", () => {
+  it("renders through the shared renderer; the only image is the how-to video poster, no Watch button (ac-10, spec-487 ac-8)", () => {
     tagAc(AC(10));
+    tagAc(AC487(8));
+    tagAc(AC487(7)); // video links the hosted .mp4, never a Drive link
     expect(html).toContain("<!doctype html>");
-    // shared-renderer brand mark + solid coral CTA button (never a gradient).
-    // Wordmark is single-colour dark-ink "Memex AI" live text (spec-465: no dot, uniform weight).
     expect(html).toContain('color:#0E1128;">Memex AI</div>');
     expect(html).toContain("background:#0482DC;color:#FFFFFF");
     expect(html).not.toContain("linear-gradient");
-    expect(html).not.toContain("<img");
-    // resources render as a presentation table (a table construct, not image buttons)
+    // spec-487: exactly ONE image — the video poster — and NO "Watch the 3-min guide" button
+    expect((html.match(/<img/g) ?? []).length).toBe(1);
+    expect(html).toContain("email-howto-create-spec-thumb-480.png");
+    expect(html).not.toContain("Watch the 3-min guide");
+    // ac-7: the thumbnail links the hosted .mp4 on the shared bucket, never a Drive link
+    expect(html).toContain("storage.googleapis.com/memex-ai-prod-app-static/media/email-howto-create-spec.mp4");
+    expect(html).not.toContain("drive.google.com");
+    // image-blocked fallback line present (raw apostrophe — not escaped)
+    expect(html).toContain("Can't see the video above?");
+    // resources still render as a presentation table
     expect(html).toContain('<table role="presentation" width="100%"');
     expect(html).toContain("Understanding Memex AI");
-    expect(html).toContain("Documentation");
-    expect(html).toContain("Community");
   });
 
-  it("deep-links the CTA + 'your Memex' from the passed URLs, not a hardcoded host (dec-8)", () => {
+  it("deep-links the Create-a-spec CTA from the passed URL, not a hardcoded host (dec-8)", () => {
     tagAc(AC(10));
     expect(html).toContain('href="https://int.memex.ai/mindset-prod/sample/specs/new"');
-    expect(html).toContain('href="https://int.memex.ai/mindset-prod/sample"');
-    // no prod host baked in when an int URL was supplied
+    // v2 dropped the "your Memex" link; the CTA is the only app deep-link
     expect(html).not.toContain('href="https://memex.ai/');
   });
 

--- a/packages/server/src/services/email/activation.test.ts
+++ b/packages/server/src/services/email/activation.test.ts
@@ -44,7 +44,7 @@ describe("buildConnectedInactiveEmail (Email 1 — connected-but-inactive)", () 
     // shared-renderer brand mark + solid coral CTA button (never a gradient).
     // Wordmark is single-colour dark-ink "Memex AI" live text (spec-465: no dot, uniform weight).
     expect(html).toContain('color:#0E1128;">Memex AI</div>');
-    expect(html).toContain("background:#FC4F64;color:#FFFFFF");
+    expect(html).toContain("background:#0482DC;color:#FFFFFF");
     expect(html).not.toContain("linear-gradient");
     expect(html).not.toContain("<img");
     // resources render as a presentation table (a table construct, not image buttons)
@@ -104,7 +104,7 @@ describe("buildSignedInDormantEmail (Email 2 — signed-in-but-dormant)", () => 
   it("renders solely through the shared renderer with the step + resources primitives, no imagery (ac-10)", () => {
     tagAc(AC(10));
     expect(html).toContain("<!doctype html>");
-    expect(html).toContain("background:#FC4F64;color:#FFFFFF");
+    expect(html).toContain("background:#0482DC;color:#FFFFFF");
     expect(html).not.toContain("linear-gradient");
     expect(html).not.toContain("<img");
     // spec-226 step primitive

--- a/packages/server/src/services/email/broadcast-transport.test.ts
+++ b/packages/server/src/services/email/broadcast-transport.test.ts
@@ -13,6 +13,7 @@ vi.mock("../comms-log.js", () => ({ recordEmailComm: vi.fn().mockResolvedValue(n
 import { PostmarkEmailSender, getEmailSender, setEmailSender } from "./sender.js";
 
 const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-427/acs/ac-${n}`;
+const AC480 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-480/acs/ac-${n}`;
 // Postmark's well-known sandbox token literal — accepts, returns 200, delivers nothing.
 const POSTMARK_TEST_TOKEN = "POSTMARK_API_TEST";
 
@@ -72,6 +73,25 @@ describe("PostmarkEmailSender — broadcast stream + List-Unsubscribe (ac-11)", 
     await sender.send({ to: "u@acme.test", subject: "Hi", text: "body" });
     const headers = (bodyOf(mock).Headers ?? []) as { Name: string }[];
     expect(headers.find((h) => h.Name === "List-Unsubscribe")).toBeUndefined();
+  });
+});
+
+describe("PostmarkEmailSender — click tracking (spec-480 ac-11)", () => {
+  it("sets TrackLinks=HtmlAndText when trackLinks is true (the win-back)", async () => {
+    tagAc(AC480(11));
+    const mock = captureFetch();
+    const sender = new PostmarkEmailSender("real-tok", "from", "broadcast-tok");
+    await sender.send({ to: "u@acme.test", subject: "Hi", text: "body", stream: "broadcast", trackLinks: true });
+    expect(bodyOf(mock).TrackLinks).toBe("HtmlAndText");
+  });
+
+  it("omits TrackLinks — and never TrackOpens/pixel — when trackLinks is not set", async () => {
+    tagAc(AC480(11));
+    const mock = captureFetch();
+    const sender = new PostmarkEmailSender("real-tok", "from", "broadcast-tok");
+    await sender.send({ to: "u@acme.test", subject: "Hi", text: "body", stream: "broadcast" });
+    expect(bodyOf(mock).TrackLinks).toBeUndefined();
+    expect(bodyOf(mock).TrackOpens).toBeUndefined(); // click tracking only, no open pixel
   });
 });
 

--- a/packages/server/src/services/email/email-howto-assets.spec-487.test.ts
+++ b/packages/server/src/services/email/email-howto-assets.spec-487.test.ts
@@ -1,0 +1,39 @@
+// spec-487 t-1 — the three per-email how-to video + poster URL constants must
+// resolve to the shared hosted static-bucket path (spec-480 pattern), never a
+// Drive link. The rendered-HTML side of ac-7 is covered by the per-email tests
+// (t-2/t-3/t-5); this locks the constants themselves.
+import { describe, it, expect } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import {
+  EMAIL_HOWTO_CREATE_SPEC,
+  EMAIL_HOWTO_CONNECT_MCP,
+  EMAIL_HOWTO_CONNECT_PEOPLE,
+} from "./templates.js";
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-487/acs/ac-${n}`;
+const BASE = "https://storage.googleapis.com/memex-ai-prod-app-static/media";
+
+describe("spec-487 t-1 — hosted how-to video + poster constants (ac-7)", () => {
+  const assets = [
+    ["create-spec (Day-2)", EMAIL_HOWTO_CREATE_SPEC, "email-howto-create-spec"],
+    ["connect-mcp (Day-3)", EMAIL_HOWTO_CONNECT_MCP, "email-howto-connect-mcp"],
+    ["connect-people (Day-12)", EMAIL_HOWTO_CONNECT_PEOPLE, "email-howto-connect-people"],
+  ] as const;
+
+  for (const [name, asset, slug] of assets) {
+    it(`${name}: video + both posters resolve to the shared hosted bucket path`, () => {
+      tagAc(AC(7));
+      expect(asset.videoUrl).toBe(`${BASE}/${slug}.mp4`);
+      expect(asset.thumb1xUrl).toBe(`${BASE}/${slug}-thumb-480.png`);
+      expect(asset.thumb2xUrl).toBe(`${BASE}/${slug}-thumb-960.png`);
+    });
+
+    it(`${name}: every URL is https and never a Drive link`, () => {
+      tagAc(AC(7));
+      for (const u of [asset.videoUrl, asset.thumb1xUrl, asset.thumb2xUrl]) {
+        expect(u.startsWith("https://")).toBe(true);
+        expect(u).not.toContain("drive.google.com");
+      }
+    });
+  }
+});

--- a/packages/server/src/services/email/email-ui-polish.test.ts
+++ b/packages/server/src/services/email/email-ui-polish.test.ts
@@ -22,7 +22,7 @@ import {
 const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-451/acs/ac-${n}`;
 
 // Brand colours (mirror templates.ts).
-const CORAL = "#FC4F64";
+const CORAL = "#0482DC";
 const INK = "#0E1128";
 const SKY = "#0C9FE3";
 const MONO_MARKER = "'SF Mono'"; // MONO_STACK signature
@@ -96,12 +96,12 @@ describe("spec-451 — spacing between wordmark and headline (ac-3, ac-8)", () =
 
 describe("spec-451 — step labels restyled, '// Step N' kept (ac-4, ac-7, ac-8)", () => {
   const stepsHtml = renderSteps([{ label: "// Step 1", title: "Connect", body: "Body." }]);
-  it("label is body-font, bold, coral — not blue mono — and keeps the '// ' prefix", () => {
+  it("label is body-font, bold, accent #0482DC — not the old blue mono — and keeps the '// ' prefix", () => {
     tagAc(AC(4));
     tagAc(AC(7));
     // The "// Step 1" text is retained.
     expect(stepsHtml).toContain("// Step 1");
-    // Restyled: coral + bold, no longer blue mono / eyebrow letter-spacing.
+    // Restyled: accent #0482DC + bold, no longer blue mono / eyebrow letter-spacing.
     expect(stepsHtml).toContain(`color:${CORAL}`);
     expect(stepsHtml).toContain("font-weight:700");
     expect(stepsHtml).not.toContain(SKY);

--- a/packages/server/src/services/email/email-ui-polish.test.ts
+++ b/packages/server/src/services/email/email-ui-polish.test.ts
@@ -65,20 +65,32 @@ describe("spec-451 — eyebrow removed everywhere (ac-1, ac-6)", () => {
     tagAc(AC(6));
     for (const [, msg] of activation) {
       expect(msg.html!).not.toContain(EYEBROW_MARKER);
-      expect(msg.html!).toMatch(/>Memex AI<\/div>\s*<h1/);
     }
+    // connected + signed-in-dormant lead with an <h1> directly under the wordmark.
+    expect(connected.html!).toMatch(/>Memex AI<\/div>\s*<h1/);
+    expect(signedIn.html!).toMatch(/>Memex AI<\/div>\s*<h1/);
+    // spec-488: the welcome v2 carries no headline, so the wordmark is followed
+    // straight by the first body paragraph (the greeting), not an <h1>.
+    expect(welcome.html!).toMatch(/>Memex AI<\/div>\s*<p[^>]*>Hi Ada,/);
   });
 });
 
 describe("spec-451 — single-colour dark wordmark (ac-2)", () => {
   it("the .AI wordmark renders in dark ink, not coral, as live text (no img/svg)", () => {
     tagAc(AC(2));
-    for (const [, msg] of [...eyebrowed, ...activation]) {
+    for (const [name, msg] of [...eyebrowed, ...activation]) {
       const html = msg.html!;
+      // the wordmark is live text in dark ink, never coral, never an image
       expect(html).toContain(`color:${INK};">Memex AI</div>`);
       expect(html).not.toContain(`color:${CORAL};">Memex AI</div>`);
-      expect(html).not.toContain("<img");
-      expect(html).not.toContain("<svg");
+      // spec-488: the welcome v2 carries the video thumbnail <img> (like the
+      // win-back); the wordmark itself is still text. Only the wordmark's
+      // image-freeness is asserted for welcome — the "no imagery anywhere" check
+      // holds for the emails that remain image-free.
+      if (name !== "welcome") {
+        expect(html).not.toContain("<img");
+        expect(html).not.toContain("<svg");
+      }
     }
   });
 });

--- a/packages/server/src/services/email/email-ui-polish.test.ts
+++ b/packages/server/src/services/email/email-ui-polish.test.ts
@@ -66,12 +66,12 @@ describe("spec-451 — eyebrow removed everywhere (ac-1, ac-6)", () => {
     for (const [, msg] of activation) {
       expect(msg.html!).not.toContain(EYEBROW_MARKER);
     }
-    // connected + signed-in-dormant lead with an <h1> directly under the wordmark.
-    expect(connected.html!).toMatch(/>Memex AI<\/div>\s*<h1/);
+    // signed-in-dormant (unchanged spec-427 builder) still leads with an <h1>.
     expect(signedIn.html!).toMatch(/>Memex AI<\/div>\s*<h1/);
-    // spec-488: the welcome v2 carries no headline, so the wordmark is followed
-    // straight by the first body paragraph (the greeting), not an <h1>.
+    // spec-488 (welcome) + spec-487 (connected-inactive v2) carry no headline — the
+    // wordmark is followed straight by the first body paragraph (the greeting), not an <h1>.
     expect(welcome.html!).toMatch(/>Memex AI<\/div>\s*<p[^>]*>Hi Ada,/);
+    expect(connected.html!).toMatch(/>Memex AI<\/div>\s*<p[^>]*>Hi Ada,/);
   });
 });
 
@@ -83,11 +83,11 @@ describe("spec-451 — single-colour dark wordmark (ac-2)", () => {
       // the wordmark is live text in dark ink, never coral, never an image
       expect(html).toContain(`color:${INK};">Memex AI</div>`);
       expect(html).not.toContain(`color:${CORAL};">Memex AI</div>`);
-      // spec-488: the welcome v2 carries the video thumbnail <img> (like the
-      // win-back); the wordmark itself is still text. Only the wordmark's
-      // image-freeness is asserted for welcome — the "no imagery anywhere" check
-      // holds for the emails that remain image-free.
-      if (name !== "welcome") {
+      // The welcome v2 (spec-488) and the connected-inactive v2 (spec-487) now carry a
+      // video thumbnail <img>; the wordmark itself is still text. Only the wordmark's
+      // image-freeness is asserted for those two — the "no imagery anywhere" check holds
+      // for the emails that remain image-free.
+      if (name !== "welcome" && name !== "connected") {
         expect(html).not.toContain("<img");
         expect(html).not.toContain("<svg");
       }

--- a/packages/server/src/services/email/preview-samples.ts
+++ b/packages/server/src/services/email/preview-samples.ts
@@ -22,6 +22,7 @@ import {
   buildAssignmentEmail,
   buildConnectedInactiveEmail,
   buildSignedInDormantEmail,
+  buildWinbackEmail,
   buildVerifiedMilestoneEmail,
   buildConnectPeopleEmail,
 } from "./templates.js";
@@ -80,6 +81,13 @@ export const EMAIL_PREVIEW_SAMPLES: Record<string, (to: string) => EmailMessage>
     }),
   "activation-signed-in-dormant": (to) =>
     buildSignedInDormantEmail({ to, firstName: "Sample", appUrl: BASE }),
+  // spec-480 — the win-back email (video thumbnail + "Connect your agent"). This is what
+  // the signed_in_dormant cohort actually receives in v1 (activation.winback); the
+  // signed-in-dormant sample above is retained as the superseded spec-427 template.
+  // Registered here so the win-back render (its one intentional image) is previewable +
+  // send-testable on int for visual QA (ac-1).
+  "activation-winback": (to) =>
+    buildWinbackEmail({ to, firstName: "Sample", connectUrl: "https://www.memex.ai/download?src=winback-email" }),
   // spec-453 — "See it verified" (verified-milestone) + "Connect with people".
   // Same hyphenated preview-key convention as the spec-427 pair above; the
   // comms_log keys stay the dotted `activation.verified_milestone` /

--- a/packages/server/src/services/email/send-conditions.test.ts
+++ b/packages/server/src/services/email/send-conditions.test.ts
@@ -1,0 +1,137 @@
+// spec-493 t-1 — the timeline send-condition metadata. Two guarantees under test:
+//   1. day-offset + comms-key facts are IMPORTED from the send path, so they cannot
+//      drift from what actually sends (dec-1 / ac-3 / ac-7); the only hand-authored
+//      fields are inherently-textual prose/flag/branch (ac-8).
+//   2. exactly the 5 onboarding emails are on the timeline, with connected-inactive /
+//      win-back as two exclusive parallel branches (dec-3 / ac-11 / ac-12).
+import { describe, it, expect } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import {
+  ONBOARDING_SEQUENCE,
+  ONBOARDING_TEMPLATES,
+  PER_COHORT_CAP,
+  type SendCondition,
+} from "./send-conditions.js";
+import {
+  ACTIVATION_DWELL_DAYS,
+  ACTIVATION_COMMS_KEY,
+  ACTIVATION_PER_COHORT_CAP,
+} from "./activation-drip.js";
+import { CONNECT_PEOPLE_DWELL_DAYS, CONNECT_PEOPLE_COMMS_KEY } from "./connect-people.js";
+import { EMAIL_TEMPLATE_NAMES } from "./preview-samples.js";
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-493/acs/ac-${n}`;
+
+const byTemplate = (t: string): SendCondition => {
+  const c = ONBOARDING_SEQUENCE.find((x) => x.template === t);
+  if (!c) throw new Error(`no send-condition for ${t}`);
+  return c;
+};
+
+// The onboarding emails whose day/key facts have an exported send-path constant.
+const IMPORTED = [
+  "activation-connected-inactive",
+  "activation-winback",
+  "activation-connect-people",
+];
+
+describe("send-conditions: day/comms facts are imported from the send path (no drift, ac-3/ac-7)", () => {
+  it("dwell day-offsets equal the send-path dwell constants", () => {
+    tagAc(AC(3));
+    tagAc(AC(7));
+    // If a future change moves ACTIVATION_DWELL_DAYS.connected_inactive to 3, this
+    // asserts the preview follows automatically — a hardcoded 2 here would fail.
+    expect(byTemplate("activation-connected-inactive").dayOffset).toBe(
+      ACTIVATION_DWELL_DAYS.connected_inactive,
+    );
+    expect(byTemplate("activation-winback").dayOffset).toBe(
+      ACTIVATION_DWELL_DAYS.signed_in_dormant,
+    );
+    expect(byTemplate("activation-connect-people").dayOffset).toBe(CONNECT_PEOPLE_DWELL_DAYS);
+  });
+
+  it("comms keys equal the send-path comms constants", () => {
+    tagAc(AC(3));
+    tagAc(AC(7));
+    expect(byTemplate("activation-connected-inactive").commsKey).toBe(
+      ACTIVATION_COMMS_KEY.connected_inactive,
+    );
+    expect(byTemplate("activation-winback").commsKey).toBe(ACTIVATION_COMMS_KEY.signed_in_dormant);
+    expect(byTemplate("activation-connect-people").commsKey).toBe(CONNECT_PEOPLE_COMMS_KEY);
+  });
+
+  it("exposes the per-cohort cap from the send path (ac-7)", () => {
+    tagAc(AC(7));
+    expect(PER_COHORT_CAP).toBe(ACTIVATION_PER_COHORT_CAP);
+  });
+});
+
+describe("send-conditions: hand-authored fields are prose/flag/branch only (ac-8)", () => {
+  it("welcome is day-0 and transactional (not flag-gated)", () => {
+    tagAc(AC(8));
+    const w = byTemplate("welcome");
+    expect(w.dayOffset).toBe(0); // inherent to 'on verification', not a duplicated dwell constant
+    expect(w.flagGated).toBe(false); // transactional — NOT held behind ACTIVATION_EMAILS_ENABLED
+    expect(w.branch).toBe("main");
+  });
+
+  it("verified-milestone is event-driven (no fixed day) and flag-gated", () => {
+    tagAc(AC(8));
+    const m = byTemplate("activation-verified-milestone");
+    expect(m.dayOffset).toBeNull();
+    expect(m.flagGated).toBe(true);
+    expect(m.commsKey).toBeNull(); // no exported constant → not re-declared here
+  });
+
+  it("every onboarding email carries non-empty trigger + cohort prose", () => {
+    tagAc(AC(8));
+    for (const c of ONBOARDING_SEQUENCE) {
+      expect(c.trigger.length).toBeGreaterThan(0);
+      expect(c.cohort.length).toBeGreaterThan(0);
+      expect(c.anchor.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("no onboarding email whose facts are imported re-declares them as a literal", () => {
+    tagAc(AC(8));
+    // The imported entries must be reference-equal to their source constant, never a
+    // copy. (A literal that happens to match today is the drift risk this rules out.)
+    expect(IMPORTED.every((t) => byTemplate(t).commsKey !== null)).toBe(true);
+  });
+});
+
+describe("send-conditions: timeline membership + cohort branches (ac-11/ac-12)", () => {
+  it("the onboarding set is exactly the 5 sequence emails", () => {
+    tagAc(AC(11));
+    expect([...ONBOARDING_TEMPLATES].sort()).toEqual(
+      [
+        "activation-connect-people",
+        "activation-connected-inactive",
+        "activation-verified-milestone",
+        "activation-winback",
+        "welcome",
+      ].sort(),
+    );
+  });
+
+  it("the superseded signed-in-dormant sample is NOT on the timeline, but stays a preview template", () => {
+    tagAc(AC(11));
+    expect(ONBOARDING_TEMPLATES.has("activation-signed-in-dormant")).toBe(false);
+    expect(EMAIL_TEMPLATE_NAMES).toContain("activation-signed-in-dormant");
+  });
+
+  it("connected-inactive and win-back are exclusive parallel branches at the same order slot", () => {
+    tagAc(AC(12));
+    const ci = byTemplate("activation-connected-inactive");
+    const wb = byTemplate("activation-winback");
+    expect(ci.branch).toBe("connected-inactive");
+    expect(wb.branch).toBe("win-back");
+    expect(ci.order).toBe(wb.order); // same slot ⇒ parallel branches, not two steps
+  });
+
+  it("milestone and connect sit on the main spine", () => {
+    tagAc(AC(12));
+    expect(byTemplate("activation-verified-milestone").branch).toBe("main");
+    expect(byTemplate("activation-connect-people").branch).toBe("main");
+  });
+});

--- a/packages/server/src/services/email/send-conditions.ts
+++ b/packages/server/src/services/email/send-conditions.ts
@@ -1,0 +1,126 @@
+// spec-493 t-1 (dec-1) — the send-condition metadata that turns the flat email preview
+// into an activation timeline. This is a DEV-ONLY descriptor consumed by the preview
+// surface (routes/__dev__.ts → the React gallery); it is NEVER read by the real send
+// path and never sends mail.
+//
+// Anti-drift contract (dec-1 / ac-3 / ac-7): the facts that ALSO live in the send path —
+// the dwell day-offsets and the stable comms_log keys — are IMPORTED from their source
+// modules here, never re-typed as literals. If a dwell timer or comms key changes in
+// activation-drip.ts / connect-people.ts, this descriptor (and the preview) follow with
+// no second edit. Only the inherently-textual facts (trigger prose, cohort prose, the
+// flag-gated boolean, the timeline branch) are hand-authored (ac-8) — they have no single
+// machine-readable source. Per dec-1 this file does NOT modify the launch-critical send
+// path; it only reads its already-exported constants.
+
+import {
+  ACTIVATION_DWELL_DAYS,
+  ACTIVATION_COMMS_KEY,
+  ACTIVATION_PER_COHORT_CAP,
+} from "./activation-drip.js";
+import { CONNECT_PEOPLE_DWELL_DAYS, CONNECT_PEOPLE_COMMS_KEY } from "./connect-people.js";
+
+// Where an email sits on the timeline. "main" is the spine; the two cohort branches are
+// mutually exclusive (classifyActivationCohort returns at most one per user), so they
+// render as PARALLEL branches at the same order slot, not two sequential steps (ac-12).
+export type TimelineBranch = "main" | "connected-inactive" | "win-back";
+
+export interface SendCondition {
+  /** Preview template key — matches a key in EMAIL_PREVIEW_SAMPLES. */
+  template: string;
+  /** Position on the timeline spine; the two cohort branches share one slot. */
+  order: number;
+  /**
+   * Day offset from the anchor, or null for an event-driven email with no fixed day.
+   * IMPORTED from the send-path dwell constants where one exists (ac-7); welcome's 0 is
+   * inherent to "fires on the verification transition", not a duplicated constant.
+   */
+  dayOffset: number | null;
+  /** Hand-authored prose: what the day offset is measured from. */
+  anchor: string;
+  /** Hand-authored prose: who this email targets. */
+  cohort: string;
+  /** Hand-authored prose: what makes it fire. */
+  trigger: string;
+  /** Spine vs. exclusive cohort branch. */
+  branch: TimelineBranch;
+  /** Held behind ACTIVATION_EMAILS_ENABLED? Welcome is transactional → false. */
+  flagGated: boolean;
+  /**
+   * Stable comms_log dedup key, IMPORTED from the send path where an exported constant
+   * exists (ac-7). null where the send path keeps the key as a private literal (welcome,
+   * verified-milestone) — we deliberately do NOT re-declare it here, to avoid drift (ac-8).
+   */
+  commsKey: string | null;
+}
+
+// The ordered onboarding journey (dec-3). Ordering is by the timeline spine:
+//   0 welcome → 1 {connected-inactive | win-back} → 2 verified-milestone → 3 connect-people
+// The v1 email the signed_in_dormant cohort actually receives is the win-back
+// (buildWinbackEmail — see activation-drip.buildActivationMessage), so the timeline's
+// win-back branch is the "activation-winback" preview key. The superseded
+// "activation-signed-in-dormant" sample is intentionally absent — it stays in the flat list.
+export const ONBOARDING_SEQUENCE: readonly SendCondition[] = [
+  {
+    template: "welcome",
+    order: 0,
+    dayOffset: 0,
+    anchor: "email verification",
+    cohort: "every verified signup",
+    trigger: "sent once, the moment a user first verifies their email",
+    branch: "main",
+    flagGated: false, // transactional — welcome-send.ts is NOT gated by the activation flag
+    commsKey: null,
+  },
+  {
+    template: "activation-connected-inactive",
+    order: 1,
+    dayOffset: ACTIVATION_DWELL_DAYS.connected_inactive,
+    anchor: "first mcp.connected",
+    cohort: "connected an agent, but no tool call and no spec yet",
+    trigger: "dwell timer after the user first connects their agent",
+    branch: "connected-inactive",
+    flagGated: true,
+    commsKey: ACTIVATION_COMMS_KEY.connected_inactive,
+  },
+  {
+    template: "activation-winback",
+    order: 1, // same slot as connected-inactive — the two cohorts are exclusive (ac-12)
+    dayOffset: ACTIVATION_DWELL_DAYS.signed_in_dormant,
+    anchor: "email verification",
+    cohort: "verified, but never connected an agent",
+    trigger: "dwell timer after signup for users who never connect",
+    branch: "win-back",
+    flagGated: true,
+    commsKey: ACTIVATION_COMMS_KEY.signed_in_dormant,
+  },
+  {
+    template: "activation-verified-milestone",
+    order: 2,
+    dayOffset: null, // event-driven — fires on the first verified AC, no fixed day
+    anchor: "first acceptance criterion verified",
+    cohort: "any user, once ever",
+    trigger: "fires when the user's first AC is verified",
+    branch: "main",
+    flagGated: true,
+    commsKey: null,
+  },
+  {
+    template: "activation-connect-people",
+    order: 3,
+    dayOffset: CONNECT_PEOPLE_DWELL_DAYS,
+    anchor: "signup",
+    cohort: "every verified signup — independent of the cohort nudge",
+    trigger: "day-12 check-in; can arrive alongside a cohort email (not exclusive)",
+    branch: "main",
+    flagGated: true,
+    commsKey: CONNECT_PEOPLE_COMMS_KEY,
+  },
+];
+
+/** The set of preview-template keys that belong on the timeline (ac-11). */
+export const ONBOARDING_TEMPLATES: ReadonlySet<string> = new Set(
+  ONBOARDING_SEQUENCE.map((c) => c.template),
+);
+
+/** The hard per-cohort send ceiling, surfaced from the send path (ac-7). */
+export const PER_COHORT_CAP = ACTIVATION_PER_COHORT_CAP;

--- a/packages/server/src/services/email/sender.ts
+++ b/packages/server/src/services/email/sender.ts
@@ -34,6 +34,14 @@ export interface EmailMessage {
   // in the URL is issued by t-4).
   stream?: string;
   listUnsubscribeUrl?: string;
+  // spec-480 dec-6 (ac-11) — enable Postmark click tracking for this message. When true,
+  // Postmark rewrites the HTML+text links through its redirect so a click fires a `Click`
+  // webhook event (recorded in comms_log via the spec-341 webhook), the only way to
+  // attribute a click on a raw-mp4/GCS link (which can't run JS). Absent → no rewriting
+  // (the default for every other email — links stay pristine). NB: this is click tracking
+  // ONLY, not open tracking — no invisible pixel is injected, keeping the email's single
+  // intentional image (the thumbnail) the only image.
+  trackLinks?: boolean;
 }
 
 // The transactional stream every existing email rides. A message with no `stream`
@@ -106,6 +114,8 @@ export class PostmarkEmailSender implements EmailSender {
         ...(message.html ? { HtmlBody: message.html } : {}),
         ...(message.replyTo ? { ReplyTo: message.replyTo } : {}),
         ...(headers ? { Headers: headers } : {}),
+        // spec-480 dec-6 (ac-11): click tracking only (never TrackOpens — no pixel).
+        ...(message.trackLinks ? { TrackLinks: "HtmlAndText" } : {}),
         MessageStream: stream,
       }),
     });

--- a/packages/server/src/services/email/templates.spec-453.copy.test.ts
+++ b/packages/server/src/services/email/templates.spec-453.copy.test.ts
@@ -23,8 +23,8 @@ describe('spec-453 "See it verified" copy', () => {
     expect(email.html).toContain("A green check a markdown spec could never give you");
     for (const body of [email.text ?? "", email.html ?? ""]) {
       expect(body).toContain("a markdown spec can never do");
-      expect(body).toContain("run another Spec");
-      expect(body).toContain("set up your standards");
+      expect(body).toContain("Run another Spec");
+      expect(body).toContain("Set up your standards");
       expect(body).toContain("check the relevant standard on every task");
     }
     // no video (copy-only) and no repeated headline (leads with the greeting)

--- a/packages/server/src/services/email/templates.spec-453.copy.test.ts
+++ b/packages/server/src/services/email/templates.spec-453.copy.test.ts
@@ -7,22 +7,31 @@ import { tagAc } from "@memex-ai-ac/vitest";
 import { buildVerifiedMilestoneEmail, buildConnectPeopleEmail } from "./templates.js";
 
 const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-453/acs/ac-${n}`;
+// spec-487 t-4 rewrote the "See it verified" copy (s-4, copy-only — no video).
+const AC487 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-487/acs/ac-${n}`;
 
 describe('spec-453 "See it verified" copy', () => {
   const appUrl = "https://int.memex.ai/acme/personal/specs";
   const email = buildVerifiedMilestoneEmail({ to: "x@y.com", firstName: "Ada", appUrl });
 
-  it("renders the signed-off subject, preheader and core copy (text + html) [ac-5][ac-13]", () => {
+  it("renders the v2 (s-4) subject, preheader and core copy (text + html) [ac-5][ac-13][spec-487 ac-10]", () => {
     tagAc(AC(5));
     tagAc(AC(13));
-    expect(email.subject).toBe("Green means it's actually done");
-    // preheader lives in the HTML only
-    expect(email.html).toContain("Every acceptance criterion, checked in CI, before anyone calls it finished.");
+    tagAc(AC487(10));
+    expect(email.subject).toBe("Nice. A markdown spec could never give you that green check");
+    // preheader lives in the HTML only (apostrophe-free substring — it's escaped)
+    expect(email.html).toContain("A green check a markdown spec could never give you");
     for (const body of [email.text ?? "", email.html ?? ""]) {
-      expect(body).toContain("Now you can prove it");
-      expect(body).toContain("verified, not assumed");
-      expect(body).toContain("spec, decision, build, proof");
+      expect(body).toContain("a markdown spec can never do");
+      expect(body).toContain("run another Spec");
+      expect(body).toContain("set up your standards");
+      expect(body).toContain("check the relevant standard on every task");
     }
+    // no video (copy-only) and no repeated headline (leads with the greeting)
+    expect(email.html).not.toContain("<img");
+    expect(email.html).not.toContain("<h1");
+    // old copy gone
+    expect(email.html).not.toContain("Now you can prove it");
   });
 
   it("CTA is the generic Specs board (no deep-link), rendered with no imagery [ac-13][ac-5]", () => {
@@ -67,5 +76,25 @@ describe('spec-453 "Connect with people" copy', () => {
       expect(body).not.toContain("www.memex.ai/discord");
     }
     expect(email.commsType).toBe("activation.connect_people");
+  });
+
+  it("inserts the how-to video (poster + fallback) before the Join-the-Discord CTA, copy unchanged [spec-487 ac-6/ac-8/ac-7]", () => {
+    tagAc(AC487(6));
+    tagAc(AC487(8));
+    tagAc(AC487(7));
+    const html = email.html ?? "";
+    // exactly one image — the video poster — and no separate "Watch the 3-min guide" button
+    expect((html.match(/<img/g) ?? []).length).toBe(1);
+    expect(html).toContain("email-howto-connect-people-thumb-480.png");
+    expect(html).not.toContain("Watch the 3-min guide");
+    // the poster sits BEFORE the "Join the Discord" button
+    expect(html.indexOf("<img")).toBeLessThan(html.indexOf(">Join the Discord</a>"));
+    // image-blocked fallback + hosted mp4, never a Drive link (ac-7)
+    expect(html).toContain("Can't see the video above?");
+    expect(html).toContain("storage.googleapis.com/memex-ai-prod-app-static/media/email-howto-connect-people.mp4");
+    expect(html).not.toContain("drive.google.com");
+    // subject + existing copy unchanged (ac-6)
+    expect(email.subject).toBe("You've run the loop. Don't run it alone.");
+    expect(html).toContain("last of your onboarding emails");
   });
 });

--- a/packages/server/src/services/email/templates.ts
+++ b/packages/server/src/services/email/templates.ts
@@ -103,6 +103,60 @@ export function renderResources(resources?: EmailResource[]): string {
   return `<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="margin:24px 0 0;">${rows}</table>`;
 }
 
+// spec-480 — hosted email video + clickable thumbnail assets (dec-1/dec-2).
+// Public objects on the prod static bucket (same bucket + media/ path as the
+// /welcome video). Stable, non-expiring, immutable-cached. SHARED with the
+// welcome email (spec-488) — hence neutral `email-*` object names, not `winback-*`.
+// The base video URL is shared; each builder appends its OWN utm_campaign so a
+// click is attributable to the right email (dec-6). A swap must mint a NEW
+// versioned object (…-v2) — never a same-name overwrite (immutable cache).
+export const EMAIL_EXPLAINER_VIDEO_URL =
+  "https://storage.googleapis.com/memex-ai-prod-app-static/media/email-explainer-60s.mp4";
+export const EMAIL_VIDEO_THUMB_1X_URL =
+  "https://storage.googleapis.com/memex-ai-prod-app-static/media/email-video-thumb-480.png";
+export const EMAIL_VIDEO_THUMB_2X_URL =
+  "https://storage.googleapis.com/memex-ai-prod-app-static/media/email-video-thumb-960.png";
+// The still Christine chose (spec-480 s-5) — used as the thumbnail alt (dec-4).
+export const EMAIL_VIDEO_TITLE =
+  "The spec-driven development system for AI coding agents";
+
+// spec-480 dec-2/dec-3/dec-4 — the clickable video-thumbnail block: a single
+// static poster image (play button baked in, dec-3) hyperlinked to the hosted
+// mp4. Returned as an HTML string injected into `bodyParagraphs` (mid-body, so
+// the video sits above the fold) — `<a>`/`<img>` are phrasing content, valid in
+// the renderer's <p> wrapper, so this needs no change to renderEmailHtml and
+// touches none of the other (image-free) emails. Bulletproof/table-safe:
+// `border:0`+`outline:none` kill Outlook's blue link border; explicit
+// width/height + `display:block`; `srcset` serves retina where supported
+// (Gmail/Outlook fall back to the 1x `src`). 480px = the email's content width
+// (560 − 2×40 padding). The image-blocked fallback (dec-4) is a SEPARATE visible
+// body line built by the caller — see `renderVideoFallbackLine`.
+export function renderVideoThumbnail(opts: {
+  videoUrl: string;
+  thumb1xUrl: string;
+  thumb2xUrl: string;
+  alt: string;
+}): string {
+  const href = escapeHtml(opts.videoUrl);
+  return (
+    `<a href="${href}" style="display:block;border:0;outline:none;text-decoration:none;">` +
+    `<img src="${escapeHtml(opts.thumb1xUrl)}" srcset="${escapeHtml(opts.thumb2xUrl)} 2x" ` +
+    `width="480" height="269" alt="${escapeHtml(opts.alt)}" ` +
+    `style="display:block;width:100%;max-width:480px;height:auto;border:0;outline:none;text-decoration:none;border-radius:8px;">` +
+    `</a>`
+  );
+}
+
+// spec-480 dec-4 — the image-blocked fallback: a visible text line so the video
+// is never unreachable when a client blocks images. "Watch it here" is the brand
+// accent (#0482DC, spec-468) and links the same video URL.
+export function renderVideoFallbackLine(videoUrl: string): string {
+  return (
+    `Can't see the video above? ` +
+    `<a href="${escapeHtml(videoUrl)}" style="color:${BRAND_ACCENT};text-decoration:none;">Watch it here</a>`
+  );
+}
+
 function renderEmailHtml(input: RenderInput): string {
   const paragraphs = input.bodyParagraphs
     .map(
@@ -539,6 +593,142 @@ export function buildSignedInDormantEmail(
     html,
     // spec-427 ac-14 / dec-7: stable comms key (see Email 1).
     commsType: "activation.signed_in_dormant",
+  };
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// spec-480 — win-back email (single video-centric re-intro)
+// ──────────────────────────────────────────────────────────────────────────
+// One warm re-intro built around the clickable explainer-video thumbnail, sent
+// to the SINGLE `signed_in_dormant` cohort — verified, never connected an MCP,
+// no Spec (dec-9). The `connected_inactive` cohort is deliberately NOT a
+// recipient (its members have already connected, so this email's one CTA —
+// "Connect your agent" — would be nonsensical); it is deferred to a later email.
+// So there is ONE segment: one fixed stall-line, one CTA, no per-segment branch.
+//
+// PURE RENDER like the spec-427 builders: no cohort/timing/send/env logic. The
+// team-identity From + monitored Reply-To + broadcast stream + suppression are
+// applied at the send site by sendLifecycleEmail; commsType IS stamped here.
+//
+// The one intentional image in the lifecycle program: the video thumbnail
+// (dec-2 overturned spec-427's self-imposed "no imagery" rule for this image
+// only). It renders via the shared renderVideoThumbnail primitive injected into
+// bodyParagraphs, so the rest of the email stays the same table/inline-CSS,
+// image-free construct as the others.
+
+// spec-480 dec-6 — UTM on the video link so a click is attributable to THIS
+// email (vs the welcome email, spec-488, which links the same asset with
+// utm_campaign=welcome). Postmark link-tracking (t-4) records the click server-side.
+const WINBACK_VIDEO_URL = `${EMAIL_EXPLAINER_VIDEO_URL}?utm_source=lifecycle&utm_medium=email&utm_campaign=winback`;
+
+export interface WinbackEmailInput {
+  to: string;
+  /** Recipient's first name; absent/empty → a graceful "Hi there,". */
+  firstName?: string;
+  /**
+   * CTA "Connect your agent" target — the one-click desktop connect flow (dec-9).
+   * Derived at the send site (dec-8 / std-2 via buildAppBaseUrl), never a hardcoded
+   * host here. t-3 resolves what this concretely is (the desktop-app download at
+   * www.memex.ai/download is the current one-click MCP-setup path, spec-460).
+   */
+  connectUrl: string;
+}
+
+export function buildWinbackEmail(input: WinbackEmailInput): EmailMessage {
+  const name = input.firstName?.trim();
+  // s-2 opens "Hey [FirstName],"; graceful nameless fallback (never a placeholder).
+  const greeting = name ? `Hey ${name},` : "Hi there,";
+
+  // Copy verbatim from s-2 (the code is the canonical authoring source; s-2 mirrors
+  // it). NOTE: s-2 says "60-second" but the hosted cut is 1:22 — left as-is per the
+  // copy owner; the discrepancy is flagged in s-5. s-2/s-3 is an OPEN copy fork
+  // (Ryan owns it); these strings are the s-2 option and swap 1:1 to s-3 if chosen.
+  const intro1 = "You signed up to Memex, then disappeared a while back.";
+  const intro2 =
+    "We thought about emailing you a reminder of what to do next, but it felt cold and a bit weird after not having much contact with you recently.";
+  const intro3 =
+    "So instead, we made a 60-second animated video with a voiceover, explaining what Memex is and why it exists (just in case you forgot or had questions!).";
+  const shortVersion =
+    "The short version, though you should still watch it: MD docs are sh*t. They're a temporary fix for coding agents that gets worse over time. Agents aren't forced to follow an MD doc spec, so they skip parts, produce slop, ignore your rules, and the whole thing becomes unmanageable and out of date.";
+  const fixes = "That's what Memex fixes.";
+  const listIntro =
+    "Every user who's come back to us every day for the past six weeks has three things in common:";
+  const item1 = "1. They connected their coding agent over MCP.";
+  const item2 = "2. They took one spec from draft → specify → build → verify.";
+  const item3 =
+    "3. They turned their CLAUDE.md / AGENTS.md rules into standards, so Memex checks a half-formed idea against what's already decided and shapes it into a near-complete spec.";
+  // dec-9 — the fixed [X] stall-line for the sole (signed_in_dormant) segment.
+  const stall =
+    "You signed up and had a look, but never connected your agent or created a spec.";
+  const closer = "Watch the video, then have another go:";
+  const signoff = "The Memex AI team";
+
+  const text = renderEmailText({
+    intro: [
+      greeting,
+      intro1,
+      intro2,
+      intro3,
+      `Watch the video: ${WINBACK_VIDEO_URL}`,
+      shortVersion,
+      fixes,
+      listIntro,
+      item1,
+      item2,
+      item3,
+      stall,
+      closer,
+    ],
+    url: input.connectUrl,
+    closing: signoff,
+  });
+
+  const html = renderEmailHtml({
+    // H1 hook — s-2's body has no headline; the shared renderer always renders one.
+    preheader:
+      "A 60-second video on what Memex actually is — then reconnect when you're ready.",
+    heading: "We made you a video",
+    bodyParagraphs: [
+      escapeHtml(greeting),
+      escapeHtml(intro1),
+      escapeHtml(intro2),
+      escapeHtml(intro3),
+      renderVideoThumbnail({
+        videoUrl: WINBACK_VIDEO_URL,
+        thumb1xUrl: EMAIL_VIDEO_THUMB_1X_URL,
+        thumb2xUrl: EMAIL_VIDEO_THUMB_2X_URL,
+        alt: `Watch: ${EMAIL_VIDEO_TITLE}`,
+      }),
+      renderVideoFallbackLine(WINBACK_VIDEO_URL),
+      escapeHtml(shortVersion),
+      escapeHtml(fixes),
+      `${escapeHtml(listIntro)}<br><br>${escapeHtml(item1)}<br>${escapeHtml(item2)}<br>${escapeHtml(item3)}`,
+      escapeHtml(stall),
+      escapeHtml(closer),
+    ],
+    ctaLabel: "Connect your agent",
+    ctaUrl: input.connectUrl,
+    showPasteLink: false,
+    afterCtaParagraphs: [escapeHtml(signoff)],
+    footerNote: ACTIVATION_FOOTER,
+  });
+
+  return {
+    to: input.to,
+    subject: "You signed up, then vanished",
+    text,
+    html,
+    // spec-480 dec-8 (re-resolved): the win-back REUSES the existing signed_in_dormant
+    // comms key — it IS that cohort's email now. Minting a new "activation.winback" key
+    // would have split the cross-repo comms-conversion contract (the metric is mirrored
+    // byte-for-byte in memex-backstage via comms-conversion.fixture.ts); reusing the key
+    // keeps that contract intact. Dedup (hasComm) + the activation-metrics join count THIS
+    // key. (Win-back vs welcome-video click attribution still separates via the UTM above.)
+    commsType: "activation.signed_in_dormant",
+    // spec-480 dec-6 (ac-11): enable Postmark click tracking so a thumbnail/fallback
+    // click on the raw-mp4 link is recorded (a GCS mp4 can't run JS; the UTM above only
+    // labels the tracked URL). Click tracking only — no open pixel.
+    trackLinks: true,
   };
 }
 

--- a/packages/server/src/services/email/templates.ts
+++ b/packages/server/src/services/email/templates.ts
@@ -123,6 +123,30 @@ export const EMAIL_VIDEO_THUMB_2X_URL =
 export const EMAIL_VIDEO_TITLE =
   "The spec-driven development system for AI coding agents";
 
+// spec-487 dec-3 (t-1) — the three per-email HOW-TO videos (Day-2 / Day-3 / Day-12),
+// hosted on the SAME static bucket + media/ path as the explainer (spec-480 pattern):
+// stable, public, non-expiring, immutable-cached. Uploaded + verified public 2026-07-17.
+// Distinct from EMAIL_EXPLAINER_VIDEO_URL ("what is Memex") — these each show HOW to do
+// that email's action. Each builder appends its OWN utm_campaign (dec-6); a swap mints a
+// NEW versioned object (…-v2), never a same-name overwrite (immutable cache).
+const EMAIL_MEDIA_BASE =
+  "https://storage.googleapis.com/memex-ai-prod-app-static/media";
+export interface HowToVideoAsset {
+  videoUrl: string;
+  thumb1xUrl: string;
+  thumb2xUrl: string;
+}
+function howToAsset(slug: string): HowToVideoAsset {
+  return {
+    videoUrl: `${EMAIL_MEDIA_BASE}/${slug}.mp4`,
+    thumb1xUrl: `${EMAIL_MEDIA_BASE}/${slug}-thumb-480.png`,
+    thumb2xUrl: `${EMAIL_MEDIA_BASE}/${slug}-thumb-960.png`,
+  };
+}
+export const EMAIL_HOWTO_CREATE_SPEC = howToAsset("email-howto-create-spec"); // Day-2 "create a spec"
+export const EMAIL_HOWTO_CONNECT_MCP = howToAsset("email-howto-connect-mcp"); // Day-3 "connect MCP + spec"
+export const EMAIL_HOWTO_CONNECT_PEOPLE = howToAsset("email-howto-connect-people"); // Day-12 "connect with people"
+
 // spec-480 dec-2/dec-3/dec-4 — the clickable video-thumbnail block: a single
 // static poster image (play button baked in, dec-3) hyperlinked to the hosted
 // mp4. Returned as an HTML string injected into `bodyParagraphs` (mid-body, so
@@ -481,23 +505,46 @@ export interface ConnectedInactiveEmailInput {
 
 // Email 1 — connected-but-inactive (MCP connected, no tool call, no Spec).
 // Subject "Memex is connected. Here's what to do next." · CTA "Create a spec".
+// spec-487 dec-6 — the Day-2 how-to video ("create a spec"), attributable via its
+// own utm_campaign (distinct from the win-back + welcome, which use the explainer).
+const CONNECTED_INACTIVE_VIDEO_URL = `${EMAIL_HOWTO_CREATE_SPEC.videoUrl}?utm_source=lifecycle&utm_medium=email&utm_campaign=connected_inactive`;
+
+// spec-487 (t-2) — the Day-2 "Connected but no Spec" email, v2 copy (s-2) + how-to
+// video. Leads with the greeting (no headline, like the welcome v2). The video is a
+// clickable poster + image-blocked fallback line (spec-480 pattern, dec-4) — NO
+// separate "Watch the 3-min guide" button (dec-4: one video, one link). commsType /
+// dedup key unchanged (activation.connected_inactive).
 export function buildConnectedInactiveEmail(
   input: ConnectedInactiveEmailInput,
 ): EmailMessage {
   const greeting = activationGreeting(input.firstName);
-  const afterCta1 =
-    "Memex will work with your agent to structure the work, and comes back with a Spec and the decisions it needs you to resolve. That's the moment it clicks.";
-  const afterCta2 = "Memex does not touch your code.";
-  const stuck = "If you get stuck, just reply here or find us in #help on Discord.";
+  const p1 =
+    "Memex is connected, but the change you signed up for does not show until there is a Spec. Without one, your agent is still working off a document: it reads what it likes, skips the rest, and fills the gaps with its own assumptions, so you are back to re-prompting and re-reviewing.";
+  const p2 =
+    "A Memex spec fixes that. You create it right from your coding agent: it reads your repo, and together you work through the major decisions and the why behind what you are building. Each one becomes a task with an acceptance criterion your agent has to build to, not prose it can pass over. The more you settle upfront, the more it gets right first time.";
+  const videoIntro = "See it done in 3 minutes: a quick guide to creating your first spec.";
+  const thenBring = "Then bring one small piece of work and paste this into your coding agent:";
+  const prompt1 =
+    "I want to create a new spec in Memex for [your idea]. Look at my codebase, and let's work through the major decisions and why we're building it.";
+  const rollingIntro = "Once you are rolling, these help too:";
+  const rollingPrompts = [
+    "Let's work through the decisions",
+    "What's our standard for this?",
+    "What's outstanding before we build?",
+    "Move to build and implement this in a worktree",
+  ];
+  const stuck = "Stuck? Reply here, or find us in #help on Discord.";
 
   const text = renderEmailText({
     intro: [
       greeting,
-      "Your Memex MCP is connected. The hard part is done.",
-      "The next step is to create your first Spec. Bring an idea and we'll help you shape it, start to finish. Not sure where to start? Click the button below and we'll guide you through step by step.",
-      afterCta1,
-      afterCta2,
-      `Watch your Spec come to life in your Memex: ${input.memexUrl}`,
+      p1,
+      p2,
+      `${videoIntro} Watch it here: ${CONNECTED_INACTIVE_VIDEO_URL}`,
+      thenBring,
+      `"${prompt1}"`,
+      rollingIntro,
+      ...rollingPrompts.map((p) => `"${p}"`),
       stuck,
     ],
     url: input.createSpecUrl,
@@ -505,20 +552,34 @@ export function buildConnectedInactiveEmail(
   });
 
   const html = renderEmailHtml({
-    preheader: "Your Memex MCP is connected — create your first Spec.",
-    heading: "Your Memex MCP is connected. The hard part is done.",
+    preheader: "Memex is connected — one Spec turns it into output.",
+    // No headline — v2 leads with the greeting (spec-488 renderer supports this).
+    heading: "",
     bodyParagraphs: [
       escapeHtml(greeting),
-      "The next step is to create your first Spec. Bring an idea and we'll help you shape it, start to finish. Not sure where to start? Click the button below and we'll guide you through step by step.",
+      escapeHtml(p1),
+      escapeHtml(p2),
+      escapeHtml(videoIntro),
+      renderVideoThumbnail({
+        videoUrl: CONNECTED_INACTIVE_VIDEO_URL,
+        thumb1xUrl: EMAIL_HOWTO_CREATE_SPEC.thumb1xUrl,
+        thumb2xUrl: EMAIL_HOWTO_CREATE_SPEC.thumb2xUrl,
+        alt: "Watch: how to create your first spec",
+      }),
+      renderVideoFallbackLine(CONNECTED_INACTIVE_VIDEO_URL),
+      escapeHtml(thenBring),
+      `<em>&ldquo;${escapeHtml(prompt1)}&rdquo;</em>`,
     ],
     ctaLabel: "Create a spec",
     ctaUrl: input.createSpecUrl,
     showPasteLink: false,
     afterCtaParagraphs: [
-      escapeHtml(afterCta1),
-      escapeHtml(afterCta2),
-      `Watch your Spec come to life in <a href="${escapeHtml(input.memexUrl)}" style="color:${BRAND_ACCENT};">your Memex</a>.`,
-      escapeHtml(stuck),
+      escapeHtml(rollingIntro),
+      rollingPrompts.map((p) => `&ldquo;${escapeHtml(p)}&rdquo;`).join("<br>"),
+      escapeHtml(stuck).replace(
+        "#help",
+        `<a href="${DISCORD_INVITE_URL}" style="color:${BRAND_ACCENT};text-decoration:none;">#help</a>`,
+      ),
       ACTIVATION_SIGNOFF_HTML,
     ],
     resources: ACTIVATION_RESOURCES,
@@ -527,12 +588,15 @@ export function buildConnectedInactiveEmail(
 
   return {
     to: input.to,
-    subject: "Memex is connected. Here's what to do next.",
+    subject: "Connected, but the output has not changed yet",
     text,
     html,
-    // spec-427 ac-14 / dec-7: stable comms key — Slice B's dedup + two-per-cohort
-    // cap count this key in comms_log, never the subject line.
+    // spec-427 ac-14 / dec-7: stable comms key — dedup counts this key in comms_log,
+    // never the subject line. Unchanged from v1 (spec-487 keeps the key).
     commsType: "activation.connected_inactive",
+    // spec-487 dec-6 — the video link is a raw GCS mp4; Postmark click-tracking makes
+    // the utm_campaign attributable (same as the win-back).
+    trackLinks: true,
   };
 }
 
@@ -622,7 +686,7 @@ export function buildSignedInDormantEmail(
 // to the SINGLE `signed_in_dormant` cohort — verified, never connected an MCP,
 // no Spec (dec-9). The `connected_inactive` cohort is deliberately NOT a
 // recipient (its members have already connected, so this email's one CTA —
-// "Connect your agent" — would be nonsensical); it is deferred to a later email.
+// "Connect your agent" — would be nonsensical); it has its own Day-2 email (spec-487).
 // So there is ONE segment: one fixed stall-line, one CTA, no per-segment branch.
 //
 // PURE RENDER like the spec-427 builders: no cohort/timing/send/env logic. The
@@ -638,7 +702,10 @@ export function buildSignedInDormantEmail(
 // spec-480 dec-6 — UTM on the video link so a click is attributable to THIS
 // email (vs the welcome email, spec-488, which links the same asset with
 // utm_campaign=welcome). Postmark link-tracking (t-4) records the click server-side.
-const WINBACK_VIDEO_URL = `${EMAIL_EXPLAINER_VIDEO_URL}?utm_source=lifecycle&utm_medium=email&utm_campaign=winback`;
+// spec-487 (t-3) — the win-back now carries the "connect the MCP + create a spec"
+// how-to video (replacing the "what is Memex" explainer, which stays on the welcome).
+// utm_campaign=winback keeps the click attributable to this email.
+const WINBACK_VIDEO_URL = `${EMAIL_HOWTO_CONNECT_MCP.videoUrl}?utm_source=lifecycle&utm_medium=email&utm_campaign=winback`;
 
 export interface WinbackEmailInput {
   to: string;
@@ -655,86 +722,89 @@ export interface WinbackEmailInput {
 
 export function buildWinbackEmail(input: WinbackEmailInput): EmailMessage {
   const name = input.firstName?.trim();
-  // s-2 opens "Hey [FirstName],"; graceful nameless fallback (never a placeholder).
-  const greeting = name ? `Hey ${name},` : "Hi there,";
+  const greeting = name ? `Hi ${name},` : "Hi there,";
 
-  // Copy verbatim from s-2 (the code is the canonical authoring source; s-2 mirrors
-  // it). NOTE: s-2 says "60-second" but the hosted cut is 1:22 — left as-is per the
-  // copy owner; the discrepancy is flagged in s-5. s-2/s-3 is an OPEN copy fork
-  // (Ryan owns it); these strings are the s-2 option and swap 1:1 to s-3 if chosen.
-  const intro1 = "You signed up to Memex, then disappeared a while back.";
-  const intro2 =
-    "We thought about emailing you a reminder of what to do next, but it felt cold and a bit weird after not having much contact with you recently.";
-  const intro3 =
-    "So instead, we made a 60-second animated video with a voiceover, explaining what Memex is and why it exists (just in case you forgot or had questions!).";
-  const shortVersion =
-    "The short version, though you should still watch it: MD docs are sh*t. They're a temporary fix for coding agents that gets worse over time. Agents aren't forced to follow an MD doc spec, so they skip parts, produce slop, ignore your rules, and the whole thing becomes unmanageable and out of date.";
-  const fixes = "That's what Memex fixes.";
-  const listIntro =
-    "Every user who's come back to us every day for the past six weeks has three things in common:";
-  const item1 = "1. They connected their coding agent over MCP.";
-  const item2 = "2. They took one spec from draft → specify → build → verify.";
-  const item3 =
-    "3. They turned their CLAUDE.md / AGENTS.md rules into standards, so Memex checks a half-formed idea against what's already decided and shapes it into a near-complete spec.";
-  // dec-9 — the fixed [X] stall-line for the sole (signed_in_dormant) segment.
-  const stall =
-    "You signed up and had a look, but never connected your agent or created a spec.";
-  const closer = "Watch the video, then have another go:";
-  const signoff = "The Memex AI team";
+  // spec-487 s-3 copy (the code is the canonical authoring source; s-3 mirrors it).
+  const p1 =
+    "Right now your agent works from markdown: files it interprets, skips, and fills in with its own assumptions. That is what drives the re-prompting and re-reviewing, and it only gets worse on brownfield code.";
+  const p2 = "Memex never touches your repo, but your coding agent does.";
+  const p3 =
+    "So connecting the MCP makes your agent the bridge: it reads your real codebase, and everything you decide gets grounded in it, in one place instead of scattered across threads and MD files. Once connected, you start speccing against your actual code, not a blank page, and the more decisions you settle upfront, the more your agent gets right first time.";
+  const videoIntro =
+    "See it done in 3 minutes: a quick guide to connecting the MCP and creating your first spec.";
+  const connectIntro = "Connect your MCP & create a spec:";
+  const connectStep =
+    "To connect the MCP, open Settings then Integrations in Memex and copy the MCP connection prompt. Paste that into your coding agent and it wires up the MCP for you.";
+  const thenSpec = "Then create your first spec. Paste this in:";
+  const prompt1 =
+    "I want to create a new spec in Memex for [your idea or MD doc name]. Look at my codebase, and let's work through the major decisions and why we're building it.";
+  const rollingIntro = "Once you have a few specs, these are worth trying:";
+  const rollingPrompts = [
+    "What have we decided before that's similar to this?",
+    "Which decisions conflict with this spec?",
+    "Which existing specs make this one stronger?",
+    "What's outstanding before we build?",
+  ];
+  const needHand = "Need a hand? Reply here, or find us in #help on Discord.";
 
   const text = renderEmailText({
     intro: [
       greeting,
-      intro1,
-      intro2,
-      intro3,
-      `Watch the video: ${WINBACK_VIDEO_URL}`,
-      shortVersion,
-      fixes,
-      listIntro,
-      item1,
-      item2,
-      item3,
-      stall,
-      closer,
+      p1,
+      p2,
+      p3,
+      `${videoIntro} Watch it here: ${WINBACK_VIDEO_URL}`,
+      connectIntro,
+      connectStep,
+      `${thenSpec} "${prompt1}"`,
+      rollingIntro,
+      ...rollingPrompts.map((p) => `"${p}"`),
+      needHand,
     ],
     url: input.connectUrl,
-    closing: signoff,
+    closing: ACTIVATION_SIGNOFF_TEXT,
   });
 
   const html = renderEmailHtml({
-    // H1 hook — s-2's body has no headline; the shared renderer always renders one.
-    preheader:
-      "A 60-second video on what Memex actually is — then reconnect when you're ready.",
-    heading: "We made you a video",
+    preheader: "Connect the MCP and your agent works from your real codebase, not markdown.",
+    // No headline — v2 leads with the greeting (spec-488 renderer supports this).
+    heading: "",
     bodyParagraphs: [
       escapeHtml(greeting),
-      escapeHtml(intro1),
-      escapeHtml(intro2),
-      escapeHtml(intro3),
+      escapeHtml(p1),
+      escapeHtml(p2),
+      escapeHtml(p3),
+      escapeHtml(videoIntro),
       renderVideoThumbnail({
         videoUrl: WINBACK_VIDEO_URL,
-        thumb1xUrl: EMAIL_VIDEO_THUMB_1X_URL,
-        thumb2xUrl: EMAIL_VIDEO_THUMB_2X_URL,
-        alt: `Watch: ${EMAIL_VIDEO_TITLE}`,
+        thumb1xUrl: EMAIL_HOWTO_CONNECT_MCP.thumb1xUrl,
+        thumb2xUrl: EMAIL_HOWTO_CONNECT_MCP.thumb2xUrl,
+        alt: "Watch: how to connect the MCP and create a spec",
       }),
       renderVideoFallbackLine(WINBACK_VIDEO_URL),
-      escapeHtml(shortVersion),
-      escapeHtml(fixes),
-      `${escapeHtml(listIntro)}<br><br>${escapeHtml(item1)}<br>${escapeHtml(item2)}<br>${escapeHtml(item3)}`,
-      escapeHtml(stall),
-      escapeHtml(closer),
+      `<strong>${escapeHtml(connectIntro)}</strong>`,
+      escapeHtml(connectStep),
+      `${escapeHtml(thenSpec)}<br><em>&ldquo;${escapeHtml(prompt1)}&rdquo;</em>`,
     ],
     ctaLabel: "Connect your agent",
     ctaUrl: input.connectUrl,
     showPasteLink: false,
-    afterCtaParagraphs: [escapeHtml(signoff)],
+    afterCtaParagraphs: [
+      escapeHtml(rollingIntro),
+      rollingPrompts.map((p) => `&ldquo;${escapeHtml(p)}&rdquo;`).join("<br>"),
+      escapeHtml(needHand).replace(
+        "#help",
+        `<a href="${DISCORD_INVITE_URL}" style="color:${BRAND_ACCENT};text-decoration:none;">#help</a>`,
+      ),
+      ACTIVATION_SIGNOFF_HTML,
+    ],
+    resources: ACTIVATION_RESOURCES,
     footerNote: ACTIVATION_FOOTER,
   });
 
   return {
     to: input.to,
-    subject: "You signed up, then vanished",
+    subject: "Ground your specs in your actual codebase",
     text,
     html,
     // spec-480 dec-8 (re-resolved): the win-back REUSES the existing signed_in_dormant
@@ -782,42 +852,60 @@ export function buildVerifiedMilestoneEmail(
   input: VerifiedMilestoneEmailInput,
 ): EmailMessage {
   const greeting = activationGreeting(input.firstName);
-  const prove = "Your agent says it's done. Now you can prove it.";
-  const para1 =
-    'Every decision you resolved turned into tasks with acceptance criteria attached, the specific, testable conditions that define "done" for that piece of work. Your agent doesn\'t just write the code, it runs the checks against those criteria and reports back.';
-  const para2 =
-    'When they go green in CI, you\'re not taking its word for it. You\'re watching the proof. No re-reading a diff hoping it\'s right, no "looks fine to me." Green means what you decided actually got built, and it\'s been verified, not assumed.';
-  const loop =
-    "That's the loop, closed: spec, decision, build, proof. However far you've got, that's the moment it starts paying for itself.";
+  // spec-487 s-4 copy (copy-only rewrite, no video). Owned by spec-453 — coordinated.
+  const p1 =
+    "Congratulations. You just did something a markdown spec can never do: an acceptance criterion, verified in CI. It went green on its own, without you re-reading a diff and hoping the agent caught what mattered. That is proof that what you decided got built.";
+  const p2 = "Two ways to make that compound.";
+  const p3 =
+    "First, run another Spec. Every one you finish makes the next faster, because your agents inherit what you have already decided.";
+  const p4 =
+    "Second, set up your standards. You already have rules written down in CLAUDE.md, AGENTS.md or your Cursor rules. Point your agent at them and paste this:";
+  const prompt =
+    "Read my CLAUDE.md and AGENTS.md, create Memex standards from the rules in them, then rewrite the MD file as a contents page that tells my agents which Memex standard applies to what.";
+  const p5 =
+    "An agent skims an MD file once and forgets it. Memex makes it check the relevant standard on every task it claims, so your rules get followed instead of just written down.";
+  const needHand = "Questions? Reply here, or find us in #help on Discord.";
 
   const text = renderEmailText({
-    intro: [greeting, prove, para1, para2, loop],
+    intro: [greeting, p1, p2, p3, p4, `"${prompt}"`, p5, needHand],
     url: input.appUrl,
     closing: ACTIVATION_SIGNOFF_TEXT,
   });
 
   const html = renderEmailHtml({
-    preheader: "Every acceptance criterion, checked in CI, before anyone calls it finished.",
-    heading: "Green means it's actually done",
+    preheader: "A green check a markdown spec could never give you — here's how to compound it.",
+    // No headline — v2 leads with the greeting (spec-488 renderer supports this).
+    heading: "",
     bodyParagraphs: [
       escapeHtml(greeting),
-      `<strong>${escapeHtml(prove)}</strong>`,
-      escapeHtml(para1),
-      escapeHtml(para2),
+      escapeHtml(p1),
+      `<strong>${escapeHtml(p2)}</strong>`,
+      escapeHtml(p3),
+      escapeHtml(p4),
+      `<em>&ldquo;${escapeHtml(prompt)}&rdquo;</em>`,
+      escapeHtml(p5),
     ],
     ctaLabel: "Go to Memex AI",
     ctaUrl: input.appUrl,
     showPasteLink: false,
-    afterCtaParagraphs: [escapeHtml(loop), ACTIVATION_SIGNOFF_HTML],
+    afterCtaParagraphs: [
+      escapeHtml(needHand).replace(
+        "#help",
+        `<a href="${DISCORD_INVITE_URL}" style="color:${BRAND_ACCENT};text-decoration:none;">#help</a>`,
+      ),
+      ACTIVATION_SIGNOFF_HTML,
+    ],
+    resources: ACTIVATION_RESOURCES,
     footerNote: ACTIVATION_FOOTER,
   });
 
   return {
     to: input.to,
-    subject: "Green means it's actually done",
+    subject: "Nice. A markdown spec could never give you that green check",
     text,
     html,
     // spec-453 dec-6: stable comms key — the trigger (t-2) dedups on THIS, never the subject.
+    // Unchanged by spec-487 (copy-only rewrite).
     commsType: "activation.verified_milestone",
   };
 }
@@ -832,6 +920,11 @@ export interface ConnectPeopleEmailInput {
 // pressure, point to the community. Pure render; the Day-12 select/dedup/send is
 // t-5, invoked by the shared scheduled endpoint (t-6). The only CTA is the confirmed
 // permanent Discord invite (dec-8). Copy mirrors s-3.
+// spec-487 (t-5) — the Day-12 how-to video, attributable via its own utm_campaign.
+const CONNECT_PEOPLE_VIDEO_URL = `${EMAIL_HOWTO_CONNECT_PEOPLE.videoUrl}?utm_source=lifecycle&utm_medium=email&utm_campaign=connect_people`;
+
+// spec-453 email; spec-487 t-5 adds the how-to video (clickable poster + fallback)
+// immediately before the "Join the Discord" CTA. Copy + subject are UNCHANGED.
 export function buildConnectPeopleEmail(
   input: ConnectPeopleEmailInput,
 ): EmailMessage {
@@ -845,7 +938,7 @@ export function buildConnectPeopleEmail(
     "This is the last of your onboarding emails, so I'll leave you to it. The door's always open whenever you want to pick things up.";
 
   const text = renderEmailText({
-    intro: [greeting, opener, para1, para2, last],
+    intro: [greeting, opener, para1, para2, `Watch it here: ${CONNECT_PEOPLE_VIDEO_URL}`, last],
     url: DISCORD_INVITE_URL,
     closing: ACTIVATION_SIGNOFF_TEXT,
   });
@@ -858,6 +951,14 @@ export function buildConnectPeopleEmail(
       `<strong>${escapeHtml(opener)}</strong>`,
       escapeHtml(para1),
       escapeHtml(para2),
+      // spec-487 t-5 — how-to video (poster + fallback), sits right before the CTA.
+      renderVideoThumbnail({
+        videoUrl: CONNECT_PEOPLE_VIDEO_URL,
+        thumb1xUrl: EMAIL_HOWTO_CONNECT_PEOPLE.thumb1xUrl,
+        thumb2xUrl: EMAIL_HOWTO_CONNECT_PEOPLE.thumb2xUrl,
+        alt: "Watch: how to connect with people",
+      }),
+      renderVideoFallbackLine(CONNECT_PEOPLE_VIDEO_URL),
     ],
     ctaLabel: "Join the Discord",
     ctaUrl: DISCORD_INVITE_URL,
@@ -871,8 +972,10 @@ export function buildConnectPeopleEmail(
     subject: "You've run the loop. Don't run it alone.",
     text,
     html,
-    // spec-453 dec-6: stable comms key — the Day-12 pass (t-5) dedups on THIS.
+    // spec-453 dec-6: stable comms key — the Day-12 pass dedups on THIS. Unchanged.
     commsType: "activation.connect_people",
+    // spec-487 t-5 — Postmark click tracking for the video link's utm attribution.
+    trackLinks: true,
   };
 }
 

--- a/packages/server/src/services/email/templates.ts
+++ b/packages/server/src/services/email/templates.ts
@@ -38,7 +38,10 @@ export interface EmailResource {
 
 interface RenderInput {
   preheader: string;
-  heading: string;
+  // Optional headline. Omit or pass "" → the email leads straight into
+  // bodyParagraphs with no <h1> (spec-488: the welcome v2 carries no repeated
+  // headline). Every other email passes a non-empty heading and is unchanged.
+  heading?: string;
   // Interpreted as HTML — caller must escape any dynamic values it interpolates.
   bodyParagraphs: string[];
   ctaLabel: string;
@@ -166,6 +169,12 @@ function renderEmailHtml(input: RenderInput): string {
     .join("");
 
   const safeUrl = escapeHtml(input.ctaUrl);
+  // spec-488 — suppress the <h1> when no heading is given (welcome v2 leads with
+  // the greeting). Title falls back to the preheader so it is never empty.
+  const headingHtml = input.heading
+    ? `<h1 style="margin:0 0 16px;color:${BRAND_INK};font-size:22px;line-height:1.3;font-weight:600;letter-spacing:-0.01em;">${escapeHtml(input.heading)}</h1>`
+    : "";
+  const titleText = input.heading || input.preheader;
   const stepsHtml = renderSteps(input.steps);
   const resourcesHtml = renderResources(input.resources);
   const pasteLink = (input.showPasteLink ?? true)
@@ -182,7 +191,7 @@ function renderEmailHtml(input: RenderInput): string {
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
-    <title>${escapeHtml(input.heading)}</title>
+    <title>${escapeHtml(titleText)}</title>
   </head>
   <body style="margin:0;padding:0;background-color:#F7F7F8;font-family:${FONT_STACK};-webkit-font-smoothing:antialiased;">
     <div style="display:none;max-height:0;overflow:hidden;opacity:0;color:transparent;">
@@ -195,7 +204,7 @@ function renderEmailHtml(input: RenderInput): string {
             <tr>
               <td style="padding:32px 40px;">
                 <div style="margin:0 0 20px;font-size:20px;font-weight:700;letter-spacing:-0.01em;color:${BRAND_INK};">Memex AI</div>
-                <h1 style="margin:0 0 16px;color:${BRAND_INK};font-size:22px;line-height:1.3;font-weight:600;letter-spacing:-0.01em;">${escapeHtml(input.heading)}</h1>
+                ${headingHtml}
                 ${paragraphs}
                 ${stepsHtml}
                 <div style="margin:24px 0 8px;">
@@ -310,10 +319,20 @@ export interface WelcomeEmailInput {
   senderName?: string;
 }
 
-// spec-428 — the day-one welcome (Option 3). Renders through the shared renderer
-// using the step + resources primitives (spec-226 dec-2). Transactional stream,
-// always sends; logged under the stable `welcome` key (dec-7). The CTA + resource
-// blocks are table/inline-CSS constructs (no imagery) per the Postmark constraints.
+// spec-480 dec-6 / spec-488 t-2 — the welcome links the SAME hosted explainer cut
+// as the win-back email (spec-480), tagged utm_campaign=welcome so a welcome-video
+// click is attributable separately from the win-back's (WINBACK_VIDEO_URL). The UTM
+// on a raw GCS mp4 is only meaningful once Postmark rewrites the link, so the send
+// carries trackLinks. (utm_source/medium mirror the win-back for one grouping.)
+const WELCOME_VIDEO_URL = `${EMAIL_EXPLAINER_VIDEO_URL}?utm_source=lifecycle&utm_medium=email&utm_campaign=welcome`;
+
+// spec-488 t-1 — the day-one welcome, v2 copy (supersedes spec-428's Option 3;
+// source of truth is spec-488 s-2). Renders through the shared renderer and LEADS
+// WITH THE GREETING — no repeated H1 headline (heading: ""). Transactional stream,
+// always sends; logged under the stable `welcome` key (spec-428 dec-7, inherited).
+// The clickable explainer-video thumbnail (spec-480 mechanism) is wired at the
+// spec-488 t-2 seam marked below; until then the email carries copy only and the
+// video degrades to nothing (t-2 adds the thumbnail + image-blocked fallback).
 export function buildWelcomeEmail(input: WelcomeEmailInput): EmailMessage {
   const firstName = input.firstName?.trim();
   const greeting = firstName ? `Hi ${firstName},` : "Hi there,";
@@ -323,81 +342,81 @@ export function buildWelcomeEmail(input: WelcomeEmailInput): EmailMessage {
   const signOffText = `Best,\n${senderName}`;
   const signOffHtml = `Best,<br>${escapeHtml(senderName)}`;
 
-  const value =
-    "Your agents are about to start building from what you actually decided, not what they guessed. Every decision is captured as you go, so nothing important gets buried in a chat thread or quietly chosen for you mid-build. And done means verified, not just claimed. No more vibe coding.";
-  const afterCtaText =
-    "We'll send you a few short emails over the next couple of weeks, and there are some resources below to get you started. If you get stuck, just reply here or find us in #help on Discord.";
-
-  const steps: EmailStep[] = [
-    {
-      label: "// Step 1",
-      title: "Connect to the Memex MCP",
-      body: "The app shows you exactly how to connect, whatever coding agent you're using.",
-    },
-    {
-      label: "// Step 2",
-      title: "Create your first Spec",
-      body: "Bring an idea and we'll help you shape it, start to finish.",
-    },
-  ];
-
-  const resources: EmailResource[] = [
-    {
-      title: "Understanding Memex AI",
-      description: "The 10-minute read on why it exists and how it works.",
-      url: "https://www.memex.ai/understanding-memex.pdf",
-    },
-    {
-      title: "Documentation",
-      description: "The complete reference, from getting started to the deep technical detail.",
-      url: "https://www.memex.ai/docs",
-    },
-    {
-      title: "Community",
-      description: "Say hello on Discord, whether you're weighing Memex up or already building.",
-      url: "https://discord.com/invite/WJfBYG9eV",
-    },
-  ];
+  const intro = "Glad you're on board. Here's why frontier teams build on Memex:";
+  const para1 =
+    "We all went all in on MD docs for building with AI: first for specifying features, then for passing context between humans and agents at scale. Exciting at first (we did it too!).";
+  // spec-488 s-2 — the "sh*t" spelling is a deliberate voice choice; the asterisk
+  // softens spam-filter risk. Accepted for the day-one transactional send.
+  const para2 =
+    "The problem? They're sh*t because they're only documents. They don't force agents to build specific things, so agents interpret, skip parts, and make executive decisions without your say-so. That's why AI coding gets so frustrating. And as the way you pass context, they go stale, need versions, and turn chaotic fast: a burst of productivity, then a ceiling.";
+  const fix1 =
+    "Your docs become living specs. Each decision becomes a perfectly scoped agent task with an acceptance criterion that forces the agent to build exactly what you want. Right the first time (yes, it's as good as it sounds).";
+  const fix2 =
+    "Each spec then speeds up the next. Memex surfaces what teammates are deciding in real time and tells you how it impacts your build, compounding into a knowledge layer that makes every new spec faster. No docs, no folders, no upkeep (finally!).";
+  const bullet1 = "Connect your agent over MCP (Claude Code, Cursor, Codex, Copilot)";
+  const bullet2 = "Create your first spec";
 
   const text = renderEmailText({
     intro: [
       greeting,
-      "Welcome to Memex AI.",
-      value,
-      "Two steps to get there.",
-      "// Step 1 — Connect to the Memex MCP: The app shows you exactly how to connect, whatever coding agent you're using.",
-      "// Step 2 — Create your first Spec: Bring an idea and we'll help you shape it, start to finish.",
-      afterCtaText,
-      "Resources: Understanding Memex AI (https://www.memex.ai/understanding-memex.pdf), Documentation (https://www.memex.ai/docs), Community (Discord).",
+      intro,
+      para1,
+      para2,
+      "Memex fixes both:",
+      `1. ${fix1}`,
+      `2. ${fix2}`,
+      "Here's a short animated walkthrough:",
+      `Watch the video: ${WELCOME_VIDEO_URL}`,
+      "To start:",
+      `- ${bullet1}`,
+      `- ${bullet2}`,
     ],
     url: input.appUrl,
     closing: signOffText,
   });
 
   const html = renderEmailHtml({
-    preheader: "Welcome to Memex AI — two steps to your first Spec.",
-    heading: "Build what you decided. Not what your agent guessed.",
+    preheader: "Why frontier teams build on Memex — right the first time.",
+    // No heading — v2 leads with the greeting (spec-488 s-2, headline dropped).
+    heading: "",
     bodyParagraphs: [
       escapeHtml(greeting),
-      "Welcome to Memex AI.",
-      escapeHtml(value),
-      "<strong>Two steps to get there.</strong>",
+      escapeHtml(intro),
+      escapeHtml(para1),
+      escapeHtml(para2),
+      "<strong>Memex fixes both:</strong>",
+      `<strong>1.</strong> ${escapeHtml(fix1)}`,
+      `<strong>2.</strong> ${escapeHtml(fix2)}`,
+      escapeHtml("Here's a short animated walkthrough:"),
+      // spec-488 t-2 — the clickable video thumbnail + image-blocked fallback,
+      // reusing spec-480's shared hosted-video + `email-*` thumbnail assets.
+      renderVideoThumbnail({
+        videoUrl: WELCOME_VIDEO_URL,
+        thumb1xUrl: EMAIL_VIDEO_THUMB_1X_URL,
+        thumb2xUrl: EMAIL_VIDEO_THUMB_2X_URL,
+        alt: `Watch: ${EMAIL_VIDEO_TITLE}`,
+      }),
+      renderVideoFallbackLine(WELCOME_VIDEO_URL),
+      `<strong>To start:</strong><br>&bull; ${escapeHtml(bullet1)}<br>&bull; ${escapeHtml(bullet2)}`,
     ],
-    steps,
     ctaLabel: "Open Memex AI",
     ctaUrl: input.appUrl,
     showPasteLink: false,
-    afterCtaParagraphs: [escapeHtml(afterCtaText), signOffHtml],
-    resources,
+    afterCtaParagraphs: [signOffHtml],
     footerNote: "You're getting this because you signed up for Memex AI, built by Mindset AI.",
   });
 
   return {
     to: input.to,
-    subject: "Build what you decided. Not what your agent guessed.",
+    subject:
+      "Agents that build it right first time, and every spec speeds up the next",
     text,
     html,
     commsType: "welcome",
+    // spec-488 t-2 / spec-480 dec-6 — enable Postmark click tracking so a click on
+    // the video thumbnail / fallback link (the raw GCS mp4) is recorded and the
+    // utm_campaign=welcome attribution is real. Click tracking only, no open pixel.
+    trackLinks: true,
   };
 }
 

--- a/packages/server/src/services/email/templates.ts
+++ b/packages/server/src/services/email/templates.ts
@@ -8,7 +8,7 @@ import type { EmailMessage } from "./sender.js";
 // renders consistently across Gmail, Apple Mail, Outlook, etc.
 
 const BRAND_INK = "#0E1128";
-const BRAND_CORAL = "#FC4F64";
+const BRAND_ACCENT = "#0482DC";
 const BRAND_SKY = "#0C9FE3";
 const BRAND_MUTED = "#6B7280";
 const BRAND_BORDER = "#E5E7EB";
@@ -78,7 +78,7 @@ export function renderSteps(steps?: EmailStep[]): string {
     .map(
       (s) =>
         `<div style="margin:20px 0;">` +
-        `<div style="font-family:${FONT_STACK};font-size:15px;font-weight:700;color:${BRAND_CORAL};">${escapeHtml(s.label)}</div>` +
+        `<div style="font-family:${FONT_STACK};font-size:15px;font-weight:700;color:${BRAND_ACCENT};">${escapeHtml(s.label)}</div>` +
         `<div style="margin:6px 0 2px;font-size:16px;font-weight:600;color:${BRAND_INK};">${escapeHtml(s.title)}</div>` +
         `<div style="color:${BRAND_INK};font-size:15px;line-height:1.6;">${escapeHtml(s.body)}</div>` +
         `</div>`,
@@ -95,7 +95,7 @@ export function renderResources(resources?: EmailResource[]): string {
     .map(
       (r) =>
         `<tr><td style="padding:12px 0;border-top:1px solid ${BRAND_BORDER};">` +
-        `<a href="${escapeHtml(r.url)}" style="color:${BRAND_CORAL};font-size:15px;font-weight:600;text-decoration:none;">${escapeHtml(r.title)}</a>` +
+        `<a href="${escapeHtml(r.url)}" style="color:${BRAND_ACCENT};font-size:15px;font-weight:600;text-decoration:none;">${escapeHtml(r.title)}</a>` +
         `<div style="margin-top:2px;color:${BRAND_MUTED};font-size:13px;line-height:1.5;">${escapeHtml(r.description)}</div>` +
         `</td></tr>`,
     )
@@ -145,7 +145,7 @@ function renderEmailHtml(input: RenderInput): string {
                 ${paragraphs}
                 ${stepsHtml}
                 <div style="margin:24px 0 8px;">
-                  <a href="${safeUrl}" style="display:inline-block;padding:12px 24px;background:${BRAND_CORAL};color:#FFFFFF;font-size:15px;font-weight:600;text-decoration:none;border-radius:8px;">${escapeHtml(input.ctaLabel)}</a>
+                  <a href="${safeUrl}" style="display:inline-block;padding:12px 24px;background:${BRAND_ACCENT};color:#FFFFFF;font-size:15px;font-weight:600;text-decoration:none;border-radius:8px;">${escapeHtml(input.ctaLabel)}</a>
                 </div>
                 ${pasteLink}
                 ${afterCta}
@@ -444,7 +444,7 @@ export function buildConnectedInactiveEmail(
     afterCtaParagraphs: [
       escapeHtml(afterCta1),
       escapeHtml(afterCta2),
-      `Watch your Spec come to life in <a href="${escapeHtml(input.memexUrl)}" style="color:${BRAND_CORAL};">your Memex</a>.`,
+      `Watch your Spec come to life in <a href="${escapeHtml(input.memexUrl)}" style="color:${BRAND_ACCENT};">your Memex</a>.`,
       escapeHtml(stuck),
       ACTIVATION_SIGNOFF_HTML,
     ],
@@ -486,7 +486,7 @@ export function buildSignedInDormantEmail(
   // escaped string is safe; the plain-text body keeps "#help" as prose.
   const afterCtaHtml = escapeHtml(afterCtaText).replace(
     "#help",
-    `<a href="${DISCORD_INVITE_URL}" style="color:${BRAND_CORAL};text-decoration:none;">#help</a>`,
+    `<a href="${DISCORD_INVITE_URL}" style="color:${BRAND_ACCENT};text-decoration:none;">#help</a>`,
   );
 
   const steps: EmailStep[] = [

--- a/packages/server/src/services/email/templates.ts
+++ b/packages/server/src/services/email/templates.ts
@@ -184,6 +184,23 @@ export function renderVideoFallbackLine(videoUrl: string): string {
   );
 }
 
+// spec-487 formatting — hanging-indent bullet / numbered lists, email-safe (<ul>/<ol>
+// with inline styles). Injected as a bodyParagraph string; items are escaped here.
+function renderBulletList(items: string[]): string {
+  return (
+    `<ul style="margin:0;padding-left:22px;color:${BRAND_INK};font-size:16px;line-height:1.6;">` +
+    items.map((i) => `<li style="margin:0 0 6px;">${escapeHtml(i)}</li>`).join("") +
+    `</ul>`
+  );
+}
+function renderNumberList(items: string[]): string {
+  return (
+    `<ol style="margin:0;padding-left:22px;color:${BRAND_INK};font-size:16px;line-height:1.6;">` +
+    items.map((i) => `<li style="margin:0 0 6px;">${escapeHtml(i)}</li>`).join("") +
+    `</ol>`
+  );
+}
+
 function renderEmailHtml(input: RenderInput): string {
   const paragraphs = input.bodyParagraphs
     .map(
@@ -549,7 +566,7 @@ export function buildConnectedInactiveEmail(
       greeting,
       p1,
       p2,
-      ...p2lines,
+      ...p2lines.map((l) => `- ${l}`),
       `${videoIntro} Watch it here: ${CONNECTED_INACTIVE_VIDEO_URL}`,
       thenBring,
       `"${prompt1}"`,
@@ -569,7 +586,7 @@ export function buildConnectedInactiveEmail(
       escapeHtml(greeting),
       escapeHtml(p1),
       escapeHtml(p2),
-      p2lines.map((l) => escapeHtml(l)).join("<br>"),
+      renderBulletList(p2lines),
       escapeHtml(videoIntro),
       renderVideoThumbnail({
         videoUrl: CONNECTED_INACTIVE_VIDEO_URL,
@@ -744,7 +761,7 @@ export function buildWinbackEmail(input: WinbackEmailInput): EmailMessage {
     "Memex never touches your repo, but your coding agent does. So connecting the MCP makes your agent the bridge:";
   const bridgeLines = [
     "It reads your real codebase, and everything you decide gets grounded in it, in one place instead of scattered across threads and MD files.",
-    "Once connected, you start speccing against your actual code, not a blank page.",
+    "Once connected, you start speccing against your actual code, not a blank page",
     "The more decisions you settle upfront, the more your agent gets right first time.",
   ];
   const videoIntro =
@@ -769,7 +786,7 @@ export function buildWinbackEmail(input: WinbackEmailInput): EmailMessage {
       greeting,
       p1,
       bridge,
-      ...bridgeLines,
+      ...bridgeLines.map((l) => `- ${l}`),
       `${videoIntro} Watch it here: ${WINBACK_VIDEO_URL}`,
       connectIntro,
       connectStep,
@@ -790,7 +807,7 @@ export function buildWinbackEmail(input: WinbackEmailInput): EmailMessage {
       escapeHtml(greeting),
       escapeHtml(p1),
       escapeHtml(bridge),
-      bridgeLines.map((l) => escapeHtml(l)).join("<br>"),
+      renderBulletList(bridgeLines),
       escapeHtml(videoIntro),
       renderVideoThumbnail({
         videoUrl: WINBACK_VIDEO_URL,
@@ -885,7 +902,7 @@ export function buildVerifiedMilestoneEmail(
   const needHand = "Questions? Reply here, or find us in #help on Discord.";
 
   const text = renderEmailText({
-    intro: [greeting, p1, p2, ...compoundLines, `"${prompt}"`, p5, needHand],
+    intro: [greeting, p1, p2, ...compoundLines.map((l, i) => `${i + 1}. ${l}`), `"${prompt}"`, p5, needHand],
     url: input.appUrl,
     closing: ACTIVATION_SIGNOFF_TEXT,
   });
@@ -898,7 +915,7 @@ export function buildVerifiedMilestoneEmail(
       escapeHtml(greeting),
       escapeHtml(p1),
       `<strong>${escapeHtml(p2)}</strong>`,
-      compoundLines.map((l) => escapeHtml(l)).join("<br>"),
+      renderNumberList(compoundLines),
       `<em>&ldquo;${escapeHtml(prompt)}&rdquo;</em>`,
       escapeHtml(p5),
     ],

--- a/packages/server/src/services/email/templates.ts
+++ b/packages/server/src/services/email/templates.ts
@@ -371,8 +371,10 @@ export function buildWelcomeEmail(input: WelcomeEmailInput): EmailMessage {
     "We all went all in on MD docs for building with AI: first for specifying features, then for passing context between humans and agents at scale. Exciting at first (we did it too!).";
   // spec-488 s-2 — the "sh*t" spelling is a deliberate voice choice; the asterisk
   // softens spam-filter risk. Accepted for the day-one transactional send.
+  // spec-487 formatting fix — "The problem?" on its own line, then the paragraph.
+  const problem = "The problem?";
   const para2 =
-    "The problem? They're sh*t because they're only documents. They don't force agents to build specific things, so agents interpret, skip parts, and make executive decisions without your say-so. That's why AI coding gets so frustrating. And as the way you pass context, they go stale, need versions, and turn chaotic fast: a burst of productivity, then a ceiling.";
+    "They're sh*t because they're only documents. They don't force agents to build specific things, so agents interpret, skip parts, and make executive decisions without your say-so. That's why AI coding gets so frustrating. And as the way you pass context, they go stale, need versions, and turn chaotic fast: a burst of productivity, then a ceiling.";
   const fix1 =
     "Your docs become living specs. Each decision becomes a perfectly scoped agent task with an acceptance criterion that forces the agent to build exactly what you want. Right the first time (yes, it's as good as it sounds).";
   const fix2 =
@@ -385,6 +387,7 @@ export function buildWelcomeEmail(input: WelcomeEmailInput): EmailMessage {
       greeting,
       intro,
       para1,
+      problem,
       para2,
       "Memex fixes both:",
       `1. ${fix1}`,
@@ -407,6 +410,7 @@ export function buildWelcomeEmail(input: WelcomeEmailInput): EmailMessage {
       escapeHtml(greeting),
       escapeHtml(intro),
       escapeHtml(para1),
+      escapeHtml(problem),
       escapeHtml(para2),
       "<strong>Memex fixes both:</strong>",
       `<strong>1.</strong> ${escapeHtml(fix1)}`,
@@ -520,8 +524,13 @@ export function buildConnectedInactiveEmail(
   const greeting = activationGreeting(input.firstName);
   const p1 =
     "Memex is connected, but the change you signed up for does not show until there is a Spec. Without one, your agent is still working off a document: it reads what it likes, skips the rest, and fills the gaps with its own assumptions, so you are back to re-prompting and re-reviewing.";
-  const p2 =
-    "A Memex spec fixes that. You create it right from your coding agent: it reads your repo, and together you work through the major decisions and the why behind what you are building. Each one becomes a task with an acceptance criterion your agent has to build to, not prose it can pass over. The more you settle upfront, the more it gets right first time.";
+  const p2 = "A Memex spec fixes that. You create it right from your coding agent:";
+  // spec-487 formatting fix — the three clauses each on their own line.
+  const p2lines = [
+    "It reads your repo, and together you work through the major decisions and the why behind what you are building.",
+    "Each one becomes a task with an acceptance criterion your agent has to build to, not prose it can pass over.",
+    "The more you settle upfront, the more it gets right first time.",
+  ];
   const videoIntro = "See it done in 3 minutes: a quick guide to creating your first spec.";
   const thenBring = "Then bring one small piece of work and paste this into your coding agent:";
   const prompt1 =
@@ -540,6 +549,7 @@ export function buildConnectedInactiveEmail(
       greeting,
       p1,
       p2,
+      ...p2lines,
       `${videoIntro} Watch it here: ${CONNECTED_INACTIVE_VIDEO_URL}`,
       thenBring,
       `"${prompt1}"`,
@@ -559,6 +569,7 @@ export function buildConnectedInactiveEmail(
       escapeHtml(greeting),
       escapeHtml(p1),
       escapeHtml(p2),
+      p2lines.map((l) => escapeHtml(l)).join("<br>"),
       escapeHtml(videoIntro),
       renderVideoThumbnail({
         videoUrl: CONNECTED_INACTIVE_VIDEO_URL,
@@ -726,10 +737,16 @@ export function buildWinbackEmail(input: WinbackEmailInput): EmailMessage {
 
   // spec-487 s-3 copy (the code is the canonical authoring source; s-3 mirrors it).
   const p1 =
-    "Right now your agent works from markdown: files it interprets, skips, and fills in with its own assumptions. That is what drives the re-prompting and re-reviewing, and it only gets worse on brownfield code.";
-  const p2 = "Memex never touches your repo, but your coding agent does.";
-  const p3 =
-    "So connecting the MCP makes your agent the bridge: it reads your real codebase, and everything you decide gets grounded in it, in one place instead of scattered across threads and MD files. Once connected, you start speccing against your actual code, not a blank page, and the more decisions you settle upfront, the more your agent gets right first time.";
+    "Right now, your agent works from markdown files it interprets, skips, and fills in with its own assumptions. That is what drives the re-prompting and re-reviewing, and it only gets worse on brownfield code.";
+  // spec-487 formatting fix — merge the bridge intro into one line, then the three
+  // clauses each on their own line.
+  const bridge =
+    "Memex never touches your repo, but your coding agent does. So connecting the MCP makes your agent the bridge:";
+  const bridgeLines = [
+    "It reads your real codebase, and everything you decide gets grounded in it, in one place instead of scattered across threads and MD files.",
+    "Once connected, you start speccing against your actual code, not a blank page.",
+    "The more decisions you settle upfront, the more your agent gets right first time.",
+  ];
   const videoIntro =
     "See it done in 3 minutes: a quick guide to connecting the MCP and creating your first spec.";
   const connectIntro = "Connect your MCP & create a spec:";
@@ -751,8 +768,8 @@ export function buildWinbackEmail(input: WinbackEmailInput): EmailMessage {
     intro: [
       greeting,
       p1,
-      p2,
-      p3,
+      bridge,
+      ...bridgeLines,
       `${videoIntro} Watch it here: ${WINBACK_VIDEO_URL}`,
       connectIntro,
       connectStep,
@@ -772,8 +789,8 @@ export function buildWinbackEmail(input: WinbackEmailInput): EmailMessage {
     bodyParagraphs: [
       escapeHtml(greeting),
       escapeHtml(p1),
-      escapeHtml(p2),
-      escapeHtml(p3),
+      escapeHtml(bridge),
+      bridgeLines.map((l) => escapeHtml(l)).join("<br>"),
       escapeHtml(videoIntro),
       renderVideoThumbnail({
         videoUrl: WINBACK_VIDEO_URL,
@@ -855,11 +872,12 @@ export function buildVerifiedMilestoneEmail(
   // spec-487 s-4 copy (copy-only rewrite, no video). Owned by spec-453 — coordinated.
   const p1 =
     "Congratulations. You just did something a markdown spec can never do: an acceptance criterion, verified in CI. It went green on its own, without you re-reading a diff and hoping the agent caught what mattered. That is proof that what you decided got built.";
-  const p2 = "Two ways to make that compound.";
-  const p3 =
-    "First, run another Spec. Every one you finish makes the next faster, because your agents inherit what you have already decided.";
-  const p4 =
-    "Second, set up your standards. You already have rules written down in CLAUDE.md, AGENTS.md or your Cursor rules. Point your agent at them and paste this:";
+  const p2 = "Two ways to make that compound:";
+  // spec-487 formatting fix — the two moves each on their own line (dropped First/Second).
+  const compoundLines = [
+    "Run another Spec. Every one you finish makes the next faster, because your agents inherit what you have already decided.",
+    "Set up your standards. You already have rules written down in CLAUDE.md, AGENTS.md or your Cursor rules. Point your agent at them and paste this:",
+  ];
   const prompt =
     "Read my CLAUDE.md and AGENTS.md, create Memex standards from the rules in them, then rewrite the MD file as a contents page that tells my agents which Memex standard applies to what.";
   const p5 =
@@ -867,7 +885,7 @@ export function buildVerifiedMilestoneEmail(
   const needHand = "Questions? Reply here, or find us in #help on Discord.";
 
   const text = renderEmailText({
-    intro: [greeting, p1, p2, p3, p4, `"${prompt}"`, p5, needHand],
+    intro: [greeting, p1, p2, ...compoundLines, `"${prompt}"`, p5, needHand],
     url: input.appUrl,
     closing: ACTIVATION_SIGNOFF_TEXT,
   });
@@ -880,8 +898,7 @@ export function buildVerifiedMilestoneEmail(
       escapeHtml(greeting),
       escapeHtml(p1),
       `<strong>${escapeHtml(p2)}</strong>`,
-      escapeHtml(p3),
-      escapeHtml(p4),
+      compoundLines.map((l) => escapeHtml(l)).join("<br>"),
       `<em>&ldquo;${escapeHtml(prompt)}&rdquo;</em>`,
       escapeHtml(p5),
     ],

--- a/packages/server/src/services/email/templates.visual.spec-465.test.ts
+++ b/packages/server/src/services/email/templates.visual.spec-465.test.ts
@@ -1,101 +1,24 @@
-// spec-465 — email design polish. Asserts the new shared + per-template treatment:
-// coral CTA button (white label), coral resource links everywhere, the "Memex AI"
-// wordmark (no dot, uniform weight), the connected-inactive "your Memex" coral link,
-// the signed-in-dormant "#help" coral Discord link, and the greeting fallback.
+// spec-465 — email design polish. The accent-COLOUR assertions moved to spec-468
+// (coral #FC4F64 → brand blue #0482DC); this file retains spec-465's still-valid,
+// colour-independent claims: the "Memex AI" wordmark (ac-3) and the greeting
+// fallback (ac-6). spec-465's coral colour ACs (ac-1/ac-2/ac-4/ac-5) are superseded
+// by spec-468 and intentionally no longer tagged here.
 import { describe, it, expect } from "vitest";
 import { tagAc } from "@memex-ai-ac/vitest";
-import {
-  buildVerificationEmail,
-  buildWelcomeEmail,
-  buildConnectedInactiveEmail,
-  buildSignedInDormantEmail,
-  buildVerifiedMilestoneEmail,
-  buildConnectPeopleEmail,
-} from "./templates.js";
+import { buildWelcomeEmail } from "./templates.js";
 
 const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-465/acs/ac-${n}`;
-
-const CORAL = "#FC4F64";
 const INK = "#0E1128";
-const DISCORD = "https://discord.com/invite/WJfBYG9eV";
 
-// A representative spread: a transactional email + the welcome + all activation emails,
-// to prove the SHARED changes cascade and the per-template ones land.
-const verification = buildVerificationEmail({ to: "a@b.test", verifyUrl: "https://int.memex.ai/verify-email?token=T" });
 const welcome = buildWelcomeEmail({ to: "a@b.test", appUrl: "https://int.memex.ai", firstName: "Ada" });
-const connected = buildConnectedInactiveEmail({ to: "a@b.test", firstName: "Ada", createSpecUrl: "https://int.memex.ai/n/m/specs/new", memexUrl: "https://int.memex.ai/n/m" });
-const signedIn = buildSignedInDormantEmail({ to: "a@b.test", firstName: "Ada", appUrl: "https://int.memex.ai" });
-const verified = buildVerifiedMilestoneEmail({ to: "a@b.test", firstName: "Ada", appUrl: "https://int.memex.ai" });
-const connect = buildConnectPeopleEmail({ to: "a@b.test", firstName: "Ada" });
-
-const all: Array<[string, { html?: string }]> = [
-  ["verification", verification],
-  ["welcome", welcome],
-  ["connected-inactive", connected],
-  ["signed-in-dormant", signedIn],
-  ["verified-milestone", verified],
-  ["connect-people", connect],
-];
-
-// Emails that render the resources block.
-const withResources: Array<[string, { html?: string }]> = [
-  ["welcome", welcome],
-  ["connected-inactive", connected],
-  ["signed-in-dormant", signedIn],
-];
-
-describe("spec-465 — coral CTA button, white label, on every email (ac-1)", () => {
-  for (const [name, msg] of all) {
-    it(`${name}: button is coral #FC4F64 with white text, no gradient`, () => {
-      tagAc(AC(1));
-      const html = msg.html ?? "";
-      expect(html).toContain(`background:${CORAL};color:#FFFFFF`);
-      expect(html).not.toContain(`background:${INK};color:#FFFFFF`);
-      expect(html).not.toContain("linear-gradient");
-    });
-  }
-});
-
-describe("spec-465 — resource-block links are coral everywhere (ac-2)", () => {
-  for (const [name, msg] of withResources) {
-    it(`${name}: the resources block links render in coral`, () => {
-      tagAc(AC(2));
-      const html = msg.html ?? "";
-      expect(html).toContain(`color:${CORAL};font-size:15px;font-weight:600;text-decoration:none;">Understanding Memex AI</a>`);
-    });
-  }
-});
 
 describe("spec-465 — the wordmark reads \"Memex AI\", uniform weight (ac-3)", () => {
   it("renders a single-colour dark-ink \"Memex AI\" wordmark — no dot, no lighter span", () => {
     tagAc(AC(3));
     const html = welcome.html ?? "";
-    // one uniform-weight dark-ink wordmark, live text
     expect(html).toContain(`color:${INK};">Memex AI</div>`);
-    // the old dotted / lighter-weight ".AI" span is gone
     expect(html).not.toContain(">.AI</span>");
     expect(html).not.toContain("font-weight:500");
-  });
-});
-
-describe("spec-465 — connected-inactive \"your Memex\" link is coral (ac-4)", () => {
-  it("renders the \"your Memex\" link in coral, not sky blue", () => {
-    tagAc(AC(4));
-    const html = connected.html ?? "";
-    expect(html).toContain(`style="color:${CORAL};">your Memex</a>`);
-    expect(html).not.toContain(`style="color:#0C9FE3;">your Memex</a>`);
-  });
-});
-
-describe("spec-465 — signed-in-dormant \"#help\" is a coral Discord link (ac-5)", () => {
-  it("links #help to the Discord invite in coral (HTML), plain text stays prose", () => {
-    tagAc(AC(5));
-    const html = signedIn.html ?? "";
-    const text = signedIn.text ?? "";
-    expect(html).toContain(`<a href="${DISCORD}" style="color:${CORAL};text-decoration:none;">#help</a>`);
-    // the plain-text body keeps "#help" as prose (no raw anchor leaking in)
-    expect(text).toContain("#help on Discord");
-    expect(text).not.toContain("<a ");
   });
 });
 

--- a/packages/server/src/services/email/templates.visual.spec-468.test.ts
+++ b/packages/server/src/services/email/templates.visual.spec-468.test.ts
@@ -34,8 +34,9 @@ const all: Array<[string, { html?: string }]> = [
   ["verified-milestone", verified],
   ["connect-people", connect],
 ];
+// spec-488: the welcome v2 dropped the "Resources to get started" block, so it
+// no longer carries resource-link accents — only the two activation emails do.
 const withResources: Array<[string, { html?: string }]> = [
-  ["welcome", welcome],
   ["connected-inactive", connected],
   ["signed-in-dormant", signedIn],
 ];
@@ -54,9 +55,10 @@ describe("spec-468 — CTA button is #0482DC with white text (ac-1, ac-3)", () =
 });
 
 describe("spec-468 — step labels + resource links are #0482DC (ac-1)", () => {
-  it("the \"// Step N\" labels render in #0482DC (welcome + signed-in-dormant)", () => {
+  it("the \"// Step N\" labels render in #0482DC (signed-in-dormant)", () => {
     tagAc(AC(1));
-    expect(welcome.html ?? "").toContain(`color:${ACCENT};">// Step 1`);
+    // spec-488: the welcome v2 dropped the "// Step N" blocks; only the
+    // signed-in-dormant email still carries them.
     expect(signedIn.html ?? "").toContain(`color:${ACCENT};">// Step 1`);
   });
   for (const [name, msg] of withResources) {

--- a/packages/server/src/services/email/templates.visual.spec-468.test.ts
+++ b/packages/server/src/services/email/templates.visual.spec-468.test.ts
@@ -1,0 +1,99 @@
+// spec-468 — email accent recolour: coral #FC4F64 → brand blue #0482DC.
+// Owns every accent-colour assertion: CTA button, "// Step N" labels, resource
+// links, connected-inactive "your Memex", signed-in-dormant "#help" — plus a
+// no-coral-anywhere guard. (Supersedes spec-465's coral colour ACs + spec-451's
+// coral step-label.)
+import { describe, it, expect } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import {
+  buildVerificationEmail,
+  buildWelcomeEmail,
+  buildConnectedInactiveEmail,
+  buildSignedInDormantEmail,
+  buildVerifiedMilestoneEmail,
+  buildConnectPeopleEmail,
+} from "./templates.js";
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-468/acs/ac-${n}`;
+const ACCENT = "#0482DC";
+const CORAL = "#FC4F64";
+const DISCORD = "https://discord.com/invite/WJfBYG9eV";
+
+const verification = buildVerificationEmail({ to: "a@b.test", verifyUrl: "https://int.memex.ai/verify-email?token=T" });
+const welcome = buildWelcomeEmail({ to: "a@b.test", appUrl: "https://int.memex.ai", firstName: "Ada" });
+const connected = buildConnectedInactiveEmail({ to: "a@b.test", firstName: "Ada", createSpecUrl: "https://int.memex.ai/n/m/specs/new", memexUrl: "https://int.memex.ai/n/m" });
+const signedIn = buildSignedInDormantEmail({ to: "a@b.test", firstName: "Ada", appUrl: "https://int.memex.ai" });
+const verified = buildVerifiedMilestoneEmail({ to: "a@b.test", firstName: "Ada", appUrl: "https://int.memex.ai" });
+const connect = buildConnectPeopleEmail({ to: "a@b.test", firstName: "Ada" });
+
+const all: Array<[string, { html?: string }]> = [
+  ["verification", verification],
+  ["welcome", welcome],
+  ["connected-inactive", connected],
+  ["signed-in-dormant", signedIn],
+  ["verified-milestone", verified],
+  ["connect-people", connect],
+];
+const withResources: Array<[string, { html?: string }]> = [
+  ["welcome", welcome],
+  ["connected-inactive", connected],
+  ["signed-in-dormant", signedIn],
+];
+
+describe("spec-468 — CTA button is #0482DC with white text (ac-1, ac-3)", () => {
+  for (const [name, msg] of all) {
+    it(`${name}: button background #0482DC, white label, no gradient`, () => {
+      tagAc(AC(1));
+      tagAc(AC(3));
+      const html = msg.html ?? "";
+      expect(html).toContain(`background:${ACCENT};color:#FFFFFF`);
+      expect(html).not.toContain(`background:${CORAL}`);
+      expect(html).not.toContain("linear-gradient");
+    });
+  }
+});
+
+describe("spec-468 — step labels + resource links are #0482DC (ac-1)", () => {
+  it("the \"// Step N\" labels render in #0482DC (welcome + signed-in-dormant)", () => {
+    tagAc(AC(1));
+    expect(welcome.html ?? "").toContain(`color:${ACCENT};">// Step 1`);
+    expect(signedIn.html ?? "").toContain(`color:${ACCENT};">// Step 1`);
+  });
+  for (const [name, msg] of withResources) {
+    it(`${name}: resource-block links render in #0482DC`, () => {
+      tagAc(AC(1));
+      expect(msg.html ?? "").toContain(`color:${ACCENT};font-size:15px;font-weight:600;text-decoration:none;">Understanding Memex AI</a>`);
+    });
+  }
+});
+
+describe("spec-468 — per-template accent links are #0482DC (ac-1)", () => {
+  it("connected-inactive \"your Memex\" link is #0482DC", () => {
+    tagAc(AC(1));
+    expect(connected.html ?? "").toContain(`style="color:${ACCENT};">your Memex</a>`);
+  });
+  it("signed-in-dormant \"#help\" is a #0482DC Discord link", () => {
+    tagAc(AC(1));
+    expect(signedIn.html ?? "").toContain(`<a href="${DISCORD}" style="color:${ACCENT};text-decoration:none;">#help</a>`);
+  });
+});
+
+describe("spec-468 — no coral remains anywhere (ac-2)", () => {
+  for (const [name, msg] of all) {
+    it(`${name}: rendered HTML contains no #FC4F64`, () => {
+      tagAc(AC(2));
+      expect((msg.html ?? "").toUpperCase()).not.toContain(CORAL);
+    });
+  }
+});
+
+describe("spec-468 — presentation-only, accent aside (ac-4)", () => {
+  it("the verification email keeps its structure (doctype, solid button, no imagery) with the new accent", () => {
+    tagAc(AC(4));
+    const html = verification.html ?? "";
+    expect(html).toContain("<!doctype html>");
+    expect(html).toContain(`background:${ACCENT};color:#FFFFFF`);
+    expect(html).not.toContain("linear-gradient");
+    expect(html).not.toContain("<img");
+  });
+});

--- a/packages/server/src/services/email/templates.visual.spec-468.test.ts
+++ b/packages/server/src/services/email/templates.visual.spec-468.test.ts
@@ -70,9 +70,10 @@ describe("spec-468 — step labels + resource links are #0482DC (ac-1)", () => {
 });
 
 describe("spec-468 — per-template accent links are #0482DC (ac-1)", () => {
-  it("connected-inactive \"your Memex\" link is #0482DC", () => {
+  it("connected-inactive \"#help\" is a #0482DC Discord link", () => {
     tagAc(AC(1));
-    expect(connected.html ?? "").toContain(`style="color:${ACCENT};">your Memex</a>`);
+    // spec-487: the v2 copy dropped the "your Memex" link; the accent link is now #help.
+    expect(connected.html ?? "").toContain(`<a href="${DISCORD}" style="color:${ACCENT};text-decoration:none;">#help</a>`);
   });
   it("signed-in-dormant \"#help\" is a #0482DC Discord link", () => {
     tagAc(AC(1));

--- a/packages/server/src/services/email/templates.visual.spec-488.test.ts
+++ b/packages/server/src/services/email/templates.visual.spec-488.test.ts
@@ -1,0 +1,47 @@
+// spec-488 t-3 — visual/structural snapshot of the welcome v2 layout. Locks the
+// two things unit copy-tests don't: (1) the v2 email leads with the greeting and
+// carries NO <h1>; (2) the video thumbnail is the ONLY image and is table-safe
+// (bulletproof <img> attributes that survive Outlook/Gmail). Tagged to ac-4.
+import { describe, it, expect } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { buildWelcomeEmail } from "./templates.js";
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-488/acs/ac-${n}`;
+
+const welcome = buildWelcomeEmail({
+  to: "a@b.test",
+  appUrl: "https://int.memex.ai",
+  firstName: "Ada",
+});
+const html = welcome.html ?? "";
+
+describe("spec-488 — welcome v2 visual layout (ac-4)", () => {
+  it("is a valid standalone HTML doc rendered through the shared table layout", () => {
+    tagAc(AC(4));
+    expect(html).toContain("<!doctype html>");
+    expect(html).toContain('role="presentation"');
+    // solid brand-blue CTA, never a gradient (shared-renderer treatment)
+    expect(html).toContain("background:#0482DC;color:#FFFFFF");
+    expect(html).not.toContain("linear-gradient");
+  });
+
+  it("leads with the greeting — the wordmark is followed by a body paragraph, no <h1>", () => {
+    tagAc(AC(4));
+    expect(html).not.toContain("<h1");
+    expect(html).toMatch(/>Memex AI<\/div>\s*<p[^>]*>Hi Ada,/);
+  });
+
+  it("the video thumbnail is the ONLY image and is table-safe (bulletproof <img>)", () => {
+    tagAc(AC(4));
+    // exactly one <img> in the whole email
+    expect(html.match(/<img/g) ?? []).toHaveLength(1);
+    // bulletproof attributes: kills Outlook's link border, forces block display,
+    // explicit dimensions so clients reserve the box, retina via srcset.
+    expect(html).toContain('width="480" height="269"');
+    expect(html).toContain("display:block;width:100%;max-width:480px;height:auto;border:0;outline:none");
+    expect(html).toContain(' 2x"'); // srcset retina descriptor
+    // the img is wrapped in a border-stripped anchor to the video (clickable, no
+    // stray link chrome in Outlook)
+    expect(html).toMatch(/<a href="[^"]*\.mp4[^"]*"[^>]*border:0;outline:none[^>]*>\s*<img/);
+  });
+});

--- a/packages/server/src/services/email/templates.visual.test.ts
+++ b/packages/server/src/services/email/templates.visual.test.ts
@@ -35,7 +35,7 @@ describe.each(samples.map((m) => [m.subject, m.html ?? ""] as const))(
     it("uses a solid coral CTA button, never a gradient", () => {
       tagAc(AC(1)); // scope: all six emails carry the corrected treatment (cascades)
       // Button colour is now coral — owned by spec-465 (reverses spec-226 dec-1/ac-4).
-      expect(html).toContain("background:#FC4F64;color:#FFFFFF");
+      expect(html).toContain("background:#0482DC;color:#FFFFFF");
       expect(html).not.toContain("linear-gradient");
     });
 

--- a/packages/server/src/services/email/welcome.test.ts
+++ b/packages/server/src/services/email/welcome.test.ts
@@ -1,66 +1,131 @@
-// spec-428 t-2 / t-4 — the welcome email template (Option 3), tagged to its ACs.
+// spec-488 t-1 — the welcome email v2 copy (supersedes spec-428's Option-3),
+// tagged to its scope ACs. The video thumbnail (ac-2/ac-3/ac-7) lands in t-2;
+// this file covers the copy swap (ac-1), the renderer path (ac-4), and the
+// greeting personalisation (ac-5).
 import { describe, it, expect } from "vitest";
 import { tagAc } from "@memex-ai-ac/vitest";
-import { buildWelcomeEmail } from "./templates.js";
+import {
+  buildWelcomeEmail,
+  EMAIL_EXPLAINER_VIDEO_URL,
+  EMAIL_VIDEO_THUMB_1X_URL,
+  EMAIL_VIDEO_THUMB_2X_URL,
+  EMAIL_VIDEO_TITLE,
+} from "./templates.js";
 
-const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-428/acs/ac-${n}`;
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-488/acs/ac-${n}`;
 
-describe("buildWelcomeEmail", () => {
+describe("buildWelcomeEmail (v2)", () => {
   const msg = buildWelcomeEmail({
     to: "new@example.com",
     appUrl: "https://int.memex.ai",
     firstName: "Sam",
   });
   const html = msg.html ?? "";
+  const text = msg.text ?? "";
 
-  it("uses the Option-3 subject/H1 and the Open Memex AI CTA, rendered from code", () => {
-    tagAc(AC(3)); // sent via the shared renderer, Option-3 layout
-    tagAc(AC(11)); // copy sourced from the code builder, not an external doc
-    expect(msg.subject).toBe("Build what you decided. Not what your agent guessed.");
-    expect(html).toContain("Build what you decided. Not what your agent guessed.");
+  it("uses the v2 subject and CTA, and drops the Option-3 headline", () => {
+    tagAc(AC(1));
+    expect(msg.subject).toBe(
+      "Agents that build it right first time, and every spec speeds up the next",
+    );
+    expect(html).not.toContain("Build what you decided. Not what your agent guessed.");
+    expect(html).toContain("frontier teams build on Memex");
     expect(html).toContain("Open Memex AI");
     expect(html).toContain('href="https://int.memex.ai"');
-  });
-
-  it("personalises the greeting", () => {
-    tagAc(AC(4));
-    expect(html).toContain("Hi Sam,");
-  });
-
-  it("renders both onboarding steps and all three resources (table, no imagery)", () => {
-    tagAc(AC(12)); // renders via the spec-226 step/resources primitives
-    expect(html).toContain("// Step 1");
-    expect(html).toContain("Connect to the Memex MCP");
-    expect(html).toContain("// Step 2");
-    expect(html).toContain("Create your first Spec");
-    expect(html).toContain("Understanding Memex AI");
-    expect(html).toContain("Documentation");
-    expect(html).toContain("Community");
-    expect(html).not.toContain("<img");
-  });
-
-  it("includes the post-CTA prose + sign-off, and suppresses the paste-link", () => {
-    // apostrophe is HTML-escaped in the body, so match an apostrophe-free substring
-    expect(html).toContain("send you a few short emails");
-    // spec-451 ac-5 — sign-off now renders on two lines.
-    expect(html).toContain("Best,<br>The Memex AI team");
-    expect(html).not.toContain("Or paste this link");
-  });
-
-  it("renders no empty eyebrow block (welcome leads with the H1)", () => {
-    expect(html).not.toContain("letter-spacing:0.14em");
-  });
-
-  it("is logged under the stable `welcome` comms key as the day-0 touch (dec-7/dec-4)", () => {
-    tagAc(AC(5)); // recorded as the day-0 touch
-    tagAc(AC(9)); // the welcome's contribution to the day-0 ↔ drip coordination
     expect(msg.commsType).toBe("welcome");
   });
 
-  it("degrades to a nameless greeting when no first name is given", () => {
+  it("renders the v2 pitch body: the two-point fixes-both list and the To-start bullets", () => {
+    tagAc(AC(1));
+    expect(html).toContain("Memex fixes both");
+    expect(html).toContain("Your docs become living specs");
+    expect(html).toContain("Each spec then speeds up the next");
+    expect(html).toContain("To start");
+    expect(html).toContain("Connect your agent over MCP");
+    expect(html).toContain("Create your first spec");
+  });
+
+  it("drops the Option-3 resources block, the '// Step N' blocks, and the 'few short emails' line", () => {
+    tagAc(AC(1));
+    expect(html).not.toContain("Understanding Memex AI");
+    expect(html).not.toContain("// Step 1");
+    // apostrophe is HTML-escaped in the body, so match an apostrophe-free substring
+    expect(html).not.toContain("send you a few short emails");
+  });
+
+  it("leads with the greeting — no repeated H1 headline (ac-4)", () => {
     tagAc(AC(4));
+    expect(html).not.toContain("<h1");
+    // the "Memex AI" wordmark div is separate from the h1 and still renders
+    expect(html).toContain(">Memex AI</div>");
+  });
+
+  it("personalises the greeting and degrades to a nameless greeting (ac-5)", () => {
+    tagAc(AC(5));
+    expect(html).toContain("Hi Sam,");
     const nameless = buildWelcomeEmail({ to: "x@y.com", appUrl: "https://int.memex.ai" }).html ?? "";
     expect(nameless).toContain("Hi there,");
     expect(nameless).not.toContain("Hi ,");
+  });
+
+  it("renders through the shared renderer under Postmark constraints (doctype, table, solid CTA) (ac-4)", () => {
+    tagAc(AC(4));
+    expect(html).toContain("<!doctype html>");
+    expect(html).toContain('role="presentation"');
+    expect(html).toContain("background:#0482DC;color:#FFFFFF");
+    expect(html).not.toContain("linear-gradient");
+    // two-line sign-off carried over from spec-451
+    expect(html).toContain("Best,<br>The Memex AI team");
+  });
+
+  it("carries the v2 copy in the plain-text body too, not the old Option-3 copy (ac-1)", () => {
+    tagAc(AC(1));
+    expect(text).toContain("frontier teams build on Memex");
+    expect(text).toContain("Create your first spec");
+    expect(text).not.toContain("Build what you decided");
+    expect(text).not.toContain("Understanding Memex AI");
+  });
+});
+
+describe("buildWelcomeEmail (v2) — clickable video thumbnail (spec-488 t-2)", () => {
+  const msg = buildWelcomeEmail({
+    to: "new@example.com",
+    appUrl: "https://int.memex.ai",
+    firstName: "Sam",
+  });
+  const html = msg.html ?? "";
+  const text = msg.text ?? "";
+
+  it("contains a clickable thumbnail that opens the hosted explainer video (ac-2)", () => {
+    tagAc(AC(2));
+    // walkthrough intro line ("Here's" is HTML-escaped → match apostrophe-free)
+    expect(html).toContain("short animated walkthrough");
+    // an <a> to the hosted mp4 wraps an <img> thumbnail
+    expect(html).toMatch(
+      /<a href="[^"]*email-explainer-60s\.mp4\?[^"]*utm_campaign=welcome[^"]*"[^>]*>\s*<img/,
+    );
+    // welcome-specific click attribution (spec-480 dec-6)
+    expect(html).toContain("utm_campaign=welcome");
+    expect(msg.trackLinks).toBe(true);
+  });
+
+  it("reuses spec-480's shared hosted-video + thumbnail assets, not a welcome-only fork (ac-7)", () => {
+    tagAc(AC(7));
+    // the shared `email-*` objects spec-480 established — a fork would use other URLs
+    expect(html).toContain(EMAIL_EXPLAINER_VIDEO_URL);
+    expect(html).toContain(`src="${EMAIL_VIDEO_THUMB_1X_URL}"`);
+    expect(html).toContain(`srcset="${EMAIL_VIDEO_THUMB_2X_URL} 2x"`);
+  });
+
+  it("degrades gracefully when images are blocked — alt text + a visible text link (ac-3)", () => {
+    tagAc(AC(3));
+    // the thumbnail img carries alt text (never a blank image)
+    expect(html).toContain(`alt="Watch: ${EMAIL_VIDEO_TITLE}"`);
+    // the image-blocked fallback: a visible text line linking the same video
+    expect(html).toContain("Can't see the video above?");
+    expect(html).toContain(">Watch it here</a>");
+    // the plain-text body always carries the video URL, so it is never unreachable
+    expect(text).toContain(EMAIL_EXPLAINER_VIDEO_URL);
+    expect(text).toContain("utm_campaign=welcome");
   });
 });

--- a/packages/server/src/services/email/winback.test.ts
+++ b/packages/server/src/services/email/winback.test.ts
@@ -1,0 +1,170 @@
+// spec-480 t-2 — the single-segment win-back email builder. PURE RENDER: no
+// cohort/timing/send/env logic (that's t-3). Asserts the clickable video
+// thumbnail + fallback + single "Connect your agent" CTA on the rendered output.
+//   ac-8  — hosted, table-safe <img> referenced by public https URL (dec-2)
+//   ac-9  — 480 default src + 960 srcset 2x, single baked poster image (dec-3)
+//   ac-10 — alt "Watch: {title}" + whole thumbnail clickable + visible fallback (dec-4)
+//   ac-14 — one segment: fixed stall-line, one "Connect your agent" CTA (dec-9)
+//   ac-15 — links the raw mp4 directly (no wrapper page / app route) (dec-5)
+//   ac-1  — the block reads as a playable video thumbnail (scope)
+import { describe, it, expect } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import {
+  buildWinbackEmail,
+  EMAIL_EXPLAINER_VIDEO_URL,
+  EMAIL_VIDEO_THUMB_1X_URL,
+  EMAIL_VIDEO_THUMB_2X_URL,
+  EMAIL_VIDEO_TITLE,
+} from "./templates.js";
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-480/acs/ac-${n}`;
+
+const CONNECT_URL = "https://www.memex.ai/download?src=winback-email";
+
+const msg = buildWinbackEmail({
+  to: "user@example.com",
+  firstName: "Ada",
+  connectUrl: CONNECT_URL,
+});
+const html = msg.html ?? "";
+const text = msg.text ?? "";
+
+// The video href the template emits (base asset URL + this email's UTM, dec-6).
+const videoHref = `${EMAIL_EXPLAINER_VIDEO_URL}?utm_source=lifecycle&utm_medium=email&utm_campaign=winback`;
+// In HTML attributes the ampersands are correctly escaped to &amp; (the plain-text
+// body keeps the raw URL).
+const videoHrefHtml = videoHref.replace(/&/g, "&amp;");
+
+describe("buildWinbackEmail — the clickable video thumbnail (ac-1/ac-8/ac-9)", () => {
+  it("renders exactly ONE image — the thumbnail — the rest stays image-free", () => {
+    tagAc(AC(1));
+    const imgCount = (html.match(/<img/g) ?? []).length;
+    expect(imgCount).toBe(1);
+  });
+
+  it("references the thumbnail via a hosted, table-safe https <img> (ac-8)", () => {
+    tagAc(AC(8));
+    // hosted public URL, not a cid: attachment
+    expect(html).toContain(`src="${EMAIL_VIDEO_THUMB_1X_URL}"`);
+    expect(html).not.toContain("cid:");
+    // bulletproof: explicit dimensions, display:block, border:0 (kills Outlook's link border)
+    expect(html).toContain('width="480"');
+    expect(html).toContain('height="269"');
+    expect(html).toContain("display:block");
+    expect(html).toContain("border:0");
+  });
+
+  it("serves 480 as the default src and 960 as the 2x srcset candidate (ac-9)", () => {
+    tagAc(AC(9));
+    expect(html).toContain(`src="${EMAIL_VIDEO_THUMB_1X_URL}"`);
+    expect(html).toContain(`srcset="${EMAIL_VIDEO_THUMB_2X_URL} 2x"`);
+  });
+});
+
+describe("buildWinbackEmail — alt text, clickable block, image-blocked fallback (ac-10)", () => {
+  it("gives the thumbnail meaningful alt text of the form 'Watch: {title}'", () => {
+    tagAc(AC(10));
+    expect(html).toContain(`alt="Watch: ${EMAIL_VIDEO_TITLE}"`);
+  });
+
+  it("wraps the whole thumbnail in an anchor to the video (clickable even before load)", () => {
+    tagAc(AC(10));
+    expect(html).toContain(`<a href="${videoHrefHtml}" style="display:block`);
+  });
+
+  it("renders a visible fallback line linking the same video when images are blocked", () => {
+    tagAc(AC(10));
+    tagAc(AC(4)); // scope: the video is never unreachable when images are blocked
+    expect(html).toContain("Can't see the video above?");
+    expect(html).toContain(`>Watch it here</a>`);
+    // the fallback link targets the same video URL
+    expect(html).toContain(`<a href="${videoHrefHtml}" style="color:#0482DC`);
+    // plain-text body also carries the video URL so it's reachable there too
+    expect(text).toContain(videoHref);
+  });
+});
+
+describe("buildWinbackEmail — single segment, single CTA (ac-14)", () => {
+  it("uses the one fixed stall-line for the signed_in_dormant segment", () => {
+    tagAc(AC(14));
+    // apostrophe-free substring (html escapes apostrophes)
+    expect(html).toContain("never connected your agent or created a spec");
+  });
+
+  it("has exactly one CTA button — 'Connect your agent' — never 'Create a spec'", () => {
+    tagAc(AC(14));
+    // one coral CTA button
+    const ctaCount = (html.match(/background:#0482DC;color:#FFFFFF/g) ?? []).length;
+    expect(ctaCount).toBe(1);
+    expect(html).toContain(">Connect your agent</a>");
+    expect(html).not.toContain(">Create a spec</a>");
+    // the CTA deep-links the passed connect URL, not a hardcoded host (std-2/dec-8)
+    expect(html).toContain(`href="${CONNECT_URL}"`);
+    expect(text).toContain(CONNECT_URL);
+  });
+
+  it("stamps the single stable comms key (dec-8) and the s-2 subject", () => {
+    tagAc(AC(14));
+    expect(msg.commsType).toBe("activation.signed_in_dormant");
+    expect(msg.subject).toBe("You signed up, then vanished");
+  });
+});
+
+describe("buildWinbackEmail — links the raw mp4 directly, no wrapper (ac-15)", () => {
+  it("the thumbnail + fallback target the raw public mp4, not an app/wrapper route", () => {
+    tagAc(AC(15));
+    // raw GCS mp4 object (Superhuman-style), no intermediary memex.ai app path
+    expect(videoHref).toContain(
+      "storage.googleapis.com/memex-ai-prod-app-static/media/email-explainer-60s.mp4",
+    );
+    expect(html).toContain(`href="${videoHrefHtml}"`);
+    // the video link is NOT a tenant/app route
+    expect(videoHref).not.toContain("/specs");
+  });
+});
+
+describe("buildWinbackEmail — click attribution (ac-11)", () => {
+  it("enables Postmark click tracking and carries win-back UTM on the video link", () => {
+    tagAc(AC(11));
+    tagAc(AC(6)); // scope: a thumbnail click is attributable
+    // Postmark rewrites the link → a click fires a webhook event (comms_log). The UTM
+    // labels the tracked URL as the winback campaign (vs the welcome reuse of the asset).
+    expect(msg.trackLinks).toBe(true);
+    expect(html).toContain("utm_source=lifecycle");
+    expect(html).toContain("utm_campaign=winback");
+  });
+});
+
+describe("buildWinbackEmail — stable public video asset (ac-2/ac-3/ac-7)", () => {
+  it("links a raw public GCS bucket mp4 — stable, permanent, no login, not a Drive share", () => {
+    tagAc(AC(7)); // served from the stable public bucket URL, never a Drive link
+    tagAc(AC(3)); // stable/permanent: no signed-URL token, no expiry, query-free base
+    tagAc(AC(2)); // click target is the public asset (no login/app route) — verified 200 + streamable in t-1
+    expect(EMAIL_EXPLAINER_VIDEO_URL).toContain(
+      "storage.googleapis.com/memex-ai-prod-app-static/media/",
+    );
+    expect(EMAIL_EXPLAINER_VIDEO_URL).toMatch(/\.mp4$/);
+    expect(EMAIL_EXPLAINER_VIDEO_URL).not.toContain("drive.google.com");
+    // permanent: no signed-URL / expiry markers, and the base asset URL is query-free
+    // (the per-send UTM is appended downstream, not baked into the stored object URL).
+    expect(EMAIL_EXPLAINER_VIDEO_URL).not.toContain("X-Goog-Signature");
+    expect(EMAIL_EXPLAINER_VIDEO_URL).not.toContain("Expires=");
+    expect(EMAIL_EXPLAINER_VIDEO_URL).not.toContain("?");
+    // no login/app gate between the click and the file
+    expect(videoHref).not.toContain("/login");
+    expect(videoHref).not.toContain("/auth");
+    expect(videoHref).not.toContain("/specs");
+  });
+});
+
+describe("buildWinbackEmail — greeting personalisation (ac-1)", () => {
+  it("interpolates the first name, degrades to 'Hi there,' with no name", () => {
+    tagAc(AC(1));
+    expect(html).toContain("Hey Ada,");
+    const nameless =
+      buildWinbackEmail({ to: "a@b.test", connectUrl: CONNECT_URL }).html ?? "";
+    expect(nameless).toContain("Hi there,");
+    expect(nameless).not.toContain("[FirstName]");
+    expect(nameless).not.toContain("Hey ,");
+  });
+});

--- a/packages/server/src/services/email/winback.test.ts
+++ b/packages/server/src/services/email/winback.test.ts
@@ -1,53 +1,40 @@
-// spec-480 t-2 — the single-segment win-back email builder. PURE RENDER: no
-// cohort/timing/send/env logic (that's t-3). Asserts the clickable video
-// thumbnail + fallback + single "Connect your agent" CTA on the rendered output.
-//   ac-8  — hosted, table-safe <img> referenced by public https URL (dec-2)
-//   ac-9  — 480 default src + 960 srcset 2x, single baked poster image (dec-3)
-//   ac-10 — alt "Watch: {title}" + whole thumbnail clickable + visible fallback (dec-4)
-//   ac-14 — one segment: fixed stall-line, one "Connect your agent" CTA (dec-9)
-//   ac-15 — links the raw mp4 directly (no wrapper page / app route) (dec-5)
-//   ac-1  — the block reads as a playable video thumbnail (scope)
+// spec-480 t-2 + spec-487 t-3 — the single-segment win-back email builder. PURE RENDER.
+// spec-480 owns the clickable-thumbnail MECHANISM + the signed_in_dormant send-path
+// keying (still holds); spec-487 swapped the VIDEO (explainer → the "connect the MCP +
+// create a spec" how-to) and the COPY (s-3), coordinated with spec-480 (dec-5).
+//   spec-480 ac-8/9/10/15/2/3/11/14 — the thumbnail mechanism + send-path keying
+//   spec-487 ac-10 — the s-3 copy · ac-8 — one poster + fallback, no Watch button
+//   spec-487 ac-9  — send path unchanged (commsType, CTA) · ac-7 — hosted how-to mp4
 import { describe, it, expect } from "vitest";
 import { tagAc } from "@memex-ai-ac/vitest";
-import {
-  buildWinbackEmail,
-  EMAIL_EXPLAINER_VIDEO_URL,
-  EMAIL_VIDEO_THUMB_1X_URL,
-  EMAIL_VIDEO_THUMB_2X_URL,
-  EMAIL_VIDEO_TITLE,
-} from "./templates.js";
+import { buildWinbackEmail, EMAIL_HOWTO_CONNECT_MCP } from "./templates.js";
 
 const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-480/acs/ac-${n}`;
+const AC487 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-487/acs/ac-${n}`;
 
 const CONNECT_URL = "https://www.memex.ai/download?src=winback-email";
 
-const msg = buildWinbackEmail({
-  to: "user@example.com",
-  firstName: "Ada",
-  connectUrl: CONNECT_URL,
-});
+const msg = buildWinbackEmail({ to: "user@example.com", firstName: "Ada", connectUrl: CONNECT_URL });
 const html = msg.html ?? "";
 const text = msg.text ?? "";
 
-// The video href the template emits (base asset URL + this email's UTM, dec-6).
-const videoHref = `${EMAIL_EXPLAINER_VIDEO_URL}?utm_source=lifecycle&utm_medium=email&utm_campaign=winback`;
-// In HTML attributes the ampersands are correctly escaped to &amp; (the plain-text
-// body keeps the raw URL).
+// The video href the template emits: the how-to asset (spec-487) + this email's UTM.
+const videoHref = `${EMAIL_HOWTO_CONNECT_MCP.videoUrl}?utm_source=lifecycle&utm_medium=email&utm_campaign=winback`;
+// In HTML attributes the ampersands are escaped to &amp; (plain-text keeps the raw URL).
 const videoHrefHtml = videoHref.replace(/&/g, "&amp;");
 
-describe("buildWinbackEmail — the clickable video thumbnail (ac-1/ac-8/ac-9)", () => {
-  it("renders exactly ONE image — the thumbnail — the rest stays image-free", () => {
+describe("buildWinbackEmail — the clickable video thumbnail (spec-480 mechanism, spec-487 ac-8)", () => {
+  it("renders exactly ONE image — the how-to thumbnail — no separate Watch button", () => {
     tagAc(AC(1));
-    const imgCount = (html.match(/<img/g) ?? []).length;
-    expect(imgCount).toBe(1);
+    tagAc(AC487(8));
+    expect((html.match(/<img/g) ?? []).length).toBe(1);
+    expect(html).not.toContain("Watch the 3-min guide");
   });
 
   it("references the thumbnail via a hosted, table-safe https <img> (ac-8)", () => {
     tagAc(AC(8));
-    // hosted public URL, not a cid: attachment
-    expect(html).toContain(`src="${EMAIL_VIDEO_THUMB_1X_URL}"`);
+    expect(html).toContain(`src="${EMAIL_HOWTO_CONNECT_MCP.thumb1xUrl}"`);
     expect(html).not.toContain("cid:");
-    // bulletproof: explicit dimensions, display:block, border:0 (kills Outlook's link border)
     expect(html).toContain('width="480"');
     expect(html).toContain('height="269"');
     expect(html).toContain("display:block");
@@ -56,15 +43,16 @@ describe("buildWinbackEmail — the clickable video thumbnail (ac-1/ac-8/ac-9)",
 
   it("serves 480 as the default src and 960 as the 2x srcset candidate (ac-9)", () => {
     tagAc(AC(9));
-    expect(html).toContain(`src="${EMAIL_VIDEO_THUMB_1X_URL}"`);
-    expect(html).toContain(`srcset="${EMAIL_VIDEO_THUMB_2X_URL} 2x"`);
+    expect(html).toContain(`src="${EMAIL_HOWTO_CONNECT_MCP.thumb1xUrl}"`);
+    expect(html).toContain(`srcset="${EMAIL_HOWTO_CONNECT_MCP.thumb2xUrl} 2x"`);
   });
 });
 
 describe("buildWinbackEmail — alt text, clickable block, image-blocked fallback (ac-10)", () => {
-  it("gives the thumbnail meaningful alt text of the form 'Watch: {title}'", () => {
+  it("gives the thumbnail meaningful alt text describing the how-to video", () => {
     tagAc(AC(10));
-    expect(html).toContain(`alt="Watch: ${EMAIL_VIDEO_TITLE}"`);
+    tagAc(AC487(8));
+    expect(html).toContain(`alt="Watch: how to connect the MCP and create a spec"`);
   });
 
   it("wraps the whole thumbnail in an anchor to the video (clickable even before load)", () => {
@@ -77,23 +65,25 @@ describe("buildWinbackEmail — alt text, clickable block, image-blocked fallbac
     tagAc(AC(4)); // scope: the video is never unreachable when images are blocked
     expect(html).toContain("Can't see the video above?");
     expect(html).toContain(`>Watch it here</a>`);
-    // the fallback link targets the same video URL
     expect(html).toContain(`<a href="${videoHrefHtml}" style="color:#0482DC`);
-    // plain-text body also carries the video URL so it's reachable there too
     expect(text).toContain(videoHref);
   });
 });
 
-describe("buildWinbackEmail — single segment, single CTA (ac-14)", () => {
-  it("uses the one fixed stall-line for the signed_in_dormant segment", () => {
-    tagAc(AC(14));
-    // apostrophe-free substring (html escapes apostrophes)
-    expect(html).toContain("never connected your agent or created a spec");
+describe("buildWinbackEmail — s-3 copy, single CTA, send path (spec-487 ac-9/ac-10)", () => {
+  it("renders the s-3 copy — subject + a key body line; old s-2 win-back copy gone", () => {
+    tagAc(AC487(10));
+    expect(msg.subject).toBe("Ground your specs in your actual codebase");
+    // key s-3 line (no apostrophes → literal in both html and text)
+    expect(html).toContain("Memex never touches your repo, but your coding agent does");
+    expect(text).toContain("Memex never touches your repo, but your coding agent does");
+    // old s-2 win-back copy is gone
+    expect(html).not.toContain("You signed up to Memex, then disappeared");
   });
 
-  it("has exactly one CTA button — 'Connect your agent' — never 'Create a spec'", () => {
+  it("keeps the send path: exactly one 'Connect your agent' CTA, never 'Create a spec' (ac-14, spec-487 ac-9)", () => {
     tagAc(AC(14));
-    // one coral CTA button
+    tagAc(AC487(9));
     const ctaCount = (html.match(/background:#0482DC;color:#FFFFFF/g) ?? []).length;
     expect(ctaCount).toBe(1);
     expect(html).toContain(">Connect your agent</a>");
@@ -103,23 +93,23 @@ describe("buildWinbackEmail — single segment, single CTA (ac-14)", () => {
     expect(text).toContain(CONNECT_URL);
   });
 
-  it("stamps the single stable comms key (dec-8) and the s-2 subject", () => {
-    tagAc(AC(14));
+  it("stamps the stable signed_in_dormant comms key + trackLinks, unchanged (spec-487 ac-9)", () => {
+    tagAc(AC487(9));
     expect(msg.commsType).toBe("activation.signed_in_dormant");
-    expect(msg.subject).toBe("You signed up, then vanished");
+    expect(msg.trackLinks).toBe(true);
   });
 });
 
-describe("buildWinbackEmail — links the raw mp4 directly, no wrapper (ac-15)", () => {
-  it("the thumbnail + fallback target the raw public mp4, not an app/wrapper route", () => {
+describe("buildWinbackEmail — links the raw how-to mp4 directly, no wrapper (ac-15, spec-487 ac-7)", () => {
+  it("the thumbnail + fallback target the raw public how-to mp4, not an app/wrapper route", () => {
     tagAc(AC(15));
-    // raw GCS mp4 object (Superhuman-style), no intermediary memex.ai app path
+    tagAc(AC487(7));
     expect(videoHref).toContain(
-      "storage.googleapis.com/memex-ai-prod-app-static/media/email-explainer-60s.mp4",
+      "storage.googleapis.com/memex-ai-prod-app-static/media/email-howto-connect-mcp.mp4",
     );
     expect(html).toContain(`href="${videoHrefHtml}"`);
-    // the video link is NOT a tenant/app route
     expect(videoHref).not.toContain("/specs");
+    expect(videoHref).not.toContain("drive.google.com");
   });
 });
 
@@ -127,30 +117,24 @@ describe("buildWinbackEmail — click attribution (ac-11)", () => {
   it("enables Postmark click tracking and carries win-back UTM on the video link", () => {
     tagAc(AC(11));
     tagAc(AC(6)); // scope: a thumbnail click is attributable
-    // Postmark rewrites the link → a click fires a webhook event (comms_log). The UTM
-    // labels the tracked URL as the winback campaign (vs the welcome reuse of the asset).
     expect(msg.trackLinks).toBe(true);
     expect(html).toContain("utm_source=lifecycle");
     expect(html).toContain("utm_campaign=winback");
   });
 });
 
-describe("buildWinbackEmail — stable public video asset (ac-2/ac-3/ac-7)", () => {
+describe("buildWinbackEmail — stable public video asset (spec-480 ac-2/ac-3/ac-7)", () => {
   it("links a raw public GCS bucket mp4 — stable, permanent, no login, not a Drive share", () => {
-    tagAc(AC(7)); // served from the stable public bucket URL, never a Drive link
-    tagAc(AC(3)); // stable/permanent: no signed-URL token, no expiry, query-free base
-    tagAc(AC(2)); // click target is the public asset (no login/app route) — verified 200 + streamable in t-1
-    expect(EMAIL_EXPLAINER_VIDEO_URL).toContain(
-      "storage.googleapis.com/memex-ai-prod-app-static/media/",
-    );
-    expect(EMAIL_EXPLAINER_VIDEO_URL).toMatch(/\.mp4$/);
-    expect(EMAIL_EXPLAINER_VIDEO_URL).not.toContain("drive.google.com");
-    // permanent: no signed-URL / expiry markers, and the base asset URL is query-free
-    // (the per-send UTM is appended downstream, not baked into the stored object URL).
-    expect(EMAIL_EXPLAINER_VIDEO_URL).not.toContain("X-Goog-Signature");
-    expect(EMAIL_EXPLAINER_VIDEO_URL).not.toContain("Expires=");
-    expect(EMAIL_EXPLAINER_VIDEO_URL).not.toContain("?");
-    // no login/app gate between the click and the file
+    tagAc(AC(7));
+    tagAc(AC(3));
+    tagAc(AC(2));
+    const base = EMAIL_HOWTO_CONNECT_MCP.videoUrl;
+    expect(base).toContain("storage.googleapis.com/memex-ai-prod-app-static/media/");
+    expect(base).toMatch(/\.mp4$/);
+    expect(base).not.toContain("drive.google.com");
+    expect(base).not.toContain("X-Goog-Signature");
+    expect(base).not.toContain("Expires=");
+    expect(base).not.toContain("?");
     expect(videoHref).not.toContain("/login");
     expect(videoHref).not.toContain("/auth");
     expect(videoHref).not.toContain("/specs");
@@ -160,11 +144,10 @@ describe("buildWinbackEmail — stable public video asset (ac-2/ac-3/ac-7)", () 
 describe("buildWinbackEmail — greeting personalisation (ac-1)", () => {
   it("interpolates the first name, degrades to 'Hi there,' with no name", () => {
     tagAc(AC(1));
-    expect(html).toContain("Hey Ada,");
-    const nameless =
-      buildWinbackEmail({ to: "a@b.test", connectUrl: CONNECT_URL }).html ?? "";
+    expect(html).toContain("Hi Ada,");
+    const nameless = buildWinbackEmail({ to: "a@b.test", connectUrl: CONNECT_URL }).html ?? "";
     expect(nameless).toContain("Hi there,");
     expect(nameless).not.toContain("[FirstName]");
-    expect(nameless).not.toContain("Hey ,");
+    expect(nameless).not.toContain("Hi ,");
   });
 });

--- a/packages/server/src/services/namespaces.rename-redirect.spec-481.integration.test.ts
+++ b/packages/server/src/services/namespaces.rename-redirect.spec-481.integration.test.ts
@@ -1,0 +1,96 @@
+// spec-481 t-1 — renameNamespaceSlug writes a namespace_rename redirect so old
+// namespace URLs forward (ac-3), and isSlugAvailable rejects a slug that is the
+// source of a live redirect (D-2 reuse-guard, ac-5).
+//
+// Per-worker-unique slugs (std-37); redirect + reservation rows created here are
+// swept afterEach (std-39 hygiene).
+
+import { describe, it, expect, afterEach } from "vitest";
+import { sql } from "drizzle-orm";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { db } from "../db/connection.js";
+import { namespaces, memexes, users } from "../db/schema.js";
+import { renameNamespaceSlug } from "./namespaces.js";
+import { isSlugAvailable } from "./shared/slug.js";
+import { insertRedirect, lookupRedirect } from "./redirects.js";
+
+const AC_481_REDIRECT =
+  "mindset-prod/memex-building-itself/specs/spec-481/acs/ac-3";
+const AC_481_GUARD =
+  "mindset-prod/memex-building-itself/specs/spec-481/acs/ac-5";
+
+function stem(): string {
+  return `s481${Math.random().toString(36).slice(2, 8)}`;
+}
+
+const slugsToClean: string[] = [];
+afterEach(async () => {
+  while (slugsToClean.length) {
+    const s = slugsToClean.pop()!;
+    await db
+      .execute(
+        sql`DELETE FROM redirects WHERE old_path LIKE ${s + "%"} OR new_path LIKE ${s + "%"}`,
+      )
+      .catch(() => {});
+    await db
+      .execute(sql`DELETE FROM namespace_slug_reservations WHERE slug LIKE ${s + "%"}`)
+      .catch(() => {});
+  }
+});
+
+// Seed a personal (user-kind) namespace + one memex; returns the ids + slug.
+async function seedUserNamespace(oldSlug: string) {
+  const [user] = await db
+    .insert(users)
+    .values({ email: `${oldSlug}@example.com` } as typeof users.$inferInsert)
+    .returning();
+  const [ns] = await db
+    .insert(namespaces)
+    .values({ slug: oldSlug, kind: "user", ownerUserId: user.id })
+    .returning();
+  await db
+    .insert(memexes)
+    .values({ namespaceId: ns.id, slug: "main", name: "Main" })
+    .returning();
+  return { userId: user.id, namespaceId: ns.id };
+}
+
+describe("renameNamespaceSlug redirect + reuse-guard (spec-481 t-1)", () => {
+  it("writes a namespace_rename redirect so a stale namespace path forwards", async () => {
+    tagAc(AC_481_REDIRECT);
+    const base = stem();
+    const oldSlug = `${base}o`;
+    const newSlug = `${base}n`;
+    slugsToClean.push(base);
+    const { userId, namespaceId } = await seedUserNamespace(oldSlug);
+
+    await renameNamespaceSlug({ namespaceId, newSlug, userId });
+
+    const ns = await db.query.namespaces.findFirst({
+      where: (n, { eq }) => eq(n.id, namespaceId),
+      columns: { slug: true },
+    });
+    expect(ns?.slug).toBe(newSlug);
+
+    // A deep path under the old namespace forwards to the new one.
+    const result = await lookupRedirect(`${oldSlug}/main/specs/spec-1/tasks/t-1`);
+    expect(result).toEqual({
+      redirected: `${newSlug}/main/specs/spec-1/tasks/t-1`,
+    });
+  });
+
+  it("isSlugAvailable rejects a slug that is the source of a live redirect", async () => {
+    tagAc(AC_481_GUARD);
+    const base = stem();
+    const orphan = `${base}src`; // never reserved — only a redirect source
+    slugsToClean.push(base);
+
+    // Available before any redirect exists.
+    expect(await isSlugAvailable(orphan)).toBe(true);
+
+    await insertRedirect(orphan, `${base}dst`, "namespace_rename");
+
+    // Now unavailable purely because it is a redirect source (no reservation).
+    expect(await isSlugAvailable(orphan)).toBe(false);
+  });
+});

--- a/packages/server/src/services/namespaces.rename-redirect.spec-481.integration.test.ts
+++ b/packages/server/src/services/namespaces.rename-redirect.spec-481.integration.test.ts
@@ -93,4 +93,33 @@ describe("renameNamespaceSlug redirect + reuse-guard (spec-481 t-1)", () => {
     // Now unavailable purely because it is a redirect source (no reservation).
     expect(await isSlugAvailable(orphan)).toBe(false);
   });
+
+  // issue-1 — the guard above must ALSO fire on the mutation path, not just the
+  // isolated helper. A raw PATCH /api/namespaces/:id/slug that targets a live
+  // redirect source (once its 30-day reservation lapses) would let a reborn
+  // namespace shadow the permanent redirect (std-10 cl-91/97) and mis-route
+  // every old link. `orphan` is a redirect source that was NEVER a namespace
+  // and holds NO reservation, so it isolates the redirect-source guard from the
+  // reservation/taken checks — exactly the D-2 hole.
+  it("renameNamespaceSlug refuses to rename TO a live redirect source", async () => {
+    tagAc(AC_481_GUARD);
+    const base = stem();
+    const cSlug = `${base}c`;
+    const orphan = `${base}src`; // redirect source, never a namespace or reservation
+    slugsToClean.push(base);
+    const { userId, namespaceId } = await seedUserNamespace(cSlug);
+
+    await insertRedirect(orphan, `${base}dst`, "namespace_rename");
+
+    await expect(
+      renameNamespaceSlug({ namespaceId, newSlug: orphan, userId }),
+    ).rejects.toThrow(/redirect/i);
+
+    // And the namespace slug is unchanged — the tx rolled back.
+    const ns = await db.query.namespaces.findFirst({
+      where: (n, { eq }) => eq(n.id, namespaceId),
+      columns: { slug: true },
+    });
+    expect(ns?.slug).toBe(cSlug);
+  });
 });

--- a/packages/server/src/services/namespaces.ts
+++ b/packages/server/src/services/namespaces.ts
@@ -17,7 +17,7 @@ import {
 } from "../db/schema.js";
 import type { Namespace } from "../db/schema.js";
 import { validateSlugFormat } from "./shared/slug.js";
-import { insertRedirect } from "./redirects.js";
+import { insertRedirect, isRedirectSource } from "./redirects.js";
 import { ConflictError, ValidationError } from "../types/errors.js";
 import { mutate, type Mutated } from "./mutate.js";
 
@@ -216,6 +216,19 @@ export async function renameNamespaceSlug(input: RenameSlugRequest): Promise<Mut
       const taken = await tx.query.namespaces.findFirst({ where: eq(namespaces.slug, newSlug) });
       if (taken) {
         throw new ConflictError(`Slug '${newSlug}' is already taken`);
+      }
+
+      // spec-481 D-2 / issue-1: reject a slug that is the SOURCE of a live
+      // redirect, even once its 30-day reservation has lapsed. Redirects never
+      // expire (std-10 cl-97), so a reborn namespace on this slug would shadow
+      // the permanent redirect under direct-first resolution (std-10 cl-91) and
+      // silently mis-route every old link. The isolated isSlugAvailable guard
+      // isn't on this mutation path (raw PATCH bypasses it), so enforce it here
+      // inside the tx alongside the reservation/taken checks.
+      if (await isRedirectSource(newSlug, tx)) {
+        throw new ConflictError(
+          `Slug '${newSlug}' was used before and is reserved by a redirect`,
+        );
       }
 
       // Reserve the OLD slug for 30 days post-rename.

--- a/packages/server/src/services/namespaces.ts
+++ b/packages/server/src/services/namespaces.ts
@@ -19,7 +19,7 @@ import type { Namespace } from "../db/schema.js";
 import { validateSlugFormat } from "./shared/slug.js";
 import { insertRedirect, isRedirectSource } from "./redirects.js";
 import { ConflictError, ValidationError } from "../types/errors.js";
-import { mutate, type Mutated } from "./mutate.js";
+import { mutate, type Mutated, type RequestCtx } from "./mutate.js";
 
 export async function getNamespaceBySlug(slug: string): Promise<Namespace | undefined> {
   return db.query.namespaces.findFirst({
@@ -144,7 +144,10 @@ export interface RenameSlugRequest {
 const SLUG_COOLDOWN_DAYS = 30;
 const SLUG_RESERVATION_DAYS = 30;
 
-export async function renameNamespaceSlug(input: RenameSlugRequest): Promise<Mutated<Namespace>> {
+export async function renameNamespaceSlug(
+  input: RenameSlugRequest,
+  ctx: RequestCtx = {},
+): Promise<Mutated<Namespace>> {
   const newSlug = input.newSlug.trim().toLowerCase();
 
   const format = validateSlugFormat(newSlug);
@@ -165,7 +168,10 @@ export async function renameNamespaceSlug(input: RenameSlugRequest): Promise<Mut
   const memexId = memexRow?.id ?? "";
 
   return mutate(
-    {},
+    // Thread the caller's channel/identity so the mutation isn't a channel-less
+    // "attribution defect" on the activity bus (std-32). The route passes
+    // channel:'rest_ui', mirroring the memex-rename sibling (spec-479).
+    ctx,
     { memexId, entity: "user_namespace", action: "updated" },
     () => db.transaction(async (tx) => {
       const ns = await tx.query.namespaces.findFirst({

--- a/packages/server/src/services/namespaces.ts
+++ b/packages/server/src/services/namespaces.ts
@@ -17,6 +17,7 @@ import {
 } from "../db/schema.js";
 import type { Namespace } from "../db/schema.js";
 import { validateSlugFormat } from "./shared/slug.js";
+import { insertRedirect } from "./redirects.js";
 import { ConflictError, ValidationError } from "../types/errors.js";
 import { mutate, type Mutated } from "./mutate.js";
 
@@ -237,6 +238,13 @@ export async function renameNamespaceSlug(input: RenameSlugRequest): Promise<Mut
         .set({ slug: newSlug, slugChangedAt: new Date() })
         .where(eq(namespaces.id, ns.id))
         .returning();
+
+      // spec-481 — record the namespace_rename redirect in the SAME transaction
+      // so old `/<old-ns>/...` URLs + MCP refs forward instead of 404ing
+      // (std-10 §7). insertRedirect accepts the 1-segment prefix + a tx executor
+      // (spec-479 D-1); the resolver prefix-matches so every descendant path is
+      // covered by this one row.
+      await insertRedirect(ns.slug, newSlug, "namespace_rename", tx);
 
       return updated;
     }),

--- a/packages/server/src/services/redirects.ts
+++ b/packages/server/src/services/redirects.ts
@@ -278,8 +278,14 @@ export async function insertRedirect(
 // resolution (std-10 cl-91) would let the new entity shadow the redirect and
 // silently mis-route every old link to the wrong place. Callers consult this
 // before (re)registering a slug. old_path is the PK, so this is an index hit.
-export async function isRedirectSource(path: string): Promise<boolean> {
-  const rows = (await db.execute(sql`
+// Accepts an optional `executor` (mirrors insertRedirect) so a rename can run
+// the guard inside its own transaction, consistent with the reservation/taken
+// checks it sits beside.
+export async function isRedirectSource(
+  path: string,
+  executor: SqlExecutor = db
+): Promise<boolean> {
+  const rows = (await executor.execute(sql`
     SELECT 1 FROM redirects WHERE old_path = ${path} LIMIT 1
   `)) as unknown as unknown[];
   return rows.length > 0;

--- a/packages/server/src/services/shared/slug.ts
+++ b/packages/server/src/services/shared/slug.ts
@@ -4,7 +4,7 @@
 // and the rename cooldown are all centralised here so the route layer, the DB
 // CHECK constraint, and the t-1 e2e spec stay in sync.
 
-import { eq, lt } from "drizzle-orm";
+import { eq, lt, sql } from "drizzle-orm";
 import { db } from "../../db/connection.js";
 import { namespaces, namespaceSlugReservations } from "../../db/schema.js";
 
@@ -90,6 +90,18 @@ export async function isSlugAvailable(slug: string): Promise<boolean> {
     where: eq(namespaceSlugReservations.slug, normalized),
   });
   if (reserved && reserved.reservedUntil > now) return false;
+
+  // spec-481 D-2 reuse-guard: a slug that a rename points AWAY from (the
+  // old_path of a live redirect) must stay unavailable even after its 30-day
+  // reservation lapses — otherwise a reborn namespace would shadow the permanent
+  // redirect under direct-first resolution (std-10 cl-91) and silently
+  // mis-route old links. Mirrors spec-479 D-4's isRedirectSource; inlined here
+  // to avoid a shared/ → services/redirects import cycle.
+  const redirected = (await db.execute(
+    sql`SELECT 1 FROM redirects WHERE old_path = ${normalized} LIMIT 1`,
+  )) as unknown as unknown[];
+  if (redirected.length > 0) return false;
+
   return true;
 }
 

--- a/packages/server/src/services/welcome-trigger.integration.test.ts
+++ b/packages/server/src/services/welcome-trigger.integration.test.ts
@@ -31,6 +31,12 @@ describe("welcome trigger via markEmailVerified", () => {
     tagAc(AC(6)); // fires on the email-verified transition
     tagAc(AC(7)); // upsertUserByEmail is the SSO/magic-link path — no account.created
     tagAc(AC(1)); // the user receives the welcome
+    // spec-488 ac-6 — the spec-428 welcome infra (markEmailVerified →
+    // sendWelcomeEmail, the `welcome` comms key, once-only) is wired and live;
+    // this exercises that path end-to-end so the "infra is live" invariant is not
+    // merely asserted in prose. (The "merged on main" half is a git fact confirmed
+    // at code-grounding, not runtime-testable.)
+    tagAc("mindset-prod/memex-building-itself/specs/spec-488/acs/ac-6");
     const email = `welcome-trigger-${Date.now()}@example.test`;
     const user = await upsertUserByEmail(email);
 

--- a/packages/ui/e2e/journey-62-spec-481-namespace-rename.spec.ts
+++ b/packages/ui/e2e/journey-62-spec-481-namespace-rename.spec.ts
@@ -73,4 +73,11 @@ test("admin renames the namespace slug from Settings; old deep links forward (ac
   // resolver rewrites every descendant path from it.
   await page.goto(tenantPath(oldNs, "workspace", "/specs"));
   await expect(page).toHaveURL(tenantPath(newNs, "workspace", "/specs"));
+
+  // ac-2 (bare home): the OLD bare namespace home forwards too. NamespaceHome
+  // consults the redirect layer on a miss rather than dead-ending on
+  // "Namespace not found" — so EVERY previously-valid URL under the old slug
+  // forwards, not just deep tenant paths.
+  await page.goto(bareUrl(`/${oldNs}`));
+  await expect(page).toHaveURL(bareUrl(`/${newNs}`));
 });

--- a/packages/ui/e2e/journey-62-spec-481-namespace-rename.spec.ts
+++ b/packages/ui/e2e/journey-62-spec-481-namespace-rename.spec.ts
@@ -1,0 +1,76 @@
+import {
+  test,
+  expect,
+  tenantPath,
+  bareUrl,
+  DEV_EMAIL,
+  seedOrg,
+  emitAcEvents,
+} from "./helpers/index.js";
+
+// Journey 62 — spec-481: rename a NAMESPACE slug from /:namespace/settings, and
+// prove old links under the namespace forward to the new slug (std-28 gate).
+//
+// Emits:
+//   ac-1 — an admin renames the namespace slug from a web UI surface (org namespace)
+//   ac-4 — the /:namespace/settings page gates on live availability, states its
+//          consequences before commit, then navigates to the new /<new-ns>/ home
+//   ac-2 — a previously-valid DEEP tenant URL under the OLD namespace slug forwards
+//          to its new-slug equivalent in the browser (TenantLayout stale-forward)
+
+const AC = [
+  "mindset-prod/memex-building-itself/specs/spec-481/acs/ac-1",
+  "mindset-prod/memex-building-itself/specs/spec-481/acs/ac-2",
+  "mindset-prod/memex-building-itself/specs/spec-481/acs/ac-4",
+];
+
+test.afterEach(async ({}, testInfo) => {
+  if (testInfo.status === "skipped") return;
+  await emitAcEvents(
+    AC,
+    testInfo.status === "passed" ? "pass" : "fail",
+    `packages/ui/e2e/journey-62-spec-481-namespace-rename.spec.ts::${testInfo.title}`,
+    testInfo.duration,
+  );
+});
+
+test("admin renames the namespace slug from Settings; old deep links forward (ac-1, ac-2, ac-4)", async ({
+  page,
+  resources,
+}) => {
+  const oldNs = resources.slug("rename-ns");
+  const newNs = resources.slug("rename-ns-new");
+  await seedOrg({
+    ownerEmail: DEV_EMAIL,
+    slug: oldNs,
+    memexSlug: "workspace",
+    memexName: "Workspace",
+  });
+
+  // ── The settings surface renders for the admin. ──
+  await page.goto(bareUrl(`/${oldNs}/settings`));
+  const section = page.getByTestId("namespace-rename");
+  await expect(section).toBeVisible();
+
+  // ── Slug: change → live availability clears → confirm consequences →
+  //    navigate to the new /<new-ns>/ home. ──
+  await page.getByTestId("namespace-slug-input").fill(newNs);
+  const renameBtn = page.getByTestId("namespace-slug-rename");
+  await expect(renameBtn).toBeEnabled(); // enables once the debounced check reports free
+  await renameBtn.click();
+
+  // ac-4: the confirm names the consequence (old links forward) BEFORE commit.
+  const confirm = page.getByTestId("namespace-slug-confirm");
+  await expect(confirm).toBeVisible();
+  await expect(confirm).toContainText("forward");
+  await page.getByTestId("namespace-slug-confirm-btn").click();
+
+  // ac-1 slug half: navigates to the new /<new-ns>/ home.
+  await expect(page).toHaveURL(bareUrl(`/${newNs}`));
+
+  // ac-2: a bookmarked OLD deep tenant URL forwards to the new-slug equivalent
+  // in the browser. The namespace_rename redirect is a 1-segment prefix, so the
+  // resolver rewrites every descendant path from it.
+  await page.goto(tenantPath(oldNs, "workspace", "/specs"));
+  await expect(page).toHaveURL(tenantPath(newNs, "workspace", "/specs"));
+});

--- a/packages/ui/e2e/journey-62-spec-484-render-correctness.spec.ts
+++ b/packages/ui/e2e/journey-62-spec-484-render-correctness.spec.ts
@@ -1,0 +1,164 @@
+import {
+  test,
+  expect,
+  tenantPath,
+  emitAcEvents,
+} from "./helpers/index.js";
+import {
+  seedOrgTenant,
+  seedSpec,
+  setDocStatus,
+  seedComment,
+} from "./helpers/retained.js";
+
+// Journey 62 — spec-484: UI rendering correctness, end-to-end against the
+// running app.
+//
+// spec-484 fixed two display defects with render-time / read-time transforms:
+//   1. Titles stored HTML-entity-encoded (legacy data, e.g. "Foo &amp;amp; Bar")
+//      now DECODE on read across every title surface — the spec board / doc list
+//      was the primary reported location (fetchDocs, previously undecoded).
+//   2. Prose fields (comment bodies, trade-offs, …) now RENDER markdown instead
+//      of literal syntax.
+//
+// The component tests mock the API layer; this journey is the full-stack proof —
+// a real seeded entity-encoded title decodes through the real fetch → board
+// render, and a real markdown comment body renders as markdown in the running UI.
+// (ac-2's public shared-viewer leg and the remaining prose surfaces stay on the
+// component suite; this journey covers the primary board surface + the comment
+// body, the highest-value user-facing paths.)
+const AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-484/acs/ac-${n}`;
+
+// Per-test AC attribution — each test emits ONLY the ACs it actually exercises,
+// so a failure in one doesn't falsely fail the other's criteria.
+const ACS_BY_TEST: Record<string, string[]> = {
+  "entity-encoded titles decode on the spec board and the doc detail (ac-1, ac-5)":
+    [AC(1), AC(5)],
+  "a markdown comment body renders as markdown, not literal syntax (ac-6)": [
+    AC(6),
+  ],
+};
+
+test.afterEach(async ({}, testInfo) => {
+  if (testInfo.status === "skipped") return;
+  const acs = ACS_BY_TEST[testInfo.title] ?? [];
+  if (acs.length === 0) return;
+  await emitAcEvents(
+    acs,
+    testInfo.status === "passed" ? "pass" : "fail",
+    `packages/ui/e2e/journey-62-spec-484-render-correctness.spec.ts::${testInfo.title}`,
+    testInfo.duration,
+  );
+});
+
+test(
+  "entity-encoded titles decode on the spec board and the doc detail (ac-1, ac-5)",
+  async ({ page, resources }) => {
+    const tenant = await seedOrgTenant({ slug: resources.slug("j62a") });
+    // Title stored DOUBLE-encoded ("&amp;amp;") — the strongest case: the
+    // fixpoint decoder must resolve it fully to a single "&" (ac-5), and it must
+    // do so on the board list surface (fetchDocs), the primary reported bug (ac-1).
+    const spec = await seedSpec({
+      memexId: tenant.memexId,
+      title: "Billing &amp;amp; Invoicing",
+      purpose: "Exercise entity-title decode-on-read across surfaces.",
+    });
+    await setDocStatus({
+      memexId: tenant.memexId,
+      docId: spec.docId,
+      status: "specify",
+    });
+
+    // ── The spec board (doc list, fetchDocs) renders the title DECODED ──
+    await page.goto(
+      tenantPath(tenant.namespaceSlug, tenant.memexSlug, "/specs"),
+      { waitUntil: "commit" },
+    );
+    await expect(
+      page.getByRole("heading", { name: "Specs" }),
+    ).toBeVisible({ timeout: 15_000 });
+
+    // ac-1 / ac-5: the decoded glyph is shown; the raw entity is NOT rendered.
+    await expect(page.getByText("Billing & Invoicing").first()).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(page.getByText(/Billing &amp;/)).toHaveCount(0);
+
+    // ── The doc detail heading is decoded too ──
+    await page.goto(
+      tenantPath(
+        tenant.namespaceSlug,
+        tenant.memexSlug,
+        `/specs/${spec.handle}`,
+      ),
+      { waitUntil: "commit" },
+    );
+    await expect(
+      page.getByRole("heading", { level: 1, name: /Billing & Invoicing/ }),
+    ).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByText(/Billing &amp;/)).toHaveCount(0);
+  },
+);
+
+test(
+  "a markdown comment body renders as markdown, not literal syntax (ac-6)",
+  async ({ page, resources }) => {
+    const tenant = await seedOrgTenant({ slug: resources.slug("j62b") });
+    const spec = await seedSpec({
+      memexId: tenant.memexId,
+      title: "Comment Markdown Spec",
+      purpose: "Exercise markdown rendering of comment bodies.",
+    });
+    await setDocStatus({
+      memexId: tenant.memexId,
+      docId: spec.docId,
+      status: "specify",
+    });
+
+    // A comment body carrying markdown — bold + a link. Before spec-484 this
+    // rendered as the literal string "**bold-text**"; now it must render as
+    // real markdown (a <strong> and an <a>).
+    await seedComment({
+      memexId: tenant.memexId,
+      target: "section",
+      targetId: spec.sectionId,
+      authorName: "Casey Comment",
+      content: "**bold-text** and a [ref link](https://example.com)",
+    });
+
+    await page.goto(
+      tenantPath(
+        tenant.namespaceSlug,
+        tenant.memexSlug,
+        `/specs/${spec.handle}`,
+      ),
+      { waitUntil: "commit" },
+    );
+    await expect(
+      page.getByRole("heading", { level: 1, name: /Comment Markdown Spec/ }),
+    ).toBeVisible({ timeout: 15_000 });
+
+    // Open the Comments sub-tab (same affordance journey-33 uses).
+    await page
+      .getByRole("button", { name: /^Comments?( \(\d+\))?$/ })
+      .click();
+
+    // The comment renders in the flat Comments view under its author byline.
+    await expect(page.getByText("Casey Comment")).toBeVisible({
+      timeout: 15_000,
+    });
+
+    // ac-6: markdown is RENDERED — "bold-text" is inside a <strong>, the link is
+    // a real <a> carrying the parsed href — and the literal markdown syntax is
+    // NOT shown as text.
+    await expect(
+      page.locator("strong", { hasText: "bold-text" }),
+    ).toBeVisible();
+    await expect(page.getByRole("link", { name: "ref link" })).toHaveAttribute(
+      "href",
+      "https://example.com",
+    );
+    await expect(page.getByText("**bold-text**")).toHaveCount(0);
+  },
+);

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -32,6 +32,9 @@ const IssuesList = lazy(() => import('./pages/IssuesList').then((m) => ({ defaul
 const NamespaceHome = lazy(() =>
   import('./pages/NamespaceHome').then((m) => ({ default: m.NamespaceHome })),
 );
+const NamespaceSettings = lazy(() =>
+  import('./pages/NamespaceSettings').then((m) => ({ default: m.NamespaceSettings })),
+);
 const HomeCanvas = lazy(() => import('./pages/HomeCanvas').then((m) => ({ default: m.HomeCanvas })));
 const StandardList = lazy(() =>
   import('./pages/StandardList').then((m) => ({ default: m.StandardList })),
@@ -593,6 +596,13 @@ export function PostLoginRouter() {
           OrgHome / Personal Home. More specific /:namespace/:memex routes below
           take precedence (React Router 7 specificity). */}
       <Route path="/:namespace" element={<FlatShell><NamespaceHome /></FlatShell>} />
+
+      {/* spec-481 t-2 (ac-4): per-namespace settings — the namespace-slug rename
+          surface. `settings` is a reserved slug (no Memex can be named it), so
+          this static segment safely wins over the `/:namespace/:memex` dynamic
+          route below (RRv7 ranks static above dynamic). Declared before it to
+          keep the precedence obvious to a reader too. */}
+      <Route path="/:namespace/settings" element={<FlatShell><NamespaceSettings /></FlatShell>} />
 
       {/* Tenancy-scoped routes — every path segment lives under /:ns/:mx. */}
       <Route path="/:namespace/:memex" element={<TenantLayout />}>

--- a/packages/ui/src/api/auth.ts
+++ b/packages/ui/src/api/auth.ts
@@ -333,7 +333,13 @@ export interface OrgCreateResponse {
   namespace: { id: string; slug: string; kind: 'user' | 'org' };
 }
 
-export type OrgSlugCheckReason = 'too_short' | 'too_long' | 'invalid_chars' | 'reserved' | 'taken';
+export type OrgSlugCheckReason =
+  | 'too_short'
+  | 'too_long'
+  | 'invalid_chars'
+  | 'reserved'
+  | 'taken'
+  | 'redirected';
 
 export interface OrgSlugCheckResult {
   available: boolean;

--- a/packages/ui/src/components/AddMemexForm.tsx
+++ b/packages/ui/src/components/AddMemexForm.tsx
@@ -22,6 +22,7 @@ const SLUG_REASON_MESSAGES: Record<OrgSlugCheckReason, string> = {
   invalid_chars: 'Use only letters, numbers, and hyphens (no leading or trailing hyphen)',
   reserved: 'That slug is reserved — pick another',
   taken: 'That slug is already taken in this Org',
+  redirected: 'That slug was used before and is reserved by a redirect',
 };
 
 const ERROR_CODE_MESSAGES: Record<string, string> = {

--- a/packages/ui/src/components/CreateOrgForm.tsx
+++ b/packages/ui/src/components/CreateOrgForm.tsx
@@ -22,6 +22,7 @@ const SLUG_REASON_MESSAGES: Record<OrgSlugCheckReason, string> = {
   invalid_chars: 'Use only letters, numbers, and hyphens (no leading or trailing hyphen)',
   reserved: 'That namespace is reserved — pick another',
   taken: 'That namespace is already taken',
+  redirected: 'That namespace was used before and is reserved by a redirect',
 };
 
 // Server-side error codes we render targeted copy for. Anything else falls through

--- a/packages/ui/src/components/RenameNamespaceSection.test.tsx
+++ b/packages/ui/src/components/RenameNamespaceSection.test.tsx
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { tagAc } from '@memex-ai-ac/vitest';
+
+// spec-481 t-2 — component-level verification of the namespace-slug rename.
+// Proves the UI behaviour (gated on live availability, states consequences
+// before commit, then renames + refreshes the session BEFORE navigating to the
+// new /<new-ns>/ home) with the API + router mocked. The full-page journey
+// (journey-62) covers ac-2's old-link forward end-to-end in CI's cold-DB gate.
+const AC_UI = 'mindset-prod/memex-building-itself/specs/spec-481/acs/ac-4';
+
+const navigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual =
+    await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return { ...actual, useNavigate: () => navigate };
+});
+
+const refreshSession = vi.fn();
+vi.mock('./AuthContext', () => ({
+  useAuth: () => ({ token: 'test-token', refreshSession }),
+}));
+
+const checkNamespaceSlugApi = vi.fn();
+const renameNamespaceSlugApi = vi.fn();
+vi.mock('../api/client', () => ({
+  checkNamespaceSlugApi: (...a: unknown[]) => checkNamespaceSlugApi(...a),
+  renameNamespaceSlugApi: (...a: unknown[]) => renameNamespaceSlugApi(...a),
+}));
+
+import { RenameNamespaceSection } from './RenameNamespaceSection';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  refreshSession.mockResolvedValue(undefined);
+});
+
+function renderSection() {
+  return render(
+    <MemoryRouter>
+      <RenameNamespaceSection namespaceId="ns-uuid" currentSlug="acme" />
+    </MemoryRouter>,
+  );
+}
+
+describe('RenameNamespaceSection (spec-481 t-2)', () => {
+  it('gates on availability, confirms consequences, then renames + refreshes before navigating', async () => {
+    tagAc(AC_UI);
+    checkNamespaceSlugApi.mockResolvedValue({ available: true });
+    renameNamespaceSlugApi.mockResolvedValue({ namespace: { id: 'ns-uuid', slug: 'globex' } });
+    const user = userEvent.setup();
+    renderSection();
+
+    const slugInput = await screen.findByTestId('namespace-slug-input');
+    await user.clear(slugInput);
+    await user.type(slugInput, 'globex');
+
+    const renameBtn = screen.getByTestId('namespace-slug-rename');
+    await waitFor(() => expect(renameBtn).toBeEnabled());
+    await user.click(renameBtn);
+
+    // Consequences stated BEFORE commit (30-day cooldown + old links forward).
+    const confirm = await screen.findByTestId('namespace-slug-confirm');
+    expect(confirm).toHaveTextContent(/forward/i);
+    expect(confirm).toHaveTextContent(/30 days/i);
+
+    await user.click(screen.getByTestId('namespace-slug-confirm-btn'));
+    await waitFor(() =>
+      expect(renameNamespaceSlugApi).toHaveBeenCalledWith('ns-uuid', 'globex', 'test-token'),
+    );
+    await waitFor(() => expect(navigate).toHaveBeenCalled());
+    // The session MUST refresh before navigating — otherwise TenantLayout gates
+    // tenant URLs on stale membership (old slug) and bounces the user. This is
+    // the spec-479 journey-61 regression, carried forward.
+    expect(refreshSession).toHaveBeenCalled();
+    expect(refreshSession.mock.invocationCallOrder[0]).toBeLessThan(
+      navigate.mock.invocationCallOrder[0],
+    );
+    // ac-4: navigates to the new /<new-ns>/ home.
+    expect(navigate).toHaveBeenCalledWith('/globex', { replace: true });
+  });
+
+  it('blocks the rename and explains when the slug is reserved by a prior rename', async () => {
+    tagAc(AC_UI);
+    checkNamespaceSlugApi.mockResolvedValue({ available: false, reason: 'redirected' });
+    const user = userEvent.setup();
+    renderSection();
+
+    const slugInput = await screen.findByTestId('namespace-slug-input');
+    await user.clear(slugInput);
+    await user.type(slugInput, 'oldname');
+
+    await waitFor(() =>
+      expect(screen.getByTestId('namespace-slug-unavailable')).toBeInTheDocument(),
+    );
+    expect(screen.getByTestId('namespace-slug-unavailable')).toHaveTextContent(/reserved/i);
+    expect(screen.getByTestId('namespace-slug-rename')).toBeDisabled();
+  });
+});

--- a/packages/ui/src/components/RenameNamespaceSection.tsx
+++ b/packages/ui/src/components/RenameNamespaceSection.tsx
@@ -1,0 +1,177 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Button } from './ui/Button';
+import { Input } from './ui/Input';
+import { Alert } from './ui/Alert';
+import { useAuth } from './AuthContext';
+import {
+  checkNamespaceSlugApi,
+  renameNamespaceSlugApi,
+  type OrgSlugCheckResult,
+} from '../api/client';
+
+// spec-481 t-2 — the namespace-slug rename control on /:namespace/settings.
+//
+// A namespace has no display name (only orgs do — edited elsewhere), so unlike
+// RenameMemexSection this is slug-only. The slug is the first URL segment;
+// renaming it changes every link under the namespace, so it goes through a
+// confirm and, on success, navigates to the new /<new-ns>/ home (ac-4). Old
+// links keep working via the server's namespace_rename redirect (std-10 §7),
+// and the freed slug can't be reused while that redirect is live (D-2) —
+// surfaced live by the availability check as "reserved by a redirect".
+export function RenameNamespaceSection({
+  namespaceId,
+  currentSlug,
+}: {
+  namespaceId: string;
+  currentSlug: string;
+}) {
+  const { token, refreshSession } = useAuth();
+  const navigate = useNavigate();
+
+  const [slug, setSlug] = useState(currentSlug);
+  const [check, setCheck] = useState<OrgSlugCheckResult | null>(null);
+  const [checking, setChecking] = useState(false);
+  const [confirming, setConfirming] = useState(false);
+  const [renaming, setRenaming] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const checkSeq = useRef(0);
+
+  // Live slug availability — 400ms debounce, seq-guarded (mirrors
+  // RenameMemexSection / CreateOrgForm), only while the slug differs from the
+  // persisted value. The namespace pool is global, so the check takes no
+  // namespaceId.
+  useEffect(() => {
+    const trimmed = slug.trim().toLowerCase();
+    if (!trimmed || trimmed === currentSlug) {
+      setCheck(null);
+      setChecking(false);
+      return;
+    }
+    setChecking(true);
+    const seq = ++checkSeq.current;
+    const handle = window.setTimeout(async () => {
+      try {
+        const result = await checkNamespaceSlugApi(trimmed, token);
+        if (checkSeq.current === seq) {
+          setCheck(result);
+          setChecking(false);
+        }
+      } catch {
+        if (checkSeq.current === seq) {
+          setCheck(null);
+          setChecking(false);
+        }
+      }
+    }, 400);
+    return () => window.clearTimeout(handle);
+  }, [slug, currentSlug, token]);
+
+  const onConfirmRename = useCallback(async () => {
+    const trimmed = slug.trim().toLowerCase();
+    setRenaming(true);
+    setError(null);
+    try {
+      const { namespace } = await renameNamespaceSlugApi(namespaceId, trimmed, token);
+      // Refresh the session FIRST: its membership rows still carry the old
+      // namespace slug, and TenantLayout gates tenant URLs on membership —
+      // navigating before the refresh can bounce the user to their default
+      // landing (the spec-479 lesson). Only then navigate to the new namespace
+      // home (server-validated slug → safe/same-origin path).
+      await refreshSession();
+      navigate(`/${namespace.slug}`, { replace: true });
+    } catch (err) {
+      setError((err as Error).message);
+      setRenaming(false);
+      setConfirming(false);
+    }
+  }, [slug, namespaceId, token, navigate, refreshSession]);
+
+  const trimmedSlug = slug.trim().toLowerCase();
+  const slugChanged = trimmedSlug !== '' && trimmedSlug !== currentSlug;
+  const slugAvailable = check?.available === true;
+
+  return (
+    <section className="space-y-6" data-testid="namespace-rename">
+      <div>
+        <h3 className="text-sm font-semibold text-heading">Namespace URL</h3>
+        <p className="text-sm text-secondary mt-1">
+          Change the address that every Memex in this namespace lives under.
+        </p>
+      </div>
+
+      {error && (
+        <Alert variant="danger" size="md">
+          {error}
+        </Alert>
+      )}
+
+      <div className="space-y-2">
+        <label className="block text-sm text-secondary">
+          URL address
+          <div className="flex gap-2 mt-1">
+            <Input
+              value={slug}
+              onChange={(e) => {
+                setSlug(e.target.value);
+                setConfirming(false);
+              }}
+              data-testid="namespace-slug-input"
+            />
+            <Button
+              variant="secondary"
+              onClick={() => setConfirming(true)}
+              disabled={!slugChanged || !slugAvailable || checking}
+              data-testid="namespace-slug-rename"
+            >
+              Rename URL
+            </Button>
+          </div>
+        </label>
+        <p className="text-xs text-muted">
+          memex.ai/<span className="text-primary">{trimmedSlug || currentSlug}</span>
+        </p>
+        {slugChanged && !checking && check && !check.available && (
+          <div
+            className="text-xs text-status-danger-text"
+            data-testid="namespace-slug-unavailable"
+          >
+            {check.reason === 'redirected'
+              ? 'That address was used before and is reserved by a redirect.'
+              : check.reason === 'taken' || check.reason === 'reserved'
+                ? 'That address is already taken.'
+                : "That address isn't valid."}
+          </div>
+        )}
+      </div>
+
+      {confirming && (
+        <div
+          className="space-y-3 p-3 rounded-lg border border-edge bg-card"
+          data-testid="namespace-slug-confirm"
+        >
+          <p className="text-sm text-primary">
+            Rename the namespace URL to <code>{trimmedSlug}</code>?
+          </p>
+          <ul className="text-xs text-secondary list-disc pl-5 space-y-1">
+            <li>Every Memex in this namespace moves to the new address.</li>
+            <li>Old links keep working — they forward to the new address.</li>
+            <li>You can't rename again for 30 days, and the old address stays reserved.</li>
+          </ul>
+          <div className="flex gap-2">
+            <Button
+              onClick={onConfirmRename}
+              disabled={renaming}
+              data-testid="namespace-slug-confirm-btn"
+            >
+              {renaming ? 'Renaming…' : 'Confirm rename'}
+            </Button>
+            <Button variant="ghost" onClick={() => setConfirming(false)} disabled={renaming}>
+              Cancel
+            </Button>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/packages/ui/src/onAccentToken.spec-167.test.ts
+++ b/packages/ui/src/onAccentToken.spec-167.test.ts
@@ -97,12 +97,15 @@ describe('spec-167: on-accent foreground token', () => {
     // "Create spec in Memex" button was removed, so it exits the set.
     // spec-304 t-55: DesktopMcpSection.tsx added — its Install/Reinstall/Repair
     // primary button renders text on a bg-accent fill (the token's intended case).
+    // spec-493 t-2: EmailPreview.tsx added — the email-preview timeline's SELECTED
+    // email chip is a bg-accent fill (the token's intended contrast case).
     expect(consumers).toEqual(
       [
         'components/DesktopMcpSection.tsx',
         'components/home/CreateFirstSpecStep.tsx',
         'components/home/IdentityStep.tsx',
         'components/upgrade/PricingCard.tsx',
+        'pages/EmailPreview.tsx',
         'pages/OauthAuthorize.tsx',
       ].sort(),
     );

--- a/packages/ui/src/pages/EmailPreview.test.tsx
+++ b/packages/ui/src/pages/EmailPreview.test.tsx
@@ -1,15 +1,89 @@
 // spec-226 t-6 / ac-6 — the designer-facing email-preview gallery.
+// spec-493 t-2 — the gallery now lays the onboarding sequence out as a TIMELINE with
+// per-email send conditions, keeping the non-onboarding templates in a separate list.
 // jsdom's hostname is "localhost", so emailPreviewEnabled() is true here (non-prod).
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { tagAc } from '@memex-ai-ac/vitest';
 import { EmailPreview } from './EmailPreview';
 
-const AC_6 = 'mindset-prod/memex-building-itself/specs/spec-226/acs/ac-6';
-const AC_7 = 'mindset-prod/memex-building-itself/specs/spec-226/acs/ac-7';
+const AC226 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-226/acs/ac-${n}`;
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-493/acs/ac-${n}`;
 
 const SAMPLE_HTML = '<!doctype html><html><body>Confirm your email</body></html>';
+
+// The /templates payload shape spec-493 introduced: one metadata object per template.
+// Onboarding emails carry sequence:true + their send-condition facts; everything else
+// is sequence:false and belongs in the flat grouped list.
+const TEMPLATES_PAYLOAD = {
+  perCohortCap: 2,
+  templates: [
+    {
+      name: 'welcome',
+      sequence: true,
+      order: 0,
+      dayOffset: 0,
+      anchor: 'email verification',
+      cohort: 'every verified signup',
+      trigger: 'sent once when a user first verifies their email',
+      branch: 'main',
+      flagGated: false,
+      commsKey: null,
+    },
+    {
+      name: 'activation-connected-inactive',
+      sequence: true,
+      order: 1,
+      dayOffset: 2,
+      anchor: 'first mcp.connected',
+      cohort: 'connected an agent, but no tool call and no spec yet',
+      trigger: 'dwell timer after the user first connects their agent',
+      branch: 'connected-inactive',
+      flagGated: true,
+      commsKey: 'activation.connected_inactive',
+    },
+    {
+      name: 'activation-winback',
+      sequence: true,
+      order: 1,
+      dayOffset: 3,
+      anchor: 'email verification',
+      cohort: 'verified, but never connected an agent',
+      trigger: 'dwell timer after signup for users who never connect',
+      branch: 'win-back',
+      flagGated: true,
+      commsKey: 'activation.signed_in_dormant',
+    },
+    {
+      name: 'activation-verified-milestone',
+      sequence: true,
+      order: 2,
+      dayOffset: null,
+      anchor: 'first acceptance criterion verified',
+      cohort: 'any user, once ever',
+      trigger: 'fires when the user’s first AC is verified',
+      branch: 'main',
+      flagGated: true,
+      commsKey: null,
+    },
+    {
+      name: 'activation-connect-people',
+      sequence: true,
+      order: 3,
+      dayOffset: 12,
+      anchor: 'signup',
+      cohort: 'every verified signup — independent of the cohort nudge',
+      trigger: 'day-12 check-in; can arrive alongside a cohort email',
+      branch: 'main',
+      flagGated: true,
+      commsKey: 'activation.connect_people',
+    },
+    { name: 'verification', sequence: false },
+    { name: 'magic-link', sequence: false },
+    { name: 'activation-signed-in-dormant', sequence: false },
+  ],
+};
 
 beforeEach(() => {
   vi.stubGlobal(
@@ -17,12 +91,10 @@ beforeEach(() => {
     vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = typeof input === 'string' ? input : input.toString();
       if (url.includes('/email-preview/send') && init?.method === 'POST') {
-        // The server resolves the recipient from the session — the UI sends no
-        // address, only the template name.
         return { ok: true, status: 200, json: async () => ({ sent: true, to: 'me@example.com' }) };
       }
       if (url.includes('/email-preview/templates')) {
-        return { ok: true, status: 200, json: async () => ({ templates: ['welcome', 'verification'] }) };
+        return { ok: true, status: 200, json: async () => TEMPLATES_PAYLOAD };
       }
       return { ok: true, status: 200, text: async () => SAMPLE_HTML };
     }),
@@ -33,45 +105,133 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
-describe('EmailPreview gallery (spec-226 t-6 / ac-6)', () => {
-  it('lists templates and renders the selected one in an iframe via srcDoc (not src)', async () => {
-    tagAc(AC_6);
-    render(
-      <MemoryRouter>
-        <EmailPreview />
-      </MemoryRouter>,
-    );
+const renderPage = () =>
+  render(
+    <MemoryRouter>
+      <EmailPreview />
+    </MemoryRouter>,
+  );
 
-    // The picker is populated from the fetched template list.
-    expect(await screen.findByTestId('tpl-welcome')).toBeTruthy();
-    expect(screen.getByTestId('tpl-verification')).toBeTruthy();
+describe('EmailPreview timeline (spec-493 t-2)', () => {
+  it('shows the onboarding emails as a timeline in send order, not a flat tab strip (ac-1)', async () => {
+    tagAc(AC(1));
+    renderPage();
 
-    // The selected template's HTML is shown in an iframe via srcDoc — NOT src
-    // (an iframe `src` to the Bearer-auth route would carry no token and 401).
+    const timeline = await screen.findByTestId('email-timeline');
+    // Every onboarding email is on the timeline...
+    for (const name of [
+      'welcome',
+      'activation-connected-inactive',
+      'activation-winback',
+      'activation-verified-milestone',
+      'activation-connect-people',
+    ]) {
+      expect(within(timeline).getByTestId(`tpl-${name}`)).toBeTruthy();
+    }
+    // ...in send order (welcome → cohort nudge → milestone → day-12).
+    const nodes = within(timeline)
+      .getAllByTestId(/^tpl-/)
+      .map((el) => el.getAttribute('data-testid'));
+    const idx = (n: string) => nodes.indexOf(`tpl-${n}`);
+    expect(idx('welcome')).toBeLessThan(idx('activation-connected-inactive'));
+    expect(idx('activation-connected-inactive')).toBeLessThan(idx('activation-verified-milestone'));
+    expect(idx('activation-verified-milestone')).toBeLessThan(idx('activation-connect-people'));
+  });
+
+  it('displays each email’s send condition in plain terms — day, cohort, trigger, flag (ac-2)', async () => {
+    tagAc(AC(2));
+    renderPage();
+
+    const timeline = await screen.findByTestId('email-timeline');
+    // welcome: Day 0, transactional (always sends — not behind the flag)
+    const welcome = within(timeline).getByTestId('cond-welcome');
+    expect(welcome.textContent).toContain('Day 0');
+    expect(welcome.textContent).toMatch(/every verified signup/i);
+    expect(welcome.textContent).toMatch(/always sends|transactional/i);
+
+    // connect-people: Day 12 + flag-gated
+    const connect = within(timeline).getByTestId('cond-activation-connect-people');
+    expect(connect.textContent).toContain('Day 12');
+    expect(connect.textContent).toMatch(/activation flag/i);
+
+    // verified-milestone: event-driven, no fixed day
+    const milestone = within(timeline).getByTestId('cond-activation-verified-milestone');
+    expect(milestone.textContent).toMatch(/event-driven/i);
+  });
+
+  it('renders connected-inactive & win-back as parallel exclusive branches, milestone/connect on the spine (ac-12)', async () => {
+    tagAc(AC(12));
+    renderPage();
+
+    const branches = await screen.findByTestId('cohort-branches');
+    // both cohort emails sit inside the single parallel-branch slot
+    expect(within(branches).getByTestId('tpl-activation-connected-inactive')).toBeTruthy();
+    expect(within(branches).getByTestId('tpl-activation-winback')).toBeTruthy();
+    // milestone + connect are NOT in the branch slot (they're on the main spine)
+    expect(within(branches).queryByTestId('tpl-activation-verified-milestone')).toBeNull();
+    expect(within(branches).queryByTestId('tpl-activation-connect-people')).toBeNull();
+  });
+
+  it('keeps non-onboarding templates in a separate grouped list, off the timeline (ac-5, ac-11)', async () => {
+    tagAc(AC(5));
+    tagAc(AC(11));
+    renderPage();
+
+    const others = await screen.findByTestId('other-emails');
+    const timeline = screen.getByTestId('email-timeline');
+
+    // system / superseded templates live in the grouped list...
+    for (const name of ['verification', 'magic-link', 'activation-signed-in-dormant']) {
+      expect(within(others).getByTestId(`tpl-${name}`)).toBeTruthy();
+      // ...and never on the timeline
+      expect(within(timeline).queryByTestId(`tpl-${name}`)).toBeNull();
+    }
+    // and the onboarding emails are NOT duplicated into the grouped list
+    expect(within(others).queryByTestId('tpl-welcome')).toBeNull();
+  });
+
+  it('every email (timeline or list) stays clickable to its HTML preview; send-to-me still works (ac-4)', async () => {
+    tagAc(AC(4));
+    renderPage();
+
+    // Clicking a timeline email renders its HTML in the iframe (srcDoc, not src).
+    const timeline = await screen.findByTestId('email-timeline');
+    fireEvent.click(within(timeline).getByTestId('tpl-activation-winback'));
     const iframe = await screen.findByTitle('Email preview');
-    await waitFor(() =>
-      expect(iframe.getAttribute('srcdoc')).toContain('Confirm your email'),
-    );
+    await waitFor(() => expect(iframe.getAttribute('srcdoc')).toContain('Confirm your email'));
+    expect(iframe.getAttribute('src')).toBeNull();
+
+    // A non-onboarding email is equally clickable.
+    const others = screen.getByTestId('other-emails');
+    fireEvent.click(within(others).getByTestId('tpl-verification'));
+    await waitFor(() => expect(iframe.getAttribute('srcdoc')).toContain('Confirm your email'));
+
+    // Send-to-my-inbox still works for the current selection.
+    fireEvent.click(screen.getByTestId('send-to-me'));
+    const status = await screen.findByTestId('send-status');
+    await waitFor(() => expect(status.textContent).toContain('Sent to me@example.com'));
+  });
+});
+
+// spec-226 regressions — the original guarantees must survive the timeline rework.
+describe('EmailPreview gallery (spec-226 t-6 / ac-6)', () => {
+  it('renders the selected template in an iframe via srcDoc (not src)', async () => {
+    tagAc(AC226(6));
+    renderPage();
+
+    const iframe = await screen.findByTitle('Email preview');
+    await waitFor(() => expect(iframe.getAttribute('srcdoc')).toContain('Confirm your email'));
     expect(iframe.getAttribute('src')).toBeNull();
   });
 
-  it('"Send to my inbox" POSTs the template (no address field) and shows the result (ac-7)', async () => {
-    tagAc(AC_7);
-    render(
-      <MemoryRouter>
-        <EmailPreview />
-      </MemoryRouter>,
-    );
+  it('"Send to my inbox" POSTs the template name only (no address field) (ac-7)', async () => {
+    tagAc(AC226(7));
+    renderPage();
 
-    const btn = await screen.findByTestId('send-to-me');
-    fireEvent.click(btn);
-
-    // Status reflects the server-resolved recipient (own email), proving the UI
-    // carries no free-text address.
+    fireEvent.click(await screen.findByTestId('send-to-me'));
     const status = await screen.findByTestId('send-status');
     await waitFor(() => expect(status.textContent).toContain('Sent to me@example.com'));
 
-    // The send POST carried the template name only — never a recipient address.
     const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
     const sendCall = fetchMock.mock.calls.find((args) =>
       String(args[0]).includes('/email-preview/send'),

--- a/packages/ui/src/pages/EmailPreview.tsx
+++ b/packages/ui/src/pages/EmailPreview.tsx
@@ -1,13 +1,19 @@
 // spec-226 t-6 (dec-3) — the designer-facing email-preview gallery.
+// spec-493 t-2 (dec-2/dec-3) — the gallery renders the activation onboarding sequence as
+// a TIMELINE with each email's send condition (day / cohort / trigger / flag), and keeps
+// the non-onboarding templates (system/sign-in mail, superseded samples) in a separate
+// grouped list. The condition metadata is served by /email-preview/templates, whose
+// day/comms facts are imported from the real send path (send-conditions.ts) so the
+// timeline cannot silently disagree with what actually sends.
 //
 // Lets a logged-in user (on int, without running localhost) browse every
-// transactional/lifecycle email's rendered HTML. The template list and each
-// template's HTML are fetched via the token-carrying http client (auth is
-// Bearer/localStorage, not cookie) and shown in an `<iframe srcDoc>` — an iframe
-// `src` pointing straight at the Bearer-auth API route would send no Authorization
-// header and 401. The page + its nav entry + route are gated off prod
-// (emailPreviewEnabled); the API route is likewise unmounted on prod.
-import { useEffect, useState } from "react";
+// transactional/lifecycle email's rendered HTML. The template list and each template's
+// HTML are fetched via the token-carrying http client (auth is Bearer/localStorage, not
+// cookie) and shown in an `<iframe srcDoc>` — an iframe `src` pointing straight at the
+// Bearer-auth API route would send no Authorization header and 401. The page + its nav
+// entry + route are gated off prod (emailPreviewEnabled); the API route is likewise
+// unmounted on prod.
+import { useEffect, useMemo, useState } from "react";
 import { fetchWithRetry } from "../api/http";
 import { emailPreviewEnabled } from "../utils/devTools";
 
@@ -15,26 +21,120 @@ const TEMPLATES_URL = "/api/__dev__/email-preview/templates";
 const previewUrl = (name: string): string =>
   `/api/__dev__/email-preview?template=${encodeURIComponent(name)}`;
 
+type TimelineBranch = "main" | "connected-inactive" | "win-back";
+
+interface OnboardingMeta {
+  name: string;
+  sequence: true;
+  order: number;
+  dayOffset: number | null;
+  anchor: string;
+  cohort: string;
+  trigger: string;
+  branch: TimelineBranch;
+  flagGated: boolean;
+  commsKey: string | null;
+}
+interface OtherMeta {
+  name: string;
+  sequence: false;
+}
+type TemplateMeta = OnboardingMeta | OtherMeta;
+
+const isOnboarding = (t: TemplateMeta): t is OnboardingMeta => t.sequence;
+
+const dayLabel = (m: OnboardingMeta): string =>
+  m.dayOffset === null ? "Event-driven" : `Day ${m.dayOffset}`;
+
+// A single selectable email chip — used both on the timeline and in the grouped list, so
+// selection + preview behaviour is identical everywhere (ac-4).
+function EmailChip({
+  name,
+  selected,
+  onSelect,
+}: {
+  name: string;
+  selected: boolean;
+  onSelect: (name: string) => void;
+}) {
+  return (
+    <button
+      type="button"
+      role="tab"
+      data-testid={`tpl-${name}`}
+      aria-selected={selected}
+      onClick={() => onSelect(name)}
+      className={`cursor-pointer rounded-md border px-3 py-1.5 text-sm font-medium transition-colors ${
+        selected
+          ? "border-accent bg-accent text-on-accent"
+          : "border-edge text-secondary hover:text-primary hover:bg-overlay"
+      }`}
+    >
+      {name}
+    </button>
+  );
+}
+
+// The send-condition line shown under each timeline email (ac-2): day/offset, who it
+// targets, what triggers it, and whether it's held behind the activation flag.
+function ConditionLine({ meta }: { meta: OnboardingMeta }) {
+  return (
+    <div data-testid={`cond-${meta.name}`} className="mt-1 space-y-0.5 text-xs text-secondary">
+      <div>
+        <span className="font-medium text-primary">{dayLabel(meta)}</span>
+        <span className="text-muted"> · after {meta.anchor}</span>
+      </div>
+      <div>Who: {meta.cohort}</div>
+      <div>Trigger: {meta.trigger}</div>
+      <div>
+        {meta.flagGated ? (
+          <span className="text-muted">Held behind the activation flag</span>
+        ) : (
+          <span className="text-muted">Always sends (transactional)</span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// One timeline email: its chip + condition line, laid out as a spine node.
+function TimelineNode({
+  meta,
+  selected,
+  onSelect,
+}: {
+  meta: OnboardingMeta;
+  selected: boolean;
+  onSelect: (name: string) => void;
+}) {
+  return (
+    <div className="rounded-lg border border-edge bg-card p-3">
+      <EmailChip name={meta.name} selected={selected} onSelect={onSelect} />
+      <ConditionLine meta={meta} />
+    </div>
+  );
+}
+
 export function EmailPreview() {
-  const [names, setNames] = useState<string[]>([]);
+  const [templates, setTemplates] = useState<TemplateMeta[]>([]);
   const [selected, setSelected] = useState<string | null>(null);
   const [html, setHtml] = useState<string>("");
   const [error, setError] = useState<string | null>(null);
   const [sending, setSending] = useState(false);
   const [sendMsg, setSendMsg] = useState<string | null>(null);
 
-  // Load the template list once.
+  // Load the template metadata once.
   useEffect(() => {
     let cancelled = false;
     fetchWithRetry(TEMPLATES_URL)
       .then((res) => {
         if (!res.ok) throw new Error(`Could not load templates (${res.status})`);
-        return res.json() as Promise<{ templates: string[] }>;
+        return res.json() as Promise<{ templates: TemplateMeta[] }>;
       })
       .then((data) => {
         if (cancelled) return;
-        setNames(data.templates);
-        setSelected((cur) => cur ?? data.templates[0] ?? null);
+        setTemplates(data.templates);
+        setSelected((cur) => cur ?? data.templates[0]?.name ?? null);
       })
       .catch((e) => {
         if (!cancelled) setError(String(e));
@@ -64,6 +164,23 @@ export function EmailPreview() {
       cancelled = true;
     };
   }, [selected]);
+
+  // Split into the ordered onboarding timeline and the flat grouped list (dec-3). The
+  // timeline is grouped into order slots; a slot with >1 email is a set of mutually
+  // exclusive parallel cohort branches (welcome→cohort nudge→milestone→day-12).
+  const { slots, others } = useMemo(() => {
+    const onboarding = templates.filter(isOnboarding).sort((a, b) => a.order - b.order);
+    const byOrder = new Map<number, OnboardingMeta[]>();
+    for (const m of onboarding) {
+      const bucket = byOrder.get(m.order) ?? [];
+      bucket.push(m);
+      byOrder.set(m.order, bucket);
+    }
+    return {
+      slots: [...byOrder.entries()].sort((a, b) => a[0] - b[0]).map(([, ms]) => ms),
+      others: templates.filter((t): t is OtherMeta => !t.sequence),
+    };
+  }, [templates]);
 
   // Send the selected template to the logged-in user's OWN inbox (spec-226 dec-4).
   // The recipient is resolved server-side from the session — there is no address
@@ -105,25 +222,71 @@ export function EmailPreview() {
         </p>
       )}
 
-      <div className="mt-6 flex flex-wrap gap-2" role="tablist" aria-label="Email templates">
-        {names.map((n) => (
-          <button
-            key={n}
-            type="button"
-            role="tab"
-            data-testid={`tpl-${n}`}
-            aria-selected={n === selected}
-            onClick={() => setSelected(n)}
-            className={`rounded-md border px-3 py-1.5 text-sm transition-colors ${
-              n === selected
-                ? "border-edge bg-card-hover text-primary"
-                : "border-edge text-secondary hover:text-primary hover:bg-overlay"
-            }`}
-          >
-            {n}
-          </button>
-        ))}
-      </div>
+      {/* The activation onboarding sequence, in send order, with each email's send
+          condition — the ordered journey, not a flat tab strip (ac-1/ac-2). */}
+      <section aria-label="Activation onboarding sequence" className="mt-6">
+        <h2 className="text-sm font-semibold text-primary">Onboarding sequence</h2>
+        <p className="mt-0.5 text-xs text-muted">
+          The order emails fire, and the condition each depends on.
+        </p>
+        <ol data-testid="email-timeline" className="mt-3 space-y-3">
+          {slots.map((slot, i) =>
+            slot.length === 1 ? (
+              <li key={slot[0].name}>
+                <TimelineNode
+                  meta={slot[0]}
+                  selected={selected === slot[0].name}
+                  onSelect={setSelected}
+                />
+              </li>
+            ) : (
+              // A parallel-branch slot: mutually exclusive cohorts — a user gets ONE of
+              // these, never both (ac-12). Rendered side by side, not as two steps.
+              <li key={`slot-${i}`}>
+                <div className="text-xs text-muted">One of, by cohort:</div>
+                <div
+                  data-testid="cohort-branches"
+                  className="mt-1 grid gap-3 sm:grid-cols-2"
+                >
+                  {slot.map((meta) => (
+                    <TimelineNode
+                      key={meta.name}
+                      meta={meta}
+                      selected={selected === meta.name}
+                      onSelect={setSelected}
+                    />
+                  ))}
+                </div>
+              </li>
+            ),
+          )}
+        </ol>
+      </section>
+
+      {/* Everything that isn't part of the ordered journey — system/sign-in mail and
+          superseded samples — kept clearly separate, never forced onto the timeline
+          (ac-5/ac-11). */}
+      <section aria-label="System and other emails" className="mt-8">
+        <h2 className="text-sm font-semibold text-primary">System &amp; other emails</h2>
+        <p className="mt-0.5 text-xs text-muted">
+          Event-triggered mail — not part of the onboarding journey.
+        </p>
+        <div
+          data-testid="other-emails"
+          className="mt-3 flex flex-wrap gap-2"
+          role="tablist"
+          aria-label="Other email templates"
+        >
+          {others.map((t) => (
+            <EmailChip
+              key={t.name}
+              name={t.name}
+              selected={selected === t.name}
+              onSelect={setSelected}
+            />
+          ))}
+        </div>
+      </section>
 
       <div className="mt-6 flex items-center gap-3">
         <button
@@ -143,12 +306,7 @@ export function EmailPreview() {
       </div>
 
       <div className="mt-4 overflow-hidden rounded-lg border border-edge bg-card">
-        <iframe
-          title="Email preview"
-          srcDoc={html}
-          sandbox=""
-          className="h-[720px] w-full"
-        />
+        <iframe title="Email preview" srcDoc={html} sandbox="" className="h-[720px] w-full" />
       </div>
     </div>
   );

--- a/packages/ui/src/pages/MemexSettings.tsx
+++ b/packages/ui/src/pages/MemexSettings.tsx
@@ -50,12 +50,13 @@ export function MemexSettings() {
       {memexId ? (
         // Emission keys moved to their own member-visible page (spec-129 dec-8,
         // Option B): /<ns>/<mx>/keys. This admin-only page keeps Memex visibility
-        // and (spec-479) the rename controls.
+        // and (spec-479) the rename controls. Order: identity + visibility first
+        // (the Memex name heading + Private/Public), rename controls last.
         <>
+          <MemexVisibilitySettings memexId={memexId} />
           {tenant?.namespace && (
             <RenameMemexSection memexId={memexId} namespaceSlug={tenant.namespace} />
           )}
-          <MemexVisibilitySettings memexId={memexId} />
         </>
       ) : (
         <div className="text-sm text-muted">No Memex selected.</div>

--- a/packages/ui/src/pages/NamespaceHome.test.tsx
+++ b/packages/ui/src/pages/NamespaceHome.test.tsx
@@ -4,11 +4,20 @@ import { MemoryRouter, Routes, Route } from 'react-router-dom';
 
 const listMyNamespacesApi = vi.hoisted(() => vi.fn());
 const getNamespaceHomeApi = vi.hoisted(() => vi.fn());
+const resolveTenantRedirectApi = vi.hoisted(() => vi.fn());
 
 vi.mock('../api/client', () => ({
   listMyNamespacesApi,
   getNamespaceHomeApi,
+  resolveTenantRedirectApi,
 }));
+
+const navigate = vi.hoisted(() => vi.fn());
+vi.mock('react-router-dom', async () => {
+  const actual =
+    await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return { ...actual, useNavigate: () => navigate };
+});
 
 vi.mock('../components/AuthContext', () => ({
   useAuth: () => ({ token: 'fake', session: { user: { id: 'u-1' } } }),
@@ -38,6 +47,9 @@ describe('NamespaceHome', () => {
   beforeEach(() => {
     listMyNamespacesApi.mockReset();
     getNamespaceHomeApi.mockReset();
+    resolveTenantRedirectApi.mockReset();
+    resolveTenantRedirectApi.mockResolvedValue(null); // default: no redirect
+    navigate.mockReset();
   });
   afterEach(() => vi.restoreAllMocks());
 
@@ -96,11 +108,24 @@ describe('NamespaceHome', () => {
     expect(screen.getByRole('button', { name: /Create an Org/ })).toBeInTheDocument();
   });
 
-  it('shows an error when the namespace is not in the picker list', async () => {
+  it('shows not-found when the namespace is missing and has no redirect', async () => {
     listMyNamespacesApi.mockResolvedValue([]);
     renderAt('/missing');
     await waitFor(() =>
-      expect(screen.getByText(/Failed to load namespace/)).toBeInTheDocument(),
+      expect(screen.getByText('Namespace not found')).toBeInTheDocument(),
     );
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it('forwards a bare stale namespace home to the renamed slug (spec-481 ac-2)', async () => {
+    // The slug isn't in the caller's list (renamed away), but the redirect
+    // layer resolves it → the bare home forwards instead of dead-ending.
+    listMyNamespacesApi.mockResolvedValue([]);
+    resolveTenantRedirectApi.mockResolvedValue('/new-ns');
+    renderAt('/old-ns');
+    await waitFor(() =>
+      expect(navigate).toHaveBeenCalledWith('/new-ns', { replace: true }),
+    );
+    expect(screen.queryByText('Namespace not found')).toBeNull();
   });
 });

--- a/packages/ui/src/pages/NamespaceHome.tsx
+++ b/packages/ui/src/pages/NamespaceHome.tsx
@@ -131,7 +131,16 @@ export function NamespaceHome() {
   if (kind === 'personal' && personalHome && namespaceSlug) {
     return (
       <div className="max-w-2xl mx-auto px-6 py-10">
-        <h1 className="text-2xl font-semibold text-heading mb-2">Your personal Memex</h1>
+        <div className="flex items-start justify-between gap-4 mb-2">
+          <h1 className="text-2xl font-semibold text-heading">Your personal Memex</h1>
+          {/* spec-481 t-2 — entry point to the namespace-slug rename surface. */}
+          <Link
+            to={`/${namespaceSlug}/settings`}
+            className="text-sm text-secondary hover:text-link whitespace-nowrap mt-1"
+          >
+            Namespace settings →
+          </Link>
+        </div>
         <p className="text-secondary mb-6">
           Yours forever. Use it for personal notes, drafts, and your own Specs.
         </p>
@@ -274,6 +283,15 @@ function OrgCard({
             <Button variant="secondary" onClick={onInviteMembers}>
               Invite members
             </Button>
+          )}
+          {isAdmin && (
+            // spec-481 t-2 — entry point to the namespace-slug rename surface.
+            <Link
+              to={`/${namespaceSlug}/settings`}
+              className="text-sm px-3 py-1.5 rounded-md border border-edge text-secondary hover:bg-card-hover transition-colors"
+            >
+              Settings
+            </Link>
           )}
           <Button variant="secondary" onClick={onAddMemex}>+ Add Memex</Button>
         </div>

--- a/packages/ui/src/pages/NamespaceHome.tsx
+++ b/packages/ui/src/pages/NamespaceHome.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useState } from 'react';
-import { useParams, Link } from 'react-router-dom';
+import { useParams, useNavigate, useLocation, Link } from 'react-router-dom';
 import { useAuth } from '../components/AuthContext';
 import {
   getNamespaceHomeApi,
   listMyNamespacesApi,
   type NamespaceHomeResponse,
 } from '../api/client';
+import { useStaleTenantForward } from '../hooks/useStaleTenantForward';
 import { tenantPathFor } from '../utils/tenantUrl';
 import { AddMemexDialog } from '../components/AddMemexDialog';
 import { CreateOrgDialog } from '../components/CreateOrgDialog';
@@ -31,6 +32,8 @@ interface OrgEntry {
 export function NamespaceHome() {
   const { namespace: namespaceSlug } = useParams<{ namespace: string }>();
   const { token, refreshSession } = useAuth();
+  const navigate = useNavigate();
+  const location = useLocation();
   const [kind, setKind] = useState<'personal' | 'org' | null>(null);
   const [personalHome, setPersonalHome] = useState<
     Extract<NamespaceHomeResponse, { kind: 'personal' }> | null
@@ -38,6 +41,12 @@ export function NamespaceHome() {
   const [orgs, setOrgs] = useState<OrgEntry[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  // spec-481 ac-2 — a bare `/<old-ns>` home is a resolution miss after a
+  // namespace rename. Unlike deep tenant paths (TenantLayout forwards those),
+  // this page has to consult the redirect layer itself so the bare home URL
+  // forwards to `/<new-ns>` too, instead of dead-ending on "Namespace not
+  // found". `notFound` gates the same stale-forward hook TenantLayout uses.
+  const [notFound, setNotFound] = useState(false);
   const [addMemexForOrg, setAddMemexForOrg] = useState<OrgEntry | null>(null);
   const [inviteForOrg, setInviteForOrg] = useState<OrgEntry | null>(null);
   const [createOrgOpen, setCreateOrgOpen] = useState(false);
@@ -50,6 +59,7 @@ export function NamespaceHome() {
     if (!namespaceSlug) return;
     setLoading(true);
     setError(null);
+    setNotFound(false);
     let cancelled = false;
     (async () => {
       try {
@@ -57,7 +67,9 @@ export function NamespaceHome() {
         const match = groups.find((g) => g.namespaceSlug === namespaceSlug);
         if (!match?.namespaceId) {
           if (!cancelled) {
-            setError('Namespace not found');
+            // Don't dead-end: flag a miss and let the stale-forward hook below
+            // consult the redirect layer (a renamed namespace forwards).
+            setNotFound(true);
             setLoading(false);
           }
           return;
@@ -110,10 +122,41 @@ export function NamespaceHome() {
     };
   }, [namespaceSlug, token, reloadTick]);
 
+  // On a resolution miss, ask the server whether this bare namespace path
+  // forwards (a renamed slug). Fires only while `notFound` (mirrors
+  // TenantLayout's use of the same hook for deep tenant paths).
+  const staleForward = useStaleTenantForward(location.pathname, notFound);
+  useEffect(() => {
+    if (staleForward.state === 'done' && staleForward.to) {
+      navigate(staleForward.to, { replace: true });
+    }
+  }, [staleForward, navigate]);
+
   if (loading) {
     return (
       <div className="flex justify-center items-center min-h-[50vh]">
         <Spinner />
+      </div>
+    );
+  }
+
+  // A miss: keep rendering the spinner while the redirect lookup is in flight or
+  // a forward is about to navigate; only show "not found" once the lookup
+  // resolves to no redirect.
+  if (notFound) {
+    const settled = staleForward.state === 'done' && !staleForward.to;
+    if (!settled) {
+      return (
+        <div className="flex justify-center items-center min-h-[50vh]">
+          <Spinner />
+        </div>
+      );
+    }
+    return (
+      <div className="px-6 py-8">
+        <div className="bg-status-danger-bg border border-status-danger-border rounded-lg p-4 text-status-danger-text">
+          Namespace not found
+        </div>
       </div>
     );
   }

--- a/packages/ui/src/pages/NamespaceSettings.test.tsx
+++ b/packages/ui/src/pages/NamespaceSettings.test.tsx
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { tagAc } from '@memex-ai-ac/vitest';
+
+// spec-481 t-2 (ac-1) — the settings page shows the rename control only to an
+// administrator, and hides it (std-7 posture) from a non-admin member. Resolves
+// the namespace + role from the caller's own namespace list.
+const AC_SCOPE = 'mindset-prod/memex-building-itself/specs/spec-481/acs/ac-1';
+
+vi.mock('../components/AuthContext', () => ({
+  useAuth: () => ({ token: 'test-token', refreshSession: vi.fn() }),
+}));
+
+const listMyNamespacesApi = vi.fn();
+vi.mock('../api/client', () => ({
+  listMyNamespacesApi: (...a: unknown[]) => listMyNamespacesApi(...a),
+}));
+
+// The rename section is exercised in its own test; stub it so this test targets
+// the page's resolve + authorize logic in isolation.
+vi.mock('../components/RenameNamespaceSection', () => ({
+  RenameNamespaceSection: ({ currentSlug }: { currentSlug: string }) => (
+    <div data-testid="rename-section">rename {currentSlug}</div>
+  ),
+}));
+
+import { NamespaceSettings } from './NamespaceSettings';
+
+function renderAt(slug: string) {
+  return render(
+    <MemoryRouter initialEntries={[`/${slug}/settings`]}>
+      <Routes>
+        <Route path="/:namespace/settings" element={<NamespaceSettings />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('NamespaceSettings (spec-481 t-2)', () => {
+  it('renders the rename control for an administrator', async () => {
+    tagAc(AC_SCOPE);
+    listMyNamespacesApi.mockResolvedValue([
+      { namespaceId: 'ns-1', namespaceSlug: 'acme', kind: 'team', role: 'administrator', memexes: [] },
+    ]);
+    renderAt('acme');
+    expect(await screen.findByTestId('rename-section')).toHaveTextContent('rename acme');
+  });
+
+  it('hides the control from a non-admin member', async () => {
+    tagAc(AC_SCOPE);
+    listMyNamespacesApi.mockResolvedValue([
+      { namespaceId: 'ns-1', namespaceSlug: 'acme', kind: 'team', role: 'member', memexes: [] },
+    ]);
+    renderAt('acme');
+    await waitFor(() =>
+      expect(screen.getByText(/only administrators/i)).toBeInTheDocument(),
+    );
+    expect(screen.queryByTestId('rename-section')).toBeNull();
+  });
+});

--- a/packages/ui/src/pages/NamespaceSettings.tsx
+++ b/packages/ui/src/pages/NamespaceSettings.tsx
@@ -1,0 +1,72 @@
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { useAuth } from '../components/AuthContext';
+import { listMyNamespacesApi, type NamespaceGroup } from '../api/client';
+import { RenameNamespaceSection } from '../components/RenameNamespaceSection';
+import { PageHeader } from '../components/PageHeader';
+import { Spinner } from '../components/Spinner';
+
+// spec-481 t-2 (ac-4/ac-1) — the per-namespace settings page, mounted at
+// /:namespace/settings (safe above /:namespace/:memex because `settings` is a
+// reserved slug, so no Memex can be named it). Serves both org and personal
+// namespaces: it resolves the namespaceId + caller role from the caller's own
+// namespace list (same source as NamespaceHome), and only an administrator sees
+// the rename control (personal-namespace owners come back as `administrator`).
+// Authorization is enforced server-side too (renameNamespaceSlug) per std-7;
+// this gate just avoids showing a control that would 4xx.
+export function NamespaceSettings() {
+  const { namespace: namespaceSlug } = useParams<{ namespace: string }>();
+  const { token } = useAuth();
+  const [group, setGroup] = useState<NamespaceGroup | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!namespaceSlug) return;
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    listMyNamespacesApi(token)
+      .then((groups) => {
+        if (cancelled) return;
+        setGroup(groups.find((g) => g.namespaceSlug === namespaceSlug) ?? null);
+        setLoading(false);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : 'Failed to load');
+        setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [namespaceSlug, token]);
+
+  if (loading) {
+    return (
+      <div className="flex justify-center items-center min-h-[50vh]">
+        <Spinner />
+      </div>
+    );
+  }
+
+  const isAdmin = group?.role === 'administrator' && !!group.namespaceId;
+
+  return (
+    <div className="max-w-2xl mx-auto px-6 py-6 space-y-6">
+      <PageHeader title="Namespace settings" />
+      {error && <p className="text-sm text-status-danger-text">{error}</p>}
+      {!error && !isAdmin && (
+        <p className="text-sm text-secondary">
+          Only administrators can configure this namespace.
+        </p>
+      )}
+      {isAdmin && group && (
+        <RenameNamespaceSection
+          namespaceId={group.namespaceId!}
+          currentSlug={group.namespaceSlug}
+        />
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Release develop → main

Promotes the accumulated `develop` work to production (std-21 merge-commit release; content invariant `git log develop..main --no-merges` empty holds).

### What ships

**Activation / lifecycle emails** (flag-gated — nothing sends on deploy; `ACTIVATION_EMAILS_ENABLED` stays `0`)
- spec-468 — email accent recolour coral `#FC4F64` → brand blue `#0482DC`
- spec-480 — win-back email: clickable video thumbnail + single-cohort send
- spec-488 — welcome email v2: new copy + clickable video thumbnail
- spec-487 — per-email how-to videos + copy rewrite (Day-2/Day-3/Day-8/Day-12)
- spec-493 — email-preview activation timeline + send conditions

**Namespace rename** (touches prod routing)
- spec-481 — namespace rename writes a redirect + reuse-guard; `/:namespace/settings` page + route; bare `/<old-ns>` forwards after rename; D-2 redirect-source guard

**Other**
- spec-484 — journey-62 full-stack e2e (test only)
- UI — Memex settings section reorder (identity + visibility first, rename last)

### Safety
- **No emails sent by this deploy** — the activation sequence stays behind `ACTIVATION_EMAILS_ENABLED=0`. The blast is a separate, deliberate step after this release.
- Postmark broadcast stream verified (canary delivered + unsubscribe rendered → confirmed Broadcast-type).
- Int green on `dd10a394` (test + deploy + CodeQL) before promotion.

### Post-merge (prod)
1. Confirm prod deploy green + `memex-api` healthy.
2. (Separately, when ready) flip `ACTIVATION_EMAILS_ENABLED=1` + controlled manual lifecycle-tick for the ~137 blast.
