### PR TITLE
release: spec-535 warning copy — ask for something the reader can do

### DIFF
--- a/packages/server/src/formatting/formatters.ts
+++ b/packages/server/src/formatting/formatters.ts
@@ -236,6 +236,10 @@ export function formatFullDocState(
         ? SENSITIVE_WARNING_PROSE.contact(doc.sensitiveByName)
         : SENSITIVE_WARNING_PROSE.contactUnknown,
     );
+    // dec-7: the discharge condition rides with the ask. A stop-and-ask with no
+    // stated end reads as "ask before every edit", which the operator learns to
+    // wave through — that destroys the signal faster than ignoring it would.
+    lines.push(SENSITIVE_WARNING_PROSE.scope);
     lines.push(SENSITIVE_WARNING_PROSE.advisory);
     lines.push(SENSITIVE_WARNING_PROSE.rule);
   }

--- a/packages/server/src/mcp/formatters.test.ts
+++ b/packages/server/src/mcp/formatters.test.ts
@@ -883,3 +883,87 @@ describe("spec-535: the sensitivity warning block", () => {
     ).toEqual([]);
   });
 });
+
+// ── spec-535 dec-7: the warning asks for something its reader can do ───────
+//
+// issue-4, the first field report after ship: an agent SAW the block, understood
+// it, relayed it upward — then coded anyway, discharging the obligation with an
+// argument it later called circular. dec-3 had designed against the spec-240
+// failure (a warning skimmed past); that is not what happened, so louder copy
+// was never the fix.
+//
+// The defect was that "Contact X before you change anything here" is
+// unsatisfiable by a reader with no channel to X. These tests pin the three
+// properties dec-7 requires, deliberately as PROPERTIES rather than exact
+// strings — the wording may still improve, the contract may not silently rot.
+describe("spec-535 dec-7: the warning is actionable and bounded", () => {
+  const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-535/acs/ac-${n}`;
+
+  const block = (name: string | null = "Robin") =>
+    formatters
+      .formatFullDocState(
+        { ...makeDoc({ sensitive: true, sensitiveByName: name, sensitiveByUserId: "u-1" }), sections: [] },
+        [],
+        [],
+      )
+      .split("\n")
+      .filter((l) => l.includes("⚠"))
+      .join("\n");
+
+  it("ac-22: it asks the reader to stop and ask their operator — an action they can perform", () => {
+    tagAc(AC(22));
+    const out = block().toLowerCase();
+
+    // The reachable action. An agent has no channel to a named human; its only
+    // available compliance is to stop and ask whoever is driving it.
+    expect(out).toMatch(/stop and ask/);
+    expect(out).toMatch(/person you are working with/);
+  });
+
+  it("ac-22: the named contact is someone to RELAY to, not an instruction to reach them", () => {
+    tagAc(AC(22));
+    const out = block("Robin");
+
+    expect(out).toContain("Robin");
+    // The name must arrive attached to the relay, not standing alone as the
+    // whole instruction — "tell them to contact Robin", never just "contact Robin".
+    expect(out.toLowerCase()).toMatch(/tell them to contact robin/);
+  });
+
+  it("ac-23: it names the trigger and the discharge, leaving no scope undefined", () => {
+    tagAc(AC(23));
+    const out = block().toLowerCase();
+
+    // WHEN it fires — the first change, not every edit.
+    expect(out).toMatch(/first change/);
+    // WHAT ends it. An undefined discharge is what let the reporting agent
+    // resolve the question in its own favour.
+    expect(out).toMatch(/one confirmation|covers this session/);
+  });
+
+  it("ac-24: it still says it blocks nothing, and stays portable", () => {
+    tagAc(AC(24));
+    const out = block();
+
+    // ac-3's promise has to survive the rewording — a stricter-sounding ask
+    // makes it MORE important to say the flag refuses nothing.
+    expect(out.toLowerCase()).toMatch(/blocks nothing/);
+    // std-22 — renders against arbitrary codebases.
+    expect(out).not.toMatch(/packages\/|src\//);
+    expect(out).not.toMatch(/\bstd-\d+\b/);
+  });
+
+  it("ac-23: with no recorded contact it still names the trigger and the discharge", () => {
+    tagAc(AC(23));
+    const out = block(null).toLowerCase();
+
+    expect(out).toMatch(/stop and ask/);
+    expect(out).toMatch(/first change/);
+    expect(out).toMatch(/one confirmation|covers this session/);
+    // Must not name nobody as if it were somebody.
+    expect(out).not.toContain("null");
+    expect(out).not.toContain("undefined");
+    // std-1: "team" is banned in user-visible copy; the house noun is "org".
+    expect(out).not.toMatch(/\bteam\b/);
+  });
+});

--- a/packages/shared/src/scaffold-data.ts
+++ b/packages/shared/src/scaffold-data.ts
@@ -2505,13 +2505,40 @@ export const SENSITIVE_WARNING_PROSE = {
   /** Top and bottom rule — what makes it a block rather than another header line. */
   rule: '⚠ ─────────────────────────────────────────────────────────────',
   /** What the flag means, in the words the person setting it would use. */
-  heading: '⚠  SENSITIVE — delicate or complex, so talk to someone first.',
-  /** The action, when the flag carries provenance. */
-  contact: (name: string): string => `⚠  Contact ${name} before you change anything here.`,
-  /** The action when provenance is absent (an unattributed write). Still warns —
-   *  degrading to silence would drop the signal exactly when attribution failed. */
-  contactUnknown: '⚠  Whoever flagged it was not recorded — ask the org before changing anything here.',
-  /** The non-blocking promise, stated where it is read (ac-3). */
+  heading: '⚠  SENSITIVE — someone should be spoken to before this changes.',
+  /**
+   * The action, when the flag carries provenance.
+   *
+   * dec-7, from issue-4: the first field report found an agent that SAW this
+   * block, relayed it, and then proceeded anyway — discharging the obligation
+   * with an argument it itself called circular. The old copy said "Contact
+   * {name} before you change anything here", which a reader with no channel to
+   * {name} CANNOT DO. An unsatisfiable instruction makes rationalising it away
+   * the path of least resistance.
+   *
+   * So the ask now names the action that is actually available — stop and ask
+   * the operator — and the contact rides along as someone to RELAY to. This does
+   * not make the flag obeyed (it is advisory by design, ac-3); it removes the
+   * honest path to non-compliance.
+   */
+  contact: (name: string): string =>
+    `⚠  Before your first change here, stop and ask the person you are working with to confirm — and tell them to contact ${name}.`,
+  /** Same ask when provenance is absent (an unattributed write). Still warns —
+   *  degrading to silence would drop the signal exactly when attribution failed —
+   *  and must not name nobody as if it were somebody. "org", never "team" (std-1). */
+  contactUnknown:
+    '⚠  Before your first change here, stop and ask the person you are working with to confirm — nobody is recorded as the contact, so ask the org who owns this.',
+  /**
+   * The discharge condition (dec-7). Without it the copy either reads as
+   * "ask before every edit" — which trains the operator to wave it through, and
+   * destroys the signal faster than ignoring it would — or leaves the scope
+   * undefined, which is precisely what the reporting agent resolved in its own
+   * favour.
+   */
+  scope: '⚠  One confirmation covers this session.',
+  /** The non-blocking promise, stated where it is read (ac-3). A firmer ask makes
+   *  this MORE load-bearing, not less: without it the honest reading of a
+   *  stop-and-ask instruction is "you may not proceed", which is not what this means. */
   advisory: '⚠  Advisory only: this blocks nothing. Every read and write still works.',
 };
 

--- a/packages/ui/src/components/SensitiveBanner.test.tsx
+++ b/packages/ui/src/components/SensitiveBanner.test.tsx
@@ -86,3 +86,57 @@ describe('SensitiveBanner (spec-535 t-7)', () => {
     expect(screen.getByTestId('sensitive-banner')).toBeInTheDocument();
   });
 });
+
+// ── spec-535 dec-7 — the web half of the reworded ask ──────────────────────
+//
+// dec-4's argument was that one signal cannot say two different things on two
+// surfaces. The MCP block now asks the reader to stop and ask their operator,
+// names the trigger, and bounds the discharge; the banner has to carry the same
+// contract or the split dec-4 rejected comes back through the copy.
+describe('SensitiveBanner — dec-7 contract (spec-535)', () => {
+  const AC7 = (n: number) => `mindset-prod/memex-building-itself/specs/spec-535/acs/ac-${n}`;
+
+  it('ac-22: asks the reader to stop and ask, with the contact as a relay', () => {
+    tagAc(AC7(22));
+    render(<SensitiveBanner contactName="Robin" />);
+    const text = (screen.getByTestId('sensitive-banner').textContent ?? '').toLowerCase();
+
+    expect(text).toMatch(/stop and ask/);
+    expect(text).toMatch(/person you are working with/);
+    expect(text).toMatch(/tell them to contact robin/);
+  });
+
+  it('ac-23: names the trigger and the discharge', () => {
+    tagAc(AC7(23));
+    render(<SensitiveBanner contactName="Robin" />);
+    const text = (screen.getByTestId('sensitive-banner').textContent ?? '').toLowerCase();
+
+    expect(text).toMatch(/first change/);
+    expect(text).toMatch(/one confirmation|covers this session/);
+  });
+
+  it('ac-24: says the same thing as the MCP block, and still says it blocks nothing', () => {
+    tagAc(AC7(24));
+    render(<SensitiveBanner contactName="Robin" />);
+    const text = (screen.getByTestId('sensitive-banner').textContent ?? '').toLowerCase();
+
+    // The shared contract, asserted on this surface too — that is what stops the
+    // two surfaces drifting into saying different things about one flag.
+    expect(text).toMatch(/stop and ask/);
+    expect(text).toMatch(/one confirmation|covers this session/);
+    expect(text).toMatch(/blocks nothing/);
+    // std-1: banned in user-visible copy, and it already cost this Spec one fix.
+    expect(text).not.toMatch(/\bteam\b/);
+  });
+
+  it('ac-23: with no contact recorded the ask and the scope survive', () => {
+    tagAc(AC7(23));
+    render(<SensitiveBanner contactName={null} />);
+    const text = (screen.getByTestId('sensitive-banner').textContent ?? '').toLowerCase();
+
+    expect(text).toMatch(/stop and ask/);
+    expect(text).toMatch(/one confirmation|covers this session/);
+    expect(text).not.toContain('null');
+    expect(text).not.toContain('undefined');
+  });
+});

--- a/packages/ui/src/components/SensitiveBanner.tsx
+++ b/packages/ui/src/components/SensitiveBanner.tsx
@@ -33,20 +33,35 @@ export function SensitiveBanner({ contactName }: { contactName: string | null })
             behind "does not depend on colour alone", where a coloured border
             alone conveys nothing to someone who cannot see it. */}
         <span className="font-medium text-heading">Sensitive — </span>
+        {/* dec-7, from issue-4: the old copy said "Contact X before you change
+            anything here", which a reader with no channel to X cannot do — and an
+            unsatisfiable instruction is one that gets rationalised away. The ask
+            now names the action that IS available, and the contact rides along as
+            someone to relay to. The MCP block says the same thing (ac-24): one
+            signal, two surfaces, one contract. */}
         {contactName ? (
           <>
-            delicate or complex. Contact{' '}
-            <span className="font-medium text-heading">{contactName}</span> before you
-            change anything here.
+            before your first change here, stop and ask the person you are working with
+            to confirm — and tell them to contact{' '}
+            <span className="font-medium text-heading">{contactName}</span>.
           </>
         ) : (
           // Provenance can be absent (an unattributed write). Still warn: going
-          // silent here would drop the signal exactly when attribution failed.
-          <>delicate or complex. Ask the org before you change anything here.</>
+          // silent here would drop the signal exactly when attribution failed —
+          // and never name nobody as if it were somebody.
+          <>
+            before your first change here, stop and ask the person you are working with
+            to confirm — nobody is recorded as the contact, so ask the org who owns this.
+          </>
         )}{' '}
-        {/* ac-3 is a promise the reader has to be able to act on. Without this
-            line the honest reading of a warning banner is "do not proceed",
-            which is the opposite of what this flag means. */}
+        {/* The discharge condition. Without it this reads as "ask before every
+            edit", which the operator learns to wave through — and a waved-through
+            warning is worth less than no warning. */}
+        <span className="text-secondary">One confirmation covers this session.</span>{' '}
+        {/* ac-3 is a promise the reader has to be able to act on, and a firmer ask
+            makes it MORE load-bearing: without it the honest reading of a
+            stop-and-ask is "you may not proceed", which is the opposite of what
+            this flag means. */}
         <span className="text-secondary">
           This is advisory: it blocks nothing, and every action still works.
         </span>


### PR DESCRIPTION
Release `develop` → `main`. **One commit** this time — `dabbbede` (#630), the spec-535 t-10 copy fix. Already deployed to int with a green smoke (`✓ Smoke passed (ENV=int)`).

## What changes for a reader

The sensitivity warning on a flagged Spec — both the MCP block and the web banner — now reads:

> **Sensitive —** someone should be spoken to before this changes. Before your first change here, stop and ask the person you are working with to confirm — and tell them to contact *X*. One confirmation covers this session. *Advisory only: this blocks nothing.*

Previously it said *"Contact X before you change anything here"*.

## Why

The first field report after spec-535 shipped (issue-4): an agent **saw the warning, understood it, and relayed it upward** — then proceeded anyway, discharging the obligation with an argument it itself called circular. Nothing was harmed.

The original design guarded against a warning being *skimmed past*. That is not what happened. The real defect was that **"contact X" is unsatisfiable by a reader with no channel to X** — and an instruction nobody can carry out is one that gets rationalised away.

The new copy names the action that is available (stop and ask your operator), names when it fires (first change), and bounds what ends it (one confirmation per session).

**It does not make the flag blocking, and must not** — advisory is the design. It removes the *honest* path to non-compliance.

## Scope and risk

Copy only. No schema, no migration, no route, no gate, no mechanism. Nothing to toggle, no manual steps, no operational action on deploy.

Both surfaces move together — one signal should not say two different things in two places, and a test asserts the contract from each side.

## Verification

24/24 spec-535 acceptance criteria verified. Server 1920 · UI 2357 · `journey-70` against a cold DB · `make check` (including the std-1 copy sweep and the scaffold drift-guard) · `make typecheck` — all green, and 23 green checks on #630.

Tests assert properties rather than exact strings, so the wording can keep improving without the contract rotting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)