### PR TITLE
fix(spec-515): bound the AC-emitter's 404 fallback before it ever reaches consumers

### DIFF
--- a/packages/ac-emit-vitest/src/emit-batch-fallback.spec-515.test.ts
+++ b/packages/ac-emit-vitest/src/emit-batch-fallback.spec-515.test.ts
@@ -1,0 +1,161 @@
+// spec-515 t-11 / ac-13, ac-14 — the 404 fallback must be bounded and must give up
+// once auth is definitively refused.
+//
+// WHAT THE FALLBACK IS FOR. A server with no `/batch` route (an older deploy, or a
+// self-hosted install on a prior version — std-22 portability) answers 404/405, and
+// emitBatch degrades to one POST per event so emissions still land. That path is
+// deliberate and permanent; spec-515 only makes it rare against Memex's own hosts.
+//
+// WHAT WAS WRONG WITH IT. `await Promise.all(bucket.map(emit))` released EVERY
+// buffered event of a file simultaneously, and vitest runs files across parallel
+// workers, so in-flight requests were (events per file) × (workers), uncapped.
+// Measured consequence on prod 2026-07-24: ~1,800 single POSTs/min. The sharpest
+// risk is not DB CPU but CONNECTION-POOL STARVATION — DB_POOL_MAX=10 × maxScale 3
+// = 30 slots total, against which one 50-test file across 7 workers can put ~350
+// concurrent requests, queueing CI traffic ahead of real users. Verbatim what
+// spec-489 ac-3 set out to prevent.
+//
+// AND: a 401 on the first fallback POST guarantees the rest will also 401 — same
+// key, same server — but they were already in flight, and nothing watched the first
+// failure to stop the others. Measured: 1,347 rejections in 3 minutes (2026-07-26),
+// which were 1,347 DISTINCT events failing once each. There is no retry in this
+// emitter; the volume came from the fan-out.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { emitBatch, tagAc } from "./index.js";
+import { MAX_FALLBACK_CONCURRENCY } from "./emit.js";
+
+const AC_BOUNDED = "mindset-prod/memex-building-itself/specs/spec-515/acs/ac-13";
+const AC_SHORTCIRCUIT = "mindset-prod/memex-building-itself/specs/spec-515/acs/ac-14";
+
+const entries = (n: number) =>
+  Array.from({ length: n }, (_, i) => ({
+    ac_uid: "mindset-prod/foo/specs/spec-1/acs/ac-1",
+    status: "pass" as const,
+    test_identifier: `test.ts::t${i}`,
+    duration_ms: 1,
+  }));
+
+/** 404 on /batch, then a caller-supplied response for each single-event POST. */
+function transportWith(single: () => Promise<unknown> | unknown) {
+  const inFlight = { now: 0, peak: 0 };
+  const singleCalls: string[] = [];
+  const fetchMock = vi.fn(async (url: string) => {
+    if (String(url).endsWith("/batch")) {
+      return { ok: false, status: 404, headers: new Headers(), text: async () => "" };
+    }
+    singleCalls.push(String(url));
+    inFlight.now += 1;
+    inFlight.peak = Math.max(inFlight.peak, inFlight.now);
+    try {
+      // Yield twice so genuinely-parallel calls overlap and `peak` is meaningful;
+      // a single microtask would let each call finish before the next begins and
+      // the assertion would pass even with an unbounded fan-out.
+      await Promise.resolve();
+      await Promise.resolve();
+      return (await single()) as never;
+    } finally {
+      inFlight.now -= 1;
+    }
+  });
+  return { fetchMock, inFlight, singleCalls };
+}
+
+const ok = () => ({ ok: true, status: 201, headers: new Headers(), text: async () => "" });
+const unauthorized = () => ({
+  ok: false,
+  status: 401,
+  headers: new Headers(),
+  text: async () => '{"error":"emission key expired"}',
+});
+
+beforeEach(() => {
+  for (const k of [
+    "MEMEX_EMIT",
+    "MEMEX_EMIT_KEY",
+    "MEMEX_TEST_EVENTS_URL",
+    "GITHUB_ACTOR",
+    "GITLAB_USER_LOGIN",
+    "BUILDKITE_BUILD_AUTHOR",
+    "CIRCLE_USERNAME",
+    "USER",
+    "USERNAME",
+  ]) {
+    vi.stubEnv(k, "");
+  }
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  // std-37 cl-5: a leaked global stub can silently swallow AC emission elsewhere.
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("emitBatch 404 fallback — bounded concurrency (spec-515 ac-13)", () => {
+  it("never holds more than the cap in flight, however many events buffered", async () => {
+    tagAc(AC_BOUNDED);
+    const { fetchMock, inFlight, singleCalls } = transportWith(ok);
+    await emitBatch(entries(40), fetchMock as unknown as typeof fetch);
+
+    // Every event still lands — bounding must not drop emissions.
+    expect(singleCalls).toHaveLength(40);
+    expect(inFlight.peak).toBeLessThanOrEqual(MAX_FALLBACK_CONCURRENCY);
+  });
+
+  it("actually parallelises up to the cap — not accidentally serial", async () => {
+    // A cap of 1 would also satisfy the assertion above while making a 500-event
+    // flush crawl and risk overrunning vitest's afterAll budget. Pin that the
+    // fallback genuinely uses its allowance.
+    tagAc(AC_BOUNDED);
+    const { fetchMock, inFlight } = transportWith(ok);
+    await emitBatch(entries(40), fetchMock as unknown as typeof fetch);
+    expect(inFlight.peak).toBeGreaterThan(1);
+  });
+
+  it("the cap is small enough to respect the server's connection pool", async () => {
+    // DB_POOL_MAX=10 × maxScale 3 = 30 slots, shared with real user traffic. The
+    // cap is per flush and several vitest workers can flush together, so it has to
+    // leave headroom rather than merely be finite.
+    tagAc(AC_BOUNDED);
+    expect(MAX_FALLBACK_CONCURRENCY).toBeLessThanOrEqual(5);
+    expect(MAX_FALLBACK_CONCURRENCY).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe("emitBatch 404 fallback — 401 short-circuit (spec-515 ac-14)", () => {
+  it("abandons the remaining events once a 401 comes back", async () => {
+    tagAc(AC_SHORTCIRCUIT);
+    const { fetchMock, singleCalls } = transportWith(unauthorized);
+    await emitBatch(entries(40), fetchMock as unknown as typeof fetch);
+
+    // An invalid key costs one rejected request per flush, not one per event. The
+    // in-flight batch cannot be recalled, so the bound is the cap — decisively
+    // fewer than 40, which is what turned 1,347 rejections into a handful.
+    expect(singleCalls.length).toBeLessThanOrEqual(MAX_FALLBACK_CONCURRENCY);
+    expect(singleCalls.length).toBeGreaterThan(0);
+  });
+
+  it("does NOT short-circuit on an ordinary non-2xx — only on refused auth", async () => {
+    // A 500 is transient and per-event; abandoning the flush would silently lose
+    // emissions the server might well have accepted. Only 401 is definitive.
+    tagAc(AC_SHORTCIRCUIT);
+    const { fetchMock, singleCalls } = transportWith(() => ({
+      ok: false,
+      status: 500,
+      headers: new Headers(),
+      text: async () => "boom",
+    }));
+    await emitBatch(entries(12), fetchMock as unknown as typeof fetch);
+    expect(singleCalls).toHaveLength(12);
+  });
+
+  it("does not throw when auth is refused mid-flush (fail-safe holds)", async () => {
+    tagAc(AC_SHORTCIRCUIT);
+    const { fetchMock } = transportWith(unauthorized);
+    await expect(
+      emitBatch(entries(20), fetchMock as unknown as typeof fetch),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/packages/ac-emit-vitest/src/emit-fallback-failsafe.spec-515.test.ts
+++ b/packages/ac-emit-vitest/src/emit-fallback-failsafe.spec-515.test.ts
@@ -1,0 +1,166 @@
+// spec-515 t-12 / ac-15 — the fail-safe contract survives the t-11 changes.
+//
+// THE CONTRACT: a failed emission must never fail — or STALL — a consumer's test
+// run. Stalling matters as much as throwing, because an awaited flush that overruns
+// vitest's `afterAll` budget fails the run just as surely.
+//
+// WHY THIS TASK EXISTS AS ITS OWN GUARD. t-11 replaced an unbounded
+// `Promise.all(bucket.map(emit))` with a bounded worker pool. That fixed
+// connection-pool starvation and introduced a NEW failure mode in its place:
+// bounding serialises, so total time became LINEAR in the buffer size. Measured
+// before the fix below, at 40ms per request with a cap of 4:
+//
+//     12 events  →  144ms   (12/4 × 40)
+//    120 events  → 1240ms   (120/4 × 40)
+//
+// Extrapolate to a HUNG server, where per-request latency is the 5s AbortSignal
+// timeout: 120 events → 120/4 × 5s = 150 SECONDS. The old unbounded fan-out failed
+// the same case in ~5s. So t-11, taken alone, converted a fast failure into a
+// guaranteed hook-timeout — the one thing the contract forbids. The fix is a total
+// deadline on top of the per-request one; these tests pin both halves.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { emitBatch, tagAc } from "./index.js";
+import {
+  FALLBACK_START_DEADLINE_MS,
+  MAX_FALLBACK_CONCURRENCY,
+  PER_REQUEST_TIMEOUT_MS,
+  runBoundedFallback,
+} from "./emit.js";
+
+const AC = "mindset-prod/memex-building-itself/specs/spec-515/acs/ac-15";
+
+const entries = (n: number) =>
+  Array.from({ length: n }, (_, i) => ({
+    ac_uid: "mindset-prod/foo/specs/spec-1/acs/ac-1",
+    status: "pass" as const,
+    test_identifier: `test.ts::t${i}`,
+    duration_ms: 1,
+  }));
+
+/** 404 on /batch so emitBatch degrades to the fallback, then `single` per event. */
+const transportWith = (single: () => Promise<unknown> | unknown) =>
+  vi.fn(async (url: string) => {
+    if (String(url).endsWith("/batch")) {
+      return { ok: false, status: 404, headers: new Headers(), text: async () => "" };
+    }
+    return (await single()) as never;
+  });
+
+const slow = (ms: number) => async () => {
+  await new Promise((r) => setTimeout(r, ms));
+  return { ok: true, status: 201, headers: new Headers(), text: async () => "" };
+};
+
+beforeEach(() => {
+  for (const k of ["MEMEX_EMIT", "MEMEX_EMIT_KEY", "MEMEX_TEST_EVENTS_URL"]) {
+    vi.stubEnv(k, "");
+  }
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  // std-37 cl-5 — a leaked global stub can silently swallow AC emission elsewhere.
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("fallback total deadline (spec-515 ac-15)", () => {
+  it("stops issuing requests once the deadline is spent", async () => {
+    // The regression this guards: without a total deadline, 200 slow events would
+    // all be attempted, 4 at a time, however long that takes.
+    tagAc(AC);
+    const transport = transportWith(slow(20));
+    await runBoundedFallback(entries(200), transport as unknown as typeof fetch, 120);
+    // 120ms of budget at 20ms per request, 4 in flight ≈ 24 requests. Assert it
+    // stopped WELL short of 200 rather than pinning a brittle exact count.
+    const singles = transport.mock.calls.filter(([u]) => !String(u).endsWith("/batch"));
+    expect(singles.length).toBeLessThan(60);
+    expect(singles.length).toBeGreaterThan(0);
+  });
+
+  it("keeps a hung server inside vitest's afterAll budget", async () => {
+    // The arithmetic that matters, asserted on the constants rather than by waiting
+    // 10s: the deadline bounds when the LAST request may START, and each request is
+    // itself bounded, so worst-case total ≤ deadline + per-request timeout. That has
+    // to leave room inside vitest's 10s default hookTimeout for everything else in
+    // afterAll.
+    tagAc(AC);
+    expect(FALLBACK_START_DEADLINE_MS + PER_REQUEST_TIMEOUT_MS).toBeLessThan(10_000);
+    // And it must be generous enough that a healthy-but-slow server still lands a
+    // realistic file's worth of events: ~4 × deadline/200ms at 200ms per request.
+    expect(FALLBACK_START_DEADLINE_MS).toBeGreaterThanOrEqual(3_000);
+  });
+
+  it("a large buffer against a healthy server still completes promptly", async () => {
+    tagAc(AC);
+    const transport = transportWith(slow(2));
+    const t0 = Date.now();
+    await runBoundedFallback(entries(120), transport as unknown as typeof fetch);
+    expect(Date.now() - t0).toBeLessThan(FALLBACK_START_DEADLINE_MS);
+  });
+});
+
+describe("fail-safe: every failure mode leaves the run green (spec-515 ac-15)", () => {
+  const modes: Array<[string, () => Promise<unknown> | unknown]> = [
+    ["401 — auth refused mid-flush", () => ({ ok: false, status: 401, headers: new Headers(), text: async () => "expired" })],
+    ["500 — transient, per-event", () => ({ ok: false, status: 500, headers: new Headers(), text: async () => "boom" })],
+    ["network error", () => { throw new Error("ECONNREFUSED"); }],
+    ["a body that cannot be read", () => ({ ok: false, status: 400, headers: new Headers(), text: async () => { throw new Error("unreadable"); } })],
+    ["a response with no headers object", () => ({ ok: true, status: 201, text: async () => "" })],
+  ];
+
+  for (const [label, single] of modes) {
+    it(`resolves, never throws: ${label}`, async () => {
+      tagAc(AC);
+      await expect(
+        emitBatch(entries(9), transportWith(single) as unknown as typeof fetch),
+      ).resolves.toBeUndefined();
+    });
+  }
+
+  it("resolves when the whole transport rejects (no /batch, no anything)", async () => {
+    tagAc(AC);
+    const transport = vi.fn(async () => {
+      throw new Error("host unreachable");
+    });
+    await expect(
+      emitBatch(entries(5), transport as unknown as typeof fetch),
+    ).resolves.toBeUndefined();
+  });
+
+  it("honours the off switch even with a full buffer — zero requests", async () => {
+    tagAc(AC);
+    vi.stubEnv("MEMEX_EMIT", "false");
+    const transport = transportWith(slow(0));
+    await emitBatch(entries(30), transport as unknown as typeof fetch);
+    expect(transport).not.toHaveBeenCalled();
+  });
+
+  it("a server with no /batch route still lands every event (std-22 self-hosted)", async () => {
+    // The fallback is a deliberate portability feature, not a bug path. Bounding and
+    // deadlining it must not turn "slower" into "lossy" for a healthy old server.
+    tagAc(AC);
+    const transport = transportWith(slow(0));
+    await emitBatch(entries(25), transport as unknown as typeof fetch);
+    const singles = transport.mock.calls.filter(([u]) => !String(u).endsWith("/batch"));
+    expect(singles).toHaveLength(25);
+  });
+
+  it("never exceeds the concurrency cap while honouring the deadline", async () => {
+    tagAc(AC);
+    let now = 0;
+    let peak = 0;
+    const transport = transportWith(async () => {
+      now += 1;
+      peak = Math.max(peak, now);
+      await Promise.resolve();
+      await Promise.resolve();
+      now -= 1;
+      return { ok: true, status: 201, headers: new Headers(), text: async () => "" };
+    });
+    await emitBatch(entries(50), transport as unknown as typeof fetch);
+    expect(peak).toBeLessThanOrEqual(MAX_FALLBACK_CONCURRENCY);
+  });
+});

--- a/packages/ac-emit-vitest/src/emit.ts
+++ b/packages/ac-emit-vitest/src/emit.ts
@@ -127,10 +127,29 @@ export async function emit(
   args: EmitArgs,
   transport: typeof fetch = globalThis.fetch,
 ): Promise<void> {
-  if (!isEmissionEnabled()) return;
+  await emitOnce(args, transport);
+}
+
+/**
+ * What one emission did. `emit()` deliberately discards this — its documented
+ * contract is `Promise<void>` that never throws, and the `ac-emission-bootstrap`
+ * topic describes that shape for other languages to copy, so it must not change.
+ *
+ * The 404 fallback needs the outcome for one reason only: a 401 means the key is
+ * refused, so every remaining event in the flush will be refused too and sending
+ * them is pure waste (spec-515 ac-14).
+ */
+type EmitOutcome = "ok" | "auth-refused" | "failed";
+
+/** `emit()` with the outcome reported instead of swallowed. Never throws. */
+async function emitOnce(
+  args: EmitArgs,
+  transport: typeof fetch = globalThis.fetch,
+): Promise<EmitOutcome> {
+  if (!isEmissionEnabled()) return "ok";
 
   const url = deriveEventsUrl(args.ac_uid);
-  if (url === null) return;
+  if (url === null) return "ok";
 
   const payload = buildPayload(args);
 
@@ -184,11 +203,72 @@ export async function emit(
         `[ac-emit] server warning for ac_uid=${args.ac_uid}: ${warning}`,
       );
     }
+    // 401 is the only DEFINITIVE refusal: same key, same server, so the rest of
+    // the flush cannot succeed either. A 5xx is transient and per-event — treat it
+    // as a plain failure so a flaky server never silently drops the whole buffer.
+    if (res.status === 401) return "auth-refused";
+    return res.ok ? "ok" : "failed";
   } catch (err) {
     // eslint-disable-next-line no-console
     console.warn(
       `[ac-emit] POST ${url} failed for ac_uid=${args.ac_uid}:`,
       err instanceof Error ? err.message : err,
+    );
+    return "failed";
+  }
+}
+
+/**
+ * How many single-event POSTs the 404 fallback may hold in flight at once
+ * (spec-515 ac-13).
+ *
+ * Was unbounded: `Promise.all` over the whole file buffer, multiplied by however
+ * many vitest workers flushed at the same moment. Observed on prod 2026-07-24 at
+ * ~1,800 POSTs/min.
+ *
+ * The binding constraint is not CPU but the server's connection pool —
+ * `DB_POOL_MAX=10` × `maxScale 3` = 30 slots, shared with real user traffic. This
+ * cap is per flush and several workers can flush together, so it has to leave
+ * headroom rather than merely be finite: 4 keeps even a simultaneous multi-worker
+ * flush in the same order of magnitude as the pool instead of hundreds of times
+ * over it. Exported so the test asserts the real value, not a copy.
+ */
+export const MAX_FALLBACK_CONCURRENCY = 4;
+
+/**
+ * Post `entries` one at a time through `emitOnce`, at most
+ * {@link MAX_FALLBACK_CONCURRENCY} in flight, stopping early if the server refuses
+ * the emission key.
+ *
+ * Never throws: `emitOnce` swallows everything, so the `Promise.all` below cannot
+ * reject and the fail-safe contract survives (spec-515 ac-15 / t-12).
+ */
+async function runBoundedFallback(
+  entries: EmitArgs[],
+  transport: typeof fetch,
+): Promise<void> {
+  let cursor = 0;
+  let authRefused = false;
+
+  const worker = async (): Promise<void> => {
+    while (!authRefused) {
+      const index = cursor++;
+      if (index >= entries.length) return;
+      if ((await emitOnce(entries[index], transport)) === "auth-refused") {
+        authRefused = true;
+      }
+    }
+  };
+
+  const width = Math.min(MAX_FALLBACK_CONCURRENCY, entries.length);
+  await Promise.all(Array.from({ length: width }, () => worker()));
+
+  if (authRefused && cursor < entries.length) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[ac-emit] emission key refused (401) — abandoned ${entries.length - cursor} ` +
+        "of this file's remaining events rather than sending requests that cannot " +
+        "succeed. Provision a fresh key (provision_ac_emission) and re-run.",
     );
   }
 }
@@ -271,9 +351,9 @@ export async function emitBatch(
       // /batch route itself only ever returns 200/400/401, so 404/405 is an
       // unambiguous "route absent" signal, not a per-request error.
       if (res.status === 404 || res.status === 405) {
-        await Promise.all(
-          bucket.map((entry) => emit(entry, transport)),
-        );
+        // spec-515 ac-13/ac-14: bounded, and abandoned early if the key is refused.
+        // Was `Promise.all(bucket.map(emit))` — every event of the file at once.
+        await runBoundedFallback(bucket, transport);
         continue;
       }
 

--- a/packages/ac-emit-vitest/src/emit.ts
+++ b/packages/ac-emit-vitest/src/emit.ts
@@ -179,7 +179,7 @@ async function emitOnce(
       // tagged test — the one thing the fail-safe contract forbids. 5s keeps
       // well under the hook budget; the abort lands in the catch below and
       // degrades to the documented warn-and-continue.
-      signal: AbortSignal.timeout(5000),
+      signal: AbortSignal.timeout(PER_REQUEST_TIMEOUT_MS),
     });
     if (!res.ok) {
       // spec-333: surface the server's RESPONSE BODY, not just the status code, so the
@@ -236,6 +236,36 @@ async function emitOnce(
 export const MAX_FALLBACK_CONCURRENCY = 4;
 
 /**
+ * Client-side bound on ONE request (both the batch POST and each fallback POST).
+ *
+ * A hung server is as dangerous as a failed one: an unbounded awaited fetch rides
+ * past vitest's hook budget and fails the tagged test, which swallowing errors alone
+ * cannot prevent.
+ */
+export const PER_REQUEST_TIMEOUT_MS = 5000;
+
+/**
+ * How long the fallback may keep STARTING new requests (spec-515 t-12 / ac-15).
+ *
+ * Bounding concurrency (ac-13) made total time linear in the buffer: measured at 40ms
+ * per request with a cap of 4, 12 events took 144ms and 120 took 1240ms. Against a
+ * HUNG server, per-request latency becomes PER_REQUEST_TIMEOUT_MS, so 120 events
+ * would take 120/4 × 5s = 150 SECONDS — where the old unbounded fan-out failed the
+ * same case in ~5s. Bounding alone therefore traded a connection-pool problem for a
+ * guaranteed hook-timeout, which the fail-safe contract forbids.
+ *
+ * This deadline gates when the LAST request may start; each request is itself
+ * bounded, so worst-case total ≤ 4000 + 5000 = 9s, inside vitest's 10s default
+ * hookTimeout with ~1s of headroom for the rest of afterAll. Generous enough that a
+ * healthy-but-slow server (200ms/request) still lands ~80 events before the cut.
+ *
+ * The trade-off is deliberate and asymmetric: truncating some emissions loses
+ * verification signal, while overrunning the hook FAILS the consumer's test run. The
+ * contract ranks those, so the deadline wins and the drop is warned about loudly.
+ */
+export const FALLBACK_START_DEADLINE_MS = 4000;
+
+/**
  * Post `entries` one at a time through `emitOnce`, at most
  * {@link MAX_FALLBACK_CONCURRENCY} in flight, stopping early if the server refuses
  * the emission key.
@@ -243,15 +273,22 @@ export const MAX_FALLBACK_CONCURRENCY = 4;
  * Never throws: `emitOnce` swallows everything, so the `Promise.all` below cannot
  * reject and the fail-safe contract survives (spec-515 ac-15 / t-12).
  */
-async function runBoundedFallback(
+export async function runBoundedFallback(
   entries: EmitArgs[],
   transport: typeof fetch,
+  startDeadlineMs: number = FALLBACK_START_DEADLINE_MS,
 ): Promise<void> {
   let cursor = 0;
   let authRefused = false;
+  const startedAt = Date.now();
+  let deadlineHit = false;
 
   const worker = async (): Promise<void> => {
     while (!authRefused) {
+      if (Date.now() - startedAt >= startDeadlineMs) {
+        deadlineHit = true;
+        return;
+      }
       const index = cursor++;
       if (index >= entries.length) return;
       if ((await emitOnce(entries[index], transport)) === "auth-refused") {
@@ -262,6 +299,17 @@ async function runBoundedFallback(
 
   const width = Math.min(MAX_FALLBACK_CONCURRENCY, entries.length);
   await Promise.all(Array.from({ length: width }, () => worker()));
+
+  if (deadlineHit) {
+    const dropped = Math.max(0, entries.length - cursor);
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[ac-emit] fallback deadline (${startDeadlineMs}ms) reached — dropped ${dropped} ` +
+        "of this file's events rather than overrun the test runner's hook budget. " +
+        "The server has no /batch route AND is responding slowly; fix either and the " +
+        "whole buffer lands in one request.",
+    );
+  }
 
   if (authRefused && cursor < entries.length) {
     // eslint-disable-next-line no-console
@@ -341,7 +389,7 @@ export async function emitBatch(
         // Bound the request client-side for the same reason emit() does: a hung
         // server must abort into the catch below rather than ride past vitest's
         // hook timeout and fail the run.
-        signal: AbortSignal.timeout(5000),
+        signal: AbortSignal.timeout(PER_REQUEST_TIMEOUT_MS),
       });
 
       // ROLLOUT SAFETY (spec-489, std-22): a 404/405 means this server has no


### PR DESCRIPTION
Two commits on `packages/ac-emit-vitest` only. No server or UI code. Deliberately split from spec-515's larger branch (`spec-515-flat-api-mount-reachability`) because this half is independent, urgent, and touches nothing a colleague recently shipped.

## Why now — this is a prerequisite, not a cleanup

`emitBatch` degrades to one POST per event when a server has no `/batch` route (an older deploy, or a self-hosted install — std-22). That path releases the **whole file buffer at once** via `Promise.all(bucket.map(emit))`, multiplied by however many vitest workers flush together.

The routing fix already on `develop` (`00394743`) made `/batch` reachable, which removed the *trigger* in our own prod. It did not disarm the fan-out.

**And the sequencing matters.** Measured on prod 2026-08-10: the published `@memex-ai-ac/vitest` is `0.2.0` from **2026-06-07**, while batching landed **2026-07-21**. So external consumers have no batch path at all today — therefore no fallback and no fan-out. Publishing batching (spec-515 t-13) *without* this PR would hand them an unbounded fan-out they do not currently have. **This must merge before that publish.**

## What changes

- `MAX_FALLBACK_CONCURRENCY = 4` — exported so the test asserts the real value. Chosen against the server's 30 connection slots (`DB_POOL_MAX=10` × `maxScale 3`), shared with real user traffic: the cap is per flush and several workers can flush together, so it has to leave headroom rather than merely be finite.
- `FALLBACK_START_DEADLINE_MS = 4000` — a total deadline, because bounding **alone** made total time linear in the buffer. Measured at 40ms/request with cap 4: 12 events → 144ms, 120 → 1240ms. Against a hung server (per-request = the 5s timeout) 120 events would take **150 seconds**, where the old unbounded fan-out failed the same case in ~5s. Bounding by itself therefore traded a connection-pool problem for a guaranteed overrun of vitest's 10s `afterAll` budget — which fails the consumer's run, the one thing the fail-safe contract forbids. Worst case is now ≤ 9s (deadline + one bounded request).
- A 401 stops the flush and warns once with the abandoned count and the `provision_ac_emission` fix. **Only 401** short-circuits: a 5xx is transient and per-event, so abandoning would silently drop emissions the server might accept (asserted).
- `PER_REQUEST_TIMEOUT_MS = 5000` named rather than repeated as a literal.

`emit()`'s public contract is untouched — still `Promise<void>`, still swallows everything, still a 5s `AbortSignal`. The outcome is reported by an internal `emitOnce()` that `emit()` awaits and discards.

## Accepted trade-off, stated plainly

The deadline **drops events** in the pathological case — 103 of 500 in the measurement — and warns loudly with the count and cause. Losing verification signal leaves an AC looking unverified; overrunning the hook fails the run. The contract ranks those, so the deadline wins. It is encapsulated in one constant if you disagree with the balance.

## Testing

- Emitter package: **13 files / 102 tests green**, including the pre-existing 404-fallback tests, so the documented rollout path still works
- `make build`: exit 0
- Deadline proven on wall-clock, not just constants: 500 events against a 40ms server cap at 4126ms with 397 of 500 sent, where before it was 5000ms and unbounded in N
- Fail-safe pinned across 401 mid-flush, 500, network error, an unreadable body, a response with no headers object, a wholly-rejecting transport, and a server with no `/batch` route at all — all resolve, none throw
- Verifies spec-515 ac-13, ac-14, ac-15

## Note on the guidance topic

`get_information(topic='ac-emission-bootstrap')` documents the single-event emitter's contract for other languages to copy. Checked: zero mentions of batch or concurrency, and `emit()`'s behaviour is unchanged — so no update was due.