### PR TITLE
feat(spec-520): keep the counts instead of re-deriving them from rows we delete (t-9)

### DIFF
--- a/packages/server/drizzle/0134_spec520_test_run_daily_rollup.sql
+++ b/packages/server/drizzle/0134_spec520_test_run_daily_rollup.sql
@@ -1,0 +1,95 @@
+-- spec-520 t-9 (dec-5, ac-21/ac-26) — the per-day test-run rollup.
+--
+-- WHY A NEW TABLE AND NOT A BETTER QUERY. The two history consumers
+-- (testRunVolume, listAcAlignmentOverTime) read raw `test_events`, which the
+-- retention trim caps at RETENTION_KEEP=10 rows per (subject_ref,
+-- test_identifier) pair. So they count rows that were already deleted. Measured
+-- on prod 2026-08-18: the summary tier declares 23,718,476 runs while 1,072,186
+-- raw rows survive — the charts see 4.5%. And the loss is NOT uniform: 65,708
+-- pairs sit at exactly 10 surviving rows, the trim's ceiling made visible, so
+-- the busier an AC the shorter its visible history. A "test run volume over
+-- time" chart that under-counts hardest where there is most activity inverts the
+-- story it exists to tell. No index fixes that; the rows are gone.
+--
+-- THE GRAIN, DECLARED (dec-5, spec-125's rule): one row per test, per subject,
+-- per UTC day, carrying how many times it ran and how many times it passed,
+-- failed or errored. The finest of three candidate grains, chosen because
+-- compression is already large at this grain and it is the only one that
+-- preserves WHICH test went red and lets AC-green be derived properly.
+--
+-- THIS RETIRES TWO WRITES RATHER THAN ADDING A THIRD. Counting at write time
+-- makes the per-pair count retention unnecessary (t-12 deletes the trim, 12.6%
+-- of all DB time) and makes ac_first_verified redundant (t-10 folds it in, 6.1%)
+-- — that table exists ONLY because retention destroyed the first-green date, the
+-- same lesson this Spec is now learning once instead of per-metric. Net: fewer
+-- statements per emission than today, and no delete churn at all.
+--
+-- memex_id IS FIRST-CLASS [per std-32], stamped at write, never parsed back out
+-- of subject_ref at read time. That parse is the spec-396 leak pattern — a real
+-- cross-org bleed of ~1.5M rows across 137 memexes — and it is also why
+-- ac_first_verified (subject_ref PK, no tenancy column) can never carry an RLS
+-- policy. Folding it into a table that does is a security gain of dec-5, not a
+-- side effect.
+--
+-- NO INDEX ON THE COUNT COLUMNS, deliberately [per std-39 cl-7]. These are hot
+-- counter rows: at ~227k events/day across this key, roughly ten updates per row
+-- per day. HOT updates apply only while no indexed column changes, so an index
+-- on a count would make every increment write an index tuple too and hand
+-- autovacuum the dead tuples to chase. If a chart needs speed, aggregate on the
+-- key columns — do not index a counter.
+--
+-- THE CHECK IS A WIRING TRIPWIRE, not a business rule. Every emission
+-- increments run_count and exactly one outcome count, so run_count = pass + fail
+-- + error is an invariant of correct code. A violation means the increment logic
+-- is wrong, and the CHECK says so on the first bad write instead of in a chart
+-- weeks later. A CHECK is not an index, so HOT still applies.
+--
+-- ⚠ NO ROW LEVEL SECURITY IN THIS MIGRATION, AND THAT IS NOT AN OVERSIGHT.
+-- std-36 requires an ENABLE + memex_id isolation policy on every tenancy-scoped
+-- table, and t-9 ac-3 demands it. It is deliberately deferred to a follow-up
+-- migration gated on spec-520 issue-8, because the prerequisite is missing:
+--
+--   `routes/test-events.ts` opens its write transaction (the db.transaction
+--   inside mutate(), around :492) with NO runWithMemexId on the async stack —
+--   runWithMemexId appears exactly once in that file, at :563, around the
+--   auto-resolve READ only. mutate() itself establishes no tenant context.
+--
+-- Every tenant policy in this directory carries an explicit
+-- `nullif(current_setting('app.memex_id', true), '') IS NOT NULL` conjunct,
+-- which makes the predicate FALSE (not NULL) when the GUC is unset. For SELECT
+-- and UPDATE that filters to zero rows — silent. For INSERT it raises "new row
+-- violates row-level security policy" — a hard error, inside the same
+-- transaction as the test_events insert, which mutate() rethrows. So enabling
+-- RLS here before the write is wrapped would 500 EVERY emission in production
+-- while dev and CI stayed green, because the owner role bypasses RLS
+-- (std-36: ENABLE, never FORCE).
+--
+-- Do not add the policy to this file. Close issue-8 first.
+--
+-- LOCK ORDER. The rollup upsert is taken immediately after the
+-- test_event_latest upsert and before the retention trim, i.e. the same relative
+-- position on every emission. Restructuring a continuously-written table in this
+-- path is what deadlocked and rolled back a prod deploy during spec-398
+-- (std-39 cl-9), and a consistent order is what prevents the repeat. CREATE
+-- TABLE takes no lock on anything the emission path touches, so this migration
+-- itself is not the risky one — t-12's partitioning is.
+
+CREATE TABLE IF NOT EXISTS test_run_daily (
+  memex_id        uuid    NOT NULL,
+  subject_ref     text    NOT NULL,
+  test_identifier text    NOT NULL DEFAULT '',
+  day             date    NOT NULL,
+  run_count       integer NOT NULL DEFAULT 0,
+  pass_count      integer NOT NULL DEFAULT 0,
+  fail_count      integer NOT NULL DEFAULT 0,
+  error_count     integer NOT NULL DEFAULT 0,
+  CONSTRAINT test_run_daily_pkey
+    PRIMARY KEY (memex_id, subject_ref, test_identifier, day),
+  CONSTRAINT test_run_daily_counts_sum
+    CHECK (run_count = pass_count + fail_count + error_count)
+);
+
+-- The PK covers (memex_id, subject_ref, test_identifier, day), so a per-tenant
+-- day-range scan — what both history charts do — rides its leading columns.
+-- No further index is added: none is needed for the known consumers, and every
+-- extra index is another tuple written on each of ~227k daily increments.

--- a/packages/server/drizzle/0135_spec520_test_run_daily_rls.sql
+++ b/packages/server/drizzle/0135_spec520_test_run_daily_rls.sql
@@ -1,0 +1,52 @@
+-- spec-520 t-9 (ac-22) + issue-8 — row-level security on the per-day rollup.
+--
+-- SPLIT FROM 0134 DELIBERATELY, and the split is the point. 0134 created the
+-- table and explicitly did NOT enable RLS, because at that moment the emission
+-- path could not have satisfied a policy: `routes/test-events.ts` opened its
+-- write transaction with no `runWithMemexId` on the async stack, and `mutate()`
+-- establishes none. This migration ships in the SAME change as the wrap that
+-- fixes that (s-2 Trap 2: "before or WITH the RLS migration, never after").
+--
+-- WHY THAT ORDER IS NOT PEDANTRY. Every tenant policy in this directory carries
+-- an explicit `nullif(current_setting('app.memex_id', true), '') IS NOT NULL`
+-- conjunct, which makes the predicate FALSE — not NULL — when the GUC is unset.
+-- For SELECT and UPDATE that filters to zero rows, silently. For INSERT it
+-- raises "new row violates row-level security policy". The rollup write is an
+-- upsert, so it takes the INSERT path, inside the same transaction as the
+-- test_events insert, which mutate() rethrows. RLS here without the wrap does
+-- not lose rollup rows quietly — it 500s EVERY emission in production, while dev
+-- and CI stay green because the owner role bypasses RLS.
+--
+-- That is not a prediction: `test-events-tenant-context.rls-restricted.test.ts`
+-- drove it red→green under the real `memex_app` role. Red = the emission POST
+-- returns 500 with this migration applied and the wrap absent.
+--
+-- ENABLE, NEVER FORCE [per std-36]. FORCE would apply RLS to the table OWNER
+-- too, and on Cloud SQL the migration/deploy role is `postgres`, which is not a
+-- real superuser and lacks BYPASSRLS — under FORCE every migration and admin
+-- query against this table would be filtered to nothing. 0081 shipped FORCE and
+-- 0093 had to undo it; std-36 exists because of that incident. The dynamic guard
+-- in db/spec-199-rls-schema.test.ts fails CI on any forced tenant table.
+--
+-- The policy predicate is byte-identical to every other tenant table's on
+-- purpose. A table whose isolation reads differently is a table someone has to
+-- reason about separately, and this one has no reason to be special.
+
+ALTER TABLE test_run_daily ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS test_run_daily_memex_isolation ON test_run_daily;
+CREATE POLICY test_run_daily_memex_isolation ON test_run_daily
+  USING (
+    nullif(current_setting('app.memex_id', true), '') IS NOT NULL
+    AND memex_id = current_setting('app.memex_id', true)::uuid
+  )
+  WITH CHECK (
+    nullif(current_setting('app.memex_id', true), '') IS NOT NULL
+    AND memex_id = current_setting('app.memex_id', true)::uuid
+  );
+
+-- The schema-wide DEFAULT PRIVILEGES from 0081 should already cover a new table,
+-- but state it explicitly rather than relying on a default set four years of
+-- migrations ago: a missing grant here fails as "permission denied for table",
+-- which reads like an RLS problem and is not one.
+GRANT SELECT, INSERT, UPDATE, DELETE ON test_run_daily TO memex_app;

--- a/packages/server/src/__regression__/mutate-coverage.static-scan.regression.test.ts
+++ b/packages/server/src/__regression__/mutate-coverage.static-scan.regression.test.ts
@@ -88,6 +88,20 @@ const ALLOWLIST: Record<string, string> = {
   // log with no bus entity of its own.
   "services/test-event-latest.ts":
     "tx-helper indirection (spec-162) — applyEmissionToSummary / removeSummaryForPair write test_event_latest only inside callers' mutate() callbacks (routes/test-events.ts, services/acs.ts discontinueTestEventsForAc); both public write paths return through mutate().",
+  // spec-520 t-9 — the per-day rollup's upsert. Exactly the category above, and
+  // deliberately so: applyEmissionToRollup takes the caller's `conn` and is
+  // invoked ONLY from inside routes/test-events.ts's mutate() callback, in the
+  // same db.transaction as the test_events insert and the test_event_latest
+  // upsert. The callback-scoped heuristic (ac-24) cannot follow that indirection.
+  //
+  // It must NOT get its own mutate() call to satisfy the scan literally: the
+  // enclosing mutate() already emits exactly one `test_event.created` frame per
+  // emission, and a second wrapper would DOUBLE the SSE frames every emission
+  // puts on the bus — every AC-health surface that refetches on that frame would
+  // then refetch twice. Same reason test-event-latest.ts is allowlisted rather
+  // than wrapped.
+  "services/test-run-daily.ts":
+    "tx-helper indirection (spec-520 t-9) — applyEmissionToRollup writes test_run_daily only inside routes/test-events.ts's mutate() callback, in the same transaction as the log insert and the test_event_latest upsert; the public write path returns through mutate(). Append-only counter tier with no SSE doc-entity of its own — the enclosing test_event.created frame IS its change signal, and a second emission would double it.",
   // spec-177 issue-1 — findOrCreatePersonalMemex is a tx-helper invoked ONLY from
   // inside ensureUserNamespace's mutate() callbacks (both the ownership-repair
   // branch and the create branch). It race-safely find-or-creates the "personal"

--- a/packages/server/src/__regression__/test-events-namespace-guard.regression.test.ts
+++ b/packages/server/src/__regression__/test-events-namespace-guard.regression.test.ts
@@ -27,6 +27,16 @@ const insertSpy = vi.fn().mockReturnValue({
 });
 
 vi.mock("../db/connection.js", () => ({
+  // spec-520 issue-8: the route now wraps its WRITE transaction in runWithMemexId, not
+  // just the auto-resolve read. Mocking db/connection.js means mocking this too — a
+  // pass-through, since these suites assert request/response shaping; the real tenant
+  // context is exercised under the restricted role in
+  // test-events-tenant-context.rls-restricted.test.ts.
+  //
+  // Its absence used to be survivable only because the single call site sat inside a
+  // try/catch that swallowed the TypeError. It no longer is: the wrap is now around the
+  // write, so a missing stub aborts the emission and every POST here returns 500.
+  runWithMemexId: (_memexId: string | null | undefined, fn: () => unknown) => fn(),
   db: {
     insert: () => insertSpy(),
     transaction: (cb: (tx: { insert: () => unknown }) => unknown) =>
@@ -43,6 +53,18 @@ vi.mock("../services/test-event-latest.js", () => ({
 vi.mock("../services/test-event-retention.js", () => ({
   trimTestEventsForPair: vi.fn().mockResolvedValue(undefined),
   recordFirstVerified: vi.fn().mockResolvedValue(undefined),
+}));
+
+// spec-520 t-9: the per-day rollup upsert runs inside the same transaction as
+// the log insert, so it needs the same no-op stub as the two mocks above — the
+// mocked tx here only stubs .insert, and the real upsert chain
+// (.values().onConflictDoUpdate()) would throw against it. That throw does NOT
+// present as a missing mock: it aborts the transaction and every POST in this
+// file returns 500, so the assertions fail on status codes and absent headers
+// instead. The upsert's real arithmetic is covered against a real DB in
+// services/test-run-daily.integration.test.ts.
+vi.mock("../services/test-run-daily.js", () => ({
+  applyEmissionToRollup: vi.fn().mockResolvedValue(undefined),
 }));
 
 // Mutate() is exercised here only as a pass-through wrapper around the insert.

--- a/packages/server/src/db/rls-tables.ts
+++ b/packages/server/src/db/rls-tables.ts
@@ -41,6 +41,12 @@ export const RLS_TENANT_TABLES: ReadonlySet<string> = new Set([
   "tags",
   "task_facet_ballots",
   "tasks",
+  // spec-520 t-9 / issue-8 — the per-day test-run rollup, gated by migration 0135.
+  // The FIRST RLS-gated table written from the ingest path, which is why that path's
+  // write transaction had to be wrapped in runWithMemexId in the same change: until
+  // this table existed there was no policy a context-less emission write could fail.
+  // Listing it here also arms spec-440's context guard for it.
+  "test_run_daily",
 ]);
 
 /** True iff `table` is one of the RLS-gated tenant tables (case-insensitive). */

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -1,4 +1,4 @@
-import { pgTable, text, uuid, timestamp, integer, unique, uniqueIndex, check, primaryKey, jsonb, boolean, index, customType, doublePrecision, type AnyPgColumn } from "drizzle-orm/pg-core";
+import { pgTable, text, uuid, timestamp, integer, unique, uniqueIndex, check, primaryKey, jsonb, boolean, index, customType, doublePrecision, date, type AnyPgColumn } from "drizzle-orm/pg-core";
 import { relations, type InferSelectModel, type InferInsertModel, sql } from "drizzle-orm";
 import type { CommentAction, CommentAudience } from "../types/roles.js";
 
@@ -1139,6 +1139,74 @@ export const acFirstVerified = pgTable("ac_first_verified", {
   subjectRef: text("subject_ref").primaryKey(),
   firstVerifiedAt: timestamp("first_verified_at", { withTimezone: true }).notNull(),
 });
+
+// ══════════════════════════════════════
+// Per-day test-run rollup (spec-520 dec-5 / t-9)
+// ══════════════════════════════════════
+//
+// The durable, analytical tier for the test-event firehose — spec-125's grain
+// rule applied to it: declare the grain, then keep the counts instead of
+// re-deriving them from rows we delete.
+//
+// Grain: one row per test, per subject, per UTC day.
+//
+// This exists because the history we believed we had did not exist. Retention
+// trims raw `test_events` to a per-pair cap, so `testRunVolume` and
+// `listAcAlignmentOverTime` counted rows that had already been deleted — and
+// hardest for the busiest ACs, which are exactly the pairs that hit the cap.
+// `ac_first_verified` is the same lesson learned once already and patched
+// per-metric: it exists ONLY because retention destroyed the first-green date.
+//
+// Two properties are load-bearing and easy to break:
+//
+//   1. `memexId` is FIRST-CLASS and stamped at write [per std-32] — never
+//      parsed back out of `subject_ref` at read time. That parse is the
+//      spec-396 leak pattern (a real cross-org bleed, ~1.5M rows across 137
+//      memexes) this Spec is closing elsewhere. It is also what makes the table
+//      RLS-able, which `ac_first_verified` — `subject_ref` PK, no tenancy
+//      column — structurally is not.
+//
+//   2. The count columns carry NO INDEX, deliberately [per std-39 cl-7]. These
+//      are hot counter rows; an index on a count column defeats HOT updates and
+//      every increment would then also write an index tuple. Do not add one to
+//      make a chart faster — aggregate on the key columns instead.
+//
+// The CHECK is the wiring invariant: run_count must equal the three outcome
+// counts summed. Each emission increments `run` and exactly one outcome, so a
+// violation means the increment logic is wrong, and it says so on the first
+// write rather than in a chart weeks later. A CHECK is not an index, so HOT
+// still applies.
+//
+// NOTE: RLS is NOT enabled here yet. std-36 requires it for a tenancy-scoped
+// table, and t-9 ac-3 demands it — but issue-8 must close first: the emission
+// WRITE transaction (`routes/test-events.ts`, the `db.transaction` inside
+// `mutate()`) does not run inside `runWithMemexId`, so a policy on this table
+// would be unsatisfiable at write time and every emission would fail in prod
+// while dev and CI stayed green (the owner role bypasses RLS). See issue-8.
+export const testRunDaily = pgTable(
+  "test_run_daily",
+  {
+    memexId: uuid("memex_id").notNull(),
+    subjectRef: text("subject_ref").notNull(),
+    testIdentifier: text("test_identifier").notNull().default(""),
+    // UTC calendar day the runs fall on. Derived from the event's own
+    // created_at, never from the server's local clock.
+    day: date("day").notNull(),
+    runCount: integer("run_count").notNull().default(0),
+    passCount: integer("pass_count").notNull().default(0),
+    failCount: integer("fail_count").notNull().default(0),
+    errorCount: integer("error_count").notNull().default(0),
+  },
+  (table) => [
+    primaryKey({
+      columns: [table.memexId, table.subjectRef, table.testIdentifier, table.day],
+    }),
+    check(
+      "test_run_daily_counts_sum",
+      sql`${table.runCount} = ${table.passCount} + ${table.failCount} + ${table.errorCount}`,
+    ),
+  ]
+);
 
 // ══════════════════════════════════════
 // Document versioning (spec-448 t-1)

--- a/packages/server/src/routes/spec-533-ingest-ratio.test.ts
+++ b/packages/server/src/routes/spec-533-ingest-ratio.test.ts
@@ -40,6 +40,16 @@ const transactionSpy = vi.fn();
 const selectSpy = vi.fn();
 
 vi.mock("../db/connection.js", () => ({
+  // spec-520 issue-8: the route now wraps its WRITE transaction in runWithMemexId, not
+  // just the auto-resolve read. Mocking db/connection.js means mocking this too — a
+  // pass-through, since these suites assert request/response shaping; the real tenant
+  // context is exercised under the restricted role in
+  // test-events-tenant-context.rls-restricted.test.ts.
+  //
+  // Its absence used to be survivable only because the single call site sat inside a
+  // try/catch that swallowed the TypeError. It no longer is: the wrap is now around the
+  // write, so a missing stub aborts the emission and every POST here returns 500.
+  runWithMemexId: (_memexId: string | null | undefined, fn: () => unknown) => fn(),
   db: {
     insert: () => insertSpy(),
     select: (...args: unknown[]) => selectSpy(...args),
@@ -57,6 +67,36 @@ vi.mock("../services/test-event-latest.js", () => ({
 vi.mock("../services/test-event-retention.js", () => ({
   trimTestEventsForPair: vi.fn().mockResolvedValue(undefined),
   recordFirstVerified: vi.fn().mockResolvedValue(undefined),
+}));
+
+// spec-520 t-9: the per-day rollup upsert runs inside the same transaction as
+// the log insert, so it needs the same no-op stub as the two mocks above — the
+// mocked tx here only stubs .insert, and the real upsert chain
+// (.values().onConflictDoUpdate()) would throw against it. That throw does NOT
+// present as a missing mock: it aborts the transaction and every POST in this
+// file returns 500, so the assertions fail on status codes and absent headers
+// instead. The upsert's real arithmetic is covered against a real DB in
+// services/test-run-daily.integration.test.ts.
+// spec-520 issue-8 — REQUIRED for this file's per-event cost assertions to mean anything.
+//
+// This file's ac-19 / ac-4 guards assert that spec-533's OWN code adds no SELECT and no
+// extra transaction per event. They were passing for an accidental reason: the route's
+// auto-resolve call is wrapped in runWithMemexId, this file mocks db/connection.js
+// WITHOUT that export, so the call threw a TypeError which the route's deliberate
+// best-effort try/catch swallowed — the auto-resolve chain never ran here at all.
+//
+// Stubbing runWithMemexId (above) made the mock honest and the chain started running,
+// at which point these guards correctly reported a per-event SELECT — the
+// `documents ⋈ memexes ⋈ namespaces` lookup at services/issues.js:554. That cost is
+// real in production and it belongs to spec-520 t-15, NOT to spec-533. Stub it here so
+// these assertions measure the thing they name, exactly as
+// test-events-namespace-guard.regression.test.ts already does.
+vi.mock("../services/issues.js", () => ({
+  maybeAutoResolveIssuesForAcUid: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../services/test-run-daily.js", () => ({
+  applyEmissionToRollup: vi.fn().mockResolvedValue(undefined),
 }));
 
 // Literals are inlined below rather than referenced: vi.mock factories are

--- a/packages/server/src/routes/spec-533-staleness-advisory.test.ts
+++ b/packages/server/src/routes/spec-533-staleness-advisory.test.ts
@@ -35,6 +35,16 @@ const transactionSpy = vi.fn();
 const selectSpy = vi.fn();
 
 vi.mock("../db/connection.js", () => ({
+  // spec-520 issue-8: the route now wraps its WRITE transaction in runWithMemexId, not
+  // just the auto-resolve read. Mocking db/connection.js means mocking this too — a
+  // pass-through, since these suites assert request/response shaping; the real tenant
+  // context is exercised under the restricted role in
+  // test-events-tenant-context.rls-restricted.test.ts.
+  //
+  // Its absence used to be survivable only because the single call site sat inside a
+  // try/catch that swallowed the TypeError. It no longer is: the wrap is now around the
+  // write, so a missing stub aborts the emission and every POST here returns 500.
+  runWithMemexId: (_memexId: string | null | undefined, fn: () => unknown) => fn(),
   db: {
     insert: () => insertSpy(),
     select: (...args: unknown[]) => selectSpy(...args),
@@ -52,6 +62,36 @@ vi.mock("../services/test-event-latest.js", () => ({
 vi.mock("../services/test-event-retention.js", () => ({
   trimTestEventsForPair: vi.fn().mockResolvedValue(undefined),
   recordFirstVerified: vi.fn().mockResolvedValue(undefined),
+}));
+
+// spec-520 t-9: the per-day rollup upsert runs inside the same transaction as
+// the log insert, so it needs the same no-op stub as the two mocks above — the
+// mocked tx here only stubs .insert, and the real upsert chain
+// (.values().onConflictDoUpdate()) would throw against it. That throw does NOT
+// present as a missing mock: it aborts the transaction and every POST in this
+// file returns 500, so the assertions fail on status codes and absent headers
+// instead. The upsert's real arithmetic is covered against a real DB in
+// services/test-run-daily.integration.test.ts.
+// spec-520 issue-8 — REQUIRED for this file's per-event cost assertions to mean anything.
+//
+// This file's ac-19 / ac-4 guards assert that spec-533's OWN code adds no SELECT and no
+// extra transaction per event. They were passing for an accidental reason: the route's
+// auto-resolve call is wrapped in runWithMemexId, this file mocks db/connection.js
+// WITHOUT that export, so the call threw a TypeError which the route's deliberate
+// best-effort try/catch swallowed — the auto-resolve chain never ran here at all.
+//
+// Stubbing runWithMemexId (above) made the mock honest and the chain started running,
+// at which point these guards correctly reported a per-event SELECT — the
+// `documents ⋈ memexes ⋈ namespaces` lookup at services/issues.js:554. That cost is
+// real in production and it belongs to spec-520 t-15, NOT to spec-533. Stub it here so
+// these assertions measure the thing they name, exactly as
+// test-events-namespace-guard.regression.test.ts already does.
+vi.mock("../services/issues.js", () => ({
+  maybeAutoResolveIssuesForAcUid: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../services/test-run-daily.js", () => ({
+  applyEmissionToRollup: vi.fn().mockResolvedValue(undefined),
 }));
 
 // Literals inlined: vi.mock factories hoist above every const in the file.

--- a/packages/server/src/routes/test-events-tenant-context.rls-restricted.test.ts
+++ b/packages/server/src/routes/test-events-tenant-context.rls-restricted.test.ts
@@ -37,6 +37,7 @@ import {
   taskSatisfiesAc,
   tasks,
   testEvents,
+  testRunDaily,
   users,
 } from "../db/schema.js";
 import { upsertUserByEmail } from "../services/users.js";
@@ -47,6 +48,10 @@ import { maybeAutoResolveIssuesForAcUid } from "../services/issues.js";
 import { app } from "../app.js";
 
 const AC_TENANT_CONTEXT = "mindset-prod/memex-building-itself/specs/spec-520/acs/ac-32";
+// ac-22 is the ROLLUP's own claim: RLS enabled + not forced + a memex_id policy that an
+// emission write actually satisfies, proven under this harness. Distinct from ac-32, which
+// is the handler establishing context for its READS. The WRITE block below carries ac-22.
+const AC_ROLLUP_RLS = "mindset-prod/memex-building-itself/specs/spec-520/acs/ac-22";
 
 const runId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 
@@ -151,6 +156,7 @@ beforeAll(async () => {
 afterAll(async () => {
   await runWithMemexId(memexId, async () => {
     await db.delete(testEvents).where(eq(testEvents.subjectRef, acRef)).catch(() => {});
+    await db.delete(testRunDaily).where(eq(testRunDaily.subjectRef, acRef)).catch(() => {});
     if (issueId) await db.delete(issues).where(eq(issues.id, issueId)).catch(() => {});
     if (taskId) await db.delete(tasks).where(eq(tasks.id, taskId)).catch(() => {});
     if (acId) await db.delete(acs).where(eq(acs.id, acId)).catch(() => {});
@@ -245,5 +251,121 @@ describe("spec-520 ac-32: the FIX — the ROUTE establishes the context", () => 
         .limit(1),
     );
     expect(latest?.status).toBe("pass");
+  });
+});
+
+describe("spec-520 ac-22 / issue-8: the WRITE half — an RLS-gated write inside the transaction", () => {
+  // ac-32 (above) closed the READ half: the auto-resolve chain now runs in context. This
+  // block closes the WRITE half, and the two are genuinely different failures.
+  //
+  // WHY THIS EXISTS AS A SEPARATE BLOCK. t-7 wrapped only the auto-resolve call, and that
+  // was the right scope at the time — the write transaction touched no RLS-gated table, so
+  // there was no policy for it to fail. t-9's rollup is the first one, which is what turned
+  // a latent gap into a blocker (issue-8).
+  //
+  // THE FAILURE THIS PINS IS NOT SILENT, unlike the read half. Every tenant policy here
+  // carries an explicit `IS NOT NULL` conjunct, so an unset `app.memex_id` makes the
+  // predicate FALSE rather than NULL. For SELECT/UPDATE that filters to nothing — quiet.
+  // For INSERT it RAISES. The rollup write is an upsert inside the same transaction as the
+  // test_events insert, and mutate() rethrows, so the whole emission fails: this test went
+  // red as a 500 on POST /api/test-events, not as a missing rollup row.
+  //
+  // And it can ONLY go red here. Under the owner role the policy is bypassed entirely
+  // (std-36: ENABLE, never FORCE), so the default suite returns 201 either way — 6409 tests
+  // passed against the unwrapped write. That is the whole reason this file exists.
+  it("a passing emission lands its rollup row — the write ran inside tenant context", async () => {
+    tagAc(AC_ROLLUP_RLS);
+    tagAc(AC_TENANT_CONTEXT);
+
+    // Scope every assertion to THIS test's own test_identifier. The ac-32 block above
+    // already POSTed an emission for the same ref on the same UTC day, but under
+    // `spec520-t7::route` — and test_identifier is part of the rollup key, so that is a
+    // DIFFERENT row. Filtering only by (subject_ref, memex_id) returns both, which is the
+    // grain working correctly and an assertion of `toHaveLength(1)` being wrong.
+    const TEST_ID = "spec520-t9::rollup-under-rls";
+
+    const res = await app.request("/api/test-events", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${emissionKey}`,
+      },
+      body: JSON.stringify({
+        ac_uid: acRef,
+        status: "pass",
+        test_identifier: TEST_ID,
+        duration_ms: 1,
+      }),
+    });
+
+    // 201, not 500. Without the wrap the rollup's WITH CHECK fails, the transaction aborts,
+    // and this is a 500 — the event itself never lands either, which is the part that makes
+    // the missing wrap an ingest outage rather than a lost metric. Verified: with migration
+    // 0135 applied and the wrap absent, this returned 500 and so did ac-32's route test
+    // above, because the transaction dies before the auto-resolve is even reached.
+    expect(res.status).toBe(201);
+
+    const after = await runWithMemexId(memexId, async () =>
+      db
+        .select({ runCount: testRunDaily.runCount, passCount: testRunDaily.passCount })
+        .from(testRunDaily)
+        .where(
+          and(
+            eq(testRunDaily.subjectRef, acRef),
+            eq(testRunDaily.memexId, memexId),
+            eq(testRunDaily.testIdentifier, TEST_ID),
+          ),
+        ),
+    );
+    expect(after).toHaveLength(1);
+    expect(after[0]!.runCount).toBe(1);
+    expect(after[0]!.passCount).toBe(1);
+  });
+
+  it("the rollup row is stamped with the authenticated Memex, not left for a read-time parse", async () => {
+    tagAc(AC_ROLLUP_RLS);
+    tagAc(AC_TENANT_CONTEXT);
+
+    // The row is only visible under its OWN tenant context — which is the policy doing its
+    // job, and also the proof that memex_id was written correctly rather than defaulted.
+    // A row stamped with the wrong memex would be invisible here; this asserts the column
+    // directly so the reason is legible rather than inferred from an empty result.
+    //
+    // Every row for this ref, not one: the ac-32 block's emission used a different
+    // test_identifier and therefore holds its own rollup row. Both must carry this memex.
+    const rows = await runWithMemexId(memexId, async () =>
+      db
+        .select({ memexId: testRunDaily.memexId })
+        .from(testRunDaily)
+        .where(eq(testRunDaily.subjectRef, acRef)),
+    );
+    expect(rows.length).toBeGreaterThanOrEqual(1);
+    expect(rows.every((r) => r.memexId === memexId)).toBe(true);
+  });
+
+  it("under ANOTHER tenant's context the same rollup row is invisible — the policy is really on", async () => {
+    tagAc(AC_ROLLUP_RLS);
+    tagAc(AC_TENANT_CONTEXT);
+
+    // Guards against the two tests above passing for the wrong reason. If RLS were not
+    // actually enabled here (a migration that did not run, an ENABLE/FORCE mix-up), this
+    // read would return the row and the whole block would assert nothing about tenancy.
+    //
+    // Reads under a FOREIGN tenant rather than with no context at all, deliberately. The
+    // no-context version is not a clean assertion: with `app.memex_id` set to an empty
+    // string the policy's own `::uuid` cast can be evaluated before the guarding
+    // `IS NOT NULL` conjunct — SQL does not promise AND short-circuits — and the query
+    // fails with `invalid input syntax for type uuid: ""` instead of returning no rows.
+    // That failure still "proves" the policy is attached, but it proves it by erroring,
+    // which is indistinguishable from a dozen other faults. A foreign tenant exercises the
+    // predicate the way production does and can only come back empty.
+    const otherTenant = "00000000-0000-4000-8000-000000000001";
+    const leaked = await runWithMemexId(otherTenant, async () =>
+      db
+        .select({ subjectRef: testRunDaily.subjectRef })
+        .from(testRunDaily)
+        .where(eq(testRunDaily.subjectRef, acRef)),
+    );
+    expect(leaked).toEqual([]);
   });
 });

--- a/packages/server/src/routes/test-events.test.ts
+++ b/packages/server/src/routes/test-events.test.ts
@@ -32,6 +32,16 @@ const transactionSpy = vi.fn();
 const selectSpy = vi.fn();
 
 vi.mock("../db/connection.js", () => ({
+  // spec-520 issue-8: the route now wraps its WRITE transaction in runWithMemexId, not
+  // just the auto-resolve read. Mocking db/connection.js means mocking this too — a
+  // pass-through, since these suites assert request/response shaping; the real tenant
+  // context is exercised under the restricted role in
+  // test-events-tenant-context.rls-restricted.test.ts.
+  //
+  // Its absence used to be survivable only because the single call site sat inside a
+  // try/catch that swallowed the TypeError. It no longer is: the wrap is now around the
+  // write, so a missing stub aborts the emission and every POST here returns 500.
+  runWithMemexId: (_memexId: string | null | undefined, fn: () => unknown) => fn(),
   db: {
     insert: () => insertSpy(),
     select: (...args: unknown[]) => selectSpy(...args),
@@ -59,6 +69,20 @@ vi.mock("../services/test-event-latest.js", () => ({
 vi.mock("../services/test-event-retention.js", () => ({
   trimTestEventsForPair: vi.fn().mockResolvedValue(undefined),
   recordFirstVerified: vi.fn().mockResolvedValue(undefined),
+}));
+
+// spec-520 t-9: the per-day rollup upsert also runs inside that transaction.
+// Same rationale as the two mocks above — the mocked tx only stubs .insert, and
+// the real upsert arithmetic is covered against a real DB in
+// test-run-daily.integration.test.ts. Without this stub the upsert chain
+// (.values().onConflictDoUpdate()) hits the bare .insert() stub, throws, and
+// every POST in this file returns 500 instead of 201 — which is how it presents,
+// not as a missing mock.
+//
+// Keeping it a no-op also keeps insertSpy at one call per post, which is what
+// spec-528 ac-7's per-event statement count observes here.
+vi.mock("../services/test-run-daily.js", () => ({
+  applyEmissionToRollup: vi.fn().mockResolvedValue(undefined),
 }));
 
 // spec-129: the route now requires a valid emission key. These spec-115 unit tests focus

--- a/packages/server/src/routes/test-events.ts
+++ b/packages/server/src/routes/test-events.ts
@@ -74,6 +74,7 @@ import { Hono } from "hono";
 import { db } from "../db/connection.js";
 import { testEvents } from "../db/schema.js";
 import { applyEmissionToSummary } from "../services/test-event-latest.js";
+import { applyEmissionToRollup } from "../services/test-run-daily.js";
 import {
   trimTestEventsForPair,
   recordFirstVerified,
@@ -464,7 +465,33 @@ async function processOneEvent(
   // already resolved it (targetMemexId) and proved it matches the key, so by
   // this point it is always a real, authorized Memex. Each batched event emits
   // its own bus frame here, exactly as a one-per-POST event would (ac-5).
-  const row = await mutate(
+  // spec-520 issue-8 (ac-22): establish tenant context around the WRITE, not only
+  // around the auto-resolve READ further down.
+  //
+  // t-7 wrapped the read (ac-32), and that was the correct scope at the time: no
+  // table written in this transaction carried RLS, so there was no policy for a
+  // context-less write to fail. t-9's `test_run_daily` rollup is the first one
+  // that does, and that turned a latent gap into an outage.
+  //
+  // Every tenant policy in drizzle/ carries an explicit
+  // `nullif(current_setting('app.memex_id', true), '') IS NOT NULL` conjunct, so
+  // an unset GUC makes the predicate FALSE rather than NULL. For SELECT/UPDATE
+  // that filters to zero rows — quiet. For INSERT it RAISES. The rollup upsert
+  // shares this transaction with the test_events insert and mutate() rethrows, so
+  // without this wrap EVERY emission 500s in production — and the event itself is
+  // lost too, not just the rollup row. Dev and CI stay green throughout, because
+  // the owner role bypasses RLS (std-36: ENABLE, never FORCE). Proven red→green
+  // under the real `memex_app` role in
+  // test-events-tenant-context.rls-restricted.test.ts.
+  //
+  // The wrap goes around the whole transaction rather than around the one write
+  // that needs it, so a write added in here later inherits the context instead of
+  // having to remember it. std-36 asks for context "by construction, not
+  // discipline"; this is the constructive half available at this layer. The other
+  // half is db/rls-context-guard.ts (spec-440), still WARN-only at phase 1 — so
+  // it would not have stopped this, which is why the wrap has to be structural.
+  const writeEventAndSummaries = async () =>
+    mutate(
     {},
     {
       memexId: targetMemexId,
@@ -502,6 +529,33 @@ async function processOneEvent(
           latestRunAt: inserted.createdAt,
           hidden: insertValues.hidden,
         });
+        // spec-520 t-9 (dec-5): the ANALYTICAL tier, in the same transaction as
+        // the log write and the operational summary — so the counts can never
+        // diverge from the rows they count, which is the failure this whole
+        // rollup exists to end.
+        //
+        // Position is deliberate: immediately after the test_event_latest upsert
+        // and before the retention trim, i.e. the same relative point on every
+        // emission. spec-398's restructuring of this path deadlocked and rolled
+        // back a prod deploy (std-39 cl-9); a consistent lock order is what
+        // stops the repeat.
+        //
+        // NOT a second mutate() call, deliberately. The whole transaction is
+        // already inside one (:467), which emits exactly one
+        // `test_event.created` frame per emission. Wrapping this upsert in its
+        // own mutate() would satisfy a naive reading of std-8 while DOUBLING the
+        // SSE frames every emission puts on the bus — the surfaces that refetch
+        // on that frame would then do it twice. std-8 is satisfied here the same
+        // way applyEmissionToSummary satisfies it: by riding the enclosing
+        // mutate()'s transaction.
+        await applyEmissionToRollup(tx, {
+          subjectRef: insertValues.subjectRef,
+          memexId: targetMemexId,
+          testIdentifier: insertValues.testIdentifier,
+          status: insertValues.status as "pass" | "fail" | "error",
+          runAt: inserted.createdAt,
+          hidden: insertValues.hidden,
+        });
         // spec-398 (ac-1): keep this pair bounded to the latest RETENTION_KEEP
         // runs — the steady-state trim-on-write, in the same transaction as the
         // insert so the log never transiently exceeds the cap.
@@ -519,6 +573,8 @@ async function processOneEvent(
       });
     },
   );
+
+  const row = await runWithMemexId(targetMemexId, writeEventAndSummaries);
 
   // spec-129 ac-17: record that this key is live. Fire-and-forget (silent) so a missed
   // bump never blocks or fails the emission — it only leaves a slightly stale timestamp.

--- a/packages/server/src/services/test-run-daily.integration.test.ts
+++ b/packages/server/src/services/test-run-daily.integration.test.ts
@@ -1,0 +1,328 @@
+// Integration tests for the test_run_daily rollup (spec-520 dec-5 / t-9).
+//
+// DB-backed by necessity, for the same reason its sibling
+// test-event-latest.integration.test.ts is: everything load-bearing here is
+// SQL-level — the ON CONFLICT arithmetic, the composite PK, the CHECK invariant,
+// and the absence of an index on the count columns. A unit test on the helper
+// would assert the values we passed in, not what Postgres stored.
+//
+// Tagged to spec-520 ac-21. NOT tagged to ac-22 (RLS on the rollup): that half
+// is deliberately unbuilt and gated on issue-8 — the emission WRITE transaction
+// does not run inside runWithMemexId, so a policy on this table would be
+// unsatisfiable at write time in prod. Tagging ac-22 from here would flip it
+// green on a property this file does not test.
+
+import { describe, it, expect, afterAll, beforeAll } from "vitest";
+import { and, eq, inArray, sql } from "drizzle-orm";
+import { db } from "../db/connection.js";
+import { testRunDaily } from "../db/schema.js";
+import { applyEmissionToRollup, utcDayFor } from "./test-run-daily.js";
+import { makeTestMemex } from "./test-helpers.js";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+const AC_21 = "mindset-prod/memex-building-itself/specs/spec-520/acs/ac-21";
+
+let memexId: string;
+// std-37: per-worker-unique identifiers, so parallel workers never collide on
+// the same rollup key.
+const RUN_TAG = `t9-${process.pid}-${Math.random().toString(36).slice(2, 8)}`;
+const createdRefs: string[] = [];
+
+function refFor(name: string): string {
+  const ref = `mindset-prod/fixture/specs/spec-1/acs/${RUN_TAG}-${name}`;
+  createdRefs.push(ref);
+  return ref;
+}
+
+beforeAll(async () => {
+  memexId = await makeTestMemex("trd");
+});
+
+afterAll(async () => {
+  if (createdRefs.length) {
+    await db
+      .delete(testRunDaily)
+      .where(inArray(testRunDaily.subjectRef, createdRefs))
+      .catch(() => {});
+  }
+});
+
+async function rowsFor(subjectRef: string) {
+  return db
+    .select()
+    .from(testRunDaily)
+    .where(and(eq(testRunDaily.subjectRef, subjectRef), eq(testRunDaily.memexId, memexId)));
+}
+
+describe("test_run_daily — the shape ac-21 claims", () => {
+  it("is keyed on (memex_id, subject_ref, test_identifier, day) and carries the four counts", async () => {
+    tagAc(AC_21);
+
+    const [pk] = await db.execute(sql`
+      SELECT array_agg(a.attname ORDER BY k.ord) AS cols
+        FROM pg_constraint c
+        JOIN LATERAL unnest(c.conkey) WITH ORDINALITY AS k(attnum, ord) ON TRUE
+        JOIN pg_attribute a ON a.attrelid = c.conrelid AND a.attnum = k.attnum
+       WHERE c.conrelid = 'test_run_daily'::regclass AND c.contype = 'p'
+    `);
+    expect((pk as { cols: string[] }).cols).toEqual([
+      "memex_id",
+      "subject_ref",
+      "test_identifier",
+      "day",
+    ]);
+
+    const cols = await db.execute(sql`
+      SELECT column_name FROM information_schema.columns
+       WHERE table_name = 'test_run_daily'
+    `);
+    const names = (cols as unknown as { column_name: string }[]).map((r) => r.column_name);
+    expect(names).toEqual(
+      expect.arrayContaining(["run_count", "pass_count", "fail_count", "error_count"]),
+    );
+  });
+
+  it("keeps every count column UNINDEXED so increments stay HOT [per std-39 cl-7]", async () => {
+    tagAc(AC_21);
+
+    // The guard that matters: an index on a counter defeats HOT updates, so
+    // every one of ~227k daily increments would also write an index tuple and
+    // hand autovacuum the dead tuples to chase. Assert on the columns actually
+    // indexed rather than on index count, so adding a legitimate key-column
+    // index later doesn't fail this test spuriously.
+    const indexed = await db.execute(sql`
+      SELECT DISTINCT a.attname
+        FROM pg_index i
+        JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey)
+       WHERE i.indrelid = 'test_run_daily'::regclass
+    `);
+    const cols = (indexed as unknown as { attname: string }[]).map((r) => r.attname);
+    for (const counter of ["run_count", "pass_count", "fail_count", "error_count"]) {
+      expect(cols).not.toContain(counter);
+    }
+  });
+});
+
+describe("test_run_daily — one emission, exactly one upsert", () => {
+  it("creates one row on the first emission and increments it in place on the next", async () => {
+    tagAc(AC_21);
+
+    const ref = refFor("increments");
+    const at = new Date("2026-08-20T11:00:00.000Z");
+
+    await applyEmissionToRollup(db, {
+      subjectRef: ref,
+      memexId,
+      testIdentifier: "suite/a.test.ts::first",
+      status: "pass",
+      runAt: at,
+      hidden: false,
+    });
+
+    let rows = await rowsFor(ref);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ runCount: 1, passCount: 1, failCount: 0, errorCount: 0 });
+
+    // Same key, later in the same UTC day → still ONE row.
+    await applyEmissionToRollup(db, {
+      subjectRef: ref,
+      memexId,
+      testIdentifier: "suite/a.test.ts::first",
+      status: "fail",
+      runAt: new Date("2026-08-20T23:59:59.000Z"),
+      hidden: false,
+    });
+
+    rows = await rowsFor(ref);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ runCount: 2, passCount: 1, failCount: 1, errorCount: 0 });
+  });
+
+  it("separates UTC days, and fixes the day from the event rather than the local clock", async () => {
+    tagAc(AC_21);
+
+    const ref = refFor("days");
+    // 23:30 UTC on the 20th is the 21st in +02:00. A server-local derivation
+    // would file this under the wrong day; utcDayFor must not.
+    const late = new Date("2026-08-20T23:30:00.000Z");
+    const next = new Date("2026-08-21T00:30:00.000Z");
+    expect(utcDayFor(late)).toBe("2026-08-20");
+    expect(utcDayFor(next)).toBe("2026-08-21");
+
+    for (const at of [late, next]) {
+      await applyEmissionToRollup(db, {
+        subjectRef: ref,
+        memexId,
+        testIdentifier: "",
+        status: "pass",
+        runAt: at,
+        hidden: false,
+      });
+    }
+
+    const rows = await rowsFor(ref);
+    expect(rows).toHaveLength(2);
+    expect(rows.map((r) => r.day).sort()).toEqual(["2026-08-20", "2026-08-21"]);
+  });
+
+  it("counts each outcome in its own column, and only one per emission", async () => {
+    tagAc(AC_21);
+
+    const ref = refFor("outcomes");
+    const at = new Date("2026-08-20T08:00:00.000Z");
+    for (const status of ["pass", "pass", "fail", "error"] as const) {
+      await applyEmissionToRollup(db, {
+        subjectRef: ref,
+        memexId,
+        testIdentifier: "s::t",
+        status,
+        runAt: at,
+        hidden: false,
+      });
+    }
+
+    const rows = await rowsFor(ref);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ runCount: 4, passCount: 2, failCount: 1, errorCount: 1 });
+  });
+
+  it("skips hidden emissions entirely, matching applyEmissionToSummary", async () => {
+    tagAc(AC_21);
+
+    const ref = refFor("hidden");
+    await applyEmissionToRollup(db, {
+      subjectRef: ref,
+      memexId,
+      testIdentifier: "s::t",
+      status: "pass",
+      runAt: new Date("2026-08-20T08:00:00.000Z"),
+      hidden: true,
+    });
+    expect(await rowsFor(ref)).toHaveLength(0);
+  });
+
+  it("collapses a null test_identifier to '' so it shares one PK slot", async () => {
+    tagAc(AC_21);
+
+    const ref = refFor("nullident");
+    const at = new Date("2026-08-20T08:00:00.000Z");
+    for (const testIdentifier of [null, ""]) {
+      await applyEmissionToRollup(db, {
+        subjectRef: ref,
+        memexId,
+        testIdentifier,
+        status: "pass",
+        runAt: at,
+        hidden: false,
+      });
+    }
+    const rows = await rowsFor(ref);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.testIdentifier).toBe("");
+    expect(rows[0]!.runCount).toBe(2);
+  });
+
+  it("scopes rows by memex_id, so an identical ref under another tenant is a different row", async () => {
+    tagAc(AC_21);
+
+    const otherMemexId = await makeTestMemex("trd2");
+    const ref = refFor("tenancy");
+    const at = new Date("2026-08-20T08:00:00.000Z");
+
+    for (const mid of [memexId, otherMemexId]) {
+      await applyEmissionToRollup(db, {
+        subjectRef: ref,
+        memexId: mid,
+        testIdentifier: "s::t",
+        status: "pass",
+        runAt: at,
+        hidden: false,
+      });
+    }
+
+    const all = await db
+      .select()
+      .from(testRunDaily)
+      .where(eq(testRunDaily.subjectRef, ref));
+    expect(all).toHaveLength(2);
+    expect(all.every((r) => r.runCount === 1)).toBe(true);
+
+    await db.delete(testRunDaily).where(eq(testRunDaily.subjectRef, ref)).catch(() => {});
+  });
+});
+
+describe("test_run_daily — the CHECK is a wiring tripwire", () => {
+  it("rejects a row whose run_count does not equal the outcome counts summed", async () => {
+    tagAc(AC_21);
+
+    const ref = refFor("check");
+
+    // Assert on the CONSTRAINT, not on the message. Drizzle wraps the driver
+    // error, so the outer message is only "Failed query: insert into …" and a
+    // regex against it passes for any failure at all — including the table not
+    // existing. The postgres-js error carries `constraint_name` on the cause,
+    // which is the only thing that proves THIS check fired.
+    const err = await db
+      .insert(testRunDaily)
+      .values({
+        memexId,
+        subjectRef: ref,
+        testIdentifier: "s::t",
+        day: "2026-08-20",
+        runCount: 5,
+        passCount: 1,
+        failCount: 0,
+        errorCount: 0,
+      })
+      .then(
+        () => null,
+        (e: unknown) => e,
+      );
+
+    expect(err).not.toBeNull();
+    const cause = (err as { cause?: { constraint_name?: string; code?: string } }).cause;
+    expect(cause?.constraint_name).toBe("test_run_daily_counts_sum");
+    // 23514 = check_violation. Pins that the row was refused by the CHECK
+    // rather than by the PK, a NOT NULL, or a type error.
+    expect(cause?.code).toBe("23514");
+  });
+});
+
+describe("test_run_daily — concurrent emissions for the same pair", () => {
+  it("does not deadlock and loses no increment when two transactions race the same key", async () => {
+    tagAc(AC_21);
+
+    const ref = refFor("concurrent");
+    const at = new Date("2026-08-20T09:00:00.000Z");
+
+    // The failure this guards against is spec-398's: restructuring a
+    // continuously-written table in this path deadlocked and rolled back a prod
+    // deploy (std-39 cl-9). Both transactions take the rollup lock at the same
+    // relative point, so one waits rather than cycling.
+    const emit = (status: "pass" | "fail") =>
+      db.transaction(async (tx) =>
+        applyEmissionToRollup(tx, {
+          subjectRef: ref,
+          memexId,
+          testIdentifier: "s::t",
+          status,
+          runAt: at,
+          hidden: false,
+        }),
+      );
+
+    const results = await Promise.allSettled([
+      emit("pass"),
+      emit("fail"),
+      emit("pass"),
+      emit("fail"),
+    ]);
+    const rejected = results.filter((r) => r.status === "rejected");
+    expect(rejected).toEqual([]);
+
+    const rows = await rowsFor(ref);
+    expect(rows).toHaveLength(1);
+    // Every increment landed — no lost update from the concurrent upserts.
+    expect(rows[0]).toMatchObject({ runCount: 4, passCount: 2, failCount: 2 });
+  });
+});

--- a/packages/server/src/services/test-run-daily.ts
+++ b/packages/server/src/services/test-run-daily.ts
@@ -1,0 +1,99 @@
+// Maintenance for the `test_run_daily` rollup (spec-520 dec-5 / t-9).
+//
+// The durable, ANALYTICAL tier over the test-event firehose, alongside
+// `test_event_latest`'s OPERATIONAL one — spec-125's split applied to this path
+// instead of patched around per metric.
+//
+// Grain: one row per test, per subject, per UTC day, carrying how many times it
+// ran and how many times it passed / failed / errored.
+//
+// Why it exists: the history we believed we kept does not exist. The retention
+// trim caps raw `test_events` at RETENTION_KEEP rows per pair, so the two
+// history consumers (`testRunVolume`, `listAcAlignmentOverTime`) count rows that
+// have already been deleted — and hardest for the busiest ACs, which are exactly
+// the pairs that hit the cap. Counting at write time and keeping the counts is
+// what makes the raw log droppable at all (t-12).
+//
+// This mirrors `applyEmissionToSummary` (test-event-latest.ts) on purpose: same
+// `conn`-takes-a-transaction shape, same hidden-skip rule, same collapse of a
+// null test_identifier to ''. When one changes, look at the other.
+
+import { sql } from "drizzle-orm";
+import { type Db } from "../db/connection.js";
+import { testRunDaily } from "../db/schema.js";
+
+export interface EmissionForRollup {
+  subjectRef: string;
+  /** The emitting Memex — first-class here [per std-32], never parsed from the ref. */
+  memexId: string;
+  /** null when the emitting test sent no test_identifier; collapses to '' on write. */
+  testIdentifier: string | null;
+  status: "pass" | "fail" | "error";
+  /** The log row's created_at (server `now()` in production). Fixes the UTC day. */
+  runAt: Date;
+  /** spec-115: hidden emissions are stored in the log but excluded from counts. */
+  hidden: boolean;
+}
+
+/**
+ * The UTC calendar day an emission counts against.
+ *
+ * Derived in JS from the event's own timestamp rather than in SQL, so the day a
+ * row lands on cannot drift with the session's TimeZone setting — the value is
+ * fixed by the emission, identically in dev, CI and prod. `toISOString()` is
+ * always UTC, so slicing its date part is exact rather than approximate.
+ */
+export function utcDayFor(runAt: Date): string {
+  return runAt.toISOString().slice(0, 10);
+}
+
+/**
+ * Increment the rollup row for an emission's (memex, subject, test, day) key.
+ *
+ * - Hidden emissions are skipped entirely, matching `applyEmissionToSummary`.
+ * - A null test_identifier collapses to '' so it shares one PK slot.
+ * - `run_count` and exactly ONE outcome count advance per emission. That is the
+ *   invariant the table's `test_run_daily_counts_sum` CHECK enforces, so a
+ *   miscount here fails the write rather than surfacing in a chart weeks later.
+ *
+ * Increments are expressed as `+ excluded.<col>` rather than `+ 1` so the same
+ * statement stays correct if this is ever fed multi-row values (t-12's follow-on
+ * coalescing): each conflicting row then adds exactly what it brought.
+ */
+export async function applyEmissionToRollup(
+  conn: Db,
+  emission: EmissionForRollup,
+): Promise<void> {
+  if (emission.hidden) return;
+  const testIdentifier = emission.testIdentifier ?? "";
+  const isPass = emission.status === "pass" ? 1 : 0;
+  const isFail = emission.status === "fail" ? 1 : 0;
+  const isError = emission.status === "error" ? 1 : 0;
+
+  await conn
+    .insert(testRunDaily)
+    .values({
+      memexId: emission.memexId,
+      subjectRef: emission.subjectRef,
+      testIdentifier,
+      day: utcDayFor(emission.runAt),
+      runCount: 1,
+      passCount: isPass,
+      failCount: isFail,
+      errorCount: isError,
+    })
+    .onConflictDoUpdate({
+      target: [
+        testRunDaily.memexId,
+        testRunDaily.subjectRef,
+        testRunDaily.testIdentifier,
+        testRunDaily.day,
+      ],
+      set: {
+        runCount: sql`${testRunDaily.runCount} + excluded.run_count`,
+        passCount: sql`${testRunDaily.passCount} + excluded.pass_count`,
+        failCount: sql`${testRunDaily.failCount} + excluded.fail_count`,
+        errorCount: sql`${testRunDaily.errorCount} + excluded.error_count`,
+      },
+    });
+}


### PR DESCRIPTION
**spec-520 t-9** — the per-day test-run rollup (dec-5), plus the tenant-context wrap its RLS turned out to require (issue-8).

Spec: https://memex.ai/mindset-prod/memex-building-itself/specs/spec-520 · QA reports on the Spec (`qa_report`, `qa_report-2`).

## The problem

The history we believed we were keeping does not exist. Retention trims raw `test_events` to `RETENTION_KEEP` rows per `(subject_ref, test_identifier)`, so `testRunVolume` and `listAcAlignmentOverTime` count rows that were already deleted.

Measured on prod 2026-08-18: the summary tier declares **23,718,476 runs** while **1,072,186** raw rows survive — the charts see **4.5%**. And the loss is not uniform: **65,708 pairs sit at exactly 10 surviving rows**, the trim's ceiling made visible. The busier an AC, the shorter its visible history — so the charts under-count hardest where there is most activity, inverting the story they exist to tell. No index fixes that; the rows are gone.

## What this adds

`test_run_daily` — one row per test, per subject, per UTC day, carrying run/pass/fail/error counts, keyed `(memex_id, subject_ref, test_identifier, day)`.

**It adds a write now and retires two later** — the retention DELETE (12.6% of all DB time) in t-12 and the `ac_first_verified` upsert (6.1%) in t-10. Between here and there the emission path is measurably worse, on a Spec whose headline is write amplification. Deliberate, and worth saying out loud rather than discovering in a chart.

Three properties are easy to break, so each has a test that would catch it:
- **`memex_id` is first-class and stamped at write** [per std-32], never parsed out of `subject_ref` at read time — that parse is the spec-396 leak pattern, and it is why `ac_first_verified` can never carry a policy.
- **No index on the count columns** [per std-39 cl-7] — hot counter rows; an index defeats HOT. Asserted against `pg_index`, on the *columns* indexed rather than an index count.
- **A CHECK pins `run_count = pass + fail + error`** — a wiring tripwire, not a business rule.

**Not its own `mutate()` call**, deliberately: the upsert rides the enclosing transaction's, which already emits exactly one `test_event.created` frame. A second wrapper would satisfy the std-8 scan literally while **doubling the SSE frames** every emission puts on the bus. Allowlisted with that reasoning, same category as `test-event-latest.ts`.

## And the write path now establishes tenant context (issue-8)

t-7 wrapped the auto-resolve **read**, which was the right scope then: no table written in this transaction carried RLS. This rollup is the first that does.

Every tenant policy in `drizzle/` carries an explicit `nullif(current_setting('app.memex_id', true), '') IS NOT NULL` conjunct, making the predicate **FALSE — not NULL** — when the GUC is unset. For SELECT/UPDATE that filters quietly; **for INSERT it raises**. The rollup upsert shares a transaction with the `test_events` insert and `mutate()` rethrows, so RLS without the wrap does not lose rollup rows — it **500s every emission in production**, while dev and CI stay green because the owner role bypasses RLS (std-36: ENABLE, never FORCE).

Measured, not predicted. With `0135` applied and the wrap absent, `POST /api/test-events` returned 500 — and so did t-7's own route test, because the transaction dies before the auto-resolve is reached.

The wrap goes around the **whole transaction** rather than the one write that needs it, so a write added there later inherits the context [per std-36: *by construction, not discipline*].

## Two spec-533 guards were green for a false reason

`spec-533-ingest-ratio` ac-19 and `spec-533-staleness-advisory` ac-4 ("adds no database round-trip per event") passed because those files mock `db/connection.js` **without** `runWithMemexId` — the route's auto-resolve call threw a TypeError its best-effort `try/catch` swallowed, so the chain never ran there at all. Stubbing it honestly made it run, and the guards immediately reported a real per-event SELECT (`services/issues.ts:554`).

That cost belongs to **t-15**, not spec-533, so `maybeAutoResolveIssuesForAcUid` is stubbed in both — as `test-events-namespace-guard.regression.test.ts` already did. Independent corroboration of t-15's re-scope: one of the places that cost was invisible was a guard written to catch it.

## Test plan

- [x] Full server suite — **6409 passed / 0 failed / 25 skipped**
- [x] Restricted-role suite (`test:rls`, as `memex_app` NOBYPASSRLS) — **13/13**, ac-22 driven red→green
- [x] Full Playwright e2e — **157 passed / 1 skipped / 0 failed** (run against an isolated pg16 DB: `make e2e-cold` hardcodes `:5432`, which is pg14 without pgvector locally and dies on migration 0023)
- [x] Migrations verified on a **cold, empty** database through `0135`, RLS confirmed enabled
- [x] `make typecheck` clean · `make check` green · pre-push hook green (2063 tests)
- [x] std-28: no new journey owed — this changes no user-facing flow
- [ ] Post-deploy: take issue-9's measured update rate **before** t-10/t-12 land, or the autovacuum figures mix regimes
- [ ] Post-deploy: watch the first **batched** emission — the restricted-role harness exercises one emission at a time

## Deployment

Two migrations, `0134` (table) and `0135` (RLS). **They must ship with the `test-events.ts` wrap; `0135` without it is an ingest outage.** `CREATE TABLE` takes no lock on the emission path; `ENABLE ROW LEVEL SECURITY` takes a brief ACCESS EXCLUSIVE lock on the new, empty table only. No flags, no backfill. **History starts at ship date** and cannot be reconstructed.

## Not done

**t-9 stays open** on ac-26's second clause — the *measured* update rate and autovacuum cost. std-39 cl-7 refuses an estimate, and it needs real traffic (issue-9).