### PR TITLE
fix(spec-520): give the AC tab its own bounds before deleting the trim that was providing one (t-12 precondition)

### DIFF
--- a/packages/server/src/services/ac-matrix-bounded.integration.test.ts
+++ b/packages/server/src/services/ac-matrix-bounded.integration.test.ts
@@ -1,0 +1,182 @@
+// spec-520 t-12 precondition — the AC tab's two full-history reads get an explicit bound
+// before the retention trim that was silently providing one is deleted.
+//
+// WHAT NOBODY WROTE DOWN. `listTestMatrixForAc` and `listTestEventDigestForAc` both read
+// EVERY test_events row for an AC with no LIMIT. That is survivable today only because
+// spec-398's trim caps each (subject_ref, test_identifier) pair at RETENTION_KEEP=10 — so
+// the matrix renders at most ten columns per row, not by any display decision but as a
+// side effect of retention. t-12 deletes the trim. At ~2.68M emissions/day (spec-520 c-12)
+// a three-day window leaves roughly an order of magnitude more rows per pair, and the AC
+// tab would degrade on the day the migration ships, with nothing in that diff to explain
+// it.
+//
+// THE TWO READS NEED DIFFERENT FIXES, and that is the point of this file.
+//
+//   • The MATRIX returns the emissions themselves, so it takes a per-pair cap — the bound
+//     the trim was providing by accident, now stated as a display decision.
+//
+//   • The DIGEST returns no emissions at all. It reads every row to compute `count`,
+//     documented as "Total emissions recorded (hidden + visible) — the audit depth", and
+//     to find the latest non-hidden one. Putting a LIMIT on it would silently redefine a
+//     displayed number as "the last N" — a quieter defect than the one being fixed. It
+//     becomes an aggregate query instead, which also stops pulling every row into Node
+//     just to call .length on them.
+
+import { describe, it, expect, afterAll, beforeAll } from "vitest";
+import { eq, inArray } from "drizzle-orm";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { db } from "../db/connection.js";
+import { documents, memexes, namespaces, testEventLatest, testEvents } from "../db/schema.js";
+import {
+  MATRIX_EMISSIONS_PER_TEST,
+  createAc,
+  listTestEventDigestForAc,
+  listTestMatrixForAc,
+} from "./acs.js";
+import { createDocDraft } from "./documents.js";
+import { makeTestMemex, seedTestEvent } from "./test-helpers.js";
+
+const AC_BOUND = "mindset-prod/memex-building-itself/specs/spec-520/acs/ac-41";
+
+let memexId: string;
+let namespaceSlug: string;
+let memexSlug: string;
+const createdDocIds: string[] = [];
+const createdRefs: string[] = [];
+
+async function seedAc(statement: string): Promise<{ acId: string; ref: string }> {
+  const doc = await createDocDraft(memexId, "matrix bound", "purpose", "spec");
+  createdDocIds.push(doc.id);
+  const ac = await createAc({
+    memexId, briefId: doc.id, kind: "implementation", statement,
+  });
+  const ref = `${namespaceSlug}/${memexSlug}/specs/${doc.handle}/acs/ac-${ac.seq}`;
+  createdRefs.push(ref);
+  return { acId: ac.id, ref };
+}
+
+/** `n` emissions for one pair, oldest first, one minute apart. */
+async function seedRun(
+  ref: string,
+  testIdentifier: string,
+  n: number,
+  status: "pass" | "fail" | "error" = "pass",
+  opts: { hidden?: boolean } = {},
+): Promise<void> {
+  const base = Date.now() - n * 60_000;
+  for (let i = 0; i < n; i++) {
+    await seedTestEvent({
+      subjectRef: ref,
+      status,
+      testIdentifier,
+      createdAt: new Date(base + i * 60_000),
+      ...(opts.hidden ? { hidden: true } : {}),
+    });
+  }
+}
+
+beforeAll(async () => {
+  memexId = await makeTestMemex("t12m");
+  const [row] = await db
+    .select({ m: memexes.slug, n: namespaces.slug })
+    .from(memexes)
+    .innerJoin(namespaces, eq(namespaces.id, memexes.namespaceId))
+    .where(eq(memexes.id, memexId))
+    .limit(1);
+  memexSlug = row!.m;
+  namespaceSlug = row!.n;
+});
+
+afterAll(async () => {
+  if (createdRefs.length) {
+    await db.delete(testEventLatest).where(inArray(testEventLatest.subjectRef, createdRefs)).catch(() => {});
+    await db.delete(testEvents).where(inArray(testEvents.subjectRef, createdRefs)).catch(() => {});
+  }
+  if (createdDocIds.length) {
+    await db.delete(documents).where(inArray(documents.id, createdDocIds)).catch(() => {});
+  }
+});
+
+describe("spec-520 ac-41: the AC matrix carries its own bound", () => {
+  it("caps emissions per test at the display bound and keeps the NEWEST", async () => {
+    tagAc(AC_BOUND);
+    const { acId, ref } = await seedAc("over the bound");
+    const over = MATRIX_EMISSIONS_PER_TEST + 7;
+    await seedRun(ref, "a::t", over);
+
+    const rows = await listTestMatrixForAc(memexId, acId);
+    const row = rows.find((r) => r.testIdentifier === "a::t")!;
+    expect(row.emissions).toHaveLength(MATRIX_EMISSIONS_PER_TEST);
+    // Newest-first, and the ones dropped are the oldest — a bound that kept the oldest
+    // would show a stale column set that never changes as tests run.
+    const times = row.emissions.map((e) => e.emittedAt.getTime());
+    expect(times).toEqual([...times].sort((a, b) => b - a));
+    expect(Math.min(...times)).toBeGreaterThan(Date.now() - over * 60_000);
+  });
+
+  it("applies the bound PER TEST, not across the whole AC", async () => {
+    tagAc(AC_BOUND);
+    const { acId, ref } = await seedAc("two tests");
+    await seedRun(ref, "a::t", MATRIX_EMISSIONS_PER_TEST + 3);
+    await seedRun(ref, "b::t", MATRIX_EMISSIONS_PER_TEST + 3);
+
+    const rows = await listTestMatrixForAc(memexId, acId);
+    // A global LIMIT would starve whichever test sorted later — the matrix would lose an
+    // entire row rather than trim a long one.
+    expect(rows.find((r) => r.testIdentifier === "a::t")!.emissions).toHaveLength(MATRIX_EMISSIONS_PER_TEST);
+    expect(rows.find((r) => r.testIdentifier === "b::t")!.emissions).toHaveLength(MATRIX_EMISSIONS_PER_TEST);
+  });
+
+  it("leaves a pair under the bound untouched", async () => {
+    tagAc(AC_BOUND);
+    const { acId, ref } = await seedAc("under the bound");
+    await seedRun(ref, "a::t", 3);
+
+    const rows = await listTestMatrixForAc(memexId, acId);
+    expect(rows.find((r) => r.testIdentifier === "a::t")!.emissions).toHaveLength(3);
+  });
+});
+
+describe("spec-520 ac-41: the digest counts everything, and reads nothing it does not need", () => {
+  it("reports the TRUE total, not the matrix bound", async () => {
+    tagAc(AC_BOUND);
+    const { acId, ref } = await seedAc("audit depth");
+    const total = MATRIX_EMISSIONS_PER_TEST + 11;
+    await seedRun(ref, "a::t", total);
+
+    const rows = await listTestEventDigestForAc(memexId, acId);
+    // `count` is documented as the audit depth. A bound applied here would redefine a
+    // displayed number as "the last N" — quieter than the defect being fixed, and worse.
+    expect(rows.find((r) => r.testIdentifier === "a::t")!.count).toBe(total);
+  });
+
+  it("still reads the verdict off the newest non-hidden emission", async () => {
+    tagAc(AC_BOUND);
+    const { acId, ref } = await seedAc("verdict survives");
+    await seedRun(ref, "a::t", MATRIX_EMISSIONS_PER_TEST + 5, "pass");
+    // The newest one is red. If the digest ever loses sight of it, the AC stops being
+    // pinned red while a test is failing — the worst direction for this to break in.
+    await seedTestEvent({
+      subjectRef: ref, status: "fail", testIdentifier: "a::t", createdAt: new Date(),
+    });
+
+    const row = (await listTestEventDigestForAc(memexId, acId)).find((r) => r.testIdentifier === "a::t")!;
+    expect(row.latestStatus).toBe("fail");
+    expect(row.pinning).toBe(true);
+    expect(row.hidden).toBe(false);
+  });
+
+  it("reports a fully hidden pair as retired, with no verdict", async () => {
+    tagAc(AC_BOUND);
+    const { acId, ref } = await seedAc("fully hidden");
+    await seedRun(ref, "h::t", 3, "pass", { hidden: true });
+
+    const row = (await listTestEventDigestForAc(memexId, acId)).find((r) => r.testIdentifier === "h::t")!;
+    expect(row.hidden).toBe(true);
+    expect(row.latestStatus).toBeNull();
+    expect(row.latestRunAt).toBeNull();
+    // Hidden rows still count toward the audit depth — that is what "hidden + visible"
+    // means, and it is how a retired pair stays visibly retired rather than vanishing.
+    expect(row.count).toBe(3);
+  });
+});

--- a/packages/server/src/services/acs.ts
+++ b/packages/server/src/services/acs.ts
@@ -738,8 +738,25 @@ export interface TestMatrixRow {
 }
 
 /**
- * Read the full test-event history for one AC, grouped by `test_identifier`,
- * each row's emissions newest-first by `created_at`.
+ * spec-520 t-12: the matrix shows at most this many emissions PER TEST.
+ *
+ * This is the bound spec-398's retention trim was providing by accident. Until now the
+ * matrix had no LIMIT of its own and was survivable only because the trim capped each
+ * (subject_ref, test_identifier) pair at RETENTION_KEEP=10 — a display bound nobody chose,
+ * enforced by a deletion policy. t-12 deletes that trim in favour of a time window, under
+ * which a busy pair keeps roughly an order of magnitude more rows (~2.68M emissions/day
+ * across the fleet, spec-520 c-12). Without this the AC tab degrades on the day that
+ * migration ships, with nothing in its diff to explain why.
+ *
+ * Ten preserves exactly what users see today. It is a display choice now, so changing it
+ * is a decision about the UI rather than a side effect of a retention policy.
+ */
+export const MATRIX_EMISSIONS_PER_TEST = 10;
+
+/**
+ * Read the recent test-event history for one AC, grouped by `test_identifier`,
+ * each row's emissions newest-first by `created_at` and capped at
+ * MATRIX_EMISSIONS_PER_TEST per test.
  *
  * No server-side run-batching, no `run_id`-aware grouping, no inferred
  * "didn't run" cells (b-96 dec-11). One column entry per `test_events` row.
@@ -755,20 +772,48 @@ export async function listTestMatrixForAc(
   // spec-115 v0.1.0: hidden events are excluded from the matrix view too —
   // the matrix is the per-AC verification timeline that drives the badge.
   // Hidden audit history is in the DB but not surfaced in v0.1.0.
-  const events = await db.query.testEvents.findMany({
-    where: and(eq(testEvents.subjectRef, subjectRef), eq(testEvents.hidden, false)),
-    orderBy: [desc(testEvents.createdAt)],
-  });
+  //
+  // The cap is PER TEST, via row_number() — not a plain LIMIT. A global limit would
+  // starve whichever test_identifier sorted later, dropping an entire matrix ROW rather
+  // than trimming a long one, and which row vanished would depend on how the AC's tests
+  // happened to be named. The window orders by (created_at DESC, id DESC), the same
+  // deterministic tiebreak the retention index uses, so a pair emitting several times
+  // within one timestamp still cuts at a stable point.
+  const events = (await db.execute(sql`
+    SELECT id, subject_ref, test_identifier, status, created_at, actor, metadata, commit_sha
+    FROM (
+      SELECT te.*,
+             row_number() OVER (
+               PARTITION BY COALESCE(te.test_identifier, '')
+               ORDER BY te.created_at DESC, te.id DESC
+             ) AS rn
+      FROM test_events te
+      WHERE te.subject_ref = ${subjectRef} AND te.hidden = false
+    ) ranked
+    WHERE rn <= ${MATRIX_EMISSIONS_PER_TEST}
+    ORDER BY created_at DESC, id DESC
+  `)) as unknown as Array<{
+    test_identifier: string | null;
+    status: string;
+    // ⚠ db.execute hands back RAW driver values, so a timestamptz arrives as a string
+    // here — unlike the query-builder reads elsewhere in this file, which map it to a
+    // Date. Typing it Date and trusting that is how a `.getTime is not a function`
+    // reaches production through a green suite.
+    created_at: Date | string;
+    actor: string | null;
+    metadata: Record<string, unknown> | null;
+    commit_sha: string | null;
+  }>;
 
   const byTestIdentifier = new Map<string, TestEventEmission[]>();
   for (const ev of events) {
-    const key = ev.testIdentifier ?? "";
+    const key = ev.test_identifier ?? "";
     const list = byTestIdentifier.get(key) ?? [];
     list.push({
       status: ev.status as "pass" | "fail" | "error",
-      emittedAt: ev.createdAt,
+      emittedAt: ev.created_at instanceof Date ? ev.created_at : new Date(ev.created_at),
       actor: ev.actor ?? null,
-      metadata: ev.metadata ?? null,
+      metadata: (ev.metadata as TestEventEmission["metadata"]) ?? null,
     });
     byTestIdentifier.set(key, list);
   }
@@ -819,39 +864,74 @@ export async function listTestEventDigestForAc(
   const slugs = await resolveBriefSlugsForRef(ac.briefId);
   const subjectRef = buildAcRef(slugs, ac.seq);
 
-  const events = await db.query.testEvents.findMany({
-    where: eq(testEvents.subjectRef, subjectRef),
-    orderBy: [desc(testEvents.createdAt)],
-  });
+  // spec-520 t-12: an AGGREGATE, not a full-history fetch.
+  //
+  // This used to read every test_events row for the AC into Node and derive the digest in
+  // JS — `count` was `evs.length`. It had no LIMIT and was survivable only because
+  // spec-398's trim capped each pair at 10; t-12 removes that trim, and a busy pair then
+  // carries roughly an order of magnitude more rows.
+  //
+  // ⚠ AND IT MUST NOT SIMPLY TAKE THE MATRIX'S BOUND. `count` is documented as the audit
+  // depth — hidden AND visible. Capping this read would quietly redefine a number the UI
+  // shows as "the last N", which is a subtler defect than the unbounded read it would be
+  // fixing. Counting in the database keeps the number exact at any table size and reads no
+  // row the digest does not use.
+  const rows = (await db.execute(sql`
+    WITH totals AS (
+      SELECT COALESCE(test_identifier, '') AS tid, count(*)::int AS n
+      FROM test_events
+      WHERE subject_ref = ${subjectRef}
+      GROUP BY 1
+    ),
+    -- The newest row of ANY visibility, for the commit-sha fallback the JS version had.
+    newest_any AS (
+      SELECT DISTINCT ON (COALESCE(test_identifier, ''))
+             COALESCE(test_identifier, '') AS tid, commit_sha
+      FROM test_events
+      WHERE subject_ref = ${subjectRef}
+      ORDER BY COALESCE(test_identifier, ''), created_at DESC, id DESC
+    ),
+    -- The verdict view: the latest NON-hidden emission. Absent for a fully retired pair,
+    -- which is exactly what the hidden flag reports.
+    latest_visible AS (
+      SELECT DISTINCT ON (COALESCE(test_identifier, ''))
+             COALESCE(test_identifier, '') AS tid, status, created_at, commit_sha
+      FROM test_events
+      WHERE subject_ref = ${subjectRef} AND hidden = false
+      ORDER BY COALESCE(test_identifier, ''), created_at DESC, id DESC
+    )
+    SELECT t.tid                AS test_identifier,
+           t.n                  AS count,
+           lv.status            AS latest_status,
+           lv.created_at        AS latest_run_at,
+           COALESCE(lv.commit_sha, na.commit_sha) AS last_commit
+    FROM totals t
+    LEFT JOIN latest_visible lv ON lv.tid = t.tid
+    LEFT JOIN newest_any     na ON na.tid = t.tid
+    ORDER BY t.tid ASC
+  `)) as unknown as Array<{
+    test_identifier: string;
+    count: number;
+    latest_status: "pass" | "fail" | "error" | null;
+    // Raw driver value — see the note on the matrix read above.
+    latest_run_at: Date | string | null;
+    last_commit: string | null;
+  }>;
 
-  const byId = new Map<string, typeof events>();
-  for (const ev of events) {
-    const key = ev.testIdentifier ?? "";
-    const list = byId.get(key) ?? [];
-    list.push(ev);
-    byId.set(key, list);
-  }
-
-  const rows: TestEventDigestRow[] = [];
-  for (const [testIdentifier, evs] of byId.entries()) {
-    // evs are newest-first; the latest non-hidden emission is the verdict view.
-    const latestVisible = evs.find((e) => !e.hidden) ?? null;
-    const latestStatus = (latestVisible?.status ?? null) as
-      | "pass"
-      | "fail"
-      | "error"
-      | null;
-    rows.push({
-      testIdentifier,
-      latestStatus,
-      latestRunAt: latestVisible?.createdAt ?? null,
-      lastCommit: latestVisible?.commitSha ?? evs[0]?.commitSha ?? null,
-      count: evs.length,
-      hidden: latestVisible === null,
-      pinning: latestStatus === "fail" || latestStatus === "error",
-    });
-  }
-  return rows.sort((a, b) => a.testIdentifier.localeCompare(b.testIdentifier));
+  return rows.map((r) => ({
+    testIdentifier: r.test_identifier,
+    latestStatus: r.latest_status,
+    latestRunAt:
+      r.latest_run_at == null
+        ? null
+        : r.latest_run_at instanceof Date
+          ? r.latest_run_at
+          : new Date(r.latest_run_at),
+    lastCommit: r.last_commit,
+    count: Number(r.count),
+    hidden: r.latest_status === null,
+    pinning: r.latest_status === "fail" || r.latest_status === "error",
+  }));
 }
 
 /**


### PR DESCRIPTION
A precondition for **t-12** that the task did not name. It surfaced while sizing the retention window, and it has to land before the trim is deleted.

## What nobody wrote down

`listTestMatrixForAc` and `listTestEventDigestForAc` read **every** `test_events` row for an AC with no LIMIT. That is survivable today only because spec-398's trim caps each `(subject_ref, test_identifier)` pair at `RETENTION_KEEP=10`.

So the matrix renders at most ten columns per row — **not by any display decision, but as a side effect of a retention policy.**

t-12 deletes that trim in favour of a time window. At ~2.68M emissions/day (c-12), three days leaves roughly an order of magnitude more rows per pair. The AC tab would degrade on the day that migration ships, with nothing in *its* diff to explain why.

## The two reads need different fixes

**The matrix** returns the emissions, so it takes a per-pair cap. Ten — preserving exactly what users see today, now stated as a display choice rather than inherited from a deletion policy.

The cap is a `row_number()` window, **not a plain LIMIT**. A global limit would starve whichever `test_identifier` sorted later, dropping an entire matrix *row* rather than trimming a long one — and which row vanished would depend on how the AC's tests happened to be named.

**The digest** returns no emissions at all. It read every row to compute `count`, documented as *"Total emissions recorded (hidden + visible) — the audit depth"*, and to find the latest non-hidden one. Giving it the matrix's bound would have silently redefined a displayed number as *"the last N"* — a quieter defect than the unbounded read it would be fixing.

It becomes an aggregate query: the count stays exact at any table size, and no row is fetched that the digest does not use.

## A trap the tests caught

`db.execute` hands back **raw driver values**, so a `timestamptz` arrives as a string, not a `Date` — unlike the query-builder reads elsewhere in the file. Typing it `Date` and trusting that is how a `.getTime is not a function` reaches production through a green suite. Both reads now coerce, and both say why.

## Test plan

- [x] New: `ac-matrix-bounded.integration.test.ts` (6, tagged **ac-41**) — the cap holds and keeps the *newest*; it applies per test rather than across the AC; a short pair is untouched; the digest reports the **true** total rather than the bound; the verdict still reads off the newest non-hidden emission (the worst direction for this to break in); a fully hidden pair stays retired and still counts toward audit depth.
- [x] Full server suite — 6443 passed
- [x] `make check`, `tsc`
- [x] Consumers exercised: `services/acs`, `routes/acs`, `mcp` — 511 passed
- [x] ac-41 emitted under a **live** key (preflight 201 first; the previous key had expired and a green suite under it would have looked identical to a successful emission)

## Not in scope

The **number of rows** in the matrix — an AC's distinct `test_identifier` count — is still unbounded. The trim never bounded that either, so this is unchanged behaviour, not a regression introduced here.