### PR TITLE
release: bound the tasks block (spec-538 t-11) + the sensitivity relay ask (spec-535)

### DIFF
--- a/packages/server/src/formatting/formatters.ts
+++ b/packages/server/src/formatting/formatters.ts
@@ -3,7 +3,11 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { Doc, DocSection, DocComment, Decision, Task, Tag } from "../db/schema.js";
 import { formatTag } from "../services/tags.js";
-import { allocateResponseBudget, effectiveBudget } from "../mcp/response-budget.js";
+import {
+  allocateResponseBudget,
+  effectiveBudget,
+  boundRenderedList,
+} from "../mcp/response-budget.js";
 import type { DocSummary } from "../types/index.js";
 import type { TaskWithBlockers } from "../services/tasks.js";
 import type { DocCommentsResult } from "../services/comments.js";
@@ -224,6 +228,9 @@ export function formatFullDocState(
   const decisionsFull =
     decisions.length > 0 ? formatDecisionList(decisions, doc, slugs) : "";
 
+  const tasksFull =
+    tasks.length > 0 ? formatTaskList(tasks, taskCommentCounts, slugs, doc) : "";
+
   const budget = allocateResponseBudget({
     signalsChars: signalLines.join("\n").length,
     // Zero is CORRECT here, not a stopgap (dec-7 option (d)). The body is
@@ -238,6 +245,10 @@ export function formatFullDocState(
     proseChars,
     decisionsFullChars: decisionsFull.length,
     decisionCount: decisions.length,
+    // spec-538 dec-8 — the region the first ladder never counted.
+    tasksFullChars: tasksFull.length,
+    taskCount: tasks.length,
+    sectionCount: doc.sections.length,
   });
 
   // Header
@@ -272,12 +283,15 @@ export function formatFullDocState(
   // Single-line pushes, like every other header line here: the scaffold
   // drift-guard (std-15) fails markdown-shaped literals of two or more newlines in
   // server/src, and this file is not on its allowlist.
+  // ac-32: the declaration covers all THREE content kinds. Announcing two of
+  // three is the honesty defect issue-2 is about — a reader told "decisions are
+  // shortened" reasonably concludes the tasks are whole.
   if (budget.tier === 1) {
-    lines.push(`Response shape: COMPLETE — every section body and decision is below in full.`);
+    lines.push(`Response shape: COMPLETE — every section body, decision and task is below in full.`);
   } else if (budget.tier === 2) {
-    lines.push(`Response shape: EXCERPTED — decision resolutions are shortened; each carries a ref that returns it in full.`);
+    lines.push(`Response shape: EXCERPTED — resolved decisions and completed tasks are summarised, open ones kept; each carries a ref that returns it in full.`);
   } else {
-    lines.push(`Response shape: SECTION MAP — section bodies are NOT below; fetch one with get_doc on its ref.`);
+    lines.push(`Response shape: SECTION MAP — section bodies are NOT below, and completed tasks are summarised; fetch any part with get_doc on its ref.`);
   }
   // spec-535 dec-3 — the sensitivity warning, LAST in the header and immediately
   // before the content, so it is the final thing read before editing starts. The
@@ -339,7 +353,11 @@ export function formatFullDocState(
 
   // Tasks
   if (tasks.length > 0) {
-    lines.push(formatTaskList(tasks, taskCommentCounts, slugs, doc));
+    lines.push(
+      budget.tier === 1
+        ? tasksFull
+        : formatTaskList(tasks, taskCommentCounts, slugs, doc, budget.tasksBudgetChars),
+    );
     lines.push("");
   }
 
@@ -922,7 +940,12 @@ function formatDecision(
   const source = decisionSourcePill(decision);
   const refLabel = decisionRef(decision, parentDoc);
   const lines = [`- ${refLabel} ${status}${source}: "${decision.title}"`];
-  const budgeted = Number.isFinite(perDecisionChars);
+  // spec-538 dec-8 — status decides. An OPEN decision is the one thing on a
+  // Spec a reader must act on; cutting it as hard as one settled three weeks ago
+  // inverts the rule. dec-5 rejected this shape on a sample where all seven
+  // decisions were resolved, so it cut identically — an argument from one
+  // sample, not from the principle. Amended there.
+  const budgeted = Number.isFinite(perDecisionChars) && decision.status !== "open";
   // The allowance is what this decision may occupy IN TOTAL, so the scaffolding it
   // cannot drop — the headline, the marker, the ref line — is measured first and
   // the resolution gets what is left. Budgeting the resolution alone was the first
@@ -942,7 +965,16 @@ function formatDecision(
     // The marker is the honest half of the excerpt: an agent must be able to tell
     // text was withheld without inferring it from a sentence that stops. The ref
     // line below is the door (spec-538 dec-6 makes it open).
-    if (kept.truncated) lines.push(`  … [shortened — the full resolution is at the ref below]`);
+    // ac-32 — say what was actually removed. The old marker spoke only of the
+    // resolution while context, options and facets were DELETED entirely, and
+    // it said "shortened" even when the allowance was 0 and nothing was shown.
+    if (kept.truncated) {
+      lines.push(
+        kept.text
+          ? `  … [resolution shortened; context and options not shown — the full decision is at the ref below]`
+          : `  … [resolution not shown — the full decision is at the ref below]`,
+      );
+    }
   }
   // Background is dropped rather than shortened once a budget applies. Truncating
   // context AND resolution would spend the same bytes twice on the same decision
@@ -1068,6 +1100,16 @@ function formatTask(
   commentCounts?: { open: number; resolved: number },
   slugs?: FormatterRefContext,
   parentDoc?: Pick<Doc, "docType" | "handle">,
+  // spec-538 dec-8 — how much this task may occupy IN TOTAL. Infinity renders
+  // exactly as before. A finite budget applies the rule:
+  //
+  //   what is finished becomes a summary; what is outstanding stays readable
+  //
+  // so a COMPLETE task collapses to a map (title, status, criteria count, ref)
+  // while an incomplete one keeps its description and its unchecked criteria.
+  // Tasks were the one region the first ladder never counted; measured on
+  // spec-538 they were 33,689 chars — of which 9 complete tasks carried 30,606.
+  budgetChars: number = Number.POSITIVE_INFINITY,
 ): string {
   let statusLabel: string;
   if (t.blocked) {
@@ -1083,23 +1125,78 @@ function formatTask(
 
   const badge = formatCommentBadge(commentCounts);
   const lines = [`- t-${t.seq} [${statusLabel}]: "${t.title}"${badge}`];
-  if (t.description) {
-    lines.push(`  ${t.description}`);
-  }
-  if (t.sectionRef) {
-    lines.push(`  Section: ${t.sectionRef}`);
-  }
-  // spec-445 dec-2 — the task's facet classification, surfaced on retrieval.
-  if (t.facets && t.facets.length > 0) {
-    lines.push(`  Facets: ${t.facets.join(", ")}`);
-  }
+  const budgeted = Number.isFinite(budgetChars);
   const criteria = (t.acceptanceCriteria ?? []) as AcceptanceCriterion[];
-  if (criteria.length > 0) {
-    lines.push(`  Acceptance criteria:`);
-    for (const c of criteria) {
-      lines.push(`    ${c.done ? "[x]" : "[ ]"} ${c.description}`);
+  const checked = criteria.filter((c) => c.done).length;
+  const isComplete = t.status === "complete";
+
+  if (budgeted && isComplete) {
+    // MAP. The work is done; the detail is history, one call away at the ref.
+    if (criteria.length > 0) {
+      lines.push(
+        `  [${criteria.length} acceptance criteria, ${checked} checked · description not included — get_doc on the ref below]`,
+      );
+    } else {
+      lines.push(`  [description not included — get_doc on the ref below]`);
+    }
+  } else if (!budgeted) {
+    if (t.description) lines.push(`  ${t.description}`);
+    if (t.sectionRef) lines.push(`  Section: ${t.sectionRef}`);
+    // spec-445 dec-2 — the task's facet classification, surfaced on retrieval.
+    if (t.facets && t.facets.length > 0) {
+      lines.push(`  Facets: ${t.facets.join(", ")}`);
+    }
+    if (criteria.length > 0) {
+      lines.push(`  Acceptance criteria:`);
+      for (const c of criteria) {
+        lines.push(`    ${c.done ? "[x]" : "[ ]"} ${c.description}`);
+      }
+    }
+  } else {
+    // An OUTSTANDING task under a budget. Everything inside it is bounded —
+    // the first version budgeted only the description and left the criteria
+    // list free, which is a per-item guarantee wearing a budget's clothes:
+    // 6 unchecked criteria x 130 chars x 50 tasks is 39,000 unaccounted chars.
+    // ac-31 exists because that is exactly how this Spec's first bound failed.
+    const overhead = lines[0].length + 220; // ref line + the two markers below
+    const spendable = Math.max(0, budgetChars - overhead);
+
+    // Criteria come first and get the larger share: they are what an agent acts
+    // on, where the description is why. Unchecked ones are listed until the
+    // share runs out; CHECKED ones never list at all, only count.
+    const forCriteria = Math.floor(spendable * 0.6);
+    const unchecked = criteria.filter((c) => !c.done);
+    const shown: string[] = [];
+    let spent = 0;
+    for (const c of unchecked) {
+      const line = `    [ ] ${c.description}`;
+      if (spent + line.length + 1 > forCriteria) break;
+      spent += line.length + 1;
+      shown.push(line);
+    }
+
+    if (t.description) {
+      const kept = excerptFor(t.description, spendable - spent);
+      if (kept.text) lines.push(`  ${kept.text}`);
+      if (kept.truncated) {
+        lines.push(`  … [description shortened — the full task is at the ref below]`);
+      }
+    }
+
+    if (criteria.length > 0) {
+      lines.push(`  Acceptance criteria:`);
+      const hidden = unchecked.length - shown.length;
+      if (checked > 0 || hidden > 0) {
+        const parts: string[] = [];
+        if (checked > 0) parts.push(`${checked} checked`);
+        if (hidden > 0) parts.push(`${hidden} more outstanding`);
+        lines.push(`    [${parts.join(", ")}, not listed — see the ref below]`);
+      }
+      for (const line of shown) lines.push(line);
     }
   }
+
+  // The ref is emitted at every budget — it is what makes a mapped task a door.
   if (parentDoc) {
     const canonical = maybeChildRef(slugs, parentDoc, "tasks", t.seq);
     lines.push(`  ref: ${canonical}`);
@@ -1112,6 +1209,7 @@ function formatTaskList(
   commentCounts?: Map<string, { open: number; resolved: number }>,
   slugs?: FormatterRefContext,
   parentDoc?: Pick<Doc, "docType" | "handle">,
+  perTaskChars: number = Number.POSITIVE_INFINITY,
 ): string {
   const ready = items.filter((t) => !t.blocked && t.status === "not_started");
   const blocked = items.filter((t) => t.blocked);
@@ -1123,8 +1221,69 @@ function formatTaskList(
     `## Tasks (${items.length} total: ${ready.length} ready, ${blocked.length} blocked, ${inProgress.length} in progress, ${complete.length} complete)`
   );
 
-  for (const t of items) {
-    lines.push(formatTask(t, commentCounts?.get(t.id), slugs, parentDoc));
+  // spec-538 dec-8 — a COMPLETE task collapses to a fixed-size map whatever the
+  // allowance, so the negotiable budget belongs entirely to the outstanding
+  // work. Splitting it across all items would starve the tasks a reader is
+  // actually working on to pay for history nobody is reading.
+  const outstanding = items.filter((t) => t.status !== "complete").length;
+  const completeCount = items.length - outstanding;
+
+  // ONE subtraction chain, in order. An earlier version reserved the list-level
+  // costs twice — once here and once at the bound below — so the single
+  // outstanding task no longer fitted in its own list and was dropped whole.
+  const OMISSION_RESERVE = 200;
+  const listReserve = lines[0].length + OMISSION_RESERVE;
+  const available = Number.isFinite(perTaskChars)
+    ? Math.max(0, perTaskChars - listReserve)
+    : Number.POSITIVE_INFINITY;
+
+  // A mapped task costs a fixed floor whatever the allowance. Reserve those
+  // first, then divide what is left among the work still outstanding — the
+  // budget belongs to what someone is doing, not to what is finished.
+  const MAPPED_TASK_COST = 260;
+  const forOutstanding = Number.isFinite(available)
+    ? Math.max(0, available - MAPPED_TASK_COST * completeCount)
+    : Number.POSITIVE_INFINITY;
+  const perOutstanding =
+    Number.isFinite(available) && outstanding > 0
+      ? Math.floor(forOutstanding / outstanding)
+      : forOutstanding;
+
+  const render = (t: TaskWithBlockers & { facets?: string[] }): string =>
+    formatTask(
+      t,
+      commentCounts?.get(t.id),
+      slugs,
+      parentDoc,
+      t.status === "complete" ? perTaskChars : perOutstanding,
+    );
+
+  if (!Number.isFinite(perTaskChars)) {
+    for (const t of items) lines.push(render(t));
+    return lines.join("\n");
+  }
+
+  // Even at a zero allowance a task costs a floor — its headline, its ref, its
+  // criteria count — roughly 200 chars that cannot be dropped. At 200 tasks the
+  // floor ALONE is the whole budget. So the list itself is bounded, exactly as
+  // `list_docs` had to be (dec-5's correction: one line per item is not a bound,
+  // it is a coefficient).
+  //
+  // Outstanding work is rendered first, so when the list must be cut it is the
+  // finished tasks that fall off the end — the same rule as everywhere else.
+  const outstandingFirst = [
+    ...items.filter((t) => t.status !== "complete"),
+    ...items.filter((t) => t.status === "complete"),
+  ];
+  const { kept, omitted } = boundRenderedList(outstandingFirst.map(render), {
+    budgetChars: Math.max(1, available),
+    reservedChars: 0, // already taken out of `available` above
+  });
+  for (const entry of kept) lines.push(entry);
+  if (omitted > 0) {
+    lines.push(
+      `… ${omitted} more task${omitted === 1 ? "" : "s"} not shown — this Spec holds more than one response can carry; fetch one with get_doc on its ref.`,
+    );
   }
 
   return lines.join("\n");

--- a/packages/server/src/formatting/formatters.ts
+++ b/packages/server/src/formatting/formatters.ts
@@ -206,6 +206,17 @@ export function formatFullDocState(
     signalLines.push("");
     signalLines.push(SENSITIVE_WARNING_PROSE.rule);
     signalLines.push(SENSITIVE_WARNING_PROSE.heading);
+    // The relay ask comes SECOND, before the substance, so it frames how the
+    // rest is read rather than arriving after a reader has already decided what
+    // to keep. Added 2026-08-26 from a field report: an agent saw this block and
+    // compressed it to one line that inverted dec-7's ask and dropped both the
+    // discharge condition and the non-blocking promise. Every other line here
+    // speaks to the EDIT; this one speaks to the CHANNEL.
+    //
+    // MCP-only, deliberately: the web banner has no intermediary to relay
+    // through — the human reading it IS the recipient. The two surfaces still
+    // ask the same thing ABOUT THE SPEC, which is what ac-24 requires.
+    signalLines.push(SENSITIVE_WARNING_PROSE.relay);
     signalLines.push(
       doc.sensitiveByName
         ? SENSITIVE_WARNING_PROSE.contact(doc.sensitiveByName)

--- a/packages/server/src/mcp/formatters.flag-survives.spec-538.test.ts
+++ b/packages/server/src/mcp/formatters.flag-survives.spec-538.test.ts
@@ -171,3 +171,34 @@ describe("bounding never became refusing (ac-2, spec-535 ac-3)", () => {
     expect(out).toMatch(/Section #1 \| ref: s-1/);
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The relay ask (2026-08-26, from a field report on spec-533).
+//
+// Deliberately UNTAGGED. spec-535 owns this copy and is `done`, so there is no
+// acceptance criterion claiming this line — inventing a tag to turn a badge
+// green would be the dishonesty this Spec keeps arguing against. The change is
+// recorded on spec-535 issue-4, the open collector for field observations.
+// ─────────────────────────────────────────────────────────────────────────────
+describe("the block asks to be relayed, not just read", () => {
+  it("carries an explicit relay instruction, and it survives every tier", () => {
+    for (const [prose, decs] of [[2_000, 2], [2_000, 12], [90_000, 7]] as const) {
+      const out = formatFullDocState(
+        flaggedSpec(prose, decs),
+        decisions(decs, 8_000),
+        [],
+      );
+      expect(out).toContain("SENSITIVE");
+      expect(out.toLowerCase()).toContain("do not summarise it away");
+    }
+  });
+
+  it("says nothing new on an unflagged Spec", () => {
+    const out = formatFullDocState(
+      { ...flaggedSpec(2_000, 2), sensitive: false, sensitiveByName: null } as never,
+      [],
+      [],
+    );
+    expect(out.toLowerCase()).not.toContain("do not summarise");
+  });
+});

--- a/packages/server/src/mcp/response-budget.tasks.spec-538.test.ts
+++ b/packages/server/src/mcp/response-budget.tasks.spec-538.test.ts
@@ -1,0 +1,265 @@
+// spec-538 t-11 (ac-29, ac-30, ac-31, ac-32) — the tasks block, and the rule
+// that decides what every item keeps.
+//
+// THE GUARD COMES FIRST, and this file is why the discipline matters. ac-4's
+// fixture renders `formatFullDocState(doc, [], [])` — no tasks, ever. So the
+// assertion "a representative large Spec stays under budget" validated a
+// mechanism it could not observe, and the defect shipped past 44 tests and a
+// green CI.
+//
+// std-45 already forbids exactly this: "A vacuity guard must be unfakeable.
+// Assert the precondition the test depends on — that the collection is
+// non-empty — before asserting the thing being claimed." Every test here
+// asserts its fixture is real before asserting what the fixture proves.
+//
+// Measured on prod, 2026-08-26 — spec-538 cannot load itself:
+//   sections 26,449 · decisions 14,347 (bounded) · TASKS 33,689 (unbounded)
+//   · envelope 14,998  =  89,483, refused by the client and spilled.
+// Of the task block, 9 complete tasks carry 30,606 — 91% of it.
+
+import { describe, it, expect } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { formatFullDocState } from "./formatters.js";
+import { RESPONSE_BODY_BUDGET_CHARS } from "./response-budget.js";
+import type { Doc, DocSection, Decision } from "../db/schema.js";
+import type { TaskWithBlockers } from "../services/tasks.js";
+
+const AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-538/acs/ac-${n}`;
+
+const baseDate = new Date("2026-03-25T12:00:00Z");
+
+/** A task the size of a real one on this Spec: ~2,500 chars rendered. */
+function makeTask(
+  seq: number,
+  opts: { complete: boolean; criteria?: number; checked?: number },
+): TaskWithBlockers {
+  const total = opts.criteria ?? 6;
+  const checked = opts.checked ?? (opts.complete ? total : 0);
+  return {
+    id: `task-${seq}`,
+    docId: "d1",
+    seq,
+    title: `Task ${seq} — a title of realistic length for a build-phase Spec`,
+    description: "D".repeat(2_000),
+    status: opts.complete ? "complete" : "not_started",
+    blocked: false,
+    blockedByDecisions: [],
+    blockedByTasks: [],
+    sectionRef: null,
+    acceptanceCriteria: Array.from({ length: total }, (_, i) => ({
+      description: `Criterion ${i + 1}: ${"c".repeat(110)}`,
+      done: i < checked,
+    })),
+    createdAt: baseDate,
+    updatedAt: baseDate,
+    completedAt: opts.complete ? baseDate : null,
+  } as unknown as TaskWithBlockers;
+}
+
+function makeDecision(seq: number, status: "open" | "resolved"): Decision {
+  return {
+    id: `dec-${seq}`,
+    docId: "d1",
+    seq,
+    title: `Decision ${seq}`,
+    status,
+    resolution: status === "resolved" ? "R".repeat(2_000) : null,
+    context: "X".repeat(1_500),
+    createdAt: baseDate,
+    updatedAt: baseDate,
+    resolvedAt: status === "resolved" ? baseDate : null,
+  } as unknown as Decision;
+}
+
+function makeSpec(proseChars: number): Doc & { sections: DocSection[] } {
+  return {
+    id: "d1",
+    memexId: "m1",
+    handle: "spec-1",
+    title: "Task-heavy Spec",
+    docType: "spec",
+    status: "build",
+    createdAt: baseDate,
+    statusChangedAt: baseDate,
+    version: 1,
+    sensitive: false,
+    sensitiveByName: null,
+    checkedOutBy: null,
+    checkedOutAt: null,
+    sections: [
+      {
+        id: "s1",
+        docId: "d1",
+        sectionType: "overview",
+        title: "Overview",
+        content: "P".repeat(proseChars),
+        seq: 1,
+        position: 1,
+        status: "active",
+        createdAt: baseDate,
+        updatedAt: baseDate,
+      } as unknown as DocSection,
+    ],
+  } as unknown as Doc & { sections: DocSection[] };
+}
+
+function render(
+  proseChars: number,
+  decisions: Decision[],
+  tasks: TaskWithBlockers[],
+): string {
+  // formatFullDocState's `tasks` param is TaskWithBlockers[]; the fixture builds
+  // exactly that, so cast through unknown rather than to Task[] (which would
+  // strip the blocker fields the READY/BLOCKED label is derived from).
+  return formatFullDocState(
+    makeSpec(proseChars),
+    decisions,
+    tasks as unknown as Parameters<typeof formatFullDocState>[2],
+  );
+}
+
+/** spec-538's own shape, measured on prod: 26,449 prose · 7 decisions · 10 tasks (9 done). */
+const SPEC_538_PROSE = 26_449;
+const SPEC_538_DECISIONS = Array.from({ length: 7 }, (_, i) =>
+  makeDecision(i + 1, "resolved"),
+);
+const SPEC_538_TASKS = [
+  ...Array.from({ length: 9 }, (_, i) => makeTask(i + 1, { complete: true })),
+  makeTask(10, { complete: false }),
+];
+
+describe("the tasks block is a measured region of the budget (ac-29)", () => {
+  it("the fixture is real — it carries tasks, which is what the old guard did not", () => {
+    tagAc(AC(29));
+    // std-45: assert the precondition before asserting the claim. ac-4's fixture
+    // passed [] here, so its budget assertion was vacuous for this whole region.
+    expect(SPEC_538_TASKS.length).toBe(10);
+    expect(SPEC_538_TASKS.filter((t) => t.status === "complete")).toHaveLength(9);
+    const unbounded = render(SPEC_538_PROSE, SPEC_538_DECISIONS, SPEC_538_TASKS);
+    expect(unbounded.length).toBeGreaterThan(20_000); // there is real weight here
+  });
+
+  it("spec-538's own shape renders under the budget — the Spec that defines the bound loads itself", () => {
+    tagAc(AC(29));
+    const out = render(SPEC_538_PROSE, SPEC_538_DECISIONS, SPEC_538_TASKS);
+    expect(out.length).toBeLessThanOrEqual(RESPONSE_BODY_BUDGET_CHARS);
+  });
+});
+
+describe("status decides what an item keeps (ac-30)", () => {
+  it("a complete task is mapped; an incomplete one keeps its description and checklist", () => {
+    tagAc(AC(30));
+    // Force tier 2 — with two tasks and short prose the doc fits, nothing is
+    // budgeted, and complete/incomplete correctly render alike. The claim is
+    // about what a BUDGET does, so the fixture has to reach one.
+    const out = render(SPEC_538_PROSE, SPEC_538_DECISIONS, [
+      makeTask(1, { complete: true }),
+      makeTask(2, { complete: false }),
+    ]);
+    expect(out).toContain("Response shape: EXCERPTED");
+    // Both are named and reachable…
+    expect(out).toContain("Task 1");
+    expect(out).toContain("Task 2");
+    expect(out).toContain("ref: t-1");
+    expect(out).toContain("ref: t-2");
+    // …but only the incomplete one carries its working detail.
+    const t1 = out.slice(out.indexOf("t-1"), out.indexOf("t-2"));
+    const t2 = out.slice(out.indexOf("t-2"));
+    expect(t2.length).toBeGreaterThan(t1.length * 2);
+  });
+
+  it("more outstanding work means more kept — two Specs identical but for completion state", () => {
+    tagAc(AC(30));
+    const allDone = Array.from({ length: 10 }, (_, i) =>
+      makeTask(i + 1, { complete: true }),
+    );
+    const noneDone = Array.from({ length: 10 }, (_, i) =>
+      makeTask(i + 1, { complete: false }),
+    );
+    const a = render(SPEC_538_PROSE, SPEC_538_DECISIONS, allDone);
+    const b = render(SPEC_538_PROSE, SPEC_538_DECISIONS, noneDone);
+
+    expect(b.length).toBeGreaterThan(a.length);
+    // …and both still fit.
+    expect(a.length).toBeLessThanOrEqual(RESPONSE_BODY_BUDGET_CHARS);
+    expect(b.length).toBeLessThanOrEqual(RESPONSE_BODY_BUDGET_CHARS);
+  });
+
+  it("an OPEN decision is kept where a resolved one is excerpted — the live defect in shipped code", () => {
+    tagAc(AC(30));
+    const decisions = [makeDecision(1, "open"), makeDecision(2, "resolved")];
+    expect(decisions.filter((d) => d.status === "open")).toHaveLength(1);
+
+    const out = render(SPEC_538_PROSE, decisions, SPEC_538_TASKS);
+    // Slice each decision to the NEXT boundary — an earlier version ran the
+    // 'resolved' slice to the end of the document, so it measured the whole
+    // tasks block and reported the open decision as the smaller of the two.
+    const open = out.slice(out.indexOf("Decision 1"), out.indexOf("Decision 2"));
+    const resolved = out.slice(out.indexOf("Decision 2"), out.indexOf("## Tasks"));
+    // The open decision — the one the reader must act on — keeps its context.
+    expect(open).toContain("X".repeat(500));
+    expect(open.length).toBeGreaterThan(resolved.length);
+  });
+});
+
+describe("the bound holds by construction, not by typical sizes (ac-31)", () => {
+  it("fifty incomplete tasks with long checklists still fit — checked criteria collapse to a count", () => {
+    tagAc(AC(31));
+    // "Keep the checklist whole" is a PER-ITEM guarantee, and a per-item
+    // guarantee is not a bound — verbatim dec-1's objection to per-decision
+    // constants. This is the case that proves the fallback exists.
+    const fifty = Array.from({ length: 50 }, (_, i) =>
+      makeTask(i + 1, { complete: false, criteria: 12, checked: 6 }),
+    );
+    expect(fifty).toHaveLength(50);
+
+    const out = render(SPEC_538_PROSE, SPEC_538_DECISIONS, fifty);
+    expect(out.length).toBeLessThanOrEqual(RESPONSE_BODY_BUDGET_CHARS);
+  });
+
+  it("no task count blows the budget", () => {
+    tagAc(AC(31));
+    for (const n of [1, 10, 50, 200, 1_000]) {
+      const tasks = Array.from({ length: n }, (_, i) =>
+        makeTask(i + 1, { complete: false }),
+      );
+      const out = render(SPEC_538_PROSE, SPEC_538_DECISIONS, tasks);
+      expect(out.length, `${n} tasks rendered ${out.length} chars`).toBeLessThanOrEqual(
+        RESPONSE_BODY_BUDGET_CHARS,
+      );
+    }
+  });
+});
+
+describe("every marker names what was actually removed (ac-32)", () => {
+  it("the tier declaration covers tasks, not only decisions and sections", () => {
+    tagAc(AC(32));
+    const out = render(SPEC_538_PROSE, SPEC_538_DECISIONS, SPEC_538_TASKS);
+    const shapeLine = out.match(/^Response shape: .*$/m)?.[0] ?? "";
+    expect(shapeLine).not.toBe("");
+    expect(shapeLine.toLowerCase()).toContain("task");
+  });
+
+  it("a decision whose context was DELETED does not say only 'shortened'", () => {
+    tagAc(AC(32));
+    const out = render(SPEC_538_PROSE, SPEC_538_DECISIONS, SPEC_538_TASKS);
+    // Context is dropped entirely when a budget applies — deliberate (t-3), but
+    // the marker must say so rather than speaking only of the resolution.
+    expect(out).not.toContain("Context: ");
+    const marker = out.match(/… \[[^\]]*\]/)?.[0] ?? "";
+    expect(marker).not.toBe("");
+    expect(marker.toLowerCase()).toMatch(/context|background|omitted|not shown/);
+  });
+
+  it("a decision shown with no excerpt at all does not claim to be 'shortened'", () => {
+    tagAc(AC(32));
+    // Tier 3: prose alone exceeds the budget, so the per-decision allowance is 0
+    // and nothing of the resolution is rendered.
+    const out = render(90_000, SPEC_538_DECISIONS, SPEC_538_TASKS);
+    expect(out).toContain("Response shape:");
+    expect(out).not.toContain("R".repeat(100)); // no resolution text survived
+    const marker = out.match(/… \[[^\]]*\]/)?.[0] ?? "";
+    expect(marker.toLowerCase()).not.toContain("shortened");
+  });
+});

--- a/packages/server/src/mcp/response-budget.test.ts
+++ b/packages/server/src/mcp/response-budget.test.ts
@@ -4,6 +4,7 @@ import { describe, it, expect } from "vitest";
 import { tagAc } from "@memex-ai-ac/vitest";
 import {
   RESPONSE_BODY_BUDGET_CHARS,
+  STRUCTURAL_RESERVE_CHARS,
   MIN_EXCERPT_CHARS,
   allocateResponseBudget,
   effectiveBudget,
@@ -110,8 +111,12 @@ describe("allocateResponseBudget — signals come off the top and are never rati
   it("subtracts signals and the envelope before anything negotiable", () => {
     tagAc(AC(9));
     const a = allocateResponseBudget({ ...SMALL, signalsChars: 1_200 });
+    // spec-538 dec-8 added a THIRD fixed cost: the document's own scaffolding
+    // (title, refs, the tier line, block headers). The intent of this assertion
+    // is unchanged — signals and envelope come off the top before anything
+    // negotiable — but the arithmetic now has three terms, not two.
     expect(a.remainingAfterFixed).toBe(
-      RESPONSE_BODY_BUDGET_CHARS - 1_200 - SMALL.envelopeChars,
+      RESPONSE_BODY_BUDGET_CHARS - 1_200 - SMALL.envelopeChars - STRUCTURAL_RESERVE_CHARS,
     );
   });
 
@@ -132,7 +137,10 @@ describe("allocateResponseBudget — signals come off the top and are never rati
     // after the fixed costs is exactly budget − signals − envelope, whatever
     // the content does.
     expect(a.remainingAfterFixed).toBe(
-      RESPONSE_BODY_BUDGET_CHARS - SMALL.signalsChars - SMALL.envelopeChars,
+      RESPONSE_BODY_BUDGET_CHARS -
+        SMALL.signalsChars -
+        SMALL.envelopeChars -
+        STRUCTURAL_RESERVE_CHARS,
     );
   });
 

--- a/packages/server/src/mcp/response-budget.ts
+++ b/packages/server/src/mcp/response-budget.ts
@@ -103,6 +103,20 @@ export const LARGEST_WORKING_BODY_CHARS = 33_501;
  */
 export const MIN_EXCERPT_CHARS = 200;
 
+/**
+ * The document's own scaffolding, reserved before anything negotiable.
+ *
+ * Title, ref, type, status, checkout, URL, the tier declaration, the block
+ * headers, the blank lines between them. None of it is content and none of it
+ * can be dropped, but the first version budgeted only signals, envelope and
+ * prose — so the shares summed to the budget and the render came out 152–557
+ * chars over it. Small, and still a bound that did not hold.
+ */
+export const STRUCTURAL_RESERVE_CHARS = 2_400;
+
+/** Per-section marker line, emitted at every tier. */
+export const SECTION_MARKER_CHARS = 200;
+
 /** Which shape the render must take. dec-4's ladder, decided by arithmetic. */
 export type ResponseTier = 1 | 2 | 3;
 
@@ -118,6 +132,22 @@ export interface BudgetInput {
   /** How many decisions that cost is spread across. */
   decisionCount: number;
   /**
+   * What the tasks block would cost rendered in full (spec-538 dec-8).
+   *
+   * This region was missing from the first version, and it was the largest
+   * unbudgeted one: 33,689 chars on spec-538 against 14,347 for its bounded
+   * decisions. The Spec that defines the bound could not load itself.
+   */
+  tasksFullChars?: number;
+  /** How many tasks that cost is spread across. */
+  taskCount?: number;
+  /**
+   * How many sections the doc has — used to reserve the per-section marker
+   * lines (`Section #N | ref: … | Type: … | Updated: …`) the render emits
+   * whatever the tier.
+   */
+  sectionCount?: number;
+  /**
    * Optional per-call ceiling. Only the client truly knows its own limit, so
    * accepting one is the theoretically correct shape — but it is never the
    * default: an agent-supplied number is one the agent can omit or get wrong.
@@ -131,6 +161,16 @@ export interface BudgetAllocation {
   /** The ceiling actually applied. */
   budget: number;
   tier: ResponseTier;
+  /**
+   * What the WHOLE tasks block may occupy. `Infinity` renders as before.
+   *
+   * The block's total is passed rather than a per-task figure, because a
+   * per-task figure cannot be multiplied back safely: below MIN_EXCERPT_CHARS
+   * it is floored to 0, and `budget * count` then reads as "no budget", which
+   * `effectiveBudget` treats as "unspecified" and answers with the full
+   * constant. The block owns its own division.
+   */
+  tasksBudgetChars: number;
   /**
    * Characters each decision's resolution may occupy. `0` means headline + ref
    * only — either the floor bit, or tier 3 where there is nothing left to give.
@@ -170,8 +210,12 @@ export function effectiveBudget(maxChars?: number): number {
 export function allocateResponseBudget(input: BudgetInput): BudgetAllocation {
   const budget = effectiveBudget(input.maxChars);
 
-  // 1. Signals and the envelope are fixed costs, taken first.
-  const fixed = input.signalsChars + input.envelopeChars;
+  // 1. Signals, the envelope and the document's own scaffolding are fixed costs.
+  const fixed =
+    input.signalsChars +
+    input.envelopeChars +
+    STRUCTURAL_RESERVE_CHARS +
+    SECTION_MARKER_CHARS * (input.sectionCount ?? 0);
   const remainingAfterFixed = budget - fixed;
 
   // 2. Section prose — what humans wrote.
@@ -186,6 +230,7 @@ export function allocateResponseBudget(input: BudgetInput): BudgetAllocation {
       budget,
       tier: 3,
       perDecisionChars: 0,
+      tasksBudgetChars: 0,
       renderProseBodies: false,
       remainingAfterFixed,
     };
@@ -193,21 +238,36 @@ export function allocateResponseBudget(input: BudgetInput): BudgetAllocation {
 
   // Tier 1: everything fits at full size. Nine Specs in ten are here and their
   // output must not change shape.
-  if (input.decisionsFullChars <= remainingAfterProse) {
+  //
+  // TASKS ARE PART OF "everything" (dec-8). The first version compared only the
+  // decisions block, so a Spec whose tasks blew the budget was still declared
+  // tier 1 or 2 — it announced a bound it did not hold, which is the defect
+  // ac-6 exists to clean up elsewhere in this Spec.
+  const tasksFull = input.tasksFullChars ?? 0;
+  if (input.decisionsFullChars + tasksFull <= remainingAfterProse) {
     return {
       budget,
       tier: 1,
       perDecisionChars: Number.POSITIVE_INFINITY,
+      tasksBudgetChars: Number.POSITIVE_INFINITY,
       renderProseBodies: true,
       remainingAfterFixed,
     };
   }
 
-  // Tier 2: tight. Divide what is left across the decisions.
+  // Tier 2: tight. What is left is shared between the two item blocks in
+  // proportion to how much each would have cost — a Spec that is mostly tasks
+  // spends most of its remainder on tasks, and vice versa. Splitting evenly
+  // would starve whichever block carries the substance.
+  const totalItemWeight = input.decisionsFullChars + tasksFull;
+  const decisionShare =
+    totalItemWeight > 0
+      ? Math.floor((remainingAfterProse * input.decisionsFullChars) / totalItemWeight)
+      : remainingAfterProse;
+  const taskShare = remainingAfterProse - decisionShare;
+
   const derived =
-    input.decisionCount > 0
-      ? Math.floor(remainingAfterProse / input.decisionCount)
-      : 0;
+    input.decisionCount > 0 ? Math.floor(decisionShare / input.decisionCount) : 0;
 
   return {
     budget,
@@ -215,6 +275,7 @@ export function allocateResponseBudget(input: BudgetInput): BudgetAllocation {
     // Below the floor an excerpt is a fragment nobody can act on; fall to
     // headline + ref rather than emit noise that still costs bytes.
     perDecisionChars: derived >= MIN_EXCERPT_CHARS ? derived : 0,
+    tasksBudgetChars: taskShare,
     renderProseBodies: true,
     remainingAfterFixed,
   };

--- a/packages/shared/src/scaffold-data.ts
+++ b/packages/shared/src/scaffold-data.ts
@@ -2540,6 +2540,41 @@ export const SENSITIVE_WARNING_PROSE = {
    *  this MORE load-bearing, not less: without it the honest reading of a
    *  stop-and-ask instruction is "you may not proceed", which is not what this means. */
   advisory: '⚠  Advisory only: this blocks nothing. Every read and write still works.',
+  /**
+   * The RELAY ask — added 2026-08-26 from a field report on spec-533.
+   *
+   * Every other line here asks the reader to do something about the EDIT. This
+   * one asks about the COMMUNICATION, and it exists because the observed failure
+   * was neither invisibility nor disobedience: an agent read the block, saw it,
+   * and compressed it to "parle à Frederic avant toute modif" — one line that
+   * inverted the ask dec-7 had deliberately replaced, and dropped both the
+   * discharge condition and the non-blocking promise.
+   *
+   * Shortening the block would NOT fix that. The agent is not copying the text,
+   * it is writing prose about it, so decoration and length are properties of a
+   * source the summary does not carry. The only thing that acts on a summary is
+   * asking, explicitly, not to summarise.
+   *
+   * HONEST ABOUT ITS FORCE: this is advisory, like everything else here. We emit
+   * the response; we do not control what a third-party agent renders to its user
+   * (the same capability boundary std-34 names for the web/MCP split). It is a
+   * probable improvement, never a guarantee — and unlike "contact someone you
+   * cannot reach", it asks for something the reader can always actually do.
+   *
+   * Three parts, each load-bearing:
+   *   RELAY:        a label, because every other line here speaks to the EDIT
+   *                 and this one speaks to the CHANNEL — the register shift has
+   *                 to be visible at a glance.
+   *   before you    a timing trigger. "Show this block" with no moment attached
+   *   continue      is a instruction that can always be deferred, which is the
+   *                 same hole dec-7 closed at the other end with a discharge
+   *                 condition.
+   *   the person    names the recipient, so the ask stays executable — dec-7's
+   *   you are       whole correction was that an unnameable target makes
+   *   working with  rationalising it away the path of least resistance.
+   */
+  relay:
+    '⚠  RELAY: before you continue, show this block as written to the person you are working with — do not summarise it away.',
 };
 
 export const BUILD_AC_NAG_PROSE = {


### PR DESCRIPTION
Two changes, both found by verifying against production rather than the diff.

| | |
|---|---|
| `f5d91e69` | **spec-538 t-11** — bound the tasks block; status decides what every item keeps (#638) |
| `119f3c35` | **spec-535** — the sensitivity block asks to be relayed, not just read (#639) |

**No migration.** `0133` shipped in the previous release; this is code-only.

## Why

**spec-538 could not load itself.** After the last release, reloading it on prod returned 89,483 chars and spilled — while announcing `Response shape: EXCERPTED`. It declared a bound it did not hold.

```
sections 26,449 · decisions 14,347 (bounded ✓) · TASKS 33,689 (never measured) · envelope 14,998
```

The tasks block was the one region the ladder never counted, and 9 complete tasks carried 91% of it. `ac-4`'s fixture passed `[]` for tasks, so the guard could not see the region it was meant to bound — the failure class this Spec exists to remove, committed by its own guard, and the thing `std-45` forbids in as many words.

**spec-535's warning survived but its relay did not.** An agent read spec-533, saw the block, and compressed it to one line that inverted `dec-7`'s ask and dropped both the discharge condition and the non-blocking promise. Decoration and length are properties of a source a summary does not carry — so the block now asks about the *channel*, not only the *edit*.

## What lands

**Tasks + decisions, one rule** — *what is finished becomes a summary; what is outstanding stays readable.* Complete tasks map, incomplete keep description + unchecked criteria, checked criteria collapse to a count. **Open decisions are now kept where resolved ones are excerpted** — correcting a live defect where the one thing a reader must act on was cut as hard as one settled weeks ago.

**Markers stop lying** — `"shortened"` was printed when context, options and facets had been *deleted*, and again when nothing was shown at all. The tier line now covers all three content kinds.

**The relay ask** — `⚠ RELAY: before you continue, show this block as written to the person you are working with — do not summarise it away.`

## Verification

Full server suite **6,396 passed / 677 files, zero failures**. Both PRs merged with **23 green checks** each, including `e2e` and `migration-applier`. `make check` and `make typecheck` clean.

**int deployed `119f3c35` successfully at 10:52 UTC** (run on `develop`), so the prod gate's int-before-prod condition is met.

## What to check after the deploy

`get_doc(spec-538, verbose)` must arrive **inline**. Today on prod it returns 100,593 chars and spills. Expected ≈60,000 against a measured 70,794 cap.

That is `ac-29`, and it is the honest acceptance test: **the Spec that defines the bound must be able to load itself.** A synthetic fixture is not a substitute — this whole issue exists because one could not see what production does.

Also visible: spec-533's block should carry the new `RELAY:` line.

## Known and recorded

- **spec-538 `ac-19` ships unverified**, deliberately — the ceiling-beats-cadence contract with spec-510 has no cadence to yield to yet (spec-510: build, 11 tasks, 0 complete). `t-9` stays open with its unblocking condition.
- **spec-542** was raised today from a separate user report: an agent cannot tell a code-grounded Spec from an ungrounded one. Not in this release.

Merged as a **merge commit** per std-21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)