### PR TITLE
fix(spec-518): CI never read the canonical config secret — two env lines, one outage

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,9 +16,20 @@ name: deploy
 # `github-deployer` service account holds standing deploy roles — a recorded
 # exception to the humans-use-PAM posture in scripts/deploy-config.sh.
 #
-# Per-env config: the gitignored scripts/deploy.<env>.env is injected from the
-# environment-scoped DEPLOY_ENV_FILE secret and written to disk before the
-# deploy runs — CI and laptops share one config mechanism, zero drift.
+# Per-env config: the CANONICAL source is the Secret Manager secret
+# `memex-<env>-deploy-env`, fetched by scripts/deploy-config.sh on every deploy
+# (DEPLOY_CONFIG_SOURCE / DEPLOY_CONFIG_PROJECT on the deploy step below).
+#
+# This header used to read "CI and laptops share one config mechanism, zero
+# drift." That sentence was wrong in a way that cost an outage, and it is worth
+# keeping the correction visible: CI and laptops shared a config FILE while
+# obeying different SOURCES. Writing scripts/deploy.<env>.env made
+# deploy-config.sh take its local-override branch — documented "ad-hoc testing
+# only" — so the canonical secret was never read in production. It already held
+# MAX_INSTANCES=8 while prod kept deploying at 3 (spec-518 dec-4).
+#
+# The DEPLOY_ENV_FILE blob is now a stale snapshot kept for one rollout so the
+# switch can be reverted in a line; it is retired in spec-518 ac-17.
 
 on:
   push:
@@ -129,6 +140,13 @@ jobs:
         # The gitignored scripts/deploy.<env>.env, exactly as a deployer's
         # laptop has it (DB_PASS is fetched from Secret Manager at source
         # time, so the secret holds coordinates, not credentials).
+        #
+        # spec-518 dec-4: this file is NO LONGER what the deploy reads. Writing it
+        # made deploy-config.sh take its LOCAL-OVERRIDE branch — documented "ad-hoc
+        # testing only" — on every CI deploy, so the canonical secret was never
+        # fetched in production. The step is kept for one rollout only, so the
+        # switch below can be reverted in one line; it is retired once both
+        # environments have deployed clean from the canonical secret (ac-17).
         env:
           DEPLOY_ENV_FILE: ${{ secrets.DEPLOY_ENV_FILE }}
         run: |
@@ -151,6 +169,24 @@ jobs:
         # checks verify their ACs on every deploy). Without it the smoke still
         # runs — emissions are just silently rejected 401.
         env:
+          # spec-518 dec-4 / t-6 — obey the CANONICAL config source.
+          #
+          # deploy-config.sh (spec-168) defines `memex-<env>-deploy-env` in Secret
+          # Manager as canonical, and a PRESENT scripts/deploy.<env>.env as an opt-in
+          # override for "ad-hoc testing only". The step above writes that file on every
+          # CI run, so every deploy silently took the override branch and the canonical
+          # secret was NEVER read in production. It already held the right values —
+          # MAX_INSTANCES=8, MIN_INSTANCES=1, DB_POOL_MAX=4 — while prod deployed at the
+          # 3-instance ceiling and shed 2000+ requests on 2026-08-11.
+          #
+          # These two lines are the whole fix. DEPLOY_CONFIG_PROJECT was referenced only
+          # INSIDE deploy-config.sh and supplied nowhere, so the canonical branch had
+          # never executed in CI even once — it would have aborted on the missing
+          # pointer. The fetch fails closed: an unreadable secret stops the deploy loudly
+          # rather than shipping stale config. github-deployer holds
+          # roles/secretmanager.secretAccessor at project level in both projects.
+          DEPLOY_CONFIG_SOURCE: secret
+          DEPLOY_CONFIG_PROJECT: memex-ai-${{ github.ref_name == 'main' && 'prod' || 'int' }}
           SMOKE_MCP_TOKEN: ${{ secrets.SMOKE_MCP_TOKEN }}
           SMOKE_SESSION_TOKEN: ${{ secrets.SMOKE_SESSION_TOKEN }}
           MEMEX_EMIT_KEY: ${{ secrets.MEMEX_EMIT_KEY }}

--- a/scripts/deploy.env.example
+++ b/scripts/deploy.env.example
@@ -58,10 +58,17 @@ SLACK_CLIENT_ID="your-slack-client-id"
 # Optional per-env override of the DB connection-pool cap per Cloud Run instance.
 # db/connection.ts defaults to 5. Budget it against Cloud SQL max_connections:
 # max-instances × (DB_POOL_MAX + 1 LISTEN) must stay under the instance's ceiling
-# (prod: 3 × (10+1) = 33 of 50). Leave COMMENTED OUT to keep the code default (5);
-# a deploy OMITS it when unset and never blanks a live value. Pool sizing is
-# spec-332's decision surface (spec-489 raised prod to 10). Prod runs DB_POOL_MAX="10".
-# DB_POOL_MAX="10"
+# (prod: ~47 usable of max_connections=50, after superuser-reserved slots). Leave
+# COMMENTED OUT to keep the code default (5); a deploy OMITS it when unset and never
+# blanks a live value. Pool sizing is spec-332's decision surface.
+#
+# PROD RUNS DB_POOL_MAX="4", NOT 10 (corrected spec-518 t-6, verified live 2026-08-11
+# on the serving revision). This paragraph claimed 10 long after spec-518 lowered it
+# for the 2026-08-03 connection-exhaustion incident, and the claim was dangerous, not
+# merely stale: prod's ceiling is now max-instances 8, so a well-meaning "restore the
+# documented value" gives 8 × (10+1) = 88 against ~47 — the exact exhaustion spec-518
+# exists to prevent. At the real value it is 8 × (4+1) = 40.
+# DB_POOL_MAX="4"
 
 # spec-244 (dec-2 / dec-9) — the Mixpanel analytics forwarder token is NOT a
 # deploy-env var. Like every other credential (anthropic/openai/postmark/…), it is


### PR DESCRIPTION
Implements **dec-4 option B**, step 1 of its rollout. Verifies ac-13, ac-18; sets up ac-15.

## The defect, in three lines

`deploy-config.sh` (spec-168) makes Secret Manager `memex-<env>-deploy-env` **canonical**, and treats a *present* `scripts/deploy.<env>.env` as an override for *"ad-hoc testing only"*:

```bash
"")  [[ -f "$ENV_FILE" ]] && _use_local=1 ;;
```

`deploy.yml` writes that file on **every** CI run. So every production deploy took the ad-hoc branch, and the canonical secret has never been read in production.

It already held the right values — `MAX_INSTANCES=8`, `MIN_INSTANCES=1`, `DB_POOL_MAX=4` — while prod deployed at `maxScale 3` and shed **2000+ Cloud Run 429s in one hour** on 2026-08-11. The 2026-08-03 incident, recurring on the Spec written to prevent it.

The blob is a **stale snapshot** of the secret: it still carries `DB_POOL_MAX=4` (which is why *that* value is live) but not the scaling lines added later, so `deploy.sh` fell through to `${MAX_INSTANCES:-3}`.

## Why nobody could have "just set it"

`DEPLOY_CONFIG_PROJECT` is referenced only **inside** `deploy-config.sh` and supplied **nowhere** — not in `deploy.yml`, not in `deploy.sh`. Had a CI deploy ever reached the canonical branch it would have aborted on the missing pointer. The override wasn't preferred; it was the only path that could work. Wiring the pointer is part of this change.

## Changes

- `DEPLOY_CONFIG_SOURCE: secret` + `DEPLOY_CONFIG_PROJECT: memex-ai-<env>` on the deploy step. **That is the whole fix.**
- The blob-writing step **stays** for this one rollout, so the switch reverts in one line. It retires in ac-17, last, once both environments deploy clean from canonical.
- Two pieces of prose corrected, because both actively hid this:
  - `deploy.env.example` claimed *"Prod runs DB_POOL_MAX=10"*. It runs **4**. At 10 the budget invariant reads `8 × 11 = 88` against ~47 usable — the exact exhaustion this Spec exists to prevent, one well-meaning "restore the documented value" away.
  - `deploy.yml`'s header claimed *"CI and laptops share one config mechanism, zero drift."* They shared a **file** while obeying different **sources**. That sentence is what let this sit unexamined.

## Pre-flight — checked, not assumed

| check | result |
|---|---|
| `github-deployer` can read the canonical secret | ✅ `roles/secretmanager.secretAccessor` at **project** level in both projects (per-secret policies are empty) |
| fetch failure mode | fails **closed** — an unreadable secret aborts the deploy loudly, never ships stale config |
| both secrets populated | ✅ int 32 lines, prod 28 |
| can an applied env var be lost? | **No.** `deploy.sh` uses `--update-env-vars` / `--update-secrets` (merge), not `--set-*`. The lone `--set-secrets` grep hit is prose inside a comment |
| `APP_BASE_URL` absent from the secret | correct, not a gap — **derived** at `deploy-config.sh:126` from `PUBLIC_HOST` |
| YAML + expression | parsed; `main → memex-ai-prod`, `develop → memex-ai-int` |
| `make check` | green |

**Finding for the record:** int's live revision carries `JOURNEY_PREVIEW_DOMAINS` and `WAITLIST_DISABLED`, which exist in **no source** — hand-set, surviving only because deploys merge. Same disease as the scaling ceiling, smaller blast radius.

## What to watch when this merges

Merging deploys **int**. Two things to confirm before the prod release:

1. The deploy log reports `[deploy-config] source=SECRET-MANAGER secret=memex-int-deploy-env` — **not** `LOCAL-OVERRIDE` (ac-13).
2. int's applied config against the pre-switch snapshot captured today: **maxScale=3, minScale absent, 39 env vars** (ac-15). A key present before and absent after is a gap in the canonical secret — fix the secret, not the switch.

Then the prod release should show `maxScale 8` / `minScale 1` appearing **on their own**, which is also what makes the hand-set rev 00126 mitigation permanent. Until then prod runs on an un-persisted manual fix — third hand-set, second erasure.

Not in this PR: **t-7**, the guard that asserts what a deploy *actually applied* by reading live Cloud Run back. Every existing check reads the source, and all three were green throughout the outage.