### PR TITLE
feat(spec-520): carry a dark pair's last known state forward instead of a blank strip (dec-9, ac-42)

### DIFF
--- a/packages/server/src/services/ac-matrix-carry-forward.integration.test.ts
+++ b/packages/server/src/services/ac-matrix-carry-forward.integration.test.ts
@@ -1,0 +1,182 @@
+// spec-520 dec-9 (ac-42) — a pair whose emissions have all left the retention window still
+// reports its last known state instead of an empty grid.
+//
+// THE NUMBER THAT FORCED THIS. t-12 swaps count-based retention ("latest 10 per pair, any
+// age") for a time window. Those rules are not interchangeable: a pair that ran ten times
+// in March keeps all ten today and would keep none under a window. Measured on prod
+// 2026-08-30, BEFORE any swap — 196,978 of 243,339 pairs have not run in three days.
+// **81%.**
+//
+// The verification badge reads test_event_latest, which retention has never touched
+// (spec-398 ac-8 guarantees it). The evidence grid reads test_events. So without this, four
+// out of five ACs would render "Verified" above an EMPTY matrix — the two halves of one tab
+// contradicting each other, and the half that looks broken being the one that carries the
+// proof.
+//
+// WHY A SEPARATE FIELD AND NOT A SYNTHETIC EMISSION. The matrix UI lays emissions out on a
+// shared TIME AXIS by emittedAt. A fabricated entry dated three months back would be
+// positioned off the axis, and worse, it would claim to be a run inside the window. ac-42
+// asks for it "marked as a carried-forward summary rather than presented as a run" — so it
+// is literally not in the emissions list. Nothing in the existing layout logic changes.
+//
+// HOW A DARK PAIR IS SIMULATED. No window exists yet, so the test deletes the raw rows and
+// keeps the summary — which is exactly the state t-12 will produce for a pair whose last
+// run predates the window.
+
+import { describe, it, expect, afterAll, beforeAll } from "vitest";
+import { and, eq, inArray } from "drizzle-orm";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { db } from "../db/connection.js";
+import { documents, memexes, namespaces, testEventLatest, testEvents } from "../db/schema.js";
+import { createAc, listTestEventDigestForAc, listTestMatrixForAc } from "./acs.js";
+import { createDocDraft } from "./documents.js";
+import { makeTestMemex, seedTestEvent } from "./test-helpers.js";
+
+const AC_CARRY = "mindset-prod/memex-building-itself/specs/spec-520/acs/ac-42";
+
+let memexId: string;
+let namespaceSlug: string;
+let memexSlug: string;
+const createdDocIds: string[] = [];
+const createdRefs: string[] = [];
+
+async function seedAc(statement: string): Promise<{ acId: string; ref: string }> {
+  const doc = await createDocDraft(memexId, "carry forward", "purpose", "spec");
+  createdDocIds.push(doc.id);
+  const ac = await createAc({ memexId, briefId: doc.id, kind: "implementation", statement });
+  const ref = `${namespaceSlug}/${memexSlug}/specs/${doc.handle}/acs/ac-${ac.seq}`;
+  createdRefs.push(ref);
+  return { acId: ac.id, ref };
+}
+
+/** Emit, then drop the raw rows — the shape a time window leaves behind for a dark pair. */
+async function goDark(
+  ref: string,
+  testIdentifier: string,
+  status: "pass" | "fail" | "error",
+  at: Date,
+): Promise<void> {
+  await seedTestEvent({ subjectRef: ref, status, testIdentifier, createdAt: at });
+  await db
+    .delete(testEvents)
+    .where(and(eq(testEvents.subjectRef, ref), eq(testEvents.testIdentifier, testIdentifier)));
+}
+
+beforeAll(async () => {
+  memexId = await makeTestMemex("d9cf");
+  const [row] = await db
+    .select({ m: memexes.slug, n: namespaces.slug })
+    .from(memexes)
+    .innerJoin(namespaces, eq(namespaces.id, memexes.namespaceId))
+    .where(eq(memexes.id, memexId))
+    .limit(1);
+  memexSlug = row!.m;
+  namespaceSlug = row!.n;
+});
+
+afterAll(async () => {
+  if (createdRefs.length) {
+    await db.delete(testEventLatest).where(inArray(testEventLatest.subjectRef, createdRefs)).catch(() => {});
+    await db.delete(testEvents).where(inArray(testEvents.subjectRef, createdRefs)).catch(() => {});
+  }
+  if (createdDocIds.length) {
+    await db.delete(documents).where(inArray(documents.id, createdDocIds)).catch(() => {});
+  }
+});
+
+describe("spec-520 ac-42: the matrix carries a dark pair's last known state forward", () => {
+  it("reports the pair with an empty emission list and a carried-forward summary", async () => {
+    tagAc(AC_CARRY);
+    const { acId, ref } = await seedAc("dark pair");
+    const lastRun = new Date("2026-06-12T09:00:00Z");
+    await goDark(ref, "a::t", "pass", lastRun);
+
+    const rows = await listTestMatrixForAc(memexId, acId);
+    const row = rows.find((r) => r.testIdentifier === "a::t");
+    // Without the fallback the pair is absent entirely — not an empty row, no row at all.
+    expect(row, "a dark pair must still appear in the matrix").toBeDefined();
+    expect(row!.emissions).toHaveLength(0);
+    expect(row!.carriedForward).not.toBeNull();
+    expect(row!.carriedForward!.status).toBe("pass");
+    expect(row!.carriedForward!.emittedAt.toISOString()).toBe(lastRun.toISOString());
+  });
+
+  it("leaves a pair that still has rows in the window untouched", async () => {
+    tagAc(AC_CARRY);
+    const { acId, ref } = await seedAc("live pair");
+    await seedTestEvent({ subjectRef: ref, status: "pass", testIdentifier: "a::t", createdAt: new Date() });
+
+    const row = (await listTestMatrixForAc(memexId, acId)).find((r) => r.testIdentifier === "a::t")!;
+    expect(row.emissions).toHaveLength(1);
+    // The fallback is for absence of evidence, not a decoration on evidence that exists.
+    expect(row.carriedForward).toBeNull();
+  });
+
+  it("carries forward a RED last-known state, not just a green one", async () => {
+    tagAc(AC_CARRY);
+    const { acId, ref } = await seedAc("dark and red");
+    await goDark(ref, "a::t", "fail", new Date("2026-06-12T09:00:00Z"));
+
+    const row = (await listTestMatrixForAc(memexId, acId)).find((r) => r.testIdentifier === "a::t")!;
+    // Only carrying greens forward would turn the fallback into a way of hiding failures.
+    expect(row.carriedForward!.status).toBe("fail");
+  });
+
+  it("does not invent a row for a pair that only ever had hidden emissions", async () => {
+    tagAc(AC_CARRY);
+    const { acId, ref } = await seedAc("hidden only");
+    await seedTestEvent({
+      subjectRef: ref, status: "pass", testIdentifier: "h::t", createdAt: new Date(), hidden: true,
+    });
+
+    // Hidden emissions never reach test_event_latest (applyEmissionToSummary returns early),
+    // and the matrix excludes them. Enumerating pairs from the summary must not change that.
+    const rows = await listTestMatrixForAc(memexId, acId);
+    expect(rows.find((r) => r.testIdentifier === "h::t")).toBeUndefined();
+  });
+});
+
+describe("spec-520 ac-42: the digest does the same without losing what it already reported", () => {
+  it("reports a dark pair with a zero count and its last known verdict", async () => {
+    tagAc(AC_CARRY);
+    const { acId, ref } = await seedAc("digest dark");
+    await goDark(ref, "a::t", "pass", new Date("2026-06-12T09:00:00Z"));
+
+    const row = (await listTestEventDigestForAc(memexId, acId)).find((r) => r.testIdentifier === "a::t");
+    expect(row, "a dark pair must still appear in the digest").toBeDefined();
+    // Zero is the honest audit depth — no rows are retained. The verdict is still known.
+    expect(row!.count).toBe(0);
+    expect(row!.latestStatus).toBe("pass");
+    expect(row!.carriedForward).toBe(true);
+    expect(row!.hidden).toBe(false);
+  });
+
+  it("still reports a hidden-only pair, which has rows but NO summary row", async () => {
+    tagAc(AC_CARRY);
+    const { acId, ref } = await seedAc("digest hidden only");
+    await seedTestEvent({
+      subjectRef: ref, status: "pass", testIdentifier: "h::t", createdAt: new Date(), hidden: true,
+    });
+
+    // The digest now has to enumerate pairs from BOTH test_events and test_event_latest.
+    // Switching to the summary alone would silently drop fully-retired pairs — repairing
+    // dark pairs by losing hidden ones.
+    const row = (await listTestEventDigestForAc(memexId, acId)).find((r) => r.testIdentifier === "h::t");
+    expect(row, "a hidden-only pair has no summary row and must not vanish").toBeDefined();
+    expect(row!.count).toBe(1);
+    expect(row!.hidden).toBe(true);
+    expect(row!.latestStatus).toBeNull();
+    expect(row!.carriedForward).toBe(false);
+  });
+
+  it("leaves a live pair reporting its real count", async () => {
+    tagAc(AC_CARRY);
+    const { acId, ref } = await seedAc("digest live");
+    await seedTestEvent({ subjectRef: ref, status: "fail", testIdentifier: "a::t", createdAt: new Date() });
+
+    const row = (await listTestEventDigestForAc(memexId, acId)).find((r) => r.testIdentifier === "a::t")!;
+    expect(row.count).toBe(1);
+    expect(row.carriedForward).toBe(false);
+    expect(row.pinning).toBe(true);
+  });
+});

--- a/packages/server/src/services/acs.ts
+++ b/packages/server/src/services/acs.ts
@@ -733,8 +733,19 @@ export interface TestEventEmission {
 export interface TestMatrixRow {
   /** test_identifier as emitted by the helper, or empty string when null. */
   testIdentifier: string;
-  /** Every emission ever recorded for this (subject_ref, test_identifier), newest-first. */
+  /** Retained emissions for this (subject_ref, test_identifier), newest-first. */
   emissions: TestEventEmission[];
+  /**
+   * spec-520 dec-9 (ac-42): the pair's last known state, carried forward from
+   * test_event_latest when NO emission for it survives in the log. Null whenever
+   * `emissions` is non-empty.
+   *
+   * ⚠ DELIBERATELY NOT AN ENTRY IN `emissions`. It is not a run inside the retention
+   * window and must never be laid out on the matrix's shared time axis as though it were —
+   * it would be positioned months off the axis and would claim evidence the log no longer
+   * holds. Consumers render it as "last known", not as a cell.
+   */
+  carriedForward: { status: "pass" | "fail" | "error"; emittedAt: Date } | null;
 }
 
 /**
@@ -818,10 +829,42 @@ export async function listTestMatrixForAc(
     byTestIdentifier.set(key, list);
   }
 
+  // spec-520 dec-9 (ac-42): a pair whose emissions have all left the retention window is
+  // absent from the query above entirely — not an empty row, NO row. Under a time window
+  // that is the majority case: measured on prod 2026-08-30, 196,978 of 243,339 pairs had
+  // not run in three days. The badge would still read "Verified" (it comes from
+  // test_event_latest, which retention never touches) above a blank grid.
+  //
+  // So pairs are enumerated from the summary too, and a dark one carries its last known
+  // state. A second small indexed read rather than a wider join: this one is keyed on the
+  // test_event_latest PK's leading column, and merging two small maps in JS is far easier
+  // to follow than the four-CTE query that would fuse them.
+  const summary = await db
+    .select({
+      testIdentifier: testEventLatest.testIdentifier,
+      latestStatus: testEventLatest.latestStatus,
+      latestRunAt: testEventLatest.latestRunAt,
+    })
+    .from(testEventLatest)
+    .where(eq(testEventLatest.subjectRef, subjectRef));
+
+  const rows: TestMatrixRow[] = Array.from(byTestIdentifier.entries()).map(
+    ([testIdentifier, emissions]) => ({ testIdentifier, emissions, carriedForward: null }),
+  );
+  for (const pair of summary) {
+    if (byTestIdentifier.has(pair.testIdentifier)) continue;
+    rows.push({
+      testIdentifier: pair.testIdentifier,
+      emissions: [],
+      carriedForward: {
+        status: pair.latestStatus as "pass" | "fail" | "error",
+        emittedAt: pair.latestRunAt,
+      },
+    });
+  }
+
   // Stable row ordering across reads — emissions already DESC from the query.
-  return Array.from(byTestIdentifier.entries())
-    .sort(([a], [b]) => a.localeCompare(b))
-    .map(([testIdentifier, emissions]) => ({ testIdentifier, emissions }));
+  return rows.sort((a, b) => a.testIdentifier.localeCompare(b.testIdentifier));
 }
 
 // ──────────────────────────────────────────────────────────────────────
@@ -854,6 +897,12 @@ export interface TestEventDigestRow {
   hidden: boolean;
   /** Latest non-hidden emission is fail/error — this identifier pins the AC red. */
   pinning: boolean;
+  /**
+   * spec-520 dec-9 (ac-42): true when NO emission for this pair survives in the log and
+   * `latestStatus` therefore comes from test_event_latest rather than from a retained row.
+   * `count` is 0 in that case — an honest audit depth, not a missing verdict.
+   */
+  carriedForward: boolean;
 }
 
 export async function listTestEventDigestForAc(
@@ -883,6 +932,22 @@ export async function listTestEventDigestForAc(
       WHERE subject_ref = ${subjectRef}
       GROUP BY 1
     ),
+    -- spec-520 dec-9 (ac-42): the durable index of pairs. A pair whose rows have all left
+    -- the window has no entry in totals and would vanish from the digest entirely.
+    summary AS (
+      SELECT test_identifier AS tid, latest_status, latest_run_at
+      FROM test_event_latest
+      WHERE subject_ref = ${subjectRef}
+    ),
+    -- ⚠ UNION, NOT a switch to the summary alone. Hidden emissions never reach
+    -- test_event_latest (applyEmissionToSummary returns early on hidden), so a fully
+    -- retired pair has rows here and NO summary row. Reading only the summary would repair
+    -- dark pairs by silently dropping retired ones.
+    pairs AS (
+      SELECT tid FROM totals
+      UNION
+      SELECT tid FROM summary
+    ),
     -- The newest row of ANY visibility, for the commit-sha fallback the JS version had.
     newest_any AS (
       SELECT DISTINCT ON (COALESCE(test_identifier, ''))
@@ -900,21 +965,28 @@ export async function listTestEventDigestForAc(
       WHERE subject_ref = ${subjectRef} AND hidden = false
       ORDER BY COALESCE(test_identifier, ''), created_at DESC, id DESC
     )
-    SELECT t.tid                AS test_identifier,
-           t.n                  AS count,
-           lv.status            AS latest_status,
-           lv.created_at        AS latest_run_at,
-           COALESCE(lv.commit_sha, na.commit_sha) AS last_commit
-    FROM totals t
-    LEFT JOIN latest_visible lv ON lv.tid = t.tid
-    LEFT JOIN newest_any     na ON na.tid = t.tid
-    ORDER BY t.tid ASC
+    SELECT p.tid                                     AS test_identifier,
+           COALESCE(t.n, 0)                          AS count,
+           COALESCE(lv.status, s.latest_status)      AS latest_status,
+           COALESCE(lv.created_at, s.latest_run_at)  AS latest_run_at,
+           COALESCE(lv.commit_sha, na.commit_sha)    AS last_commit,
+           -- Carried forward exactly when the log holds no visible row for the pair but
+           -- the summary knows its state. A hidden-only pair satisfies neither side and
+           -- stays reported as retired, which is what it is.
+           (lv.status IS NULL AND s.latest_status IS NOT NULL) AS carried_forward
+    FROM pairs p
+    LEFT JOIN totals         t  ON t.tid  = p.tid
+    LEFT JOIN summary        s  ON s.tid  = p.tid
+    LEFT JOIN latest_visible lv ON lv.tid = p.tid
+    LEFT JOIN newest_any     na ON na.tid = p.tid
+    ORDER BY p.tid ASC
   `)) as unknown as Array<{
     test_identifier: string;
     count: number;
     latest_status: "pass" | "fail" | "error" | null;
     // Raw driver value — see the note on the matrix read above.
     latest_run_at: Date | string | null;
+    carried_forward: boolean;
     last_commit: string | null;
   }>;
 
@@ -931,6 +1003,7 @@ export async function listTestEventDigestForAc(
     count: Number(r.count),
     hidden: r.latest_status === null,
     pinning: r.latest_status === "fail" || r.latest_status === "error",
+    carriedForward: r.carried_forward === true,
   }));
 }
 

--- a/packages/ui/src/api/acs.ts
+++ b/packages/ui/src/api/acs.ts
@@ -134,9 +134,20 @@ export interface AcTestMatrixRow {
   /** test_identifier as emitted by the helper; empty string when the
    *  source row had a NULL test_identifier (legacy / hand-rolled emit). */
   testIdentifier: string;
-  /** Every emission ever recorded for this (acUid, testIdentifier),
-   *  newest-first. Per b-96 dec-11: one entry per emission, no run-batching. */
+  /** Every RETAINED emission for this (acUid, testIdentifier), newest-first.
+   *  Per b-96 dec-11: one entry per emission, no run-batching. */
   emissions: TestMatrixEmission[];
+  /**
+   * spec-520 dec-9 (ac-42): the pair's last known state, carried forward from the
+   * durable summary when no emission for it survives retention. Null whenever
+   * `emissions` is non-empty.
+   *
+   * Not an emission, and deliberately not in the list above: it is older than the
+   * matrix's axis window, so it must be rendered as text rather than positioned as a
+   * square claiming a run inside that window. Optional so a response from a server
+   * predating the field still renders.
+   */
+  carriedForward?: { status: TestEventStatus; emittedAt: string } | null;
 }
 
 export async function fetchAcTestMatrix(

--- a/packages/ui/src/components/TestMatrix.carryForward.test.tsx
+++ b/packages/ui/src/components/TestMatrix.carryForward.test.tsx
@@ -1,0 +1,78 @@
+// spec-520 dec-9 (ac-42) — a row whose emissions have all left the retention window shows
+// its last known state instead of a blank strip.
+//
+// Measured on prod 2026-08-30, before any swap: 196,978 of 243,339 pairs had not run in
+// three days. Under the time window t-12 introduces, four out of five rows would render an
+// empty strip beneath a "Verified" badge — the badge reads test_event_latest, which
+// retention never touches, and the strip reads the log. A blank strip asserts "no evidence";
+// the truth is "the evidence aged out, and here is what it said".
+//
+// The carried-forward state is NOT an emission and must never reach the strip's time axis:
+// it is months older than the window, so positioning it as a square would put it off the
+// axis and claim a run that the log no longer holds.
+
+import { describe, it, expect } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { TestMatrix } from './TestMatrix';
+import type { AcTestMatrixRow } from '../api/client';
+
+const AC_CARRY = 'mindset-prod/memex-building-itself/specs/spec-520/acs/ac-42';
+
+const NOW = new Date('2026-08-30T12:00:00Z').getTime();
+
+function darkRow(id: string, status: 'pass' | 'fail'): AcTestMatrixRow {
+  return {
+    testIdentifier: id,
+    emissions: [],
+    carriedForward: { status, emittedAt: '2026-06-12T09:00:00.000Z' },
+  };
+}
+
+function liveRow(id: string): AcTestMatrixRow {
+  return {
+    testIdentifier: id,
+    emissions: [{ status: 'pass', emittedAt: '2026-08-30T11:00:00.000Z' }],
+    carriedForward: null,
+  };
+}
+
+describe('TestMatrix · carried-forward rows', () => {
+  it('shows the last known state where the strip would otherwise be blank', () => {
+    tagAc(AC_CARRY);
+    render(<TestMatrix rows={[darkRow('a::t', 'pass')]} now={NOW} />);
+    const strip = screen.getByTestId('test-matrix-strip');
+    expect(strip.textContent).toMatch(/last known/i);
+    // The date matters: "last known: passed" with no WHEN is nearly as misleading as a
+    // blank strip. Computed here rather than hardcoded, so the assertion does not depend
+    // on the runner's locale.
+    const shown = new Date('2026-06-12T09:00:00.000Z').toLocaleDateString();
+    expect(strip.textContent).toContain(shown);
+    // …and hovering explains why the strip is empty, not just what it last said.
+    expect(within(strip).getByTitle(/no retained emissions/i)).toBeInTheDocument();
+  });
+
+  it('does not place the carried-forward state on the time axis', () => {
+    tagAc(AC_CARRY);
+    const { container } = render(<TestMatrix rows={[darkRow('a::t', 'pass')]} now={NOW} />);
+    // No emission square: a June point on an axis whose left edge is 30 days back would be
+    // positioned off the strip, and it would assert a run inside the window.
+    expect(container.querySelectorAll('[data-testid="emission-square"]')).toHaveLength(0);
+  });
+
+  it('carries a RED state forward as red', () => {
+    tagAc(AC_CARRY);
+    render(<TestMatrix rows={[darkRow('a::t', 'fail')]} now={NOW} />);
+    const strip = screen.getByTestId('test-matrix-strip');
+    // Carrying only greens forward would make the fallback a way of hiding failures.
+    expect(strip.textContent).toMatch(/fail/i);
+  });
+
+  it('leaves a row that still has emissions completely alone', () => {
+    tagAc(AC_CARRY);
+    render(<TestMatrix rows={[liveRow('a::t')]} now={NOW} />);
+    const strip = screen.getByTestId('test-matrix-strip');
+    expect(strip.textContent).not.toMatch(/last known/i);
+    expect(strip.querySelectorAll('[data-testid="emission-square"]').length).toBeGreaterThan(0);
+  });
+});

--- a/packages/ui/src/components/TestMatrix.tsx
+++ b/packages/ui/src/components/TestMatrix.tsx
@@ -262,6 +262,7 @@ function EmissionSquare({
 
   return (
     <span
+      data-testid="emission-square"
       className="group/sq absolute inline-block"
       style={{ left: leftPx, top: 0 }}
     >
@@ -392,6 +393,23 @@ export function TestMatrix({
                     leftPx={em.leftPx}
                   />
                 ))}
+                {/* spec-520 dec-9 (ac-42): every emission for this pair has left the
+                    retention window. A blank strip asserts "no evidence"; the truth is
+                    "the evidence aged out, and this is what it last said". Rendered as
+                    TEXT, never as a square — the state is months older than the axis
+                    window, so positioning it would put it off the strip and claim a run
+                    inside a window it is not in. */}
+                {positioned.length === 0 && row.carriedForward && (
+                  <span
+                    className="absolute inset-y-0 left-0 flex items-center whitespace-nowrap text-[11px] italic text-zinc-500 dark:text-zinc-400"
+                    title={`No retained emissions — last known state, recorded ${new Date(
+                      row.carriedForward.emittedAt,
+                    ).toLocaleString()}`}
+                  >
+                    last known: {STATUS_LABEL[row.carriedForward.status]} ·{' '}
+                    {formatAxisDate(new Date(row.carriedForward.emittedAt).getTime())}
+                  </span>
+                )}
               </div>
               <span className="shrink-0">
                 {renderRowAction ? renderRowAction(row) : null}


### PR DESCRIPTION
> **Stacked on #653** (`spec-520-t12a-bound-ac-matrix`), which rewrote both of these reads and is not yet merged. Retarget to `develop` once #653 lands.

## The number that forced this

t-12 swaps count-based retention (*"latest 10 per pair, any age"*) for a time window. Those rules are **not interchangeable**: a pair that ran ten times in March keeps all ten today and would keep **none** under a window.

Measured on prod **before any swap**, at the point this becomes irreversible:

| window | pairs gone dark | of 243,339 |
|---|---|---|
| 1 day | 206,142 | 85% |
| **3 days** | **196,978** | **81%** |
| 7 days | 154,735 | 64% |
| 30 days | 32,906 | 14% |

The badge reads `test_event_latest`, which retention has never touched (spec-398 ac-8 guarantees exactly that). The evidence grid reads `test_events`. So **four out of five ACs** would render **"Verified" above an empty matrix** — the two halves of one tab contradicting each other, and the half that looks broken being the one that carries the proof.

That is a product regression, not a retention detail. It is recorded as **dec-9**, with the alternatives and why they lost.

## What changed

Both reads enumerate pairs from the durable summary as well as the log. A pair with no surviving emission carries its **last known status and when**. The information already exists and is already trusted — this only stops the tab from hiding it.

**It is deliberately not an entry in `emissions`.** The matrix lays emissions out on a shared **time axis** by `emittedAt`; a June state would be positioned off the axis and would claim a run inside a window it is not in. It travels as its own field and renders as text — `last known: passed · 12/06/2026`, with the reason on hover.

**The digest UNIONs its pair set** rather than switching to the summary. Hidden emissions never reach `test_event_latest` (`applyEmissionToSummary` returns early on `hidden`), so a fully retired pair has rows and **no** summary row. Reading only the summary would have repaired dark pairs by silently dropping retired ones. Its `count` stays `0` for a dark pair — an honest audit depth, not a missing verdict.

## Rejected, and why

- **"Keep the window OR the latest N per pair, whichever is more."** Partition membership is by time; that rule is by pair-rank. It cannot be expressed as `DROP PARTITION` and would reinstate the per-pair `DELETE` that t-12 exists to remove — 13.4% of DB time, to solve a display problem.
- **A 30-day window.** Brings dark pairs to 14%, at ~80M steady-state rows instead of ~8M. An order of magnitude in storage and scan cost to soften a symptom the read side handles for free.

## Sequencing

Ships **before** t-12, not inside it. t-12 is already the highest-risk task in the Spec, and a fallback landing after the migration is one that arrives too late for the deploy that needed it. It is inert until the window shrinks, which makes landing it early safe.

## Test plan

- [x] `ac-matrix-carry-forward.integration.test.ts` (7, tagged **ac-42**) — a dark pair appears with an empty emission list and a carried-forward state; a live pair is untouched; a **red** state carries forward as red (carrying only greens would make this a way of hiding failures); a hidden-only pair is not invented into the matrix; the digest reports a dark pair at count 0 with its verdict; **and still reports the hidden-only pair that has rows but no summary row**.
- [x] `TestMatrix.carryForward.test.tsx` (4, tagged **ac-42**) — the chip renders with its date, no emission square is placed on the axis, red carries as red, a live row is untouched.
- [x] Existing `TestMatrix.test.tsx` unaffected — 34 passed together
- [x] Full server suite 6450 · full UI suite 2381 · `make check` · `pnpm --filter @memex/ui build`
- [x] ac-42 emitted from **both** packages under a live key, confirmed with `get_ac`

Dark-pair simulation: no window exists yet, so the tests emit and then delete the raw rows, keeping the summary — exactly the state t-12 will produce.