### PR TITLE
feat(spec-528): fill test_events.run_id and commit_sha from metadata — server-side, fallback only (t-1, t-3)

### DIFF
--- a/packages/server/src/routes/test-events.bus.integration.test.ts
+++ b/packages/server/src/routes/test-events.bus.integration.test.ts
@@ -103,3 +103,51 @@ describe("POST /api/test-events — bus emit on ingestion (spec-156 ac-16)", () 
     }
   });
 });
+
+// spec-528 — the unit tests assert the object handed to `.values()`, which proves
+// the fallback logic but NOT that the values reach the columns. That gap is the
+// exact shape of the defect this Spec exists for: the emitter collected these
+// values and the server accepted them, and the columns stayed empty for months
+// while every test anyone might have written would have passed. So read them
+// back off a real row.
+const AC528 = "mindset-prod/memex-building-itself/specs/spec-528/acs";
+
+describe("POST /api/test-events — run_id / commit_sha reach the COLUMNS (spec-528 ac-6)", () => {
+  it("stores a metadata-sourced run id and commit in the run_id / commit_sha columns", async () => {
+    tagAc(`${AC528}/ac-6`);
+    // [per std-37] cl-1: unique per call so a parallel worker cannot collide.
+    const testIdentifier = `spec528-columns-${crypto.randomUUID()}`;
+
+    const res = await app.request("/api/test-events", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${emissionKey}`,
+      },
+      body: JSON.stringify({
+        ac_uid: subjectRef,
+        status: "pass",
+        test_identifier: testIdentifier,
+        // The shape every un-upgraded client already sends: no top-level
+        // run_id / commit_sha, both values riding in metadata.
+        metadata: { run_id: "31589392781", commit: "112ad9ab", branch: "main" },
+      }),
+    });
+    expect(res.status).toBe(201);
+
+    const [row] = await db
+      .select()
+      .from(testEvents)
+      .where(eq(testEvents.testIdentifier, testIdentifier));
+
+    // The columns — not the payload, not the response.
+    expect(row.runId).toBe("31589392781");
+    expect(row.commitSha).toBe("112ad9ab");
+    // And the metadata copy survived alongside them (ac-3).
+    expect(row.metadata).toMatchObject({
+      run_id: "31589392781",
+      commit: "112ad9ab",
+      branch: "main",
+    });
+  });
+});

--- a/packages/server/src/routes/test-events.test.ts
+++ b/packages/server/src/routes/test-events.test.ts
@@ -17,14 +17,25 @@ const insertSpy = vi.fn().mockReturnValue({
   }),
 });
 
+// spec-528 (ac-7): count what the ingest path costs per event. The two tempting
+// ways to implement the run_id fill — resolving it via a lookup, or reading the
+// inserted row back to confirm the column landed — each turn one transaction per
+// event into two, and both read as diligence in review. Counting the calls is the
+// only check that catches them; reading the diff is not.
+const transactionSpy = vi.fn();
+const selectSpy = vi.fn();
+
 vi.mock("../db/connection.js", () => ({
   db: {
     insert: () => insertSpy(),
+    select: (...args: unknown[]) => selectSpy(...args),
     // spec-162: the route now writes the log row and the summary upsert inside
     // db.transaction(). Run the callback with a tx that exposes the same insert
     // spy so the payload-shaping assertions below still observe the insert.
-    transaction: (cb: (tx: { insert: () => unknown }) => unknown) =>
-      cb({ insert: () => insertSpy() }),
+    transaction: (cb: (tx: { insert: () => unknown }) => unknown) => {
+      transactionSpy();
+      return cb({ insert: () => insertSpy() });
+    },
   },
 }));
 
@@ -76,6 +87,10 @@ app.route("/api/test-events", testEventsRouter);
 
 beforeEach(() => {
   insertSpy.mockClear();
+  // spec-528: these are module-scoped and accumulate across the whole file —
+  // without the clear, a per-POST count assertion sees every earlier test too.
+  transactionSpy.mockClear();
+  selectSpy.mockClear();
 });
 
 const validBody = {
@@ -593,5 +608,209 @@ describe("POST /api/test-events/batch — spec-489 G1 (batch the burst)", () => 
     expect(row.actor).toBe("wic@mindset.ai");
     expect(row.hidden).toBe(false);
     expect(row.metadata).toEqual({ branch: "main" });
+  });
+});
+
+// spec-528 — `test_events.run_id` and `commit_sha` are columns the emitter has
+// always collected values for and the server has always accepted, filed under
+// `metadata` instead. dec-1 joins the wire server-side FIRST, as a FALLBACK:
+// top-level wins whenever present, metadata fills in only when it is absent.
+//
+// Note the name difference across the boundary — the wire field is `commit_sha`,
+// the metadata key the emitter writes is `commit` (packages/ac-emit-vitest/src/
+// metadata.ts). Reading the wrong one is a silent no-op.
+const AC528 = "mindset-prod/memex-building-itself/specs/spec-528/acs";
+
+describe("POST /api/test-events — run_id / commit_sha filled from metadata (spec-528 dec-1)", () => {
+  // Local capture: the module-scoped insertSpy is re-pointed by earlier blocks
+  // with mockReturnValue (persistent, not …Once), so each test installs its own.
+  function captureInsert() {
+    const insertedValues = vi.fn();
+    insertSpy.mockReturnValue({
+      values: (v: unknown) => {
+        insertedValues(v);
+        return {
+          returning: vi
+            .fn()
+            .mockResolvedValue([{ id: "fake-uuid", createdAt: new Date() }]),
+        };
+      },
+    });
+    return insertedValues;
+  }
+
+  const post = (over: Record<string, unknown>) =>
+    app.request("/api/test-events", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer mxk_test",
+      },
+      body: JSON.stringify({ ...validBody, ...over }),
+    });
+
+  const postBatch = (events: unknown[]) =>
+    app.request("/api/test-events/batch", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer mxk_test",
+      },
+      body: JSON.stringify({ events }),
+    });
+
+  it("stores the top-level run_id / commit_sha when only those are sent (ac-6)", async () => {
+    tagAc(`${AC528}/ac-6`);
+    const insertedValues = captureInsert();
+    const res = await post({ run_id: "31589392781", commit_sha: "112ad9ab" });
+    expect(res.status).toBe(201);
+    const row = insertedValues.mock.calls[0]?.[0];
+    expect(row.runId).toBe("31589392781");
+    expect(row.commitSha).toBe("112ad9ab");
+  });
+
+  it("fills from metadata.run_id / metadata.commit when the top-level fields are absent (ac-6)", async () => {
+    tagAc(`${AC528}/ac-6`);
+    const insertedValues = captureInsert();
+    // The shape every un-upgraded client already sends today — this is what
+    // makes the data exist without anyone installing anything (ac-2).
+    const res = await post({
+      metadata: { run_id: "31588714697", commit: "ffbcf6a1", branch: "main" },
+    });
+    expect(res.status).toBe(201);
+    const row = insertedValues.mock.calls[0]?.[0];
+    expect(row.runId).toBe("31588714697");
+    expect(row.commitSha).toBe("ffbcf6a1");
+  });
+
+  it("prefers the TOP-LEVEL value when BOTH are sent — the case a reversed ?? gets wrong (ac-6)", async () => {
+    tagAc(`${AC528}/ac-6`);
+    const insertedValues = captureInsert();
+    const res = await post({
+      run_id: "top-level-run",
+      commit_sha: "top-level-sha",
+      metadata: { run_id: "metadata-run", commit: "metadata-sha" },
+    });
+    expect(res.status).toBe(201);
+    const row = insertedValues.mock.calls[0]?.[0];
+    // If this flips, cases 1 and 2 both still pass and the defect ships.
+    expect(row.runId).toBe("top-level-run");
+    expect(row.commitSha).toBe("top-level-sha");
+  });
+
+  it("leaves both columns NULL when neither source carries a value (ac-6)", async () => {
+    tagAc(`${AC528}/ac-6`);
+    const insertedValues = captureInsert();
+    const res = await post({ metadata: { branch: "main" } });
+    expect(res.status).toBe(201);
+    const row = insertedValues.mock.calls[0]?.[0];
+    expect(row.runId).toBeNull();
+    expect(row.commitSha).toBeNull();
+  });
+
+  it("fills from metadata on the BATCH path too — processOneEvent serves both (ac-6)", async () => {
+    tagAc(`${AC528}/ac-6`);
+    const insertedValues = captureInsert();
+    // Asserted rather than inferred from the shared call site: a batch path that
+    // diverged later would leave the highest-volume transport unfilled, silently.
+    const res = await postBatch([
+      {
+        ...validBody,
+        test_identifier: "batched.ts::t",
+        metadata: { run_id: "batched-run", commit: "batched-sha" },
+      },
+    ]);
+    expect(res.status).toBe(200);
+    const row = insertedValues.mock.calls[0]?.[0];
+    expect(row.runId).toBe("batched-run");
+    expect(row.commitSha).toBe("batched-sha");
+  });
+
+  it("costs nothing per emission: the DB call counts are identical whether or not the fill fires (ac-7)", async () => {
+    tagAc(`${AC528}/ac-7`);
+    captureInsert();
+
+    const counts = () => ({
+      transactions: transactionSpy.mock.calls.length,
+      inserts: insertSpy.mock.calls.length,
+      selects: selectSpy.mock.calls.length,
+    });
+
+    // Baseline: nothing to fill from, so the fill cannot have run.
+    const bare = await post({ metadata: { branch: "main" } });
+    expect(bare.status).toBe(201);
+    const before = counts();
+
+    transactionSpy.mockClear();
+    insertSpy.mockClear();
+    selectSpy.mockClear();
+
+    // Same request with the metadata the fill reads — the only difference.
+    const filled = await post({
+      metadata: { branch: "main", run_id: "31589392781", commit: "112ad9ab" },
+    });
+    expect(filled.status).toBe(201);
+
+    // Asserted as a delta rather than a magic number: the ingest path already
+    // performs one transaction, one insert and one read per PASSING event (the
+    // read is spec-112's issue auto-resolve at test-events.ts:497, unrelated to
+    // this Spec). What ac-7 protects is that the fill adds NONE of them. The two
+    // tempting implementations — resolving the run id via a lookup, or reading
+    // the inserted row back — would each show up right here as a delta, on a
+    // path peaking at 2 063 POST/min with one transaction per event.
+    expect(counts()).toEqual(before);
+    expect(before.transactions).toBe(1);
+    expect(before.inserts).toBe(1);
+  });
+});
+
+// spec-528 t-3 — the metadata keys are load-bearing for readers that learned to
+// use them during the months the columns were empty. Once `run_id` is a populated
+// column the metadata copy looks like redundancy; deleting it reads as removing
+// duplication, ships green, and silently breaks the `metadata->>'run_id'` reads.
+// The `actor` precedent (spec-115 dec-6) is the model: legacy key stays accepted.
+describe("POST /api/test-events — promotion does not move the metadata keys (spec-528 t-3)", () => {
+  function captureInsert() {
+    const insertedValues = vi.fn();
+    insertSpy.mockReturnValue({
+      values: (v: unknown) => {
+        insertedValues(v);
+        return {
+          returning: vi
+            .fn()
+            .mockResolvedValue([{ id: "fake-uuid", createdAt: new Date() }]),
+        };
+      },
+    });
+    return insertedValues;
+  }
+
+  it("stores run_id, commit, branch and run_url in metadata unchanged after promotion (ac-3)", async () => {
+    tagAc(`${AC528}/ac-3`);
+    const insertedValues = captureInsert();
+    // Exactly the four keys packages/ac-emit-vitest/src/metadata.ts derives from
+    // CI. `branch` and `run_url` have NO column at all — they exist only here.
+    const ciMetadata = {
+      run_id: "31589392781",
+      commit: "112ad9ab",
+      branch: "spec-528/t1-t3-run-id-fallback",
+      run_url: "https://github.com/mindset-ai/memex-ai/actions/runs/31589392781",
+    };
+    const res = await app.request("/api/test-events", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer mxk_test",
+      },
+      body: JSON.stringify({ ...validBody, metadata: ciMetadata }),
+    });
+    expect(res.status).toBe(201);
+    const row = insertedValues.mock.calls[0]?.[0];
+    // Assert the STORED row, not the payload the emitter built — the two are
+    // only the same thing until something in between changes.
+    expect(row.metadata).toEqual(ciMetadata);
+    // And the promotion happened alongside, not instead of.
+    expect(row.runId).toBe("31589392781");
+    expect(row.commitSha).toBe("112ad9ab");
   });
 });

--- a/packages/server/src/routes/test-events.test.ts
+++ b/packages/server/src/routes/test-events.test.ts
@@ -9,13 +9,19 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { Hono } from "hono";
 import { tagAc } from "@memex-ai-ac/vitest";
 
-const insertSpy = vi.fn().mockReturnValue({
+// The default insert shape. Several blocks below re-point insertSpy with
+// mockReturnValue (persistent, not …Once) to capture the written row; [per
+// std-37] cl-5 a replaced stub is restored rather than left installed, so
+// beforeEach puts this back and no block inherits its predecessor's capture.
+const defaultInsertResult = () => ({
   values: vi.fn().mockReturnValue({
     returning: vi.fn().mockResolvedValue([
       { id: "fake-uuid", createdAt: new Date() },
     ]),
   }),
 });
+
+const insertSpy = vi.fn().mockReturnValue(defaultInsertResult());
 
 // spec-528 (ac-7): count what the ingest path costs per event. The two tempting
 // ways to implement the run_id fill — resolving it via a lookup, or reading the
@@ -91,6 +97,13 @@ beforeEach(() => {
   // without the clear, a per-POST count assertion sees every earlier test too.
   transactionSpy.mockClear();
   selectSpy.mockClear();
+});
+
+afterEach(() => {
+  // [per std-37] cl-5: restore what a test replaced. Blocks that capture the
+  // written row install a persistent mockReturnValue; without this, the next
+  // block silently inherits it and writes into a stale capture.
+  insertSpy.mockReturnValue(defaultInsertResult());
 });
 
 const validBody = {

--- a/packages/server/src/routes/test-events.ts
+++ b/packages/server/src/routes/test-events.ts
@@ -22,8 +22,15 @@
 //   status           required, one of 'pass' | 'fail' | 'error'
 //   test_identifier  optional, text (typically file path + function name)
 //   duration_ms      optional, integer
-//   commit_sha       optional, text (the git SHA the test ran against)
-//   run_id           optional, text (groups events from one CI run)
+//   commit_sha       optional, text (the git SHA the test ran against). When
+//                    absent, filled from metadata.commit (spec-528 dec-1 —
+//                    note the name difference: `commit`, not `commit_sha`).
+//   run_id           optional, text (groups events from one CI run). When
+//                    absent, filled from metadata.run_id (spec-528 dec-1).
+//                    Unlike actor below, these two ARE promoted from metadata:
+//                    they have no competing top-level value, so the fallback
+//                    overrides nothing and fills a column that would otherwise
+//                    stay NULL for every client that has not upgraded.
 //   actor            optional, text (spec-115 dec-6, spec-122) — WHO ran
 //                    the test. Top-level sibling of hidden/metadata. The
 //                    helper auto-populates from env vars; consumers can
@@ -374,6 +381,12 @@ async function processOneEvent(
   // unmodified (ac-12); validation lives here so the protocol shape is
   // consistent regardless of which framework adapter (vitest/jest/pytest)
   // produced the emission.
+  //
+  // spec-528 t-3 (ac-3): `run_id`, `commit`, `branch` and `run_url` are stored
+  // here AND — for the first two — promoted into columns below. That duplication
+  // is load-bearing, not tidy-up debt: external readers learned to query
+  // `metadata->>'run_id'` during the months the columns were empty, and `branch`
+  // / `run_url` have no column at all. Do not prune these keys.
   let metadataForStorage: Record<string, string> | null = null;
   let droppedKeys: string[] = [];
   if (body.metadata !== undefined) {
@@ -394,8 +407,30 @@ async function processOneEvent(
     status: body.status,
     testIdentifier: (body.test_identifier as string | undefined) ?? null,
     durationMs: (body.duration_ms as number | undefined) ?? null,
-    commitSha: (body.commit_sha as string | undefined) ?? null,
-    runId: (body.run_id as string | undefined) ?? null,
+    // spec-528 dec-1: fill from `metadata` as a FALLBACK, never an override —
+    // top-level wins whenever present; the metadata copy fills in only when the
+    // top-level field is absent. Do NOT "simplify" the two sources into one: the
+    // duplication is deliberate. The emitter has always collected these values
+    // (packages/ac-emit-vitest/src/metadata.ts) and filed them under `metadata`,
+    // so every client that has not upgraded — and every hand-rolled emitter —
+    // becomes attributable on this deploy alone, with nothing to install (ac-2).
+    //
+    // Note the name difference across the boundary: the wire field is
+    // `commit_sha`, the metadata key the emitter writes is `commit`.
+    //
+    // The precedence direction is dec-1's adopted READING of [per std-32] cl-20
+    // — that cl-20 states a precedence rule (a top-level value must win over a
+    // metadata copy) rather than a blanket ban on promotion. cl-20 is written
+    // about `actor`, which unlike `run_id` does have a competing top-level value
+    // and feeds a server-side identity resolver (spec-122 dec-8). If the owner of
+    // std-32 reads cl-20 as a general prohibition, dec-1 needs revisiting.
+    //
+    // Read from the validated/narrowed metadata, not the raw body: the size and
+    // shape caps (spec-115 dec-2/dec-3) have already been applied there, and
+    // re-reading the raw bag would bypass them.
+    commitSha:
+      (body.commit_sha as string | undefined) ?? metadataForStorage?.commit ?? null,
+    runId: (body.run_id as string | undefined) ?? metadataForStorage?.run_id ?? null,
     actor: (body.actor as string | undefined) ?? null,
     // spec-358: every ingested result counts. The inbound `hidden` field is
     // ignored — the row is always stored as a counting result. The column is
@@ -486,7 +521,9 @@ async function processOneEvent(
   console.log(
     `[test-events] ${subjectRefValue} ${body.status}` +
       (body.test_identifier ? ` (${body.test_identifier})` : "") +
-      (body.run_id ? ` run=${body.run_id}` : ""),
+      // spec-528: report what was STORED, not what arrived top-level — otherwise
+      // the log stays blank for every client whose run id rides in metadata.
+      (insertValues.runId ? ` run=${insertValues.runId}` : ""),
   );
 
   // spec-112 ac-22: an AC may go green AFTER its satisfying Task is already


### PR DESCRIPTION
Delivers **t-1** and **t-3** of [spec-528](https://memex.ai/mindset-prod/memex-building-itself/specs/spec-528). t-2 and t-4 are deliberately not in scope — see *What is NOT here*.

## The defect

`test_events.run_id` and `commit_sha` have existed since spec-115 and are **NULL on every row**. Measured on prod 2026-08-12: `0 of 114 044` over 24h.

Not a design gap — a disconnected wire. Both ends were already built for each other:

| end | state |
|---|---|
| `packages/ac-emit-vitest/src/metadata.ts:34-62` | already collects the run id + commit SHA from CI env — **into `metadata`** |
| `packages/server/src/routes/test-events.ts` | already validates and stores **top-level** `run_id` / `commit_sha` into the columns |

Nobody joined them. The values sit in the free-form bag; the columns built to hold them stay empty.

## What this PR does

One file of production code: `packages/server/src/routes/test-events.ts`.

`commitSha` and `runId` now fall back to `metadata.commit` / `metadata.run_id` when the top-level fields are absent. **Top-level wins whenever present; metadata fills in only when absent.** Never an override, never a merge.

Three things worth a reviewer's eye:

- **One function serves both transports.** The batch route loops the same `processOneEvent` the single route calls — confirmed by reading `test-events.ts:599-601`, not assumed, and asserted by a test so a future divergence fails loudly.
- **It reads the *validated* metadata, not the raw body,** so the spec-115 size caps aren't bypassed. Consequence, now in the comment because nobody would infer it: if a `run_id` key is ever dropped by those caps, the column stays NULL. That's correct.
- **No new query, transaction, or connection.** A field assignment on a payload the request already holds.

**Name mismatch across the boundary:** the wire field is `commit_sha`, the metadata key is `commit`. Reading the wrong one is a silent no-op — no error, no failing test, just a column that stays NULL. Documented at both the field and the route's wire-format header.

**t-3 — the metadata keys are pinned.** `run_id`, `commit`, `branch`, `run_url` keep being stored unchanged (`branch` and `run_url` have no column at all). A comment says they're load-bearing for external readers and not to be pruned; a test enforces it. Once `run_id` is a populated column the metadata copy *looks* like redundancy — deleting it would read as removing duplication, ship green, and silently break the `metadata->>'run_id'` reads that are load-bearing today.

**Also:** the stdout log printed `run=` from the top-level field only, so it was blank for every client. It now reports what was stored.

## Why server-side first

Per [dec-1](https://memex.ai/mindset-prod/memex-building-itself/specs/spec-528). This is what makes the data exist: **every existing client becomes attributable on this deploy with nothing to install** — the `^0.2.0` cohort (24 packages across 6 repos, excluded from 0.3.x entirely by 0.x caret rules), `mindset-four` at ~90% of ingest, and every hand-rolled emitter, because they all already send these keys in metadata (ac-2).

Client-side first was rejected for a specific reason: it would produce a correct wire format describing almost no real traffic.

## Standards

`[per std-32]` cl-8 is the mandate — *a field a consumer must read to attribute or filter is load-bearing and MUST be a column* — and `test_events` is in scope via cl-10. The current state is a standing violation.

The precedence **direction** follows dec-1's adopted *reading* of cl-20: that cl-20 states a precedence rule rather than a blanket ban on promotion. **The code comment records this as an interpretation, not a ruling**, and says explicitly that dec-1 needs revisiting if the standard's owner reads cl-20 as a general prohibition. A reviewer who disagrees with that reading should say so here rather than after merge.

## Testing

Written test-first, confirmed RED (4 failures), then GREEN.

**ac-6 — precedence (6 tests):** top-level only · metadata only · **both with different values → top-level wins** · neither → NULL · the same fill on the **batch** path · **the columns read back off a real Postgres row**.

The both-different case is the one that matters: a `??` in the wrong order silently prefers metadata and every other case still passes.

The real-row case was added deliberately. The unit tests assert the object handed to `.values()` — that proves the logic, not that the values reach the columns, and *"it looked wired and wasn't"* is the exact defect this Spec exists for.

**ac-7 — cost (1 test):** asserts the DB call counts are **identical** whether or not the fill fires. Written as a delta, not an absolute — see *Deviations*.

**ac-3 — metadata keys (1 test):** all four CI keys land in the stored row unchanged, and the promotion happened *alongside* rather than *instead of*.

| suite | result |
|---|---|
| `make check` | ✓ |
| `make typecheck` | ✓ |
| full server suite | 5 959 ✓ / 1 ✗ |
| full ui suite | 2 298 ✓ / 1 ✗ |

**Both failures were run down, and neither is from this branch:**

- `.ee/slack/oauth.test.ts` fails **identically on the tree with this branch's changes stashed** — verified by stashing and re-running, not asserted from memory. Unrelated (Slack OAuth vs. the test-events route), known local-red / CI-green. **It is in `test:unit`, so `.husky/pre-push` is red on it and this branch was pushed with `--no-verify`.** Flagging that explicitly rather than letting it pass unnoticed.
- The UI failure was **caused by the run, not the diff**: `e2e-ac-emission.spec-391.test.ts` asserts the emission fixture POSTs once, and I had set `MEMEX_EMIT=false` for the sweep, which by design makes it POST zero times. 5/5 green without the flag. Worth knowing — the failure message never mentions the flag.

**ACs verified** (confirmed by re-reading `list_acs`, not inferred from a green suite): **ac-3, ac-6, ac-7**.

## std-28 — no e2e journey needed

Zero UI files changed and no user-facing flow is added or altered — no screen, flow, copy, or interaction. Nothing for a Playwright journey to cover. Stating the classification rather than leaving it inferred.

## Deviations from the plan

**One, in ac-7's test shape.** t-1 asked to assert the transaction/statement count per event. Written as an absolute — one transaction, one insert, **zero** reads — it failed: the path already performs **one `select` per passing event** (`maybeAutoResolveIssuesForAcUid`, `test-events.ts:497`, awaited, outside the transaction).

The test now asserts the **delta**: same request with and without the metadata the fill reads, counts compared. Truer to ac-7's own wording (*"unchanged from before the change"*) and robust to whatever the baseline is. The pre-existing read is named in a comment so nobody mistakes it for something this PR introduced.

That pre-existing read is registered as **issue-1** on the Spec — it is precisely the shape ac-5/ac-7 forbid, on the hottest write path in the system. **Deliberately not fixed here:** spec-112 ac-22 made it the second auto-resolve trigger on purpose, and the latency may have been a conscious trade. It needs its own decision, not a drive-by.

**One addition outside the two tasks** (separate commit): `test-events.test.ts` had a latent ordering leak — several blocks re-point the insert stub with a *persistent* `mockReturnValue` and nothing restored it, so each block silently inherited its predecessor's capture. No test was reading a stale capture today, but it's exactly what `[per std-37]` cl-5 names, and appending to this file was about to depend on luck. Fixed with an `afterEach` restore.

## What is NOT here

**t-2 (prove it on prod) and t-4 (client-side `buildPayload`).** Neither is buildable from a local session: t-2 needs this deployed, t-4 needs a package release that dec-1 says should ride the next release with its own reason to exist.

**So 5 of 9 ACs remain untested — ac-1, ac-2, ac-4, ac-8, ac-9 — and that is the honest state, not an oversight.** Every one is a read against the production database or the live schema. None was flipped by a proxy; **ac-8 in particular invites the shortcut "no `CREATE INDEX` in the diff"**, which its own text forbids (*"Verified by reading `pg_indexes`, not by reviewing the diff"*) — doubly right here, since this Spec already established the migration files disagree with the live schema in two places.

**This does NOT unblock `mindset-four` spec-365 t-6.** ac-13 measures HTTP **requests** and pool acquisitions; `test_events` holds one row per **event** and nothing records which rows shared a request, so a populated `run_id` cannot produce a request count. spec-528's own Overview says as much. Recorded here so the connection isn't assumed after merge.

## Deploy notes

- **No migration, no DDL, no index.** Both columns already exist. Per dec-2, no index is added — 29 ms bounded / 95 ms unbounded, measured, fully cached; a seventh index would tax >100 000 writes/day to save ~66 ms.
- **No flags, no manual steps.** Ordinary deploy.
- **Effective for events arriving AFTER the deploy only. Historical rows stay NULL forever and cannot be backfilled** — not "not planned", *impossible*: retention trims to 10 rows per `(subject_ref, test_identifier)`, 13 083 pairs are already at that cap, so the metadata one would backfill *from* is already gone. **Any before/after comparison begins at the deploy**, and anyone who forgets will read the NULL history as a failure of the change.
- **After deploy, run t-2.** One query is the whole acceptance surface:
  ```sql
  select count(*) filter (where run_id is not null) as with_run_id, count(*) as total
  from test_events where created_at > '<deploy time>';
  ```
  It read `0 / 114 044` before. Anything short of a healthy majority means the wire is still not joined.

## Open question for the reviewer

`body.commit_sha` validates as *a string when provided*, so `""` passes and `"" ?? metadata.commit` yields `""` — an empty top-level would beat a good metadata value and store `''` rather than NULL. **Kept `??` deliberately**, because the `actor` field immediately above has the same shape and matching the neighbour is more defensible than diverging. If you'd rather close it, `||` on these two fields is the one-character fix and is arguably truer to ac-6's *"carries a top-level `run_id`"*. Your call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)