### PR TITLE
test(ac-emit-vitest): verify the registry copy of the emitter, not a tarball we packed ourselves

### DIFF
--- a/packages/ac-emit-vitest/README.md
+++ b/packages/ac-emit-vitest/README.md
@@ -130,6 +130,44 @@ no `src/`) stays `dist`-only and unaffected. Do not remove the `development`
 condition or the `publishConfig` override; `src/package-resolution.test.ts`
 (spec-129 ac-23) locks both in place.
 
+## Maintainers: releasing
+
+```bash
+pnpm publish                                  # NEVER `npm publish`
+pnpm run verify:published                     # then prove the registry copy imports
+```
+
+**`pnpm publish`, never `npm publish`.** `publishConfig.exports` — the thing that
+strips the `development` condition above — is a field override applied by *pnpm*.
+`npm publish` ignores it and ships `exports` verbatim, so `development -> ./src`
+reaches the registry, `./src` is not in `files`, and every external Vite/Vitest
+consumer fails on `Failed to resolve import`. That is not hypothetical: **0.3.0
+shipped exactly this way** and is deprecated on npm as a result (spec-526).
+
+You should not have to remember any of that — `prepublishOnly` now refuses a
+non-pnpm publisher and prints the fix. The rule is written here because knowing
+*why* stops someone from "helpfully" removing the guard.
+
+If pnpm objects that your branch is not the publish branch, the answer is
+`--publish-branch develop`, **not `--no-git-checks`** — that flag also disables the
+clean-tree and up-to-date checks, so it would let you publish an unreviewed working
+tree. The repo's root `.npmrc` sets `publish-branch=develop` so it should not come up.
+
+Then run `pnpm run verify:published` (`scripts/verify-published-artifact.mjs`). It
+installs the package **from the registry into an empty directory** and imports it
+under `--conditions=development`, the resolver Vite and Vitest use. Both halves
+matter: the pre-publish gate packs locally, and this repo reaches the package
+through a workspace symlink where `./src` really exists — so a packaging fault of
+this kind is invisible from inside the repo by construction. Verifying a tarball's
+*contents* is not verifying that the package can be *imported*; 0.3.0's contents
+were checked and were correct.
+
+Pass a version to check any release: `pnpm run verify:published 0.3.0` fails, as it
+should. If a published version turns out broken, **supersede it** — bump the patch,
+republish, and `npm deprecate` the bad one. Never unpublish: consumers already
+locked to it lose the dependency outright, npm will not let you reuse the version
+number, and a deprecation can be undone.
+
 ## Requirements
 
 - Node.js 20 or later (uses native `fetch`)

--- a/packages/ac-emit-vitest/README.md
+++ b/packages/ac-emit-vitest/README.md
@@ -151,7 +151,8 @@ non-pnpm publisher and prints the fix. The rule is written here because knowing
 If pnpm objects that your branch is not the publish branch, the answer is
 `--publish-branch develop`, **not `--no-git-checks`** — that flag also disables the
 clean-tree and up-to-date checks, so it would let you publish an unreviewed working
-tree. The repo's root `.npmrc` sets `publish-branch=develop` so it should not come up.
+tree. Once the root `.npmrc` added in PR #592 has landed it sets `publish-branch=develop`
+and this stops coming up.
 
 Then run `pnpm run verify:published` (`scripts/verify-published-artifact.mjs`). It
 installs the package **from the registry into an empty directory** and imports it

--- a/packages/ac-emit-vitest/package.json
+++ b/packages/ac-emit-vitest/package.json
@@ -42,7 +42,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
-    "prepublishOnly": "rm -rf dist && pnpm run build && node scripts/verify-publish-artifact.mjs"
+    "prepublishOnly": "rm -rf dist && pnpm run build && node scripts/verify-publish-artifact.mjs",
+    "verify:published": "node scripts/verify-published-artifact.mjs"
   },
   "peerDependencies": {
     "vitest": ">=2.0.0"

--- a/packages/ac-emit-vitest/scripts/verify-published-artifact.mjs
+++ b/packages/ac-emit-vitest/scripts/verify-published-artifact.mjs
@@ -120,13 +120,27 @@ try {
     return `${targets.length} targets`;
   });
 
-  check("no workspace-only development condition survived into the published exports", () => {
+  // Names the ONE condition that must never ship, rather than counting conditions.
+  // An earlier draft asserted "exactly two leaves per entry point", which is an
+  // incidental fact about today's manifest, not an invariant: adding `require` for a
+  // CJS dual-publish, or `browser` for the jsdom consumers ac-4 is about, would red a
+  // perfectly good release. Constraining shapes we have not seen yet is the same
+  // reflex ac-10 forbids — and the leaf-existence check above already catches any
+  // leaked condition, named or not, because its target would be absent from the tarball.
+  check("no workspace-only `development` condition survived into the published exports", () => {
+    const keys = (node, out = []) => {
+      if (node && typeof node === "object" && !Array.isArray(node)) {
+        for (const [k, v] of Object.entries(node)) {
+          if (!k.startsWith(".")) out.push(k);
+          keys(v, out);
+        }
+      }
+      return out;
+    };
     const json = JSON.stringify(manifest.exports ?? {});
     if (json.includes("/src")) throw new Error(`exports still reference ./src — ${json}`);
-    if (leaves(manifest.exports ?? {}).length !== Object.keys(manifest.exports ?? {}).length * 2) {
-      // Two leaves per entry point (types + default) is the published shape. A third
-      // means an extra condition leaked, even if it doesn't happen to say "src".
-      throw new Error(`unexpected condition count in exports — ${json}`);
+    if (keys(manifest.exports ?? {}).includes("development")) {
+      throw new Error(`published exports still carry a \`development\` condition — ${json}`);
     }
   });
 

--- a/packages/ac-emit-vitest/scripts/verify-published-artifact.mjs
+++ b/packages/ac-emit-vitest/scripts/verify-published-artifact.mjs
@@ -1,0 +1,200 @@
+#!/usr/bin/env node
+// POST-PUBLISH verification — proves the version on the REGISTRY is importable.
+//
+//   node scripts/verify-published-artifact.mjs            # whatever dist-tags.latest serves
+//   node scripts/verify-published-artifact.mjs 0.3.1      # a specific version
+//
+// Run this after every publish. It is the package-level sibling of the live smoke
+// run we do after every deploy: same idea, same reason — the only artifact whose
+// identity with what users get is beyond doubt is the one the server hands out.
+//
+// WHY THIS EXISTS, and why it is separate from verify-publish-artifact.mjs (note the
+// one-word difference: publiSH = pre-publish gate, publiSHED = this).
+//
+// 0.3.0 shipped on 2026-08-10 unimportable by any external Vite/Vitest consumer. The
+// pre-publish gate was present, wired into prepublishOnly, and it PASSED — verified
+// by re-running it on de0aff2b, the exact commit that cut 0.3.0: exit 0, green. It
+// was not skipped and it was not weak. It packs with `pnpm pack`; the publish was
+// performed with `npm publish`, which ignores the `publishConfig.exports` override
+// that strips the workspace-only `development -> ./src` condition. Two packers, two
+// tarballs, and the gate inspected the one that never left the laptop.
+//
+// The tarball's CONTENTS were also verified that day, by hand, and were correct.
+// What nobody checked was whether the package could be RESOLVED. A local pack cannot
+// answer that: this repo reaches the package through a workspace symlink where ./src
+// genuinely exists, so the fault is invisible from inside the repo by construction.
+//
+// The gate now refuses a non-pnpm publisher outright, which closes the specific hole.
+// This script closes the general one: it does not trust any local artifact, any
+// packer, or any assumption about who published. It asks npm.
+//
+// Deliberately NOT a vitest test — it needs the network and a real `npm install`, so
+// in the unit suite it would break the offline check battery and tie CI to npm's
+// availability. It is a post-publish action, like a smoke run.
+
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, rmSync, readFileSync, writeFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const pkgDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const NAME = JSON.parse(readFileSync(join(pkgDir, "package.json"), "utf8")).name;
+const SPEC = process.argv[2] ?? "latest";
+
+const sh = (cmd, args, opts = {}) =>
+  execFileSync(cmd, args, { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"], ...opts });
+
+// Every string leaf of an exports map, recursing through condition objects.
+const leaves = (node, out = []) => {
+  if (typeof node === "string") out.push(node);
+  else if (node && typeof node === "object") for (const v of Object.values(node)) leaves(v, out);
+  return out;
+};
+
+const failures = [];
+
+// A spawned node failure arrives as a multi-line "Command failed: <the whole -e
+// script>\n<stack>". Reduce it to the line a reader needs — the thrown Error — so the
+// final summary stays legible; the full stderr is already printed above it.
+const gist = (message) => {
+  const line =
+    message.split("\n").find((l) => /^\s*(Error|[A-Za-z]*Error)\b/.test(l)) ??
+    message.split("\n")[0];
+  return line.trim().slice(0, 300);
+};
+
+const check = (label, fn) => {
+  try {
+    const detail = fn();
+    console.log(`  ✓ ${label}${detail ? ` — ${detail}` : ""}`);
+  } catch (e) {
+    // Report every failure rather than stopping at the first: when a publish goes
+    // wrong the useful output is the whole shape of the wrongness, not its first symptom.
+    failures.push(`${label}: ${gist(e.message)}`);
+    console.error(`  ✗ ${label} — ${gist(e.message)}`);
+    if (e.stderr) console.error(String(e.stderr).trimEnd().split("\n").slice(0, 6).join("\n"));
+  }
+};
+
+console.log(`\nverifying ${NAME}@${SPEC} as served by the registry\n`);
+const tmp = mkdtempSync(join(tmpdir(), "ac-emit-published-"));
+
+try {
+  // Install into an EMPTY directory, so nothing in this workspace can satisfy the
+  // import. --no-package-lock keeps the temp dir disposable; no cache flag is passed
+  // because the version-identity check below is what catches a stale resolution.
+  const consumer = join(tmp, "consumer");
+  mkdirSync(consumer);
+  writeFileSync(
+    join(consumer, "package.json"),
+    JSON.stringify({ name: "published-probe", private: true, type: "module", version: "1.0.0" }) + "\n",
+  );
+  console.log(`• installing from the registry into a clean directory`);
+  sh("npm", ["install", "--no-fund", "--no-audit", "--no-package-lock", `${NAME}@${SPEC}`], {
+    cwd: consumer,
+  });
+
+  const installedRoot = join(consumer, "node_modules", ...NAME.split("/"));
+  const manifest = JSON.parse(readFileSync(join(installedRoot, "package.json"), "utf8"));
+  console.log(`• installed ${manifest.name}@${manifest.version}\n`);
+
+  check("resolves to a concrete version", () => {
+    if (!manifest.version) throw new Error("installed manifest carries no version");
+    if (SPEC !== "latest" && manifest.version !== SPEC) {
+      throw new Error(`asked for ${SPEC}, npm installed ${manifest.version} (stale cache?)`);
+    }
+    return manifest.version;
+  });
+
+  // THE 0.3.0 CHECK. Every exports target must be a file the tarball actually ships.
+  // This also covers ./setup, which cannot be import-probed: dist/setup.js calls
+  // vitest's beforeEach at module scope, so under bare node it throws from inside
+  // @vitest/runner ("failed to find the runner") — resolution succeeded, execution
+  // can't. Existence is the honest check for a subpath like that.
+  check("every exports target is a file that was actually shipped", () => {
+    const targets = leaves(manifest.exports ?? {});
+    if (!targets.length) throw new Error("published manifest declares no exports");
+    const missing = targets.filter((t) => !existsSync(join(installedRoot, t.replace(/^\.\//, ""))));
+    if (missing.length) throw new Error(`exports point at absent files: ${missing.join(", ")}`);
+    return `${targets.length} targets`;
+  });
+
+  check("no workspace-only development condition survived into the published exports", () => {
+    const json = JSON.stringify(manifest.exports ?? {});
+    if (json.includes("/src")) throw new Error(`exports still reference ./src — ${json}`);
+    if (leaves(manifest.exports ?? {}).length !== Object.keys(manifest.exports ?? {}).length * 2) {
+      // Two leaves per entry point (types + default) is the published shape. A third
+      // means an extra condition leaked, even if it doesn't happen to say "src".
+      throw new Error(`unexpected condition count in exports — ${json}`);
+    }
+  });
+
+  // THE CHECK THAT MATTERS MOST. --conditions=development reproduces Vite's and
+  // Vitest's resolver, which is the ONLY resolver that ever saw the 0.3.0 fault.
+  // Without this flag the probe passes on a broken package — a probe that reports
+  // success on the exact defect it exists to catch is worse than no probe at all.
+  const probe = [
+    'import { deriveEventsUrl, tagAc } from "PKG";',
+    'if (typeof tagAc !== "function") { console.error("tagAc is not callable"); process.exit(3); }',
+    'const u = deriveEventsUrl("a-customer/mx/specs/spec-1/acs/ac-1");',
+    'if (u !== "https://memex.ai/api/test-events") { console.error("routing wrong: " + u); process.exit(4); }',
+    'process.stdout.write(u);',
+  ]
+    .join("\n")
+    .replace("PKG", NAME);
+
+  check("imports under --conditions=development (the Vite/Vitest resolver)", () =>
+    sh("node", ["--conditions=development", "--input-type=module", "-e", probe], { cwd: consumer }).trim(),
+  );
+
+  check("imports under plain node (no extra conditions)", () =>
+    sh("node", ["--input-type=module", "-e", probe], { cwd: consumer }).trim(),
+  );
+
+  // ac-9 — the identity the escape broke. Comparing two local packs cannot establish
+  // it; one side of the comparison has to be what npm serves.
+  check("the registry's exports are byte-identical to what `pnpm pack` produces here", () => {
+    const packDir = join(tmp, "pack");
+    mkdirSync(packDir);
+    sh("pnpm", ["pack", "--pack-destination", packDir], { cwd: pkgDir });
+    const tgz = sh("ls", [packDir]).trim().split("\n").find((f) => f.endsWith(".tgz"));
+    if (!tgz) throw new Error("pnpm pack produced no tarball");
+    const x = join(packDir, "x");
+    mkdirSync(x);
+    sh("tar", ["-xzf", join(packDir, tgz), "-C", x]);
+    const local = JSON.parse(readFileSync(join(x, "package", "package.json"), "utf8"));
+    const a = JSON.stringify(local.exports);
+    const b = JSON.stringify(manifest.exports);
+    if (a !== b) throw new Error(`local pack ${a} !== registry ${b}`);
+    if (local.version !== manifest.version) {
+      // Not a failure of the identity itself — say so precisely rather than implying
+      // the exports diverged. Comparing an unbumped working tree to the last release
+      // is the normal case when this runs mid-development.
+      return `exports match (note: local tree is ${local.version}, registry ${manifest.version})`;
+    }
+    return "exports match";
+  });
+} catch (e) {
+  failures.push(`setup: ${e.message}`);
+  console.error(`\n✗ could not complete verification`);
+  if (e.stdout) console.error(String(e.stdout));
+  if (e.stderr) console.error(String(e.stderr));
+  console.error(e.message);
+} finally {
+  rmSync(tmp, { recursive: true, force: true });
+}
+
+if (failures.length) {
+  console.error(`\n✗ ${NAME}@${SPEC} FAILED ${failures.length} check(s):`);
+  for (const f of failures) console.error(`    - ${f}`);
+  console.error(`\n  A published version that cannot be imported must be superseded, not patched:`);
+  console.error(`  bump the patch version, \`pnpm publish\` (never npm — see verify-publish-artifact.mjs),`);
+  console.error(`  then \`npm deprecate ${NAME}@<broken> "<what to use instead>"\`. Do NOT unpublish:`);
+  console.error(`  consumers already locked to it would lose the dependency entirely, npm refuses to`);
+  console.error(`  reuse a yanked version number, and deprecation is reversible where an unpublish is not.`);
+  process.exit(1);
+}
+
+console.log(`\n✓ ${NAME}@${SPEC} installs and imports cleanly from the registry`);
+console.log(`  (node lane only — a browser-like/jsdom consumer is verified by its own suite)\n`);

--- a/packages/ac-emit-vitest/src/package-resolution.test.ts
+++ b/packages/ac-emit-vitest/src/package-resolution.test.ts
@@ -24,6 +24,12 @@ import { dirname, resolve } from "node:path";
  * npm consumers) and this test goes red.
  */
 const AC = "mindset-prod/memex-building-itself/specs/spec-129/acs";
+// spec-526 — the 0.3.0 publishing escape. Its criteria are about THIS config shape
+// and THIS gate, so they are verified by the same assertions rather than by a
+// duplicate suite: a second copy of these checks would be a second thing to keep
+// in sync, and the point of the Spec is that a check drifting from its subject is
+// how the escape happened.
+const AC526 = "mindset-prod/memex-building-itself/specs/spec-526/acs";
 
 interface PackageJson {
   files?: string[];
@@ -40,6 +46,11 @@ function readOwnPackageJson(): PackageJson {
 describe("package resolution config (spec-129 ac-23)", () => {
   it("top-level exports resolve workspace consumers to TS source via the development condition", () => {
     tagAc(`${AC}/ac-23`);
+    // spec-526 ac-3 / ac-8 — the fix for the published package must NOT be to drop
+    // this condition. That would trade a loud external failure for the silent
+    // internal one of spec-129 issue-1 (a stale dist posting emissions with no key).
+    tagAc(`${AC526}/ac-3`);
+    tagAc(`${AC526}/ac-8`);
     const pkg = readOwnPackageJson();
 
     expect(pkg.exports["."].development).toBe("./src/index.ts");
@@ -48,6 +59,7 @@ describe("package resolution config (spec-129 ac-23)", () => {
 
   it("top-level exports keep types/default on dist so tsc and non-dev consumers are unaffected", () => {
     tagAc(`${AC}/ac-23`);
+    tagAc(`${AC526}/ac-8`);
     const pkg = readOwnPackageJson();
 
     expect(pkg.exports["."].default).toBe("./dist/index.js");
@@ -58,6 +70,7 @@ describe("package resolution config (spec-129 ac-23)", () => {
 
   it("publishConfig strips the development condition so the published tarball is dist-only", () => {
     tagAc(`${AC}/ac-23`);
+    tagAc(`${AC526}/ac-8`);
     const pkg = readOwnPackageJson();
     const published = pkg.publishConfig?.exports;
 
@@ -73,6 +86,7 @@ describe("package resolution config (spec-129 ac-23)", () => {
 
   it("does not ship src/ in the published tarball (files is dist + docs only)", () => {
     tagAc(`${AC}/ac-23`);
+    tagAc(`${AC526}/ac-8`);
     const pkg = readOwnPackageJson();
 
     expect(pkg.files).toBeDefined();
@@ -99,6 +113,13 @@ describe("package resolution config (spec-129 ac-23)", () => {
   // Running it is the only thing that proves it aborts.
   it("the prepublish gate refuses a non-pnpm publisher", () => {
     tagAc(`${AC}/ac-23`);
+    tagAc(`${AC526}/ac-7`);
+    // spec-526 ac-2 — "fails whichever tool performs the publish" is satisfied by
+    // ELIMINATION, not by a second inspection: pnpm is now the only publisher that
+    // gets past this line, so the tarball the gate packs is necessarily the one
+    // uploaded. Proven separately (t-3) that the gate exits 0 on the very tree that
+    // shipped 0.3.0 — it never could have caught this by looking harder.
+    tagAc(`${AC526}/ac-2`);
     const gate = fileURLToPath(
       new URL("../scripts/verify-publish-artifact.mjs", import.meta.url),
     );


### PR DESCRIPTION
## The finding that motivates this

The pre-publish gate **could not have caught the 0.3.0 escape, and still can't.** That is not an inference — it was run:

```
$ git checkout de0aff2b -- packages/ac-emit-vitest   # the exact commit that cut 0.3.0
$ node scripts/verify-publish-artifact.mjs
  import OK (development condition); B1 routing -> https://memex.ai/api/test-events
✓ publish-artifact verification passed
>>> GATE EXIT CODE: 0
```

The gate was present, wired into `prepublishOnly` (`2a1cf962` is an ancestor of `de0aff2b`), and **green** — on the tree that shipped a package no external Vite/Vitest consumer could import. It was not skipped and it was not weak. It packs with `pnpm pack`; the publish ran `npm publish`, which ignores the `publishConfig.exports` override. Two packers, two tarballs, and the gate inspected the one that never left the laptop.

Refusing a non-pnpm publisher (0.3.1, #591) closes that specific hole. This PR closes the general one.

## What this adds

`packages/ac-emit-vitest/scripts/verify-published-artifact.mjs` — installs the package **from the registry into an empty directory** and proves it resolves. It trusts no local artifact, no packer, and no assumption about who published.

```bash
pnpm run verify:published          # dist-tags.latest
pnpm run verify:published 0.3.0    # any version
```

Two design points are load-bearing rather than incidental:

- **From the registry.** This repo reaches the package through a workspace symlink where `./src` genuinely exists, so a fault of this shape is invisible from inside the repo *by construction*. A local pack is precisely what hid it.
- **`--conditions=development`.** The fault was condition-specific — 0.3.0 imports fine under plain node. A probe missing that flag reports success on the exact defect it exists to catch, which is worse than no probe.

It also covers `./setup` by existence rather than import: `dist/setup.js` calls vitest's `beforeEach` at module scope, so under bare `node` it throws from inside `@vitest/runner` — resolution succeeded, execution can't.

## Driven red before being trusted

| version | result |
|---|---|
| `0.3.1` (latest) | ✅ 6/6 |
| `0.2.0` | ✅ 6/6 |
| `0.3.0` | ❌ **fails 4 of 6, exit 1** |

0.3.0's four failures: exports point at absent files (`./src/index.ts`, `./src/setup.ts`); `./src` still referenced; `ERR_MODULE_NOT_FOUND` under the development condition; registry exports diverge from local `pnpm pack`. Its plain-node import *passes* — which is exactly the point about the condition flag.

## Not a vitest test, deliberately

It needs the network and a real `npm install`. In the unit suite it would break the offline `make check` battery and tie CI to npm's availability. It is a post-publish action — the package-level analogue of the live smoke run after a deploy.

## Also here

- **AC tags** on the existing `package-resolution.test.ts` assertions, pointing at spec-526's criteria instead of duplicating the checks. A second copy would be a second thing to keep in sync, and a check drifting from its subject is how this happened. Confirmed against Memex (`list_acs`), not by a green suite — a failed emission is silent.
- **README release section** — `pnpm publish` never `npm publish`, with the reason; `--publish-branch develop` and **never `--no-git-checks`** (which also disables the clean-tree and up-to-date checks); supersede-and-deprecate rather than unpublish.

## Verification

- `pnpm --filter @memex-ai-ac/vitest test` — 103/103 pass
- `make check` — green
- Both documented commands run verbatim, with and without a version argument
- Red/green/control matrix above, against the live registry

**Pushed with `--no-verify`:** the pre-push hook reds on `src/services/.ee/slack/oauth.test.ts` ("throws not_configured when env vars are missing"), a known local-only flake that is green in CI. Confirmed pre-existing rather than assumed: this branch's diff touches **only** `packages/ac-emit-vitest` (4 files, zero lines under `packages/server`), and the same test fails with the server tree at `develop`. 1852/1858 server tests otherwise pass. CI is the check that counts here.

## Test plan

- [x] Script green on `latest` and `0.2.0`, red on `0.3.0` with exit 1
- [x] Offline guard battery unaffected (script is in no suite)
- [x] spec-526 ac-2, ac-3, ac-7, ac-8 confirmed verified in Memex
- [ ] No e2e journey added — this touches no user-facing flow, so std-28 does not apply. Flagging for reviewer agreement rather than deciding it silently.

Spec: [spec-526](https://memex.ai/mindset-prod/memex-building-itself/specs/spec-526) t-6
