### PR TITLE
release(spec-518): t-7 — assert the scaling a deploy ACTUALLY applied, read back from live Cloud Run

### DIFF
--- a/packages/server/deploy.sh
+++ b/packages/server/deploy.sh
@@ -323,6 +323,18 @@ DATABASE_URL="${DB_URL}" bash "${PKG_DIR}/scripts/apply-hand-migrations.sh"
 # of Step 5 — DB_URL stays valid for the backfills without re-establishing the proxy.
 echo "Schema migrations complete (1a/1b) — proxy stays up for post-cutover backfills (Step 5)."
 
+# ── Step 3b: connection-budget PRE-FLIGHT (spec-518 t-7) ──────
+# The cheap save: refuse to touch prod at all if the scaling config is not explicit, or if the
+# values about to be applied do not fit the connection ceiling. Runs HERE because the proxy from
+# Step 3 is up, so the ceiling is read from Postgres (`pg_settings`) rather than from
+# `gcloud sql describe`'s recorded flags — prod ran a week on a recorded ceiling sized for a
+# machine that no longer existed (spec-518 dec-2). On prod an absent MAX_INSTANCES / MIN_INSTANCES /
+# DB_POOL_MAX aborts: `${VAR:-default}` below turns a missing variable into a live configuration
+# change, and that default is the trap rather than the arithmetic. On int the guard warns and
+# continues (spec-518 dec-5) — int violates the corrected invariant at its own defaults
+# (2 × 3 × (5+1) = 36 against 22 usable) and survives it, because int's load never extends the pools.
+DB_URL="${DB_URL}" pnpm run deploy:verify-scaling -- --mode=plan
+
 # ── Step 4: Deploy to Cloud Run ───────────────────────────────
 echo ""
 echo "Deploying to Cloud Run..."
@@ -409,10 +421,19 @@ REMOVE_CONVERSION_SECRETS="${REMOVE_CONVERSION_SECRETS#,}"  # strip leading comm
 # survive. --min-instances/--max-instances are ENV-KEYED per-env (spec-518): MIN_INSTANCES /
 # MAX_INSTANCES come from the memex-<env>-deploy-env secret and default to 0/3 (today's
 # behaviour) when unset, so prod and int can differ and the live scaling can't drift from
-# config. Budget invariant (spec-518 / db/connection.ts:29): MAX_INSTANCES × (DB_POOL_MAX + 1
-# relay LISTEN) must stay under the DB's effective ceiling (prod ~47) — a value pair that
-# violates it can exhaust connections (the 2026-08-03 FATAL). DB_POOL_MAX is the per-env pool
-# cap (prod=4 under maxScale 8 → 8×(4+1)=40<47; spec-489/spec-518/spec-332); omitted when unset.
+# config. Budget invariant (spec-518 t-7) — now ASSERTED, in Steps 3b and 4b, not merely stated
+# here. The single-term form this comment used to carry (MAX_INSTANCES × (DB_POOL_MAX + 1) < ~47)
+# was not wrong, it was a sum with terms missing, and it was green throughout BOTH of this Spec's
+# incidents:
+#     Σ over every Cloud Run service on this Cloud SQL instance of
+#       2 × MAX_INSTANCES × (DB_POOL_MAX + 1 relay LISTEN)   +   admin reserve
+#     ≤ max_connections − superuser_reserved − reserved      (read from Postgres, not from gcloud)
+# The 2× is the cutover: a draining revision holds its pool while serving nothing, so a deploy is
+# the one moment the budget must hold twice over — and the only moment anyone changes the config.
+# Prod today: 2×8×(4+1)=80 + backstage 2×3×(10+1)=66 + admin 5 = 151 against 197 usable (dec-2
+# raised max_connections 50 → 200 on 2026-08-12; the old ~47 is what the 2026-08-03 FATAL and the
+# 2026-08-11 outage were measured against). DB_POOL_MAX is the per-env pool cap (prod=4 under
+# maxScale 8; spec-489/spec-518/spec-332); omitted when unset.
 # MEMEX_EMISSION_* (spec-525 t-6) are the admission gate's knobs: GATE_MODE (shadow|enforcing —
 # default shadow, the SAFE one, so a wiring mistake under-protects rather than silently
 # enforcing untuned limits), WAIT_MS and MAX_WAITERS. All three optional; unset means the code
@@ -436,6 +457,27 @@ gcloud run deploy "${SERVICE}" \
   --update-env-vars "^|^NODE_ENV=production|DATABASE_URL=postgresql://${RUNTIME_DB_USER}:${RUNTIME_DB_PASS_ENC}@localhost:${DB_PORT}/${DB_NAME}|CLOUD_SQL_SOCKET=/cloudsql/${CLOUD_SQL_INSTANCE_CONN}|GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID}|EMAIL_FROM=${EMAIL_FROM}|APP_BASE_URL=${APP_BASE_URL}|OAUTH_ENABLED=1|MEMEX_RLS_GUARD_THROW=1|SLACK_CLIENT_ID=${SLACK_CLIENT_ID}|SLACK_OAUTH_REDIRECT_URI=${API_BASE_URL}/api/auth/slack/callback|KMS_KEY_NAME=projects/${GCP_PROJECT}/locations/${REGION}/keyRings/memex/cryptoKeys/slack-tokens${DB_POOL_MAX+|DB_POOL_MAX=${DB_POOL_MAX}}${HIDDEN_FEATURES+|HIDDEN_FEATURES=${HIDDEN_FEATURES}}${SIGNUP_DOMAIN_ALLOWLIST+|SIGNUP_DOMAIN_ALLOWLIST=${SIGNUP_DOMAIN_ALLOWLIST}}${STRIPE_PREMIUM_MONTHLY_PRICE_ID+|STRIPE_PREMIUM_MONTHLY_PRICE_ID=${STRIPE_PREMIUM_MONTHLY_PRICE_ID}}${STRIPE_PREMIUM_ANNUAL_PRICE_ID+|STRIPE_PREMIUM_ANNUAL_PRICE_ID=${STRIPE_PREMIUM_ANNUAL_PRICE_ID}}${STRIPE_ENTERPRISE_MONTHLY_PRICE_ID+|STRIPE_ENTERPRISE_MONTHLY_PRICE_ID=${STRIPE_ENTERPRISE_MONTHLY_PRICE_ID}}${STRIPE_ENTERPRISE_ANNUAL_PRICE_ID+|STRIPE_ENTERPRISE_ANNUAL_PRICE_ID=${STRIPE_ENTERPRISE_ANNUAL_PRICE_ID}}${OTEL_EXPORTER_OTLP_ENDPOINT+|OTEL_EXPORTER_OTLP_ENDPOINT=${OTEL_EXPORTER_OTLP_ENDPOINT}}${MEMEX_OTEL_EXPORT_INTERVAL_MS+|MEMEX_OTEL_EXPORT_INTERVAL_MS=${MEMEX_OTEL_EXPORT_INTERVAL_MS}}${EMAIL_ACTIVATION_FROM+|EMAIL_ACTIVATION_FROM=${EMAIL_ACTIVATION_FROM}}${EMAIL_ACTIVATION_REPLY_TO+|EMAIL_ACTIVATION_REPLY_TO=${EMAIL_ACTIVATION_REPLY_TO}}${EMAIL_SENDER_NAME+|EMAIL_SENDER_NAME=${EMAIL_SENDER_NAME}}${ACTIVATION_EMAILS_ENABLED+|ACTIVATION_EMAILS_ENABLED=${ACTIVATION_EMAILS_ENABLED}}${ACTIVATION_CONNECT_GO_LIVE+|ACTIVATION_CONNECT_GO_LIVE=${ACTIVATION_CONNECT_GO_LIVE}}${STORAGE_PROVIDER+|STORAGE_PROVIDER=${STORAGE_PROVIDER}}${STORAGE_GCS_BUCKET+|STORAGE_GCS_BUCKET=${STORAGE_GCS_BUCKET}}${MEMEX_EMISSION_GATE_MODE+|MEMEX_EMISSION_GATE_MODE=${MEMEX_EMISSION_GATE_MODE}}${MEMEX_EMISSION_WAIT_MS+|MEMEX_EMISSION_WAIT_MS=${MEMEX_EMISSION_WAIT_MS}}${MEMEX_EMISSION_MAX_WAITERS+|MEMEX_EMISSION_MAX_WAITERS=${MEMEX_EMISSION_MAX_WAITERS}}" \
   --update-secrets "${SECRETS_WIRING}" \
   ${REMOVE_CONVERSION_SECRETS:+--remove-secrets="${REMOVE_CONVERSION_SECRETS}"}
+
+# ── Step 4b: assert what the deploy ACTUALLY applied (spec-518 t-7) ──
+# Every check that runs before this line reads the SOURCE — this file's flag syntax,
+# deploy-config.sh's exports, the budget arithmetic in a regression test. All of them were green
+# throughout the 2026-08-03 and 2026-08-11 incidents, because none of them can observe what
+# reached the running revision. This one reads the OUTCOME: it resolves the revision traffic is
+# actually on (never spec.template, which is intent), compares every value config SET against
+# what that revision carries, and re-checks the connection budget on the numbers in force,
+# summed over EVERY Cloud Run service attached to this Cloud SQL instance (`backstage` included —
+# it carries no pool cap and appeared in no arithmetic until now, spec-518 issue-2).
+#
+# Deliberately AFTER the cutover: what was applied cannot be known before applying it. So this
+# gate is loud, not preventive — on a mismatch, roll back by re-running the deploy workflow
+# (workflow_dispatch) against the previous SHA. A mismatch aborts in EVERY environment: a value
+# set in config that did not arrive is a plumbing defect with no environmental excuse, and int is
+# where it must be caught, since int deploys first.
+#
+# Placed BEFORE Step 5, so an abort here also skips the post-cutover data backfills. That is
+# acceptable and deliberate: 1d/1f are idempotent and resume on the next deploy (spec-417 dec-6),
+# and a deploy whose applied configuration is wrong should not go on to do more work.
+DB_URL="${DB_URL}" pnpm run deploy:verify-scaling -- --mode=applied
 
 # ── Step 5: Post-cutover data backfills (spec-417 dec-6) ──────
 # The new revision is now serving 100% of traffic. These DATA backfills/generation

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -38,6 +38,7 @@
     "db:purge-starter-specs": "tsx scripts/purge-starter-specs.ts",
     "check-reserved-roots": "tsx scripts/check-reserved-root-collisions.ts",
     "activation:backlog": "tsx scripts/activation-backlog.ts",
+    "deploy:verify-scaling": "tsx scripts/verify-scaling-budget.ts",
     "oauth:smoke": "node scripts/oauth-smoke.mjs",
     "docker:build": "docker build -t memex-server .",
     "docker:run": "docker run -p 8080:8080 --env-file .env memex-server",

--- a/packages/server/scripts/verify-scaling-budget.ts
+++ b/packages/server/scripts/verify-scaling-budget.ts
@@ -1,0 +1,320 @@
+#!/usr/bin/env tsx
+/**
+ * spec-518 t-7 — assert the scaling a deploy ACTUALLY applied, read back from live Cloud Run.
+ *
+ * Every other check on this Spec reads the source. `deploy.sh`'s flag syntax, `deploy-config.sh`'s
+ * exports, the budget arithmetic in a regression test — all three were green throughout BOTH of
+ * this Spec's incidents, because none of them can observe that CI never ran the exporting branch.
+ * They read intent; the defect lives in the outcome. This is the only check that reads the outcome.
+ *
+ * It lives in the deploy rather than in the HTTP smoke suite because it needs gcloud and a
+ * database connection — the smoke only knows a base URL. Which is also why it had never been
+ * written: the deploy is the one place no test runs.
+ *
+ * ── Two invocations, both inside deploy.sh's cloud-sql-proxy window ──
+ *
+ *   --mode=plan      BEFORE the cutover. Refuses an ABSENT scaling value on prod (a missing
+ *                    variable becoming a live `${VAR:-default}` is the trap), and checks the
+ *                    budget on the values this deploy is ABOUT to apply. Cheap save: it aborts
+ *                    before prod is touched.
+ *
+ *   --mode=applied   AFTER the cutover. Reads the revision traffic is actually on, compares every
+ *                    value config set against what that revision carries, and re-checks the budget
+ *                    on the numbers IN FORCE. Necessarily after: what was applied cannot be known
+ *                    before applying it. Pair a failure here with the rollback path (a
+ *                    workflow_dispatch redeploy of the previous SHA).
+ *
+ * ── What it counts ──
+ *
+ * `src/deploy/scaling-budget.ts` holds the arithmetic and the comparison, pure and unit-tested
+ * (ac-16 / ac-19 / ac-20). Read the invariant's derivation there. In short: every Cloud Run
+ * service attached to this Cloud SQL instance, each at `2 × maxInstances × (pool + 1)`, plus an
+ * admin reserve, against `max_connections − superuser_reserved − reserved` READ FROM POSTGRES.
+ * Not from `gcloud sql describe`: prod ran a week on a recorded ceiling sized for a machine that
+ * no longer existed (dec-2).
+ *
+ * ── Posture (dec-5) ──
+ *
+ * A budget violation aborts on prod and warns on int, because int violates the corrected
+ * invariant today (`2 × 3 × (5+1) = 36` against 22 usable) and survives it — int's load never
+ * extends the pools. A MISMATCH aborts everywhere: a value set in config that did not reach the
+ * running revision is a plumbing defect with no environmental excuse, and int is exactly where it
+ * must be caught, since int deploys first.
+ *
+ * A read that FAILS is treated the same way as a violation — fatal on prod, a warning elsewhere.
+ * A guard that cannot read must not report success; "nobody checked" is what this exists to end.
+ */
+
+import { execFileSync } from "node:child_process";
+import postgres from "postgres";
+import {
+  CLOUD_RUN_DEFAULT_MAX_INSTANCES,
+  SCALING_KEYS,
+  type ScalingKey,
+  type ServiceObservation,
+  comparePlan,
+  computeBudget,
+  decideOutcome,
+  formatBudgetReport,
+  isProd,
+  parseRevisionScaling,
+  parseServingRevisions,
+  usableConnections,
+} from "../src/deploy/scaling-budget.js";
+
+type Mode = "plan" | "applied";
+
+const mode: Mode = process.argv.includes("--mode=applied") ? "applied" : "plan";
+
+const ENV = process.env.ENV ?? "int";
+const SERVICE = process.env.SERVICE ?? "memex-api";
+const REGION = process.env.REGION ?? "us-east4";
+const PROJECT = process.env.GCP_PROJECT ?? "";
+const INSTANCE_CONN = process.env.CLOUD_SQL_INSTANCE_CONN ?? "";
+// deploy.sh's proxy URL. DATABASE_URL is the fallback so the script is runnable by hand.
+const DB_URL = process.env.DB_URL ?? process.env.DATABASE_URL ?? "";
+
+/** What config asked for — absent stays absent, which is a fact the comparison needs. */
+const intended: Partial<Record<ScalingKey, string | undefined>> = {
+  MAX_INSTANCES: process.env.MAX_INSTANCES,
+  MIN_INSTANCES: process.env.MIN_INSTANCES,
+  DB_POOL_MAX: process.env.DB_POOL_MAX,
+};
+
+const readFailures: string[] = [];
+
+function gcloudJson(args: string[]): unknown {
+  const out = execFileSync("gcloud", [...args, "--format=json"], {
+    encoding: "utf-8",
+    maxBuffer: 32 * 1024 * 1024,
+  });
+  return JSON.parse(out);
+}
+
+/** Ceiling from Postgres — the value in force, not the value recorded. */
+async function readCeiling(): Promise<number | undefined> {
+  if (!DB_URL) {
+    readFailures.push("no DB_URL — cannot read the connection ceiling from Postgres");
+    return undefined;
+  }
+  // max: 1 and a short timeout: this runs during a deploy, against the ceiling it is measuring.
+  const sql = postgres(DB_URL, { max: 1, idle_timeout: 5, connect_timeout: 10 });
+  try {
+    const rows = await sql<{ name: string; setting: string }[]>`
+      select name, setting from pg_settings
+      where name in ('max_connections', 'superuser_reserved_connections', 'reserved_connections')
+    `;
+    const get = (n: string) => Number(rows.find((r) => r.name === n)?.setting ?? Number.NaN);
+    const maxConnections = get("max_connections");
+    if (!Number.isFinite(maxConnections)) {
+      readFailures.push("pg_settings returned no max_connections");
+      return undefined;
+    }
+    const superuserReserved = get("superuser_reserved_connections");
+    const reserved = get("reserved_connections");
+    const usable = usableConnections({
+      maxConnections,
+      superuserReserved: Number.isFinite(superuserReserved) ? superuserReserved : 0,
+      // reserved_connections is PG16+; an older server simply has no such row.
+      reserved: Number.isFinite(reserved) ? reserved : 0,
+    });
+    console.log(
+      `  ceiling (read from Postgres): max_connections ${maxConnections} − superuser ${superuserReserved || 0} ` +
+        `− reserved ${Number.isFinite(reserved) ? reserved : 0} = ${usable} usable`,
+    );
+    return usable;
+  } catch (err) {
+    readFailures.push(`could not read the ceiling from Postgres: ${(err as Error).message}`);
+    return undefined;
+  } finally {
+    await sql.end({ timeout: 5 }).catch(() => {});
+  }
+}
+
+type LiveService = {
+  observation: ServiceObservation;
+  serving: string[];
+  latestReady?: string;
+};
+
+/**
+ * Every Cloud Run service in this region whose SERVING revision is attached to our Cloud SQL
+ * instance. Enumerated from gcloud rather than from a list in this repo on purpose: `backstage`
+ * has no deploy definition here, and the term that gets forgotten is the one nobody wrote down.
+ */
+function readLiveServices(): LiveService[] {
+  const listed = gcloudJson(["run", "services", "list", "--region", REGION, "--project", PROJECT]);
+  const services = Array.isArray(listed) ? listed : [];
+  const live: LiveService[] = [];
+
+  for (const svc of services) {
+    const name = (svc as { metadata?: { name?: string } })?.metadata?.name;
+    if (!name) continue;
+    const { serving, latestReady } = parseServingRevisions(svc);
+    const revisionName = serving[0] ?? latestReady;
+    if (!revisionName) continue;
+
+    const revision = parseRevisionScaling(
+      gcloudJson(["run", "revisions", "describe", revisionName, "--region", REGION, "--project", PROJECT]),
+    );
+    if (!revision.cloudSqlInstances.includes(INSTANCE_CONN)) continue;
+
+    if (revision.maxInstances === undefined) {
+      // Not a value anyone chose — Cloud Run's own default. On a shared database that deserves
+      // to be counted at its real ceiling and said out loud.
+      console.log(
+        `  ⚠ ${name} sets no maxScale — counting Cloud Run's default of ${CLOUD_RUN_DEFAULT_MAX_INSTANCES}`,
+      );
+    }
+
+    live.push({
+      serving,
+      latestReady,
+      observation: {
+        service: name,
+        revision: revisionName,
+        maxInstances: revision.maxInstances ?? CLOUD_RUN_DEFAULT_MAX_INSTANCES,
+        minInstances: revision.minInstances,
+        dbPoolMax: revision.dbPoolMax,
+        // Only our own service's pool default is knowable from this codebase; anything else is
+        // counted at the postgres-js default, because over-counting fails safe.
+        ownCode: name === SERVICE,
+      },
+    });
+  }
+  return live;
+}
+
+function requireEnv(): void {
+  if (!PROJECT) readFailures.push("GCP_PROJECT is not set");
+  if (!INSTANCE_CONN) readFailures.push("CLOUD_SQL_INSTANCE_CONN is not set");
+}
+
+async function main(): Promise<void> {
+  console.log("");
+  console.log(
+    `── spec-518 t-7: connection-budget guard (mode=${mode}, ENV=${ENV}, service=${SERVICE}) ──`,
+  );
+
+  requireEnv();
+  const usable = await readCeiling();
+
+  let live: LiveService[] = [];
+  if (readFailures.length === 0) {
+    try {
+      live = readLiveServices();
+    } catch (err) {
+      readFailures.push(`could not read live Cloud Run configuration: ${(err as Error).message}`);
+    }
+  }
+
+  const self = live.find((s) => s.observation.service === SERVICE);
+
+  // ── The comparison (applied mode only — before the cutover there is nothing new to compare) ──
+  let comparison;
+  let revision;
+  if (mode === "applied") {
+    if (!self) {
+      readFailures.push(`${SERVICE} was not found among the services attached to ${INSTANCE_CONN}`);
+    } else {
+      const applied: Partial<Record<ScalingKey, string | undefined>> = {
+        MAX_INSTANCES: String(self.observation.maxInstances),
+        MIN_INSTANCES: String(self.observation.minInstances ?? 0),
+        DB_POOL_MAX:
+          self.observation.dbPoolMax === undefined ? undefined : String(self.observation.dbPoolMax),
+      };
+      comparison = comparePlan({ env: ENV, intended, applied });
+      revision = self.latestReady
+        ? { serving: self.serving, expectedLatestReady: self.latestReady }
+        : undefined;
+
+      console.log("  applied on the serving revision:");
+      console.log(`    revision: ${self.observation.revision} (traffic: ${self.serving.join(", ") || "none"})`);
+      for (const key of SCALING_KEYS) {
+        console.log(`    ${key}: config ${intended[key] ?? "(unset)"} → applied ${applied[key] ?? "(absent)"}`);
+      }
+    }
+  } else if (isProd(ENV)) {
+    // Pre-cutover, prod's only checkable claim is that it expressed every value explicitly.
+    comparison = comparePlan({
+      env: ENV,
+      intended,
+      // Nothing to compare against yet, so mirror the intent: this pass exists to catch
+      // ABSENCE, and comparing intent to itself keeps that the only thing it can report.
+      applied: intended,
+    });
+  }
+
+  // ── The budget ──
+  let budget;
+  if (usable !== undefined && live.length > 0) {
+    const services = live.map((s) => {
+      if (mode === "plan" && s.observation.service === SERVICE) {
+        // This deploy is about to change our own numbers — budget the ones it will apply.
+        const wantMax = Number(intended.MAX_INSTANCES);
+        const wantPool = Number(intended.DB_POOL_MAX);
+        return {
+          ...s.observation,
+          maxInstances: Number.isFinite(wantMax) ? wantMax : s.observation.maxInstances,
+          dbPoolMax: Number.isFinite(wantPool) ? wantPool : undefined,
+        };
+      }
+      return s.observation;
+    });
+    budget = computeBudget({ services, usable });
+    console.log(`  budget (${mode === "plan" ? "values about to be applied" : "values in force"}):`);
+    for (const line of formatBudgetReport(budget)) console.log(line);
+  }
+
+  const outcome = decideOutcome({ env: ENV, budget, comparison, revision });
+
+  // A read failure is "nobody checked", which is the condition this guard exists to end.
+  const failures = [...outcome.failures];
+  const warnings = [...outcome.warnings];
+  for (const f of readFailures) {
+    if (isProd(ENV)) failures.push(`guard could not verify: ${f}`);
+    else warnings.push(`guard could not verify: ${f} — non-fatal on ${ENV}`);
+  }
+
+  for (const w of warnings) console.log(`  ⚠ ${w}`);
+  for (const f of failures) console.error(`  ✗ ${f}`);
+
+  if (failures.length > 0) {
+    console.error("");
+    console.error(
+      `  ABORTING (${mode}): the applied configuration does not match the plan, or does not fit the ` +
+        `connection ceiling. Roll back by redeploying the previous SHA (workflow_dispatch) if this ` +
+        `ran post-cutover.`,
+    );
+    process.exit(1);
+  }
+
+  // The summary must never claim more than the findings support. A line reading "fits the
+  // ceiling" above a warning saying it does not is the defect class this whole Spec documents.
+  if (warnings.length > 0) {
+    console.log(
+      `  ✓ nothing fatal for ENV=${ENV}, but ${warnings.length} warning${warnings.length > 1 ? "s" : ""} above ` +
+        `— this configuration would ABORT on prod`,
+    );
+  } else {
+    console.log(
+      `  ✓ ${mode === "plan" ? "plan is explicit and fits the ceiling" : "applied configuration matches the plan and fits the ceiling"}`,
+    );
+  }
+  console.log("");
+}
+
+main().catch((err) => {
+  // Never a silent pass: an unexpected throw is itself an unverified deploy. On prod that is
+  // fatal. Off prod it must not block the deploy (dec-5's posture), but it must still be
+  // impossible to mistake for a clean run in the log — int is where the guard is exercised most,
+  // so a guard that crashed on every int deploy while printing nothing loud would be invisible
+  // exactly where it is watched.
+  console.error(`  ✗ scaling-budget guard CRASHED — nothing was verified: ${(err as Error).stack ?? err}`);
+  if (isProd(ENV)) process.exit(1);
+  console.error(
+    `  ⚠ continuing anyway because ENV=${ENV} is not prod (spec-518 dec-5) — but this deploy went ` +
+      `out UNVERIFIED, which is the condition t-7 exists to end. Fix the crash before the next prod release.`,
+  );
+  process.exit(0);
+});

--- a/packages/server/src/__regression__/spec-518-applied-scaling.regression.test.ts
+++ b/packages/server/src/__regression__/spec-518-applied-scaling.regression.test.ts
@@ -1,0 +1,338 @@
+// spec-518 t-7 — the guard every existing check cannot be.
+//
+// The sibling file spec-518-scaling-budget.regression.test.ts asserts the SOURCE:
+// deploy.sh's flag syntax, deploy-config.sh's exports, the intended arithmetic. Every one
+// of those assertions was GREEN throughout the 2026-08-11 outage, because none of them can
+// observe that CI never ran the exporting branch. They read intent; the defect lives in the
+// outcome.
+//
+// So these tests cover the logic of a guard that reads back what a deploy APPLIED, and they
+// exist as a separate file to keep that distinction legible rather than blurring it into the
+// source-reading suite (t-7's own rationale for not widening t-3).
+//
+// Three claims are under test:
+//   ac-16  the budget is checked against values in force, with every term counted
+//   ac-19  a budget violation aborts on prod and warns on int (dec-5)
+//   ac-20  an applied-vs-intended mismatch is fatal everywhere; an absent prod value too
+//
+// The live half of the guard (ac-14: it really reads the running revision) is NOT provable
+// here. It is proved by the deploy running it on int, then prod — see t-7.
+
+import { describe, it, expect } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import {
+  ADMIN_SESSION_RESERVE,
+  CUTOVER_REVISION_FACTOR,
+  FOREIGN_SERVICE_DEFAULT_POOL,
+  comparePlan,
+  computeBudget,
+  decideOutcome,
+  parseRevisionScaling,
+  parseServingRevisions,
+  serviceTerm,
+  usableConnections,
+} from "../deploy/scaling-budget.js";
+import { DEFAULT_POOL_MAX } from "../db/pool-size.js";
+
+const SPEC = "mindset-prod/memex-building-itself/specs/spec-518/acs";
+const AC_APPLIED_BUDGET = `${SPEC}/ac-16`;
+const AC_PER_ENV_POSTURE = `${SPEC}/ac-19`;
+const AC_MISMATCH_FATAL = `${SPEC}/ac-20`;
+
+// ── The two environments, measured 2026-08-14 from pg_settings through a proxy ──
+// NOT from `gcloud sql describe`'s recorded flags: dec-2's whole thesis is that the value
+// recorded is not the value in force.
+const PROD_CEILING = { maxConnections: 200, superuserReserved: 3, reserved: 0 }; // → 197
+const INT_CEILING = { maxConnections: 25, superuserReserved: 3, reserved: 0 }; //   →  22
+
+// ── What prod actually serves, read back from the running revisions 2026-08-14 ──
+const PROD_APPLIED = [
+  { service: "memex-api", revision: "memex-api-00130-hgj", maxInstances: 8, dbPoolMax: 4, ownCode: true },
+  // backstage shares memex-prod and carries NO pool cap — issue-2's uncounted consumer.
+  { service: "backstage", revision: "backstage-00050-9kn", maxInstances: 3, ownCode: false },
+];
+
+// int is deliberately unset (t-4), so it runs deploy.sh's 0/3 defaults and the code's pool.
+const INT_APPLIED = [
+  { service: "memex-api", revision: "memex-api-00623-zpb", maxInstances: 3, ownCode: true },
+];
+
+describe("spec-518 ac-16: the budget counts values in force, and every term", () => {
+  it("usable connections subtract BOTH reservations, not just the superuser one", () => {
+    tagAc(AC_APPLIED_BUDGET);
+    expect(usableConnections(PROD_CEILING)).toBe(197);
+    expect(usableConnections(INT_CEILING)).toBe(22);
+    // PG17 has reserved_connections too; it is 0 today and must still be subtracted, or the
+    // guard's ceiling silently drifts the day someone sets it.
+    expect(usableConnections({ maxConnections: 200, superuserReserved: 3, reserved: 10 })).toBe(187);
+  });
+
+  it("a per-instance term is pool + 1, and the +1 is the spec-156 relay LISTEN", () => {
+    tagAc(AC_APPLIED_BUDGET);
+    const term = serviceTerm({ service: "memex-api", maxInstances: 8, dbPoolMax: 4, ownCode: true });
+    expect(term.perInstance).toBe(5);
+    expect(term.steady).toBe(40);
+    // A deploy runs the draining and starting revisions together, and a draining instance
+    // holds its pool while serving nothing — so the peak is up to 2 × maxInstances.
+    expect(term.peak).toBe(80);
+    expect(CUTOVER_REVISION_FACTOR).toBe(2);
+  });
+
+  it("a service with NO pool cap contributes its default, never zero", () => {
+    tagAc(AC_APPLIED_BUDGET);
+    // This is the missing-term failure mode itself: an unconfigured consumer currently
+    // contributes nothing to the arithmetic while consuming connections in reality.
+    const foreign = serviceTerm({ service: "backstage", maxInstances: 3, ownCode: false });
+    expect(foreign.poolMax).toBe(FOREIGN_SERVICE_DEFAULT_POOL);
+    expect(foreign.poolSource).toBe("foreign-default");
+    expect(foreign.steady).toBe(33);
+
+    // For OUR OWN image the default is knowable, so the guard reads it from the code rather
+    // than restating it — this is why the number cannot drift from what the pool really does.
+    const ours = serviceTerm({ service: "memex-api", maxInstances: 3, ownCode: true });
+    expect(ours.poolMax).toBe(DEFAULT_POOL_MAX);
+    expect(ours.poolSource).toBe("our-code-default");
+    // Over-counting a foreign service fails safe; under-counting is the defect.
+    expect(FOREIGN_SERVICE_DEFAULT_POOL).toBeGreaterThan(DEFAULT_POOL_MAX);
+  });
+
+  it("prod's applied configuration is within budget today, with the margin stated", () => {
+    tagAc(AC_APPLIED_BUDGET);
+    const budget = computeBudget({ services: PROD_APPLIED, usable: usableConnections(PROD_CEILING) });
+    expect(budget.steadyTotal).toBe(40 + 33 + ADMIN_SESSION_RESERVE);
+    expect(budget.peakTotal).toBe(80 + 66 + ADMIN_SESSION_RESERVE);
+    expect(budget.withinBudget).toBe(true);
+    expect(budget.headroom).toBe(197 - (80 + 66 + ADMIN_SESSION_RESERVE));
+  });
+
+  it("the budget ENUMERATES what it counted, so a third consumer cannot be silently omitted", () => {
+    tagAc(AC_APPLIED_BUDGET);
+    const budget = computeBudget({ services: PROD_APPLIED, usable: 197 });
+    expect(budget.terms.map((t) => t.service)).toEqual(["memex-api", "backstage"]);
+    // The defect here was never a wrong number — it was a missing term. A check that names
+    // its terms is the only kind that notices a new one.
+    const withAThird = computeBudget({
+      services: [...PROD_APPLIED, { service: "some-new-worker", maxInstances: 10, ownCode: false }],
+      usable: 197,
+    });
+    expect(withAThird.terms).toHaveLength(3);
+    expect(withAThird.peakTotal).toBeGreaterThan(budget.peakTotal);
+  });
+
+  it("restoring the DB_POOL_MAX=10 that deploy.env.example advertises FAILS the budget", () => {
+    tagAc(AC_APPLIED_BUDGET);
+    // ac-16 names this case: 8 × 11 = 88 is the 2026-08-03 exhaustion, and it must fail
+    // against the ceiling of the day — against 47 outright, and against today's 197 once
+    // the cutover term and backstage are counted.
+    const poolTen = [{ ...PROD_APPLIED[0], dbPoolMax: 10 }, PROD_APPLIED[1]];
+    expect(serviceTerm(poolTen[0]).steady).toBe(88);
+    expect(computeBudget({ services: poolTen, usable: 47 }).withinBudget).toBe(false);
+    expect(computeBudget({ services: poolTen, usable: 197 }).withinBudget).toBe(false);
+  });
+});
+
+describe("spec-518 ac-19: prod aborts, int warns — same arithmetic, different exit (dec-5)", () => {
+  // int violates the corrected invariant TODAY: 2 × 3 × (5+1) = 36 against 22 usable. It
+  // survives because int's load never extends the pools; the bound is real arithmetic about
+  // a peak int does not run. Measured, not assumed — int's max_connections is 25.
+  const intBudget = computeBudget({ services: INT_APPLIED, usable: usableConnections(INT_CEILING) });
+
+  it("int's applied configuration really does violate the corrected invariant", () => {
+    tagAc(AC_PER_ENV_POSTURE);
+    expect(intBudget.steadyTotal).toBe(18 + ADMIN_SESSION_RESERVE);
+    expect(intBudget.peakTotal).toBe(36 + ADMIN_SESSION_RESERVE);
+    expect(intBudget.withinBudget).toBe(false);
+  });
+
+  it("on int that violation warns and does NOT abort", () => {
+    tagAc(AC_PER_ENV_POSTURE);
+    const outcome = decideOutcome({ env: "int", budget: intBudget });
+    expect(outcome.fatal).toBe(false);
+    expect(outcome.warnings.join(" ")).toMatch(/budget/i);
+    // Silence would be the other failure: the truth is stated either way.
+    expect(outcome.warnings).not.toHaveLength(0);
+  });
+
+  it("the SAME violation on prod aborts", () => {
+    tagAc(AC_PER_ENV_POSTURE);
+    const outcome = decideOutcome({ env: "prod", budget: intBudget });
+    expect(outcome.fatal).toBe(true);
+    expect(outcome.failures.join(" ")).toMatch(/budget/i);
+  });
+
+  it("prod's real configuration is not fatal — the guard does not block a healthy deploy", () => {
+    tagAc(AC_PER_ENV_POSTURE);
+    const budget = computeBudget({ services: PROD_APPLIED, usable: 197 });
+    const outcome = decideOutcome({ env: "prod", budget });
+    expect(outcome.fatal).toBe(false);
+    expect(outcome.failures).toHaveLength(0);
+    expect(outcome.warnings).toHaveLength(0);
+  });
+});
+
+describe("spec-518 ac-20: a mismatch is fatal in every environment", () => {
+  const INTENDED_PROD = { MAX_INSTANCES: "8", MIN_INSTANCES: "1", DB_POOL_MAX: "4" };
+
+  it("the 2026-08-11 red case: sourced 8, applied 3 — fatal", () => {
+    tagAc(AC_MISMATCH_FATAL);
+    const comparison = comparePlan({
+      env: "prod",
+      intended: INTENDED_PROD,
+      applied: { MAX_INSTANCES: "3", MIN_INSTANCES: "1", DB_POOL_MAX: "4" },
+    });
+    expect(comparison.mismatches).toEqual([{ key: "MAX_INSTANCES", intended: "8", applied: "3" }]);
+    expect(decideOutcome({ env: "prod", comparison }).fatal).toBe(true);
+    // No per-env excuse: a value that is set and does not arrive is a plumbing defect, and
+    // int is exactly where it must be caught, because int is deployed first.
+    expect(decideOutcome({ env: "int", comparison }).fatal).toBe(true);
+  });
+
+  it("a value declared in the secret but ABSENT from the running revision is a mismatch", () => {
+    tagAc(AC_MISMATCH_FATAL);
+    // This was prod's real state until rev 00128: DB_POOL_MAX=4 declared, the serving
+    // revision still carrying what it started with. Declared and in force are two facts.
+    const comparison = comparePlan({
+      env: "prod",
+      intended: INTENDED_PROD,
+      applied: { MAX_INSTANCES: "8", MIN_INSTANCES: "1", DB_POOL_MAX: undefined },
+    });
+    expect(comparison.mismatches).toEqual([
+      { key: "DB_POOL_MAX", intended: "4", applied: undefined },
+    ]);
+    expect(decideOutcome({ env: "prod", comparison }).fatal).toBe(true);
+  });
+
+  it("matching values compare clean, numerically not textually", () => {
+    tagAc(AC_MISMATCH_FATAL);
+    const comparison = comparePlan({
+      env: "prod",
+      intended: INTENDED_PROD,
+      applied: { MAX_INSTANCES: "08", MIN_INSTANCES: "1", DB_POOL_MAX: "4" },
+    });
+    expect(comparison.mismatches).toHaveLength(0);
+    expect(decideOutcome({ env: "prod", comparison }).fatal).toBe(false);
+  });
+
+  it("an ABSENT scaling value is fatal on prod — silence must not become a live default", () => {
+    tagAc(AC_MISMATCH_FATAL);
+    // `${MAX_INSTANCES:-3}` turns a missing value into a live configuration change. That is
+    // the trap, and it is the default rather than the arithmetic.
+    const comparison = comparePlan({
+      env: "prod",
+      intended: { MAX_INSTANCES: "8", MIN_INSTANCES: undefined, DB_POOL_MAX: "4" },
+      applied: { MAX_INSTANCES: "8", MIN_INSTANCES: "0", DB_POOL_MAX: "4" },
+    });
+    expect(comparison.missing).toEqual(["MIN_INSTANCES"]);
+    const outcome = decideOutcome({ env: "prod", comparison });
+    expect(outcome.fatal).toBe(true);
+    expect(outcome.failures.join(" ")).toMatch(/MIN_INSTANCES/);
+  });
+
+  it("the same absence on int is NOT a mismatch — unset is int's chosen posture (t-4)", () => {
+    tagAc(AC_MISMATCH_FATAL);
+    const comparison = comparePlan({
+      env: "int",
+      intended: { MAX_INSTANCES: undefined, MIN_INSTANCES: undefined, DB_POOL_MAX: undefined },
+      applied: { MAX_INSTANCES: "3", MIN_INSTANCES: "0", DB_POOL_MAX: undefined },
+    });
+    expect(comparison.mismatches).toHaveLength(0);
+    expect(comparison.missing).toHaveLength(0);
+    expect(comparison.ignored).toEqual(["MAX_INSTANCES", "MIN_INSTANCES", "DB_POOL_MAX"]);
+    expect(decideOutcome({ env: "int", comparison }).fatal).toBe(false);
+  });
+
+  it("traffic left on an older revision is itself the applied-vs-intended gap", () => {
+    tagAc(AC_MISMATCH_FATAL);
+    // A rollout that reported success while traffic stayed on the previous revision would
+    // pass every value comparison against a revision nobody is being served.
+    const split = decideOutcome({
+      env: "int",
+      revision: { serving: ["memex-api-00622-abc"], expectedLatestReady: "memex-api-00623-zpb" },
+    });
+    expect(split.fatal).toBe(true);
+    expect(split.failures.join(" ")).toMatch(/traffic/i);
+
+    const clean = decideOutcome({
+      env: "int",
+      revision: { serving: ["memex-api-00623-zpb"], expectedLatestReady: "memex-api-00623-zpb" },
+    });
+    expect(clean.fatal).toBe(false);
+  });
+});
+
+describe("spec-518 ac-16: the readers parse the REVISION, because the template is intent", () => {
+  // `gcloud run services describe` returns spec.template — what the next revision WOULD get.
+  // Reading it would ship a second source-reader with extra steps. The applied truth is on
+  // the revision that traffic is on. These fixtures are the real shapes, trimmed.
+  const REVISION_JSON = {
+    metadata: {
+      name: "memex-api-00130-hgj",
+      annotations: {
+        "autoscaling.knative.dev/maxScale": "8",
+        "autoscaling.knative.dev/minScale": "1",
+        "run.googleapis.com/cloudsql-instances": "memex-ai-prod:us-east4:memex-prod",
+      },
+    },
+    spec: {
+      containers: [{ env: [{ name: "NODE_ENV", value: "production" }, { name: "DB_POOL_MAX", value: "4" }] }],
+    },
+  };
+
+  it("reads maxScale / minScale / DB_POOL_MAX off the revision", () => {
+    tagAc(AC_APPLIED_BUDGET);
+    const parsed = parseRevisionScaling(REVISION_JSON);
+    expect(parsed).toMatchObject({
+      revision: "memex-api-00130-hgj",
+      maxInstances: 8,
+      minInstances: 1,
+      dbPoolMax: 4,
+      cloudSqlInstances: ["memex-ai-prod:us-east4:memex-prod"],
+    });
+  });
+
+  it("an absent minScale annotation reads as 0, and an absent DB_POOL_MAX as undefined", () => {
+    tagAc(AC_APPLIED_BUDGET);
+    // Cloud Run omits the annotation entirely at minScale 0 — that is int's live shape. The
+    // two absences mean different things and must not collapse: 0 is a value, undefined is
+    // "the code default applies", which is what the budget has to substitute.
+    const parsed = parseRevisionScaling({
+      metadata: {
+        name: "memex-api-00623-zpb",
+        annotations: {
+          "autoscaling.knative.dev/maxScale": "3",
+          "run.googleapis.com/cloudsql-instances": "memex-ai-int:us-east4:memex-mvp",
+        },
+      },
+      spec: { containers: [{ env: [{ name: "NODE_ENV", value: "production" }] }] },
+    });
+    expect(parsed.minInstances).toBe(0);
+    expect(parsed.dbPoolMax).toBeUndefined();
+  });
+
+  it("resolves which revision traffic is actually on", () => {
+    tagAc(AC_APPLIED_BUDGET);
+    const parsed = parseServingRevisions({
+      status: {
+        latestReadyRevisionName: "memex-api-00130-hgj",
+        traffic: [{ latestRevision: true, percent: 100, revisionName: "memex-api-00130-hgj" }],
+      },
+    });
+    expect(parsed).toEqual({ serving: ["memex-api-00130-hgj"], latestReady: "memex-api-00130-hgj" });
+  });
+
+  it("a split rollout reports EVERY revision carrying traffic", () => {
+    tagAc(AC_APPLIED_BUDGET);
+    const parsed = parseServingRevisions({
+      status: {
+        latestReadyRevisionName: "memex-api-00131-xyz",
+        traffic: [
+          { percent: 50, revisionName: "memex-api-00130-hgj" },
+          { percent: 50, revisionName: "memex-api-00131-xyz" },
+          { percent: 0, revisionName: "memex-api-00129-old" },
+        ],
+      },
+    });
+    // A 0% entry is not serving; both 50% entries are, and during a split BOTH hold pools.
+    expect(parsed.serving).toEqual(["memex-api-00130-hgj", "memex-api-00131-xyz"]);
+  });
+});

--- a/packages/server/src/__regression__/spec-518-scaling-budget.regression.test.ts
+++ b/packages/server/src/__regression__/spec-518-scaling-budget.regression.test.ts
@@ -20,9 +20,20 @@ const connectionBudget = (maxInstances: number, dbPoolMax: number) =>
   maxInstances * (dbPoolMax + 1);
 
 // Intended per-env scaling — the values carried in each memex-<env>-deploy-env secret.
-// Ceiling = max_connections − superuser_reserved_connections (prod: 50 − 3 = 47).
+//
+// The ceiling here is the one the 2026-08-03 FATAL and the 2026-08-11 outage were measured
+// against: max_connections 50 − superuser_reserved 3 = 47. **It is history, not today's number** —
+// dec-2 raised max_connections to 200 on 2026-08-12, so prod now has 197 usable. The historical
+// figure is kept deliberately, because the assertions below are about the incident configurations
+// and would stop meaning anything against 197.
+//
+// Today's ceiling is not a constant anywhere: spec-518 t-7's guard READS it from Postgres at
+// deploy time (`src/deploy/scaling-budget.ts`, exercised by
+// spec-518-applied-scaling.regression.test.ts), precisely because a recorded ceiling outlived its
+// machine here once already.
+const INCIDENT_CEILING = 47;
 const ENV_PLAN = {
-  prod: { maxInstances: 8, dbPoolMax: 4, ceiling: 47 },
+  prod: { maxInstances: 8, dbPoolMax: 4, ceiling: INCIDENT_CEILING },
 } as const;
 
 describe("spec-518 ac-8: Cloud Run scaling flags are env-keyed with safe defaults", () => {

--- a/packages/server/src/deploy/scaling-budget.ts
+++ b/packages/server/src/deploy/scaling-budget.ts
@@ -1,0 +1,449 @@
+// spec-518 t-7 — the connection budget, computed over the values a deploy APPLIED.
+//
+// Every other check on this Spec reads the SOURCE: deploy.sh's flag syntax, deploy-config.sh's
+// exports, the intended arithmetic in a regression test. All of them were green throughout the
+// 2026-08-03 and 2026-08-11 incidents, because none of them can observe what actually reached
+// the running revision. This module is the arithmetic and the comparison for a guard that reads
+// the outcome instead — `scripts/verify-scaling-budget.ts` supplies the live values.
+//
+// It is deliberately PURE: no gcloud, no database, no process.exit. That is what makes the
+// guard's own logic unit-testable (spec-518 ac-16 / ac-19 / ac-20), and it is why the guard is
+// not written in bash — issue-5 is what a shell guard invites.
+//
+// ── The invariant, and why the obvious form of it is unsound ──
+//
+// deploy.sh has carried this since spec-518's config path landed:
+//
+//     MAX_INSTANCES × (DB_POOL_MAX + 1 relay LISTEN)  <  usable connections
+//
+// It is not wrong; it is a sum with terms missing (spec-332 dec-3 reached the same conclusion on
+// 2026-06-23). Four investigations on this Spec each contributed one:
+//
+//   issue-4  a cutover runs the draining AND starting revision together, and a draining instance
+//            holds its pool while serving nothing → the peak is 2 × maxInstances
+//   issue-2  `backstage` shares the same Cloud SQL instance and appears in no arithmetic
+//   issue-3  the invariant is a COMMENT — nothing asserts it, nothing aborts
+//   —        admin / migration sessions, including the deploy's own cloud-sql-proxy
+//
+// So what this module computes is:
+//
+//     Σ over every service on the instance  of  2 × maxInstances × (poolMax + 1)
+//       + an admin reserve                                        ≤  usable
+//
+// The peak matters more than the steady state for one uncomfortable reason: **a deploy is the
+// one moment the budget must hold twice over, and it is also the only moment anyone changes the
+// configuration.** A guard that checks steady state passes on exactly the configuration that
+// failed on 2026-08-11.
+
+import { DEFAULT_POOL_MAX } from "../db/pool-size.js";
+
+/**
+ * The spec-156 bus-relay `LISTEN` connection: one persistent connection per Cloud Run instance,
+ * opened with `{ max: 1 }` and no idle timeout, deliberately — a LISTEN socket must stay open to
+ * receive NOTIFYs. It sits OUTSIDE the pool, which is why the per-instance footprint is
+ * `poolMax + 1` and not `poolMax` (db/connection.ts).
+ */
+export const RELAY_LISTEN_PER_INSTANCE = 1;
+
+/**
+ * During a revision cutover BOTH revisions hold instances: the new one serving, the old one
+ * draining while still holding its pool. Request count does not bound instance count — on
+ * 2026-08-11 the draining revision served 3 requests and the incoming one 997, and the
+ * connections were exhausted anyway.
+ */
+export const CUTOVER_REVISION_FACTOR = 2;
+
+/**
+ * What to assume for a service that sets no explicit pool cap and is NOT our image.
+ *
+ * postgres-js defaults to `max: 10`. Our own services default to {@link DEFAULT_POOL_MAX} (5),
+ * read from the code rather than restated here so the guard's number cannot drift from what the
+ * pool really does. For anything else, assume the library default: over-counting a foreign
+ * service costs headroom, under-counting it is the defect this guard exists to catch — an
+ * unconfigured consumer contributing ZERO to the arithmetic while consuming connections.
+ */
+export const FOREIGN_SERVICE_DEFAULT_POOL = 10;
+
+/**
+ * Slots kept for the consumers no service annotation describes: the deploy's own
+ * cloud-sql-proxy, hand-run migrations, `cloudsqladmin`, and an operator's psql session. Prod
+ * measured 4 `cloudsqladmin` + 1 psql at rest on 2026-08-11, so 5 is the observed figure rather
+ * than a guess. It is a reserve, not a cap — nothing enforces it on those sessions.
+ */
+export const ADMIN_SESSION_RESERVE = 5;
+
+/**
+ * Cloud Run's own default when a service carries no `maxScale` annotation. Not a value anyone
+ * chose — which is exactly why a service on a shared database that never set one deserves to be
+ * counted at 100 and shouted about.
+ */
+export const CLOUD_RUN_DEFAULT_MAX_INSTANCES = 100;
+
+/** The scaling values dec-3 pins per environment, and therefore the ones a deploy must apply. */
+export const SCALING_KEYS = ["MAX_INSTANCES", "MIN_INSTANCES", "DB_POOL_MAX"] as const;
+export type ScalingKey = (typeof SCALING_KEYS)[number];
+
+/** `prod` is the only environment where a budget violation stops a deploy (dec-5). */
+export function isProd(env: string): boolean {
+  return env === "prod";
+}
+
+// ── Ceiling ───────────────────────────────────────────────────────────────────
+
+export type CeilingSettings = {
+  maxConnections: number;
+  /** `superuser_reserved_connections` — 3 on both of ours. */
+  superuserReserved?: number;
+  /** `reserved_connections` — PG16+, 0 today. Subtracted anyway, or the ceiling drifts the day it isn't. */
+  reserved?: number;
+};
+
+/**
+ * Connections actually available to the runtime role.
+ *
+ * Read these from Postgres (`pg_settings`), never from `gcloud sql describe`'s recorded flags:
+ * dec-2's thesis is that the value recorded is not the value in force — prod ran a week on a
+ * `max_connections` sized for a machine that no longer existed.
+ */
+export function usableConnections({
+  maxConnections,
+  superuserReserved = 0,
+  reserved = 0,
+}: CeilingSettings): number {
+  return Math.max(0, maxConnections - superuserReserved - reserved);
+}
+
+// ── Per-service demand ────────────────────────────────────────────────────────
+
+export type ServiceObservation = {
+  service: string;
+  revision?: string;
+  maxInstances: number;
+  minInstances?: number;
+  /** `undefined` = the running revision carries no `DB_POOL_MAX`, so a default applies. */
+  dbPoolMax?: number;
+  /** `true` when this service runs OUR image, whose pool default is knowable from the code. */
+  ownCode?: boolean;
+};
+
+export type PoolSource = "applied" | "our-code-default" | "foreign-default";
+
+export type ServiceTerm = {
+  service: string;
+  revision?: string;
+  maxInstances: number;
+  poolMax: number;
+  poolSource: PoolSource;
+  /** pool + the relay LISTEN. */
+  perInstance: number;
+  /** One revision at full scale. */
+  steady: number;
+  /** Both revisions at full scale — what a cutover can actually demand. */
+  peak: number;
+};
+
+function resolvePool(obs: ServiceObservation): { poolMax: number; poolSource: PoolSource } {
+  const applied = obs.dbPoolMax;
+  if (applied !== undefined && Number.isFinite(applied) && applied >= 1) {
+    return { poolMax: Math.floor(applied), poolSource: "applied" };
+  }
+  return obs.ownCode
+    ? { poolMax: DEFAULT_POOL_MAX, poolSource: "our-code-default" }
+    : { poolMax: FOREIGN_SERVICE_DEFAULT_POOL, poolSource: "foreign-default" };
+}
+
+export function serviceTerm(obs: ServiceObservation): ServiceTerm {
+  const { poolMax, poolSource } = resolvePool(obs);
+  const perInstance = poolMax + RELAY_LISTEN_PER_INSTANCE;
+  const steady = obs.maxInstances * perInstance;
+  return {
+    service: obs.service,
+    revision: obs.revision,
+    maxInstances: obs.maxInstances,
+    poolMax,
+    poolSource,
+    perInstance,
+    steady,
+    peak: steady * CUTOVER_REVISION_FACTOR,
+  };
+}
+
+// ── The budget ────────────────────────────────────────────────────────────────
+
+export type Budget = {
+  /** One entry per service counted — the enumeration IS the point (see below). */
+  terms: ServiceTerm[];
+  adminReserve: number;
+  steadyTotal: number;
+  peakTotal: number;
+  usable: number;
+  /** Slots left at peak. Negative when the budget is blown. */
+  headroom: number;
+  withinBudget: boolean;
+};
+
+/**
+ * Sum the demand of every service attached to the instance against the usable ceiling.
+ *
+ * The returned `terms` are not decoration. The defect here was never a wrong number — it was a
+ * missing term, and a check that enumerates what it counted is the only kind that notices when a
+ * new consumer appears.
+ */
+export function computeBudget({
+  services,
+  usable,
+  adminReserve = ADMIN_SESSION_RESERVE,
+}: {
+  services: ServiceObservation[];
+  usable: number;
+  adminReserve?: number;
+}): Budget {
+  const terms = services.map(serviceTerm);
+  const steadyTotal = terms.reduce((sum, t) => sum + t.steady, 0) + adminReserve;
+  const peakTotal = terms.reduce((sum, t) => sum + t.peak, 0) + adminReserve;
+  return {
+    terms,
+    adminReserve,
+    steadyTotal,
+    peakTotal,
+    usable,
+    headroom: usable - peakTotal,
+    withinBudget: peakTotal <= usable,
+  };
+}
+
+// ── Applied vs intended ───────────────────────────────────────────────────────
+
+export type Mismatch = { key: ScalingKey; intended: string; applied: string | undefined };
+
+export type PlanComparison = {
+  /** Set in config, different (or absent) on the running revision. Fatal in every environment. */
+  mismatches: Mismatch[];
+  /** Absent from config where config must be explicit — prod only. */
+  missing: ScalingKey[];
+  /** Absent from config where absence is the chosen posture (int, t-4). Not a defect. */
+  ignored: ScalingKey[];
+};
+
+function sameValue(intended: string, applied: string | undefined): boolean {
+  if (applied === undefined) return false;
+  const a = Number(intended);
+  const b = Number(applied);
+  if (Number.isFinite(a) && Number.isFinite(b)) return a === b;
+  return intended === applied;
+}
+
+/**
+ * Compare what config asked for against what the running revision carries.
+ *
+ * Two asymmetries, both deliberate:
+ *
+ * - **A set value that did not arrive is always a defect.** `DB_POOL_MAX=4` sat declared in the
+ *   canonical secret while the serving revision carried something else — declared and in force
+ *   are two different facts, and that gap is this Spec's whole lesson.
+ * - **An absent value means different things per environment.** On prod, silence must not become
+ *   a live configuration change: `${MAX_INSTANCES:-3}` turning a missing variable into an applied
+ *   `3` is the trap, and it is the default rather than the arithmetic. On int, unset IS the chosen
+ *   posture (t-4), so absence is recorded and not judged — the applied value still feeds the
+ *   budget, it just isn't compared to an intent nobody expressed.
+ */
+export function comparePlan({
+  env,
+  intended,
+  applied,
+}: {
+  env: string;
+  intended: Partial<Record<ScalingKey, string | undefined>>;
+  applied: Partial<Record<ScalingKey, string | undefined>>;
+}): PlanComparison {
+  const mustBeExplicit = isProd(env);
+  const mismatches: Mismatch[] = [];
+  const missing: ScalingKey[] = [];
+  const ignored: ScalingKey[] = [];
+
+  for (const key of SCALING_KEYS) {
+    const want = intended[key];
+    if (want === undefined || want === "") {
+      (mustBeExplicit ? missing : ignored).push(key);
+      continue;
+    }
+    const got = applied[key];
+    if (!sameValue(want, got)) mismatches.push({ key, intended: want, applied: got });
+  }
+
+  return { mismatches, missing, ignored };
+}
+
+// ── The verdict ───────────────────────────────────────────────────────────────
+
+export type RevisionTraffic = {
+  /** Every revision carrying >0% of traffic. */
+  serving: string[];
+  /** The revision this deploy just created and expects to be serving alone. */
+  expectedLatestReady: string;
+};
+
+export type Outcome = {
+  fatal: boolean;
+  failures: string[];
+  warnings: string[];
+};
+
+/**
+ * Turn observations into an exit code, per dec-5:
+ *
+ * | verdict                        | prod  | anything else |
+ * |--------------------------------|-------|---------------|
+ * | budget exceeded                | abort | warn          |
+ * | applied ≠ intended             | abort | abort         |
+ * | scaling value absent in config | abort | fine          |
+ * | traffic not on the new revision| abort | abort         |
+ *
+ * The budget row is the only one with a per-env posture, and it has one because int violates the
+ * corrected invariant today (`2 × 3 × (5+1) = 36` against 22 usable) and survives it — int's load
+ * never extends the pools. The verdict is REPORTED identically in both; only the exit differs.
+ * The other rows are plumbing defects with no environmental excuse, and int is precisely where
+ * they must be caught, since int deploys first.
+ */
+export function decideOutcome({
+  env,
+  budget,
+  comparison,
+  revision,
+}: {
+  env: string;
+  budget?: Budget;
+  comparison?: PlanComparison;
+  revision?: RevisionTraffic;
+}): Outcome {
+  const failures: string[] = [];
+  const warnings: string[] = [];
+
+  if (revision) {
+    const { serving, expectedLatestReady } = revision;
+    if (serving.length !== 1 || serving[0] !== expectedLatestReady) {
+      failures.push(
+        `traffic is on ${serving.length ? serving.join(" + ") : "no revision"}, expected 100% on ${expectedLatestReady} — ` +
+          `a rollout that reported success while traffic stayed put IS the applied-vs-intended gap`,
+      );
+    }
+  }
+
+  if (comparison) {
+    for (const m of comparison.mismatches) {
+      failures.push(
+        `${m.key}: config says ${m.intended}, the serving revision has ${m.applied ?? "no value at all"} — ` +
+          `a value declared and a value in force are two different facts`,
+      );
+    }
+    for (const key of comparison.missing) {
+      failures.push(
+        `${key} is ABSENT from ${env} config — silence would become a live configuration change ` +
+          `via the shell default, which is the trap rather than the arithmetic`,
+      );
+    }
+  }
+
+  if (budget && !budget.withinBudget) {
+    const detail =
+      `connection budget exceeded: peak ${budget.peakTotal} > ${budget.usable} usable ` +
+      `(${budget.terms
+        .map((t) => `${t.service} ${CUTOVER_REVISION_FACTOR}×${t.maxInstances}×(${t.poolMax}+1)=${t.peak}`)
+        .join(" + ")} + admin ${budget.adminReserve})`;
+    if (isProd(env)) failures.push(detail);
+    else warnings.push(`${detail} — non-fatal on ${env} per spec-518 dec-5`);
+  }
+
+  return { fatal: failures.length > 0, failures, warnings };
+}
+
+// ── Reporting ─────────────────────────────────────────────────────────────────
+
+/** The enumeration a reader needs to spot a term that should be there and isn't. */
+export function formatBudgetReport(budget: Budget): string[] {
+  const lines = budget.terms.map(
+    (t) =>
+      `    ${t.service}${t.revision ? ` (${t.revision})` : ""}: ` +
+      `maxInstances ${t.maxInstances} × (pool ${t.poolMax} [${t.poolSource}] + ${RELAY_LISTEN_PER_INSTANCE} relay LISTEN) ` +
+      `= ${t.steady} steady, ${t.peak} at cutover`,
+  );
+  lines.push(`    admin / migration reserve: ${budget.adminReserve}`);
+  lines.push(
+    `    TOTAL: ${budget.steadyTotal} steady, ${budget.peakTotal} at cutover, against ${budget.usable} usable ` +
+      `→ ${budget.withinBudget ? `${budget.headroom} spare` : `OVER by ${-budget.headroom}`}`,
+  );
+  return lines;
+}
+
+// ── Reading the applied truth out of gcloud JSON ──────────────────────────────
+//
+// `gcloud run services describe` returns `spec.template` — what the NEXT revision would get.
+// That is intent, and reading it would ship a second source-reader with extra steps. The applied
+// truth lives on the revision that traffic is actually on.
+
+export type RevisionScaling = {
+  revision?: string;
+  /** `undefined` when the service never set `maxScale` — Cloud Run's own default then applies. */
+  maxInstances?: number;
+  /** Cloud Run omits the annotation entirely at 0, so absent reads as 0 here. */
+  minInstances: number;
+  /** `undefined` = no `DB_POOL_MAX` on the revision, so a code default applies. */
+  dbPoolMax?: number;
+  cloudSqlInstances: string[];
+};
+
+const MAX_SCALE = "autoscaling.knative.dev/maxScale";
+const MIN_SCALE = "autoscaling.knative.dev/minScale";
+const CLOUD_SQL = "run.googleapis.com/cloudsql-instances";
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" ? (value as Record<string, unknown>) : {};
+}
+
+function asNumber(value: unknown): number | undefined {
+  if (value === undefined || value === null || value === "") return undefined;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+export function parseRevisionScaling(json: unknown): RevisionScaling {
+  const root = asRecord(json);
+  const metadata = asRecord(root.metadata);
+  const annotations = asRecord(metadata.annotations);
+  const containers = asRecord(root.spec).containers;
+  const first = Array.isArray(containers) ? asRecord(containers[0]) : {};
+  const env = Array.isArray(first.env) ? first.env.map(asRecord) : [];
+  const pool = env.find((e) => e.name === "DB_POOL_MAX");
+
+  return {
+    revision: typeof metadata.name === "string" ? metadata.name : undefined,
+    maxInstances: asNumber(annotations[MAX_SCALE]),
+    // 0 and undefined are NOT the same thing elsewhere in this module, but they are here:
+    // Cloud Run drops the annotation at minScale 0, which is int's live shape.
+    minInstances: asNumber(annotations[MIN_SCALE]) ?? 0,
+    dbPoolMax: asNumber(pool?.value),
+    cloudSqlInstances: String(annotations[CLOUD_SQL] ?? "")
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean),
+  };
+}
+
+export function parseServingRevisions(json: unknown): {
+  serving: string[];
+  latestReady?: string;
+} {
+  const status = asRecord(asRecord(json).status);
+  const traffic = Array.isArray(status.traffic) ? status.traffic.map(asRecord) : [];
+  const serving = traffic
+    // A 0% entry is a tag or a leftover, not a consumer of instances. Anything above 0 is
+    // serving, and during a split EVERY serving revision holds its own pool.
+    .filter((t) => (asNumber(t.percent) ?? 0) > 0)
+    .map((t) => (typeof t.revisionName === "string" ? t.revisionName : ""))
+    .filter(Boolean);
+  return {
+    serving,
+    latestReady:
+      typeof status.latestReadyRevisionName === "string" ? status.latestReadyRevisionName : undefined,
+  };
+}


### PR DESCRIPTION
Release of **one commit** (`6e33577c`) — spec-518 t-7. `git log main..develop --no-merges` carries nothing else, so this is an isolated release rather than a batch.

Lands as a **merge commit** per std-21 cl-50 (GitHub's PR surface can't fast-forward; the content invariant is `git log develop..main --no-merges` empty, not SHA-identity).

## What ships

The guard every existing check on spec-518 cannot be.

`deploy.sh`'s flag syntax, `deploy-config.sh`'s exports and the budget arithmetic in a regression test all read the **source** — and all three were green throughout the 2026-08-03 shedding incident and the 2026-08-11 connection exhaustion, because none of them can observe what actually reached the running revision. This reads the **outcome**.

Two invocations in `packages/server/deploy.sh`, both inside the existing cloud-sql-proxy window so the ceiling is read from Postgres (`pg_settings`) rather than from `gcloud sql describe`'s recorded flag — prod ran a week on a ceiling sized for a machine that no longer existed (dec-2):

| step | when | what it refuses |
|---|---|---|
| **3b** `--mode=plan` | pre-cutover | on prod, an ABSENT `MAX_INSTANCES` / `MIN_INSTANCES` / `DB_POOL_MAX` — `${VAR:-default}` turning silence into a live config change is the trap, not the arithmetic. Plus the budget on the values about to be applied. Aborts before prod is touched. |
| **4b** `--mode=applied` | post-cutover | a value config SET that the serving revision does not carry; traffic left on an older revision; the budget on the numbers **in force**. |

### The invariant is now a sum, and it is asserted rather than commented

The old form counted one revision of one service. It was not wrong — it was a sum with terms missing (spec-332 dec-3 reached this on 2026-06-23):

```
Σ over every Cloud Run service on the Cloud SQL instance of
   2 × MAX_INSTANCES × (DB_POOL_MAX + 1 relay LISTEN)  +  admin reserve   ≤   usable
```

The `2 ×` is the cutover: a draining revision holds its pool while serving nothing, so a deploy is the one moment the budget must hold twice over — and the only moment anyone changes the config. `backstage` is counted too (issue-2): it shares `memex-prod`, carries no pool cap, and appeared in no arithmetic until now.

### Per-env posture (dec-5, resolved this session)

| verdict | prod | int |
|---|---|---|
| budget exceeded | **abort** | warn loudly, continue |
| applied ≠ intended | **abort** | **abort** |
| scaling value absent in config | **abort** | fine (int is deliberately unset, t-4) |
| traffic not on the new revision | **abort** | **abort** |

int violates the corrected invariant today — measured from `pg_settings`, not assumed: `max_connections 25 − 3 = 22 usable` against `2 × 3 × (5+1) = 36` — and survives it, because int's load never extends the pools. A mismatch has no environmental excuse: it is a plumbing defect, and int is where it must be caught since int deploys first.

## Files

| file | role |
|---|---|
| `src/deploy/scaling-budget.ts` (new) | the arithmetic + comparison, **pure** — no gcloud, no DB, no `process.exit`, so the logic is unit-testable and the guard is not a bash script (issue-5 is what a shell guard invites) |
| `scripts/verify-scaling-budget.ts` (new) | the live reads (gcloud + `pg_settings`) and the exit code |
| `deploy.sh` | the two invocations; the stale comment claiming a `~47` ceiling corrected |
| `src/__regression__/spec-518-applied-scaling.regression.test.ts` (new) | 20 tests, tagged ac-16 / ac-19 / ac-20 |
| `src/__regression__/spec-518-scaling-budget.regression.test.ts` | the `47` renamed `INCIDENT_CEILING` — it is history, not today's number |

No schema change, no migration, no route, no dependency added, no UI file touched. Fair-code (std-25) — no `.ee.` files.

## Test plan

**Already done:**

- [x] 20 new tests driven **red→green** (red confirmed as an import error before the module existed), tagged to ac-16 / ac-19 / ac-20 — all three now **verified**, confirmed via `list_acs` rather than inferred from a green suite
- [x] full server suite: **6089 passed / 1 failed** — the failure is the known local-only `.ee/slack/oauth.test.ts` env-stub red, **green in CI on this SHA**; nothing here touches Slack
- [x] `make check` + `make typecheck` clean
- [x] **all four green paths run live, read-only, with the exact env `deploy.sh` supplies** — prod plan/applied exit 0 (151 of 197 at cutover, 46 spare), int plan/applied exit 0 with one warning
- [x] **int deploy `31828099552` ran both invocations for real and passed.** Plan mode read `memex-api-00623-zpb`, applied mode read `memex-api-00624-trq` — a revision that did not exist when the deploy started, which is the proof it reads the serving revision and not `spec.template`
- [x] **red paths proven against live prod**, because "int passed" only shows the guard lets through: a mismatch (sourced 3 vs applied 8) → `exit 1` while the budget block above it passes; `DB_POOL_MAX=10` restored → 247 against 197 → `exit 1` in **plan** mode; and the same through `pnpm` under `set -euo pipefail` with a sentinel `echo` that never printed, so `deploy.sh` really does die there
- [x] verified **before** shipping the gate that prod's current config passes it — a new guard that is wrong blocks delivery

**On this PR / after merge:**

- [ ] CI green on the merge commit
- [ ] prod deploy runs Steps 3b and 4b — **read the log**: expect `MAX_INSTANCES: config 8 → applied 8`, `MIN_INSTANCES: config 1 → applied 1`, `DB_POOL_MAX: config 4 → applied 4`, and `151 of 197 → 46 spare`
- [ ] prod smoke green (std-17)
- [ ] that log is ac-14's and ac-9's evidence — the only thing standing between t-7 and complete

## Operational notes

- **A prod deploy is a revision cutover — the mechanism of 2026-08-11.** spec-525's admission gate is deployed but in **shadow**: it counts, it does not refuse, so it does not protect this cutover yet. What protects it is the 197 ceiling (dec-2) and `mindset-four` batching. **Prefer a lull over a CI peak.**
- **Step 4b can fail the deploy after traffic has moved.** Deliberate — the alternative is the status quo where nothing observes the outcome. Rollback: `workflow_dispatch` redeploy of the previous SHA. An abort there also skips the Step 5 backfills, which are idempotent and resume next deploy (spec-417 dec-6).
- **A red on the prod run would be a good outcome**, not a setback: it would mean a real gap between sourced and applied, which is the guard's entire purpose.
- **spec-525's observation window has been running since 2026-08-13 13:10Z**; a cutover briefly doubles instances and therefore gates, so expect a small bump in that window. t-7 changes nothing about per-event cost, so this is not the case spec-532 forbids.

## Spec

spec-518 · t-7 (stays open until the prod log lands) · dec-5 (new) · ac-16 / ac-19 / ac-20 verified · ac-14 / ac-9 pending this release
<https://memex.ai/mindset-prod/memex-building-itself/specs/spec-518>

🤖 Generated with [Claude Code](https://claude.com/claude-code)