### PR TITLE
feat(spec-520): give ac_first_verified the tenancy column it never had (dec-7 option C)

### DIFF
--- a/packages/server/drizzle/0136_spec520_first_verified_tenancy.sql
+++ b/packages/server/drizzle/0136_spec520_first_verified_tenancy.sql
@@ -1,0 +1,71 @@
+-- spec-520 dec-7 option C (ac-23 amended) — give ac_first_verified the tenancy column it
+-- has never had, so it can be isolated like every other tenant table.
+--
+-- WHY THE TABLE STAYS. t-10 planned to fold this into the per-day rollup and drop it. It
+-- cannot be folded: the fact is per (memex_id, subject_ref) — "when did this subject first
+-- go green" — while the rollup's grain is (memex_id, subject_ref, test_identifier, day).
+-- Storing a date at a finer grain than it has forces either a sentinel row with an invented
+-- test_identifier and day, or the date duplicated across every row for that subject and
+-- rewritten daily. Both are worse than a second small table. dec-7 has the full reasoning.
+--
+-- WHAT WAS ACTUALLY WRONG WITH IT — and it is not the storage, it is the tenancy.
+-- `ac_first_verified` is subject_ref PK + first_verified_at, with NO memex_id at all. So it
+-- cannot carry an RLS policy even once spec-399 lands, and its only reader (acsOverTime's
+-- first_pass CTE, services/analytics.ts) scopes by `subject_ref LIKE 'ns/mx/%'` — tenancy
+-- carried by a STRING. That is the spec-396 leak pattern: a real cross-org bleed of ~1.5M
+-- rows across 137 memexes, whose fix was to stop parsing tenancy out of ref strings at read
+-- time. This table never adopted it. That is what this migration closes.
+--
+-- NO DATA MOVES. Every existing row stays exactly where it is with its date untouched —
+-- which matters more here than anywhere: this table exists ONLY because retention destroyed
+-- the first-green date once already, and losing it again while "improving" it would be a
+-- particularly bad repeat.
+--
+-- memex_id IS NULLABLE, DELIBERATELY. The backfill resolves it from test_event_latest,
+-- which carries memex_id for each subject_ref and is never trimmed by retention. A ref with
+-- no surviving summary row — a discontinued AC, a deleted Spec — cannot be resolved, and
+-- the rule from dec-7 is that such a row is ENUMERATED, never silently discarded. Leaving
+-- the column nullable keeps the row and its date: under RLS a NULL memex_id matches no
+-- tenant, so it is invisible to the product but fully visible to the owner role for
+-- inspection. A NOT NULL here would have forced the migration to either fail or delete.
+--
+-- Count what is left behind after applying:
+--   SELECT count(*) FROM ac_first_verified WHERE memex_id IS NULL;
+
+ALTER TABLE ac_first_verified ADD COLUMN IF NOT EXISTS memex_id uuid;
+
+-- Backfill from the summary tier. DISTINCT because test_event_latest is keyed
+-- (subject_ref, test_identifier) — one subject can have many test identifiers, but they all
+-- belong to the same memex, so any one of them answers the question.
+UPDATE ac_first_verified a
+   SET memex_id = l.memex_id
+  FROM (SELECT DISTINCT subject_ref, memex_id FROM test_event_latest) l
+ WHERE a.subject_ref = l.subject_ref
+   AND a.memex_id IS NULL;
+
+-- Index the tenancy column: the read is now `WHERE memex_id = $1` and this table is small
+-- but read on every Insights page load. Cheap to add now, awkward once it is hot.
+CREATE INDEX IF NOT EXISTS ac_first_verified_memex_id_idx ON ac_first_verified (memex_id);
+
+-- ENABLE, never FORCE [per std-36]. FORCE would apply RLS to the table OWNER too, and on
+-- Cloud SQL the migration/deploy role is `postgres`, which is not a real superuser and lacks
+-- BYPASSRLS — under FORCE every migration and admin query here would be filtered to nothing.
+-- 0081 shipped FORCE and 0093 had to undo it; the dynamic guard in
+-- db/spec-199-rls-schema.test.ts fails CI on any forced tenant table.
+ALTER TABLE ac_first_verified ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS ac_first_verified_memex_isolation ON ac_first_verified;
+CREATE POLICY ac_first_verified_memex_isolation ON ac_first_verified
+  USING (
+    nullif(current_setting('app.memex_id', true), '') IS NOT NULL
+    AND memex_id = current_setting('app.memex_id', true)::uuid
+  )
+  WITH CHECK (
+    nullif(current_setting('app.memex_id', true), '') IS NOT NULL
+    AND memex_id = current_setting('app.memex_id', true)::uuid
+  );
+
+-- Byte-identical to every other tenant policy on purpose. A table whose isolation reads
+-- differently is a table someone has to reason about separately, and this one has no reason
+-- to be special.
+GRANT SELECT, INSERT, UPDATE, DELETE ON ac_first_verified TO memex_app;

--- a/packages/server/src/db/rls-tables.ts
+++ b/packages/server/src/db/rls-tables.ts
@@ -20,6 +20,9 @@
 // is an identity-establishment table read BEFORE any tenant context exists, so
 // it must stay RLS-free (pinned by __regression__/emission-key-contextless-verify).
 export const RLS_TENANT_TABLES: ReadonlySet<string> = new Set([
+  // spec-520 dec-7 option C — gated by migration 0136. Registering it here also arms
+  // spec-440's context guard for it.
+  "ac_first_verified",
   "acs",
   "clause_refs",
   "comment_mentions",

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -1138,6 +1138,19 @@ export const acFirstVerified = pgTable("ac_first_verified", {
   // spec-151 dec-3: renamed ac_uid → subject_ref (AC ref OR clause ref).
   subjectRef: text("subject_ref").primaryKey(),
   firstVerifiedAt: timestamp("first_verified_at", { withTimezone: true }).notNull(),
+  // spec-520 dec-7 option C (migration 0136): the tenancy column this table never had.
+  //
+  // Without it the table could not carry an RLS policy at all, and its only reader scoped
+  // by `subject_ref LIKE 'ns/mx/%'` — tenancy carried by a STRING, the spec-396 leak
+  // pattern this Spec closes elsewhere. That, not the storage cost, was what was actually
+  // wrong with this table.
+  //
+  // NULLABLE on purpose. Backfilled from test_event_latest; a subject_ref with no surviving
+  // summary row (a discontinued AC, a deleted Spec) cannot be resolved, and dec-7's rule is
+  // that such a row is ENUMERATED, never discarded — this table exists because first-green
+  // dates were lost once already. Under RLS a NULL memex_id matches no tenant, so the row is
+  // invisible to the product and fully visible to the owner role for inspection.
+  memexId: uuid("memex_id"),
 });
 
 // ══════════════════════════════════════

--- a/packages/server/src/routes/analytics.integration.test.ts
+++ b/packages/server/src/routes/analytics.integration.test.ts
@@ -341,13 +341,21 @@ describe("GET /analytics/acs-over-time and /analytics/test-run-volume", () => {
     // snapshot (retention deletes the oldest pass from test_events), not
     // min(created_at) over the log. Seed it the way migration 0110 backfills:
     // earliest NON-hidden pass per subject_ref.
+    // spec-520 dec-7 option C: ac_first_verified now carries memex_id, and the read scopes
+    // by it instead of by a subject_ref prefix. A fixture that inserts the row WITHOUT the
+    // tenant writes a shape production no longer produces — the row exists and is invisible,
+    // which is indistinguishable from "this AC never went green".
+    //
+    // Seeded through the real writer rather than hand-rolled SQL, for the same reason
+    // seedTestEvent exists: the fixture then cannot drift from the path it stands in for.
     await db.execute(sql`
-      INSERT INTO ac_first_verified (subject_ref, first_verified_at)
-      SELECT subject_ref, min(created_at) FROM test_events
+      INSERT INTO ac_first_verified (subject_ref, first_verified_at, memex_id)
+      SELECT subject_ref, min(created_at), ${m.memexId}::uuid FROM test_events
       WHERE subject_ref LIKE ${prefix + "/%"} AND status = 'pass' AND hidden = false
       GROUP BY subject_ref
       ON CONFLICT (subject_ref) DO UPDATE
-        SET first_verified_at = LEAST(ac_first_verified.first_verified_at, EXCLUDED.first_verified_at)
+        SET first_verified_at = LEAST(ac_first_verified.first_verified_at, EXCLUDED.first_verified_at),
+            memex_id = COALESCE(ac_first_verified.memex_id, EXCLUDED.memex_id)
     `);
 
     const otRes = await app.request(`${path}/analytics/acs-over-time`, withApexHost());

--- a/packages/server/src/routes/first-verified-tenancy.rls-restricted.test.ts
+++ b/packages/server/src/routes/first-verified-tenancy.rls-restricted.test.ts
@@ -1,0 +1,132 @@
+// spec-520 dec-7 option C — ac_first_verified is tenancy-isolated, and the READ still works.
+//
+// Runs ONLY under vitest.rls.config.ts, as the restricted `memex_app` role. In the default
+// owner-connection suite RLS is bypassed entirely (std-36: ENABLE, never FORCE), so every
+// assertion here passes there for the wrong reason.
+//
+// WHY THIS FILE HAD TO EXIST BEFORE THE POLICY SHIPPED. issue-8 was the WRITE-side version
+// of this trap: a context-less write to an RLS-gated table is rejected in prod while dev and
+// CI stay green. This is the READ-side twin, and it is quieter — a context-less READ returns
+// FEWER ROWS rather than an error, which is indistinguishable from "this AC never went
+// green". The chart would simply flatten to zero and nobody would get an exception.
+//
+// dec-7 named it as a build constraint: "confirm the read is ALS-wrapped before enabling the
+// policy, or the chart silently returns nothing under the non-owner role."
+
+import { describe, it, expect, afterAll, beforeAll } from "vitest";
+import { eq, inArray, sql } from "drizzle-orm";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { db, runWithMemexId } from "../db/connection.js";
+import { acFirstVerified, acs, documents, memexes, namespaces, users } from "../db/schema.js";
+import { createDocDraft } from "../services/documents.js";
+import { recordFirstVerified } from "../services/test-event-retention.js";
+import { acsOverTime } from "../services/analytics.js";
+import { upsertUserByEmail } from "../services/users.js";
+import { ensureUserNamespace } from "../services/user-namespaces.js";
+
+const AC_TENANCY = "mindset-prod/memex-building-itself/specs/spec-520/acs/ac-37";
+
+const runId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+let memexId: string;
+let userId: string;
+let namespaceSlug: string;
+let docId: string;
+let acRef: string;
+
+beforeAll(async () => {
+  const user = await upsertUserByEmail(`spec520-c-${runId}@example.com`);
+  userId = user.id;
+  const created = await ensureUserNamespace(userId);
+  memexId = created.memex.id;
+  const [ns] = await db
+    .select({ slug: namespaces.slug })
+    .from(namespaces)
+    .where(eq(namespaces.id, created.memex.namespaceId))
+    .limit(1);
+  namespaceSlug = ns!.slug;
+
+  await runWithMemexId(memexId, async () => {
+    const doc = await createDocDraft(memexId, `spec520 optC ${runId}`, "", "spec");
+    docId = doc.id;
+    await db.insert(acs).values({
+      memexId,
+      briefId: docId,
+      seq: 1,
+      kind: "implementation",
+      statement: "the criterion that went green",
+      status: "active",
+    } as typeof acs.$inferInsert);
+    acRef = `${namespaceSlug}/${created.memex.slug}/specs/${doc.handle}/acs/ac-1`;
+  });
+});
+
+afterAll(async () => {
+  await runWithMemexId(memexId, async () => {
+    await db.delete(acFirstVerified).where(eq(acFirstVerified.subjectRef, acRef)).catch(() => {});
+    if (docId) await db.delete(documents).where(eq(documents.id, docId)).catch(() => {});
+  });
+  await db.delete(memexes).where(eq(memexes.id, memexId)).catch(() => {});
+  await db.delete(namespaces).where(eq(namespaces.slug, namespaceSlug)).catch(() => {});
+  await db.delete(users).where(inArray(users.id, [userId])).catch(() => {});
+});
+
+describe("spec-520 ac-37: ac_first_verified is isolated, and its reader still sees its own rows", () => {
+  it("a write from the emission path satisfies the policy", async () => {
+    tagAc(AC_TENANCY);
+    // The WRITE half. Under memex_app this INSERT's WITH CHECK is evaluated for real; the
+    // emission route runs inside runWithMemexId (issue-8), which is what makes it satisfiable.
+    await runWithMemexId(memexId, async () =>
+      recordFirstVerified(db, acRef, new Date("2026-08-20T10:00:00.000Z"), memexId),
+    );
+
+    const rows = await runWithMemexId(memexId, async () =>
+      db
+        .select({ at: acFirstVerified.firstVerifiedAt, memexId: acFirstVerified.memexId })
+        .from(acFirstVerified)
+        .where(eq(acFirstVerified.subjectRef, acRef)),
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.memexId).toBe(memexId);
+  });
+
+  it("THE READ WORKS under the restricted role — acsOverTime still counts the first pass", async () => {
+    tagAc(AC_TENANCY);
+
+    // THE assertion this file exists for. If the reader were not ALS-wrapped, this would
+    // return a curve of zeroes rather than throw — the silent shape. A non-zero verified
+    // count proves the policy and the read agree.
+    const points = await runWithMemexId(memexId, async () => acsOverTime(memexId));
+    const verified = points.reduce((n, p) => n + p.verified, 0);
+    expect(verified).toBeGreaterThan(0);
+  });
+
+  it("another tenant sees none of it", async () => {
+    tagAc(AC_TENANCY);
+    // Reads under a foreign tenant rather than with NO context: with app.memex_id unset the
+    // policy's ::uuid cast can be evaluated before the guarding IS NOT NULL conjunct — SQL
+    // does not promise AND short-circuits — and the query errors instead of returning empty.
+    // Erroring still "proves" the policy is attached, but by a route indistinguishable from a
+    // dozen other faults. A foreign tenant exercises the predicate the way production does.
+    const other = "00000000-0000-4000-8000-000000000042";
+    const leaked = await runWithMemexId(other, async () =>
+      db
+        .select({ subjectRef: acFirstVerified.subjectRef })
+        .from(acFirstVerified)
+        .where(eq(acFirstVerified.subjectRef, acRef)),
+    );
+    expect(leaked).toEqual([]);
+  });
+
+  it("the policy is ENABLEd and NOT FORCEd", async () => {
+    tagAc(AC_TENANCY);
+    // std-36: FORCE would apply RLS to the table OWNER too, and on Cloud SQL the deploy role
+    // is not a superuser and lacks BYPASSRLS — every migration against this table would then
+    // be filtered to nothing. 0081 shipped FORCE and 0093 had to undo it.
+    const [row] = (await db.execute(sql`
+      SELECT relrowsecurity AS enabled, relforcerowsecurity AS forced
+        FROM pg_class WHERE relname = 'ac_first_verified'
+    `)) as unknown as Array<{ enabled: boolean; forced: boolean }>;
+    expect(row.enabled).toBe(true);
+    expect(row.forced).toBe(false);
+  });
+});

--- a/packages/server/src/routes/test-events.ts
+++ b/packages/server/src/routes/test-events.ts
@@ -567,7 +567,7 @@ async function processOneEvent(
         // spec-398 t-6: durably snapshot the earliest pass BEFORE retention can
         // trim it away, so analytics keeps a true "first went green" date.
         if (insertValues.status === "pass" && !insertValues.hidden) {
-          await recordFirstVerified(tx, insertValues.subjectRef, inserted.createdAt);
+          await recordFirstVerified(tx, insertValues.subjectRef, inserted.createdAt, targetMemexId);
         }
         return inserted;
       });

--- a/packages/server/src/services/analytics.ts
+++ b/packages/server/src/services/analytics.ts
@@ -355,14 +355,10 @@ export interface AcsOverTimePoint {
  * emissions for since-deleted ACs are a tolerable over-count noted here.
  */
 export async function acsOverTime(memexId: string): Promise<AcsOverTimePoint[]> {
-  const [slugs] = (await db.execute(sql`
-    SELECT n.slug AS ns, m.slug AS mx
-    FROM memexes m JOIN namespaces n ON n.id = m.namespace_id
-    WHERE m.id = ${memexId}
-  `)) as unknown as Array<{ ns: string; mx: string }>;
-  if (!slugs) return [];
-  const prefix = `${slugs.ns}/${slugs.mx}/`;
-
+  // spec-520 dec-7 option C: the slug lookup that used to run here is gone with the
+  // prefix it fed. Both CTEs now scope by memex_id, so this function no longer needs to
+  // know its own namespace/memex slugs — one fewer query per Insights page load, and one
+  // fewer place where tenancy is reconstructed from strings.
   const rows = (await db.execute(sql`
     WITH created_per_day AS (
       SELECT created_at::date AS day, count(*)::int AS n
@@ -375,9 +371,17 @@ export async function acsOverTime(memexId: string): Promise<AcsOverTimePoint[]> 
     -- deletes the oldest passing row, so the operational log can no longer answer
     -- "when did this AC first go green". One row per subject_ref already, so no min().
     first_pass AS (
+      -- spec-520 dec-7 option C: scoped by memex_id, not by a subject_ref STRING PREFIX.
+      -- The old LIKE 'ns/mx/%' predicate carried tenancy in a string — the spec-396 leak pattern
+      -- (a real cross-org bleed of ~1.5M rows across 137 memexes), whose whole fix was to
+      -- stop parsing tenancy out of refs at read time. This table never adopted it; 0136
+      -- gives it the column and this is the read catching up.
+      --
+      -- Rows the 0136 backfill could not resolve carry a NULL memex_id and so match no
+      -- tenant here. They are preserved, not deleted — see the migration.
       SELECT subject_ref, first_verified_at::date AS day
       FROM ac_first_verified
-      WHERE subject_ref LIKE ${prefix + "%"}
+      WHERE memex_id = ${memexId}
     ),
     verified_per_day AS (
       SELECT day, count(*)::int AS n FROM first_pass GROUP BY 1

--- a/packages/server/src/services/first-verified-throttle.integration.test.ts
+++ b/packages/server/src/services/first-verified-throttle.integration.test.ts
@@ -28,10 +28,16 @@ import { tagAc } from "@memex-ai-ac/vitest";
 import { db } from "../db/connection.js";
 import { acFirstVerified } from "../db/schema.js";
 import { recordFirstVerified } from "./test-event-retention.js";
+import { makeTestMemex } from "./test-helpers.js";
 
 const AC_THROTTLE = "mindset-prod/memex-building-itself/specs/spec-520/acs/ac-34";
 
 const RUN = `spec520-d-${process.pid}-${Math.random().toString(36).slice(2, 8)}`;
+// spec-520 dec-7 option C: ac_first_verified now carries memex_id, so the writer needs a
+// real tenant. Under the default OWNER connection RLS is bypassed (std-36: ENABLE, never
+// FORCE), so this file still exercises the throttle rather than the policy — the policy is
+// proven separately under the restricted role.
+let memexId: string;
 const refs: string[] = [];
 
 function refFor(name: string): string {
@@ -51,6 +57,7 @@ async function readRow(subjectRef: string): Promise<{ at: string; xmin: string }
 }
 
 beforeAll(async () => {
+  memexId = await makeTestMemex("d");
   await db.delete(acFirstVerified).where(inArray(acFirstVerified.subjectRef, refs)).catch(() => {});
 });
 
@@ -69,7 +76,7 @@ describe("spec-520 ac-34: first-verified is written once, not on every passing e
     const ref = refFor("first");
     expect(await readRow(ref)).toBeNull();
 
-    await recordFirstVerified(db, ref, new Date("2026-08-20T10:00:00.000Z"));
+    await recordFirstVerified(db, ref, new Date("2026-08-20T10:00:00.000Z"), memexId);
     const row = await readRow(ref);
     expect(row).not.toBeNull();
     expect(new Date(row!.at).toISOString()).toBe("2026-08-20T10:00:00.000Z");
@@ -78,11 +85,11 @@ describe("spec-520 ac-34: first-verified is written once, not on every passing e
   it("does NOT rewrite the row for a LATER pass — same value AND same row version", async () => {
     tagAc(AC_THROTTLE);
     const ref = refFor("later");
-    await recordFirstVerified(db, ref, new Date("2026-08-20T10:00:00.000Z"));
+    await recordFirstVerified(db, ref, new Date("2026-08-20T10:00:00.000Z"), memexId);
     const before = await readRow(ref);
 
     // The ~31/s case: an AC that is already green keeps emitting.
-    await recordFirstVerified(db, ref, new Date("2026-08-21T10:00:00.000Z"));
+    await recordFirstVerified(db, ref, new Date("2026-08-21T10:00:00.000Z"), memexId);
     const after = await readRow(ref);
 
     expect(after!.at).toBe(before!.at);
@@ -95,10 +102,10 @@ describe("spec-520 ac-34: first-verified is written once, not on every passing e
     tagAc(AC_THROTTLE);
     const ref = refFor("equal");
     const at = new Date("2026-08-20T10:00:00.000Z");
-    await recordFirstVerified(db, ref, at);
+    await recordFirstVerified(db, ref, at, memexId);
     const before = await readRow(ref);
 
-    await recordFirstVerified(db, ref, at);
+    await recordFirstVerified(db, ref, at, memexId);
     const after = await readRow(ref);
     expect(after!.xmin).toBe(before!.xmin);
   });
@@ -106,12 +113,12 @@ describe("spec-520 ac-34: first-verified is written once, not on every passing e
   it("STILL writes for a genuinely EARLIER pass — LEAST-wins survives the throttle", async () => {
     tagAc(AC_THROTTLE);
     const ref = refFor("earlier");
-    await recordFirstVerified(db, ref, new Date("2026-08-20T10:00:00.000Z"));
+    await recordFirstVerified(db, ref, new Date("2026-08-20T10:00:00.000Z"), memexId);
     const before = await readRow(ref);
 
     // Out-of-order arrival: a replay or backfill carrying an earlier first pass. This is
     // the arm a careless predicate breaks, turning "earliest" into "first seen".
-    await recordFirstVerified(db, ref, new Date("2026-08-01T09:00:00.000Z"));
+    await recordFirstVerified(db, ref, new Date("2026-08-01T09:00:00.000Z"), memexId);
     const after = await readRow(ref);
 
     expect(new Date(after!.at).toISOString()).toBe("2026-08-01T09:00:00.000Z");
@@ -122,10 +129,10 @@ describe("spec-520 ac-34: first-verified is written once, not on every passing e
     tagAc(AC_THROTTLE);
     const target = refFor("target");
     const bystander = refFor("bystander");
-    await recordFirstVerified(db, bystander, new Date("2026-08-20T10:00:00.000Z"));
+    await recordFirstVerified(db, bystander, new Date("2026-08-20T10:00:00.000Z"), memexId);
     const bystanderBefore = await readRow(bystander);
 
-    await recordFirstVerified(db, target, new Date("2026-08-22T10:00:00.000Z"));
+    await recordFirstVerified(db, target, new Date("2026-08-22T10:00:00.000Z"), memexId);
 
     // A predicate written without the id/ref conjunct in the right place could suppress or
     // rewrite unrelated rows; a single-ref assertion would never see it.

--- a/packages/server/src/services/spec-398-retention.integration.test.ts
+++ b/packages/server/src/services/spec-398-retention.integration.test.ts
@@ -193,11 +193,15 @@ describe("spec-398 retention + tenancy", () => {
       .limit(1);
     expect(tel.memexId).toBe(memexId);
     // first-verified snapshot recorded too.
-    await recordFirstVerified(db, subjectRef, new Date(Date.UTC(2026, 0, 1)));
+    // spec-520 dec-7 option C: the snapshot now carries the tenant too, so the writer takes
+    // the memexId. The assertion below gains a tenancy check for the same reason the row
+    // gained the column — this table used to be scoped purely by ref string.
+    await recordFirstVerified(db, subjectRef, new Date(Date.UTC(2026, 0, 1)), memexId);
     const [fv] = await db
-      .select({ at: acFirstVerified.firstVerifiedAt })
+      .select({ at: acFirstVerified.firstVerifiedAt, memexId: acFirstVerified.memexId })
       .from(acFirstVerified)
       .where(eq(acFirstVerified.subjectRef, subjectRef));
+    expect(fv!.memexId).toBe(memexId);
     expect(fv).toBeDefined();
   });
 

--- a/packages/server/src/services/test-event-retention.ts
+++ b/packages/server/src/services/test-event-retention.ts
@@ -50,6 +50,7 @@ export async function recordFirstVerified(
   conn: Db,
   subjectRef: string,
   at: Date,
+  memexId: string,
 ): Promise<void> {
   // Pass the timestamp as an ISO string + explicit cast: a raw drizzle `sql`
   // template has no column-type context, so postgres.js can't bind a bare Date.
@@ -76,10 +77,17 @@ export async function recordFirstVerified(
   // still has no memex_id — see dec-7 for why the retirement (ac-23) was separated from
   // this and deliberately left open.
   await conn.execute(sql`
-    INSERT INTO ac_first_verified (subject_ref, first_verified_at)
-    VALUES (${subjectRef}, ${at.toISOString()}::timestamptz)
+    INSERT INTO ac_first_verified (subject_ref, first_verified_at, memex_id)
+    VALUES (${subjectRef}, ${at.toISOString()}::timestamptz, ${memexId}::uuid)
     ON CONFLICT (subject_ref) DO UPDATE
-      SET first_verified_at = LEAST(ac_first_verified.first_verified_at, EXCLUDED.first_verified_at)
+      SET first_verified_at = LEAST(ac_first_verified.first_verified_at, EXCLUDED.first_verified_at),
+          -- spec-520 dec-7 option C: heal a NULL left by the 0136 backfill. A row whose ref
+          -- had no surviving test_event_latest match could not be resolved at migration time;
+          -- the next emission for it knows the memex and fills it in. Never OVERWRITES a
+          -- resolved value — a ref cannot change tenant, so a differing value would be a bug
+          -- worth keeping visible rather than silently reconciling.
+          memex_id = COALESCE(ac_first_verified.memex_id, EXCLUDED.memex_id)
       WHERE ac_first_verified.first_verified_at > EXCLUDED.first_verified_at
+         OR ac_first_verified.memex_id IS NULL
   `);
 }


### PR DESCRIPTION
**spec-520 dec-7 option C / ac-37.** Migration `0136`. No data moves.

Spec: https://memex.ai/mindset-prod/memex-building-itself/specs/spec-520 · the reasoning is `dec-7`.

## Why the table stays

t-10 planned to fold this into the per-day rollup and drop it. **It cannot be folded.**

The fact is per `(memex_id, subject_ref)` — *"when did this subject first go green"*. The rollup's grain is `(memex_id, subject_ref, test_identifier, day)`, which is **finer**. Storing a date at a finer grain than it has forces one of two bad shapes:

- a sentinel row with an **invented** `test_identifier` and `day` — reintroducing exactly the invention the option was chosen to avoid; or
- the date **duplicated** across every row for that subject, rewritten daily, and wrong the moment two rows disagree.

Both are worse than a second small table.

## What was actually wrong with it — the tenancy, not the storage

`ac_first_verified` was `subject_ref` PK + `first_verified_at`, with **no `memex_id` at all**. So it could not carry an RLS policy even once spec-399 lands, and its only reader scoped by `subject_ref LIKE 'ns/mx/%'`.

That is **tenancy carried by a string** — the spec-396 leak pattern (a real cross-org bleed of ~1.5M rows across 137 memexes), whose whole fix was to stop parsing tenancy out of refs at read time. This table never adopted it. `0136` closes that.

**No data moves.** Every row keeps its date exactly where it is — which matters more here than anywhere, because this table exists *only* because retention destroyed the first-green date once already.

## `memex_id` is nullable, deliberately

Backfilled from `test_event_latest`, which carries the memex for each `subject_ref` and is never trimmed. A ref with no surviving summary row — a discontinued AC, a deleted Spec — **cannot** be resolved, and dec-7's rule is that such a row is **enumerated, never discarded**.

Nullable keeps the row *and* its date: under the policy a NULL `memex_id` matches no tenant, so it is invisible to the product and fully visible to the owner role.

```sql
SELECT count(*) FROM ac_first_verified WHERE memex_id IS NULL;
```

The writer heals those NULLs on the next emission for that ref (`COALESCE`, never overwriting a resolved value — a ref cannot change tenant, so a differing value would be a bug worth keeping visible).

## The READ is the half that needed proving, and it is the quiet one

**issue-8 was the write-side version of this trap**: a context-less write to an RLS-gated table is rejected in prod while dev and CI stay green.

This is its twin and it fails **more softly** — a context-less READ returns *fewer rows* rather than raising, which is **indistinguishable from "this AC never went green"**. The chart would flatten to zero with no exception anywhere.

So the verification is an actual `acsOverTime()` call under `runWithMemexId` as `memex_app`, asserting a **non-zero verified count** — not a schema introspection. New file `first-verified-tenancy.rls-restricted.test.ts`; **`test:rls` 17/17**. The default owner-role suite cannot show any of this (std-36: ENABLE, never FORCE).

It also asserts **ENABLE-not-FORCE** directly: `0081` shipped FORCE and `0093` had to undo it, because the Cloud SQL deploy role is not a superuser and lacks `BYPASSRLS`.

## Two more fixtures writing shapes production no longer produces

Same class as the three #646 found — **five this week**. `analytics.integration` seeded `ac_first_verified` with hand-rolled SQL that set no `memex_id`: the row existed and was **invisible**, which reads exactly like *"never went green"*. Now stamped. `spec-398-retention`'s call site gained the argument and a tenancy assertion, for the same reason the row gained the column.

## Test plan

- [x] Server suite — **6426 passed / 0 failed / 25 skipped**
- [x] **Restricted-role suite — 17/17**, including the four new tenancy tests
- [x] `make typecheck` clean · `make check` green
- [x] Migration applies cleanly; `0136` is additive (one nullable column, one index, ENABLE + policy + grant)
- [x] std-28: no new journey owed — no user-facing flow changes
- [x] **ac-37 verified**
- [x] Swept every touched file for the dead-import class the PR bot blocks on

## ⚠ ac-23 is now false and needs the owner

ac-23 reads *"first-verified is derived from the earliest rollup day carrying a pass, `ac_first_verified` is retired"*. dec-7 resolved **not** to do that. **ac-23 is not amended here and ac-37 does not silently stand in for it** — same posture as ac-8 and ac-22's scope note.

Option D's throttle (`73475f7a`) stays exactly as it was; C builds on it.