### PR TITLE
chore(ac-emit-vitest): bump 0.3.0 — then a maintainer must publish

### DIFF
--- a/packages/ac-emit-vitest/package.json
+++ b/packages/ac-emit-vitest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memex-ai-ac/vitest",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Acceptance Criteria emit helper for Vitest. Tag tests with tagAc(), emit pass/fail to a Memex workspace.",
   "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "https://memex.ai",


### PR DESCRIPTION
One line: `0.2.0` → `0.3.0` in `packages/ac-emit-vitest/package.json`. **Merging this does not publish anything** — see the handoff at the bottom.

## Why a publish is the actual fix

```
published on npm:  0.2.0, 2026-06-07
batching landed:          2026-07-21   (spec-489 G1)
bounded fallback:         2026-08-10   (#582)
```

**No consumer installing from the registry has ever had a batch path.** Not a broken fallback — an absence. It posts one request per event, unconditionally.

Measured on prod 2026-08-10, identical 15-minute window (13:00–13:15Z):

| Day | per-event POSTs | batch calls |
|---|---|---|
| 08-04 (before the routing fix) | 8,421 | 6 × 404 |
| 08-10 (after it) | **8,508** | **none** |

So `00394743` did exactly what it could — it made `/batch` reachable — and no more. Only consumers inside this monorepo (`workspace:*` → a locally built, gitignored `dist/`) batch, and only if their `dist` was rebuilt after 21 July. That is why the fleet never batched despite the code sitting on `develop` for three weeks.

spec-515 **ac-3 stays unmet until the publish**, not until this merge.

## Why this could not have been published earlier

#582 had to land first. External consumers have no batch path today, therefore no 404 fallback and no fan-out. Publishing batching **without** the bound would have given them `Promise.all` over the whole file buffer for every server lacking `/batch` — older deploys, self-hosted installs per std-22 — which is strictly worse than what they run now. The ordering was a safety property, and it is now satisfied.

## Pre-publish verification already done

Run on `develop` at `7e5e5c08`, before this bump:

- `node scripts/verify-publish-artifact.mjs` → **passed**. It packs the real tarball and imports it as a consumer, which is the check that exists because a `development → ./src` export condition once leaked into the published artifact and broke every external Vitest consumer (spec-90).
- Packed tarball inspected, not assumed — `dist/emit.js` carries `/batch` (6), `MAX_FALLBACK_CONCURRENCY` (3), `FALLBACK_START_DEADLINE_MS` (2), `auth-refused` (2).
- Emitter package: 13 files / 102 tests green. `make build`: exit 0.

## Handoff — this needs a package maintainer

`npm publish` requires one of the three registry maintainers (`wicver`, `wicverm`, `jonathancecil`). After this merges:

```bash
git checkout develop && git pull --ff-only
cd packages/ac-emit-vitest && npm publish
```

`prepublishOnly` rebuilds `dist` and re-runs the verification gate on the publisher's machine, so nothing is taken on trust from this PR.

## Separate issue worth a decision, not fixed here

`dist/` is gitignored, so "is batching active?" varies per machine with no signal — that is the mechanism behind the three-week gap above. Publishing 0.3.0 fixes external consumers; it does not fix this. Options: a build hook, a CI step, or pointing `main` at source. Recorded on spec-515 t-13.