### PR TITLE
spec-489 G1: batch the AC-emit burst (/api/test-events/batch + batched emitter)

### DIFF
--- a/packages/ac-emit-vitest/src/emit-batch.test.ts
+++ b/packages/ac-emit-vitest/src/emit-batch.test.ts
@@ -1,0 +1,239 @@
+// spec-489 G1 — emitBatch(): flush MANY emissions in ONE request. The durable
+// relief for the CI-burst problem — a suite that tags N tests makes ~one request
+// per file instead of N per-test POSTs (ac-3). Same fail-safe contract as emit().
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { emitBatch, tagAc } from "./index.js";
+
+const AC489 = "mindset-prod/memex-building-itself/specs/spec-489/acs";
+
+const okBatchResponse = (accepted: number) => ({
+  ok: true,
+  status: 200,
+  headers: new Headers(),
+  json: async () => ({ accepted, rejected: 0, results: [] }),
+});
+
+const entry = (over: Partial<{ ac_uid: string; test_identifier: string }> = {}) => ({
+  ac_uid: "mindset-prod/foo/specs/spec-1/acs/ac-1",
+  status: "pass" as const,
+  test_identifier: "test.ts::t",
+  duration_ms: 1,
+  ...over,
+});
+
+beforeEach(() => {
+  vi.stubEnv("MEMEX_EMIT", "");
+  vi.stubEnv("MEMEX_EMIT_KEY", "");
+  vi.stubEnv("MEMEX_TEST_EVENTS_URL", "");
+  // Clear the actor fallback chain so payload assertions are stable.
+  vi.stubEnv("GITHUB_ACTOR", "");
+  vi.stubEnv("GITLAB_USER_LOGIN", "");
+  vi.stubEnv("BUILDKITE_BUILD_AUTHOR", "");
+  vi.stubEnv("CIRCLE_USERNAME", "");
+  vi.stubEnv("USER", "");
+  vi.stubEnv("USERNAME", "");
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+});
+
+describe("emitBatch() — one request carries many events (spec-489 G1)", () => {
+  it("posts a SINGLE batch request for N entries, collapsing N round trips to 1 (ac-3)", async () => {
+    tagAc(`${AC489}/ac-3`);
+    const fetchMock = vi.fn().mockResolvedValue(okBatchResponse(5));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const entries = Array.from({ length: 5 }, (_, i) =>
+      entry({ test_identifier: `test.ts::t${i}` }),
+    );
+    await emitBatch(entries);
+
+    // 5 tagged results, ONE HTTP request (and one pool slot), not 5.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://memex.ai/api/test-events/batch");
+    expect(init.method).toBe("POST");
+    const body = JSON.parse(init.body as string) as { events: unknown[] };
+    expect(body.events).toHaveLength(5);
+  });
+
+  it("makes ZERO requests when MEMEX_EMIT is off (ac-3 — off switch honoured)", async () => {
+    tagAc(`${AC489}/ac-3`);
+    vi.stubEnv("MEMEX_EMIT", "false");
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await emitBatch([entry(), entry()]);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("makes ZERO requests for an empty buffer (no tagged tests → no HTTP)", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await emitBatch([]);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("drops entries whose ref can't be routed, batching only the valid ones", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okBatchResponse(1));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await emitBatch([
+      entry({ ac_uid: "" }), // malformed — no namespace, dropped
+      entry({ ac_uid: "mindset-prod/foo/specs/spec-1/acs/ac-1" }),
+    ]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string) as { events: unknown[] };
+    expect(body.events).toHaveLength(1);
+  });
+
+  it("sends one batch PER destination when a file mixes namespaces", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okBatchResponse(1));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await emitBatch([
+      entry({ ac_uid: "mindset-prod/foo/specs/spec-1/acs/ac-1" }),
+      entry({ ac_uid: "mindset-int/foo/specs/spec-1/acs/ac-1" }),
+    ]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const urls = fetchMock.mock.calls.map((c) => c[0]);
+    expect(urls).toContain("https://memex.ai/api/test-events/batch");
+    expect(urls).toContain("https://int.memex.ai/api/test-events/batch");
+  });
+
+  it("attaches Authorization: Bearer <key> and Content-Type on the batch request (spec-129)", async () => {
+    vi.stubEnv("MEMEX_EMIT_KEY", "mxk_batch_key");
+    const fetchMock = vi.fn().mockResolvedValue(okBatchResponse(1));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await emitBatch([entry()]);
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const headers = init.headers as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer mxk_batch_key");
+    expect(headers["Content-Type"]).toBe("application/json");
+  });
+
+  it("sends NO Authorization header when MEMEX_EMIT_KEY is unset (batch still attempted)", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okBatchResponse(1));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await emitBatch([entry()]);
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const headers = init.headers as Record<string, string>;
+    expect(headers.Authorization).toBeUndefined();
+  });
+});
+
+describe("emitBatch() — fail-safe contract (spec-489 G1, mirrors emit())", () => {
+  it("does NOT throw and surfaces the body on a non-2xx batch response", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      headers: new Headers(),
+      text: async () => "call provision_ac_emission for a fresh key",
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(emitBatch([entry(), entry()])).resolves.toBeUndefined();
+    const warned = warnSpy.mock.calls.flat().join(" ");
+    expect(warned).toContain("401");
+    expect(warned).toContain("call provision_ac_emission for a fresh key");
+    warnSpy.mockRestore();
+  });
+
+  it("does NOT throw when fetch itself rejects (network error swallowed)", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const fetchMock = vi.fn().mockRejectedValue(new Error("network down"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(emitBatch([entry()])).resolves.toBeUndefined();
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it("bounds the batch POST with an AbortSignal so a hung server cannot stall the suite", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okBatchResponse(1));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await emitBatch([entry()]);
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("falls back to single-event POSTs when the server has no /batch route (404) — rollout safety", async () => {
+    tagAc(`${AC489}/ac-3`);
+    // Older server / self-hosted install without the batch endpoint: /batch 404s.
+    // The emitter must still land every event via the single-event route so a
+    // deploy-ordering gap never drops emissions.
+    const fetchMock = vi.fn().mockImplementation((url: string) => {
+      if (url.endsWith("/batch")) {
+        return Promise.resolve({ ok: false, status: 404, headers: new Headers(), text: async () => "Not Found" });
+      }
+      return Promise.resolve({ ok: true, status: 201, headers: new Headers() });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await emitBatch([
+      entry({ test_identifier: "a" }),
+      entry({ test_identifier: "b" }),
+      entry({ test_identifier: "c" }),
+    ]);
+
+    const urls = fetchMock.mock.calls.map((c) => c[0] as string);
+    // One /batch attempt, then one single POST per event (3) once it 404s.
+    expect(urls.filter((u) => u.endsWith("/batch"))).toHaveLength(1);
+    expect(urls.filter((u) => u === "https://memex.ai/api/test-events")).toHaveLength(3);
+  });
+
+  it("does the same fallback on a 405 (method/route not present)", async () => {
+    const fetchMock = vi.fn().mockImplementation((url: string) => {
+      if (url.endsWith("/batch")) {
+        return Promise.resolve({ ok: false, status: 405, headers: new Headers(), text: async () => "" });
+      }
+      return Promise.resolve({ ok: true, status: 201, headers: new Headers() });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await emitBatch([entry()]);
+
+    const urls = fetchMock.mock.calls.map((c) => c[0] as string);
+    expect(urls).toContain("https://memex.ai/api/test-events/batch");
+    expect(urls).toContain("https://memex.ai/api/test-events");
+  });
+
+  it("surfaces per-event rejections carried in a 200 batch body (partial failure stays loud, spec-333)", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers(),
+      json: async () => ({
+        accepted: 1,
+        rejected: 1,
+        results: [
+          { index: 0, ok: true, id: "x" },
+          { index: 1, ok: false, error: "scoped to Spec spec-999" },
+        ],
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(emitBatch([entry(), entry()])).resolves.toBeUndefined();
+    const warned = warnSpy.mock.calls.flat().join(" ");
+    expect(warned).toContain("rejected");
+    expect(warned).toContain("scoped to Spec spec-999");
+    warnSpy.mockRestore();
+  });
+});

--- a/packages/ac-emit-vitest/src/emit.ts
+++ b/packages/ac-emit-vitest/src/emit.ts
@@ -192,3 +192,127 @@ export async function emit(
     );
   }
 }
+
+/**
+ * POST MANY emissions to the Memex BATCH endpoint in ONE request (spec-489 G1).
+ *
+ * This is the durable relief for the CI-burst problem: instead of one POST per
+ * tagged test (setup.ts previously awaited `emit()` in an `afterEach`), the
+ * setup module buffers a file's emissions and flushes them here as a single
+ * request. A suite that tags N tests then makes ~one request per test FILE, so
+ * it no longer opens one server connection-pool slot per test.
+ *
+ * Honours the SAME fail-safe contract as `emit()`: it swallows a non-2xx
+ * response AND any network / timeout error (a failed emission must never fail a
+ * test run), bounds the request with a 5s `AbortSignal.timeout` (a hung server
+ * must not stall the suite), and surfaces the server's response body on a
+ * non-2xx. It also surfaces per-event rejections the batch endpoint reports in a
+ * 200 body (e.g. a scoped-key mismatch), so the actionable 401 guidance still
+ * reaches the developer (spec-333) even when batched.
+ *
+ * Events are grouped by their derived destination (`deriveEventsUrl`), so a file
+ * that happens to tag refs in more than one namespace sends one batch per
+ * destination. An entry whose ref can't be routed (malformed, no namespace) is
+ * dropped, exactly as `emit()` drops it.
+ *
+ * `transport` defaults to the live `globalThis.fetch` for unit tests; production
+ * (setup.ts) passes `capturedFetch` for spec-302 immunity.
+ */
+export async function emitBatch(
+  entries: EmitArgs[],
+  transport: typeof fetch = globalThis.fetch,
+): Promise<void> {
+  if (!isEmissionEnabled()) return;
+  if (entries.length === 0) return;
+
+  // Group ENTRIES by destination base URL (deriveEventsUrl applies the namespace
+  // routing table + MEMEX_TEST_EVENTS_URL override). Entries in one test file
+  // normally share a namespace, so this is usually a single bucket. We keep the
+  // original entries (not just payloads) so a batch that lands on a server
+  // without the /batch route can fall back to per-event single POSTs.
+  const byUrl = new Map<string, EmitArgs[]>();
+  for (const entry of entries) {
+    const url = deriveEventsUrl(entry.ac_uid);
+    if (url === null) continue; // malformed ref → nothing to route, drop it
+    const bucket = byUrl.get(url);
+    if (bucket) bucket.push(entry);
+    else byUrl.set(url, [entry]);
+  }
+
+  // spec-129: attach the emission key as a Bearer token when MEMEX_EMIT_KEY is
+  // set (one key authenticates the whole batch, server-side). When unset, no
+  // Authorization header — the batch is rejected once the server enforces keys,
+  // which is swallowed like any other failed emission.
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  const emissionKey = readEmissionKey();
+  if (emissionKey) {
+    headers.Authorization = `Bearer ${emissionKey}`;
+  }
+
+  for (const [eventsUrl, bucket] of byUrl) {
+    // The batch endpoint sits alongside the single-event route: `…/api/test-events/batch`.
+    const batchUrl = `${eventsUrl}/batch`;
+    const events = bucket.map((entry) => buildPayload(entry));
+    try {
+      const res = await transport(batchUrl, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ events }),
+        // Bound the request client-side for the same reason emit() does: a hung
+        // server must abort into the catch below rather than ride past vitest's
+        // hook timeout and fail the run.
+        signal: AbortSignal.timeout(5000),
+      });
+
+      // ROLLOUT SAFETY (spec-489, std-22): a 404/405 means this server has no
+      // /batch route yet (an older deploy, or a self-hosted install on a prior
+      // version). Fall back to the single-event endpoint so emissions still land
+      // — the batch endpoint is an optimisation, never a hard dependency. The
+      // /batch route itself only ever returns 200/400/401, so 404/405 is an
+      // unambiguous "route absent" signal, not a per-request error.
+      if (res.status === 404 || res.status === 405) {
+        await Promise.all(
+          bucket.map((entry) => emit(entry, transport)),
+        );
+        continue;
+      }
+
+      if (!res.ok) {
+        const responseBody = await Promise.resolve()
+          .then(() => res.text())
+          .catch(() => "");
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[ac-emit] batch POST ${batchUrl} returned ${res.status} for ${events.length} event(s)` +
+            (responseBody ? `: ${responseBody}` : ""),
+        );
+      } else {
+        // A 200 batch can still carry per-event rejections (partial failure).
+        // Surface them so a scoped-key / boundary rejection stays loud (spec-333),
+        // guarded so a body-read failure never breaks the fail-safe contract.
+        const summary = (await Promise.resolve()
+          .then(() => res.json())
+          .catch(() => null)) as {
+          rejected?: number;
+          results?: Array<{ index: number; ok: boolean; error?: string }>;
+        } | null;
+        if (summary?.rejected && summary.rejected > 0) {
+          const failures = (summary.results ?? []).filter((r) => !r.ok);
+          // eslint-disable-next-line no-console
+          console.warn(
+            `[ac-emit] batch POST ${batchUrl}: ${summary.rejected} of ${events.length} event(s) rejected` +
+              (failures.length
+                ? `: ${failures.map((f) => `#${f.index} ${f.error ?? ""}`.trim()).join("; ")}`
+                : ""),
+          );
+        }
+      }
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[ac-emit] batch POST ${batchUrl} failed for ${events.length} event(s):`,
+        err instanceof Error ? err.message : err,
+      );
+    }
+  }
+}

--- a/packages/ac-emit-vitest/src/index.ts
+++ b/packages/ac-emit-vitest/src/index.ts
@@ -3,7 +3,7 @@ import type { TagAcOptions } from "./types.js";
 export type { AcEventPayload, TagAcOptions } from "./types.js";
 export { readAutoActor } from "./actor.js";
 export { deriveEventsUrl } from "./derive-url.js";
-export { isEmissionEnabled, readEmissionKey, buildPayload, emit } from "./emit.js";
+export { isEmissionEnabled, readEmissionKey, buildPayload, emit, emitBatch } from "./emit.js";
 export { buildMetadata } from "./metadata.js";
 
 const META_KEY = "__memex_ac_uids";

--- a/packages/ac-emit-vitest/src/setup.ts
+++ b/packages/ac-emit-vitest/src/setup.ts
@@ -1,5 +1,5 @@
 /**
- * Vitest setup module — wires beforeEach / afterEach hooks for AC emission.
+ * Vitest setup module — wires beforeEach / afterEach / afterAll hooks for AC emission.
  *
  * Import this file for side effects from your `vitest.config.ts`
  * setupFiles:
@@ -9,16 +9,45 @@
  * Tests opt in by calling `tagAc('<canonical-ac-ref>')` from
  * '@memex-ai-ac/vitest' inside an `it()` / `test()` body. Untagged tests
  * emit nothing.
+ *
+ * spec-489 G1 — emissions are BATCHED. `afterEach` buffers each tagged test's
+ * result instead of POSTing it; a top-level `afterAll` flushes the whole file's
+ * buffer as ONE batch request (`emitBatch`). A suite that tags N tests then
+ * makes ~one request per test FILE rather than N per-test POSTs — the
+ * connection-pool relief the CI-burst report asked for. This changes only the
+ * transport (how events travel), never their meaning: every buffered event is
+ * still emitted, exactly once, with the same wire payload. No consumer config
+ * changes — the same `setupFiles` import wires it.
  */
-import { beforeEach, afterEach } from "vitest";
-import { _setCurrentTask, _readCurrentEntries, type TaskLike } from "./index.js";
-import { emit, capturedFetch } from "./emit.js";
+import { beforeEach, afterEach, afterAll } from "vitest";
+import {
+  _setCurrentTask,
+  _readCurrentEntries,
+  type TaskLike,
+} from "./index.js";
+import { emitBatch, capturedFetch } from "./emit.js";
+import type { TagAcOptions } from "./types.js";
+
+interface BufferedEmission {
+  ac_uid: string;
+  status: "pass" | "fail";
+  test_identifier: string;
+  duration_ms: number;
+  options?: TagAcOptions;
+}
+
+// The file's pending emissions, buffered by afterEach and drained by afterAll.
+// Module-scoped, so it holds exactly the emissions of the test file this setup
+// module was evaluated for; the afterAll drain (splice) makes it robust even if
+// a runner shares the module across files — each flush sends only what has
+// accumulated since the previous flush.
+const pending: BufferedEmission[] = [];
 
 beforeEach(({ task }) => {
   _setCurrentTask(task as unknown as TaskLike);
 });
 
-afterEach(async ({ task }) => {
+afterEach(({ task }) => {
   const taskLike = task as unknown as TaskLike;
   const entries = _readCurrentEntries(taskLike);
   if (entries.length === 0) {
@@ -35,13 +64,22 @@ afterEach(async ({ task }) => {
   const test_identifier = `${task.file?.name ?? "<unknown>"}::${task.name}`;
   const duration_ms = task.result?.duration ?? 0;
 
-  // Emit through the module-load-captured fetch (spec-302): immune to any test
-  // that replaced globalThis.fetch and didn't restore it.
-  await Promise.all(
-    entries.map(({ ac_uid, options }) =>
-      emit({ ac_uid, status: state, test_identifier, duration_ms, options }, capturedFetch),
-    ),
-  );
+  // Buffer (don't POST) — a test tagged with K ACs contributes K events, exactly
+  // as before; only the flush is deferred to the end of the file.
+  for (const { ac_uid, options } of entries) {
+    pending.push({ ac_uid, status: state, test_identifier, duration_ms, options });
+  }
 
   _setCurrentTask(null);
+});
+
+afterAll(async () => {
+  if (pending.length === 0) return;
+  // Drain so a second flush (shared-module runner) can't re-send these events.
+  const batch = pending.splice(0, pending.length);
+  // Flush through the module-load-captured fetch (spec-302): immune to any test
+  // that replaced globalThis.fetch and didn't restore it. emitBatch honours the
+  // fail-safe contract (swallows non-2xx + network/timeout), so a flush can
+  // never fail the run.
+  await emitBatch(batch, capturedFetch);
 });

--- a/packages/server/src/routes/test-events.test.ts
+++ b/packages/server/src/routes/test-events.test.ts
@@ -60,10 +60,13 @@ import {
   META_MAX_TOTAL_BYTES,
   META_MAX_KEYS,
   META_MAX_VALUE_CHARS,
+  MAX_BATCH_EVENTS,
 } from "./test-events.js";
 // spec-333: the mocked emission-keys module (see vi.mock above) — imported so individual
 // tests can override verifyEmissionKey to exercise the scoped-key / missing-key 401 paths.
-import { verifyEmissionKey } from "../services/emission-keys.js";
+// spec-489: resolveMemexId is imported too so a batch test can force ONE event to resolve to a
+// different Memex than the key authorises (the in-batch auth-boundary case).
+import { verifyEmissionKey, resolveMemexId } from "../services/emission-keys.js";
 
 const AC = "mindset-prod/memex-building-itself/specs/spec-115/acs";
 const AC333 = "mindset-prod/memex-building-itself/specs/spec-333/acs";
@@ -452,5 +455,143 @@ describe("META_MAX_VALUE_CHARS constant is exported", () => {
 
   it("exports the 4096 byte total cap", () => {
     expect(META_MAX_TOTAL_BYTES).toBe(4096);
+  });
+});
+
+// spec-489 G1 — POST /api/test-events/batch. The durable relief for the CI-burst
+// problem: many emissions ride ONE authenticated request instead of one POST per
+// tagged test (ac-3), with semantics identical to N single POSTs (ac-5). Same
+// mocked DB / auth harness as the single-event tests above.
+const AC489 = "mindset-prod/memex-building-itself/specs/spec-489/acs";
+
+describe("POST /api/test-events/batch — spec-489 G1 (batch the burst)", () => {
+  // Widened past validBody's four keys so a test can add actor / metadata / an
+  // invalid status when exercising a specific in-batch code path.
+  const ev = (over: Record<string, unknown> = {}) => ({ ...validBody, ...over });
+
+  const postBatch = (events: unknown, auth = true) =>
+    app.request("/api/test-events/batch", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...(auth ? { Authorization: "Bearer mxk_test" } : {}),
+      },
+      body: JSON.stringify({ events }),
+    });
+
+  it("ingests N events in ONE request → N inserts, accepted=N (ac-3, ac-5)", async () => {
+    tagAc(`${AC489}/ac-3`);
+    tagAc(`${AC489}/ac-5`);
+    const res = await postBatch([
+      ev({ test_identifier: "a" }),
+      ev({ test_identifier: "b" }),
+      ev({ test_identifier: "c" }),
+    ]);
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as {
+      accepted: number;
+      rejected: number;
+      results: Array<{ ok: boolean }>;
+    };
+    expect(json.accepted).toBe(3);
+    expect(json.rejected).toBe(0);
+    expect(json.results).toHaveLength(3);
+    expect(json.results.every((r) => r.ok)).toBe(true);
+    // One request, but one insert PER event — same DB path as a single POST, just
+    // no longer one HTTP round trip (and one pool slot) per tagged test.
+    expect(insertSpy).toHaveBeenCalledTimes(3);
+  });
+
+  it("authenticates ONCE per batch — a missing key 401s the whole batch, zero inserts (ac-5)", async () => {
+    tagAc(`${AC489}/ac-5`);
+    const res = await postBatch([ev(), ev()], /* auth */ false);
+    expect(res.status).toBe(401);
+    expect(insertSpy).not.toHaveBeenCalled();
+  });
+
+  it("partial failure — a malformed event is rejected but its neighbours still land (ac-5)", async () => {
+    tagAc(`${AC489}/ac-5`);
+    const res = await postBatch([
+      ev({ test_identifier: "good1" }),
+      ev({ status: "bogus" }), // invalid status → rejected in-batch
+      ev({ test_identifier: "good2" }),
+    ]);
+    // The batch as a whole succeeds (200) even though one event failed — a bad
+    // event does NOT 400 the request or discard the good events.
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as {
+      accepted: number;
+      rejected: number;
+      results: Array<{ index: number; ok: boolean; error?: string }>;
+    };
+    expect(json.accepted).toBe(2);
+    expect(json.rejected).toBe(1);
+    expect(json.results[1]!.ok).toBe(false);
+    expect(json.results[1]!.error).toContain("status");
+    expect(insertSpy).toHaveBeenCalledTimes(2); // only the two good events inserted
+  });
+
+  it("preserves the Memex auth boundary — a cross-Memex event is rejected in-batch, neighbours unaffected (ac-5)", async () => {
+    tagAc(`${AC489}/ac-5`);
+    // Force the FIRST event to resolve to a Memex the key does not authorise.
+    vi.mocked(resolveMemexId).mockResolvedValueOnce("some-other-memex");
+    const res = await postBatch([
+      ev({ test_identifier: "cross" }),
+      ev({ test_identifier: "ok1" }),
+      ev({ test_identifier: "ok2" }),
+    ]);
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as {
+      accepted: number;
+      rejected: number;
+      results: Array<{ index: number; ok: boolean; error?: string }>;
+    };
+    expect(json.accepted).toBe(2);
+    expect(json.rejected).toBe(1);
+    expect(json.results[0]!.ok).toBe(false);
+    expect(json.results[0]!.error).toContain("does not authorise");
+    // Batching added no new cross-boundary write path: the rejected event never inserted.
+    expect(insertSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects a non-array events body and an oversized batch with 400, inserting nothing (ac-5 boundary)", async () => {
+    tagAc(`${AC489}/ac-5`);
+    const notArray = await postBatch("nope");
+    expect(notArray.status).toBe(400);
+
+    const oversized = await postBatch(
+      Array.from({ length: MAX_BATCH_EVENTS + 1 }, () => ev()),
+    );
+    expect(oversized.status).toBe(400);
+    expect(insertSpy).not.toHaveBeenCalled();
+  });
+
+  it("a batched event stores a row identical to a single POST (ac-5 — same meaning)", async () => {
+    tagAc(`${AC489}/ac-5`);
+    const captured: Array<Record<string, unknown>> = [];
+    insertSpy.mockReturnValue({
+      values: (v: Record<string, unknown>) => {
+        captured.push(v);
+        return {
+          returning: vi
+            .fn()
+            .mockResolvedValue([{ id: "fake-uuid", createdAt: new Date() }]),
+        };
+      },
+    });
+    const one = ev({
+      test_identifier: "same.ts::t",
+      actor: "wic@mindset.ai",
+      metadata: { branch: "main" },
+    });
+    const res = await postBatch([one]);
+    expect(res.status).toBe(200);
+    const row = captured[0]!;
+    expect(row.subjectRef).toBe(one.ac_uid);
+    expect(row.status).toBe("pass");
+    expect(row.testIdentifier).toBe("same.ts::t");
+    expect(row.actor).toBe("wic@mindset.ai");
+    expect(row.hidden).toBe(false);
+    expect(row.metadata).toEqual({ branch: "main" });
   });
 });

--- a/packages/server/src/routes/test-events.ts
+++ b/packages/server/src/routes/test-events.ts
@@ -50,6 +50,18 @@
 //
 // Also logs every received event to stdout so observers can watch the
 // stream during deploys and incident triage.
+//
+// ── Batch ingest: POST /api/test-events/batch (spec-489 G1) ────────────────
+// Ingests MANY emissions in ONE authenticated request so a CI suite that tags N
+// tests no longer fires N per-test POSTs (each taking a DB-pool slot) — it sends
+// ~one request per test FILE instead. Body: { events: [ <same shape as above>,
+// … ] } (1..MAX_BATCH_EVENTS). Auth is once per batch (the same Bearer key);
+// each event is still independently memex-matched + spec-scope-gated, so a batch
+// cannot write across a Memex boundary. Partial failure is non-fatal: bad events
+// are reported per-index and the good ones still land. Response: 200 with
+// { accepted, rejected, results: [{ index, ok, id?, status?, error? }] }. The
+// single-event route above is unchanged and remains the documented protocol for
+// hand-rolled emitters.
 
 import { Hono } from "hono";
 import { db } from "../db/connection.js";
@@ -174,23 +186,45 @@ function specHandleFromAcUid(subjectRef: string): string {
   return parts.length >= 4 && parts[2] === "specs" ? parts[3]! : "";
 }
 
-testEventsRouter.post("/", async (c) => {
-  // ── Emission-key auth (spec-129 dec-3) ──────────────────────────
-  // A valid per-Memex key is required for every emission. Authenticate from the
-  // Authorization: Bearer header ONLY (ac-8), BEFORE any payload work (ac-9).
-  // The memex-match (ac-10) runs once ac_uid is known. This key match is the
-  // SOLE identity gate — there is no server-owned-namespace check (spec-90 dec-7).
-  const authHeader = c.req.header("Authorization") ?? "";
+// spec-489 G1: the maximum number of events one POST /batch may carry. Bounds
+// the memory + DB work a single request can trigger so a batch cannot be used
+// to exhaust an instance (std-39 — reason about cost/growth, not just
+// correctness). A green CI file rarely tags more than a few dozen tests; 500 is
+// generous headroom. An oversized batch is a hard 400, never a silent truncation.
+export const MAX_BATCH_EVENTS = 500;
+
+// spec-489 G1: the outcome of ingesting ONE event. Returned as data (not an HTTP
+// response) so the single-event route and the batch route can each shape their
+// own response from the same processing. On success `droppedKeys` names any
+// metadata keys shed by the size caps (surfaced as a header on POST /, and
+// inline per-event on POST /batch).
+type ProcessResult =
+  | { ok: true; id: string; createdAt: Date; status: string; droppedKeys: string[] }
+  | { ok: false; code: 400 | 401; body: { error: string; message?: string } };
+
+type VerifiedEmissionKey = NonNullable<Awaited<ReturnType<typeof verifyEmissionKey>>>;
+
+// spec-489 G1: authenticate the emission key from the Authorization: Bearer
+// header ONLY (spec-129 ac-8), BEFORE any payload work (ac-9). Shared by the
+// single-event and batch routes so both gate identically. Returns the verified
+// key, or the exact 401 body callers should return.
+async function authenticateEmission(
+  authHeader: string,
+): Promise<
+  | { ok: true; key: VerifiedEmissionKey }
+  | { ok: false; body: { error: string; message: string } }
+> {
   const rawKey = authHeader.startsWith("Bearer ")
     ? authHeader.slice("Bearer ".length).trim()
     : "";
-  const emissionKey = rawKey ? await verifyEmissionKey(rawKey) : null;
-  if (!emissionKey) {
+  const key = rawKey ? await verifyEmissionKey(rawKey) : null;
+  if (!key) {
     // spec-333 ac-6: verifyEmissionKey returns null for a missing, invalid, OR expired key
     // alike. Give ONE remedy that fits all three (no expiry oracle, per spec-333's Architecture
     // & Security section): a coding agent re-provisions over MCP; CI uses a human-minted key.
-    return c.json(
-      {
+    return {
+      ok: false,
+      body: {
         error: "unauthorized",
         message:
           "A valid emission key is required (it may be missing, invalid, or expired). " +
@@ -200,16 +234,31 @@ testEventsRouter.post("/", async (c) => {
           "settings (Emission Keys) and stores it as the MEMEX_EMIT_KEY secret; the helper " +
           "attaches it as `Authorization: Bearer <key>`.",
       },
-      401,
-    );
+    };
   }
+  return { ok: true, key };
+}
 
-  let body: TestEventBody;
-  try {
-    body = await c.req.json();
-  } catch {
-    return c.json({ error: "Body must be valid JSON" }, 400);
+// spec-489 G1: the per-event ingest pipeline, extracted from POST / so the
+// single-event and the batched routes share ONE code path. A batched event
+// therefore produces a byte-identical stored row to a one-per-POST event (ac-5:
+// batching changes only how events travel, never what they mean).
+//
+// Authentication is NOT performed here — the caller verifies the emission key
+// ONCE (authenticateEmission) and passes the resolved key in. Every event is
+// still independently memex-matched (spec-129 ac-10) and spec-scope-gated
+// (spec-234 ac-11) against that one key, so batching adds NO new way to write
+// across a Memex boundary (ac-5). A per-event failure is returned as data; the
+// batch caller keeps the good events (partial-failure) rather than discarding
+// the whole batch.
+async function processOneEvent(
+  emissionKey: VerifiedEmissionKey,
+  rawBody: unknown,
+): Promise<ProcessResult> {
+  if (typeof rawBody !== "object" || rawBody === null || Array.isArray(rawBody)) {
+    return { ok: false, code: 400, body: { error: "event must be a JSON object" } };
   }
+  const body = rawBody as TestEventBody;
 
   // spec-151 dec-3: dual-accept the neutral `subject_ref` field and the legacy
   // `ac_uid` wire field, mapping BOTH to the subject_ref column. `subject_ref`
@@ -221,28 +270,33 @@ testEventsRouter.post("/", async (c) => {
       ? body.subject_ref
       : body.ac_uid;
   if (typeof subjectRefValue !== "string" || subjectRefValue.length === 0) {
-    return c.json(
-      { error: "subject_ref (or legacy ac_uid) is required (string)" },
-      400,
-    );
+    return {
+      ok: false,
+      code: 400,
+      body: { error: "subject_ref (or legacy ac_uid) is required (string)" },
+    };
   }
   if (typeof body.status !== "string" || !VALID_STATUSES.has(body.status)) {
-    return c.json({ error: "status is required and must be one of pass|fail|error" }, 400);
+    return {
+      ok: false,
+      code: 400,
+      body: { error: "status is required and must be one of pass|fail|error" },
+    };
   }
   if (body.test_identifier !== undefined && typeof body.test_identifier !== "string") {
-    return c.json({ error: "test_identifier must be a string when provided" }, 400);
+    return { ok: false, code: 400, body: { error: "test_identifier must be a string when provided" } };
   }
   if (body.duration_ms !== undefined && typeof body.duration_ms !== "number") {
-    return c.json({ error: "duration_ms must be a number when provided" }, 400);
+    return { ok: false, code: 400, body: { error: "duration_ms must be a number when provided" } };
   }
   if (body.commit_sha !== undefined && typeof body.commit_sha !== "string") {
-    return c.json({ error: "commit_sha must be a string when provided" }, 400);
+    return { ok: false, code: 400, body: { error: "commit_sha must be a string when provided" } };
   }
   if (body.run_id !== undefined && typeof body.run_id !== "string") {
-    return c.json({ error: "run_id must be a string when provided" }, 400);
+    return { ok: false, code: 400, body: { error: "run_id must be a string when provided" } };
   }
   if (body.actor !== undefined && typeof body.actor !== "string") {
-    return c.json({ error: "actor must be a string when provided" }, 400);
+    return { ok: false, code: 400, body: { error: "actor must be a string when provided" } };
   }
   // spec-358 (dec-3, ac-1/ac-11): the inbound `hidden` field is no longer
   // honoured. We still accept it for backward compatibility — an old /
@@ -257,10 +311,7 @@ testEventsRouter.post("/", async (c) => {
       body.metadata === null ||
       Array.isArray(body.metadata))
   ) {
-    return c.json(
-      { error: "metadata must be an object when provided" },
-      400,
-    );
+    return { ok: false, code: 400, body: { error: "metadata must be an object when provided" } };
   }
 
   // spec-90 dec-7 (A1): no server-owned-namespace guard. The ref's namespace is
@@ -278,15 +329,16 @@ testEventsRouter.post("/", async (c) => {
     memexSlugFromAcUid(subjectRefValue),
   );
   if (!targetMemexId || targetMemexId !== emissionKey.memexId) {
-    return c.json(
-      {
+    return {
+      ok: false,
+      code: 401,
+      body: {
         error: "unauthorized",
         message:
           "This emission key does not authorise the Memex named in the subject ref. A key only " +
           "works for the Memex it was generated in.",
       },
-      401,
-    );
+    };
   }
 
   // Spec-scope gate (spec-234 ac-11): an ephemeral / agent key carries a
@@ -303,8 +355,10 @@ testEventsRouter.post("/", async (c) => {
     // emitting for. The route already holds both handles, so the breadcrumb is precise.
     const targetSpecHandle = specHandleFromAcUid(subjectRefValue);
     const targetSpecRef = `${refNamespace}/${memexSlugFromAcUid(subjectRefValue)}/specs/${targetSpecHandle}`;
-    return c.json(
-      {
+    return {
+      ok: false,
+      code: 401,
+      body: {
         error: "unauthorized",
         message:
           `This emission key is scoped to Spec ${emissionKey.scopedSpecHandle} and cannot ` +
@@ -312,8 +366,7 @@ testEventsRouter.post("/", async (c) => {
           `\`provision_ac_emission\` MCP tool with ref ${targetSpecRef} to mint a key for ` +
           `that Spec, set it as MEMEX_EMIT_KEY, and re-run.`,
       },
-      401,
-    );
+    };
   }
 
   // spec-115 dec-2 / dec-3: validate metadata size caps and drop offending
@@ -361,7 +414,8 @@ testEventsRouter.post("/", async (c) => {
   // refetch the instant a run posts — no longer reliant on AcPanel's 3s poll.
   // The bus key is the memex the AC lives under: spec-129's emission-key auth
   // already resolved it (targetMemexId) and proved it matches the key, so by
-  // this point it is always a real, authorized Memex.
+  // this point it is always a real, authorized Memex. Each batched event emits
+  // its own bus frame here, exactly as a one-per-POST event would (ac-5).
   const row = await mutate(
     {},
     {
@@ -382,7 +436,10 @@ testEventsRouter.post("/", async (c) => {
     // summary in one transaction so the two can't diverge on a crash. The
     // upsert skips hidden emissions (ac-6) and keys null test_identifier as ''
     // (ac-9). mutate() is not itself transactional — the db.transaction() here
-    // is what makes the pair atomic.
+    // is what makes the pair atomic. spec-489: in a batch these run
+    // SEQUENTIALLY (one event at a time), so a batch holds ONE pool slot at a
+    // time rather than one-per-event — the connection-pressure relief (std-39:
+    // bound the connections/locks a request can hold).
     async () => {
       return db.transaction(async (tx) => {
         const [inserted] = await tx
@@ -432,27 +489,139 @@ testEventsRouter.post("/", async (c) => {
       (body.run_id ? ` run=${body.run_id}` : ""),
   );
 
-  if (droppedKeys.length > 0) {
-    c.header(
-      "X-Memex-Warning",
-      `metadata keys dropped (size limits exceeded): ${droppedKeys.join(", ")}`,
-    );
-  }
-
   // spec-112 ac-22: an AC may go green AFTER its satisfying Task is already
   // complete. The ingestion path is the second auto-resolve trigger — a passing
   // event for an AC that verifies a converted Issue's Task closes the
-  // bug→failing-AC→green-AC→resolved loop. Best-effort: never fail the 201.
+  // bug→failing-AC→green-AC→resolved loop. Best-effort: never fail the write.
   if (body.status === "pass") {
     await maybeAutoResolveIssuesForAcUid(subjectRefValue).catch(() => {});
     // spec-453 t-2 (dec-1/dec-4/dec-9): fire the "See it verified" milestone email.
     // FIRE-AND-FORGET — never awaited on this CI hot path, so it cannot add latency to
-    // or break the 201. Attributed to the emission key's OWNER (not test_events.actor),
+    // or break the write. Attributed to the emission key's OWNER (not test_events.actor),
     // gated first-ever + flag inside; fully advisory (its own try/catch swallows all).
     void fireVerifiedMilestoneForUser(emissionKey.createdByUserId);
   }
 
-  return c.json({ id: row.id, created_at: row.createdAt }, 201);
+  return {
+    ok: true,
+    id: row.id,
+    createdAt: row.createdAt,
+    status: body.status,
+    droppedKeys,
+  };
+}
+
+// POST /api/test-events — ingest ONE test-event emission (spec-90 dec-7: the
+// per-Memex emission key is the SOLE identity gate). Unchanged contract; the
+// body processing now delegates to processOneEvent so it stays byte-identical
+// to a batched event.
+testEventsRouter.post("/", async (c) => {
+  const auth = await authenticateEmission(c.req.header("Authorization") ?? "");
+  if (!auth.ok) return c.json(auth.body, 401);
+
+  let body: TestEventBody;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: "Body must be valid JSON" }, 400);
+  }
+
+  const result = await processOneEvent(auth.key, body);
+  if (!result.ok) return c.json(result.body, result.code);
+
+  if (result.droppedKeys.length > 0) {
+    c.header(
+      "X-Memex-Warning",
+      `metadata keys dropped (size limits exceeded): ${result.droppedKeys.join(", ")}`,
+    );
+  }
+  return c.json({ id: result.id, created_at: result.createdAt }, 201);
+});
+
+// spec-489 G1 — POST /api/test-events/batch — ingest MANY emissions in ONE
+// authenticated request. This is the durable relief for the CI-burst problem:
+// a suite that tags N tests sends ~one request per test FILE instead of N
+// per-test POSTs, so it no longer opens one connection-pool slot per test
+// (ac-3). Semantics are identical to N single POSTs because every event runs
+// through the same processOneEvent (ac-5).
+//
+//   Request : { "events": [ <same body as POST />, ... ] }   (1..MAX_BATCH_EVENTS)
+//   Response: 200 { accepted, rejected, results: [{ index, ok, id?, status?, error? }] }
+//
+// Authentication is at the BATCH level (one Bearer key for the whole request);
+// a missing/invalid/expired key 401s the whole batch before any DB work. Each
+// event is still independently memex-matched + spec-scope-gated against that
+// key, so a batch cannot write across a Memex boundary (ac-5). Partial failure
+// is expected and non-fatal: a malformed or unauthorized event is reported in
+// results[] with ok:false, and the good events in the same batch still land —
+// a bad event never discards its neighbours (ac-5).
+testEventsRouter.post("/batch", async (c) => {
+  const auth = await authenticateEmission(c.req.header("Authorization") ?? "");
+  if (!auth.ok) return c.json(auth.body, 401);
+
+  let parsed: unknown;
+  try {
+    parsed = await c.req.json();
+  } catch {
+    return c.json({ error: "Body must be valid JSON" }, 400);
+  }
+
+  const events =
+    typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
+      ? (parsed as { events?: unknown }).events
+      : undefined;
+  if (!Array.isArray(events)) {
+    return c.json({ error: "events is required and must be an array" }, 400);
+  }
+  if (events.length === 0) {
+    return c.json({ error: "events must contain at least one event" }, 400);
+  }
+  if (events.length > MAX_BATCH_EVENTS) {
+    return c.json(
+      { error: `events exceeds the maximum batch size of ${MAX_BATCH_EVENTS}` },
+      400,
+    );
+  }
+
+  // Process sequentially so the whole batch occupies ONE pool slot at a time
+  // (std-39: bound the connections/locks a request holds) — the point of
+  // batching is to relieve pool pressure, not to fan N inserts across N slots.
+  const results: Array<{
+    index: number;
+    ok: boolean;
+    id?: string;
+    status?: string;
+    error?: string;
+    warning?: string;
+  }> = [];
+  let accepted = 0;
+  let rejected = 0;
+  for (let index = 0; index < events.length; index++) {
+    const result = await processOneEvent(auth.key, events[index]);
+    if (result.ok) {
+      accepted++;
+      results.push({
+        index,
+        ok: true,
+        id: result.id,
+        status: result.status,
+        ...(result.droppedKeys.length > 0
+          ? {
+              warning: `metadata keys dropped (size limits exceeded): ${result.droppedKeys.join(", ")}`,
+            }
+          : {}),
+      });
+    } else {
+      rejected++;
+      results.push({
+        index,
+        ok: false,
+        error: result.body.message ?? result.body.error,
+      });
+    }
+  }
+
+  return c.json({ accepted, rejected, results }, 200);
 });
 
 export { testEventsRouter };


### PR DESCRIPTION
## What & why

An external integrator's CI (spec-489) load-tests `POST /api/test-events` — a suite that tags N tests fires N per-test POSTs, each taking a DB-pool slot. The burst queues behind the pool and trips their 3s client timeout. **G1 takes the burst off the table** by carrying many emissions in one request.

This is **G1 only** of spec-489 (ac-3 + ac-5). G2 (ac-4 guidance), the keyless-POST reversal (ac-1 / dec-1), and the spec-332 load-shape handoff (ac-6) are **not** in this PR.

## Changes

**Server** (`packages/server/src/routes/test-events.ts`)
- Extract the per-event pipeline into `processOneEvent()`; `POST /` delegates to it, so a batched event stores a **byte-identical** row to a one-per-POST event (ac-5). Auth factored into `authenticateEmission()`.
- **New `POST /api/test-events/batch`**: `{ events: [...] }` (1..500), authenticates **once**, processes events **sequentially** (one pool slot for the whole batch — std-39), returns `200 { accepted, rejected, results }`. Each event is still memex-matched + spec-scope-gated (no new cross-Memex write path); a bad event is reported per-index and its neighbours still land (**partial failure**). Every event still writes via `mutate()` + bus (std-8).

**Emitter** (`@memex-ai-ac/vitest`)
- `emitBatch()` — POSTs `{ events }` to `/batch` with the same fail-safe contract as `emit()` (swallow non-2xx + network/timeout, 5s `AbortSignal`, surface response body + per-event rejections).
- `setup.ts` — `afterEach` **buffers**; a top-level `afterAll` flushes **one batch per test file** via `capturedFetch`. M per-test POSTs → ~one request per file (ac-3). **No consumer config change** (same `setupFiles` import).
- **Rollout safety (std-22):** on `404/405` from `/batch` (a server without the route), fall back to per-event single POSTs so emissions never drop during the deploy gap. Single-event `emit()` unchanged.

## Testing

- Server `test-events.test.ts` **+6 tagged** tests (ac-3, ac-5); `test-events` + `emission-auth` suites **46 pass**, no regression.
- Emitter `emit-batch.test.ts` **+13** tests incl. the **404/405 fallback**; whole package **84 pass**.
- Both packages: `tsc --noEmit` + `pnpm build` clean.
- **Live:** ran the tagged suites with a provisioned key — **ac-3 and ac-5 are now `verified`** on the prod board (landed via the 404 fallback, since prod has no `/batch` yet).

## Rollout note

Emission routes by the ref's namespace, so this branch's CI posts `mindset-prod/…` events to prod's `/batch`. The **404 fallback makes deploy ordering non-fatal** (older server → single-POST). No migration; additive route only; single-event contract + `ac-emission-bootstrap` guidance unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGX7hAhjAFyTGUPrSJYRez
