### PR TITLE
release: spec-515 — flat /api mount reachability, its three guards, and the AC-emitter bound

### DIFF
--- a/packages/ac-emit-vitest/package.json
+++ b/packages/ac-emit-vitest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memex-ai-ac/vitest",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Acceptance Criteria emit helper for Vitest. Tag tests with tagAc(), emit pass/fail to a Memex workspace.",
   "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "https://memex.ai",

--- a/packages/ac-emit-vitest/src/emit-batch-fallback.spec-515.test.ts
+++ b/packages/ac-emit-vitest/src/emit-batch-fallback.spec-515.test.ts
@@ -1,0 +1,161 @@
+// spec-515 t-11 / ac-13, ac-14 — the 404 fallback must be bounded and must give up
+// once auth is definitively refused.
+//
+// WHAT THE FALLBACK IS FOR. A server with no `/batch` route (an older deploy, or a
+// self-hosted install on a prior version — std-22 portability) answers 404/405, and
+// emitBatch degrades to one POST per event so emissions still land. That path is
+// deliberate and permanent; spec-515 only makes it rare against Memex's own hosts.
+//
+// WHAT WAS WRONG WITH IT. `await Promise.all(bucket.map(emit))` released EVERY
+// buffered event of a file simultaneously, and vitest runs files across parallel
+// workers, so in-flight requests were (events per file) × (workers), uncapped.
+// Measured consequence on prod 2026-07-24: ~1,800 single POSTs/min. The sharpest
+// risk is not DB CPU but CONNECTION-POOL STARVATION — DB_POOL_MAX=10 × maxScale 3
+// = 30 slots total, against which one 50-test file across 7 workers can put ~350
+// concurrent requests, queueing CI traffic ahead of real users. Verbatim what
+// spec-489 ac-3 set out to prevent.
+//
+// AND: a 401 on the first fallback POST guarantees the rest will also 401 — same
+// key, same server — but they were already in flight, and nothing watched the first
+// failure to stop the others. Measured: 1,347 rejections in 3 minutes (2026-07-26),
+// which were 1,347 DISTINCT events failing once each. There is no retry in this
+// emitter; the volume came from the fan-out.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { emitBatch, tagAc } from "./index.js";
+import { MAX_FALLBACK_CONCURRENCY } from "./emit.js";
+
+const AC_BOUNDED = "mindset-prod/memex-building-itself/specs/spec-515/acs/ac-13";
+const AC_SHORTCIRCUIT = "mindset-prod/memex-building-itself/specs/spec-515/acs/ac-14";
+
+const entries = (n: number) =>
+  Array.from({ length: n }, (_, i) => ({
+    ac_uid: "mindset-prod/foo/specs/spec-1/acs/ac-1",
+    status: "pass" as const,
+    test_identifier: `test.ts::t${i}`,
+    duration_ms: 1,
+  }));
+
+/** 404 on /batch, then a caller-supplied response for each single-event POST. */
+function transportWith(single: () => Promise<unknown> | unknown) {
+  const inFlight = { now: 0, peak: 0 };
+  const singleCalls: string[] = [];
+  const fetchMock = vi.fn(async (url: string) => {
+    if (String(url).endsWith("/batch")) {
+      return { ok: false, status: 404, headers: new Headers(), text: async () => "" };
+    }
+    singleCalls.push(String(url));
+    inFlight.now += 1;
+    inFlight.peak = Math.max(inFlight.peak, inFlight.now);
+    try {
+      // Yield twice so genuinely-parallel calls overlap and `peak` is meaningful;
+      // a single microtask would let each call finish before the next begins and
+      // the assertion would pass even with an unbounded fan-out.
+      await Promise.resolve();
+      await Promise.resolve();
+      return (await single()) as never;
+    } finally {
+      inFlight.now -= 1;
+    }
+  });
+  return { fetchMock, inFlight, singleCalls };
+}
+
+const ok = () => ({ ok: true, status: 201, headers: new Headers(), text: async () => "" });
+const unauthorized = () => ({
+  ok: false,
+  status: 401,
+  headers: new Headers(),
+  text: async () => '{"error":"emission key expired"}',
+});
+
+beforeEach(() => {
+  for (const k of [
+    "MEMEX_EMIT",
+    "MEMEX_EMIT_KEY",
+    "MEMEX_TEST_EVENTS_URL",
+    "GITHUB_ACTOR",
+    "GITLAB_USER_LOGIN",
+    "BUILDKITE_BUILD_AUTHOR",
+    "CIRCLE_USERNAME",
+    "USER",
+    "USERNAME",
+  ]) {
+    vi.stubEnv(k, "");
+  }
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  // std-37 cl-5: a leaked global stub can silently swallow AC emission elsewhere.
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("emitBatch 404 fallback — bounded concurrency (spec-515 ac-13)", () => {
+  it("never holds more than the cap in flight, however many events buffered", async () => {
+    tagAc(AC_BOUNDED);
+    const { fetchMock, inFlight, singleCalls } = transportWith(ok);
+    await emitBatch(entries(40), fetchMock as unknown as typeof fetch);
+
+    // Every event still lands — bounding must not drop emissions.
+    expect(singleCalls).toHaveLength(40);
+    expect(inFlight.peak).toBeLessThanOrEqual(MAX_FALLBACK_CONCURRENCY);
+  });
+
+  it("actually parallelises up to the cap — not accidentally serial", async () => {
+    // A cap of 1 would also satisfy the assertion above while making a 500-event
+    // flush crawl and risk overrunning vitest's afterAll budget. Pin that the
+    // fallback genuinely uses its allowance.
+    tagAc(AC_BOUNDED);
+    const { fetchMock, inFlight } = transportWith(ok);
+    await emitBatch(entries(40), fetchMock as unknown as typeof fetch);
+    expect(inFlight.peak).toBeGreaterThan(1);
+  });
+
+  it("the cap is small enough to respect the server's connection pool", async () => {
+    // DB_POOL_MAX=10 × maxScale 3 = 30 slots, shared with real user traffic. The
+    // cap is per flush and several vitest workers can flush together, so it has to
+    // leave headroom rather than merely be finite.
+    tagAc(AC_BOUNDED);
+    expect(MAX_FALLBACK_CONCURRENCY).toBeLessThanOrEqual(5);
+    expect(MAX_FALLBACK_CONCURRENCY).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe("emitBatch 404 fallback — 401 short-circuit (spec-515 ac-14)", () => {
+  it("abandons the remaining events once a 401 comes back", async () => {
+    tagAc(AC_SHORTCIRCUIT);
+    const { fetchMock, singleCalls } = transportWith(unauthorized);
+    await emitBatch(entries(40), fetchMock as unknown as typeof fetch);
+
+    // An invalid key costs one rejected request per flush, not one per event. The
+    // in-flight batch cannot be recalled, so the bound is the cap — decisively
+    // fewer than 40, which is what turned 1,347 rejections into a handful.
+    expect(singleCalls.length).toBeLessThanOrEqual(MAX_FALLBACK_CONCURRENCY);
+    expect(singleCalls.length).toBeGreaterThan(0);
+  });
+
+  it("does NOT short-circuit on an ordinary non-2xx — only on refused auth", async () => {
+    // A 500 is transient and per-event; abandoning the flush would silently lose
+    // emissions the server might well have accepted. Only 401 is definitive.
+    tagAc(AC_SHORTCIRCUIT);
+    const { fetchMock, singleCalls } = transportWith(() => ({
+      ok: false,
+      status: 500,
+      headers: new Headers(),
+      text: async () => "boom",
+    }));
+    await emitBatch(entries(12), fetchMock as unknown as typeof fetch);
+    expect(singleCalls).toHaveLength(12);
+  });
+
+  it("does not throw when auth is refused mid-flush (fail-safe holds)", async () => {
+    tagAc(AC_SHORTCIRCUIT);
+    const { fetchMock } = transportWith(unauthorized);
+    await expect(
+      emitBatch(entries(20), fetchMock as unknown as typeof fetch),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/packages/ac-emit-vitest/src/emit-fallback-failsafe.spec-515.test.ts
+++ b/packages/ac-emit-vitest/src/emit-fallback-failsafe.spec-515.test.ts
@@ -1,0 +1,166 @@
+// spec-515 t-12 / ac-15 — the fail-safe contract survives the t-11 changes.
+//
+// THE CONTRACT: a failed emission must never fail — or STALL — a consumer's test
+// run. Stalling matters as much as throwing, because an awaited flush that overruns
+// vitest's `afterAll` budget fails the run just as surely.
+//
+// WHY THIS TASK EXISTS AS ITS OWN GUARD. t-11 replaced an unbounded
+// `Promise.all(bucket.map(emit))` with a bounded worker pool. That fixed
+// connection-pool starvation and introduced a NEW failure mode in its place:
+// bounding serialises, so total time became LINEAR in the buffer size. Measured
+// before the fix below, at 40ms per request with a cap of 4:
+//
+//     12 events  →  144ms   (12/4 × 40)
+//    120 events  → 1240ms   (120/4 × 40)
+//
+// Extrapolate to a HUNG server, where per-request latency is the 5s AbortSignal
+// timeout: 120 events → 120/4 × 5s = 150 SECONDS. The old unbounded fan-out failed
+// the same case in ~5s. So t-11, taken alone, converted a fast failure into a
+// guaranteed hook-timeout — the one thing the contract forbids. The fix is a total
+// deadline on top of the per-request one; these tests pin both halves.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { emitBatch, tagAc } from "./index.js";
+import {
+  FALLBACK_START_DEADLINE_MS,
+  MAX_FALLBACK_CONCURRENCY,
+  PER_REQUEST_TIMEOUT_MS,
+  runBoundedFallback,
+} from "./emit.js";
+
+const AC = "mindset-prod/memex-building-itself/specs/spec-515/acs/ac-15";
+
+const entries = (n: number) =>
+  Array.from({ length: n }, (_, i) => ({
+    ac_uid: "mindset-prod/foo/specs/spec-1/acs/ac-1",
+    status: "pass" as const,
+    test_identifier: `test.ts::t${i}`,
+    duration_ms: 1,
+  }));
+
+/** 404 on /batch so emitBatch degrades to the fallback, then `single` per event. */
+const transportWith = (single: () => Promise<unknown> | unknown) =>
+  vi.fn(async (url: string) => {
+    if (String(url).endsWith("/batch")) {
+      return { ok: false, status: 404, headers: new Headers(), text: async () => "" };
+    }
+    return (await single()) as never;
+  });
+
+const slow = (ms: number) => async () => {
+  await new Promise((r) => setTimeout(r, ms));
+  return { ok: true, status: 201, headers: new Headers(), text: async () => "" };
+};
+
+beforeEach(() => {
+  for (const k of ["MEMEX_EMIT", "MEMEX_EMIT_KEY", "MEMEX_TEST_EVENTS_URL"]) {
+    vi.stubEnv(k, "");
+  }
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  // std-37 cl-5 — a leaked global stub can silently swallow AC emission elsewhere.
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("fallback total deadline (spec-515 ac-15)", () => {
+  it("stops issuing requests once the deadline is spent", async () => {
+    // The regression this guards: without a total deadline, 200 slow events would
+    // all be attempted, 4 at a time, however long that takes.
+    tagAc(AC);
+    const transport = transportWith(slow(20));
+    await runBoundedFallback(entries(200), transport as unknown as typeof fetch, 120);
+    // 120ms of budget at 20ms per request, 4 in flight ≈ 24 requests. Assert it
+    // stopped WELL short of 200 rather than pinning a brittle exact count.
+    const singles = transport.mock.calls.filter(([u]) => !String(u).endsWith("/batch"));
+    expect(singles.length).toBeLessThan(60);
+    expect(singles.length).toBeGreaterThan(0);
+  });
+
+  it("keeps a hung server inside vitest's afterAll budget", async () => {
+    // The arithmetic that matters, asserted on the constants rather than by waiting
+    // 10s: the deadline bounds when the LAST request may START, and each request is
+    // itself bounded, so worst-case total ≤ deadline + per-request timeout. That has
+    // to leave room inside vitest's 10s default hookTimeout for everything else in
+    // afterAll.
+    tagAc(AC);
+    expect(FALLBACK_START_DEADLINE_MS + PER_REQUEST_TIMEOUT_MS).toBeLessThan(10_000);
+    // And it must be generous enough that a healthy-but-slow server still lands a
+    // realistic file's worth of events: ~4 × deadline/200ms at 200ms per request.
+    expect(FALLBACK_START_DEADLINE_MS).toBeGreaterThanOrEqual(3_000);
+  });
+
+  it("a large buffer against a healthy server still completes promptly", async () => {
+    tagAc(AC);
+    const transport = transportWith(slow(2));
+    const t0 = Date.now();
+    await runBoundedFallback(entries(120), transport as unknown as typeof fetch);
+    expect(Date.now() - t0).toBeLessThan(FALLBACK_START_DEADLINE_MS);
+  });
+});
+
+describe("fail-safe: every failure mode leaves the run green (spec-515 ac-15)", () => {
+  const modes: Array<[string, () => Promise<unknown> | unknown]> = [
+    ["401 — auth refused mid-flush", () => ({ ok: false, status: 401, headers: new Headers(), text: async () => "expired" })],
+    ["500 — transient, per-event", () => ({ ok: false, status: 500, headers: new Headers(), text: async () => "boom" })],
+    ["network error", () => { throw new Error("ECONNREFUSED"); }],
+    ["a body that cannot be read", () => ({ ok: false, status: 400, headers: new Headers(), text: async () => { throw new Error("unreadable"); } })],
+    ["a response with no headers object", () => ({ ok: true, status: 201, text: async () => "" })],
+  ];
+
+  for (const [label, single] of modes) {
+    it(`resolves, never throws: ${label}`, async () => {
+      tagAc(AC);
+      await expect(
+        emitBatch(entries(9), transportWith(single) as unknown as typeof fetch),
+      ).resolves.toBeUndefined();
+    });
+  }
+
+  it("resolves when the whole transport rejects (no /batch, no anything)", async () => {
+    tagAc(AC);
+    const transport = vi.fn(async () => {
+      throw new Error("host unreachable");
+    });
+    await expect(
+      emitBatch(entries(5), transport as unknown as typeof fetch),
+    ).resolves.toBeUndefined();
+  });
+
+  it("honours the off switch even with a full buffer — zero requests", async () => {
+    tagAc(AC);
+    vi.stubEnv("MEMEX_EMIT", "false");
+    const transport = transportWith(slow(0));
+    await emitBatch(entries(30), transport as unknown as typeof fetch);
+    expect(transport).not.toHaveBeenCalled();
+  });
+
+  it("a server with no /batch route still lands every event (std-22 self-hosted)", async () => {
+    // The fallback is a deliberate portability feature, not a bug path. Bounding and
+    // deadlining it must not turn "slower" into "lossy" for a healthy old server.
+    tagAc(AC);
+    const transport = transportWith(slow(0));
+    await emitBatch(entries(25), transport as unknown as typeof fetch);
+    const singles = transport.mock.calls.filter(([u]) => !String(u).endsWith("/batch"));
+    expect(singles).toHaveLength(25);
+  });
+
+  it("never exceeds the concurrency cap while honouring the deadline", async () => {
+    tagAc(AC);
+    let now = 0;
+    let peak = 0;
+    const transport = transportWith(async () => {
+      now += 1;
+      peak = Math.max(peak, now);
+      await Promise.resolve();
+      await Promise.resolve();
+      now -= 1;
+      return { ok: true, status: 201, headers: new Headers(), text: async () => "" };
+    });
+    await emitBatch(entries(50), transport as unknown as typeof fetch);
+    expect(peak).toBeLessThanOrEqual(MAX_FALLBACK_CONCURRENCY);
+  });
+});

--- a/packages/ac-emit-vitest/src/emit.ts
+++ b/packages/ac-emit-vitest/src/emit.ts
@@ -127,10 +127,29 @@ export async function emit(
   args: EmitArgs,
   transport: typeof fetch = globalThis.fetch,
 ): Promise<void> {
-  if (!isEmissionEnabled()) return;
+  await emitOnce(args, transport);
+}
+
+/**
+ * What one emission did. `emit()` deliberately discards this — its documented
+ * contract is `Promise<void>` that never throws, and the `ac-emission-bootstrap`
+ * topic describes that shape for other languages to copy, so it must not change.
+ *
+ * The 404 fallback needs the outcome for one reason only: a 401 means the key is
+ * refused, so every remaining event in the flush will be refused too and sending
+ * them is pure waste (spec-515 ac-14).
+ */
+type EmitOutcome = "ok" | "auth-refused" | "failed";
+
+/** `emit()` with the outcome reported instead of swallowed. Never throws. */
+async function emitOnce(
+  args: EmitArgs,
+  transport: typeof fetch = globalThis.fetch,
+): Promise<EmitOutcome> {
+  if (!isEmissionEnabled()) return "ok";
 
   const url = deriveEventsUrl(args.ac_uid);
-  if (url === null) return;
+  if (url === null) return "ok";
 
   const payload = buildPayload(args);
 
@@ -184,11 +203,72 @@ export async function emit(
         `[ac-emit] server warning for ac_uid=${args.ac_uid}: ${warning}`,
       );
     }
+    // 401 is the only DEFINITIVE refusal: same key, same server, so the rest of
+    // the flush cannot succeed either. A 5xx is transient and per-event — treat it
+    // as a plain failure so a flaky server never silently drops the whole buffer.
+    if (res.status === 401) return "auth-refused";
+    return res.ok ? "ok" : "failed";
   } catch (err) {
     // eslint-disable-next-line no-console
     console.warn(
       `[ac-emit] POST ${url} failed for ac_uid=${args.ac_uid}:`,
       err instanceof Error ? err.message : err,
+    );
+    return "failed";
+  }
+}
+
+/**
+ * How many single-event POSTs the 404 fallback may hold in flight at once
+ * (spec-515 ac-13).
+ *
+ * Was unbounded: `Promise.all` over the whole file buffer, multiplied by however
+ * many vitest workers flushed at the same moment. Observed on prod 2026-07-24 at
+ * ~1,800 POSTs/min.
+ *
+ * The binding constraint is not CPU but the server's connection pool —
+ * `DB_POOL_MAX=10` × `maxScale 3` = 30 slots, shared with real user traffic. This
+ * cap is per flush and several workers can flush together, so it has to leave
+ * headroom rather than merely be finite: 4 keeps even a simultaneous multi-worker
+ * flush in the same order of magnitude as the pool instead of hundreds of times
+ * over it. Exported so the test asserts the real value, not a copy.
+ */
+export const MAX_FALLBACK_CONCURRENCY = 4;
+
+/**
+ * Post `entries` one at a time through `emitOnce`, at most
+ * {@link MAX_FALLBACK_CONCURRENCY} in flight, stopping early if the server refuses
+ * the emission key.
+ *
+ * Never throws: `emitOnce` swallows everything, so the `Promise.all` below cannot
+ * reject and the fail-safe contract survives (spec-515 ac-15 / t-12).
+ */
+async function runBoundedFallback(
+  entries: EmitArgs[],
+  transport: typeof fetch,
+): Promise<void> {
+  let cursor = 0;
+  let authRefused = false;
+
+  const worker = async (): Promise<void> => {
+    while (!authRefused) {
+      const index = cursor++;
+      if (index >= entries.length) return;
+      if ((await emitOnce(entries[index], transport)) === "auth-refused") {
+        authRefused = true;
+      }
+    }
+  };
+
+  const width = Math.min(MAX_FALLBACK_CONCURRENCY, entries.length);
+  await Promise.all(Array.from({ length: width }, () => worker()));
+
+  if (authRefused && cursor < entries.length) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[ac-emit] emission key refused (401) — abandoned ${entries.length - cursor} ` +
+        "of this file's remaining events rather than sending requests that cannot " +
+        "succeed. Provision a fresh key (provision_ac_emission) and re-run.",
     );
   }
 }
@@ -271,9 +351,9 @@ export async function emitBatch(
       // /batch route itself only ever returns 200/400/401, so 404/405 is an
       // unambiguous "route absent" signal, not a per-request error.
       if (res.status === 404 || res.status === 405) {
-        await Promise.all(
-          bucket.map((entry) => emit(entry, transport)),
-        );
+        // spec-515 ac-13/ac-14: bounded, and abandoned early if the key is refused.
+        // Was `Promise.all(bucket.map(emit))` — every event of the file at once.
+        await runBoundedFallback(bucket, transport);
         continue;
       }
 

--- a/packages/ac-emit-vitest/src/emit.ts
+++ b/packages/ac-emit-vitest/src/emit.ts
@@ -179,7 +179,7 @@ async function emitOnce(
       // tagged test — the one thing the fail-safe contract forbids. 5s keeps
       // well under the hook budget; the abort lands in the catch below and
       // degrades to the documented warn-and-continue.
-      signal: AbortSignal.timeout(5000),
+      signal: AbortSignal.timeout(PER_REQUEST_TIMEOUT_MS),
     });
     if (!res.ok) {
       // spec-333: surface the server's RESPONSE BODY, not just the status code, so the
@@ -236,6 +236,36 @@ async function emitOnce(
 export const MAX_FALLBACK_CONCURRENCY = 4;
 
 /**
+ * Client-side bound on ONE request (both the batch POST and each fallback POST).
+ *
+ * A hung server is as dangerous as a failed one: an unbounded awaited fetch rides
+ * past vitest's hook budget and fails the tagged test, which swallowing errors alone
+ * cannot prevent.
+ */
+export const PER_REQUEST_TIMEOUT_MS = 5000;
+
+/**
+ * How long the fallback may keep STARTING new requests (spec-515 t-12 / ac-15).
+ *
+ * Bounding concurrency (ac-13) made total time linear in the buffer: measured at 40ms
+ * per request with a cap of 4, 12 events took 144ms and 120 took 1240ms. Against a
+ * HUNG server, per-request latency becomes PER_REQUEST_TIMEOUT_MS, so 120 events
+ * would take 120/4 × 5s = 150 SECONDS — where the old unbounded fan-out failed the
+ * same case in ~5s. Bounding alone therefore traded a connection-pool problem for a
+ * guaranteed hook-timeout, which the fail-safe contract forbids.
+ *
+ * This deadline gates when the LAST request may start; each request is itself
+ * bounded, so worst-case total ≤ 4000 + 5000 = 9s, inside vitest's 10s default
+ * hookTimeout with ~1s of headroom for the rest of afterAll. Generous enough that a
+ * healthy-but-slow server (200ms/request) still lands ~80 events before the cut.
+ *
+ * The trade-off is deliberate and asymmetric: truncating some emissions loses
+ * verification signal, while overrunning the hook FAILS the consumer's test run. The
+ * contract ranks those, so the deadline wins and the drop is warned about loudly.
+ */
+export const FALLBACK_START_DEADLINE_MS = 4000;
+
+/**
  * Post `entries` one at a time through `emitOnce`, at most
  * {@link MAX_FALLBACK_CONCURRENCY} in flight, stopping early if the server refuses
  * the emission key.
@@ -243,15 +273,22 @@ export const MAX_FALLBACK_CONCURRENCY = 4;
  * Never throws: `emitOnce` swallows everything, so the `Promise.all` below cannot
  * reject and the fail-safe contract survives (spec-515 ac-15 / t-12).
  */
-async function runBoundedFallback(
+export async function runBoundedFallback(
   entries: EmitArgs[],
   transport: typeof fetch,
+  startDeadlineMs: number = FALLBACK_START_DEADLINE_MS,
 ): Promise<void> {
   let cursor = 0;
   let authRefused = false;
+  const startedAt = Date.now();
+  let deadlineHit = false;
 
   const worker = async (): Promise<void> => {
     while (!authRefused) {
+      if (Date.now() - startedAt >= startDeadlineMs) {
+        deadlineHit = true;
+        return;
+      }
       const index = cursor++;
       if (index >= entries.length) return;
       if ((await emitOnce(entries[index], transport)) === "auth-refused") {
@@ -262,6 +299,17 @@ async function runBoundedFallback(
 
   const width = Math.min(MAX_FALLBACK_CONCURRENCY, entries.length);
   await Promise.all(Array.from({ length: width }, () => worker()));
+
+  if (deadlineHit) {
+    const dropped = Math.max(0, entries.length - cursor);
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[ac-emit] fallback deadline (${startDeadlineMs}ms) reached — dropped ${dropped} ` +
+        "of this file's events rather than overrun the test runner's hook budget. " +
+        "The server has no /batch route AND is responding slowly; fix either and the " +
+        "whole buffer lands in one request.",
+    );
+  }
 
   if (authRefused && cursor < entries.length) {
     // eslint-disable-next-line no-console
@@ -341,7 +389,7 @@ export async function emitBatch(
         // Bound the request client-side for the same reason emit() does: a hung
         // server must abort into the catch below rather than ride past vitest's
         // hook timeout and fail the run.
-        signal: AbortSignal.timeout(5000),
+        signal: AbortSignal.timeout(PER_REQUEST_TIMEOUT_MS),
       });
 
       // ROLLOUT SAFETY (spec-489, std-22): a 404/405 means this server has no

--- a/packages/server/deploy.sh
+++ b/packages/server/deploy.sh
@@ -294,8 +294,17 @@ RUNTIME_DB_PASS_ENC=$(python3 -c "import urllib.parse,sys; print(urllib.parse.qu
 # backfills in Step 5, a collision here means a live tenant is about to go
 # unroutable. Exit 2 ("could not check") is treated exactly like exit 1: an
 # unverified deploy is not a verified one.
+#
+# Invoked through the package's own `check-reserved-roots` script, matching every
+# sibling one-off in packages/server (`db:backfill-*`, `db:seed*`). The first
+# attempt was `pnpm --filter @memex/server tsx <file>`, which pnpm reads as "run
+# the script NAMED tsx" — there is none, so it died with
+# ERR_PNPM_RECURSIVE_RUN_NO_SCRIPT and, because this gate is fail-closed, aborted
+# the whole deploy on its first real run. A named script keeps the deploy calling
+# exactly what a developer can call locally, and deploy-script-parity.test.ts now
+# asserts every script deploy.sh invokes actually exists.
 echo "  1·pre. reserved-root collision check (spec-515)..."
-if ! DATABASE_URL="${DB_URL}" pnpm --filter @memex/server tsx scripts/check-reserved-root-collisions.ts; then
+if ! DATABASE_URL="${DB_URL}" pnpm --filter @memex/server check-reserved-roots; then
   echo ""
   echo "ERROR: reserved-root collision check did not pass — aborting before migrations."
   kill ${PROXY_PID} 2>/dev/null || true

--- a/packages/server/deploy.sh
+++ b/packages/server/deploy.sh
@@ -283,6 +283,25 @@ RUNTIME_DB_USER="${RUNTIME_DB_USER:-$DB_USER}"
 RUNTIME_DB_PASS="${RUNTIME_DB_PASS:-$DB_PASS}"
 RUNTIME_DB_PASS_ENC=$(python3 -c "import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1], safe=''))" "${RUNTIME_DB_PASS}")
 
+# ── spec-515 t-3: reserved-root collision gate (PRE-condition, gating) ────────
+# `memexResolver` treats a word in RESERVED_API_ROOTS as "not a tenant", which is
+# what makes a flat /api/<root> mount reachable — and what would strand a tenant
+# that already owns that word as its namespace slug. The two features compete for
+# one vocabulary (std-3 cl-7); this is the interlock.
+#
+# Runs BEFORE migrations on purpose: it is a precondition, so it must fail while
+# the schema is still untouched. GATING (no `|| true`) — unlike the idempotent
+# backfills in Step 5, a collision here means a live tenant is about to go
+# unroutable. Exit 2 ("could not check") is treated exactly like exit 1: an
+# unverified deploy is not a verified one.
+echo "  1·pre. reserved-root collision check (spec-515)..."
+if ! DATABASE_URL="${DB_URL}" pnpm --filter @memex/server tsx scripts/check-reserved-root-collisions.ts; then
+  echo ""
+  echo "ERROR: reserved-root collision check did not pass — aborting before migrations."
+  kill ${PROXY_PID} 2>/dev/null || true
+  exit 1
+fi
+
 echo "  1a. drizzle-kit journal migrations..."
 DATABASE_URL="${DB_URL}" pnpm db:migrate
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -36,6 +36,7 @@
     "db:backfill-mixpanel-profiles": "tsx scripts/backfill-mixpanel-profiles.ts",
     "db:generate-whats-new": "tsx scripts/generate-whats-new.ts",
     "db:purge-starter-specs": "tsx scripts/purge-starter-specs.ts",
+    "check-reserved-roots": "tsx scripts/check-reserved-root-collisions.ts",
     "activation:backlog": "tsx scripts/activation-backlog.ts",
     "oauth:smoke": "node scripts/oauth-smoke.mjs",
     "docker:build": "docker build -t memex-server .",

--- a/packages/server/scripts/check-reserved-root-collisions.ts
+++ b/packages/server/scripts/check-reserved-root-collisions.ts
@@ -1,0 +1,61 @@
+// spec-515 t-3 / ac-7 — deploy PRE-condition: no namespace slug may squat a
+// reserved API root.
+//
+// Usage (wired into packages/server/deploy.sh, before migrations):
+//   DATABASE_URL="..." pnpm --filter @memex/server tsx scripts/check-reserved-root-collisions.ts
+//
+// GATING, unlike the backfill scripts that run post-cutover with `|| echo`. A
+// collision means a live tenant is about to become unroutable, which is not
+// something to discover from a support ticket. Exit codes:
+//
+//   0 — no collision, safe to proceed
+//   1 — collision found; the deploy MUST NOT proceed
+//   2 — the check itself could not run (no DATABASE_URL, DB unreachable)
+//
+// Exit 2 is deliberately distinct from exit 1 and is ALSO fail-closed at the call
+// site: "the check broke" must never be read as "the check passed". That
+// distinction is the whole reason this isn't a `|| true` step.
+//
+// Read-only: it runs before migrations against a live database and issues nothing
+// but SELECTs.
+
+import {
+  findReservedRootSlugCollisions,
+  formatCollisions,
+} from "../src/services/reserved-root-collisions.js";
+
+async function main(): Promise<number> {
+  if (!process.env.DATABASE_URL) {
+    console.error(
+      "[reserved-root-check] DATABASE_URL is not set — cannot verify. Refusing to report success.",
+    );
+    return 2;
+  }
+
+  const collisions = await findReservedRootSlugCollisions();
+
+  if (collisions.length === 0) {
+    console.log(
+      "[reserved-root-check] ✓ no namespace slug or post-rename reservation collides with a reserved API root.",
+    );
+    return 0;
+  }
+
+  console.error(
+    `[reserved-root-check] ✗ ${collisions.length} collision(s) — the deploy will NOT proceed:\n` +
+      `${formatCollisions(collisions)}\n\n` +
+      "Reserving one of these roots makes the tenant that owns it unroutable\n" +
+      "(memexResolver stops resolving the word, per std-3 cl-7 / spec-515 dec-3).\n" +
+      "Resolve it before deploying — rename the tenant via the spec-479 rename +\n" +
+      "redirect path, or mount the API route under a different root.",
+  );
+  return 1;
+}
+
+main()
+  .then((code) => process.exit(code))
+  .catch((err) => {
+    // Fail closed: an unreachable DB or a schema surprise is "unknown", not "clean".
+    console.error("[reserved-root-check] check could not complete:", err);
+    process.exit(2);
+  });

--- a/packages/server/src/__regression__/flat-api-mount-invariant.spec-515.regression.test.ts
+++ b/packages/server/src/__regression__/flat-api-mount-invariant.spec-515.regression.test.ts
@@ -1,0 +1,121 @@
+// spec-515 t-8 / ac-4, ac-11 — the whole-class guard: a flat `/api/<root>` mount
+// cannot exist without BOTH halves of its invariant.
+//
+// WHY A DEDICATED REGRESSION FILE. This defect has recurred six times. `stripe`,
+// `postmark` and `internal` each carry an in-code comment describing the exact
+// failure, and it still happened three more times (`email`, `test-events`, and the
+// seven latent roots). Comments and review did not hold. The individual assertions
+// also exist closer to their subjects (routes/flat-api-mounts.test.ts,
+// services/shared/slug.reserved-composition.spec-515.test.ts) — this file is the
+// single place that states the CLASS, so a reader grepping for "why can't I just
+// app.route a new /api root" lands on one explanation.
+//
+// THE INVARIANT, both halves. For every reserved `/api` root:
+//   1. `parseMemexPath` returns null for it → its subpaths reach the router instead
+//      of being swallowed by tenant resolution (the spec-515 production defect).
+//   2. `validateSlugFormat` refuses it → no tenant can claim the word and be made
+//      unroutable by half 1 (std-3 cl-7, amended 2026-07-28).
+// Either half alone leaves a live defect, which is why they are asserted together.
+//
+// DELIBERATELY NO `app.request(...)` AND NO DB MOCK. A route-level assertion cannot
+// see this defect: `routes/test-events.test.ts` builds its own Hono and mocks
+// `db/connection`, so its six batch-route tests pass while production 404s. This
+// file asserts against the pure functions and the declaration, so there is nothing
+// to mock and nothing to be blinded by.
+//
+// TEETH. Each assertion below was verified to FAIL by breaking the code it guards —
+// see the task record on spec-515 t-8 for the three experiments and their output.
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import {
+  FLAT_API_MOUNT_ROOTS,
+  NON_FLAT_RESERVED_ROOTS,
+  reservedApiRoots,
+} from "../routes/api-roots.js";
+import { parseMemexPath } from "../middleware/memex-resolver.js";
+import { validateSlugFormat } from "../services/shared/slug.js";
+
+const AC_CLASS = "mindset-prod/memex-building-itself/specs/spec-515/acs/ac-4";
+const AC_GUARD = "mindset-prod/memex-building-itself/specs/spec-515/acs/ac-11";
+
+const APP_SRC = readFileSync(
+  fileURLToPath(new URL("../app.ts", import.meta.url)),
+  "utf8",
+);
+
+/** Roots app.ts actually mounts flat, read from source. */
+const MOUNTED_IN_APP = [
+  ...new Set(
+    [...APP_SRC.matchAll(/mountFlatApi\(\s*app\s*,\s*"([a-z0-9-]+)"/g)].map(
+      (m) => m[1],
+    ),
+  ),
+].sort();
+
+describe("flat /api mount invariant (spec-515 t-8)", () => {
+  it("finds the mounts it is meant to guard", () => {
+    // Guards the guard. If the mount form changes and this scan silently matches
+    // nothing, every assertion below would pass vacuously — the worst outcome for
+    // a guard test, since it reports safety it is not checking.
+    tagAc(AC_GUARD);
+    expect(MOUNTED_IN_APP.length).toBeGreaterThan(20);
+    expect(MOUNTED_IN_APP).toContain("email");
+    expect(MOUNTED_IN_APP).toContain("test-events");
+  });
+
+  it("every root mounted in app.ts is declared", () => {
+    // `mountFlatApi` also throws at boot for an undeclared root, so this is
+    // belt-and-braces — but it fails at PR time with a readable diff rather than
+    // as an import error inside whichever test happened to load the app first.
+    tagAc(AC_GUARD);
+    const undeclared = MOUNTED_IN_APP.filter((r) => !FLAT_API_MOUNT_ROOTS.has(r));
+    expect(undeclared).toEqual([]);
+  });
+
+  it("half 1 — every reserved root is exempt from tenant parsing", () => {
+    tagAc(AC_GUARD);
+    const swallowed = [...reservedApiRoots()].filter(
+      (root) => parseMemexPath(`/api/${root}/anything`) !== null,
+    );
+    expect(swallowed).toEqual([]);
+  });
+
+  it("half 2 — every reserved root is unclaimable as a namespace slug", () => {
+    tagAc(AC_GUARD);
+    const claimable = [...reservedApiRoots()].filter(
+      (root) => validateSlugFormat(root).valid,
+    );
+    expect(claimable).toEqual([]);
+  });
+
+  it("no raw app.route(\"/api/<root>\") bypasses the mount helper", () => {
+    // The escape hatch dec-7 accepted when it chose option A over a full
+    // restructure. This scan is what closes it. Deep mounts
+    // (`/api/stripe/webhook`), tenant-prefixed mounts (`/api/:namespace/...`) and
+    // the catch-all (`/api/*`) are out of scope — only a flat single-segment root.
+    tagAc(AC_CLASS);
+    const raw = [
+      ...APP_SRC.matchAll(/app\.route\(\s*"\/api\/([a-z0-9-]+)"\s*,/g),
+    ].map((m) => m[1]);
+    expect(raw).toEqual([]);
+  });
+
+  it("keeps the hand-maintained half small and auditable", () => {
+    // dec-7's argument for splitting the vocabulary was that the part needing human
+    // judgement stays small enough to review. If NON_FLAT_RESERVED_ROOTS starts
+    // growing, that argument has quietly expired and the split needs revisiting.
+    tagAc(AC_CLASS);
+    expect(NON_FLAT_RESERVED_ROOTS.size).toBeLessThanOrEqual(12);
+  });
+
+  it("does not over-reach — a genuine tenant path still resolves", () => {
+    tagAc(AC_GUARD);
+    expect(parseMemexPath("/api/mindset-prod/memex-building-itself/docs")).toEqual({
+      namespaceSlug: "mindset-prod",
+      memexSlug: "memex-building-itself",
+    });
+  });
+});

--- a/packages/server/src/__smoke__/flat-api-reachability.smoke.test.ts
+++ b/packages/server/src/__smoke__/flat-api-reachability.smoke.test.ts
@@ -1,0 +1,75 @@
+// spec-515 t-9 / ac-12 — post-deploy proof that every flat `/api/<root>` mount is
+// actually REACHABLE on the deployed host.
+//
+// THIS IS THE GUARD THAT WOULD HAVE CAUGHT JULY. The other layers cannot: in the
+// July incident the code was correct, committed, and present in the running image
+// (`dist/routes/test-events.js:457`), and the route still 404'd. A green local suite
+// says nothing about it, because the defect lives in the composition of a global
+// middleware with a route and only manifests over a real HTTP request to a real
+// deployment. Had this check existed, `/api/test-events/batch` would have failed the
+// 2026-07-21 deploy instead of being found on 2026-07-27, and
+// `/api/email/unsubscribe` would have failed on 2026-07-01 instead of sitting dead
+// for 27 days.
+//
+// WHAT IT ASSERTS, AND WHY NOT THE OBVIOUS THING. Not the status code, and not the
+// body. `{"error":"Not found"}` is emitted by at least six code paths, so a router
+// legitimately reporting "no such id" is byte-identical to the resolver swallowing
+// the route — measured during t-2, where `/api/issues/x` and an unmounted control
+// root returned the same bytes. Instead it asserts the resolver's positive
+// exemption marker (dec-6): `x-memex-tenant: exempt` means "this request was
+// recognised as a non-tenant API root and passed through", which is exactly the
+// claim. Its ABSENCE on a root that should have it is the failure.
+//
+// Public tier: unauthenticated, non-destructive, no credentials, so it always runs
+// (std-17) — and per std-26 gotcha #8 it must not be one of the skipped ones. It
+// touches no namespace or memex.
+
+import { describe, expect, it } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { reservedApiRoots, TENANT_EXEMPT_HEADER } from "../middleware/memex-resolver.js";
+import { SMOKE_BASE_URL } from "./smoke-env.js";
+
+const AC = "mindset-prod/memex-building-itself/specs/spec-515/acs/ac-12";
+const AC_NOLEAK = "mindset-prod/memex-building-itself/specs/spec-515/acs/ac-17";
+
+// Driven from the shared declaration, never a hardcoded list — a root added to
+// api-roots.ts is covered by this check the day it lands, with no second edit.
+// That property is the whole point of spec-515; hardcoding here would reintroduce
+// the hand-sync this Spec exists to remove.
+const ROOTS = [...reservedApiRoots()].sort();
+
+describe(`flat /api mount reachability smoke @ ${SMOKE_BASE_URL}`, () => {
+  it("carries the exemption marker on every reserved API root", async () => {
+    tagAc(AC);
+    // A guard on the guard: if the declaration were somehow empty, an all-pass loop
+    // would report safety it never checked.
+    expect(ROOTS.length).toBeGreaterThan(20);
+
+    const unreachable: string[] = [];
+    for (const root of ROOTS) {
+      // A path with a segment after the root, so the resolver would parse it as
+      // `<namespace>/<memex>` if the root were NOT exempt. `probe` is a plain slug
+      // on purpose: an identifier with underscores would fail the slug grammar and
+      // no-op the resolver for the wrong reason, making the check pass vacuously.
+      const res = await fetch(`${SMOKE_BASE_URL}/api/${root}/probe`, {
+        redirect: "manual",
+      });
+      if (res.headers.get(TENANT_EXEMPT_HEADER) !== "exempt") {
+        unreachable.push(`${root} (status ${res.status})`);
+      }
+    }
+    // Named, not counted, so a failure says WHICH mount is swallowed.
+    expect(unreachable).toEqual([]);
+  });
+
+  it("does not mark a tenant path — std-7 non-enumeration holds on the deployed host", async () => {
+    tagAc(AC_NOLEAK);
+    // A namespace that does not exist. The marker must be absent, so this response
+    // stays indistinguishable from a private-but-existing memex.
+    const res = await fetch(
+      `${SMOKE_BASE_URL}/api/zzz-spec515-absent/zzz-absent/docs`,
+      { redirect: "manual" },
+    );
+    expect(res.headers.get(TENANT_EXEMPT_HEADER)).toBeNull();
+  });
+});

--- a/packages/server/src/__smoke__/flat-api-reachability.smoke.test.ts
+++ b/packages/server/src/__smoke__/flat-api-reachability.smoke.test.ts
@@ -26,7 +26,7 @@
 
 import { describe, expect, it } from "vitest";
 import { tagAc } from "@memex-ai-ac/vitest";
-import { reservedApiRoots, TENANT_EXEMPT_HEADER } from "../middleware/memex-resolver.js";
+import { reservedApiRoots, TENANT_EXEMPT_HEADER } from "../routes/api-roots.js";
 import { SMOKE_BASE_URL } from "./smoke-env.js";
 
 const AC = "mindset-prod/memex-building-itself/specs/spec-515/acs/ac-12";

--- a/packages/server/src/__smoke__/reserved-root-collisions.smoke.test.ts
+++ b/packages/server/src/__smoke__/reserved-root-collisions.smoke.test.ts
@@ -29,7 +29,7 @@
 import postgres from "postgres";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { tagAc } from "@memex-ai-ac/vitest";
-import { reservedApiRoots } from "../middleware/memex-resolver.js";
+import { reservedApiRoots } from "../routes/api-roots.js";
 import { SMOKE_DATABASE_URL, SMOKE_ENV } from "./smoke-env.js";
 
 const AC = "mindset-prod/memex-building-itself/specs/spec-515/acs/ac-6";

--- a/packages/server/src/__smoke__/reserved-root-collisions.smoke.test.ts
+++ b/packages/server/src/__smoke__/reserved-root-collisions.smoke.test.ts
@@ -1,0 +1,78 @@
+// spec-515 t-3 / ac-6 — no live tenant is stranded by the reserved-root fix.
+//
+// THE HAZARD. Adding a root to the exempt vocabulary makes `parseMemexPath` no-op for
+// it, which is what makes a flat `/api/<root>` mount reachable — and what would make
+// a tenant that already OWNS that word as its namespace slug unroutable, because
+// `/<root>/<memex>/…` would stop resolving. The two features compete for one
+// vocabulary (std-3 cl-7) and this is the interlock.
+//
+// WHY A SMOKE-TIER CHECK AND NOT ONLY THE DEPLOY GATE. `deploy.sh` already runs the
+// same function as a gating pre-condition before migrations (t-3), so a deploy cannot
+// proceed over a collision. But that gate only fires when someone deploys. This tier
+// makes the same claim checkable ON DEMAND against a live database — which is what
+// ac-6 asks for ("prod and int are confirmed…"), and what turns a one-off manual
+// query into something a reviewer can re-run.
+//
+// dec-3 verified by hand on 2026-07-28: prod (328 namespaces) and int (78) both
+// clear, for the nine new roots, the 21 already-reserved ones, and the post-rename
+// reservation table. That was a point-in-time observation — a namespace can be
+// created at any moment — so the value here is the repeatability, not the first pass.
+//
+// DB tier: skips cleanly when SMOKE_DATABASE_URL is unset (std-26 gotcha #8 —
+// "skipped" is the normal green for a run without credentials). Requires a
+// cloud-sql-proxy. STRICTLY READ-ONLY: SELECTs only, against production data.
+//
+//   cloud-sql-proxy --port 15432 memex-ai-prod:us-east4:memex-prod &
+//   SMOKE_DATABASE_URL="postgresql://…@localhost:15432/memex" \
+//     pnpm --filter @memex/server smoke
+
+import postgres from "postgres";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { reservedApiRoots } from "../middleware/memex-resolver.js";
+import { SMOKE_DATABASE_URL, SMOKE_ENV } from "./smoke-env.js";
+
+const AC = "mindset-prod/memex-building-itself/specs/spec-515/acs/ac-6";
+
+const ENABLED = !!SMOKE_DATABASE_URL;
+
+describe.skipIf(!ENABLED)(
+  `reserved-root collision smoke @ ${SMOKE_ENV || "(env unset)"}`,
+  () => {
+    let sql: ReturnType<typeof postgres>;
+    // Read-only by construction as well as by intent: the role may still be a
+    // superuser on some envs, so the queries below are the only guarantee.
+    beforeAll(() => {
+      sql = postgres(SMOKE_DATABASE_URL, { max: 2 });
+    });
+    afterAll(async () => {
+      await sql?.end?.({ timeout: 5 });
+    });
+
+    it("no namespace slug and no post-rename reservation squats a reserved API root", async () => {
+      tagAc(AC);
+      const roots = [...reservedApiRoots()];
+      // Guard the guard: an empty vocabulary would make both queries trivially
+      // return nothing and the assertion pass while checking nothing at all.
+      expect(roots.length).toBeGreaterThan(20);
+
+      const [claimed, held, total] = await Promise.all([
+        sql<{ slug: string }[]>`select slug from namespaces where slug = any(${sql.array(roots)})`,
+        sql<{ slug: string }[]>`select slug from namespace_slug_reservations where slug = any(${sql.array(roots)})`,
+        sql<{ n: number }[]>`select count(*)::int as n from namespaces`,
+      ]);
+
+      // Sanity: prove the queries actually saw data rather than being masked by
+      // row-level security (std-36 uses ENABLE, not FORCE, but the runtime role is
+      // non-owner). Without this, "no collisions" could mean "no visibility".
+      expect(total[0].n).toBeGreaterThan(0);
+
+      // Named, not counted, so a failure says WHICH tenant is about to be stranded
+      // and by which word.
+      expect({
+        namespaces: claimed.map((r) => r.slug).sort(),
+        reservations: held.map((r) => r.slug).sort(),
+      }).toEqual({ namespaces: [], reservations: [] });
+    });
+  },
+);

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -46,6 +46,7 @@ import driftRouter from "./routes/drift.js";
 import { search } from "./routes/search.js";
 import { internalLifecycleRouter } from "./routes/internal-lifecycle.js";
 import { testEventsRouter } from "./routes/test-events.js";
+import { mountFlatApi } from "./routes/flat-api-mounts.js";
 import { specCheckoutRouter } from "./routes/spec-checkout.js";
 import { hookKeysRouter } from "./routes/hook-keys.js";
 import { testOnlyRouter } from "./routes/__test__.js";
@@ -320,7 +321,7 @@ app.route("/api/:namespace/:memex/telemetry", telemetryRouter);
 //
 //   ORG:      /api/orgs/:orgId/scaffold/*           — org-admin gated (b-68 t-10)
 //   PERSONAL: /api/:namespace/:memex/scaffold/*     — namespace-owner gated
-app.route("/api/orgs", scaffoldRouter);
+mountFlatApi(app, "orgs", scaffoldRouter);
 app.route("/api/:namespace/:memex/scaffold", personalScaffoldRouter);
 app.use("/api/:namespace/:memex/llm/*", sessionMiddleware);
 app.route("/api/:namespace/:memex/llm", llmRouter);
@@ -352,33 +353,33 @@ app.route("/api/:namespace/:memex/memexes", memexesRouter);
 // which reads currentMemexId set by sessionMiddleware from either the path-resolved
 // memex (above) or the caller's single membership (below). For multi-membership
 // callers, only the path-prefixed mount works — that's the std-5 ambiguity contract.
-app.route("/api/docs", docEventsRouter);
-app.route("/api/docs", docs);
-app.route("/api/comments", comments);
-app.route("/api/decisions", decisionsRouter);
-app.route("/api/tasks", tasksRouter);
-app.route("/api/issues", issuesRouter);
-app.route("/api/acs", acsRouter);
-app.route("/api/execution-plans", executionPlans);
-app.route("/api/drift", driftRouter);
+mountFlatApi(app, "docs", docEventsRouter);
+mountFlatApi(app, "docs", docs);
+mountFlatApi(app, "comments", comments);
+mountFlatApi(app, "decisions", decisionsRouter);
+mountFlatApi(app, "tasks", tasksRouter);
+mountFlatApi(app, "issues", issuesRouter);
+mountFlatApi(app, "acs", acsRouter);
+mountFlatApi(app, "execution-plans", executionPlans);
+mountFlatApi(app, "drift", driftRouter);
 // feat-ac-spike V0.0.1 — test-event receiver for AC pass/fail emissions from the codebase.
-app.route("/api/test-events", testEventsRouter);
+mountFlatApi(app, "test-events", testEventsRouter);
 // spec-371 — record-only checkout phone-home (Bearer hook-key auth, body-resolved tenant).
-app.route("/api/spec-checkout", specCheckoutRouter);
+mountFlatApi(app, "spec-checkout", specCheckoutRouter);
 // /api/llm/* migrated to sessionMiddleware (t-13). Legacy middleware/auth.ts deleted.
 app.use("/api/llm/*", sessionMiddleware);
-app.route("/api/llm", llmRouter);
+mountFlatApi(app, "llm", llmRouter);
 
 // Caller-scoped + public surfaces — stay flat (no path prefix). These have no
 // per-memex semantics, so prefixing them would be noise.
 // spec-479 dec-5 — public page-path redirect resolution for the CDN-served SPA.
-app.route("/api/redirects", redirectsRouter);
+mountFlatApi(app, "redirects", redirectsRouter);
 
-app.route("/api/waitlist", waitlist);
+mountFlatApi(app, "waitlist", waitlist);
 // spec-458 (PROTOTYPE) — PUBLIC global live-stats aggregate behind memex.ai/live.
 // Flat + tenant-less + NO session middleware (the /api/health pattern): the
 // payload is aggregates + a templated ticker only. Kill switch inside the router.
-app.route("/api/live", live);
+mountFlatApi(app, "live", live);
 // spec-324 — the ANONYMOUS-capable engagement ingress (the spec-244 retrofit).
 // Flat + tenant-less + PERMISSIVE publicSessionMiddleware so a PRE-AUTH visitor
 // (no user, no memex) is captured keyed on the consent-gated visitor_id — the
@@ -386,50 +387,50 @@ app.route("/api/live", live);
 // surfaces; `/api/telemetry` (2 segments) never collides with the 4-segment
 // `/api/:ns/:mx/telemetry`.
 app.use("/api/telemetry/*", publicSessionMiddleware);
-app.route("/api/telemetry", anonTelemetryRouter);
-app.route("/api/auth", auth);
+mountFlatApi(app, "telemetry", anonTelemetryRouter);
+mountFlatApi(app, "auth", auth);
 // /api/internal — spec-453 t-6 (dec-11): machine-only lifecycle scheduler tick. Flat,
 // non-tenant (global drip + Day-12 pass); self-authenticates a shared bearer secret
 // (LIFECYCLE_TICK_SECRET), NOT the user session. The sole trigger is Cloud Scheduler.
-app.route("/api/internal", internalLifecycleRouter);
+mountFlatApi(app, "internal", internalLifecycleRouter);
 // spec-507 + spec-508: /api/welcome-video (spec-444's video dismiss) and /api/onboarding
 // (spec-206's voice greeting gate) are both retired with their first-run gates. The
 // users.video_welcomed_at column survives as history (spec-507 dec-2); onboarding_greeted_at
 // was dropped with the voice guide (spec-508, migration 0130).
 // /api/orgs — t-14 + t-16 of doc-15. Single org-creation + admin surface.
 // Replaces the retired /api/accounts and /api/account mounts.
-app.route("/api/orgs", orgsRouter);
+mountFlatApi(app, "orgs", orgsRouter);
 // /api/orgs/:orgId/scaffold — read the merged base+org scaffold and administer
 // per-Org GuidanceBlock additions (b-68 t-10). Mounted EARLIER (above, before
 // the param-prefixed personal scaffold router) so the literal `orgs` path isn't
 // shadowed by `/api/:namespace/:memex/scaffold` — see the ordering note there.
 // /api/namespaces — doc-19 t-3: namespace-keyed endpoints (slug check, rename,
 // home payload, sibling-memex creation).
-app.route("/api/namespaces", namespacesRouter);
+mountFlatApi(app, "namespaces", namespacesRouter);
 // /api/consent — t-13 of doc-15. The domain-match consent prompt the React UI
 // surfaces on session start. SSO no longer auto-inserts memberships; this is
 // the only path that does.
-app.route("/api/consent", consentRouter);
+mountFlatApi(app, "consent", consentRouter);
 // `/api/invites/accept` stays flat — the invite token IS the authorization;
 // caller doesn't have a tenant context yet (joining the invite is what grants
 // them one). The mint/list/revoke trio moved under the tenant prefix above.
-app.route("/api/invites", invitesAcceptRouter);
+mountFlatApi(app, "invites", invitesAcceptRouter);
 // Caller-scoped endpoints — namespace picker (std-5) and minimal session shape.
-app.route("/api/me", meRouter);
+mountFlatApi(app, "me", meRouter);
 // spec-303 — Home Canvas onboarding journey-state (user-level, no memex). Derived
 // position + measurement + operator preview.
-app.route("/api/me", journeyRouter);
+mountFlatApi(app, "me", journeyRouter);
 // spec-315 — the graduated Home surface (user-level, no memex): where-you're-needed
 // + specs-in-flight, aggregated across all the user's memberships.
-app.route("/api/me", homeRouter);
+mountFlatApi(app, "me", homeRouter);
 // spec-200: global What's New feed (not tenant-scoped).
-app.route("/api/whats-new", whatsNewRouter);
+mountFlatApi(app, "whats-new", whatsNewRouter);
 // PUBLIC: share routes skip session middleware — guests access shared docs by token alone (t-10).
-app.route("/api/share", shareRouter);
+mountFlatApi(app, "share", shareRouter);
 
 // spec-427 t-4 — PUBLIC lifecycle-email unsubscribe (GET one-click + POST RFC 8058).
 // No session/tenant middleware: the HMAC token in the URL is the capability.
-app.route("/api/email", unsubscribeRouter);
+mountFlatApi(app, "email", unsubscribeRouter);
 
 // spec-171 t-3: Stripe webhook receiver. No session middleware — the
 // Stripe-Signature HMAC header IS the auth (verified inside the router).
@@ -441,20 +442,20 @@ app.route("/api/postmark/webhook", postmarkWebhookRouter);
 
 // Platform backstage — dev-mode only today. Gated inside the router itself. Registered on
 // the bare domain so operators can hit it without a tenant subdomain.
-app.route("/api/backstage", backstageRouter);
+mountFlatApi(app, "backstage", backstageRouter);
 
 // Device-flow installer + token settings (t-14).
 app.route("/api/cli/auth", cliAuth);
 app.route("/api/mcp/tokens", mcpTokensRouter);
 // spec-430 dec-3: hook keys are per USER, never per memex — user-level mint, no
 // :namespace/:memex in the path (modelled on /api/mcp/tokens above).
-app.route("/api/hook-keys", hookKeysRouter);
+mountFlatApi(app, "hook-keys", hookKeysRouter);
 
 // OAuth 2.1 + DCR + PKCE (b-31 W1). Gated by OAUTH_ENABLED=1 so the entire
 // surface (routes + well-known discovery) is dead until explicitly turned on.
 // Existing `mxt_` users are unaffected when this flag is off.
 if (isOAuthEnabled()) {
-  app.route("/api/oauth", oauth);
+  mountFlatApi(app, "oauth", oauth);
   app.route("/.well-known", wellKnown);
 }
 

--- a/packages/server/src/deploy-script-parity.test.ts
+++ b/packages/server/src/deploy-script-parity.test.ts
@@ -1,0 +1,138 @@
+// spec-515 — every pnpm script deploy.sh invokes must actually exist.
+//
+// WHY THIS EXISTS. The reserved-root collision gate (t-3) was wired into deploy.sh
+// as `pnpm --filter @memex/server tsx scripts/check-reserved-root-collisions.ts`.
+// pnpm reads the token after the filter as a SCRIPT NAME, not a binary, so it died
+// with ERR_PNPM_RECURSIVE_RUN_NO_SCRIPT. Because that gate is deliberately
+// fail-closed ("could not check" == "did not pass"), the broken invocation aborted
+// the entire int deploy on the first run that ever exercised it — 2026-08-10,
+// three weeks after the script itself was written and unit-tested.
+//
+// The unit tests proved the script's LOGIC. Nothing proved it could be REACHED,
+// because the only thing that runs deploy.sh is a deploy. That is the whole gap:
+// implemented is not activated, and a deploy step is the one kind of code whose
+// call site never runs in CI.
+//
+// This test closes it statically, with no database and no network: parse the real
+// deploy.sh, extract every pnpm script invocation, and assert each one resolves in
+// the package.json it would run against. A typo'd or renamed script now reddens a
+// PR instead of stranding a deploy.
+
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+const PKG_DIR = join(import.meta.dirname, "..");
+const REPO_ROOT = join(PKG_DIR, "..", "..");
+
+// deploy.sh `cd "${PKG_DIR}"` at the top (line ~22), so a bare `pnpm <script>`
+// resolves against packages/server. An explicit `--filter <pkg>` overrides that.
+const DEFAULT_PKG = "@memex/server";
+
+// pnpm subcommands that are NOT script names — the token after them is an
+// argument, so there is nothing to look up.
+const PNPM_SUBCOMMANDS = new Set([
+  "exec",
+  "dlx",
+  "install",
+  "add",
+  "remove",
+  "why",
+  "list",
+  "config",
+  "publish",
+  "pack",
+  "store",
+  "prune",
+  "rebuild",
+  "deploy",
+  "licenses",
+  "audit",
+  "outdated",
+  "update",
+]);
+
+type Invocation = { line: number; pkg: string; script: string; raw: string };
+
+/**
+ * Pull every pnpm script invocation out of a shell script.
+ *
+ * Comment lines are skipped, which is load-bearing rather than tidiness: the fix
+ * for this very defect left a comment in deploy.sh quoting the BROKEN command as
+ * a warning to the next reader. A scanner that read comments would flag that
+ * warning as the defect it warns about — and the cheapest way to silence it would
+ * be to delete the explanation.
+ */
+export function parsePnpmScriptInvocations(shell: string): Invocation[] {
+  const out: Invocation[] = [];
+
+  shell.split("\n").forEach((rawLine, i) => {
+    const line = rawLine.trim();
+    if (line.startsWith("#") || line === "") return;
+
+    // `pnpm [--filter <pkg>] [run] <script>` — capture the filter and the token
+    // that lands in script position.
+    const re = /\bpnpm\s+(?:--filter\s+(\S+)\s+)?(?:run\s+)?([A-Za-z0-9:_-]+)/g;
+    for (const m of line.matchAll(re)) {
+      const pkg = m[1] ?? DEFAULT_PKG;
+      const script = m[2];
+      if (PNPM_SUBCOMMANDS.has(script)) continue;
+      // A flag in script position means the invocation is something else.
+      if (script.startsWith("-")) continue;
+      out.push({ line: i + 1, pkg, script, raw: line });
+    }
+  });
+
+  return out;
+}
+
+function scriptsFor(pkgName: string): Record<string, string> {
+  // The two packages deploy.sh can name today. Resolved by name rather than by
+  // globbing the workspace so an unexpected package is a loud failure.
+  const dirByName: Record<string, string> = {
+    "@memex/server": join(REPO_ROOT, "packages", "server"),
+    "@memex/ui": join(REPO_ROOT, "packages", "ui"),
+    "@memex/shared": join(REPO_ROOT, "packages", "shared"),
+  };
+  const dir = dirByName[pkgName];
+  if (!dir) throw new Error(`deploy.sh names an unmapped package: ${pkgName}`);
+  const pkg = JSON.parse(readFileSync(join(dir, "package.json"), "utf8"));
+  return pkg.scripts ?? {};
+}
+
+describe("deploy.sh pnpm script parity (spec-515)", () => {
+  const shell = readFileSync(join(PKG_DIR, "deploy.sh"), "utf8");
+  const invocations = parsePnpmScriptInvocations(shell);
+
+  it("finds the invocations at all — an empty scan would pass vacuously", () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-515/acs/ac-4");
+    expect(invocations.length).toBeGreaterThan(3);
+  });
+
+  it("every script deploy.sh invokes exists in its package", () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-515/acs/ac-4");
+
+    const missing = invocations
+      .filter((inv) => !(inv.script in scriptsFor(inv.pkg)))
+      // Named, not counted, so the failure says WHICH line and WHICH script.
+      .map((inv) => `deploy.sh:${inv.line} → ${inv.pkg} has no script "${inv.script}"`);
+
+    expect(missing).toEqual([]);
+  });
+
+  it("the reserved-root gate specifically resolves — the one that broke the deploy", () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-515/acs/ac-4");
+
+    const gate = invocations.find((inv) => inv.script === "check-reserved-roots");
+    expect(gate, "deploy.sh no longer invokes check-reserved-roots").toBeDefined();
+    expect(scriptsFor(gate!.pkg)).toHaveProperty("check-reserved-roots");
+  });
+
+  it("skips commented-out invocations, so an explanatory comment cannot redden this", () => {
+    const parsed = parsePnpmScriptInvocations(
+      ["# pnpm --filter @memex/server tsx scripts/whatever.ts", "pnpm db:migrate"].join("\n"),
+    );
+    expect(parsed.map((p) => p.script)).toEqual(["db:migrate"]);
+  });
+});

--- a/packages/server/src/middleware/memex-resolver.test.ts
+++ b/packages/server/src/middleware/memex-resolver.test.ts
@@ -6,6 +6,8 @@
 // sessionMiddleware auto-resolve a single-membership user to their own memex
 // regardless of what URL they actually typed).
 
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { describe, it, expect, vi } from "vitest";
 
 vi.mock("../db/connection.js", () => ({
@@ -19,7 +21,7 @@ vi.mock("../db/connection.js", () => ({
 
 import { Hono } from "hono";
 import { tagAc } from "@memex-ai-ac/vitest";
-import { memexResolver, parseMemexPath } from "./memex-resolver.js";
+import { memexResolver, parseMemexPath, reservedApiRoots } from "./memex-resolver.js";
 
 const app = new Hono();
 app.use("/*", memexResolver);
@@ -120,5 +122,167 @@ describe("memexResolver malformed-path guard (b-38 A4)", () => {
     // (mocked DB returns null → 404).
     const res = await app.request("/foo/bar");
     expect(res.status).toBe(404);
+  });
+});
+
+// spec-515 t-2 / ac-8 — every flat `/api/<root>` mount must be exempt from
+// tenant parsing.
+//
+// memexResolver is registered as `app.use("*", …)` BEFORE any route, so it sees
+// the path first. parseMemexPath reads `/api/<a>/<b>` as a tenant address, which
+// means a flat mount whose root is missing from RESERVED_API_ROOTS has its
+// SUBPATHS swallowed: the resolver looks up a namespace that doesn't exist and
+// returns 404 per std-7 before the router ever runs.
+//
+// The bare mount always works — `/api/test-events` has one segment after /api,
+// so parseMemexPath returns null on the length check. Only the subpath breaks.
+// That asymmetry is why this shipped unnoticed: see the `stripe`, `postmark` and
+// `internal` comments in memex-resolver.ts, each describing this same failure.
+//
+// Measured against prod on 2026-07-27: nine mounts unguarded.
+// `/api/email/unsubscribe` (the RFC 8058 one-click target carried on every
+// lifecycle email) had 404'd since 2026-07-01, and `/api/test-events/batch` had
+// silently disabled spec-489's CI-burst batching, driving Cloud SQL CPU to 100%.
+//
+// Derived from app.ts source rather than a hardcoded list, so a NEW flat mount is
+// covered the day it lands. Deliberately NOT written with `app.request(...)`:
+// this file mocks db/connection.js (top of file), and that mock is precisely why
+// six batch-route tests pass in routes/test-events.test.ts while production 404s.
+// A route-level assertion here would inherit the same blind spot.
+const APP_SRC = readFileSync(
+  fileURLToPath(new URL("../app.ts", import.meta.url)),
+  "utf8",
+);
+
+// Matches the mount forms app.ts actually uses: `mountFlatApi(app, "<root>", …)`
+// (spec-515 t-6 — the helper that ties a mount to its exemption) and any surviving
+// `app.use("/api/<root>/*", …)` middleware pairing. The character class excludes `:`
+// and `*`, so tenant-prefixed mounts and the catch-all (`/api/*`) are skipped.
+const FLAT_API_MOUNT_ROOTS = [
+  ...new Set(
+    [
+      ...APP_SRC.matchAll(
+        /mountFlatApi\(\s*app\s*,\s*"([a-z0-9-]+)"|app\.(?:route|use)\(\s*"\/api\/([a-z0-9-]+)(?:\/\*)?"/g,
+      ),
+    ].map((m) => m[1] ?? m[2]),
+  ),
+].sort();
+
+describe("flat /api/<root> mounts survive tenant resolution (spec-515)", () => {
+  it("finds the flat mounts it is meant to guard", () => {
+    // Guards the guard: if the regex stops matching after a refactor changes how
+    // mounts are registered, the assertions below would vacuously pass.
+    expect(FLAT_API_MOUNT_ROOTS.length).toBeGreaterThan(20);
+    expect(FLAT_API_MOUNT_ROOTS).toContain("test-events");
+    expect(FLAT_API_MOUNT_ROOTS).toContain("email");
+  });
+
+  it("returns null for a subpath under every flat mount root", () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-515/acs/ac-8");
+    const swallowed = FLAT_API_MOUNT_ROOTS.filter(
+      (root) => parseMemexPath(`/api/${root}/anything`) !== null,
+    );
+    // Named rather than counted so a failure says WHICH mount is unreachable.
+    expect(swallowed).toEqual([]);
+  });
+
+  it("still resolves a genuine two-segment tenant path", () => {
+    // The fix must not over-reach: a real `/api/<ns>/<mx>/…` must still parse.
+    expect(
+      parseMemexPath("/api/mindset-prod/memex-building-itself/docs"),
+    ).toEqual({
+      namespaceSlug: "mindset-prod",
+      memexSlug: "memex-building-itself",
+    });
+  });
+
+  // Named anchors for the five paths observed 404ing in production, so a future
+  // regression reports the user-visible consequence, not just a bare root.
+  it.each([
+    ["/api/email/unsubscribe", "RFC 8058 one-click unsubscribe target"],
+    ["/api/test-events/batch", "spec-489 CI-burst batch ingest"],
+    ["/api/acs/doc/some-uuid", "AC lookup by doc"],
+    ["/api/issues/some-uuid", "issue lookup"],
+    ["/api/hook-keys/some-uuid/revoke", "hook-key revoke"],
+  ])("does not swallow %s (%s)", (path) => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-515/acs/ac-8");
+    expect(parseMemexPath(path)).toBeNull();
+  });
+});
+
+// spec-515 t-9 / dec-6 / ac-12, ac-17 — the exemption marker.
+//
+// WHY A MARKER AT ALL. The post-deploy smoke check has to prove every flat
+// `/api/<root>` mount is reachable on the deployed host. It cannot do that from the
+// response body: `{"error":"Not found"}` is emitted by at least six code paths
+// (memexResolver ×3, session.ts, permissions.ts, hook-key-or-session.ts, plus
+// NotFoundError), so a router legitimately reporting "no such id" is byte-identical
+// to the resolver swallowing the route. Measured during t-2: after the fix,
+// `/api/issues/x` and an unmounted control root returned the same bytes.
+//
+// WHY IT MARKS THE EXEMPTION, NOT THE FAILURE (dec-6). memexResolver performs no
+// membership check — it does two lookups and 404s if either misses; authorization is
+// enforced later. Marking the FAILURE would therefore have split two cases std-7
+// requires to be indistinguishable: a nonexistent namespace (resolver 404s → marked)
+// versus a private-but-existing memex (resolver passes; a later layer 404s → not
+// marked). That is namespace enumeration, and std-7 exists to prevent it.
+//
+// Marking the exemption leaks nothing: the header only says "this word is an API
+// root", which the route surface already makes public, and it never appears on a
+// tenant path.
+describe("exemption marker x-memex-tenant (spec-515 t-9 / dec-6)", () => {
+  const AC_SMOKE = "mindset-prod/memex-building-itself/specs/spec-515/acs/ac-12";
+  const AC_NOLEAK = "mindset-prod/memex-building-itself/specs/spec-515/acs/ac-17";
+
+  it("marks every reserved API root, driven from the shared declaration", async () => {
+    tagAc(AC_SMOKE);
+    const unmarked: string[] = [];
+    for (const root of reservedApiRoots()) {
+      const res = await app.request(`/api/${root}/probe`);
+      if (res.headers.get("x-memex-tenant") !== "exempt") unmarked.push(root);
+    }
+    expect(unmarked).toEqual([]);
+  });
+
+  it("survives a downstream handler that builds its own response", async () => {
+    // The catch-all above answers with c.json(...), i.e. a NEW Response object. A
+    // header set by middleware before next() has to survive that or the smoke check
+    // would read as 'unreachable' on a perfectly healthy route.
+    tagAc(AC_SMOKE);
+    const res = await app.request("/api/test-events/batch");
+    expect(res.status).toBe(200); // the test catch-all, not the real router
+    expect(res.headers.get("x-memex-tenant")).toBe("exempt");
+  });
+
+  it("marks a single-segment reserved root too", async () => {
+    tagAc(AC_SMOKE);
+    const res = await app.request("/api/health");
+    expect(res.headers.get("x-memex-tenant")).toBe("exempt");
+  });
+
+  it("does NOT mark a tenant path — nonexistent and private stay indistinguishable", async () => {
+    // The std-7 claim. The mocked DB returns null for the namespace lookup, so this
+    // is the "namespace does not exist" branch — the one a failure-marker would have
+    // singled out. It must look exactly like any other 404.
+    tagAc(AC_NOLEAK);
+    const res = await app.request("/api/mindset/memex-app/docs");
+    expect(res.status).toBe(404);
+    expect(res.headers.get("x-memex-tenant")).toBeNull();
+  });
+
+  it("does NOT mark a path that fails tenant parsing for other reasons", async () => {
+    // The claim is "this root is exempt", not "this wasn't a tenant path". A browser
+    // route and a malformed slug both no-op the resolver without being exempt.
+    tagAc(AC_NOLEAK);
+    for (const path of ["/login", "/api/UPPER/case/docs"]) {
+      const res = await app.request(path);
+      expect(res.headers.get("x-memex-tenant")).toBeNull();
+    }
+  });
+
+  it("does NOT mark an unreserved root that looks tenant-shaped", async () => {
+    tagAc(AC_NOLEAK);
+    const res = await app.request("/api/zzznotreserved/thing");
+    expect(res.headers.get("x-memex-tenant")).toBeNull();
   });
 });

--- a/packages/server/src/middleware/memex-resolver.ts
+++ b/packages/server/src/middleware/memex-resolver.ts
@@ -1,6 +1,7 @@
 import { createMiddleware } from "hono/factory";
 import { and, eq } from "drizzle-orm";
 import { db } from "../db/connection.js";
+import { reservedApiRoots as resolveReservedApiRoots } from "../routes/api-roots.js";
 import { memexes, namespaces, orgMemberships } from "../db/schema.js";
 import type { Memex, Namespace } from "../db/schema.js";
 
@@ -89,66 +90,11 @@ interface PathPrefix {
 // namespace and "check" as a memex; same logic for every other API mount. The
 // reserved-slug list (services/shared/slug.ts) covers user-facing reservations;
 // this list covers internal API path roots.
-const RESERVED_API_ROOTS = new Set([
-  "health",
-  "share",
-  "auth",
-  "oauth",
-  "waitlist",
-  "cli",
-  "mcp",
-  "me",
-  "onboarding",
-  "orgs",
-  "namespaces",
-  "redirects",
-  "consent",
-  "invites",
-  "team",
-  "backstage",
-  "docs",
-  "comments",
-  "decisions",
-  "tasks",
-  "execution-plans",
-  "llm",
-  "drift",
-  "__test__",
-  // spec-171: the Stripe webhook receiver mounts at /api/stripe/webhook (public —
-  // the Stripe-Signature HMAC is the auth). Without this, parseMemexPath reads
-  // "/api/stripe/webhook" as namespace=stripe / memex=webhook and 404s before the
-  // webhook router runs, so Stripe deliveries fail and orgs never get their tier.
-  "stripe",
-  // spec-341: the Postmark delivery webhook mounts at /api/postmark/webhook
-  // (public — the Basic-auth credential is the auth). Without this, parseMemexPath
-  // reads "/api/postmark/webhook" as namespace=postmark / memex=webhook and 404s
-  // before the webhook router runs, so Postmark deliveries never update comms_log.
-  // (Same class of bug as spec-171's "stripe" entry.)
-  "postmark",
-  // spec-453 t-6: the machine lifecycle-tick mounts at /api/internal/lifecycle-tick
-  // (non-tenant; a shared bearer secret is the auth). Without this, parseMemexPath reads
-  // "/api/internal/lifecycle-tick" as namespace=internal / memex=lifecycle-tick and 404s
-  // before the router runs, so Cloud Scheduler could never trigger the drip / Day-12 pass.
-  // (Same class of bug as the stripe / postmark webhook entries above.)
-  "internal",
-  // spec-515: nine more flat `/api/<root>` mounts (app.ts) that were never added here,
-  // so parseMemexPath read `/api/<root>/<x>` as namespace=<root>/memex=<x> and 404'd
-  // before their router ran — the same recurring class as stripe/postmark/internal.
-  // The sharpest consequence: `/api/test-events/batch` 404'd, so the CI AC-emitter fell
-  // back to unbounded per-event POSTs (`emitBatch` 404 → Promise.all(single)) — ~11.6M
-  // INSERT/DELETE/upsert calls that drove prod Cloud SQL to ~100% CPU (2026-08). Also
-  // 404'd one-click unsubscribe (`/api/email/...`). The flat-mount scan test
-  // (reserved-api-roots.spec-515.test.ts) now fails CI if a flat root is ever left out.
-  "issues",
-  "acs",
-  "test-events",
-  "spec-checkout",
-  "live",
-  "telemetry",
-  "whats-new",
-  "email",
-  "hook-keys",
-]);
+// spec-515 — "is this root a tenant namespace?" has ONE definition, in
+// routes/api-roots.ts (zero imports, so the reserved-slug list can share it).
+// Re-exported here because this module is the historical home and several
+// callers still reach for it through the resolver.
+export { reservedApiRoots } from "../routes/api-roots.js";
 
 // Parses `/<namespace>/<memex>/...` or `/api/<namespace>/<memex>/...` from a
 // request path. Returns null when the path is a top-level reserved word
@@ -179,7 +125,7 @@ export function parseMemexPath(rawPath: string): PathPrefix | null {
   if (!SLUG_RE.test(second)) return null;
 
   // Path roots reserved for API mounts can't be tenant namespaces.
-  if (RESERVED_API_ROOTS.has(first)) return null;
+  if (resolveReservedApiRoots().has(first)) return null;
 
   return { namespaceSlug: first, memexSlug: second };
 }
@@ -192,6 +138,29 @@ export function parseMemexPath(rawPath: string): PathPrefix | null {
 // memex regardless of what URL they typed (a debugging footgun, not an IDOR).
 const ENCODED_PATH_SEPARATOR = /%2[Ff]|%5[Cc]/;
 
+/**
+ * The response header the resolver stamps on a request it EXEMPTS from tenant
+ * parsing (spec-515 dec-6). The post-deploy smoke check asserts its presence for
+ * every reserved root — see `__smoke__/flat-api-reachability.smoke.test.ts`.
+ */
+export const TENANT_EXEMPT_HEADER = "x-memex-tenant";
+
+/**
+ * The reserved API root this path is exempt under, or null.
+ *
+ * Deliberately narrower than "parseMemexPath returned null": a single-segment path,
+ * a malformed slug or a browser route also no-op the resolver, but they are not
+ * *exempt roots* and must not be marked. The marker's claim is precise so the smoke
+ * check cannot read a coincidence as reachability.
+ */
+export function exemptApiRoot(rawPath: string): string | null {
+  const path = rawPath.split("?")[0];
+  if (!path.startsWith("/api/")) return null;
+  const first = path.slice("/api/".length).split("/")[0];
+  if (!first) return null;
+  return resolveReservedApiRoots().has(first) ? first : null;
+}
+
 export const memexResolver = createMiddleware<MemexResolverEnv>(async (c, next) => {
   const path = c.req.path;
 
@@ -201,6 +170,20 @@ export const memexResolver = createMiddleware<MemexResolverEnv>(async (c, next) 
     return c.json({ error: "Malformed path" }, 400);
   }
 
+  // spec-515 dec-6 — stamp the requests we EXEMPT, never the ones whose tenant
+  // lookup fails. Marking a failure would distinguish "namespace does not exist"
+  // (resolver 404s) from "memex exists but is private" (resolver passes, a later
+  // layer 404s) — the namespace enumeration std-7 exists to prevent. Marking the
+  // exemption says only "this word is an API root", which the route surface already
+  // makes public, and never appears on a tenant path.
+  if (exemptApiRoot(path) !== null) {
+    c.header(TENANT_EXEMPT_HEADER, "exempt");
+  }
+
+  // NOTE the ordering: the marker is set BEFORE the fast-path loop below, which
+  // `return next()`s for anything in NON_TENANT_API_PREFIXES. Setting it after would
+  // silently skip ~10 roots (health, cli, mcp, __test__, onboarding, …) and the smoke
+  // check would report them unreachable while they are perfectly healthy.
   // Fast path for /api routes that are intentionally non-tenant. Without this
   // skip, /api/health and /api/auth/login would try to resolve "auth/login" as
   // a (namespace, memex) pair — wasted DB query that always returns null.

--- a/packages/server/src/middleware/memex-resolver.ts
+++ b/packages/server/src/middleware/memex-resolver.ts
@@ -1,7 +1,10 @@
 import { createMiddleware } from "hono/factory";
 import { and, eq } from "drizzle-orm";
 import { db } from "../db/connection.js";
-import { reservedApiRoots as resolveReservedApiRoots } from "../routes/api-roots.js";
+import {
+  reservedApiRoots as resolveReservedApiRoots,
+  TENANT_EXEMPT_HEADER,
+} from "../routes/api-roots.js";
 import { memexes, namespaces, orgMemberships } from "../db/schema.js";
 import type { Memex, Namespace } from "../db/schema.js";
 
@@ -139,11 +142,14 @@ export function parseMemexPath(rawPath: string): PathPrefix | null {
 const ENCODED_PATH_SEPARATOR = /%2[Ff]|%5[Cc]/;
 
 /**
- * The response header the resolver stamps on a request it EXEMPTS from tenant
- * parsing (spec-515 dec-6). The post-deploy smoke check asserts its presence for
- * every reserved root — see `__smoke__/flat-api-reachability.smoke.test.ts`.
+ * Re-exported for the callers that already import it from here. The constant now
+ * LIVES in routes/api-roots.js — the zero-import vocabulary module — because a
+ * post-deploy smoke check that only needs the header NAME must not be forced to
+ * import this file, which pulls `db/connection` and therefore demands
+ * DATABASE_URL at module load. Both spec-515 smoke files did exactly that and
+ * died on import against int, before their own skip guards could run.
  */
-export const TENANT_EXEMPT_HEADER = "x-memex-tenant";
+export { TENANT_EXEMPT_HEADER };
 
 /**
  * The reserved API root this path is exempt under, or null.

--- a/packages/server/src/middleware/reserved-api-roots.spec-515.test.ts
+++ b/packages/server/src/middleware/reserved-api-roots.spec-515.test.ts
@@ -38,15 +38,36 @@ const SPEC_515_ROOTS = [
   "hook-keys",
 ];
 
-// Every literal `/api/<root>` mount (app.route/use/get/post/...). Tenant mounts start
-// `/api/:namespace/...`; the leading char class excludes ':' so those are NOT captured —
-// they ARE tenant paths and must stay resolvable.
+// Every literal `/api/<root>` mount. Tenant mounts start `/api/:namespace/...`; the
+// leading char class excludes ':' so those are NOT captured — they ARE tenant paths and
+// must stay resolvable.
+//
+// TWO mount forms are recognised, because spec-515 t-6 introduced a helper AFTER this
+// test was written:
+//   1. `mountFlatApi(app, "<root>", …)` — the current form. The helper also refuses to
+//      mount an undeclared root at boot, so this scan is now the second line of defence
+//      rather than the only one.
+//   2. `app.route|use|get|... ("/api/<root>"` — still used by deep mounts
+//      (`/api/stripe/webhook`) and direct handlers (`app.get("/api/health")`), which the
+//      helper does not cover.
+//
+// The guard-the-guard assertion below is what caught the t-6 restructure: when the
+// helper landed, form 1 was invisible here and the count fell from 36 to 7, failing
+// loudly instead of passing vacuously. Keep that assertion.
+//
+// A broader sibling lives in __regression__/flat-api-mount-invariant.spec-515.regression.test.ts
+// (both halves of the invariant, plus a no-raw-app.route scan). The overlap is deliberate:
+// this class of defect recurred six times, so two independent readings are worth their cost.
 function flatApiRoots(src: string): string[] {
-  const re =
-    /app\.(?:route|use|get|post|put|patch|delete)\(\s*["'`]\/api\/([a-z0-9][a-z0-9-]*)/g;
+  const patterns = [
+    /mountFlatApi\(\s*app\s*,\s*["'`]([a-z0-9][a-z0-9-]*)/g,
+    /app\.(?:route|use|get|post|put|patch|delete)\(\s*["'`]\/api\/([a-z0-9][a-z0-9-]*)/g,
+  ];
   const roots = new Set<string>();
-  let m: RegExpExecArray | null;
-  while ((m = re.exec(src)) !== null) roots.add(m[1]);
+  for (const re of patterns) {
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(src)) !== null) roots.add(m[1]);
+  }
   return [...roots].sort();
 }
 

--- a/packages/server/src/routes/__test__.ts
+++ b/packages/server/src/routes/__test__.ts
@@ -13,6 +13,8 @@ import {
   type QueuedFakeResponse,
 } from "../agent/anthropic-fake.js";
 import { db } from "../db/connection.js";
+import { unsubscribeUrl } from "../services/email/unsubscribe-token.js";
+import { isLifecycleEmailUnsubscribed } from "../services/users.js";
 import {
   users,
   namespaces,
@@ -248,6 +250,38 @@ const seedSpecSchema = z.object({
   // (spec-178 seeds 5 per Memex) do NOT count toward the hasSpec milestone / landing.
   isDemo: z.boolean().optional(),
 });
+// spec-515 t-10 / ac-2 — the one-click unsubscribe journey needs the real
+// unsubscribe URL, and a Playwright test cannot mint it: the token is an HMAC over
+// the userId signed with a server-side secret (services/email/unsubscribe-token.ts).
+// Handing the URL out here is what lets the journey exercise the SAME link a mail
+// client would follow, instead of a hand-rolled approximation that could pass while
+// the real link stays broken — which is exactly the defect spec-515 is fixing.
+const unsubscribeUrlSchema = z.object({ email: z.string() });
+testOnlyRouter.post("/unsubscribe-url", async (c) => {
+  const parsed = unsubscribeUrlSchema.safeParse(await c.req.json().catch(() => null));
+  if (!parsed.success) {
+    return c.json({ error: "Invalid request", details: parsed.error.issues }, 400);
+  }
+  const user = await getUserByEmail(parsed.data.email);
+  if (!user) return c.json({ error: `User ${parsed.data.email} not found` }, 404);
+  return c.json({ url: unsubscribeUrl(user.id) });
+});
+
+// The suppression state the unsubscribe is supposed to produce — the same column the
+// pre-send gate reads (isLifecycleEmailUnsubscribed, consumed by sendLifecycleEmail at
+// services/email/lifecycle-send.ts:38). Read through the service, not the column, so
+// the journey asserts what the SEND PATH will see rather than a schema detail.
+const unsubscribedStateSchema = z.object({ email: z.string() });
+testOnlyRouter.post("/lifecycle-unsubscribed", async (c) => {
+  const parsed = unsubscribedStateSchema.safeParse(await c.req.json().catch(() => null));
+  if (!parsed.success) {
+    return c.json({ error: "Invalid request", details: parsed.error.issues }, 400);
+  }
+  const user = await getUserByEmail(parsed.data.email);
+  if (!user) return c.json({ error: `User ${parsed.data.email} not found` }, 404);
+  return c.json({ unsubscribed: await isLifecycleEmailUnsubscribed(user.id) });
+});
+
 testOnlyRouter.post("/seed-spec", async (c) => {
   const body = await c.req.json().catch(() => null);
   const parsed = seedSpecSchema.safeParse(body);

--- a/packages/server/src/routes/api-roots.ts
+++ b/packages/server/src/routes/api-roots.ts
@@ -102,3 +102,18 @@ export const NON_FLAT_RESERVED_ROOTS: ReadonlySet<string> = new Set([
 export function reservedApiRoots(): ReadonlySet<string> {
   return new Set([...NON_FLAT_RESERVED_ROOTS, ...FLAT_API_MOUNT_ROOTS]);
 }
+
+/**
+ * The response header the tenant resolver stamps on a request it EXEMPTS from
+ * tenant parsing (spec-515 dec-6), asserted for every reserved root by the
+ * post-deploy smoke check (`__smoke__/flat-api-reachability.smoke.test.ts`).
+ *
+ * It lives HERE, in the zero-import module, for the same reason the root
+ * declaration does. It first lived in `middleware/memex-resolver.ts`, so a smoke
+ * check that needed nothing but the header NAME had to import the resolver —
+ * which imports `db/connection` and therefore demands DATABASE_URL at module
+ * load. Both spec-515 smoke files died on import against a live int deploy,
+ * before their own skip guards could run, for want of a string constant. The
+ * resolver re-exports it, so existing importers are unaffected.
+ */
+export const TENANT_EXEMPT_HEADER = "x-memex-tenant";

--- a/packages/server/src/routes/api-roots.ts
+++ b/packages/server/src/routes/api-roots.ts
@@ -1,0 +1,104 @@
+// spec-515 — the `/api` root vocabulary: which top-level words are NOT tenant
+// namespaces.
+//
+// This module has **zero imports on purpose**. Three very different places need the
+// same answer, and none of them should drag the others in:
+//
+//   middleware/memex-resolver.ts  — must a path be parsed as `<namespace>/<memex>`?
+//   services/shared/slug.ts       — may a user claim this word as a namespace slug?
+//   routes/flat-api-mounts.ts     — is this root declared, so the mount may proceed?
+//
+// `slug.ts` importing the resolver would pull `db/connection` into slug validation;
+// the resolver importing `slug.ts` would be a cycle. A dependency-free declaration
+// is what lets both read one definition instead of keeping two in step by hand.
+//
+// std-3 cl-7 (amended 2026-07-28) states the rule this file implements: the
+// reserved-slug list is the UNION of the app/marketing words and the API roots, and
+// the coupling is required in both directions — a word that is both an API root and
+// a namespace slug makes one of the two unreachable.
+
+// MEASURED IMPACT (from a colleague's independent reconstruction of this fix on
+// origin/develop, commit 00394743 — better quantified than the original diagnosis and
+// preserved here because that inline list was folded into this module):
+// `pg_stat_statements` showed **~11.6M INSERT/DELETE/upsert calls** across the
+// test_events emission path — about **31% of prod Cloud SQL CPU**, saturating the
+// 1-vCPU instance and slowing every DB-backed endpoint. Reserving `test-events` makes
+// /batch reachable, so the already-published emitter batches and the write volume
+// collapses.
+
+/**
+ * Every top-level segment under which a NON-TENANT router is mounted flat at
+ * `/api/<root>`. Declaring a root here is what permits `mountFlatApi` to mount it
+ * (see `flat-api-mounts.ts`) AND what exempts it from tenant parsing AND what makes
+ * it unclaimable as a namespace slug. One edit, three consequences.
+ *
+ * Roots reserved for other shapes live in {@link NON_FLAT_RESERVED_ROOTS}.
+ */
+export const FLAT_API_MOUNT_ROOTS: ReadonlySet<string> = new Set([
+  "acs",
+  "auth",
+  "backstage",
+  "comments",
+  "consent",
+  "decisions",
+  "docs",
+  "drift",
+  "email",
+  "execution-plans",
+  "hook-keys",
+  "internal",
+  "invites",
+  "issues",
+  "live",
+  "llm",
+  "me",
+  "namespaces",
+  "oauth",
+  "orgs",
+  "redirects",
+  "share",
+  "spec-checkout",
+  "tasks",
+  "telemetry",
+  "test-events",
+  "waitlist",
+  "whats-new",
+]);
+
+/**
+ * Roots reserved for shapes `mountFlatApi` cannot record, each declared by hand WITH
+ * its reason. Keeping these separate from the flat mounts is the point: the
+ * hand-maintained half stays small enough that a reviewer can audit every entry.
+ */
+export const NON_FLAT_RESERVED_ROOTS: ReadonlySet<string> = new Set([
+  // Direct handler, not a router mount: app.get("/api/health").
+  "health",
+  // Deep mounts — the root carries no router of its own, but `/api/<root>/<sub>` is
+  // two segments after /api, so the resolver would read <root> as a namespace.
+  "cli", //      /api/cli/auth
+  "mcp", //      /api/mcp/tokens  (+ app.all("/mcp"), outside /api entirely)
+  "stripe", //   /api/stripe/webhook — the Stripe-Signature HMAC is the auth (spec-171)
+  "postmark", // /api/postmark/webhook — a Basic-auth credential is the auth (spec-341)
+  // Env-gated test surface, mounted conditionally. The slug grammar rejects
+  // underscores anyway, so this entry is belt-and-braces.
+  "__test__",
+  // spec-515 dec-7 found these two apparently stale and deliberately KEPT them:
+  // `onboarding` has no mount in app.ts at all, and `team` is only mounted
+  // tenant-prefixed (/api/:namespace/:memex/team), so neither needs an exemption
+  // today. An extra entry only reserves a word; removing them is a slug-availability
+  // change that does not belong in a routing fix.
+  "onboarding",
+  "team",
+]);
+
+/**
+ * The effective set of `/api` roots that are not tenant namespaces.
+ *
+ * A function rather than a const so every consumer — `parseMemexPath`, the
+ * reserved-slug list, the deploy-precondition collision check (spec-515 t-3) and the
+ * guard tests — resolves the same definition at call time. No consumer can hold a
+ * stale copy, which is the failure this Spec exists to close.
+ */
+export function reservedApiRoots(): ReadonlySet<string> {
+  return new Set([...NON_FLAT_RESERVED_ROOTS, ...FLAT_API_MOUNT_ROOTS]);
+}

--- a/packages/server/src/routes/flat-api-mounts.test.ts
+++ b/packages/server/src/routes/flat-api-mounts.test.ts
@@ -1,0 +1,85 @@
+// spec-515 t-6 / ac-9 — a flat `/api/<root>` mount cannot exist without its
+// tenant-parsing exemption.
+//
+// dec-7 chose option A: one helper registers the routers AND ties the root to the
+// exemption, so the two cannot disagree. This file pins the three claims that make
+// that true, plus a static scan proving no raw `app.route("/api/<root>", …)`
+// survives to bypass the helper.
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { Hono } from "hono";
+import { describe, expect, it } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { mountFlatApi } from "./flat-api-mounts.js";
+import { FLAT_API_MOUNT_ROOTS } from "./api-roots.js";
+import { parseMemexPath, reservedApiRoots } from "../middleware/memex-resolver.js";
+
+const AC = "mindset-prod/memex-building-itself/specs/spec-515/acs/ac-9";
+
+const APP_SRC = readFileSync(
+  fileURLToPath(new URL("../app.ts", import.meta.url)),
+  "utf8",
+);
+
+describe("mountFlatApi (spec-515 t-6 / ac-9)", () => {
+  it("refuses to mount a root that is not declared — at boot, not at 404 time", () => {
+    // THE guarantee. Today's failure mode is a route that mounts fine and then
+    // 404s in production for six months. After this, the same mistake refuses to
+    // start the server: loud, immediate, impossible to deploy past.
+    tagAc(AC);
+    const app = new Hono();
+    expect(() => mountFlatApi(app, "not-a-declared-root", new Hono())).toThrow(
+      /not-a-declared-root/,
+    );
+  });
+
+  it("mounts every router it is given, in the order given", () => {
+    tagAc(AC);
+    const app = new Hono();
+    const first = new Hono().get("/only-on-first", (c) => c.text("first"));
+    const second = new Hono().get("/only-on-second", (c) => c.text("second"));
+    // `docs` is a real declared root that carries two routers in app.ts — the
+    // shape a flat list could not express (dec-7).
+    mountFlatApi(app, "docs", first, second);
+    expect(app.routes.some((r) => r.path === "/api/docs/only-on-first")).toBe(true);
+    expect(app.routes.some((r) => r.path === "/api/docs/only-on-second")).toBe(true);
+  });
+
+  it("exempts every declared flat root from tenant parsing", () => {
+    tagAc(AC);
+    const swallowed = [...FLAT_API_MOUNT_ROOTS].filter(
+      (root) => parseMemexPath(`/api/${root}/anything`) !== null,
+    );
+    expect(swallowed).toEqual([]);
+  });
+
+  it("the effective exempt set is the declared roots plus the non-flat ones", () => {
+    tagAc(AC);
+    const effective = reservedApiRoots();
+    for (const root of FLAT_API_MOUNT_ROOTS) expect(effective).toContain(root);
+    // Non-flat shapes that still need exemption: a deep mount and a direct handler.
+    expect(effective).toContain("stripe"); // /api/stripe/webhook
+    expect(effective).toContain("health"); // app.get("/api/health")
+  });
+
+  it("no raw app.route(\"/api/<root>\") bypasses the helper in app.ts", () => {
+    // The escape hatch dec-7 accepted: the helper is by-construction only for
+    // callers that use it. This scan is what closes it. Tenant-prefixed mounts
+    // (`/api/:namespace/...`), deep mounts (`/api/stripe/webhook`) and the
+    // catch-all (`/api/*`) are all out of scope — only a flat single-segment root.
+    tagAc(AC);
+    const raw = [
+      ...APP_SRC.matchAll(/app\.route\(\s*"\/api\/([a-z0-9-]+)"\s*,/g),
+    ].map((m) => m[1]);
+    expect(raw).toEqual([]);
+  });
+
+  it("still resolves a genuine tenant path", () => {
+    tagAc(AC);
+    expect(parseMemexPath("/api/mindset-prod/memex-building-itself/docs")).toEqual({
+      namespaceSlug: "mindset-prod",
+      memexSlug: "memex-building-itself",
+    });
+  });
+});

--- a/packages/server/src/routes/flat-api-mounts.ts
+++ b/packages/server/src/routes/flat-api-mounts.ts
@@ -1,0 +1,79 @@
+// spec-515 t-6 / dec-7 — flat `/api/<root>` mounts and their tenant-parsing
+// exemption, declared in one place.
+//
+// THE PROBLEM THIS CLOSES. `memexResolver` runs before routing and reads any
+// `/api/<a>/<b>` as a tenant address. A flat mount whose root is not exempt has its
+// SUBPATHS swallowed: the resolver looks up a namespace that doesn't exist and
+// returns 404 per std-7 before the router runs. The bare mount still works (one
+// segment fails the length check), so the defect is invisible until someone hits a
+// subpath — which is how `/api/email/unsubscribe` stayed dead for 27 days and
+// `/api/test-events/batch` silently disabled spec-489's batching.
+//
+// Six recurrences under review-based enforcement (`stripe`, `postmark`, `internal`
+// each carry a comment describing this exact failure) is the evidence that a
+// hand-synced pair of lists does not hold.
+//
+// HOW IT WORKS. `mountFlatApi` refuses to mount a root that is not declared below.
+// The mistake therefore stops the server at boot instead of producing a route that
+// mounts cleanly and 404s in production. Adding a mount is still two edits, but the
+// second one cannot be forgotten — omit it and nothing starts.
+//
+// WHY NOT A LIST app.ts ITERATES (dec-7 option C, rejected). Hono matches in
+// registration ORDER, so position is behaviour. `/api/orgs` is mounted at two points
+// ~78 lines apart with unrelated mounts between; `/api/docs` and `/api/me` carry
+// several routers; `/api/llm` and `/api/telemetry` need an `app.use` registered
+// first; `/api/oauth` is conditional. A flat ordered table cannot express that
+// without making route ordering a data concern in a security-relevant path.
+//
+// WHY NOT HONO'S ROUTE TABLE (dec-1, rejected). Reading `app.routes` couples tenant
+// routing to a framework internal that can reshape in a minor release, and the
+// resolver is registered before the mounts so it would need lazy evaluation. This
+// declaration is ours and is static.
+//
+// The root DECLARATION lives in `api-roots.ts` (zero imports) because the
+// reserved-slug list needs it too and must not pull `db/connection` in through
+// the resolver. This module owns only the mounting mechanism.
+
+import type { Hono } from "hono";
+import { FLAT_API_MOUNT_ROOTS } from "./api-roots.js";
+
+
+/**
+ * Mount one or more routers flat at `/api/<root>`, and assert the root is declared
+ * above so it is exempt from tenant parsing.
+ *
+ * Call it exactly where the `app.route(...)` calls used to sit — order, arity,
+ * middleware pairing and conditionality are all preserved by leaving the call
+ * sites in place. Calling it twice with the same root is expected (`/api/orgs`,
+ * `/api/docs`, `/api/me` all do).
+ *
+ * @throws if `root` is not in {@link FLAT_API_MOUNT_ROOTS} — deliberately at module
+ * evaluation, i.e. server boot, so an undeclared mount can never reach production.
+ */
+export function mountFlatApi(
+  // `Hono` is generic over its env; the app's own bindings are irrelevant here and
+  // pinning them would force every caller to thread type args through.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  app: Hono<any, any, any>,
+  root: string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ...routers: Hono<any, any, any>[]
+): void {
+  if (!FLAT_API_MOUNT_ROOTS.has(root)) {
+    throw new Error(
+      `mountFlatApi: "${root}" is not a declared flat API mount root. ` +
+        "Add it to FLAT_API_MOUNT_ROOTS in routes/flat-api-mounts.ts — without that, " +
+        "memexResolver reads /api/" +
+        root +
+        "/<rest> as namespace=" +
+        root +
+        " and every subpath 404s before the router runs (spec-515).",
+    );
+  }
+  if (routers.length === 0) {
+    throw new Error(`mountFlatApi: no router passed for "/api/${root}".`);
+  }
+  for (const router of routers) {
+    app.route(`/api/${root}`, router);
+  }
+}

--- a/packages/server/src/services/reserved-root-collisions.integration.test.ts
+++ b/packages/server/src/services/reserved-root-collisions.integration.test.ts
@@ -1,0 +1,133 @@
+// spec-515 t-3 / ac-7 — the deploy precondition for the reserved-root fix.
+//
+// Adding a root to RESERVED_API_ROOTS makes parseMemexPath no-op for it, which
+// strands any existing tenant whose slug is that word: the resolver stops
+// resolving it, so `/<root>/<memex>/…` becomes unroutable. dec-3 verified by hand
+// on 2026-07-28 that prod (328 namespaces) and int (78) held no collision — but
+// that is a point-in-time result. A namespace can be created between then and any
+// future deploy, so the check has to be mechanical and it has to BLOCK.
+//
+// FIXTURE NOTE (learned the hard way). An earlier draft inserted a bare
+// `namespaces` row with kind='org' and no owning org, then deleted it in afterAll.
+// That row is malformed — every org-kind namespace is expected to carry an
+// ownerOrgId — and its presence reddened six unrelated share / doc_views
+// integration tests in the full suite while passing in isolation. Proven by
+// substituting an inert 614th test file, which left the suite green: the shard
+// reshuffle was not the cause, the malformed row was. So this file builds tenants
+// only through `makeTestMemex()`, the sanctioned fixture (namespace + org + memex
+// in one transaction, `uniqueSlug` per std-37 cl-2), and never hand-rolls one.
+//
+// The collision-detecting function takes its root set as a parameter, so the test
+// passes the fixture's own generated slug as the "root" — no fixed literal, no
+// need to name a real reserved word to exercise the namespace branch. A separate
+// assertion pins the production default to the resolver's real set so the two
+// cannot drift.
+
+import { afterAll, describe, expect, it } from "vitest";
+import { eq, inArray } from "drizzle-orm";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { db } from "../db/connection.js";
+import { memexes, namespaces, namespaceSlugReservations } from "../db/schema.js";
+import { reservedApiRoots } from "../middleware/memex-resolver.js";
+import { makeTestMemex } from "./test-helpers.js";
+import {
+  findReservedRootSlugCollisions,
+  type ReservedRootCollision,
+} from "./reserved-root-collisions.js";
+
+const AC = "mindset-prod/memex-building-itself/specs/spec-515/acs/ac-7";
+
+// Reservation slugs are per-worker-unique (std-37 cl-1) and must satisfy the
+// table's CHECK constraint on the slug grammar `[a-z0-9][a-z0-9-]{0,38}`.
+const WORKER = process.env.VITEST_POOL_ID ?? "0";
+const RESERVATION_SLUG = `zzz515-resv-${WORKER}`;
+
+const createdReservationSlugs: string[] = [];
+
+/** The slug of a well-formed tenant created via the sanctioned fixture. */
+async function makeTenantSlug(): Promise<string> {
+  const memexId = await makeTestMemex("s515");
+  const [row] = await db
+    .select({ slug: namespaces.slug })
+    .from(namespaces)
+    .innerJoin(memexes, eq(memexes.namespaceId, namespaces.id))
+    .where(eq(memexes.id, memexId));
+  return row.slug;
+}
+
+afterAll(async () => {
+  // Only the reservation rows are torn down (scoped + idempotent, std-37 cl-6).
+  // The `makeTestMemex` tenants are left in place: they carry uniqueSlug-generated
+  // slugs that collide with nothing, and deleting namespaces cascades — the blast
+  // radius of cleanup is larger than the cost of leaving them, which is the
+  // convention the rest of the suite follows.
+  if (createdReservationSlugs.length > 0) {
+    await db
+      .delete(namespaceSlugReservations)
+      .where(inArray(namespaceSlugReservations.slug, createdReservationSlugs));
+  }
+});
+
+describe("findReservedRootSlugCollisions (spec-515 t-3 / ac-7)", () => {
+  it("returns nothing when no namespace or reservation holds the root", async () => {
+    tagAc(AC);
+    expect(await findReservedRootSlugCollisions([`zzz515-absent-${WORKER}`])).toEqual([]);
+  });
+
+  it("reports a namespace whose slug IS a reserved root", async () => {
+    tagAc(AC);
+    const slug = await makeTenantSlug();
+    expect(await findReservedRootSlugCollisions([slug])).toEqual<ReservedRootCollision[]>([
+      { slug, source: "namespace" },
+    ]);
+  });
+
+  it("reports a slug held in the post-rename reservation table", async () => {
+    // std-3 cl-13 keeps a renamed-away slug reserved for 30 days, reclaimable in
+    // that window — as much a collision risk as a live namespace. Checking only
+    // `namespaces` would miss it.
+    tagAc(AC);
+    await db.insert(namespaceSlugReservations).values({
+      slug: RESERVATION_SLUG,
+      reservedUntil: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+    });
+    createdReservationSlugs.push(RESERVATION_SLUG);
+
+    expect(
+      await findReservedRootSlugCollisions([RESERVATION_SLUG]),
+    ).toEqual<ReservedRootCollision[]>([{ slug: RESERVATION_SLUG, source: "reservation" }]);
+  });
+
+  it("reports both sources together, deterministically ordered", async () => {
+    tagAc(AC);
+    const slug = await makeTenantSlug();
+    const both = await findReservedRootSlugCollisions([slug, RESERVATION_SLUG]);
+    expect(both).toHaveLength(2);
+    expect(both.map((c) => c.source).sort()).toEqual(["namespace", "reservation"]);
+  });
+
+  it("defaults to the resolver's effective reserved set, not a copy", async () => {
+    // The failure this guards against: someone hand-copies the root list into the
+    // check, the resolver's list grows, and the check keeps reporting green against
+    // the stale copy. Asserting on the default parameter is what forecloses that.
+    tagAc(AC);
+    const seen = new Set<string>();
+    await findReservedRootSlugCollisions(undefined, {
+      onRootsResolved: (roots) => {
+        for (const r of roots) seen.add(r);
+      },
+    });
+    expect(seen).toEqual(new Set(reservedApiRoots()));
+    // Spot-check the two roots whose absence was doing real damage in production.
+    expect(seen).toContain("email");
+    expect(seen).toContain("test-events");
+  });
+
+  it("is read-only — running it changes no rows", async () => {
+    tagAc(AC);
+    const before = await db.select({ id: namespaces.id }).from(namespaces);
+    await findReservedRootSlugCollisions();
+    const after = await db.select({ id: namespaces.id }).from(namespaces);
+    expect(after.length).toBe(before.length);
+  });
+});

--- a/packages/server/src/services/reserved-root-collisions.ts
+++ b/packages/server/src/services/reserved-root-collisions.ts
@@ -1,0 +1,93 @@
+// spec-515 t-3 / ac-7 — is any namespace slug squatting a reserved API root?
+//
+// WHY THIS EXISTS. `memexResolver` treats a word in `RESERVED_API_ROOTS` as "not a
+// tenant", so `parseMemexPath` returns null for it and tenant resolution no-ops.
+// That is exactly what makes a flat `/api/<root>` mount reachable — and it is also
+// what would strand a tenant that already OWNS that word as its namespace slug:
+// `/<root>/<memex>/…` would stop resolving. The two features are competing for one
+// vocabulary (std-3 cl-7), and this check is the interlock.
+//
+// dec-3 verified by hand on 2026-07-28 that prod (328 namespaces) and int (78) held
+// no collision. That result expires the moment someone signs up: it is a
+// point-in-time observation, not an invariant. This function makes it repeatable so
+// the deploy can enforce it (see scripts/check-reserved-root-collisions.ts).
+//
+// STRICTLY READ-ONLY. It runs as a deploy PRE-condition, before migrations, against
+// a live database. It must never write, and it must never mutate its inputs.
+
+import { inArray } from "drizzle-orm";
+import { db } from "../db/connection.js";
+import { namespaces, namespaceSlugReservations } from "../db/schema.js";
+import { reservedApiRoots } from "../middleware/memex-resolver.js";
+
+/** A word that is BOTH a reserved API root and a claimed namespace slug. */
+export interface ReservedRootCollision {
+  slug: string;
+  /**
+   * `namespace` — a live tenant owns the slug; reserving the root makes it
+   * unroutable right now.
+   * `reservation` — a post-rename hold (std-3 cl-13, 30 days). Nobody is stranded
+   * today, but the slug is reclaimable inside the window, so shipping over it
+   * converts a latent collision into a live one.
+   */
+  source: "namespace" | "reservation";
+}
+
+interface Hooks {
+  /**
+   * Test seam (not used in production): reports the root set the call actually
+   * resolved. Exists so a test can pin the DEFAULT to the resolver's live set —
+   * the failure mode being guarded is a hand-copied root list that keeps passing
+   * while the resolver's list grows past it.
+   */
+  onRootsResolved?: (roots: readonly string[]) => void;
+}
+
+/**
+ * Returns every reserved API root that is currently claimed as a namespace slug or
+ * held in the post-rename reservation table. Empty array = safe to ship.
+ *
+ * `roots` defaults to the resolver's own effective set (`reservedApiRoots()`) so the check cannot
+ * drift from the thing it is checking. Pass an explicit set only in tests.
+ */
+export async function findReservedRootSlugCollisions(
+  roots: Iterable<string> = reservedApiRoots(),
+  hooks: Hooks = {},
+): Promise<ReservedRootCollision[]> {
+  const candidates = [...new Set(roots)];
+  hooks.onRootsResolved?.(candidates);
+
+  // `inArray` with an empty list generates invalid SQL in some drivers, and an
+  // empty root set trivially has no collisions — bail before touching the DB.
+  if (candidates.length === 0) return [];
+
+  const [claimed, held] = await Promise.all([
+    db
+      .select({ slug: namespaces.slug })
+      .from(namespaces)
+      .where(inArray(namespaces.slug, candidates)),
+    db
+      .select({ slug: namespaceSlugReservations.slug })
+      .from(namespaceSlugReservations)
+      .where(inArray(namespaceSlugReservations.slug, candidates)),
+  ]);
+
+  // Deterministic order so a deploy log diff is readable and a test can assert
+  // on the array without sorting at every call site.
+  return [
+    ...claimed.map((r) => ({ slug: r.slug, source: "namespace" as const })),
+    ...held.map((r) => ({ slug: r.slug, source: "reservation" as const })),
+  ].sort((a, b) => a.slug.localeCompare(b.slug) || a.source.localeCompare(b.source));
+}
+
+/** Human-readable failure text for the deploy log. */
+export function formatCollisions(collisions: readonly ReservedRootCollision[]): string {
+  return collisions
+    .map(
+      (c) =>
+        c.source === "namespace"
+          ? `  ✗ "${c.slug}" is a LIVE namespace slug — reserving it makes that tenant unroutable`
+          : `  ✗ "${c.slug}" is held in namespace_slug_reservations — reclaimable inside the 30-day window (std-3 cl-13)`,
+    )
+    .join("\n");
+}

--- a/packages/server/src/services/shared/slug.reserved-composition.spec-515.test.ts
+++ b/packages/server/src/services/shared/slug.reserved-composition.spec-515.test.ts
@@ -1,0 +1,125 @@
+// spec-515 t-7 / ac-5, ac-10 — the two reserved vocabularies are composed, not
+// hand-synced.
+//
+// THE INTERLOCK. A word that is simultaneously an API mount root and a namespace
+// slug makes one of the two unreachable, in either direction:
+//
+//   slug shadows an API root → that route's subpaths go into tenant resolution and
+//                              404 before the handler runs (the spec-515 defect)
+//   API root claimed as slug → memexResolver stops resolving the word, so that
+//                              tenant becomes unroutable
+//
+// Before this, the two lists were maintained by hand and shared only **6 entries
+// out of 27 and 28**. std-3 cl-7 (amended 2026-07-28) now states the rule: the
+// reserved-slug list is the union of the app/marketing words and the API roots.
+//
+// These assertions are what make the Standard's promise true in code. cl-7 is
+// classified `config-parity`, i.e. the Standard explicitly claims a test proves the
+// two agree — this is that test.
+
+import { describe, expect, it } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { reservedApiRoots } from "../../routes/api-roots.js";
+import { parseMemexPath } from "../../middleware/memex-resolver.js";
+import { RESERVED_SLUGS, validateSlugFormat } from "./slug.js";
+
+const AC_INVARIANT = "mindset-prod/memex-building-itself/specs/spec-515/acs/ac-5";
+const AC_COMPOSITION = "mindset-prod/memex-building-itself/specs/spec-515/acs/ac-10";
+
+describe("RESERVED_SLUGS composition (spec-515 t-7)", () => {
+  it("rejects every reserved API root as a namespace slug", () => {
+    tagAc(AC_COMPOSITION);
+    const claimable = [...reservedApiRoots()].filter((root) => {
+      // `__test__` cannot be a slug regardless — the grammar rejects underscores,
+      // so it fails as `invalid_chars` rather than `reserved`. Both are refusals.
+      const verdict = validateSlugFormat(root);
+      return verdict.valid;
+    });
+    expect(claimable).toEqual([]);
+  });
+
+  it("reports reserved API roots as `reserved`, not merely malformed", () => {
+    // A word rejected for the right reason produces the right error for the user.
+    tagAc(AC_COMPOSITION);
+    for (const root of ["email", "test-events", "acs", "issues", "hook-keys"]) {
+      expect(validateSlugFormat(root)).toEqual({ valid: false, error: "reserved" });
+    }
+  });
+
+  it("adding an API root reserves its slug with no second edit", () => {
+    // The composition, asserted structurally: RESERVED_SLUGS is a SUPERSET of the
+    // API roots. Nothing to remember to update — declaring a root is the only act.
+    tagAc(AC_COMPOSITION);
+    const missing = [...reservedApiRoots()].filter((r) => !RESERVED_SLUGS.has(r));
+    expect(missing).toEqual([]);
+  });
+
+  it("holds the invariant in BOTH directions for every flat mount root", () => {
+    // ac-5. Direction 1: the root is exempt from tenant parsing, so its subpaths
+    // reach the router. Direction 2: the root is unclaimable as a slug, so no
+    // tenant can ever shadow it. Either half alone leaves a live defect.
+    tagAc(AC_INVARIANT);
+    const broken: string[] = [];
+    for (const root of reservedApiRoots()) {
+      if (parseMemexPath(`/api/${root}/anything`) !== null) {
+        broken.push(`${root}: NOT exempt from tenant parsing`);
+      }
+      if (validateSlugFormat(root).valid) {
+        broken.push(`${root}: still claimable as a namespace slug`);
+      }
+    }
+    expect(broken).toEqual([]);
+  });
+
+  it("still reserves the app-utility and marketing words", () => {
+    // Regression guard: composing the list must not drop what it already covered.
+    tagAc(AC_COMPOSITION);
+    for (const word of [
+      "login",
+      "signup",
+      "settings",
+      "admin",
+      "memex",
+      "pricing",
+      "story",
+      "writing",
+      "research",
+      "coding-agents",
+      "legal",
+      "branding",
+      "get-started",
+      "community",
+    ]) {
+      expect(validateSlugFormat(word)).toEqual({ valid: false, error: "reserved" });
+    }
+  });
+
+  it("keeps the marketing group equal to the apex→www redirect set", () => {
+    // std-3 cl-6(b) names the `memex-app-lb` URL map as the authority. Verified
+    // against the live prod URL map on 2026-07-28: these ten are exactly the
+    // single-segment paths it redirects apex→www. Dotted paths it also redirects
+    // (`llms.txt`, `rss.xml`, `sitemap.xml`, `docs.html`, `story.html`) need no
+    // entry — the slug grammar rejects dots.
+    tagAc(AC_COMPOSITION);
+    for (const word of [
+      "docs",
+      "pricing",
+      "story",
+      "community",
+      "writing",
+      "legal",
+      "research",
+      "coding-agents",
+      "get-started",
+      "branding",
+    ]) {
+      expect(RESERVED_SLUGS.has(word)).toBe(true);
+    }
+  });
+
+  it("does not over-reserve — an ordinary slug is still available", () => {
+    tagAc(AC_COMPOSITION);
+    expect(validateSlugFormat("acme-corp")).toEqual({ valid: true });
+    expect(validateSlugFormat("frederic")).toEqual({ valid: true });
+  });
+});

--- a/packages/server/src/services/shared/slug.ts
+++ b/packages/server/src/services/shared/slug.ts
@@ -7,6 +7,7 @@
 import { eq, lt, sql } from "drizzle-orm";
 import { db } from "../../db/connection.js";
 import { namespaces, namespaceSlugReservations } from "../../db/schema.js";
+import { reservedApiRoots } from "../../routes/api-roots.js";
 
 // std-3 — reserved slugs fall in two groups:
 //   1. App-utility paths (login, api, mcp, …) that collide with the app's own
@@ -19,7 +20,7 @@ import { namespaces, namespaceSlugReservations } from "../../db/schema.js";
 //      these slugs on the apex, so we reserve them to prevent the conflict up
 //      front. Keep this group in sync with the top-level routes in
 //      memex-website/src/lib/routes.ts.
-export const RESERVED_SLUGS = new Set([
+const APP_AND_MARKETING_SLUGS = new Set([
   // group 1 — app-utility paths
   "login",
   "signup",
@@ -50,6 +51,21 @@ export const RESERVED_SLUGS = new Set([
   "coding-agents",
   "get-started",
   "branding",
+]);
+
+// spec-515 t-7 / std-3 cl-7 — COMPOSED, not enumerated by hand.
+//
+// The reserved list is the union of the words above and the `/api` root vocabulary
+// (routes/api-roots.ts). Declaring an API root therefore makes its slug unclaimable
+// in the same edit, with no second list to remember.
+//
+// Required in BOTH directions: a slug that shadows an API root sends that route's
+// subpaths into tenant resolution (they 404 before the handler runs — the spec-515
+// defect), and an API root claimed as a slug makes that tenant unroutable. Before
+// this, the two lists were hand-synced and shared only 6 entries out of 27 and 28.
+export const RESERVED_SLUGS: ReadonlySet<string> = new Set([
+  ...APP_AND_MARKETING_SLUGS,
+  ...reservedApiRoots(),
 ]);
 
 const SLUG_RE = /^[a-z0-9][a-z0-9-]{0,38}$/;

--- a/packages/ui/e2e/helpers/seed.ts
+++ b/packages/ui/e2e/helpers/seed.ts
@@ -502,3 +502,35 @@ export async function seedComment(opts: {
 }): Promise<{ commentId: string; seq: number }> {
   return call("POST", "/seed-comment", opts);
 }
+
+/**
+ * spec-515 t-10 / ac-2 — the REAL one-click unsubscribe URL for a seeded user.
+ *
+ * Minted server-side because the token is an HMAC over the userId signed with a
+ * secret the browser never sees (services/email/unsubscribe-token.ts). Asking the
+ * server for the same URL `unsubscribeUrl()` puts in every lifecycle email is what
+ * makes the journey exercise the actual link a mail client follows — a hand-built
+ * approximation could pass while the shipped link stays broken, which is precisely
+ * the defect spec-515 exists to fix.
+ */
+export async function getUnsubscribeUrl(email: string): Promise<string> {
+  const { url } = await call<{ url: string }>("POST", "/unsubscribe-url", { email });
+  return url;
+}
+
+/**
+ * Whether the lifecycle-email PRE-SEND GATE would suppress this user.
+ *
+ * Read through `isLifecycleEmailUnsubscribed` — the same function
+ * `sendLifecycleEmail` consults before any activation/win-back send
+ * (services/email/lifecycle-send.ts) — so the journey asserts what the send path
+ * will actually see, not a schema column.
+ */
+export async function isLifecycleUnsubscribed(email: string): Promise<boolean> {
+  const { unsubscribed } = await call<{ unsubscribed: boolean }>(
+    "POST",
+    "/lifecycle-unsubscribed",
+    { email },
+  );
+  return unsubscribed;
+}

--- a/packages/ui/e2e/journey-67-unsubscribe-one-click.spec.ts
+++ b/packages/ui/e2e/journey-67-unsubscribe-one-click.spec.ts
@@ -1,0 +1,131 @@
+import { test, expect, emitAcEvents } from "./helpers/index.js";
+import {
+  ensureUser,
+  getUnsubscribeUrl,
+  isLifecycleUnsubscribed,
+} from "./helpers/seed.js";
+
+// Journey 67 — one-click unsubscribe, end to end (spec-515 t-10 / ac-2, std-28 gate).
+//
+// WHY THIS JOURNEY EXISTS. `/api/email/unsubscribe` is the RFC 8058
+// `List-Unsubscribe-Post` target carried on EVERY lifecycle email
+// (services/email/sender.ts emits the header pair; unsubscribe-token.ts builds the
+// URL). It 404'd in production from 2026-07-01 to 2026-07-28 — the tenant resolver
+// swallowed it, because `email` was missing from the exempt API roots. The handler
+// and its confirmation page had existed the whole time; they were simply
+// unreachable. Nothing in the suite noticed, which is what std-28 exists to prevent.
+//
+// SCOPE — the whole chain, the way a mail client walks it:
+//   1. the POST a mail client fires for one-click: no session, no CSRF token, no
+//      page — must suppress the recipient on the strength of the token alone
+//   2. the GET a human clicks in the body: must render a readable confirmation, not
+//      raw JSON and not an error
+//   3. the suppression must be what the SEND GATE reads — asserted through
+//      `isLifecycleEmailUnsubscribed`, the same function `sendLifecycleEmail`
+//      consults before any activation/win-back send, rather than through a column
+//   4. a malformed token must be refused, and must say so legibly
+//
+// The URL under test is minted SERVER-SIDE by the real `unsubscribeUrl()` (via the
+// env-gated test surface, per std-28 — no raw SQL). Hand-building it here would let
+// the journey pass against a link the product never actually sends.
+//
+// NOT IN SCOPE: that a suppressed user is then skipped by a real send. That gate is
+// `lifecycle-send.ts:38` and is covered by spec-427's own tests; re-proving it needs
+// a send harness, not a browser. What this journey pins is that the link produces
+// the state that gate reads.
+
+const AC2 = "mindset-prod/memex-building-itself/specs/spec-515/acs/ac-2";
+
+// Per-test unique so parallel workers and repeat runs cannot collide on the users
+// table's unique email [per std-37 cl-1].
+const stamp = () => `${process.env.TEST_WORKER_INDEX ?? "0"}-${Math.random().toString(36).slice(2, 10)}`;
+
+test.afterEach(async ({}, testInfo) => {
+  if (testInfo.status === "skipped") return;
+  await emitAcEvents(
+    [AC2],
+    testInfo.status === "passed" ? "pass" : "fail",
+    `packages/ui/e2e/journey-67-unsubscribe-one-click.spec.ts::${testInfo.title}`,
+    testInfo.duration,
+  );
+});
+
+test("the mail client's one-click POST suppresses the recipient with no session (ac-2)", async ({
+  request,
+}) => {
+  const email = `s515-oneclick-${stamp()}@example.com`;
+  await ensureUser(email);
+  expect(await isLifecycleUnsubscribed(email)).toBe(false);
+
+  const url = await getUnsubscribeUrl(email);
+  // Sanity: the product's own URL builder must still target the path this Spec
+  // repaired. If it ever moves, this journey should say so rather than silently
+  // testing a different endpoint.
+  expect(url).toContain("/api/email/unsubscribe?token=");
+
+  // Exactly what Gmail/Apple Mail send for List-Unsubscribe-Post: a bare POST with
+  // the one-click marker in the body, no cookies, no CSRF token, no Referer.
+  const res = await request.post(url, {
+    form: { "List-Unsubscribe": "One-Click" },
+  });
+  expect(res.status()).toBe(200);
+
+  expect(await isLifecycleUnsubscribed(email)).toBe(true);
+});
+
+test("the in-body GET link renders a readable confirmation, not JSON (ac-2)", async ({
+  page,
+}) => {
+  const email = `s515-getlink-${stamp()}@example.com`;
+  await ensureUser(email);
+  const url = await getUnsubscribeUrl(email);
+
+  await page.goto(url);
+  // A human landing here must understand what happened. Asserting on the rendered
+  // heading rather than the status code is the point: a 200 carrying raw JSON would
+  // satisfy the endpoint and fail the person reading it.
+  await expect(page.getByRole("heading", { name: /unsubscribed/i })).toBeVisible({
+    timeout: 15_000,
+  });
+  // And it must say what still sends, so nobody thinks account email stopped too.
+  await expect(page.getByText(/sign-in links/i)).toBeVisible();
+
+  expect(await isLifecycleUnsubscribed(email)).toBe(true);
+});
+
+test("unsubscribing twice is idempotent — the second visit still confirms (ac-2)", async ({
+  page,
+}) => {
+  // A mail-client link scanner may prefetch the URL before the human clicks it, so
+  // the second visit is the NORMAL case, not an edge case. It must not error.
+  const email = `s515-twice-${stamp()}@example.com`;
+  await ensureUser(email);
+  const url = await getUnsubscribeUrl(email);
+
+  await page.goto(url);
+  await expect(page.getByRole("heading", { name: /unsubscribed/i })).toBeVisible({
+    timeout: 15_000,
+  });
+  await page.goto(url);
+  await expect(page.getByRole("heading", { name: /unsubscribed/i })).toBeVisible();
+
+  expect(await isLifecycleUnsubscribed(email)).toBe(true);
+});
+
+test("a malformed token is refused and says so legibly (ac-2)", async ({ page }) => {
+  const email = `s515-badtoken-${stamp()}@example.com`;
+  await ensureUser(email);
+
+  // Derive the origin from the product's OWN builder and corrupt only the token —
+  // hardcoding a host here would bake in an assumption the helpers already own.
+  const forged = (await getUnsubscribeUrl(email)).replace(
+    /token=.*$/,
+    "token=not-a-real-token",
+  );
+  const res = await page.goto(forged);
+  expect(res?.status()).toBe(400);
+  await expect(page.getByRole("heading", { name: /isn't valid/i })).toBeVisible();
+
+  // The decisive half: a forged token must not suppress anyone.
+  expect(await isLifecycleUnsubscribed(email)).toBe(false);
+});

--- a/packages/ui/playwright.config.ts
+++ b/packages/ui/playwright.config.ts
@@ -77,7 +77,14 @@ export default defineConfig({
           // `reuseExistingServer` below silently adopts another worktree's server
           // and every journey runs against that branch's code while reporting a
           // pass. e2e/global-setup.ts refuses to proceed on a mismatch.
-          command: `GOOGLE_CLIENT_ID="" MEMEX_ANTHROPIC_FAKE=1 JOURNEY_PREVIEW_DOMAINS="memex.ai" SLACK_TOKEN_ENCRYPTION="${process.env.SLACK_TOKEN_ENCRYPTION ?? "plaintext"}" DATABASE_URL="${DATABASE_URL}" MEMEX_WORKSPACE_ID="${process.env.MEMEX_WORKSPACE_ID ?? ""}" PORT=${SERVER_PORT} pnpm --filter @memex/server dev`,
+          // APP_BASE_URL: spec-515 t-10. Server-side URL builders read it, and it is
+          // NOT in packages/server/.env, so it would default to `https://memex.ai`
+          // (services/email/unsubscribe-token.ts). A journey that follows a
+          // product-built link would then navigate to PRODUCTION instead of the
+          // build under test — silently green while proving nothing. Pin it to the
+          // e2e API origin: the unsubscribe pages are server-rendered, so no Vite
+          // proxy hop is needed for them.
+          command: `GOOGLE_CLIENT_ID="" MEMEX_ANTHROPIC_FAKE=1 JOURNEY_PREVIEW_DOMAINS="memex.ai" APP_BASE_URL="http://localhost:${SERVER_PORT}" SLACK_TOKEN_ENCRYPTION="${process.env.SLACK_TOKEN_ENCRYPTION ?? "plaintext"}" DATABASE_URL="${DATABASE_URL}" MEMEX_WORKSPACE_ID="${process.env.MEMEX_WORKSPACE_ID ?? ""}" PORT=${SERVER_PORT} pnpm --filter @memex/server dev`,
           url: `http://localhost:${SERVER_PORT}/api/health`,
           reuseExistingServer: !process.env.CI,
           timeout: 60_000,


### PR DESCRIPTION
Promoting `develop@da82821d` to production. 6 commits, 26 files, +2097/−111 — all spec-515 plus the AC-emitter version bump.

## std-21 release preconditions [per cl-42]

| check | clause | result |
|---|---|---|
| `develop` CI green | cl-43 | ✅ `test` success @ `da82821d` |
| int deploy + smoke green | cl-44 | ✅ `deploy` success @ `da82821d`, smoke 7 passed / 2 skipped / 0 failed, revision `memex-api-3` |
| `git log develop..main --no-merges` empty | cl-45 | ✅ 0 commits |

Merging as a **merge commit** [per cl-50] — not squash.

## What ships

**The incident fix is already in prod** (`44a34cc3`, revision 00123, 2026-08-07). This release ships the hardening that stops the defect class returning, plus the two fixes for defects in that hardening's own wiring, found by running it for real.

- **One vocabulary.** `routes/api-roots.ts` declares every `/api` root once; the tenant resolver and the reserved-slug list both read it. 32 call sites in `app.ts` mount through `mountFlatApi`, which registers the router *and* records the root — mounting an undeclared root throws at module evaluation. `RESERVED_SLUGS` is composed rather than copied: 36 reserved roots, 0 still claimable as a namespace slug (was 6 of 27). Amends std-3.
- **Three guards, at three distances.** A PR-time regression test; a deploy pre-condition that runs *before* migrations and is fail-closed; a post-deploy smoke asserting the resolver's `x-memex-tenant: exempt` marker on every reserved root, driven from the shared declaration.
- **The AC-emitter bound** — the 404 fallback no longer fans out an unbounded `Promise.all`; concurrency ceiling, per-request timeout, start deadline, and an immediate stop on a definitive auth rejection. Published as `0.3.0`.
- **std-28 journey** for one-click unsubscribe, plus `deploy-script-parity.test.ts`.

## What this release buys in prod specifically

Prod currently has **no** exemption marker, so three roots — `team`, `share`, `onboarding` — are **indeterminate from outside**: std-7 turns unauthorized into 404, so an unauthenticated probe cannot distinguish "router said no" from "resolver swallowed it". This morning's prod sweep proved 30 of 36 roots positively and had to record those three as unknown.

On int, post-deploy, all three carry the marker. This release brings that to prod and closes ac-1.

It also arms the collision pre-condition and the reachability smoke on the prod deploy — both of which have now run for real on int, which is how the two wiring defects in this release were found.

## Honest notes

- **Both guard defects were mine, and both were found only by a real deploy.** The gate named a pnpm script that did not exist (`ERR_PNPM_RECURSIVE_RUN_NO_SCRIPT`); the smoke files imported the resolver and so demanded `DATABASE_URL` in a tier that has none. In both cases the logic was unit-tested and the wiring was not — the only thing that runs `deploy.sh`, or a smoke against a live host, is a deploy. Recorded on spec-515 c-5.
- **Fail-closed proved its worth**: an unrunnable check stopped the deploy instead of being silently skipped. Had it defaulted the other way, ac-12 would have been decorative on every future deploy.
- **`journey-53` (welcome-video gate) is flaky** and blocked the int deploy twice today — 4 failures, green on rerun each time. Pre-existing (the last green develop run already reported `1 flaky` in that shard) and unrelated to this work. Filed as spec-515 issue-1 for the spec-507 owner. If the prod deploy's gate reads a red verdict from that test, rerun rather than assuming this release is at fault.
- Prod deploy runs **unattended** [per cl-36] — merging this is the decision to ship.