### PR TITLE
fix(spec-520): the last consumer leaves the raw log, and the chart admits where its history begins (t-11)

### DIFF
--- a/packages/server/src/routes/__test__.ts
+++ b/packages/server/src/routes/__test__.ts
@@ -5,7 +5,7 @@
 
 import { Hono } from "hono";
 import { z } from "zod/v4";
-import { eq, and, isNull } from "drizzle-orm";
+import { eq, and } from "drizzle-orm";
 import {
   clearFakeQueue,
   enqueueFakeResponse,

--- a/packages/server/src/routes/__test__.ts
+++ b/packages/server/src/routes/__test__.ts
@@ -68,6 +68,7 @@ import { createAc, buildAcRef } from "../services/acs.js";
 import { createIssue } from "../services/issues.js";
 import { testEvents } from "../db/schema.js";
 import { applyEmissionToSummary } from "../services/test-event-latest.js";
+import { applyEmissionToRollup } from "../services/test-run-daily.js";
 import { createExecutionPlan } from "../services/execution_plans.js";
 import { addTaskComment, addComment, addDecisionComment, addAnchoredComment } from "../services/comments.js";
 // spec-320 t-5: seed comment @-mentions + assignment through the real services so
@@ -1256,6 +1257,19 @@ testOnlyRouter.post("/seed-test-event", async (c) => {
       testIdentifier,
       status,
       latestRunAt: row.createdAt,
+      hidden: false,
+    });
+    // spec-520 t-11: the per-day rollup is the THIRD tier, and it is what both history
+    // charts now read. Omitting it here would make this fixture write a shape production
+    // never produces — a journey could seed a green emission and still find the alignment
+    // sparkline saying "No alignment history yet", with nothing in the diff to explain it.
+    // Same defect class as the unit fixtures that were root-fixed in seedTestEvent.
+    await applyEmissionToRollup(tx, {
+      subjectRef,
+      memexId,
+      testIdentifier,
+      status,
+      runAt: row.createdAt,
       hidden: false,
     });
   });

--- a/packages/server/src/services/acs.ts
+++ b/packages/server/src/services/acs.ts
@@ -1217,6 +1217,15 @@ export interface AlignmentDay {
   total: number;
   /** Same as listAcsForBriefWithVerification, broken down by kind. */
   kind: "scope" | "implementation";
+  /**
+   * False for days that predate the per-day rollup's first row for this Memex — days we
+   * CANNOT measure, because the per-day past was destroyed by retention and cannot be
+   * reconstructed. Their `verified: 0` is an absence of measurement, not a measured
+   * absence, and ac-5 requires the chart say so rather than let a truncated past read as
+   * data. Callers must render an unmeasured span distinctly; the span shrinks on its own
+   * as history accumulates and eventually disappears.
+   */
+  measured: boolean;
 }
 
 /**
@@ -1225,7 +1234,8 @@ export interface AlignmentDay {
  *   - total  = ACs active on that day (created on or before; status='active'
  *              today — V0.0.1 simplification, we don't reconstruct historical
  *              status transitions, which would require an audit table)
- *   - verified = ACs whose latest test_event AS OF END-OF-DAY is 'pass'
+ *   - verified = ACs that were GREEN as of end-of-day: on the most recent day the AC ran
+ *                at all (≤ this day), every one of its tests passed
  *
  * V0.0.1 caveat: status reconstruction is not historical. An AC currently
  * `rejected` or `superseded` is excluded from the total even on days when it
@@ -1233,10 +1243,9 @@ export interface AlignmentDay {
  * what we care about TODAY; backfilling true historical status would need a
  * status-event log we don't have.
  *
- * SQL is a window-function pair per day, fanned out via generate_series. The
- * heavy lifting is the LATERAL join that finds the latest test event per
- * (subject_ref, day) ≤ end-of-day. Bounded by the AC set in the Spec, which is
- * small (rarely >100), so this is cheap even at 90 days.
+ * SQL fans days out via generate_series and, per (day × AC), reads the per-day ROLLUP —
+ * not the raw log. Bounded by the AC set in the Spec, which is small (rarely >100), so
+ * this stays cheap even at 90 days.
  */
 export async function listAcAlignmentOverTime(
   memexId: string,
@@ -1269,8 +1278,33 @@ export async function listAcAlignmentOverTime(
     sql`, `,
   );
 
-  // For each (day × ac), find the latest event ≤ end-of-day for that subject_ref;
-  // 'verified' iff that latest is 'pass'. Total = ACs that existed by then.
+  // spec-520 t-11 (ac-24): per (day × AC), read the per-day ROLLUP — not the raw log.
+  //
+  // THE DEFECT THIS CLOSES. This carried a correlated
+  //   SELECT te.status FROM test_events te
+  //   WHERE te.subject_ref = a.subject_ref AND te.created_at < day+1
+  //   ORDER BY te.created_at DESC LIMIT 1
+  // against a table the retention trim caps at RETENTION_KEEP=10 rows per (subject_ref,
+  // test_identifier). For a BUSY AC those ten rows are all from the last few hours, so
+  // every older day found nothing and read as "never verified". Same bias as testRunVolume
+  // and it runs the same direction: the more an AC is tested, the less of its history the
+  // chart could see (prod 2026-08-18 — 65,708 pairs sitting at exactly the cap).
+  //
+  // AND THE DERIVATION IS NOW HONEST. "Latest single event" answered with whichever row
+  // happened to write last, so one passing test masked a sibling that went red in the same
+  // minute. The rollup keeps per-test counts, so green is what it should always have
+  // meant: on the most recent day the AC ran at all, EVERY one of its tests passed. That
+  // is the property t-11 names, and it was not answerable before this table existed.
+  //
+  // SCOPED BY memex_id. The old read filtered on subject_ref alone — tenancy carried by a
+  // string, the spec-396 leak pattern (a real cross-org bleed of ~1.5M rows across 137
+  // memexes) this Spec closes elsewhere.
+  //
+  // ⚠ HISTORY STARTS AT THE ROLLUP'S FIRST ROW. Unlike testRunVolume — which begins its
+  // series at min(day) and so cannot show a fabricated past — this query generates a FIXED
+  // `days`-long window, so it necessarily emits days it cannot measure. `measured` marks
+  // them (ac-5); rendering them as a plain zero would let a deleted past read as measured
+  // absence, which is the specific misreading ac-5 forbids.
   const rows = (await db.execute(sql`
     WITH ac_set(subject_ref, kind, created_at, accepted_at) AS (
       VALUES ${acSetValues}
@@ -1282,6 +1316,9 @@ export async function listAcAlignmentOverTime(
         '1 day'::interval
       )::date AS day
     ),
+    coverage AS (
+      SELECT min(day) AS first_day FROM test_run_daily WHERE memex_id = ${memexId}
+    ),
     daily AS (
       SELECT
         s.day,
@@ -1290,13 +1327,20 @@ export async function listAcAlignmentOverTime(
         a.created_at,
         a.accepted_at,
         (
-          SELECT te.status
-          FROM test_events te
-          WHERE te.subject_ref = a.subject_ref
-            AND te.created_at < (s.day + INTERVAL '1 day')
-          ORDER BY te.created_at DESC
+          -- The most recent day this AC ran at or before s.day, collapsed across all of
+          -- its tests. NULL when it had not run by then — distinct from FALSE (ran, and
+          -- something was red), and the two are treated differently below.
+          SELECT sum(r.fail_count) = 0
+             AND sum(r.error_count) = 0
+             AND sum(r.pass_count) > 0
+          FROM test_run_daily r
+          WHERE r.memex_id = ${memexId}
+            AND r.subject_ref = a.subject_ref
+            AND r.day <= s.day
+          GROUP BY r.day
+          ORDER BY r.day DESC
           LIMIT 1
-        ) AS latest_status
+        ) AS green
       FROM series s
       CROSS JOIN ac_set a
     )
@@ -1304,26 +1348,34 @@ export async function listAcAlignmentOverTime(
       day::text AS date,
       kind,
       COUNT(*) FILTER (WHERE created_at <= day + INTERVAL '1 day') AS total,
-      -- Gate verified on AC existence too — otherwise a test_event predating
-      -- the AC's createdAt (only possible with synthetic seed data, but the
-      -- contract should hold) yields verified > total, which is nonsense.
+      -- Gate verified on AC existence too — otherwise history predating the AC's
+      -- createdAt yields verified > total, which is nonsense.
       --
-      -- spec-188 dec-1/dec-2: a manual acceptance counts as verified from the
-      -- day it was recorded, with the same evidence-wins precedence as
-      -- deriveVerificationState — a failing/erroring latest status suppresses
-      -- it. (V0.0.1 caveat, same as status above: accepted_at is TODAY's
-      -- value, not historically reconstructed across un-accept cycles.)
+      -- spec-188 dec-1/dec-2: a manual acceptance counts as verified from the day it was
+      -- recorded, with the same evidence-wins precedence as deriveVerificationState — a
+      -- red latest day suppresses it. green IS NOT FALSE is the precise form: an AC that
+      -- has never run (NULL) keeps its acceptance, one whose tests are red loses it.
+      -- (V0.0.1 caveat: accepted_at is TODAY's value, not reconstructed across un-accept
+      -- cycles.)
       COUNT(*) FILTER (
         WHERE created_at <= day + INTERVAL '1 day'
           AND (
-            latest_status = 'pass'
+            green
             OR (
               accepted_at IS NOT NULL
               AND accepted_at < day + INTERVAL '1 day'
-              AND (latest_status IS NULL OR latest_status = 'pass')
+              AND green IS NOT FALSE
             )
           )
-      ) AS verified
+      ) AS verified,
+      -- An expression on day, which is already grouped. A Memex with no rollup rows at
+      -- all has first_day NULL, so every day is unmeasured — the strongest form of the
+      -- same statement, and the one a naive "is there a row for this day" flag would miss
+      -- by having nothing to report.
+      (
+        (SELECT first_day FROM coverage) IS NOT NULL
+        AND day >= (SELECT first_day FROM coverage)
+      ) AS measured
     FROM daily
     GROUP BY day, kind
     ORDER BY day ASC, kind ASC
@@ -1332,6 +1384,7 @@ export async function listAcAlignmentOverTime(
     kind: "scope" | "implementation";
     total: string | number;
     verified: string | number;
+    measured: boolean;
   }>;
 
   return rows.map((r) => ({
@@ -1339,6 +1392,7 @@ export async function listAcAlignmentOverTime(
     kind: r.kind,
     total: Number(r.total),
     verified: Number(r.verified),
+    measured: r.measured === true,
   }));
 }
 

--- a/packages/server/src/services/alignment-over-time-rollup.integration.test.ts
+++ b/packages/server/src/services/alignment-over-time-rollup.integration.test.ts
@@ -1,0 +1,316 @@
+// spec-520 t-11 (second half) — listAcAlignmentOverTime reads the per-day rollup.
+//
+// THE DEFECT. This query carried a correlated subquery per (day × AC):
+//
+//     SELECT te.status FROM test_events te
+//     WHERE te.subject_ref = a.subject_ref AND te.created_at < (s.day + INTERVAL '1 day')
+//     ORDER BY te.created_at DESC LIMIT 1
+//
+// against a table the retention trim caps at RETENTION_KEEP=10 rows per
+// (subject_ref, test_identifier). For a BUSY AC those ten rows are all from the last few
+// hours, so every older day finds nothing and reads as "never verified". The bias is the
+// same one that broke testRunVolume and it runs the same direction: the more an AC is
+// tested, the less of its history the chart can see. Measured on prod 2026-08-18 — 65,708
+// pairs sitting at exactly the cap of 10.
+//
+// THE PROOF SHAPE, as for ac-24's first half: seed the ROLLUP and leave the raw log EMPTY.
+// Under the old implementation that is indistinguishable from "nothing ever happened",
+// which is precisely the defect. Seeding raw events too would let a still-broken
+// implementation pass.
+//
+// AND A SEMANTIC UPGRADE t-11 ASKS FOR BY NAME: derive AC-green from ALL of an AC's tests
+// passing that day, not from whichever single event happened to be latest. The old read
+// took one row, so a passing test could mask a sibling that went red in the same minute.
+// The rollup keeps per-test counts, so the honest question is answerable for the first
+// time — and the third case below is red under any "latest single event" implementation.
+
+import { describe, it, expect, afterAll, beforeAll } from "vitest";
+import { eq, inArray, sql } from "drizzle-orm";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { db } from "../db/connection.js";
+import {
+  documents,
+  memexes,
+  namespaces,
+  testEventLatest,
+  testEvents,
+  testRunDaily,
+} from "../db/schema.js";
+import { createAc, listAcAlignmentOverTime } from "./acs.js";
+import { createDocDraft } from "./documents.js";
+import { makeTestMemex, seedTestEvent } from "./test-helpers.js";
+
+const AC_CHARTS = "mindset-prod/memex-building-itself/specs/spec-520/acs/ac-24";
+// NOT ac-5. That criterion also claims "no behavioural change on the AC-health surfaces —
+// colours, counts and verification states identical before and after", which nothing here
+// exercises. Tagging it from the boundary clause alone would flip it green on a weaker
+// property than it states — the ac-22/ac-32 mistake. ac-40 is the boundary clause on its
+// own, and the sparkline half of it is proven in AcSparkline.boundary.test.tsx.
+const AC_BOUNDARY = "mindset-prod/memex-building-itself/specs/spec-520/acs/ac-40";
+
+let memexId: string;
+let otherMemexId: string;
+/** Deliberately never given a rollup row — `otherMemexId` gets one by the tenancy case. */
+let emptyMemexId: string;
+/**
+ * The boundary cases need a Memex of their own. Coverage is min(day) across the WHOLE
+ * tenant, so a row seeded by any earlier case in this file would move the boundary under
+ * them — the cases would pass or fail on execution order rather than on the property.
+ */
+let boundaryMemexId: string;
+let boundarySlug: string;
+let namespaceSlug: string;
+let memexSlug: string;
+const createdDocIds: string[] = [];
+const createdRefs: string[] = [];
+
+async function seedBrief(): Promise<{ id: string; handle: string }> {
+  const doc = await createDocDraft(memexId, "alignment rollup test", "purpose", "spec");
+  createdDocIds.push(doc.id);
+  return { id: doc.id, handle: doc.handle! };
+}
+
+function refOf(briefHandle: string, seq: number): string {
+  const ref = `${namespaceSlug}/${memexSlug}/specs/${briefHandle}/acs/ac-${seq}`;
+  createdRefs.push(ref);
+  return ref;
+}
+
+/**
+ * Write one rollup row. `dayOffset` counts BACK from the database's CURRENT_DATE — the
+ * query anchors its series on the server clock, so the fixture has to speak the same
+ * calendar rather than JS's.
+ */
+async function seedRollup(row: {
+  ref: string;
+  test: string;
+  dayOffset: number;
+  pass?: number;
+  fail?: number;
+  error?: number;
+  memex?: string;
+}): Promise<void> {
+  const pass = row.pass ?? 0;
+  const fail = row.fail ?? 0;
+  const error = row.error ?? 0;
+  await db.execute(sql`
+    INSERT INTO test_run_daily
+      (memex_id, subject_ref, test_identifier, day, run_count, pass_count, fail_count, error_count)
+    VALUES (
+      ${row.memex ?? memexId}::uuid, ${row.ref}, ${row.test},
+      CURRENT_DATE - ${row.dayOffset}::int,
+      ${pass + fail + error}, ${pass}, ${fail}, ${error}
+    )
+    ON CONFLICT (memex_id, subject_ref, test_identifier, day) DO UPDATE SET
+      run_count = EXCLUDED.run_count, pass_count = EXCLUDED.pass_count,
+      fail_count = EXCLUDED.fail_count, error_count = EXCLUDED.error_count
+  `);
+}
+
+/**
+ * Move an AC's createdAt back N days. The query gates `verified` on AC existence — an AC
+ * created today counts toward neither total nor verified on any earlier day — so a case
+ * asserting anything about the past has to put the AC in the past first.
+ */
+async function backdateAc(acId: string, days: number): Promise<void> {
+  await db.execute(sql`
+    UPDATE acs SET created_at = now() - (${days} || ' days')::interval WHERE id = ${acId}
+  `);
+}
+
+beforeAll(async () => {
+  memexId = await makeTestMemex("t11b");
+  otherMemexId = await makeTestMemex("t11bx");
+  emptyMemexId = await makeTestMemex("t11be");
+  boundaryMemexId = await makeTestMemex("t11bb");
+  const [row] = await db
+    .select({ m: memexes.slug, n: namespaces.slug })
+    .from(memexes)
+    .innerJoin(namespaces, eq(namespaces.id, memexes.namespaceId))
+    .where(eq(memexes.id, memexId))
+    .limit(1);
+  memexSlug = row!.m;
+  namespaceSlug = row!.n;
+  const [b] = await db
+    .select({ m: memexes.slug })
+    .from(memexes)
+    .where(eq(memexes.id, boundaryMemexId))
+    .limit(1);
+  boundarySlug = b!.m;
+});
+
+afterAll(async () => {
+  await db.delete(testRunDaily).where(eq(testRunDaily.memexId, memexId)).catch(() => {});
+  await db.delete(testRunDaily).where(eq(testRunDaily.memexId, otherMemexId)).catch(() => {});
+  await db.delete(testRunDaily).where(eq(testRunDaily.memexId, emptyMemexId)).catch(() => {});
+  await db.delete(testRunDaily).where(eq(testRunDaily.memexId, boundaryMemexId)).catch(() => {});
+  if (createdRefs.length) {
+    await db.delete(testEventLatest).where(inArray(testEventLatest.subjectRef, createdRefs)).catch(() => {});
+    await db.delete(testEvents).where(inArray(testEvents.subjectRef, createdRefs)).catch(() => {});
+  }
+  if (createdDocIds.length) {
+    await db.delete(documents).where(inArray(documents.id, createdDocIds)).catch(() => {});
+  }
+});
+
+describe("spec-520 ac-24: alignment history comes from the rollup, not the raw log", () => {
+  it("reports an AC as verified from rollup counts alone, with NO raw events", async () => {
+    tagAc(AC_CHARTS);
+    const spec = await seedBrief();
+    const ac = await createAc({
+      memexId, briefId: spec.id, kind: "implementation", statement: "green from the rollup",
+    });
+    const ref = refOf(spec.handle, ac.seq);
+
+    await seedRollup({ ref, test: "a::t", dayOffset: 1, pass: 3 });
+
+    const days = await listAcAlignmentOverTime(memexId, spec.id, 7);
+    const today = days.at(-1)!;
+    expect(today.total).toBe(1);
+    // The raw log is empty. Anything reading test_events sees zero here.
+    expect(today.verified).toBe(1);
+  });
+
+  it("carries a green forward on days the AC did not run", async () => {
+    tagAc(AC_CHARTS);
+    const spec = await seedBrief();
+    const ac = await createAc({
+      memexId, briefId: spec.id, kind: "implementation", statement: "ran once, still green",
+    });
+    const ref = refOf(spec.handle, ac.seq);
+
+    await backdateAc(ac.id, 5);
+    // Passed three days ago and has not run since. It is still green today — "latest
+    // known state", not "ran today".
+    await seedRollup({ ref, test: "a::t", dayOffset: 3, pass: 2 });
+
+    const days = await listAcAlignmentOverTime(memexId, spec.id, 7);
+    expect(days.at(-1)!.verified).toBe(1);
+    expect(days.at(-2)!.verified).toBe(1);
+    // …and not before it ran.
+    expect(days.at(-5)!.verified).toBe(0);
+  });
+
+  it("is NOT verified when one of its tests failed that day, even though another passed", async () => {
+    tagAc(AC_CHARTS);
+    const spec = await seedBrief();
+    const ac = await createAc({
+      memexId, briefId: spec.id, kind: "implementation", statement: "two tests, one red",
+    });
+    const ref = refOf(spec.handle, ac.seq);
+
+    // THE SEMANTIC UPGRADE. Two tests carry this AC on the same day; one is green, one is
+    // red. "Latest single event" answers whichever wrote last — a coin toss that reads
+    // green half the time. An AC with a failing test is not verified.
+    // The green test also gets a REAL emission, so the raw log holds a passing row and
+    // nothing else. That is what makes this case discriminating rather than vacuous: a
+    // "latest single event" read finds that pass and calls the AC verified. Every other
+    // case here runs against an empty log, where any implementation answers zero.
+    const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000);
+    await seedTestEvent({
+      subjectRef: ref, status: "pass", createdAt: yesterday, testIdentifier: "green::t",
+    });
+    await seedRollup({ ref, test: "red::t", dayOffset: 1, fail: 1 });
+
+    const days = await listAcAlignmentOverTime(memexId, spec.id, 7);
+    expect(days.at(-1)!.total).toBe(1);
+    expect(days.at(-1)!.verified).toBe(0);
+  });
+
+  it("goes green again on the day the red test starts passing", async () => {
+    tagAc(AC_CHARTS);
+    const spec = await seedBrief();
+    const ac = await createAc({
+      memexId, briefId: spec.id, kind: "implementation", statement: "red then green",
+    });
+    const ref = refOf(spec.handle, ac.seq);
+
+    await backdateAc(ac.id, 5);
+    await seedRollup({ ref, test: "a::t", dayOffset: 2, fail: 1 });
+    await seedRollup({ ref, test: "a::t", dayOffset: 1, pass: 1 });
+
+    const days = await listAcAlignmentOverTime(memexId, spec.id, 7);
+    const byOffset = (n: number) => days.at(-1 - n)!;
+    expect(byOffset(2).verified).toBe(0); // still red
+    expect(byOffset(1).verified).toBe(1); // fixed
+    expect(byOffset(0).verified).toBe(1); // stays fixed
+  });
+
+  it("counts an errored run as not-green, the same as a failure", async () => {
+    tagAc(AC_CHARTS);
+    const spec = await seedBrief();
+    const ac = await createAc({
+      memexId, briefId: spec.id, kind: "implementation", statement: "errored",
+    });
+    const ref = refOf(spec.handle, ac.seq);
+
+    await seedRollup({ ref, test: "a::t", dayOffset: 1, error: 1 });
+
+    const days = await listAcAlignmentOverTime(memexId, spec.id, 7);
+    expect(days.at(-1)!.verified).toBe(0);
+  });
+
+  it("ignores another tenant's rows carrying the very same subject_ref", async () => {
+    tagAc(AC_CHARTS);
+    const spec = await seedBrief();
+    const ac = await createAc({
+      memexId, briefId: spec.id, kind: "implementation", statement: "tenancy",
+    });
+    const ref = refOf(spec.handle, ac.seq);
+
+    // The old query filtered on subject_ref ALONE — no memex_id anywhere. Tenancy carried
+    // by a string is the spec-396 leak pattern this Spec closes elsewhere; a foreign row
+    // claiming this ref would have decided our chart.
+    await seedRollup({ ref, test: "a::t", dayOffset: 1, pass: 9, memex: otherMemexId });
+
+    const days = await listAcAlignmentOverTime(memexId, spec.id, 7);
+    expect(days.at(-1)!.verified).toBe(0);
+  });
+});
+
+describe("spec-520 ac-40: the chart declares where its history actually begins", () => {
+  it("marks days before the rollup's first row as unmeasured, and measured ones as measured", async () => {
+    tagAc(AC_BOUNDARY);
+    const doc = await createDocDraft(boundaryMemexId, "boundary", "purpose", "spec");
+    createdDocIds.push(doc.id);
+    const ac = await createAc({
+      memexId: boundaryMemexId, briefId: doc.id, kind: "implementation", statement: "boundary",
+    });
+    // The real canonical ref. `measured` is a TENANT-level property — it would read true
+    // off any row this Memex owns — so a made-up ref here would still pass, and would
+    // quietly tell the next reader that this row is what makes the boundary.
+    const ref = `${namespaceSlug}/${boundarySlug}/specs/${doc.handle}/acs/ac-${ac.seq}`;
+
+    // The rollup ships mid-history. Every day before its first row is a day we CANNOT
+    // measure — the per-day past was deleted by retention and cannot be reconstructed.
+    // Rendering those as verified=0 without saying so lets a truncated past read as
+    // measured absence, which is exactly what ac-5 forbids.
+    await seedRollup({ ref, test: "a::t", dayOffset: 2, pass: 1, memex: boundaryMemexId });
+
+    const days = await listAcAlignmentOverTime(boundaryMemexId, doc.id, 7);
+    expect(days.at(-1)!.measured).toBe(true);
+    expect(days.at(-2)!.measured).toBe(true);
+    expect(days.at(-3)!.measured).toBe(true);
+    // One day earlier than anything the rollup holds.
+    expect(days.at(-4)!.measured).toBe(false);
+    expect(days[0]!.measured).toBe(false);
+  });
+
+  it("marks every day unmeasured when the rollup holds nothing for this tenant", async () => {
+    tagAc(AC_BOUNDARY);
+    // A Memex whose rollup is entirely empty — a brand-new tenant, or any tenant on the
+    // day the rollup ships. Its flat-zero line is not a measured absence of green; it is
+    // the absence of measurement. Claiming otherwise is the same lie in its strongest
+    // form, and this is the case a per-day flag derived from "is there a row" would get
+    // wrong by returning nothing to flag.
+    const doc = await createDocDraft(emptyMemexId, "empty rollup", "purpose", "spec");
+    createdDocIds.push(doc.id);
+    await createAc({
+      memexId: emptyMemexId, briefId: doc.id, kind: "implementation", statement: "no history",
+    });
+
+    const days = await listAcAlignmentOverTime(emptyMemexId, doc.id, 7);
+    expect(days.length).toBeGreaterThan(0);
+    expect(days.every((d) => d.measured === false)).toBe(true);
+  });
+});

--- a/packages/server/src/services/t11-rebased-consumers.integration.test.ts
+++ b/packages/server/src/services/t11-rebased-consumers.integration.test.ts
@@ -1,11 +1,17 @@
 // spec-520 t-11 — the two consumers that could be re-based cleanly.
 //
-// ac-24 (testRunVolume) and ac-25 (verifyingAcIsGreen). The other two named by t-11 are
-// NOT here and not attempted:
+// ac-24 (testRunVolume) and ac-25 (verifyingAcIsGreen). Of the other two named by t-11:
 //   • auditCiEmissionForBrief needs run_id + metadata, which test_event_latest does not
 //     carry — dec-8.
-//   • listAcAlignmentOverTime's first-verified half reads ac_first_verified, which dec-7
-//     deliberately left in place.
+//   • listAcAlignmentOverTime moved in a follow-up, and now lives in
+//     alignment-over-time-rollup.integration.test.ts.
+//
+// ⚠ AN EARLIER VERSION OF THIS NOTE WAS WRONG and is corrected here rather than deleted,
+// because it is the kind of error that costs the next reader a wasted afternoon. It said
+// listAcAlignmentOverTime "reads ac_first_verified, which dec-7 deliberately left in
+// place". It never did: its accepted_at comes from the `acs` table via the inlined
+// ac_set VALUES list. The only reader of ac_first_verified is analytics.acsOverTime
+// (analytics.ts:383) — a THIRD chart, and the one dec-7's note is actually about.
 //
 // THE PROOF SHAPE ac-24 ASKS FOR is "results no longer change when raw events age out".
 // So these tests seed the DERIVED tier and leave the raw log EMPTY. Under the old

--- a/packages/server/src/services/t11-rebased-consumers.integration.test.ts
+++ b/packages/server/src/services/t11-rebased-consumers.integration.test.ts
@@ -42,6 +42,12 @@ import { upsertUserByEmail } from "./users.js";
 // exactly why ac-22 and ac-32 were split. It briefly happened here before these existed;
 // the stale emissions on ac-24/ac-25 were retired with discontinue_test_events.
 const AC_CHARTS = "mindset-prod/memex-building-itself/specs/spec-520/acs/ac-35";
+// ac-24 names BOTH history consumers. Its second half — listAcAlignmentOverTime — landed
+// in alignment-over-time-rollup.integration.test.ts once dec-7 unblocked it, so the
+// criterion is now true as written and is tagged from both halves rather than either one
+// alone. That is the whole reason ac-35 exists: it held the half that could ship while the
+// other was blocked, and it stays as the narrower statement.
+const AC_BOTH_CHARTS = "mindset-prod/memex-building-itself/specs/spec-520/acs/ac-24";
 const AC_LATEST = "mindset-prod/memex-building-itself/specs/spec-520/acs/ac-36";
 
 let memexId: string;
@@ -79,6 +85,7 @@ afterAll(async () => {
 describe("spec-520 ac-24: testRunVolume reads the rollup, not the raw log", () => {
   it("reports the counts the rollup holds even with NO raw events at all", async () => {
     tagAc(AC_CHARTS);
+    tagAc(AC_BOTH_CHARTS);
 
     const ref = `${namespaceSlug}/${memexSlug}/specs/spec-1/acs/ac-1`;
     createdRefs.push(ref);
@@ -101,6 +108,7 @@ describe("spec-520 ac-24: testRunVolume reads the rollup, not the raw log", () =
 
   it("is scoped by memex_id, not by a subject_ref string prefix", async () => {
     tagAc(AC_CHARTS);
+    tagAc(AC_BOTH_CHARTS);
 
     // The old read matched `subject_ref LIKE 'ns/mx/%'` — tenancy carried by a string,
     // which is the spec-396 leak pattern this Spec closes elsewhere. A row belonging to

--- a/packages/ui/src/api/acs.ts
+++ b/packages/ui/src/api/acs.ts
@@ -60,6 +60,16 @@ export interface AcAlignmentDay {
   kind: AcKind;
   verified: number;
   total: number;
+  /**
+   * spec-520 ac-5. False for days that predate the per-day rollup's first row for this
+   * Memex — days the server CANNOT measure, because the per-day past was destroyed by
+   * retention and cannot be reconstructed. Their `verified: 0` is an absence of
+   * measurement, not a measured absence, and must never be drawn as a flat zero line.
+   *
+   * Optional so a response from a server predating the flag still renders: absent is
+   * treated as measured, which is exactly the pre-flag behaviour.
+   */
+  measured?: boolean;
 }
 
 export async function fetchAcsForBrief(

--- a/packages/ui/src/components/AcPanel.tsx
+++ b/packages/ui/src/components/AcPanel.tsx
@@ -132,24 +132,41 @@ function relativeTime(d: Date | null): string {
 // The alignment-history endpoint returns one row per (date, kind). The
 // unified header sums verified + total across kinds so the sparkline reflects
 // one health curve, not two stacked ones.
-function mergeAlignmentHistory(history: AcAlignmentDay[]): AcAlignmentDay[] {
-  const byDate = new Map<string, { verified: number; total: number }>();
+//
+// Exported for test only: it is the single path feeding the sparkline, so a regression
+// here is invisible in every chart-level assertion.
+export function mergeAlignmentHistory(history: AcAlignmentDay[]): AcAlignmentDay[] {
+  const byDate = new Map<
+    string,
+    { verified: number; total: number; measured: boolean }
+  >();
   for (const h of history) {
-    const entry = byDate.get(h.date) ?? { verified: 0, total: 0 };
+    const entry = byDate.get(h.date) ?? {
+      verified: 0,
+      total: 0,
+      measured: true,
+    };
     entry.verified += h.verified;
     entry.total += h.total;
+    // spec-520 ac-5: `measured` is a property of the DAY, so both kinds carry the same
+    // value and AND-ing is a no-op today. It is written as an AND rather than an
+    // overwrite so that if the two ever disagree the chart under-claims — the safe
+    // direction. Dropping the flag here would leave the sparkline's whole boundary
+    // treatment as dead code, since this is the only path that feeds it.
+    entry.measured = entry.measured && h.measured !== false;
     byDate.set(h.date, entry);
   }
   return Array.from(byDate.entries())
     .sort(([a], [b]) => a.localeCompare(b))
-    .map(([date, { verified, total }]) => ({
-      // `kind` is unused by the sparkline (it only reads date/verified/total)
+    .map(([date, { verified, total, measured }]) => ({
+      // `kind` is unused by the sparkline (it only reads date/verified/total/measured)
       // but the type requires the field, so we tag the merged rows as 'scope'
       // arbitrarily. Don't read this value downstream.
       date,
       kind: 'scope' as const,
       verified,
       total,
+      measured,
     }));
 }
 

--- a/packages/ui/src/components/AcSparkline.boundary.test.tsx
+++ b/packages/ui/src/components/AcSparkline.boundary.test.tsx
@@ -14,7 +14,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { tagAc } from '@memex-ai-ac/vitest';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { AcSparkline } from './AcSparkline';
 import type { AcAlignmentDay } from '../api/client';
 
@@ -82,6 +82,35 @@ describe('AcSparkline · unmeasured history', () => {
     // The note must retire itself once history covers the window, or it becomes furniture
     // that everyone learns to ignore.
     expect(screen.queryByText(/no history before/i)).not.toBeInTheDocument();
+  });
+
+  it('explains the boundary on hover instead of reporting a measured zero', () => {
+    tagAc(AC_BOUNDARY);
+    // The interaction a reader trusts most. Excluding unmeasured days from the LINE while
+    // the tooltip still says "0/2 verified · 0%" over them puts the forbidden statement
+    // back on screen in the one place someone went looking for detail. Hover is where the
+    // boundary should get explained, not where it leaks.
+    const { container } = render(
+      <AcSparkline
+        data={[
+          day('2026-08-24', 0, 2, false),
+          day('2026-08-27', 2, 2, true),
+          day('2026-08-28', 2, 2, true),
+        ]}
+      />,
+    );
+    const svg = container.querySelector('svg')!;
+    svg.getBoundingClientRect = () =>
+      ({ left: 0, top: 0, width: 320, height: 48 }) as DOMRect;
+
+    fireEvent.mouseMove(svg, { clientX: 0 });
+    expect(screen.queryByText(/0%/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/verified/)).not.toBeInTheDocument();
+    expect(screen.getByText(/not measured/i)).toBeInTheDocument();
+
+    // …and a measured day still reports its numbers.
+    fireEvent.mouseMove(svg, { clientX: 320 });
+    expect(screen.getByText(/2\/2 verified/)).toBeInTheDocument();
   });
 
   it('treats a response with no `measured` field as measured', () => {

--- a/packages/ui/src/components/AcSparkline.boundary.test.tsx
+++ b/packages/ui/src/components/AcSparkline.boundary.test.tsx
@@ -1,0 +1,141 @@
+// spec-520 ac-40 — the alignment sparkline declares where its history actually begins.
+//
+// The per-day rollup ships mid-history. Every day before its first row is a day we CANNOT
+// measure: the per-day past was destroyed by retention and cannot be reconstructed. The
+// server marks those days `measured: false`.
+//
+// Drawing them as a flat 0% line would be the exact misreading ac-5 forbids — a deleted
+// past rendering as a measured absence of green, which reads as "this Spec was red for a
+// month" when the truth is "we were not counting yet". So: no line over unmeasured days,
+// a visibly distinct band, and a note that names the first day we can actually vouch for.
+//
+// The span shrinks on its own as history accumulates and eventually disappears, so this is
+// a treatment that retires itself rather than a permanent caveat.
+
+import { describe, it, expect } from 'vitest';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { render, screen } from '@testing-library/react';
+import { AcSparkline } from './AcSparkline';
+import type { AcAlignmentDay } from '../api/client';
+
+const AC_BOUNDARY =
+  'mindset-prod/memex-building-itself/specs/spec-520/acs/ac-40';
+
+function day(
+  date: string,
+  verified: number,
+  total: number,
+  measured: boolean,
+): AcAlignmentDay {
+  return { date, kind: 'scope', verified, total, measured };
+}
+
+/** Count the drawn vertices — `M` plus one per `L`. */
+function vertexCount(container: HTMLElement): number {
+  const d = container.querySelector('path')?.getAttribute('d') ?? '';
+  if (!d) return 0;
+  return (d.match(/[ML]/g) ?? []).length;
+}
+
+describe('AcSparkline · unmeasured history', () => {
+  it('draws no line across days the rollup cannot vouch for', () => {
+    tagAc(AC_BOUNDARY);
+    const { container } = render(
+      <AcSparkline
+        data={[
+          day('2026-08-24', 0, 2, false),
+          day('2026-08-25', 0, 2, false),
+          day('2026-08-26', 1, 2, true),
+          day('2026-08-27', 2, 2, true),
+          day('2026-08-28', 2, 2, true),
+        ]}
+      />,
+    );
+    // Three measured days → three vertices. A line drawn over all five would put the
+    // curve at 0% for two days nobody measured.
+    expect(vertexCount(container)).toBe(3);
+  });
+
+  it('names the first day it can vouch for', () => {
+    tagAc(AC_BOUNDARY);
+    render(
+      <AcSparkline
+        data={[
+          day('2026-08-24', 0, 2, false),
+          day('2026-08-27', 2, 2, true),
+        ]}
+      />,
+    );
+    expect(screen.getByText(/no history before 2026-08-27/i)).toBeInTheDocument();
+  });
+
+  it('says nothing when every day is measured', () => {
+    tagAc(AC_BOUNDARY);
+    render(
+      <AcSparkline
+        data={[
+          day('2026-08-27', 1, 2, true),
+          day('2026-08-28', 2, 2, true),
+        ]}
+      />,
+    );
+    // The note must retire itself once history covers the window, or it becomes furniture
+    // that everyone learns to ignore.
+    expect(screen.queryByText(/no history before/i)).not.toBeInTheDocument();
+  });
+
+  it('treats a response with no `measured` field as measured', () => {
+    tagAc(AC_BOUNDARY);
+    // Backward compatibility with a server that predates the flag: the absence of the
+    // field must not paint the whole chart as unmeasured.
+    const legacy = [
+      { date: '2026-08-27', kind: 'scope', verified: 1, total: 2 },
+      { date: '2026-08-28', kind: 'scope', verified: 2, total: 2 },
+    ] as unknown as AcAlignmentDay[];
+    const { container } = render(<AcSparkline data={legacy} />);
+    expect(vertexCount(container)).toBe(2);
+    expect(screen.queryByText(/no history before/i)).not.toBeInTheDocument();
+  });
+
+  it('reports the whole window as unmeasured rather than as a flat zero', () => {
+    tagAc(AC_BOUNDARY);
+    const { container } = render(
+      <AcSparkline
+        data={[
+          day('2026-08-27', 0, 2, false),
+          day('2026-08-28', 0, 2, false),
+        ]}
+      />,
+    );
+    // A brand-new Memex, or any tenant on the day the rollup ships. A flat 0% line here
+    // would be the strongest form of the same lie.
+    expect(vertexCount(container)).toBe(0);
+    expect(screen.getByText(/no alignment history yet/i)).toBeInTheDocument();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// The wiring that decides whether any of the above reaches a user.
+// ─────────────────────────────────────────────────────────────────────────
+//
+// The panel merges the server's per-(date, kind) rows into one curve before handing them
+// to the sparkline. That merge is the ONLY path into the chart, so a merge that drops
+// `measured` leaves every assertion above passing while the real screen still draws a flat
+// zero line across a month nobody measured.
+
+describe('AcPanel · the kind-merge preserves the boundary flag', () => {
+  it('keeps a day unmeasured through the merge of both kinds', async () => {
+    tagAc(AC_BOUNDARY);
+    const { mergeAlignmentHistory } = await import('./AcPanel');
+    const merged = mergeAlignmentHistory([
+      { date: '2026-08-24', kind: 'scope', verified: 0, total: 1, measured: false },
+      { date: '2026-08-24', kind: 'implementation', verified: 0, total: 2, measured: false },
+      { date: '2026-08-25', kind: 'scope', verified: 1, total: 1, measured: true },
+      { date: '2026-08-25', kind: 'implementation', verified: 2, total: 2, measured: true },
+    ]);
+    expect(merged.map((d) => [d.date, d.total, d.measured])).toEqual([
+      ['2026-08-24', 3, false],
+      ['2026-08-25', 3, true],
+    ]);
+  });
+});

--- a/packages/ui/src/components/AcSparkline.tsx
+++ b/packages/ui/src/components/AcSparkline.tsx
@@ -23,7 +23,12 @@
 //                         green line, which is exactly the message.
 //   - Hover             → vertical guide line + a small tooltip showing
 //                         date + verified/total + percentage for the point
-//                         under the cursor. Snaps to the nearest x.
+//                         under the cursor. Snaps to the nearest x. Over an
+//                         UNMEASURED day it says so instead of reporting a
+//                         percentage: the guide still tracks (so the shaded
+//                         span is explorable rather than dead) but there is no
+//                         dot on the baseline and no "0%" — that number would
+//                         be the exact claim the shading exists to deny.
 //
 // Y-axis is fixed 0..100 (absolute %, not stretched to data range).
 // X-axis is index-based (day count). Coordinates: SVG y grows downward, so
@@ -199,7 +204,8 @@ export function AcSparkline({
                 strokeLinecap="round"
               />
             )}
-            {/* Hover guide line + dot. */}
+            {/* Hover guide line + dot. No dot on an unmeasured day: it would sit on
+                the 0% baseline and read as a measured zero. */}
             {hovered && (
               <>
                 <line
@@ -211,7 +217,9 @@ export function AcSparkline({
                   strokeOpacity={0.3}
                   strokeWidth={1}
                 />
-                <circle cx={hovered.x} cy={hovered.y} r={4} fill={stroke} />
+                {hovered.measured && (
+                  <circle cx={hovered.x} cy={hovered.y} r={4} fill={stroke} />
+                )}
               </>
             )}
             {/* The persistent "where are we now" dot at the last point. */}
@@ -235,10 +243,16 @@ export function AcSparkline({
               }}
             >
               <div className="font-medium">{hovered.date}</div>
-              <div>
-                {hovered.verified}/{hovered.total} verified ·{' '}
-                {hovered.total === 0 ? '—' : `${Math.round(hovered.pct)}%`}
-              </div>
+              {hovered.measured ? (
+                <div>
+                  {hovered.verified}/{hovered.total} verified ·{' '}
+                  {hovered.total === 0 ? '—' : `${Math.round(hovered.pct)}%`}
+                </div>
+              ) : (
+                <div>
+                  Not measured — counts start {drawn[0]?.date ?? 'later'}
+                </div>
+              )}
             </div>
           )}
         </>

--- a/packages/ui/src/components/AcSparkline.tsx
+++ b/packages/ui/src/components/AcSparkline.tsx
@@ -11,6 +11,13 @@
 //
 // Behaviour:
 //   - Empty data        → renders the baseline + a "no history yet" hint.
+//   - Unmeasured days   → NOT drawn (spec-520 ac-5). Days before the per-day rollup's
+//                         first row cannot be measured — the past was deleted by
+//                         retention — so a flat 0% line there would read as "this Spec
+//                         was red for a month" when the truth is "we were not counting
+//                         yet". The span is shaded, excluded from the path, and named
+//                         below the chart. It shrinks on its own and eventually goes
+//                         away, so it is a treatment that retires itself.
 //   - One data point    → renders as a tiny dot, no path.
 //   - All-100% data     → flat green line at the top. Looks like a flat
 //                         green line, which is exactly the message.
@@ -39,6 +46,11 @@ export interface AcSparklineProps {
 function percent(d: AcAlignmentDay): number {
   if (d.total === 0) return 0;
   return (d.verified / d.total) * 100;
+}
+
+// Absent means "server predates the flag" — treat as measured so nothing regresses.
+function isMeasured(d: AcAlignmentDay): boolean {
+  return d.measured !== false;
 }
 
 export function AcSparkline({
@@ -81,16 +93,32 @@ export function AcSparkline({
         : padX + (i / (data.length - 1)) * usableW;
     const pct = percent(d);
     const y = padY + (1 - pct / 100) * usableH;
-    return { x, y, pct, date: d.date, verified: d.verified, total: d.total };
+    return {
+      x, y, pct,
+      date: d.date,
+      verified: d.verified,
+      total: d.total,
+      measured: isMeasured(d),
+    };
   });
 
-  const path =
-    points.length >= 2
-      ? `M ${points[0].x} ${points[0].y} ` +
-        points.slice(1).map((p) => `L ${p.x} ${p.y}`).join(' ')
-      : '';
+  // The unmeasured span is always a PREFIX — coverage is "every day at or after the
+  // rollup's first row", so it cannot have holes. Taking the first measured index rather
+  // than filtering keeps that assumption visible: if the server ever sends a gap, the
+  // chart draws through it instead of silently stitching two eras into one line.
+  const firstMeasured = points.findIndex((p) => p.measured);
+  const drawn = firstMeasured === -1 ? [] : points.slice(firstMeasured);
+  const unmeasuredCount = firstMeasured === -1 ? points.length : firstMeasured;
 
-  const lastPoint = points[points.length - 1];
+  const path =
+    drawn.length >= 2
+      ? `M ${drawn[0].x} ${drawn[0].y} ` +
+        drawn.slice(1).map((p) => `L ${p.x} ${p.y}`).join(' ')
+      : drawn.length === 1
+        ? `M ${drawn[0].x} ${drawn[0].y}`
+        : '';
+
+  const lastPoint = drawn[drawn.length - 1];
   const hovered = hoverIndex !== null ? points[hoverIndex] : null;
 
   function handleMove(e: React.MouseEvent<SVGSVGElement>) {
@@ -112,7 +140,7 @@ export function AcSparkline({
 
   return (
     <div ref={containerRef} className={`relative ${className ?? ''}`}>
-      {data.length === 0 ? (
+      {drawn.length === 0 ? (
         <div className="text-xs text-muted italic py-2">
           No alignment history yet.
         </div>
@@ -123,13 +151,24 @@ export function AcSparkline({
             height={height}
             viewBox={`0 0 ${width} ${height}`}
             role="img"
-            aria-label={`Alignment over ${data.length} days, currently ${
+            aria-label={`Alignment over ${drawn.length} measured days, currently ${
               lastPoint ? Math.round(lastPoint.pct) : 0
             }% verified`}
             onMouseMove={handleMove}
             onMouseLeave={() => setHoverIndex(null)}
             style={{ display: 'block' }}
           >
+            {/* The span we cannot vouch for — drawn FIRST so the chart sits on top. */}
+            {unmeasuredCount > 0 && drawn.length > 0 && (
+              <rect
+                x={padX}
+                y={padY}
+                width={Math.max(0, drawn[0].x - padX)}
+                height={usableH}
+                fill="currentColor"
+                fillOpacity={0.05}
+              />
+            )}
             {/* Baseline + top dashed line so the band reads as a chart. */}
             <line
               x1={padX}
@@ -180,6 +219,12 @@ export function AcSparkline({
               <circle cx={lastPoint.x} cy={lastPoint.y} r={3} fill={stroke} />
             )}
           </svg>
+          {/* Says on the chart's face where its history begins (spec-520 ac-5). */}
+          {unmeasuredCount > 0 && drawn.length > 0 && (
+            <div className="text-[11px] text-muted italic mt-1">
+              No history before {drawn[0].date} — per-day counts start there.
+            </div>
+          )}
           {/* Tooltip — positioned in CSS so it can extend outside the SVG. */}
           {hovered && (
             <div


### PR DESCRIPTION
Completes **t-11** of spec-520. The first half shipped in #645 (`testRunVolume`, `verifyingAcIsGreen`); this moves the consumer that was blocked on dec-7.

## The defect

`listAcAlignmentOverTime` ran, per (day × AC):

```sql
SELECT te.status FROM test_events te
WHERE te.subject_ref = a.subject_ref AND te.created_at < day+1
ORDER BY te.created_at DESC LIMIT 1
```

against a table the retention trim caps at 10 rows per `(subject_ref, test_identifier)`. For a busy AC those ten rows are all from the last few hours, so every older day found nothing and read as *never verified* — the same bias that broke `testRunVolume`, running the same direction: **the more an AC is tested, the less of its history the chart could see.** Measured on prod 2026-08-18: 65,708 pairs sitting at exactly the cap.

## What changed

**The read moves to the per-day rollup**, and the derivation is honest for the first time. "Latest single event" answered with whichever row wrote last, so one passing test masked a sibling that went red in the same minute. Green now means what it should always have meant: *on the most recent day the AC ran at all, every one of its tests passed.* That property was not answerable before the rollup existed.

**Scoped by `memex_id`.** The old query filtered on `subject_ref` alone — tenancy carried by a string, the spec-396 leak pattern this Spec closes elsewhere.

**The boundary is stated rather than implied (ac-40).** Unlike `testRunVolume`, which starts its series at `min(day)` and so cannot show a fabricated past, this query generates a fixed window and necessarily emits days it cannot measure. A flat 0% line there reads as *"this Spec was red for a month"* when the truth is *"we were not counting yet"*. The server flags each day; the sparkline excludes unmeasured days from its line, shades the span, and names the first day it can vouch for. **The treatment retires itself** as history accumulates.

Two things review caught after the first commit:

- The **hover** still read the unmeasured points — tooltip saying `0/2 verified · 0%` with a dot on the baseline, putting the forbidden statement back on screen in the one interaction a reader goes to for detail. Hover now explains the boundary instead.
- The **e2e seed surface** wrote `test_events` + the latest-summary but not the rollup, producing a shape production never produces. Same defect class as the unit fixtures root-fixed in `seedTestEvent`.

## Criteria

- **ac-24** — now tagged from **both** halves rather than either alone; its second consumer was blocked on dec-7 and is unblocked, so the criterion is true as written.
- **ac-40** (new) — the boundary clause on its own. Deliberately **not** tagged onto ac-5, which also claims no behavioural change across the AC-health surfaces that nothing here exercises; that is the ac-22/ac-32 split repeated on purpose.

## Test plan

- [x] New: `alignment-over-time-rollup.integration.test.ts` (8) — seeds the rollup and leaves the raw log **empty**, the proof shape ac-24 asks for. The semantic case additionally seeds a real passing emission so a "latest single event" read answers green and fails.
- [x] New: `AcSparkline.boundary.test.tsx` (7) — line, note, hover, legacy-response fallback, and the `mergeAlignmentHistory` wiring that is the only path into the chart.
- [x] Full server suite — 6445 passed
- [x] Full UI suite — 2384 passed
- [x] `make check`, server `tsc`, `pnpm --filter @memex/ui build`
- [x] **std-28: 157/157 journeys**, run in a clean worktree at this commit. The main worktree reported 14 SSE/agent failures; a clean worktree on identical code passes all of them — the known degradation, diagnosed rather than assumed.

## Not in scope

`analytics.acsOverTime` still reads `ac_first_verified` — a third chart, which dec-7 deliberately left in place. A comment in `t11-rebased-consumers` that misattributed that read to `listAcAlignmentOverTime` is corrected here rather than deleted.