### PR TITLE
fix(ui): multiplex the per-user SSE stream — six copies saturated the browser's socket pool

### DIFF
--- a/packages/ui/src/hooks/useUserChangeStream.test.tsx
+++ b/packages/ui/src/hooks/useUserChangeStream.test.tsx
@@ -1,0 +1,270 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+
+vi.mock('../components/AuthContext', () => ({
+  useAuth: () => ({ token: 'test-token' }),
+}));
+
+vi.mock('../api/http', () => ({
+  BASE_URL: '/api',
+}));
+
+// eslint-disable-next-line import/first
+import { useUserChangeStream, useUserChangeStreamWithToken } from './useUserChangeStream';
+
+interface MockStream {
+  push: (chunk: string) => void;
+  close: () => void;
+  response: Response;
+  closed: boolean;
+}
+
+function makeMockStream(): MockStream {
+  let controller: ReadableStreamDefaultController<Uint8Array> | null = null;
+  const stream = new ReadableStream<Uint8Array>({
+    start(c) {
+      controller = c;
+    },
+  });
+  const m: MockStream = {
+    response: new Response(stream, {
+      status: 200,
+      headers: { 'content-type': 'text/event-stream' },
+    }),
+    push: (chunk: string) => {
+      controller?.enqueue(new TextEncoder().encode(chunk));
+    },
+    close: () => {
+      if (m.closed) return;
+      m.closed = true;
+      try {
+        controller?.close();
+      } catch {
+        // already closed
+      }
+    },
+    closed: false,
+  };
+  return m;
+}
+
+describe('useUserChangeStream', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  let streams: MockStream[];
+
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    streams = [];
+    fetchMock = vi.fn().mockImplementation(() => {
+      const s = makeMockStream();
+      streams.push(s);
+      return Promise.resolve(s.response);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    for (const s of streams) s.close();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it('does NOT call onEvent on the initial connection (consumer already fetched on mount)', async () => {
+    const onEvent = vi.fn();
+    renderHook(() => useUserChangeStream(onEvent));
+
+    await waitFor(() => expect(streams.length).toBe(1));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+    expect(onEvent).not.toHaveBeenCalled();
+  });
+
+  it('calls onEvent (debounced) when a user_change event arrives', async () => {
+    const onEvent = vi.fn();
+    renderHook(() => useUserChangeStream(onEvent));
+
+    await waitFor(() => expect(streams.length).toBe(1));
+    streams[0].push('event: user_change\ndata: {"entity":"mcp_token"}\n\n');
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300);
+    });
+    expect(onEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT call onEvent for non-user_change event types (e.g. keepalive)', async () => {
+    const onEvent = vi.fn();
+    renderHook(() => useUserChangeStream(onEvent));
+
+    await waitFor(() => expect(streams.length).toBe(1));
+    streams[0].push('event: keepalive\ndata: \n\n');
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+    expect(onEvent).not.toHaveBeenCalled();
+  });
+
+  it('triggers a refetch when the SSE stream re-establishes (doc-16 dec-4)', async () => {
+    const onEvent = vi.fn();
+    renderHook(() => useUserChangeStream(onEvent));
+
+    await waitFor(() => expect(streams.length).toBe(1));
+    streams[0].close();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1500);
+    });
+    await waitFor(() => expect(streams.length).toBe(2));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300);
+    });
+
+    expect(onEvent).toHaveBeenCalledTimes(1);
+  });
+
+  // ── entityFilter stays a per-subscriber concern ────────────────────────────
+  // It must NOT become a property of the shared connection: two subscribers with
+  // different filters share one stream, so filtering happens at dispatch.
+
+  it('respects entityFilter — an unlisted entity does not fire the callback', async () => {
+    const onEvent = vi.fn();
+    renderHook(() => useUserChangeStream(onEvent, ['mcp_token']));
+
+    await waitFor(() => expect(streams.length).toBe(1));
+    streams[0].push('event: user_change\ndata: {"entity":"user_slack_token"}\n\n');
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+    expect(onEvent).not.toHaveBeenCalled();
+  });
+
+  it('fires when an event with no readable entity arrives (permissive contract)', async () => {
+    const onEvent = vi.fn();
+    renderHook(() => useUserChangeStream(onEvent, ['mcp_token']));
+
+    await waitFor(() => expect(streams.length).toBe(1));
+    streams[0].push('event: user_change\ndata: not-json\n\n');
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300);
+    });
+    expect(onEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires a filtered subscriber on RECONNECT regardless of its filter (dec-4)', async () => {
+    const onEvent = vi.fn();
+    renderHook(() => useUserChangeStream(onEvent, ['mcp_token']));
+
+    await waitFor(() => expect(streams.length).toBe(1));
+    streams[0].close();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1500);
+    });
+    await waitFor(() => expect(streams.length).toBe(2));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300);
+    });
+
+    expect(onEvent).toHaveBeenCalledTimes(1);
+  });
+
+  // ── Connection sharing ─────────────────────────────────────────────────────
+  // There is exactly ONE per-user channel, so every call site is on the same
+  // scope. They MUST multiplex onto one streaming fetch: a never-closing stream
+  // per call site saturates the browser's per-origin pool (HTTP/1.1: 6) and
+  // starves every later request to that origin — including full-document
+  // navigations, which then hang with no error. This is the same defect
+  // spec-118 fixed in useDocChangeStream.
+
+  it('shares ONE connection across multiple subscribers', async () => {
+    const a = vi.fn();
+    const b = vi.fn();
+    const c = vi.fn();
+    renderHook(() => useUserChangeStream(a));
+    renderHook(() => useUserChangeStream(b));
+    renderHook(() => useUserChangeStream(c));
+
+    await waitFor(() => expect(streams.length).toBe(1));
+    // Give any stray second connection a chance to appear before asserting.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+    expect(streams.length).toBe(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    streams[0].push('event: user_change\ndata: {"entity":"mcp_token"}\n\n');
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300);
+    });
+    expect(a).toHaveBeenCalledTimes(1);
+    expect(b).toHaveBeenCalledTimes(1);
+    expect(c).toHaveBeenCalledTimes(1);
+  });
+
+  it('fans one event out by entity — each subscriber applies its OWN filter', async () => {
+    const tokens = vi.fn();
+    const slack = vi.fn();
+    const all = vi.fn();
+    renderHook(() => useUserChangeStream(tokens, ['mcp_token']));
+    renderHook(() => useUserChangeStream(slack, ['user_slack_token']));
+    renderHook(() => useUserChangeStream(all));
+
+    await waitFor(() => expect(streams.length).toBe(1));
+    streams[0].push('event: user_change\ndata: {"entity":"user_slack_token"}\n\n');
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300);
+    });
+    expect(slack).toHaveBeenCalledTimes(1);
+    expect(all).toHaveBeenCalledTimes(1);
+    expect(tokens).not.toHaveBeenCalled();
+  });
+
+  it('opens SEPARATE connections for different tokens (stream scope includes identity)', async () => {
+    renderHook(() => useUserChangeStreamWithToken('token-a', vi.fn()));
+    renderHook(() => useUserChangeStreamWithToken('token-b', vi.fn()));
+    await waitFor(() => expect(streams.length).toBe(2));
+  });
+
+  it('keeps the shared connection open until the LAST subscriber unmounts', async () => {
+    const first = renderHook(() => useUserChangeStream(vi.fn()));
+    const second = renderHook(() => useUserChangeStream(vi.fn()));
+    await waitFor(() => expect(streams.length).toBe(1));
+
+    const signal = (fetchMock.mock.calls[0][1] as RequestInit).signal as AbortSignal;
+
+    first.unmount();
+    expect(signal.aborted).toBe(false);
+
+    second.unmount();
+    expect(signal.aborted).toBe(true);
+  });
+
+  it('aborts the in-flight fetch and clears debounce on unmount (no orphan callbacks)', async () => {
+    const onEvent = vi.fn();
+    const { unmount } = renderHook(() => useUserChangeStream(onEvent));
+
+    await waitFor(() => expect(streams.length).toBe(1));
+
+    streams[0].push('event: user_change\ndata: {"entity":"mcp_token"}\n\n');
+    unmount();
+
+    const signal = (fetchMock.mock.calls[0][1] as RequestInit).signal as AbortSignal;
+    expect(signal.aborted).toBe(true);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+    expect(onEvent).not.toHaveBeenCalled();
+
+    const callsBefore = fetchMock.mock.calls.length;
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+    expect(fetchMock.mock.calls.length).toBe(callsBefore);
+  });
+});

--- a/packages/ui/src/hooks/useUserChangeStream.ts
+++ b/packages/ui/src/hooks/useUserChangeStream.ts
@@ -15,7 +15,161 @@ import { BASE_URL } from '../api/http';
  * the new connection. The `entityFilter` param lets callers narrow which
  * entity types trigger the callback — e.g. SettingsTokens only cares about
  * `mcp_token` events.
+ *
+ * Connection sharing: every call site here subscribes to the SAME stream scope
+ * — there is exactly one per-user channel, `/api/me/events` — so N call sites
+ * used to mean N never-closing streaming fetches to one origin. Under HTTP/1.1
+ * (local dev and the e2e run go through the Vite proxy) the browser caps
+ * concurrent connections per origin at 6, so the app saturated the pool and
+ * starved every subsequent request: API fetches AND full-document navigations
+ * alike queued forever with no error and no timeout. `useDocChangeStream` was
+ * given exactly this fix in spec-118; this hook — its stated mirror — never
+ * inherited it, and quietly crossed the limit as call sites accumulated
+ * (AuthContext + DesktopMcpStatusSync are app-global, and Settings →
+ * Integrations mounts four more at once). Subscribers now multiplex onto ONE
+ * shared connection per `(url, token)` scope, so the whole app holds one
+ * user-channel stream instead of ten.
+ *
+ * The `entityFilter` stays a SUBSCRIBER concern, not a connection one: the
+ * shared reader dispatches each event's entity to every subscriber and each
+ * decides whether it cares. A reconnect dispatches `null`, which every
+ * subscriber treats as "refetch regardless of filter" — preserving dec-4.
  */
+
+// ── Shared SSE connection registry ──────────────────────────────────────────
+// Keyed by `${url}::${token}` so every subscriber on the same stream scope
+// shares one underlying streaming fetch. Ref-counted: the connection opens with
+// the first subscriber and aborts when the last one leaves.
+
+/**
+ * Called with the event's `entity` value, or `null` to mean "unconditional" —
+ * either a reconnect (dec-4) or an event whose entity could not be read, which
+ * this hook has always treated permissively.
+ */
+type Subscriber = (entity: string | null) => void;
+
+interface SharedConn {
+  subscribers: Set<Subscriber>;
+  abort: AbortController;
+  closed: boolean;
+}
+
+const connections = new Map<string, SharedConn>();
+
+function notify(conn: SharedConn, entity: string | null): void {
+  // Snapshot so a subscriber that unsubscribes during dispatch can't mutate the
+  // set mid-iteration.
+  for (const sub of Array.from(conn.subscribers)) {
+    sub(entity);
+  }
+}
+
+function runConnection(key: string, url: string, headers: Record<string, string>): void {
+  const conn = connections.get(key);
+  if (!conn) return;
+
+  let retryDelay = 1000;
+  // doc-16 dec-4: every SSE consumer MUST refetch when the stream re-establishes,
+  // even before any event arrives on the new connection. The FIRST connect does
+  // NOT fire (each consumer's own initial fetch covers that); every subsequent
+  // reconnect notifies all current subscribers.
+  let hasConnectedBefore = false;
+
+  async function connect(): Promise<void> {
+    try {
+      const res = await fetch(url, { headers, signal: conn!.abort.signal });
+      if (!res.ok) throw new Error(`SSE connection failed: ${res.status}`);
+
+      const reader = res.body!.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
+
+      retryDelay = 1000; // Reset on successful connection
+
+      if (hasConnectedBefore) notify(conn!, null);
+      hasConnectedBefore = true;
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const parts = buffer.split('\n\n');
+        buffer = parts.pop() ?? '';
+
+        for (const part of parts) {
+          if (!part.trim()) continue;
+
+          let eventType = '';
+          let dataLine = '';
+          for (const line of part.split('\n')) {
+            if (line.startsWith('event:')) {
+              eventType = line.slice(6).trim();
+            } else if (line.startsWith('data:')) {
+              dataLine = line.slice(5).trim();
+            }
+          }
+
+          if (eventType !== 'user_change' || conn!.closed) continue;
+
+          // `null` = "no entity to filter on" → every subscriber fires. That is
+          // the pre-existing permissive contract for an absent or unparseable
+          // payload; keep it, so a malformed event can never silently drop a
+          // refetch.
+          let entity: string | null = null;
+          if (dataLine) {
+            try {
+              entity = (JSON.parse(dataLine) as { entity?: string }).entity ?? null;
+            } catch {
+              entity = null;
+            }
+          }
+          notify(conn!, entity);
+        }
+      }
+    } catch (err) {
+      if ((err as Error).name === 'AbortError') return;
+    }
+
+    // Reconnect with exponential backoff while subscribers remain.
+    if (!conn!.closed) {
+      await new Promise((resolve) => setTimeout(resolve, retryDelay));
+      retryDelay = Math.min(retryDelay * 2, 30_000);
+      if (!conn!.closed) connect();
+    }
+  }
+
+  connect();
+}
+
+function acquire(
+  key: string,
+  url: string,
+  headers: Record<string, string>,
+  sub: Subscriber,
+): void {
+  let conn = connections.get(key);
+  if (!conn) {
+    conn = { subscribers: new Set(), abort: new AbortController(), closed: false };
+    connections.set(key, conn);
+    conn.subscribers.add(sub);
+    runConnection(key, url, headers);
+    return;
+  }
+  conn.subscribers.add(sub);
+}
+
+function release(key: string, sub: Subscriber): void {
+  const conn = connections.get(key);
+  if (!conn) return;
+  conn.subscribers.delete(sub);
+  if (conn.subscribers.size === 0) {
+    conn.closed = true;
+    conn.abort.abort();
+    connections.delete(key);
+  }
+}
+
 export function useUserChangeStream(
   onEvent: () => void,
   entityFilter?: ReadonlyArray<string>
@@ -42,7 +196,13 @@ export function useUserChangeStreamWithToken(
 
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const debouncedCallback = useCallback(() => {
+  // Stable identity: this is what the shared connection holds, so it must not
+  // change between renders or the subscriber would churn on every render.
+  const subscriber = useCallback((entity: string | null) => {
+    // `null` = reconnect or unreadable payload → always refetch.
+    if (entity !== null && filterRef.current && !filterRef.current.includes(entity)) {
+      return;
+    }
     if (debounceRef.current) clearTimeout(debounceRef.current);
     debounceRef.current = setTimeout(() => {
       onEventRef.current();
@@ -50,99 +210,21 @@ export function useUserChangeStreamWithToken(
   }, []);
 
   useEffect(() => {
-    let abortController = new AbortController();
-    let retryDelay = 1000;
-    let mounted = true;
-    // doc-16 dec-4: every SSE consumer triggers a refetch on reconnect. The
-    // first connect after mount does NOT fire — the page's initial fetch
-    // covers that case — but every subsequent reconnect does.
-    let hasConnectedBefore = false;
-
-    async function connect() {
-      // Pulse (b-60) t-11: state the action contract explicitly. This hook only
-      // wants mutations (created/updated/deleted), matching the server default,
-      // so behaviour is unchanged — we just no longer rely on the implicit default.
-      const url = `${BASE_URL}/me/events?include=mutations`;
-      const headers: Record<string, string> = {};
-      if (token) {
-        headers['Authorization'] = `Bearer ${token}`;
-      }
-
-      try {
-        const res = await fetch(url, {
-          headers,
-          signal: abortController.signal,
-        });
-
-        if (!res.ok) {
-          throw new Error(`SSE connection failed: ${res.status}`);
-        }
-
-        const reader = res.body!.getReader();
-        const decoder = new TextDecoder();
-        let buffer = '';
-
-        retryDelay = 1000;
-
-        if (hasConnectedBefore) {
-          debouncedCallback();
-        }
-        hasConnectedBefore = true;
-
-        while (true) {
-          const { done, value } = await reader.read();
-          if (done) break;
-
-          buffer += decoder.decode(value, { stream: true });
-
-          const parts = buffer.split('\n\n');
-          buffer = parts.pop() ?? '';
-
-          for (const part of parts) {
-            if (!part.trim()) continue;
-
-            let eventType = '';
-            let dataLine = '';
-            for (const line of part.split('\n')) {
-              if (line.startsWith('event:')) {
-                eventType = line.slice(6).trim();
-              } else if (line.startsWith('data:')) {
-                dataLine = line.slice(5).trim();
-              }
-            }
-
-            if (eventType === 'user_change' && mounted) {
-              if (filterRef.current && dataLine) {
-                try {
-                  const parsed = JSON.parse(dataLine) as { entity?: string };
-                  if (parsed.entity && !filterRef.current.includes(parsed.entity)) {
-                    continue;
-                  }
-                } catch {
-                  // Parse failure: be permissive and fire anyway.
-                }
-              }
-              debouncedCallback();
-            }
-          }
-        }
-      } catch (err) {
-        if ((err as Error).name === 'AbortError') return;
-      }
-
-      if (mounted) {
-        await new Promise((resolve) => setTimeout(resolve, retryDelay));
-        retryDelay = Math.min(retryDelay * 2, 30_000);
-        if (mounted) connect();
-      }
+    // Pulse (b-60) t-11: state the action contract explicitly. This hook only
+    // wants mutations (created/updated/deleted), matching the server default,
+    // so behaviour is unchanged — we just no longer rely on the implicit default.
+    const url = `${BASE_URL}/me/events?include=mutations`;
+    const headers: Record<string, string> = {};
+    if (token) {
+      headers['Authorization'] = `Bearer ${token}`;
     }
 
-    connect();
+    const key = `${url}::${token ?? ''}`;
+    acquire(key, url, headers, subscriber);
 
     return () => {
-      mounted = false;
-      abortController.abort();
+      release(key, subscriber);
       if (debounceRef.current) clearTimeout(debounceRef.current);
     };
-  }, [token, debouncedCallback]);
+  }, [token, subscriber]);
 }


### PR DESCRIPTION
journey-53 (spec-507) has been failing on `develop` at its last step, blocking every PR since the e2e suite is a required check (std-28). The test navigates to `/welcome` and the navigation never commits, so the `toPass` wrapper burns its whole 20s budget.

It is **not** a test defect, and **not** related to PR #593 — `/welcome` renders fine. The app never got as far as asking for it.

## Root cause

`useUserChangeStream` opened **one long-lived streaming `fetch` per call site**, and every call site is on the **same scope** — there is exactly one per-user channel, `/api/me/events`. Settings → Integrations mounts six subscribers at once:

| Subscriber | Mounted |
|---|---|
| `AuthContext` | app-global |
| `DesktopMcpStatusSync` | app-global (`App.tsx`) |
| `DesktopMcpSection` | Integrations page |
| `McpTokensSection` | Integrations page |
| `SlackIntegrationSection` | Integrations page |
| `DiscordIntegrationSection` | Integrations page |

Under HTTP/1.1 — which is what local dev and the e2e run get through the Vite proxy — Chrome caps concurrent connections at **6 per origin**. Streams that never close took every socket, so the next request to that origin was queued and **never sent**. Not a timeout, not an error, no console message: silence. journey-53's `page.goto(bareUrl("/welcome"))` was that request.

### Evidence from the failing trace

The trace says exactly this, and says nothing about routing:

- the `/welcome` entry has `timings: {send: -1, wait: -1, receive: -1}` — the request was never put on the wire;
- three ordinary API GETs issued in the same instant (`/api/mcp/tokens`, `/drift`, `/qa-reports/unread`) died the same way;
- after that moment, the only requests in the whole trace that still complete are **cross-origin** (GA4, the OpenAI pixel) — which have their own pool.

That is the signature of connection-pool starvation, not a broken route.

### This is a known defect, fixed once already

`useDocChangeStream` carries [the spec-118 fix](packages/ui/src/hooks/useDocChangeStream.ts) for precisely this, and its docblock names the mechanism: *"the browser caps concurrent connections per origin at 6, so a handful of these never-closing streams SATURATED the pool and starved every other request."* `useUserChangeStream` describes itself as that hook's mirror but never inherited the fix, and crossed the limit silently as call sites accumulated.

## The fix

Adopt `useDocChangeStream`'s registry: subscribers multiplex onto one shared connection per `(url, token)` scope, ref-counted, aborted when the last leaves. The whole app now holds **one** user-channel stream instead of ten.

The one thing that could not be copied is `entityFilter`, which the doc hook has no equivalent of. It stays a **subscriber** concern rather than becoming a property of the connection: the shared reader dispatches each event's `entity` and each subscriber decides whether it cares. Reconnects dispatch `null`, which every subscriber treats as "refetch regardless of filter" — that is what preserves doc-16 dec-4. `null` is also what an absent or unparseable payload dispatches, keeping the pre-existing permissive contract, so a malformed event still cannot silently drop a refetch.

## Evidence, measured rather than argued

Running the journey once proves little — on a warm `make e2e` it passes even unfixed, because the failure needs every stream established before the goto is issued. So the mechanism was measured directly with a throwaway probe (signup → `/settings/integrations` → wait for all sections to mount → count streams → navigate):

| | streams opened | `/welcome` navigation |
|---|---|---|
| **before** | 10 × `/api/me/events` + 2 × `docs/events` = **12** | **never committed** (20s timeout) |
| **after** | 2 × `/api/me/events` + 2 × `docs/events` = **4** | **8 ms** |

The residual 2 per scope are React StrictMode's dev-only double-invoke (mount, cleanup, remount) — the steady state is one.

The probe's own wall time fell **33.9s → 8.4s**. With the pool free, everything after the settings page stopped queueing. That speed-up is the user-facing half of this bug: anyone on Integrations in local dev had an app that silently stalled every later request.

Prod is unaffected today only because Cloud Run serves HTTP/2, where one connection multiplexes ~100 streams. The fix still cuts per-tab `/me/events` subscriptions ~5×, which is load spec-518 has been fighting from the server side.

## Verification

- **`useUserChangeStream.test.tsx`** (new, mirrors the sibling's): 12 tests. The 3 sharing tests are a genuine red→green guard — they **fail on the old hook**, verified by stashing the implementation and re-running. The other 9 pin behaviour and pass on both, which is the evidence that semantics are unchanged.
- `pnpm --filter @memex/ui exec vitest run` — 339 files, **2293 passed**, 9 skipped.
- `make typecheck` clean; `make check` green.
- `make e2e-cold` — full suite green, journey-53 included.

Nothing was weakened to get here: no timeout was raised, no assertion loosened, no retry added. journey-53 is byte-for-byte unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
