### PR TITLE
fix(spec-539): two test gates that reported something other than the truth

### DIFF
--- a/packages/server/src/services/.ee/slack/oauth.test.ts
+++ b/packages/server/src/services/.ee/slack/oauth.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
 
 // ──────────────────────────────────────────────────────────────────────────
 // Mocks
@@ -157,7 +158,19 @@ describe("exchangeOAuthCode", () => {
   });
 
   it("throws not_configured when env vars are missing", async () => {
-    vi.unstubAllEnvs();
+    // spec-539 dec-2: this used to be `vi.unstubAllEnvs()`, which restores the REAL
+    // process.env — populated locally from packages/server/.env, empty in CI. So the
+    // test passed only where no .env exists, making `.husky/pre-push` red on every
+    // developer machine and `--no-verify` routine. Stub the three variables away
+    // explicitly, mirroring how this same describe stubs them in at L129-131.
+    tagAc("mindset-prod/memex-building-itself/specs/spec-539/acs/ac-8");
+    tagAc("mindset-prod/memex-building-itself/specs/spec-539/acs/ac-9");
+    // scope ac-4: the test still proves what it was written to prove — refusal with
+    // not_configured when the credentials are absent. Made env-independent, not weaker.
+    tagAc("mindset-prod/memex-building-itself/specs/spec-539/acs/ac-4");
+    vi.stubEnv("SLACK_CLIENT_ID", "");
+    vi.stubEnv("SLACK_CLIENT_SECRET", "");
+    vi.stubEnv("SLACK_OAUTH_REDIRECT_URI", "");
     await expect(exchangeOAuthCode("any-code")).rejects.toMatchObject({
       name: "SlackOAuthError",
       code: "not_configured",

--- a/packages/server/src/services/auth.test.ts
+++ b/packages/server/src/services/auth.test.ts
@@ -21,6 +21,10 @@ describe("getHiddenFeatures (session payload hiddenFeatures)", () => {
     // ac-5 — fail-open default: an unset/empty value ⇒ [] ⇒ nothing hidden.
     tagAc("mindset-prod/memex-building-itself/specs/spec-146/acs/ac-3");
     tagAc("mindset-prod/memex-building-itself/specs/spec-146/acs/ac-5");
+    // spec-539: this test no longer reads the ambient environment (ac-8), and still
+    // fails if getHiddenFeatures stops fail-opening on an empty value (ac-9).
+    tagAc("mindset-prod/memex-building-itself/specs/spec-539/acs/ac-8");
+    tagAc("mindset-prod/memex-building-itself/specs/spec-539/acs/ac-9");
 
     // (a) set → split on comma into the slug list.
     vi.stubEnv("HIDDEN_FEATURES", "scaffold,pulse");
@@ -29,7 +33,12 @@ describe("getHiddenFeatures (session payload hiddenFeatures)", () => {
     // (b) unset/empty → [] (fail-open; never throws, never hides by default).
     vi.stubEnv("HIDDEN_FEATURES", "");
     expect(getHiddenFeatures()).toEqual([]);
-    vi.unstubAllEnvs();
+    // spec-539 dec-2: this used to be `vi.unstubAllEnvs()`, which restores the REAL
+    // process.env — so the assertion below was really "assert against whatever this
+    // machine exports". It passed only because nobody happens to set HIDDEN_FEATURES
+    // in packages/server/.env; the day someone does, it goes red locally and green in
+    // CI. Stub the variable away explicitly instead — same intent, no ambient read.
+    vi.stubEnv("HIDDEN_FEATURES", "");
     expect(getHiddenFeatures()).toEqual([]);
 
     // (c) whitespace + empty entries are trimmed and dropped.

--- a/packages/ui/e2e/helpers/emit-ac.test.ts
+++ b/packages/ui/e2e/helpers/emit-ac.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+// spec-539 t-1 — the e2e emitter's payload.
+//
+// This file is the monorepo's only unit test under e2e/ (dec-3): the emitter is
+// e2e-only code whose behaviour is worth testing without booting Playwright, and the
+// alternative was moving runtime code into src/ purely for testability.
+//
+// The claim that matters most is NEGATIVE. ac-10 exists because the obvious-looking
+// call — buildMetadata(process.env) — merges the ENTIRE environment into the payload,
+// and test_events metadata is world-readable on a public Memex [per std-31]. A test
+// that only checked "run_id is present" would have passed that mistake.
+const SPEC = "mindset-prod/memex-building-itself/specs/spec-539";
+const AC_IMPORTS = `${SPEC}/acs/ac-6`;   // provenance comes from the imported builder
+const AC_BOTH_ENVS = `${SPEC}/acs/ac-7`; // CI env → run_id; bare env → none, still emits
+const AC_NO_LEAK = `${SPEC}/acs/ac-10`;  // metadata never carries arbitrary env vars
+const AC_WIRED = `${SPEC}/acs/ac-11`;    // this file is actually picked up by vitest
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+/** Capture what emitAcEvents POSTs, without letting a request leave the process. */
+function captureFetch() {
+  const calls: { url: string; body: Record<string, unknown> }[] = [];
+  const spy = vi.fn(async (url: string | URL, init?: RequestInit) => {
+    calls.push({
+      url: String(url),
+      body: JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>,
+    });
+    return new Response("{}", { status: 200 });
+  });
+  vi.stubGlobal("fetch", spy);
+  return calls;
+}
+
+const AC_UNDER_TEST = "mindset-prod/memex-building-itself/specs/spec-1/acs/ac-1";
+
+afterEach(() => {
+  // std-37 cl-5: restore every global and env this file replaced, or a sibling
+  // inherits a stubbed fetch and its emissions vanish.
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+  vi.resetModules();
+});
+
+async function emitOnce() {
+  const { emitAcEvents } = await import("./emit-ac.js");
+  await emitAcEvents([AC_UNDER_TEST], "pass", "unit/emit-ac.test.ts", 1);
+}
+
+describe("spec-539: the e2e emitter carries honest CI provenance", () => {
+  it("is picked up by packages/ui's vitest run at all", () => {
+    tagAc(AC_WIRED);
+    // Vacuous-looking on purpose: if the include entry is ever dropped, this file
+    // stops running and every other assertion here goes silently missing rather
+    // than red. This is the canary for that.
+    expect(true).toBe(true);
+
+    const config = readFileSync(join(HERE, "..", "..", "vitest.config.ts"), "utf8");
+    expect(config).toContain("e2e/helpers/**/*.test.ts");
+    // dec-3 obligation 1: the convention break is explained, not silent.
+    const line = config
+      .split("\n")
+      .findIndex((l) => l.includes("e2e/helpers/**/*.test.ts"));
+    const preceding = config.split("\n").slice(Math.max(0, line - 6), line).join("\n");
+    expect(preceding).toMatch(/spec-539|e2e-only|dec-3/);
+  });
+
+  it("derives provenance from the imported builder, not from a second hand-rolled copy", async () => {
+    tagAc(AC_IMPORTS);
+    const src = readFileSync(join(HERE, "emit-ac.ts"), "utf8");
+
+    expect(src).toMatch(/import\s*\{[^}]*buildMetadata[^}]*\}\s*from\s*["']@memex-ai-ac\/vitest["']/);
+    // No second derivation: the GitHub env vars belong to buildMetadata alone.
+    for (const envVar of ["GITHUB_RUN_ID", "GITHUB_SHA", "GITHUB_REF_NAME", "GITHUB_HEAD_REF", "GITHUB_SERVER_URL"]) {
+      expect(src, `${envVar} must be read by buildMetadata, not here`).not.toContain(envVar);
+    }
+  });
+
+  it("attaches run_id and run_url under a GitHub Actions environment", async () => {
+    tagAc(AC_BOTH_ENVS);
+    vi.stubEnv("MEMEX_EMIT_KEY", "mxk_test");
+    vi.stubEnv("GITHUB_ACTIONS", "true");
+    vi.stubEnv("GITHUB_RUN_ID", "42424242");
+    vi.stubEnv("GITHUB_SERVER_URL", "https://github.com");
+    vi.stubEnv("GITHUB_REPOSITORY", "mindset-ai/memex-ai");
+    vi.stubEnv("GITHUB_SHA", "deadbeef");
+    const calls = captureFetch();
+
+    await emitOnce();
+
+    expect(calls).toHaveLength(1);
+    const md = calls[0].body.metadata as Record<string, string>;
+    expect(md.run_id).toBe("42424242");
+    expect(md.run_url).toBe("https://github.com/mindset-ai/memex-ai/actions/runs/42424242");
+    expect(md.commit).toBe("deadbeef");
+    expect(md.host).toBe("ci");
+  });
+
+  it("emits with no run_id under a bare local environment — provenance added, never faked", async () => {
+    tagAc(AC_BOTH_ENVS);
+    // scope ac-2: the anti-cheat. A fix that fabricated CI attribution to silence the
+    // audit's warning would be worse than the warning — this is what forbids it.
+    tagAc(`${SPEC}/acs/ac-2`);
+    vi.stubEnv("MEMEX_EMIT_KEY", "mxk_test");
+    // Explicitly absent rather than un-stubbed: this test must not read whatever
+    // the developer's machine happens to export — the exact defect dec-2 is fixing
+    // two files down the repo.
+    vi.stubEnv("GITHUB_ACTIONS", "");
+    vi.stubEnv("GITHUB_RUN_ID", "");
+    vi.stubEnv("CI", "");
+    const calls = captureFetch();
+
+    await emitOnce();
+
+    // Still emitted — a local run is recorded, just not dressed up as CI.
+    expect(calls).toHaveLength(1);
+    const md = (calls[0].body.metadata ?? {}) as Record<string, string>;
+    expect(md.run_id).toBeUndefined();
+    expect(md.run_url).toBeUndefined();
+  });
+
+  it("never puts an arbitrary environment variable in metadata", async () => {
+    tagAc(AC_NO_LEAK);
+    vi.stubEnv("MEMEX_EMIT_KEY", "mxk_test");
+    vi.stubEnv("GITHUB_ACTIONS", "true");
+    vi.stubEnv("GITHUB_RUN_ID", "1");
+    // A secret-shaped variable of exactly the kind a developer shell carries.
+    vi.stubEnv("GITTOKEN", "ghp_this_must_never_be_published");
+    const calls = captureFetch();
+
+    await emitOnce();
+
+    const md = (calls[0].body.metadata ?? {}) as Record<string, string>;
+    // Guard against passing vacuously: if metadata were absent entirely, the key-set
+    // loop below would iterate zero times and this test would prove nothing.
+    expect(md.run_id, "metadata must actually be populated for this check to mean anything").toBe("1");
+    // The allowed set is what the helper derives itself, plus MEMEX_METADATA_* keys.
+    const WELL_KNOWN = new Set(["branch", "commit", "host", "run_id", "run_url"]);
+    for (const key of Object.keys(md)) {
+      expect(WELL_KNOWN.has(key), `unexpected metadata key "${key}" — is process.env being passed to buildMetadata?`).toBe(true);
+    }
+    expect(JSON.stringify(calls[0].body)).not.toContain("ghp_this_must_never_be_published");
+    expect(Object.keys(md)).not.toContain("GITTOKEN");
+  });
+});

--- a/packages/ui/e2e/helpers/emit-ac.ts
+++ b/packages/ui/e2e/helpers/emit-ac.ts
@@ -8,6 +8,19 @@
 // missing key warns server-side and the AC simply stays unverified, it never
 // fails the run.
 
+// spec-539 dec-1: provenance is DERIVED IN ONE PLACE. buildMetadata() reads the CI
+// environment itself (GitHub Actions / GitLab / BuildKite / CircleCI) plus the
+// MEMEX_METADATA_* convention, and is the same function the official vitest emitter
+// uses — so the two paths cannot report a run differently. Do not re-derive any
+// GITHUB_* variable here; that second copy was the defect this Spec fixes.
+//
+// ⚠ buildMetadata's parameter is EXPLICIT PER-CALL METADATA, not the environment.
+// buildMetadata(process.env) merges every environment variable into the payload, and
+// test_events metadata is world-readable on a public Memex [per std-31] — that would
+// publish every CI runner's and every laptop's secrets. Call it with NO argument.
+// ac-10's test fails the suite if an arbitrary env key ever reaches the payload.
+import { buildMetadata } from "@memex-ai-ac/vitest";
+
 const NAMESPACE_TO_BASE_URL: Record<string, string> = {
   "mindset-prod": "https://memex.ai",
   "mindset-int": "https://int.memex.ai",
@@ -26,6 +39,8 @@ export async function emitAcEvents(
   if (/^(false|0|no|off)$/i.test(process.env.MEMEX_EMIT ?? "")) return;
 
   const key = process.env.MEMEX_EMIT_KEY;
+  // One derivation per call, shared by every ref in this batch.
+  const metadata = buildMetadata();
   for (const ac_uid of acRefs) {
     const namespace = ac_uid.split("/")[0] ?? "";
     const base = NAMESPACE_TO_BASE_URL[namespace];
@@ -47,6 +62,10 @@ export async function emitAcEvents(
           test_identifier: testIdentifier,
           duration_ms: durationMs,
           actor: process.env.GITHUB_ACTOR ?? process.env.USER,
+          // Omitted entirely when empty (a bare local run) rather than sent as `{}`:
+          // an absent key reads as "no provenance", which is the honest answer, and
+          // spec-391 dec-4's audit then correctly reports the run as local-only.
+          ...(Object.keys(metadata).length > 0 ? { metadata } : {}),
         }),
       });
     } catch {

--- a/packages/ui/playwright.config.ts
+++ b/packages/ui/playwright.config.ts
@@ -22,6 +22,14 @@ const DATABASE_URL =
 
 export default defineConfig({
   testDir: "./e2e",
+  // spec-539: journeys are `*.spec.ts` — ONLY. Playwright's default testMatch also
+  // collects `*.test.ts`, which silently swept up the vitest unit test that dec-3 put
+  // beside its subject at `e2e/helpers/emit-ac.test.ts` and ran it under the Playwright
+  // runner, where a vitest `describe`/`tagAc` throws "Vitest failed to find the current
+  // suite" — killing all three e2e shards in CI while every local `--grep`-filtered run
+  // stayed green, because a filter never collected the file. Pinning the pattern closes
+  // the class, not just that one file.
+  testMatch: "**/*.spec.ts",
   // spec-172 dec-3: name the dev user once per run, AFTER webServer boots (Playwright starts
   // webServers before globalSetup), so a cold DB doesn't route every journey into Onboarding.
   // See e2e/global-setup.ts.

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -37,7 +37,14 @@ const COLLECT_ONLY_THRESHOLDS = Object.fromEntries(
 export default defineConfig({
   plugins: [react()],
   test: {
-    include: ['src/**/*.test.{ts,tsx}'],
+    // spec-539 dec-3 — the ONLY vitest include outside `src/**` in this monorepo, and
+    // deliberate. `e2e/helpers/emit-ac.ts` is e2e-only code (the Playwright AC emitter)
+    // whose payload-building is worth unit-testing without booting Playwright and a
+    // database. The alternative was moving that runtime code into `src/` purely for
+    // testability, which would put e2e-only code in the app's module graph. Note nothing
+    // under `e2e/` is compiled by `tsc -b` (tsconfig.app.json includes only `src`), so a
+    // type error in these files surfaces when vitest runs them, not at typecheck.
+    include: ['src/**/*.test.{ts,tsx}', 'e2e/helpers/**/*.test.ts'],
     environment: 'jsdom',
     globals: true,
     setupFiles: ['./src/test/setup.ts'],


### PR DESCRIPTION
Spec: [spec-539](https://memex.ai/mindset-prod/memex-building-itself/specs/spec-539) · open core (test infrastructure only, nothing ships in the product) · **no migration, no schema change, no env var, no flag**

Two defects, one shape: a guard that reports something other than what happened. Both surfaced while verifying spec-537; neither was that Spec's work.

## 1. The Playwright AC emitter sent no CI provenance

`emitAcEvents` posted `ac_uid`/`status`/`test_identifier`/`duration_ms`/`actor` and nothing else — **no `metadata`, no top-level `run_id`**.

spec-391 dec-4's audit reads top-level `run_id` **or** `metadata.run_id`/`run_url` (*"metadata as fallback for hand-rolled emitters"*). The Playwright port supplied neither, so every AC a journey verifies was reported local-only **forever**, even after a green CI run. Since **std-28 makes a journey the mandatory gate for every user-facing flow change**, the criteria only journeys can verify were exactly the ones the deploy-confidence signal was told not to trust. The warning was real advice pointing at the wrong culprit.

**Fixed by importing, not by re-deriving.** `@memex-ai-ac/vitest` was *already* a `workspace:*` dependency of `packages/ui` and already exported `buildMetadata`. spec-172's *"Playwright isn't wired to the @memex-ai-ac/vitest setup helper"* is true of the vitest `afterEach` hook and had been over-applied to the payload builders. One derivation now, so the two paths cannot drift again. `spec-181-ac16-reporter.ts` delegates to `emitAcEvents`, so it inherits the fix — one site, not two.

### ⚠️ The near-miss worth reading

`buildMetadata`'s parameter is **explicit per-call metadata, not the environment**:

```ts
export function buildMetadata(explicit?: Record<string, string>) {
  const auto = readAutoPopulated();   // reads process.env internally
  const env  = readEnvMetadata();     // MEMEX_METADATA_* only
  return { ...auto, ...env, ...(explicit ?? {}) };
}
```

`buildMetadata(process.env)` — the obvious-looking call, and the one the Spec's own illustrative snippet showed — merges **every environment variable** into the payload. A probe on this machine printed `GITTOKEN`, `GEMINI_API_KEY`, `MCP_API_KEY` and keystore paths that way. `test_events` metadata is world-readable, and **this Memex is published publicly** (std-31), so that would have posted the full environment of every CI runner and every developer laptop to a public surface. Nothing leaked — the probe used `playwright test --list`, which loads imports without running tests, so no emission fired.

It is called with **no argument**, and **`ac-10` fails the suite if an arbitrary env key ever reaches the payload** — mutation-verified by reintroducing the exact mistake:

```
AssertionError: unexpected metadata key "GJS_DEBUG_TOPICS" — is process.env being passed to buildMetadata?
```

`metadata` is **omitted entirely** on a bare local run rather than sent as `{}`, so a laptop run stays honestly labelled local. Provenance is added, never fabricated (`ac-2`).

## 2. Two tests read the ambient environment as their fixture

Both asserted an absence via `vi.unstubAllEnvs()`, which restores the **real** `process.env` — populated locally from `packages/server/.env`, empty in CI:

| | |
|---|---|
| `.ee/slack/oauth.test.ts` | Red on every machine with a `.env`. This is why `.husky/pre-push` was red for everyone and `--no-verify` had become routine — including twice in this session's own history. |
| `auth.test.ts` | **Latent, found by measurement.** Passes only because nobody sets `HIDDEN_FEATURES` locally. Same defect, waiting. |

Both now stub their variables explicitly to empty — the pattern each file already used a few lines above. Mutation-verified: breaking `exchangeOAuthCode`'s refusal, and `getHiddenFeatures`' fail-open, reds each in turn.

**No guard test, and that is a measured call.** dec-2 counted 41 `unstubAllEnvs()` call sites: **35 legitimate teardown** (exactly what std-37 cl-5 requires), **2 defective**. Separating them needs *context*, not syntax — same call, same line shape — so a scan would flag innocents, and a guard that cries wolf is the precise pathology this PR exists to end.

## dec-3 — one convention deliberately broken

`packages/ui/vitest.config.ts`'s `include` gains `e2e/helpers/**/*.test.ts`. This is the **monorepo's only vitest include outside `src/**`** (server, shared, extractor, ac-emit-vitest and ui all use the same shape), and the added line carries a comment saying why: the emitter is e2e-only code whose payload-building is worth unit-testing without booting Playwright and a database, and the alternative was moving runtime code into `src/` purely for testability.

Two obligations discharged: both guard tests that read that config file (`coverage-tiers.spec-390`, `coverage-threshold-floor.spec-386`) were re-run green; and nothing under `e2e/` is compiled by `tsc -b` (`tsconfig.app.json` includes only `src`) — the standing posture for the whole e2e tree, now written down rather than left to be discovered.

## Test plan

- [x] `emit-ac.test.ts` — 5 tests, incl. the mutation-verified no-leak guard
- [x] Full UI suite — **2374 / 2374** (351 files; +1 file, +5 tests from this PR)
- [x] `oauth.test.ts` + `auth.test.ts` — 17 / 17 **with a populated `.env` present**
- [x] Mutation checks on both production subjects; both files confirmed reverted intact
- [x] `journey-71` green **with the import in place** — proves a journey still runs, which `--list` could not
- [x] Both config guard tests re-run green (9 / 9)
- [x] **`.husky/pre-push` GREEN — this branch was pushed WITHOUT `--no-verify`**, the first time in this session. That is `ac-3`, demonstrated by the act rather than asserted.
- [ ] `ac-1` / `ac-5` — need this PR's own CI run (t-3): that a real CI journey emission is accepted as CI-originated, and that spec-537's four scope ACs stop being flagged laptop-provenance.
- [ ] `ac-3` stays **untagged on purpose** — "pre-push passes" is not assertable by a test, since the hook *is* the suite. Exercised and observed; recorded as such.

## Follow-ups, recorded not dropped

- **Import `emit`/`emitBatch` too**, now that the import boundary is proven. It would bring the spec-515/spec-525 hardening — batching, the 4s fan-out bound, no-retry, 401-stops-the-flush — none of which the hand-rolled transport has. Out of scope here because `emit()` may assume vitest task context, and breaking e2e emission outright is worse than anonymous emission.
- **A std-37 clause** for "never un-stub to mean absent". The gap is real (cl-5 governs leakage *between* tests, not a test that reads ambient state *as* its fixture), but it is a change to someone else's standard, better raised once there is more than a two-instance pattern to point at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
