### PR TITLE
feat(spec-530): a proposal can be accepted — one verb, one transaction (t-4, t-5)

### DIFF
--- a/packages/server/src/__regression__/mutate-coverage.endpoint.regression.test.ts
+++ b/packages/server/src/__regression__/mutate-coverage.endpoint.regression.test.ts
@@ -196,6 +196,21 @@ const MUTATING_MCP_TOOLS: Record<string, ToolMutation[]> = {
     { entity: "comment", action: "created" },
     { entity: "standard_drift", action: "created" },
   ],
+  // spec-530 t-4 (dec-4): the accept applies a SET of clause operations and resolves
+  // the proposal in ONE transaction, so it emits a composite — one event per clause
+  // touched (the action depends on the operation kind, so all three appear here), the
+  // `section` updated for the regenerated rule text, and the `comment` +
+  // `standard_drift` pair that clears the Inbox row and the drift-count chip. A silent
+  // accept is the same defect as the one this Spec fixes: the work happened and the
+  // surface still says it did not (ac-12).
+  accept_standard_change: [
+    { entity: "clause", action: "created" },
+    { entity: "clause", action: "updated" },
+    { entity: "clause", action: "deleted" },
+    { entity: "section", action: "updated" },
+    { entity: "comment", action: "updated" },
+    { entity: "standard_drift", action: "updated" },
+  ],
 };
 
 describe("doc-16 t-11 / spec-156 ac-25: endpoint coverage — every mutation entry point is registered", () => {

--- a/packages/server/src/__regression__/ref-emission.regression.test.ts
+++ b/packages/server/src/__regression__/ref-emission.regression.test.ts
@@ -37,7 +37,7 @@ import {
 } from "../db/schema.js";
 import { makeTestMemex } from "../services/test-helpers.js";
 import { createDocDraft } from "../services/documents.js";
-import { createStandard } from "../services/standards.js";
+import { createStandard, proposeStandardChange } from "../services/standards.js";
 import { createClause } from "../services/clauses.js";
 import { createIssue } from "../services/issues.js";
 import { addSection } from "../services/sections.js";
@@ -276,6 +276,10 @@ describe("regression: every entity-acting MCP tool emits `ref:` and no raw UUID 
   let driftSectionRef: string;
   let proposeSectionRef: string;
   let proposeClauseRef: string;
+  // spec-530 t-4: accept_standard_change needs an OPEN proposal to apply. Authored in
+  // beforeAll (not by the propose probe) so its comment seq is stable regardless of
+  // which probes run or in what order.
+  let acceptCommentRef: string;
 
   beforeAll(async () => {
     memexId = await makeTestMemex("ref-emit");
@@ -408,6 +412,7 @@ describe("regression: every entity-acting MCP tool emits `ref:` and no raw UUID 
       sections: [
         { sectionType: "rule-drift", content: "Original rule body for drift probe." },
         { sectionType: "rule-propose", content: "Original rule body for propose probe." },
+        { sectionType: "rule-accept", content: "Original rule body for accept probe." },
       ],
     });
     cleanup.docs.push(std.id);
@@ -423,6 +428,18 @@ describe("regression: every entity-acting MCP tool emits `ref:` and no raw UUID 
       "RefEmit: original rule body.",
     );
     proposeClauseRef = `${stdBase}/clauses/cl-${probeClause.seq}`;
+    // spec-530 t-4: an open proposal on its own section, for the accept probe.
+    const acceptClause = await createClause(
+      memexId,
+      std.sections.find((s) => s.sectionType === "rule-accept")!.id,
+      "RefEmit: rule body to be accepted.",
+    );
+    const acceptProposal = await proposeStandardChange(
+      memexId,
+      [{ op: "edit", clauseId: acceptClause.id, after: "RefEmit: accepted rule body." }],
+      "refemit accept rationale",
+    );
+    acceptCommentRef = `${stdBase}/comments/c-${acceptProposal.comment.seq}`;
   });
 
   // Build the per-tool case registry. One per shared spec that emits a
@@ -717,6 +734,12 @@ describe("regression: every entity-acting MCP tool emits `ref:` and no raw UUID 
             ],
             rationale: "refemit rationale",
           }),
+        },
+      ],
+      [
+        "accept_standard_change",
+        {
+          input: () => ({ ref: acceptCommentRef }),
         },
       ],
     ]);

--- a/packages/server/src/agent/accept-mode-gate.spec-530.test.ts
+++ b/packages/server/src/agent/accept-mode-gate.spec-530.test.ts
@@ -1,0 +1,60 @@
+// spec-530 t-4 (dec-4, ac-13) — the apply verb is reachable from exactly the two agents
+// that handle Standards, and REFUSED everywhere else.
+//
+// std-38 is explicit that authoring scope is enforced server-side, not by prompt: the
+// `/tools/execute` route consults `isToolAllowedInMode` before running anything, so a
+// scoped mode that does not own a verb is refused there — not merely denied the tool
+// definition. Hiding a tool from the model is a hint; the gate is the enforcement.
+//
+// This matters more for this verb than for most: it is the one call that rewrites a
+// Standard's rule text and closes the proposal in the same breath.
+
+import { describe, it, expect } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { getToolDefinitions, isToolAllowedInMode, type AgentMode } from "./tools.js";
+
+const AC_13 = "mindset-prod/memex-building-itself/specs/spec-530/acs/ac-13";
+
+const VERB = "accept_standard_change";
+
+/** Every scoped mode that must NOT be able to accept a Standard change. */
+const FOREIGN_MODES: Exclude<AgentMode, "spec">[] = ["scaffold", "issues", "skills"];
+
+describe("spec-530 ac-13: accept_standard_change is scoped to the Standards agents", () => {
+  it("is offered to the drift and standards modes", () => {
+    tagAc(AC_13);
+    for (const mode of ["drift", "standards"] as const) {
+      const names = getToolDefinitions({ mode }).map((t) => t.name);
+      expect(names, `${mode} mode should offer ${VERB}`).toContain(VERB);
+    }
+  });
+
+  it("is REFUSED by the gate predicate for every other scoped mode, not just hidden", () => {
+    tagAc(AC_13);
+    for (const mode of FOREIGN_MODES) {
+      // The definition filter — what the model can see.
+      expect(getToolDefinitions({ mode }).map((t) => t.name), `${mode} definitions`).not.toContain(
+        VERB,
+      );
+      // The authoritative gate — what /tools/execute will actually run. A model that
+      // learned the name from anywhere else (a cached surface, a pasted transcript)
+      // still cannot execute it here [per std-38].
+      expect(isToolAllowedInMode(mode, VERB), `${mode} gate`).toBe(false);
+    }
+  });
+
+  it("permits it in the two owning modes at the gate", () => {
+    tagAc(AC_13);
+    expect(isToolAllowedInMode("drift", VERB)).toBe(true);
+    expect(isToolAllowedInMode("standards", VERB)).toBe(true);
+  });
+
+  it("is available on the unrestricted spec surface, like every other server tool", () => {
+    tagAc(AC_13);
+    // `spec` (and an absent mode) is governed by phase / reviewer gates rather than a
+    // mode subset — asserted so a later reader does not mistake its presence there for
+    // a leak in the scoped-mode wall.
+    expect(isToolAllowedInMode("spec", VERB)).toBe(true);
+    expect(isToolAllowedInMode(undefined, VERB)).toBe(true);
+  });
+});

--- a/packages/server/src/agent/handlers/standards.ts
+++ b/packages/server/src/agent/handlers/standards.ts
@@ -16,6 +16,7 @@ import {
   proposeStandardChange,
   type ProposalOperationInput,
 } from "../../services/standards.js";
+import { acceptStandardChange } from "../../services/standard-accept.js";
 import {
   createDocDraft,
 } from "../../services/documents.js";
@@ -251,6 +252,68 @@ export const standardsTools: ToolSpec[] = [
       return commentRef
         ? `Proposed change recorded on ${result.standard.handle} section "${sectionLabel}" (ref: ${commentRef}).`
         : `Proposed change recorded on ${result.standard.handle} section "${sectionLabel}".`;
+    },
+  },
+  {
+    // spec-530 t-4 (dec-4): the transactional apply verb. It takes the proposal's
+    // comment ref and NOTHING else — no bodies, no targets, no override (ac-11).
+    // The proposal already carries what will be applied, so the agent cannot apply
+    // something other than what the human reviewed. That is deliberate: the agent's
+    // role here is judgement plus one gated call, not authorship.
+    name: "accept_standard_change",
+    annotations: { title: "Accept Standard change", readOnlyHint: false, destructiveHint: false },
+    description:
+      "Accept an open proposal (a `plan_revision` comment) and apply it to the Standard. Pass ONLY the proposal's comment ref — the proposal already carries which clauses change and what they should say, so there is nothing else to supply and no way to apply something different from what was proposed. Every clause operation lands, or none does, and the proposal is resolved 'accepted' in the same transaction. " +
+      "If the rule text changed after the proposal was written, this REFUSES rather than overwriting that change, and names the clause and what it now says — relay that to the user and offer to re-propose against the current rule. " +
+      "Propose this through `render_confirmation` FIRST, showing what will change; never apply until the user confirms. To REJECT instead, leave the rule alone and resolve the comment with `update_comment` (status `resolved`, resolution `'rejected'`).",
+    schema: {
+      ref: z
+        .string()
+        .describe(
+          "Canonical ref to the proposal comment, e.g. `<ns>/<mx>/standards/std-7/comments/c-3` — the ref `list_comments` emits for a plan_revision. NOT a UUID.",
+        ),
+      verbose: VERBOSE_FIELD,
+    },
+    async handler(input, ctx) {
+      const ref = input.ref as string;
+
+      // std-10: the comment is addressed by its canonical c-N ref; resolveRefArg
+      // rejects a raw UUID at the boundary.
+      const resolved = await resolveRefArg(ctx, ref);
+      if (resolved.entity.kind !== "comment") {
+        throw new ValidationError(
+          `accept_standard_change takes a proposal comment ref (c-N); got ${resolved.entity.kind} for "${ref}".`,
+        );
+      }
+      // spec-156 W2 (FINDING 3): thread the invoking surface so the rule change is
+      // attributed to the actor (mcp vs in_app_agent) rather than defaulting to
+      // channel 'server' [per std-32] — "who accepted this rule change" is exactly
+      // the question the activity contract exists to answer (ac-20).
+      const result = await acceptStandardChange(
+        resolved.memexId,
+        resolved.entity.row.id,
+        reqCtx(ctx),
+      );
+
+      // b-36 D-8: lead with the canonical `ref:` of the resolved proposal, never a
+      // raw UUID.
+      const slugs = await memexSlugsById(resolved.memexId);
+      const commentRef = slugs
+        ? buildChildRef(slugs, result.standard, { type: "comments", seq: result.comment.seq })
+        : null;
+      const sectionLabel = result.section.title ?? result.section.sectionType;
+      const opCount = `${result.applied} clause operation${result.applied === 1 ? "" : "s"}`;
+      if (ctx.verbose) {
+        const state = await fullDocState(resolved.memexId, result.standard.id);
+        const url = await ctx.workspaceUrl(resolved.memexId);
+        const head = commentRef
+          ? `Proposal accepted — applied ${opCount} to ${result.standard.handle} section "${sectionLabel}" (ref: ${commentRef}).`
+          : `Proposal accepted — applied ${opCount} to ${result.standard.handle} section "${sectionLabel}".`;
+        return `${head}\n\n${await formatState(url, state, ctx)}`;
+      }
+      return commentRef
+        ? `Proposal accepted — applied ${opCount} to ${result.standard.handle} section "${sectionLabel}" (ref: ${commentRef}).`
+        : `Proposal accepted — applied ${opCount} to ${result.standard.handle} section "${sectionLabel}".`;
     },
   },
   // (search_standards spec deleted by b-34 T-5 — replaced by the live

--- a/packages/server/src/agent/tool-specs.audit.integration.test.ts
+++ b/packages/server/src/agent/tool-specs.audit.integration.test.ts
@@ -35,7 +35,7 @@ import {
 } from "../db/schema.js";
 import { makeTestMemex } from "../services/test-helpers.js";
 import { createDocDraft } from "../services/documents.js";
-import { createStandard } from "../services/standards.js";
+import { createStandard, proposeStandardChange } from "../services/standards.js";
 import { createClause } from "../services/clauses.js";
 import { createIssue } from "../services/issues.js";
 import { addSection } from "../services/sections.js";
@@ -857,6 +857,10 @@ describe("audit: b-36 D-8 — every terse mutation/list response emits `ref:` an
   let driftSectionRef: string;
   let proposeSectionRef: string;
   let proposeClauseRef: string;
+  // spec-530 t-4: accept_standard_change needs an OPEN proposal to apply. Authored in
+  // beforeAll (not by the propose probe) so its comment seq is stable regardless of
+  // which probes run or in what order.
+  let acceptCommentRef: string;
 
   beforeAll(async () => {
     memexId = await makeTestMemex("probe-ref");
@@ -999,6 +1003,7 @@ describe("audit: b-36 D-8 — every terse mutation/list response emits `ref:` an
       sections: [
         { sectionType: "rule-drift", content: "Original rule body for drift probe." },
         { sectionType: "rule-propose", content: "Original rule body for propose probe." },
+        { sectionType: "rule-accept", content: "Original rule body for accept probe." },
       ],
     });
     cleanup.docs.push(std.id);
@@ -1014,6 +1019,18 @@ describe("audit: b-36 D-8 — every terse mutation/list response emits `ref:` an
       "Original rule body for propose probe.",
     );
     proposeClauseRef = `${stdBase}/clauses/cl-${probeClause.seq}`;
+    // spec-530 t-4: an open proposal on its own section, for the accept probe.
+    const acceptClause = await createClause(
+      memexId,
+      std.sections.find((s) => s.sectionType === "rule-accept")!.id,
+      "Probe: rule body to be accepted.",
+    );
+    const acceptProposal = await proposeStandardChange(
+      memexId,
+      [{ op: "edit", clauseId: acceptClause.id, after: "Probe: accepted rule body." }],
+      "probe accept rationale",
+    );
+    acceptCommentRef = `${stdBase}/comments/c-${acceptProposal.comment.seq}`;
   });
 
   type ProbeCase = {
@@ -1357,6 +1374,12 @@ describe("audit: b-36 D-8 — every terse mutation/list response emits `ref:` an
             ],
             rationale: "probe rationale",
           }),
+        },
+      ],
+      [
+        "accept_standard_change",
+        {
+          input: () => ({ ref: acceptCommentRef }),
         },
       ],
     ]);

--- a/packages/server/src/agent/tools.drift-mode.test.ts
+++ b/packages/server/src/agent/tools.drift-mode.test.ts
@@ -23,6 +23,10 @@ const AC_DRIFT_MECHANISM =
 const EXPECTED_DRIFT_SERVER_TOOLS = [
   "flag_drift",
   "propose_standard_change",
+  // spec-530 t-4 (dec-4): applying an accepted proposal is ONE server verb, not a
+  // sequence the agent performs. The Drift Inbox has no action controls (spec-143
+  // dec-3), so this conversation is the only path a user can accept from.
+  "accept_standard_change",
   "search_memex",
   "get_doc",
   // spec-143: the drift agent can now HANDLE drift, not just report it —

--- a/packages/server/src/agent/tools.mode-map.test.ts
+++ b/packages/server/src/agent/tools.mode-map.test.ts
@@ -57,6 +57,8 @@ const READ_BASE = ["search_memex", "get_doc"];
 // along on top and are asserted separately).
 const EXPECTED: Record<Exclude<AgentMode, "spec">, string[]> = {
   drift: [
+    // spec-530 t-4 (ac-13): the apply verb lives in BOTH Standards-handling modes.
+    "accept_standard_change",
     "flag_drift",
     "propose_standard_change",
     "search_memex",
@@ -84,6 +86,8 @@ const EXPECTED: Record<Exclude<AgentMode, "spec">, string[]> = {
     "edit_clause",
     "delete_clause",
     "propose_standard_change",
+    // spec-530 t-4 (ac-13): both agents that handle Standards own the apply verb.
+    "accept_standard_change",
     "flag_drift",
   ],
   issues: [

--- a/packages/server/src/agent/tools.ts
+++ b/packages/server/src/agent/tools.ts
@@ -454,6 +454,11 @@ export function isReadOnlyTool(name: string): boolean {
 const DRIFT_SERVER_TOOLS = new Set<string>([
   "flag_drift",
   "propose_standard_change",
+  // spec-530 t-4 (dec-4/ac-13): the apply verb. The drift agent is the surface a
+  // user accepts a proposal FROM — the Drift Inbox has no action controls
+  // (spec-143 dec-3), so this conversation is the only path. Presence here is the
+  // definition filter; /tools/execute is the authoritative gate [per std-38].
+  "accept_standard_change",
   "search_memex",
   "get_doc",
   "list_comments",
@@ -502,6 +507,9 @@ const STANDARDS_SERVER_TOOLS = new Set<string>([
   "edit_clause",
   "delete_clause",
   "propose_standard_change",
+  // spec-530 t-4 (dec-4/ac-13): both agents that handle Standards own the apply
+  // verb — the standards agent authors rules, so it accepts corrections to them too.
+  "accept_standard_change",
   "flag_drift",
 ]);
 

--- a/packages/server/src/routes/drift-accept-route.spec-530.test.ts
+++ b/packages/server/src/routes/drift-accept-route.spec-530.test.ts
@@ -1,0 +1,78 @@
+// spec-530 t-4 / dec-6 (ac-24) — there is exactly ONE way to accept a proposal, and no
+// mounted surface that pretends to be another.
+//
+// `POST /api/drift/proposals/:commentId/accept` was built as spec-63's t-12. It applied
+// a proposal with `updateSection`, which has thrown on every Standard since spec-161
+// made them clause-backed — and a `plan_revision` only ever exists on a Standard. So it
+// could not succeed on any real proposal, and no client ever called it (spec-143 dec-3
+// removed the buttons that used to).
+//
+// A reachable endpoint that always throws is the same defect this whole Spec exists to
+// fix, in a different medium: it looks authoritative, and only running it reveals it is
+// dead. This session nearly reasoned from it — spec-530's own Overview asserted no such
+// route existed, and that had to be corrected in s-3. So the assertion is 404 (route
+// absent), not "refuses with a nice message".
+
+import { describe, it, expect, vi } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+vi.mock("../middleware/session.js", async () => {
+  const { createMiddleware } = await import("hono/factory");
+  return {
+    sessionMiddleware: createMiddleware(async (_c: unknown, next: () => Promise<void>) =>
+      next(),
+    ),
+  };
+});
+
+import driftRouter from "./drift.js";
+import { makeTestAppWithTenant } from "./route-test-helpers.js";
+
+const AC_24 = "mindset-prod/memex-building-itself/specs/spec-530/acs/ac-24";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+function makeApp() {
+  const app = makeTestAppWithTenant({ memexId: "00000000-0000-0000-0000-000000000001" });
+  app.route("/api/drift", driftRouter);
+  return app;
+}
+
+describe("spec-530 dec-6: the dead accept route is gone (ac-24)", () => {
+  it("POST /api/drift/proposals/:id/accept is not routed at all — 404, not 500", async () => {
+    tagAc(AC_24);
+    const res = await makeApp().request(
+      "/api/drift/proposals/11111111-1111-1111-1111-111111111111/accept",
+      { method: "POST" },
+    );
+
+    // 404 means Hono has no handler for the path. A mounted-but-refusing endpoint
+    // would answer 4xx-with-a-body from inside a handler, which is exactly the
+    // misleading state dec-6 removed.
+    expect(res.status).toBe(404);
+  });
+
+  it("no longer imports updateSection — the call that made it dead on arrival", () => {
+    tagAc(AC_24);
+    const source = readFileSync(resolve(HERE, "drift.ts"), "utf8");
+
+    // The import and the CALL are the fingerprints — not the word. The file's header
+    // deliberately still explains what `updateSection` was and why it could never
+    // work, because that history is the reason this route must not come back; an
+    // assertion that forbade the name would delete the explanation along with the bug.
+    expect(source).not.toMatch(/from "\.\.\/services\/sections\.js"/);
+    expect(source).not.toMatch(/\bupdateSection\s*\(/);
+    // And the route registration itself is gone, not merely commented out.
+    expect(source).not.toMatch(/drift\.post\(/);
+  });
+
+  it("GET /api/drift still serves the Inbox — only the accept path was removed", async () => {
+    tagAc(AC_24);
+    const res = await makeApp().request("/api/drift");
+    // Whatever the read path answers (it hits the DB), it must not be "no such route".
+    expect(res.status).not.toBe(404);
+  });
+});

--- a/packages/server/src/routes/drift.ts
+++ b/packages/server/src/routes/drift.ts
@@ -1,34 +1,31 @@
 // GET /api/drift — Standards Drift Inbox endpoint (t-10 of doc-8; scoped to
 // Standards in b-63). Optional `?doc=std-N` narrows to a single standard.
-// POST /api/drift/proposals/:commentId/accept — apply a plan_revision (t-12).
 //
 // The inbox returns every open `drift` and `plan_revision` typed comment on a
 // Standard, with parent doc + section context attached so the React UI can
-// render the inbox in one round-trip.
+// render the inbox in one round-trip. It is READ-ONLY: the Inbox carries no
+// action controls (spec-143 dec-3 removed them deliberately — accepting a
+// proposal is a judgement, not a one-click yes/no).
 //
-// Accepting a proposal: the standard owner clicks Accept on a `plan_revision`
-// comment in the inbox; the server parses the proposed-content fence out of
-// the comment body, updates the section, and resolves the comment in one
-// transaction. Rejecting is just `POST /api/comments/:id/resolve` (existing
-// surface), so we don't add a separate endpoint for that.
+// There is NO accept endpoint here. `POST /proposals/:commentId/accept` existed
+// from spec-63 t-12 until spec-530 dec-6 deleted it: it applied a proposal with
+// `updateSection`, which has thrown on every Standard since spec-161 made them
+// clause-backed, so it could not succeed on any real proposal — and no client
+// ever called it. Accepting goes through `accept_standard_change`
+// (services/standard-accept.ts), which the drift agent calls behind its
+// confirmation gate. If a future Spec revisits spec-143 dec-3 and adds a UI
+// control, it adds an HTTP route THEN, against that verb.
 //
 // Memex scoping is handled by sessionMiddleware (resolves the user's
 // current memex from the session JWT + path-resolved memex);
 // service-layer guards re-assert the memex_id filter in SQL.
 
 import { Hono } from "hono";
-import { eq } from "drizzle-orm";
-import { db } from "../db/connection.js";
-import { docComments } from "../db/schema.js";
 import { sessionMiddleware, type SessionEnv } from "../middleware/session.js";
 import type { MemexResolverEnv } from "../middleware/memex-resolver.js";
 import { requireMemexId } from "./shared.js";
-import { restCtx } from "./_actor-ctx.js";
 import { listDriftInbox } from "../services/drift-inbox.js";
-import { parseProposedChangeBody } from "../services/standards.js";
-import { updateSection } from "../services/sections.js";
-import { resolveComment } from "../services/comments.js";
-import { NotFoundError, ValidationError } from "../types/errors.js";
+import { ValidationError } from "../types/errors.js";
 
 type Env = MemexResolverEnv & SessionEnv;
 const drift = new Hono<Env>();
@@ -47,57 +44,6 @@ drift.get("/", async (c) => {
   }
   const page = await listDriftInbox(memexId, { limit, cursor, docHandle });
   return c.json({ items: page.items, nextCursor: page.nextCursor });
-});
-
-// std-5 exemption: comment-UUID lookup. The memex is derived from the comment
-// entity's FK; the route works at the flat path even when the caller has
-// multiple memberships (the comment row itself ties it to a single memex).
-drift.post("/proposals/:commentId/accept", async (c) => {
-  const memexId = requireMemexId(c);
-  const commentId = c.req.param("commentId");
-
-  const comment = await db.query.docComments.findFirst({
-    where: eq(docComments.id, commentId),
-  });
-  if (!comment || comment.memexId !== memexId) {
-    throw new NotFoundError(`Proposal ${commentId} not found`);
-  }
-  if (comment.commentType !== "plan_revision") {
-    throw new ValidationError(
-      `Comment ${commentId} is a ${comment.commentType} comment, not a plan_revision proposal.`,
-    );
-  }
-  if (comment.resolvedAt) {
-    throw new ValidationError("Proposal is already resolved");
-  }
-  if (!comment.sectionId) {
-    throw new ValidationError(
-      "Proposal isn't anchored to a section — cannot apply.",
-    );
-  }
-
-  const parsed = parseProposedChangeBody(comment.content);
-  if (!parsed) {
-    throw new ValidationError(
-      "Proposal body is missing the proposed-content block; cannot extract replacement text.",
-    );
-  }
-  // spec-530 t-1: this route is dead code and has been since spec-161 made Standards
-  // clause-backed — `updateSection` hard-rejects on a Standard, so the line below
-  // throws for every real proposal, and nothing in the UI calls this endpoint. t-4
-  // settles its fate (delete, or re-point at `accept_standard_change`). Until then,
-  // refuse a clause-grained proposal with a reason instead of feeding it to a call
-  // that cannot work.
-  if (parsed.kind === "clause-ops") {
-    throw new ValidationError(
-      "This proposal is clause-grained. Applying it goes through the accept verb, not this route (spec-530 t-4).",
-    );
-  }
-
-  await updateSection(memexId, comment.sectionId, parsed.proposed);
-  const resolved = await resolveComment(memexId, comment.id, "accepted", restCtx(c));
-
-  return c.json({ ok: true, comment: resolved });
 });
 
 export default drift;

--- a/packages/server/src/services/clause-order.spec-530.integration.test.ts
+++ b/packages/server/src/services/clause-order.spec-530.integration.test.ts
@@ -1,0 +1,154 @@
+// spec-530 t-4 / dec-5 (ac-23) — clause order is a function of the rows, not of query luck.
+//
+// Two defects that compound, registered together as issue-1 during session 1:
+//
+//   1. `createClause` wrote the caller's `position` with no shift, so passing an
+//      OCCUPIED ordinal produced two live rows sharing a position.
+//   2. `liveClausesForSection` ordered by `position` alone, with no tiebreaker, so
+//      tied rows came back in whatever order the scan produced.
+//
+// Together they meant a section's composed text was not a function of its rows:
+// `regenerateSectionContentTx` joins the clauses in that order and writes the result
+// to `doc_sections.content`, so a Standard's rendered rule text could change between
+// two regenerations with no write in between.
+//
+// t-4's anchor→ordinal translation (ac-19) walks into defect 1 on EVERY `add`
+// operation by construction — resolving an anchor to "just before/after cl-N" yields
+// an ordinal that is already occupied; that is what "insert here" means.
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { and, asc, eq, ne } from "drizzle-orm";
+import { db } from "../db/connection.js";
+import { documents, docSections, standardClauses } from "../db/schema.js";
+import { createDocDraft } from "./documents.js";
+import { addSection } from "./sections.js";
+import { createClause, updateClause, deleteClause } from "./clauses.js";
+import { makeTestMemex } from "./test-helpers.js";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+const AC_23 = "mindset-prod/memex-building-itself/specs/spec-530/acs/ac-23";
+
+const createdDocIds: string[] = [];
+let memexId: string;
+
+beforeAll(async () => {
+  memexId = await makeTestMemex("s530ord");
+});
+
+afterAll(async () => {
+  for (const id of createdDocIds) {
+    await db.delete(documents).where(eq(documents.id, id));
+  }
+});
+
+/** A standard section carrying `bodies` as appended clauses — positions 1..N. */
+async function seededSection(bodies: string[]): Promise<{ docId: string; sectionId: string }> {
+  const doc = await createDocDraft(memexId, "Clause Order Standard", "purpose", "standard");
+  createdDocIds.push(doc.id);
+  const section = await addSection(memexId, doc.id, "rule", "");
+  for (const body of bodies) {
+    await createClause(memexId, section.id, body);
+  }
+  return { docId: doc.id, sectionId: section.id };
+}
+
+/** Live clauses as stored, read with an explicit total order so the ASSERTION never
+ *  depends on the very ordering under test. */
+async function liveRows(sectionId: string) {
+  return db
+    .select()
+    .from(standardClauses)
+    .where(and(eq(standardClauses.sectionId, sectionId), ne(standardClauses.status, "deleted")))
+    .orderBy(asc(standardClauses.position), asc(standardClauses.seq));
+}
+
+async function sectionContent(sectionId: string): Promise<string> {
+  const row = await db.query.docSections.findFirst({ where: eq(docSections.id, sectionId) });
+  return row!.content;
+}
+
+describe("spec-530 dec-5: inserting at an occupied ordinal shifts, never ties (ac-23)", () => {
+  it("shifts every live sibling at or after the target ordinal", async () => {
+    tagAc(AC_23);
+    const { sectionId } = await seededSection(["one", "two", "three", "four"]);
+
+    await createClause(memexId, sectionId, "inserted", 2);
+
+    const rows = await liveRows(sectionId);
+    expect(rows.map((r) => r.body)).toEqual(["one", "inserted", "two", "three", "four"]);
+    // Dense and unique — the property that makes "insert before cl-N" mean the same
+    // thing to every caller.
+    expect(rows.map((r) => r.position)).toEqual([1, 2, 3, 4, 5]);
+    expect(new Set(rows.map((r) => r.position)).size).toBe(rows.length);
+  });
+
+  it("composes the section in the shifted order, not the insertion order", async () => {
+    tagAc(AC_23);
+    const { sectionId } = await seededSection(["alpha", "beta"]);
+
+    await createClause(memexId, sectionId, "wedged", 1);
+
+    // The derived content is what a reader of the Standard actually sees.
+    expect(await sectionContent(sectionId)).toBe("wedged\n\nalpha\n\nbeta");
+  });
+
+  it("a soft-deleted clause never consumes an ordinal in the shift", async () => {
+    tagAc(AC_23);
+    const { sectionId } = await seededSection(["keep-1", "doomed", "keep-2"]);
+    const before = await liveRows(sectionId);
+    await deleteClause(memexId, before[1].id);
+
+    // Live rows are now keep-1 (1) and keep-2 (3) — the deleted row froze position 2.
+    await createClause(memexId, sectionId, "inserted", 2);
+
+    const rows = await liveRows(sectionId);
+    expect(rows.map((r) => r.body)).toEqual(["keep-1", "inserted", "keep-2"]);
+    expect(new Set(rows.map((r) => r.position)).size).toBe(rows.length);
+    // And the deleted clause is still absent from the rendered rule.
+    expect(await sectionContent(sectionId)).not.toContain("doomed");
+  });
+
+  it("appending is unaffected — no position supplied still lands last", async () => {
+    tagAc(AC_23);
+    const { sectionId } = await seededSection(["first", "second"]);
+
+    await createClause(memexId, sectionId, "appended");
+
+    const rows = await liveRows(sectionId);
+    expect(rows.map((r) => r.body)).toEqual(["first", "second", "appended"]);
+    expect(rows[2].position).toBe(3);
+  });
+});
+
+describe("spec-530 dec-5: rows already tied compose deterministically (ac-23)", () => {
+  it("orders tied clauses by seq, so composition cannot follow scan order", async () => {
+    tagAc(AC_23);
+    const { docId, sectionId } = await seededSection(["anchor"]);
+
+    // Two live rows sharing position 2 — the state no insert-side fix can retroactively
+    // repair, because it already exists in databases written before dec-5.
+    //
+    // The seqs are deliberately INVERTED relative to insertion order: the row inserted
+    // FIRST carries the HIGHER seq. So heap order (what an untied scan tends to return)
+    // and seq order disagree, and only a real `ORDER BY position, seq` produces the
+    // expected text. Without the tiebreaker this is exactly the coin-flip that let a
+    // Standard's content change with no write behind it.
+    await db.insert(standardClauses).values([
+      { memexId, docId, sectionId, seq: 900, position: 2, body: "should-render-second" },
+    ] as (typeof standardClauses.$inferInsert)[]);
+    await db.insert(standardClauses).values([
+      { memexId, docId, sectionId, seq: 800, position: 2, body: "should-render-first" },
+    ] as (typeof standardClauses.$inferInsert)[]);
+
+    // Force a regeneration through the ordinary path (editing an unrelated clause).
+    const [anchor] = await liveRows(sectionId);
+    await updateClause(memexId, anchor.id, "anchor");
+
+    const content = await sectionContent(sectionId);
+    expect(content).toBe("anchor\n\nshould-render-first\n\nshould-render-second");
+
+    // And it is stable: a second regeneration produces the same bytes.
+    await updateClause(memexId, anchor.id, "anchor");
+    expect(await sectionContent(sectionId)).toBe(content);
+  });
+});

--- a/packages/server/src/services/clauses.ts
+++ b/packages/server/src/services/clauses.ts
@@ -15,7 +15,7 @@
 // never reused). `position` orders clauses within their section for composition; it
 // may move freely and is not the identity.
 
-import { and, asc, eq, ne, sql } from "drizzle-orm";
+import { and, asc, eq, gte, ne, sql } from "drizzle-orm";
 import { db } from "../db/connection.js";
 import { documents, docSections, standardClauses } from "../db/schema.js";
 import type { DocSection, StandardClause } from "../db/schema.js";
@@ -59,12 +59,46 @@ async function loadOwnedClause(memexId: string, clauseId: string): Promise<Stand
   return clause;
 }
 
+// spec-530 dec-5 (ac-23): `position` THEN `seq`. Ordering by position alone left tied
+// rows to scan order, so a section's composed content was not a function of its rows —
+// two regenerations with no write in between could differ. dec-5's shift prevents NEW
+// ties; this tiebreaker is what makes the rows already tied in a production database
+// compose deterministically, which no insert-side fix can reach. `seq` is allocate-once,
+// unique per doc and never resequenced (spec-150 dec-2), so the order is total.
 async function liveClausesForSection(tx: Tx, sectionId: string): Promise<StandardClause[]> {
   return tx
     .select()
     .from(standardClauses)
     .where(and(eq(standardClauses.sectionId, sectionId), ne(standardClauses.status, "deleted")))
-    .orderBy(asc(standardClauses.position));
+    .orderBy(asc(standardClauses.position), asc(standardClauses.seq));
+}
+
+/**
+ * Make room at `fromPosition` by pushing every LIVE sibling at or after it down one.
+ *
+ * spec-530 dec-5 (issue-1, ac-23). Inserting at an occupied ordinal used to simply write
+ * the duplicate, and `add_clause`'s optional `position` makes that reachable by any
+ * caller. t-4's anchor→ordinal translation hits it on every `add` by construction, since
+ * "insert before cl-N" resolves to an ordinal that is by definition already taken.
+ *
+ * Soft-deleted rows are excluded, matching liveClausesForSection's filter: a deleted
+ * clause has no place in the order and must not consume an ordinal.
+ */
+async function shiftPositionsFromTx(
+  tx: Tx,
+  sectionId: string,
+  fromPosition: number,
+): Promise<void> {
+  await tx
+    .update(standardClauses)
+    .set({ position: sql`${standardClauses.position} + 1` })
+    .where(
+      and(
+        eq(standardClauses.sectionId, sectionId),
+        ne(standardClauses.status, "deleted"),
+        gte(standardClauses.position, fromPosition),
+      ),
+    );
 }
 
 async function maxClauseSeqTx(tx: Tx, docId: string): Promise<number> {
@@ -185,6 +219,79 @@ export async function decomposeSection(
   );
 }
 
+// ── Transaction-level primitives ──────────────────────
+//
+// spec-530 t-4: `accept_standard_change` applies a SET of clause operations and resolves
+// the proposal in ONE transaction (dec-4's atomicity property). The public verbs below
+// each open their own `db.transaction`, so calling them in a loop would give N
+// transactions and a Standard that can be left half-rewritten — the exact state ac-10
+// forbids. These primitives are the composable core: they take the caller's `tx`, do no
+// regeneration and no emitting, and leave both to whoever owns the transaction.
+//
+// The public verbs are thin wrappers over them, so there is one implementation of each
+// write rather than a second copy living in the accept path.
+
+/** Insert one clause inside the caller's transaction. Allocates the doc-wide `seq`
+ *  (MAX+1, allocate-once), and for a supplied `position` shifts live siblings out of the
+ *  way first [per dec-5] so ordinals stay unique and dense. No position → append. */
+export async function insertClauseTx(
+  tx: Tx,
+  memexId: string,
+  section: Pick<DocSection, "id" | "docId">,
+  body: string,
+  position?: number,
+): Promise<StandardClause> {
+  const seq = (await maxClauseSeqTx(tx, section.docId)) + 1;
+  let pos: number;
+  if (position === undefined) {
+    pos = (await maxPositionTx(tx, section.id)) + 1;
+  } else {
+    pos = position;
+    await shiftPositionsFromTx(tx, section.id, pos);
+  }
+  const [row] = await tx
+    .insert(standardClauses)
+    .values({ memexId, docId: section.docId, sectionId: section.id, seq, position: pos, body })
+    .returning();
+  await syncClauseRefsTx(tx, row); // spec-179: materialize handle mentions
+  return row;
+}
+
+/** Replace one clause's body inside the caller's transaction. */
+export async function updateClauseBodyTx(
+  tx: Tx,
+  clauseId: string,
+  body: string,
+): Promise<StandardClause> {
+  const [row] = await tx
+    .update(standardClauses)
+    .set({ body, updatedAt: new Date() })
+    .where(eq(standardClauses.id, clauseId))
+    .returning();
+  await syncClauseRefsTx(tx, row); // spec-179: re-derive handle mentions
+  return row;
+}
+
+/** Soft-delete one clause inside the caller's transaction. No resequencing (spec-150
+ *  dec-2): the freed `seq` is frozen and every other `cl-N` handle is untouched. */
+export async function softDeleteClauseTx(
+  tx: Tx,
+  clause: StandardClause,
+): Promise<StandardClause> {
+  const [row] = await tx
+    .update(standardClauses)
+    .set({ status: "deleted", previousStatus: clause.status, updatedAt: new Date() })
+    .where(eq(standardClauses.id, clause.id))
+    .returning();
+  await syncClauseRefsTx(tx, row); // spec-179: soft-deleted clause keeps zero refs
+  return row;
+}
+
+export { regenerateSectionContentTx, liveClausesForSection };
+export type { Tx };
+
+// ── Public verbs ──────────────────────────────────────
+
 /** Append (or insert at `position`) a clause to a decomposed section; regenerate content. */
 export async function createClause(
   memexId: string,
@@ -207,13 +314,7 @@ export async function createClause(
 
   return mutate(ctx, keys, async () =>
     db.transaction(async (tx) => {
-      const seq = (await maxClauseSeqTx(tx, section.docId)) + 1;
-      const pos = position ?? (await maxPositionTx(tx, sectionId)) + 1;
-      const [row] = await tx
-        .insert(standardClauses)
-        .values({ memexId, docId: section.docId, sectionId, seq, position: pos, body })
-        .returning();
-      await syncClauseRefsTx(tx, row); // spec-179: materialize handle mentions
+      const row = await insertClauseTx(tx, memexId, section, body, position);
       await regenerateSectionContentTx(tx, section, actor);
       return row;
     }),
@@ -328,12 +429,7 @@ export async function updateClause(
 
   return mutate(ctx, keys, async () =>
     db.transaction(async (tx) => {
-      const [row] = await tx
-        .update(standardClauses)
-        .set({ body, updatedAt: new Date() })
-        .where(eq(standardClauses.id, clauseId))
-        .returning();
-      await syncClauseRefsTx(tx, row); // spec-179: re-derive handle mentions
+      const row = await updateClauseBodyTx(tx, clauseId, body);
       await regenerateSectionContentTx(tx, section, actor);
       return row;
     }),
@@ -368,12 +464,7 @@ export async function deleteClause(
 
   return mutate(ctx, keys, async () =>
     db.transaction(async (tx) => {
-      const [row] = await tx
-        .update(standardClauses)
-        .set({ status: "deleted", previousStatus: clause.status, updatedAt: new Date() })
-        .where(eq(standardClauses.id, clauseId))
-        .returning();
-      await syncClauseRefsTx(tx, row); // spec-179: soft-deleted clause keeps zero refs
+      const row = await softDeleteClauseTx(tx, clause);
       await regenerateSectionContentTx(tx, section, actor);
       return row;
     }),

--- a/packages/server/src/services/standard-accept-atomicity.spec-530.integration.test.ts
+++ b/packages/server/src/services/standard-accept-atomicity.spec-530.integration.test.ts
@@ -1,0 +1,149 @@
+// spec-530 t-4 (dec-4, ac-10) — the accept is all-or-nothing.
+//
+// This is the property the two-call, agent-orchestrated alternative could not hold, and
+// dec-1 is what made it matter: a proposal is a SET, so "two calls" would have been
+// "N+1 calls". An interruption partway would leave a Standard half-rewritten with its
+// proposal still open — a state indistinguishable, to the next reader, from one not yet
+// applied. One transaction removes that state rather than asking anyone to reason about it.
+//
+// Isolated in its own file because it mocks the clause-write module, and a module mock
+// applies to every test in the file it lives in [per std-37: restore global stubs].
+
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+import { and, asc, eq, ne } from "drizzle-orm";
+
+// The failure is injected at the clause-write seam: the SECOND body write in a run
+// throws, standing in for any mid-transaction fault (a constraint violation, a dropped
+// connection, a deploy restarting the process). What matters is not which fault it is,
+// but that the operations already applied do not survive it.
+let bodyWriteCalls = 0;
+let failOnBodyWrite: number | null = null;
+
+vi.mock("./clauses.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./clauses.js")>();
+  return {
+    ...actual,
+    updateClauseBodyTx: async (
+      ...args: Parameters<typeof actual.updateClauseBodyTx>
+    ): ReturnType<typeof actual.updateClauseBodyTx> => {
+      bodyWriteCalls += 1;
+      if (failOnBodyWrite !== null && bodyWriteCalls === failOnBodyWrite) {
+        throw new Error("injected mid-transaction fault");
+      }
+      return actual.updateClauseBodyTx(...args);
+    },
+  };
+});
+
+const { db } = await import("../db/connection.js");
+const { documents, docComments, docSections, standardClauses } = await import("../db/schema.js");
+const { createStandard, proposeStandardChange } = await import("./standards.js");
+const { addClausesToSection } = await import("./clauses.js");
+const { acceptStandardChange } = await import("./standard-accept.js");
+const { makeTestMemex } = await import("./test-helpers.js");
+const { tagAc } = await import("@memex-ai-ac/vitest");
+
+const AC_10 = "mindset-prod/memex-building-itself/specs/spec-530/acs/ac-10";
+
+const createdDocIds: string[] = [];
+let memexId: string;
+
+beforeAll(async () => {
+  memexId = await makeTestMemex("s530atom");
+});
+
+afterAll(async () => {
+  failOnBodyWrite = null;
+  vi.restoreAllMocks();
+  for (const id of createdDocIds) {
+    await db.delete(documents).where(eq(documents.id, id)).catch(() => {});
+  }
+});
+
+async function liveBodies(sectionId: string): Promise<string[]> {
+  const rows = await db
+    .select()
+    .from(standardClauses)
+    .where(and(eq(standardClauses.sectionId, sectionId), ne(standardClauses.status, "deleted")))
+    .orderBy(asc(standardClauses.position), asc(standardClauses.seq));
+  return rows.map((r) => r.body);
+}
+
+describe("spec-530 ac-10: a failure mid-set leaves the Standard exactly as it was", () => {
+  it("forced failure on operation 2 of 3 applies NOTHING and leaves the proposal open", async () => {
+    tagAc(AC_10);
+    const std = await createStandard(memexId, {
+      title: "Atomicity Target Standard",
+      sections: [{ sectionType: "rule", content: "" }],
+    });
+    createdDocIds.push(std.id);
+    const sectionId = std.sections[0].id;
+    const clauses = await addClausesToSection(memexId, sectionId, [
+      { body: "one", facets: [] },
+      { body: "two", facets: [] },
+      { body: "three", facets: [] },
+    ]);
+
+    const proposal = await proposeStandardChange(memexId, [
+      { op: "edit", clauseId: clauses[0].id, after: "one-changed" },
+      { op: "edit", clauseId: clauses[1].id, after: "two-changed" },
+      { op: "edit", clauseId: clauses[2].id, after: "three-changed" },
+    ]);
+
+    const contentBefore = (
+      await db.query.docSections.findFirst({ where: eq(docSections.id, sectionId) })
+    )!.content;
+
+    bodyWriteCalls = 0;
+    failOnBodyWrite = 2; // operation 2 of 3
+
+    await expect(acceptStandardChange(memexId, proposal.comment.id)).rejects.toThrow(
+      /injected mid-transaction fault/,
+    );
+    failOnBodyWrite = null;
+
+    // Operation 1 DID execute before the fault — and it is gone. That is the whole
+    // claim: clause 1 is byte-identical to its pre-call state, not "one-changed".
+    expect(await liveBodies(sectionId)).toEqual(["one", "two", "three"]);
+    expect(
+      (await db.query.docSections.findFirst({ where: eq(docSections.id, sectionId) }))!.content,
+    ).toBe(contentBefore);
+
+    // And the proposal is still open, so the Standard and its Inbox agree about what
+    // has happened: nothing.
+    const comment = await db.query.docComments.findFirst({
+      where: eq(docComments.id, proposal.comment.id),
+    });
+    expect(comment!.resolvedAt).toBeNull();
+    expect(comment!.resolution).toBeNull();
+  });
+
+  it("the same proposal applies cleanly once the fault is gone — the rollback lost nothing", async () => {
+    tagAc(AC_10);
+    const std = await createStandard(memexId, {
+      title: "Atomicity Retry Standard",
+      sections: [{ sectionType: "rule", content: "" }],
+    });
+    createdDocIds.push(std.id);
+    const sectionId = std.sections[0].id;
+    const clauses = await addClausesToSection(memexId, sectionId, [
+      { body: "alpha", facets: [] },
+      { body: "beta", facets: [] },
+    ]);
+    const proposal = await proposeStandardChange(memexId, [
+      { op: "edit", clauseId: clauses[0].id, after: "alpha-changed" },
+      { op: "edit", clauseId: clauses[1].id, after: "beta-changed" },
+    ]);
+
+    bodyWriteCalls = 0;
+    failOnBodyWrite = 2;
+    await expect(acceptStandardChange(memexId, proposal.comment.id)).rejects.toThrow();
+    failOnBodyWrite = null;
+
+    // A refused accept is not a spent one. The proposal's stored "before" still matches
+    // the live clauses precisely BECAUSE the rollback was total — so dec-3's staleness
+    // guard passes and the retry succeeds.
+    await acceptStandardChange(memexId, proposal.comment.id);
+    expect(await liveBodies(sectionId)).toEqual(["alpha-changed", "beta-changed"]);
+  });
+});

--- a/packages/server/src/services/standard-accept-staleness.spec-530.integration.test.ts
+++ b/packages/server/src/services/standard-accept-staleness.spec-530.integration.test.ts
@@ -1,0 +1,192 @@
+// spec-530 t-5 (dec-3, ac-14/ac-15) — the staleness guard inside the accept.
+//
+// A proposal is a stale read BY NATURE: authored at T0, accepted at T1, possibly days
+// later and possibly after another agent edited the very clause it targets. Applying it
+// blind at T1 discards that intervening edit silently — and "a Standard losing a
+// correction without anyone noticing" is the failure this whole Spec exists to prevent.
+// Fixing the grain while leaving that hole would have traded one silent-loss bug for
+// another.
+//
+// The guard lives in the PROPOSAL (dec-3), not on `edit_clause`: the staleness is the
+// proposal's, so the evidence belongs next to the text a reviewer is already reading,
+// and no other caller's contract moves. dec-4 then gives the comparison exactly one
+// home — inside the accept transaction, with no path that skips it.
+//
+// Separate file from the happy path because this is the SAFETY property, and safety
+// properties that ride along with happy paths are the ones that ship untested.
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { and, asc, eq, ne } from "drizzle-orm";
+import { db } from "../db/connection.js";
+import { documents, docComments, standardClauses } from "../db/schema.js";
+import type { StandardClause } from "../db/schema.js";
+import { createStandard, proposeStandardChange } from "./standards.js";
+import { addClausesToSection, updateClause } from "./clauses.js";
+import { acceptStandardChange } from "./standard-accept.js";
+import { makeTestMemex } from "./test-helpers.js";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+const AC = "mindset-prod/memex-building-itself/specs/spec-530/acs";
+
+const createdDocIds: string[] = [];
+let memexId: string;
+
+beforeAll(async () => {
+  memexId = await makeTestMemex("s530stale");
+});
+
+afterAll(async () => {
+  for (const id of createdDocIds) {
+    await db.delete(documents).where(eq(documents.id, id)).catch(() => {});
+  }
+});
+
+async function seededStandard(bodies: string[]): Promise<{
+  sectionId: string;
+  clauses: StandardClause[];
+}> {
+  const std = await createStandard(memexId, {
+    title: "Staleness Target Standard",
+    sections: [{ sectionType: "rule", content: "" }],
+  });
+  createdDocIds.push(std.id);
+  const sectionId = std.sections[0].id;
+  const clauses = await addClausesToSection(
+    memexId,
+    sectionId,
+    bodies.map((body) => ({ body, facets: [] })),
+  );
+  return { sectionId, clauses: [...clauses] };
+}
+
+async function liveBodies(sectionId: string): Promise<string[]> {
+  const rows = await db
+    .select()
+    .from(standardClauses)
+    .where(and(eq(standardClauses.sectionId, sectionId), ne(standardClauses.status, "deleted")))
+    .orderBy(asc(standardClauses.position), asc(standardClauses.seq));
+  return rows.map((r) => r.body);
+}
+
+async function isOpen(commentId: string): Promise<boolean> {
+  const row = await db.query.docComments.findFirst({ where: eq(docComments.id, commentId) });
+  return row!.resolvedAt === null;
+}
+
+describe("spec-530 ac-14: accepting a stale proposal cannot discard someone else's edit", () => {
+  it("refuses, and the clause still holds the intervening edit byte-identical", async () => {
+    tagAc(`${AC}/ac-14`);
+    tagAc(`${AC}/ac-3`); // scope: the outcome this mechanism delivers
+    const { sectionId, clauses } = await seededStandard(["cache all writes"]);
+
+    // T0 — the proposal is authored against what the rule says today.
+    const proposal = await proposeStandardChange(memexId, [
+      { op: "edit", clauseId: clauses[0].id, after: "cache all writes, including PUT" },
+    ]);
+
+    // Between T0 and T1 someone else corrects the same clause. This is the edit that
+    // must survive.
+    const intervening = "cache all writes except mutating endpoints";
+    await updateClause(memexId, clauses[0].id, intervening);
+
+    // T1 — the accept must fail loudly rather than overwrite.
+    await expect(acceptStandardChange(memexId, proposal.comment.id)).rejects.toThrow(
+      /changed after this proposal was written/i,
+    );
+
+    expect(await liveBodies(sectionId)).toEqual([intervening]);
+    expect(await isOpen(proposal.comment.id)).toBe(true);
+  });
+
+  it("refuses on a WHITESPACE-only divergence too — exactness is the point", async () => {
+    tagAc(`${AC}/ac-14`);
+    const { sectionId, clauses } = await seededStandard(["never log secrets"]);
+    const proposal = await proposeStandardChange(memexId, [
+      { op: "edit", clauseId: clauses[0].id, after: "never log secrets or tokens" },
+    ]);
+
+    // A trailing space is a real difference. A "close enough" comparison would reopen
+    // the silent-overwrite class this guard exists to close, and the cost of a false
+    // refusal is one re-proposal — deliberately the cheaper failure (dec-3).
+    const nudged = "never log secrets ";
+    await updateClause(memexId, clauses[0].id, nudged);
+
+    await expect(acceptStandardChange(memexId, proposal.comment.id)).rejects.toThrow();
+    expect(await liveBodies(sectionId)).toEqual([nudged]);
+  });
+
+  it("applies normally when nothing moved — the guard is not a general obstacle", async () => {
+    tagAc(`${AC}/ac-14`);
+    const { sectionId, clauses } = await seededStandard(["retry idempotent calls"]);
+    const proposal = await proposeStandardChange(memexId, [
+      { op: "edit", clauseId: clauses[0].id, after: "retry idempotent calls up to 3 times" },
+    ]);
+
+    await acceptStandardChange(memexId, proposal.comment.id);
+
+    expect(await liveBodies(sectionId)).toEqual(["retry idempotent calls up to 3 times"]);
+    expect(await isOpen(proposal.comment.id)).toBe(false);
+  });
+
+  it("guards DELETE operations, not only edits", async () => {
+    tagAc(`${AC}/ac-14`);
+    const { sectionId, clauses } = await seededStandard(["obsolete rule", "keeper"]);
+    const proposal = await proposeStandardChange(memexId, [
+      { op: "delete", clauseId: clauses[0].id },
+    ]);
+
+    // The clause someone thought was obsolete has since been rewritten into something
+    // current. Deleting it now would discard that work with no trace.
+    await updateClause(memexId, clauses[0].id, "rule, now rewritten and current");
+
+    await expect(acceptStandardChange(memexId, proposal.comment.id)).rejects.toThrow(
+      /changed after this proposal was written/i,
+    );
+    expect(await liveBodies(sectionId)).toEqual(["rule, now rewritten and current", "keeper"]);
+  });
+});
+
+describe("spec-530 ac-15: one stale operation refuses the ENTIRE set, actionably", () => {
+  it("applies nothing when only operation 2 of 3 has drifted", async () => {
+    tagAc(`${AC}/ac-15`);
+    const { sectionId, clauses } = await seededStandard(["first", "second", "third"]);
+    const proposal = await proposeStandardChange(memexId, [
+      { op: "edit", clauseId: clauses[0].id, after: "first-changed" },
+      { op: "edit", clauseId: clauses[1].id, after: "second-changed" },
+      { op: "edit", clauseId: clauses[2].id, after: "third-changed" },
+    ]);
+
+    // Only the middle target moves.
+    const drifted = "second, corrected by someone else";
+    await updateClause(memexId, clauses[1].id, drifted);
+
+    await expect(acceptStandardChange(memexId, proposal.comment.id)).rejects.toThrow();
+
+    // A set is ONE reviewed intent. Applying the two clean operations would leave the
+    // Standard saying something no one proposed — worse than the failure it replaces,
+    // because it looks like success.
+    expect(await liveBodies(sectionId)).toEqual(["first", drifted, "third"]);
+    expect(await isOpen(proposal.comment.id)).toBe(true);
+  });
+
+  it("names the drifted clause AND what it now says, so the next move is obvious", async () => {
+    tagAc(`${AC}/ac-15`);
+    const { clauses } = await seededStandard(["alpha", "beta"]);
+    const proposal = await proposeStandardChange(memexId, [
+      { op: "edit", clauseId: clauses[0].id, after: "alpha-changed" },
+      { op: "edit", clauseId: clauses[1].id, after: "beta-changed" },
+    ]);
+
+    const nowReads = "beta, as rewritten by another agent";
+    await updateClause(memexId, clauses[1].id, nowReads);
+
+    // "Conflict" alone fails this criterion: a reviewer would have to go and look. The
+    // refusal has to carry enough to act on — re-propose against the current rule —
+    // without further investigation.
+    const err = await acceptStandardChange(memexId, proposal.comment.id).catch((e: Error) => e);
+    expect(err).toBeInstanceOf(Error);
+    const message = (err as Error).message;
+    expect(message).toContain(`cl-${clauses[1].seq}`);
+    expect(message).toContain(nowReads);
+  });
+});

--- a/packages/server/src/services/standard-accept.spec-530.integration.test.ts
+++ b/packages/server/src/services/standard-accept.spec-530.integration.test.ts
@@ -1,0 +1,380 @@
+// spec-530 t-4 (dec-4) — `accept_standard_change`, the transactional apply verb.
+//
+// Before this, accepting a proposal was impossible: proposals were section-grained and
+// `update_section` hard-rejects on a Standard, so the only instruction the drift agent
+// had was a call that always threw. This suite is the proof the loop closes.
+//
+// The atomicity ROLLBACK case lives in its own file
+// (standard-accept-atomicity.spec-530.integration.test.ts) because it mocks the clause
+// write module, and a module mock leaks across every test in its file [per std-37].
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { and, asc, eq, ne } from "drizzle-orm";
+import { db } from "../db/connection.js";
+import { documents, docComments, docSections, standardClauses, users } from "../db/schema.js";
+import type { StandardClause } from "../db/schema.js";
+import { bus, type ChangeEvent } from "./bus.js";
+import { createStandard, proposeStandardChange } from "./standards.js";
+import { addClausesToSection, createClause } from "./clauses.js";
+import { acceptStandardChange } from "./standard-accept.js";
+import { makeTestMemex } from "./test-helpers.js";
+import type { RequestCtx } from "./mutate.js";
+import { toolSpecs } from "../agent/tool-specs.js";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+const AC = "mindset-prod/memex-building-itself/specs/spec-530/acs";
+
+const createdDocIds: string[] = [];
+const createdUserIds: string[] = [];
+let memexId: string;
+let accepter: { id: string; name: string };
+
+// std-37: per-worker-unique identifiers so parallel workers never collide.
+function uniqueEmail(who: string): string {
+  return `spec530-t4-${who}-${process.env.VITEST_WORKER_ID ?? "0"}-${process.hrtime.bigint()}@example.com`;
+}
+
+beforeAll(async () => {
+  memexId = await makeTestMemex("s530acc");
+  const [row] = await db
+    .insert(users)
+    .values({ email: uniqueEmail("accepter"), name: "Rule Accepter" } as typeof users.$inferInsert)
+    .returning();
+  createdUserIds.push(row.id);
+  accepter = { id: row.id, name: "Rule Accepter" };
+});
+
+afterAll(async () => {
+  for (const id of createdDocIds) {
+    await db.delete(documents).where(eq(documents.id, id)).catch(() => {});
+  }
+  for (const id of createdUserIds) {
+    await db.delete(users).where(eq(users.id, id)).catch(() => {});
+  }
+});
+
+/** ctx as an authenticated in-app agent accept. */
+function accepterCtx(): RequestCtx {
+  return { actorUserId: accepter.id, channel: "in_app_agent" };
+}
+
+/** A Standard with one section carrying `bodies` as ordered clauses. */
+async function seededStandard(bodies: string[]): Promise<{
+  docId: string;
+  sectionId: string;
+  clauses: StandardClause[];
+}> {
+  const std = await createStandard(memexId, {
+    title: "Accept Target Standard",
+    sections: [{ sectionType: "rule", content: "" }],
+  });
+  createdDocIds.push(std.id);
+  const sectionId = std.sections[0].id;
+  const clauses = await addClausesToSection(
+    memexId,
+    sectionId,
+    bodies.map((body) => ({ body, facets: [] })),
+  );
+  return { docId: std.id, sectionId, clauses: [...clauses] };
+}
+
+async function liveRows(sectionId: string): Promise<StandardClause[]> {
+  return db
+    .select()
+    .from(standardClauses)
+    .where(and(eq(standardClauses.sectionId, sectionId), ne(standardClauses.status, "deleted")))
+    .orderBy(asc(standardClauses.position), asc(standardClauses.seq));
+}
+
+async function commentRow(commentId: string) {
+  return db.query.docComments.findFirst({ where: eq(docComments.id, commentId) });
+}
+
+async function sectionRow(sectionId: string) {
+  const row = await db.query.docSections.findFirst({ where: eq(docSections.id, sectionId) });
+  return row!;
+}
+
+async function captureEvents(body: () => Promise<void>): Promise<ChangeEvent[]> {
+  const events: ChangeEvent[] = [];
+  const unsub = bus.subscribe({}, (e) => events.push(e));
+  try {
+    await body();
+  } finally {
+    unsub();
+  }
+  return events;
+}
+
+describe("spec-530 t-4: a proposal is applied and resolved in one operation", () => {
+  it("applies a mixed add/edit/delete set and resolves the comment (ac-10)", async () => {
+    tagAc(`${AC}/ac-10`);
+    const { sectionId, clauses } = await seededStandard(["keep me", "edit me", "delete me"]);
+
+    const proposal = await proposeStandardChange(memexId, [
+      { op: "edit", clauseId: clauses[1].id, after: "edited by the proposal" },
+      { op: "delete", clauseId: clauses[2].id },
+      { op: "add", anchorClauseId: clauses[0].id, placement: "after", body: "added by the proposal" },
+    ]);
+
+    const result = await acceptStandardChange(memexId, proposal.comment.id, accepterCtx());
+
+    expect(result.applied).toBe(3);
+    const rows = await liveRows(sectionId);
+    expect(rows.map((r) => r.body)).toEqual([
+      "keep me",
+      "added by the proposal",
+      "edited by the proposal",
+    ]);
+    // The comment is resolved in the SAME operation — there is no window where the
+    // Standard is rewritten and the proposal still open, or the reverse.
+    const comment = await commentRow(proposal.comment.id);
+    expect(comment!.resolvedAt).not.toBeNull();
+    expect(comment!.resolution).toBe("accepted");
+    // And the derived rule text a reader sees was regenerated from the new row set.
+    expect((await sectionRow(sectionId)).content).toBe(
+      "keep me\n\nadded by the proposal\n\nedited by the proposal",
+    );
+  });
+
+  it("applies exactly the text that was proposed — no argument can change it (ac-11)", async () => {
+    tagAc(`${AC}/ac-11`);
+    const { sectionId, clauses } = await seededStandard(["the original rule"]);
+    const proposedText = "the corrected rule, verbatim — including `~~~` and ``` fences";
+
+    const proposal = await proposeStandardChange(memexId, [
+      { op: "edit", clauseId: clauses[0].id, after: proposedText },
+    ]);
+    await acceptStandardChange(memexId, proposal.comment.id, accepterCtx());
+
+    // What landed is byte-identical to what a human reviewed. That is what makes "the
+    // user approved THIS text" a fact rather than a hope about the agent's fidelity.
+    expect((await liveRows(sectionId))[0].body).toBe(proposedText);
+  });
+
+  it("exposes no body or target parameter on the tool at all (ac-11)", async () => {
+    tagAc(`${AC}/ac-11`);
+    const spec = toolSpecs.find((s) => s.name === "accept_standard_change");
+    expect(spec, "accept_standard_change is not registered").toBeDefined();
+
+    // The whole surface is the proposal ref (+ the shared verbose flag). No `body`, no
+    // `operations`, no `clause` — there is no argument through which a caller could
+    // apply something other than what was proposed and reviewed.
+    expect(Object.keys(spec!.schema).sort()).toEqual(["ref", "verbose"]);
+  });
+
+  it("emits so an open Inbox and the drift-count chip both clear themselves (ac-12)", async () => {
+    tagAc(`${AC}/ac-12`);
+    const { docId, clauses } = await seededStandard(["a rule that will change"]);
+    const proposal = await proposeStandardChange(memexId, [
+      { op: "edit", clauseId: clauses[0].id, after: "the changed rule" },
+    ]);
+
+    const events = await captureEvents(async () => {
+      await acceptStandardChange(memexId, proposal.comment.id, accepterCtx());
+    });
+
+    const mine = events.filter((e) => e.memexId === memexId && e.docId === docId);
+    // The aggregate the StandardList drift-count subscriber watches — mirrors the dual
+    // emit proposeStandardChange already performs. Without it the chip keeps counting a
+    // proposal that is no longer open.
+    expect(mine.some((e) => e.entity === "standard_drift")).toBe(true);
+    // The Inbox row itself.
+    expect(mine.some((e) => e.entity === "comment" && e.action === "updated")).toBe(true);
+    // And the rule text that changed.
+    expect(mine.some((e) => e.entity === "clause" && e.action === "updated")).toBe(true);
+    expect(mine.some((e) => e.entity === "section" && e.action === "updated")).toBe(true);
+  });
+
+  it("attributes the rule change to whoever accepted it, and how (ac-20)", async () => {
+    tagAc(`${AC}/ac-20`);
+    const { sectionId, clauses } = await seededStandard(["unattributed rule"]);
+    const proposal = await proposeStandardChange(memexId, [
+      { op: "edit", clauseId: clauses[0].id, after: "attributed rule" },
+    ]);
+
+    await acceptStandardChange(memexId, proposal.comment.id, accepterCtx());
+
+    // "Who changed this rule, and from where" is precisely the question the activity
+    // contract exists to answer [per std-32 cl-1, cl-3, cl-4], and an accept is the one
+    // mutation where it matters most.
+    const row = await sectionRow(sectionId);
+    expect(row.content).toContain("attributed rule");
+    expect(row.actorUserId).toBe(accepter.id);
+    expect(row.actorName).toBe(accepter.name);
+    expect(row.channel).toBe("in_app_agent");
+  });
+});
+
+describe("spec-530 t-4: adding a clause is proposable, and lands where it was meant to", () => {
+  it("adds a clause that did not exist, with a fresh cl-N, siblings unresequenced (ac-9)", async () => {
+    tagAc(`${AC}/ac-9`);
+    const { sectionId, clauses } = await seededStandard(["first rule", "second rule"]);
+    const seqsBefore = clauses.map((c) => c.seq);
+
+    // "The rule is missing a case" — expressible as a proposal at all only because
+    // dec-1 made a proposal a set of OPERATIONS rather than a single clause edit.
+    const proposal = await proposeStandardChange(memexId, [
+      { op: "add", anchorClauseId: clauses[0].id, placement: "after", body: "the missing case" },
+    ]);
+    await acceptStandardChange(memexId, proposal.comment.id, accepterCtx());
+
+    const rows = await liveRows(sectionId);
+    expect(rows.map((r) => r.body)).toEqual(["first rule", "the missing case", "second rule"]);
+
+    // A FRESH handle, allocate-once — and every pre-existing cl-N is untouched
+    // [per spec-150 dec-2: seq is identity, position is order].
+    const added = rows[1];
+    expect(seqsBefore).not.toContain(added.seq);
+    expect(added.seq).toBeGreaterThan(Math.max(...seqsBefore));
+    const survivingSeqs = rows.filter((r) => r.id !== added.id).map((r) => r.seq);
+    expect(survivingSeqs).toEqual(seqsBefore);
+  });
+
+  it("lands next to its ANCHOR even after a clause was inserted ahead of it (ac-19)", async () => {
+    tagAc(`${AC}/ac-19`);
+    const { sectionId, clauses } = await seededStandard(["alpha", "beta", "gamma"]);
+
+    // Authored when `beta` sat at ordinal 2.
+    const proposal = await proposeStandardChange(memexId, [
+      { op: "add", anchorClauseId: clauses[1].id, placement: "after", body: "after-beta" },
+    ]);
+
+    // Between authoring and accepting, someone inserts a clause AHEAD of the anchor.
+    // Every ordinal after it shifts — so an ordinal captured at authoring time now
+    // points at the wrong place, and nothing would detect that. This is why the
+    // proposal stores an anchor cl-N and the accept resolves it at apply time.
+    await createClause(memexId, sectionId, "wedged-in", 1);
+
+    await acceptStandardChange(memexId, proposal.comment.id, accepterCtx());
+
+    const rows = await liveRows(sectionId);
+    expect(rows.map((r) => r.body)).toEqual([
+      "wedged-in",
+      "alpha",
+      "beta",
+      "after-beta",
+      "gamma",
+    ]);
+    // Had the stored ordinal been used, "after-beta" would have landed at position 3 —
+    // between alpha and beta — silently attaching the new rule to the wrong clause.
+  });
+
+  it("resolves each anchor against the state the EARLIER operations left behind (ac-19)", async () => {
+    tagAc(`${AC}/ac-19`);
+    const { sectionId, clauses } = await seededStandard(["A", "B", "C"]);
+
+    // Two adds in one proposal. The first inserts ahead of the second's anchor, so by
+    // the time operation 2 runs, B has moved — WITHIN this same transaction, after the
+    // pre-flight read. Resolving anchors once up front is not enough; each has to be
+    // read against the rows as they now stand.
+    const proposal = await proposeStandardChange(memexId, [
+      { op: "add", anchorClauseId: clauses[0].id, placement: "after", body: "X" },
+      { op: "add", anchorClauseId: clauses[1].id, placement: "after", body: "Y" },
+    ]);
+    await acceptStandardChange(memexId, proposal.comment.id, accepterCtx());
+
+    expect((await liveRows(sectionId)).map((r) => r.body)).toEqual(["A", "X", "B", "Y", "C"]);
+    // With a stale ordinal for B, Y lands directly after X — ["A","X","Y","B","C"] —
+    // attaching the new rule to the wrong clause with nothing to detect it.
+  });
+
+  it("refuses when the anchor was deleted after authoring, rather than appending (ac-16)", async () => {
+    tagAc(`${AC}/ac-16`);
+    const { sectionId, clauses } = await seededStandard(["anchor rule", "other rule"]);
+    const proposal = await proposeStandardChange(memexId, [
+      { op: "add", anchorClauseId: clauses[0].id, placement: "after", body: "orphaned addition" },
+    ]);
+
+    const anchorHandle = `cl-${clauses[0].seq}`;
+    const { deleteClause } = await import("./clauses.js");
+    await deleteClause(memexId, clauses[0].id);
+
+    // A clause proposed relative to a clause that no longer exists has no defined
+    // position. Guessing (appending to the end) would put a rule somewhere nobody chose.
+    await expect(acceptStandardChange(memexId, proposal.comment.id)).rejects.toThrow(
+      new RegExp(anchorHandle),
+    );
+
+    // And nothing was written.
+    expect((await liveRows(sectionId)).map((r) => r.body)).toEqual(["other rule"]);
+    expect((await commentRow(proposal.comment.id))!.resolvedAt).toBeNull();
+  });
+});
+
+describe("spec-530 t-4: the verb refuses what it cannot honestly apply", () => {
+  it("refuses a proposal that is already resolved", async () => {
+    tagAc(`${AC}/ac-10`);
+    const { clauses } = await seededStandard(["a rule"]);
+    const proposal = await proposeStandardChange(memexId, [
+      { op: "edit", clauseId: clauses[0].id, after: "a corrected rule" },
+    ]);
+    await acceptStandardChange(memexId, proposal.comment.id, accepterCtx());
+
+    // Re-accepting must not apply the same edit twice or silently succeed.
+    await expect(acceptStandardChange(memexId, proposal.comment.id)).rejects.toThrow(
+      /already resolved/i,
+    );
+  });
+
+  it("refuses a legacy whole-section proposal with the reason, never half-applying it (ac-18)", async () => {
+    tagAc(`${AC}/ac-18`);
+    const { sectionId, clauses } = await seededStandard(["a rule with a legacy proposal"]);
+    const proposal = await proposeStandardChange(memexId, [
+      { op: "edit", clauseId: clauses[0].id, after: "irrelevant" },
+    ]);
+
+    // Rewrite the stored body into the PRE-cutover single-fence shape — what a row
+    // written before spec-530 actually looks like (a straggler from a long-running
+    // branch, a restored backup, an environment converted at a different time).
+    await db
+      .update(docComments)
+      .set({
+        content: [
+          "**Proposed change to section [rule]**",
+          "",
+          "legacy rationale",
+          "",
+          "~~~proposed-content",
+          "A whole replacement section body.",
+          "~~~",
+        ].join("\n"),
+      })
+      .where(eq(docComments.id, proposal.comment.id));
+
+    await expect(acceptStandardChange(memexId, proposal.comment.id)).rejects.toThrow(
+      /clause grain/i,
+    );
+    // The rule is untouched and the proposal stays open — one unapplicable row, not a
+    // corrupted Standard.
+    expect((await liveRows(sectionId))[0].body).toBe("a rule with a legacy proposal");
+    expect((await commentRow(proposal.comment.id))!.resolvedAt).toBeNull();
+  });
+
+  it("refuses a comment that is not a proposal at all", async () => {
+    tagAc(`${AC}/ac-10`);
+    const { docId, sectionId } = await seededStandard(["a rule"]);
+    const { flagDrift } = await import("./standards.js");
+    const drift = await flagDrift(memexId, sectionId, "the code diverged from this rule");
+    expect(drift.docId ?? docId).toBeTruthy();
+
+    // A drift observation carries no operations. Applying one is meaningless, and the
+    // refusal says which kind it actually is.
+    await expect(acceptStandardChange(memexId, drift.id)).rejects.toThrow(/not a proposal/i);
+  });
+
+  it("does not find a proposal that belongs to another memex (std-7)", async () => {
+    tagAc(`${AC}/ac-10`);
+    const { clauses } = await seededStandard(["a tenant-scoped rule"]);
+    const proposal = await proposeStandardChange(memexId, [
+      { op: "edit", clauseId: clauses[0].id, after: "changed" },
+    ]);
+    const otherMemexId = await makeTestMemex("s530acc-other");
+
+    // 404-shaped, not 403 — an unauthorized resource is indistinguishable from one that
+    // does not exist [per std-7].
+    await expect(acceptStandardChange(otherMemexId, proposal.comment.id)).rejects.toThrow(
+      /not found/i,
+    );
+  });
+});

--- a/packages/server/src/services/standard-accept.ts
+++ b/packages/server/src/services/standard-accept.ts
@@ -1,0 +1,257 @@
+// spec-530 t-4 (dec-4) — `accept_standard_change`: the transactional apply verb.
+//
+// Accepting a proposal used to be a sequence the AGENT performed. dec-4 made it one
+// server operation, for three reasons the code below is shaped by:
+//
+//   1. ATOMICITY. dec-1 made a proposal a SET of operations, so "two agent calls"
+//      would have been "N+1 agent calls" — an interruption leaving a Standard half
+//      rewritten with its proposal still open, indistinguishable to the next reader
+//      from one not yet applied (ac-10).
+//   2. ONE ENFORCEMENT POINT. dec-3's staleness guard and std-8's emit contract are
+//      each enforced here, once, instead of being re-derived by every caller.
+//   3. CORRECTNESS STOPS LIVING IN THE PROMPT. This Spec exists because a prompt
+//      instructed `update_section` on a Standard — a call that has thrown since
+//      spec-161 — and nothing noticed for months, because nothing executes prose as a
+//      contract. A verb the server owns is testable; a sequence the agent is told to
+//      perform is not.
+//
+// The verb takes the proposal's comment ref and NOTHING else (ac-11): no bodies, no
+// targets, no override. The proposal already carries what will be applied, so there is
+// no argument through which a caller could apply something other than what a human
+// reviewed.
+
+import { and, eq, ne } from "drizzle-orm";
+import { db } from "../db/connection.js";
+import { docComments, docSections, standardClauses } from "../db/schema.js";
+import type { Doc, DocComment, DocSection, StandardClause } from "../db/schema.js";
+import { NotFoundError, ValidationError } from "../types/errors.js";
+import { mutate, type ChangeKey, type Mutated, type RequestCtx } from "./mutate.js";
+import { resolveActorColumns } from "./actor.js";
+import {
+  insertClauseTx,
+  regenerateSectionContentTx,
+  softDeleteClauseTx,
+  updateClauseBodyTx,
+} from "./clauses.js";
+import {
+  loadOwnedStandard,
+  parseProposedChangeBody,
+  type ClauseOperation,
+} from "./standards.js";
+
+export interface AcceptStandardChangeResult {
+  /** The standard whose rule text changed. */
+  standard: Doc;
+  /** The section the proposal targeted. */
+  section: DocSection;
+  /** The now-resolved plan_revision comment. */
+  comment: DocComment;
+  /** How many clause operations were applied. */
+  applied: number;
+}
+
+/** One operation paired with the live clause row it resolved to. */
+type ResolvedOp = { op: ClauseOperation; clause: StandardClause };
+
+/** The `cl-N` handle for a clause row — the identifier every refusal names, so a
+ *  reviewer can act on the message without further investigation [per std-10]. */
+function handleOf(clause: StandardClause): string {
+  return `cl-${clause.seq}`;
+}
+
+/**
+ * Apply an open `plan_revision` proposal and resolve it, in one transaction.
+ *
+ * Every read and every check happens BEFORE the transaction writes anything: a
+ * mismatch refuses the whole set rather than the offending operation, because a set is
+ * one reviewed intent and partial application is what ac-10 forbids.
+ */
+export async function acceptStandardChange(
+  memexId: string,
+  commentId: string,
+  ctx: RequestCtx = {},
+): Promise<Mutated<AcceptStandardChangeResult>> {
+  // ── The proposal itself ──
+  const comment = await db.query.docComments.findFirst({
+    where: and(eq(docComments.id, commentId), eq(docComments.memexId, memexId)),
+  });
+  // std-7: a comment in another memex is indistinguishable from one that does not
+  // exist. Not found, never "not yours".
+  if (!comment) throw new NotFoundError(`Proposal ${commentId} not found`);
+
+  if (comment.commentType !== "plan_revision") {
+    throw new ValidationError(
+      `That comment is a ${comment.commentType}, not a proposal. Only a plan_revision carries clause operations to apply.`,
+    );
+  }
+  if (comment.resolvedAt) {
+    throw new ValidationError(
+      "That proposal is already resolved — nothing to apply. Re-propose against the current rule if the change is still wanted.",
+    );
+  }
+  if (!comment.sectionId) {
+    throw new ValidationError("That proposal is not anchored to a section, so it has no target.");
+  }
+
+  const parsed = parseProposedChangeBody(comment.content);
+  if (!parsed) {
+    throw new ValidationError(
+      "That proposal's body carries no readable operations — it cannot be applied. Re-propose it.",
+    );
+  }
+  // t-9's degrade-never-crash contract, seen from the accept side: a pre-cutover
+  // whole-section body still READS, but nothing clause-grained can apply it. Refuse
+  // with the reason rather than half-applying something (spec-530 dec-2 / t-11 convert
+  // the stragglers).
+  if (parsed.kind === "legacy") {
+    throw new ValidationError(
+      "That proposal predates the clause grain — it replaces a whole section, which cannot be applied clause by clause. Restate it as clause operations and re-propose (spec-530 t-11).",
+    );
+  }
+  const operations = parsed.operations;
+
+  // ── The target section + standard ──
+  const section = await db.query.docSections.findFirst({
+    where: eq(docSections.id, comment.sectionId),
+  });
+  if (!section) throw new NotFoundError(`Section ${comment.sectionId} not found`);
+  const standard = await loadOwnedStandard(memexId, section.docId);
+
+  // ── Resolve every target, memex- AND doc-scoped ──
+  // A `cl-N` handle is per-STANDARD (seq is allocated MAX+1 per doc), so the lookup is
+  // scoped to this standard's docId. Scoping by memex alone would let a handle collide
+  // across two standards in the same memex and apply to the wrong rule.
+  const resolved: ResolvedOp[] = [];
+  for (const op of operations) {
+    const handle = op.op === "add" ? op.anchor : op.clause;
+    const seq = Number.parseInt(handle.replace(/^cl-/, ""), 10);
+    if (!Number.isInteger(seq)) {
+      throw new ValidationError(`Operation targets "${handle}", which is not a cl-N handle.`);
+    }
+    const clause = await db.query.standardClauses.findFirst({
+      where: and(
+        eq(standardClauses.docId, standard.id),
+        eq(standardClauses.seq, seq),
+        ne(standardClauses.status, "deleted"),
+      ),
+    });
+    if (!clause) {
+      // Covers dec-3's check for `add`: a clause proposed relative to a clause that has
+      // since been deleted has no defined position, so the accept refuses rather than
+      // guessing — never an append-to-end fallback (ac-16).
+      throw new ValidationError(
+        op.op === "add"
+          ? `${handle} — the clause this proposal adds next to — no longer exists on ${standard.handle}. Re-propose against the current rule.`
+          : `${handle} no longer exists on ${standard.handle}. Re-propose against the current rule.`,
+      );
+    }
+    if (clause.sectionId !== section.id) {
+      throw new ValidationError(
+        `${handle} has moved to a different section since this proposal was written. Re-propose against the current rule.`,
+      );
+    }
+    resolved.push({ op, clause });
+  }
+
+  // An `add` anchored on a clause this same set deletes has no coherent meaning — the
+  // anchor is gone by the time the add runs. Caught here, before any write, so the
+  // refusal is total like every other (ac-10).
+  const deletedHandles = new Set(
+    resolved.filter((r) => r.op.op === "delete").map((r) => handleOf(r.clause)),
+  );
+  for (const { op, clause } of resolved) {
+    if (op.op === "add" && deletedHandles.has(handleOf(clause))) {
+      throw new ValidationError(
+        `This proposal adds a clause next to ${handleOf(clause)} and also deletes ${handleOf(clause)}. Those cannot both hold — re-propose with a different anchor.`,
+      );
+    }
+  }
+
+  // ── dec-3's staleness guard: exact compare, before anything is written ──
+  // The proposal is a stale read by nature — authored at T0, accepted at T1, possibly
+  // after another agent edited that clause. Applying blind at T1 discards the
+  // intervening edit silently, which is the failure class this whole Spec exists to
+  // close. Comparison is EXACT, whitespace included: a "close enough" match reopens the
+  // silent-overwrite class, and the cost of a false refusal is one re-proposal.
+  for (const { op, clause } of resolved) {
+    if (op.op === "add") continue; // no "before" to compare — its check is anchor-exists, above
+    if (clause.body !== op.before) {
+      throw new ValidationError(
+        `${handleOf(clause)} changed after this proposal was written, so applying it would discard that change. ` +
+          `It now reads:\n\n${clause.body}\n\nRe-propose against the current rule.`,
+      );
+    }
+  }
+
+  // ── Emit keys [per std-8] ──
+  // One event per logical change, mirroring the composite the clause verbs already
+  // emit, plus the pair the propose path fires: `comment` updated so an open Inbox row
+  // clears, and `standard_drift` so the per-standard drift-count chip refetches. An
+  // accept that does not emit is the same defect in miniature as the one being fixed —
+  // the work happened and the surface still says it did not (ac-12).
+  const keys: ChangeKey[] = [
+    ...operations.map((op) => ({
+      memexId,
+      docId: standard.id,
+      entity: "clause" as const,
+      action:
+        op.op === "add" ? ("created" as const) : op.op === "edit" ? ("updated" as const) : ("deleted" as const),
+    })),
+    { memexId, docId: standard.id, entity: "section", action: "updated" },
+    { memexId, docId: standard.id, entity: "comment", action: "updated" },
+    { memexId, docId: standard.id, entity: "standard_drift", action: "updated" },
+  ];
+
+  // Resolved once, before the transaction opens (an indexed users lookup), so the tx
+  // stays free of a round trip — same idiom as the clause verbs. This is what makes the
+  // rule change attributable: WHO accepted it and HOW [per std-32] (ac-20).
+  const actor = await resolveActorColumns(ctx);
+
+  return mutate(ctx, keys, async () =>
+    db.transaction(async (tx) => {
+      for (const { op, clause } of resolved) {
+        if (op.op === "edit") {
+          await updateClauseBodyTx(tx, clause.id, op.after);
+        } else if (op.op === "delete") {
+          await softDeleteClauseTx(tx, clause);
+        } else {
+          // ANCHOR → ORDINAL, resolved HERE and not at authoring time (ac-19). An
+          // ordinal captured when the proposal was written is stale by construction: a
+          // clause inserted ahead of the anchor shifts it, and nothing would detect
+          // that. So the anchor's CURRENT position is re-read inside the transaction —
+          // it may have moved since the pre-flight read, because an earlier operation
+          // in this same set may have shifted it.
+          const [current] = await tx
+            .select()
+            .from(standardClauses)
+            .where(eq(standardClauses.id, clause.id));
+          const ordinal = op.placement === "before" ? current.position : current.position + 1;
+          // insertClauseTx shifts live siblings out of the way [per dec-5], so the new
+          // clause lands next to its anchor with ordinals left unique and dense.
+          await insertClauseTx(tx, memexId, section, op.body, ordinal);
+        }
+      }
+
+      // Once, at the end — not per operation. The composed text is a function of the
+      // final row set, so N regenerations would do the same work N times and only the
+      // last one would matter.
+      await regenerateSectionContentTx(tx, section, actor);
+
+      // Resolving the proposal is part of the SAME transaction, which is the point of
+      // the verb: there is no window in which the Standard is rewritten and the
+      // proposal still open, or the reverse.
+      const [updatedComment] = await tx
+        .update(docComments)
+        .set({ resolvedAt: new Date(), resolution: "accepted" })
+        .where(and(eq(docComments.id, comment.id), eq(docComments.memexId, memexId)))
+        .returning();
+
+      return {
+        standard,
+        section,
+        comment: updatedComment,
+        applied: operations.length,
+      };
+    }),
+  );
+}

--- a/packages/server/src/services/standards.ts
+++ b/packages/server/src/services/standards.ts
@@ -96,7 +96,9 @@ export interface StandardListEntry {
 
 // ── Helpers ────────────────────────────────────────────
 
-async function loadOwnedStandard(
+// Exported for the accept path (spec-530 t-4, `standard-accept.ts`), which must apply a
+// proposal through the SAME memex-scope + standard-type guard the propose path uses.
+export async function loadOwnedStandard(
   memexId: string,
   standardId: string,
 ): Promise<Doc> {
@@ -593,7 +595,11 @@ function isClauseOperation(value: unknown): value is ClauseOperation {
 /**
  * Parser companion for buildProposedChangeBody — pull the proposed-content payload
  * out of a comment body. Returns null if the comment isn't shaped like a proposal.
- * Exported for the React UI / future server-side accept flow.
+ *
+ * Exported for its two real consumers: the Drift Inbox read model (which renders the
+ * diff) and `acceptStandardChange` (which applies it). The "future server-side accept
+ * flow" this comment used to point at is no longer future and no longer a route —
+ * spec-530 dec-6 deleted the dead REST endpoint; the verb is the accept path.
  */
 export function parseProposedChangeBody(body: string): ParsedProposal | null {
   // The clause-grained shape first — it is what everything written from spec-530

--- a/packages/shared/src/scaffold-data.ts
+++ b/packages/shared/src/scaffold-data.ts
@@ -135,11 +135,12 @@ export const DRIFT_AGENT_GUIDANCE: PromptBlockNode = {
     '- If the rule itself is outdated, either record a proposed rewording with `propose_standard_change`, or — with the user\'s explicit consent — edit the rule text directly with the clause verbs (`edit_clause`, `add_clause`, `delete_clause`).\n\n' +
     '**A Standard is edited at the CLAUSE grain, never as a whole section.** `update_section` refuses on a Standard: its rule text is a set of addressable clauses (`cl-N`), and the clause verbs are the only way to change it. A proposal names the clauses it changes, so applying one means editing those clauses — not rewriting everything around them.\n\n' +
     'Handling a PROPOSAL (a `plan_revision`):\n' +
-    '- If the user ACCEPTS: apply each of the proposal\'s clause operations with the matching verb (`edit_clause` / `add_clause` / `delete_clause`), then resolve the comment with `update_comment` (status `resolved`, resolution `\'accepted\'`).\n' +
+    '- If the user ACCEPTS: call `accept_standard_change` with the proposal\'s comment ref. That single call applies every clause operation the proposal carries AND resolves the comment as accepted, together — so do not apply the clauses yourself and do not resolve the comment separately. You pass nothing but the ref: what gets applied is exactly what was proposed and reviewed, which is what makes the user\'s approval mean something.\n' +
+    '- If it REFUSES because a clause changed after the proposal was written, that is the guard working, not an error to retry. It names the clause and what it now says: show the user, and offer to re-propose against the current rule.\n' +
     '- If the user REJECTS: resolve the comment with `update_comment` (status `resolved`, resolution `\'rejected\'`) — leave the rule unchanged.\n' +
     '- A plain dismissal: resolve the comment with `update_comment` (status `resolved`, resolution `\'resolved\'`).\n\n' +
     '**The Drift Inbox has no action buttons — none.** There is no Accept, no Reject, no Resolve control on a row; the only button opens this conversation. So never tell someone to "click Accept" or point them at a control to finish the job: acceptance happens HERE, in conversation, and you are the one who applies it once they confirm. Describing an affordance the screen does not have sends them looking for something that was deliberately removed, and costs more trust than saying plainly "I\'ll apply it — confirm?".\n\n' +
-    'Mutation protocol (non-negotiable): propose EVERY mutation — the clause verbs, `update_comment`, `propose_standard_change`, `flag_drift` — through `render_confirmation` first, showing exactly what will change, and never mutate until the user confirms. Ask any clarifying questions in plain text first, then confirm, then act. Confirm an action only after the tool returns success.',
+    'Mutation protocol (non-negotiable): propose EVERY mutation — `accept_standard_change`, the clause verbs, `update_comment`, `propose_standard_change`, `flag_drift` — through `render_confirmation` first, showing exactly what will change, and never mutate until the user confirms. Ask any clarifying questions in plain text first, then confirm, then act. Confirm an action only after the tool returns success.',
   rationale:
     'spec-143 t-4 (dec-6): the drift-agent mode prompt block, appended by buildSystemBlocks only when the per-request driftMode flag is set (the React UI sets mode "drift" on the Drift Inbox). Intentionally NOT in any phase promptBlockIds (conditionally injected, like BASE_READ_ONLY / BASE_REVIEW). The mode-machinery is built here in spec-143; spec-142 will reuse the pattern. Portable per std-22 — no language/framework/repo/path/tooling assumptions; the real mutation enforcement is the render_confirmation gate + the /tools/execute server gate, not this prose.',
 };
@@ -624,7 +625,7 @@ const BASE_STANDARDS_PROTOCOL: PromptBlockNode = {
   surface: 'shared_nudge',
   text:
     '**Standards protocol** — when working with a standard:\n' +
-    '- If the rule is wrong or out of date, call `propose_standard_change(ref, proposed)` with the corrected text — `ref` is the section\'s canonical ref (e.g. `…/standards/std-N/sections/s-M`), not a UUID. The proposal lands as a `plan_revision` typed comment for the standard owner to accept or reject.\n' +
+    '- If the rule is wrong or out of date, call `propose_standard_change(operations)` naming the clauses that should change and what they should say — each target is a clause\'s canonical ref (e.g. `…/standards/std-N/clauses/cl-M`), not a UUID, and every clause in one proposal must belong to the same section. The proposal lands as a `plan_revision` typed comment for the standard owner to accept or reject.\n' +
     '- If the rule is correct but the codebase has drifted from it, call `flag_drift(ref, observation)` with the section\'s canonical ref. Drift comments surface in the Standards Drift Inbox (sourced \'agent\').\n' +
     '- When citing a standard in code or in another doc, use the `[per std-N]` form so the back-reference resolves automatically.\n' +
     '- Use `search_memex({ query, kind: \'standard\' })` (handle / FTS / vector) before authoring new rules — duplicate standards confuse the agent loop.',
@@ -1144,7 +1145,9 @@ const TOOL_RATIONALES: Record<string, string> = {
   flag_drift:
     "Flag drift on a standard section: post a typed `drift` comment (sourced 'agent') when the rule is right but the codebase has diverged from it. Surfaces in the Drift Inbox; use propose_standard_change instead when the rule itself is wrong.",
   propose_standard_change:
-    "Propose a corrected version of a standard section: lands a typed `plan_revision` comment (sourced 'agent') with the full replacement markdown and a rationale, for the standard owner to accept or reject in the Drift Inbox.",
+    "Propose a correction to a standard's rule text at the clause grain: name the clauses that should change and what they should say, and it lands as a typed `plan_revision` comment (sourced 'agent') for the standard owner to accept or reject. You never supply a clause's current text — the server reads it, so an accept can tell whether the clause moved underneath the proposal.",
+  accept_standard_change:
+    "Accept an open proposal and apply it to the Standard: every clause operation lands, or none does, and the proposal is resolved 'accepted' in the same transaction. Takes the proposal's comment ref and nothing else, so what gets applied is exactly what was reviewed. Refuses, naming the clause and its current text, if the rule changed after the proposal was written.",
   facets:
     "Read (and later manage) your Memex's facet vocabulary — the closed, per-owner set of cross-cutting practice areas a standard's clauses are tagged with. Verb-dispatched so the surface stays one tool; v0 supports verb:'list'.",
   create_ac:

--- a/packages/shared/src/tool-manifest.ts
+++ b/packages/shared/src/tool-manifest.ts
@@ -454,6 +454,15 @@ export const toolManifest: ToolManifestEntry[] = [
     homePhase: null,
   },
   {
+    name: 'accept_standard_change',
+    summary:
+      "Accept an open proposal (a `plan_revision` comment) and apply it to the Standard: every clause operation the proposal carries lands, or none does, and the proposal is resolved 'accepted' in the same transaction. Takes the comment ref and nothing else, so what is applied is exactly what was reviewed. Refuses \u2014 naming the clause and its current text \u2014 if the rule changed after the proposal was written, rather than overwriting that change.",
+    args: 'accept_standard_change(ref)',
+    group: 'build',
+    readOnlyHint: false,
+    homePhase: null,
+  },
+  {
     name: 'facets',
     summary:
       "Check which parts of your Standards apply to a piece of work: lists the topics they are tagged by (the Memex's facets). Cast these as the facetBallot on create_task / create_decision and Memex surfaces the governing standard sections.",

--- a/packages/ui/src/api/comments.ts
+++ b/packages/ui/src/api/comments.ts
@@ -55,9 +55,14 @@ export async function createComment(
 }
 
 // spec-143 dec-4: thread the optional resolution string through so the agent
-// can stamp a distinct audit trail — Reject → 'rejected', Resolve → 'resolved'
-// (Accept stays 'accepted' via the /drift/proposals/:id/accept path). Omitting
-// it POSTs an empty body, preserving the prior no-resolution behaviour.
+// can stamp a distinct audit trail — Reject → 'rejected', Resolve → 'resolved'.
+// Accepting is NOT one of these: it changes rule text, so it goes through the
+// server's `accept_standard_change` verb, which applies the proposal's clause
+// operations and stamps 'accepted' in the same transaction (spec-530 dec-4).
+// The `/drift/proposals/:id/accept` route this comment used to name was deleted
+// by spec-530 dec-6 — it had been unable to succeed since spec-161, and nothing
+// here ever called it. Omitting the resolution POSTs an empty body, preserving
+// the prior no-resolution behaviour.
 export async function resolveComment(
   commentId: string,
   resolution?: string,


### PR DESCRIPTION
## Why

**A proposal on a Standard could not be accepted.** Not "was awkward to accept" — could not. The drift agent was instructed to apply one with `update_section`, a call that has thrown on every Standard since spec-161 made them clause-backed. That instruction sat wrong for months because **nothing executes prose as a contract**.

The previous PR (#612) moved the proposal to the clause grain — the foundation. This one closes the loop: it makes accepting possible, and it does so as a server verb precisely so the failure that caused this Spec cannot recur in the same shape.

📋 [spec-530](https://memex.ai/mindset-prod/memex-building-itself/specs/spec-530) — delivers **t-4** and **t-5**.

## Two decisions raised and resolved before any code

The plan named these forks and told the builder not to invent answers. Both are on the Spec with full reasoning.

**[dec-5](https://memex.ai/mindset-prod/memex-building-itself/specs/spec-530) — clause order (issue-1): fix `createClause` at the source, and add a tiebreaker on read.**

Two defects that compound. `createClause` wrote the caller's `position` with no shift, so an occupied ordinal produced two live rows sharing it. `liveClausesForSection` ordered by `position` alone with no tiebreaker, so tied rows came back in scan order. Together, **a section's composed text was not a function of its rows** — `regenerateSectionContentTx` joins in that order and writes the result to `doc_sections.content`, so a Standard's rendered rule text could change between two regenerations with no write in between.

That is not theoretical: the test inserts two tied rows whose `seq` order and heap order disagree, and the pre-fix run returned the wrong one first.

Fixed at the source rather than routed around in the accept. dec-3 declined to reshape a shared tool for one consumer — this is the inverse: a pre-existing bug in a shared primitive that `add_clause`'s optional `position` already exposes to every caller. Both halves are needed: the shift prevents new ties, and the `position, seq` tiebreaker is the only thing that reaches rows already tied in a database written before this.

**[dec-6](https://memex.ai/mindset-prod/memex-building-itself/specs/spec-530) — the dead accept route: delete it, don't re-point it.**

`POST /api/drift/proposals/:commentId/accept` (spec-63 t-12, mounted in `app.ts`) called `updateSection` and therefore could never succeed on a real proposal. No UI caller exists — spec-143 dec-3 removed the buttons deliberately. Re-pointing it would quietly pre-build the Accept affordance this Spec's non-goals exclude.

And a mounted endpoint that always throws **is this Spec's own defect in another medium**: the next reader greps for "accept", finds it, and reasons from it — as spec-530's own Overview did, before s-3 had to correct it. The test asserts 404, not a polite refusal.

## What lands

**`accept_standard_change(ref)`** takes the proposal's comment ref and *nothing else*. No bodies, no targets, no override — the proposal already carries what will be applied, so no caller can apply something other than what a human reviewed. Every clause operation lands or none does, and the comment resolves `'accepted'` in the same transaction, emitting per **std-8** so the Inbox row and the drift-count chip both clear.

**Atomicity is tested, not asserted.** A fault injected at operation 2 of 3 leaves clause 1 byte-identical and the proposal open — and the same proposal then applies cleanly, because the rollback was total enough that dec-3's staleness guard still matched.

**dec-3's staleness guard (t-5)** runs before any write: each `edit`/`delete` compares the target's authoring-time body *exactly*, and any divergence refuses the whole set, naming the clause and quoting what it now says. An `add`'s check is that its anchor still exists. Deletes are guarded as well as edits — deleting a clause someone has since rewritten discards that work with no trace, and the plan only named the edit case.

**Anchor→ordinal translation** is the new primitive. An ordinal captured at authoring time is stale by construction, so an `add` stores an anchor `cl-N` and the accept resolves it to a current position *inside* the transaction, re-read per operation.

Threads a real `RequestCtx`, so "who accepted this rule change, and from where" has an answer [per **std-32**] — riding the seam t-3 built. Present in the drift **and** standards `MODE_TOOLS` sets and refused by the gate predicate everywhere else, not merely hidden from tool definitions [per **std-38**].

## Three things worth a reviewer's attention

**1. One of my tests did not bite, and I found it by checking.** The first ac-19 test passed — but mutating the code to use a stale ordinal *still passed it*, because the pre-flight read already covered that scenario. The case that actually needs the in-transaction re-read is two `add` operations in ONE set, where the first shifts the second's anchor. With the mutation that composes `A,X,Y,B,C` instead of `A,X,B,Y,C` — a rule attached to the wrong clause, silently. A green test that does not discriminate is worse than no test.

**2. The plan did not anticipate an atomicity blocker.** `createClause` / `updateClause` / `deleteClause` each open their *own* `db.transaction`, so calling them in a loop gave N transactions — the exact state ac-10 forbids. `insertClauseTx` / `updateClauseBodyTx` / `softDeleteClauseTx` are extracted; the public verbs are now thin wrappers, so there is one implementation of each write rather than a second copy in the accept path.

**3. The full suite caught a FOURTH contract registry.** `mutate-coverage` (std-8) requires every mutating manifest tool to declare its `(entity, action)` pairs — and it failed after the two probe registries and the shared manifest were all green. Session 1's QA report warned that a tool-contract change hides in four places in this repo; that count is now confirmed at four.

Three stale Scaffold entries left by earlier tasks are corrected here too: the drift agent's apply path now names the accept verb (**t-8 recorded this as its own forward obligation**), and two texts still described the section grain t-2 replaced.

## Test plan

- [x] New: `standard-accept.spec-530.integration` (13), `standard-accept-staleness.spec-530.integration` (6), `standard-accept-atomicity.spec-530.integration` (2, isolated because it mocks a module), `clause-order.spec-530.integration` (5), `accept-mode-gate.spec-530` (4), `drift-accept-route.spec-530` (3)
- [x] **ac-23 driven red→green for real** — the pre-fix run returned tied clauses in the wrong order
- [x] Both probe registries (`tool-specs.audit`, `__regression__/ref-emission`) carry a real PROBE for the new verb, not a skip entry — they exercise the accept end-to-end through the MCP-shaped handler
- [x] Full server suite: **1 failed / 6202 passed / 25 skipped (6228)** — the one failure is `.ee/slack/oauth.test.ts`, the documented local-red / CI-green flake
- [x] `make check` green · `tsc --noEmit` clean · `pnpm --filter @memex/ui build` green
- [x] **ACs verified via `list_acs`, not inferred from a green suite: 19 of 24.** New this PR: ac-9, ac-10, ac-11, ac-12, ac-13, ac-14, ac-15, ac-16, ac-18, ac-19, ac-20, ac-23, ac-24, and scope ac-3
- [ ] ac-1, ac-2, ac-6 need t-7's Inbox diff; ac-4, ac-17 need t-11's conversion. All correctly still red
- [ ] e2e journey [per std-28] is t-10, blocked on t-7's UI — no user-facing flow changes in this PR

## Still not deployable to production

⚠️ Merging to `develop` is intended. **Promoting to `main` is not**, until t-11 converts the legacy proposals still open (#5 on std-9, #8 on std-21). The mechanism now works; the proposals that prompted the Spec are still stuck until then, which is exactly what ac-4 forbids at ship.

No schema changes, no migrations, no new routes (one deleted). Tenancy unchanged; RLS untouched [per std-36]; every mutation through `mutate()` [per std-8]. Fair-code [per std-25].

## Also worth knowing

`make standards-check` passes at 42 standards, but the live Memex now returns std-43…std-48 in governance lookups. The check compares CLAUDE.md against a local generated manifest, so it cannot see standards added since the last `make standards-gen`. Not touched here — flagging it as a separate drift.
