### PR TITLE
spec-499: diagnose an absent facet ballot instead of blaming the caller

### DIFF
--- a/packages/server/src/agent/facet-ballot-diagnosis.spec-499.integration.test.ts
+++ b/packages/server/src/agent/facet-ballot-diagnosis.spec-499.integration.test.ts
@@ -1,0 +1,247 @@
+// spec-499 t-2 (dec-2, dec-3) — the required-but-absent facet ballot is DIAGNOSED,
+// not merely reported.
+//
+// "Absent" covers three different situations and the old message named only the one the
+// server could see ("none was supplied"), with a remediation — reconnect your MCP client
+// — that is right in at most one of them. These tests pin the discriminated branches:
+// a near-miss argument name gets named and the cache hint suppressed; a genuine absence
+// echoes the argument names that DID arrive and keeps the hint.
+//
+// The requireLead branches are exercised directly against `requireBallotForMemex` with
+// channel 'mcp' (the surface the hint is written for), and end-to-end through
+// executeServerTool for the handler wiring + the dec-3 "reject, never alias" guarantee.
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { eq } from "drizzle-orm";
+import { db } from "../db/connection.js";
+import {
+  users,
+  namespaces,
+  orgs,
+  orgMemberships,
+  memexes,
+  documents,
+  facets,
+  decisions,
+  tasks,
+} from "../db/schema.js";
+import { requireBallotForMemex, nearMissBallotArg } from "../services/facet-ballot.js";
+import { ValidationError } from "../types/errors.js";
+import { executeServerTool } from "./tools.js";
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-499/acs/ac-${n}`;
+
+let userId: string;
+let memexId: string;
+let specRef: string;
+let specDocId: string;
+
+// std-37: per-worker-unique identifiers so parallel workers never collide.
+const uniq = `x499-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`.toLowerCase();
+
+const COMPLETE = { verdict: { "xc-security": true, "xc-perf": false }, none: false };
+const EMPTY_BALLOT = { verdict: {}, none: false };
+
+beforeAll(async () => {
+  const [u] = await db.insert(users).values({ email: `${uniq}@memex.ai` } as never).returning();
+  userId = u.id;
+  const [ns] = await db.insert(namespaces).values({ slug: uniq, kind: "org" }).returning();
+  const [org] = await db.insert(orgs).values({ namespaceId: ns.id, name: `Test ${uniq}` }).returning();
+  await db.update(namespaces).set({ ownerOrgId: org.id }).where(eq(namespaces.id, ns.id));
+  const [mx] = await db.insert(memexes).values({ namespaceId: ns.id, slug: "main", name: "Main" }).returning();
+  memexId = mx.id;
+  await db.insert(orgMemberships).values({ userId, orgId: org.id, role: "administrator" });
+
+  // A vocabulary must exist for the ballot to be forced at all.
+  for (const key of ["xc-security", "xc-perf"]) {
+    await db.insert(facets).values({ ownerType: "org", ownerId: org.id, key, description: key });
+  }
+
+  const [spec] = await db
+    .insert(documents)
+    .values({ memexId, handle: "spec-1", title: "Consumer spec", docType: "spec", status: "build" })
+    .returning();
+  specDocId = spec.id;
+  specRef = `${uniq}/main/specs/spec-1`;
+});
+
+afterAll(async () => {
+  await db.delete(documents).where(eq(documents.memexId, memexId)).catch(() => {});
+  await db.delete(memexes).where(eq(memexes.id, memexId)).catch(() => {});
+  await db.delete(users).where(eq(users.id, userId)).catch(() => {});
+});
+
+/** Capture the rejection message from an absent-ballot guard call. */
+async function absentBallotMessage(receivedArgNames: string[] | undefined, noun: "decision" | "task") {
+  try {
+    await requireBallotForMemex(
+      memexId,
+      { provided: false, ballot: EMPTY_BALLOT, receivedArgNames },
+      { noun, channel: "mcp" },
+    );
+  } catch (err) {
+    expect(err).toBeInstanceOf(ValidationError);
+    return (err as Error).message;
+  }
+  throw new Error("expected requireBallotForMemex to reject an absent ballot");
+}
+
+describe("spec-499 dec-2 — near-miss argument name is named, not guessed at", () => {
+  it("names the key received and the key expected (ac-7)", async () => {
+    tagAc(AC(7));
+    tagAc(AC(1));
+    const msg = await absentBallotMessage(["ref", "title", "facet_ballot"], "decision");
+    expect(msg).toContain("facet_ballot"); // what arrived
+    expect(msg).toContain("facetBallot"); // what was expected
+    expect(msg).toMatch(/DISCARDED because the name does not match/);
+    // The old lead actively misled — it asserted the caller supplied nothing.
+    expect(msg).not.toMatch(/none was supplied/);
+  });
+
+  it("suppresses the stale-tool-list hint when a ballot demonstrably was sent (ac-9)", async () => {
+    tagAc(AC(9));
+    tagAc(AC(3));
+    const msg = await absentBallotMessage(["ref", "title", "facet_ballot"], "decision");
+    expect(msg).not.toMatch(/cached\s+tool list/);
+    expect(msg).not.toMatch(/reconnect/i);
+  });
+
+  it("catches the realistic spelling variants, and only those (ac-7)", () => {
+    tagAc(AC(7));
+    expect(nearMissBallotArg(["ref", "facet_ballot"])).toBe("facet_ballot");
+    expect(nearMissBallotArg(["facet-ballot"])).toBe("facet-ballot");
+    expect(nearMissBallotArg(["FacetBallot"])).toBe("FacetBallot");
+    expect(nearMissBallotArg(["Facet_Ballot"])).toBe("Facet_Ballot");
+    // The correctly-spelled argument is not a near miss, and unrelated args are ignored.
+    expect(nearMissBallotArg(["facetBallot"])).toBeUndefined();
+    expect(nearMissBallotArg(["ref", "title", "context"])).toBeUndefined();
+    expect(nearMissBallotArg(["facets"])).toBeUndefined();
+    expect(nearMissBallotArg([])).toBeUndefined();
+  });
+});
+
+describe("spec-499 dec-2 — a genuine absence is evidenced by what did arrive", () => {
+  it("lists the argument names the server actually received (ac-8)", async () => {
+    tagAc(AC(8));
+    tagAc(AC(2));
+    const msg = await absentBallotMessage(["ref", "title", "context"], "decision");
+    expect(msg).toMatch(/No `facetBallot` argument reached the server/);
+    expect(msg).toMatch(/The arguments it did receive were: ref, title, context\./);
+  });
+
+  it("keeps the stale-tool-list hint in the branch where a drop is actually possible (ac-9)", async () => {
+    tagAc(AC(9));
+    tagAc(AC(3));
+    const msg = await absentBallotMessage(["ref", "title", "context"], "decision");
+    expect(msg).toMatch(/cached\s+tool list/);
+    expect(msg).toMatch(/reconnect\/reload the Memex MCP server/);
+  });
+
+  it("degrades gracefully when no argument names were threaded through (ac-8)", async () => {
+    tagAc(AC(8));
+    const msg = await absentBallotMessage(undefined, "decision");
+    expect(msg).toMatch(/No `facetBallot` argument reached the server/);
+    expect(msg).toMatch(/It received no arguments at all\./);
+  });
+
+  it("names create_task, not create_decision, on the task noun (ac-8)", async () => {
+    tagAc(AC(8));
+    const msg = await absentBallotMessage(["ref", "title", "description"], "task");
+    expect(msg).toMatch(/create_task/);
+    expect(msg).not.toMatch(/create_decision/);
+    expect(msg).toMatch(/every task in this Memex/);
+  });
+
+  it("still re-hands the full vocabulary and ballot shape in both branches (ac-1, ac-2)", async () => {
+    tagAc(AC(1));
+    tagAc(AC(2));
+    for (const received of [["ref", "facet_ballot"], ["ref", "title"]]) {
+      const msg = await absentBallotMessage(received, "decision");
+      expect(msg).toContain("xc-security");
+      expect(msg).toContain("xc-perf");
+      expect(msg).toMatch(/none:true for legitimate no-facet work/);
+    }
+  });
+});
+
+describe("spec-499 dec-3 — a misnamed ballot is rejected, never aliased", () => {
+  it("create_decision rejects a complete ballot under a near-miss key and creates no row (ac-10)", async () => {
+    tagAc(AC(10));
+    const before = await db.select().from(decisions).where(eq(decisions.docId, specDocId));
+    await expect(
+      executeServerTool(
+        memexId,
+        "create_decision",
+        { ref: specRef, title: "misnamed ballot", facet_ballot: COMPLETE },
+        userId,
+      ),
+    ).rejects.toThrow(/facet_ballot/);
+    const after = await db.select().from(decisions).where(eq(decisions.docId, specDocId));
+    // Rejected BEFORE the write — no orphan decision, and nothing was coerced through.
+    expect(after.length).toBe(before.length);
+  });
+
+  it("create_task rejects the same way and creates no row (ac-10)", async () => {
+    tagAc(AC(10));
+    const before = await db.select().from(tasks).where(eq(tasks.docId, specDocId));
+    await expect(
+      executeServerTool(
+        memexId,
+        "create_task",
+        { ref: specRef, title: "misnamed", description: "d", facet_ballot: COMPLETE },
+        userId,
+      ),
+    ).rejects.toThrow(/facet_ballot/);
+    const after = await db.select().from(tasks).where(eq(tasks.docId, specDocId));
+    expect(after.length).toBe(before.length);
+  });
+
+  it("never echoes argument VALUES back to the caller, only names (ac-8)", async () => {
+    tagAc(AC(8));
+    const secret = `sentinel-${uniq}-do-not-echo`;
+    await expect(
+      executeServerTool(
+        memexId,
+        "create_decision",
+        { ref: specRef, title: secret, context: secret },
+        userId,
+      ),
+    ).rejects.toThrow(
+      expect.objectContaining({
+        message: expect.not.stringContaining(secret) as unknown as string,
+      }),
+    );
+  });
+});
+
+describe("spec-499 — correct callers are unaffected", () => {
+  it("a complete ballot still creates the decision and returns the governing standards (ac-4)", async () => {
+    tagAc(AC(4));
+    const out = await executeServerTool(
+      memexId,
+      "create_decision",
+      { ref: specRef, title: "properly balloted", facetBallot: COMPLETE },
+      userId,
+    );
+    expect(out).toMatch(/Decision created/);
+    const rows = await db.select().from(decisions).where(eq(decisions.docId, specDocId));
+    expect(rows.some((d) => d.title === "properly balloted")).toBe(true);
+  });
+
+  it("an unknown extra argument alongside a correct ballot breaks nothing (ac-4)", async () => {
+    tagAc(AC(4));
+    const out = await executeServerTool(
+      memexId,
+      "create_decision",
+      {
+        ref: specRef,
+        title: "balloted with extras",
+        facetBallot: COMPLETE,
+        somethingUndeclared: { nested: true },
+      },
+      userId,
+    );
+    expect(out).toMatch(/Decision created/);
+  });
+});

--- a/packages/server/src/agent/handlers/decisions.ts
+++ b/packages/server/src/agent/handlers/decisions.ts
@@ -116,7 +116,10 @@ export const decisionsTools: ToolSpec[] = [
       const ballot = parseBallotArg(input.facetBallot);
       const vocab = await requireBallotForMemex(
         memexId,
-        { provided: hasBallot, ballot },
+        // spec-499 dec-2: hand over the argument NAMES this call actually arrived with
+        // (never their values) so an absent ballot is diagnosed — a near-miss key gets
+        // named, and a genuine drop is evidenced by the names that did make it.
+        { provided: hasBallot, ballot, receivedArgNames: Object.keys(input) },
         { noun: "decision", channel: ctx.channel },
       );
       const queryText = `${title}\n${context ?? ""}`;

--- a/packages/server/src/agent/handlers/tasks.ts
+++ b/packages/server/src/agent/handlers/tasks.ts
@@ -191,7 +191,9 @@ export const tasksTools: ToolSpec[] = [
       const ballot = parseBallotArg(input.facetBallot);
       const vocab = await requireBallotForMemex(
         memexId,
-        { provided: hasBallot, ballot },
+        // spec-499 dec-2 — see the matching call in handlers/decisions.ts: argument
+        // NAMES only, so an absent ballot can be diagnosed rather than merely reported.
+        { provided: hasBallot, ballot, receivedArgNames: Object.keys(input) },
         { noun: "task", channel: ctx.channel },
       );
       const task = await createTask(

--- a/packages/server/src/mcp/loose-tool-args.spec-499.test.ts
+++ b/packages/server/src/mcp/loose-tool-args.spec-499.test.ts
@@ -1,0 +1,172 @@
+// spec-499 t-1 (dec-1) — undeclared tool arguments SURVIVE MCP argument validation.
+//
+// Zod objects strip unknown keys by default, and the SDK hands the handler the parsed
+// (stripped) result. That strip is what made the forced-facet-ballot failure
+// undiagnosable: a ballot sent as `facet_ballot` and a ballot never sent at all reached
+// the handler as the identical state, so the server could only ever say "none was
+// supplied". Registering the shape as a LOOSE object preserves the key so the error can
+// name what actually arrived (services/facet-ballot.ts).
+//
+// These assertions go through the REAL registration path — createMcpServer's
+// `_registeredTools`, the same introspection the std-16 parity gate uses — and through
+// the SDK's own validate/publish helpers, so they'd catch the seam regressing back to a
+// bare shape. No DB.
+
+import { describe, it, expect } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { readFileSync } from "node:fs";
+import { normalizeObjectSchema, safeParseAsync } from "@modelcontextprotocol/sdk/server/zod-compat.js";
+import { toJsonSchemaCompat } from "@modelcontextprotocol/sdk/server/zod-json-schema-compat.js";
+import { createMcpServer } from "./tools.js";
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-499/acs/ac-${n}`;
+
+const TEST_USER_ID = "00000000-0000-0000-0000-00000000beef";
+
+/** The schema the SDK actually stored for a tool, as its own helpers expect it. */
+type RegisteredSchema = NonNullable<Parameters<typeof normalizeObjectSchema>[0]>;
+
+function registeredTool(name: string): RegisteredSchema {
+  const server = createMcpServer(TEST_USER_ID);
+  const tools = (
+    server as unknown as { _registeredTools: Record<string, { inputSchema?: RegisteredSchema }> }
+  )._registeredTools;
+  const tool = tools[name];
+  if (!tool?.inputSchema) throw new Error(`no registered tool '${name}' with an inputSchema`);
+  return tool.inputSchema;
+}
+
+/** The registered schema as an object schema — the form both SDK paths normalise to. */
+function normalised(toolName: string) {
+  const obj = normalizeObjectSchema(registeredTool(toolName));
+  // A bare raw shape would normalise to a STRICT object and silently strip again, so
+  // failing here is itself the regression signal.
+  if (!obj) throw new Error(`tool '${toolName}' did not normalise to an object schema`);
+  return obj;
+}
+
+/** Parse args exactly as the SDK does before dispatching to a handler (mcp.js). */
+async function parseAsSdk(toolName: string, args: Record<string, unknown>) {
+  return (await safeParseAsync(normalised(toolName), args)) as
+    | { success: true; data: Record<string, unknown> }
+    | { success: false; error: unknown };
+}
+
+/** The JSON Schema the SDK publishes for a tool in its tools/list response. */
+function publishedSchema(toolName: string): {
+  properties?: Record<string, unknown>;
+  required?: string[];
+} {
+  return toJsonSchemaCompat(normalised(toolName), {} as never) as never;
+}
+
+const COMPLETE_BALLOT = { none: false, verdict: { "xc-security": true, "xc-perf": false } };
+
+describe("spec-499 dec-1 — undeclared arguments survive MCP validation", () => {
+  it("keeps an argument the schema doesn't declare instead of stripping it (ac-5)", async () => {
+    tagAc(AC(5));
+    const result = await parseAsSdk("create_decision", {
+      ref: "ns/main/specs/spec-1",
+      title: "T",
+      // The exact shape that used to vanish: a complete ballot under a near-miss name.
+      facet_ballot: COMPLETE_BALLOT,
+    });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    // Visible to the handler — this is what requireLead() reads to name the near miss.
+    expect(Object.keys(result.data)).toContain("facet_ballot");
+    expect(result.data.facet_ballot).toEqual(COMPLETE_BALLOT);
+    // ...and the declared arguments still arrive normally.
+    expect(result.data.ref).toBe("ns/main/specs/spec-1");
+    expect(result.data.title).toBe("T");
+  });
+
+  it("preserves undeclared arguments on create_task too, not just create_decision (ac-5)", async () => {
+    tagAc(AC(5));
+    const result = await parseAsSdk("create_task", {
+      ref: "ns/main/specs/spec-1",
+      title: "T",
+      description: "d",
+      facet_ballot: COMPLETE_BALLOT,
+    });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(Object.keys(result.data)).toContain("facet_ballot");
+  });
+
+  it("still accepts a correctly-named ballot unchanged (ac-4)", async () => {
+    tagAc(AC(4));
+    const result = await parseAsSdk("create_decision", {
+      ref: "ns/main/specs/spec-1",
+      title: "T",
+      facetBallot: COMPLETE_BALLOT,
+    });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.facetBallot).toEqual(COMPLETE_BALLOT);
+  });
+
+  it("still REJECTS a malformed ballot — loose applies to unknown keys, not to declared types (ac-4)", async () => {
+    tagAc(AC(4));
+    // Guards the boundary of the change: a stringified ballot must keep failing loudly
+    // at the SDK, which is why it never reaches the "none was supplied" branch at all.
+    const stringified = await parseAsSdk("create_decision", {
+      ref: "ns/main/specs/spec-1",
+      title: "T",
+      facetBallot: JSON.stringify(COMPLETE_BALLOT),
+    });
+    expect(stringified.success).toBe(false);
+
+    const badVerdictType = await parseAsSdk("create_decision", {
+      ref: "ns/main/specs/spec-1",
+      title: "T",
+      facetBallot: { none: false, verdict: { "xc-security": "true" } },
+    });
+    expect(badVerdictType.success).toBe(false);
+  });
+
+  it("still REJECTS a call missing a genuinely required argument (ac-4)", async () => {
+    tagAc(AC(4));
+    const result = await parseAsSdk("create_decision", { title: "no ref" });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("spec-499 dec-1 — the published tool contract is unchanged", () => {
+  it("create_decision still declares facetBallot and still requires exactly [ref, title] (ac-6)", () => {
+    tagAc(AC(6));
+    const schema = publishedSchema("create_decision");
+    expect(schema.properties).toHaveProperty("facetBallot");
+    // Requiredness is what models actually condition on — the loose change must not
+    // touch it in either direction.
+    expect(schema.required).toEqual(["ref", "title"]);
+  });
+
+  it("create_task still declares facetBallot and keeps its required set (ac-6)", () => {
+    tagAc(AC(6));
+    const schema = publishedSchema("create_task");
+    expect(schema.properties).toHaveProperty("facetBallot");
+    expect(schema.required).toEqual(["ref", "title", "description"]);
+  });
+});
+
+describe("spec-499 dec-4 — licence boundary", () => {
+  it("changes stay in the fair-code core: no .ee marker on any touched file (ac-11)", () => {
+    tagAc(AC(11));
+    const touched = [
+      "src/mcp/tools.ts",
+      "src/services/facet-ballot.ts",
+      "src/agent/handlers/decisions.ts",
+      "src/agent/handlers/tasks.ts",
+      "src/mcp/loose-tool-args.spec-499.test.ts",
+      "src/agent/facet-ballot-diagnosis.spec-499.integration.test.ts",
+    ];
+    for (const path of touched) {
+      // Each file exists where the Spec says it does...
+      expect(() => readFileSync(new URL(`../../${path}`, import.meta.url))).not.toThrow();
+      // ...and carries neither licence marker (`.ee.` filename or `.ee/` dirname).
+      expect(path).not.toMatch(/\.ee\./);
+      expect(path).not.toMatch(/(^|\/)\.ee\//);
+    }
+  });
+});

--- a/packages/server/src/mcp/tools.ts
+++ b/packages/server/src/mcp/tools.ts
@@ -14,6 +14,7 @@
 // tools here without bumping that test's MCP_ONLY whitelist.
 
 import { randomUUID } from "node:crypto";
+import { z } from "zod";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { listMemberships } from "../services/users.js";
 import { NotFoundError, ValidationError } from "../types/errors.js";
@@ -506,7 +507,38 @@ export function createMcpServer(
       // spec-471 dec-3: the auto-pick disclosure line, if the read path set one.
       () => autoPickNotice,
     );
-    server.tool(spec.name, spec.description, spec.schema, spec.annotations, handler);
+    // spec-499 dec-1: register the shape as a LOOSE object so an argument the
+    // schema doesn't declare SURVIVES validation and reaches the handler.
+    //
+    // Zod objects strip unknown keys by default, and that strip is what made the
+    // forced-facet-ballot failure undiagnosable: a ballot sent as `facet_ballot`
+    // and a ballot never sent at all arrived at the handler as the identical
+    // state (`input.facetBallot === undefined`), so the server could only report
+    // "none was supplied" for both. Preserving the key lets requireLead() name
+    // what actually arrived (services/facet-ballot.ts).
+    //
+    // Safe across every tool: handlers read named fields off `input`, so a
+    // surviving unknown key is inert unless a handler deliberately looks for it.
+    // Not a contract change either — the published JSON Schema still declares
+    // every field and the same `required` set; only `additionalProperties`
+    // becomes permissive, which is now an accurate description of the server.
+    //
+    // Registered via `registerTool` (the config-object API) rather than the
+    // positional `tool(...)` overload: that overload accepts ONLY a raw shape and
+    // rejects a constructed schema outright ("expected a Zod schema or
+    // ToolAnnotations, but received an unrecognized object" — isZodRawShapeCompat
+    // returns false for schema instances). `registerTool` runs the same
+    // `_createRegisteredTool` path with the same `taskSupport: 'forbidden'`, and
+    // passes a schema instance straight through via getZodSchemaObject.
+    server.registerTool(
+      spec.name,
+      {
+        description: spec.description,
+        inputSchema: z.looseObject(spec.schema as z.ZodRawShape),
+        annotations: spec.annotations,
+      },
+      handler,
+    );
   }
 
   return server;

--- a/packages/server/src/services/facet-ballot.ts
+++ b/packages/server/src/services/facet-ballot.ts
@@ -116,28 +116,82 @@ export async function validateBallotForMemex(memexId: string, input: BallotInput
   return vocab;
 }
 
+/** The exact argument name the ballot must arrive under. */
+const BALLOT_ARG = "facetBallot";
+
+/** Fold an argument name to its comparable core: lowercase, alphanumerics only.
+ *  `facet_ballot`, `facet-ballot`, and `FacetBallot` all fold to `facetballot`. */
+function normaliseArgName(name: string): string {
+  return name.toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+/**
+ * spec-499 dec-2 — the received argument that was CLEARLY meant to be the ballot but
+ * arrived under a name the schema doesn't declare, or undefined if there wasn't one.
+ *
+ * This only ever sees anything because tool schemas are registered as loose objects
+ * (dec-1, mcp/tools.ts); with the default strip the misnamed key is deleted before the
+ * handler runs and is indistinguishable from a ballot that was never sent.
+ */
+export function nearMissBallotArg(receivedArgNames: string[]): string | undefined {
+  return receivedArgNames.find(
+    (name) => name !== BALLOT_ARG && normaliseArgName(name) === normaliseArgName(BALLOT_ARG),
+  );
+}
+
 /** Re-handing message for a ballot that is REQUIRED but ABSENT: leads with why it
- *  failed, hands the full ballot shape + vocabulary (via reHand), and, for a non-in-app
- *  caller, adds the stale-schema reload branch (an MCP client on a cached tool list can
- *  only start sending facetBallot after it reloads). */
+ *  failed and hands the full ballot shape + vocabulary (via reHand).
+ *
+ *  spec-499 dec-2 — the lead DISCRIMINATES, because "absent" covers three different
+ *  situations and the old single message named only the one the server could see:
+ *    • a near-miss key arrived (`facet_ballot`) → name what came and what was expected,
+ *      and do NOT suggest reconnecting: we can see a ballot was sent, so the cache hint
+ *      would send the caller chasing the wrong thing;
+ *    • nothing ballot-shaped arrived → echo the argument NAMES that did (never their
+ *      values — see the disclosure note in the Spec's Architecture lens), which is what
+ *      makes a client-side drop visible as evidence rather than inferred, and keep the
+ *      stale-schema hint here, where it is genuinely a candidate.
+ *  Per dec-3 a near-miss is named and REJECTED, never aliased into a valid ballot. */
 function requireLead(
   vocab: VocabFacet[],
-  opts: { noun: "task" | "decision"; channel?: "mcp" | "in_app_agent" },
+  opts: {
+    noun: "task" | "decision";
+    channel?: "mcp" | "in_app_agent";
+    receivedArgNames?: string[];
+  },
 ): string {
   // The ballot is forced at the CREATE site for both nouns (create_task / create_decision);
   // resolve_decision only ever VALIDATES a provided ballot, so it never reaches this
   // absent-branch. Name the create tool so the remediation points at the right call.
   const tool = opts.noun === "task" ? "create_task" : "create_decision";
   const verb = "created";
+  const received = opts.receivedArgNames ?? [];
+  const preamble =
+    `A facet ballot is REQUIRED on every ${opts.noun} in this Memex (it has a facet vocabulary) ` +
+    `— the ${opts.noun} was NOT ${verb}.`;
+
+  const nearMiss = nearMissBallotArg(received);
+  if (nearMiss) {
+    return reHand(
+      vocab,
+      `${preamble} An argument named \`${nearMiss}\` arrived, but \`${tool}\` expects ` +
+        `\`${BALLOT_ARG}\` — it was DISCARDED because the name does not match. Re-send the ` +
+        `same ballot under the exact name \`${BALLOT_ARG}\`.`,
+    );
+  }
+
   let msg = reHand(
     vocab,
-    `A facet ballot is REQUIRED on every ${opts.noun} in this Memex (it has a facet vocabulary), ` +
-      `and none was supplied — the ${opts.noun} was NOT ${verb}.`,
+    `${preamble} No \`${BALLOT_ARG}\` argument reached the server. ` +
+      (received.length > 0
+        ? `The arguments it did receive were: ${received.join(", ")}.`
+        : `It received no arguments at all.`),
   );
   if (opts.channel !== "in_app_agent") {
     msg +=
-      ` If your \`${tool}\` tool exposes no \`facetBallot\` parameter, your MCP client is on a cached ` +
-      `tool list — reconnect/reload the Memex MCP server to refresh it, then retry.`;
+      ` If you believe you sent \`${BALLOT_ARG}\`, it was dropped before reaching the server: ` +
+      `your MCP client may be on a cached tool list on which \`${tool}\` exposes no ` +
+      `\`${BALLOT_ARG}\` parameter — reconnect/reload the Memex MCP server to refresh it, then retry.`;
   }
   return msg;
 }
@@ -152,12 +206,23 @@ function requireLead(
  */
 export async function requireBallotForMemex(
   memexId: string,
-  input: { provided: boolean; ballot: BallotInput },
+  input: {
+    provided: boolean;
+    ballot: BallotInput;
+    /** spec-499 dec-2: the argument names the handler actually received, so an absent
+     *  ballot can be diagnosed instead of merely reported. Callers pass
+     *  `Object.keys(input)`; omitted, the message degrades to the un-echoed form. */
+    receivedArgNames?: string[];
+  },
   opts: { noun: "task" | "decision"; channel?: "mcp" | "in_app_agent" },
 ): Promise<VocabFacet[]> {
   const vocab = await vocabForMemex(memexId);
   if (vocab.length === 0) return vocab; // no vocabulary → nothing to adjudicate
-  if (!input.provided) throw new ValidationError(requireLead(vocab, opts));
+  if (!input.provided) {
+    throw new ValidationError(
+      requireLead(vocab, { ...opts, receivedArgNames: input.receivedArgNames }),
+    );
+  }
   const check = validateBallot(input.ballot, vocab);
   if (!check.ok) throw new ValidationError(check.message);
   return vocab;


### PR DESCRIPTION
## Why

`create_decision` / `create_task` reject a required-but-absent `facetBallot` with:

> A facet ballot is REQUIRED on every decision in this Memex … and **none was supplied** — the decision was NOT created. … If your `create_decision` tool exposes no `facetBallot` parameter, your MCP client is on a cached tool list — reconnect/reload.

Multiple agents have burned sessions on this ([spec-499](https://memex.ai/mindset-prod/memex-building-itself/specs/spec-499) collects three independent reports). Both halves of that message misdirect: the lead asserts the caller supplied nothing, which from the caller's side is false; the remediation names a client cache, which is right in at most one of the three situations the message covers — and c-3 on the Spec records a session where reloading the schema did *not* clear it and a bare retry immediately did.

## Root cause

**Zod objects strip unknown keys by default.** A ballot sent as `facet_ballot` and a ballot never sent at all both reach the handler as `input.facetBallot === undefined`. The server cannot distinguish them, so it reports the one it can name — the wrong one.

Two genuinely different upstream causes collapse into that single indistinguishable state: a **client/transport drop** (stale or partial tool schema) and **caller key variance**. Nothing in any report to date can tell them apart, which is exactly why diagnosis kept costing whole sessions.

**Ruled out:** nested-object serialisation, which was the reporters' own hypothesis. The SDK zod-validates arguments *before* the handler runs, so a stringified ballot, a stringified `verdict`, or string verdict values all fail loudly and explicitly (`"expected object, received string"`) and never reach this branch at all. A repro driving the reported payload plus five mutations through the real schema is in the Spec's Evidence lens.

## What changed

**`mcp/tools.ts`** — register tool input schemas as **loose objects**, so an argument the schema doesn't declare survives validation and reaches the handler.

Uses `registerTool(name, {description, inputSchema, annotations}, handler)` rather than the positional `tool(...)` overload: that overload accepts *only* a raw shape and rejects a constructed schema outright (`isZodRawShapeCompat` returns false for schema instances). `registerTool` reaches the same `_createRegisteredTool` path with the same `taskSupport: 'forbidden'`.

Applies to every registered tool by design, and is safe: handlers read named fields off `input`, so a surviving unknown key is inert unless a handler looks for it. **Not a contract change** — the published JSON Schema still declares every field with the same `required` set; only `additionalProperties` becomes permissive, which is now an accurate description of the server.

**`services/facet-ballot.ts`** — split the absent-ballot message:

| Situation | Message |
|---|---|
| Near-miss key arrived (`facet_ballot`, `facet-ballot`, `FacetBallot`) | Names the key received **and** the key expected; says it was discarded on name mismatch. **No cache hint** — we can see a ballot was sent. |
| Nothing ballot-shaped arrived | Lists the argument **names** that did arrive. **Keeps the cache hint**, where a drop is genuinely a candidate. |

Both keep the existing vocabulary + ballot-shape re-hand. Argument **names only, never values** — asserted by a sentinel test.

**`handlers/{decisions,tasks}.ts`** — thread the received argument names through. Only the two create sites can reach this branch; `update_*` / `resolve_decision` pass `provided: true`.

## Deliberately not done

Aliasing, JSON-string coercion, or a flatter ballot encoding — all requested by the reporting agents, all declined in [dec-3](https://memex.ai/mindset-prod/memex-building-itself/specs/spec-499). The ballot is a deliberate governance act (spec-423 dec-5) and every accepted shape becomes a permanent contract. With this message the failure self-corrects in one round-trip, which is what coercion would have bought. Ballot *ergonomics* remains tracked at spec-466 dec-3.

## Why ship before the upstream cause is known

This is the instrument that will settle it. The next occurrence in the wild produces either a named near-miss key or a list of arguments that demonstrably excludes the ballot — so the report itself will say which of the two causes it was.

## Verification

- **11/11 ACs verified** (7 implementation + 4 scope), 100% covered.
- **Full server suite: 5892 passed, 0 failed** (624 files).
- std-16 manifest↔catalogue parity gates (`tools-coverage`, `mutate-coverage`) green — no tool added, renamed, or removed.
- Typecheck clean.
- The first run of the new t-1 test caught a genuine defect in this change (the `tool()` overload rejecting a constructed schema), which is why the registration API moved to `registerTool`.

**e2e:** no user-facing flow changes — the entire surface is the MCP tool boundary, so no journey was added [per std-28, recorded as `n/a` in the Spec's Design lens]. Same shape as spec-445.

## Licensing

Fair-code core. No `.ee.` filename or `.ee/` directory touched (dec-4, guarded by ac-11).

---

Spec: **[spec-499](https://memex.ai/mindset-prod/memex-building-itself/specs/spec-499)** · decisions dec-1…dec-4 · tasks t-1, t-2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AWPrs6gvedm2QJeEKaHED1
