### PR TITLE
feat(spec-529): a referenced Spec carries its own status — reference pills in document bodies

### DIFF
--- a/packages/server/src/agent/handlers/docs.spec-529.test.ts
+++ b/packages/server/src/agent/handlers/docs.spec-529.test.ts
@@ -12,9 +12,6 @@ import { describe, it, expect } from "vitest";
 import { tagAc } from "@memex-ai-ac/vitest";
 import { docsTools } from "./docs.js";
 
-const BODY_WITH_HANDLES =
-  "The board work is spec-335, and the verbatim record is spec-372.";
-
 describe("get_doc is untouched by spec-529", () => {
   it("appends no resolved-references block to its description or schema", () => {
     tagAc("mindset-prod/memex-building-itself/specs/spec-529/acs/ac-7");
@@ -34,10 +31,16 @@ describe("get_doc is untouched by spec-529", () => {
     expect(names.filter((n) => /ref|pill|handle/i.test(n))).toEqual([]);
   });
 
-  it("leaves a body's bare handles as literal text — the agent reads what was written", () => {
-    // The rendering layer never touches storage, so a handle in a body is still
-    // the same string an agent receives.
-    expect(BODY_WITH_HANDLES).toContain("spec-335");
-    expect(BODY_WITH_HANDLES).toContain("spec-372");
+  it("exposes no handle-resolution argument an agent could ask status through", () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-529/acs/ac-7");
+    const getDoc = docsTools.find((t) => t.name === "get_doc");
+    // The whole surface an agent can reach is ref + verbose. There is no opt-in
+    // that would return resolved status for the handles a body mentions, which is
+    // what dec-3 decided against.
+    const schema = getDoc?.schema ?? {};
+    expect(Object.keys(schema)).toEqual(["ref", "verbose"]);
+    expect(Object.keys(schema)).not.toContain("resolveRefs");
+    expect(Object.keys(schema)).not.toContain("includeReferencedSpecs");
   });
+
 });

--- a/packages/server/src/agent/handlers/docs.spec-529.test.ts
+++ b/packages/server/src/agent/handlers/docs.spec-529.test.ts
@@ -1,0 +1,43 @@
+// spec-529 t-6 (ac-7, dec-3) — the MCP surface is OUT OF SCOPE for this Spec, and
+// this test is what keeps it that way.
+//
+// The temptation is real: the pill resolves every handle a body mentions, so it
+// looks natural to hand an agent the same thing. dec-3 says no. An agent can
+// already fetch a referenced Spec's status whenever it wants one; the reader who
+// cannot is the human looking at a rendered page. So `get_doc` must return the
+// body byte-for-byte, with nothing appended and no status attached — and the
+// tool catalogue must not have grown a resolution tool either.
+
+import { describe, it, expect } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { docsTools } from "./docs.js";
+
+const BODY_WITH_HANDLES =
+  "The board work is spec-335, and the verbatim record is spec-372.";
+
+describe("get_doc is untouched by spec-529", () => {
+  it("appends no resolved-references block to its description or schema", () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-529/acs/ac-7");
+    const getDoc = docsTools.find((t) => t.name === "get_doc");
+    expect(getDoc).toBeDefined();
+    const description = getDoc?.description ?? "";
+    // Nothing in the contract offers resolved status for referenced handles.
+    expect(description).not.toMatch(/referenced spec/i);
+    expect(description).not.toMatch(/task progress|taskProgress/i);
+    expect(Object.keys(getDoc?.schema ?? {})).toEqual(["ref", "verbose"]);
+  });
+
+  it("adds no reference-resolution tool to the catalogue", () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-529/acs/ac-7");
+    const names = docsTools.map((t) => t.name);
+    expect(names).not.toContain("resolve_spec_refs");
+    expect(names.filter((n) => /ref|pill|handle/i.test(n))).toEqual([]);
+  });
+
+  it("leaves a body's bare handles as literal text — the agent reads what was written", () => {
+    // The rendering layer never touches storage, so a handle in a body is still
+    // the same string an agent receives.
+    expect(BODY_WITH_HANDLES).toContain("spec-335");
+    expect(BODY_WITH_HANDLES).toContain("spec-372");
+  });
+});

--- a/packages/server/src/routes/documents.spec-529.test.ts
+++ b/packages/server/src/routes/documents.spec-529.test.ts
@@ -1,0 +1,110 @@
+// spec-529 t-2 — the `?handles=` filter and the `taskProgress` include on the docs
+// list route, the ONE request a document view makes to resolve every `spec-N` its
+// body mentions.
+//
+// Mock-based (no DB), mirroring documents.tags.test.ts: stub the services + session
+// middleware, then assert the handler turns query params into listDocs options. The
+// aggregation itself is covered service-side; what is proved here is the wiring and
+// the boundary's parsing, which is where a malformed handle in prose would otherwise
+// take down a whole page's resolution.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { makeTestAppWithTenant, passthroughMiddleware } from "./route-test-helpers.js";
+
+vi.mock("../middleware/session.js", () => ({
+  sessionMiddleware: passthroughMiddleware,
+  publicSessionMiddleware: passthroughMiddleware,
+}));
+
+vi.mock("../services/documents.js", () => ({
+  listDocs: vi.fn(),
+  getDoc: vi.fn(),
+}));
+
+vi.mock("../services/sections.js", () => ({ splitSection: vi.fn() }));
+vi.mock("../services/decisions.js", () => ({ listDecisions: vi.fn().mockResolvedValue([]) }));
+vi.mock("../services/tasks.js", () => ({ listTasks: vi.fn().mockResolvedValue([]) }));
+vi.mock("../services/share-tokens.js", () => ({
+  createShareToken: vi.fn(),
+  listShareTokensForDoc: vi.fn(),
+  revokeShareToken: vi.fn(),
+}));
+vi.mock("../services/tags.js", () => ({
+  parseTagInput: (raw: string) => ({ scope: null, value: raw }),
+  listDocTags: vi.fn(),
+  listMemexTags: vi.fn(),
+  listMemexTagsWithCounts: vi.fn(),
+  listDocTagsForDocs: vi.fn().mockResolvedValue(new Map()),
+  applyTagStrings: vi.fn(),
+  removeTagFromDoc: vi.fn(),
+  createTag: vi.fn(),
+  renameTag: vi.fn(),
+  deleteTag: vi.fn(),
+}));
+
+import { docs } from "./documents.js";
+import { listDocs } from "../services/documents.js";
+
+const TEST_MEMEX_ID = "00000000-0000-0000-0000-000000000001";
+const TEST_USER_ID = "00000000-0000-0000-0000-000000000010";
+
+const app = makeTestAppWithTenant({ memexId: TEST_MEMEX_ID, userId: TEST_USER_ID });
+app.route("/api/docs", docs);
+
+function optsFromLastCall() {
+  return (listDocs as unknown as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[1];
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (listDocs as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+});
+
+describe("GET /api/docs — spec-529 reference resolution", () => {
+  it("passes a CSV handle set through as a handle filter", async () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-529/acs/ac-10");
+    const res = await app.request("/api/docs?handles=spec-335,spec-373,spec-371");
+    expect(res.status).toBe(200);
+    expect(optsFromLastCall().handles).toEqual(["spec-335", "spec-373", "spec-371"]);
+  });
+
+  it("accepts repeated params and de-duplicates the set", async () => {
+    const res = await app.request("/api/docs?handles=spec-335&handles=spec-335,spec-373");
+    expect(res.status).toBe(200);
+    expect(optsFromLastCall().handles).toEqual(["spec-335", "spec-373"]);
+  });
+
+  it("drops malformed handles instead of failing the whole resolution", async () => {
+    // A rendered body is the caller here. One odd string in prose must not 400 the
+    // page, and a dropped handle is indistinguishable from an unreadable one.
+    const res = await app.request(
+      "/api/docs?handles=spec-335,Spec-9,spec-007,spec-0,spec-,nonsense,spec-3a",
+    );
+    expect(res.status).toBe(200);
+    expect(optsFromLastCall().handles).toEqual(["spec-335"]);
+  });
+
+  it("filters to nothing rather than the whole Memex when every handle is dropped", async () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-529/acs/ac-11");
+    const res = await app.request("/api/docs?handles=nonsense");
+    expect(res.status).toBe(200);
+    // An explicit `?handles=` still means "these Specs" — an empty array, never undefined.
+    expect(optsFromLastCall().handles).toEqual([]);
+  });
+
+  it("leaves the handle filter unset when the caller does not ask", async () => {
+    const res = await app.request("/api/docs?type=spec");
+    expect(res.status).toBe(200);
+    expect(optsFromLastCall().handles).toBeUndefined();
+  });
+
+  it("turns ?include=taskProgress into the service opt, and leaves it off otherwise", async () => {
+    await app.request("/api/docs?include=taskProgress,acHealth");
+    expect(optsFromLastCall().includeTaskProgress).toBe(true);
+    expect(optsFromLastCall().includeAcHealth).toBe(true);
+
+    await app.request("/api/docs?include=acHealth");
+    expect(optsFromLastCall().includeTaskProgress).toBe(false);
+  });
+});

--- a/packages/server/src/routes/documents.tags.test.ts
+++ b/packages/server/src/routes/documents.tags.test.ts
@@ -117,6 +117,7 @@ describe("GET /api/docs (tag filter)", () => {
       includeAcHealth: false,
       includeAssignees: false,
       includeTaskProgress: false,
+      includeLastActivity: false,
       includeArchived: false,
       tags: [
         { scope: "priority", value: "high" },
@@ -135,6 +136,7 @@ describe("GET /api/docs (tag filter)", () => {
       includeAcHealth: false,
       includeAssignees: false,
       includeTaskProgress: false,
+      includeLastActivity: false,
       includeArchived: false,
       tags: [
         { scope: "priority", value: "low" },
@@ -153,6 +155,7 @@ describe("GET /api/docs (tag filter)", () => {
       includeAcHealth: false,
       includeAssignees: false,
       includeTaskProgress: false,
+      includeLastActivity: false,
       // spec-521 (ac-5): the archive view is the one caller that asks for archived
       // rows; every other read passes false explicitly.
       includeArchived: false,

--- a/packages/server/src/routes/documents.tags.test.ts
+++ b/packages/server/src/routes/documents.tags.test.ts
@@ -116,6 +116,7 @@ describe("GET /api/docs (tag filter)", () => {
       includeDriftCount: false,
       includeAcHealth: false,
       includeAssignees: false,
+      includeTaskProgress: false,
       includeArchived: false,
       tags: [
         { scope: "priority", value: "high" },
@@ -133,6 +134,7 @@ describe("GET /api/docs (tag filter)", () => {
       includeDriftCount: false,
       includeAcHealth: false,
       includeAssignees: false,
+      includeTaskProgress: false,
       includeArchived: false,
       tags: [
         { scope: "priority", value: "low" },
@@ -150,6 +152,7 @@ describe("GET /api/docs (tag filter)", () => {
       includeDriftCount: false,
       includeAcHealth: false,
       includeAssignees: false,
+      includeTaskProgress: false,
       // spec-521 (ac-5): the archive view is the one caller that asks for archived
       // rows; every other read passes false explicitly.
       includeArchived: false,

--- a/packages/server/src/routes/documents.test.ts
+++ b/packages/server/src/routes/documents.test.ts
@@ -101,6 +101,7 @@ describe("GET /api/docs", () => {
       includeDriftCount: false,
       includeAcHealth: false,
       includeAssignees: false,
+      includeTaskProgress: false,
       // spec-521 (ac-5): the archive view is the one caller that asks for archived
       // rows; every other read passes false explicitly.
       includeArchived: false,
@@ -116,6 +117,7 @@ describe("GET /api/docs", () => {
       includeDriftCount: false,
       includeAcHealth: false,
       includeAssignees: false,
+      includeTaskProgress: false,
       // spec-521 (ac-5): the archive view is the one caller that asks for archived
       // rows; every other read passes false explicitly.
       includeArchived: false,
@@ -131,6 +133,7 @@ describe("GET /api/docs", () => {
       includeDriftCount: true,
       includeAcHealth: false,
       includeAssignees: false,
+      includeTaskProgress: false,
       // spec-521 (ac-5): the archive view is the one caller that asks for archived
       // rows; every other read passes false explicitly.
       includeArchived: false,
@@ -146,6 +149,7 @@ describe("GET /api/docs", () => {
       includeDriftCount: false,
       includeAcHealth: true,
       includeAssignees: false,
+      includeTaskProgress: false,
       // spec-521 (ac-5): the archive view is the one caller that asks for archived
       // rows; every other read passes false explicitly.
       includeArchived: false,
@@ -161,6 +165,7 @@ describe("GET /api/docs", () => {
       includeDriftCount: true,
       includeAcHealth: true,
       includeAssignees: false,
+      includeTaskProgress: false,
       // spec-521 (ac-5): the archive view is the one caller that asks for archived
       // rows; every other read passes false explicitly.
       includeArchived: false,
@@ -176,6 +181,7 @@ describe("GET /api/docs", () => {
       includeDriftCount: false,
       includeAcHealth: false,
       includeAssignees: true,
+      includeTaskProgress: false,
       includeArchived: false,
     });
   });

--- a/packages/server/src/routes/documents.test.ts
+++ b/packages/server/src/routes/documents.test.ts
@@ -102,6 +102,7 @@ describe("GET /api/docs", () => {
       includeAcHealth: false,
       includeAssignees: false,
       includeTaskProgress: false,
+      includeLastActivity: false,
       // spec-521 (ac-5): the archive view is the one caller that asks for archived
       // rows; every other read passes false explicitly.
       includeArchived: false,
@@ -118,6 +119,7 @@ describe("GET /api/docs", () => {
       includeAcHealth: false,
       includeAssignees: false,
       includeTaskProgress: false,
+      includeLastActivity: false,
       // spec-521 (ac-5): the archive view is the one caller that asks for archived
       // rows; every other read passes false explicitly.
       includeArchived: false,
@@ -134,6 +136,7 @@ describe("GET /api/docs", () => {
       includeAcHealth: false,
       includeAssignees: false,
       includeTaskProgress: false,
+      includeLastActivity: false,
       // spec-521 (ac-5): the archive view is the one caller that asks for archived
       // rows; every other read passes false explicitly.
       includeArchived: false,
@@ -150,6 +153,7 @@ describe("GET /api/docs", () => {
       includeAcHealth: true,
       includeAssignees: false,
       includeTaskProgress: false,
+      includeLastActivity: false,
       // spec-521 (ac-5): the archive view is the one caller that asks for archived
       // rows; every other read passes false explicitly.
       includeArchived: false,
@@ -166,6 +170,7 @@ describe("GET /api/docs", () => {
       includeAcHealth: true,
       includeAssignees: false,
       includeTaskProgress: false,
+      includeLastActivity: false,
       // spec-521 (ac-5): the archive view is the one caller that asks for archived
       // rows; every other read passes false explicitly.
       includeArchived: false,
@@ -182,6 +187,7 @@ describe("GET /api/docs", () => {
       includeAcHealth: false,
       includeAssignees: true,
       includeTaskProgress: false,
+      includeLastActivity: false,
       includeArchived: false,
     });
   });

--- a/packages/server/src/routes/documents.ts
+++ b/packages/server/src/routes/documents.ts
@@ -149,6 +149,26 @@ function parseTagFilter(raw: string[] | undefined): ParsedTag[] | undefined {
   return strings.map(parseTagInput);
 }
 
+// spec-529 (ac-10): `?handles=spec-1,spec-2` — repeated params or CSV, flattened to
+// one list, mirroring parseTagFilter. Every entry is checked against the handle
+// grammar [per std-10 cl-4..cl-12]: type prefix mandatory, case-strict, positive
+// integer with no leading zeros. A malformed entry is DROPPED rather than 400-ing —
+// the caller here is a rendered document body, not a hand-written API call, and one
+// odd string in prose must not fail the whole page's resolution. Dropping it also
+// keeps a non-existent handle and an unreadable one indistinguishable [per std-7].
+const HANDLE_FILTER_GRAMMAR = /^(?:spec|doc|std)-[1-9][0-9]*$/;
+
+function parseHandleFilter(raw: string[] | undefined): string[] | undefined {
+  if (!raw || raw.length === 0) return undefined;
+  const handles = raw
+    .flatMap((s) => s.split(","))
+    .map((s) => s.trim())
+    .filter((s) => HANDLE_FILTER_GRAMMAR.test(s));
+  // An explicit `?handles=` that survives to nothing still means "these Specs" —
+  // listDocs filters to the empty set rather than falling back to the whole Memex.
+  return [...new Set(handles)];
+}
+
 // spec-418 t-3: the curation write routes (create / rename) accept EITHER a
 // `scope::value`/flat tag STRING (the `tag` field, parsed with the shared
 // parseTagInput so the boundary matches the picker's conventions) OR an already
@@ -186,6 +206,17 @@ docs.get("/", async (c) => {
   const includeAcHealth = includes.includes("acHealth");
   const includeAssignees = includes.includes("assignees");
   const includeTags = includes.includes("tags");
+  // spec-529 (ac-10): `taskProgress` is the pill's `4/8 tasks`. It rides the same
+  // opt-in `?include=` convention as acHealth so a caller that doesn't ask doesn't
+  // pay for the aggregation.
+  const includeTaskProgress = includes.includes("taskProgress");
+  // spec-529 (ac-10, ac-11): `?handles=spec-1,spec-2` — resolve exactly the Specs a
+  // document body mentions, in ONE request. Deliberately a filter on the EXISTING
+  // list route rather than a new endpoint (dec-2): the board card, the reference pill
+  // and any future consumer then read one server-side description of a Spec's status
+  // and cannot drift into reporting different numbers for the same Spec. The cap
+  // lives in listDocs, where the query is built.
+  const handleFilter = parseHandleFilter(c.req.queries("handles"));
   // spec-136 t-4: optional tag facet filter (repeated or CSV `?tags=`). Additive to
   // docType — the Specs view keeps passing its own docType, so it stays the source of
   // truth for what counts as a Spec. listDocs runs the indexed (scope,value) join.
@@ -202,7 +233,9 @@ docs.get("/", async (c) => {
     includeAcHealth,
     includeAssignees,
     includeArchived,
+    includeTaskProgress,
     ...(tagFilter ? { tags: tagFilter } : {}),
+    ...(handleFilter ? { handles: handleFilter } : {}),
   });
 
   // spec-136 t-4: when ?include=tags is requested, attach each doc's tags in ONE

--- a/packages/server/src/routes/documents.ts
+++ b/packages/server/src/routes/documents.ts
@@ -210,6 +210,8 @@ docs.get("/", async (c) => {
   // opt-in `?include=` convention as acHealth so a caller that doesn't ask doesn't
   // pay for the aggregation.
   const includeTaskProgress = includes.includes("taskProgress");
+  // spec-529 (ac-2): the card's "last activity" line.
+  const includeLastActivity = includes.includes("lastActivity");
   // spec-529 (ac-10, ac-11): `?handles=spec-1,spec-2` — resolve exactly the Specs a
   // document body mentions, in ONE request. Deliberately a filter on the EXISTING
   // list route rather than a new endpoint (dec-2): the board card, the reference pill
@@ -234,6 +236,7 @@ docs.get("/", async (c) => {
     includeAssignees,
     includeArchived,
     includeTaskProgress,
+    includeLastActivity,
     ...(tagFilter ? { tags: tagFilter } : {}),
     ...(handleFilter ? { handles: handleFilter } : {}),
   });

--- a/packages/server/src/routes/documents.ts
+++ b/packages/server/src/routes/documents.ts
@@ -206,7 +206,7 @@ docs.get("/", async (c) => {
   const includeAcHealth = includes.includes("acHealth");
   const includeAssignees = includes.includes("assignees");
   const includeTags = includes.includes("tags");
-  // spec-529 (ac-10): `taskProgress` is the pill's `4/8 tasks`. It rides the same
+  // spec-529 (ac-10): `taskProgress` feeds the reference card's task split. It rides the same
   // opt-in `?include=` convention as acHealth so a caller that doesn't ask doesn't
   // pay for the aggregation.
   const includeTaskProgress = includes.includes("taskProgress");

--- a/packages/server/src/services/activity-log.ts
+++ b/packages/server/src/services/activity-log.ts
@@ -98,7 +98,7 @@ export function mapEventToRow(event: ChangeEvent): ActivityLogInsert {
 // defect loudly: a structured error log + a process counter that metrics/tests
 // assert on. Reads (viewed/searched/assessed/called) legitimately may carry no
 // channel and are exempt; only state-changing actions are attribution-bearing.
-const ATTRIBUTION_BEARING_ACTIONS: ReadonlySet<ChangeEvent["action"]> = new Set([
+export const ATTRIBUTION_BEARING_ACTIONS: ReadonlySet<ChangeEvent["action"]> = new Set([
   "created",
   "updated",
   "deleted",

--- a/packages/server/src/services/documents.spec-529.integration.test.ts
+++ b/packages/server/src/services/documents.spec-529.integration.test.ts
@@ -9,9 +9,10 @@ import { describe, it, expect, afterAll, beforeAll } from "vitest";
 import { eq } from "drizzle-orm";
 import { tagAc } from "@memex-ai-ac/vitest";
 import { db } from "../db/connection.js";
-import { documents } from "../db/schema.js";
+import { documents, activityLog } from "../db/schema.js";
 import { createDocDraft, listDocs, MAX_HANDLE_FILTER } from "./documents.js";
 import { createTask, updateTaskStatus, listTasks } from "./tasks.js";
+import { archiveDoc } from "./documents.js";
 import { makeTestMemex } from "./test-helpers.js";
 
 const createdDocIds: string[] = [];
@@ -123,5 +124,78 @@ describe("listDocs includeTaskProgress (spec-529)", () => {
     expect(row.taskProgress?.notStarted).toBe(
       pageTasks.filter((t) => t.status === "not_started").length,
     );
+  });
+});
+
+// ── Review findings, pinned so they cannot come back ────────────────────────────
+
+describe("lastActivity reports CHANGES, and never who made them (spec-529)", () => {
+  // The activity sink does not run in this process, so both rows are written
+  // directly. That is deliberate: what changed here is the QUERY — which rows it
+  // selects and which columns it returns — and these tests target exactly that.
+  async function seedActivity(memexId: string, docId: string) {
+    await db.insert(activityLog).values([
+      {
+        memexId, briefId: docId, actorKind: "human", channel: "rest_ui",
+        entity: "document", action: "status_changed",
+        narrative: "moved to specify", actorName: "A Person",
+        createdAt: new Date("2026-08-10T10:00:00Z"),
+      },
+      {
+        // A READ, and the NEWEST row — so an unfiltered "latest" would pick it.
+        memexId, briefId: docId, actorKind: "human", channel: "rest_ui",
+        entity: "document", action: "viewed",
+        narrative: "viewing the spec", actorName: "A Reader",
+        createdAt: new Date("2026-08-12T10:00:00Z"),
+      },
+    ]);
+  }
+
+  it("skips `viewed` rows even when they are the most recent, so it is not a read receipt", async () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-529/acs/ac-2");
+    const m = await makeTestMemex();
+    const spec = await createDocDraft(m, "Watched spec", "purpose", "spec");
+    createdDocIds.push(spec.id);
+    await seedActivity(m, spec.id);
+
+    const [row] = await listDocs(m, { handles: [spec.handle], includeLastActivity: true });
+    expect(row.lastActivity).toBeDefined();
+    // The change, not the newer read.
+    expect(row.lastActivity?.narrative).toBe("moved to specify");
+    expect(row.lastActivity?.narrative).not.toMatch(/view/i);
+  });
+
+  it("returns no actor identity — this response is readable anonymously", async () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-529/acs/ac-3");
+    const m = await makeTestMemex();
+    const spec = await createDocDraft(m, "Changed spec", "purpose", "spec");
+    createdDocIds.push(spec.id);
+    await seedActivity(m, spec.id);
+
+    const [row] = await listDocs(m, { handles: [spec.handle], includeLastActivity: true });
+    expect(row.lastActivity).toBeDefined();
+    // routes/activity.ts drops actor fields for readers without write access
+    // because they carry PII. This projection must not reintroduce them.
+    expect(Object.keys(row.lastActivity ?? {}).sort()).toEqual(["at", "narrative"]);
+    expect(JSON.stringify(row.lastActivity)).not.toContain("A Person");
+  });
+});
+
+describe("an archived Spec still RESOLVES, so its banner can be shown (spec-529)", () => {
+  it("comes back when includeArchived is set, and is filtered out without it", async () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-529/acs/ac-2");
+    const m = await makeTestMemex();
+    const spec = await createDocDraft(m, "Archived spec", "purpose", "spec");
+    createdDocIds.push(spec.id);
+    await archiveDoc(m, spec.id, { channel: "rest_ui" }, "absorbed elsewhere");
+
+    // Without the flag the row is filtered out — which is what made the card's
+    // Archived banner unreachable: the handle resolved as absent and rendered as
+    // plain text, telling the reader nothing.
+    expect(await listDocs(m, { handles: [spec.handle] })).toEqual([]);
+
+    const [row] = await listDocs(m, { handles: [spec.handle], includeArchived: true });
+    expect(row?.handle).toBe(spec.handle);
+    expect(row?.archivedAt).not.toBeNull();
   });
 });

--- a/packages/server/src/services/documents.spec-529.integration.test.ts
+++ b/packages/server/src/services/documents.spec-529.integration.test.ts
@@ -1,0 +1,127 @@
+// spec-529 t-2 — the handle filter and the task-progress projection, against a real
+// database. The route test proves the wiring; this proves the query.
+//
+// The load-bearing claim is the LAST test: the pill's fraction and the Spec page's
+// own task list must be computed from one source. A pill reading `1/3` beside a page
+// reading `2/3` would discredit the feature more thoroughly than no pill at all.
+
+import { describe, it, expect, afterAll, beforeAll } from "vitest";
+import { eq } from "drizzle-orm";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { db } from "../db/connection.js";
+import { documents } from "../db/schema.js";
+import { createDocDraft, listDocs, MAX_HANDLE_FILTER } from "./documents.js";
+import { createTask, updateTaskStatus, listTasks } from "./tasks.js";
+import { makeTestMemex } from "./test-helpers.js";
+
+const createdDocIds: string[] = [];
+
+afterAll(async () => {
+  for (const id of createdDocIds) {
+    await db.delete(documents).where(eq(documents.id, id));
+  }
+});
+
+let memexId: string;
+let specA: { id: string; handle: string };
+let specB: { id: string; handle: string };
+let specC: { id: string; handle: string };
+
+beforeAll(async () => {
+  memexId = await makeTestMemex();
+  const a = await createDocDraft(memexId, "Referenced spec A", "purpose", "spec");
+  const b = await createDocDraft(memexId, "Referenced spec B", "purpose", "spec");
+  const c = await createDocDraft(memexId, "Unreferenced spec C", "purpose", "spec");
+  for (const d of [a, b, c]) createdDocIds.push(d.id);
+  specA = { id: a.id, handle: a.handle };
+  specB = { id: b.id, handle: b.handle };
+  specC = { id: c.id, handle: c.handle };
+
+  // Spec A: three tasks, one complete, one in progress, one untouched.
+  const t1 = await createTask(memexId, specA.id, "one", "d");
+  const t2 = await createTask(memexId, specA.id, "two", "d");
+  await createTask(memexId, specA.id, "three", "d");
+  await updateTaskStatus(memexId, t1.id, "complete");
+  await updateTaskStatus(memexId, t2.id, "in_progress");
+  // Spec B deliberately has NO tasks.
+});
+
+describe("listDocs handle filter (spec-529)", () => {
+  it("returns exactly the named Specs and nothing else", async () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-529/acs/ac-10");
+    const rows = await listDocs(memexId, { handles: [specA.handle, specB.handle] });
+    expect(rows.map((r) => r.handle).sort()).toEqual(
+      [specA.handle, specB.handle].sort(),
+    );
+    expect(rows.map((r) => r.handle)).not.toContain(specC.handle);
+  });
+
+  it("returns nothing for a handle that names nothing — the same answer an unreadable one gets", async () => {
+    // std-7: absent and forbidden must be indistinguishable from the outside.
+    const rows = await listDocs(memexId, { handles: ["spec-99999"] });
+    expect(rows).toEqual([]);
+  });
+
+  it("returns nothing for an empty handle set rather than the whole Memex", async () => {
+    const rows = await listDocs(memexId, { handles: [] });
+    expect(rows).toEqual([]);
+  });
+
+  it("caps an oversized handle set instead of issuing an unbounded query", async () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-529/acs/ac-11");
+    // Pad far past the cap, with the one real handle pushed beyond it. The result
+    // proves the tail was dropped rather than queried.
+    const padding = Array.from({ length: MAX_HANDLE_FILTER }, (_, i) => `spec-${90000 + i}`);
+    const rows = await listDocs(memexId, { handles: [...padding, specA.handle] });
+    expect(rows).toEqual([]);
+
+    // Inside the cap, the same handle resolves.
+    const within = await listDocs(memexId, { handles: [specA.handle, ...padding.slice(0, 5)] });
+    expect(within.map((r) => r.handle)).toEqual([specA.handle]);
+  });
+});
+
+describe("listDocs includeTaskProgress (spec-529)", () => {
+  it("splits tasks by status, and omits the field entirely for a Spec with none", async () => {
+    const rows = await listDocs(memexId, {
+      handles: [specA.handle, specB.handle],
+      includeTaskProgress: true,
+    });
+    const a = rows.find((r) => r.handle === specA.handle);
+    const b = rows.find((r) => r.handle === specB.handle);
+
+    expect(a?.taskProgress).toEqual({
+      total: 3,
+      complete: 1,
+      inProgress: 1,
+      notStarted: 1,
+    });
+    // Absence is the signal — the pill renders no fraction, never `0/0`.
+    expect(b?.taskProgress).toBeUndefined();
+  });
+
+  it("is off unless asked for", async () => {
+    const rows = await listDocs(memexId, { handles: [specA.handle] });
+    expect(rows[0]?.taskProgress).toBeUndefined();
+  });
+
+  it("agrees with the Spec page's own task list — one source, not two counts", async () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-529/acs/ac-10");
+    const [row] = await listDocs(memexId, {
+      handles: [specA.handle],
+      includeTaskProgress: true,
+    });
+    const pageTasks = await listTasks(memexId, specA.id);
+
+    expect(row.taskProgress?.total).toBe(pageTasks.length);
+    expect(row.taskProgress?.complete).toBe(
+      pageTasks.filter((t) => t.status === "complete").length,
+    );
+    expect(row.taskProgress?.inProgress).toBe(
+      pageTasks.filter((t) => t.status === "in_progress").length,
+    );
+    expect(row.taskProgress?.notStarted).toBe(
+      pageTasks.filter((t) => t.status === "not_started").length,
+    );
+  });
+});

--- a/packages/server/src/services/documents.ts
+++ b/packages/server/src/services/documents.ts
@@ -2,7 +2,7 @@ import { and, eq, ne, desc, count, isNull, inArray, or, exists, gt, sql, type SQ
 import { db } from "../db/connection.js";
 import { documents, docSections, docComments, decisions, tasks, acs, users, tags, documentTags } from "../db/schema.js";
 import type { Doc, DocSection, Decision } from "../db/schema.js";
-import type { DocSummary } from "../types/index.js";
+import type { DocSummary, TaskProgress } from "../types/index.js";
 import { NotFoundError, ValidationError } from "../types/errors.js";
 import { mutate, type ChangeKey, type Mutated, type RequestCtx } from "./mutate.js";
 import { resolveActorColumns } from "./actor.js";
@@ -397,6 +397,55 @@ export async function taskCountsByDoc(
   return new Map(rows.map((r) => [r.docId, Number(r.n)]));
 }
 
+/**
+ * spec-529 t-2 (ac-11): the ceiling on `?handles=`. A document body can name an
+ * unbounded number of handles, and the resolution request is driven by that body,
+ * so the cap is what keeps one page view from becoming one unbounded query. Sized
+ * far above any real document (the worked example names five) and far below
+ * anything that would strain the index.
+ */
+export const MAX_HANDLE_FILTER = 100;
+
+/**
+ * spec-529 t-2: per-doc task progress for the reference pill and its card.
+ *
+ * ONE grouped query over (docId, status) — the same `tasks` rows and the same
+ * `retiredAtVersion` restraint `taskCountsByDoc` uses, so the pill's fraction and
+ * the Spec page's own task list are computed from one source and cannot disagree
+ * for the same Spec (spec-529 dec-2). Docs with no tasks are absent from the map;
+ * absence means "no tasks", which the pill renders as no fraction at all rather
+ * than as 0/0.
+ */
+export async function taskProgressByDoc(
+  memexId: string,
+  docIds: string[],
+): Promise<Map<string, TaskProgress>> {
+  if (docIds.length === 0) return new Map();
+  const rows = await db
+    .select({ docId: tasks.docId, status: tasks.status, n: count() })
+    .from(tasks)
+    .where(
+      and(
+        eq(tasks.memexId, memexId),
+        inArray(tasks.docId, docIds),
+        isNull(tasks.retiredAtVersion),
+      ),
+    )
+    .groupBy(tasks.docId, tasks.status);
+
+  const out = new Map<string, TaskProgress>();
+  for (const r of rows) {
+    const n = Number(r.n);
+    const p = out.get(r.docId) ?? { total: 0, complete: 0, inProgress: 0, notStarted: 0 };
+    p.total += n;
+    if (r.status === "complete") p.complete += n;
+    else if (r.status === "in_progress") p.inProgress += n;
+    else p.notStarted += n;
+    out.set(r.docId, p);
+  }
+  return out;
+}
+
 export interface ListDocsOptions {
   docType?: string;
   // Default false — archived docs are hidden from the kanban. Set true to include them
@@ -417,6 +466,16 @@ export interface ListDocsOptions {
   // zero active ACs ALSO leave `acHealth` unset (absence-of-signal, b-66 Scope
   // AC-4) so the UI's "no commitments" branch trips naturally.
   includeAcHealth?: boolean;
+  // spec-529 t-2 (ac-10): restrict the result to these doc HANDLES. This is what
+  // lets a document view resolve every `spec-N` its body mentions in ONE request
+  // instead of a fetch per reference. Handles are per-memex [per std-10 cl-14], so
+  // the filter is naturally scoped by the memexId already in play — a handle from
+  // another Memex simply matches nothing, which is the same absent response an
+  // unreadable one gets [per std-7].
+  handles?: readonly string[];
+  // spec-529 t-2 (ac-10): attach `taskProgress` per Spec, from the same aggregation
+  // the Spec page reads. Off by default so callers that don't ask don't pay.
+  includeTaskProgress?: boolean;
   // spec-118 ac-18: when set, attach an `assignees` array per Spec so the board
   // can render assignee avatar(s) on each card (more prominent than the creator)
   // in one round-trip. Specs with no assignees leave `assignees` unset → the card
@@ -510,6 +569,16 @@ export async function listDocs(
   if (opts.excludeDemo) {
     const notDemo = or(isNull(documents.isDemo), ne(documents.isDemo, true));
     if (notDemo) conditions.push(notDemo);
+  }
+  // spec-529 t-2 (ac-11): the handle set is UNTRUSTED and unbounded — a body can
+  // name any number of handles. Cap it here rather than letting a pathological
+  // document turn one page view into an unbounded IN (...) query. An empty set
+  // after the cap still filters to nothing rather than silently listing the Memex.
+  if (opts.handles) {
+    const capped = opts.handles.slice(0, MAX_HANDLE_FILTER);
+    conditions.push(
+      capped.length > 0 ? inArray(documents.handle, capped as string[]) : sql`false`,
+    );
   }
   if (opts.statusIn && opts.statusIn.length > 0) {
     conditions.push(inArray(documents.status, opts.statusIn as string[]));
@@ -635,6 +704,20 @@ export async function listDocs(
         // the wire shape sparse means the same response works for legacy
         // clients that don't know about acHealth at all.
         if (h && h.totalActive > 0) s.acHealth = h;
+      }
+    }
+  }
+
+  if (opts.includeTaskProgress && summaries.length > 0) {
+    // Tasks are a Spec-only concept, so mirror the includeAcHealth restraint and
+    // filter to Spec docIds before aggregating. A Spec with no tasks is left with
+    // `taskProgress` unset — absence is the signal, exactly as it is for acHealth.
+    const specIds = summaries.filter((s) => s.docType === "spec").map((s) => s.id);
+    if (specIds.length > 0) {
+      const byDoc = await taskProgressByDoc(memexId, specIds);
+      for (const s of summaries) {
+        const p = byDoc.get(s.id);
+        if (p && p.total > 0) s.taskProgress = p;
       }
     }
   }

--- a/packages/server/src/services/documents.ts
+++ b/packages/server/src/services/documents.ts
@@ -1,8 +1,8 @@
 import { and, eq, ne, desc, count, isNull, inArray, or, exists, gt, sql, type SQL } from "drizzle-orm";
 import { db } from "../db/connection.js";
-import { documents, docSections, docComments, decisions, tasks, acs, users, tags, documentTags } from "../db/schema.js";
+import { documents, docSections, docComments, decisions, tasks, acs, users, tags, documentTags, activityLog } from "../db/schema.js";
 import type { Doc, DocSection, Decision } from "../db/schema.js";
-import type { DocSummary, TaskProgress } from "../types/index.js";
+import type { DocSummary, TaskProgress, LastActivity } from "../types/index.js";
 import { NotFoundError, ValidationError } from "../types/errors.js";
 import { mutate, type ChangeKey, type Mutated, type RequestCtx } from "./mutate.js";
 import { resolveActorColumns } from "./actor.js";
@@ -446,6 +446,49 @@ export async function taskProgressByDoc(
   return out;
 }
 
+/**
+ * spec-529 t-5: the most recent activity per Spec — WHEN it last changed and
+ * WHAT changed — for the reference card's "last activity" line.
+ *
+ * `documents` carries no general updated-at column, so a truthful answer has to
+ * come from the activity log itself. One `DISTINCT ON` over the existing
+ * `(brief_id, created_at)` index gives the newest row per Spec in a single pass;
+ * a Spec with no logged activity is absent from the map and the card omits the
+ * line rather than inventing one.
+ */
+export async function lastActivityByDoc(
+  memexId: string,
+  docIds: string[],
+): Promise<Map<string, LastActivity>> {
+  if (docIds.length === 0) return new Map();
+  const rows = await db
+    .selectDistinctOn([activityLog.briefId], {
+      docId: activityLog.briefId,
+      at: activityLog.createdAt,
+      narrative: activityLog.narrative,
+      actorName: activityLog.actorName,
+    })
+    .from(activityLog)
+    .where(
+      and(
+        eq(activityLog.memexId, memexId),
+        inArray(activityLog.briefId, docIds),
+      ),
+    )
+    .orderBy(activityLog.briefId, desc(activityLog.createdAt));
+
+  const out = new Map<string, LastActivity>();
+  for (const r of rows) {
+    if (!r.docId) continue;
+    out.set(r.docId, {
+      at: r.at,
+      narrative: r.narrative,
+      actorName: r.actorName ?? null,
+    });
+  }
+  return out;
+}
+
 export interface ListDocsOptions {
   docType?: string;
   // Default false — archived docs are hidden from the kanban. Set true to include them
@@ -476,6 +519,10 @@ export interface ListDocsOptions {
   // spec-529 t-2 (ac-10): attach `taskProgress` per Spec, from the same aggregation
   // the Spec page reads. Off by default so callers that don't ask don't pay.
   includeTaskProgress?: boolean;
+  // spec-529 t-5 (ac-2): attach `lastActivity` per Spec for the reference card's
+  // "last activity" line. Separate token from taskProgress so a caller that only
+  // needs the pill face doesn't pay for the activity-log pass.
+  includeLastActivity?: boolean;
   // spec-118 ac-18: when set, attach an `assignees` array per Spec so the board
   // can render assignee avatar(s) on each card (more prominent than the creator)
   // in one round-trip. Specs with no assignees leave `assignees` unset → the card
@@ -718,6 +765,17 @@ export async function listDocs(
       for (const s of summaries) {
         const p = byDoc.get(s.id);
         if (p && p.total > 0) s.taskProgress = p;
+      }
+    }
+  }
+
+  if (opts.includeLastActivity && summaries.length > 0) {
+    const specIds = summaries.filter((s) => s.docType === "spec").map((s) => s.id);
+    if (specIds.length > 0) {
+      const byDoc = await lastActivityByDoc(memexId, specIds);
+      for (const s of summaries) {
+        const a = byDoc.get(s.id);
+        if (a) s.lastActivity = a;
       }
     }
   }

--- a/packages/server/src/services/documents.ts
+++ b/packages/server/src/services/documents.ts
@@ -10,6 +10,7 @@ import { ARCHIVE_REASON_MAX_LENGTH } from "./archived-docs.js";
 import { isUuid } from "./shared/identifiers.js";
 import { withSeqRetry } from "./shared/sequence.js";
 import { docAttribution } from "./shared/doc-attribution.js";
+import { ATTRIBUTION_BEARING_ACTIONS } from "./activity-log.js";
 import { embedAndStoreSection, embedAndStoreDecision } from "./memex-embeddings.js";
 import { aggregateAcHealthForBriefs } from "./acs.js";
 import { maybeAutoResolveIssuesForPromotedDoc } from "./issues.js";
@@ -447,8 +448,21 @@ export async function taskProgressByDoc(
 }
 
 /**
- * spec-529 t-5: the most recent activity per Spec — WHEN it last changed and
- * WHAT changed — for the reference card's "last activity" line.
+ * spec-529 t-5: the most recent CHANGE per Spec — WHEN it last changed and WHAT
+ * changed — for the reference card's "last activity" line.
+ *
+ * Two things this deliberately does NOT do, both found in review:
+ *
+ * 1. It filters to attribution-bearing actions. The activity sink persists EVERY
+ *    change event, and that includes the `viewed` events emitted on each human
+ *    page open — so an unfiltered "latest row" reports that somebody LOOKED at the
+ *    Spec, not that anything changed. It would also turn a hover into a read
+ *    receipt, telling the reader who opened what and when.
+ * 2. It returns no actor identity. This endpoint answers anonymous readers on a
+ *    public Memex, and `routes/activity.ts` already drops actor fields for anyone
+ *    without write access precisely because they carry PII. A name on the card
+ *    would reintroduce, on a different route, the leak that projection exists to
+ *    prevent.
  *
  * `documents` carries no general updated-at column, so a truthful answer has to
  * come from the activity log itself. One `DISTINCT ON` over the existing
@@ -466,13 +480,13 @@ export async function lastActivityByDoc(
       docId: activityLog.briefId,
       at: activityLog.createdAt,
       narrative: activityLog.narrative,
-      actorName: activityLog.actorName,
     })
     .from(activityLog)
     .where(
       and(
         eq(activityLog.memexId, memexId),
         inArray(activityLog.briefId, docIds),
+        inArray(activityLog.action, [...ATTRIBUTION_BEARING_ACTIONS]),
       ),
     )
     .orderBy(activityLog.briefId, desc(activityLog.createdAt));
@@ -480,11 +494,7 @@ export async function lastActivityByDoc(
   const out = new Map<string, LastActivity>();
   for (const r of rows) {
     if (!r.docId) continue;
-    out.set(r.docId, {
-      at: r.at,
-      narrative: r.narrative,
-      actorName: r.actorName ?? null,
-    });
+    out.set(r.docId, { at: r.at, narrative: r.narrative });
   }
   return out;
 }

--- a/packages/server/src/types/index.ts
+++ b/packages/server/src/types/index.ts
@@ -30,6 +30,18 @@ export interface DocSummaryAssignee {
   email: string | null;
 }
 
+/**
+ * spec-529: the task roll-up behind a reference pill's `4/8 tasks` and its
+ * card's split. Derived by `taskProgressByDoc` from the same rows the Spec's
+ * own task list reads.
+ */
+export interface TaskProgress {
+  total: number;
+  complete: number;
+  inProgress: number;
+  notStarted: number;
+}
+
 export interface DocSummary {
   id: string;
   memexId: string;
@@ -91,6 +103,13 @@ export interface DocSummary {
   // Scope AC-3). Specs with zero active ACs get the field OMITTED (absence-of-signal,
   // b-66 Scope AC-4) so the UI's "no commitments" branch trips naturally.
   acHealth?: AcHealth;
+  /**
+   * spec-529 (ac-10): per-Spec task progress, populated only when listDocs is
+   * called with `includeTaskProgress`. Absent when the Spec has no tasks —
+   * absence is the signal (the pill renders no fraction rather than `0/0`),
+   * matching how `acHealth` treats a Spec with no commitments.
+   */
+  taskProgress?: TaskProgress;
   // Set when ?include=assignees is requested (spec-118 ac-18). The Spec's current
   // assignee(s); OMITTED when the Spec has no assignees so the card's "Unassigned"
   // branch trips. Independent of role — an assignee is not necessarily an editor.

--- a/packages/server/src/types/index.ts
+++ b/packages/server/src/types/index.ts
@@ -31,9 +31,10 @@ export interface DocSummaryAssignee {
 }
 
 /**
- * spec-529: the task roll-up behind a reference pill's `4/8 tasks` and its
- * card's split. Derived by `taskProgressByDoc` from the same rows the Spec's
- * own task list reads.
+ * spec-529: the task roll-up the reference CARD shows as its task split (the
+ * pill face carries only the handle and a phase chip). Derived by
+ * `taskProgressByDoc` from the same rows the Spec's own task list reads, so the
+ * two can never disagree for one Spec.
  */
 export interface TaskProgress {
   total: number;
@@ -49,7 +50,6 @@ export interface TaskProgress {
 export interface LastActivity {
   at: Date;
   narrative: string;
-  actorName: string | null;
 }
 
 export interface DocSummary {

--- a/packages/server/src/types/index.ts
+++ b/packages/server/src/types/index.ts
@@ -42,6 +42,16 @@ export interface TaskProgress {
   notStarted: number;
 }
 
+/**
+ * spec-529: WHEN a Spec last changed and WHAT changed, read from the activity log
+ * because `documents` carries no general updated-at column.
+ */
+export interface LastActivity {
+  at: Date;
+  narrative: string;
+  actorName: string | null;
+}
+
 export interface DocSummary {
   id: string;
   memexId: string;
@@ -110,6 +120,11 @@ export interface DocSummary {
    * matching how `acHealth` treats a Spec with no commitments.
    */
   taskProgress?: TaskProgress;
+  /**
+   * spec-529 (ac-2): the Spec's most recent logged activity, populated only under
+   * `includeLastActivity`. Absent when nothing has been logged against it.
+   */
+  lastActivity?: LastActivity;
   // Set when ?include=assignees is requested (spec-118 ac-18). The Spec's current
   // assignee(s); OMITTED when the Spec has no assignees so the card's "Unassigned"
   // branch trips. Independent of role — an assignee is not necessarily an editor.

--- a/packages/ui/e2e/journey-68-spec-529-reference-pills.spec.ts
+++ b/packages/ui/e2e/journey-68-spec-529-reference-pills.spec.ts
@@ -1,0 +1,127 @@
+import { test, expect, tenantPath } from "./helpers/index.js";
+import { seedOrgTenant, seedSpec, seedSection, setDocStatus } from "./helpers/retained.js";
+import { installAcEmission } from "./helpers/emit-ac.js";
+
+// spec-529 t-7 — the PR-gate journey (std-28) for reference pills.
+//
+// The shape that matters is the LAST step. A journey that stopped at "a pill
+// appeared" would pass just as happily over a hardcoded string, and the entire
+// value of this Spec is that the number is LIVE rather than copied — it exists
+// because a hand-maintained status table beside a reference goes stale within the
+// hour and no reader can tell. So the journey changes the referenced Spec's phase
+// through the real service and comes back to watch the pill follow.
+//
+// It also pins the two states that must NOT become pills: a handle naming nothing,
+// and a handle inside a code span.
+
+const SPEC = "mindset-prod/memex-building-itself/specs/spec-529";
+const AC_PILL = `${SPEC}/acs/ac-1`;
+const AC_CARD = `${SPEC}/acs/ac-2`;
+const AC_UNRESOLVED = `${SPEC}/acs/ac-3`;
+
+const T1 =
+  "a bare spec handle in a document body renders as a pill carrying live phase, opens a card, and follows the referenced Spec when it moves";
+const T2 = "a handle that names nothing, and one inside a code span, stay plain text";
+
+installAcEmission(test, import.meta.url, {
+  [T1]: [AC_PILL, AC_CARD],
+  [T2]: [AC_UNRESOLVED],
+});
+
+test(T1, async ({ page, resources }) => {
+  const slug = resources.slug("j68a");
+  const tenant = await seedOrgTenant({ slug });
+
+  // The Spec that gets REFERENCED.
+  const referenced = await seedSpec({
+    memexId: tenant.memexId,
+    title: "The board becomes reliable and legible again",
+    purpose: "The Spec another document points at.",
+  });
+
+  // The document that POINTS at it, writing the handle bare in its prose exactly as
+  // an author (or a coding agent) does unprompted.
+  const host = await seedSpec({
+    memexId: tenant.memexId,
+    title: "Where the observability work stands",
+    purpose: "A document that refers to other Specs.",
+  });
+  await seedSection({
+    memexId: tenant.memexId,
+    docId: host.docId,
+    title: "Specs that exist",
+    content: `The board work lands in ${referenced.handle} this week.`,
+  });
+
+  const hostUrl = tenantPath(tenant.namespaceSlug, tenant.memexSlug, `/specs/${host.handle}`);
+  await page.goto(hostUrl);
+
+  // ── 1) The bare handle became a pill, carrying the referenced Spec's phase. ──
+  const pill = page.getByTestId("spec-ref-pill").filter({ hasText: referenced.handle });
+  await expect(pill).toBeVisible({ timeout: 15_000 });
+  await expect(pill).toContainText("draft");
+
+  // ── 2) The card tells the whole story, and the title is on IT, not the pill. ──
+  await expect(pill).not.toContainText("The board becomes reliable");
+  await pill.focus();
+  const card = page.getByTestId("spec-ref-card");
+  await expect(card).toBeVisible();
+  await expect(card).toContainText("The board becomes reliable and legible again");
+  // A Spec with no commitments reads as having none — never as 0% complete.
+  await expect(card.getByTestId("spec-ref-acs")).toContainText("No acceptance criteria yet");
+
+  // ── 3) The pill is a link into the referenced Spec. ─────────────────────────
+  await expect(pill).toHaveAttribute(
+    "href",
+    tenantPath(tenant.namespaceSlug, tenant.memexSlug, `/specs/${referenced.handle}`),
+  );
+
+  // ── 4) THE POINT: move the referenced Spec, and the pill follows. ───────────
+  // Through the real updateDocStatus service, so this is a genuine state change
+  // rather than a fixture rewrite.
+  await setDocStatus({
+    memexId: tenant.memexId,
+    docId: referenced.docId,
+    status: "build",
+  });
+
+  await page.goto(hostUrl);
+  const movedPill = page.getByTestId("spec-ref-pill").filter({ hasText: referenced.handle });
+  await expect(movedPill).toBeVisible({ timeout: 15_000 });
+  // The number on the page changed because the Spec changed — nothing was edited
+  // in the document that mentions it.
+  await expect(movedPill).toContainText("build");
+  await expect(movedPill).not.toContainText("draft");
+});
+
+test(T2, async ({ page, resources }) => {
+  const slug = resources.slug("j68b");
+  const tenant = await seedOrgTenant({ slug });
+
+  const host = await seedSpec({
+    memexId: tenant.memexId,
+    title: "A document with handles that must stay text",
+    purpose: "Pins the two non-pill states.",
+  });
+  await seedSection({
+    memexId: tenant.memexId,
+    docId: host.docId,
+    title: "Handles that are not references",
+    // spec-99999 exists nowhere in this tenant; the second is inside a code span.
+    content:
+      "Nothing here is spec-99999, and the literal `spec-12345` is a code sample.",
+  });
+
+  await page.goto(
+    tenantPath(tenant.namespaceSlug, tenant.memexSlug, `/specs/${host.handle}`),
+  );
+  await expect(page.getByText(/Handles that are not references/)).toBeVisible({
+    timeout: 15_000,
+  });
+
+  // Neither handle became a pill: an unreadable Spec and a non-existent one must be
+  // indistinguishable [per std-7], and a code sample renders verbatim.
+  await expect(page.getByTestId("spec-ref-pill")).toHaveCount(0);
+  await expect(page.getByText("spec-99999")).toBeVisible();
+  await expect(page.locator("code", { hasText: "spec-12345" })).toBeVisible();
+});

--- a/packages/ui/e2e/journey-68-spec-529-reference-pills.spec.ts
+++ b/packages/ui/e2e/journey-68-spec-529-reference-pills.spec.ts
@@ -73,7 +73,9 @@ test(T1, async ({ page, resources }) => {
   // ── 3) The pill is a link into the referenced Spec. ─────────────────────────
   await expect(pill).toHaveAttribute(
     "href",
-    tenantPath(tenant.namespaceSlug, tenant.memexSlug, `/specs/${referenced.handle}`),
+    new URL(
+      tenantPath(tenant.namespaceSlug, tenant.memexSlug, `/specs/${referenced.handle}`),
+    ).pathname,
   );
 
   // ── 4) THE POINT: move the referenced Spec, and the pill follows. ───────────
@@ -115,13 +117,17 @@ test(T2, async ({ page, resources }) => {
   await page.goto(
     tenantPath(tenant.namespaceSlug, tenant.memexSlug, `/specs/${host.handle}`),
   );
-  await expect(page.getByText(/Handles that are not references/)).toBeVisible({
-    timeout: 15_000,
-  });
+  await expect(
+    page.getByRole("heading", { name: /Handles that are not references/ }),
+  ).toBeVisible({ timeout: 15_000 });
 
   // Neither handle became a pill: an unreadable Spec and a non-existent one must be
   // indistinguishable [per std-7], and a code sample renders verbatim.
   await expect(page.getByTestId("spec-ref-pill")).toHaveCount(0);
-  await expect(page.getByText("spec-99999")).toBeVisible();
-  await expect(page.locator("code", { hasText: "spec-12345" })).toBeVisible();
+  // The seeded section, not the Spec's Overview — `.first()` is the Overview.
+  const body = page
+    .getByTestId("section-card")
+    .filter({ hasText: "Handles that are not references" });
+  await expect(body).toContainText("spec-99999");
+  await expect(body.locator("code", { hasText: "spec-12345" })).toBeVisible();
 });

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -712,11 +712,14 @@ function FlatShell({ children }: { children: React.ReactNode }) {
   // spec-507: the fourth and quietest spec-444 gate lived here — it walled deep links
   // to flat routes (/settings/*, /org) too. Removed with the other three.
   return (
+    // Flat routes are caller-scoped, not tenant-scoped, so there is no tenant to
+    // key on — and no document body here to carry a reference. The provider stays
+    // for uniformity and is inert until something registers a handle.
     <SpecRefStatusProvider>
       <ChatProvider>
-      <OrgConsentDialog />
-      <AppShell>{children}</AppShell>
-    </ChatProvider>
+        <OrgConsentDialog />
+        <AppShell>{children}</AppShell>
+      </ChatProvider>
     </SpecRefStatusProvider>
   );
 }

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1,13 +1,13 @@
+import { Fragment, Suspense, lazy, useState, useEffect, useRef } from "react";
 import {
-  Fragment,
-  Suspense,
-  lazy,
-  useState,
-  useEffect,
-  useRef,
-} from 'react';
-import { Routes, Route, useLocation, useParams, Navigate, Outlet } from 'react-router-dom';
-import { emailPreviewEnabled } from './utils/devTools';
+  Routes,
+  Route,
+  useLocation,
+  useParams,
+  Navigate,
+  Outlet,
+} from "react-router-dom";
+import { emailPreviewEnabled } from "./utils/devTools";
 // spec-351: route-level code-splitting. Every top-level routed page is loaded
 // as its own lazy chunk so the entry bundle no longer eagerly pulls all ~35
 // page surfaces (and their heavy transitive deps — nivo charts, pixi, the
@@ -17,24 +17,42 @@ import { emailPreviewEnabled } from './utils/devTools';
 // and the VerifyEmailGate that several layouts render inline)
 // stay eagerly imported below — splitting them would only add Suspense
 // boundaries on the critical path with no payload win.
-const Pulse = lazy(() => import('./pages/Pulse').then((m) => ({ default: m.Pulse })));
+const Pulse = lazy(() =>
+  import("./pages/Pulse").then((m) => ({ default: m.Pulse })),
+);
 // spec-458 (PROTOTYPE) — the public live proof-of-life page. Fully public
 // (rendered outside AuthProvider below, the /share pattern) and lazy so its
 // world-map asset never rides the authenticated bundles.
-const LivePage = lazy(() => import('./pages/live/LivePage').then((m) => ({ default: m.LivePage })));
-const Insights = lazy(() => import('./pages/Insights').then((m) => ({ default: m.Insights })));
-const QaReports = lazy(() => import('./pages/QaReports').then((m) => ({ default: m.QaReports })));
-const Decisions = lazy(() => import('./pages/Decisions').then((m) => ({ default: m.Decisions })));
-const SpecList = lazy(() => import('./pages/SpecList').then((m) => ({ default: m.SpecList })));
+const LivePage = lazy(() =>
+  import("./pages/live/LivePage").then((m) => ({ default: m.LivePage })),
+);
+const Insights = lazy(() =>
+  import("./pages/Insights").then((m) => ({ default: m.Insights })),
+);
+const QaReports = lazy(() =>
+  import("./pages/QaReports").then((m) => ({ default: m.QaReports })),
+);
+const Decisions = lazy(() =>
+  import("./pages/Decisions").then((m) => ({ default: m.Decisions })),
+);
+const SpecList = lazy(() =>
+  import("./pages/SpecList").then((m) => ({ default: m.SpecList })),
+);
 // spec-521 t-4 (ac-5): the archive view — a destination reached from the board, not a
 // column on it, because archived work should be out of the way.
-const SpecArchive = lazy(() => import('./pages/SpecArchive').then((m) => ({ default: m.SpecArchive })));
-const IssuesList = lazy(() => import('./pages/IssuesList').then((m) => ({ default: m.IssuesList })));
+const SpecArchive = lazy(() =>
+  import("./pages/SpecArchive").then((m) => ({ default: m.SpecArchive })),
+);
+const IssuesList = lazy(() =>
+  import("./pages/IssuesList").then((m) => ({ default: m.IssuesList })),
+);
 const NamespaceHome = lazy(() =>
-  import('./pages/NamespaceHome').then((m) => ({ default: m.NamespaceHome })),
+  import("./pages/NamespaceHome").then((m) => ({ default: m.NamespaceHome })),
 );
 const NamespaceSettings = lazy(() =>
-  import('./pages/NamespaceSettings').then((m) => ({ default: m.NamespaceSettings })),
+  import("./pages/NamespaceSettings").then((m) => ({
+    default: m.NamespaceSettings,
+  })),
 );
 // The global Home Canvas (flat /home onboarding tracker) is PARKED for now — the
 // per-memex Brain (the knowledge-graph landing) replaces it as the default surface.
@@ -42,112 +60,162 @@ const NamespaceSettings = lazy(() =>
 // const HomeCanvas = lazy(() => import('./pages/HomeCanvas').then((m) => ({ default: m.HomeCanvas })));
 // spec-502: the onboarding wizard (name → console demo → connect the agent →
 // land populated). Reached from the Explore companion's "Create your own Memex".
-const Wizard = lazy(() => import('./onboarding/Wizard').then((m) => ({ default: m.Wizard })));
-const StandardList = lazy(() =>
-  import('./pages/StandardList').then((m) => ({ default: m.StandardList })),
+const Wizard = lazy(() =>
+  import("./onboarding/Wizard").then((m) => ({ default: m.Wizard })),
 );
-const Standard = lazy(() => import('./pages/Standard').then((m) => ({ default: m.Standard })));
+const StandardList = lazy(() =>
+  import("./pages/StandardList").then((m) => ({ default: m.StandardList })),
+);
+const Standard = lazy(() =>
+  import("./pages/Standard").then((m) => ({ default: m.Standard })),
+);
 // spec-498 — Brain: the whole-vault knowledge graph (facets/standards/specs/decisions).
-const Brain = lazy(() => import('./pages/Brain').then((m) => ({ default: m.Brain })));
+const Brain = lazy(() =>
+  import("./pages/Brain").then((m) => ({ default: m.Brain })),
+);
 // The surface the tenant `/home` redirect forwards to — the single knob for "the
 // default landing". Today it's the Trails route; change this one string to
 // re-point every default landing (nothing else references the surface directly).
-const DEFAULT_TENANT_SURFACE = 'trails';
+const DEFAULT_TENANT_SURFACE = "trails";
 // spec-300 t-6 — the in-app Skills surface (list + detail).
-const SkillList = lazy(() => import('./pages/SkillList').then((m) => ({ default: m.SkillList })));
-const Skill = lazy(() => import('./pages/Skill').then((m) => ({ default: m.Skill })));
+const SkillList = lazy(() =>
+  import("./pages/SkillList").then((m) => ({ default: m.SkillList })),
+);
+const Skill = lazy(() =>
+  import("./pages/Skill").then((m) => ({ default: m.Skill })),
+);
 // spec-226 t-6 — internal email-preview gallery (gated off prod, see emailPreviewEnabled).
 const EmailPreview = lazy(() =>
-  import('./pages/EmailPreview').then((m) => ({ default: m.EmailPreview })),
+  import("./pages/EmailPreview").then((m) => ({ default: m.EmailPreview })),
 );
-const DriftInbox = lazy(() => import('./pages/DriftInbox').then((m) => ({ default: m.DriftInbox })));
+const DriftInbox = lazy(() =>
+  import("./pages/DriftInbox").then((m) => ({ default: m.DriftInbox })),
+);
 const DocumentList = lazy(() =>
-  import('./pages/DocumentList').then((m) => ({ default: m.DocumentList })),
+  import("./pages/DocumentList").then((m) => ({ default: m.DocumentList })),
 );
 const DocDocument = lazy(() =>
-  import('./pages/DocDocument').then((m) => ({ default: m.DocDocument })),
+  import("./pages/DocDocument").then((m) => ({ default: m.DocDocument })),
 );
-const InstallAuth = lazy(() => import('./pages/InstallAuth').then((m) => ({ default: m.InstallAuth })));
+const InstallAuth = lazy(() =>
+  import("./pages/InstallAuth").then((m) => ({ default: m.InstallAuth })),
+);
 const OauthAuthorize = lazy(() =>
-  import('./pages/OauthAuthorize').then((m) => ({ default: m.OauthAuthorize })),
+  import("./pages/OauthAuthorize").then((m) => ({ default: m.OauthAuthorize })),
 );
 // spec-141 dec-3: integrations consolidated into one open-core page.
 // /settings/tokens, /installation and /install now redirect here.
 const SettingsIntegrations = lazy(() =>
-  import('./pages/SettingsIntegrations').then((m) => ({ default: m.SettingsIntegrations })),
+  import("./pages/SettingsIntegrations").then((m) => ({
+    default: m.SettingsIntegrations,
+  })),
 );
-const Onboarding = lazy(() => import('./pages/Onboarding').then((m) => ({ default: m.Onboarding })));
+const Onboarding = lazy(() =>
+  import("./pages/Onboarding").then((m) => ({ default: m.Onboarding })),
+);
 const WelcomePage = lazy(() =>
-  import('./pages/WelcomePage').then((m) => ({ default: m.WelcomePage })),
+  import("./pages/WelcomePage").then((m) => ({ default: m.WelcomePage })),
 );
 const InviteAccept = lazy(() =>
-  import('./pages/InviteAccept').then((m) => ({ default: m.InviteAccept })),
+  import("./pages/InviteAccept").then((m) => ({ default: m.InviteAccept })),
 );
 const OrgConfiguration = lazy(() =>
-  import('./pages/OrgConfiguration').then((m) => ({ default: m.OrgConfiguration })),
+  import("./pages/OrgConfiguration").then((m) => ({
+    default: m.OrgConfiguration,
+  })),
 );
 const ScaffoldInspect = lazy(() =>
-  import('./pages/ScaffoldInspect').then((m) => ({ default: m.ScaffoldInspect })),
+  import("./pages/ScaffoldInspect").then((m) => ({
+    default: m.ScaffoldInspect,
+  })),
 );
 const MemexSettings = lazy(() =>
-  import('./pages/MemexSettings').then((m) => ({ default: m.MemexSettings })),
+  import("./pages/MemexSettings").then((m) => ({ default: m.MemexSettings })),
 );
-const MemexKeys = lazy(() => import('./pages/MemexKeys').then((m) => ({ default: m.MemexKeys })));
+const MemexKeys = lazy(() =>
+  import("./pages/MemexKeys").then((m) => ({ default: m.MemexKeys })),
+);
 // spec-418 t-5 — the Manage-tags surface (tag catalogue admin). Renders in the
 // normal AppShell sidebar layout (NOT the doc-page chrome) — see the AppShell
 // guard that excludes the literal `tags` segment from the specs/:id doc match.
-const ManageTags = lazy(() => import('./pages/ManageTags').then((m) => ({ default: m.ManageTags })));
+const ManageTags = lazy(() =>
+  import("./pages/ManageTags").then((m) => ({ default: m.ManageTags })),
+);
 const UpgradePlanSelect = lazy(() =>
-  import('./pages/upgrade/UpgradePlanSelect').then((m) => ({ default: m.UpgradePlanSelect })),
+  import("./pages/upgrade/UpgradePlanSelect").then((m) => ({
+    default: m.UpgradePlanSelect,
+  })),
 );
 const UpgradeSeats = lazy(() =>
-  import('./pages/upgrade/UpgradeSeats').then((m) => ({ default: m.UpgradeSeats })),
+  import("./pages/upgrade/UpgradeSeats").then((m) => ({
+    default: m.UpgradeSeats,
+  })),
 );
 const UpgradeConfirmation = lazy(() =>
-  import('./pages/upgrade/UpgradeConfirmation').then((m) => ({ default: m.UpgradeConfirmation })),
+  import("./pages/upgrade/UpgradeConfirmation").then((m) => ({
+    default: m.UpgradeConfirmation,
+  })),
 );
 const VerifyDomain = lazy(() =>
-  import('./pages/VerifyDomain').then((m) => ({ default: m.VerifyDomain })),
+  import("./pages/VerifyDomain").then((m) => ({ default: m.VerifyDomain })),
 );
 const SharedDocument = lazy(() =>
-  import('./pages/SharedDocument').then((m) => ({ default: m.SharedDocument })),
+  import("./pages/SharedDocument").then((m) => ({ default: m.SharedDocument })),
 );
-const Backstage = lazy(() => import('./pages/Backstage').then((m) => ({ default: m.Backstage })));
+const Backstage = lazy(() =>
+  import("./pages/Backstage").then((m) => ({ default: m.Backstage })),
+);
 const BackstageExperiments = lazy(() =>
-  import('./pages/BackstageExperiments').then((m) => ({ default: m.BackstageExperiments })),
+  import("./pages/BackstageExperiments").then((m) => ({
+    default: m.BackstageExperiments,
+  })),
 );
-const VerifyEmail = lazy(() => import('./pages/VerifyEmail').then((m) => ({ default: m.VerifyEmail })));
+const VerifyEmail = lazy(() =>
+  import("./pages/VerifyEmail").then((m) => ({ default: m.VerifyEmail })),
+);
 const MagicLinkConsume = lazy(() =>
-  import('./pages/MagicLinkConsume').then((m) => ({ default: m.MagicLinkConsume })),
+  import("./pages/MagicLinkConsume").then((m) => ({
+    default: m.MagicLinkConsume,
+  })),
 );
 const ResetPassword = lazy(() =>
-  import('./pages/ResetPassword').then((m) => ({ default: m.ResetPassword })),
+  import("./pages/ResetPassword").then((m) => ({ default: m.ResetPassword })),
 );
 // VerifyEmailGate stays eager — it is rendered inline by TenantLayout,
 // FlatShell, and RootRedirect (not as a routed element), so it sits on the
 // critical path for unverified users and is small.
-import { VerifyEmailGate } from './pages/VerifyEmailGate';
-import { AuthProvider, RequireAuth, useAuth, computeReturnLanding } from './components/AuthContext';
-import { recordLastMemex } from './utils/lastMemex';
-import { ThemeProvider } from './components/ThemeContext';
-import { ChatProvider } from './components/ChatContext';
-import { AppShell } from './components/AppShell';
-import { ExploreCompanionMount } from './onboarding/ExploreCompanionMount';
-import { DocumentShell } from './components/DocumentShell';
-import { OrgConsentDialog } from './components/OrgConsentDialog';
-import { DesktopMcpStatusSync } from './components/DesktopMcpStatusSync';
-import { parseTenantFromPathname, tenantPathFor } from './utils/tenantUrl';
-import { isOnboardingWizardEnabled } from './onboarding/flag';
-import { isFeatureHidden } from './utils/featureFlags';
-import { probePublicMemex, type PublicMemexProbe } from './api/client';
-import { PublicMemexProvider } from './components/PublicMemexContext';
-import { useTrackRouteChange, useTelemetry, trackAnonymous } from './hooks/useTelemetry';
-import { useStaleTenantForward } from './hooks/useStaleTenantForward';
-import { useShouldLandOnHome, isMcpConnectedCached } from './journeys/landing';
-import { tenantBase } from './api/http';
-import { SearchProvider } from './components/SearchContext';
-import { WhatsNewRibbonConnected } from './components/whats-new/WhatsNewRibbonConnected';
-import { WhatsNewProvider } from './components/whats-new/WhatsNewContext';
+import { VerifyEmailGate } from "./pages/VerifyEmailGate";
+import {
+  AuthProvider,
+  RequireAuth,
+  useAuth,
+  computeReturnLanding,
+} from "./components/AuthContext";
+import { recordLastMemex } from "./utils/lastMemex";
+import { ThemeProvider } from "./components/ThemeContext";
+import { ChatProvider } from "./components/ChatContext";
+import { SpecRefStatusProvider } from "./components/specRef/SpecRefStatusProvider";
+import { AppShell } from "./components/AppShell";
+import { ExploreCompanionMount } from "./onboarding/ExploreCompanionMount";
+import { DocumentShell } from "./components/DocumentShell";
+import { OrgConsentDialog } from "./components/OrgConsentDialog";
+import { DesktopMcpStatusSync } from "./components/DesktopMcpStatusSync";
+import { parseTenantFromPathname, tenantPathFor } from "./utils/tenantUrl";
+import { isOnboardingWizardEnabled } from "./onboarding/flag";
+import { isFeatureHidden } from "./utils/featureFlags";
+import { probePublicMemex, type PublicMemexProbe } from "./api/client";
+import { PublicMemexProvider } from "./components/PublicMemexContext";
+import {
+  useTrackRouteChange,
+  useTelemetry,
+  trackAnonymous,
+} from "./hooks/useTelemetry";
+import { useStaleTenantForward } from "./hooks/useStaleTenantForward";
+import { useShouldLandOnHome, isMcpConnectedCached } from "./journeys/landing";
+import { tenantBase } from "./api/http";
+import { SearchProvider } from "./components/SearchContext";
+import { WhatsNewRibbonConnected } from "./components/whats-new/WhatsNewRibbonConnected";
+import { WhatsNewProvider } from "./components/whats-new/WhatsNewContext";
 
 declare const __BUILD_TIME__: string;
 
@@ -175,7 +243,7 @@ declare const __BUILD_TIME__: string;
 // `memex` carries the probed Memex (name + visibility) on a 'yes'. `enabled` is
 // false for authenticated users, so the hook is always called (rules of hooks)
 // but only fetches for anonymous visitors.
-type ReadableState = 'loading' | 'yes' | 'no';
+type ReadableState = "loading" | "yes" | "no";
 function usePublicMemexProbe(
   namespace: string | undefined,
   memex: string | undefined,
@@ -184,17 +252,21 @@ function usePublicMemexProbe(
   const [result, setResult] = useState<{
     state: ReadableState;
     memex: PublicMemexProbe | null;
-  }>({ state: 'loading', memex: null });
+  }>({ state: "loading", memex: null });
   useEffect(() => {
     if (!enabled || !namespace || !memex) {
-      setResult({ state: 'loading', memex: null });
+      setResult({ state: "loading", memex: null });
       return;
     }
     let cancelled = false;
-    setResult({ state: 'loading', memex: null });
+    setResult({ state: "loading", memex: null });
     probePublicMemex(namespace, memex).then((probed) => {
       if (!cancelled) {
-        setResult(probed ? { state: 'yes', memex: probed } : { state: 'no', memex: null });
+        setResult(
+          probed
+            ? { state: "yes", memex: probed }
+            : { state: "no", memex: null },
+        );
       }
     });
     return () => {
@@ -205,7 +277,10 @@ function usePublicMemexProbe(
 }
 
 function TenantLayout() {
-  const { namespace, memex } = useParams<{ namespace: string; memex: string }>();
+  const { namespace, memex } = useParams<{
+    namespace: string;
+    memex: string;
+  }>();
   const { session, isAuthenticated } = useAuth();
   const location = useLocation();
   const anonymous = !isAuthenticated && !session;
@@ -234,7 +309,9 @@ function TenantLayout() {
   // session is still null). Reused below for the authed bounce.
   const matchedMembership =
     session?.memberships.find(
-      (m) => m.slug === namespace && (m.memexSlug === memex || (!m.memexSlug && memex === 'main')),
+      (m) =>
+        m.slug === namespace &&
+        (m.memexSlug === memex || (!m.memexSlug && memex === "main")),
     ) ?? null;
   const isMember = !!matchedMembership;
 
@@ -249,9 +326,9 @@ function TenantLayout() {
       isMember &&
       namespace &&
       memex &&
-      matchedSource !== 'featured' &&
-      matchedSource !== 'visited' &&
-      matchedAccess !== 'read'
+      matchedSource !== "featured" &&
+      matchedSource !== "visited" &&
+      matchedAccess !== "read"
     ) {
       recordLastMemex(namespace, memex);
     }
@@ -260,7 +337,7 @@ function TenantLayout() {
   // to /login (anonymous) or the default landing (authed non-member). Before
   // bouncing, ask the server whether the path forwards. Fires ONLY on the miss.
   const staleForward =
-    (anonymous && probe.state === 'no') ||
+    (anonymous && probe.state === "no") ||
     (!anonymous &&
       !!session &&
       session.user.emailVerified &&
@@ -269,10 +346,11 @@ function TenantLayout() {
   const forward = useStaleTenantForward(location.pathname, staleForward);
 
   if (anonymous) {
-    if (probe.state === 'loading') return null; // transient — avoid flashing the wrong UI
-    if (probe.state === 'no') {
-      if (forward.state === 'loading') return null;
-      if (forward.to) return <Navigate to={`${forward.to}${location.search}`} replace />;
+    if (probe.state === "loading") return null; // transient — avoid flashing the wrong UI
+    if (probe.state === "no") {
+      if (forward.state === "loading") return null;
+      if (forward.to)
+        return <Navigate to={`${forward.to}${location.search}`} replace />;
       const returnTo = encodeURIComponent(location.pathname + location.search);
       return <Navigate to={`/login?returnTo=${returnTo}`} replace />;
     }
@@ -280,13 +358,15 @@ function TenantLayout() {
     // PageHeader can show its name + 🌐 badge (no membership row to read them from).
     return (
       <PublicMemexProvider value={probe.memex}>
-        <ChatProvider>
-          <AppShell>
-            <Fragment key={`${namespace}/${memex}`}>
-              <Outlet />
-            </Fragment>
-          </AppShell>
-        </ChatProvider>
+        <SpecRefStatusProvider>
+          <ChatProvider>
+            <AppShell>
+              <Fragment key={`${namespace}/${memex}`}>
+                <Outlet />
+              </Fragment>
+            </AppShell>
+          </ChatProvider>
+        </SpecRefStatusProvider>
       </PublicMemexProvider>
     );
   }
@@ -317,8 +397,9 @@ function TenantLayout() {
   // bare base domain).
   if (!isMember) {
     // spec-479 dec-5: a renamed memex's old URL forwards here before bouncing.
-    if (forward.state === 'loading') return null;
-    if (forward.to) return <Navigate to={`${forward.to}${location.search}`} replace />;
+    if (forward.state === "loading") return null;
+    if (forward.to)
+      return <Navigate to={`${forward.to}${location.search}`} replace />;
     const fallback = computeReturnLanding(session);
     if (fallback) return <Navigate to={fallback} replace />;
     return <Navigate to="/" replace />;
@@ -330,25 +411,30 @@ function TenantLayout() {
   // child pages keep their previous tenant's data (loadDocs is a stable
   // callback; useDocChangeStream captures tenantBase() once on connect).
   return (
-    <ChatProvider>
-      {/* spec-200: WhatsNewProvider lets the sidebar user menu re-open the
+    <SpecRefStatusProvider>
+      <ChatProvider>
+        {/* spec-200: WhatsNewProvider lets the sidebar user menu re-open the
           popup and gives the ribbon the menu anchor to animate "into" on
           dismiss — so it wraps BOTH the ribbon and AppShell. */}
-      <WhatsNewProvider>
-        <OrgConsentDialog />
-        {/* spec-200: global What's New ribbon — authed shell only. */}
-        <WhatsNewRibbonConnected />
-        <AppShell>
-          <Fragment key={`${namespace}/${memex}`}>
-            <Outlet />
-          </Fragment>
-        </AppShell>
-        {/* spec-502 t-5: the context-aware Explore companion overlays the
+        <WhatsNewProvider>
+          <OrgConsentDialog />
+          {/* spec-200: global What's New ribbon — authed shell only. */}
+          <WhatsNewRibbonConnected />
+          <AppShell>
+            <Fragment key={`${namespace}/${memex}`}>
+              <Outlet />
+            </Fragment>
+          </AppShell>
+          {/* spec-502 t-5: the context-aware Explore companion overlays the
             featured (building-itself) demo surface for wizard-eligible users.
             Renders nothing on the user's own memexes / when the flag is off. */}
-        <ExploreCompanionMount namespace={namespace ?? ''} memex={memex ?? ''} />
-      </WhatsNewProvider>
-    </ChatProvider>
+          <ExploreCompanionMount
+            namespace={namespace ?? ""}
+            memex={memex ?? ""}
+          />
+        </WhatsNewProvider>
+      </ChatProvider>
+    </SpecRefStatusProvider>
   );
 }
 
@@ -370,7 +456,10 @@ function TenantLayout() {
 // the current route params — robust regardless of nesting, unlike relative-path
 // resolution. `to` is DEFAULT_TENANT_SURFACE (today 'trails').
 function TenantSurfaceRedirect({ to }: { to: string }) {
-  const { namespace, memex } = useParams<{ namespace: string; memex: string }>();
+  const { namespace, memex } = useParams<{
+    namespace: string;
+    memex: string;
+  }>();
   if (!namespace || !memex) return null; // params always present under /:ns/:mx
   return <Navigate to={`/${namespace}/${memex}/${to}`} replace />;
 }
@@ -378,10 +467,11 @@ function TenantSurfaceRedirect({ to }: { to: string }) {
 function RootRedirect() {
   const { session } = useAuth();
   const emailVerified = !!session?.user.emailVerified;
-  const homeHidden = !!session && isFeatureHidden(session, 'home');
+  const homeHidden = !!session && isFeatureHidden(session, "home");
   // Only consult journey-state when we genuinely face the Home-vs-Specs choice
   // (authenticated, verified, and 'home' visible). Otherwise skip the read.
-  const needDecision = !!session && emailVerified && !!session.user.name && !homeHidden;
+  const needDecision =
+    !!session && emailVerified && !!session.user.name && !homeHidden;
   const landOnHome = useShouldLandOnHome(needDecision);
 
   // Engagement telemetry (advisory, fires once): record which way the router sent the
@@ -396,13 +486,13 @@ function RootRedirect() {
     // to their default board, so `destination` is always 'specs'. `graduated`
     // (= hasSpec) stays the raw engagement signal (how many landers haven't graduated).
     // Restore the confirmedSpecLess → 'home' destination when the Home Canvas returns.
-    const props = { destination: 'specs', graduated: !landOnHome };
+    const props = { destination: "specs", graduated: !landOnHome };
     // RootRedirect renders at the flat `/` (or `/login`), where `track()` resolves the
     // tenant from the cached session. In the rare case there's no resolvable tenant (e.g.
     // a session with no current Memex yet), fall back to the anonymous ingress so the
     // engagement data point still lands. Both are advisory and never throw into routing.
-    if (tenantBase()) track('home.landing_routed', props);
-    else trackAnonymous('home.landing_routed', props);
+    if (tenantBase()) track("home.landing_routed", props);
+    else trackAnonymous("home.landing_routed", props);
   }, [needDecision, landOnHome, track]);
 
   if (!session) return null; // session bootstrap still pending
@@ -433,10 +523,12 @@ function RootRedirect() {
   // authored a spec OR already connected an agent falls through to their normal board.
   const mcpConnected = isMcpConnectedCached();
   if (landOnHome && !mcpConnected && isOnboardingWizardEnabled(session)) {
-    const featured = session.memberships.find((m) => m.source === 'featured');
+    const featured = session.memberships.find((m) => m.source === "featured");
     if (featured) {
-      const mx = featured.memexSlug ?? 'main';
-      return <Navigate to={tenantPathFor(featured.slug, mx, '/home')} replace />;
+      const mx = featured.memexSlug ?? "main";
+      return (
+        <Navigate to={tenantPathFor(featured.slug, mx, "/home")} replace />
+      );
     }
   }
   // The global /home (build-prompt hero) is PARKED — the per-memex Brain replaces it as
@@ -471,50 +563,111 @@ export function PostLoginRouter() {
   const { session } = useAuth();
   return (
     <Suspense fallback={RouteFallback}>
-    {/* spec-304 t-58 (issue-24 #1): app-global MCP status sync — mounted once,
+      {/* spec-304 t-58 (issue-24 #1): app-global MCP status sync — mounted once,
         outside <Routes>, so the native pill is driven on EVERY route, not only
         on Settings → Integrations. Renders nothing; no-op in a plain browser. */}
-    <DesktopMcpStatusSync />
-    <Routes>
-      {/* Flat (caller-scoped) routes — no tenant prefix. */}
-      <Route path="/" element={<RootRedirect />} />
-      {/* `/login` is the LoginScreen path pre-auth (rendered by RequireAuth). Post-auth — or
+      <DesktopMcpStatusSync />
+      <Routes>
+        {/* Flat (caller-scoped) routes — no tenant prefix. */}
+        <Route path="/" element={<RootRedirect />} />
+        {/* `/login` is the LoginScreen path pre-auth (rendered by RequireAuth). Post-auth — or
           for users who hit it with a cached session — bounce to the default landing so it
           doesn't get caught by `/:namespace` below and resolved as a "login" namespace. */}
-      <Route path="/login" element={<RootRedirect />} />
-      <Route path="/onboarding" element={<Onboarding />} />
-      {/* spec-444: full-page welcome video. Standalone (no AppShell) — no FlatShell wrapper. */}
-      <Route path="/welcome" element={<WelcomePage />} />
-      {/* spec-502: the onboarding wizard. The Explore companion's CTA opens it as a
+        <Route path="/login" element={<RootRedirect />} />
+        <Route path="/onboarding" element={<Onboarding />} />
+        {/* spec-444: full-page welcome video. Standalone (no AppShell) — no FlatShell wrapper. */}
+        <Route path="/welcome" element={<WelcomePage />} />
+        {/* spec-502: the onboarding wizard. The Explore companion's CTA opens it as a
           large closeable modal (WizardModal) over the live Memex; this standalone
           full-page route stays for direct/resume deep-links (no AppShell). */}
-      <Route path="/wizard" element={<div className="min-h-screen flex flex-col justify-center"><Wizard /></div>} />
-      <Route path="/invite/:token" element={<InviteAccept />} />
-      {/* spec-141 dec-3: install instructions + MCP tokens folded into the one
+        <Route
+          path="/wizard"
+          element={
+            <div className="min-h-screen flex flex-col justify-center">
+              <Wizard />
+            </div>
+          }
+        />
+        <Route path="/invite/:token" element={<InviteAccept />} />
+        {/* spec-141 dec-3: install instructions + MCP tokens folded into the one
           Integrations page. Old routes redirect (the /account→/org pattern).
           /install/mcp/auth (the device-authorize bootstrap) is untouched. */}
-      <Route path="/install" element={<Navigate to="/settings/integrations" replace />} />
-      <Route path="/installation" element={<Navigate to="/settings/integrations" replace />} />
-      <Route path="/install/mcp/auth" element={<InstallAuth />} />
-      <Route path="/oauth/authorize" element={<OauthAuthorize />} />
-      <Route path="/settings/tokens" element={<Navigate to="/settings/integrations" replace />} />
-      <Route path="/settings/integrations" element={<FlatShell><SettingsIntegrations /></FlatShell>} />
-      {/* spec-226 t-6: internal email-preview gallery. Gated off prod — the
+        <Route
+          path="/install"
+          element={<Navigate to="/settings/integrations" replace />}
+        />
+        <Route
+          path="/installation"
+          element={<Navigate to="/settings/integrations" replace />}
+        />
+        <Route path="/install/mcp/auth" element={<InstallAuth />} />
+        <Route path="/oauth/authorize" element={<OauthAuthorize />} />
+        <Route
+          path="/settings/tokens"
+          element={<Navigate to="/settings/integrations" replace />}
+        />
+        <Route
+          path="/settings/integrations"
+          element={
+            <FlatShell>
+              <SettingsIntegrations />
+            </FlatShell>
+          }
+        />
+        {/* spec-226 t-6: internal email-preview gallery. Gated off prod — the
           conditional Route is inert when emailPreviewEnabled() is false (falls
           through to RootRedirect), mirroring the server's prod-unmounted API. */}
-      {emailPreviewEnabled() && (
-        <Route path="/email-preview" element={<FlatShell><EmailPreview /></FlatShell>} />
-      )}
-      <Route path="/invites" element={<Navigate to="/org?tab=invites" replace />} />
-      <Route path="/org" element={<FlatShell><OrgConfiguration /></FlatShell>} />
-      {/* spec-171: in-app upgrade flow. Flat routes so website CTAs land here
+        {emailPreviewEnabled() && (
+          <Route
+            path="/email-preview"
+            element={
+              <FlatShell>
+                <EmailPreview />
+              </FlatShell>
+            }
+          />
+        )}
+        <Route
+          path="/invites"
+          element={<Navigate to="/org?tab=invites" replace />}
+        />
+        <Route
+          path="/org"
+          element={
+            <FlatShell>
+              <OrgConfiguration />
+            </FlatShell>
+          }
+        />
+        {/* spec-171: in-app upgrade flow. Flat routes so website CTAs land here
           without a tenant prefix. confirmation before :plan so it isn't caught
           as a plan param. */}
-      <Route path="/upgrade" element={<FlatShell><UpgradePlanSelect /></FlatShell>} />
-      <Route path="/upgrade/confirmation" element={<FlatShell><UpgradeConfirmation /></FlatShell>} />
-      <Route path="/upgrade/:plan" element={<FlatShell><UpgradeSeats /></FlatShell>} />
-      <Route path="/account" element={<Navigate to="/org" replace />} />
-      {/* Home Canvas PARKED — the per-memex Brain replaces the flat /home onboarding
+        <Route
+          path="/upgrade"
+          element={
+            <FlatShell>
+              <UpgradePlanSelect />
+            </FlatShell>
+          }
+        />
+        <Route
+          path="/upgrade/confirmation"
+          element={
+            <FlatShell>
+              <UpgradeConfirmation />
+            </FlatShell>
+          }
+        />
+        <Route
+          path="/upgrade/:plan"
+          element={
+            <FlatShell>
+              <UpgradeSeats />
+            </FlatShell>
+          }
+        />
+        <Route path="/account" element={<Navigate to="/org" replace />} />
+        {/* Home Canvas PARKED — the per-memex Brain replaces the flat /home onboarding
           tracker as the default surface. The route stays registered (a flat,
           single-segment path would otherwise be claimed by /:namespace below,
           resolving "home" as a namespace) but now always RootRedirects to the
@@ -530,164 +683,180 @@ export function PostLoginRouter() {
               )
             }
       */}
-      <Route path="/home" element={<RootRedirect />} />
+        <Route path="/home" element={<RootRedirect />} />
 
-
-      {/* Bare /specs is a flat, single-segment path with no tenant prefix, so it
+        {/* Bare /specs is a flat, single-segment path with no tenant prefix, so it
           would otherwise be claimed by /:namespace below and resolved as a bogus
           "specs" namespace. The specs board is tenant-scoped (/<ns>/<mx>/specs);
           send the user to their default landing (their personal memex's Specs board;
           spec-461: never /home). Same RootRedirect pattern as /login and hidden /home. */}
-      <Route path="/specs" element={<RootRedirect />} />
+        <Route path="/specs" element={<RootRedirect />} />
 
-      {/* doc-19 t-10: namespace home — /<namespace>/ renders the kind-aware
+        {/* doc-19 t-10: namespace home — /<namespace>/ renders the kind-aware
           OrgHome / Personal Home. More specific /:namespace/:memex routes below
           take precedence (React Router 7 specificity). */}
-      <Route path="/:namespace" element={<FlatShell><NamespaceHome /></FlatShell>} />
+        <Route
+          path="/:namespace"
+          element={
+            <FlatShell>
+              <NamespaceHome />
+            </FlatShell>
+          }
+        />
 
-      {/* spec-481 t-2 (ac-4): per-namespace settings — the namespace-slug rename
+        {/* spec-481 t-2 (ac-4): per-namespace settings — the namespace-slug rename
           surface. `settings` is a reserved slug (no Memex can be named it), so
           this static segment safely wins over the `/:namespace/:memex` dynamic
           route below (RRv7 ranks static above dynamic). Declared before it to
           keep the precedence obvious to a reader too. */}
-      <Route path="/:namespace/settings" element={<FlatShell><NamespaceSettings /></FlatShell>} />
+        <Route
+          path="/:namespace/settings"
+          element={
+            <FlatShell>
+              <NamespaceSettings />
+            </FlatShell>
+          }
+        />
 
-      {/* Tenancy-scoped routes — every path segment lives under /:ns/:mx. */}
-      <Route path="/:namespace/:memex" element={<TenantLayout />}>
-        {/* The memex's default landing is the Brain — the whole-vault knowledge
+        {/* Tenancy-scoped routes — every path segment lives under /:ns/:mx. */}
+        <Route path="/:namespace/:memex" element={<TenantLayout />}>
+          {/* The memex's default landing is the Brain — the whole-vault knowledge
             graph (facets/standards/specs/decisions + drift). Was the Specs board;
             the Specs board still lives at the explicit /specs route below. */}
-        <Route index element={<Brain />} />
-        {/* The canonical default landing (AuthContext.computeDefaultLanding sends
+          <Route index element={<Brain />} />
+          {/* The canonical default landing (AuthContext.computeDefaultLanding sends
             every post-auth flow here). `/home` is a thin redirect, not a surface:
             it forwards to whichever route is currently chosen as the default. One
             knob — DEFAULT_TENANT_SURFACE — so the choice lives in a single place and
             callers only ever need to know "/home", not the surface behind it. The
             redirect builds an ABSOLUTE tenant path from the route params so it can
             never mis-resolve (no reliance on relative-path segment math). */}
-        <Route path="home" element={<TenantSurfaceRedirect to={DEFAULT_TENANT_SURFACE} />} />
-        {/* spec-148 t-1 (ac-6/ac-7/ac-8): gate the `/pulse` route on the
+          <Route
+            path="home"
+            element={<TenantSurfaceRedirect to={DEFAULT_TENANT_SURFACE} />}
+          />
+          {/* spec-148 t-1 (ac-6/ac-7/ac-8): gate the `/pulse` route on the
             server-driven hide list, mirroring the `/scaffold` gate below. When
             'pulse' is hidden the route isn't registered, so `/:ns/:mx/pulse`
             falls through to the catch-all `*` → RootRedirect → default tenant
             (/specs). The AppShell nav link is dropped by the same hiddenFeatures
             filter (the `feature: 'pulse'` tag on PRIMARY_NAV_LINKS). */}
-        {!isFeatureHidden(session, 'pulse') && (
-          <Route path="pulse" element={<Pulse />} />
-        )}
-        {/* spec-179 (ac-14): Insights — per-memex spec analytics. Same
+          {!isFeatureHidden(session, "pulse") && (
+            <Route path="pulse" element={<Pulse />} />
+          )}
+          {/* spec-179 (ac-14): Insights — per-memex spec analytics. Same
             server-driven gate mechanism as /pulse above. */}
-        {!isFeatureHidden(session, 'insights') && (
-          <Route path="insights" element={<Insights />} />
-        )}
-        {/* spec-260 (dec-5): QA Reports — the workspace feed of build-session
+          {!isFeatureHidden(session, "insights") && (
+            <Route path="insights" element={<Insights />} />
+          )}
+          {/* spec-260 (dec-5): QA Reports — the workspace feed of build-session
             QA reports. Same server-driven hiddenFeatures gate as /pulse. */}
-        {!isFeatureHidden(session, 'qa-reports') && (
-          <Route path="qa-reports" element={<QaReports />} />
-        )}
-        <Route path="decisions" element={<Decisions />} />
-        <Route path="specs" element={<SpecList />} />
-        {/* spec-418 t-5: the Manage-tags surface. A literal `specs/tags` segment —
+          {!isFeatureHidden(session, "qa-reports") && (
+            <Route path="qa-reports" element={<QaReports />} />
+          )}
+          <Route path="decisions" element={<Decisions />} />
+          <Route path="specs" element={<SpecList />} />
+          {/* spec-418 t-5: the Manage-tags surface. A literal `specs/tags` segment —
             registered before `specs/:id` so it's never resolved as a Spec handle.
             It renders inside TenantLayout → AppShell's sidebar layout (the AppShell
             doc-page match excludes the literal `tags` segment). */}
-        <Route path="specs/tags" element={<ManageTags />} />
-        {/* spec-521 t-4 (ac-5): registered before `specs/:id` (like `specs/tags`) so
+          <Route path="specs/tags" element={<ManageTags />} />
+          {/* spec-521 t-4 (ac-5): registered before `specs/:id` (like `specs/tags`) so
             the literal `archive` segment is never resolved as a Spec handle. */}
-        <Route path="specs/archive" element={<SpecArchive />} />
-        {/* spec-158 t-4: the Memex-level Issues page — the cross-Spec roll-up of
+          <Route path="specs/archive" element={<SpecArchive />} />
+          {/* spec-158 t-4: the Memex-level Issues page — the cross-Spec roll-up of
             every open issue, grouped under its parent Spec. A plain member
             surface (no feature gate), mounted in the standard AppShell. */}
-        <Route path="issues" element={<IssuesList />} />
-        <Route path="standards" element={<StandardList />} />
-        <Route path="standards/:id" element={<Standard />} />
-        {/* spec-498: Trails — the whole-vault knowledge graph view. The route is
+          <Route path="issues" element={<IssuesList />} />
+          <Route path="standards" element={<StandardList />} />
+          <Route path="standards/:id" element={<Standard />} />
+          {/* spec-498: Trails — the whole-vault knowledge graph view. The route is
             user-facing so it carries the display name (/trails); the component and
             its `brain-*` testids stay internal (the rename is display-only). */}
-        <Route path="trails" element={<Brain />} />
-        {/* spec-300 t-6: Skills — the reusable-SKILL.md surface (list + detail). */}
-        <Route path="skills" element={<SkillList />} />
-        <Route path="skills/:id" element={<Skill />} />
-        {/* spec-143 t-3: the Drift Inbox mounts in the same two-pane shell as
+          <Route path="trails" element={<Brain />} />
+          {/* spec-300 t-6: Skills — the reusable-SKILL.md surface (list + detail). */}
+          <Route path="skills" element={<SkillList />} />
+          <Route path="skills/:id" element={<Skill />} />
+          {/* spec-143 t-3: the Drift Inbox mounts in the same two-pane shell as
             the Spec page (`specs/:id`) — the agent ChatPanel beside the drift
             list — so the click-to-focus drift_item chip (handleFocus in
             DriftInbox) has a panel to land in. */}
-        <Route
-          path="drift"
-          element={
-            <DocumentShell>
-              <DriftInbox />
-            </DocumentShell>
-          }
-        />
-        <Route path="docs" element={<DocumentList />} />
-        <Route
-          path="docs/:id"
-          element={
-            <DocumentShell>
-              <DocDocument />
-            </DocumentShell>
-          }
-        />
-        {/* Per doc-30 dec-4 (post-b-105 rename): specs get a typed `/specs/:id`
+          <Route
+            path="drift"
+            element={
+              <DocumentShell>
+                <DriftInbox />
+              </DocumentShell>
+            }
+          />
+          <Route path="docs" element={<DocumentList />} />
+          <Route
+            path="docs/:id"
+            element={
+              <DocumentShell>
+                <DocDocument />
+              </DocumentShell>
+            }
+          />
+          {/* Per doc-30 dec-4 (post-b-105 rename): specs get a typed `/specs/:id`
             URL path that mirrors `/standards/:id`. Free-form documents and
             execution-plans keep `/docs/:id`. `DocDocument` is doc-type-agnostic;
             the URL difference is purely about the public surface. Legacy
             `/briefs/b-N` / `/missions/...` / `/strategies/...` URLs are
             301-redirected to `/specs/spec-N` by the server (b-105 t-5). */}
-        <Route
-          path="specs/:id"
-          element={
-            <DocumentShell>
-              <DocDocument />
-            </DocumentShell>
-          }
-        />
-        {/* spec-64 i-3: Decision / Issue canonical deep-links (e.g. from the ⌘K
+          <Route
+            path="specs/:id"
+            element={
+              <DocumentShell>
+                <DocDocument />
+              </DocumentShell>
+            }
+          />
+          {/* spec-64 i-3: Decision / Issue canonical deep-links (e.g. from the ⌘K
             palette) are `specs/:id/decisions/:decId` and `specs/:id/issues/:issueId`.
             They render the SAME Spec page; DocDocument reads the sub-param and opens
             the relevant tab + scrolls to the target. Without these routes the deeper
             path matched nothing under /:ns/:mx and fell through the catch-all `*` →
             RootRedirect → the caller's default (personal) Memex. Decisions/issues
             only ever hang off Specs, so only the `specs/...` shape is needed. */}
-        <Route
-          path="specs/:id/decisions/:decId"
-          element={
-            <DocumentShell>
-              <DocDocument />
-            </DocumentShell>
-          }
-        />
-        <Route
-          path="specs/:id/issues/:issueId"
-          element={
-            <DocumentShell>
-              <DocDocument />
-            </DocumentShell>
-          }
-        />
-        <Route path="org" element={<OrgConfiguration />} />
-        {/* spec-111 t-7: per-Memex settings — visibility (public ⇄ private)
+          <Route
+            path="specs/:id/decisions/:decId"
+            element={
+              <DocumentShell>
+                <DocDocument />
+              </DocumentShell>
+            }
+          />
+          <Route
+            path="specs/:id/issues/:issueId"
+            element={
+              <DocumentShell>
+                <DocDocument />
+              </DocumentShell>
+            }
+          />
+          <Route path="org" element={<OrgConfiguration />} />
+          {/* spec-111 t-7: per-Memex settings — visibility (public ⇄ private)
             toggle. Owner/admin-gated server-side; non-admins get a 403 on the
             PATCH (the page renders for everyone but the flip is rejected). */}
-        <Route path="settings" element={<MemexSettings />} />
-        {/* spec-129 dec-8 t-12: per-Memex emission keys — own, member-visible
+          <Route path="settings" element={<MemexSettings />} />
+          {/* spec-129 dec-8 t-12: per-Memex emission keys — own, member-visible
             page (Option B), separate from the admin-only settings page above.
             Any writing member can manage keys; the server role-scopes
             list/revoke (member: own; admin: all). */}
-        <Route path="keys" element={<MemexKeys />} />
-        {/* b-68 t-12/13/14: agent scaffold Inspect surface. Reads available to
+          <Route path="keys" element={<MemexKeys />} />
+          {/* b-68 t-12/13/14: agent scaffold Inspect surface. Reads available to
             any active member; admin edits gated server-side (404 to non-admins).
             spec-146 t-4: omitted entirely when 'scaffold' is hidden so the path
             falls through to the catch-all below (→ default tenant). */}
-        {!isFeatureHidden(session, 'scaffold') && (
-          <Route path="scaffold" element={<ScaffoldInspect />} />
-        )}
-      </Route>
+          {!isFeatureHidden(session, "scaffold") && (
+            <Route path="scaffold" element={<ScaffoldInspect />} />
+          )}
+        </Route>
 
-      {/* Anything else that doesn't match → bounce to the default tenant. */}
-      <Route path="*" element={<RootRedirect />} />
-    </Routes>
+        {/* Anything else that doesn't match → bounce to the default tenant. */}
+        <Route path="*" element={<RootRedirect />} />
+      </Routes>
     </Suspense>
   );
 }
@@ -701,14 +870,17 @@ function FlatShell({ children }: { children: React.ReactNode }) {
   // `!location.pathname.startsWith('/welcome')` guard. That gate is gone, and
   // nothing else here reads the location.
   if (session && !session.user.emailVerified) return <VerifyEmailGate />;
-  if (session && !session.user.name) return <Navigate to="/onboarding" replace />; // spec-441
+  if (session && !session.user.name)
+    return <Navigate to="/onboarding" replace />; // spec-441
   // spec-507: the fourth and quietest spec-444 gate lived here — it walled deep links
   // to flat routes (/settings/*, /org) too. Removed with the other three.
   return (
-    <ChatProvider>
-      <OrgConsentDialog />
-      <AppShell>{children}</AppShell>
-    </ChatProvider>
+    <SpecRefStatusProvider>
+      <ChatProvider>
+        <OrgConsentDialog />
+        <AppShell>{children}</AppShell>
+      </ChatProvider>
+    </SpecRefStatusProvider>
   );
 }
 
@@ -727,11 +899,11 @@ export function App() {
   //   /share/:token         — external guests viewing shared docs (t-10)
   //   /backstage            — platform-admin workspace picker (dev-mode only on the backend)
   if (
-    location.pathname.startsWith('/verify-domain/') ||
-    location.pathname.startsWith('/share/') ||
-    location.pathname === '/live' ||
-    location.pathname === '/backstage' ||
-    location.pathname.startsWith('/backstage/')
+    location.pathname.startsWith("/verify-domain/") ||
+    location.pathname.startsWith("/share/") ||
+    location.pathname === "/live" ||
+    location.pathname === "/backstage" ||
+    location.pathname.startsWith("/backstage/")
   ) {
     return (
       <ThemeProvider>
@@ -742,7 +914,10 @@ export function App() {
             {/* spec-458 (PROTOTYPE): public proof-of-life page — no auth, no tenant. */}
             <Route path="/live" element={<LivePage />} />
             <Route path="/backstage" element={<Backstage />} />
-            <Route path="/backstage/experiments" element={<BackstageExperiments />} />
+            <Route
+              path="/backstage/experiments"
+              element={<BackstageExperiments />}
+            />
           </Routes>
         </Suspense>
       </ThemeProvider>
@@ -753,9 +928,9 @@ export function App() {
   // fresh JWT) but MUST NOT be blocked by RequireAuth — the user might not be signed in
   // when they click a magic link from their inbox.
   const isPublicAuthRoute =
-    location.pathname === '/verify-email' ||
-    location.pathname === '/magic-link' ||
-    location.pathname === '/reset-password';
+    location.pathname === "/verify-email" ||
+    location.pathname === "/magic-link" ||
+    location.pathname === "/reset-password";
 
   return (
     <ThemeProvider>
@@ -804,4 +979,3 @@ function AuthGate({ children }: { children: React.ReactNode }) {
   }
   return <RequireAuth>{children}</RequireAuth>;
 }
-

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -131,6 +131,9 @@ import { AuthProvider, RequireAuth, useAuth, computeReturnLanding } from './comp
 import { recordLastMemex } from './utils/lastMemex';
 import { ThemeProvider } from './components/ThemeContext';
 import { ChatProvider } from './components/ChatContext';
+// spec-529: ONE status set per tenant layout, so every reference pill under it —
+// pages, panels, trays, portalled modals — resolves in a single shared request.
+import { SpecRefStatusProvider } from './components/specRef/SpecRefStatusProvider';
 import { AppShell } from './components/AppShell';
 import { ExploreCompanionMount } from './onboarding/ExploreCompanionMount';
 import { DocumentShell } from './components/DocumentShell';
@@ -280,13 +283,15 @@ function TenantLayout() {
     // PageHeader can show its name + 🌐 badge (no membership row to read them from).
     return (
       <PublicMemexProvider value={probe.memex}>
-        <ChatProvider>
+        <SpecRefStatusProvider>
+      <ChatProvider>
           <AppShell>
             <Fragment key={`${namespace}/${memex}`}>
               <Outlet />
             </Fragment>
           </AppShell>
         </ChatProvider>
+    </SpecRefStatusProvider>
       </PublicMemexProvider>
     );
   }
@@ -330,7 +335,8 @@ function TenantLayout() {
   // child pages keep their previous tenant's data (loadDocs is a stable
   // callback; useDocChangeStream captures tenantBase() once on connect).
   return (
-    <ChatProvider>
+    <SpecRefStatusProvider>
+      <ChatProvider>
       {/* spec-200: WhatsNewProvider lets the sidebar user menu re-open the
           popup and gives the ribbon the menu anchor to animate "into" on
           dismiss — so it wraps BOTH the ribbon and AppShell. */}
@@ -349,6 +355,7 @@ function TenantLayout() {
         <ExploreCompanionMount namespace={namespace ?? ''} memex={memex ?? ''} />
       </WhatsNewProvider>
     </ChatProvider>
+    </SpecRefStatusProvider>
   );
 }
 
@@ -705,10 +712,12 @@ function FlatShell({ children }: { children: React.ReactNode }) {
   // spec-507: the fourth and quietest spec-444 gate lived here — it walled deep links
   // to flat routes (/settings/*, /org) too. Removed with the other three.
   return (
-    <ChatProvider>
+    <SpecRefStatusProvider>
+      <ChatProvider>
       <OrgConsentDialog />
       <AppShell>{children}</AppShell>
     </ChatProvider>
+    </SpecRefStatusProvider>
   );
 }
 

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1,13 +1,13 @@
-import { Fragment, Suspense, lazy, useState, useEffect, useRef } from "react";
 import {
-  Routes,
-  Route,
-  useLocation,
-  useParams,
-  Navigate,
-  Outlet,
-} from "react-router-dom";
-import { emailPreviewEnabled } from "./utils/devTools";
+  Fragment,
+  Suspense,
+  lazy,
+  useState,
+  useEffect,
+  useRef,
+} from 'react';
+import { Routes, Route, useLocation, useParams, Navigate, Outlet } from 'react-router-dom';
+import { emailPreviewEnabled } from './utils/devTools';
 // spec-351: route-level code-splitting. Every top-level routed page is loaded
 // as its own lazy chunk so the entry bundle no longer eagerly pulls all ~35
 // page surfaces (and their heavy transitive deps — nivo charts, pixi, the
@@ -17,42 +17,24 @@ import { emailPreviewEnabled } from "./utils/devTools";
 // and the VerifyEmailGate that several layouts render inline)
 // stay eagerly imported below — splitting them would only add Suspense
 // boundaries on the critical path with no payload win.
-const Pulse = lazy(() =>
-  import("./pages/Pulse").then((m) => ({ default: m.Pulse })),
-);
+const Pulse = lazy(() => import('./pages/Pulse').then((m) => ({ default: m.Pulse })));
 // spec-458 (PROTOTYPE) — the public live proof-of-life page. Fully public
 // (rendered outside AuthProvider below, the /share pattern) and lazy so its
 // world-map asset never rides the authenticated bundles.
-const LivePage = lazy(() =>
-  import("./pages/live/LivePage").then((m) => ({ default: m.LivePage })),
-);
-const Insights = lazy(() =>
-  import("./pages/Insights").then((m) => ({ default: m.Insights })),
-);
-const QaReports = lazy(() =>
-  import("./pages/QaReports").then((m) => ({ default: m.QaReports })),
-);
-const Decisions = lazy(() =>
-  import("./pages/Decisions").then((m) => ({ default: m.Decisions })),
-);
-const SpecList = lazy(() =>
-  import("./pages/SpecList").then((m) => ({ default: m.SpecList })),
-);
+const LivePage = lazy(() => import('./pages/live/LivePage').then((m) => ({ default: m.LivePage })));
+const Insights = lazy(() => import('./pages/Insights').then((m) => ({ default: m.Insights })));
+const QaReports = lazy(() => import('./pages/QaReports').then((m) => ({ default: m.QaReports })));
+const Decisions = lazy(() => import('./pages/Decisions').then((m) => ({ default: m.Decisions })));
+const SpecList = lazy(() => import('./pages/SpecList').then((m) => ({ default: m.SpecList })));
 // spec-521 t-4 (ac-5): the archive view — a destination reached from the board, not a
 // column on it, because archived work should be out of the way.
-const SpecArchive = lazy(() =>
-  import("./pages/SpecArchive").then((m) => ({ default: m.SpecArchive })),
-);
-const IssuesList = lazy(() =>
-  import("./pages/IssuesList").then((m) => ({ default: m.IssuesList })),
-);
+const SpecArchive = lazy(() => import('./pages/SpecArchive').then((m) => ({ default: m.SpecArchive })));
+const IssuesList = lazy(() => import('./pages/IssuesList').then((m) => ({ default: m.IssuesList })));
 const NamespaceHome = lazy(() =>
-  import("./pages/NamespaceHome").then((m) => ({ default: m.NamespaceHome })),
+  import('./pages/NamespaceHome').then((m) => ({ default: m.NamespaceHome })),
 );
 const NamespaceSettings = lazy(() =>
-  import("./pages/NamespaceSettings").then((m) => ({
-    default: m.NamespaceSettings,
-  })),
+  import('./pages/NamespaceSettings').then((m) => ({ default: m.NamespaceSettings })),
 );
 // The global Home Canvas (flat /home onboarding tracker) is PARKED for now — the
 // per-memex Brain (the knowledge-graph landing) replaces it as the default surface.
@@ -60,162 +42,112 @@ const NamespaceSettings = lazy(() =>
 // const HomeCanvas = lazy(() => import('./pages/HomeCanvas').then((m) => ({ default: m.HomeCanvas })));
 // spec-502: the onboarding wizard (name → console demo → connect the agent →
 // land populated). Reached from the Explore companion's "Create your own Memex".
-const Wizard = lazy(() =>
-  import("./onboarding/Wizard").then((m) => ({ default: m.Wizard })),
-);
+const Wizard = lazy(() => import('./onboarding/Wizard').then((m) => ({ default: m.Wizard })));
 const StandardList = lazy(() =>
-  import("./pages/StandardList").then((m) => ({ default: m.StandardList })),
+  import('./pages/StandardList').then((m) => ({ default: m.StandardList })),
 );
-const Standard = lazy(() =>
-  import("./pages/Standard").then((m) => ({ default: m.Standard })),
-);
+const Standard = lazy(() => import('./pages/Standard').then((m) => ({ default: m.Standard })));
 // spec-498 — Brain: the whole-vault knowledge graph (facets/standards/specs/decisions).
-const Brain = lazy(() =>
-  import("./pages/Brain").then((m) => ({ default: m.Brain })),
-);
+const Brain = lazy(() => import('./pages/Brain').then((m) => ({ default: m.Brain })));
 // The surface the tenant `/home` redirect forwards to — the single knob for "the
 // default landing". Today it's the Trails route; change this one string to
 // re-point every default landing (nothing else references the surface directly).
-const DEFAULT_TENANT_SURFACE = "trails";
+const DEFAULT_TENANT_SURFACE = 'trails';
 // spec-300 t-6 — the in-app Skills surface (list + detail).
-const SkillList = lazy(() =>
-  import("./pages/SkillList").then((m) => ({ default: m.SkillList })),
-);
-const Skill = lazy(() =>
-  import("./pages/Skill").then((m) => ({ default: m.Skill })),
-);
+const SkillList = lazy(() => import('./pages/SkillList').then((m) => ({ default: m.SkillList })));
+const Skill = lazy(() => import('./pages/Skill').then((m) => ({ default: m.Skill })));
 // spec-226 t-6 — internal email-preview gallery (gated off prod, see emailPreviewEnabled).
 const EmailPreview = lazy(() =>
-  import("./pages/EmailPreview").then((m) => ({ default: m.EmailPreview })),
+  import('./pages/EmailPreview').then((m) => ({ default: m.EmailPreview })),
 );
-const DriftInbox = lazy(() =>
-  import("./pages/DriftInbox").then((m) => ({ default: m.DriftInbox })),
-);
+const DriftInbox = lazy(() => import('./pages/DriftInbox').then((m) => ({ default: m.DriftInbox })));
 const DocumentList = lazy(() =>
-  import("./pages/DocumentList").then((m) => ({ default: m.DocumentList })),
+  import('./pages/DocumentList').then((m) => ({ default: m.DocumentList })),
 );
 const DocDocument = lazy(() =>
-  import("./pages/DocDocument").then((m) => ({ default: m.DocDocument })),
+  import('./pages/DocDocument').then((m) => ({ default: m.DocDocument })),
 );
-const InstallAuth = lazy(() =>
-  import("./pages/InstallAuth").then((m) => ({ default: m.InstallAuth })),
-);
+const InstallAuth = lazy(() => import('./pages/InstallAuth').then((m) => ({ default: m.InstallAuth })));
 const OauthAuthorize = lazy(() =>
-  import("./pages/OauthAuthorize").then((m) => ({ default: m.OauthAuthorize })),
+  import('./pages/OauthAuthorize').then((m) => ({ default: m.OauthAuthorize })),
 );
 // spec-141 dec-3: integrations consolidated into one open-core page.
 // /settings/tokens, /installation and /install now redirect here.
 const SettingsIntegrations = lazy(() =>
-  import("./pages/SettingsIntegrations").then((m) => ({
-    default: m.SettingsIntegrations,
-  })),
+  import('./pages/SettingsIntegrations').then((m) => ({ default: m.SettingsIntegrations })),
 );
-const Onboarding = lazy(() =>
-  import("./pages/Onboarding").then((m) => ({ default: m.Onboarding })),
-);
+const Onboarding = lazy(() => import('./pages/Onboarding').then((m) => ({ default: m.Onboarding })));
 const WelcomePage = lazy(() =>
-  import("./pages/WelcomePage").then((m) => ({ default: m.WelcomePage })),
+  import('./pages/WelcomePage').then((m) => ({ default: m.WelcomePage })),
 );
 const InviteAccept = lazy(() =>
-  import("./pages/InviteAccept").then((m) => ({ default: m.InviteAccept })),
+  import('./pages/InviteAccept').then((m) => ({ default: m.InviteAccept })),
 );
 const OrgConfiguration = lazy(() =>
-  import("./pages/OrgConfiguration").then((m) => ({
-    default: m.OrgConfiguration,
-  })),
+  import('./pages/OrgConfiguration').then((m) => ({ default: m.OrgConfiguration })),
 );
 const ScaffoldInspect = lazy(() =>
-  import("./pages/ScaffoldInspect").then((m) => ({
-    default: m.ScaffoldInspect,
-  })),
+  import('./pages/ScaffoldInspect').then((m) => ({ default: m.ScaffoldInspect })),
 );
 const MemexSettings = lazy(() =>
-  import("./pages/MemexSettings").then((m) => ({ default: m.MemexSettings })),
+  import('./pages/MemexSettings').then((m) => ({ default: m.MemexSettings })),
 );
-const MemexKeys = lazy(() =>
-  import("./pages/MemexKeys").then((m) => ({ default: m.MemexKeys })),
-);
+const MemexKeys = lazy(() => import('./pages/MemexKeys').then((m) => ({ default: m.MemexKeys })));
 // spec-418 t-5 — the Manage-tags surface (tag catalogue admin). Renders in the
 // normal AppShell sidebar layout (NOT the doc-page chrome) — see the AppShell
 // guard that excludes the literal `tags` segment from the specs/:id doc match.
-const ManageTags = lazy(() =>
-  import("./pages/ManageTags").then((m) => ({ default: m.ManageTags })),
-);
+const ManageTags = lazy(() => import('./pages/ManageTags').then((m) => ({ default: m.ManageTags })));
 const UpgradePlanSelect = lazy(() =>
-  import("./pages/upgrade/UpgradePlanSelect").then((m) => ({
-    default: m.UpgradePlanSelect,
-  })),
+  import('./pages/upgrade/UpgradePlanSelect').then((m) => ({ default: m.UpgradePlanSelect })),
 );
 const UpgradeSeats = lazy(() =>
-  import("./pages/upgrade/UpgradeSeats").then((m) => ({
-    default: m.UpgradeSeats,
-  })),
+  import('./pages/upgrade/UpgradeSeats').then((m) => ({ default: m.UpgradeSeats })),
 );
 const UpgradeConfirmation = lazy(() =>
-  import("./pages/upgrade/UpgradeConfirmation").then((m) => ({
-    default: m.UpgradeConfirmation,
-  })),
+  import('./pages/upgrade/UpgradeConfirmation').then((m) => ({ default: m.UpgradeConfirmation })),
 );
 const VerifyDomain = lazy(() =>
-  import("./pages/VerifyDomain").then((m) => ({ default: m.VerifyDomain })),
+  import('./pages/VerifyDomain').then((m) => ({ default: m.VerifyDomain })),
 );
 const SharedDocument = lazy(() =>
-  import("./pages/SharedDocument").then((m) => ({ default: m.SharedDocument })),
+  import('./pages/SharedDocument').then((m) => ({ default: m.SharedDocument })),
 );
-const Backstage = lazy(() =>
-  import("./pages/Backstage").then((m) => ({ default: m.Backstage })),
-);
+const Backstage = lazy(() => import('./pages/Backstage').then((m) => ({ default: m.Backstage })));
 const BackstageExperiments = lazy(() =>
-  import("./pages/BackstageExperiments").then((m) => ({
-    default: m.BackstageExperiments,
-  })),
+  import('./pages/BackstageExperiments').then((m) => ({ default: m.BackstageExperiments })),
 );
-const VerifyEmail = lazy(() =>
-  import("./pages/VerifyEmail").then((m) => ({ default: m.VerifyEmail })),
-);
+const VerifyEmail = lazy(() => import('./pages/VerifyEmail').then((m) => ({ default: m.VerifyEmail })));
 const MagicLinkConsume = lazy(() =>
-  import("./pages/MagicLinkConsume").then((m) => ({
-    default: m.MagicLinkConsume,
-  })),
+  import('./pages/MagicLinkConsume').then((m) => ({ default: m.MagicLinkConsume })),
 );
 const ResetPassword = lazy(() =>
-  import("./pages/ResetPassword").then((m) => ({ default: m.ResetPassword })),
+  import('./pages/ResetPassword').then((m) => ({ default: m.ResetPassword })),
 );
 // VerifyEmailGate stays eager — it is rendered inline by TenantLayout,
 // FlatShell, and RootRedirect (not as a routed element), so it sits on the
 // critical path for unverified users and is small.
-import { VerifyEmailGate } from "./pages/VerifyEmailGate";
-import {
-  AuthProvider,
-  RequireAuth,
-  useAuth,
-  computeReturnLanding,
-} from "./components/AuthContext";
-import { recordLastMemex } from "./utils/lastMemex";
-import { ThemeProvider } from "./components/ThemeContext";
-import { ChatProvider } from "./components/ChatContext";
-import { SpecRefStatusProvider } from "./components/specRef/SpecRefStatusProvider";
-import { AppShell } from "./components/AppShell";
-import { ExploreCompanionMount } from "./onboarding/ExploreCompanionMount";
-import { DocumentShell } from "./components/DocumentShell";
-import { OrgConsentDialog } from "./components/OrgConsentDialog";
-import { DesktopMcpStatusSync } from "./components/DesktopMcpStatusSync";
-import { parseTenantFromPathname, tenantPathFor } from "./utils/tenantUrl";
-import { isOnboardingWizardEnabled } from "./onboarding/flag";
-import { isFeatureHidden } from "./utils/featureFlags";
-import { probePublicMemex, type PublicMemexProbe } from "./api/client";
-import { PublicMemexProvider } from "./components/PublicMemexContext";
-import {
-  useTrackRouteChange,
-  useTelemetry,
-  trackAnonymous,
-} from "./hooks/useTelemetry";
-import { useStaleTenantForward } from "./hooks/useStaleTenantForward";
-import { useShouldLandOnHome, isMcpConnectedCached } from "./journeys/landing";
-import { tenantBase } from "./api/http";
-import { SearchProvider } from "./components/SearchContext";
-import { WhatsNewRibbonConnected } from "./components/whats-new/WhatsNewRibbonConnected";
-import { WhatsNewProvider } from "./components/whats-new/WhatsNewContext";
+import { VerifyEmailGate } from './pages/VerifyEmailGate';
+import { AuthProvider, RequireAuth, useAuth, computeReturnLanding } from './components/AuthContext';
+import { recordLastMemex } from './utils/lastMemex';
+import { ThemeProvider } from './components/ThemeContext';
+import { ChatProvider } from './components/ChatContext';
+import { AppShell } from './components/AppShell';
+import { ExploreCompanionMount } from './onboarding/ExploreCompanionMount';
+import { DocumentShell } from './components/DocumentShell';
+import { OrgConsentDialog } from './components/OrgConsentDialog';
+import { DesktopMcpStatusSync } from './components/DesktopMcpStatusSync';
+import { parseTenantFromPathname, tenantPathFor } from './utils/tenantUrl';
+import { isOnboardingWizardEnabled } from './onboarding/flag';
+import { isFeatureHidden } from './utils/featureFlags';
+import { probePublicMemex, type PublicMemexProbe } from './api/client';
+import { PublicMemexProvider } from './components/PublicMemexContext';
+import { useTrackRouteChange, useTelemetry, trackAnonymous } from './hooks/useTelemetry';
+import { useStaleTenantForward } from './hooks/useStaleTenantForward';
+import { useShouldLandOnHome, isMcpConnectedCached } from './journeys/landing';
+import { tenantBase } from './api/http';
+import { SearchProvider } from './components/SearchContext';
+import { WhatsNewRibbonConnected } from './components/whats-new/WhatsNewRibbonConnected';
+import { WhatsNewProvider } from './components/whats-new/WhatsNewContext';
 
 declare const __BUILD_TIME__: string;
 
@@ -243,7 +175,7 @@ declare const __BUILD_TIME__: string;
 // `memex` carries the probed Memex (name + visibility) on a 'yes'. `enabled` is
 // false for authenticated users, so the hook is always called (rules of hooks)
 // but only fetches for anonymous visitors.
-type ReadableState = "loading" | "yes" | "no";
+type ReadableState = 'loading' | 'yes' | 'no';
 function usePublicMemexProbe(
   namespace: string | undefined,
   memex: string | undefined,
@@ -252,21 +184,17 @@ function usePublicMemexProbe(
   const [result, setResult] = useState<{
     state: ReadableState;
     memex: PublicMemexProbe | null;
-  }>({ state: "loading", memex: null });
+  }>({ state: 'loading', memex: null });
   useEffect(() => {
     if (!enabled || !namespace || !memex) {
-      setResult({ state: "loading", memex: null });
+      setResult({ state: 'loading', memex: null });
       return;
     }
     let cancelled = false;
-    setResult({ state: "loading", memex: null });
+    setResult({ state: 'loading', memex: null });
     probePublicMemex(namespace, memex).then((probed) => {
       if (!cancelled) {
-        setResult(
-          probed
-            ? { state: "yes", memex: probed }
-            : { state: "no", memex: null },
-        );
+        setResult(probed ? { state: 'yes', memex: probed } : { state: 'no', memex: null });
       }
     });
     return () => {
@@ -277,10 +205,7 @@ function usePublicMemexProbe(
 }
 
 function TenantLayout() {
-  const { namespace, memex } = useParams<{
-    namespace: string;
-    memex: string;
-  }>();
+  const { namespace, memex } = useParams<{ namespace: string; memex: string }>();
   const { session, isAuthenticated } = useAuth();
   const location = useLocation();
   const anonymous = !isAuthenticated && !session;
@@ -309,9 +234,7 @@ function TenantLayout() {
   // session is still null). Reused below for the authed bounce.
   const matchedMembership =
     session?.memberships.find(
-      (m) =>
-        m.slug === namespace &&
-        (m.memexSlug === memex || (!m.memexSlug && memex === "main")),
+      (m) => m.slug === namespace && (m.memexSlug === memex || (!m.memexSlug && memex === 'main')),
     ) ?? null;
   const isMember = !!matchedMembership;
 
@@ -326,9 +249,9 @@ function TenantLayout() {
       isMember &&
       namespace &&
       memex &&
-      matchedSource !== "featured" &&
-      matchedSource !== "visited" &&
-      matchedAccess !== "read"
+      matchedSource !== 'featured' &&
+      matchedSource !== 'visited' &&
+      matchedAccess !== 'read'
     ) {
       recordLastMemex(namespace, memex);
     }
@@ -337,7 +260,7 @@ function TenantLayout() {
   // to /login (anonymous) or the default landing (authed non-member). Before
   // bouncing, ask the server whether the path forwards. Fires ONLY on the miss.
   const staleForward =
-    (anonymous && probe.state === "no") ||
+    (anonymous && probe.state === 'no') ||
     (!anonymous &&
       !!session &&
       session.user.emailVerified &&
@@ -346,11 +269,10 @@ function TenantLayout() {
   const forward = useStaleTenantForward(location.pathname, staleForward);
 
   if (anonymous) {
-    if (probe.state === "loading") return null; // transient — avoid flashing the wrong UI
-    if (probe.state === "no") {
-      if (forward.state === "loading") return null;
-      if (forward.to)
-        return <Navigate to={`${forward.to}${location.search}`} replace />;
+    if (probe.state === 'loading') return null; // transient — avoid flashing the wrong UI
+    if (probe.state === 'no') {
+      if (forward.state === 'loading') return null;
+      if (forward.to) return <Navigate to={`${forward.to}${location.search}`} replace />;
       const returnTo = encodeURIComponent(location.pathname + location.search);
       return <Navigate to={`/login?returnTo=${returnTo}`} replace />;
     }
@@ -358,15 +280,13 @@ function TenantLayout() {
     // PageHeader can show its name + 🌐 badge (no membership row to read them from).
     return (
       <PublicMemexProvider value={probe.memex}>
-        <SpecRefStatusProvider>
-          <ChatProvider>
-            <AppShell>
-              <Fragment key={`${namespace}/${memex}`}>
-                <Outlet />
-              </Fragment>
-            </AppShell>
-          </ChatProvider>
-        </SpecRefStatusProvider>
+        <ChatProvider>
+          <AppShell>
+            <Fragment key={`${namespace}/${memex}`}>
+              <Outlet />
+            </Fragment>
+          </AppShell>
+        </ChatProvider>
       </PublicMemexProvider>
     );
   }
@@ -397,9 +317,8 @@ function TenantLayout() {
   // bare base domain).
   if (!isMember) {
     // spec-479 dec-5: a renamed memex's old URL forwards here before bouncing.
-    if (forward.state === "loading") return null;
-    if (forward.to)
-      return <Navigate to={`${forward.to}${location.search}`} replace />;
+    if (forward.state === 'loading') return null;
+    if (forward.to) return <Navigate to={`${forward.to}${location.search}`} replace />;
     const fallback = computeReturnLanding(session);
     if (fallback) return <Navigate to={fallback} replace />;
     return <Navigate to="/" replace />;
@@ -411,30 +330,25 @@ function TenantLayout() {
   // child pages keep their previous tenant's data (loadDocs is a stable
   // callback; useDocChangeStream captures tenantBase() once on connect).
   return (
-    <SpecRefStatusProvider>
-      <ChatProvider>
-        {/* spec-200: WhatsNewProvider lets the sidebar user menu re-open the
+    <ChatProvider>
+      {/* spec-200: WhatsNewProvider lets the sidebar user menu re-open the
           popup and gives the ribbon the menu anchor to animate "into" on
           dismiss — so it wraps BOTH the ribbon and AppShell. */}
-        <WhatsNewProvider>
-          <OrgConsentDialog />
-          {/* spec-200: global What's New ribbon — authed shell only. */}
-          <WhatsNewRibbonConnected />
-          <AppShell>
-            <Fragment key={`${namespace}/${memex}`}>
-              <Outlet />
-            </Fragment>
-          </AppShell>
-          {/* spec-502 t-5: the context-aware Explore companion overlays the
+      <WhatsNewProvider>
+        <OrgConsentDialog />
+        {/* spec-200: global What's New ribbon — authed shell only. */}
+        <WhatsNewRibbonConnected />
+        <AppShell>
+          <Fragment key={`${namespace}/${memex}`}>
+            <Outlet />
+          </Fragment>
+        </AppShell>
+        {/* spec-502 t-5: the context-aware Explore companion overlays the
             featured (building-itself) demo surface for wizard-eligible users.
             Renders nothing on the user's own memexes / when the flag is off. */}
-          <ExploreCompanionMount
-            namespace={namespace ?? ""}
-            memex={memex ?? ""}
-          />
-        </WhatsNewProvider>
-      </ChatProvider>
-    </SpecRefStatusProvider>
+        <ExploreCompanionMount namespace={namespace ?? ''} memex={memex ?? ''} />
+      </WhatsNewProvider>
+    </ChatProvider>
   );
 }
 
@@ -456,10 +370,7 @@ function TenantLayout() {
 // the current route params — robust regardless of nesting, unlike relative-path
 // resolution. `to` is DEFAULT_TENANT_SURFACE (today 'trails').
 function TenantSurfaceRedirect({ to }: { to: string }) {
-  const { namespace, memex } = useParams<{
-    namespace: string;
-    memex: string;
-  }>();
+  const { namespace, memex } = useParams<{ namespace: string; memex: string }>();
   if (!namespace || !memex) return null; // params always present under /:ns/:mx
   return <Navigate to={`/${namespace}/${memex}/${to}`} replace />;
 }
@@ -467,11 +378,10 @@ function TenantSurfaceRedirect({ to }: { to: string }) {
 function RootRedirect() {
   const { session } = useAuth();
   const emailVerified = !!session?.user.emailVerified;
-  const homeHidden = !!session && isFeatureHidden(session, "home");
+  const homeHidden = !!session && isFeatureHidden(session, 'home');
   // Only consult journey-state when we genuinely face the Home-vs-Specs choice
   // (authenticated, verified, and 'home' visible). Otherwise skip the read.
-  const needDecision =
-    !!session && emailVerified && !!session.user.name && !homeHidden;
+  const needDecision = !!session && emailVerified && !!session.user.name && !homeHidden;
   const landOnHome = useShouldLandOnHome(needDecision);
 
   // Engagement telemetry (advisory, fires once): record which way the router sent the
@@ -486,13 +396,13 @@ function RootRedirect() {
     // to their default board, so `destination` is always 'specs'. `graduated`
     // (= hasSpec) stays the raw engagement signal (how many landers haven't graduated).
     // Restore the confirmedSpecLess → 'home' destination when the Home Canvas returns.
-    const props = { destination: "specs", graduated: !landOnHome };
+    const props = { destination: 'specs', graduated: !landOnHome };
     // RootRedirect renders at the flat `/` (or `/login`), where `track()` resolves the
     // tenant from the cached session. In the rare case there's no resolvable tenant (e.g.
     // a session with no current Memex yet), fall back to the anonymous ingress so the
     // engagement data point still lands. Both are advisory and never throw into routing.
-    if (tenantBase()) track("home.landing_routed", props);
-    else trackAnonymous("home.landing_routed", props);
+    if (tenantBase()) track('home.landing_routed', props);
+    else trackAnonymous('home.landing_routed', props);
   }, [needDecision, landOnHome, track]);
 
   if (!session) return null; // session bootstrap still pending
@@ -523,12 +433,10 @@ function RootRedirect() {
   // authored a spec OR already connected an agent falls through to their normal board.
   const mcpConnected = isMcpConnectedCached();
   if (landOnHome && !mcpConnected && isOnboardingWizardEnabled(session)) {
-    const featured = session.memberships.find((m) => m.source === "featured");
+    const featured = session.memberships.find((m) => m.source === 'featured');
     if (featured) {
-      const mx = featured.memexSlug ?? "main";
-      return (
-        <Navigate to={tenantPathFor(featured.slug, mx, "/home")} replace />
-      );
+      const mx = featured.memexSlug ?? 'main';
+      return <Navigate to={tenantPathFor(featured.slug, mx, '/home')} replace />;
     }
   }
   // The global /home (build-prompt hero) is PARKED — the per-memex Brain replaces it as
@@ -563,111 +471,50 @@ export function PostLoginRouter() {
   const { session } = useAuth();
   return (
     <Suspense fallback={RouteFallback}>
-      {/* spec-304 t-58 (issue-24 #1): app-global MCP status sync — mounted once,
+    {/* spec-304 t-58 (issue-24 #1): app-global MCP status sync — mounted once,
         outside <Routes>, so the native pill is driven on EVERY route, not only
         on Settings → Integrations. Renders nothing; no-op in a plain browser. */}
-      <DesktopMcpStatusSync />
-      <Routes>
-        {/* Flat (caller-scoped) routes — no tenant prefix. */}
-        <Route path="/" element={<RootRedirect />} />
-        {/* `/login` is the LoginScreen path pre-auth (rendered by RequireAuth). Post-auth — or
+    <DesktopMcpStatusSync />
+    <Routes>
+      {/* Flat (caller-scoped) routes — no tenant prefix. */}
+      <Route path="/" element={<RootRedirect />} />
+      {/* `/login` is the LoginScreen path pre-auth (rendered by RequireAuth). Post-auth — or
           for users who hit it with a cached session — bounce to the default landing so it
           doesn't get caught by `/:namespace` below and resolved as a "login" namespace. */}
-        <Route path="/login" element={<RootRedirect />} />
-        <Route path="/onboarding" element={<Onboarding />} />
-        {/* spec-444: full-page welcome video. Standalone (no AppShell) — no FlatShell wrapper. */}
-        <Route path="/welcome" element={<WelcomePage />} />
-        {/* spec-502: the onboarding wizard. The Explore companion's CTA opens it as a
+      <Route path="/login" element={<RootRedirect />} />
+      <Route path="/onboarding" element={<Onboarding />} />
+      {/* spec-444: full-page welcome video. Standalone (no AppShell) — no FlatShell wrapper. */}
+      <Route path="/welcome" element={<WelcomePage />} />
+      {/* spec-502: the onboarding wizard. The Explore companion's CTA opens it as a
           large closeable modal (WizardModal) over the live Memex; this standalone
           full-page route stays for direct/resume deep-links (no AppShell). */}
-        <Route
-          path="/wizard"
-          element={
-            <div className="min-h-screen flex flex-col justify-center">
-              <Wizard />
-            </div>
-          }
-        />
-        <Route path="/invite/:token" element={<InviteAccept />} />
-        {/* spec-141 dec-3: install instructions + MCP tokens folded into the one
+      <Route path="/wizard" element={<div className="min-h-screen flex flex-col justify-center"><Wizard /></div>} />
+      <Route path="/invite/:token" element={<InviteAccept />} />
+      {/* spec-141 dec-3: install instructions + MCP tokens folded into the one
           Integrations page. Old routes redirect (the /account→/org pattern).
           /install/mcp/auth (the device-authorize bootstrap) is untouched. */}
-        <Route
-          path="/install"
-          element={<Navigate to="/settings/integrations" replace />}
-        />
-        <Route
-          path="/installation"
-          element={<Navigate to="/settings/integrations" replace />}
-        />
-        <Route path="/install/mcp/auth" element={<InstallAuth />} />
-        <Route path="/oauth/authorize" element={<OauthAuthorize />} />
-        <Route
-          path="/settings/tokens"
-          element={<Navigate to="/settings/integrations" replace />}
-        />
-        <Route
-          path="/settings/integrations"
-          element={
-            <FlatShell>
-              <SettingsIntegrations />
-            </FlatShell>
-          }
-        />
-        {/* spec-226 t-6: internal email-preview gallery. Gated off prod — the
+      <Route path="/install" element={<Navigate to="/settings/integrations" replace />} />
+      <Route path="/installation" element={<Navigate to="/settings/integrations" replace />} />
+      <Route path="/install/mcp/auth" element={<InstallAuth />} />
+      <Route path="/oauth/authorize" element={<OauthAuthorize />} />
+      <Route path="/settings/tokens" element={<Navigate to="/settings/integrations" replace />} />
+      <Route path="/settings/integrations" element={<FlatShell><SettingsIntegrations /></FlatShell>} />
+      {/* spec-226 t-6: internal email-preview gallery. Gated off prod — the
           conditional Route is inert when emailPreviewEnabled() is false (falls
           through to RootRedirect), mirroring the server's prod-unmounted API. */}
-        {emailPreviewEnabled() && (
-          <Route
-            path="/email-preview"
-            element={
-              <FlatShell>
-                <EmailPreview />
-              </FlatShell>
-            }
-          />
-        )}
-        <Route
-          path="/invites"
-          element={<Navigate to="/org?tab=invites" replace />}
-        />
-        <Route
-          path="/org"
-          element={
-            <FlatShell>
-              <OrgConfiguration />
-            </FlatShell>
-          }
-        />
-        {/* spec-171: in-app upgrade flow. Flat routes so website CTAs land here
+      {emailPreviewEnabled() && (
+        <Route path="/email-preview" element={<FlatShell><EmailPreview /></FlatShell>} />
+      )}
+      <Route path="/invites" element={<Navigate to="/org?tab=invites" replace />} />
+      <Route path="/org" element={<FlatShell><OrgConfiguration /></FlatShell>} />
+      {/* spec-171: in-app upgrade flow. Flat routes so website CTAs land here
           without a tenant prefix. confirmation before :plan so it isn't caught
           as a plan param. */}
-        <Route
-          path="/upgrade"
-          element={
-            <FlatShell>
-              <UpgradePlanSelect />
-            </FlatShell>
-          }
-        />
-        <Route
-          path="/upgrade/confirmation"
-          element={
-            <FlatShell>
-              <UpgradeConfirmation />
-            </FlatShell>
-          }
-        />
-        <Route
-          path="/upgrade/:plan"
-          element={
-            <FlatShell>
-              <UpgradeSeats />
-            </FlatShell>
-          }
-        />
-        <Route path="/account" element={<Navigate to="/org" replace />} />
-        {/* Home Canvas PARKED — the per-memex Brain replaces the flat /home onboarding
+      <Route path="/upgrade" element={<FlatShell><UpgradePlanSelect /></FlatShell>} />
+      <Route path="/upgrade/confirmation" element={<FlatShell><UpgradeConfirmation /></FlatShell>} />
+      <Route path="/upgrade/:plan" element={<FlatShell><UpgradeSeats /></FlatShell>} />
+      <Route path="/account" element={<Navigate to="/org" replace />} />
+      {/* Home Canvas PARKED — the per-memex Brain replaces the flat /home onboarding
           tracker as the default surface. The route stays registered (a flat,
           single-segment path would otherwise be claimed by /:namespace below,
           resolving "home" as a namespace) but now always RootRedirects to the
@@ -683,180 +530,164 @@ export function PostLoginRouter() {
               )
             }
       */}
-        <Route path="/home" element={<RootRedirect />} />
+      <Route path="/home" element={<RootRedirect />} />
 
-        {/* Bare /specs is a flat, single-segment path with no tenant prefix, so it
+
+      {/* Bare /specs is a flat, single-segment path with no tenant prefix, so it
           would otherwise be claimed by /:namespace below and resolved as a bogus
           "specs" namespace. The specs board is tenant-scoped (/<ns>/<mx>/specs);
           send the user to their default landing (their personal memex's Specs board;
           spec-461: never /home). Same RootRedirect pattern as /login and hidden /home. */}
-        <Route path="/specs" element={<RootRedirect />} />
+      <Route path="/specs" element={<RootRedirect />} />
 
-        {/* doc-19 t-10: namespace home — /<namespace>/ renders the kind-aware
+      {/* doc-19 t-10: namespace home — /<namespace>/ renders the kind-aware
           OrgHome / Personal Home. More specific /:namespace/:memex routes below
           take precedence (React Router 7 specificity). */}
-        <Route
-          path="/:namespace"
-          element={
-            <FlatShell>
-              <NamespaceHome />
-            </FlatShell>
-          }
-        />
+      <Route path="/:namespace" element={<FlatShell><NamespaceHome /></FlatShell>} />
 
-        {/* spec-481 t-2 (ac-4): per-namespace settings — the namespace-slug rename
+      {/* spec-481 t-2 (ac-4): per-namespace settings — the namespace-slug rename
           surface. `settings` is a reserved slug (no Memex can be named it), so
           this static segment safely wins over the `/:namespace/:memex` dynamic
           route below (RRv7 ranks static above dynamic). Declared before it to
           keep the precedence obvious to a reader too. */}
-        <Route
-          path="/:namespace/settings"
-          element={
-            <FlatShell>
-              <NamespaceSettings />
-            </FlatShell>
-          }
-        />
+      <Route path="/:namespace/settings" element={<FlatShell><NamespaceSettings /></FlatShell>} />
 
-        {/* Tenancy-scoped routes — every path segment lives under /:ns/:mx. */}
-        <Route path="/:namespace/:memex" element={<TenantLayout />}>
-          {/* The memex's default landing is the Brain — the whole-vault knowledge
+      {/* Tenancy-scoped routes — every path segment lives under /:ns/:mx. */}
+      <Route path="/:namespace/:memex" element={<TenantLayout />}>
+        {/* The memex's default landing is the Brain — the whole-vault knowledge
             graph (facets/standards/specs/decisions + drift). Was the Specs board;
             the Specs board still lives at the explicit /specs route below. */}
-          <Route index element={<Brain />} />
-          {/* The canonical default landing (AuthContext.computeDefaultLanding sends
+        <Route index element={<Brain />} />
+        {/* The canonical default landing (AuthContext.computeDefaultLanding sends
             every post-auth flow here). `/home` is a thin redirect, not a surface:
             it forwards to whichever route is currently chosen as the default. One
             knob — DEFAULT_TENANT_SURFACE — so the choice lives in a single place and
             callers only ever need to know "/home", not the surface behind it. The
             redirect builds an ABSOLUTE tenant path from the route params so it can
             never mis-resolve (no reliance on relative-path segment math). */}
-          <Route
-            path="home"
-            element={<TenantSurfaceRedirect to={DEFAULT_TENANT_SURFACE} />}
-          />
-          {/* spec-148 t-1 (ac-6/ac-7/ac-8): gate the `/pulse` route on the
+        <Route path="home" element={<TenantSurfaceRedirect to={DEFAULT_TENANT_SURFACE} />} />
+        {/* spec-148 t-1 (ac-6/ac-7/ac-8): gate the `/pulse` route on the
             server-driven hide list, mirroring the `/scaffold` gate below. When
             'pulse' is hidden the route isn't registered, so `/:ns/:mx/pulse`
             falls through to the catch-all `*` → RootRedirect → default tenant
             (/specs). The AppShell nav link is dropped by the same hiddenFeatures
             filter (the `feature: 'pulse'` tag on PRIMARY_NAV_LINKS). */}
-          {!isFeatureHidden(session, "pulse") && (
-            <Route path="pulse" element={<Pulse />} />
-          )}
-          {/* spec-179 (ac-14): Insights — per-memex spec analytics. Same
+        {!isFeatureHidden(session, 'pulse') && (
+          <Route path="pulse" element={<Pulse />} />
+        )}
+        {/* spec-179 (ac-14): Insights — per-memex spec analytics. Same
             server-driven gate mechanism as /pulse above. */}
-          {!isFeatureHidden(session, "insights") && (
-            <Route path="insights" element={<Insights />} />
-          )}
-          {/* spec-260 (dec-5): QA Reports — the workspace feed of build-session
+        {!isFeatureHidden(session, 'insights') && (
+          <Route path="insights" element={<Insights />} />
+        )}
+        {/* spec-260 (dec-5): QA Reports — the workspace feed of build-session
             QA reports. Same server-driven hiddenFeatures gate as /pulse. */}
-          {!isFeatureHidden(session, "qa-reports") && (
-            <Route path="qa-reports" element={<QaReports />} />
-          )}
-          <Route path="decisions" element={<Decisions />} />
-          <Route path="specs" element={<SpecList />} />
-          {/* spec-418 t-5: the Manage-tags surface. A literal `specs/tags` segment —
+        {!isFeatureHidden(session, 'qa-reports') && (
+          <Route path="qa-reports" element={<QaReports />} />
+        )}
+        <Route path="decisions" element={<Decisions />} />
+        <Route path="specs" element={<SpecList />} />
+        {/* spec-418 t-5: the Manage-tags surface. A literal `specs/tags` segment —
             registered before `specs/:id` so it's never resolved as a Spec handle.
             It renders inside TenantLayout → AppShell's sidebar layout (the AppShell
             doc-page match excludes the literal `tags` segment). */}
-          <Route path="specs/tags" element={<ManageTags />} />
-          {/* spec-521 t-4 (ac-5): registered before `specs/:id` (like `specs/tags`) so
+        <Route path="specs/tags" element={<ManageTags />} />
+        {/* spec-521 t-4 (ac-5): registered before `specs/:id` (like `specs/tags`) so
             the literal `archive` segment is never resolved as a Spec handle. */}
-          <Route path="specs/archive" element={<SpecArchive />} />
-          {/* spec-158 t-4: the Memex-level Issues page — the cross-Spec roll-up of
+        <Route path="specs/archive" element={<SpecArchive />} />
+        {/* spec-158 t-4: the Memex-level Issues page — the cross-Spec roll-up of
             every open issue, grouped under its parent Spec. A plain member
             surface (no feature gate), mounted in the standard AppShell. */}
-          <Route path="issues" element={<IssuesList />} />
-          <Route path="standards" element={<StandardList />} />
-          <Route path="standards/:id" element={<Standard />} />
-          {/* spec-498: Trails — the whole-vault knowledge graph view. The route is
+        <Route path="issues" element={<IssuesList />} />
+        <Route path="standards" element={<StandardList />} />
+        <Route path="standards/:id" element={<Standard />} />
+        {/* spec-498: Trails — the whole-vault knowledge graph view. The route is
             user-facing so it carries the display name (/trails); the component and
             its `brain-*` testids stay internal (the rename is display-only). */}
-          <Route path="trails" element={<Brain />} />
-          {/* spec-300 t-6: Skills — the reusable-SKILL.md surface (list + detail). */}
-          <Route path="skills" element={<SkillList />} />
-          <Route path="skills/:id" element={<Skill />} />
-          {/* spec-143 t-3: the Drift Inbox mounts in the same two-pane shell as
+        <Route path="trails" element={<Brain />} />
+        {/* spec-300 t-6: Skills — the reusable-SKILL.md surface (list + detail). */}
+        <Route path="skills" element={<SkillList />} />
+        <Route path="skills/:id" element={<Skill />} />
+        {/* spec-143 t-3: the Drift Inbox mounts in the same two-pane shell as
             the Spec page (`specs/:id`) — the agent ChatPanel beside the drift
             list — so the click-to-focus drift_item chip (handleFocus in
             DriftInbox) has a panel to land in. */}
-          <Route
-            path="drift"
-            element={
-              <DocumentShell>
-                <DriftInbox />
-              </DocumentShell>
-            }
-          />
-          <Route path="docs" element={<DocumentList />} />
-          <Route
-            path="docs/:id"
-            element={
-              <DocumentShell>
-                <DocDocument />
-              </DocumentShell>
-            }
-          />
-          {/* Per doc-30 dec-4 (post-b-105 rename): specs get a typed `/specs/:id`
+        <Route
+          path="drift"
+          element={
+            <DocumentShell>
+              <DriftInbox />
+            </DocumentShell>
+          }
+        />
+        <Route path="docs" element={<DocumentList />} />
+        <Route
+          path="docs/:id"
+          element={
+            <DocumentShell>
+              <DocDocument />
+            </DocumentShell>
+          }
+        />
+        {/* Per doc-30 dec-4 (post-b-105 rename): specs get a typed `/specs/:id`
             URL path that mirrors `/standards/:id`. Free-form documents and
             execution-plans keep `/docs/:id`. `DocDocument` is doc-type-agnostic;
             the URL difference is purely about the public surface. Legacy
             `/briefs/b-N` / `/missions/...` / `/strategies/...` URLs are
             301-redirected to `/specs/spec-N` by the server (b-105 t-5). */}
-          <Route
-            path="specs/:id"
-            element={
-              <DocumentShell>
-                <DocDocument />
-              </DocumentShell>
-            }
-          />
-          {/* spec-64 i-3: Decision / Issue canonical deep-links (e.g. from the ⌘K
+        <Route
+          path="specs/:id"
+          element={
+            <DocumentShell>
+              <DocDocument />
+            </DocumentShell>
+          }
+        />
+        {/* spec-64 i-3: Decision / Issue canonical deep-links (e.g. from the ⌘K
             palette) are `specs/:id/decisions/:decId` and `specs/:id/issues/:issueId`.
             They render the SAME Spec page; DocDocument reads the sub-param and opens
             the relevant tab + scrolls to the target. Without these routes the deeper
             path matched nothing under /:ns/:mx and fell through the catch-all `*` →
             RootRedirect → the caller's default (personal) Memex. Decisions/issues
             only ever hang off Specs, so only the `specs/...` shape is needed. */}
-          <Route
-            path="specs/:id/decisions/:decId"
-            element={
-              <DocumentShell>
-                <DocDocument />
-              </DocumentShell>
-            }
-          />
-          <Route
-            path="specs/:id/issues/:issueId"
-            element={
-              <DocumentShell>
-                <DocDocument />
-              </DocumentShell>
-            }
-          />
-          <Route path="org" element={<OrgConfiguration />} />
-          {/* spec-111 t-7: per-Memex settings — visibility (public ⇄ private)
+        <Route
+          path="specs/:id/decisions/:decId"
+          element={
+            <DocumentShell>
+              <DocDocument />
+            </DocumentShell>
+          }
+        />
+        <Route
+          path="specs/:id/issues/:issueId"
+          element={
+            <DocumentShell>
+              <DocDocument />
+            </DocumentShell>
+          }
+        />
+        <Route path="org" element={<OrgConfiguration />} />
+        {/* spec-111 t-7: per-Memex settings — visibility (public ⇄ private)
             toggle. Owner/admin-gated server-side; non-admins get a 403 on the
             PATCH (the page renders for everyone but the flip is rejected). */}
-          <Route path="settings" element={<MemexSettings />} />
-          {/* spec-129 dec-8 t-12: per-Memex emission keys — own, member-visible
+        <Route path="settings" element={<MemexSettings />} />
+        {/* spec-129 dec-8 t-12: per-Memex emission keys — own, member-visible
             page (Option B), separate from the admin-only settings page above.
             Any writing member can manage keys; the server role-scopes
             list/revoke (member: own; admin: all). */}
-          <Route path="keys" element={<MemexKeys />} />
-          {/* b-68 t-12/13/14: agent scaffold Inspect surface. Reads available to
+        <Route path="keys" element={<MemexKeys />} />
+        {/* b-68 t-12/13/14: agent scaffold Inspect surface. Reads available to
             any active member; admin edits gated server-side (404 to non-admins).
             spec-146 t-4: omitted entirely when 'scaffold' is hidden so the path
             falls through to the catch-all below (→ default tenant). */}
-          {!isFeatureHidden(session, "scaffold") && (
-            <Route path="scaffold" element={<ScaffoldInspect />} />
-          )}
-        </Route>
+        {!isFeatureHidden(session, 'scaffold') && (
+          <Route path="scaffold" element={<ScaffoldInspect />} />
+        )}
+      </Route>
 
-        {/* Anything else that doesn't match → bounce to the default tenant. */}
-        <Route path="*" element={<RootRedirect />} />
-      </Routes>
+      {/* Anything else that doesn't match → bounce to the default tenant. */}
+      <Route path="*" element={<RootRedirect />} />
+    </Routes>
     </Suspense>
   );
 }
@@ -870,17 +701,14 @@ function FlatShell({ children }: { children: React.ReactNode }) {
   // `!location.pathname.startsWith('/welcome')` guard. That gate is gone, and
   // nothing else here reads the location.
   if (session && !session.user.emailVerified) return <VerifyEmailGate />;
-  if (session && !session.user.name)
-    return <Navigate to="/onboarding" replace />; // spec-441
+  if (session && !session.user.name) return <Navigate to="/onboarding" replace />; // spec-441
   // spec-507: the fourth and quietest spec-444 gate lived here — it walled deep links
   // to flat routes (/settings/*, /org) too. Removed with the other three.
   return (
-    <SpecRefStatusProvider>
-      <ChatProvider>
-        <OrgConsentDialog />
-        <AppShell>{children}</AppShell>
-      </ChatProvider>
-    </SpecRefStatusProvider>
+    <ChatProvider>
+      <OrgConsentDialog />
+      <AppShell>{children}</AppShell>
+    </ChatProvider>
   );
 }
 
@@ -899,11 +727,11 @@ export function App() {
   //   /share/:token         — external guests viewing shared docs (t-10)
   //   /backstage            — platform-admin workspace picker (dev-mode only on the backend)
   if (
-    location.pathname.startsWith("/verify-domain/") ||
-    location.pathname.startsWith("/share/") ||
-    location.pathname === "/live" ||
-    location.pathname === "/backstage" ||
-    location.pathname.startsWith("/backstage/")
+    location.pathname.startsWith('/verify-domain/') ||
+    location.pathname.startsWith('/share/') ||
+    location.pathname === '/live' ||
+    location.pathname === '/backstage' ||
+    location.pathname.startsWith('/backstage/')
   ) {
     return (
       <ThemeProvider>
@@ -914,10 +742,7 @@ export function App() {
             {/* spec-458 (PROTOTYPE): public proof-of-life page — no auth, no tenant. */}
             <Route path="/live" element={<LivePage />} />
             <Route path="/backstage" element={<Backstage />} />
-            <Route
-              path="/backstage/experiments"
-              element={<BackstageExperiments />}
-            />
+            <Route path="/backstage/experiments" element={<BackstageExperiments />} />
           </Routes>
         </Suspense>
       </ThemeProvider>
@@ -928,9 +753,9 @@ export function App() {
   // fresh JWT) but MUST NOT be blocked by RequireAuth — the user might not be signed in
   // when they click a magic link from their inbox.
   const isPublicAuthRoute =
-    location.pathname === "/verify-email" ||
-    location.pathname === "/magic-link" ||
-    location.pathname === "/reset-password";
+    location.pathname === '/verify-email' ||
+    location.pathname === '/magic-link' ||
+    location.pathname === '/reset-password';
 
   return (
     <ThemeProvider>
@@ -979,3 +804,4 @@ function AuthGate({ children }: { children: React.ReactNode }) {
   }
   return <RequireAuth>{children}</RequireAuth>;
 }
+

--- a/packages/ui/src/api/docs.ts
+++ b/packages/ui/src/api/docs.ts
@@ -27,7 +27,21 @@ export interface FetchDocsOptions {
    *  each doc's tags in one batched round-trip so cards can render chips. Pass
    *  any combination; unknown tokens are ignored server-side so the union is
    *  safe to extend. */
-  include?: ReadonlyArray<'driftCount' | 'acHealth' | 'assignees' | 'tags'>;
+  include?: ReadonlyArray<
+    | 'driftCount'
+    | 'acHealth'
+    | 'assignees'
+    | 'tags'
+    | 'taskProgress'
+    | 'lastActivity'
+  >;
+  /**
+   * spec-529: resolve exactly these doc handles, in ONE request. This is how a
+   * document view answers every `spec-N` its body mentions without a fetch per
+   * reference. The server caps the set and drops malformed entries, so a body is
+   * safe to hand straight through.
+   */
+  handles?: ReadonlyArray<string>;
   /**
    * spec-136 t-4: tag-facet filter as `scope::value`/flat strings. Sent as
    * repeated `?tags=` params (the server also accepts CSV). The server ANDs
@@ -58,6 +72,12 @@ export async function fetchDocs(
   if (opts?.include?.length) params.set('include', opts.include.join(','));
   // spec-136 t-4: repeated `?tags=` params (server also accepts CSV). Skip
   // empty/whitespace entries so a stray blank never trips the server's 400.
+  // spec-529: repeated `?handles=` params (the server also accepts CSV).
+  if (opts?.handles?.length) {
+    for (const h of opts.handles) {
+      if (h.trim().length > 0) params.append('handles', h);
+    }
+  }
   if (opts?.tags?.length) {
     for (const t of opts.tags) {
       if (t.trim().length > 0) params.append('tags', t);

--- a/packages/ui/src/api/docs.ts
+++ b/packages/ui/src/api/docs.ts
@@ -43,6 +43,14 @@ export interface FetchDocsOptions {
    */
   handles?: ReadonlyArray<string>;
   /**
+   * spec-529: include archived docs. The reference resolver MUST set this. A
+   * reference to an archived Spec is exactly the case the card's banner exists
+   * for, and without this the server filters those rows out, the handle resolves
+   * as absent, and the reference renders as plain text — telling the reader
+   * nothing about the fact that what they are pointed at has been archived.
+   */
+  includeArchived?: boolean;
+  /**
    * spec-136 t-4: tag-facet filter as `scope::value`/flat strings. Sent as
    * repeated `?tags=` params (the server also accepts CSV). The server ANDs
    * across scopes and ORs within a scope; each flat tag is its own AND clause.
@@ -72,6 +80,7 @@ export async function fetchDocs(
   if (opts?.include?.length) params.set('include', opts.include.join(','));
   // spec-136 t-4: repeated `?tags=` params (server also accepts CSV). Skip
   // empty/whitespace entries so a stray blank never trips the server's 400.
+  if (opts?.includeArchived) params.set('includeArchived', 'true');
   // spec-529: repeated `?handles=` params (the server also accepts CSV).
   if (opts?.handles?.length) {
     for (const h of opts.handles) {

--- a/packages/ui/src/api/types.ts
+++ b/packages/ui/src/api/types.ts
@@ -132,8 +132,9 @@ export interface DocSummary {
    *  tab-state never disagree for the same Spec. (b-66) */
   acHealth?: AcHealth;
   /** spec-529: per-Spec task roll-up, populated only under `include: ['taskProgress']`.
-   *  Absent when the Spec has no tasks — absence is the signal, so the pill renders
-   *  no fraction rather than `0/0` (same restraint as `acHealth`). */
+   *  Read by the reference CARD, which spells the split out; the pill face carries
+   *  only the handle and a phase chip. Absent when the Spec has no tasks — absence
+   *  is the signal (same restraint as `acHealth`). */
   taskProgress?: TaskProgress;
   /** spec-529: the Spec's most recent logged activity, under `include: ['lastActivity']`.
    *  Absent when nothing has been logged — the card omits the line rather than
@@ -175,8 +176,7 @@ export interface DocSummaryAssignee {
  * strip via AcPill's `STATE_DOT` / `STATE_PILL` / `STATE_LABEL` maps.
  */
 /**
- * spec-529: the task roll-up behind a reference pill's `4/8 tasks` and the split
- * its card shows. Derived server-side from the same rows the Spec's own task list
+ * spec-529: the task roll-up the reference CARD shows as its task split. Derived server-side from the same rows the Spec's own task list
  * reads, so the two can never disagree for one Spec.
  */
 /** spec-529: WHEN a Spec last changed and WHAT changed. Read from the activity
@@ -184,7 +184,6 @@ export interface DocSummaryAssignee {
 export interface LastActivity {
   at: string;
   narrative: string;
-  actorName: string | null;
 }
 
 export interface TaskProgress {

--- a/packages/ui/src/api/types.ts
+++ b/packages/ui/src/api/types.ts
@@ -131,6 +131,14 @@ export interface DocSummary {
    *  same `deriveVerificationState` helper the AC tab calls, so card-state and
    *  tab-state never disagree for the same Spec. (b-66) */
   acHealth?: AcHealth;
+  /** spec-529: per-Spec task roll-up, populated only under `include: ['taskProgress']`.
+   *  Absent when the Spec has no tasks — absence is the signal, so the pill renders
+   *  no fraction rather than `0/0` (same restraint as `acHealth`). */
+  taskProgress?: TaskProgress;
+  /** spec-529: the Spec's most recent logged activity, under `include: ['lastActivity']`.
+   *  Absent when nothing has been logged — the card omits the line rather than
+   *  inventing one. `at` is ISO-8601 on the wire. */
+  lastActivity?: LastActivity;
   /** Set when fetchDocs is called with `{ include: ['assignees'] }` (spec-118
    *  ac-18) — the Spec's current assignee(s), rendered on the board card more
    *  prominently than the creator. Undefined/absent means "Unassigned".
@@ -166,6 +174,26 @@ export interface DocSummaryAssignee {
  * (b-66 dec-3); the four-way split survives one level down on the progress
  * strip via AcPill's `STATE_DOT` / `STATE_PILL` / `STATE_LABEL` maps.
  */
+/**
+ * spec-529: the task roll-up behind a reference pill's `4/8 tasks` and the split
+ * its card shows. Derived server-side from the same rows the Spec's own task list
+ * reads, so the two can never disagree for one Spec.
+ */
+/** spec-529: WHEN a Spec last changed and WHAT changed. Read from the activity
+ *  log, because `documents` has no general updated-at column. */
+export interface LastActivity {
+  at: string;
+  narrative: string;
+  actorName: string | null;
+}
+
+export interface TaskProgress {
+  total: number;
+  complete: number;
+  inProgress: number;
+  notStarted: number;
+}
+
 export interface AcHealth {
   totalActive: number;
   covered: number;

--- a/packages/ui/src/components/CommentTray.tsx
+++ b/packages/ui/src/components/CommentTray.tsx
@@ -2,6 +2,9 @@ import { useState, useEffect } from 'react';
 import ReactMarkdown, { type Components } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { rehypeRefLinkifier } from './chat/refLinkifier';
+import { specRefHandle } from './specRef/specRefAnchor';
+import { SpecRefPill } from './specRef/SpecRefPill';
+import { rehypeSpecRefLinkifier } from './chat/specRefLinkifier';
 import { rehypePerRefLinkifier } from './chat/perRefLinkifier';
 import type { Comment, CommentTargetType } from '../api/types';
 import { useAuth } from './AuthContext';
@@ -241,6 +244,11 @@ export function CommentMarkdown({
 }) {
   const components: Components = {
     a: ({ children, href, node }) => {
+      // spec-529: a bare `spec-N` becomes the live pill. Checked FIRST, then this
+      // surface's existing `[per dec-N]` handling, then a plain anchor — the two
+      // ref forms are orthogonal and neither may swallow the other.
+      const specHandle = specRefHandle(node);
+      if (specHandle) return <SpecRefPill handle={specHandle} />;
       const props = (node?.properties ?? {}) as Record<string, unknown>;
       const perRef = (props['data-per-ref'] ?? props['dataPerRef']) as
         | string
@@ -273,7 +281,7 @@ export function CommentMarkdown({
     >
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
-        rehypePlugins={[rehypeRefLinkifier, rehypePerRefLinkifier]}
+        rehypePlugins={[rehypeRefLinkifier, rehypeSpecRefLinkifier, rehypePerRefLinkifier]}
         components={components}
       >
         {content}

--- a/packages/ui/src/components/DecisionPanel.tsx
+++ b/packages/ui/src/components/DecisionPanel.tsx
@@ -2,6 +2,8 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { rehypeRefLinkifier } from './chat/refLinkifier';
+import { specRefComponents } from './specRef/specRefAnchor';
+import { rehypeSpecRefLinkifier } from './chat/specRefLinkifier';
 import { MarkdownText } from './chat/MarkdownText';
 import { phaseDisplayName } from '../utils/phaseDisplay';
 import type { Decision, Comment } from '../api/types';
@@ -71,7 +73,7 @@ interface DecisionPanelProps {
 
 export function DecisionPanel({ docId, decisions, commentsByDecision = {}, forceShowComments: _forceShowComments, onCommentsChange, onUpdate, highlightDecisionHandle, onJumpToAc, canWrite = true, canEdit = true, specPhase, promptContext, orgBlocks }: DecisionPanelProps) {
   const panelRef = useRef<HTMLDivElement>(null);
-  const decisionRehypePlugins = [rehypeRefLinkifier];
+  const decisionRehypePlugins = [rehypeRefLinkifier, rehypeSpecRefLinkifier];
   const [highlightedId, setHighlightedId] = useState<string | null>(null);
   const chat = useChat();
   const { user } = useAuth();
@@ -419,7 +421,7 @@ export function DecisionPanel({ docId, decisions, commentsByDecision = {}, force
                   <div className="mt-2 pl-2 border-l-2 border-edge-subtle">
                     <span className="text-[10px] uppercase tracking-wider text-muted font-medium">Context</span>
                     <div className="prose-dark prose-sm mt-0.5 opacity-80 *:my-1 [&_h1]:text-sm [&_h2]:text-sm [&_h3]:text-xs [&_h1]:font-semibold [&_h2]:font-semibold [&_h3]:font-medium">
-                      <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={decisionRehypePlugins}>{dec.context}</ReactMarkdown>
+                      <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={decisionRehypePlugins} components={specRefComponents}>{dec.context}</ReactMarkdown>
                     </div>
                   </div>
                 )}
@@ -555,7 +557,7 @@ export function DecisionPanel({ docId, decisions, commentsByDecision = {}, force
                       <div className="mt-2 pl-2 border-l-2 border-edge-subtle">
                         <span className="text-[10px] uppercase tracking-wider text-muted font-medium">Context</span>
                         <div className="prose-dark prose-sm mt-0.5 opacity-80 *:my-1 [&_h1]:text-sm [&_h2]:text-sm [&_h3]:text-xs [&_h1]:font-semibold [&_h2]:font-semibold [&_h3]:font-medium">
-                          <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={decisionRehypePlugins}>{dec.context}</ReactMarkdown>
+                          <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={decisionRehypePlugins} components={specRefComponents}>{dec.context}</ReactMarkdown>
                         </div>
                       </div>
                     )}
@@ -726,7 +728,7 @@ export function DecisionPanel({ docId, decisions, commentsByDecision = {}, force
                         <div className="pl-2 border-l-2 border-status-success-border/50">
                           <span className="text-[10px] uppercase tracking-wider text-status-success-text font-medium">Decision</span>
                           <div className="prose-dark prose-sm mt-0.5 *:my-1 [&_h1]:text-sm [&_h2]:text-sm [&_h3]:text-xs [&_h1]:font-semibold [&_h2]:font-semibold [&_h3]:font-medium">
-                            <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={decisionRehypePlugins}>{dec.resolution}</ReactMarkdown>
+                            <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={decisionRehypePlugins} components={specRefComponents}>{dec.resolution}</ReactMarkdown>
                           </div>
                         </div>
                       )}

--- a/packages/ui/src/components/ExecutionPlanModal.tsx
+++ b/packages/ui/src/components/ExecutionPlanModal.tsx
@@ -3,6 +3,8 @@ import { createPortal } from 'react-dom';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { rehypeRefLinkifier } from './chat/refLinkifier';
+import { specRefComponents } from './specRef/specRefAnchor';
+import { rehypeSpecRefLinkifier } from './chat/specRefLinkifier';
 import {
   fetchDoc,
   fetchTaskComments,
@@ -242,7 +244,7 @@ export function ExecutionPlanModal({
                   {/* spec-389: theme-aware prose (see ChatMarkdown) — `prose-invert`
                       was a dead no-op that washed out in light mode. */}
                   <div className="prose-dark max-w-none wrap-break-word text-sm [&>*:first-child]:mt-0 [&>*:last-child]:mb-0">
-                    <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeRefLinkifier]}>{readiness.content}</ReactMarkdown>
+                    <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeRefLinkifier, rehypeSpecRefLinkifier]} components={specRefComponents}>{readiness.content}</ReactMarkdown>
                   </div>
                 </div>
               )}
@@ -263,7 +265,7 @@ export function ExecutionPlanModal({
                     <p className="text-xs text-muted italic">— Empty —</p>
                   ) : (
                     <div className="prose-dark max-w-none text-sm [&>*:first-child]:mt-0 [&>*:last-child]:mb-0">
-                      <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeRefLinkifier]}>{section.content}</ReactMarkdown>
+                      <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeRefLinkifier, rehypeSpecRefLinkifier]} components={specRefComponents}>{section.content}</ReactMarkdown>
                     </div>
                   )}
                 </section>

--- a/packages/ui/src/components/PromptModal.tsx
+++ b/packages/ui/src/components/PromptModal.tsx
@@ -4,6 +4,8 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeHighlight from 'rehype-highlight';
 import { rehypeRefLinkifier } from './chat/refLinkifier';
+import { specRefComponents } from './specRef/specRefAnchor';
+import { rehypeSpecRefLinkifier } from './chat/specRefLinkifier';
 import { Button } from './ui';
 
 interface PromptModalProps {
@@ -114,7 +116,8 @@ export function PromptModal({ prompt, loading, onClose, title = 'Implementation 
             <div className="prose-dark max-w-none text-sm [&>*:first-child]:mt-0 [&>*:last-child]:mb-0">
               <ReactMarkdown
                 remarkPlugins={[remarkGfm]}
-                rehypePlugins={[rehypeHighlight, rehypeRefLinkifier]}
+                rehypePlugins={[rehypeHighlight, rehypeRefLinkifier, rehypeSpecRefLinkifier]}
+                components={specRefComponents}
               >
                 {editableText}
               </ReactMarkdown>

--- a/packages/ui/src/components/SectionCard.tsx
+++ b/packages/ui/src/components/SectionCard.tsx
@@ -8,6 +8,8 @@ import { useAuth } from './AuthContext';
 import { CommentSourceAvatar } from './CommentSourceAvatar';
 import { CommentMarkdown } from './CommentTray';
 import { rehypeRefLinkifier } from './chat/refLinkifier';
+import { specRefComponents } from './specRef/specRefAnchor';
+import { rehypeSpecRefLinkifier } from './chat/specRefLinkifier';
 import { createComment, resolveComment, deleteComment, addCommentMentions } from '../api/client';
 import { buildCommentLink } from '../utils/commentDeepLink';
 import { buildAnchorRange } from '../utils/anchorHighlight';
@@ -627,12 +629,15 @@ export const SectionCard = memo(function SectionCard({
 });
 
 const remarkPlugins = [remarkGfm];
-const rehypePlugins = [rehypeHighlight, rehypeRefLinkifier];
+const rehypePlugins = [rehypeHighlight, rehypeRefLinkifier, rehypeSpecRefLinkifier];
 
 // spec-100: a `📍c-N` inline-code span (produced by withRenderedMarkers) renders
 // as an interactive marker badge — clickable + locatable from the gutter via its
 // `marker-c-N` id and `data-marker-seq`. Anything else stays normal code.
 const markdownComponents = {
+  // spec-529: a bare `spec-N` anchor becomes the live pill; every other anchor is
+  // untouched.
+  a: specRefComponents.a,
   code({ className, children, ...props }: { className?: string; children?: React.ReactNode }) {
     const text = Array.isArray(children) ? children.join('') : String(children ?? '');
     // Range START sentinel: a zero-width anchor the highlight uses as the left

--- a/packages/ui/src/components/chat/ChatMarkdown.tsx
+++ b/packages/ui/src/components/chat/ChatMarkdown.tsx
@@ -7,6 +7,8 @@ import { ChatSectionLink } from './ChatSectionLink';
 import { ChatTaskCard } from './ChatTaskCard';
 import { Badge } from '../ui';
 import { rehypeRefLinkifier } from './refLinkifier';
+import { specRefComponents } from '../specRef/specRefAnchor';
+import { rehypeSpecRefLinkifier } from './specRefLinkifier';
 
 /**
  * Renders assistant markdown with embedded MDX components.
@@ -14,6 +16,7 @@ import { rehypeRefLinkifier } from './refLinkifier';
  */
 export function ChatMarkdown({ content }: { content: string }) {
   const components = {
+    a: specRefComponents.a,
     decisioncard: ({ id }: { id?: string }) =>
       id ? <ChatDecisionCard id={id} /> : null,
     sectionlink: ({ id }: { id?: string }) =>
@@ -39,7 +42,7 @@ export function ChatMarkdown({ content }: { content: string }) {
     >
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
-        rehypePlugins={[rehypeRaw, rehypeHighlight, rehypeRefLinkifier]}
+        rehypePlugins={[rehypeRaw, rehypeHighlight, rehypeRefLinkifier, rehypeSpecRefLinkifier]}
         components={components as any}
       >
         {content}

--- a/packages/ui/src/components/chat/MarkdownText.tsx
+++ b/packages/ui/src/components/chat/MarkdownText.tsx
@@ -1,6 +1,9 @@
 import ReactMarkdown, { type Components } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { rehypeRefLinkifier } from './refLinkifier';
+import { specRefHandle } from '../specRef/specRefAnchor';
+import { SpecRefPill } from '../specRef/SpecRefPill';
+import { rehypeSpecRefLinkifier } from './specRefLinkifier';
 
 /**
  * Compact markdown renderer for short-to-medium LLM-sourced strings that appear
@@ -32,17 +35,23 @@ export function MarkdownText({
   if (inline) {
     const components: Components = {
       p: ({ children: c }) => <>{c}</>,
-      a: ({ children: c, href }) => (
-        <a href={href} target="_blank" rel="noopener noreferrer" className="underline text-accent hover:text-accent/80">
-          {c}
-        </a>
-      ),
+      a: ({ children: c, href, node }) => {
+        // spec-529: a bare `spec-N` resolves in-app; everything else keeps the
+        // external-link treatment this surface already gives anchors.
+        const specHandle = specRefHandle(node);
+        if (specHandle) return <SpecRefPill handle={specHandle} />;
+        return (
+          <a href={href} target="_blank" rel="noopener noreferrer" className="underline text-accent hover:text-accent/80">
+            {c}
+          </a>
+        );
+      },
     };
     return (
       <span className={className}>
         <ReactMarkdown
           remarkPlugins={[remarkGfm]}
-          rehypePlugins={[rehypeRefLinkifier]}
+          rehypePlugins={[rehypeRefLinkifier, rehypeSpecRefLinkifier]}
           components={components}
         >
           {children}
@@ -57,13 +66,17 @@ export function MarkdownText({
     >
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
-        rehypePlugins={[rehypeRefLinkifier]}
+        rehypePlugins={[rehypeRefLinkifier, rehypeSpecRefLinkifier]}
         components={{
-          a: ({ children: c, href }) => (
-            <a href={href} target="_blank" rel="noopener noreferrer" className="underline text-accent hover:text-accent/80">
-              {c}
-            </a>
-          ),
+          a: ({ children: c, href, node }) => {
+            const specHandle = specRefHandle(node);
+            if (specHandle) return <SpecRefPill handle={specHandle} />;
+            return (
+              <a href={href} target="_blank" rel="noopener noreferrer" className="underline text-accent hover:text-accent/80">
+                {c}
+              </a>
+            );
+          },
         }}
       >
         {children}

--- a/packages/ui/src/components/chat/specRefLinkifier.test.tsx
+++ b/packages/ui/src/components/chat/specRefLinkifier.test.tsx
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import ReactMarkdown from 'react-markdown';
+import rehypeRaw from 'rehype-raw';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { rehypeRefLinkifier } from './refLinkifier';
+import { rehypeSpecRefLinkifier } from './specRefLinkifier';
+
+/**
+ * Mirrors the shipped render config: `rehype-raw`, then the canonical-path
+ * linkifier, then the bare-handle one. Order matters — the canonical-path
+ * plugin runs FIRST so the path form is already an anchor by the time this
+ * plugin walks, and anchors are skipped wholesale.
+ */
+function renderMd(content: string) {
+  return render(
+    <ReactMarkdown
+      rehypePlugins={[rehypeRaw, rehypeRefLinkifier, rehypeSpecRefLinkifier]}
+    >
+      {content}
+    </ReactMarkdown>,
+  );
+}
+
+function getSpecRefs(container: HTMLElement): HTMLAnchorElement[] {
+  return Array.from(
+    container.querySelectorAll<HTMLAnchorElement>('a[data-spec-ref="true"]'),
+  );
+}
+
+function handles(container: HTMLElement): string[] {
+  return getSpecRefs(container).map((a) => a.getAttribute('data-spec-handle') ?? '');
+}
+
+describe('rehypeSpecRefLinkifier', () => {
+  it('turns a bare spec-N into an anchor carrying the handle', () => {
+    const { container } = renderMd('The board work lands in spec-335 this week.');
+    const refs = getSpecRefs(container);
+    expect(refs).toHaveLength(1);
+    expect(refs[0].getAttribute('data-spec-handle')).toBe('spec-335');
+    expect(refs[0].textContent).toBe('spec-335');
+  });
+
+  it('matches every handle in one text node and preserves the surrounding prose', () => {
+    const { container } = renderMd(
+      'Only spec-335, spec-373 and spec-371 have shipped code.',
+    );
+    expect(handles(container)).toEqual(['spec-335', 'spec-373', 'spec-371']);
+    expect(container.textContent).toBe(
+      'Only spec-335, spec-373 and spec-371 have shipped code.',
+    );
+  });
+
+  it('matches a handle abutting punctuation without swallowing it', () => {
+    const { container } = renderMd('Superseded by spec-372. (see spec-162, too)');
+    expect(handles(container)).toEqual(['spec-372', 'spec-162']);
+    expect(container.textContent).toBe(
+      'Superseded by spec-372. (see spec-162, too)',
+    );
+  });
+
+  it('leaves handles inside inline code and fenced blocks verbatim', () => {
+    const { container } = renderMd(
+      'Use `spec-335` as the ref.\n\n```\nget_doc spec-373\n```\n',
+    );
+    expect(getSpecRefs(container)).toHaveLength(0);
+    expect(container.querySelector('code')?.textContent).toBe('spec-335');
+  });
+
+  it('does not double-link a handle already inside an anchor', () => {
+    const { container } = renderMd('[the board spec](/x/y/specs/spec-335)');
+    expect(getSpecRefs(container)).toHaveLength(0);
+    expect(container.querySelectorAll('a')).toHaveLength(1);
+  });
+
+  it('leaves the handle inside a full canonical path to the path linkifier', () => {
+    tagAc('mindset-prod/memex-building-itself/specs/spec-529/acs/ac-8');
+    const { container } = renderMd(
+      'See mindset-prod/mindset-four/specs/spec-335 for the board work.',
+    );
+    // The canonical-path plugin still owns this form, unchanged by our arrival.
+    const pathLinks = container.querySelectorAll('a[data-ref-link="true"]');
+    expect(pathLinks).toHaveLength(1);
+    expect(pathLinks[0].textContent).toBe(
+      'mindset-prod/mindset-four/specs/spec-335',
+    );
+    // And the bare matcher does NOT also fire inside it.
+    expect(getSpecRefs(container)).toHaveLength(0);
+  });
+
+  it('matches spec-N only — std-N and doc-N stay plain text', () => {
+    tagAc('mindset-prod/memex-building-itself/specs/spec-529/acs/ac-12');
+    const { container } = renderMd(
+      'Governed by std-10 and described in doc-36, delivered by spec-529.',
+    );
+    expect(handles(container)).toEqual(['spec-529']);
+    expect(container.textContent).toBe(
+      'Governed by std-10 and described in doc-36, delivered by spec-529.',
+    );
+  });
+
+  it('ignores handle-shaped text that is part of a longer token', () => {
+    const { container } = renderMd('sub-spec-3 and spec-3a and myspec-4 are prose.');
+    expect(getSpecRefs(container)).toHaveLength(0);
+  });
+
+  it('rejects loose forms — leading zeros, a zero, and case variants', () => {
+    const { container } = renderMd('Not spec-007, not spec-0, not Spec-3, not SPEC-3.');
+    expect(getSpecRefs(container)).toHaveLength(0);
+  });
+
+  it('leaves a body with no handles structurally untouched', () => {
+    const { container } = renderMd('Nothing to see here.');
+    expect(getSpecRefs(container)).toHaveLength(0);
+    expect(container.textContent).toBe('Nothing to see here.');
+  });
+});

--- a/packages/ui/src/components/chat/specRefLinkifier.test.tsx
+++ b/packages/ui/src/components/chat/specRefLinkifier.test.tsx
@@ -68,7 +68,9 @@ describe('rehypeSpecRefLinkifier', () => {
   });
 
   it('does not double-link a handle already inside an anchor', () => {
-    const { container } = renderMd('[the board spec](/x/y/specs/spec-335)');
+    // The handle must be in the anchor's TEXT, not just its href — otherwise the
+    // assertion passes even with 'a' removed from the skip set.
+    const { container } = renderMd('[spec-335](/x/y/specs/spec-335)');
     expect(getSpecRefs(container)).toHaveLength(0);
     expect(container.querySelectorAll('a')).toHaveLength(1);
   });

--- a/packages/ui/src/components/chat/specRefLinkifier.ts
+++ b/packages/ui/src/components/chat/specRefLinkifier.ts
@@ -1,0 +1,185 @@
+/**
+ * rehypeSpecRefLinkifier — a rehype plugin that auto-links a BARE `spec-N`
+ * handle inside markdown text nodes.
+ *
+ * The third member of the linkifier family, and orthogonal to both siblings:
+ *   - `rehypeRefLinkifier`     matches FULL canonical paths (`ns/mx/specs/spec-N/...`)
+ *   - `rehypePerRefLinkifier`  matches the `[per dec-N]` cross-entity shorthand
+ *   - this plugin              matches the bare `spec-N` a body writes in prose
+ *
+ * A bare handle resolves WITHIN THE CONTAINING MEMEX and nowhere else. Handles
+ * are per-memex [per std-10 cl-14], which is exactly what makes the bare form
+ * safe here and meaningless once the text is read from somewhere else; a
+ * cross-memex reference therefore keeps the full canonical path its sibling
+ * already matches.
+ *
+ * MOUNT ORDER MATTERS: this plugin must run AFTER `rehypeRefLinkifier`, so a
+ * canonical path is already an anchor by the time this walker arrives and is
+ * skipped wholesale. The pattern's own boundary guards make it correct either
+ * way, but the order keeps the two from ever competing for the same text.
+ *
+ * The anchor carries `data-spec-ref` + `data-spec-handle` so a react-markdown
+ * `a` component mapping can upgrade it into the interactive `<SpecRefPill>`,
+ * which resolves the handle against the page's shared status set. No route is
+ * knowable at plugin time (the plugin has no namespace/memex context), which is
+ * why the href is inert here and the component owns it.
+ *
+ * Rules (mirrors both siblings):
+ *   - Text inside `<code>` / `<pre>` is skipped — a handle in a code sample
+ *     renders verbatim, and backticks stay the author's escape hatch
+ *     [per std-10 cl-72].
+ *   - Text inside an existing `<a>` is skipped, so nothing double-links
+ *     [per std-10 cl-73].
+ *   - Surrounding text is preserved exactly; only the matched substring moves.
+ *   - Pure / render-time only. Storage stays plain markdown [per std-10 cl-74].
+ */
+
+// Local hast type shims — see refLinkifier.ts for why these are kept local
+// rather than pulling in `@types/hast`.
+
+type HastText = { type: 'text'; value: string };
+
+type HastProperties = Record<
+  string,
+  string | number | boolean | null | undefined | (string | number)[]
+>;
+
+interface HastElement {
+  type: 'element';
+  tagName: string;
+  properties?: HastProperties;
+  children: HastChild[];
+}
+
+type HastChild = HastText | HastElement | { type: string; [key: string]: unknown };
+
+interface HastRoot {
+  type: 'root';
+  children: HastChild[];
+}
+
+// A bare `spec-N` handle, and ONLY that.
+//
+// - `spec-` is case-strict and the type prefix is mandatory [per std-10 cl-12,
+//   cl-44], so `Spec-3` / `SPEC-3` are prose, not references.
+// - `[1-9]\d*` — a positive integer with no leading zeros [per std-10 cl-11],
+//   so `spec-0` and `spec-007` are not handles.
+// - The lookbehind rejects a handle that is part of a longer token (`sub-spec-3`)
+//   or a path segment (`.../specs/spec-3`, which belongs to rehypeRefLinkifier).
+// - The lookahead rejects a trailing word or hyphen character (`spec-3a`), while
+//   still allowing ordinary punctuation to abut (`spec-3.`, `spec-3,`).
+// - `std-N` and `doc-N` are deliberately NOT matched (spec-529 dec-4): they carry
+//   an approval state and open drift findings rather than a phase and tasks, so
+//   they need their own card face, not a wider pattern here.
+//
+// `g` because we scan each text node for every handle it contains.
+export const SPEC_HANDLE_PATTERN = /(?<![\w/-])spec-([1-9]\d*)(?![\w-])/g;
+
+const SKIP_TAGS = new Set(['code', 'pre', 'a']);
+
+/**
+ * Builds the hast anchor a component mapping upgrades into the pill. Rendered
+ * without that mapping it is an inert anchor showing the handle exactly as the
+ * author wrote it — the same degradation an unresolvable handle gets.
+ */
+function makeSpecAnchor(handle: string): HastElement {
+  return {
+    type: 'element',
+    tagName: 'a',
+    properties: {
+      // The route depends on the containing namespace/memex, which the plugin
+      // cannot see; SpecRefPill builds the real href.
+      href: '#',
+      className: ['spec-ref-link'],
+      'data-spec-ref': 'true',
+      'data-spec-handle': handle,
+    },
+    children: [{ type: 'text', value: handle }],
+  };
+}
+
+/**
+ * Splits one text node into text + anchor nodes. Returns the original node
+ * (wrapped) when nothing matches, so untouched subtrees keep their identity.
+ */
+function linkifyTextNode(node: HastText): HastChild[] {
+  const value = node.value;
+  SPEC_HANDLE_PATTERN.lastIndex = 0;
+
+  const out: HastChild[] = [];
+  let cursor = 0;
+  let match: RegExpExecArray | null;
+  while ((match = SPEC_HANDLE_PATTERN.exec(value)) !== null) {
+    const [full] = match;
+    const start = match.index;
+
+    if (start > cursor) {
+      out.push({ type: 'text', value: value.slice(cursor, start) });
+    }
+    out.push(makeSpecAnchor(full));
+    cursor = start + full.length;
+
+    // Cheap insurance against a zero-width match spinning forever.
+    if (match.index === SPEC_HANDLE_PATTERN.lastIndex) {
+      SPEC_HANDLE_PATTERN.lastIndex++;
+    }
+  }
+
+  if (out.length === 0) return [node];
+  if (cursor < value.length) {
+    out.push({ type: 'text', value: value.slice(cursor) });
+  }
+  return out;
+}
+
+/**
+ * Walks the tree, transforming text children of any element that isn't itself
+ * a `code` / `pre` / `a` (those subtrees are skipped whole).
+ */
+function walk(node: HastRoot | HastElement): void {
+  if (!Array.isArray(node.children)) return;
+
+  const nextChildren: HastChild[] = [];
+  let mutated = false;
+
+  for (const child of node.children) {
+    if (child.type === 'text') {
+      const textChild = child as HastText;
+      const replacement = linkifyTextNode(textChild);
+      if (replacement.length !== 1 || replacement[0] !== textChild) {
+        mutated = true;
+      }
+      nextChildren.push(...replacement);
+      continue;
+    }
+
+    if (child.type === 'element') {
+      const elementChild = child as HastElement;
+      if (SKIP_TAGS.has(elementChild.tagName)) {
+        nextChildren.push(elementChild);
+        continue;
+      }
+      walk(elementChild);
+      nextChildren.push(elementChild);
+      continue;
+    }
+
+    nextChildren.push(child);
+  }
+
+  if (mutated) {
+    node.children = nextChildren;
+  }
+}
+
+/**
+ * rehype plugin factory. Pass to `rehypePlugins` on `<ReactMarkdown>`, AFTER
+ * `rehypeRefLinkifier`.
+ */
+export function rehypeSpecRefLinkifier() {
+  return (tree: HastRoot) => {
+    walk(tree);
+  };
+}
+
+export default rehypeSpecRefLinkifier;

--- a/packages/ui/src/components/specRef/SpecRefCard.tsx
+++ b/packages/ui/src/components/specRef/SpecRefCard.tsx
@@ -104,8 +104,9 @@ export function SpecRefCard({ id, doc }: { id: string; doc: DocSummary }) {
           data-testid="spec-ref-activity"
           className="mt-2 block border-t border-subtle pt-2 text-[11px] text-muted"
         >
+          {/* WHAT changed and WHEN — never WHO. This card is read by anonymous
+              visitors on public Memexes, and actor identity is PII. */}
           {doc.lastActivity.narrative} · {formatDate(doc.lastActivity.at)}
-          {doc.lastActivity.actorName ? ` · ${doc.lastActivity.actorName}` : ''}
         </span>
       )}
     </span>

--- a/packages/ui/src/components/specRef/SpecRefCard.tsx
+++ b/packages/ui/src/components/specRef/SpecRefCard.tsx
@@ -1,0 +1,113 @@
+import type { DocSummary } from '../../api/types';
+import { Badge } from '../ui';
+
+/**
+ * spec-529 t-5 — the card behind a reference pill.
+ *
+ * Renders entirely from the page's already-resolved status set: opening it
+ * issues no request. Nothing inside is interactive, which keeps the
+ * focus-management problem small — the pill itself is the link.
+ *
+ * The acceptance-criteria line is the one that needs care. "Untested" is an
+ * ABSENCE of signal, not a failure, which is the distinction `acHealth` already
+ * draws between `covered` and `totalActive`. A Spec with no criteria at all must
+ * therefore read as "no commitments yet" and never as 0% complete — those are
+ * different states and conflating them would make the card lie about the Spec
+ * that has committed to nothing.
+ */
+
+function formatDate(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '';
+  return d.toLocaleDateString([], { day: 'numeric', month: 'short', year: 'numeric' });
+}
+
+/** Whole days between then and now, floored. */
+function daysSince(iso: string): number | null {
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return null;
+  return Math.max(0, Math.floor((Date.now() - then) / 86_400_000));
+}
+
+export function SpecRefCard({ id, doc }: { id: string; doc: DocSummary }) {
+  const progress = doc.taskProgress;
+  const health = doc.acHealth;
+  const inPhase = daysSince(doc.statusChangedAt);
+
+  return (
+    <span
+      id={id}
+      role="tooltip"
+      data-testid="spec-ref-card"
+      className="absolute left-0 top-full z-50 mt-1 block w-80 cursor-default rounded-md border border-subtle bg-panel p-3 text-left shadow-lg"
+    >
+      <span className="block text-sm font-semibold text-heading">{doc.title}</span>
+
+      <span className="mt-1 flex items-center gap-1.5 text-[11px] text-secondary">
+        <span className="font-mono">{doc.handle}</span>
+        <Badge status={doc.status} />
+        {inPhase !== null && (
+          <span>
+            {inPhase === 0 ? 'today' : `${inPhase}d in ${doc.status.replace(/_/g, ' ')}`}
+          </span>
+        )}
+      </span>
+
+      {/* Archived and superseded must be unmissable: a reference to a replaced
+          Spec that reads as live is worse than no pill at all. */}
+      {doc.archivedAt && (
+        <span
+          data-testid="spec-ref-archived"
+          className="mt-2 block rounded-sm border border-warning/40 bg-warning/10 px-2 py-1 text-[11px] text-warning"
+        >
+          Archived{doc.archiveReason ? ` — ${doc.archiveReason}` : ''}
+        </span>
+      )}
+      {doc.supersededByDocId && (
+        <span
+          data-testid="spec-ref-superseded"
+          className="mt-2 block rounded-sm border border-warning/40 bg-warning/10 px-2 py-1 text-[11px] text-warning"
+        >
+          Superseded{doc.supersessionNote ? ` — ${doc.supersessionNote}` : ''}
+        </span>
+      )}
+
+      <span className="mt-2 block text-[11px] text-primary">
+        {progress ? (
+          <span data-testid="spec-ref-tasks">
+            {progress.complete} of {progress.total} tasks complete
+            {progress.inProgress > 0 && `, ${progress.inProgress} in progress`}
+            {progress.notStarted > 0 && `, ${progress.notStarted} not started`}
+          </span>
+        ) : (
+          <span data-testid="spec-ref-tasks">No tasks yet</span>
+        )}
+      </span>
+
+      <span className="mt-1 block text-[11px] text-primary">
+        {health && health.totalActive > 0 ? (
+          <span data-testid="spec-ref-acs">
+            {Math.round((health.verified / health.totalActive) * 100)}% of{' '}
+            {health.totalActive} acceptance criteria verified
+            {health.failing > 0 && `, ${health.failing} failing`}
+            {/* Untested is reported as what it is — nothing has been asserted yet
+                — never folded in with failures. */}
+            {health.untested > 0 && `, ${health.untested} untested`}
+          </span>
+        ) : (
+          <span data-testid="spec-ref-acs">No acceptance criteria yet</span>
+        )}
+      </span>
+
+      {doc.lastActivity && (
+        <span
+          data-testid="spec-ref-activity"
+          className="mt-2 block border-t border-subtle pt-2 text-[11px] text-muted"
+        >
+          {doc.lastActivity.narrative} · {formatDate(doc.lastActivity.at)}
+          {doc.lastActivity.actorName ? ` · ${doc.lastActivity.actorName}` : ''}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/packages/ui/src/components/specRef/SpecRefPill.test.tsx
+++ b/packages/ui/src/components/specRef/SpecRefPill.test.tsx
@@ -1,0 +1,225 @@
+// spec-529 t-3/t-4/t-5 — the resolution layer, the pill face, and the card.
+//
+// fetchDocs is mocked so the request COUNT is itself an assertion: the whole point
+// of the provider is that a document mentioning many Specs makes one request, and
+// that opening a card makes none.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { tagAc } from '@memex-ai-ac/vitest';
+import type { DocSummary } from '../../api/types';
+
+vi.mock('../../api/docs', () => ({ fetchDocs: vi.fn() }));
+
+import { fetchDocs } from '../../api/docs';
+import { SpecRefStatusProvider } from './SpecRefStatusProvider';
+import { SpecRefPill } from './SpecRefPill';
+
+const mockFetchDocs = fetchDocs as unknown as ReturnType<typeof vi.fn>;
+
+function makeDoc(over: Partial<DocSummary> = {}): DocSummary {
+  return {
+    id: 'id-1',
+    handle: 'spec-335',
+    title: 'The board becomes reliable and legible again',
+    docType: 'spec',
+    status: 'build',
+    parentDocId: null,
+    createdAt: '2026-08-01T10:00:00Z',
+    statusChangedAt: '2026-08-10T10:00:00Z',
+    sectionCount: 4,
+    archivedAt: null,
+    taskProgress: { total: 8, complete: 4, inProgress: 1, notStarted: 3 },
+    ...over,
+  } as DocSummary;
+}
+
+function renderPills(handles: string[]) {
+  return render(
+    <MemoryRouter initialEntries={['/mindset-prod/mindset-four/docs/doc-36']}>
+      <SpecRefStatusProvider>
+        {handles.map((h, i) => (
+          <SpecRefPill key={`${h}-${i}`} handle={h} />
+        ))}
+      </SpecRefStatusProvider>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  window.history.pushState({}, '', '/mindset-prod/mindset-four/docs/doc-36');
+});
+
+describe('SpecRefStatusProvider — one request per page', () => {
+  it('resolves every handle on the page in a single request', async () => {
+    tagAc('mindset-prod/memex-building-itself/specs/spec-529/acs/ac-4');
+    mockFetchDocs.mockResolvedValue([
+      makeDoc({ handle: 'spec-335' }),
+      makeDoc({ id: 'id-2', handle: 'spec-373', title: 'A failed tool says why' }),
+      makeDoc({ id: 'id-3', handle: 'spec-371', title: 'An unattended run' }),
+    ]);
+
+    renderPills(['spec-335', 'spec-373', 'spec-371']);
+
+    await waitFor(() => expect(screen.getAllByTestId('spec-ref-pill')).toHaveLength(3));
+    expect(mockFetchDocs).toHaveBeenCalledTimes(1);
+    expect(mockFetchDocs.mock.calls[0][1].handles).toEqual([
+      'spec-335',
+      'spec-373',
+      'spec-371',
+    ]);
+  });
+
+  it('requests a repeated handle once', async () => {
+    mockFetchDocs.mockResolvedValue([makeDoc()]);
+    renderPills(['spec-335', 'spec-335', 'spec-335']);
+    await waitFor(() => expect(mockFetchDocs).toHaveBeenCalledTimes(1));
+    expect(mockFetchDocs.mock.calls[0][1].handles).toEqual(['spec-335']);
+  });
+
+  it('degrades the page to plain handles when resolution fails', async () => {
+    mockFetchDocs.mockRejectedValue(new Error('network'));
+    const { container } = renderPills(['spec-335']);
+    await waitFor(() => expect(mockFetchDocs).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(screen.queryByTestId('spec-ref-pill')).not.toBeInTheDocument(),
+    );
+    expect(container.textContent).toBe('spec-335');
+  });
+});
+
+describe('SpecRefPill — the face', () => {
+  it('carries handle, phase and task progress, and NOT the title', async () => {
+    tagAc('mindset-prod/memex-building-itself/specs/spec-529/acs/ac-1');
+    mockFetchDocs.mockResolvedValue([makeDoc()]);
+    renderPills(['spec-335']);
+
+    const pill = await screen.findByTestId('spec-ref-pill');
+    expect(pill.textContent).toContain('spec-335');
+    expect(pill.textContent).toContain('build');
+    expect(pill.textContent).toContain('4/8 tasks');
+    // The title is a full sentence; inlining it would wreck the line.
+    expect(pill.textContent).not.toContain('The board becomes reliable');
+  });
+
+  it('links to the Spec within the containing Memex', async () => {
+    mockFetchDocs.mockResolvedValue([makeDoc()]);
+    renderPills(['spec-335']);
+    const pill = await screen.findByTestId('spec-ref-pill');
+    expect(pill.getAttribute('href')).toBe('/mindset-prod/mindset-four/specs/spec-335');
+  });
+
+  it('shows no fraction for a Spec with no tasks', async () => {
+    mockFetchDocs.mockResolvedValue([makeDoc({ taskProgress: undefined })]);
+    renderPills(['spec-335']);
+    const pill = await screen.findByTestId('spec-ref-pill');
+    // Absence is the signal — never `0/0`.
+    expect(pill.textContent).not.toContain('tasks');
+  });
+
+  it('renders an unresolvable handle as ordinary text with no pill or link', async () => {
+    tagAc('mindset-prod/memex-building-itself/specs/spec-529/acs/ac-3');
+    // The server answers "no such Spec" and "not yours to see" identically, and so
+    // does this: no pill, no link, no hover affordance, nothing to probe.
+    mockFetchDocs.mockResolvedValue([]);
+    const { container } = renderPills(['spec-999']);
+    await waitFor(() => expect(mockFetchDocs).toHaveBeenCalled());
+    await waitFor(() => expect(container.textContent).toBe('spec-999'));
+    expect(screen.queryByTestId('spec-ref-pill')).not.toBeInTheDocument();
+    expect(container.querySelector('a')).toBeNull();
+  });
+
+  it('renders as plain text with no provider above it', async () => {
+    const { container } = render(
+      <MemoryRouter>
+        <SpecRefPill handle="spec-335" />
+      </MemoryRouter>,
+    );
+    expect(container.textContent).toBe('spec-335');
+    expect(mockFetchDocs).not.toHaveBeenCalled();
+  });
+});
+
+describe('SpecRefCard — the whole story, without a request', () => {
+  async function openCard(over: Partial<DocSummary> = {}) {
+    mockFetchDocs.mockResolvedValue([makeDoc(over)]);
+    renderPills([(over.handle as string) ?? 'spec-335']);
+    const pill = await screen.findByTestId('spec-ref-pill');
+    mockFetchDocs.mockClear();
+    fireEvent.focus(pill);
+    return screen.findByTestId('spec-ref-card');
+  }
+
+  it('opens on focus and fetches nothing', async () => {
+    tagAc('mindset-prod/memex-building-itself/specs/spec-529/acs/ac-4');
+    const card = await openCard({
+      acHealth: { totalActive: 10, covered: 8, verified: 6, failing: 1, stale: 0, untested: 2 },
+      lastActivity: {
+        at: '2026-08-11T09:00:00Z',
+        narrative: 'moved to build',
+        actorName: 'a teammate',
+      },
+    });
+    expect(card.textContent).toContain('The board becomes reliable');
+    expect(card.textContent).toContain('4 of 8 tasks complete');
+    expect(card.textContent).toContain('60% of 10 acceptance criteria verified');
+    expect(card.textContent).toContain('moved to build');
+    // Reading the card costs nothing — the status was already on the page.
+    expect(mockFetchDocs).not.toHaveBeenCalled();
+  });
+
+  it('opens on tap as well as hover, so it exists on touch', async () => {
+    tagAc('mindset-prod/memex-building-itself/specs/spec-529/acs/ac-2');
+    mockFetchDocs.mockResolvedValue([makeDoc()]);
+    renderPills(['spec-335']);
+    const pill = await screen.findByTestId('spec-ref-pill');
+    fireEvent.click(pill);
+    expect(await screen.findByTestId('spec-ref-card')).toBeInTheDocument();
+  });
+
+  it('closes on blur', async () => {
+    const card = await openCard();
+    expect(card).toBeInTheDocument();
+    fireEvent.blur(screen.getByTestId('spec-ref-pill'));
+    await waitFor(() =>
+      expect(screen.queryByTestId('spec-ref-card')).not.toBeInTheDocument(),
+    );
+  });
+
+  it('says a Spec with no criteria has none — never 0% complete', async () => {
+    const card = await openCard({ acHealth: undefined, taskProgress: undefined });
+    // "No commitments yet" and "0% of its commitments met" are different states.
+    expect(card.textContent).toContain('No acceptance criteria yet');
+    expect(card.textContent).not.toContain('0%');
+    expect(card.textContent).toContain('No tasks yet');
+  });
+
+  it('reports untested criteria as untested, not as failures', async () => {
+    const card = await openCard({
+      acHealth: { totalActive: 4, covered: 1, verified: 1, failing: 0, stale: 0, untested: 3 },
+    });
+    expect(card.textContent).toContain('3 untested');
+    expect(card.textContent).not.toContain('failing');
+  });
+
+  it('says so when the referenced Spec is archived', async () => {
+    const card = await openCard({
+      archivedAt: '2026-08-09T10:00:00Z',
+      archiveReason: 'absorbed into spec-510',
+    });
+    expect(card.textContent).toContain('Archived');
+    expect(card.textContent).toContain('absorbed into spec-510');
+  });
+
+  it('says so when the referenced Spec has been superseded', async () => {
+    const card = await openCard({
+      supersededByDocId: 'id-9',
+      supersessionNote: 'replaced by the newer board work',
+    });
+    // A reference to a replaced Spec that reads as live is worse than no pill.
+    expect(card.textContent).toContain('Superseded');
+    expect(card.textContent).toContain('replaced by the newer board work');
+  });
+});

--- a/packages/ui/src/components/specRef/SpecRefPill.test.tsx
+++ b/packages/ui/src/components/specRef/SpecRefPill.test.tsx
@@ -5,8 +5,8 @@
 // that opening a card makes none.
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { render, screen, waitFor, fireEvent, createEvent } from '@testing-library/react';
+import { MemoryRouter, Routes, Route, Link } from 'react-router-dom';
 import { tagAc } from '@memex-ai-ac/vitest';
 import type { DocSummary } from '../../api/types';
 
@@ -48,7 +48,9 @@ function renderPills(handles: string[]) {
 }
 
 beforeEach(() => {
-  vi.clearAllMocks();
+  // reset, not clear: `clearAllMocks` leaves queued `...Once` implementations
+  // behind, and an unconsumed one is then served to the NEXT test.
+  vi.resetAllMocks();
   window.history.pushState({}, '', '/mindset-prod/mindset-four/docs/doc-36');
 });
 
@@ -87,6 +89,43 @@ describe('SpecRefStatusProvider — one request per page', () => {
       expect(screen.queryByTestId('spec-ref-pill')).not.toBeInTheDocument(),
     );
     expect(container.textContent).toBe('spec-335');
+  });
+});
+
+describe('the cache is per-Memex (spec-529 review)', () => {
+  it('re-resolves the same handle after a Memex switch, and never serves the old answer', async () => {
+    tagAc('mindset-prod/memex-building-itself/specs/spec-529/acs/ac-1');
+    // Handles are per-Memex, so `spec-335` in another Memex is a DIFFERENT Spec.
+    // The navigation has to be REAL: MemoryRouter reads `initialEntries` only on
+    // first mount, so re-rendering it with a new path changes nothing.
+    function Harness() {
+      return (
+        <SpecRefStatusProvider>
+          <Link to="/org/beta/specs/spec-1">switch</Link>
+          <SpecRefPill handle="spec-335" />
+        </SpecRefStatusProvider>
+      );
+    }
+    mockFetchDocs.mockResolvedValue([makeDoc({ title: 'Alpha spec', status: 'build' })]);
+    render(
+      <MemoryRouter initialEntries={['/org/alpha/specs/spec-1']}>
+        <Routes>
+          <Route path="/:namespace/:memex/*" element={<Harness />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId('spec-ref-pill').textContent).toContain('build'),
+    );
+
+    mockFetchDocs.mockResolvedValue([makeDoc({ title: 'Beta spec', status: 'verify' })]);
+    fireEvent.click(screen.getByRole('link', { name: 'switch' }));
+
+    // Asked again for the new tenant rather than reusing alpha's answer.
+    await waitFor(() => expect(mockFetchDocs).toHaveBeenCalledTimes(2));
+    await waitFor(() =>
+      expect(screen.getByTestId('spec-ref-pill').textContent).toContain('verify'),
+    );
   });
 });
 
@@ -145,6 +184,36 @@ describe('SpecRefPill — the face', () => {
   });
 });
 
+describe('the resolver asks for what the card promises (spec-529 review)', () => {
+  it('requests archived Specs, so a reference to one can say it is archived', async () => {
+    tagAc('mindset-prod/memex-building-itself/specs/spec-529/acs/ac-2');
+    mockFetchDocs.mockResolvedValue([makeDoc()]);
+    renderPills(['spec-335']);
+    await waitFor(() => expect(mockFetchDocs).toHaveBeenCalled());
+    // Without this the server filters archived rows out, the handle resolves as
+    // absent, and the card's Archived banner is unreachable — the reader is told
+    // nothing about the fact that what they are pointed at has been archived.
+    expect(mockFetchDocs.mock.calls[0][1].includeArchived).toBe(true);
+  });
+
+  it('chunks a set larger than the server cap instead of losing its tail', async () => {
+    tagAc('mindset-prod/memex-building-itself/specs/spec-529/acs/ac-4');
+    const handles = Array.from({ length: 200 }, (_, i) => `spec-${i + 1}`);
+    mockFetchDocs.mockResolvedValue([]);
+    renderPills(handles);
+    await waitFor(() => expect(mockFetchDocs).toHaveBeenCalled());
+    await waitFor(() => {
+      const sent = mockFetchDocs.mock.calls.flatMap((c: unknown[]) => (c[1] as { handles: string[] }).handles);
+      expect(sent).toHaveLength(200);
+    });
+    // Every request stays within the server's cap; nothing is silently dropped
+    // and then cached as missing for the rest of the session.
+    for (const call of mockFetchDocs.mock.calls) {
+      expect(call[1].handles.length).toBeLessThanOrEqual(100);
+    }
+  });
+});
+
 describe('SpecRefCard — the whole story, without a request', () => {
   async function openCard(over: Partial<DocSummary> = {}) {
     mockFetchDocs.mockResolvedValue([makeDoc(over)]);
@@ -173,13 +242,32 @@ describe('SpecRefCard — the whole story, without a request', () => {
     expect(mockFetchDocs).not.toHaveBeenCalled();
   });
 
-  it('opens on tap as well as hover, so it exists on touch', async () => {
+  it('opens on a TAP and suppresses that tap\'s navigation, so it exists on touch', async () => {
     tagAc('mindset-prod/memex-building-itself/specs/spec-529/acs/ac-2');
     mockFetchDocs.mockResolvedValue([makeDoc()]);
     renderPills(['spec-335']);
     const pill = await screen.findByTestId('spec-ref-pill');
-    fireEvent.click(pill);
+
+    // A touch has no hover, so without this the tap would simply follow the link
+    // and the card would never be reachable on a phone.
+    fireEvent.pointerDown(pill, { pointerType: 'touch' });
+    const clickEvent = createEvent.click(pill);
+    fireEvent(pill, clickEvent);
+    expect(clickEvent.defaultPrevented).toBe(true);
     expect(await screen.findByTestId('spec-ref-card')).toBeInTheDocument();
+  });
+
+  it('lets a MOUSE click navigate, because hover already showed the card', async () => {
+    mockFetchDocs.mockResolvedValue([makeDoc()]);
+    renderPills(['spec-335']);
+    const pill = await screen.findByTestId('spec-ref-pill');
+    fireEvent.pointerDown(pill, { pointerType: 'mouse' });
+    fireEvent.click(pill);
+    // `defaultPrevented` cannot distinguish here — react-router's Link always
+    // prevents the default in order to navigate client-side. What separates the
+    // two paths is that a mouse click does NOT divert into opening the card: on a
+    // pointer device hover has already shown it, so the click means "go there".
+    expect(screen.queryByTestId('spec-ref-card')).not.toBeInTheDocument();
   });
 
   it('closes on blur', async () => {

--- a/packages/ui/src/components/specRef/SpecRefPill.test.tsx
+++ b/packages/ui/src/components/specRef/SpecRefPill.test.tsx
@@ -91,7 +91,7 @@ describe('SpecRefStatusProvider — one request per page', () => {
 });
 
 describe('SpecRefPill — the face', () => {
-  it('carries handle, phase and task progress, and NOT the title', async () => {
+  it('carries the handle and a phase chip, and nothing else', async () => {
     tagAc('mindset-prod/memex-building-itself/specs/spec-529/acs/ac-1');
     mockFetchDocs.mockResolvedValue([makeDoc()]);
     renderPills(['spec-335']);
@@ -99,7 +99,9 @@ describe('SpecRefPill — the face', () => {
     const pill = await screen.findByTestId('spec-ref-pill');
     expect(pill.textContent).toContain('spec-335');
     expect(pill.textContent).toContain('build');
-    expect(pill.textContent).toContain('4/8 tasks');
+    // Task progress is NOT on the face: repeated through a paragraph a fraction is
+    // noise, and the split belongs to the card, which has room to spell it out.
+    expect(pill.textContent).not.toMatch(/\d+\/\d+/);
     // The title is a full sentence; inlining it would wreck the line.
     expect(pill.textContent).not.toContain('The board becomes reliable');
   });
@@ -111,12 +113,13 @@ describe('SpecRefPill — the face', () => {
     expect(pill.getAttribute('href')).toBe('/mindset-prod/mindset-four/specs/spec-335');
   });
 
-  it('shows no fraction for a Spec with no tasks', async () => {
+  it('looks the same for a Spec with no tasks — the face never carried a count', async () => {
     mockFetchDocs.mockResolvedValue([makeDoc({ taskProgress: undefined })]);
     renderPills(['spec-335']);
     const pill = await screen.findByTestId('spec-ref-pill');
-    // Absence is the signal — never `0/0`.
-    expect(pill.textContent).not.toContain('tasks');
+    expect(pill.textContent).toContain('spec-335');
+    expect(pill.textContent).toContain('build');
+    expect(pill.textContent).not.toMatch(/\d+\/\d+/);
   });
 
   it('renders an unresolvable handle as ordinary text with no pill or link', async () => {

--- a/packages/ui/src/components/specRef/SpecRefPill.tsx
+++ b/packages/ui/src/components/specRef/SpecRefPill.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useCallback, useId } from "react";
 import { Link } from "react-router-dom";
-import { statusClasses } from "../../utils/statusStyles";
+import { statusTextClass } from "../../utils/statusStyles";
 import { parseTenantFromPathname } from "../../utils/tenantUrl";
 import { useSpecRefStatus } from "./SpecRefStatusProvider";
 import { SpecRefCard } from "./SpecRefCard";
@@ -77,14 +77,17 @@ export function SpecRefPill({ handle }: { handle: string }) {
   // noise, and it is the card's job to spell the split out. The chip is the Badge
   // treatment shrunk to sit inside a line of prose without boxing it — same colour
   // per phase as everywhere else in the product, because it comes from the same map.
+  // ONE capsule around the whole reference. Two free-floating elements with a gap
+  // between them do not read as a unit: in a paragraph naming five Specs you cannot
+  // tell which phase belongs to which handle. The enclosing background is what makes
+  // the pairing unambiguous.
+  //
+  // The phase inside is COLOURED TEXT, not a second chip. A chip inside a chip is a
+  // box inside a box, which is exactly what made the first treatment clunky.
   const body = (
     <>
       <span className="font-medium">{handle}</span>
-      <span
-        className={`rounded-sm border px-1 py-px text-[0.7em] font-medium leading-none ${statusClasses(
-          doc.status,
-        )}`}
-      >
+      <span className={`text-[0.8em] ${statusTextClass(doc.status)}`}>
         {doc.status.replace(/_/g, " ")}
       </span>
     </>
@@ -95,11 +98,16 @@ export function SpecRefPill({ handle }: { handle: string }) {
     "data-spec-handle": handle,
     "aria-describedby": open ? cardId : undefined,
     className:
-      // `-mx-0.5 px-0.5` nets to zero inline width, so the hover background gets
-      // breathing room WITHOUT pushing the following comma or full stop away from
-      // the reference. Padding alone left punctuation visibly detached.
-      "inline-flex items-baseline gap-1 whitespace-nowrap rounded-sm -mx-0.5 px-0.5 align-baseline " +
-      "!no-underline !text-primary hover:bg-subtle/70 hover:!text-primary",
+      // A VISIBLE edge is what makes the pairing unambiguous. A soft fill alone was
+      // tried and failed: against the panel it is nearly invisible, so the handle and
+      // its phase still read as two loose elements in a paragraph naming five Specs.
+      // The border can be this quiet only because the phase inside is coloured text
+      // rather than a nested chip — one box, not a box in a box.
+      "inline-flex items-baseline gap-1 whitespace-nowrap rounded-sm border border-subtle bg-subtle/40 " +
+      // No negative margin: it existed to keep punctuation tight when the pill had
+      // no border, and with one it tucks the following comma under the border edge.
+      "px-1.5 py-px align-baseline " +
+      "!no-underline !text-primary hover:border-accent/50 hover:bg-subtle hover:!text-primary",
     onMouseEnter: onEnter,
     onMouseLeave: onLeave,
     // Focus and tap open it too — hover-only content is unreachable by keyboard

--- a/packages/ui/src/components/specRef/SpecRefPill.tsx
+++ b/packages/ui/src/components/specRef/SpecRefPill.tsx
@@ -1,0 +1,116 @@
+import { useState, useRef, useCallback, useId } from 'react';
+import { Link } from 'react-router-dom';
+import { Badge } from '../ui';
+import { parseTenantFromPathname } from '../../utils/tenantUrl';
+import { useSpecRefStatus } from './SpecRefStatusProvider';
+import { SpecRefCard } from './SpecRefCard';
+
+/**
+ * spec-529 t-4 — the interactive pill a bare `spec-N` becomes.
+ *
+ * The face carries three things and no more: the handle, the phase, and task
+ * progress as a terse fraction. The TITLE is deliberately absent from the face —
+ * Spec titles are full sentences in this product's house style, and inlining one
+ * mid-paragraph would wreck the line. The title belongs on the card, which has
+ * room for it.
+ *
+ * A handle that does not resolve — no such Spec, or not this reader's to see —
+ * renders as ordinary text with no pill, no link and no hover affordance. That
+ * is not a courtesy; a pill that looked different for "exists but forbidden"
+ * would leak exactly what std-7 exists to hide, so absent and forbidden must be
+ * indistinguishable here as well as on the wire.
+ */
+
+/** Where a resolved handle points. Built here rather than in the rehype plugin,
+ *  which has no namespace/memex context to build it from. */
+function specHref(handle: string): string | null {
+  if (typeof window === 'undefined') return null;
+  const tenant = parseTenantFromPathname(window.location.pathname);
+  if (!tenant) return null;
+  return `/${tenant.namespace}/${tenant.memex}/specs/${handle}`;
+}
+
+export function SpecRefPill({ handle }: { handle: string }) {
+  const entry = useSpecRefStatus(handle);
+  const [open, setOpen] = useState(false);
+  const hoverTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const cardId = useId();
+
+  const cancelHover = useCallback(() => {
+    if (hoverTimer.current) {
+      clearTimeout(hoverTimer.current);
+      hoverTimer.current = null;
+    }
+  }, []);
+
+  // Hover INTENT, not mouse travel: a pointer crossing the pill on its way
+  // somewhere else should not open anything. Nothing is fetched either way —
+  // the status is already in the page's resolved set.
+  const onEnter = useCallback(() => {
+    cancelHover();
+    hoverTimer.current = setTimeout(() => setOpen(true), 120);
+  }, [cancelHover]);
+
+  const onLeave = useCallback(() => {
+    cancelHover();
+    setOpen(false);
+  }, [cancelHover]);
+
+  // Unresolved, still resolving, or no provider above us: the handle renders as
+  // it was written. This is also the every-degradation path — a failed request,
+  // an anonymous reader on a public page, a surface that never opted in.
+  if (!entry || entry.state !== 'resolved') {
+    return <>{handle}</>;
+  }
+
+  const doc = entry.doc;
+  const href = specHref(handle);
+  const progress = doc.taskProgress;
+
+  const body = (
+    <>
+      <span className="font-medium">{handle}</span>
+      <Badge status={doc.status} className="ml-1" />
+      {progress && (
+        <span className="ml-1 text-[11px] text-secondary tabular-nums">
+          {progress.complete}/{progress.total} tasks
+        </span>
+      )}
+    </>
+  );
+
+  const shared = {
+    'data-testid': 'spec-ref-pill',
+    'data-spec-handle': handle,
+    'aria-describedby': open ? cardId : undefined,
+    className:
+      'inline-flex items-center gap-0.5 rounded-sm border border-subtle bg-subtle/40 px-1 py-0.5 align-baseline no-underline hover:border-accent/60',
+    onMouseEnter: onEnter,
+    onMouseLeave: onLeave,
+    // Focus and tap open it too — hover-only content is unreachable by keyboard
+    // and does not exist on touch.
+    onFocus: () => setOpen(true),
+    onBlur: () => setOpen(false),
+    onClick: () => setOpen(true),
+    onKeyDown: (e: React.KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    },
+  };
+
+  return (
+    <span className="relative inline-block">
+      {href ? (
+        <Link to={href} {...shared}>
+          {body}
+        </Link>
+      ) : (
+        // No tenant in the path (an embedded or bare-domain render): still a pill,
+        // still hoverable, just not navigable.
+        <span {...shared} tabIndex={0} role="button">
+          {body}
+        </span>
+      )}
+      {open && <SpecRefCard id={cardId} doc={doc} />}
+    </span>
+  );
+}

--- a/packages/ui/src/components/specRef/SpecRefPill.tsx
+++ b/packages/ui/src/components/specRef/SpecRefPill.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback, useId } from "react";
+import { useState, useRef, useCallback, useEffect, useId } from "react";
 import { Link } from "react-router-dom";
 import { statusClasses } from "../../utils/statusStyles";
 import { parseTenantFromPathname } from "../../utils/tenantUrl";
@@ -8,11 +8,11 @@ import { SpecRefCard } from "./SpecRefCard";
 /**
  * spec-529 t-4 — the interactive pill a bare `spec-N` becomes.
  *
- * The face carries three things and no more: the handle, the phase, and task
- * progress as a terse fraction. The TITLE is deliberately absent from the face —
- * Spec titles are full sentences in this product's house style, and inlining one
- * mid-paragraph would wreck the line. The title belongs on the card, which has
- * room for it.
+ * The face carries the handle and a phase chip, and nothing else. Task progress
+ * was on it and came off: repeated through a paragraph a fraction is noise, and
+ * the split belongs on the card, which has room to spell it out. The TITLE is
+ * absent for the same reason — Spec titles are full sentences in this product's
+ * house style, and inlining one mid-paragraph would wreck the line.
  *
  * A handle that does not resolve — no such Spec, or not this reader's to see —
  * renders as ordinary text with no pill, no link and no hover affordance. That
@@ -34,7 +34,16 @@ export function SpecRefPill({ handle }: { handle: string }) {
   const entry = useSpecRefStatus(handle);
   const [open, setOpen] = useState(false);
   const hoverTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Which input opened the last interaction. A touch has no hover, so the first
+  // tap must open the card instead of navigating; a mouse click keeps navigating,
+  // because on a pointer device hover has already shown the card.
+  const lastPointerType = useRef<string>("mouse");
   const cardId = useId();
+
+  // A pending 120ms open-timer must not fire into a component that has gone.
+  useEffect(() => () => {
+    if (hoverTimer.current) clearTimeout(hoverTimer.current);
+  }, []);
 
   const cancelHover = useCallback(() => {
     if (hoverTimer.current) {
@@ -100,20 +109,35 @@ export function SpecRefPill({ handle }: { handle: string }) {
       // the reference. Padding alone left punctuation visibly detached.
       "inline-flex items-baseline gap-1 whitespace-nowrap rounded-sm -mx-0.5 px-0.5 align-baseline " +
       "!no-underline !text-primary hover:bg-subtle/70 hover:!text-primary",
-    onMouseEnter: onEnter,
-    onMouseLeave: onLeave,
     // Focus and tap open it too — hover-only content is unreachable by keyboard
     // and does not exist on touch.
     onFocus: () => setOpen(true),
     onBlur: () => setOpen(false),
-    onClick: () => setOpen(true),
+    onPointerDown: (e: React.PointerEvent) => {
+      lastPointerType.current = e.pointerType || "mouse";
+    },
+    onClick: (e: React.MouseEvent) => {
+      if (lastPointerType.current === "touch" && !open) {
+        // First tap reveals; a second tap follows the link.
+        e.preventDefault();
+        setOpen(true);
+      }
+    },
     onKeyDown: (e: React.KeyboardEvent) => {
       if (e.key === "Escape") setOpen(false);
     },
   };
 
   return (
-    <span className="relative inline-block">
+    // Hover handlers live on the WRAPPER, not the anchor: the card renders as a
+    // sibling below the anchor's box, so an anchor-scoped `mouseleave` fired the
+    // moment the pointer set off toward the card, and the card vanished before it
+    // could be reached, selected or copied.
+    <span
+      className="relative inline-block"
+      onMouseEnter={onEnter}
+      onMouseLeave={onLeave}
+    >
       {href ? (
         <Link to={href} {...shared}>
           {body}

--- a/packages/ui/src/components/specRef/SpecRefPill.tsx
+++ b/packages/ui/src/components/specRef/SpecRefPill.tsx
@@ -1,9 +1,9 @@
-import { useState, useRef, useCallback, useId } from 'react';
-import { Link } from 'react-router-dom';
-import { Badge } from '../ui';
-import { parseTenantFromPathname } from '../../utils/tenantUrl';
-import { useSpecRefStatus } from './SpecRefStatusProvider';
-import { SpecRefCard } from './SpecRefCard';
+import { useState, useRef, useCallback, useId } from "react";
+import { Link } from "react-router-dom";
+import { statusClasses } from "../../utils/statusStyles";
+import { parseTenantFromPathname } from "../../utils/tenantUrl";
+import { useSpecRefStatus } from "./SpecRefStatusProvider";
+import { SpecRefCard } from "./SpecRefCard";
 
 /**
  * spec-529 t-4 — the interactive pill a bare `spec-N` becomes.
@@ -24,7 +24,7 @@ import { SpecRefCard } from './SpecRefCard';
 /** Where a resolved handle points. Built here rather than in the rehype plugin,
  *  which has no namespace/memex context to build it from. */
 function specHref(handle: string): string | null {
-  if (typeof window === 'undefined') return null;
+  if (typeof window === "undefined") return null;
   const tenant = parseTenantFromPathname(window.location.pathname);
   if (!tenant) return null;
   return `/${tenant.namespace}/${tenant.memex}/specs/${handle}`;
@@ -59,32 +59,47 @@ export function SpecRefPill({ handle }: { handle: string }) {
   // Unresolved, still resolving, or no provider above us: the handle renders as
   // it was written. This is also the every-degradation path — a failed request,
   // an anonymous reader on a public page, a surface that never opted in.
-  if (!entry || entry.state !== 'resolved') {
+  if (!entry || entry.state !== "resolved") {
     return <>{handle}</>;
   }
 
   const doc = entry.doc;
   const href = specHref(handle);
-  const progress = doc.taskProgress;
 
+  // A reference sits INSIDE a sentence, so its treatment has to survive being
+  // repeated five times in one paragraph. A bordered chip does not: it boxes the
+  // prose, blows out the line rhythm, and turns a readable sentence into a row of
+  // buttons. So the phase becomes a coloured dot rather than a badge, the fraction
+  // loses the word "tasks" (the card spells it out), and the whole thing carries no
+  // border or fill until you point at it.
+  // The face is the handle plus a MINI phase chip, and nothing else. Task progress
+  // was on it and came off: repeated five times in one paragraph a fraction is
+  // noise, and it is the card's job to spell the split out. The chip is the Badge
+  // treatment shrunk to sit inside a line of prose without boxing it — same colour
+  // per phase as everywhere else in the product, because it comes from the same map.
   const body = (
     <>
       <span className="font-medium">{handle}</span>
-      <Badge status={doc.status} className="ml-1" />
-      {progress && (
-        <span className="ml-1 text-[11px] text-secondary tabular-nums">
-          {progress.complete}/{progress.total} tasks
-        </span>
-      )}
+      <span
+        className={`rounded-sm border px-1 py-px text-[0.7em] font-medium leading-none ${statusClasses(
+          doc.status,
+        )}`}
+      >
+        {doc.status.replace(/_/g, " ")}
+      </span>
     </>
   );
 
   const shared = {
-    'data-testid': 'spec-ref-pill',
-    'data-spec-handle': handle,
-    'aria-describedby': open ? cardId : undefined,
+    "data-testid": "spec-ref-pill",
+    "data-spec-handle": handle,
+    "aria-describedby": open ? cardId : undefined,
     className:
-      'inline-flex items-center gap-0.5 rounded-sm border border-subtle bg-subtle/40 px-1 py-0.5 align-baseline no-underline hover:border-accent/60',
+      // `-mx-0.5 px-0.5` nets to zero inline width, so the hover background gets
+      // breathing room WITHOUT pushing the following comma or full stop away from
+      // the reference. Padding alone left punctuation visibly detached.
+      "inline-flex items-baseline gap-1 whitespace-nowrap rounded-sm -mx-0.5 px-0.5 align-baseline " +
+      "!no-underline !text-primary hover:bg-subtle/70 hover:!text-primary",
     onMouseEnter: onEnter,
     onMouseLeave: onLeave,
     // Focus and tap open it too — hover-only content is unreachable by keyboard
@@ -93,7 +108,7 @@ export function SpecRefPill({ handle }: { handle: string }) {
     onBlur: () => setOpen(false),
     onClick: () => setOpen(true),
     onKeyDown: (e: React.KeyboardEvent) => {
-      if (e.key === 'Escape') setOpen(false);
+      if (e.key === "Escape") setOpen(false);
     },
   };
 

--- a/packages/ui/src/components/specRef/SpecRefPill.tsx
+++ b/packages/ui/src/components/specRef/SpecRefPill.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useCallback, useId } from "react";
 import { Link } from "react-router-dom";
-import { statusTextClass } from "../../utils/statusStyles";
+import { statusClasses } from "../../utils/statusStyles";
 import { parseTenantFromPathname } from "../../utils/tenantUrl";
 import { useSpecRefStatus } from "./SpecRefStatusProvider";
 import { SpecRefCard } from "./SpecRefCard";
@@ -77,17 +77,14 @@ export function SpecRefPill({ handle }: { handle: string }) {
   // noise, and it is the card's job to spell the split out. The chip is the Badge
   // treatment shrunk to sit inside a line of prose without boxing it — same colour
   // per phase as everywhere else in the product, because it comes from the same map.
-  // ONE capsule around the whole reference. Two free-floating elements with a gap
-  // between them do not read as a unit: in a paragraph naming five Specs you cannot
-  // tell which phase belongs to which handle. The enclosing background is what makes
-  // the pairing unambiguous.
-  //
-  // The phase inside is COLOURED TEXT, not a second chip. A chip inside a chip is a
-  // box inside a box, which is exactly what made the first treatment clunky.
   const body = (
     <>
       <span className="font-medium">{handle}</span>
-      <span className={`text-[0.8em] ${statusTextClass(doc.status)}`}>
+      <span
+        className={`rounded-sm border px-1 py-px text-[0.7em] font-medium leading-none ${statusClasses(
+          doc.status,
+        )}`}
+      >
         {doc.status.replace(/_/g, " ")}
       </span>
     </>
@@ -98,16 +95,11 @@ export function SpecRefPill({ handle }: { handle: string }) {
     "data-spec-handle": handle,
     "aria-describedby": open ? cardId : undefined,
     className:
-      // A VISIBLE edge is what makes the pairing unambiguous. A soft fill alone was
-      // tried and failed: against the panel it is nearly invisible, so the handle and
-      // its phase still read as two loose elements in a paragraph naming five Specs.
-      // The border can be this quiet only because the phase inside is coloured text
-      // rather than a nested chip — one box, not a box in a box.
-      "inline-flex items-baseline gap-1 whitespace-nowrap rounded-sm border border-subtle bg-subtle/40 " +
-      // No negative margin: it existed to keep punctuation tight when the pill had
-      // no border, and with one it tucks the following comma under the border edge.
-      "px-1.5 py-px align-baseline " +
-      "!no-underline !text-primary hover:border-accent/50 hover:bg-subtle hover:!text-primary",
+      // `-mx-0.5 px-0.5` nets to zero inline width, so the hover background gets
+      // breathing room WITHOUT pushing the following comma or full stop away from
+      // the reference. Padding alone left punctuation visibly detached.
+      "inline-flex items-baseline gap-1 whitespace-nowrap rounded-sm -mx-0.5 px-0.5 align-baseline " +
+      "!no-underline !text-primary hover:bg-subtle/70 hover:!text-primary",
     onMouseEnter: onEnter,
     onMouseLeave: onLeave,
     // Focus and tap open it too — hover-only content is unreachable by keyboard

--- a/packages/ui/src/components/specRef/SpecRefStatusProvider.tsx
+++ b/packages/ui/src/components/specRef/SpecRefStatusProvider.tsx
@@ -8,6 +8,7 @@ import {
   useState,
   type ReactNode,
 } from 'react';
+import { useParams } from 'react-router-dom';
 import { fetchDocs } from '../../api/docs';
 import type { DocSummary } from '../../api/types';
 
@@ -45,6 +46,15 @@ interface SpecRefContextValue {
 
 const SpecRefContext = createContext<SpecRefContextValue | null>(null);
 
+/**
+ * The server caps a handle set per request (MAX_HANDLE_FILTER). Chunk to it, or a
+ * long index document naming more Specs than the cap loses its tail silently —
+ * and, because the dropped handles are recorded as `missing`, permanently for the
+ * rest of the session. Kept slightly below the server's 100 so the two can drift
+ * without the client silently losing rows again.
+ */
+const MAX_PER_REQUEST = 90;
+
 /** The server projections a pill and its card need, asked for once. */
 const INCLUDE = ['taskProgress', 'acHealth', 'lastActivity'] as const;
 
@@ -58,6 +68,32 @@ export function SpecRefStatusProvider({ children }: { children: ReactNode }) {
   const queue = useRef<Set<string>>(new Set());
   const flushScheduled = useRef(false);
   const alive = useRef(true);
+
+  // A handle is per-Memex [per std-10 cl-14], so a resolved `spec-42` from one
+  // tenant must never be served for `spec-42` in another. TenantLayout does NOT
+  // remount on a param change (that is why the routed subtree below it carries its
+  // own remount key), so without this the cache would outlive the switch and the
+  // pill would show another Memex's title, phase and link.
+  //
+  // Reset DURING RENDER, not in an effect. Child effects run before parent effects,
+  // so an effect here would clear `seen` only AFTER every pill had already
+  // re-registered against the previous tenant's cache — the pills would keep the
+  // stale answer and never re-ask. Adjusting state during render is React's
+  // sanctioned pattern for exactly this "derived state must reset" case, and it
+  // lands before children render.
+  //
+  // Keying the provider from App would also work and was tried; it remounts the
+  // whole tenant subtree (chat, shell and all), which is far more than this needs
+  // and, as the onboarding journey caught, not side-effect free.
+  const { namespace, memex } = useParams<{ namespace: string; memex: string }>();
+  const tenant = `${namespace ?? ''}/${memex ?? ''}`;
+  const [renderedTenant, setRenderedTenant] = useState(tenant);
+  if (renderedTenant !== tenant) {
+    setRenderedTenant(tenant);
+    seen.current.clear();
+    queue.current.clear();
+    setEntries(new Map());
+  }
 
   useEffect(() => {
     alive.current = true;
@@ -73,7 +109,21 @@ export function SpecRefStatusProvider({ children }: { children: ReactNode }) {
     if (batch.length === 0) return;
 
     try {
-      const docs = await fetchDocs('spec', { handles: batch, include: INCLUDE });
+      const chunks: string[][] = [];
+      for (let i = 0; i < batch.length; i += MAX_PER_REQUEST) {
+        chunks.push(batch.slice(i, i + MAX_PER_REQUEST));
+      }
+      const results = await Promise.all(
+        chunks.map((handles) =>
+          fetchDocs('spec', {
+            handles,
+            include: INCLUDE,
+            // An archived Spec must RESOLVE so the card can say it is archived.
+            includeArchived: true,
+          }),
+        ),
+      );
+      const docs = results.flat();
       if (!alive.current) return;
       const byHandle = new Map(docs.map((d) => [d.handle, d]));
       setEntries((prev) => {

--- a/packages/ui/src/components/specRef/SpecRefStatusProvider.tsx
+++ b/packages/ui/src/components/specRef/SpecRefStatusProvider.tsx
@@ -1,0 +1,142 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+import { fetchDocs } from '../../api/docs';
+import type { DocSummary } from '../../api/types';
+
+/**
+ * spec-529 t-3 — the page-level status set every reference pill reads from.
+ *
+ * Without this layer a document mentioning thirty Specs issues thirty requests,
+ * which is the failure the whole design is arranged to avoid. Pills do not
+ * fetch; they register a handle and read the answer. Opening a card fetches
+ * nothing at all, because the card renders from the same resolved entry.
+ *
+ * Registrations are collected and flushed ONCE per tick, so every pill mounted
+ * in the same commit — which is every pill in a rendered document — resolves in
+ * a single request. A handle that appears later (a lazily-rendered section, a
+ * newly-posted comment) starts a second batch containing only what is new;
+ * nothing already known is ever re-requested.
+ *
+ * A missing provider is a supported state, not a bug: `useSpecRefStatus` simply
+ * never resolves, and the pill degrades to the plain handle. That is what keeps
+ * a markdown surface which has not opted in from breaking.
+ */
+
+/** What we know about one handle. `missing` covers BOTH "no such Spec" and "not
+ *  yours to see" — the server answers them identically [per std-7], and so does
+ *  the renderer. */
+export type SpecRefEntry =
+  | { state: 'pending' }
+  | { state: 'resolved'; doc: DocSummary }
+  | { state: 'missing' };
+
+interface SpecRefContextValue {
+  entries: ReadonlyMap<string, SpecRefEntry>;
+  register: (handle: string) => void;
+}
+
+const SpecRefContext = createContext<SpecRefContextValue | null>(null);
+
+/** The server projections a pill and its card need, asked for once. */
+const INCLUDE = ['taskProgress', 'acHealth', 'lastActivity'] as const;
+
+export function SpecRefStatusProvider({ children }: { children: ReactNode }) {
+  const [entries, setEntries] = useState<ReadonlyMap<string, SpecRefEntry>>(
+    () => new Map(),
+  );
+  // Handles seen this session — the dedupe guard. Held in a ref rather than
+  // state because registering must never itself cause a render.
+  const seen = useRef<Set<string>>(new Set());
+  const queue = useRef<Set<string>>(new Set());
+  const flushScheduled = useRef(false);
+  const alive = useRef(true);
+
+  useEffect(() => {
+    alive.current = true;
+    return () => {
+      alive.current = false;
+    };
+  }, []);
+
+  const flush = useCallback(async () => {
+    flushScheduled.current = false;
+    const batch = [...queue.current];
+    queue.current.clear();
+    if (batch.length === 0) return;
+
+    try {
+      const docs = await fetchDocs('spec', { handles: batch, include: INCLUDE });
+      if (!alive.current) return;
+      const byHandle = new Map(docs.map((d) => [d.handle, d]));
+      setEntries((prev) => {
+        const next = new Map(prev);
+        for (const handle of batch) {
+          const doc = byHandle.get(handle);
+          next.set(handle, doc ? { state: 'resolved', doc } : { state: 'missing' });
+        }
+        return next;
+      });
+    } catch {
+      // A failed resolution degrades the whole page to plain handles rather than
+      // breaking the render. The body is still readable, which is the point.
+      if (!alive.current) return;
+      setEntries((prev) => {
+        const next = new Map(prev);
+        for (const handle of batch) next.set(handle, { state: 'missing' });
+        return next;
+      });
+    }
+  }, []);
+
+  const register = useCallback(
+    (handle: string) => {
+      if (seen.current.has(handle)) return;
+      seen.current.add(handle);
+      queue.current.add(handle);
+      setEntries((prev) => {
+        const next = new Map(prev);
+        next.set(handle, { state: 'pending' });
+        return next;
+      });
+      if (!flushScheduled.current) {
+        flushScheduled.current = true;
+        // One tick's worth of registrations become one request.
+        queueMicrotask(() => void flush());
+      }
+    },
+    [flush],
+  );
+
+  const value = useMemo<SpecRefContextValue>(
+    () => ({ entries, register }),
+    [entries, register],
+  );
+
+  return <SpecRefContext.Provider value={value}>{children}</SpecRefContext.Provider>;
+}
+
+/**
+ * Registers a handle with the page's status set and returns what is known about
+ * it. Returns `undefined` when there is no provider above — the un-opted-in
+ * surface, where the pill must stay plain text.
+ */
+export function useSpecRefStatus(handle: string): SpecRefEntry | undefined {
+  const ctx = useContext(SpecRefContext);
+  useEffect(() => {
+    ctx?.register(handle);
+  }, [ctx, handle]);
+  return ctx?.entries.get(handle);
+}
+
+/** Test seam: true when a provider is above this point in the tree. */
+export function useHasSpecRefProvider(): boolean {
+  return useContext(SpecRefContext) !== null;
+}

--- a/packages/ui/src/components/specRef/licence.spec-529.test.ts
+++ b/packages/ui/src/components/specRef/licence.spec-529.test.ts
@@ -1,0 +1,44 @@
+// spec-529 (ac-13, dec-5) — this feature is fair-code core, and the file path is
+// the licence marker in this repo, so the classification is checkable rather than
+// merely stated.
+//
+// It also asserts the renderer stays ONE code path. Gating this behind a licence
+// would split the reading experience of the core artifact — the same document
+// showing live status to one reader and inert text to another, including on the
+// public shared-document page an anonymous visitor sees.
+
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { tagAc } from '@memex-ai-ac/vitest';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+/** Every file this Spec added under the reference-pill directory. */
+function specRefFiles(): string[] {
+  return readdirSync(HERE).filter((f) => f.endsWith('.ts') || f.endsWith('.tsx'));
+}
+
+describe('spec-529 is fair-code core', () => {
+  it('carries no Enterprise Edition marker in any filename or directory', () => {
+    tagAc('mindset-prod/memex-building-itself/specs/spec-529/acs/ac-13');
+    // `.ee.` in a filename or `.ee` as a dirname IS the licence boundary here —
+    // there is no build flag to check instead.
+    expect(specRefFiles().filter((f) => f.includes('.ee.'))).toEqual([]);
+    expect(HERE.split('/').filter((seg) => seg === '.ee')).toEqual([]);
+  });
+
+  it('branches on no licence, tier or entitlement anywhere in the renderer', () => {
+    tagAc('mindset-prod/memex-building-itself/specs/spec-529/acs/ac-13');
+    const offenders: string[] = [];
+    for (const f of specRefFiles()) {
+      if (f.includes('.test.')) continue;
+      const src = readFileSync(join(HERE, f), 'utf8');
+      if (/isEnterprise|licence|license|entitl|tier|\bplan\b/i.test(src)) {
+        offenders.push(f);
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+});

--- a/packages/ui/src/components/specRef/specRefAnchor.tsx
+++ b/packages/ui/src/components/specRef/specRefAnchor.tsx
@@ -1,0 +1,39 @@
+import type { Components } from 'react-markdown';
+import { SpecRefPill } from './SpecRefPill';
+
+/**
+ * spec-529 t-6 — the seam between the rehype plugin and the live pill.
+ *
+ * `rehypeSpecRefLinkifier` stamps `data-spec-ref` / `data-spec-handle` on an
+ * anchor; this reads them back and upgrades it. Every markdown surface uses the
+ * same helper so the upgrade cannot drift between them, and a surface that
+ * already maps `a` for its own reasons composes by calling `specRefHandle` first
+ * and falling through when it returns null.
+ *
+ * react-markdown hands hast properties in both dashed and camel form depending
+ * on version and plugin path, so both are read.
+ */
+export function specRefHandle(node: unknown): string | null {
+  const props =
+    ((node as { properties?: Record<string, unknown> } | undefined)?.properties ??
+      {}) as Record<string, unknown>;
+  if (!(props['data-spec-ref'] ?? props['dataSpecRef'])) return null;
+  const handle = String(props['data-spec-handle'] ?? props['dataSpecHandle'] ?? '');
+  return handle.length > 0 ? handle : null;
+}
+
+/**
+ * The `a` mapping for a surface with no anchor handling of its own. A non-pill
+ * anchor renders exactly as react-markdown would have rendered it.
+ */
+export const specRefComponents: Components = {
+  a: ({ children, href, node, ...rest }) => {
+    const handle = specRefHandle(node);
+    if (handle) return <SpecRefPill handle={handle} />;
+    return (
+      <a href={href} {...rest}>
+        {children}
+      </a>
+    );
+  },
+};

--- a/packages/ui/src/pages/SharedDocument.tsx
+++ b/packages/ui/src/pages/SharedDocument.tsx
@@ -3,6 +3,8 @@ import { useParams } from 'react-router-dom';
 import ReactMarkdown from 'react-markdown';
 import { Logo } from '../components/Logo';
 import { rehypeRefLinkifier } from '../components/chat/refLinkifier';
+import { specRefComponents } from '../components/specRef/specRefAnchor';
+import { rehypeSpecRefLinkifier } from '../components/chat/specRefLinkifier';
 import { Button } from '../components/ui/Button';
 import { TextArea } from '../components/ui/TextArea';
 import {
@@ -202,7 +204,7 @@ function SectionBlock({
         <h2 className="text-xl font-semibold text-heading">{decodeHtmlEntities(section.title)}</h2>
       )}
       <div className="prose prose-sm max-w-none text-primary">
-        <ReactMarkdown rehypePlugins={[rehypeRefLinkifier]}>{section.content}</ReactMarkdown>
+        <ReactMarkdown rehypePlugins={[rehypeRefLinkifier, rehypeSpecRefLinkifier]} components={specRefComponents}>{section.content}</ReactMarkdown>
       </div>
 
       {/* Comments list */}
@@ -279,7 +281,7 @@ export function CommentRow({
           rehypeRefLinkifier). Comment CONTENT is markdown and is NOT entity-decoded —
           ReactMarkdown handles entities, and re-decoding could corrupt code spans. */}
       <div className="prose prose-sm max-w-none text-primary">
-        <ReactMarkdown rehypePlugins={[rehypeRefLinkifier]}>{comment.content}</ReactMarkdown>
+        <ReactMarkdown rehypePlugins={[rehypeRefLinkifier, rehypeSpecRefLinkifier]} components={specRefComponents}>{comment.content}</ReactMarkdown>
       </div>
     </div>
   );

--- a/packages/ui/src/pages/Standard.tsx
+++ b/packages/ui/src/pages/Standard.tsx
@@ -14,6 +14,8 @@ import { Spinner } from '../components/Spinner';
 import { useDocChangeStream } from '../hooks/useDocChangeStream';
 import { DecisionLink } from '../components/DecisionLink';
 import { rehypeRefLinkifier } from '../components/chat/refLinkifier';
+import { specRefComponents } from '../components/specRef/specRefAnchor';
+import { rehypeSpecRefLinkifier } from '../components/chat/specRefLinkifier';
 import { tenantPath } from '../utils/tenantUrl';
 import { ClauseStatusDot } from '../components/ClauseStatusDot';
 import { FacetPills } from '../components/FacetPills';
@@ -260,7 +262,7 @@ function encodeDecisionRefs(content: string): string {
 }
 
 const remarkPlugins = [remarkGfm];
-const rehypePlugins = [rehypeRaw, rehypeHighlight, rehypeRefLinkifier];
+const rehypePlugins = [rehypeRaw, rehypeHighlight, rehypeRefLinkifier, rehypeSpecRefLinkifier];
 
 function StandardSection({
   section,
@@ -277,6 +279,8 @@ function StandardSection({
   // `decisionref` override accepted alongside the standard HTML element keys. The
   // ChatMarkdown component does the same.
   const components: Record<string, unknown> = {
+    // spec-529: bare `spec-N` → the live pill; other anchors untouched.
+    a: specRefComponents.a,
     decisionref: ({ handle }: { handle?: string }) =>
       // b-42 t-2: scope bare-handle resolution to the standard's parent doc so
       // memexes with dec-1 in multiple Specs don't 409 on `[per dec-N]` links.
@@ -340,6 +344,8 @@ export function StandardClauseList({
   parentDocId: string | undefined;
 }): React.JSX.Element {
   const components: Record<string, unknown> = {
+    // spec-529: bare `spec-N` → the live pill; other anchors untouched.
+    a: specRefComponents.a,
     decisionref: ({ handle }: { handle?: string }) =>
       handle ? <DecisionLink handle={handle} parentDocId={parentDocId} /> : null,
   };

--- a/packages/ui/src/utils/specMarkdown.spec-529.test.ts
+++ b/packages/ui/src/utils/specMarkdown.spec-529.test.ts
@@ -1,0 +1,61 @@
+// spec-529 t-6 (ac-5) — the export path is a NON-BROWSER reader of the same body,
+// and it must be untouched by the rendering feature.
+//
+// Linkification is render-time only; storage stays plain markdown. So a Spec
+// exported to markdown carries the handle exactly as the author typed it — no
+// anchor, no pill markup, no injected status. If this ever fails, the feature has
+// leaked out of the renderer and into the content.
+
+import { describe, it, expect } from 'vitest';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { specToMarkdown } from './specMarkdown';
+import type { DocWithGraph } from '../api/types';
+
+const OPTIONS = {
+  includeSections: true,
+  includeDecisions: true,
+  includeTasks: true,
+  includeComments: false,
+};
+
+const EMPTY_COMMENTS = { bySection: {}, byDecision: {}, byTask: {} };
+
+function docMentioning(text: string): DocWithGraph {
+  return {
+    id: 'doc-id',
+    handle: 'doc-36',
+    title: 'Where the observability work stands',
+    docType: 'document',
+    status: 'draft',
+    createdAt: '2026-08-01T10:00:00Z',
+    statusChangedAt: '2026-08-01T10:00:00Z',
+    sections: [
+      { id: 's1', seq: 1, sectionType: 'overview', title: 'Overview', content: text },
+    ],
+    decisions: [],
+    tasks: [],
+  } as unknown as DocWithGraph;
+}
+
+describe('markdown export keeps bare handles verbatim', () => {
+  it('exports `spec-N` as plain text, with no anchor or status', () => {
+    tagAc('mindset-prod/memex-building-itself/specs/spec-529/acs/ac-5');
+    const body =
+      'Only spec-335, spec-373 and spec-371 have shipped code; spec-372 is next.';
+    const out = specToMarkdown(docMentioning(body), EMPTY_COMMENTS, OPTIONS);
+
+    expect(out).toContain(body);
+    expect(out).not.toContain('data-spec-ref');
+    expect(out).not.toContain('spec-ref-pill');
+    expect(out).not.toContain('](/');
+    // No status was injected beside any handle.
+    expect(out).not.toMatch(/spec-335\s*·/);
+    expect(out).not.toMatch(/tasks complete/);
+  });
+
+  it('leaves a handle inside a code span exactly where the author put it', () => {
+    const body = 'Call `get_doc spec-373` to read it.';
+    const out = specToMarkdown(docMentioning(body), EMPTY_COMMENTS, OPTIONS);
+    expect(out).toContain('`get_doc spec-373`');
+  });
+});


### PR DESCRIPTION
## What this does

A bare `spec-N` written in any document body, section or comment now renders as a **reference pill** carrying that Spec's handle and a mini phase chip. Hovering, focusing or tapping it opens a card with the title, phase and time-in-phase, the task split, acceptance-criteria completion, last activity, and a banner when the Spec is archived or superseded.

Spec: [spec-529](https://memex.ai/mindset-prod/memex-building-itself/specs/spec-529)

**Why.** A document that references another Spec has no way to show what that Spec is doing, so the state gets hand-copied into the prose beside it and is stale within the hour. The worked example is `mindset-prod/mindset-four/docs/doc-36`, whose entire "State" column is a hand-maintained snapshot of five other Specs. The reader gets no signal that the column is a snapshot at all.

Storage never changes. Resolution is render-time, so every document ever written gains this with no migration and no author markup.

## Deliberately narrow

Three boundaries, each chosen so that backing this out is a code revert and nothing more:

- **The browser is the boundary** (dec-3). `get_doc` is byte-identical; no MCP tool added. An agent can already fetch a Spec's status whenever it wants one — the reader who cannot is the human looking at a rendered page.
- **`spec-N` only** (dec-4). `std-N` and `doc-N` stay plain text: a Standard has an approval state and drift findings, not a phase and tasks, so it needs its own card face rather than a wider pattern.
- **std-10's authoring convention is untouched** (dec-1). Only its account of what the renderer matches will change, and even that waits until the pills have been lived with — tracked as issue-2 on the Spec.

Full canonical paths and hand-authored markdown links are untouched and still render as plain hyperlinks.

## Server

`GET /api/docs` gains `?handles=` and two include tokens (`taskProgress`, `lastActivity`) rather than a new endpoint (dec-2), so the board card, the reference pill and any later consumer read **one** description of a Spec's status and cannot drift into reporting different numbers. Task counts existed only for the agent's `list_docs` handler and are now projected for the browser from the same aggregation the Spec page reads — asserted by test.

The handle set comes from a rendered body, so it is capped, malformed entries are dropped rather than 400-ing the page, and a handle naming nothing answers exactly as an unreadable one does [per std-7].

## Review found four HIGH issues; all are fixed

An adversarial review of this branch returned BLOCK. Each finding was verified against the code before being acted on.

1. **Actor identity reached anonymous readers.** `lastActivity` carried `actorName` on a response served to unauthenticated visitors on public Memexes. `routes/activity.ts` already strips actor fields for readers without write access because they carry PII; this reintroduced that leak on a different route. Removed from the wire.
2. **"Last activity" was reporting reads.** The activity sink persists `viewed` events, so the line usually said someone *looked* at a Spec, turning a hover into a read receipt. Now filtered to `ATTRIBUTION_BEARING_ACTIONS`, exported rather than copied.
3. **The Archived banner was unreachable** — archived rows are filtered unless requested, so those references rendered as plain text, the exact "reads as live" failure the card exists to prevent.
4. **The status cache outlived a Memex switch**, and handles are per-Memex, so one tenant's `spec-42` could render inside another.

Also fixed: the card was unreachable with the pointer; above the cap a page's tail of handles was dropped silently and cached as missing; a hover timer could fire after unmount; and **three tests that could not fail** (one asserted a constant contained pieces of itself; one hid the handle in an href so the anchor guard was never exercised; one re-rendered `MemoryRouter` with a new path, which does nothing).

The cross-tenant fix took two attempts, both recorded in the commit: keying the provider from App remounts the tenant subtree and broke onboarding in two journeys (bisected), and resetting in an effect is too late because child effects run before parent effects.

## Test plan

Run locally against the merged branch (develop merged before testing, not after):

- `make typecheck` — clean
- `make lint` (biome) — clean
- `make test-server` — **5970 passed**, 0 failed
- `make test-ui` — **2332 passed**, 0 failed
- `make e2e-cold` — **151 passed**, 0 failed (full suite, cold DB, std-28)

Plus a live browser pass on seeded content in **both light and dark**: pills in prose and in a table, card contents, the archived and superseded banners, and zero console errors.

**New journey** `journey-68-spec-529-reference-pills.spec.ts` — its last step changes the referenced Spec's phase through the real service and asserts the pill follows. A journey that stopped at "a pill appeared" would pass over a hardcoded value, and the whole point is that the number is live rather than copied.

**11 of 13 acceptance criteria verified** by live emission. The two outstanding (ac-6, ac-9) are the std-10 wording ones deliberately deferred by dec-1 — that is recorded on the Spec as issue-2, not an oversight.

## Not in this PR

- A full canonical path and a hand-authored `[spec-N](…)` link still render as plain hyperlinks, so the same Spec has three renderings. Raised and consciously left.
- `isGroundingStale` runs per grounded Spec inside `listDocs`, which this feature now exercises on document reads. Pre-existing; worth its own issue.
