### PR TITLE
perf(spec-520): stop rewriting a first-verified row that isn't changing (dec-7 option D)

### DIFF
--- a/packages/server/src/services/first-verified-throttle.integration.test.ts
+++ b/packages/server/src/services/first-verified-throttle.integration.test.ts
@@ -1,0 +1,136 @@
+// spec-520 dec-7 option D / ac-34 — the first-verified upsert stops rewriting a row it is
+// not changing.
+//
+// THE WASTE. `recordFirstVerified` runs on every non-hidden PASSING emission and does
+// `ON CONFLICT DO UPDATE SET first_verified_at = LEAST(existing, EXCLUDED)`. After the
+// first pass LEAST always returns the value ALREADY STORED — so every subsequent write
+// stores an identical value and still creates a new row version. Measured on prod
+// 2026-08-28 as a 600s delta: 30.972 calls/s at 0.0496 ms, one per event, ~21.3M lifetime
+// updates that changed nothing.
+//
+// ⚠ THE TEST-DESIGN TRAP, and it is the whole reason this file reads the way it does.
+// Asserting the stored VALUE is unchanged proves NOTHING here: LEAST already returns the
+// same value with or without the fix. A value assertion passes identically against the
+// wasteful implementation and the fixed one. What has to be observed is whether the ROW
+// WAS REWRITTEN — so these tests read `xmin`, the system column holding the transaction
+// that last wrote the row. Same value + same xmin = the statement found no row. Same value
+// + new xmin = the waste is still there.
+//
+// The second arm matters as much as the first: LEAST-wins exists for OUT-OF-ORDER arrival
+// (replays, backfills). A predicate that suppresses ALL conflicts rather than only the
+// ones where the stored value is already at or before the incoming one would silently turn
+// "earliest pass" into "first pass SEEN" — and no test asserting only the no-op case would
+// catch it.
+
+import { describe, it, expect, afterAll, beforeAll } from "vitest";
+import { eq, inArray, sql } from "drizzle-orm";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { db } from "../db/connection.js";
+import { acFirstVerified } from "../db/schema.js";
+import { recordFirstVerified } from "./test-event-retention.js";
+
+const AC_THROTTLE = "mindset-prod/memex-building-itself/specs/spec-520/acs/ac-34";
+
+const RUN = `spec520-d-${process.pid}-${Math.random().toString(36).slice(2, 8)}`;
+const refs: string[] = [];
+
+function refFor(name: string): string {
+  const r = `mindset-prod/fixture/specs/spec-1/acs/${RUN}-${name}`;
+  refs.push(r);
+  return r;
+}
+
+/** The stored date AND the row version that produced it. */
+async function readRow(subjectRef: string): Promise<{ at: string; xmin: string } | null> {
+  const rows = await db.execute(sql`
+    SELECT first_verified_at::text AS at, xmin::text AS xmin
+      FROM ac_first_verified WHERE subject_ref = ${subjectRef}
+  `);
+  const r = (rows as unknown as { at: string; xmin: string }[])[0];
+  return r ?? null;
+}
+
+beforeAll(async () => {
+  await db.delete(acFirstVerified).where(inArray(acFirstVerified.subjectRef, refs)).catch(() => {});
+});
+
+afterAll(async () => {
+  if (refs.length) {
+    await db
+      .delete(acFirstVerified)
+      .where(inArray(acFirstVerified.subjectRef, refs))
+      .catch(() => {});
+  }
+});
+
+describe("spec-520 ac-34: first-verified is written once, not on every passing event", () => {
+  it("writes on the first pass", async () => {
+    tagAc(AC_THROTTLE);
+    const ref = refFor("first");
+    expect(await readRow(ref)).toBeNull();
+
+    await recordFirstVerified(db, ref, new Date("2026-08-20T10:00:00.000Z"));
+    const row = await readRow(ref);
+    expect(row).not.toBeNull();
+    expect(new Date(row!.at).toISOString()).toBe("2026-08-20T10:00:00.000Z");
+  });
+
+  it("does NOT rewrite the row for a LATER pass — same value AND same row version", async () => {
+    tagAc(AC_THROTTLE);
+    const ref = refFor("later");
+    await recordFirstVerified(db, ref, new Date("2026-08-20T10:00:00.000Z"));
+    const before = await readRow(ref);
+
+    // The ~31/s case: an AC that is already green keeps emitting.
+    await recordFirstVerified(db, ref, new Date("2026-08-21T10:00:00.000Z"));
+    const after = await readRow(ref);
+
+    expect(after!.at).toBe(before!.at);
+    // THE assertion. Without the predicate the value is identical and xmin MOVES, because
+    // LEAST wrote the same date into a brand-new row version.
+    expect(after!.xmin).toBe(before!.xmin);
+  });
+
+  it("does NOT rewrite the row for an IDENTICAL timestamp either", async () => {
+    tagAc(AC_THROTTLE);
+    const ref = refFor("equal");
+    const at = new Date("2026-08-20T10:00:00.000Z");
+    await recordFirstVerified(db, ref, at);
+    const before = await readRow(ref);
+
+    await recordFirstVerified(db, ref, at);
+    const after = await readRow(ref);
+    expect(after!.xmin).toBe(before!.xmin);
+  });
+
+  it("STILL writes for a genuinely EARLIER pass — LEAST-wins survives the throttle", async () => {
+    tagAc(AC_THROTTLE);
+    const ref = refFor("earlier");
+    await recordFirstVerified(db, ref, new Date("2026-08-20T10:00:00.000Z"));
+    const before = await readRow(ref);
+
+    // Out-of-order arrival: a replay or backfill carrying an earlier first pass. This is
+    // the arm a careless predicate breaks, turning "earliest" into "first seen".
+    await recordFirstVerified(db, ref, new Date("2026-08-01T09:00:00.000Z"));
+    const after = await readRow(ref);
+
+    expect(new Date(after!.at).toISOString()).toBe("2026-08-01T09:00:00.000Z");
+    expect(after!.xmin).not.toBe(before!.xmin);
+  });
+
+  it("touches only the ref it was given", async () => {
+    tagAc(AC_THROTTLE);
+    const target = refFor("target");
+    const bystander = refFor("bystander");
+    await recordFirstVerified(db, bystander, new Date("2026-08-20T10:00:00.000Z"));
+    const bystanderBefore = await readRow(bystander);
+
+    await recordFirstVerified(db, target, new Date("2026-08-22T10:00:00.000Z"));
+
+    // A predicate written without the id/ref conjunct in the right place could suppress or
+    // rewrite unrelated rows; a single-ref assertion would never see it.
+    const bystanderAfter = await readRow(bystander);
+    expect(bystanderAfter!.xmin).toBe(bystanderBefore!.xmin);
+    expect(bystanderAfter!.at).toBe(bystanderBefore!.at);
+  });
+});

--- a/packages/server/src/services/first-verified-throttle.integration.test.ts
+++ b/packages/server/src/services/first-verified-throttle.integration.test.ts
@@ -23,7 +23,7 @@
 // catch it.
 
 import { describe, it, expect, afterAll, beforeAll } from "vitest";
-import { eq, inArray, sql } from "drizzle-orm";
+import { inArray, sql } from "drizzle-orm";
 import { tagAc } from "@memex-ai-ac/vitest";
 import { db } from "../db/connection.js";
 import { acFirstVerified } from "../db/schema.js";

--- a/packages/server/src/services/test-event-retention.ts
+++ b/packages/server/src/services/test-event-retention.ts
@@ -53,10 +53,33 @@ export async function recordFirstVerified(
 ): Promise<void> {
   // Pass the timestamp as an ISO string + explicit cast: a raw drizzle `sql`
   // template has no column-type context, so postgres.js can't bind a bare Date.
+  // spec-520 dec-7 option D (ac-34): the DO UPDATE is now predicated, so it stops
+  // rewriting a row it is not changing.
+  //
+  // Without the WHERE, LEAST returns the value ALREADY STORED on every pass after the
+  // first — so the statement wrote an identical date into a brand-new row version, every
+  // time. Measured on prod 2026-08-28 as a 600s delta: 30.972 calls/s at 0.0496 ms, one
+  // per passing event, ~21.3M lifetime updates that changed nothing. The statement still
+  // runs; it now finds no row, so there is no new row version and no dead tuple.
+  //
+  // ⚠ THE WHERE MUST COMPARE, NOT JUST SUPPRESS. LEAST-wins exists for OUT-OF-ORDER
+  // arrival — a replay or backfill carrying an EARLIER first pass must still win, or
+  // "earliest pass" quietly becomes "first pass SEEN". `stored > EXCLUDED` fires exactly
+  // when LEAST would actually change the value and never otherwise. A blanket
+  // `DO NOTHING` would have been cheaper to write and would have broken that silently.
+  //
+  // LEAST is kept in the SET even though the WHERE already implies it: it states the
+  // intent at the point of the write, and it keeps the statement correct if the predicate
+  // is ever loosened.
+  //
+  // Note this is the COST half only. `ac_first_verified` still exists, is still read, and
+  // still has no memex_id — see dec-7 for why the retirement (ac-23) was separated from
+  // this and deliberately left open.
   await conn.execute(sql`
     INSERT INTO ac_first_verified (subject_ref, first_verified_at)
     VALUES (${subjectRef}, ${at.toISOString()}::timestamptz)
     ON CONFLICT (subject_ref) DO UPDATE
       SET first_verified_at = LEAST(ac_first_verified.first_verified_at, EXCLUDED.first_verified_at)
+      WHERE ac_first_verified.first_verified_at > EXCLUDED.first_verified_at
   `);
 }


### PR DESCRIPTION
**spec-520 dec-7 option D / ac-34.** One predicate. No migration, no data touched.

Spec: https://memex.ai/mindset-prod/memex-building-itself/specs/spec-520 · the bind this is a partial answer to is `dec-7`; prod measurements in `c-9`.

## The waste

`recordFirstVerified` runs on every non-hidden **passing** emission and does `ON CONFLICT DO UPDATE SET first_verified_at = LEAST(existing, EXCLUDED)`.

After the first pass, **LEAST always returns the value already stored** — so every subsequent write stored an identical date into a brand-new row version. Measured on prod as a 600s delta, 2026-08-28: **30.972 calls/s at 0.0496 ms**, one per passing event (event rate: 30.973), ~21.3M lifetime updates that changed nothing.

Added `WHERE ac_first_verified.first_verified_at > EXCLUDED.first_verified_at`. The statement still runs; it now finds no row, so there is no new row version and no dead tuple.

## The predicate must COMPARE, not just suppress

`LEAST`-wins exists for **out-of-order arrival** — a replay or backfill carrying an *earlier* first pass must still win, or *"earliest pass"* quietly becomes *"first pass **seen**"*.

`stored > EXCLUDED` fires exactly when LEAST would change the value and never otherwise. A blanket `DO NOTHING` would have been shorter to write and would have broken that silently. There is a test for that arm specifically.

## The test-design trap — why this file reads the way it does

**Asserting the stored VALUE is unchanged proves nothing here.** LEAST returns the same value with or without the fix, so a value assertion passes identically against the wasteful implementation and the fixed one — a test that could never fail for the reason it exists.

What has to be observed is whether the **row was rewritten**, so the tests read `xmin`, the system column holding the transaction that last wrote the row:

```
same value + same xmin  ->  the statement found no row      (fixed)
same value + new  xmin  ->  the waste is still there
```

The red proved it precisely: `expected '2506068' to be '2506067'` — one transaction apart, identical date.

Five cases:

| | |
|---|---|
| first pass | writes |
| a **later** pass | does not rewrite (same xmin) |
| an **identical** timestamp | does not rewrite |
| a genuinely **earlier** pass | still writes — LEAST-wins survives |
| a bystander ref | untouched (a predicate misplaced relative to the conflict target could suppress or rewrite unrelated rows, which no single-ref assertion would see) |

## What this deliberately does NOT do

This is **option D: the cost half only.**

`ac_first_verified` still exists, is still read at `analytics.ts:373`, and still has **no `memex_id`** — so it still cannot carry an RLS policy even once spec-399 lands, and its reader still scopes by `subject_ref LIKE prefix%`, the spec-396 tenancy-by-ref-string pattern this Spec closes elsewhere.

**That retirement is ac-23 and it stays OPEN.** `dec-7` records why the halves were separated: the rollup is a **counter** table and `ac_first_verified` holds a **date**, so folding one into the other means inventing a `test_identifier` it does not have and a `pass_count` that fabricates ~18,839 test runs into the exact chart ac-24 exists to correct. Options B/C/E remain live; **B is the standing recommendation**.

⚠ **Do not let D become the answer by default.** The cost pressure that made this urgent is gone once it lands — which is exactly when an open question stops being asked.

## Test plan

- [x] Driven red→green on `xmin`, not on the value
- [x] Full server suite — **6422 passed / 0 failed / 25 skipped**
- [x] Full Playwright e2e — **157 passed / 1 skipped / 0 failed**, clean worktree, cold DB
- [x] `make typecheck` clean · `make check` green
- [x] std-28: no new journey owed — no user-facing flow changes
- [x] **ac-34 verified**
- [ ] ac-23 remains untested by design — this PR does not attempt it