### PR TITLE
perf(spec-520): memoise the batch memex resolve PER EVENT, never hoisted (t-5)

### DIFF
--- a/packages/server/src/routes/batch-tenant-boundary.integration.test.ts
+++ b/packages/server/src/routes/batch-tenant-boundary.integration.test.ts
@@ -1,0 +1,200 @@
+// spec-520 t-5 / ac-29 — the batch route's memex resolve is memoised PER EVENT'S OWN
+// parsed (namespace, memex) pair, never hoisted out of the loop.
+//
+// ⚠ THIS IS THE SHARPEST HAZARD IN THE SPEC (s-2 Trap 1), and the natural optimisation is
+// the dangerous one.
+//
+// processOneEvent performs a PER-EVENT authorization check: it parses the namespace and
+// memex slug out of THAT EVENT'S OWN subject_ref, resolves them, and rejects unless the
+// result matches the bearer key's Memex (spec-129 ac-10). The batch endpoint accepts
+// arbitrary per-event subject_refs — nothing requires one batch to name one Memex, and the
+// CALLER controls every ref in the array.
+//
+//   SAFE:   memoise keyed on each event's own parsed (namespace, memex).
+//   UNSAFE: resolve once and reuse for every event. That silently turns the check into
+//           `emissionKey.memexId === emissionKey.memexId` — trivially true — and lets a
+//           valid key for Memex A write events into Memex B.
+//
+// AND THERE IS NO DATABASE BACKSTOP. test_events, test_event_latest and ac_first_verified
+// carry no RLS on this path today (spec-398 ac-10 asserted their absence; spec-399 is
+// unbuilt). An application-layer mistake here IS the tenant-isolation failure.
+//
+// So this test is written to FAIL if the resolve is hoisted: it posts one batch whose events
+// name two different Memexes and asserts the foreign one is rejected while its neighbours
+// land. A test that posted a single-tenant batch would pass against the hoisted version and
+// prove nothing.
+
+import { describe, it, expect, afterAll, beforeAll } from "vitest";
+import { eq, inArray } from "drizzle-orm";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { db } from "../db/connection.js";
+import { memexEmissionKeys, memexes, namespaces, testEvents, users } from "../db/schema.js";
+import { mintEmissionKey, mintEphemeralEmissionKey } from "../services/emission-keys.js";
+import { upsertUserByEmail } from "../services/users.js";
+import { ensureUserNamespace } from "../services/user-namespaces.js";
+import { app } from "../app.js";
+
+const AC_BATCH_SCOPE = "mindset-prod/memex-building-itself/specs/spec-520/acs/ac-29";
+
+const runId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+let userA: string;
+let userB: string;
+let memexA: string;
+let memexB: string;
+let refA: (n: number) => string;
+let refB: (n: number) => string;
+let keyA: string;
+const createdRefs: string[] = [];
+
+async function makeTenant(tag: string): Promise<{
+  userId: string;
+  memexId: string;
+  ref: (n: number) => string;
+}> {
+  const user = await upsertUserByEmail(`spec520-t5-${tag}-${runId}@example.com`);
+  const created = await ensureUserNamespace(user.id);
+  const [ns] = await db
+    .select({ slug: namespaces.slug })
+    .from(namespaces)
+    .where(eq(namespaces.id, created.memex.namespaceId))
+    .limit(1);
+  const prefix = `${ns!.slug}/${created.memex.slug}/specs/spec-1/acs`;
+  return {
+    userId: user.id,
+    memexId: created.memex.id,
+    ref: (n: number) => {
+      const r = `${prefix}/ac-${n}`;
+      createdRefs.push(r);
+      return r;
+    },
+  };
+}
+
+beforeAll(async () => {
+  const a = await makeTenant("a");
+  const b = await makeTenant("b");
+  userA = a.userId;
+  memexA = a.memexId;
+  refA = a.ref;
+  userB = b.userId;
+  memexB = b.memexId;
+  refB = b.ref;
+  keyA = (await mintEmissionKey(memexA, `t5-${runId}`, userA)).raw;
+});
+
+afterAll(async () => {
+  if (createdRefs.length) {
+    await db.delete(testEvents).where(inArray(testEvents.subjectRef, createdRefs)).catch(() => {});
+  }
+  await db.delete(memexEmissionKeys).where(eq(memexEmissionKeys.memexId, memexA)).catch(() => {});
+  for (const m of [memexA, memexB]) {
+    await db.delete(memexes).where(eq(memexes.id, m)).catch(() => {});
+  }
+  await db.delete(users).where(inArray(users.id, [userA, userB])).catch(() => {});
+});
+
+async function postBatch(key: string, events: unknown[]) {
+  const res = await app.request("/api/test-events/batch", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: `Bearer ${key}` },
+    body: JSON.stringify({ events }),
+  });
+  return { status: res.status, body: (await res.json()) as {
+    accepted: number;
+    rejected: number;
+    results: Array<{ index: number; ok: boolean; error?: string }>;
+  } };
+}
+
+const ev = (ref: string, id: string) => ({
+  subject_ref: ref,
+  status: "pass",
+  test_identifier: id,
+  duration_ms: 1,
+});
+
+describe("spec-520 ac-29: one batch, two Memexes — the foreign event is rejected", () => {
+  it("rejects ONLY the foreign-Memex event and lands every neighbour in the same batch", async () => {
+    tagAc(AC_BATCH_SCOPE);
+
+    // Key authorises Memex A. Event at index 1 names Memex B — a ref the CALLER chose.
+    // If the resolve were hoisted, index 1's ref would never be resolved at all and the
+    // check would compare A's id with itself: the foreign event would LAND.
+    const { status, body } = await postBatch(keyA, [
+      ev(refA(1), "t::a1"),
+      ev(refB(9), "t::foreign"),
+      ev(refA(2), "t::a2"),
+    ]);
+
+    expect(status).toBe(200);
+    expect(body.results[0]!.ok).toBe(true);
+    expect(body.results[1]!.ok).toBe(false);
+    expect(body.results[2]!.ok).toBe(true);
+    expect(body.accepted).toBe(2);
+    expect(body.rejected).toBe(1);
+  });
+
+  it("writes NO row for the foreign ref — the rejection is a refusal, not a relabel", async () => {
+    tagAc(AC_BATCH_SCOPE);
+
+    const foreign = refB(9);
+    await postBatch(keyA, [ev(refA(3), "t::a3"), ev(foreign, "t::foreign2")]);
+
+    // The failure mode this guards is subtler than "it was accepted": a hoisted resolve
+    // would write the foreign event into Memex A under A's memex_id — a row that exists,
+    // is tenant-stamped wrong, and looks entirely normal.
+    const rows = await db
+      .select({ id: testEvents.id, memexId: testEvents.memexId })
+      .from(testEvents)
+      .where(eq(testEvents.subjectRef, foreign));
+    expect(rows).toEqual([]);
+  });
+
+  it("a batch naming only its own Memex still collapses to ONE resolve", async () => {
+    tagAc(AC_BATCH_SCOPE);
+
+    // The win the memo is for: a normal single-suite batch resolves once, not once per
+    // event. Asserted through behaviour — all events land — plus the count assertion in
+    // the unit test that can observe the resolver directly.
+    const { status, body } = await postBatch(keyA, [
+      ev(refA(4), "t::x1"),
+      ev(refA(4), "t::x2"),
+      ev(refA(5), "t::x3"),
+    ]);
+    expect(status).toBe(200);
+    expect(body.accepted).toBe(3);
+    expect(body.rejected).toBe(0);
+  });
+});
+
+describe("spec-520 ac-29: the scoped-agent-key gate also holds PER EVENT in a batch", () => {
+  it("a scoped key emitting for another Spec's AC is rejected, while its own Spec's event lands", async () => {
+    tagAc(AC_BATCH_SCOPE);
+
+    // spec-234 ac-11: an ephemeral / agent key carries a scoped_spec_handle and may emit
+    // ONLY for ACs of that one Spec — so an in-progress agent run cannot flip the
+    // verification bar of any other Spec on the shared board.
+    //
+    // This is the SECOND per-event gate, and it is the one most likely to be lost to the
+    // same optimisation: unlike the Memex check it compares against a handle parsed from
+    // the ref, so hoisting anything out of the loop makes it compare one event's Spec
+    // against itself. Both events below belong to the SAME Memex, so the first gate passes
+    // for both — only the scope gate separates them.
+    const scoped = await mintEphemeralEmissionKey(memexA, "spec-1", userA);
+
+    const own = `${refA(20).replace(/\/specs\/spec-1\//, "/specs/spec-1/")}`;
+    const other = refA(21).replace("/specs/spec-1/", "/specs/spec-2/");
+    createdRefs.push(other);
+
+    const { status, body } = await postBatch(scoped.raw, [
+      ev(own, "t::in-scope"),
+      ev(other, "t::out-of-scope"),
+    ]);
+
+    expect(status).toBe(200);
+    expect(body.results[0]!.ok).toBe(true);
+    expect(body.results[1]!.ok).toBe(false);
+    expect(body.rejected).toBe(1);
+  });
+});

--- a/packages/server/src/routes/batch-tenant-boundary.integration.test.ts
+++ b/packages/server/src/routes/batch-tenant-boundary.integration.test.ts
@@ -183,7 +183,12 @@ describe("spec-520 ac-29: the scoped-agent-key gate also holds PER EVENT in a ba
     // for both — only the scope gate separates them.
     const scoped = await mintEphemeralEmissionKey(memexA, "spec-1", userA);
 
-    const own = `${refA(20).replace(/\/specs\/spec-1\//, "/specs/spec-1/")}`;
+    // refA() already builds spec-1 refs, so `own` needs no rewriting — an earlier draft
+    // replaced "/specs/spec-1/" with itself here, a no-op that READ as if the two refs were
+    // being derived symmetrically. CodeQL flagged it. In a test whose entire point is that
+    // the two refs differ, a line that looks like it transforms one and does not is worse
+    // than useless.
+    const own = refA(20);
     const other = refA(21).replace("/specs/spec-1/", "/specs/spec-2/");
     createdRefs.push(other);
 

--- a/packages/server/src/routes/test-events.test.ts
+++ b/packages/server/src/routes/test-events.test.ts
@@ -107,7 +107,7 @@ import {
 // tests can override verifyEmissionKey to exercise the scoped-key / missing-key 401 paths.
 // spec-489: resolveMemexId is imported too so a batch test can force ONE event to resolve to a
 // different Memex than the key authorises (the in-batch auth-boundary case).
-import { verifyEmissionKey, resolveMemexId } from "../services/emission-keys.js";
+import { verifyEmissionKey, resolveMemexId, bumpLastUsed } from "../services/emission-keys.js";
 
 const AC = "mindset-prod/memex-building-itself/specs/spec-115/acs";
 const AC333 = "mindset-prod/memex-building-itself/specs/spec-333/acs";
@@ -585,10 +585,25 @@ describe("POST /api/test-events/batch — spec-489 G1 (batch the burst)", () => 
 
   it("preserves the Memex auth boundary — a cross-Memex event is rejected in-batch, neighbours unaffected (ac-5)", async () => {
     tagAc(`${AC489}/ac-5`);
-    // Force the FIRST event to resolve to a Memex the key does not authorise.
-    vi.mocked(resolveMemexId).mockResolvedValueOnce("some-other-memex");
+    // spec-520 t-5: the cross-Memex event now carries a DIFFERENT subject_ref, which is
+    // what a real cross-tenant batch looks like — the caller names another Memex in the ref.
+    //
+    // It used to reuse the SAME ref for all three and force the first resolve with
+    // mockResolvedValueOnce. That models one (namespace, memex) pair resolving to two
+    // different Memexes within one request, which resolveMemexId — a deterministic lookup
+    // keyed on exactly that pair — cannot do. The batch now memoises per parsed pair
+    // (ac-29), so the forced value applied to all three and the test failed. The fixture,
+    // not the memo, was describing something reality does not produce.
+    //
+    // Pinning the boundary with two DISTINCT refs is also strictly stronger: it exercises
+    // the per-event comparison against that event's OWN resolution, which is the property
+    // s-2 Trap 1 is about. Proven end to end against a real database in
+    // batch-tenant-boundary.integration.test.ts.
+    vi.mocked(resolveMemexId).mockImplementation(async (ns: string, mx: string) =>
+      mx === "foreign" ? "some-other-memex" : "memex-1",
+    );
     const res = await postBatch([
-      ev({ test_identifier: "cross" }),
+      ev({ subject_ref: "mindset-prod/foreign/specs/spec-1/acs/ac-1", test_identifier: "cross" }),
       ev({ test_identifier: "ok1" }),
       ev({ test_identifier: "ok2" }),
     ]);
@@ -604,6 +619,13 @@ describe("POST /api/test-events/batch — spec-489 G1 (batch the burst)", () => 
     expect(json.results[0]!.error).toContain("does not authorise");
     // Batching added no new cross-boundary write path: the rejected event never inserted.
     expect(insertSpy).toHaveBeenCalledTimes(2);
+
+    // [per std-37 cl-5] restore what this test replaced. mockImplementation PERSISTS, and
+    // this file's vi.mock sets a plain mockResolvedValue — leaving the ref-dependent
+    // implementation installed would silently change every later test that resolves a ref.
+    // Nothing broke when it was left in, which is the point: that would have been ordering
+    // luck, not safety.
+    vi.mocked(resolveMemexId).mockResolvedValue("memex-1");
   });
 
   it("rejects a non-array events body and an oversized batch with 400, inserting nothing (ac-5 boundary)", async () => {
@@ -868,5 +890,78 @@ describe("POST /api/test-events — promotion does not move the metadata keys (s
     // And the promotion happened alongside, not instead of.
     expect(row.runId).toBe("31589392781");
     expect(row.commitSha).toBe("112ad9ab");
+  });
+});
+
+// ── spec-520 t-5 (ac-29): the batch collapses lookups without collapsing the CHECK ──
+//
+// Two separate claims, and conflating them is the whole hazard (s-2 Trap 1):
+//   • the RESOLVE is memoised per each event's OWN parsed (namespace, memex) — so a
+//     single-suite batch does one lookup, and a two-tenant batch does two;
+//   • the AUTHORIZATION comparison still runs per event, against that event's own result.
+//
+// The tenant-boundary behaviour is proven against a REAL database in
+// batch-tenant-boundary.integration.test.ts, which was confirmed to fail against the
+// hoisted form. What is asserted HERE is the count — observable only because this file
+// mocks the resolver — i.e. that the win is actually being taken.
+describe("POST /api/test-events/batch — one resolve per distinct Memex, one key bump per batch (spec-520 ac-29)", () => {
+  const AC520 = "mindset-prod/memex-building-itself/specs/spec-520/acs/ac-29";
+
+  const batchOf = (refs: string[]) =>
+    new Request("http://localhost/api/test-events/batch", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: "Bearer mxk_x" },
+      body: JSON.stringify({
+        events: refs.map((r, i) => ({
+          subject_ref: r,
+          status: "pass",
+          test_identifier: `t::${i}`,
+          duration_ms: 1,
+        })),
+      }),
+    });
+
+  it("resolves ONCE for a batch that names one Memex, however many events it carries", async () => {
+    tagAc(AC520);
+    vi.mocked(resolveMemexId).mockClear();
+    vi.mocked(bumpLastUsed).mockClear();
+
+    const ref = "mindset-prod/foo/specs/spec-1/acs/ac-1";
+    const res = await app.request(batchOf([ref, ref, ref, ref, ref]));
+    expect(res.status).toBe(200);
+
+    // The win: ~500 identical lookups in a real suite collapse to 1.
+    expect(vi.mocked(resolveMemexId)).toHaveBeenCalledTimes(1);
+    // And the key is bumped once for the request, not once per event.
+    expect(vi.mocked(bumpLastUsed)).toHaveBeenCalledTimes(1);
+  });
+
+  it("resolves ONCE PER DISTINCT (namespace, memex) — not once for the batch", async () => {
+    tagAc(AC520);
+    vi.mocked(resolveMemexId).mockClear();
+
+    // THE assertion that separates memoisation from hoisting. A hoisted resolve would show
+    // 1 here — and would have skipped resolving the second Memex at all, which is exactly
+    // how the authorization check degenerates into comparing a value with itself.
+    await app.request(
+      batchOf([
+        "mindset-prod/foo/specs/spec-1/acs/ac-1",
+        "mindset-prod/other/specs/spec-1/acs/ac-1",
+        "mindset-prod/foo/specs/spec-1/acs/ac-2",
+      ]),
+    );
+    expect(vi.mocked(resolveMemexId)).toHaveBeenCalledTimes(2);
+  });
+
+  it("still bumps the key once when every event in the batch is rejected", async () => {
+    tagAc(AC520);
+    vi.mocked(bumpLastUsed).mockClear();
+    // A rejected batch still PRESENTED and verified the key, which is what last_used_at
+    // records. Skipping the bump here would make a key that only ever emits rejected events
+    // look unused.
+    vi.mocked(resolveMemexId).mockResolvedValueOnce("some-other-memex");
+    const res = await app.request(batchOf(["mindset-prod/foo/specs/spec-1/acs/ac-1"]));
+    expect(res.status).toBe(200);
+    expect(vi.mocked(bumpLastUsed)).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/server/src/routes/test-events.ts
+++ b/packages/server/src/routes/test-events.ts
@@ -272,9 +272,24 @@ async function authenticateEmission(
 // across a Memex boundary (ac-5). A per-event failure is returned as data; the
 // batch caller keeps the good events (partial-failure) rather than discarding
 // the whole batch.
+/**
+ * spec-520 t-5 (ac-29): per-BATCH scratch space, threaded in by the /batch route.
+ *
+ * ⚠ `resolveMemo` is keyed on each event's OWN parsed `<namespace>/<memex>` pair, and that
+ * is the whole safety property — NOT a single resolved id reused for the batch. See the
+ * note at the resolve site below before changing anything here.
+ */
+interface BatchScope {
+  /** `${namespace}/${memexSlug}` -> resolved memex id (or null when it does not resolve). */
+  resolveMemo: Map<string, string | null>;
+  /** The /batch route bumps the key once for the whole request instead of per event. */
+  deferKeyBump: boolean;
+}
+
 async function processOneEvent(
   emissionKey: VerifiedEmissionKey,
   rawBody: unknown,
+  scope?: BatchScope,
 ): Promise<ProcessResult> {
   if (typeof rawBody !== "object" || rawBody === null || Array.isArray(rawBody)) {
     return { ok: false, code: 400, body: { error: "event must be a JSON object" } };
@@ -345,10 +360,34 @@ async function processOneEvent(
   // Resolve the memex named by the ref (<namespace>/<memex>/…) and confirm it matches the
   // authenticated key's memexId. This blocks cross-tenant tampering even with a valid key
   // for a different Memex.
-  const targetMemexId = await resolveMemexId(
-    refNamespace,
-    memexSlugFromAcUid(subjectRefValue),
-  );
+  //
+  // spec-520 t-5 (ac-29): MEMOISED PER EVENT, NEVER HOISTED. This is s-2 Trap 1, the
+  // sharpest hazard in the Spec, and the natural optimisation is the dangerous one.
+  //
+  // The memo key is THIS EVENT'S OWN parsed (namespace, memex) pair, so a batch naming two
+  // Memexes gets two entries and the comparison below still does real work. Hoisting the
+  // resolve out of the loop — resolving once and reusing it — silently turns the check into
+  // `emissionKey.memexId === emissionKey.memexId`, which is trivially true, and lets a valid
+  // key for Memex A write events into Memex B. The /batch endpoint accepts arbitrary
+  // per-event subject_refs and the CALLER controls every one of them.
+  //
+  // There is no database backstop behind this: test_events, test_event_latest and
+  // ac_first_verified carry no RLS on this path (spec-398 ac-10 asserted their absence;
+  // spec-399 is unbuilt). An application-layer mistake here IS the tenant-isolation failure.
+  //
+  // batch-tenant-boundary.integration.test.ts posts one batch naming two Memexes and was
+  // confirmed to FAIL against the hoisted form — 2 of its 3 cases. The third, a
+  // single-tenant batch, passes either way, which is exactly why the mixed case is the one
+  // that has to exist.
+  const memexSlug = memexSlugFromAcUid(subjectRefValue);
+  const memoKey = `${refNamespace}/${memexSlug}`;
+  let targetMemexId: string | null;
+  if (scope?.resolveMemo.has(memoKey)) {
+    targetMemexId = scope.resolveMemo.get(memoKey) ?? null;
+  } else {
+    targetMemexId = await resolveMemexId(refNamespace, memexSlug);
+    scope?.resolveMemo.set(memoKey, targetMemexId);
+  }
   if (!targetMemexId || targetMemexId !== emissionKey.memexId) {
     return {
       ok: false,
@@ -582,7 +621,10 @@ async function processOneEvent(
 
   // spec-129 ac-17: record that this key is live. Fire-and-forget (silent) so a missed
   // bump never blocks or fails the emission — it only leaves a slightly stale timestamp.
-  bumpLastUsed(emissionKey.id);
+  // spec-520 t-5: one key authenticates the WHOLE batch and is verified once, so bumping it
+  // per event is pure waste — the /batch route defers and bumps once after the loop. No
+  // tenant hazard here, unlike the resolve above: there is only ever one key in play.
+  if (!scope?.deferKeyBump) bumpLastUsed(emissionKey.id);
 
   // spec-342: a test_event NEVER changes a Spec's phase. It updates the AC
   // verdict (applyEmissionToSummary, above) and the audit trail only; phase is
@@ -737,8 +779,12 @@ testEventsRouter.post("/batch", async (c) => {
   }> = [];
   let accepted = 0;
   let rejected = 0;
+  // ONE memo for the whole request, keyed per event's own (namespace, memex) — see the note
+  // at the resolve site. A normal single-suite batch collapses ~500 identical lookups to 1;
+  // a batch naming two Memexes still resolves both and still rejects the foreign one.
+  const scope: BatchScope = { resolveMemo: new Map(), deferKeyBump: true };
   for (let index = 0; index < events.length; index++) {
-    const result = await processOneEvent(auth.key, events[index]);
+    const result = await processOneEvent(auth.key, events[index], scope);
     if (result.ok) {
       accepted++;
       results.push({
@@ -766,6 +812,12 @@ testEventsRouter.post("/batch", async (c) => {
   // rejected batch counts what landed, which understates batching slightly and
   // never overstates adoption (ac-19).
   recordEmissionAccepted(accepted, { route: "batch" });
+  // spec-520 t-5: ONE key bump for the whole batch, after the loop. Fire-and-forget, like
+  // the single-event path — a missed bump only leaves a slightly stale "last used" and must
+  // never delay or fail an emission. Bumped even when every event was rejected: the KEY was
+  // still presented and verified, which is what last_used_at records.
+  bumpLastUsed(auth.key.id);
+
   return c.json({ accepted, rejected, results }, 200);
 });
 


### PR DESCRIPTION
**spec-520 t-5 / ac-29.** s-2 **Trap 1** — the sharpest hazard in this Spec, where the natural optimisation is the dangerous one.

Spec: https://memex.ai/mindset-prod/memex-building-itself/specs/spec-520 · measurement in `c-12`.

## The hazard

`processOneEvent` performs a **per-event** authorization check: it parses namespace and memex slug out of **that event's own** `subject_ref`, resolves them, and rejects unless the result matches the bearer key's Memex (spec-129 ac-10). `/batch` accepts arbitrary per-event `subject_ref`s — nothing requires one batch to name one Memex, and the **caller** controls every ref in the array.

| | |
|---|---|
| **SAFE** | memoise keyed on each event's **own** parsed `(namespace, memex)` |
| **UNSAFE** | resolve once and reuse — silently turns the check into `emissionKey.memexId === emissionKey.memexId`, trivially true, letting a valid key for Memex A write into Memex B |

**There is no database backstop.** `test_events`, `test_event_latest` and `ac_first_verified` carry no RLS on this path (spec-398 ac-10 asserted their absence; spec-399 is unbuilt). An application-layer mistake here **is** the tenant-isolation failure.

## The net was proven to have teeth BEFORE the optimisation went in

`batch-tenant-boundary.integration.test.ts` posts **one batch naming two Memexes** against a real database. Run against a deliberately hoisted implementation, **2 of its 3 cases failed**.

The case that matters is not *"the foreign event was accepted"* — it is *"no row was written for it"*. The real defect would not be a rejected event slipping through; it would be a row **written into Memex A under A's `memex_id`** — present, tenant-stamped wrong, and looking entirely normal.

**The third case, a single-tenant batch, passed even hoisted.** That is precisely why the mixed-tenant case had to exist: a hoisted resolve looks perfect until two tenants share a batch.

It also pins the **second** per-event gate (spec-234 ac-11): a scoped agent key emitting for another Spec's AC is rejected while its own Spec's event in the same batch lands. Both share a Memex, so the first gate passes for both and only the scope gate separates them.

## The win, and how it is observed

One memo per request: a single-suite batch collapses ~500 identical lookups to **1**; a two-Memex batch still resolves **both**. Counted in the unit file (which mocks the resolver): 1 call for a five-event single-tenant batch, **2** for a three-event batch naming two Memexes. That second assertion is what separates memoisation from hoisting — a hoisted version shows 1.

`bumpLastUsed` is batch-scoped: once per request, after the loop, **including when every event was rejected** — the key was still presented and verified, which is what `last_used_at` records.

## A pre-existing test describing an impossible shape (the seventh)

`test-events.test.ts`'s in-batch auth-boundary case reused the **same** `subject_ref` for all three events and forced the first resolve with `mockResolvedValueOnce`. That models one `(namespace, memex)` pair resolving to two different Memexes within one request — which `resolveMemexId`, a deterministic lookup keyed on exactly that pair, **cannot do**. Memoising made the forced value apply to all three and it failed.

Corrected to two **distinct** refs: what a real cross-tenant batch looks like, and strictly stronger. Its `mockImplementation` is now restored afterwards [per std-37 cl-5] — it persists, and nothing breaking when it was left installed would have been ordering luck, not safety.

## Measurement (c-12) — and one number t-12 needs that nobody had stated

**Events-per-batch: ~7.85**, derived from the prod 600s delta rather than new instrumentation — the key verify runs once per **batch** (3.947/s), the `test_events` INSERT once per **event** (30.973/s), so their ratio *is* the answer. It also independently confirms spec-489's batching is live: without it the two rates would be equal.

**`distinct-pairs-per-batch` is NOT measured** and cannot be from this data — `pg_stat_statements` counts statements, not their arguments. Recorded as absent rather than estimated.

⚠ **The consequence for t-12.** At 30.973 events/s the table accrues **~2.68M rows/day**. Moving from count-based to **time**-based retention does not shrink `test_events` — it **grows it by an order of magnitude**:

| | rows |
|---|---|
| today (count retention deletes 95% of everything written) | ~1.07M |
| 3-day window | ~8M |
| 7-day window | ~18.8M |

The 13.4% DELETE goes to zero, but partition sizing, index bloat and the activity-feed reads must be planned against the **new** number.

## Test plan

- [x] Safety net confirmed **red** against a deliberately hoisted implementation before the change
- [x] Full server suite — **6445 passed / 0 failed / 25 skipped**
- [x] Restricted-role suite — **17/17**
- [x] `make typecheck` clean · `make check` green · dead-import sweep clean
- [x] std-28: no new journey owed — no user-facing flow changes
- [x] **ac-29 verified**

## Follow-on

t-12 still needs **t-11's remaining half** (`listAcAlignmentOverTime` is the last consumer on the raw log) and carries **t-8** with it.