### PR TITLE
test(spec-520): tag ac-23 from both halves of dec-7, and cover the clause nothing tested

### DIFF
--- a/packages/server/src/routes/first-verified-tenancy.rls-restricted.test.ts
+++ b/packages/server/src/routes/first-verified-tenancy.rls-restricted.test.ts
@@ -26,6 +26,14 @@ import { ensureUserNamespace } from "../services/user-namespaces.js";
 
 const AC_TENANCY = "mindset-prod/memex-building-itself/specs/spec-520/acs/ac-37";
 
+// spec-520 ac-23 is the COMPOSITE statement of what dec-7 actually delivered, so it is
+// tagged from BOTH halves — the tenancy work here and the throttle in
+// first-verified-throttle.integration.test.ts. Tagging it from either alone would flip it
+// green on half its claim, which is exactly the mistake ac-24/ac-25 made earlier in this
+// Spec and why ac-35/ac-36 had to be split out of them.
+const AC_DEC7 = "mindset-prod/memex-building-itself/specs/spec-520/acs/ac-23";
+
+
 const runId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 let memexId: string;
 let userId: string;
@@ -73,6 +81,7 @@ afterAll(async () => {
 describe("spec-520 ac-37: ac_first_verified is isolated, and its reader still sees its own rows", () => {
   it("a write from the emission path satisfies the policy", async () => {
     tagAc(AC_TENANCY);
+    tagAc(AC_DEC7);
     // The WRITE half. Under memex_app this INSERT's WITH CHECK is evaluated for real; the
     // emission route runs inside runWithMemexId (issue-8), which is what makes it satisfiable.
     await runWithMemexId(memexId, async () =>
@@ -91,6 +100,7 @@ describe("spec-520 ac-37: ac_first_verified is isolated, and its reader still se
 
   it("THE READ WORKS under the restricted role — acsOverTime still counts the first pass", async () => {
     tagAc(AC_TENANCY);
+    tagAc(AC_DEC7);
 
     // THE assertion this file exists for. If the reader were not ALS-wrapped, this would
     // return a curve of zeroes rather than throw — the silent shape. A non-zero verified
@@ -102,6 +112,7 @@ describe("spec-520 ac-37: ac_first_verified is isolated, and its reader still se
 
   it("another tenant sees none of it", async () => {
     tagAc(AC_TENANCY);
+    tagAc(AC_DEC7);
     // Reads under a foreign tenant rather than with NO context: with app.memex_id unset the
     // policy's ::uuid cast can be evaluated before the guarding IS NOT NULL conjunct — SQL
     // does not promise AND short-circuits — and the query errors instead of returning empty.
@@ -117,8 +128,30 @@ describe("spec-520 ac-37: ac_first_verified is isolated, and its reader still se
     expect(leaked).toEqual([]);
   });
 
+  it("keeps memex_id NULLABLE, so a ref with no surviving summary row kept its date", async () => {
+    tagAc(AC_TENANCY);
+    tagAc(AC_DEC7);
+    // ac_first_verified exists BECAUSE retention destroyed the first-green date once
+    // already. Migration 0136 backfilled memex_id from test_event_latest — but a ref whose
+    // summary row is gone (a discontinued AC, a deleted Spec) has nothing to resolve from.
+    // Making the column NOT NULL would have forced those rows to be deleted or the
+    // migration to fail, and deleting them would be the same loss happening a second time,
+    // this time on purpose.
+    //
+    // Under the policy a NULL matches no tenant, so the row is invisible to the product and
+    // visible to the owner role; the writer heals it on that ref's next emission. This
+    // asserts the column stayed nullable — the schema fact the choice rests on.
+    const [col] = (await db.execute(sql`
+      SELECT is_nullable::text AS is_nullable
+      FROM information_schema.columns
+      WHERE table_name = 'ac_first_verified' AND column_name = 'memex_id'
+    `)) as unknown as Array<{ is_nullable: string }>;
+    expect(col.is_nullable).toBe("YES");
+  });
+
   it("the policy is ENABLEd and NOT FORCEd", async () => {
     tagAc(AC_TENANCY);
+    tagAc(AC_DEC7);
     // std-36: FORCE would apply RLS to the table OWNER too, and on Cloud SQL the deploy role
     // is not a superuser and lacks BYPASSRLS — every migration against this table would then
     // be filtered to nothing. 0081 shipped FORCE and 0093 had to undo it.

--- a/packages/server/src/services/first-verified-throttle.integration.test.ts
+++ b/packages/server/src/services/first-verified-throttle.integration.test.ts
@@ -32,6 +32,14 @@ import { makeTestMemex } from "./test-helpers.js";
 
 const AC_THROTTLE = "mindset-prod/memex-building-itself/specs/spec-520/acs/ac-34";
 
+// spec-520 ac-23 is the COMPOSITE statement of what dec-7 actually delivered, so it is
+// tagged from BOTH halves — the tenancy work here and the throttle in
+// first-verified-throttle.integration.test.ts. Tagging it from either alone would flip it
+// green on half its claim, which is exactly the mistake ac-24/ac-25 made earlier in this
+// Spec and why ac-35/ac-36 had to be split out of them.
+const AC_DEC7 = "mindset-prod/memex-building-itself/specs/spec-520/acs/ac-23";
+
+
 const RUN = `spec520-d-${process.pid}-${Math.random().toString(36).slice(2, 8)}`;
 // spec-520 dec-7 option C: ac_first_verified now carries memex_id, so the writer needs a
 // real tenant. Under the default OWNER connection RLS is bypassed (std-36: ENABLE, never
@@ -73,6 +81,7 @@ afterAll(async () => {
 describe("spec-520 ac-34: first-verified is written once, not on every passing event", () => {
   it("writes on the first pass", async () => {
     tagAc(AC_THROTTLE);
+    tagAc(AC_DEC7);
     const ref = refFor("first");
     expect(await readRow(ref)).toBeNull();
 
@@ -84,6 +93,7 @@ describe("spec-520 ac-34: first-verified is written once, not on every passing e
 
   it("does NOT rewrite the row for a LATER pass — same value AND same row version", async () => {
     tagAc(AC_THROTTLE);
+    tagAc(AC_DEC7);
     const ref = refFor("later");
     await recordFirstVerified(db, ref, new Date("2026-08-20T10:00:00.000Z"), memexId);
     const before = await readRow(ref);
@@ -100,6 +110,7 @@ describe("spec-520 ac-34: first-verified is written once, not on every passing e
 
   it("does NOT rewrite the row for an IDENTICAL timestamp either", async () => {
     tagAc(AC_THROTTLE);
+    tagAc(AC_DEC7);
     const ref = refFor("equal");
     const at = new Date("2026-08-20T10:00:00.000Z");
     await recordFirstVerified(db, ref, at, memexId);
@@ -112,6 +123,7 @@ describe("spec-520 ac-34: first-verified is written once, not on every passing e
 
   it("STILL writes for a genuinely EARLIER pass — LEAST-wins survives the throttle", async () => {
     tagAc(AC_THROTTLE);
+    tagAc(AC_DEC7);
     const ref = refFor("earlier");
     await recordFirstVerified(db, ref, new Date("2026-08-20T10:00:00.000Z"), memexId);
     const before = await readRow(ref);
@@ -127,6 +139,7 @@ describe("spec-520 ac-34: first-verified is written once, not on every passing e
 
   it("touches only the ref it was given", async () => {
     tagAc(AC_THROTTLE);
+    tagAc(AC_DEC7);
     const target = refFor("target");
     const bystander = refFor("bystander");
     await recordFirstVerified(db, bystander, new Date("2026-08-20T10:00:00.000Z"), memexId);


### PR DESCRIPTION
Closes the last thing holding **t-10** open. Tests only — no behaviour changes.

## The criterion was describing work that never happened

ac-23 said *"first-verified is derived from the earliest rollup day carrying a pass; ac_first_verified is retired"*. **dec-7 decided against that** — the fact's grain is `(memex_id, subject_ref)` and the rollup's is finer, so storing the date there needs an invented `test_identifier` and `day`, or the date duplicated across every row for the subject.

Its text now states what dec-7 actually delivered. Amended by the agent at the Spec owner's instruction, same posture as spec-398 ac-5/ac-6.

## Tagged from both halves, deliberately

The new claim spans two shipped pieces, so it is tagged from both:

- **tenancy** (#647, migration 0136) — policy satisfied on write, the read works under the restricted role, cross-tenant invisibility, ENABLE-not-FORCE
- **throttle** (#645) — writes the first pass, no rewrite on a later or identical timestamp, **still** writes for a genuinely earlier out-of-order pass

Tagging from one file alone would have flipped ac-23 green on half its claim. That is the ac-24/ac-25 mistake this Spec already made once, and why ac-35/ac-36 had to be split out of them.

## One clause had no test at all

ac-23 asserts a ref with **no surviving summary row keeps its row**. Nothing covered it.

Migration 0136 left `memex_id` NULLABLE precisely so a discontinued AC or a deleted Spec keeps its date, rather than the migration failing or those rows being deleted. And deleting them would be the same first-green loss happening a second time — this table exists *because* retention destroyed that date once already.

A test now asserts the column is still nullable, which is the schema fact the choice rests on. Under the policy a NULL matches no tenant, so the row stays invisible to the product and visible to the owner role; the writer heals it on that ref's next emission.

## Verification

- [x] `first-verified-tenancy.rls-restricted.test.ts` — 5 passed (restricted-role config)
- [x] `first-verified-throttle.integration.test.ts` — 5 passed
- [x] **ac-23 verified**, confirmed with `get_test_matrix`: all ten tests, both files
- [x] `tsc`