### PR TITLE
fix(deploy): refuse to silently reduce Cloud Run capacity — the 2026-08-07 prod downscale

### DIFF
--- a/packages/server/deploy.sh
+++ b/packages/server/deploy.sh
@@ -375,16 +375,122 @@ REMOVE_CONVERSION_SECRETS="${REMOVE_CONVERSION_SECRETS#,}"  # strip leading comm
 # MERGE leaves the live setting intact rather than blanking it — a deploy from a
 # checkout that never set the value can't silently un-hide features (spec-168
 # dec-4). The ${var+...} form is safe under `set -u`.
+# ── Step 4a: the scale-down guard ─────────────────────────────
+#
+# WHY THIS EXISTS. On 2026-08-07 a prod deploy silently cut Cloud Run from
+# minScale 1 / maxScale 8 down to 0 / 3. Nothing errored and nothing was misconfigured
+# in any obvious way: the flags below substitute ${MIN_INSTANCES:-0} / ${MAX_INSTANCES:-3},
+# the two keys were absent from the env blob THIS deploy actually reads, so the defaults
+# applied and gcloud dutifully re-asserted them over the live values. The whole event is
+# invisible in the deploy log — MIN_INSTANCES/MAX_INSTANCES appear zero times.
+#
+# THE TRAP is that per-env scaling config lives in TWO stores and only one is read here:
+#   * CI writes scripts/deploy.<env>.env from the GitHub Actions environment secret
+#     DEPLOY_ENV_FILE (.github/workflows/deploy.yml) — this is what a deploy consumes.
+#   * The GCP Secret Manager secret memex-<env>-deploy-env is what a human inspects.
+# A key present in the second and absent from the first reads as "configured" and deploys
+# as "default". Verifying the wrong store is exactly how the 2026-08-07 reduction was
+# green-lit.
+#
+# So this guard deliberately does NOT validate config, and does not require the variables
+# to be set. It compares what is about to be ASSERTED against what is LIVE and refuses to
+# shrink capacity. That holds whatever the cause — an unset key, the wrong store, a typo,
+# a stale blob, or a scaling knob nobody has added a check for yet — which is why it is a
+# comparison against reality rather than a required-variable assertion. std-26 §6 cl-136 is
+# the rule it enforces: a deploy re-asserts everything, so anything it fails to restate is
+# silently destroyed.
+#
+# Scaling UP is always allowed. Only a reduction stops the deploy, and ALLOW_SCALE_DOWN=1
+# is the sanctioned way to mean it on purpose — an unoverridable guard gets deleted by the
+# first person who legitimately needs to scale down, which would leave nothing at all.
+RESOLVED_MIN_INSTANCES="${MIN_INSTANCES:-0}"
+RESOLVED_MAX_INSTANCES="${MAX_INSTANCES:-3}"
+if [ -n "${MIN_INSTANCES+set}" ]; then
+  MIN_INSTANCES_SOURCE="config"
+else
+  MIN_INSTANCES_SOURCE="DEFAULT — MIN_INSTANCES absent from scripts/deploy.${ENV}.env"
+fi
+if [ -n "${MAX_INSTANCES+set}" ]; then
+  MAX_INSTANCES_SOURCE="config"
+else
+  MAX_INSTANCES_SOURCE="DEFAULT — MAX_INSTANCES absent from scripts/deploy.${ENV}.env"
+fi
+echo "  scaling to assert: --min-instances ${RESOLVED_MIN_INSTANCES} [${MIN_INSTANCES_SOURCE}]"
+echo "                     --max-instances ${RESOLVED_MAX_INSTANCES} [${MAX_INSTANCES_SOURCE}]"
+
+# Read the LIVE annotations. `|| true` because a first-ever deploy has no service to
+# describe, and `set -e` would otherwise abort here rather than proceed to create it.
+_live_scale_annotation() {
+  gcloud run services describe "${SERVICE}" \
+    --region "${REGION}" \
+    --project "${GCP_PROJECT}" \
+    --format="value(spec.template.metadata.annotations['autoscaling.knative.dev/$1'])" \
+    2>/dev/null || true
+}
+LIVE_MIN_INSTANCES="$(_live_scale_annotation minScale)"
+LIVE_MAX_INSTANCES="$(_live_scale_annotation maxScale)"
+
+SCALE_DOWN_REPORT=""
+if [ -n "${LIVE_MIN_INSTANCES}" ] && [ "${RESOLVED_MIN_INSTANCES}" -lt "${LIVE_MIN_INSTANCES}" ]; then
+  SCALE_DOWN_REPORT="${SCALE_DOWN_REPORT}    min-instances: live ${LIVE_MIN_INSTANCES} → would become ${RESOLVED_MIN_INSTANCES}  [${MIN_INSTANCES_SOURCE}]
+"
+fi
+if [ -n "${LIVE_MAX_INSTANCES}" ] && [ "${RESOLVED_MAX_INSTANCES}" -lt "${LIVE_MAX_INSTANCES}" ]; then
+  SCALE_DOWN_REPORT="${SCALE_DOWN_REPORT}    max-instances: live ${LIVE_MAX_INSTANCES} → would become ${RESOLVED_MAX_INSTANCES}  [${MAX_INSTANCES_SOURCE}]
+"
+fi
+
+if [ -z "${LIVE_MIN_INSTANCES}${LIVE_MAX_INSTANCES}" ]; then
+  echo "  scale-down guard: no live scaling annotations on ${SERVICE} (first deploy?) — nothing to compare"
+elif [ -n "${SCALE_DOWN_REPORT}" ]; then
+  if [ "${ALLOW_SCALE_DOWN:-}" = "1" ]; then
+    echo "  ⚠ SCALE-DOWN GUARD OVERRIDDEN (ALLOW_SCALE_DOWN=1) — reducing ${ENV} capacity deliberately:"
+    printf '%s' "${SCALE_DOWN_REPORT}"
+  else
+    {
+      echo ""
+      echo "═══════════════════════════════════════════════"
+      echo "  ✗ SCALE-DOWN GUARD: refusing to reduce ${ENV} Cloud Run capacity"
+      echo "═══════════════════════════════════════════════"
+      printf '%s' "${SCALE_DOWN_REPORT}"
+      echo ""
+      echo "  A deploy re-asserts every scaling flag (std-26 §6 cl-136), so this would"
+      echo "  have destroyed the live value rather than left it alone."
+      echo ""
+      echo "  If a value reads as DEFAULT above, the key is missing from the blob THIS"
+      echo "  deploy reads. Note there are two stores and they can disagree:"
+      echo "    • CI  → the GitHub Actions '${ENV}' environment secret DEPLOY_ENV_FILE"
+      echo "            (written to scripts/deploy.${ENV}.env by .github/workflows/deploy.yml)"
+      echo "    • human-inspected → GCP Secret Manager 'memex-${ENV}-deploy-env'"
+      echo "  Setting it in the second WITHOUT the first is what caused the 2026-08-07"
+      echo "  prod reduction. Fix the store this deploy actually reads."
+      echo ""
+      echo "  Budget invariant before raising MAX_INSTANCES (spec-518, db/connection.ts):"
+      echo "    MAX_INSTANCES × (DB_POOL_MAX + 1 relay LISTEN) < the DB's usable ceiling"
+      echo "    (prod: max_connections 50 − 3 superuser ≈ 47)"
+      echo ""
+      echo "  To reduce capacity on purpose, re-run with ALLOW_SCALE_DOWN=1."
+      echo "═══════════════════════════════════════════════"
+    } >&2
+    exit 1
+  fi
+else
+  echo "  scale-down guard: OK (live ${LIVE_MIN_INSTANCES}/${LIVE_MAX_INSTANCES} → ${RESOLVED_MIN_INSTANCES}/${RESOLVED_MAX_INSTANCES})"
+fi
+
+# ── Step 4b: Deploy to Cloud Run ──────────────────────────────
 # Resource/scaling flags are re-asserted every deploy: gcloud reverts anything a deploy
 # doesn't restate, so a console-set value silently disappears on the next deploy (std-26 §6
 # cl-136, spec-489). --memory/--concurrency/--cpu-boost restate the current live values so they
 # survive. --min-instances/--max-instances are ENV-KEYED per-env (spec-518): MIN_INSTANCES /
 # MAX_INSTANCES come from the memex-<env>-deploy-env secret and default to 0/3 (today's
 # behaviour) when unset, so prod and int can differ and the live scaling can't drift from
-# config. Budget invariant (spec-518 / db/connection.ts:29): MAX_INSTANCES × (DB_POOL_MAX + 1
-# relay LISTEN) must stay under the DB's effective ceiling (prod ~47) — a value pair that
-# violates it can exhaust connections (the 2026-08-03 FATAL). DB_POOL_MAX is the per-env pool
-# cap (prod=4 under maxScale 8 → 8×(4+1)=40<47; spec-489/spec-518/spec-332); omitted when unset.
+# config. Both pass through the Step 4a scale-down guard above, so a default that would
+# shrink live capacity aborts the deploy instead of silently applying. Budget invariant
+# (spec-518 / db/connection.ts:29): MAX_INSTANCES × (DB_POOL_MAX + 1 relay LISTEN) must stay
+# under the DB's effective ceiling (prod ~47) — a value pair that violates it can exhaust
+# connections (the 2026-08-03 FATAL). DB_POOL_MAX is the per-env pool cap (prod=4 under
+# maxScale 8 → 8×(4+1)=40<47; spec-489/spec-518/spec-332); omitted when unset.
 gcloud run deploy "${SERVICE}" \
   --image "${IMAGE}" \
   --platform managed \

--- a/packages/server/src/__regression__/deploy-scale-down-guard.regression.test.ts
+++ b/packages/server/src/__regression__/deploy-scale-down-guard.regression.test.ts
@@ -1,0 +1,186 @@
+// The scale-down guard in packages/server/deploy.sh (Step 4a).
+//
+// WHAT IT PREVENTS. On 2026-08-07 a prod deploy silently reduced Cloud Run from
+// minScale 1 / maxScale 8 to 0 / 3. The scaling flags substitute
+// ${MIN_INSTANCES:-0} / ${MAX_INSTANCES:-3}; those two keys were absent from the env
+// blob the deploy actually reads, so the defaults applied and gcloud re-asserted them
+// over the live values (std-26 §6 cl-136 — a deploy destroys anything it fails to
+// restate). MIN_INSTANCES/MAX_INSTANCES appeared ZERO times in the deploy log, so
+// nothing about it was visible either during or after.
+//
+// WHY THESE TESTS EXECUTE THE SCRIPT RATHER THAN GREP IT. The sibling
+// spec-518-scaling-budget regression test asserts statically that the flags read from
+// env — and it passed on the day the reduction shipped, because presence of the
+// mechanism was never the problem. A static assertion cannot tell you whether the
+// guard actually refuses. So each case below EXTRACTS the real Step 4a block out of
+// the real deploy.sh and RUNS it under bash with a stubbed `gcloud`, asserting the
+// exit code and the operator-facing message. Re-implementing the logic here would
+// only prove that this file's copy works, which is worthless — that mistake is
+// precisely what spec-521's archived-guard tests were written to avoid.
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+
+const REPO_ROOT = join(__dirname, "..", "..", "..", "..");
+const DEPLOY_SH = readFileSync(join(REPO_ROOT, "packages", "server", "deploy.sh"), "utf-8");
+
+// Pull the guard out of the shipped script by its step markers. If either marker ever
+// moves or is renamed, extraction fails loudly rather than silently testing nothing —
+// an empty block that "passes" would be the worst outcome here.
+function extractGuardBlock(): string {
+  const start = DEPLOY_SH.indexOf("# ── Step 4a: the scale-down guard");
+  const end = DEPLOY_SH.indexOf("# ── Step 4b: Deploy to Cloud Run");
+  if (start === -1 || end === -1 || end <= start) {
+    throw new Error(
+      "could not extract Step 4a scale-down guard from deploy.sh — markers moved? " +
+        `start=${start} end=${end}`,
+    );
+  }
+  const block = DEPLOY_SH.slice(start, end);
+  if (!block.includes("SCALE_DOWN_REPORT") || !block.includes("ALLOW_SCALE_DOWN")) {
+    throw new Error("extracted block does not look like the scale-down guard");
+  }
+  return block;
+}
+
+const GUARD = extractGuardBlock();
+
+interface RunOpts {
+  liveMin: string;
+  liveMax: string;
+  minInstances?: string;
+  maxInstances?: string;
+  allowScaleDown?: string;
+}
+
+// Runs the REAL guard text with `gcloud` shadowed by a shell function. A bash function
+// takes precedence over an executable of the same name, so the guard's own
+// `_live_scale_annotation` calls land on the stub without the guard being modified.
+function runGuard(o: RunOpts): { status: number; stdout: string; stderr: string } {
+  const script = `
+set -euo pipefail
+ENV=prod
+SERVICE=memex-api
+REGION=us-east4
+GCP_PROJECT=memex-ai-prod
+gcloud() {
+  case "$*" in
+    *minScale*) printf '%s' "\${STUB_LIVE_MIN}" ;;
+    *maxScale*) printf '%s' "\${STUB_LIVE_MAX}" ;;
+    *) return 1 ;;
+  esac
+}
+${GUARD}
+`;
+  const env: Record<string, string> = {
+    ...process.env,
+    STUB_LIVE_MIN: o.liveMin,
+    STUB_LIVE_MAX: o.liveMax,
+  };
+  if (o.minInstances !== undefined) env.MIN_INSTANCES = o.minInstances;
+  if (o.maxInstances !== undefined) env.MAX_INSTANCES = o.maxInstances;
+  if (o.allowScaleDown !== undefined) env.ALLOW_SCALE_DOWN = o.allowScaleDown;
+  const r = spawnSync("bash", ["-c", script], { env, encoding: "utf-8" });
+  return { status: r.status ?? -1, stdout: r.stdout ?? "", stderr: r.stderr ?? "" };
+}
+
+describe("deploy.sh scale-down guard — the 2026-08-07 prod reduction cannot recur", () => {
+  it("REPRODUCES the incident: live 1/8 with both keys unset is REFUSED", () => {
+    // The exact 2026-08-07 shape — nothing set, defaults 0/3, live 1/8.
+    const r = runGuard({ liveMin: "1", liveMax: "8" });
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain("refusing to reduce prod Cloud Run capacity");
+    expect(r.stderr).toContain("min-instances: live 1 → would become 0");
+    expect(r.stderr).toContain("max-instances: live 8 → would become 3");
+  });
+
+  it("names the DEFAULT as the cause, so the log says why", () => {
+    const r = runGuard({ liveMin: "1", liveMax: "8" });
+    expect(r.stderr).toContain("MAX_INSTANCES absent from scripts/deploy.prod.env");
+  });
+
+  it("names BOTH config stores — verifying the wrong one is how the incident happened", () => {
+    const r = runGuard({ liveMin: "1", liveMax: "8" });
+    expect(r.stderr).toContain("DEPLOY_ENV_FILE");
+    expect(r.stderr).toContain("memex-prod-deploy-env");
+  });
+
+  it("allows the correct config through untouched (live 1/8 → 1/8)", () => {
+    const r = runGuard({ liveMin: "1", liveMax: "8", minInstances: "1", maxInstances: "8" });
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain("scale-down guard: OK");
+  });
+
+  it("allows scaling UP — the guard is one-directional", () => {
+    const r = runGuard({ liveMin: "1", liveMax: "8", minInstances: "2", maxInstances: "16" });
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain("scale-down guard: OK");
+  });
+
+  it("refuses a partial reduction — max held, min dropped", () => {
+    const r = runGuard({ liveMin: "1", liveMax: "8", minInstances: "0", maxInstances: "8" });
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain("min-instances: live 1 → would become 0");
+    expect(r.stderr).not.toContain("max-instances: live");
+  });
+
+  it("ALLOW_SCALE_DOWN=1 permits a deliberate reduction, and says so loudly", () => {
+    const r = runGuard({
+      liveMin: "1",
+      liveMax: "8",
+      minInstances: "0",
+      maxInstances: "3",
+      allowScaleDown: "1",
+    });
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain("SCALE-DOWN GUARD OVERRIDDEN");
+    expect(r.stdout).toContain("max-instances: live 8 → would become 3");
+  });
+
+  it("does not block a first-ever deploy, where there is no live service to compare", () => {
+    const r = runGuard({ liveMin: "", liveMax: "" });
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain("first deploy?");
+  });
+
+  it("still guards when only one annotation is readable", () => {
+    // minScale absent on the live service, maxScale present — the max reduction must
+    // still be caught rather than skipped because the pair was incomplete.
+    const r = runGuard({ liveMin: "", liveMax: "8" });
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain("max-instances: live 8 → would become 3");
+  });
+
+  it("surfaces the connection-budget invariant before anyone raises MAX_INSTANCES", () => {
+    // Raising max-instances to escape this guard is the obvious next move, and doing it
+    // without the pool arithmetic is what caused the 2026-08-03 connection FATAL.
+    const r = runGuard({ liveMin: "1", liveMax: "8" });
+    expect(r.stderr).toContain("DB_POOL_MAX + 1");
+  });
+});
+
+describe("deploy.sh scale-down guard — wiring", () => {
+  it("runs BEFORE the gcloud run deploy it protects", () => {
+    const guardAt = DEPLOY_SH.indexOf("# ── Step 4a: the scale-down guard");
+    const deployAt = DEPLOY_SH.indexOf('gcloud run deploy "${SERVICE}"');
+    expect(guardAt).toBeGreaterThan(-1);
+    expect(deployAt).toBeGreaterThan(-1);
+    expect(guardAt).toBeLessThan(deployAt);
+  });
+
+  it("compares against LIVE state rather than asserting the variables are set", () => {
+    // The distinction matters: a required-variable check would pass the moment someone
+    // set the keys in either store, including the wrong one. Comparing to live state is
+    // what makes the guard indifferent to which store is at fault.
+    expect(GUARD).toContain("gcloud run services describe");
+    expect(GUARD).toContain("autoscaling.knative.dev/");
+  });
+
+  it("does not abort the deploy when the live lookup itself fails", () => {
+    // `|| true` on the describe: a transient API error or a missing service must not
+    // become a deploy outage under `set -e`.
+    expect(GUARD).toContain("|| true");
+  });
+});


### PR DESCRIPTION
## What happened

A prod deploy on 2026-08-07 cut Cloud Run from `minScale 1 / maxScale 8` to `0 / 3`. Nothing errored. The flags substitute `${MIN_INSTANCES:-0}` / `${MAX_INSTANCES:-3}`; those keys were absent from the env blob the deploy actually reads, so the defaults applied and gcloud re-asserted them over the live values — std-26 §6 cl-136: **a deploy destroys anything it fails to restate.** `MIN_INSTANCES`/`MAX_INSTANCES` appear **zero times** in that deploy's log, so the reduction was invisible during and after.

## The trap

Per-env scaling config lives in **two stores** and only one is read at deploy time:

| store | read by | contains the keys? |
|---|---|---|
| GitHub Actions env secret `DEPLOY_ENV_FILE` → `scripts/deploy.<env>.env` | **the deploy** (`deploy.yml:133`) | **no** |
| GCP Secret Manager `memex-<env>-deploy-env` | humans inspecting config | yes — `MIN_INSTANCES=1`, `MAX_INSTANCES=8`, `DB_POOL_MAX=4` |

So the values read as *configured* and deployed as *default*. Verifying the wrong store is exactly how the reduction was green-lit.

## The fix

A pre-deploy guard (Step 4a) that **deliberately does not validate config** and does not require the variables to be set. It compares what is about to be **asserted** against what is **live**, and refuses to shrink capacity.

That distinction is the whole point: a required-variable assertion would have passed the moment someone set the keys in *either* store, including the wrong one. Comparing against live state makes the guard indifferent to which store is at fault — it holds for an unset key, the wrong store, a typo, a stale blob, or a scaling knob nobody has added a check for yet.

- Scaling **up** is always allowed; only a reduction stops the deploy
- `ALLOW_SCALE_DOWN=1` is the sanctioned override — a guard with no escape hatch gets deleted by the first person who legitimately needs to scale down
- A first-ever deploy (no live service to describe) is not blocked
- A failed live lookup cannot itself abort the deploy (`|| true` under `set -e`)
- The refusal names **both stores**, marks which value came from a `DEFAULT`, and states the connection-budget invariant — because raising `MAX_INSTANCES` is the obvious way to escape the guard, and doing that without the pool arithmetic is what caused the 2026-08-03 connection FATAL

## Immediate consequence — read before merging

Prod's live `1/8` was restored out-of-band. Until the GitHub `prod` environment's `DEPLOY_ENV_FILE` secret carries `MIN_INSTANCES=1` and `MAX_INSTANCES=8`, **the next prod deploy will ABORT** rather than clobber it. Capacity is preserved, the deploy is blocked, and the message says exactly what to fix — fail-closed in the safe direction. Adding those two keys to that secret clears it.

## Tests — they execute the guard, they don't grep for it

The existing `spec-518-scaling-budget` regression test asserts *statically* that the flags read from env, and **it passed on the day the reduction shipped** — presence of the mechanism was never the problem, so a static assertion could not have caught this.

So each of the 13 cases here extracts the real Step 4a block out of the shipped `deploy.sh` and runs it under `bash` with `gcloud` shadowed by a shell function, asserting exit code and operator-facing output — including a direct reproduction of the 2026-08-07 shape (live 1/8, both keys unset → refused). Re-implementing the logic in the test would only prove the test's own copy works.

Removing the guard makes extraction throw, so the tests fail loudly rather than silently testing nothing.

## Verification

`bash -n` clean · `shellcheck -S error` clean · biome clean · `tsc --noEmit` clean · `make check` clean · full server suite **5,905 passed / 0 failed** (622 files) · red proven before green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)