### PR TITLE
fix(spec-520) t-7: the ingest path never told the database which tenant it was

### DIFF
--- a/packages/server/src/routes/test-events-tenant-context.rls-restricted.test.ts
+++ b/packages/server/src/routes/test-events-tenant-context.rls-restricted.test.ts
@@ -1,0 +1,249 @@
+// spec-520 t-7 / ac-32 — the ingest path establishes tenant context, so its READS see
+// their own rows. Runs ONLY under vitest.rls.config.ts, as the restricted `memex_app`
+// role. In the default owner-connection suite RLS is bypassed (std-36: ENABLE, never
+// FORCE), so this defect is INVISIBLE there — which is exactly why it lived in prod.
+//
+// THE DEFECT (spec-520 issue-6, measured on prod): the ingest path's issue auto-resolve
+// returns empty for 99.96% of passing events. Not a tuning problem. `processOneEvent`
+// calls `maybeAutoResolveIssuesForAcUid`, whose FIRST statement is a
+// `documents ⋈ memexes ⋈ namespaces` join; `documents` carries `documents_memex_isolation`
+// on `app.memex_id`; and `runWithMemexId` appeared NOWHERE in routes/test-events.ts. Under
+// the non-owner runtime role the lookup is filtered to zero rows, so the chain concludes
+// "nothing to resolve" — every time. spec-112 ac-22's second auto-resolve trigger, the one
+// that closes the bug→failing-AC→green-AC→resolved loop from ingest, has been dead.
+//
+// THREE LAYERS OF SILENCE hid it, and each is individually reasonable:
+//   1. the call is `.catch(() => {})` by design, so a test-result write can never fail
+//   2. the owner role bypasses RLS, so dev and the default suite cannot reproduce it
+//   3. the tenant-context guard that exists for this class watches WRITES — this is a READ
+// A fix is not finished until at least one of those layers would now speak up. This file
+// is that layer: under the real role, the route either resolves the Issue or it does not.
+//
+// SECOND INSTANCE OF A CLASS SPEC-440 WAS MEANT TO CLOSE. spec-440 t-6 fixed exactly this
+// shape in `markPresent` (its own rls-restricted test sits beside this one) and shipped the
+// write-side guard. The class is not closed for READS. Worth carrying to spec-440.
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { and, desc, eq, inArray } from "drizzle-orm";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { db, runWithMemexId } from "../db/connection.js";
+import {
+  acs,
+  documents,
+  issues,
+  memexEmissionKeys,
+  memexes,
+  namespaces,
+  taskSatisfiesAc,
+  tasks,
+  testEvents,
+  users,
+} from "../db/schema.js";
+import { upsertUserByEmail } from "../services/users.js";
+import { ensureUserNamespace } from "../services/user-namespaces.js";
+import { createDocDraft } from "../services/documents.js";
+import { mintEmissionKey } from "../services/emission-keys.js";
+import { maybeAutoResolveIssuesForAcUid } from "../services/issues.js";
+import { app } from "../app.js";
+
+const AC_TENANT_CONTEXT = "mindset-prod/memex-building-itself/specs/spec-520/acs/ac-32";
+
+const runId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+let memexId: string;
+let userId: string;
+let namespaceSlug: string;
+let memexSlug: string;
+let docId: string;
+let taskId: string;
+let acId: string;
+let issueId: string;
+let emissionKey: string;
+let acRef: string;
+let specHandle: string;
+
+/** The AC ref the route will receive, and the one the auto-resolve chain reverses. */
+const AC_SEQ = 1;
+
+beforeAll(async () => {
+  const user = await upsertUserByEmail(`spec520-t7-${runId}@example.com`);
+  userId = user.id;
+
+  // namespace + memex are NOT RLS-gated — writable by memex_app with no tenant GUC.
+  const created = await ensureUserNamespace(userId);
+  memexId = created.memex.id;
+  memexSlug = created.memex.slug;
+  const [ns] = await db
+    .select({ slug: namespaces.slug })
+    .from(namespaces)
+    .where(eq(namespaces.id, created.memex.namespaceId))
+    .limit(1);
+  namespaceSlug = ns!.slug;
+
+  // Everything below is RLS-gated, so seed it under the matching tenant context. Seeding
+  // is NOT what is under test — the route's own context is.
+  //
+  // Worth recording: the first draft of this file read `documents.handle` back OUTSIDE the
+  // wrapper and crashed on `undefined` — RLS filtered the row away. The test fell into the
+  // very defect it exists to pin, which is how easy this class is to reintroduce.
+  await runWithMemexId(memexId, async () => {
+    const doc = await createDocDraft(memexId, `spec520 t7 target ${runId}`, "", "spec");
+    docId = doc.id;
+    specHandle = doc.handle;
+
+    const [ac] = await db
+      .insert(acs)
+      .values({
+        memexId,
+        briefId: docId,
+        seq: AC_SEQ,
+        kind: "implementation",
+        statement: "the verifying criterion",
+        status: "active",
+      } as typeof acs.$inferInsert)
+      .returning();
+    acId = ac!.id;
+
+    const [task] = await db
+      .insert(tasks)
+      .values({
+        memexId,
+        docId,
+        seq: 1,
+        title: "the satisfying task",
+        description: "",
+        // COMPLETE is a precondition: maybeAutoResolveIssuesForTask returns [] otherwise.
+        status: "complete",
+      } as typeof tasks.$inferInsert)
+      .returning();
+    taskId = task!.id;
+
+    await db.insert(taskSatisfiesAc).values({ taskId, acId } as typeof taskSatisfiesAc.$inferInsert);
+
+    // A CONVERTED issue pointing at that task — the shape the down-bridge produces and the
+    // only shape auto-resolve acts on.
+    const [issue] = await db
+      .insert(issues)
+      .values({
+        memexId,
+        docId,
+        seq: 1,
+        title: "the issue awaiting a green AC",
+        body: "",
+        type: "bug",
+        severity: "high",
+        status: "converted",
+        source: "agent",
+        satisfyingTaskId: taskId,
+        createdByUserId: userId,
+      } as typeof issues.$inferInsert)
+      .returning();
+    issueId = issue!.id;
+  });
+
+  // The ref the emitter will send, built exactly as the chain reverses it. The handle comes
+  // from the create result rather than a read-back — one less gated query to get wrong.
+  acRef = `${namespaceSlug}/${memexSlug}/specs/${specHandle}/acs/ac-${AC_SEQ}`;
+
+  emissionKey = (await mintEmissionKey(memexId, `spec520-t7-${runId}`, userId)).raw;
+});
+
+afterAll(async () => {
+  await runWithMemexId(memexId, async () => {
+    await db.delete(testEvents).where(eq(testEvents.subjectRef, acRef)).catch(() => {});
+    if (issueId) await db.delete(issues).where(eq(issues.id, issueId)).catch(() => {});
+    if (taskId) await db.delete(tasks).where(eq(tasks.id, taskId)).catch(() => {});
+    if (acId) await db.delete(acs).where(eq(acs.id, acId)).catch(() => {});
+    if (docId) await db.delete(documents).where(eq(documents.id, docId)).catch(() => {});
+  });
+  await db.delete(memexEmissionKeys).where(eq(memexEmissionKeys.memexId, memexId)).catch(() => {});
+  await db.delete(memexes).where(eq(memexes.id, memexId)).catch(() => {});
+  await db.delete(namespaces).where(eq(namespaces.slug, namespaceSlug)).catch(() => {});
+  await db.delete(users).where(inArray(users.id, [userId])).catch(() => {});
+});
+
+describe("spec-520 ac-32: the DIAGNOSIS — tenant context is what the chain needs", () => {
+  // These two do not prove the fix (the fix is at the call site, not in this function).
+  // They pin WHY the fix is what it is, under the real role — so a future reader cannot
+  // conclude the auto-resolve chain is simply broken and rewrite the wrong thing.
+  it("WITHOUT tenant context the chain finds nothing, though the Issue is resolvable", async () => {
+    tagAc(AC_TENANT_CONTEXT);
+    const resolved = await maybeAutoResolveIssuesForAcUid(acRef);
+    // Zero, and not because there is nothing to resolve — the next test resolves the very
+    // same Issue from the very same row. The documents lookup is filtered to no rows.
+    expect(resolved).toEqual([]);
+  });
+
+  it("WITH tenant context the same call resolves the same Issue", async () => {
+    tagAc(AC_TENANT_CONTEXT);
+    // Give the AC a green event first: verifyingAcIsGreen gates the resolve.
+    await runWithMemexId(memexId, async () => {
+      await db.insert(testEvents).values({
+        memexId,
+        subjectRef: acRef,
+        status: "pass",
+        testIdentifier: "spec520-t7::diagnosis",
+        durationMs: 1,
+      } as typeof testEvents.$inferInsert);
+    });
+
+    const resolved = await runWithMemexId(memexId, async () =>
+      maybeAutoResolveIssuesForAcUid(acRef),
+    );
+    expect(resolved).toContain(issueId);
+
+    // Put it back to converted so the route test below starts from the same state.
+    await runWithMemexId(memexId, async () => {
+      await db.update(issues).set({ status: "converted" }).where(eq(issues.id, issueId));
+    });
+  });
+});
+
+describe("spec-520 ac-32: the FIX — the ROUTE establishes the context", () => {
+  it("a passing emission through POST /api/test-events resolves the converted Issue", async () => {
+    tagAc(AC_TENANT_CONTEXT);
+    // THE red→green assertion. Before the fix the route called auto-resolve with no tenant
+    // context, so this Issue stayed `converted` forever while the event was written happily
+    // — silent, because the call is best-effort by design. Nothing in the response differs;
+    // only the row does, which is why this asserts the ROW and not the status code.
+    const res = await app.request("/api/test-events", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${emissionKey}`,
+      },
+      body: JSON.stringify({
+        ac_uid: acRef,
+        status: "pass",
+        test_identifier: "spec520-t7::route",
+        duration_ms: 1,
+      }),
+    });
+    expect(res.status).toBe(201);
+
+    // NOTE the `async` callback. `runWithMemexId(id, () => db.select(...))` returns the
+    // QUERY BUILDER, and AsyncLocalStorage.run() has already returned by the time the
+    // outer await executes it — so the query runs OUTSIDE the context and RLS filters it
+    // to nothing. Cost me a debugging round; the async form keeps execution in the subtree.
+    const [row] = await runWithMemexId(memexId, async () =>
+      db.select({ status: issues.status }).from(issues).where(eq(issues.id, issueId)).limit(1),
+    );
+    expect(row?.status).toBe("resolved");
+  });
+
+  it("the event itself still lands — the fix must not cost the write", async () => {
+    tagAc(AC_TENANT_CONTEXT);
+    // The auto-resolve call is deliberately best-effort so it can never fail a CI run's
+    // result write. Wrapping it in tenant context must not change that: assert the event
+    // row exists regardless of what the resolve did.
+    const [latest] = await runWithMemexId(memexId, async () =>
+      db
+        .select({ status: testEvents.status, id: testEvents.testIdentifier })
+        .from(testEvents)
+        .where(and(eq(testEvents.subjectRef, acRef), eq(testEvents.status, "pass")))
+        .orderBy(desc(testEvents.createdAt))
+        .limit(1),
+    );
+    expect(latest?.status).toBe("pass");
+  });
+});

--- a/packages/server/src/routes/test-events.ts
+++ b/packages/server/src/routes/test-events.ts
@@ -79,6 +79,7 @@ import {
   recordFirstVerified,
 } from "../services/test-event-retention.js";
 import { maybeAutoResolveIssuesForAcUid } from "../services/issues.js";
+import { runWithMemexId } from "../db/connection.js";
 import { fireVerifiedMilestoneForUser } from "../services/email/verified-milestone-send.js";
 import {
   verifyEmissionKey,
@@ -531,7 +532,28 @@ async function processOneEvent(
   // event for an AC that verifies a converted Issue's Task closes the
   // bug→failing-AC→green-AC→resolved loop. Best-effort: never fail the write.
   if (body.status === "pass") {
-    await maybeAutoResolveIssuesForAcUid(subjectRefValue).catch(() => {});
+    // spec-520 t-7 (ac-32): run it INSIDE the tenant context. Without this the chain's
+    // first statement — a `documents ⋈ memexes ⋈ namespaces` join — is filtered to zero
+    // rows by `documents_memex_isolation` under the non-owner runtime role, so it concluded
+    // "nothing to resolve" for 99.96% of passing events and spec-112 ac-22's second
+    // auto-resolve trigger was dead in prod (issue-6).
+    //
+    // Three things kept it silent, which is why it needs a comment rather than just a fix:
+    // the call is `.catch(() => {})` by design so a CI result write can never fail; the
+    // owner role bypasses RLS so dev and the default suite cannot reproduce it; and the
+    // tenant-context guard built for this class (spec-440) watches WRITES, not READS.
+    // Proven under the restricted role in test-events-tenant-context.rls-restricted.test.ts.
+    // try/catch, not just `.catch()`: a SYNCHRONOUS throw here escapes a trailing
+    // `.catch` and 500s the event write. Observed while building this — a missing import
+    // turned every passing emission into a 500. The old single-expression form had the
+    // same hole; best-effort has to mean best-effort against both failure shapes.
+    try {
+      await runWithMemexId(targetMemexId, () =>
+        maybeAutoResolveIssuesForAcUid(subjectRefValue),
+      );
+    } catch {
+      // advisory by contract — an auto-resolve failure must never fail a CI result write
+    }
     // spec-453 t-2 (dec-1/dec-4/dec-9): fire the "See it verified" milestone email.
     // FIRE-AND-FORGET — never awaited on this CI hot path, so it cannot add latency to
     // or break the write. Attributed to the emission key's OWNER (not test_events.actor),


### PR DESCRIPTION
`spec-112` ac-22's second auto-resolve trigger — the one that closes the **bug → failing-AC → green-AC → resolved** loop from the ingest path — has been **dead in production**. Measured: the chain returns empty for **99.96% of passing events** (`issue-6`).

## It is not a broken chain, and not a tuning problem

`processOneEvent` calls `maybeAutoResolveIssuesForAcUid`, whose *first* statement is a `documents ⋈ memexes ⋈ namespaces` lookup. `documents` carries `documents_memex_isolation` on `app.memex_id`. And **`runWithMemexId` appeared nowhere in `routes/test-events.ts`**.

Under the non-owner runtime role that lookup is filtered to zero rows, so the chain concludes "nothing to resolve" — every single time.

## Three layers of silence hid it, each individually reasonable

| | |
|---|---|
| the call is best-effort by design (`.catch(() => {})`) | so a CI result write can never fail — nothing surfaces |
| the owner role bypasses RLS (std-36: ENABLE, never FORCE) | so dev and the default suite **cannot reproduce it** |
| the tenant-context guard built for this class watches **writes** | this is a **read** — it never fired |

A context-less *write* is rejected by Postgres and made loud. A context-less *read* just returns **fewer rows**, which every caller reads as "nothing to do".

## The fix

Wrap the call in `runWithMemexId(targetMemexId, …)` — the memexId the request has already authenticated against.

**And harden the best-effort contract while here.** The old form was `await f(x).catch(() => {})`, which covers a *rejection* but not a **synchronous throw**. Demonstrated accidentally mid-build: a missing import turned every passing emission into a **500**. Now a `try/catch`, so best-effort holds against both failure shapes.

## Proof

A new `*.rls-restricted.test.ts`, running as `memex_app` — the real NOBYPASSRLS runtime role — **because the default owner-connection suite cannot show this defect at all**.

- **DIAGNOSIS** (passes either way; pins *why* the fix is what it is): without context the chain finds nothing though the Issue is resolvable; with context the same call resolves the same Issue from the same row. Without this, a future reader could conclude the chain is simply broken and rewrite the wrong thing.
- **THE FIX** (red→green): a passing emission through `POST /api/test-events` leaves the converted Issue `resolved`. Asserts the **row**, not the status code — nothing in the response ever differed.
- **The event still lands**, so the fix cannot have cost the write.

## Two traps this cost me, both now written into the test

- Reading `documents.handle` back **outside** the wrapper crashed on `undefined`. The test fell into the very defect it exists to pin — which is how easy this class is to reintroduce.
- `runWithMemexId(id, () => db.select(...))` returns the **query builder**; `AsyncLocalStorage.run()` has already returned by the time the outer `await` executes it, so the query runs **outside** the context. The callback must be `async` to keep execution in the subtree.

## Second instance of a class spec-440 was meant to close

spec-440 t-6 fixed this exact shape in `markPresent` and shipped the write-side guard. **The class is not closed for reads.** Recorded on spec-440 (`c-2`) with three options and the cheap grep-based audit that would size the remaining exposure — no build proposed there, it is in `verify` and the call is its owner's.

## Why ac-32 is new

`ac-22` bundled this property with the **rollup table's** RLS posture. The rollup does not exist yet — it is t-9, held behind spec-525's shadow window until after t-10. Proving the achievable half would have flipped ac-22 green on a weaker property than it states. ac-22 keeps the rollup claim; **ac-32** carries this one.

## Test plan

- [x] RLS restricted-role suite: **10/10** (`test:rls`), red→green on the route assertion
- [x] `make check`, `make typecheck` clean
- [x] Full server suite: **6 161 passed / 1 failed** — `.ee/slack/oauth.test.ts`, the documented local-red / CI-green case, untouched here
- [ ] `make e2e-cold` not run locally — no user-facing flow change; `e2e-result` is the gate

## Window safety (spec-532)

This changes **no per-event write cost**. It adds a tenant GUC to a call that already ran on every passing event, and makes three previously-filtered SELECTs actually return rows on the **0.04%** of events that have an Issue to resolve. spec-532 names this explicitly as safe during spec-525's shadow window.