### PR TITLE
fix(e2e): harden journey-53 /welcome nav against net::ERR_ABORTED flake

### DIFF
--- a/packages/ui/e2e/journey-53-spec-507-no-video-gate.spec.ts
+++ b/packages/ui/e2e/journey-53-spec-507-no-video-gate.spec.ts
@@ -121,8 +121,18 @@ test("a new user never meets the welcome video, and can still choose to watch it
   await expect(watchEntry).toBeVisible();
   await expect(watchEntry).toHaveAttribute("href", "/welcome");
 
-  await page.goto(bareUrl("/welcome"), { waitUntil: "commit" });
-  await expect(page).toHaveURL(/\/welcome/, { timeout: 15_000 });
+  // Dismiss the account popover before navigating. A full-document goto issued while
+  // the popover is still mounted loses the race to the SPA re-render and aborts the
+  // navigation (net::ERR_ABORTED; "frame was detached") — persistently enough under CI
+  // load to burn a whole retry budget. Close it and wait for it to unmount first; the
+  // toPass wrapper (the same idiom used for the onboarding form above) then re-issues
+  // the goto should a residual re-render still race it.
+  await page.keyboard.press("Escape");
+  await expect(watchEntry).toBeHidden();
+  await expect(async () => {
+    await page.goto(bareUrl("/welcome"), { waitUntil: "commit" });
+    await expect(page).toHaveURL(/\/welcome/, { timeout: 5_000 });
+  }).toPass({ timeout: 20_000 });
   // Assert on the heading (plain DOM text, always present when WelcomePage mounts)
   // rather than the <video> element — the video's src is a real external GCS asset
   // the cold e2e env may not fetch, leaving the element with zero dimensions.


### PR DESCRIPTION
## Why

PR #574 (spec-518) merged to `develop` but the deploy was **skipped** — the deploy gate fails closed on a red `test` workflow, and `test` went red on a single flaky e2e journey: `journey-53-spec-507-no-video-gate.spec.ts` (**1 failed / 45 passed**, then **6/6 across retries**).

The failure is **not** from #574 — that change is entirely under `packages/server` + `deploy.sh`, and Playwright sharding only sees `packages/ui/e2e/*.spec.ts`, so shard composition was byte-identical. journey-53 would fail the same on the parent commit; it's a genuinely flaky journey now failing hard and blocking **all** develop deploys.

## Root cause

The test issues a full-document `page.goto("/welcome", { waitUntil: "commit" })` immediately after opening the account popover. The CI trace shows the `/welcome` request with `status = -1`, no `redirectURL`, `net::ERR_ABORTED; "frame was detached"` — the navigation is **aborted client-side before any server response**, losing the race to the SPA re-render while the popover is still mounted. Not a server error, not a redirect-away, not "/welcome broken."

## Fix

Dismiss the popover (`Escape`) and wait for it to unmount **before** navigating, so the goto starts from a settled DOM — removing the race at its source. A `toPass` wrapper (the same idiom this file already uses for the onboarding form above) re-issues the goto if a residual re-render still races it.

> A first pass wrapped the goto in `toPass` alone; on CI that still left a persistent-abort tail that burned the whole retry budget and recovered only via Playwright's test-level retry (`1 flaky`). Closing the popover fixes attempt 1 itself.

## Verification

Cold run (CI parity), scoped + stressed:

```
PGPASSWORD=postgres make e2e-cold ARGS="journey-53 --repeat-each=5"
→ 5 passed (43.7s)
```

Unblocks the spec-518 int deploy once merged (re-greens the gate for the SHA).

🤖 Generated with [Claude Code](https://claude.com/claude-code)