### PR TITLE
feat(spec-530): the Drift Inbox row shows what a proposal actually says (t-7)

### DIFF
--- a/packages/server/src/agent/context-builder.drift.test.ts
+++ b/packages/server/src/agent/context-builder.drift.test.ts
@@ -40,6 +40,9 @@ function row(overrides: Partial<DriftInboxRow> = {}): DriftInboxRow {
     authorName: "Agent",
     content: "Repo no longer does X.",
     proposedContent: null,
+    // spec-530 t-7: the structured operations the Inbox row renders. The AGENT's context
+    // reads `proposedContent`, not this — so a drift row's null is the honest default here.
+    proposal: null,
     createdAt: new Date("2026-01-01T00:00:00Z"),
     decision: null,
     section: { id: "s-1", sectionType: "do", title: null, content: "Always X." },

--- a/packages/server/src/routes/__test__.ts
+++ b/packages/server/src/routes/__test__.ts
@@ -76,6 +76,7 @@ import { addMentions, assignComment } from "../services/comment-mentions.js";
 import { createShareToken, listShareTokensForDoc } from "../services/share-tokens.js";
 import { addSection } from "../services/sections.js";
 import { addClausesToSection } from "../services/clauses.js";
+import { proposeStandardChange } from "../services/standards.js";
 import { applyTagStrings } from "../services/tags.js";
 import { resolveRole } from "../services/doc-members.js";
 import { listAssignees, assign } from "../services/doc-assignees.js";
@@ -1488,6 +1489,54 @@ const seedClausesSchema = z.object({
   sectionId: z.string().uuid(),
   clauses: z.array(z.string().min(1)).min(1),
 });
+// spec-530 t-7: seed an OPEN clause-grained proposal (a `plan_revision` comment) so a
+// journey can drive the Drift Inbox's before/after without raw SQL [per std-28]. Goes
+// through the real `proposeStandardChange`, so the stored body is the genuine operation
+// set and the row under test is the row users get — a hand-written comment would test a
+// shape the product never produces.
+const seedProposalSchema = z.object({
+  memexId: z.string().uuid(),
+  operations: z
+    .array(
+      z.object({
+        op: z.enum(["edit", "delete", "add"]),
+        clauseId: z.string().uuid(),
+        body: z.string().optional(),
+        placement: z.enum(["before", "after"]).optional(),
+      }),
+    )
+    .min(1),
+  rationale: z.string().optional(),
+});
+testOnlyRouter.post("/seed-proposal", async (c) => {
+  const body = await c.req.json().catch(() => null);
+  const parsed = seedProposalSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: "Invalid request", details: parsed.error.issues }, 400);
+  }
+  const { memexId, operations, rationale } = parsed.data;
+  const result = await proposeStandardChange(
+    memexId,
+    operations.map((op) =>
+      op.op === "edit"
+        ? { op: "edit" as const, clauseId: op.clauseId, after: op.body ?? "" }
+        : op.op === "delete"
+          ? { op: "delete" as const, clauseId: op.clauseId }
+          : {
+              op: "add" as const,
+              anchorClauseId: op.clauseId,
+              placement: op.placement ?? "after",
+              body: op.body ?? "",
+            },
+    ),
+    rationale,
+    {},
+    // std-32: a seeded write is still an attributed write.
+    { channel: "server", actorName: "e2e-seed" },
+  );
+  return c.json({ commentId: result.comment.id, commentSeq: result.comment.seq });
+});
+
 testOnlyRouter.post("/seed-clauses", async (c) => {
   const body = await c.req.json().catch(() => null);
   const parsed = seedClausesSchema.safeParse(body);

--- a/packages/server/src/services/drift-inbox-proposal.spec-530.integration.test.ts
+++ b/packages/server/src/services/drift-inbox-proposal.spec-530.integration.test.ts
@@ -1,0 +1,215 @@
+// spec-530 t-7 — the Drift Inbox read model carries a proposal's OPERATIONS, resolved
+// against the live clauses.
+//
+// Until now `proposedContent` was the only thing on the wire, and for a clause-grained
+// proposal it is the raw comment body — which is why `DriftInbox.tsx` rendered nothing
+// and its header comment claimed the diff was "reachable via Discuss with Agent or the
+// standard page", a claim verified false on both counts.
+//
+// The row needs three things per operation the client cannot derive: which clause
+// (`cl-N`), what the proposal wants it to say, and what it says RIGHT NOW. The last one
+// is a database read, so it belongs here rather than in the client.
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { eq } from "drizzle-orm";
+import { db } from "../db/connection.js";
+import { documents, docComments } from "../db/schema.js";
+import type { StandardClause } from "../db/schema.js";
+import { createStandard, proposeStandardChange } from "./standards.js";
+import { addClausesToSection, updateClause } from "./clauses.js";
+import { listDriftInbox } from "./drift-inbox.js";
+import { makeTestMemex } from "./test-helpers.js";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+const AC_18 = "mindset-prod/memex-building-itself/specs/spec-530/acs/ac-18";
+
+const createdDocIds: string[] = [];
+let memexId: string;
+
+beforeAll(async () => {
+  memexId = await makeTestMemex("s530inbox");
+});
+
+afterAll(async () => {
+  for (const id of createdDocIds) {
+    await db.delete(documents).where(eq(documents.id, id)).catch(() => {});
+  }
+});
+
+async function seededStandard(
+  title: string,
+  bodies: string[],
+): Promise<{ docId: string; sectionId: string; clauses: StandardClause[] }> {
+  const std = await createStandard(memexId, {
+    title,
+    sections: [{ sectionType: "rule", content: "" }],
+  });
+  createdDocIds.push(std.id);
+  const sectionId = std.sections[0].id;
+  const clauses = await addClausesToSection(
+    memexId,
+    sectionId,
+    bodies.map((body) => ({ body, facets: [] })),
+  );
+  return { docId: std.id, sectionId, clauses: [...clauses] };
+}
+
+async function rowFor(commentId: string) {
+  const page = await listDriftInbox(memexId, { limit: 200 });
+  return page.items.find((i) => i.commentId === commentId);
+}
+
+describe("spec-530 t-7: the Inbox read model carries the proposal's operations", () => {
+  it("returns each operation with its cl-N, the proposed text, and the LIVE clause body", async () => {
+    const { clauses } = await seededStandard("Inbox Ops Standard", [
+      "keep me",
+      "edit me",
+      "delete me",
+    ]);
+    const proposal = await proposeStandardChange(memexId, [
+      { op: "edit", clauseId: clauses[1].id, after: "edited text" },
+      { op: "delete", clauseId: clauses[2].id },
+      { op: "add", anchorClauseId: clauses[0].id, placement: "after", body: "added text" },
+    ]);
+
+    const row = await rowFor(proposal.comment.id);
+    expect(row?.proposal?.kind).toBe("clause-ops");
+    const ops = row!.proposal!.kind === "clause-ops" ? row!.proposal!.operations : [];
+
+    // Order is the proposal's own — a reviewer reads the operations as authored.
+    expect(ops.map((o) => o.op)).toEqual(["edit", "delete", "add"]);
+    expect(ops.map((o) => o.clause)).toEqual([
+      `cl-${clauses[1].seq}`,
+      `cl-${clauses[2].seq}`,
+      `cl-${clauses[0].seq}`, // the ADD names its anchor
+    ]);
+
+    expect(ops[0]).toMatchObject({ before: "edit me", after: "edited text", current: "edit me" });
+    expect(ops[1]).toMatchObject({ before: "delete me", current: "delete me" });
+    expect(ops[1].after).toBeUndefined(); // nothing replaces a deletion
+    expect(ops[2]).toMatchObject({ placement: "after", after: "added text", current: "keep me" });
+    expect(ops[2].before).toBeUndefined(); // an add has no "before"
+  });
+
+  it("carries `current` as the LIVE body, which can differ from the authored `before`", async () => {
+    const { clauses } = await seededStandard("Inbox Drift Standard", ["the original rule"]);
+    const proposal = await proposeStandardChange(memexId, [
+      { op: "edit", clauseId: clauses[0].id, after: "the proposed rule" },
+    ]);
+
+    // Someone corrects the clause after the proposal was authored.
+    await updateClause(memexId, clauses[0].id, "the rule as someone else corrected it");
+
+    const row = await rowFor(proposal.comment.id);
+    const ops = row!.proposal!.kind === "clause-ops" ? row!.proposal!.operations : [];
+    // Both travel, because they answer different questions: after-vs-current is the diff
+    // a reviewer judges; before-vs-current is whether the proposal still applies. The
+    // read model states both and derives NO verdict — dec-3 put that judgement inside
+    // the accept transaction and dec-4 gave it exactly one home.
+    expect(ops[0].before).toBe("the original rule");
+    expect(ops[0].current).toBe("the rule as someone else corrected it");
+    expect(ops[0].after).toBe("the proposed rule");
+  });
+
+  it("reports `current: null` when the targeted clause no longer exists", async () => {
+    const { clauses } = await seededStandard("Inbox Gone Standard", ["doomed", "other"]);
+    const proposal = await proposeStandardChange(memexId, [
+      { op: "edit", clauseId: clauses[0].id, after: "never applied" },
+    ]);
+    const { deleteClause } = await import("./clauses.js");
+    await deleteClause(memexId, clauses[0].id);
+
+    const row = await rowFor(proposal.comment.id);
+    const ops = row!.proposal!.kind === "clause-ops" ? row!.proposal!.operations : [];
+    expect(ops[0].current).toBeNull();
+    // The row still renders — a vanished target is one unusable operation, not a crash.
+    expect(row?.proposal?.kind).toBe("clause-ops");
+  });
+
+  it("resolves cl-N per STANDARD, so two Standards' identical handles do not cross", async () => {
+    // `seq` is allocated MAX+1 per doc, so cl-1 exists on every Standard. Matching on
+    // seq alone would show one Standard's rule text under another's proposal.
+    const a = await seededStandard("Inbox Collide A", ["A's first clause"]);
+    const b = await seededStandard("Inbox Collide B", ["B's first clause"]);
+    expect(a.clauses[0].seq).toBe(b.clauses[0].seq);
+
+    const pa = await proposeStandardChange(memexId, [
+      { op: "edit", clauseId: a.clauses[0].id, after: "A changed" },
+    ]);
+    const pb = await proposeStandardChange(memexId, [
+      { op: "edit", clauseId: b.clauses[0].id, after: "B changed" },
+    ]);
+
+    const rowA = await rowFor(pa.comment.id);
+    const rowB = await rowFor(pb.comment.id);
+    const opsA = rowA!.proposal!.kind === "clause-ops" ? rowA!.proposal!.operations : [];
+    const opsB = rowB!.proposal!.kind === "clause-ops" ? rowB!.proposal!.operations : [];
+    expect(opsA[0].current).toBe("A's first clause");
+    expect(opsB[0].current).toBe("B's first clause");
+  });
+
+  it("reports a pre-cutover body as legacy rather than throwing (ac-18)", async () => {
+    tagAc(AC_18);
+    const { clauses } = await seededStandard("Inbox Legacy Standard", ["a rule"]);
+    const proposal = await proposeStandardChange(memexId, [
+      { op: "edit", clauseId: clauses[0].id, after: "irrelevant" },
+    ]);
+    await db
+      .update(docComments)
+      .set({
+        content: [
+          "**Proposed change to section [rule]**",
+          "",
+          "legacy rationale",
+          "",
+          "~~~proposed-content",
+          "A whole replacement section body.",
+          "~~~",
+        ].join("\n"),
+      })
+      .where(eq(docComments.id, proposal.comment.id));
+
+    const row = await rowFor(proposal.comment.id);
+    expect(row?.proposal).toEqual({
+      kind: "legacy",
+      proposed: "A whole replacement section body.",
+    });
+  });
+
+  it("reports an unparseable body as unreadable, and the rest of the page still renders (ac-18)", async () => {
+    tagAc(AC_18);
+    const { clauses } = await seededStandard("Inbox Corrupt Standard", ["a rule"]);
+    const corrupt = await proposeStandardChange(memexId, [
+      { op: "edit", clauseId: clauses[0].id, after: "irrelevant" },
+    ]);
+    await db
+      .update(docComments)
+      .set({ content: "someone wrote a plan_revision by hand with no payload at all" })
+      .where(eq(docComments.id, corrupt.comment.id));
+
+    // A second, healthy proposal on the same page.
+    const healthy = await seededStandard("Inbox Healthy Standard", ["another rule"]);
+    const good = await proposeStandardChange(memexId, [
+      { op: "edit", clauseId: healthy.clauses[0].id, after: "a good change" },
+    ]);
+
+    const page = await listDriftInbox(memexId, { limit: 200 });
+    expect(page.items.find((i) => i.commentId === corrupt.comment.id)?.proposal).toEqual({
+      kind: "unreadable",
+    });
+    // The blast radius of one bad body is ONE row, never the page.
+    expect(page.items.find((i) => i.commentId === good.comment.id)?.proposal?.kind).toBe(
+      "clause-ops",
+    );
+  });
+
+  it("leaves a drift observation with no proposal at all", async () => {
+    const { sectionId } = await seededStandard("Inbox Observation Standard", ["a rule"]);
+    const { flagDrift } = await import("./standards.js");
+    const drift = await flagDrift(memexId, sectionId, "the code diverged");
+
+    const row = await rowFor(drift.id);
+    expect(row?.proposal).toBeNull();
+    expect(row?.proposedContent).toBeNull();
+  });
+});

--- a/packages/server/src/services/drift-inbox.ts
+++ b/packages/server/src/services/drift-inbox.ts
@@ -29,9 +29,51 @@
 // AND comment_type IN ('drift', 'plan_revision')` so the query stays O(limit)
 // regardless of total comment count.
 
-import { sql } from "drizzle-orm";
+import { and, eq, inArray, ne, or, sql } from "drizzle-orm";
 import { db } from "../db/connection.js";
+import { standardClauses } from "../db/schema.js";
 import { parseProposedChangeBody } from "./standards.js";
+
+/**
+ * One clause operation of a proposal, as the Drift Inbox row renders it (spec-530 t-7).
+ *
+ * `before` is the target clause's body AS THE PROPOSAL WAS AUTHORED — the staleness
+ * evidence dec-3's guard compares against. `current` is what the clause says RIGHT NOW.
+ * Both travel because they answer different questions: `after` vs `current` is the diff a
+ * reviewer judges, while `before` vs `current` is whether the proposal still applies.
+ *
+ * Deliberately NO derived "is stale" verdict here. dec-3 put that judgement inside the
+ * accept transaction, and dec-4 gave it exactly one home; a second copy on a read model
+ * that can go out of date before the user acts would be the duplication dec-4's rationale
+ * exists to prevent. The row shows both bodies and lets the difference speak.
+ */
+export interface DriftProposalOperation {
+  op: "edit" | "delete" | "add";
+  /** The target's `cl-N` handle. For `add`, the ANCHOR it sits relative to. */
+  clause: string;
+  /** `add` only — which side of the anchor the new clause goes. */
+  placement?: "before" | "after";
+  /** The target's body at authoring time. Absent for `add` (nothing was there). */
+  before?: string;
+  /** The proposed text. Absent for `delete` (nothing replaces it). */
+  after?: string;
+  /** The clause's live body now, or null when it no longer exists (deleted since). */
+  current: string | null;
+}
+
+/**
+ * What a `plan_revision` row's body turned out to be.
+ *
+ * `legacy` is a pre-spec-530 whole-section replacement: readable, but not applyable by
+ * the clause-grained accept path. `unreadable` is a body that parses as neither — a
+ * proposal authored outside `proposeStandardChange`, or a corrupted payload. Both
+ * degrade to an explanatory row rather than throwing: one unusable row is the acceptable
+ * cost, a broken Inbox for every other item on the page is not (spec-530 ac-18).
+ */
+export type DriftProposal =
+  | { kind: "clause-ops"; operations: DriftProposalOperation[] }
+  | { kind: "legacy"; proposed: string }
+  | { kind: "unreadable" };
 
 export interface DriftInboxRow {
   commentId: string;
@@ -47,15 +89,29 @@ export interface DriftInboxRow {
   authorName: string;
   content: string;
   /**
-   * Normalized proposed replacement text for a `plan_revision` row (spec-143
-   * dec-2 / ac-9). ALWAYS non-null for a `plan_revision` so the React UI can
-   * render a before/after diff without re-parsing the fence — and so a proposal
-   * authored without the `~~~proposed-content` fence (older rows, or proposals
-   * written outside `proposeStandardChange`) still carries applyable text
-   * instead of falling through to an undifferentiated markdown blob. `null` for
-   * a `drift` observation, which is a finding with no proposed edit.
+   * Proposed replacement text for a `plan_revision` row. Non-null for every
+   * `plan_revision`, null for a `drift` observation.
+   *
+   * spec-530 t-7 CORRECTION: this field's original contract — "normalized proposed
+   * replacement text, so the UI renders a before/after diff" (spec-143 dec-2 / ac-9) —
+   * only ever made sense when a proposal WAS one replacement body. At the clause grain
+   * a proposal is a SET of operations and has no single "proposed body", so for a
+   * clause-ops row this carries the raw comment content (which holds the operations
+   * payload) rather than a synthesised rendering. **The UI renders `proposal`, not this
+   * field.** It stays non-null because the drift agent's context reads it, and after
+   * dec-4 the agent no longer needs to reproduce proposal text verbatim — it explains
+   * the proposal and calls the accept verb by ref, for which the payload suffices.
+   *
+   * Kept rather than removed, and its docstring corrected rather than left describing a
+   * contract it stopped honouring — which is the exact defect class this Spec is named
+   * after.
    */
   proposedContent: string | null;
+  /**
+   * The proposal's operations, resolved against the live clauses (spec-530 t-7). This
+   * is what the Inbox row renders. `null` for a `drift` observation.
+   */
+  proposal: DriftProposal | null;
   createdAt: Date;
   /**
    * The source DECISION a `drift` finding contradicts (spec-498 dec-4): a drift
@@ -136,18 +192,108 @@ function normalizeProposedContent(
 ): string | null {
   if (commentType !== "plan_revision") return null;
   const parsed = parseProposedChangeBody(content);
-  // spec-530 t-1: only the LEGACY shape yields a single replacement text. A
-  // clause-grained proposal is a set of operations and has no one "proposed body" —
-  // it falls through to the raw content below, exactly as an unfenced proposal does,
-  // until t-7 carries the structured operations to the client and renders per-clause
-  // diffs. Deliberately no synthesised rendering here: inventing one would put text
-  // on screen that no one proposed.
+  // Only the LEGACY shape yields a single replacement text. A clause-grained proposal is
+  // a set of operations and has no one "proposed body", so it falls through to the raw
+  // content — which is what the agent reads, and which carries the operations payload.
+  // Deliberately no synthesised rendering: inventing one would put text on a screen that
+  // nobody proposed. The structured `proposal` field below is what the UI renders
+  // (spec-530 t-7); see the field docstring for why this one survives.
   if (parsed?.kind === "legacy" && parsed.proposed.trim().length > 0) {
     return parsed.proposed;
   }
-  // Unfenced proposal: surface the raw body so the row still renders a diff
-  // rather than falling through to a blob.
   return content;
+}
+
+/**
+ * Resolve every proposal on the page against the live clauses, in ONE query.
+ *
+ * `cl-N` is per-STANDARD (seq is allocated MAX+1 per doc), so a handle only identifies a
+ * clause together with its docId — matching on seq alone would collide across two
+ * Standards in the same Memex and show the wrong rule text. The lookup is therefore an
+ * OR of per-doc `seq IN (…)` groups.
+ *
+ * Batched deliberately [per std-39]: the natural shape is a lookup inside the operation
+ * loop, which would be one query per clause per row — 50 proposals of 3 operations each
+ * would be 150 round-trips on a page render.
+ */
+async function resolveProposals(
+  memexId: string,
+  rows: { docId: string; commentType: "drift" | "plan_revision"; content: string }[],
+): Promise<Map<string, DriftProposal | null>> {
+  const out = new Map<string, DriftProposal | null>();
+  const parsedByKey = new Map<string, ReturnType<typeof parseProposedChangeBody>>();
+  const seqsByDoc = new Map<string, Set<number>>();
+
+  rows.forEach((r, i) => {
+    if (r.commentType !== "plan_revision") return;
+    const parsed = parseProposedChangeBody(r.content);
+    parsedByKey.set(String(i), parsed);
+    if (parsed?.kind !== "clause-ops") return;
+    for (const op of parsed.operations) {
+      const handle = op.op === "add" ? op.anchor : op.clause;
+      const seq = Number.parseInt(handle.replace(/^cl-/, ""), 10);
+      if (!Number.isInteger(seq)) continue;
+      const set = seqsByDoc.get(r.docId) ?? new Set<number>();
+      set.add(seq);
+      seqsByDoc.set(r.docId, set);
+    }
+  });
+
+  // doc → seq → live body, for every clause any proposal on this page targets.
+  const bodies = new Map<string, string>();
+  if (seqsByDoc.size > 0) {
+    const groups = [...seqsByDoc.entries()].map(([docId, seqs]) =>
+      and(eq(standardClauses.docId, docId), inArray(standardClauses.seq, [...seqs])),
+    );
+    const clauseRows = await db
+      .select({
+        docId: standardClauses.docId,
+        seq: standardClauses.seq,
+        body: standardClauses.body,
+      })
+      .from(standardClauses)
+      .where(
+        and(
+          eq(standardClauses.memexId, memexId),
+          ne(standardClauses.status, "deleted"),
+          groups.length === 1 ? groups[0] : or(...groups),
+        ),
+      );
+    for (const c of clauseRows) bodies.set(`${c.docId}|${c.seq}`, c.body);
+  }
+
+  rows.forEach((r, i) => {
+    if (r.commentType !== "plan_revision") {
+      out.set(String(i), null);
+      return;
+    }
+    const parsed = parsedByKey.get(String(i));
+    if (!parsed) {
+      out.set(String(i), { kind: "unreadable" });
+      return;
+    }
+    if (parsed.kind === "legacy") {
+      out.set(String(i), { kind: "legacy", proposed: parsed.proposed });
+      return;
+    }
+    const operations: DriftProposalOperation[] = parsed.operations.map((op) => {
+      const handle = op.op === "add" ? op.anchor : op.clause;
+      const seq = Number.parseInt(handle.replace(/^cl-/, ""), 10);
+      const current = Number.isInteger(seq)
+        ? (bodies.get(`${r.docId}|${seq}`) ?? null)
+        : null;
+      if (op.op === "add") {
+        return { op: "add", clause: op.anchor, placement: op.placement, after: op.body, current };
+      }
+      if (op.op === "edit") {
+        return { op: "edit", clause: op.clause, before: op.before, after: op.after, current };
+      }
+      return { op: "delete", clause: op.clause, before: op.before, current };
+    });
+    out.set(String(i), { kind: "clause-ops", operations });
+  });
+
+  return out;
 }
 
 interface RawRow {
@@ -277,7 +423,17 @@ export async function listDriftInbox(
   const last = pageRows[pageRows.length - 1];
   const nextCursor = hasMore && last ? encodeCursor(last.created_at, last.comment_id) : null;
 
-  const items: DriftInboxRow[] = pageRows.map((r) => ({
+  // One extra query for the whole page, not one per operation [per std-39].
+  const proposals = await resolveProposals(
+    memexId,
+    pageRows.map((r) => ({
+      docId: r.doc_id,
+      commentType: r.comment_type,
+      content: r.content,
+    })),
+  );
+
+  const items: DriftInboxRow[] = pageRows.map((r, i) => ({
     commentId: r.comment_id,
     // The `(doc_id, seq)` allocator mints per-doc `c-N` handles (schema.ts);
     // derive the canonical form here so every consumer gets the same string.
@@ -287,6 +443,7 @@ export async function listDriftInbox(
     authorName: r.author_name,
     content: r.content,
     proposedContent: normalizeProposedContent(r.comment_type, r.content),
+    proposal: proposals.get(String(i)) ?? null,
     // Raw SQL via db.execute returns timestamptz as ISO string; DriftInboxRow.createdAt
     // is typed as Date for callers, so coerce here.
     createdAt: r.created_at instanceof Date ? r.created_at : new Date(r.created_at),

--- a/packages/ui/e2e/helpers/retained.ts
+++ b/packages/ui/e2e/helpers/retained.ts
@@ -267,6 +267,21 @@ export async function seedExecutionPlan(opts: {
   return call("POST", "/seed-execution-plan", opts);
 }
 
+/** spec-530 t-7: seed an OPEN clause-grained proposal on a standard, through the real
+ *  `proposeStandardChange` — so the Drift Inbox row under test is the row users get. */
+export async function seedProposal(opts: {
+  memexId: string;
+  operations: {
+    op: "edit" | "delete" | "add";
+    clauseId: string;
+    body?: string;
+    placement?: "before" | "after";
+  }[];
+  rationale?: string;
+}): Promise<{ commentId: string; commentSeq: number }> {
+  return call("POST", "/seed-proposal", opts);
+}
+
 /** spec-496: seed clauses onto a standard's section through the real clause
  *  service — `std-N` mentions in bodies materialize as clause_refs mention
  *  edges (the standards map's backbone). */

--- a/packages/ui/e2e/journey-69-spec-530-proposal-diff.spec.ts
+++ b/packages/ui/e2e/journey-69-spec-530-proposal-diff.spec.ts
@@ -1,0 +1,108 @@
+import { test, expect, tenantPath } from "./helpers/index.js";
+import {
+  seedOrgTenant,
+  seedStandard,
+  seedClauses,
+  seedProposal,
+} from "./helpers/retained.js";
+
+// Journey 69 (spec-530 t-7): a proposal's before/after is READABLE in the Drift Inbox.
+//
+// The flow this covers used to dead-end. A proposal row was one line — "Proposes a
+// change to std-N …" — and the proposed text, though fetched to the client, was rendered
+// by no component. The file's own header claimed the diff was "reachable via Discuss
+// with Agent or the standard page"; it was reachable via neither. A user asked to judge
+// a proposal had no way to see what it said, which is half of what spec-530 ac-2 forbids
+// (the other half, the agent's truncated copy, is covered by ac-22's unit tests).
+//
+// Deliberately does NOT drive the accept. `accept_standard_change` is spec-530 t-4 and
+// is not on this branch; extending this journey to seed → read → accept → watch the row
+// clear is t-10, once that verb has merged. Asserting a read-only flow here rather than
+// pretending to cover the whole loop keeps the journey honest about what ships.
+//
+// Seeded through the env-gated test surface, never raw SQL [per std-28]; navigation is
+// path-based [per std-2].
+
+test("a proposal in the Drift Inbox reveals current vs proposed, per clause", async ({
+  page,
+  resources,
+}) => {
+  const slug = resources.slug("j69");
+  const tenant = await seedOrgTenant({ slug });
+
+  const standard = await seedStandard({
+    memexId: tenant.memexId,
+    title: "Caching Standard",
+    body: "",
+  });
+  const { clauseIds } = await seedClauses({
+    memexId: tenant.memexId,
+    sectionId: standard.sectionId,
+    clauses: [
+      "Cache every write.",
+      "Invalidate on delete.",
+    ],
+  });
+
+  // One proposal, two operations — an edit and an add — so the row exercises the SET
+  // shape dec-1 settled on, not just a single-clause change.
+  await seedProposal({
+    memexId: tenant.memexId,
+    operations: [
+      {
+        op: "edit",
+        clauseId: clauseIds[0],
+        body: "Cache every write except mutating endpoints.",
+      },
+      {
+        op: "add",
+        clauseId: clauseIds[1],
+        placement: "after",
+        body: "Never cache a response carrying a Set-Cookie header.",
+      },
+    ],
+    rationale: "The rule is too broad and is missing a case.",
+  });
+
+  await page.goto(tenantPath(tenant.namespaceSlug, tenant.memexSlug, "/drift"));
+
+  const row = page.getByTestId("drift-inbox-row").first();
+  await expect(row).toBeVisible();
+  await expect(row).toHaveAttribute("data-row-type", "proposal");
+
+  // Collapsed on arrival — spec-498 took the wall of text out of this list deliberately,
+  // and a proposal is now a SET, so an expanded default would put N blocks in a list.
+  await expect(page.getByTestId("drift-proposal-diff")).toHaveCount(0);
+
+  const toggle = row.getByTestId("drift-proposal-toggle");
+  await expect(toggle).toHaveText(/2 clause changes/);
+  await toggle.click();
+
+  const operations = page.getByTestId("drift-proposal-operation");
+  await expect(operations).toHaveCount(2);
+
+  // The edit: what the rule says now, and what the proposal wants it to say. This is
+  // the text a user could not see before.
+  const edit = operations.nth(0);
+  await expect(edit).toHaveAttribute("data-op", "edit");
+  await expect(edit.getByTestId("drift-proposal-current")).toContainText("Cache every write.");
+  await expect(edit.getByTestId("drift-proposal-proposed")).toContainText(
+    "Cache every write except mutating endpoints.",
+  );
+  // Named by its canonical handle [per std-10] — the same identifier the agent acts on.
+  await expect(edit.getByTestId("drift-proposal-clause")).toHaveText(/^cl-\d+$/);
+
+  // The add: a clause the rule does not have yet, anchored to one it does.
+  const add = operations.nth(1);
+  await expect(add).toHaveAttribute("data-op", "add");
+  await expect(add).toContainText("Never cache a response carrying a Set-Cookie header.");
+
+  // Read-only [per spec-143 dec-3, restated in spec-530's non-goals]: reading the diff
+  // must not put an Accept control on screen. Acceptance is a conversation.
+  await expect(page.getByRole("button", { name: /^accept/i })).toHaveCount(0);
+  await expect(page.getByRole("button", { name: /^reject/i })).toHaveCount(0);
+
+  // And it collapses again, so a reader who opened the wrong row can put it back.
+  await toggle.click();
+  await expect(page.getByTestId("drift-proposal-operation")).toHaveCount(0);
+});

--- a/packages/ui/src/api/drift.ts
+++ b/packages/ui/src/api/drift.ts
@@ -6,6 +6,38 @@ import { fetchWithRetry } from './http';
 import { tBase } from './internal';
 
 /**
+ * One clause operation of a proposal (spec-530 t-7).
+ *
+ * `after` vs `current` is the diff a reviewer judges. `before` vs `current` says whether
+ * the proposal still applies — the row shows both bodies and derives no verdict, because
+ * that judgement lives inside the accept transaction (spec-530 dec-3/dec-4), not here.
+ */
+export interface DriftProposalOperation {
+  op: 'edit' | 'delete' | 'add';
+  /** The target's `cl-N` handle. For `add`, the ANCHOR it sits relative to. */
+  clause: string;
+  /** `add` only — which side of the anchor the new clause goes. */
+  placement?: 'before' | 'after';
+  /** The target's body at authoring time. Absent for `add`. */
+  before?: string;
+  /** The proposed text. Absent for `delete`. */
+  after?: string;
+  /** The clause's live body now, or null when it no longer exists. */
+  current: string | null;
+}
+
+/**
+ * A `plan_revision`'s body, as the server read it. `legacy` is a pre-spec-530
+ * whole-section replacement (readable, not applyable clause by clause); `unreadable` is
+ * a body that parses as neither. Both render an explanatory row rather than breaking the
+ * page for every other item on it.
+ */
+export type DriftProposal =
+  | { kind: 'clause-ops'; operations: DriftProposalOperation[] }
+  | { kind: 'legacy'; proposed: string }
+  | { kind: 'unreadable' };
+
+/**
  * Drift Inbox row — open `drift` or `plan_revision` typed comment with parent
  * doc + section context attached. See packages/server/src/services/drift-inbox.ts
  * for the canonical shape.
@@ -21,13 +53,19 @@ export interface DriftInboxItem {
   authorName: string;
   content: string;
   /**
-   * Normalized proposed replacement text (spec-143 dec-2 / ac-9). The server
-   * guarantees this is non-null for every `plan_revision` — including proposals
-   * authored without the `~~~proposed-content` fence — so the inbox always
-   * renders a proposal as a before/after diff and never falls through to an
-   * undifferentiated blob. `null` for a `drift` observation.
+   * Proposed replacement text; non-null for every `plan_revision`, null for a `drift`.
+   *
+   * spec-530 t-7: **the row does NOT render this.** At the clause grain a proposal is a
+   * set of operations with no single "proposed body", so for a clause-ops row this is
+   * the raw comment content. It survives because the drift agent's context reads it.
+   * Render `proposal` instead.
    */
   proposedContent: string | null;
+  /**
+   * The proposal's operations, resolved against the live clauses (spec-530 t-7) — what
+   * the row renders. `null` for a `drift` observation.
+   */
+  proposal: DriftProposal | null;
   createdAt: string; // ISO timestamp from the JSON wire
   /**
    * The source DECISION a `drift` finding contradicts (spec-498 dec-4) — its

--- a/packages/ui/src/components/drift/ProposalDisclosure.tsx
+++ b/packages/ui/src/components/drift/ProposalDisclosure.tsx
@@ -1,0 +1,170 @@
+import { useState } from 'react';
+import type { DriftProposal, DriftProposalOperation } from '../../api/client';
+
+/**
+ * The before/after a Drift Inbox proposal row promises (spec-530 t-7).
+ *
+ * The row used to claim, in its own header comment, that the diff was "reachable via
+ * Discuss with Agent or the standard page". Verified 2026-08-13: it was reachable via
+ * neither. `proposedContent` was fetched to the client and rendered by nothing, so a
+ * user judging a proposal had no way to see what it actually said.
+ *
+ * **Collapsed by default, and collapsed means NOT RENDERED — not hidden with CSS.**
+ * spec-498 deliberately took the heavy diff out of the list ("the important information
+ * at a glance, not a wall of text") and pinned that with tests asserting the diff
+ * element is absent. Those tests stay green here, unchanged: nothing of the diff enters
+ * the DOM until the reader asks for it. A 12-operation proposal is therefore still one
+ * scannable line in the list, which is the only way dec-1's operation SETS could live on
+ * this surface at all.
+ *
+ * **Read-only.** No Accept / Reject / Resolve control — spec-143 dec-3 removed those
+ * deliberately, on the grounds that accepting a proposal is a judgement rather than a
+ * one-click yes/no, and spec-530's non-goals explicitly decline to revisit that. The
+ * reader forms a view here and tells the agent; the agent applies it behind a
+ * confirmation gate.
+ */
+export function ProposalDisclosure({ proposal }: { proposal: DriftProposal | null }) {
+  const [open, setOpen] = useState(false);
+  if (!proposal) return null;
+
+  // A legacy or unreadable body has no operations to diff. Say so in one line rather
+  // than dumping the body — an unapplicable row must cost one explanatory sentence, not
+  // the wall of text spec-498 removed (spec-530 ac-18).
+  if (proposal.kind !== 'clause-ops') {
+    return (
+      <p
+        className="mt-2 text-xs text-muted"
+        data-testid="drift-proposal-unapplicable"
+        data-proposal-kind={proposal.kind}
+      >
+        {proposal.kind === 'legacy'
+          ? 'This proposal predates the clause grain — it replaces a whole section, so it cannot be applied clause by clause. Ask the agent to restate it against the current rule.'
+          : 'This proposal carries no readable changes, so it cannot be applied. Ask the agent to re-propose it.'}
+      </p>
+    );
+  }
+
+  const count = proposal.operations.length;
+  const label = `${count} clause change${count === 1 ? '' : 's'}`;
+
+  return (
+    <div className="mt-2">
+      <button
+        type="button"
+        // The row itself focuses the agent on click; expanding a diff must not also
+        // fire that.
+        onClick={(e) => {
+          e.stopPropagation();
+          setOpen((v) => !v);
+        }}
+        aria-expanded={open}
+        className="text-xs px-2.5 py-1 rounded-full border border-edge bg-card-hover text-secondary hover:text-primary hover:border-accent transition-colors"
+        data-testid="drift-proposal-toggle"
+        data-open={open ? 'true' : 'false'}
+      >
+        {open ? 'Hide' : 'Show'} {label}
+      </button>
+
+      {open && (
+        <div
+          className="mt-3 space-y-3"
+          data-testid="drift-proposal-diff"
+          onClick={(e) => e.stopPropagation()}
+        >
+          {proposal.operations.map((op, i) => (
+            <OperationDiff key={`${op.op}-${op.clause}-${i}`} op={op} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+const OP_LABEL: Record<DriftProposalOperation['op'], string> = {
+  edit: 'Edit',
+  add: 'Add',
+  delete: 'Remove',
+};
+
+function OperationDiff({ op }: { op: DriftProposalOperation }) {
+  return (
+    <div
+      className="border border-edge-subtle rounded-md p-3 bg-surface/40"
+      data-testid="drift-proposal-operation"
+      data-op={op.op}
+      data-clause={op.clause}
+    >
+      <div className="flex items-baseline gap-2 mb-2">
+        <span className="text-xs font-medium text-secondary">{OP_LABEL[op.op]}</span>
+        {/* The cl-N is what the reader and the agent both name the target by
+            [per std-10] — never "the second clause". */}
+        <span className="font-mono text-xs text-muted" data-testid="drift-proposal-clause">
+          {op.clause}
+        </span>
+        {op.op === 'add' && (
+          <span className="text-xs text-muted">
+            new clause {op.placement === 'before' ? 'before' : 'after'} it
+          </span>
+        )}
+      </div>
+
+      {/* An add's `current` is its ANCHOR's text — context for where the new clause
+          lands, not something being replaced. */}
+      {op.op === 'add' ? (
+        <>
+          {op.current !== null && (
+            <Body kind="context" label="Anchored to" text={op.current} />
+          )}
+          {op.after !== undefined && <Body kind="proposed" label="New clause" text={op.after} />}
+        </>
+      ) : (
+        <>
+          {op.current === null ? (
+            <p className="text-xs text-muted" data-testid="drift-proposal-clause-gone">
+              This clause no longer exists on the Standard.
+            </p>
+          ) : (
+            <Body kind="current" label="Now" text={op.current} />
+          )}
+          {op.op === 'edit' && op.after !== undefined && (
+            <Body kind="proposed" label="Proposed" text={op.after} />
+          )}
+          {op.op === 'delete' && (
+            <p className="mt-2 text-xs text-status-danger-text">Removed entirely.</p>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+/**
+ * One side of a diff. The tints are the shared status tokens, so both themes are handled
+ * by the token layer rather than by a palette invented here [per the design system].
+ */
+function Body({
+  kind,
+  label,
+  text,
+}: {
+  kind: 'current' | 'proposed' | 'context';
+  label: string;
+  text: string;
+}) {
+  const tone =
+    kind === 'proposed'
+      ? 'bg-status-success-bg border-status-success-border text-status-success-text'
+      : kind === 'current'
+        ? 'bg-status-danger-bg border-status-danger-border text-status-danger-text'
+        : 'border-edge-subtle text-muted';
+  return (
+    <div className="mt-2 first:mt-0" data-testid={`drift-proposal-${kind}`}>
+      <div className="text-[10px] uppercase tracking-wide text-muted mb-1">{label}</div>
+      {/* whitespace-pre-wrap: clause bodies are markdown and their line breaks are
+          meaningful. break-words so a long URL cannot widen the row. */}
+      <div className={`border rounded-sm px-2 py-1.5 text-xs whitespace-pre-wrap break-words ${tone}`}>
+        {text}
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/pages/DriftInbox.proposal.spec-530.test.tsx
+++ b/packages/ui/src/pages/DriftInbox.proposal.spec-530.test.tsx
@@ -1,0 +1,307 @@
+// spec-530 t-7 (ac-2) — the human half of "the proposed text is fully visible to both
+// readers who must judge it".
+//
+// ac-2 is a SCOPE criterion covering two readers, and it fails unless BOTH pass:
+//   - the AGENT half is ac-22, already green — `buildDriftContext` stops truncating
+//     `proposedContent` at 500 characters (spec-530 t-6);
+//   - the HUMAN half is this file — the Drift Inbox row renders the current clause and
+//     the proposed clause, with the cl-N visible.
+// Tagging ac-2 here is therefore only honest BECAUSE ac-22 is green. If ac-22 ever goes
+// red, ac-2's badge is lying regardless of what this file says.
+//
+// The row previously rendered NOTHING of the proposal: `proposedContent` came down the
+// wire and no component read it, while the file's own header claimed the diff was
+// "reachable via Discuss with Agent or the standard page" — true of neither.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { DriftInbox } from './DriftInbox';
+import type { DriftInboxItem, DriftProposalOperation } from '../api/client';
+
+// scope ac-2: BOTH readers see the proposal whole (composes with ac-22, the agent half).
+const AC_2 = 'mindset-prod/memex-building-itself/specs/spec-530/acs/ac-2';
+// spec-143 dec-3 / spec-530 non-goals: the Inbox carries no action controls.
+const AC_5 = 'mindset-prod/memex-building-itself/specs/spec-530/acs/ac-5';
+// spec-530 t-9: a legacy body degrades to an explanatory row, never a crash.
+const AC_18 = 'mindset-prod/memex-building-itself/specs/spec-530/acs/ac-18';
+
+vi.mock('../hooks/useDocChangeStream', () => ({ useDocChangeStream: () => {} }));
+vi.mock('../components/ChatContext', () => ({
+  useChat: () => ({
+    addContextChip: vi.fn(),
+    sendMessage: vi.fn(),
+    enterDriftMode: vi.fn(),
+    exitDriftMode: vi.fn(),
+    isDriftMode: true,
+  }),
+}));
+vi.mock('../components/ChatPanel', () => ({
+  ChatPanel: () => <div data-testid="chat-panel">agent</div>,
+}));
+vi.mock('../components/AuthContext', () => ({ useAuth: () => ({ isAuthenticated: true }) }));
+vi.mock('../hooks/useMemexAccess', () => ({ useMemexAccess: () => ({ canWrite: true }) }));
+
+const fetchDriftInboxMock = vi.fn();
+vi.mock('../api/client', () => ({
+  fetchDriftInbox: (...args: unknown[]) => fetchDriftInboxMock(...args),
+  resolveComment: vi.fn(),
+}));
+
+function proposalItem(overrides: Partial<DriftInboxItem> = {}): DriftInboxItem {
+  return {
+    commentId: 'prop-1',
+    commentHandle: 'c-5',
+    commentType: 'plan_revision',
+    source: 'agent',
+    authorName: 'Agent',
+    content: 'raw comment body with the operations payload',
+    proposedContent: 'raw comment body with the operations payload',
+    proposal: {
+      kind: 'clause-ops',
+      operations: [
+        {
+          op: 'edit',
+          clause: 'cl-12',
+          before: 'Cache every write.',
+          after: 'Cache every write except mutating endpoints.',
+          current: 'Cache every write.',
+        },
+      ],
+    },
+    createdAt: '2025-01-01T00:00:00Z',
+    decision: null,
+    section: { id: 's-1', sectionType: 'do', title: null, content: 'Cache every write.' },
+    doc: {
+      id: 'd-1',
+      handle: 'std-100',
+      title: 'Caching standard',
+      docType: 'standard',
+      status: 'build',
+    },
+    ...overrides,
+  };
+}
+
+function renderInbox() {
+  return render(
+    <MemoryRouter initialEntries={['/drift']}>
+      <DriftInbox />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('spec-530 t-7: a proposal row shows current vs proposed per operation (ac-2)', () => {
+  it('reveals the current clause, the proposed clause and the cl-N when expanded', async () => {
+    tagAc(AC_2);
+    fetchDriftInboxMock.mockResolvedValueOnce([proposalItem()]);
+    const user = userEvent.setup();
+    renderInbox();
+
+    // Collapsed to start — nothing of the diff is in the DOM yet (see the
+    // spec-498 note below).
+    expect(await screen.findByTestId('drift-inbox-row')).toBeInTheDocument();
+    expect(screen.queryByTestId('drift-proposal-diff')).toBeNull();
+
+    await user.click(screen.getByTestId('drift-proposal-toggle'));
+
+    const diff = screen.getByTestId('drift-proposal-diff');
+    // The target, named by its canonical handle [per std-10] — never "the second one".
+    expect(diff.querySelector('[data-testid="drift-proposal-clause"]')!.textContent).toBe('cl-12');
+    // What the rule says now…
+    expect(diff.querySelector('[data-testid="drift-proposal-current"]')!.textContent).toContain(
+      'Cache every write.',
+    );
+    // …and what the proposal wants it to say. THIS is the text a user could not see.
+    expect(diff.querySelector('[data-testid="drift-proposal-proposed"]')!.textContent).toContain(
+      'Cache every write except mutating endpoints.',
+    );
+  });
+
+  it('renders the proposed text in full — not truncated, which is ac-2\'s whole point', async () => {
+    tagAc(AC_2);
+    // Longer than DRIFT_BODY_MAX (500), the cap that silently cut the AGENT's copy
+    // until t-6. Neither reader may see a string that has been quietly shortened.
+    const long = `${'A'.repeat(600)}END-OF-PROPOSAL`;
+    fetchDriftInboxMock.mockResolvedValueOnce([
+      proposalItem({
+        proposal: {
+          kind: 'clause-ops',
+          operations: [
+            { op: 'edit', clause: 'cl-3', before: 'short', after: long, current: 'short' },
+          ],
+        },
+      }),
+    ]);
+    const user = userEvent.setup();
+    renderInbox();
+
+    await user.click(await screen.findByTestId('drift-proposal-toggle'));
+    expect(
+      screen.getByTestId('drift-proposal-diff').querySelector('[data-testid="drift-proposal-proposed"]')!
+        .textContent,
+    ).toContain('END-OF-PROPOSAL');
+  });
+
+  it('shows an add as a new clause anchored to a cl-N, and a delete as a removal', async () => {
+    tagAc(AC_2);
+    fetchDriftInboxMock.mockResolvedValueOnce([
+      proposalItem({
+        proposal: {
+          kind: 'clause-ops',
+          operations: [
+            {
+              op: 'add',
+              clause: 'cl-7',
+              placement: 'after',
+              after: 'The rule was missing this case.',
+              current: 'The anchor clause.',
+            },
+            { op: 'delete', clause: 'cl-9', before: 'Obsolete.', current: 'Obsolete.' },
+          ],
+        },
+      }),
+    ]);
+    const user = userEvent.setup();
+    renderInbox();
+    await user.click(await screen.findByTestId('drift-proposal-toggle'));
+
+    const ops = screen.getAllByTestId('drift-proposal-operation');
+    expect(ops).toHaveLength(2);
+    expect(ops[0]).toHaveAttribute('data-op', 'add');
+    expect(ops[0]).toHaveAttribute('data-clause', 'cl-7');
+    expect(ops[0].textContent).toContain('The rule was missing this case.');
+    expect(ops[1]).toHaveAttribute('data-op', 'delete');
+    expect(ops[1].textContent).toContain('Removed entirely.');
+  });
+
+  it('says so when the targeted clause no longer exists, instead of rendering a blank', async () => {
+    tagAc(AC_2);
+    fetchDriftInboxMock.mockResolvedValueOnce([
+      proposalItem({
+        proposal: {
+          kind: 'clause-ops',
+          operations: [
+            { op: 'edit', clause: 'cl-4', before: 'gone', after: 'never applied', current: null },
+          ],
+        },
+      }),
+    ]);
+    const user = userEvent.setup();
+    renderInbox();
+    await user.click(await screen.findByTestId('drift-proposal-toggle'));
+
+    expect(screen.getByTestId('drift-proposal-clause-gone').textContent).toContain(
+      'no longer exists',
+    );
+  });
+});
+
+describe('spec-530 t-7: the list stays scannable, and gains no action controls', () => {
+  it('keeps a 12-operation proposal to one line until the reader opens it', async () => {
+    tagAc(AC_2);
+    const operations: DriftProposalOperation[] = Array.from({ length: 12 }, (_, i) => ({
+      op: 'edit' as const,
+      clause: `cl-${i + 1}`,
+      before: `old body ${i + 1}`,
+      after: `new body ${i + 1}`,
+      current: `old body ${i + 1}`,
+    }));
+    fetchDriftInboxMock.mockResolvedValueOnce([
+      proposalItem({ proposal: { kind: 'clause-ops', operations } }),
+    ]);
+    const user = userEvent.setup();
+    renderInbox();
+
+    // dec-1 made a proposal a SET, which is only liveable on this surface because the
+    // set is collapsed by default. Twelve operations must not become twelve stacked
+    // blocks in a list.
+    const toggle = await screen.findByTestId('drift-proposal-toggle');
+    expect(toggle.textContent).toContain('12 clause changes');
+    expect(screen.queryAllByTestId('drift-proposal-operation')).toHaveLength(0);
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+
+    await user.click(toggle);
+    expect(screen.getAllByTestId('drift-proposal-operation')).toHaveLength(12);
+    expect(toggle).toHaveAttribute('aria-expanded', 'true');
+
+    // And it collapses again — a reader who opened the wrong row can put it back.
+    await user.click(toggle);
+    expect(screen.queryAllByTestId('drift-proposal-operation')).toHaveLength(0);
+  });
+
+  it('adds NO Accept / Reject / Resolve control — spec-143 dec-3 stands (ac-5)', async () => {
+    tagAc(AC_5);
+    fetchDriftInboxMock.mockResolvedValueOnce([proposalItem()]);
+    const user = userEvent.setup();
+    renderInbox();
+    await user.click(await screen.findByTestId('drift-proposal-toggle'));
+
+    // The row is READ-ONLY. spec-530's non-goals decline to revisit spec-143 dec-3, and
+    // the drift agent's guidance tells users acceptance happens in conversation — an
+    // Accept button here would make that guidance a lie again [per std-34].
+    const row = screen.getByTestId('drift-inbox-row');
+    for (const name of [/^accept/i, /^reject/i, /^resolve/i, /^apply/i]) {
+      expect(screen.queryByRole('button', { name })).toBeNull();
+    }
+    // Exactly two buttons on the row: Discuss with Agent, and the diff disclosure.
+    expect(row.querySelectorAll('button')).toHaveLength(2);
+  });
+
+  it('expanding the diff does not fire the row-level focus action', async () => {
+    tagAc(AC_2);
+    fetchDriftInboxMock.mockResolvedValueOnce([proposalItem()]);
+    const user = userEvent.setup();
+    renderInbox();
+
+    // The row focuses the agent on click. The disclosure sits inside it, so without
+    // stopPropagation, reading a diff would silently retarget the agent conversation.
+    await user.click(await screen.findByTestId('drift-proposal-toggle'));
+    expect(screen.getByTestId('drift-proposal-diff')).toBeInTheDocument();
+  });
+});
+
+describe('spec-530 t-7: an unapplicable proposal degrades to one row, never a crash (ac-18)', () => {
+  it('explains a legacy whole-section proposal instead of dumping its body', async () => {
+    tagAc(AC_18);
+    fetchDriftInboxMock.mockResolvedValueOnce([
+      proposalItem({
+        proposal: { kind: 'legacy', proposed: 'A WHOLE REPLACEMENT SECTION BODY.' },
+      }),
+    ]);
+    renderInbox();
+
+    const note = await screen.findByTestId('drift-proposal-unapplicable');
+    expect(note).toHaveAttribute('data-proposal-kind', 'legacy');
+    expect(note.textContent).toContain('predates the clause grain');
+    // The wall of text spec-498 removed does not come back through this door.
+    expect(screen.getByTestId('drift-inbox-row').textContent).not.toContain(
+      'A WHOLE REPLACEMENT SECTION BODY.',
+    );
+    // Nothing to expand — there are no operations to diff.
+    expect(screen.queryByTestId('drift-proposal-toggle')).toBeNull();
+  });
+
+  it('renders every OTHER row when one proposal is unreadable — the blast radius is one row', async () => {
+    tagAc(AC_18);
+    fetchDriftInboxMock.mockResolvedValueOnce([
+      proposalItem({ commentId: 'bad', proposal: { kind: 'unreadable' } }),
+      proposalItem({ commentId: 'good' }),
+    ]);
+    renderInbox();
+
+    const rows = await screen.findAllByTestId('drift-inbox-row');
+    expect(rows).toHaveLength(2);
+    expect(screen.getByTestId('drift-proposal-unapplicable').textContent).toContain(
+      'no readable changes',
+    );
+    // The healthy row still offers its diff.
+    expect(screen.getAllByTestId('drift-proposal-toggle')).toHaveLength(1);
+  });
+});

--- a/packages/ui/src/pages/DriftInbox.test.tsx
+++ b/packages/ui/src/pages/DriftInbox.test.tsx
@@ -368,6 +368,23 @@ describe('DriftInbox — two explicit row types, drift-card style (spec-143 dec-
         commentType: 'plan_revision',
         content: 'Reword.\n~~~proposed-content\nAlways cache with Redis.\n~~~',
         proposedContent: 'Always cache with Redis.',
+        // spec-530 t-7: this fixture now carries real operations. Without them the
+        // assertions below passed for the wrong reason — the row had no proposal to
+        // render at all, so "the diff is not in the list" was true vacuously. With them,
+        // this test genuinely re-asserts spec-498's invariant against the new rendering
+        // path: the diff exists, and it is COLLAPSED, so nothing of it reaches the list.
+        proposal: {
+          kind: 'clause-ops',
+          operations: [
+            {
+              op: 'edit',
+              clause: 'cl-1',
+              before: 'Always cache.',
+              after: 'Always cache with Redis.',
+              current: 'Always cache.',
+            },
+          ],
+        },
         section: { id: 's-9', sectionType: 'do', title: null, content: 'Always cache.' },
       }),
     ]);

--- a/packages/ui/src/pages/DriftInbox.tsx
+++ b/packages/ui/src/pages/DriftInbox.tsx
@@ -7,6 +7,7 @@ import { tenantPath } from '../utils/tenantUrl';
 import { timeAgo } from '../utils/timeAgo';
 import { Spinner } from '../components/Spinner';
 import { OpeningDriftController } from '../components/chat/OpeningDriftController';
+import { ProposalDisclosure } from '../components/drift/ProposalDisclosure';
 
 /**
  * Standards Drift Inbox (t-10 of doc-8; scoped to Standards in b-63). Surfaces
@@ -23,8 +24,17 @@ import { OpeningDriftController } from '../components/chat/OpeningDriftControlle
  *     standard (`std-N` + title) it violates. The full comment body is NOT dumped
  *     into the list (too much to read); the agent explains detail on Discuss.
  *   - Proposal (`plan_revision`) — a proposed change to a standard. Rendered as a
- *     one-line "Proposes a change to std-N …". The heavy before/after diff is out
- *     of the list — reachable via Discuss with Agent or the standard page.
+ *     one-line "Proposes a change to std-N …" plus a COLLAPSED disclosure carrying the
+ *     per-clause before/after (spec-530 t-7). Collapsed means not rendered, not hidden:
+ *     the list stays scannable at a glance, which is what spec-498 was protecting, and
+ *     a 12-operation proposal is still one line until the reader opens it.
+ *
+ * This header used to claim the diff was "reachable via Discuss with Agent or the
+ * standard page". Verified 2026-08-13: it was reachable via NEITHER — `proposedContent`
+ * came down the wire and was rendered by no component, so a user judging a proposal had
+ * no way to see what it said. That claim is corrected rather than deleted, because the
+ * gap between what a comment promises and what the code does is the defect spec-530 is
+ * named after.
  *
  * No inline action buttons (spec-143 dec-3). The per-row Accept / Reject /
  * Resolve buttons are gone — deciding whether a standard should change in
@@ -320,20 +330,26 @@ function DriftInboxBody({
                     one-liner. Neither dumps the full comment body / diff (spec-498
                     — too much to read in a list; the agent explains on Discuss). */}
                 {isProposal ? (
-                  <div
-                    className="flex items-baseline gap-1.5 text-sm min-w-0"
-                    data-testid="drift-proposal-summary"
-                  >
-                    <span className="flex-none text-muted">Proposes a change to</span>
-                    <Link
-                      to={docHref}
-                      onClick={(e) => e.stopPropagation()}
-                      className="flex-none font-mono text-secondary hover:underline"
+                  <>
+                    <div
+                      className="flex items-baseline gap-1.5 text-sm min-w-0"
+                      data-testid="drift-proposal-summary"
                     >
-                      {item.doc.handle}
-                    </Link>
-                    <span className="truncate text-secondary">{item.doc.title}</span>
-                  </div>
+                      <span className="flex-none text-muted">Proposes a change to</span>
+                      <Link
+                        to={docHref}
+                        onClick={(e) => e.stopPropagation()}
+                        className="flex-none font-mono text-secondary hover:underline"
+                      >
+                        {item.doc.handle}
+                      </Link>
+                      <span className="truncate text-secondary">{item.doc.title}</span>
+                    </div>
+                    {/* spec-530 t-7: the before/after this row has promised since
+                        spec-143 and never delivered. Read-only — spec-143 dec-3's
+                        no-action-buttons rule stands. */}
+                    <ProposalDisclosure proposal={item.proposal ?? null} />
+                  </>
                 ) : (
                   <div className="space-y-1 text-sm" data-testid="drift-observation-body">
                     {item.decision ? (


### PR DESCRIPTION
## Why

**The row promised a diff and delivered nothing.** `proposedContent` came down the wire and was rendered by no component, while `DriftInbox.tsx`'s own header claimed the before/after was *"reachable via Discuss with Agent or the standard page"* — verified 2026-08-13 as true of **neither**. A user asked to judge a proposal had no way to see what it said.

That is the human half of **ac-2**. The agent half — a copy silently truncated at 500 characters — was t-6, already shipped. ac-2 needs both, and it goes green with this.

📋 [spec-530](https://memex.ai/mindset-prod/memex-building-itself/specs/spec-530) — delivers **t-7**. Independent of PR #622 (t-4/t-5); this one depends only on the clause-grain body contract already on `develop`.

## What lands

**The read model carries the proposal's operations.** Per operation: the `cl-N`, the proposed text, and what that clause says **right now**. `current` is a database read, so it belongs on the server rather than re-derived in the client — and `cl-N` is per-*Standard*, so the lookup is scoped by `docId`. Matching on `seq` alone would show one Standard's rule text under another's proposal, which is tested.

Batched to **one query per page**, not one per operation [per **std-39**] — the natural shape is a lookup inside the operation loop, and 50 proposals of 3 operations each would be 150 round-trips on a page render.

**Deliberately no derived "this is stale" verdict.** `before` and `current` both travel because they answer different questions — `after` vs `current` is the diff a reviewer judges, `before` vs `current` is whether the proposal still applies. But the row states them and concludes nothing: dec-3 put that judgement inside the accept transaction and dec-4 gave it exactly one home. A second copy on a read model that can go stale before the user acts is the duplication dec-4's rationale exists to prevent.

**Collapsed by default — and collapsed means NOT RENDERED, not CSS-hidden.** That is what makes dec-1's operation *sets* liveable on this surface: a 12-operation proposal is still one line until the reader opens it.

**Read-only.** No Accept / Reject / Resolve control — spec-143 dec-3 stands and this Spec's non-goals decline to revisit it. A button here would make the drift agent's corrected guidance a lie again [per **std-34**].

## The conflict with spec-498, reconciled and verified

spec-498 deliberately took the heavy diff out of this list and **pinned its absence with tests**. This PR puts a diff back, so that needed settling rather than papering over.

It settles cleanly: those tests assert the diff is absent *on initial render*, and a disclosure that renders nothing until opened satisfies them literally. **All 23 stay green, none re-baselined.**

But they were also passing for the **wrong reason** — their proposal fixture had no `proposal` field at all, so "the diff is not in the list" was vacuously true and the test never exercised the new path. The ac-9 fixture now carries real operations, and I confirmed that test **fails** when the diff renders unconditionally. spec-498's invariant is now genuinely guarded rather than accidentally satisfied.

## Also corrected

`proposedContent`'s docstring still promised *"normalized proposed replacement text… so the inbox always renders a proposal as a before/after diff"* — a contract it stopped honouring the moment a proposal became a set of operations. It is now documented as what it actually is: the raw payload the **agent** reads. The UI renders `proposal`. Leaving that comment as-is would have been the exact defect this Spec is named after.

## Test plan

- [x] New: `drift-inbox-proposal.spec-530.integration` (7, server read model), `DriftInbox.proposal.spec-530` (9, the row)
- [x] **The tests were mutation-checked**: rendering the diff unconditionally fails 2 of mine *and* spec-498's ac-9 test. A green test that doesn't discriminate is worse than no test
- [x] `journey-69-spec-530-proposal-diff.spec.ts` [per **std-28**] — seeded through a new `/seed-proposal` endpoint on the env-gated surface, going through the real `proposeStandardChange` (no raw SQL). **1 passed** locally against an isolated pg16 e2e DB
- [x] Full server suite: **1 failed / 6173 passed** — the known `.ee/slack/oauth.test.ts` local-red/CI-green flake
- [x] Full UI suite: 1 failed / 2340 passed on the first run — the **tailwind-rename guard** on a deprecated `rounded`, which a targeted run misses — then green
- [x] `make check` green · `tsc -b` + vite build green
- [x] ac-2 and ac-18 green via `list_acs`; **19 → 20 of 24 verified**
- [ ] **Not visually inspected in light and dark.** Conformance is by construction (shared `status-success`/`status-danger` tokens, existing row treatment, no invented palette) plus the rename guard. Worth a human eyeball before verify
- [ ] The journey does **not** drive the accept — that verb is t-4, on another branch. Seed → read → accept → row-clears is **t-10**, now unblocked

## Known gaps

**issue-2 registered (todo, pre-existing).** Running any journey floods the log with std-32 `ATTRIBUTION DEFECT` lines, because `/seed-doc` calls `createDocDraft` and `addSection` with no `RequestCtx`. Verified pre-existing on `develop`, not introduced here. Worth fixing not because the seeded rows' attribution matters, but because **that log is the mechanism std-32 chose to make unattributed writes visible** — a surface that fires it dozens of times per run trains every reader to scroll past it, and the next real one is indistinguishable from the noise. Deliberately not folded into a UI task.

## Deployment

No schema changes, no migrations. One new **env-gated** test-surface endpoint (`/seed-proposal`), never mounted in production. Tenancy unchanged; every mutation still through `mutate()` [per **std-8**]. Fair-code [per **std-25**].

Merging to `develop` is fine independently of #622. Promotion to `main` still waits on t-11 converting the legacy proposals — unchanged from #622's note.
