### PR TITLE
feat(spec-516): hide the web agent on a desktop-hosted Spec page (dec-10, t-8)

### DIFF
--- a/packages/ui/e2e/journey-67-spec-516-desktop-spec-layout.spec.ts
+++ b/packages/ui/e2e/journey-67-spec-516-desktop-spec-layout.spec.ts
@@ -1,0 +1,177 @@
+// Journey 67 — a Spec page hosted in the DESKTOP shell hides the web agent
+// (spec-516 dec-10).
+//
+// The desktop client gives a Spec its own tab split into two columns: a column
+// reserved for a later coding session (spec-322) on the left, the Spec on the
+// right. But DocumentShell already splits a Spec into two columns of its OWN — the
+// agent rail at 24%, then the canvas — so composed inside that tab a Spec rendered
+// THREE columns: reserved placeholder, agent rail, canvas. Two narrow left rails
+// competing, one of them deliberately empty for months, which is worse than the
+// full-width page the desktop layout set out to improve on.
+//
+// dec-10 settles it in React rather than in the shell: the page already knows when
+// it is hosted in the desktop (isDesktopShell(), spec-304 dec-19), so it decides
+// what it draws and the shell keeps owning only the frame. The desktop never
+// reaches into the DOM.
+//
+// The story here is the whole rule, in three legs — the narrowness matters as much
+// as the hiding, so the two negative controls are not padding:
+//   1. plain browser + Spec  → the agent is there, exactly as today
+//   2. desktop shell + Spec  → no agent at all, and the Spec still renders
+//   3. desktop shell + a NON-Spec document page → the agent is still there
+//
+// Seeding goes over the test-only HTTP surface (real services → the std-8 bus),
+// navigation is path-based [per std-2], no SQL.
+//
+// Verifies spec-516 ac-22 (this journey exists and covers the flow) and ac-21 (the
+// behaviour it asserts).
+
+import { test, expect, tenantPath, type TestResources } from "./helpers/index.js";
+import {
+  seedOrgTenant,
+  seedSpec,
+  seedDoc,
+  seedOpenDecision,
+  type SeededOrgTenant,
+} from "./helpers/retained.js";
+import { emitAcEvents } from "./helpers/index.js";
+import type { Page } from "@playwright/test";
+
+const AC = [
+  "mindset-prod/memex-building-itself/specs/spec-516/acs/ac-21",
+  "mindset-prod/memex-building-itself/specs/spec-516/acs/ac-22",
+];
+
+interface DesktopSeed {
+  tenant: SeededOrgTenant;
+  specHandle: string;
+  docHandle: string;
+  /** Handle of a real decision on the Spec, for the sub-page leg. */
+  decisionHandle: string;
+}
+
+const test2 = test.extend<{ seed: DesktopSeed }>({
+  seed: async ({ resources }: { resources: TestResources }, use) => {
+    const slug = resources.slug("j67");
+    const tenant = await seedOrgTenant({ slug });
+    const spec = await seedSpec({
+      memexId: tenant.memexId,
+      title: "Desktop Spec layout",
+      purpose: "A Spec to open in the desktop two-column tab.",
+    });
+    // A non-Spec document page, to prove the rule is Spec-scoped and did not
+    // quietly strip the agent from every document in the desktop app.
+    const doc = await seedDoc({
+      memexId: tenant.memexId,
+      title: "An ordinary document",
+      body: "Not a Spec.",
+    });
+    // A real decision, so the sub-page leg drives a route that actually exists.
+    // NOTE: the web app's Spec child routes are `decisions/:decId` and
+    // `issues/:issueId` only — there is no `tasks/:taskId` route, despite the
+    // desktop matcher (and spec-516 ac-8) using `…/specs/spec-N/tasks/t-1` as the
+    // canonical sub-page example. Rendering two columns for an unreachable URL is
+    // harmless, but a journey must exercise a reachable one.
+    const decision = await seedOpenDecision({
+      memexId: tenant.memexId,
+      docId: spec.docId,
+      title: "A fork to settle",
+      options: [{ label: "One way" }, { label: "The other way" }],
+    });
+    await use({
+      tenant,
+      specHandle: spec.handle,
+      docHandle: doc.handle,
+      decisionHandle: `dec-${decision.seq}`,
+    });
+  },
+});
+
+/**
+ * Makes `isDesktopShell()` true for the page by planting the same
+ * `window.flutter_inappwebview` shim the real Flutter host injects — installed
+ * BEFORE any page script runs, so the very first render already sees the desktop.
+ * Every handler resolves `{ ok: true }`; this journey asserts layout, not bridge
+ * traffic, and the shell's own handlers are covered in memex-clients.
+ */
+async function poseAsDesktopShell(page: Page) {
+  await page.addInitScript(() => {
+    (window as unknown as { flutter_inappwebview: unknown }).flutter_inappwebview = {
+      callHandler: () => ({ ok: true }),
+    };
+  });
+}
+
+async function goto(page: Page, seed: DesktopSeed, path: string) {
+  await page.goto(tenantPath(seed.tenant.namespaceSlug, seed.tenant.memexSlug, path));
+}
+
+/** The agent is gone entirely — the panel AND its collapsed strip. */
+async function expectNoAgent(page: Page) {
+  await expect(page.getByTestId("chat-input")).toHaveCount(0);
+  await expect(page.getByTestId("doc-chat-collapsed")).toHaveCount(0);
+  await expect(page.getByTestId("chat-collapse")).toHaveCount(0);
+}
+
+test2.afterEach(async ({}, testInfo) => {
+  if (testInfo.status === "skipped") return;
+  await emitAcEvents(
+    AC,
+    testInfo.status === "passed" ? "pass" : "fail",
+    `packages/ui/e2e/journey-67-spec-516-desktop-spec-layout.spec.ts::${testInfo.title}`,
+    testInfo.duration,
+  );
+});
+
+test2.describe("Desktop-hosted Spec hides the web agent (spec-516 dec-10)", () => {
+  test2("in a plain browser, a Spec page still shows the web agent", async ({ page, seed }) => {
+    await goto(page, seed, `/specs/${seed.specHandle}`);
+
+    // The control leg: nothing about the browser experience changes, so if this
+    // ever goes red the rule has leaked out of the desktop.
+    await expect(page.getByTestId("chat-input")).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByRole("heading", { name: "Desktop Spec layout" })).toBeVisible();
+  });
+
+  test2("inside the desktop shell, a Spec page shows NO web agent", async ({ page, seed }) => {
+    await poseAsDesktopShell(page);
+    await goto(page, seed, `/specs/${seed.specHandle}`);
+
+    // The Spec itself is there and readable — this is a layout change, not a
+    // content one. Waiting on the heading also settles the page before the
+    // negative assertions, so they cannot pass merely by running early.
+    await expect(page.getByRole("heading", { name: "Desktop Spec layout" })).toBeVisible({
+      timeout: 15_000,
+    });
+    await expectNoAgent(page);
+  });
+
+  test2("inside the desktop shell, a Spec SUB-page also shows no web agent", async ({
+    page,
+    seed,
+  }) => {
+    await poseAsDesktopShell(page);
+    // The desktop renders two columns for Spec sub-pages too (its isSpecUrl matcher
+    // counts them as "a Spec is open"), so the two sides must agree — otherwise a
+    // sub-page is three columns again. `decisions/:decId` is one of the two child
+    // routes the web app actually defines.
+    await goto(page, seed, `/specs/${seed.specHandle}/decisions/${seed.decisionHandle}`);
+
+    await expect(page.getByRole("heading", { name: "Desktop Spec layout" })).toBeVisible({
+      timeout: 15_000,
+    });
+    await expectNoAgent(page);
+  });
+
+  test2("inside the desktop shell, a NON-Spec document page keeps its agent", async ({
+    page,
+    seed,
+  }) => {
+    await poseAsDesktopShell(page);
+    await goto(page, seed, `/docs/${seed.docHandle}`);
+
+    // dec-10's scope is Spec pages only. If this goes red the change is broader
+    // than the decision authorised.
+    await expect(page.getByTestId("chat-input")).toBeVisible({ timeout: 15_000 });
+  });
+});

--- a/packages/ui/src/components/DocumentShell.spec-516.test.tsx
+++ b/packages/ui/src/components/DocumentShell.spec-516.test.tsx
@@ -1,0 +1,132 @@
+// spec-516 dec-10: a Spec page hosted in the DESKTOP shell hides the web agent.
+//
+// The desktop client (spec-516) gives a Spec its own tab split into two columns —
+// a reserved column held for a later coding session on the left, the Spec on the
+// right. But DocumentShell already lays a Spec out as two columns of its OWN (the
+// ChatPanel rail at 24%, then the canvas), so composed inside that tab a Spec
+// rendered THREE columns: reserved placeholder, agent rail, canvas. Two narrow
+// left rails competing, one of them deliberately empty for months.
+//
+// dec-10 settles it here rather than in the shell: React already knows when it is
+// hosted in the desktop (isDesktopShell(), spec-304 dec-19), so the page decides
+// what it draws and the shell keeps owning only the frame. The desktop never
+// reaches into the DOM.
+//
+// Scope is deliberately narrow — Spec pages only. In the desktop app every other
+// DocumentShell page keeps its agent, and a plain browser is untouched.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { tagAc } from '@memex-ai-ac/vitest';
+
+const AC_HIDES = 'mindset-prod/memex-building-itself/specs/spec-516/acs/ac-21';
+
+let mockIsDesktopShell = false;
+vi.mock('../desktop/bridge', () => ({
+  isDesktopShell: () => mockIsDesktopShell,
+}));
+
+vi.mock('./ChatContext', () => ({ useChat: () => ({ isDriftMode: false }) }));
+vi.mock('./AuthContext', () => ({ useAuth: () => ({ isAuthenticated: true }) }));
+vi.mock('../hooks/useMemexAccess', () => ({
+  useMemexAccess: () => ({ canWrite: true }),
+}));
+vi.mock('./ChatPanel', () => ({
+  ChatPanel: () => <div data-testid="chat-panel" />,
+}));
+// react-resizable-panels measures layout — render its parts as plain wrappers so
+// the expanded branch mounts cleanly in jsdom.
+vi.mock('react-resizable-panels', () => ({
+  Group: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  Panel: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  Separator: () => <div data-testid="resize-handle" />,
+}));
+
+import { DocumentShell } from './DocumentShell';
+
+const SPEC_PAGE = '/mindset-prod/memex-building-itself/specs/spec-516';
+const SPEC_SUBPAGE = `${SPEC_PAGE}/tasks/t-1`;
+const SPEC_TAGS = '/mindset-prod/memex-building-itself/specs/tags';
+const STANDARD_PAGE = '/mindset-prod/memex-building-itself/standards/std-25';
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <DocumentShell>
+        <div data-testid="content">page</div>
+      </DocumentShell>
+    </MemoryRouter>,
+  );
+}
+
+/** The agent is gone entirely — panel, collapsed strip and the resize seam. */
+function expectNoAgent() {
+  expect(screen.queryByTestId('chat-panel')).not.toBeInTheDocument();
+  expect(screen.queryByTestId('doc-chat-collapsed')).not.toBeInTheDocument();
+  expect(screen.queryByTestId('resize-handle')).not.toBeInTheDocument();
+  // …and the Spec itself still renders, at full width.
+  expect(screen.getByTestId('content')).toBeInTheDocument();
+}
+
+function expectAgent() {
+  expect(screen.getByTestId('chat-panel')).toBeInTheDocument();
+  expect(screen.getByTestId('content')).toBeInTheDocument();
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+  mockIsDesktopShell = false;
+});
+
+describe('DocumentShell — hide the web agent on a desktop-hosted Spec (spec-516 dec-10)', () => {
+  it('desktop shell + Spec page → no agent panel, no collapsed strip, no seam', () => {
+    tagAc(AC_HIDES);
+    mockIsDesktopShell = true;
+    renderAt(SPEC_PAGE);
+    expectNoAgent();
+  });
+
+  it('desktop shell + Spec SUB-page → also no agent', () => {
+    tagAc(AC_HIDES);
+    // The desktop renders two columns for Spec sub-pages too (its isSpecUrl
+    // matcher counts `…/specs/spec-N/tasks/t-1` as "a Spec is open"), so the two
+    // sides must agree — otherwise a sub-page is three columns again.
+    mockIsDesktopShell = true;
+    renderAt(SPEC_SUBPAGE);
+    expectNoAgent();
+  });
+
+  it('desktop shell + a NON-Spec document page → the agent still renders', () => {
+    tagAc(AC_HIDES);
+    mockIsDesktopShell = true;
+    renderAt(STANDARD_PAGE);
+    expectAgent();
+  });
+
+  it('desktop shell + the specs/tags surface → the agent still renders', () => {
+    tagAc(AC_HIDES);
+    // `/:ns/:mx/specs/:id` also matches the literal `specs/tags` manage-tags
+    // surface (spec-418 t-5). That is not a Spec, so it keeps its agent.
+    mockIsDesktopShell = true;
+    renderAt(SPEC_TAGS);
+    expectAgent();
+  });
+
+  it('plain browser + Spec page → the agent renders exactly as before', () => {
+    tagAc(AC_HIDES);
+    mockIsDesktopShell = false;
+    renderAt(SPEC_PAGE);
+    expectAgent();
+  });
+
+  it('the desktop rule does not depend on the collapse preference either way', () => {
+    tagAc(AC_HIDES);
+    // A previously-collapsed agent must not resurrect as the collapsed STRIP in
+    // the desktop — the whole rail is gone, not merely narrowed.
+    window.localStorage.setItem('memex:doc-chat-collapsed:spec', '1');
+    mockIsDesktopShell = true;
+    renderAt(SPEC_PAGE);
+    expectNoAgent();
+  });
+});

--- a/packages/ui/src/components/DocumentShell.tsx
+++ b/packages/ui/src/components/DocumentShell.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, type ReactNode } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useMatch } from 'react-router-dom';
 import { Group, Panel, Separator } from 'react-resizable-panels';
+import { isDesktopShell } from '../desktop/bridge';
 import { ChatPanel } from './ChatPanel';
 import { ChatCollapseProvider } from './chat/ChatCollapseContext';
 import { CollapsedChatStrip } from './chat/CollapsedChatStrip';
@@ -48,6 +49,34 @@ export function DocumentShell({ children }: { children: ReactNode }) {
   const collapseKey = `${COLLAPSE_KEY_BASE}:${agent}`;
   const label = isDriftMode ? 'Drift' : 'Assistant';
 
+  // spec-516 dec-10: a Spec page hosted in the DESKTOP shell hides the web agent
+  // entirely and gives the Spec the full width.
+  //
+  // The desktop client gives a Spec its own tab split into two columns — a column
+  // reserved for a later coding session on the left, the Spec on the right. This
+  // shell already splits a Spec into two columns of its own, so composed inside
+  // that tab a Spec rendered THREE columns: reserved placeholder, this agent rail,
+  // canvas. Two narrow left rails competing, one of them deliberately empty until
+  // spec-322 lands — worse than the full-width page the desktop layout set out to
+  // improve on.
+  //
+  // It is settled HERE rather than in the shell because the page must own what the
+  // page draws: the alternative was the desktop injecting CSS to suppress a
+  // surface we chose to render, which would be brittle against any change in here
+  // and invisible to these tests. Same division of labour as spec-304 dec-19.
+  //
+  // SPEC PAGES ONLY. Every other document page keeps its agent in the desktop app,
+  // and a plain browser is untouched (isDesktopShell() is false there).
+  const specPageMatch = useMatch('/:namespace/:memex/specs/:id');
+  // `/:ns/:mx/specs/:id` also matches the literal `specs/tags` manage-tags surface
+  // (spec-418 t-5), which is not a Spec — exclude it, exactly as AppShell does.
+  const onSpecPage = !!specPageMatch && specPageMatch.params.id !== 'tags';
+  // Spec sub-pages (`specs/:id/tasks/t-1`, `…/decisions/dec-2`, …) count too: the
+  // desktop's own matcher treats them as "a Spec is open" and renders two columns,
+  // so if we kept the rail here a sub-page would be three columns again.
+  const onSpecChildPage = !!useMatch('/:namespace/:memex/specs/:id/:childType/:childId');
+  const hideAgentForDesktop = isDesktopShell() && (onSpecPage || onSpecChildPage);
+
   const [collapsed, setCollapsed] = useState<boolean>(() => readCollapsed(collapseKey));
 
   // Adopt the active agent's saved state whenever the agent identity changes.
@@ -63,6 +92,15 @@ export function DocumentShell({ children }: { children: ReactNode }) {
       window.localStorage.setItem(collapseKey, next ? '1' : '0');
     }
   };
+
+  // Desktop-hosted Spec (spec-516 dec-10): no agent at all — not the panel, and
+  // not the collapsed strip either. The strip would be a second narrow rail beside
+  // the desktop's reserved column, which is the very thing this avoids, so the
+  // whole rail is gone rather than merely narrowed. Checked BEFORE `collapsed` so a
+  // stored collapse preference cannot resurrect it as a strip.
+  if (hideAgentForDesktop) {
+    return <main className="flex-1 h-full overflow-y-auto">{children}</main>;
+  }
 
   // Collapsed: the agent shrinks to its strip and the canvas takes the full
   // width — no resizable group while closed.


### PR DESCRIPTION
The desktop client gives a Spec its own tab split into two columns. With the web
agent panel also rendering, a Spec opened in the desktop shell came out as three
columns — worse than the full-width page the desktop layout set out to give it.

`isDesktopShell() && (onSpecPage || onSpecChildPage)` suppresses the agent in the
page that draws it, rather than the desktop injecting CSS to hide someone else's
element. Spec pages only: every other document page keeps its agent in the
desktop app, and a plain browser is untouched.

**Inert for web users.** `isDesktopShell()` is false in a browser, so this
changes nothing anyone sees today — it only takes effect once a page is hosted
inside the desktop shell. That is why it does not need to wait for the
memex-clients side to land.

## Provenance

This commit had been sitting **local-only and unpushed** on a development
machine, 25 commits behind `develop`. It has been rebased onto current `develop`
(clean, no conflicts) and is unchanged otherwise.

## Verification

- `packages/ui` unit tests for the component: **6 passed**
  (`DocumentShell.spec-516.test.tsx`)
- `tsc --noEmit -p packages/ui/tsconfig.json`: **clean**
- `make e2e-cold` (std-28): **148 passed, 1 skipped, 1 failed**

### The one e2e failure is PRE-EXISTING on `develop`, not from this change

`journey-53-spec-507-no-video-gate` fails identically on `develop` at `06ffe60`
with this branch checked out and with it not — verified by running the journey on
both. It never reaches the code this PR touches: the journey makes no reference
to the agent, to `DocumentShell`, or to a Spec page.

```
Error: Timeout 20000ms exceeded while waiting on the predicate
  133 |     await page.goto(bareUrl("/welcome"), { waitUntil: "commit" });
  134 |     await expect(page).toHaveURL(/\/welcome/, { timeout: 5_000 });
> 135 |   }).toPass({ timeout: 20_000 });
```

**`develop` is therefore red on a required check** and that blocks more than this
PR. Raised separately — it should not be fixed by riding along in here.