### PR TITLE
fix(spec-518): export DB_POOL_MAX — unblock prod deploys after t-7's guard correctly refused one

### DIFF
--- a/packages/server/src/__regression__/spec-518-applied-scaling.regression.test.ts
+++ b/packages/server/src/__regression__/spec-518-applied-scaling.regression.test.ts
@@ -19,6 +19,8 @@
 // here. It is proved by the deploy running it on int, then prod — see t-7.
 
 import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { tagAc } from "@memex-ai-ac/vitest";
 import {
   ADMIN_SESSION_RESERVE,
@@ -257,6 +259,46 @@ describe("spec-518 ac-20: a mismatch is fatal in every environment", () => {
       revision: { serving: ["memex-api-00623-zpb"], expectedLatestReady: "memex-api-00623-zpb" },
     });
     expect(clean.fatal).toBe(false);
+  });
+});
+
+describe("spec-518 ac-20: the guard can SEE what config set — a third state, not two", () => {
+  // Found by the guard's own first prod run (2026-08-14, run 31832139745), which aborted at the
+  // pre-flight reporting `DB_POOL_MAX is ABSENT from prod config` while `memex-prod-deploy-env`
+  // carried DB_POOL_MAX=4 and Cloud Run was applying it.
+  //
+  // Both facts were true. `deploy.sh`'s own gcloud line reads the value through
+  // ${DB_POOL_MAX+|DB_POOL_MAX=...}, which expands in THAT shell, where a plain sourced
+  // assignment is visible — so prod has run the right pool all along. But a plain assignment is
+  // not exported, and the guard is a CHILD process. MIN_INSTANCES / MAX_INSTANCES already carried
+  // explicit export guards for exactly this reason; DB_POOL_MAX never needed one until something
+  // outside the deploy shell had to read it.
+  //
+  // So the Spec's "declared vs in force" pair is really a triple: declared, in force, and VISIBLE
+  // to whatever is checking. int could not have caught this — int genuinely does not set the value,
+  // so its guard run was correct and silent.
+  const DEPLOY_CONFIG = readFileSync(
+    join(__dirname, "..", "..", "..", "..", "scripts", "deploy-config.sh"),
+    "utf-8",
+  );
+
+  it.each(["MIN_INSTANCES", "MAX_INSTANCES", "DB_POOL_MAX"])(
+    "%s is exported, so a child process sees what the per-env config set",
+    (key) => {
+      tagAc(AC_MISMATCH_FATAL);
+      expect(DEPLOY_CONFIG).toMatch(
+        new RegExp(`if \\[ -n "\\$\\{${key}\\+set\\}" \\]; then\\s*\\n\\s*export ${key}`),
+      );
+    },
+  );
+
+  it("the export keeps set-vs-unset semantics — an env that never sets it stays unchanged", () => {
+    tagAc(AC_MISMATCH_FATAL);
+    // An UNGUARDED `export DB_POOL_MAX` would export an empty value on int, which deploy.sh's
+    // ${DB_POOL_MAX+...} would then treat as SET and push to Cloud Run — blanking a live pool.
+    // So there must be exactly one occurrence, and the assertion above proves that one is guarded.
+    const occurrences = DEPLOY_CONFIG.match(/export DB_POOL_MAX/g) ?? [];
+    expect(occurrences).toHaveLength(1);
   });
 });
 

--- a/scripts/deploy-config.sh
+++ b/scripts/deploy-config.sh
@@ -303,5 +303,17 @@ fi
 if [ -n "${MAX_INSTANCES+set}" ]; then
   export MAX_INSTANCES
 fi
+# DB_POOL_MAX — spec-518 t-7: exported for the same reason, and it took a red prod deploy to
+# notice it wasn't. The value has always been read correctly by deploy.sh's own gcloud line
+# (${DB_POOL_MAX+|DB_POOL_MAX=...} expands in THAT shell, where a plain sourced assignment is
+# visible), so prod has run the right pool for weeks. But a plain assignment is not exported, so
+# no CHILD process could see it — and t-7's guard is a child process. Its first prod run therefore
+# reported DB_POOL_MAX absent while the canonical secret carried DB_POOL_MAX=4 and Cloud Run was
+# applying it. Three states, not two: declared, in force, and VISIBLE to the thing checking.
+# int could never have caught this, because int genuinely does not set the value.
+# Same set-vs-unset semantics, so an env that never sets it still deploys byte-for-byte unchanged.
+if [ -n "${DB_POOL_MAX+set}" ]; then
+  export DB_POOL_MAX
+fi
 
 echo "[deploy-config] ENV=$ENV  project=$GCP_PROJECT  host=$PUBLIC_HOST  api=$API_PUBLIC_HOST"


### PR DESCRIPTION
Release of **one commit** (`dfe5bdd8`). `git log main..develop --no-merges` carries nothing else.

Merge commit per std-21 cl-50.

## Why this exists

t-7's guard shipped in #609 and **refused the very next prod deploy** (run `31832139745`). It aborted at Step 3b — the pre-flight, before the cutover — so **prod was never touched**: it stayed on `memex-api-00130-hgj`, health 200 in ~0.36 s throughout, and remains there now.

```
── spec-518 t-7: connection-budget guard (mode=plan, ENV=prod, service=memex-api) ──
  ceiling (read from Postgres): max_connections 200 − superuser 3 − reserved 0 = 197 usable
    memex-api (memex-api-00130-hgj): 8 × (pool 5 [our-code-default] + 1) = 48 steady, 96 at cutover
    TOTAL: 86 steady, 167 at cutover, against 197 usable → 30 spare
  ✗ DB_POOL_MAX is ABSENT from prod config — silence would become a live configuration
    change via the shell default, which is the trap rather than the arithmetic
  ABORTING (plan)
```

## Both facts were true at once, and that is the finding

`memex-prod-deploy-env` carries `DB_POOL_MAX=4`, and Cloud Run has been applying it for weeks — the serving revision reads `4` right now. The guard was **also** right that it could not see it.

`deploy.sh`'s gcloud line reads the value through `${DB_POOL_MAX+|DB_POOL_MAX=…}`, which expands in **that** shell, where a plain sourced assignment is visible. So the correct pool has always shipped. But a plain assignment is **not exported**, and the guard is a **child process**. `MIN_INSTANCES` / `MAX_INSTANCES` already carried explicit export guards for exactly this reason (added by t-2, because `deploy.sh` itself needed them); `DB_POOL_MAX` never needed one **until something outside the deploy shell had to read it**.

**So this Spec's "declared vs in force" pair is really a triple: declared, in force, and VISIBLE to whatever is checking.** The third state had no name until a guard stood outside the shell and looked in. It is the same shape as `max_connections=50` outliving its machine and as a canonical secret whose branch never executed — one layer further out.

**int could not have caught this.** int genuinely does not set `DB_POOL_MAX` (t-4), so its guard run was correct and silent — the absent-variable refusal is prod-only by dec-5. This is the concrete form of a reviewer's warning before #609: *"passed on int" only shows the guard lets through, not that it stops.*

## The change

One `if`/`export` in `scripts/deploy-config.sh`, matching the two beside it. **Guarded on purpose**: an unguarded `export DB_POOL_MAX` would export an EMPTY value on int, which `${DB_POOL_MAX+…}` treats as **set** and would push to Cloud Run — blanking a live pool. The guarded form keeps an env that never sets the value deploying byte-for-byte unchanged.

Plus 2 regression tests (`ac-20`) so it cannot come back.

## Test plan

**Done:**

- [x] 2 new tests tagged ac-20, driven **red against the unfixed `deploy-config.sh`** (2 failed / 22 passed) → **green** (24/24)
- [x] end-to-end: after sourcing `deploy-config.sh` for prod, a child process now sees `DB_POOL_MAX=4 MAX_INSTANCES=8 MIN_INSTANCES=1`. Before, it saw only the latter two.
- [x] the guard re-run against **live prod through the real `deploy-config.sh` wiring** reads `pool 4 [applied]` instead of `pool 5 [our-code-default]` and **exits 0** — `151 at cutover against 197 usable, 46 spare`
- [x] **int deploy `31851137618` green**, and the guard's int behaviour is byte-for-byte what it was before this change (`config (unset) → applied 3 / 0 / (absent)`, same warning) — the set-vs-unset claim verified in a real deploy rather than inferred
- [x] full CI on `dfe5bdd8`: `test`, `deploy`, `CodeQL`, `Code Quality` all green

**After merge:**

- [ ] the prod deploy reaches Step 4b this time — **read the log**: expect `config 8 → applied 8`, `config 1 → applied 1`, `config 4 → applied 4`, `151 / 197 → 46 spare`, `✓ applied configuration matches the plan and fits the ceiling`
- [ ] prod smoke green (std-17)
- [ ] that log is ac-14's and ac-9's evidence, and the last thing between t-7 and complete

## Operational notes

- **Prod deploys are currently blocked** until this lands — the gate working as designed, not an incident. Prod itself is healthy and unchanged.
- **This deploy will reach the cutover**, unlike the last one. spec-525's admission gate is deployed but in **shadow**: it counts, it does not refuse. What protects the cutover is the 197 ceiling (dec-2) and `mindset-four` batching. **Prefer a lull over a CI peak.**
- Rollback remains a `workflow_dispatch` redeploy of the previous SHA.

## Spec

spec-518 · t-7 · ac-20 (extended) · ac-14 / ac-9 pending this release
<https://memex.ai/mindset-prod/memex-building-itself/specs/spec-518>

🤖 Generated with [Claude Code](https://claude.com/claude-code)