### PR TITLE
spec-517: app conversion instrumentation — GA4 + OpenAI pixel + suppression (hardcoded)

### DIFF
--- a/packages/ui/index.html
+++ b/packages/ui/index.html
@@ -27,6 +27,21 @@
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
     })(window,document,'script','dataLayer','GTM-MMCZ5GSX');</script>
+    <!-- GA4 (spec-517 dec-1): hardcoded on the app deploy, mirroring the marketing
+         site. Same measurement ID as www.memex.ai so a session that begins there
+         continues into the app (shared _ga cookie on .memex.ai) rather than starting
+         a new one. Only GA4 is added here — Google Ads (AW-18098801347) and LinkedIn
+         already fire on the app via the GTM container, so configuring them here too
+         would double-count. gtag() is already global from the consent block above. -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-9R0MM1G4PH"></script>
+    <script>
+      gtag('js', new Date());
+      gtag('config', 'G-9R0MM1G4PH');
+    </script>
+    <!-- OpenAI advertising pixel base (spec-517 dec-1): defines window.oaiq and loads
+         the SDK, mirroring the marketing site. registration_completed is fired from the
+         auth flow (fireSignupConversion) — without this base snippet that call no-ops. -->
+    <script>!function(w,d,s,u){if(w.oaiq)return;var q=function(){q.q.push(arguments)};q.q=[];w.oaiq=q;var j=d.createElement(s);j.async=1;j.src=u;var f=d.getElementsByTagName(s)[0];f.parentNode.insertBefore(j,f)}(window,document,"script","https://bzrcdn.openai.com/sdk/oaiq.min.js");oaiq("init",{pixelId:"PjRCVoZPvvHxvY26WNoWaU"});</script>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />

--- a/packages/ui/src/components/AuthContext.tsx
+++ b/packages/ui/src/components/AuthContext.tsx
@@ -16,7 +16,7 @@ import {
   AuthApiError,
   type SessionPayload,
 } from '../api/client';
-import { readAttributionCookie, pushDataLayer } from '../lib/attribution';
+import { readAttributionCookie, fireSignupConversion } from '../lib/attribution';
 import { LoginScreen } from './LoginScreen';
 import { MemexReadyGate } from './MemexReadyGate';
 import { isFeatureHidden } from '../utils/featureFlags';
@@ -414,11 +414,11 @@ export function RequireAuth({ children }: { children: ReactNode }) {
         const s = await ssoLoginApi(credential);
         acceptSession(s);
         if (s.isNewAccount) {
-          pushDataLayer({
-            event: 'sign_up_completed',
-            event_id: s.conversionEventId ?? crypto.randomUUID(),
-            ...readAttributionCookie(),
-          });
+          fireSignupConversion(
+            s.conversionEventId ?? crypto.randomUUID(),
+            s.user.email,
+            readAttributionCookie(),
+          );
         }
       }).then(() => undefined),
     [wrap, acceptSession],

--- a/packages/ui/src/lib/attribution.spec-517.test.ts
+++ b/packages/ui/src/lib/attribution.spec-517.test.ts
@@ -1,0 +1,101 @@
+// Tests for spec-517: fireSignupConversion routes a new-account conversion to
+// every channel (dataLayer→GTM, GA4 gtag, OpenAI oaiq), never throws when a tag
+// is missing, and fires nothing for internal (@mindset.ai) sign-ups.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { fireSignupConversion } from './attribution';
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-517/acs/ac-${n}`;
+
+type W = {
+  dataLayer?: unknown[];
+  gtag?: (...args: unknown[]) => void;
+  oaiq?: (...args: unknown[]) => void;
+};
+
+describe('fireSignupConversion (spec-517)', () => {
+  const w = window as unknown as W;
+  let dataLayer: unknown[];
+  let gtag: ReturnType<typeof vi.fn>;
+  let oaiq: ReturnType<typeof vi.fn>;
+  let warn: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    dataLayer = [];
+    w.dataLayer = dataLayer;
+    gtag = vi.fn();
+    oaiq = vi.fn();
+    w.gtag = gtag;
+    w.oaiq = oaiq;
+    warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    delete w.gtag;
+    delete w.oaiq;
+    delete w.dataLayer;
+    warn.mockRestore();
+  });
+
+  it('sends the GA4 sign_up_completed event with event_id + attribution (ac-3)', () => {
+    tagAc(AC(3));
+    fireSignupConversion('evt-1', 'person@example.com', { gclid: 'g1' });
+    expect(gtag).toHaveBeenCalledWith(
+      'event',
+      'sign_up_completed',
+      expect.objectContaining({ event_id: 'evt-1', gclid: 'g1' }),
+    );
+    // dataLayer push (GTM → Google Ads + LinkedIn) still happens alongside GA4.
+    expect(dataLayer).toContainEqual(
+      expect.objectContaining({ event: 'sign_up_completed', event_id: 'evt-1', gclid: 'g1' }),
+    );
+  });
+
+  it('sends the OpenAI registration_completed event with the shared event_id (ac-4)', () => {
+    tagAc(AC(4));
+    fireSignupConversion('evt-2', 'person@example.com', null);
+    expect(oaiq).toHaveBeenCalledWith(
+      'track',
+      'registration_completed',
+      expect.objectContaining({ event_id: 'evt-2' }),
+    );
+  });
+
+  it('never throws and logs an observable skip when a tag is absent (ac-5)', () => {
+    tagAc(AC(5));
+    delete w.gtag;
+    delete w.oaiq;
+    expect(() => fireSignupConversion('evt-3', 'person@example.com', null)).not.toThrow();
+    // A missing tag is warned about, not silently dropped — so it can't masquerade
+    // as zero conversions.
+    expect(warn).toHaveBeenCalled();
+    // The GTM path is independent of gtag/oaiq, so it still fires.
+    expect(dataLayer).toContainEqual(
+      expect.objectContaining({ event: 'sign_up_completed', event_id: 'evt-3' }),
+    );
+  });
+
+  it('fires nothing on any channel for an internal @mindset.ai account (ac-7)', () => {
+    tagAc(AC(7));
+    fireSignupConversion('evt-4', 'qa@mindset.ai', { gclid: 'g1' });
+    expect(gtag).not.toHaveBeenCalled();
+    expect(oaiq).not.toHaveBeenCalled();
+    expect(dataLayer).toHaveLength(0);
+  });
+
+  it('treats the internal domain case-insensitively (ac-7)', () => {
+    tagAc(AC(7));
+    fireSignupConversion('evt-5', 'QA@MINDSET.AI', null);
+    expect(gtag).not.toHaveBeenCalled();
+    expect(oaiq).not.toHaveBeenCalled();
+    expect(dataLayer).toHaveLength(0);
+  });
+
+  it('does not treat a lookalike domain as internal (ac-7)', () => {
+    tagAc(AC(7));
+    fireSignupConversion('evt-6', 'person@notmindset.ai', null);
+    expect(gtag).toHaveBeenCalled();
+    expect(oaiq).toHaveBeenCalled();
+    expect(dataLayer).toHaveLength(1);
+  });
+});

--- a/packages/ui/src/lib/attribution.ts
+++ b/packages/ui/src/lib/attribution.ts
@@ -28,3 +28,63 @@ export function pushDataLayer(event: Record<string, unknown>): void {
     // never throw from analytics
   }
 }
+
+// Internal / test accounts must produce no conversion anywhere downstream
+// (spec-517 ac-7), matching the server-side "real users" exclusion already
+// enforced in packages/server/src/services/conversion-apis.ts (spec-505). Both
+// sides key on the mindset.ai email domain so the client pixels and the server
+// conversion APIs agree on who counts as internal.
+function isInternalEmail(email: string | null | undefined): boolean {
+  if (!email) return false;
+  const at = email.lastIndexOf('@');
+  if (at === -1) return false;
+  return email.slice(at + 1).trim().toLowerCase() === 'mindset.ai';
+}
+
+// Fires the sign-up conversion across every channel for a newly created account.
+// Called once, on first authenticated landing of a new user (spec-517 dec-1):
+//   - dataLayer push → GTM forwards to Google Ads + LinkedIn (unchanged).
+//   - gtag event     → GA4 key event `sign_up_completed` (GA4 is hardcoded, not in GTM).
+//   - oaiq track     → OpenAI `registration_completed`.
+// Analytics must never break the auth flow, so every send is guarded and can't
+// throw. A missing tag is LOGGED rather than silently skipped, so an absent or
+// ad-blocked tag can't masquerade as zero conversions (spec-517 ac-5).
+export function fireSignupConversion(
+  eventId: string,
+  email: string | null | undefined,
+  attribution: AttributionData | null,
+): void {
+  // spec-517 ac-7 — internal / test sign-ups fire nothing on any channel.
+  if (isInternalEmail(email)) return;
+
+  const attr = attribution ?? {};
+  const w = window as unknown as {
+    gtag?: (...args: unknown[]) => void;
+    oaiq?: (...args: unknown[]) => void;
+  };
+
+  // GTM → Google Ads + LinkedIn (unchanged from the original dataLayer push).
+  pushDataLayer({ event: 'sign_up_completed', event_id: eventId, ...attr });
+
+  // GA4 key event (hardcoded gtag from index.html).
+  try {
+    if (typeof w.gtag === 'function') {
+      w.gtag('event', 'sign_up_completed', { event_id: eventId, ...attr });
+    } else {
+      console.warn('[spec-517] GA4 gtag not loaded — sign_up_completed not sent to GA4');
+    }
+  } catch {
+    // never throw from analytics
+  }
+
+  // OpenAI advertising pixel (hardcoded oaiq from index.html).
+  try {
+    if (typeof w.oaiq === 'function') {
+      w.oaiq('track', 'registration_completed', { event_id: eventId });
+    } else {
+      console.warn('[spec-517] OpenAI pixel (oaiq) not loaded — registration_completed not sent');
+    }
+  } catch {
+    // never throw from analytics
+  }
+}

--- a/packages/ui/src/pages/MagicLinkConsume.tsx
+++ b/packages/ui/src/pages/MagicLinkConsume.tsx
@@ -3,7 +3,7 @@ import { Link, useSearchParams } from 'react-router-dom';
 import { useAuth, computeDefaultLanding } from '../components/AuthContext';
 import { isFeatureHidden } from '../utils/featureFlags';
 import { magicLinkConsumeApi, AuthApiError } from '../api/client';
-import { readAttributionCookie, pushDataLayer } from '../lib/attribution';
+import { readAttributionCookie, fireSignupConversion } from '../lib/attribution';
 import { Spinner } from '../components/Spinner';
 
 type Stage = 'consuming' | 'success' | 'failed';
@@ -34,11 +34,11 @@ export function MagicLinkConsume() {
       .then((session) => {
         acceptSession(session);
         if (session.isNewAccount) {
-          pushDataLayer({
-            event: 'sign_up_completed',
-            event_id: session.conversionEventId ?? crypto.randomUUID(),
-            ...readAttributionCookie(),
-          });
+          fireSignupConversion(
+            session.conversionEventId ?? crypto.randomUUID(),
+            session.user.email,
+            readAttributionCookie(),
+          );
         }
         setStage('success');
         // spec-421 dec-5: route through /login (whose element is RootRedirect) so the

--- a/packages/ui/src/pages/VerifyEmail.tsx
+++ b/packages/ui/src/pages/VerifyEmail.tsx
@@ -4,7 +4,7 @@ import { useAuth, computeDefaultLanding } from '../components/AuthContext';
 import { isFeatureHidden } from '../utils/featureFlags';
 import { Logo } from '../components/Logo';
 import { verifyEmailApi, AuthApiError } from '../api/client';
-import { readAttributionCookie, pushDataLayer } from '../lib/attribution';
+import { readAttributionCookie, fireSignupConversion } from '../lib/attribution';
 import { Spinner } from '../components/Spinner';
 import { Confetti } from '../components/Confetti';
 import { Button } from '../components/ui/Button';
@@ -38,11 +38,11 @@ export function VerifyEmail() {
       .then((s) => {
         acceptSession(s);
         if (s.isNewAccount) {
-          pushDataLayer({
-            event: 'sign_up_completed',
-            event_id: s.conversionEventId ?? crypto.randomUUID(),
-            ...readAttributionCookie(),
-          });
+          fireSignupConversion(
+            s.conversionEventId ?? crypto.randomUUID(),
+            s.user.email,
+            readAttributionCookie(),
+          );
         }
         setStage('success');
       })


### PR DESCRIPTION
Closes the gap Niamh found live: the app deploy (`memex.ai`) has no GA4 and no OpenAI base pixel — only the GTM container reaches it, and that carries just Google Ads + LinkedIn. Sign-up completes in this repo, so the moment of conversion was firing on the one deploy with neither tag (`window.oaiq` undefined, zero GA4 `/g/collect` hits). Recorded conversions: zero.

## Decision
Per **spec-517 dec-1** (Barrie's call): hardcode GA4 + the OpenAI base pixel in the app repo, mirroring the proven memex-website setup. Chosen over moving them into GTM because that would be a two-repo coordinated change (add to GTM *and* strip the website's hardcoded copies in the same window, or the site double-counts) — this ships as one self-contained, testable PR today. Formally accepts the divergence from spec-505 dec-5; GTM consolidation is deferred to a separate cleanup.

## Changes
- **`index.html`** — GA4 base (`gtag config G-9R0MM1G4PH`, same measurement ID as www so the session carries over via the shared `.memex.ai` `_ga` cookie) + OpenAI base pixel (`window.oaiq`). **Google Ads / LinkedIn are deliberately NOT added here** — they already fire via GTM, so re-configuring them would double-count.
- **`lib/attribution.ts`** — new `fireSignupConversion()` routes one new-account conversion to every channel: dataLayer push (GTM → Google Ads + LinkedIn, unchanged), GA4 `gtag` `sign_up_completed`, OpenAI `oaiq` `registration_completed`. Guarded so it never throws; **warns rather than silently skipping** when a tag is absent so a missing tag can't masquerade as zero conversions (ac-5). Internal `@mindset.ai` sign-ups fire nothing (ac-7), matching the server-side spec-505 exclusion so client + server agree on "internal".
- The three completion sites (`VerifyEmail`, `MagicLinkConsume`, `AuthContext` Google SSO) call the helper instead of an inline dataLayer push.

## Tests
`attribution.spec-517.test.ts` (tagged ac-3/4/5/7) + existing spec-21 sign-up tests: **10 passed**. Typecheck clean.

## Niamh — please verify live after deploy (can't be unit-tested)
- **ac-1 / ac-2:** on `memex.ai/app`, confirm GA4 `/g/collect` hits fire and `window.oaiq` is a callable function with `oaiq.min.js` loaded. Note ac-1's "page_view on every route" relies on **GA4 Enhanced Measurement** (history-change tracking) being enabled on the property, since the app is a SPA — if it isn't on, we'd add an explicit route hook (flag it and I'll follow up).
- **ac-6 (consent):** confirm no GA4/Ads/LinkedIn/OpenAI calls before banner acceptance, and they fire after — matching the website. Consent Mode v2 is already wired in the app `index.html`; OpenAI/LinkedIn behaviour mirrors the website's existing implementation.
- **No website double-count:** this PR doesn't touch memex-website, so its hardcoded GA4/OpenAI are unchanged and the app fires independently — worth a glance to confirm.
- **ac-7 suppression = `@mindset.ai` email domain.** This is the one spot the spec left open ("a test flag"). I mirrored the server-side domain exclusion. Practical consequence for tonight: **run your real test sign-ups from a non-`@mindset.ai` address** to see conversions land, and a `@mindset.ai` one to confirm suppression. If you'd rather have an explicit query-param flag instead, it's a small follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)