### PR TITLE
fix(onboarding): wizard no longer defaults the new-Memex name to "Personal Memex"

### DIFF
--- a/packages/ui/src/onboarding/Wizard.tsx
+++ b/packages/ui/src/onboarding/Wizard.tsx
@@ -30,7 +30,11 @@ export function Wizard() {
   const [step, setStep] = useState<Step>('name');
 
   const personal = session?.memberships?.find((m) => m.kind === 'personal') ?? null;
-  const defaultName = personal?.memexName ?? personal?.name ?? 'my-first-memex';
+  // A friendly, neutral suggestion for the user's FIRST project Memex. We deliberately
+  // do NOT echo the personal membership's name here: every user's auto-provisioned
+  // personal Memex is named "Personal Memex", so preferring it pre-filled a confusing,
+  // already-taken-looking default. The field stays fully editable.
+  const defaultName = 'My first Memex';
 
   // Land the user in their (own) personal Memex. After a real connect the agent
   // authors their first spec over MCP, so the board is populated — never empty


### PR DESCRIPTION
Small onboarding-wizard copy fix spotted on int.

The wizard's "Name your Memex" step pre-filled the input with **"Personal Memex"** — because it defaulted to `personal.memexName`, and every user's auto-provisioned personal Memex is named exactly that. So the suggested name read as already-taken/confusing at the highest-friction moment.

Now it defaults to a neutral, friendly **"My first Memex"**. The field stays fully editable, and `personal` is still used for the post-wizard landing.

Verified: production build (tsc + vite) green, onboarding + landing unit tests green (65).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WRCAT8VpnEhPAdxmMiRXrX
