### PR TITLE
perf(spec-520): one bind parameter for the AC-health reads, not one per AC ref (t-4)

### DIFF
--- a/packages/server/drizzle/out-of-band/0138_spec520_ac_health_index.sql
+++ b/packages/server/drizzle/out-of-band/0138_spec520_ac_health_index.sql
@@ -1,0 +1,50 @@
+-- spec-520 t-4 (ac-9) — the (memex_id, subject_ref) index on test_event_latest.
+--
+-- ⚠ THIS FILE IS NOT APPLIED BY `pnpm db:migrate`, AND THAT IS THE POINT.
+--
+-- `scripts/apply-hand-migrations.mjs` wraps EVERY migration in `sql.begin()`, and
+-- `CREATE INDEX CONCURRENTLY` cannot run inside a transaction block — Postgres refuses it
+-- outright. The runner reads `drizzle/` with a NON-recursive readdirSync, so this
+-- subdirectory is invisible to it by construction rather than by anyone remembering.
+-- `out-of-band-migrations.regression.test.ts` pins both halves of that.
+--
+-- 0131 hit the same wall and chose a plain inline CREATE INDEX, correctly: `documents` is
+-- in the low hundreds of rows per Memex, a build measured in milliseconds. It also wrote
+-- down when that stops being the right call — "if it ever grows to the point where this
+-- stops being true, a future index on it belongs out-of-band". test_event_latest is that
+-- case: 182,634 rows and 64MB of heap on prod, continuously written by the emission path.
+--
+-- HOW TO APPLY (prod, and int first):
+--   1. PAM grant `memex-prod-deploy-server`, then cloud-sql-proxy — the
+--      `prod-analytics-readonly-access` recipe, minus the read-only transaction setting.
+--   2. Run the statement below. CONCURRENTLY takes no ACCESS EXCLUSIVE lock, so emissions
+--      keep writing throughout; it is slower and can fail leaving an INVALID index.
+--   3. Verify: the query at the bottom must report indisvalid = true. If it is false, DROP
+--      the index and re-run — an invalid index is never used but is still maintained on
+--      every write, which is the worst of both.
+--
+-- ⚠ DO NOT EXPECT THIS TO FIX THE 642 ms READ, and do not let anyone size it that way.
+-- s-4 §3 EXPLAINed the tenant that generates the load: ONE Memex holds 81.0% of this table
+-- (147,989 of 182,634 rows). For it, `memex_id = $1` selects four rows in five, and Postgres
+-- will correctly prefer a SEQUENTIAL SCAN — an index scan touching four rows in five is
+-- slower. This index helps the many small tenants and will be declined for the big one.
+-- spec-520 ac-8 expects an index scan and is wrong for exactly that reason (see c-4).
+--
+-- The win t-4 actually delivers is in the code, not here: 1,223 statement fingerprints
+-- collapse to 1, and planning time goes 7.564 ms -> 0.037 ms.
+--
+-- WRITE COST (cl-19): low, and worth checking rather than assuming. test_event_latest's PK
+-- is (subject_ref, test_identifier); every emission UPDATEs latest_status / latest_run_at /
+-- run_count / latest_run_id / latest_metadata. None of those is in this index, and neither
+-- memex_id nor subject_ref changes on update — so HOT updates still apply and the ~23.5M
+-- lifetime updates pay nothing for it. The cost falls on INSERTs only (~195k lifetime).
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS test_event_latest_memex_subject_idx
+  ON test_event_latest (memex_id, subject_ref);
+
+-- Verify the build actually completed. An interrupted CONCURRENTLY build leaves the index
+-- present but INVALID: never used by the planner, still maintained on every write.
+--
+--   SELECT c.relname, i.indisvalid
+--     FROM pg_class c JOIN pg_index i ON i.indexrelid = c.oid
+--    WHERE c.relname = 'test_event_latest_memex_subject_idx';

--- a/packages/server/src/__regression__/ac-health-bind-shape.regression.test.ts
+++ b/packages/server/src/__regression__/ac-health-bind-shape.regression.test.ts
@@ -1,0 +1,82 @@
+// spec-520 t-4 (ac-7 / ac-11) — no hot-path read binds one parameter per AC ref.
+//
+// ⚠ THIS IS A SOURCE SCAN, and it is worth saying so rather than dressing it as behavioural.
+// The claim is about the SHAPE of the generated SQL, and the honest behavioural test would
+// compare pg_stat_statements queryids across two runs with different ref counts — identical
+// under the fix, different before it. pg_stat_statements is not loaded on the local cluster
+// (it needs shared_preload_libraries and a restart), so that test cannot run here. What CAN
+// be pinned locally is that the offending construct does not come back, which is the
+// regression that actually threatens this fix. Correctness is covered separately and
+// behaviourally by ac-health-parity.spec-520.test.ts.
+//
+// THE COST BEING PREVENTED. `inArray(testEventLatest.subjectRef, refs)` emits
+// `subject_ref IN ($1, $2, … $n)`. Each distinct n is its own prepared statement, plan-cache
+// entry and pg_stat_statements row. Measured on prod: 1,098 fingerprints on 2026-08-18 and
+// 1,223 on 2026-08-28 — ~12/day, ~24.5% of the instance's 5,000-entry cap, which is 98.6%
+// full and already evicting (issue-10). Planning time for the 1,800-literal form was 7.564 ms
+// against 0.037 ms for the simple one.
+//
+// The two replacements are deliberately DIFFERENT, and neither is a stylistic preference:
+//   • aggregateAcHealthForBriefs -> `memex_id = $1`. It already read every row of the tenant
+//     (the seq scan touches them all), so scoping tenant-wide costs nothing and makes
+//     tenancy an explicit predicate instead of an inference from ref-string uniqueness.
+//   • listAcsForBriefWithVerification and the clause-coverage read -> `= ANY($1::text[])`.
+//     These serve ONE Spec / one standard, so a tenant-wide read would fetch ~148k rows for
+//     the largest Memex to filter down to a handful. ANY is one parameter regardless of ref
+//     count, which removes the fragmentation without the over-fetch.
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+const AC_SCOPED = "mindset-prod/memex-building-itself/specs/spec-520/acs/ac-7";
+const AC_NO_WIDE_IN = "mindset-prod/memex-building-itself/specs/spec-520/acs/ac-11";
+
+const src = (rel: string) =>
+  readFileSync(resolve(import.meta.dirname, "..", rel), "utf8");
+
+describe("spec-520 ac-7 / ac-11: no read binds one parameter per AC ref", () => {
+  it("no hot-path read passes a ref ARRAY to inArray against test_event_latest.subject_ref", () => {
+    tagAc(AC_NO_WIDE_IN);
+    // Located by construct, not by line — this Spec's line references have drifted between
+    // grounding passes, and the task says so explicitly.
+    const offenders: string[] = [];
+    for (const rel of ["services/acs.ts", "services/clause-coverage.ts"]) {
+      const text = src(rel);
+      if (/inArray\(\s*testEventLatest\.subjectRef/.test(text)) offenders.push(rel);
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it("aggregateAcHealthForBriefs scopes the summary read on memex_id", () => {
+    tagAc(AC_SCOPED);
+    const text = src("services/acs.ts");
+    // The whole function, isolated so a match elsewhere in this large file cannot pass it.
+    const start = text.indexOf("export async function aggregateAcHealthForBriefs");
+    expect(start).toBeGreaterThan(-1);
+    const body = text.slice(start, start + 6000);
+    expect(body).toMatch(/eq\(testEventLatest\.memexId, memexId\)/);
+  });
+
+  it("the single-Spec reads bind the ref list as ONE array parameter", () => {
+    tagAc(AC_NO_WIDE_IN);
+    for (const rel of ["services/acs.ts", "services/clause-coverage.ts"]) {
+      const text = src(rel);
+      // sql.param() is the load-bearing half: a bare `${refs}` makes drizzle interpolate the
+      // array as a LIST of parameters — the very fragmentation being removed — and fails
+      // against `= ANY(…)` outright. That is not hypothetical; it happened while building
+      // this, and the query errored with the array flattened into separate params.
+      expect(text).toMatch(/ANY\(\$\{sql\.param\(allRefs\)\}::text\[\]\)/);
+    }
+  });
+
+  it("both single-Spec reads also carry an explicit memex_id predicate", () => {
+    tagAc(AC_SCOPED);
+    // Tenancy stops being an inference from ref-string uniqueness (the spec-396 posture),
+    // and it is what makes the (memex_id, subject_ref) index usable for these reads at all.
+    for (const rel of ["services/acs.ts", "services/clause-coverage.ts"]) {
+      expect(src(rel)).toMatch(/eq\(testEventLatest\.memexId, memexId\)/);
+    }
+  });
+});

--- a/packages/server/src/__regression__/out-of-band-migrations.regression.test.ts
+++ b/packages/server/src/__regression__/out-of-band-migrations.regression.test.ts
@@ -1,0 +1,66 @@
+// spec-520 t-4 (ac-9) — CREATE INDEX CONCURRENTLY must never reach the migration runner.
+//
+// The runner (`scripts/apply-hand-migrations.mjs`) wraps every migration in `sql.begin()`,
+// and CONCURRENTLY cannot run inside a transaction block. A file that needs it therefore
+// lives in `drizzle/out-of-band/`, which the runner's NON-recursive readdirSync cannot see.
+//
+// Both halves are pinned here because both are easy to undo by accident: someone adds
+// CONCURRENTLY to a normal migration (fails at deploy, loudly), or someone makes the runner
+// recursive to "pick up everything" (fails at deploy, also loudly, but after the recursive
+// change looks like a tidy-up in review).
+
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync } from "node:fs";
+import { resolve } from "node:path";
+
+const AC_OUT_OF_BAND = "mindset-prod/memex-building-itself/specs/spec-520/acs/ac-39";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+const drizzleDir = resolve(import.meta.dirname, "../../drizzle");
+
+describe("spec-520 ac-39: out-of-band index builds stay out of the transactional runner", () => {
+  it("no migration the runner picks up contains CREATE INDEX CONCURRENTLY", () => {
+    tagAc(AC_OUT_OF_BAND);
+    // Exactly the runner's own glob: readdirSync (non-recursive) filtered to .sql.
+    const applied = readdirSync(drizzleDir).filter((f) => f.endsWith(".sql"));
+    const offenders = applied.filter((f) => {
+      // STRIP `--` COMMENT LINES FIRST. 0125 and 0131 both DISCUSS CONCURRENTLY at length —
+      // explaining why they correctly chose a plain inline CREATE INDEX instead — and that
+      // prose is exactly what we want future migrations to keep writing. A check that fails
+      // on files for reasoning about the constraint would punish the documentation it
+      // depends on. The first draft of this test did precisely that.
+      const sqlOnly = readFileSync(resolve(drizzleDir, f), "utf8")
+        .split("\n")
+        .filter((l) => !l.trim().startsWith("--"))
+        .join("\n");
+      return /CREATE\s+INDEX\s+CONCURRENTLY/i.test(sqlOnly);
+    });
+    expect(offenders).toEqual([]);
+  });
+
+  it("the runner's directory read is NOT recursive, so out-of-band/ stays invisible", () => {
+    tagAc(AC_OUT_OF_BAND);
+    const runner = readFileSync(
+      resolve(import.meta.dirname, "../../scripts/apply-hand-migrations.mjs"),
+      "utf8",
+    );
+    // A `recursive: true` here would silently pull out-of-band files into a transaction and
+    // break the deploy — after a change that reads as harmless tidying.
+    expect(runner).toMatch(/readdirSync\(drizzleDir\)/);
+    expect(runner).not.toMatch(/readdirSync\(drizzleDir,\s*\{[^}]*recursive/);
+  });
+
+  it("the out-of-band file exists and carries its apply + verify instructions", () => {
+    tagAc(AC_OUT_OF_BAND);
+    // A statement nobody knows how to run is not a migration, it is a note. The file has to
+    // say how to apply it AND how to confirm the build did not leave an INVALID index —
+    // invalid means never used by the planner but still maintained on every write.
+    const oob = readFileSync(
+      resolve(drizzleDir, "out-of-band/0138_spec520_ac_health_index.sql"),
+      "utf8",
+    );
+    expect(oob).toMatch(/CREATE INDEX CONCURRENTLY/);
+    expect(oob).toMatch(/indisvalid/);
+    expect(oob).toMatch(/HOW TO APPLY/);
+  });
+});

--- a/packages/server/src/services/acs.ts
+++ b/packages/server/src/services/acs.ts
@@ -460,7 +460,31 @@ export async function listAcsForBriefWithVerification(
       runCount: testEventLatest.runCount,
     })
     .from(testEventLatest)
-    .where(inArray(testEventLatest.subjectRef, allRefs));
+    // spec-520 t-4 (ac-11): ONE bind parameter for the whole ref list.
+    //
+    // `IN (…)` binds one parameter PER REF, and each distinct COUNT is its own prepared
+    // statement, plan-cache entry and pg_stat_statements row. That fragmentation is what
+    // put 1,223 fingerprints — ~24.5% of the instance's 5,000 cap, which is 98.6% full and
+    // already evicting — behind one logical read (issue-10).
+    //
+    // `= ANY($1::text[])` is one parameter however many refs there are, so ONE fingerprint.
+    // Deliberately NOT rewritten to `memex_id = $1` alone like aggregateAcHealthForBriefs:
+    // that read already touched every row of the tenant, so scoping it tenant-wide cost
+    // nothing. This one serves a SINGLE Spec — tens of refs — and a tenant-wide read would
+    // fetch ~148k rows for the largest Memex to filter down to a handful.
+    //
+    // memex_id is added alongside so tenancy is an explicit predicate rather than an
+    // inference from ref-string uniqueness — the spec-396 posture, and what makes the
+    // (memex_id, subject_ref) index usable here.
+    .where(
+      and(
+        eq(testEventLatest.memexId, memexId),
+        // sql.param() is load-bearing: a bare `${allRefs}` makes drizzle interpolate the
+        // array as a LIST of parameters — the very fragmentation this is removing, and it
+        // fails outright against `= ANY(…)`. sql.param binds it as ONE array parameter.
+        sql`${testEventLatest.subjectRef} = ANY(${sql.param(allRefs)}::text[])`,
+      ),
+    );
 
   // Pull every parent link for our AC set in one query. The Decisions tab
   // uses these to find "the ACs hanging off this resolved decision" without
@@ -1071,11 +1095,38 @@ export async function aggregateAcHealthForBriefs(
   const allRefs = Array.from(refsByAcId.values());
   if (allRefs.length === 0) return result;
 
-  // Q2 — spec-162: the latest-per-pair summary for the AC universe, read
-  // directly from test_event_latest. Bounded by active AC×test pairs, not by
-  // history depth — this is the whole point of the change (ac-1). Hidden events
-  // were excluded at write time so there's no hidden filter here; '' is the
-  // stored key for null test_identifier (dec-2).
+  // Q2 — spec-162: the latest-per-pair summary for the AC universe, read directly from
+  // test_event_latest.
+  //
+  // spec-520 t-4 (dec-1, ac-7): ONE tenant parameter, not one per AC ref.
+  //
+  // This used to bind `subject_ref IN (…)` with every active ref — up to 3,745 values,
+  // 25KB of SQL. The cost that buys is not what the old comment ("bounded by active AC×test
+  // pairs, not by history depth") suggests:
+  //
+  //   • Each distinct bind-parameter COUNT is its own prepared statement, its own plan-cache
+  //     entry and its own pg_stat_statements row. Measured on prod: 1,098 fingerprints on
+  //     2026-08-18, 1,223 on 2026-08-28 — ~12/day, and ~24.5% of the instance's entire
+  //     5,000-entry cap, which is 98.6% full and already evicting (issue-10). One logical
+  //     read presenting as a thousand also makes that table illegible to anyone reading it
+  //     for top costs.
+  //   • Planning time 7.564 ms for the 1,800-literal form versus 0.037 ms for the simple
+  //     one — 200×, paid on every call before a row is touched.
+  //
+  // ⚠ DO NOT SIZE THIS AS A LATENCY FIX. s-4 §3 EXPLAINed both forms at ~48 ms with
+  // everything in shared_hit on a quiet connection, while pg_stat_statements puts the same
+  // read at a 642 ms mean in production. That 13× gap is contention and cache state, not
+  // plan shape, so a rewrite that only changes the plan will not deliver 642 → 48.
+  //
+  // ⚠ AND THE PLAN WILL PROBABLY STAY A SEQ SCAN for the tenant that matters, which is
+  // correct: one Memex holds 81.0% of this table (147,989 of 182,634 rows), so
+  // `memex_id = $1` selects four rows in five and an index scan would be slower. ac-8
+  // expects an index scan and is wrong for that tenant — see c-4.
+  //
+  // Over-fetching rows for ACs outside the requested Spec set is the accepted trade-off
+  // (dec-1): they are all read today anyway, since the seq scan touches every row. The
+  // bucketing below drops them, so the map stays bounded by the requested universe and
+  // parity is exact by construction rather than by argument.
   const summaryRows = await db
     .select({
       subjectRef: testEventLatest.subjectRef,
@@ -1085,13 +1136,18 @@ export async function aggregateAcHealthForBriefs(
       runCount: testEventLatest.runCount,
     })
     .from(testEventLatest)
-    .where(inArray(testEventLatest.subjectRef, allRefs));
+    .where(eq(testEventLatest.memexId, memexId));
 
   // Bucket the summary rows into per-AC snapshots in the same shape the AC tab
   // consumes, so deriveVerificationState gets identical input — card colour and
   // tab agree by construction (ac-2 parity). '' maps back to null.
   const snapshotsByRef = new Map<string, AcTestSnapshot[]>();
+  // spec-520 t-4: the read is now tenant-wide, so skip refs outside the requested universe.
+  // The tally below looks refs UP rather than iterating this map, so extra entries would be
+  // inert either way — this keeps the map bounded by the ACs actually asked about.
+  const wantedRefs = new Set(allRefs);
   for (const row of summaryRows) {
+    if (!wantedRefs.has(row.subjectRef)) continue;
     const list = snapshotsByRef.get(row.subjectRef) ?? [];
     list.push({
       testIdentifier: row.testIdentifier === "" ? null : row.testIdentifier,

--- a/packages/server/src/services/clause-coverage.ts
+++ b/packages/server/src/services/clause-coverage.ts
@@ -15,7 +15,7 @@
 // The denominator is TESTABLE OBLIGATIONS only (dec-5): non-obligations / untestable
 // clauses are shown but excluded from the coverage counts.
 
-import { and, asc, eq, inArray, ne } from "drizzle-orm";
+import { and, asc, eq, ne, sql } from "drizzle-orm";
 import { db } from "../db/connection.js";
 import {
   documents,
@@ -142,7 +142,22 @@ export async function listClausesForStandardWithVerification(
       runCount: testEventLatest.runCount,
     })
     .from(testEventLatest)
-    .where(inArray(testEventLatest.subjectRef, allRefs));
+    // spec-520 t-4 (ac-11): one bind parameter for the whole ref list, not one per ref.
+    // Each distinct IN-count is its own prepared statement and pg_stat_statements row —
+    // the fragmentation that put ~24.5% of the instance's fingerprint cap behind a single
+    // logical read (issue-10). Same shape as listAcsForBriefWithVerification, and NOT
+    // `memex_id = $1` alone: this serves one standard's clauses, so a tenant-wide read
+    // would fetch far more than it filters.
+    //
+    // sql.param() is load-bearing — a bare `${allRefs}` makes drizzle interpolate the array
+    // as a LIST of parameters, which is the fragmentation being removed and fails against
+    // `= ANY(…)` outright.
+    .where(
+      and(
+        eq(testEventLatest.memexId, memexId),
+        sql`${testEventLatest.subjectRef} = ANY(${sql.param(allRefs)}::text[])`,
+      ),
+    );
 
   const testsByRef = new Map<string, AcTestSnapshot[]>();
   for (const row of summaryRows) {


### PR DESCRIPTION
**spec-520 t-4 / ac-7 / ac-11 / ac-39.**

Spec: https://memex.ai/mindset-prod/memex-building-itself/specs/spec-520 · measurements in `s-4 §3`, `c-9`, `issue-10`.

## What the wide `IN` actually costs

`subject_ref IN ($1 … $n)` binds one parameter **per active AC ref** — up to 3,745, 25KB of SQL.

- Each distinct bind-parameter **count** is its own prepared statement, plan-cache entry and `pg_stat_statements` row. Measured on prod: **1,098 fingerprints** on 2026-08-18, **1,223** on 2026-08-28 — ~12/day, and **~24.5% of the instance's entire 5,000-entry cap**, which is 98.6% full and already evicting (`issue-10`). One logical read presenting as a thousand also makes that table illegible to anyone reading it for top costs.
- **Planning time 7.564 ms** for the 1,800-literal form vs **0.037 ms** for the simple one — 200×, paid on every call before a row is touched.

## ⚠ Two things this is NOT

**Not a latency fix.** `s-4 §3` EXPLAINed both forms at ~48 ms with everything in `shared_hit` on a quiet connection, while `pg_stat_statements` puts the same read at a **642 ms mean** in production. That 13× gap is contention and cache state, not plan shape.

**Not going to produce an index scan for the tenant that matters** — correctly. One Memex holds **81.0%** of `test_event_latest` (147,989 of 182,634 rows), so `memex_id = $1` selects four rows in five and an index scan would be slower. **ac-8 expects an index scan and is wrong for that tenant** (`c-4`). It is not amended here — still the owner's call.

## Two different replacements, and the difference is the point

**`aggregateAcHealthForBriefs` → `memex_id = $1`.** It already read every row of the tenant (the seq scan touches them all), so scoping tenant-wide costs nothing and makes tenancy an explicit predicate rather than an inference from ref-string uniqueness. Over-fetched refs are dropped during bucketing, so the map stays bounded by the requested universe and **parity is exact by construction**.

**`listAcsForBriefWithVerification` and the clause-coverage read → `= ANY($1::text[])`** plus an explicit `memex_id`. These serve **one Spec / one standard** — tens of refs — so a tenant-wide read would fetch ~148k rows for the largest Memex to filter down to a handful. `ANY` is one parameter regardless of ref count: the fragmentation goes without the over-fetch.

**`sql.param()` is load-bearing there.** A bare `${allRefs}` makes drizzle interpolate the array as a **list** of parameters — the very fragmentation being removed — and fails against `= ANY(…)` outright. Not hypothetical: the first attempt errored with the array flattened into separate params, which is why the form was **verified against a real database before being repeated** in the second file.

## The index goes out-of-band, and that is now structural (ac-39)

`apply-hand-migrations.mjs` wraps every migration in `sql.begin()`, and `CREATE INDEX CONCURRENTLY` cannot run inside a transaction. Migration `0131` hit the same wall, chose a plain inline index **correctly**, and wrote down when that stops being right: *"if it ever grows to the point where this stops being true, a future index on it belongs out-of-band."* `test_event_latest` is that case.

So the statement lives in `drizzle/out-of-band/`, which the runner's **non-recursive** `readdirSync` cannot see. A guard pins **both** directions, because both are undone by plausible edits: someone adds `CONCURRENTLY` to a normal migration, or someone makes the runner recursive *"to pick everything up"* — which reads as tidying in review and would silently pull it into a transaction.

The file carries **how to apply and how to verify**: an interrupted `CONCURRENTLY` build leaves an **INVALID** index — never used by the planner, still maintained on every write.

**Write cost checked, not assumed** [cl-19]: the PK is `(subject_ref, test_identifier)`, and every emission updates only `latest_status` / `latest_run_at` / `run_count` / `latest_run_id` / `latest_metadata`. Neither indexed column changes on update, so HOT still applies and the ~23.5M lifetime updates pay nothing.

## Test plan

- [x] **t-2's parity harness green against the UNCHANGED implementation first** — the task's own first criterion — and green again after: identical payload, same buckets, same counts, same derived state
- [x] Full server suite — **6433 passed / 0 failed / 25 skipped**
- [x] Restricted-role suite — **17/17**
- [x] `make typecheck` clean · `make check` green
- [x] **ac-39 verified**; ac-7 / ac-11 tagged
- [x] Dead-import sweep clean

### Two honest notes on method

**ac-7 / ac-11's guard is a SOURCE SCAN and says so in its header** rather than dressing itself as behavioural. The honest behavioural test compares `pg_stat_statements` queryids across two ref counts; that extension is not loaded on the local cluster (it needs `shared_preload_libraries` and a restart). Correctness is covered behaviourally by the parity harness; the scan pins the regression that actually threatens this fix.

**The out-of-band guard's first draft was wrong** — it matched `CONCURRENTLY` inside **comments**, failing on `0125` and `0131`, which discuss it precisely to explain why they correctly did *not* use it. A check that punishes the documentation it depends on is a bad check; it now strips `--` lines, as the runner itself does.

## Deploy note

The index is **not applied by this PR**. It is a documented out-of-band step — int first, then prod — with a validity check afterwards.