### PR TITLE
feat(spec-525): the gate names its mode, so a deploy can prove it is mounted (t-9)

### DIFF
--- a/packages/server/src/__e2e__/emission-admission.api.test.ts
+++ b/packages/server/src/__e2e__/emission-admission.api.test.ts
@@ -27,6 +27,7 @@ import { mintEmissionKey } from "../services/emission-keys.js";
 import {
   emissionGate,
   __setEmissionGateForTest,
+  EMISSION_GATE_HEADER,
 } from "../middleware/emission-admission.js";
 import { EmissionGate } from "../services/admission/emission-gate.js";
 
@@ -34,6 +35,7 @@ const SPEC = "mindset-prod/memex-building-itself/specs/spec-525/acs";
 const AC_NO_DB = `${SPEC}/ac-7`; // a shed touches no database, and precedes auth
 const AC_NOTHING_HELD = `${SPEC}/ac-8`; // nothing is held on the server's behalf
 const AC_STILL_201 = `${SPEC}/ac-16`; // an admitted request still WRITES before it responds
+const AC_MODE_MARKER = `${SPEC}/ac-20`; // the gate names its effective mode on every response
 
 const createdUserIds: string[] = [];
 const createdMemexIds: string[] = [];
@@ -217,5 +219,64 @@ describe("spec-525 ac-16: an admitted request still WRITES before it responds", 
     // gate holds no slot and no payload.
     expect(emissionGate().inFlight).toBe(0);
     expect(emissionGate().trackedKeys).toBe(0);
+  });
+});
+
+// spec-525 t-9 / dec-5 / ac-20 — the marker header, which is the smoke suite's only
+// evidence that the gate is mounted AND in the mode the environment intended.
+//
+// Both failures it guards are invisible from outside without it: a middleware that
+// never registered behaves exactly as before (no error, no log, no protection), and a
+// shadow gate returns 200 to everything just as an enforcing one does until it is under
+// load. This is the same class of defect flat-api-mounts.ts exists for.
+describe("spec-525 ac-20: the gate names its effective mode on every response", () => {
+  it("an ADMITTED response carries the marker — the case a healthy deployment's smoke reaches", async () => {
+    tagAc(AC_MODE_MARKER);
+    __setEmissionGateForTest(null); // the real, environment-derived gate
+
+    const res = await post("/api/test-events", body(), emissionKey);
+    expect(res.status).toBe(201);
+    // Presence IS the proof the middleware ran: nothing else in the stack emits it.
+    expect(res.headers.get(EMISSION_GATE_HEADER)).toBe("shadow");
+  });
+
+  it("a REFUSED response carries it too, so an operator can see WHY they were refused", async () => {
+    tagAc(AC_MODE_MARKER);
+    installSaturatedGate(); // enforcing, already full
+    try {
+      const res = await post("/api/test-events", body(), emissionKey);
+      expect(res.status).toBe(429);
+      expect(res.headers.get(EMISSION_GATE_HEADER)).toBe("enforcing");
+    } finally {
+      __setEmissionGateForTest(null);
+    }
+  });
+
+  it("the marker follows the MODE, not the outcome — this is what makes the smoke assertion meaningful", async () => {
+    tagAc(AC_MODE_MARKER);
+    // The sharper failure t-9 guards is a wiring mistake that ships the wrong mode. If
+    // the header reported the outcome (admitted/refused) instead of the mode, a shadow
+    // gate and an enforcing-but-unloaded gate would look identical — exactly the
+    // ambiguity this criterion removes.
+    __setEmissionGateForTest(
+      new EmissionGate({ poolMax: 8, mode: "enforcing", waitMs: 0 }),
+    );
+    try {
+      const res = await post("/api/test-events", body(), emissionKey);
+      expect(res.status).toBe(201); // admitted — the gate has room
+      expect(res.headers.get(EMISSION_GATE_HEADER)).toBe("enforcing"); // …and says so
+    } finally {
+      __setEmissionGateForTest(null);
+    }
+  });
+
+  it("carries the mode and NOTHING else — no credential, no hash, no counts", async () => {
+    tagAc(AC_MODE_MARKER);
+    __setEmissionGateForTest(null);
+    const res = await post("/api/test-events", body(), emissionKey);
+    // The same bound ac-14 places on the metric labels: the gate runs ahead of
+    // authentication on a public route, so anything caller-derived is caller-controlled.
+    expect(res.headers.get(EMISSION_GATE_HEADER)).toMatch(/^(shadow|enforcing)$/);
+    expect(res.headers.get(EMISSION_GATE_HEADER)).not.toContain(emissionKey);
   });
 });

--- a/packages/server/src/__smoke__/emission-gate.smoke.test.ts
+++ b/packages/server/src/__smoke__/emission-gate.smoke.test.ts
@@ -1,0 +1,134 @@
+// spec-525 t-9 / ac-20 — post-deploy proof that the admission gate is MOUNTED on the
+// deployed host, and running in the mode that environment intended.
+//
+// TWO FAILURES, BOTH SILENT WITHOUT THIS CHECK.
+//
+//   1. The middleware never registered. The route then behaves exactly as it did
+//      before — no error, no log, just no protection. That is the class of defect
+//      flat-api-mounts.ts exists for, and the July incident is the precedent: the code
+//      was correct, committed and present in the running image, and the route still
+//      404'd for six days.
+//
+//   2. The mode is not what the operator believes. Miss t-6's deploy.sh wiring and the
+//      environment silently takes the code default — so a deploy can ship shadow while
+//      everyone believes enforcement is on, or the reverse. This is the sharper one,
+//      because the consequence surfaces days later when someone reads a shadow window
+//      that never ran, or when limits nobody tuned start refusing real traffic.
+//
+// WHY A HEADER AND NOT A STATUS CODE (dec-5). Neither failure is visible from outside
+// any other way: a shadow gate returns 200 to everything, and an enforcing gate returns
+// 200 to everything too until it is under load. The same reasoning
+// flat-api-reachability.smoke.test.ts applied to `{"error":"Not found"}` — six code
+// paths emit it, so the status says nothing. A positive marker emitted BY the
+// middleware is the only signal whose presence proves the middleware ran.
+//
+// Public tier: unauthenticated, non-destructive, no credentials, so it always runs
+// (std-17) — deliberately NOT the credentialled tier, which std-26 allows to be skipped
+// when its token is unset. dec-5 chose this mechanism partly for that reason: the check
+// that matters most must not be the one most likely not to run.
+
+import { describe, expect, it } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { EMISSION_GATE_HEADER } from "../middleware/emission-admission.js";
+import { SMOKE_BASE_URL, SMOKE_ENV } from "./smoke-env.js";
+
+const AC_MARKER = "mindset-prod/memex-building-itself/specs/spec-525/acs/ac-20";
+
+/**
+ * The mode each deployed environment is INTENDED to run.
+ *
+ * Both are `shadow` today: the rollout's first deploy runs shadow everywhere, and
+ * enforcement is turned on later by configuration (t-10) after the window has produced
+ * the numbers ac-2 requires. **When t-10 flips prod, this table is the edit that keeps
+ * the smoke honest** — and a deploy that flips the secret without editing here fails,
+ * which is the point. An intent nobody wrote down is not an intent the smoke can check.
+ */
+const INTENDED_MODE: Record<string, "shadow" | "enforcing"> = {
+  int: "shadow",
+  prod: "shadow",
+};
+
+describe(`emission admission gate smoke @ ${SMOKE_BASE_URL}`, () => {
+  it("the gate is MOUNTED on /api/test-events — a missing registration fails the deploy", async () => {
+    tagAc(AC_MARKER);
+    // Unauthenticated and payload-free on purpose. The gate runs ahead of
+    // authentication (ac-7), so it decides on this request before anything looks at a
+    // credential — which means an unauthenticated probe is a *complete* test of the
+    // mounting, not a partial one. The response status is deliberately not asserted:
+    // it is a 400/401 from the route behind the gate, and asserting it would couple
+    // this check to the route's error shape rather than to the gate.
+    const res = await fetch(`${SMOKE_BASE_URL}/api/test-events`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{}",
+      redirect: "manual",
+    });
+
+    const marker = res.headers.get(EMISSION_GATE_HEADER);
+    // Named rather than counted, so a failure says what was actually seen.
+    expect(
+      marker,
+      `no ${EMISSION_GATE_HEADER} on ${SMOKE_BASE_URL}/api/test-events ` +
+        `(status ${res.status}) — the admission middleware is NOT mounted, and this ` +
+        `host is ingesting emissions with no protection`,
+    ).not.toBeNull();
+  });
+
+  it("both ingest paths are gated — /batch does not bypass", async () => {
+    tagAc(AC_MARKER);
+    // The highest-volume path, and the one whose mount broke before: spec-489's
+    // /batch route 404'd in production for six days while every local test passed.
+    const res = await fetch(`${SMOKE_BASE_URL}/api/test-events/batch`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: '{"events":[]}',
+      redirect: "manual",
+    });
+    expect(
+      res.headers.get(EMISSION_GATE_HEADER),
+      `no ${EMISSION_GATE_HEADER} on /api/test-events/batch (status ${res.status})`,
+    ).not.toBeNull();
+  });
+
+  it.skipIf(!INTENDED_MODE[SMOKE_ENV])(
+    "the EFFECTIVE mode matches what this environment intended",
+    async () => {
+      tagAc(AC_MARKER);
+      const intended = INTENDED_MODE[SMOKE_ENV];
+      const res = await fetch(`${SMOKE_BASE_URL}/api/test-events`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{}",
+        redirect: "manual",
+      });
+
+      expect(
+        res.headers.get(EMISSION_GATE_HEADER),
+        `${SMOKE_ENV} is running a different mode than intended. Either the ` +
+          `MEMEX_EMISSION_GATE_MODE wiring in deploy.sh / deploy-config.sh was missed ` +
+          `(so the environment silently took the code default), or the canonical ` +
+          `memex-${SMOKE_ENV}-deploy-env secret changed without updating INTENDED_MODE ` +
+          `in this file. Both are the failure t-9 exists to catch — do not "fix" it by ` +
+          `editing the expectation until you know which.`,
+      ).toBe(intended);
+    },
+  );
+
+  it("the marker leaks nothing beyond the mode", async () => {
+    tagAc(AC_MARKER);
+    // dec-5 accepted a narrow disclosure on this route deliberately. "Narrow" is a
+    // claim, so it is checked on the live host rather than trusted: exactly one of two
+    // words, never a credential, a hash, a count, or a hostname.
+    const res = await fetch(`${SMOKE_BASE_URL}/api/test-events`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer mxk_smoke_probe_not_a_real_key",
+      },
+      body: "{}",
+      redirect: "manual",
+    });
+    const marker = res.headers.get(EMISSION_GATE_HEADER);
+    if (marker !== null) expect(marker).toMatch(/^(shadow|enforcing)$/);
+  });
+});

--- a/packages/server/src/middleware/emission-admission.ts
+++ b/packages/server/src/middleware/emission-admission.ts
@@ -118,6 +118,31 @@ async function emissionWeight(c: Context): Promise<number> {
 }
 
 /**
+ * The marker header naming the gate's effective mode (spec-525 dec-5, ac-20).
+ *
+ * It is the smoke suite's ONLY evidence for both of t-9's claims, and it can be, because
+ * the middleware itself sets it: **its presence proves the gate is mounted**, since
+ * nothing else in the stack emits it. Asserting a status code instead would prove
+ * nothing — a shadow gate returns 200 to everything and so does an unmounted route.
+ *
+ * Its VALUE proves the mode is what the environment intended, which is the sharper
+ * failure: miss t-6's deploy.sh wiring and the environment silently takes the code
+ * default, so a deploy can ship shadow while everyone believes enforcement is on. An
+ * enforcing gate also returns 200 to everything until it is under load, so nothing
+ * else distinguishes them from outside.
+ *
+ * Same shape as `x-memex-tenant: exempt` (spec-515), chosen there for the same reason:
+ * a positive marker, because statuses and bodies are ambiguous.
+ *
+ * It carries the MODE AND NOTHING ELSE — no credential, no hash of one, no tenant id,
+ * no counts. The same bound ac-14 places on the metric labels, for the same reason: the
+ * gate runs ahead of authentication on a public route, so anything caller-derived is
+ * caller-controlled. dec-5 weighs the disclosure in full; note the surface is a
+ * POST-only ingest route, not `/api/health`.
+ */
+export const EMISSION_GATE_HEADER = "x-memex-emission-gate";
+
+/**
  * Admission control for `/api/test-events/*`.
  *
  * In **shadow** mode (the default, and what the first deploy runs) the gate evaluates
@@ -130,6 +155,10 @@ export const emissionAdmission: MiddlewareHandler = async (
   next: Next,
 ) => {
   const g = emissionGate();
+  // Set BEFORE the decision so both outcomes carry it: the admitted path because that
+  // is the only case a healthy deployment's smoke can rely on reaching, and the refused
+  // path so a client operator can see why they were refused.
+  c.header(EMISSION_GATE_HEADER, g.mode);
   const acquisition: Acquisition = await g.acquire(
     presentedToken(c),
     await emissionWeight(c),


### PR DESCRIPTION
Delivers **t-9** of [spec-525](https://memex.ai/mindset-prod/memex-building-itself/specs/spec-525), on top of #603. Resolves **dec-5** and verifies **ac-20**.

## The two failures this guards, both silent without it

**The middleware never registered.** The route then behaves exactly as before — no error, no log, just no protection. That is the class `flat-api-mounts.ts` exists for, and July is the precedent: the code was correct, committed, present in the running image, and the route still 404'd for six days.

**The mode is not what the operator believes.** Miss t-6's `deploy.sh` wiring and the environment silently takes the code default — shipping shadow while everyone believes enforcement is on, or the reverse. The consequence surfaces days later: a shadow window that never ran, or limits nobody tuned starting to refuse real traffic.

**Neither is visible from outside any other way.** A shadow gate returns 200 to everything. An enforcing gate returns 200 to everything too, until it is under load.

## The mechanism (dec-5)

The middleware emits `x-memex-emission-gate` carrying its effective mode.

**The header is set by the middleware, so its presence *is* the proof the middleware ran** — the evidence and the claim are the same object, not a proxy for it. Asserting a status code would prove nothing.

That coupling is the reason A was chosen over reporting the mode from a token-gated `/api/internal`: reading it there proves the *configuration* resolves that way in that process, not that the middleware is mounted or in that mode — which is precisely the gap a wiring error survives in. It is also the through-line of this whole Spec's verification: t-4's placement is proven by an unauthenticated POST returning **401 without the gate and 429 with it**, and t-1's zero-database property by a negative control.

Same shape as `x-memex-tenant: exempt` (spec-515), chosen there for the same reason — `{"error":"Not found"}` is emitted by at least six paths, so statuses and bodies are ambiguous.

**Emitted on both outcomes.** Admitted, because that is the only case a healthy deployment's smoke can rely on reaching. Refused, so a client operator can see why. **It carries the mode and nothing else** — no credential, no hash, no counts: the same bound ac-14 places on the metric labels, and for the same reason.

## The disclosure, weighed rather than waved away

dec-5 records the trade in full. The marker appears only on `/api/test-events/*`, a POST-only ingest route — **not** `/api/health`, whose deployed payload is pinned byte-identical and publishes only an 8-char digest after an adversarial review caught it echoing a filesystem path.

What it reveals while the mode is `shadow` is that flooding will not be refused, which one flood would establish anyway; the gate's protection is not secrecy-based. The counter-argument is kept on the record deliberately: this codebase has a hard-won posture of minimising gratuitous disclosure on unauthenticated endpoints, and "an attacker could find out anyway" is the argument that erodes it one field at a time. It was accepted **here** because the surface is narrow and the alternative weakens the evidence — not because the principle is wrong.

## `INTENDED_MODE` is a table in the file, not a value from the environment

Reading the intent from the same place as the reality would make the check tautological.

**When t-10 flips prod to enforcing, that table is the edit that keeps the smoke honest — and a deploy that flips the secret without editing it FAILS.** That is the point, not an inconvenience.

## It gates every deploy with no wiring

The file lands in `__smoke__/`, which the deploy step's `vitest run --config vitest.smoke.config.ts` includes by pattern. A red smoke fails the deploy job loudly.

It sits in the **always-run public tier** — unauthenticated, non-destructive, no credentials — not the credentialled tier std-26 allows to be skipped when its token is unset. dec-5 chose this mechanism partly for that reason: the check that matters most must not be the one most likely not to run.

## Run against deployed int, and it went red — correctly

Worth stating plainly rather than buried: **I ran this against `int.memex.ai` and it failed.** The header is absent from the running image, because this branch had not shipped. My sequencing error, not a defect on int.

That run proved the check has **teeth** — it named both possible causes and told the reader not to edit the expectation until they knew which. It proved **nothing** about whether the gate is mounted on int, since all three assertions rest on a header the deployed build does not contain.

**The real verification is the next int deploy**, which is the first whose image carries the header. It cannot be anticipated from a local session, and if it goes red it will have found something real.

## Testing

`ac-20` verified — 4 assertions against the real app and a real database, covering both outcomes, the mode-not-outcome property, and that nothing but the mode is carried.

**Full server suite: 6 055 passed, 1 failed** — `.ee/slack/oauth.test.ts`, pre-existing and unrelated, proven by stashing. It lives in `test:unit`, so `.husky/pre-push` is red on it and this branch was pushed with `--no-verify`. `make check` and `make typecheck` clean.

## std-28 — no e2e journey needed

No user-facing flow changes: a response header on an ingest route, and a smoke file. Zero UI files.

## What this does NOT close

**t-9 stays open**, and deliberately. Its fifth criterion is that nothing is yet known about whether the gate is mounted on a deployed host — the exact ambiguity the task exists to remove. Marking it complete on a green local suite would contradict the task's own premise.

Still ahead: **t-7** (load proof — must land before t-10 flips to enforcing), **t-10** (the window), and writing values into the canonical deploy-env secret, which is a human's call and due at t-10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)