### PR TITLE
spec-503: edit_section, surgical find/replace inside a section

### DIFF
--- a/packages/server/src/__regression__/mutate-coverage.endpoint.regression.test.ts
+++ b/packages/server/src/__regression__/mutate-coverage.endpoint.regression.test.ts
@@ -101,6 +101,9 @@ const MUTATING_MCP_TOOLS: Record<string, ToolMutation[]> = {
   // sections.ts
   add_section: [{ entity: "section", action: "created" }],
   update_section: [{ entity: "section", action: "updated" }],
+  // spec-503 — edit_section applies a literal find/replace then writes through
+  // the same updateSection service path, so it emits the same key.
+  edit_section: [{ entity: "section", action: "updated" }],
   retitle_section: [{ entity: "section", action: "updated" }],
   delete_section: [{ entity: "section", action: "deleted" }],
   // qa-reports.ts (spec-260) — appendQaReport rides addSection's mutate() path,

--- a/packages/server/src/__regression__/ref-emission.regression.test.ts
+++ b/packages/server/src/__regression__/ref-emission.regression.test.ts
@@ -481,6 +481,20 @@ describe("regression: every entity-acting MCP tool emits `ref:` and no raw UUID 
         },
       ],
       [
+        // spec-503: literal find/replace on the shared section. Runs after
+        // update_section in catalogue order, so the body is "new body" here;
+        // the edit keeps that text stable ("new body" → "new body probed")
+        // without perturbing seq/sectionType for later cases.
+        "edit_section",
+        {
+          input: () => ({
+            ref: refForChild(slugs, docHandle, "sections", sectionSeq),
+            oldText: "new body",
+            newText: "new body probed",
+          }),
+        },
+      ],
+      [
         "retitle_section",
         {
           // Title-only retitle keeps seq/sectionType stable, so it doesn't

--- a/packages/server/src/__regression__/section-body-roundtrip.spec-503.regression.test.ts
+++ b/packages/server/src/__regression__/section-body-roundtrip.spec-503.regression.test.ts
@@ -1,0 +1,132 @@
+// spec-503 (ac-5): the byte-identity guarantee that makes edit_section usable.
+// Agents copy oldText from get_doc output, so the section body get_doc renders
+// must contain the stored doc_sections.content VERBATIM: no decoration,
+// escaping, numbering, or reflow inside the body. If this test goes red,
+// edit_section's exact matching silently stops working for copy-pasted text,
+// and agents fall back to whole-body update_section.
+import { describe, it, expect, afterAll } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { eq, inArray } from "drizzle-orm";
+import { db } from "../db/connection.js";
+import { memexes, namespaces, documents, docSections, users } from "../db/schema.js";
+import { makeTestMemex } from "../services/test-helpers.js";
+import { createDocDraft } from "../services/documents.js";
+import { addSection } from "../services/sections.js";
+import { ValidationError } from "../types/errors.js";
+import { toolSpecs, type ToolCtx } from "../agent/tool-specs.js";
+
+const AC_ROUNDTRIP = "mindset-prod/memex-building-itself/specs/spec-503/acs/ac-5";
+
+// Markdown-heavy fixture: code fences, inline code, nested lists, blank lines,
+// tabs, trailing spaces, $-sequences, unicode punctuation and emoji. Anything
+// a Spec section realistically contains must survive the roundtrip unchanged.
+const GNARLY = [
+  "# Heading with `inline code` and *emphasis*",
+  "",
+  "- item one",
+  "  - nested with two-space indent",
+  "",
+  "```ts",
+  'const x: Record<string, number> = { "a": 1 };',
+  "```",
+  "",
+  "Text with $& and $1 and a\ttab, plus unicode: café ☕ → «done».",
+  "Trailing spaces stay:  ",
+  "> a quote line",
+].join("\n");
+
+const cleanup = { memexes: [] as string[], docs: [] as string[], users: [] as string[] };
+
+afterAll(async () => {
+  if (cleanup.docs.length) {
+    await db.delete(docSections).where(inArray(docSections.docId, cleanup.docs)).catch(() => {});
+    await db.delete(documents).where(inArray(documents.id, cleanup.docs)).catch(() => {});
+  }
+  for (const id of cleanup.memexes) {
+    await db.delete(memexes).where(eq(memexes.id, id)).catch(() => {});
+  }
+  for (const id of cleanup.users) {
+    await db.delete(users).where(eq(users.id, id)).catch(() => {});
+  }
+});
+
+function spec(name: string) {
+  const s = toolSpecs.find((t) => t.name === name);
+  if (!s) throw new Error(`ToolSpec not found: ${name}`);
+  return s;
+}
+
+function ctxWithResolver(memexId: string, userId: string, verbose = false): ToolCtx {
+  return {
+    userId,
+    verbose,
+    resolveMemexFromEntity: async () => memexId,
+    resolveMemex: async () => memexId,
+    resolveRef: async (ref: string) => {
+      const { parseRef } = await import("../services/refs.js");
+      const { resolveRef: resolveCanonicalRef } = await import("../services/resolver.js");
+      const { NotFoundError } = await import("../types/errors.js");
+      const parsed = parseRef(ref);
+      if (!parsed.ok) throw new ValidationError(`Invalid ref "${ref}": ${parsed.reason}`);
+      const result = await resolveCanonicalRef(parsed.ref);
+      if ("redirected" in result) throw new ValidationError(`Ref redirected: ${result.newRef}`);
+      if ("notFound" in result) throw new NotFoundError(`Ref "${ref}" not found (${result.reason})`);
+      const entity = result.entity;
+      const doc = "doc" in entity ? entity.doc : entity.row;
+      if (doc.memexId !== memexId) throw new NotFoundError(`Ref "${ref}" not found.`);
+      return {
+        entity,
+        memexId: doc.memexId,
+        doc,
+        slugs: { namespace: parsed.ref.namespace, memex: parsed.ref.memex },
+      };
+    },
+    workspaceUrl: async () => "https://test.example",
+  } as ToolCtx;
+}
+
+describe("spec-503 roundtrip: get_doc body === stored content", () => {
+  it("renders the stored section body verbatim, and text copied from get_doc matches in edit_section", async () => {
+    tagAc(AC_ROUNDTRIP);
+    const [u] = await db
+      .insert(users)
+      .values({
+        email: `s503-rt-${Date.now()}-${Math.random().toString(36).slice(2, 6)}@memex.ai`,
+      } as never)
+      .returning();
+    cleanup.users.push(u.id);
+    const memexId = await makeTestMemex("s503rt");
+    cleanup.memexes.push(memexId);
+    const doc = await createDocDraft(memexId, "spec-503 roundtrip", "purpose", "spec");
+    cleanup.docs.push(doc.id);
+    const section = await addSection(memexId, doc.id, "gnarly", GNARLY);
+
+    const m = await db.query.memexes.findFirst({ where: eq(memexes.id, memexId) });
+    const ns = await db.query.namespaces.findFirst({ where: eq(namespaces.id, m!.namespaceId) });
+    const docRef = `${ns!.slug}/${m!.slug}/specs/${doc.handle}`;
+    const ctx = ctxWithResolver(memexId, u.id);
+
+    // 1. The get_doc rendering (the verbose body-carrying form agents read
+    // content from) contains the stored body byte-for-byte.
+    const rendered = (await spec("get_doc").handler(
+      { ref: docRef, verbose: true },
+      ctxWithResolver(memexId, u.id, true),
+    )) as string;
+    expect(rendered).toContain(GNARLY);
+
+    // 2. Copy oldText OUT OF the get_doc output (provenance matters: this is
+    // exactly what an agent does) and edit with it.
+    const start = rendered.indexOf('const x: Record<string, number> = { "a": 1 };');
+    expect(start).toBeGreaterThan(-1);
+    const copied = rendered.slice(start, start + 'const x: Record<string, number> = { "a": 1 };'.length);
+    const sectionRef = `${docRef}/sections/s-${section.seq}`;
+    const result = await spec("edit_section").handler(
+      { ref: sectionRef, oldText: copied, newText: 'const x: Record<string, number> = { "a": 2 };' },
+      ctx,
+    );
+    expect(result).toBe(`Section edited: 1 occurrence(s) replaced (ref: ${sectionRef}).`);
+
+    const row = await db.query.docSections.findFirst({ where: eq(docSections.id, section.id) });
+    expect(row!.content).toBe(GNARLY.replace('"a": 1', '"a": 2'));
+  });
+});

--- a/packages/server/src/agent/edit-section.spec-503.integration.test.ts
+++ b/packages/server/src/agent/edit-section.spec-503.integration.test.ts
@@ -1,0 +1,268 @@
+// spec-503: edit_section end-to-end through the ToolSpec handler against a live
+// DB. Covers the guard paths (nothing written on any failure), the standards
+// clause-grain gate, the terse/verbose payloads, actor stamping via the
+// updateSection service, and the surface wiring (one catalogue, both surfaces,
+// absent from every scoped mode).
+import { describe, it, expect, afterAll } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { eq, inArray } from "drizzle-orm";
+import { db } from "../db/connection.js";
+import {
+  memexes,
+  namespaces,
+  documents,
+  docSections,
+  standardClauses,
+  users,
+} from "../db/schema.js";
+import { makeTestMemex } from "../services/test-helpers.js";
+import { createDocDraft } from "../services/documents.js";
+import { createStandard } from "../services/standards.js";
+import { addSection } from "../services/sections.js";
+import { ValidationError } from "../types/errors.js";
+import { toolSpecs, type ToolCtx } from "./tool-specs.js";
+import { getToolDefinitions, isToolAllowedInMode } from "./tools.js";
+import { createMcpServer } from "../mcp/tools.js";
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-503/acs/ac-${n}`;
+
+const cleanup = { memexes: [] as string[], docs: [] as string[], users: [] as string[] };
+
+afterAll(async () => {
+  if (cleanup.docs.length) {
+    await db.delete(standardClauses).where(inArray(standardClauses.docId, cleanup.docs)).catch(() => {});
+    await db.delete(docSections).where(inArray(docSections.docId, cleanup.docs)).catch(() => {});
+    await db.delete(documents).where(inArray(documents.id, cleanup.docs)).catch(() => {});
+  }
+  for (const id of cleanup.memexes) {
+    await db.delete(memexes).where(eq(memexes.id, id)).catch(() => {});
+  }
+  for (const id of cleanup.users) {
+    await db.delete(users).where(eq(users.id, id)).catch(() => {});
+  }
+});
+
+async function makeUser(prefix: string): Promise<string> {
+  const [u] = await db
+    .insert(users)
+    .values({
+      email: `s503-${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 6)}@memex.ai`,
+    } as never)
+    .returning();
+  cleanup.users.push(u.id);
+  return u.id;
+}
+
+async function slugsFor(memexId: string): Promise<{ namespace: string; memex: string }> {
+  const m = await db.query.memexes.findFirst({ where: eq(memexes.id, memexId) });
+  if (!m) throw new Error(`memex ${memexId} not found`);
+  const ns = await db.query.namespaces.findFirst({ where: eq(namespaces.id, m.namespaceId) });
+  if (!ns) throw new Error(`namespace for memex ${memexId} not found`);
+  return { namespace: ns.slug, memex: m.slug };
+}
+
+// Real resolver behind the ctx `resolveRef` hook (mirrors buildAgentCtx).
+function ctxWithResolver(memexId: string, userId: string, verbose = false): ToolCtx {
+  return {
+    userId,
+    resolveMemexFromEntity: async () => memexId,
+    resolveMemex: async () => memexId,
+    resolveRef: async (ref: string) => {
+      const { parseRef } = await import("../services/refs.js");
+      const { resolveRef: resolveCanonicalRef } = await import("../services/resolver.js");
+      const { NotFoundError } = await import("../types/errors.js");
+      const parsed = parseRef(ref);
+      if (!parsed.ok) throw new ValidationError(`Invalid ref "${ref}": ${parsed.reason}`);
+      const result = await resolveCanonicalRef(parsed.ref);
+      if ("redirected" in result) throw new ValidationError(`Ref redirected: ${result.newRef}`);
+      if ("notFound" in result) throw new NotFoundError(`Ref "${ref}" not found (${result.reason})`);
+      const entity = result.entity;
+      const doc = "doc" in entity ? entity.doc : entity.row;
+      if (doc.memexId !== memexId) throw new NotFoundError(`Ref "${ref}" not found.`);
+      return {
+        entity,
+        memexId: doc.memexId,
+        doc,
+        slugs: { namespace: parsed.ref.namespace, memex: parsed.ref.memex },
+      };
+    },
+    workspaceUrl: async () => "https://test.example",
+    verbose,
+  } as ToolCtx;
+}
+
+function editSectionSpec() {
+  const spec = toolSpecs.find((s) => s.name === "edit_section");
+  if (!spec) throw new Error("edit_section ToolSpec not found");
+  return spec;
+}
+
+interface Fixture {
+  memexId: string;
+  userId: string;
+  sectionRef: string;
+  sectionId: string;
+}
+
+const ORIGINAL = "The quick brown fox.\nA second line with token and token again.\n";
+
+async function makeSpecFixture(prefix: string): Promise<Fixture> {
+  const userId = await makeUser(prefix);
+  const memexId = await makeTestMemex(`s503${prefix}`);
+  cleanup.memexes.push(memexId);
+  const doc = await createDocDraft(memexId, `spec-503 ${prefix}`, "purpose", "spec");
+  cleanup.docs.push(doc.id);
+  const section = await addSection(memexId, doc.id, `body-${prefix}`, ORIGINAL);
+  const slugs = await slugsFor(memexId);
+  return {
+    memexId,
+    userId,
+    sectionId: section.id,
+    sectionRef: `${slugs.namespace}/${slugs.memex}/specs/${doc.handle}/sections/s-${section.seq}`,
+  };
+}
+
+async function storedContent(sectionId: string): Promise<string> {
+  const row = await db.query.docSections.findFirst({ where: eq(docSections.id, sectionId) });
+  return row!.content;
+}
+
+describe("edit_section: successful edits", () => {
+  it("replaces a single unique hit without re-emitting the body; terse payload carries count + ref", async () => {
+    tagAc(AC(1));
+    tagAc(AC(11));
+    const fx = await makeSpecFixture("single");
+    const result = await editSectionSpec().handler(
+      { ref: fx.sectionRef, oldText: "quick brown fox", newText: "slow green turtle" },
+      ctxWithResolver(fx.memexId, fx.userId),
+    );
+    expect(result).toBe(`Section edited: 1 occurrence(s) replaced (ref: ${fx.sectionRef}).`);
+    expect(await storedContent(fx.sectionId)).toBe(
+      "The slow green turtle.\nA second line with token and token again.\n",
+    );
+  });
+
+  it("replaceAll replaces every occurrence and reports the count", async () => {
+    tagAc(AC(3));
+    const fx = await makeSpecFixture("all");
+    const result = await editSectionSpec().handler(
+      { ref: fx.sectionRef, oldText: "token", newText: "value", replaceAll: true },
+      ctxWithResolver(fx.memexId, fx.userId),
+    );
+    expect(result).toBe(`Section edited: 2 occurrence(s) replaced (ref: ${fx.sectionRef}).`);
+    expect(await storedContent(fx.sectionId)).toContain("value and value again");
+  });
+
+  it("stamps the acting user on the section row (std-32, via updateSection)", async () => {
+    tagAc(AC(10));
+    const fx = await makeSpecFixture("actor");
+    await editSectionSpec().handler(
+      { ref: fx.sectionRef, oldText: "fox", newText: "hare" },
+      ctxWithResolver(fx.memexId, fx.userId),
+    );
+    const row = await db.query.docSections.findFirst({ where: eq(docSections.id, fx.sectionId) });
+    expect(row!.actorUserId).toBe(fx.userId);
+  });
+
+  it("verbose: true returns full document state instead of the terse line", async () => {
+    tagAc(AC(11));
+    const fx = await makeSpecFixture("verbose");
+    const result = await editSectionSpec().handler(
+      { ref: fx.sectionRef, oldText: "fox", newText: "lynx", verbose: true },
+      ctxWithResolver(fx.memexId, fx.userId, true),
+    );
+    expect(result).not.toBe(`Section edited: 1 occurrence(s) replaced (ref: ${fx.sectionRef}).`);
+    expect(result).toContain("lynx");
+  });
+});
+
+describe("edit_section: failure paths write nothing", () => {
+  it("zero hits: ValidationError names the ref, exactness, and the get_doc re-read; content untouched", async () => {
+    tagAc(AC(2));
+    tagAc(AC(8));
+    const fx = await makeSpecFixture("zero");
+    const ctx = ctxWithResolver(fx.memexId, fx.userId);
+    await expect(
+      editSectionSpec().handler({ ref: fx.sectionRef, oldText: "absent text", newText: "x" }, ctx),
+    ).rejects.toThrow(/oldText not found in .*s-\d+.*exact.*get_doc/s);
+    expect(await storedContent(fx.sectionId)).toBe(ORIGINAL);
+  });
+
+  it("ambiguous hits with replaceAll false: error names the count and both remedies; content untouched", async () => {
+    tagAc(AC(2));
+    tagAc(AC(8));
+    const fx = await makeSpecFixture("ambig");
+    const ctx = ctxWithResolver(fx.memexId, fx.userId);
+    await expect(
+      editSectionSpec().handler({ ref: fx.sectionRef, oldText: "token", newText: "x" }, ctx),
+    ).rejects.toThrow(/matches 2 places .*Widen oldText.*replaceAll: true/s);
+    expect(await storedContent(fx.sectionId)).toBe(ORIGINAL);
+  });
+
+  it("empty oldText and oldText===newText are rejected before any write", async () => {
+    tagAc(AC(12));
+    const fx = await makeSpecFixture("guards");
+    const ctx = ctxWithResolver(fx.memexId, fx.userId);
+    await expect(
+      editSectionSpec().handler({ ref: fx.sectionRef, oldText: "", newText: "x" }, ctx),
+    ).rejects.toThrow(/must not be empty.*update_section/s);
+    await expect(
+      editSectionSpec().handler({ ref: fx.sectionRef, oldText: "token", newText: "token" }, ctx),
+    ).rejects.toThrow(/identical/);
+    expect(await storedContent(fx.sectionId)).toBe(ORIGINAL);
+  });
+
+  it("a doc-level ref is rejected (section refs only)", async () => {
+    tagAc(AC(8));
+    const fx = await makeSpecFixture("doclevel");
+    const docRef = fx.sectionRef.replace(/\/sections\/s-\d+$/, "");
+    await expect(
+      editSectionSpec().handler({ ref: docRef, oldText: "a", newText: "b" }, ctxWithResolver(fx.memexId, fx.userId)),
+    ).rejects.toThrow(/expects a section ref/);
+  });
+});
+
+describe("edit_section: standards reject at the clause-grain gate", () => {
+  it("redirects to add_clause / edit_clause / delete_clause and writes nothing", async () => {
+    tagAc(AC(4));
+    tagAc(AC(10));
+    const userId = await makeUser("std");
+    const memexId = await makeTestMemex("s503std");
+    cleanup.memexes.push(memexId);
+    const std = await createStandard(memexId, {
+      title: "spec-503 gate standard",
+      sections: [{ sectionType: "rule", content: "One aspect." }],
+    });
+    cleanup.docs.push(std.id);
+    const section = std.sections[0];
+    const slugs = await slugsFor(memexId);
+    const ref = `${slugs.namespace}/${slugs.memex}/standards/${std.handle}/sections/s-${section.seq}`;
+    await expect(
+      editSectionSpec().handler(
+        { ref, oldText: "One aspect.", newText: "Another." },
+        ctxWithResolver(memexId, userId),
+      ),
+    ).rejects.toThrow(/clause grain.*add_clause \/ edit_clause \/ delete_clause/s);
+  });
+});
+
+describe("edit_section: surface wiring (std-16, one catalogue)", () => {
+  it("is exposed to the in-app 'spec' mode and to the MCP endpoint from the same toolSpecs", () => {
+    tagAc(AC(6));
+    tagAc(AC(10));
+    expect(getToolDefinitions().map((t) => t.name)).toContain("edit_section");
+    const server = createMcpServer("00000000-0000-0000-0000-0000000000ff");
+    const mcpNames = Object.keys(
+      (server as unknown as { _registeredTools: Record<string, unknown> })._registeredTools,
+    );
+    expect(mcpNames).toContain("edit_section");
+  });
+
+  it("is absent from every scoped mode allow-list", () => {
+    tagAc(AC(10));
+    for (const mode of ["drift", "scaffold", "standards", "issues", "skills"] as const) {
+      expect(isToolAllowedInMode(mode, "edit_section")).toBe(false);
+    }
+    expect(isToolAllowedInMode(undefined, "edit_section")).toBe(true);
+  });
+});

--- a/packages/server/src/agent/handlers/sections.ts
+++ b/packages/server/src/agent/handlers/sections.ts
@@ -19,6 +19,7 @@ import {
 import {
   appendQaReport,
 } from "../../services/qa-reports.js";
+import { applyLiteralEdit } from "../../services/section-edit.js";
 import {
   addClausesToSection,
   createClause,
@@ -237,6 +238,83 @@ export const sectionsTools: ToolSpec[] = [
       }
       const sectionRef = buildChildRef(slugs, doc, { type: "sections", seq: section.seq });
       return `Section updated (ref: ${sectionRef}).`;
+    },
+  },
+  // spec-503: the surgical sibling of update_section. Exact-match find/replace
+  // doubles as optimistic concurrency: if the section changed since the caller
+  // read it, oldText stops matching and the call fails loudly instead of
+  // clobbering the concurrent edit.
+  {
+    name: "edit_section",
+    annotations: { title: "Edit section (find/replace)", readOnlyHint: false, destructiveHint: false },
+    description:
+      "Surgically edit a NON-standard document section by literal find/replace: ONE oldText/newText pair per call, so a targeted change never costs re-emitting the whole body. Matching is exact (case, whitespace, markdown syntax; no regex). With replaceAll false (the default) oldText must match exactly once; zero or multiple hits fail with the remedy named and nothing written. replaceAll: true applies the edit to every match. Standards are edited at the clause grain instead (add/edit/delete_clause). For a deliberate full recut of a section body, use update_section.",
+    schema: {
+      ref: z
+        .string()
+        .describe(
+          "Canonical ref to the section, e.g. `mindset/main/specs/spec-3/sections/s-3`.",
+        ),
+      oldText: z
+        .string()
+        .describe(
+          "Exact literal text to find: case- and whitespace-sensitive, regex metacharacters are plain text. Copy it verbatim from get_doc output. Must not be empty.",
+        ),
+      newText: z
+        .string()
+        .describe("Replacement text. May be empty (deletes oldText). Must differ from oldText."),
+      replaceAll: z
+        .boolean()
+        .optional()
+        .describe("Replace every occurrence. Default false: exactly one match required."),
+      verbose: VERBOSE_FIELD,
+    },
+    async handler(input, ctx) {
+      const ref = input.ref as string;
+      const oldText = input.oldText as string;
+      const newText = input.newText as string;
+      const replaceAll = (input.replaceAll as boolean | undefined) ?? false;
+
+      const resolved = await resolveRefArg(ctx, ref);
+      if (resolved.entity.kind !== "section") {
+        throw new ValidationError(
+          `edit_section expects a section ref; got ${resolved.entity.kind}.`,
+        );
+      }
+      const { memexId, doc, slugs, entity } = resolved;
+      if (doc.docType === "standard") {
+        throw new ValidationError(
+          "Standards are edited at the clause grain. Use add_clause / edit_clause / delete_clause, not edit_section.",
+        );
+      }
+      const sectionRef = buildChildRef(slugs, doc, { type: "sections", seq: entity.row.seq });
+
+      const result = applyLiteralEdit(entity.row.content, oldText, newText, replaceAll);
+      if (result.kind === "invalid") {
+        throw new ValidationError(
+          result.reason === "empty-old"
+            ? "oldText must not be empty. To replace the whole section body, use update_section."
+            : "oldText and newText are identical; nothing to change.",
+        );
+      }
+      if (result.kind === "zero") {
+        throw new ValidationError(
+          `oldText not found in ${sectionRef}. Matching is exact, including whitespace and markdown syntax; re-read the section with get_doc and copy the text verbatim.`,
+        );
+      }
+      if (result.kind === "ambiguous") {
+        throw new ValidationError(
+          `oldText matches ${result.count} places in ${sectionRef}. Widen oldText with surrounding context until it is unique, or pass replaceAll: true to replace all ${result.count}.`,
+        );
+      }
+
+      const section = await updateSection(memexId, entity.row.id, result.content, {}, reqCtx(ctx));
+      if (ctx.verbose) {
+        const state = await fullDocState(memexId, section.docId);
+        const url = await ctx.workspaceUrl(memexId);
+        return await formatState(url, state, ctx);
+      }
+      return `Section edited: ${result.count} occurrence(s) replaced (ref: ${sectionRef}).`;
     },
   },
   // ── Clause CRUD (standards only) ──────────────────────────

--- a/packages/server/src/agent/tool-specs.audit.integration.test.ts
+++ b/packages/server/src/agent/tool-specs.audit.integration.test.ts
@@ -1080,6 +1080,19 @@ describe("audit: b-36 D-8 — every terse mutation/list response emits `ref:` an
         },
       ],
       [
+        // spec-503: literal find/replace on the shared section. Runs after
+        // update_section set the body to "new body for probe"; the edit keeps
+        // that text present so later probes are unperturbed.
+        "edit_section",
+        {
+          input: () => ({
+            ref: childRef(slugs, docHandle, "sections", sectionSeq),
+            oldText: "new body for probe",
+            newText: "new body for probe (edited)",
+          }),
+        },
+      ],
+      [
         "retitle_section",
         {
           // Title-only retitle keeps seq/sectionType stable.

--- a/packages/server/src/services/section-edit.test.ts
+++ b/packages/server/src/services/section-edit.test.ts
@@ -1,0 +1,139 @@
+// spec-503: the pure literal-edit engine's truth table. The engine is the
+// no-surprises core of edit_section — literal matching only, no regex and no
+// String.replace $-pattern semantics may leak into replacements.
+import { describe, expect, it } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { applyLiteralEdit } from "./section-edit.js";
+
+const AC_LITERAL = "mindset-prod/memex-building-itself/specs/spec-503/acs/ac-7";
+const AC_SINGLE_PAIR = "mindset-prod/memex-building-itself/specs/spec-503/acs/ac-12";
+
+describe("applyLiteralEdit — hit counting", () => {
+  it("zero hits → kind 'zero', content untouched", () => {
+    tagAc(AC_LITERAL);
+    const result = applyLiteralEdit("alpha beta gamma", "delta", "epsilon", false);
+    expect(result).toEqual({ kind: "zero" });
+  });
+
+  it("one hit → replaced, count 1", () => {
+    tagAc(AC_LITERAL);
+    const result = applyLiteralEdit("alpha beta gamma", "beta", "BETA", false);
+    expect(result).toEqual({ kind: "ok", content: "alpha BETA gamma", count: 1 });
+  });
+
+  it("many hits with replaceAll false → kind 'ambiguous' with the exact count", () => {
+    tagAc(AC_LITERAL);
+    const result = applyLiteralEdit("x y x y x", "x", "z", false);
+    expect(result).toEqual({ kind: "ambiguous", count: 3 });
+  });
+
+  it("many hits with replaceAll true → all replaced, count reported", () => {
+    tagAc(AC_LITERAL);
+    const result = applyLiteralEdit("x y x y x", "x", "z", true);
+    expect(result).toEqual({ kind: "ok", content: "z y z y z", count: 3 });
+  });
+
+  it("replaceAll true with a single hit still succeeds with count 1", () => {
+    tagAc(AC_LITERAL);
+    const result = applyLiteralEdit("alpha beta", "beta", "gamma", true);
+    expect(result).toEqual({ kind: "ok", content: "alpha gamma", count: 1 });
+  });
+
+  it("counts non-overlapping occurrences only", () => {
+    tagAc(AC_LITERAL);
+    // "aaaa" contains two non-overlapping "aa", not three.
+    const result = applyLiteralEdit("aaaa", "aa", "b", true);
+    expect(result).toEqual({ kind: "ok", content: "bb", count: 2 });
+  });
+});
+
+describe("applyLiteralEdit — literal semantics (no regex, no $-patterns)", () => {
+  it("treats regex metacharacters in oldText as plain text", () => {
+    tagAc(AC_LITERAL);
+    const content = "value = arr[i].*x + (y)?";
+    const result = applyLiteralEdit(content, "arr[i].*x + (y)?", "next", false);
+    expect(result).toEqual({ kind: "ok", content: "value = next", count: 1 });
+  });
+
+  it("a metacharacter oldText does not match via regex interpretation", () => {
+    tagAc(AC_LITERAL);
+    // As a regex ".*" would match anything; literally it must match nothing here.
+    const result = applyLiteralEdit("plain words only", ".*", "x", false);
+    expect(result).toEqual({ kind: "zero" });
+  });
+
+  it("leaves $-patterns in newText verbatim (no substitution semantics)", () => {
+    tagAc(AC_LITERAL);
+    const result = applyLiteralEdit("keep the token here", "token", "$& $1 $' literal", false);
+    expect(result).toEqual({
+      kind: "ok",
+      content: "keep the $& $1 $' literal here",
+      count: 1,
+    });
+  });
+
+  it("is case-sensitive", () => {
+    tagAc(AC_LITERAL);
+    expect(applyLiteralEdit("Alpha alpha", "ALPHA", "x", false)).toEqual({ kind: "zero" });
+  });
+
+  it("is whitespace-sensitive", () => {
+    tagAc(AC_LITERAL);
+    expect(applyLiteralEdit("a  b", "a b", "x", false)).toEqual({ kind: "zero" });
+  });
+
+  it("matches multi-line oldText across newlines exactly", () => {
+    tagAc(AC_LITERAL);
+    const content = "line one\nline two\nline three";
+    const result = applyLiteralEdit(content, "line two\nline", "row 2\nrow", false);
+    expect(result).toEqual({ kind: "ok", content: "line one\nrow 2\nrow three", count: 1 });
+  });
+
+  it("handles unicode (emoji, combining marks) as plain code units", () => {
+    tagAc(AC_LITERAL);
+    const result = applyLiteralEdit("café ☕ café", "café", "tea", true);
+    expect(result).toEqual({ kind: "ok", content: "tea ☕ tea", count: 2 });
+  });
+
+  it("matches inside markdown syntax verbatim (backticks, fences, list markers)", () => {
+    tagAc(AC_LITERAL);
+    const content = "- item `code`\n```ts\nconst a = 1;\n```";
+    const result = applyLiteralEdit(content, "`code`", "`snippet`", false);
+    expect(result).toEqual({
+      kind: "ok",
+      content: "- item `snippet`\n```ts\nconst a = 1;\n```",
+      count: 1,
+    });
+  });
+});
+
+describe("applyLiteralEdit — input guards (one valid pair per call)", () => {
+  it("empty oldText → kind 'invalid' (whole-body replacement is update_section's job)", () => {
+    tagAc(AC_SINGLE_PAIR);
+    expect(applyLiteralEdit("anything", "", "x", false)).toEqual({
+      kind: "invalid",
+      reason: "empty-old",
+    });
+  });
+
+  it("oldText identical to newText → kind 'invalid' (no-op edit)", () => {
+    tagAc(AC_SINGLE_PAIR);
+    expect(applyLiteralEdit("a b c", "b", "b", false)).toEqual({
+      kind: "invalid",
+      reason: "same-text",
+    });
+    // Guard fires even when replaceAll is set and the text has many hits.
+    expect(applyLiteralEdit("b b b", "b", "b", true)).toEqual({
+      kind: "invalid",
+      reason: "same-text",
+    });
+  });
+
+  it("guards win over matching (invalid before zero/ambiguous)", () => {
+    tagAc(AC_SINGLE_PAIR);
+    expect(applyLiteralEdit("no hits here", "", "", false)).toEqual({
+      kind: "invalid",
+      reason: "empty-old",
+    });
+  });
+});

--- a/packages/server/src/services/section-edit.ts
+++ b/packages/server/src/services/section-edit.ts
@@ -1,0 +1,63 @@
+// spec-503: the pure literal-edit engine behind the edit_section tool.
+// Literal string semantics only — the ambiguity remedy ("widen oldText until
+// unique") depends on matching being exact, so neither regex interpretation
+// nor String.replace's $-pattern substitution may ever apply here (dec-1).
+// The engine returns a discriminated result and never throws; the tool
+// handler owns error wording (it knows the section ref the messages cite).
+
+export type SectionEditResult =
+  | { kind: "invalid"; reason: "empty-old" | "same-text" }
+  | { kind: "zero" }
+  | { kind: "ambiguous"; count: number }
+  | { kind: "ok"; content: string; count: number };
+
+/** Count non-overlapping occurrences of `needle` in `haystack`. */
+function countOccurrences(haystack: string, needle: string): number {
+  let count = 0;
+  let index = haystack.indexOf(needle);
+  while (index !== -1) {
+    count += 1;
+    index = haystack.indexOf(needle, index + needle.length);
+  }
+  return count;
+}
+
+/**
+ * Apply one literal oldText → newText edit to `content`.
+ *
+ * - `replaceAll: false` requires exactly one occurrence; more is `ambiguous`
+ *   (the caller reports the count and the two remedies), none is `zero`.
+ * - `replaceAll: true` replaces every non-overlapping occurrence.
+ *
+ * Replacement is built by slicing/joining — never String.replace with a
+ * string pattern — so `$&`-style sequences in newText stay verbatim.
+ */
+export function applyLiteralEdit(
+  content: string,
+  oldText: string,
+  newText: string,
+  replaceAll: boolean,
+): SectionEditResult {
+  if (oldText.length === 0) {
+    return { kind: "invalid", reason: "empty-old" };
+  }
+  if (oldText === newText) {
+    return { kind: "invalid", reason: "same-text" };
+  }
+
+  const count = countOccurrences(content, oldText);
+  if (count === 0) {
+    return { kind: "zero" };
+  }
+  if (count > 1 && !replaceAll) {
+    return { kind: "ambiguous", count };
+  }
+
+  if (replaceAll) {
+    return { kind: "ok", content: content.split(oldText).join(newText), count };
+  }
+  const index = content.indexOf(oldText);
+  const next =
+    content.slice(0, index) + newText + content.slice(index + oldText.length);
+  return { kind: "ok", content: next, count: 1 };
+}

--- a/packages/shared/src/scaffold-data.ts
+++ b/packages/shared/src/scaffold-data.ts
@@ -1099,6 +1099,8 @@ const TOOL_RATIONALES: Record<string, string> = {
     'Append a new typed section to a document. The (doc, sectionType) pair is unique within a doc.',
   update_section:
     'Update the markdown content of an existing section. The vehicle for reflecting resolved decisions into the narrative.',
+  edit_section:
+    'Surgical literal find/replace inside one section: a targeted change costs one oldText/newText pair instead of re-emitting the whole body. Ambiguous or missing matches fail loudly with the remedy named.',
   retitle_section:
     'Change a section\'s heading (and optionally its machine key) without touching content. Closes the section-CRUD gap for clean recuts — fixing a stale heading the old surface could only tombstone.',
   delete_section:

--- a/packages/shared/src/tool-manifest.spec-503.test.ts
+++ b/packages/shared/src/tool-manifest.spec-503.test.ts
@@ -1,0 +1,43 @@
+// spec-503: the manifest is the steering surface (std-16) — edit_section must
+// exist as a planning verb and update_section must point targeted edits at it,
+// with both summaries inside the manifest bound.
+import { describe, expect, it } from 'vitest';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { toolManifest } from './tool-manifest.js';
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-503/acs/ac-${n}`;
+
+// Mirrors MAX_SUMMARY_LEN in tool-manifest.test.ts — kept in both places so a
+// bound change is a deliberate two-file edit.
+const MAX_SUMMARY_LEN = 240;
+
+describe('spec-503: edit_section manifest entry + update_section steering', () => {
+  const editEntry = toolManifest.find((e) => e.name === 'edit_section');
+  const updateEntry = toolManifest.find((e) => e.name === 'update_section');
+
+  it('edit_section is a planning-group mutating verb with the one-pair args shape', () => {
+    tagAc(AC(9));
+    expect(editEntry).toBeDefined();
+    expect(editEntry!.group).toBe('planning');
+    expect(editEntry!.readOnlyHint).toBe(false);
+    expect(editEntry!.args).toBe('edit_section(ref, oldText, newText, replaceAll?)');
+  });
+
+  it('edit_section summary leads with the cost advantage and names the failure remedies', () => {
+    tagAc(AC(9));
+    tagAc(AC(6));
+    const summary = editEntry!.summary;
+    expect(summary).toMatch(/no body re-emission/i);
+    expect(summary).toMatch(/replaceAll/);
+    expect(summary.length).toBeLessThanOrEqual(MAX_SUMMARY_LEN);
+  });
+
+  it('update_section is marked as full-body replacement and steers to edit_section', () => {
+    tagAc(AC(9));
+    tagAc(AC(6));
+    const summary = updateEntry!.summary;
+    expect(summary).toMatch(/ENTIRE markdown body/);
+    expect(summary).toMatch(/prefer edit_section/);
+    expect(summary.length).toBeLessThanOrEqual(MAX_SUMMARY_LEN);
+  });
+});

--- a/packages/shared/src/tool-manifest.ts
+++ b/packages/shared/src/tool-manifest.ts
@@ -229,8 +229,19 @@ export const toolManifest: ToolManifestEntry[] = [
   {
     name: 'update_section',
     summary:
-      'Update the markdown content of a NON-standard document section (+ optional sectionType key / description). Blocked on standards — edit at the clause grain (add/edit/delete_clause). A sectionType collision fails with a readable error.',
+      'Replace the ENTIRE markdown body of a NON-standard section (+ optional sectionType / description); for a targeted edit prefer edit_section. Blocked on standards: edit at clause grain. A sectionType collision fails with a readable error.',
     args: 'update_section(ref, content, sectionType?, description?)',
+    group: 'planning',
+    readOnlyHint: false,
+    homePhase: null,
+  },
+  // spec-503: the surgical sibling of update_section. A targeted change costs
+  // one oldText/newText pair, never a re-emission of the whole section body.
+  {
+    name: 'edit_section',
+    summary:
+      'Surgical find/replace inside a NON-standard section: ONE literal oldText/newText pair, the cheap way to make a targeted change (no body re-emission). Zero or ambiguous matches fail naming the remedy; replaceAll replaces every hit.',
+    args: 'edit_section(ref, oldText, newText, replaceAll?)',
     group: 'planning',
     readOnlyHint: false,
     homePhase: null,
@@ -430,7 +441,7 @@ export const toolManifest: ToolManifestEntry[] = [
   {
     name: 'facets',
     summary:
-      "Check which parts of your Standards apply to a piece of work. Lists the topics your Standards are tagged by (security, db-migrations, e2e-testing, and so on). Internally these are your Memex's facets: you cast them as the facetBallot argument on create_task / create_decision, and Memex surfaces the governing standard sections.",
+      "Check which parts of your Standards apply to a piece of work: lists the topics they are tagged by (the Memex's facets). Cast these as the facetBallot on create_task / create_decision and Memex surfaces the governing standard sections.",
     args: 'facets(verb, memex?)',
     group: 'read',
     readOnlyHint: true,
@@ -665,7 +676,7 @@ export const toolManifest: ToolManifestEntry[] = [
   {
     name: 'list_skills',
     summary:
-      "List active Skills alphabetically — each carries name, description, capability flags, and ref; never the SKILL.md body or allowed-tools. When a skill is named without a Memex, pass all_memexes:true to find it across every Memex you can access (grouped by Memex), then get_skill by the returned ref; on a name that appears in more than one Memex, ALWAYS ask the user which to use.",
+      "List active Skills alphabetically: name, description, capability flags, ref (never the SKILL.md body). Pass all_memexes:true to find a named skill across your Memexes; if it appears in more than one Memex, ALWAYS ask which to use.",
     args: 'list_skills(memex?, all_memexes?)',
     group: 'read',
     readOnlyHint: true,

--- a/packages/ui/e2e/journey-45-spec-304-mcp-session-mint.spec.ts
+++ b/packages/ui/e2e/journey-45-spec-304-mcp-session-mint.spec.ts
@@ -124,7 +124,12 @@ test(INSTALL_TEST, async ({ page }) => {
         }),
       });
     } else {
-      await route.continue();
+      // Fulfil the tokens LIST locally instead of forwarding it. The list is
+      // incidental here (test 1 covers the real endpoint end-to-end); forwarded,
+      // it queues behind the page's churning SSE streams on the dev proxy's
+      // per-origin connection pool and can starve past every assert window,
+      // leaving the section stuck without rows.
+      await route.fulfill({ status: 200, contentType: "application/json", body: "[]" });
     }
   });
 
@@ -135,8 +140,12 @@ test(INSTALL_TEST, async ({ page }) => {
     page.getByRole("heading", { name: "Install Memex MCP on this device" }),
   ).toBeVisible({ timeout: 15_000 });
 
+  // The rows render only after the tokens fetch resolves, and that GET can be
+  // starved for several seconds behind the page's SSE streams churning against
+  // the dev proxy (browser per-origin connection cap). The heading mounts
+  // immediately; the rows need the same generous window, not the 5s default.
   const codeRow = page.getByTestId("mcp-client-claudeCode");
-  await expect(codeRow).toBeVisible();
+  await expect(codeRow).toBeVisible({ timeout: 15_000 });
 
   // A never-installed client reads "Not installed" with an Install action.
   await expect(page.getByTestId("mcp-status-claudeCode")).toHaveText("Not installed");

--- a/packages/ui/e2e/journey-52-spec-441-onboarding-gate.spec.ts
+++ b/packages/ui/e2e/journey-52-spec-441-onboarding-gate.spec.ts
@@ -72,8 +72,18 @@ test(
       timeout: 10_000,
     });
 
-    // Fill in a display name and submit.
-    await page.getByPlaceholder("Your display name").fill("Gate User");
+    // Fill in a display name and submit. The onboarding form can REMOUNT while
+    // boot-time queries settle (full-suite cold runs: the click log shows the
+    // button resolving enabled, the element detaching, and the fresh mount
+    // rendering disabled because the remount wiped the controlled input).
+    // Fill-and-verify inside a retry loop so a remount re-fills instead of
+    // leaving the click waiting forever on a disabled button.
+    await expect(async () => {
+      await page.getByPlaceholder("Your display name").fill("Gate User");
+      await expect(page.getByRole("button", { name: /^Continue$/ })).toBeEnabled({
+        timeout: 2_000,
+      });
+    }).toPass({ timeout: 15_000 });
     await page.getByRole("button", { name: /^Continue$/ }).click();
 
     // spec-444: after name capture, the welcome video gate fires for new users.

--- a/packages/ui/src/api/mcp.ts
+++ b/packages/ui/src/api/mcp.ts
@@ -49,9 +49,13 @@ export interface McpTokenSummary {
   createdAt: string;
 }
 
-export async function listMcpTokensApi(token: string | null): Promise<McpTokenSummary[]> {
+export async function listMcpTokensApi(
+  token: string | null,
+  init?: { signal?: AbortSignal },
+): Promise<McpTokenSummary[]> {
   const res = await fetchWithRetry(`${BASE_URL}/mcp/tokens`, {
     headers: authHeaders(token),
+    ...(init?.signal ? { signal: init.signal } : {}),
   });
   if (!res.ok) throw new Error(`List MCP tokens failed: ${res.status}`);
   return res.json();

--- a/packages/ui/src/hooks/useDesktopMcpStatus.fetch-timeout.test.tsx
+++ b/packages/ui/src/hooks/useDesktopMcpStatus.fetch-timeout.test.tsx
@@ -1,0 +1,129 @@
+// The tokens fetch inside useDesktopMcpStatus must be BOUNDED. Under a
+// saturated per-origin connection pool (SSE streams churning against the dev
+// proxy) the GET can be queued indefinitely; without a timeout the hook's
+// Promise.all never settles and the install surface shows "Checking MCP
+// status…" forever. The contract: each attempt is aborted after a timeout
+// (freeing its connection slot), bounded retries follow, and the terminal
+// failure is an honest 'error' phase, never an eternal 'loading'.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import {
+  useDesktopMcpStatus,
+  TOKENS_FETCH_TIMEOUT_MS,
+  TOKENS_FETCH_ATTEMPTS,
+} from './useDesktopMcpStatus';
+
+vi.mock('../components/AuthContext', () => ({ useAuth: () => ({ token: 'test-token' }) }));
+vi.mock('../hooks/useUserChangeStream', () => ({ useUserChangeStream: () => {} }));
+
+const listMcpTokensApi = vi.fn();
+vi.mock('../api/mcp', () => ({
+  listMcpTokensApi: (...a: unknown[]) => listMcpTokensApi(...a),
+  mintMcpTokenApi: vi.fn(),
+}));
+
+const STATUS = {
+  ok: true,
+  targets: {
+    claudeCode: { installed: false, urlMatches: false, tokenPrefix: null },
+    claudeDesktop: { installed: false, urlMatches: false, tokenPrefix: null },
+  },
+};
+
+function installShell() {
+  (window as unknown as { flutter_inappwebview?: unknown }).flutter_inappwebview = {
+    callHandler: (name: string) => {
+      if (name === 'mcpStatus') return STATUS;
+      return { ok: true };
+    },
+  };
+}
+
+function Probe() {
+  const { phase, clients, error } = useDesktopMcpStatus();
+  return (
+    <div data-testid="probe">
+      {phase}:{clients.length}:{error ?? 'no-error'}
+    </div>
+  );
+}
+
+/** A tokens fetch that never resolves on its own but honours the abort signal. */
+function hangingFetch(): void {
+  listMcpTokensApi.mockImplementation(
+    (_token: unknown, init?: { signal?: AbortSignal }) =>
+      new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () =>
+          reject(Object.assign(new Error('aborted'), { name: 'AbortError' })),
+        );
+      }),
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  installShell();
+  vi.useFakeTimers();
+});
+afterEach(() => {
+  delete (window as unknown as { flutter_inappwebview?: unknown }).flutter_inappwebview;
+  vi.useRealTimers();
+});
+
+async function advance(ms: number) {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(ms);
+  });
+}
+
+describe('useDesktopMcpStatus — bounded tokens fetch', () => {
+  it('a starved fetch is aborted per attempt and ends in phase error, never eternal loading', async () => {
+    hangingFetch();
+    render(<Probe />);
+    await advance(0);
+    expect(screen.getByTestId('probe').textContent).toMatch(/^loading:/);
+
+    // Sit through every attempt's timeout window (plus slack).
+    await advance(TOKENS_FETCH_TIMEOUT_MS * TOKENS_FETCH_ATTEMPTS + 1_000);
+
+    const text = screen.getByTestId('probe').textContent!;
+    expect(text).toMatch(/^error:0:/);
+    expect(text).not.toMatch(/no-error/);
+    // Every attempt got its own call, each carrying an abort signal.
+    expect(listMcpTokensApi).toHaveBeenCalledTimes(TOKENS_FETCH_ATTEMPTS);
+    for (const call of listMcpTokensApi.mock.calls) {
+      expect((call[1] as { signal?: AbortSignal } | undefined)?.signal).toBeInstanceOf(AbortSignal);
+    }
+  });
+
+  it('a hang on the first attempt recovers on retry and reaches ready with clients', async () => {
+    let attempt = 0;
+    listMcpTokensApi.mockImplementation(
+      (_token: unknown, init?: { signal?: AbortSignal }) => {
+        attempt += 1;
+        if (attempt === 1) {
+          return new Promise((_resolve, reject) => {
+            init?.signal?.addEventListener('abort', () =>
+              reject(Object.assign(new Error('aborted'), { name: 'AbortError' })),
+            );
+          });
+        }
+        return Promise.resolve([]);
+      },
+    );
+    render(<Probe />);
+    await advance(TOKENS_FETCH_TIMEOUT_MS + 1_000);
+
+    expect(screen.getByTestId('probe').textContent).toMatch(/^ready:2:no-error/);
+    expect(listMcpTokensApi).toHaveBeenCalledTimes(2);
+  });
+
+  it('an HTTP failure is NOT retried — it surfaces as error immediately', async () => {
+    listMcpTokensApi.mockRejectedValue(new Error('List MCP tokens failed: 401'));
+    render(<Probe />);
+    await advance(1_000);
+
+    expect(screen.getByTestId('probe').textContent).toMatch(/^error:/);
+    expect(listMcpTokensApi).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/ui/src/hooks/useDesktopMcpStatus.ts
+++ b/packages/ui/src/hooks/useDesktopMcpStatus.ts
@@ -60,6 +60,38 @@ export interface DesktopMcpStatus {
   refresh: () => Promise<void>;
 }
 
+// The tokens GET must be BOUNDED: under a saturated per-origin connection pool
+// (e.g. SSE streams churning against the dev proxy) the browser can queue the
+// request indefinitely, and an unbounded await here leaves the install surface
+// on "Checking MCP status…" forever. Each attempt is aborted after the timeout
+// (freeing its connection slot); only abort/network failures retry, an HTTP
+// error surfaces immediately.
+export const TOKENS_FETCH_TIMEOUT_MS = 5_000;
+export const TOKENS_FETCH_ATTEMPTS = 3;
+
+function isRetryableFetchError(err: unknown): boolean {
+  return (err instanceof Error && err.name === 'AbortError') || err instanceof TypeError;
+}
+
+async function listTokensBounded(
+  token: string | null,
+): Promise<Awaited<ReturnType<typeof listMcpTokensApi>>> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < TOKENS_FETCH_ATTEMPTS; attempt++) {
+    const controller = new AbortController();
+    const timer = window.setTimeout(() => controller.abort(), TOKENS_FETCH_TIMEOUT_MS);
+    try {
+      return await listMcpTokensApi(token, { signal: controller.signal });
+    } catch (err) {
+      if (!isRetryableFetchError(err)) throw err;
+      lastError = err;
+    } finally {
+      window.clearTimeout(timer);
+    }
+  }
+  throw lastError instanceof Error ? lastError : new Error('Could not read MCP tokens');
+}
+
 /**
  * Probe + derive + push the desktop MCP status. Safe to mount more than once
  * (the app-global sync AND the Settings section both call it); each call pushes
@@ -94,7 +126,7 @@ export function useDesktopMcpStatus(): DesktopMcpStatus {
     try {
       const [local, tokens] = await Promise.all([
         mcpStatusBridge(),
-        listMcpTokensApi(token),
+        listTokensBounded(token),
       ]);
       if (!local) {
         // Probe failed — tolerate transient failures before showing an error.


### PR DESCRIPTION
## Summary

Ships **`edit_section(ref, oldText, newText, replaceAll?)`**: the surgical sibling of `update_section`. A targeted change to a Spec section costs one literal oldText/newText pair instead of re-emitting the whole section body. Literal matching only (regex metacharacters are plain text, no $-pattern substitution); zero or ambiguous matches fail with the remedy named and nothing written; `replaceAll: true` opts into multi-hit; Standards keep the clause grain (hard reject toward add/edit/delete_clause). Implemented handler-level over the existing `updateSection` service, so std-8 bus emission, embedding refresh, and std-32 actor stamping are inherited unchanged; both agent surfaces (MCP + in-app) receive it from the one manifest (std-16).

Spec: [spec-503](https://memex.ai/mindset-prod/memex-building-itself/specs/spec-503) (in verify; QA report on the Spec). Fair-code (std-25).

## Changes

- `packages/server/src/services/section-edit.ts`: pure literal-edit engine, discriminated result, slice/join semantics (no `String.replace(string, string)` anywhere).
- `packages/server/src/agent/handlers/sections.ts`: the `edit_section` ToolSpec; terse payload carries the occurrence count + `(ref: s-N)` (b-36 D-8).
- `packages/shared/src/tool-manifest.ts`: new entry; `update_section` reworded as ENTIRE-body replacement steering targeted edits to `edit_section`. Also fixes two summaries that were red on develop against the 240-char manifest bound (`facets`, `list_skills`; `list_skills` keeps the ac-65 collision wording).
- Guard registries updated for the new tool: mutate-coverage endpoint catalogue, ref-emission probes, tool-specs audit probes; scaffold rationale added.
- **Riders (each with its own paper trail on the Spec):**
  - `useDesktopMcpStatus`: the tokens GET is now bounded (AbortSignal per attempt, 3 attempts, honest error state). The unbounded fetch could be starved indefinitely by a saturated per-origin connection pool, leaving Settings > Integrations on 'Checking MCP status…' forever; reproduced on clean develop (spec-503 t-6).
  - e2e hardening: journey-52's onboarding-form remount race (fill-and-verify retry) and journey-45's starvation (timeout widening + stubbing its incidental tokens list). Both were failing before these fixes and hold in full cold runs since.

## Test plan

- [x] Unit: section-edit truth table (17 tests: hits, replaceAll, metacharacters, $-patterns, multi-line, unicode, guards)
- [x] Unit: useDesktopMcpStatus bounded fetch (3 tests: hang-to-error, hang-to-recover, no-retry-on-HTTP)
- [x] Integration: edit_section end-to-end against live DB (11 tests: success, no-write-on-failure, standards gate, actor stamping, terse/verbose, surface wiring, scoped-mode absence)
- [x] Regression: get_doc body is byte-identical to stored content, and text copied from get_doc matches in edit_section (the guarantee copy-paste matching depends on)
- [x] Full server suite: 5865 passed. Full UI suite: 2201 passed. Shared: 587 passed. Typechecks on all three packages.
- [x] All 12 spec-503 ACs have tagged tests emitting to the Spec board
- [ ] e2e-cold locally: 151/153 per run with a rotating 1-3 timing failures; every one passes in isolation and the set differs each run. Diagnosed as environment contention and registered as [spec-503 issue-1](https://memex.ai/mindset-prod/memex-building-itself/specs/spec-503) (SSE stream churn vs the dev proxy's per-origin connection cap). This PR's CI run is the arbitration: no journey ever implicated this branch's code, and the two deterministic failures found along the way were red on clean develop and are root-fixed here.

std-28 note: no new journey is required by the feature itself (agent tool, no new user-facing flow; existing doc-view reactivity journeys cover the section-update SSE path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)