### PR TITLE
docs(spec-520): correct an attribution that told readers the 31% was already solved (issue-2)

### DIFF
--- a/packages/server/src/middleware/reserved-api-roots.spec-515.test.ts
+++ b/packages/server/src/middleware/reserved-api-roots.spec-515.test.ts
@@ -7,6 +7,9 @@
 // internal (spec-453), then nine more surfaced in 2026-08. The sharpest instance:
 // `/api/test-events/batch` 404'd, so the CI AC-emitter fell back from one batch request
 // to unbounded per-event POSTs (emitBatch: 404 → Promise.all(single)) — ~11.6M
+// (⚠ that figure is the whole emission path's statement volume, and restoring /batch
+//  removes the REQUEST amplification, not those statements — six of seven are per-event
+//  either way. Corrected in routes/api-roots.ts; spec-520 issue-2.)
 // INSERT/DELETE/upsert calls that drove prod Cloud SQL to ~100% CPU.
 //
 // This scan derives the flat roots from app.ts SOURCE (never hardcoded) and fails if any

--- a/packages/server/src/routes/api-roots.ts
+++ b/packages/server/src/routes/api-roots.ts
@@ -17,14 +17,37 @@
 // the coupling is required in both directions — a word that is both an API root and
 // a namespace slug makes one of the two unreachable.
 
-// MEASURED IMPACT (from a colleague's independent reconstruction of this fix on
-// origin/develop, commit 00394743 — better quantified than the original diagnosis and
-// preserved here because that inline list was folded into this module):
-// `pg_stat_statements` showed **~11.6M INSERT/DELETE/upsert calls** across the
-// test_events emission path — about **31% of prod Cloud SQL CPU**, saturating the
-// 1-vCPU instance and slowing every DB-backed endpoint. Reserving `test-events` makes
-// /batch reachable, so the already-published emitter batches and the write volume
-// collapses.
+// MEASURED IMPACT — and ⚠ CORRECTED 2026-08-28 (spec-520 issue-2), because the original
+// wording attributed a cost to this fix that this fix does not remove, in the direction
+// that stops someone looking further.
+//
+// The observation was real: `pg_stat_statements` showed **~11.6M INSERT/DELETE/upsert
+// calls** across the test_events emission path, about **31% of prod Cloud SQL CPU** on a
+// 1-vCPU instance. Reserving `test-events` makes /batch reachable, and that IS a real fix.
+//
+// WHAT IT FIXED: the REQUEST count. Before, the emitter's batch POST 404'd and it fell back
+// to one POST per test — so a suite tagging 500 criteria opened 500 requests, each taking a
+// DB-pool slot. Restoring /batch collapses that to roughly one request per test FILE, and
+// amortises the ONE statement that is per-request: the emission-key verify.
+//
+// WHAT IT DID NOT FIX: the per-EVENT statement cost, which is most of that 31%. The batch
+// route authenticates once and then loops `processOneEvent` per event, so six of the seven
+// statements run exactly as often as before. Restoring the route removed approximately none
+// of them.
+//
+// Measured on prod as a 600s delta, 2026-08-28 (spec-520 c-9) — the batching is visible in
+// exactly one row and absent from the rest:
+//
+//   30.973 calls/s  INSERT test_events          <- per EVENT
+//   30.973 calls/s  DELETE test_events (trim)   <- per EVENT
+//   30.973 calls/s  INSERT test_run_daily       <- per EVENT
+//   30.972 calls/s  INSERT ac_first_verified    <- per EVENT
+//   30.972 calls/s  UPDATE memex_emission_keys  <- per EVENT
+//    3.947 calls/s  SELECT memex_emission_keys  <- per BATCH: ~1 auth per 8 events
+//
+// So: spec-515 fixed request amplification; spec-520 is the Spec that attacks the write
+// amplification, and its t-6 / t-12 / dec-7 work is what actually removes those rows. Do not
+// read this paragraph as "the 31% was solved here".
 
 /**
  * Every top-level segment under which a NON-TENANT router is mounted flat at


### PR DESCRIPTION
**spec-520 issue-2** — the one part of t-8 that could be done independently. Comments only, no behaviour change.

## The claim being corrected

`routes/api-roots.ts` said that reserving `test-events` — making `/batch` reachable again — makes *"the write volume collapse"*, sitting directly beside a measurement of **~11.6M statements** and **~31% of prod Cloud SQL CPU**.

Read plainly, that says **spec-515 fixed the 31%**. It did not. And the wording fails in the direction that matters most: it tells the next reader the problem is solved, so they stop looking.

## What spec-515 actually fixed, and what it did not

**Fixed — the REQUEST count.** The emitter's batch POST 404'd and it fell back to one POST per test, so a suite tagging 500 criteria opened 500 requests, each taking a DB-pool slot. Restoring `/batch` collapses that to roughly one request per test *file*, and amortises the one statement that is per-request: the emission-key verify.

**Not fixed — the per-EVENT statement cost**, which is most of the 31%. The batch route authenticates once and then loops `processOneEvent`, so six of the seven statements run exactly as often as before.

## Corrected with measurement, not argument

Prod, 600s delta, 2026-08-28 (`c-9`). The batching is visible in **exactly one row** and absent from the rest:

| calls/s | statement | scope |
|---|---|---|
| 30.973 | `INSERT test_events` | per **event** |
| 30.973 | `DELETE test_events` (trim) | per **event** |
| 30.973 | `INSERT test_run_daily` | per **event** |
| 30.972 | `INSERT ac_first_verified` | per **event** |
| 30.972 | `UPDATE memex_emission_keys` | per **event** |
| **3.947** | `SELECT memex_emission_keys` | per **batch** — ~1 auth per 8 events |

spec-515 fixed **request** amplification; spec-520 is the Spec that attacks **write** amplification, and its t-6 / t-12 / dec-7 work is what actually removes those rows.

## ⚠ The task's file reference had drifted

t-8 places this comment in `middleware/memex-resolver.ts`. **It lives in `routes/api-roots.ts`** — the reserved-root list was folded into that module, and the resolver now only re-exports from it.

Relocated by symbol and **said out loud**, per the build rule that a drifted anchor is a mismatch to report rather than silently follow.

Also cross-referenced from `reserved-api-roots.spec-515.test.ts`, which repeats the ~11.6M figure in its own header.

## Test plan

- [x] `make typecheck` clean · `make check` green
- [x] The two suites covering these files — 4 passed
- [x] Comments only; no behaviour, no schema, no route surface changed
- [x] Dead-import sweep clean

## Note on the rest of t-8

**t-8 cannot land before t-12 — it has to land WITH it**, and its remaining four criteria are blocked on a bound that does not exist yet (`RETENTION_KEEP = 10` is the only retention constant in the tree; ac-14 makes the window t-12's to design). Recorded in full as `c-11` on the task so nobody plans them as two PRs.