### PR TITLE
release: spec-518 — CI obeys the canonical config secret, and prod's scaling ceiling finally persists

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,9 +16,20 @@ name: deploy
 # `github-deployer` service account holds standing deploy roles — a recorded
 # exception to the humans-use-PAM posture in scripts/deploy-config.sh.
 #
-# Per-env config: the gitignored scripts/deploy.<env>.env is injected from the
-# environment-scoped DEPLOY_ENV_FILE secret and written to disk before the
-# deploy runs — CI and laptops share one config mechanism, zero drift.
+# Per-env config: the CANONICAL source is the Secret Manager secret
+# `memex-<env>-deploy-env`, fetched by scripts/deploy-config.sh on every deploy
+# (DEPLOY_CONFIG_SOURCE / DEPLOY_CONFIG_PROJECT on the deploy step below).
+#
+# This header used to read "CI and laptops share one config mechanism, zero
+# drift." That sentence was wrong in a way that cost an outage, and it is worth
+# keeping the correction visible: CI and laptops shared a config FILE while
+# obeying different SOURCES. Writing scripts/deploy.<env>.env made
+# deploy-config.sh take its local-override branch — documented "ad-hoc testing
+# only" — so the canonical secret was never read in production. It already held
+# MAX_INSTANCES=8 while prod kept deploying at 3 (spec-518 dec-4).
+#
+# The DEPLOY_ENV_FILE blob is now a stale snapshot kept for one rollout so the
+# switch can be reverted in a line; it is retired in spec-518 ac-17.
 
 on:
   push:
@@ -129,6 +140,13 @@ jobs:
         # The gitignored scripts/deploy.<env>.env, exactly as a deployer's
         # laptop has it (DB_PASS is fetched from Secret Manager at source
         # time, so the secret holds coordinates, not credentials).
+        #
+        # spec-518 dec-4: this file is NO LONGER what the deploy reads. Writing it
+        # made deploy-config.sh take its LOCAL-OVERRIDE branch — documented "ad-hoc
+        # testing only" — on every CI deploy, so the canonical secret was never
+        # fetched in production. The step is kept for one rollout only, so the
+        # switch below can be reverted in one line; it is retired once both
+        # environments have deployed clean from the canonical secret (ac-17).
         env:
           DEPLOY_ENV_FILE: ${{ secrets.DEPLOY_ENV_FILE }}
         run: |
@@ -151,6 +169,24 @@ jobs:
         # checks verify their ACs on every deploy). Without it the smoke still
         # runs — emissions are just silently rejected 401.
         env:
+          # spec-518 dec-4 / t-6 — obey the CANONICAL config source.
+          #
+          # deploy-config.sh (spec-168) defines `memex-<env>-deploy-env` in Secret
+          # Manager as canonical, and a PRESENT scripts/deploy.<env>.env as an opt-in
+          # override for "ad-hoc testing only". The step above writes that file on every
+          # CI run, so every deploy silently took the override branch and the canonical
+          # secret was NEVER read in production. It already held the right values —
+          # MAX_INSTANCES=8, MIN_INSTANCES=1, DB_POOL_MAX=4 — while prod deployed at the
+          # 3-instance ceiling and shed 2000+ requests on 2026-08-11.
+          #
+          # These two lines are the whole fix. DEPLOY_CONFIG_PROJECT was referenced only
+          # INSIDE deploy-config.sh and supplied nowhere, so the canonical branch had
+          # never executed in CI even once — it would have aborted on the missing
+          # pointer. The fetch fails closed: an unreadable secret stops the deploy loudly
+          # rather than shipping stale config. github-deployer holds
+          # roles/secretmanager.secretAccessor at project level in both projects.
+          DEPLOY_CONFIG_SOURCE: secret
+          DEPLOY_CONFIG_PROJECT: memex-ai-${{ github.ref_name == 'main' && 'prod' || 'int' }}
           SMOKE_MCP_TOKEN: ${{ secrets.SMOKE_MCP_TOKEN }}
           SMOKE_SESSION_TOKEN: ${{ secrets.SMOKE_SESSION_TOKEN }}
           MEMEX_EMIT_KEY: ${{ secrets.MEMEX_EMIT_KEY }}

--- a/scripts/deploy.env.example
+++ b/scripts/deploy.env.example
@@ -58,10 +58,17 @@ SLACK_CLIENT_ID="your-slack-client-id"
 # Optional per-env override of the DB connection-pool cap per Cloud Run instance.
 # db/connection.ts defaults to 5. Budget it against Cloud SQL max_connections:
 # max-instances × (DB_POOL_MAX + 1 LISTEN) must stay under the instance's ceiling
-# (prod: 3 × (10+1) = 33 of 50). Leave COMMENTED OUT to keep the code default (5);
-# a deploy OMITS it when unset and never blanks a live value. Pool sizing is
-# spec-332's decision surface (spec-489 raised prod to 10). Prod runs DB_POOL_MAX="10".
-# DB_POOL_MAX="10"
+# (prod: ~47 usable of max_connections=50, after superuser-reserved slots). Leave
+# COMMENTED OUT to keep the code default (5); a deploy OMITS it when unset and never
+# blanks a live value. Pool sizing is spec-332's decision surface.
+#
+# PROD RUNS DB_POOL_MAX="4", NOT 10 (corrected spec-518 t-6, verified live 2026-08-11
+# on the serving revision). This paragraph claimed 10 long after spec-518 lowered it
+# for the 2026-08-03 connection-exhaustion incident, and the claim was dangerous, not
+# merely stale: prod's ceiling is now max-instances 8, so a well-meaning "restore the
+# documented value" gives 8 × (10+1) = 88 against ~47 — the exact exhaustion spec-518
+# exists to prevent. At the real value it is 8 × (4+1) = 40.
+# DB_POOL_MAX="4"
 
 # spec-244 (dec-2 / dec-9) — the Mixpanel analytics forwarder token is NOT a
 # deploy-env var. Like every other credential (anthropic/openai/postmark/…), it is


### PR DESCRIPTION
Promoting `develop@14568776`. One commit — spec-518 t-6.

## std-21 preconditions [per cl-42]

| check | clause | result |
|---|---|---|
| `develop` CI green | cl-43 | ✅ `test` success @ `14568776` |
| int deploy + smoke green | cl-44 | ✅ `deploy` success, smoke 7 passed / 2 skipped / 0 failed |
| `develop..main --no-merges` empty | cl-45 | ✅ 0 |

Merging as a **merge commit** [per cl-50].

## What this release actually does

It changes **two environment lines** on the deploy step. Everything else is prose.

`deploy-config.sh` (spec-168) makes `memex-<env>-deploy-env` in Secret Manager canonical, and treats a *present* `scripts/deploy.<env>.env` as an override documented *"ad-hoc testing only"*. `deploy.yml` writes that file on every CI run — so every production deploy took the ad-hoc branch and the canonical secret had **never been read in production**.

It already held the right values while prod deployed at the wrong ones.

## Why this release is not neutral, and what to watch

**int was the null test: nothing should change, and nothing did** — 39 env vars before, 39 after, maxScale 3 both sides, no key lost. That is what proves the canonical secret is complete relative to the unreadable GitHub blob.

**prod is the live test: something must change.** `memex-prod-deploy-env` carries `MAX_INSTANCES=8` and `MIN_INSTANCES=1`, so this deploy should apply them **on its own** — verifying ac-14 and making permanent the ceiling that has been set by hand three times and erased by a deploy twice.

**If `8` / `1` do NOT appear, this release re-runs the incident.** Prod currently serves a hand-set `maxScale 8` (rev 00126, un-persisted). A deploy overwrites that either way: it either applies 8/1 from the canonical secret, or falls back to `${MAX_INSTANCES:-3}` and reproduces the 2026-08-11 load-shed. There is no outcome where prod keeps the manual value untouched, which is precisely why it must be watched rather than assumed.

Verify immediately after:

1. Deploy log reports `[deploy-config] source=SECRET-MANAGER secret=memex-prod-deploy-env project=memex-ai-prod` (ac-13).
2. `gcloud run services describe memex-api --region=us-east4 --project=memex-ai-prod` shows `maxScale 8` **and** `minScale 1` (ac-14).
3. No env var present on rev 00126 is missing afterwards (ac-15).
4. Budget invariant on the **applied** numbers: `8 × (4 + 1) = 40` against ~47 usable (ac-16).

Rollback if any of that is wrong: `workflow_dispatch` redeploy of the previous `main` SHA, then re-apply `--max-instances=8` by hand as today.

## Also in this release

`scripts/deploy.env.example` stopped claiming prod runs `DB_POOL_MAX=10`. It runs **4**, and at 10 the budget reads `8 × 11 = 88` against ~47 — the exact exhaustion spec-518 exists to prevent, one "restore the documented value" away. `deploy.yml`'s header stopped claiming CI and laptops share one mechanism with *"zero drift"*; they shared a file while obeying different sources.

## Not in this release

**t-7** — the guard that asserts what a deploy *actually applied*, read back from live Cloud Run. Every existing check reads the source, and all three stayed green throughout both outages. Until it lands, steps 1–4 above are a human checklist rather than a gate.

Prod deploy is unattended [per cl-36] — merging this is the decision to ship.