### PR TITLE
fix(spec-525) t-11: the shadow window was counting into a void

### DIFF
--- a/packages/server/src/middleware/emission-admission.ts
+++ b/packages/server/src/middleware/emission-admission.ts
@@ -34,6 +34,7 @@ import type { Context, MiddlewareHandler, Next } from "hono";
 import {
   EmissionGate,
   resolveWaitConfig,
+  resolveGateMode,
   EMISSION_GATE_HEADER,
   type Acquisition,
 } from "../services/admission/emission-gate.js";
@@ -45,6 +46,7 @@ import {
 export { EMISSION_GATE_HEADER };
 import { resolvePoolMax } from "../db/pool-size.js";
 import { recordEmissionShed } from "../observability/otel/index.js";
+import { logEmissionShed } from "../observability/emission-shed-log.js";
 import { MAX_BATCH_EVENTS } from "../routes/test-events.js";
 
 /**
@@ -67,8 +69,23 @@ export function emissionGate(): EmissionGate {
       // The same hook fires for a real shed and for a shadow-mode would-be shed, which
       // is what puts ac-17's counterfactual on ac-13's counter rather than leaving it
       // in an in-module field.
-      onShed: (weight, cause, waited) =>
-        recordEmissionShed(weight, { cause, waited }),
+      // spec-525 t-11 / ac-21: TWO instruments, deliberately, because they answer
+      // different questions. The counter is the alertable one ac-13 requires — and it is
+      // a no-op until an OTLP endpoint exists, which it does in neither environment
+      // today. The log line is the READABLE one: Cloud Run ships stdout to Cloud Logging,
+      // which aggregates across instances and survives their recycling, so t-10 can
+      // actually read the shadow window. Removing either one loses a distinct property.
+      onShed: (weight, cause, waited) => {
+        recordEmissionShed(weight, { cause, waited });
+        // `gate` rather than a captured mode: it is assigned before any shed can fire,
+        // and it reports the mode that actually refused — including one a test injected.
+        logEmissionShed({
+          events: weight,
+          cause,
+          waited,
+          mode: gate?.mode ?? resolveGateMode(),
+        });
+      },
     });
   }
   return gate;

--- a/packages/server/src/middleware/emission-shed-log.spec-525.test.ts
+++ b/packages/server/src/middleware/emission-shed-log.spec-525.test.ts
@@ -1,0 +1,200 @@
+// spec-525 t-11 / ac-21 — a shed leaves a record readable from OUTSIDE the process.
+//
+// THE BUG THIS REPRODUCES. On 2026-08-16 the shadow window had been running in prod for
+// two days and had recorded nothing anyone could read. The chain, each link verified
+// against the running system rather than assumed:
+//
+//   recordEmissionShed  → `if (!config.enabled) return;`
+//   config.enabled      → requires OTEL_EXPORTER_OTLP_ENDPOINT
+//   prod revision       → memex-api-00131-zk5 carries 40 env vars; that one is ABSENT
+//   int revision        → absent as well
+//   EmissionGate.wouldShed → in-process getter, exposed by no route, on instances that recycle
+//
+// So spec-525 t-10 — "read the counter by cause, set the wait interval and waiter bound
+// from that data" — had no input, and spec-532 was holding spec-520 back to protect a
+// measurement that was not being taken.
+//
+// WHAT THIS IS NOT. It is NOT ac-13. ac-13 says in its own words that "a log line alone
+// fails this", and it is right: the 2026-08-11 incident had `writesFailed: 251` sitting
+// in the logs and was still found by a person saying the app was broken. ac-13 is about
+// an ALERTABLE metric and stays unsatisfied until an OTLP endpoint exists. This AC is
+// about a READABLE measurement — the one-time read t-10 needs, which is ac-2's
+// requirement that the ceiling and wait interval come from shadow data rather than being
+// chosen in advance. Closing ac-21 must never be used to close ac-13.
+//
+// WHY JSON AND NOT A PRETTY LINE. Cloud Run ships stdout to Cloud Logging, which parses a
+// line that is ENTIRELY valid JSON into `jsonPayload` and makes its fields queryable and
+// aggregatable — across instances and across restarts, which is exactly what the
+// in-process counter could not do. A `[emission-gate] shed ...` text line in the repo's
+// usual style would be human-readable and NOT aggregatable by cause, so it would leave
+// t-10 hand-counting log entries. Hence the departure from the `console.log("[domain] …")`
+// convention used in test-events.ts, and hence the JSON.parse assertions below: a test
+// that merely checked "something was logged" would pass against an unparseable line and
+// prove nothing about the property that matters.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { logEmissionShed } from "../observability/emission-shed-log.js";
+import {
+  emissionGate,
+  __setEmissionGateForTest,
+} from "./emission-admission.js";
+
+const AC_READABLE = "mindset-prod/memex-building-itself/specs/spec-525/acs/ac-21";
+
+let lines: string[] = [];
+let logSpy: ReturnType<typeof vi.spyOn>;
+
+/** Every stdout line this test captured, parsed. Non-JSON lines fail the parse on purpose. */
+const parsed = () => lines.map((l) => JSON.parse(l) as Record<string, unknown>);
+
+beforeEach(() => {
+  lines = [];
+  logSpy = vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+    lines.push(args.map(String).join(" "));
+  });
+});
+
+afterEach(() => {
+  // [per std-37] cl-5: restore what the test replaced — console is the very thing this
+  // file observes, and a leaked stub would silently swallow a sibling's output.
+  logSpy.mockRestore();
+  vi.unstubAllEnvs();
+  __setEmissionGateForTest(null);
+});
+
+describe("spec-525 ac-21: a shed writes one queryable JSON record to stdout", () => {
+  it("writes exactly one line, and it parses as JSON", () => {
+    tagAc(AC_READABLE);
+    logEmissionShed({
+      events: 1,
+      cause: "key_slice_full",
+      waited: false,
+      mode: "shadow",
+    });
+
+    expect(lines).toHaveLength(1);
+    // The assertion that carries the whole point. Cloud Logging only lifts fields into
+    // `jsonPayload` when the ENTIRE line is valid JSON; a prefix like "[emission-gate] "
+    // would leave it an opaque textPayload and un-aggregatable.
+    expect(() => JSON.parse(lines[0])).not.toThrow();
+  });
+
+  it("carries a stable marker so the record can be filtered from everything else on stdout", () => {
+    tagAc(AC_READABLE);
+    logEmissionShed({
+      events: 1,
+      cause: "key_slice_full",
+      waited: false,
+      mode: "shadow",
+    });
+    // Without this, reading the window means grepping for a shape rather than a name.
+    expect(parsed()[0].event).toBe("emission_shed");
+  });
+
+  it("carries cause and waited as DISTINCT fields — the two axes t-10 must split on", () => {
+    tagAc(AC_READABLE);
+    logEmissionShed({ events: 4, cause: "key_slice_full", waited: false, mode: "shadow" });
+    logEmissionShed({
+      events: 7,
+      cause: "instance_ceiling_full",
+      waited: true,
+      mode: "shadow",
+    });
+
+    const [first, second] = parsed();
+    expect(first.cause).toBe("key_slice_full");
+    expect(first.waited).toBe(false);
+    expect(second.cause).toBe("instance_ceiling_full");
+    expect(second.waited).toBe(true);
+    // `waited` separates opposite operator responses: refused AFTER waiting is accidental
+    // overload (holding the slot is right); refused WITHOUT waiting is a flood (refusing
+    // instantly preserves capacity). Collapsing them would make the window unreadable.
+  });
+
+  it("counts EMISSIONS, not requests — a shed batch of 500 must not read as 1", () => {
+    tagAc(AC_READABLE);
+    logEmissionShed({
+      events: 500,
+      cause: "instance_ceiling_full",
+      waited: true,
+      mode: "shadow",
+    });
+    const rec = parsed()[0];
+    // Same unit as ac-13's counter: emitBatch drops the WHOLE bucket on a 429 with no
+    // fallback, so one refused request can destroy 500 verification results.
+    expect(rec.events).toBe(500);
+    expect(rec.requests).toBe(1);
+  });
+
+  it("carries the mode, so a shadow would-be shed is never mistaken for a real refusal", () => {
+    tagAc(AC_READABLE);
+    logEmissionShed({ events: 1, cause: "key_slice_full", waited: false, mode: "shadow" });
+    logEmissionShed({
+      events: 1,
+      cause: "key_slice_full",
+      waited: false,
+      mode: "enforcing",
+    });
+
+    const [shadowRec, enforcingRec] = parsed();
+    expect(shadowRec.mode).toBe("shadow");
+    expect(enforcingRec.mode).toBe("enforcing");
+    // During the window every record is a COUNTERFACTUAL — nothing was actually refused.
+    // A reader who cannot tell the two apart would report the window's would-be sheds as
+    // real data loss, which is the opposite of what shadow mode means.
+  });
+
+  it("marks a real refusal at a higher severity than a counterfactual one", () => {
+    tagAc(AC_READABLE);
+    logEmissionShed({ events: 1, cause: "key_slice_full", waited: false, mode: "shadow" });
+    logEmissionShed({
+      events: 1,
+      cause: "key_slice_full",
+      waited: false,
+      mode: "enforcing",
+    });
+
+    const [shadowRec, enforcingRec] = parsed();
+    // Cloud Logging reads `severity` out of a JSON payload, so this is a free filter
+    // rather than decoration. It is NOT an alert — see the ac-13 note at the top.
+    expect(shadowRec.severity).toBe("INFO");
+    expect(enforcingRec.severity).toBe("WARNING");
+  });
+
+  it("NEVER writes the credential — not the token, not a hash of it", () => {
+    tagAc(AC_READABLE);
+    logEmissionShed({ events: 1, cause: "key_slice_full", waited: false, mode: "shadow" });
+    // The gate runs BEFORE authentication on a public route, so the presented token is an
+    // unverified caller-controlled secret. ac-14 forbids it as a metric label for
+    // cardinality reasons; here the reason is stronger — logs are retained and widely
+    // readable, so a credential written once is a credential leaked.
+    expect(Object.keys(parsed()[0]).sort()).toEqual(
+      ["cause", "event", "events", "mode", "requests", "severity", "waited"].sort(),
+    );
+  });
+});
+
+describe("spec-525 ac-21: the record is WIRED to the gate the server actually runs", () => {
+  it("a shed on the process-wide gate produces the record — not just a callable function", () => {
+    tagAc(AC_READABLE);
+    // This is the assertion that would have caught the original bug. A log helper that
+    // exists but is never reached from `emissionGate()`'s onShed hook leaves prod exactly
+    // as silent as it was, and every content test above would still pass.
+    vi.stubEnv("DB_POOL_MAX", "2"); // ceiling 1 — saturates in one acquire
+    vi.stubEnv("MEMEX_EMISSION_GATE_MODE", "enforcing");
+    __setEmissionGateForTest(null); // force a rebuild from the stubbed environment
+
+    const g = emissionGate();
+    expect(g.mode).toBe("enforcing");
+    for (let i = 0; i < g.ceiling + 1; i++) g.tryAcquire("occupant", 1);
+    g.tryAcquire("someone-else", 500);
+
+    const sheds = parsed().filter((r) => r.event === "emission_shed");
+    expect(sheds.length).toBeGreaterThanOrEqual(1);
+    const last = sheds[sheds.length - 1];
+    expect(last.events).toBe(500);
+    expect(last.cause).toBe("instance_ceiling_full");
+    expect(last.mode).toBe("enforcing");
+  });
+});

--- a/packages/server/src/observability/emission-shed-log.ts
+++ b/packages/server/src/observability/emission-shed-log.ts
@@ -1,0 +1,79 @@
+// spec-525 t-11 / ac-21 — the shed record that survives the process.
+//
+// WHY THIS EXISTS ALONGSIDE ac-13's COUNTER, rather than instead of it. `recordEmissionShed`
+// returns at `if (!config.enabled) return;` unless `OTEL_EXPORTER_OTLP_ENDPOINT` is set,
+// and on 2026-08-16 it was set in NEITHER environment — checked against the running prod
+// revision `memex-api-00131-zk5`, whose 40 env vars do not include it. The only other
+// record, `EmissionGate.wouldShed`, is an in-process getter no route exposes, held in the
+// memory of instances that recycle. So the shadow window opened on 2026-08-14 13:10:19 UTC
+// and counted into a void, leaving t-10 — "read the counter by cause, set the wait interval
+// and waiter bound from that data" — with no input at all.
+//
+// THIS IS NOT ac-13, AND CLOSING ac-21 MUST NOT CLOSE IT. ac-13 states that "a log line
+// alone fails this" and is right: the 2026-08-11 incident had `writesFailed: 251` sitting
+// in the logs and was still found by a person saying the app was broken. ac-13 wants an
+// ALERTABLE metric and stays unsatisfied until an OTLP endpoint exists. This wants a
+// READABLE measurement — the one-time read that lets ac-2's ceiling and wait interval come
+// from shadow data instead of being chosen in advance. Different needs; this serves one.
+//
+// WHY ENTIRELY-JSON, DEPARTING FROM THE REPO'S `console.log("[domain] …")` STYLE. Cloud Run
+// ships stdout to Cloud Logging, which lifts a line into a queryable `jsonPayload` only when
+// the WHOLE line parses as JSON — a `[emission-gate] ` prefix leaves it an opaque
+// textPayload. Aggregating by cause is the entire point, so the prefix loses more than the
+// consistency gains. `severity` is likewise a field Cloud Logging reads out of the payload.
+//
+// NOT std-14's domain logger. That one fans out to `packages/server/.logs/<domain>.log`,
+// which is a local-dev debugging aid: on Cloud Run the filesystem is ephemeral, and a file
+// write per shed would put I/O on the exact path this Spec exists to keep cheap.
+//
+// VOLUME, stated so a reviewer can check it rather than discover it. One line per shed,
+// bounded by request rate — peak measured 2 063 POST/min. Worst case ≈3M lines/day at
+// ~200 bytes ≈ 600 MB/day, under $1/day of Cloud Logging ingest, for a window of days.
+// Re-judge if the window is extended or if enforcing mode runs indefinitely.
+
+import type { GateMode, ShedCause } from "../services/admission/emission-gate.js";
+
+/** One refused (or, in shadow, would-be refused) request. */
+export interface ShedRecord {
+  /** EMISSIONS lost — the batch's length, not 1. Same unit as ac-13's counter. */
+  readonly events: number;
+  /** Which bound refused: the credential's own slice, or the instance ceiling. */
+  readonly cause: ShedCause;
+  /** Refused AFTER waiting (accidental overload) or WITHOUT (a flood). Opposite responses. */
+  readonly waited: boolean;
+  /** `shadow` means nothing was actually refused — the record is a counterfactual. */
+  readonly mode: GateMode;
+}
+
+/** The marker every record carries, so the window can be filtered by name not by shape. */
+export const SHED_LOG_EVENT = "emission_shed";
+
+/**
+ * Write one shed to stdout as a single line of JSON.
+ *
+ * **The credential is never written**, in any form. The gate runs BEFORE authentication on
+ * a public route, so the presented token is an unverified, caller-controlled secret. ac-14
+ * bars it from metric labels for cardinality reasons; the reason here is stronger — logs
+ * are retained and broadly readable, so a credential written once is a credential leaked.
+ *
+ * Deliberately not wrapped in try/catch: `JSON.stringify` over four primitives cannot
+ * throw, and `console.log` failing would mean stdout itself is gone. Swallowing here would
+ * only hide a defect, and unlike the emitter's POST there is no network to fail.
+ */
+export function logEmissionShed(record: ShedRecord): void {
+  console.log(
+    JSON.stringify({
+      event: SHED_LOG_EVENT,
+      // A real refusal loses verification results; a shadow one loses nothing and is the
+      // expected state during the window. Same event, different operator meaning.
+      severity: record.mode === "enforcing" ? "WARNING" : "INFO",
+      cause: record.cause,
+      waited: record.waited,
+      events: record.events,
+      // The companion axis to `events`: one shed batch of 500 and 500 shed single POSTs
+      // are identical on the event count and completely different situations.
+      requests: 1,
+      mode: record.mode,
+    }),
+  );
+}


### PR DESCRIPTION
The admission gate has been observing in production since **2026-08-14 13:10:19 UTC** and recording nothing anyone could read.

## The chain, verified against the running system

| link | state |
|---|---|
| `recordEmissionShed` | `if (!config.enabled) return;` |
| `config.enabled` | requires `OTEL_EXPORTER_OTLP_ENDPOINT` |
| prod `memex-api-00131-zk5` | 40 env vars, **that one ABSENT** |
| int | absent as well |
| stdout | no log call in the middleware |
| `EmissionGate.wouldShed` | in-process getter, no route exposes it, on instances that recycle |

So **t-10** — *"read the counter by cause, set the wait interval and waiter bound from that data"* — had no input, and spec-532 was holding spec-520 back to protect a measurement that was not being taken. The worst of both.

## The fix

The middleware writes one line of JSON per shed to stdout. Cloud Run ships stdout to Cloud Logging, which lifts a fully-JSON line into a queryable `jsonPayload` and aggregates it **across instances and across restarts** — the exact property the in-process counter lacked.

Fields: `event`, `severity`, `cause`, `waited`, `events`, `requests`, `mode`.

## This is NOT ac-13 — please do not let it close ac-13

ac-13 says in its own words that *"a log line alone fails this"*, and it is right: the 2026-08-11 incident had `writesFailed: 251` sitting in the logs and was still found by a person saying the app was broken.

**ac-13 wants an alertable metric** and stays unsatisfied until an OTLP endpoint exists in prod. **ac-21 wants a readable measurement** — the one-time read ac-2 requires so the ceiling and wait interval come from shadow data rather than being chosen in advance. Both instruments are kept; removing either loses a distinct property. The distinction is written into the code, the AC, and the commit message.

`ac-4` also stays untested — *"visible on a surface someone actually looks at"* is a dashboard, not a log you query on demand.

## Two deliberate departures from convention

- **Entirely-JSON, not `console.log("[domain] …")`.** Cloud Logging only parses a line that is *wholly* JSON; a prefix leaves it an opaque `textPayload`, un-aggregatable by cause — which is the entire point.
- **Not std-14's domain logger.** That fans out to `packages/server/.logs/<domain>.log`; Cloud Run's filesystem is ephemeral, and a file write per shed puts I/O on the path this Spec exists to keep cheap.

The credential is **never** written, in any form — the gate runs before authentication on a public route, and logs are retained and broadly readable.

## Volume, stated so it is reviewed rather than discovered

One line per shed, bounded by request rate (peak measured 2 063 POST/min). Worst case ~3M lines/day at ~200 bytes ≈ 600 MB/day — under \$1/day of ingest, for a window of days. Re-judge if enforcing mode runs indefinitely.

## Test plan

- [x] **Test-first, red→green recorded on ac-21**: 8 red (including the wiring assertion reading `expected 0 to be greater than or equal to 1`), then 8 green. ac-21 went `failing` → `verified` on Memex.
- [x] The **wiring test** is the one that would have caught the original defect — a helper that exists but is never reached from `emissionGate()`'s `onShed` hook leaves prod exactly as silent, and every content assertion still passes.
- [x] JSON parsing asserted explicitly — a test that only checked "something was logged" would pass against an unparseable line.
- [x] `make check`, `make typecheck` (exit 0)
- [x] Full server suite: **6 145 passed / 1 failed** — the failure is `.ee/slack/oauth.test.ts`, the documented local-red / CI-green case, untouched by this diff
- [ ] `make e2e-cold` not run locally — no user-facing flow changes; `e2e-result` on this PR is the gate

## After merge

Merging to `develop` deploys to **int**, and the window measures **prod** — so this records nothing useful until the `develop → main` release (10 commits pending). End-to-end verification on int comes first: saturate the gate in shadow mode and confirm the line really lands in Cloud Logging as a queryable field, because otherwise silence in prod cannot be told apart from a broken log.