### PR TITLE
fix(spec-515): the smoke checks imported the resolver, so they demanded a database and died on import

### DIFF
--- a/packages/server/src/__smoke__/flat-api-reachability.smoke.test.ts
+++ b/packages/server/src/__smoke__/flat-api-reachability.smoke.test.ts
@@ -26,7 +26,7 @@
 
 import { describe, expect, it } from "vitest";
 import { tagAc } from "@memex-ai-ac/vitest";
-import { reservedApiRoots, TENANT_EXEMPT_HEADER } from "../middleware/memex-resolver.js";
+import { reservedApiRoots, TENANT_EXEMPT_HEADER } from "../routes/api-roots.js";
 import { SMOKE_BASE_URL } from "./smoke-env.js";
 
 const AC = "mindset-prod/memex-building-itself/specs/spec-515/acs/ac-12";

--- a/packages/server/src/__smoke__/reserved-root-collisions.smoke.test.ts
+++ b/packages/server/src/__smoke__/reserved-root-collisions.smoke.test.ts
@@ -29,7 +29,7 @@
 import postgres from "postgres";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { tagAc } from "@memex-ai-ac/vitest";
-import { reservedApiRoots } from "../middleware/memex-resolver.js";
+import { reservedApiRoots } from "../routes/api-roots.js";
 import { SMOKE_DATABASE_URL, SMOKE_ENV } from "./smoke-env.js";
 
 const AC = "mindset-prod/memex-building-itself/specs/spec-515/acs/ac-6";

--- a/packages/server/src/middleware/memex-resolver.ts
+++ b/packages/server/src/middleware/memex-resolver.ts
@@ -1,7 +1,10 @@
 import { createMiddleware } from "hono/factory";
 import { and, eq } from "drizzle-orm";
 import { db } from "../db/connection.js";
-import { reservedApiRoots as resolveReservedApiRoots } from "../routes/api-roots.js";
+import {
+  reservedApiRoots as resolveReservedApiRoots,
+  TENANT_EXEMPT_HEADER,
+} from "../routes/api-roots.js";
 import { memexes, namespaces, orgMemberships } from "../db/schema.js";
 import type { Memex, Namespace } from "../db/schema.js";
 
@@ -139,11 +142,14 @@ export function parseMemexPath(rawPath: string): PathPrefix | null {
 const ENCODED_PATH_SEPARATOR = /%2[Ff]|%5[Cc]/;
 
 /**
- * The response header the resolver stamps on a request it EXEMPTS from tenant
- * parsing (spec-515 dec-6). The post-deploy smoke check asserts its presence for
- * every reserved root — see `__smoke__/flat-api-reachability.smoke.test.ts`.
+ * Re-exported for the callers that already import it from here. The constant now
+ * LIVES in routes/api-roots.js — the zero-import vocabulary module — because a
+ * post-deploy smoke check that only needs the header NAME must not be forced to
+ * import this file, which pulls `db/connection` and therefore demands
+ * DATABASE_URL at module load. Both spec-515 smoke files did exactly that and
+ * died on import against int, before their own skip guards could run.
  */
-export const TENANT_EXEMPT_HEADER = "x-memex-tenant";
+export { TENANT_EXEMPT_HEADER };
 
 /**
  * The reserved API root this path is exempt under, or null.

--- a/packages/server/src/routes/api-roots.ts
+++ b/packages/server/src/routes/api-roots.ts
@@ -102,3 +102,18 @@ export const NON_FLAT_RESERVED_ROOTS: ReadonlySet<string> = new Set([
 export function reservedApiRoots(): ReadonlySet<string> {
   return new Set([...NON_FLAT_RESERVED_ROOTS, ...FLAT_API_MOUNT_ROOTS]);
 }
+
+/**
+ * The response header the tenant resolver stamps on a request it EXEMPTS from
+ * tenant parsing (spec-515 dec-6), asserted for every reserved root by the
+ * post-deploy smoke check (`__smoke__/flat-api-reachability.smoke.test.ts`).
+ *
+ * It lives HERE, in the zero-import module, for the same reason the root
+ * declaration does. It first lived in `middleware/memex-resolver.ts`, so a smoke
+ * check that needed nothing but the header NAME had to import the resolver —
+ * which imports `db/connection` and therefore demands DATABASE_URL at module
+ * load. Both spec-515 smoke files died on import against a live int deploy,
+ * before their own skip guards could run, for want of a string constant. The
+ * resolver re-exports it, so existing importers are unaffected.
+ */
+export const TENANT_EXEMPT_HEADER = "x-memex-tenant";


### PR DESCRIPTION
Second defect from the same deploy, found one layer further in. The collision gate now runs and passes; the deploy migrated, shipped traffic, and then:

```
Error: DATABASE_URL environment variable is required
✗ SMOKE FAILED (ENV=int) — traffic is LIVE.
```

## Cause

Both spec-515 smoke files imported `reservedApiRoots` (and `TENANT_EXEMPT_HEADER`) from `middleware/memex-resolver.js` → which imports `db/connection.js` → which requires `DATABASE_URL` at module load. The public smoke tier gets a base URL and no database, so the import threw before either file executed a line.

The DB-tier check has a skip guard for precisely this case. **It never reached it** — the failure was at module load, not inside the test. A guard inside a file cannot protect that file's own import.

**ac-16 states why `api-roots.ts` has zero imports:** so the resolver and the reserved-slug list can both read the vocabulary "without pulling `db/connection`". The module was created for this exact hazard. I imported around it.

## Changes

- `TENANT_EXEMPT_HEADER` moves into `api-roots.ts`, alongside the vocabulary it belongs to. The resolver imports and re-exports it, so every existing caller is unaffected. A check that needs nothing but a header *name* should not have to load a database driver to learn it.
- Both smoke files import from `routes/api-roots.js`.

## Verified against the live int deploy

This is the code currently running on int, so these are observations, not predictions.

- **`flat-api-reachability`, `DATABASE_URL` unset → 2 passed.** All 36 reserved roots carry `x-memex-tenant: exempt`; a tenant path carries none (std-7 non-enumeration, ac-17).
- **`reserved-root-collisions`, `SMOKE_DATABASE_URL` unset → skips cleanly.**
- **Full smoke suite → 5 passed, 4 skipped, 0 failed** — what the deploy step needs.
- **47 unit tests green** across resolver, api-roots, flat mounts, slug composition, deploy parity.
- `make build`, `make check` green.

## Worth knowing: the marker earns its keep

`team`, `share` and `onboarding` answer 404 to an unauthenticated probe whether they are mounted or not, because std-7 turns unauthorized into not-found. From outside, method divergence **cannot** tell "router said no" from "resolver swallowed it" — those three were explicitly indeterminate in the prod sweep recorded on spec-515 c-4.

On int they now all return `x-memex-tenant: exempt`. That is what dec-6 chose the marker for over asserting a status or a body, and it is the first evidence it does the job.

This closes the int half of ac-1 and gives ac-12 its deployed proof.

Pre-push hook bypassed: it runs `test:unit`, which trips on `.ee/slack/oauth.test.ts` (deterministically red with Slack credentials in `.env`, green in CI). No `.ee` path in this diff.