### PR TITLE
release: spec-537 — a user can rename themselves

### DIFF
--- a/packages/server/src/services/users.rename-attribution.spec-537.integration.test.ts
+++ b/packages/server/src/services/users.rename-attribution.spec-537.integration.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, afterAll } from "vitest";
+import { eq, inArray } from "drizzle-orm";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+import { db } from "../db/connection.js";
+import { docSections, documents, users } from "../db/schema.js";
+import { createDocDraft } from "./documents.js";
+import { updateUserProfile, upsertUserByEmail } from "./users.js";
+import { makeTestMemexWithDevAdmin } from "./test-helpers.js";
+
+// spec-537 t-5 (ac-13) — renaming a user must NOT rewrite historical attribution.
+//
+// No product code implements this: the guarantee comes from std-32 cl-6, which stamps
+// `actor_name` onto the row at write time precisely "so a later user rename or deletion
+// never rewrites historical attribution". This test is the REGRESSION GUARD — it exists
+// so a future well-meaning backfill (or a switch to a read-time join on users.name)
+// can't land unnoticed. dec-4 records that the user explicitly declined such a backfill.
+//
+// Both directions are asserted. Checking only that the old row keeps the old name would
+// also pass if attribution were simply broken and never updating, so the test writes a
+// second row AFTER the rename and requires it to carry the NEW name.
+const AC_HISTORY = "mindset-prod/memex-building-itself/specs/spec-537/acs/ac-13";
+
+const NAME_BEFORE = "Attribution Before";
+const NAME_AFTER = "Attribution After";
+
+// std-37 cl-1: unique per worker AND per call — never a bare Date.now() or a literal.
+function uniqueEmail(): string {
+  const worker = process.env.VITEST_POOL_ID ?? "0";
+  const tail = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+  return `spec537-rename-${worker}-${tail}@example.test`;
+}
+
+const createdDocIds: string[] = [];
+const createdUserIds: string[] = [];
+
+afterAll(async () => {
+  // std-37 cl-6: teardown is idempotent and scoped to what this file created.
+  if (createdDocIds.length > 0) {
+    await db.delete(documents).where(inArray(documents.id, createdDocIds));
+  }
+  if (createdUserIds.length > 0) {
+    await db.delete(users).where(inArray(users.id, createdUserIds));
+  }
+});
+
+// The attribution snapshot lives on the doc's SECTIONS, not on `documents` itself:
+// `documents` carries only `created_by_user_id` (a join key, no denormalised name),
+// while createDocDraft stamps `bornAttribution` — {actorUserId, actorName, channel}
+// from resolveActorColumns — onto every section it inserts (documents.ts ~L293).
+// doc_sections is on std-32's activity-bearing list, so it is the right row to assert.
+async function sectionActorNames(docId: string): Promise<(string | null)[]> {
+  const rows = await db
+    .select({ actorName: docSections.actorName })
+    .from(docSections)
+    .where(eq(docSections.docId, docId));
+  return rows.map((r) => r.actorName);
+}
+
+describe("spec-537 ac-13: a user rename does not rewrite recorded attribution", () => {
+  it("freezes actor_name on rows written before the rename, and uses the new name after", async () => {
+    tagAc(AC_HISTORY);
+
+    const { memexId } = await makeTestMemexWithDevAdmin("s537");
+    const user = await upsertUserByEmail(uniqueEmail());
+    createdUserIds.push(user.id);
+    await updateUserProfile(user.id, { name: NAME_BEFORE });
+
+    // Deliberately pass ONLY {actorUserId, channel} — no actorName. That forces
+    // resolveActorColumns() to snapshot the name from `users` at write time, which is
+    // the exact mechanism ac-13 depends on. A ctx that pre-carried the name would
+    // prove less.
+    const before = await createDocDraft(
+      memexId,
+      "Written before the rename",
+      "Fixture for spec-537 ac-13.",
+      "spec",
+      undefined,
+      undefined,
+      user.id,
+      { actorUserId: user.id, channel: "rest_ui" },
+    );
+    createdDocIds.push(before.id);
+    const bornBefore = await sectionActorNames(before.id);
+    expect(bornBefore.length).toBeGreaterThan(0);
+    expect(new Set(bornBefore)).toEqual(new Set([NAME_BEFORE]));
+
+    // The rename itself — the same service call the profile page's endpoint makes.
+    await updateUserProfile(user.id, { name: NAME_AFTER });
+    const [renamed] = await db
+      .select({ name: users.name })
+      .from(users)
+      .where(eq(users.id, user.id));
+    expect(renamed?.name).toBe(NAME_AFTER);
+
+    // (1) History is intact — the pre-rename rows still read the old name.
+    expect(new Set(await sectionActorNames(before.id))).toEqual(new Set([NAME_BEFORE]));
+
+    // (2) …and attribution is not merely frozen/broken: a new write picks up the
+    // new name. Without this half, a totally broken write path would pass (1).
+    const after = await createDocDraft(
+      memexId,
+      "Written after the rename",
+      "Fixture for spec-537 ac-13.",
+      "spec",
+      undefined,
+      undefined,
+      user.id,
+      { actorUserId: user.id, channel: "rest_ui" },
+    );
+    createdDocIds.push(after.id);
+    const bornAfter = await sectionActorNames(after.id);
+    expect(bornAfter.length).toBeGreaterThan(0);
+    expect(new Set(bornAfter)).toEqual(new Set([NAME_AFTER]));
+
+    // (3) Writing the second doc did not retro-touch the first (no backfill).
+    expect(new Set(await sectionActorNames(before.id))).toEqual(new Set([NAME_BEFORE]));
+  });
+});

--- a/packages/ui/e2e/journey-71-spec-537-my-profile.spec.ts
+++ b/packages/ui/e2e/journey-71-spec-537-my-profile.spec.ts
@@ -1,0 +1,112 @@
+import { test, expect, tenantPath, bareUrl, DEV_EMAIL, DEV_NAME } from "./helpers/index.js";
+import { seedOrgTenant } from "./helpers/retained.js";
+import { setUserName } from "./helpers/seed.js";
+import { installAcEmission } from "./helpers/emit-ac.js";
+
+// spec-537 t-4 — the PR-gate journey (std-28) for editing your own display name.
+//
+// The whole point of this Spec is that a name set at signup used to be permanent:
+// /onboarding bounces you once you have a name, and the onboarding identity step is
+// inert (spec-433 put it in HIDDEN_STEP_IDS). So the loop this journey drives IS the
+// feature — open the account menu, reach the page from there, rename, and see the new
+// name without reloading.
+//
+// Two things here are unreachable by any unit test, which is why they live in a browser:
+//
+//   * the menu row actually RESOLVES (scope ac-2 / std-34). A unit test asserts an href
+//     string; only real navigation proves the route is registered and the page mounts.
+//     A menu entry pointing at a 404 is exactly the failure std-34 exists to prevent.
+//   * the repaint happens with NO RELOAD (scope ac-4). The save returns a fresh session
+//     and updateSession recomputes the derived user; whether the sidebar identity card
+//     re-renders from that is a property of the assembled app, and a mocked component
+//     test would pass either way.
+const SPEC = "mindset-prod/memex-building-itself/specs/spec-537";
+const AC_CAN_RENAME = `${SPEC}/acs/ac-1`;
+const AC_MENU_WORKS = `${SPEC}/acs/ac-2`;
+const AC_SILENT = `${SPEC}/acs/ac-3`;
+const AC_NO_RELOAD = `${SPEC}/acs/ac-4`;
+
+const T1 =
+  "a user reaches My profile from the account menu, renames themselves, and the new name appears with no reload";
+const T2 = "the profile page states the email boundary and says nothing about past activity";
+
+installAcEmission(test, import.meta.url, {
+  [T1]: [AC_CAN_RENAME, AC_MENU_WORKS, AC_NO_RELOAD],
+  [T2]: [AC_SILENT],
+});
+
+const RENAMED = "Renamed In Journey";
+
+test(T1, async ({ page, resources }) => {
+  const slug = resources.slug("j71a");
+  const tenant = await seedOrgTenant({ slug });
+
+  // This journey renames the SHARED dev user, so the restore has to survive a failed
+  // assertion. A restore as the last statement would be skipped on any failure above
+  // it, leaving "Renamed In Journey" for whatever runs next in this worker — and on
+  // `make e2e` (shared dev DB) that is a real leak, not a hypothetical. The fixture's
+  // beforeEach re-asserts the baseline too; try/finally means we don't depend on it.
+  try {
+    // Land inside the tenant shell, where the account menu lives.
+    await page.goto(tenantPath(tenant.namespaceSlug, tenant.memexSlug, "/specs"));
+
+    // ── 1) Open the account menu and take the new row. Navigating by CLICK, not by
+    //       page.goto, is the part that proves the menu entry resolves (ac-2). ──
+    await page.getByText(DEV_NAME, { exact: true }).click();
+    const profileRow = page.getByTestId("user-menu-profile");
+    await expect(profileRow).toHaveText(/my profile/i);
+    await profileRow.click();
+
+    await expect(page).toHaveURL(bareUrl("/settings/profile"));
+    await expect(page.getByRole("heading", { level: 1, name: /my profile/i })).toBeVisible();
+
+    // ── 2) Rename. The field arrives pre-filled with the current name, and Save is
+    //       inert until the value actually changes (ac-12's guard, seen from outside). ──
+    const nameInput = page.getByTestId("profile-name-input");
+    await expect(nameInput).toHaveValue(DEV_NAME);
+    const save = page.getByTestId("profile-name-save");
+    await expect(save).toBeDisabled();
+
+    await nameInput.fill(RENAMED);
+    await expect(save).toBeEnabled();
+    await save.click();
+
+    // No confirmation step — one click commits (dec-4 / spec-479 D-2).
+    await expect(page.getByText(/name saved/i)).toBeVisible();
+
+    // ── 3) The repaint, with no reload. The sidebar identity card is the account
+    //       menu's own trigger, so the new name showing there IS the app-wide repaint
+    //       (ac-4). Asserting the old name is gone matters as much as the new one
+    //       appearing — a card rendering both would mean a stale duplicate. ──
+    await expect(page.getByText(RENAMED, { exact: true })).toBeVisible();
+    await expect(page.getByText(DEV_NAME, { exact: true })).toHaveCount(0);
+
+    // ── 4) And it survives a reload, i.e. it was persisted rather than only held in
+    //       local state — the failure a no-reload assertion alone would miss. ──
+    await page.reload();
+    await expect(page.getByTestId("profile-name-input")).toHaveValue(RENAMED);
+  } finally {
+    await setUserName(DEV_EMAIL, DEV_NAME);
+  }
+});
+
+test(T2, async ({ page, resources }) => {
+  const slug = resources.slug("j71b");
+  const tenant = await seedOrgTenant({ slug });
+  await page.goto(tenantPath(tenant.namespaceSlug, tenant.memexSlug, "/specs"));
+  await page.getByText(DEV_NAME, { exact: true }).click();
+  await page.getByTestId("user-menu-profile").click();
+
+  // std-34: the email boundary is STATED, not implied by the field's absence.
+  const email = page.getByTestId("profile-email");
+  await expect(email).toBeDisabled();
+  await expect(email).toHaveValue(DEV_EMAIL);
+  await expect(page.getByText(/can't be changed here/i)).toBeVisible();
+
+  // dec-4: the user chose silence about historical attribution. This pins that
+  // choice on the assembled page, so re-adding the helper line is a deliberate
+  // reopening of dec-4. (The history guarantee itself is ac-13, server-side.)
+  await expect(
+    page.getByText(/previous name|old name|past activity|already recorded/i),
+  ).toHaveCount(0);
+});

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -76,6 +76,11 @@ const OauthAuthorize = lazy(() =>
 const SettingsIntegrations = lazy(() =>
   import('./pages/SettingsIntegrations').then((m) => ({ default: m.SettingsIntegrations })),
 );
+// spec-537 dec-1: the user's own profile. Nested under the reserved `settings` root so
+// it cannot shadow a namespace slug (std-3 cl-6) — never a flat /profile.
+const SettingsProfile = lazy(() =>
+  import('./pages/SettingsProfile').then((m) => ({ default: m.SettingsProfile })),
+);
 const Onboarding = lazy(() => import('./pages/Onboarding').then((m) => ({ default: m.Onboarding })));
 const WelcomePage = lazy(() =>
   import('./pages/WelcomePage').then((m) => ({ default: m.WelcomePage })),
@@ -506,6 +511,7 @@ export function PostLoginRouter() {
       <Route path="/oauth/authorize" element={<OauthAuthorize />} />
       <Route path="/settings/tokens" element={<Navigate to="/settings/integrations" replace />} />
       <Route path="/settings/integrations" element={<FlatShell><SettingsIntegrations /></FlatShell>} />
+      <Route path="/settings/profile" element={<FlatShell><SettingsProfile /></FlatShell>} />
       {/* spec-226 t-6: internal email-preview gallery. Gated off prod — the
           conditional Route is inert when emailPreviewEnabled() is false (falls
           through to RootRedirect), mirroring the server's prod-unmounted API. */}

--- a/packages/ui/src/components/AppShell.spec-537.test.tsx
+++ b/packages/ui/src/components/AppShell.spec-537.test.tsx
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { ThemeProvider } from './ThemeContext';
+
+// spec-537 t-1 (ac-7) — the "My profile" row in the account menu. The assertion that
+// matters is ADJACENCY to Sign out, not mere presence: "no other menu item between
+// them" is the part of the claim a presence check would silently let rot.
+const AC_MENU_ROW = 'mindset-prod/memex-building-itself/specs/spec-537/acs/ac-7';
+
+const TEAM_ADMIN = {
+  memexId: 'm1',
+  slug: 'acme',
+  memexSlug: 'team',
+  name: 'Acme Inc',
+  memexName: 'Team',
+  kind: 'team' as const,
+  role: 'administrator' as const,
+};
+
+const session = {
+  user: { id: 'u1', name: 'Tester', email: 't@acme.test' },
+  memberships: [TEAM_ADMIN],
+  currentMemexId: 'm1',
+};
+
+vi.mock('./AuthContext', () => ({
+  useAuth: () => ({
+    user: { id: 'u1', name: 'Tester', email: 't@acme.test' },
+    session,
+    logout: vi.fn(),
+  }),
+}));
+
+vi.mock('./whats-new/WhatsNewContext', () => ({
+  useWhatsNew: () => ({
+    available: true,
+    hasUnseen: false,
+    openPopup: vi.fn(),
+    registerMenuAnchor: vi.fn(),
+  }),
+}));
+
+vi.mock('./MemexSwitcher', () => ({ MemexSwitcher: () => <div data-testid="memex-switcher" /> }));
+vi.mock('./InviteMembersDialog', () => ({ InviteMembersDialog: () => <div data-testid="invite-dialog" /> }));
+vi.mock('../hooks/useMemexAccess', () => ({
+  useMemexAccess: () => ({ isAuthenticated: true, isVisitedReadOnly: false }),
+}));
+vi.mock('../hooks/useDriftInboxCount', () => ({ useDriftInboxCount: () => 0 }));
+vi.mock('../journeys/journeyStateCache', () => ({
+  getCachedJourneyState: () => ({ milestones: { mcpConnected: true } }),
+}));
+vi.mock('../api/journey', () => ({
+  fetchJourneyStateApi: () => Promise.resolve({ milestones: { mcpConnected: true } }),
+}));
+vi.mock('../hooks/useTelemetry', () => ({
+  useTelemetry: () => ({ track: vi.fn(), optedOut: false, setOptOut: vi.fn() }),
+}));
+
+import { AppShell } from './AppShell';
+
+function openMenu() {
+  render(
+    <ThemeProvider>
+      <MemoryRouter initialEntries={['/acme/team/specs']}>
+        <AppShell>
+          <div data-testid="page-content">page</div>
+        </AppShell>
+      </MemoryRouter>
+    </ThemeProvider>,
+  );
+  fireEvent.click(screen.getByText('Tester'));
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('spec-537 ac-7: "My profile" in the account menu', () => {
+  it('links to /settings/profile and carries an icon, per the spec-456 menu convention', () => {
+    tagAc(AC_MENU_ROW);
+    openMenu();
+
+    const profile = screen.getByTestId('user-menu-profile');
+    expect(profile).toHaveTextContent('My profile');
+    expect(profile).toHaveAttribute('href', '/settings/profile');
+    expect(profile.querySelector('svg')).not.toBeNull();
+  });
+
+  it('sits immediately above Sign out, with no menu item between them', () => {
+    tagAc(AC_MENU_ROW);
+    openMenu();
+
+    const profile = screen.getByTestId('user-menu-profile');
+    const signOut = screen.getByText('Sign out').closest('button');
+    expect(signOut).not.toBeNull();
+
+    // The claim is adjacency: no menu ITEM between them. The one element that IS
+    // allowed between is the separator that keeps Sign out in its own destructive
+    // group — spec-456 ac-3 requires Sign out's previous sibling to be that
+    // separator, so asserting the exact chain here pins both contracts at once and
+    // catches a future row inserted into the gap.
+    const divider = profile.nextElementSibling;
+    expect(divider).toHaveAttribute('role', 'separator');
+    expect(divider!.nextElementSibling).toBe(signOut);
+  });
+
+  it('does not reuse the invite icon, whose glyph reads "add someone"', () => {
+    tagAc(AC_MENU_ROW);
+    openMenu();
+
+    const profileIcon = screen.getByTestId('user-menu-profile').querySelector('svg');
+    const invitePath = 'M18 7.5v3m0 0v3m0-3h3m-3 0h-3';
+    expect(profileIcon?.innerHTML ?? '').not.toContain(invitePath);
+  });
+});

--- a/packages/ui/src/components/AppShell.tsx
+++ b/packages/ui/src/components/AppShell.tsx
@@ -314,6 +314,20 @@ function PlayCircleIcon() {
   );
 }
 
+// spec-537 t-1: a plain person glyph for "My profile". InvitePersonIcon (below) is
+// the same figure PLUS a "+", which reads "invite someone" — wrong verb for this row.
+function PersonIcon() {
+  return (
+    <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.75}>
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M15.75 6a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0zM4.5 20.118a7.5 7.5 0 0115 0A17.933 17.933 0 0112 21.75c-2.676 0-5.216-.584-7.5-1.632z"
+      />
+    </svg>
+  );
+}
+
 function LogoutIcon() {
   return (
     <svg className={MENU_ICON_CLASS} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.75} aria-hidden="true">
@@ -651,6 +665,20 @@ function SidebarUserCard({
             <BookCallIcon />
             Book a call
           </a>
+          {/* spec-537 ac-7: the user's own profile — the account menu's only route to
+              editing your own display name (dec-1: /settings/profile, never a flat
+              /profile). It is the LAST menu item before Sign out, and it sits ABOVE
+              the divider on purpose: spec-456 ac-3 requires Sign out's immediately
+              preceding sibling to be the separator, so that the destructive action
+              keeps its own group. Nothing but that divider separates the two. */}
+          <UserMenuLink
+            to="/settings/profile"
+            icon={<PersonIcon />}
+            testId="user-menu-profile"
+            onClick={() => setOpen(false)}
+          >
+            My profile
+          </UserMenuLink>
           <UserMenuDivider />
           <button
             onClick={() => {

--- a/packages/ui/src/components/ProfileNameSection.test.tsx
+++ b/packages/ui/src/components/ProfileNameSection.test.tsx
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { tagAc } from '@memex-ai-ac/vitest';
+
+// spec-537 t-3 — component-level verification of the profile name editor, with the
+// API and auth context mocked. The full-page journey (t-4) covers the no-reload
+// repaint end-to-end in CI's cold-DB gate.
+const SPEC = 'mindset-prod/memex-building-itself/specs/spec-537';
+const AC_FIELDS = `${SPEC}/acs/ac-9`;   // name editable + email read-only, with copy
+const AC_ABSENT = `${SPEC}/acs/ac-10`;  // no avatar / no role triangle / name-only body
+const AC_SAVE = `${SPEC}/acs/ac-11`;    // one PATCH via updateProfileApi, session adopted
+const AC_GUARD = `${SPEC}/acs/ac-12`;   // save disabled empty/unchanged; error in place
+const AC_SILENT = `${SPEC}/acs/ac-14`;  // no attribution copy, no confirm dialog
+
+const USER = { id: 'u1', name: 'Ada Lovelace', email: 'ada@example.com', picture: '' };
+
+const updateSession = vi.fn();
+vi.mock('./AuthContext', () => ({
+  useAuth: () => ({ token: 'test-token', user: USER, updateSession }),
+}));
+
+const updateProfileApi = vi.fn();
+vi.mock('../api/client', () => ({
+  updateProfileApi: (...a: unknown[]) => updateProfileApi(...a),
+}));
+
+import { ProfileNameSection } from './ProfileNameSection';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  updateProfileApi.mockResolvedValue({ user: { ...USER, name: 'Ada B' } });
+});
+
+const nameInput = () => screen.getByTestId('profile-name-input');
+const saveButton = () => screen.getByTestId('profile-name-save');
+
+describe('ProfileNameSection', () => {
+  it('pre-fills the name from the session and shows the email read-only', () => {
+    tagAc(AC_FIELDS);
+    render(<ProfileNameSection />);
+
+    expect(nameInput()).toHaveValue('Ada Lovelace');
+    expect(nameInput()).not.toBeDisabled();
+    expect(nameInput()).toHaveAttribute('maxlength', '100');
+
+    const email = screen.getByTestId('profile-email');
+    expect(email).toHaveValue('ada@example.com');
+    expect(email).toBeDisabled();
+    // std-34: the boundary is stated, not implied by leaving the field out.
+    expect(screen.getByText(/can't be changed here/i)).toBeInTheDocument();
+  });
+
+  it('renders no avatar and no role triangle, and sends the name only', async () => {
+    tagAc(AC_ABSENT);
+    render(<ProfileNameSection />);
+
+    // spec-296 owns the avatar; spec-433 parked the role triangle.
+    expect(screen.queryByTestId('role-triangle')).toBeNull();
+    expect(screen.queryByRole('img')).toBeNull();
+
+    await userEvent.clear(nameInput());
+    await userEvent.type(nameInput(), 'Ada B');
+    await userEvent.click(saveButton());
+
+    await waitFor(() => expect(updateProfileApi).toHaveBeenCalledTimes(1));
+    // Only (token, name) — a third roleCoords argument would write to a dormant field.
+    expect(updateProfileApi.mock.calls[0]).toEqual(['test-token', 'Ada B']);
+  });
+
+  it('saves once and adopts the returned session', async () => {
+    tagAc(AC_SAVE);
+    render(<ProfileNameSection />);
+
+    await userEvent.clear(nameInput());
+    await userEvent.type(nameInput(), 'Ada B');
+    await userEvent.click(saveButton());
+
+    await waitFor(() => expect(updateSession).toHaveBeenCalledTimes(1));
+    expect(updateSession).toHaveBeenCalledWith({ user: { ...USER, name: 'Ada B' } });
+    expect(updateProfileApi).toHaveBeenCalledTimes(1);
+    expect(await screen.findByText(/name saved/i)).toBeInTheDocument();
+  });
+
+  it('disables save while the name is unchanged, blank, or whitespace-only', async () => {
+    tagAc(AC_GUARD);
+    render(<ProfileNameSection />);
+
+    // Unchanged.
+    expect(saveButton()).toBeDisabled();
+
+    // Blank — this is what keeps the server's empty-name rejection unreachable.
+    await userEvent.clear(nameInput());
+    expect(saveButton()).toBeDisabled();
+
+    // Whitespace-only trims to empty.
+    await userEvent.type(nameInput(), '   ');
+    expect(saveButton()).toBeDisabled();
+
+    // A real change enables it.
+    await userEvent.clear(nameInput());
+    await userEvent.type(nameInput(), 'Ada B');
+    expect(saveButton()).toBeEnabled();
+
+    // Typing the persisted value back disables it again.
+    await userEvent.clear(nameInput());
+    await userEvent.type(nameInput(), 'Ada Lovelace');
+    expect(saveButton()).toBeDisabled();
+  });
+
+  it('surfaces a failed save in place and leaves the field editable', async () => {
+    tagAc(AC_GUARD);
+    updateProfileApi.mockRejectedValue(new Error('Name must be 100 characters or fewer'));
+    render(<ProfileNameSection />);
+
+    await userEvent.clear(nameInput());
+    await userEvent.type(nameInput(), 'Ada B');
+    await userEvent.click(saveButton());
+
+    expect(await screen.findByText(/100 characters or fewer/i)).toBeInTheDocument();
+    expect(nameInput()).not.toBeDisabled();
+    expect(nameInput()).toHaveValue('Ada B');
+    expect(updateSession).not.toHaveBeenCalled();
+  });
+
+  it('says nothing about historical attribution and asks for no confirmation', async () => {
+    tagAc(AC_SILENT);
+    render(<ProfileNameSection />);
+
+    // dec-4: the user chose silence. This asserts that choice, so re-adding the
+    // helper line is a deliberate reopening of dec-4, not a drive-by edit.
+    expect(
+      screen.queryByText(/previous name|old name|past activity|already recorded|history/i),
+    ).toBeNull();
+
+    await userEvent.clear(nameInput());
+    await userEvent.type(nameInput(), 'Ada B');
+    await userEvent.click(saveButton());
+
+    // Commits on the first click — spec-479 D-2's no-confirm treatment.
+    await waitFor(() => expect(updateProfileApi).toHaveBeenCalledTimes(1));
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+});

--- a/packages/ui/src/components/ProfileNameSection.tsx
+++ b/packages/ui/src/components/ProfileNameSection.tsx
@@ -1,0 +1,118 @@
+import { useCallback, useState } from 'react';
+import { Button } from './ui/Button';
+import { Input } from './ui/Input';
+import { Alert } from './ui/Alert';
+import { useAuth } from './AuthContext';
+import { updateProfileApi } from '../api/client';
+
+// spec-537 t-3 — the user's own display name, editable after signup.
+//
+// Until this Spec the only writers of `users.name` were the two onboarding surfaces,
+// and both are one-way doors: `/onboarding` self-redirects once a name exists
+// (Onboarding.tsx L35) and IdentityStep is inert ('identity' is in HIDDEN_STEP_IDS
+// since spec-433). A name set at signup was therefore permanent. spec-433's "Name
+// handling" section promised Settings as "a pre-existing surface"; it wasn't one.
+// This is that surface (spec-537 issue-1 tracks correcting that record).
+//
+// Per dec-3 the server is untouched: PATCH /api/auth/profile and updateUserProfile()
+// are reused exactly as they are. Per dec-4 this section says NOTHING about historical
+// attribution — see the note on the save handler.
+export function ProfileNameSection() {
+  const { token, user, updateSession } = useAuth();
+  const [name, setName] = useState(user?.name ?? '');
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const trimmed = name.trim();
+  const persisted = user?.name ?? '';
+  // Blank is what keeps the server's empty-name rejection unreachable from here
+  // (`requireString(..., { trim: true })` would 400); unchanged avoids a no-op write.
+  const canSave = !saving && trimmed !== '' && trimmed !== persisted;
+
+  const onSave = useCallback(async () => {
+    if (saving || trimmed === '' || trimmed === persisted) return;
+    setSaving(true);
+    setError(null);
+    setSaved(false);
+    try {
+      // dec-3, accepted debt: this endpoint hardcodes `confirmIdentity: true`, so every
+      // save here re-stamps `users.identity_confirmed_at` — a column whose name means
+      // "completed the onboarding identity step", not "last edited their name". It is
+      // inert TODAY because the only readers treat it as a boolean
+      // (`needsOnboarding = !user.identityConfirmedAt`, services/auth.ts:177 and :273,
+      // and journey-state.ts:97 keys the identity milestone off role_coords instead).
+      // If you are here because you want to read that column as a DATE: it will give you
+      // "last renamed", not "onboarded at". Fix the endpoint (make confirmIdentity
+      // opt-in) rather than inferring anything from the value.
+      //
+      // Two arguments only — passing roleCoords would write to the field spec-433
+      // deliberately parked.
+      const session = await updateProfileApi(token, trimmed);
+      updateSession(session);
+      setSaved(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not save your name. Please try again.');
+    } finally {
+      setSaving(false);
+    }
+  }, [saving, trimmed, persisted, token, updateSession]);
+
+  return (
+    <section className="space-y-6" data-testid="profile-name">
+      <div>
+        <h3 className="text-sm font-semibold text-heading">Your name</h3>
+        <p className="text-sm text-secondary mt-1">
+          How you appear to everyone else — on Specs you author, in comments, and in
+          mentions.
+        </p>
+      </div>
+
+      {error && (
+        <Alert variant="danger" size="md">
+          {error}
+        </Alert>
+      )}
+
+      <div className="space-y-2">
+        <label className="block text-sm text-secondary">
+          Display name
+          <div className="flex gap-2 mt-1">
+            <Input
+              value={name}
+              maxLength={100}
+              onChange={(e) => {
+                setName(e.target.value);
+                setSaved(false);
+              }}
+              data-testid="profile-name-input"
+            />
+            {/* dec-4 / spec-479 D-2: commits on the first click. A name rename breaks
+                no links, so it gets the display-name treatment (no confirm), not the
+                slug treatment (confirm). */}
+            <Button onClick={onSave} disabled={!canSave} data-testid="profile-name-save">
+              {saving ? 'Saving…' : 'Save'}
+            </Button>
+          </div>
+        </label>
+        {saved && <div className="text-xs text-status-success-text">Name saved.</div>}
+      </div>
+
+      <div className="space-y-2">
+        <label className="block text-sm text-secondary">
+          Email
+          <div className="mt-1">
+            <Input value={user?.email ?? ''} disabled readOnly data-testid="profile-email" />
+          </div>
+        </label>
+        {/* std-34: name the boundary rather than leaving the field out and letting a
+            user conclude the feature is missing. Changing the sign-in address touches
+            native auth (std-13), verification, and domain auto-join consent (std-6) —
+            its own Spec. */}
+        <p className="text-xs text-secondary">
+          Your email is how you sign in, and can't be changed here.
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/packages/ui/src/pages/SettingsProfile.test.tsx
+++ b/packages/ui/src/pages/SettingsProfile.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { tagAc } from '@memex-ai-ac/vitest';
+
+// spec-537 t-2 — the profile page and its route wiring. Two claims in ac-8, verified
+// the way each demands: the rendered scroll container by mounting the page, and the
+// route registration by reading App.tsx (the same source-assertion shape
+// App.spec-507.test.tsx uses to pin route wiring). Real navigation through the
+// account menu is covered by the Playwright journey in t-4.
+const AC_ROUTE = 'mindset-prod/memex-building-itself/specs/spec-537/acs/ac-8';
+const AC_SCOPE_CLARITY = 'mindset-prod/memex-building-itself/specs/spec-537/acs/ac-5';
+
+vi.mock('../components/AuthContext', () => ({
+  useAuth: () => ({
+    token: 'test-token',
+    user: { id: 'u1', name: 'Ada Lovelace', email: 'ada@example.com', picture: '' },
+    updateSession: vi.fn(),
+  }),
+}));
+
+vi.mock('../api/client', () => ({
+  updateProfileApi: vi.fn(),
+}));
+
+import { SettingsProfile } from './SettingsProfile';
+
+const appSource = () =>
+  readFileSync(join(dirname(fileURLToPath(import.meta.url)), '..', 'App.tsx'), 'utf8');
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={['/settings/profile']}>
+      <SettingsProfile />
+    </MemoryRouter>
+  );
+}
+
+describe('spec-537 ac-8: the profile page and its route', () => {
+  it('owns its own scroll container', () => {
+    tagAc(AC_ROUTE);
+    renderPage();
+
+    // AppShell's <main> is overflow-hidden, so a page that does not scroll itself
+    // gets clipped. Same contract as SettingsIntegrations / Standard.
+    const scroller = screen.getByTestId('profile-scroll');
+    expect(scroller.className).toContain('overflow-y-auto');
+    expect(scroller.className).toContain('h-full');
+  });
+
+  it('registers /settings/profile inside FlatShell, and adds no flat /profile route', () => {
+    tagAc(AC_ROUTE);
+    const src = appSource();
+
+    // The route exists and is wrapped in FlatShell (same shell as its sibling
+    // /settings/integrations). Whitespace-insensitive so Prettier reflowing the JSX
+    // can't red this — the claim is the wiring, not the formatting.
+    const routeDecl = src
+      .split('\n')
+      .find((l) => l.includes('path="/settings/profile"'));
+    expect(routeDecl, '/settings/profile route not registered in App.tsx').toBeDefined();
+    expect(routeDecl!.replace(/\s+/g, '')).toContain(
+      'element={<FlatShell><SettingsProfile/></FlatShell>}',
+    );
+
+    // dec-1: a flat /profile route is FORBIDDEN. `profile` is not on std-3 cl-6's
+    // reserved-slug list, so such a route would shadow any namespace holding that
+    // slug and make a live tenant unroutable. This pins the rejected option.
+    expect(src).not.toMatch(/path="\/profile"/);
+  });
+
+  it('names the identity it governs, so it is not mistaken for Memex or org settings', () => {
+    tagAc(AC_SCOPE_CLARITY);
+    renderPage();
+
+    expect(screen.getByRole('heading', { level: 1, name: /my profile/i })).toBeInTheDocument();
+    // Points elsewhere for the things it does NOT govern (scope ac-5).
+    expect(screen.getByText(/memex and org settings live on their own pages/i)).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/pages/SettingsProfile.tsx
+++ b/packages/ui/src/pages/SettingsProfile.tsx
@@ -1,0 +1,35 @@
+// spec-537 t-2 (dec-1) — the user's own account surface, reached from "My profile" in
+// the account menu.
+//
+// Flat route `/settings/profile`, NOT `/profile`: tenancy is path-based on the apex
+// (std-2), and `settings` is on std-3 cl-6's reserved-slug list while `profile` is not
+// — so nesting here costs no reserved-list edit and cannot shadow a namespace. Same
+// collision-safety argument spec-481 dec-1 used to carve `/:namespace/settings`.
+//
+// AppShell's <main> is `overflow-hidden`, so the page owns its own scroll container
+// (the pattern SettingsIntegrations and Standard both use).
+//
+// Open core — no `.ee.` marker (std-25): editing your own display name is table-stakes
+// account management, not an Enterprise capability.
+import { ProfileNameSection } from '../components/ProfileNameSection';
+
+export function SettingsProfile() {
+  return (
+    <div className="h-full overflow-y-auto" data-testid="profile-scroll">
+      <div className="max-w-3xl mx-auto px-8 py-8 space-y-14">
+        <div>
+          <h1 className="text-xl font-semibold mb-2 text-heading">My profile</h1>
+          {/* scope ac-5: say which identity this page governs, and point elsewhere for
+              the two it doesn't — a user should never wonder whether renaming here
+              renames their workspace. */}
+          <p className="text-sm text-secondary">
+            Your name and the email you sign in with. Memex and org settings live on
+            their own pages.
+          </p>
+        </div>
+
+        <ProfileNameSection />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Promotes `develop` → `main`. Merging this PR **is** the decision to ship: the prod deploy runs unattended on merge (no approval gate, std-21 cl-42).

## What ships

Exactly one commit. `main` is otherwise identical to `develop`.

```
620738bf feat(spec-537): a user can rename themselves, from a menu row that leads somewhere (#632)
```

9 files, +762, all in `packages/ui` plus one server-side test. [spec-537](https://memex.ai/mindset-prod/memex-building-itself/specs/spec-537) · 13/13 ACs verified.

**User-visible change:** a "My profile" row in the account menu, and a page at `/settings/profile` where a user can change their own display name — which until now was permanent once set at signup.

## std-21 cl-42 release checklist

- [x] **(a) `develop` CI is green** — PR #632, 11/11 required checks including all three `e2e` shards.
- [x] **(b) int deploy + smoke green** — run [32724352359](https://github.com/mindset-ai/memex-ai/actions/runs/32724352359) on `620738bf`, step *"Deploy (server + UI + smoke)"* → success. Verified the smoke step actually ran rather than inferring it from a green job.
- [x] **(c) `git log origin/develop..origin/main --no-merges` is empty** — no stealth commits on `main`; the content invariant (cl-52) holds and will still hold after this merge.

## Risk

**Low.** No migration, no schema change, no new environment variable, no secret, no feature flag. Server-side the diff is one added test file — `PATCH /api/auth/profile` and `updateUserProfile()` are reused untouched, and `services/users.ts` is allowlisted out of `mutate()` coverage so nothing new emits on the bus.

The change is additive in the UI: one menu row and one new route under the already-reserved `settings` root (std-3 cl-6), so it cannot shadow a namespace slug.

**Rollback:** `workflow_dispatch` redeploy of `fd78beb5` (the current `main`), per std-21 cl-76.

## Merge method

**Merge commit, not squash** (std-21 cl-50) — squash/rebase rewrite SHAs and would deploy commits that never ran CI on `develop`. The release merge commit is the visible release record.

## Note on required checks

`codeql-result` is **develop-only** (`codeql.yml` has `pull_request: branches: [develop]`), so it will not report here. That is expected and is why it is not in `main`'s required set — requiring it would permanently block every release. `db-schema-drift` is path-filtered and will be absent too; this release touches no schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
