### PR TITLE
perf(spec-520): stop rewriting a row per emission, and stop polling for a hidden tab (t-6)

### DIFF
--- a/packages/server/src/services/emission-keys-last-used-throttle.integration.test.ts
+++ b/packages/server/src/services/emission-keys-last-used-throttle.integration.test.ts
@@ -1,0 +1,140 @@
+// spec-520 t-6 / ac-28 — the last_used_at bump updates ZERO rows when the stored
+// timestamp is already recent.
+//
+// THE COST BEING REMOVED. `bumpLastUsed` fires on every accepted emission with no
+// predicate, so `memex_emission_keys` — a table of roughly 1,100 rows — takes one UPDATE
+// per event. Measured on prod as a 600s delta 2026-08-28 (spec-520 c-9): **30.972
+// calls/s, 0.0426 ms each**, against an event rate of 30.973. Lifetime counters put it at
+// 23.6M updates and 613 autovacuums on those ~1,100 rows.
+//
+// Nothing consumes this timestamp at second-level freshness — it answers "is this key
+// live", shown in the settings UI. A five-minute window keeps that answer true and turns
+// almost every one of those UPDATEs into a no-op that writes nothing and creates no dead
+// tuple. The statement still runs; it just stops costing a row version.
+//
+// WHY THIS IS DB-BACKED AND POLLS. `bumpLastUsed` is deliberately fire-and-forget — it
+// returns void, wraps its mutate() in `void … .catch()`, and is `silent: true` so a missed
+// bump can never fail or delay an emission. There is nothing to await, so the test polls
+// for the write [per std-37] rather than assuming it has landed. Asserting against a mock
+// would prove only that we called a function.
+
+import { describe, it, expect, afterAll, beforeAll } from "vitest";
+import { eq, inArray, sql } from "drizzle-orm";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { db } from "../db/connection.js";
+import { memexEmissionKeys } from "../db/schema.js";
+import { bumpLastUsed, mintEmissionKey } from "./emission-keys.js";
+import { makeTestMemex } from "./test-helpers.js";
+import { upsertUserByEmail } from "./users.js";
+
+const AC_THROTTLE = "mindset-prod/memex-building-itself/specs/spec-520/acs/ac-28";
+
+let memexId: string;
+let userId: string;
+const createdKeyIds: string[] = [];
+
+async function readLastUsed(keyId: string): Promise<Date | null> {
+  const [row] = await db
+    .select({ lastUsedAt: memexEmissionKeys.lastUsedAt })
+    .from(memexEmissionKeys)
+    .where(eq(memexEmissionKeys.id, keyId))
+    .limit(1);
+  return row?.lastUsedAt ?? null;
+}
+
+/** Poll until `lastUsedAt` differs from `from`, or give up. Returns the observed value. */
+async function pollForBump(keyId: string, from: Date | null, tries = 40): Promise<Date | null> {
+  for (let i = 0; i < tries; i++) {
+    const now = await readLastUsed(keyId);
+    if (now?.getTime() !== from?.getTime()) return now;
+    await new Promise((r) => setTimeout(r, 25));
+  }
+  return readLastUsed(keyId);
+}
+
+async function newKey(name: string): Promise<string> {
+  // mintEmissionKey returns { raw, row } — the id is on `row`, not the top level.
+  const minted = await mintEmissionKey(memexId, name, userId);
+  createdKeyIds.push(minted.row.id);
+  return minted.row.id;
+}
+
+beforeAll(async () => {
+  memexId = await makeTestMemex("t6k");
+  const user = await upsertUserByEmail(`spec520-t6-${process.pid}@example.com`);
+  userId = user.id;
+});
+
+afterAll(async () => {
+  if (createdKeyIds.length) {
+    await db
+      .delete(memexEmissionKeys)
+      .where(inArray(memexEmissionKeys.id, createdKeyIds))
+      .catch(() => {});
+  }
+});
+
+describe("spec-520 ac-28: last_used_at is bumped at most once per window", () => {
+  it("writes the timestamp on the first use, when it is still NULL", async () => {
+    tagAc(AC_THROTTLE);
+    const keyId = await newKey("first-use");
+    expect(await readLastUsed(keyId)).toBeNull();
+
+    bumpLastUsed(keyId);
+    const after = await pollForBump(keyId, null);
+    // The NULL arm of the predicate must fire, or a brand-new key would never record a
+    // first use at all — the throttle would have turned "cheap" into "broken".
+    expect(after).not.toBeNull();
+  });
+
+  it("updates ZERO rows on an immediate second use — the row version is not rewritten", async () => {
+    tagAc(AC_THROTTLE);
+    const keyId = await newKey("within-window");
+
+    bumpLastUsed(keyId);
+    const first = await pollForBump(keyId, null);
+    expect(first).not.toBeNull();
+
+    // The whole point: a key emitting continuously must stop rewriting its row. This is
+    // the ~31 updates/s case measured on prod.
+    bumpLastUsed(keyId);
+    await new Promise((r) => setTimeout(r, 250));
+    expect((await readLastUsed(keyId))?.getTime()).toBe(first!.getTime());
+  });
+
+  it("updates the row again once the window has elapsed", async () => {
+    tagAc(AC_THROTTLE);
+    const keyId = await newKey("past-window");
+
+    bumpLastUsed(keyId);
+    const first = await pollForBump(keyId, null);
+    expect(first).not.toBeNull();
+
+    // Backdate rather than sleep five minutes. The predicate compares against the
+    // DATABASE's now(), so the fixture moves the stored value, not the clock.
+    await db
+      .update(memexEmissionKeys)
+      .set({ lastUsedAt: sql`now() - interval '10 minutes'` })
+      .where(eq(memexEmissionKeys.id, keyId));
+    const backdated = await readLastUsed(keyId);
+
+    bumpLastUsed(keyId);
+    const bumped = await pollForBump(keyId, backdated);
+    expect(bumped!.getTime()).toBeGreaterThan(backdated!.getTime());
+  });
+
+  it("touches only the key it was given", async () => {
+    tagAc(AC_THROTTLE);
+    // The predicate is an AND on top of the id match. Getting the boolean structure wrong
+    // — an OR where an AND belongs — would update every stale key on the table at once,
+    // which is worse than the cost being removed and would not show up in a single-key
+    // assertion.
+    const target = await newKey("target");
+    const bystander = await newKey("bystander");
+
+    bumpLastUsed(target);
+    expect(await pollForBump(target, null)).not.toBeNull();
+    await new Promise((r) => setTimeout(r, 100));
+    expect(await readLastUsed(bystander)).toBeNull();
+  });
+});

--- a/packages/server/src/services/emission-keys.ts
+++ b/packages/server/src/services/emission-keys.ts
@@ -1,5 +1,5 @@
 import { randomBytes, createHash } from "node:crypto";
-import { eq, and, isNull, or, gt, desc, sql } from "drizzle-orm";
+import { eq, and, isNull, or, gt, lt, desc, sql } from "drizzle-orm";
 import { db } from "../db/connection.js";
 import {
   memexEmissionKeys,
@@ -159,10 +159,36 @@ export function bumpLastUsed(keyId: string): void {
     {},
     { memexId: "", entity: "memex_emission_key", action: "updated" },
     async () => {
+      // spec-520 t-6 (ac-28): throttled to at most one write per key per window.
+      //
+      // Unpredicated, this fired one UPDATE per accepted emission against a table of
+      // roughly 1,100 rows. Measured on prod as a 600s delta 2026-08-28 (spec-520 c-9):
+      // 30.972 calls/s at 0.0426 ms — one per event, matching the event rate exactly —
+      // and 23.6M lifetime updates with 613 autovacuums chasing the dead tuples.
+      //
+      // The statement still runs on every emission; it just stops finding a row, so it
+      // writes no new row version and creates no dead tuple. That is the cheap half of
+      // this fix and it needs no call-site change: keeping the call unconditional means
+      // the throttle cannot be defeated by a caller that forgets it.
+      //
+      // Five minutes is chosen against the CONSUMER, not the cost: last_used_at answers
+      // "is this key live" in the settings UI. Nothing reads it at second-level
+      // freshness, so a value up to five minutes stale is still a true answer.
+      //
+      // The NULL arm is load-bearing — without it a brand-new key would never record a
+      // first use at all, and the throttle would have turned cheap into broken.
       await db
         .update(memexEmissionKeys)
         .set({ lastUsedAt: sql`now()` })
-        .where(eq(memexEmissionKeys.id, keyId));
+        .where(
+          and(
+            eq(memexEmissionKeys.id, keyId),
+            or(
+              isNull(memexEmissionKeys.lastUsedAt),
+              lt(memexEmissionKeys.lastUsedAt, sql`now() - interval '5 minutes'`),
+            ),
+          ),
+        );
     },
     { silent: true },
   ).catch((err) => {

--- a/packages/ui/src/pages/Pulse.test.tsx
+++ b/packages/ui/src/pages/Pulse.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {
@@ -467,3 +467,111 @@ describe('Pulse page', () => {
 
 // Placate the unused-import linter if `within` ends up unused in some refactors.
 void within;
+
+// ── spec-520 t-6 (ac-16 / ac-17 / ac-18): the poll pauses while the tab is hidden ──
+//
+// Pulse polls fetchDocs('spec', { include: ['acHealth'] }) every 15s. Leaving the route
+// already stopped it; being merely HIDDEN did not — a Pulse tab on a second monitor kept
+// firing for nobody, and each tick is the AC-health aggregate, 640–790 ms server-side on
+// prod. AcPanel, DecisionPanel and HomeValue all already gate on document.visibilityState;
+// this pins Pulse to the same behaviour.
+//
+// ⚠ FAKE TIMERS MUST BE INSTALLED BEFORE render(). Installing them afterwards does not
+// adopt the interval the mount already scheduled on the real clock, so advancing fake time
+// does nothing and the assertion reads as "the poll never fired" — which is exactly what a
+// correctly-paused poll looks like. Two of these three tests passed for that wrong reason
+// on the first draft.
+//
+// jsdom's document.visibilityState is a readonly getter, so it is redefined per test and
+// deleted after [per std-37 cl-5] — leaving it patched would silently change every later
+// test in this file.
+describe('Pulse — the AC-health poll pauses while the tab is hidden (spec-520 t-6)', () => {
+  const AC520 = (n: number) =>
+    `mindset-prod/memex-building-itself/specs/spec-520/acs/ac-${n}`;
+
+  function setVisibility(state: 'visible' | 'hidden') {
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => state,
+    });
+    document.dispatchEvent(new Event('visibilitychange'));
+  }
+
+  afterEach(() => {
+    // Restore jsdom's own getter rather than pinning 'visible' — a pinned value is
+    // indistinguishable from the real one until something depends on it changing.
+    delete (document as unknown as Record<string, unknown>).visibilityState;
+    vi.useRealTimers();
+  });
+
+  /** Mount with fake timers already running, and flush the mount's own fetch. */
+  async function mountWithFakeTimers() {
+    vi.useFakeTimers();
+    const view = renderPulse();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fetchDocsMock).toHaveBeenCalled();
+    fetchDocsMock.mockClear();
+    return view;
+  }
+
+  it('polls on a 15s interval while visible, and issues nothing while hidden [ac-16][ac-18]', async () => {
+    tagAc(AC520(16));
+    tagAc(AC520(18));
+
+    await mountWithFakeTimers();
+
+    // Visible: the interval is unchanged at 15s (ac-18). Asserted BEFORE hiding, so a
+    // paused-from-the-start poll cannot pass this test by never firing at all.
+    await vi.advanceTimersByTimeAsync(15_000);
+    expect(fetchDocsMock).toHaveBeenCalledTimes(1);
+
+    setVisibility('hidden');
+    fetchDocsMock.mockClear();
+
+    // Three full intervals with the tab hidden must produce nothing (ac-16).
+    await vi.advanceTimersByTimeAsync(45_000);
+    expect(fetchDocsMock).not.toHaveBeenCalled();
+  });
+
+  it('refreshes once immediately on becoming visible rather than waiting out the interval [ac-17]', async () => {
+    tagAc(AC520(17));
+
+    await mountWithFakeTimers();
+
+    setVisibility('hidden');
+    await vi.advanceTimersByTimeAsync(30_000);
+    fetchDocsMock.mockClear();
+
+    // The point of ac-17: a returning user must not read AC health that is up to 15s
+    // stale while the resumed interval counts down. The refresh is immediate — asserted
+    // with the clock advanced by ZERO.
+    setVisibility('visible');
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fetchDocsMock).toHaveBeenCalledTimes(1);
+
+    // …and the interval genuinely resumed, rather than the tab-show refresh being the
+    // only thing left alive.
+    fetchDocsMock.mockClear();
+    await vi.advanceTimersByTimeAsync(15_000);
+    expect(fetchDocsMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('still stops on unmount, so leaving the route ends the poll [ac-18]', async () => {
+    tagAc(AC520(18));
+
+    const view = await mountWithFakeTimers();
+
+    // Prove the poll was actually running first — otherwise the assertion below is
+    // vacuous and would hold against a component that never polled.
+    await vi.advanceTimersByTimeAsync(15_000);
+    expect(fetchDocsMock).toHaveBeenCalledTimes(1);
+
+    view.unmount();
+    fetchDocsMock.mockClear();
+
+    // The pre-existing guarantee. The visibility gate adds a second stop condition; it
+    // must not have replaced this one.
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(fetchDocsMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/pages/Pulse.tsx
+++ b/packages/ui/src/pages/Pulse.tsx
@@ -126,10 +126,51 @@ export function Pulse() {
       .catch(() => {})
       .finally(() => setSpecsLoading(false));
   }, []);
+  // Initial fetch + polling, paused while the tab is hidden (spec-520 t-6,
+  // ac-16/17/18).
+  //
+  // Leaving the route already stopped this — the interval clears on unmount and
+  // refreshSpecs is a stable useCallback([]). What it did NOT do is stop when the tab is
+  // merely hidden, so a Pulse tab on a second monitor or behind another window kept
+  // firing every 15 seconds for nobody. Each tick is the AC-health aggregate, measured at
+  // 640–790 ms server-side on prod, so an idle backgrounded tab was not free.
+  //
+  // This is the established local pattern, not a new one: AcPanel, DecisionPanel and
+  // HomeValue all start/stop on document.visibilityState. Pulse was the outlier — copied
+  // from AcPanel deliberately so the four read the same.
+  //
+  // The interval stays 15s. Whether Pulse should poll AT ALL is spec-408 dec-4's
+  // question (the same one for the presence band on this page) and is not settled here;
+  // the bus does not currently carry AC-health changes, which SpecList.tsx documents.
   useEffect(() => {
+    let timer: ReturnType<typeof setInterval> | null = null;
     refreshSpecs();
-    const id = setInterval(refreshSpecs, 15_000);
-    return () => clearInterval(id);
+    const start = () => {
+      if (timer !== null) return;
+      timer = setInterval(refreshSpecs, 15_000);
+    };
+    const stop = () => {
+      if (timer !== null) {
+        clearInterval(timer);
+        timer = null;
+      }
+    };
+    const onVisChange = () => {
+      if (document.visibilityState === 'visible') {
+        // Refresh once on tab-show rather than waiting out the remainder of the
+        // interval, so a returning user never reads stale AC health (ac-17).
+        refreshSpecs();
+        start();
+      } else {
+        stop();
+      }
+    };
+    if (document.visibilityState === 'visible') start();
+    document.addEventListener('visibilitychange', onVisChange);
+    return () => {
+      stop();
+      document.removeEventListener('visibilitychange', onVisChange);
+    };
   }, [refreshSpecs]);
 
   const pickerSpecs: SpecPickerSpec[] = useMemo(


### PR DESCRIPTION
**spec-520 t-6** — ac-16, ac-17, ac-18, ac-28. Two small independent changes, no migration, nothing renegotiated.

Spec: https://memex.ai/mindset-prod/memex-building-itself/specs/spec-520 · prod measurements in `c-9`.

## 1. The `last_used_at` throttle (ac-28)

`bumpLastUsed` fired an unpredicated `UPDATE` on every accepted emission against `memex_emission_keys` — a table of roughly **1,100 rows**. Measured on prod as a 600s delta, 2026-08-28:

| | |
|---|---|
| rate | **30.972 calls/s** (event rate: 30.973 — one per event, exactly) |
| mean | 0.0426 ms |
| lifetime | 23.6M updates, 613 autovacuums chasing the dead tuples |

Added `AND (last_used_at IS NULL OR last_used_at < now() - interval '5 minutes')`. **The statement still runs on every emission; it just stops finding a row** — so it writes no new row version and creates no dead tuple.

Three deliberate choices:

- **Five minutes is chosen against the CONSUMER, not the cost.** This timestamp answers *"is this key live"* in the settings UI. Nothing reads it at second-level freshness, so a value up to five minutes stale is still a true answer.
- **The window lives in the predicate, not the call site.** A caller that forgets the throttle cannot defeat it.
- **The `IS NULL` arm is load-bearing.** Without it a brand-new key would never record a first use at all — the throttle would have turned *cheap* into *broken*. There is a test for exactly that.

`services/mcp-tokens.ts` carries a **second** `bumpLastUsed` on a different table and a far lower-volume path. **Confirmed untouched by git, not assumed** — that is one of the task's criteria.

## 2. The Pulse visibility gate (ac-16, ac-17, ac-18)

Leaving the route already stopped the poll (interval clears on unmount, `refreshSpecs` is a stable `useCallback([])`). What it did **not** do is stop when the tab is merely **hidden** — a Pulse tab on a second monitor or behind another window kept firing every 15 seconds for nobody. Each tick is the AC-health aggregate, **640–790 ms server-side on prod**, so an idle backgrounded tab was not free.

This is the established local pattern, not a new one: `AcPanel`, `DecisionPanel` and `HomeValue` all start/stop on `document.visibilityState`. Pulse was the outlier — copied from `AcPanel` deliberately so the four read the same. Interval unchanged at 15s; refreshes once on becoming visible so a returning user never reads stale AC health.

Whether Pulse should poll **at all** stays spec-408 dec-4's question and is not settled here — the bus does not currently carry AC-health changes, which `SpecList.tsx` documents.

## Test method — two of these went green for the wrong reason first

**Fake timers must be installed BEFORE `render()`.** Installing them afterwards does not adopt the interval the mount already scheduled on the real clock, so advancing fake time does nothing — and the assertion then reads as *"the poll never fired"*, which is **indistinguishable from a correctly-paused poll**. The first draft passed two of three tests that way.

All three now mount under fake timers, and each asserts the poll **is running** before asserting it stops, so none can hold against a component that never polls.

**Red proven by reverting `Pulse.tsx` and re-running:** ac-16 and ac-17 fail without the fix. The third (stops on unmount) passes either way *by design* — it pins a pre-existing guarantee the visibility gate must not have replaced.

The throttle test is **DB-backed and polls for its write**: `bumpLastUsed` is deliberately fire-and-forget (returns void, `void mutate(…).catch()`, `silent: true`), so there is nothing to await [per std-37]. Asserting against a mock would prove only that we called a function. It also pins that the bump touches **only the key it was given** — an `OR` where the `AND` belongs would update every stale key on the table at once, which is worse than the cost being removed and invisible to a single-key assertion.

`document.visibilityState` is a readonly getter in jsdom, so it is redefined per test and **deleted** afterwards rather than pinned to `'visible'` [per std-37 cl-5] — a pinned value is indistinguishable from the real one until something depends on it changing.

## Test plan

- [x] Server suite — **6413 passed / 0 failed / 25 skipped**
- [x] UI suite — **2377 passed / 0 failed / 9 skipped**
- [x] Full Playwright e2e — **157 passed / 1 skipped / 0 failed**, clean worktree, cold DB
- [x] `make typecheck` clean · `pnpm --filter @memex/ui build` clean (`tsc --noEmit` alone misses what the CI build gate catches) · `make check` green
- [x] std-28: no new journey owed — no user-facing flow changes; the existing Pulse / AC-tab journeys are the regression gate, per the Spec's build notes
- [x] **ac-16, ac-17, ac-18, ac-28 all verified** — confirmed by re-reading the Spec, not inferred from a green suite

## Deviation

t-6's body says these *"ride PR 1"* alongside t-4 and t-5. **That grouping is stale** — neither has shipped, and both are independent of these two changes. Shipped alone rather than held for a batch that does not exist.

Note also that ac-28 describes the table as 912 rows; it measures ~1,100 now. The argument is unaffected — the point is the ratio of updates to rows.

## Independent of #643

That PR (t-15) branches from the same `develop` and touches only `services/issues.ts`. No overlap; either can land first.