### PR TITLE
fix(spec-505): internal-account conversion exclusion + Google Ads tracker repair (v23 + userIdentifiers)

### DIFF
--- a/packages/server/src/services/conversion-apis.test.ts
+++ b/packages/server/src/services/conversion-apis.test.ts
@@ -1,0 +1,80 @@
+// Unit tests for spec-505 ac-4: internal/test accounts must not fire ad-platform
+// conversions. Reuses the same "real users" definition as the Mixpanel profile sync
+// (spec-297 dec-7, std-35 cl-31: email_domain === 'mindset.ai').
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { fireAllConversions, type ConversionParams } from './conversion-apis.js';
+
+const AC4 = 'mindset-prod/memex-building-itself/specs/spec-505/acs/ac-4';
+
+// Enough env vars for all three fire* functions to pass their required-config gates,
+// so a missing-credential no-op can't be mistaken for the internal-account exclusion.
+const REQUIRED_ENV: Record<string, string> = {
+  GOOGLE_ADS_CLIENT_ID: 'id',
+  GOOGLE_ADS_CLIENT_SECRET: 'secret',
+  GOOGLE_ADS_REFRESH_TOKEN: 'refresh',
+  GOOGLE_ADS_DEVELOPER_TOKEN: 'dev',
+  GOOGLE_ADS_CUSTOMER_ID: 'cust',
+  GOOGLE_ADS_CONVERSION_ACTION_ID: 'action',
+  LINKEDIN_ACCESS_TOKEN: 'token',
+  LINKEDIN_AD_ACCOUNT_ID: 'acct',
+  LINKEDIN_CONVERSION_ID: 'conv',
+  OPENAI_PIXEL_ID: 'pixel',
+  OPENAI_PIXEL_API_KEY: 'key',
+};
+
+function paramsFor(email: string): ConversionParams {
+  return {
+    email,
+    hashedEmail: 'hashed-email',
+    eventId: 'evt-1',
+    attribution: { gclid: 'g1', li_fat_id: 'l1', oppref: 'o1' },
+    conversionDateTime: new Date(0).toISOString(),
+  };
+}
+
+async function flush() {
+  await new Promise((r) => setTimeout(r, 0));
+}
+
+describe('fireAllConversions — internal account exclusion (spec-505 ac-4)', () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    for (const [key, value] of Object.entries(REQUIRED_ENV)) vi.stubEnv(key, value);
+    fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('{}', { status: 200 }));
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    fetchSpy.mockRestore();
+  });
+
+  it('fires no network calls for an internal (mindset.ai) account', async () => {
+    tagAc(AC4);
+    fireAllConversions(paramsFor('qa@mindset.ai'));
+    await flush();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('is case-insensitive on the email domain', async () => {
+    tagAc(AC4);
+    fireAllConversions(paramsFor('QA@MINDSET.AI'));
+    await flush();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not treat a lookalike domain as internal', async () => {
+    tagAc(AC4);
+    fireAllConversions(paramsFor('person@notmindset.ai'));
+    await flush();
+    expect(fetchSpy).toHaveBeenCalled();
+  });
+
+  it('fires network calls for a real external account', async () => {
+    tagAc(AC4);
+    fireAllConversions(paramsFor('person@example.com'));
+    await flush();
+    expect(fetchSpy).toHaveBeenCalled();
+  });
+});

--- a/packages/server/src/services/conversion-apis.test.ts
+++ b/packages/server/src/services/conversion-apis.test.ts
@@ -3,7 +3,7 @@
 // (spec-297 dec-7, std-35 cl-31: email_domain === 'mindset.ai').
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { tagAc } from '@memex-ai-ac/vitest';
-import { fireAllConversions, type ConversionParams } from './conversion-apis.js';
+import { fireAllConversions, fireGoogleAdsConversion, type ConversionParams } from './conversion-apis.js';
 
 const AC4 = 'mindset-prod/memex-building-itself/specs/spec-505/acs/ac-4';
 
@@ -76,5 +76,39 @@ describe('fireAllConversions — internal account exclusion (spec-505 ac-4)', ()
     fireAllConversions(paramsFor('person@example.com'));
     await flush();
     expect(fetchSpy).toHaveBeenCalled();
+  });
+});
+
+describe('fireGoogleAdsConversion — Enhanced Conversions request contract (spec-505 issue-3)', () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    for (const [key, value] of Object.entries(REQUIRED_ENV)) vi.stubEnv(key, value);
+    // First fetch = OAuth token exchange; second = the click-conversion upload.
+    fetchSpy = vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response(JSON.stringify({ access_token: 'at' }), { status: 200 }))
+      .mockResolvedValueOnce(new Response('{}', { status: 200 }));
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    fetchSpy.mockRestore();
+  });
+
+  it('uploads to a currently-supported API version, not the sunset v17', async () => {
+    await fireGoogleAdsConversion(paramsFor('person@example.com'));
+    const uploadUrl = String(fetchSpy.mock.calls[1][0]);
+    expect(uploadUrl).toContain('/v23/');
+    expect(uploadUrl).not.toContain('/v17/');
+  });
+
+  it('sends the hashed email as a first-party userIdentifier, not a top-level hashedEmailAddress', async () => {
+    await fireGoogleAdsConversion(paramsFor('person@example.com'));
+    const body = JSON.parse(String((fetchSpy.mock.calls[1][1] as RequestInit).body));
+    const conversion = body.conversions[0];
+    expect(conversion.userIdentifiers).toEqual([
+      { hashedEmail: 'hashed-email', userIdentifierSource: 'FIRST_PARTY' },
+    ]);
+    expect(conversion).not.toHaveProperty('hashedEmailAddress');
   });
 });

--- a/packages/server/src/services/conversion-apis.ts
+++ b/packages/server/src/services/conversion-apis.ts
@@ -5,6 +5,13 @@
 import type { AttributionData } from "./attribution.js";
 import { extractEmailDomain } from "./mixpanel-profile.js";
 
+// Pinned Google Ads API major version. Google sunsets versions on a rolling
+// ~14-month cadence — bump this when the current one nears its date on
+// https://developers.google.com/google-ads/api/docs/sunset-dates. v17 sunset
+// 2025-06-04 and v20 on 2026-06-10; v21–v23 are supported as of 2026-07, so
+// this targets the newest for maximum runway (spec-505 issue-3).
+const GOOGLE_ADS_API_VERSION = "v23";
+
 export interface ConversionParams {
   email: string;
   hashedEmail: string;
@@ -55,7 +62,7 @@ export async function fireGoogleAdsConversion(params: ConversionParams): Promise
     return;
   }
 
-  const url = `https://googleads.googleapis.com/v17/customers/${customerId}:uploadClickConversions`;
+  const url = `https://googleads.googleapis.com/${GOOGLE_ADS_API_VERSION}/customers/${customerId}:uploadClickConversions`;
   await fetch(url, {
     method: "POST",
     headers: {
@@ -68,7 +75,13 @@ export async function fireGoogleAdsConversion(params: ConversionParams): Promise
         gclid: params.attribution.gclid,
         conversionAction: `customers/${customerId}/conversionActions/${actionId}`,
         conversionDateTime: params.conversionDateTime,
-        hashedEmailAddress: params.hashedEmail,
+        // Enhanced Conversions: the hashed email is a first-party UserIdentifier,
+        // not a top-level field. `hashedEmailAddress` is not a valid ClickConversion
+        // member and is silently ignored by the API (spec-505 issue-3).
+        userIdentifiers: [{
+          hashedEmail: params.hashedEmail,
+          userIdentifierSource: "FIRST_PARTY",
+        }],
       }],
       partialFailure: true,
     }),

--- a/packages/server/src/services/conversion-apis.ts
+++ b/packages/server/src/services/conversion-apis.ts
@@ -3,6 +3,7 @@
 // required env vars are absent so dev/staging environments don't error.
 
 import type { AttributionData } from "./attribution.js";
+import { extractEmailDomain } from "./mixpanel-profile.js";
 
 export interface ConversionParams {
   email: string;
@@ -153,7 +154,12 @@ export async function fireOpenAiConversion(params: ConversionParams): Promise<vo
 
 // Fires all three conversion APIs for a new account. Non-blocking — does NOT
 // await individual calls; errors are logged but never surfaced to the caller.
+// Skips entirely for internal accounts — same "real users" definition already
+// used to gate the Mixpanel profile sync (spec-297 dec-7, std-35 cl-31:
+// email_domain === 'mindset.ai') — so QA/dogfooding/test sign-ups never
+// inflate ad-platform conversion counts (spec-505 ac-4).
 export function fireAllConversions(params: ConversionParams): void {
+  if (extractEmailDomain(params.email) === "mindset.ai") return;
   fireGoogleAdsConversion(params).catch(() => {});
   fireLinkedInConversion(params).catch(() => {});
   fireOpenAiConversion(params).catch(() => {});


### PR DESCRIPTION
Two commits, both spec-505 conversion-tracking fixes, kept in one PR because they touch the same file and ship as one conversion-tracking release.

## 1. Internal-account exclusion (Niamh, `1c4e8df`) — ac-4/ac-6
`fireAllConversions` returns early when the new account's email domain is `mindset.ai`, before any conversion API fires. Reuses the "real users" definition already gating the Mixpanel profile sync (spec-297 dec-7, std-35 cl-31), so both analytics surfaces agree on who's internal. Single choke point → covers both magic-link and password verify-email paths. 4 tests.

## 2. Google Ads tracker repair (`b44945c`) — issue-3
`fireGoogleAdsConversion` was broken two ways, both latent because the `google-ads-*` secrets never existed so the code never ran against the live API:
- **Dead API version** — pinned `v17`, which sunset 2025-06-04. Extracted to `GOOGLE_ADS_API_VERSION`, set to `v23` (v17 and v20 both past sunset; v21–v23 supported as of 2026-07).
- **Malformed payload** — sent the hashed email as a top-level `hashedEmailAddress`, which is not a valid `ClickConversion` field and is silently ignored. Enhanced Conversions requires a first-party `userIdentifiers[].hashedEmail`. Fixed.

2 added tests assert the upload URL targets a live version (not v17) and that the body carries `userIdentifiers`, not `hashedEmailAddress`.

## Verification
6 tests green against current develop; type-check clean. The Google fix is contract-conformant per Google's docs but **not live-verified** — that needs a real test conversion once the six `google-ads-*` secrets are provisioned in memex-ai-prod. When provisioning, store `google-ads-customer-id` as digits only (no dashes) — the code interpolates it raw into the request URL.

## Provenance
Both commits cherry-picked/authored clean onto current develop. Deliberately excludes the stale `feat/spec-21-conversion-tracking` branch's `deploy.sh` changes — develop already has that fix (`83bc62e`); #517 (the branch's version) was closed unmerged.

## Related (out of scope)
- issue-4 — LinkedIn credentials deferred; deploy-safe (guarded off in `deploy.sh` + `fireLinkedInConversion`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012YNv9xVmQcGSMtz4kLeNyr