### PR TITLE
spec-512: agent-native refactor — hermetic worktree parallelism, a fast offline guard lane, and derived operating docs

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -2,11 +2,17 @@
 # fails on your laptop instead. Each step mirrors a required check on the PR:
 #
 #   lint        → the `lint` job (biome ci)
-#   typecheck   → server + ui tsc (base config, tests INCLUDED). A superset of the
-#                 deploy's build-config type gate (tsconfig.build.json excludes
-#                 tests) — so it catches both the deploy gate that has historically
-#                 turned develop red AND test-file type drift, keeping the test
-#                 suite type-clean even though CI's build gate skips it.
+#   typecheck   → server `tsc --noEmit` (base config, tests INCLUDED — a superset of
+#                 the deploy's tsconfig.build.json gate, which excludes tests) PLUS
+#                 ui `tsc -b`.
+#
+#                 The ui half MUST stay `tsc -b`. packages/ui/tsconfig.json is a
+#                 solution-style config with `files: []`, so plain `tsc --noEmit`
+#                 type-checks ZERO ui files and exits 0 unconditionally — this hook
+#                 carried a "superset" claim that was false for the ui for as long as
+#                 that form was used (spec-512; it is why commit 5b930ff had to drop
+#                 unused imports that only the CI build gate caught). Guarded by
+#                 packages/server/src/__regression__/spec-512-workspace-isolation.regression.test.ts.
 #   unit tests  → the `server` job's unit subset
 #
 # Slower gates stay manual by design: e2e (`make e2e-cold`, std-28) and the full

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,18 +2,9 @@
 
 This file is a pointer. The system of record is Memex itself.
 
-## Where Memex lives (prod is live as of 2026-05-24)
+## Where Memex lives
 
-The platform is deployed and the workspace has moved. INT is no longer the source of truth.
-
-| Surface | URL |
-|---|---|
-| **Production app** (React UI + API + MCP) | `https://memex.ai/<namespace>/<memex>/...` |
-| **Staging app (int)** | `https://int.memex.ai/<namespace>/<memex>/...` |
-| **Marketing site** | `https://www.memex.ai/` |
-| **MCP endpoint** (prod / int) | `https://memex.ai/mcp` · `https://int.memex.ai/mcp` |
-
-**This codebase's Memex is now `mindset-prod/memex-building-itself`** (web: `https://memex.ai/mindset-prod/memex-building-itself`). It was migrated from the old `mindset-int/memex-app` on 2026-05-24 via direct SQL (b-65) — the memex was renamed (`memex-app` → `memex-building-itself`) and rehomed under the `mindset-prod` namespace, with all UUIDs and `b-N`/`std-N` handles preserved. The old INT workspace at `mindset-int/memex-app` remains readable for reference only; each INT doc carries a breadcrumb comment pointing at its PROD counterpart. Full infra + routing topology lives in std-9.
+**This codebase's Memex is `mindset-prod/memex-building-itself`** — <https://memex.ai/mindset-prod/memex-building-itself>. Prod is `memex.ai`, staging is `int.memex.ai`, and each serves the app, the API and `/mcp` off the same host. Full topology: std-9. (The old `mindset-int/memex-app` workspace is read-only history.)
 
 ## How to orient (every session)
 
@@ -84,52 +75,47 @@ If a Standard contradicts the code, the Standard is probably right and the code 
 brew services start postgresql@16
 pnpm install
 pnpm --filter @memex/server db:migrate
-make dev          # server (8080) + React UI (5173)
+make dev          # server + UI on THIS workspace's derived ports (it prints them)
+make check        # offline guard battery — no DB, no network, ~1s
+make affected     # which suites your diff actually needs (advisory)
 make test         # full server suite
 ```
+
+Ports and e2e database names are **derived per workspace** from a hash of its path
+(`scripts/ci/workspace-alloc.mjs`), so parallel worktrees never collide. Never hardcode a
+port — run `make dev` and read the ones it prints, or `node scripts/ci/workspace-alloc.mjs --all`.
+Prove isolation with `make prove-concurrent`.
 
 Local Postgres connection string: `postgresql://postgres:postgres@localhost:5432/memex` (full local-dev posture lives in std-9 §9).
 
 ## Repository shape
 
-```
-packages/server/    Hono API, Drizzle ORM, auth, email, AI agent, MCP endpoint
-packages/ui/        React 19 UI (Vite, TailwindCSS) — the "React UI"
-packages/cli/       memex-ai npm package (MCP installer, zero-dep)
-packages/extractor/ Code intelligence ingestion
-packages/shared/    Shared types/utilities (pure — no server deps)
-packages/db-schema/    Standalone Drizzle schema, published to the GitHub npm registry (Backstage control plane)
-packages/ac-emit-vitest/  `@memex-ai/vitest` — the AC test-event emitter for Vitest
-scripts/deploy-config.sh    env-keyed deploy values (std-9 documents this)
-Makefile / deploy.sh / docker-compose.yml / Rakefile
-```
+`packages/`: **server** (Hono API, Drizzle, auth, agent, MCP) · **ui** (React 19 + Vite) · **shared** (pure, imported everywhere) · **cli** (`memex-ai` installer) · **db-schema** (published standalone) · **extractor** · **ac-emit-vitest** (the AC emitter). Service architecture: std-12. For anything deeper, `ls` — a tree copied here goes stale.
 
-For deeper layouts inside any package, `ls` is the source of truth — replicating the tree here goes stale fast.
+## Licensing — open core + EE
 
-## Licensing — open core + EE (the `.ee` marker)
+Memex is [**fair-code**](https://faircode.io/). **The file path is the licence marker**: `.ee.` in a filename or `.ee` as a dirname means [Memex Enterprise License](LICENSE_EE.md); everything else is the [Sustainable Use License](LICENSE.md). Dev and testing are always free — only *production* use of EE files needs a licence.
 
-Memex is [**fair-code**](https://faircode.io/) (open core). Two licenses, and **the file path is the license marker** — there is no private fork, submodule, or build flag. EE = **Enterprise Edition** (the *Memex Enterprise License*).
+Adding or removing the marker **re-licenses the file**, so treat it as deliberate, and give every Spec an explicit fair-code/EE call (std-25). PRs touching `.ee.` files need a signed CLA (`CONTRIBUTING.md`).
 
-| Scope | License | Production use |
+Full statement: `README.md` ("Where enterprise code lives") and `CONTRIBUTING.md`. Enquiries: [hello@memex.ai](mailto:hello@memex.ai).
+
+## Mechanics the machines enforce
+
+Each rule below has a check. Break one and the check tells you what to run — you shouldn't need to remember any of this.
+
+| Rule | Check | Fix |
 |---|---|---|
-| Default — everything else | [Sustainable Use License](LICENSE.md) | Free for internal-business / non-commercial / personal use |
-| Files with **`.ee.` in the filename** or **`.ee` as a dirname** | [Memex Enterprise License](LICENSE_EE.md) | Requires a valid Memex Enterprise license |
+| The standards index above matches Memex | `make standards-check` (in `make check`) | `make standards-gen` |
+| Your e2e run can't silently test another workspace's code | `scripts/ci/e2e-preflight.mjs` (auto, via `make e2e`/`e2e-cold`) | it prints the exact command |
+| Two worktrees don't collide on ports or databases | `make prove-concurrent` | — |
+| UI types are really checked (`tsc -b`, not the no-op `--noEmit`) | `make typecheck`, pinned by `spec-512-workspace-isolation` | — |
+| Emitted tenant URLs are path-based (std-2) | `make check-url-shape` | — |
+| Every mutation goes through `mutate()` (std-8) | `mutate-coverage.*` guards | — |
+| No direct `new Anthropic(...)` (std-30) | `no-direct-anthropic` guard | use `getAnthropicClient()` |
+| Every user-facing flow change has an e2e journey (std-28) | `make e2e-cold` before every PR | — |
 
-```
-packages/server/src/routes/.ee/slack.integration.test.ts   # filename marker (.ee. test)
-packages/server/src/services/.ee/slack/oauth.ts            # dirname marker (.ee/ cluster)
-packages/ui/src/components/.ee/SlackIntegrationSection.tsx # dirname marker (.ee/ cluster)
-```
-
-Rules to respect when working in this repo:
-
-- **Either marker qualifies** — it's a file-path test, not a build flag. Single-file EE features use the `.ee.` filename; multi-file EE clusters use a `.ee/` directory. They're interchangeable.
-- **Dev/testing is always free** — only *production* use of EE-marked files needs a license.
-- **Don't move code across the line silently.** Adding `.ee.`/`.ee` re-licenses a file (and gates it commercially); removing it relicenses it as open core. Treat the marker as deliberate.
-- **PRs touching `.ee.` files need a signed CLA** and prior coordination with Mindset — see `CONTRIBUTING.md` ("EE feature"). "Changes to `.ee.` files without a signed CLA" is on the won't-merge list.
-- Branches other than `main` are not licensed; third-party components keep their original licenses.
-
-Full statement lives in `README.md` ("Where enterprise code lives") and `CONTRIBUTING.md`. Licensing enquiries: [hello@memex.ai](mailto:hello@memex.ai).
+`make check` runs the offline battery (no DB, no network, ~1s). `.husky/pre-push` runs lint + typecheck + unit tests.
 
 ## When in doubt
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,7 @@ mcp__memex__get_doc({ref: "mindset-prod/memex-building-itself/standards/std-N"})
 
 ## Standards index
 
+<!-- BEGIN generated: standards-index -->
 | Standard | Covers |
 |---|---|
 | std-1 | Namespace / org / memex are three distinct concepts — plus user-facing vocabulary and handle conventions (`b-N` / `doc-N` / `std-N` / `s-N` / `dec-N` / `t-N` / `c-N`). |
@@ -68,6 +69,12 @@ mcp__memex__get_doc({ref: "mindset-prod/memex-building-itself/standards/std-N"})
 | std-35 | Usage events / Mixpanel — the metering + product-analytics event recipe. |
 | std-36 | Tenant RLS posture — `ENABLE` row-level security, never `FORCE`; `runWithMemexId` ALS sets `memex_id`; views are `security_invoker`. |
 | std-37 | Test fixtures are isolated under parallel execution — per-worker-unique identifiers, poll for async writes, restore global stubs. |
+| std-38 | In-app agents share one contract — same visual shell (`ChatPanel`), Memex-wide grounding, narrow per-mode authoring scope enforced server-side by a `MODE_TOOLS` allow-list, copyable handoff on refusal. |
+| std-39 | Database hygiene — every DB interaction is reasoned about for cost, locks, and growth, not just correctness. Covers migrations, handlers, MCP tools, relays, cron, and the React UI's query/polling patterns. |
+| std-40 | Plugins are the Claude-Code delivery vehicle — one plugin, one concern. Covers hooks (std-41), a bundled MCP server, or slash commands; excludes the `memex-ai` CLI credential installer. |
+| std-41 | Hooks make capability a side effect of work you already do — use them sparingly, never for correctness. Six tests gate whether a hook is the right tool; correctness/security/mutation work belongs on the server (std-8). |
+| std-42 | Desktop client (memex-clients) releases follow one runbook — signing on BOTH platforms, notarization, auto-update, and per-channel distribution. An unsigned build is a CI artifact only, never published. |
+<!-- END generated: standards-index -->
 
 If a Standard contradicts the code, the Standard is probably right and the code has drifted — flag it.
 

--- a/Makefile
+++ b/Makefile
@@ -109,9 +109,17 @@ test-ui:
 ## compare against), so a second worktree silently adopts the first's servers and the
 ## shared dev database — reporting PASS. It is the command developers run while
 ## iterating, so it was the most exposed target, not the least.
+## E2E_API_URL / E2E_BASE_URL must be set ALONGSIDE the ports. Journeys read the
+## API host two different ways — some as `E2E_SERVER_PORT ?? 8090`, others as
+## `E2E_API_URL ?? "http://localhost:8090"` — so setting only the ports leaves the
+## second group pointing at the OLD hardcoded 8090 while the server listens on the
+## derived port. Caught by journey-45 failing `ECONNREFUSED ::1:8090`; a defect
+## this Spec's own port derivation introduced.
 e2e: e2e-preflight
 	MEMEX_WORKSPACE_ID="$(E2E_WS_ID)" \
 		E2E_SERVER_PORT="$(E2E_API_PORT)" E2E_UI_PORT="$(E2E_UI_PORT_)" \
+		E2E_API_URL="http://localhost:$(E2E_API_PORT)" \
+		E2E_BASE_URL="http://localhost:$(E2E_UI_PORT_)" \
 		pnpm --filter @memex/ui test:e2e $(ARGS)
 
 ## UI: e2e against a throwaway, freshly-migrated database — exact CI parity (std-28).
@@ -158,6 +166,8 @@ e2e-cold: e2e-preflight
 	DATABASE_URL="$(E2E_COLD_DB)" E2E_DATABASE_URL="$(E2E_COLD_DB)" \
 		MEMEX_WORKSPACE_ID="$(E2E_WS_ID)" \
 		E2E_SERVER_PORT="$(E2E_API_PORT)" E2E_UI_PORT="$(E2E_UI_PORT_)" \
+		E2E_API_URL="http://localhost:$(E2E_API_PORT)" \
+		E2E_BASE_URL="http://localhost:$(E2E_UI_PORT_)" \
 		pnpm --filter @memex/ui test:e2e $(ARGS)
 
 ## Refuse to start an e2e run that would silently test the wrong code (spec-512).

--- a/Makefile
+++ b/Makefile
@@ -182,9 +182,22 @@ build:
 	pnpm build
 
 ## TypeScript type checking (no emit)
+##
+## spec-512: the UI half MUST use `tsc -b`, not `tsc --noEmit`.
+## packages/ui/tsconfig.json is a solution-style config — `{"files": [], "references":
+## [./tsconfig.app.json]}`. Plain `tsc --noEmit` honours `files: []` and therefore
+## type-checks ZERO UI files, exiting 0 no matter what. Proven by planting
+## `const x: number = "not a number"` in packages/ui/src/main.tsx: `tsc --noEmit`
+## reported nothing; `tsc -b` caught TS2322 + TS6133 immediately.
+##
+## That made .husky/pre-push's "superset of the deploy's build-config type gate"
+## claim false for the UI, and is the direct cause of commit 5b930ff
+## ("drop unused imports the voice removal orphaned (production-build gate)").
+## `tsc -b` follows the reference into tsconfig.app.json, which carries
+## noUnusedLocals/noUnusedParameters — matching what CI's `build` job runs.
 typecheck:
 	pnpm --filter @memex/server exec tsc --noEmit
-	pnpm --filter @memex/ui exec tsc --noEmit
+	pnpm --filter @memex/ui exec tsc -b
 
 ## Lint (Biome — curated baseline per spec-356; no reformat)
 lint:

--- a/Makefile
+++ b/Makefile
@@ -90,8 +90,18 @@ test-ui:
 ## (5173) itself via the Playwright webServer block; needs local Postgres running.
 ## Runs against your dev DB; use e2e-cold for the CI posture. Extra args via ARGS,
 ## e.g. `make e2e ARGS="journey-18 --headed"`.
-e2e:
-	pnpm --filter @memex/ui test:e2e $(ARGS)
+##
+## spec-512 C1: this target gets the SAME workspace arming as e2e-cold. It was
+## originally left bare, and adversarial review reproduced the original incident on
+## it end-to-end: with no MEMEX_WORKSPACE_ID, playwright.config.ts falls back to the
+## literal 5173/8090 AND e2e/global-setup.ts's guard early-returns (it has nothing to
+## compare against), so a second worktree silently adopts the first's servers and the
+## shared dev database — reporting PASS. It is the command developers run while
+## iterating, so it was the most exposed target, not the least.
+e2e: e2e-preflight
+	MEMEX_WORKSPACE_ID="$(E2E_WS_ID)" \
+		E2E_SERVER_PORT="$(E2E_API_PORT)" E2E_UI_PORT="$(E2E_UI_PORT_)" \
+		pnpm --filter @memex/ui test:e2e $(ARGS)
 
 ## UI: e2e against a throwaway, freshly-migrated database — exact CI parity (std-28).
 ## Fast path: migrations are replayed ONCE into memex_e2e_template (rebuilt only when
@@ -128,7 +138,11 @@ e2e-cold: e2e-preflight
 	else \
 		echo "✓ e2e template DB $(E2E_TPL_NAME) up to date"; \
 	fi
-	dropdb --if-exists -h localhost -U postgres $(E2E_DB_NAME)
+	@# --force (spec-512): a lingering e2e server from an interrupted run holds the
+	@# database and blocks a plain dropdb, aborting the whole run. The vitest tier
+	@# already does this (vitest.global-setup.ts uses DROP DATABASE ... WITH FORCE);
+	@# the e2e tier had not inherited it.
+	dropdb --if-exists --force -h localhost -U postgres $(E2E_DB_NAME)
 	createdb -h localhost -U postgres -T $(E2E_TPL_NAME) $(E2E_DB_NAME)
 	DATABASE_URL="$(E2E_COLD_DB)" E2E_DATABASE_URL="$(E2E_COLD_DB)" \
 		MEMEX_WORKSPACE_ID="$(E2E_WS_ID)" \
@@ -173,9 +187,18 @@ smoke-prod-with-db:
 
 # ── Dev ──────────────────────────────────────────────────────
 
-## Start server + UI dev servers
+## Start server + UI dev servers on this workspace's derived ports (spec-512), so
+## two worktrees can run `make dev` at once. Previously hardcoded 8080/5173 with
+## Vite's strictPort: true, so the second worktree's dev server exited EADDRINUSE.
+## PORT / VITE_PORT still override.
+DEV_API_PORT := $(shell node scripts/ci/workspace-alloc.mjs dev-api-port)
+DEV_UI_PORT  := $(shell node scripts/ci/workspace-alloc.mjs dev-ui-port)
 dev:
-	pnpm dev:server & pnpm dev:ui & wait
+	@echo "▶ dev server  http://localhost:$(DEV_API_PORT)"
+	@echo "▶ dev UI      http://localhost:$(DEV_UI_PORT)"
+	MEMEX_WORKSPACE_ID="$(E2E_WS_ID)" PORT=$(DEV_API_PORT) pnpm dev:server & \
+		VITE_PORT=$(DEV_UI_PORT) VITE_API_PROXY="http://localhost:$(DEV_API_PORT)" pnpm dev:ui & \
+		wait
 
 ## Build all packages
 build:

--- a/Makefile
+++ b/Makefile
@@ -25,9 +25,19 @@
 # ──────────────────────────────────────────────────────────────
 
 .PHONY: test test-unit test-integration test-api test-security test-perf test-regression test-rls \
-        test-server test-ui e2e e2e-cold smoke smoke-int smoke-prod smoke-int-with-db smoke-prod-with-db \
+        test-server test-ui e2e e2e-cold e2e-preflight smoke smoke-int smoke-prod smoke-int-with-db smoke-prod-with-db \
         dev build db-migrate db-seed typecheck lint \
-        check-url-shape help
+        check check-url-shape help
+
+# ── Fast offline lane (spec-512) ─────────────────────────────
+
+## The sub-minute guard battery: no database, no network. This is what replaces
+## "push and wait for CI" as the tight feedback loop. Everything here is a pure
+## static check — anything needing Postgres belongs in `make test`.
+check: check-url-shape lint
+	@node scripts/ci/workspace-alloc.mjs --all > /dev/null || \
+		{ echo "✗ workspace allocator failed — see scripts/ci/workspace-alloc.mjs"; exit 1; }
+	@echo "✓ offline guard battery passed"
 
 # ── Tests ────────────────────────────────────────────────────
 
@@ -88,28 +98,48 @@ e2e:
 ## the drizzle/*.sql set changes — detected via a hash stored as the template DB's
 ## COMMENT), then memex_e2e is cloned from it with `createdb -T` (near-instant).
 ## Never touches the dev `memex` database.
-E2E_COLD_DB := postgresql://postgres:postgres@localhost:5432/memex_e2e
-E2E_TPL_DB  := postgresql://postgres:postgres@localhost:5432/memex_e2e_template
-e2e-cold:
+## spec-512 dec-3: every e2e resource name and port is DERIVED from a hash of this
+## workspace's path by the single allocator (scripts/ci/workspace-alloc.mjs), so two
+## worktrees can run e2e at the same time. These used to be the literals `memex_e2e`
+## and `memex_e2e_template`, which meant a second worktree's `dropdb` destroyed the
+## first one's database mid-run. Overrides (E2E_DATABASE_URL, E2E_SERVER_PORT,
+## E2E_UI_PORT) still win — the allocator honours them.
+E2E_DB_NAME  := $(shell node scripts/ci/workspace-alloc.mjs e2e-database-name)
+E2E_TPL_NAME := $(shell node scripts/ci/workspace-alloc.mjs e2e-template-name)
+E2E_COLD_DB  := $(shell node scripts/ci/workspace-alloc.mjs e2e-database-url)
+E2E_TPL_DB   := $(shell node scripts/ci/workspace-alloc.mjs e2e-template-url)
+E2E_WS_ID    := $(shell node scripts/ci/workspace-alloc.mjs workspace-id)
+E2E_API_PORT := $(shell node scripts/ci/workspace-alloc.mjs e2e-api-port)
+E2E_UI_PORT_ := $(shell node scripts/ci/workspace-alloc.mjs e2e-ui-port)
+
+e2e-cold: e2e-preflight
 	@HASH=$$(cat packages/server/drizzle/*.sql | shasum -a 256 | cut -d' ' -f1); \
 	CUR=$$(psql -h localhost -U postgres -At -c \
-		"SELECT shobj_description(oid, 'pg_database') FROM pg_database WHERE datname = 'memex_e2e_template'" \
+		"SELECT shobj_description(oid, 'pg_database') FROM pg_database WHERE datname = '$(E2E_TPL_NAME)'" \
 		postgres 2>/dev/null); \
 	if [ "$$CUR" != "$$HASH" ]; then \
-		echo "⏳ (Re)building e2e template DB — migration set changed"; \
-		dropdb --if-exists -h localhost -U postgres memex_e2e_template || exit 1; \
-		createdb -h localhost -U postgres memex_e2e_template || exit 1; \
+		echo "⏳ (Re)building e2e template DB $(E2E_TPL_NAME) — migration set changed"; \
+		dropdb --if-exists -h localhost -U postgres $(E2E_TPL_NAME) || exit 1; \
+		createdb -h localhost -U postgres $(E2E_TPL_NAME) || exit 1; \
 		for f in packages/server/drizzle/*.sql; do \
 			psql -v ON_ERROR_STOP=1 "$(E2E_TPL_DB)" -f "$$f" > /dev/null || exit 1; \
 		done; \
-		psql -h localhost -U postgres -c "COMMENT ON DATABASE memex_e2e_template IS '$$HASH'" postgres > /dev/null || exit 1; \
+		psql -h localhost -U postgres -c "COMMENT ON DATABASE $(E2E_TPL_NAME) IS '$$HASH'" postgres > /dev/null || exit 1; \
 	else \
-		echo "✓ e2e template DB up to date"; \
+		echo "✓ e2e template DB $(E2E_TPL_NAME) up to date"; \
 	fi
-	dropdb --if-exists -h localhost -U postgres memex_e2e
-	createdb -h localhost -U postgres -T memex_e2e_template memex_e2e
+	dropdb --if-exists -h localhost -U postgres $(E2E_DB_NAME)
+	createdb -h localhost -U postgres -T $(E2E_TPL_NAME) $(E2E_DB_NAME)
 	DATABASE_URL="$(E2E_COLD_DB)" E2E_DATABASE_URL="$(E2E_COLD_DB)" \
+		MEMEX_WORKSPACE_ID="$(E2E_WS_ID)" \
+		E2E_SERVER_PORT="$(E2E_API_PORT)" E2E_UI_PORT="$(E2E_UI_PORT_)" \
 		pnpm --filter @memex/ui test:e2e $(ARGS)
+
+## Refuse to start an e2e run that would silently test the wrong code (spec-512).
+## Checks: foreign server holding our port, PGPASSWORD hang, stale @memex/shared
+## build, and where AC emission would land.
+e2e-preflight:
+	@node scripts/ci/e2e-preflight.mjs
 
 ## Smoke test — verify a running server responds (one-line health curl)
 smoke:

--- a/Makefile
+++ b/Makefile
@@ -27,17 +27,28 @@
 .PHONY: test test-unit test-integration test-api test-security test-perf test-regression test-rls \
         test-server test-ui e2e e2e-cold e2e-preflight smoke smoke-int smoke-prod smoke-int-with-db smoke-prod-with-db \
         dev build db-migrate db-seed typecheck lint \
-        check check-url-shape help
+        check check-url-shape standards-check standards-gen standards-sync affected prove-concurrent help
 
 # ── Fast offline lane (spec-512) ─────────────────────────────
 
 ## The sub-minute guard battery: no database, no network. This is what replaces
 ## "push and wait for CI" as the tight feedback loop. Everything here is a pure
 ## static check — anything needing Postgres belongs in `make test`.
-check: check-url-shape lint
+check: check-url-shape lint standards-check
 	@node scripts/ci/workspace-alloc.mjs --all > /dev/null || \
 		{ echo "✗ workspace allocator failed — see scripts/ci/workspace-alloc.mjs"; exit 1; }
 	@echo "✓ offline guard battery passed"
+
+## Which suites are worth running for your current diff (advisory — CI still
+## runs the full matrix). An unrecognised path widens to everything, never to
+## nothing. `make affected ARGS=--json` for machine-readable output.
+affected:
+	@node scripts/ci/affected-tests.mjs $(ARGS)
+
+## Prove two working copies run concurrently without collisions (spec-512 ac-1).
+## PROVE_E2E=1 adds the two-full-suite tier.
+prove-concurrent:
+	@bash scripts/ci/prove-concurrent-workspaces.sh
 
 # ── Tests ────────────────────────────────────────────────────
 
@@ -259,3 +270,20 @@ help:
 	@grep -E '^## ' $(MAKEFILE_LIST) | sed 's/^## /  /'
 	@echo ""
 	@echo "Run 'make <target>' to execute."
+
+# ── Standards index (spec-512 dec-4) ─────────────────────────────────────────
+
+## Fail if the CLAUDE.md standards index has drifted from the manifest.
+standards-check:
+	@node scripts/ci/standards-index.mjs --check
+
+## Regenerate the CLAUDE.md standards index from standards.manifest.json.
+standards-gen:
+	@node scripts/ci/standards-index.mjs --write
+
+## Refresh the manifest FROM Memex (online — an agent runs search_memex and
+## rewrites standards.manifest.json), then regenerate. Deliberately not part of
+## `make check`: the offline lane must never need the network.
+standards-sync:
+	@echo "Refresh standards.manifest.json from Memex, then run: make standards-gen"
+	@echo "  search_memex({ memex: 'mindset-prod/memex-building-itself', kind: 'standard' })"

--- a/packages/server/src/__regression__/spec-512-affected-tests.regression.test.ts
+++ b/packages/server/src/__regression__/spec-512-affected-tests.regression.test.ts
@@ -1,0 +1,123 @@
+// spec-512 ac-4 — the diff→affected-tests mapper must never return silently empty.
+//
+// The whole value of a "run just these" tool is that an agent trusts it. That
+// makes its failure mode uniquely dangerous: a mapper that shrugs at a path it
+// does not recognise and prints an empty list is read as "nothing to run, you're
+// safe" — a confident wrong answer, which is the exact category this Spec exists
+// to delete. So an unrecognised path must widen to the full matrix, never narrow
+// to nothing, and the tool must always say CI still runs everything.
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { planFor, RULES } from "../../../../scripts/ci/affected-tests.mjs";
+
+const REPO_ROOT = join(__dirname, "..", "..", "..", "..");
+const SOURCE = readFileSync(
+  join(REPO_ROOT, "scripts", "ci", "affected-tests.mjs"),
+  "utf8",
+);
+
+describe("spec-512: the affected-tests mapper fails safe, never silent", () => {
+  it("an UNRECOGNISED path widens to the full matrix (ac-4)", () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-512/acs/ac-4");
+
+    for (const weird of [
+      "some/unknown/path.xyz",
+      "totally-new-top-level-dir/thing.rs",
+      "packages/brand-new-package/src/index.ts",
+      ".hidden-config",
+    ]) {
+      const plan = planFor([weird]);
+      expect(
+        plan.full,
+        `"${weird}" matches no rule, so the mapper must widen to the FULL matrix. ` +
+          `Narrowing an incomplete map tells an agent "nothing to run" and it will ` +
+          `believe that.\n\nCheck: scripts/ci/affected-tests.mjs`,
+      ).toBe(true);
+      expect(plan.commands.length).toBeGreaterThan(0);
+      expect(plan.unmatched).toContain(weird);
+    }
+  });
+
+  it("an EMPTY changed-file list widens too (ac-4)", () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-512/acs/ac-4");
+    // "I found no changes" and "there are no changes" are indistinguishable from
+    // the outside, and the dangerous reading of both is "skip the tests".
+    for (const input of [[], null, undefined]) {
+      const plan = planFor(input as never);
+      expect(plan.full).toBe(true);
+      expect(plan.commands.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("one unknown path poisons an otherwise-narrowable set (ac-4)", () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-512/acs/ac-4");
+    // The subtle case: recognised files would narrow happily, and it is tempting
+    // to return their union and quietly drop the stranger.
+    const plan = planFor(["packages/ui/src/App.tsx", "mystery/file.bin"]);
+    expect(
+      plan.full,
+      "A recognised path alongside an unrecognised one must still widen — " +
+        "dropping the stranger silently under-runs the suite.",
+    ).toBe(true);
+    expect(plan.unmatched).toEqual(["mystery/file.bin"]);
+  });
+
+  it("broad-impact paths widen with a stated reason (ac-4)", () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-512/acs/ac-4");
+    for (const broad of [
+      "pnpm-lock.yaml",
+      "packages/shared/src/scaffold-data.ts",
+      "packages/server/src/db/schema.ts",
+      ".github/workflows/test.yml",
+      "Makefile",
+    ]) {
+      const plan = planFor([broad]);
+      expect(plan.full, `"${broad}" must widen to the full matrix`).toBe(true);
+      expect(plan.reason).toBeTruthy();
+    }
+  });
+
+  it("genuinely narrow changes DO narrow — the tool is still useful (ac-4)", () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-512/acs/ac-4");
+    // The counterweight: a mapper that always returns "full" would pass every
+    // assertion above while being worthless.
+    const plan = planFor(["packages/ui/src/components/Foo.tsx"]);
+    expect(plan.full).toBe(false);
+    expect(plan.commands).toEqual(["make test-ui"]);
+
+    const server = planFor(["packages/server/src/routes/docs.ts"]);
+    expect(server.full).toBe(false);
+    expect(server.commands).toContain("make test-api");
+  });
+
+  it("every run states that CI still runs the full matrix (ac-4)", () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-512/acs/ac-4");
+    // Printed unconditionally in emit(), including the docs-only case where the
+    // command list is legitimately empty — that is exactly when a reader is most
+    // likely to mistake it for a merge guarantee.
+    expect(
+      SOURCE,
+      "The human-readable output must always say CI runs the full matrix.",
+    ).toMatch(/CI still runs the full matrix/);
+    expect(SOURCE).toMatch(/advisory/i);
+  });
+
+  it("the rule table is real and ordered first-match-wins (ac-4)", () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-512/acs/ac-4");
+    // Denominator: a truncated rule table would make everything widen and the
+    // tool would look "safe" while being useless.
+    expect(
+      RULES.length,
+      `Only ${RULES.length} mapping rules — the table has probably been truncated, ` +
+        `which would make every change widen to the full matrix.`,
+    ).toBeGreaterThan(15);
+    for (const r of RULES) {
+      expect(r.test).toBeInstanceOf(RegExp);
+      expect(r.why, "every rule states WHY, so its output can be audited").toBeTruthy();
+      expect(r.full === true || Array.isArray(r.cmds)).toBe(true);
+    }
+  });
+});

--- a/packages/server/src/__regression__/spec-512-claudemd-pointers.regression.test.ts
+++ b/packages/server/src/__regression__/spec-512-claudemd-pointers.regression.test.ts
@@ -1,0 +1,125 @@
+// spec-512 ac-7 — CLAUDE.md may only name checks that actually exist.
+//
+// The doc rewrite reduced binding mechanics to one line each, naming the check
+// that enforces them. That trade only works if the names are real: a pointer to a
+// check that does not exist is worse than the prose it replaced, because the
+// reader believes a machine is watching when nothing is. It is also the easiest
+// thing in this Spec to break later — a target gets renamed, and the doc silently
+// becomes fiction.
+//
+// So: parse the "Mechanics the machines enforce" table and the command blocks out
+// of CLAUDE.md, and assert every `make <target>` and `scripts/...` path referenced
+// there resolves.
+
+import { describe, it, expect } from "vitest";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+const REPO_ROOT = join(__dirname, "..", "..", "..", "..");
+const CLAUDE_MD = readFileSync(join(REPO_ROOT, "CLAUDE.md"), "utf8");
+const MAKEFILE = readFileSync(join(REPO_ROOT, "Makefile"), "utf8");
+
+/** Makefile targets that actually exist (`name:` at column 0, not a variable). */
+const REAL_TARGETS = new Set(
+  [...MAKEFILE.matchAll(/^([a-z][a-z0-9-]*):/gm)].map((m) => m[1]),
+);
+
+describe("spec-512: CLAUDE.md's pointers resolve (ac-7)", () => {
+  it("the Makefile actually defines the targets CLAUDE.md tells you to run", () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-512/acs/ac-7");
+
+    // Denominator first: if the Makefile parse broke, every check below would
+    // "pass" against an empty set of known targets.
+    expect(
+      REAL_TARGETS.size,
+      `Parsed only ${REAL_TARGETS.size} Makefile targets — the parse has broken, ` +
+        `which would make the assertions below vacuous.`,
+    ).toBeGreaterThan(20);
+
+    // Match ONLY inside code spans (`make x`) and fenced blocks — never bare
+    // prose. The first version of this scan matched `\bmake (\w+)` anywhere and
+    // flagged std-41's summary, "Hooks **make capability** a side effect of work
+    // you already do", as a missing Makefile target. English is not a command
+    // line; a regex over prose will keep insisting otherwise.
+    //
+    // Backtick pairing is done PER LINE. Matching /`([^`]+)`/ across the whole
+    // document lets one unbalanced backtick shift every pair after it, so the
+    // prose BETWEEN two unrelated code spans on different lines gets captured as
+    // code — which is how "Hooks make capability…" survived the first fix. Per
+    // line, a stray backtick can only corrupt its own line.
+    const fenced = [...CLAUDE_MD.matchAll(/```[a-z]*\n([\s\S]*?)```/g)].map((m) => m[1]);
+    const withoutFences = CLAUDE_MD.replace(/```[a-z]*\n[\s\S]*?```/g, "");
+    const codeSpans = withoutFences
+      .split("\n")
+      .flatMap((line) => [...line.matchAll(/`([^`]+)`/g)].map((m) => m[1]));
+    const codeOnly = [...codeSpans, ...fenced].join("\n");
+
+    const referenced = [
+      ...new Set(
+        [...codeOnly.matchAll(/\bmake ([a-z][a-z0-9-]*)/g)].map((m) => m[1]),
+      ),
+    ];
+    expect(
+      referenced.length,
+      "CLAUDE.md should reference several make targets; found none, so this test " +
+        "is checking nothing.",
+    ).toBeGreaterThan(4);
+
+    const missing = referenced.filter((t) => !REAL_TARGETS.has(t));
+    expect(
+      missing,
+      `CLAUDE.md names make target(s) that DO NOT EXIST: ${missing.join(", ")}.\n\n` +
+        `A pointer to a check that isn't there is worse than the prose it replaced —\n` +
+        `the reader believes a machine is watching when nothing is.\n\n` +
+        `Fix: add the target to the Makefile, or correct the reference in CLAUDE.md.\n` +
+        `  make help   # lists every real target\n\n` +
+        `Check: packages/server/src/__regression__/spec-512-claudemd-pointers.regression.test.ts`,
+    ).toEqual([]);
+  });
+
+  it("every scripts/ path CLAUDE.md names is a real file", () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-512/acs/ac-7");
+
+    const paths = [
+      ...new Set(
+        [...CLAUDE_MD.matchAll(/\b(scripts\/[A-Za-z0-9._/-]+\.(?:mjs|sh|ts))/g)].map(
+          (m) => m[1],
+        ),
+      ),
+    ];
+    expect(paths.length).toBeGreaterThan(0);
+
+    const missing = paths.filter((p) => !existsSync(join(REPO_ROOT, p)));
+    expect(
+      missing,
+      `CLAUDE.md points at script(s) that do not exist: ${missing.join(", ")}.\n\n` +
+        `Fix: correct the path, or restore the script.\n\n` +
+        `Check: packages/server/src/__regression__/spec-512-claudemd-pointers.regression.test.ts`,
+    ).toEqual([]);
+  });
+
+  it("does not resurrect the hardcoded dev ports the allocator replaced", () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-512/acs/ac-7");
+
+    // The pre-spec-512 doc said `make dev   # server (8080) + React UI (5173)`.
+    // Once ports became per-workspace derived that line was simply false, and a
+    // false instruction in the orientation doc is a context tax paid by every
+    // session. Guard the correction rather than trusting it to survive.
+    const proseLines = CLAUDE_MD.split("\n").filter(
+      (l) => !/^\|\s*std-\d+\s*\|/.test(l),
+    );
+    const hardcoded = proseLines.filter((l) => /\b(8080|5173)\b/.test(l));
+
+    expect(
+      hardcoded,
+      `CLAUDE.md names hardcoded port(s) again:\n  ${hardcoded.join("\n  ")}\n\n` +
+        `Ports are DERIVED per workspace (scripts/ci/workspace-alloc.mjs) so parallel\n` +
+        `worktrees don't collide — a fixed number here is wrong for every workspace\n` +
+        `but one, and sends readers to another worktree's server.\n\n` +
+        `Fix: say to run \`make dev\` and read the ports it prints, or\n` +
+        `  node scripts/ci/workspace-alloc.mjs --all\n\n` +
+        `Check: packages/server/src/__regression__/spec-512-claudemd-pointers.regression.test.ts`,
+    ).toEqual([]);
+  });
+});

--- a/packages/server/src/__regression__/spec-512-standards-index.regression.test.ts
+++ b/packages/server/src/__regression__/spec-512-standards-index.regression.test.ts
@@ -1,0 +1,153 @@
+// spec-512 dec-4 — the CLAUDE.md standards index is GENERATED, and stays honest.
+//
+// THE DRIFT THIS ENDS (measured, not hypothetical): the index was hand-maintained
+// and stopped at std-37, while std-38, std-39, std-40, std-41 and std-42 were all
+// APPROVED in Memex. Five binding Standards were invisible to any agent orienting
+// from the codebase pointer — so they bound nobody's behaviour.
+//
+// The pre-existing guard (spec-172-e2e-standard-index) pins that ONE row, std-28,
+// exists. That is a presence check, not a completeness check, so adding a Standard
+// left the pointer stale with nothing red. This file closes that.
+//
+// The generator introduces the repo's FIRST BEGIN/END generated region — every
+// other generated artifact here is whole-file with a prose banner — so these tests
+// deliberately hammer the documented marker failure mode: a generator that
+// rewrites only the FIRST marked block passes its own check while leaving the file
+// broken.
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tagAc } from "@memex-ai-ac/vitest";
+import {
+  BEGIN,
+  END,
+  renderTable,
+  findRegions,
+  applyRegions,
+} from "../../../../scripts/ci/standards-index.mjs";
+
+const REPO_ROOT = join(__dirname, "..", "..", "..", "..");
+const CLAUDE_MD = readFileSync(join(REPO_ROOT, "CLAUDE.md"), "utf8");
+const MANIFEST = JSON.parse(
+  readFileSync(join(REPO_ROOT, "standards.manifest.json"), "utf8"),
+);
+
+describe("spec-512: the standards index is generated and complete", () => {
+  it("CLAUDE.md's table matches the manifest exactly (ac-15)", () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-512/acs/ac-15");
+
+    const handlesInFile = [...CLAUDE_MD.matchAll(/^\|\s*(std-\d+)\s*\|/gm)].map(
+      (m) => m[1],
+    );
+    // Denominator: a broken regex here would make every assertion below vacuous.
+    expect(
+      handlesInFile.length,
+      `Parsed ${handlesInFile.length} std-N rows out of CLAUDE.md — far too few to ` +
+        `be the real index. The table shape or the regex has broken, which would ` +
+        `make the completeness assertion below pass against nothing.`,
+    ).toBeGreaterThan(30);
+
+    const handlesInManifest = MANIFEST.standards.map(
+      (s: { handle: string }) => s.handle,
+    );
+    const missing = handlesInManifest.filter(
+      (h: string) => !handlesInFile.includes(h),
+    );
+
+    expect(
+      missing,
+      `Standards approved in the manifest but MISSING from the CLAUDE.md index: ` +
+        `${missing.join(", ")}.\n\n` +
+        `CLAUDE.md is how an agent discovers which rules bind it — an absent row ` +
+        `means an approved Standard governs nobody.\n\n` +
+        `Fix:\n  make standards-gen\n\n` +
+        `Check: packages/server/src/__regression__/spec-512-standards-index.regression.test.ts`,
+    ).toEqual([]);
+
+    // The five that had actually drifted. Pinned by name so a regression is named,
+    // not merely counted.
+    for (const h of ["std-38", "std-39", "std-40", "std-41", "std-42"]) {
+      expect(handlesInFile, `${h} must be indexed in CLAUDE.md`).toContain(h);
+    }
+  });
+
+  it("the table sits inside generated markers (ac-15)", () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-512/acs/ac-15");
+    expect(CLAUDE_MD).toContain(BEGIN);
+    expect(CLAUDE_MD).toContain(END);
+    const regions = findRegions(CLAUDE_MD);
+    expect(regions.length).toBe(1);
+    // The table must be INSIDE the region, not adjacent to it.
+    const inner = CLAUDE_MD.slice(regions[0].start, regions[0].end);
+    expect(inner).toMatch(/\|\s*std-1\s*\|/);
+    expect(inner).toMatch(/\|\s*std-42\s*\|/);
+  });
+});
+
+describe("spec-512: the generator handles EVERY marked region, not just the first", () => {
+  const body = "GENERATED-BODY";
+
+  it("rewrites all regions when a file has several (ac-15)", () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-512/acs/ac-15");
+
+    // The documented failure mode: regenerate the first block, copy the rest
+    // verbatim, pass your own check, ship a broken file.
+    const doc = `intro\n${BEGIN}\nOLD-ONE\n${END}\nmiddle\n${BEGIN}\nOLD-TWO\n${END}\ntail\n`;
+    const out = applyRegions(doc, body);
+
+    expect(out).not.toContain("OLD-ONE");
+    expect(
+      out,
+      "The SECOND generated region was left stale — a generator that rewrites only " +
+        "the first block passes its own staleness check while the file is broken.",
+    ).not.toContain("OLD-TWO");
+    expect(out.split(body).length - 1).toBe(2);
+    // Non-generated prose is preserved untouched.
+    expect(out).toContain("intro");
+    expect(out).toContain("middle");
+    expect(out).toContain("tail");
+  });
+
+  it("refuses orphaned, unbalanced, out-of-order and nested markers (ac-15)", () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-512/acs/ac-15");
+
+    const cases: Array<[string, string, RegExp]> = [
+      ["orphan BEGIN", `a\n${BEGIN}\nb\n`, /Unbalanced generated markers/],
+      ["orphan END", `a\n${END}\nb\n`, /Unbalanced generated markers/],
+      ["no markers at all", `just prose\n`, /No generated region found/],
+      ["reversed order", `${END}\nx\n${BEGIN}\n`, /out of order|Unbalanced/],
+      [
+        "nested",
+        `${BEGIN}\n${BEGIN}\nx\n${END}\n${END}\n`,
+        /Nested generated regions|out of order/,
+      ],
+    ];
+
+    for (const [label, doc, expected] of cases) {
+      expect(
+        () => applyRegions(doc, body),
+        `A ${label} must be REFUSED — a partial rewrite would corrupt the file, ` +
+          `so the generator must write nothing and say why.`,
+      ).toThrow(expected);
+    }
+  });
+
+  it("the rendered table is derived from the manifest, in order (ac-15)", () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-512/acs/ac-15");
+
+    const table = renderTable([
+      { handle: "std-1", summary: "first" },
+      { handle: "std-2", summary: "second" },
+    ]);
+    expect(table).toBe(
+      "| Standard | Covers |\n|---|---|\n| std-1 | first |\n| std-2 | second |",
+    );
+
+    // And the real manifest is sorted, so the generated table reads in order.
+    const nums = MANIFEST.standards.map((s: { handle: string }) =>
+      Number(s.handle.slice(4)),
+    );
+    expect(nums).toEqual([...nums].sort((a: number, b: number) => a - b));
+  });
+});

--- a/packages/server/src/__regression__/spec-512-workspace-isolation.regression.test.ts
+++ b/packages/server/src/__regression__/spec-512-workspace-isolation.regression.test.ts
@@ -1,0 +1,245 @@
+// spec-512 — per-workspace e2e isolation, and the guards that make a collision loud.
+//
+// THE INCIDENT THIS PREVENTS (reproduced empirically during spec-512 build, from
+// outside the test harness, against the real command):
+//
+//   playwright.config.ts sets `reuseExistingServer: !process.env.CI`, and the e2e
+//   ports were fixed literals (8090/5173). A stub HTTP server was started on 8090
+//   to impersonate another worktree, then `pnpm --filter @memex/ui test:e2e
+//   journey-10` was run in this checkout. Playwright NEVER started this checkout's
+//   server — it saw 8090 answering /api/health and adopted the stub. The stub
+//   received 12 real requests (/api/health, /api/__test__/ensure-user,
+//   /api/__test__/clear-user-specs, …). Against a real sibling worktree rather
+//   than a stub, those journeys would have run happily against the WRONG branch's
+//   code and the WRONG database and reported a PASS.
+//
+//   The same command also hardcoded `memex_e2e` / `memex_e2e_template` in the
+//   Makefile, so a second worktree's `dropdb --if-exists` destroyed the first
+//   one's database mid-run.
+//
+// The fix derives every e2e resource from sha1(workspaceRoot) — the shape already
+// proven by src/db/test-db-url.ts for the vitest tier — and makes a foreign server
+// a loud refusal instead of a silent adoption. This file guards that the
+// derivation stays pure, the Makefile stays wired to it, and the guards keep
+// firing.
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tagAc } from "@memex-ai-ac/vitest";
+import {
+  workspaceHash,
+  derivePorts,
+  deriveE2eDbNames,
+  resolveE2eConfig,
+} from "../../../../scripts/ci/workspace-alloc.mjs";
+import { classifyPortOwner, isStaleBuild } from "../../../../scripts/ci/e2e-preflight.mjs";
+
+const REPO_ROOT = join(__dirname, "..", "..", "..", "..");
+const MAKEFILE = readFileSync(join(REPO_ROOT, "Makefile"), "utf8");
+const PLAYWRIGHT_CONFIG = readFileSync(
+  join(REPO_ROOT, "packages", "ui", "playwright.config.ts"),
+  "utf8",
+);
+const GLOBAL_SETUP = readFileSync(
+  join(REPO_ROOT, "packages", "ui", "e2e", "global-setup.ts"),
+  "utf8",
+);
+
+const WS_A = "/Users/dev/work/memex-ai";
+const WS_B = "/Users/dev/work/memex-ai-spec-499";
+
+describe("spec-512: the allocator is pure, deterministic, and collision-free across worktrees", () => {
+  it("derives stable, distinct ports and database names per workspace (ac-12)", () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-512/acs/ac-12");
+
+    // Deterministic: same input, same output, every time.
+    expect(derivePorts(WS_A)).toEqual(derivePorts(WS_A));
+    expect(deriveE2eDbNames(WS_A)).toEqual(deriveE2eDbNames(WS_A));
+
+    // Distinct: two worktrees must not share a port or a database. This is the
+    // whole point — sharing either is what let one run clobber another.
+    expect(derivePorts(WS_A).e2eApi).not.toBe(derivePorts(WS_B).e2eApi);
+    expect(deriveE2eDbNames(WS_A).database).not.toBe(deriveE2eDbNames(WS_B).database);
+
+    // A workspace's own ports must not overlap each other.
+    const p = derivePorts(WS_A);
+    expect(new Set(Object.values(p)).size).toBe(Object.values(p).length);
+
+    // Postgres identifiers cap at 63 chars.
+    const names = deriveE2eDbNames(WS_A);
+    expect(names.database.length).toBeLessThanOrEqual(63);
+    expect(names.template.length).toBeLessThanOrEqual(63);
+
+    // The advertised id must be a bare hex digest — never a filesystem path.
+    // /api/health is unauthenticated, so a path here would leak host layout.
+    expect(workspaceHash(WS_A)).toMatch(/^[0-9a-f]{8}$/);
+    expect(workspaceHash(WS_A)).not.toContain("/");
+  });
+
+  it("ports land outside the ephemeral range so the OS cannot steal them (ac-12)", () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-512/acs/ac-12");
+    // Sample broadly rather than trusting one example — a bad window would
+    // otherwise only show up on whichever machine happened to hash into it.
+    for (let i = 0; i < 500; i++) {
+      const ports = Object.values(derivePorts(`/tmp/workspace-${i}`)) as number[];
+      for (const port of ports) {
+        expect(port).toBeGreaterThanOrEqual(20000);
+        expect(port).toBeLessThan(49152); // macOS/BSD ephemeral range starts here
+      }
+    }
+  });
+
+  it("every pre-existing override still wins over the derivation (ac-12)", () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-512/acs/ac-12");
+
+    const overridden = resolveE2eConfig(
+      {
+        E2E_SERVER_PORT: "9999",
+        E2E_UI_PORT: "9998",
+        E2E_DATABASE_URL: "postgresql://postgres:postgres@localhost:5432/my_exact_db",
+      },
+      WS_A,
+    );
+    expect(overridden.apiPort).toBe(9999);
+    expect(overridden.uiPort).toBe(9998);
+    // An explicit database URL is honoured VERBATIM. Silently rewriting a name
+    // someone chose by hand would be its own silent lie.
+    expect(overridden.databaseName).toBe("my_exact_db");
+    expect(overridden.usingOverride).toBe(true);
+
+    const derived = resolveE2eConfig({}, WS_A);
+    expect(derived.apiPort).toBe(derivePorts(WS_A).e2eApi);
+    expect(derived.usingOverride).toBe(false);
+  });
+});
+
+describe("spec-512: the foreign-server classifier flags every unsafe case", () => {
+  // Scanner meta-tests — feed the pure core crafted input and assert it flags,
+  // rather than relying on a real collision existing to be found.
+  const MINE = "aaaaaaaa";
+
+  it("adopts only a server that proves it is ours (ac-14)", async () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-512/acs/ac-14");
+
+    const classify = (health: unknown) =>
+      classifyPortOwner({
+        port: 1234,
+        expectedWorkspaceId: MINE,
+        probe: async () => health,
+      });
+
+    // Safe: nothing there, or demonstrably ours.
+    expect(await classify(null)).toEqual({ kind: "free" });
+    expect(await classify({ status: "ok", workspace: MINE })).toEqual({ kind: "own" });
+
+    // Unsafe: another workspace's server. THE anchor case.
+    expect((await classify({ status: "ok", workspace: "bbbbbbbb" })).kind).toBe("foreign");
+
+    // Unsafe: a server that answers health but claims no workspace. This is the
+    // pre-spec-512 posture and the easiest real-world collision — a plain
+    // `make dev` server, or a sibling worktree on an older commit.
+    expect((await classify({ status: "ok" })).kind).toBe("unidentified");
+
+    // Unsafe: something on the port that is not our server at all.
+    expect((await classify("<html>not us</html>")).kind).toBe("foreign");
+  });
+
+  it("treats a missing or outdated shared build as stale (ac-14)", () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-512/acs/ac-14");
+
+    expect(isStaleBuild("/nonexistent/dist", "/nonexistent/src").stale).toBe(true);
+
+    // src newer than dist → stale (the trap: React never mounts, every journey
+    // fails identically with a generic "heading not found").
+    const stale = isStaleBuild("/dist", "/src", {
+      listFiles: (d: string) => [`${d}/f`],
+    });
+    expect(typeof stale.stale).toBe("boolean");
+  });
+});
+
+describe("spec-512: the wiring cannot be quietly removed", () => {
+  it("the Makefile derives e2e names instead of hardcoding them (ac-12)", () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-512/acs/ac-12");
+
+    // Sanity: prove this test actually read a Makefile, so a bad path can't turn
+    // every assertion below into a vacuous pass.
+    expect(MAKEFILE.length).toBeGreaterThan(2000);
+    expect(MAKEFILE).toContain("e2e-cold:");
+
+    // The literals that caused one worktree to drop another's database must not
+    // come back. Matched with a word boundary so the DERIVED names
+    // (memex_e2e_<hash>) don't trip it.
+    //
+    // Comments are stripped FIRST. Without that, this scan flags the very
+    // comments that explain the ban — including the ones in this repo's Makefile
+    // and the message below. That is not hypothetical: it happened on the first
+    // run of this test, and it is the classic "a regex over source treats prose
+    // as code" defect. A recipe line is tab-indented; a `#` comment is not code.
+    const codeLines = MAKEFILE.split("\n").filter(
+      (line) => !/^\s*#/.test(line) && line.trim() !== "",
+    );
+    // Denominator check (ac-8). Stripping comments is exactly the kind of step
+    // that can silently reduce the scan to nothing — and a scanner that examines
+    // nothing reports universal success, which is the same lie this Spec exists
+    // to remove. Assert we still have real recipe lines to look at.
+    expect(
+      codeLines.length,
+      `The Makefile scan examined ${codeLines.length} non-comment lines — far too ` +
+        `few to be real. The comment-stripping filter has probably broken, which ` +
+        `would make every assertion below pass vacuously.`,
+    ).toBeGreaterThan(60);
+
+    const hardcoded = codeLines.filter((line) =>
+      /\bmemex_e2e(_template)?\b(?!_)/.test(line),
+    );
+    expect(
+      hardcoded,
+      `Makefile hardcodes the shared e2e database name(s) again (spec-512 dec-3).\n` +
+        `A literal memex_e2e / memex_e2e_template is shared by every worktree, so a\n` +
+        `second run's \`dropdb --if-exists\` destroys the first run's database mid-run.\n` +
+        `Offending line(s):\n  ${hardcoded.join("\n  ")}\n\n` +
+        `Fix: derive the name instead —\n` +
+        `  E2E_DB_NAME := $(shell node scripts/ci/workspace-alloc.mjs e2e-database-name)\n\n` +
+        `Check: packages/server/src/__regression__/spec-512-workspace-isolation.regression.test.ts`,
+    ).toEqual([]);
+
+    expect(MAKEFILE).toContain("scripts/ci/workspace-alloc.mjs");
+  });
+
+  it("e2e-cold runs the preflight, and the offline lane exists (ac-10, ac-14)", () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-512/acs/ac-10");
+    tagAc("mindset-prod/memex-building-itself/specs/spec-512/acs/ac-14");
+
+    expect(
+      MAKEFILE,
+      "e2e-cold must depend on e2e-preflight — without it a run can silently " +
+        "adopt another workspace's server. Fix: `e2e-cold: e2e-preflight`.",
+    ).toMatch(/e2e-cold:\s*e2e-preflight/);
+
+    expect(MAKEFILE).toMatch(/^e2e-preflight:/m);
+    expect(MAKEFILE).toMatch(/^check:/m);
+    expect(MAKEFILE).toContain("scripts/ci/e2e-preflight.mjs");
+  });
+
+  it("the e2e harness threads and verifies workspace identity (ac-13, ac-14)", () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-512/acs/ac-13");
+    tagAc("mindset-prod/memex-building-itself/specs/spec-512/acs/ac-14");
+
+    expect(PLAYWRIGHT_CONFIG.length).toBeGreaterThan(1000);
+    // The spawned server must advertise which workspace started it, or the
+    // global-setup assertion below has nothing to compare against.
+    expect(
+      PLAYWRIGHT_CONFIG,
+      "playwright.config.ts must pass MEMEX_WORKSPACE_ID into the server webServer " +
+        "command, otherwise /api/health cannot identify which workspace owns it.",
+    ).toContain("MEMEX_WORKSPACE_ID");
+
+    expect(GLOBAL_SETUP).toContain("MEMEX_WORKSPACE_ID");
+    expect(
+      GLOBAL_SETUP,
+      "e2e/global-setup.ts must refuse to run against a foreign workspace's server.",
+    ).toMatch(/ANOTHER WORKSPACE'S SERVER/);
+  });
+});

--- a/packages/server/src/__regression__/spec-512-workspace-isolation.regression.test.ts
+++ b/packages/server/src/__regression__/spec-512-workspace-isolation.regression.test.ts
@@ -145,6 +145,43 @@ describe("spec-512: the foreign-server classifier flags every unsafe case", () =
     expect((await classify("<html>not us</html>")).kind).toBe("foreign");
   });
 
+  it("probes BOTH the API and the UI port, not just one (ac-14)", () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-512/acs/ac-14");
+
+    // Found by adversarial review. The first cut of the preflight probed only the
+    // API port and merely PRINTED the UI port in its success line — so a foreign
+    // UI server with a free API port sailed through, and Playwright (which applies
+    // reuseExistingServer to BOTH its webServer entries) would reuse that foreign
+    // UI. Same silent lie, different door.
+    const preflight = readFileSync(
+      join(REPO_ROOT, "scripts", "ci", "e2e-preflight.mjs"),
+      "utf8",
+    );
+
+    // Look at real call sites, not the prose that explains them — the comments in
+    // that file necessarily name both ports.
+    const callSites = preflight
+      .split("\n")
+      .filter((l) => !/^\s*(\/\/|\*|\/\*)/.test(l))
+      // `await` distinguishes a real call site from the `async function`
+      // DEFINITION, which otherwise matches too and inflated this count to 3.
+      .filter((l) => /await\s+checkPortOwnership\(cfg,/.test(l));
+
+    expect(
+      callSites.length,
+      `e2e-preflight must call checkPortOwnership for BOTH the API and the UI port, ` +
+        `but found ${callSites.length} call site(s):\n  ${callSites.join("\n  ")}\n\n` +
+        `Playwright's reuseExistingServer applies to both its webServer entries, so ` +
+        `an unchecked UI port lets a foreign UI be adopted silently.\n\n` +
+        `Fix — in scripts/ci/e2e-preflight.mjs main():\n` +
+        `  await checkPortOwnership(cfg, { port: cfg.uiPort, label: "UI" });\n\n` +
+        `Check: packages/server/src/__regression__/spec-512-workspace-isolation.regression.test.ts`,
+    ).toBe(2);
+
+    expect(callSites.join("\n")).toMatch(/cfg\.apiPort/);
+    expect(callSites.join("\n")).toMatch(/cfg\.uiPort/);
+  });
+
   it("treats a missing or outdated shared build as stale (ac-14)", () => {
     tagAc("mindset-prod/memex-building-itself/specs/spec-512/acs/ac-14");
 

--- a/packages/server/src/__regression__/spec-512-workspace-isolation.regression.test.ts
+++ b/packages/server/src/__regression__/spec-512-workspace-isolation.regression.test.ts
@@ -33,7 +33,11 @@ import {
   deriveE2eDbNames,
   resolveE2eConfig,
 } from "../../../../scripts/ci/workspace-alloc.mjs";
-import { classifyPortOwner, isStaleBuild } from "../../../../scripts/ci/e2e-preflight.mjs";
+import {
+  classifyPortOwner,
+  isStaleBuild,
+  portsToCheck,
+} from "../../../../scripts/ci/e2e-preflight.mjs";
 
 const REPO_ROOT = join(__dirname, "..", "..", "..", "..");
 const MAKEFILE = readFileSync(join(REPO_ROOT, "Makefile"), "utf8");
@@ -48,6 +52,22 @@ const GLOBAL_SETUP = readFileSync(
 
 const WS_A = "/Users/dev/work/memex-ai";
 const WS_B = "/Users/dev/work/memex-ai-spec-499";
+
+/** The recipe lines of one Makefile target (tab-indented lines after `name:`),
+ *  with `#` comments stripped so prose ABOUT a rule can't satisfy a rule. */
+function makeRecipe(target: string): string {
+  const lines = MAKEFILE.split("\n");
+  const start = lines.findIndex((l) => new RegExp(`^${target}:`).test(l));
+  if (start === -1) return "";
+  const body: string[] = [];
+  for (const line of lines.slice(start + 1)) {
+    if (line.trim() === "") continue;
+    if (!line.startsWith("\t")) break; // next target begins
+    if (/^\t\s*@?#/.test(line)) continue; // recipe comment
+    body.push(line);
+  }
+  return body.join("\n");
+}
 
 describe("spec-512: the allocator is pure, deterministic, and collision-free across worktrees", () => {
   it("derives stable, distinct ports and database names per workspace (ac-12)", () => {
@@ -145,54 +165,120 @@ describe("spec-512: the foreign-server classifier flags every unsafe case", () =
     expect((await classify("<html>not us</html>")).kind).toBe("foreign");
   });
 
-  it("probes BOTH the API and the UI port, not just one (ac-14)", () => {
+  it("covers BOTH the API and the UI port — asserted behaviourally (ac-14)", () => {
     tagAc("mindset-prod/memex-building-itself/specs/spec-512/acs/ac-14");
 
-    // Found by adversarial review. The first cut of the preflight probed only the
-    // API port and merely PRINTED the UI port in its success line — so a foreign
-    // UI server with a free API port sailed through, and Playwright (which applies
-    // reuseExistingServer to BOTH its webServer entries) would reuse that foreign
-    // UI. Same silent lie, different door.
-    const preflight = readFileSync(
-      join(REPO_ROOT, "scripts", "ci", "e2e-preflight.mjs"),
-      "utf8",
-    );
-
-    // Look at real call sites, not the prose that explains them — the comments in
-    // that file necessarily name both ports.
-    const callSites = preflight
-      .split("\n")
-      .filter((l) => !/^\s*(\/\/|\*|\/\*)/.test(l))
-      // `await` distinguishes a real call site from the `async function`
-      // DEFINITION, which otherwise matches too and inflated this count to 3.
-      .filter((l) => /await\s+checkPortOwnership\(cfg,/.test(l));
+    // The first version of this test counted `await checkPortOwnership(cfg,` lines
+    // in the source and asserted === 2. Adversarial review defeated it three ways:
+    // wrapping the UI probe in `if (process.env.SKIP_UI_CHECK)` kept the count at 2
+    // and the test GREEN while a real foreign UI was adopted; so did replacing the
+    // probe with a same-shaped string literal; and an honest refactor to a `for`
+    // loop made it FAIL. It passed two broken files and failed one correct one —
+    // the very "regex over source treats prose as code" defect this file elsewhere
+    // congratulates itself for having fixed.
+    //
+    // So assert the DATA the loop consumes, not the shape of the source.
+    const targets = portsToCheck({ apiPort: 1111, uiPort: 2222 });
+    const ports = targets.map((t) => t.port);
 
     expect(
-      callSites.length,
-      `e2e-preflight must call checkPortOwnership for BOTH the API and the UI port, ` +
-        `but found ${callSites.length} call site(s):\n  ${callSites.join("\n  ")}\n\n` +
-        `Playwright's reuseExistingServer applies to both its webServer entries, so ` +
-        `an unchecked UI port lets a foreign UI be adopted silently.\n\n` +
-        `Fix — in scripts/ci/e2e-preflight.mjs main():\n` +
-        `  await checkPortOwnership(cfg, { port: cfg.uiPort, label: "UI" });\n\n` +
+      ports,
+      `e2e-preflight must check BOTH the API and the UI port. portsToCheck returned ` +
+        `${JSON.stringify(targets)}.\n\n` +
+        `Playwright's reuseExistingServer applies to both of its webServer entries, ` +
+        `so an unchecked port lets a foreign server be adopted silently.\n\n` +
+        `Fix — in scripts/ci/e2e-preflight.mjs, make portsToCheck() return both:\n` +
+        `  return [{ port: cfg.apiPort, label: "API" }, { port: cfg.uiPort, label: "UI" }];\n\n` +
         `Check: packages/server/src/__regression__/spec-512-workspace-isolation.regression.test.ts`,
-    ).toBe(2);
+    ).toEqual([1111, 2222]);
 
-    expect(callSites.join("\n")).toMatch(/cfg\.apiPort/);
-    expect(callSites.join("\n")).toMatch(/cfg\.uiPort/);
+    expect(targets.map((t) => t.label)).toEqual(["API", "UI"]);
   });
 
-  it("treats a missing or outdated shared build as stale (ac-14)", () => {
+  it("classifies a SLOW or unparseable server as occupied, never free (ac-14)", async () => {
     tagAc("mindset-prod/memex-building-itself/specs/spec-512/acs/ac-14");
 
-    expect(isStaleBuild("/nonexistent/dist", "/nonexistent/src").stale).toBe(true);
+    // Both of these were live false negatives found by adversarial review, and both
+    // reinstated silent adoption:
+    //   * a foreign server slower than the 2s probe timeout — 1500ms was caught,
+    //     2100ms printed "✓ preflight passed" even though the server's own log
+    //     showed it had RECEIVED the probe. Playwright waits 60s, so it adopts it.
+    //   * a 200 whose body is not JSON (SPA HTML fallback, empty body, redirect) —
+    //     res.json() threw into the same catch that handles ECONNREFUSED.
+    // ONLY a refused connection may be classified "free".
+    const classify = (health: unknown) =>
+      classifyPortOwner({
+        port: 1234,
+        expectedWorkspaceId: "aaaaaaaa",
+        probe: async () => health,
+      });
 
-    // src newer than dist → stale (the trap: React never mounts, every journey
-    // fails identically with a generic "heading not found").
-    const stale = isStaleBuild("/dist", "/src", {
-      listFiles: (d: string) => [`${d}/f`],
+    for (const [label, health] of [
+      ["timeout", { timedOut: true }],
+      ["non-JSON 200", { unparseable: true }],
+      ["HTTP 500", { unhealthy: 500 }],
+      ["empty workspace", { status: "ok", workspace: "" }],
+      ["whitespace workspace", { status: "ok", workspace: "   " }],
+      ["null workspace", { status: "ok", workspace: null }],
+    ] as const) {
+      const verdict = await classify(health);
+      expect(
+        verdict.kind,
+        `A ${label} response must NOT be treated as a free port — something is ` +
+          `listening and cannot prove it is ours, so the run must stop. Got ` +
+          `"${verdict.kind}".\n\nCheck: scripts/ci/e2e-preflight.mjs classifyPortOwner`,
+      ).not.toBe("free");
+      expect(verdict.kind).not.toBe("own");
+    }
+
+    // The one case that genuinely IS free: nothing listening at all.
+    expect((await classify(null)).kind).toBe("free");
+  });
+
+  it("detects a PARTIAL shared build, not just an old one (ac-14)", () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-512/acs/ac-14");
+
+    // Adversarial review showed the previous version of this test was doubly
+    // vacuous: `existsSync("/dist")` short-circuited so the injected `listFiles`
+    // fixture was NEVER invoked (0 calls), and the assertion was
+    // `expect(typeof stale.stale).toBe("boolean")` — true for every possible
+    // return value of the function. Of three verdicts, only `missing` was covered.
+    //
+    // It also showed the implementation itself was blind to its own stated
+    // purpose: a max-mtime comparison cannot see a MISSING module, yet the check
+    // exists for "a stale dist missing an export the UI now imports". A dist with
+    // 1 of 38 modules reported {stale:false}, and one `touch` cleared a genuine
+    // stale verdict. Hence the coverage comparison, tested here for real.
+    const missingDist = isStaleBuild("/nonexistent/dist", "/nonexistent/src");
+    expect(missingDist).toEqual({ stale: true, reason: "missing" });
+
+    // Use this repo's real, freshly-built shared package as the healthy control.
+    const realDist = join(REPO_ROOT, "packages", "shared", "dist");
+    const realSrc = join(REPO_ROOT, "packages", "shared", "src");
+
+    // Partial build: every source module present, but only ONE emitted.
+    const srcModules = ["/a.ts", "/b.ts", "/c.ts"];
+    const partial = isStaleBuild(realDist, realSrc, {
+      listFiles: (d: string) =>
+        d === realSrc ? srcModules.map((m) => d + m) : [`${d}/a.js`],
     });
-    expect(typeof stale.stale).toBe("boolean");
+    expect(
+      partial,
+      "A dist holding 1 of 3 source modules must be reported stale (reason " +
+        "'incomplete', 2 missing) — this is the interrupted-build case the check " +
+        "exists for, and a newest-mtime comparison is structurally blind to it.",
+    ).toMatchObject({ stale: true, reason: "incomplete", missingCount: 2 });
+
+    // Fully covered and freshly emitted → not stale. Proves the check can still
+    // say "healthy", so the partial verdict above isn't just a checker that
+    // always returns true.
+    const complete = isStaleBuild(realDist, realSrc, {
+      listFiles: (d: string) =>
+        d === realSrc
+          ? srcModules.map((m) => d + m)
+          : srcModules.map((m) => d + m.replace(/\.ts$/, ".js")),
+    });
+    expect(complete.stale).toBe(false);
   });
 });
 
@@ -245,15 +331,63 @@ describe("spec-512: the wiring cannot be quietly removed", () => {
     expect(MAKEFILE).toContain("scripts/ci/workspace-alloc.mjs");
   });
 
-  it("e2e-cold runs the preflight, and the offline lane exists (ac-10, ac-14)", () => {
+  it("EVERY e2e target is armed, not just e2e-cold (ac-10, ac-14)", () => {
     tagAc("mindset-prod/memex-building-itself/specs/spec-512/acs/ac-10");
     tagAc("mindset-prod/memex-building-itself/specs/spec-512/acs/ac-14");
 
+    // spec-512's worst defect, found by adversarial review that reproduced the
+    // original incident end-to-end: the hardening was applied to `e2e-cold` only.
+    // Bare `make e2e` — the command developers run while iterating, and the first
+    // one in packages/ui/e2e/README.md — fell back to the literal ports and the
+    // SHARED dev database, and e2e/global-setup.ts's guard early-returns when
+    // MEMEX_WORKSPACE_ID is unset, so the backstop disarmed itself on exactly that
+    // path. A guard that fails OPEN on its most common path is worse than none,
+    // because it reads as protection.
+    for (const target of ["e2e", "e2e-cold"]) {
+      const recipe = makeRecipe(target);
+      expect(
+        recipe,
+        `Makefile target "${target}" was not found — the arming assertions below ` +
+          `would pass vacuously.`,
+      ).not.toBe("");
+
+      expect(
+        new RegExp(`^${target}:.*\\be2e-preflight\\b`, "m").test(MAKEFILE),
+        `Makefile target "${target}" must depend on e2e-preflight.\n\n` +
+          `Without it, a run can silently adopt another workspace's server and ` +
+          `report a pass against the wrong code.\n\n` +
+          `Fix:\n  ${target}: e2e-preflight\n\n` +
+          `Check: packages/server/src/__regression__/spec-512-workspace-isolation.regression.test.ts`,
+      ).toBe(true);
+
+      expect(
+        recipe,
+        `Makefile target "${target}" must export MEMEX_WORKSPACE_ID.\n\n` +
+          `packages/ui/e2e/global-setup.ts returns early when it is unset — so ` +
+          `without it the foreign-server backstop silently checks nothing.\n\n` +
+          `Observed recipe:\n${recipe}\n\n` +
+          `Fix — add to the recipe:\n  MEMEX_WORKSPACE_ID="$(E2E_WS_ID)" \\\n\n` +
+          `Check: packages/server/src/__regression__/spec-512-workspace-isolation.regression.test.ts`,
+      ).toContain("MEMEX_WORKSPACE_ID");
+
+      expect(recipe).toContain("E2E_SERVER_PORT");
+      expect(recipe).toContain("E2E_UI_PORT");
+    }
+
+    // `make dev` must use derived ports too, or two worktrees cannot run dev
+    // servers concurrently (Vite's strictPort makes the second exit EADDRINUSE).
+    const devRecipe = makeRecipe("dev");
+    expect(devRecipe).not.toBe("");
     expect(
-      MAKEFILE,
-      "e2e-cold must depend on e2e-preflight — without it a run can silently " +
-        "adopt another workspace's server. Fix: `e2e-cold: e2e-preflight`.",
-    ).toMatch(/e2e-cold:\s*e2e-preflight/);
+      devRecipe,
+      `\`make dev\` must bind this workspace's DERIVED ports.\n\n` +
+        `Observed recipe:\n${devRecipe}\n\n` +
+        `Hardcoded 8080/5173 plus Vite's strictPort:true means a second worktree's ` +
+        `dev server exits EADDRINUSE.\n\n` +
+        `Fix — in the dev recipe:\n  PORT=$(DEV_API_PORT) ... VITE_PORT=$(DEV_UI_PORT)\n\n` +
+        `Check: packages/server/src/__regression__/spec-512-workspace-isolation.regression.test.ts`,
+    ).toMatch(/DEV_API_PORT/);
+    expect(devRecipe).toMatch(/DEV_UI_PORT/);
 
     expect(MAKEFILE).toMatch(/^e2e-preflight:/m);
     expect(MAKEFILE).toMatch(/^check:/m);

--- a/packages/server/src/__regression__/spec-512-workspace-isolation.regression.test.ts
+++ b/packages/server/src/__regression__/spec-512-workspace-isolation.regression.test.ts
@@ -372,6 +372,30 @@ describe("spec-512: the wiring cannot be quietly removed", () => {
 
       expect(recipe).toContain("E2E_SERVER_PORT");
       expect(recipe).toContain("E2E_UI_PORT");
+
+      // The ports are NOT sufficient on their own. Journeys read the API host two
+      // different ways — `E2E_SERVER_PORT ?? 8090` in some files, and
+      // `E2E_API_URL ?? "http://localhost:8090"` in others (e.g.
+      // journey-45-spec-304, journey-8, journey-16, journey-20, journey-47,
+      // journey-55, journey-65). Setting only the ports leaves that second group
+      // pointing at the OLD hardcoded 8090 while the server listens on the derived
+      // port, and they die with ECONNREFUSED ::1:8090 — a defect this Spec's own
+      // port derivation introduced, found by running the full suite.
+      for (const v of ["E2E_API_URL", "E2E_BASE_URL"]) {
+        expect(
+          recipe,
+          `Makefile target "${target}" sets the e2e PORTS but not ${v}.\n\n` +
+            `Observed recipe:\n${recipe}\n\n` +
+            `Journeys that read ${v} fall back to the hardcoded localhost:8090, which\n` +
+            `is not where the derived server listens — they fail ECONNREFUSED while\n` +
+            `every port-reading journey passes, so the suite looks flaky rather than\n` +
+            `misconfigured.\n\n` +
+            `Fix — add to the recipe:\n` +
+            `  E2E_API_URL="http://localhost:$(E2E_API_PORT)" \\\n` +
+            `  E2E_BASE_URL="http://localhost:$(E2E_UI_PORT_)" \\\n\n` +
+            `Check: packages/server/src/__regression__/spec-512-workspace-isolation.regression.test.ts`,
+        ).toContain(v);
+      }
     }
 
     // `make dev` must use derived ports too, or two worktrees cannot run dev

--- a/packages/server/src/__regression__/spec-512-workspace-isolation.regression.test.ts
+++ b/packages/server/src/__regression__/spec-512-workspace-isolation.regression.test.ts
@@ -223,6 +223,59 @@ describe("spec-512: the wiring cannot be quietly removed", () => {
     expect(MAKEFILE).toContain("scripts/ci/e2e-preflight.mjs");
   });
 
+  it("the UI type gate actually checks files — never the no-op form (ac-11)", () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-512/acs/ac-11");
+
+    // THE DEFECT THIS PINS (live on develop until spec-512, proven empirically):
+    // packages/ui/tsconfig.json is `{"files": [], "references": [tsconfig.app.json]}`.
+    // Plain `tsc --noEmit` honours `files: []` and type-checks ZERO ui files,
+    // exiting 0 unconditionally. Planting `const x: number = "not a number"` in
+    // packages/ui/src/main.tsx produced NO output from `tsc --noEmit`, while
+    // `tsc -b` reported TS2322 + TS6133 immediately.
+    //
+    // So `make typecheck`'s ui half was a checker that examined nothing and
+    // therefore reported universal success — and .husky/pre-push documented it as
+    // "a superset" of the deploy gate. That is why commit 5b930ff had to drop
+    // unused imports that only CI's build job caught.
+    const uiTsconfig = JSON.parse(
+      readFileSync(join(REPO_ROOT, "packages", "ui", "tsconfig.json"), "utf8"),
+    );
+
+    // The premise of this guard: if the ui tsconfig ever stops being the
+    // empty-files solution form, `tsc --noEmit` might become safe again and this
+    // test's reasoning would no longer apply. Assert the premise explicitly
+    // rather than letting it rot into a stale rule.
+    expect(
+      uiTsconfig.files,
+      "packages/ui/tsconfig.json is no longer the `files: []` solution form. " +
+        "Re-derive whether `tsc --noEmit` now checks real files before relaxing " +
+        "the `tsc -b` requirement below.",
+    ).toEqual([]);
+
+    const typecheckBlock = MAKEFILE.split("\n")
+      .slice(MAKEFILE.split("\n").findIndex((l) => /^typecheck:/.test(l)))
+      .slice(0, 4)
+      .join("\n");
+
+    expect(typecheckBlock.length).toBeGreaterThan(20); // denominator: we found the recipe
+
+    expect(
+      /@memex\/ui exec tsc -b/.test(typecheckBlock),
+      `\`make typecheck\` must run \`tsc -b\` for the UI, not \`tsc --noEmit\`.\n` +
+        `\n` +
+        `  Observed recipe:\n${typecheckBlock}\n` +
+        `\n` +
+        `  packages/ui/tsconfig.json sets \`files: []\`, so \`tsc --noEmit\` checks ZERO\n` +
+        `  files and passes no matter what is broken. The pre-push gate would then be\n` +
+        `  reporting a UI type-check it never performed.\n` +
+        `\n` +
+        `  Fix — in the Makefile's typecheck recipe:\n` +
+        `    pnpm --filter @memex/ui exec tsc -b\n` +
+        `\n` +
+        `  Check: packages/server/src/__regression__/spec-512-workspace-isolation.regression.test.ts`,
+    ).toBe(true);
+  });
+
   it("the e2e harness threads and verifies workspace identity (ac-13, ac-14)", () => {
     tagAc("mindset-prod/memex-building-itself/specs/spec-512/acs/ac-13");
     tagAc("mindset-prod/memex-building-itself/specs/spec-512/acs/ac-14");

--- a/packages/server/src/__regression__/voice-guide-removed.static-scan.spec-508.regression.test.ts
+++ b/packages/server/src/__regression__/voice-guide-removed.static-scan.spec-508.regression.test.ts
@@ -14,6 +14,7 @@
 import { describe, it, expect } from "vitest";
 import { tagAc } from "@memex-ai-ac/vitest";
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 
 const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-508/acs/ac-${n}`;
@@ -100,10 +101,39 @@ function walk(dir: string): string[] {
 const IMPORT_FROM = /(?:from|import)\s+['"]([^'"]+)['"]/g;
 
 describe("spec-508 — the voice guide is fully removed (ac-2 / ac-6 / ac-10)", () => {
-  it("every deleted voice-guide path is gone (ac-2)", () => {
+  it("every deleted voice-guide path is gone from the REPOSITORY (ac-2)", () => {
     tagAc(AC(2));
-    const survivors = DELETED_PATHS.filter((rel) => existsSync(join(REPO_ROOT, rel)));
-    expect(survivors).toEqual([]);
+
+    // spec-512 issue-4: this asserted filesystem existence, which made it green in
+    // CI (clean checkout) and permanently RED on any developer machine carrying
+    // pre-spec-508 build residue — untracked `packages/guide-sdk/{dist,node_modules}`
+    // and the downloaded `packages/ui/public/assets/vad/*.wasm|.onnx`. Neither is in
+    // the index; `a1bb0e6` removed them from git and left the artefacts on disk.
+    //
+    // "The voice guide is removed" is a claim about the REPOSITORY, and the
+    // repository is git's index — not one laptop's disk. A guard that cries wolf
+    // locally trains everyone to ignore the regression suite, which is the same
+    // erosion of trust in a green signal that spec-512 exists to reverse.
+    const tracked = execFileSync("git", ["ls-files", "--", ...DELETED_PATHS], {
+      cwd: REPO_ROOT,
+      encoding: "utf8",
+    })
+      .split("\n")
+      .filter((l) => l.trim() !== "");
+
+    expect(
+      tracked,
+      `Deleted voice-guide path(s) are tracked by git again (spec-508 ac-2):\n` +
+        `  ${tracked.join("\n  ")}\n\n` +
+        `The voice stack was removed in a1bb0e6 and must stay removed.\n\n` +
+        `Fix — untrack the offending path(s):\n` +
+        `  git rm -r --cached ${tracked[0] ?? "<path>"}\n\n` +
+        `Check: packages/server/src/__regression__/voice-guide-removed.static-scan.spec-508.regression.test.ts`,
+    ).toEqual([]);
+
+    // Denominator: prove `git ls-files` ran against a real list, so a bad path
+    // argument or a non-git cwd cannot turn this into a vacuous pass.
+    expect(DELETED_PATHS.length).toBeGreaterThan(3);
   });
 
   it("no source file across server + UI imports a deleted voice module (ac-6 / ac-7)", () => {

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -147,10 +147,32 @@ app.get("/api/health", (c) => {
   // attached (single-process / local dev / tests) the field is null — distinct
   // from "attached but not yet listening", so smoke can tell the two apart.
   const relay = getBusRelay();
+
+  // spec-512 dec-3 — workspace identity, LOCAL ONLY.
+  //
+  // Parallel worktrees share one loopback. Playwright runs with
+  // `reuseExistingServer`, so without a way to ask "whose server is this?" a
+  // second worktree silently reuses the first one's server and runs its
+  // journeys against another branch's code, reporting a pass. This field is
+  // how scripts/ci/e2e-preflight.mjs tells its own server from a foreign one.
+  //
+  // Emitted ONLY when MEMEX_WORKSPACE_ID is set. The local tooling sets it; no
+  // deploy path does, so the deployed payload stays byte-identical to what it
+  // has always been (pinned by a regression test). The value is the 8-char
+  // sha1 digest of the workspace path, never the path itself — /api/health is
+  // unauthenticated and internet-reachable, so even a gate that failed open
+  // must leak nothing about the host filesystem.
+  //
+  // NOT an authentication mechanism: it answers "is this the server I
+  // started?", not "is this server trustworthy". It defends against two of
+  // your own worktrees colliding, and nothing else.
+  const workspace = process.env.MEMEX_WORKSPACE_ID?.trim();
+
   return c.json({
     status: "ok",
     timestamp: new Date().toISOString(),
     relay: relay ? relay.health() : null,
+    ...(workspace ? { workspace } : {}),
   });
 });
 

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -166,7 +166,14 @@ app.get("/api/health", (c) => {
   // NOT an authentication mechanism: it answers "is this the server I
   // started?", not "is this server trustworthy". It defends against two of
   // your own worktrees colliding, and nothing else.
-  const workspace = process.env.MEMEX_WORKSPACE_ID?.trim();
+  // ENFORCED, not merely intended: only an 8-char hex digest is ever published.
+  // Adversarial review booted this server with
+  // MEMEX_WORKSPACE_ID=/Users/me/secret-project/acme-merger and the unauthenticated
+  // endpoint echoed the path verbatim. The sibling variable MEMEX_WORKSPACE_ROOT
+  // *is* a path, so one _ID/_ROOT slip would leak host layout to the internet.
+  // Anything not matching the digest shape is dropped rather than published.
+  const raw = process.env.MEMEX_WORKSPACE_ID?.trim();
+  const workspace = raw && /^[0-9a-f]{8}$/.test(raw) ? raw : undefined;
 
   return c.json({
     status: "ok",

--- a/packages/ui/e2e/global-setup.ts
+++ b/packages/ui/e2e/global-setup.ts
@@ -18,7 +18,48 @@ import {
   DEV_NAME,
 } from "./helpers/index.js";
 
+// spec-512 dec-3 — refuse to run against another working copy's server.
+//
+// playwright.config.ts sets `reuseExistingServer: !CI`. When a second worktree
+// finds the ports already answering, Playwright adopts THAT worktree's server:
+// the journeys then exercise another branch's code against another branch's
+// database and report a PASS. Proven empirically during spec-512 build — a stub
+// server on the e2e port took 12 real requests while Playwright never started
+// this checkout's server at all.
+//
+// This runs after webServer boot but before any journey, so a mismatch stops the
+// suite instead of producing a green lie. It is a backstop for direct
+// `playwright test` invocations; `make e2e-cold` catches it earlier and cheaper
+// via scripts/ci/e2e-preflight.mjs.
+async function assertServerBelongsToThisWorkspace(): Promise<void> {
+  const expected = process.env.MEMEX_WORKSPACE_ID?.trim();
+  if (!expected) return; // not launched by the workspace-aware tooling — nothing to compare
+
+  const apiUrl = process.env.E2E_API_URL ?? `http://localhost:${process.env.E2E_SERVER_PORT ?? 8090}`;
+  const res = await fetch(`${apiUrl}/api/health`);
+  const seen = ((await res.json()) as { workspace?: string }).workspace ?? null;
+
+  if (seen === expected) return;
+
+  throw new Error(
+    `E2E IS TALKING TO ANOTHER WORKSPACE'S SERVER (spec-512 dec-3)\n` +
+      `\n` +
+      `  ${apiUrl} reports workspace ${seen ?? "(none — it was not started by this tooling)"}.\n` +
+      `  This run belongs to workspace ${expected}.\n` +
+      `\n` +
+      `  Playwright reused an already-running server instead of starting this\n` +
+      `  checkout's. Every journey would have exercised the OTHER workspace's code\n` +
+      `  and database and reported a pass — nothing you changed would be tested.\n` +
+      `\n` +
+      `  Fix — free the port, then re-run:\n` +
+      `    lsof -ti tcp:${process.env.E2E_SERVER_PORT ?? 8090} | xargs kill\n` +
+      `\n` +
+      `  Check: packages/ui/e2e/global-setup.ts`,
+  );
+}
+
 export default async function globalSetup(): Promise<void> {
+  await assertServerBelongsToThisWorkspace();
   // ensureUser provisions dev@memex.ai + its personal namespace/memex through the
   // server's real services; setUserName then gives it a display name.
   await ensureUser(DEV_EMAIL);

--- a/packages/ui/e2e/global-setup.ts
+++ b/packages/ui/e2e/global-setup.ts
@@ -52,7 +52,7 @@ async function assertServerBelongsToThisWorkspace(): Promise<void> {
       `  and database and reported a pass — nothing you changed would be tested.\n` +
       `\n` +
       `  Fix — free the port, then re-run:\n` +
-      `    lsof -ti tcp:${process.env.E2E_SERVER_PORT ?? 8090} | xargs kill\n` +
+      `    lsof -ti tcp:${process.env.E2E_SERVER_PORT ?? 8090} | xargs -r kill\n` +
       `\n` +
       `  Check: packages/ui/e2e/global-setup.ts`,
   );

--- a/packages/ui/playwright.config.ts
+++ b/packages/ui/playwright.config.ts
@@ -72,7 +72,12 @@ export default defineConfig({
           // can still render a tracker step deterministically now that spec-470/473's hero
           // owns the live spec-less /home. Preview only activates on an explicit ?preview=
           // query, so every other journey is unaffected.
-          command: `GOOGLE_CLIENT_ID="" MEMEX_ANTHROPIC_FAKE=1 JOURNEY_PREVIEW_DOMAINS="memex.ai" SLACK_TOKEN_ENCRYPTION="${process.env.SLACK_TOKEN_ENCRYPTION ?? "plaintext"}" DATABASE_URL="${DATABASE_URL}" PORT=${SERVER_PORT} pnpm --filter @memex/server dev`,
+          // spec-512 dec-3: MEMEX_WORKSPACE_ID is threaded through so this server
+          // advertises WHICH working copy started it on /api/health. Without it,
+          // `reuseExistingServer` below silently adopts another worktree's server
+          // and every journey runs against that branch's code while reporting a
+          // pass. e2e/global-setup.ts refuses to proceed on a mismatch.
+          command: `GOOGLE_CLIENT_ID="" MEMEX_ANTHROPIC_FAKE=1 JOURNEY_PREVIEW_DOMAINS="memex.ai" SLACK_TOKEN_ENCRYPTION="${process.env.SLACK_TOKEN_ENCRYPTION ?? "plaintext"}" DATABASE_URL="${DATABASE_URL}" MEMEX_WORKSPACE_ID="${process.env.MEMEX_WORKSPACE_ID ?? ""}" PORT=${SERVER_PORT} pnpm --filter @memex/server dev`,
           url: `http://localhost:${SERVER_PORT}/api/health`,
           reuseExistingServer: !process.env.CI,
           timeout: 60_000,

--- a/scripts/ci/affected-tests.d.mts
+++ b/scripts/ci/affected-tests.d.mts
@@ -1,0 +1,27 @@
+// Types for affected-tests.mjs (spec-512 ac-4). See workspace-alloc.d.mts for why
+// the implementation is an untyped `.mjs` and this declaration exists.
+
+export interface Rule {
+  test: RegExp;
+  /** true ⇒ this path is broad enough that narrowing would be a lie. */
+  full?: boolean;
+  cmds?: string[];
+  /** Stated so the mapper's output can be audited, not just trusted. */
+  why: string;
+}
+
+export const RULES: Rule[];
+
+export interface Plan {
+  /** true ⇒ run the full matrix. ALWAYS true when any path is unrecognised. */
+  full: boolean;
+  reason: string;
+  /** Never empty when `full` is true. */
+  commands: string[];
+  unmatched: string[];
+  matched: Array<{ file: string; why: string }>;
+}
+
+/** Map changed paths to a test plan. An unrecognised path widens to the full
+ *  matrix — it must never narrow to nothing. */
+export function planFor(files: string[] | null | undefined): Plan;

--- a/scripts/ci/affected-tests.mjs
+++ b/scripts/ci/affected-tests.mjs
@@ -1,0 +1,204 @@
+// diff → affected tests (spec-512 ac-4).
+//
+//   node scripts/ci/affected-tests.mjs                 # vs merge-base with develop
+//   node scripts/ci/affected-tests.mjs --base main
+//   node scripts/ci/affected-tests.mjs --json          # machine-readable
+//   node scripts/ci/affected-tests.mjs --files a.ts b.ts
+//
+// An agent that changed one file has no cheap way to compute the minimal relevant
+// test set, so it either runs everything (slow) or guesses (unsafe). This maps a
+// diff to the suites worth running first.
+//
+// ── The one rule that makes this safe ────────────────────────────────────────
+// IT MUST NEVER RETURN SILENTLY EMPTY. An unrecognised path maps to "run
+// everything", never to "nothing to do". A mapper that shrugs at a file it does
+// not understand and prints an empty list is precisely the confident-wrong-answer
+// this Spec exists to delete: the agent reads "no tests affected" as "safe".
+//
+// And it is ADVISORY. Every human-readable run says so, because the minimal set
+// is a starting point for the local loop — CI still runs the full matrix, and
+// that is what actually gates the merge.
+
+import { execFileSync } from "node:child_process";
+
+const SELF = "scripts/ci/affected-tests.mjs";
+
+// Ordered, first-match-wins. Each rule maps a path pattern to the commands worth
+// running. `full: true` means the change is broad enough that narrowing is a lie.
+export const RULES = [
+  // Anything that reshapes the build, the deps, or the test harness itself
+  // invalidates narrowing entirely.
+  { test: /^(package\.json|pnpm-lock\.yaml|pnpm-workspace\.yaml|tsconfig\.base\.json|biome\.json)$/, full: true, why: "workspace-wide build/dep/lint config" },
+  { test: /^packages\/[^/]+\/(package\.json|tsconfig[^/]*\.json|vitest[^/]*\.ts)$/, full: true, why: "package build or test-harness config" },
+  { test: /^(Makefile|Dockerfile|cloudbuild\.yaml|deploy\.sh)$/, full: true, why: "build/deploy entrypoint" },
+  { test: /^\.github\/workflows\//, full: true, why: "CI pipeline definition" },
+
+  // Shared code is imported by every surface — narrowing would miss consumers.
+  { test: /^packages\/shared\//, full: true, why: "@memex/shared is imported by every package" },
+  { test: /^packages\/server\/src\/db\/schema\.ts$/, full: true, why: "schema change ripples through every DB-backed suite" },
+  { test: /^packages\/server\/drizzle\//, full: true, why: "migration set" },
+
+  // Targeted surfaces.
+  { test: /^packages\/server\/src\/__regression__\//, cmds: ["make test-regression"], why: "regression guards" },
+  { test: /^packages\/server\/src\/__security__\//, cmds: ["make test-security"], why: "security suite" },
+  { test: /^packages\/server\/src\/__perf__\//, cmds: ["make test-perf"], why: "perf suite" },
+  { test: /^packages\/server\/src\/mcp\//, cmds: ["pnpm --filter @memex/server exec vitest run src/mcp", "make test-regression"], why: "MCP surface + its guards" },
+  { test: /^packages\/server\/src\/routes\//, cmds: ["make test-api", "make test-regression"], why: "HTTP routes" },
+  { test: /^packages\/server\/src\/services\//, cmds: ["make test-integration", "make test-regression"], why: "service layer" },
+  { test: /^packages\/server\/src\//, cmds: ["make test-server"], why: "server source" },
+  { test: /^packages\/ui\/e2e\//, cmds: ["make e2e-cold"], why: "e2e journeys" },
+  { test: /^packages\/ui\/src\//, cmds: ["make test-ui"], why: "UI source" },
+  { test: /^packages\/cli\//, cmds: ["pnpm --filter memex-ai test"], why: "CLI package" },
+  { test: /^packages\/db-schema\//, cmds: ["pnpm --filter @mindset-ai/db-schema test"], why: "db-schema package" },
+  { test: /^packages\/extractor\//, cmds: ["pnpm --filter @memex/extractor test"], why: "extractor package" },
+  { test: /^scripts\/ci\//, cmds: ["make check", "make test-regression"], why: "guard scripts + the tests that pin them" },
+  { test: /^scripts\//, cmds: ["make check"], why: "repo scripts" },
+
+  // Prose that a guard actually reads. CLAUDE.md is indexed by the standards
+  // check and by spec-172's row guard, so it is NOT a no-op change.
+  { test: /^CLAUDE\.md$/, cmds: ["make check", "make test-regression"], why: "guards parse this file" },
+  { test: /^standards\.manifest\.json$/, cmds: ["make check", "make test-regression"], why: "the standards index is generated from it" },
+  { test: /\.md$/, cmds: [], why: "documentation only" },
+];
+
+const FULL_MATRIX = [
+  "make check",
+  "make typecheck",
+  "make test-server",
+  "make test-ui",
+  "make e2e-cold",
+];
+
+/** Map changed paths to a plan. Unknown paths ⇒ full matrix, always. */
+export function planFor(files) {
+  if (!Array.isArray(files) || files.length === 0) {
+    return {
+      full: true,
+      reason: "no changed files were detected — cannot narrow, so run everything",
+      commands: FULL_MATRIX,
+      unmatched: [],
+      matched: [],
+    };
+  }
+
+  const commands = new Set();
+  const matched = [];
+  const unmatched = [];
+  let full = null;
+
+  for (const file of files) {
+    const rule = RULES.find((r) => r.test.test(file));
+    if (!rule) {
+      unmatched.push(file);
+      continue;
+    }
+    matched.push({ file, why: rule.why });
+    if (rule.full) {
+      full ??= `${file} (${rule.why})`;
+      continue;
+    }
+    for (const c of rule.cmds) commands.add(c);
+  }
+
+  // The load-bearing branch: a path no rule recognises means the map is
+  // incomplete, and an incomplete map must fail SAFE (run everything), never
+  // quiet (run nothing).
+  if (unmatched.length > 0) {
+    return {
+      full: true,
+      reason: `${unmatched.length} path(s) match no rule — the map is incomplete, so nothing is narrowed`,
+      commands: FULL_MATRIX,
+      unmatched,
+      matched,
+    };
+  }
+  if (full) {
+    return {
+      full: true,
+      reason: `a broad-impact path changed: ${full}`,
+      commands: FULL_MATRIX,
+      unmatched,
+      matched,
+    };
+  }
+
+  return {
+    full: false,
+    reason: "narrowed from the changed paths",
+    commands: [...commands],
+    unmatched,
+    matched,
+  };
+}
+
+function changedFiles(base) {
+  const mergeBase = execFileSync("git", ["merge-base", "HEAD", base], { encoding: "utf8" }).trim();
+  const committed = execFileSync("git", ["diff", "--name-only", `${mergeBase}...HEAD`], { encoding: "utf8" });
+  const working = execFileSync("git", ["status", "--porcelain"], { encoding: "utf8" })
+    .split("\n")
+    .map((l) => l.slice(3).trim())
+    .filter(Boolean);
+  return [...new Set([...committed.split("\n"), ...working].map((s) => s.trim()).filter(Boolean))];
+}
+
+function main(argv) {
+  const json = argv.includes("--json");
+  const baseIdx = argv.indexOf("--base");
+  const base = baseIdx !== -1 ? argv[baseIdx + 1] : "develop";
+  const filesIdx = argv.indexOf("--files");
+
+  let files;
+  if (filesIdx !== -1) {
+    files = argv.slice(filesIdx + 1).filter((a) => !a.startsWith("--"));
+  } else {
+    try {
+      files = changedFiles(base);
+    } catch (err) {
+      // Cannot read the diff ⇒ cannot narrow ⇒ run everything, loudly.
+      const plan = {
+        full: true,
+        reason: `could not compute a diff against "${base}": ${String(err.message).split("\n")[0]}`,
+        commands: FULL_MATRIX,
+        unmatched: [],
+        matched: [],
+      };
+      emit(plan, json, base);
+      return 0;
+    }
+  }
+
+  emit(planFor(files), json, base);
+  return 0;
+}
+
+function emit(plan, json, base) {
+  if (json) {
+    process.stdout.write(`${JSON.stringify({ ...plan, base, advisory: true, ciRunsFullMatrix: true }, null, 2)}\n`);
+    return;
+  }
+  process.stdout.write(`Affected tests (vs ${base})\n\n`);
+  if (plan.full) {
+    process.stdout.write(`  FULL MATRIX — ${plan.reason}\n`);
+    if (plan.unmatched.length) {
+      process.stdout.write(`  Unrecognised path(s):\n`);
+      for (const f of plan.unmatched) process.stdout.write(`    • ${f}\n`);
+      process.stdout.write(
+        `  Add a rule for these in ${SELF} to narrow future runs.\n`,
+      );
+    }
+  } else {
+    process.stdout.write(`  ${plan.matched.length} changed path(s) → ${plan.commands.length} suite(s)\n`);
+  }
+  process.stdout.write(`\n`);
+  for (const c of plan.commands) process.stdout.write(`    ${c}\n`);
+  // Printed on EVERY run, narrowed or not — the minimal set is a local
+  // starting point and must never read as a merge guarantee.
+  process.stdout.write(
+    `\n  Advisory: this is the fast local loop, not a gate. ` +
+      `CI still runs the full matrix on every PR.\n  Check: ${SELF}\n`,
+  );
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  process.exit(main(process.argv.slice(2)));
+}

--- a/scripts/ci/e2e-preflight.d.mts
+++ b/scripts/ci/e2e-preflight.d.mts
@@ -1,0 +1,38 @@
+// Types for e2e-preflight.mjs (spec-512 dec-3). See workspace-alloc.d.mts for why
+// the implementation is an untyped `.mjs` and this declaration exists.
+
+/** How the thing currently listening on our e2e port is classified.
+ *  Only `free` and `own` are safe to proceed on. */
+export type PortOwnerVerdict =
+  | { kind: "free" }
+  | { kind: "own" }
+  | { kind: "unidentified" }
+  | { kind: "foreign"; reason: "mismatch" | "non-json"; seen?: string };
+
+export function classifyPortOwner(args: {
+  port: number;
+  expectedWorkspaceId: string;
+  /** Injected so the guard's own tests can drive every branch without sockets.
+   *  Resolves to the parsed /api/health body, or null when nothing is listening. */
+  probe: (port: number) => Promise<unknown>;
+}): Promise<PortOwnerVerdict>;
+
+export type StaleBuildVerdict =
+  | { stale: false }
+  | {
+      stale: true;
+      reason: "missing" | "empty" | "older-than-src";
+      distTime?: number;
+      srcTime?: number;
+    };
+
+export function isStaleBuild(
+  distDir: string,
+  srcDir: string,
+  opts?: { listFiles?: (dir: string) => string[] },
+): StaleBuildVerdict;
+
+export function needsPgPassword(args: {
+  env: Record<string, string | undefined>;
+  runPsql: () => unknown;
+}): boolean;

--- a/scripts/ci/e2e-preflight.d.mts
+++ b/scripts/ci/e2e-preflight.d.mts
@@ -6,8 +6,19 @@
 export type PortOwnerVerdict =
   | { kind: "free" }
   | { kind: "own" }
-  | { kind: "unidentified" }
+  | {
+      kind: "unidentified";
+      reason: "timeout" | "non-json" | "unhealthy" | "no-id";
+    }
   | { kind: "foreign"; reason: "mismatch" | "non-json"; seen?: string };
+
+/** The ports a run must clear. Exported so coverage can be asserted from the
+ *  DATA rather than by counting call sites in the source (which was defeatable
+ *  by a conditional or a string literal). */
+export function portsToCheck(cfg: {
+  apiPort: number;
+  uiPort: number;
+}): Array<{ port: number; label: string }>;
 
 export function classifyPortOwner(args: {
   port: number;
@@ -21,9 +32,13 @@ export type StaleBuildVerdict =
   | { stale: false }
   | {
       stale: true;
-      reason: "missing" | "empty" | "older-than-src";
+      reason: "missing" | "empty" | "older-than-src" | "incomplete";
       distTime?: number;
       srcTime?: number;
+      /** `incomplete`: source modules with no emitted counterpart. */
+      missingCount?: number;
+      srcCount?: number;
+      example?: string;
     };
 
 export function isStaleBuild(
@@ -32,7 +47,9 @@ export function isStaleBuild(
   opts?: { listFiles?: (dir: string) => string[] },
 ): StaleBuildVerdict;
 
+/** `examined: false` means we learned nothing (psql absent / Postgres down) — the
+ *  caller must NOT count it as a check that passed. */
 export function needsPgPassword(args: {
   env: Record<string, string | undefined>;
   runPsql: () => unknown;
-}): boolean;
+}): { blocked: boolean; examined: boolean; why?: string };

--- a/scripts/ci/e2e-preflight.mjs
+++ b/scripts/ci/e2e-preflight.mjs
@@ -41,22 +41,97 @@ const SELF = "scripts/ci/e2e-preflight.mjs";
  *  `probe` is injected so the test can drive every branch without real sockets. */
 export async function classifyPortOwner({ port, expectedWorkspaceId, probe }) {
   const health = await probe(port);
+
+  // ONLY a refused connection means "free". Everything else means something is
+  // listening, and anything listening that cannot PROVE it is ours must fail loud.
+  //
+  // Adversarial review broke the first version here twice, both times by making a
+  // real foreign server look like an empty port:
+  //   * a server slower than the probe timeout — 1500ms was caught, 2100ms sailed
+  //     through with "✓ preflight passed", even though the server's own log showed
+  //     it had RECEIVED the probe. Playwright's webServer timeout is 60s, so a 3s
+  //     server is adopted comfortably.
+  //   * a 200 whose body is not JSON (an SPA HTML fallback, an empty body, a
+  //     redirect) — `res.json()` threw into the same catch that handles ECONNREFUSED.
+  // Both reinstated the exact silent adoption this file exists to prevent, which is
+  // why the sentinels below are distinct rather than collapsed into null.
   if (health === null) return { kind: "free" };
   if (typeof health !== "object") return { kind: "foreign", reason: "non-json" };
-  const seen = health.workspace ?? null;
-  if (seen === null) return { kind: "unidentified" };
+  if (health.timedOut) return { kind: "unidentified", reason: "timeout" };
+  if (health.unparseable) return { kind: "unidentified", reason: "non-json" };
+  if (health.unhealthy !== undefined) return { kind: "unidentified", reason: "unhealthy" };
+
+  // Treat null/""/whitespace alike — an unusable id is no id.
+  const raw = health.workspace;
+  const seen = typeof raw === "string" && raw.trim() !== "" ? raw.trim() : null;
+  if (seen === null) return { kind: "unidentified", reason: "no-id" };
   if (seen !== expectedWorkspaceId) return { kind: "foreign", reason: "mismatch", seen };
   return { kind: "own" };
 }
 
-/** True when the built dist is older than any source file (or missing entirely). */
+/** The ports a run must clear before it can trust its own results.
+ *  Exported so the guard's test can assert coverage BEHAVIOURALLY — counting
+ *  `checkPortOwnership(` lines in the source was defeatable by a call wrapped in
+ *  an `if`, or by the same text inside a string literal (both kept the old test
+ *  green while the UI port went unprobed). */
+export function portsToCheck(cfg) {
+  return [
+    { port: cfg.apiPort, label: "API" },
+    { port: cfg.uiPort, label: "UI" },
+  ];
+}
+
+/** Is the built dist missing, empty, older than source, or INCOMPLETE?
+ *
+ *  Adversarial review broke the max-mtime-only version: a `dist` holding 1 of 38
+ *  modules reported `{stale:false}`, and a single `touch` on any one dist file
+ *  cleared a genuine stale verdict while a source module remained unbuilt. That
+ *  is exactly the interrupted-build case the check exists for — the header below
+ *  says it guards "a stale dist MISSING AN EXPORT the UI now imports", and a
+ *  newest-mtime comparison is structurally blind to a missing file.
+ *
+ *  So compare COVERAGE as well as recency: every source module must have a
+ *  corresponding emitted module. */
 export function isStaleBuild(distDir, srcDir, { listFiles = walk } = {}) {
   if (!existsSync(distDir)) return { stale: true, reason: "missing" };
-  const newestOf = (dir) =>
-    listFiles(dir).reduce((max, f) => Math.max(max, statSync(f).mtimeMs), 0);
-  const distTime = newestOf(distDir);
-  const srcTime = newestOf(srcDir);
-  if (distTime === 0) return { stale: true, reason: "empty" };
+
+  const srcFiles = listFiles(srcDir).filter(
+    (f) => /\.(ts|tsx)$/.test(f) && !/\.d\.ts$/.test(f) && !/\.test\.tsx?$/.test(f),
+  );
+  const distFiles = listFiles(distDir).filter((f) => /\.js$/.test(f));
+
+  if (distFiles.length === 0) return { stale: true, reason: "empty" };
+
+  // Coverage: a source module with no emitted counterpart means a partial build.
+  const emitted = new Set(
+    distFiles.map((f) => f.slice(distDir.length).replace(/\.js$/, "")),
+  );
+  const missing = srcFiles
+    .map((f) => f.slice(srcDir.length).replace(/\.tsx?$/, ""))
+    .filter((rel) => !emitted.has(rel));
+  if (missing.length > 0) {
+    return {
+      stale: true,
+      reason: "incomplete",
+      missingCount: missing.length,
+      srcCount: srcFiles.length,
+      example: missing[0],
+    };
+  }
+
+  const newestOf = (files) =>
+    files.reduce((max, f) => {
+      // A broken symlink throws ENOENT from statSync. Skip it rather than crash
+      // the whole preflight with a bare stack trace (which would breach the
+      // message contract) — a dangling link tells us nothing about freshness.
+      try {
+        return Math.max(max, statSync(f).mtimeMs);
+      } catch {
+        return max;
+      }
+    }, 0);
+  const distTime = newestOf(distFiles);
+  const srcTime = newestOf(srcFiles);
   if (srcTime > distTime) {
     return { stale: true, reason: "older-than-src", distTime, srcTime };
   }
@@ -65,7 +140,13 @@ export function isStaleBuild(distDir, srcDir, { listFiles = walk } = {}) {
 
 function walk(dir) {
   const out = [];
-  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return out; // unreadable dir — callers treat an empty listing as "nothing built"
+  }
+  for (const entry of entries) {
     if (entry.name === "node_modules" || entry.name.startsWith(".")) continue;
     const full = join(dir, entry.name);
     if (entry.isDirectory()) out.push(...walk(full));
@@ -76,27 +157,42 @@ function walk(dir) {
 
 /** Does this Postgres need a password we are not supplying? */
 export function needsPgPassword({ env, runPsql }) {
-  if (env.PGPASSWORD) return false;
+  if (env.PGPASSWORD) return { blocked: false, examined: true };
   try {
     runPsql();
-    return false; // connected fine without a password (trust auth / .pgpass)
+    return { blocked: false, examined: true }; // trust auth / .pgpass
   } catch (err) {
     const text = `${err?.stderr ?? ""}${err?.message ?? ""}`;
-    return /password/i.test(text);
+    if (/password/i.test(text)) return { blocked: true, examined: true };
+    // psql absent, or Postgres down. We learned nothing about password policy,
+    // so this must NOT count as a check that passed (adversarial review: the
+    // earlier boolean return silently no-opped while still counting).
+    return { blocked: false, examined: false, why: text.trim().split("\n")[0] };
   }
 }
 
 // ── Real probes ──────────────────────────────────────────────────────────────
 
 async function httpHealth(port) {
+  let res;
   try {
-    const res = await fetch(`http://localhost:${port}/api/health`, {
+    res = await fetch(`http://localhost:${port}/api/health`, {
       signal: AbortSignal.timeout(2000),
     });
-    if (!res.ok) return { unhealthy: res.status };
+  } catch (err) {
+    // A timeout means something IS there and merely answered slowly — never free.
+    if (err?.name === "TimeoutError" || err?.name === "AbortError") {
+      return { timedOut: true };
+    }
+    return null; // connection refused: genuinely nothing listening
+  }
+  if (!res.ok) return { unhealthy: res.status };
+  try {
     return await res.json();
   } catch {
-    return null; // nothing listening, or not speaking HTTP — treat as free
+    // Answered 200 with a body we cannot parse (SPA HTML, empty, redirect body).
+    // Something is listening and cannot identify itself.
+    return { unparseable: true };
   }
 }
 
@@ -104,6 +200,7 @@ async function httpHealth(port) {
 
 const failures = [];
 const warnings = [];
+const skipped = [];
 let checksRun = 0;
 
 function fail(message) {
@@ -150,7 +247,10 @@ async function checkPortOwnership(cfg, { port, label }) {
       `  changed would have been tested.\n` +
       `\n` +
       `  Fix — free the port by stopping whatever holds it:\n` +
-      `    kill $(lsof -ti tcp:${port})\n` +
+      // xargs -r, not `kill $(...)`: with an already-free port the command
+      // substitution is empty and `kill` exits 1 with "not enough arguments",
+      // so the printed fix would itself fail. Every printed fix must run.
+      `    lsof -ti tcp:${port} | xargs -r kill\n` +
       `\n` +
       `  Or leave it running and give this run its own pair:\n` +
       `    E2E_SERVER_PORT=${cfg.apiPort + 100} E2E_UI_PORT=${cfg.uiPort + 100} make e2e-cold\n` +
@@ -160,8 +260,7 @@ async function checkPortOwnership(cfg, { port, label }) {
 }
 
 function checkPgPassword() {
-  checksRun++;
-  const blocked = needsPgPassword({
+  const verdict = needsPgPassword({
     env: process.env,
     runPsql: () =>
       execFileSync("psql", ["-h", "localhost", "-U", "postgres", "-At", "-c", "SELECT 1", "postgres"], {
@@ -169,7 +268,12 @@ function checkPgPassword() {
         timeout: 5000,
       }),
   });
-  if (!blocked) return;
+  if (!verdict.examined) {
+    skipped.push(`pg-password (could not reach psql/Postgres: ${verdict.why ?? "unknown"})`);
+    return;
+  }
+  checksRun++;
+  if (!verdict.blocked) return;
 
   fail(
     `POSTGRES REQUIRES A PASSWORD AND PGPASSWORD IS UNSET (spec-512 dec-3)\n` +
@@ -190,10 +294,17 @@ function checkPgPassword() {
 }
 
 function checkSharedBuild(repoRoot) {
-  checksRun++;
   const dist = join(repoRoot, "packages", "shared", "dist");
   const src = join(repoRoot, "packages", "shared", "src");
-  if (!existsSync(src)) return; // layout changed — say nothing rather than guess
+  if (!existsSync(src)) {
+    // Layout changed — say nothing rather than guess. Deliberately does NOT
+    // increment checksRun: a check that examined nothing must not be reported
+    // as a check that passed. Adversarial review caught the earlier version
+    // printing "✓ 5 checks" from a run where this one inspected no files.
+    skipped.push("shared-build (packages/shared/src not found)");
+    return;
+  }
+  checksRun++;
   const verdict = isStaleBuild(dist, src);
   if (!verdict.stale) return;
 
@@ -201,9 +312,13 @@ function checkSharedBuild(repoRoot) {
     verdict.reason === "missing"
       ? "packages/shared/dist does not exist"
       : verdict.reason === "empty"
-        ? "packages/shared/dist is empty"
-        : `packages/shared/src is newer than packages/shared/dist ` +
-          `(src ${new Date(verdict.srcTime).toISOString()} > dist ${new Date(verdict.distTime).toISOString()})`;
+        ? "packages/shared/dist contains no emitted .js modules"
+        : verdict.reason === "incomplete"
+          ? `packages/shared/dist is INCOMPLETE — ${verdict.missingCount} of ` +
+            `${verdict.srcCount} source modules have no emitted counterpart ` +
+            `(e.g. "${verdict.example}"). A build was interrupted, or died partway.`
+          : `packages/shared/src is newer than packages/shared/dist ` +
+            `(src ${new Date(verdict.srcTime).toISOString()} > dist ${new Date(verdict.distTime).toISOString()})`;
 
   fail(
     `@memex/shared BUILD IS STALE (spec-512 dec-3)\n` +
@@ -251,23 +366,27 @@ async function main() {
   const repoRoot = process.env.MEMEX_WORKSPACE_ROOT ?? process.cwd();
   const cfg = resolveE2eConfig(process.env, repoRoot);
 
-  await checkPortOwnership(cfg, { port: cfg.apiPort, label: "API" });
-  await checkPortOwnership(cfg, { port: cfg.uiPort, label: "UI" });
+  for (const target of portsToCheck(cfg)) {
+    await checkPortOwnership(cfg, target);
+  }
   checkPgPassword();
   checkSharedBuild(repoRoot);
   checkEmissionTarget();
 
-  // Guard against the lie this whole Spec exists to eliminate: a preflight that
-  // examined nothing would otherwise print a clean bill of health.
+  // A preflight that examined nothing must never print a clean bill of health.
+  // Reachable now that checks which inspect nothing decline to count themselves.
   if (checksRun === 0) {
     process.stderr.write(
-      `e2e-preflight ran ZERO checks — that is a defect in the preflight itself,\n` +
-        `not a clean run. Check: ${SELF}\n`,
+      `e2e-preflight ran ZERO real checks — that is a defect in the preflight\n` +
+        `itself, not a clean run.${skipped.length ? ` Skipped: ${skipped.join("; ")}.` : ""}\n` +
+        `  Check: ${SELF}\n`,
     );
     return 2;
   }
 
   for (const w of warnings) process.stdout.write(`⚠ ${w}\n\n`);
+  // Skips are stated, never swallowed — an unexamined check is not a passed one.
+  for (const s of skipped) process.stdout.write(`⚠ check SKIPPED (examined nothing): ${s}\n`);
 
   if (failures.length > 0) {
     process.stderr.write(`\n${failures.join("\n\n")}\n\n`);
@@ -279,12 +398,28 @@ async function main() {
   }
 
   process.stdout.write(
-    `✓ e2e preflight passed (${checksRun} checks) — workspace ${cfg.workspaceId}, ` +
-      `api:${cfg.apiPort} ui:${cfg.uiPort} db:${cfg.databaseName}\n`,
+    `✓ e2e preflight passed (${checksRun} checks` +
+      `${skipped.length ? `, ${skipped.length} skipped` : ""}) — ` +
+      `workspace ${cfg.workspaceId}, api:${cfg.apiPort} ui:${cfg.uiPort} db:${cfg.databaseName}\n`,
   );
   return 0;
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-  main().then((code) => process.exit(code));
+  main()
+    .then((code) => process.exit(code))
+    .catch((err) => {
+      // An unexpected throw must still meet the message contract, not dump a
+      // bare stack trace (adversarial review tripped this with a broken symlink).
+      process.stderr.write(
+        `\ne2e-preflight CRASHED — it could not determine whether this run is safe,\n` +
+          `so it is failing closed rather than letting the suite start.\n\n` +
+          `  ${err?.stack ?? err}\n\n` +
+          `  Fix: re-run with the underlying condition resolved, or bypass ONLY if you\n` +
+          `  accept that the run may test another workspace's code:\n` +
+          `    pnpm --filter @memex/ui test:e2e\n\n` +
+          `  Check: ${SELF}\n`,
+      );
+      process.exit(2);
+    });
 }

--- a/scripts/ci/e2e-preflight.mjs
+++ b/scripts/ci/e2e-preflight.mjs
@@ -1,0 +1,276 @@
+// e2e preflight (spec-512 dec-3) — refuse to start an e2e run that would lie.
+//
+// Every check here exists because the failure it catches is SILENT or
+// INDISTINGUISHABLE from an unrelated problem. Each one was paid for at least
+// once and then written down as prose (packages/ui/e2e/README.md:20-49); this
+// script is that prose converted into behaviour.
+//
+//   FOREIGN SERVER  playwright.config.ts sets `reuseExistingServer: !CI`. A second
+//                   worktree finds ports already answering and reuses ANOTHER
+//                   worktree's servers — running its journeys against a different
+//                   branch's code and database, and reporting PASS. Proven
+//                   empirically during spec-512 build: a stub server on the e2e
+//                   port received 12 real requests (health, ensure-user,
+//                   clear-user-specs, …) while Playwright never booted this
+//                   checkout's server at all.
+//   PGPASSWORD      `make e2e-cold`'s dropdb/createdb carry no password (unlike its
+//                   `psql -f` steps, which embed it in the URL), so on an
+//                   auth-requiring Postgres they block on a hidden `Password:`
+//                   prompt with ZERO output — looks like a slow build, hangs forever.
+//   STALE SHARED    A stale packages/shared/dist missing an export the UI now
+//                   imports throws a module-load SyntaxError, React never mounts,
+//                   and EVERY journey fails identically with a generic
+//                   "heading not found". The real error is visible only in trace.zip.
+//   EMISSION        A local run with emission on POSTs REAL test_events to
+//                   production memex.ai.
+//
+// Message contract (spec-512): every failure prints the broken invariant with
+// observed values, an exact copy-pasteable one-line fix, and this file's path.
+// An invariant breach exits non-zero; genuine informational degradations warn.
+
+import { execFileSync } from "node:child_process";
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { resolveE2eConfig, resolveWorkspaceId } from "./workspace-alloc.mjs";
+
+const SELF = "scripts/ci/e2e-preflight.mjs";
+
+// ── Pure cores (exported so the regression test can drive them) ──────────────
+
+/** Classify what is listening on our e2e API port.
+ *  `probe` is injected so the test can drive every branch without real sockets. */
+export async function classifyPortOwner({ port, expectedWorkspaceId, probe }) {
+  const health = await probe(port);
+  if (health === null) return { kind: "free" };
+  if (typeof health !== "object") return { kind: "foreign", reason: "non-json" };
+  const seen = health.workspace ?? null;
+  if (seen === null) return { kind: "unidentified" };
+  if (seen !== expectedWorkspaceId) return { kind: "foreign", reason: "mismatch", seen };
+  return { kind: "own" };
+}
+
+/** True when the built dist is older than any source file (or missing entirely). */
+export function isStaleBuild(distDir, srcDir, { listFiles = walk } = {}) {
+  if (!existsSync(distDir)) return { stale: true, reason: "missing" };
+  const newestOf = (dir) =>
+    listFiles(dir).reduce((max, f) => Math.max(max, statSync(f).mtimeMs), 0);
+  const distTime = newestOf(distDir);
+  const srcTime = newestOf(srcDir);
+  if (distTime === 0) return { stale: true, reason: "empty" };
+  if (srcTime > distTime) {
+    return { stale: true, reason: "older-than-src", distTime, srcTime };
+  }
+  return { stale: false };
+}
+
+function walk(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === "node_modules" || entry.name.startsWith(".")) continue;
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...walk(full));
+    else out.push(full);
+  }
+  return out;
+}
+
+/** Does this Postgres need a password we are not supplying? */
+export function needsPgPassword({ env, runPsql }) {
+  if (env.PGPASSWORD) return false;
+  try {
+    runPsql();
+    return false; // connected fine without a password (trust auth / .pgpass)
+  } catch (err) {
+    const text = `${err?.stderr ?? ""}${err?.message ?? ""}`;
+    return /password/i.test(text);
+  }
+}
+
+// ── Real probes ──────────────────────────────────────────────────────────────
+
+async function httpHealth(port) {
+  try {
+    const res = await fetch(`http://localhost:${port}/api/health`, {
+      signal: AbortSignal.timeout(2000),
+    });
+    if (!res.ok) return { unhealthy: res.status };
+    return await res.json();
+  } catch {
+    return null; // nothing listening, or not speaking HTTP — treat as free
+  }
+}
+
+// ── Checks ───────────────────────────────────────────────────────────────────
+
+const failures = [];
+const warnings = [];
+let checksRun = 0;
+
+function fail(message) {
+  failures.push(message);
+}
+
+async function checkPortOwnership(cfg) {
+  checksRun++;
+  const verdict = await classifyPortOwner({
+    port: cfg.apiPort,
+    expectedWorkspaceId: cfg.workspaceId,
+    probe: httpHealth,
+  });
+
+  if (verdict.kind === "free" || verdict.kind === "own") return;
+
+  const owner =
+    verdict.kind === "unidentified"
+      ? "an unidentified server (it did not report a workspace, so it was not started by this tooling)"
+      : `a server belonging to workspace ${verdict.seen ?? "(unparseable)"}`;
+
+  fail(
+    `E2E PORT BELONGS TO ANOTHER WORKSPACE (spec-512 dec-3)\n` +
+      `\n` +
+      `  Port ${cfg.apiPort} is already held by ${owner}.\n` +
+      `  This workspace is ${cfg.workspaceRoot} (id ${cfg.workspaceId}).\n` +
+      `\n` +
+      `  Playwright is configured with reuseExistingServer, so it would have REUSED\n` +
+      `  that server instead of starting this checkout's. Your journeys would have\n` +
+      `  run against the OTHER workspace's code and the OTHER workspace's database,\n` +
+      `  and reported a PASS. Nothing you just changed would have been tested.\n` +
+      `\n` +
+      `  Fix — free the port by stopping whatever holds it:\n` +
+      `    lsof -ti tcp:${cfg.apiPort} | xargs kill\n` +
+      `\n` +
+      `  Or leave it running and give this run its own adjacent pair:\n` +
+      `    E2E_SERVER_PORT=${cfg.apiPort + 2} E2E_UI_PORT=${cfg.apiPort + 3} make e2e-cold\n` +
+      `\n` +
+      `  Check: ${SELF}`,
+  );
+}
+
+function checkPgPassword() {
+  checksRun++;
+  const blocked = needsPgPassword({
+    env: process.env,
+    runPsql: () =>
+      execFileSync("psql", ["-h", "localhost", "-U", "postgres", "-At", "-c", "SELECT 1", "postgres"], {
+        stdio: ["ignore", "pipe", "pipe"],
+        timeout: 5000,
+      }),
+  });
+  if (!blocked) return;
+
+  fail(
+    `POSTGRES REQUIRES A PASSWORD AND PGPASSWORD IS UNSET (spec-512 dec-3)\n` +
+      `\n` +
+      `  Connecting as postgres@localhost failed asking for a password, and\n` +
+      `  PGPASSWORD is not set in this environment.\n` +
+      `\n` +
+      `  make e2e-cold's dropdb/createdb steps carry no password (its psql -f steps\n` +
+      `  embed one in the URL, which is why those work). Without PGPASSWORD they\n` +
+      `  block on a hidden "Password:" prompt that prints NOTHING — the run looks\n` +
+      `  like a slow build and hangs forever.\n` +
+      `\n` +
+      `  Fix:\n` +
+      `    PGPASSWORD=postgres make e2e-cold\n` +
+      `\n` +
+      `  Check: ${SELF}`,
+  );
+}
+
+function checkSharedBuild(repoRoot) {
+  checksRun++;
+  const dist = join(repoRoot, "packages", "shared", "dist");
+  const src = join(repoRoot, "packages", "shared", "src");
+  if (!existsSync(src)) return; // layout changed — say nothing rather than guess
+  const verdict = isStaleBuild(dist, src);
+  if (!verdict.stale) return;
+
+  const detail =
+    verdict.reason === "missing"
+      ? "packages/shared/dist does not exist"
+      : verdict.reason === "empty"
+        ? "packages/shared/dist is empty"
+        : `packages/shared/src is newer than packages/shared/dist ` +
+          `(src ${new Date(verdict.srcTime).toISOString()} > dist ${new Date(verdict.distTime).toISOString()})`;
+
+  fail(
+    `@memex/shared BUILD IS STALE (spec-512 dec-3)\n` +
+      `\n` +
+      `  ${detail}.\n` +
+      `\n` +
+      `  The UI imports @memex/shared from its dist. When dist is missing an export\n` +
+      `  the UI now uses, the browser throws a module-load SyntaxError, React never\n` +
+      `  mounts, and EVERY journey fails identically with a generic "heading not\n` +
+      `  found" timeout — the real error is only visible inside trace.zip. That\n` +
+      `  looks exactly like a broken test and costs an afternoon.\n` +
+      `\n` +
+      `  Fix:\n` +
+      `    pnpm --filter @memex/shared build\n` +
+      `\n` +
+      `  Check: ${SELF}`,
+  );
+}
+
+function checkEmissionTarget() {
+  checksRun++;
+  const emit = process.env.MEMEX_EMIT;
+  const off = emit === "off" || emit === "false" || emit === "0";
+  if (off) return;
+  if (!process.env.MEMEX_EMIT_KEY) {
+    // No key: emissions are rejected 401 and dropped. Informational, not fatal —
+    // the run is still honest about the code under test.
+    warnings.push(
+      `AC emission is on but MEMEX_EMIT_KEY is unset — events will be rejected 401\n` +
+        `  and silently dropped, so no AC will verify from this run. Proceeding.\n` +
+        `  Silence it with: MEMEX_EMIT=off make e2e-cold`,
+    );
+    return;
+  }
+  warnings.push(
+    `AC emission is ON with a key set — this run will POST REAL test_events to the\n` +
+      `  configured Memex (production memex.ai unless overridden). Proceeding.\n` +
+      `  Suppress with: MEMEX_EMIT=off make e2e-cold`,
+  );
+}
+
+// ── Entrypoint ───────────────────────────────────────────────────────────────
+
+async function main() {
+  const repoRoot = process.env.MEMEX_WORKSPACE_ROOT ?? process.cwd();
+  const cfg = resolveE2eConfig(process.env, repoRoot);
+
+  await checkPortOwnership(cfg);
+  checkPgPassword();
+  checkSharedBuild(repoRoot);
+  checkEmissionTarget();
+
+  // Guard against the lie this whole Spec exists to eliminate: a preflight that
+  // examined nothing would otherwise print a clean bill of health.
+  if (checksRun === 0) {
+    process.stderr.write(
+      `e2e-preflight ran ZERO checks — that is a defect in the preflight itself,\n` +
+        `not a clean run. Check: ${SELF}\n`,
+    );
+    return 2;
+  }
+
+  for (const w of warnings) process.stdout.write(`⚠ ${w}\n\n`);
+
+  if (failures.length > 0) {
+    process.stderr.write(`\n${failures.join("\n\n")}\n\n`);
+    process.stderr.write(
+      `e2e preflight FAILED — ${failures.length} of ${checksRun} checks tripped. ` +
+        `Refusing to start a run that could report a false pass.\n`,
+    );
+    return 1;
+  }
+
+  process.stdout.write(
+    `✓ e2e preflight passed (${checksRun} checks) — workspace ${cfg.workspaceId}, ` +
+      `api:${cfg.apiPort} ui:${cfg.uiPort} db:${cfg.databaseName}\n`,
+  );
+  return 0;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().then((code) => process.exit(code));
+}

--- a/scripts/ci/e2e-preflight.mjs
+++ b/scripts/ci/e2e-preflight.mjs
@@ -31,7 +31,7 @@
 import { execFileSync } from "node:child_process";
 import { existsSync, readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
-import { resolveE2eConfig, resolveWorkspaceId } from "./workspace-alloc.mjs";
+import { resolveE2eConfig } from "./workspace-alloc.mjs";
 
 const SELF = "scripts/ci/e2e-preflight.mjs";
 

--- a/scripts/ci/e2e-preflight.mjs
+++ b/scripts/ci/e2e-preflight.mjs
@@ -110,10 +110,22 @@ function fail(message) {
   failures.push(message);
 }
 
-async function checkPortOwnership(cfg) {
+// Playwright's webServer block has TWO entries — the API server AND the Vite UI
+// server — and `reuseExistingServer` applies to BOTH. Checking only the API port
+// leaves the exact same silent lie available through the other door: a free API
+// port and a foreign UI port means Playwright boots our API, reuses THEIR UI, and
+// the journeys drive another workspace's bundle. (Found by adversarial review of
+// the first cut of this file, which probed only the API port and merely PRINTED
+// the UI port in its success line — the reassuring-but-unchecked shape this whole
+// Spec exists to eliminate.)
+//
+// The UI port is a Vite dev server with no /api/health of its own, but it PROXIES
+// /api/* to whichever API it was configured against — so probing health through it
+// answers the sharper question: which API is this UI actually wired to?
+async function checkPortOwnership(cfg, { port, label }) {
   checksRun++;
   const verdict = await classifyPortOwner({
-    port: cfg.apiPort,
+    port,
     expectedWorkspaceId: cfg.workspaceId,
     probe: httpHealth,
   });
@@ -126,21 +138,22 @@ async function checkPortOwnership(cfg) {
       : `a server belonging to workspace ${verdict.seen ?? "(unparseable)"}`;
 
   fail(
-    `E2E PORT BELONGS TO ANOTHER WORKSPACE (spec-512 dec-3)\n` +
+    `E2E ${label} PORT BELONGS TO ANOTHER WORKSPACE (spec-512 dec-3)\n` +
       `\n` +
-      `  Port ${cfg.apiPort} is already held by ${owner}.\n` +
+      `  Port ${port} (the ${label} server) is already held by ${owner}.\n` +
       `  This workspace is ${cfg.workspaceRoot} (id ${cfg.workspaceId}).\n` +
       `\n` +
-      `  Playwright is configured with reuseExistingServer, so it would have REUSED\n` +
-      `  that server instead of starting this checkout's. Your journeys would have\n` +
-      `  run against the OTHER workspace's code and the OTHER workspace's database,\n` +
-      `  and reported a PASS. Nothing you just changed would have been tested.\n` +
+      `  Playwright is configured with reuseExistingServer for BOTH its API and UI\n` +
+      `  servers, so it would have REUSED that one instead of starting this\n` +
+      `  checkout's. Your journeys would have run against the OTHER workspace's code\n` +
+      `  and the OTHER workspace's database, and reported a PASS. Nothing you just\n` +
+      `  changed would have been tested.\n` +
       `\n` +
       `  Fix — free the port by stopping whatever holds it:\n` +
-      `    lsof -ti tcp:${cfg.apiPort} | xargs kill\n` +
+      `    kill $(lsof -ti tcp:${port})\n` +
       `\n` +
-      `  Or leave it running and give this run its own adjacent pair:\n` +
-      `    E2E_SERVER_PORT=${cfg.apiPort + 2} E2E_UI_PORT=${cfg.apiPort + 3} make e2e-cold\n` +
+      `  Or leave it running and give this run its own pair:\n` +
+      `    E2E_SERVER_PORT=${cfg.apiPort + 100} E2E_UI_PORT=${cfg.uiPort + 100} make e2e-cold\n` +
       `\n` +
       `  Check: ${SELF}`,
   );
@@ -238,7 +251,8 @@ async function main() {
   const repoRoot = process.env.MEMEX_WORKSPACE_ROOT ?? process.cwd();
   const cfg = resolveE2eConfig(process.env, repoRoot);
 
-  await checkPortOwnership(cfg);
+  await checkPortOwnership(cfg, { port: cfg.apiPort, label: "API" });
+  await checkPortOwnership(cfg, { port: cfg.uiPort, label: "UI" });
   checkPgPassword();
   checkSharedBuild(repoRoot);
   checkEmissionTarget();

--- a/scripts/ci/prove-concurrent-workspaces.sh
+++ b/scripts/ci/prove-concurrent-workspaces.sh
@@ -199,9 +199,38 @@ if [ "${PROVE_E2E:-0}" = "1" ]; then
   ( cd "$WORKTREE_DIR"  && PGPASSWORD=postgres MEMEX_EMIT=off make e2e-cold >/tmp/ac1-e2e-b.log 2>&1 ) & B_PID=$!
   wait $A_PID; RC_A=$?
   wait $B_PID; RC_B=$?
-  { [ $RC_A -eq 0 ] && [ $RC_B -eq 0 ]; } \
-    && pass "both e2e suites passed concurrently" \
-    || fail "concurrent e2e failed (A=$RC_A B=$RC_B)" "see /tmp/ac1-e2e-a.log and /tmp/ac1-e2e-b.log"
+
+  # What this tier can and cannot conclude.
+  #
+  # A pre-existing red journey makes both suites exit non-zero, and blaming that
+  # on concurrency would be a false accusation in the same family as the false
+  # passes this Spec exists to remove — a harness must not claim a collision it
+  # did not observe. So: report the counts, and name the failures each side saw.
+  # Only failures unique to ONE side can plausibly be interference; a journey that
+  # fails identically in both is a property of the branch, not of running two.
+  #
+  # Observed 2026-07-27: A 137 passed/1 failed, B 136 passed/2 failed. The shared
+  # failure (journey-45) reproduces on clean `develop` against a cold DB with no
+  # spec-512 code present — filed as issue-6, unrelated to concurrency.
+  fails_of() {
+    grep -oE '\[chromium\] › e2e/journey-[^ ]+\.spec\.ts:[0-9]+:[0-9]+' "$1" 2>/dev/null \
+      | sort -u
+  }
+  A_FAILS=$(fails_of /tmp/ac1-e2e-a.log); B_FAILS=$(fails_of /tmp/ac1-e2e-b.log)
+  ONLY_ONE_SIDE=$(comm -3 <(echo "$A_FAILS") <(echo "$B_FAILS") | tr -d '\t' | sed '/^$/d')
+
+  printf '    A: %s\n' "$(grep -cE '^\s+[0-9]+ passed' /tmp/ac1-e2e-a.log >/dev/null && grep -oE '[0-9]+ passed \([^)]*\)' /tmp/ac1-e2e-a.log | tail -1)"
+  printf '    B: %s\n' "$(grep -oE '[0-9]+ passed \([^)]*\)' /tmp/ac1-e2e-b.log | tail -1)"
+
+  if [ $RC_A -eq 0 ] && [ $RC_B -eq 0 ]; then
+    pass "both e2e suites passed concurrently"
+  elif [ -z "$ONLY_ONE_SIDE" ]; then
+    pass "both suites ran to completion concurrently; every failure was common to BOTH (pre-existing, not interference) — verify each against a solo run"
+    printf '      shared failures: %s\n' "$(echo "$A_FAILS" | tr '\n' ' ')"
+  else
+    fail "failure(s) unique to ONE workspace — possible interference" \
+      "$(echo "$ONLY_ONE_SIDE" | tr '\n' ' ') | logs: /tmp/ac1-e2e-a.log /tmp/ac1-e2e-b.log"
+  fi
 else
   echo "  ⚠ SKIPPED (opt-in). This tier is the fullest form of the claim —"
   echo "    tiers 1-3 prove allocation, binding and identity, not a whole suite."

--- a/scripts/ci/prove-concurrent-workspaces.sh
+++ b/scripts/ci/prove-concurrent-workspaces.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # spec-512 ac-1 — PROVE two working copies run concurrently without collisions.
 #
-# The motivating brief is blunt about why this script exists rather than a
+# The motivating guidance is blunt about why this script exists rather than a
 # paragraph of reasoning: "Shared state hides in unexpected places. You will only
 # find this by genuinely running two copies at once." Every collision spec-512
 # fixed was found that way, and the two that were merely reasoned about (the dev

--- a/scripts/ci/prove-concurrent-workspaces.sh
+++ b/scripts/ci/prove-concurrent-workspaces.sh
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+# spec-512 ac-1 — PROVE two working copies run concurrently without collisions.
+#
+# The motivating brief is blunt about why this script exists rather than a
+# paragraph of reasoning: "Shared state hides in unexpected places. You will only
+# find this by genuinely running two copies at once." Every collision spec-512
+# fixed was found that way, and the two that were merely reasoned about (the dev
+# ports, and `make e2e` vs `make e2e-cold`) were both wrong until an independent
+# reviewer actually ran them.
+#
+# So this does not inspect config. It provisions a second working copy, starts
+# real servers in both, and drives real HTTP at them, concurrently.
+#
+# Re-runnable and self-cleaning: the throwaway worktree, its databases and every
+# process are removed on exit, including on failure (trap).
+#
+#   bash scripts/ci/prove-concurrent-workspaces.sh          # tiers 1-3 (fast, ~1 min)
+#   PROVE_E2E=1 bash scripts/ci/prove-concurrent-workspaces.sh   # + tier 4 (slow)
+#
+# Tier 4 runs two full Playwright suites at once. It is opt-in because it takes
+# many minutes and needs a Postgres that can seat both.
+
+set -uo pipefail
+
+SELF="scripts/ci/prove-concurrent-workspaces.sh"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORKTREE_DIR="${PROVE_WORKTREE_DIR:-/tmp/memex-ac1-proof}"
+WORKTREE_BRANCH="spec-512-ac1-proof-$$"
+PGHOST="${PGHOST:-localhost}"
+PGUSER="${PGUSER:-postgres}"
+
+PIDS=()
+OWNED_PORTS=()   # every port this script binds; cleanup frees exactly these
+FAILURES=0
+CHECKS=0
+
+# ── output ───────────────────────────────────────────────────────────────────
+pass() { CHECKS=$((CHECKS + 1)); printf '  ✓ %s\n' "$1"; }
+fail() {
+  CHECKS=$((CHECKS + 1))
+  FAILURES=$((FAILURES + 1))
+  printf '  ✗ %s\n' "$1"
+  [ $# -gt 1 ] && printf '      %s\n' "$2"
+}
+section() { printf '\n▶ %s\n' "$1"; }
+
+cleanup() {
+  local code=$?
+  section "Cleanup"
+  # Kill by PORT, not by process group. `kill -- -PGID` would take down this
+  # script too: the background servers share its process group, so the first
+  # cleanup attempt killed the runner mid-teardown (exit 144). Ports are the
+  # precise handle — and they also catch the grandchildren pnpm spawns, which a
+  # bare `kill $pid` leaves orphaned holding the port.
+  for port in "${OWNED_PORTS[@]:-}"; do
+    [ -n "${port:-}" ] && lsof -ti tcp:"$port" 2>/dev/null | xargs -r kill 2>/dev/null
+  done
+  sleep 1
+  for port in "${OWNED_PORTS[@]:-}"; do
+    [ -n "${port:-}" ] && lsof -ti tcp:"$port" 2>/dev/null | xargs -r kill -9 2>/dev/null
+  done
+  if [ -d "$WORKTREE_DIR" ]; then
+    local wdb
+    wdb=$(cd "$WORKTREE_DIR" 2>/dev/null && node scripts/ci/workspace-alloc.mjs e2e-database-name 2>/dev/null)
+    local wtpl
+    wtpl=$(cd "$WORKTREE_DIR" 2>/dev/null && node scripts/ci/workspace-alloc.mjs e2e-template-name 2>/dev/null)
+    for db in "$wdb" "$wtpl"; do
+      [ -n "${db:-}" ] && dropdb --if-exists --force -h "$PGHOST" -U "$PGUSER" "$db" 2>/dev/null
+    done
+    git -C "$REPO_ROOT" worktree remove --force "$WORKTREE_DIR" 2>/dev/null
+  fi
+  git -C "$REPO_ROOT" branch -D "$WORKTREE_BRANCH" 2>/dev/null >/dev/null
+  echo "  worktree, databases and processes removed"
+  exit $code
+}
+trap cleanup EXIT INT TERM
+
+# Wait for an HTTP endpoint, up to N seconds. Returns 1 on timeout.
+wait_for_http() {
+  local url=$1 secs=${2:-60} i=0
+  while [ $i -lt "$secs" ]; do
+    curl -sf --max-time 2 "$url" >/dev/null 2>&1 && return 0
+    sleep 1
+    i=$((i + 1))
+  done
+  return 1
+}
+
+printf '═══ spec-512 ac-1: concurrent-workspace proof ═══\n'
+printf 'workspace A: %s\n' "$REPO_ROOT"
+
+# ── Provision the second working copy ────────────────────────────────────────
+section "Provisioning workspace B"
+git -C "$REPO_ROOT" worktree remove --force "$WORKTREE_DIR" 2>/dev/null
+rm -rf "$WORKTREE_DIR"
+if ! git -C "$REPO_ROOT" worktree add -b "$WORKTREE_BRANCH" "$WORKTREE_DIR" HEAD >/dev/null 2>&1; then
+  echo "  ✗ could not create worktree at $WORKTREE_DIR"; exit 1
+fi
+printf 'workspace B: %s\n' "$WORKTREE_DIR"
+# Install for real — ~3s against the shared pnpm store. The first version of this
+# script symlinked workspace A's node_modules instead, and workspace B's server
+# then died with `tsx: command not found`: a root symlink does not provide the
+# per-package .bin shims. That produced a FALSE ac-1 failure — the proof harness
+# lying about the thing it exists to measure. Provision the way a developer does.
+echo "  installing dependencies (shared pnpm store)…"
+if ! ( cd "$WORKTREE_DIR" && pnpm install --prefer-offline --ignore-scripts >/dev/null 2>&1 ); then
+  echo "  ✗ pnpm install failed in workspace B — cannot run the proof"; exit 1
+fi
+# @memex/shared is built, not compiled on demand; copy A's dist so B's UI resolves
+# the same exports (the alternative is a second full build for no extra signal).
+[ -d "$REPO_ROOT/packages/shared/dist" ] && cp -R "$REPO_ROOT/packages/shared/dist" "$WORKTREE_DIR/packages/shared/dist" 2>/dev/null
+
+alloc_a() { (cd "$REPO_ROOT" && node scripts/ci/workspace-alloc.mjs "$1"); }
+alloc_b() { (cd "$WORKTREE_DIR" && node scripts/ci/workspace-alloc.mjs "$1"); }
+
+# ── TIER 1: allocations must not overlap ─────────────────────────────────────
+section "Tier 1 — derived allocations are disjoint"
+ID_A=$(alloc_a workspace-id);        ID_B=$(alloc_b workspace-id)
+[ "$ID_A" != "$ID_B" ] \
+  && pass "workspace ids differ ($ID_A vs $ID_B)" \
+  || fail "workspace ids COLLIDE ($ID_A)" "both copies would claim the same identity"
+
+PORTS_A=$(alloc_a e2e-api-port)" "$(alloc_a e2e-ui-port)" "$(alloc_a dev-api-port)" "$(alloc_a dev-ui-port)
+PORTS_B=$(alloc_b e2e-api-port)" "$(alloc_b e2e-ui-port)" "$(alloc_b dev-api-port)" "$(alloc_b dev-ui-port)
+OVERLAP=$(comm -12 <(tr ' ' '\n' <<<"$PORTS_A" | sort -u) <(tr ' ' '\n' <<<"$PORTS_B" | sort -u))
+[ -z "$OVERLAP" ] \
+  && pass "all 8 ports disjoint (A: $PORTS_A | B: $PORTS_B)" \
+  || fail "PORT COLLISION: $(tr '\n' ' ' <<<"$OVERLAP")" "one copy's server would answer the other's tests"
+
+DB_A=$(alloc_a e2e-database-name);   DB_B=$(alloc_b e2e-database-name)
+TPL_A=$(alloc_a e2e-template-name);  TPL_B=$(alloc_b e2e-template-name)
+{ [ "$DB_A" != "$DB_B" ] && [ "$TPL_A" != "$TPL_B" ]; } \
+  && pass "e2e databases + templates disjoint ($DB_A vs $DB_B)" \
+  || fail "DATABASE COLLISION ($DB_A / $DB_B)" "one run's dropdb would destroy the other's data mid-run"
+
+# ── TIER 2: two dev servers, actually running, at the same time ──────────────
+# This is the half of ac-1 that was FALSE until the dev ports were wired: the
+# allocator computed them but nothing read them, so both copies bound 8080 and
+# Vite's strictPort killed the second.
+section "Tier 2 — two dev servers bound concurrently"
+DEV_A=$(alloc_a dev-api-port); DEV_B=$(alloc_b dev-api-port)
+OWNED_PORTS+=("$DEV_A" "$DEV_B")
+# DATABASE_URL is passed explicitly: packages/server/.env is gitignored, so a
+# fresh worktree has none and the server throws at import. (That failure is loud
+# and well-messaged, so it is not a silent-lie trap — but it does mean a new
+# worktree cannot `make dev` until its .env exists. Noted, out of scope here.)
+# Both dev servers share the dev database on purpose: `make dev` has always done
+# so, and spec-512 derived the E2E databases, not the dev one.
+DEV_DB="${PROVE_DEV_DATABASE_URL:-postgresql://postgres:postgres@localhost:5432/memex}"
+for spec in "A:$REPO_ROOT:$DEV_A:$ID_A" "B:$WORKTREE_DIR:$DEV_B:$ID_B"; do
+  IFS=: read -r name dir port wsid <<<"$spec"
+  ( cd "$dir" && MEMEX_WORKSPACE_ID="$wsid" PORT="$port" GOOGLE_CLIENT_ID="" \
+      DATABASE_URL="$DEV_DB" SLACK_TOKEN_ENCRYPTION=plaintext \
+      pnpm --filter @memex/server dev >"/tmp/ac1-dev-$name.log" 2>&1 ) &
+  PIDS+=($!)
+done
+
+BOOTED=0
+for spec in "A:$DEV_A" "B:$DEV_B"; do
+  IFS=: read -r name port <<<"$spec"
+  if wait_for_http "http://localhost:$port/api/health" 75; then
+    BOOTED=$((BOOTED + 1))
+  else
+    fail "workspace $name dev server never bound :$port" \
+      "$(tail -3 "/tmp/ac1-dev-$name.log" 2>/dev/null | tr '\n' ' ' || echo 'no log')"
+  fi
+done
+[ "$BOOTED" -eq 2 ] && pass "both dev servers live simultaneously (:$DEV_A and :$DEV_B)"
+
+# ── TIER 3: each server proves WHICH copy it belongs to ──────────────────────
+# Identity is what makes a foreign server refusable rather than adoptable.
+section "Tier 3 — each server reports its own workspace identity"
+if [ "$BOOTED" -eq 2 ]; then
+  SEEN_A=$(curl -s --max-time 3 "http://localhost:$DEV_A/api/health" | sed -n 's/.*"workspace":"\([^"]*\)".*/\1/p')
+  SEEN_B=$(curl -s --max-time 3 "http://localhost:$DEV_B/api/health" | sed -n 's/.*"workspace":"\([^"]*\)".*/\1/p')
+  { [ "$SEEN_A" = "$ID_A" ] && [ "$SEEN_B" = "$ID_B" ] && [ "$SEEN_A" != "$SEEN_B" ]; } \
+    && pass "servers self-identify correctly and distinctly ($SEEN_A / $SEEN_B)" \
+    || fail "identity mismatch (A reported '$SEEN_A' want '$ID_A'; B reported '$SEEN_B' want '$ID_B')" \
+            "without distinct identity the preflight cannot tell a foreign server from its own"
+
+  # The load-bearing negative: B's preflight must REFUSE A's server.
+  OUT=$( cd "$WORKTREE_DIR" && MEMEX_EMIT=off E2E_SERVER_PORT="$DEV_A" \
+           node scripts/ci/e2e-preflight.mjs 2>&1 )
+  if grep -q "BELONGS TO ANOTHER WORKSPACE" <<<"$OUT"; then
+    pass "workspace B's preflight REFUSES workspace A's live server"
+  else
+    fail "workspace B's preflight ACCEPTED workspace A's server" \
+      "this is the original silent-adoption bug — B would test A's code and pass"
+  fi
+else
+  fail "skipped — dev servers did not both boot" "cannot test identity without two live servers"
+fi
+
+# ── TIER 4 (opt-in): two full e2e suites at once ─────────────────────────────
+section "Tier 4 — concurrent e2e suites"
+if [ "${PROVE_E2E:-0}" = "1" ]; then
+  echo "  running two full Playwright suites concurrently (slow)…"
+  ( cd "$REPO_ROOT"     && PGPASSWORD=postgres MEMEX_EMIT=off make e2e-cold >/tmp/ac1-e2e-a.log 2>&1 ) & A_PID=$!
+  ( cd "$WORKTREE_DIR"  && PGPASSWORD=postgres MEMEX_EMIT=off make e2e-cold >/tmp/ac1-e2e-b.log 2>&1 ) & B_PID=$!
+  wait $A_PID; RC_A=$?
+  wait $B_PID; RC_B=$?
+  { [ $RC_A -eq 0 ] && [ $RC_B -eq 0 ]; } \
+    && pass "both e2e suites passed concurrently" \
+    || fail "concurrent e2e failed (A=$RC_A B=$RC_B)" "see /tmp/ac1-e2e-a.log and /tmp/ac1-e2e-b.log"
+else
+  echo "  ⚠ SKIPPED (opt-in). This tier is the fullest form of the claim —"
+  echo "    tiers 1-3 prove allocation, binding and identity, not a whole suite."
+  echo "    Run it with: PROVE_E2E=1 bash $SELF"
+fi
+
+# ── Verdict ──────────────────────────────────────────────────────────────────
+section "Verdict"
+if [ "$CHECKS" -eq 0 ]; then
+  echo "  ✗ ZERO checks ran — that is a defect in this script, not a clean result."
+  echo "    Check: $SELF"
+  exit 2
+fi
+if [ "$FAILURES" -gt 0 ]; then
+  printf '  ✗ ac-1 NOT PROVEN — %d of %d checks failed.\n' "$FAILURES" "$CHECKS"
+  printf '    Two working copies cannot yet run concurrently without collisions.\n'
+  printf '    Check: %s\n' "$SELF"
+  exit 1
+fi
+printf '  ✓ ac-1 HOLDS for the tiers run — %d/%d checks passed.\n' "$CHECKS" "$CHECKS"
+[ "${PROVE_E2E:-0}" = "1" ] || printf '    (tier 4, concurrent full e2e, was skipped — see above)\n'
+exit 0

--- a/scripts/ci/standards-index.d.mts
+++ b/scripts/ci/standards-index.d.mts
@@ -1,0 +1,19 @@
+// Types for standards-index.mjs (spec-512 dec-4). See workspace-alloc.d.mts for
+// why the implementation is an untyped `.mjs` and this declaration exists.
+
+export const BEGIN: string;
+export const END: string;
+
+export interface StandardEntry {
+  handle: string;
+  summary: string;
+}
+
+export function renderTable(standards: StandardEntry[]): string;
+
+/** Byte offsets of every generated region. Throws on unbalanced, orphaned,
+ *  out-of-order or nested markers rather than rewriting part of the file. */
+export function findRegions(text: string): Array<{ start: number; end: number }>;
+
+/** Replace the body of EVERY generated region — never only the first. */
+export function applyRegions(text: string, body: string): string;

--- a/scripts/ci/standards-index.mjs
+++ b/scripts/ci/standards-index.mjs
@@ -1,0 +1,190 @@
+// The CLAUDE.md standards index is GENERATED (spec-512 dec-4).
+//
+//   node scripts/ci/standards-index.mjs --check   # staleness gate (offline lane)
+//   node scripts/ci/standards-index.mjs --write   # regenerate  (`make standards-gen`)
+//
+// Why this exists: the index was hand-maintained, and it drifted — std-38, std-39,
+// std-40, std-41 and std-42 were all approved in Memex and simply absent from the
+// table agents orient from at session start. A Standard nobody can find from the
+// codebase pointer is not binding anyone's behaviour. The pre-existing guard
+// (spec-172-e2e-standard-index) pinned that ONE row (std-28) existed; nothing
+// enforced completeness, so adding a Standard left the pointer stale with nothing red.
+//
+// Source of truth chain:
+//   Memex (authoritative)  --agent, online-->  standards.manifest.json (committed)
+//   standards.manifest.json  --this script-->  the CLAUDE.md table
+//
+// The manifest is the OFFLINE authority on purpose: CI holds no Memex credentials
+// and the fast lane must not need the network. Manifest-vs-Memex drift is a
+// separate online concern; an offline PR must never fail because a network call
+// was unavailable.
+//
+// ── Marker handling ──────────────────────────────────────────────────────────
+// This introduces the repo's FIRST BEGIN/END generated region (every other
+// generated artifact here is whole-file with a prose banner), so it is written
+// against the documented failure mode: a generator that rewrites only the FIRST
+// marked block passes its own check while leaving the file broken. This one
+// rewrites EVERY region and rejects duplicate, orphaned, unmatched or
+// out-of-order markers rather than guessing.
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SELF = "scripts/ci/standards-index.mjs";
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const CLAUDE_MD = join(ROOT, "CLAUDE.md");
+const MANIFEST = join(ROOT, "standards.manifest.json");
+
+export const BEGIN = "<!-- BEGIN generated: standards-index -->";
+export const END = "<!-- END generated: standards-index -->";
+
+/** Render the manifest as the markdown table body (no surrounding markers). */
+export function renderTable(standards) {
+  const lines = ["| Standard | Covers |", "|---|---|"];
+  for (const s of standards) lines.push(`| ${s.handle} | ${s.summary} |`);
+  return lines.join("\n");
+}
+
+/** Locate every generated region. Throws with a contract-shaped message on any
+ *  malformed marker rather than silently rewriting part of the file. */
+export function findRegions(text) {
+  const begins = [...text.matchAll(new RegExp(escapeRe(BEGIN), "g"))].map((m) => m.index);
+  const ends = [...text.matchAll(new RegExp(escapeRe(END), "g"))].map((m) => m.index);
+
+  if (begins.length !== ends.length) {
+    throw new Error(
+      `Unbalanced generated markers in CLAUDE.md — ${begins.length} BEGIN vs ${ends.length} END.\n` +
+        `  An orphaned marker means a partial rewrite would corrupt the file, so nothing was written.\n` +
+        `  Fix: restore the matching marker, or delete the orphan, then re-run:\n` +
+        `    make standards-gen\n` +
+        `  Check: ${SELF}`,
+    );
+  }
+  if (begins.length === 0) {
+    throw new Error(
+      `No generated region found in CLAUDE.md.\n` +
+        `  Expected a block delimited by:\n    ${BEGIN}\n    ${END}\n` +
+        `  Fix: re-add the markers around the standards table, then run:\n` +
+        `    make standards-gen\n` +
+        `  Check: ${SELF}`,
+    );
+  }
+  const regions = [];
+  for (let i = 0; i < begins.length; i++) {
+    if (ends[i] < begins[i]) {
+      throw new Error(
+        `Generated markers are out of order in CLAUDE.md (END at ${ends[i]} precedes BEGIN at ${begins[i]}).\n` +
+          `  Fix: correct the marker order, then run:\n    make standards-gen\n` +
+          `  Check: ${SELF}`,
+      );
+    }
+    if (i > 0 && begins[i] < ends[i - 1]) {
+      throw new Error(
+        `Nested generated regions in CLAUDE.md (region ${i + 1} starts inside region ${i}).\n` +
+          `  Fix: unnest the markers, then run:\n    make standards-gen\n` +
+          `  Check: ${SELF}`,
+      );
+    }
+    regions.push({ start: begins[i], end: ends[i] + END.length });
+  }
+  return regions;
+}
+
+function escapeRe(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/** Rewrite EVERY generated region — never just the first. */
+export function applyRegions(text, body) {
+  const regions = findRegions(text);
+  const block = `${BEGIN}\n${body}\n${END}`;
+  let out = "";
+  let cursor = 0;
+  for (const r of regions) {
+    out += text.slice(cursor, r.start) + block;
+    cursor = r.end;
+  }
+  return out + text.slice(cursor);
+}
+
+function loadManifest() {
+  const parsed = JSON.parse(readFileSync(MANIFEST, "utf8"));
+  const standards = parsed.standards ?? [];
+  if (standards.length === 0) {
+    throw new Error(
+      `standards.manifest.json lists ZERO standards — refusing to generate an empty index.\n` +
+        `  An empty manifest would silently blank the table agents orient from.\n` +
+        `  Fix: refresh it from Memex (search_memex({kind:'standard'})), then:\n` +
+        `    make standards-gen\n` +
+        `  Check: ${SELF}`,
+    );
+  }
+  return standards;
+}
+
+function main(argv) {
+  const mode = argv.includes("--write") ? "write" : "check";
+  const standards = loadManifest();
+  const current = readFileSync(CLAUDE_MD, "utf8");
+  const next = applyRegions(current, renderTable(standards));
+
+  if (mode === "write") {
+    if (next === current) {
+      process.stdout.write(`✓ CLAUDE.md standards index already current (${standards.length} standards)\n`);
+      return 0;
+    }
+    writeFileSync(CLAUDE_MD, next);
+    process.stdout.write(
+      `✓ regenerated the CLAUDE.md standards index from standards.manifest.json ` +
+        `(${standards.length} standards)\n`,
+    );
+    return 0;
+  }
+
+  if (next !== current) {
+    const inFile = new Set(
+      [...current.matchAll(/^\|\s*(std-\d+)\s*\|/gm)].map((m) => m[1]),
+    );
+    const inManifest = standards.map((s) => s.handle);
+    const missing = inManifest.filter((h) => !inFile.has(h));
+    const extra = [...inFile].filter((h) => !inManifest.includes(h));
+
+    process.stderr.write(
+      `CLAUDE.md STANDARDS INDEX IS STALE (spec-512 dec-4)\n` +
+        `\n` +
+        `  The generated table does not match standards.manifest.json.\n` +
+        `  Manifest lists ${inManifest.length} standards; CLAUDE.md's table has ${inFile.size}.\n` +
+        (missing.length
+          ? `  Missing from CLAUDE.md: ${missing.join(", ")}\n`
+          : "") +
+        (extra.length ? `  In CLAUDE.md but not the manifest: ${extra.join(", ")}\n` : "") +
+        (!missing.length && !extra.length
+          ? `  Same handles, but one or more summaries differ.\n`
+          : "") +
+        `\n` +
+        `  CLAUDE.md is how an agent discovers which rules bind it. A Standard that is\n` +
+        `  approved but absent from this table is not binding anyone's behaviour.\n` +
+        `\n` +
+        `  Fix:\n` +
+        `    make standards-gen\n` +
+        `\n` +
+        `  Check: ${SELF}\n`,
+    );
+    return 1;
+  }
+
+  process.stdout.write(
+    `✓ CLAUDE.md standards index matches the manifest (${standards.length} standards)\n`,
+  );
+  return 0;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  try {
+    process.exit(main(process.argv.slice(2)));
+  } catch (err) {
+    process.stderr.write(`\n${err.message}\n`);
+    process.exit(2);
+  }
+}

--- a/scripts/ci/workspace-alloc.d.mts
+++ b/scripts/ci/workspace-alloc.d.mts
@@ -36,9 +36,6 @@ export function workspaceHash(workspaceRoot: string): string;
 export function derivePorts(workspaceRoot: string): WorkspacePorts;
 export function deriveE2eDbNames(workspaceRoot: string): E2eDbNames;
 export function withDatabase(baseUrl: string, databaseName: string): string;
-export function resolveWorkspaceId(
-  env?: Record<string, string | undefined>,
-): string | null;
 export function resolveE2eConfig(
   env?: Record<string, string | undefined>,
   workspaceRoot?: string,

--- a/scripts/ci/workspace-alloc.d.mts
+++ b/scripts/ci/workspace-alloc.d.mts
@@ -1,0 +1,43 @@
+// Types for workspace-alloc.mjs (spec-512 dec-3).
+//
+// The implementation is deliberately a zero-dependency `.mjs` so the Makefile can
+// shell out to it with no build step and no transpile, per dec-2 (the house
+// pattern set by scripts/check-url-shape.mjs and scripts/ci/deploy-gate.mjs).
+// This declaration exists so the TypeScript regression suite can import the pure
+// cores under `noImplicitAny` without an escape hatch.
+
+export interface WorkspacePorts {
+  e2eApi: number;
+  e2eUi: number;
+  dev: number;
+  devUi: number;
+}
+
+export interface E2eDbNames {
+  database: string;
+  template: string;
+}
+
+export interface E2eConfig {
+  workspaceRoot: string;
+  workspaceId: string;
+  apiPort: number;
+  uiPort: number;
+  databaseUrl: string;
+  templateUrl: string;
+  databaseName: string;
+  templateName: string;
+  usingOverride: boolean;
+}
+
+export function workspaceHash(workspaceRoot: string): string;
+export function derivePorts(workspaceRoot: string): WorkspacePorts;
+export function deriveE2eDbNames(workspaceRoot: string): E2eDbNames;
+export function withDatabase(baseUrl: string, databaseName: string): string;
+export function resolveWorkspaceId(
+  env?: Record<string, string | undefined>,
+): string | null;
+export function resolveE2eConfig(
+  env?: Record<string, string | undefined>,
+  workspaceRoot?: string,
+): E2eConfig;

--- a/scripts/ci/workspace-alloc.d.mts
+++ b/scripts/ci/workspace-alloc.d.mts
@@ -23,6 +23,8 @@ export interface E2eConfig {
   workspaceId: string;
   apiPort: number;
   uiPort: number;
+  devPort: number;
+  devUiPort: number;
   databaseUrl: string;
   templateUrl: string;
   databaseName: string;

--- a/scripts/ci/workspace-alloc.mjs
+++ b/scripts/ci/workspace-alloc.mjs
@@ -110,6 +110,9 @@ export function resolveE2eConfig(env = process.env, workspaceRoot = process.cwd(
     // and remain the escape hatch.
     apiPort: Number(env.E2E_SERVER_PORT ?? ports.e2eApi),
     uiPort: Number(env.E2E_UI_PORT ?? ports.e2eUi),
+    // `make dev` ports. PORT/VITE_PORT keep precedence, as they always have.
+    devPort: Number(env.PORT ?? ports.dev),
+    devUiPort: Number(env.VITE_PORT ?? ports.devUi),
     // An explicit E2E_DATABASE_URL is taken verbatim — someone naming a database
     // by hand means it, and silently rewriting it would be its own silent lie.
     databaseUrl: env.E2E_DATABASE_URL ?? withDatabase(baseUrl, names.database),
@@ -129,6 +132,13 @@ const FIELDS = {
   "workspace-id": (c) => c.workspaceId,
   "e2e-api-port": (c) => c.apiPort,
   "e2e-ui-port": (c) => c.uiPort,
+  // spec-512: derivePorts() always computed dev/devUi, but these two fields were
+  // never exposed, so nothing could read them and `make dev` stayed on hardcoded
+  // 8080/5173 with Vite's strictPort — a second worktree's dev server died
+  // EADDRINUSE. Adversarial review caught them as dead values: the intent was
+  // implemented and then not wired.
+  "dev-api-port": (c) => c.devPort,
+  "dev-ui-port": (c) => c.devUiPort,
   "e2e-database-url": (c) => c.databaseUrl,
   "e2e-template-url": (c) => c.templateUrl,
   "e2e-database-name": (c) => c.databaseName,

--- a/scripts/ci/workspace-alloc.mjs
+++ b/scripts/ci/workspace-alloc.mjs
@@ -86,14 +86,14 @@ export function withDatabase(baseUrl, databaseName) {
 
 // ── Env-aware resolution (overrides always win) ──────────────────────────────
 
-/** The workspace identity a server should advertise, or null when it should
- *  advertise nothing. Absent MEMEX_WORKSPACE_ID means "not a managed local
- *  workspace" — which is exactly the production posture, so /api/health stays
- *  byte-identical to what it has always returned. */
-export function resolveWorkspaceId(env = process.env) {
-  const explicit = env.MEMEX_WORKSPACE_ID;
-  return explicit && explicit.trim() !== "" ? explicit.trim() : null;
-}
+// NOTE: there is deliberately no `resolveWorkspaceId(env)` helper reading
+// MEMEX_WORKSPACE_ID. The preflight must derive the identity it EXPECTS from the
+// workspace path (`resolveE2eConfig().workspaceId`) and compare that against what
+// a running server advertises. Trusting the env var for both sides would compare
+// a value to itself and always agree — the check would pass while a foreign
+// server was adopted. (Flagged as dead code by adversarial review and by the
+// code-quality bot on PR #571; removed rather than wired in, because wiring it in
+// is the bug.)
 
 /** Effective e2e config, with every pre-existing override honoured ahead of the
  *  derivation so no current workflow breaks. */

--- a/scripts/ci/workspace-alloc.mjs
+++ b/scripts/ci/workspace-alloc.mjs
@@ -1,0 +1,163 @@
+// Per-workspace resource allocation (spec-512 dec-3).
+//
+// This repo is worked by parallel agents in many git worktrees at once (13 live
+// when this was written). The vitest tier already isolates itself — see
+// packages/server/src/db/test-db-url.ts, which derives `<base>_test_<sha1(root)[0:8]>`
+// — but the e2e tier did not, and that gap made a green run a lie:
+//
+//   * Makefile hardcoded `memex_e2e` / `memex_e2e_template`, so a second worktree's
+//     `dropdb --if-exists` destroyed the first one's database MID-RUN.
+//   * playwright.config.ts pinned ports 8090/5173 with `reuseExistingServer: !CI`,
+//     so a second worktree found those ports answering and SILENTLY reused the
+//     first worktree's servers — running its journeys against another branch's
+//     code and another branch's database, and reporting PASS.
+//
+// This module is the single allocator for both, so the Makefile and the Playwright
+// harness can never disagree about which database or port is in play. Two sources
+// of truth for a resource name is the exact class of bug being closed here.
+//
+// Every derivation is a pure function of the workspace root — deterministic,
+// idempotent, no scanning for free ports. A scan would make the allocation depend
+// on whatever else happened to be running, so the same workspace would get
+// different ports on different days and a failure would be unreproducible. A
+// genuine hash collision instead fails LOUDLY (see checkPortCollision) with the
+// override to set. Rare and diagnosable beats common and invisible.
+
+import { createHash } from "node:crypto";
+
+// ── Derivation ───────────────────────────────────────────────────────────────
+
+/** 8 hex chars of sha1(workspaceRoot). The stable identity of a working copy.
+ *  Deliberately a hash, never the path: it rides on /api/health, which is an
+ *  unauthenticated endpoint, so it must disclose nothing about the machine. */
+export function workspaceHash(workspaceRoot) {
+  return createHash("sha1").update(workspaceRoot).digest("hex").slice(0, 8);
+}
+
+// Port window: [PORT_BASE, PORT_BASE + PORT_SLOTS*PORTS_PER_SLOT) must stay
+// strictly below 49152, where macOS/BSD starts handing out ephemeral ports — a
+// derived port inside that range can be stolen by an unrelated outbound socket
+// between the preflight check and the server bind, producing exactly the
+// intermittent, unreproducible failure this module exists to prevent.
+//
+// The first draft used 10000 slots and topped out at 59999 — well INSIDE the
+// ephemeral range — while carrying a comment asserting the opposite. The
+// regression test's arithmetic caught it. The bound below is now asserted in
+// that test rather than trusted to prose: 20000 + 7000*4 = 48000 < 49152.
+//
+// 7000 slots keeps the birthday odds of two of ~20 concurrent worktrees
+// colliding near 0.3% — and a collision is caught loudly, not tolerated.
+const PORT_BASE = 20000;
+const PORT_SLOTS = 7000;
+const PORTS_PER_SLOT = 4;
+const EPHEMERAL_FLOOR = 49152;
+
+// Fail at import time rather than shipping a window that can be silently stolen.
+if (PORT_BASE + PORT_SLOTS * PORTS_PER_SLOT > EPHEMERAL_FLOOR) {
+  throw new Error(
+    `workspace-alloc: port window [${PORT_BASE}, ${PORT_BASE + PORT_SLOTS * PORTS_PER_SLOT}) ` +
+      `overlaps the ephemeral range (${EPHEMERAL_FLOOR}+). Derived ports could be stolen by the OS.\n` +
+      `  Fix: lower PORT_SLOTS so PORT_BASE + PORT_SLOTS*PORTS_PER_SLOT <= ${EPHEMERAL_FLOOR}.\n` +
+      `  Check: scripts/ci/workspace-alloc.mjs`,
+  );
+}
+
+/** Ports for one workspace: { e2eApi, e2eUi, dev, devUi }. Pure, deterministic. */
+export function derivePorts(workspaceRoot) {
+  const hash = workspaceHash(workspaceRoot);
+  const slot = Number.parseInt(hash, 16) % PORT_SLOTS;
+  const base = PORT_BASE + slot * PORTS_PER_SLOT;
+  return { e2eApi: base, e2eUi: base + 1, dev: base + 2, devUi: base + 3 };
+}
+
+/** e2e database names for one workspace. Postgres identifiers cap at 63 chars;
+ *  the longest of these is 26, so there is no truncation hazard. */
+export function deriveE2eDbNames(workspaceRoot) {
+  const hash = workspaceHash(workspaceRoot);
+  return { database: `memex_e2e_${hash}`, template: `memex_e2e_tpl_${hash}` };
+}
+
+/** Rewrite a Postgres URL's database name, preserving credentials/host/port/query. */
+export function withDatabase(baseUrl, databaseName) {
+  const url = new URL(baseUrl);
+  url.pathname = `/${databaseName}`;
+  return url.toString();
+}
+
+// ── Env-aware resolution (overrides always win) ──────────────────────────────
+
+/** The workspace identity a server should advertise, or null when it should
+ *  advertise nothing. Absent MEMEX_WORKSPACE_ID means "not a managed local
+ *  workspace" — which is exactly the production posture, so /api/health stays
+ *  byte-identical to what it has always returned. */
+export function resolveWorkspaceId(env = process.env) {
+  const explicit = env.MEMEX_WORKSPACE_ID;
+  return explicit && explicit.trim() !== "" ? explicit.trim() : null;
+}
+
+/** Effective e2e config, with every pre-existing override honoured ahead of the
+ *  derivation so no current workflow breaks. */
+export function resolveE2eConfig(env = process.env, workspaceRoot = process.cwd()) {
+  const ports = derivePorts(workspaceRoot);
+  const names = deriveE2eDbNames(workspaceRoot);
+  const baseUrl =
+    env.E2E_DATABASE_URL ?? "postgresql://postgres:postgres@localhost:5432/memex";
+
+  return {
+    workspaceRoot,
+    workspaceId: workspaceHash(workspaceRoot),
+    // E2E_UI_PORT / E2E_SERVER_PORT predate this module (playwright.config.ts:15,18)
+    // and remain the escape hatch.
+    apiPort: Number(env.E2E_SERVER_PORT ?? ports.e2eApi),
+    uiPort: Number(env.E2E_UI_PORT ?? ports.e2eUi),
+    // An explicit E2E_DATABASE_URL is taken verbatim — someone naming a database
+    // by hand means it, and silently rewriting it would be its own silent lie.
+    databaseUrl: env.E2E_DATABASE_URL ?? withDatabase(baseUrl, names.database),
+    templateUrl: withDatabase(baseUrl, names.template),
+    databaseName: env.E2E_DATABASE_URL
+      ? decodeURIComponent(new URL(env.E2E_DATABASE_URL).pathname.slice(1))
+      : names.database,
+    templateName: names.template,
+    usingOverride: Boolean(env.E2E_DATABASE_URL),
+  };
+}
+
+// ── CLI: `node scripts/ci/workspace-alloc.mjs <field>` ───────────────────────
+// The Makefile shells out to this so there is exactly one allocator.
+
+const FIELDS = {
+  "workspace-id": (c) => c.workspaceId,
+  "e2e-api-port": (c) => c.apiPort,
+  "e2e-ui-port": (c) => c.uiPort,
+  "e2e-database-url": (c) => c.databaseUrl,
+  "e2e-template-url": (c) => c.templateUrl,
+  "e2e-database-name": (c) => c.databaseName,
+  "e2e-template-name": (c) => c.templateName,
+};
+
+function main(argv) {
+  const field = argv[2];
+  const cfg = resolveE2eConfig(process.env, process.env.MEMEX_WORKSPACE_ROOT ?? process.cwd());
+
+  if (field === "--all" || field === undefined) {
+    for (const [name, get] of Object.entries(FIELDS)) {
+      process.stdout.write(`${name}=${get(cfg)}\n`);
+    }
+    return 0;
+  }
+  const get = FIELDS[field];
+  if (!get) {
+    process.stderr.write(
+      `workspace-alloc: unknown field "${field}".\n` +
+        `Known fields: ${Object.keys(FIELDS).join(", ")}\n` +
+        `  Check: scripts/ci/workspace-alloc.mjs\n`,
+    );
+    return 2;
+  }
+  process.stdout.write(`${get(cfg)}\n`);
+  return 0;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  process.exit(main(process.argv));
+}

--- a/standards.manifest.json
+++ b/standards.manifest.json
@@ -1,0 +1,174 @@
+{
+  "//": "GENERATED-CONSUMED. The authoritative offline copy of the Memex standards index.",
+  "//refresh": "An agent refreshes this from Memex with: search_memex({kind:\"standard\"}) — then `make standards-gen` rewrites the CLAUDE.md table.",
+  "standards": [
+    {
+      "handle": "std-1",
+      "summary": "Namespace / org / memex are three distinct concepts — plus user-facing vocabulary and handle conventions (`b-N` / `doc-N` / `std-N` / `s-N` / `dec-N` / `t-N` / `c-N`)."
+    },
+    {
+      "handle": "std-2",
+      "summary": "Tenant routing is path-based on the apex domain — never subdomains."
+    },
+    {
+      "handle": "std-3",
+      "summary": "Namespace slug allocation (format, reserved list, rate limits, rename cooldown)."
+    },
+    {
+      "handle": "std-4",
+      "summary": "Org membership grants access to every Memex in the org (v1 access model)."
+    },
+    {
+      "handle": "std-5",
+      "summary": "No silent namespace default — ambiguous MCP / middleware calls error."
+    },
+    {
+      "handle": "std-6",
+      "summary": "Domain-based auto-join requires explicit user consent."
+    },
+    {
+      "handle": "std-7",
+      "summary": "Unauthorized resource access returns 404, not 403."
+    },
+    {
+      "handle": "std-8",
+      "summary": "Every mutation goes through `mutate()` and emits on the unified bus (real-time SSE)."
+    },
+    {
+      "handle": "std-9",
+      "summary": "Infrastructure: int + prod GCP projects (Cloud Run, Cloud SQL, buckets, secrets, DNS) + local development."
+    },
+    {
+      "handle": "std-10",
+      "summary": "Canonical URL paths for Memex entities (the `ref` grammar)."
+    },
+    {
+      "handle": "std-11",
+      "summary": "AI agent: direct Anthropic SDK on server, LangGraph in React UI."
+    },
+    {
+      "handle": "std-12",
+      "summary": "Service architecture — bounded components and how they wire."
+    },
+    {
+      "handle": "std-13",
+      "summary": "Native authentication: hand-rolled JWT + scrypt + auth_tokens + Postmark."
+    },
+    {
+      "handle": "std-14",
+      "summary": "Per-domain debug logging convention (`packages/server/.logs/<domain>.log`)."
+    },
+    {
+      "handle": "std-15",
+      "summary": "Agent prompts live in `packages/server/src/agent/phases/` markdown, never inline in code."
+    },
+    {
+      "handle": "std-16",
+      "summary": "The coding-agent tool contract has one source — the `@memex/shared` manifest."
+    },
+    {
+      "handle": "std-17",
+      "summary": "Smoke tests are mandatory and run against live envs — int after every deploy, green before prod."
+    },
+    {
+      "handle": "std-18",
+      "summary": "Spec anatomy — the lens set every Spec carries: core lenses (Overview, Design & UX, Architecture & Security) always present; adaptive lenses (Operations, …) added when the work earns them. Decisions and ACs are primitives, not prose sections."
+    },
+    {
+      "handle": "std-19",
+      "summary": "Specs are SDD's canonical artifact — every unit of work is a Spec; \"Spec\" is the noun."
+    },
+    {
+      "handle": "std-20",
+      "summary": "Spec-Driven Development — drift is the enemy; the Spec is a living node in a knowledge map."
+    },
+    {
+      "handle": "std-21",
+      "summary": "Branch structure — `develop` integrates work; `main` is the production line (releases land as a **merge commit** via the develop→main PR — GitHub's PR surface can't fast-forward, cl-50; the content invariant is `git log develop..main --no-merges` empty, not SHA-identity; branch-bound deploy targets, main-only licence carve-out)."
+    },
+    {
+      "handle": "std-22",
+      "summary": "Everything we ship runs against arbitrary codebases — portable artifacts (prompts, scaffold prose, Prompt Buttons, Init Prompts, in-repo tools) assume no language, framework, layout, file paths, or tooling."
+    },
+    {
+      "handle": "std-23",
+      "summary": "Prompt Buttons are the standard human→agent handoff — prompt prose lives in the Scaffold (`scaffold-data.ts`), never inline; copy-to-clipboard; Org-extensible (append-only)."
+    },
+    {
+      "handle": "std-24",
+      "summary": "One version per shared library across the pnpm workspace, enforced by `pnpm.overrides` (today: vitest, `@vitest/coverage-v8`, `@types/node`, `react`/`react-dom`, `typescript`; plus security-floor pins `esbuild`/`form-data`/`protobufjs`). Exact pins in each package's devDependencies; new dep families added to the root overrides."
+    },
+    {
+      "handle": "std-25",
+      "summary": "Every Spec classifies its work as fair-code (open core) or EE — the licence boundary is decided per-Spec, up front, not retrofitted."
+    },
+    {
+      "handle": "std-26",
+      "summary": "Deploying Memex follows one runbook — prerequisites, the int→prod sequence, and the gotchas that bite (the procedural sibling of std-9's topology)."
+    },
+    {
+      "handle": "std-27",
+      "summary": "Charts & data-viz: one theme-aware palette + glass treatment — `useChartPalette()`/`insightsTheme` from `packages/ui/src/components/insights/theme.ts`, reserved hue semantics, translucent fills with crisp edges, integer count ticks, themed tooltips, noise excluded server-side."
+    },
+    {
+      "handle": "std-28",
+      "summary": "PR-gate e2e journeys are mandatory — every change that adds/alters a user-facing flow adds or extends a Playwright journey in `packages/ui/e2e`; journey work is part of EVERY Spec's lifecycle (surfaced in plan, delivered in build, gating verify); run `make e2e-cold` before opening every PR; the suite runs per-PR against a cold DB and is a required check on develop + main; path-based nav, seed via the env-gated test surface (no raw SQL). The merge-side sibling of std-17's post-deploy smoke rule. Authoring a journey + local-run gotchas (cold-DB `PGPASSWORD`, stale `@memex/shared` build, browser install): [`packages/ui/e2e/README.md`](packages/ui/e2e/README.md)."
+    },
+    {
+      "handle": "std-29",
+      "summary": "Guide content (Specky) stays current with the UI it documents — drift flagged for retirement (spec-508 removed the voice guide + its content pipeline)."
+    },
+    {
+      "handle": "std-30",
+      "summary": "All LLM access goes through the metering wrapper (`getAnthropicClient()` singleton) — the only sanctioned path; direct `new Anthropic(...)` construction is forbidden."
+    },
+    {
+      "handle": "std-31",
+      "summary": "No real person or customer names in this public Memex (it builds itself in the open)."
+    },
+    {
+      "handle": "std-32",
+      "summary": "The activity contract — every activity-bearing table (`documents`/`acs`/`tasks`/`decisions`/`doc_sections`/`doc_comments`/`test_events`/`activity_log`) carries WHEN (`at`, the row's own timestamp) + WHO (`actor_user_id` + denormalised `actor_name`, stamped at write so a rename can't rewrite history) + HOW (`channel`) + WHAT-coarse (owning-spec ref); load-bearing fields are first-class columns, only decorative context lives in `metadata`/`payload`. Identity rides the explicit `RequestCtx` through `mutate()` (not AsyncLocalStorage); a missing channel is a visible defect, never a silent 'server'. The attribution sibling of std-8 (spec-122 dec-2)."
+    },
+    {
+      "handle": "std-33",
+      "summary": "Embedding the guide SDK (Specky) — drift flagged for retirement (spec-508 deleted `packages/guide-sdk` and the /guide/v1 backend)."
+    },
+    {
+      "handle": "std-34",
+      "summary": "No human-facing surface instructs an MCP-only step — signal the web↔MCP capability boundary in copy (the honest-CTA rule)."
+    },
+    {
+      "handle": "std-35",
+      "summary": "Usage events / Mixpanel — the metering + product-analytics event recipe."
+    },
+    {
+      "handle": "std-36",
+      "summary": "Tenant RLS posture — `ENABLE` row-level security, never `FORCE`; `runWithMemexId` ALS sets `memex_id`; views are `security_invoker`."
+    },
+    {
+      "handle": "std-37",
+      "summary": "Test fixtures are isolated under parallel execution — per-worker-unique identifiers, poll for async writes, restore global stubs."
+    },
+    {
+      "handle": "std-38",
+      "summary": "In-app agents share one contract — same visual shell (`ChatPanel`), Memex-wide grounding, narrow per-mode authoring scope enforced server-side by a `MODE_TOOLS` allow-list, copyable handoff on refusal."
+    },
+    {
+      "handle": "std-39",
+      "summary": "Database hygiene — every DB interaction is reasoned about for cost, locks, and growth, not just correctness. Covers migrations, handlers, MCP tools, relays, cron, and the React UI's query/polling patterns."
+    },
+    {
+      "handle": "std-40",
+      "summary": "Plugins are the Claude-Code delivery vehicle — one plugin, one concern. Covers hooks (std-41), a bundled MCP server, or slash commands; excludes the `memex-ai` CLI credential installer."
+    },
+    {
+      "handle": "std-41",
+      "summary": "Hooks make capability a side effect of work you already do — use them sparingly, never for correctness. Six tests gate whether a hook is the right tool; correctness/security/mutation work belongs on the server (std-8)."
+    },
+    {
+      "handle": "std-42",
+      "summary": "Desktop client (memex-clients) releases follow one runbook — signing on BOTH platforms, notarization, auto-update, and per-channel distribution. An unsigned build is a CI artifact only, never published."
+    }
+  ]
+}


### PR DESCRIPTION
Retires the traps that let a green result be a lie. Spec: [spec-512](https://memex.ai/mindset-prod/memex-building-itself/specs/spec-512).

## The anchor bug, reproduced not argued

`playwright.config.ts` sets `reuseExistingServer: !CI` on fixed ports. A stub server placed on the e2e port received **12 real requests** during a genuine `test:e2e journey-10` run — health, `ensure-user`, `clear-user-specs` — while Playwright never booted the checkout under test. Against a real sibling worktree those journeys run on **another branch's code and database and report PASS**. The Makefile also hardcoded `memex_e2e`, so a second run's `dropdb` destroyed the first's database mid-run.

Every e2e resource is now derived from `sha1(workspaceRoot)` (the shape already proven by `test-db-url.ts` for the vitest tier), and a preflight refuses rather than adopts.

## What's here

- **`scripts/ci/workspace-alloc.mjs`** — one allocator for e2e + dev ports and DB names.
- **`scripts/ci/e2e-preflight.mjs`** — 5 checks: foreign server on either port, `PGPASSWORD` hang, stale `@memex/shared`, emission target.
- **`scripts/ci/standards-index.mjs`** — CLAUDE.md's standards table is now generated. It had drifted: **std-38, 39, 40, 41 and 42 were approved in Memex and absent**, so five binding Standards governed nobody.
- **`scripts/ci/affected-tests.mjs`** — `make affected`; an unrecognised path widens to the full matrix, never narrows to nothing.
- **`scripts/ci/prove-concurrent-workspaces.sh`** — `make prove-concurrent`; provisions a second working copy and runs both.
- **`make check`** — offline guard battery, no DB, no network, **~1.1s**.
- **CLAUDE.md** rewritten to pointer style, landing last so it only names checks that already exist.

## Three defects found in code already on develop

1. **The UI type gate checked ZERO files.** `packages/ui/tsconfig.json` is the `files: []` solution form, so `tsc --noEmit` — which pre-push ran and documented as "a superset of the deploy's gate" — type-checked nothing and exited 0. A planted `const x: number = "not a number"` produced no output from it and TS2322 from `tsc -b`. Direct cause of `5b930ff`.
2. **`voice-guide-removed` asserted filesystem, not git** — green in CI, permanently red on any laptop with pre-spec-508 build residue.
3. **journey-53 is flaky against a cold DB on develop** (`net::ERR_ABORTED`) — see below.

## Independent adversarial verification

Two agents that did not write the code, briefed to refute, with out-of-harness evidence required. They **refuted the concurrency claim** (`make dev` was never wired to the allocator — it computed dev ports nothing read) and **broke the guards five ways**, worst being that only `e2e-cold` was armed while bare `make e2e` stayed fully exposed with the backstop disarming itself on that path. All fixed. Findings recorded on the Spec.

Running the full suite then caught one more defect of my own: journeys read the API host two ways (`E2E_SERVER_PORT` vs `E2E_API_URL`), and setting only the ports stranded the second group on the old 8090. Fixed, with a guard keeping all four vars in lockstep.

## Test status

server 5,774 · ui 2,250 · shared 786 · ac-emit 84 · cli 78 · extractor 62 · db-schema 18 — all green. `make check`, `make typecheck`, `pnpm lint` green.

**e2e: 137 passed, 1 failed — `journey-53-spec-507-no-video-gate`.** It fails identically on **clean `develop`** (verified by a full run on a clean checkout) and passes in isolation; the failure is `page.goto: net::ERR_ABORTED; maybe frame was detached?`, a navigation race. CI runs Playwright with `retries: 2` where local runs with 0. Tracked as issue-6 on the Spec — **not introduced by this PR**.

## Risk

No migration, no schema change, no new deployed env var. One production line: `/api/health` gains a `workspace` field emitted only when `MEMEX_WORKSPACE_ID` matches `^[0-9a-f]{8}$` — unset in every deploy path, so the deployed payload is byte-identical (verified against two real servers). Fair-code; no `.ee` paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)