### PR TITLE
fix(spec-520): give the rollup the cascading tenant FK migration 0134 omitted (t-13, ac-30)

### DIFF
--- a/packages/server/drizzle/0139_spec520_rollup_tenant_fk.sql
+++ b/packages/server/drizzle/0139_spec520_rollup_tenant_fk.sql
@@ -1,0 +1,80 @@
+-- spec-520 t-13 (ac-30) — give test_run_daily the cascading tenant FK that migration
+-- 0134 should have declared, so workspace deletion reaches it BY CONSTRUCTION.
+--
+-- THE DEFECT THIS CLOSES, AND WHOSE IT IS. 0134 declared `memex_id uuid NOT NULL` with no
+-- REFERENCES clause. Every other tenant table in this database is reached automatically
+-- when a memex row goes: 16 carry an ON DELETE CASCADE foreign key to `memexes`, and
+-- others (acs, issues) inherit it transitively through `documents`. The emission family —
+-- test_events, test_event_latest, ac_first_verified and, as shipped, test_run_daily —
+-- carries NO foreign key at all, direct or transitive. It sits outside the cascade graph.
+--
+-- WHY IT NEVER BIT BEFORE. Retention was the de facto eraser on this path: the trim capped
+-- test_events, so a deleted tenant's rows aged out on their own. test_run_daily is
+-- PERMANENT by design — it exists so history survives retention — and grows per tenant,
+-- per subject, per test, per day, forever. Nothing would ever remove it. And t-12 is about
+-- to stop retention erasing test_events too.
+--
+-- ⚠ THE LEAK IS LATENT, NOT LIVE. There is no production tenant-deletion path today: the
+-- only DELETE against memexes/orgs/namespaces in the entire server is the env-gated test
+-- surface, no route deletes a memex, and there is no soft-delete column. So nothing is
+-- orphaned yet. This constraint is what makes the guarantee true in advance of that path
+-- being built, rather than a line someone must remember to add to an enumeration — which
+-- is exactly the distinction t-13 draws. The three sibling tables are recorded as a
+-- separate finding; they predate this Spec and fixing them is not its scope.
+--
+-- LOCKS [per std-39 cl-2/cl-3]. Adding a foreign key normally takes ACCESS EXCLUSIVE and
+-- then scans the whole table to validate — on a continuously-written table that is the
+-- shape that deadlocked and rolled back a prod deploy during spec-398 (std-39 cl-9). So
+-- it is split in two:
+--
+--   * THIS FILE adds the constraint NOT VALID. That takes ACCESS EXCLUSIVE but performs NO
+--     scan, so the exclusive window is O(1) rather than O(rows). New writes are checked
+--     from this moment on.
+--   * 0140 validates it, under SHARE UPDATE EXCLUSIVE, which does not block reads OR
+--     writes.
+--
+-- The split is load-bearing because the migration runner wraps each FILE in its own
+-- transaction (scripts/apply-hand-migrations.mjs). Putting both statements here would hold
+-- the ACCESS EXCLUSIVE lock from the ADD until the VALIDATE finished, and the weaker lock
+-- would buy nothing.
+--
+-- lock_timeout is SET LOCAL so it dies with this transaction and cannot leak into the
+-- migrations that follow on the same connection. Failing fast is correct here: a deploy
+-- that cannot get the lock in three seconds should retry on the next one, not queue behind
+-- the emission path and stall it.
+--
+-- WRITE COST [per std-39 cl-7], MEASURED — not reasoned. The first draft of this comment
+-- claimed the referential check fires only on genuinely new rows, because the rollup's
+-- writes are `INSERT ... ON CONFLICT DO UPDATE` and the DO UPDATE branch never touches
+-- memex_id. THAT CLAIM IS WRONG, and the benchmark said so.
+--
+-- 20,000 all-conflicting upserts, arms interleaved with a VACUUM before each timing so
+-- accumulating dead tuples could not favour whichever arm ran first (local pg16,
+-- 2026-08-30):
+--
+--     with FK     272 ms   262 ms   244 ms      (mean ~259)
+--     without FK  216 ms   215 ms   222 ms      (mean ~218)
+--
+-- A consistent ~41 ms per 20k, i.e. **~2 µs per upsert**, ~19% on this microbenchmark.
+-- The RI trigger fires on the UPDATE path too and pays for the comparison even when the
+-- referencing column is unchanged. (EXPLAIN ANALYZE cannot settle this — it surfaced no
+-- "Trigger for constraint" line for RI checks on this version, which is what sent the
+-- first draft down the reasoning-instead-of-measuring path.)
+--
+-- WHY THAT IS STILL FINE. 2 µs sits against an emission transaction that already does an
+-- insert, two upserts and a first-verified write. At the measured production rate of
+-- ~31 events/s that is ~62 µs of CPU per second — 0.006% of one core — to buy a tenancy
+-- guarantee that holds without anyone maintaining a list. A 19% figure on a synthetic
+-- single-statement loop is not a 19% figure on the emission path.
+--
+-- NO NEW INDEX. A cascading delete needs to find the child rows by memex_id; the table's
+-- PRIMARY KEY is (memex_id, subject_ref, test_identifier, day), so its leading column
+-- already serves that. Adding one would put another index tuple on every increment for no
+-- gain (cl-7).
+
+SET LOCAL lock_timeout = '3s';
+
+ALTER TABLE test_run_daily
+  ADD CONSTRAINT test_run_daily_memex_id_fkey
+  FOREIGN KEY (memex_id) REFERENCES memexes(id) ON DELETE CASCADE
+  NOT VALID;

--- a/packages/server/drizzle/0140_spec520_rollup_tenant_fk_validate.sql
+++ b/packages/server/drizzle/0140_spec520_rollup_tenant_fk_validate.sql
@@ -1,0 +1,17 @@
+-- spec-520 t-13 (ac-30) — validate the tenant FK added NOT VALID in 0139.
+--
+-- Separate FILE, therefore a separate transaction (the runner wraps each file in its own
+-- sql.begin), which is the whole point: VALIDATE CONSTRAINT takes SHARE UPDATE EXCLUSIVE
+-- and blocks neither reads nor writes, so the emission path keeps running while the scan
+-- proceeds. Merged into 0139 it would have inherited that file's ACCESS EXCLUSIVE lock for
+-- the duration of the scan.
+--
+-- The scan can only fail on an orphan row — a rollup row whose memex_id names no memex.
+-- None can exist: the column has always been written from the resolved emitting Memex
+-- (std-32, never parsed from subject_ref), and there is no tenant-deletion path in
+-- production that could have stranded one. A failure here would therefore be real news
+-- about the write path, not migration noise, and it should stop the deploy.
+
+SET LOCAL lock_timeout = '3s';
+
+ALTER TABLE test_run_daily VALIDATE CONSTRAINT test_run_daily_memex_id_fkey;

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -1209,7 +1209,12 @@ export const acFirstVerified = pgTable("ac_first_verified", {
 export const testRunDaily = pgTable(
   "test_run_daily",
   {
-    memexId: uuid("memex_id").notNull(),
+    // spec-520 t-13 (ac-30): the cascading tenant FK migration 0134 omitted. Workspace
+    // deletion reaches this table BY CONSTRUCTION, not by an enumeration someone
+    // maintains — see drizzle/0139.
+    memexId: uuid("memex_id")
+      .notNull()
+      .references(() => memexes.id, { onDelete: "cascade" }),
     subjectRef: text("subject_ref").notNull(),
     testIdentifier: text("test_identifier").notNull().default(""),
     // UTC calendar day the runs fall on. Derived from the event's own

--- a/packages/server/src/services/rollup-tenant-deletion.integration.test.ts
+++ b/packages/server/src/services/rollup-tenant-deletion.integration.test.ts
@@ -1,0 +1,106 @@
+// spec-520 t-13 (ac-30) — deleting a workspace must reach the per-day rollup.
+//
+// WHY THIS TABLE AND NOT THE OTHERS. Every table on the emission path has so far been
+// forgiven by retention: the trim capped test_events, so a deleted tenant's rows aged out
+// on their own. Retention was the de facto eraser. `test_run_daily` is PERMANENT by
+// design — it exists precisely so history survives retention — and it grows per tenant,
+// per subject, per test, per day, forever. Nothing will ever remove it on its own.
+//
+// WHAT THE INVESTIGATION FOUND (recorded on t-13):
+//
+//   1. There is NO production tenant-deletion path. The only DELETE against `memexes`,
+//      `orgs` or `namespaces` in the whole server is the env-gated test surface. No route
+//      on memexes.ts/orgs.ts deletes, and there is no soft-delete column.
+//   2. Coverage for every other tenant table IS by construction — 16 tables carry an
+//      ON DELETE CASCADE foreign key to `memexes`, and `acs`/`issues` inherit it
+//      transitively through `documents`.
+//   3. The emission family — test_events, test_event_latest, ac_first_verified and (as
+//      shipped) test_run_daily — carries NO foreign key at all, direct or transitive. It
+//      sits entirely outside the cascade graph.
+//
+// So the leak is latent rather than live: nothing deletes a tenant today, so nothing is
+// orphaned yet. But when that path is built it will silently miss these four tables, and
+// t-13 is explicit that coverage must be by construction rather than by someone
+// remembering to add a line to an enumeration.
+//
+// THIS TEST DELETES THE ROW DIRECTLY, not through any service. That is deliberate: the
+// guarantee has to hold for whatever code eventually issues the delete, including code
+// that has never heard of this table. Going through a helper would prove only that the
+// helper remembered.
+
+import { describe, it, expect, afterAll, beforeAll } from "vitest";
+import { eq, sql } from "drizzle-orm";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { db } from "../db/connection.js";
+import { memexes, testRunDaily } from "../db/schema.js";
+import { makeTestMemex } from "./test-helpers.js";
+
+const AC_DELETION = "mindset-prod/memex-building-itself/specs/spec-520/acs/ac-30";
+
+let doomedMemexId: string;
+let survivorMemexId: string;
+
+async function seedRollup(memexId: string, subjectRef: string): Promise<void> {
+  await db.insert(testRunDaily).values({
+    memexId,
+    subjectRef,
+    testIdentifier: "a::t",
+    day: "2026-08-30",
+    runCount: 3,
+    passCount: 3,
+    failCount: 0,
+    errorCount: 0,
+  } as typeof testRunDaily.$inferInsert);
+}
+
+async function rollupRowsFor(memexId: string): Promise<number> {
+  const rows = await db
+    .select({ n: sql<number>`count(*)::int` })
+    .from(testRunDaily)
+    .where(eq(testRunDaily.memexId, memexId));
+  return Number(rows[0]?.n ?? 0);
+}
+
+beforeAll(async () => {
+  doomedMemexId = await makeTestMemex("t13d");
+  survivorMemexId = await makeTestMemex("t13s");
+});
+
+afterAll(async () => {
+  await db.delete(testRunDaily).where(eq(testRunDaily.memexId, survivorMemexId)).catch(() => {});
+  await db.delete(memexes).where(eq(memexes.id, survivorMemexId)).catch(() => {});
+});
+
+describe("spec-520 ac-30: workspace deletion reaches the rollup", () => {
+  it("removes the rollup rows when the memex row is deleted, with no application code involved", async () => {
+    tagAc(AC_DELETION);
+    await seedRollup(doomedMemexId, "ns/mx/specs/spec-1/acs/ac-1");
+    await seedRollup(doomedMemexId, "ns/mx/specs/spec-1/acs/ac-2");
+    await seedRollup(survivorMemexId, "ns/other/specs/spec-1/acs/ac-1");
+    expect(await rollupRowsFor(doomedMemexId)).toBe(2);
+
+    // The raw row delete — the thing every future deletion path will ultimately do.
+    await db.delete(memexes).where(eq(memexes.id, doomedMemexId));
+
+    expect(await rollupRowsFor(doomedMemexId)).toBe(0);
+    // A cascade that took the neighbours with it would be a far worse bug than the one
+    // being fixed, and it would look like success from the doomed tenant's side.
+    expect(await rollupRowsFor(survivorMemexId)).toBe(1);
+  });
+
+  it("holds the guarantee structurally — the constraint exists and cascades", async () => {
+    tagAc(AC_DELETION);
+    // The behavioural case above would keep passing if someone replaced the cascade with
+    // an application-level cleanup. This asserts the guarantee is where t-13 requires it:
+    // in the schema, reached automatically, not in a list somebody maintains.
+    const rows = (await db.execute(sql`
+      SELECT c.confdeltype::text AS on_delete
+      FROM pg_constraint c
+      WHERE c.contype = 'f'
+        AND c.conrelid = 'test_run_daily'::regclass
+        AND c.confrelid = 'memexes'::regclass
+    `)) as unknown as Array<{ on_delete: string }>;
+    expect(rows).toHaveLength(1);
+    expect(rows[0].on_delete).toBe("c"); // 'c' = ON DELETE CASCADE
+  });
+});


### PR DESCRIPTION
## The question t-13 asked, answered honestly

t-13 requires the workspace-deletion path be *"identified and described — confirmed to exist, not assumed"*.

**It does not exist.** The only `DELETE` against `memexes`, `orgs` or `namespaces` in the entire server is `routes/__test__.ts`, the env-gated test surface. No route on `memexes.ts` or `orgs.ts` exposes a DELETE verb, and there is no soft-delete column. Recorded as **issue-11**.

## What the investigation turned up

Coverage for everything *else* is by construction. Verified against the live schema, not the migration files:

- **16 tenant tables** carry an `ON DELETE CASCADE` FK straight to `memexes`
- `acs` and `issues` inherit it **transitively** through `documents`
- **`test_events`, `test_event_latest`, `ac_first_verified` and `test_run_daily` carry no foreign key at all** — direct or transitive. The emission family sits entirely outside the cascade graph.

That never bit because **retention was the de facto eraser**: the trim capped `test_events`, so a deleted tenant's rows aged out on their own. Two things change it. `test_run_daily` is permanent *by design* — it exists so history survives retention — and grows per tenant, per subject, per test, per day, forever. And **t-12 is about to stop retention erasing `test_events` too.**

So the leak is **latent, not live**. Nothing deletes a tenant today. But the day that path is built it silently misses these tables.

## What this fixes, and what it does not

Migration **0139/0140** gives `test_run_daily` the cascading FK that **my own migration 0134 omitted**. That table is spec-520's, and it is now reached by construction.

The other three are **not** fixed here. They predate this Spec, and an FK on a soon-to-be-partitioned `test_events` belongs with t-12's work. Recorded rather than quietly widened.

## Lock discipline

The FK is added `NOT VALID` in **0139** and validated in **0140** — separate **files**, therefore separate transactions, because the runner wraps each file in its own `sql.begin()`. Merged into one file, the `ACCESS EXCLUSIVE` lock from the ADD would be held across the validation scan and the weaker `SHARE UPDATE EXCLUSIVE` would buy nothing. `lock_timeout` is `SET LOCAL` so it cannot leak into later migrations on the same connection.

## The cost claim is measured, and the first draft was wrong

The migration comment originally reasoned that the RI check never fires on the `DO UPDATE` branch, since `memex_id` is never updated. **The benchmark contradicted it.** 20k all-conflicting upserts, arms interleaved with a `VACUUM` before each timing so accumulating dead tuples could not favour whichever ran first:

| | run 1 | run 2 | run 3 |
|---|---|---|---|
| with FK | 272 ms | 262 ms | 244 ms |
| without FK | 216 ms | 215 ms | 222 ms |

**~2 µs per upsert.** The trigger fires on the update path and pays for the comparison even when the column is unchanged. Against the measured ~31 events/s that is ~62 µs of CPU per second — 0.006% of a core — to buy a guarantee that holds without anyone maintaining a list. The comment now carries the numbers and the correction.

(`EXPLAIN ANALYZE` surfaced no `Trigger for constraint` line for RI checks on this version — which is what sent the first draft down the reasoning-instead-of-measuring path.)

## Test plan

- [x] New: `rollup-tenant-deletion.integration.test.ts` (2, tagged **ac-30**, verified via `get_ac`)
  - deletes the `memexes` row **directly**, with no service involved — the guarantee must hold for whatever code eventually issues the delete, including code that has never heard of this table
  - asserts a neighbouring tenant's rows survive (a cascade that took them too would look like success from the deleted side)
  - asserts the constraint **structurally** (`confdeltype = 'c'`), so replacing it with application-level cleanup fails loudly
- [x] Full server suite — 6439 passed, with 0139/0140 applied to fresh test DBs
- [x] `make check`, `tsc`
- [x] Drizzle schema updated to match, so the schema-drift check stays honest

## ac-19 / ac-20 — diff-verified, by design

Both are assertions about the *shape* of the change, not runtime behaviour, so t-13 asks they be recorded as diff-verified rather than left looking like missing coverage. This diff touches four files: two migrations, `db/schema.ts`, one test. It does **not** touch `db/connection.ts` and contains no `DB_POOL_MAX`, `maxScale`, `minScale` or `max_connections` value. The connection budget stays with spec-518 (dec-4).