### PR TITLE
feat(spec-520): partition test_events and delete the per-pair trim (t-12)

### DIFF
--- a/packages/server/deploy.sh
+++ b/packages/server/deploy.sh
@@ -317,6 +317,23 @@ DATABASE_URL="${DB_URL}" pnpm db:migrate
 echo "  1b. hand-written migrations..."
 DATABASE_URL="${DB_URL}" bash "${PKG_DIR}/scripts/apply-hand-migrations.sh"
 
+# spec-520 t-12: create the days ahead, drop the days past the retention window.
+#
+# ⚠ HERE, AND NOT IN THE SERVER. DROP TABLE requires ownership, and the request path's role
+# must not have it [per std-36]. This runs on DB_URL — the owner connection already open for
+# migrations — never on RUNTIME_DB_*. It is deliberately not the in-process setInterval
+# shape used by activity-log-sweep, which runs inside the API server as the runtime role.
+#
+# Idempotent and safe on a schema that predates 0142: it exits quietly if test_events is not
+# partitioned yet. A failure here is NOT fatal to the deploy — 60 days of partitions are
+# created ahead, so a skipped run costs nothing until the horizon is nearly reached, and
+# aborting a deploy over housekeeping would be the wrong trade.
+echo "  1c. test_events partition maintenance..."
+if ! DATABASE_URL="${DB_URL}" node "${PKG_DIR}/scripts/maintain-test-events-partitions.mjs"; then
+  echo "  WARNING: partition maintenance failed — deploy continues (60-day horizon absorbs it)."
+  echo "           Investigate before the horizon runs out, or inserts will start failing."
+fi
+
 # NOTE (spec-417 dec-6): the data backfills/generation that used to run here (1c–1f)
 # now run in Step 5, AFTER the Cloud Run cutover. The cloud-sql-proxy started above
 # is deliberately LEFT RUNNING across the cutover (Step 4) and is torn down at the end

--- a/packages/server/deploy.sh
+++ b/packages/server/deploy.sh
@@ -277,8 +277,19 @@ DB_URL="postgresql://${DB_USER}:${DB_PASS_ENC}@localhost:${PROXY_PORT}/${DB_NAME
 
 # Runtime credentials for Cloud Run (spec-199 t-14). Migrations ALWAYS use the
 # superuser path (DB_USER/DB_PASS) — RUNTIME_DB_* is the restricted memex_app
-# role that RLS enforces on. Defaults to DB_USER/DB_PASS until t-14 is rolled
-# out per environment via RUNTIME_DB_USER/RUNTIME_DB_PASS in the deploy-env secret.
+# role that RLS enforces on.
+#
+# ⚠ THE ROLLOUT HAS HAPPENED. This comment used to end "Defaults to DB_USER/DB_PASS until
+# t-14 is rolled out per environment", which read as if the cutover were still pending.
+# Verified 2026-08-31: BOTH memex-int-deploy-env and memex-prod-deploy-env set
+# RUNTIME_DB_USER=memex_app, so the fallback below never fires in either environment and
+# spec-199 t-14's acceptance criteria hold.
+#
+# The stale wording cost real time: it was read as evidence that the request path still ran
+# as the owner, and that conclusion was repeated into a migration comment, a test, and a
+# Spec record before anyone checked the secret. The fallback stays as a safety net for a
+# NEW environment whose secret has not been populated yet — not as a description of int or
+# prod.
 RUNTIME_DB_USER="${RUNTIME_DB_USER:-$DB_USER}"
 RUNTIME_DB_PASS="${RUNTIME_DB_PASS:-$DB_PASS}"
 RUNTIME_DB_PASS_ENC=$(python3 -c "import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1], safe=''))" "${RUNTIME_DB_PASS}")

--- a/packages/server/drizzle/0142_spec520_partition_test_events.sql
+++ b/packages/server/drizzle/0142_spec520_partition_test_events.sql
@@ -1,0 +1,187 @@
+-- spec-520 t-12, STEP 2 of 2 — test_events becomes time-partitioned; the per-pair trim dies.
+--
+-- ⚠ RUN drizzle/out-of-band/0141_..._prep.sql FIRST, and confirm its index is VALID.
+-- Without it this migration builds a 1.4M-row unique index inside its exclusive window.
+--
+-- WHAT THIS BUYS. `trimTestEventsForPair` deleted the oldest rows of a pair inside every
+-- emission transaction: 13.4% of all database time, 11.24M deletes against 11.87M inserts,
+-- and autovacuum running near-continuously behind it. Retention becomes a property of
+-- WHICH PARTITION a row landed in. Rows leave only when an aged-out partition is dropped —
+-- a catalogue operation. No deletes, no dead tuples, nothing to vacuum. The 13.4% does not
+-- shrink; it goes to zero.
+--
+-- ── HOW THIS AVOIDS REPEATING 0111 ──────────────────────────────────────────────────────
+--
+-- spec-398's migration 0111 restructured this same table by copying every row into a new
+-- one, holding ACCESS EXCLUSIVE for ~80 s — and its first prod release DEADLOCKED against
+-- live traffic (40P01) and rolled the whole file back. That is std-39 cl-9's worked
+-- example, and it is this table.
+--
+-- This migration COPIES NOTHING. The existing table is renamed and ATTACHed as the first
+-- partition of a new parent, which is a catalogue operation plus one validation scan.
+--
+-- MEASURED at production scale (local pg16, 1.4M rows, 2026-08-30): the entire exclusive
+-- window below — create parent, adopt the PK, attach 1.4M rows, create the parent
+-- indexes — is **~150 ms**. Not an estimate; the probe ran.
+--
+-- ⚠ WHY 150 ms MATTERS AND 80 s DOES NOT MERELY "COST LATENCY". The AC emitter has a 5 s
+-- client timeout and NEVER retries (std-48 — a retry storm against a saturated server is
+-- worse than a dropped event). So a blocked emission is not delayed, it is DISCARDED, with
+-- only a warning in someone's CI log. At ~31 events/s an 80 s window silently drops ~2,500
+-- emissions and leaves their ACs on a stale verdict. 150 ms drops none.
+--
+-- ── LOCK ORDER (std-39 cl-2/cl-3) ───────────────────────────────────────────────────────
+--
+-- Live emissions take test_events then test_event_latest, in that order
+-- (routes/test-events.ts). This migration takes BOTH up front in the SAME order, so no
+-- lock-order cycle can form: it either wins a clean window or fails fast on lock_timeout
+-- and retries on the next deploy. It can never deadlock.
+--
+-- The LOCK is wrapped in a DO block because this file is applied two ways: the hand-runner
+-- wraps it in one transaction (a bare LOCK is fine there), while the e2e-cold template
+-- build pipes it through `psql -f` in AUTOCOMMIT, where a bare LOCK errors with "can only
+-- be used in transaction blocks". A DO block runs its body in an implicit transaction in
+-- both paths. That lesson is 0111's too.
+--
+-- ── WHAT THIS MIGRATION DELIBERATELY DOES NOT DO ────────────────────────────────────────
+--
+-- IT DELETES NO DATA. Every existing row is carried into the legacy partition, whatever its
+-- age. Retention is applied afterwards, by maintenance, from configuration — so the
+-- irreversible moment is a separate, config-driven step that can be paused, not a side
+-- effect of a schema change. A 3-day window would otherwise have discarded 1,046,386 of
+-- the 1,404,630 rows here, at the exact moment the schema was also changing.
+--
+-- IT ADDS NO RLS. spec-398 ac-10 asserts test_events carries none and that spec-399 owns
+-- it; verified against the live catalogue 2026-08-30 (relrowsecurity = false). ⚠ FOR
+-- spec-399: a policy created on this parent is INHERITED by every partition, including ones
+-- maintenance creates later — so the policy belongs on the PARENT and must never be written
+-- per-partition. Designing that is spec-399's call, not an assumption to inherit from here.
+
+-- ── 0. Deadlock guard — both locks up front, in the emission path's order ────────────────
+DO $$
+BEGIN
+  SET LOCAL lock_timeout = '10s';
+  LOCK TABLE test_events IN ACCESS EXCLUSIVE MODE;
+  LOCK TABLE test_event_latest IN ACCESS EXCLUSIVE MODE;
+END $$;
+
+-- ── 1. The whole swap, in one dynamic block ─────────────────────────────────────────────
+--
+-- Dynamic because the partition boundary is computed AT RUN TIME. Hardcoding a date would
+-- force this file and the deploy calendar to agree; a deploy that slipped past it would
+-- start rejecting inserts. `date_trunc('day', now()) + 1 day` means the legacy partition
+-- absorbs everything up to the next UTC midnight and the daily partitions take over
+-- cleanly from there, whenever the deploy actually happens.
+DO $$
+DECLARE
+  boundary   timestamptz := date_trunc('day', now() AT TIME ZONE 'UTC') AT TIME ZONE 'UTC' + interval '1 day';
+  view_def   text;
+  part_start timestamptz;
+  horizon    int := 60;   -- keep in step with PARTITION_HORIZON_DAYS in test-event-retention.ts
+BEGIN
+  -- The activity_view test_events arm would silently follow the table through the rename
+  -- and end up reading the LEGACY PARTITION instead of the parent — seeing old rows only,
+  -- with no error anywhere. It is captured and replayed rather than re-typed here: a
+  -- hardcoded copy would be a snapshot of the view as it was the day this was written, and
+  -- 0119 already renamed a column inside it once since 0111.
+  SELECT pg_get_viewdef('activity_view'::regclass, true) INTO view_def;
+  DROP VIEW activity_view;
+
+  -- The old PK is on (id) alone. A partitioned parent keyed (id, created_at) requires each
+  -- partition to carry an equivalent unique index; 0141 built it CONCURRENTLY.
+  ALTER TABLE test_events RENAME TO test_events_legacy;
+
+  -- ⚠ SELF-SUFFICIENT ON PURPOSE. 0141 builds this index CONCURRENTLY so production never
+  -- pays for the build inside the exclusive window — but every FRESH database (each
+  -- per-worker test DB, the e2e cold-template build, a new dev machine) applies migrations
+  -- through the runner, which never sees out-of-band/. Depending on 0141 made
+  -- `pnpm db:migrate` fail everywhere except prod. On prod the index already exists and
+  -- follows the rename, so IF NOT EXISTS skips it; on a fresh database the table is empty
+  -- and the build is instant. 0141 is now an optimisation, not a prerequisite.
+  CREATE UNIQUE INDEX IF NOT EXISTS test_events_id_created_at_key
+    ON test_events_legacy (id, created_at);
+
+  ALTER TABLE test_events_legacy DROP CONSTRAINT test_events_new_pkey;
+  ALTER TABLE test_events_legacy ADD PRIMARY KEY USING INDEX test_events_id_created_at_key;
+
+  CREATE TABLE test_events (
+    id              uuid        NOT NULL DEFAULT gen_random_uuid(),
+    subject_ref     text        NOT NULL,
+    memex_id        uuid        NOT NULL,
+    status          text        NOT NULL,
+    test_identifier text,
+    duration_ms     integer,
+    commit_sha      text,
+    run_id          text,
+    actor           text,
+    hidden          boolean     NOT NULL DEFAULT false,
+    metadata        jsonb,
+    created_at      timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT test_events_pkey PRIMARY KEY (id, created_at),
+    CONSTRAINT test_events_status_valid CHECK (status = ANY (ARRAY['pass'::text, 'fail'::text, 'error'::text]))
+  ) PARTITION BY RANGE (created_at);
+
+  -- ⚠ NO DEFAULT PARTITION, and that was measured rather than reasoned. Once rows for a day
+  -- land in a DEFAULT partition, creating that day's real partition FAILS outright:
+  --   ERROR: updated partition constraint for default partition would be violated by some row
+  -- A default would turn a quiet gap between deploys into a migration that cannot apply
+  -- until someone drains it by hand. A missing partition is instead a loud, immediate
+  -- insert error, and the 60-day horizon exists so it is never reached.
+  EXECUTE format(
+    'ALTER TABLE test_events ATTACH PARTITION test_events_legacy FOR VALUES FROM (%L) TO (%L)',
+    '2000-01-01'::timestamptz, boundary);
+
+  -- ⚠ BOUNDS ARE timestamptz, NEVER date. A `date` used as a partition bound is
+  -- interpreted in the SESSION's timezone, not UTC. This migration was first written with
+  -- `boundary::date` and failed immediately on a machine running Europe/Lisbon:
+  --
+  --   ERROR: partition "test_events_20260831" would overlap partition "test_events_legacy"
+  --
+  -- because boundary was 2026-08-31 00:00 UTC while the date literal '2026-08-31' resolved
+  -- to 2026-08-30 23:00 UTC — the daily partition started an hour before the legacy one
+  -- ended. Cloud SQL runs UTC, so this would have passed in production and lain in wait
+  -- for the first developer or restore on a non-UTC server. %L on a timestamptz emits a
+  -- literal carrying its offset, so no session can reinterpret it.
+  part_start := boundary;
+  WHILE part_start < boundary + (horizon || ' days')::interval LOOP
+    EXECUTE format(
+      'CREATE TABLE IF NOT EXISTS test_events_%s PARTITION OF test_events FOR VALUES FROM (%L) TO (%L)',
+      to_char(part_start AT TIME ZONE 'UTC', 'YYYYMMDD'), part_start, part_start + interval '1 day');
+    part_start := part_start + interval '1 day';
+  END LOOP;
+
+  -- Creating an index on the parent REUSES a matching index that already exists on a
+  -- partition rather than rebuilding it — verified on pg16: the legacy table's existing
+  -- indexes became children of the parent's. So this costs nothing on the 1.4M legacy rows
+  -- and only builds on the (empty) forward partitions.
+  --
+  -- Index inventory, checked with EXPLAIN against every surviving reader on develop
+  -- 2026-08-30 rather than assumed from the names:
+  --   retention_idx (subject_ref, test_identifier, created_at)
+  --       KEPT. Named for the trim being deleted, but it is the workhorse: it serves the
+  --       AC matrix's row_number() read, BOTH of the digest's CTEs, and the targeted
+  --       discontinue delete. Dropping it "with the trim" would have been a plausible,
+  --       measurable mistake.
+  --   memex_id_created_at_idx  KEPT — the activity_view arm.
+  --   created_at_idx           KEPT — testSignalPulse's window. Partition pruning narrows
+  --                            it to a day, but a day holds ~2.7M rows.
+  -- Two more exist today and were chosen by NO reader in that sweep:
+  -- ac_uid_created_at_idx (subject_ref, created_at) and test_identifier_idx. They are NOT
+  -- dropped here — a local EXPLAIN sweep is not proof about prod, and pg_stat_user_indexes
+  -- on prod settles it. Carried forward unchanged; retiring them is a separate, evidenced
+  -- change. Every index carried costs a tuple per insert on every partition (cl-7), so
+  -- this is a real cost being consciously deferred, not overlooked.
+  CREATE INDEX IF NOT EXISTS test_events_retention_idx        ON test_events (subject_ref, test_identifier, created_at);
+  CREATE INDEX IF NOT EXISTS test_events_memex_id_created_at_idx ON test_events (memex_id, created_at);
+  CREATE INDEX IF NOT EXISTS test_events_created_at_idx       ON test_events (created_at);
+  CREATE INDEX IF NOT EXISTS test_events_ac_uid_created_at_idx ON test_events (subject_ref, created_at);
+  CREATE INDEX IF NOT EXISTS test_events_test_identifier_idx  ON test_events (test_identifier, created_at);
+
+  -- 0081's GRANT ... ON ALL TABLES was a one-time statement; it does not reach a table
+  -- created today. Every table added since carries its own explicit grant, and omitting it
+  -- here would 401 nothing and 500 everything: the runtime role would lose the emission
+  -- path entirely.
+  GRANT SELECT, INSERT, UPDATE, DELETE ON test_events TO memex_app;
+
+  EXECUTE format('CREATE VIEW activity_view WITH (security_invoker = true) AS %s', view_def);
+END $$;

--- a/packages/server/drizzle/0142_spec520_partition_test_events.sql
+++ b/packages/server/drizzle/0142_spec520_partition_test_events.sql
@@ -61,8 +61,10 @@
 DO $$
 BEGIN
   SET LOCAL lock_timeout = '10s';
-  LOCK TABLE test_events IN ACCESS EXCLUSIVE MODE;
-  LOCK TABLE test_event_latest IN ACCESS EXCLUSIVE MODE;
+  -- ONE statement, listing them in the emission path's order — the same form 0111 settled
+  -- on after its deadlock, so the two migrations read identically and the discipline is
+  -- copyable rather than reconstructed each time.
+  LOCK TABLE test_events, test_event_latest IN ACCESS EXCLUSIVE MODE;
 END $$;
 
 -- ── 1. The whole swap, in one dynamic block ─────────────────────────────────────────────

--- a/packages/server/drizzle/0142_spec520_partition_test_events.sql
+++ b/packages/server/drizzle/0142_spec520_partition_test_events.sql
@@ -150,10 +150,24 @@ BEGIN
     part_start := part_start + interval '1 day';
   END LOOP;
 
-  -- Creating an index on the parent REUSES a matching index that already exists on a
-  -- partition rather than rebuilding it — verified on pg16: the legacy table's existing
-  -- indexes became children of the parent's. So this costs nothing on the 1.4M legacy rows
-  -- and only builds on the (empty) forward partitions.
+  -- ⚠ THE LEGACY PARTITION'S INDEXES ARE RENAMED FIRST, AND THAT IS LOAD-BEARING.
+  --
+  -- After the table rename its indexes keep their original names, so they still occupy
+  -- `test_events_retention_idx` and friends. The first version of this migration used
+  -- CREATE INDEX **IF NOT EXISTS** with those same names — which found the names taken and
+  -- silently created NOTHING on the parent. The rehearsal under load caught it: the parent
+  -- ended up with only its primary key, so every FORWARD partition had only a PK too, and
+  -- from the first daily partition onward the matrix, the digest, the Pulse and the
+  -- activity feed would all have sequential-scanned ~2.7M rows a day. A NOTICE is the only
+  -- thing that would have said so, and it scrolled past.
+  --
+  -- Renaming frees the canonical names, and IF NOT EXISTS is gone: at this point in the
+  -- migration a name collision is a bug, and it must stop the deploy rather than disarm the
+  -- statement.
+  --
+  -- Creating an index on the parent then REUSES the (renamed) matching index on the legacy
+  -- partition rather than rebuilding it — verified on pg16 — so the 1.4M legacy rows cost
+  -- nothing and only the empty forward partitions are built.
   --
   -- Index inventory, checked with EXPLAIN against every surviving reader on develop
   -- 2026-08-30 rather than assumed from the names:
@@ -171,11 +185,17 @@ BEGIN
   -- on prod settles it. Carried forward unchanged; retiring them is a separate, evidenced
   -- change. Every index carried costs a tuple per insert on every partition (cl-7), so
   -- this is a real cost being consciously deferred, not overlooked.
-  CREATE INDEX IF NOT EXISTS test_events_retention_idx        ON test_events (subject_ref, test_identifier, created_at);
-  CREATE INDEX IF NOT EXISTS test_events_memex_id_created_at_idx ON test_events (memex_id, created_at);
-  CREATE INDEX IF NOT EXISTS test_events_created_at_idx       ON test_events (created_at);
-  CREATE INDEX IF NOT EXISTS test_events_ac_uid_created_at_idx ON test_events (subject_ref, created_at);
-  CREATE INDEX IF NOT EXISTS test_events_test_identifier_idx  ON test_events (test_identifier, created_at);
+  ALTER INDEX test_events_retention_idx           RENAME TO test_events_legacy_retention_idx;
+  ALTER INDEX test_events_memex_id_created_at_idx RENAME TO test_events_legacy_memex_created_idx;
+  ALTER INDEX test_events_created_at_idx          RENAME TO test_events_legacy_created_at_idx;
+  ALTER INDEX test_events_ac_uid_created_at_idx   RENAME TO test_events_legacy_subject_created_idx;
+  ALTER INDEX test_events_test_identifier_idx     RENAME TO test_events_legacy_test_ident_idx;
+
+  CREATE INDEX test_events_retention_idx           ON test_events (subject_ref, test_identifier, created_at);
+  CREATE INDEX test_events_memex_id_created_at_idx ON test_events (memex_id, created_at);
+  CREATE INDEX test_events_created_at_idx          ON test_events (created_at);
+  CREATE INDEX test_events_ac_uid_created_at_idx   ON test_events (subject_ref, created_at);
+  CREATE INDEX test_events_test_identifier_idx     ON test_events (test_identifier, created_at);
 
   -- 0081's GRANT ... ON ALL TABLES was a one-time statement; it does not reach a table
   -- created today. Every table added since carries its own explicit grant, and omitting it

--- a/packages/server/drizzle/out-of-band/0141_spec520_test_events_partition_prep.sql
+++ b/packages/server/drizzle/out-of-band/0141_spec520_test_events_partition_prep.sql
@@ -1,0 +1,49 @@
+-- spec-520 t-12 — OUT OF BAND. An OPTIMISATION for production, not a prerequisite.
+--
+-- ⚠ THIS FILE IS DELIBERATELY OUTSIDE THE MIGRATION RUNNER. apply-hand-migrations.mjs
+-- wraps every file in one transaction, and CREATE INDEX CONCURRENTLY cannot run inside a
+-- transaction block. Same posture as 0138. The runner's readdirSync is non-recursive, so a
+-- file in out-of-band/ is never picked up automatically.
+--
+-- ⚠ 0142 DOES NOT DEPEND ON THIS FILE. It creates the same index itself with IF NOT
+-- EXISTS, because every fresh database — each per-worker test DB, the e2e cold-template
+-- build, a new dev machine — applies migrations through a runner that never sees
+-- out-of-band/. Running this file first is what keeps PRODUCTION's build out of the
+-- exclusive window; skipping it does not break anything, it just makes the window as long
+-- as the index build.
+--
+-- WHY IT EXISTS. 0142 converts test_events into a partitioned table by ATTACHing the
+-- existing table as its first partition. A partitioned parent whose PRIMARY KEY is
+-- (id, created_at) requires each partition to carry an equivalent unique index. The
+-- existing PK is on (id) alone, so a new one has to be built — and building it inside the
+-- migration would hold ACCESS EXCLUSIVE for the length of the build on the hottest table
+-- in the system.
+--
+-- Built CONCURRENTLY here, it blocks no writes at all. 0142 then adopts it with
+-- ADD PRIMARY KEY USING INDEX, which is a catalogue operation.
+--
+-- MEASURED (local pg16, 2026-08-30, 1.4M rows — production scale): with this index already
+-- in place, 0142's entire exclusive window is ~150 ms. Without it, the build lands inside
+-- that window. For comparison, spec-398's migration 0111 held ACCESS EXCLUSIVE for ~80 s
+-- to copy 1.9M rows, and deadlocked a prod deploy on its first attempt (std-39 cl-9).
+--
+-- ⚠ 150 ms VERSUS 80 s IS NOT A TIDINESS ARGUMENT. The AC emitter has a 5 s client timeout
+-- and NEVER retries (std-48): a blocked emission is not delayed, it is DROPPED, silently,
+-- with only a warning in the CI log. At the measured ~31 events/s, an 80 s window discards
+-- roughly 2,500 emissions and the ACs they carried keep a stale verdict. A 150 ms window
+-- discards none.
+--
+-- RUN IT LIKE THIS (int first, then prod), with the deploy proxy up:
+--
+--     psql "$DB_URL" -f packages/server/drizzle/out-of-band/0141_spec520_test_events_partition_prep.sql
+--
+-- THEN CONFIRM IT IS VALID before deploying 0142. A CONCURRENTLY build that fails leaves an
+-- INVALID index behind, which 0142 would happily adopt as a primary key that enforces
+-- nothing:
+--
+--     SELECT indisvalid FROM pg_index WHERE indexrelid = 'test_events_id_created_at_key'::regclass;
+--
+-- If it returns false: DROP INDEX test_events_id_created_at_key; and run this file again.
+
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS test_events_id_created_at_key
+  ON test_events (id, created_at);

--- a/packages/server/scripts/maintain-test-events-partitions.mjs
+++ b/packages/server/scripts/maintain-test-events-partitions.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+// spec-520 t-12 — partition maintenance for test_events. Creates the days ahead, drops the
+// days past the retention window.
+//
+// ⚠ RUNS AS THE OWNING ROLE, FROM DEPLOY — NEVER FROM THE REQUEST PATH.
+// DROP TABLE requires ownership, and the request path's role must not have it [per
+// std-36]. deploy.sh already holds an owner connection for migrations (DB_URL); this hooks
+// in beside them. It is deliberately NOT the in-process setInterval shape used by
+// activity-log-sweep: that runs inside the API server, as the runtime role, which is
+// exactly the role this must not be.
+//
+// FAILURE DIRECTION, ON PURPOSE. If no deploy happens for a long time:
+//   • no new partitions are created — but 60 days of horizon were pre-created, so inserts
+//     keep working;
+//   • no old partitions are dropped — so the table GROWS.
+// Growing is the safe failure. The alternative (a DEFAULT partition as a catch-all) was
+// measured and rejected: once rows land in a default, creating that day's real partition
+// fails outright, so the next deploy's migration cannot apply until someone drains it.
+//
+// IDEMPOTENT. Creating is IF NOT EXISTS; dropping only touches partitions whose entire
+// range is already outside the window. Re-running changes nothing.
+
+import postgres from "postgres";
+
+const RETENTION_DAYS = clampInt(process.env.TEST_EVENTS_RETENTION_DAYS, 3, 1, 90);
+const HORIZON_DAYS = 60; // keep in step with PARTITION_HORIZON_DAYS in test-event-retention.ts
+
+function clampInt(raw, fallback, min, max) {
+  if (raw === undefined || raw === "") return fallback;
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n) || n < min) return fallback;
+  return Math.min(n, max);
+}
+
+const url = process.env.DATABASE_URL;
+if (!url) {
+  console.error("[partitions] DATABASE_URL is required");
+  process.exit(1);
+}
+
+const sql = postgres(url, { max: 1 });
+
+try {
+  // Bail out quietly if the table is not partitioned yet — this script ships with 0142 but
+  // deploy.sh calls it unconditionally, and a deploy of an older schema must not fail here.
+  const [{ kind } = {}] = await sql`
+    SELECT relkind AS kind FROM pg_class WHERE relname = 'test_events'
+  `;
+  if (kind !== "p") {
+    console.log("[partitions] test_events is not partitioned yet — nothing to do");
+    process.exit(0);
+  }
+
+  // ── create ahead ────────────────────────────────────────────────────────────────────
+  // The day list and the cutoff are computed in JS from ONE reading of the database clock.
+  // Deriving them in SQL meant parameterising intervals inside a tagged template, which
+  // postgres.js cannot type ("could not determine data type of parameter $1"). One clock
+  // read also means every decision below shares a single instant — a loop that re-read
+  // now() could straddle midnight and create or drop the wrong day.
+  const [{ now: dbNow }] = await sql`SELECT now() AS now`;
+  const nowMs = new Date(dbNow).getTime();
+  const DAY_MS = 86_400_000;
+  // Midnight UTC of the current day, so bounds never depend on the session timezone —
+  // a `date` bound is resolved in the SESSION's zone, which silently shifts every boundary
+  // on a non-UTC server. 0142 hit exactly that.
+  const todayUtc = Date.UTC(
+    new Date(nowMs).getUTCFullYear(),
+    new Date(nowMs).getUTCMonth(),
+    new Date(nowMs).getUTCDate(),
+  );
+
+  const nameFor = (ms) => `test_events_${new Date(ms).toISOString().slice(0, 10).replace(/-/g, "")}`;
+
+  // Read every existing partition's REAL range once, and use it for both halves below.
+  //
+  // ⚠ COVERAGE, NOT NAMES. The first version skipped a day when a table of that NAME
+  // existed — which let it try to create test_events_20260830 while `test_events_legacy`
+  // already covered that day, and Postgres refused with "would overlap". The legacy
+  // partition is the whole point of the attach-based migration and it is not named for a
+  // day, so any name-based reasoning is wrong here by construction.
+  const partitions = (
+    await sql`
+      SELECT c.relname AS name, pg_get_expr(c.relpartbound, c.oid) AS bound
+      FROM pg_class c
+      JOIN pg_inherits i ON i.inhrelid = c.oid
+      WHERE i.inhparent = 'test_events'::regclass
+    `
+  ).map((row) => {
+    const m = /FROM \('([^']+)'\) TO \('([^']+)'\)/.exec(row.bound ?? "");
+    return {
+      name: row.name,
+      from: m ? new Date(m[1]).getTime() : null,
+      to: m ? new Date(m[2]).getTime() : null, // null for a DEFAULT partition
+    };
+  });
+
+  const covered = (from, to) =>
+    partitions.some((p) => p.from !== null && p.to !== null && p.from < to && p.to > from);
+
+  let madeCount = 0;
+  for (let i = 0; i <= HORIZON_DAYS; i++) {
+    const from = todayUtc + i * DAY_MS;
+    const to = from + DAY_MS;
+    if (covered(from, to)) continue;
+    const name = nameFor(from);
+    await sql.unsafe(
+      `CREATE TABLE IF NOT EXISTS ${name} PARTITION OF test_events ` +
+        `FOR VALUES FROM ('${new Date(from).toISOString()}') TO ('${new Date(to).toISOString()}')`,
+    );
+    partitions.push({ name, from, to });
+    madeCount += 1;
+  }
+
+  // ── drop what is entirely past the window ───────────────────────────────────────────
+  // The partition's UPPER bound is read from the catalogue rather than parsed out of its
+  // name: a partition whose name and bounds disagree (a hand-made one, a restore) would
+  // otherwise be dropped on the strength of its name. This also covers `test_events_legacy`
+  // with no special case — it is dropped once its whole range, which ends at the
+  // migration's boundary, has aged out.
+  const cutoffMs = nowMs - RETENTION_DAYS * DAY_MS;
+
+  let droppedCount = 0;
+  for (const row of partitions) {
+    if (row.to === null) continue; // a DEFAULT partition has no TO bound — never dropped here
+    if (!Number.isFinite(row.to) || row.to > cutoffMs) continue;
+    // DETACH first, then DROP. Detaching takes a brief lock on the parent and leaves a
+    // standalone table; dropping that table then touches nothing the emission path uses.
+    // A bare DROP of an attached partition holds its lock on the parent for the whole drop.
+    await sql.unsafe(`ALTER TABLE test_events DETACH PARTITION ${row.name}`);
+    await sql.unsafe(`DROP TABLE ${row.name}`);
+    droppedCount += 1;
+    console.log(`[partitions] dropped ${row.name} (ended ${new Date(row.to).toISOString()}, window ${RETENTION_DAYS}d)`);
+  }
+
+  console.log(
+    `[partitions] created ${madeCount} ahead (horizon ${HORIZON_DAYS}d), dropped ${droppedCount} past the ${RETENTION_DAYS}d window`,
+  );
+} catch (err) {
+  console.error("[partitions] FAILED", err);
+  process.exitCode = 1;
+} finally {
+  await sql.end({ timeout: 5 });
+}

--- a/packages/server/scripts/rehearse-test-events-partition.sh
+++ b/packages/server/scripts/rehearse-test-events-partition.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# spec-520 t-12 — rehearse migration 0142 against a realistic-volume copy UNDER CONCURRENT
+# WRITE LOAD, and record the result. This is the AC an agent cannot satisfy alone; it needs
+# a database the agent must not touch.
+#
+# WHY THIS EXISTS AND WHY IT IS NOT OPTIONAL. spec-398's migration 0111 restructured this
+# same table and its first production release DEADLOCKED against live traffic (40P01) and
+# rolled back — std-39 cl-9's worked example. 0142 is designed so that cannot recur (both
+# locks taken up front in the emission path's order, and no row copy at all), and the design
+# was measured: ~150 ms of ACCESS EXCLUSIVE at 1.4M rows. But "measured on an idle local
+# database" is not "measured under load", and the difference is exactly where 0111 failed.
+#
+# WHAT IT DOES
+#   1. Builds a throwaway database at realistic volume (default 1.5M rows, ~prod).
+#   2. Starts N writers hammering the emission shape — INSERT + summary UPSERT in one
+#      transaction, in the SAME lock order as routes/test-events.ts.
+#   3. Applies 0141 (out-of-band) then 0142 while they run.
+#   4. Reports: how long the exclusive window actually took, whether any writer saw a
+#      deadlock or a lock timeout, and how many writes were lost.
+#
+# WHAT TO RECORD ON t-12 AFTERWARDS: the exclusive-window duration, the writer error count
+# by SQLSTATE, and the row counts before/after. A rehearsal whose result is not written down
+# has not been rehearsed.
+#
+#   ./scripts/rehearse-test-events-partition.sh [ROWS] [WRITERS] [SECONDS]
+#
+# Defaults: 1500000 rows, 8 writers, load running throughout the migration.
+set -euo pipefail
+
+ROWS="${1:-1500000}"
+WRITERS="${2:-8}"
+PGPORT_LOCAL="${PGPORT_LOCAL:-5433}"
+DB="memex_t12_rehearsal"
+PKG_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+export PGPASSWORD="${PGPASSWORD:-postgres}"
+PSQL="psql -h localhost -p ${PGPORT_LOCAL} -U postgres"
+URL="postgresql://postgres:postgres@localhost:${PGPORT_LOCAL}/${DB}"
+
+echo "── building a ${ROWS}-row copy in ${DB} ─────────────────────────────────────"
+$PSQL -q -c "DROP DATABASE IF EXISTS ${DB}" postgres
+$PSQL -q -c "CREATE DATABASE ${DB}" postgres
+for f in "${PKG_DIR}"/drizzle/*.sql; do
+  # Stop before the migration under rehearsal — it is applied later, under load.
+  case "$f" in *0142_spec520_partition_test_events.sql) break;; esac
+  psql -v ON_ERROR_STOP=1 "$URL" -f "$f" >/dev/null
+done
+
+psql -q "$URL" <<SQL
+INSERT INTO namespaces (slug, kind) VALUES ('reh', 'org') ON CONFLICT DO NOTHING;
+INSERT INTO memexes (namespace_id, slug, name)
+  SELECT id, 'mx', 'rehearsal' FROM namespaces WHERE slug='reh' ON CONFLICT DO NOTHING;
+INSERT INTO test_events (subject_ref, memex_id, status, test_identifier, created_at)
+SELECT 'reh/mx/specs/spec-' || (g % 500) || '/acs/ac-' || (g % 40),
+       (SELECT m.id FROM memexes m JOIN namespaces n ON n.id=m.namespace_id WHERE n.slug='reh'),
+       (ARRAY['pass','fail','error'])[1 + (g % 3)],
+       'file' || (g % 200) || '.test.ts::it',
+       now() - ((g % 90) || ' days')::interval - ((g % 86400) || ' seconds')::interval
+FROM generate_series(1, ${ROWS}) g;
+ANALYZE test_events;
+SQL
+echo "rows: $(psql -t -A "$URL" -c 'SELECT count(*) FROM test_events')"
+
+echo "── starting ${WRITERS} writers in the emission's lock order ─────────────────"
+ERRLOG="$(mktemp)"
+for i in $(seq 1 "$WRITERS"); do
+  (
+    while [ ! -f /tmp/t12_rehearsal_stop ]; do
+      psql -v ON_ERROR_STOP=1 "$URL" -q >>"$ERRLOG" 2>&1 <<SQL || true
+BEGIN;
+INSERT INTO test_events (subject_ref, memex_id, status, test_identifier)
+  VALUES ('reh/mx/specs/spec-1/acs/ac-1',
+          (SELECT m.id FROM memexes m JOIN namespaces n ON n.id=m.namespace_id WHERE n.slug='reh'),
+          'pass', 'load::w${i}');
+INSERT INTO test_event_latest (subject_ref, test_identifier, latest_status, latest_run_at, memex_id, run_count)
+  VALUES ('reh/mx/specs/spec-1/acs/ac-1', 'load::w${i}', 'pass', now(),
+          (SELECT m.id FROM memexes m JOIN namespaces n ON n.id=m.namespace_id WHERE n.slug='reh'), 1)
+  ON CONFLICT (subject_ref, test_identifier) DO UPDATE SET run_count = test_event_latest.run_count + 1;
+COMMIT;
+SQL
+    done
+  ) &
+done
+rm -f /tmp/t12_rehearsal_stop
+sleep 3
+
+echo "── applying 0141 (out-of-band) UNDER LOAD ──────────────────────────────────"
+/usr/bin/time -f "  0141 wall: %e s" psql -v ON_ERROR_STOP=1 "$URL" \
+  -f "${PKG_DIR}/drizzle/out-of-band/0141_spec520_test_events_partition_prep.sql" 2>&1 | tail -2
+
+echo "── applying 0142 UNDER LOAD — this is the exclusive window ─────────────────"
+START=$(date +%s.%N)
+psql -v ON_ERROR_STOP=1 "$URL" -f "${PKG_DIR}/drizzle/0142_spec520_partition_test_events.sql" 2>&1 | tail -3
+END=$(date +%s.%N)
+
+touch /tmp/t12_rehearsal_stop
+sleep 2
+wait 2>/dev/null || true
+
+echo ""
+echo "══ RESULT ══════════════════════════════════════════════════════════════════"
+echo "  exclusive window (0142 wall clock): $(echo "$END - $START" | bc) s"
+echo "  partitioned:  $(psql -t -A "$URL" -c "SELECT relkind FROM pg_class WHERE relname='test_events'")  (want p)"
+echo "  rows after:   $(psql -t -A "$URL" -c 'SELECT count(*) FROM test_events')"
+echo "  partitions:   $(psql -t -A "$URL" -c "SELECT count(*) FROM pg_inherits WHERE inhparent='test_events'::regclass")"
+echo ""
+echo "  writer errors by kind (empty = no writer was refused):"
+grep -oE 'ERROR:[^\"]*' "$ERRLOG" | sort | uniq -c | sed 's/^/    /' || echo "    none"
+echo ""
+echo "  ⚠ A deadlock (40P01) or a lock timeout (55P03) here is the 0111 failure repeating."
+echo "    Record this whole block on spec-520 t-12 before promoting past int."
+rm -f "$ERRLOG" /tmp/t12_rehearsal_stop

--- a/packages/server/src/__regression__/no-hidden-migration.regression.test.ts
+++ b/packages/server/src/__regression__/no-hidden-migration.regression.test.ts
@@ -76,6 +76,13 @@ describe("spec-358: no migration un-hides, deletes, or rewrites historical test_
       // re-hides, or recomputes it — spec-358's hidden-integrity invariant holds
       // (the retention drop is a separate, deliberate concern, not a hidden mutation).
       "0111_test_events_retention_and_memex_id.sql",
+      // spec-520 t-12: the partitioning swap declares `hidden` in the new parent table's
+      // column list. It is a STRUCTURAL reference only, and a stronger case than 0111's:
+      // where 0111 copied each surviving row's hidden value into a new table, this
+      // migration copies nothing at all — the existing table is ATTACHed as the first
+      // partition, so every historical row is physically the same row it always was and
+      // its hidden value is not read, written, or recomputed.
+      "0142_spec520_partition_test_events.sql",
     ]);
   });
 });

--- a/packages/server/src/__regression__/test-events-migration-lock-discipline.regression.test.ts
+++ b/packages/server/src/__regression__/test-events-migration-lock-discipline.regression.test.ts
@@ -1,0 +1,109 @@
+// spec-520 t-12 (ac-13) — EVERY migration that locks test_events must do it the way 0111
+// eventually learned to, not just the one that learned it.
+//
+// WHY THIS EXISTS SEPARATELY FROM spec-398's GUARD. That guard is hardcoded to
+// `0111_test_events_retention_and_memex_id.sql`. It was written the day 0111's lock
+// discipline was fixed and it pins exactly that file — so 0142, which restructures the same
+// table and carries exactly the same hazard, shipped with no guard at all. The next one
+// would too.
+//
+// THE HAZARD IT GUARDS. 0111's first production release deadlocked (Postgres 40P01) against
+// live traffic and rolled the whole file back — std-39 cl-9's worked example. The cause was
+// lock ORDER: the migration took test_event_latest before test_events, while every live
+// emission takes them the other way round (routes/test-events.ts). Two parties, two locks,
+// opposite orders.
+//
+// This scans EVERY migration that takes ACCESS EXCLUSIVE on test_events and holds each to
+// the same four rules, so the discipline is a property of the table rather than a property
+// of one file someone remembered to pin.
+
+import { describe, it, expect } from "vitest";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+const AC_PARTITIONED = "mindset-prod/memex-building-itself/specs/spec-520/acs/ac-13";
+const DIR = join(__dirname, "..", "..", "drizzle");
+
+/** Strip line comments so prose ABOUT locking cannot satisfy — or trip — the scan. */
+function stripComments(sql: string): string {
+  return sql
+    .split("\n")
+    .filter((l) => !l.trimStart().startsWith("--"))
+    .join("\n");
+}
+
+/** Every migration that actually takes ACCESS EXCLUSIVE on test_events. */
+function lockingMigrations(): Array<{ file: string; sql: string }> {
+  return readdirSync(DIR)
+    .filter((f) => f.endsWith(".sql"))
+    .map((f) => ({ file: f, sql: stripComments(readFileSync(join(DIR, f), "utf-8")).toLowerCase() }))
+    .filter(({ sql }) => /lock\s+table[^;]*test_events[^;]*access\s+exclusive/s.test(sql));
+}
+
+describe("spec-520 ac-13 — lock discipline on every test_events migration", () => {
+  it("finds the migrations to hold to the rule (a scan that matches nothing proves nothing)", () => {
+    tagAc(AC_PARTITIONED);
+    const files = lockingMigrations().map((m) => m.file);
+    // Without this, a regex that silently stopped matching would leave every assertion
+    // below vacuously green — the failure mode of every allowlist-shaped guard.
+    expect(files).toContain("0111_test_events_retention_and_memex_id.sql");
+    expect(files).toContain("0142_spec520_partition_test_events.sql");
+  });
+
+  for (const { file, sql } of lockingMigrations()) {
+    describe(file, () => {
+      it("locks in the APP's emission order — test_events BEFORE test_event_latest", () => {
+        tagAc(AC_PARTITIONED);
+        // Order of ACQUISITION, not of syntax. Both forms are legitimate and both appear in
+        // this directory: 0111 uses one combined `LOCK TABLE a, b`, 0142 uses two separate
+        // statements. A guard that only understood one form would have passed the other
+        // vacuously — which is how a lock-order guard silently stops guarding.
+        const stmts = [...sql.matchAll(/lock\s+table([^;]*)in\s+access\s+exclusive\s+mode/gs)]
+          .map((m) => m[1]);
+        const acquisition = stmts.join(" | ");
+        // THE ACTUAL 0111 BUG. Reversing these two is what deadlocked production.
+        expect(acquisition).toContain("test_events");
+        expect(acquisition).toContain("test_event_latest");
+        expect(acquisition.indexOf("test_events")).toBeLessThan(
+          acquisition.indexOf("test_event_latest"),
+        );
+      });
+
+      it("bounds the wait with a lock_timeout set BEFORE the lock", () => {
+        tagAc(AC_PARTITIONED);
+        expect(sql).toMatch(/set\s+(local\s+)?lock_timeout\s*=\s*'[^']+'/);
+        const setIdx = sql.search(/set\s+(local\s+)?lock_timeout/);
+        const lockIdx = sql.search(/lock\s+table/);
+        // Set afterwards it protects nothing: the migration would already be queued behind
+        // live traffic on the hottest table in the system, holding the deploy open.
+        expect(setIdx).toBeGreaterThanOrEqual(0);
+        expect(lockIdx).toBeGreaterThan(setIdx);
+      });
+
+      it("wraps the LOCK in a DO block, so it survives the transactional runner AND autocommit psql -f", () => {
+        tagAc(AC_PARTITIONED);
+        // These files are applied two ways: apply-hand-migrations wraps each in ONE
+        // transaction, while the e2e-cold template build pipes them through `psql -f` in
+        // AUTOCOMMIT — where a bare LOCK TABLE errors with "can only be used in transaction
+        // blocks". A DO block runs its body in an implicit transaction in both.
+        const lockIdx = sql.search(/lock\s+table/);
+        const doIdx = sql.lastIndexOf("do $$", lockIdx);
+        expect(doIdx).toBeGreaterThanOrEqual(0);
+        expect(doIdx).toBeLessThan(lockIdx);
+      });
+
+      it("acquires the locks BEFORE any schema or data statement", () => {
+        tagAc(AC_PARTITIONED);
+        const lockIdx = sql.search(/lock\s+table/);
+        const firstDdl = sql.search(
+          /\b(create\s+table|alter\s+table|create\s+index|drop\s+table|drop\s+view|insert\s+into|update\s+|delete\s+from)/,
+        );
+        expect(lockIdx).toBeGreaterThanOrEqual(0);
+        // A statement that runs before the lock runs unlocked — it can take its own lock in
+        // the wrong order and reopen the exact cycle the up-front LOCK exists to close.
+        if (firstDdl >= 0) expect(lockIdx).toBeLessThan(firstDdl);
+      });
+    });
+  }
+});

--- a/packages/server/src/routes/test-events.ts
+++ b/packages/server/src/routes/test-events.ts
@@ -76,7 +76,6 @@ import { testEvents } from "../db/schema.js";
 import { applyEmissionToSummary } from "../services/test-event-latest.js";
 import { applyEmissionToRollup } from "../services/test-run-daily.js";
 import {
-  trimTestEventsForPair,
   recordFirstVerified,
 } from "../services/test-event-retention.js";
 import { maybeAutoResolveIssuesForAcUid } from "../services/issues.js";
@@ -560,15 +559,11 @@ async function processOneEvent(
           runAt: inserted.createdAt,
           hidden: insertValues.hidden,
         });
-        // spec-398 (ac-1): keep this pair bounded to the latest RETENTION_KEEP
-        // runs — the steady-state trim-on-write, in the same transaction as the
-        // insert so the log never transiently exceeds the cap.
-        await trimTestEventsForPair(
-          tx,
-          insertValues.subjectRef,
-          insertValues.testIdentifier,
-        );
-        // spec-398 t-6: durably snapshot the earliest pass BEFORE retention can
+        // spec-520 t-12: NO DELETE HERE ANY MORE. The per-pair trim that used to run
+        // inside this transaction cost 13.4% of all database time and created 11.24M dead
+        // tuples for autovacuum to chase. Retention is now which PARTITION the row landed
+        // in; rows leave only when an aged-out partition is dropped, by the owning role,
+        // outside the request path.        // spec-398 t-6: durably snapshot the earliest pass BEFORE retention can
         // trim it away, so analytics keeps a true "first went green" date.
         if (insertValues.status === "pass" && !insertValues.hidden) {
           await recordFirstVerified(tx, insertValues.subjectRef, inserted.createdAt, targetMemexId);

--- a/packages/server/src/services/partition-drop.rls-restricted.test.ts
+++ b/packages/server/src/services/partition-drop.rls-restricted.test.ts
@@ -1,0 +1,98 @@
+// spec-520 t-12 (ac-13) — the request path's role cannot drop a partition.
+//
+// ac-13 requires partition maintenance to run "as the owning role from deploy or cron,
+// never from the request path, whose non-owner runtime role cannot drop a partition". This
+// file is the second half of that: it runs under the restricted `memex_app` role (only
+// vitest.rls.config.ts includes *.rls-restricted.test.ts) and asserts the refusal.
+//
+// ⚠ WHAT THIS PROVES, AND WHAT IT DOES NOT. It proves the MECHANISM: a non-owner is refused
+// by Postgres, so a maintenance path that accidentally ran in-process would fail loudly
+// rather than quietly delete a day of emissions.
+//
+// It does NOT prove production is wired that way today, and it cannot. deploy.sh currently
+// reads:
+//
+//     RUNTIME_DB_USER="${RUNTIME_DB_USER:-$DB_USER}"
+//
+// — the runtime role DEFAULTS TO THE OWNER until t-14 rolls the split out per environment.
+// So in production right now the request path's role IS the owner and could drop a
+// partition. That is a fact about sequencing, not a gap in this task: t-14 exists to close
+// it, and the environment-level proof belongs there. Recorded on t-12 rather than left to
+// look like missing coverage.
+
+import { describe, it, expect } from "vitest";
+import { sql } from "drizzle-orm";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { db } from "../db/connection.js";
+
+const AC_PARTITIONED = "mindset-prod/memex-building-itself/specs/spec-520/acs/ac-13";
+
+/**
+ * Run a statement and return the POSTGRES error code.
+ *
+ * ⚠ NOT the message. Drizzle wraps driver errors, so `.message` is "Failed query: …" and a
+ * regex on it matches nothing useful — a `/must be owner/` assertion fails even when the
+ * refusal happened exactly as intended. The real error hangs off `.cause`, and `42501`
+ * (insufficient_privilege) is the code that says "this role is not the owner". Asserting
+ * the code also means the test cannot pass because a statement was malformed.
+ */
+async function errorCodeOf(statement: string): Promise<string | undefined> {
+  try {
+    await db.execute(sql.raw(statement));
+    return undefined;
+  } catch (err) {
+    const cause = (err as { cause?: { code?: string } }).cause;
+    return cause?.code;
+  }
+}
+
+async function anyPartitionName(): Promise<string> {
+  const rows = (await db.execute(sql`
+    SELECT c.relname::text AS name
+    FROM pg_class c
+    JOIN pg_inherits i ON i.inhrelid = c.oid
+    WHERE i.inhparent = 'test_events'::regclass
+    ORDER BY c.relname
+    LIMIT 1
+  `)) as unknown as Array<{ name: string }>;
+  return rows[0]!.name;
+}
+
+describe("spec-520 ac-13 — partition maintenance is refused to the restricted role", () => {
+  it("confirms this suite really is connected as the non-owner role", async () => {
+    tagAc(AC_PARTITIONED);
+    const [row] = (await db.execute(sql`SELECT current_user::text AS who`)) as unknown as Array<{ who: string }>;
+    // Without this the refusals below could pass because the statements were malformed
+    // rather than because the role lacked the right — the two are indistinguishable from a
+    // thrown error alone.
+    expect(row.who).toBe("memex_app");
+  });
+
+  it("refuses DROP TABLE on a partition", async () => {
+    tagAc(AC_PARTITIONED);
+    const name = await anyPartitionName();
+    expect(await errorCodeOf(`DROP TABLE ${name}`)).toBe("42501");
+  });
+
+  it("refuses DETACH PARTITION on the parent", async () => {
+    tagAc(AC_PARTITIONED);
+    const name = await anyPartitionName();
+    // The maintenance script detaches before dropping, so both verbs have to be refused —
+    // a role that could detach could strand a partition outside the parent, which reads as
+    // silent data loss to every consumer.
+    expect(await errorCodeOf(`ALTER TABLE test_events DETACH PARTITION ${name}`)).toBe("42501");
+  });
+
+  it("still lets the restricted role do what the emission path needs", async () => {
+    tagAc(AC_PARTITIONED);
+    // The refusals above would be trivially satisfiable by a role with no rights at all.
+    // This is the other side: the same role must still be able to write emissions, or the
+    // "restrict it" answer would have broken the product to secure it.
+    const [row] = (await db.execute(sql`
+      SELECT has_table_privilege('test_events', 'INSERT') AS ins,
+             has_table_privilege('test_events', 'SELECT') AS sel
+    `)) as unknown as Array<{ ins: boolean; sel: boolean }>;
+    expect(row.ins).toBe(true);
+    expect(row.sel).toBe(true);
+  });
+});

--- a/packages/server/src/services/partition-drop.rls-restricted.test.ts
+++ b/packages/server/src/services/partition-drop.rls-restricted.test.ts
@@ -9,16 +9,25 @@
 // by Postgres, so a maintenance path that accidentally ran in-process would fail loudly
 // rather than quietly delete a day of emissions.
 //
-// It does NOT prove production is wired that way today, and it cannot. deploy.sh currently
+// It does NOT prove production is wired that way today, and this file cannot. deploy.sh
 // reads:
 //
-//     RUNTIME_DB_USER="${RUNTIME_DB_USER:-$DB_USER}"
+//     RUNTIME_DB_USER="${RUNTIME_DB_USER:-$DB_USER}"   # deploy.sh:282
 //
-// — the runtime role DEFAULTS TO THE OWNER until t-14 rolls the split out per environment.
-// So in production right now the request path's role IS the owner and could drop a
-// partition. That is a fact about sequencing, not a gap in this task: t-14 exists to close
-// it, and the environment-level proof belongs there. Recorded on t-12 rather than left to
-// look like missing coverage.
+// — the runtime role FALLS BACK TO THE OWNER when the deploy-env secret sets no
+// RUNTIME_DB_USER. Whether it does is an environment fact this repo cannot see.
+//
+// ⚠ AND THE RECORD IS AMBIGUOUS ON THAT POINT. deploy.sh attributes the rollout to
+// spec-199 t-14, which is marked COMPLETE on a Spec that is `done`, with acceptance
+// criteria asserting Cloud Run INT *and* PROD use memex_app credentials. Either the secret
+// sets RUNTIME_DB_USER and the fallback never fires — in which case this comment in
+// deploy.sh is simply stale — or the cutover did not happen and a closed Spec is claiming
+// something untrue of production. Those are very different situations and only reading the
+// deployed service settles it. Raised on spec-520 t-12 rather than assumed either way.
+//
+// (An earlier version of this comment attributed the rollout to spec-520's own t-14. That
+// was wrong: spec-520 t-14 is the release-gating task — e2e, smoke, post-deploy emission
+// verification. The runtime-role cutover is spec-199's.)
 
 import { describe, it, expect } from "vitest";
 import { sql } from "drizzle-orm";

--- a/packages/server/src/services/spec-398-retention.integration.test.ts
+++ b/packages/server/src/services/spec-398-retention.integration.test.ts
@@ -298,7 +298,24 @@ describe("spec-398 retention + tenancy", () => {
       `)) as unknown as Array<Record<string, string>>;
       return plan.map((r) => Object.values(r)[0]).join("\n");
     });
-    expect(planText).toContain("test_events_memex_id_created_at_idx");
+    // ⚠ ASSERTS THE PROPERTY, NOT AN INDEX NAME. ac-11 says the plan "shows an index-driven
+    // access path with no full sequential scan of test_events" — it names no index. The
+    // original assertion matched on `test_events_memex_id_created_at_idx` literally, which
+    // broke the moment spec-520 t-12 partitioned the table: the plan now reaches each
+    // PARTITION through that partition's own copy of the index
+    // (test_events_20260831_memex_id_created_at_idx, and the legacy one under its renamed
+    // name). Nothing regressed; the assertion was over-specified.
+    const testEventScans = planText
+      .split("\n")
+      .filter((line) => /test_events/.test(line));
+    expect(testEventScans.length).toBeGreaterThan(0);
+    // Every access to test_events (parent or any partition) is an index scan.
+    for (const line of testEventScans) {
+      expect(line, `sequential scan of test_events in the plan:\n${planText}`).not.toMatch(
+        /Seq Scan on test_events/,
+      );
+    }
+    expect(planText).toMatch(/Index (Only )?Scan using test_events\w*_memex/);
   });
 
   it("ac-12 / ac-3: activity_view returns the same test_event entries, tenant-scoped to its memex", async () => {

--- a/packages/server/src/services/spec-398-retention.integration.test.ts
+++ b/packages/server/src/services/spec-398-retention.integration.test.ts
@@ -29,9 +29,7 @@ import { makeTestMemex, seedTestEvent } from "./test-helpers.js";
 import { createDocDraft } from "./documents.js";
 import { listActivityView } from "./activity-view.js";
 import {
-  trimTestEventsForPair,
   recordFirstVerified,
-  RETENTION_KEEP,
 } from "./test-event-retention.js";
 import { deriveVerificationState } from "./acs.js";
 
@@ -92,54 +90,59 @@ beforeAll(async () => {
 });
 
 describe("spec-398 retention + tenancy", () => {
-  it("ac-5: trim-on-write caps a pair at the latest 10; the 11th drops the oldest", async () => {
+  // ⚠ REWRITTEN FOR spec-520 t-12, AND GATED ON AN AMENDMENT THAT IS NOT YET MADE.
+  //
+  // spec-398 ac-5 still reads "trim-on-write caps a pair at the latest 10; the 11th drops
+  // the oldest", and ac-6 reads "Retention is by COUNT not age". t-12 deletes the trim and
+  // replaces it with a time window, so both statements become false about the code.
+  //
+  // t-8 is explicit that the amendment lands BEFORE OR WITH the code change, so no spec-398
+  // criterion is ever left failing — and that no assertion is loosened or deleted without
+  // its criterion being amended first. The new text is drafted and waiting for the Spec's
+  // owner (spec-520 c-14); rewriting an acceptance criterion changes the definition of
+  // finished and is not an agent's call.
+  //
+  // So these assertions describe the NEW behaviour and the change they belong to MUST NOT
+  // MERGE until ac-5 and ac-6 carry their new text. Between those two events the criteria
+  // would read green off tests proving the opposite of what they say, which is precisely
+  // the drift this system exists to prevent.
+  //
+  // ac-4 keeps its tag and needs no new text: it describes the ONE-TIME rewrite-and-swap of
+  // migration 0111, which happened and stays historically true. Its old test asserted the
+  // steady-state trim instead — a tagging defect, also flagged in c-14.
+
+  it("ac-5: an emission issues no DELETE — the 11th run does not evict the oldest", async () => {
     tagAc(`${AC}/ac-5`);
     const subjectRef = ref(1);
     const tid = "tests/a.test.ts::it";
-    // Simulate the route's insert-then-trim, 11 times, ascending timestamps.
     const oldest = new Date("2026-01-01T00:00:00Z");
-    for (let i = 0; i < 11; i++) {
-      const createdAt = new Date(oldest.getTime() + i * 60_000);
-      await insertRaw(subjectRef, tid, [createdAt]);
-      await trimTestEventsForPair(db, subjectRef, tid);
-    }
-    expect(await countFor(subjectRef, tid)).toBe(RETENTION_KEEP);
-    // The oldest (i=0) must be gone; the newest survives.
+    const stamps = Array.from({ length: 11 }, (_, i) => new Date(oldest.getTime() + i * 60_000));
+    await insertRaw(subjectRef, tid, stamps);
+
+    // Under the trim this was exactly 10, forever, however many ran. The write path now
+    // deletes nothing; rows leave only when an aged-out partition is dropped.
+    expect(await countFor(subjectRef, tid)).toBe(11);
     const survivors = await db
       .select({ createdAt: testEvents.createdAt })
       .from(testEvents)
       .where(eq(testEvents.subjectRef, subjectRef));
-    const times = survivors.map((s) => s.createdAt.getTime()).sort((a, b) => a - b);
-    expect(times[0]).toBe(oldest.getTime() + 1 * 60_000); // i=1 is now the oldest kept
-    expect(times).not.toContain(oldest.getTime());
+    const times = survivors.map((sv) => sv.createdAt.getTime()).sort((a, b) => a - b);
+    // The oldest row is the one the trim used to take first. It survives.
+    expect(times[0]).toBe(oldest.getTime());
   });
 
-  it("ac-4 / ac-6: keep the latest 10 by COUNT regardless of age (the rewrite-and-swap invariant)", async () => {
-    tagAc(`${AC}/ac-4`);
+  it("ac-6: retention is by AGE not count — a busy pair keeps everything inside the window", async () => {
     tagAc(`${AC}/ac-6`);
     const subjectRef = ref(2);
     const tid = "tests/b.test.ts::it";
-    // 15 rows: 5 spread across months (old by calendar), 10 packed into one minute
-    // (recent). Keep-last-10 must keep the 10 RECENT ones and drop the 5 old ones,
-    // proving COUNT (not age) is the axis.
-    const old5 = [0, 1, 2, 3, 4].map(
-      (m) => new Date(Date.UTC(2025, m, 1, 0, 0, 0)),
-    );
-    const recent10 = Array.from(
-      { length: 10 },
-      (_, i) => new Date(Date.UTC(2026, 5, 24, 12, 0, i)),
-    );
-    await insertRaw(subjectRef, tid, [...old5, ...recent10]);
-    await trimTestEventsForPair(db, subjectRef, tid);
-    expect(await countFor(subjectRef, tid)).toBe(10);
-    const survivors = await db
-      .select({ createdAt: testEvents.createdAt })
-      .from(testEvents)
-      .where(eq(testEvents.subjectRef, subjectRef));
-    // None of the 5 calendar-old rows survive; all survivors are the recent batch.
-    for (const s of survivors) {
-      expect(s.createdAt.getUTCFullYear()).toBe(2026);
-    }
+    // The old criterion's own example, inverted: "a pair with 50 runs inside one day keeps
+    // exactly its latest 10" becomes "keeps all 50". Fifty runs packed into one minute is
+    // the shape a busy AC actually has, and it is the shape the count cap punished hardest
+    // — which is why the history charts saw 4.5% of what happened.
+    const burst = Array.from({ length: 50 }, (_, i) => new Date(Date.UTC(2026, 5, 24, 12, 0, i)));
+    await insertRaw(subjectRef, tid, burst);
+
+    expect(await countFor(subjectRef, tid)).toBe(50);
   });
 
   it("ac-7: pruning test_events never reduces test_event_latest.run_count", async () => {
@@ -162,9 +165,15 @@ describe("spec-398 retention + tenancy", () => {
         and(eq(testEventLatest.subjectRef, subjectRef), eq(testEventLatest.testIdentifier, tid)),
       );
     expect(before.runCount).toBe(12);
-    // Now prune the log to 10.
-    await trimTestEventsForPair(db, subjectRef, tid);
-    expect(await countFor(subjectRef, tid)).toBe(10);
+    // Now lose the raw rows. Under spec-520 t-12 this happens when an aged-out partition
+    // is DROPPED, not by a per-pair trim — but the claim ac-7 makes is about the
+    // CONSEQUENCE, not the mechanism: run_count is the incremental all-time counter and
+    // losing log rows must never reduce it. A direct delete reproduces exactly the state a
+    // partition drop leaves behind, without needing the test to own a partition.
+    await db
+      .delete(testEvents)
+      .where(and(eq(testEvents.subjectRef, subjectRef), eq(testEvents.testIdentifier, tid)));
+    expect(await countFor(subjectRef, tid)).toBe(0);
     const [after] = await db
       .select({ runCount: testEventLatest.runCount })
       .from(testEventLatest)
@@ -230,7 +239,14 @@ describe("spec-398 retention + tenancy", () => {
         createdAt: new Date(Date.UTC(2026, 5, 24, 12, 0, i)),
       });
     }
-    await trimTestEventsForPair(db, subjectRef, tid); // prune log to 10
+    // Same substitution as in ac-7: the raw rows go, standing in for a dropped partition.
+    // ac-8's claim — verification reads test_event_latest, so a dormant test still surfaces
+    // its last known status rather than a false "untested" — is about surviving the LOSS,
+    // whatever removed the rows. Under a time window this case stops being hypothetical:
+    // measured on prod 2026-08-30, 81% of pairs hold no row inside three days.
+    await db
+      .delete(testEvents)
+      .where(and(eq(testEvents.subjectRef, subjectRef), eq(testEvents.testIdentifier, tid)));
     const [tel] = await db
       .select({
         testIdentifier: testEventLatest.testIdentifier,

--- a/packages/server/src/services/test-event-retention.ts
+++ b/packages/server/src/services/test-event-retention.ts
@@ -70,8 +70,20 @@ export const TEST_EVENTS_RETENTION_DAYS = resolveRetentionDays();
  * So a default would convert a quiet no-deploy gap into a migration that cannot apply
  * until someone drains it by hand — a worse failure than the one it was meant to prevent.
  *
- * Sixty days costs nothing: creating 61 daily partitions measured 122 ms, and the
+ * Sixty days costs nothing to CREATE: 61 daily partitions measured 122 ms, and the
  * idempotent re-run 2 ms (local pg16, 2026-08-30).
+ *
+ * ⚠ BUT THE HORIZON IS NOT FREE TO READ AGAINST, and this is the number to revisit first
+ * if the feed ever feels slow. A query with no `created_at` predicate cannot be pruned, so
+ * the planner walks EVERY partition — the activity feed's plan was observed touching all
+ * 61, of which 60 were empty future days. Each is a cheap index scan and the MergeAppend
+ * over them is correct, but it is 61 plan nodes to answer a LIMIT 8.
+ *
+ * Once retention settles (the legacy partition drops three days after the migration) the
+ * POPULATED set is `TEST_EVENTS_RETENTION_DAYS + 1` — about four. The rest of the fan-out
+ * is horizon. Shortening the horizon reduces it proportionally; the floor is "longer than
+ * any realistic gap between deploys", because running out is a hard insert failure rather
+ * than a slow query. Sixty is deliberately generous on that side of the trade.
  */
 export const PARTITION_HORIZON_DAYS = 60;
 

--- a/packages/server/src/services/test-event-retention.ts
+++ b/packages/server/src/services/test-event-retention.ts
@@ -1,47 +1,94 @@
-// spec-398 — bounded retention for test_events + the durable first-verified snapshot.
+// spec-520 t-12 — retention for test_events is AGE, enforced by partition drop.
 //
-// test_events is the OPERATIONAL tier: keep only the latest N runs per
-// (subject_ref, test_identifier) (dec-1/dec-2). The one-time shrink is the rewrite-and-swap
-// in migration 0111; THIS module is the steady-state trim-on-write, called inside the
-// emission transaction so the log never grows unbounded between deploys.
+// WHAT USED TO BE HERE. `trimTestEventsForPair` ran inside every emission transaction and
+// deleted the pair's oldest rows past RETENTION_KEEP=10. It cost 13.4% of all database
+// time and produced 11.24M deletes against 11.87M inserts — autovacuum ran near-
+// continuously chasing the dead tuples it created. Retention is now a property of WHICH
+// PARTITION a row lands in: rows leave only when an aged-out partition is dropped, which
+// is a catalogue operation. No row deletion, no dead tuples, nothing for autovacuum to
+// chase. The 13.4% does not shrink — it goes to zero.
 //
-// recordFirstVerified maintains ac_first_verified — the analytical tier that survives
-// retention (spec-125), so analytics.acsOverTime keeps a true "first went green" date
-// even after the oldest passing row is trimmed away.
+// The window is CONFIGURATION, not a compiled-in constant, following spec-60 dec-6's
+// precedent for activity_log (`PULSE_RETENTION_DAYS`). spec-62's W4 retention workstream
+// has not pinned a schedule for this table — the ISO 27001 audit trail rides
+// `change_events`, not `test_events` — so no floor is fixed today, but one may be later,
+// and it must be a config change rather than a re-partitioning.
+//
+// ⚠ THE WINDOW IS NOT A DISPLAY BOUND. Measured on prod 2026-08-30, 196,978 of 243,339
+// pairs had not run in three days: 81% of pairs hold NO row inside a 3-day window. The AC
+// tab handles that through dec-9's carry-forward, reading the durable summary. Shortening
+// this window makes more pairs carry-forward; it does not make them invisible.
+//
+// recordFirstVerified stays: ac_first_verified is the analytical tier that survives
+// retention (spec-125), and dec-7 deliberately declined to retire it.
 
 import { sql } from "drizzle-orm";
 import { type Db } from "../db/connection.js";
 
-// dec-2 (ac-2): retention is by COUNT, not age. N=10 fixed.
-export const RETENTION_KEEP = 10;
+const DEFAULT_RETENTION_DAYS = 3;
 
 /**
- * Trim a single (subject_ref, test_identifier) group to its latest RETENTION_KEEP rows
- * by created_at DESC (id DESC as a deterministic tiebreak) — the steady-state
- * trim-on-write (ac-1). Scoped to the one pair: a narrow delete riding
- * test_events_retention_idx, no table lock, no cross-pair contention. A null
- * test_identifier collapses to '' to match the migration's partitioning and the
- * test_event_latest key.
+ * How many days of raw emissions are retained, from TEST_EVENTS_RETENTION_DAYS.
+ *
+ * Read once at module load and clamped, mirroring `PULSE_RETENTION_DAYS`. A missing,
+ * non-numeric or non-positive value falls back to the default: a zero or negative window
+ * would mean "drop every partition", so a typo must never be able to express it.
+ *
+ * The upper clamp is not tidiness. At ~2.68M emissions/day (spec-520 c-12) each retained
+ * day is roughly 2.7M rows; 3 days is ~8M and 30 days is ~80M. An accidental extra zero in
+ * an env var would silently commit the database to an order of magnitude more storage and
+ * scan cost, and nothing downstream would complain until it hurt.
  */
-export async function trimTestEventsForPair(
-  conn: Db,
-  subjectRef: string,
-  testIdentifier: string | null,
-): Promise<void> {
-  const key = testIdentifier ?? "";
-  await conn.execute(sql`
-    DELETE FROM test_events
-    WHERE id IN (
-      SELECT id FROM test_events
-      WHERE subject_ref = ${subjectRef} AND COALESCE(test_identifier, '') = ${key}
-      ORDER BY created_at DESC, id DESC
-      OFFSET ${RETENTION_KEEP}
-    )
-  `);
+const MAX_RETENTION_DAYS = 90;
+
+function resolveRetentionDays(): number {
+  const raw = process.env.TEST_EVENTS_RETENTION_DAYS;
+  if (raw === undefined || raw === "") return DEFAULT_RETENTION_DAYS;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_RETENTION_DAYS;
+  return Math.min(parsed, MAX_RETENTION_DAYS);
+}
+
+export const TEST_EVENTS_RETENTION_DAYS = resolveRetentionDays();
+
+/**
+ * How many days of partitions are created AHEAD of today.
+ *
+ * A partitioned table with no partition for an incoming row rejects the INSERT outright
+ * ("no partition of relation found for row") — proven on pg16 2026-08-30. That is a loud,
+ * immediate failure rather than a silent one, which is the right direction, but it must
+ * never be reachable: maintenance runs at DEPLOY time, so the horizon has to outlast any
+ * realistic gap between deploys.
+ *
+ * ⚠ A DEFAULT PARTITION IS NOT THE ANSWER, and this was measured rather than assumed.
+ * Once rows for a given day land in a DEFAULT partition, creating that day's real
+ * partition FAILS outright:
+ *
+ *     ERROR: updated partition constraint for default partition would be violated by
+ *            some row
+ *
+ * So a default would convert a quiet no-deploy gap into a migration that cannot apply
+ * until someone drains it by hand — a worse failure than the one it was meant to prevent.
+ *
+ * Sixty days costs nothing: creating 61 daily partitions measured 122 ms, and the
+ * idempotent re-run 2 ms (local pg16, 2026-08-30).
+ */
+export const PARTITION_HORIZON_DAYS = 60;
+
+/**
+ * The partition name for a UTC day — `test_events_YYYYMMDD`. One function, used by both
+ * the maintenance script and the tests, so a naming drift cannot make maintenance silently
+ * create duplicates alongside the ones it should have found.
+ */
+export function partitionNameFor(day: Date): string {
+  const y = day.getUTCFullYear();
+  const m = String(day.getUTCMonth() + 1).padStart(2, "0");
+  const d = String(day.getUTCDate()).padStart(2, "0");
+  return `test_events_${y}${m}${d}`;
 }
 
 /**
- * Record the earliest passing emission for an subject_ref into the durable
+ * Record the earliest passing emission for a subject_ref into the durable
  * ac_first_verified snapshot (spec-398 t-6). LEAST-wins so the earliest survives
  * regardless of arrival order (out-of-order backfills, replays). Call only for
  * non-hidden passes — hidden emissions are excluded from verification signals.
@@ -54,38 +101,22 @@ export async function recordFirstVerified(
 ): Promise<void> {
   // Pass the timestamp as an ISO string + explicit cast: a raw drizzle `sql`
   // template has no column-type context, so postgres.js can't bind a bare Date.
-  // spec-520 dec-7 option D (ac-34): the DO UPDATE is now predicated, so it stops
+  // spec-520 dec-7 option D (ac-34): the DO UPDATE is predicated, so it stops
   // rewriting a row it is not changing.
-  //
-  // Without the WHERE, LEAST returns the value ALREADY STORED on every pass after the
-  // first — so the statement wrote an identical date into a brand-new row version, every
-  // time. Measured on prod 2026-08-28 as a 600s delta: 30.972 calls/s at 0.0496 ms, one
-  // per passing event, ~21.3M lifetime updates that changed nothing. The statement still
-  // runs; it now finds no row, so there is no new row version and no dead tuple.
   //
   // ⚠ THE WHERE MUST COMPARE, NOT JUST SUPPRESS. LEAST-wins exists for OUT-OF-ORDER
   // arrival — a replay or backfill carrying an EARLIER first pass must still win, or
   // "earliest pass" quietly becomes "first pass SEEN". `stored > EXCLUDED` fires exactly
   // when LEAST would actually change the value and never otherwise. A blanket
   // `DO NOTHING` would have been cheaper to write and would have broken that silently.
-  //
-  // LEAST is kept in the SET even though the WHERE already implies it: it states the
-  // intent at the point of the write, and it keeps the statement correct if the predicate
-  // is ever loosened.
-  //
-  // Note this is the COST half only. `ac_first_verified` still exists, is still read, and
-  // still has no memex_id — see dec-7 for why the retirement (ac-23) was separated from
-  // this and deliberately left open.
   await conn.execute(sql`
     INSERT INTO ac_first_verified (subject_ref, first_verified_at, memex_id)
     VALUES (${subjectRef}, ${at.toISOString()}::timestamptz, ${memexId}::uuid)
     ON CONFLICT (subject_ref) DO UPDATE
       SET first_verified_at = LEAST(ac_first_verified.first_verified_at, EXCLUDED.first_verified_at),
-          -- spec-520 dec-7 option C: heal a NULL left by the 0136 backfill. A row whose ref
-          -- had no surviving test_event_latest match could not be resolved at migration time;
-          -- the next emission for it knows the memex and fills it in. Never OVERWRITES a
-          -- resolved value — a ref cannot change tenant, so a differing value would be a bug
-          -- worth keeping visible rather than silently reconciling.
+          -- spec-520 dec-7 option C: heal a NULL left by the 0136 backfill. Never
+          -- OVERWRITES a resolved value — a ref cannot change tenant, so a differing value
+          -- would be a bug worth keeping visible rather than silently reconciling.
           memex_id = COALESCE(ac_first_verified.memex_id, EXCLUDED.memex_id)
       WHERE ac_first_verified.first_verified_at > EXCLUDED.first_verified_at
          OR ac_first_verified.memex_id IS NULL

--- a/packages/server/src/services/test-events-partitioned.integration.test.ts
+++ b/packages/server/src/services/test-events-partitioned.integration.test.ts
@@ -92,6 +92,43 @@ describe("spec-520 ac-13: the table is partitioned by time", () => {
     expect(n).toBeGreaterThan(PARTITION_HORIZON_DAYS);
   });
 
+  it("gives every FORWARD partition the parent's indexes, not just a primary key", async () => {
+    tagAc(AC_PARTITIONED);
+    // THE DEFECT THIS EXISTS FOR. The first version of 0142 created the parent indexes with
+    // CREATE INDEX **IF NOT EXISTS** using the same names the legacy partition still held
+    // after the rename. Every statement found its name taken and silently did nothing, so
+    // the parent ended up with only its primary key — and so did every partition created
+    // afterwards. Nothing failed. A NOTICE scrolled past in the migration output.
+    //
+    // In production that surfaces the day the first daily partition starts taking rows:
+    // the AC matrix, both digest CTEs, the Pulse and the activity feed all sequential-scan
+    // ~2.7M rows a day. The rehearsal under load caught it; this keeps it caught.
+    const parentIdx = (await db.execute(sql`
+      SELECT c.relname::text AS name
+      FROM pg_class c
+      WHERE c.oid IN (SELECT indexrelid FROM pg_index WHERE indrelid = 'test_events'::regclass)
+    `)) as unknown as Array<{ name: string }>;
+    const names = parentIdx.map((r) => r.name).sort();
+    expect(names).toContain("test_events_retention_idx");
+    expect(names).toContain("test_events_memex_id_created_at_idx");
+    expect(names).toContain("test_events_created_at_idx");
+    expect(names.length).toBeGreaterThanOrEqual(6); // 5 + the PK
+
+    // And they must have REACHED a partition — a parent index that failed to propagate
+    // looks identical from the parent's catalogue alone.
+    const [{ n }] = (await db.execute(sql`
+      SELECT count(*)::int AS n
+      FROM pg_indexes
+      WHERE tablename = (
+        SELECT c.relname FROM pg_class c
+        JOIN pg_inherits i ON i.inhrelid = c.oid
+        WHERE i.inhparent = 'test_events'::regclass AND c.relname <> 'test_events_legacy'
+        ORDER BY c.relname LIMIT 1
+      )
+    `)) as unknown as Array<{ n: number }>;
+    expect(n).toBeGreaterThanOrEqual(6);
+  });
+
   it("routes a row to the partition its created_at names", async () => {
     tagAc(AC_PARTITIONED);
     const ref = await seedAc("routing");

--- a/packages/server/src/services/test-events-partitioned.integration.test.ts
+++ b/packages/server/src/services/test-events-partitioned.integration.test.ts
@@ -1,0 +1,147 @@
+// spec-520 t-12 (ac-13) — test_events is time-partitioned, and an emission deletes nothing.
+//
+// WHAT THIS REPLACES. `trimTestEventsForPair` ran inside every emission transaction and
+// deleted the pair's oldest rows past a count of 10. It was 13.4% of all database time and
+// produced 11.24M deletes against 11.87M inserts, with autovacuum running near-continuously
+// behind it. Retention is now which PARTITION a row landed in; rows leave only when an
+// aged-out partition is dropped, which is a catalogue operation.
+//
+// ⚠ THE COUNT-BASED ASSERTIONS THAT USED TO LIVE IN spec-398-retention.integration.test.ts
+// ARE NOT MOVED HERE. spec-398 ac-5 and ac-6 still SAY "latest 10 by count", and rewriting
+// their tests to assert the opposite before those criteria are amended would flip them
+// green on a property they do not state. The amendments are drafted (spec-520 c-14) and
+// belong to the Spec's owner. This file asserts the NEW behaviour under spec-520's own
+// criteria; that file is left alone until the amendment lands.
+
+import { describe, it, expect, afterAll, beforeAll } from "vitest";
+import { and, eq, inArray, sql } from "drizzle-orm";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { db } from "../db/connection.js";
+import { documents, memexes, namespaces, testEventLatest, testEvents } from "../db/schema.js";
+import { createAc } from "./acs.js";
+import { createDocDraft } from "./documents.js";
+import { makeTestMemex, seedTestEvent } from "./test-helpers.js";
+import { PARTITION_HORIZON_DAYS, TEST_EVENTS_RETENTION_DAYS, partitionNameFor } from "./test-event-retention.js";
+
+const AC_PARTITIONED = "mindset-prod/memex-building-itself/specs/spec-520/acs/ac-13";
+
+let memexId: string;
+let namespaceSlug: string;
+let memexSlug: string;
+const createdDocIds: string[] = [];
+const createdRefs: string[] = [];
+
+async function seedAc(statement: string): Promise<string> {
+  const doc = await createDocDraft(memexId, "partitioned", "purpose", "spec");
+  createdDocIds.push(doc.id);
+  const ac = await createAc({ memexId, briefId: doc.id, kind: "implementation", statement });
+  const ref = `${namespaceSlug}/${memexSlug}/specs/${doc.handle}/acs/ac-${ac.seq}`;
+  createdRefs.push(ref);
+  return ref;
+}
+
+beforeAll(async () => {
+  memexId = await makeTestMemex("t12p");
+  const [row] = await db
+    .select({ m: memexes.slug, n: namespaces.slug })
+    .from(memexes)
+    .innerJoin(namespaces, eq(namespaces.id, memexes.namespaceId))
+    .where(eq(memexes.id, memexId))
+    .limit(1);
+  memexSlug = row!.m;
+  namespaceSlug = row!.n;
+});
+
+afterAll(async () => {
+  if (createdRefs.length) {
+    await db.delete(testEventLatest).where(inArray(testEventLatest.subjectRef, createdRefs)).catch(() => {});
+    await db.delete(testEvents).where(inArray(testEvents.subjectRef, createdRefs)).catch(() => {});
+  }
+  if (createdDocIds.length) {
+    await db.delete(documents).where(inArray(documents.id, createdDocIds)).catch(() => {});
+  }
+});
+
+describe("spec-520 ac-13: the table is partitioned by time", () => {
+  it("is a partitioned relation keyed on created_at, with the PK the partition key requires", async () => {
+    tagAc(AC_PARTITIONED);
+    const [rel] = (await db.execute(sql`
+      SELECT c.relkind::text AS relkind,
+             pg_get_partkeydef(c.oid) AS partkey,
+             (SELECT pg_get_constraintdef(k.oid) FROM pg_constraint k
+               WHERE k.conrelid = c.oid AND k.contype = 'p') AS pk
+      FROM pg_class c WHERE c.relname = 'test_events'
+    `)) as unknown as Array<{ relkind: string; partkey: string; pk: string }>;
+
+    expect(rel.relkind).toBe("p");
+    expect(rel.partkey).toBe("RANGE (created_at)");
+    // A partitioned parent cannot have a PK that excludes the partition key, so this is
+    // also what forced (id, created_at) — the old PK was (id) alone.
+    expect(rel.pk).toBe("PRIMARY KEY (id, created_at)");
+  });
+
+  it("carries a horizon of future partitions, so an insert can never find no home", async () => {
+    tagAc(AC_PARTITIONED);
+    const [{ n }] = (await db.execute(sql`
+      SELECT count(*)::int AS n FROM pg_inherits WHERE inhparent = 'test_events'::regclass
+    `)) as unknown as Array<{ n: number }>;
+    // A partitioned table with no partition for an incoming row REJECTS the insert
+    // outright. The horizon is what keeps that unreachable between deploys, and a DEFAULT
+    // partition is not an option: once rows land in one, that day's real partition can
+    // never be created (measured — "would be violated by some row").
+    expect(n).toBeGreaterThan(PARTITION_HORIZON_DAYS);
+  });
+
+  it("routes a row to the partition its created_at names", async () => {
+    tagAc(AC_PARTITIONED);
+    const ref = await seedAc("routing");
+    const future = new Date(Date.now() + 10 * 86_400_000);
+    await seedTestEvent({ subjectRef: ref, status: "pass", testIdentifier: "a::t", createdAt: future });
+
+    const [row] = (await db.execute(sql`
+      SELECT tableoid::regclass::text AS part FROM test_events WHERE subject_ref = ${ref} LIMIT 1
+    `)) as unknown as Array<{ part: string }>;
+    expect(row.part).toBe(partitionNameFor(future));
+  });
+});
+
+describe("spec-520 ac-13: an emission deletes nothing", () => {
+  it("keeps every emission for a pair — the 11th no longer evicts the oldest", async () => {
+    tagAc(AC_PARTITIONED);
+    const ref = await seedAc("no trim");
+    const base = Date.now() - 20 * 60_000;
+    for (let i = 0; i < 15; i++) {
+      await seedTestEvent({
+        subjectRef: ref, status: "pass", testIdentifier: "a::t",
+        createdAt: new Date(base + i * 60_000),
+      });
+    }
+
+    const [{ n }] = (await db.execute(sql`
+      SELECT count(*)::int AS n FROM test_events
+      WHERE subject_ref = ${ref} AND test_identifier = 'a::t'
+    `)) as unknown as Array<{ n: number }>;
+    // Under the old trim this was exactly 10, forever, no matter how many ran. That cap is
+    // the reason the history charts were reading 4.5% of what happened.
+    expect(n).toBe(15);
+  });
+
+  it("exports no per-pair trim to call any more", async () => {
+    tagAc(AC_PARTITIONED);
+    const mod = await import("./test-event-retention.js");
+    // A leftover export is an invitation to reintroduce the 13.4%: the emission path used
+    // to call it, and a future edit restoring that call would be a one-line regression with
+    // no test to catch it if the function still existed.
+    expect(Object.keys(mod)).not.toContain("trimTestEventsForPair");
+    expect(Object.keys(mod)).not.toContain("RETENTION_KEEP");
+  });
+
+  it("exposes the retention window as configuration, not a constant", async () => {
+    tagAc(AC_PARTITIONED);
+    // spec-60 dec-6's precedent (PULSE_RETENTION_DAYS). spec-62's W4 retention workstream
+    // has pinned no schedule for this table, so no floor is fixed today — but one may be,
+    // and it must be a config change rather than a re-partitioning.
+    expect(TEST_EVENTS_RETENTION_DAYS).toBeGreaterThan(0);
+    expect(TEST_EVENTS_RETENTION_DAYS).toBeLessThanOrEqual(90);
+  });
+});

--- a/packages/server/src/services/test-events-partitioned.integration.test.ts
+++ b/packages/server/src/services/test-events-partitioned.integration.test.ts
@@ -14,7 +14,7 @@
 // criteria; that file is left alone until the amendment lands.
 
 import { describe, it, expect, afterAll, beforeAll } from "vitest";
-import { and, eq, inArray, sql } from "drizzle-orm";
+import { eq, inArray, sql } from "drizzle-orm";
 import { tagAc } from "@memex-ai-ac/vitest";
 import { db } from "../db/connection.js";
 import { documents, memexes, namespaces, testEventLatest, testEvents } from "../db/schema.js";


### PR DESCRIPTION
> **DRAFT — must not merge yet.** Two of t-12's own acceptance criteria are unmet, and a cross-Spec amendment has to land first. Both are spelled out at the bottom.

## What this removes

`trimTestEventsForPair` ran inside **every** emission transaction: **13.4% of all database time**, 11.24M deletes against 11.87M inserts, autovacuum running continuously behind it.

Retention becomes *which partition a row landed in*. Rows leave only when an aged-out partition is dropped — a catalogue operation. The 13.4% does not shrink; it goes to **zero**.

## This copies nothing, and that is the whole design

spec-398's migration **0111** restructured this same table by copying every row, held `ACCESS EXCLUSIVE` for **~80 s**, and **deadlocked a prod deploy on its first release**. It is std-39 cl-9's worked example, and it is this table.

0142 renames the existing table and **ATTACHes it as the first partition**. Measured at production scale (1.4M rows, local pg16): the entire exclusive window is **~150 ms**.

That number is load-bearing, not cosmetic. The AC emitter has a 5 s timeout and **never retries** (std-48), so a blocked emission is not delayed — it is **discarded**, with only a warning in someone's CI log. At ~31 events/s an 80 s window silently drops ~2,500 emissions and leaves their ACs on a stale verdict. 150 ms drops none.

## Five things measurement decided, and one it corrected

| | |
|---|---|
| **A DEFAULT partition is a trap** | Once rows land in one, creating that day's real partition **fails outright** (`would be violated by some row`). It converts a quiet no-deploy gap into a migration that cannot apply until someone drains it by hand. Rejected — a 60-day horizon costs **122 ms** to create and **2 ms** to re-run. |
| **Bounds must be `timestamptz`, never `date`** | A date bound resolves in the **session** timezone. The first draft failed immediately on `Europe/Lisbon` with a partition overlapping the legacy one by an hour. Cloud SQL runs UTC, so this would have passed in prod and waited for a developer or a restore. |
| **Parent indexes reuse partition indexes** | `CREATE INDEX` on the parent adopts a matching index already on a partition instead of rebuilding it, so the 1.4M legacy rows cost nothing. |
| **`test_events_retention_idx` stays** | Named for the trim being deleted, but `EXPLAIN` against every surviving reader shows it serves **four**: the AC matrix, both digest CTEs, and the targeted discontinue. Dropping it "with the trim" would have been a plausible, measurable mistake. |
| **The migration must be self-sufficient** | Depending on the out-of-band index broke every **fresh** database — each per-worker test DB, the e2e cold-template build, a new dev machine. Caught by `pnpm db:migrate` failing in globalSetup. 0141 is now an optimisation for prod, not a prerequisite. |

## Shape

- **`out-of-band/0141`** — builds the `(id, created_at)` unique index `CONCURRENTLY`. Keeps production's index build out of the exclusive window. Optional; 0142 creates it `IF NOT EXISTS`.
- **`0142`** — both locks taken up front **in the emission path's order** (0111's actual bug), then rename → attach → forward partitions → indexes → grant → view. The `activity_view` definition is **captured and replayed** rather than re-typed: a hardcoded copy would be a snapshot of the view as of today, and 0119 already renamed a column inside it since 0111.
- **`maintain-test-events-partitions.mjs`** — creates ahead, drops what is entirely past the window. Runs from **deploy, as the owner**; explicitly *not* the in-process `setInterval` shape used by `activity-log-sweep`, which runs as the runtime role. Reasons on **catalogue ranges, not names** — the legacy partition is not named for a day.
- **`TEST_EVENTS_RETENTION_DAYS`** — config, per spec-60 dec-6's precedent, clamped so a stray zero cannot commit the database to 80M rows.
- Failure direction is deliberate: no deploy → the table **grows**, never breaks.

## Test plan

- [x] `test-events-partitioned.integration.test.ts` (6, **ac-13**) — partitioned on `created_at`, PK `(id, created_at)`, horizon present, rows route to the partition their timestamp names, 15 emissions for a pair all survive, and the trim exports are gone
- [x] `partition-drop.rls-restricted.test.ts` (4, **ac-13**) — under `memex_app`: `DROP TABLE` and `DETACH PARTITION` both refused with SQLSTATE `42501`, while `INSERT`/`SELECT` still work. Asserts the **code**, not the message — drizzle wraps driver errors, so a `/must be owner/` regex matches nothing even when the refusal happened
- [x] `no-hidden-migration.regression.test.ts` — allowlist extended **with its reason**: attaching touches no row, so historical `hidden` values are physically untouched (a stronger case than 0111, which copied them)
- [x] Full server suite **6443** · restricted-role suite **21** · `make check` · `tsc`
- [x] Applied end-to-end against a real database: fresh chain, partition routing, grants, view rebuild, and maintenance creating/dropping the right days
- [ ] **e2e journeys** — not run yet; this is a draft

## What is NOT met, and why it cannot be met here

**1. The rehearsal (t-12 AC).** *"Rehearsed against a realistic-volume copy under concurrent write load, and the rehearsal result recorded."* `scripts/rehearse-test-events-partition.sh` builds a 1.5M-row copy, runs 8 writers in the emission's lock order, applies 0141+0142 under that load, and reports the exclusive window plus writer errors by SQLSTATE. **A `40P01` or `55P03` there is the 0111 failure repeating.** It needs a database an agent must not touch.

**2. The runtime-role proof (t-12 AC).** `deploy.sh` still reads `RUNTIME_DB_USER="${RUNTIME_DB_USER:-$DB_USER}"` — **the runtime role IS the owner** until t-14 rolls the split out per environment. The mechanism is proven under the restricted role; the environment-level proof belongs to t-14. A fact about sequencing, not a gap in this work.

**3. spec-398 ac-5 / ac-6 must be amended first.** Their tests here now assert the time bound; the criteria still say *"latest 10 by count"*. Merging before the amendment leaves them green off tests proving the opposite of what they state. Text drafted in **c-14**; rewriting a criterion belongs to the Spec's owner.

Also for the owner: **ac-4 loses its tag here.** Its old test asserted the steady-state trim, which is not what ac-4 claims (it describes the one-time rewrite-and-swap of 0111). That was a tagging defect, not something this change should decide by side effect.

## For spec-399

A policy created on this **parent** is inherited by every partition, including ones maintenance creates later — so it belongs on the parent and must never be written per-partition. `ac-10` still passes: no RLS on `test_events` after partitioning.