### PR TITLE
perf(spec-520): move the volume chart and the auto-resolve gate off the raw log (t-11, partial)

### DIFF
--- a/packages/server/src/routes/analytics.integration.test.ts
+++ b/packages/server/src/routes/analytics.integration.test.ts
@@ -19,7 +19,7 @@ vi.hoisted(() => {
 import { db } from "../db/connection.js";
 import { acs, activityLog, documents, memexes, namespaces, testEventLatest, testEvents } from "../db/schema.js";
 import { app } from "../app.js";
-import { makeTestMemexWithDevAdmin } from "../services/test-helpers.js";
+import { makeTestMemexWithDevAdmin, seedTestEvent } from "../services/test-helpers.js";
 
 const AC_OVER_TIME = "mindset-prod/memex-building-itself/specs/spec-179/acs/ac-1";
 const AC_BY_PHASE_AND_DURATIONS = "mindset-prod/memex-building-itself/specs/spec-179/acs/ac-2";
@@ -315,9 +315,13 @@ describe("GET /analytics/acs-over-time and /analytics/test-run-volume", () => {
     await mkAc(3, "2026-06-02T00:00:00Z");
 
     const prefix = `${m.slug}/main/specs/spec-mom/acs`;
-    const emit = (acN: number, status: string, at: string, hidden = false) =>
-      db.insert(testEvents).values({
-        memexId: m.memexId,
+    // spec-520 t-11: seeded through the helper so all three tiers are written, as the
+    // emission route does. testRunVolume now reads the per-day rollup (ac-24) rather than
+    // counting raw rows retention has already deleted, so a raw-only fixture would leave
+    // this chart empty — which is exactly the production defect being fixed, reproduced in
+    // a fixture.
+    const emit = (acN: number, status: "pass" | "fail" | "error", at: string, hidden = false) =>
+      seedTestEvent({
         subjectRef: `${prefix}/ac-${acN}`,
         status,
         testIdentifier: `t-${acN}`,
@@ -361,8 +365,18 @@ describe("GET /analytics/acs-over-time and /analytics/test-run-volume", () => {
       points: Array<{ day: string; pass: number; fail: number; error: number }>;
     };
     expect(vol.find((p) => p.day === "2026-06-01")).toMatchObject({ pass: 0, fail: 1, error: 0 });
-    // Jun 2: visible pass + hidden pass + error — hidden runs ARE volume.
-    expect(vol.find((p) => p.day === "2026-06-02")).toMatchObject({ pass: 2, fail: 0, error: 1 });
+    // ⚠ SEMANTIC CHANGE, spec-520 t-11, and deliberately narrow. This used to read
+    // `pass: 2` because the old testRunVolume counted RAW test_events rows with no
+    // `hidden` filter, so a hidden run counted as volume. The rollup skips hidden
+    // emissions, matching applyEmissionToSummary — `hidden` means "excluded from
+    // verification signals", and the rollup is the verification/analytics tier.
+    //
+    // This branch is UNREACHABLE in production: spec-358 froze `hidden` at false on the
+    // ingest path, and the rollup only ever holds post-ship-date rows, so no hidden
+    // emission can enter it. The fixture reaches it only by seeding hidden:true directly.
+    // If the old semantics is wanted back, the change is in applyEmissionToRollup — but
+    // then a hidden run also lands in pass/fail/error, which feed verification.
+    expect(vol.find((p) => p.day === "2026-06-02")).toMatchObject({ pass: 1, fail: 0, error: 1 });
     expect(vol.find((p) => p.day === "2026-06-03")).toMatchObject({ pass: 1, fail: 0, error: 0 });
   });
 });
@@ -376,6 +390,10 @@ describe("GET /analytics/test-signal-pulse", () => {
     const prefix = `${m.slug}/main/specs/spec-pulse/acs`;
     // Emit a handful of recent events (default createdAt = now()), so they land
     // in the current minute bucket of the rolling window.
+    // Deliberately a RAW insert, unlike `emit` above: testSignalPulse is one of the two
+    // consumers t-11 leaves on the raw log (a minutes-wide window), so the raw row IS the
+    // representative shape for it. Do not "tidy" this into seedTestEvent without checking
+    // that its hidden-counts-as-volume assertion still holds.
     const emitNow = (acN: number, status: string, hidden = false) =>
       db.insert(testEvents).values({
         memexId: m.memexId,

--- a/packages/server/src/routes/test-events-tenant-context.rls-restricted.test.ts
+++ b/packages/server/src/routes/test-events-tenant-context.rls-restricted.test.ts
@@ -44,6 +44,7 @@ import { upsertUserByEmail } from "../services/users.js";
 import { ensureUserNamespace } from "../services/user-namespaces.js";
 import { createDocDraft } from "../services/documents.js";
 import { mintEmissionKey } from "../services/emission-keys.js";
+import { seedTestEvent } from "../services/test-helpers.js";
 import { maybeAutoResolveIssuesForAcUid } from "../services/issues.js";
 import { app } from "../app.js";
 
@@ -183,14 +184,18 @@ describe("spec-520 ac-32: the DIAGNOSIS — tenant context is what the chain nee
   it("WITH tenant context the same call resolves the same Issue", async () => {
     tagAc(AC_TENANT_CONTEXT);
     // Give the AC a green event first: verifyingAcIsGreen gates the resolve.
+    //
+    // spec-520 t-11: seeded through the helper, not a bare insert. This used to insert a
+    // raw test_events row only, and passed because verifyingAcIsGreen scanned the raw log.
+    // ac-25 moved that gate to test_event_latest, and this went red immediately — the
+    // fixture had been writing a shape production never writes (the emission route
+    // maintains all three tiers in one transaction).
     await runWithMemexId(memexId, async () => {
-      await db.insert(testEvents).values({
-        memexId,
+      await seedTestEvent({
         subjectRef: acRef,
         status: "pass",
         testIdentifier: "spec520-t7::diagnosis",
-        durationMs: 1,
-      } as typeof testEvents.$inferInsert);
+      });
     });
 
     const resolved = await runWithMemexId(memexId, async () =>

--- a/packages/server/src/services/analytics.ts
+++ b/packages/server/src/services/analytics.ts
@@ -421,20 +421,35 @@ export interface TestRunVolumePoint {
  * verification badge. Gapless from the first emission to today.
  */
 export async function testRunVolume(memexId: string): Promise<TestRunVolumePoint[]> {
-  const [slugs] = (await db.execute(sql`
-    SELECT n.slug AS ns, m.slug AS mx
-    FROM memexes m JOIN namespaces n ON n.id = m.namespace_id
-    WHERE m.id = ${memexId}
-  `)) as unknown as Array<{ ns: string; mx: string }>;
-  if (!slugs) return [];
-  const prefix = `${slugs.ns}/${slugs.mx}/`;
-
+  // spec-520 t-11 (ac-24): reads the per-day ROLLUP, not the raw log.
+  //
+  // THE DEFECT THIS CLOSES. This counted rows in `test_events` — a table the retention
+  // trim caps at RETENTION_KEEP per (subject_ref, test_identifier). So it counted rows
+  // that had already been deleted, and the chart sloped upward as an artefact of deletion
+  // rather than because activity grew. Measured on prod 2026-08-18: the summary tier
+  // declared 23,718,476 runs while 1,072,186 raw rows survived — the chart was showing
+  // 4.5% of what happened. And the loss is NOT uniform: 65,708 pairs sat at exactly the
+  // cap of 10, so the busier an AC, the shorter its visible history. A volume chart that
+  // under-counts hardest where there is most activity inverts the story it exists to tell.
+  //
+  // ⚠ HISTORY STARTS AT THE ROLLUP'S SHIP DATE (2026-08-27). The per-day past was already
+  // deleted and cannot be reconstructed, so this chart is now CORRECT but SHORT. That is
+  // the fix landing, not a regression — but a chart spanning the boundary must say so on
+  // its face (ac-5, ac-6), or a truncated past reads as measured absence.
+  //
+  // Scoped by memex_id, which also retires the `subject_ref LIKE 'ns/mx/%'` predicate this
+  // used to carry — tenancy by string prefix, the spec-396 leak pattern (a real cross-org
+  // bleed of ~1.5M rows across 137 memexes) that this Spec closes elsewhere. The slug
+  // lookup it needed is gone with it.
   const rows = (await db.execute(sql`
     WITH per_day AS (
-      SELECT created_at::date AS day, status, count(*)::int AS n
-      FROM test_events
-      WHERE subject_ref LIKE ${prefix + "%"}
-      GROUP BY 1, 2
+      SELECT day,
+             sum(pass_count)::int  AS pass,
+             sum(fail_count)::int  AS fail,
+             sum(error_count)::int AS error
+      FROM test_run_daily
+      WHERE memex_id = ${memexId}
+      GROUP BY day
     ),
     days AS (
       SELECT generate_series(
@@ -445,12 +460,11 @@ export async function testRunVolume(memexId: string): Promise<TestRunVolumePoint
     )
     SELECT
       to_char(days.day, 'YYYY-MM-DD') AS day,
-      COALESCE(sum(per_day.n) FILTER (WHERE per_day.status = 'pass'), 0)::int AS pass,
-      COALESCE(sum(per_day.n) FILTER (WHERE per_day.status = 'fail'), 0)::int AS fail,
-      COALESCE(sum(per_day.n) FILTER (WHERE per_day.status = 'error'), 0)::int AS error
+      COALESCE(per_day.pass, 0)::int  AS pass,
+      COALESCE(per_day.fail, 0)::int  AS fail,
+      COALESCE(per_day.error, 0)::int AS error
     FROM days
     LEFT JOIN per_day ON per_day.day = days.day
-    GROUP BY days.day
     ORDER BY days.day
   `)) as unknown as TestRunVolumePoint[];
   return rows;

--- a/packages/server/src/services/issues-conversions.integration.test.ts
+++ b/packages/server/src/services/issues-conversions.integration.test.ts
@@ -33,7 +33,7 @@ import {
 } from "./issues.js";
 import { buildAcRef } from "./acs.js";
 import { searchMemex } from "./memex-search.js";
-import { makeTestMemex } from "./test-helpers.js";
+import { makeTestMemex, seedTestEvent } from "./test-helpers.js";
 import { tagAc } from "@memex-ai-ac/vitest";
 
 const AC = (n: number) =>
@@ -97,8 +97,13 @@ async function emitEvent(
   at: Date = new Date(),
 ): Promise<void> {
   createdAcUids.push(subjectRef);
-  await db.insert(testEvents).values({
-    memexId,
+  // spec-520 t-11: seed through the helper, not a bare insert. The emission route
+  // maintains test_events, test_event_latest AND the per-day rollup in one
+  // transaction, so a raw-only row is a shape production never writes. This fixture
+  // used to insert raw only and passed purely because verifyingAcIsGreen scanned the
+  // raw log; the moment that gate moved to the summary (ac-25) it went red — the
+  // fixture had been unrepresentative all along.
+  await seedTestEvent({
     subjectRef,
     status,
     testIdentifier: "tests/example.test.ts::it",

--- a/packages/server/src/services/issues.ts
+++ b/packages/server/src/services/issues.ts
@@ -34,7 +34,7 @@ import {
   acs,
   acParentLinks,
   taskSatisfiesAc,
-  testEvents,
+  testEventLatest,
   memexes,
   namespaces,
 } from "../db/schema.js";
@@ -471,11 +471,24 @@ async function verifyingAcIsGreen(satisfyingTaskId: string, docId: string): Prom
   // the general case so multi-AC tasks don't resolve prematurely.
   for (const link of links) {
     const subjectRef = buildAcRef(slugs, link.seq);
+    // spec-520 t-11 (ac-25): read the verdict from the SUMMARY, not by scanning the raw
+    // log. test_event_latest already holds the newest emission per (subject_ref,
+    // test_identifier), so the newest overall is the row with the greatest latest_run_at —
+    // the same answer, without depending on a row the raw log may no longer have.
+    //
+    // That dependency is why this had to move: t-12 replaces count-based retention with a
+    // short TIME window, at which point the newest emission for a long-since-verified AC
+    // ages out and this gate would start answering "not green" for ACs that are.
+    //
+    // One deliberate semantic gain: the summary EXCLUDES hidden emissions (spec-115), which
+    // this raw scan did not. Hidden means "excluded from verification signals", so reading
+    // the summary is the more correct behaviour, not merely the cheaper one. Only historical
+    // rows can be hidden — spec-358 froze the column at false.
     const [latest] = await db
-      .select({ status: testEvents.status })
-      .from(testEvents)
-      .where(eq(testEvents.subjectRef, subjectRef))
-      .orderBy(desc(testEvents.createdAt))
+      .select({ status: testEventLatest.latestStatus })
+      .from(testEventLatest)
+      .where(eq(testEventLatest.subjectRef, subjectRef))
+      .orderBy(desc(testEventLatest.latestRunAt))
       .limit(1);
     if (!latest || latest.status !== "pass") return false;
   }

--- a/packages/server/src/services/t11-rebased-consumers.integration.test.ts
+++ b/packages/server/src/services/t11-rebased-consumers.integration.test.ts
@@ -1,0 +1,220 @@
+// spec-520 t-11 — the two consumers that could be re-based cleanly.
+//
+// ac-24 (testRunVolume) and ac-25 (verifyingAcIsGreen). The other two named by t-11 are
+// NOT here and not attempted:
+//   • auditCiEmissionForBrief needs run_id + metadata, which test_event_latest does not
+//     carry — dec-8.
+//   • listAcAlignmentOverTime's first-verified half reads ac_first_verified, which dec-7
+//     deliberately left in place.
+//
+// THE PROOF SHAPE ac-24 ASKS FOR is "results no longer change when raw events age out".
+// So these tests seed the DERIVED tier and leave the raw log EMPTY. Under the old
+// implementation that is indistinguishable from "nothing ever happened" — which is exactly
+// the defect: the charts read a log that retention had already emptied. Seeding the raw log
+// too would let a still-broken implementation pass.
+
+import { describe, it, expect, afterAll, beforeAll } from "vitest";
+import { and, eq, inArray } from "drizzle-orm";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { db, runWithMemexId } from "../db/connection.js";
+import {
+  acs,
+  documents,
+  issues,
+  memexes,
+  namespaces,
+  taskSatisfiesAc,
+  tasks,
+  testEventLatest,
+  testEvents,
+  testRunDaily,
+} from "../db/schema.js";
+import { testRunVolume } from "./analytics.js";
+import { createDocDraft } from "./documents.js";
+import { maybeAutoResolveIssuesForTask } from "./issues.js";
+import { makeTestMemex } from "./test-helpers.js";
+import { upsertUserByEmail } from "./users.js";
+
+// NARROWED to ac-35 / ac-36 rather than ac-24 / ac-25 (2026-08-28). Each of those states
+// TWO consumers and only one of each pair could be moved — listAcAlignmentOverTime is
+// blocked on dec-7, auditCiEmissionForBrief on dec-8. Tagging the two-consumer criteria
+// from half the work would flip them green on a weaker property than they state, which is
+// exactly why ac-22 and ac-32 were split. It briefly happened here before these existed;
+// the stale emissions on ac-24/ac-25 were retired with discontinue_test_events.
+const AC_CHARTS = "mindset-prod/memex-building-itself/specs/spec-520/acs/ac-35";
+const AC_LATEST = "mindset-prod/memex-building-itself/specs/spec-520/acs/ac-36";
+
+let memexId: string;
+let userId: string;
+let namespaceSlug: string;
+let memexSlug: string;
+const createdDocIds: string[] = [];
+const createdRefs: string[] = [];
+
+beforeAll(async () => {
+  memexId = await makeTestMemex("t11");
+  const user = await upsertUserByEmail(`spec520-t11-${process.pid}@example.com`);
+  userId = user.id;
+  const [row] = await db
+    .select({ m: memexes.slug, n: namespaces.slug })
+    .from(memexes)
+    .innerJoin(namespaces, eq(memexes.namespaceId, namespaces.id))
+    .where(eq(memexes.id, memexId))
+    .limit(1);
+  memexSlug = row!.m;
+  namespaceSlug = row!.n;
+});
+
+afterAll(async () => {
+  await db.delete(testRunDaily).where(eq(testRunDaily.memexId, memexId)).catch(() => {});
+  if (createdRefs.length) {
+    await db.delete(testEventLatest).where(inArray(testEventLatest.subjectRef, createdRefs)).catch(() => {});
+    await db.delete(testEvents).where(inArray(testEvents.subjectRef, createdRefs)).catch(() => {});
+  }
+  if (createdDocIds.length) {
+    await db.delete(documents).where(inArray(documents.id, createdDocIds)).catch(() => {});
+  }
+});
+
+describe("spec-520 ac-24: testRunVolume reads the rollup, not the raw log", () => {
+  it("reports the counts the rollup holds even with NO raw events at all", async () => {
+    tagAc(AC_CHARTS);
+
+    const ref = `${namespaceSlug}/${memexSlug}/specs/spec-1/acs/ac-1`;
+    createdRefs.push(ref);
+
+    // The rollup is the durable tier. The raw log is left EMPTY on purpose — that is the
+    // aged-out state the charts have been misreading as "no activity".
+    await db.insert(testRunDaily).values([
+      { memexId, subjectRef: ref, testIdentifier: "a::t", day: "2026-08-20", runCount: 5, passCount: 4, failCount: 1, errorCount: 0 },
+      { memexId, subjectRef: ref, testIdentifier: "b::t", day: "2026-08-20", runCount: 3, passCount: 3, failCount: 0, errorCount: 0 },
+      { memexId, subjectRef: ref, testIdentifier: "a::t", day: "2026-08-21", runCount: 2, passCount: 1, failCount: 0, errorCount: 1 },
+    ] as (typeof testRunDaily.$inferInsert)[]);
+
+    const points = await testRunVolume(memexId);
+    const byDay = new Map(points.map((p) => [p.day, p]));
+
+    // Summed ACROSS test_identifiers, which is what a per-day volume chart means.
+    expect(byDay.get("2026-08-20")).toMatchObject({ pass: 7, fail: 1, error: 0 });
+    expect(byDay.get("2026-08-21")).toMatchObject({ pass: 1, fail: 0, error: 1 });
+  });
+
+  it("is scoped by memex_id, not by a subject_ref string prefix", async () => {
+    tagAc(AC_CHARTS);
+
+    // The old read matched `subject_ref LIKE 'ns/mx/%'` — tenancy carried by a string,
+    // which is the spec-396 leak pattern this Spec closes elsewhere. A row belonging to
+    // another tenant must not appear however its ref happens to read.
+    const otherMemexId = await makeTestMemex("t11b");
+    const foreignRef = `${namespaceSlug}/${memexSlug}/specs/spec-9/acs/ac-9`;
+    createdRefs.push(foreignRef);
+    await db.insert(testRunDaily).values({
+      memexId: otherMemexId,
+      subjectRef: foreignRef,
+      testIdentifier: "x::t",
+      day: "2026-08-20",
+      runCount: 99,
+      passCount: 99,
+      failCount: 0,
+      errorCount: 0,
+    } as typeof testRunDaily.$inferInsert);
+
+    const points = await testRunVolume(memexId);
+    const day = points.find((p) => p.day === "2026-08-20");
+    // 7, not 106 — the foreign row carries this memex's ref prefix but another memex_id.
+    expect(day?.pass).toBe(7);
+
+    await db.delete(testRunDaily).where(eq(testRunDaily.memexId, otherMemexId)).catch(() => {});
+  });
+});
+
+describe("spec-520 ac-25: the auto-resolve gate reads test_event_latest, not the raw log", () => {
+  it("resolves a converted Issue from the SUMMARY alone, with the raw log empty", async () => {
+    tagAc(AC_LATEST);
+
+    const built = await runWithMemexId(memexId, async () => {
+      const doc = await createDocDraft(memexId, `t11 gate ${process.pid}`, "", "spec");
+      createdDocIds.push(doc.id);
+
+      const [ac] = await db
+        .insert(acs)
+        .values({ memexId, briefId: doc.id, seq: 1, kind: "implementation", statement: "verifies", status: "active" } as typeof acs.$inferInsert)
+        .returning();
+      const [task] = await db
+        .insert(tasks)
+        .values({ memexId, docId: doc.id, seq: 1, title: "satisfying", description: "", status: "complete" } as typeof tasks.$inferInsert)
+        .returning();
+      await db.insert(taskSatisfiesAc).values({ taskId: task!.id, acId: ac!.id } as typeof taskSatisfiesAc.$inferInsert);
+      const [issue] = await db
+        .insert(issues)
+        .values({ memexId, docId: doc.id, seq: 1, title: "awaiting green", body: "", type: "bug", severity: "high", status: "converted", source: "agent", satisfyingTaskId: task!.id, createdByUserId: userId } as typeof issues.$inferInsert)
+        .returning();
+      return { handle: doc.handle, taskId: task!.id, issueId: issue!.id };
+    });
+
+    const ref = `${namespaceSlug}/${memexSlug}/specs/${built.handle}/acs/ac-1`;
+    createdRefs.push(ref);
+
+    // ONLY the summary. No raw test_events row exists — the state after retention has aged
+    // the passing event out. The old implementation scans test_events, finds nothing, and
+    // refuses to resolve; that is the red.
+    await runWithMemexId(memexId, async () => {
+      await db.insert(testEventLatest).values({
+        subjectRef: ref,
+        memexId,
+        testIdentifier: "suite::verifies",
+        latestStatus: "pass",
+        latestRunAt: new Date("2026-08-20T10:00:00.000Z"),
+        runCount: 1,
+      } as typeof testEventLatest.$inferInsert);
+    });
+
+    const resolved = await runWithMemexId(memexId, async () =>
+      maybeAutoResolveIssuesForTask(memexId, built.taskId),
+    );
+    expect(resolved).toContain(built.issueId);
+  });
+
+  it("still refuses when the summary's latest is a FAIL", async () => {
+    tagAc(AC_LATEST);
+
+    const built = await runWithMemexId(memexId, async () => {
+      const doc = await createDocDraft(memexId, `t11 gate red ${process.pid}`, "", "spec");
+      createdDocIds.push(doc.id);
+      const [ac] = await db
+        .insert(acs)
+        .values({ memexId, briefId: doc.id, seq: 1, kind: "implementation", statement: "verifies", status: "active" } as typeof acs.$inferInsert)
+        .returning();
+      const [task] = await db
+        .insert(tasks)
+        .values({ memexId, docId: doc.id, seq: 1, title: "satisfying", description: "", status: "complete" } as typeof tasks.$inferInsert)
+        .returning();
+      await db.insert(taskSatisfiesAc).values({ taskId: task!.id, acId: ac!.id } as typeof taskSatisfiesAc.$inferInsert);
+      const [issue] = await db
+        .insert(issues)
+        .values({ memexId, docId: doc.id, seq: 1, title: "awaiting green", body: "", type: "bug", severity: "high", status: "converted", source: "agent", satisfyingTaskId: task!.id, createdByUserId: userId } as typeof issues.$inferInsert)
+        .returning();
+      return { handle: doc.handle, taskId: task!.id, issueId: issue!.id };
+    });
+
+    const ref = `${namespaceSlug}/${memexSlug}/specs/${built.handle}/acs/ac-1`;
+    createdRefs.push(ref);
+
+    await runWithMemexId(memexId, async () => {
+      await db.insert(testEventLatest).values({
+        subjectRef: ref,
+        memexId,
+        testIdentifier: "suite::verifies",
+        latestStatus: "fail",
+        latestRunAt: new Date("2026-08-20T10:00:00.000Z"),
+        runCount: 1,
+      } as typeof testEventLatest.$inferInsert);
+    });
+
+    // Re-basing must not weaken the gate into "a row exists" — the STATUS still decides.
+    const resolved = await runWithMemexId(memexId, async () =>
+      maybeAutoResolveIssuesForTask(memexId, built.taskId),
+    );
+    expect(resolved).toEqual([]);
+  });
+});

--- a/packages/server/src/services/t11-rebased-consumers.integration.test.ts
+++ b/packages/server/src/services/t11-rebased-consumers.integration.test.ts
@@ -14,7 +14,7 @@
 // too would let a still-broken implementation pass.
 
 import { describe, it, expect, afterAll, beforeAll } from "vitest";
-import { and, eq, inArray } from "drizzle-orm";
+import { eq, inArray } from "drizzle-orm";
 import { tagAc } from "@memex-ai-ac/vitest";
 import { db, runWithMemexId } from "../db/connection.js";
 import {

--- a/packages/server/src/services/test-helpers.ts
+++ b/packages/server/src/services/test-helpers.ts
@@ -8,6 +8,7 @@ import { namespaces, orgs, memexes, orgMemberships, testEvents, users } from "..
 import { upsertUserByEmail } from "./users.js";
 import { ensureUserNamespace } from "./user-namespaces.js";
 import { applyEmissionToSummary } from "./test-event-latest.js";
+import { applyEmissionToRollup } from "./test-run-daily.js";
 import { resolveMemexId } from "./emission-keys.js";
 
 function uniqueSlug(prefix: string): string {
@@ -27,12 +28,17 @@ export interface SeedTestEventInput {
 }
 
 /**
- * Seed a test_events row the way the real emission route does (spec-162):
- * insert the log row AND maintain the test_event_latest summary in ONE
- * transaction. Integration tests that assert on the badge read paths
- * (aggregateAcHealthForBriefs / listAcsForBriefWithVerification) must seed via
- * this helper — a bare db.insert(testEvents) leaves the summary the reads
- * consume empty, so the AC would read as untested.
+ * Seed a test_events row the way the real emission route does: insert the log row
+ * AND maintain every derived tier, in ONE transaction — test_event_latest
+ * (spec-162) and, since spec-520 t-9, the per-day test_run_daily rollup.
+ *
+ * ALWAYS seed through this helper. A bare `db.insert(testEvents)` writes a shape
+ * PRODUCTION NEVER PRODUCES: the emission route maintains all three tiers
+ * together, so a raw-only row is not a smaller version of a real emission, it is
+ * an impossible one. Fixtures that did it worked only for as long as the consumer
+ * under test happened to read the raw log — spec-520 t-11 moved two consumers to
+ * the derived tiers and two such fixtures failed immediately, which is the test
+ * suite noticing a defect in itself rather than a regression in the code.
  */
 export async function seedTestEvent(input: SeedTestEventInput): Promise<void> {
   const hidden = input.hidden ?? false;
@@ -66,6 +72,18 @@ export async function seedTestEvent(input: SeedTestEventInput): Promise<void> {
       testIdentifier,
       status: input.status,
       latestRunAt: row.createdAt,
+      hidden,
+    });
+    // spec-520 t-9: the third tier. Keep this in step with routes/test-events.ts —
+    // a fixture that maintains only some of the tiers is the shape production
+    // never writes, and it silently invalidates any test whose consumer reads the
+    // tier the fixture skipped.
+    await applyEmissionToRollup(tx, {
+      subjectRef: input.subjectRef,
+      memexId,
+      testIdentifier,
+      status: input.status,
+      runAt: row.createdAt,
       hidden,
     });
   });


### PR DESCRIPTION
**spec-520 t-11 — two of its four consumers.** The other two could not move and are recorded as decisions rather than guessed at.

Spec: https://memex.ai/mindset-prod/memex-building-itself/specs/spec-520 · prod measurements in `c-9` and `s-4 §5`.

## `testRunVolume` → the per-day rollup (ac-35)

It counted rows in `test_events`, a table retention caps per `(subject_ref, test_identifier)`. So it counted rows **already deleted**, and sloped upward as an artefact of deletion rather than because activity grew.

Measured on prod 2026-08-18: the summary tier declared **23,718,476 runs** while **1,072,186** raw rows survived — the chart showed **4.5%** of what happened. And not uniformly: **65,708 pairs sat at exactly the cap of 10**, so the busier an AC the shorter its visible history. A volume chart that under-counts hardest where there is most activity inverts the story it exists to tell.

Also drops `subject_ref LIKE 'ns/mx/%'` for `memex_id = $1` — tenancy carried by a string, the spec-396 leak pattern (a real cross-org bleed of ~1.5M rows across 137 memexes) this Spec closes elsewhere. A test asserts a foreign-tenant row carrying this Memex's ref prefix does not appear.

⚠ **History starts at the rollup's ship date (2026-08-27).** The chart is now **correct but short** — ac-5/ac-6 require any chart spanning that boundary to say so on its face.

## `verifyingAcIsGreen` → `test_event_latest` (ac-36)

Needed, not merely cheaper. It reads the latest emission for an AC that is **already verified**, so the row can be arbitrarily old. **t-12 replaces count-based retention with a short time window**, at which point that row ages out and the gate starts answering *"not green"* for ACs that are green.

One deliberate semantic gain: the summary excludes hidden emissions, which the raw scan did not. `hidden` means *"excluded from verification signals"*, so this is the more correct behaviour, not only the cheaper one.

## A fixture defect this exposed — and the root fix

**Three suites seeded raw `test_events` rows with a bare `db.insert` instead of `seedTestEvent`** — a shape **production never writes**, since the emission route maintains all three tiers in one transaction. They passed only for as long as the consumer under test happened to read the raw log. The moment two consumers moved to the derived tiers, all three went red.

That is the suite noticing a defect **in itself**, not a regression in the code — the same class as the spec-533 guards that were green because a missing mock made the auto-resolve chain throw and be swallowed.

**Root fix rather than three patched assertions:** `seedTestEvent` now maintains the rollup too (it already did `test_event_latest`), so it fully mirrors the route, and the three fixtures route through it. Its docstring says why a bare insert is not a smaller version of a real emission but an impossible one.

`analytics.integration.test.ts`'s *other* helper stays a raw insert **on purpose**, with a comment: `testSignalPulse` is one of the two consumers t-11 deliberately leaves on the raw log.

## One semantic change, stated rather than buried

A pinned assertion read *"hidden runs ARE volume"* (the old read had no `hidden` filter). The rollup skips hidden, matching `applyEmissionToSummary`.

**The branch is unreachable in production** — spec-358 froze `hidden` at false and the rollup only holds post-ship rows — so the fixture reached it only by seeding `hidden: true` directly. The assertion now carries that reasoning and names exactly where to reverse it.

## Why ac-24 and ac-25 are NOT tagged

Each states **two** consumers and only one of each pair could move:

- **`listAcAlignmentOverTime`** — its first-verified half reads `ac_first_verified`, which **dec-7** deliberately left in place. Blocked on that decision.
- **`auditCiEmissionForBrief`** — reads `run_id` and `metadata`, which `test_event_latest` **does not carry at all**. t-11's claim that *"the summary table already holds it"* is true of the status and the time and **false of the provenance**. That is **dec-8**, and a hard prerequisite for t-12: once retention is a time window, that function silently reports *"no non-CI emissions"* instead of the truth.

Tagging ac-24/ac-25 from half the work would flip them green on a weaker property than they state — the exact failure ac-22/ac-32 were split to avoid. **It briefly happened** before ac-35/ac-36 existed; the stale emissions were retired with `discontinue_test_events` and both are back to `untested`, which is the truth.

## Test plan

- [x] Driven red→green — the three tests that should fail did, the one that holds either way did not
- [x] Full server suite — **6426 passed / 0 failed / 25 skipped**
- [x] Restricted-role suite — **13/13** (one of the three unrepresentative fixtures lived here)
- [x] `make typecheck` clean · `make check` green
- [x] std-28: no new journey owed — no user-facing flow changes
- [x] **ac-35 and ac-36 verified**; ac-24 and ac-25 deliberately left untested
- [x] The two consumers that must stay on the raw log (`testSignalPulse`, the `activity_view` test-events arm) confirmed unchanged by diff

## Follow-on

**dec-8 blocks t-12** and is raised by this PR. t-11 stays open on its other half.