### PR TITLE
release: spec-530 proposals can be accepted (atomically, and refused when stale) · spec-520 tenant-scoped ingest

### DIFF
--- a/packages/server/src/__regression__/mutate-coverage.endpoint.regression.test.ts
+++ b/packages/server/src/__regression__/mutate-coverage.endpoint.regression.test.ts
@@ -196,6 +196,21 @@ const MUTATING_MCP_TOOLS: Record<string, ToolMutation[]> = {
     { entity: "comment", action: "created" },
     { entity: "standard_drift", action: "created" },
   ],
+  // spec-530 t-4 (dec-4): the accept applies a SET of clause operations and resolves
+  // the proposal in ONE transaction, so it emits a composite — one event per clause
+  // touched (the action depends on the operation kind, so all three appear here), the
+  // `section` updated for the regenerated rule text, and the `comment` +
+  // `standard_drift` pair that clears the Inbox row and the drift-count chip. A silent
+  // accept is the same defect as the one this Spec fixes: the work happened and the
+  // surface still says it did not (ac-12).
+  accept_standard_change: [
+    { entity: "clause", action: "created" },
+    { entity: "clause", action: "updated" },
+    { entity: "clause", action: "deleted" },
+    { entity: "section", action: "updated" },
+    { entity: "comment", action: "updated" },
+    { entity: "standard_drift", action: "updated" },
+  ],
 };
 
 describe("doc-16 t-11 / spec-156 ac-25: endpoint coverage — every mutation entry point is registered", () => {

--- a/packages/server/src/__regression__/ref-emission.regression.test.ts
+++ b/packages/server/src/__regression__/ref-emission.regression.test.ts
@@ -37,7 +37,7 @@ import {
 } from "../db/schema.js";
 import { makeTestMemex } from "../services/test-helpers.js";
 import { createDocDraft } from "../services/documents.js";
-import { createStandard } from "../services/standards.js";
+import { createStandard, proposeStandardChange } from "../services/standards.js";
 import { createClause } from "../services/clauses.js";
 import { createIssue } from "../services/issues.js";
 import { addSection } from "../services/sections.js";
@@ -276,6 +276,10 @@ describe("regression: every entity-acting MCP tool emits `ref:` and no raw UUID 
   let driftSectionRef: string;
   let proposeSectionRef: string;
   let proposeClauseRef: string;
+  // spec-530 t-4: accept_standard_change needs an OPEN proposal to apply. Authored in
+  // beforeAll (not by the propose probe) so its comment seq is stable regardless of
+  // which probes run or in what order.
+  let acceptCommentRef: string;
 
   beforeAll(async () => {
     memexId = await makeTestMemex("ref-emit");
@@ -408,6 +412,7 @@ describe("regression: every entity-acting MCP tool emits `ref:` and no raw UUID 
       sections: [
         { sectionType: "rule-drift", content: "Original rule body for drift probe." },
         { sectionType: "rule-propose", content: "Original rule body for propose probe." },
+        { sectionType: "rule-accept", content: "Original rule body for accept probe." },
       ],
     });
     cleanup.docs.push(std.id);
@@ -423,6 +428,18 @@ describe("regression: every entity-acting MCP tool emits `ref:` and no raw UUID 
       "RefEmit: original rule body.",
     );
     proposeClauseRef = `${stdBase}/clauses/cl-${probeClause.seq}`;
+    // spec-530 t-4: an open proposal on its own section, for the accept probe.
+    const acceptClause = await createClause(
+      memexId,
+      std.sections.find((s) => s.sectionType === "rule-accept")!.id,
+      "RefEmit: rule body to be accepted.",
+    );
+    const acceptProposal = await proposeStandardChange(
+      memexId,
+      [{ op: "edit", clauseId: acceptClause.id, after: "RefEmit: accepted rule body." }],
+      "refemit accept rationale",
+    );
+    acceptCommentRef = `${stdBase}/comments/c-${acceptProposal.comment.seq}`;
   });
 
   // Build the per-tool case registry. One per shared spec that emits a
@@ -717,6 +734,12 @@ describe("regression: every entity-acting MCP tool emits `ref:` and no raw UUID 
             ],
             rationale: "refemit rationale",
           }),
+        },
+      ],
+      [
+        "accept_standard_change",
+        {
+          input: () => ({ ref: acceptCommentRef }),
         },
       ],
     ]);

--- a/packages/server/src/agent/accept-mode-gate.spec-530.test.ts
+++ b/packages/server/src/agent/accept-mode-gate.spec-530.test.ts
@@ -1,0 +1,60 @@
+// spec-530 t-4 (dec-4, ac-13) — the apply verb is reachable from exactly the two agents
+// that handle Standards, and REFUSED everywhere else.
+//
+// std-38 is explicit that authoring scope is enforced server-side, not by prompt: the
+// `/tools/execute` route consults `isToolAllowedInMode` before running anything, so a
+// scoped mode that does not own a verb is refused there — not merely denied the tool
+// definition. Hiding a tool from the model is a hint; the gate is the enforcement.
+//
+// This matters more for this verb than for most: it is the one call that rewrites a
+// Standard's rule text and closes the proposal in the same breath.
+
+import { describe, it, expect } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { getToolDefinitions, isToolAllowedInMode, type AgentMode } from "./tools.js";
+
+const AC_13 = "mindset-prod/memex-building-itself/specs/spec-530/acs/ac-13";
+
+const VERB = "accept_standard_change";
+
+/** Every scoped mode that must NOT be able to accept a Standard change. */
+const FOREIGN_MODES: Exclude<AgentMode, "spec">[] = ["scaffold", "issues", "skills"];
+
+describe("spec-530 ac-13: accept_standard_change is scoped to the Standards agents", () => {
+  it("is offered to the drift and standards modes", () => {
+    tagAc(AC_13);
+    for (const mode of ["drift", "standards"] as const) {
+      const names = getToolDefinitions({ mode }).map((t) => t.name);
+      expect(names, `${mode} mode should offer ${VERB}`).toContain(VERB);
+    }
+  });
+
+  it("is REFUSED by the gate predicate for every other scoped mode, not just hidden", () => {
+    tagAc(AC_13);
+    for (const mode of FOREIGN_MODES) {
+      // The definition filter — what the model can see.
+      expect(getToolDefinitions({ mode }).map((t) => t.name), `${mode} definitions`).not.toContain(
+        VERB,
+      );
+      // The authoritative gate — what /tools/execute will actually run. A model that
+      // learned the name from anywhere else (a cached surface, a pasted transcript)
+      // still cannot execute it here [per std-38].
+      expect(isToolAllowedInMode(mode, VERB), `${mode} gate`).toBe(false);
+    }
+  });
+
+  it("permits it in the two owning modes at the gate", () => {
+    tagAc(AC_13);
+    expect(isToolAllowedInMode("drift", VERB)).toBe(true);
+    expect(isToolAllowedInMode("standards", VERB)).toBe(true);
+  });
+
+  it("is available on the unrestricted spec surface, like every other server tool", () => {
+    tagAc(AC_13);
+    // `spec` (and an absent mode) is governed by phase / reviewer gates rather than a
+    // mode subset — asserted so a later reader does not mistake its presence there for
+    // a leak in the scoped-mode wall.
+    expect(isToolAllowedInMode("spec", VERB)).toBe(true);
+    expect(isToolAllowedInMode(undefined, VERB)).toBe(true);
+  });
+});

--- a/packages/server/src/agent/context-builder.drift.test.ts
+++ b/packages/server/src/agent/context-builder.drift.test.ts
@@ -40,6 +40,9 @@ function row(overrides: Partial<DriftInboxRow> = {}): DriftInboxRow {
     authorName: "Agent",
     content: "Repo no longer does X.",
     proposedContent: null,
+    // spec-530 t-7: the structured operations the Inbox row renders. The AGENT's context
+    // reads `proposedContent`, not this — so a drift row's null is the honest default here.
+    proposal: null,
     createdAt: new Date("2026-01-01T00:00:00Z"),
     decision: null,
     section: { id: "s-1", sectionType: "do", title: null, content: "Always X." },

--- a/packages/server/src/agent/handlers/standards.ts
+++ b/packages/server/src/agent/handlers/standards.ts
@@ -16,6 +16,7 @@ import {
   proposeStandardChange,
   type ProposalOperationInput,
 } from "../../services/standards.js";
+import { acceptStandardChange } from "../../services/standard-accept.js";
 import {
   createDocDraft,
 } from "../../services/documents.js";
@@ -251,6 +252,68 @@ export const standardsTools: ToolSpec[] = [
       return commentRef
         ? `Proposed change recorded on ${result.standard.handle} section "${sectionLabel}" (ref: ${commentRef}).`
         : `Proposed change recorded on ${result.standard.handle} section "${sectionLabel}".`;
+    },
+  },
+  {
+    // spec-530 t-4 (dec-4): the transactional apply verb. It takes the proposal's
+    // comment ref and NOTHING else — no bodies, no targets, no override (ac-11).
+    // The proposal already carries what will be applied, so the agent cannot apply
+    // something other than what the human reviewed. That is deliberate: the agent's
+    // role here is judgement plus one gated call, not authorship.
+    name: "accept_standard_change",
+    annotations: { title: "Accept Standard change", readOnlyHint: false, destructiveHint: false },
+    description:
+      "Accept an open proposal (a `plan_revision` comment) and apply it to the Standard. Pass ONLY the proposal's comment ref — the proposal already carries which clauses change and what they should say, so there is nothing else to supply and no way to apply something different from what was proposed. Every clause operation lands, or none does, and the proposal is resolved 'accepted' in the same transaction. " +
+      "If the rule text changed after the proposal was written, this REFUSES rather than overwriting that change, and names the clause and what it now says — relay that to the user and offer to re-propose against the current rule. " +
+      "Propose this through `render_confirmation` FIRST, showing what will change; never apply until the user confirms. To REJECT instead, leave the rule alone and resolve the comment with `update_comment` (status `resolved`, resolution `'rejected'`).",
+    schema: {
+      ref: z
+        .string()
+        .describe(
+          "Canonical ref to the proposal comment, e.g. `<ns>/<mx>/standards/std-7/comments/c-3` — the ref `list_comments` emits for a plan_revision. NOT a UUID.",
+        ),
+      verbose: VERBOSE_FIELD,
+    },
+    async handler(input, ctx) {
+      const ref = input.ref as string;
+
+      // std-10: the comment is addressed by its canonical c-N ref; resolveRefArg
+      // rejects a raw UUID at the boundary.
+      const resolved = await resolveRefArg(ctx, ref);
+      if (resolved.entity.kind !== "comment") {
+        throw new ValidationError(
+          `accept_standard_change takes a proposal comment ref (c-N); got ${resolved.entity.kind} for "${ref}".`,
+        );
+      }
+      // spec-156 W2 (FINDING 3): thread the invoking surface so the rule change is
+      // attributed to the actor (mcp vs in_app_agent) rather than defaulting to
+      // channel 'server' [per std-32] — "who accepted this rule change" is exactly
+      // the question the activity contract exists to answer (ac-20).
+      const result = await acceptStandardChange(
+        resolved.memexId,
+        resolved.entity.row.id,
+        reqCtx(ctx),
+      );
+
+      // b-36 D-8: lead with the canonical `ref:` of the resolved proposal, never a
+      // raw UUID.
+      const slugs = await memexSlugsById(resolved.memexId);
+      const commentRef = slugs
+        ? buildChildRef(slugs, result.standard, { type: "comments", seq: result.comment.seq })
+        : null;
+      const sectionLabel = result.section.title ?? result.section.sectionType;
+      const opCount = `${result.applied} clause operation${result.applied === 1 ? "" : "s"}`;
+      if (ctx.verbose) {
+        const state = await fullDocState(resolved.memexId, result.standard.id);
+        const url = await ctx.workspaceUrl(resolved.memexId);
+        const head = commentRef
+          ? `Proposal accepted — applied ${opCount} to ${result.standard.handle} section "${sectionLabel}" (ref: ${commentRef}).`
+          : `Proposal accepted — applied ${opCount} to ${result.standard.handle} section "${sectionLabel}".`;
+        return `${head}\n\n${await formatState(url, state, ctx)}`;
+      }
+      return commentRef
+        ? `Proposal accepted — applied ${opCount} to ${result.standard.handle} section "${sectionLabel}" (ref: ${commentRef}).`
+        : `Proposal accepted — applied ${opCount} to ${result.standard.handle} section "${sectionLabel}".`;
     },
   },
   // (search_standards spec deleted by b-34 T-5 — replaced by the live

--- a/packages/server/src/agent/tool-specs.audit.integration.test.ts
+++ b/packages/server/src/agent/tool-specs.audit.integration.test.ts
@@ -35,7 +35,7 @@ import {
 } from "../db/schema.js";
 import { makeTestMemex } from "../services/test-helpers.js";
 import { createDocDraft } from "../services/documents.js";
-import { createStandard } from "../services/standards.js";
+import { createStandard, proposeStandardChange } from "../services/standards.js";
 import { createClause } from "../services/clauses.js";
 import { createIssue } from "../services/issues.js";
 import { addSection } from "../services/sections.js";
@@ -857,6 +857,10 @@ describe("audit: b-36 D-8 — every terse mutation/list response emits `ref:` an
   let driftSectionRef: string;
   let proposeSectionRef: string;
   let proposeClauseRef: string;
+  // spec-530 t-4: accept_standard_change needs an OPEN proposal to apply. Authored in
+  // beforeAll (not by the propose probe) so its comment seq is stable regardless of
+  // which probes run or in what order.
+  let acceptCommentRef: string;
 
   beforeAll(async () => {
     memexId = await makeTestMemex("probe-ref");
@@ -999,6 +1003,7 @@ describe("audit: b-36 D-8 — every terse mutation/list response emits `ref:` an
       sections: [
         { sectionType: "rule-drift", content: "Original rule body for drift probe." },
         { sectionType: "rule-propose", content: "Original rule body for propose probe." },
+        { sectionType: "rule-accept", content: "Original rule body for accept probe." },
       ],
     });
     cleanup.docs.push(std.id);
@@ -1014,6 +1019,18 @@ describe("audit: b-36 D-8 — every terse mutation/list response emits `ref:` an
       "Original rule body for propose probe.",
     );
     proposeClauseRef = `${stdBase}/clauses/cl-${probeClause.seq}`;
+    // spec-530 t-4: an open proposal on its own section, for the accept probe.
+    const acceptClause = await createClause(
+      memexId,
+      std.sections.find((s) => s.sectionType === "rule-accept")!.id,
+      "Probe: rule body to be accepted.",
+    );
+    const acceptProposal = await proposeStandardChange(
+      memexId,
+      [{ op: "edit", clauseId: acceptClause.id, after: "Probe: accepted rule body." }],
+      "probe accept rationale",
+    );
+    acceptCommentRef = `${stdBase}/comments/c-${acceptProposal.comment.seq}`;
   });
 
   type ProbeCase = {
@@ -1357,6 +1374,12 @@ describe("audit: b-36 D-8 — every terse mutation/list response emits `ref:` an
             ],
             rationale: "probe rationale",
           }),
+        },
+      ],
+      [
+        "accept_standard_change",
+        {
+          input: () => ({ ref: acceptCommentRef }),
         },
       ],
     ]);

--- a/packages/server/src/agent/tools.drift-mode.test.ts
+++ b/packages/server/src/agent/tools.drift-mode.test.ts
@@ -23,6 +23,10 @@ const AC_DRIFT_MECHANISM =
 const EXPECTED_DRIFT_SERVER_TOOLS = [
   "flag_drift",
   "propose_standard_change",
+  // spec-530 t-4 (dec-4): applying an accepted proposal is ONE server verb, not a
+  // sequence the agent performs. The Drift Inbox has no action controls (spec-143
+  // dec-3), so this conversation is the only path a user can accept from.
+  "accept_standard_change",
   "search_memex",
   "get_doc",
   // spec-143: the drift agent can now HANDLE drift, not just report it —

--- a/packages/server/src/agent/tools.mode-map.test.ts
+++ b/packages/server/src/agent/tools.mode-map.test.ts
@@ -57,6 +57,8 @@ const READ_BASE = ["search_memex", "get_doc"];
 // along on top and are asserted separately).
 const EXPECTED: Record<Exclude<AgentMode, "spec">, string[]> = {
   drift: [
+    // spec-530 t-4 (ac-13): the apply verb lives in BOTH Standards-handling modes.
+    "accept_standard_change",
     "flag_drift",
     "propose_standard_change",
     "search_memex",
@@ -84,6 +86,8 @@ const EXPECTED: Record<Exclude<AgentMode, "spec">, string[]> = {
     "edit_clause",
     "delete_clause",
     "propose_standard_change",
+    // spec-530 t-4 (ac-13): both agents that handle Standards own the apply verb.
+    "accept_standard_change",
     "flag_drift",
   ],
   issues: [

--- a/packages/server/src/agent/tools.ts
+++ b/packages/server/src/agent/tools.ts
@@ -454,6 +454,11 @@ export function isReadOnlyTool(name: string): boolean {
 const DRIFT_SERVER_TOOLS = new Set<string>([
   "flag_drift",
   "propose_standard_change",
+  // spec-530 t-4 (dec-4/ac-13): the apply verb. The drift agent is the surface a
+  // user accepts a proposal FROM — the Drift Inbox has no action controls
+  // (spec-143 dec-3), so this conversation is the only path. Presence here is the
+  // definition filter; /tools/execute is the authoritative gate [per std-38].
+  "accept_standard_change",
   "search_memex",
   "get_doc",
   "list_comments",
@@ -502,6 +507,9 @@ const STANDARDS_SERVER_TOOLS = new Set<string>([
   "edit_clause",
   "delete_clause",
   "propose_standard_change",
+  // spec-530 t-4 (dec-4/ac-13): both agents that handle Standards own the apply
+  // verb — the standards agent authors rules, so it accepts corrections to them too.
+  "accept_standard_change",
   "flag_drift",
 ]);
 

--- a/packages/server/src/routes/__test__.ts
+++ b/packages/server/src/routes/__test__.ts
@@ -76,6 +76,7 @@ import { addMentions, assignComment } from "../services/comment-mentions.js";
 import { createShareToken, listShareTokensForDoc } from "../services/share-tokens.js";
 import { addSection } from "../services/sections.js";
 import { addClausesToSection } from "../services/clauses.js";
+import { proposeStandardChange } from "../services/standards.js";
 import { applyTagStrings } from "../services/tags.js";
 import { resolveRole } from "../services/doc-members.js";
 import { listAssignees, assign } from "../services/doc-assignees.js";
@@ -1488,6 +1489,54 @@ const seedClausesSchema = z.object({
   sectionId: z.string().uuid(),
   clauses: z.array(z.string().min(1)).min(1),
 });
+// spec-530 t-7: seed an OPEN clause-grained proposal (a `plan_revision` comment) so a
+// journey can drive the Drift Inbox's before/after without raw SQL [per std-28]. Goes
+// through the real `proposeStandardChange`, so the stored body is the genuine operation
+// set and the row under test is the row users get — a hand-written comment would test a
+// shape the product never produces.
+const seedProposalSchema = z.object({
+  memexId: z.string().uuid(),
+  operations: z
+    .array(
+      z.object({
+        op: z.enum(["edit", "delete", "add"]),
+        clauseId: z.string().uuid(),
+        body: z.string().optional(),
+        placement: z.enum(["before", "after"]).optional(),
+      }),
+    )
+    .min(1),
+  rationale: z.string().optional(),
+});
+testOnlyRouter.post("/seed-proposal", async (c) => {
+  const body = await c.req.json().catch(() => null);
+  const parsed = seedProposalSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: "Invalid request", details: parsed.error.issues }, 400);
+  }
+  const { memexId, operations, rationale } = parsed.data;
+  const result = await proposeStandardChange(
+    memexId,
+    operations.map((op) =>
+      op.op === "edit"
+        ? { op: "edit" as const, clauseId: op.clauseId, after: op.body ?? "" }
+        : op.op === "delete"
+          ? { op: "delete" as const, clauseId: op.clauseId }
+          : {
+              op: "add" as const,
+              anchorClauseId: op.clauseId,
+              placement: op.placement ?? "after",
+              body: op.body ?? "",
+            },
+    ),
+    rationale,
+    {},
+    // std-32: a seeded write is still an attributed write.
+    { channel: "server", actorName: "e2e-seed" },
+  );
+  return c.json({ commentId: result.comment.id, commentSeq: result.comment.seq });
+});
+
 testOnlyRouter.post("/seed-clauses", async (c) => {
   const body = await c.req.json().catch(() => null);
   const parsed = seedClausesSchema.safeParse(body);

--- a/packages/server/src/routes/drift-accept-route.spec-530.test.ts
+++ b/packages/server/src/routes/drift-accept-route.spec-530.test.ts
@@ -1,0 +1,78 @@
+// spec-530 t-4 / dec-6 (ac-24) — there is exactly ONE way to accept a proposal, and no
+// mounted surface that pretends to be another.
+//
+// `POST /api/drift/proposals/:commentId/accept` was built as spec-63's t-12. It applied
+// a proposal with `updateSection`, which has thrown on every Standard since spec-161
+// made them clause-backed — and a `plan_revision` only ever exists on a Standard. So it
+// could not succeed on any real proposal, and no client ever called it (spec-143 dec-3
+// removed the buttons that used to).
+//
+// A reachable endpoint that always throws is the same defect this whole Spec exists to
+// fix, in a different medium: it looks authoritative, and only running it reveals it is
+// dead. This session nearly reasoned from it — spec-530's own Overview asserted no such
+// route existed, and that had to be corrected in s-3. So the assertion is 404 (route
+// absent), not "refuses with a nice message".
+
+import { describe, it, expect, vi } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+vi.mock("../middleware/session.js", async () => {
+  const { createMiddleware } = await import("hono/factory");
+  return {
+    sessionMiddleware: createMiddleware(async (_c: unknown, next: () => Promise<void>) =>
+      next(),
+    ),
+  };
+});
+
+import driftRouter from "./drift.js";
+import { makeTestAppWithTenant } from "./route-test-helpers.js";
+
+const AC_24 = "mindset-prod/memex-building-itself/specs/spec-530/acs/ac-24";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+function makeApp() {
+  const app = makeTestAppWithTenant({ memexId: "00000000-0000-0000-0000-000000000001" });
+  app.route("/api/drift", driftRouter);
+  return app;
+}
+
+describe("spec-530 dec-6: the dead accept route is gone (ac-24)", () => {
+  it("POST /api/drift/proposals/:id/accept is not routed at all — 404, not 500", async () => {
+    tagAc(AC_24);
+    const res = await makeApp().request(
+      "/api/drift/proposals/11111111-1111-1111-1111-111111111111/accept",
+      { method: "POST" },
+    );
+
+    // 404 means Hono has no handler for the path. A mounted-but-refusing endpoint
+    // would answer 4xx-with-a-body from inside a handler, which is exactly the
+    // misleading state dec-6 removed.
+    expect(res.status).toBe(404);
+  });
+
+  it("no longer imports updateSection — the call that made it dead on arrival", () => {
+    tagAc(AC_24);
+    const source = readFileSync(resolve(HERE, "drift.ts"), "utf8");
+
+    // The import and the CALL are the fingerprints — not the word. The file's header
+    // deliberately still explains what `updateSection` was and why it could never
+    // work, because that history is the reason this route must not come back; an
+    // assertion that forbade the name would delete the explanation along with the bug.
+    expect(source).not.toMatch(/from "\.\.\/services\/sections\.js"/);
+    expect(source).not.toMatch(/\bupdateSection\s*\(/);
+    // And the route registration itself is gone, not merely commented out.
+    expect(source).not.toMatch(/drift\.post\(/);
+  });
+
+  it("GET /api/drift still serves the Inbox — only the accept path was removed", async () => {
+    tagAc(AC_24);
+    const res = await makeApp().request("/api/drift");
+    // Whatever the read path answers (it hits the DB), it must not be "no such route".
+    expect(res.status).not.toBe(404);
+  });
+});

--- a/packages/server/src/routes/drift.ts
+++ b/packages/server/src/routes/drift.ts
@@ -1,34 +1,31 @@
 // GET /api/drift — Standards Drift Inbox endpoint (t-10 of doc-8; scoped to
 // Standards in b-63). Optional `?doc=std-N` narrows to a single standard.
-// POST /api/drift/proposals/:commentId/accept — apply a plan_revision (t-12).
 //
 // The inbox returns every open `drift` and `plan_revision` typed comment on a
 // Standard, with parent doc + section context attached so the React UI can
-// render the inbox in one round-trip.
+// render the inbox in one round-trip. It is READ-ONLY: the Inbox carries no
+// action controls (spec-143 dec-3 removed them deliberately — accepting a
+// proposal is a judgement, not a one-click yes/no).
 //
-// Accepting a proposal: the standard owner clicks Accept on a `plan_revision`
-// comment in the inbox; the server parses the proposed-content fence out of
-// the comment body, updates the section, and resolves the comment in one
-// transaction. Rejecting is just `POST /api/comments/:id/resolve` (existing
-// surface), so we don't add a separate endpoint for that.
+// There is NO accept endpoint here. `POST /proposals/:commentId/accept` existed
+// from spec-63 t-12 until spec-530 dec-6 deleted it: it applied a proposal with
+// `updateSection`, which has thrown on every Standard since spec-161 made them
+// clause-backed, so it could not succeed on any real proposal — and no client
+// ever called it. Accepting goes through `accept_standard_change`
+// (services/standard-accept.ts), which the drift agent calls behind its
+// confirmation gate. If a future Spec revisits spec-143 dec-3 and adds a UI
+// control, it adds an HTTP route THEN, against that verb.
 //
 // Memex scoping is handled by sessionMiddleware (resolves the user's
 // current memex from the session JWT + path-resolved memex);
 // service-layer guards re-assert the memex_id filter in SQL.
 
 import { Hono } from "hono";
-import { eq } from "drizzle-orm";
-import { db } from "../db/connection.js";
-import { docComments } from "../db/schema.js";
 import { sessionMiddleware, type SessionEnv } from "../middleware/session.js";
 import type { MemexResolverEnv } from "../middleware/memex-resolver.js";
 import { requireMemexId } from "./shared.js";
-import { restCtx } from "./_actor-ctx.js";
 import { listDriftInbox } from "../services/drift-inbox.js";
-import { parseProposedChangeBody } from "../services/standards.js";
-import { updateSection } from "../services/sections.js";
-import { resolveComment } from "../services/comments.js";
-import { NotFoundError, ValidationError } from "../types/errors.js";
+import { ValidationError } from "../types/errors.js";
 
 type Env = MemexResolverEnv & SessionEnv;
 const drift = new Hono<Env>();
@@ -47,57 +44,6 @@ drift.get("/", async (c) => {
   }
   const page = await listDriftInbox(memexId, { limit, cursor, docHandle });
   return c.json({ items: page.items, nextCursor: page.nextCursor });
-});
-
-// std-5 exemption: comment-UUID lookup. The memex is derived from the comment
-// entity's FK; the route works at the flat path even when the caller has
-// multiple memberships (the comment row itself ties it to a single memex).
-drift.post("/proposals/:commentId/accept", async (c) => {
-  const memexId = requireMemexId(c);
-  const commentId = c.req.param("commentId");
-
-  const comment = await db.query.docComments.findFirst({
-    where: eq(docComments.id, commentId),
-  });
-  if (!comment || comment.memexId !== memexId) {
-    throw new NotFoundError(`Proposal ${commentId} not found`);
-  }
-  if (comment.commentType !== "plan_revision") {
-    throw new ValidationError(
-      `Comment ${commentId} is a ${comment.commentType} comment, not a plan_revision proposal.`,
-    );
-  }
-  if (comment.resolvedAt) {
-    throw new ValidationError("Proposal is already resolved");
-  }
-  if (!comment.sectionId) {
-    throw new ValidationError(
-      "Proposal isn't anchored to a section — cannot apply.",
-    );
-  }
-
-  const parsed = parseProposedChangeBody(comment.content);
-  if (!parsed) {
-    throw new ValidationError(
-      "Proposal body is missing the proposed-content block; cannot extract replacement text.",
-    );
-  }
-  // spec-530 t-1: this route is dead code and has been since spec-161 made Standards
-  // clause-backed — `updateSection` hard-rejects on a Standard, so the line below
-  // throws for every real proposal, and nothing in the UI calls this endpoint. t-4
-  // settles its fate (delete, or re-point at `accept_standard_change`). Until then,
-  // refuse a clause-grained proposal with a reason instead of feeding it to a call
-  // that cannot work.
-  if (parsed.kind === "clause-ops") {
-    throw new ValidationError(
-      "This proposal is clause-grained. Applying it goes through the accept verb, not this route (spec-530 t-4).",
-    );
-  }
-
-  await updateSection(memexId, comment.sectionId, parsed.proposed);
-  const resolved = await resolveComment(memexId, comment.id, "accepted", restCtx(c));
-
-  return c.json({ ok: true, comment: resolved });
 });
 
 export default drift;

--- a/packages/server/src/routes/test-events-tenant-context.rls-restricted.test.ts
+++ b/packages/server/src/routes/test-events-tenant-context.rls-restricted.test.ts
@@ -1,0 +1,249 @@
+// spec-520 t-7 / ac-32 — the ingest path establishes tenant context, so its READS see
+// their own rows. Runs ONLY under vitest.rls.config.ts, as the restricted `memex_app`
+// role. In the default owner-connection suite RLS is bypassed (std-36: ENABLE, never
+// FORCE), so this defect is INVISIBLE there — which is exactly why it lived in prod.
+//
+// THE DEFECT (spec-520 issue-6, measured on prod): the ingest path's issue auto-resolve
+// returns empty for 99.96% of passing events. Not a tuning problem. `processOneEvent`
+// calls `maybeAutoResolveIssuesForAcUid`, whose FIRST statement is a
+// `documents ⋈ memexes ⋈ namespaces` join; `documents` carries `documents_memex_isolation`
+// on `app.memex_id`; and `runWithMemexId` appeared NOWHERE in routes/test-events.ts. Under
+// the non-owner runtime role the lookup is filtered to zero rows, so the chain concludes
+// "nothing to resolve" — every time. spec-112 ac-22's second auto-resolve trigger, the one
+// that closes the bug→failing-AC→green-AC→resolved loop from ingest, has been dead.
+//
+// THREE LAYERS OF SILENCE hid it, and each is individually reasonable:
+//   1. the call is `.catch(() => {})` by design, so a test-result write can never fail
+//   2. the owner role bypasses RLS, so dev and the default suite cannot reproduce it
+//   3. the tenant-context guard that exists for this class watches WRITES — this is a READ
+// A fix is not finished until at least one of those layers would now speak up. This file
+// is that layer: under the real role, the route either resolves the Issue or it does not.
+//
+// SECOND INSTANCE OF A CLASS SPEC-440 WAS MEANT TO CLOSE. spec-440 t-6 fixed exactly this
+// shape in `markPresent` (its own rls-restricted test sits beside this one) and shipped the
+// write-side guard. The class is not closed for READS. Worth carrying to spec-440.
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { and, desc, eq, inArray } from "drizzle-orm";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { db, runWithMemexId } from "../db/connection.js";
+import {
+  acs,
+  documents,
+  issues,
+  memexEmissionKeys,
+  memexes,
+  namespaces,
+  taskSatisfiesAc,
+  tasks,
+  testEvents,
+  users,
+} from "../db/schema.js";
+import { upsertUserByEmail } from "../services/users.js";
+import { ensureUserNamespace } from "../services/user-namespaces.js";
+import { createDocDraft } from "../services/documents.js";
+import { mintEmissionKey } from "../services/emission-keys.js";
+import { maybeAutoResolveIssuesForAcUid } from "../services/issues.js";
+import { app } from "../app.js";
+
+const AC_TENANT_CONTEXT = "mindset-prod/memex-building-itself/specs/spec-520/acs/ac-32";
+
+const runId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+let memexId: string;
+let userId: string;
+let namespaceSlug: string;
+let memexSlug: string;
+let docId: string;
+let taskId: string;
+let acId: string;
+let issueId: string;
+let emissionKey: string;
+let acRef: string;
+let specHandle: string;
+
+/** The AC ref the route will receive, and the one the auto-resolve chain reverses. */
+const AC_SEQ = 1;
+
+beforeAll(async () => {
+  const user = await upsertUserByEmail(`spec520-t7-${runId}@example.com`);
+  userId = user.id;
+
+  // namespace + memex are NOT RLS-gated — writable by memex_app with no tenant GUC.
+  const created = await ensureUserNamespace(userId);
+  memexId = created.memex.id;
+  memexSlug = created.memex.slug;
+  const [ns] = await db
+    .select({ slug: namespaces.slug })
+    .from(namespaces)
+    .where(eq(namespaces.id, created.memex.namespaceId))
+    .limit(1);
+  namespaceSlug = ns!.slug;
+
+  // Everything below is RLS-gated, so seed it under the matching tenant context. Seeding
+  // is NOT what is under test — the route's own context is.
+  //
+  // Worth recording: the first draft of this file read `documents.handle` back OUTSIDE the
+  // wrapper and crashed on `undefined` — RLS filtered the row away. The test fell into the
+  // very defect it exists to pin, which is how easy this class is to reintroduce.
+  await runWithMemexId(memexId, async () => {
+    const doc = await createDocDraft(memexId, `spec520 t7 target ${runId}`, "", "spec");
+    docId = doc.id;
+    specHandle = doc.handle;
+
+    const [ac] = await db
+      .insert(acs)
+      .values({
+        memexId,
+        briefId: docId,
+        seq: AC_SEQ,
+        kind: "implementation",
+        statement: "the verifying criterion",
+        status: "active",
+      } as typeof acs.$inferInsert)
+      .returning();
+    acId = ac!.id;
+
+    const [task] = await db
+      .insert(tasks)
+      .values({
+        memexId,
+        docId,
+        seq: 1,
+        title: "the satisfying task",
+        description: "",
+        // COMPLETE is a precondition: maybeAutoResolveIssuesForTask returns [] otherwise.
+        status: "complete",
+      } as typeof tasks.$inferInsert)
+      .returning();
+    taskId = task!.id;
+
+    await db.insert(taskSatisfiesAc).values({ taskId, acId } as typeof taskSatisfiesAc.$inferInsert);
+
+    // A CONVERTED issue pointing at that task — the shape the down-bridge produces and the
+    // only shape auto-resolve acts on.
+    const [issue] = await db
+      .insert(issues)
+      .values({
+        memexId,
+        docId,
+        seq: 1,
+        title: "the issue awaiting a green AC",
+        body: "",
+        type: "bug",
+        severity: "high",
+        status: "converted",
+        source: "agent",
+        satisfyingTaskId: taskId,
+        createdByUserId: userId,
+      } as typeof issues.$inferInsert)
+      .returning();
+    issueId = issue!.id;
+  });
+
+  // The ref the emitter will send, built exactly as the chain reverses it. The handle comes
+  // from the create result rather than a read-back — one less gated query to get wrong.
+  acRef = `${namespaceSlug}/${memexSlug}/specs/${specHandle}/acs/ac-${AC_SEQ}`;
+
+  emissionKey = (await mintEmissionKey(memexId, `spec520-t7-${runId}`, userId)).raw;
+});
+
+afterAll(async () => {
+  await runWithMemexId(memexId, async () => {
+    await db.delete(testEvents).where(eq(testEvents.subjectRef, acRef)).catch(() => {});
+    if (issueId) await db.delete(issues).where(eq(issues.id, issueId)).catch(() => {});
+    if (taskId) await db.delete(tasks).where(eq(tasks.id, taskId)).catch(() => {});
+    if (acId) await db.delete(acs).where(eq(acs.id, acId)).catch(() => {});
+    if (docId) await db.delete(documents).where(eq(documents.id, docId)).catch(() => {});
+  });
+  await db.delete(memexEmissionKeys).where(eq(memexEmissionKeys.memexId, memexId)).catch(() => {});
+  await db.delete(memexes).where(eq(memexes.id, memexId)).catch(() => {});
+  await db.delete(namespaces).where(eq(namespaces.slug, namespaceSlug)).catch(() => {});
+  await db.delete(users).where(inArray(users.id, [userId])).catch(() => {});
+});
+
+describe("spec-520 ac-32: the DIAGNOSIS — tenant context is what the chain needs", () => {
+  // These two do not prove the fix (the fix is at the call site, not in this function).
+  // They pin WHY the fix is what it is, under the real role — so a future reader cannot
+  // conclude the auto-resolve chain is simply broken and rewrite the wrong thing.
+  it("WITHOUT tenant context the chain finds nothing, though the Issue is resolvable", async () => {
+    tagAc(AC_TENANT_CONTEXT);
+    const resolved = await maybeAutoResolveIssuesForAcUid(acRef);
+    // Zero, and not because there is nothing to resolve — the next test resolves the very
+    // same Issue from the very same row. The documents lookup is filtered to no rows.
+    expect(resolved).toEqual([]);
+  });
+
+  it("WITH tenant context the same call resolves the same Issue", async () => {
+    tagAc(AC_TENANT_CONTEXT);
+    // Give the AC a green event first: verifyingAcIsGreen gates the resolve.
+    await runWithMemexId(memexId, async () => {
+      await db.insert(testEvents).values({
+        memexId,
+        subjectRef: acRef,
+        status: "pass",
+        testIdentifier: "spec520-t7::diagnosis",
+        durationMs: 1,
+      } as typeof testEvents.$inferInsert);
+    });
+
+    const resolved = await runWithMemexId(memexId, async () =>
+      maybeAutoResolveIssuesForAcUid(acRef),
+    );
+    expect(resolved).toContain(issueId);
+
+    // Put it back to converted so the route test below starts from the same state.
+    await runWithMemexId(memexId, async () => {
+      await db.update(issues).set({ status: "converted" }).where(eq(issues.id, issueId));
+    });
+  });
+});
+
+describe("spec-520 ac-32: the FIX — the ROUTE establishes the context", () => {
+  it("a passing emission through POST /api/test-events resolves the converted Issue", async () => {
+    tagAc(AC_TENANT_CONTEXT);
+    // THE red→green assertion. Before the fix the route called auto-resolve with no tenant
+    // context, so this Issue stayed `converted` forever while the event was written happily
+    // — silent, because the call is best-effort by design. Nothing in the response differs;
+    // only the row does, which is why this asserts the ROW and not the status code.
+    const res = await app.request("/api/test-events", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${emissionKey}`,
+      },
+      body: JSON.stringify({
+        ac_uid: acRef,
+        status: "pass",
+        test_identifier: "spec520-t7::route",
+        duration_ms: 1,
+      }),
+    });
+    expect(res.status).toBe(201);
+
+    // NOTE the `async` callback. `runWithMemexId(id, () => db.select(...))` returns the
+    // QUERY BUILDER, and AsyncLocalStorage.run() has already returned by the time the
+    // outer await executes it — so the query runs OUTSIDE the context and RLS filters it
+    // to nothing. Cost me a debugging round; the async form keeps execution in the subtree.
+    const [row] = await runWithMemexId(memexId, async () =>
+      db.select({ status: issues.status }).from(issues).where(eq(issues.id, issueId)).limit(1),
+    );
+    expect(row?.status).toBe("resolved");
+  });
+
+  it("the event itself still lands — the fix must not cost the write", async () => {
+    tagAc(AC_TENANT_CONTEXT);
+    // The auto-resolve call is deliberately best-effort so it can never fail a CI run's
+    // result write. Wrapping it in tenant context must not change that: assert the event
+    // row exists regardless of what the resolve did.
+    const [latest] = await runWithMemexId(memexId, async () =>
+      db
+        .select({ status: testEvents.status, id: testEvents.testIdentifier })
+        .from(testEvents)
+        .where(and(eq(testEvents.subjectRef, acRef), eq(testEvents.status, "pass")))
+        .orderBy(desc(testEvents.createdAt))
+        .limit(1),
+    );
+    expect(latest?.status).toBe("pass");
+  });
+});

--- a/packages/server/src/routes/test-events.ts
+++ b/packages/server/src/routes/test-events.ts
@@ -79,6 +79,7 @@ import {
   recordFirstVerified,
 } from "../services/test-event-retention.js";
 import { maybeAutoResolveIssuesForAcUid } from "../services/issues.js";
+import { runWithMemexId } from "../db/connection.js";
 import { fireVerifiedMilestoneForUser } from "../services/email/verified-milestone-send.js";
 import {
   verifyEmissionKey,
@@ -531,7 +532,28 @@ async function processOneEvent(
   // event for an AC that verifies a converted Issue's Task closes the
   // bug→failing-AC→green-AC→resolved loop. Best-effort: never fail the write.
   if (body.status === "pass") {
-    await maybeAutoResolveIssuesForAcUid(subjectRefValue).catch(() => {});
+    // spec-520 t-7 (ac-32): run it INSIDE the tenant context. Without this the chain's
+    // first statement — a `documents ⋈ memexes ⋈ namespaces` join — is filtered to zero
+    // rows by `documents_memex_isolation` under the non-owner runtime role, so it concluded
+    // "nothing to resolve" for 99.96% of passing events and spec-112 ac-22's second
+    // auto-resolve trigger was dead in prod (issue-6).
+    //
+    // Three things kept it silent, which is why it needs a comment rather than just a fix:
+    // the call is `.catch(() => {})` by design so a CI result write can never fail; the
+    // owner role bypasses RLS so dev and the default suite cannot reproduce it; and the
+    // tenant-context guard built for this class (spec-440) watches WRITES, not READS.
+    // Proven under the restricted role in test-events-tenant-context.rls-restricted.test.ts.
+    // try/catch, not just `.catch()`: a SYNCHRONOUS throw here escapes a trailing
+    // `.catch` and 500s the event write. Observed while building this — a missing import
+    // turned every passing emission into a 500. The old single-expression form had the
+    // same hole; best-effort has to mean best-effort against both failure shapes.
+    try {
+      await runWithMemexId(targetMemexId, () =>
+        maybeAutoResolveIssuesForAcUid(subjectRefValue),
+      );
+    } catch {
+      // advisory by contract — an auto-resolve failure must never fail a CI result write
+    }
     // spec-453 t-2 (dec-1/dec-4/dec-9): fire the "See it verified" milestone email.
     // FIRE-AND-FORGET — never awaited on this CI hot path, so it cannot add latency to
     // or break the write. Attributed to the emission key's OWNER (not test_events.actor),

--- a/packages/server/src/services/ac-health-parity.spec-520.test.ts
+++ b/packages/server/src/services/ac-health-parity.spec-520.test.ts
@@ -1,0 +1,285 @@
+// spec-520 t-2 / ac-10 — the AC-health parity harness, built BEFORE the query changes.
+//
+// WHAT THIS IS. A characterization test: it pins what `aggregateAcHealthForBriefs`
+// returns TODAY so t-4's rewrite cannot silently change it. ac-10's words are "for
+// identical Memex state, the payload returned by the rewritten aggregate is EQUAL to the
+// payload the pre-change implementation returned — same buckets, same counts, same derived
+// verification state per Spec." A harness written after the rewrite proves nothing; the
+// pre-change behaviour is gone by then.
+//
+// WHY IT ASSERTS THE WHOLE OBJECT WITH toEqual, and never cherry-picks fields.
+// `AcHealth` is declared THREE times in this repo and the declarations DISAGREE:
+//
+//   services/acs.ts:985   7 fields — includes `accepted`   <- what the function returns
+//   types/index.ts:134    6 fields — no `accepted`          <- the DocSummary field type
+//   ui/src/api/types.ts   6 fields — no `accepted`          <- what the UI consumes
+//
+// So a rewrite that dropped `accepted` would still typecheck against two of the three
+// declarations, and a field-by-field assertion written from the wrong one would stay
+// green. `toEqual` on the full payload is the only form that catches it. (The divergence
+// itself is drift worth fixing, but not here — t-2 pins behaviour, it does not refactor
+// types.)
+//
+// THE BUCKETS, and the precedence a rewrite is most likely to get subtly wrong
+// (`deriveVerificationState`): failing > accepted > untested > stale > verified. Failing
+// evidence suppresses a manual acceptance; an acceptance presents over stale AND verified.
+// Each of those five is seeded below, plus the two "counted but not a state" fields —
+// `totalActive` (every active AC) and `covered` (≥1 tagged event, whatever its status).
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { eq, inArray } from "drizzle-orm";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { db } from "../db/connection.js";
+import {
+  acs,
+  documents,
+  memexes,
+  namespaces,
+  testEventLatest,
+  users,
+} from "../db/schema.js";
+import { createOrgWithMemexAndOwner } from "./__test__/seed-org.js";
+import { createDocDraft } from "./documents.js";
+import {
+  aggregateAcHealthForBriefs,
+  buildAcRef,
+  STALE_THRESHOLD_DAYS,
+} from "./acs.js";
+
+const AC_PARITY = "mindset-prod/memex-building-itself/specs/spec-520/acs/ac-10";
+
+// [per std-37] cl-1: unique per worker AND per call.
+const runId = `${process.env.VITEST_POOL_ID ?? "0"}-${crypto.randomUUID().slice(0, 8)}`;
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+/** Comfortably past the threshold, so a clock skew of hours cannot flip the bucket. */
+const STALE_AGO = new Date(Date.now() - (STALE_THRESHOLD_DAYS + 3) * DAY_MS);
+const FRESH_AGO = new Date(Date.now() - 1 * DAY_MS);
+
+const createdUserIds: string[] = [];
+const createdMemexIds: string[] = [];
+const createdRefs: string[] = [];
+
+let memexId: string;
+let otherMemexId: string;
+let richDocId: string;
+let emptyDocId: string;
+let otherDocId: string;
+
+/** Seed an AC and return its canonical ref. */
+async function seedAc(
+  targetMemexId: string,
+  briefId: string,
+  slugs: { namespace: string; memex: string; briefHandle: string },
+  seq: number,
+  opts: { acceptedAt?: Date | null; status?: string } = {},
+): Promise<string> {
+  await db.insert(acs).values({
+    memexId: targetMemexId,
+    briefId,
+    seq,
+    kind: "implementation",
+    statement: `ac ${seq}`,
+    status: opts.status ?? "active",
+    acceptedAt: opts.acceptedAt ?? null,
+  } as typeof acs.$inferInsert);
+  const ref = buildAcRef(slugs, seq);
+  createdRefs.push(ref);
+  return ref;
+}
+
+/** Seed a latest-event row. `memexIdOverride` exists for the disagreement case below. */
+async function seedLatest(
+  ref: string,
+  status: "pass" | "fail" | "error",
+  runAt: Date,
+  ownerMemexId: string,
+  testIdentifier = "t",
+): Promise<void> {
+  await db.insert(testEventLatest).values({
+    subjectRef: ref,
+    testIdentifier,
+    latestStatus: status,
+    latestRunAt: runAt,
+    runCount: 1,
+    memexId: ownerMemexId,
+  } as typeof testEventLatest.$inferInsert);
+}
+
+beforeAll(async () => {
+  const [u] = await db
+    .insert(users)
+    .values({
+      email: `spec520-parity-${runId}@example.com`,
+      emailVerifiedAt: new Date(),
+    } as typeof users.$inferInsert)
+    .returning();
+  createdUserIds.push(u.id);
+
+  const main = await createOrgWithMemexAndOwner({
+    slug: `s520-parity-a-${runId}`,
+    ownerUserId: u.id,
+  });
+  memexId = main.memex.id;
+  createdMemexIds.push(memexId);
+
+  const other = await createOrgWithMemexAndOwner({
+    slug: `s520-parity-b-${runId}`,
+    ownerUserId: u.id,
+  });
+  otherMemexId = other.memex.id;
+  createdMemexIds.push(otherMemexId);
+
+  // ── The rich Spec: one AC per bucket, plus the precedence cases ──────────────
+  const rich = await createDocDraft(memexId, `parity rich ${runId}`, "", "spec");
+  richDocId = rich.id;
+  const richSlugs = {
+    namespace: main.namespace.slug,
+    memex: main.memex.slug,
+    briefHandle: rich.handle,
+  };
+
+  // 1 — verified: passing, recent.
+  await seedLatest(await seedAc(memexId, richDocId, richSlugs, 1), "pass", FRESH_AGO, memexId);
+  // 2 — failing: one failing test.
+  await seedLatest(await seedAc(memexId, richDocId, richSlugs, 2), "fail", FRESH_AGO, memexId);
+  // 3 — stale: passing, but older than the threshold.
+  await seedLatest(await seedAc(memexId, richDocId, richSlugs, 3), "pass", STALE_AGO, memexId);
+  // 4 — untested: active, no events at all.
+  await seedAc(memexId, richDocId, richSlugs, 4);
+  // 5 — accepted: manual acceptance, no contradicting evidence. Deliberately given a
+  //     STALE passing test, to pin that acceptance presents OVER stale (spec-188 dec-2).
+  await seedLatest(
+    await seedAc(memexId, richDocId, richSlugs, 5, { acceptedAt: new Date() }),
+    "pass",
+    STALE_AGO,
+    memexId,
+  );
+  // 6 — accepted BUT failing: evidence wins, so this must land in `failing`, not
+  //     `accepted`. The single assertion most likely to break under a rewrite that
+  //     reorders the precedence chain.
+  await seedLatest(
+    await seedAc(memexId, richDocId, richSlugs, 6, { acceptedAt: new Date() }),
+    "error",
+    FRESH_AGO,
+    memexId,
+  );
+  // 7 — NOT active: must be invisible to every counter, including totalActive.
+  //     Valid statuses are proposed | active | rejected | superseded (acs_status_valid);
+  //     `superseded` is the retired-equivalent the aggregator's status filter excludes.
+  await seedAc(memexId, richDocId, richSlugs, 7, { status: "superseded" });
+
+  // ── A Spec with no ACs at all: must come back as the empty payload, PRESENT in the
+  //    map rather than absent — callers iterate the input list and expect a value.
+  const empty = await createDocDraft(memexId, `parity empty ${runId}`, "", "spec");
+  emptyDocId = empty.id;
+
+  // ── A second tenant, carrying its own Spec + ACs + events. Today Q2 filters on
+  //    subject_ref alone; t-4 adds a memex_id predicate. This is what proves the new
+  //    predicate does not change the answer for the tenant under test.
+  const otherDoc = await createDocDraft(otherMemexId, `parity other ${runId}`, "", "spec");
+  otherDocId = otherDoc.id;
+  const otherSlugs = {
+    namespace: other.namespace.slug,
+    memex: other.memex.slug,
+    briefHandle: otherDoc.handle,
+  };
+  await seedLatest(
+    await seedAc(otherMemexId, otherDocId, otherSlugs, 1),
+    "pass",
+    FRESH_AGO,
+    otherMemexId,
+  );
+});
+
+afterAll(async () => {
+  if (createdRefs.length) {
+    await db
+      .delete(testEventLatest)
+      .where(inArray(testEventLatest.subjectRef, createdRefs))
+      .catch(() => {});
+  }
+  for (const id of [richDocId, emptyDocId, otherDocId].filter(Boolean)) {
+    await db.delete(acs).where(eq(acs.briefId, id)).catch(() => {});
+    await db.delete(documents).where(eq(documents.id, id)).catch(() => {});
+  }
+  if (createdMemexIds.length) {
+    await db.delete(memexes).where(inArray(memexes.id, createdMemexIds)).catch(() => {});
+    await db
+      .delete(namespaces)
+      .where(inArray(namespaces.slug, [`s520-parity-a-${runId}`, `s520-parity-b-${runId}`]))
+      .catch(() => {});
+  }
+  for (const id of createdUserIds) {
+    await db.delete(users).where(eq(users.id, id)).catch(() => {});
+  }
+});
+
+describe("spec-520 ac-10: the AC-health payload, pinned bucket by bucket", () => {
+  it("returns the exact payload for a Spec exercising every bucket", async () => {
+    tagAc(AC_PARITY);
+    const health = await aggregateAcHealthForBriefs(memexId, [richDocId]);
+
+    // toEqual on the WHOLE object, deliberately. A rewrite that drops `accepted` — a
+    // field two of this repo's three AcHealth declarations do not even have — fails here
+    // and nowhere else.
+    expect(health.get(richDocId)).toEqual({
+      totalActive: 6, // seq 1..6; the retired seq 7 is invisible
+      covered: 5, // 1,2,3,5,6 have events; 4 has none
+      verified: 1, // seq 1
+      failing: 2, // seq 2, and seq 6 where evidence beats the acceptance
+      stale: 1, // seq 3
+      untested: 1, // seq 4
+      accepted: 1, // seq 5 — presents over its own stale passing test
+    });
+  });
+
+  it("a Spec with no active ACs is PRESENT in the map with the empty payload", async () => {
+    tagAc(AC_PARITY);
+    const health = await aggregateAcHealthForBriefs(memexId, [emptyDocId]);
+    // Absence and zero mean different things to the caller: the board omits the pill for
+    // a Spec with no commitments, and it can only do that if the key exists.
+    expect(health.has(emptyDocId)).toBe(true);
+    expect(health.get(emptyDocId)).toEqual({
+      totalActive: 0,
+      covered: 0,
+      verified: 0,
+      failing: 0,
+      stale: 0,
+      untested: 0,
+      accepted: 0,
+    });
+  });
+
+  it("an empty Spec-id list returns an empty map without querying", async () => {
+    tagAc(AC_PARITY);
+    expect((await aggregateAcHealthForBriefs(memexId, [])).size).toBe(0);
+  });
+});
+
+describe("spec-520 ac-10: tenancy — the parity risk t-4 actually introduces", () => {
+  it("another tenant's Specs and events do not affect this tenant's payload", async () => {
+    tagAc(AC_PARITY);
+    // Today Q2 reads test_event_latest filtered by subject_ref ALONE — no memex_id.
+    // t-4 adds `memex_id = ?`. Since subject_ref embeds the namespace and memex slugs it
+    // is globally unique in practice, so both forms should agree. This pins that they do.
+    const health = await aggregateAcHealthForBriefs(memexId, [richDocId, otherDocId]);
+
+    // The foreign Spec is seeded EMPTY rather than omitted: the aggregate seeds every
+    // requested id up-front, and Q1's `acs.memexId = memexId` predicate is what keeps the
+    // foreign AC out. A rewrite that moved tenancy enforcement into Q2 only would leak it.
+    expect(health.get(otherDocId)).toEqual({
+      totalActive: 0,
+      covered: 0,
+      verified: 0,
+      failing: 0,
+      stale: 0,
+      untested: 0,
+      accepted: 0,
+    });
+    // …and asking as the OTHER tenant must not surface this one's Spec either.
+    const reverse = await aggregateAcHealthForBriefs(otherMemexId, [richDocId, otherDocId]);
+    expect(reverse.get(richDocId)?.totalActive).toBe(0);
+    expect(reverse.get(otherDocId)?.totalActive).toBe(1);
+  });
+});

--- a/packages/server/src/services/clause-order.spec-530.integration.test.ts
+++ b/packages/server/src/services/clause-order.spec-530.integration.test.ts
@@ -1,0 +1,154 @@
+// spec-530 t-4 / dec-5 (ac-23) — clause order is a function of the rows, not of query luck.
+//
+// Two defects that compound, registered together as issue-1 during session 1:
+//
+//   1. `createClause` wrote the caller's `position` with no shift, so passing an
+//      OCCUPIED ordinal produced two live rows sharing a position.
+//   2. `liveClausesForSection` ordered by `position` alone, with no tiebreaker, so
+//      tied rows came back in whatever order the scan produced.
+//
+// Together they meant a section's composed text was not a function of its rows:
+// `regenerateSectionContentTx` joins the clauses in that order and writes the result
+// to `doc_sections.content`, so a Standard's rendered rule text could change between
+// two regenerations with no write in between.
+//
+// t-4's anchor→ordinal translation (ac-19) walks into defect 1 on EVERY `add`
+// operation by construction — resolving an anchor to "just before/after cl-N" yields
+// an ordinal that is already occupied; that is what "insert here" means.
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { and, asc, eq, ne } from "drizzle-orm";
+import { db } from "../db/connection.js";
+import { documents, docSections, standardClauses } from "../db/schema.js";
+import { createDocDraft } from "./documents.js";
+import { addSection } from "./sections.js";
+import { createClause, updateClause, deleteClause } from "./clauses.js";
+import { makeTestMemex } from "./test-helpers.js";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+const AC_23 = "mindset-prod/memex-building-itself/specs/spec-530/acs/ac-23";
+
+const createdDocIds: string[] = [];
+let memexId: string;
+
+beforeAll(async () => {
+  memexId = await makeTestMemex("s530ord");
+});
+
+afterAll(async () => {
+  for (const id of createdDocIds) {
+    await db.delete(documents).where(eq(documents.id, id));
+  }
+});
+
+/** A standard section carrying `bodies` as appended clauses — positions 1..N. */
+async function seededSection(bodies: string[]): Promise<{ docId: string; sectionId: string }> {
+  const doc = await createDocDraft(memexId, "Clause Order Standard", "purpose", "standard");
+  createdDocIds.push(doc.id);
+  const section = await addSection(memexId, doc.id, "rule", "");
+  for (const body of bodies) {
+    await createClause(memexId, section.id, body);
+  }
+  return { docId: doc.id, sectionId: section.id };
+}
+
+/** Live clauses as stored, read with an explicit total order so the ASSERTION never
+ *  depends on the very ordering under test. */
+async function liveRows(sectionId: string) {
+  return db
+    .select()
+    .from(standardClauses)
+    .where(and(eq(standardClauses.sectionId, sectionId), ne(standardClauses.status, "deleted")))
+    .orderBy(asc(standardClauses.position), asc(standardClauses.seq));
+}
+
+async function sectionContent(sectionId: string): Promise<string> {
+  const row = await db.query.docSections.findFirst({ where: eq(docSections.id, sectionId) });
+  return row!.content;
+}
+
+describe("spec-530 dec-5: inserting at an occupied ordinal shifts, never ties (ac-23)", () => {
+  it("shifts every live sibling at or after the target ordinal", async () => {
+    tagAc(AC_23);
+    const { sectionId } = await seededSection(["one", "two", "three", "four"]);
+
+    await createClause(memexId, sectionId, "inserted", 2);
+
+    const rows = await liveRows(sectionId);
+    expect(rows.map((r) => r.body)).toEqual(["one", "inserted", "two", "three", "four"]);
+    // Dense and unique — the property that makes "insert before cl-N" mean the same
+    // thing to every caller.
+    expect(rows.map((r) => r.position)).toEqual([1, 2, 3, 4, 5]);
+    expect(new Set(rows.map((r) => r.position)).size).toBe(rows.length);
+  });
+
+  it("composes the section in the shifted order, not the insertion order", async () => {
+    tagAc(AC_23);
+    const { sectionId } = await seededSection(["alpha", "beta"]);
+
+    await createClause(memexId, sectionId, "wedged", 1);
+
+    // The derived content is what a reader of the Standard actually sees.
+    expect(await sectionContent(sectionId)).toBe("wedged\n\nalpha\n\nbeta");
+  });
+
+  it("a soft-deleted clause never consumes an ordinal in the shift", async () => {
+    tagAc(AC_23);
+    const { sectionId } = await seededSection(["keep-1", "doomed", "keep-2"]);
+    const before = await liveRows(sectionId);
+    await deleteClause(memexId, before[1].id);
+
+    // Live rows are now keep-1 (1) and keep-2 (3) — the deleted row froze position 2.
+    await createClause(memexId, sectionId, "inserted", 2);
+
+    const rows = await liveRows(sectionId);
+    expect(rows.map((r) => r.body)).toEqual(["keep-1", "inserted", "keep-2"]);
+    expect(new Set(rows.map((r) => r.position)).size).toBe(rows.length);
+    // And the deleted clause is still absent from the rendered rule.
+    expect(await sectionContent(sectionId)).not.toContain("doomed");
+  });
+
+  it("appending is unaffected — no position supplied still lands last", async () => {
+    tagAc(AC_23);
+    const { sectionId } = await seededSection(["first", "second"]);
+
+    await createClause(memexId, sectionId, "appended");
+
+    const rows = await liveRows(sectionId);
+    expect(rows.map((r) => r.body)).toEqual(["first", "second", "appended"]);
+    expect(rows[2].position).toBe(3);
+  });
+});
+
+describe("spec-530 dec-5: rows already tied compose deterministically (ac-23)", () => {
+  it("orders tied clauses by seq, so composition cannot follow scan order", async () => {
+    tagAc(AC_23);
+    const { docId, sectionId } = await seededSection(["anchor"]);
+
+    // Two live rows sharing position 2 — the state no insert-side fix can retroactively
+    // repair, because it already exists in databases written before dec-5.
+    //
+    // The seqs are deliberately INVERTED relative to insertion order: the row inserted
+    // FIRST carries the HIGHER seq. So heap order (what an untied scan tends to return)
+    // and seq order disagree, and only a real `ORDER BY position, seq` produces the
+    // expected text. Without the tiebreaker this is exactly the coin-flip that let a
+    // Standard's content change with no write behind it.
+    await db.insert(standardClauses).values([
+      { memexId, docId, sectionId, seq: 900, position: 2, body: "should-render-second" },
+    ] as (typeof standardClauses.$inferInsert)[]);
+    await db.insert(standardClauses).values([
+      { memexId, docId, sectionId, seq: 800, position: 2, body: "should-render-first" },
+    ] as (typeof standardClauses.$inferInsert)[]);
+
+    // Force a regeneration through the ordinary path (editing an unrelated clause).
+    const [anchor] = await liveRows(sectionId);
+    await updateClause(memexId, anchor.id, "anchor");
+
+    const content = await sectionContent(sectionId);
+    expect(content).toBe("anchor\n\nshould-render-first\n\nshould-render-second");
+
+    // And it is stable: a second regeneration produces the same bytes.
+    await updateClause(memexId, anchor.id, "anchor");
+    expect(await sectionContent(sectionId)).toBe(content);
+  });
+});

--- a/packages/server/src/services/clauses.ts
+++ b/packages/server/src/services/clauses.ts
@@ -15,7 +15,7 @@
 // never reused). `position` orders clauses within their section for composition; it
 // may move freely and is not the identity.
 
-import { and, asc, eq, ne, sql } from "drizzle-orm";
+import { and, asc, eq, gte, ne, sql } from "drizzle-orm";
 import { db } from "../db/connection.js";
 import { documents, docSections, standardClauses } from "../db/schema.js";
 import type { DocSection, StandardClause } from "../db/schema.js";
@@ -59,12 +59,46 @@ async function loadOwnedClause(memexId: string, clauseId: string): Promise<Stand
   return clause;
 }
 
+// spec-530 dec-5 (ac-23): `position` THEN `seq`. Ordering by position alone left tied
+// rows to scan order, so a section's composed content was not a function of its rows —
+// two regenerations with no write in between could differ. dec-5's shift prevents NEW
+// ties; this tiebreaker is what makes the rows already tied in a production database
+// compose deterministically, which no insert-side fix can reach. `seq` is allocate-once,
+// unique per doc and never resequenced (spec-150 dec-2), so the order is total.
 async function liveClausesForSection(tx: Tx, sectionId: string): Promise<StandardClause[]> {
   return tx
     .select()
     .from(standardClauses)
     .where(and(eq(standardClauses.sectionId, sectionId), ne(standardClauses.status, "deleted")))
-    .orderBy(asc(standardClauses.position));
+    .orderBy(asc(standardClauses.position), asc(standardClauses.seq));
+}
+
+/**
+ * Make room at `fromPosition` by pushing every LIVE sibling at or after it down one.
+ *
+ * spec-530 dec-5 (issue-1, ac-23). Inserting at an occupied ordinal used to simply write
+ * the duplicate, and `add_clause`'s optional `position` makes that reachable by any
+ * caller. t-4's anchor→ordinal translation hits it on every `add` by construction, since
+ * "insert before cl-N" resolves to an ordinal that is by definition already taken.
+ *
+ * Soft-deleted rows are excluded, matching liveClausesForSection's filter: a deleted
+ * clause has no place in the order and must not consume an ordinal.
+ */
+async function shiftPositionsFromTx(
+  tx: Tx,
+  sectionId: string,
+  fromPosition: number,
+): Promise<void> {
+  await tx
+    .update(standardClauses)
+    .set({ position: sql`${standardClauses.position} + 1` })
+    .where(
+      and(
+        eq(standardClauses.sectionId, sectionId),
+        ne(standardClauses.status, "deleted"),
+        gte(standardClauses.position, fromPosition),
+      ),
+    );
 }
 
 async function maxClauseSeqTx(tx: Tx, docId: string): Promise<number> {
@@ -185,6 +219,79 @@ export async function decomposeSection(
   );
 }
 
+// ── Transaction-level primitives ──────────────────────
+//
+// spec-530 t-4: `accept_standard_change` applies a SET of clause operations and resolves
+// the proposal in ONE transaction (dec-4's atomicity property). The public verbs below
+// each open their own `db.transaction`, so calling them in a loop would give N
+// transactions and a Standard that can be left half-rewritten — the exact state ac-10
+// forbids. These primitives are the composable core: they take the caller's `tx`, do no
+// regeneration and no emitting, and leave both to whoever owns the transaction.
+//
+// The public verbs are thin wrappers over them, so there is one implementation of each
+// write rather than a second copy living in the accept path.
+
+/** Insert one clause inside the caller's transaction. Allocates the doc-wide `seq`
+ *  (MAX+1, allocate-once), and for a supplied `position` shifts live siblings out of the
+ *  way first [per dec-5] so ordinals stay unique and dense. No position → append. */
+export async function insertClauseTx(
+  tx: Tx,
+  memexId: string,
+  section: Pick<DocSection, "id" | "docId">,
+  body: string,
+  position?: number,
+): Promise<StandardClause> {
+  const seq = (await maxClauseSeqTx(tx, section.docId)) + 1;
+  let pos: number;
+  if (position === undefined) {
+    pos = (await maxPositionTx(tx, section.id)) + 1;
+  } else {
+    pos = position;
+    await shiftPositionsFromTx(tx, section.id, pos);
+  }
+  const [row] = await tx
+    .insert(standardClauses)
+    .values({ memexId, docId: section.docId, sectionId: section.id, seq, position: pos, body })
+    .returning();
+  await syncClauseRefsTx(tx, row); // spec-179: materialize handle mentions
+  return row;
+}
+
+/** Replace one clause's body inside the caller's transaction. */
+export async function updateClauseBodyTx(
+  tx: Tx,
+  clauseId: string,
+  body: string,
+): Promise<StandardClause> {
+  const [row] = await tx
+    .update(standardClauses)
+    .set({ body, updatedAt: new Date() })
+    .where(eq(standardClauses.id, clauseId))
+    .returning();
+  await syncClauseRefsTx(tx, row); // spec-179: re-derive handle mentions
+  return row;
+}
+
+/** Soft-delete one clause inside the caller's transaction. No resequencing (spec-150
+ *  dec-2): the freed `seq` is frozen and every other `cl-N` handle is untouched. */
+export async function softDeleteClauseTx(
+  tx: Tx,
+  clause: StandardClause,
+): Promise<StandardClause> {
+  const [row] = await tx
+    .update(standardClauses)
+    .set({ status: "deleted", previousStatus: clause.status, updatedAt: new Date() })
+    .where(eq(standardClauses.id, clause.id))
+    .returning();
+  await syncClauseRefsTx(tx, row); // spec-179: soft-deleted clause keeps zero refs
+  return row;
+}
+
+export { regenerateSectionContentTx, liveClausesForSection };
+export type { Tx };
+
+// ── Public verbs ──────────────────────────────────────
+
 /** Append (or insert at `position`) a clause to a decomposed section; regenerate content. */
 export async function createClause(
   memexId: string,
@@ -207,13 +314,7 @@ export async function createClause(
 
   return mutate(ctx, keys, async () =>
     db.transaction(async (tx) => {
-      const seq = (await maxClauseSeqTx(tx, section.docId)) + 1;
-      const pos = position ?? (await maxPositionTx(tx, sectionId)) + 1;
-      const [row] = await tx
-        .insert(standardClauses)
-        .values({ memexId, docId: section.docId, sectionId, seq, position: pos, body })
-        .returning();
-      await syncClauseRefsTx(tx, row); // spec-179: materialize handle mentions
+      const row = await insertClauseTx(tx, memexId, section, body, position);
       await regenerateSectionContentTx(tx, section, actor);
       return row;
     }),
@@ -328,12 +429,7 @@ export async function updateClause(
 
   return mutate(ctx, keys, async () =>
     db.transaction(async (tx) => {
-      const [row] = await tx
-        .update(standardClauses)
-        .set({ body, updatedAt: new Date() })
-        .where(eq(standardClauses.id, clauseId))
-        .returning();
-      await syncClauseRefsTx(tx, row); // spec-179: re-derive handle mentions
+      const row = await updateClauseBodyTx(tx, clauseId, body);
       await regenerateSectionContentTx(tx, section, actor);
       return row;
     }),
@@ -368,12 +464,7 @@ export async function deleteClause(
 
   return mutate(ctx, keys, async () =>
     db.transaction(async (tx) => {
-      const [row] = await tx
-        .update(standardClauses)
-        .set({ status: "deleted", previousStatus: clause.status, updatedAt: new Date() })
-        .where(eq(standardClauses.id, clauseId))
-        .returning();
-      await syncClauseRefsTx(tx, row); // spec-179: soft-deleted clause keeps zero refs
+      const row = await softDeleteClauseTx(tx, clause);
       await regenerateSectionContentTx(tx, section, actor);
       return row;
     }),

--- a/packages/server/src/services/drift-inbox-proposal.spec-530.integration.test.ts
+++ b/packages/server/src/services/drift-inbox-proposal.spec-530.integration.test.ts
@@ -1,0 +1,215 @@
+// spec-530 t-7 — the Drift Inbox read model carries a proposal's OPERATIONS, resolved
+// against the live clauses.
+//
+// Until now `proposedContent` was the only thing on the wire, and for a clause-grained
+// proposal it is the raw comment body — which is why `DriftInbox.tsx` rendered nothing
+// and its header comment claimed the diff was "reachable via Discuss with Agent or the
+// standard page", a claim verified false on both counts.
+//
+// The row needs three things per operation the client cannot derive: which clause
+// (`cl-N`), what the proposal wants it to say, and what it says RIGHT NOW. The last one
+// is a database read, so it belongs here rather than in the client.
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { eq } from "drizzle-orm";
+import { db } from "../db/connection.js";
+import { documents, docComments } from "../db/schema.js";
+import type { StandardClause } from "../db/schema.js";
+import { createStandard, proposeStandardChange } from "./standards.js";
+import { addClausesToSection, updateClause } from "./clauses.js";
+import { listDriftInbox } from "./drift-inbox.js";
+import { makeTestMemex } from "./test-helpers.js";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+const AC_18 = "mindset-prod/memex-building-itself/specs/spec-530/acs/ac-18";
+
+const createdDocIds: string[] = [];
+let memexId: string;
+
+beforeAll(async () => {
+  memexId = await makeTestMemex("s530inbox");
+});
+
+afterAll(async () => {
+  for (const id of createdDocIds) {
+    await db.delete(documents).where(eq(documents.id, id)).catch(() => {});
+  }
+});
+
+async function seededStandard(
+  title: string,
+  bodies: string[],
+): Promise<{ docId: string; sectionId: string; clauses: StandardClause[] }> {
+  const std = await createStandard(memexId, {
+    title,
+    sections: [{ sectionType: "rule", content: "" }],
+  });
+  createdDocIds.push(std.id);
+  const sectionId = std.sections[0].id;
+  const clauses = await addClausesToSection(
+    memexId,
+    sectionId,
+    bodies.map((body) => ({ body, facets: [] })),
+  );
+  return { docId: std.id, sectionId, clauses: [...clauses] };
+}
+
+async function rowFor(commentId: string) {
+  const page = await listDriftInbox(memexId, { limit: 200 });
+  return page.items.find((i) => i.commentId === commentId);
+}
+
+describe("spec-530 t-7: the Inbox read model carries the proposal's operations", () => {
+  it("returns each operation with its cl-N, the proposed text, and the LIVE clause body", async () => {
+    const { clauses } = await seededStandard("Inbox Ops Standard", [
+      "keep me",
+      "edit me",
+      "delete me",
+    ]);
+    const proposal = await proposeStandardChange(memexId, [
+      { op: "edit", clauseId: clauses[1].id, after: "edited text" },
+      { op: "delete", clauseId: clauses[2].id },
+      { op: "add", anchorClauseId: clauses[0].id, placement: "after", body: "added text" },
+    ]);
+
+    const row = await rowFor(proposal.comment.id);
+    expect(row?.proposal?.kind).toBe("clause-ops");
+    const ops = row!.proposal!.kind === "clause-ops" ? row!.proposal!.operations : [];
+
+    // Order is the proposal's own — a reviewer reads the operations as authored.
+    expect(ops.map((o) => o.op)).toEqual(["edit", "delete", "add"]);
+    expect(ops.map((o) => o.clause)).toEqual([
+      `cl-${clauses[1].seq}`,
+      `cl-${clauses[2].seq}`,
+      `cl-${clauses[0].seq}`, // the ADD names its anchor
+    ]);
+
+    expect(ops[0]).toMatchObject({ before: "edit me", after: "edited text", current: "edit me" });
+    expect(ops[1]).toMatchObject({ before: "delete me", current: "delete me" });
+    expect(ops[1].after).toBeUndefined(); // nothing replaces a deletion
+    expect(ops[2]).toMatchObject({ placement: "after", after: "added text", current: "keep me" });
+    expect(ops[2].before).toBeUndefined(); // an add has no "before"
+  });
+
+  it("carries `current` as the LIVE body, which can differ from the authored `before`", async () => {
+    const { clauses } = await seededStandard("Inbox Drift Standard", ["the original rule"]);
+    const proposal = await proposeStandardChange(memexId, [
+      { op: "edit", clauseId: clauses[0].id, after: "the proposed rule" },
+    ]);
+
+    // Someone corrects the clause after the proposal was authored.
+    await updateClause(memexId, clauses[0].id, "the rule as someone else corrected it");
+
+    const row = await rowFor(proposal.comment.id);
+    const ops = row!.proposal!.kind === "clause-ops" ? row!.proposal!.operations : [];
+    // Both travel, because they answer different questions: after-vs-current is the diff
+    // a reviewer judges; before-vs-current is whether the proposal still applies. The
+    // read model states both and derives NO verdict — dec-3 put that judgement inside
+    // the accept transaction and dec-4 gave it exactly one home.
+    expect(ops[0].before).toBe("the original rule");
+    expect(ops[0].current).toBe("the rule as someone else corrected it");
+    expect(ops[0].after).toBe("the proposed rule");
+  });
+
+  it("reports `current: null` when the targeted clause no longer exists", async () => {
+    const { clauses } = await seededStandard("Inbox Gone Standard", ["doomed", "other"]);
+    const proposal = await proposeStandardChange(memexId, [
+      { op: "edit", clauseId: clauses[0].id, after: "never applied" },
+    ]);
+    const { deleteClause } = await import("./clauses.js");
+    await deleteClause(memexId, clauses[0].id);
+
+    const row = await rowFor(proposal.comment.id);
+    const ops = row!.proposal!.kind === "clause-ops" ? row!.proposal!.operations : [];
+    expect(ops[0].current).toBeNull();
+    // The row still renders — a vanished target is one unusable operation, not a crash.
+    expect(row?.proposal?.kind).toBe("clause-ops");
+  });
+
+  it("resolves cl-N per STANDARD, so two Standards' identical handles do not cross", async () => {
+    // `seq` is allocated MAX+1 per doc, so cl-1 exists on every Standard. Matching on
+    // seq alone would show one Standard's rule text under another's proposal.
+    const a = await seededStandard("Inbox Collide A", ["A's first clause"]);
+    const b = await seededStandard("Inbox Collide B", ["B's first clause"]);
+    expect(a.clauses[0].seq).toBe(b.clauses[0].seq);
+
+    const pa = await proposeStandardChange(memexId, [
+      { op: "edit", clauseId: a.clauses[0].id, after: "A changed" },
+    ]);
+    const pb = await proposeStandardChange(memexId, [
+      { op: "edit", clauseId: b.clauses[0].id, after: "B changed" },
+    ]);
+
+    const rowA = await rowFor(pa.comment.id);
+    const rowB = await rowFor(pb.comment.id);
+    const opsA = rowA!.proposal!.kind === "clause-ops" ? rowA!.proposal!.operations : [];
+    const opsB = rowB!.proposal!.kind === "clause-ops" ? rowB!.proposal!.operations : [];
+    expect(opsA[0].current).toBe("A's first clause");
+    expect(opsB[0].current).toBe("B's first clause");
+  });
+
+  it("reports a pre-cutover body as legacy rather than throwing (ac-18)", async () => {
+    tagAc(AC_18);
+    const { clauses } = await seededStandard("Inbox Legacy Standard", ["a rule"]);
+    const proposal = await proposeStandardChange(memexId, [
+      { op: "edit", clauseId: clauses[0].id, after: "irrelevant" },
+    ]);
+    await db
+      .update(docComments)
+      .set({
+        content: [
+          "**Proposed change to section [rule]**",
+          "",
+          "legacy rationale",
+          "",
+          "~~~proposed-content",
+          "A whole replacement section body.",
+          "~~~",
+        ].join("\n"),
+      })
+      .where(eq(docComments.id, proposal.comment.id));
+
+    const row = await rowFor(proposal.comment.id);
+    expect(row?.proposal).toEqual({
+      kind: "legacy",
+      proposed: "A whole replacement section body.",
+    });
+  });
+
+  it("reports an unparseable body as unreadable, and the rest of the page still renders (ac-18)", async () => {
+    tagAc(AC_18);
+    const { clauses } = await seededStandard("Inbox Corrupt Standard", ["a rule"]);
+    const corrupt = await proposeStandardChange(memexId, [
+      { op: "edit", clauseId: clauses[0].id, after: "irrelevant" },
+    ]);
+    await db
+      .update(docComments)
+      .set({ content: "someone wrote a plan_revision by hand with no payload at all" })
+      .where(eq(docComments.id, corrupt.comment.id));
+
+    // A second, healthy proposal on the same page.
+    const healthy = await seededStandard("Inbox Healthy Standard", ["another rule"]);
+    const good = await proposeStandardChange(memexId, [
+      { op: "edit", clauseId: healthy.clauses[0].id, after: "a good change" },
+    ]);
+
+    const page = await listDriftInbox(memexId, { limit: 200 });
+    expect(page.items.find((i) => i.commentId === corrupt.comment.id)?.proposal).toEqual({
+      kind: "unreadable",
+    });
+    // The blast radius of one bad body is ONE row, never the page.
+    expect(page.items.find((i) => i.commentId === good.comment.id)?.proposal?.kind).toBe(
+      "clause-ops",
+    );
+  });
+
+  it("leaves a drift observation with no proposal at all", async () => {
+    const { sectionId } = await seededStandard("Inbox Observation Standard", ["a rule"]);
+    const { flagDrift } = await import("./standards.js");
+    const drift = await flagDrift(memexId, sectionId, "the code diverged");
+
+    const row = await rowFor(drift.id);
+    expect(row?.proposal).toBeNull();
+    expect(row?.proposedContent).toBeNull();
+  });
+});

--- a/packages/server/src/services/drift-inbox.ts
+++ b/packages/server/src/services/drift-inbox.ts
@@ -29,9 +29,51 @@
 // AND comment_type IN ('drift', 'plan_revision')` so the query stays O(limit)
 // regardless of total comment count.
 
-import { sql } from "drizzle-orm";
+import { and, eq, inArray, ne, or, sql } from "drizzle-orm";
 import { db } from "../db/connection.js";
+import { standardClauses } from "../db/schema.js";
 import { parseProposedChangeBody } from "./standards.js";
+
+/**
+ * One clause operation of a proposal, as the Drift Inbox row renders it (spec-530 t-7).
+ *
+ * `before` is the target clause's body AS THE PROPOSAL WAS AUTHORED — the staleness
+ * evidence dec-3's guard compares against. `current` is what the clause says RIGHT NOW.
+ * Both travel because they answer different questions: `after` vs `current` is the diff a
+ * reviewer judges, while `before` vs `current` is whether the proposal still applies.
+ *
+ * Deliberately NO derived "is stale" verdict here. dec-3 put that judgement inside the
+ * accept transaction, and dec-4 gave it exactly one home; a second copy on a read model
+ * that can go out of date before the user acts would be the duplication dec-4's rationale
+ * exists to prevent. The row shows both bodies and lets the difference speak.
+ */
+export interface DriftProposalOperation {
+  op: "edit" | "delete" | "add";
+  /** The target's `cl-N` handle. For `add`, the ANCHOR it sits relative to. */
+  clause: string;
+  /** `add` only — which side of the anchor the new clause goes. */
+  placement?: "before" | "after";
+  /** The target's body at authoring time. Absent for `add` (nothing was there). */
+  before?: string;
+  /** The proposed text. Absent for `delete` (nothing replaces it). */
+  after?: string;
+  /** The clause's live body now, or null when it no longer exists (deleted since). */
+  current: string | null;
+}
+
+/**
+ * What a `plan_revision` row's body turned out to be.
+ *
+ * `legacy` is a pre-spec-530 whole-section replacement: readable, but not applyable by
+ * the clause-grained accept path. `unreadable` is a body that parses as neither — a
+ * proposal authored outside `proposeStandardChange`, or a corrupted payload. Both
+ * degrade to an explanatory row rather than throwing: one unusable row is the acceptable
+ * cost, a broken Inbox for every other item on the page is not (spec-530 ac-18).
+ */
+export type DriftProposal =
+  | { kind: "clause-ops"; operations: DriftProposalOperation[] }
+  | { kind: "legacy"; proposed: string }
+  | { kind: "unreadable" };
 
 export interface DriftInboxRow {
   commentId: string;
@@ -47,15 +89,29 @@ export interface DriftInboxRow {
   authorName: string;
   content: string;
   /**
-   * Normalized proposed replacement text for a `plan_revision` row (spec-143
-   * dec-2 / ac-9). ALWAYS non-null for a `plan_revision` so the React UI can
-   * render a before/after diff without re-parsing the fence — and so a proposal
-   * authored without the `~~~proposed-content` fence (older rows, or proposals
-   * written outside `proposeStandardChange`) still carries applyable text
-   * instead of falling through to an undifferentiated markdown blob. `null` for
-   * a `drift` observation, which is a finding with no proposed edit.
+   * Proposed replacement text for a `plan_revision` row. Non-null for every
+   * `plan_revision`, null for a `drift` observation.
+   *
+   * spec-530 t-7 CORRECTION: this field's original contract — "normalized proposed
+   * replacement text, so the UI renders a before/after diff" (spec-143 dec-2 / ac-9) —
+   * only ever made sense when a proposal WAS one replacement body. At the clause grain
+   * a proposal is a SET of operations and has no single "proposed body", so for a
+   * clause-ops row this carries the raw comment content (which holds the operations
+   * payload) rather than a synthesised rendering. **The UI renders `proposal`, not this
+   * field.** It stays non-null because the drift agent's context reads it, and after
+   * dec-4 the agent no longer needs to reproduce proposal text verbatim — it explains
+   * the proposal and calls the accept verb by ref, for which the payload suffices.
+   *
+   * Kept rather than removed, and its docstring corrected rather than left describing a
+   * contract it stopped honouring — which is the exact defect class this Spec is named
+   * after.
    */
   proposedContent: string | null;
+  /**
+   * The proposal's operations, resolved against the live clauses (spec-530 t-7). This
+   * is what the Inbox row renders. `null` for a `drift` observation.
+   */
+  proposal: DriftProposal | null;
   createdAt: Date;
   /**
    * The source DECISION a `drift` finding contradicts (spec-498 dec-4): a drift
@@ -136,18 +192,108 @@ function normalizeProposedContent(
 ): string | null {
   if (commentType !== "plan_revision") return null;
   const parsed = parseProposedChangeBody(content);
-  // spec-530 t-1: only the LEGACY shape yields a single replacement text. A
-  // clause-grained proposal is a set of operations and has no one "proposed body" —
-  // it falls through to the raw content below, exactly as an unfenced proposal does,
-  // until t-7 carries the structured operations to the client and renders per-clause
-  // diffs. Deliberately no synthesised rendering here: inventing one would put text
-  // on screen that no one proposed.
+  // Only the LEGACY shape yields a single replacement text. A clause-grained proposal is
+  // a set of operations and has no one "proposed body", so it falls through to the raw
+  // content — which is what the agent reads, and which carries the operations payload.
+  // Deliberately no synthesised rendering: inventing one would put text on a screen that
+  // nobody proposed. The structured `proposal` field below is what the UI renders
+  // (spec-530 t-7); see the field docstring for why this one survives.
   if (parsed?.kind === "legacy" && parsed.proposed.trim().length > 0) {
     return parsed.proposed;
   }
-  // Unfenced proposal: surface the raw body so the row still renders a diff
-  // rather than falling through to a blob.
   return content;
+}
+
+/**
+ * Resolve every proposal on the page against the live clauses, in ONE query.
+ *
+ * `cl-N` is per-STANDARD (seq is allocated MAX+1 per doc), so a handle only identifies a
+ * clause together with its docId — matching on seq alone would collide across two
+ * Standards in the same Memex and show the wrong rule text. The lookup is therefore an
+ * OR of per-doc `seq IN (…)` groups.
+ *
+ * Batched deliberately [per std-39]: the natural shape is a lookup inside the operation
+ * loop, which would be one query per clause per row — 50 proposals of 3 operations each
+ * would be 150 round-trips on a page render.
+ */
+async function resolveProposals(
+  memexId: string,
+  rows: { docId: string; commentType: "drift" | "plan_revision"; content: string }[],
+): Promise<Map<string, DriftProposal | null>> {
+  const out = new Map<string, DriftProposal | null>();
+  const parsedByKey = new Map<string, ReturnType<typeof parseProposedChangeBody>>();
+  const seqsByDoc = new Map<string, Set<number>>();
+
+  rows.forEach((r, i) => {
+    if (r.commentType !== "plan_revision") return;
+    const parsed = parseProposedChangeBody(r.content);
+    parsedByKey.set(String(i), parsed);
+    if (parsed?.kind !== "clause-ops") return;
+    for (const op of parsed.operations) {
+      const handle = op.op === "add" ? op.anchor : op.clause;
+      const seq = Number.parseInt(handle.replace(/^cl-/, ""), 10);
+      if (!Number.isInteger(seq)) continue;
+      const set = seqsByDoc.get(r.docId) ?? new Set<number>();
+      set.add(seq);
+      seqsByDoc.set(r.docId, set);
+    }
+  });
+
+  // doc → seq → live body, for every clause any proposal on this page targets.
+  const bodies = new Map<string, string>();
+  if (seqsByDoc.size > 0) {
+    const groups = [...seqsByDoc.entries()].map(([docId, seqs]) =>
+      and(eq(standardClauses.docId, docId), inArray(standardClauses.seq, [...seqs])),
+    );
+    const clauseRows = await db
+      .select({
+        docId: standardClauses.docId,
+        seq: standardClauses.seq,
+        body: standardClauses.body,
+      })
+      .from(standardClauses)
+      .where(
+        and(
+          eq(standardClauses.memexId, memexId),
+          ne(standardClauses.status, "deleted"),
+          groups.length === 1 ? groups[0] : or(...groups),
+        ),
+      );
+    for (const c of clauseRows) bodies.set(`${c.docId}|${c.seq}`, c.body);
+  }
+
+  rows.forEach((r, i) => {
+    if (r.commentType !== "plan_revision") {
+      out.set(String(i), null);
+      return;
+    }
+    const parsed = parsedByKey.get(String(i));
+    if (!parsed) {
+      out.set(String(i), { kind: "unreadable" });
+      return;
+    }
+    if (parsed.kind === "legacy") {
+      out.set(String(i), { kind: "legacy", proposed: parsed.proposed });
+      return;
+    }
+    const operations: DriftProposalOperation[] = parsed.operations.map((op) => {
+      const handle = op.op === "add" ? op.anchor : op.clause;
+      const seq = Number.parseInt(handle.replace(/^cl-/, ""), 10);
+      const current = Number.isInteger(seq)
+        ? (bodies.get(`${r.docId}|${seq}`) ?? null)
+        : null;
+      if (op.op === "add") {
+        return { op: "add", clause: op.anchor, placement: op.placement, after: op.body, current };
+      }
+      if (op.op === "edit") {
+        return { op: "edit", clause: op.clause, before: op.before, after: op.after, current };
+      }
+      return { op: "delete", clause: op.clause, before: op.before, current };
+    });
+    out.set(String(i), { kind: "clause-ops", operations });
+  });
+
+  return out;
 }
 
 interface RawRow {
@@ -277,7 +423,17 @@ export async function listDriftInbox(
   const last = pageRows[pageRows.length - 1];
   const nextCursor = hasMore && last ? encodeCursor(last.created_at, last.comment_id) : null;
 
-  const items: DriftInboxRow[] = pageRows.map((r) => ({
+  // One extra query for the whole page, not one per operation [per std-39].
+  const proposals = await resolveProposals(
+    memexId,
+    pageRows.map((r) => ({
+      docId: r.doc_id,
+      commentType: r.comment_type,
+      content: r.content,
+    })),
+  );
+
+  const items: DriftInboxRow[] = pageRows.map((r, i) => ({
     commentId: r.comment_id,
     // The `(doc_id, seq)` allocator mints per-doc `c-N` handles (schema.ts);
     // derive the canonical form here so every consumer gets the same string.
@@ -287,6 +443,7 @@ export async function listDriftInbox(
     authorName: r.author_name,
     content: r.content,
     proposedContent: normalizeProposedContent(r.comment_type, r.content),
+    proposal: proposals.get(String(i)) ?? null,
     // Raw SQL via db.execute returns timestamptz as ISO string; DriftInboxRow.createdAt
     // is typed as Date for callers, so coerce here.
     createdAt: r.created_at instanceof Date ? r.created_at : new Date(r.created_at),

--- a/packages/server/src/services/standard-accept-atomicity.spec-530.integration.test.ts
+++ b/packages/server/src/services/standard-accept-atomicity.spec-530.integration.test.ts
@@ -1,0 +1,149 @@
+// spec-530 t-4 (dec-4, ac-10) — the accept is all-or-nothing.
+//
+// This is the property the two-call, agent-orchestrated alternative could not hold, and
+// dec-1 is what made it matter: a proposal is a SET, so "two calls" would have been
+// "N+1 calls". An interruption partway would leave a Standard half-rewritten with its
+// proposal still open — a state indistinguishable, to the next reader, from one not yet
+// applied. One transaction removes that state rather than asking anyone to reason about it.
+//
+// Isolated in its own file because it mocks the clause-write module, and a module mock
+// applies to every test in the file it lives in [per std-37: restore global stubs].
+
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+import { and, asc, eq, ne } from "drizzle-orm";
+
+// The failure is injected at the clause-write seam: the SECOND body write in a run
+// throws, standing in for any mid-transaction fault (a constraint violation, a dropped
+// connection, a deploy restarting the process). What matters is not which fault it is,
+// but that the operations already applied do not survive it.
+let bodyWriteCalls = 0;
+let failOnBodyWrite: number | null = null;
+
+vi.mock("./clauses.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./clauses.js")>();
+  return {
+    ...actual,
+    updateClauseBodyTx: async (
+      ...args: Parameters<typeof actual.updateClauseBodyTx>
+    ): ReturnType<typeof actual.updateClauseBodyTx> => {
+      bodyWriteCalls += 1;
+      if (failOnBodyWrite !== null && bodyWriteCalls === failOnBodyWrite) {
+        throw new Error("injected mid-transaction fault");
+      }
+      return actual.updateClauseBodyTx(...args);
+    },
+  };
+});
+
+const { db } = await import("../db/connection.js");
+const { documents, docComments, docSections, standardClauses } = await import("../db/schema.js");
+const { createStandard, proposeStandardChange } = await import("./standards.js");
+const { addClausesToSection } = await import("./clauses.js");
+const { acceptStandardChange } = await import("./standard-accept.js");
+const { makeTestMemex } = await import("./test-helpers.js");
+const { tagAc } = await import("@memex-ai-ac/vitest");
+
+const AC_10 = "mindset-prod/memex-building-itself/specs/spec-530/acs/ac-10";
+
+const createdDocIds: string[] = [];
+let memexId: string;
+
+beforeAll(async () => {
+  memexId = await makeTestMemex("s530atom");
+});
+
+afterAll(async () => {
+  failOnBodyWrite = null;
+  vi.restoreAllMocks();
+  for (const id of createdDocIds) {
+    await db.delete(documents).where(eq(documents.id, id)).catch(() => {});
+  }
+});
+
+async function liveBodies(sectionId: string): Promise<string[]> {
+  const rows = await db
+    .select()
+    .from(standardClauses)
+    .where(and(eq(standardClauses.sectionId, sectionId), ne(standardClauses.status, "deleted")))
+    .orderBy(asc(standardClauses.position), asc(standardClauses.seq));
+  return rows.map((r) => r.body);
+}
+
+describe("spec-530 ac-10: a failure mid-set leaves the Standard exactly as it was", () => {
+  it("forced failure on operation 2 of 3 applies NOTHING and leaves the proposal open", async () => {
+    tagAc(AC_10);
+    const std = await createStandard(memexId, {
+      title: "Atomicity Target Standard",
+      sections: [{ sectionType: "rule", content: "" }],
+    });
+    createdDocIds.push(std.id);
+    const sectionId = std.sections[0].id;
+    const clauses = await addClausesToSection(memexId, sectionId, [
+      { body: "one", facets: [] },
+      { body: "two", facets: [] },
+      { body: "three", facets: [] },
+    ]);
+
+    const proposal = await proposeStandardChange(memexId, [
+      { op: "edit", clauseId: clauses[0].id, after: "one-changed" },
+      { op: "edit", clauseId: clauses[1].id, after: "two-changed" },
+      { op: "edit", clauseId: clauses[2].id, after: "three-changed" },
+    ]);
+
+    const contentBefore = (
+      await db.query.docSections.findFirst({ where: eq(docSections.id, sectionId) })
+    )!.content;
+
+    bodyWriteCalls = 0;
+    failOnBodyWrite = 2; // operation 2 of 3
+
+    await expect(acceptStandardChange(memexId, proposal.comment.id)).rejects.toThrow(
+      /injected mid-transaction fault/,
+    );
+    failOnBodyWrite = null;
+
+    // Operation 1 DID execute before the fault — and it is gone. That is the whole
+    // claim: clause 1 is byte-identical to its pre-call state, not "one-changed".
+    expect(await liveBodies(sectionId)).toEqual(["one", "two", "three"]);
+    expect(
+      (await db.query.docSections.findFirst({ where: eq(docSections.id, sectionId) }))!.content,
+    ).toBe(contentBefore);
+
+    // And the proposal is still open, so the Standard and its Inbox agree about what
+    // has happened: nothing.
+    const comment = await db.query.docComments.findFirst({
+      where: eq(docComments.id, proposal.comment.id),
+    });
+    expect(comment!.resolvedAt).toBeNull();
+    expect(comment!.resolution).toBeNull();
+  });
+
+  it("the same proposal applies cleanly once the fault is gone — the rollback lost nothing", async () => {
+    tagAc(AC_10);
+    const std = await createStandard(memexId, {
+      title: "Atomicity Retry Standard",
+      sections: [{ sectionType: "rule", content: "" }],
+    });
+    createdDocIds.push(std.id);
+    const sectionId = std.sections[0].id;
+    const clauses = await addClausesToSection(memexId, sectionId, [
+      { body: "alpha", facets: [] },
+      { body: "beta", facets: [] },
+    ]);
+    const proposal = await proposeStandardChange(memexId, [
+      { op: "edit", clauseId: clauses[0].id, after: "alpha-changed" },
+      { op: "edit", clauseId: clauses[1].id, after: "beta-changed" },
+    ]);
+
+    bodyWriteCalls = 0;
+    failOnBodyWrite = 2;
+    await expect(acceptStandardChange(memexId, proposal.comment.id)).rejects.toThrow();
+    failOnBodyWrite = null;
+
+    // A refused accept is not a spent one. The proposal's stored "before" still matches
+    // the live clauses precisely BECAUSE the rollback was total — so dec-3's staleness
+    // guard passes and the retry succeeds.
+    await acceptStandardChange(memexId, proposal.comment.id);
+    expect(await liveBodies(sectionId)).toEqual(["alpha-changed", "beta-changed"]);
+  });
+});

--- a/packages/server/src/services/standard-accept-degrade.spec-530.integration.test.ts
+++ b/packages/server/src/services/standard-accept-degrade.spec-530.integration.test.ts
@@ -1,0 +1,171 @@
+// spec-530 t-9 (ac-18) — a proposal the clause path cannot apply DEGRADES; it never
+// half-applies and never crashes the caller.
+//
+// t-9's criteria were written against a two-shape world: clause-grained, or "legacy"
+// (a pre-cutover whole-section replacement inside a `~~~proposed-content` fence). t-11's
+// sweep of all 49 Standards found a THIRD shape and it is not rare — of the six open
+// proposals in the real corpus, three were free-form prose with no fence at all, written
+// before `propose_standard_change` was the only way to author one. Those parse to
+// neither shape: `parseProposedChangeBody` returns null.
+//
+// The accept verb already refuses both, but only the `legacy` branch had a test. This
+// file covers the branch the real corpus actually hits most, and pins the property that
+// matters for both: the Standard is untouched and the proposal stays open, so a body
+// nobody can apply costs one unusable row rather than a damaged rule or a stuck loop.
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { and, asc, eq, ne } from "drizzle-orm";
+import { db } from "../db/connection.js";
+import { documents, docComments, standardClauses } from "../db/schema.js";
+import type { StandardClause } from "../db/schema.js";
+import { createStandard, proposeStandardChange } from "./standards.js";
+import { addClausesToSection } from "./clauses.js";
+import { acceptStandardChange } from "./standard-accept.js";
+import { listDriftInbox } from "./drift-inbox.js";
+import { makeTestMemex } from "./test-helpers.js";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+const AC_18 = "mindset-prod/memex-building-itself/specs/spec-530/acs/ac-18";
+
+const createdDocIds: string[] = [];
+let memexId: string;
+
+beforeAll(async () => {
+  memexId = await makeTestMemex("s530degr");
+});
+
+afterAll(async () => {
+  for (const id of createdDocIds) {
+    await db.delete(documents).where(eq(documents.id, id)).catch(() => {});
+  }
+});
+
+async function seeded(bodies: string[]): Promise<{ sectionId: string; clauses: StandardClause[] }> {
+  const std = await createStandard(memexId, {
+    title: "Degrade Target Standard",
+    sections: [{ sectionType: "rule", content: "" }],
+  });
+  createdDocIds.push(std.id);
+  const sectionId = std.sections[0].id;
+  const clauses = await addClausesToSection(
+    memexId,
+    sectionId,
+    bodies.map((body) => ({ body, facets: [] })),
+  );
+  return { sectionId, clauses: [...clauses] };
+}
+
+async function liveBodies(sectionId: string): Promise<string[]> {
+  const rows = await db
+    .select()
+    .from(standardClauses)
+    .where(and(eq(standardClauses.sectionId, sectionId), ne(standardClauses.status, "deleted")))
+    .orderBy(asc(standardClauses.position), asc(standardClauses.seq));
+  return rows.map((r) => r.body);
+}
+
+/** Overwrite a real proposal's stored body, standing in for a row written before the
+ *  clause grain existed. Going through proposeStandardChange first keeps every other
+ *  column (type, section anchor, source) exactly as the product produces it. */
+async function withBody(clauseId: string, content: string): Promise<string> {
+  const proposal = await proposeStandardChange(memexId, [
+    { op: "edit", clauseId, after: "irrelevant" },
+  ]);
+  await db.update(docComments).set({ content }).where(eq(docComments.id, proposal.comment.id));
+  return proposal.comment.id;
+}
+
+describe("spec-530 t-9: an unapplicable proposal degrades, it does not half-apply (ac-18)", () => {
+  it("refuses a FREE-FORM proposal — the shape half the real corpus turned out to be", async () => {
+    tagAc(AC_18);
+    const { sectionId, clauses } = await seeded(["the rule as it stands"]);
+    // Modelled on std-19 c-1, a real proposal found by t-11's sweep: prose, no fence,
+    // authored when propose_standard_change could not take the target the author had.
+    const commentId = await withBody(
+      clauses[0].id,
+      [
+        "Proposed amendment (spec-164 dec-1 / ac-14) — add a clause to the Rule:",
+        "",
+        "(e) Phase values and phase display names are two sanctioned layers.",
+        "",
+        "(Filed as a plan_revision comment directly: propose_standard_change requires a",
+        "section UUID that the MCP surface doesn't expose.)",
+      ].join("\n"),
+    );
+
+    await expect(acceptStandardChange(memexId, commentId)).rejects.toThrow(
+      /no readable operations/i,
+    );
+
+    // The rule is untouched and the proposal is still open — the two properties that
+    // make an unapplicable body cost one row rather than a damaged Standard.
+    expect(await liveBodies(sectionId)).toEqual(["the rule as it stands"]);
+    const row = await db.query.docComments.findFirst({ where: eq(docComments.id, commentId) });
+    expect(row!.resolvedAt).toBeNull();
+  });
+
+  it("refuses a body whose fenced payload is corrupt, rather than applying part of it", async () => {
+    tagAc(AC_18);
+    const { sectionId, clauses } = await seeded(["keep me exactly"]);
+    // A clause-grained fence whose JSON is truncated — a restored backup, a partial
+    // write. The parser must not surface a half-decoded operation set.
+    const commentId = await withBody(
+      clauses[0].id,
+      [
+        "**Proposed change to section [rule]**",
+        "",
+        "rationale",
+        "",
+        "~~~proposed-clauses",
+        '{"v":1,"operations":[{"op":"edit","clause":"cl-1","before":"keep me exact',
+        "~~~",
+      ].join("\n"),
+    );
+
+    await expect(acceptStandardChange(memexId, commentId)).rejects.toThrow(
+      /no readable operations/i,
+    );
+    expect(await liveBodies(sectionId)).toEqual(["keep me exactly"]);
+  });
+
+  it("keeps the Inbox readable when a page mixes all three shapes", async () => {
+    tagAc(AC_18);
+    // The real corpus t-11 found: clause-grained, legacy-fenced, and free-form, side by
+    // side. One unreadable row must not cost the reader the other two.
+    const good = await seeded(["a rule that will change"]);
+    const goodProposal = await proposeStandardChange(memexId, [
+      { op: "edit", clauseId: good.clauses[0].id, after: "the changed rule" },
+    ]);
+
+    const legacy = await seeded(["a rule with a legacy proposal"]);
+    const legacyId = await withBody(
+      legacy.clauses[0].id,
+      [
+        "**Proposed change to section [rule]**",
+        "",
+        "legacy rationale",
+        "",
+        "~~~proposed-content",
+        "A whole replacement section body.",
+        "~~~",
+      ].join("\n"),
+    );
+
+    const free = await seeded(["a rule with a free-form proposal"]);
+    const freeId = await withBody(free.clauses[0].id, "Someone's prose, no fence at all.");
+
+    const page = await listDriftInbox(memexId, { limit: 200 });
+    const byId = new Map(page.items.map((i) => [i.commentId, i]));
+    expect(byId.get(goodProposal.comment.id)?.proposal?.kind).toBe("clause-ops");
+    expect(byId.get(legacyId)?.proposal?.kind).toBe("legacy");
+    expect(byId.get(freeId)?.proposal?.kind).toBe("unreadable");
+
+    // Every row still carries the context the reader triages on — the blast radius of an
+    // unapplicable body is its own row's diff, nothing else.
+    for (const id of [goodProposal.comment.id, legacyId, freeId]) {
+      const item = byId.get(id)!;
+      expect(item.doc.handle).toMatch(/^std-/);
+      expect(item.commentHandle).toMatch(/^c-\d+$/);
+    }
+  });
+});

--- a/packages/server/src/services/standard-accept-staleness.spec-530.integration.test.ts
+++ b/packages/server/src/services/standard-accept-staleness.spec-530.integration.test.ts
@@ -1,0 +1,192 @@
+// spec-530 t-5 (dec-3, ac-14/ac-15) — the staleness guard inside the accept.
+//
+// A proposal is a stale read BY NATURE: authored at T0, accepted at T1, possibly days
+// later and possibly after another agent edited the very clause it targets. Applying it
+// blind at T1 discards that intervening edit silently — and "a Standard losing a
+// correction without anyone noticing" is the failure this whole Spec exists to prevent.
+// Fixing the grain while leaving that hole would have traded one silent-loss bug for
+// another.
+//
+// The guard lives in the PROPOSAL (dec-3), not on `edit_clause`: the staleness is the
+// proposal's, so the evidence belongs next to the text a reviewer is already reading,
+// and no other caller's contract moves. dec-4 then gives the comparison exactly one
+// home — inside the accept transaction, with no path that skips it.
+//
+// Separate file from the happy path because this is the SAFETY property, and safety
+// properties that ride along with happy paths are the ones that ship untested.
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { and, asc, eq, ne } from "drizzle-orm";
+import { db } from "../db/connection.js";
+import { documents, docComments, standardClauses } from "../db/schema.js";
+import type { StandardClause } from "../db/schema.js";
+import { createStandard, proposeStandardChange } from "./standards.js";
+import { addClausesToSection, updateClause } from "./clauses.js";
+import { acceptStandardChange } from "./standard-accept.js";
+import { makeTestMemex } from "./test-helpers.js";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+const AC = "mindset-prod/memex-building-itself/specs/spec-530/acs";
+
+const createdDocIds: string[] = [];
+let memexId: string;
+
+beforeAll(async () => {
+  memexId = await makeTestMemex("s530stale");
+});
+
+afterAll(async () => {
+  for (const id of createdDocIds) {
+    await db.delete(documents).where(eq(documents.id, id)).catch(() => {});
+  }
+});
+
+async function seededStandard(bodies: string[]): Promise<{
+  sectionId: string;
+  clauses: StandardClause[];
+}> {
+  const std = await createStandard(memexId, {
+    title: "Staleness Target Standard",
+    sections: [{ sectionType: "rule", content: "" }],
+  });
+  createdDocIds.push(std.id);
+  const sectionId = std.sections[0].id;
+  const clauses = await addClausesToSection(
+    memexId,
+    sectionId,
+    bodies.map((body) => ({ body, facets: [] })),
+  );
+  return { sectionId, clauses: [...clauses] };
+}
+
+async function liveBodies(sectionId: string): Promise<string[]> {
+  const rows = await db
+    .select()
+    .from(standardClauses)
+    .where(and(eq(standardClauses.sectionId, sectionId), ne(standardClauses.status, "deleted")))
+    .orderBy(asc(standardClauses.position), asc(standardClauses.seq));
+  return rows.map((r) => r.body);
+}
+
+async function isOpen(commentId: string): Promise<boolean> {
+  const row = await db.query.docComments.findFirst({ where: eq(docComments.id, commentId) });
+  return row!.resolvedAt === null;
+}
+
+describe("spec-530 ac-14: accepting a stale proposal cannot discard someone else's edit", () => {
+  it("refuses, and the clause still holds the intervening edit byte-identical", async () => {
+    tagAc(`${AC}/ac-14`);
+    tagAc(`${AC}/ac-3`); // scope: the outcome this mechanism delivers
+    const { sectionId, clauses } = await seededStandard(["cache all writes"]);
+
+    // T0 — the proposal is authored against what the rule says today.
+    const proposal = await proposeStandardChange(memexId, [
+      { op: "edit", clauseId: clauses[0].id, after: "cache all writes, including PUT" },
+    ]);
+
+    // Between T0 and T1 someone else corrects the same clause. This is the edit that
+    // must survive.
+    const intervening = "cache all writes except mutating endpoints";
+    await updateClause(memexId, clauses[0].id, intervening);
+
+    // T1 — the accept must fail loudly rather than overwrite.
+    await expect(acceptStandardChange(memexId, proposal.comment.id)).rejects.toThrow(
+      /changed after this proposal was written/i,
+    );
+
+    expect(await liveBodies(sectionId)).toEqual([intervening]);
+    expect(await isOpen(proposal.comment.id)).toBe(true);
+  });
+
+  it("refuses on a WHITESPACE-only divergence too — exactness is the point", async () => {
+    tagAc(`${AC}/ac-14`);
+    const { sectionId, clauses } = await seededStandard(["never log secrets"]);
+    const proposal = await proposeStandardChange(memexId, [
+      { op: "edit", clauseId: clauses[0].id, after: "never log secrets or tokens" },
+    ]);
+
+    // A trailing space is a real difference. A "close enough" comparison would reopen
+    // the silent-overwrite class this guard exists to close, and the cost of a false
+    // refusal is one re-proposal — deliberately the cheaper failure (dec-3).
+    const nudged = "never log secrets ";
+    await updateClause(memexId, clauses[0].id, nudged);
+
+    await expect(acceptStandardChange(memexId, proposal.comment.id)).rejects.toThrow();
+    expect(await liveBodies(sectionId)).toEqual([nudged]);
+  });
+
+  it("applies normally when nothing moved — the guard is not a general obstacle", async () => {
+    tagAc(`${AC}/ac-14`);
+    const { sectionId, clauses } = await seededStandard(["retry idempotent calls"]);
+    const proposal = await proposeStandardChange(memexId, [
+      { op: "edit", clauseId: clauses[0].id, after: "retry idempotent calls up to 3 times" },
+    ]);
+
+    await acceptStandardChange(memexId, proposal.comment.id);
+
+    expect(await liveBodies(sectionId)).toEqual(["retry idempotent calls up to 3 times"]);
+    expect(await isOpen(proposal.comment.id)).toBe(false);
+  });
+
+  it("guards DELETE operations, not only edits", async () => {
+    tagAc(`${AC}/ac-14`);
+    const { sectionId, clauses } = await seededStandard(["obsolete rule", "keeper"]);
+    const proposal = await proposeStandardChange(memexId, [
+      { op: "delete", clauseId: clauses[0].id },
+    ]);
+
+    // The clause someone thought was obsolete has since been rewritten into something
+    // current. Deleting it now would discard that work with no trace.
+    await updateClause(memexId, clauses[0].id, "rule, now rewritten and current");
+
+    await expect(acceptStandardChange(memexId, proposal.comment.id)).rejects.toThrow(
+      /changed after this proposal was written/i,
+    );
+    expect(await liveBodies(sectionId)).toEqual(["rule, now rewritten and current", "keeper"]);
+  });
+});
+
+describe("spec-530 ac-15: one stale operation refuses the ENTIRE set, actionably", () => {
+  it("applies nothing when only operation 2 of 3 has drifted", async () => {
+    tagAc(`${AC}/ac-15`);
+    const { sectionId, clauses } = await seededStandard(["first", "second", "third"]);
+    const proposal = await proposeStandardChange(memexId, [
+      { op: "edit", clauseId: clauses[0].id, after: "first-changed" },
+      { op: "edit", clauseId: clauses[1].id, after: "second-changed" },
+      { op: "edit", clauseId: clauses[2].id, after: "third-changed" },
+    ]);
+
+    // Only the middle target moves.
+    const drifted = "second, corrected by someone else";
+    await updateClause(memexId, clauses[1].id, drifted);
+
+    await expect(acceptStandardChange(memexId, proposal.comment.id)).rejects.toThrow();
+
+    // A set is ONE reviewed intent. Applying the two clean operations would leave the
+    // Standard saying something no one proposed — worse than the failure it replaces,
+    // because it looks like success.
+    expect(await liveBodies(sectionId)).toEqual(["first", drifted, "third"]);
+    expect(await isOpen(proposal.comment.id)).toBe(true);
+  });
+
+  it("names the drifted clause AND what it now says, so the next move is obvious", async () => {
+    tagAc(`${AC}/ac-15`);
+    const { clauses } = await seededStandard(["alpha", "beta"]);
+    const proposal = await proposeStandardChange(memexId, [
+      { op: "edit", clauseId: clauses[0].id, after: "alpha-changed" },
+      { op: "edit", clauseId: clauses[1].id, after: "beta-changed" },
+    ]);
+
+    const nowReads = "beta, as rewritten by another agent";
+    await updateClause(memexId, clauses[1].id, nowReads);
+
+    // "Conflict" alone fails this criterion: a reviewer would have to go and look. The
+    // refusal has to carry enough to act on — re-propose against the current rule —
+    // without further investigation.
+    const err = await acceptStandardChange(memexId, proposal.comment.id).catch((e: Error) => e);
+    expect(err).toBeInstanceOf(Error);
+    const message = (err as Error).message;
+    expect(message).toContain(`cl-${clauses[1].seq}`);
+    expect(message).toContain(nowReads);
+  });
+});

--- a/packages/server/src/services/standard-accept.spec-530.integration.test.ts
+++ b/packages/server/src/services/standard-accept.spec-530.integration.test.ts
@@ -1,0 +1,380 @@
+// spec-530 t-4 (dec-4) — `accept_standard_change`, the transactional apply verb.
+//
+// Before this, accepting a proposal was impossible: proposals were section-grained and
+// `update_section` hard-rejects on a Standard, so the only instruction the drift agent
+// had was a call that always threw. This suite is the proof the loop closes.
+//
+// The atomicity ROLLBACK case lives in its own file
+// (standard-accept-atomicity.spec-530.integration.test.ts) because it mocks the clause
+// write module, and a module mock leaks across every test in its file [per std-37].
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { and, asc, eq, ne } from "drizzle-orm";
+import { db } from "../db/connection.js";
+import { documents, docComments, docSections, standardClauses, users } from "../db/schema.js";
+import type { StandardClause } from "../db/schema.js";
+import { bus, type ChangeEvent } from "./bus.js";
+import { createStandard, proposeStandardChange } from "./standards.js";
+import { addClausesToSection, createClause } from "./clauses.js";
+import { acceptStandardChange } from "./standard-accept.js";
+import { makeTestMemex } from "./test-helpers.js";
+import type { RequestCtx } from "./mutate.js";
+import { toolSpecs } from "../agent/tool-specs.js";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+const AC = "mindset-prod/memex-building-itself/specs/spec-530/acs";
+
+const createdDocIds: string[] = [];
+const createdUserIds: string[] = [];
+let memexId: string;
+let accepter: { id: string; name: string };
+
+// std-37: per-worker-unique identifiers so parallel workers never collide.
+function uniqueEmail(who: string): string {
+  return `spec530-t4-${who}-${process.env.VITEST_WORKER_ID ?? "0"}-${process.hrtime.bigint()}@example.com`;
+}
+
+beforeAll(async () => {
+  memexId = await makeTestMemex("s530acc");
+  const [row] = await db
+    .insert(users)
+    .values({ email: uniqueEmail("accepter"), name: "Rule Accepter" } as typeof users.$inferInsert)
+    .returning();
+  createdUserIds.push(row.id);
+  accepter = { id: row.id, name: "Rule Accepter" };
+});
+
+afterAll(async () => {
+  for (const id of createdDocIds) {
+    await db.delete(documents).where(eq(documents.id, id)).catch(() => {});
+  }
+  for (const id of createdUserIds) {
+    await db.delete(users).where(eq(users.id, id)).catch(() => {});
+  }
+});
+
+/** ctx as an authenticated in-app agent accept. */
+function accepterCtx(): RequestCtx {
+  return { actorUserId: accepter.id, channel: "in_app_agent" };
+}
+
+/** A Standard with one section carrying `bodies` as ordered clauses. */
+async function seededStandard(bodies: string[]): Promise<{
+  docId: string;
+  sectionId: string;
+  clauses: StandardClause[];
+}> {
+  const std = await createStandard(memexId, {
+    title: "Accept Target Standard",
+    sections: [{ sectionType: "rule", content: "" }],
+  });
+  createdDocIds.push(std.id);
+  const sectionId = std.sections[0].id;
+  const clauses = await addClausesToSection(
+    memexId,
+    sectionId,
+    bodies.map((body) => ({ body, facets: [] })),
+  );
+  return { docId: std.id, sectionId, clauses: [...clauses] };
+}
+
+async function liveRows(sectionId: string): Promise<StandardClause[]> {
+  return db
+    .select()
+    .from(standardClauses)
+    .where(and(eq(standardClauses.sectionId, sectionId), ne(standardClauses.status, "deleted")))
+    .orderBy(asc(standardClauses.position), asc(standardClauses.seq));
+}
+
+async function commentRow(commentId: string) {
+  return db.query.docComments.findFirst({ where: eq(docComments.id, commentId) });
+}
+
+async function sectionRow(sectionId: string) {
+  const row = await db.query.docSections.findFirst({ where: eq(docSections.id, sectionId) });
+  return row!;
+}
+
+async function captureEvents(body: () => Promise<void>): Promise<ChangeEvent[]> {
+  const events: ChangeEvent[] = [];
+  const unsub = bus.subscribe({}, (e) => events.push(e));
+  try {
+    await body();
+  } finally {
+    unsub();
+  }
+  return events;
+}
+
+describe("spec-530 t-4: a proposal is applied and resolved in one operation", () => {
+  it("applies a mixed add/edit/delete set and resolves the comment (ac-10)", async () => {
+    tagAc(`${AC}/ac-10`);
+    const { sectionId, clauses } = await seededStandard(["keep me", "edit me", "delete me"]);
+
+    const proposal = await proposeStandardChange(memexId, [
+      { op: "edit", clauseId: clauses[1].id, after: "edited by the proposal" },
+      { op: "delete", clauseId: clauses[2].id },
+      { op: "add", anchorClauseId: clauses[0].id, placement: "after", body: "added by the proposal" },
+    ]);
+
+    const result = await acceptStandardChange(memexId, proposal.comment.id, accepterCtx());
+
+    expect(result.applied).toBe(3);
+    const rows = await liveRows(sectionId);
+    expect(rows.map((r) => r.body)).toEqual([
+      "keep me",
+      "added by the proposal",
+      "edited by the proposal",
+    ]);
+    // The comment is resolved in the SAME operation — there is no window where the
+    // Standard is rewritten and the proposal still open, or the reverse.
+    const comment = await commentRow(proposal.comment.id);
+    expect(comment!.resolvedAt).not.toBeNull();
+    expect(comment!.resolution).toBe("accepted");
+    // And the derived rule text a reader sees was regenerated from the new row set.
+    expect((await sectionRow(sectionId)).content).toBe(
+      "keep me\n\nadded by the proposal\n\nedited by the proposal",
+    );
+  });
+
+  it("applies exactly the text that was proposed — no argument can change it (ac-11)", async () => {
+    tagAc(`${AC}/ac-11`);
+    const { sectionId, clauses } = await seededStandard(["the original rule"]);
+    const proposedText = "the corrected rule, verbatim — including `~~~` and ``` fences";
+
+    const proposal = await proposeStandardChange(memexId, [
+      { op: "edit", clauseId: clauses[0].id, after: proposedText },
+    ]);
+    await acceptStandardChange(memexId, proposal.comment.id, accepterCtx());
+
+    // What landed is byte-identical to what a human reviewed. That is what makes "the
+    // user approved THIS text" a fact rather than a hope about the agent's fidelity.
+    expect((await liveRows(sectionId))[0].body).toBe(proposedText);
+  });
+
+  it("exposes no body or target parameter on the tool at all (ac-11)", async () => {
+    tagAc(`${AC}/ac-11`);
+    const spec = toolSpecs.find((s) => s.name === "accept_standard_change");
+    expect(spec, "accept_standard_change is not registered").toBeDefined();
+
+    // The whole surface is the proposal ref (+ the shared verbose flag). No `body`, no
+    // `operations`, no `clause` — there is no argument through which a caller could
+    // apply something other than what was proposed and reviewed.
+    expect(Object.keys(spec!.schema).sort()).toEqual(["ref", "verbose"]);
+  });
+
+  it("emits so an open Inbox and the drift-count chip both clear themselves (ac-12)", async () => {
+    tagAc(`${AC}/ac-12`);
+    const { docId, clauses } = await seededStandard(["a rule that will change"]);
+    const proposal = await proposeStandardChange(memexId, [
+      { op: "edit", clauseId: clauses[0].id, after: "the changed rule" },
+    ]);
+
+    const events = await captureEvents(async () => {
+      await acceptStandardChange(memexId, proposal.comment.id, accepterCtx());
+    });
+
+    const mine = events.filter((e) => e.memexId === memexId && e.docId === docId);
+    // The aggregate the StandardList drift-count subscriber watches — mirrors the dual
+    // emit proposeStandardChange already performs. Without it the chip keeps counting a
+    // proposal that is no longer open.
+    expect(mine.some((e) => e.entity === "standard_drift")).toBe(true);
+    // The Inbox row itself.
+    expect(mine.some((e) => e.entity === "comment" && e.action === "updated")).toBe(true);
+    // And the rule text that changed.
+    expect(mine.some((e) => e.entity === "clause" && e.action === "updated")).toBe(true);
+    expect(mine.some((e) => e.entity === "section" && e.action === "updated")).toBe(true);
+  });
+
+  it("attributes the rule change to whoever accepted it, and how (ac-20)", async () => {
+    tagAc(`${AC}/ac-20`);
+    const { sectionId, clauses } = await seededStandard(["unattributed rule"]);
+    const proposal = await proposeStandardChange(memexId, [
+      { op: "edit", clauseId: clauses[0].id, after: "attributed rule" },
+    ]);
+
+    await acceptStandardChange(memexId, proposal.comment.id, accepterCtx());
+
+    // "Who changed this rule, and from where" is precisely the question the activity
+    // contract exists to answer [per std-32 cl-1, cl-3, cl-4], and an accept is the one
+    // mutation where it matters most.
+    const row = await sectionRow(sectionId);
+    expect(row.content).toContain("attributed rule");
+    expect(row.actorUserId).toBe(accepter.id);
+    expect(row.actorName).toBe(accepter.name);
+    expect(row.channel).toBe("in_app_agent");
+  });
+});
+
+describe("spec-530 t-4: adding a clause is proposable, and lands where it was meant to", () => {
+  it("adds a clause that did not exist, with a fresh cl-N, siblings unresequenced (ac-9)", async () => {
+    tagAc(`${AC}/ac-9`);
+    const { sectionId, clauses } = await seededStandard(["first rule", "second rule"]);
+    const seqsBefore = clauses.map((c) => c.seq);
+
+    // "The rule is missing a case" — expressible as a proposal at all only because
+    // dec-1 made a proposal a set of OPERATIONS rather than a single clause edit.
+    const proposal = await proposeStandardChange(memexId, [
+      { op: "add", anchorClauseId: clauses[0].id, placement: "after", body: "the missing case" },
+    ]);
+    await acceptStandardChange(memexId, proposal.comment.id, accepterCtx());
+
+    const rows = await liveRows(sectionId);
+    expect(rows.map((r) => r.body)).toEqual(["first rule", "the missing case", "second rule"]);
+
+    // A FRESH handle, allocate-once — and every pre-existing cl-N is untouched
+    // [per spec-150 dec-2: seq is identity, position is order].
+    const added = rows[1];
+    expect(seqsBefore).not.toContain(added.seq);
+    expect(added.seq).toBeGreaterThan(Math.max(...seqsBefore));
+    const survivingSeqs = rows.filter((r) => r.id !== added.id).map((r) => r.seq);
+    expect(survivingSeqs).toEqual(seqsBefore);
+  });
+
+  it("lands next to its ANCHOR even after a clause was inserted ahead of it (ac-19)", async () => {
+    tagAc(`${AC}/ac-19`);
+    const { sectionId, clauses } = await seededStandard(["alpha", "beta", "gamma"]);
+
+    // Authored when `beta` sat at ordinal 2.
+    const proposal = await proposeStandardChange(memexId, [
+      { op: "add", anchorClauseId: clauses[1].id, placement: "after", body: "after-beta" },
+    ]);
+
+    // Between authoring and accepting, someone inserts a clause AHEAD of the anchor.
+    // Every ordinal after it shifts — so an ordinal captured at authoring time now
+    // points at the wrong place, and nothing would detect that. This is why the
+    // proposal stores an anchor cl-N and the accept resolves it at apply time.
+    await createClause(memexId, sectionId, "wedged-in", 1);
+
+    await acceptStandardChange(memexId, proposal.comment.id, accepterCtx());
+
+    const rows = await liveRows(sectionId);
+    expect(rows.map((r) => r.body)).toEqual([
+      "wedged-in",
+      "alpha",
+      "beta",
+      "after-beta",
+      "gamma",
+    ]);
+    // Had the stored ordinal been used, "after-beta" would have landed at position 3 —
+    // between alpha and beta — silently attaching the new rule to the wrong clause.
+  });
+
+  it("resolves each anchor against the state the EARLIER operations left behind (ac-19)", async () => {
+    tagAc(`${AC}/ac-19`);
+    const { sectionId, clauses } = await seededStandard(["A", "B", "C"]);
+
+    // Two adds in one proposal. The first inserts ahead of the second's anchor, so by
+    // the time operation 2 runs, B has moved — WITHIN this same transaction, after the
+    // pre-flight read. Resolving anchors once up front is not enough; each has to be
+    // read against the rows as they now stand.
+    const proposal = await proposeStandardChange(memexId, [
+      { op: "add", anchorClauseId: clauses[0].id, placement: "after", body: "X" },
+      { op: "add", anchorClauseId: clauses[1].id, placement: "after", body: "Y" },
+    ]);
+    await acceptStandardChange(memexId, proposal.comment.id, accepterCtx());
+
+    expect((await liveRows(sectionId)).map((r) => r.body)).toEqual(["A", "X", "B", "Y", "C"]);
+    // With a stale ordinal for B, Y lands directly after X — ["A","X","Y","B","C"] —
+    // attaching the new rule to the wrong clause with nothing to detect it.
+  });
+
+  it("refuses when the anchor was deleted after authoring, rather than appending (ac-16)", async () => {
+    tagAc(`${AC}/ac-16`);
+    const { sectionId, clauses } = await seededStandard(["anchor rule", "other rule"]);
+    const proposal = await proposeStandardChange(memexId, [
+      { op: "add", anchorClauseId: clauses[0].id, placement: "after", body: "orphaned addition" },
+    ]);
+
+    const anchorHandle = `cl-${clauses[0].seq}`;
+    const { deleteClause } = await import("./clauses.js");
+    await deleteClause(memexId, clauses[0].id);
+
+    // A clause proposed relative to a clause that no longer exists has no defined
+    // position. Guessing (appending to the end) would put a rule somewhere nobody chose.
+    await expect(acceptStandardChange(memexId, proposal.comment.id)).rejects.toThrow(
+      new RegExp(anchorHandle),
+    );
+
+    // And nothing was written.
+    expect((await liveRows(sectionId)).map((r) => r.body)).toEqual(["other rule"]);
+    expect((await commentRow(proposal.comment.id))!.resolvedAt).toBeNull();
+  });
+});
+
+describe("spec-530 t-4: the verb refuses what it cannot honestly apply", () => {
+  it("refuses a proposal that is already resolved", async () => {
+    tagAc(`${AC}/ac-10`);
+    const { clauses } = await seededStandard(["a rule"]);
+    const proposal = await proposeStandardChange(memexId, [
+      { op: "edit", clauseId: clauses[0].id, after: "a corrected rule" },
+    ]);
+    await acceptStandardChange(memexId, proposal.comment.id, accepterCtx());
+
+    // Re-accepting must not apply the same edit twice or silently succeed.
+    await expect(acceptStandardChange(memexId, proposal.comment.id)).rejects.toThrow(
+      /already resolved/i,
+    );
+  });
+
+  it("refuses a legacy whole-section proposal with the reason, never half-applying it (ac-18)", async () => {
+    tagAc(`${AC}/ac-18`);
+    const { sectionId, clauses } = await seededStandard(["a rule with a legacy proposal"]);
+    const proposal = await proposeStandardChange(memexId, [
+      { op: "edit", clauseId: clauses[0].id, after: "irrelevant" },
+    ]);
+
+    // Rewrite the stored body into the PRE-cutover single-fence shape — what a row
+    // written before spec-530 actually looks like (a straggler from a long-running
+    // branch, a restored backup, an environment converted at a different time).
+    await db
+      .update(docComments)
+      .set({
+        content: [
+          "**Proposed change to section [rule]**",
+          "",
+          "legacy rationale",
+          "",
+          "~~~proposed-content",
+          "A whole replacement section body.",
+          "~~~",
+        ].join("\n"),
+      })
+      .where(eq(docComments.id, proposal.comment.id));
+
+    await expect(acceptStandardChange(memexId, proposal.comment.id)).rejects.toThrow(
+      /clause grain/i,
+    );
+    // The rule is untouched and the proposal stays open — one unapplicable row, not a
+    // corrupted Standard.
+    expect((await liveRows(sectionId))[0].body).toBe("a rule with a legacy proposal");
+    expect((await commentRow(proposal.comment.id))!.resolvedAt).toBeNull();
+  });
+
+  it("refuses a comment that is not a proposal at all", async () => {
+    tagAc(`${AC}/ac-10`);
+    const { docId, sectionId } = await seededStandard(["a rule"]);
+    const { flagDrift } = await import("./standards.js");
+    const drift = await flagDrift(memexId, sectionId, "the code diverged from this rule");
+    expect(drift.docId ?? docId).toBeTruthy();
+
+    // A drift observation carries no operations. Applying one is meaningless, and the
+    // refusal says which kind it actually is.
+    await expect(acceptStandardChange(memexId, drift.id)).rejects.toThrow(/not a proposal/i);
+  });
+
+  it("does not find a proposal that belongs to another memex (std-7)", async () => {
+    tagAc(`${AC}/ac-10`);
+    const { clauses } = await seededStandard(["a tenant-scoped rule"]);
+    const proposal = await proposeStandardChange(memexId, [
+      { op: "edit", clauseId: clauses[0].id, after: "changed" },
+    ]);
+    const otherMemexId = await makeTestMemex("s530acc-other");
+
+    // 404-shaped, not 403 — an unauthorized resource is indistinguishable from one that
+    // does not exist [per std-7].
+    await expect(acceptStandardChange(otherMemexId, proposal.comment.id)).rejects.toThrow(
+      /not found/i,
+    );
+  });
+});

--- a/packages/server/src/services/standard-accept.ts
+++ b/packages/server/src/services/standard-accept.ts
@@ -1,0 +1,257 @@
+// spec-530 t-4 (dec-4) — `accept_standard_change`: the transactional apply verb.
+//
+// Accepting a proposal used to be a sequence the AGENT performed. dec-4 made it one
+// server operation, for three reasons the code below is shaped by:
+//
+//   1. ATOMICITY. dec-1 made a proposal a SET of operations, so "two agent calls"
+//      would have been "N+1 agent calls" — an interruption leaving a Standard half
+//      rewritten with its proposal still open, indistinguishable to the next reader
+//      from one not yet applied (ac-10).
+//   2. ONE ENFORCEMENT POINT. dec-3's staleness guard and std-8's emit contract are
+//      each enforced here, once, instead of being re-derived by every caller.
+//   3. CORRECTNESS STOPS LIVING IN THE PROMPT. This Spec exists because a prompt
+//      instructed `update_section` on a Standard — a call that has thrown since
+//      spec-161 — and nothing noticed for months, because nothing executes prose as a
+//      contract. A verb the server owns is testable; a sequence the agent is told to
+//      perform is not.
+//
+// The verb takes the proposal's comment ref and NOTHING else (ac-11): no bodies, no
+// targets, no override. The proposal already carries what will be applied, so there is
+// no argument through which a caller could apply something other than what a human
+// reviewed.
+
+import { and, eq, ne } from "drizzle-orm";
+import { db } from "../db/connection.js";
+import { docComments, docSections, standardClauses } from "../db/schema.js";
+import type { Doc, DocComment, DocSection, StandardClause } from "../db/schema.js";
+import { NotFoundError, ValidationError } from "../types/errors.js";
+import { mutate, type ChangeKey, type Mutated, type RequestCtx } from "./mutate.js";
+import { resolveActorColumns } from "./actor.js";
+import {
+  insertClauseTx,
+  regenerateSectionContentTx,
+  softDeleteClauseTx,
+  updateClauseBodyTx,
+} from "./clauses.js";
+import {
+  loadOwnedStandard,
+  parseProposedChangeBody,
+  type ClauseOperation,
+} from "./standards.js";
+
+export interface AcceptStandardChangeResult {
+  /** The standard whose rule text changed. */
+  standard: Doc;
+  /** The section the proposal targeted. */
+  section: DocSection;
+  /** The now-resolved plan_revision comment. */
+  comment: DocComment;
+  /** How many clause operations were applied. */
+  applied: number;
+}
+
+/** One operation paired with the live clause row it resolved to. */
+type ResolvedOp = { op: ClauseOperation; clause: StandardClause };
+
+/** The `cl-N` handle for a clause row — the identifier every refusal names, so a
+ *  reviewer can act on the message without further investigation [per std-10]. */
+function handleOf(clause: StandardClause): string {
+  return `cl-${clause.seq}`;
+}
+
+/**
+ * Apply an open `plan_revision` proposal and resolve it, in one transaction.
+ *
+ * Every read and every check happens BEFORE the transaction writes anything: a
+ * mismatch refuses the whole set rather than the offending operation, because a set is
+ * one reviewed intent and partial application is what ac-10 forbids.
+ */
+export async function acceptStandardChange(
+  memexId: string,
+  commentId: string,
+  ctx: RequestCtx = {},
+): Promise<Mutated<AcceptStandardChangeResult>> {
+  // ── The proposal itself ──
+  const comment = await db.query.docComments.findFirst({
+    where: and(eq(docComments.id, commentId), eq(docComments.memexId, memexId)),
+  });
+  // std-7: a comment in another memex is indistinguishable from one that does not
+  // exist. Not found, never "not yours".
+  if (!comment) throw new NotFoundError(`Proposal ${commentId} not found`);
+
+  if (comment.commentType !== "plan_revision") {
+    throw new ValidationError(
+      `That comment is a ${comment.commentType}, not a proposal. Only a plan_revision carries clause operations to apply.`,
+    );
+  }
+  if (comment.resolvedAt) {
+    throw new ValidationError(
+      "That proposal is already resolved — nothing to apply. Re-propose against the current rule if the change is still wanted.",
+    );
+  }
+  if (!comment.sectionId) {
+    throw new ValidationError("That proposal is not anchored to a section, so it has no target.");
+  }
+
+  const parsed = parseProposedChangeBody(comment.content);
+  if (!parsed) {
+    throw new ValidationError(
+      "That proposal's body carries no readable operations — it cannot be applied. Re-propose it.",
+    );
+  }
+  // t-9's degrade-never-crash contract, seen from the accept side: a pre-cutover
+  // whole-section body still READS, but nothing clause-grained can apply it. Refuse
+  // with the reason rather than half-applying something (spec-530 dec-2 / t-11 convert
+  // the stragglers).
+  if (parsed.kind === "legacy") {
+    throw new ValidationError(
+      "That proposal predates the clause grain — it replaces a whole section, which cannot be applied clause by clause. Restate it as clause operations and re-propose (spec-530 t-11).",
+    );
+  }
+  const operations = parsed.operations;
+
+  // ── The target section + standard ──
+  const section = await db.query.docSections.findFirst({
+    where: eq(docSections.id, comment.sectionId),
+  });
+  if (!section) throw new NotFoundError(`Section ${comment.sectionId} not found`);
+  const standard = await loadOwnedStandard(memexId, section.docId);
+
+  // ── Resolve every target, memex- AND doc-scoped ──
+  // A `cl-N` handle is per-STANDARD (seq is allocated MAX+1 per doc), so the lookup is
+  // scoped to this standard's docId. Scoping by memex alone would let a handle collide
+  // across two standards in the same memex and apply to the wrong rule.
+  const resolved: ResolvedOp[] = [];
+  for (const op of operations) {
+    const handle = op.op === "add" ? op.anchor : op.clause;
+    const seq = Number.parseInt(handle.replace(/^cl-/, ""), 10);
+    if (!Number.isInteger(seq)) {
+      throw new ValidationError(`Operation targets "${handle}", which is not a cl-N handle.`);
+    }
+    const clause = await db.query.standardClauses.findFirst({
+      where: and(
+        eq(standardClauses.docId, standard.id),
+        eq(standardClauses.seq, seq),
+        ne(standardClauses.status, "deleted"),
+      ),
+    });
+    if (!clause) {
+      // Covers dec-3's check for `add`: a clause proposed relative to a clause that has
+      // since been deleted has no defined position, so the accept refuses rather than
+      // guessing — never an append-to-end fallback (ac-16).
+      throw new ValidationError(
+        op.op === "add"
+          ? `${handle} — the clause this proposal adds next to — no longer exists on ${standard.handle}. Re-propose against the current rule.`
+          : `${handle} no longer exists on ${standard.handle}. Re-propose against the current rule.`,
+      );
+    }
+    if (clause.sectionId !== section.id) {
+      throw new ValidationError(
+        `${handle} has moved to a different section since this proposal was written. Re-propose against the current rule.`,
+      );
+    }
+    resolved.push({ op, clause });
+  }
+
+  // An `add` anchored on a clause this same set deletes has no coherent meaning — the
+  // anchor is gone by the time the add runs. Caught here, before any write, so the
+  // refusal is total like every other (ac-10).
+  const deletedHandles = new Set(
+    resolved.filter((r) => r.op.op === "delete").map((r) => handleOf(r.clause)),
+  );
+  for (const { op, clause } of resolved) {
+    if (op.op === "add" && deletedHandles.has(handleOf(clause))) {
+      throw new ValidationError(
+        `This proposal adds a clause next to ${handleOf(clause)} and also deletes ${handleOf(clause)}. Those cannot both hold — re-propose with a different anchor.`,
+      );
+    }
+  }
+
+  // ── dec-3's staleness guard: exact compare, before anything is written ──
+  // The proposal is a stale read by nature — authored at T0, accepted at T1, possibly
+  // after another agent edited that clause. Applying blind at T1 discards the
+  // intervening edit silently, which is the failure class this whole Spec exists to
+  // close. Comparison is EXACT, whitespace included: a "close enough" match reopens the
+  // silent-overwrite class, and the cost of a false refusal is one re-proposal.
+  for (const { op, clause } of resolved) {
+    if (op.op === "add") continue; // no "before" to compare — its check is anchor-exists, above
+    if (clause.body !== op.before) {
+      throw new ValidationError(
+        `${handleOf(clause)} changed after this proposal was written, so applying it would discard that change. ` +
+          `It now reads:\n\n${clause.body}\n\nRe-propose against the current rule.`,
+      );
+    }
+  }
+
+  // ── Emit keys [per std-8] ──
+  // One event per logical change, mirroring the composite the clause verbs already
+  // emit, plus the pair the propose path fires: `comment` updated so an open Inbox row
+  // clears, and `standard_drift` so the per-standard drift-count chip refetches. An
+  // accept that does not emit is the same defect in miniature as the one being fixed —
+  // the work happened and the surface still says it did not (ac-12).
+  const keys: ChangeKey[] = [
+    ...operations.map((op) => ({
+      memexId,
+      docId: standard.id,
+      entity: "clause" as const,
+      action:
+        op.op === "add" ? ("created" as const) : op.op === "edit" ? ("updated" as const) : ("deleted" as const),
+    })),
+    { memexId, docId: standard.id, entity: "section", action: "updated" },
+    { memexId, docId: standard.id, entity: "comment", action: "updated" },
+    { memexId, docId: standard.id, entity: "standard_drift", action: "updated" },
+  ];
+
+  // Resolved once, before the transaction opens (an indexed users lookup), so the tx
+  // stays free of a round trip — same idiom as the clause verbs. This is what makes the
+  // rule change attributable: WHO accepted it and HOW [per std-32] (ac-20).
+  const actor = await resolveActorColumns(ctx);
+
+  return mutate(ctx, keys, async () =>
+    db.transaction(async (tx) => {
+      for (const { op, clause } of resolved) {
+        if (op.op === "edit") {
+          await updateClauseBodyTx(tx, clause.id, op.after);
+        } else if (op.op === "delete") {
+          await softDeleteClauseTx(tx, clause);
+        } else {
+          // ANCHOR → ORDINAL, resolved HERE and not at authoring time (ac-19). An
+          // ordinal captured when the proposal was written is stale by construction: a
+          // clause inserted ahead of the anchor shifts it, and nothing would detect
+          // that. So the anchor's CURRENT position is re-read inside the transaction —
+          // it may have moved since the pre-flight read, because an earlier operation
+          // in this same set may have shifted it.
+          const [current] = await tx
+            .select()
+            .from(standardClauses)
+            .where(eq(standardClauses.id, clause.id));
+          const ordinal = op.placement === "before" ? current.position : current.position + 1;
+          // insertClauseTx shifts live siblings out of the way [per dec-5], so the new
+          // clause lands next to its anchor with ordinals left unique and dense.
+          await insertClauseTx(tx, memexId, section, op.body, ordinal);
+        }
+      }
+
+      // Once, at the end — not per operation. The composed text is a function of the
+      // final row set, so N regenerations would do the same work N times and only the
+      // last one would matter.
+      await regenerateSectionContentTx(tx, section, actor);
+
+      // Resolving the proposal is part of the SAME transaction, which is the point of
+      // the verb: there is no window in which the Standard is rewritten and the
+      // proposal still open, or the reverse.
+      const [updatedComment] = await tx
+        .update(docComments)
+        .set({ resolvedAt: new Date(), resolution: "accepted" })
+        .where(and(eq(docComments.id, comment.id), eq(docComments.memexId, memexId)))
+        .returning();
+
+      return {
+        standard,
+        section,
+        comment: updatedComment,
+        applied: operations.length,
+      };
+    }),
+  );
+}

--- a/packages/server/src/services/standards.ts
+++ b/packages/server/src/services/standards.ts
@@ -96,7 +96,9 @@ export interface StandardListEntry {
 
 // ── Helpers ────────────────────────────────────────────
 
-async function loadOwnedStandard(
+// Exported for the accept path (spec-530 t-4, `standard-accept.ts`), which must apply a
+// proposal through the SAME memex-scope + standard-type guard the propose path uses.
+export async function loadOwnedStandard(
   memexId: string,
   standardId: string,
 ): Promise<Doc> {
@@ -593,7 +595,11 @@ function isClauseOperation(value: unknown): value is ClauseOperation {
 /**
  * Parser companion for buildProposedChangeBody — pull the proposed-content payload
  * out of a comment body. Returns null if the comment isn't shaped like a proposal.
- * Exported for the React UI / future server-side accept flow.
+ *
+ * Exported for its two real consumers: the Drift Inbox read model (which renders the
+ * diff) and `acceptStandardChange` (which applies it). The "future server-side accept
+ * flow" this comment used to point at is no longer future and no longer a route —
+ * spec-530 dec-6 deleted the dead REST endpoint; the verb is the accept path.
  */
 export function parseProposedChangeBody(body: string): ParsedProposal | null {
   // The clause-grained shape first — it is what everything written from spec-530

--- a/packages/shared/src/scaffold-data.ts
+++ b/packages/shared/src/scaffold-data.ts
@@ -135,11 +135,12 @@ export const DRIFT_AGENT_GUIDANCE: PromptBlockNode = {
     '- If the rule itself is outdated, either record a proposed rewording with `propose_standard_change`, or — with the user\'s explicit consent — edit the rule text directly with the clause verbs (`edit_clause`, `add_clause`, `delete_clause`).\n\n' +
     '**A Standard is edited at the CLAUSE grain, never as a whole section.** `update_section` refuses on a Standard: its rule text is a set of addressable clauses (`cl-N`), and the clause verbs are the only way to change it. A proposal names the clauses it changes, so applying one means editing those clauses — not rewriting everything around them.\n\n' +
     'Handling a PROPOSAL (a `plan_revision`):\n' +
-    '- If the user ACCEPTS: apply each of the proposal\'s clause operations with the matching verb (`edit_clause` / `add_clause` / `delete_clause`), then resolve the comment with `update_comment` (status `resolved`, resolution `\'accepted\'`).\n' +
+    '- If the user ACCEPTS: call `accept_standard_change` with the proposal\'s comment ref. That single call applies every clause operation the proposal carries AND resolves the comment as accepted, together — so do not apply the clauses yourself and do not resolve the comment separately. You pass nothing but the ref: what gets applied is exactly what was proposed and reviewed, which is what makes the user\'s approval mean something.\n' +
+    '- If it REFUSES because a clause changed after the proposal was written, that is the guard working, not an error to retry. It names the clause and what it now says: show the user, and offer to re-propose against the current rule.\n' +
     '- If the user REJECTS: resolve the comment with `update_comment` (status `resolved`, resolution `\'rejected\'`) — leave the rule unchanged.\n' +
     '- A plain dismissal: resolve the comment with `update_comment` (status `resolved`, resolution `\'resolved\'`).\n\n' +
     '**The Drift Inbox has no action buttons — none.** There is no Accept, no Reject, no Resolve control on a row; the only button opens this conversation. So never tell someone to "click Accept" or point them at a control to finish the job: acceptance happens HERE, in conversation, and you are the one who applies it once they confirm. Describing an affordance the screen does not have sends them looking for something that was deliberately removed, and costs more trust than saying plainly "I\'ll apply it — confirm?".\n\n' +
-    'Mutation protocol (non-negotiable): propose EVERY mutation — the clause verbs, `update_comment`, `propose_standard_change`, `flag_drift` — through `render_confirmation` first, showing exactly what will change, and never mutate until the user confirms. Ask any clarifying questions in plain text first, then confirm, then act. Confirm an action only after the tool returns success.',
+    'Mutation protocol (non-negotiable): propose EVERY mutation — `accept_standard_change`, the clause verbs, `update_comment`, `propose_standard_change`, `flag_drift` — through `render_confirmation` first, showing exactly what will change, and never mutate until the user confirms. Ask any clarifying questions in plain text first, then confirm, then act. Confirm an action only after the tool returns success.',
   rationale:
     'spec-143 t-4 (dec-6): the drift-agent mode prompt block, appended by buildSystemBlocks only when the per-request driftMode flag is set (the React UI sets mode "drift" on the Drift Inbox). Intentionally NOT in any phase promptBlockIds (conditionally injected, like BASE_READ_ONLY / BASE_REVIEW). The mode-machinery is built here in spec-143; spec-142 will reuse the pattern. Portable per std-22 — no language/framework/repo/path/tooling assumptions; the real mutation enforcement is the render_confirmation gate + the /tools/execute server gate, not this prose.',
 };
@@ -624,7 +625,7 @@ const BASE_STANDARDS_PROTOCOL: PromptBlockNode = {
   surface: 'shared_nudge',
   text:
     '**Standards protocol** — when working with a standard:\n' +
-    '- If the rule is wrong or out of date, call `propose_standard_change(ref, proposed)` with the corrected text — `ref` is the section\'s canonical ref (e.g. `…/standards/std-N/sections/s-M`), not a UUID. The proposal lands as a `plan_revision` typed comment for the standard owner to accept or reject.\n' +
+    '- If the rule is wrong or out of date, call `propose_standard_change(operations)` naming the clauses that should change and what they should say — each target is a clause\'s canonical ref (e.g. `…/standards/std-N/clauses/cl-M`), not a UUID, and every clause in one proposal must belong to the same section. The proposal lands as a `plan_revision` typed comment for the standard owner to accept or reject.\n' +
     '- If the rule is correct but the codebase has drifted from it, call `flag_drift(ref, observation)` with the section\'s canonical ref. Drift comments surface in the Standards Drift Inbox (sourced \'agent\').\n' +
     '- When citing a standard in code or in another doc, use the `[per std-N]` form so the back-reference resolves automatically.\n' +
     '- Use `search_memex({ query, kind: \'standard\' })` (handle / FTS / vector) before authoring new rules — duplicate standards confuse the agent loop.',
@@ -1144,7 +1145,9 @@ const TOOL_RATIONALES: Record<string, string> = {
   flag_drift:
     "Flag drift on a standard section: post a typed `drift` comment (sourced 'agent') when the rule is right but the codebase has diverged from it. Surfaces in the Drift Inbox; use propose_standard_change instead when the rule itself is wrong.",
   propose_standard_change:
-    "Propose a corrected version of a standard section: lands a typed `plan_revision` comment (sourced 'agent') with the full replacement markdown and a rationale, for the standard owner to accept or reject in the Drift Inbox.",
+    "Propose a correction to a standard's rule text at the clause grain: name the clauses that should change and what they should say, and it lands as a typed `plan_revision` comment (sourced 'agent') for the standard owner to accept or reject. You never supply a clause's current text — the server reads it, so an accept can tell whether the clause moved underneath the proposal.",
+  accept_standard_change:
+    "Accept an open proposal and apply it to the Standard: every clause operation lands, or none does, and the proposal is resolved 'accepted' in the same transaction. Takes the proposal's comment ref and nothing else, so what gets applied is exactly what was reviewed. Refuses, naming the clause and its current text, if the rule changed after the proposal was written.",
   facets:
     "Read (and later manage) your Memex's facet vocabulary — the closed, per-owner set of cross-cutting practice areas a standard's clauses are tagged with. Verb-dispatched so the surface stays one tool; v0 supports verb:'list'.",
   create_ac:

--- a/packages/shared/src/tool-manifest.ts
+++ b/packages/shared/src/tool-manifest.ts
@@ -454,6 +454,15 @@ export const toolManifest: ToolManifestEntry[] = [
     homePhase: null,
   },
   {
+    name: 'accept_standard_change',
+    summary:
+      "Accept an open proposal (a `plan_revision` comment) and apply it to the Standard: every clause operation the proposal carries lands, or none does, and the proposal is resolved 'accepted' in the same transaction. Takes the comment ref and nothing else, so what is applied is exactly what was reviewed. Refuses \u2014 naming the clause and its current text \u2014 if the rule changed after the proposal was written, rather than overwriting that change.",
+    args: 'accept_standard_change(ref)',
+    group: 'build',
+    readOnlyHint: false,
+    homePhase: null,
+  },
+  {
     name: 'facets',
     summary:
       "Check which parts of your Standards apply to a piece of work: lists the topics they are tagged by (the Memex's facets). Cast these as the facetBallot on create_task / create_decision and Memex surfaces the governing standard sections.",

--- a/packages/ui/e2e/helpers/fixtures.ts
+++ b/packages/ui/e2e/helpers/fixtures.ts
@@ -166,7 +166,12 @@ export async function gotoSpecsBoard(
  * input state committed), and click it. Use for any journey driving the chat.
  */
 export async function sendChat(page: Page, text: string): Promise<void> {
-  const input = page.getByPlaceholder(/Ask me anything/i);
+  // Target the input by testid, not by placeholder. ChatPanel varies its placeholder by
+  // scoped mode ("Ask about the drift…", "Ask about the Standards…", …), so a
+  // placeholder match only ever worked on Spec pages — every scoped-mode surface was
+  // undrivable from a journey until spec-530 t-10 needed the drift agent. Same element,
+  // strictly wider reach.
+  const input = page.getByTestId("chat-input");
   await input.waitFor({ state: "visible", timeout: 15_000 });
   await input.fill(text);
   // Wait for Send to enable (its disabled gate is `!input.trim()`), proving the

--- a/packages/ui/e2e/helpers/retained.ts
+++ b/packages/ui/e2e/helpers/retained.ts
@@ -267,6 +267,21 @@ export async function seedExecutionPlan(opts: {
   return call("POST", "/seed-execution-plan", opts);
 }
 
+/** spec-530 t-7: seed an OPEN clause-grained proposal on a standard, through the real
+ *  `proposeStandardChange` — so the Drift Inbox row under test is the row users get. */
+export async function seedProposal(opts: {
+  memexId: string;
+  operations: {
+    op: "edit" | "delete" | "add";
+    clauseId: string;
+    body?: string;
+    placement?: "before" | "after";
+  }[];
+  rationale?: string;
+}): Promise<{ commentId: string; commentSeq: number }> {
+  return call("POST", "/seed-proposal", opts);
+}
+
 /** spec-496: seed clauses onto a standard's section through the real clause
  *  service — `std-N` mentions in bodies materialize as clause_refs mention
  *  edges (the standards map's backbone). */

--- a/packages/ui/e2e/journey-69-spec-530-proposal-diff.spec.ts
+++ b/packages/ui/e2e/journey-69-spec-530-proposal-diff.spec.ts
@@ -1,0 +1,108 @@
+import { test, expect, tenantPath } from "./helpers/index.js";
+import {
+  seedOrgTenant,
+  seedStandard,
+  seedClauses,
+  seedProposal,
+} from "./helpers/retained.js";
+
+// Journey 69 (spec-530 t-7): a proposal's before/after is READABLE in the Drift Inbox.
+//
+// The flow this covers used to dead-end. A proposal row was one line — "Proposes a
+// change to std-N …" — and the proposed text, though fetched to the client, was rendered
+// by no component. The file's own header claimed the diff was "reachable via Discuss
+// with Agent or the standard page"; it was reachable via neither. A user asked to judge
+// a proposal had no way to see what it said, which is half of what spec-530 ac-2 forbids
+// (the other half, the agent's truncated copy, is covered by ac-22's unit tests).
+//
+// Deliberately does NOT drive the accept. `accept_standard_change` is spec-530 t-4 and
+// is not on this branch; extending this journey to seed → read → accept → watch the row
+// clear is t-10, once that verb has merged. Asserting a read-only flow here rather than
+// pretending to cover the whole loop keeps the journey honest about what ships.
+//
+// Seeded through the env-gated test surface, never raw SQL [per std-28]; navigation is
+// path-based [per std-2].
+
+test("a proposal in the Drift Inbox reveals current vs proposed, per clause", async ({
+  page,
+  resources,
+}) => {
+  const slug = resources.slug("j69");
+  const tenant = await seedOrgTenant({ slug });
+
+  const standard = await seedStandard({
+    memexId: tenant.memexId,
+    title: "Caching Standard",
+    body: "",
+  });
+  const { clauseIds } = await seedClauses({
+    memexId: tenant.memexId,
+    sectionId: standard.sectionId,
+    clauses: [
+      "Cache every write.",
+      "Invalidate on delete.",
+    ],
+  });
+
+  // One proposal, two operations — an edit and an add — so the row exercises the SET
+  // shape dec-1 settled on, not just a single-clause change.
+  await seedProposal({
+    memexId: tenant.memexId,
+    operations: [
+      {
+        op: "edit",
+        clauseId: clauseIds[0],
+        body: "Cache every write except mutating endpoints.",
+      },
+      {
+        op: "add",
+        clauseId: clauseIds[1],
+        placement: "after",
+        body: "Never cache a response carrying a Set-Cookie header.",
+      },
+    ],
+    rationale: "The rule is too broad and is missing a case.",
+  });
+
+  await page.goto(tenantPath(tenant.namespaceSlug, tenant.memexSlug, "/drift"));
+
+  const row = page.getByTestId("drift-inbox-row").first();
+  await expect(row).toBeVisible();
+  await expect(row).toHaveAttribute("data-row-type", "proposal");
+
+  // Collapsed on arrival — spec-498 took the wall of text out of this list deliberately,
+  // and a proposal is now a SET, so an expanded default would put N blocks in a list.
+  await expect(page.getByTestId("drift-proposal-diff")).toHaveCount(0);
+
+  const toggle = row.getByTestId("drift-proposal-toggle");
+  await expect(toggle).toHaveText(/2 clause changes/);
+  await toggle.click();
+
+  const operations = page.getByTestId("drift-proposal-operation");
+  await expect(operations).toHaveCount(2);
+
+  // The edit: what the rule says now, and what the proposal wants it to say. This is
+  // the text a user could not see before.
+  const edit = operations.nth(0);
+  await expect(edit).toHaveAttribute("data-op", "edit");
+  await expect(edit.getByTestId("drift-proposal-current")).toContainText("Cache every write.");
+  await expect(edit.getByTestId("drift-proposal-proposed")).toContainText(
+    "Cache every write except mutating endpoints.",
+  );
+  // Named by its canonical handle [per std-10] — the same identifier the agent acts on.
+  await expect(edit.getByTestId("drift-proposal-clause")).toHaveText(/^cl-\d+$/);
+
+  // The add: a clause the rule does not have yet, anchored to one it does.
+  const add = operations.nth(1);
+  await expect(add).toHaveAttribute("data-op", "add");
+  await expect(add).toContainText("Never cache a response carrying a Set-Cookie header.");
+
+  // Read-only [per spec-143 dec-3, restated in spec-530's non-goals]: reading the diff
+  // must not put an Accept control on screen. Acceptance is a conversation.
+  await expect(page.getByRole("button", { name: /^accept/i })).toHaveCount(0);
+  await expect(page.getByRole("button", { name: /^reject/i })).toHaveCount(0);
+
+  // And it collapses again, so a reader who opened the wrong row can put it back.
+  await toggle.click();
+  await expect(page.getByTestId("drift-proposal-operation")).toHaveCount(0);
+});

--- a/packages/ui/e2e/journey-70-spec-530-accept-proposal.spec.ts
+++ b/packages/ui/e2e/journey-70-spec-530-accept-proposal.spec.ts
@@ -1,0 +1,125 @@
+import { test, expect, tenantPath, sendChat } from "./helpers/index.js";
+import {
+  seedOrgTenant,
+  seedStandard,
+  seedClauses,
+  seedProposal,
+} from "./helpers/retained.js";
+import {
+  clearAnthropicQueue,
+  queueAnthropicResponse,
+} from "./helpers/anthropic-fake.js";
+
+// Journey 70 (spec-530 t-10): a proposal is read, accepted, and the Inbox clears itself.
+//
+// This is the flow the whole Spec exists to make possible. Before it, a proposal on a
+// Standard could not be accepted AT ALL: the drift agent was told to apply one with
+// `update_section`, which has thrown on every Standard since spec-161 made them
+// clause-backed. The agent refused, correctly, and then invented an Accept button to get
+// out of the corner.
+//
+// Journey 69 covers the READ half (the row shows current vs proposed). This one covers
+// what 69 deliberately left out, and could not have run until t-4's verb and t-7's row
+// were on the same branch:
+//
+//   1. the row shows the diff  →  2. the user tells the agent to accept
+//   3. the agent calls accept_standard_change through /tools/execute (ONE verb, one
+//      transaction — spec-530 dec-4)
+//   4. the row disappears from the open Inbox with NO manual reload (the std-8 emit
+//      contract, ac-12) and 5. the Standard's rule text really changed (ac-1).
+//
+// The accept is driven through the REAL agent path — a queued `tool_use` block against
+// the server-side Anthropic fake — not by calling the endpoint. That matters: the Drift
+// Inbox has no Accept control by design (spec-143 dec-3, restated in spec-530's
+// non-goals), so conversation IS the user's path, and a journey that bypassed it would
+// assert a flow no user has.
+//
+// Seeded through the env-gated test surface, never raw SQL [per std-28]; navigation is
+// path-based [per std-2].
+
+test("a proposal is read, accepted through the agent, and the Inbox clears itself", async ({
+  page,
+  resources,
+}) => {
+  const slug = resources.slug("j70");
+  const tenant = await seedOrgTenant({ slug });
+
+  const standard = await seedStandard({
+    memexId: tenant.memexId,
+    title: "Caching Standard",
+    body: "",
+  });
+  const { clauseIds } = await seedClauses({
+    memexId: tenant.memexId,
+    sectionId: standard.sectionId,
+    clauses: ["Cache every write.", "Invalidate on delete."],
+  });
+
+  const proposed = "Cache every write except mutating endpoints.";
+  const proposal = await seedProposal({
+    memexId: tenant.memexId,
+    operations: [{ op: "edit", clauseId: clauseIds[0], body: proposed }],
+    rationale: "The rule is too broad — it tells people to cache POSTs.",
+  });
+
+  // accept_standard_change takes the proposal's canonical comment ref and NOTHING else
+  // (ac-11) — the proposal already carries what will be applied.
+  const commentRef = `${tenant.namespaceSlug}/${tenant.memexSlug}/standards/${standard.handle}/comments/c-${proposal.commentSeq}`;
+
+  await clearAnthropicQueue();
+  await queueAnthropicResponse({
+    textDeltas: [],
+    content: [
+      {
+        type: "tool_use",
+        id: "toolu_j70_accept",
+        name: "accept_standard_change",
+        input: { ref: commentRef },
+      },
+    ],
+    stopReason: "tool_use",
+  });
+  await queueAnthropicResponse({
+    textDeltas: ["Proposal ", "applied."],
+    content: [{ type: "text", text: "Proposal applied." }],
+    stopReason: "end_turn",
+  });
+
+  await page.goto(tenantPath(tenant.namespaceSlug, tenant.memexSlug, "/drift"));
+
+  // ── 1. The row shows what the proposal actually says (ac-2) ──
+  const row = page.getByTestId("drift-inbox-row").first();
+  await expect(row).toBeVisible({ timeout: 15_000 });
+  await expect(row).toHaveAttribute("data-row-type", "proposal");
+
+  await row.getByTestId("drift-proposal-toggle").click();
+  const edit = page.getByTestId("drift-proposal-operation").first();
+  await expect(edit.getByTestId("drift-proposal-current")).toContainText("Cache every write.");
+  await expect(edit.getByTestId("drift-proposal-proposed")).toContainText(proposed);
+
+  // ── 2. The user accepts in conversation — the only path there is ──
+  await sendChat(page, "accept this proposal");
+
+  await expect(page.getByTestId("chat-markdown")).toHaveText(/Proposal applied\./, {
+    timeout: 20_000,
+  });
+
+  // ── 3. The Inbox clears ITSELF (ac-12) ──
+  // No reload, no navigation. The row goes because accept_standard_change emitted on the
+  // unified bus [per std-8] and the page's useDocChangeStream refetched. A silent accept
+  // would leave this row on screen saying the work had not happened — the same defect
+  // class the Spec was written to fix.
+  await expect(page.getByTestId("drift-inbox-row")).toHaveCount(0, { timeout: 20_000 });
+  await expect(page.getByTestId("drift-empty-state")).toBeVisible({ timeout: 20_000 });
+
+  // ── 4. The rule text really changed (ac-1) ──
+  await page.goto(
+    tenantPath(tenant.namespaceSlug, tenant.memexSlug, `/standards/${standard.handle}`),
+  );
+  await expect(page.getByText(proposed)).toBeVisible({ timeout: 15_000 });
+  // And the clause the proposal did NOT touch is untouched — "without any untouched
+  // clause being rewritten in the process" is part of ac-1's claim, and it is what the
+  // clause grain buys over the section rewrite this replaced.
+  await expect(page.getByText("Invalidate on delete.")).toBeVisible();
+  await expect(page.getByText("Cache every write.", { exact: true })).toHaveCount(0);
+});

--- a/packages/ui/src/api/comments.ts
+++ b/packages/ui/src/api/comments.ts
@@ -55,9 +55,14 @@ export async function createComment(
 }
 
 // spec-143 dec-4: thread the optional resolution string through so the agent
-// can stamp a distinct audit trail — Reject → 'rejected', Resolve → 'resolved'
-// (Accept stays 'accepted' via the /drift/proposals/:id/accept path). Omitting
-// it POSTs an empty body, preserving the prior no-resolution behaviour.
+// can stamp a distinct audit trail — Reject → 'rejected', Resolve → 'resolved'.
+// Accepting is NOT one of these: it changes rule text, so it goes through the
+// server's `accept_standard_change` verb, which applies the proposal's clause
+// operations and stamps 'accepted' in the same transaction (spec-530 dec-4).
+// The `/drift/proposals/:id/accept` route this comment used to name was deleted
+// by spec-530 dec-6 — it had been unable to succeed since spec-161, and nothing
+// here ever called it. Omitting the resolution POSTs an empty body, preserving
+// the prior no-resolution behaviour.
 export async function resolveComment(
   commentId: string,
   resolution?: string,

--- a/packages/ui/src/api/drift.ts
+++ b/packages/ui/src/api/drift.ts
@@ -6,6 +6,38 @@ import { fetchWithRetry } from './http';
 import { tBase } from './internal';
 
 /**
+ * One clause operation of a proposal (spec-530 t-7).
+ *
+ * `after` vs `current` is the diff a reviewer judges. `before` vs `current` says whether
+ * the proposal still applies — the row shows both bodies and derives no verdict, because
+ * that judgement lives inside the accept transaction (spec-530 dec-3/dec-4), not here.
+ */
+export interface DriftProposalOperation {
+  op: 'edit' | 'delete' | 'add';
+  /** The target's `cl-N` handle. For `add`, the ANCHOR it sits relative to. */
+  clause: string;
+  /** `add` only — which side of the anchor the new clause goes. */
+  placement?: 'before' | 'after';
+  /** The target's body at authoring time. Absent for `add`. */
+  before?: string;
+  /** The proposed text. Absent for `delete`. */
+  after?: string;
+  /** The clause's live body now, or null when it no longer exists. */
+  current: string | null;
+}
+
+/**
+ * A `plan_revision`'s body, as the server read it. `legacy` is a pre-spec-530
+ * whole-section replacement (readable, not applyable clause by clause); `unreadable` is
+ * a body that parses as neither. Both render an explanatory row rather than breaking the
+ * page for every other item on it.
+ */
+export type DriftProposal =
+  | { kind: 'clause-ops'; operations: DriftProposalOperation[] }
+  | { kind: 'legacy'; proposed: string }
+  | { kind: 'unreadable' };
+
+/**
  * Drift Inbox row — open `drift` or `plan_revision` typed comment with parent
  * doc + section context attached. See packages/server/src/services/drift-inbox.ts
  * for the canonical shape.
@@ -21,13 +53,19 @@ export interface DriftInboxItem {
   authorName: string;
   content: string;
   /**
-   * Normalized proposed replacement text (spec-143 dec-2 / ac-9). The server
-   * guarantees this is non-null for every `plan_revision` — including proposals
-   * authored without the `~~~proposed-content` fence — so the inbox always
-   * renders a proposal as a before/after diff and never falls through to an
-   * undifferentiated blob. `null` for a `drift` observation.
+   * Proposed replacement text; non-null for every `plan_revision`, null for a `drift`.
+   *
+   * spec-530 t-7: **the row does NOT render this.** At the clause grain a proposal is a
+   * set of operations with no single "proposed body", so for a clause-ops row this is
+   * the raw comment content. It survives because the drift agent's context reads it.
+   * Render `proposal` instead.
    */
   proposedContent: string | null;
+  /**
+   * The proposal's operations, resolved against the live clauses (spec-530 t-7) — what
+   * the row renders. `null` for a `drift` observation.
+   */
+  proposal: DriftProposal | null;
   createdAt: string; // ISO timestamp from the JSON wire
   /**
    * The source DECISION a `drift` finding contradicts (spec-498 dec-4) — its

--- a/packages/ui/src/components/drift/ProposalDisclosure.tsx
+++ b/packages/ui/src/components/drift/ProposalDisclosure.tsx
@@ -1,0 +1,170 @@
+import { useState } from 'react';
+import type { DriftProposal, DriftProposalOperation } from '../../api/client';
+
+/**
+ * The before/after a Drift Inbox proposal row promises (spec-530 t-7).
+ *
+ * The row used to claim, in its own header comment, that the diff was "reachable via
+ * Discuss with Agent or the standard page". Verified 2026-08-13: it was reachable via
+ * neither. `proposedContent` was fetched to the client and rendered by nothing, so a
+ * user judging a proposal had no way to see what it actually said.
+ *
+ * **Collapsed by default, and collapsed means NOT RENDERED — not hidden with CSS.**
+ * spec-498 deliberately took the heavy diff out of the list ("the important information
+ * at a glance, not a wall of text") and pinned that with tests asserting the diff
+ * element is absent. Those tests stay green here, unchanged: nothing of the diff enters
+ * the DOM until the reader asks for it. A 12-operation proposal is therefore still one
+ * scannable line in the list, which is the only way dec-1's operation SETS could live on
+ * this surface at all.
+ *
+ * **Read-only.** No Accept / Reject / Resolve control — spec-143 dec-3 removed those
+ * deliberately, on the grounds that accepting a proposal is a judgement rather than a
+ * one-click yes/no, and spec-530's non-goals explicitly decline to revisit that. The
+ * reader forms a view here and tells the agent; the agent applies it behind a
+ * confirmation gate.
+ */
+export function ProposalDisclosure({ proposal }: { proposal: DriftProposal | null }) {
+  const [open, setOpen] = useState(false);
+  if (!proposal) return null;
+
+  // A legacy or unreadable body has no operations to diff. Say so in one line rather
+  // than dumping the body — an unapplicable row must cost one explanatory sentence, not
+  // the wall of text spec-498 removed (spec-530 ac-18).
+  if (proposal.kind !== 'clause-ops') {
+    return (
+      <p
+        className="mt-2 text-xs text-muted"
+        data-testid="drift-proposal-unapplicable"
+        data-proposal-kind={proposal.kind}
+      >
+        {proposal.kind === 'legacy'
+          ? 'This proposal predates the clause grain — it replaces a whole section, so it cannot be applied clause by clause. Ask the agent to restate it against the current rule.'
+          : 'This proposal carries no readable changes, so it cannot be applied. Ask the agent to re-propose it.'}
+      </p>
+    );
+  }
+
+  const count = proposal.operations.length;
+  const label = `${count} clause change${count === 1 ? '' : 's'}`;
+
+  return (
+    <div className="mt-2">
+      <button
+        type="button"
+        // The row itself focuses the agent on click; expanding a diff must not also
+        // fire that.
+        onClick={(e) => {
+          e.stopPropagation();
+          setOpen((v) => !v);
+        }}
+        aria-expanded={open}
+        className="text-xs px-2.5 py-1 rounded-full border border-edge bg-card-hover text-secondary hover:text-primary hover:border-accent transition-colors"
+        data-testid="drift-proposal-toggle"
+        data-open={open ? 'true' : 'false'}
+      >
+        {open ? 'Hide' : 'Show'} {label}
+      </button>
+
+      {open && (
+        <div
+          className="mt-3 space-y-3"
+          data-testid="drift-proposal-diff"
+          onClick={(e) => e.stopPropagation()}
+        >
+          {proposal.operations.map((op, i) => (
+            <OperationDiff key={`${op.op}-${op.clause}-${i}`} op={op} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+const OP_LABEL: Record<DriftProposalOperation['op'], string> = {
+  edit: 'Edit',
+  add: 'Add',
+  delete: 'Remove',
+};
+
+function OperationDiff({ op }: { op: DriftProposalOperation }) {
+  return (
+    <div
+      className="border border-edge-subtle rounded-md p-3 bg-surface/40"
+      data-testid="drift-proposal-operation"
+      data-op={op.op}
+      data-clause={op.clause}
+    >
+      <div className="flex items-baseline gap-2 mb-2">
+        <span className="text-xs font-medium text-secondary">{OP_LABEL[op.op]}</span>
+        {/* The cl-N is what the reader and the agent both name the target by
+            [per std-10] — never "the second clause". */}
+        <span className="font-mono text-xs text-muted" data-testid="drift-proposal-clause">
+          {op.clause}
+        </span>
+        {op.op === 'add' && (
+          <span className="text-xs text-muted">
+            new clause {op.placement === 'before' ? 'before' : 'after'} it
+          </span>
+        )}
+      </div>
+
+      {/* An add's `current` is its ANCHOR's text — context for where the new clause
+          lands, not something being replaced. */}
+      {op.op === 'add' ? (
+        <>
+          {op.current !== null && (
+            <Body kind="context" label="Anchored to" text={op.current} />
+          )}
+          {op.after !== undefined && <Body kind="proposed" label="New clause" text={op.after} />}
+        </>
+      ) : (
+        <>
+          {op.current === null ? (
+            <p className="text-xs text-muted" data-testid="drift-proposal-clause-gone">
+              This clause no longer exists on the Standard.
+            </p>
+          ) : (
+            <Body kind="current" label="Now" text={op.current} />
+          )}
+          {op.op === 'edit' && op.after !== undefined && (
+            <Body kind="proposed" label="Proposed" text={op.after} />
+          )}
+          {op.op === 'delete' && (
+            <p className="mt-2 text-xs text-status-danger-text">Removed entirely.</p>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+/**
+ * One side of a diff. The tints are the shared status tokens, so both themes are handled
+ * by the token layer rather than by a palette invented here [per the design system].
+ */
+function Body({
+  kind,
+  label,
+  text,
+}: {
+  kind: 'current' | 'proposed' | 'context';
+  label: string;
+  text: string;
+}) {
+  const tone =
+    kind === 'proposed'
+      ? 'bg-status-success-bg border-status-success-border text-status-success-text'
+      : kind === 'current'
+        ? 'bg-status-danger-bg border-status-danger-border text-status-danger-text'
+        : 'border-edge-subtle text-muted';
+  return (
+    <div className="mt-2 first:mt-0" data-testid={`drift-proposal-${kind}`}>
+      <div className="text-[10px] uppercase tracking-wide text-muted mb-1">{label}</div>
+      {/* whitespace-pre-wrap: clause bodies are markdown and their line breaks are
+          meaningful. break-words so a long URL cannot widen the row. */}
+      <div className={`border rounded-sm px-2 py-1.5 text-xs whitespace-pre-wrap break-words ${tone}`}>
+        {text}
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/pages/DriftInbox.proposal.spec-530.test.tsx
+++ b/packages/ui/src/pages/DriftInbox.proposal.spec-530.test.tsx
@@ -1,0 +1,307 @@
+// spec-530 t-7 (ac-2) — the human half of "the proposed text is fully visible to both
+// readers who must judge it".
+//
+// ac-2 is a SCOPE criterion covering two readers, and it fails unless BOTH pass:
+//   - the AGENT half is ac-22, already green — `buildDriftContext` stops truncating
+//     `proposedContent` at 500 characters (spec-530 t-6);
+//   - the HUMAN half is this file — the Drift Inbox row renders the current clause and
+//     the proposed clause, with the cl-N visible.
+// Tagging ac-2 here is therefore only honest BECAUSE ac-22 is green. If ac-22 ever goes
+// red, ac-2's badge is lying regardless of what this file says.
+//
+// The row previously rendered NOTHING of the proposal: `proposedContent` came down the
+// wire and no component read it, while the file's own header claimed the diff was
+// "reachable via Discuss with Agent or the standard page" — true of neither.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { DriftInbox } from './DriftInbox';
+import type { DriftInboxItem, DriftProposalOperation } from '../api/client';
+
+// scope ac-2: BOTH readers see the proposal whole (composes with ac-22, the agent half).
+const AC_2 = 'mindset-prod/memex-building-itself/specs/spec-530/acs/ac-2';
+// spec-143 dec-3 / spec-530 non-goals: the Inbox carries no action controls.
+const AC_5 = 'mindset-prod/memex-building-itself/specs/spec-530/acs/ac-5';
+// spec-530 t-9: a legacy body degrades to an explanatory row, never a crash.
+const AC_18 = 'mindset-prod/memex-building-itself/specs/spec-530/acs/ac-18';
+
+vi.mock('../hooks/useDocChangeStream', () => ({ useDocChangeStream: () => {} }));
+vi.mock('../components/ChatContext', () => ({
+  useChat: () => ({
+    addContextChip: vi.fn(),
+    sendMessage: vi.fn(),
+    enterDriftMode: vi.fn(),
+    exitDriftMode: vi.fn(),
+    isDriftMode: true,
+  }),
+}));
+vi.mock('../components/ChatPanel', () => ({
+  ChatPanel: () => <div data-testid="chat-panel">agent</div>,
+}));
+vi.mock('../components/AuthContext', () => ({ useAuth: () => ({ isAuthenticated: true }) }));
+vi.mock('../hooks/useMemexAccess', () => ({ useMemexAccess: () => ({ canWrite: true }) }));
+
+const fetchDriftInboxMock = vi.fn();
+vi.mock('../api/client', () => ({
+  fetchDriftInbox: (...args: unknown[]) => fetchDriftInboxMock(...args),
+  resolveComment: vi.fn(),
+}));
+
+function proposalItem(overrides: Partial<DriftInboxItem> = {}): DriftInboxItem {
+  return {
+    commentId: 'prop-1',
+    commentHandle: 'c-5',
+    commentType: 'plan_revision',
+    source: 'agent',
+    authorName: 'Agent',
+    content: 'raw comment body with the operations payload',
+    proposedContent: 'raw comment body with the operations payload',
+    proposal: {
+      kind: 'clause-ops',
+      operations: [
+        {
+          op: 'edit',
+          clause: 'cl-12',
+          before: 'Cache every write.',
+          after: 'Cache every write except mutating endpoints.',
+          current: 'Cache every write.',
+        },
+      ],
+    },
+    createdAt: '2025-01-01T00:00:00Z',
+    decision: null,
+    section: { id: 's-1', sectionType: 'do', title: null, content: 'Cache every write.' },
+    doc: {
+      id: 'd-1',
+      handle: 'std-100',
+      title: 'Caching standard',
+      docType: 'standard',
+      status: 'build',
+    },
+    ...overrides,
+  };
+}
+
+function renderInbox() {
+  return render(
+    <MemoryRouter initialEntries={['/drift']}>
+      <DriftInbox />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('spec-530 t-7: a proposal row shows current vs proposed per operation (ac-2)', () => {
+  it('reveals the current clause, the proposed clause and the cl-N when expanded', async () => {
+    tagAc(AC_2);
+    fetchDriftInboxMock.mockResolvedValueOnce([proposalItem()]);
+    const user = userEvent.setup();
+    renderInbox();
+
+    // Collapsed to start — nothing of the diff is in the DOM yet (see the
+    // spec-498 note below).
+    expect(await screen.findByTestId('drift-inbox-row')).toBeInTheDocument();
+    expect(screen.queryByTestId('drift-proposal-diff')).toBeNull();
+
+    await user.click(screen.getByTestId('drift-proposal-toggle'));
+
+    const diff = screen.getByTestId('drift-proposal-diff');
+    // The target, named by its canonical handle [per std-10] — never "the second one".
+    expect(diff.querySelector('[data-testid="drift-proposal-clause"]')!.textContent).toBe('cl-12');
+    // What the rule says now…
+    expect(diff.querySelector('[data-testid="drift-proposal-current"]')!.textContent).toContain(
+      'Cache every write.',
+    );
+    // …and what the proposal wants it to say. THIS is the text a user could not see.
+    expect(diff.querySelector('[data-testid="drift-proposal-proposed"]')!.textContent).toContain(
+      'Cache every write except mutating endpoints.',
+    );
+  });
+
+  it('renders the proposed text in full — not truncated, which is ac-2\'s whole point', async () => {
+    tagAc(AC_2);
+    // Longer than DRIFT_BODY_MAX (500), the cap that silently cut the AGENT's copy
+    // until t-6. Neither reader may see a string that has been quietly shortened.
+    const long = `${'A'.repeat(600)}END-OF-PROPOSAL`;
+    fetchDriftInboxMock.mockResolvedValueOnce([
+      proposalItem({
+        proposal: {
+          kind: 'clause-ops',
+          operations: [
+            { op: 'edit', clause: 'cl-3', before: 'short', after: long, current: 'short' },
+          ],
+        },
+      }),
+    ]);
+    const user = userEvent.setup();
+    renderInbox();
+
+    await user.click(await screen.findByTestId('drift-proposal-toggle'));
+    expect(
+      screen.getByTestId('drift-proposal-diff').querySelector('[data-testid="drift-proposal-proposed"]')!
+        .textContent,
+    ).toContain('END-OF-PROPOSAL');
+  });
+
+  it('shows an add as a new clause anchored to a cl-N, and a delete as a removal', async () => {
+    tagAc(AC_2);
+    fetchDriftInboxMock.mockResolvedValueOnce([
+      proposalItem({
+        proposal: {
+          kind: 'clause-ops',
+          operations: [
+            {
+              op: 'add',
+              clause: 'cl-7',
+              placement: 'after',
+              after: 'The rule was missing this case.',
+              current: 'The anchor clause.',
+            },
+            { op: 'delete', clause: 'cl-9', before: 'Obsolete.', current: 'Obsolete.' },
+          ],
+        },
+      }),
+    ]);
+    const user = userEvent.setup();
+    renderInbox();
+    await user.click(await screen.findByTestId('drift-proposal-toggle'));
+
+    const ops = screen.getAllByTestId('drift-proposal-operation');
+    expect(ops).toHaveLength(2);
+    expect(ops[0]).toHaveAttribute('data-op', 'add');
+    expect(ops[0]).toHaveAttribute('data-clause', 'cl-7');
+    expect(ops[0].textContent).toContain('The rule was missing this case.');
+    expect(ops[1]).toHaveAttribute('data-op', 'delete');
+    expect(ops[1].textContent).toContain('Removed entirely.');
+  });
+
+  it('says so when the targeted clause no longer exists, instead of rendering a blank', async () => {
+    tagAc(AC_2);
+    fetchDriftInboxMock.mockResolvedValueOnce([
+      proposalItem({
+        proposal: {
+          kind: 'clause-ops',
+          operations: [
+            { op: 'edit', clause: 'cl-4', before: 'gone', after: 'never applied', current: null },
+          ],
+        },
+      }),
+    ]);
+    const user = userEvent.setup();
+    renderInbox();
+    await user.click(await screen.findByTestId('drift-proposal-toggle'));
+
+    expect(screen.getByTestId('drift-proposal-clause-gone').textContent).toContain(
+      'no longer exists',
+    );
+  });
+});
+
+describe('spec-530 t-7: the list stays scannable, and gains no action controls', () => {
+  it('keeps a 12-operation proposal to one line until the reader opens it', async () => {
+    tagAc(AC_2);
+    const operations: DriftProposalOperation[] = Array.from({ length: 12 }, (_, i) => ({
+      op: 'edit' as const,
+      clause: `cl-${i + 1}`,
+      before: `old body ${i + 1}`,
+      after: `new body ${i + 1}`,
+      current: `old body ${i + 1}`,
+    }));
+    fetchDriftInboxMock.mockResolvedValueOnce([
+      proposalItem({ proposal: { kind: 'clause-ops', operations } }),
+    ]);
+    const user = userEvent.setup();
+    renderInbox();
+
+    // dec-1 made a proposal a SET, which is only liveable on this surface because the
+    // set is collapsed by default. Twelve operations must not become twelve stacked
+    // blocks in a list.
+    const toggle = await screen.findByTestId('drift-proposal-toggle');
+    expect(toggle.textContent).toContain('12 clause changes');
+    expect(screen.queryAllByTestId('drift-proposal-operation')).toHaveLength(0);
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+
+    await user.click(toggle);
+    expect(screen.getAllByTestId('drift-proposal-operation')).toHaveLength(12);
+    expect(toggle).toHaveAttribute('aria-expanded', 'true');
+
+    // And it collapses again — a reader who opened the wrong row can put it back.
+    await user.click(toggle);
+    expect(screen.queryAllByTestId('drift-proposal-operation')).toHaveLength(0);
+  });
+
+  it('adds NO Accept / Reject / Resolve control — spec-143 dec-3 stands (ac-5)', async () => {
+    tagAc(AC_5);
+    fetchDriftInboxMock.mockResolvedValueOnce([proposalItem()]);
+    const user = userEvent.setup();
+    renderInbox();
+    await user.click(await screen.findByTestId('drift-proposal-toggle'));
+
+    // The row is READ-ONLY. spec-530's non-goals decline to revisit spec-143 dec-3, and
+    // the drift agent's guidance tells users acceptance happens in conversation — an
+    // Accept button here would make that guidance a lie again [per std-34].
+    const row = screen.getByTestId('drift-inbox-row');
+    for (const name of [/^accept/i, /^reject/i, /^resolve/i, /^apply/i]) {
+      expect(screen.queryByRole('button', { name })).toBeNull();
+    }
+    // Exactly two buttons on the row: Discuss with Agent, and the diff disclosure.
+    expect(row.querySelectorAll('button')).toHaveLength(2);
+  });
+
+  it('expanding the diff does not fire the row-level focus action', async () => {
+    tagAc(AC_2);
+    fetchDriftInboxMock.mockResolvedValueOnce([proposalItem()]);
+    const user = userEvent.setup();
+    renderInbox();
+
+    // The row focuses the agent on click. The disclosure sits inside it, so without
+    // stopPropagation, reading a diff would silently retarget the agent conversation.
+    await user.click(await screen.findByTestId('drift-proposal-toggle'));
+    expect(screen.getByTestId('drift-proposal-diff')).toBeInTheDocument();
+  });
+});
+
+describe('spec-530 t-7: an unapplicable proposal degrades to one row, never a crash (ac-18)', () => {
+  it('explains a legacy whole-section proposal instead of dumping its body', async () => {
+    tagAc(AC_18);
+    fetchDriftInboxMock.mockResolvedValueOnce([
+      proposalItem({
+        proposal: { kind: 'legacy', proposed: 'A WHOLE REPLACEMENT SECTION BODY.' },
+      }),
+    ]);
+    renderInbox();
+
+    const note = await screen.findByTestId('drift-proposal-unapplicable');
+    expect(note).toHaveAttribute('data-proposal-kind', 'legacy');
+    expect(note.textContent).toContain('predates the clause grain');
+    // The wall of text spec-498 removed does not come back through this door.
+    expect(screen.getByTestId('drift-inbox-row').textContent).not.toContain(
+      'A WHOLE REPLACEMENT SECTION BODY.',
+    );
+    // Nothing to expand — there are no operations to diff.
+    expect(screen.queryByTestId('drift-proposal-toggle')).toBeNull();
+  });
+
+  it('renders every OTHER row when one proposal is unreadable — the blast radius is one row', async () => {
+    tagAc(AC_18);
+    fetchDriftInboxMock.mockResolvedValueOnce([
+      proposalItem({ commentId: 'bad', proposal: { kind: 'unreadable' } }),
+      proposalItem({ commentId: 'good' }),
+    ]);
+    renderInbox();
+
+    const rows = await screen.findAllByTestId('drift-inbox-row');
+    expect(rows).toHaveLength(2);
+    expect(screen.getByTestId('drift-proposal-unapplicable').textContent).toContain(
+      'no readable changes',
+    );
+    // The healthy row still offers its diff.
+    expect(screen.getAllByTestId('drift-proposal-toggle')).toHaveLength(1);
+  });
+});

--- a/packages/ui/src/pages/DriftInbox.test.tsx
+++ b/packages/ui/src/pages/DriftInbox.test.tsx
@@ -368,6 +368,23 @@ describe('DriftInbox — two explicit row types, drift-card style (spec-143 dec-
         commentType: 'plan_revision',
         content: 'Reword.\n~~~proposed-content\nAlways cache with Redis.\n~~~',
         proposedContent: 'Always cache with Redis.',
+        // spec-530 t-7: this fixture now carries real operations. Without them the
+        // assertions below passed for the wrong reason — the row had no proposal to
+        // render at all, so "the diff is not in the list" was true vacuously. With them,
+        // this test genuinely re-asserts spec-498's invariant against the new rendering
+        // path: the diff exists, and it is COLLAPSED, so nothing of it reaches the list.
+        proposal: {
+          kind: 'clause-ops',
+          operations: [
+            {
+              op: 'edit',
+              clause: 'cl-1',
+              before: 'Always cache.',
+              after: 'Always cache with Redis.',
+              current: 'Always cache.',
+            },
+          ],
+        },
         section: { id: 's-9', sectionType: 'do', title: null, content: 'Always cache.' },
       }),
     ]);

--- a/packages/ui/src/pages/DriftInbox.tsx
+++ b/packages/ui/src/pages/DriftInbox.tsx
@@ -7,6 +7,7 @@ import { tenantPath } from '../utils/tenantUrl';
 import { timeAgo } from '../utils/timeAgo';
 import { Spinner } from '../components/Spinner';
 import { OpeningDriftController } from '../components/chat/OpeningDriftController';
+import { ProposalDisclosure } from '../components/drift/ProposalDisclosure';
 
 /**
  * Standards Drift Inbox (t-10 of doc-8; scoped to Standards in b-63). Surfaces
@@ -23,8 +24,17 @@ import { OpeningDriftController } from '../components/chat/OpeningDriftControlle
  *     standard (`std-N` + title) it violates. The full comment body is NOT dumped
  *     into the list (too much to read); the agent explains detail on Discuss.
  *   - Proposal (`plan_revision`) — a proposed change to a standard. Rendered as a
- *     one-line "Proposes a change to std-N …". The heavy before/after diff is out
- *     of the list — reachable via Discuss with Agent or the standard page.
+ *     one-line "Proposes a change to std-N …" plus a COLLAPSED disclosure carrying the
+ *     per-clause before/after (spec-530 t-7). Collapsed means not rendered, not hidden:
+ *     the list stays scannable at a glance, which is what spec-498 was protecting, and
+ *     a 12-operation proposal is still one line until the reader opens it.
+ *
+ * This header used to claim the diff was "reachable via Discuss with Agent or the
+ * standard page". Verified 2026-08-13: it was reachable via NEITHER — `proposedContent`
+ * came down the wire and was rendered by no component, so a user judging a proposal had
+ * no way to see what it said. That claim is corrected rather than deleted, because the
+ * gap between what a comment promises and what the code does is the defect spec-530 is
+ * named after.
  *
  * No inline action buttons (spec-143 dec-3). The per-row Accept / Reject /
  * Resolve buttons are gone — deciding whether a standard should change in
@@ -320,20 +330,26 @@ function DriftInboxBody({
                     one-liner. Neither dumps the full comment body / diff (spec-498
                     — too much to read in a list; the agent explains on Discuss). */}
                 {isProposal ? (
-                  <div
-                    className="flex items-baseline gap-1.5 text-sm min-w-0"
-                    data-testid="drift-proposal-summary"
-                  >
-                    <span className="flex-none text-muted">Proposes a change to</span>
-                    <Link
-                      to={docHref}
-                      onClick={(e) => e.stopPropagation()}
-                      className="flex-none font-mono text-secondary hover:underline"
+                  <>
+                    <div
+                      className="flex items-baseline gap-1.5 text-sm min-w-0"
+                      data-testid="drift-proposal-summary"
                     >
-                      {item.doc.handle}
-                    </Link>
-                    <span className="truncate text-secondary">{item.doc.title}</span>
-                  </div>
+                      <span className="flex-none text-muted">Proposes a change to</span>
+                      <Link
+                        to={docHref}
+                        onClick={(e) => e.stopPropagation()}
+                        className="flex-none font-mono text-secondary hover:underline"
+                      >
+                        {item.doc.handle}
+                      </Link>
+                      <span className="truncate text-secondary">{item.doc.title}</span>
+                    </div>
+                    {/* spec-530 t-7: the before/after this row has promised since
+                        spec-143 and never delivered. Read-only — spec-143 dec-3's
+                        no-action-buttons rule stands. */}
+                    <ProposalDisclosure proposal={item.proposal ?? null} />
+                  </>
                 ) : (
                   <div className="space-y-1 text-sm" data-testid="drift-observation-body">
                     {item.decision ? (


### PR DESCRIPTION
Release `develop` → `main`. **10 commits, two Specs.**

⚠️ **Merge as a MERGE COMMIT, not rebase or squash** [per std-21 cl-50] — GitHub's PR surface cannot fast-forward, and squash/rebase rewrite SHAs, deploying commits that never ran CI on `develop`. The merge commit is the visible release record.

Merging this PR **is** the decision to ship: the prod deploy runs unattended, gated by its own fail-closed test check and the std-17 live smoke against `memex.ai`.

## Release confirmations [per std-21 §5]

Checked on the tip being promoted, `dc9e7883`:

- **(a) `develop` CI is green** — `test` workflow: success
- **(b) int deploy + smoke green for that SHA** — `deploy` workflow: success
- **(c) `git log origin/develop..origin/main --no-merges` is empty** — no stealth non-merge commits on `main`

*One thing a reviewer will notice and should not worry about:* the deploy for `15e71bb0` (one commit earlier) shows `failure`. Its test run was **cancelled**, not red — two PRs merged 28 seconds apart and the concurrency group killed the in-flight run. The gate then refused on a non-`success` verdict, exactly as fail-closed is meant to. The tip's own run is green.

## What ships

### spec-530 — a proposed Standard change can actually be accepted (8 commits)

A proposal on a Standard **could not be accepted at all**. Proposals targeted a whole section; Standards can only be edited clause by clause; `update_section` throws on every Standard. Nothing bridged the two, and the drift agent's guidance instructed the throwing call — wrong for months, because nothing executes prose as a contract.

Already live from the previous release: clause-grained proposals, the untruncated proposal text, and the corrected agent guidance. **This release adds the half that makes it safe:**

- **`accept_standard_change`** — one verb, one transaction. Every clause operation lands or none does; the proposal resolves in the same transaction. No more "Standard rewritten, proposal still open".
- **A staleness guard.** If the rule changed after the proposal was written, the accept **refuses** and names the clause and what it now says, instead of silently discarding that work. This is not hypothetical: a clause on std-3 changed between a proposal being written and applied this week.
- **The Drift Inbox row shows the diff** — current vs proposed, per clause, collapsed by default so a twelve-operation proposal stays one line. Read-only; acceptance stays a conversation [per spec-143 dec-3].
- **Clause order is deterministic** (dec-5). `createClause` shifted nothing when inserting at an occupied ordinal and reads had no tiebreaker, so a Standard's rendered text was not a function of its rows — two regenerations with no write between could differ. Fixed at the source, plus a total ordering on read.
- **Rule changes are attributed** — who changed a Standard, and from where [per std-32].
- **A dead route removed** (dec-6). `POST /api/drift/proposals/:commentId/accept` was mounted, reachable, and could never succeed since spec-161. Nothing called it.

### spec-520 (2 commits)

- The ingest path never told the database which tenant it was.
- An AC-health payload pinned before its query is rewritten.

## What this unblocks, and one gotcha

Once live, accepting a proposal becomes one gated call instead of the agent performing two unguarded ones — which is what production does today.

**Gotcha for whoever verifies it:** there is currently **no open proposal to demonstrate on.** The two clause-grained proposals authored this week were both accepted through the manual path before this release. Verifying the end-to-end loop needs a fresh proposal — the next real one will do, or author one deliberately.

## Risk

No schema changes, no migrations, no flags. One route removed that nothing called. Every mutation still through `mutate()` [per std-8]; tenancy and RLS posture unchanged [per std-36].

The material change in behaviour is that accepting a proposal becomes atomic and guarded. Today's path is neither, so this reduces risk rather than adding it.
