### PR TITLE
perf(spec-520): the auto-resolve reverse lookup costs one query, not three (t-15)

### DIFF
--- a/packages/server/src/routes/test-events.test.ts
+++ b/packages/server/src/routes/test-events.test.ts
@@ -788,13 +788,32 @@ describe("POST /api/test-events — run_id / commit_sha filled from metadata (sp
     });
     expect(filled.status).toBe(201);
 
-    // Asserted as a delta rather than a magic number: the ingest path already
-    // performs one transaction, one insert and one read per PASSING event (the
-    // read is spec-112's issue auto-resolve at test-events.ts:497, unrelated to
-    // this Spec). What ac-7 protects is that the fill adds NONE of them. The two
-    // tempting implementations — resolving the run id via a lookup, or reading
-    // the inserted row back — would each show up right here as a delta, on a
-    // path peaking at 2 063 POST/min with one transaction per event.
+    // Asserted as a DELTA rather than a magic number, and that choice is what has
+    // kept this test correct while the number underneath it moved three times.
+    // What ac-7 protects is that the run_id fill adds no transaction, no insert and
+    // no read — the two tempting implementations (resolving the run id via a lookup,
+    // or reading the inserted row back) would each show up right here, on a path
+    // peaking at 2 063 POST/min.
+    //
+    // ⚠ THE READ COUNT: this comment used to say "one read", naming spec-112's issue
+    // auto-resolve. That was true of what this file OBSERVED and never of production.
+    // Corrected 2026-08-28 (spec-520 t-15) — three regimes, one number each:
+    //
+    //   1. Pre-t-7 (until 2026-08-18): the chain's first statement was a
+    //      `documents ⋈ memexes ⋈ namespaces` lookup, `documents` carries RLS on
+    //      app.memex_id, and the ingest path had no tenant context — so it was
+    //      filtered to zero rows and the chain returned at statement 1. ONE read, and
+    //      the reason was a defect, not a design.
+    //   2. Post-t-7, pre-t-15: with context established the chain ran to completion on
+    //      essentially every passing event. THREE reads (documents join, `acs`,
+    //      `task_satisfies_ac`) — measured on prod at 30.970 calls/s against an event
+    //      rate of 30.973 (spec-520 c-9).
+    //   3. Now (t-15 / ac-33): those three are collapsed into ONE join returning the
+    //      satisfying task ids directly. Back to one read, this time by design.
+    //
+    // So do NOT pin `selects` to a literal here. It is not this Spec's number, it has
+    // moved for reasons that had nothing to do with spec-528, and a literal would have
+    // made this test fail three times while asserting nothing about the fill.
     expect(counts()).toEqual(before);
     expect(before.transactions).toBe(1);
     expect(before.inserts).toBe(1);

--- a/packages/server/src/services/issues-auto-resolve-query-count.integration.test.ts
+++ b/packages/server/src/services/issues-auto-resolve-query-count.integration.test.ts
@@ -1,0 +1,179 @@
+// spec-520 t-15 / ac-33 — the ingest path's auto-resolve reverse lookup costs ONE query,
+// not three.
+//
+// WHY THIS IS DB-BACKED AND COUNTS AGAINST A REAL `db`. Two ways to write this test are
+// available and both are wrong, and t-15 exists partly because the second one hid the cost
+// for months:
+//
+//   1. Against the route's mocked `db.select`: the bare stub makes `.from()` throw, the
+//      handler's deliberate best-effort catch swallows it, and the spy records exactly ONE
+//      call however many the real path makes. A count assertion there reports 1 forever —
+//      it would have passed against the three-query implementation and against a one-query
+//      one, identically.
+//   2. Without tenant context: pre-t-7, `documents` RLS filtered the first lookup to zero
+//      rows, so the chain returned at statement 1. A test in that state also sees one
+//      query, also passes, and also measures nothing. That is precisely the reading that
+//      made s-4 §4 conclude the cost was 0.44% of DB time and t-15's premise dead.
+//
+// So the count is taken against a real database, with a resolvable document, inside
+// `runWithMemexId`. (Under the default owner connection RLS is bypassed anyway — std-36:
+// ENABLE, never FORCE — so the wrapper is not what makes this work here. It is kept
+// because the property under test is "the chain runs to completion", and the wrapper is
+// how the production path guarantees that.)
+//
+// THE COST BEING REMOVED, measured on prod as a 600s delta 2026-08-28 (c-9):
+//   documents ⋈ memexes ⋈ namespaces   30.970 calls/s   0.0770 ms
+//   task_satisfies_ac                  30.972 calls/s   0.0314 ms
+//   (event rate                        30.973 calls/s)
+// The chain runs on essentially every event and costs ≈18% of the emission path. A third
+// statement — the `acs` lookup — is in the chain but was outside that query filter, so
+// 0.1084 ms/event is a lower bound.
+
+import { describe, it, expect, afterAll, beforeAll, vi } from "vitest";
+import { eq, inArray } from "drizzle-orm";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { db, runWithMemexId } from "../db/connection.js";
+import { acs, documents, memexes, namespaces, taskSatisfiesAc, tasks } from "../db/schema.js";
+import { createDocDraft } from "./documents.js";
+import { maybeAutoResolveIssuesForAcUid } from "./issues.js";
+import { makeTestMemex } from "./test-helpers.js";
+
+const AC_ONE_QUERY = "mindset-prod/memex-building-itself/specs/spec-520/acs/ac-33";
+
+let memexId: string;
+let namespaceSlug: string;
+let memexSlug: string;
+const createdDocIds: string[] = [];
+
+/** Seed a Spec + one AC, and return the ref the ingest path would receive. */
+async function seedAcRef(seq: number, withSatisfyingTask: boolean): Promise<string> {
+  return runWithMemexId(memexId, async () => {
+    const doc = await createDocDraft(memexId, `t15 target ${seq}`, "", "spec");
+    createdDocIds.push(doc.id);
+
+    const [ac] = await db
+      .insert(acs)
+      .values({
+        memexId,
+        briefId: doc.id,
+        seq,
+        kind: "implementation",
+        statement: "the criterion under reverse lookup",
+        status: "active",
+      } as typeof acs.$inferInsert)
+      .returning();
+
+    if (withSatisfyingTask) {
+      const [task] = await db
+        .insert(tasks)
+        .values({
+          memexId,
+          docId: doc.id,
+          seq: 1,
+          title: "the satisfying task",
+          description: "",
+          status: "complete",
+        } as typeof tasks.$inferInsert)
+        .returning();
+      await db
+        .insert(taskSatisfiesAc)
+        .values({ taskId: task!.id, acId: ac!.id } as typeof taskSatisfiesAc.$inferInsert);
+    }
+
+    return `${namespaceSlug}/${memexSlug}/specs/${doc.handle}/acs/ac-${seq}`;
+  });
+}
+
+beforeAll(async () => {
+  memexId = await makeTestMemex("t15");
+  const [row] = await db
+    .select({ m: memexes.slug, n: namespaces.slug })
+    .from(memexes)
+    .innerJoin(namespaces, eq(memexes.namespaceId, namespaces.id))
+    .where(eq(memexes.id, memexId))
+    .limit(1);
+  memexSlug = row!.m;
+  namespaceSlug = row!.n;
+});
+
+afterAll(async () => {
+  if (createdDocIds.length) {
+    await db.delete(documents).where(inArray(documents.id, createdDocIds)).catch(() => {});
+  }
+});
+
+describe("spec-520 ac-33: the auto-resolve reverse lookup issues ONE query", () => {
+  it("costs exactly one query on the common path — an AC with no satisfying task", async () => {
+    tagAc(AC_ONE_QUERY);
+
+    // THE dominant case, and the one the prod delta measures: the overwhelming majority of
+    // passing events are for ACs that no converted Issue is waiting on. Before this change
+    // such an event still paid all three statements to discover there was nothing to do —
+    // `documents ⋈ memexes ⋈ namespaces`, then `acs`, then `task_satisfies_ac` — because
+    // every early return in the chain is a NOT-FOUND return, never a cheap-path return.
+    const acRef = await seedAcRef(1, false);
+
+    const spy = vi.spyOn(db, "select");
+    try {
+      const resolved = await runWithMemexId(memexId, async () =>
+        maybeAutoResolveIssuesForAcUid(acRef),
+      );
+      expect(resolved).toEqual([]);
+      // Was 3. Counting db.select isolates the reverse lookup: everything downstream
+      // (maybeAutoResolveIssuesForTask, verifyingAcIsGreen) goes through db.query.*, and on
+      // this path the satisfying set is empty so none of it runs at all.
+      expect(spy).toHaveBeenCalledTimes(1);
+    } finally {
+      // std-37 cl-5: restore what the test replaced, or the next file inherits the spy.
+      spy.mockRestore();
+    }
+  });
+
+  it("still finds the satisfying task through that single query", async () => {
+    tagAc(AC_ONE_QUERY);
+
+    // The collapse must not lose the join's RESULT. This asserts the lookup still reaches
+    // the satisfying task — the row the old third statement existed to fetch — rather than
+    // only asserting that fewer queries ran, which a broken implementation returning []
+    // would also satisfy.
+    const acRef = await seedAcRef(2, true);
+
+    const spy = vi.spyOn(db, "select");
+    try {
+      await runWithMemexId(memexId, async () => maybeAutoResolveIssuesForAcUid(acRef));
+      expect(spy).toHaveBeenCalledTimes(1);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("keeps the tenant scoping — a ref naming another namespace resolves to nothing [per std-7]", async () => {
+    tagAc(AC_ONE_QUERY);
+
+    // `documents.handle` is per-memex, NOT globally unique. Collapsing three statements
+    // into one join is exactly where a scoping conjunct is easiest to drop, and dropping it
+    // turns a bare handle match into a cross-tenant resolution. The one-query form must
+    // still require namespace AND memex to match.
+    const acRef = await seedAcRef(3, true);
+    const foreign = acRef.replace(`${namespaceSlug}/${memexSlug}/`, `${namespaceSlug}/not-this-memex/`);
+    expect(foreign).not.toBe(acRef);
+
+    const resolved = await runWithMemexId(memexId, async () =>
+      maybeAutoResolveIssuesForAcUid(foreign),
+    );
+    expect(resolved).toEqual([]);
+  });
+
+  it("returns nothing for a ref that is not an AC ref at all", async () => {
+    tagAc(AC_ONE_QUERY);
+    // The grammar guard runs before any query. Kept so the collapse cannot accidentally
+    // move parsing after the database round trip.
+    const spy = vi.spyOn(db, "select");
+    try {
+      expect(await maybeAutoResolveIssuesForAcUid("not/a/valid/ref")).toEqual([]);
+      expect(spy).not.toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});

--- a/packages/server/src/services/issues.ts
+++ b/packages/server/src/services/issues.ts
@@ -551,36 +551,49 @@ export async function maybeAutoResolveIssuesForAcUid(subjectRef: string): Promis
   const specHandle = m[3];
   const acSeq = Number(m[4]);
 
-  const [doc] = await db
-    .select({ id: documents.id, memexId: documents.memexId })
+  // spec-520 t-15 (ac-33): ONE query, not three. This used to walk the reverse lookup in
+  // three awaited round trips — documents ⋈ memexes ⋈ namespaces, then `acs`, then
+  // `task_satisfies_ac` — and every one of its early returns was a NOT-FOUND return, never
+  // a cheap-path return. So an event whose AC has no converted Issue still paid all three
+  // to discover there was nothing to do, and that is the overwhelming majority of events.
+  //
+  // Measured on prod as a 600s delta 2026-08-28 (spec-520 c-9), AFTER t-7 made the chain
+  // actually run: the documents join ran at 30.970 calls/s against an event rate of 30.973
+  // — on essentially every event — and the two measurable statements cost 0.1084 ms/event,
+  // about 18% of the whole emission path, with this join the third most expensive statement
+  // per call on it.
+  //
+  // ⚠ THE PRE-t-7 COUNTERS SAY THE OPPOSITE, and they are not evidence. Lifetime
+  // pg_stat_statements showed 221 calls against 21.2M — but only because `documents` RLS
+  // filtered this first statement to zero rows while the ingest path had no tenant context,
+  // so the chain returned at statement 1 every time. That is a measurement of the chain not
+  // RUNNING, not of it being cheap. Do not re-derive this cost from cumulative counters;
+  // take a delta.
+  //
+  // The scoping conjuncts are the part to guard when touching this. `documents.handle`
+  // (e.g. `spec-1`) is per-memex, NOT globally unique, so namespace AND memex must both
+  // match or a bare handle resolves across tenants [per std-7].
+  const satisfying = await db
+    .select({ taskId: taskSatisfiesAc.taskId, memexId: documents.memexId })
     .from(documents)
     .innerJoin(memexes, eq(documents.memexId, memexes.id))
     .innerJoin(namespaces, eq(memexes.namespaceId, namespaces.id))
+    .innerJoin(acs, and(eq(acs.briefId, documents.id), eq(acs.seq, acSeq)))
+    .innerJoin(taskSatisfiesAc, eq(taskSatisfiesAc.acId, acs.id))
     .where(
       and(
         eq(documents.handle, specHandle),
         eq(memexes.slug, memexSlug),
         eq(namespaces.slug, namespaceSlug),
       ),
-    )
-    .limit(1);
-  if (!doc) return [];
+    );
 
-  const [ac] = await db
-    .select({ id: acs.id })
-    .from(acs)
-    .where(and(eq(acs.briefId, doc.id), eq(acs.seq, acSeq)))
-    .limit(1);
-  if (!ac) return [];
-
-  const satisfying = await db
-    .select({ taskId: taskSatisfiesAc.taskId })
-    .from(taskSatisfiesAc)
-    .where(eq(taskSatisfiesAc.acId, ac.id));
-
+  // Every not-found case the three statements returned early on now simply yields no rows:
+  // no such doc, no such AC, or no task satisfying it. All three meant `[]` before and mean
+  // `[]` now, so the behaviour is unchanged — only the round trips are gone.
   const resolved: string[] = [];
   for (const s of satisfying) {
-    const ids = await maybeAutoResolveIssuesForTask(doc.memexId, s.taskId);
+    const ids = await maybeAutoResolveIssuesForTask(s.memexId, s.taskId);
     resolved.push(...ids);
   }
   return resolved;


### PR DESCRIPTION
**spec-520 t-15 / ac-33.** Three awaited round trips on every passing event collapse into one join.

Spec: https://memex.ai/mindset-prod/memex-building-itself/specs/spec-520 · measurement in `c-9`, re-scope rationale in the task body.

## The change

`maybeAutoResolveIssuesForAcUid` walked `ac_uid → doc → AC → satisfying tasks` in three sequential queries. Every early return in it is a **not-found** return, never a cheap-path return — so an event whose AC has no converted Issue still paid all three to discover there was nothing to do. That is the overwhelming majority of events.

One join now returns the satisfying task ids directly. **No behaviour change:** the three cases that returned early (no such doc, no such AC, no task satisfying it) all yield zero rows, which means the same `[]`.

## Why the existing numbers said the opposite

Lifetime `pg_stat_statements` showed this chain at **221 calls against 21.2M events**, 0.44% of DB time — and the Spec's own `s-4 §4` concluded from that the framing was wrong and this task's premise dead.

It was never a measurement of a cheap chain. It was a measurement of a chain **that wasn't running**: `documents` carries RLS on `app.memex_id`, the ingest path had no tenant context, so the first statement was filtered to zero rows and the chain returned at statement 1 every time. t-7 fixed that and reached prod on 2026-08-18. The counters kept eight weeks of "not running" and averaged the truth away.

**Re-measured on prod as a 600s DELTA** — the only instrument that works once a cost switches on mid-window:

| statement | calls/s | mean ms |
|---|---|---|
| `documents ⋈ memexes ⋈ namespaces` | **30.970** | 0.0770 |
| `task_satisfies_ac` | **30.972** | 0.0314 |
| *(`test_events` INSERT — the event rate)* | *30.973* | *0.1453* |

Identical to three significant figures: the chain runs on **essentially every event**. The two measurable statements are **0.1084 ms/event, ≈18% of the whole emission path**, and this join is the third most expensive statement per call on it — ahead of every write except the `test_events` INSERT and the retention DELETE.

A third statement (the `acs` lookup) is in the chain but fell outside that query filter, so **0.1084 ms is a lower bound**. It cannot not run: `task_satisfies_ac` executes at the full event rate and only runs after `acs` has found the AC.

## The part to guard when touching this

`documents.handle` (e.g. `spec-1`) is **per-memex, not globally unique**, so namespace AND memex must both match or a bare handle resolves across tenants [per std-7]. Collapsing statements into one join is precisely where such a conjunct is easiest to drop — a test asserts a foreign-memex ref still resolves to nothing.

## Verification — and both easy ways to write it are wrong

- **Against the route's mocked `db.select`:** the bare stub makes `.from()` throw, the handler's best-effort catch swallows it, and the spy records **one** call however many the real path makes. That assertion passes identically against three queries and against one.
- **Without tenant context:** that reproduces the pre-t-7 regime where the chain dies at statement 1. Also one query, also green, also measuring nothing.

So the count is asserted against a **real database**, with a resolvable document, inside `runWithMemexId`. Both traps are written into the test file for the next reader.

## Test plan

- [x] Driven red→green — `expected select to be called 1 times, but got 3 times`, then 4/4
- [x] Full server suite — **6413 passed / 0 failed / 25 skipped**
- [x] Restricted-role suite — **13/13**. The end-to-end behaviour check lives here: a passing emission through `POST /api/test-events` still resolves its converted Issue (spec-112 ac-22), under the real `memex_app` role
- [x] Full Playwright e2e — **157 passed / 1 skipped / 0 failed**, clean worktree, cold DB
- [x] `make typecheck` clean · `make check` green
- [x] std-28: no new journey owed — no user-facing flow changes
- [x] **ac-33 verified** (created for this: t-15 was pinned by no criterion — ac-31 covers the baseline, ac-27 the write statements, neither the collapse)

## Also in this PR

spec-528 ac-7's inline comment described the baseline as *"one read"*. True of what the mocked file **observed**, never of production. It now states all three regimes — one (RLS-filtered, pre-t-7), three (post-t-7), one (post-t-15, by design) — and says not to pin `selects` to a literal: that number has moved three times for reasons unrelated to spec-528, and the delta assertion is what kept the test honest throughout.

## Not in scope

The per-event cost this removes is a **read**. The Spec's write-side targets stay with t-10 (`ac_first_verified`, 0.0496 ms/event) and t-12 (the retention DELETE, 0.1727 ms/event).