### PR TITLE
feat(spec-520): carry emission provenance on the summary so the CI audit survives t-12 (dec-8 option A)

### DIFF
--- a/packages/server/drizzle/0137_spec520_summary_provenance.sql
+++ b/packages/server/drizzle/0137_spec520_summary_provenance.sql
@@ -1,0 +1,43 @@
+-- spec-520 dec-8 option A — carry the emission's PROVENANCE on the summary row, so the
+-- CI-origin audit survives t-12's retention window.
+--
+-- WHAT BREAKS WITHOUT THIS. `auditCiEmissionForBrief` answers "which of your GREEN criteria
+-- were last verified by something other than CI". It reads run_id and metadata from the RAW
+-- log, and it reads them for an AC that is ALREADY verified — so the row can be arbitrarily
+-- old. Today retention keeps 10 rows per pair, which for a rarely-run test spans months.
+-- t-12 replaces that with a short TIME window, and then the row is gone and the code's
+-- `if (!latest) continue` reports "no local-only ACs" — telling the reader the evidence is
+-- STRONGER than it is.
+--
+-- That output is not decorative. It reaches the `assess_spec` MCP tool, which every agent is
+-- instructed to call before every forward phase move, and renders as: "N verified acceptance
+-- criteria's latest emission came from a laptop, not CI ... 'Verified' here rests on a
+-- local-only run the deploy signal can't trust." An audit that quietly starts saying "all
+-- clear" at a phase decision is worse than no audit.
+--
+-- WHY THE RAW COLUMNS AND NOT A BOOLEAN. "CI-originated" is whatever
+-- emissionIsCiOriginated({run_id, metadata}) currently decides — a run_id, or a run_id /
+-- run_url inside metadata. Storing the VERDICT would freeze today's rule into the row and
+-- make any later change unappliable to the past. Storing the inputs keeps it derivable.
+--
+-- ⚠ NULL METADATA MEANS "NEVER OBSERVED", NOT "NOT CI". Rows written before this migration
+-- have no provenance to recover, and there is nothing to backfill from — the raw rows that
+-- knew are the ones retention deletes. Read naively, emissionIsCiOriginated({null, null})
+-- returns FALSE, which would report every pre-existing AC as laptop-verified: a false
+-- POSITIVE, the mirror of the false negative this migration exists to prevent.
+--
+-- The discriminator costs nothing extra: applyEmissionToSummary writes metadata as `{}` when
+-- an emission carries none, so from here on the column is always non-NULL. NULL therefore
+-- means exactly one thing — this row predates provenance being recorded — and the audit
+-- treats it as UNKNOWN and skips it, which is what it does today for a missing row.
+--
+-- NEITHER COLUMN IS INDEXED [per std-39 cl-7]. This row is updated on every emission for its
+-- pair; an indexed jsonb column would defeat HOT updates and hand autovacuum the difference.
+-- The audit reads by subject_ref, which the primary key already covers.
+
+ALTER TABLE test_event_latest ADD COLUMN IF NOT EXISTS latest_run_id text;
+ALTER TABLE test_event_latest ADD COLUMN IF NOT EXISTS latest_metadata jsonb;
+
+-- No backfill, deliberately. See the NULL-means-unknown note above: inventing a value here
+-- would be inventing provenance, and provenance is the one thing this column exists to be
+-- honest about.

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -1113,6 +1113,16 @@ export const testEventLatest = pgTable(
     // spec-398 dec-4 (ac-8): tenancy column mirroring test_events [per std-32],
     // backfilled in the rewrite-and-swap migration. RLS is spec-399's (ac-9).
     memexId: uuid("memex_id").notNull(),
+    // spec-520 dec-8 option A (migration 0137): the latest emission's PROVENANCE, so the
+    // CI-origin audit survives t-12's retention window. The raw inputs rather than a
+    // computed boolean, so the "is this CI" rule stays derivable if it ever changes.
+    //
+    // ⚠ latestMetadata NULL means "never observed", NOT "not CI". Rows predating 0137 have
+    // no provenance to recover. From 0137 on, applyEmissionToSummary writes `{}` when an
+    // emission carries no metadata, so NULL is unambiguous — and the audit must treat it as
+    // UNKNOWN and skip, or every pre-existing AC reads as laptop-verified.
+    latestRunId: text("latest_run_id"),
+    latestMetadata: jsonb("latest_metadata").$type<Record<string, string> | null>(),
   },
   (table) => [
     primaryKey({ columns: [table.subjectRef, table.testIdentifier] }),

--- a/packages/server/src/routes/test-events.ts
+++ b/packages/server/src/routes/test-events.ts
@@ -528,6 +528,10 @@ async function processOneEvent(
           status: insertValues.status as "pass" | "fail" | "error",
           latestRunAt: inserted.createdAt,
           hidden: insertValues.hidden,
+          // spec-520 dec-8: the same values written to the log row, so the CI-origin audit
+          // can read provenance from the summary once retention stops keeping the log row.
+          runId: insertValues.runId,
+          metadata: insertValues.metadata,
         });
         // spec-520 t-9 (dec-5): the ANALYTICAL tier, in the same transaction as
         // the log write and the operational summary — so the counts can never

--- a/packages/server/src/services/acs.ts
+++ b/packages/server/src/services/acs.ts
@@ -1343,19 +1343,38 @@ export async function auditCiEmissionForBrief(
 
   const out: CiEmissionAuditRow[] = [];
   for (const r of verified) {
-    // The latest non-hidden emission for this AC across all its test_identifiers.
+    // spec-520 dec-8 option A: provenance now comes from the SUMMARY, not the raw log.
+    //
+    // This reads the latest emission of an AC that is ALREADY verified, so the row can be
+    // arbitrarily old. Retention keeps 10 rows per pair today, which for a rarely-run test
+    // spans months — but t-12 replaces that with a short TIME window, at which point the raw
+    // row is gone and `if (!latest) continue` would report "no local-only ACs". That is a
+    // FALSE NEGATIVE on a provenance audit, and it reaches assess_spec's phase rubric, so it
+    // would tell a reader the evidence is stronger than it is at a phase decision.
+    //
+    // test_event_latest holds one row per (subject_ref, test_identifier); the newest overall
+    // is the greatest latest_run_at, and 0137 carries that emission's run id and metadata
+    // beside it.
     const [latest] = await db
       .select({
-        runId: testEvents.runId,
-        metadata: testEvents.metadata,
-        createdAt: testEvents.createdAt,
+        runId: testEventLatest.latestRunId,
+        metadata: testEventLatest.latestMetadata,
+        runAt: testEventLatest.latestRunAt,
       })
-      .from(testEvents)
-      .where(and(eq(testEvents.subjectRef, r.canonicalRef), eq(testEvents.hidden, false)))
-      .orderBy(desc(testEvents.createdAt))
+      .from(testEventLatest)
+      .where(eq(testEventLatest.subjectRef, r.canonicalRef))
+      .orderBy(desc(testEventLatest.latestRunAt))
       .limit(1);
     // A verified AC always has ≥1 passing emission; defensively skip if none.
     if (!latest) continue;
+    // ⚠ NULL metadata means "never observed", NOT "not CI". Rows written before 0137 carry
+    // no provenance and nothing can recover it — the raw rows that knew are exactly the ones
+    // retention deletes. Judging them would report every pre-existing AC as laptop-verified:
+    // a FALSE POSITIVE, the mirror of the false negative above, and just as misleading at a
+    // phase decision. From 0137 on the writer stores `{}` rather than null when an emission
+    // carries no metadata, so NULL here means one thing only, and UNKNOWN skips — exactly
+    // what a missing row does today.
+    if (latest.metadata == null) continue;
     if (!emissionIsCiOriginated({ runId: latest.runId, metadata: latest.metadata })) {
       out.push({ handle: `ac-${r.ac.seq}` });
     }

--- a/packages/server/src/services/ci-emission-audit.spec-391.integration.test.ts
+++ b/packages/server/src/services/ci-emission-audit.spec-391.integration.test.ts
@@ -8,7 +8,7 @@
 
 import { describe, it, expect, afterAll, beforeAll } from "vitest";
 import { tagAc } from "@memex-ai-ac/vitest";
-import { eq, inArray, desc } from "drizzle-orm";
+import { eq, inArray } from "drizzle-orm";
 import { db } from "../db/connection.js";
 import { documents, acs, testEvents, testEventLatest, memexes, namespaces } from "../db/schema.js";
 import { createDocDraft } from "./documents.js";
@@ -71,19 +71,18 @@ async function passAc(
 ): Promise<void> {
   const ref = refOf(briefHandle, seq);
   createdAcUids.push(ref);
-  await seedTestEvent({ subjectRef: ref, status: "pass", createdAt: new Date(), testIdentifier: "t::ci" });
-  if (provenance) {
-    const [latest] = await db
-      .select({ id: testEvents.id })
-      .from(testEvents)
-      .where(eq(testEvents.subjectRef, ref))
-      .orderBy(desc(testEvents.createdAt))
-      .limit(1);
-    await db
-      .update(testEvents)
-      .set({ runId: provenance.runId ?? null, metadata: provenance.metadata ?? null })
-      .where(eq(testEvents.id, latest.id));
-  }
+  // spec-520 dec-8: provenance goes through the seeder, not patched onto the raw row
+  // afterwards. The route writes run_id / metadata to BOTH the log and the summary, and the
+  // audit now reads the summary — so patching only the log produced a shape production never
+  // writes, and this test failed the moment the audit moved. Sixth fixture of that class.
+  await seedTestEvent({
+    subjectRef: ref,
+    status: "pass",
+    createdAt: new Date(),
+    testIdentifier: "t::ci",
+    runId: provenance?.runId ?? null,
+    metadata: provenance?.metadata ?? null,
+  });
 }
 
 describe("emissionIsCiOriginated (spec-391 ac-10, pure)", () => {

--- a/packages/server/src/services/ci-provenance-from-summary.integration.test.ts
+++ b/packages/server/src/services/ci-provenance-from-summary.integration.test.ts
@@ -1,0 +1,167 @@
+// spec-520 dec-8 option A / ac-38 — the CI-origin audit reads provenance from the summary,
+// and knows the difference between "not CI" and "we don't know".
+//
+// WHAT THE AUDIT IS FOR. auditCiEmissionForBrief answers "which of your GREEN criteria were
+// last verified by something other than CI". Its output reaches phase-assessment's
+// localOnlyHandles and from there the assess_spec MCP tool, which every agent is instructed
+// to call before every forward phase move. It renders as: "'Verified' here rests on a
+// local-only run the deploy signal can't trust."
+//
+// TWO OPPOSITE WAYS TO GET THIS WRONG, and this file pins both:
+//
+//   FALSE NEGATIVE — reading the RAW log. The row is the latest emission of an ALREADY
+//   verified AC, so it can be arbitrarily old. Once t-12 shortens retention it ages out,
+//   `if (!latest) continue` fires, and the audit says "all clear" for an AC it can no longer
+//   see. Worse than no audit, at a phase decision.
+//
+//   FALSE POSITIVE — reading the summary naively. Rows predating migration 0137 have NULL
+//   provenance, and emissionIsCiOriginated({null, null}) returns FALSE, so every pre-existing
+//   AC would be reported as laptop-verified.
+//
+// The discriminator is that the writer stores `{}` and not null when an emission carries no
+// metadata. NULL therefore means only "predates 0137" → UNKNOWN → skip.
+
+import { describe, it, expect, afterAll, beforeAll } from "vitest";
+import { eq, inArray, sql } from "drizzle-orm";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { db, runWithMemexId } from "../db/connection.js";
+import { acs, documents, memexes, namespaces, testEventLatest } from "../db/schema.js";
+import { auditCiEmissionForBrief } from "./acs.js";
+import { createDocDraft } from "./documents.js";
+import { seedTestEvent } from "./test-helpers.js";
+import { makeTestMemex } from "./test-helpers.js";
+
+const AC_PROVENANCE = "mindset-prod/memex-building-itself/specs/spec-520/acs/ac-38";
+
+let memexId: string;
+let namespaceSlug: string;
+let memexSlug: string;
+const createdDocIds: string[] = [];
+const createdRefs: string[] = [];
+
+/** A Spec with one active AC, verified by one passing emission. Returns its docId + ref. */
+async function specWithVerifiedAc(
+  label: string,
+  seq: number,
+): Promise<{ docId: string; ref: string }> {
+  return runWithMemexId(memexId, async () => {
+    const doc = await createDocDraft(memexId, `dec8 ${label}`, "", "spec");
+    createdDocIds.push(doc.id);
+    await db.insert(acs).values({
+      memexId,
+      briefId: doc.id,
+      seq,
+      kind: "implementation",
+      statement: "the criterion under audit",
+      status: "active",
+    } as typeof acs.$inferInsert);
+    const ref = `${namespaceSlug}/${memexSlug}/specs/${doc.handle}/acs/ac-${seq}`;
+    createdRefs.push(ref);
+    return { docId: doc.id, ref };
+  });
+}
+
+beforeAll(async () => {
+  memexId = await makeTestMemex("d8");
+  const [row] = await db
+    .select({ m: memexes.slug, n: namespaces.slug })
+    .from(memexes)
+    .innerJoin(namespaces, eq(memexes.namespaceId, namespaces.id))
+    .where(eq(memexes.id, memexId))
+    .limit(1);
+  memexSlug = row!.m;
+  namespaceSlug = row!.n;
+});
+
+afterAll(async () => {
+  if (createdRefs.length) {
+    await db.delete(testEventLatest).where(inArray(testEventLatest.subjectRef, createdRefs)).catch(() => {});
+  }
+  if (createdDocIds.length) {
+    await db.delete(documents).where(inArray(documents.id, createdDocIds)).catch(() => {});
+  }
+});
+
+describe("spec-520 ac-38: CI provenance comes from the summary", () => {
+  it("flags a verified AC whose latest emission carries NO CI marker", async () => {
+    tagAc(AC_PROVENANCE);
+    const { docId, ref } = await specWithVerifiedAc("local", 1);
+    await seedTestEvent({ subjectRef: ref, status: "pass", testIdentifier: "s::t" });
+
+    // A laptop run: the writer stored `{}`, so provenance WAS observed and is genuinely
+    // absent — which is the one case that should be reported.
+    const flagged = await runWithMemexId(memexId, async () =>
+      auditCiEmissionForBrief(memexId, docId),
+    );
+    expect(flagged.map((r) => r.handle)).toContain("ac-1");
+  });
+
+  it("does NOT flag one whose latest emission carries a run id", async () => {
+    tagAc(AC_PROVENANCE);
+    const { docId, ref } = await specWithVerifiedAc("ci", 1);
+    await seedTestEvent({ subjectRef: ref, status: "pass", testIdentifier: "s::t" });
+
+    await db
+      .update(testEventLatest)
+      .set({ latestRunId: "31589392781" })
+      .where(eq(testEventLatest.subjectRef, ref));
+
+    const flagged = await runWithMemexId(memexId, async () =>
+      auditCiEmissionForBrief(memexId, docId),
+    );
+    expect(flagged.map((r) => r.handle)).not.toContain("ac-1");
+  });
+
+  it("does NOT flag one whose run id rides in metadata instead", async () => {
+    tagAc(AC_PROVENANCE);
+    const { docId, ref } = await specWithVerifiedAc("ci-md", 1);
+    await seedTestEvent({ subjectRef: ref, status: "pass", testIdentifier: "s::t" });
+
+    // emissionIsCiOriginated accepts run_id OR run_url inside the bag — the shape a
+    // hand-rolled emitter produces. Re-deriving from the raw inputs is why dec-8 stored them
+    // rather than a computed boolean.
+    await db
+      .update(testEventLatest)
+      .set({ latestMetadata: { run_url: "https://ci.example/run/7" } })
+      .where(eq(testEventLatest.subjectRef, ref));
+
+    const flagged = await runWithMemexId(memexId, async () =>
+      auditCiEmissionForBrief(memexId, docId),
+    );
+    expect(flagged.map((r) => r.handle)).not.toContain("ac-1");
+  });
+
+  it("treats a row with NO RECORDED PROVENANCE as unknown and does NOT flag it", async () => {
+    tagAc(AC_PROVENANCE);
+    const { docId, ref } = await specWithVerifiedAc("pre-0137", 1);
+    await seedTestEvent({ subjectRef: ref, status: "pass", testIdentifier: "s::t" });
+
+    // Reproduce a row written BEFORE 0137: provenance never recorded, both columns NULL.
+    // Judged naively this reads as "not CI" and the AC is reported laptop-verified — the
+    // false positive that mirrors the false negative the raw-log read produced.
+    await db
+      .update(testEventLatest)
+      .set({ latestRunId: null, latestMetadata: null })
+      .where(eq(testEventLatest.subjectRef, ref));
+
+    const flagged = await runWithMemexId(memexId, async () =>
+      auditCiEmissionForBrief(memexId, docId),
+    );
+    expect(flagged.map((r) => r.handle)).not.toContain("ac-1");
+  });
+
+  it("answers without the raw log — the row t-12's retention window will delete", async () => {
+    tagAc(AC_PROVENANCE);
+    const { docId, ref } = await specWithVerifiedAc("no-raw", 1);
+    await seedTestEvent({ subjectRef: ref, status: "pass", testIdentifier: "s::t" });
+
+    // THE point of dec-8. Delete every raw row and the audit must still answer, because it
+    // is reading the summary. Before this change it returned nothing here — silently.
+    await db.execute(sql`DELETE FROM test_events WHERE subject_ref = ${ref}`);
+
+    const flagged = await runWithMemexId(memexId, async () =>
+      auditCiEmissionForBrief(memexId, docId),
+    );
+    expect(flagged.map((r) => r.handle)).toContain("ac-1");
+  });
+});

--- a/packages/server/src/services/test-event-latest.ts
+++ b/packages/server/src/services/test-event-latest.ts
@@ -11,7 +11,7 @@
 
 import { and, eq, sql } from "drizzle-orm";
 import { type Db } from "../db/connection.js";
-import { testEvents, testEventLatest } from "../db/schema.js";
+import { testEventLatest } from "../db/schema.js";
 
 export interface EmissionForSummary {
   subjectRef: string;
@@ -24,6 +24,14 @@ export interface EmissionForSummary {
   latestRunAt: Date;
   /** spec-115: hidden emissions are stored in the log but excluded from badges. */
   hidden: boolean;
+  /** spec-520 dec-8: the emission's CI run id, if it carried one. */
+  runId?: string | null;
+  /**
+   * spec-520 dec-8: the emission's metadata bag. Written as `{}` when absent, NEVER left
+   * null — a NULL on this column means "this row predates provenance being recorded", and
+   * the CI-origin audit relies on that being unambiguous.
+   */
+  metadata?: Record<string, string> | null;
 }
 
 /**
@@ -55,6 +63,10 @@ export async function applyEmissionToSummary(
       latestStatus: emission.status,
       latestRunAt: emission.latestRunAt,
       runCount: 1,
+      latestRunId: emission.runId ?? null,
+      // `{}` and not null when the emission carries none — see the interface note. NULL is
+      // reserved to mean "this row predates 0137".
+      latestMetadata: emission.metadata ?? {},
     })
     .onConflictDoUpdate({
       target: [testEventLatest.subjectRef, testEventLatest.testIdentifier],
@@ -65,6 +77,11 @@ export async function applyEmissionToSummary(
         latestRunAt: sql`GREATEST(excluded.latest_run_at, ${testEventLatest.latestRunAt})`,
         // Every non-hidden emission counts, regardless of arrival order.
         runCount: sql`${testEventLatest.runCount} + 1`,
+        // spec-520 dec-8: provenance follows the STATUS, not the clock — it must describe
+        // the same emission the badge is showing, or the audit would report the origin of
+        // one run against the verdict of another. Same newest-wins guard as latestStatus.
+        latestRunId: sql`CASE WHEN excluded.latest_run_at >= ${testEventLatest.latestRunAt} THEN excluded.latest_run_id ELSE ${testEventLatest.latestRunId} END`,
+        latestMetadata: sql`CASE WHEN excluded.latest_run_at >= ${testEventLatest.latestRunAt} THEN excluded.latest_metadata ELSE ${testEventLatest.latestMetadata} END`,
       },
     });
 }

--- a/packages/server/src/services/test-helpers.ts
+++ b/packages/server/src/services/test-helpers.ts
@@ -25,6 +25,14 @@ export interface SeedTestEventInput {
   /** Defaults to server now(). Pass a past date to exercise stale / out-of-order paths. */
   createdAt?: Date;
   hidden?: boolean;
+  /**
+   * spec-520 dec-8: the emission's CI provenance. The route writes these to BOTH the log row
+   * and the summary, so a fixture that patches them onto the raw row afterwards produces a
+   * shape production never writes — and any consumer reading the summary then sees a
+   * local-only run where a CI one happened.
+   */
+  runId?: string | null;
+  metadata?: Record<string, string> | null;
 }
 
 /**
@@ -63,6 +71,8 @@ export async function seedTestEvent(input: SeedTestEventInput): Promise<void> {
         status: input.status,
         testIdentifier,
         hidden,
+        runId: input.runId ?? null,
+        metadata: input.metadata ?? null,
         ...(input.createdAt ? { createdAt: input.createdAt } : {}),
       })
       .returning({ createdAt: testEvents.createdAt });
@@ -73,6 +83,8 @@ export async function seedTestEvent(input: SeedTestEventInput): Promise<void> {
       status: input.status,
       latestRunAt: row.createdAt,
       hidden,
+      runId: input.runId ?? null,
+      metadata: input.metadata ?? null,
     });
     // spec-520 t-9: the third tier. Keep this in step with routes/test-events.ts —
     // a fixture that maintains only some of the tiers is the shape production


### PR DESCRIPTION
**spec-520 dec-8 option A / ac-38.** Migration `0137`. **This unblocks t-12.**

Spec: https://memex.ai/mindset-prod/memex-building-itself/specs/spec-520 · the reasoning is `dec-8`.

## What breaks without it

`auditCiEmissionForBrief` answers *"which of your **green** criteria were last verified by something other than CI"*. It read `run_id` and `metadata` from the **raw log**, for an AC that is **already verified** — so the row can be arbitrarily old. Retention keeps 10 rows per pair today, which for a rarely-run test spans months.

**t-12 replaces that with a short time window.** The row ages out, `if (!latest) continue` fires, and the audit reports *"no local-only ACs"* — a **false negative** on a provenance audit.

## That output is not decorative — and tracing it is what decided dec-8

```
auditCiEmissionForBrief → phase-assessment.localOnlyHandles
                        → agent/handlers/lifecycle.ts
                        → the assess_spec MCP tool
```

`assess_spec` is the tool **every agent is instructed to call before every forward phase move**. It renders:

> *"N verified acceptance criteria's latest emission came from a laptop, not CI … 'Verified' here rests on a local-only run the deploy signal can't trust."*

An audit that quietly starts saying "all clear" **at a phase decision** is worse than no audit. That trace also killed option D (delete the surface): something *does* act on this, at the worst possible moment to be wrong.

## The raw inputs, not a computed boolean

"CI-originated" is whatever `emissionIsCiOriginated({ run_id, metadata })` currently decides — a `run_id`, or a `run_id`/`run_url` inside the bag. Storing the **verdict** would freeze today's rule into the row and make any later change unappliable to the past. Storing the inputs keeps it derivable.

## ⚠ The mirror defect, and the discriminator that avoids it

The naive fix produces the **opposite** error. Rows written before `0137` have NULL provenance, and `emissionIsCiOriginated({null, null})` returns **false** — so every pre-existing AC would be reported as laptop-verified. A false **positive**, equally misleading, at the same moment.

There is nothing to backfill from: **the raw rows that knew are exactly the ones retention deletes.**

So the writer stores `{}` and not null when an emission carries no metadata. From `0137` on the column is always non-NULL, **NULL therefore means one thing only** — *this row predates provenance being recorded* — and the audit treats it as **unknown and skips**, which is what a missing row does today.

**Provenance follows the STATUS, not the clock.** The upsert guards both columns with the same newest-wins condition as `latest_status`, so the stored origin always describes the same emission the badge is showing. Without it, an out-of-order arrival could pair one run's verdict with another run's origin.

**Neither column is indexed** [per std-39 cl-7] — this row is updated on every emission for its pair, and an indexed jsonb column would defeat HOT updates.

## A sixth fixture writing a shape production never writes

spec-391's own audit test seeded correctly and then **patched provenance onto the raw row afterwards**. The route writes it to both tiers, so that was a shape production never produces — and the test failed the moment the audit moved. Same class as the five #646 and #647 found.

**Root fix again, not a patched assertion:** `seedTestEvent` now carries `runId`/`metadata` through to **both** tiers, and `passAc` passes them instead of patching. `seedTestEvent` is now the single fixture path for emissions — every field the route writes flows through it, or fixtures drift from the path they stand in for.

## Test plan

- [x] Driven red→green — **4 of ac-38's 5 tests fail without the change**, including *"answers without the raw log — the row t-12's retention window will delete"*. The fifth passes either way **by design**: it pins behaviour that must be preserved.
- [x] Full server suite — **6431 passed / 0 failed / 25 skipped**
- [x] Restricted-role suite — **17/17**
- [x] `make typecheck` clean · `make check` green
- [x] Migration `0137` is additive: two nullable columns, no backfill, no index
- [x] std-28: no new journey owed — no user-facing flow changes
- [x] **ac-38 verified**
- [x] Swept every touched file for the dead-import class the PR bot blocks on — including **two this change itself created**

## Follow-on

**t-12 is now unblocked** on this axis. It still needs **t-8** (amending spec-398's retention ACs, owner work) before the retention window can change.