### PR TITLE
feat(spec-528) t-4: the emitter sends run_id and commit_sha where the format declares them

### DIFF
--- a/packages/ac-emit-vitest/src/emit-run-attribution.spec-528.test.ts
+++ b/packages/ac-emit-vitest/src/emit-run-attribution.spec-528.test.ts
@@ -1,0 +1,168 @@
+// spec-528 t-4 / ac-6 — the emitter sends run_id and commit_sha where the wire
+// format declares them: at the top level.
+//
+// WHAT THIS DOES NOT CHANGE. Nothing observable. t-1 shipped 2026-08-13 and the
+// server already fills both columns from `metadata.run_id` / `metadata.commit` when
+// the top-level fields are absent — measured on prod the next day at 86% overall and
+// 100% for the workspace that generates most of the load. An event sent by this code
+// and an event sent by the version before it produce an identical stored row.
+//
+// WHAT IT DOES CHANGE. Today the server-side fallback is not a compatibility path —
+// it is the ONLY path, because no client sends the declared fields. dec-1 called that
+// out at the time: "a compatibility shim in the hottest write path, and shims outlive
+// their reasons." After this, an up-to-date client sends the fields properly and the
+// fallback goes back to being what it was designed as: a bridge for clients that have
+// not upgraded, removable once they are gone.
+//
+// A small irony this closes: the bootstrap protocol served to developers hand-rolling
+// an emitter documents `run_id` and `commit_sha` as top-level fields. Until now the
+// official helper was the one client not following the official protocol.
+//
+// THE NAME DIFFERS ACROSS THE BOUNDARY. The wire field is `commit_sha`; the metadata
+// key is `commit`. Getting that backwards is a silent no-op — no error, no failing
+// test, just a column that stays NULL. It is asserted below rather than trusted.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { buildPayload } from "./emit.js";
+import { tagAc } from "./index.js";
+
+const AC_PRECEDENCE = "mindset-prod/memex-building-itself/specs/spec-528/acs/ac-6";
+
+const args = {
+  ac_uid: "mindset-prod/foo/specs/spec-1/acs/ac-1",
+  status: "pass" as const,
+  test_identifier: "attribution.test.ts::t",
+  duration_ms: 1,
+};
+
+/** The env a GitHub Actions run presents. */
+function inGitHubActions(): void {
+  vi.stubEnv("GITHUB_ACTIONS", "true");
+  vi.stubEnv("GITHUB_RUN_ID", "31711914788");
+  vi.stubEnv("GITHUB_SHA", "15e241cd11aa22bb33cc44dd55ee66ff77889900");
+  vi.stubEnv("GITHUB_REF_NAME", "develop");
+}
+
+beforeEach(() => {
+  // Neutralise the ambient environment first: this suite asserts what a payload
+  // carries, and a developer's own shell (USER, a real CI var) would otherwise leak
+  // into the assertions. Same discipline as the spec-515 sibling suites.
+  for (const k of [
+    "GITHUB_ACTIONS",
+    "GITHUB_RUN_ID",
+    "GITHUB_SHA",
+    "GITHUB_REF_NAME",
+    "GITHUB_HEAD_REF",
+    "GITHUB_SERVER_URL",
+    "GITHUB_REPOSITORY",
+    "GITHUB_ACTOR",
+    "GITLAB_CI",
+    "CI_JOB_ID",
+    "CI_COMMIT_SHA",
+    "BUILDKITE",
+    "CIRCLECI",
+    "CI",
+    "USER",
+    "USERNAME",
+  ]) {
+    vi.stubEnv(k, "");
+  }
+});
+
+afterEach(() => {
+  // [per std-37] cl-5: restore what the test replaced — a leaked env stub can
+  // silently swallow AC emission in a sibling file.
+  vi.unstubAllEnvs();
+});
+
+describe("spec-528 ac-6: the emitter sends run attribution at the top level", () => {
+  it("carries run_id and commit_sha when CI provides them", () => {
+    tagAc(AC_PRECEDENCE);
+    inGitHubActions();
+
+    const payload = buildPayload(args);
+
+    expect(payload.run_id).toBe("31711914788");
+    // The wire field is commit_sha; the metadata key it derives from is `commit`.
+    // Asserted explicitly because reversing the two is a silent no-op.
+    expect(payload.commit_sha).toBe("15e241cd11aa22bb33cc44dd55ee66ff77889900");
+  });
+
+  it("OMITS both fields entirely outside CI — never an empty string", () => {
+    tagAc(AC_PRECEDENCE);
+    // No CI env stubbed by beforeEach, so nothing to derive.
+    const payload = buildPayload(args);
+
+    // `in` rather than a value check: sending "" would make the server store an
+    // empty string instead of NULL, and the top-level value wins over metadata —
+    // so an empty top-level field would BEAT a good metadata one. This is the same
+    // hazard the `actor` field is written to avoid.
+    expect("run_id" in payload).toBe(false);
+    expect("commit_sha" in payload).toBe(false);
+  });
+
+  it("keeps the metadata copy alongside — the duplication is deliberate (ac-3)", () => {
+    tagAc(AC_PRECEDENCE);
+    inGitHubActions();
+
+    const payload = buildPayload(args);
+
+    // External readers learned `metadata->>'run_id'` during the months the columns
+    // were empty, and `branch` / `run_url` have no column at all. Removing these
+    // would read as tidying up duplication and would silently break them.
+    expect(payload.metadata?.run_id).toBe("31711914788");
+    expect(payload.metadata?.commit).toBe("15e241cd11aa22bb33cc44dd55ee66ff77889900");
+    expect(payload.metadata?.branch).toBe("develop");
+  });
+
+  it("follows a per-call metadata override rather than re-reading the environment", () => {
+    tagAc(AC_PRECEDENCE);
+    inGitHubActions();
+
+    // buildMetadata's merge order is: auto-populated < MEMEX_METADATA_* < per-call.
+    // Promoting from the MERGED result rather than from the env keeps one source of
+    // truth — an adopter who overrides the run id gets that override in the column
+    // too, instead of the payload disagreeing with its own metadata.
+    const payload = buildPayload({
+      ...args,
+      options: { metadata: { run_id: "overridden-run" } },
+    });
+
+    expect(payload.run_id).toBe("overridden-run");
+    expect(payload.metadata?.run_id).toBe("overridden-run");
+  });
+
+  it("derives from any supported CI provider, not GitHub alone", () => {
+    tagAc(AC_PRECEDENCE);
+    vi.stubEnv("GITLAB_CI", "true");
+    vi.stubEnv("CI_JOB_ID", "gitlab-4242");
+    vi.stubEnv("CI_COMMIT_SHA", "abcdef1234567890");
+
+    const payload = buildPayload(args);
+
+    // The promotion reuses buildMetadata rather than re-reading env vars, so every
+    // provider it already supports (GitHub, GitLab, BuildKite, Circle) is covered
+    // by construction. This asserts that property holds rather than assuming it.
+    expect(payload.run_id).toBe("gitlab-4242");
+    expect(payload.commit_sha).toBe("abcdef1234567890");
+  });
+});
+
+describe("spec-528 ac-6: one payload builder serves both transports", () => {
+  it("the batch path carries the same fields — it maps this same builder", () => {
+    tagAc(AC_PRECEDENCE);
+    inGitHubActions();
+
+    // emitBatch maps buildPayload over its bucket, so batching cannot be left
+    // behind by construction. Asserted rather than trusted: a batch path that
+    // diverged later would leave the highest-volume transport unattributed, and
+    // silently — exactly the shape of the defect spec-528 exists to fix.
+    const built = [args, { ...args, test_identifier: "b::2" }].map(buildPayload);
+
+    expect(built).toHaveLength(2);
+    for (const p of built) {
+      expect(p.run_id).toBe("31711914788");
+      expect(p.commit_sha).toBe("15e241cd11aa22bb33cc44dd55ee66ff77889900");
+    }
+  });
+});

--- a/packages/ac-emit-vitest/src/emit.ts
+++ b/packages/ac-emit-vitest/src/emit.ts
@@ -113,6 +113,31 @@ export function buildPayload({
     payload.metadata = metadata;
   }
 
+  // spec-528 t-4: send the run id and commit where the wire format declares them.
+  //
+  // Promoted from the MERGED metadata rather than re-read from the environment, so
+  // there is one source of truth: every CI provider buildMetadata already supports
+  // is covered by construction, and a per-call or MEMEX_METADATA_* override lands in
+  // the column too instead of the payload disagreeing with its own metadata.
+  //
+  // Note the name difference across the boundary — the wire field is `commit_sha`,
+  // the metadata key is `commit`. Reversing them is a silent no-op: no error, no
+  // failing test, just a column that stays NULL.
+  //
+  // Omitted entirely when absent, following the `actor` pattern above, so the server
+  // stores NULL rather than "". An empty top-level value would BEAT a good metadata
+  // one under the server's precedence rule (spec-528 dec-1) — the fallback fills in
+  // only when the field is absent, not when it is empty.
+  //
+  // The metadata copies stay (spec-528 ac-3). After this the values travel twice, and
+  // that is intended until someone has audited the readers of the metadata form.
+  if (metadata.run_id) {
+    payload.run_id = metadata.run_id;
+  }
+  if (metadata.commit) {
+    payload.commit_sha = metadata.commit;
+  }
+
   return payload;
 }
 

--- a/packages/ac-emit-vitest/src/types.ts
+++ b/packages/ac-emit-vitest/src/types.ts
@@ -35,6 +35,30 @@ export interface AcEventPayload {
    */
   actor?: string;
   /**
+   * The CI run this emission came from, and the commit it ran against
+   * (spec-528 t-4). Top-level siblings of `metadata` because the wire format
+   * declares them there and the server stores them in dedicated columns — they
+   * are attribution, not free-form provenance, and [per std-32] cl-8 a field a
+   * consumer reads to attribute MUST be a column.
+   *
+   * Derived from the same CI detection that populates `metadata.run_id` /
+   * `metadata.commit` (see metadata.ts), so every provider already supported is
+   * covered and a per-call override is honoured. **Note the name difference
+   * across the boundary: the wire field is `commit_sha`, the metadata key is
+   * `commit`.** Reversing the two is a silent no-op.
+   *
+   * Omitted entirely when no CI environment supplies them, so the server stores
+   * NULL rather than an empty string — an empty top-level value would WIN over a
+   * good metadata one under the server's precedence rule (spec-528 dec-1).
+   *
+   * The metadata copies are kept alongside on purpose (spec-528 ac-3): external
+   * readers learned `metadata->>'run_id'` during the months the columns were
+   * empty, and `branch` / `run_url` have no column at all.
+   */
+  run_id?: string;
+  /** The commit SHA the test ran against — see {@link AcEventPayload.run_id}. */
+  commit_sha?: string;
+  /**
    * Extensible metadata bag (v0.1.0). Surfaced in the Memex UI tooltip on
    * each test event. Well-known keys (actor, branch, commit, host, run_id,
    * run_url) render specially; unknown keys render as plain key-value pairs.


### PR DESCRIPTION
Closes the client half of **spec-528**. The server half (t-1) has been in prod since 2026-08-13.

## What this changes

**Nothing observable.** An event emitted before and after this produces an identical stored row — the server already fills `run_id` / `commit_sha` from metadata when the top-level fields are absent, measured on prod at **86% attributed overall, 100% for `mindset-four`**.

What changes is the **status of the server-side fill**. Today it is not a compatibility path, it is the *only* path, because no client sends the declared fields. dec-1 flagged that when it was chosen: *"a compatibility shim in the hottest write path, and shims outlive their reasons."* After this, an up-to-date client sends the fields properly and the fallback goes back to being a bridge for un-upgraded clients — removable once they are gone.

A small irony this closes: the bootstrap protocol we serve to developers hand-rolling an emitter documents `run_id` / `commit_sha` as top-level fields. Until now the official helper was the one client not following the official protocol.

## Three details that decided the implementation

- **Promoted from the MERGED metadata**, not re-read from the environment. One source of truth: every provider `buildMetadata` already supports is covered by construction (GitHub and GitLab both asserted), and a per-call or `MEMEX_METADATA_*` override lands in the column too instead of the payload disagreeing with its own metadata.
- **Both fields are OMITTED outside CI, never sent empty.** `""` would make the server store an empty string instead of NULL — and an empty top-level value *beats* a good metadata one under the precedence rule, since the fallback fills in only when the field is **absent**. Asserted with `in`, not by value. Same hazard the `actor` field is written to avoid.
- **The metadata copies stay** (ac-3). External readers learned `metadata->>'run_id'` during the months the columns were empty, and `branch` / `run_url` have no column at all. Duplication is the correct state until something has audited the readers.

## The trap this is guarded against

The wire field is `commit_sha`; the metadata key is `commit`. Getting it backwards is a **silent no-op** — no error, no failing test, just a column that stays NULL. That is precisely the failure mode spec-528 exists to end, so it is asserted rather than trusted.

## Test plan

- [x] 6 new tests tagged to `spec-528/acs/ac-6`, **written first** — 4 of 6 red before the implementation
- [x] **Negative control**: swapping `commit` / `commit_sha` reds 3 of the 6 tests
- [x] Batch path covered — `emitBatch` maps the same builder; asserted, not assumed
- [x] Emitter suite green: **115 passed / 15 files**
- [ ] `make e2e-cold` **not run locally** — this change touches no user-facing flow (std-28's journey rule does not bite), and the local runner has a known port/pg-version problem. The `e2e-result` check on this PR is the gate.

## Notes for the reviewer

- **Not published.** `@memex-ai-ac/vitest` stays at `0.3.1` here. memex-ai consumes it via `workspace:*`, so this PR is what starts exercising the path in CI. A standalone `0.3.2` follows once it has soaked — deliberately not bundled with another release, so it is trivial to diagnose and roll back.
- **The `^0.2.0` cohort is unaffected and does not need this.** 24 packages across 6 repos are pinned where 0.x caret rules exclude 0.3.x entirely; attribution already works for them via the server fill. That is why dec-1 chose both halves.
- **Provenance**: these three files were originally swept into commit `32e56cd6` (`feat(spec-530): …`) by a concurrent session running `git add -A` in a shared working tree. They were extracted into a clean branch rather than left there. `rescue/32e56cd6-spec530-mixed` holds the original mixed commit.