### PR TITLE
spec-460: welcome video v6 — new 4:43 cut, video-first layout, 75% CTA reveal (issue-1)

### DIFF
--- a/packages/ui/e2e/journey-54-spec-460-welcome-ctas.spec.ts
+++ b/packages/ui/e2e/journey-54-spec-460-welcome-ctas.spec.ts
@@ -4,7 +4,7 @@
 // exercised against the running app:
 //   - the /welcome video src is the v6 asset (ac-1)
 //   - the "book a call" line is hidden during playback and revealed once the
-//     viewer crosses ~85%, linking to the booking alias in a new tab (ac-2)
+//     viewer crosses ~75%, linking to the booking alias in a new tab (ac-2)
 //   - the Getting Started sidebar card shows its rows and dismissal persists
 //     across a reload; dismissing every row unmounts the card (ac-3, ac-4)
 //   - the avatar dropdown carries the Download desktop app + Book a call
@@ -56,7 +56,7 @@ test(
     const callCta = page.getByTestId("welcome-video-call-cta");
     await expect(callCta).toHaveAttribute("aria-hidden", "true");
 
-    // Drive the <video> past the 85% reveal threshold and fire timeupdate. jsdom
+    // Drive the <video> past the 75% reveal threshold and fire timeupdate. jsdom
     // can't decode the media, so we set the numbers directly and dispatch the event
     // the component listens on (matches how the unit test stubs playback).
     await page.getByTestId("welcome-video-player").evaluate((el) => {

--- a/packages/ui/e2e/journey-54-spec-460-welcome-ctas.spec.ts
+++ b/packages/ui/e2e/journey-54-spec-460-welcome-ctas.spec.ts
@@ -50,7 +50,7 @@ test(
 
     // ac-1: the video src is the v6 asset on the public CDN.
     const videoSrc = await page.getByTestId("welcome-video-player").getAttribute("src");
-    expect(videoSrc).toContain("welcome-to-memex-v6.mp4");
+    expect(videoSrc).toContain("welcome-to-memex-v6-1080p.mp4");
 
     // ac-2: the call line is hidden during playback.
     const callCta = page.getByTestId("welcome-video-call-cta");

--- a/packages/ui/e2e/journey-54-spec-460-welcome-ctas.spec.ts
+++ b/packages/ui/e2e/journey-54-spec-460-welcome-ctas.spec.ts
@@ -2,7 +2,7 @@
 //
 // Extends the spec-444 welcome arc (journey-53) with the spec-460 additions,
 // exercised against the running app:
-//   - the /welcome video src is the v5 asset (ac-1)
+//   - the /welcome video src is the v6 asset (ac-1)
 //   - the "book a call" line is hidden during playback and revealed once the
 //     viewer crosses ~85%, linking to the booking alias in a new tab (ac-2)
 //   - the Getting Started sidebar card shows its rows and dismissal persists
@@ -42,15 +42,15 @@ test.afterEach(async ({}, testInfo) => {
 });
 
 test(
-  "/welcome plays the v5 video (ac-1) and reveals the book-a-call line near the end (ac-2)",
+  "/welcome plays the v6 video (ac-1) and reveals the book-a-call line near the end (ac-2)",
   async ({ page }) => {
     await setVideoWelcomed(DEV_EMAIL, false);
     await page.goto(bareUrl("/"), { waitUntil: "commit" });
     await expect(page).toHaveURL(/\/welcome/, { timeout: 15_000 });
 
-    // ac-1: the video src is the v5 asset on the public CDN.
+    // ac-1: the video src is the v6 asset on the public CDN.
     const videoSrc = await page.getByTestId("welcome-video-player").getAttribute("src");
-    expect(videoSrc).toContain("welcome-to-memex-v5.mp4");
+    expect(videoSrc).toContain("welcome-to-memex-v6.mp4");
 
     // ac-2: the call line is hidden during playback.
     const callCta = page.getByTestId("welcome-video-call-cta");

--- a/packages/ui/src/pages/WelcomePage.telemetry.test.tsx
+++ b/packages/ui/src/pages/WelcomePage.telemetry.test.tsx
@@ -63,7 +63,7 @@ describe('WelcomePage — onboarding.video_* telemetry', () => {
     const started = track.mock.calls.filter((c) => c[0] === 'onboarding.video_started');
     expect(started).toHaveLength(1);
     expect(started[0][1]).toEqual({
-      video_id: 'welcome-to-memex-v5',
+      video_id: 'welcome-to-memex-v6',
       position_seconds: 3,
       duration_seconds: 120,
       percent_watched: 3, // 3/120 = 2.5 → rounded
@@ -80,7 +80,7 @@ describe('WelcomePage — onboarding.video_* telemetry', () => {
 
     const completed = track.mock.calls.filter((c) => c[0] === 'onboarding.video_completed');
     expect(completed).toHaveLength(1);
-    expect(completed[0][1]).toMatchObject({ video_id: 'welcome-to-memex-v5', percent_watched: 100 });
+    expect(completed[0][1]).toMatchObject({ video_id: 'welcome-to-memex-v6', percent_watched: 100 });
   });
 
   // spec-462: before completion the primary button is "▶ Play now" / "Playing…",
@@ -97,7 +97,7 @@ describe('WelcomePage — onboarding.video_* telemetry', () => {
 
     const skipped = track.mock.calls.filter((c) => c[0] === 'onboarding.video_skipped');
     expect(skipped).toHaveLength(1);
-    expect(skipped[0][1]).toMatchObject({ video_id: 'welcome-to-memex-v5', position_seconds: 10 });
+    expect(skipped[0][1]).toMatchObject({ video_id: 'welcome-to-memex-v6', position_seconds: 10 });
     await waitFor(() => expect(dismissWelcomeVideoApi).toHaveBeenCalled());
   });
 
@@ -227,7 +227,7 @@ describe('WelcomePage — spec-460 book-a-call reveal', () => {
     renderPage();
     const src = screen.getByTestId('welcome-video-player').getAttribute('src');
     expect(src).toBe(
-      'https://storage.googleapis.com/memex-ai-prod-app-static/media/welcome-to-memex-v5.mp4',
+      'https://storage.googleapis.com/memex-ai-prod-app-static/media/welcome-to-memex-v6.mp4',
     );
   });
 

--- a/packages/ui/src/pages/WelcomePage.telemetry.test.tsx
+++ b/packages/ui/src/pages/WelcomePage.telemetry.test.tsx
@@ -63,7 +63,7 @@ describe('WelcomePage — onboarding.video_* telemetry', () => {
     const started = track.mock.calls.filter((c) => c[0] === 'onboarding.video_started');
     expect(started).toHaveLength(1);
     expect(started[0][1]).toEqual({
-      video_id: 'welcome-to-memex-v6',
+      video_id: 'welcome-to-memex-v6-1080p',
       position_seconds: 3,
       duration_seconds: 120,
       percent_watched: 3, // 3/120 = 2.5 → rounded
@@ -80,7 +80,7 @@ describe('WelcomePage — onboarding.video_* telemetry', () => {
 
     const completed = track.mock.calls.filter((c) => c[0] === 'onboarding.video_completed');
     expect(completed).toHaveLength(1);
-    expect(completed[0][1]).toMatchObject({ video_id: 'welcome-to-memex-v6', percent_watched: 100 });
+    expect(completed[0][1]).toMatchObject({ video_id: 'welcome-to-memex-v6-1080p', percent_watched: 100 });
   });
 
   // spec-462: before completion the primary button is "▶ Play now" / "Playing…",
@@ -97,7 +97,7 @@ describe('WelcomePage — onboarding.video_* telemetry', () => {
 
     const skipped = track.mock.calls.filter((c) => c[0] === 'onboarding.video_skipped');
     expect(skipped).toHaveLength(1);
-    expect(skipped[0][1]).toMatchObject({ video_id: 'welcome-to-memex-v6', position_seconds: 10 });
+    expect(skipped[0][1]).toMatchObject({ video_id: 'welcome-to-memex-v6-1080p', position_seconds: 10 });
     await waitFor(() => expect(dismissWelcomeVideoApi).toHaveBeenCalled());
   });
 
@@ -227,7 +227,7 @@ describe('WelcomePage — spec-460 book-a-call reveal', () => {
     renderPage();
     const src = screen.getByTestId('welcome-video-player').getAttribute('src');
     expect(src).toBe(
-      'https://storage.googleapis.com/memex-ai-prod-app-static/media/welcome-to-memex-v6.mp4',
+      'https://storage.googleapis.com/memex-ai-prod-app-static/media/welcome-to-memex-v6-1080p.mp4',
     );
   });
 

--- a/packages/ui/src/pages/WelcomePage.telemetry.test.tsx
+++ b/packages/ui/src/pages/WelcomePage.telemetry.test.tsx
@@ -136,7 +136,7 @@ describe('WelcomePage — onboarding.video_* telemetry', () => {
 });
 
 // spec-460 dec-1/dec-7: the "book a call" line is hidden during playback, revealed
-// once the viewer is ≥85% through (or the video ends), links to the neutral booking
+// once the viewer is ≥75% through (or the video ends), links to the neutral booking
 // alias in a new tab, and never gates the path to /specs.
 describe('WelcomePage — spec-460 book-a-call reveal', () => {
   beforeEach(() => {
@@ -160,7 +160,7 @@ describe('WelcomePage — spec-460 book-a-call reveal', () => {
     expect(track.mock.calls.filter((c) => c[0] === 'onboarding.video_call_cta_shown')).toHaveLength(0);
 
     const video = screen.getByTestId('welcome-video-player') as HTMLVideoElement;
-    stubPlayback(video, 90, 100); // 90% > 85% threshold
+    stubPlayback(video, 90, 100); // 90% > 75% threshold
     fireEvent.timeUpdate(video);
 
     expect(cta).toHaveAttribute('aria-hidden', 'false');
@@ -172,7 +172,7 @@ describe('WelcomePage — spec-460 book-a-call reveal', () => {
     expect(screen.getByTestId('welcome-video-cta')).toBeInTheDocument();
   });
 
-  it('reveals at ≥85% via playback/seek, and via ended, and stays shown once revealed (fires once) (ac-9)', () => {
+  it('reveals at ≥75% via playback/seek, and via ended, and stays shown once revealed (fires once) (ac-9)', () => {
     tagAc(AC(9));
     renderPage();
     const cta = screen.getByTestId('welcome-video-call-cta');
@@ -184,7 +184,7 @@ describe('WelcomePage — spec-460 book-a-call reveal', () => {
     expect(cta).toHaveAttribute('aria-hidden', 'true');
 
     // Cross threshold: revealed.
-    stubPlayback(video, 86, 100);
+    stubPlayback(video, 76, 100);
     fireEvent.timeUpdate(video);
     expect(cta).toHaveAttribute('aria-hidden', 'false');
 

--- a/packages/ui/src/pages/WelcomePage.tsx
+++ b/packages/ui/src/pages/WelcomePage.tsx
@@ -27,10 +27,12 @@ const VIDEO_ID = 'welcome-to-memex-v6';
 // dec-6). ?src attributes the booking to this surface.
 const BOOK_A_CALL_URL = 'https://www.memex.ai/book-a-call?src=welcome-video';
 
-// spec-460 dec-7: reveal the call CTA once the viewer is ≥85% through the video.
-// The v4 cut is ~3 min, so a strict "on ended" reveal would reach far fewer
-// viewers; 85% catches near-finishers while staying roughly synced to the outro.
-const CALL_CTA_REVEAL_FRACTION = 0.85;
+// spec-460 dec-7: reveal the call CTA once the viewer is ≥75% through the video.
+// A strict "on ended" reveal would reach far fewer viewers; the fraction catches
+// near-finishers while staying roughly synced to the wind-down. Originally 85%
+// against the ~3-min v4 cut; lowered for the 4:43 v6 cut so the reveal lands at
+// ~3:33 instead of ~4:01 (issue-1 — fewer viewers survive to 85% of a longer video).
+const CALL_CTA_REVEAL_FRACTION = 0.75;
 
 // Build the numeric playback props shared by every onboarding.video_* event.
 // duration is NaN until metadata loads, so percent_watched is guarded against

--- a/packages/ui/src/pages/WelcomePage.tsx
+++ b/packages/ui/src/pages/WelcomePage.tsx
@@ -190,7 +190,11 @@ export function WelcomePage() {
         </svg>
       </button>
 
-      <div className="w-full max-w-[560px] flex flex-col gap-6">
+      {/* spec-460 issue-1: the column is video-first — 960px wide for the player
+          (the v6 cut is UI screen capture; legibility wants size), while the
+          button/link cluster below stays capped at 560px so the CTA doesn't
+          stretch to banner width. */}
+      <div className="w-full max-w-[960px] flex flex-col gap-6">
         <div className="text-center">
           <h1 className="text-4xl font-bold tracking-tight text-gray-900">Let's dive in.</h1>
           <p className="mt-2 text-base text-gray-600">
@@ -209,10 +213,16 @@ export function WelcomePage() {
           onPlaying={onVideoPlay}
           onTimeUpdate={onVideoTimeUpdate}
           onEnded={onVideoEnded}
-          className="w-full rounded-lg"
-          style={{ aspectRatio: '16/9' }}
+          className="w-full mx-auto rounded-lg"
+          // The v6 asset is 1128×720 (~1.567:1, not 16:9) — the box matches the
+          // video exactly so nothing letterboxes. The max-width term caps the
+          // rendered height at ~65vh (width = height × 1.5667) so heading +
+          // video + CTA stay on-screen together on shorter laptop viewports.
+          style={{ aspectRatio: '1128 / 720', maxWidth: 'min(100%, calc(65vh * 1.5667))' }}
         />
 
+        {/* Controls keep the original 560px measure under the wider video. */}
+        <div className="w-full max-w-[560px] mx-auto flex flex-col gap-6">
         {!isRewatch ? (
           <>
             {/* spec-462: one primary button, three states. Same testid + reserved
@@ -289,6 +299,7 @@ export function WelcomePage() {
             Book a 30-minute call with us
           </a>
         </p>
+        </div>
       </div>
     </div>
   );

--- a/packages/ui/src/pages/WelcomePage.tsx
+++ b/packages/ui/src/pages/WelcomePage.tsx
@@ -15,12 +15,12 @@ import { dismissWelcomeVideoApi } from '../api/auth';
 import { useTelemetry } from '../hooks/useTelemetry';
 
 const VIDEO_URL =
-  'https://storage.googleapis.com/memex-ai-prod-app-static/media/welcome-to-memex-v5.mp4';
+  'https://storage.googleapis.com/memex-ai-prod-app-static/media/welcome-to-memex-v6.mp4';
 
 // Stable, low-cardinality identifier for this video — the filename stem of
 // VIDEO_URL. Kept as its own const so a src bump is a one-line, deliberate change
 // (props carry ids/counts only — std-35 cl-5).
-const VIDEO_ID = 'welcome-to-memex-v5';
+const VIDEO_ID = 'welcome-to-memex-v6';
 
 // spec-460: the "book a call" CTA revealed near the end of the video points at the
 // neutral booking alias on the marketing site (never the raw HubSpot URL — std-31,

--- a/packages/ui/src/pages/WelcomePage.tsx
+++ b/packages/ui/src/pages/WelcomePage.tsx
@@ -15,12 +15,12 @@ import { dismissWelcomeVideoApi } from '../api/auth';
 import { useTelemetry } from '../hooks/useTelemetry';
 
 const VIDEO_URL =
-  'https://storage.googleapis.com/memex-ai-prod-app-static/media/welcome-to-memex-v6.mp4';
+  'https://storage.googleapis.com/memex-ai-prod-app-static/media/welcome-to-memex-v6-1080p.mp4';
 
 // Stable, low-cardinality identifier for this video — the filename stem of
 // VIDEO_URL. Kept as its own const so a src bump is a one-line, deliberate change
 // (props carry ids/counts only — std-35 cl-5).
-const VIDEO_ID = 'welcome-to-memex-v6';
+const VIDEO_ID = 'welcome-to-memex-v6-1080p';
 
 // spec-460: the "book a call" CTA revealed near the end of the video points at the
 // neutral booking alias on the marketing site (never the raw HubSpot URL — std-31,


### PR DESCRIPTION
## What

Implements spec-460 **issue-1** — replace the /welcome first-login video with the new cut.

1. **Asset swap v5 → v6.** `VIDEO_URL`/`VIDEO_ID` in `WelcomePage.tsx` now point at `welcome-to-memex-v6-1080p.mp4` (new 4:43 cut). Re-encoded to the streaming treatment at native 1692×1080 — H.264 CRF 21, ~2.1 Mbps, `+faststart` (raw export was 611 MB @ 17.2 Mbps → 75 MB; a 720p pass looked soft in the 960px player on 2x-DPR displays) — and already uploaded to `gs://memex-ai-prod-app-static/media/` (public URL 200, range 206, immutable cache). Nothing serves it until this merges.
2. **Video-first layout.** The v6 asset is 1128×720 (~1.567:1, not 16:9). The player box now matches the real aspect ratio (was hard-coded `16/9`, which would pillarbox), the video column widens 560px → 960px for legibility of the screen-capture content, with rendered height capped at ~65vh so heading + video + CTA fit shorter laptop viewports. The button/skip/book-a-call cluster keeps its original 560px measure.
3. **Book-a-call reveal 85% → 75%** (spec-460 dec-7 threshold). 85% of 4:43 is ~4:01 — materially fewer viewers reach it than on the ~3-min cut the threshold was tuned for. 75% lands the reveal at ~3:33, still in the wind-down.

No behaviour, telemetry-shape, or copy changes. The spec-462 three-state Play button is untouched (event-driven, duration-agnostic).

## Testing

- Unit: `WelcomePage.telemetry.test.tsx` 14/14 (stubs updated to the 75% boundary); `tsc` clean.
- e2e: `make e2e-cold` — **153 passed**, 2 failed = the two journey-45 (spec-304 MCP mint) tests that fail locally on a clean checkout too (pre-existing local-env issue, green on CI); journey-54 (this page) passes.
- Manual: verified locally via start-memex.sh — v6 streams instantly from GCS, layout checked on /welcome (first-run + rewatch variants), reveal checked by seeking past 75%. Ryan signed off the look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

