### PR TITLE
fix(spec-525) t-11: make the window's SILENCE readable, not just its sheds

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -5,6 +5,8 @@ import { app } from "./app.js";
 import { cleanupExpiredDomainVerificationTokens } from "./services/domain-verification.js";
 import { warnIfLlmNotConfigured } from "./agent/anthropic-client.js";
 import { startBusObservability } from "./services/bus-observability.js";
+import { startEmissionGateHeartbeat } from "./observability/emission-shed-log.js";
+import { emissionGate } from "./middleware/emission-admission.js";
 import { startActivityLogSink } from "./services/activity-log.js";
 import { startUsageBackendSink } from "./services/usage-backend-sink.js";
 import { startUsageForwarder } from "./services/usage-forwarder.js";
@@ -34,6 +36,12 @@ const server = serve({ fetch: app.fetch, port }, (info) => {
   // doc-16 dec-3: passive observability for write-vs-emit divergence. The
   // timer is .unref()'d so it doesn't keep the process alive during shutdown.
   startBusObservability()?.unref();
+  // spec-525 t-11 / ac-21: the emission gate's window record. Same cadence and the same
+  // .unref() discipline as the line above — but it NEVER skips a quiet window, because a
+  // window with nothing shed is the observation it exists to make readable. Records with
+  // zero counters mean the instrument works and nothing was refused; no records at all
+  // mean it is broken. The gate is passed lazily so it is still built on first use.
+  startEmissionGateHeartbeat({ gate: () => emissionGate() })?.unref();
   // b-60 t-3: the activity_log sink — one bus subscriber that persists every
   // interaction for Pulse. Advisory: insert failures are swallowed, writes are
   // detached from the emit path.

--- a/packages/server/src/observability/emission-gate-heartbeat.spec-525.test.ts
+++ b/packages/server/src/observability/emission-gate-heartbeat.spec-525.test.ts
@@ -1,0 +1,203 @@
+// spec-525 t-11 / ac-21 — the heartbeat that makes SILENCE interpretable.
+//
+// WHY THE PER-SHED LINE IS NOT ENOUGH, learned by trying it rather than by reasoning.
+// On 2026-08-16 the per-shed record shipped to int and then refused to produce a single
+// line under 200, and then 1 500, concurrent requests. The cause was not the log: an
+// unauthenticated request never awaits anything (`test-events.ts:227` —
+// `rawKey ? await verifyEmissionKey(rawKey) : null`), so it traverses the gate and
+// releases its slot inside one tick of the event loop. Simulated occupancy never exceeds
+// 1, and int's per-key slice IS 1 (pool 5 → ceiling 2 → slice `ceiling - 1`). No
+// contention is reachable that way, at any burst size.
+//
+// That left the original defect only half fixed. A per-shed line makes a shed readable,
+// but it cannot make ZERO readable — and after four days of window, "Cloud Logging
+// returns nothing" would still mean either "nothing was ever refused" (the good news) or
+// "the log is broken" (the bug we just fixed), with no way to tell them apart. Shipping a
+// measurement whose silence is ambiguous is the same class of mistake as the instrument
+// wired to a backend that does not exist.
+//
+// So the heartbeat reports the window's state on a timer, unconditionally.
+//
+//   records present, counters zero  → the log works AND nothing was refused
+//   no records at all               → the log is broken
+//
+// THE DELIBERATE DIVERGENCE FROM `[BUS METRICS]`. That logger, whose timer shape this one
+// copies, applies a skip-zero rule: "a quiet window (no writes, no emits) doesn't warrant
+// a log line". Correct there, fatal here — a quiet window is exactly the observation this
+// exists to record. Do not "align" the two.
+//
+// WHY DELTAS AS WELL AS A CUMULATIVE TOTAL. `wouldShed` is per-instance and dies when the
+// instance recycles, which on Cloud Run is routine. Summing the per-window deltas across
+// every heartbeat and every instance survives that; reading the cumulative alone would
+// lose whatever an instance had counted before it went away.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import {
+  startEmissionGateHeartbeat,
+  _resetEmissionGateHeartbeat,
+  GATE_WINDOW_EVENT,
+  type GateSnapshotSource,
+} from "./emission-shed-log.js";
+
+const AC_READABLE = "mindset-prod/memex-building-itself/specs/spec-525/acs/ac-21";
+
+let lines: string[] = [];
+let logSpy: ReturnType<typeof vi.spyOn>;
+
+const windows = () =>
+  lines
+    .map((l) => JSON.parse(l) as Record<string, unknown>)
+    .filter((r) => r.event === GATE_WINDOW_EVENT);
+
+/** A stand-in for the gate, so the heartbeat can be driven without building a real one. */
+function fakeGate(over: Partial<GateSnapshotSource> = {}): GateSnapshotSource {
+  return {
+    mode: "shadow",
+    ceiling: 2,
+    perKeySlice: 1,
+    inFlight: 0,
+    trackedKeys: 0,
+    wouldShed: { total: 0, byCause: { key_slice_full: 0, instance_ceiling_full: 0 } },
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  lines = [];
+  logSpy = vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+    lines.push(args.map(String).join(" "));
+  });
+});
+
+afterEach(() => {
+  // [per std-37] cl-5: restore what the test replaced, and stop the timer — a leaked
+  // interval would keep logging into a sibling test's captured console.
+  _resetEmissionGateHeartbeat();
+  logSpy.mockRestore();
+  vi.useRealTimers();
+});
+
+describe("spec-525 ac-21: the heartbeat makes a QUIET window observable", () => {
+  it("emits a record when nothing has been shed — the whole point", async () => {
+    tagAc(AC_READABLE);
+    startEmissionGateHeartbeat({ gate: () => fakeGate(), intervalMs: 20 });
+    await new Promise((r) => setTimeout(r, 70));
+
+    // THE assertion this file exists for. Without it, "Cloud Logging returns nothing"
+    // after four days is unreadable: no way to separate a healthy quiet window from a
+    // broken instrument. `[BUS METRICS]`'s skip-zero rule would fail this test.
+    expect(windows().length).toBeGreaterThanOrEqual(1);
+    expect(windows()[0].wouldShed).toBe(0);
+  });
+
+  it("carries the gate's configuration, so the window's numbers can be interpreted later", async () => {
+    tagAc(AC_READABLE);
+    startEmissionGateHeartbeat({
+      gate: () => fakeGate({ ceiling: 2, perKeySlice: 1, mode: "shadow" }),
+      intervalMs: 20,
+    });
+    await new Promise((r) => setTimeout(r, 50));
+
+    const w = windows()[0];
+    // t-10 sets the ceiling and wait interval FROM this data. A count with no record of
+    // the bounds that produced it cannot be reasoned about a week later — and the bounds
+    // are derived from the pool at runtime, so they are not knowable from the source.
+    expect(w.ceiling).toBe(2);
+    expect(w.perKeySlice).toBe(1);
+    expect(w.mode).toBe("shadow");
+  });
+
+  it("is valid JSON with a stable marker, exactly like the per-shed record", async () => {
+    tagAc(AC_READABLE);
+    startEmissionGateHeartbeat({ gate: () => fakeGate(), intervalMs: 20 });
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(lines.length).toBeGreaterThanOrEqual(1);
+    expect(() => JSON.parse(lines[0])).not.toThrow();
+    expect(JSON.parse(lines[0]).event).toBe(GATE_WINDOW_EVENT);
+  });
+});
+
+describe("spec-525 ac-21: the heartbeat reports per-window deltas that survive instance recycling", () => {
+  it("reports what changed in the window, then reports zero once it stops changing", async () => {
+    tagAc(AC_READABLE);
+    let total = 0;
+    let bySlice = 0;
+    startEmissionGateHeartbeat({
+      gate: () =>
+        fakeGate({
+          wouldShed: {
+            total,
+            byCause: { key_slice_full: bySlice, instance_ceiling_full: 0 },
+          },
+        }),
+      intervalMs: 25,
+    });
+
+    total = 7;
+    bySlice = 7;
+    await new Promise((r) => setTimeout(r, 40)); // first window sees the 7
+    await new Promise((r) => setTimeout(r, 40)); // second sees no further change
+
+    const w = windows();
+    expect(w.length).toBeGreaterThanOrEqual(2);
+    expect(w[0].wouldShed).toBe(7);
+    expect((w[0].wouldShedByCause as Record<string, number>).key_slice_full).toBe(7);
+    // Summing deltas across every heartbeat and every instance is what survives a Cloud
+    // Run recycle; reading the cumulative alone loses whatever a dead instance held.
+    expect(w[1].wouldShed).toBe(0);
+    // …while the cumulative stays available for a single-instance sanity check.
+    expect(w[1].wouldShedTotal).toBe(7);
+  });
+});
+
+describe("spec-525 ac-21: the heartbeat can never take the server down", () => {
+  it("survives a gate accessor that throws, and keeps ticking afterwards", async () => {
+    tagAc(AC_READABLE);
+    let boom = true;
+    startEmissionGateHeartbeat({
+      gate: () => {
+        if (boom) throw new Error("gate unavailable");
+        return fakeGate();
+      },
+      intervalMs: 20,
+    });
+
+    await new Promise((r) => setTimeout(r, 45));
+    boom = false;
+    await new Promise((r) => setTimeout(r, 45));
+
+    // A periodic observer that throws is a worse failure than the gap it reports — the
+    // same rule `[BUS METRICS]` states for its own snapshot. And it must RECOVER, not
+    // merely avoid crashing: a heartbeat that dies on its first bad tick is silence again.
+    expect(windows().length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("is idempotent — a second start does not double the records", async () => {
+    tagAc(AC_READABLE);
+    startEmissionGateHeartbeat({ gate: () => fakeGate(), intervalMs: 20 });
+    startEmissionGateHeartbeat({ gate: () => fakeGate(), intervalMs: 20 });
+    await new Promise((r) => setTimeout(r, 50));
+
+    const perTick = windows().length;
+    // ANTI-VACUITY FIRST: an upper bound alone passes when NOTHING is logged, which is
+    // exactly the state this whole file exists to make impossible. It passed against the
+    // red stub for that reason. Assert the records exist before asserting there aren't
+    // too many.
+    expect(perTick).toBeGreaterThanOrEqual(1);
+    // Two timers would double every count read off this log, silently — and the reader
+    // has no way to detect it. Guarded here rather than trusted, matching the `started`
+    // flag `[BUS METRICS]` uses.
+    expect(perTick).toBeLessThanOrEqual(3);
+  });
+
+  it("returns the timer so startup can unref it — an unref'd timer cannot hold the process open", async () => {
+    tagAc(AC_READABLE);
+    const timer = startEmissionGateHeartbeat({ gate: () => fakeGate(), intervalMs: 20 });
+    // index.ts does `start…()?.unref()`, matching startBusObservability. A null return
+    // would make that a silent no-op and the heartbeat would never run in production.
+    expect(timer).not.toBeNull();
+    expect(typeof timer?.unref).toBe("function");
+  });
+});

--- a/packages/server/src/observability/emission-shed-log.ts
+++ b/packages/server/src/observability/emission-shed-log.ts
@@ -31,7 +31,11 @@
 // ~200 bytes ≈ 600 MB/day, under $1/day of Cloud Logging ingest, for a window of days.
 // Re-judge if the window is extended or if enforcing mode runs indefinitely.
 
-import type { GateMode, ShedCause } from "../services/admission/emission-gate.js";
+import type {
+  GateMode,
+  ShedCause,
+  WouldShedCount,
+} from "../services/admission/emission-gate.js";
 
 /** One refused (or, in shadow, would-be refused) request. */
 export interface ShedRecord {
@@ -76,4 +80,97 @@ export function logEmissionShed(record: ShedRecord): void {
       mode: record.mode,
     }),
   );
+}
+
+/** The shape the heartbeat reads. Structural, so the gate needs no knowledge of this file. */
+export interface GateSnapshotSource {
+  readonly mode: GateMode;
+  readonly ceiling: number;
+  readonly perKeySlice: number;
+  readonly inFlight: number;
+  readonly trackedKeys: number;
+  readonly wouldShed: WouldShedCount;
+}
+
+export const GATE_WINDOW_EVENT = "emission_gate_window";
+
+/** Same cadence as `[BUS METRICS]`, so the two read side by side in one log stream. */
+const GATE_WINDOW_INTERVAL_MS = 60_000;
+
+let heartbeat: ReturnType<typeof setInterval> | null = null;
+
+/**
+ * Start the periodic window record. Returns the timer so startup can `.unref()` it,
+ * matching `startBusObservability` (`index.ts:36`).
+ *
+ * **It NEVER skips a quiet window**, which is the one place it deliberately diverges from
+ * `[BUS METRICS]`. That logger skips a window with no activity — correct there, fatal
+ * here: a window with nothing shed is precisely the observation this exists to record.
+ * Records present with zero counters mean the instrument works and nothing was refused;
+ * no records at all mean the instrument is broken. Without that, four days of silence in
+ * Cloud Logging cannot be told apart from the defect this task was opened to fix.
+ *
+ * **Deltas as well as a cumulative total.** `wouldShed` is per-instance and dies when the
+ * instance recycles, which on Cloud Run is routine. Summing per-window deltas across every
+ * heartbeat and every instance survives that; the cumulative alone loses whatever a dead
+ * instance had counted.
+ *
+ * The gate is passed as an accessor rather than imported: the gate lives in the middleware,
+ * which imports this file, so importing it back would be a cycle. It is also called lazily
+ * inside the tick, which preserves the gate's deliberate build-on-first-use behaviour — and
+ * means the first heartbeat proves the log path works even on an instance that has served
+ * no emission traffic at all.
+ */
+export function startEmissionGateHeartbeat(opts: {
+  gate: () => GateSnapshotSource;
+  intervalMs?: number;
+}): ReturnType<typeof setInterval> | null {
+  if (heartbeat) return heartbeat;
+  const intervalMs = opts.intervalMs ?? GATE_WINDOW_INTERVAL_MS;
+  let previous: WouldShedCount | null = null;
+
+  heartbeat = setInterval(() => {
+    try {
+      const g = opts.gate();
+      const now = g.wouldShed;
+      const before = previous ?? { total: 0, byCause: { key_slice_full: 0, instance_ceiling_full: 0 } };
+      previous = { total: now.total, byCause: { ...now.byCause } };
+
+      console.log(
+        JSON.stringify({
+          event: GATE_WINDOW_EVENT,
+          severity: "INFO",
+          mode: g.mode,
+          windowMs: intervalMs,
+          // The bounds are DERIVED from the pool at runtime, so they are not knowable from
+          // the source a week later. A count without them cannot be reasoned about.
+          ceiling: g.ceiling,
+          perKeySlice: g.perKeySlice,
+          inFlight: g.inFlight,
+          trackedKeys: g.trackedKeys,
+          wouldShed: now.total - before.total,
+          wouldShedByCause: {
+            key_slice_full: now.byCause.key_slice_full - before.byCause.key_slice_full,
+            instance_ceiling_full:
+              now.byCause.instance_ceiling_full - before.byCause.instance_ceiling_full,
+          },
+          wouldShedTotal: now.total,
+        }),
+      );
+    } catch (err) {
+      // A periodic observer that throws is a worse failure than the gap it reports — the
+      // rule `[BUS METRICS]` states for its own snapshot. Catching INSIDE the tick (rather
+      // than around the interval) is what lets it recover: a heartbeat that died on its
+      // first bad tick would be silence again, which is the defect, not the fix.
+      console.error("[emission-gate] heartbeat failed (passive — ignoring):", err);
+    }
+  }, intervalMs);
+
+  return heartbeat;
+}
+
+/** Test-only: stop the timer and clear state so a suite can re-arm with a tighter interval. */
+export function _resetEmissionGateHeartbeat(): void {
+  if (heartbeat) clearInterval(heartbeat);
+  heartbeat = null;
 }


### PR DESCRIPTION
Follow-up to #613. That PR made a **shed** readable. This one makes **zero** readable — and the difference turned out to matter.

## What happened when #613 reached int

The per-shed record shipped, and then produced **nothing** under 200, and then 1 500, concurrent requests.

Not a defect in the log. An unauthenticated request never awaits anything — `test-events.ts:227` reads `rawKey ? await verifyEmissionKey(rawKey) : null` — so it crosses the gate and releases its slot **inside one tick of the event loop**. Simulated occupancy never exceeds 1, and int's per-key slice *is* 1 (pool 5 → ceiling 2 → `ceiling - 1`). No burst size reaches contention that way.

Failing to saturate int is the small finding. The large one is what it exposed:

> A per-shed line makes a shed readable but **cannot make ZERO readable.**

Four days from now, "Cloud Logging returns nothing" would still mean *either* "nothing was ever refused" — the good news — *or* "the instrument is broken" — the defect this task was opened to fix. Shipping a measurement whose silence is ambiguous is the same class of mistake as an instrument wired to a backend that does not exist.

## The heartbeat

A `.unref()`'d 60 s timer beside `startBusObservability` writes one JSON line per window:

```json
{"event":"emission_gate_window","severity":"INFO","mode":"shadow","windowMs":60000,
 "ceiling":2,"perKeySlice":1,"inFlight":0,"trackedKeys":0,
 "wouldShed":0,"wouldShedByCause":{"key_slice_full":0,"instance_ceiling_full":0},
 "wouldShedTotal":0}
```

| observation | meaning |
|---|---|
| records present, counters zero | the instrument works **and** nothing was refused |
| no records at all | the instrument is broken |

**It never skips a quiet window.** That is the one place it deliberately diverges from `[BUS METRICS]`, whose skip-zero rule (*"a quiet window doesn't warrant a log line"*) is correct there and fatal here — the quiet window is the observation.

**Deltas as well as a cumulative total**, because `wouldShed` is per-instance and dies when the instance recycles, which on Cloud Run is routine. Summing per-window deltas across every heartbeat and every instance survives that.

**The bounds ride along** (`ceiling`, `perKeySlice`, `mode`) because they are *derived from the pool at runtime* — a count without them cannot be reasoned about a week later, and **t-10 sets the real ceiling and wait interval from exactly this data**.

**The gate is passed as an accessor, not imported** — it lives in the middleware, which imports this file, so importing it back would be a cycle. Called lazily inside the tick, so the gate keeps its build-on-first-use behaviour, and the first heartbeat proves the log path works even on an instance that has served no emission traffic.

## Test plan

- [x] 7 new tagged tests, red→green on ac-21: emits on a **quiet** window, carries the derived bounds, reports deltas then zero, survives a throwing accessor **and recovers**, is idempotent, returns an unref-able timer
- [x] The idempotence test gained an explicit **anti-vacuity lower bound** — an upper bound alone passed against the red stub, when nothing was logged at all
- [x] `make check`, `make typecheck` (exit 0)
- [x] Full server suite: **6 152 passed / 1 failed** — confirmed by re-running it alone to be `.ee/slack/oauth.test.ts` *"throws not_configured when env vars are missing"*, the documented local-red / CI-green case, untouched by this diff
- [ ] `make e2e-cold` not run locally — no user-facing flow changes; `e2e-result` on this PR is the gate

## Still not ac-13, still not ac-4

`ac-13` wants an **alertable metric** and stays unsatisfied until an OTLP endpoint exists in prod. `ac-4` wants a surface someone actually looks at; a log queried on demand is not that. This is `ac-21` only — the **readable measurement** that unblocks `ac-2`.