### PR TITLE
release: spec-525 t-12 — the shadow counter reports emissions and requests separately

### DIFF
--- a/packages/server/src/observability/emission-gate-heartbeat.spec-525.test.ts
+++ b/packages/server/src/observability/emission-gate-heartbeat.spec-525.test.ts
@@ -58,7 +58,12 @@ function fakeGate(over: Partial<GateSnapshotSource> = {}): GateSnapshotSource {
     perKeySlice: 1,
     inFlight: 0,
     trackedKeys: 0,
-    wouldShed: { total: 0, byCause: { key_slice_full: 0, instance_ceiling_full: 0 } },
+    wouldShed: {
+      events: 0,
+      requests: 0,
+      eventsByCause: { key_slice_full: 0, instance_ceiling_full: 0 },
+      requestsByCause: { key_slice_full: 0, instance_ceiling_full: 0 },
+    },
     ...over,
   };
 }
@@ -88,7 +93,8 @@ describe("spec-525 ac-21: the heartbeat makes a QUIET window observable", () => 
     // after four days is unreadable: no way to separate a healthy quiet window from a
     // broken instrument. `[BUS METRICS]`'s skip-zero rule would fail this test.
     expect(windows().length).toBeGreaterThanOrEqual(1);
-    expect(windows()[0].wouldShed).toBe(0);
+    expect(windows()[0].wouldShedEvents).toBe(0);
+    expect(windows()[0].wouldShedRequests).toBe(0);
   });
 
   it("carries the gate's configuration, so the window's numbers can be interpreted later", async () => {
@@ -122,33 +128,40 @@ describe("spec-525 ac-21: the heartbeat makes a QUIET window observable", () => 
 describe("spec-525 ac-21: the heartbeat reports per-window deltas that survive instance recycling", () => {
   it("reports what changed in the window, then reports zero once it stops changing", async () => {
     tagAc(AC_READABLE);
-    let total = 0;
-    let bySlice = 0;
+    let events = 0;
+    let requests = 0;
     startEmissionGateHeartbeat({
       gate: () =>
         fakeGate({
           wouldShed: {
-            total,
-            byCause: { key_slice_full: bySlice, instance_ceiling_full: 0 },
+            events,
+            requests,
+            eventsByCause: { key_slice_full: events, instance_ceiling_full: 0 },
+            requestsByCause: { key_slice_full: requests, instance_ceiling_full: 0 },
           },
         }),
       intervalMs: 25,
     });
 
-    total = 7;
-    bySlice = 7;
+    // 7 EMISSIONS lost across 1 refused REQUEST — the ratio the old single field hid.
+    events = 7;
+    requests = 1;
     await new Promise((r) => setTimeout(r, 40)); // first window sees the 7
     await new Promise((r) => setTimeout(r, 40)); // second sees no further change
 
     const w = windows();
     expect(w.length).toBeGreaterThanOrEqual(2);
-    expect(w[0].wouldShed).toBe(7);
-    expect((w[0].wouldShedByCause as Record<string, number>).key_slice_full).toBe(7);
+    expect(w[0].wouldShedEvents).toBe(7);
+    expect(w[0].wouldShedRequests).toBe(1);
+    expect((w[0].wouldShedEventsByCause as Record<string, number>).key_slice_full).toBe(7);
+    expect((w[0].wouldShedRequestsByCause as Record<string, number>).key_slice_full).toBe(1);
     // Summing deltas across every heartbeat and every instance is what survives a Cloud
     // Run recycle; reading the cumulative alone loses whatever a dead instance held.
-    expect(w[1].wouldShed).toBe(0);
+    expect(w[1].wouldShedEvents).toBe(0);
+    expect(w[1].wouldShedRequests).toBe(0);
     // …while the cumulative stays available for a single-instance sanity check.
-    expect(w[1].wouldShedTotal).toBe(7);
+    expect(w[1].wouldShedEventsTotal).toBe(7);
+    expect(w[1].wouldShedRequestsTotal).toBe(1);
   });
 });
 

--- a/packages/server/src/observability/emission-shed-log.ts
+++ b/packages/server/src/observability/emission-shed-log.ts
@@ -133,8 +133,15 @@ export function startEmissionGateHeartbeat(opts: {
     try {
       const g = opts.gate();
       const now = g.wouldShed;
-      const before = previous ?? { total: 0, byCause: { key_slice_full: 0, instance_ceiling_full: 0 } };
-      previous = { total: now.total, byCause: { ...now.byCause } };
+      const zero = { key_slice_full: 0, instance_ceiling_full: 0 };
+      const before =
+        previous ?? { events: 0, requests: 0, eventsByCause: zero, requestsByCause: zero };
+      previous = {
+        events: now.events,
+        requests: now.requests,
+        eventsByCause: { ...now.eventsByCause },
+        requestsByCause: { ...now.requestsByCause },
+      };
 
       console.log(
         JSON.stringify({
@@ -148,13 +155,25 @@ export function startEmissionGateHeartbeat(opts: {
           perKeySlice: g.perKeySlice,
           inFlight: g.inFlight,
           trackedKeys: g.trackedKeys,
-          wouldShed: now.total - before.total,
-          wouldShedByCause: {
-            key_slice_full: now.byCause.key_slice_full - before.byCause.key_slice_full,
+          // BOTH axes, each named for its unit (t-12). A single `wouldShed` field is what
+          // let a request count be read as an emission count for twelve hours of window:
+          // measured at ~8.1 emissions per refused request, batches up to 261.
+          wouldShedEvents: now.events - before.events,
+          wouldShedRequests: now.requests - before.requests,
+          wouldShedEventsByCause: {
+            key_slice_full: now.eventsByCause.key_slice_full - before.eventsByCause.key_slice_full,
             instance_ceiling_full:
-              now.byCause.instance_ceiling_full - before.byCause.instance_ceiling_full,
+              now.eventsByCause.instance_ceiling_full - before.eventsByCause.instance_ceiling_full,
           },
-          wouldShedTotal: now.total,
+          wouldShedRequestsByCause: {
+            key_slice_full:
+              now.requestsByCause.key_slice_full - before.requestsByCause.key_slice_full,
+            instance_ceiling_full:
+              now.requestsByCause.instance_ceiling_full -
+              before.requestsByCause.instance_ceiling_full,
+          },
+          wouldShedEventsTotal: now.events,
+          wouldShedRequestsTotal: now.requests,
         }),
       );
     } catch (err) {

--- a/packages/server/src/services/admission/emission-gate-shadow.test.ts
+++ b/packages/server/src/services/admission/emission-gate-shadow.test.ts
@@ -45,7 +45,7 @@ describe("spec-525 ac-17: shadow refuses nothing", () => {
     expect(gate.inFlight).toBeGreaterThan(gate.ceiling);
 
     await new Promise((r) => setTimeout(r, 60)); // let the simulated waits resolve
-    expect(gate.wouldShed.total).toBeGreaterThan(0);
+    expect(gate.wouldShed.requests).toBeGreaterThan(0);
     results.forEach((r) => r.ok && r.release());
   });
 
@@ -64,7 +64,7 @@ describe("spec-525 ac-17: shadow refuses nothing", () => {
     const a = await gate.acquire("quiet");
     expect(a.ok).toBe(true);
     await settle();
-    expect(gate.wouldShed.total).toBe(0);
+    expect(gate.wouldShed.requests).toBe(0);
   });
 
   it("the WAIT runs in shadow too — a would-be waiter that gets a slot is not a shed", async () => {
@@ -81,7 +81,7 @@ describe("spec-525 ac-17: shadow refuses nothing", () => {
     held[0]!.ok && held[0]!.release(); // frees a simulated slot well inside the interval
     await new Promise((r) => setTimeout(r, 60));
 
-    expect(gate.wouldShed.total).toBe(0); // it would have been SERVED, not shed
+    expect(gate.wouldShed.requests).toBe(0); // it would have been SERVED, not shed
     held.forEach((r) => r.ok && r.release());
     late.ok && late.release();
   });
@@ -92,7 +92,7 @@ describe("spec-525 ac-17: shadow refuses nothing", () => {
     const held = await Promise.all([gate.acquire("a"), gate.acquire("b")]);
     await gate.acquire("c"); // nothing frees; the simulated waiter expires
     await new Promise((r) => setTimeout(r, 80));
-    expect(gate.wouldShed.total).toBe(1);
+    expect(gate.wouldShed.requests).toBe(1);
     held.forEach((r) => r.ok && r.release());
   });
 
@@ -126,10 +126,10 @@ describe("spec-525 ac-14: the shadow count says WHY, in the enforcing vocabulary
     await gate.acquire("a"); // "a" already holds its whole slice → slice
     await new Promise((r) => setTimeout(r, 40));
 
-    expect(gate.wouldShed.byCause.instance_ceiling_full).toBeGreaterThan(0);
-    expect(gate.wouldShed.byCause.key_slice_full).toBeGreaterThan(0);
-    expect(gate.wouldShed.total).toBe(
-      gate.wouldShed.byCause.instance_ceiling_full + gate.wouldShed.byCause.key_slice_full,
+    expect(gate.wouldShed.requestsByCause.instance_ceiling_full).toBeGreaterThan(0);
+    expect(gate.wouldShed.requestsByCause.key_slice_full).toBeGreaterThan(0);
+    expect(gate.wouldShed.requests).toBe(
+      gate.wouldShed.requestsByCause.instance_ceiling_full + gate.wouldShed.requestsByCause.key_slice_full,
     );
     held.forEach((r) => r.ok && r.release());
   });

--- a/packages/server/src/services/admission/emission-gate.ts
+++ b/packages/server/src/services/admission/emission-gate.ts
@@ -100,10 +100,30 @@ export function resolveGateMode(env: Record<string, string | undefined> = proces
   return env.MEMEX_EMISSION_GATE_MODE === "enforcing" ? "enforcing" : DEFAULT_GATE_MODE;
 }
 
-/** What shadow mode observed: how many emissions enforcing would have refused, and why. */
+/**
+ * What shadow mode observed: what enforcing WOULD have refused, on both axes, and why.
+ *
+ * **Every field names its unit, and that is not cosmetic.** This interface previously
+ * carried `total` under a comment promising "how many emissions" while the code counted
+ * REQUESTS — so t-11's heartbeat published a request count that every reader would take
+ * for emissions. Measured on the live window (prod `memex-api-00132-64q`, 2.7 h): 3 000
+ * refused requests carrying 24 323 emissions, ~8.1 per request, batches up to 261. An
+ * ~8x under-report, unbounded above, growing with batch size — which is what spec-489's
+ * batching work exists to increase.
+ *
+ * ac-13 states the rule: "The counter's unit is EMISSIONS LOST, not requests refused …
+ * one 429 can destroy 500 emissions while a per-request counter reads 1." ac-14 requires
+ * BOTH ("refusals must ALSO be countable as requests"), because one shed batch of 500 and
+ * 500 shed single POSTs are identical on the event axis and completely different
+ * situations. Neither axis can be inferred from the other; keep both.
+ */
 export interface WouldShedCount {
-  readonly total: number;
-  readonly byCause: Record<ShedCause, number>;
+  /** EMISSIONS that would have been lost — the batch's weight. ac-13's unit. */
+  readonly events: number;
+  /** REQUESTS that would have been refused — one per shed, whatever it weighed. */
+  readonly requests: number;
+  readonly eventsByCause: Record<ShedCause, number>;
+  readonly requestsByCause: Record<ShedCause, number>;
 }
 
 /** Default interval a caller may be held while waiting for a slot. */
@@ -337,7 +357,12 @@ export class EmissionGate {
    * stays comparable the moment enforcement goes on.
    */
   get wouldShed(): WouldShedCount {
-    return { total: this.#wouldShedTotal, byCause: { ...this.#wouldShedByCause } };
+    return {
+      events: this.#wouldShedEvents,
+      requests: this.#wouldShedRequests,
+      eventsByCause: { ...this.#wouldShedEventsByCause },
+      requestsByCause: { ...this.#wouldShedRequestsByCause },
+    };
   }
 
   readonly #onShed?: (weight: number, cause: ShedCause, waited: boolean) => void;
@@ -353,8 +378,13 @@ export class EmissionGate {
     }
   }
 
-  #wouldShedTotal = 0;
-  #wouldShedByCause: Record<ShedCause, number> = {
+  #wouldShedEvents = 0;
+  #wouldShedRequests = 0;
+  #wouldShedEventsByCause: Record<ShedCause, number> = {
+    key_slice_full: 0,
+    instance_ceiling_full: 0,
+  };
+  #wouldShedRequestsByCause: Record<ShedCause, number> = {
     key_slice_full: 0,
     instance_ceiling_full: 0,
   };
@@ -453,8 +483,12 @@ export class EmissionGate {
         if (callerReleased) simulated.release();
         else simRelease = simulated.release;
       } else {
-        this.#wouldShedTotal += 1;
-        this.#wouldShedByCause[simulated.cause] += 1;
+        // `weight` on the event axis, 1 on the request axis. Incrementing both by 1 is
+        // the defect t-12 fixed: it read as emissions and counted requests.
+        this.#wouldShedEvents += weight;
+        this.#wouldShedRequests += 1;
+        this.#wouldShedEventsByCause[simulated.cause] += weight;
+        this.#wouldShedRequestsByCause[simulated.cause] += 1;
         // Through the SAME hook the enforcing path uses, so a week of shadow data is
         // directly comparable to enforcing data on the same instrument (ac-17, ac-14).
         this.#reportShed(weight, simulated.cause, simulated.waited);

--- a/packages/server/src/services/admission/emission-shed-counter.test.ts
+++ b/packages/server/src/services/admission/emission-shed-counter.test.ts
@@ -155,7 +155,11 @@ describe("spec-525 ac-13/ac-17: the gate reports sheds, in shadow as well as enf
     expect(admitted.ok).toBe(true);
     // …and the simulation is not awaited, so let its microtasks drain.
     await new Promise((r) => setTimeout(r, 20));
-    expect(gate.wouldShed.total).toBeGreaterThan(0);
+    // Both axes, since this AC's unit is EMISSIONS: a batch of 500 must read 500 on the
+    // event axis and 1 on the request axis. Asserting only "greater than zero" on a single
+    // field is what let a request count pass for an emission count until t-12.
+    expect(gate.wouldShed.events).toBe(500);
+    expect(gate.wouldShed.requests).toBe(1);
     expect(seen).toContain(500);
   });
 });

--- a/packages/server/src/services/admission/emission-shed-unit.spec-525.test.ts
+++ b/packages/server/src/services/admission/emission-shed-unit.spec-525.test.ts
@@ -1,0 +1,138 @@
+// spec-525 t-12 / ac-14 + ac-21 — the shadow counter counts BOTH axes, and says which is which.
+//
+// THE DEFECT THIS PINS, found in production data rather than in review. `WouldShedCount`'s
+// doc comment read "how many EMISSIONS enforcing would have refused"; the code did
+// `this.#wouldShedTotal += 1` — one per REQUEST, whatever the batch weighed. t-11's
+// heartbeat then published that number as `wouldShed`, and ac-21's text called it "the
+// wouldShed delta" without naming a unit. Every surface said or implied emissions; every
+// one of them carried requests.
+//
+// ac-13 states the rule the shadow path was breaking: "The counter's unit is EMISSIONS
+// LOST, not requests refused … one 429 can destroy 500 emissions while a per-request
+// counter reads 1." The OTEL counter already honours it (`#reportShed(weight, …)`); the
+// shadow counter did not — and the shadow counter is the one t-10 reads.
+//
+// MEASURED ON THE LIVE WINDOW, which is why this is not a style complaint. Prod revision
+// memex-api-00132-64q, per-shed records over 2.7 h: 3 000 refused requests carrying
+// 24 323 emissions — a mean of ~8.1 emissions per refused request, batches up to 261. A
+// reader taking the heartbeat's number as events under-reports by ~8×, and the error grows
+// with batch size, which spec-489's batching work exists to increase.
+//
+// So both axes are now first-class and named for their unit. ac-14 already required this
+// ("refusals must ALSO be countable as requests — either a second instrument or a second
+// dimension"); this brings the shadow path up to a criterion already on the board.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { EmissionGate } from "./emission-gate.js";
+import {
+  startEmissionGateHeartbeat,
+  _resetEmissionGateHeartbeat,
+  GATE_WINDOW_EVENT,
+} from "../../observability/emission-shed-log.js";
+
+const SPEC = "mindset-prod/memex-building-itself/specs/spec-525/acs";
+const AC_BOTH_AXES = `${SPEC}/ac-14`; // says WHY, and requests are countable separately
+const AC_READABLE = `${SPEC}/ac-21`; // the record a human can read afterwards
+
+/**
+ * Fill the gate, then shed one batch of `weight`.
+ *
+ * The shed MUST go through `acquire`, not `tryAcquire`: the latter is the raw primitive
+ * and says so in its own header — "It does not know about shadow mode. Counting-without-
+ * refusing is t-3, layered on." A `tryAcquire` shed increments nothing, so a test built on
+ * it reads zero and looks like a missing feature. And the simulation is deliberately not
+ * awaited (awaiting it would add the wait interval to real requests), so its microtasks
+ * need draining before the counter is read.
+ */
+async function shedOneBatch(weight: number): Promise<EmissionGate> {
+  const gate = new EmissionGate({ poolMax: 2, mode: "shadow", waitMs: 0 });
+  for (let i = 0; i < gate.ceiling + 2; i++) gate.tryAcquire("occupant", 1);
+  await gate.acquire("loud", weight);
+  await new Promise((r) => setTimeout(r, 20));
+  return gate;
+}
+
+describe("spec-525 ac-14: the shadow counter separates EMISSIONS from REQUESTS", () => {
+  it("a shed batch of 500 counts 500 emissions and 1 request — never 1 and 1", async () => {
+    tagAc(AC_BOTH_AXES);
+    const gate = await shedOneBatch(500);
+
+    // THE assertion. Before this, `total` was 1 for both, under a comment promising
+    // emissions — so one refused CI file read as a single lost verification result.
+    expect(gate.wouldShed.events).toBe(500);
+    expect(gate.wouldShed.requests).toBe(1);
+  });
+
+  it("splits BOTH axes by cause, so neither can be inferred from the other", async () => {
+    tagAc(AC_BOTH_AXES);
+    const gate = await shedOneBatch(7);
+
+    // 'one shed batch of 500' vs '500 shed single POSTs' is the distinction ac-14 exists
+    // for, and it is invisible unless the cause split carries both units.
+    //
+    // Asserted on the SUM across causes rather than on a named one: this fixture saturates
+    // the instance ceiling with the occupant, so the refusal is `instance_ceiling_full`,
+    // not `key_slice_full`. Hardcoding the cause tested the fixture rather than the split —
+    // and it is the same confusion prod showed, where 100% of refusals were the OTHER cause.
+    const e = gate.wouldShed.eventsByCause;
+    const r = gate.wouldShed.requestsByCause;
+    expect(e.key_slice_full + e.instance_ceiling_full).toBe(7);
+    expect(r.key_slice_full + r.instance_ceiling_full).toBe(1);
+    // Each split must reconcile with its own axis total, or one of them is bookkeeping
+    // that nobody maintains.
+    expect(e.key_slice_full + e.instance_ceiling_full).toBe(gate.wouldShed.events);
+    expect(r.key_slice_full + r.instance_ceiling_full).toBe(gate.wouldShed.requests);
+  });
+
+  it("the two axes agree only when every shed is a single-event POST", async () => {
+    tagAc(AC_BOTH_AXES);
+    const singles = new EmissionGate({ poolMax: 2, mode: "shadow", waitMs: 0 });
+    for (let i = 0; i < singles.ceiling + 2; i++) singles.tryAcquire("occupant", 1);
+    for (let i = 0; i < 5; i++) await singles.acquire("loud", 1);
+    await new Promise((r) => setTimeout(r, 20));
+
+    // A guard against a "fix" that simply aliases one field to the other: with weight 1
+    // they MUST coincide, which is exactly why the old bug survived review.
+    expect(singles.wouldShed.events).toBe(singles.wouldShed.requests);
+    expect(singles.wouldShed.events).toBeGreaterThan(0);
+  });
+});
+
+describe("spec-525 ac-21: the heartbeat publishes both axes under names that state the unit", () => {
+  let lines: string[] = [];
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    lines = [];
+    logSpy = vi.spyOn(console, "log").mockImplementation((...a: unknown[]) => {
+      lines.push(a.map(String).join(" "));
+    });
+  });
+
+  afterEach(() => {
+    _resetEmissionGateHeartbeat();
+    logSpy.mockRestore();
+  });
+
+  it("reports wouldShedEvents AND wouldShedRequests, not one ambiguous number", async () => {
+    tagAc(AC_READABLE);
+    const gate = await shedOneBatch(500);
+    startEmissionGateHeartbeat({ gate: () => gate, intervalMs: 20 });
+    await new Promise((r) => setTimeout(r, 50));
+
+    const w = lines
+      .map((l) => JSON.parse(l) as Record<string, unknown>)
+      .find((r) => r.event === GATE_WINDOW_EVENT);
+
+    expect(w).toBeDefined();
+    // Named for the unit. `wouldShed` alone is what let a request count be read as an
+    // emission count for twelve hours of production window.
+    expect(w?.wouldShedEvents).toBe(500);
+    expect(w?.wouldShedRequests).toBe(1);
+    // And the ambiguous name must be GONE, not merely joined by clearer siblings — a
+    // reader who finds it will use it.
+    expect("wouldShed" in (w ?? {})).toBe(false);
+    expect("wouldShedTotal" in (w ?? {})).toBe(false);
+  });
+});


### PR DESCRIPTION
One commit, `5e64cc27`. Observability only — **no behaviour change to the gate**, which stays in `shadow` and refuses nothing.

## Why now rather than nearer t-10

The shadow window has been recording in prod since the last release. Its counter promised emissions and counted **requests**: `WouldShedCount`'s own doc comment read *"how many EMISSIONS enforcing would have refused"* over `this.#wouldShedTotal += 1`.

Measured on the live window (`memex-api-00132-64q`, 2.7 h): **3 000 refused requests carrying 24 323 emissions** — ~8.1 per request, batches to 261. An **~8× under-report**, unbounded above, growing with batch size.

t-10 (~2026-08-21) sizes the ceiling and wait interval from this number, in the direction that **under-protects**, and invisibly, because the record looks authoritative. Every hour the fix waits is an hour of window that has to be corrected by hand afterwards.

## What changes

```
WouldShedCount { events, requests, eventsByCause, requestsByCause }
heartbeat      { wouldShedEvents, wouldShedRequests,
                 wouldShedEventsByCause, wouldShedRequestsByCause,
                 wouldShedEventsTotal, wouldShedRequestsTotal }
```

Renamed at the source rather than documented — the ambiguity had already produced one defect, and the type's own comment was the thing that was wrong. `ac-14` already required both axes, so this brings the shadow path up to a criterion already on the board.

## ⚠ One operational consequence: the log stream is not continuous across this deploy

Records written **before** this release carry `wouldShed` / `wouldShedTotal` (request counts). Records **after** carry `wouldShedRequests` / `wouldShedEvents`.

Whoever aggregates the window must read **both shapes** and know the switchover moment. This is the deliberate cost of renaming over aliasing — and the reason to pay it now rather than the day before t-10. No data is lost either way: the **per-shed** lines have carried `events` since the previous release, so the pre-existing window can be re-read correctly by summing that field.

## Verified on int (`memex-api-00633-6sz`)

| check | result |
|---|---|
| new fields queryable (`jsonPayload.wouldShedEvents>=0`) | ✅ |
| **negative control** — `jsonPayload.wouldShed` still present? | **0 entries** ✅ |
| 13 expected fields, none extra | ✅ |
| gate header | still `shadow` |
| int deploy + std-17 smoke | green |

**What int could NOT prove, stated plainly:** both axes read `0` there. int cannot create contention — an unauthenticated request never awaits anything (`test-events.ts:227`), so it crosses the gate inside one event-loop tick. The **divergence** between the axes is proven elsewhere: by unit test (500 events / 1 request) and by yesterday's prod data (24 323 / 3 000). int's job here was to prove the rename broke nothing and left nothing ambiguous behind, and it did.

## Merge method

**Merge commit, not squash** — std-21 cl-50.

## Post-deploy verification

- [ ] std-17 smoke green (automatic in the deploy job)
- [ ] `x-memex-emission-gate: shadow` still returned — the mode did not move
- [ ] `jsonPayload.wouldShedEvents` present on `memex-ai-prod`, and `jsonPayload.wouldShed` absent
- [ ] within an hour or two, `wouldShedEvents` > `wouldShedRequests` under real CI load — the divergence int cannot show