### PR TITLE
spec-518: env-key Cloud Run scaling flags (prod≠int, no deploy-pin revert)

### DIFF
--- a/packages/server/deploy.sh
+++ b/packages/server/deploy.sh
@@ -375,13 +375,16 @@ REMOVE_CONVERSION_SECRETS="${REMOVE_CONVERSION_SECRETS#,}"  # strip leading comm
 # MERGE leaves the live setting intact rather than blanking it — a deploy from a
 # checkout that never set the value can't silently un-hide features (spec-168
 # dec-4). The ${var+...} form is safe under `set -u`.
-# Resource/scaling flags (--memory/--min-instances/--max-instances/--concurrency/--cpu-boost)
-# are PINNED here, never left to the console: gcloud reverts anything a deploy doesn't
-# re-assert, so a console-set value silently disappears on the next deploy (std-26 §6 cl-136,
-# spec-489). --concurrency 80 / --cpu-boost restate the current live values so they survive.
-# DB_POOL_MAX is an optional per-env override of the db/connection.ts pool cap (prod=10, sized
-# against Cloud SQL max_connections=50 — spec-489/spec-332); omitted when unset, so a deploy
-# never blanks a live value.
+# Resource/scaling flags are re-asserted every deploy: gcloud reverts anything a deploy
+# doesn't restate, so a console-set value silently disappears on the next deploy (std-26 §6
+# cl-136, spec-489). --memory/--concurrency/--cpu-boost restate the current live values so they
+# survive. --min-instances/--max-instances are ENV-KEYED per-env (spec-518): MIN_INSTANCES /
+# MAX_INSTANCES come from the memex-<env>-deploy-env secret and default to 0/3 (today's
+# behaviour) when unset, so prod and int can differ and the live scaling can't drift from
+# config. Budget invariant (spec-518 / db/connection.ts:29): MAX_INSTANCES × (DB_POOL_MAX + 1
+# relay LISTEN) must stay under the DB's effective ceiling (prod ~47) — a value pair that
+# violates it can exhaust connections (the 2026-08-03 FATAL). DB_POOL_MAX is the per-env pool
+# cap (prod=4 under maxScale 8 → 8×(4+1)=40<47; spec-489/spec-518/spec-332); omitted when unset.
 gcloud run deploy "${SERVICE}" \
   --image "${IMAGE}" \
   --platform managed \
@@ -391,8 +394,8 @@ gcloud run deploy "${SERVICE}" \
   --allow-unauthenticated \
   --port 8080 \
   --memory 512Mi \
-  --min-instances 0 \
-  --max-instances 3 \
+  --min-instances "${MIN_INSTANCES:-0}" \
+  --max-instances "${MAX_INSTANCES:-3}" \
   --concurrency 80 \
   --cpu-boost \
   --add-cloudsql-instances "${CLOUD_SQL_INSTANCE_CONN}" \

--- a/packages/server/src/__regression__/spec-518-scaling-budget.regression.test.ts
+++ b/packages/server/src/__regression__/spec-518-scaling-budget.regression.test.ts
@@ -1,0 +1,70 @@
+// spec-518: Cloud Run scaling is env-keyed, and the connection budget stays under the DB's
+// usable ceiling. Static assertions on deploy.sh / deploy-config.sh (same shape as the
+// spec-168 deploy-config regression tests) plus the budget-invariant arithmetic that the
+// 2026-08-03 incident violated. Live per-env enforcement is the post-deploy check (ac-9);
+// these guard the mechanism + the intended numbers so a regression fails CI.
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+const SPEC = "mindset-prod/memex-building-itself/specs/spec-518";
+const REPO_ROOT = join(__dirname, "..", "..", "..", "..");
+const DEPLOY_SH = readFileSync(join(REPO_ROOT, "packages", "server", "deploy.sh"), "utf-8");
+const DEPLOY_CONFIG = readFileSync(join(REPO_ROOT, "scripts", "deploy-config.sh"), "utf-8");
+
+// Per-instance DB footprint = DB_POOL_MAX + 1. The +1 is the spec-156 bus-relay LISTEN
+// connection — one persistent connection per Cloud Run instance (db/connection.ts:29).
+const connectionBudget = (maxInstances: number, dbPoolMax: number) =>
+  maxInstances * (dbPoolMax + 1);
+
+// Intended per-env scaling — the values carried in each memex-<env>-deploy-env secret.
+// Ceiling = max_connections − superuser_reserved_connections (prod: 50 − 3 = 47).
+const ENV_PLAN = {
+  prod: { maxInstances: 8, dbPoolMax: 4, ceiling: 47 },
+} as const;
+
+describe("spec-518 ac-8: Cloud Run scaling flags are env-keyed with safe defaults", () => {
+  it("deploy.sh sources --min-instances/--max-instances from env, defaulting to 0/3", () => {
+    tagAc(`${SPEC}/acs/ac-8`);
+    expect(DEPLOY_SH).toMatch(/--min-instances\s+"\$\{MIN_INSTANCES:-0\}"/);
+    expect(DEPLOY_SH).toMatch(/--max-instances\s+"\$\{MAX_INSTANCES:-3\}"/);
+  });
+
+  it("deploy-config.sh exports MIN_INSTANCES/MAX_INSTANCES per-env", () => {
+    tagAc(`${SPEC}/acs/ac-8`);
+    expect(DEPLOY_CONFIG).toMatch(/export MIN_INSTANCES/);
+    expect(DEPLOY_CONFIG).toMatch(/export MAX_INSTANCES/);
+  });
+});
+
+describe("spec-518 ac-10: connection budget stays under the effective ceiling", () => {
+  it("counts the +1 relay LISTEN per instance", () => {
+    tagAc(`${SPEC}/acs/ac-10`);
+    expect(connectionBudget(8, 4)).toBe(40); // prod: 8 × (4+1)
+    expect(connectionBudget(3, 5)).toBe(18); // deploy.sh defaults: 3 × (5+1)
+  });
+
+  it("intended per-env values are under their ceilings", () => {
+    tagAc(`${SPEC}/acs/ac-10`);
+    for (const [env, p] of Object.entries(ENV_PLAN)) {
+      expect(
+        connectionBudget(p.maxInstances, p.dbPoolMax),
+        `${env} over budget`,
+      ).toBeLessThan(p.ceiling);
+    }
+  });
+
+  it("regression: the 2026-08-03 mitigation (maxScale 8 × pool 5 = 48) is OVER the prod ceiling", () => {
+    tagAc(`${SPEC}/acs/ac-10`);
+    // This is the exact config that threw `FATAL: remaining connection slots` — the guard
+    // that would have caught it: 8 × (5+1) = 48 ≥ 47.
+    expect(connectionBudget(8, 5)).toBeGreaterThanOrEqual(ENV_PLAN.prod.ceiling);
+  });
+
+  it("the deploy.sh defaults (unset env) are budget-safe", () => {
+    tagAc(`${SPEC}/acs/ac-10`);
+    expect(connectionBudget(3, 5)).toBeLessThan(ENV_PLAN.prod.ceiling);
+  });
+});

--- a/packages/server/src/__smoke__/bus-relay.smoke.test.ts
+++ b/packages/server/src/__smoke__/bus-relay.smoke.test.ts
@@ -232,7 +232,7 @@ describe.skipIf(!SMOKE_MCP_TOKEN || !SMOKE_SESSION_TOKEN)(
     });
 
     // ── ac-1 (scope): repeated MCP mutations ALL arrive on one long-lived SSE
-    //    stream. On prod (--max-instances 3, no session affinity) the /mcp
+    //    stream. On prod (multiple instances — maxScale is env-keyed, 8 today — no session affinity) the /mcp
     //    request and the SSE stream routinely land on DIFFERENT instances, so a
     //    multi-round loop exercises the relay's cross-instance hop with high
     //    probability — the single-round test above can get lucky on one warm

--- a/packages/server/src/services/bus-relay.test.ts
+++ b/packages/server/src/services/bus-relay.test.ts
@@ -604,15 +604,19 @@ describe("spec-156 W1: health reports relay LISTEN-connection status (ac-12)", (
   });
 });
 
-describe("spec-156 W1 (dec-3): deploy.sh keeps --max-instances 3 (ac-27)", () => {
-  it("deploy.sh still pins --max-instances 3 — no interim single-instance throttle", () => {
+describe("spec-156 W1 (dec-3): deploy.sh runs prod at full scale (ac-27)", () => {
+  it("deploy.sh never throttles prod to a single instance — full scale via env-keyed flag", () => {
     tagAc(AC(27));
     tagAc(AC(5)); // scope ac-5: prod runs at full scale throughout (dec-3)
     const here = dirname(fileURLToPath(import.meta.url));
     // src/services/ -> packages/server/deploy.sh
     const deployPath = join(here, "..", "..", "deploy.sh");
     const deploy = readFileSync(deployPath, "utf8");
-    expect(deploy).toMatch(/--max-instances\s+3\b/);
+    // spec-518 env-keyed this flag: `--max-instances ${MAX_INSTANCES:-3}` (prod = 8 via the
+    // deploy-env secret). The spec-156 dec-3 invariant holds: prod is NEVER throttled to a
+    // single instance — the default is full scale (3) and the live value only goes up.
+    expect(deploy).toMatch(/--max-instances\s+"\$\{MAX_INSTANCES:-3\}"/);
     expect(deploy).not.toMatch(/--max-instances\s+1\b/);
+    expect(deploy).not.toMatch(/MAX_INSTANCES:-1\b/);
   });
 });

--- a/scripts/deploy-config.sh
+++ b/scripts/deploy-config.sh
@@ -226,4 +226,18 @@ if [ -n "${SERVICE_ACCOUNT+set}" ]; then
   export SERVICE_ACCOUNT
 fi
 
+# MIN_INSTANCES / MAX_INSTANCES — spec-518: per-env Cloud Run autoscaling bounds, consumed by
+# packages/server/deploy.sh as --min-instances ${MIN_INSTANCES:-0} / --max-instances
+# ${MAX_INSTANCES:-3}. Unset → the 0/3 defaults (current behaviour), so an env that never sets
+# them deploys unchanged. Set them in the memex-<env>-deploy-env secret to raise an env's
+# ceiling (prod: MIN_INSTANCES=1, MAX_INSTANCES=8). Budget invariant: MAX_INSTANCES ×
+# (DB_POOL_MAX + 1 relay LISTEN) must stay under the DB's effective max_connections ceiling
+# (prod ~47). Same set-vs-unset export as the knobs above.
+if [ -n "${MIN_INSTANCES+set}" ]; then
+  export MIN_INSTANCES
+fi
+if [ -n "${MAX_INSTANCES+set}" ]; then
+  export MAX_INSTANCES
+fi
+
 echo "[deploy-config] ENV=$ENV  project=$GCP_PROJECT  host=$PUBLIC_HOST  api=$API_PUBLIC_HOST"


### PR DESCRIPTION
## What & why

Executes the config half of **spec-518** (2026-08-03 prod incident hardening).

`packages/server/deploy.sh` hardcoded `--max-instances 3` / `--min-instances 0` as shared literals, so (a) the emergency scaling mitigation lived only on the running revision and any deploy reverted it — the ingress-429 revert hazard — and (b) int and prod couldn't differ. This env-keys those flags from `MIN_INSTANCES`/`MAX_INSTANCES` in each `memex-<env>-deploy-env` secret (defaults `0`/`3` = current behaviour), making config the source of truth.

**Per-env target:** prod `maxScale 8 / minScale 1 / DB_POOL_MAX 4` → budget `8 × (4+1) = 40 < ~47`; int stays `3 / 0` (its `db-f1-micro` can't take more).

The connection budget is `maxScale × (DB_POOL_MAX + 1 relay LISTEN)` — the `+1` is the spec-156 bus-relay LISTEN (one persistent connection per instance). The post-mitigation FATAL was `8 × (5+1) = 48 > 47`, corrected live to pool 4 (40). **No `connection.ts` change** — the pool already reaps idles (`idle_timeout 60`).

## Tests

- New `spec-518-scaling-budget.regression.test.ts` (6 green): env-keying + budget invariant + a regression guard that the `8×6=48` mitigation is over the prod ceiling. Tagged spec-518 ac-8 / ac-10.
- Updated the spec-156 `ac-27`/`ac-5` assertion to the env-keyed form (invariant "prod never throttled to a single instance" preserved) + a stale smoke-test comment.
- Full unit suite green (1818 passed).

## Rollout / sequencing (important)

The prod `memex-prod-deploy-env` secret has **already** been updated with `MAX_INSTANCES=8 / MIN_INSTANCES=1 / DB_POOL_MAX=4`. Until this reaches **main**, main's `deploy.sh` still hardcodes maxScale 3 and ignores `MAX_INSTANCES` — so a prod deploy before this merges reverts maxScale to 3 (429 risk). Land this through develop → int → main before the next prod release. Live prod is currently safe (rev 122, budget 40<47).

Spec: `mindset-prod/memex-building-itself/specs/spec-518`

🤖 Generated with [Claude Code](https://claude.com/claude-code)