### PR TITLE
chore: name develop as the publish branch so pnpm publish stops refusing it

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,17 @@
+# Workspace-wide pnpm/npm config.
+#
+# publish-branch — the branch a package may be published FROM.
+#
+# pnpm defaults this to `master|main` and refuses to publish from anything else.
+# This repo publishes packages from `develop`, deliberately: `main` is the
+# production line (std-21), so tying a package release to `main` would couple an
+# npm fix to a production deploy — and a broken published package should never
+# have to wait for a database maintenance window to be fixed.
+#
+# Why this line exists rather than a note in a README: on 2026-08-12 the 0.3.1
+# republish of @memex-ai-ac/vitest was blocked by pnpm's default while `main`
+# still carried the broken 0.3.0, and the reflex fix is `--no-git-checks` — which
+# also disables the clean-tree and up-to-date checks, i.e. it would allow
+# publishing an unreviewed working tree. Naming the branch keeps those two checks
+# on. (spec-526; the durable answer is publishing from CI, spec-526 t-5.)
+publish-branch=develop


### PR DESCRIPTION
One line of config. It unblocks nothing outstanding — `0.3.1` is already published — but it removes the obstacle the *next* publish would hit.

## What happened

`pnpm publish` refuses any branch but its default `master|main`:

> You're on branch "develop" but your "publish-branch" is set to "master|main".

No `.npmrc` existed in this repo, so `publish-branch` resolved to `undefined` and pnpm's default applied. That stopped the `0.3.1` republish of `@memex-ai-ac/vitest` mid-incident — and "publish from `main`" was not an alternative: `main` still carried the broken `0.3.0`, and npm refuses to republish an existing version regardless.

## Why `develop` is the right answer, not a workaround

This repo publishes packages from `develop` deliberately. `main` is the production line [per std-21], so binding a package release to `main` would couple an npm fix to a **production deploy** — and a broken published package should never have to wait for a database maintenance window to be fixed. That coupling is not hypothetical today: prod deploys are frozen pending the `max_connections` raise (spec-518 dec-2).

## Why a config line rather than a README note

The reflex fix when pnpm complains about git checks is `--no-git-checks`. That flag disables **three** things — the branch check, the **clean-tree** check, and the **up-to-date** check — so it would permit publishing an unreviewed working tree. Naming the branch removes only the check that was wrong for us and leaves the other two armed.

It is also the third time in two days that a *written instruction* about publishing turned out to be incomplete: `npm publish` (which ignores `publishConfig` — spec-526), then `pnpm install` for consumers (which keeps a still-in-range broken version), now the publish branch. Each was correct for the author and wrong for the person running it. Config is a better home for correctness than prose.

## Verified, not assumed

| check | before | after |
|---|---|---|
| `pnpm config get publish-branch` (from `packages/ac-emit-vitest`) | `undefined` | **`develop`** |
| `npm config get publish-branch` (from `packages/cli`) | `undefined` | `undefined` — key is pnpm-only, so the CLI's documented `npm publish` flow is untouched |
| `make check` | — | green |

The middle row matters: `packages/cli` has no `publishConfig` and publishes with `npm`, so it must not be disturbed by this.

## No guard test, deliberately

If this line is removed, `pnpm publish` fails loudly with the branch error. The failure mode is already self-announcing, so an assertion would only restate it. The reflex this week has been to add a check after every escape — this is the case where that would be noise rather than protection.

## Not the real fix

spec-526 **t-5** is: publish from CI, where the command is not typed by anyone and the packer is a property of the pipeline rather than of whoever is at a keyboard. This PR makes the manual path work correctly; it does not make the manual path the right long-term answer.