### PR TITLE
fix(ac-emit-vitest): 0.3.1 — refuse a non-pnpm publisher; 0.3.0 shipped broken on npm

### DIFF
--- a/packages/ac-emit-vitest/package.json
+++ b/packages/ac-emit-vitest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memex-ai-ac/vitest",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Acceptance Criteria emit helper for Vitest. Tag tests with tagAc(), emit pass/fail to a Memex workspace.",
   "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "https://memex.ai",

--- a/packages/ac-emit-vitest/scripts/verify-publish-artifact.mjs
+++ b/packages/ac-emit-vitest/scripts/verify-publish-artifact.mjs
@@ -40,6 +40,41 @@ const leaves = (node, out = []) => {
   return out;
 };
 
+// ── CHECK 0: refuse the wrong publisher ───────────────────────────────────────
+// `publishConfig.exports` — the thing that strips the workspace-only
+// `development` condition — is a field override applied by **pnpm**. `npm publish`
+// IGNORES it and ships `exports` verbatim, so the leaked `development -> ./src`
+// condition reappears and every external Vitest consumer breaks on
+// "Failed to resolve import".
+//
+// That is not hypothetical: 0.3.0 was published with `npm publish` on 2026-08-10
+// and is broken on npm for exactly this reason. Every other layer held — the
+// override, this gate, `src/package-resolution.test.ts`, and a README that says
+// not to remove either. The defence was in depth; the entry point was wrong, and
+// the checks below could not see it because they inspect what *pnpm* would ship.
+//
+// So this check comes FIRST and needs no tarball: documentation already failed
+// once here, and replacing it with firmer documentation would repeat the mistake.
+const ua = process.env.npm_config_user_agent ?? "";
+if (ua && !/\bpnpm\//.test(ua)) {
+  console.error("✗ WRONG PUBLISHER — aborting publish\n");
+  console.error(`  detected: ${ua}`);
+  console.error("  This package MUST be published with `pnpm publish`.\n");
+  console.error("  `publishConfig.exports` strips the repo-only `development` export");
+  console.error("  condition (which points at ./src, and ./src is not in `files`).");
+  console.error("  pnpm applies that override; npm does not — so `npm publish` ships a");
+  console.error("  tarball whose exports point at files it does not contain, and every");
+  console.error("  external Vitest consumer fails with \"Failed to resolve import\".");
+  console.error("  This is how 0.3.0 shipped broken.\n");
+  console.error("  Run:  pnpm publish");
+  process.exit(1);
+}
+if (!ua) {
+  // Direct `node scripts/verify-publish-artifact.mjs` — a deliberate local run of
+  // the gate, not a publish. The artifact checks below still apply.
+  console.log("• no npm_config_user_agent — running the artifact checks only (not a publish)");
+}
+
 const tmp = mkdtempSync(join(tmpdir(), "ac-emit-verify-"));
 let failed = false;
 try {

--- a/packages/ac-emit-vitest/src/package-resolution.test.ts
+++ b/packages/ac-emit-vitest/src/package-resolution.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { tagAc } from "./index.js";
 import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
 
@@ -77,5 +78,41 @@ describe("package resolution config (spec-129 ac-23)", () => {
     expect(pkg.files).toBeDefined();
     expect(pkg.files).not.toContain("src");
     expect(pkg.files).toContain("dist");
+  });
+
+  // spec-489 issue-1 / 0.3.1 — the override above is only APPLIED by pnpm.
+  //
+  // 0.3.0 shipped broken on 2026-08-10 because it was published with `npm publish`,
+  // which ignores publishConfig field overrides: the repo-only `development ->
+  // ./src` condition reached the registry, ./src is not in `files`, and every
+  // external Vitest consumer failed with "Failed to resolve import". Every other
+  // layer held — the override, the prepublish gate, the assertions above, and a
+  // README saying not to remove either. The gate could not see it, because it
+  // inspects what *pnpm* would ship.
+  //
+  // So the publisher itself is now a guarded precondition, and this asserts the
+  // guard exists rather than trusting prose: documentation is precisely what
+  // failed here, and firmer documentation would repeat it.
+  // Asserts the gate's BEHAVIOUR, not its source text. Two earlier drafts of this
+  // test grepped the script and both broke on regex escaping — and a text match
+  // would pass just as happily on a gate that printed a warning and continued.
+  // Running it is the only thing that proves it aborts.
+  it("the prepublish gate refuses a non-pnpm publisher", () => {
+    tagAc(`${AC}/ac-23`);
+    const gate = fileURLToPath(
+      new URL("../scripts/verify-publish-artifact.mjs", import.meta.url),
+    );
+
+    const run = spawnSync(process.execPath, [gate], {
+      encoding: "utf8",
+      // What `npm publish` sets. The gate must reject it BEFORE packing anything,
+      // so this path is fast and touches no registry.
+      env: { ...process.env, npm_config_user_agent: "npm/10.9.0 node/v22.14.0 linux x64" },
+    });
+
+    expect(run.status, "gate must exit non-zero to abort the publish").toBe(1);
+    expect(run.stderr).toContain("WRONG PUBLISHER");
+    // It must name the fix, not just refuse: whoever hits this is mid-publish.
+    expect(run.stderr).toContain("pnpm publish");
   });
 });


### PR DESCRIPTION
**`0.3.0` is unusable for every external consumer.** `mindset-four` PR #500 did the bump correctly — all 16 manifests, lockfile regenerated — and its entire CI went red:

```
Failed to resolve import "@memex-ai-ac/vitest" from "src/embed-bundle.test.ts"
```

## Cause

The package declares a **repo-only** `development` export condition pointing at `./src`, so workspace consumers resolve to live TS and can never run a stale `dist` — the spec-129 issue-1 defect, where an old keyless `dist` dropped the emission key and every POST 401'd in silence. `./src` is not in `files`, so that condition must never reach the registry, and `publishConfig.exports` strips it.

**`publishConfig` field overrides are applied by pnpm. `npm publish` ignores them.** Proven both ways:

| | published `exports` |
|---|---|
| `npm pack` | contains `"development": "./src/index.ts"` |
| `pnpm pack` | dist-only ✅ |

Vite and Vitest set the `development` condition, so every external consumer resolves to a file the tarball does not contain.

## Nothing was mis-designed — four layers held

The `publishConfig` override; the prepublish gate (static **and** dynamic, installing the tarball and importing it under `--conditions=development`); `src/package-resolution.test.ts`; and a README that says in as many words not to remove either.

**The gate could not catch it.** It packs with `pnpm pack` — deliberately, so it sees publishConfig applied — so it inspected what *pnpm* would ship while npm shipped something else. Defence in depth, wrong entry point.

**What failed was the instruction.** `npm publish` is what spec-515 t-13 told the maintainer to run. So the fix is not firmer documentation: documentation is the thing that failed.

## Changes

- **`verify-publish-artifact.mjs` — new CHECK 0, before any packing.** Reads `npm_config_user_agent`, exits 1 on a non-pnpm publisher, and names both the reason and the fix. `prepublishOnly` is honoured by npm too, so this fires exactly where the mistake happens.
- **`package-resolution.test.ts` — assert the gate's *behaviour*.** Runs it with npm's user agent and requires exit 1 plus the message. Two earlier drafts of this test grepped the script's source; both broke on regex escaping, and a text match would pass just as happily on a gate that printed a warning and continued.
- **version → `0.3.1`.**

## Verification

| check | result |
|---|---|
| gate under npm UA | exit **1**, `WRONG PUBLISHER` |
| gate under pnpm UA | exit **0**, artifact checks pass |
| emitter suite | **103 passed** (13 files) |
| `make build` / `make check` | green |

## For the publisher

**Publish with `pnpm publish`. Never `npm publish`** — it will reproduce the identical broken tarball, and the gate will now stop you.

**Open question, not decided here:** whether to `npm deprecate` `0.3.0` so nobody installs it. It is a public, irreversible registry action, and the publish rights sit with the maintainers rather than this PR's author.

**`mindset-four` PR #500 should stay open** until 0.3.1 is on the registry — its red CI is a true signal, and its content needs no change beyond re-resolving the lockfile against 0.3.1.