### PR TITLE
release: spec-525 t-13 — the counterfactual that unblocks dec-6

### DIFF
--- a/packages/server/src/observability/emission-gate-heartbeat.spec-525.test.ts
+++ b/packages/server/src/observability/emission-gate-heartbeat.spec-525.test.ts
@@ -63,6 +63,8 @@ function fakeGate(over: Partial<GateSnapshotSource> = {}): GateSnapshotSource {
       requests: 0,
       eventsByCause: { key_slice_full: 0, instance_ceiling_full: 0 },
       requestsByCause: { key_slice_full: 0, instance_ceiling_full: 0 },
+      ceilingOnlyEvents: 0,
+      ceilingOnlyRequests: 0,
     },
     ...over,
   };
@@ -138,6 +140,8 @@ describe("spec-525 ac-21: the heartbeat reports per-window deltas that survive i
             requests,
             eventsByCause: { key_slice_full: events, instance_ceiling_full: 0 },
             requestsByCause: { key_slice_full: requests, instance_ceiling_full: 0 },
+            ceilingOnlyEvents: 0,
+            ceilingOnlyRequests: 0,
           },
         }),
       intervalMs: 25,

--- a/packages/server/src/observability/emission-shed-log.ts
+++ b/packages/server/src/observability/emission-shed-log.ts
@@ -127,7 +127,15 @@ export function startEmissionGateHeartbeat(opts: {
 }): ReturnType<typeof setInterval> | null {
   if (heartbeat) return heartbeat;
   const intervalMs = opts.intervalMs ?? GATE_WINDOW_INTERVAL_MS;
-  let previous: WouldShedCount | null = null;
+  // Only the DELTA'd axes. The ceiling-alone counterfactual (t-13) is reported cumulative
+  // on purpose — it is read once, at dec-6, not tracked window by window — so it has no
+  // place in the previous-window state and typing it as the full WouldShedCount would be
+  // a lie the compiler happens to accept.
+  type DeltaState = Pick<
+    WouldShedCount,
+    "events" | "requests" | "eventsByCause" | "requestsByCause"
+  >;
+  let previous: DeltaState | null = null;
 
   heartbeat = setInterval(() => {
     try {
@@ -174,6 +182,11 @@ export function startEmissionGateHeartbeat(opts: {
           },
           wouldShedEventsTotal: now.events,
           wouldShedRequestsTotal: now.requests,
+          // t-13 — the ceiling-alone counterfactual, an UPPER BOUND (see WouldShedCount).
+          // Cumulative rather than a delta: this one is read once, at dec-6, not tracked
+          // window by window, and a running total is what a single query wants.
+          ceilingOnlyWouldShedEvents: now.ceilingOnlyEvents,
+          ceilingOnlyWouldShedRequests: now.ceilingOnlyRequests,
         }),
       );
     } catch (err) {

--- a/packages/server/src/services/admission/emission-ceiling-only.spec-525.test.ts
+++ b/packages/server/src/services/admission/emission-ceiling-only.spec-525.test.ts
@@ -1,0 +1,172 @@
+// spec-525 t-13 / ac-14 + ac-21 — what the instance ceiling would refuse ON ITS OWN.
+//
+// THE QUESTION dec-6 CANNOT BE RESOLVED WITHOUT. The first full prod window showed 100%
+// of would-be refusals caused by `key_slice_full` and 0% by `instance_ceiling_full`. That
+// is not evidence the ceiling would never refuse — it is evidence the slice always refused
+// FIRST, and structurally so: `#take` tests the slice before the ceiling, so a key already
+// holding its slice can never reach the ceiling check. At prod's numbers (slice 1,
+// ceiling 2) the ceiling branch is unreachable for the credential carrying ~90% of load.
+//
+// So the window measured a system in which one bound hid the other, and neither option A
+// (raise the pool) nor option C (drop the slice) can be argued on data. This counter
+// produces the missing number: how much would be refused if the slice did not exist.
+//
+// ────────────────────────────────────────────────────────────────────────────────────────
+// IT IS AN UPPER BOUND, DELIBERATELY. STATE THIS WHEN QUOTING IT.
+//
+// The counterfactual counts a refusal when ceiling-only occupancy is full AT ARRIVAL. A
+// real ceiling-only gate would also WAIT up to `waitMs` (250ms in prod) and would serve
+// some of those arrivals from slots freed during the wait — 96% of observed refusals had
+// `waited: true`, so that population is large.
+//
+// Modelling the wait faithfully would mean running a second queue with its own timers on
+// the hot path. The bias is accepted instead, because it points the safe way: this number
+// OVER-estimates what a ceiling-only gate would refuse. If it comes back small, option C
+// is safe by a margin. If it comes back large, that is a signal to look harder rather than
+// a verdict — the true figure is lower by an unmeasured amount.
+// ────────────────────────────────────────────────────────────────────────────────────────
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { EmissionGate } from "./emission-gate.js";
+import {
+  startEmissionGateHeartbeat,
+  _resetEmissionGateHeartbeat,
+  GATE_WINDOW_EVENT,
+} from "../../observability/emission-shed-log.js";
+
+const SPEC = "mindset-prod/memex-building-itself/specs/spec-525/acs";
+const AC_BOTH_AXES = `${SPEC}/ac-14`;
+const AC_READABLE = `${SPEC}/ac-21`;
+
+/** Let the simulation's microtasks drain — it is deliberately not awaited by `acquire`. */
+const settle = () => new Promise((r) => setTimeout(r, 20));
+
+/**
+ * Acquire in shadow, where the caller is ALWAYS admitted, and narrow the union so the
+ * release handle is reachable. Asserted rather than cast: if shadow ever started refusing,
+ * that is the single most important regression this Spec could have, and a cast would hide
+ * it behind a type error that never fires.
+ */
+async function admitted(gate: EmissionGate, key: string, weight: number) {
+  const a = await gate.acquire(key, weight);
+  if (!a.ok) throw new Error(`shadow mode refused — cause ${a.cause}`);
+  return a;
+}
+
+describe("spec-525 ac-14: the ceiling-alone counterfactual answers what the slice was hiding", () => {
+  it("ONE key filling the whole ceiling: the slice refuses, the ceiling would NOT have", async () => {
+    tagAc(AC_BOTH_AXES);
+    // THE test this task exists for. poolMax 4 → ceiling 2 → slice 1, prod's exact shape.
+    const gate = new EmissionGate({ poolMax: 4, mode: "shadow", waitMs: 0 });
+    expect(gate.ceiling).toBe(2);
+    expect(gate.perKeySlice).toBe(1);
+
+    // Two concurrent emissions from ONE credential — the mindset-four situation.
+    const a = await admitted(gate, "loud", 1);
+    const b = await admitted(gate, "loud", 1);
+    await settle();
+
+    // The slice refused the second: one key may hold 1.
+    expect(gate.wouldShed.requestsByCause.key_slice_full).toBeGreaterThan(0);
+    // …but 2 in flight is exactly the ceiling, so a ceiling-only gate would have served
+    // BOTH. This divergence is the entire content of dec-6: the refusals prod is counting
+    // are not protecting the pool, and until now nothing could show that.
+    expect(gate.wouldShed.ceilingOnlyRequests).toBe(0);
+    expect(gate.wouldShed.ceilingOnlyEvents).toBe(0);
+
+    a.release();
+    b.release();
+  });
+
+  it("past the ceiling, the counterfactual DOES count — it is not hardwired to zero", async () => {
+    tagAc(AC_BOTH_AXES);
+    const gate = new EmissionGate({ poolMax: 4, mode: "shadow", waitMs: 0 });
+
+    // Three concurrent against a ceiling of 2: the third exceeds it on any gate.
+    const held = [await admitted(gate, "k1", 1), await admitted(gate, "k2", 1)];
+    await gate.acquire("k3", 5);
+    await settle();
+
+    // An anti-vacuity guard on the test above: a counter stuck at 0 would satisfy that
+    // assertion for the wrong reason, and this is what separates the two.
+    expect(gate.wouldShed.ceilingOnlyRequests).toBe(1);
+    expect(gate.wouldShed.ceilingOnlyEvents).toBe(5);
+
+    for (const h of held) h.release();
+  });
+
+  it("counts EMISSIONS and REQUESTS separately, like every other axis (t-12)", async () => {
+    tagAc(AC_BOTH_AXES);
+    const gate = new EmissionGate({ poolMax: 4, mode: "shadow", waitMs: 0 });
+    const held = [await admitted(gate, "k1", 1), await admitted(gate, "k2", 1)];
+
+    await gate.acquire("k3", 100);
+    await gate.acquire("k4", 100);
+    await settle();
+
+    // A single number here would repeat exactly the defect t-12 fixed, on a counter whose
+    // whole purpose is to be quoted in a decision.
+    expect(gate.wouldShed.ceilingOnlyRequests).toBe(2);
+    expect(gate.wouldShed.ceilingOnlyEvents).toBe(200);
+
+    for (const h of held) h.release();
+  });
+
+  it("releases its occupancy — a finished request must not hold the counterfactual open", async () => {
+    tagAc(AC_BOTH_AXES);
+    const gate = new EmissionGate({ poolMax: 4, mode: "shadow", waitMs: 0 });
+
+    const a = await admitted(gate, "k1", 1);
+    const b = await admitted(gate, "k2", 1);
+    a.release();
+    b.release();
+    await settle();
+
+    // With both slots given back, a third arrival must be admitted by the counterfactual.
+    // A leak here would make the counter drift toward "refuses everything" over hours and
+    // silently argue for option A.
+    await gate.acquire("k3", 1);
+    await settle();
+    expect(gate.wouldShed.ceilingOnlyRequests).toBe(0);
+  });
+});
+
+describe("spec-525 ac-21: the counterfactual reaches the window record", () => {
+  let lines: string[] = [];
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    lines = [];
+    logSpy = vi.spyOn(console, "log").mockImplementation((...a: unknown[]) => {
+      lines.push(a.map(String).join(" "));
+    });
+  });
+
+  afterEach(() => {
+    _resetEmissionGateHeartbeat();
+    logSpy.mockRestore();
+  });
+
+  it("the heartbeat publishes both counterfactual axes", async () => {
+    tagAc(AC_READABLE);
+    const gate = new EmissionGate({ poolMax: 4, mode: "shadow", waitMs: 0 });
+    const held = [await admitted(gate, "k1", 1), await admitted(gate, "k2", 1)];
+    await gate.acquire("k3", 9);
+    await settle();
+
+    startEmissionGateHeartbeat({ gate: () => gate, intervalMs: 20 });
+    await new Promise((r) => setTimeout(r, 50));
+
+    const w = lines
+      .map((l) => JSON.parse(l) as Record<string, unknown>)
+      .find((r) => r.event === GATE_WINDOW_EVENT);
+
+    // A counter nobody can read from outside the process is the defect t-11 fixed; a
+    // counter that exists only in a unit test repeats it in miniature.
+    expect(w?.ceilingOnlyWouldShedEvents).toBe(9);
+    expect(w?.ceilingOnlyWouldShedRequests).toBe(1);
+
+    for (const h of held) h.release();
+  });
+});

--- a/packages/server/src/services/admission/emission-gate.ts
+++ b/packages/server/src/services/admission/emission-gate.ts
@@ -124,6 +124,25 @@ export interface WouldShedCount {
   readonly requests: number;
   readonly eventsByCause: Record<ShedCause, number>;
   readonly requestsByCause: Record<ShedCause, number>;
+  /**
+   * t-13 — what the INSTANCE CEILING ALONE would have refused, with the per-key slice
+   * removed. The question dec-6 cannot be resolved without.
+   *
+   * `#take` tests the slice BEFORE the ceiling, so a key already holding its slice can
+   * never reach the ceiling check: at prod's numbers (slice 1, ceiling 2) that branch is
+   * unreachable for the credential carrying ~90% of load. The window's 100%/0% split is
+   * therefore structural, and says nothing about what the ceiling would do on its own.
+   *
+   * **It is an UPPER BOUND — say so when quoting it.** A refusal is counted when
+   * ceiling-only occupancy is full AT ARRIVAL. A real ceiling-only gate would also wait
+   * up to `waitMs` and serve some of those from slots freed meanwhile — and 96% of
+   * observed refusals had `waited: true`, so that population is large. Modelling the wait
+   * would mean a second queue with its own timers on the hot path; the bias is accepted
+   * instead because it points the safe way. Small here means option C is safe by a
+   * margin; large is a reason to look harder, not a verdict.
+   */
+  readonly ceilingOnlyEvents: number;
+  readonly ceilingOnlyRequests: number;
 }
 
 /** Default interval a caller may be held while waiting for a slot. */
@@ -362,6 +381,8 @@ export class EmissionGate {
       requests: this.#wouldShedRequests,
       eventsByCause: { ...this.#wouldShedEventsByCause },
       requestsByCause: { ...this.#wouldShedRequestsByCause },
+      ceilingOnlyEvents: this.#ceilingOnlyEvents,
+      ceilingOnlyRequests: this.#ceilingOnlyRequests,
     };
   }
 
@@ -380,6 +401,10 @@ export class EmissionGate {
 
   #wouldShedEvents = 0;
   #wouldShedRequests = 0;
+  // t-13's counterfactual: an occupancy counter that knows only the ceiling.
+  #ceilingOnlyInFlight = 0;
+  #ceilingOnlyEvents = 0;
+  #ceilingOnlyRequests = 0;
   #wouldShedEventsByCause: Record<ShedCause, number> = {
     key_slice_full: 0,
     instance_ceiling_full: 0,
@@ -470,6 +495,19 @@ export class EmissionGate {
     this.#realInFlight += 1;
     this.#realHeld.set(key, (this.#realHeld.get(key) ?? 0) + 1);
 
+    // t-13 — the ceiling-alone counterfactual, evaluated on arrival against its OWN
+    // occupancy. It cannot be derived from the counters above: a request the slice
+    // refuses never occupies a simulated slot, so the primary simulation's occupancy is
+    // systematically lower than a ceiling-only gate's would be.
+    let ceilingOnlyHeld = false;
+    if (this.#ceilingOnlyInFlight >= this.ceiling) {
+      this.#ceilingOnlyEvents += weight;
+      this.#ceilingOnlyRequests += 1;
+    } else {
+      this.#ceilingOnlyInFlight += 1;
+      ceilingOnlyHeld = true;
+    }
+
     // The simulated slot, if the simulation ends up granting one. It may resolve after the
     // caller has already released, so the two are reconciled rather than assumed ordered.
     let simRelease: (() => void) | null = null;
@@ -501,6 +539,11 @@ export class EmissionGate {
       released = true;
       callerReleased = true;
       this.#realInFlight -= 1;
+      // Give the counterfactual's slot back on the caller's own lifetime — in shadow the
+      // caller is admitted regardless, so that IS the true occupancy duration. Leaking it
+      // would drift the counter toward "refuses everything" over hours and silently argue
+      // for dec-6 option A.
+      if (ceilingOnlyHeld) this.#ceilingOnlyInFlight -= 1;
       const remaining = (this.#realHeld.get(key) ?? 1) - 1;
       if (remaining <= 0) this.#realHeld.delete(key);
       else this.#realHeld.set(key, remaining);


### PR DESCRIPTION
One commit, `66cb27b2`. Observability only — **no behaviour change to the gate**, which stays in `shadow` and refuses nothing.

## Why this one is time-critical

The counter only accumulates where the window runs, and the window runs in **prod**. **t-10 is ~2026-08-21**, and `dec-6` — *what replaces `perKeySlice = ceiling - 1`* — cannot be resolved without this number. Every day it waits is a day of counterfactual that does not exist.

## What the window could not tell us, and why

The first full prod window showed **100% of would-be refusals caused by `key_slice_full`, 0% by `instance_ceiling_full`**. That reads like "the ceiling never binds". It is not what it means.

`#take` tests the per-key slice **before** the instance ceiling, so a key already holding its slice **never reaches the ceiling check**. At prod's numbers — `DB_POOL_MAX 4` → ceiling 2 → slice 1 — that branch is *unreachable* for the credential carrying ~90% of load. **The split is structural, not statistical.**

Neither dec-6 option can be argued on it: **A** (raise the pool) spends 32 of 46 remaining budget connections for a factor of 2; **C** (drop the slice) moves refusals onto the ceiling by an amount nobody has measured. This produces that amount.

## What ships

A **separate occupancy counter**, not a derivation — a request the slice refuses never occupies a simulated slot, so the existing occupancy is systematically lower than a ceiling-only gate's would be.

```
WouldShedCount { …, ceilingOnlyEvents, ceilingOnlyRequests }
heartbeat      { …, ceilingOnlyWouldShedEvents, ceilingOnlyWouldShedRequests }
```

Both axes per t-12. Cumulative rather than delta'd — read once, at dec-6, and a running total is what a single query wants.

## ⚠ Quote it as an UPPER BOUND

A refusal is counted when ceiling-only occupancy is full **at arrival**. A real ceiling-only gate would also wait up to `waitMs` and serve some of those from slots freed meanwhile — and **96% of observed refusals had `waited: true`**. The bias points the safe way: **small** → option C is safe by a margin; **large** → a reason to look harder, not a verdict.

## Verified on int (`memex-api-00634-nwf`)

`jsonPayload.ceilingOnlyWouldShedEvents` is queryable — it is a parsed field, not text. Deploy + std-17 smoke green.

**What int could not prove:** the value is `0` there. int cannot create contention — an unauthenticated request never awaits anything (`test-events.ts:227`), so it crosses the gate inside one event-loop tick. The counter's behaviour under contention is proven by unit test; its behaviour in the field can only come from prod.

## A note on the two red runs that preceded this

Both were **GitHub infrastructure**, not code: `429 Too Many Requests` from `codeload.github.com` while downloading actions (`pnpm/action-setup`, then `actions/download-artifact`), failing at *Set up job* before any of our code ran. Re-run, both green. The `deploy` red that followed was the fail-closed gate doing its job — an aborted test run correctly blocked the deploy.

Worth recording: `server-result` failed while all three `server` shards and `server-rls` were green. That shape means aggregator or infrastructure, not tests.

## Merge method

**Merge commit, not squash** — std-21 cl-50.

## Post-deploy verification

- [ ] std-17 smoke green (automatic)
- [ ] `x-memex-emission-gate: shadow` — the mode did not move
- [ ] `jsonPayload.ceilingOnlyWouldShedEvents` present on `memex-ai-prod`, from more than one instance
- [ ] within a few hours, a **non-zero** reading under real CI load — the number dec-6 is waiting on